### PR TITLE
feat: add policy management API and webhook dispatcher

### DIFF
--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -136,6 +136,17 @@ func (a *App) Router() http.Handler {
 			r.Get("/approvals", a.listApprovals)
 			r.Post("/approvals/{id}", a.resolveApproval)
 		})
+
+		// Policy management (admin only)
+		r.Group(func(r chi.Router) {
+			r.Use(a.requireRoles("admin"))
+			r.Get("/policies", a.listPolicies)
+			r.Post("/policies", a.createPolicy)
+			r.Get("/policies/{policyId}", a.getPolicy)
+			r.Put("/policies/{policyId}", a.updatePolicy)
+			r.Delete("/policies/{policyId}", a.deletePolicy)
+			r.Post("/policies/validate", a.validatePolicy)
+		})
 	})
 
 	return r

--- a/internal/api/policies.go
+++ b/internal/api/policies.go
@@ -1,0 +1,377 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+)
+
+// PolicyInfo represents a named policy configuration.
+type PolicyInfo struct {
+	ID          string         `json:"id"`
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Type        string         `json:"type"` // "file", "network", "command", "env"
+	Rules       []PolicyRule   `json:"rules"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+}
+
+// PolicyRule represents a single policy rule.
+type PolicyRule struct {
+	Name           string   `json:"name"`
+	Patterns       []string `json:"patterns,omitempty"`
+	Paths          []string `json:"paths,omitempty"`
+	Operations     []string `json:"operations,omitempty"`
+	Commands       []string `json:"commands,omitempty"`
+	Domains        []string `json:"domains,omitempty"`
+	CIDRs          []string `json:"cidrs,omitempty"`
+	Ports          []int    `json:"ports,omitempty"`
+	Action         string   `json:"action"` // "allow", "deny", "approve", "redirect"
+	TimeoutSeconds int      `json:"timeout_seconds,omitempty"`
+	Message        string   `json:"message,omitempty"`
+}
+
+// PolicyValidationResult represents the result of policy validation.
+type PolicyValidationResult struct {
+	Valid   bool              `json:"valid"`
+	Errors  []ValidationError `json:"errors,omitempty"`
+	Warning []string          `json:"warnings,omitempty"`
+}
+
+// ValidationError represents a single validation error.
+type ValidationError struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+	Rule    string `json:"rule,omitempty"`
+}
+
+// CreatePolicyRequest represents a request to create a policy.
+type CreatePolicyRequest struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	Type        string         `json:"type"`
+	Rules       []PolicyRule   `json:"rules"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+}
+
+// UpdatePolicyRequest represents a request to update a policy.
+type UpdatePolicyRequest struct {
+	Name        string         `json:"name,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Rules       []PolicyRule   `json:"rules,omitempty"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+}
+
+// listPolicies returns all configured policies.
+func (a *App) listPolicies(w http.ResponseWriter, r *http.Request) {
+	// Get policies from the policy engine
+	// For now, return the current policy configuration
+	policies := a.getPoliciesFromEngine()
+	writeJSON(w, http.StatusOK, map[string]any{
+		"policies": policies,
+		"count":    len(policies),
+	})
+}
+
+// getPolicy returns a specific policy by ID.
+func (a *App) getPolicy(w http.ResponseWriter, r *http.Request) {
+	policyID := chi.URLParam(r, "policyId")
+	if policyID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "policy ID required"})
+		return
+	}
+
+	policy := a.findPolicyByID(policyID)
+	if policy == nil {
+		writeJSON(w, http.StatusNotFound, map[string]any{"error": "policy not found"})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, policy)
+}
+
+// createPolicy creates a new policy.
+func (a *App) createPolicy(w http.ResponseWriter, r *http.Request) {
+	var req CreatePolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid request body"})
+		return
+	}
+
+	// Validate request
+	if req.Name == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "name is required"})
+		return
+	}
+	if req.Type == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "type is required"})
+		return
+	}
+
+	// Validate the policy rules
+	result := validatePolicyRules(req.Type, req.Rules)
+	if !result.Valid {
+		writeJSON(w, http.StatusBadRequest, map[string]any{
+			"error":      "invalid policy rules",
+			"validation": result,
+		})
+		return
+	}
+
+	now := time.Now().UTC()
+	policy := PolicyInfo{
+		ID:          "policy-" + uuid.NewString()[:8],
+		Name:        req.Name,
+		Description: req.Description,
+		Type:        req.Type,
+		Rules:       req.Rules,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Metadata:    req.Metadata,
+	}
+
+	// Store the policy (in-memory for now, would be persisted in production)
+	a.storePolicyInfo(policy)
+
+	// Emit event
+	ev := types.Event{
+		ID:        uuid.NewString(),
+		Timestamp: now,
+		Type:      "policy_created",
+		Fields: map[string]any{
+			"policy_id":   policy.ID,
+			"policy_name": policy.Name,
+			"policy_type": policy.Type,
+		},
+	}
+	_ = a.store.AppendEvent(r.Context(), ev)
+	a.broker.Publish(ev)
+
+	writeJSON(w, http.StatusCreated, policy)
+}
+
+// updatePolicy updates an existing policy.
+func (a *App) updatePolicy(w http.ResponseWriter, r *http.Request) {
+	policyID := chi.URLParam(r, "policyId")
+	if policyID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "policy ID required"})
+		return
+	}
+
+	existing := a.findPolicyByID(policyID)
+	if existing == nil {
+		writeJSON(w, http.StatusNotFound, map[string]any{"error": "policy not found"})
+		return
+	}
+
+	var req UpdatePolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid request body"})
+		return
+	}
+
+	// Update fields if provided
+	if req.Name != "" {
+		existing.Name = req.Name
+	}
+	if req.Description != "" {
+		existing.Description = req.Description
+	}
+	if len(req.Rules) > 0 {
+		// Validate new rules
+		result := validatePolicyRules(existing.Type, req.Rules)
+		if !result.Valid {
+			writeJSON(w, http.StatusBadRequest, map[string]any{
+				"error":      "invalid policy rules",
+				"validation": result,
+			})
+			return
+		}
+		existing.Rules = req.Rules
+	}
+	if req.Metadata != nil {
+		existing.Metadata = req.Metadata
+	}
+	existing.UpdatedAt = time.Now().UTC()
+
+	// Store updated policy
+	a.storePolicyInfo(*existing)
+
+	// Emit event
+	ev := types.Event{
+		ID:        uuid.NewString(),
+		Timestamp: existing.UpdatedAt,
+		Type:      "policy_updated",
+		Fields: map[string]any{
+			"policy_id":   existing.ID,
+			"policy_name": existing.Name,
+		},
+	}
+	_ = a.store.AppendEvent(r.Context(), ev)
+	a.broker.Publish(ev)
+
+	writeJSON(w, http.StatusOK, existing)
+}
+
+// deletePolicy removes a policy.
+func (a *App) deletePolicy(w http.ResponseWriter, r *http.Request) {
+	policyID := chi.URLParam(r, "policyId")
+	if policyID == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "policy ID required"})
+		return
+	}
+
+	if !a.removePolicyByID(policyID) {
+		writeJSON(w, http.StatusNotFound, map[string]any{"error": "policy not found"})
+		return
+	}
+
+	// Emit event
+	ev := types.Event{
+		ID:        uuid.NewString(),
+		Timestamp: time.Now().UTC(),
+		Type:      "policy_deleted",
+		Fields: map[string]any{
+			"policy_id": policyID,
+		},
+	}
+	_ = a.store.AppendEvent(r.Context(), ev)
+	a.broker.Publish(ev)
+
+	writeJSON(w, http.StatusOK, map[string]any{"deleted": true})
+}
+
+// validatePolicy validates a policy without applying it.
+func (a *App) validatePolicy(w http.ResponseWriter, r *http.Request) {
+	var req CreatePolicyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]any{"error": "invalid request body"})
+		return
+	}
+
+	result := validatePolicyRules(req.Type, req.Rules)
+	writeJSON(w, http.StatusOK, result)
+}
+
+// validatePolicyRules validates policy rules and returns validation result.
+func validatePolicyRules(policyType string, rules []PolicyRule) PolicyValidationResult {
+	result := PolicyValidationResult{Valid: true}
+
+	validActions := map[string]bool{
+		"allow": true, "deny": true, "approve": true, "redirect": true,
+	}
+	validTypes := map[string]bool{
+		"file": true, "network": true, "command": true, "env": true, "dns": true,
+	}
+
+	if !validTypes[policyType] {
+		result.Valid = false
+		result.Errors = append(result.Errors, ValidationError{
+			Field:   "type",
+			Message: "invalid policy type, must be one of: file, network, command, env, dns",
+		})
+	}
+
+	for i, rule := range rules {
+		if rule.Name == "" {
+			result.Valid = false
+			result.Errors = append(result.Errors, ValidationError{
+				Field:   "rules",
+				Message: "rule name is required",
+				Rule:    "",
+			})
+		}
+
+		if !validActions[rule.Action] {
+			result.Valid = false
+			result.Errors = append(result.Errors, ValidationError{
+				Field:   "rules",
+				Message: "invalid action, must be one of: allow, deny, approve, redirect",
+				Rule:    rule.Name,
+			})
+		}
+
+		// Type-specific validation
+		switch policyType {
+		case "file":
+			if len(rule.Paths) == 0 && len(rule.Patterns) == 0 {
+				result.Warning = append(result.Warning,
+					"rule "+rule.Name+" has no paths or patterns, will match nothing")
+			}
+		case "network":
+			if len(rule.Domains) == 0 && len(rule.CIDRs) == 0 && len(rule.Ports) == 0 {
+				result.Warning = append(result.Warning,
+					"rule "+rule.Name+" has no domains, CIDRs, or ports, will match nothing")
+			}
+		case "command":
+			if len(rule.Commands) == 0 && len(rule.Patterns) == 0 {
+				result.Warning = append(result.Warning,
+					"rule "+rule.Name+" has no commands or patterns, will match nothing")
+			}
+		}
+
+		// Timeout validation for approve action
+		if rule.Action == "approve" && rule.TimeoutSeconds <= 0 {
+			result.Warning = append(result.Warning,
+				"rule "+rule.Name+" with approve action has no timeout, will use default")
+		}
+
+		_ = i // silence unused variable warning
+	}
+
+	return result
+}
+
+// In-memory policy storage (would be replaced with persistent storage)
+var (
+	policyStore   = make(map[string]PolicyInfo)
+	policyStoreMu = make(chan struct{}, 1)
+)
+
+func init() {
+	policyStoreMu <- struct{}{}
+}
+
+func (a *App) getPoliciesFromEngine() []PolicyInfo {
+	<-policyStoreMu
+	defer func() { policyStoreMu <- struct{}{} }()
+
+	policies := make([]PolicyInfo, 0, len(policyStore))
+	for _, p := range policyStore {
+		policies = append(policies, p)
+	}
+	return policies
+}
+
+func (a *App) findPolicyByID(id string) *PolicyInfo {
+	<-policyStoreMu
+	defer func() { policyStoreMu <- struct{}{} }()
+
+	if p, ok := policyStore[id]; ok {
+		return &p
+	}
+	return nil
+}
+
+func (a *App) storePolicyInfo(p PolicyInfo) {
+	<-policyStoreMu
+	defer func() { policyStoreMu <- struct{}{} }()
+	policyStore[p.ID] = p
+}
+
+func (a *App) removePolicyByID(id string) bool {
+	<-policyStoreMu
+	defer func() { policyStoreMu <- struct{}{} }()
+
+	if _, ok := policyStore[id]; ok {
+		delete(policyStore, id)
+		return true
+	}
+	return false
+}

--- a/internal/api/policies_test.go
+++ b/internal/api/policies_test.go
@@ -1,0 +1,482 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/events"
+	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/store/composite"
+	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/go-chi/chi/v5"
+)
+
+// mockEventStore is a minimal event store for testing
+type mockEventStore struct{}
+
+func (mockEventStore) AppendEvent(ctx context.Context, ev types.Event) error { return nil }
+func (mockEventStore) QueryEvents(ctx context.Context, q types.EventQuery) ([]types.Event, error) {
+	return nil, nil
+}
+func (mockEventStore) Close() error { return nil }
+
+func newTestAppForPolicies(t *testing.T) *App {
+	cfg := &config.Config{}
+	mgr := session.NewManager(5)
+	store := composite.New(mockEventStore{}, nil)
+	broker := events.NewBroker()
+	return NewApp(cfg, mgr, store, nil, broker, nil, nil, nil)
+}
+
+func TestValidatePolicyRules(t *testing.T) {
+	tests := []struct {
+		name       string
+		policyType string
+		rules      []PolicyRule
+		wantValid  bool
+		wantErrs   int
+	}{
+		{
+			name:       "valid file policy",
+			policyType: "file",
+			rules: []PolicyRule{
+				{Name: "allow-workspace", Paths: []string{"/workspace/**"}, Action: "allow"},
+			},
+			wantValid: true,
+			wantErrs:  0,
+		},
+		{
+			name:       "valid network policy",
+			policyType: "network",
+			rules: []PolicyRule{
+				{Name: "allow-https", Ports: []int{443}, Action: "allow"},
+				{Name: "deny-http", Ports: []int{80}, Action: "deny"},
+			},
+			wantValid: true,
+			wantErrs:  0,
+		},
+		{
+			name:       "valid command policy",
+			policyType: "command",
+			rules: []PolicyRule{
+				{Name: "allow-git", Commands: []string{"git"}, Action: "allow"},
+			},
+			wantValid: true,
+			wantErrs:  0,
+		},
+		{
+			name:       "invalid policy type",
+			policyType: "invalid",
+			rules: []PolicyRule{
+				{Name: "test", Action: "allow"},
+			},
+			wantValid: false,
+			wantErrs:  1,
+		},
+		{
+			name:       "missing rule name",
+			policyType: "file",
+			rules: []PolicyRule{
+				{Paths: []string{"/tmp"}, Action: "allow"},
+			},
+			wantValid: false,
+			wantErrs:  1,
+		},
+		{
+			name:       "invalid action",
+			policyType: "file",
+			rules: []PolicyRule{
+				{Name: "test", Paths: []string{"/tmp"}, Action: "invalid"},
+			},
+			wantValid: false,
+			wantErrs:  1,
+		},
+		{
+			name:       "approve action without timeout warning",
+			policyType: "file",
+			rules: []PolicyRule{
+				{Name: "approve-sensitive", Paths: []string{"/etc/**"}, Action: "approve"},
+			},
+			wantValid: true,
+			wantErrs:  0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validatePolicyRules(tt.policyType, tt.rules)
+			if result.Valid != tt.wantValid {
+				t.Errorf("Valid = %v, want %v", result.Valid, tt.wantValid)
+			}
+			if len(result.Errors) != tt.wantErrs {
+				t.Errorf("len(Errors) = %d, want %d: %+v", len(result.Errors), tt.wantErrs, result.Errors)
+			}
+		})
+	}
+}
+
+func TestValidatePolicyRules_Warnings(t *testing.T) {
+	tests := []struct {
+		name         string
+		policyType   string
+		rules        []PolicyRule
+		wantWarnings int
+	}{
+		{
+			name:       "file policy without paths",
+			policyType: "file",
+			rules: []PolicyRule{
+				{Name: "empty", Action: "allow"},
+			},
+			wantWarnings: 1,
+		},
+		{
+			name:       "network policy without domains or ports",
+			policyType: "network",
+			rules: []PolicyRule{
+				{Name: "empty", Action: "allow"},
+			},
+			wantWarnings: 1,
+		},
+		{
+			name:       "command policy without commands",
+			policyType: "command",
+			rules: []PolicyRule{
+				{Name: "empty", Action: "allow"},
+			},
+			wantWarnings: 1,
+		},
+		{
+			name:       "approve without timeout",
+			policyType: "file",
+			rules: []PolicyRule{
+				{Name: "approve-test", Paths: []string{"/tmp"}, Action: "approve"},
+			},
+			wantWarnings: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validatePolicyRules(tt.policyType, tt.rules)
+			if len(result.Warning) != tt.wantWarnings {
+				t.Errorf("len(Warnings) = %d, want %d: %v", len(result.Warning), tt.wantWarnings, result.Warning)
+			}
+		})
+	}
+}
+
+func TestPolicyStore_CRUD(t *testing.T) {
+	// Reset store for test isolation
+	<-policyStoreMu
+	policyStore = make(map[string]PolicyInfo)
+	policyStoreMu <- struct{}{}
+
+	app := newTestAppForPolicies(t)
+
+	// Create policy
+	policy := PolicyInfo{
+		ID:   "policy-test1",
+		Name: "Test Policy",
+		Type: "file",
+		Rules: []PolicyRule{
+			{Name: "allow-all", Paths: []string{"/**"}, Action: "allow"},
+		},
+	}
+	app.storePolicyInfo(policy)
+
+	// Get policy
+	got := app.findPolicyByID("policy-test1")
+	if got == nil {
+		t.Fatal("findPolicyByID returned nil")
+	}
+	if got.Name != policy.Name {
+		t.Errorf("Name = %s, want %s", got.Name, policy.Name)
+	}
+
+	// List policies
+	list := app.getPoliciesFromEngine()
+	if len(list) != 1 {
+		t.Errorf("len(list) = %d, want 1", len(list))
+	}
+
+	// Update policy
+	policy.Name = "Updated Policy"
+	app.storePolicyInfo(policy)
+	got = app.findPolicyByID("policy-test1")
+	if got.Name != "Updated Policy" {
+		t.Errorf("Name after update = %s, want Updated Policy", got.Name)
+	}
+
+	// Delete policy
+	if !app.removePolicyByID("policy-test1") {
+		t.Error("removePolicyByID returned false")
+	}
+	if app.findPolicyByID("policy-test1") != nil {
+		t.Error("policy should be nil after delete")
+	}
+
+	// Delete non-existent
+	if app.removePolicyByID("policy-nonexistent") {
+		t.Error("removePolicyByID should return false for non-existent")
+	}
+}
+
+func TestPolicyAPI_CreatePolicy(t *testing.T) {
+	// Reset store
+	<-policyStoreMu
+	policyStore = make(map[string]PolicyInfo)
+	policyStoreMu <- struct{}{}
+
+	app := newTestAppForPolicies(t)
+	r := chi.NewRouter()
+	r.Post("/policies", app.createPolicy)
+
+	tests := []struct {
+		name       string
+		body       CreatePolicyRequest
+		wantStatus int
+	}{
+		{
+			name: "valid policy",
+			body: CreatePolicyRequest{
+				Name: "Test Policy",
+				Type: "file",
+				Rules: []PolicyRule{
+					{Name: "allow-tmp", Paths: []string{"/tmp/**"}, Action: "allow"},
+				},
+			},
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name: "missing name",
+			body: CreatePolicyRequest{
+				Type: "file",
+				Rules: []PolicyRule{
+					{Name: "rule1", Paths: []string{"/tmp"}, Action: "allow"},
+				},
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "missing type",
+			body: CreatePolicyRequest{
+				Name: "Test",
+				Rules: []PolicyRule{
+					{Name: "rule1", Paths: []string{"/tmp"}, Action: "allow"},
+				},
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name: "invalid rules",
+			body: CreatePolicyRequest{
+				Name: "Test",
+				Type: "file",
+				Rules: []PolicyRule{
+					{Paths: []string{"/tmp"}, Action: "allow"}, // missing name
+				},
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, _ := json.Marshal(tt.body)
+			req := httptest.NewRequest(http.MethodPost, "/policies", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d: %s", w.Code, tt.wantStatus, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestPolicyAPI_GetPolicy(t *testing.T) {
+	// Reset store
+	<-policyStoreMu
+	policyStore = make(map[string]PolicyInfo)
+	policyStoreMu <- struct{}{}
+
+	app := newTestAppForPolicies(t)
+	app.storePolicyInfo(PolicyInfo{
+		ID:   "policy-123",
+		Name: "Test Policy",
+		Type: "file",
+	})
+
+	r := chi.NewRouter()
+	r.Get("/policies/{policyId}", app.getPolicy)
+
+	tests := []struct {
+		name       string
+		policyID   string
+		wantStatus int
+	}{
+		{
+			name:       "existing policy",
+			policyID:   "policy-123",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "non-existent policy",
+			policyID:   "policy-999",
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/policies/"+tt.policyID, nil)
+			w := httptest.NewRecorder()
+
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}
+
+func TestPolicyAPI_UpdatePolicy(t *testing.T) {
+	// Reset store
+	<-policyStoreMu
+	policyStore = make(map[string]PolicyInfo)
+	policyStoreMu <- struct{}{}
+
+	app := newTestAppForPolicies(t)
+	app.storePolicyInfo(PolicyInfo{
+		ID:   "policy-123",
+		Name: "Original Name",
+		Type: "file",
+		Rules: []PolicyRule{
+			{Name: "rule1", Paths: []string{"/tmp"}, Action: "allow"},
+		},
+	})
+
+	r := chi.NewRouter()
+	r.Put("/policies/{policyId}", app.updatePolicy)
+
+	// Update name
+	body, _ := json.Marshal(UpdatePolicyRequest{Name: "Updated Name"})
+	req := httptest.NewRequest(http.MethodPut, "/policies/policy-123", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	// Verify update
+	got := app.findPolicyByID("policy-123")
+	if got.Name != "Updated Name" {
+		t.Errorf("Name = %s, want Updated Name", got.Name)
+	}
+}
+
+func TestPolicyAPI_DeletePolicy(t *testing.T) {
+	// Reset store
+	<-policyStoreMu
+	policyStore = make(map[string]PolicyInfo)
+	policyStoreMu <- struct{}{}
+
+	app := newTestAppForPolicies(t)
+	app.storePolicyInfo(PolicyInfo{
+		ID:   "policy-123",
+		Name: "Test Policy",
+		Type: "file",
+	})
+
+	r := chi.NewRouter()
+	r.Delete("/policies/{policyId}", app.deletePolicy)
+
+	// Delete existing
+	req := httptest.NewRequest(http.MethodDelete, "/policies/policy-123", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	// Delete again should fail
+	req = httptest.NewRequest(http.MethodDelete, "/policies/policy-123", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("second delete status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestPolicyAPI_ValidatePolicy(t *testing.T) {
+	app := newTestAppForPolicies(t)
+	r := chi.NewRouter()
+	r.Post("/policies/validate", app.validatePolicy)
+
+	tests := []struct {
+		name      string
+		body      CreatePolicyRequest
+		wantValid bool
+	}{
+		{
+			name: "valid policy",
+			body: CreatePolicyRequest{
+				Name: "Test",
+				Type: "file",
+				Rules: []PolicyRule{
+					{Name: "rule1", Paths: []string{"/tmp"}, Action: "allow"},
+				},
+			},
+			wantValid: true,
+		},
+		{
+			name: "invalid policy",
+			body: CreatePolicyRequest{
+				Name: "Test",
+				Type: "invalid",
+				Rules: []PolicyRule{
+					{Name: "rule1", Action: "allow"},
+				},
+			},
+			wantValid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, _ := json.Marshal(tt.body)
+			req := httptest.NewRequest(http.MethodPost, "/policies/validate", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			w := httptest.NewRecorder()
+
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+			}
+
+			var result PolicyValidationResult
+			if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+
+			if result.Valid != tt.wantValid {
+				t.Errorf("Valid = %v, want %v", result.Valid, tt.wantValid)
+			}
+		})
+	}
+}

--- a/internal/webhook/dispatcher.go
+++ b/internal/webhook/dispatcher.go
@@ -1,0 +1,370 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"text/template"
+	"time"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// Dispatcher manages multiple webhook configurations and dispatches events to them.
+type Dispatcher struct {
+	mu       sync.RWMutex
+	webhooks map[string]*WebhookConfig
+	client   *http.Client
+}
+
+// WebhookConfig defines a webhook endpoint and its configuration.
+type WebhookConfig struct {
+	// Name is a unique identifier for this webhook.
+	Name string `yaml:"name" json:"name"`
+
+	// URL is the webhook endpoint URL.
+	URL string `yaml:"url" json:"url"`
+
+	// Method is the HTTP method (default: POST).
+	Method string `yaml:"method" json:"method"`
+
+	// Headers are additional HTTP headers to include.
+	Headers map[string]string `yaml:"headers" json:"headers"`
+
+	// Template is a Go template for the request body.
+	// If empty, events are sent as JSON.
+	Template string `yaml:"template" json:"template"`
+
+	// Events is a list of event types to send to this webhook.
+	// Use "*" to match all events.
+	Events []string `yaml:"events" json:"events"`
+
+	// BatchSize is the number of events to batch before sending.
+	BatchSize int `yaml:"batch_size" json:"batch_size"`
+
+	// FlushInterval is how often to flush the batch.
+	FlushInterval time.Duration `yaml:"flush_interval" json:"flush_interval"`
+
+	// Timeout is the HTTP request timeout.
+	Timeout time.Duration `yaml:"timeout" json:"timeout"`
+
+	// Enabled indicates if this webhook is active.
+	Enabled bool `yaml:"enabled" json:"enabled"`
+
+	// RetryCount is the number of retries on failure.
+	RetryCount int `yaml:"retry_count" json:"retry_count"`
+
+	// RetryDelay is the delay between retries.
+	RetryDelay time.Duration `yaml:"retry_delay" json:"retry_delay"`
+
+	// compiled template
+	tmpl *template.Template
+
+	// event matching set
+	eventSet map[string]bool
+
+	// batching state
+	mu        sync.Mutex
+	buf       []types.Event
+	lastFlush time.Time
+}
+
+// NewDispatcher creates a new webhook dispatcher.
+func NewDispatcher() *Dispatcher {
+	return &Dispatcher{
+		webhooks: make(map[string]*WebhookConfig),
+		client:   &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// Register adds a webhook configuration.
+func (d *Dispatcher) Register(cfg WebhookConfig) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Set defaults
+	if cfg.Method == "" {
+		cfg.Method = http.MethodPost
+	}
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = 1 // No batching by default
+	}
+	if cfg.FlushInterval <= 0 {
+		cfg.FlushInterval = 5 * time.Second
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 10 * time.Second
+	}
+
+	// Compile template if provided
+	if cfg.Template != "" {
+		tmpl, err := template.New(cfg.Name).Parse(cfg.Template)
+		if err != nil {
+			return fmt.Errorf("invalid template: %w", err)
+		}
+		cfg.tmpl = tmpl
+	}
+
+	// Build event set for matching
+	cfg.eventSet = make(map[string]bool)
+	for _, e := range cfg.Events {
+		cfg.eventSet[e] = true
+	}
+
+	cfg.lastFlush = time.Now().UTC()
+	d.webhooks[cfg.Name] = &cfg
+	return nil
+}
+
+// Unregister removes a webhook configuration.
+func (d *Dispatcher) Unregister(name string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	delete(d.webhooks, name)
+}
+
+// Dispatch sends an event to all matching webhooks.
+func (d *Dispatcher) Dispatch(ctx context.Context, event types.Event) {
+	d.mu.RLock()
+	webhooks := make([]*WebhookConfig, 0, len(d.webhooks))
+	for _, wh := range d.webhooks {
+		if wh.Enabled && wh.matchesEvent(event.Type) {
+			webhooks = append(webhooks, wh)
+		}
+	}
+	d.mu.RUnlock()
+
+	for _, wh := range webhooks {
+		wh.addEvent(ctx, event, d.client)
+	}
+}
+
+// DispatchBatch sends multiple events to all matching webhooks.
+func (d *Dispatcher) DispatchBatch(ctx context.Context, events []types.Event) {
+	for _, ev := range events {
+		d.Dispatch(ctx, ev)
+	}
+}
+
+// Flush forces all webhooks to flush their buffers.
+func (d *Dispatcher) Flush(ctx context.Context) {
+	d.mu.RLock()
+	webhooks := make([]*WebhookConfig, 0, len(d.webhooks))
+	for _, wh := range d.webhooks {
+		webhooks = append(webhooks, wh)
+	}
+	d.mu.RUnlock()
+
+	for _, wh := range webhooks {
+		wh.flush(ctx, d.client)
+	}
+}
+
+// matchesEvent checks if an event type matches this webhook's filter.
+func (c *WebhookConfig) matchesEvent(eventType string) bool {
+	if len(c.eventSet) == 0 || c.eventSet["*"] {
+		return true
+	}
+	if c.eventSet[eventType] {
+		return true
+	}
+	// Check for wildcard patterns like "file_*"
+	for pattern := range c.eventSet {
+		if strings.HasSuffix(pattern, "*") {
+			prefix := strings.TrimSuffix(pattern, "*")
+			if strings.HasPrefix(eventType, prefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// addEvent adds an event to the buffer and flushes if needed.
+func (c *WebhookConfig) addEvent(ctx context.Context, event types.Event, client *http.Client) {
+	c.mu.Lock()
+	c.buf = append(c.buf, event)
+	shouldFlush := len(c.buf) >= c.BatchSize ||
+		(c.FlushInterval > 0 && time.Since(c.lastFlush) >= c.FlushInterval)
+	var toSend []types.Event
+	if shouldFlush {
+		toSend = c.buf
+		c.buf = nil
+		c.lastFlush = time.Now().UTC()
+	}
+	c.mu.Unlock()
+
+	if len(toSend) > 0 {
+		go c.send(ctx, toSend, client)
+	}
+}
+
+// flush forces a flush of the buffer.
+func (c *WebhookConfig) flush(ctx context.Context, client *http.Client) {
+	c.mu.Lock()
+	toSend := c.buf
+	c.buf = nil
+	c.lastFlush = time.Now().UTC()
+	c.mu.Unlock()
+
+	if len(toSend) > 0 {
+		c.send(ctx, toSend, client)
+	}
+}
+
+// send sends events to the webhook endpoint.
+func (c *WebhookConfig) send(ctx context.Context, events []types.Event, client *http.Client) {
+	var body []byte
+	var err error
+
+	if c.tmpl != nil {
+		// Use template to render body
+		data := map[string]any{
+			"Events": events,
+			"Event":  events[0], // For single-event templates
+			"Count":  len(events),
+		}
+		var buf bytes.Buffer
+		if err := c.tmpl.Execute(&buf, data); err != nil {
+			// Log error but continue
+			return
+		}
+		body = buf.Bytes()
+	} else {
+		// Send as JSON
+		if len(events) == 1 && c.BatchSize <= 1 {
+			body, err = json.Marshal(events[0])
+		} else {
+			body, err = json.Marshal(events)
+		}
+		if err != nil {
+			return
+		}
+	}
+
+	// Send with retries
+	for attempt := 0; attempt <= c.RetryCount; attempt++ {
+		if attempt > 0 {
+			time.Sleep(c.RetryDelay)
+		}
+
+		reqCtx, cancel := context.WithTimeout(ctx, c.Timeout)
+		req, err := http.NewRequestWithContext(reqCtx, c.Method, c.URL, bytes.NewReader(body))
+		if err != nil {
+			cancel()
+			continue
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+		for k, v := range c.Headers {
+			req.Header.Set(k, v)
+		}
+
+		resp, err := client.Do(req)
+		cancel()
+		if err != nil {
+			continue
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return // Success
+		}
+	}
+}
+
+// List returns all registered webhook names.
+func (d *Dispatcher) List() []string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	names := make([]string, 0, len(d.webhooks))
+	for name := range d.webhooks {
+		names = append(names, name)
+	}
+	return names
+}
+
+// Get returns a webhook configuration by name.
+func (d *Dispatcher) Get(name string) *WebhookConfig {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.webhooks[name]
+}
+
+// SlackWebhook creates a webhook config for Slack.
+func SlackWebhook(name, url string, events []string) WebhookConfig {
+	return WebhookConfig{
+		Name:    name,
+		URL:     url,
+		Method:  http.MethodPost,
+		Headers: map[string]string{"Content-Type": "application/json"},
+		Template: `{
+  "text": "{{.Event.Type}} in session {{.Event.SessionID}}",
+  "blocks": [
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "*{{.Event.Type}}*\nSession: {{.Event.SessionID}}"
+      }
+    }
+  ]
+}`,
+		Events:    events,
+		BatchSize: 1,
+		Timeout:   5 * time.Second,
+		Enabled:   true,
+	}
+}
+
+// PagerDutyWebhook creates a webhook config for PagerDuty.
+func PagerDutyWebhook(name, url, routingKey string, events []string) WebhookConfig {
+	return WebhookConfig{
+		Name:   name,
+		URL:    url,
+		Method: http.MethodPost,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Template: `{
+  "routing_key": "` + routingKey + `",
+  "event_action": "trigger",
+  "payload": {
+    "summary": "{{.Event.Type}}: {{.Event.Path}}",
+    "source": "agentsh",
+    "severity": "warning",
+    "custom_details": {
+      "session_id": "{{.Event.SessionID}}",
+      "command_id": "{{.Event.CommandID}}",
+      "timestamp": "{{.Event.Timestamp}}"
+    }
+  }
+}`,
+		Events:     events,
+		BatchSize:  1,
+		Timeout:    5 * time.Second,
+		RetryCount: 2,
+		RetryDelay: time.Second,
+		Enabled:    true,
+	}
+}
+
+// GenericWebhook creates a simple JSON webhook config.
+func GenericWebhook(name, url string, events []string) WebhookConfig {
+	return WebhookConfig{
+		Name:          name,
+		URL:           url,
+		Method:        http.MethodPost,
+		Headers:       map[string]string{"Content-Type": "application/json"},
+		Events:        events,
+		BatchSize:     100,
+		FlushInterval: 5 * time.Second,
+		Timeout:       10 * time.Second,
+		Enabled:       true,
+	}
+}

--- a/internal/webhook/dispatcher_test.go
+++ b/internal/webhook/dispatcher_test.go
@@ -1,0 +1,590 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+func TestNewDispatcher(t *testing.T) {
+	d := NewDispatcher()
+	if d == nil {
+		t.Fatal("NewDispatcher returned nil")
+	}
+	if d.webhooks == nil {
+		t.Error("webhooks map is nil")
+	}
+	if d.client == nil {
+		t.Error("client is nil")
+	}
+}
+
+func TestDispatcher_Register(t *testing.T) {
+	d := NewDispatcher()
+
+	cfg := WebhookConfig{
+		Name:    "test",
+		URL:     "http://example.com/webhook",
+		Events:  []string{"file_read", "file_write"},
+		Enabled: true,
+	}
+
+	if err := d.Register(cfg); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	// Verify defaults were applied
+	got := d.Get("test")
+	if got == nil {
+		t.Fatal("Get returned nil")
+	}
+	if got.Method != http.MethodPost {
+		t.Errorf("Method = %s, want POST", got.Method)
+	}
+	if got.BatchSize != 1 {
+		t.Errorf("BatchSize = %d, want 1", got.BatchSize)
+	}
+	if got.FlushInterval != 5*time.Second {
+		t.Errorf("FlushInterval = %v, want 5s", got.FlushInterval)
+	}
+	if got.Timeout != 10*time.Second {
+		t.Errorf("Timeout = %v, want 10s", got.Timeout)
+	}
+
+	// Verify event set
+	if !got.eventSet["file_read"] {
+		t.Error("eventSet missing file_read")
+	}
+	if !got.eventSet["file_write"] {
+		t.Error("eventSet missing file_write")
+	}
+}
+
+func TestDispatcher_Register_Template(t *testing.T) {
+	d := NewDispatcher()
+
+	cfg := WebhookConfig{
+		Name:     "test",
+		URL:      "http://example.com/webhook",
+		Template: `{"event": "{{.Event.Type}}"}`,
+		Enabled:  true,
+	}
+
+	if err := d.Register(cfg); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	got := d.Get("test")
+	if got.tmpl == nil {
+		t.Error("template not compiled")
+	}
+}
+
+func TestDispatcher_Register_InvalidTemplate(t *testing.T) {
+	d := NewDispatcher()
+
+	cfg := WebhookConfig{
+		Name:     "test",
+		URL:      "http://example.com/webhook",
+		Template: `{{.Invalid`,
+		Enabled:  true,
+	}
+
+	err := d.Register(cfg)
+	if err == nil {
+		t.Error("expected error for invalid template")
+	}
+}
+
+func TestDispatcher_Unregister(t *testing.T) {
+	d := NewDispatcher()
+
+	cfg := WebhookConfig{
+		Name:    "test",
+		URL:     "http://example.com/webhook",
+		Enabled: true,
+	}
+	d.Register(cfg)
+
+	d.Unregister("test")
+
+	if d.Get("test") != nil {
+		t.Error("webhook should be nil after unregister")
+	}
+}
+
+func TestDispatcher_List(t *testing.T) {
+	d := NewDispatcher()
+
+	d.Register(WebhookConfig{Name: "wh1", URL: "http://example.com/1", Enabled: true})
+	d.Register(WebhookConfig{Name: "wh2", URL: "http://example.com/2", Enabled: true})
+
+	list := d.List()
+	if len(list) != 2 {
+		t.Errorf("len(List) = %d, want 2", len(list))
+	}
+}
+
+func TestWebhookConfig_MatchesEvent(t *testing.T) {
+	tests := []struct {
+		name      string
+		events    []string
+		eventType string
+		want      bool
+	}{
+		{
+			name:      "empty events matches all",
+			events:    []string{},
+			eventType: "file_read",
+			want:      true,
+		},
+		{
+			name:      "wildcard matches all",
+			events:    []string{"*"},
+			eventType: "file_read",
+			want:      true,
+		},
+		{
+			name:      "exact match",
+			events:    []string{"file_read", "file_write"},
+			eventType: "file_read",
+			want:      true,
+		},
+		{
+			name:      "no match",
+			events:    []string{"file_read", "file_write"},
+			eventType: "net_connect",
+			want:      false,
+		},
+		{
+			name:      "prefix wildcard match",
+			events:    []string{"file_*"},
+			eventType: "file_read",
+			want:      true,
+		},
+		{
+			name:      "prefix wildcard no match",
+			events:    []string{"file_*"},
+			eventType: "net_connect",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &WebhookConfig{
+				eventSet: make(map[string]bool),
+			}
+			for _, e := range tt.events {
+				cfg.eventSet[e] = true
+			}
+
+			if got := cfg.matchesEvent(tt.eventType); got != tt.want {
+				t.Errorf("matchesEvent(%s) = %v, want %v", tt.eventType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDispatcher_Dispatch(t *testing.T) {
+	var received []types.Event
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var ev types.Event
+		if err := json.Unmarshal(body, &ev); err != nil {
+			t.Errorf("unmarshal event: %v", err)
+		}
+		mu.Lock()
+		received = append(received, ev)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	d := NewDispatcher()
+	d.Register(WebhookConfig{
+		Name:      "test",
+		URL:       server.URL,
+		Events:    []string{"file_read"},
+		BatchSize: 1,
+		Enabled:   true,
+	})
+
+	ctx := context.Background()
+	ev := types.Event{
+		ID:        "ev1",
+		Type:      "file_read",
+		SessionID: "sess1",
+		Path:      "/tmp/test.txt",
+	}
+
+	d.Dispatch(ctx, ev)
+
+	// Wait for async send
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 1 {
+		t.Errorf("received %d events, want 1", len(received))
+	}
+	if len(received) > 0 && received[0].ID != "ev1" {
+		t.Errorf("event ID = %s, want ev1", received[0].ID)
+	}
+}
+
+func TestDispatcher_Dispatch_FilteredOut(t *testing.T) {
+	var callCount int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	d := NewDispatcher()
+	d.Register(WebhookConfig{
+		Name:      "test",
+		URL:       server.URL,
+		Events:    []string{"file_read"},
+		BatchSize: 1,
+		Enabled:   true,
+	})
+
+	ctx := context.Background()
+	ev := types.Event{
+		Type: "net_connect", // Not in events list
+	}
+
+	d.Dispatch(ctx, ev)
+	time.Sleep(100 * time.Millisecond)
+
+	if atomic.LoadInt32(&callCount) != 0 {
+		t.Error("webhook should not be called for filtered event")
+	}
+}
+
+func TestDispatcher_Dispatch_Disabled(t *testing.T) {
+	var callCount int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	d := NewDispatcher()
+	d.Register(WebhookConfig{
+		Name:      "test",
+		URL:       server.URL,
+		Events:    []string{"*"},
+		BatchSize: 1,
+		Enabled:   false, // Disabled
+	})
+
+	ctx := context.Background()
+	ev := types.Event{Type: "file_read"}
+
+	d.Dispatch(ctx, ev)
+	time.Sleep(100 * time.Millisecond)
+
+	if atomic.LoadInt32(&callCount) != 0 {
+		t.Error("disabled webhook should not be called")
+	}
+}
+
+func TestDispatcher_Dispatch_Template(t *testing.T) {
+	var receivedBody string
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		receivedBody = string(body)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	d := NewDispatcher()
+	d.Register(WebhookConfig{
+		Name:      "test",
+		URL:       server.URL,
+		Template:  `{"type": "{{.Event.Type}}", "session": "{{.Event.SessionID}}"}`,
+		BatchSize: 1,
+		Enabled:   true,
+	})
+
+	ctx := context.Background()
+	ev := types.Event{
+		Type:      "file_read",
+		SessionID: "sess-123",
+	}
+
+	d.Dispatch(ctx, ev)
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	var parsed map[string]string
+	if err := json.Unmarshal([]byte(receivedBody), &parsed); err != nil {
+		t.Fatalf("parse response: %v (body: %s)", err, receivedBody)
+	}
+
+	if parsed["type"] != "file_read" {
+		t.Errorf("type = %s, want file_read", parsed["type"])
+	}
+	if parsed["session"] != "sess-123" {
+		t.Errorf("session = %s, want sess-123", parsed["session"])
+	}
+}
+
+func TestDispatcher_Batching(t *testing.T) {
+	var receivedBatches [][]types.Event
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var events []types.Event
+		if err := json.Unmarshal(body, &events); err != nil {
+			t.Errorf("unmarshal events: %v", err)
+		}
+		mu.Lock()
+		receivedBatches = append(receivedBatches, events)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	d := NewDispatcher()
+	d.Register(WebhookConfig{
+		Name:          "test",
+		URL:           server.URL,
+		BatchSize:     3,
+		FlushInterval: 5 * time.Second, // Long interval, won't trigger
+		Enabled:       true,
+	})
+
+	ctx := context.Background()
+
+	// Send 3 events to trigger batch
+	for i := 0; i < 3; i++ {
+		d.Dispatch(ctx, types.Event{
+			ID:   "ev" + string(rune('0'+i)),
+			Type: "file_read",
+		})
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(receivedBatches) != 1 {
+		t.Errorf("received %d batches, want 1", len(receivedBatches))
+	}
+	if len(receivedBatches) > 0 && len(receivedBatches[0]) != 3 {
+		t.Errorf("batch size = %d, want 3", len(receivedBatches[0]))
+	}
+}
+
+func TestDispatcher_Flush(t *testing.T) {
+	var received []types.Event
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var ev types.Event
+		json.Unmarshal(body, &ev)
+		mu.Lock()
+		received = append(received, ev)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	d := NewDispatcher()
+	d.Register(WebhookConfig{
+		Name:          "test",
+		URL:           server.URL,
+		BatchSize:     10, // Large batch, won't trigger automatically
+		FlushInterval: time.Hour,
+		Enabled:       true,
+	})
+
+	ctx := context.Background()
+	d.Dispatch(ctx, types.Event{ID: "ev1", Type: "file_read"})
+
+	// Force flush
+	d.Flush(ctx)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 1 {
+		t.Errorf("received %d events, want 1", len(received))
+	}
+}
+
+func TestDispatcher_Retry(t *testing.T) {
+	var attempts int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	d := NewDispatcher()
+	d.Register(WebhookConfig{
+		Name:       "test",
+		URL:        server.URL,
+		BatchSize:  1,
+		RetryCount: 3,
+		RetryDelay: 10 * time.Millisecond,
+		Enabled:    true,
+	})
+
+	ctx := context.Background()
+	d.Dispatch(ctx, types.Event{Type: "file_read"})
+
+	time.Sleep(200 * time.Millisecond)
+
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("attempts = %d, want 3", got)
+	}
+}
+
+func TestDispatcher_Headers(t *testing.T) {
+	var receivedHeaders http.Header
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	d := NewDispatcher()
+	d.Register(WebhookConfig{
+		Name: "test",
+		URL:  server.URL,
+		Headers: map[string]string{
+			"X-Custom-Header": "custom-value",
+			"Authorization":   "Bearer token123",
+		},
+		BatchSize: 1,
+		Enabled:   true,
+	})
+
+	ctx := context.Background()
+	d.Dispatch(ctx, types.Event{Type: "file_read"})
+
+	time.Sleep(100 * time.Millisecond)
+
+	if receivedHeaders.Get("X-Custom-Header") != "custom-value" {
+		t.Errorf("X-Custom-Header = %s, want custom-value", receivedHeaders.Get("X-Custom-Header"))
+	}
+	if receivedHeaders.Get("Authorization") != "Bearer token123" {
+		t.Errorf("Authorization header not set correctly")
+	}
+	if receivedHeaders.Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type = %s, want application/json", receivedHeaders.Get("Content-Type"))
+	}
+}
+
+func TestSlackWebhook(t *testing.T) {
+	cfg := SlackWebhook("slack-alerts", "https://hooks.slack.com/test", []string{"*"})
+
+	if cfg.Name != "slack-alerts" {
+		t.Errorf("Name = %s, want slack-alerts", cfg.Name)
+	}
+	if cfg.Template == "" {
+		t.Error("Template should not be empty")
+	}
+	if cfg.BatchSize != 1 {
+		t.Errorf("BatchSize = %d, want 1", cfg.BatchSize)
+	}
+	if !cfg.Enabled {
+		t.Error("should be enabled by default")
+	}
+}
+
+func TestPagerDutyWebhook(t *testing.T) {
+	cfg := PagerDutyWebhook("pd-alerts", "https://events.pagerduty.com/v2/enqueue", "routing-key-123", []string{"blocked_*"})
+
+	if cfg.Name != "pd-alerts" {
+		t.Errorf("Name = %s, want pd-alerts", cfg.Name)
+	}
+	if cfg.Template == "" {
+		t.Error("Template should not be empty")
+	}
+	if cfg.RetryCount != 2 {
+		t.Errorf("RetryCount = %d, want 2", cfg.RetryCount)
+	}
+}
+
+func TestGenericWebhook(t *testing.T) {
+	cfg := GenericWebhook("generic", "http://example.com/events", []string{"file_*"})
+
+	if cfg.Name != "generic" {
+		t.Errorf("Name = %s, want generic", cfg.Name)
+	}
+	if cfg.BatchSize != 100 {
+		t.Errorf("BatchSize = %d, want 100", cfg.BatchSize)
+	}
+	if cfg.FlushInterval != 5*time.Second {
+		t.Errorf("FlushInterval = %v, want 5s", cfg.FlushInterval)
+	}
+}
+
+func TestDispatchBatch(t *testing.T) {
+	var received []types.Event
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var ev types.Event
+		json.Unmarshal(body, &ev)
+		mu.Lock()
+		received = append(received, ev)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	d := NewDispatcher()
+	d.Register(WebhookConfig{
+		Name:      "test",
+		URL:       server.URL,
+		BatchSize: 1,
+		Enabled:   true,
+	})
+
+	ctx := context.Background()
+	events := []types.Event{
+		{ID: "ev1", Type: "file_read"},
+		{ID: "ev2", Type: "file_write"},
+	}
+
+	d.DispatchBatch(ctx, events)
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(received) != 2 {
+		t.Errorf("received %d events, want 2", len(received))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds REST API endpoints for policy management under `/api/v1/policies` (admin-only)
  - `GET /policies` - list all policies
  - `GET /policies/{id}` - get a specific policy
  - `POST /policies` - create a new policy
  - `PUT /policies/{id}` - update an existing policy
  - `DELETE /policies/{id}` - delete a policy
  - `POST /policies/validate` - validate policy rules without saving
- Adds webhook dispatcher (`internal/webhook/dispatcher.go`) with:
  - Go template support for custom message formatting
  - Event filtering by type with wildcard support
  - Batching with configurable batch size and flush interval
  - Retry logic with configurable attempts and delay
  - Custom HTTP headers
  - Pre-built configurations for Slack, PagerDuty, and generic webhooks
- Policy validation with type-specific rules for file, network, command, env, and dns policies

## Test plan

- [x] Unit tests for policy validation (`TestValidatePolicyRules`, `TestValidatePolicyRules_Warnings`)
- [x] Unit tests for policy CRUD operations (`TestPolicyStore_CRUD`, `TestPolicyAPI_*`)
- [x] Unit tests for webhook dispatcher (`TestDispatcher_*`, `TestWebhookConfig_*`)
- [x] Full test suite passes (`go test ./...`)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)