### PR TITLE
feat: add cross-platform process tree tracking

### DIFF
--- a/internal/process/tree.go
+++ b/internal/process/tree.go
@@ -1,0 +1,219 @@
+package process
+
+import (
+	"context"
+	"os"
+	"sync"
+	"time"
+)
+
+// ProcessNode represents a process in the tree.
+type ProcessNode struct {
+	PID       int
+	PPID      int
+	Command   string
+	Args      []string
+	StartTime time.Time
+	EndTime   *time.Time
+	ExitCode  *int
+	Children  []*ProcessNode
+}
+
+// ProcessTree tracks a process and all its descendants.
+type ProcessTree struct {
+	Root    *ProcessNode
+	mu      sync.RWMutex
+	tracker ProcessTracker
+	onSpawn func(*ProcessNode)
+	onExit  func(*ProcessNode, int)
+}
+
+// ProcessTracker is the platform-specific interface for tracking processes.
+type ProcessTracker interface {
+	// Track starts tracking a process and its descendants.
+	Track(pid int) error
+
+	// ListPIDs returns all PIDs in the tracked tree.
+	ListPIDs() []int
+
+	// Contains checks if a PID is in the tracked tree.
+	Contains(pid int) bool
+
+	// KillAll sends a signal to all processes in the tree.
+	KillAll(signal os.Signal) error
+
+	// Wait waits for all processes to exit.
+	Wait(ctx context.Context) error
+
+	// Info returns information about a process.
+	Info(pid int) (*ProcessInfo, error)
+
+	// OnSpawn registers a callback for new process spawns.
+	OnSpawn(func(pid int, ppid int))
+
+	// OnExit registers a callback for process exits.
+	OnExit(func(pid int, exitCode int))
+
+	// Stop stops tracking and cleans up resources.
+	Stop() error
+}
+
+// ProcessInfo contains information about a process.
+type ProcessInfo struct {
+	PID     int
+	PPID    int
+	Command string
+	Args    []string
+}
+
+// TrackerCapabilities describes what features the tracker supports.
+type TrackerCapabilities struct {
+	AutoChildTracking bool // Children are automatically tracked
+	SpawnNotification bool // Real-time spawn notifications
+	ExitNotification  bool // Real-time exit notifications
+	ExitCodes         bool // Exit codes are available
+}
+
+// NewProcessTree creates a tracker for the given root PID.
+func NewProcessTree(rootPID int) (*ProcessTree, error) {
+	tracker := newPlatformTracker()
+
+	tree := &ProcessTree{
+		Root: &ProcessNode{
+			PID:       rootPID,
+			StartTime: time.Now(),
+		},
+		tracker: tracker,
+	}
+
+	tracker.OnSpawn(tree.handleSpawn)
+	tracker.OnExit(tree.handleExit)
+
+	if err := tracker.Track(rootPID); err != nil {
+		return nil, err
+	}
+
+	return tree, nil
+}
+
+// OnSpawn registers a callback for process spawn events.
+func (t *ProcessTree) OnSpawn(cb func(*ProcessNode)) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.onSpawn = cb
+}
+
+// OnExit registers a callback for process exit events.
+func (t *ProcessTree) OnExit(cb func(*ProcessNode, int)) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.onExit = cb
+}
+
+// ListPIDs returns all PIDs in the tree.
+func (t *ProcessTree) ListPIDs() []int {
+	return t.tracker.ListPIDs()
+}
+
+// Contains checks if a PID is in the tree.
+func (t *ProcessTree) Contains(pid int) bool {
+	return t.tracker.Contains(pid)
+}
+
+// KillAll sends a signal to all processes in the tree.
+func (t *ProcessTree) KillAll(signal os.Signal) error {
+	return t.tracker.KillAll(signal)
+}
+
+// Wait waits for all processes to exit.
+func (t *ProcessTree) Wait(ctx context.Context) error {
+	return t.tracker.Wait(ctx)
+}
+
+// Stop stops tracking and cleans up resources.
+func (t *ProcessTree) Stop() error {
+	return t.tracker.Stop()
+}
+
+func (t *ProcessTree) handleSpawn(pid, ppid int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	parent := t.findNode(t.Root, ppid)
+	if parent == nil {
+		return
+	}
+
+	child := &ProcessNode{
+		PID:       pid,
+		PPID:      ppid,
+		StartTime: time.Now(),
+	}
+	parent.Children = append(parent.Children, child)
+
+	if t.onSpawn != nil {
+		t.onSpawn(child)
+	}
+}
+
+func (t *ProcessTree) handleExit(pid, exitCode int) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	node := t.findNode(t.Root, pid)
+	if node == nil {
+		return
+	}
+
+	now := time.Now()
+	node.EndTime = &now
+	node.ExitCode = &exitCode
+
+	if t.onExit != nil {
+		t.onExit(node, exitCode)
+	}
+}
+
+func (t *ProcessTree) findNode(node *ProcessNode, pid int) *ProcessNode {
+	if node == nil {
+		return nil
+	}
+	if node.PID == pid {
+		return node
+	}
+	for _, child := range node.Children {
+		if found := t.findNode(child, pid); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+// GetNode returns a copy of the node for the given PID.
+func (t *ProcessTree) GetNode(pid int) *ProcessNode {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.findNode(t.Root, pid)
+}
+
+// Walk traverses the tree, calling fn for each node.
+func (t *ProcessTree) Walk(fn func(*ProcessNode) bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	t.walkNode(t.Root, fn)
+}
+
+func (t *ProcessTree) walkNode(node *ProcessNode, fn func(*ProcessNode) bool) bool {
+	if node == nil {
+		return true
+	}
+	if !fn(node) {
+		return false
+	}
+	for _, child := range node.Children {
+		if !t.walkNode(child, fn) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/process/tree_darwin.go
+++ b/internal/process/tree_darwin.go
@@ -1,0 +1,231 @@
+//go:build darwin
+
+package process
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// DarwinProcessTracker implements ProcessTracker using polling and ps/pgrep.
+type DarwinProcessTracker struct {
+	rootPID int
+	known   map[int]bool
+	mu      sync.RWMutex
+	spawnCb func(pid, ppid int)
+	exitCb  func(pid, exitCode int)
+	done    chan struct{}
+}
+
+func newPlatformTracker() ProcessTracker {
+	return &DarwinProcessTracker{
+		known: make(map[int]bool),
+		done:  make(chan struct{}),
+	}
+}
+
+// Track implements ProcessTracker.
+func (t *DarwinProcessTracker) Track(pid int) error {
+	t.rootPID = pid
+	t.known[pid] = true
+
+	go t.poll()
+	return nil
+}
+
+func (t *DarwinProcessTracker) poll() {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-t.done:
+			return
+		case <-ticker.C:
+			t.scanProcesses()
+		}
+	}
+}
+
+func (t *DarwinProcessTracker) scanProcesses() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Get all children of known processes using pgrep
+	newPids := make(map[int]bool)
+	for pid := range t.known {
+		children := t.getChildren(pid)
+		for _, child := range children {
+			newPids[child] = true
+			if !t.known[child] {
+				t.known[child] = true
+				if t.spawnCb != nil {
+					t.spawnCb(child, pid)
+				}
+			}
+		}
+	}
+
+	// Check for exits
+	for pid := range t.known {
+		if pid == t.rootPID {
+			continue
+		}
+		if !t.processExists(pid) {
+			delete(t.known, pid)
+			if t.exitCb != nil {
+				t.exitCb(pid, 0)
+			}
+		}
+	}
+}
+
+func (t *DarwinProcessTracker) getChildren(ppid int) []int {
+	// Use pgrep to find children
+	out, err := exec.Command("pgrep", "-P", strconv.Itoa(ppid)).Output()
+	if err != nil {
+		return nil
+	}
+
+	var children []int
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		if pid, err := strconv.Atoi(line); err == nil {
+			children = append(children, pid)
+		}
+	}
+	return children
+}
+
+func (t *DarwinProcessTracker) getPPID(pid int) int {
+	out, err := exec.Command("ps", "-o", "ppid=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return 0
+	}
+	ppid, _ := strconv.Atoi(strings.TrimSpace(string(out)))
+	return ppid
+}
+
+func (t *DarwinProcessTracker) processExists(pid int) bool {
+	return unix.Kill(pid, 0) == nil
+}
+
+// ListPIDs implements ProcessTracker.
+func (t *DarwinProcessTracker) ListPIDs() []int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	pids := make([]int, 0, len(t.known))
+	for pid := range t.known {
+		pids = append(pids, pid)
+	}
+	return pids
+}
+
+// Contains implements ProcessTracker.
+func (t *DarwinProcessTracker) Contains(pid int) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.known[pid]
+}
+
+// KillAll implements ProcessTracker.
+func (t *DarwinProcessTracker) KillAll(signal os.Signal) error {
+	sig, ok := signal.(unix.Signal)
+	if !ok {
+		sig = unix.SIGTERM
+	}
+
+	// Kill children first (reverse order)
+	pids := t.ListPIDs()
+	for i := len(pids) - 1; i >= 0; i-- {
+		unix.Kill(pids[i], sig)
+	}
+	return nil
+}
+
+// Wait implements ProcessTracker.
+func (t *DarwinProcessTracker) Wait(ctx context.Context) error {
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			pids := t.ListPIDs()
+			if len(pids) == 0 {
+				return nil
+			}
+			if !t.processExists(t.rootPID) {
+				return nil
+			}
+		}
+	}
+}
+
+// Info implements ProcessTracker.
+func (t *DarwinProcessTracker) Info(pid int) (*ProcessInfo, error) {
+	if !t.Contains(pid) {
+		return nil, fmt.Errorf("pid %d not tracked", pid)
+	}
+
+	info := &ProcessInfo{
+		PID:  pid,
+		PPID: t.getPPID(pid),
+	}
+
+	// Get command using ps
+	out, err := exec.Command("ps", "-o", "command=", "-p", strconv.Itoa(pid)).Output()
+	if err == nil {
+		cmdline := strings.TrimSpace(string(out))
+		parts := strings.Fields(cmdline)
+		if len(parts) > 0 {
+			info.Command = parts[0]
+			if len(parts) > 1 {
+				info.Args = parts[1:]
+			}
+		}
+	}
+
+	return info, nil
+}
+
+// OnSpawn implements ProcessTracker.
+func (t *DarwinProcessTracker) OnSpawn(cb func(pid, ppid int)) {
+	t.spawnCb = cb
+}
+
+// OnExit implements ProcessTracker.
+func (t *DarwinProcessTracker) OnExit(cb func(pid, exitCode int)) {
+	t.exitCb = cb
+}
+
+// Stop implements ProcessTracker.
+func (t *DarwinProcessTracker) Stop() error {
+	close(t.done)
+	return nil
+}
+
+// Capabilities returns tracker capabilities.
+func (t *DarwinProcessTracker) Capabilities() TrackerCapabilities {
+	return TrackerCapabilities{
+		AutoChildTracking: false, // Polling-based
+		SpawnNotification: true,
+		ExitNotification:  true,
+		ExitCodes:         false,
+	}
+}
+
+var _ ProcessTracker = (*DarwinProcessTracker)(nil)

--- a/internal/process/tree_linux.go
+++ b/internal/process/tree_linux.go
@@ -1,0 +1,368 @@
+//go:build linux
+
+package process
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// LinuxProcessTracker implements ProcessTracker using cgroups and /proc.
+type LinuxProcessTracker struct {
+	rootPID    int
+	cgroupPath string
+	known      map[int]bool
+	mu         sync.RWMutex
+	spawnCb    func(pid, ppid int)
+	exitCb     func(pid, exitCode int)
+	done       chan struct{}
+}
+
+func newPlatformTracker() ProcessTracker {
+	return &LinuxProcessTracker{
+		known: make(map[int]bool),
+		done:  make(chan struct{}),
+	}
+}
+
+// Track implements ProcessTracker.
+func (t *LinuxProcessTracker) Track(pid int) error {
+	t.rootPID = pid
+	t.known[pid] = true
+
+	// Try cgroups first (preferred - automatic child tracking)
+	if cgroupPath, err := t.setupCgroup(pid); err == nil {
+		t.cgroupPath = cgroupPath
+		go t.watchCgroupProcs()
+		return nil
+	}
+
+	// Fallback to /proc polling
+	go t.pollProc()
+	return nil
+}
+
+func (t *LinuxProcessTracker) setupCgroup(pid int) (string, error) {
+	// Try to find the current cgroup
+	data, err := os.ReadFile("/proc/self/cgroup")
+	if err != nil {
+		return "", err
+	}
+
+	// Parse cgroup path (v2 format: "0::/path")
+	line := strings.TrimSpace(string(data))
+	parts := strings.Split(line, ":")
+	if len(parts) < 3 {
+		return "", fmt.Errorf("unexpected cgroup format")
+	}
+
+	basePath := filepath.Join("/sys/fs/cgroup", strings.TrimPrefix(parts[2], "/"))
+	cgroupPath := filepath.Join(basePath, fmt.Sprintf("agentsh-session-%d", pid))
+
+	// Create cgroup directory
+	if err := os.MkdirAll(cgroupPath, 0o755); err != nil {
+		return "", err
+	}
+
+	// Move process to cgroup
+	procsFile := filepath.Join(cgroupPath, "cgroup.procs")
+	if err := os.WriteFile(procsFile, []byte(strconv.Itoa(pid)), 0o644); err != nil {
+		os.Remove(cgroupPath)
+		return "", err
+	}
+
+	return cgroupPath, nil
+}
+
+func (t *LinuxProcessTracker) watchCgroupProcs() {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-t.done:
+			return
+		case <-ticker.C:
+			t.updateFromCgroupProcs()
+		}
+	}
+}
+
+func (t *LinuxProcessTracker) updateFromCgroupProcs() {
+	procsFile := filepath.Join(t.cgroupPath, "cgroup.procs")
+	data, err := os.ReadFile(procsFile)
+	if err != nil {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	currentPids := make(map[int]bool)
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		pid, err := strconv.Atoi(line)
+		if err != nil {
+			continue
+		}
+		currentPids[pid] = true
+
+		if !t.known[pid] {
+			t.known[pid] = true
+			ppid := t.getPPID(pid)
+			if t.spawnCb != nil {
+				t.spawnCb(pid, ppid)
+			}
+		}
+	}
+
+	// Check for exits
+	for pid := range t.known {
+		if pid == t.rootPID {
+			continue
+		}
+		if !currentPids[pid] {
+			delete(t.known, pid)
+			if t.exitCb != nil {
+				t.exitCb(pid, 0)
+			}
+		}
+	}
+}
+
+func (t *LinuxProcessTracker) pollProc() {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-t.done:
+			return
+		case <-ticker.C:
+			t.scanProc()
+		}
+	}
+}
+
+func (t *LinuxProcessTracker) scanProc() {
+	files, err := os.ReadDir("/proc")
+	if err != nil {
+		return
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Check for new children of known processes
+	for _, f := range files {
+		pid, err := strconv.Atoi(f.Name())
+		if err != nil {
+			continue
+		}
+
+		if t.known[pid] {
+			continue
+		}
+
+		ppid := t.getPPID(pid)
+		if ppid > 0 && t.known[ppid] {
+			t.known[pid] = true
+			if t.spawnCb != nil {
+				t.spawnCb(pid, ppid)
+			}
+		}
+	}
+
+	// Check for exits
+	for pid := range t.known {
+		if pid == t.rootPID {
+			continue
+		}
+		if !t.processExists(pid) {
+			delete(t.known, pid)
+			if t.exitCb != nil {
+				t.exitCb(pid, 0)
+			}
+		}
+	}
+}
+
+func (t *LinuxProcessTracker) getPPID(pid int) int {
+	statPath := filepath.Join("/proc", strconv.Itoa(pid), "stat")
+	data, err := os.ReadFile(statPath)
+	if err != nil {
+		return 0
+	}
+
+	// Parse: pid (comm) state ppid ...
+	// Need to find the closing ) of comm first
+	s := string(data)
+	idx := strings.LastIndex(s, ")")
+	if idx < 0 || idx+2 >= len(s) {
+		return 0
+	}
+
+	fields := strings.Fields(s[idx+2:])
+	if len(fields) < 2 {
+		return 0
+	}
+
+	ppid, _ := strconv.Atoi(fields[1])
+	return ppid
+}
+
+func (t *LinuxProcessTracker) processExists(pid int) bool {
+	return unix.Kill(pid, 0) == nil
+}
+
+// ListPIDs implements ProcessTracker.
+func (t *LinuxProcessTracker) ListPIDs() []int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	pids := make([]int, 0, len(t.known))
+	for pid := range t.known {
+		pids = append(pids, pid)
+	}
+	return pids
+}
+
+// Contains implements ProcessTracker.
+func (t *LinuxProcessTracker) Contains(pid int) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.known[pid]
+}
+
+// KillAll implements ProcessTracker.
+func (t *LinuxProcessTracker) KillAll(signal os.Signal) error {
+	sig, ok := signal.(unix.Signal)
+	if !ok {
+		sig = unix.SIGTERM
+	}
+
+	// Try cgroup.kill first (Linux 5.14+)
+	if t.cgroupPath != "" {
+		killFile := filepath.Join(t.cgroupPath, "cgroup.kill")
+		if err := os.WriteFile(killFile, []byte("1"), 0o644); err == nil {
+			return nil
+		}
+	}
+
+	// Iterate and kill (children first)
+	pids := t.ListPIDs()
+	for i := len(pids) - 1; i >= 0; i-- {
+		unix.Kill(pids[i], sig)
+	}
+	return nil
+}
+
+// Wait implements ProcessTracker.
+func (t *LinuxProcessTracker) Wait(ctx context.Context) error {
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			pids := t.ListPIDs()
+			if len(pids) == 0 {
+				return nil
+			}
+			// Check if root process has exited
+			if !t.processExists(t.rootPID) {
+				return nil
+			}
+		}
+	}
+}
+
+// Info implements ProcessTracker.
+func (t *LinuxProcessTracker) Info(pid int) (*ProcessInfo, error) {
+	if !t.Contains(pid) {
+		return nil, fmt.Errorf("pid %d not tracked", pid)
+	}
+
+	info := &ProcessInfo{
+		PID:  pid,
+		PPID: t.getPPID(pid),
+	}
+
+	// Read command
+	cmdPath := filepath.Join("/proc", strconv.Itoa(pid), "cmdline")
+	if data, err := os.ReadFile(cmdPath); err == nil {
+		parts := strings.Split(string(data), "\x00")
+		if len(parts) > 0 {
+			info.Command = parts[0]
+			if len(parts) > 1 {
+				info.Args = parts[1 : len(parts)-1] // Last element is empty
+			}
+		}
+	}
+
+	// Fallback to comm if cmdline is empty
+	if info.Command == "" {
+		commPath := filepath.Join("/proc", strconv.Itoa(pid), "comm")
+		if data, err := os.ReadFile(commPath); err == nil {
+			info.Command = strings.TrimSpace(string(data))
+		}
+	}
+
+	return info, nil
+}
+
+// OnSpawn implements ProcessTracker.
+func (t *LinuxProcessTracker) OnSpawn(cb func(pid, ppid int)) {
+	t.spawnCb = cb
+}
+
+// OnExit implements ProcessTracker.
+func (t *LinuxProcessTracker) OnExit(cb func(pid, exitCode int)) {
+	t.exitCb = cb
+}
+
+// Stop implements ProcessTracker.
+func (t *LinuxProcessTracker) Stop() error {
+	close(t.done)
+
+	// Clean up cgroup
+	if t.cgroupPath != "" {
+		// Move processes back to parent first
+		procsFile := filepath.Join(t.cgroupPath, "cgroup.procs")
+		if data, err := os.ReadFile(procsFile); err == nil {
+			parentProcs := filepath.Join(filepath.Dir(t.cgroupPath), "cgroup.procs")
+			scanner := bufio.NewScanner(strings.NewReader(string(data)))
+			for scanner.Scan() {
+				_ = os.WriteFile(parentProcs, []byte(scanner.Text()), 0o644)
+			}
+		}
+		os.Remove(t.cgroupPath)
+	}
+
+	return nil
+}
+
+// Capabilities returns tracker capabilities.
+func (t *LinuxProcessTracker) Capabilities() TrackerCapabilities {
+	return TrackerCapabilities{
+		AutoChildTracking: t.cgroupPath != "",
+		SpawnNotification: true,
+		ExitNotification:  true,
+		ExitCodes:         false, // Would need ptrace or wait
+	}
+}
+
+var _ ProcessTracker = (*LinuxProcessTracker)(nil)

--- a/internal/process/tree_other.go
+++ b/internal/process/tree_other.go
@@ -1,0 +1,70 @@
+//go:build !linux && !darwin && !windows
+
+package process
+
+import (
+	"context"
+	"fmt"
+	"os"
+)
+
+// NoopProcessTracker is a no-op implementation for unsupported platforms.
+type NoopProcessTracker struct {
+	rootPID int
+}
+
+func newPlatformTracker() ProcessTracker {
+	return &NoopProcessTracker{}
+}
+
+// Track implements ProcessTracker.
+func (t *NoopProcessTracker) Track(pid int) error {
+	t.rootPID = pid
+	return fmt.Errorf("process tracking not supported on this platform")
+}
+
+// ListPIDs implements ProcessTracker.
+func (t *NoopProcessTracker) ListPIDs() []int {
+	if t.rootPID != 0 {
+		return []int{t.rootPID}
+	}
+	return nil
+}
+
+// Contains implements ProcessTracker.
+func (t *NoopProcessTracker) Contains(pid int) bool {
+	return pid == t.rootPID
+}
+
+// KillAll implements ProcessTracker.
+func (t *NoopProcessTracker) KillAll(signal os.Signal) error {
+	return fmt.Errorf("process tracking not supported on this platform")
+}
+
+// Wait implements ProcessTracker.
+func (t *NoopProcessTracker) Wait(ctx context.Context) error {
+	return fmt.Errorf("process tracking not supported on this platform")
+}
+
+// Info implements ProcessTracker.
+func (t *NoopProcessTracker) Info(pid int) (*ProcessInfo, error) {
+	return nil, fmt.Errorf("process tracking not supported on this platform")
+}
+
+// OnSpawn implements ProcessTracker.
+func (t *NoopProcessTracker) OnSpawn(cb func(pid, ppid int)) {}
+
+// OnExit implements ProcessTracker.
+func (t *NoopProcessTracker) OnExit(cb func(pid, exitCode int)) {}
+
+// Stop implements ProcessTracker.
+func (t *NoopProcessTracker) Stop() error {
+	return nil
+}
+
+// Capabilities returns tracker capabilities.
+func (t *NoopProcessTracker) Capabilities() TrackerCapabilities {
+	return TrackerCapabilities{}
+}
+
+var _ ProcessTracker = (*NoopProcessTracker)(nil)

--- a/internal/process/tree_test.go
+++ b/internal/process/tree_test.go
@@ -1,0 +1,135 @@
+package process
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProcessNode(t *testing.T) {
+	now := time.Now()
+	exitCode := 0
+	endTime := now.Add(time.Second)
+
+	node := &ProcessNode{
+		PID:       1234,
+		PPID:      1000,
+		Command:   "/bin/bash",
+		Args:      []string{"-c", "echo hello"},
+		StartTime: now,
+		EndTime:   &endTime,
+		ExitCode:  &exitCode,
+		Children:  nil,
+	}
+
+	if node.PID != 1234 {
+		t.Errorf("PID = %d, want 1234", node.PID)
+	}
+	if node.PPID != 1000 {
+		t.Errorf("PPID = %d, want 1000", node.PPID)
+	}
+	if node.Command != "/bin/bash" {
+		t.Errorf("Command = %q, want /bin/bash", node.Command)
+	}
+	if len(node.Args) != 2 {
+		t.Errorf("Args length = %d, want 2", len(node.Args))
+	}
+	if *node.ExitCode != 0 {
+		t.Errorf("ExitCode = %d, want 0", *node.ExitCode)
+	}
+}
+
+func TestProcessNode_WithChildren(t *testing.T) {
+	parent := &ProcessNode{
+		PID:       1000,
+		StartTime: time.Now(),
+	}
+
+	child1 := &ProcessNode{
+		PID:       1001,
+		PPID:      1000,
+		StartTime: time.Now(),
+	}
+
+	child2 := &ProcessNode{
+		PID:       1002,
+		PPID:      1000,
+		StartTime: time.Now(),
+	}
+
+	parent.Children = []*ProcessNode{child1, child2}
+
+	if len(parent.Children) != 2 {
+		t.Errorf("Children count = %d, want 2", len(parent.Children))
+	}
+	if parent.Children[0].PID != 1001 {
+		t.Errorf("First child PID = %d, want 1001", parent.Children[0].PID)
+	}
+	if parent.Children[1].PID != 1002 {
+		t.Errorf("Second child PID = %d, want 1002", parent.Children[1].PID)
+	}
+}
+
+func TestProcessInfo(t *testing.T) {
+	info := &ProcessInfo{
+		PID:     1234,
+		PPID:    1000,
+		Command: "/usr/bin/python",
+		Args:    []string{"script.py", "--verbose"},
+	}
+
+	if info.PID != 1234 {
+		t.Errorf("PID = %d, want 1234", info.PID)
+	}
+	if info.PPID != 1000 {
+		t.Errorf("PPID = %d, want 1000", info.PPID)
+	}
+	if info.Command != "/usr/bin/python" {
+		t.Errorf("Command = %q, want /usr/bin/python", info.Command)
+	}
+}
+
+func TestTrackerCapabilities_Defaults(t *testing.T) {
+	caps := TrackerCapabilities{}
+
+	if caps.AutoChildTracking {
+		t.Error("AutoChildTracking should default to false")
+	}
+	if caps.SpawnNotification {
+		t.Error("SpawnNotification should default to false")
+	}
+	if caps.ExitNotification {
+		t.Error("ExitNotification should default to false")
+	}
+	if caps.ExitCodes {
+		t.Error("ExitCodes should default to false")
+	}
+}
+
+func TestTrackerCapabilities_Full(t *testing.T) {
+	caps := TrackerCapabilities{
+		AutoChildTracking: true,
+		SpawnNotification: true,
+		ExitNotification:  true,
+		ExitCodes:         true,
+	}
+
+	if !caps.AutoChildTracking {
+		t.Error("AutoChildTracking should be true")
+	}
+	if !caps.SpawnNotification {
+		t.Error("SpawnNotification should be true")
+	}
+	if !caps.ExitNotification {
+		t.Error("ExitNotification should be true")
+	}
+	if !caps.ExitCodes {
+		t.Error("ExitCodes should be true")
+	}
+}
+
+func TestNewPlatformTracker(t *testing.T) {
+	tracker := newPlatformTracker()
+	if tracker == nil {
+		t.Fatal("newPlatformTracker() returned nil")
+	}
+}

--- a/internal/process/tree_windows.go
+++ b/internal/process/tree_windows.go
@@ -1,0 +1,416 @@
+//go:build windows
+
+package process
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// JOBOBJECT_BASIC_PROCESS_ID_LIST for querying process IDs in a job.
+type jobObjectBasicProcessIDList struct {
+	NumberOfAssignedProcesses  uint32
+	NumberOfProcessIdsInList   uint32
+	ProcessIdList              [1]uintptr // Variable length array
+}
+
+const jobObjectBasicProcessIdList = 3 // JobObjectBasicProcessIdList info class
+
+// WindowsProcessTracker implements ProcessTracker using Windows Job Objects.
+type WindowsProcessTracker struct {
+	rootPID   int
+	jobHandle windows.Handle
+	known     map[int]bool
+	mu        sync.RWMutex
+	spawnCb   func(pid, ppid int)
+	exitCb    func(pid, exitCode int)
+	done      chan struct{}
+}
+
+func newPlatformTracker() ProcessTracker {
+	return &WindowsProcessTracker{
+		known: make(map[int]bool),
+		done:  make(chan struct{}),
+	}
+}
+
+// Track implements ProcessTracker.
+func (t *WindowsProcessTracker) Track(pid int) error {
+	t.rootPID = pid
+	t.known[pid] = true
+
+	// Try to create a Job Object for automatic child tracking
+	if err := t.setupJobObject(pid); err != nil {
+		// Fall back to polling
+		go t.poll()
+		return nil
+	}
+
+	go t.poll() // Still poll for process info updates
+	return nil
+}
+
+func (t *WindowsProcessTracker) setupJobObject(pid int) error {
+	// Create job object
+	job, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return err
+	}
+	t.jobHandle = job
+
+	// Configure job to kill all processes when job closes
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{}
+	info.BasicLimitInformation.LimitFlags = windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+
+	_, err = windows.SetInformationJobObject(
+		job,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info)),
+	)
+	if err != nil {
+		windows.CloseHandle(job)
+		return err
+	}
+
+	// Open the target process
+	proc, err := windows.OpenProcess(
+		windows.PROCESS_SET_QUOTA|windows.PROCESS_TERMINATE,
+		false,
+		uint32(pid),
+	)
+	if err != nil {
+		windows.CloseHandle(job)
+		return err
+	}
+	defer windows.CloseHandle(proc)
+
+	// Assign process to job
+	if err := windows.AssignProcessToJobObject(job, proc); err != nil {
+		windows.CloseHandle(job)
+		return err
+	}
+
+	return nil
+}
+
+func (t *WindowsProcessTracker) poll() {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-t.done:
+			return
+		case <-ticker.C:
+			t.scanProcesses()
+		}
+	}
+}
+
+func (t *WindowsProcessTracker) scanProcesses() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// If we have a job object, get processes from it
+	if t.jobHandle != 0 {
+		pids := t.getJobProcesses()
+		currentPids := make(map[int]bool)
+		for _, pid := range pids {
+			currentPids[pid] = true
+			if !t.known[pid] {
+				t.known[pid] = true
+				ppid := t.getPPID(pid)
+				if t.spawnCb != nil {
+					t.spawnCb(pid, ppid)
+				}
+			}
+		}
+
+		// Check for exits
+		for pid := range t.known {
+			if pid == t.rootPID {
+				continue
+			}
+			if !currentPids[pid] {
+				delete(t.known, pid)
+				if t.exitCb != nil {
+					t.exitCb(pid, 0)
+				}
+			}
+		}
+		return
+	}
+
+	// Fallback: scan for children using CreateToolhelp32Snapshot
+	t.scanWithToolhelp()
+}
+
+func (t *WindowsProcessTracker) getJobProcesses() []int {
+	if t.jobHandle == 0 {
+		return nil
+	}
+
+	// Query job object for process list
+	// Start with buffer for 64 processes
+	bufSize := uint32(unsafe.Sizeof(jobObjectBasicProcessIDList{}) + 64*unsafe.Sizeof(uintptr(0)))
+	buf := make([]byte, bufSize)
+
+	for {
+		err := windows.QueryInformationJobObject(
+			t.jobHandle,
+			jobObjectBasicProcessIdList,
+			uintptr(unsafe.Pointer(&buf[0])),
+			bufSize,
+			nil,
+		)
+		if err == nil {
+			break
+		}
+		if err == windows.ERROR_MORE_DATA {
+			bufSize *= 2
+			buf = make([]byte, bufSize)
+			continue
+		}
+		return nil
+	}
+
+	// Parse the result
+	list := (*jobObjectBasicProcessIDList)(unsafe.Pointer(&buf[0]))
+	pids := make([]int, 0, list.NumberOfProcessIdsInList)
+
+	// The ProcessIdList starts after the header
+	pidPtr := uintptr(unsafe.Pointer(&buf[0])) + unsafe.Offsetof(list.ProcessIdList)
+	for i := uint32(0); i < list.NumberOfProcessIdsInList; i++ {
+		pid := *(*uintptr)(unsafe.Pointer(pidPtr + uintptr(i)*unsafe.Sizeof(uintptr(0))))
+		pids = append(pids, int(pid))
+	}
+
+	return pids
+}
+
+func (t *WindowsProcessTracker) scanWithToolhelp() {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return
+	}
+	defer windows.CloseHandle(snapshot)
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		return
+	}
+
+	for {
+		pid := int(entry.ProcessID)
+		ppid := int(entry.ParentProcessID)
+
+		if !t.known[pid] && t.known[ppid] {
+			t.known[pid] = true
+			if t.spawnCb != nil {
+				t.spawnCb(pid, ppid)
+			}
+		}
+
+		if err := windows.Process32Next(snapshot, &entry); err != nil {
+			break
+		}
+	}
+
+	// Check for exits
+	for pid := range t.known {
+		if pid == t.rootPID {
+			continue
+		}
+		if !t.processExists(pid) {
+			delete(t.known, pid)
+			if t.exitCb != nil {
+				t.exitCb(pid, 0)
+			}
+		}
+	}
+}
+
+func (t *WindowsProcessTracker) getPPID(pid int) int {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return 0
+	}
+	defer windows.CloseHandle(snapshot)
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		return 0
+	}
+
+	for {
+		if int(entry.ProcessID) == pid {
+			return int(entry.ParentProcessID)
+		}
+		if err := windows.Process32Next(snapshot, &entry); err != nil {
+			break
+		}
+	}
+
+	return 0
+}
+
+func (t *WindowsProcessTracker) processExists(pid int) bool {
+	proc, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return false
+	}
+	defer windows.CloseHandle(proc)
+
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(proc, &exitCode); err != nil {
+		return false
+	}
+	return exitCode == 259 // STILL_ACTIVE
+}
+
+// ListPIDs implements ProcessTracker.
+func (t *WindowsProcessTracker) ListPIDs() []int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	pids := make([]int, 0, len(t.known))
+	for pid := range t.known {
+		pids = append(pids, pid)
+	}
+	return pids
+}
+
+// Contains implements ProcessTracker.
+func (t *WindowsProcessTracker) Contains(pid int) bool {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.known[pid]
+}
+
+// KillAll implements ProcessTracker.
+func (t *WindowsProcessTracker) KillAll(signal os.Signal) error {
+	// If we have a job object, terminate it
+	if t.jobHandle != 0 {
+		return windows.TerminateJobObject(t.jobHandle, 1)
+	}
+
+	// Otherwise terminate each process individually
+	pids := t.ListPIDs()
+	for i := len(pids) - 1; i >= 0; i-- {
+		t.terminateProcess(pids[i])
+	}
+	return nil
+}
+
+func (t *WindowsProcessTracker) terminateProcess(pid int) error {
+	proc, err := windows.OpenProcess(windows.PROCESS_TERMINATE, false, uint32(pid))
+	if err != nil {
+		return err
+	}
+	defer windows.CloseHandle(proc)
+	return windows.TerminateProcess(proc, 1)
+}
+
+// Wait implements ProcessTracker.
+func (t *WindowsProcessTracker) Wait(ctx context.Context) error {
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			pids := t.ListPIDs()
+			if len(pids) == 0 {
+				return nil
+			}
+			if !t.processExists(t.rootPID) {
+				return nil
+			}
+		}
+	}
+}
+
+// Info implements ProcessTracker.
+func (t *WindowsProcessTracker) Info(pid int) (*ProcessInfo, error) {
+	if !t.Contains(pid) {
+		return nil, fmt.Errorf("pid %d not tracked", pid)
+	}
+
+	info := &ProcessInfo{
+		PID:  pid,
+		PPID: t.getPPID(pid),
+	}
+
+	// Get executable name from toolhelp
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return info, nil
+	}
+	defer windows.CloseHandle(snapshot)
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		return info, nil
+	}
+
+	for {
+		if int(entry.ProcessID) == pid {
+			info.Command = windows.UTF16ToString(entry.ExeFile[:])
+			break
+		}
+		if err := windows.Process32Next(snapshot, &entry); err != nil {
+			break
+		}
+	}
+
+	return info, nil
+}
+
+// OnSpawn implements ProcessTracker.
+func (t *WindowsProcessTracker) OnSpawn(cb func(pid, ppid int)) {
+	t.spawnCb = cb
+}
+
+// OnExit implements ProcessTracker.
+func (t *WindowsProcessTracker) OnExit(cb func(pid, exitCode int)) {
+	t.exitCb = cb
+}
+
+// Stop implements ProcessTracker.
+func (t *WindowsProcessTracker) Stop() error {
+	close(t.done)
+
+	if t.jobHandle != 0 {
+		windows.CloseHandle(t.jobHandle)
+		t.jobHandle = 0
+	}
+
+	return nil
+}
+
+// Capabilities returns tracker capabilities.
+func (t *WindowsProcessTracker) Capabilities() TrackerCapabilities {
+	return TrackerCapabilities{
+		AutoChildTracking: t.jobHandle != 0,
+		SpawnNotification: true,
+		ExitNotification:  true,
+		ExitCodes:         false,
+	}
+}
+
+var _ ProcessTracker = (*WindowsProcessTracker)(nil)


### PR DESCRIPTION
## Summary

- Adds `ProcessTracker` interface for platform-agnostic process tree tracking
- Linux: Uses cgroups v2 for automatic child tracking with /proc polling fallback
- macOS: Uses pgrep/ps polling for child process discovery
- Windows: Uses Job Objects for process containment with Toolhelp32Snapshot fallback
- Other platforms: Noop implementation with error returns

## Features

- **Track**: Start tracking a process and all its descendants
- **ListPIDs/Contains**: Query tracked processes
- **KillAll**: Signal entire tree (uses cgroup.kill on Linux 5.14+)
- **Wait**: Block until all tracked processes exit
- **OnSpawn/OnExit**: Register callbacks for process lifecycle events
- **Info**: Get process details (command, args, ppid)
- **Capabilities**: Platform feature detection

## Test plan

- [x] Unit tests for types and interface
- [x] All existing tests pass
- [x] Cross-compilation verified for Linux, Darwin, Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)