### PR TITLE
feat: add unified platform configuration with fallback support

### DIFF
--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -117,3 +117,91 @@ func TestPlatformMode_String(t *testing.T) {
 		}
 	}
 }
+
+func TestParsePlatformMode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  platform.PlatformMode
+	}{
+		// Auto/default
+		{"auto", platform.ModeAuto},
+		{"", platform.ModeAuto},
+		{"  auto  ", platform.ModeAuto},
+
+		// Linux
+		{"linux", platform.ModeLinuxNative},
+		{"linux-native", platform.ModeLinuxNative},
+		{"LINUX", platform.ModeLinuxNative},
+
+		// Darwin
+		{"darwin", platform.ModeDarwinNative},
+		{"darwin-native", platform.ModeDarwinNative},
+		{"macos", platform.ModeDarwinNative},
+
+		// Darwin Lima
+		{"darwin-lima", platform.ModeDarwinLima},
+		{"lima", platform.ModeDarwinLima},
+
+		// Windows
+		{"windows", platform.ModeWindowsNative},
+		{"windows-native", platform.ModeWindowsNative},
+
+		// Windows WSL2
+		{"windows-wsl2", platform.ModeWindowsWSL2},
+		{"wsl2", platform.ModeWindowsWSL2},
+		{"wsl", platform.ModeWindowsWSL2},
+
+		// Unknown defaults to auto
+		{"unknown", platform.ModeAuto},
+		{"foobar", platform.ModeAuto},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := platform.ParsePlatformMode(tt.input)
+			if got != tt.want {
+				t.Errorf("ParsePlatformMode(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewWithOptions_LinuxMode(t *testing.T) {
+	opts := platform.PlatformOptions{
+		Mode: "linux",
+	}
+	p, err := platform.NewWithOptions(opts)
+	if err != nil {
+		t.Fatalf("NewWithOptions() failed: %v", err)
+	}
+	if p.Name() != "linux" {
+		t.Errorf("expected platform name 'linux', got %q", p.Name())
+	}
+}
+
+func TestNewWithOptions_AutoMode(t *testing.T) {
+	opts := platform.PlatformOptions{
+		Mode: "auto",
+	}
+	p, err := platform.NewWithOptions(opts)
+	if err != nil {
+		t.Fatalf("NewWithOptions() failed: %v", err)
+	}
+	// On Linux test system, should get linux platform
+	if p.Name() != "linux" {
+		t.Errorf("expected platform name 'linux', got %q", p.Name())
+	}
+}
+
+func TestNewWithOptions_EmptyMode(t *testing.T) {
+	opts := platform.PlatformOptions{
+		Mode: "",
+	}
+	p, err := platform.NewWithOptions(opts)
+	if err != nil {
+		t.Fatalf("NewWithOptions() with empty mode failed: %v", err)
+	}
+	if p.Name() != "linux" {
+		t.Errorf("expected platform name 'linux', got %q", p.Name())
+	}
+}

--- a/internal/platform/types.go
+++ b/internal/platform/types.go
@@ -1,6 +1,7 @@
 package platform
 
 import (
+	"strings"
 	"time"
 
 	"github.com/agentsh/agentsh/pkg/types"
@@ -383,5 +384,26 @@ func (m PlatformMode) String() string {
 		return "windows-wsl2"
 	default:
 		return "unknown"
+	}
+}
+
+// ParsePlatformMode parses a platform mode string.
+// Accepts variations like "linux", "linux-native", "darwin", "windows-wsl2", etc.
+func ParsePlatformMode(s string) PlatformMode {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "auto", "":
+		return ModeAuto
+	case "linux", "linux-native":
+		return ModeLinuxNative
+	case "darwin", "darwin-native", "macos":
+		return ModeDarwinNative
+	case "darwin-lima", "lima":
+		return ModeDarwinLima
+	case "windows", "windows-native":
+		return ModeWindowsNative
+	case "windows-wsl2", "wsl2", "wsl":
+		return ModeWindowsWSL2
+	default:
+		return ModeAuto
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `PlatformConfig` to config structure with mode selection and fallback behavior
- Adds `ParsePlatformMode()` for parsing platform mode strings from config
- Adds `NewWithOptions()` for config-based platform selection with automatic fallback
- Adds platform-specific mount point configuration per OS
- Adds `AGENTSH_PLATFORM_MODE` environment variable override

## Configuration Example

```yaml
platform:
  mode: auto  # auto, linux, darwin, windows, windows-wsl2
  fallback:
    enabled: true
    order:
      - windows-wsl2
      - windows
      - darwin-lima
      - darwin
  mount_points:
    linux: /tmp/agentsh/workspace
    darwin: /tmp/agentsh/workspace
    windows: "X:"
    windows_wsl2: /tmp/agentsh/workspace
```

## Mode Parsing

Accepts flexible inputs:
- `linux`, `linux-native` → ModeLinuxNative
- `darwin`, `darwin-native`, `macos` → ModeDarwinNative
- `darwin-lima`, `lima` → ModeDarwinLima
- `windows`, `windows-native` → ModeWindowsNative
- `windows-wsl2`, `wsl2`, `wsl` → ModeWindowsWSL2
- `auto`, empty → ModeAuto (automatic detection)

## Test plan

- [x] ParsePlatformMode tests for all mode variations
- [x] NewWithOptions tests for linux, auto, and empty modes
- [x] Full test suite passes (`go test ./...`)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)