### PR TITLE
feat: add PolicyAdapter to bridge platform.PolicyEngine to policy.Engine

### DIFF
--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -72,8 +72,7 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 				CommandIDFunc: func() string {
 					return s.CurrentCommandID()
 				},
-				// PolicyEngine bridging is TODO - for now, nil means allow all
-				// The existing fsmonitor still applies policy internally when available
+				PolicyEngine: platform.NewPolicyAdapter(a.policy),
 			}
 
 			// Configure soft-delete/trash if enabled

--- a/internal/platform/policy_adapter.go
+++ b/internal/platform/policy_adapter.go
@@ -1,0 +1,72 @@
+package platform
+
+import (
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+// PolicyAdapter wraps *policy.Engine to implement platform.PolicyEngine.
+// This bridges the existing policy engine to the platform abstraction layer.
+type PolicyAdapter struct {
+	engine *policy.Engine
+}
+
+// NewPolicyAdapter creates a new adapter wrapping the given policy engine.
+func NewPolicyAdapter(engine *policy.Engine) *PolicyAdapter {
+	if engine == nil {
+		return nil
+	}
+	return &PolicyAdapter{engine: engine}
+}
+
+// Engine returns the underlying *policy.Engine.
+// This is used by platform implementations that need the raw engine.
+func (a *PolicyAdapter) Engine() *policy.Engine {
+	if a == nil {
+		return nil
+	}
+	return a.engine
+}
+
+// CheckFile evaluates file access policy.
+func (a *PolicyAdapter) CheckFile(path string, op FileOperation) Decision {
+	if a == nil || a.engine == nil {
+		return DecisionAllow
+	}
+	decision := a.engine.CheckFile(path, string(op))
+	return decision.EffectiveDecision
+}
+
+// CheckNetwork evaluates network access policy.
+func (a *PolicyAdapter) CheckNetwork(addr string, port int, protocol string) Decision {
+	if a == nil || a.engine == nil {
+		return DecisionAllow
+	}
+	// The policy engine's CheckNetwork takes domain and port
+	// Protocol is not currently used by the policy engine
+	decision := a.engine.CheckNetwork(addr, port)
+	return decision.EffectiveDecision
+}
+
+// CheckEnv evaluates environment variable access policy.
+func (a *PolicyAdapter) CheckEnv(name string, op EnvOperation) Decision {
+	if a == nil || a.engine == nil {
+		return DecisionAllow
+	}
+	// The policy engine doesn't have a direct CheckEnv method.
+	// Environment policies are handled differently (via EnvPolicy in Decision).
+	// For now, allow all env access at this level.
+	// TODO: Implement proper env policy checking when needed.
+	return DecisionAllow
+}
+
+// CheckCommand evaluates command execution policy.
+func (a *PolicyAdapter) CheckCommand(cmd string, args []string) Decision {
+	if a == nil || a.engine == nil {
+		return DecisionAllow
+	}
+	decision := a.engine.CheckCommand(cmd, args)
+	return decision.EffectiveDecision
+}
+
+// Compile-time interface check
+var _ PolicyEngine = (*PolicyAdapter)(nil)

--- a/internal/platform/policy_adapter_test.go
+++ b/internal/platform/policy_adapter_test.go
@@ -1,0 +1,122 @@
+package platform
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+func TestNewPolicyAdapter_Nil(t *testing.T) {
+	adapter := NewPolicyAdapter(nil)
+	if adapter != nil {
+		t.Error("NewPolicyAdapter(nil) should return nil")
+	}
+}
+
+func TestPolicyAdapter_NilEngine(t *testing.T) {
+	var adapter *PolicyAdapter
+
+	// All methods should return DecisionAllow on nil adapter
+	if got := adapter.CheckFile("/test", FileOpRead); got != DecisionAllow {
+		t.Errorf("CheckFile on nil adapter = %v, want %v", got, DecisionAllow)
+	}
+	if got := adapter.CheckNetwork("example.com", 443, "tcp"); got != DecisionAllow {
+		t.Errorf("CheckNetwork on nil adapter = %v, want %v", got, DecisionAllow)
+	}
+	if got := adapter.CheckEnv("HOME", EnvOpRead); got != DecisionAllow {
+		t.Errorf("CheckEnv on nil adapter = %v, want %v", got, DecisionAllow)
+	}
+	if got := adapter.CheckCommand("ls", nil); got != DecisionAllow {
+		t.Errorf("CheckCommand on nil adapter = %v, want %v", got, DecisionAllow)
+	}
+	if got := adapter.Engine(); got != nil {
+		t.Error("Engine() on nil adapter should return nil")
+	}
+}
+
+func TestPolicyAdapter_WithEngine(t *testing.T) {
+	// Create a simple allow-all policy
+	pol := &policy.Policy{
+		Version: 1,
+		Name:    "test-policy",
+		FileRules: []policy.FileRule{
+			{
+				Name:       "allow-all",
+				Paths:      []string{"/**"},
+				Operations: []string{"*"},
+				Decision:   "allow",
+			},
+		},
+		CommandRules: []policy.CommandRule{
+			{
+				Name:     "allow-all",
+				Commands: []string{"*"},
+				Decision: "allow",
+			},
+		},
+		NetworkRules: []policy.NetworkRule{
+			{
+				Name:     "allow-all",
+				Domains:  []string{"**"},
+				Decision: "allow",
+			},
+		},
+	}
+
+	engine, err := policy.NewEngine(pol, false)
+	if err != nil {
+		t.Fatalf("Failed to create policy engine: %v", err)
+	}
+
+	adapter := NewPolicyAdapter(engine)
+	if adapter == nil {
+		t.Fatal("NewPolicyAdapter returned nil for valid engine")
+	}
+
+	// Check that Engine() returns the original engine
+	if adapter.Engine() != engine {
+		t.Error("Engine() should return the wrapped engine")
+	}
+
+	// Check that decisions work (allow-all policy)
+	if got := adapter.CheckFile("/workspace/test.txt", FileOpRead); got != DecisionAllow {
+		t.Errorf("CheckFile = %v, want %v", got, DecisionAllow)
+	}
+	if got := adapter.CheckCommand("ls", []string{"-la"}); got != DecisionAllow {
+		t.Errorf("CheckCommand = %v, want %v", got, DecisionAllow)
+	}
+	if got := adapter.CheckNetwork("example.com", 443, "tcp"); got != DecisionAllow {
+		t.Errorf("CheckNetwork = %v, want %v", got, DecisionAllow)
+	}
+}
+
+func TestPolicyAdapter_DenyPolicy(t *testing.T) {
+	// Create a deny-all policy
+	pol := &policy.Policy{
+		Version: 1,
+		Name:    "deny-policy",
+		FileRules: []policy.FileRule{
+			{
+				Name:       "deny-all",
+				Paths:      []string{"/**"},
+				Operations: []string{"*"},
+				Decision:   "deny",
+			},
+		},
+	}
+
+	engine, err := policy.NewEngine(pol, false)
+	if err != nil {
+		t.Fatalf("Failed to create policy engine: %v", err)
+	}
+
+	adapter := NewPolicyAdapter(engine)
+
+	// Check that deny decision works
+	if got := adapter.CheckFile("/test.txt", FileOpWrite); got != DecisionDeny {
+		t.Errorf("CheckFile with deny policy = %v, want %v", got, DecisionDeny)
+	}
+}
+
+// Compile-time check
+var _ PolicyEngine = (*PolicyAdapter)(nil)


### PR DESCRIPTION
## Summary

- Adds `PolicyAdapter` in `internal/platform/` to wrap `*policy.Engine` and implement `platform.PolicyEngine` interface
- Exposes `Engine()` method for platform implementations that need access to the raw policy engine (like FUSE interceptor)
- Updates `linux/filesystem.go` to extract the engine from `PolicyAdapter` via type assertion
- Wires the adapter in `core.go` via `platform.NewPolicyAdapter(a.policy)`
- Adds comprehensive unit tests for the adapter including nil-safety, allow-all and deny-all policies

This bridges the gap between the platform abstraction layer and the existing policy engine, enabling FUSE and future interceptors to enforce file, network, and command policies through the platform layer.

## Test plan

- [x] Unit tests for PolicyAdapter (nil engine, with engine, deny policy)
- [x] Full test suite passes (`go test ./...`)
- [x] Build succeeds (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)