### PR TITLE
feat: add rate limiting and quota management

### DIFF
--- a/pkg/ratelimit/limiter.go
+++ b/pkg/ratelimit/limiter.go
@@ -1,0 +1,264 @@
+// Package ratelimit provides rate limiting and quota management for agentsh.
+package ratelimit
+
+import (
+	"sync"
+	"time"
+)
+
+// Config defines rate limit configuration.
+type Config struct {
+	// Session limits
+	Session SessionLimits `json:"session" yaml:"session"`
+
+	// Agent limits (across all sessions)
+	Agent AgentLimits `json:"agent" yaml:"agent"`
+
+	// Tenant limits
+	Tenant TenantLimits `json:"tenant" yaml:"tenant"`
+
+	// Global limits
+	Global GlobalLimits `json:"global" yaml:"global"`
+
+	// Actions when limits exceeded
+	Actions ActionConfig `json:"actions" yaml:"actions"`
+}
+
+// SessionLimits defines per-session rate limits.
+type SessionLimits struct {
+	FileOpsPerSecond     float64 `json:"file_ops_per_second" yaml:"file_ops_per_second"`
+	NetworkConnsPerSecond float64 `json:"network_conns_per_second" yaml:"network_conns_per_second"`
+	DNSQueriesPerSecond  float64 `json:"dns_queries_per_second" yaml:"dns_queries_per_second"`
+	BurstMultiplier      float64 `json:"burst_multiplier" yaml:"burst_multiplier"`
+}
+
+// AgentLimits defines per-agent limits.
+type AgentLimits struct {
+	MaxConcurrentSessions    int   `json:"max_concurrent_sessions" yaml:"max_concurrent_sessions"`
+	MaxTotalOperationsPerHour int64 `json:"max_total_operations_per_hour" yaml:"max_total_operations_per_hour"`
+}
+
+// TenantLimits defines per-tenant limits.
+type TenantLimits struct {
+	MaxConcurrentSessions int   `json:"max_concurrent_sessions" yaml:"max_concurrent_sessions"`
+	MaxStorageBytes       int64 `json:"max_storage_bytes" yaml:"max_storage_bytes"`
+	MaxNetworkBytesPerDay int64 `json:"max_network_bytes_per_day" yaml:"max_network_bytes_per_day"`
+}
+
+// GlobalLimits defines global limits.
+type GlobalLimits struct {
+	MaxConcurrentSessions int `json:"max_concurrent_sessions" yaml:"max_concurrent_sessions"`
+	MaxPendingApprovals   int `json:"max_pending_approvals" yaml:"max_pending_approvals"`
+}
+
+// ActionConfig defines actions when limits are exceeded.
+type ActionConfig struct {
+	FileOps     LimitAction `json:"file_ops" yaml:"file_ops"`
+	NetworkConns LimitAction `json:"network_conns" yaml:"network_conns"`
+	DNSQueries  LimitAction `json:"dns_queries" yaml:"dns_queries"`
+}
+
+// LimitAction defines what happens when a limit is exceeded.
+type LimitAction struct {
+	Action  ActionType `json:"action" yaml:"action"`
+	DelayMs int        `json:"delay_ms,omitempty" yaml:"delay_ms,omitempty"`
+	Message string     `json:"message,omitempty" yaml:"message,omitempty"`
+}
+
+// ActionType represents the type of action to take.
+type ActionType string
+
+const (
+	ActionThrottle ActionType = "throttle"
+	ActionBlock    ActionType = "block"
+	ActionAlert    ActionType = "alert"
+)
+
+// DefaultConfig returns sensible default rate limit configuration.
+func DefaultConfig() Config {
+	return Config{
+		Session: SessionLimits{
+			FileOpsPerSecond:      1000,
+			NetworkConnsPerSecond: 100,
+			DNSQueriesPerSecond:   50,
+			BurstMultiplier:       5,
+		},
+		Agent: AgentLimits{
+			MaxConcurrentSessions:    10,
+			MaxTotalOperationsPerHour: 1000000,
+		},
+		Tenant: TenantLimits{
+			MaxConcurrentSessions: 100,
+			MaxStorageBytes:       10 * 1024 * 1024 * 1024, // 10GB
+			MaxNetworkBytesPerDay: 100 * 1024 * 1024 * 1024, // 100GB
+		},
+		Global: GlobalLimits{
+			MaxConcurrentSessions: 1000,
+			MaxPendingApprovals:   100,
+		},
+		Actions: ActionConfig{
+			FileOps: LimitAction{
+				Action:  ActionThrottle,
+				DelayMs: 100,
+			},
+			NetworkConns: LimitAction{
+				Action:  ActionBlock,
+				Message: "Connection rate limit exceeded",
+			},
+			DNSQueries: LimitAction{
+				Action:  ActionThrottle,
+				DelayMs: 50,
+			},
+		},
+	}
+}
+
+// ResourceType identifies the type of resource being rate limited.
+type ResourceType string
+
+const (
+	ResourceFileOps     ResourceType = "file_ops"
+	ResourceNetworkConns ResourceType = "network_conns"
+	ResourceDNSQueries  ResourceType = "dns_queries"
+	ResourceOperations  ResourceType = "operations"
+	ResourceStorage     ResourceType = "storage"
+	ResourceNetworkBytes ResourceType = "network_bytes"
+)
+
+// Limiter provides token bucket rate limiting.
+type Limiter struct {
+	rate      float64 // tokens per second
+	burst     int     // maximum burst size
+	tokens    float64
+	lastTime  time.Time
+	mu        sync.Mutex
+}
+
+// NewLimiter creates a new rate limiter.
+func NewLimiter(rate float64, burst int) *Limiter {
+	return &Limiter{
+		rate:     rate,
+		burst:    burst,
+		tokens:   float64(burst),
+		lastTime: time.Now(),
+	}
+}
+
+// Allow checks if an operation is allowed and consumes a token if so.
+func (l *Limiter) Allow() bool {
+	return l.AllowN(1)
+}
+
+// AllowN checks if n operations are allowed and consumes n tokens if so.
+func (l *Limiter) AllowN(n int) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(l.lastTime).Seconds()
+	l.lastTime = now
+
+	// Add tokens based on elapsed time
+	l.tokens += elapsed * l.rate
+	if l.tokens > float64(l.burst) {
+		l.tokens = float64(l.burst)
+	}
+
+	// Check if we have enough tokens
+	if l.tokens >= float64(n) {
+		l.tokens -= float64(n)
+		return true
+	}
+
+	return false
+}
+
+// Wait waits until a token is available and consumes it.
+func (l *Limiter) Wait() time.Duration {
+	return l.WaitN(1)
+}
+
+// WaitN waits until n tokens are available, consumes them, and returns the wait duration.
+func (l *Limiter) WaitN(n int) time.Duration {
+	l.mu.Lock()
+
+	now := time.Now()
+	elapsed := now.Sub(l.lastTime).Seconds()
+	l.lastTime = now
+
+	// Add tokens based on elapsed time
+	l.tokens += elapsed * l.rate
+	if l.tokens > float64(l.burst) {
+		l.tokens = float64(l.burst)
+	}
+
+	// Check if we have enough tokens
+	if l.tokens >= float64(n) {
+		l.tokens -= float64(n)
+		l.mu.Unlock()
+		return 0
+	}
+
+	// Calculate wait time
+	needed := float64(n) - l.tokens
+	waitDuration := time.Duration(needed / l.rate * float64(time.Second))
+
+	l.tokens = 0 // Will be replenished when we wake up
+	l.mu.Unlock()
+
+	time.Sleep(waitDuration)
+
+	l.mu.Lock()
+	l.tokens = float64(n) - needed // Account for replenishment during sleep
+	l.tokens -= float64(n)
+	if l.tokens < 0 {
+		l.tokens = 0
+	}
+	l.lastTime = time.Now()
+	l.mu.Unlock()
+
+	return waitDuration
+}
+
+// Tokens returns the current number of available tokens.
+func (l *Limiter) Tokens() float64 {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(l.lastTime).Seconds()
+
+	tokens := l.tokens + elapsed*l.rate
+	if tokens > float64(l.burst) {
+		tokens = float64(l.burst)
+	}
+
+	return tokens
+}
+
+// Rate returns the token refill rate per second.
+func (l *Limiter) Rate() float64 {
+	return l.rate
+}
+
+// Burst returns the maximum burst size.
+func (l *Limiter) Burst() int {
+	return l.burst
+}
+
+// SetRate updates the rate limit.
+func (l *Limiter) SetRate(rate float64) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.rate = rate
+}
+
+// SetBurst updates the burst limit.
+func (l *Limiter) SetBurst(burst int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.burst = burst
+	if l.tokens > float64(burst) {
+		l.tokens = float64(burst)
+	}
+}

--- a/pkg/ratelimit/limiter_test.go
+++ b/pkg/ratelimit/limiter_test.go
@@ -1,0 +1,169 @@
+package ratelimit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	if cfg.Session.FileOpsPerSecond != 1000 {
+		t.Errorf("FileOpsPerSecond = %v, want 1000", cfg.Session.FileOpsPerSecond)
+	}
+	if cfg.Session.BurstMultiplier != 5 {
+		t.Errorf("BurstMultiplier = %v, want 5", cfg.Session.BurstMultiplier)
+	}
+	if cfg.Global.MaxConcurrentSessions != 1000 {
+		t.Errorf("MaxConcurrentSessions = %v, want 1000", cfg.Global.MaxConcurrentSessions)
+	}
+}
+
+func TestNewLimiter(t *testing.T) {
+	l := NewLimiter(10, 50)
+
+	if l == nil {
+		t.Fatal("NewLimiter returned nil")
+	}
+	if l.Rate() != 10 {
+		t.Errorf("Rate() = %v, want 10", l.Rate())
+	}
+	if l.Burst() != 50 {
+		t.Errorf("Burst() = %v, want 50", l.Burst())
+	}
+}
+
+func TestLimiter_Allow(t *testing.T) {
+	l := NewLimiter(10, 5)
+
+	// Should allow burst
+	for i := 0; i < 5; i++ {
+		if !l.Allow() {
+			t.Errorf("Allow() returned false on attempt %d within burst", i+1)
+		}
+	}
+
+	// Should deny after burst exhausted
+	if l.Allow() {
+		t.Error("Allow() should return false after burst exhausted")
+	}
+}
+
+func TestLimiter_AllowN(t *testing.T) {
+	l := NewLimiter(100, 10)
+
+	// Should allow 5 tokens
+	if !l.AllowN(5) {
+		t.Error("AllowN(5) should return true")
+	}
+
+	// Should allow another 5
+	if !l.AllowN(5) {
+		t.Error("AllowN(5) should return true again")
+	}
+
+	// Should deny 5 more (burst exhausted)
+	if l.AllowN(5) {
+		t.Error("AllowN(5) should return false after burst exhausted")
+	}
+}
+
+func TestLimiter_TokensReplenish(t *testing.T) {
+	l := NewLimiter(100, 10) // 100 tokens/second
+
+	// Exhaust burst
+	l.AllowN(10)
+
+	// Should be empty
+	if l.Tokens() > 0.5 {
+		t.Errorf("Tokens() = %v, expected near 0", l.Tokens())
+	}
+
+	// Wait for replenishment
+	time.Sleep(50 * time.Millisecond)
+
+	// Should have ~5 tokens (100/sec * 0.05s = 5)
+	tokens := l.Tokens()
+	if tokens < 3 || tokens > 7 {
+		t.Errorf("Tokens() = %v, expected ~5", tokens)
+	}
+}
+
+func TestLimiter_SetRate(t *testing.T) {
+	l := NewLimiter(10, 5)
+
+	l.SetRate(100)
+	if l.Rate() != 100 {
+		t.Errorf("Rate() = %v, want 100", l.Rate())
+	}
+}
+
+func TestLimiter_SetBurst(t *testing.T) {
+	l := NewLimiter(10, 50)
+
+	l.SetBurst(10)
+	if l.Burst() != 10 {
+		t.Errorf("Burst() = %v, want 10", l.Burst())
+	}
+
+	// Tokens should be capped at new burst
+	if l.Tokens() > 10 {
+		t.Errorf("Tokens() = %v, should be capped at 10", l.Tokens())
+	}
+}
+
+func TestLimiter_Wait(t *testing.T) {
+	l := NewLimiter(1000, 1) // Fast for testing
+
+	// First should be immediate
+	d := l.Wait()
+	if d > time.Millisecond {
+		t.Errorf("First Wait() = %v, expected immediate", d)
+	}
+
+	// Second should require waiting
+	start := time.Now()
+	l.Wait()
+	elapsed := time.Since(start)
+
+	// Should have waited approximately 1ms (1/1000 second)
+	if elapsed < 500*time.Microsecond {
+		t.Errorf("Second Wait() elapsed = %v, expected some delay", elapsed)
+	}
+}
+
+func TestActionType(t *testing.T) {
+	tests := []struct {
+		action ActionType
+		want   string
+	}{
+		{ActionThrottle, "throttle"},
+		{ActionBlock, "block"},
+		{ActionAlert, "alert"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.action) != tt.want {
+			t.Errorf("ActionType = %q, want %q", tt.action, tt.want)
+		}
+	}
+}
+
+func TestResourceType(t *testing.T) {
+	tests := []struct {
+		resource ResourceType
+		want     string
+	}{
+		{ResourceFileOps, "file_ops"},
+		{ResourceNetworkConns, "network_conns"},
+		{ResourceDNSQueries, "dns_queries"},
+		{ResourceStorage, "storage"},
+		{ResourceNetworkBytes, "network_bytes"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.resource) != tt.want {
+			t.Errorf("ResourceType = %q, want %q", tt.resource, tt.want)
+		}
+	}
+}

--- a/pkg/ratelimit/quota.go
+++ b/pkg/ratelimit/quota.go
@@ -1,0 +1,466 @@
+package ratelimit
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// QuotaManager manages resource quotas across sessions, agents, and tenants.
+type QuotaManager struct {
+	config   Config
+	limiters map[string]*Limiter
+	quotas   map[string]*ResourceQuota
+	mu       sync.RWMutex
+
+	// Callbacks
+	onWarning func(id string, resource ResourceType, percentage float64)
+	onExceed  func(id string, resource ResourceType, err *QuotaExceededError)
+}
+
+// ResourceQuota tracks usage of a resource.
+type ResourceQuota struct {
+	Resource   ResourceType `json:"resource"`
+	Limit      int64        `json:"limit"`
+	Used       int64        `json:"used"`
+	ResetAt    time.Time    `json:"reset_at"`
+	Percentage float64      `json:"percentage"`
+	mu         sync.Mutex
+}
+
+// QuotaExceededError is returned when a quota is exceeded.
+type QuotaExceededError struct {
+	Resource  ResourceType
+	Limit     int64
+	Used      int64
+	Requested int64
+}
+
+func (e *QuotaExceededError) Error() string {
+	return fmt.Sprintf("quota exceeded for %s: limit=%d, used=%d, requested=%d",
+		e.Resource, e.Limit, e.Used, e.Requested)
+}
+
+// NewQuotaManager creates a new quota manager.
+func NewQuotaManager(config Config) *QuotaManager {
+	return &QuotaManager{
+		config:   config,
+		limiters: make(map[string]*Limiter),
+		quotas:   make(map[string]*ResourceQuota),
+	}
+}
+
+// OnWarning sets a callback for quota warnings (approaching limit).
+func (q *QuotaManager) OnWarning(fn func(id string, resource ResourceType, percentage float64)) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.onWarning = fn
+}
+
+// OnExceed sets a callback for quota exceeded events.
+func (q *QuotaManager) OnExceed(fn func(id string, resource ResourceType, err *QuotaExceededError)) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.onExceed = fn
+}
+
+// GetSessionLimiter returns a rate limiter for a session and resource type.
+func (q *QuotaManager) GetSessionLimiter(sessionID string, resource ResourceType) *Limiter {
+	key := fmt.Sprintf("session:%s:%s", sessionID, resource)
+
+	q.mu.RLock()
+	limiter, exists := q.limiters[key]
+	q.mu.RUnlock()
+
+	if exists {
+		return limiter
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if limiter, exists = q.limiters[key]; exists {
+		return limiter
+	}
+
+	// Create new limiter based on resource type
+	var rate float64
+	var burst int
+
+	switch resource {
+	case ResourceFileOps:
+		rate = q.config.Session.FileOpsPerSecond
+		burst = int(rate * q.config.Session.BurstMultiplier)
+	case ResourceNetworkConns:
+		rate = q.config.Session.NetworkConnsPerSecond
+		burst = int(rate * q.config.Session.BurstMultiplier)
+	case ResourceDNSQueries:
+		rate = q.config.Session.DNSQueriesPerSecond
+		burst = int(rate * q.config.Session.BurstMultiplier)
+	default:
+		rate = 100
+		burst = 500
+	}
+
+	if burst < 1 {
+		burst = 1
+	}
+
+	limiter = NewLimiter(rate, burst)
+	q.limiters[key] = limiter
+
+	return limiter
+}
+
+// CheckRateLimit checks if an operation is allowed by rate limits.
+func (q *QuotaManager) CheckRateLimit(sessionID string, resource ResourceType) (allowed bool, action LimitAction) {
+	limiter := q.GetSessionLimiter(sessionID, resource)
+
+	if limiter.Allow() {
+		return true, LimitAction{}
+	}
+
+	// Get action for this resource
+	switch resource {
+	case ResourceFileOps:
+		action = q.config.Actions.FileOps
+	case ResourceNetworkConns:
+		action = q.config.Actions.NetworkConns
+	case ResourceDNSQueries:
+		action = q.config.Actions.DNSQueries
+	default:
+		action = LimitAction{Action: ActionBlock}
+	}
+
+	return false, action
+}
+
+// WaitForRateLimit waits until an operation is allowed by rate limits.
+func (q *QuotaManager) WaitForRateLimit(ctx context.Context, sessionID string, resource ResourceType) error {
+	limiter := q.GetSessionLimiter(sessionID, resource)
+
+	// Check if we can proceed immediately
+	if limiter.Allow() {
+		return nil
+	}
+
+	// Get action for this resource
+	var action LimitAction
+	switch resource {
+	case ResourceFileOps:
+		action = q.config.Actions.FileOps
+	case ResourceNetworkConns:
+		action = q.config.Actions.NetworkConns
+	case ResourceDNSQueries:
+		action = q.config.Actions.DNSQueries
+	default:
+		action = LimitAction{Action: ActionBlock}
+	}
+
+	switch action.Action {
+	case ActionBlock:
+		return fmt.Errorf("rate limit exceeded: %s", action.Message)
+	case ActionThrottle:
+		delay := time.Duration(action.DelayMs) * time.Millisecond
+		select {
+		case <-time.After(delay):
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	case ActionAlert:
+		// Alert but allow
+		return nil
+	}
+
+	return nil
+}
+
+// getQuotaKey returns the storage key for a quota.
+func getQuotaKey(scope, id string, resource ResourceType) string {
+	return fmt.Sprintf("%s:%s:%s", scope, id, resource)
+}
+
+// GetQuota returns the current quota for a resource.
+func (q *QuotaManager) GetQuota(scope, id string, resource ResourceType) *ResourceQuota {
+	key := getQuotaKey(scope, id, resource)
+
+	q.mu.RLock()
+	quota, exists := q.quotas[key]
+	q.mu.RUnlock()
+
+	if exists {
+		return quota
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	// Double-check
+	if quota, exists = q.quotas[key]; exists {
+		return quota
+	}
+
+	// Create new quota based on scope and resource
+	var limit int64
+	var resetDuration time.Duration
+
+	switch scope {
+	case "agent":
+		switch resource {
+		case ResourceOperations:
+			limit = q.config.Agent.MaxTotalOperationsPerHour
+			resetDuration = time.Hour
+		default:
+			limit = 1000000
+			resetDuration = time.Hour
+		}
+	case "tenant":
+		switch resource {
+		case ResourceStorage:
+			limit = q.config.Tenant.MaxStorageBytes
+			resetDuration = 0 // Never resets
+		case ResourceNetworkBytes:
+			limit = q.config.Tenant.MaxNetworkBytesPerDay
+			resetDuration = 24 * time.Hour
+		default:
+			limit = 1000000000
+			resetDuration = 24 * time.Hour
+		}
+	default:
+		limit = 1000000
+		resetDuration = time.Hour
+	}
+
+	resetAt := time.Time{}
+	if resetDuration > 0 {
+		resetAt = time.Now().Add(resetDuration)
+	}
+
+	quota = &ResourceQuota{
+		Resource: resource,
+		Limit:    limit,
+		Used:     0,
+		ResetAt:  resetAt,
+	}
+
+	q.quotas[key] = quota
+	return quota
+}
+
+// CheckAndConsume checks if quota allows consumption and consumes if so.
+func (q *QuotaManager) CheckAndConsume(ctx context.Context, scope, id string, resource ResourceType, amount int64) error {
+	quota := q.GetQuota(scope, id, resource)
+
+	quota.mu.Lock()
+	defer quota.mu.Unlock()
+
+	// Check if quota has reset
+	if !quota.ResetAt.IsZero() && time.Now().After(quota.ResetAt) {
+		quota.Used = 0
+		// Calculate next reset time
+		switch resource {
+		case ResourceOperations:
+			quota.ResetAt = time.Now().Add(time.Hour)
+		case ResourceNetworkBytes:
+			quota.ResetAt = time.Now().Add(24 * time.Hour)
+		}
+	}
+
+	// Check if consumption would exceed limit
+	if quota.Used+amount > quota.Limit {
+		err := &QuotaExceededError{
+			Resource:  resource,
+			Limit:     quota.Limit,
+			Used:      quota.Used,
+			Requested: amount,
+		}
+
+		q.mu.RLock()
+		onExceed := q.onExceed
+		q.mu.RUnlock()
+
+		if onExceed != nil {
+			onExceed(id, resource, err)
+		}
+
+		return err
+	}
+
+	// Consume quota
+	oldPct := quota.Percentage
+	quota.Used += amount
+	quota.Percentage = float64(quota.Used) / float64(quota.Limit) * 100
+
+	// Alert if crossing 80% threshold
+	if quota.Percentage > 80 && oldPct <= 80 {
+		q.mu.RLock()
+		onWarning := q.onWarning
+		q.mu.RUnlock()
+
+		if onWarning != nil {
+			onWarning(id, resource, quota.Percentage)
+		}
+	}
+
+	return nil
+}
+
+// GetUsage returns the current usage for a quota.
+func (q *QuotaManager) GetUsage(scope, id string, resource ResourceType) (used, limit int64, percentage float64) {
+	quota := q.GetQuota(scope, id, resource)
+
+	quota.mu.Lock()
+	defer quota.mu.Unlock()
+
+	return quota.Used, quota.Limit, quota.Percentage
+}
+
+// ResetQuota resets a quota to zero usage.
+func (q *QuotaManager) ResetQuota(scope, id string, resource ResourceType) {
+	quota := q.GetQuota(scope, id, resource)
+
+	quota.mu.Lock()
+	defer quota.mu.Unlock()
+
+	quota.Used = 0
+	quota.Percentage = 0
+}
+
+// SessionCounter tracks concurrent session counts.
+type SessionCounter struct {
+	config  Config
+	counts  map[string]int // key -> count
+	mu      sync.Mutex
+}
+
+// NewSessionCounter creates a new session counter.
+func NewSessionCounter(config Config) *SessionCounter {
+	return &SessionCounter{
+		config: config,
+		counts: make(map[string]int),
+	}
+}
+
+// TryAcquireSession attempts to acquire a session slot.
+func (c *SessionCounter) TryAcquireSession(agentID, tenantID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Check global limit
+	globalKey := "global"
+	if c.counts[globalKey] >= c.config.Global.MaxConcurrentSessions {
+		return fmt.Errorf("global session limit exceeded: %d", c.config.Global.MaxConcurrentSessions)
+	}
+
+	// Check agent limit
+	agentKey := "agent:" + agentID
+	if c.counts[agentKey] >= c.config.Agent.MaxConcurrentSessions {
+		return fmt.Errorf("agent session limit exceeded: %d", c.config.Agent.MaxConcurrentSessions)
+	}
+
+	// Check tenant limit
+	tenantKey := "tenant:" + tenantID
+	if c.counts[tenantKey] >= c.config.Tenant.MaxConcurrentSessions {
+		return fmt.Errorf("tenant session limit exceeded: %d", c.config.Tenant.MaxConcurrentSessions)
+	}
+
+	// Acquire slots
+	c.counts[globalKey]++
+	c.counts[agentKey]++
+	c.counts[tenantKey]++
+
+	return nil
+}
+
+// ReleaseSession releases a session slot.
+func (c *SessionCounter) ReleaseSession(agentID, tenantID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	globalKey := "global"
+	if c.counts[globalKey] > 0 {
+		c.counts[globalKey]--
+	}
+
+	agentKey := "agent:" + agentID
+	if c.counts[agentKey] > 0 {
+		c.counts[agentKey]--
+	}
+
+	tenantKey := "tenant:" + tenantID
+	if c.counts[tenantKey] > 0 {
+		c.counts[tenantKey]--
+	}
+}
+
+// GetCounts returns current session counts.
+func (c *SessionCounter) GetCounts() (global, agent, tenant map[string]int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	global = map[string]int{"global": c.counts["global"]}
+	agent = make(map[string]int)
+	tenant = make(map[string]int)
+
+	for k, v := range c.counts {
+		if len(k) > 6 && k[:6] == "agent:" {
+			agent[k[6:]] = v
+		} else if len(k) > 7 && k[:7] == "tenant:" {
+			tenant[k[7:]] = v
+		}
+	}
+
+	return
+}
+
+// ApprovalLimiter limits the number of pending approvals.
+type ApprovalLimiter struct {
+	maxPending int
+	pending    int
+	mu         sync.Mutex
+}
+
+// NewApprovalLimiter creates a new approval limiter.
+func NewApprovalLimiter(maxPending int) *ApprovalLimiter {
+	return &ApprovalLimiter{
+		maxPending: maxPending,
+	}
+}
+
+// TryAcquire attempts to acquire a pending approval slot.
+func (a *ApprovalLimiter) TryAcquire() bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.pending >= a.maxPending {
+		return false
+	}
+
+	a.pending++
+	return true
+}
+
+// Release releases a pending approval slot.
+func (a *ApprovalLimiter) Release() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.pending > 0 {
+		a.pending--
+	}
+}
+
+// Pending returns the current number of pending approvals.
+func (a *ApprovalLimiter) Pending() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.pending
+}
+
+// MaxPending returns the maximum allowed pending approvals.
+func (a *ApprovalLimiter) MaxPending() int {
+	return a.maxPending
+}

--- a/pkg/ratelimit/quota_test.go
+++ b/pkg/ratelimit/quota_test.go
@@ -1,0 +1,421 @@
+package ratelimit
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewQuotaManager(t *testing.T) {
+	cfg := DefaultConfig()
+	qm := NewQuotaManager(cfg)
+
+	if qm == nil {
+		t.Fatal("NewQuotaManager returned nil")
+	}
+}
+
+func TestQuotaManager_GetSessionLimiter(t *testing.T) {
+	cfg := DefaultConfig()
+	qm := NewQuotaManager(cfg)
+
+	l1 := qm.GetSessionLimiter("sess-1", ResourceFileOps)
+	if l1 == nil {
+		t.Fatal("GetSessionLimiter returned nil")
+	}
+
+	// Same session/resource should return same limiter
+	l2 := qm.GetSessionLimiter("sess-1", ResourceFileOps)
+	if l1 != l2 {
+		t.Error("GetSessionLimiter should return same instance for same session/resource")
+	}
+
+	// Different resource should return different limiter
+	l3 := qm.GetSessionLimiter("sess-1", ResourceNetworkConns)
+	if l1 == l3 {
+		t.Error("GetSessionLimiter should return different instance for different resource")
+	}
+}
+
+func TestQuotaManager_CheckRateLimit(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Session.FileOpsPerSecond = 5
+	cfg.Session.BurstMultiplier = 2
+	qm := NewQuotaManager(cfg)
+
+	// Should allow within burst
+	for i := 0; i < 10; i++ {
+		allowed, _ := qm.CheckRateLimit("sess-1", ResourceFileOps)
+		if !allowed {
+			t.Logf("Denied at attempt %d (expected around burst limit)", i+1)
+			break
+		}
+	}
+}
+
+func TestQuotaManager_CheckRateLimit_Action(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Session.FileOpsPerSecond = 1
+	cfg.Session.BurstMultiplier = 1
+	cfg.Actions.FileOps = LimitAction{
+		Action:  ActionThrottle,
+		DelayMs: 100,
+	}
+	qm := NewQuotaManager(cfg)
+
+	// Exhaust burst
+	qm.CheckRateLimit("sess-1", ResourceFileOps)
+
+	// Next should return action
+	allowed, action := qm.CheckRateLimit("sess-1", ResourceFileOps)
+	if allowed {
+		t.Error("Should not be allowed after burst exhausted")
+	}
+	if action.Action != ActionThrottle {
+		t.Errorf("Action = %v, want throttle", action.Action)
+	}
+	if action.DelayMs != 100 {
+		t.Errorf("DelayMs = %d, want 100", action.DelayMs)
+	}
+}
+
+func TestQuotaManager_WaitForRateLimit(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Session.FileOpsPerSecond = 1000
+	cfg.Session.BurstMultiplier = 1
+	cfg.Actions.FileOps = LimitAction{
+		Action:  ActionThrottle,
+		DelayMs: 10,
+	}
+	qm := NewQuotaManager(cfg)
+
+	ctx := context.Background()
+
+	// First should be immediate
+	err := qm.WaitForRateLimit(ctx, "sess-1", ResourceFileOps)
+	if err != nil {
+		t.Errorf("First WaitForRateLimit error: %v", err)
+	}
+
+	// Second should wait (throttle)
+	start := time.Now()
+	err = qm.WaitForRateLimit(ctx, "sess-1", ResourceFileOps)
+	if err != nil {
+		t.Errorf("Second WaitForRateLimit error: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < 5*time.Millisecond {
+		t.Logf("Elapsed = %v (expected some delay from throttle)", elapsed)
+	}
+}
+
+func TestQuotaManager_WaitForRateLimit_Block(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Session.NetworkConnsPerSecond = 1
+	cfg.Session.BurstMultiplier = 1
+	cfg.Actions.NetworkConns = LimitAction{
+		Action:  ActionBlock,
+		Message: "blocked",
+	}
+	qm := NewQuotaManager(cfg)
+
+	ctx := context.Background()
+
+	// First should succeed
+	err := qm.WaitForRateLimit(ctx, "sess-1", ResourceNetworkConns)
+	if err != nil {
+		t.Errorf("First WaitForRateLimit error: %v", err)
+	}
+
+	// Second should be blocked
+	err = qm.WaitForRateLimit(ctx, "sess-1", ResourceNetworkConns)
+	if err == nil {
+		t.Error("Second WaitForRateLimit should return error for block action")
+	}
+}
+
+func TestQuotaManager_GetQuota(t *testing.T) {
+	cfg := DefaultConfig()
+	qm := NewQuotaManager(cfg)
+
+	q := qm.GetQuota("agent", "agent-1", ResourceOperations)
+	if q == nil {
+		t.Fatal("GetQuota returned nil")
+	}
+	if q.Limit != cfg.Agent.MaxTotalOperationsPerHour {
+		t.Errorf("Limit = %d, want %d", q.Limit, cfg.Agent.MaxTotalOperationsPerHour)
+	}
+}
+
+func TestQuotaManager_CheckAndConsume(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Agent.MaxTotalOperationsPerHour = 100
+	qm := NewQuotaManager(cfg)
+
+	ctx := context.Background()
+
+	// Should succeed
+	err := qm.CheckAndConsume(ctx, "agent", "agent-1", ResourceOperations, 50)
+	if err != nil {
+		t.Errorf("CheckAndConsume error: %v", err)
+	}
+
+	// Check usage
+	used, limit, pct := qm.GetUsage("agent", "agent-1", ResourceOperations)
+	if used != 50 {
+		t.Errorf("used = %d, want 50", used)
+	}
+	if limit != 100 {
+		t.Errorf("limit = %d, want 100", limit)
+	}
+	if pct != 50 {
+		t.Errorf("percentage = %v, want 50", pct)
+	}
+}
+
+func TestQuotaManager_CheckAndConsume_Exceed(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Agent.MaxTotalOperationsPerHour = 100
+	qm := NewQuotaManager(cfg)
+
+	ctx := context.Background()
+
+	// Use 80
+	qm.CheckAndConsume(ctx, "agent", "agent-1", ResourceOperations, 80)
+
+	// Try to use 30 more (would exceed)
+	err := qm.CheckAndConsume(ctx, "agent", "agent-1", ResourceOperations, 30)
+	if err == nil {
+		t.Error("CheckAndConsume should return error when exceeding quota")
+	}
+
+	qerr, ok := err.(*QuotaExceededError)
+	if !ok {
+		t.Fatalf("expected QuotaExceededError, got %T", err)
+	}
+	if qerr.Limit != 100 {
+		t.Errorf("Limit = %d, want 100", qerr.Limit)
+	}
+	if qerr.Used != 80 {
+		t.Errorf("Used = %d, want 80", qerr.Used)
+	}
+	if qerr.Requested != 30 {
+		t.Errorf("Requested = %d, want 30", qerr.Requested)
+	}
+}
+
+func TestQuotaManager_WarningCallback(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Agent.MaxTotalOperationsPerHour = 100
+	qm := NewQuotaManager(cfg)
+
+	var warned bool
+	var warnedPct float64
+	qm.OnWarning(func(id string, resource ResourceType, pct float64) {
+		warned = true
+		warnedPct = pct
+	})
+
+	ctx := context.Background()
+
+	// Use 81% (should trigger warning)
+	qm.CheckAndConsume(ctx, "agent", "agent-1", ResourceOperations, 81)
+
+	if !warned {
+		t.Error("Warning callback should have been called")
+	}
+	if warnedPct != 81 {
+		t.Errorf("Warning percentage = %v, want 81", warnedPct)
+	}
+}
+
+func TestQuotaManager_ResetQuota(t *testing.T) {
+	cfg := DefaultConfig()
+	qm := NewQuotaManager(cfg)
+
+	ctx := context.Background()
+	qm.CheckAndConsume(ctx, "agent", "agent-1", ResourceOperations, 50)
+
+	qm.ResetQuota("agent", "agent-1", ResourceOperations)
+
+	used, _, _ := qm.GetUsage("agent", "agent-1", ResourceOperations)
+	if used != 0 {
+		t.Errorf("used = %d, want 0 after reset", used)
+	}
+}
+
+func TestQuotaExceededError_Error(t *testing.T) {
+	err := &QuotaExceededError{
+		Resource:  ResourceOperations,
+		Limit:     100,
+		Used:      80,
+		Requested: 30,
+	}
+
+	msg := err.Error()
+	if msg == "" {
+		t.Error("Error() returned empty string")
+	}
+}
+
+func TestNewSessionCounter(t *testing.T) {
+	cfg := DefaultConfig()
+	c := NewSessionCounter(cfg)
+
+	if c == nil {
+		t.Fatal("NewSessionCounter returned nil")
+	}
+}
+
+func TestSessionCounter_TryAcquireSession(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Agent.MaxConcurrentSessions = 2
+	cfg.Tenant.MaxConcurrentSessions = 3
+	cfg.Global.MaxConcurrentSessions = 5
+	c := NewSessionCounter(cfg)
+
+	// Should succeed
+	err := c.TryAcquireSession("agent-1", "tenant-1")
+	if err != nil {
+		t.Errorf("TryAcquireSession error: %v", err)
+	}
+
+	// Should succeed again
+	err = c.TryAcquireSession("agent-1", "tenant-1")
+	if err != nil {
+		t.Errorf("TryAcquireSession error: %v", err)
+	}
+
+	// Third should fail (agent limit = 2)
+	err = c.TryAcquireSession("agent-1", "tenant-1")
+	if err == nil {
+		t.Error("TryAcquireSession should fail when agent limit exceeded")
+	}
+}
+
+func TestSessionCounter_ReleaseSession(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Agent.MaxConcurrentSessions = 1
+	c := NewSessionCounter(cfg)
+
+	c.TryAcquireSession("agent-1", "tenant-1")
+
+	// Should fail (limit reached)
+	err := c.TryAcquireSession("agent-1", "tenant-1")
+	if err == nil {
+		t.Error("Should fail when limit reached")
+	}
+
+	// Release
+	c.ReleaseSession("agent-1", "tenant-1")
+
+	// Should succeed now
+	err = c.TryAcquireSession("agent-1", "tenant-1")
+	if err != nil {
+		t.Errorf("TryAcquireSession after release error: %v", err)
+	}
+}
+
+func TestSessionCounter_GetCounts(t *testing.T) {
+	cfg := DefaultConfig()
+	c := NewSessionCounter(cfg)
+
+	c.TryAcquireSession("agent-1", "tenant-1")
+	c.TryAcquireSession("agent-1", "tenant-1")
+	c.TryAcquireSession("agent-2", "tenant-1")
+
+	global, agent, tenant := c.GetCounts()
+
+	if global["global"] != 3 {
+		t.Errorf("global = %d, want 3", global["global"])
+	}
+	if agent["agent-1"] != 2 {
+		t.Errorf("agent-1 = %d, want 2", agent["agent-1"])
+	}
+	if agent["agent-2"] != 1 {
+		t.Errorf("agent-2 = %d, want 1", agent["agent-2"])
+	}
+	if tenant["tenant-1"] != 3 {
+		t.Errorf("tenant-1 = %d, want 3", tenant["tenant-1"])
+	}
+}
+
+func TestNewApprovalLimiter(t *testing.T) {
+	a := NewApprovalLimiter(10)
+
+	if a == nil {
+		t.Fatal("NewApprovalLimiter returned nil")
+	}
+	if a.MaxPending() != 10 {
+		t.Errorf("MaxPending() = %d, want 10", a.MaxPending())
+	}
+}
+
+func TestApprovalLimiter_TryAcquire(t *testing.T) {
+	a := NewApprovalLimiter(2)
+
+	if !a.TryAcquire() {
+		t.Error("First TryAcquire should succeed")
+	}
+	if !a.TryAcquire() {
+		t.Error("Second TryAcquire should succeed")
+	}
+	if a.TryAcquire() {
+		t.Error("Third TryAcquire should fail (limit = 2)")
+	}
+}
+
+func TestApprovalLimiter_Release(t *testing.T) {
+	a := NewApprovalLimiter(1)
+
+	a.TryAcquire()
+	if a.TryAcquire() {
+		t.Error("Should fail when limit reached")
+	}
+
+	a.Release()
+	if !a.TryAcquire() {
+		t.Error("Should succeed after release")
+	}
+}
+
+func TestApprovalLimiter_Pending(t *testing.T) {
+	a := NewApprovalLimiter(10)
+
+	if a.Pending() != 0 {
+		t.Errorf("Pending() = %d, want 0", a.Pending())
+	}
+
+	a.TryAcquire()
+	a.TryAcquire()
+
+	if a.Pending() != 2 {
+		t.Errorf("Pending() = %d, want 2", a.Pending())
+	}
+}
+
+func TestQuotaManager_Concurrent(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Agent.MaxTotalOperationsPerHour = 10000
+	qm := NewQuotaManager(cfg)
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+
+	// Concurrent consumption
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			qm.CheckAndConsume(ctx, "agent", "agent-1", ResourceOperations, 10)
+		}()
+	}
+
+	wg.Wait()
+
+	used, _, _ := qm.GetUsage("agent", "agent-1", ResourceOperations)
+	if used != 1000 {
+		t.Errorf("used = %d, want 1000", used)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `pkg/ratelimit` with rate limiting and quota management per spec §23.

## Components

### Rate Limiter (`limiter.go`)
- Token bucket algorithm with configurable rate and burst
- `Allow()` / `AllowN(n)` - non-blocking rate limit checks
- `Wait()` / `WaitN(n)` - blocking with delay until tokens available
- `Tokens()` - current available tokens
- `SetRate()` / `SetBurst()` - dynamic limit adjustment
- Thread-safe with proper token replenishment over time

### Configuration Types
```yaml
rate_limits:
  session:
    file_ops_per_second: 1000
    network_conns_per_second: 100
    dns_queries_per_second: 50
    burst_multiplier: 5
  agent:
    max_concurrent_sessions: 10
    max_total_operations_per_hour: 1000000
  tenant:
    max_concurrent_sessions: 100
    max_storage_bytes: 10737418240  # 10GB
    max_network_bytes_per_day: 107374182400  # 100GB
  global:
    max_concurrent_sessions: 1000
    max_pending_approvals: 100
```

### Quota Manager (`quota.go`)
- `CheckAndConsume()` - atomic quota check and consumption
- `GetUsage()` - current usage stats (used, limit, percentage)
- `ResetQuota()` - manual quota reset
- Warning callbacks at 80% usage threshold
- Exceed callbacks for quota violations
- Automatic reset based on time windows (hourly, daily)

### Session Counter
- `TryAcquireSession()` - hierarchical limit checks (global → tenant → agent)
- `ReleaseSession()` - cleanup on session end
- `GetCounts()` - current session counts by scope

### Approval Limiter
- `TryAcquire()` / `Release()` - limit pending approvals
- Prevents resource exhaustion from too many pending approvals

## Actions When Limits Exceeded
- **throttle**: Delay operations by configurable milliseconds
- **block**: Return error immediately
- **alert**: Allow but trigger notification

## Test plan

- [x] Token bucket rate limiting (allow, allowN, wait, replenishment)
- [x] Configuration defaults
- [x] Quota consumption and exceeding
- [x] Warning callback at 80% threshold
- [x] Session counter with hierarchical limits
- [x] Approval limiter acquire/release
- [x] Concurrent access safety
- [x] Tests pass: `go test ./pkg/ratelimit/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)