### PR TITLE
Fix: address code review issues for production readiness

### DIFF
--- a/internal/api/exec_timeout_test.go
+++ b/internal/api/exec_timeout_test.go
@@ -38,4 +38,3 @@ func TestChooseCommandTimeout_DefaultWhenNoPolicy(t *testing.T) {
 		t.Fatalf("expected default %s, got %s", defaultCommandTimeout, got)
 	}
 }
-

--- a/internal/api/pty_grpc_policy_test.go
+++ b/internal/api/pty_grpc_policy_test.go
@@ -111,4 +111,3 @@ func TestGRPC_PTY_RespectsCommandPolicyDeny(t *testing.T) {
 		t.Fatalf("expected PermissionDenied, got %v: %v", st.Code(), st.Message())
 	}
 }
-

--- a/internal/api/session_create_test.go
+++ b/internal/api/session_create_test.go
@@ -28,7 +28,7 @@ func TestCreateSession_AllowsCustomID(t *testing.T) {
 	app := newTestApp(t, sessions, store)
 	h := app.Router()
 
-	body := fmt.Sprintf(`{"id":"session-custom","workspace":%q,"policy":"default"}`, ws)
+	body := fmt.Sprintf(`{"id":"session_custom","workspace":%q,"policy":"default"}`, ws)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", strings.NewReader(body))
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
@@ -40,8 +40,8 @@ func TestCreateSession_AllowsCustomID(t *testing.T) {
 	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if out.ID != "session-custom" {
-		t.Fatalf("expected id session-custom, got %q", out.ID)
+	if out.ID != "session_custom" {
+		t.Fatalf("expected id session_custom, got %q", out.ID)
 	}
 
 	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", strings.NewReader(body))

--- a/internal/api/testutil_server_test.go
+++ b/internal/api/testutil_server_test.go
@@ -23,4 +23,3 @@ func newHTTPTestServerOrSkip(t *testing.T, h http.Handler) *httptest.Server {
 	t.Cleanup(srv.Close)
 	return srv
 }
-

--- a/internal/cli/exec_flags_test.go
+++ b/internal/cli/exec_flags_test.go
@@ -8,4 +8,3 @@ func TestExecCmd_HasArgv0Flag(t *testing.T) {
 		t.Fatalf("expected exec command to define --argv0 flag")
 	}
 }
-

--- a/internal/cli/testutil_server_test.go
+++ b/internal/cli/testutil_server_test.go
@@ -23,4 +23,3 @@ func newHTTPTestServerOrSkip(t *testing.T, h http.Handler) *httptest.Server {
 	t.Cleanup(srv.Close)
 	return srv
 }
-

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -114,9 +114,9 @@ type SessionsConfig struct {
 }
 
 type SandboxConfig struct {
-	FUSE    SandboxFUSEConfig    `yaml:"fuse"`
-	Network SandboxNetworkConfig `yaml:"network"`
-	Cgroups SandboxCgroupsConfig `yaml:"cgroups"`
+	FUSE        SandboxFUSEConfig        `yaml:"fuse"`
+	Network     SandboxNetworkConfig     `yaml:"network"`
+	Cgroups     SandboxCgroupsConfig     `yaml:"cgroups"`
 	UnixSockets SandboxUnixSocketsConfig `yaml:"unix_sockets"`
 }
 
@@ -174,7 +174,7 @@ type SandboxCgroupsConfig struct {
 }
 
 type SandboxUnixSocketsConfig struct {
-	Enabled   bool   `yaml:"enabled"`
+	Enabled    bool   `yaml:"enabled"`
 	WrapperBin string `yaml:"wrapper_bin"` // optional override; defaults to "agentsh-unixwrap" in PATH
 }
 

--- a/internal/fsmonitor/fuse.go
+++ b/internal/fsmonitor/fuse.go
@@ -495,7 +495,9 @@ func (n *node) emitFileEvent(ctx context.Context, evType string, virtPath string
 	for k, v := range extra {
 		ev.Fields[k] = v
 	}
-	_ = n.hooks.Emit.AppendEvent(ctx, ev)
+	if err := n.hooks.Emit.AppendEvent(ctx, ev); err != nil {
+		fmt.Fprintf(os.Stderr, "fuse: failed to append event (type=%s path=%s): %v\n", evType, virtPath, err)
+	}
 	n.hooks.Emit.Publish(ev)
 }
 

--- a/internal/fsmonitor/mount.go
+++ b/internal/fsmonitor/mount.go
@@ -41,8 +41,8 @@ func MountWorkspace(backingDir string, mountPoint string, hooks *Hooks) (*Mount,
 
 	opts := &fs.Options{
 		MountOptions: fuse.MountOptions{
-			FsName:      "agentsh-workspace",
-			Name:        "agentsh",
+			FsName:        "agentsh-workspace",
+			Name:          "agentsh",
 			DisableXAttrs: false,
 		},
 	}
@@ -64,4 +64,3 @@ func (m *Mount) Unmount() error {
 	}
 	return m.Server.Unmount()
 }
-

--- a/internal/fsmonitor/path_test.go
+++ b/internal/fsmonitor/path_test.go
@@ -49,4 +49,3 @@ func TestResolveRealPathUnderRoot_UsesParentForCreate(t *testing.T) {
 		t.Fatalf("expected escape error")
 	}
 }
-

--- a/internal/fsmonitor/rename_policy_test.go
+++ b/internal/fsmonitor/rename_policy_test.go
@@ -40,4 +40,3 @@ func TestCombinePathDecisionsForRename_ApproveWinsOverAllow(t *testing.T) {
 		t.Fatalf("expected approval metadata, got %+v", out.Approval)
 	}
 }
-

--- a/internal/netmonitor/dns_policy_test.go
+++ b/internal/netmonitor/dns_policy_test.go
@@ -34,7 +34,7 @@ func TestDNSInterceptorPolicyAdjustments(t *testing.T) {
 		dnsCache:  NewDNSCache(5 * time.Minute),
 	}
 
-	dec := d.policyDecision("example.com", 53)
+	dec := d.policyDecision(context.Background(), "example.com", 53)
 	if dec.PolicyDecision != types.DecisionApprove {
 		t.Fatalf("expected approve decision for example.com, got %v", dec.PolicyDecision)
 	}
@@ -43,7 +43,7 @@ func TestDNSInterceptorPolicyAdjustments(t *testing.T) {
 		t.Fatalf("approval should time out -> deny, got %v", dec.EffectiveDecision)
 	}
 
-	defaultDeny := d.policyDecision("foo.com", 53)
+	defaultDeny := d.policyDecision(context.Background(), "foo.com", 53)
 	if defaultDeny.PolicyDecision != types.DecisionDeny || defaultDeny.Rule != "default-deny-network" {
 		t.Fatalf("unexpected default decision: %+v", defaultDeny)
 	}

--- a/internal/netmonitor/ebpf/collector.go
+++ b/internal/netmonitor/ebpf/collector.go
@@ -96,6 +96,10 @@ func (c *Collector) loop() {
 
 func copyToEvent(ev *ConnectEvent, data []byte) {
 	// Layout matches struct in connect.bpf.c
+	// Minimum 30 bytes required for base fields (up to Protocol at offset 29)
+	if len(data) < 30 {
+		return
+	}
 	ev.TsNs = le64(data[0:])
 	ev.Cookie = le64(data[8:])
 	ev.PID = le32(data[16:])

--- a/internal/netmonitor/subnet.go
+++ b/internal/netmonitor/subnet.go
@@ -48,4 +48,3 @@ func AllocateSubnet(subnetBase string, nsName string) (string, string, string, s
 	nsIf = strings.ReplaceAll(nsIf, "-", "")
 	return subnetCIDR, hostIPCIDR, nsIPCIDR, hostIf, nsIf
 }
-

--- a/internal/netmonitor/transparent_tcp_unsupported.go
+++ b/internal/netmonitor/transparent_tcp_unsupported.go
@@ -18,4 +18,3 @@ func StartTransparentTCP(listenAddr string, sessionID string, sess *session.Sess
 }
 
 func (t *TransparentTCP) Close() error { return nil }
-

--- a/internal/policy/limits_test.go
+++ b/internal/policy/limits_test.go
@@ -44,4 +44,3 @@ resource_limits:
 		t.Fatalf("idle_timeout: expected 56m, got %s", lim.IdleTimeout)
 	}
 }
-

--- a/internal/policy/load.go
+++ b/internal/policy/load.go
@@ -37,4 +37,3 @@ func ResolvePolicyPath(dir, name string) (string, error) {
 	}
 	return "", fmt.Errorf("policy %q not found in %q", name, dir)
 }
-

--- a/internal/server/approvals_auth_test.go
+++ b/internal/server/approvals_auth_test.go
@@ -44,4 +44,3 @@ func TestServer_RejectsAPIApprovalsWithoutAuth(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
-

--- a/internal/server/grpc_test.go
+++ b/internal/server/grpc_test.go
@@ -99,9 +99,9 @@ func TestServer_GRPC_CreateSessionAndExec(t *testing.T) {
 	}
 
 	execReq, err := structpb.NewStruct(map[string]any{
-		"session_id": snap.ID,
-		"command":    "sh",
-		"args":       []any{"-c", "echo hi"},
+		"session_id":     snap.ID,
+		"command":        "sh",
+		"args":           []any{"-c", "echo hi"},
 		"include_events": "none",
 	})
 	if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -48,9 +48,9 @@ type Server struct {
 	grpcServer *grpc.Server
 	grpcLn     net.Listener
 
-	store      *composite.Store
-	broker     *events.Broker
-	sessions   *session.Manager
+	store    *composite.Store
+	broker   *events.Broker
+	sessions *session.Manager
 
 	sessionTimeout time.Duration
 	idleTimeout    time.Duration

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -70,4 +70,3 @@ func TestManager_ReapExpired_SessionTimeoutWins(t *testing.T) {
 		t.Fatalf("expected to reap session by session_timeout, got %+v", got)
 	}
 }
-

--- a/internal/shim/session_id.go
+++ b/internal/shim/session_id.go
@@ -28,9 +28,9 @@ type ResolveSessionIDOptions struct {
 // ResolveSessionID resolves the current agentsh session ID using environment and file-based fallbacks.
 //
 // Priority:
-//  1) AGENTSH_SESSION_ID (return directly; no file path)
-//  2) AGENTSH_SESSION_FILE (read/create; returns that file path)
-//  3) File-backed fallback (scope controlled by AGENTSH_SESSION_SCOPE=global|workspace)
+//  1. AGENTSH_SESSION_ID (return directly; no file path)
+//  2. AGENTSH_SESSION_FILE (read/create; returns that file path)
+//  3. File-backed fallback (scope controlled by AGENTSH_SESSION_SCOPE=global|workspace)
 //
 // It returns (sessionID, backingFilePathOrEmpty, error).
 func ResolveSessionID(opts ResolveSessionIDOptions) (string, string, error) {

--- a/internal/store/composite/composite.go
+++ b/internal/store/composite/composite.go
@@ -61,4 +61,3 @@ func (s *Store) Close() error {
 	}
 	return firstErr
 }
-

--- a/internal/store/jsonl/jsonl.go
+++ b/internal/store/jsonl/jsonl.go
@@ -110,4 +110,3 @@ func (s *Store) rotateIfNeededLocked() error {
 	s.file = f
 	return nil
 }
-

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -297,4 +297,3 @@ func boolToInt(b bool) int {
 	}
 	return 0
 }
-

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -16,4 +16,3 @@ type OutputStore interface {
 	SaveOutput(ctx context.Context, sessionID, commandID string, stdout, stderr []byte, stdoutTotal, stderrTotal int64, stdoutTrunc, stderrTrunc bool) error
 	ReadOutputChunk(ctx context.Context, commandID string, stream string, offset, limit int64) (chunk []byte, total int64, truncated bool, err error)
 }
-


### PR DESCRIPTION
## Summary

This PR addresses 16 issues identified during a comprehensive code review, improving security, concurrency safety, and robustness.

### Security Fixes
- Add context support to `CheckNetwork` to prevent TOCTOU in DNS resolution during policy checks
- Add bounds check in eBPF event parsing to prevent panics from malformed data
- Strip hop-by-hop headers in HTTP proxy per RFC 2616 Section 13.5.1
- Restrict session IDs to alphanumeric and underscore only (removed hyphen to prevent flag injection)
- Add `filepath.IsAbs` check to prevent Windows path escape in `resolveWorkingDir`

### Concurrency Fixes
- Add mutex protection to test event emitter (`captureEmitter`)
- Fix goroutine leak in proxy by closing both connections when either copy completes
- Refactor `ReapExpired` to use two-pass approach, avoiding nested locking (deadlock prevention)
- Use `sync.Once` for TTY file close in approvals to prevent double-close panic

### Robustness Improvements
- Log DNS parse failures instead of returning silent empty string
- Log process group kill failures
- Log dropped events in broker with counter (logs on first drop and every 100th)
- Log `AppendEvent` errors in FUSE operations
- Add rate limiting for approval requests (max 10 concurrent per session)
- Limit command history to 1000 entries to prevent unbounded memory growth

## Test plan

- [x] All existing tests pass
- [x] Updated `dns_policy_test.go` to pass context to `policyDecision`
- [x] Updated `session_create_test.go` to use underscore instead of hyphen in session ID
- [x] Verified build with `go build ./...`
- [x] Verified formatting with `gofmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)