### PR TITLE
test: add cross-platform integration test suite

### DIFF
--- a/test/integration/env_policy_test.go
+++ b/test/integration/env_policy_test.go
@@ -1,0 +1,311 @@
+//go:build integration
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+// TestEnvPolicyCheckEnv tests the CheckEnv method with glob patterns.
+func TestEnvPolicyCheckEnv(t *testing.T) {
+	p := &policy.Policy{
+		Version: 1,
+		Name:    "test-env-policy",
+		EnvPolicy: policy.EnvPolicy{
+			Allow: []string{"PATH", "HOME", "USER", "MY_*"},
+			Deny:  []string{"MY_SECRET_*", "*_TOKEN"},
+		},
+	}
+
+	engine, err := policy.NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("NewEngine failed: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		allowed bool
+	}{
+		// Explicitly allowed
+		{"PATH", true},
+		{"HOME", true},
+		{"USER", true},
+
+		// Allowed by pattern
+		{"MY_VAR", true},
+		{"MY_APP_DATA", true},
+
+		// Denied by pattern (deny wins over allow)
+		{"MY_SECRET_KEY", false},
+		{"MY_SECRET_TOKEN", false},
+		{"GITHUB_TOKEN", false},
+		{"API_TOKEN", false},
+
+		// Not in allow list (default deny when allow patterns defined)
+		{"OTHER_VAR", false},
+		{"AWS_ACCESS_KEY_ID", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dec := engine.CheckEnv(tt.name)
+			if dec.Allowed != tt.allowed {
+				t.Errorf("CheckEnv(%q) = Allowed:%v (MatchedBy:%s), want Allowed:%v",
+					tt.name, dec.Allowed, dec.MatchedBy, tt.allowed)
+			}
+		})
+	}
+}
+
+// TestEnvPolicyDefaultSecrets tests default secret blocking.
+func TestEnvPolicyDefaultSecrets(t *testing.T) {
+	// No explicit allow/deny - uses default secret deny list
+	p := &policy.Policy{
+		Version:   1,
+		Name:      "test-default-secrets",
+		EnvPolicy: policy.EnvPolicy{},
+	}
+
+	engine, err := policy.NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("NewEngine failed: %v", err)
+	}
+
+	// These should be blocked by default
+	secrets := []string{
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SESSION_TOKEN",
+		"GITHUB_TOKEN",
+		"GH_TOKEN",
+		"KUBECONFIG",
+		"GOOGLE_APPLICATION_CREDENTIALS",
+		"AZURE_CLIENT_SECRET",
+	}
+
+	for _, secret := range secrets {
+		t.Run(secret, func(t *testing.T) {
+			dec := engine.CheckEnv(secret)
+			if dec.Allowed {
+				t.Errorf("CheckEnv(%q) should be denied by default, got Allowed=true (MatchedBy:%s)",
+					secret, dec.MatchedBy)
+			}
+		})
+	}
+
+	// These should be allowed
+	allowed := []string{"PATH", "HOME", "USER", "MY_VAR", "CUSTOM_VAR"}
+	for _, v := range allowed {
+		t.Run(v, func(t *testing.T) {
+			dec := engine.CheckEnv(v)
+			if !dec.Allowed {
+				t.Errorf("CheckEnv(%q) should be allowed, got Allowed=false (MatchedBy:%s)",
+					v, dec.MatchedBy)
+			}
+		})
+	}
+}
+
+// TestBuildEnvGlobPatterns tests BuildEnv with glob patterns.
+func TestBuildEnvGlobPatterns(t *testing.T) {
+	pol := policy.ResolvedEnvPolicy{
+		Allow: []string{"PATH", "HOME", "MY_*"},
+		Deny:  []string{"MY_SECRET_*"},
+	}
+
+	baseEnv := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/user",
+		"MY_VAR=value1",
+		"MY_APP=value2",
+		"MY_SECRET_KEY=secret",
+		"OTHER_VAR=other",
+	}
+
+	result, err := policy.BuildEnv(pol, baseEnv, nil)
+	if err != nil {
+		t.Fatalf("BuildEnv failed: %v", err)
+	}
+
+	// Build a set of expected vars
+	expected := map[string]bool{
+		"PATH=/usr/bin":   true,
+		"HOME=/home/user": true,
+		"MY_VAR=value1":   true,
+		"MY_APP=value2":   true,
+	}
+
+	// MY_SECRET_KEY and OTHER_VAR should NOT be in result
+	notExpected := map[string]bool{
+		"MY_SECRET_KEY=secret": true,
+		"OTHER_VAR=other":      true,
+	}
+
+	for _, kv := range result {
+		if notExpected[kv] {
+			t.Errorf("BuildEnv should not include %q", kv)
+		}
+		delete(expected, kv)
+	}
+
+	for kv := range expected {
+		t.Errorf("BuildEnv missing expected var %q", kv)
+	}
+}
+
+// TestBuildEnvMaxKeys tests max_keys enforcement.
+func TestBuildEnvMaxKeys(t *testing.T) {
+	pol := policy.ResolvedEnvPolicy{
+		MaxKeys: 2,
+	}
+
+	baseEnv := []string{
+		"A=1",
+		"B=2",
+		"C=3",
+	}
+
+	_, err := policy.BuildEnv(pol, baseEnv, nil)
+	if err == nil {
+		t.Error("BuildEnv should fail when exceeding max_keys")
+	}
+}
+
+// TestBuildEnvMaxBytes tests max_bytes enforcement.
+func TestBuildEnvMaxBytes(t *testing.T) {
+	pol := policy.ResolvedEnvPolicy{
+		MaxBytes: 10,
+	}
+
+	baseEnv := []string{
+		"PATH=/usr/local/bin:/usr/bin:/bin",
+	}
+
+	_, err := policy.BuildEnv(pol, baseEnv, nil)
+	if err == nil {
+		t.Error("BuildEnv should fail when exceeding max_bytes")
+	}
+}
+
+// TestBuildEnvAddKeys tests additional keys merging.
+func TestBuildEnvAddKeys(t *testing.T) {
+	pol := policy.ResolvedEnvPolicy{
+		Allow: []string{"PATH", "HOME", "EXTRA_*"},
+	}
+
+	baseEnv := []string{
+		"PATH=/usr/bin",
+		"HOME=/home/user",
+	}
+
+	addKeys := map[string]string{
+		"EXTRA_VAR": "added",
+	}
+
+	result, err := policy.BuildEnv(pol, baseEnv, addKeys)
+	if err != nil {
+		t.Fatalf("BuildEnv failed: %v", err)
+	}
+
+	found := false
+	for _, kv := range result {
+		if kv == "EXTRA_VAR=added" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Error("BuildEnv should include EXTRA_VAR from addKeys")
+	}
+}
+
+// TestMergeEnvPolicy tests policy merging.
+func TestMergeEnvPolicy(t *testing.T) {
+	global := policy.EnvPolicy{
+		Allow:          []string{"PATH", "HOME"},
+		Deny:           []string{"SECRET_*"},
+		MaxBytes:       1000,
+		MaxKeys:        10,
+		BlockIteration: false,
+	}
+
+	rule := policy.CommandRule{
+		EnvAllow:          []string{"PATH", "HOME", "EXTRA"},
+		EnvDeny:           []string{"SECRET_*", "TOKEN_*"},
+		EnvMaxBytes:       500,
+		EnvMaxKeys:        5,
+		EnvBlockIteration: boolPtr(true),
+	}
+
+	merged := policy.MergeEnvPolicy(global, rule)
+
+	// Rule should override global
+	if len(merged.Allow) != 3 {
+		t.Errorf("expected 3 allow entries, got %d", len(merged.Allow))
+	}
+	if len(merged.Deny) != 2 {
+		t.Errorf("expected 2 deny entries, got %d", len(merged.Deny))
+	}
+	if merged.MaxBytes != 500 {
+		t.Errorf("expected MaxBytes=500, got %d", merged.MaxBytes)
+	}
+	if merged.MaxKeys != 5 {
+		t.Errorf("expected MaxKeys=5, got %d", merged.MaxKeys)
+	}
+	if !merged.BlockIteration {
+		t.Error("expected BlockIteration=true")
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+// TestValidateEnvPolicy tests policy validation.
+func TestValidateEnvPolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  policy.EnvPolicy
+		wantErr bool
+	}{
+		{
+			name:    "valid empty policy",
+			policy:  policy.EnvPolicy{},
+			wantErr: false,
+		},
+		{
+			name: "valid policy with limits",
+			policy: policy.EnvPolicy{
+				MaxBytes: 1000,
+				MaxKeys:  10,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid negative max_bytes",
+			policy: policy.EnvPolicy{
+				MaxBytes: -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid negative max_keys",
+			policy: policy.EnvPolicy{
+				MaxKeys: -1,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := policy.ValidateEnvPolicy(tt.policy)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateEnvPolicy() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/test/integration/platform_test.go
+++ b/test/integration/platform_test.go
@@ -1,0 +1,455 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/platform"
+	_ "github.com/agentsh/agentsh/internal/platform/linux"
+)
+
+// TestPlatformCapabilities verifies platform detection and capability reporting.
+func TestPlatformCapabilities(t *testing.T) {
+	p, err := platform.New()
+	if err != nil {
+		t.Fatalf("failed to create platform: %v", err)
+	}
+
+	caps := p.Capabilities()
+	t.Logf("Platform: %s", p.Name())
+	t.Logf("FUSE: available=%v implementation=%s", caps.HasFUSE, caps.FUSEImplementation)
+	t.Logf("Network: available=%v implementation=%s", caps.HasNetworkIntercept, caps.NetworkImplementation)
+	t.Logf("Isolation: level=%v", caps.IsolationLevel)
+	t.Logf("Seccomp: %v", caps.HasSeccomp)
+	t.Logf("Cgroups: %v", caps.HasCgroups)
+
+	// Platform name must be non-empty
+	if p.Name() == "" {
+		t.Error("platform name must not be empty")
+	}
+}
+
+// TestPlatformWithOptions verifies platform creation with config options.
+func TestPlatformWithOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		opts platform.PlatformOptions
+	}{
+		{
+			name: "auto mode",
+			opts: platform.PlatformOptions{Mode: "auto"},
+		},
+		{
+			name: "empty mode defaults to auto",
+			opts: platform.PlatformOptions{Mode: ""},
+		},
+		{
+			name: "explicit linux mode",
+			opts: platform.PlatformOptions{Mode: "linux"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p, err := platform.NewWithOptions(tt.opts)
+			if err != nil {
+				t.Fatalf("NewWithOptions failed: %v", err)
+			}
+			if p == nil {
+				t.Fatal("platform is nil")
+			}
+			t.Logf("Created platform: %s", p.Name())
+		})
+	}
+}
+
+// TestFilesystemInterceptor verifies filesystem interceptor availability.
+func TestFilesystemInterceptor(t *testing.T) {
+	p, err := platform.New()
+	if err != nil {
+		t.Fatalf("failed to create platform: %v", err)
+	}
+
+	fs := p.Filesystem()
+	if fs == nil {
+		t.Fatal("Filesystem() returned nil")
+	}
+
+	t.Logf("Filesystem available: %v", fs.Available())
+	t.Logf("Filesystem implementation: %s", fs.Implementation())
+
+	caps := p.Capabilities()
+	if caps.HasFUSE && !fs.Available() {
+		t.Error("capabilities reports HasFUSE but Filesystem not available")
+	}
+}
+
+// TestNetworkInterceptor verifies network interceptor availability.
+func TestNetworkInterceptor(t *testing.T) {
+	p, err := platform.New()
+	if err != nil {
+		t.Fatalf("failed to create platform: %v", err)
+	}
+
+	net := p.Network()
+	if net == nil {
+		t.Fatal("Network() returned nil")
+	}
+
+	t.Logf("Network available: %v", net.Available())
+	t.Logf("Network implementation: %s", net.Implementation())
+
+	caps := p.Capabilities()
+	if caps.HasNetworkIntercept && !net.Available() {
+		t.Error("capabilities reports HasNetworkIntercept but Network not available")
+	}
+}
+
+// TestSandboxManager verifies sandbox manager availability.
+func TestSandboxManager(t *testing.T) {
+	p, err := platform.New()
+	if err != nil {
+		t.Fatalf("failed to create platform: %v", err)
+	}
+
+	sm := p.Sandbox()
+	if sm == nil {
+		t.Fatal("Sandbox() returned nil")
+	}
+
+	t.Logf("Sandbox available: %v", sm.Available())
+	t.Logf("Sandbox isolation level: %v", sm.IsolationLevel())
+
+	caps := p.Capabilities()
+	if caps.IsolationLevel != sm.IsolationLevel() {
+		t.Errorf("capabilities isolation level %v != sandbox isolation level %v",
+			caps.IsolationLevel, sm.IsolationLevel())
+	}
+}
+
+// TestResourceLimiter verifies resource limiter availability.
+func TestResourceLimiter(t *testing.T) {
+	p, err := platform.New()
+	if err != nil {
+		t.Fatalf("failed to create platform: %v", err)
+	}
+
+	rl := p.Resources()
+	if rl == nil {
+		t.Fatal("Resources() returned nil")
+	}
+
+	t.Logf("Resources available: %v", rl.Available())
+	t.Logf("Supported limits: %v", rl.SupportedLimits())
+}
+
+// TestSandboxCreate tests sandbox creation (if available).
+func TestSandboxCreate(t *testing.T) {
+	p, err := platform.New()
+	if err != nil {
+		t.Fatalf("failed to create platform: %v", err)
+	}
+
+	sm := p.Sandbox()
+	if !sm.Available() {
+		t.Skip("sandbox not available on this platform")
+	}
+
+	tmpDir := t.TempDir()
+	sandbox, err := sm.Create(platform.SandboxConfig{
+		Name:          "test-sandbox",
+		WorkspacePath: tmpDir,
+	})
+	if err != nil {
+		t.Fatalf("sandbox creation failed: %v", err)
+	}
+	defer sandbox.Close()
+
+	if sandbox.ID() == "" {
+		t.Error("sandbox ID must not be empty")
+	}
+	t.Logf("Created sandbox: %s", sandbox.ID())
+}
+
+// TestSandboxExecute tests command execution in sandbox.
+func TestSandboxExecute(t *testing.T) {
+	p, err := platform.New()
+	if err != nil {
+		t.Fatalf("failed to create platform: %v", err)
+	}
+
+	sm := p.Sandbox()
+	if !sm.Available() {
+		t.Skip("sandbox not available on this platform")
+	}
+
+	tmpDir := t.TempDir()
+	sandbox, err := sm.Create(platform.SandboxConfig{
+		Name:          "test-exec",
+		WorkspacePath: tmpDir,
+	})
+	if err != nil {
+		t.Fatalf("sandbox creation failed: %v", err)
+	}
+	defer sandbox.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	result, err := sandbox.Execute(ctx, "echo", "hello")
+	if err != nil {
+		t.Fatalf("sandbox execute failed: %v", err)
+	}
+
+	t.Logf("Exit code: %d", result.ExitCode)
+	t.Logf("Stdout: %s", string(result.Stdout))
+	t.Logf("Stderr: %s", string(result.Stderr))
+
+	if result.ExitCode != 0 {
+		t.Errorf("expected exit code 0, got %d", result.ExitCode)
+	}
+}
+
+// TestPlatformInitializeShutdown tests platform lifecycle.
+func TestPlatformInitializeShutdown(t *testing.T) {
+	p, err := platform.New()
+	if err != nil {
+		t.Fatalf("failed to create platform: %v", err)
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	events := make(chan platform.IOEvent, 100)
+	cfg := platform.Config{
+		WorkspacePath: tmpDir,
+		EventChannel:  events,
+	}
+
+	if err := p.Initialize(ctx, cfg); err != nil {
+		t.Logf("Initialize returned: %v (may be expected for some platforms)", err)
+	}
+
+	if err := p.Shutdown(ctx); err != nil {
+		t.Logf("Shutdown returned: %v (may be expected for some platforms)", err)
+	}
+}
+
+// TestParsePlatformMode verifies mode parsing.
+func TestParsePlatformMode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  platform.PlatformMode
+	}{
+		{"auto", platform.ModeAuto},
+		{"", platform.ModeAuto},
+		{"linux", platform.ModeLinuxNative},
+		{"linux-native", platform.ModeLinuxNative},
+		{"darwin", platform.ModeDarwinNative},
+		{"darwin-native", platform.ModeDarwinNative},
+		{"macos", platform.ModeDarwinNative},
+		{"darwin-lima", platform.ModeDarwinLima},
+		{"lima", platform.ModeDarwinLima},
+		{"windows", platform.ModeWindowsNative},
+		{"windows-native", platform.ModeWindowsNative},
+		{"windows-wsl2", platform.ModeWindowsWSL2},
+		{"wsl2", platform.ModeWindowsWSL2},
+		{"wsl", platform.ModeWindowsWSL2},
+		{"unknown", platform.ModeAuto},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := platform.ParsePlatformMode(tt.input)
+			if got != tt.want {
+				t.Errorf("ParsePlatformMode(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDetect verifies platform detection.
+func TestDetect(t *testing.T) {
+	mode, caps, err := platform.Detect()
+	if err != nil {
+		t.Fatalf("Detect() failed: %v", err)
+	}
+
+	t.Logf("Detected mode: %v", mode)
+	t.Logf("Capabilities: FUSE=%v Seccomp=%v Cgroups=%v Isolation=%v",
+		caps.HasFUSE, caps.HasSeccomp, caps.HasCgroups, caps.IsolationLevel)
+
+	if mode == platform.ModeAuto {
+		t.Error("Detect() should return a concrete mode, not ModeAuto")
+	}
+}
+
+// TestPlatformModeString verifies mode string conversion.
+func TestPlatformModeString(t *testing.T) {
+	tests := []struct {
+		mode platform.PlatformMode
+		want string
+	}{
+		{platform.ModeAuto, "auto"},
+		{platform.ModeLinuxNative, "linux-native"},
+		{platform.ModeDarwinNative, "darwin-native"},
+		{platform.ModeDarwinLima, "darwin-lima"},
+		{platform.ModeWindowsNative, "windows-native"},
+		{platform.ModeWindowsWSL2, "windows-wsl2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := tt.mode.String()
+			if got != tt.want {
+				t.Errorf("PlatformMode(%d).String() = %q, want %q", tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResourceLimiterApply tests resource limit application (if available).
+func TestResourceLimiterApply(t *testing.T) {
+	p, err := platform.New()
+	if err != nil {
+		t.Fatalf("failed to create platform: %v", err)
+	}
+
+	rl := p.Resources()
+	if !rl.Available() {
+		t.Skip("resource limiter not available on this platform")
+	}
+
+	supported := rl.SupportedLimits()
+	t.Logf("Supported limits: %v", supported)
+
+	// Only apply if we have memory support
+	hasMemory := false
+	for _, s := range supported {
+		if s == platform.ResourceMemory {
+			hasMemory = true
+			break
+		}
+	}
+
+	if !hasMemory {
+		t.Skip("memory limits not supported")
+	}
+
+	handle, err := rl.Apply(platform.ResourceConfig{
+		Name:        "test-limits",
+		MaxMemoryMB: 512,
+	})
+	if err != nil {
+		t.Fatalf("Apply failed: %v", err)
+	}
+	defer handle.Release()
+
+	stats := handle.Stats()
+	t.Logf("Initial stats: MemoryMB=%d CPUPercent=%.2f", stats.MemoryMB, stats.CPUPercent)
+}
+
+// TestIsolationLevel verifies isolation level consistency.
+func TestIsolationLevel(t *testing.T) {
+	tests := []struct {
+		level platform.IsolationLevel
+		str   string
+	}{
+		{platform.IsolationNone, "none"},
+		{platform.IsolationMinimal, "minimal"},
+		{platform.IsolationPartial, "partial"},
+		{platform.IsolationFull, "full"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.str, func(t *testing.T) {
+			got := tt.level.String()
+			if got != tt.str {
+				t.Errorf("IsolationLevel(%d).String() = %q, want %q", tt.level, got, tt.str)
+			}
+		})
+	}
+}
+
+// TestEventTypes verifies event type constants.
+func TestEventTypes(t *testing.T) {
+	events := []platform.EventType{
+		platform.EventFileOpen,
+		platform.EventFileRead,
+		platform.EventFileWrite,
+		platform.EventFileCreate,
+		platform.EventFileDelete,
+		platform.EventNetConnect,
+		platform.EventDNSQuery,
+		platform.EventEnvRead,
+		platform.EventEnvList,
+		platform.EventProcessExec,
+	}
+
+	for _, e := range events {
+		if e == "" {
+			t.Error("event type should not be empty")
+		}
+		t.Logf("EventType: %s", e)
+	}
+}
+
+// TestFileOperation verifies file operation constants.
+func TestFileOperation(t *testing.T) {
+	ops := []platform.FileOperation{
+		platform.FileOpRead,
+		platform.FileOpWrite,
+		platform.FileOpCreate,
+		platform.FileOpDelete,
+		platform.FileOpRename,
+		platform.FileOpStat,
+		platform.FileOpList,
+	}
+
+	for _, op := range ops {
+		if op == "" {
+			t.Error("file operation should not be empty")
+		}
+		t.Logf("FileOperation: %s", op)
+	}
+}
+
+// TestEnvOperation verifies env operation constants.
+func TestEnvOperation(t *testing.T) {
+	ops := []platform.EnvOperation{
+		platform.EnvOpRead,
+		platform.EnvOpList,
+		platform.EnvOpWrite,
+		platform.EnvOpDelete,
+	}
+
+	for _, op := range ops {
+		if op == "" {
+			t.Error("env operation should not be empty")
+		}
+		t.Logf("EnvOperation: %s", op)
+	}
+}
+
+// TestDecisionConstants verifies decision constants.
+func TestDecisionConstants(t *testing.T) {
+	if platform.DecisionAllow == "" {
+		t.Error("DecisionAllow should not be empty")
+	}
+	if platform.DecisionDeny == "" {
+		t.Error("DecisionDeny should not be empty")
+	}
+	if platform.DecisionApprove == "" {
+		t.Error("DecisionApprove should not be empty")
+	}
+	if platform.DecisionRedirect == "" {
+		t.Error("DecisionRedirect should not be empty")
+	}
+
+	t.Logf("Decisions: allow=%s deny=%s approve=%s redirect=%s",
+		platform.DecisionAllow, platform.DecisionDeny,
+		platform.DecisionApprove, platform.DecisionRedirect)
+}


### PR DESCRIPTION
## Summary

Adds comprehensive integration tests for the platform abstraction layer and env policy:

### Platform Tests (`test/integration/platform_test.go`)
- Platform capability detection and verification
- Platform creation with different modes (auto, linux, explicit)
- Filesystem/Network/Sandbox/Resource interceptor availability
- Sandbox creation and command execution
- Platform lifecycle (initialize/shutdown)
- Mode parsing and string conversion
- Resource limiter application
- Decision and operation constant verification

### Env Policy Tests (`test/integration/env_policy_test.go`)
- CheckEnv with glob patterns (allow/deny)
- Default secret blocking (AWS, GH tokens, etc.)
- BuildEnv with glob pattern filtering
- Max keys/bytes enforcement
- Additional keys merging
- Policy merging (global + rule override)
- Policy validation

## Usage

```bash
# Run integration tests
go test -tags=integration ./test/integration/...

# Run with verbose output
go test -tags=integration ./test/integration/... -v
```

## Test plan

- [x] All platform integration tests pass on Linux
- [x] All env policy integration tests pass
- [x] Regular test suite still passes (`go test ./...`)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)