### PR TITLE
feat: add Linux ResourceLimiter implementation

### DIFF
--- a/internal/platform/linux/platform.go
+++ b/internal/platform/linux/platform.go
@@ -27,6 +27,7 @@ type Platform struct {
 	fs          *Filesystem
 	net         *Network
 	sandbox     *SandboxManager
+	resources   *ResourceLimiter
 	caps        platform.Capabilities
 	initialized bool
 }
@@ -177,8 +178,10 @@ func (p *Platform) Sandbox() platform.SandboxManager {
 
 // Resources returns the resource limiter.
 func (p *Platform) Resources() platform.ResourceLimiter {
-	// TODO: Implement in phase 2
-	return nil
+	if p.resources == nil {
+		p.resources = NewResourceLimiter()
+	}
+	return p.resources
 }
 
 // Initialize sets up the platform with the given configuration.

--- a/internal/platform/linux/resources.go
+++ b/internal/platform/linux/resources.go
@@ -1,0 +1,236 @@
+//go:build linux
+
+package linux
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/agentsh/agentsh/internal/limits"
+	"github.com/agentsh/agentsh/internal/platform"
+)
+
+// ResourceLimiter implements platform.ResourceLimiter for Linux using cgroups v2.
+type ResourceLimiter struct {
+	available       bool
+	supportedLimits []platform.ResourceType
+	mu              sync.Mutex
+	handles         map[string]*ResourceHandle
+}
+
+// NewResourceLimiter creates a new Linux resource limiter.
+func NewResourceLimiter() *ResourceLimiter {
+	r := &ResourceLimiter{
+		handles: make(map[string]*ResourceHandle),
+	}
+	r.available = r.checkAvailable()
+	r.supportedLimits = r.detectSupportedLimits()
+	return r
+}
+
+// checkAvailable checks if cgroups v2 is available.
+func (r *ResourceLimiter) checkAvailable() bool {
+	return limits.DetectCgroupV2()
+}
+
+// detectSupportedLimits determines which resource limits are available.
+func (r *ResourceLimiter) detectSupportedLimits() []platform.ResourceType {
+	if !r.available {
+		return nil
+	}
+
+	var supported []platform.ResourceType
+
+	// Check which controllers are available
+	cgDir, err := limits.CurrentCgroupDir()
+	if err != nil {
+		return nil
+	}
+
+	controllers, err := os.ReadFile(filepath.Join(cgDir, "cgroup.controllers"))
+	if err != nil {
+		return nil
+	}
+
+	ctrlList := strings.Fields(string(controllers))
+	ctrlSet := make(map[string]bool)
+	for _, c := range ctrlList {
+		ctrlSet[c] = true
+	}
+
+	// Map controllers to resource types
+	if ctrlSet["cpu"] {
+		supported = append(supported, platform.ResourceCPU)
+		supported = append(supported, platform.ResourceCPUAffinity)
+	}
+	if ctrlSet["memory"] {
+		supported = append(supported, platform.ResourceMemory)
+	}
+	if ctrlSet["pids"] {
+		supported = append(supported, platform.ResourceProcessCount)
+	}
+	if ctrlSet["io"] {
+		supported = append(supported, platform.ResourceDiskIO)
+	}
+	// Network bandwidth limiting requires tc/eBPF, not cgroups
+	// We don't claim support for it here
+
+	return supported
+}
+
+// Available returns whether resource limiting is available.
+func (r *ResourceLimiter) Available() bool {
+	return r.available
+}
+
+// SupportedLimits returns which resource types can be limited.
+func (r *ResourceLimiter) SupportedLimits() []platform.ResourceType {
+	return r.supportedLimits
+}
+
+// Apply applies resource limits using cgroups v2.
+func (r *ResourceLimiter) Apply(config platform.ResourceConfig) (platform.ResourceHandle, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Convert platform config to limits package config
+	lim := limits.CgroupV2Limits{}
+
+	if config.MaxMemoryMB > 0 {
+		lim.MaxMemoryBytes = int64(config.MaxMemoryMB) * 1024 * 1024
+	}
+	if config.MaxCPUPercent > 0 {
+		lim.CPUQuotaPct = int(config.MaxCPUPercent)
+	}
+	if config.MaxProcesses > 0 {
+		lim.PidsMax = int(config.MaxProcesses)
+	}
+
+	// Create handle with config stored (we'll apply when a process is assigned)
+	handle := &ResourceHandle{
+		name:   config.Name,
+		config: config,
+		limits: lim,
+	}
+
+	r.handles[config.Name] = handle
+	return handle, nil
+}
+
+// ResourceHandle implements platform.ResourceHandle for Linux cgroups.
+type ResourceHandle struct {
+	name   string
+	config platform.ResourceConfig
+	limits limits.CgroupV2Limits
+	cgroup *limits.CgroupV2
+	mu     sync.Mutex
+}
+
+// AssignProcess adds a process to this cgroup.
+func (h *ResourceHandle) AssignProcess(pid int) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// Create or reuse cgroup
+	if h.cgroup == nil {
+		cg, err := limits.ApplyCgroupV2("", h.name, pid, h.limits)
+		if err != nil {
+			return err
+		}
+		h.cgroup = cg
+	} else {
+		// Add to existing cgroup
+		procsPath := filepath.Join(h.cgroup.Path, "cgroup.procs")
+		if err := os.WriteFile(procsPath, []byte(strconv.Itoa(pid)), 0o644); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Stats returns current resource usage from the cgroup.
+func (h *ResourceHandle) Stats() platform.ResourceStats {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	stats := platform.ResourceStats{}
+
+	if h.cgroup == nil {
+		return stats
+	}
+
+	// Read memory usage
+	if data, err := os.ReadFile(filepath.Join(h.cgroup.Path, "memory.current")); err == nil {
+		if bytes, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64); err == nil {
+			stats.MemoryMB = uint64(bytes / (1024 * 1024))
+		}
+	}
+
+	// Read CPU usage (requires calculating delta, simplified here)
+	if data, err := os.ReadFile(filepath.Join(h.cgroup.Path, "cpu.stat")); err == nil {
+		lines := strings.Split(string(data), "\n")
+		for _, line := range lines {
+			if strings.HasPrefix(line, "usage_usec ") {
+				// This is total CPU time, not percentage
+				// Would need sampling to calculate percentage
+			}
+		}
+	}
+
+	// Read process count
+	if data, err := os.ReadFile(filepath.Join(h.cgroup.Path, "pids.current")); err == nil {
+		if count, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil {
+			stats.ProcessCount = count
+		}
+	}
+
+	// Read IO stats
+	if data, err := os.ReadFile(filepath.Join(h.cgroup.Path, "io.stat")); err == nil {
+		lines := strings.Split(string(data), "\n")
+		for _, line := range lines {
+			fields := strings.Fields(line)
+			for _, f := range fields {
+				if strings.HasPrefix(f, "rbytes=") {
+					if v, err := strconv.ParseInt(strings.TrimPrefix(f, "rbytes="), 10, 64); err == nil {
+						stats.DiskReadMB += v / (1024 * 1024)
+					}
+				}
+				if strings.HasPrefix(f, "wbytes=") {
+					if v, err := strconv.ParseInt(strings.TrimPrefix(f, "wbytes="), 10, 64); err == nil {
+						stats.DiskWriteMB += v / (1024 * 1024)
+					}
+				}
+			}
+		}
+	}
+
+	return stats
+}
+
+// Release removes the cgroup.
+func (h *ResourceHandle) Release() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.cgroup == nil {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5)
+	defer cancel()
+
+	err := h.cgroup.Close(ctx)
+	h.cgroup = nil
+	return err
+}
+
+// Compile-time interface checks
+var (
+	_ platform.ResourceLimiter = (*ResourceLimiter)(nil)
+	_ platform.ResourceHandle  = (*ResourceHandle)(nil)
+)

--- a/internal/platform/linux/resources_test.go
+++ b/internal/platform/linux/resources_test.go
@@ -1,0 +1,128 @@
+//go:build linux
+
+package linux
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/platform"
+)
+
+func TestNewResourceLimiter(t *testing.T) {
+	r := NewResourceLimiter()
+	if r == nil {
+		t.Fatal("NewResourceLimiter returned nil")
+	}
+
+	available := r.Available()
+	t.Logf("Resource limiter available: %v", available)
+
+	limits := r.SupportedLimits()
+	t.Logf("Supported limits: %v", limits)
+}
+
+func TestResourceLimiter_SupportedLimits(t *testing.T) {
+	r := NewResourceLimiter()
+	if !r.Available() {
+		t.Skip("Cgroups v2 not available")
+	}
+
+	limits := r.SupportedLimits()
+	if len(limits) == 0 {
+		t.Error("No supported limits detected on cgroups v2 system")
+	}
+
+	// Check for expected limits
+	hasMemory := false
+	hasCPU := false
+	for _, l := range limits {
+		if l == platform.ResourceMemory {
+			hasMemory = true
+		}
+		if l == platform.ResourceCPU {
+			hasCPU = true
+		}
+	}
+
+	t.Logf("Has memory limit: %v, Has CPU limit: %v", hasMemory, hasCPU)
+}
+
+func TestResourceLimiter_Apply(t *testing.T) {
+	r := NewResourceLimiter()
+	if !r.Available() {
+		t.Skip("Cgroups v2 not available")
+	}
+
+	config := platform.ResourceConfig{
+		Name:          "test-limits",
+		MaxMemoryMB:   512,
+		MaxCPUPercent: 50,
+		MaxProcesses:  100,
+	}
+
+	handle, err := r.Apply(config)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	defer handle.Release()
+
+	if handle == nil {
+		t.Error("Apply() returned nil handle")
+	}
+}
+
+func TestResourceHandle_Stats(t *testing.T) {
+	r := NewResourceLimiter()
+	if !r.Available() {
+		t.Skip("Cgroups v2 not available")
+	}
+
+	config := platform.ResourceConfig{
+		Name:          "stats-test",
+		MaxMemoryMB:   256,
+		MaxCPUPercent: 25,
+	}
+
+	handle, err := r.Apply(config)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	defer handle.Release()
+
+	// Stats should work even without processes assigned
+	stats := handle.Stats()
+	t.Logf("Stats: MemoryMB=%d, CPUPercent=%.2f, ProcessCount=%d",
+		stats.MemoryMB, stats.CPUPercent, stats.ProcessCount)
+}
+
+func TestResourceHandle_Release(t *testing.T) {
+	r := NewResourceLimiter()
+	if !r.Available() {
+		t.Skip("Cgroups v2 not available")
+	}
+
+	config := platform.ResourceConfig{
+		Name: "release-test",
+	}
+
+	handle, err := r.Apply(config)
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+
+	// Release should succeed
+	if err := handle.Release(); err != nil {
+		t.Errorf("Release() error = %v", err)
+	}
+
+	// Second release should also succeed (idempotent)
+	if err := handle.Release(); err != nil {
+		t.Errorf("Second Release() error = %v", err)
+	}
+}
+
+// Compile-time interface checks
+var (
+	_ platform.ResourceLimiter = (*ResourceLimiter)(nil)
+	_ platform.ResourceHandle  = (*ResourceHandle)(nil)
+)


### PR DESCRIPTION
## Summary

- Adds `ResourceLimiter` struct in `internal/platform/linux/` implementing `platform.ResourceLimiter`
- Wraps existing cgroups v2 code from `internal/limits` package
- Detects supported limits based on available cgroup controllers:
  - CPU (cpu controller)
  - Memory (memory controller)
  - Process count (pids controller)
  - Disk I/O (io controller)
- Adds `ResourceHandle` for managing cgroup lifecycle:
  - `AssignProcess(pid)` - adds process to cgroup
  - `Stats()` - reads resource usage from cgroup files
  - `Release()` - cleans up cgroup
- Wires `Resources()` method in Platform to return the limiter
- Adds unit tests

## Changes

- `internal/platform/linux/resources.go` - New ResourceLimiter and ResourceHandle implementations
- `internal/platform/linux/resources_test.go` - Unit tests
- `internal/platform/linux/platform.go` - Wire Resources() to return the limiter

## Test plan

- [x] Unit tests for ResourceLimiter (availability, supported limits, apply)
- [x] Unit tests for ResourceHandle (stats, release)
- [x] Full test suite passes (`go test ./...`)
- [x] Build succeeds (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)