### PR TITLE
feat: add cross-platform metadata support to trash package

### DIFF
--- a/internal/trash/platform_darwin.go
+++ b/internal/trash/platform_darwin.go
@@ -1,0 +1,100 @@
+//go:build darwin
+
+package trash
+
+import (
+	"os"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// capturePlatformMetadata captures macOS-specific metadata.
+func capturePlatformMetadata(path string, info os.FileInfo, entry *Entry, cfg Config) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if ok {
+		entry.UID = int(stat.Uid)
+		entry.GID = int(stat.Gid)
+		entry.MacFlags = stat.Flags
+	}
+
+	// Capture extended attributes (common on macOS for things like
+	// com.apple.quarantine, com.apple.FinderInfo, etc.)
+	if cfg.PreserveXattrs {
+		xattrs, err := listXattrs(path)
+		if err == nil {
+			for _, name := range xattrs {
+				value, err := getXattr(path, name)
+				if err == nil {
+					entry.Xattrs = append(entry.Xattrs, Xattr{
+						Name:  name,
+						Value: value,
+					})
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// restorePlatformMetadata restores macOS-specific metadata.
+func restorePlatformMetadata(path string, entry *Entry) error {
+	// Restore ownership
+	if entry.UID != 0 || entry.GID != 0 {
+		if err := os.Lchown(path, entry.UID, entry.GID); err != nil {
+			if !os.IsPermission(err) {
+				return err
+			}
+		}
+	}
+
+	// Restore macOS file flags (immutable, hidden, etc.)
+	if entry.MacFlags != 0 {
+		_ = unix.Chflags(path, int(entry.MacFlags))
+	}
+
+	// Restore extended attributes
+	for _, xattr := range entry.Xattrs {
+		_ = setXattr(path, xattr.Name, xattr.Value)
+	}
+
+	return nil
+}
+
+// listXattrs lists all extended attributes on a file.
+func listXattrs(path string) ([]string, error) {
+	size, err := unix.Llistxattr(path, nil)
+	if err != nil || size == 0 {
+		return nil, err
+	}
+	buf := make([]byte, size)
+	size, err = unix.Llistxattr(path, buf)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, name := range strings.Split(string(buf[:size]), "\x00") {
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+// getXattr gets the value of an extended attribute.
+func getXattr(path, name string) ([]byte, error) {
+	size, err := unix.Lgetxattr(path, name, nil)
+	if err != nil || size <= 0 {
+		return nil, err
+	}
+	buf := make([]byte, size)
+	_, err = unix.Lgetxattr(path, name, buf)
+	return buf, err
+}
+
+// setXattr sets an extended attribute.
+func setXattr(path, name string, value []byte) error {
+	return unix.Lsetxattr(path, name, value, 0)
+}

--- a/internal/trash/platform_linux.go
+++ b/internal/trash/platform_linux.go
@@ -1,0 +1,94 @@
+//go:build linux
+
+package trash
+
+import (
+	"os"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// capturePlatformMetadata captures Linux-specific metadata.
+func capturePlatformMetadata(path string, info os.FileInfo, entry *Entry, cfg Config) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if ok {
+		entry.UID = int(stat.Uid)
+		entry.GID = int(stat.Gid)
+	}
+
+	// Capture extended attributes if requested
+	if cfg.PreserveXattrs {
+		xattrs, err := listXattrs(path)
+		if err == nil {
+			for _, name := range xattrs {
+				value, err := getXattr(path, name)
+				if err == nil {
+					entry.Xattrs = append(entry.Xattrs, Xattr{
+						Name:  name,
+						Value: value,
+					})
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// restorePlatformMetadata restores Linux-specific metadata.
+func restorePlatformMetadata(path string, entry *Entry) error {
+	// Restore ownership
+	if entry.UID != 0 || entry.GID != 0 {
+		if err := os.Lchown(path, entry.UID, entry.GID); err != nil {
+			// Ignore permission errors
+			if !os.IsPermission(err) {
+				return err
+			}
+		}
+	}
+
+	// Restore extended attributes
+	for _, xattr := range entry.Xattrs {
+		_ = setXattr(path, xattr.Name, xattr.Value)
+	}
+
+	return nil
+}
+
+// listXattrs lists all extended attributes on a file.
+func listXattrs(path string) ([]string, error) {
+	size, err := unix.Llistxattr(path, nil)
+	if err != nil || size == 0 {
+		return nil, err
+	}
+	buf := make([]byte, size)
+	size, err = unix.Llistxattr(path, buf)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, name := range strings.Split(string(buf[:size]), "\x00") {
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+// getXattr gets the value of an extended attribute.
+func getXattr(path, name string) ([]byte, error) {
+	size, err := unix.Lgetxattr(path, name, nil)
+	if err != nil || size <= 0 {
+		return nil, err
+	}
+	buf := make([]byte, size)
+	_, err = unix.Lgetxattr(path, name, buf)
+	return buf, err
+}
+
+// setXattr sets an extended attribute.
+func setXattr(path, name string, value []byte) error {
+	return unix.Lsetxattr(path, name, value, 0)
+}

--- a/internal/trash/platform_other.go
+++ b/internal/trash/platform_other.go
@@ -1,0 +1,19 @@
+//go:build !linux && !darwin && !windows
+
+package trash
+
+import (
+	"os"
+)
+
+// capturePlatformMetadata is a no-op on unsupported platforms.
+func capturePlatformMetadata(path string, info os.FileInfo, entry *Entry, cfg Config) error {
+	// No platform-specific metadata on unsupported platforms
+	return nil
+}
+
+// restorePlatformMetadata is a no-op on unsupported platforms.
+func restorePlatformMetadata(path string, entry *Entry) error {
+	// No platform-specific metadata on unsupported platforms
+	return nil
+}

--- a/internal/trash/platform_windows.go
+++ b/internal/trash/platform_windows.go
@@ -1,0 +1,101 @@
+//go:build windows
+
+package trash
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// capturePlatformMetadata captures Windows-specific metadata.
+func capturePlatformMetadata(path string, info os.FileInfo, entry *Entry, cfg Config) error {
+	// Get Windows file attributes
+	pathPtr, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return err
+	}
+
+	attrs, err := syscall.GetFileAttributes(pathPtr)
+	if err == nil {
+		entry.WinAttrs = attrs
+	}
+
+	// Capture security descriptor if requested
+	if cfg.PreserveSecurity {
+		sd, err := getSecurityDescriptor(path)
+		if err == nil {
+			entry.WinSecurity = sd
+		}
+	}
+
+	return nil
+}
+
+// restorePlatformMetadata restores Windows-specific metadata.
+func restorePlatformMetadata(path string, entry *Entry) error {
+	// Restore Windows file attributes
+	if entry.WinAttrs != 0 {
+		pathPtr, err := syscall.UTF16PtrFromString(path)
+		if err == nil {
+			_ = syscall.SetFileAttributes(pathPtr, entry.WinAttrs)
+		}
+	}
+
+	// Restore security descriptor
+	if len(entry.WinSecurity) > 0 {
+		_ = setSecurityDescriptor(path, entry.WinSecurity)
+	}
+
+	return nil
+}
+
+// getSecurityDescriptor retrieves the security descriptor for a file.
+func getSecurityDescriptor(path string) ([]byte, error) {
+	var sd *windows.SECURITY_DESCRIPTOR
+	err := windows.GetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION|windows.OWNER_SECURITY_INFORMATION,
+		nil, nil, nil, nil,
+		&sd,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if sd != nil {
+			_, _ = windows.LocalFree(windows.Handle(unsafe.Pointer(sd)))
+		}
+	}()
+
+	length := sd.Length()
+	buf := make([]byte, length)
+	copy(buf, unsafe.Slice((*byte)(unsafe.Pointer(sd)), length))
+	return buf, nil
+}
+
+// setSecurityDescriptor sets the security descriptor for a file.
+func setSecurityDescriptor(path string, sdBytes []byte) error {
+	if len(sdBytes) == 0 {
+		return nil
+	}
+
+	sd := (*windows.SECURITY_DESCRIPTOR)(unsafe.Pointer(&sdBytes[0]))
+
+	dacl, _, err := sd.DACL()
+	if err != nil {
+		return err
+	}
+
+	return windows.SetNamedSecurityInfo(
+		path,
+		windows.SE_FILE_OBJECT,
+		windows.DACL_SECURITY_INFORMATION,
+		nil, nil,
+		dacl,
+		nil,
+	)
+}


### PR DESCRIPTION
## Summary

Enhances the trash package with cross-platform metadata preservation:

- Adds `Platform` field to `Entry` to track which OS created the entry
- **Linux**: Captures/restores UID, GID, and extended attributes (xattrs)
- **macOS**: Captures/restores UID, GID, chflags, and extended attributes
- **Windows**: Captures/restores file attributes and security descriptors
- Adds `PreserveXattrs` and `PreserveSecurity` config options

New purge functionality:
- `PurgeOptions.QuotaCount` - limit max number of entries
- `PurgeOptions.DryRun` - preview mode without actual deletion
- `PurgeResult` struct with detailed purge results (entries, bytes reclaimed)
- `PurgeWithResult()` function for detailed results

Platform-specific files:
- `platform_linux.go` - xattr via golang.org/x/sys/unix
- `platform_darwin.go` - xattr + chflags via golang.org/x/sys/unix
- `platform_windows.go` - file attributes + security descriptors via golang.org/x/sys/windows
- `platform_other.go` - no-op fallback

## Test plan

- [x] Existing trash tests pass
- [x] New tests for PurgeWithResult, DryRun, QuotaCount
- [x] Platform field is set correctly
- [x] xattr capture test (Linux/macOS only)
- [x] Session-only purge still works (TestDestroySessionPurgesTrash)
- [x] Full test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)