### PR TITLE
feat: add comprehensive observability package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cilium/ebpf v0.20.0
 	github.com/creack/pty v1.1.18
 	github.com/docker/docker v28.5.1+incompatible
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-chi/chi/v5 v5.2.3
 	github.com/gobwas/glob v0.2.3
 	github.com/google/uuid v1.6.0
@@ -17,6 +18,8 @@ require (
 	github.com/seccomp/libseccomp-golang v0.10.0
 	github.com/spf13/cobra v1.10.1
 	github.com/testcontainers/testcontainers-go v0.40.0
+	go.opentelemetry.io/otel v1.39.0
+	go.opentelemetry.io/otel/trace v1.39.0
 	golang.org/x/sys v0.39.0
 	golang.org/x/term v0.38.0
 	google.golang.org/grpc v1.77.0
@@ -43,7 +46,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
@@ -77,11 +79,9 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
-	go.opentelemetry.io/otel v1.39.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.39.0 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	golang.org/x/crypto v0.43.0 // indirect
 	golang.org/x/mod v0.29.0 // indirect

--- a/pkg/observability/logging.go
+++ b/pkg/observability/logging.go
@@ -1,0 +1,297 @@
+package observability
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+// LogLevel represents the severity level of a log entry.
+type LogLevel string
+
+const (
+	LogDebug LogLevel = "debug"
+	LogInfo  LogLevel = "info"
+	LogWarn  LogLevel = "warn"
+	LogError LogLevel = "error"
+)
+
+// AuditLogger provides structured logging with session/agent context.
+type AuditLogger struct {
+	output    io.Writer
+	mu        sync.Mutex
+	sessionID string
+	agentID   string
+	tenantID  string
+	minLevel  LogLevel
+}
+
+// AuditLoggerConfig configures the audit logger.
+type AuditLoggerConfig struct {
+	Output    io.Writer
+	SessionID string
+	AgentID   string
+	TenantID  string
+	MinLevel  LogLevel
+}
+
+// NewAuditLogger creates a new structured audit logger.
+func NewAuditLogger(cfg AuditLoggerConfig) *AuditLogger {
+	output := cfg.Output
+	if output == nil {
+		output = os.Stdout
+	}
+	minLevel := cfg.MinLevel
+	if minLevel == "" {
+		minLevel = LogInfo
+	}
+	return &AuditLogger{
+		output:    output,
+		sessionID: cfg.SessionID,
+		agentID:   cfg.AgentID,
+		tenantID:  cfg.TenantID,
+		minLevel:  minLevel,
+	}
+}
+
+// LogEntry represents a structured log entry.
+type LogEntry struct {
+	Level     string            `json:"level"`
+	Timestamp string            `json:"ts"`
+	Message   string            `json:"msg"`
+	SessionID string            `json:"session_id,omitempty"`
+	AgentID   string            `json:"agent_id,omitempty"`
+	TenantID  string            `json:"tenant_id,omitempty"`
+	TraceID   string            `json:"trace_id,omitempty"`
+	SpanID    string            `json:"span_id,omitempty"`
+	Fields    map[string]any    `json:"-"`
+}
+
+// MarshalJSON implements custom JSON marshaling to flatten Fields.
+func (e LogEntry) MarshalJSON() ([]byte, error) {
+	// Create a map with all standard fields
+	m := make(map[string]any)
+	m["level"] = e.Level
+	m["ts"] = e.Timestamp
+	m["msg"] = e.Message
+
+	if e.SessionID != "" {
+		m["session_id"] = e.SessionID
+	}
+	if e.AgentID != "" {
+		m["agent_id"] = e.AgentID
+	}
+	if e.TenantID != "" {
+		m["tenant_id"] = e.TenantID
+	}
+	if e.TraceID != "" {
+		m["trace_id"] = e.TraceID
+	}
+	if e.SpanID != "" {
+		m["span_id"] = e.SpanID
+	}
+
+	// Merge in custom fields
+	for k, v := range e.Fields {
+		m[k] = v
+	}
+
+	return json.Marshal(m)
+}
+
+// WithSession returns a new logger with session context.
+func (l *AuditLogger) WithSession(sessionID string) *AuditLogger {
+	return &AuditLogger{
+		output:    l.output,
+		sessionID: sessionID,
+		agentID:   l.agentID,
+		tenantID:  l.tenantID,
+		minLevel:  l.minLevel,
+	}
+}
+
+// WithAgent returns a new logger with agent context.
+func (l *AuditLogger) WithAgent(agentID string) *AuditLogger {
+	return &AuditLogger{
+		output:    l.output,
+		sessionID: l.sessionID,
+		agentID:   agentID,
+		tenantID:  l.tenantID,
+		minLevel:  l.minLevel,
+	}
+}
+
+// WithTenant returns a new logger with tenant context.
+func (l *AuditLogger) WithTenant(tenantID string) *AuditLogger {
+	return &AuditLogger{
+		output:    l.output,
+		sessionID: l.sessionID,
+		agentID:   l.agentID,
+		tenantID:  tenantID,
+		minLevel:  l.minLevel,
+	}
+}
+
+func (l *AuditLogger) shouldLog(level LogLevel) bool {
+	levels := map[LogLevel]int{
+		LogDebug: 0,
+		LogInfo:  1,
+		LogWarn:  2,
+		LogError: 3,
+	}
+	return levels[level] >= levels[l.minLevel]
+}
+
+func (l *AuditLogger) log(ctx context.Context, level LogLevel, msg string, fields map[string]any) {
+	if !l.shouldLog(level) {
+		return
+	}
+
+	entry := LogEntry{
+		Level:     string(level),
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		Message:   msg,
+		SessionID: l.sessionID,
+		AgentID:   l.agentID,
+		TenantID:  l.tenantID,
+		TraceID:   ExtractTraceID(ctx),
+		SpanID:    ExtractSpanID(ctx),
+		Fields:    fields,
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.output.Write(data)
+	l.output.Write([]byte("\n"))
+}
+
+// Debug logs a debug-level message.
+func (l *AuditLogger) Debug(ctx context.Context, msg string, fields map[string]any) {
+	l.log(ctx, LogDebug, msg, fields)
+}
+
+// Info logs an info-level message.
+func (l *AuditLogger) Info(ctx context.Context, msg string, fields map[string]any) {
+	l.log(ctx, LogInfo, msg, fields)
+}
+
+// Warn logs a warning-level message.
+func (l *AuditLogger) Warn(ctx context.Context, msg string, fields map[string]any) {
+	l.log(ctx, LogWarn, msg, fields)
+}
+
+// Error logs an error-level message.
+func (l *AuditLogger) Error(ctx context.Context, msg string, fields map[string]any) {
+	l.log(ctx, LogError, msg, fields)
+}
+
+// LogOperation logs an intercepted operation with decision.
+func (l *AuditLogger) LogOperation(ctx context.Context, op *InterceptedOperation, decision string, latency time.Duration) {
+	fields := map[string]any{
+		"type":       string(op.Type),
+		"decision":   decision,
+		"latency_us": latency.Microseconds(),
+	}
+
+	if op.Path != "" {
+		fields["path"] = op.Path
+	}
+	if op.Target != "" {
+		fields["target"] = op.Target
+	}
+	for k, v := range op.Extra {
+		fields[k] = v
+	}
+
+	l.Info(ctx, "operation", fields)
+}
+
+// LogApproval logs an approval event.
+func (l *AuditLogger) LogApproval(ctx context.Context, opType OperationType, path string, approver string, approved bool, latency time.Duration) {
+	fields := map[string]any{
+		"type":       string(opType),
+		"path":       path,
+		"approver":   approver,
+		"approved":   approved,
+		"latency_ms": latency.Milliseconds(),
+	}
+
+	l.Info(ctx, "approval", fields)
+}
+
+// LogSessionStart logs session start.
+func (l *AuditLogger) LogSessionStart(ctx context.Context, workspacePath string, policySet string) {
+	fields := map[string]any{
+		"workspace":  workspacePath,
+		"policy_set": policySet,
+	}
+
+	l.Info(ctx, "session_start", fields)
+}
+
+// LogSessionEnd logs session end.
+func (l *AuditLogger) LogSessionEnd(ctx context.Context, exitCode int, duration time.Duration, state string) {
+	fields := map[string]any{
+		"exit_code":   exitCode,
+		"duration_s":  duration.Seconds(),
+		"final_state": state,
+	}
+
+	l.Info(ctx, "session_end", fields)
+}
+
+// LogPolicyDeny logs a policy denial.
+func (l *AuditLogger) LogPolicyDeny(ctx context.Context, op *InterceptedOperation, ruleName string, reason string) {
+	fields := map[string]any{
+		"type":      string(op.Type),
+		"rule_name": ruleName,
+		"reason":    reason,
+	}
+
+	if op.Path != "" {
+		fields["path"] = op.Path
+	}
+	if op.Target != "" {
+		fields["target"] = op.Target
+	}
+
+	l.Warn(ctx, "policy_deny", fields)
+}
+
+// LogWebhook logs a webhook dispatch.
+func (l *AuditLogger) LogWebhook(ctx context.Context, url string, statusCode int, latency time.Duration, err error) {
+	fields := map[string]any{
+		"url":        url,
+		"latency_ms": latency.Milliseconds(),
+	}
+
+	if statusCode > 0 {
+		fields["status_code"] = statusCode
+	}
+
+	if err != nil {
+		fields["error"] = err.Error()
+		l.Error(ctx, "webhook_error", fields)
+	} else {
+		l.Debug(ctx, "webhook_dispatch", fields)
+	}
+}
+
+// LogSecurityEvent logs a security-relevant event (for SIEM ingestion).
+func (l *AuditLogger) LogSecurityEvent(ctx context.Context, eventType string, severity string, fields map[string]any) {
+	if fields == nil {
+		fields = make(map[string]any)
+	}
+	fields["event_type"] = eventType
+	fields["severity"] = severity
+
+	l.Info(ctx, "security_event", fields)
+}

--- a/pkg/observability/logging_test.go
+++ b/pkg/observability/logging_test.go
@@ -1,0 +1,428 @@
+package observability
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewAuditLogger(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewAuditLogger(AuditLoggerConfig{
+		Output:    buf,
+		SessionID: "sess-123",
+		AgentID:   "agent-456",
+		TenantID:  "tenant-789",
+	})
+
+	if logger == nil {
+		t.Fatal("NewAuditLogger returned nil")
+	}
+
+	if logger.sessionID != "sess-123" {
+		t.Errorf("sessionID = %q, want sess-123", logger.sessionID)
+	}
+	if logger.agentID != "agent-456" {
+		t.Errorf("agentID = %q, want agent-456", logger.agentID)
+	}
+	if logger.tenantID != "tenant-789" {
+		t.Errorf("tenantID = %q, want tenant-789", logger.tenantID)
+	}
+}
+
+func TestAuditLogger_DefaultOutput(t *testing.T) {
+	logger := NewAuditLogger(AuditLoggerConfig{})
+	if logger.output == nil {
+		t.Error("output should default to stdout")
+	}
+}
+
+func TestAuditLogger_WithSession(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewAuditLogger(AuditLoggerConfig{Output: buf})
+
+	newLogger := logger.WithSession("new-session")
+	if newLogger.sessionID != "new-session" {
+		t.Errorf("sessionID = %q, want new-session", newLogger.sessionID)
+	}
+	if newLogger.output != buf {
+		t.Error("output should be preserved")
+	}
+}
+
+func TestAuditLogger_WithAgent(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewAuditLogger(AuditLoggerConfig{Output: buf, SessionID: "sess-123"})
+
+	newLogger := logger.WithAgent("new-agent")
+	if newLogger.agentID != "new-agent" {
+		t.Errorf("agentID = %q, want new-agent", newLogger.agentID)
+	}
+	if newLogger.sessionID != "sess-123" {
+		t.Error("sessionID should be preserved")
+	}
+}
+
+func TestAuditLogger_WithTenant(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewAuditLogger(AuditLoggerConfig{Output: buf})
+
+	newLogger := logger.WithTenant("new-tenant")
+	if newLogger.tenantID != "new-tenant" {
+		t.Errorf("tenantID = %q, want new-tenant", newLogger.tenantID)
+	}
+}
+
+func TestAuditLogger_LogLevels(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewAuditLogger(AuditLoggerConfig{
+		Output:   buf,
+		MinLevel: LogInfo,
+	})
+
+	ctx := context.Background()
+
+	// Debug should be filtered out
+	logger.Debug(ctx, "debug message", nil)
+	if buf.Len() > 0 {
+		t.Error("debug message should be filtered when minLevel is info")
+	}
+
+	// Info should pass
+	buf.Reset()
+	logger.Info(ctx, "info message", nil)
+	if buf.Len() == 0 {
+		t.Error("info message should be logged")
+	}
+
+	// Warn should pass
+	buf.Reset()
+	logger.Warn(ctx, "warn message", nil)
+	if buf.Len() == 0 {
+		t.Error("warn message should be logged")
+	}
+
+	// Error should pass
+	buf.Reset()
+	logger.Error(ctx, "error message", nil)
+	if buf.Len() == 0 {
+		t.Error("error message should be logged")
+	}
+}
+
+func TestAuditLogger_LogFormat(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewAuditLogger(AuditLoggerConfig{
+		Output:    buf,
+		SessionID: "sess-123",
+		AgentID:   "agent-456",
+		TenantID:  "tenant-789",
+	})
+
+	ctx := context.Background()
+	logger.Info(ctx, "test message", map[string]any{
+		"custom_field": "custom_value",
+		"count":        42,
+	})
+
+	// Parse the JSON output
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log output: %v", err)
+	}
+
+	// Check required fields
+	if entry["level"] != "info" {
+		t.Errorf("level = %v, want info", entry["level"])
+	}
+	if entry["msg"] != "test message" {
+		t.Errorf("msg = %v, want 'test message'", entry["msg"])
+	}
+	if entry["session_id"] != "sess-123" {
+		t.Errorf("session_id = %v, want sess-123", entry["session_id"])
+	}
+	if entry["agent_id"] != "agent-456" {
+		t.Errorf("agent_id = %v, want agent-456", entry["agent_id"])
+	}
+	if entry["tenant_id"] != "tenant-789" {
+		t.Errorf("tenant_id = %v, want tenant-789", entry["tenant_id"])
+	}
+
+	// Check custom fields
+	if entry["custom_field"] != "custom_value" {
+		t.Errorf("custom_field = %v, want custom_value", entry["custom_field"])
+	}
+	if entry["count"] != float64(42) { // JSON numbers are float64
+		t.Errorf("count = %v, want 42", entry["count"])
+	}
+
+	// Check timestamp format (RFC3339Nano)
+	ts, ok := entry["ts"].(string)
+	if !ok {
+		t.Error("ts should be a string")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, ts); err != nil {
+		t.Errorf("ts should be RFC3339Nano format: %v", err)
+	}
+}
+
+func TestAuditLogger_LogOperation(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewAuditLogger(AuditLoggerConfig{
+		Output:    buf,
+		SessionID: "sess-123",
+	})
+
+	ctx := context.Background()
+	op := &InterceptedOperation{
+		Type:      OpFileRead,
+		SessionID: "sess-123",
+		AgentID:   "agent-456",
+		Path:      "/etc/passwd",
+	}
+
+	logger.LogOperation(ctx, op, "deny", 150*time.Microsecond)
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log output: %v", err)
+	}
+
+	if entry["msg"] != "operation" {
+		t.Errorf("msg = %v, want operation", entry["msg"])
+	}
+	if entry["type"] != "file_read" {
+		t.Errorf("type = %v, want file_read", entry["type"])
+	}
+	if entry["decision"] != "deny" {
+		t.Errorf("decision = %v, want deny", entry["decision"])
+	}
+	if entry["path"] != "/etc/passwd" {
+		t.Errorf("path = %v, want /etc/passwd", entry["path"])
+	}
+	if entry["latency_us"] != float64(150) {
+		t.Errorf("latency_us = %v, want 150", entry["latency_us"])
+	}
+}
+
+func TestAuditLogger_LogApproval(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewAuditLogger(AuditLoggerConfig{Output: buf})
+
+	ctx := context.Background()
+	logger.LogApproval(ctx, OpFileDelete, "/workspace/file.txt", "user@example.com", true, 5*time.Second)
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log output: %v", err)
+	}
+
+	if entry["msg"] != "approval" {
+		t.Errorf("msg = %v, want approval", entry["msg"])
+	}
+	if entry["approver"] != "user@example.com" {
+		t.Errorf("approver = %v, want user@example.com", entry["approver"])
+	}
+	if entry["approved"] != true {
+		t.Errorf("approved = %v, want true", entry["approved"])
+	}
+}
+
+func TestAuditLogger_LogSessionStart(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewAuditLogger(AuditLoggerConfig{Output: buf})
+
+	ctx := context.Background()
+	logger.LogSessionStart(ctx, "/workspace", "default")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log output: %v", err)
+	}
+
+	if entry["msg"] != "session_start" {
+		t.Errorf("msg = %v, want session_start", entry["msg"])
+	}
+	if entry["workspace"] != "/workspace" {
+		t.Errorf("workspace = %v, want /workspace", entry["workspace"])
+	}
+	if entry["policy_set"] != "default" {
+		t.Errorf("policy_set = %v, want default", entry["policy_set"])
+	}
+}
+
+func TestAuditLogger_LogSessionEnd(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewAuditLogger(AuditLoggerConfig{Output: buf})
+
+	ctx := context.Background()
+	logger.LogSessionEnd(ctx, 0, 5*time.Minute, "completed")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log output: %v", err)
+	}
+
+	if entry["msg"] != "session_end" {
+		t.Errorf("msg = %v, want session_end", entry["msg"])
+	}
+	if entry["exit_code"] != float64(0) {
+		t.Errorf("exit_code = %v, want 0", entry["exit_code"])
+	}
+	if entry["final_state"] != "completed" {
+		t.Errorf("final_state = %v, want completed", entry["final_state"])
+	}
+}
+
+func TestAuditLogger_LogPolicyDeny(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewAuditLogger(AuditLoggerConfig{Output: buf})
+
+	ctx := context.Background()
+	op := &InterceptedOperation{
+		Type: OpFileRead,
+		Path: "/etc/shadow",
+	}
+	logger.LogPolicyDeny(ctx, op, "deny-shadow", "Access to shadow file denied")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log output: %v", err)
+	}
+
+	if entry["level"] != "warn" {
+		t.Errorf("level = %v, want warn", entry["level"])
+	}
+	if entry["msg"] != "policy_deny" {
+		t.Errorf("msg = %v, want policy_deny", entry["msg"])
+	}
+	if entry["rule_name"] != "deny-shadow" {
+		t.Errorf("rule_name = %v, want deny-shadow", entry["rule_name"])
+	}
+}
+
+func TestAuditLogger_LogWebhook(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewAuditLogger(AuditLoggerConfig{
+		Output:   buf,
+		MinLevel: LogDebug,
+	})
+
+	ctx := context.Background()
+
+	// Success case
+	logger.LogWebhook(ctx, "https://hooks.example.com", 200, 100*time.Millisecond, nil)
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log output: %v", err)
+	}
+
+	if entry["level"] != "debug" {
+		t.Errorf("level = %v, want debug", entry["level"])
+	}
+	if entry["msg"] != "webhook_dispatch" {
+		t.Errorf("msg = %v, want webhook_dispatch", entry["msg"])
+	}
+
+	// Error case
+	buf.Reset()
+	logger.LogWebhook(ctx, "https://hooks.example.com", 0, 100*time.Millisecond, context.DeadlineExceeded)
+
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log output: %v", err)
+	}
+
+	if entry["level"] != "error" {
+		t.Errorf("level = %v, want error", entry["level"])
+	}
+	if entry["msg"] != "webhook_error" {
+		t.Errorf("msg = %v, want webhook_error", entry["msg"])
+	}
+}
+
+func TestAuditLogger_LogSecurityEvent(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewAuditLogger(AuditLoggerConfig{Output: buf})
+
+	ctx := context.Background()
+	logger.LogSecurityEvent(ctx, "registry_modification", "critical", map[string]any{
+		"path":      `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Run`,
+		"technique": "T1547.001",
+	})
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("failed to parse log output: %v", err)
+	}
+
+	if entry["event_type"] != "registry_modification" {
+		t.Errorf("event_type = %v, want registry_modification", entry["event_type"])
+	}
+	if entry["severity"] != "critical" {
+		t.Errorf("severity = %v, want critical", entry["severity"])
+	}
+	if entry["technique"] != "T1547.001" {
+		t.Errorf("technique = %v, want T1547.001", entry["technique"])
+	}
+}
+
+func TestAuditLogger_JSONNewlineDelimited(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewAuditLogger(AuditLoggerConfig{Output: buf})
+
+	ctx := context.Background()
+	logger.Info(ctx, "message 1", nil)
+	logger.Info(ctx, "message 2", nil)
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Errorf("expected 2 lines, got %d", len(lines))
+	}
+
+	// Each line should be valid JSON
+	for i, line := range lines {
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Errorf("line %d is not valid JSON: %v", i+1, err)
+		}
+	}
+}
+
+func TestLogEntry_MarshalJSON(t *testing.T) {
+	entry := LogEntry{
+		Level:     "info",
+		Timestamp: "2025-01-15T14:30:00Z",
+		Message:   "test",
+		SessionID: "sess-123",
+		Fields: map[string]any{
+			"custom": "value",
+		},
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("MarshalJSON error: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to parse marshaled JSON: %v", err)
+	}
+
+	// Standard fields should be present
+	if parsed["level"] != "info" {
+		t.Errorf("level = %v, want info", parsed["level"])
+	}
+	if parsed["session_id"] != "sess-123" {
+		t.Errorf("session_id = %v, want sess-123", parsed["session_id"])
+	}
+
+	// Custom fields should be flattened
+	if parsed["custom"] != "value" {
+		t.Errorf("custom = %v, want value", parsed["custom"])
+	}
+}

--- a/pkg/observability/prometheus.go
+++ b/pkg/observability/prometheus.go
@@ -1,0 +1,514 @@
+// Package observability provides Prometheus metrics, OpenTelemetry tracing,
+// and structured logging for agentsh.
+package observability
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// PrometheusCollector provides Prometheus-compatible metrics.
+type PrometheusCollector struct {
+	startedAt time.Time
+
+	// Session metrics
+	sessionsActive  atomic.Int64
+	sessionsCreated sync.Map // key: "state:tenant_id" -> *atomic.Uint64
+	sessionDurations []sessionDuration
+	sessionDurMu     sync.Mutex
+
+	// Operation metrics
+	operationsTotal   sync.Map // key: "type:decision" -> *atomic.Uint64
+	operationLatencies []operationLatency
+	operationLatMu     sync.Mutex
+
+	// Approval metrics
+	approvalsPending   atomic.Int64
+	approvalLatencies []time.Duration
+	approvalLatMu     sync.Mutex
+
+	// Policy metrics
+	policyEvalLatencies []time.Duration
+	policyEvalMu        sync.Mutex
+
+	// Legacy event metrics (for compatibility)
+	eventsTotal atomic.Uint64
+	byType      sync.Map // string -> *atomic.Uint64
+
+	// eBPF metrics
+	ebpfDropped     atomic.Uint64
+	ebpfAttachFail  atomic.Uint64
+	ebpfUnavailable atomic.Uint64
+}
+
+type sessionDuration struct {
+	tenantID  string
+	exitState string
+	duration  time.Duration
+}
+
+type operationLatency struct {
+	opType  string
+	latency time.Duration
+}
+
+// NewPrometheusCollector creates a new Prometheus metrics collector.
+func NewPrometheusCollector() *PrometheusCollector {
+	return &PrometheusCollector{
+		startedAt: time.Now().UTC(),
+	}
+}
+
+// Session metrics
+
+// IncSessionActive increments the active session count.
+func (c *PrometheusCollector) IncSessionActive() {
+	if c == nil {
+		return
+	}
+	c.sessionsActive.Add(1)
+}
+
+// DecSessionActive decrements the active session count.
+func (c *PrometheusCollector) DecSessionActive() {
+	if c == nil {
+		return
+	}
+	c.sessionsActive.Add(-1)
+}
+
+// IncSessionCreated increments the session created counter by state and tenant.
+func (c *PrometheusCollector) IncSessionCreated(state, tenantID string) {
+	if c == nil {
+		return
+	}
+	key := state + ":" + tenantID
+	ptr, _ := c.sessionsCreated.LoadOrStore(key, &atomic.Uint64{})
+	ptr.(*atomic.Uint64).Add(1)
+}
+
+// RecordSessionDuration records a session duration for histogram.
+func (c *PrometheusCollector) RecordSessionDuration(tenantID, exitState string, duration time.Duration) {
+	if c == nil {
+		return
+	}
+	c.sessionDurMu.Lock()
+	defer c.sessionDurMu.Unlock()
+	c.sessionDurations = append(c.sessionDurations, sessionDuration{
+		tenantID:  tenantID,
+		exitState: exitState,
+		duration:  duration,
+	})
+}
+
+// Operation metrics
+
+// IncOperation increments the operation counter by type and decision.
+func (c *PrometheusCollector) IncOperation(opType, decision string) {
+	if c == nil {
+		return
+	}
+	key := opType + ":" + decision
+	ptr, _ := c.operationsTotal.LoadOrStore(key, &atomic.Uint64{})
+	ptr.(*atomic.Uint64).Add(1)
+}
+
+// RecordOperationLatency records an operation latency for histogram.
+func (c *PrometheusCollector) RecordOperationLatency(opType string, latency time.Duration) {
+	if c == nil {
+		return
+	}
+	c.operationLatMu.Lock()
+	defer c.operationLatMu.Unlock()
+	c.operationLatencies = append(c.operationLatencies, operationLatency{
+		opType:  opType,
+		latency: latency,
+	})
+}
+
+// Approval metrics
+
+// IncApprovalPending increments pending approvals.
+func (c *PrometheusCollector) IncApprovalPending() {
+	if c == nil {
+		return
+	}
+	c.approvalsPending.Add(1)
+}
+
+// DecApprovalPending decrements pending approvals.
+func (c *PrometheusCollector) DecApprovalPending() {
+	if c == nil {
+		return
+	}
+	c.approvalsPending.Add(-1)
+}
+
+// RecordApprovalLatency records approval latency for histogram.
+func (c *PrometheusCollector) RecordApprovalLatency(latency time.Duration) {
+	if c == nil {
+		return
+	}
+	c.approvalLatMu.Lock()
+	defer c.approvalLatMu.Unlock()
+	c.approvalLatencies = append(c.approvalLatencies, latency)
+}
+
+// Policy metrics
+
+// RecordPolicyEvalLatency records policy evaluation latency.
+func (c *PrometheusCollector) RecordPolicyEvalLatency(latency time.Duration) {
+	if c == nil {
+		return
+	}
+	c.policyEvalMu.Lock()
+	defer c.policyEvalMu.Unlock()
+	c.policyEvalLatencies = append(c.policyEvalLatencies, latency)
+}
+
+// Legacy event metrics
+
+// IncEvent increments event counter by type.
+func (c *PrometheusCollector) IncEvent(eventType string) {
+	if c == nil {
+		return
+	}
+	c.eventsTotal.Add(1)
+	if eventType == "" {
+		eventType = "unknown"
+	}
+	ptr, _ := c.byType.LoadOrStore(eventType, &atomic.Uint64{})
+	ptr.(*atomic.Uint64).Add(1)
+}
+
+// eBPF metrics
+
+// IncEBPFDropped increments dropped eBPF events counter.
+func (c *PrometheusCollector) IncEBPFDropped() {
+	if c == nil {
+		return
+	}
+	c.ebpfDropped.Add(1)
+}
+
+// IncEBPFAttachFail increments eBPF attach failure counter.
+func (c *PrometheusCollector) IncEBPFAttachFail() {
+	if c == nil {
+		return
+	}
+	c.ebpfAttachFail.Add(1)
+}
+
+// IncEBPFUnavailable increments eBPF unavailable counter.
+func (c *PrometheusCollector) IncEBPFUnavailable() {
+	if c == nil {
+		return
+	}
+	c.ebpfUnavailable.Add(1)
+}
+
+// HandlerOptions configures the metrics HTTP handler.
+type HandlerOptions struct {
+	SessionCount func() int
+}
+
+// Handler returns an HTTP handler for Prometheus metrics.
+func (c *PrometheusCollector) Handler(opts HandlerOptions) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+
+		// Server up
+		fmt.Fprint(w, "# HELP agentsh_up Whether the agentsh server is running.\n")
+		fmt.Fprint(w, "# TYPE agentsh_up gauge\n")
+		fmt.Fprint(w, "agentsh_up 1\n\n")
+
+		// Session metrics
+		fmt.Fprint(w, "# HELP agentsh_sessions_active Number of currently active sessions.\n")
+		fmt.Fprint(w, "# TYPE agentsh_sessions_active gauge\n")
+		fmt.Fprintf(w, "agentsh_sessions_active %d\n\n", c.sessionsActive.Load())
+
+		c.writeSessionsTotal(w)
+		c.writeSessionDurations(w)
+
+		// Operation metrics
+		c.writeOperationsTotal(w)
+		c.writeOperationLatencies(w)
+
+		// Approval metrics
+		fmt.Fprint(w, "# HELP agentsh_approvals_pending Number of pending approvals.\n")
+		fmt.Fprint(w, "# TYPE agentsh_approvals_pending gauge\n")
+		fmt.Fprintf(w, "agentsh_approvals_pending %d\n\n", c.approvalsPending.Load())
+
+		c.writeApprovalLatencies(w)
+
+		// Policy metrics
+		c.writePolicyEvalLatencies(w)
+
+		// Legacy event metrics
+		fmt.Fprint(w, "# HELP agentsh_events_total Total number of events appended.\n")
+		fmt.Fprint(w, "# TYPE agentsh_events_total counter\n")
+		fmt.Fprintf(w, "agentsh_events_total %d\n\n", c.eventsTotal.Load())
+
+		c.writeEventsByType(w)
+
+		// eBPF metrics
+		fmt.Fprint(w, "# HELP agentsh_net_ebpf_dropped_events_total eBPF connect events dropped due to backpressure.\n")
+		fmt.Fprint(w, "# TYPE agentsh_net_ebpf_dropped_events_total counter\n")
+		fmt.Fprintf(w, "agentsh_net_ebpf_dropped_events_total %d\n\n", c.ebpfDropped.Load())
+
+		fmt.Fprint(w, "# HELP agentsh_net_ebpf_attach_fail_total eBPF attach failures.\n")
+		fmt.Fprint(w, "# TYPE agentsh_net_ebpf_attach_fail_total counter\n")
+		fmt.Fprintf(w, "agentsh_net_ebpf_attach_fail_total %d\n\n", c.ebpfAttachFail.Load())
+
+		fmt.Fprint(w, "# HELP agentsh_net_ebpf_unavailable_total Times eBPF was unavailable on host.\n")
+		fmt.Fprint(w, "# TYPE agentsh_net_ebpf_unavailable_total counter\n")
+		fmt.Fprintf(w, "agentsh_net_ebpf_unavailable_total %d\n", c.ebpfUnavailable.Load())
+	})
+}
+
+func (c *PrometheusCollector) writeSessionsTotal(w http.ResponseWriter) {
+	keys := snapshotMapKeys(&c.sessionsCreated)
+	if len(keys) == 0 {
+		return
+	}
+	fmt.Fprint(w, "# HELP agentsh_sessions_total Total sessions by state and tenant.\n")
+	fmt.Fprint(w, "# TYPE agentsh_sessions_total counter\n")
+	for _, key := range keys {
+		parts := strings.SplitN(key, ":", 2)
+		state, tenantID := parts[0], ""
+		if len(parts) > 1 {
+			tenantID = parts[1]
+		}
+		ptr, _ := c.sessionsCreated.Load(key)
+		n := ptr.(*atomic.Uint64).Load()
+		fmt.Fprintf(w, "agentsh_sessions_total{state=%q,tenant_id=%q} %d\n",
+			escapeLabelValue(state), escapeLabelValue(tenantID), n)
+	}
+	fmt.Fprint(w, "\n")
+}
+
+func (c *PrometheusCollector) writeSessionDurations(w http.ResponseWriter) {
+	c.sessionDurMu.Lock()
+	durations := make([]sessionDuration, len(c.sessionDurations))
+	copy(durations, c.sessionDurations)
+	c.sessionDurMu.Unlock()
+
+	if len(durations) == 0 {
+		return
+	}
+
+	// Histogram buckets in seconds
+	buckets := []float64{1, 10, 60, 300, 900, 3600}
+
+	fmt.Fprint(w, "# HELP agentsh_session_duration_seconds Session duration in seconds.\n")
+	fmt.Fprint(w, "# TYPE agentsh_session_duration_seconds histogram\n")
+
+	// Group by tenant_id and exit_state
+	groups := make(map[string][]time.Duration)
+	for _, d := range durations {
+		key := d.tenantID + ":" + d.exitState
+		groups[key] = append(groups[key], d.duration)
+	}
+
+	for key, durs := range groups {
+		parts := strings.SplitN(key, ":", 2)
+		tenantID, exitState := parts[0], ""
+		if len(parts) > 1 {
+			exitState = parts[1]
+		}
+		labels := fmt.Sprintf("tenant_id=%q,exit_state=%q", escapeLabelValue(tenantID), escapeLabelValue(exitState))
+
+		var sum float64
+		for _, bucket := range buckets {
+			count := 0
+			for _, d := range durs {
+				if d.Seconds() <= bucket {
+					count++
+				}
+			}
+			fmt.Fprintf(w, "agentsh_session_duration_seconds_bucket{%s,le=\"%.0f\"} %d\n", labels, bucket, count)
+		}
+		fmt.Fprintf(w, "agentsh_session_duration_seconds_bucket{%s,le=\"+Inf\"} %d\n", labels, len(durs))
+		for _, d := range durs {
+			sum += d.Seconds()
+		}
+		fmt.Fprintf(w, "agentsh_session_duration_seconds_sum{%s} %.3f\n", labels, sum)
+		fmt.Fprintf(w, "agentsh_session_duration_seconds_count{%s} %d\n", labels, len(durs))
+	}
+	fmt.Fprint(w, "\n")
+}
+
+func (c *PrometheusCollector) writeOperationsTotal(w http.ResponseWriter) {
+	keys := snapshotMapKeys(&c.operationsTotal)
+	if len(keys) == 0 {
+		return
+	}
+	fmt.Fprint(w, "# HELP agentsh_operations_total Total operations by type and decision.\n")
+	fmt.Fprint(w, "# TYPE agentsh_operations_total counter\n")
+	for _, key := range keys {
+		parts := strings.SplitN(key, ":", 2)
+		opType, decision := parts[0], ""
+		if len(parts) > 1 {
+			decision = parts[1]
+		}
+		ptr, _ := c.operationsTotal.Load(key)
+		n := ptr.(*atomic.Uint64).Load()
+		fmt.Fprintf(w, "agentsh_operations_total{type=%q,decision=%q} %d\n",
+			escapeLabelValue(opType), escapeLabelValue(decision), n)
+	}
+	fmt.Fprint(w, "\n")
+}
+
+func (c *PrometheusCollector) writeOperationLatencies(w http.ResponseWriter) {
+	c.operationLatMu.Lock()
+	latencies := make([]operationLatency, len(c.operationLatencies))
+	copy(latencies, c.operationLatencies)
+	c.operationLatMu.Unlock()
+
+	if len(latencies) == 0 {
+		return
+	}
+
+	// Histogram buckets in seconds
+	buckets := []float64{0.0001, 0.001, 0.01, 0.1, 1, 10}
+
+	fmt.Fprint(w, "# HELP agentsh_operation_latency_seconds Operation interception latency.\n")
+	fmt.Fprint(w, "# TYPE agentsh_operation_latency_seconds histogram\n")
+
+	// Group by type
+	groups := make(map[string][]time.Duration)
+	for _, l := range latencies {
+		groups[l.opType] = append(groups[l.opType], l.latency)
+	}
+
+	for opType, lats := range groups {
+		labels := fmt.Sprintf("type=%q", escapeLabelValue(opType))
+		var sum float64
+		for _, bucket := range buckets {
+			count := 0
+			for _, l := range lats {
+				if l.Seconds() <= bucket {
+					count++
+				}
+			}
+			fmt.Fprintf(w, "agentsh_operation_latency_seconds_bucket{%s,le=\"%g\"} %d\n", labels, bucket, count)
+		}
+		fmt.Fprintf(w, "agentsh_operation_latency_seconds_bucket{%s,le=\"+Inf\"} %d\n", labels, len(lats))
+		for _, l := range lats {
+			sum += l.Seconds()
+		}
+		fmt.Fprintf(w, "agentsh_operation_latency_seconds_sum{%s} %.6f\n", labels, sum)
+		fmt.Fprintf(w, "agentsh_operation_latency_seconds_count{%s} %d\n", labels, len(lats))
+	}
+	fmt.Fprint(w, "\n")
+}
+
+func (c *PrometheusCollector) writeApprovalLatencies(w http.ResponseWriter) {
+	c.approvalLatMu.Lock()
+	latencies := make([]time.Duration, len(c.approvalLatencies))
+	copy(latencies, c.approvalLatencies)
+	c.approvalLatMu.Unlock()
+
+	if len(latencies) == 0 {
+		return
+	}
+
+	// Histogram buckets in seconds
+	buckets := []float64{1, 5, 10, 30, 60, 300}
+
+	fmt.Fprint(w, "# HELP agentsh_approval_latency_seconds Time to receive approval decision.\n")
+	fmt.Fprint(w, "# TYPE agentsh_approval_latency_seconds histogram\n")
+
+	var sum float64
+	for _, bucket := range buckets {
+		count := 0
+		for _, l := range latencies {
+			if l.Seconds() <= bucket {
+				count++
+			}
+		}
+		fmt.Fprintf(w, "agentsh_approval_latency_seconds_bucket{le=\"%.0f\"} %d\n", bucket, count)
+	}
+	fmt.Fprintf(w, "agentsh_approval_latency_seconds_bucket{le=\"+Inf\"} %d\n", len(latencies))
+	for _, l := range latencies {
+		sum += l.Seconds()
+	}
+	fmt.Fprintf(w, "agentsh_approval_latency_seconds_sum %.3f\n", sum)
+	fmt.Fprintf(w, "agentsh_approval_latency_seconds_count %d\n\n", len(latencies))
+}
+
+func (c *PrometheusCollector) writePolicyEvalLatencies(w http.ResponseWriter) {
+	c.policyEvalMu.Lock()
+	latencies := make([]time.Duration, len(c.policyEvalLatencies))
+	copy(latencies, c.policyEvalLatencies)
+	c.policyEvalMu.Unlock()
+
+	if len(latencies) == 0 {
+		return
+	}
+
+	// Histogram buckets in seconds (microsecond-level)
+	buckets := []float64{0.00001, 0.0001, 0.001, 0.01}
+
+	fmt.Fprint(w, "# HELP agentsh_policy_eval_latency_seconds Policy evaluation latency.\n")
+	fmt.Fprint(w, "# TYPE agentsh_policy_eval_latency_seconds histogram\n")
+
+	var sum float64
+	for _, bucket := range buckets {
+		count := 0
+		for _, l := range latencies {
+			if l.Seconds() <= bucket {
+				count++
+			}
+		}
+		fmt.Fprintf(w, "agentsh_policy_eval_latency_seconds_bucket{le=\"%g\"} %d\n", bucket, count)
+	}
+	fmt.Fprintf(w, "agentsh_policy_eval_latency_seconds_bucket{le=\"+Inf\"} %d\n", len(latencies))
+	for _, l := range latencies {
+		sum += l.Seconds()
+	}
+	fmt.Fprintf(w, "agentsh_policy_eval_latency_seconds_sum %.9f\n", sum)
+	fmt.Fprintf(w, "agentsh_policy_eval_latency_seconds_count %d\n\n", len(latencies))
+}
+
+func (c *PrometheusCollector) writeEventsByType(w http.ResponseWriter) {
+	types := snapshotMapKeys(&c.byType)
+	if len(types) == 0 {
+		return
+	}
+	fmt.Fprint(w, "# HELP agentsh_events_by_type_total Total events appended by type.\n")
+	fmt.Fprint(w, "# TYPE agentsh_events_by_type_total counter\n")
+	for _, t := range types {
+		ptr, _ := c.byType.Load(t)
+		n := uint64(0)
+		if ptr != nil {
+			n = ptr.(*atomic.Uint64).Load()
+		}
+		fmt.Fprintf(w, "agentsh_events_by_type_total{type=%q} %d\n", escapeLabelValue(t), n)
+	}
+	fmt.Fprint(w, "\n")
+}
+
+func snapshotMapKeys(m *sync.Map) []string {
+	var out []string
+	m.Range(func(k, _ any) bool {
+		if s, ok := k.(string); ok {
+			out = append(out, s)
+		}
+		return true
+	})
+	sort.Strings(out)
+	return out
+}
+
+func escapeLabelValue(v string) string {
+	v = strings.ReplaceAll(v, "\\", "\\\\")
+	v = strings.ReplaceAll(v, "\n", "\\n")
+	v = strings.ReplaceAll(v, "\"", "\\\"")
+	return v
+}

--- a/pkg/observability/prometheus_test.go
+++ b/pkg/observability/prometheus_test.go
@@ -1,0 +1,207 @@
+package observability
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewPrometheusCollector(t *testing.T) {
+	c := NewPrometheusCollector()
+	if c == nil {
+		t.Fatal("NewPrometheusCollector() returned nil")
+	}
+}
+
+func TestPrometheusCollector_SessionMetrics(t *testing.T) {
+	c := NewPrometheusCollector()
+
+	// Test active sessions
+	c.IncSessionActive()
+	c.IncSessionActive()
+	if c.sessionsActive.Load() != 2 {
+		t.Errorf("sessionsActive = %d, want 2", c.sessionsActive.Load())
+	}
+
+	c.DecSessionActive()
+	if c.sessionsActive.Load() != 1 {
+		t.Errorf("sessionsActive = %d, want 1", c.sessionsActive.Load())
+	}
+
+	// Test session created counter
+	c.IncSessionCreated("created", "tenant-1")
+	c.IncSessionCreated("created", "tenant-1")
+	c.IncSessionCreated("created", "tenant-2")
+
+	// Test session duration recording
+	c.RecordSessionDuration("tenant-1", "completed", 30*time.Second)
+	c.RecordSessionDuration("tenant-1", "completed", 60*time.Second)
+}
+
+func TestPrometheusCollector_OperationMetrics(t *testing.T) {
+	c := NewPrometheusCollector()
+
+	// Test operation counter
+	c.IncOperation("file_read", "allow")
+	c.IncOperation("file_read", "allow")
+	c.IncOperation("file_read", "deny")
+	c.IncOperation("net_connect", "allow")
+
+	// Test operation latency
+	c.RecordOperationLatency("file_read", 100*time.Microsecond)
+	c.RecordOperationLatency("file_read", 200*time.Microsecond)
+	c.RecordOperationLatency("net_connect", 500*time.Microsecond)
+}
+
+func TestPrometheusCollector_ApprovalMetrics(t *testing.T) {
+	c := NewPrometheusCollector()
+
+	// Test pending approvals
+	c.IncApprovalPending()
+	c.IncApprovalPending()
+	if c.approvalsPending.Load() != 2 {
+		t.Errorf("approvalsPending = %d, want 2", c.approvalsPending.Load())
+	}
+
+	c.DecApprovalPending()
+	if c.approvalsPending.Load() != 1 {
+		t.Errorf("approvalsPending = %d, want 1", c.approvalsPending.Load())
+	}
+
+	// Test approval latency
+	c.RecordApprovalLatency(5 * time.Second)
+	c.RecordApprovalLatency(30 * time.Second)
+}
+
+func TestPrometheusCollector_PolicyMetrics(t *testing.T) {
+	c := NewPrometheusCollector()
+
+	c.RecordPolicyEvalLatency(10 * time.Microsecond)
+	c.RecordPolicyEvalLatency(50 * time.Microsecond)
+	c.RecordPolicyEvalLatency(100 * time.Microsecond)
+}
+
+func TestPrometheusCollector_LegacyEventMetrics(t *testing.T) {
+	c := NewPrometheusCollector()
+
+	c.IncEvent("file_read")
+	c.IncEvent("file_read")
+	c.IncEvent("net_connect")
+	c.IncEvent("") // Should become "unknown"
+
+	if c.eventsTotal.Load() != 4 {
+		t.Errorf("eventsTotal = %d, want 4", c.eventsTotal.Load())
+	}
+}
+
+func TestPrometheusCollector_EBPFMetrics(t *testing.T) {
+	c := NewPrometheusCollector()
+
+	c.IncEBPFDropped()
+	c.IncEBPFDropped()
+	if c.ebpfDropped.Load() != 2 {
+		t.Errorf("ebpfDropped = %d, want 2", c.ebpfDropped.Load())
+	}
+
+	c.IncEBPFAttachFail()
+	if c.ebpfAttachFail.Load() != 1 {
+		t.Errorf("ebpfAttachFail = %d, want 1", c.ebpfAttachFail.Load())
+	}
+
+	c.IncEBPFUnavailable()
+	if c.ebpfUnavailable.Load() != 1 {
+		t.Errorf("ebpfUnavailable = %d, want 1", c.ebpfUnavailable.Load())
+	}
+}
+
+func TestPrometheusCollector_NilSafety(t *testing.T) {
+	var c *PrometheusCollector
+
+	// None of these should panic
+	c.IncSessionActive()
+	c.DecSessionActive()
+	c.IncSessionCreated("created", "tenant")
+	c.RecordSessionDuration("tenant", "completed", time.Second)
+	c.IncOperation("file_read", "allow")
+	c.RecordOperationLatency("file_read", time.Microsecond)
+	c.IncApprovalPending()
+	c.DecApprovalPending()
+	c.RecordApprovalLatency(time.Second)
+	c.RecordPolicyEvalLatency(time.Microsecond)
+	c.IncEvent("test")
+	c.IncEBPFDropped()
+	c.IncEBPFAttachFail()
+	c.IncEBPFUnavailable()
+}
+
+func TestPrometheusCollector_Handler(t *testing.T) {
+	c := NewPrometheusCollector()
+
+	// Add some metrics
+	c.IncSessionActive()
+	c.IncSessionCreated("created", "tenant-1")
+	c.IncOperation("file_read", "allow")
+	c.RecordOperationLatency("file_read", 100*time.Microsecond)
+	c.RecordSessionDuration("tenant-1", "completed", 30*time.Second)
+	c.RecordApprovalLatency(5 * time.Second)
+	c.RecordPolicyEvalLatency(10 * time.Microsecond)
+	c.IncEvent("file_read")
+	c.IncEBPFDropped()
+
+	// Create handler and request
+	handler := c.Handler(HandlerOptions{})
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200", resp.StatusCode)
+	}
+
+	body := w.Body.String()
+
+	// Check for expected metrics
+	expectedMetrics := []string{
+		"agentsh_up 1",
+		"agentsh_sessions_active",
+		"agentsh_sessions_total",
+		"agentsh_operations_total",
+		"agentsh_operation_latency_seconds",
+		"agentsh_approvals_pending",
+		"agentsh_approval_latency_seconds",
+		"agentsh_policy_eval_latency_seconds",
+		"agentsh_events_total",
+		"agentsh_events_by_type_total",
+		"agentsh_net_ebpf_dropped_events_total",
+	}
+
+	for _, metric := range expectedMetrics {
+		if !strings.Contains(body, metric) {
+			t.Errorf("response missing metric: %s", metric)
+		}
+	}
+}
+
+func TestEscapeLabelValue(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple", "simple"},
+		{"with\\backslash", "with\\\\backslash"},
+		{"with\"quote", "with\\\"quote"},
+		{"with\nnewline", "with\\nnewline"},
+		{"all\\of\"these\n", "all\\\\of\\\"these\\n"},
+	}
+
+	for _, tt := range tests {
+		got := escapeLabelValue(tt.input)
+		if got != tt.want {
+			t.Errorf("escapeLabelValue(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/pkg/observability/tracing.go
+++ b/pkg/observability/tracing.go
@@ -1,0 +1,191 @@
+package observability
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	// TracerName is the OpenTelemetry tracer name.
+	TracerName = "agentsh"
+)
+
+// OperationType represents the type of intercepted operation.
+type OperationType string
+
+const (
+	OpFileRead    OperationType = "file_read"
+	OpFileWrite   OperationType = "file_write"
+	OpFileCreate  OperationType = "file_create"
+	OpFileDelete  OperationType = "file_delete"
+	OpNetConnect  OperationType = "net_connect"
+	OpDNSQuery    OperationType = "dns_query"
+	OpEnvRead     OperationType = "env_read"
+	OpEnvWrite    OperationType = "env_write"
+	OpExec        OperationType = "exec"
+	OpRegistryRead  OperationType = "registry_read"
+	OpRegistryWrite OperationType = "registry_write"
+)
+
+// String returns the string representation of the operation type.
+func (o OperationType) String() string {
+	return string(o)
+}
+
+// InterceptedOperation represents an operation being traced.
+type InterceptedOperation struct {
+	Type      OperationType
+	SessionID string
+	AgentID   string
+	TenantID  string
+	Path      string
+	Target    string // For network: host:port, for DNS: domain
+	Extra     map[string]string
+}
+
+// TraceOperation starts a new span for an intercepted operation.
+func TraceOperation(ctx context.Context, op *InterceptedOperation) (context.Context, trace.Span) {
+	tracer := otel.Tracer(TracerName)
+
+	attrs := []attribute.KeyValue{
+		attribute.String("session.id", op.SessionID),
+		attribute.String("agent.id", op.AgentID),
+		attribute.String("operation.type", string(op.Type)),
+	}
+
+	if op.TenantID != "" {
+		attrs = append(attrs, attribute.String("tenant.id", op.TenantID))
+	}
+	if op.Path != "" {
+		attrs = append(attrs, attribute.String("operation.path", op.Path))
+	}
+	if op.Target != "" {
+		attrs = append(attrs, attribute.String("operation.target", op.Target))
+	}
+	for k, v := range op.Extra {
+		attrs = append(attrs, attribute.String("operation."+k, v))
+	}
+
+	ctx, span := tracer.Start(ctx, op.Type.String(),
+		trace.WithAttributes(attrs...),
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+
+	return ctx, span
+}
+
+// RecordDecision records the policy decision on a span.
+func RecordDecision(span trace.Span, decision string, ruleName string) {
+	span.SetAttributes(
+		attribute.String("decision", decision),
+		attribute.String("decision.rule", ruleName),
+	)
+
+	if decision == "deny" {
+		span.SetStatus(codes.Error, "operation denied by policy")
+	}
+}
+
+// RecordApproval records approval-related events on a span.
+func RecordApproval(span trace.Span, approver string, approved bool, duration time.Duration) {
+	span.AddEvent("approval_received", trace.WithAttributes(
+		attribute.String("approver", approver),
+		attribute.Bool("approved", approved),
+		attribute.Int64("duration_ms", duration.Milliseconds()),
+	))
+
+	if !approved {
+		span.SetStatus(codes.Error, "approval denied")
+	}
+}
+
+// RecordRedirect records a redirect action on a span.
+func RecordRedirect(span trace.Span, originalPath, redirectPath string) {
+	span.AddEvent("redirect", trace.WithAttributes(
+		attribute.String("original_path", originalPath),
+		attribute.String("redirect_path", redirectPath),
+	))
+}
+
+// RecordError records an error on a span.
+func RecordError(span trace.Span, err error) {
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+}
+
+// PolicyEvalSpan creates a child span for policy evaluation.
+func PolicyEvalSpan(ctx context.Context) (context.Context, trace.Span) {
+	tracer := otel.Tracer(TracerName)
+	return tracer.Start(ctx, "policy_eval",
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+}
+
+// ApprovalSpan creates a child span for approval workflow.
+func ApprovalSpan(ctx context.Context, opType OperationType, path string) (context.Context, trace.Span) {
+	tracer := otel.Tracer(TracerName)
+	return tracer.Start(ctx, "awaiting_approval",
+		trace.WithAttributes(
+			attribute.String("operation.type", string(opType)),
+			attribute.String("operation.path", path),
+		),
+		trace.WithSpanKind(trace.SpanKindInternal),
+	)
+}
+
+// WebhookSpan creates a child span for webhook dispatch.
+func WebhookSpan(ctx context.Context, url string) (context.Context, trace.Span) {
+	tracer := otel.Tracer(TracerName)
+	return tracer.Start(ctx, "webhook_dispatch",
+		trace.WithAttributes(
+			attribute.String("webhook.url", url),
+		),
+		trace.WithSpanKind(trace.SpanKindClient),
+	)
+}
+
+// RecordWebhookResult records webhook dispatch result.
+func RecordWebhookResult(span trace.Span, statusCode int, err error) {
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return
+	}
+	span.SetAttributes(attribute.Int("http.status_code", statusCode))
+	if statusCode >= 400 {
+		span.SetStatus(codes.Error, "webhook returned error status")
+	}
+}
+
+// ExtractTraceID extracts the trace ID from a context.
+func ExtractTraceID(ctx context.Context) string {
+	span := trace.SpanFromContext(ctx)
+	if span == nil {
+		return ""
+	}
+	sc := span.SpanContext()
+	if !sc.IsValid() {
+		return ""
+	}
+	return sc.TraceID().String()
+}
+
+// ExtractSpanID extracts the span ID from a context.
+func ExtractSpanID(ctx context.Context) string {
+	span := trace.SpanFromContext(ctx)
+	if span == nil {
+		return ""
+	}
+	sc := span.SpanContext()
+	if !sc.IsValid() {
+		return ""
+	}
+	return sc.SpanID().String()
+}

--- a/pkg/observability/tracing_test.go
+++ b/pkg/observability/tracing_test.go
@@ -1,0 +1,208 @@
+package observability
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+func init() {
+	// Use noop tracer for tests
+	otel.SetTracerProvider(noop.NewTracerProvider())
+}
+
+func TestOperationType_String(t *testing.T) {
+	tests := []struct {
+		op   OperationType
+		want string
+	}{
+		{OpFileRead, "file_read"},
+		{OpFileWrite, "file_write"},
+		{OpNetConnect, "net_connect"},
+		{OpDNSQuery, "dns_query"},
+		{OpExec, "exec"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.op.String(); got != tt.want {
+			t.Errorf("%v.String() = %q, want %q", tt.op, got, tt.want)
+		}
+	}
+}
+
+func TestTraceOperation(t *testing.T) {
+	ctx := context.Background()
+	op := &InterceptedOperation{
+		Type:      OpFileRead,
+		SessionID: "sess-123",
+		AgentID:   "agent-456",
+		TenantID:  "tenant-789",
+		Path:      "/etc/passwd",
+		Extra: map[string]string{
+			"mode": "r",
+		},
+	}
+
+	ctx, span := TraceOperation(ctx, op)
+	defer span.End()
+
+	if span == nil {
+		t.Error("TraceOperation returned nil span")
+	}
+
+	// Verify context is updated
+	if ctx == nil {
+		t.Error("TraceOperation returned nil context")
+	}
+}
+
+func TestTraceOperation_MinimalOp(t *testing.T) {
+	ctx := context.Background()
+	op := &InterceptedOperation{
+		Type:      OpNetConnect,
+		SessionID: "sess-123",
+		AgentID:   "agent-456",
+		Target:    "api.example.com:443",
+	}
+
+	ctx, span := TraceOperation(ctx, op)
+	defer span.End()
+
+	if span == nil {
+		t.Error("TraceOperation returned nil span")
+	}
+}
+
+func TestRecordDecision(t *testing.T) {
+	ctx := context.Background()
+	op := &InterceptedOperation{
+		Type:      OpFileRead,
+		SessionID: "sess-123",
+		AgentID:   "agent-456",
+	}
+
+	_, span := TraceOperation(ctx, op)
+	defer span.End()
+
+	// Should not panic
+	RecordDecision(span, "allow", "rule-1")
+	RecordDecision(span, "deny", "rule-2")
+}
+
+func TestRecordApproval(t *testing.T) {
+	ctx := context.Background()
+	op := &InterceptedOperation{
+		Type:      OpFileDelete,
+		SessionID: "sess-123",
+		AgentID:   "agent-456",
+	}
+
+	_, span := TraceOperation(ctx, op)
+	defer span.End()
+
+	// Should not panic
+	RecordApproval(span, "user@example.com", true, 5*time.Second)
+	RecordApproval(span, "user@example.com", false, 10*time.Second)
+}
+
+func TestRecordRedirect(t *testing.T) {
+	ctx := context.Background()
+	op := &InterceptedOperation{
+		Type:      OpFileWrite,
+		SessionID: "sess-123",
+		AgentID:   "agent-456",
+	}
+
+	_, span := TraceOperation(ctx, op)
+	defer span.End()
+
+	// Should not panic
+	RecordRedirect(span, "/secret/file", "/workspace/.scratch/file")
+}
+
+func TestRecordError(t *testing.T) {
+	ctx := context.Background()
+	op := &InterceptedOperation{
+		Type:      OpFileRead,
+		SessionID: "sess-123",
+		AgentID:   "agent-456",
+	}
+
+	_, span := TraceOperation(ctx, op)
+	defer span.End()
+
+	// Should not panic with nil error
+	RecordError(span, nil)
+
+	// Should not panic with real error
+	RecordError(span, context.DeadlineExceeded)
+}
+
+func TestPolicyEvalSpan(t *testing.T) {
+	ctx := context.Background()
+
+	ctx, span := PolicyEvalSpan(ctx)
+	defer span.End()
+
+	if span == nil {
+		t.Error("PolicyEvalSpan returned nil span")
+	}
+}
+
+func TestApprovalSpan(t *testing.T) {
+	ctx := context.Background()
+
+	ctx, span := ApprovalSpan(ctx, OpFileDelete, "/workspace/important.txt")
+	defer span.End()
+
+	if span == nil {
+		t.Error("ApprovalSpan returned nil span")
+	}
+}
+
+func TestWebhookSpan(t *testing.T) {
+	ctx := context.Background()
+
+	ctx, span := WebhookSpan(ctx, "https://hooks.example.com/notify")
+	defer span.End()
+
+	if span == nil {
+		t.Error("WebhookSpan returned nil span")
+	}
+}
+
+func TestRecordWebhookResult(t *testing.T) {
+	ctx := context.Background()
+	_, span := WebhookSpan(ctx, "https://hooks.example.com/notify")
+	defer span.End()
+
+	// Should not panic
+	RecordWebhookResult(span, 200, nil)
+	RecordWebhookResult(span, 500, nil)
+	RecordWebhookResult(span, 0, context.DeadlineExceeded)
+}
+
+func TestExtractTraceID(t *testing.T) {
+	// With noop tracer, should return empty string
+	ctx := context.Background()
+	traceID := ExtractTraceID(ctx)
+
+	// Noop tracer returns invalid span context, so trace ID should be empty
+	if traceID != "" {
+		t.Logf("TraceID with noop tracer: %q", traceID)
+	}
+}
+
+func TestExtractSpanID(t *testing.T) {
+	// With noop tracer, should return empty string
+	ctx := context.Background()
+	spanID := ExtractSpanID(ctx)
+
+	// Noop tracer returns invalid span context, so span ID should be empty
+	if spanID != "" {
+		t.Logf("SpanID with noop tracer: %q", spanID)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `pkg/observability` with Prometheus metrics, OpenTelemetry tracing, and structured logging per spec §22.

## Components

### Prometheus Metrics (`prometheus.go`)
- **Session metrics**: `agentsh_sessions_active`, `agentsh_sessions_total{state,tenant_id}`, `agentsh_session_duration_seconds` histogram
- **Operation metrics**: `agentsh_operations_total{type,decision}`, `agentsh_operation_latency_seconds` histogram
- **Approval metrics**: `agentsh_approvals_pending`, `agentsh_approval_latency_seconds` histogram
- **Policy metrics**: `agentsh_policy_eval_latency_seconds` histogram
- Legacy event metrics for compatibility with existing `internal/metrics`
- eBPF metrics: dropped, attach fail, unavailable

### OpenTelemetry Tracing (`tracing.go`)
- `TraceOperation()` - creates spans for intercepted operations with session/agent/tenant attributes
- `RecordDecision()`, `RecordApproval()`, `RecordRedirect()` - span attributes/events
- `PolicyEvalSpan()`, `ApprovalSpan()`, `WebhookSpan()` - child spans for sub-operations
- `ExtractTraceID()`, `ExtractSpanID()` - for log correlation

### Structured Logging (`logging.go`)
- `AuditLogger` with session/agent/tenant context
- JSON newline-delimited format for SIEM ingestion
- Level filtering (debug, info, warn, error)
- Specialized methods:
  - `LogOperation()` - operation with decision and latency
  - `LogApproval()` - approval workflow events
  - `LogSessionStart()` / `LogSessionEnd()` - lifecycle
  - `LogPolicyDeny()` - policy denials (warn level)
  - `LogSecurityEvent()` - MITRE ATT&CK style events
- Automatic trace ID correlation in log entries

## Example Output

```json
{"level":"info","ts":"2025-01-15T14:30:00Z","msg":"operation",
 "session_id":"sess_123","agent_id":"agent_456","type":"file_read",
 "path":"/etc/passwd","decision":"deny","latency_us":150,"trace_id":"abc123"}
```

## Test plan

- [x] Unit tests for Prometheus collector (all metric types, nil safety, handler output)
- [x] Unit tests for tracing (span creation, attributes, child spans)
- [x] Unit tests for structured logging (all log methods, JSON format, level filtering)
- [x] Tests pass: `go test ./pkg/observability/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)