### PR TITLE
feat: add command interception and file path redirect support

### DIFF
--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -33,9 +33,11 @@ type Limits struct {
 }
 
 type compiledFileRule struct {
-	rule  FileRule
-	globs []glob.Glob
-	ops   map[string]struct{}
+	rule         FileRule
+	globs        []glob.Glob
+	ops          map[string]struct{}
+	redirectTo   string // Expanded redirect target
+	preserveTree bool
 }
 
 type compiledNetworkRule struct {
@@ -64,6 +66,7 @@ type Decision struct {
 	Message           string
 	Approval          *types.ApprovalInfo
 	Redirect          *types.RedirectInfo
+	FileRedirect      *types.FileRedirectInfo
 	EnvPolicy         ResolvedEnvPolicy
 }
 
@@ -74,7 +77,12 @@ func NewEngine(p *Policy, enforceApprovals bool) (*Engine, error) {
 	}
 
 	for _, r := range p.FileRules {
-		cr := compiledFileRule{rule: r, ops: map[string]struct{}{}}
+		cr := compiledFileRule{
+			rule:         r,
+			ops:          map[string]struct{}{},
+			redirectTo:   r.RedirectTo,
+			preserveTree: r.PreserveTree,
+		}
 		for _, op := range r.Operations {
 			cr.ops[strings.ToLower(op)] = struct{}{}
 		}
@@ -277,12 +285,38 @@ func (e *Engine) CheckFile(p string, operation string) Decision {
 		}
 		for _, g := range r.globs {
 			if g.Match(p) {
-				return e.wrapDecision(r.rule.Decision, r.rule.Name, r.rule.Message, nil)
+				dec := e.wrapDecision(r.rule.Decision, r.rule.Name, r.rule.Message, nil)
+
+				// Handle file redirect if configured
+				if r.redirectTo != "" && dec.PolicyDecision == types.DecisionRedirect {
+					dec.FileRedirect = computeFileRedirect(p, operation, r.redirectTo, r.preserveTree, r.rule.Message)
+				}
+
+				return dec
 			}
 		}
 	}
 	// Default deny (policy files typically include an explicit default deny, but we enforce it here too).
 	return e.wrapDecision(string(types.DecisionDeny), "default-deny-files", "", nil)
+}
+
+// computeFileRedirect calculates the redirected path for a file operation.
+func computeFileRedirect(originalPath, operation, targetBase string, preserveTree bool, msg string) *types.FileRedirectInfo {
+	var newPath string
+	if preserveTree {
+		// /home/user/file.txt -> /workspace/.scratch/home/user/file.txt
+		newPath = filepath.Join(targetBase, originalPath)
+	} else {
+		// /home/user/file.txt -> /workspace/.scratch/file.txt
+		newPath = filepath.Join(targetBase, filepath.Base(originalPath))
+	}
+
+	return &types.FileRedirectInfo{
+		OriginalPath: originalPath,
+		RedirectPath: newPath,
+		Operation:    operation,
+		Reason:       msg,
+	}
 }
 
 // CheckUnixSocket evaluates unix_socket_rules against a path and operation (connect|bind|listen|sendto).
@@ -430,6 +464,22 @@ func (e *Engine) wrapDecision(decision string, rule string, msg string, redirect
 			Message:           msg,
 			Redirect:          toRedirectInfo(redirect, msg),
 		}
+	case types.DecisionAudit:
+		// Audit is allow + enhanced logging (caller should emit audit event)
+		return Decision{
+			PolicyDecision:    pd,
+			EffectiveDecision: types.DecisionAllow,
+			Rule:              rule,
+			Message:           msg,
+		}
+	case types.DecisionSoftDelete:
+		// Soft delete means redirect destructive operations to trash
+		return Decision{
+			PolicyDecision:    pd,
+			EffectiveDecision: types.DecisionAllow,
+			Rule:              rule,
+			Message:           msg,
+		}
 	default:
 		// Safe fallback.
 		return Decision{PolicyDecision: types.DecisionDeny, EffectiveDecision: types.DecisionDeny, Rule: "invalid-policy-decision", Message: "invalid decision in policy"}
@@ -441,8 +491,21 @@ func toRedirectInfo(r *CommandRedirect, msg string) *types.RedirectInfo {
 		return nil
 	}
 	return &types.RedirectInfo{
-		Command: r.Command,
-		Args:    append([]string{}, r.Args...),
-		Reason:  msg,
+		Command:     r.Command,
+		Args:        append([]string{}, r.Args...),
+		ArgsAppend:  append([]string{}, r.ArgsAppend...),
+		Environment: copyMap(r.Environment),
+		Reason:      msg,
 	}
+}
+
+func copyMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	result := make(map[string]string, len(m))
+	for k, v := range m {
+		result[k] = v
+	}
+	return result
 }

--- a/internal/policy/model.go
+++ b/internal/policy/model.go
@@ -30,6 +30,10 @@ type FileRule struct {
 	Decision    string   `yaml:"decision"`
 	Message     string   `yaml:"message"`
 	Timeout     duration `yaml:"timeout"`
+
+	// Redirect configuration for file operations
+	RedirectTo   string `yaml:"redirect_to,omitempty"`   // Target directory for redirected files
+	PreserveTree bool   `yaml:"preserve_tree,omitempty"` // Preserve directory structure under target
 }
 
 type NetworkRule struct {
@@ -60,8 +64,10 @@ type CommandRule struct {
 }
 
 type CommandRedirect struct {
-	Command string   `yaml:"command"`
-	Args    []string `yaml:"args,omitempty"`
+	Command     string            `yaml:"command"`
+	Args        []string          `yaml:"args,omitempty"`        // Prepended args
+	ArgsAppend  []string          `yaml:"args_append,omitempty"` // Appended args
+	Environment map[string]string `yaml:"environment,omitempty"` // Environment overrides
 }
 
 // UnixSocketRule controls AF_UNIX socket operations such as connect/bind/listen.

--- a/internal/policy/redirect.go
+++ b/internal/policy/redirect.go
@@ -1,0 +1,133 @@
+package policy
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/gobwas/glob"
+)
+
+// PathRedirector redirects file paths based on configured rules.
+// It is typically used by FUSE or other file system interceptors.
+type PathRedirector struct {
+	rules []compiledRedirectRule
+}
+
+// PathRedirectRule defines a path redirect rule.
+type PathRedirectRule struct {
+	Name          string   `yaml:"name"`
+	SourcePattern string   `yaml:"source_pattern"` // Glob pattern for source path
+	TargetBase    string   `yaml:"target_base"`    // Base directory for redirected files
+	Operations    []string `yaml:"operations"`     // write, create, delete, etc.
+	PreserveTree  bool     `yaml:"preserve_tree"`  // Preserve directory structure under target
+}
+
+type compiledRedirectRule struct {
+	rule PathRedirectRule
+	glob glob.Glob
+	ops  map[string]struct{}
+}
+
+// NewPathRedirector creates a PathRedirector from a list of rules.
+func NewPathRedirector(rules []PathRedirectRule) (*PathRedirector, error) {
+	pr := &PathRedirector{}
+	for _, r := range rules {
+		g, err := glob.Compile(r.SourcePattern, '/')
+		if err != nil {
+			return nil, err
+		}
+		cr := compiledRedirectRule{
+			rule: r,
+			glob: g,
+			ops:  make(map[string]struct{}),
+		}
+		for _, op := range r.Operations {
+			cr.ops[strings.ToLower(op)] = struct{}{}
+		}
+		pr.rules = append(pr.rules, cr)
+	}
+	return pr, nil
+}
+
+// Redirect checks if a path should be redirected for the given operation.
+// Returns the new path and true if redirected, or the original path and false if not.
+func (pr *PathRedirector) Redirect(path string, operation string) (string, bool) {
+	if pr == nil {
+		return path, false
+	}
+
+	operation = strings.ToLower(operation)
+	for _, r := range pr.rules {
+		if !matchRedirectOp(r.ops, operation) {
+			continue
+		}
+		if !r.glob.Match(path) {
+			continue
+		}
+
+		// Calculate redirected path
+		var newPath string
+		if r.rule.PreserveTree {
+			// /home/user/file.txt -> /workspace/.scratch/home/user/file.txt
+			newPath = filepath.Join(r.rule.TargetBase, path)
+		} else {
+			// /home/user/file.txt -> /workspace/.scratch/file.txt
+			newPath = filepath.Join(r.rule.TargetBase, filepath.Base(path))
+		}
+
+		return newPath, true
+	}
+
+	return path, false
+}
+
+// RedirectWithInfo is like Redirect but returns full redirect information.
+func (pr *PathRedirector) RedirectWithInfo(path string, operation string) *types.FileRedirectInfo {
+	if pr == nil {
+		return nil
+	}
+
+	operation = strings.ToLower(operation)
+	for _, r := range pr.rules {
+		if !matchRedirectOp(r.ops, operation) {
+			continue
+		}
+		if !r.glob.Match(path) {
+			continue
+		}
+
+		var newPath string
+		if r.rule.PreserveTree {
+			newPath = filepath.Join(r.rule.TargetBase, path)
+		} else {
+			newPath = filepath.Join(r.rule.TargetBase, filepath.Base(path))
+		}
+
+		return &types.FileRedirectInfo{
+			OriginalPath: path,
+			RedirectPath: newPath,
+			Operation:    operation,
+			Reason:       r.rule.Name,
+		}
+	}
+
+	return nil
+}
+
+// EnsureRedirectDir creates the parent directory for a redirected path if needed.
+func EnsureRedirectDir(redirectPath string) error {
+	return os.MkdirAll(filepath.Dir(redirectPath), 0o755)
+}
+
+func matchRedirectOp(ops map[string]struct{}, op string) bool {
+	if len(ops) == 0 {
+		return true // Empty means all operations
+	}
+	if _, ok := ops["*"]; ok {
+		return true
+	}
+	_, ok := ops[op]
+	return ok
+}

--- a/internal/policy/redirect_test.go
+++ b/internal/policy/redirect_test.go
@@ -1,0 +1,279 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+func TestPathRedirector_Redirect(t *testing.T) {
+	rules := []PathRedirectRule{
+		{
+			Name:          "redirect-home",
+			SourcePattern: "/home/**",
+			TargetBase:    "/workspace/.scratch",
+			Operations:    []string{"write", "create"},
+			PreserveTree:  true,
+		},
+		{
+			Name:          "redirect-tmp",
+			SourcePattern: "/tmp/**",
+			TargetBase:    "/workspace/.tmp",
+			Operations:    []string{"*"},
+			PreserveTree:  false,
+		},
+	}
+
+	pr, err := NewPathRedirector(rules)
+	if err != nil {
+		t.Fatalf("NewPathRedirector: %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		path       string
+		operation  string
+		wantPath   string
+		wantRedirect bool
+	}{
+		{
+			name:         "redirect home write with tree",
+			path:         "/home/user/file.txt",
+			operation:    "write",
+			wantPath:     "/workspace/.scratch/home/user/file.txt",
+			wantRedirect: true,
+		},
+		{
+			name:         "redirect home create with tree",
+			path:         "/home/user/subdir/file.txt",
+			operation:    "create",
+			wantPath:     "/workspace/.scratch/home/user/subdir/file.txt",
+			wantRedirect: true,
+		},
+		{
+			name:         "no redirect home read",
+			path:         "/home/user/file.txt",
+			operation:    "read",
+			wantPath:     "/home/user/file.txt",
+			wantRedirect: false,
+		},
+		{
+			name:         "redirect tmp without tree",
+			path:         "/tmp/foo/bar/file.txt",
+			operation:    "write",
+			wantPath:     "/workspace/.tmp/file.txt",
+			wantRedirect: true,
+		},
+		{
+			name:         "no redirect unmatched path",
+			path:         "/var/log/syslog",
+			operation:    "write",
+			wantPath:     "/var/log/syslog",
+			wantRedirect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotPath, gotRedirect := pr.Redirect(tt.path, tt.operation)
+			if gotPath != tt.wantPath {
+				t.Errorf("Redirect() path = %q, want %q", gotPath, tt.wantPath)
+			}
+			if gotRedirect != tt.wantRedirect {
+				t.Errorf("Redirect() redirected = %v, want %v", gotRedirect, tt.wantRedirect)
+			}
+		})
+	}
+}
+
+func TestPathRedirector_RedirectWithInfo(t *testing.T) {
+	rules := []PathRedirectRule{
+		{
+			Name:          "redirect-home",
+			SourcePattern: "/home/**",
+			TargetBase:    "/workspace/.scratch",
+			Operations:    []string{"write"},
+			PreserveTree:  true,
+		},
+	}
+
+	pr, err := NewPathRedirector(rules)
+	if err != nil {
+		t.Fatalf("NewPathRedirector: %v", err)
+	}
+
+	// Test redirect
+	info := pr.RedirectWithInfo("/home/user/file.txt", "write")
+	if info == nil {
+		t.Fatal("expected redirect info, got nil")
+	}
+	if info.OriginalPath != "/home/user/file.txt" {
+		t.Errorf("OriginalPath = %q, want %q", info.OriginalPath, "/home/user/file.txt")
+	}
+	if info.RedirectPath != "/workspace/.scratch/home/user/file.txt" {
+		t.Errorf("RedirectPath = %q, want %q", info.RedirectPath, "/workspace/.scratch/home/user/file.txt")
+	}
+	if info.Operation != "write" {
+		t.Errorf("Operation = %q, want %q", info.Operation, "write")
+	}
+
+	// Test no redirect
+	info = pr.RedirectWithInfo("/home/user/file.txt", "read")
+	if info != nil {
+		t.Errorf("expected nil for read operation, got %+v", info)
+	}
+}
+
+func TestPathRedirector_Nil(t *testing.T) {
+	var pr *PathRedirector
+	path, redirected := pr.Redirect("/home/user/file.txt", "write")
+	if redirected {
+		t.Error("nil PathRedirector should not redirect")
+	}
+	if path != "/home/user/file.txt" {
+		t.Errorf("path = %q, want original", path)
+	}
+}
+
+func TestCheckFile_WithRedirect(t *testing.T) {
+	policy := &Policy{
+		Version: 1,
+		Name:    "test",
+		FileRules: []FileRule{
+			{
+				Name:         "redirect-home-writes",
+				Paths:        []string{"/home/**"},
+				Operations:   []string{"write", "create"},
+				Decision:     "redirect",
+				Message:      "Writes outside workspace redirected",
+				RedirectTo:   "/workspace/.scratch",
+				PreserveTree: true,
+			},
+			{
+				Name:       "allow-workspace",
+				Paths:      []string{"/workspace/**"},
+				Operations: []string{"*"},
+				Decision:   "allow",
+			},
+		},
+	}
+
+	engine, err := NewEngine(policy, false)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	// Test redirect
+	dec := engine.CheckFile("/home/user/file.txt", "write")
+	if dec.PolicyDecision != types.DecisionRedirect {
+		t.Errorf("PolicyDecision = %q, want redirect", dec.PolicyDecision)
+	}
+	if dec.FileRedirect == nil {
+		t.Fatal("expected FileRedirect, got nil")
+	}
+	if dec.FileRedirect.RedirectPath != "/workspace/.scratch/home/user/file.txt" {
+		t.Errorf("RedirectPath = %q, want /workspace/.scratch/home/user/file.txt", dec.FileRedirect.RedirectPath)
+	}
+
+	// Test allow (no redirect)
+	dec = engine.CheckFile("/workspace/myproject/file.txt", "write")
+	if dec.PolicyDecision != types.DecisionAllow {
+		t.Errorf("PolicyDecision = %q, want allow", dec.PolicyDecision)
+	}
+	if dec.FileRedirect != nil {
+		t.Errorf("expected nil FileRedirect for allow, got %+v", dec.FileRedirect)
+	}
+}
+
+func TestCheckCommand_WithEnhancedRedirect(t *testing.T) {
+	policy := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{
+				Name:     "redirect-curl",
+				Commands: []string{"curl", "wget"},
+				Decision: "redirect",
+				Message:  "Network requests routed through audited fetch",
+				RedirectTo: &CommandRedirect{
+					Command:     "agentsh-fetch",
+					Args:        []string{"--audit"},
+					ArgsAppend:  []string{"--log-session"},
+					Environment: map[string]string{"AGENTSH_AUDIT": "1"},
+				},
+			},
+		},
+	}
+
+	engine, err := NewEngine(policy, false)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	dec := engine.CheckCommand("curl", []string{"https://example.com"})
+	if dec.PolicyDecision != types.DecisionRedirect {
+		t.Errorf("PolicyDecision = %q, want redirect", dec.PolicyDecision)
+	}
+	if dec.Redirect == nil {
+		t.Fatal("expected Redirect, got nil")
+	}
+	if dec.Redirect.Command != "agentsh-fetch" {
+		t.Errorf("Redirect.Command = %q, want agentsh-fetch", dec.Redirect.Command)
+	}
+	if len(dec.Redirect.Args) != 1 || dec.Redirect.Args[0] != "--audit" {
+		t.Errorf("Redirect.Args = %v, want [--audit]", dec.Redirect.Args)
+	}
+	if len(dec.Redirect.ArgsAppend) != 1 || dec.Redirect.ArgsAppend[0] != "--log-session" {
+		t.Errorf("Redirect.ArgsAppend = %v, want [--log-session]", dec.Redirect.ArgsAppend)
+	}
+	if dec.Redirect.Environment["AGENTSH_AUDIT"] != "1" {
+		t.Errorf("Redirect.Environment = %v, want AGENTSH_AUDIT=1", dec.Redirect.Environment)
+	}
+}
+
+func TestDecision_AuditAndSoftDelete(t *testing.T) {
+	policy := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{
+				Name:     "audit-git",
+				Commands: []string{"git"},
+				Decision: "audit",
+				Message:  "Git commands are audited",
+			},
+		},
+		FileRules: []FileRule{
+			{
+				Name:       "soft-delete",
+				Paths:      []string{"/workspace/**"},
+				Operations: []string{"delete"},
+				Decision:   "soft_delete",
+				Message:    "Deletions go to trash",
+			},
+		},
+	}
+
+	engine, err := NewEngine(policy, false)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	// Test audit decision
+	dec := engine.CheckCommand("git", []string{"push"})
+	if dec.PolicyDecision != types.DecisionAudit {
+		t.Errorf("PolicyDecision = %q, want audit", dec.PolicyDecision)
+	}
+	if dec.EffectiveDecision != types.DecisionAllow {
+		t.Errorf("EffectiveDecision = %q, want allow (audit is allow + logging)", dec.EffectiveDecision)
+	}
+
+	// Test soft_delete decision
+	dec = engine.CheckFile("/workspace/file.txt", "delete")
+	if dec.PolicyDecision != types.DecisionSoftDelete {
+		t.Errorf("PolicyDecision = %q, want soft_delete", dec.PolicyDecision)
+	}
+	if dec.EffectiveDecision != types.DecisionAllow {
+		t.Errorf("EffectiveDecision = %q, want allow (soft_delete proceeds with trash)", dec.EffectiveDecision)
+	}
+}

--- a/pkg/types/decision.go
+++ b/pkg/types/decision.go
@@ -3,10 +3,12 @@ package types
 type Decision string
 
 const (
-	DecisionAllow    Decision = "allow"
-	DecisionDeny     Decision = "deny"
-	DecisionApprove  Decision = "approve"
-	DecisionRedirect Decision = "redirect"
+	DecisionAllow      Decision = "allow"
+	DecisionDeny       Decision = "deny"
+	DecisionApprove    Decision = "approve"
+	DecisionRedirect   Decision = "redirect"
+	DecisionAudit      Decision = "audit"       // Allow + enhanced logging
+	DecisionSoftDelete Decision = "soft_delete" // Redirect destructive ops to trash
 )
 
 type ApprovalMode string
@@ -17,7 +19,17 @@ const (
 )
 
 type RedirectInfo struct {
-	Command string   `json:"command"`
-	Args    []string `json:"args,omitempty"`
-	Reason  string   `json:"reason,omitempty"`
+	Command     string            `json:"command"`
+	Args        []string          `json:"args,omitempty"`        // Prepended args
+	ArgsAppend  []string          `json:"args_append,omitempty"` // Appended args
+	Environment map[string]string `json:"environment,omitempty"` // Environment overrides
+	Reason      string            `json:"reason,omitempty"`
+}
+
+// FileRedirectInfo describes a file path redirect.
+type FileRedirectInfo struct {
+	OriginalPath string `json:"original_path"`
+	RedirectPath string `json:"redirect_path"`
+	Operation    string `json:"operation"`
+	Reason       string `json:"reason,omitempty"`
 }


### PR DESCRIPTION
## Summary

Implements cross-platform command interception and file path redirect support (spec §10):

- Adds new `Decision` types:
  - `audit` - Allow + enhanced logging (caller should emit audit event)
  - `soft_delete` - Redirect destructive operations to trash

- Enhances `CommandRedirect` with:
  - `ArgsAppend` - Arguments appended after original args
  - `Environment` - Environment variable overrides

- Adds `FileRedirectInfo` type for file path redirection information

- Adds `PathRedirector` component for standalone path redirection:
  - Usable by FUSE or other file system interceptors
  - Supports operation filtering (write, create, delete, etc.)
  - Supports tree preservation (maintain directory structure)

- Updates `FileRule` with redirect configuration:
  - `RedirectTo` - Target directory for redirected files
  - `PreserveTree` - Whether to preserve directory structure

- Updates `CheckFile` to compute and return file redirect information

## Example Usage

```yaml
# Command redirect with enhanced options
command_rules:
  - name: redirect-curl
    commands: [curl, wget]
    decision: redirect
    redirect_to:
      command: agentsh-fetch
      args: ["--audit"]
      args_append: ["--log-session"]
      environment:
        AGENTSH_AUDIT: "1"

# File path redirect
file_rules:
  - name: redirect-home-writes
    paths: ["/home/**"]
    operations: [write, create]
    decision: redirect
    redirect_to: "/workspace/.scratch"
    preserve_tree: true
```

## Test plan

- [x] Unit tests for PathRedirector
- [x] Unit tests for file redirect in CheckFile
- [x] Unit tests for enhanced CommandRedirect
- [x] Unit tests for audit and soft_delete decisions
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)