### PR TITLE
feat: add comprehensive event schema

### DIFF
--- a/internal/events/base.go
+++ b/internal/events/base.go
@@ -1,0 +1,119 @@
+package events
+
+// BaseEvent contains fields common to ALL events.
+// Every event is self-contained for independent parsing and analysis.
+type BaseEvent struct {
+	// Identity & Location
+	Hostname         string `json:"hostname"`
+	MachineID        string `json:"machine_id"`
+	ContainerID      string `json:"container_id,omitempty"`
+	ContainerImage   string `json:"container_image,omitempty"`
+	ContainerRuntime string `json:"container_runtime,omitempty"`
+	K8sNamespace     string `json:"k8s_namespace,omitempty"`
+	K8sPod           string `json:"k8s_pod,omitempty"`
+	K8sNode          string `json:"k8s_node,omitempty"`
+	K8sCluster       string `json:"k8s_cluster,omitempty"`
+
+	// Network Identity
+	IPv4Addresses    []string `json:"ipv4_addresses,omitempty"`
+	IPv6Addresses    []string `json:"ipv6_addresses,omitempty"`
+	PrimaryInterface string   `json:"primary_interface,omitempty"`
+	MACAddress       string   `json:"mac_address,omitempty"`
+
+	// Timestamp
+	Timestamp       string `json:"timestamp"`
+	TimestampUnixUS int64  `json:"timestamp_unix_us"`
+	MonotonicNS     int64  `json:"monotonic_ns"`
+	Sequence        int64  `json:"sequence"`
+
+	// Operating System
+	OS            string `json:"os"`
+	OSVersion     string `json:"os_version,omitempty"`
+	OSDistro      string `json:"os_distro,omitempty"`
+	KernelVersion string `json:"kernel_version,omitempty"`
+	Arch          string `json:"arch"`
+
+	// Platform Details
+	PlatformVariant string `json:"platform_variant,omitempty"`
+	FSBackend       string `json:"fs_backend,omitempty"`
+	NetBackend      string `json:"net_backend,omitempty"`
+	ProcessBackend  string `json:"process_backend,omitempty"`
+	IPCBackend      string `json:"ipc_backend,omitempty"`
+
+	// Versioning
+	AgentshVersion     string `json:"agentsh_version,omitempty"`
+	AgentshCommit      string `json:"agentsh_commit,omitempty"`
+	AgentshBuildTime   string `json:"agentsh_build_time,omitempty"`
+	EventSchemaVersion string `json:"event_schema_version"`
+	PolicyVersion      string `json:"policy_version,omitempty"`
+	PolicyName         string `json:"policy_name,omitempty"`
+
+	// Correlation IDs
+	EventID         string `json:"event_id"`
+	SessionID       string `json:"session_id"`
+	CommandID       string `json:"command_id,omitempty"`
+	TraceID         string `json:"trace_id,omitempty"`
+	SpanID          string `json:"span_id,omitempty"`
+	ParentSpanID    string `json:"parent_span_id,omitempty"`
+	TraceFlags      string `json:"trace_flags,omitempty"`
+	RequestID       string `json:"request_id,omitempty"`
+	CausedByEventID string `json:"caused_by_event_id,omitempty"`
+
+	// Process Context
+	PID         int      `json:"pid"`
+	PPID        int      `json:"ppid,omitempty"`
+	ProcessName string   `json:"process_name,omitempty"`
+	Executable  string   `json:"executable,omitempty"`
+	Cmdline     []string `json:"cmdline,omitempty"`
+	UID         int      `json:"uid,omitempty"`
+	GID         int      `json:"gid,omitempty"`
+	Username    string   `json:"username,omitempty"`
+	Groupname   string   `json:"groupname,omitempty"`
+	Cwd         string   `json:"cwd,omitempty"`
+	TreeDepth   int      `json:"tree_depth,omitempty"`
+	RootPID     int      `json:"root_pid,omitempty"`
+
+	// Agent Context
+	AgentID        string `json:"agent_id,omitempty"`
+	AgentType      string `json:"agent_type,omitempty"`
+	AgentFramework string `json:"agent_framework,omitempty"`
+	OperatorID     string `json:"operator_id,omitempty"`
+	TenantID       string `json:"tenant_id,omitempty"`
+	WorkspaceID    string `json:"workspace_id,omitempty"`
+
+	// Policy & Decision
+	Decision         string   `json:"decision,omitempty"`
+	PolicyRule       string   `json:"policy_rule,omitempty"`
+	RiskLevel        string   `json:"risk_level,omitempty"`
+	RiskFactors      []string `json:"risk_factors,omitempty"`
+	ApprovalRequired bool     `json:"approval_required,omitempty"`
+	ApprovalID       string   `json:"approval_id,omitempty"`
+	ApprovedBy       string   `json:"approved_by,omitempty"`
+
+	// Performance Metrics
+	LatencyUS    int64 `json:"latency_us,omitempty"`
+	QueueTimeUS  int64 `json:"queue_time_us,omitempty"`
+	PolicyEvalUS int64 `json:"policy_eval_us,omitempty"`
+	InterceptUS  int64 `json:"intercept_us,omitempty"`
+	BackendUS    int64 `json:"backend_us,omitempty"`
+
+	// Error Context
+	Error         string `json:"error,omitempty"`
+	ErrorCode     string `json:"error_code,omitempty"`
+	Errno         int    `json:"errno,omitempty"`
+	ErrorCategory string `json:"error_category,omitempty"`
+	Retryable     bool   `json:"retryable,omitempty"`
+
+	// Event Type
+	Type     EventType `json:"type"`
+	Category string    `json:"category"`
+
+	// Custom Metadata
+	Metadata map[string]string `json:"metadata,omitempty"`
+	Tags     []string          `json:"tags,omitempty"`
+	Labels   map[string]string `json:"labels,omitempty"`
+
+	// Sanitization Info
+	SanitizedFields    []string `json:"sanitized_fields,omitempty"`
+	SanitizationReason string   `json:"sanitization_reason,omitempty"`
+}

--- a/internal/events/context.go
+++ b/internal/events/context.go
@@ -1,0 +1,246 @@
+package events
+
+import (
+	"bufio"
+	"net"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// RuntimeContext holds static information collected at startup.
+type RuntimeContext struct {
+	// Identity
+	Hostname         string
+	MachineID        string
+	ContainerID      string
+	ContainerImage   string
+	ContainerRuntime string
+	K8sNamespace     string
+	K8sPod           string
+	K8sNode          string
+	K8sCluster       string
+
+	// Network
+	IPv4Addresses    []string
+	IPv6Addresses    []string
+	PrimaryInterface string
+	MACAddress       string
+
+	// OS
+	OS            string
+	OSVersion     string
+	OSDistro      string
+	KernelVersion string
+	Arch          string
+
+	// Platform
+	PlatformVariant string
+	FSBackend       string
+	NetBackend      string
+	ProcessBackend  string
+	IPCBackend      string
+
+	// Version
+	AgentshVersion     string
+	AgentshCommit      string
+	AgentshBuildTime   string
+	EventSchemaVersion string
+}
+
+// DetectRuntimeContext collects all static context at startup.
+func DetectRuntimeContext() *RuntimeContext {
+	ctx := &RuntimeContext{
+		OS:                 runtime.GOOS,
+		Arch:               runtime.GOARCH,
+		EventSchemaVersion: "1.0",
+	}
+
+	ctx.Hostname, _ = os.Hostname()
+	ctx.MachineID = detectMachineID()
+	ctx.ContainerID, ctx.ContainerRuntime = detectContainer()
+	ctx.ContainerImage = os.Getenv("AGENTSH_CONTAINER_IMAGE")
+
+	// Kubernetes detection
+	ctx.K8sNamespace = os.Getenv("KUBERNETES_NAMESPACE")
+	if ctx.K8sNamespace == "" {
+		ctx.K8sNamespace = os.Getenv("POD_NAMESPACE")
+	}
+	ctx.K8sPod = os.Getenv("KUBERNETES_POD_NAME")
+	if ctx.K8sPod == "" && os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
+		ctx.K8sPod = os.Getenv("HOSTNAME")
+	}
+	ctx.K8sNode = os.Getenv("KUBERNETES_NODE_NAME")
+	ctx.K8sCluster = os.Getenv("KUBERNETES_CLUSTER_NAME")
+
+	ctx.IPv4Addresses, ctx.IPv6Addresses, ctx.PrimaryInterface, ctx.MACAddress = detectNetworkInfo()
+	ctx.OSVersion, ctx.OSDistro = detectOSVersion()
+	ctx.KernelVersion = detectKernelVersion()
+
+	return ctx
+}
+
+func detectMachineID() string {
+	switch runtime.GOOS {
+	case "linux":
+		if data, err := os.ReadFile("/etc/machine-id"); err == nil {
+			return strings.TrimSpace(string(data))
+		}
+		if data, err := os.ReadFile("/var/lib/dbus/machine-id"); err == nil {
+			return strings.TrimSpace(string(data))
+		}
+	case "darwin":
+		out, err := exec.Command("ioreg", "-rd1", "-c", "IOPlatformExpertDevice").Output()
+		if err == nil {
+			for _, line := range strings.Split(string(out), "\n") {
+				if strings.Contains(line, "IOPlatformUUID") {
+					parts := strings.Split(line, "=")
+					if len(parts) >= 2 {
+						return strings.Trim(strings.TrimSpace(parts[1]), `"`)
+					}
+				}
+			}
+		}
+	case "windows":
+		out, err := exec.Command("reg", "query",
+			`HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography`,
+			"/v", "MachineGuid").Output()
+		if err == nil {
+			lines := strings.Split(string(out), "\n")
+			for _, line := range lines {
+				if strings.Contains(line, "MachineGuid") {
+					fields := strings.Fields(line)
+					if len(fields) >= 3 {
+						return fields[len(fields)-1]
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func detectContainer() (containerID, runtime string) {
+	// Check for Docker
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		runtime = "docker"
+	}
+
+	// Check cgroup for container ID
+	if data, err := os.ReadFile("/proc/1/cgroup"); err == nil {
+		lines := strings.Split(string(data), "\n")
+		for _, line := range lines {
+			if strings.Contains(line, "docker") ||
+				strings.Contains(line, "containerd") ||
+				strings.Contains(line, "crio") {
+				parts := strings.Split(line, "/")
+				if len(parts) > 0 {
+					containerID = parts[len(parts)-1]
+					if len(containerID) >= 12 {
+						containerID = containerID[:12]
+					}
+				}
+			}
+		}
+	}
+
+	if runtime == "" && os.Getenv("CONTAINER_RUNTIME") != "" {
+		runtime = os.Getenv("CONTAINER_RUNTIME")
+	}
+
+	if os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
+		if runtime == "" {
+			runtime = "containerd"
+		}
+	}
+
+	return
+}
+
+func detectNetworkInfo() (ipv4, ipv6 []string, primaryIface, macAddr string) {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return
+	}
+
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagLoopback != 0 || iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+
+		for _, addr := range addrs {
+			ipNet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+
+			ip := ipNet.IP
+			if ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+				continue
+			}
+
+			if ip.To4() != nil {
+				ipv4 = append(ipv4, ip.String())
+				if primaryIface == "" {
+					primaryIface = iface.Name
+					macAddr = iface.HardwareAddr.String()
+				}
+			} else {
+				ipv6 = append(ipv6, ip.String())
+			}
+		}
+	}
+
+	return
+}
+
+func detectOSVersion() (version, distro string) {
+	switch runtime.GOOS {
+	case "linux":
+		if f, err := os.Open("/etc/os-release"); err == nil {
+			defer f.Close()
+			scanner := bufio.NewScanner(f)
+			for scanner.Scan() {
+				line := scanner.Text()
+				if strings.HasPrefix(line, "PRETTY_NAME=") {
+					version = strings.Trim(strings.TrimPrefix(line, "PRETTY_NAME="), `"`)
+				}
+				if strings.HasPrefix(line, "ID=") {
+					distro = strings.Trim(strings.TrimPrefix(line, "ID="), `"`)
+				}
+			}
+		}
+	case "darwin":
+		if out, err := exec.Command("sw_vers", "-productVersion").Output(); err == nil {
+			version = "macOS " + strings.TrimSpace(string(out))
+		}
+	case "windows":
+		if out, err := exec.Command("cmd", "/c", "ver").Output(); err == nil {
+			version = strings.TrimSpace(string(out))
+		}
+	}
+	return
+}
+
+func detectKernelVersion() string {
+	switch runtime.GOOS {
+	case "linux", "darwin":
+		if out, err := exec.Command("uname", "-r").Output(); err == nil {
+			return strings.TrimSpace(string(out))
+		}
+	case "windows":
+		if out, err := exec.Command("cmd", "/c", "wmic", "os", "get", "version").Output(); err == nil {
+			lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+			if len(lines) >= 2 {
+				return strings.TrimSpace(lines[1])
+			}
+		}
+	}
+	return ""
+}

--- a/internal/events/factory.go
+++ b/internal/events/factory.go
@@ -1,0 +1,196 @@
+package events
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+// EventConfig controls event generation behavior.
+type EventConfig struct {
+	// Include IP addresses in events
+	IncludeNetworkInfo bool `yaml:"include_network_info"`
+
+	// Include MAC address in events
+	IncludeMACAddress bool `yaml:"include_mac_address"`
+
+	// Enable path/content sanitization
+	SanitizePaths bool `yaml:"sanitize_paths"`
+
+	// Custom sanitization patterns
+	SanitizePatterns SanitizePatterns `yaml:"sanitize_patterns"`
+
+	// Default metadata added to all events
+	DefaultMetadata map[string]string `yaml:"default_metadata"`
+
+	// Default tags added to all events
+	DefaultTags []string `yaml:"default_tags"`
+
+	// Default labels added to all events
+	DefaultLabels map[string]string `yaml:"default_labels"`
+}
+
+// DefaultEventConfig returns sensible defaults.
+func DefaultEventConfig() *EventConfig {
+	return &EventConfig{
+		IncludeNetworkInfo: true,
+		IncludeMACAddress:  false,
+		SanitizePaths:      true,
+		SanitizePatterns:   DefaultSensitivePatterns,
+		DefaultMetadata:    map[string]string{},
+		DefaultTags:        []string{},
+		DefaultLabels:      map[string]string{},
+	}
+}
+
+// EventFactory creates events with pre-populated base fields.
+type EventFactory struct {
+	ctx       *RuntimeContext
+	sessionID string
+	sequence  int64
+	sanitizer *Sanitizer
+	config    *EventConfig
+}
+
+// NewEventFactory creates a factory for a session.
+func NewEventFactory(ctx *RuntimeContext, sessionID string, config *EventConfig) *EventFactory {
+	if config == nil {
+		config = DefaultEventConfig()
+	}
+	return &EventFactory{
+		ctx:       ctx,
+		sessionID: sessionID,
+		config:    config,
+		sanitizer: NewSanitizer(config.SanitizePatterns),
+	}
+}
+
+// NewEvent creates a new event with all base fields populated.
+func (f *EventFactory) NewEvent(eventType EventType, pid int) *BaseEvent {
+	now := time.Now()
+	seq := atomic.AddInt64(&f.sequence, 1)
+
+	event := &BaseEvent{
+		// Identity
+		Hostname:         f.ctx.Hostname,
+		MachineID:        f.ctx.MachineID,
+		ContainerID:      f.ctx.ContainerID,
+		ContainerImage:   f.ctx.ContainerImage,
+		ContainerRuntime: f.ctx.ContainerRuntime,
+		K8sNamespace:     f.ctx.K8sNamespace,
+		K8sPod:           f.ctx.K8sPod,
+		K8sNode:          f.ctx.K8sNode,
+		K8sCluster:       f.ctx.K8sCluster,
+
+		// Timestamp
+		Timestamp:       now.Format("2006-01-02T15:04:05.000000Z07:00"),
+		TimestampUnixUS: now.UnixMicro(),
+		MonotonicNS:     now.UnixNano(),
+		Sequence:        seq,
+
+		// OS
+		OS:            f.ctx.OS,
+		OSVersion:     f.ctx.OSVersion,
+		OSDistro:      f.ctx.OSDistro,
+		KernelVersion: f.ctx.KernelVersion,
+		Arch:          f.ctx.Arch,
+
+		// Platform
+		PlatformVariant: f.ctx.PlatformVariant,
+		FSBackend:       f.ctx.FSBackend,
+		NetBackend:      f.ctx.NetBackend,
+		ProcessBackend:  f.ctx.ProcessBackend,
+		IPCBackend:      f.ctx.IPCBackend,
+
+		// Version
+		AgentshVersion:     f.ctx.AgentshVersion,
+		AgentshCommit:      f.ctx.AgentshCommit,
+		AgentshBuildTime:   f.ctx.AgentshBuildTime,
+		EventSchemaVersion: f.ctx.EventSchemaVersion,
+
+		// Correlation
+		EventID:   generateEventID(),
+		SessionID: f.sessionID,
+
+		// Process
+		PID: pid,
+
+		// Type
+		Type:     eventType,
+		Category: EventCategory[eventType],
+
+		// Custom metadata
+		Metadata: f.config.DefaultMetadata,
+		Tags:     f.config.DefaultTags,
+		Labels:   f.config.DefaultLabels,
+	}
+
+	// Network info (if configured)
+	if f.config.IncludeNetworkInfo {
+		event.IPv4Addresses = f.ctx.IPv4Addresses
+		event.IPv6Addresses = f.ctx.IPv6Addresses
+		event.PrimaryInterface = f.ctx.PrimaryInterface
+	}
+	if f.config.IncludeMACAddress {
+		event.MACAddress = f.ctx.MACAddress
+	}
+
+	return event
+}
+
+// SetCommandID sets the command ID for correlation.
+func (f *EventFactory) SetCommandID(event *BaseEvent, commandID string) {
+	event.CommandID = commandID
+}
+
+// SetTraceContext sets OpenTelemetry trace context.
+func (f *EventFactory) SetTraceContext(event *BaseEvent, traceID, spanID, parentSpanID string) {
+	event.TraceID = traceID
+	event.SpanID = spanID
+	event.ParentSpanID = parentSpanID
+	event.TraceFlags = "01" // sampled
+}
+
+// SetDecision sets policy decision information.
+func (f *EventFactory) SetDecision(event *BaseEvent, decision, rule string) {
+	event.Decision = decision
+	event.PolicyRule = rule
+}
+
+// SetError sets error context.
+func (f *EventFactory) SetError(event *BaseEvent, err error, code string, errno int) {
+	if err != nil {
+		event.Error = err.Error()
+	}
+	event.ErrorCode = code
+	event.Errno = errno
+}
+
+// SanitizePath sanitizes a path if configured.
+func (f *EventFactory) SanitizePath(event *BaseEvent, path string) string {
+	if !f.config.SanitizePaths {
+		return path
+	}
+	sanitized, fields := f.sanitizer.SanitizePath(path)
+	if len(fields) > 0 {
+		event.SanitizedFields = append(event.SanitizedFields, fields...)
+		event.SanitizationReason = "sensitive_path_pattern"
+	}
+	return sanitized
+}
+
+// SanitizeCmdline sanitizes command line arguments if configured.
+func (f *EventFactory) SanitizeCmdline(event *BaseEvent, cmdline []string) []string {
+	if !f.config.SanitizePaths {
+		return cmdline
+	}
+	return f.sanitizer.SanitizeCmdline(cmdline)
+}
+
+func generateEventID() string {
+	b := make([]byte, 4)
+	rand.Read(b)
+	return fmt.Sprintf("evt-%x-%s", time.Now().UnixNano(), hex.EncodeToString(b))
+}

--- a/internal/events/sanitizer.go
+++ b/internal/events/sanitizer.go
@@ -1,0 +1,140 @@
+package events
+
+import (
+	"regexp"
+	"strings"
+)
+
+// SanitizePatterns contains patterns for sensitive content.
+type SanitizePatterns struct {
+	PathPatterns    []string `yaml:"path_patterns"`
+	CmdlinePatterns []string `yaml:"cmdline_patterns"`
+	EnvVarPatterns  []string `yaml:"env_var_patterns"`
+}
+
+// DefaultSensitivePatterns contains default patterns for sensitive content.
+var DefaultSensitivePatterns = SanitizePatterns{
+	PathPatterns: []string{
+		`(?i)\.ssh`,
+		`(?i)\.aws`,
+		`(?i)\.kube`,
+		`(?i)\.gnupg`,
+		`(?i)/secrets?/`,
+		`(?i)/credentials?/`,
+		`(?i)/private/`,
+		`(?i)\.env$`,
+		`(?i)\.pem$`,
+		`(?i)\.key$`,
+		`(?i)\.p12$`,
+		`(?i)password`,
+		`(?i)token`,
+		`(?i)api.?key`,
+	},
+	CmdlinePatterns: []string{
+		`(?i)(--password[=\s]+)\S+`,
+		`(?i)(--token[=\s]+)\S+`,
+		`(?i)(--api-key[=\s]+)\S+`,
+		`(?i)(-p\s+)\S+`,
+		`(?i)(PASS(WORD)?=)\S+`,
+		`(?i)(TOKEN=)\S+`,
+		`(?i)(API_KEY=)\S+`,
+		`(?i)(SECRET=)\S+`,
+	},
+	EnvVarPatterns: []string{
+		`(?i).*PASSWORD.*`,
+		`(?i).*SECRET.*`,
+		`(?i).*TOKEN.*`,
+		`(?i).*API.?KEY.*`,
+		`(?i).*PRIVATE.?KEY.*`,
+		`(?i).*CREDENTIAL.*`,
+		`(?i)AWS_.*`,
+		`(?i)GITHUB_TOKEN`,
+		`(?i)NPM_TOKEN`,
+	},
+}
+
+// Sanitizer handles redaction of sensitive information in events.
+type Sanitizer struct {
+	pathPatterns    []*regexp.Regexp
+	contentPatterns []*regexp.Regexp
+	envVarPatterns  []*regexp.Regexp
+}
+
+// NewSanitizer creates a new sanitizer with the given patterns.
+func NewSanitizer(patterns SanitizePatterns) *Sanitizer {
+	s := &Sanitizer{}
+
+	for _, p := range patterns.PathPatterns {
+		if re, err := regexp.Compile(p); err == nil {
+			s.pathPatterns = append(s.pathPatterns, re)
+		}
+	}
+
+	for _, p := range patterns.CmdlinePatterns {
+		if re, err := regexp.Compile(p); err == nil {
+			s.contentPatterns = append(s.contentPatterns, re)
+		}
+	}
+
+	for _, p := range patterns.EnvVarPatterns {
+		if re, err := regexp.Compile(p); err == nil {
+			s.envVarPatterns = append(s.envVarPatterns, re)
+		}
+	}
+
+	return s
+}
+
+// NewDefaultSanitizer creates a sanitizer with default patterns.
+func NewDefaultSanitizer() *Sanitizer {
+	return NewSanitizer(DefaultSensitivePatterns)
+}
+
+// SanitizePath checks if a path matches sensitive patterns.
+// Returns sanitized path and list of fields that were sanitized.
+func (s *Sanitizer) SanitizePath(path string) (string, []string) {
+	for _, re := range s.pathPatterns {
+		if re.MatchString(path) {
+			parts := strings.Split(path, "/")
+			for i, part := range parts {
+				if re.MatchString(part) {
+					parts[i] = "[REDACTED]"
+				}
+			}
+			return strings.Join(parts, "/"), []string{"path"}
+		}
+	}
+	return path, nil
+}
+
+// SanitizeCmdline redacts sensitive values in command line arguments.
+func (s *Sanitizer) SanitizeCmdline(cmdline []string) []string {
+	result := make([]string, len(cmdline))
+	for i, arg := range cmdline {
+		result[i] = arg
+		for _, re := range s.contentPatterns {
+			result[i] = re.ReplaceAllString(result[i], "${1}[REDACTED]")
+		}
+	}
+	return result
+}
+
+// ShouldSanitizeEnvVar checks if an environment variable should be redacted.
+func (s *Sanitizer) ShouldSanitizeEnvVar(name string) bool {
+	for _, re := range s.envVarPatterns {
+		if re.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsSensitivePath checks if a path matches any sensitive patterns.
+func (s *Sanitizer) IsSensitivePath(path string) bool {
+	for _, re := range s.pathPatterns {
+		if re.MatchString(path) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/events/schema.go
+++ b/internal/events/schema.go
@@ -1,0 +1,273 @@
+package events
+
+// ShellInvokeEvent - Shell shim intercepted a shell call.
+type ShellInvokeEvent struct {
+	BaseEvent
+
+	Shell       string   `json:"shell"`        // "sh", "bash", "zsh", "powershell", "cmd"
+	InvokedAs   string   `json:"invoked_as"`   // Actual binary name used
+	Args        []string `json:"args"`         // Arguments passed
+	Mode        string   `json:"mode"`         // "command" (-c), "script", "interactive"
+	Command     string   `json:"command,omitempty"`
+	Script      string   `json:"script,omitempty"`
+	Intercepted bool     `json:"intercepted"`
+	Strategy    string   `json:"strategy"` // "binary_replace", "path", "profile", "terminal"
+}
+
+// ShellPassthroughEvent - Shell shim bypassed (not in agentsh mode).
+type ShellPassthroughEvent struct {
+	BaseEvent
+
+	Shell     string `json:"shell"`
+	Reason    string `json:"reason"`     // "no_session", "no_server", "disabled"
+	RealShell string `json:"real_shell"` // Path to actual shell used
+}
+
+// SessionAutostartEvent - Server auto-started by shim.
+type SessionAutostartEvent struct {
+	BaseEvent
+
+	StartMethod string `json:"start_method"` // "fork", "systemd", "launchd", "service"
+	ConfigPath  string `json:"config_path"`
+	NewSession  string `json:"new_session_id"`
+	Workspace   string `json:"workspace"`
+	StartupMS   int64  `json:"startup_ms"`
+}
+
+// CommandInterceptEvent - Command evaluated by policy engine.
+type CommandInterceptEvent struct {
+	BaseEvent
+
+	Command    string            `json:"command"`
+	Args       []string          `json:"args"`
+	Executable string            `json:"executable"`
+	WorkingDir string            `json:"working_dir"`
+	EnvSet     map[string]string `json:"env_set,omitempty"`
+	EnvUnset   []string          `json:"env_unset,omitempty"`
+}
+
+// CommandRedirectEvent - Command redirected to different binary.
+type CommandRedirectEvent struct {
+	BaseEvent
+
+	OriginalCommand string   `json:"original_command"`
+	OriginalArgs    []string `json:"original_args"`
+	NewCommand      string   `json:"new_command"`
+	NewArgs         []string `json:"new_args"`
+	Reason          string   `json:"reason"`
+	Message         string   `json:"message"`
+	RedirectRule    string   `json:"redirect_rule"`
+}
+
+// CommandBlockedEvent - Command denied by policy.
+type CommandBlockedEvent struct {
+	BaseEvent
+
+	Command      string   `json:"command"`
+	Args         []string `json:"args"`
+	Reason       string   `json:"reason"`
+	Message      string   `json:"message"`
+	Suggestions  []string `json:"suggestions,omitempty"`
+	Alternatives []string `json:"alternatives,omitempty"`
+}
+
+// PathRedirectEvent - File path redirected to different location.
+type PathRedirectEvent struct {
+	BaseEvent
+
+	OriginalPath  string `json:"original_path"`
+	RedirectPath  string `json:"redirect_path"`
+	Operation     string `json:"operation"` // "write", "create", "mkdir"
+	RedirectRule  string `json:"redirect_rule"`
+	ParentCreated bool   `json:"parent_created"`
+}
+
+// ResourceLimits contains resource limit values.
+type ResourceLimits struct {
+	MaxMemoryMB      int64 `json:"max_memory_mb,omitempty"`
+	MaxSwapMB        int64 `json:"max_swap_mb,omitempty"`
+	CPUQuotaPercent  int   `json:"cpu_quota_percent,omitempty"`
+	MaxProcesses     int   `json:"max_processes,omitempty"`
+	MaxDiskReadMBps  int64 `json:"max_disk_read_mbps,omitempty"`
+	MaxDiskWriteMBps int64 `json:"max_disk_write_mbps,omitempty"`
+	CommandTimeoutS  int   `json:"command_timeout_s,omitempty"`
+}
+
+// LinuxCgroupInfo contains Linux cgroup details.
+type LinuxCgroupInfo struct {
+	Path        string   `json:"path"`
+	Controllers []string `json:"controllers"`
+	Version     int      `json:"version"`
+}
+
+// DarwinRlimitInfo contains macOS rlimit details.
+type DarwinRlimitInfo struct {
+	LimitsSet []string `json:"limits_set"`
+	NiceValue int      `json:"nice_value,omitempty"`
+}
+
+// WindowsJobInfo contains Windows Job Object details.
+type WindowsJobInfo struct {
+	JobHandle    uint64 `json:"job_handle"`
+	LimitFlags   uint32 `json:"limit_flags"`
+	CPURateFlags uint32 `json:"cpu_rate_flags,omitempty"`
+}
+
+// ResourceLimitSetEvent - Limits applied to process/session.
+type ResourceLimitSetEvent struct {
+	BaseEvent
+
+	TargetPID    int              `json:"target_pid"`
+	TargetType   string           `json:"target_type"` // "session", "command", "process"
+	Limits       ResourceLimits   `json:"limits"`
+	LinuxCgroup  *LinuxCgroupInfo `json:"linux_cgroup,omitempty"`
+	DarwinRlimit *DarwinRlimitInfo `json:"darwin_rlimit,omitempty"`
+	WindowsJob   *WindowsJobInfo  `json:"windows_job,omitempty"`
+}
+
+// ResourceLimitWarningEvent - Usage approaching threshold.
+type ResourceLimitWarningEvent struct {
+	BaseEvent
+
+	Resource    string  `json:"resource"` // "memory", "cpu", "disk", "processes"
+	Current     int64   `json:"current"`
+	CurrentUnit string  `json:"current_unit"` // "MB", "percent", "count"
+	Limit       int64   `json:"limit"`
+	Percentage  float64 `json:"percentage"`
+	Threshold   float64 `json:"threshold"`
+}
+
+// ResourceLimitExceededEvent - Limit hit.
+type ResourceLimitExceededEvent struct {
+	BaseEvent
+
+	Resource   string `json:"resource"`
+	Current    int64  `json:"current"`
+	Limit      int64  `json:"limit"`
+	Unit       string `json:"unit"`
+	Action     string `json:"action"` // "throttle", "kill", "deny", "warn"
+	Terminated bool   `json:"terminated"`
+	TermSignal int    `json:"term_signal,omitempty"`
+}
+
+// ResourceUsageEvent - Periodic usage snapshot.
+type ResourceUsageEvent struct {
+	BaseEvent
+
+	MemoryMB      int64   `json:"memory_mb"`
+	MemoryPercent float64 `json:"memory_percent"`
+	CPUPercent    float64 `json:"cpu_percent"`
+	DiskReadMB    int64   `json:"disk_read_mb"`
+	DiskWriteMB   int64   `json:"disk_write_mb"`
+	NetSentMB     int64   `json:"net_sent_mb"`
+	NetReceivedMB int64   `json:"net_received_mb"`
+	ProcessCount  int     `json:"process_count"`
+	ThreadCount   int     `json:"thread_count"`
+	OpenFiles     int     `json:"open_files"`
+	IntervalMS    int64   `json:"interval_ms"`
+}
+
+// ProcessAncestry contains process ancestry info.
+type ProcessAncestry struct {
+	PID  int    `json:"pid"`
+	Comm string `json:"comm"`
+}
+
+// ProcessSpawnEvent - Child process created.
+type ProcessSpawnEvent struct {
+	BaseEvent
+
+	ChildPID         int               `json:"child_pid"`
+	ChildComm        string            `json:"child_comm"`
+	ChildExe         string            `json:"child_exe"`
+	ChildArgs        []string          `json:"child_args"`
+	ParentPID        int               `json:"parent_pid"`
+	ParentComm       string            `json:"parent_comm"`
+	Ancestry         []ProcessAncestry `json:"ancestry,omitempty"`
+	Depth            int               `json:"depth"`
+	LinuxCgroupPath  string            `json:"linux_cgroup_path,omitempty"`
+	WindowsJobHandle uint64            `json:"windows_job_handle,omitempty"`
+	Expected         bool              `json:"expected"`
+}
+
+// ProcessExitEvent - Process exited.
+type ProcessExitEvent struct {
+	BaseEvent
+
+	ExitPID          int    `json:"exit_pid"`
+	ExitComm         string `json:"exit_comm"`
+	ExitCode         int    `json:"exit_code"`
+	ExitSignal       int    `json:"exit_signal,omitempty"`
+	ExitReason       string `json:"exit_reason"` // "normal", "signal", "oom", "timeout"
+	RuntimeMS        int64  `json:"runtime_ms"`
+	CPUTimeMS        int64  `json:"cpu_time_ms"`
+	MaxMemoryMB      int64  `json:"max_memory_mb"`
+	OrphanedChildren []int  `json:"orphaned_children,omitempty"`
+}
+
+// ProcessKillInfo contains info about a killed process.
+type ProcessKillInfo struct {
+	PID      int    `json:"pid"`
+	Comm     string `json:"comm"`
+	ExitCode int    `json:"exit_code"`
+}
+
+// ProcessTreeKillEvent - Entire tree terminated.
+type ProcessTreeKillEvent struct {
+	BaseEvent
+
+	Reason          string            `json:"reason"` // "timeout", "limit_exceeded", "session_end", "manual", "policy"
+	Signal          int               `json:"signal"`
+	ProcessesKilled []ProcessKillInfo `json:"processes_killed"`
+	TotalKilled     int               `json:"total_killed"`
+	Survivors       []int             `json:"survivors,omitempty"`
+	KillDurationMS  int64             `json:"kill_duration_ms"`
+}
+
+// UnixSocketEvent - Unix domain socket operation.
+type UnixSocketEvent struct {
+	BaseEvent
+
+	Operation    string `json:"operation"` // "connect", "bind", "listen", "accept"
+	SocketType   string `json:"socket_type"` // "stream", "dgram", "seqpacket"
+	Path         string `json:"path,omitempty"`
+	AbstractName string `json:"abstract_name,omitempty"`
+	IsAbstract   bool   `json:"is_abstract"`
+	PeerPID      int    `json:"peer_pid,omitempty"`
+	PeerUID      int    `json:"peer_uid,omitempty"`
+	PeerGID      int    `json:"peer_gid,omitempty"`
+	PeerComm     string `json:"peer_comm,omitempty"`
+	Service      string `json:"service,omitempty"` // "docker", "ssh-agent", "dbus", etc.
+	Method       string `json:"method"`            // "seccomp", "dtrace", "poll"
+}
+
+// NamedPipeEvent - Windows named pipe operation.
+type NamedPipeEvent struct {
+	BaseEvent
+
+	Operation  string `json:"operation"`   // "open", "create", "connect"
+	Path       string `json:"path"`        // \\.\pipe\NAME
+	PipeMode   string `json:"pipe_mode"`   // "byte", "message"
+	AccessMode string `json:"access_mode"` // "read", "write", "readwrite"
+	IsServer   bool   `json:"is_server"`
+	Service    string `json:"service,omitempty"`
+	Method     string `json:"method"` // "etw", "minifilter", "poll"
+}
+
+// IPCEndpoint contains IPC endpoint info.
+type IPCEndpoint struct {
+	PID  int    `json:"pid"`
+	Comm string `json:"comm"`
+	Role string `json:"role"` // "server", "client", "unknown"
+}
+
+// IPCObservedEvent - Audit-only detection (no enforcement).
+type IPCObservedEvent struct {
+	BaseEvent
+
+	IPCType    string        `json:"ipc_type"` // "unix_socket", "named_pipe", "shm", "mqueue"
+	Path       string        `json:"path"`
+	Method     string        `json:"method"`     // "proc_net_unix", "lsof", "pipe_enum"
+	Limitation string        `json:"limitation"` // "no_seccomp", "no_root", "audit_only"
+	Endpoints  []IPCEndpoint `json:"endpoints,omitempty"`
+}

--- a/internal/events/schema_test.go
+++ b/internal/events/schema_test.go
@@ -1,0 +1,284 @@
+package events
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEventTypes(t *testing.T) {
+	// Verify all event types have categories
+	for _, et := range AllEventTypes {
+		if _, ok := EventCategory[et]; !ok {
+			t.Errorf("Event type %q has no category", et)
+		}
+	}
+}
+
+func TestEventCategory(t *testing.T) {
+	tests := []struct {
+		eventType EventType
+		category  string
+	}{
+		{EventFileOpen, "file"},
+		{EventNetConnect, "network"},
+		{EventProcessSpawn, "process"},
+		{EventShellInvoke, "shell"},
+		{EventCommandRedirect, "command"},
+		{EventResourceLimitSet, "resource"},
+		{EventUnixSocketConnect, "ipc"},
+	}
+
+	for _, tt := range tests {
+		if got := EventCategory[tt.eventType]; got != tt.category {
+			t.Errorf("EventCategory[%q] = %q, want %q", tt.eventType, got, tt.category)
+		}
+	}
+}
+
+func TestRuntimeContext(t *testing.T) {
+	ctx := DetectRuntimeContext()
+
+	if ctx.OS == "" {
+		t.Error("OS should not be empty")
+	}
+	if ctx.Arch == "" {
+		t.Error("Arch should not be empty")
+	}
+	if ctx.EventSchemaVersion != "1.0" {
+		t.Errorf("EventSchemaVersion = %q, want 1.0", ctx.EventSchemaVersion)
+	}
+}
+
+func TestEventFactory(t *testing.T) {
+	ctx := &RuntimeContext{
+		Hostname:           "test-host",
+		OS:                 "linux",
+		Arch:               "amd64",
+		EventSchemaVersion: "1.0",
+	}
+
+	factory := NewEventFactory(ctx, "session-123", nil)
+	event := factory.NewEvent(EventFileOpen, 1234)
+
+	if event.Hostname != "test-host" {
+		t.Errorf("Hostname = %q, want test-host", event.Hostname)
+	}
+	if event.OS != "linux" {
+		t.Errorf("OS = %q, want linux", event.OS)
+	}
+	if event.SessionID != "session-123" {
+		t.Errorf("SessionID = %q, want session-123", event.SessionID)
+	}
+	if event.PID != 1234 {
+		t.Errorf("PID = %d, want 1234", event.PID)
+	}
+	if event.Type != EventFileOpen {
+		t.Errorf("Type = %q, want file_open", event.Type)
+	}
+	if event.Category != "file" {
+		t.Errorf("Category = %q, want file", event.Category)
+	}
+	if event.EventID == "" {
+		t.Error("EventID should not be empty")
+	}
+	if event.Timestamp == "" {
+		t.Error("Timestamp should not be empty")
+	}
+	if event.Sequence != 1 {
+		t.Errorf("Sequence = %d, want 1", event.Sequence)
+	}
+}
+
+func TestEventFactorySequence(t *testing.T) {
+	ctx := &RuntimeContext{OS: "linux", Arch: "amd64", EventSchemaVersion: "1.0"}
+	factory := NewEventFactory(ctx, "session-123", nil)
+
+	e1 := factory.NewEvent(EventFileOpen, 1)
+	e2 := factory.NewEvent(EventFileRead, 2)
+	e3 := factory.NewEvent(EventFileWrite, 3)
+
+	if e1.Sequence != 1 {
+		t.Errorf("e1.Sequence = %d, want 1", e1.Sequence)
+	}
+	if e2.Sequence != 2 {
+		t.Errorf("e2.Sequence = %d, want 2", e2.Sequence)
+	}
+	if e3.Sequence != 3 {
+		t.Errorf("e3.Sequence = %d, want 3", e3.Sequence)
+	}
+}
+
+func TestSanitizer(t *testing.T) {
+	s := NewDefaultSanitizer()
+
+	tests := []struct {
+		path     string
+		expected bool
+	}{
+		{"/home/user/.ssh/id_rsa", true},
+		{"/home/user/.aws/credentials", true},
+		{"/etc/passwd", false},
+		{"/var/log/app.log", false},
+		{"/home/user/.kube/config", true},
+		{"/home/user/project/password.txt", true},
+		{"/home/user/project/token.json", true},
+	}
+
+	for _, tt := range tests {
+		if got := s.IsSensitivePath(tt.path); got != tt.expected {
+			t.Errorf("IsSensitivePath(%q) = %v, want %v", tt.path, got, tt.expected)
+		}
+	}
+}
+
+func TestSanitizerPath(t *testing.T) {
+	s := NewDefaultSanitizer()
+
+	path := "/home/user/.ssh/id_rsa"
+	sanitized, fields := s.SanitizePath(path)
+
+	if !strings.Contains(sanitized, "[REDACTED]") {
+		t.Errorf("Expected sanitized path to contain [REDACTED], got %q", sanitized)
+	}
+	if len(fields) == 0 {
+		t.Error("Expected fields to be non-empty")
+	}
+}
+
+func TestSanitizerCmdline(t *testing.T) {
+	s := NewDefaultSanitizer()
+
+	cmdline := []string{"mysql", "-u", "root", "--password=secret123", "dbname"}
+	sanitized := s.SanitizeCmdline(cmdline)
+
+	for i, arg := range sanitized {
+		if strings.Contains(arg, "secret123") {
+			t.Errorf("Arg %d should not contain secret: %q", i, arg)
+		}
+	}
+}
+
+func TestSanitizerEnvVar(t *testing.T) {
+	s := NewDefaultSanitizer()
+
+	tests := []struct {
+		name     string
+		expected bool
+	}{
+		{"AWS_SECRET_ACCESS_KEY", true},
+		{"DATABASE_PASSWORD", true},
+		{"API_KEY", true},
+		{"GITHUB_TOKEN", true},
+		{"PATH", false},
+		{"HOME", false},
+		{"USER", false},
+	}
+
+	for _, tt := range tests {
+		if got := s.ShouldSanitizeEnvVar(tt.name); got != tt.expected {
+			t.Errorf("ShouldSanitizeEnvVar(%q) = %v, want %v", tt.name, got, tt.expected)
+		}
+	}
+}
+
+func TestEventConfig(t *testing.T) {
+	config := DefaultEventConfig()
+
+	if !config.IncludeNetworkInfo {
+		t.Error("IncludeNetworkInfo should default to true")
+	}
+	if config.IncludeMACAddress {
+		t.Error("IncludeMACAddress should default to false")
+	}
+	if !config.SanitizePaths {
+		t.Error("SanitizePaths should default to true")
+	}
+}
+
+func TestBaseEvent(t *testing.T) {
+	event := BaseEvent{
+		Hostname:  "test-host",
+		MachineID: "machine-123",
+		OS:        "linux",
+		Arch:      "amd64",
+		Type:      EventFileOpen,
+		Category:  "file",
+		PID:       1234,
+		SessionID: "session-123",
+	}
+
+	if event.Hostname != "test-host" {
+		t.Errorf("Hostname = %q, want test-host", event.Hostname)
+	}
+	if event.Type != EventFileOpen {
+		t.Errorf("Type = %q, want file_open", event.Type)
+	}
+}
+
+func TestShellInvokeEvent(t *testing.T) {
+	event := ShellInvokeEvent{
+		Shell:       "bash",
+		InvokedAs:   "/bin/bash",
+		Args:        []string{"-c", "echo hello"},
+		Mode:        "command",
+		Command:     "echo hello",
+		Intercepted: true,
+		Strategy:    "binary_replace",
+	}
+
+	if event.Shell != "bash" {
+		t.Errorf("Shell = %q, want bash", event.Shell)
+	}
+	if !event.Intercepted {
+		t.Error("Intercepted should be true")
+	}
+}
+
+func TestResourceLimits(t *testing.T) {
+	limits := ResourceLimits{
+		MaxMemoryMB:     2048,
+		CPUQuotaPercent: 80,
+		MaxProcesses:    100,
+	}
+
+	if limits.MaxMemoryMB != 2048 {
+		t.Errorf("MaxMemoryMB = %d, want 2048", limits.MaxMemoryMB)
+	}
+	if limits.CPUQuotaPercent != 80 {
+		t.Errorf("CPUQuotaPercent = %d, want 80", limits.CPUQuotaPercent)
+	}
+}
+
+func TestProcessSpawnEvent(t *testing.T) {
+	event := ProcessSpawnEvent{
+		ChildPID:  1235,
+		ChildComm: "node",
+		ParentPID: 1234,
+		Depth:     2,
+		Expected:  true,
+	}
+
+	if event.ChildPID != 1235 {
+		t.Errorf("ChildPID = %d, want 1235", event.ChildPID)
+	}
+	if event.Depth != 2 {
+		t.Errorf("Depth = %d, want 2", event.Depth)
+	}
+}
+
+func TestUnixSocketEvent(t *testing.T) {
+	event := UnixSocketEvent{
+		Operation:  "connect",
+		SocketType: "stream",
+		Path:       "/var/run/docker.sock",
+		Service:    "docker",
+		Method:     "seccomp",
+	}
+
+	if event.Path != "/var/run/docker.sock" {
+		t.Errorf("Path = %q, want /var/run/docker.sock", event.Path)
+	}
+	if event.Service != "docker" {
+		t.Errorf("Service = %q, want docker", event.Service)
+	}
+}

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -1,0 +1,174 @@
+package events
+
+// EventType identifies the type of event.
+type EventType string
+
+// File operation events.
+const (
+	EventFileOpen   EventType = "file_open"
+	EventFileRead   EventType = "file_read"
+	EventFileWrite  EventType = "file_write"
+	EventFileCreate EventType = "file_create"
+	EventFileDelete EventType = "file_delete"
+	EventFileRename EventType = "file_rename"
+	EventFileStat   EventType = "file_stat"
+	EventFileChmod  EventType = "file_chmod"
+	EventDirCreate  EventType = "dir_create"
+	EventDirDelete  EventType = "dir_delete"
+	EventDirList    EventType = "dir_list"
+)
+
+// Network operation events.
+const (
+	EventDNSQuery   EventType = "dns_query"
+	EventNetConnect EventType = "net_connect"
+	EventNetListen  EventType = "net_listen"
+	EventNetAccept  EventType = "net_accept"
+)
+
+// Process operation events.
+const (
+	EventProcessStart EventType = "process_start"
+	EventProcessEnd   EventType = "process_end"
+	EventProcessSpawn EventType = "process_spawn"
+	EventProcessExit  EventType = "process_exit"
+	EventProcessTree  EventType = "process_tree_kill"
+)
+
+// Environment operation events.
+const (
+	EventEnvRead    EventType = "env_read"
+	EventEnvWrite   EventType = "env_write"
+	EventEnvList    EventType = "env_list"
+	EventEnvBlocked EventType = "env_blocked"
+)
+
+// Soft delete operation events.
+const (
+	EventSoftDelete   EventType = "soft_delete"
+	EventTrashRestore EventType = "trash_restore"
+	EventTrashPurge   EventType = "trash_purge"
+)
+
+// Shell shim events.
+const (
+	EventShellInvoke      EventType = "shell_invoke"
+	EventShellPassthrough EventType = "shell_passthrough"
+	EventSessionAutostart EventType = "session_autostart"
+)
+
+// Command interception events.
+const (
+	EventCommandIntercept EventType = "command_intercept"
+	EventCommandRedirect  EventType = "command_redirect"
+	EventCommandBlocked   EventType = "command_blocked"
+	EventPathRedirect     EventType = "path_redirect"
+)
+
+// Resource limit events.
+const (
+	EventResourceLimitSet      EventType = "resource_limit_set"
+	EventResourceLimitWarning  EventType = "resource_limit_warning"
+	EventResourceLimitExceeded EventType = "resource_limit_exceeded"
+	EventResourceUsage         EventType = "resource_usage_snapshot"
+)
+
+// IPC events.
+const (
+	EventUnixSocketConnect EventType = "unix_socket_connect"
+	EventUnixSocketBind    EventType = "unix_socket_bind"
+	EventUnixSocketBlocked EventType = "unix_socket_blocked"
+	EventNamedPipeOpen     EventType = "named_pipe_open"
+	EventNamedPipeBlocked  EventType = "named_pipe_blocked"
+	EventIPCObserved       EventType = "ipc_observed"
+)
+
+// EventCategory maps event types to their categories.
+var EventCategory = map[EventType]string{
+	// File
+	EventFileOpen:   "file",
+	EventFileRead:   "file",
+	EventFileWrite:  "file",
+	EventFileCreate: "file",
+	EventFileDelete: "file",
+	EventFileRename: "file",
+	EventFileStat:   "file",
+	EventFileChmod:  "file",
+	EventDirCreate:  "file",
+	EventDirDelete:  "file",
+	EventDirList:    "file",
+
+	// Network
+	EventDNSQuery:   "network",
+	EventNetConnect: "network",
+	EventNetListen:  "network",
+	EventNetAccept:  "network",
+
+	// Process
+	EventProcessStart: "process",
+	EventProcessEnd:   "process",
+	EventProcessSpawn: "process",
+	EventProcessExit:  "process",
+	EventProcessTree:  "process",
+
+	// Environment
+	EventEnvRead:    "environment",
+	EventEnvWrite:   "environment",
+	EventEnvList:    "environment",
+	EventEnvBlocked: "environment",
+
+	// Soft delete
+	EventSoftDelete:   "trash",
+	EventTrashRestore: "trash",
+	EventTrashPurge:   "trash",
+
+	// Shell
+	EventShellInvoke:      "shell",
+	EventShellPassthrough: "shell",
+	EventSessionAutostart: "shell",
+
+	// Command
+	EventCommandIntercept: "command",
+	EventCommandRedirect:  "command",
+	EventCommandBlocked:   "command",
+	EventPathRedirect:     "command",
+
+	// Resource
+	EventResourceLimitSet:      "resource",
+	EventResourceLimitWarning:  "resource",
+	EventResourceLimitExceeded: "resource",
+	EventResourceUsage:         "resource",
+
+	// IPC
+	EventUnixSocketConnect: "ipc",
+	EventUnixSocketBind:    "ipc",
+	EventUnixSocketBlocked: "ipc",
+	EventNamedPipeOpen:     "ipc",
+	EventNamedPipeBlocked:  "ipc",
+	EventIPCObserved:       "ipc",
+}
+
+// AllEventTypes lists all event types.
+var AllEventTypes = []EventType{
+	// File
+	EventFileOpen, EventFileRead, EventFileWrite, EventFileCreate,
+	EventFileDelete, EventFileRename, EventFileStat, EventFileChmod,
+	EventDirCreate, EventDirDelete, EventDirList,
+	// Network
+	EventDNSQuery, EventNetConnect, EventNetListen, EventNetAccept,
+	// Process
+	EventProcessStart, EventProcessEnd, EventProcessSpawn, EventProcessExit, EventProcessTree,
+	// Environment
+	EventEnvRead, EventEnvWrite, EventEnvList, EventEnvBlocked,
+	// Soft delete
+	EventSoftDelete, EventTrashRestore, EventTrashPurge,
+	// Shell
+	EventShellInvoke, EventShellPassthrough, EventSessionAutostart,
+	// Command
+	EventCommandIntercept, EventCommandRedirect, EventCommandBlocked, EventPathRedirect,
+	// Resource
+	EventResourceLimitSet, EventResourceLimitWarning, EventResourceLimitExceeded, EventResourceUsage,
+	// IPC
+	EventUnixSocketConnect, EventUnixSocketBind, EventUnixSocketBlocked,
+	EventNamedPipeOpen, EventNamedPipeBlocked, EventIPCObserved,
+}


### PR DESCRIPTION
## Summary

Implements standardized event schema (spec §14) for cross-platform monitoring with self-contained events for independent parsing and analysis.

### Components

- **Event Types** (`types.go`): Constants for all event categories with category mapping
- **BaseEvent** (`base.go`): Comprehensive base structure with 80+ fields covering identity, OS, platform, correlation, process, agent context, policy, metrics, and errors
- **RuntimeContext** (`context.go`): Detects machine/container/K8s info at startup (machine-id, IPs, OS version, kernel)
- **EventFactory** (`factory.go`): Creates events with pre-populated base fields and sequence numbers
- **Sanitizer** (`sanitizer.go`): Redacts sensitive paths, cmdline args, and env vars based on configurable patterns

### Domain-Specific Events (`schema.go`)

| Category | Events |
|----------|--------|
| Shell | `shell_invoke`, `shell_passthrough`, `session_autostart` |
| Command | `command_intercept`, `command_redirect`, `command_blocked`, `path_redirect` |
| Resource | `resource_limit_set`, `resource_limit_warning`, `resource_limit_exceeded`, `resource_usage_snapshot` |
| Process | `process_spawn`, `process_exit`, `process_tree_kill` |
| IPC | `unix_socket_connect`, `unix_socket_bind`, `named_pipe_open`, `ipc_observed` |

## Test plan

- [x] Unit tests for types, factory, sanitizer, and event structs
- [x] All existing tests pass
- [x] Cross-compilation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)