### PR TITLE
feat: add testing and simulation modes package (§24)

### DIFF
--- a/pkg/simulation/modes.go
+++ b/pkg/simulation/modes.go
@@ -1,0 +1,217 @@
+// Package simulation provides testing and simulation modes for agentsh.
+package simulation
+
+// ModeConfig defines simulation mode configuration.
+type ModeConfig struct {
+	// DryRun logs what would happen without enforcing
+	DryRun DryRunConfig `json:"dry_run" yaml:"dry_run"`
+
+	// Simulation runs against recorded sessions
+	Simulation SimulationConfig `json:"simulation" yaml:"simulation"`
+
+	// Permissive allows all but logs everything
+	Permissive PermissiveConfig `json:"permissive" yaml:"permissive"`
+
+	// Strict denies by default
+	Strict StrictConfig `json:"strict" yaml:"strict"`
+}
+
+// DryRunConfig configures dry-run mode.
+type DryRunConfig struct {
+	Enabled      bool `json:"enabled" yaml:"enabled"`
+	LogDecisions bool `json:"log_decisions" yaml:"log_decisions"`
+}
+
+// SimulationConfig configures simulation/replay mode.
+type SimulationConfig struct {
+	Enabled    bool   `json:"enabled" yaml:"enabled"`
+	ReplayFile string `json:"replay_file" yaml:"replay_file"`
+}
+
+// PermissiveConfig configures permissive mode.
+type PermissiveConfig struct {
+	Enabled bool `json:"enabled" yaml:"enabled"`
+}
+
+// StrictConfig configures strict mode.
+type StrictConfig struct {
+	Enabled bool `json:"enabled" yaml:"enabled"`
+}
+
+// DefaultModeConfig returns sensible defaults.
+func DefaultModeConfig() ModeConfig {
+	return ModeConfig{
+		DryRun: DryRunConfig{
+			Enabled:      false,
+			LogDecisions: true,
+		},
+		Simulation: SimulationConfig{
+			Enabled: false,
+		},
+		Permissive: PermissiveConfig{
+			Enabled: false,
+		},
+		Strict: StrictConfig{
+			Enabled: true,
+		},
+	}
+}
+
+// Mode represents the current operational mode.
+type Mode string
+
+const (
+	ModeNormal     Mode = "normal"
+	ModeDryRun     Mode = "dry_run"
+	ModeSimulation Mode = "simulation"
+	ModePermissive Mode = "permissive"
+	ModeStrict     Mode = "strict"
+)
+
+// Decision represents a policy decision.
+type Decision string
+
+const (
+	DecisionAllow    Decision = "allow"
+	DecisionDeny     Decision = "deny"
+	DecisionApprove  Decision = "approve"
+	DecisionRedirect Decision = "redirect"
+	DecisionAudit    Decision = "audit"
+)
+
+// ModeManager manages operational modes.
+type ModeManager struct {
+	config      ModeConfig
+	currentMode Mode
+	logger      DecisionLogger
+}
+
+// DecisionLogger logs decisions in various modes.
+type DecisionLogger interface {
+	LogDecision(op *Operation, decision Decision, wouldEnforce bool)
+}
+
+// Operation represents an operation being evaluated.
+type Operation struct {
+	Type        string            `json:"type"`
+	Path        string            `json:"path,omitempty"`
+	Domain      string            `json:"domain,omitempty"`
+	Variable    string            `json:"variable,omitempty"`
+	ProcessName string            `json:"process_name,omitempty"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+}
+
+// NewModeManager creates a new mode manager.
+func NewModeManager(config ModeConfig, logger DecisionLogger) *ModeManager {
+	m := &ModeManager{
+		config: config,
+		logger: logger,
+	}
+	m.currentMode = m.detectMode()
+	return m
+}
+
+// detectMode determines the active mode from config.
+func (m *ModeManager) detectMode() Mode {
+	if m.config.DryRun.Enabled {
+		return ModeDryRun
+	}
+	if m.config.Simulation.Enabled {
+		return ModeSimulation
+	}
+	if m.config.Permissive.Enabled {
+		return ModePermissive
+	}
+	if m.config.Strict.Enabled {
+		return ModeStrict
+	}
+	return ModeNormal
+}
+
+// CurrentMode returns the current operational mode.
+func (m *ModeManager) CurrentMode() Mode {
+	return m.currentMode
+}
+
+// SetMode changes the operational mode.
+func (m *ModeManager) SetMode(mode Mode) {
+	m.currentMode = mode
+}
+
+// ShouldEnforce returns whether decisions should be enforced.
+func (m *ModeManager) ShouldEnforce() bool {
+	switch m.currentMode {
+	case ModeDryRun:
+		return false
+	case ModePermissive:
+		return false
+	default:
+		return true
+	}
+}
+
+// ShouldLog returns whether decisions should be logged.
+func (m *ModeManager) ShouldLog() bool {
+	switch m.currentMode {
+	case ModeDryRun:
+		return m.config.DryRun.LogDecisions
+	case ModePermissive:
+		return true
+	default:
+		return true
+	}
+}
+
+// DefaultDecision returns the default decision for the current mode.
+func (m *ModeManager) DefaultDecision() Decision {
+	switch m.currentMode {
+	case ModePermissive:
+		return DecisionAllow
+	case ModeStrict:
+		return DecisionDeny
+	default:
+		return DecisionDeny
+	}
+}
+
+// ProcessDecision processes a decision based on the current mode.
+func (m *ModeManager) ProcessDecision(op *Operation, decision Decision) Decision {
+	wouldEnforce := m.ShouldEnforce()
+
+	// Log if needed
+	if m.ShouldLog() && m.logger != nil {
+		m.logger.LogDecision(op, decision, wouldEnforce)
+	}
+
+	// In dry-run and permissive modes, always allow
+	if !wouldEnforce {
+		return DecisionAllow
+	}
+
+	return decision
+}
+
+// IsDryRun returns whether dry-run mode is active.
+func (m *ModeManager) IsDryRun() bool {
+	return m.currentMode == ModeDryRun
+}
+
+// IsSimulation returns whether simulation mode is active.
+func (m *ModeManager) IsSimulation() bool {
+	return m.currentMode == ModeSimulation
+}
+
+// IsPermissive returns whether permissive mode is active.
+func (m *ModeManager) IsPermissive() bool {
+	return m.currentMode == ModePermissive
+}
+
+// IsStrict returns whether strict mode is active.
+func (m *ModeManager) IsStrict() bool {
+	return m.currentMode == ModeStrict
+}
+
+// Config returns the current mode configuration.
+func (m *ModeManager) Config() ModeConfig {
+	return m.config
+}

--- a/pkg/simulation/modes_test.go
+++ b/pkg/simulation/modes_test.go
@@ -1,0 +1,192 @@
+package simulation
+
+import (
+	"testing"
+)
+
+func TestDefaultModeConfig(t *testing.T) {
+	cfg := DefaultModeConfig()
+
+	if cfg.DryRun.Enabled {
+		t.Error("DryRun should be disabled by default")
+	}
+	if !cfg.DryRun.LogDecisions {
+		t.Error("DryRun.LogDecisions should be true by default")
+	}
+	if !cfg.Strict.Enabled {
+		t.Error("Strict should be enabled by default")
+	}
+}
+
+type mockLogger struct {
+	calls []struct {
+		op          *Operation
+		decision    Decision
+		wouldEnforce bool
+	}
+}
+
+func (m *mockLogger) LogDecision(op *Operation, decision Decision, wouldEnforce bool) {
+	m.calls = append(m.calls, struct {
+		op           *Operation
+		decision     Decision
+		wouldEnforce bool
+	}{op, decision, wouldEnforce})
+}
+
+func TestNewModeManager(t *testing.T) {
+	cfg := DefaultModeConfig()
+	logger := &mockLogger{}
+	mm := NewModeManager(cfg, logger)
+
+	if mm == nil {
+		t.Fatal("NewModeManager returned nil")
+	}
+
+	// Should be strict by default
+	if mm.CurrentMode() != ModeStrict {
+		t.Errorf("CurrentMode() = %v, want strict", mm.CurrentMode())
+	}
+}
+
+func TestModeManager_DryRunMode(t *testing.T) {
+	cfg := DefaultModeConfig()
+	cfg.DryRun.Enabled = true
+	cfg.Strict.Enabled = false
+	logger := &mockLogger{}
+	mm := NewModeManager(cfg, logger)
+
+	if mm.CurrentMode() != ModeDryRun {
+		t.Errorf("CurrentMode() = %v, want dry_run", mm.CurrentMode())
+	}
+
+	if mm.ShouldEnforce() {
+		t.Error("ShouldEnforce() should return false in dry-run mode")
+	}
+
+	if !mm.IsDryRun() {
+		t.Error("IsDryRun() should return true")
+	}
+}
+
+func TestModeManager_PermissiveMode(t *testing.T) {
+	cfg := DefaultModeConfig()
+	cfg.Permissive.Enabled = true
+	cfg.Strict.Enabled = false
+	logger := &mockLogger{}
+	mm := NewModeManager(cfg, logger)
+
+	if mm.CurrentMode() != ModePermissive {
+		t.Errorf("CurrentMode() = %v, want permissive", mm.CurrentMode())
+	}
+
+	if mm.ShouldEnforce() {
+		t.Error("ShouldEnforce() should return false in permissive mode")
+	}
+
+	if mm.DefaultDecision() != DecisionAllow {
+		t.Errorf("DefaultDecision() = %v, want allow", mm.DefaultDecision())
+	}
+}
+
+func TestModeManager_StrictMode(t *testing.T) {
+	cfg := DefaultModeConfig()
+	mm := NewModeManager(cfg, nil)
+
+	if mm.CurrentMode() != ModeStrict {
+		t.Errorf("CurrentMode() = %v, want strict", mm.CurrentMode())
+	}
+
+	if !mm.ShouldEnforce() {
+		t.Error("ShouldEnforce() should return true in strict mode")
+	}
+
+	if mm.DefaultDecision() != DecisionDeny {
+		t.Errorf("DefaultDecision() = %v, want deny", mm.DefaultDecision())
+	}
+}
+
+func TestModeManager_ProcessDecision_DryRun(t *testing.T) {
+	cfg := DefaultModeConfig()
+	cfg.DryRun.Enabled = true
+	cfg.DryRun.LogDecisions = true
+	cfg.Strict.Enabled = false
+	logger := &mockLogger{}
+	mm := NewModeManager(cfg, logger)
+
+	op := &Operation{Type: "file_read", Path: "/etc/passwd"}
+
+	// In dry-run, deny should become allow
+	result := mm.ProcessDecision(op, DecisionDeny)
+	if result != DecisionAllow {
+		t.Errorf("ProcessDecision() = %v, want allow (dry-run converts deny)", result)
+	}
+
+	// Should have logged
+	if len(logger.calls) != 1 {
+		t.Errorf("Expected 1 log call, got %d", len(logger.calls))
+	}
+	if logger.calls[0].wouldEnforce {
+		t.Error("wouldEnforce should be false in dry-run")
+	}
+}
+
+func TestModeManager_ProcessDecision_Strict(t *testing.T) {
+	cfg := DefaultModeConfig()
+	logger := &mockLogger{}
+	mm := NewModeManager(cfg, logger)
+
+	op := &Operation{Type: "file_read", Path: "/etc/passwd"}
+
+	// In strict mode, deny stays deny
+	result := mm.ProcessDecision(op, DecisionDeny)
+	if result != DecisionDeny {
+		t.Errorf("ProcessDecision() = %v, want deny", result)
+	}
+
+	// Should have logged
+	if len(logger.calls) != 1 {
+		t.Errorf("Expected 1 log call, got %d", len(logger.calls))
+	}
+	if !logger.calls[0].wouldEnforce {
+		t.Error("wouldEnforce should be true in strict mode")
+	}
+}
+
+func TestModeManager_SetMode(t *testing.T) {
+	cfg := DefaultModeConfig()
+	mm := NewModeManager(cfg, nil)
+
+	mm.SetMode(ModePermissive)
+	if mm.CurrentMode() != ModePermissive {
+		t.Errorf("CurrentMode() = %v, want permissive", mm.CurrentMode())
+	}
+}
+
+func TestMode_Constants(t *testing.T) {
+	modes := []Mode{ModeNormal, ModeDryRun, ModeSimulation, ModePermissive, ModeStrict}
+	for _, m := range modes {
+		if string(m) == "" {
+			t.Error("Mode constant is empty")
+		}
+	}
+}
+
+func TestDecision_Constants(t *testing.T) {
+	decisions := []Decision{DecisionAllow, DecisionDeny, DecisionApprove, DecisionRedirect, DecisionAudit}
+	for _, d := range decisions {
+		if string(d) == "" {
+			t.Error("Decision constant is empty")
+		}
+	}
+}
+
+func TestModeManager_Config(t *testing.T) {
+	cfg := DefaultModeConfig()
+	mm := NewModeManager(cfg, nil)
+
+	got := mm.Config()
+	if got.Strict.Enabled != cfg.Strict.Enabled {
+		t.Error("Config() should return the configuration")
+	}
+}

--- a/pkg/simulation/recording.go
+++ b/pkg/simulation/recording.go
@@ -1,0 +1,326 @@
+package simulation
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+// RecordedEvent represents a recorded operation event.
+type RecordedEvent struct {
+	Timestamp  time.Time       `json:"ts"`
+	Type       string          `json:"type"`
+	SessionID  string          `json:"session_id,omitempty"`
+	AgentID    string          `json:"agent_id,omitempty"`
+	Request    json.RawMessage `json:"request"`
+	Decision   string          `json:"decision"`
+	PolicyRule string          `json:"policy_rule,omitempty"`
+	Latency    time.Duration   `json:"latency_ns"`
+}
+
+// SessionRecorder records session events to a file.
+type SessionRecorder struct {
+	sessionID  string
+	output     io.WriteCloser
+	encoder    *json.Encoder
+	mu         sync.Mutex
+	eventCount int
+	startTime  time.Time
+	closed     bool
+}
+
+// RecorderConfig configures the session recorder.
+type RecorderConfig struct {
+	SessionID  string
+	OutputPath string
+	Append     bool
+}
+
+// NewSessionRecorder creates a new session recorder.
+func NewSessionRecorder(config RecorderConfig) (*SessionRecorder, error) {
+	flags := os.O_CREATE | os.O_WRONLY
+	if config.Append {
+		flags |= os.O_APPEND
+	} else {
+		flags |= os.O_TRUNC
+	}
+
+	file, err := os.OpenFile(config.OutputPath, flags, 0644)
+	if err != nil {
+		return nil, fmt.Errorf("opening output file: %w", err)
+	}
+
+	return &SessionRecorder{
+		sessionID: config.SessionID,
+		output:    file,
+		encoder:   json.NewEncoder(file),
+		startTime: time.Now(),
+	}, nil
+}
+
+// NewSessionRecorderWriter creates a recorder with a custom writer.
+func NewSessionRecorderWriter(sessionID string, w io.WriteCloser) *SessionRecorder {
+	return &SessionRecorder{
+		sessionID: sessionID,
+		output:    w,
+		encoder:   json.NewEncoder(w),
+		startTime: time.Now(),
+	}
+}
+
+// Record records an event.
+func (r *SessionRecorder) Record(op *Operation, decision Decision, policyRule string, latency time.Duration) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closed {
+		return fmt.Errorf("recorder is closed")
+	}
+
+	request, err := json.Marshal(op)
+	if err != nil {
+		return fmt.Errorf("marshaling request: %w", err)
+	}
+
+	event := RecordedEvent{
+		Timestamp:  time.Now(),
+		Type:       op.Type,
+		SessionID:  r.sessionID,
+		Request:    request,
+		Decision:   string(decision),
+		PolicyRule: policyRule,
+		Latency:    latency,
+	}
+
+	if err := r.encoder.Encode(event); err != nil {
+		return fmt.Errorf("encoding event: %w", err)
+	}
+
+	r.eventCount++
+	return nil
+}
+
+// RecordRaw records a raw event.
+func (r *SessionRecorder) RecordRaw(event RecordedEvent) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closed {
+		return fmt.Errorf("recorder is closed")
+	}
+
+	if err := r.encoder.Encode(event); err != nil {
+		return fmt.Errorf("encoding event: %w", err)
+	}
+
+	r.eventCount++
+	return nil
+}
+
+// EventCount returns the number of recorded events.
+func (r *SessionRecorder) EventCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.eventCount
+}
+
+// Duration returns the recording duration.
+func (r *SessionRecorder) Duration() time.Duration {
+	return time.Since(r.startTime)
+}
+
+// Close closes the recorder.
+func (r *SessionRecorder) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closed {
+		return nil
+	}
+
+	r.closed = true
+	return r.output.Close()
+}
+
+// SessionReplayer replays recorded sessions against a policy.
+type SessionReplayer struct {
+	recordingPath string
+	evaluator     PolicyEvaluator
+}
+
+// ReplayResults contains the results of replaying a session.
+type ReplayResults struct {
+	TotalEvents int          `json:"total_events"`
+	Matched     int          `json:"matched"`
+	Differences []Difference `json:"differences,omitempty"`
+	Errors      []string     `json:"errors,omitempty"`
+}
+
+// Difference describes a decision difference during replay.
+type Difference struct {
+	Event       RecordedEvent `json:"event"`
+	OldDecision string        `json:"old_decision"`
+	NewDecision string        `json:"new_decision"`
+	OldRule     string        `json:"old_rule,omitempty"`
+	NewRule     string        `json:"new_rule,omitempty"`
+}
+
+// NewSessionReplayer creates a new session replayer.
+func NewSessionReplayer(recordingPath string, evaluator PolicyEvaluator) *SessionReplayer {
+	return &SessionReplayer{
+		recordingPath: recordingPath,
+		evaluator:     evaluator,
+	}
+}
+
+// Replay replays the recorded session and compares decisions.
+func (r *SessionReplayer) Replay() (*ReplayResults, error) {
+	file, err := os.Open(r.recordingPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening recording: %w", err)
+	}
+	defer file.Close()
+
+	return r.ReplayReader(file)
+}
+
+// ReplayReader replays from a reader.
+func (r *SessionReplayer) ReplayReader(reader io.Reader) (*ReplayResults, error) {
+	results := &ReplayResults{}
+	scanner := bufio.NewScanner(reader)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event RecordedEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			results.Errors = append(results.Errors, fmt.Sprintf("parsing event: %v", err))
+			continue
+		}
+
+		results.TotalEvents++
+
+		// Parse the request back to an Operation
+		var op Operation
+		if err := json.Unmarshal(event.Request, &op); err != nil {
+			results.Errors = append(results.Errors, fmt.Sprintf("parsing request: %v", err))
+			continue
+		}
+
+		// Evaluate with current policy
+		newResult := r.evaluator.Evaluate(&op)
+
+		if newResult.Decision == event.Decision {
+			results.Matched++
+		} else {
+			results.Differences = append(results.Differences, Difference{
+				Event:       event,
+				OldDecision: event.Decision,
+				NewDecision: newResult.Decision,
+				OldRule:     event.PolicyRule,
+				NewRule:     newResult.PolicyRule,
+			})
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading recording: %w", err)
+	}
+
+	return results, nil
+}
+
+// Summary returns a human-readable summary.
+func (r *ReplayResults) Summary() string {
+	if r.TotalEvents == 0 {
+		return "No events replayed"
+	}
+
+	diffCount := len(r.Differences)
+	if diffCount == 0 {
+		return fmt.Sprintf("MATCH: All %d events matched", r.TotalEvents)
+	}
+
+	return fmt.Sprintf("DIFF: %d/%d events differ (%d matched)",
+		diffCount, r.TotalEvents, r.Matched)
+}
+
+// HasDifferences returns true if there are any differences.
+func (r *ReplayResults) HasDifferences() bool {
+	return len(r.Differences) > 0
+}
+
+// LoadRecording loads all events from a recording file.
+func LoadRecording(path string) ([]RecordedEvent, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var events []RecordedEvent
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var event RecordedEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			continue
+		}
+		events = append(events, event)
+	}
+
+	return events, scanner.Err()
+}
+
+// RecordingStats returns statistics about a recording.
+type RecordingStats struct {
+	EventCount    int                  `json:"event_count"`
+	Duration      time.Duration        `json:"duration"`
+	FirstEvent    time.Time            `json:"first_event"`
+	LastEvent     time.Time            `json:"last_event"`
+	EventsByType  map[string]int       `json:"events_by_type"`
+	DecisionCount map[string]int       `json:"decisions"`
+	SessionID     string               `json:"session_id,omitempty"`
+}
+
+// GetRecordingStats returns statistics about a recording file.
+func GetRecordingStats(path string) (*RecordingStats, error) {
+	events, err := LoadRecording(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(events) == 0 {
+		return &RecordingStats{}, nil
+	}
+
+	stats := &RecordingStats{
+		EventCount:    len(events),
+		EventsByType:  make(map[string]int),
+		DecisionCount: make(map[string]int),
+		FirstEvent:    events[0].Timestamp,
+		LastEvent:     events[len(events)-1].Timestamp,
+		SessionID:     events[0].SessionID,
+	}
+
+	for _, e := range events {
+		stats.EventsByType[e.Type]++
+		stats.DecisionCount[e.Decision]++
+	}
+
+	stats.Duration = stats.LastEvent.Sub(stats.FirstEvent)
+
+	return stats, nil
+}

--- a/pkg/simulation/recording_test.go
+++ b/pkg/simulation/recording_test.go
@@ -1,0 +1,317 @@
+package simulation
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+type nopCloser struct {
+	io.Writer
+}
+
+func (nopCloser) Close() error { return nil }
+
+func TestNewSessionRecorder(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "recording.jsonl")
+
+	r, err := NewSessionRecorder(RecorderConfig{
+		SessionID:  "sess-123",
+		OutputPath: path,
+	})
+	if err != nil {
+		t.Fatalf("NewSessionRecorder error: %v", err)
+	}
+	defer r.Close()
+
+	if r == nil {
+		t.Fatal("NewSessionRecorder returned nil")
+	}
+}
+
+func TestSessionRecorder_Record(t *testing.T) {
+	buf := &bytes.Buffer{}
+	r := NewSessionRecorderWriter("sess-123", nopCloser{buf})
+
+	op := &Operation{
+		Type: "file_read",
+		Path: "/workspace/file.txt",
+	}
+
+	err := r.Record(op, DecisionAllow, "workspace", 100*time.Microsecond)
+	if err != nil {
+		t.Fatalf("Record error: %v", err)
+	}
+
+	if r.EventCount() != 1 {
+		t.Errorf("EventCount() = %d, want 1", r.EventCount())
+	}
+
+	// Parse the output
+	var event RecordedEvent
+	if err := json.Unmarshal(buf.Bytes(), &event); err != nil {
+		t.Fatalf("Unmarshal error: %v", err)
+	}
+
+	if event.Type != "file_read" {
+		t.Errorf("Type = %q, want file_read", event.Type)
+	}
+	if event.Decision != "allow" {
+		t.Errorf("Decision = %q, want allow", event.Decision)
+	}
+	if event.PolicyRule != "workspace" {
+		t.Errorf("PolicyRule = %q, want workspace", event.PolicyRule)
+	}
+	if event.SessionID != "sess-123" {
+		t.Errorf("SessionID = %q, want sess-123", event.SessionID)
+	}
+}
+
+func TestSessionRecorder_RecordMultiple(t *testing.T) {
+	buf := &bytes.Buffer{}
+	r := NewSessionRecorderWriter("sess-123", nopCloser{buf})
+
+	for i := 0; i < 3; i++ {
+		op := &Operation{Type: "file_read", Path: "/test"}
+		r.Record(op, DecisionAllow, "", time.Microsecond)
+	}
+
+	if r.EventCount() != 3 {
+		t.Errorf("EventCount() = %d, want 3", r.EventCount())
+	}
+
+	// Should be 3 newline-delimited JSON objects
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 {
+		t.Errorf("got %d lines, want 3", len(lines))
+	}
+}
+
+func TestSessionRecorder_Duration(t *testing.T) {
+	buf := &bytes.Buffer{}
+	r := NewSessionRecorderWriter("sess-123", nopCloser{buf})
+
+	time.Sleep(10 * time.Millisecond)
+
+	d := r.Duration()
+	if d < 10*time.Millisecond {
+		t.Errorf("Duration() = %v, expected >= 10ms", d)
+	}
+}
+
+func TestSessionRecorder_CloseIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "recording.jsonl")
+
+	r, err := NewSessionRecorder(RecorderConfig{
+		SessionID:  "sess-123",
+		OutputPath: path,
+	})
+	if err != nil {
+		t.Fatalf("NewSessionRecorder error: %v", err)
+	}
+
+	// Close should be idempotent
+	if err := r.Close(); err != nil {
+		t.Errorf("First Close() error: %v", err)
+	}
+	if err := r.Close(); err != nil {
+		t.Errorf("Second Close() error: %v", err)
+	}
+
+	// Recording after close should error
+	op := &Operation{Type: "test"}
+	if err := r.Record(op, DecisionAllow, "", 0); err == nil {
+		t.Error("Record() should error after Close()")
+	}
+}
+
+func TestNewSessionReplayer(t *testing.T) {
+	eval := &mockEvaluator{}
+	r := NewSessionReplayer("/path/to/recording.jsonl", eval)
+
+	if r == nil {
+		t.Fatal("NewSessionReplayer returned nil")
+	}
+}
+
+func TestSessionReplayer_ReplayReader(t *testing.T) {
+	eval := &mockEvaluator{
+		results: map[string]TestResult{
+			"file_read:/workspace/file.txt": {Decision: "allow"},
+			"file_read:/etc/passwd":         {Decision: "deny"}, // Changed from allow
+		},
+	}
+
+	// Create recording data
+	events := []RecordedEvent{
+		{
+			Type:     "file_read",
+			Decision: "allow",
+			Request:  json.RawMessage(`{"type":"file_read","path":"/workspace/file.txt"}`),
+		},
+		{
+			Type:     "file_read",
+			Decision: "allow", // Was allow, now deny
+			Request:  json.RawMessage(`{"type":"file_read","path":"/etc/passwd"}`),
+		},
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	for _, e := range events {
+		enc.Encode(e)
+	}
+
+	r := NewSessionReplayer("", eval)
+	results, err := r.ReplayReader(&buf)
+	if err != nil {
+		t.Fatalf("ReplayReader error: %v", err)
+	}
+
+	if results.TotalEvents != 2 {
+		t.Errorf("TotalEvents = %d, want 2", results.TotalEvents)
+	}
+	if results.Matched != 1 {
+		t.Errorf("Matched = %d, want 1", results.Matched)
+	}
+	if len(results.Differences) != 1 {
+		t.Errorf("Differences = %d, want 1", len(results.Differences))
+	}
+
+	if results.Differences[0].OldDecision != "allow" {
+		t.Errorf("OldDecision = %q, want allow", results.Differences[0].OldDecision)
+	}
+	if results.Differences[0].NewDecision != "deny" {
+		t.Errorf("NewDecision = %q, want deny", results.Differences[0].NewDecision)
+	}
+}
+
+func TestReplayResults_Summary(t *testing.T) {
+	tests := []struct {
+		results *ReplayResults
+		want    string
+	}{
+		{
+			results: &ReplayResults{TotalEvents: 0},
+			want:    "No events replayed",
+		},
+		{
+			results: &ReplayResults{TotalEvents: 10, Matched: 10},
+			want:    "MATCH: All 10 events matched",
+		},
+		{
+			results: &ReplayResults{
+				TotalEvents: 10,
+				Matched:     8,
+				Differences: make([]Difference, 2),
+			},
+			want: "DIFF: 2/10 events differ (8 matched)",
+		},
+	}
+
+	for _, tt := range tests {
+		got := tt.results.Summary()
+		if got != tt.want {
+			t.Errorf("Summary() = %q, want %q", got, tt.want)
+		}
+	}
+}
+
+func TestReplayResults_HasDifferences(t *testing.T) {
+	r := &ReplayResults{}
+	if r.HasDifferences() {
+		t.Error("HasDifferences() should return false with no differences")
+	}
+
+	r.Differences = []Difference{{}}
+	if !r.HasDifferences() {
+		t.Error("HasDifferences() should return true with differences")
+	}
+}
+
+func TestLoadRecording(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "recording.jsonl")
+
+	// Create recording file
+	events := []RecordedEvent{
+		{Type: "file_read", Decision: "allow", Request: json.RawMessage(`{}`)},
+		{Type: "net_connect", Decision: "deny", Request: json.RawMessage(`{}`)},
+	}
+
+	f, _ := os.Create(path)
+	enc := json.NewEncoder(f)
+	for _, e := range events {
+		enc.Encode(e)
+	}
+	f.Close()
+
+	loaded, err := LoadRecording(path)
+	if err != nil {
+		t.Fatalf("LoadRecording error: %v", err)
+	}
+
+	if len(loaded) != 2 {
+		t.Errorf("loaded %d events, want 2", len(loaded))
+	}
+}
+
+func TestGetRecordingStats(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "recording.jsonl")
+
+	now := time.Now()
+	events := []RecordedEvent{
+		{Type: "file_read", Decision: "allow", Timestamp: now, SessionID: "sess-1", Request: json.RawMessage(`{}`)},
+		{Type: "file_read", Decision: "allow", Timestamp: now.Add(time.Second), Request: json.RawMessage(`{}`)},
+		{Type: "net_connect", Decision: "deny", Timestamp: now.Add(2 * time.Second), Request: json.RawMessage(`{}`)},
+	}
+
+	f, _ := os.Create(path)
+	enc := json.NewEncoder(f)
+	for _, e := range events {
+		enc.Encode(e)
+	}
+	f.Close()
+
+	stats, err := GetRecordingStats(path)
+	if err != nil {
+		t.Fatalf("GetRecordingStats error: %v", err)
+	}
+
+	if stats.EventCount != 3 {
+		t.Errorf("EventCount = %d, want 3", stats.EventCount)
+	}
+	if stats.EventsByType["file_read"] != 2 {
+		t.Errorf("EventsByType[file_read] = %d, want 2", stats.EventsByType["file_read"])
+	}
+	if stats.DecisionCount["allow"] != 2 {
+		t.Errorf("DecisionCount[allow] = %d, want 2", stats.DecisionCount["allow"])
+	}
+	if stats.SessionID != "sess-1" {
+		t.Errorf("SessionID = %q, want sess-1", stats.SessionID)
+	}
+}
+
+func TestGetRecordingStats_Empty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.jsonl")
+
+	os.WriteFile(path, []byte{}, 0644)
+
+	stats, err := GetRecordingStats(path)
+	if err != nil {
+		t.Fatalf("GetRecordingStats error: %v", err)
+	}
+
+	if stats.EventCount != 0 {
+		t.Errorf("EventCount = %d, want 0", stats.EventCount)
+	}
+}

--- a/pkg/simulation/testing.go
+++ b/pkg/simulation/testing.go
@@ -1,0 +1,246 @@
+package simulation
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// PolicyTestCase represents a single policy test case.
+type PolicyTestCase struct {
+	Name        string         `yaml:"name" json:"name"`
+	Description string         `yaml:"description,omitempty" json:"description,omitempty"`
+	Operation   TestOperation  `yaml:"operation" json:"operation"`
+	Expected    ExpectedResult `yaml:"expected" json:"expected"`
+}
+
+// TestOperation defines the operation to test.
+type TestOperation struct {
+	Type        string            `yaml:"type" json:"type"`
+	Path        string            `yaml:"path,omitempty" json:"path,omitempty"`
+	Domain      string            `yaml:"domain,omitempty" json:"domain,omitempty"`
+	Port        int               `yaml:"port,omitempty" json:"port,omitempty"`
+	Variable    string            `yaml:"variable,omitempty" json:"variable,omitempty"`
+	Command     string            `yaml:"command,omitempty" json:"command,omitempty"`
+	ProcessName string            `yaml:"process_name,omitempty" json:"process_name,omitempty"`
+	Metadata    map[string]string `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+}
+
+// ToOperation converts TestOperation to Operation.
+func (t *TestOperation) ToOperation() *Operation {
+	return &Operation{
+		Type:        t.Type,
+		Path:        t.Path,
+		Domain:      t.Domain,
+		Variable:    t.Variable,
+		ProcessName: t.ProcessName,
+		Metadata:    t.Metadata,
+	}
+}
+
+// ExpectedResult defines the expected outcome of a test.
+type ExpectedResult struct {
+	Decision   string `yaml:"decision" json:"decision"`
+	PolicyRule string `yaml:"policy_rule,omitempty" json:"policy_rule,omitempty"`
+	RedirectTo string `yaml:"redirect_to,omitempty" json:"redirect_to,omitempty"`
+	Message    string `yaml:"message,omitempty" json:"message,omitempty"`
+}
+
+// PolicyTestFile represents a file containing test cases.
+type PolicyTestFile struct {
+	Tests []PolicyTestCase `yaml:"tests" json:"tests"`
+}
+
+// TestResults contains the results of running policy tests.
+type TestResults struct {
+	Passed  int            `json:"passed"`
+	Failed  int            `json:"failed"`
+	Skipped int            `json:"skipped"`
+	Total   int            `json:"total"`
+	Errors  []TestFailure  `json:"errors,omitempty"`
+}
+
+// TestFailure describes a failed test.
+type TestFailure struct {
+	TestName    string         `json:"test_name"`
+	Description string         `json:"description,omitempty"`
+	Operation   TestOperation  `json:"operation"`
+	Expected    ExpectedResult `json:"expected"`
+	Got         TestResult     `json:"got"`
+	Error       string         `json:"error,omitempty"`
+}
+
+// TestResult is the actual result from evaluation.
+type TestResult struct {
+	Decision   string `json:"decision"`
+	PolicyRule string `json:"policy_rule,omitempty"`
+	RedirectTo string `json:"redirect_to,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+// PolicyEvaluator evaluates operations against policies.
+type PolicyEvaluator interface {
+	Evaluate(op *Operation) TestResult
+}
+
+// PolicyTester runs policy tests.
+type PolicyTester struct {
+	evaluator PolicyEvaluator
+}
+
+// NewPolicyTester creates a new policy tester.
+func NewPolicyTester(evaluator PolicyEvaluator) *PolicyTester {
+	return &PolicyTester{
+		evaluator: evaluator,
+	}
+}
+
+// RunTests runs a set of test cases.
+func (p *PolicyTester) RunTests(tests []PolicyTestCase) *TestResults {
+	results := &TestResults{
+		Total: len(tests),
+	}
+
+	for _, test := range tests {
+		result := p.evaluator.Evaluate(test.Operation.ToOperation())
+
+		if p.compareResults(test.Expected, result) {
+			results.Passed++
+		} else {
+			results.Failed++
+			results.Errors = append(results.Errors, TestFailure{
+				TestName:    test.Name,
+				Description: test.Description,
+				Operation:   test.Operation,
+				Expected:    test.Expected,
+				Got:         result,
+			})
+		}
+	}
+
+	return results
+}
+
+// RunTestFile runs tests from a file.
+func (p *PolicyTester) RunTestFile(path string) (*TestResults, error) {
+	tests, err := LoadTestFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return p.RunTests(tests), nil
+}
+
+// RunTestDir runs all test files in a directory.
+func (p *PolicyTester) RunTestDir(dir string) (*TestResults, error) {
+	combined := &TestResults{}
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		if !isTestFile(path) {
+			return nil
+		}
+
+		results, err := p.RunTestFile(path)
+		if err != nil {
+			combined.Skipped++
+			combined.Errors = append(combined.Errors, TestFailure{
+				TestName: path,
+				Error:    err.Error(),
+			})
+			return nil
+		}
+
+		combined.Passed += results.Passed
+		combined.Failed += results.Failed
+		combined.Total += results.Total
+		combined.Errors = append(combined.Errors, results.Errors...)
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return combined, nil
+}
+
+// compareResults compares expected and actual results.
+func (p *PolicyTester) compareResults(expected ExpectedResult, got TestResult) bool {
+	if expected.Decision != got.Decision {
+		return false
+	}
+	if expected.PolicyRule != "" && expected.PolicyRule != got.PolicyRule {
+		return false
+	}
+	if expected.RedirectTo != "" && expected.RedirectTo != got.RedirectTo {
+		return false
+	}
+	return true
+}
+
+// isTestFile checks if a file is a test file.
+func isTestFile(path string) bool {
+	ext := filepath.Ext(path)
+	if ext != ".yaml" && ext != ".yml" {
+		return false
+	}
+	base := filepath.Base(path)
+	return strings.HasSuffix(strings.TrimSuffix(base, ext), "_test") ||
+		strings.HasSuffix(strings.TrimSuffix(base, ext), "-test")
+}
+
+// LoadTestFile loads test cases from a YAML file.
+func LoadTestFile(path string) ([]PolicyTestCase, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading test file: %w", err)
+	}
+
+	var file PolicyTestFile
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return nil, fmt.Errorf("parsing test file: %w", err)
+	}
+
+	return file.Tests, nil
+}
+
+// SaveTestFile saves test cases to a YAML file.
+func SaveTestFile(path string, tests []PolicyTestCase) error {
+	file := PolicyTestFile{Tests: tests}
+
+	data, err := yaml.Marshal(file)
+	if err != nil {
+		return fmt.Errorf("marshaling tests: %w", err)
+	}
+
+	return os.WriteFile(path, data, 0644)
+}
+
+// Summary returns a human-readable summary of test results.
+func (r *TestResults) Summary() string {
+	if r.Total == 0 {
+		return "No tests run"
+	}
+
+	status := "PASS"
+	if r.Failed > 0 {
+		status = "FAIL"
+	}
+
+	return fmt.Sprintf("%s: %d/%d tests passed (%d failed, %d skipped)",
+		status, r.Passed, r.Total, r.Failed, r.Skipped)
+}
+
+// Success returns true if all tests passed.
+func (r *TestResults) Success() bool {
+	return r.Failed == 0 && r.Total > 0
+}

--- a/pkg/simulation/testing_test.go
+++ b/pkg/simulation/testing_test.go
@@ -1,0 +1,316 @@
+package simulation
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type mockEvaluator struct {
+	results map[string]TestResult
+}
+
+func (m *mockEvaluator) Evaluate(op *Operation) TestResult {
+	key := op.Type + ":" + op.Path
+	if result, ok := m.results[key]; ok {
+		return result
+	}
+	return TestResult{Decision: "deny"}
+}
+
+func TestPolicyTestCase(t *testing.T) {
+	tc := PolicyTestCase{
+		Name:        "test_read",
+		Description: "Test file read",
+		Operation: TestOperation{
+			Type: "file_read",
+			Path: "/workspace/file.txt",
+		},
+		Expected: ExpectedResult{
+			Decision:   "allow",
+			PolicyRule: "workspace",
+		},
+	}
+
+	op := tc.Operation.ToOperation()
+	if op.Type != "file_read" {
+		t.Errorf("Type = %v, want file_read", op.Type)
+	}
+	if op.Path != "/workspace/file.txt" {
+		t.Errorf("Path = %v, want /workspace/file.txt", op.Path)
+	}
+}
+
+func TestNewPolicyTester(t *testing.T) {
+	eval := &mockEvaluator{}
+	pt := NewPolicyTester(eval)
+
+	if pt == nil {
+		t.Fatal("NewPolicyTester returned nil")
+	}
+}
+
+func TestPolicyTester_RunTests_Pass(t *testing.T) {
+	eval := &mockEvaluator{
+		results: map[string]TestResult{
+			"file_read:/workspace/file.txt": {Decision: "allow", PolicyRule: "workspace"},
+		},
+	}
+	pt := NewPolicyTester(eval)
+
+	tests := []PolicyTestCase{
+		{
+			Name: "test_workspace_read",
+			Operation: TestOperation{
+				Type: "file_read",
+				Path: "/workspace/file.txt",
+			},
+			Expected: ExpectedResult{
+				Decision:   "allow",
+				PolicyRule: "workspace",
+			},
+		},
+	}
+
+	results := pt.RunTests(tests)
+
+	if results.Passed != 1 {
+		t.Errorf("Passed = %d, want 1", results.Passed)
+	}
+	if results.Failed != 0 {
+		t.Errorf("Failed = %d, want 0", results.Failed)
+	}
+	if !results.Success() {
+		t.Error("Success() should return true")
+	}
+}
+
+func TestPolicyTester_RunTests_Fail(t *testing.T) {
+	eval := &mockEvaluator{
+		results: map[string]TestResult{
+			"file_read:/etc/passwd": {Decision: "deny", PolicyRule: "sensitive"},
+		},
+	}
+	pt := NewPolicyTester(eval)
+
+	tests := []PolicyTestCase{
+		{
+			Name: "test_passwd_read",
+			Operation: TestOperation{
+				Type: "file_read",
+				Path: "/etc/passwd",
+			},
+			Expected: ExpectedResult{
+				Decision: "allow", // Expected allow but will get deny
+			},
+		},
+	}
+
+	results := pt.RunTests(tests)
+
+	if results.Passed != 0 {
+		t.Errorf("Passed = %d, want 0", results.Passed)
+	}
+	if results.Failed != 1 {
+		t.Errorf("Failed = %d, want 1", results.Failed)
+	}
+	if len(results.Errors) != 1 {
+		t.Errorf("Errors = %d, want 1", len(results.Errors))
+	}
+	if results.Success() {
+		t.Error("Success() should return false")
+	}
+}
+
+func TestPolicyTester_RunTests_RedirectMatch(t *testing.T) {
+	eval := &mockEvaluator{
+		results: map[string]TestResult{
+			"file_read:/etc/passwd": {
+				Decision:   "redirect",
+				RedirectTo: "/honeypot/passwd",
+			},
+		},
+	}
+	pt := NewPolicyTester(eval)
+
+	tests := []PolicyTestCase{
+		{
+			Name: "test_redirect",
+			Operation: TestOperation{
+				Type: "file_read",
+				Path: "/etc/passwd",
+			},
+			Expected: ExpectedResult{
+				Decision:   "redirect",
+				RedirectTo: "/honeypot/passwd",
+			},
+		},
+	}
+
+	results := pt.RunTests(tests)
+	if results.Failed != 0 {
+		t.Errorf("Failed = %d, want 0", results.Failed)
+	}
+}
+
+func TestTestResults_Summary(t *testing.T) {
+	tests := []struct {
+		results *TestResults
+		want    string
+	}{
+		{
+			results: &TestResults{Total: 0},
+			want:    "No tests run",
+		},
+		{
+			results: &TestResults{Passed: 5, Total: 5},
+			want:    "PASS: 5/5 tests passed (0 failed, 0 skipped)",
+		},
+		{
+			results: &TestResults{Passed: 3, Failed: 2, Total: 5},
+			want:    "FAIL: 3/5 tests passed (2 failed, 0 skipped)",
+		},
+	}
+
+	for _, tt := range tests {
+		got := tt.results.Summary()
+		if got != tt.want {
+			t.Errorf("Summary() = %q, want %q", got, tt.want)
+		}
+	}
+}
+
+func TestLoadTestFile(t *testing.T) {
+	// Create temp test file
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test_policy_test.yaml")
+
+	content := `tests:
+  - name: test_read
+    operation:
+      type: file_read
+      path: /workspace/file.txt
+    expected:
+      decision: allow
+  - name: test_deny
+    operation:
+      type: file_read
+      path: /etc/shadow
+    expected:
+      decision: deny
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+
+	tests, err := LoadTestFile(path)
+	if err != nil {
+		t.Fatalf("LoadTestFile error: %v", err)
+	}
+
+	if len(tests) != 2 {
+		t.Errorf("loaded %d tests, want 2", len(tests))
+	}
+
+	if tests[0].Name != "test_read" {
+		t.Errorf("tests[0].Name = %q, want test_read", tests[0].Name)
+	}
+}
+
+func TestSaveTestFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output_test.yaml")
+
+	tests := []PolicyTestCase{
+		{
+			Name: "test_1",
+			Operation: TestOperation{
+				Type: "file_read",
+				Path: "/test",
+			},
+			Expected: ExpectedResult{
+				Decision: "allow",
+			},
+		},
+	}
+
+	if err := SaveTestFile(path, tests); err != nil {
+		t.Fatalf("SaveTestFile error: %v", err)
+	}
+
+	// Verify file exists and can be loaded
+	loaded, err := LoadTestFile(path)
+	if err != nil {
+		t.Fatalf("LoadTestFile error: %v", err)
+	}
+
+	if len(loaded) != 1 {
+		t.Errorf("loaded %d tests, want 1", len(loaded))
+	}
+}
+
+func TestIsTestFile(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"policy_test.yaml", true},
+		{"policy-test.yaml", true},
+		{"policy_test.yml", true},
+		{"policy.yaml", false},
+		{"test.txt", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		got := isTestFile(tt.path)
+		if got != tt.want {
+			t.Errorf("isTestFile(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestPolicyTester_RunTestDir(t *testing.T) {
+	eval := &mockEvaluator{
+		results: map[string]TestResult{
+			"file_read:/workspace/a.txt": {Decision: "allow"},
+			"file_read:/workspace/b.txt": {Decision: "allow"},
+		},
+	}
+	pt := NewPolicyTester(eval)
+
+	// Create temp directory with test files
+	dir := t.TempDir()
+
+	test1 := `tests:
+  - name: test_a
+    operation:
+      type: file_read
+      path: /workspace/a.txt
+    expected:
+      decision: allow
+`
+	test2 := `tests:
+  - name: test_b
+    operation:
+      type: file_read
+      path: /workspace/b.txt
+    expected:
+      decision: allow
+`
+	os.WriteFile(filepath.Join(dir, "a_test.yaml"), []byte(test1), 0644)
+	os.WriteFile(filepath.Join(dir, "b_test.yaml"), []byte(test2), 0644)
+	os.WriteFile(filepath.Join(dir, "not_a_test.yaml"), []byte("not a test"), 0644)
+
+	results, err := pt.RunTestDir(dir)
+	if err != nil {
+		t.Fatalf("RunTestDir error: %v", err)
+	}
+
+	if results.Passed != 2 {
+		t.Errorf("Passed = %d, want 2", results.Passed)
+	}
+	if results.Total != 2 {
+		t.Errorf("Total = %d, want 2", results.Total)
+	}
+}


### PR DESCRIPTION
## Summary

Implements §24 Testing & Simulation Modes from the multiplatform spec:

- **Simulation modes** (`modes.go`):
  - `ModeManager` for dry-run, permissive, and strict modes
  - Dry-run mode: logs decisions but doesn't enforce (for policy validation)
  - Permissive mode: allows by default, logs denials (for gradual rollout)
  - Strict mode: enforces all policy decisions (production)
  - `ProcessDecision()` for mode-aware decision handling

- **Policy testing framework** (`testing.go`):
  - `PolicyTestCase` and `TestOperation` types for test definitions
  - `PolicyTester` for running tests against policy evaluators
  - YAML test file support (`LoadTestFile`, `SaveTestFile`)
  - Directory-based test discovery (`RunTestDir`)
  - `TestResults` with pass/fail/skip tracking and error details

- **Session recording and replay** (`recording.go`):
  - `SessionRecorder` for recording operations to JSONL files
  - `RecordedEvent` with timestamps, decisions, policy rules, latency
  - `SessionReplayer` for replaying recordings against new policies
  - `ReplayResults` showing differences between old/new decisions
  - `GetRecordingStats` for recording analysis and statistics

## Test plan

- [x] Unit tests for mode management (11 tests)
- [x] Unit tests for policy testing framework (11 tests)
- [x] Unit tests for session recording/replay (11 tests)
- [x] All 33 tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)