### PR TITLE
feat: add unified configuration with platform detection and policy file loading

### DIFF
--- a/internal/config/platform.go
+++ b/internal/config/platform.go
@@ -1,0 +1,118 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/agentsh/agentsh/internal/platform"
+)
+
+// InitializePlatform creates and configures a platform based on the config.
+func InitializePlatform(cfg *Config) (platform.Platform, error) {
+	opts := platform.PlatformOptions{
+		Mode:            cfg.Platform.Mode,
+		FallbackEnabled: cfg.Platform.Fallback.Enabled,
+		FallbackOrder:   cfg.Platform.Fallback.Order,
+	}
+
+	p, err := platform.NewWithOptions(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize platform: %w", err)
+	}
+
+	// Validate platform capabilities meet requirements
+	caps := p.Capabilities()
+
+	if cfg.Sandbox.Enabled && !cfg.Sandbox.AllowDegraded {
+		if caps.IsolationLevel < platform.IsolationFull {
+			return nil, fmt.Errorf(
+				"platform %s has degraded isolation (level %s), "+
+					"set sandbox.allow_degraded=true to continue",
+				p.Name(), caps.IsolationLevel,
+			)
+		}
+	}
+
+	return p, nil
+}
+
+// GetMountPoint returns the appropriate mount point for the current platform.
+func GetMountPoint(cfg *Config) string {
+	mode := platform.ParsePlatformMode(cfg.Platform.Mode)
+
+	switch mode {
+	case platform.ModeLinuxNative:
+		return cfg.Platform.MountPoints.Linux
+	case platform.ModeDarwinNative, platform.ModeDarwinLima:
+		return cfg.Platform.MountPoints.Darwin
+	case platform.ModeWindowsNative:
+		return cfg.Platform.MountPoints.Windows
+	case platform.ModeWindowsWSL2:
+		return cfg.Platform.MountPoints.WindowsWSL2
+	default:
+		// Fallback based on runtime OS
+		switch runtime.GOOS {
+		case "windows":
+			return cfg.Platform.MountPoints.Windows
+		case "darwin":
+			return cfg.Platform.MountPoints.Darwin
+		default:
+			return cfg.Platform.MountPoints.Linux
+		}
+	}
+}
+
+// GetDataDir returns the platform-appropriate data directory.
+func GetDataDir() string {
+	switch runtime.GOOS {
+	case "windows":
+		if dir := os.Getenv("PROGRAMDATA"); dir != "" {
+			return dir + `\agentsh`
+		}
+		return `C:\ProgramData\agentsh`
+	case "darwin":
+		return "/usr/local/var/agentsh"
+	default:
+		return "/var/lib/agentsh"
+	}
+}
+
+// GetConfigDir returns the platform-appropriate config directory.
+func GetConfigDir() string {
+	switch runtime.GOOS {
+	case "windows":
+		if dir := os.Getenv("PROGRAMDATA"); dir != "" {
+			return dir + `\agentsh`
+		}
+		return `C:\ProgramData\agentsh`
+	case "darwin":
+		return "/usr/local/etc/agentsh"
+	default:
+		return "/etc/agentsh"
+	}
+}
+
+// GetPoliciesDir returns the platform-appropriate policies directory.
+func GetPoliciesDir() string {
+	return GetConfigDir() + string(os.PathSeparator) + "policies"
+}
+
+// GetUserConfigDir returns the user-specific config directory.
+func GetUserConfigDir() string {
+	home, _ := os.UserHomeDir()
+	switch runtime.GOOS {
+	case "windows":
+		if appdata := os.Getenv("APPDATA"); appdata != "" {
+			return appdata + `\agentsh`
+		}
+		return home + `\AppData\Roaming\agentsh`
+	case "darwin":
+		return home + "/Library/Application Support/agentsh"
+	default:
+		if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+			return xdg + "/agentsh"
+		}
+		return home + "/.config/agentsh"
+	}
+}

--- a/internal/config/platform_test.go
+++ b/internal/config/platform_test.go
@@ -1,0 +1,324 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestGetMountPoint(t *testing.T) {
+	cfg := &Config{}
+	cfg.Platform.Mode = "auto"
+	cfg.Platform.MountPoints.Linux = "/tmp/agentsh/linux"
+	cfg.Platform.MountPoints.Darwin = "/tmp/agentsh/darwin"
+	cfg.Platform.MountPoints.Windows = "X:"
+	cfg.Platform.MountPoints.WindowsWSL2 = "/tmp/agentsh/wsl2"
+
+	// Test with auto mode - should return based on current OS
+	mp := GetMountPoint(cfg)
+	switch runtime.GOOS {
+	case "linux":
+		if mp != "/tmp/agentsh/linux" {
+			t.Errorf("GetMountPoint() = %q, want %q", mp, "/tmp/agentsh/linux")
+		}
+	case "darwin":
+		if mp != "/tmp/agentsh/darwin" {
+			t.Errorf("GetMountPoint() = %q, want %q", mp, "/tmp/agentsh/darwin")
+		}
+	case "windows":
+		if mp != "X:" {
+			t.Errorf("GetMountPoint() = %q, want %q", mp, "X:")
+		}
+	}
+
+	// Test with explicit mode
+	cfg.Platform.Mode = "linux"
+	mp = GetMountPoint(cfg)
+	if mp != "/tmp/agentsh/linux" {
+		t.Errorf("GetMountPoint(linux) = %q, want %q", mp, "/tmp/agentsh/linux")
+	}
+
+	cfg.Platform.Mode = "darwin"
+	mp = GetMountPoint(cfg)
+	if mp != "/tmp/agentsh/darwin" {
+		t.Errorf("GetMountPoint(darwin) = %q, want %q", mp, "/tmp/agentsh/darwin")
+	}
+
+	cfg.Platform.Mode = "windows"
+	mp = GetMountPoint(cfg)
+	if mp != "X:" {
+		t.Errorf("GetMountPoint(windows) = %q, want %q", mp, "X:")
+	}
+
+	cfg.Platform.Mode = "windows-wsl2"
+	mp = GetMountPoint(cfg)
+	if mp != "/tmp/agentsh/wsl2" {
+		t.Errorf("GetMountPoint(windows-wsl2) = %q, want %q", mp, "/tmp/agentsh/wsl2")
+	}
+}
+
+func TestGetDataDir(t *testing.T) {
+	dir := GetDataDir()
+	if dir == "" {
+		t.Error("GetDataDir() returned empty string")
+	}
+	// Just verify it returns something reasonable based on OS
+	switch runtime.GOOS {
+	case "windows":
+		if !filepath.IsAbs(dir) {
+			t.Errorf("GetDataDir() = %q, expected absolute path", dir)
+		}
+	default:
+		if !filepath.IsAbs(dir) {
+			t.Errorf("GetDataDir() = %q, expected absolute path", dir)
+		}
+	}
+}
+
+func TestGetConfigDir(t *testing.T) {
+	dir := GetConfigDir()
+	if dir == "" {
+		t.Error("GetConfigDir() returned empty string")
+	}
+	if !filepath.IsAbs(dir) {
+		t.Errorf("GetConfigDir() = %q, expected absolute path", dir)
+	}
+}
+
+func TestGetPoliciesDir(t *testing.T) {
+	dir := GetPoliciesDir()
+	if dir == "" {
+		t.Error("GetPoliciesDir() returned empty string")
+	}
+	// Should be a subdirectory of config dir
+	configDir := GetConfigDir()
+	if !filepath.HasPrefix(dir, configDir) {
+		t.Errorf("GetPoliciesDir() = %q, expected to be under %q", dir, configDir)
+	}
+}
+
+func TestGetUserConfigDir(t *testing.T) {
+	dir := GetUserConfigDir()
+	if dir == "" {
+		t.Error("GetUserConfigDir() returned empty string")
+	}
+	// Should contain "agentsh"
+	if !filepath.IsAbs(dir) {
+		t.Errorf("GetUserConfigDir() = %q, expected absolute path", dir)
+	}
+}
+
+func TestLoad_SandboxLimits(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(cfgPath, []byte(`
+sandbox:
+  enabled: true
+  allow_degraded: true
+  limits:
+    max_memory_mb: 4096
+    max_cpu_percent: 80
+    max_processes: 200
+    max_disk_io_mbps: 200
+    max_network_mbps: 100
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cfg.Sandbox.Enabled {
+		t.Error("sandbox.enabled should be true")
+	}
+	if !cfg.Sandbox.AllowDegraded {
+		t.Error("sandbox.allow_degraded should be true")
+	}
+	if cfg.Sandbox.Limits.MaxMemoryMB != 4096 {
+		t.Errorf("sandbox.limits.max_memory_mb = %d, want 4096", cfg.Sandbox.Limits.MaxMemoryMB)
+	}
+	if cfg.Sandbox.Limits.MaxCPUPercent != 80 {
+		t.Errorf("sandbox.limits.max_cpu_percent = %d, want 80", cfg.Sandbox.Limits.MaxCPUPercent)
+	}
+	if cfg.Sandbox.Limits.MaxProcesses != 200 {
+		t.Errorf("sandbox.limits.max_processes = %d, want 200", cfg.Sandbox.Limits.MaxProcesses)
+	}
+	if cfg.Sandbox.Limits.MaxDiskIOMbps != 200 {
+		t.Errorf("sandbox.limits.max_disk_io_mbps = %d, want 200", cfg.Sandbox.Limits.MaxDiskIOMbps)
+	}
+	if cfg.Sandbox.Limits.MaxNetworkMbps != 100 {
+		t.Errorf("sandbox.limits.max_network_mbps = %d, want 100", cfg.Sandbox.Limits.MaxNetworkMbps)
+	}
+}
+
+func TestLoad_SandboxLimitsDefaults(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(cfgPath, []byte(`
+sandbox:
+  enabled: true
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check defaults are applied
+	if cfg.Sandbox.Limits.MaxMemoryMB != 2048 {
+		t.Errorf("sandbox.limits.max_memory_mb default = %d, want 2048", cfg.Sandbox.Limits.MaxMemoryMB)
+	}
+	if cfg.Sandbox.Limits.MaxCPUPercent != 50 {
+		t.Errorf("sandbox.limits.max_cpu_percent default = %d, want 50", cfg.Sandbox.Limits.MaxCPUPercent)
+	}
+	if cfg.Sandbox.Limits.MaxProcesses != 100 {
+		t.Errorf("sandbox.limits.max_processes default = %d, want 100", cfg.Sandbox.Limits.MaxProcesses)
+	}
+}
+
+func TestLoad_NetworkInterceptConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(cfgPath, []byte(`
+sandbox:
+  network:
+    enabled: true
+    proxy_port: 9090
+    dns_port: 9054
+    intercept_mode: tcp_only
+    tls_inspection:
+      enabled: true
+      ca_cert: "/path/to/ca.crt"
+      ca_key: "/path/to/ca.key"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Sandbox.Network.ProxyPort != 9090 {
+		t.Errorf("sandbox.network.proxy_port = %d, want 9090", cfg.Sandbox.Network.ProxyPort)
+	}
+	if cfg.Sandbox.Network.DNSPort != 9054 {
+		t.Errorf("sandbox.network.dns_port = %d, want 9054", cfg.Sandbox.Network.DNSPort)
+	}
+	if cfg.Sandbox.Network.InterceptMode != "tcp_only" {
+		t.Errorf("sandbox.network.intercept_mode = %q, want tcp_only", cfg.Sandbox.Network.InterceptMode)
+	}
+	if !cfg.Sandbox.Network.TLSInspection.Enabled {
+		t.Error("sandbox.network.tls_inspection.enabled should be true")
+	}
+	if cfg.Sandbox.Network.TLSInspection.CACert != "/path/to/ca.crt" {
+		t.Errorf("sandbox.network.tls_inspection.ca_cert = %q", cfg.Sandbox.Network.TLSInspection.CACert)
+	}
+}
+
+func TestLoad_NetworkInterceptDefaults(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(cfgPath, []byte(`
+sandbox:
+  network:
+    enabled: true
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Sandbox.Network.ProxyPort != 9080 {
+		t.Errorf("sandbox.network.proxy_port default = %d, want 9080", cfg.Sandbox.Network.ProxyPort)
+	}
+	if cfg.Sandbox.Network.DNSPort != 9053 {
+		t.Errorf("sandbox.network.dns_port default = %d, want 9053", cfg.Sandbox.Network.DNSPort)
+	}
+	if cfg.Sandbox.Network.InterceptMode != "all" {
+		t.Errorf("sandbox.network.intercept_mode default = %q, want all", cfg.Sandbox.Network.InterceptMode)
+	}
+}
+
+func TestLoad_InvalidInterceptMode(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(cfgPath, []byte(`
+sandbox:
+  network:
+    intercept_mode: invalid_mode
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(cfgPath)
+	if err == nil {
+		t.Error("expected error for invalid intercept_mode")
+	}
+}
+
+func TestLoad_InvalidPlatformMode(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(cfgPath, []byte(`
+platform:
+  mode: invalid_platform
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(cfgPath)
+	if err == nil {
+		t.Error("expected error for invalid platform.mode")
+	}
+}
+
+func TestLoad_PlatformConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(cfgPath, []byte(`
+platform:
+  mode: darwin-lima
+  fallback:
+    enabled: true
+    order:
+      - darwin
+      - linux
+  mount_points:
+    linux: /mnt/workspace
+    darwin: /Volumes/workspace
+    windows: "Y:"
+    windows_wsl2: /mnt/wsl
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Platform.Mode != "darwin-lima" {
+		t.Errorf("platform.mode = %q, want darwin-lima", cfg.Platform.Mode)
+	}
+	if !cfg.Platform.Fallback.Enabled {
+		t.Error("platform.fallback.enabled should be true")
+	}
+	if len(cfg.Platform.Fallback.Order) != 2 {
+		t.Errorf("platform.fallback.order len = %d, want 2", len(cfg.Platform.Fallback.Order))
+	}
+	if cfg.Platform.MountPoints.Linux != "/mnt/workspace" {
+		t.Errorf("platform.mount_points.linux = %q", cfg.Platform.MountPoints.Linux)
+	}
+	if cfg.Platform.MountPoints.Darwin != "/Volumes/workspace" {
+		t.Errorf("platform.mount_points.darwin = %q", cfg.Platform.MountPoints.Darwin)
+	}
+}

--- a/internal/config/policy_loader.go
+++ b/internal/config/policy_loader.go
@@ -1,0 +1,392 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PolicyFiles represents policy configuration loaded from separate files.
+type PolicyFiles struct {
+	Env      *EnvProtectionPolicy `yaml:"env_protection"`
+	File     *FilePolicyConfig    `yaml:"file_policy"`
+	Network  *NetworkPolicyConfig `yaml:"network_policy"`
+	DNS      *DNSPolicyConfig     `yaml:"dns_policy"`
+	Registry *RegistryPolicyConfig `yaml:"registry_policy"` // Windows only
+}
+
+// EnvProtectionPolicy configures environment variable protection.
+type EnvProtectionPolicy struct {
+	Enabled           bool     `yaml:"enabled"`
+	Mode              string   `yaml:"mode"` // "allowlist" or "blocklist"
+	Allowlist         []string `yaml:"allowlist"`
+	Blocklist         []string `yaml:"blocklist"`
+	SensitivePatterns []string `yaml:"sensitive_patterns"`
+	RedactInsteadOfRemove bool   `yaml:"redact_instead_of_remove"`
+	RedactPlaceholder     string `yaml:"redact_placeholder"`
+	LogAccess             bool   `yaml:"log_access"`
+	AlertOnSensitive      bool   `yaml:"alert_on_sensitive"`
+}
+
+// FilePolicyConfig configures file access policy.
+type FilePolicyConfig struct {
+	DefaultAction string           `yaml:"default_action"` // deny, allow, approve
+	Rules         []FilePolicyRule `yaml:"rules"`
+}
+
+// FilePolicyRule defines a file access rule.
+type FilePolicyRule struct {
+	Name           string   `yaml:"name"`
+	Paths          []string `yaml:"paths"`
+	Operations     []string `yaml:"operations"` // read, write, create, delete, rename, stat
+	Action         string   `yaml:"action"`     // allow, deny, approve, redirect
+	TimeoutSeconds int      `yaml:"timeout_seconds,omitempty"`
+	Redirect       *FileRedirectConfig `yaml:"redirect,omitempty"`
+}
+
+// FileRedirectConfig configures file redirect behavior.
+type FileRedirectConfig struct {
+	FilePath string `yaml:"file_path"`
+}
+
+// NetworkPolicyConfig configures network access policy.
+type NetworkPolicyConfig struct {
+	DefaultAction string              `yaml:"default_action"`
+	Rules         []NetworkPolicyRule `yaml:"rules"`
+}
+
+// NetworkPolicyRule defines a network access rule.
+type NetworkPolicyRule struct {
+	Name           string   `yaml:"name"`
+	Domains        []string `yaml:"domains,omitempty"`
+	CIDRs          []string `yaml:"cidrs,omitempty"`
+	Ports          []int    `yaml:"ports,omitempty"`
+	Action         string   `yaml:"action"` // allow, deny, approve, redirect
+	TimeoutSeconds int      `yaml:"timeout_seconds,omitempty"`
+	Redirect       *NetworkRedirectConfig `yaml:"redirect,omitempty"`
+}
+
+// NetworkRedirectConfig configures network redirect behavior.
+type NetworkRedirectConfig struct {
+	Host string `yaml:"host"`
+	Port int    `yaml:"port"`
+}
+
+// DNSPolicyConfig configures DNS query policy.
+type DNSPolicyConfig struct {
+	Rules []DNSPolicyRule `yaml:"rules"`
+}
+
+// DNSPolicyRule defines a DNS policy rule.
+type DNSPolicyRule struct {
+	Name     string   `yaml:"name"`
+	Patterns []string `yaml:"patterns"` // glob patterns like "*.malware.com"
+	Action   string   `yaml:"action"`   // allow, deny, redirect
+	Redirect *DNSRedirectConfig `yaml:"redirect,omitempty"`
+}
+
+// DNSRedirectConfig configures DNS redirect behavior.
+type DNSRedirectConfig struct {
+	IPAddress string `yaml:"ip_address"`
+}
+
+// RegistryPolicyConfig configures Windows registry access policy.
+type RegistryPolicyConfig struct {
+	DefaultAction string               `yaml:"default_action"`
+	LogAll        bool                 `yaml:"log_all"`
+	Rules         []RegistryPolicyRule `yaml:"rules"`
+}
+
+// RegistryPolicyRule defines a Windows registry access rule.
+type RegistryPolicyRule struct {
+	Name           string   `yaml:"name"`
+	Paths          []string `yaml:"paths"` // e.g., "HKLM\\SOFTWARE\\..."
+	Operations     []string `yaml:"operations"` // read, write, create, delete
+	Action         string   `yaml:"action"` // allow, deny, approve, redirect
+	TimeoutSeconds int      `yaml:"timeout_seconds,omitempty"`
+	Redirect       *RegistryRedirectConfig `yaml:"redirect,omitempty"`
+}
+
+// RegistryRedirectConfig configures registry redirect behavior.
+type RegistryRedirectConfig struct {
+	Value string `yaml:"value"`
+}
+
+// LoadPolicyFiles loads policy configuration from separate files in a directory.
+func LoadPolicyFiles(dir string) (*PolicyFiles, error) {
+	policies := &PolicyFiles{}
+
+	// Load env policy
+	if p, err := loadEnvPolicyFile(dir, "env.yaml", "env.yml"); err != nil {
+		return nil, fmt.Errorf("load env policy: %w", err)
+	} else if p != nil {
+		policies.Env = p
+	}
+
+	// Load file policy
+	if p, err := loadFilePolicyFile(dir, "files.yaml", "files.yml", "file.yaml", "file.yml"); err != nil {
+		return nil, fmt.Errorf("load file policy: %w", err)
+	} else if p != nil {
+		policies.File = p
+	}
+
+	// Load network policy
+	if p, err := loadNetworkPolicyFile(dir, "network.yaml", "network.yml"); err != nil {
+		return nil, fmt.Errorf("load network policy: %w", err)
+	} else if p != nil {
+		policies.Network = p
+	}
+
+	// Load DNS policy (may be embedded in network.yaml or separate)
+	if p, err := loadDNSPolicyFile(dir, "dns.yaml", "dns.yml"); err != nil {
+		return nil, fmt.Errorf("load dns policy: %w", err)
+	} else if p != nil {
+		policies.DNS = p
+	}
+
+	// Load registry policy (Windows only)
+	if p, err := loadRegistryPolicyFile(dir, "registry.yaml", "registry.yml"); err != nil {
+		return nil, fmt.Errorf("load registry policy: %w", err)
+	} else if p != nil {
+		policies.Registry = p
+	}
+
+	return policies, nil
+}
+
+// Wrapper types for YAML files with top-level keys
+type envPolicyWrapper struct {
+	EnvProtection *EnvProtectionPolicy `yaml:"env_protection"`
+}
+
+type filePolicyWrapper struct {
+	FilePolicy *FilePolicyConfig `yaml:"file_policy"`
+}
+
+type networkPolicyWrapper struct {
+	NetworkPolicy *NetworkPolicyConfig `yaml:"network_policy"`
+}
+
+type dnsPolicyWrapper struct {
+	DNSPolicy *DNSPolicyConfig `yaml:"dns_policy"`
+}
+
+type registryPolicyWrapper struct {
+	RegistryPolicy *RegistryPolicyConfig `yaml:"registry_policy"`
+}
+
+func loadEnvPolicyFile(dir string, names ...string) (*EnvProtectionPolicy, error) {
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			continue
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+
+		var wrapper envPolicyWrapper
+		if err := yaml.Unmarshal(data, &wrapper); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+
+		return wrapper.EnvProtection, nil
+	}
+	return nil, nil
+}
+
+func loadFilePolicyFile(dir string, names ...string) (*FilePolicyConfig, error) {
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			continue
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+
+		var wrapper filePolicyWrapper
+		if err := yaml.Unmarshal(data, &wrapper); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+
+		return wrapper.FilePolicy, nil
+	}
+	return nil, nil
+}
+
+func loadNetworkPolicyFile(dir string, names ...string) (*NetworkPolicyConfig, error) {
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			continue
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+
+		var wrapper networkPolicyWrapper
+		if err := yaml.Unmarshal(data, &wrapper); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+
+		return wrapper.NetworkPolicy, nil
+	}
+	return nil, nil
+}
+
+func loadDNSPolicyFile(dir string, names ...string) (*DNSPolicyConfig, error) {
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			continue
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+
+		var wrapper dnsPolicyWrapper
+		if err := yaml.Unmarshal(data, &wrapper); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+
+		return wrapper.DNSPolicy, nil
+	}
+	return nil, nil
+}
+
+func loadRegistryPolicyFile(dir string, names ...string) (*RegistryPolicyConfig, error) {
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			continue
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+
+		var wrapper registryPolicyWrapper
+		if err := yaml.Unmarshal(data, &wrapper); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+
+		return wrapper.RegistryPolicy, nil
+	}
+	return nil, nil
+}
+
+// LoadMinimalPolicy loads a minimal starter policy from a single file.
+func LoadMinimalPolicy(path string) (*PolicyFiles, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var policies PolicyFiles
+	if err := yaml.Unmarshal(data, &policies); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+
+	return &policies, nil
+}
+
+// ValidatePolicyFiles validates the loaded policy files.
+func ValidatePolicyFiles(policies *PolicyFiles) error {
+	if policies.Env != nil {
+		if err := validateEnvPolicy(policies.Env); err != nil {
+			return fmt.Errorf("env policy: %w", err)
+		}
+	}
+	if policies.File != nil {
+		if err := validateFilePolicy(policies.File); err != nil {
+			return fmt.Errorf("file policy: %w", err)
+		}
+	}
+	if policies.Network != nil {
+		if err := validateNetworkPolicy(policies.Network); err != nil {
+			return fmt.Errorf("network policy: %w", err)
+		}
+	}
+	if policies.Registry != nil {
+		if err := validateRegistryPolicy(policies.Registry); err != nil {
+			return fmt.Errorf("registry policy: %w", err)
+		}
+	}
+	return nil
+}
+
+func validateEnvPolicy(p *EnvProtectionPolicy) error {
+	switch strings.ToLower(p.Mode) {
+	case "", "allowlist", "blocklist":
+	default:
+		return fmt.Errorf("invalid mode %q (must be 'allowlist' or 'blocklist')", p.Mode)
+	}
+	return nil
+}
+
+func validateFilePolicy(p *FilePolicyConfig) error {
+	if err := validateAction(p.DefaultAction); err != nil {
+		return fmt.Errorf("default_action: %w", err)
+	}
+	for i, rule := range p.Rules {
+		if rule.Name == "" {
+			return fmt.Errorf("rule[%d]: name is required", i)
+		}
+		if err := validateAction(rule.Action); err != nil {
+			return fmt.Errorf("rule[%d] %q: action: %w", i, rule.Name, err)
+		}
+	}
+	return nil
+}
+
+func validateNetworkPolicy(p *NetworkPolicyConfig) error {
+	if err := validateAction(p.DefaultAction); err != nil {
+		return fmt.Errorf("default_action: %w", err)
+	}
+	for i, rule := range p.Rules {
+		if rule.Name == "" {
+			return fmt.Errorf("rule[%d]: name is required", i)
+		}
+		if err := validateAction(rule.Action); err != nil {
+			return fmt.Errorf("rule[%d] %q: action: %w", i, rule.Name, err)
+		}
+	}
+	return nil
+}
+
+func validateRegistryPolicy(p *RegistryPolicyConfig) error {
+	if err := validateAction(p.DefaultAction); err != nil {
+		return fmt.Errorf("default_action: %w", err)
+	}
+	for i, rule := range p.Rules {
+		if rule.Name == "" {
+			return fmt.Errorf("rule[%d]: name is required", i)
+		}
+		if err := validateAction(rule.Action); err != nil {
+			return fmt.Errorf("rule[%d] %q: action: %w", i, rule.Name, err)
+		}
+	}
+	return nil
+}
+
+func validateAction(action string) error {
+	switch strings.ToLower(action) {
+	case "", "allow", "deny", "approve", "redirect":
+		return nil
+	default:
+		return fmt.Errorf("invalid action %q (must be 'allow', 'deny', 'approve', or 'redirect')", action)
+	}
+}

--- a/internal/config/policy_loader_test.go
+++ b/internal/config/policy_loader_test.go
@@ -1,0 +1,465 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadPolicyFiles_EnvPolicy(t *testing.T) {
+	dir := t.TempDir()
+
+	envPolicy := `
+env_protection:
+  enabled: true
+  mode: allowlist
+  allowlist:
+    - PATH
+    - HOME
+    - USER
+  blocklist:
+    - "*_SECRET*"
+    - "*_TOKEN*"
+  sensitive_patterns:
+    - "(?i)password"
+  redact_instead_of_remove: true
+  redact_placeholder: "[HIDDEN]"
+  log_access: true
+  alert_on_sensitive: true
+`
+	if err := os.WriteFile(filepath.Join(dir, "env.yaml"), []byte(envPolicy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	policies, err := LoadPolicyFiles(dir)
+	if err != nil {
+		t.Fatalf("LoadPolicyFiles: %v", err)
+	}
+
+	if policies.Env == nil {
+		t.Fatal("env policy should not be nil")
+	}
+	if !policies.Env.Enabled {
+		t.Error("env_protection.enabled should be true")
+	}
+	if policies.Env.Mode != "allowlist" {
+		t.Errorf("env_protection.mode = %q, want allowlist", policies.Env.Mode)
+	}
+	if len(policies.Env.Allowlist) != 3 {
+		t.Errorf("env_protection.allowlist len = %d, want 3", len(policies.Env.Allowlist))
+	}
+	if len(policies.Env.Blocklist) != 2 {
+		t.Errorf("env_protection.blocklist len = %d, want 2", len(policies.Env.Blocklist))
+	}
+	if !policies.Env.RedactInsteadOfRemove {
+		t.Error("env_protection.redact_instead_of_remove should be true")
+	}
+	if policies.Env.RedactPlaceholder != "[HIDDEN]" {
+		t.Errorf("env_protection.redact_placeholder = %q, want [HIDDEN]", policies.Env.RedactPlaceholder)
+	}
+}
+
+func TestLoadPolicyFiles_FilePolicy(t *testing.T) {
+	dir := t.TempDir()
+
+	filePolicy := `
+file_policy:
+  default_action: deny
+  rules:
+    - name: workspace
+      paths:
+        - "${WORKSPACE}/**"
+      operations:
+        - read
+        - write
+        - create
+      action: allow
+    - name: sensitive
+      paths:
+        - "**/.ssh/**"
+        - "**/.env"
+      operations:
+        - read
+        - write
+      action: deny
+    - name: redirect-test
+      paths:
+        - "/etc/passwd"
+      operations:
+        - read
+      action: redirect
+      redirect:
+        file_path: "/opt/honeypot/fake-passwd"
+`
+	if err := os.WriteFile(filepath.Join(dir, "files.yaml"), []byte(filePolicy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	policies, err := LoadPolicyFiles(dir)
+	if err != nil {
+		t.Fatalf("LoadPolicyFiles: %v", err)
+	}
+
+	if policies.File == nil {
+		t.Fatal("file policy should not be nil")
+	}
+	if policies.File.DefaultAction != "deny" {
+		t.Errorf("file_policy.default_action = %q, want deny", policies.File.DefaultAction)
+	}
+	if len(policies.File.Rules) != 3 {
+		t.Errorf("file_policy.rules len = %d, want 3", len(policies.File.Rules))
+	}
+
+	// Check redirect rule
+	redirectRule := policies.File.Rules[2]
+	if redirectRule.Action != "redirect" {
+		t.Errorf("redirect rule action = %q, want redirect", redirectRule.Action)
+	}
+	if redirectRule.Redirect == nil {
+		t.Fatal("redirect rule should have redirect config")
+	}
+	if redirectRule.Redirect.FilePath != "/opt/honeypot/fake-passwd" {
+		t.Errorf("redirect.file_path = %q", redirectRule.Redirect.FilePath)
+	}
+}
+
+func TestLoadPolicyFiles_NetworkPolicy(t *testing.T) {
+	dir := t.TempDir()
+
+	networkPolicy := `
+network_policy:
+  default_action: deny
+  rules:
+    - name: package-registries
+      domains:
+        - npmjs.org
+        - pypi.org
+        - github.com
+      action: allow
+    - name: internal-block
+      cidrs:
+        - 10.0.0.0/8
+        - 192.168.0.0/16
+      action: deny
+    - name: redirect-api
+      domains:
+        - api.openai.com
+      action: redirect
+      redirect:
+        host: localhost
+        port: 8080
+`
+	if err := os.WriteFile(filepath.Join(dir, "network.yaml"), []byte(networkPolicy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	policies, err := LoadPolicyFiles(dir)
+	if err != nil {
+		t.Fatalf("LoadPolicyFiles: %v", err)
+	}
+
+	if policies.Network == nil {
+		t.Fatal("network policy should not be nil")
+	}
+	if policies.Network.DefaultAction != "deny" {
+		t.Errorf("network_policy.default_action = %q, want deny", policies.Network.DefaultAction)
+	}
+	if len(policies.Network.Rules) != 3 {
+		t.Errorf("network_policy.rules len = %d, want 3", len(policies.Network.Rules))
+	}
+
+	// Check redirect rule
+	redirectRule := policies.Network.Rules[2]
+	if redirectRule.Redirect == nil {
+		t.Fatal("redirect rule should have redirect config")
+	}
+	if redirectRule.Redirect.Host != "localhost" {
+		t.Errorf("redirect.host = %q, want localhost", redirectRule.Redirect.Host)
+	}
+	if redirectRule.Redirect.Port != 8080 {
+		t.Errorf("redirect.port = %d, want 8080", redirectRule.Redirect.Port)
+	}
+}
+
+func TestLoadPolicyFiles_DNSPolicy(t *testing.T) {
+	dir := t.TempDir()
+
+	dnsPolicy := `
+dns_policy:
+  rules:
+    - name: block-malware
+      patterns:
+        - "*.malware.com"
+        - "*.evil.net"
+      action: deny
+    - name: redirect-dns
+      patterns:
+        - "*"
+      action: redirect
+      redirect:
+        ip_address: "1.1.1.2"
+`
+	if err := os.WriteFile(filepath.Join(dir, "dns.yaml"), []byte(dnsPolicy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	policies, err := LoadPolicyFiles(dir)
+	if err != nil {
+		t.Fatalf("LoadPolicyFiles: %v", err)
+	}
+
+	if policies.DNS == nil {
+		t.Fatal("dns policy should not be nil")
+	}
+	if len(policies.DNS.Rules) != 2 {
+		t.Errorf("dns_policy.rules len = %d, want 2", len(policies.DNS.Rules))
+	}
+
+	// Check redirect rule
+	redirectRule := policies.DNS.Rules[1]
+	if redirectRule.Redirect == nil {
+		t.Fatal("redirect rule should have redirect config")
+	}
+	if redirectRule.Redirect.IPAddress != "1.1.1.2" {
+		t.Errorf("redirect.ip_address = %q, want 1.1.1.2", redirectRule.Redirect.IPAddress)
+	}
+}
+
+func TestLoadPolicyFiles_RegistryPolicy(t *testing.T) {
+	dir := t.TempDir()
+
+	registryPolicy := `
+registry_policy:
+  default_action: allow
+  log_all: true
+  rules:
+    - name: block-autorun
+      paths:
+        - "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run*"
+        - "HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run*"
+      operations:
+        - write
+        - create
+        - delete
+      action: deny
+    - name: approve-services
+      paths:
+        - "HKLM\\SYSTEM\\CurrentControlSet\\Services\\*"
+      operations:
+        - create
+        - write
+      action: approve
+      timeout_seconds: 300
+`
+	if err := os.WriteFile(filepath.Join(dir, "registry.yaml"), []byte(registryPolicy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	policies, err := LoadPolicyFiles(dir)
+	if err != nil {
+		t.Fatalf("LoadPolicyFiles: %v", err)
+	}
+
+	if policies.Registry == nil {
+		t.Fatal("registry policy should not be nil")
+	}
+	if policies.Registry.DefaultAction != "allow" {
+		t.Errorf("registry_policy.default_action = %q, want allow", policies.Registry.DefaultAction)
+	}
+	if !policies.Registry.LogAll {
+		t.Error("registry_policy.log_all should be true")
+	}
+	if len(policies.Registry.Rules) != 2 {
+		t.Errorf("registry_policy.rules len = %d, want 2", len(policies.Registry.Rules))
+	}
+
+	approveRule := policies.Registry.Rules[1]
+	if approveRule.TimeoutSeconds != 300 {
+		t.Errorf("approve rule timeout_seconds = %d, want 300", approveRule.TimeoutSeconds)
+	}
+}
+
+func TestLoadPolicyFiles_NoFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	policies, err := LoadPolicyFiles(dir)
+	if err != nil {
+		t.Fatalf("LoadPolicyFiles: %v", err)
+	}
+
+	// All policies should be nil when no files exist
+	if policies.Env != nil {
+		t.Error("env policy should be nil")
+	}
+	if policies.File != nil {
+		t.Error("file policy should be nil")
+	}
+	if policies.Network != nil {
+		t.Error("network policy should be nil")
+	}
+	if policies.DNS != nil {
+		t.Error("dns policy should be nil")
+	}
+	if policies.Registry != nil {
+		t.Error("registry policy should be nil")
+	}
+}
+
+func TestLoadMinimalPolicy(t *testing.T) {
+	dir := t.TempDir()
+
+	minimalPolicy := `
+env_protection:
+  enabled: true
+  mode: allowlist
+  allowlist: [PATH, HOME, USER]
+  blocklist: ["*_SECRET*"]
+
+file_policy:
+  default_action: deny
+  rules:
+    - name: workspace
+      paths: ["${WORKSPACE}/**"]
+      operations: [read, write, create]
+      action: allow
+
+network_policy:
+  default_action: deny
+  rules:
+    - name: https
+      ports: [443]
+      action: allow
+`
+	path := filepath.Join(dir, "minimal.yaml")
+	if err := os.WriteFile(path, []byte(minimalPolicy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	policies, err := LoadMinimalPolicy(path)
+	if err != nil {
+		t.Fatalf("LoadMinimalPolicy: %v", err)
+	}
+
+	if policies.Env == nil {
+		t.Fatal("env policy should not be nil")
+	}
+	if policies.File == nil {
+		t.Fatal("file policy should not be nil")
+	}
+	if policies.Network == nil {
+		t.Fatal("network policy should not be nil")
+	}
+}
+
+func TestValidatePolicyFiles_InvalidEnvMode(t *testing.T) {
+	policies := &PolicyFiles{
+		Env: &EnvProtectionPolicy{
+			Enabled: true,
+			Mode:    "invalid_mode",
+		},
+	}
+
+	err := ValidatePolicyFiles(policies)
+	if err == nil {
+		t.Error("expected error for invalid env mode")
+	}
+}
+
+func TestValidatePolicyFiles_InvalidFileAction(t *testing.T) {
+	policies := &PolicyFiles{
+		File: &FilePolicyConfig{
+			DefaultAction: "invalid_action",
+		},
+	}
+
+	err := ValidatePolicyFiles(policies)
+	if err == nil {
+		t.Error("expected error for invalid file default_action")
+	}
+}
+
+func TestValidatePolicyFiles_MissingRuleName(t *testing.T) {
+	policies := &PolicyFiles{
+		File: &FilePolicyConfig{
+			DefaultAction: "allow",
+			Rules: []FilePolicyRule{
+				{
+					// Name is missing
+					Action: "allow",
+				},
+			},
+		},
+	}
+
+	err := ValidatePolicyFiles(policies)
+	if err == nil {
+		t.Error("expected error for missing rule name")
+	}
+}
+
+func TestValidatePolicyFiles_ValidPolicies(t *testing.T) {
+	policies := &PolicyFiles{
+		Env: &EnvProtectionPolicy{
+			Enabled: true,
+			Mode:    "allowlist",
+		},
+		File: &FilePolicyConfig{
+			DefaultAction: "deny",
+			Rules: []FilePolicyRule{
+				{
+					Name:   "test",
+					Action: "allow",
+				},
+			},
+		},
+		Network: &NetworkPolicyConfig{
+			DefaultAction: "deny",
+			Rules: []NetworkPolicyRule{
+				{
+					Name:   "test",
+					Action: "allow",
+				},
+			},
+		},
+		Registry: &RegistryPolicyConfig{
+			DefaultAction: "allow",
+			Rules: []RegistryPolicyRule{
+				{
+					Name:   "test",
+					Action: "deny",
+				},
+			},
+		},
+	}
+
+	err := ValidatePolicyFiles(policies)
+	if err != nil {
+		t.Errorf("ValidatePolicyFiles: %v", err)
+	}
+}
+
+func TestLoadPolicyFiles_YmlExtension(t *testing.T) {
+	dir := t.TempDir()
+
+	// Use .yml extension instead of .yaml
+	envPolicy := `
+env_protection:
+  enabled: true
+  mode: blocklist
+`
+	if err := os.WriteFile(filepath.Join(dir, "env.yml"), []byte(envPolicy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	policies, err := LoadPolicyFiles(dir)
+	if err != nil {
+		t.Fatalf("LoadPolicyFiles: %v", err)
+	}
+
+	if policies.Env == nil {
+		t.Fatal("env policy should not be nil (loaded from .yml)")
+	}
+	if policies.Env.Mode != "blocklist" {
+		t.Errorf("env_protection.mode = %q, want blocklist", policies.Env.Mode)
+	}
+}


### PR DESCRIPTION
## Summary

Implements Unified Configuration (§15) from the multiplatform spec:

- **Platform detection and initialization**
  - `InitializePlatform()` creates platform from config with fallback support
  - `GetMountPoint()` returns platform-appropriate mount point
  - `GetDataDir()`, `GetConfigDir()`, `GetPoliciesDir()` for cross-platform paths

- **Extended sandbox configuration**
  - Add `Enabled`, `AllowDegraded` fields to SandboxConfig
  - Add `SandboxLimitsConfig` for resource limits (max_memory_mb, max_cpu_percent, etc.)
  - Add network interception config (proxy_port, dns_port, intercept_mode, tls_inspection)

- **Policy file loading**
  - Load separate policy files: env.yaml, files.yaml, network.yaml, dns.yaml, registry.yaml
  - Support both .yaml and .yml extensions
  - Validation for all policy types

- **Cross-platform policy types**
  - `EnvProtectionPolicy` with allowlist/blocklist modes
  - `FilePolicyConfig` with file rules and redirect support
  - `NetworkPolicyConfig` with domain/CIDR rules and redirect
  - `DNSPolicyConfig` with pattern matching and redirect to safe DNS
  - `RegistryPolicyConfig` for Windows registry access control

## Files Changed

- `internal/config/config.go` - Extended SandboxConfig and SandboxNetworkConfig
- `internal/config/platform.go` - Platform detection and initialization
- `internal/config/platform_test.go` - Platform tests
- `internal/config/policy_loader.go` - Policy file loading
- `internal/config/policy_loader_test.go` - Policy loader tests

## Test plan

- [x] All unit tests pass (`go test ./internal/config/...`)
- [x] Full test suite passes (`go test ./...`)
- [x] Build succeeds (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)