### PR TITLE
feat: add cross-platform shell shim and session ID support

### DIFF
--- a/internal/shim/flock_unix.go
+++ b/internal/shim/flock_unix.go
@@ -1,0 +1,28 @@
+//go:build unix
+
+package shim
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// lockFileExclusive acquires an exclusive lock on the file.
+func lockFileExclusive(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_EX)
+}
+
+// unlockFile releases the lock on the file.
+func unlockFile(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_UN)
+}
+
+// defaultSessionBaseDirs returns platform-specific default directories for session files.
+func defaultSessionBaseDirs(workspaceRoot string) []string {
+	return []string{
+		"/run/agentsh",
+		"/tmp/agentsh",
+		workspaceRoot + "/.agentsh",
+	}
+}

--- a/internal/shim/flock_windows.go
+++ b/internal/shim/flock_windows.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package shim
+
+import (
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/windows"
+)
+
+// lockFileExclusive acquires an exclusive lock on the file.
+// On Windows, we use LockFileEx with LOCKFILE_EXCLUSIVE_LOCK.
+func lockFileExclusive(f *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,
+		1, 0,
+		&overlapped,
+	)
+}
+
+// unlockFile releases the lock on the file.
+func unlockFile(f *os.File) error {
+	var overlapped windows.Overlapped
+	return windows.UnlockFileEx(
+		windows.Handle(f.Fd()),
+		0,
+		1, 0,
+		&overlapped,
+	)
+}
+
+// defaultSessionBaseDirs returns platform-specific default directories for session files.
+func defaultSessionBaseDirs(workspaceRoot string) []string {
+	// On Windows, use %LOCALAPPDATA%\agentsh or fallback to workspace
+	localAppData := os.Getenv("LOCALAPPDATA")
+	if localAppData == "" {
+		home, _ := os.UserHomeDir()
+		localAppData = filepath.Join(home, "AppData", "Local")
+	}
+
+	tempDir := os.Getenv("TEMP")
+	if tempDir == "" {
+		tempDir = os.TempDir()
+	}
+
+	return []string{
+		filepath.Join(localAppData, "agentsh"),
+		filepath.Join(tempDir, "agentsh"),
+		filepath.Join(workspaceRoot, ".agentsh"),
+	}
+}

--- a/internal/shim/install_darwin.go
+++ b/internal/shim/install_darwin.go
@@ -1,0 +1,311 @@
+//go:build darwin
+
+package shim
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DarwinShimStrategy defines the strategy for shell shimming on macOS.
+type DarwinShimStrategy string
+
+const (
+	// StrategyPATH creates shims in ~/.agentsh/bin that must be added to PATH.
+	StrategyPATH DarwinShimStrategy = "path"
+
+	// StrategyProfile adds hooks to shell profile files (.zshrc, .bashrc).
+	StrategyProfile DarwinShimStrategy = "profile"
+)
+
+// DarwinShimConfig configures macOS shell shim installation.
+type DarwinShimConfig struct {
+	// Strategy selects how to install the shim
+	Strategy DarwinShimStrategy
+
+	// AgentshBinary is the path to the agentsh binary
+	AgentshBinary string
+
+	// Shells to shim (for PATH strategy)
+	Shells []string
+
+	// ProfilePaths to modify (for profile strategy)
+	// If empty, defaults are used based on detected shells
+	ProfilePaths []string
+}
+
+// DefaultDarwinShells returns the default shells to shim on macOS.
+func DefaultDarwinShells() []string {
+	return []string{"sh", "bash", "zsh", "dash"}
+}
+
+// InstallDarwinPATH creates wrapper scripts in ~/.agentsh/bin for each shell.
+// Users must add ~/.agentsh/bin to their PATH.
+func InstallDarwinPATH(cfg DarwinShimConfig) error {
+	if cfg.AgentshBinary == "" {
+		cfg.AgentshBinary = "agentsh"
+	}
+	if len(cfg.Shells) == 0 {
+		cfg.Shells = DefaultDarwinShells()
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("get home dir: %w", err)
+	}
+
+	shimDir := filepath.Join(home, ".agentsh", "bin")
+	if err := os.MkdirAll(shimDir, 0o755); err != nil {
+		return fmt.Errorf("create shim dir: %w", err)
+	}
+
+	for _, shell := range cfg.Shells {
+		shimPath := filepath.Join(shimDir, shell)
+		script := fmt.Sprintf(`#!/bin/bash
+# agentsh shell shim for %s
+# This wrapper routes shell commands through agentsh for policy enforcement.
+
+# Find the real shell
+REAL_SHELL=""
+for candidate in /bin/%s /usr/bin/%s /opt/homebrew/bin/%s; do
+    if [ -x "$candidate" ] && [ "$candidate" != "$0" ]; then
+        REAL_SHELL="$candidate"
+        break
+    fi
+done
+
+if [ -z "$REAL_SHELL" ]; then
+    echo "agentsh: cannot find real %s binary" >&2
+    exit 1
+fi
+
+# If agentsh is not active, pass through to real shell
+if [ -z "$AGENTSH_SESSION" ] && [ -z "$AGENTSH_ENABLED" ]; then
+    exec "$REAL_SHELL" "$@"
+fi
+
+# Route through agentsh
+exec %s shim-exec "$REAL_SHELL" "$@"
+`, shell, shell, shell, shell, shell, cfg.AgentshBinary)
+
+		if err := os.WriteFile(shimPath, []byte(script), 0o755); err != nil {
+			return fmt.Errorf("write shim %s: %w", shimPath, err)
+		}
+	}
+
+	return nil
+}
+
+// UninstallDarwinPATH removes the shim directory.
+func UninstallDarwinPATH() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("get home dir: %w", err)
+	}
+
+	shimDir := filepath.Join(home, ".agentsh", "bin")
+	if err := os.RemoveAll(shimDir); err != nil {
+		return fmt.Errorf("remove shim dir: %w", err)
+	}
+
+	return nil
+}
+
+// GetDarwinPATHInstruction returns the instruction for adding shims to PATH.
+func GetDarwinPATHInstruction() string {
+	return `# Add to your shell profile (~/.zshrc or ~/.bashrc):
+export PATH="$HOME/.agentsh/bin:$PATH"`
+}
+
+// ProfileHookConfig configures profile hook installation.
+type ProfileHookConfig struct {
+	// Zsh installs hook to ~/.zshrc
+	Zsh bool
+
+	// Bash installs hook to ~/.bashrc and ~/.bash_profile
+	Bash bool
+}
+
+// profileHookMarkerStart is used to identify our additions.
+const profileHookMarkerStart = "# >>> agentsh shell integration >>>"
+const profileHookMarkerEnd = "# <<< agentsh shell integration <<<"
+
+// InstallDarwinProfileHook adds agentsh integration to shell profile files.
+func InstallDarwinProfileHook(cfg ProfileHookConfig) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("get home dir: %w", err)
+	}
+
+	hook := fmt.Sprintf(`%s
+# When AGENTSH_ENABLED is set, wrap the shell session
+if [[ -z "$AGENTSH_INSIDE" && -n "$AGENTSH_ENABLED" ]]; then
+    export AGENTSH_INSIDE=1
+    if [[ -n "$AGENTSH_SESSION" ]]; then
+        exec agentsh session attach "$AGENTSH_SESSION"
+    fi
+fi
+%s
+`, profileHookMarkerStart, profileHookMarkerEnd)
+
+	if cfg.Zsh {
+		zshrc := filepath.Join(home, ".zshrc")
+		if err := appendIfMissing(zshrc, hook); err != nil {
+			return fmt.Errorf("install zsh hook: %w", err)
+		}
+	}
+
+	if cfg.Bash {
+		bashrc := filepath.Join(home, ".bashrc")
+		if err := appendIfMissing(bashrc, hook); err != nil {
+			return fmt.Errorf("install bashrc hook: %w", err)
+		}
+
+		bashProfile := filepath.Join(home, ".bash_profile")
+		if err := appendIfMissing(bashProfile, hook); err != nil {
+			return fmt.Errorf("install bash_profile hook: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// UninstallDarwinProfileHook removes agentsh integration from shell profiles.
+func UninstallDarwinProfileHook(cfg ProfileHookConfig) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("get home dir: %w", err)
+	}
+
+	if cfg.Zsh {
+		zshrc := filepath.Join(home, ".zshrc")
+		if err := removeHookFromFile(zshrc); err != nil {
+			return fmt.Errorf("remove zsh hook: %w", err)
+		}
+	}
+
+	if cfg.Bash {
+		bashrc := filepath.Join(home, ".bashrc")
+		if err := removeHookFromFile(bashrc); err != nil {
+			return fmt.Errorf("remove bashrc hook: %w", err)
+		}
+
+		bashProfile := filepath.Join(home, ".bash_profile")
+		if err := removeHookFromFile(bashProfile); err != nil {
+			return fmt.Errorf("remove bash_profile hook: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// appendIfMissing appends content to file if our marker is not already present.
+func appendIfMissing(path, content string) error {
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if strings.Contains(string(existing), profileHookMarkerStart) {
+		// Already installed
+		return nil
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Add newline before our content if file doesn't end with one
+	if len(existing) > 0 && existing[len(existing)-1] != '\n' {
+		if _, err := f.WriteString("\n"); err != nil {
+			return err
+		}
+	}
+
+	_, err = f.WriteString("\n" + content + "\n")
+	return err
+}
+
+// removeHookFromFile removes our hook block from a file.
+func removeHookFromFile(path string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	lines := strings.Split(string(content), "\n")
+	var result []string
+	inBlock := false
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == strings.TrimSpace(profileHookMarkerStart) {
+			inBlock = true
+			continue
+		}
+		if strings.TrimSpace(line) == strings.TrimSpace(profileHookMarkerEnd) {
+			inBlock = false
+			continue
+		}
+		if !inBlock {
+			result = append(result, line)
+		}
+	}
+
+	return os.WriteFile(path, []byte(strings.Join(result, "\n")), 0o644)
+}
+
+// DarwinShimStatus reports the status of macOS shim installation.
+type DarwinShimStatus struct {
+	PATHInstalled    bool     `json:"path_installed"`
+	PATHDir          string   `json:"path_dir"`
+	PATHShells       []string `json:"path_shells"`
+	PATHInPath       bool     `json:"path_in_path"`
+	ProfileZsh       bool     `json:"profile_zsh"`
+	ProfileBash      bool     `json:"profile_bash"`
+}
+
+// GetDarwinShimStatus checks the current installation status.
+func GetDarwinShimStatus() (*DarwinShimStatus, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("get home dir: %w", err)
+	}
+
+	status := &DarwinShimStatus{
+		PATHDir: filepath.Join(home, ".agentsh", "bin"),
+	}
+
+	// Check PATH-based installation
+	if entries, err := os.ReadDir(status.PATHDir); err == nil {
+		status.PATHInstalled = true
+		for _, e := range entries {
+			if !e.IsDir() {
+				status.PATHShells = append(status.PATHShells, e.Name())
+			}
+		}
+	}
+
+	// Check if shim dir is in PATH
+	pathEnv := os.Getenv("PATH")
+	status.PATHInPath = strings.Contains(pathEnv, status.PATHDir)
+
+	// Check profile hooks
+	zshrc := filepath.Join(home, ".zshrc")
+	if content, err := os.ReadFile(zshrc); err == nil {
+		status.ProfileZsh = strings.Contains(string(content), profileHookMarkerStart)
+	}
+
+	bashrc := filepath.Join(home, ".bashrc")
+	if content, err := os.ReadFile(bashrc); err == nil {
+		status.ProfileBash = strings.Contains(string(content), profileHookMarkerStart)
+	}
+
+	return status, nil
+}

--- a/internal/shim/install_windows.go
+++ b/internal/shim/install_windows.go
@@ -1,0 +1,282 @@
+//go:build windows
+
+package shim
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// WindowsShimStrategy defines the strategy for shell shimming on Windows.
+type WindowsShimStrategy string
+
+const (
+	// StrategyPSProfile adds hooks to PowerShell profile.
+	StrategyPSProfile WindowsShimStrategy = "psprofile"
+
+	// StrategyWrapper creates wrapper executables in PATH.
+	StrategyWrapper WindowsShimStrategy = "wrapper"
+)
+
+// WindowsShimConfig configures Windows shell shim installation.
+type WindowsShimConfig struct {
+	Strategy      WindowsShimStrategy
+	AgentshBinary string
+}
+
+// psProfileHookMarkerStart is used to identify our additions.
+const psProfileHookMarkerStart = "# >>> agentsh PowerShell integration >>>"
+const psProfileHookMarkerEnd = "# <<< agentsh PowerShell integration <<<"
+
+// GetPowerShellProfilePath returns the path to the current user's PowerShell profile.
+func GetPowerShellProfilePath() (string, error) {
+	// PowerShell Core (pwsh) profile location
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("get home dir: %w", err)
+	}
+
+	// Try PowerShell Core first (cross-platform)
+	pwshProfile := filepath.Join(home, "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1")
+
+	// Fallback to Windows PowerShell
+	winPSProfile := filepath.Join(home, "Documents", "WindowsPowerShell", "Microsoft.PowerShell_profile.ps1")
+
+	// Check if PowerShell Core directory exists
+	if _, err := os.Stat(filepath.Dir(pwshProfile)); err == nil {
+		return pwshProfile, nil
+	}
+
+	// Use Windows PowerShell location
+	return winPSProfile, nil
+}
+
+// InstallWindowsPSProfile adds agentsh integration to PowerShell profile.
+func InstallWindowsPSProfile(cfg WindowsShimConfig) error {
+	if cfg.AgentshBinary == "" {
+		cfg.AgentshBinary = "agentsh"
+	}
+
+	profilePath, err := GetPowerShellProfilePath()
+	if err != nil {
+		return err
+	}
+
+	// Ensure profile directory exists
+	if err := os.MkdirAll(filepath.Dir(profilePath), 0o755); err != nil {
+		return fmt.Errorf("create profile dir: %w", err)
+	}
+
+	hook := fmt.Sprintf(`%s
+# agentsh PowerShell integration
+# When AGENTSH_ENABLED is set, commands are routed through agentsh
+
+if ($env:AGENTSH_ENABLED -and -not $env:AGENTSH_INSIDE) {
+    $env:AGENTSH_INSIDE = "1"
+
+    # Function to execute commands via agentsh
+    function Invoke-AgentshCommand {
+        param([string]$Command)
+        & %s exec $env:AGENTSH_SESSION -- powershell -Command $Command
+    }
+    Set-Alias -Name ash -Value Invoke-AgentshCommand -Scope Global
+
+    # If session is set, attach to it
+    if ($env:AGENTSH_SESSION) {
+        Write-Host "agentsh: attached to session $env:AGENTSH_SESSION" -ForegroundColor Cyan
+    }
+}
+%s
+`, psProfileHookMarkerStart, cfg.AgentshBinary, psProfileHookMarkerEnd)
+
+	return appendIfMissingPS(profilePath, hook)
+}
+
+// UninstallWindowsPSProfile removes agentsh integration from PowerShell profile.
+func UninstallWindowsPSProfile() error {
+	profilePath, err := GetPowerShellProfilePath()
+	if err != nil {
+		return err
+	}
+
+	return removeHookFromFilePS(profilePath)
+}
+
+// appendIfMissingPS appends content to PowerShell profile if marker is not present.
+func appendIfMissingPS(path, content string) error {
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if strings.Contains(string(existing), psProfileHookMarkerStart) {
+		// Already installed
+		return nil
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Add newlines before our content
+	if len(existing) > 0 && existing[len(existing)-1] != '\n' {
+		if _, err := f.WriteString("\r\n"); err != nil {
+			return err
+		}
+	}
+
+	_, err = f.WriteString("\r\n" + content + "\r\n")
+	return err
+}
+
+// removeHookFromFilePS removes our hook block from a PowerShell file.
+func removeHookFromFilePS(path string) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	// Handle both Windows and Unix line endings
+	text := strings.ReplaceAll(string(content), "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	var result []string
+	inBlock := false
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == strings.TrimSpace(psProfileHookMarkerStart) {
+			inBlock = true
+			continue
+		}
+		if trimmed == strings.TrimSpace(psProfileHookMarkerEnd) {
+			inBlock = false
+			continue
+		}
+		if !inBlock {
+			result = append(result, line)
+		}
+	}
+
+	// Use Windows line endings
+	return os.WriteFile(path, []byte(strings.Join(result, "\r\n")), 0o644)
+}
+
+// InstallWindowsWrapper creates wrapper batch files in a PATH directory.
+func InstallWindowsWrapper(cfg WindowsShimConfig) error {
+	if cfg.AgentshBinary == "" {
+		cfg.AgentshBinary = "agentsh"
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("get home dir: %w", err)
+	}
+
+	wrapperDir := filepath.Join(home, ".agentsh", "bin")
+	if err := os.MkdirAll(wrapperDir, 0o755); err != nil {
+		return fmt.Errorf("create wrapper dir: %w", err)
+	}
+
+	// Create wrapper for cmd.exe
+	cmdWrapper := filepath.Join(wrapperDir, "cmd.bat")
+	cmdScript := fmt.Sprintf(`@echo off
+REM agentsh cmd.exe wrapper
+IF NOT DEFINED AGENTSH_SESSION (
+    %%SystemRoot%%\System32\cmd.exe %%*
+) ELSE (
+    %s exec %%AGENTSH_SESSION%% -- %%SystemRoot%%\System32\cmd.exe %%*
+)
+`, cfg.AgentshBinary)
+
+	if err := os.WriteFile(cmdWrapper, []byte(cmdScript), 0o755); err != nil {
+		return fmt.Errorf("write cmd wrapper: %w", err)
+	}
+
+	// Create wrapper for PowerShell
+	psWrapper := filepath.Join(wrapperDir, "powershell.bat")
+	psScript := fmt.Sprintf(`@echo off
+REM agentsh PowerShell wrapper
+IF NOT DEFINED AGENTSH_SESSION (
+    powershell.exe %%*
+) ELSE (
+    %s exec %%AGENTSH_SESSION%% -- powershell.exe %%*
+)
+`, cfg.AgentshBinary)
+
+	if err := os.WriteFile(psWrapper, []byte(psScript), 0o755); err != nil {
+		return fmt.Errorf("write powershell wrapper: %w", err)
+	}
+
+	return nil
+}
+
+// UninstallWindowsWrapper removes the wrapper directory.
+func UninstallWindowsWrapper() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("get home dir: %w", err)
+	}
+
+	wrapperDir := filepath.Join(home, ".agentsh", "bin")
+	return os.RemoveAll(wrapperDir)
+}
+
+// GetWindowsWrapperInstruction returns the instruction for adding wrappers to PATH.
+func GetWindowsWrapperInstruction() string {
+	home, _ := os.UserHomeDir()
+	wrapperDir := filepath.Join(home, ".agentsh", "bin")
+	return fmt.Sprintf(`# Add to your PATH environment variable:
+# %s
+
+# Or run this in PowerShell (admin):
+[Environment]::SetEnvironmentVariable("Path", $env:Path + ";%s", "User")
+`, wrapperDir, wrapperDir)
+}
+
+// WindowsShimStatus reports the status of Windows shim installation.
+type WindowsShimStatus struct {
+	PSProfileInstalled bool   `json:"psprofile_installed"`
+	PSProfilePath      string `json:"psprofile_path"`
+	WrapperInstalled   bool   `json:"wrapper_installed"`
+	WrapperDir         string `json:"wrapper_dir"`
+	WrapperInPath      bool   `json:"wrapper_in_path"`
+}
+
+// GetWindowsShimStatus checks the current installation status.
+func GetWindowsShimStatus() (*WindowsShimStatus, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("get home dir: %w", err)
+	}
+
+	status := &WindowsShimStatus{
+		WrapperDir: filepath.Join(home, ".agentsh", "bin"),
+	}
+
+	// Check PowerShell profile
+	profilePath, err := GetPowerShellProfilePath()
+	if err == nil {
+		status.PSProfilePath = profilePath
+		if content, err := os.ReadFile(profilePath); err == nil {
+			status.PSProfileInstalled = strings.Contains(string(content), psProfileHookMarkerStart)
+		}
+	}
+
+	// Check wrapper installation
+	if _, err := os.Stat(status.WrapperDir); err == nil {
+		status.WrapperInstalled = true
+	}
+
+	// Check if wrapper dir is in PATH
+	pathEnv := os.Getenv("PATH")
+	status.WrapperInPath = strings.Contains(strings.ToLower(pathEnv), strings.ToLower(status.WrapperDir))
+
+	return status, nil
+}


### PR DESCRIPTION
## Summary

- Adds macOS shell shim installation (`install_darwin.go`) with two strategies:
  - **PATH-based**: Creates wrapper scripts in `~/.agentsh/bin` for sh/bash/zsh/dash
  - **Profile hook**: Adds integration hooks to `.zshrc` and `.bashrc`
- Adds Windows shell shim installation (`install_windows.go`) with two strategies:
  - **PowerShell profile**: Adds agentsh integration to PowerShell profile
  - **Wrapper**: Creates batch file wrappers for cmd.exe and PowerShell
- Refactors `session_id.go` for cross-platform file locking:
  - Extracts locking into `flock_unix.go` (uses `unix.Flock`)
  - Adds `flock_windows.go` (uses Windows `LockFileEx`/`UnlockFileEx`)
  - Uses platform-appropriate default session directories

## Test plan

- [x] All existing shim tests pass
- [x] Full test suite passes (`go test ./...`)
- [x] Build succeeds for local platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)