### PR TITLE
feat: add glob pattern support for environment variable filtering

### DIFF
--- a/internal/platform/policy_adapter.go
+++ b/internal/platform/policy_adapter.go
@@ -52,11 +52,11 @@ func (a *PolicyAdapter) CheckEnv(name string, op EnvOperation) Decision {
 	if a == nil || a.engine == nil {
 		return DecisionAllow
 	}
-	// The policy engine doesn't have a direct CheckEnv method.
-	// Environment policies are handled differently (via EnvPolicy in Decision).
-	// For now, allow all env access at this level.
-	// TODO: Implement proper env policy checking when needed.
-	return DecisionAllow
+	decision := a.engine.CheckEnv(name)
+	if decision.Allowed {
+		return DecisionAllow
+	}
+	return DecisionDeny
 }
 
 // CheckCommand evaluates command execution policy.

--- a/internal/policy/env_test.go
+++ b/internal/policy/env_test.go
@@ -1,0 +1,235 @@
+package policy
+
+import (
+	"testing"
+)
+
+func TestEngine_CheckEnv_DenyPatterns(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		EnvPolicy: EnvPolicy{
+			Deny: []string{"AWS_*", "*_SECRET", "PASSWORD"},
+		},
+	}
+	e, err := NewEngine(p, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		allowed bool
+		matchBy string
+	}{
+		{"AWS_ACCESS_KEY_ID", false, "deny"},
+		{"AWS_SECRET_ACCESS_KEY", false, "deny"},
+		{"MY_SECRET", false, "deny"},
+		{"PASSWORD", false, "deny"},
+		{"PATH", true, "default-allow"},
+		{"HOME", true, "default-allow"},
+		{"USER", true, "default-allow"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dec := e.CheckEnv(tc.name)
+			if dec.Allowed != tc.allowed {
+				t.Errorf("expected Allowed=%v, got %v (MatchedBy=%s)", tc.allowed, dec.Allowed, dec.MatchedBy)
+			}
+			if dec.MatchedBy != tc.matchBy {
+				t.Errorf("expected MatchedBy=%q, got %q", tc.matchBy, dec.MatchedBy)
+			}
+		})
+	}
+}
+
+func TestEngine_CheckEnv_AllowPatterns(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		EnvPolicy: EnvPolicy{
+			Allow: []string{"PATH", "HOME", "USER", "MY_*"},
+			Deny:  []string{"MY_SECRET"},
+		},
+	}
+	e, err := NewEngine(p, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		allowed bool
+		matchBy string
+	}{
+		{"PATH", true, "allow"},
+		{"HOME", true, "allow"},
+		{"USER", true, "allow"},
+		{"MY_VAR", true, "allow"},
+		{"MY_APP_DATA", true, "allow"},
+		{"MY_SECRET", false, "deny"},           // Deny wins over allow
+		{"OTHER_VAR", false, "default-deny"},   // Not in allow list
+		{"AWS_ACCESS_KEY_ID", false, "default-deny"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dec := e.CheckEnv(tc.name)
+			if dec.Allowed != tc.allowed {
+				t.Errorf("expected Allowed=%v, got %v (MatchedBy=%s)", tc.allowed, dec.Allowed, dec.MatchedBy)
+			}
+			if dec.MatchedBy != tc.matchBy {
+				t.Errorf("expected MatchedBy=%q, got %q", tc.matchBy, dec.MatchedBy)
+			}
+		})
+	}
+}
+
+func TestEngine_CheckEnv_DefaultSecrets(t *testing.T) {
+	// No explicit allow/deny patterns - should use defaultSecretDeny
+	p := &Policy{
+		Version:   1,
+		Name:      "test",
+		EnvPolicy: EnvPolicy{},
+	}
+	e, err := NewEngine(p, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		allowed bool
+		matchBy string
+	}{
+		{"AWS_SECRET_ACCESS_KEY", false, "default-secret-deny"},
+		{"AWS_ACCESS_KEY_ID", false, "default-secret-deny"},
+		{"GITHUB_TOKEN", false, "default-secret-deny"},
+		{"GH_TOKEN", false, "default-secret-deny"},
+		{"KUBECONFIG", false, "default-secret-deny"},
+		{"PATH", true, "default-allow"},
+		{"HOME", true, "default-allow"},
+		{"MY_CUSTOM_VAR", true, "default-allow"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dec := e.CheckEnv(tc.name)
+			if dec.Allowed != tc.allowed {
+				t.Errorf("expected Allowed=%v, got %v (MatchedBy=%s)", tc.allowed, dec.Allowed, dec.MatchedBy)
+			}
+			if dec.MatchedBy != tc.matchBy {
+				t.Errorf("expected MatchedBy=%q, got %q", tc.matchBy, dec.MatchedBy)
+			}
+		})
+	}
+}
+
+func TestEngine_CheckEnv_NilEngine(t *testing.T) {
+	var e *Engine
+	dec := e.CheckEnv("PATH")
+	if !dec.Allowed || dec.MatchedBy != "default-allow" {
+		t.Errorf("nil engine should allow, got Allowed=%v MatchedBy=%s", dec.Allowed, dec.MatchedBy)
+	}
+}
+
+func TestBuildEnv_GlobPatterns(t *testing.T) {
+	pol := ResolvedEnvPolicy{
+		Allow: []string{"PATH", "HOME", "MY_*"},
+		Deny:  []string{"MY_SECRET_*"},
+	}
+	baseEnv := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/user",
+		"MY_VAR=value1",
+		"MY_SECRET_KEY=secret",
+		"OTHER_VAR=other",
+	}
+
+	result, err := BuildEnv(pol, baseEnv, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]bool{
+		"PATH=/usr/bin":    true,
+		"HOME=/home/user":  true,
+		"MY_VAR=value1":    true,
+	}
+
+	if len(result) != len(expected) {
+		t.Errorf("expected %d vars, got %d: %v", len(expected), len(result), result)
+	}
+
+	for _, kv := range result {
+		if !expected[kv] {
+			t.Errorf("unexpected var in result: %s", kv)
+		}
+	}
+}
+
+func TestBuildEnv_DefaultSecretDeny(t *testing.T) {
+	// No allow patterns, should use default secret deny
+	pol := ResolvedEnvPolicy{}
+	baseEnv := []string{
+		"PATH=/usr/bin",
+		"AWS_SECRET_ACCESS_KEY=secret",
+		"GITHUB_TOKEN=token",
+		"MY_VAR=value",
+	}
+
+	result, err := BuildEnv(pol, baseEnv, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// AWS_SECRET_ACCESS_KEY and GITHUB_TOKEN should be filtered out
+	for _, kv := range result {
+		if kv == "AWS_SECRET_ACCESS_KEY=secret" || kv == "GITHUB_TOKEN=token" {
+			t.Errorf("secret var should have been filtered: %s", kv)
+		}
+	}
+
+	// PATH and MY_VAR should remain
+	found := map[string]bool{}
+	for _, kv := range result {
+		found[kv] = true
+	}
+	if !found["PATH=/usr/bin"] {
+		t.Error("PATH should be in result")
+	}
+	if !found["MY_VAR=value"] {
+		t.Error("MY_VAR should be in result")
+	}
+}
+
+func TestBuildEnv_MaxKeys(t *testing.T) {
+	pol := ResolvedEnvPolicy{
+		MaxKeys: 2,
+	}
+	baseEnv := []string{
+		"A=1",
+		"B=2",
+		"C=3",
+	}
+
+	_, err := BuildEnv(pol, baseEnv, nil)
+	if err == nil {
+		t.Error("expected error for exceeding max_keys")
+	}
+}
+
+func TestBuildEnv_MaxBytes(t *testing.T) {
+	pol := ResolvedEnvPolicy{
+		MaxBytes: 10,
+	}
+	baseEnv := []string{
+		"PATH=/usr/local/bin:/usr/bin:/bin",
+	}
+
+	_, err := BuildEnv(pol, baseEnv, nil)
+	if err == nil {
+		t.Error("expected error for exceeding max_bytes")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `CheckEnv` method to `policy.Engine` with glob pattern matching support
- Updates `BuildEnv` to use glob patterns in allow/deny lists (e.g., `AWS_*`, `*_TOKEN`)
- Updates `PolicyAdapter.CheckEnv` to delegate to the policy engine instead of always allowing
- Adds comprehensive unit tests for environment variable filtering

## Implementation Details

The env policy now supports glob patterns for flexible environment variable filtering:

```yaml
env_policy:
  allow:
    - PATH
    - HOME
    - MY_*
  deny:
    - "*_SECRET"
    - "*_TOKEN"
    - AWS_*
```

Key behavior:
- **Deny patterns win**: If a variable matches both allow and deny, it's denied
- **Default secrets**: When no explicit allow patterns are defined, `defaultSecretDeny` list is applied (AWS keys, GH tokens, etc.)
- **Allowlist mode**: When allow patterns are defined, only matching variables are passed through

## Test plan

- [x] Unit tests for CheckEnv deny patterns
- [x] Unit tests for CheckEnv allow patterns  
- [x] Unit tests for CheckEnv default secret deny
- [x] Unit tests for CheckEnv nil engine handling
- [x] Unit tests for BuildEnv glob patterns
- [x] Unit tests for BuildEnv default secret deny
- [x] Unit tests for BuildEnv max_keys/max_bytes limits
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)