### PR TITLE
feat: add Linux NetworkInterceptor implementation

### DIFF
--- a/internal/platform/linux/network.go
+++ b/internal/platform/linux/network.go
@@ -1,0 +1,94 @@
+//go:build linux
+
+package linux
+
+import (
+	"os"
+	"os/exec"
+	"sync"
+
+	"github.com/agentsh/agentsh/internal/platform"
+)
+
+// Network implements platform.NetworkInterceptor for Linux.
+// It uses iptables for traffic redirection and network namespaces for isolation.
+type Network struct {
+	available      bool
+	implementation string
+	mu             sync.Mutex
+	configured     bool
+	config         platform.NetConfig
+}
+
+// NewNetwork creates a new Linux network interceptor.
+func NewNetwork() *Network {
+	n := &Network{}
+	n.available = n.checkAvailable()
+	n.implementation = n.detectImplementation()
+	return n
+}
+
+// checkAvailable checks if network interception is available.
+func (n *Network) checkAvailable() bool {
+	// Check for iptables
+	if _, err := exec.LookPath("iptables"); err != nil {
+		return false
+	}
+	// Check for ip command (for netns management)
+	if _, err := exec.LookPath("ip"); err != nil {
+		return false
+	}
+	// Check if we have network namespace support
+	if _, err := os.Stat("/proc/self/ns/net"); err != nil {
+		return false
+	}
+	return true
+}
+
+// detectImplementation returns the network implementation name.
+func (n *Network) detectImplementation() string {
+	// Check for nftables (newer)
+	if _, err := exec.LookPath("nft"); err == nil {
+		// Check if nftables is actually in use
+		if data, err := os.ReadFile("/proc/net/nf_tables"); err == nil && len(data) > 0 {
+			return "nftables+netns"
+		}
+	}
+	// Default to iptables
+	return "iptables+netns"
+}
+
+// Available returns whether network interception is available.
+func (n *Network) Available() bool {
+	return n.available
+}
+
+// Implementation returns the network implementation name.
+func (n *Network) Implementation() string {
+	return n.implementation
+}
+
+// Setup configures network interception.
+// Note: The actual per-session network namespace setup is currently handled
+// by the api layer (tryStartTransparentNetwork). This method stores the config
+// for future use when we migrate the netns logic to the platform layer.
+func (n *Network) Setup(config platform.NetConfig) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	n.config = config
+	n.configured = true
+	return nil
+}
+
+// Teardown removes network interception.
+func (n *Network) Teardown() error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	n.configured = false
+	return nil
+}
+
+// Compile-time interface check
+var _ platform.NetworkInterceptor = (*Network)(nil)

--- a/internal/platform/linux/network_test.go
+++ b/internal/platform/linux/network_test.go
@@ -1,0 +1,46 @@
+//go:build linux
+
+package linux
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/platform"
+)
+
+func TestNewNetwork(t *testing.T) {
+	n := NewNetwork()
+	if n == nil {
+		t.Fatal("NewNetwork returned nil")
+	}
+
+	// Implementation should be set
+	impl := n.Implementation()
+	if impl == "" {
+		t.Error("Implementation() returned empty string")
+	}
+	if impl != "iptables+netns" && impl != "nftables+netns" {
+		t.Errorf("Implementation() = %q, want iptables+netns or nftables+netns", impl)
+	}
+}
+
+func TestNetwork_SetupTeardown(t *testing.T) {
+	n := NewNetwork()
+
+	// Setup should succeed
+	cfg := platform.NetConfig{
+		ProxyPort: 8080,
+		DNSPort:   5353,
+	}
+	if err := n.Setup(cfg); err != nil {
+		t.Errorf("Setup() error = %v", err)
+	}
+
+	// Teardown should succeed
+	if err := n.Teardown(); err != nil {
+		t.Errorf("Teardown() error = %v", err)
+	}
+}
+
+// Compile-time interface check
+var _ platform.NetworkInterceptor = (*Network)(nil)

--- a/internal/platform/linux/platform.go
+++ b/internal/platform/linux/platform.go
@@ -25,6 +25,7 @@ func init() {
 type Platform struct {
 	config      platform.Config
 	fs          *Filesystem
+	net         *Network
 	caps        platform.Capabilities
 	initialized bool
 }
@@ -159,8 +160,10 @@ func (p *Platform) Filesystem() platform.FilesystemInterceptor {
 
 // Network returns the network interceptor.
 func (p *Platform) Network() platform.NetworkInterceptor {
-	// TODO: Implement in phase 2
-	return nil
+	if p.net == nil {
+		p.net = NewNetwork()
+	}
+	return p.net
 }
 
 // Sandbox returns the sandbox manager.


### PR DESCRIPTION
## Summary

- Adds `Network` struct in `internal/platform/linux/` implementing `platform.NetworkInterceptor`
- Checks availability via iptables/ip commands and network namespace support
- Detects implementation type (iptables+netns or nftables+netns based on system)
- Wires `Network()` method in Platform to return the interceptor
- Adds unit tests for Network

The actual per-session network namespace setup remains in the api layer (`tryStartTransparentNetwork`) for now. This provides the platform abstraction foundation - future work can migrate the netns logic to use this interface.

## Changes

- `internal/platform/linux/network.go` - New NetworkInterceptor implementation
- `internal/platform/linux/network_test.go` - Unit tests
- `internal/platform/linux/platform.go` - Wire Network() to return the interceptor

## Test plan

- [x] Unit tests for Network (availability check, setup/teardown)
- [x] Full test suite passes (`go test ./...`)
- [x] Build succeeds (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)