### PR TITLE
feat(windows): add native WPF approval dialog

### DIFF
--- a/.github/workflows/driver-windows.yml
+++ b/.github/workflows/driver-windows.yml
@@ -1,4 +1,4 @@
-name: Windows Driver Build
+name: Windows Build
 
 on:
   push:
@@ -6,10 +6,12 @@ on:
       - main
     paths:
       - 'drivers/windows/**'
+      - 'windows/**'
       - '.github/workflows/driver-windows.yml'
   pull_request:
     paths:
       - 'drivers/windows/**'
+      - 'windows/**'
       - '.github/workflows/driver-windows.yml'
   workflow_dispatch:
     inputs:
@@ -246,26 +248,62 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
+  # Build Windows ApprovalDialog (WPF/.NET Framework 4.8.1)
+  build-approval-dialog:
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build ApprovalDialog
+        shell: cmd
+        run: |
+          echo Building Windows ApprovalDialog...
+          msbuild windows\ApprovalDialog\ApprovalDialog.csproj /p:Configuration=Release /v:minimal
+          if errorlevel 1 exit /b 1
+          echo Build successful
+
+      - name: Upload ApprovalDialog artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentsh-approval-dialog-windows
+          path: |
+            windows/ApprovalDialog/bin/Release/agentsh-approval-dialog.exe
+          if-no-files-found: error
+          retention-days: 30
+
   # Summary job that runs after all builds complete
   build-summary:
-    needs: build-driver
+    needs: [build-driver, build-approval-dialog]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check build results
         run: |
-          if [ "${{ needs.build-driver.result }}" == "success" ]; then
-            echo "✅ All driver builds completed successfully"
+          driver_result="${{ needs.build-driver.result }}"
+          dialog_result="${{ needs.build-approval-dialog.result }}"
+
+          echo "Build Results:"
+          echo "  - Driver: $driver_result"
+          echo "  - ApprovalDialog: $dialog_result"
+          echo ""
+
+          if [ "$driver_result" == "success" ] && [ "$dialog_result" == "success" ]; then
+            echo "✅ All Windows builds completed successfully"
             echo ""
             echo "Artifacts available:"
             echo "  - agentsh-driver-x64-Debug"
             echo "  - agentsh-driver-x64-Release (test-signed)"
             echo "  - agentsh-driver-scripts"
+            echo "  - agentsh-approval-dialog-windows"
             echo ""
             echo "Note: For production deployment, the Release driver must be"
             echo "signed with an EV code signing certificate and submitted to"
             echo "Microsoft for attestation signing."
           else
-            echo "❌ Driver build failed"
+            echo "❌ One or more builds failed"
             exit 1
           fi

--- a/windows/ApprovalDialog/App.xaml
+++ b/windows/ApprovalDialog/App.xaml
@@ -1,0 +1,5 @@
+<Application x:Class="ApprovalDialog.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+</Application>

--- a/windows/ApprovalDialog/App.xaml.cs
+++ b/windows/ApprovalDialog/App.xaml.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Windows;
+
+namespace ApprovalDialog
+{
+    public partial class App : Application
+    {
+        public static string ProcessName { get; private set; } = "unknown";
+        public static string ProcessPath { get; private set; } = "";
+        public static int ProcessId { get; private set; } = 0;
+        public static string Target { get; private set; } = "unknown";
+        public static int Port { get; private set; } = 0;
+        public static string Protocol { get; private set; } = "tcp";
+        public static int TimeoutSeconds { get; private set; } = 30;
+
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            base.OnStartup(e);
+            ParseArguments(e.Args);
+        }
+
+        private void ParseArguments(string[] args)
+        {
+            for (int i = 0; i < args.Length; i++)
+            {
+                switch (args[i])
+                {
+                    case "--process-name":
+                    case "-n":
+                        if (i + 1 < args.Length) ProcessName = args[++i];
+                        break;
+                    case "--process-path":
+                    case "-p":
+                        if (i + 1 < args.Length) ProcessPath = args[++i];
+                        break;
+                    case "--pid":
+                        if (i + 1 < args.Length && int.TryParse(args[++i], out int pid)) ProcessId = pid;
+                        break;
+                    case "--target":
+                    case "-t":
+                        if (i + 1 < args.Length) Target = args[++i];
+                        break;
+                    case "--port":
+                        if (i + 1 < args.Length && int.TryParse(args[++i], out int port)) Port = port;
+                        break;
+                    case "--protocol":
+                        if (i + 1 < args.Length) Protocol = args[++i];
+                        break;
+                    case "--timeout":
+                        if (i + 1 < args.Length && int.TryParse(args[++i], out int timeout)) TimeoutSeconds = timeout;
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/windows/ApprovalDialog/ApprovalDialog.csproj
+++ b/windows/ApprovalDialog/ApprovalDialog.csproj
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <RootNamespace>ApprovalDialog</RootNamespace>
+    <AssemblyName>agentsh-approval-dialog</AssemblyName>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <WarningLevel>4</WarningLevel>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xaml">
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
+    </Reference>
+    <Reference Include="WindowsBase" />
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
+  </ItemGroup>
+  <ItemGroup>
+    <ApplicationDefinition Include="App.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </ApplicationDefinition>
+    <Page Include="MainWindow.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Compile Include="App.xaml.cs">
+      <DependentUpon>App.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="MainWindow.xaml.cs">
+      <DependentUpon>MainWindow.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.manifest" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/windows/ApprovalDialog/MainWindow.xaml
+++ b/windows/ApprovalDialog/MainWindow.xaml
@@ -1,0 +1,79 @@
+<Window x:Class="ApprovalDialog.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Network Access Request"
+        Height="380" Width="520"
+        MinHeight="340" MinWidth="480"
+        WindowStartupLocation="CenterScreen"
+        ResizeMode="NoResize"
+        Topmost="True"
+        Background="#FAFAFA">
+
+    <DockPanel Margin="24">
+        <!-- Header - Top -->
+        <TextBlock DockPanel.Dock="Top" Text="Network Access Request" FontSize="20" FontWeight="SemiBold"
+                   Foreground="#1a1a1a" Margin="0,0,0,16"/>
+
+        <!-- Buttons - Bottom (always visible) -->
+        <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,16,0,0">
+            <Button x:Name="DenyButton" Content="Deny" Click="DenyButton_Click"
+                    Padding="20,10" MinWidth="100" Margin="0,0,10,0"
+                    Background="#F5F5F5" BorderBrush="#CCC"/>
+            <Button x:Name="AllowOnceButton" Content="Allow Once" Click="AllowOnceButton_Click"
+                    Padding="20,10" MinWidth="100" Margin="0,0,10,0"
+                    Background="#F5F5F5" BorderBrush="#CCC"/>
+            <Button x:Name="AllowAlwaysButton" Content="Allow Always" Click="AllowAlwaysButton_Click"
+                    Padding="20,10" MinWidth="100"
+                    Background="#0078D4" Foreground="White" BorderBrush="#0078D4"/>
+        </StackPanel>
+
+        <!-- Timeout indicator - Bottom -->
+        <TextBlock DockPanel.Dock="Bottom" x:Name="TimeoutText" FontSize="12" Foreground="#888"
+                   Margin="0,12,0,0"/>
+
+        <!-- Scrollable Details Box - Fill remaining space -->
+        <Border Background="White" CornerRadius="4" BorderBrush="#E0E0E0" BorderThickness="1">
+            <ScrollViewer VerticalScrollBarVisibility="Auto" Padding="16">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="90"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Grid.Row="0" Grid.Column="0" Text="Process:" FontWeight="SemiBold"
+                               Foreground="#666" Margin="0,0,0,12"/>
+                    <TextBlock Grid.Row="0" Grid.Column="1" x:Name="ProcessText"
+                               Foreground="#1a1a1a" TextWrapping="Wrap" Margin="0,0,0,12"/>
+
+                    <TextBlock Grid.Row="1" Grid.Column="0" Text="PID:" FontWeight="SemiBold"
+                               Foreground="#666" Margin="0,0,0,12"/>
+                    <TextBlock Grid.Row="1" Grid.Column="1" x:Name="PidText"
+                               Foreground="#1a1a1a" Margin="0,0,0,12"/>
+
+                    <TextBlock Grid.Row="2" Grid.Column="0" Text="Target:" FontWeight="SemiBold"
+                               Foreground="#666" Margin="0,0,0,12"/>
+                    <TextBlock Grid.Row="2" Grid.Column="1" x:Name="TargetText"
+                               Foreground="#1a1a1a" TextWrapping="Wrap" Margin="0,0,0,12"/>
+
+                    <TextBlock Grid.Row="3" Grid.Column="0" Text="Protocol:" FontWeight="SemiBold"
+                               Foreground="#666" Margin="0,0,0,12"/>
+                    <TextBlock Grid.Row="3" Grid.Column="1" x:Name="ProtocolText"
+                               Foreground="#1a1a1a" Margin="0,0,0,12"/>
+
+                    <!-- Path (only shown if available) -->
+                    <TextBlock Grid.Row="4" Grid.Column="0" x:Name="PathLabel" Text="Path:" FontWeight="SemiBold"
+                               Foreground="#666" Visibility="Collapsed"/>
+                    <TextBlock Grid.Row="4" Grid.Column="1" x:Name="PathText"
+                               Foreground="#888" TextWrapping="Wrap" FontSize="11" Visibility="Collapsed"/>
+                </Grid>
+            </ScrollViewer>
+        </Border>
+    </DockPanel>
+</Window>

--- a/windows/ApprovalDialog/MainWindow.xaml.cs
+++ b/windows/ApprovalDialog/MainWindow.xaml.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media.Imaging;
+using System.Windows.Threading;
+
+namespace ApprovalDialog
+{
+    public partial class MainWindow : Window
+    {
+        private readonly DispatcherTimer _timer;
+        private int _remainingSeconds;
+        private string _decision = "deny"; // Default to deny for safety
+
+        // Exit codes matching the Go implementation
+        private const int EXIT_ALLOW_ONCE = 0;
+        private const int EXIT_ALLOW_ALWAYS = 1;
+        private const int EXIT_DENY = 2;
+        private const int EXIT_TIMEOUT = 3;
+
+        // Win32 API for loading system icons
+        [DllImport("shell32.dll", CharSet = CharSet.Unicode)]
+        private static extern IntPtr ExtractIconEx(string lpszFile, int nIconIndex, IntPtr[] phiconLarge, IntPtr[] phiconSmall, int nIcons);
+
+        [DllImport("user32.dll")]
+        private static extern bool DestroyIcon(IntPtr hIcon);
+
+        public MainWindow()
+        {
+            InitializeComponent();
+
+            // Set window icon to Windows shield icon
+            SetShieldIcon();
+
+            // Set up the UI with request details
+            ProcessText.Text = App.ProcessName;
+            PidText.Text = App.ProcessId.ToString();
+            TargetText.Text = App.Port > 0 ? $"{App.Target}:{App.Port}" : App.Target;
+            ProtocolText.Text = App.Protocol.ToUpper();
+
+            // Show path if available
+            if (!string.IsNullOrEmpty(App.ProcessPath))
+            {
+                PathLabel.Visibility = Visibility.Visible;
+                PathText.Visibility = Visibility.Visible;
+                PathText.Text = App.ProcessPath;
+            }
+
+            // Set up timeout timer
+            _remainingSeconds = App.TimeoutSeconds;
+            UpdateTimeoutText();
+
+            _timer = new DispatcherTimer
+            {
+                Interval = TimeSpan.FromSeconds(1)
+            };
+            _timer.Tick += Timer_Tick;
+            _timer.Start();
+
+            // Handle window closing (X button, Alt+F4, etc.)
+            Closing += MainWindow_Closing;
+
+            // Focus deny button (safe default)
+            DenyButton.Focus();
+        }
+
+        private void Timer_Tick(object sender, EventArgs e)
+        {
+            _remainingSeconds--;
+            UpdateTimeoutText();
+
+            if (_remainingSeconds <= 0)
+            {
+                _timer.Stop();
+                _decision = "timeout";
+                OutputDecision(EXIT_TIMEOUT);
+            }
+        }
+
+        private void UpdateTimeoutText()
+        {
+            TimeoutText.Text = $"Auto-deny in {_remainingSeconds}s";
+        }
+
+        private void AllowOnceButton_Click(object sender, RoutedEventArgs e)
+        {
+            _timer.Stop();
+            _decision = "allow_once";
+            OutputDecision(EXIT_ALLOW_ONCE);
+        }
+
+        private void AllowAlwaysButton_Click(object sender, RoutedEventArgs e)
+        {
+            _timer.Stop();
+            _decision = "allow_always";
+            OutputDecision(EXIT_ALLOW_ALWAYS);
+        }
+
+        private void DenyButton_Click(object sender, RoutedEventArgs e)
+        {
+            _timer.Stop();
+            _decision = "deny";
+            OutputDecision(EXIT_DENY);
+        }
+
+        private void MainWindow_Closing(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            // If window is closed without a decision, treat as deny
+            _timer.Stop();
+            if (_decision == "deny")
+            {
+                OutputDecision(EXIT_DENY);
+            }
+        }
+
+        private void OutputDecision(int exitCode)
+        {
+            // Output decision to stdout for the parent process to read
+            Console.WriteLine(_decision);
+            Application.Current.Shutdown(exitCode);
+        }
+
+        private void SetShieldIcon()
+        {
+            try
+            {
+                // Extract shield icon from Windows (icon index 77 in imageres.dll is the shield)
+                IntPtr[] largeIcons = new IntPtr[1];
+                IntPtr[] smallIcons = new IntPtr[1];
+
+                // Try imageres.dll first (Windows Vista+)
+                string iconPath = Environment.ExpandEnvironmentVariables(@"%SystemRoot%\System32\imageres.dll");
+                ExtractIconEx(iconPath, 77, largeIcons, smallIcons, 1);
+
+                if (largeIcons[0] != IntPtr.Zero)
+                {
+                    Icon = Imaging.CreateBitmapSourceFromHIcon(
+                        largeIcons[0],
+                        Int32Rect.Empty,
+                        BitmapSizeOptions.FromEmptyOptions());
+                    DestroyIcon(largeIcons[0]);
+                }
+                if (smallIcons[0] != IntPtr.Zero)
+                {
+                    DestroyIcon(smallIcons[0]);
+                }
+            }
+            catch
+            {
+                // Ignore icon errors - app will work without custom icon
+            }
+        }
+    }
+}

--- a/windows/ApprovalDialog/app.manifest
+++ b/windows/ApprovalDialog/app.manifest
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="ApprovalDialog"/>
+
+  <!-- Windows Common Controls v6 for modern look -->
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls"
+                        version="6.0.0.0" processorArchitecture="*"
+                        publicKeyToken="6595b64144ccf1df" language="*" />
+    </dependentAssembly>
+  </dependency>
+
+  <!-- DPI Awareness -->
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2,permonitor</dpiAwareness>
+    </windowsSettings>
+  </application>
+
+  <!-- Windows 10/11 compatibility -->
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
## Summary

- Add native Windows approval dialog using WPF/.NET Framework 4.8.1
- Custom UI matching macOS ApprovalDialog functionality (Process, PID, Target, Protocol, Path fields)
- Three response buttons: Deny, Allow Once, Allow Always
- Countdown timeout with auto-deny behavior
- System shield icon extracted from `imageres.dll` at runtime (no bundled icon needed)

## Build System

- Add `build-approval-dialog-windows` target to Makefile
- Update GitHub Actions workflow to build and upload `agentsh-approval-dialog-windows` artifact
- Output binary: `agentsh-approval-dialog.exe`

## Test plan

- [ ] GitHub Actions Windows build completes successfully
- [ ] Artifact `agentsh-approval-dialog-windows` is uploaded
- [ ] Manual test on Windows (dialog displays correctly, buttons work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)