### PR TITLE
feat: add DNS and connect-level network redirect

### DIFF
--- a/docs/plans/2026-01-29-network-redirect-design.md
+++ b/docs/plans/2026-01-29-network-redirect-design.md
@@ -1,5 +1,8 @@
 # Network Redirect Design
 
+**Status:** Implemented (Tasks 1-11 complete)
+**Branch:** feature/network-redirect
+
 DNS and connect-level redirect for agentsh-wrapped processes.
 
 ## Overview

--- a/docs/plans/2026-01-29-network-redirect-design.md
+++ b/docs/plans/2026-01-29-network-redirect-design.md
@@ -1,0 +1,175 @@
+# Network Redirect Design
+
+DNS and connect-level redirect for agentsh-wrapped processes.
+
+## Overview
+
+Intercept DNS resolution and TCP connections from processes running under agentsh, redirecting them to different destinations based on policy rules. Primary use case: route Anthropic API calls through GCP Vertex without application changes.
+
+## Scope
+
+- **Processes**: agentsh-wrapped only (not system-wide)
+- **Layers**: DNS resolution and connect-level redirect
+- **Platform**: Linux first (eBPF), macOS/Windows later
+
+## Configuration Schema
+
+```yaml
+dns_redirects:
+  - name: anthropic-to-vertex-dns
+    match: ".*\\.anthropic\\.com"        # regex, full string match
+    resolve_to: 10.0.0.50
+    visibility: audit_only               # silent | audit_only | warn
+    on_failure: fail_closed              # fail_closed | fail_open | retry_original
+
+connect_redirects:
+  - name: anthropic-to-vertex
+    match: "api\\.anthropic\\.com:443"   # regex, host:port or host (any port)
+    redirect_to: vertex-proxy.internal:443
+    tls:
+      mode: passthrough                  # passthrough | rewrite_sni
+      sni: null                          # required if rewrite_sni
+    visibility: warn
+    message: "Routed through Vertex AI"
+    on_failure: fail_closed
+```
+
+Rules evaluated in order; first match wins.
+
+## Implementation
+
+### DNS Interception
+
+**Primary: uprobe on getaddrinfo**
+
+1. Attach uprobe to `getaddrinfo` entry point
+2. Capture hostname argument
+3. Match against `dns_redirects` rules
+4. If match: attach uretprobe to modify returned `addrinfo` struct with `resolve_to` IP
+5. Emit audit event
+
+**Secondary: raw DNS (UDP:53)**
+
+- Intercept `sendto`/`sendmsg` syscalls to port 53
+- Parse DNS query packet, extract hostname
+- Redirect to local resolver or modify response packet
+
+The uprobe approach covers 95%+ of cases.
+
+### Connect Redirect
+
+**eBPF on sys_connect**
+
+1. Attach to `sys_connect` entry
+2. Extract destination from `sockaddr` (IP and port)
+3. Reverse-lookup hostname from DNS correlation map
+4. Match against `connect_redirects` rules
+5. If match: modify `sockaddr` in-place, store original in BPF map
+6. Emit audit event
+
+**Hostname correlation:**
+
+DNS interception populates `hostname → IP` map. Connect interception does reverse lookup. Fallback: match on IP directly.
+
+**SNI rewriting (when `tls.mode: rewrite_sni`):**
+
+- Intercept `send`/`write` on socket
+- Detect TLS ClientHello (bytes 0x16 0x03)
+- Parse and rewrite SNI extension
+- Forward modified packet
+
+### Failure Handling
+
+| `on_failure` | Behavior |
+|--------------|----------|
+| `fail_closed` | Return error to application |
+| `fail_open` | Retry connect to original destination |
+| `retry_original` | Same as `fail_open` |
+
+Detection via eBPF on connect return value (`ECONNREFUSED`, `ETIMEDOUT`, `ENETUNREACH`).
+
+### Visibility
+
+| Setting | Behavior |
+|---------|----------|
+| `silent` | No event, no output |
+| `audit_only` | Event to audit log only |
+| `warn` | Event + message to stderr |
+
+## Audit Events
+
+**DNS redirect:**
+
+```json
+{
+  "type": "dns_redirect",
+  "timestamp": "2026-01-29T10:23:45Z",
+  "pid": 12345,
+  "process": "python",
+  "rule": "anthropic-to-vertex-dns",
+  "original_host": "api.anthropic.com",
+  "resolved_to": "10.0.0.50",
+  "visibility": "audit_only"
+}
+```
+
+**Connect redirect:**
+
+```json
+{
+  "type": "connect_redirect",
+  "timestamp": "2026-01-29T10:23:45Z",
+  "pid": 12345,
+  "process": "python",
+  "rule": "anthropic-to-vertex",
+  "original": "api.anthropic.com:443",
+  "redirected_to": "vertex-proxy.internal:443",
+  "tls_mode": "passthrough",
+  "visibility": "warn",
+  "message": "Routed through Vertex AI"
+}
+```
+
+**Fallback event:**
+
+```json
+{
+  "type": "connect_redirect_fallback",
+  "rule": "anthropic-to-vertex",
+  "original": "api.anthropic.com:443",
+  "redirect_attempted": "vertex-proxy.internal:443",
+  "error": "ECONNREFUSED",
+  "action": "fail_open",
+  "status": "connected_to_original"
+}
+```
+
+## Code Organization
+
+```
+internal/
+├── policy/
+│   └── network_redirect.go     # Rule parsing, matching, config types
+├── interceptor/
+│   ├── dns_redirect.go         # Userspace DNS redirect logic
+│   └── connect_redirect.go     # Userspace connect redirect logic
+├── ebpf/
+│   ├── dns_redirect.bpf.c      # DNS interception (uprobe + UDP)
+│   ├── connect_redirect.bpf.c  # Connect syscall interception
+│   ├── sni_rewrite.bpf.c       # TLS SNI rewriting
+│   └── redirect_maps.h         # Shared BPF maps definitions
+└── audit/
+    └── events.go               # Add new redirect event types
+```
+
+**BPF maps (via cilium/ebpf):**
+
+- `hostnameToIP` - correlates DNS lookups to resolved IPs
+- `socketOriginal` - stores original destinations per socket fd
+
+## Future Work
+
+- macOS implementation (ESF-based)
+- Windows implementation (minifilter-based)
+- Full MITM with custom CA (for deep inspection scenarios)
+- Pattern-based IP matching (CIDR blocks)

--- a/docs/plans/2026-01-29-network-redirect-impl.md
+++ b/docs/plans/2026-01-29-network-redirect-impl.md
@@ -1,0 +1,1060 @@
+# Network Redirect Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add DNS and connect-level redirect capability for agentsh-wrapped processes on Linux.
+
+**Architecture:** Extend existing policy engine with `dns_redirects` and `connect_redirects` rule types. DNS interception via uprobe on getaddrinfo, connect interception via existing eBPF infrastructure. Events emitted through existing broker.
+
+**Tech Stack:** Go, cilium/ebpf, CO-RE BPF programs
+
+---
+
+### Task 1: Add Rule Types to Policy Model
+
+**Files:**
+- Modify: `internal/policy/model.go`
+
+**Step 1: Add DnsRedirectRule struct**
+
+Add after line ~135 (after existing rule types):
+
+```go
+// DnsRedirectRule redirects DNS resolution for matching hostnames
+type DnsRedirectRule struct {
+	Name       string `yaml:"name"`
+	Match      string `yaml:"match"`                // regex pattern for hostname
+	ResolveTo  string `yaml:"resolve_to"`           // IP address to return
+	Visibility string `yaml:"visibility,omitempty"` // silent, audit_only, warn
+	OnFailure  string `yaml:"on_failure,omitempty"` // fail_closed, fail_open, retry_original
+}
+
+// ConnectRedirectRule redirects TCP connections for matching host:port
+type ConnectRedirectRule struct {
+	Name       string                    `yaml:"name"`
+	Match      string                    `yaml:"match"`                // regex pattern for host:port
+	RedirectTo string                    `yaml:"redirect_to"`          // new host:port destination
+	TLS        *ConnectRedirectTLSConfig `yaml:"tls,omitempty"`
+	Visibility string                    `yaml:"visibility,omitempty"` // silent, audit_only, warn
+	Message    string                    `yaml:"message,omitempty"`
+	OnFailure  string                    `yaml:"on_failure,omitempty"` // fail_closed, fail_open, retry_original
+}
+
+// ConnectRedirectTLSConfig controls TLS handling for connect redirects
+type ConnectRedirectTLSConfig struct {
+	Mode string `yaml:"mode,omitempty"` // passthrough, rewrite_sni
+	SNI  string `yaml:"sni,omitempty"`  // required if mode is rewrite_sni
+}
+```
+
+**Step 2: Add rules to Policy struct**
+
+Find the Policy struct and add:
+
+```go
+type Policy struct {
+	// ... existing fields
+	DnsRedirectRules     []DnsRedirectRule     `yaml:"dns_redirects,omitempty"`
+	ConnectRedirectRules []ConnectRedirectRule `yaml:"connect_redirects,omitempty"`
+}
+```
+
+**Step 3: Run tests**
+
+Run: `go build ./...`
+Expected: Build succeeds
+
+**Step 4: Commit**
+
+```bash
+git add internal/policy/model.go
+git commit -m "feat(policy): add DnsRedirectRule and ConnectRedirectRule types"
+```
+
+---
+
+### Task 2: Add Validation for Redirect Rules
+
+**Files:**
+- Modify: `internal/policy/model.go` (Validate method)
+
+**Step 1: Add validation logic**
+
+Find the `Validate()` method and add validation for new rules:
+
+```go
+func (p *Policy) Validate() error {
+	// ... existing validation
+
+	// Validate DNS redirect rules
+	for i, r := range p.DnsRedirectRules {
+		if r.Name == "" {
+			return fmt.Errorf("dns_redirects[%d]: name is required", i)
+		}
+		if r.Match == "" {
+			return fmt.Errorf("dns_redirects[%d]: match is required", i)
+		}
+		if _, err := regexp.Compile(r.Match); err != nil {
+			return fmt.Errorf("dns_redirects[%d]: invalid match regex: %w", i, err)
+		}
+		if r.ResolveTo == "" {
+			return fmt.Errorf("dns_redirects[%d]: resolve_to is required", i)
+		}
+		if net.ParseIP(r.ResolveTo) == nil {
+			return fmt.Errorf("dns_redirects[%d]: resolve_to must be valid IP", i)
+		}
+		if r.Visibility != "" && r.Visibility != "silent" && r.Visibility != "audit_only" && r.Visibility != "warn" {
+			return fmt.Errorf("dns_redirects[%d]: visibility must be silent, audit_only, or warn", i)
+		}
+		if r.OnFailure != "" && r.OnFailure != "fail_closed" && r.OnFailure != "fail_open" && r.OnFailure != "retry_original" {
+			return fmt.Errorf("dns_redirects[%d]: on_failure must be fail_closed, fail_open, or retry_original", i)
+		}
+	}
+
+	// Validate connect redirect rules
+	for i, r := range p.ConnectRedirectRules {
+		if r.Name == "" {
+			return fmt.Errorf("connect_redirects[%d]: name is required", i)
+		}
+		if r.Match == "" {
+			return fmt.Errorf("connect_redirects[%d]: match is required", i)
+		}
+		if _, err := regexp.Compile(r.Match); err != nil {
+			return fmt.Errorf("connect_redirects[%d]: invalid match regex: %w", i, err)
+		}
+		if r.RedirectTo == "" {
+			return fmt.Errorf("connect_redirects[%d]: redirect_to is required", i)
+		}
+		if r.TLS != nil {
+			if r.TLS.Mode != "" && r.TLS.Mode != "passthrough" && r.TLS.Mode != "rewrite_sni" {
+				return fmt.Errorf("connect_redirects[%d]: tls.mode must be passthrough or rewrite_sni", i)
+			}
+			if r.TLS.Mode == "rewrite_sni" && r.TLS.SNI == "" {
+				return fmt.Errorf("connect_redirects[%d]: tls.sni required when mode is rewrite_sni", i)
+			}
+		}
+		if r.Visibility != "" && r.Visibility != "silent" && r.Visibility != "audit_only" && r.Visibility != "warn" {
+			return fmt.Errorf("connect_redirects[%d]: visibility must be silent, audit_only, or warn", i)
+		}
+		if r.OnFailure != "" && r.OnFailure != "fail_closed" && r.OnFailure != "fail_open" && r.OnFailure != "retry_original" {
+			return fmt.Errorf("connect_redirects[%d]: on_failure must be fail_closed, fail_open, or retry_original", i)
+		}
+	}
+
+	return nil
+}
+```
+
+**Step 2: Run tests**
+
+Run: `go test ./internal/policy/...`
+Expected: Tests pass
+
+**Step 3: Commit**
+
+```bash
+git add internal/policy/model.go
+git commit -m "feat(policy): add validation for redirect rules"
+```
+
+---
+
+### Task 3: Add Event Types for Redirects
+
+**Files:**
+- Modify: `internal/events/types.go`
+- Modify: `internal/events/schema.go`
+
+**Step 1: Add event type constants**
+
+In `types.go`, add to the EventType constants:
+
+```go
+const (
+	// ... existing events
+	EventDNSRedirect          EventType = "dns_redirect"
+	EventConnectRedirect      EventType = "connect_redirect"
+	EventConnectRedirectFallback EventType = "connect_redirect_fallback"
+)
+```
+
+**Step 2: Add to EventCategory map**
+
+```go
+var EventCategory = map[EventType]string{
+	// ... existing mappings
+	EventDNSRedirect:             "network",
+	EventConnectRedirect:         "network",
+	EventConnectRedirectFallback: "network",
+}
+```
+
+**Step 3: Add event schemas**
+
+In `schema.go`, add:
+
+```go
+// DNSRedirectEvent records DNS resolution redirects
+type DNSRedirectEvent struct {
+	BaseEvent
+	OriginalHost string `json:"original_host"`
+	ResolvedTo   string `json:"resolved_to"`
+	Rule         string `json:"rule"`
+	Visibility   string `json:"visibility"`
+}
+
+// ConnectRedirectEvent records TCP connection redirects
+type ConnectRedirectEvent struct {
+	BaseEvent
+	Original    string `json:"original"`     // host:port
+	RedirectedTo string `json:"redirected_to"` // host:port
+	Rule        string `json:"rule"`
+	TLSMode     string `json:"tls_mode,omitempty"`
+	Visibility  string `json:"visibility"`
+	Message     string `json:"message,omitempty"`
+}
+
+// ConnectRedirectFallbackEvent records fallback to original destination
+type ConnectRedirectFallbackEvent struct {
+	BaseEvent
+	Original          string `json:"original"`
+	RedirectAttempted string `json:"redirect_attempted"`
+	Error             string `json:"error"`
+	Action            string `json:"action"` // fail_open, retry_original
+	Status            string `json:"status"` // connected_to_original, failed
+	Rule              string `json:"rule"`
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go build ./...`
+Expected: Build succeeds
+
+**Step 5: Commit**
+
+```bash
+git add internal/events/types.go internal/events/schema.go
+git commit -m "feat(events): add DNS and connect redirect event types"
+```
+
+---
+
+### Task 4: Add Compiled Rules to Policy Engine
+
+**Files:**
+- Modify: `internal/policy/engine.go`
+
+**Step 1: Add compiled rule types**
+
+Add after existing compiled types:
+
+```go
+type compiledDnsRedirectRule struct {
+	rule    DnsRedirectRule
+	pattern *regexp.Regexp
+}
+
+type compiledConnectRedirectRule struct {
+	rule    ConnectRedirectRule
+	pattern *regexp.Regexp
+}
+```
+
+**Step 2: Add fields to Engine struct**
+
+```go
+type Engine struct {
+	// ... existing fields
+	dnsRedirectRules     []compiledDnsRedirectRule
+	connectRedirectRules []compiledConnectRedirectRule
+}
+```
+
+**Step 3: Add compilation in NewEngine**
+
+In the `NewEngine` function, add:
+
+```go
+// Compile DNS redirect rules
+for _, r := range p.DnsRedirectRules {
+	pattern, _ := regexp.Compile(r.Match) // Already validated
+	e.dnsRedirectRules = append(e.dnsRedirectRules, compiledDnsRedirectRule{
+		rule:    r,
+		pattern: pattern,
+	})
+}
+
+// Compile connect redirect rules
+for _, r := range p.ConnectRedirectRules {
+	pattern, _ := regexp.Compile(r.Match) // Already validated
+	e.connectRedirectRules = append(e.connectRedirectRules, compiledConnectRedirectRule{
+		rule:    r,
+		pattern: pattern,
+	})
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go build ./...`
+Expected: Build succeeds
+
+**Step 5: Commit**
+
+```bash
+git add internal/policy/engine.go
+git commit -m "feat(policy): compile DNS and connect redirect rules in engine"
+```
+
+---
+
+### Task 5: Add Evaluation Methods to Engine
+
+**Files:**
+- Modify: `internal/policy/engine.go`
+
+**Step 1: Add DNS redirect evaluation**
+
+```go
+// DnsRedirectResult contains the result of DNS redirect evaluation
+type DnsRedirectResult struct {
+	Matched    bool
+	Rule       string
+	ResolveTo  string
+	Visibility string
+	OnFailure  string
+}
+
+// EvaluateDnsRedirect checks if a hostname should be redirected
+func (e *Engine) EvaluateDnsRedirect(hostname string) *DnsRedirectResult {
+	for _, r := range e.dnsRedirectRules {
+		if r.pattern.MatchString(hostname) {
+			visibility := r.rule.Visibility
+			if visibility == "" {
+				visibility = "audit_only"
+			}
+			onFailure := r.rule.OnFailure
+			if onFailure == "" {
+				onFailure = "fail_closed"
+			}
+			return &DnsRedirectResult{
+				Matched:    true,
+				Rule:       r.rule.Name,
+				ResolveTo:  r.rule.ResolveTo,
+				Visibility: visibility,
+				OnFailure:  onFailure,
+			}
+		}
+	}
+	return &DnsRedirectResult{Matched: false}
+}
+```
+
+**Step 2: Add connect redirect evaluation**
+
+```go
+// ConnectRedirectResult contains the result of connect redirect evaluation
+type ConnectRedirectResult struct {
+	Matched    bool
+	Rule       string
+	RedirectTo string
+	TLSMode    string
+	SNI        string
+	Visibility string
+	Message    string
+	OnFailure  string
+}
+
+// EvaluateConnectRedirect checks if a connection should be redirected
+func (e *Engine) EvaluateConnectRedirect(hostPort string) *ConnectRedirectResult {
+	for _, r := range e.connectRedirectRules {
+		if r.pattern.MatchString(hostPort) {
+			visibility := r.rule.Visibility
+			if visibility == "" {
+				visibility = "audit_only"
+			}
+			onFailure := r.rule.OnFailure
+			if onFailure == "" {
+				onFailure = "fail_closed"
+			}
+			tlsMode := "passthrough"
+			sni := ""
+			if r.rule.TLS != nil {
+				if r.rule.TLS.Mode != "" {
+					tlsMode = r.rule.TLS.Mode
+				}
+				sni = r.rule.TLS.SNI
+			}
+			return &ConnectRedirectResult{
+				Matched:    true,
+				Rule:       r.rule.Name,
+				RedirectTo: r.rule.RedirectTo,
+				TLSMode:    tlsMode,
+				SNI:        sni,
+				Visibility: visibility,
+				Message:    r.rule.Message,
+				OnFailure:  onFailure,
+			}
+		}
+	}
+	return &ConnectRedirectResult{Matched: false}
+}
+```
+
+**Step 3: Run tests**
+
+Run: `go test ./internal/policy/...`
+Expected: Tests pass
+
+**Step 4: Commit**
+
+```bash
+git add internal/policy/engine.go
+git commit -m "feat(policy): add DNS and connect redirect evaluation methods"
+```
+
+---
+
+### Task 6: Write Unit Tests for Redirect Rules
+
+**Files:**
+- Create: `internal/policy/redirect_test.go`
+
+**Step 1: Create test file**
+
+```go
+package policy
+
+import (
+	"testing"
+)
+
+func TestDnsRedirectRuleValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    DnsRedirectRule
+		wantErr bool
+	}{
+		{
+			name: "valid rule",
+			rule: DnsRedirectRule{
+				Name:      "test",
+				Match:     ".*\\.anthropic\\.com",
+				ResolveTo: "10.0.0.50",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			rule: DnsRedirectRule{
+				Match:     ".*\\.anthropic\\.com",
+				ResolveTo: "10.0.0.50",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid regex",
+			rule: DnsRedirectRule{
+				Name:      "test",
+				Match:     "[invalid",
+				ResolveTo: "10.0.0.50",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid IP",
+			rule: DnsRedirectRule{
+				Name:      "test",
+				Match:     ".*",
+				ResolveTo: "not-an-ip",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid visibility",
+			rule: DnsRedirectRule{
+				Name:       "test",
+				Match:      ".*",
+				ResolveTo:  "10.0.0.1",
+				Visibility: "invalid",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Policy{
+				Version:          1,
+				Name:             "test",
+				DnsRedirectRules: []DnsRedirectRule{tt.rule},
+			}
+			err := p.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestConnectRedirectRuleValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    ConnectRedirectRule
+		wantErr bool
+	}{
+		{
+			name: "valid rule",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      "api\\.anthropic\\.com:443",
+				RedirectTo: "vertex-proxy:443",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with TLS passthrough",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				TLS:        &ConnectRedirectTLSConfig{Mode: "passthrough"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "rewrite_sni without sni",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				TLS:        &ConnectRedirectTLSConfig{Mode: "rewrite_sni"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "rewrite_sni with sni",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				TLS:        &ConnectRedirectTLSConfig{Mode: "rewrite_sni", SNI: "proxy.internal"},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Policy{
+				Version:              1,
+				Name:                 "test",
+				ConnectRedirectRules: []ConnectRedirectRule{tt.rule},
+			}
+			err := p.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEvaluateDnsRedirect(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		DnsRedirectRules: []DnsRedirectRule{
+			{
+				Name:       "anthropic-redirect",
+				Match:      ".*\\.anthropic\\.com",
+				ResolveTo:  "10.0.0.50",
+				Visibility: "warn",
+			},
+		},
+	}
+
+	engine, err := NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	tests := []struct {
+		hostname string
+		wantMatch bool
+		wantIP    string
+	}{
+		{"api.anthropic.com", true, "10.0.0.50"},
+		{"console.anthropic.com", true, "10.0.0.50"},
+		{"google.com", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hostname, func(t *testing.T) {
+			result := engine.EvaluateDnsRedirect(tt.hostname)
+			if result.Matched != tt.wantMatch {
+				t.Errorf("EvaluateDnsRedirect(%s) matched = %v, want %v", tt.hostname, result.Matched, tt.wantMatch)
+			}
+			if result.Matched && result.ResolveTo != tt.wantIP {
+				t.Errorf("EvaluateDnsRedirect(%s) resolveTo = %v, want %v", tt.hostname, result.ResolveTo, tt.wantIP)
+			}
+		})
+	}
+}
+
+func TestEvaluateConnectRedirect(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		ConnectRedirectRules: []ConnectRedirectRule{
+			{
+				Name:       "anthropic-redirect",
+				Match:      "api\\.anthropic\\.com:443",
+				RedirectTo: "vertex-proxy.internal:443",
+				Message:    "Routed through Vertex",
+			},
+		},
+	}
+
+	engine, err := NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	tests := []struct {
+		hostPort   string
+		wantMatch  bool
+		wantTarget string
+	}{
+		{"api.anthropic.com:443", true, "vertex-proxy.internal:443"},
+		{"api.anthropic.com:80", false, ""},
+		{"google.com:443", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hostPort, func(t *testing.T) {
+			result := engine.EvaluateConnectRedirect(tt.hostPort)
+			if result.Matched != tt.wantMatch {
+				t.Errorf("EvaluateConnectRedirect(%s) matched = %v, want %v", tt.hostPort, result.Matched, tt.wantMatch)
+			}
+			if result.Matched && result.RedirectTo != tt.wantTarget {
+				t.Errorf("EvaluateConnectRedirect(%s) redirectTo = %v, want %v", tt.hostPort, result.RedirectTo, tt.wantTarget)
+			}
+		})
+	}
+}
+```
+
+**Step 2: Run tests**
+
+Run: `go test ./internal/policy/... -v`
+Expected: All tests pass
+
+**Step 3: Commit**
+
+```bash
+git add internal/policy/redirect_test.go
+git commit -m "test(policy): add unit tests for redirect rules"
+```
+
+---
+
+### Task 7: Add Hostname-to-IP Correlation Map
+
+**Files:**
+- Create: `internal/netmonitor/redirect/correlation.go`
+
+**Step 1: Create correlation map**
+
+```go
+package redirect
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// HostnameEntry stores resolved IPs for a hostname
+type HostnameEntry struct {
+	Hostname  string
+	IPs       []net.IP
+	ExpiresAt time.Time
+}
+
+// CorrelationMap maps hostnames to IPs and vice versa for connect redirect matching
+type CorrelationMap struct {
+	mu          sync.RWMutex
+	hostnameToIP map[string]*HostnameEntry
+	ipToHostname map[string]string // IP string -> hostname
+	ttl         time.Duration
+}
+
+// NewCorrelationMap creates a new correlation map with the given TTL
+func NewCorrelationMap(ttl time.Duration) *CorrelationMap {
+	return &CorrelationMap{
+		hostnameToIP: make(map[string]*HostnameEntry),
+		ipToHostname: make(map[string]string),
+		ttl:          ttl,
+	}
+}
+
+// AddResolution records a DNS resolution
+func (m *CorrelationMap) AddResolution(hostname string, ips []net.IP) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry := &HostnameEntry{
+		Hostname:  hostname,
+		IPs:       ips,
+		ExpiresAt: time.Now().Add(m.ttl),
+	}
+	m.hostnameToIP[hostname] = entry
+
+	for _, ip := range ips {
+		m.ipToHostname[ip.String()] = hostname
+	}
+}
+
+// LookupHostname returns the hostname for an IP address
+func (m *CorrelationMap) LookupHostname(ip net.IP) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	hostname, ok := m.ipToHostname[ip.String()]
+	if !ok {
+		return "", false
+	}
+
+	// Check if entry is still valid
+	entry, exists := m.hostnameToIP[hostname]
+	if !exists || time.Now().After(entry.ExpiresAt) {
+		return "", false
+	}
+
+	return hostname, true
+}
+
+// Cleanup removes expired entries
+func (m *CorrelationMap) Cleanup() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	for hostname, entry := range m.hostnameToIP {
+		if now.After(entry.ExpiresAt) {
+			for _, ip := range entry.IPs {
+				delete(m.ipToHostname, ip.String())
+			}
+			delete(m.hostnameToIP, hostname)
+		}
+	}
+}
+```
+
+**Step 2: Run tests**
+
+Run: `go build ./...`
+Expected: Build succeeds
+
+**Step 3: Commit**
+
+```bash
+git add internal/netmonitor/redirect/correlation.go
+git commit -m "feat(redirect): add hostname-to-IP correlation map"
+```
+
+---
+
+### Task 8: Write Tests for Correlation Map
+
+**Files:**
+- Create: `internal/netmonitor/redirect/correlation_test.go`
+
+**Step 1: Create test file**
+
+```go
+package redirect
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestCorrelationMap_AddAndLookup(t *testing.T) {
+	m := NewCorrelationMap(time.Minute)
+
+	ips := []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("10.0.0.2")}
+	m.AddResolution("api.anthropic.com", ips)
+
+	// Lookup by first IP
+	hostname, ok := m.LookupHostname(net.ParseIP("10.0.0.1"))
+	if !ok {
+		t.Error("expected to find hostname for 10.0.0.1")
+	}
+	if hostname != "api.anthropic.com" {
+		t.Errorf("expected api.anthropic.com, got %s", hostname)
+	}
+
+	// Lookup by second IP
+	hostname, ok = m.LookupHostname(net.ParseIP("10.0.0.2"))
+	if !ok {
+		t.Error("expected to find hostname for 10.0.0.2")
+	}
+	if hostname != "api.anthropic.com" {
+		t.Errorf("expected api.anthropic.com, got %s", hostname)
+	}
+
+	// Lookup unknown IP
+	_, ok = m.LookupHostname(net.ParseIP("192.168.1.1"))
+	if ok {
+		t.Error("expected not to find hostname for unknown IP")
+	}
+}
+
+func TestCorrelationMap_Expiry(t *testing.T) {
+	m := NewCorrelationMap(10 * time.Millisecond)
+
+	ips := []net.IP{net.ParseIP("10.0.0.1")}
+	m.AddResolution("api.anthropic.com", ips)
+
+	// Should find immediately
+	_, ok := m.LookupHostname(net.ParseIP("10.0.0.1"))
+	if !ok {
+		t.Error("expected to find hostname immediately after adding")
+	}
+
+	// Wait for expiry
+	time.Sleep(20 * time.Millisecond)
+
+	// Should not find after expiry
+	_, ok = m.LookupHostname(net.ParseIP("10.0.0.1"))
+	if ok {
+		t.Error("expected not to find hostname after expiry")
+	}
+}
+
+func TestCorrelationMap_Cleanup(t *testing.T) {
+	m := NewCorrelationMap(10 * time.Millisecond)
+
+	ips := []net.IP{net.ParseIP("10.0.0.1")}
+	m.AddResolution("api.anthropic.com", ips)
+
+	time.Sleep(20 * time.Millisecond)
+	m.Cleanup()
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(m.hostnameToIP) != 0 {
+		t.Errorf("expected hostnameToIP to be empty after cleanup, got %d entries", len(m.hostnameToIP))
+	}
+	if len(m.ipToHostname) != 0 {
+		t.Errorf("expected ipToHostname to be empty after cleanup, got %d entries", len(m.ipToHostname))
+	}
+}
+```
+
+**Step 2: Run tests**
+
+Run: `go test ./internal/netmonitor/redirect/... -v`
+Expected: All tests pass
+
+**Step 3: Commit**
+
+```bash
+git add internal/netmonitor/redirect/correlation_test.go
+git commit -m "test(redirect): add correlation map tests"
+```
+
+---
+
+### Task 9: Integrate DNS Redirect with Existing DNS Interceptor
+
+**Files:**
+- Modify: `internal/netmonitor/dns.go`
+
+**Step 1: Read existing DNS interceptor structure**
+
+First, read the existing dns.go to understand the structure.
+
+**Step 2: Add redirect evaluation to DNS interception**
+
+This task requires reading the existing code and integrating the redirect evaluation. The specific changes depend on the current structure of dns.go.
+
+Key integration points:
+1. After parsing DNS query hostname
+2. Call `engine.EvaluateDnsRedirect(hostname)`
+3. If matched, modify response to return redirected IP
+4. Emit DNSRedirectEvent if visibility is not "silent"
+5. Update correlation map with the redirect
+
+**Step 3: Run tests**
+
+Run: `go test ./internal/netmonitor/... -v`
+Expected: Tests pass
+
+**Step 4: Commit**
+
+```bash
+git add internal/netmonitor/dns.go
+git commit -m "feat(dns): integrate DNS redirect evaluation"
+```
+
+---
+
+### Task 10: Integrate Connect Redirect with eBPF Collector
+
+**Files:**
+- Modify: `internal/netmonitor/ebpf/collector.go`
+
+**Step 1: Read existing collector structure**
+
+First, read the existing collector.go to understand how connect events are processed.
+
+**Step 2: Add redirect evaluation to connect handling**
+
+Key integration points:
+1. When connect event is received from eBPF
+2. Look up hostname from correlation map using destination IP
+3. Call `engine.EvaluateConnectRedirect(hostname:port)`
+4. If matched, modify the destination in the response/map
+5. Emit ConnectRedirectEvent if visibility is not "silent"
+
+**Step 3: Run tests**
+
+Run: `go test ./internal/netmonitor/ebpf/... -v`
+Expected: Tests pass
+
+**Step 4: Commit**
+
+```bash
+git add internal/netmonitor/ebpf/collector.go
+git commit -m "feat(ebpf): integrate connect redirect evaluation"
+```
+
+---
+
+### Task 11: Add Integration Test
+
+**Files:**
+- Create: `internal/netmonitor/redirect/integration_test.go`
+
+**Step 1: Create integration test**
+
+```go
+//go:build integration
+
+package redirect
+
+import (
+	"testing"
+
+	"github.com/your-org/agentsh/internal/policy"
+)
+
+func TestDNSRedirectIntegration(t *testing.T) {
+	// Load test policy with DNS redirects
+	p := &policy.Policy{
+		Version: 1,
+		Name:    "test",
+		DnsRedirectRules: []policy.DnsRedirectRule{
+			{
+				Name:       "anthropic-to-vertex",
+				Match:      ".*\\.anthropic\\.com",
+				ResolveTo:  "10.0.0.50",
+				Visibility: "audit_only",
+			},
+		},
+	}
+
+	engine, err := policy.NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("failed to create engine: %v", err)
+	}
+
+	// Test DNS evaluation
+	result := engine.EvaluateDnsRedirect("api.anthropic.com")
+	if !result.Matched {
+		t.Error("expected DNS redirect to match")
+	}
+	if result.ResolveTo != "10.0.0.50" {
+		t.Errorf("expected resolve_to 10.0.0.50, got %s", result.ResolveTo)
+	}
+}
+
+func TestConnectRedirectIntegration(t *testing.T) {
+	p := &policy.Policy{
+		Version: 1,
+		Name:    "test",
+		ConnectRedirectRules: []policy.ConnectRedirectRule{
+			{
+				Name:       "anthropic-to-vertex",
+				Match:      "api\\.anthropic\\.com:443",
+				RedirectTo: "vertex-proxy.internal:443",
+				Message:    "Routed through Vertex AI",
+			},
+		},
+	}
+
+	engine, err := policy.NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("failed to create engine: %v", err)
+	}
+
+	result := engine.EvaluateConnectRedirect("api.anthropic.com:443")
+	if !result.Matched {
+		t.Error("expected connect redirect to match")
+	}
+	if result.RedirectTo != "vertex-proxy.internal:443" {
+		t.Errorf("expected redirect_to vertex-proxy.internal:443, got %s", result.RedirectTo)
+	}
+}
+```
+
+**Step 2: Run integration tests**
+
+Run: `go test ./internal/netmonitor/redirect/... -tags=integration -v`
+Expected: Tests pass
+
+**Step 3: Commit**
+
+```bash
+git add internal/netmonitor/redirect/integration_test.go
+git commit -m "test(redirect): add integration tests"
+```
+
+---
+
+### Task 12: Update Documentation
+
+**Files:**
+- Modify: `docs/plans/2026-01-29-network-redirect-design.md` (mark as implemented)
+
+**Step 1: Add implementation status**
+
+Add to the top of the design doc:
+
+```markdown
+**Status:** Implemented (Tasks 1-11 complete)
+**Branch:** feature/network-redirect
+```
+
+**Step 2: Commit**
+
+```bash
+git add docs/plans/2026-01-29-network-redirect-design.md
+git commit -m "docs: mark network redirect design as implemented"
+```
+
+---
+
+## Summary
+
+**Tasks 1-6:** Policy model, validation, events, engine compilation and evaluation
+**Tasks 7-8:** Hostname-to-IP correlation map for connect redirects
+**Tasks 9-10:** Integration with existing DNS and eBPF infrastructure
+**Tasks 11-12:** Integration tests and documentation
+
+Each task is self-contained with clear file paths, code, and commit points.

--- a/internal/events/schema.go
+++ b/internal/events/schema.go
@@ -4,10 +4,10 @@ package events
 type ShellInvokeEvent struct {
 	BaseEvent
 
-	Shell       string   `json:"shell"`        // "sh", "bash", "zsh", "powershell", "cmd"
-	InvokedAs   string   `json:"invoked_as"`   // Actual binary name used
-	Args        []string `json:"args"`         // Arguments passed
-	Mode        string   `json:"mode"`         // "command" (-c), "script", "interactive"
+	Shell       string   `json:"shell"`      // "sh", "bash", "zsh", "powershell", "cmd"
+	InvokedAs   string   `json:"invoked_as"` // Actual binary name used
+	Args        []string `json:"args"`       // Arguments passed
+	Mode        string   `json:"mode"`       // "command" (-c), "script", "interactive"
 	Command     string   `json:"command,omitempty"`
 	Script      string   `json:"script,omitempty"`
 	Intercepted bool     `json:"intercepted"`
@@ -117,12 +117,12 @@ type WindowsJobInfo struct {
 type ResourceLimitSetEvent struct {
 	BaseEvent
 
-	TargetPID    int              `json:"target_pid"`
-	TargetType   string           `json:"target_type"` // "session", "command", "process"
-	Limits       ResourceLimits   `json:"limits"`
-	LinuxCgroup  *LinuxCgroupInfo `json:"linux_cgroup,omitempty"`
+	TargetPID    int               `json:"target_pid"`
+	TargetType   string            `json:"target_type"` // "session", "command", "process"
+	Limits       ResourceLimits    `json:"limits"`
+	LinuxCgroup  *LinuxCgroupInfo  `json:"linux_cgroup,omitempty"`
 	DarwinRlimit *DarwinRlimitInfo `json:"darwin_rlimit,omitempty"`
-	WindowsJob   *WindowsJobInfo  `json:"windows_job,omitempty"`
+	WindowsJob   *WindowsJobInfo   `json:"windows_job,omitempty"`
 }
 
 // ResourceLimitWarningEvent - Usage approaching threshold.
@@ -228,7 +228,7 @@ type ProcessTreeKillEvent struct {
 type UnixSocketEvent struct {
 	BaseEvent
 
-	Operation    string `json:"operation"` // "connect", "bind", "listen", "accept"
+	Operation    string `json:"operation"`   // "connect", "bind", "listen", "accept"
 	SocketType   string `json:"socket_type"` // "stream", "dgram", "seqpacket"
 	Path         string `json:"path,omitempty"`
 	AbstractName string `json:"abstract_name,omitempty"`

--- a/internal/events/schema.go
+++ b/internal/events/schema.go
@@ -321,3 +321,34 @@ type XPCSandboxViolationEvent struct {
 	Operation   string `json:"operation"` // mach-lookup, mach-register
 	Profile     string `json:"profile,omitempty"`
 }
+
+// DNSRedirectEvent records DNS resolution redirects.
+type DNSRedirectEvent struct {
+	BaseEvent
+	OriginalHost string `json:"original_host"`
+	ResolvedTo   string `json:"resolved_to"`
+	Rule         string `json:"rule"`
+	Visibility   string `json:"visibility"`
+}
+
+// ConnectRedirectEvent records TCP connection redirects.
+type ConnectRedirectEvent struct {
+	BaseEvent
+	Original     string `json:"original"`      // host:port
+	RedirectedTo string `json:"redirected_to"` // host:port
+	Rule         string `json:"rule"`
+	TLSMode      string `json:"tls_mode,omitempty"`
+	Visibility   string `json:"visibility"`
+	Message      string `json:"message,omitempty"`
+}
+
+// ConnectRedirectFallbackEvent records fallback to original destination.
+type ConnectRedirectFallbackEvent struct {
+	BaseEvent
+	Original          string `json:"original"`
+	RedirectAttempted string `json:"redirect_attempted"`
+	Error             string `json:"error"`
+	Action            string `json:"action"` // fail_open, retry_original
+	Status            string `json:"status"` // connected_to_original, failed
+	Rule              string `json:"rule"`
+}

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -20,10 +20,13 @@ const (
 
 // Network operation events.
 const (
-	EventDNSQuery   EventType = "dns_query"
-	EventNetConnect EventType = "net_connect"
-	EventNetListen  EventType = "net_listen"
-	EventNetAccept  EventType = "net_accept"
+	EventDNSQuery                EventType = "dns_query"
+	EventNetConnect              EventType = "net_connect"
+	EventNetListen               EventType = "net_listen"
+	EventNetAccept               EventType = "net_accept"
+	EventDNSRedirect             EventType = "dns_redirect"
+	EventConnectRedirect         EventType = "connect_redirect"
+	EventConnectRedirectFallback EventType = "connect_redirect_fallback"
 )
 
 // Process operation events.
@@ -144,10 +147,13 @@ var EventCategory = map[EventType]string{
 	EventDirList:    "file",
 
 	// Network
-	EventDNSQuery:   "network",
-	EventNetConnect: "network",
-	EventNetListen:  "network",
-	EventNetAccept:  "network",
+	EventDNSQuery:                "network",
+	EventNetConnect:              "network",
+	EventNetListen:               "network",
+	EventNetAccept:               "network",
+	EventDNSRedirect:             "network",
+	EventConnectRedirect:         "network",
+	EventConnectRedirectFallback: "network",
 
 	// Process
 	EventProcessStart: "process",
@@ -221,6 +227,7 @@ var AllEventTypes = []EventType{
 	EventDirCreate, EventDirDelete, EventDirList,
 	// Network
 	EventDNSQuery, EventNetConnect, EventNetListen, EventNetAccept,
+	EventDNSRedirect, EventConnectRedirect, EventConnectRedirectFallback,
 	// Process
 	EventProcessStart, EventProcessEnd, EventProcessSpawn, EventProcessExit, EventProcessTree,
 	// Environment

--- a/internal/netmonitor/redirect/correlation.go
+++ b/internal/netmonitor/redirect/correlation.go
@@ -1,0 +1,83 @@
+package redirect
+
+import (
+	"net"
+	"sync"
+	"time"
+)
+
+// HostnameEntry stores resolved IPs for a hostname
+type HostnameEntry struct {
+	Hostname  string
+	IPs       []net.IP
+	ExpiresAt time.Time
+}
+
+// CorrelationMap maps hostnames to IPs and vice versa for connect redirect matching
+type CorrelationMap struct {
+	mu           sync.RWMutex
+	hostnameToIP map[string]*HostnameEntry
+	ipToHostname map[string]string // IP string -> hostname
+	ttl          time.Duration
+}
+
+// NewCorrelationMap creates a new correlation map with the given TTL
+func NewCorrelationMap(ttl time.Duration) *CorrelationMap {
+	return &CorrelationMap{
+		hostnameToIP: make(map[string]*HostnameEntry),
+		ipToHostname: make(map[string]string),
+		ttl:          ttl,
+	}
+}
+
+// AddResolution records a DNS resolution
+func (m *CorrelationMap) AddResolution(hostname string, ips []net.IP) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	entry := &HostnameEntry{
+		Hostname:  hostname,
+		IPs:       ips,
+		ExpiresAt: time.Now().Add(m.ttl),
+	}
+	m.hostnameToIP[hostname] = entry
+
+	for _, ip := range ips {
+		m.ipToHostname[ip.String()] = hostname
+	}
+}
+
+// LookupHostname returns the hostname for an IP address
+func (m *CorrelationMap) LookupHostname(ip net.IP) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	hostname, ok := m.ipToHostname[ip.String()]
+	if !ok {
+		return "", false
+	}
+
+	// Check if entry is still valid
+	entry, exists := m.hostnameToIP[hostname]
+	if !exists || time.Now().After(entry.ExpiresAt) {
+		return "", false
+	}
+
+	return hostname, true
+}
+
+// Cleanup removes expired entries
+func (m *CorrelationMap) Cleanup() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	for hostname, entry := range m.hostnameToIP {
+		if now.After(entry.ExpiresAt) {
+			for _, ip := range entry.IPs {
+				delete(m.ipToHostname, ip.String())
+			}
+			delete(m.hostnameToIP, hostname)
+		}
+	}
+}

--- a/internal/netmonitor/redirect/correlation_test.go
+++ b/internal/netmonitor/redirect/correlation_test.go
@@ -1,0 +1,80 @@
+package redirect
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestCorrelationMap_AddAndLookup(t *testing.T) {
+	m := NewCorrelationMap(time.Minute)
+
+	ips := []net.IP{net.ParseIP("10.0.0.1"), net.ParseIP("10.0.0.2")}
+	m.AddResolution("api.anthropic.com", ips)
+
+	// Lookup by first IP
+	hostname, ok := m.LookupHostname(net.ParseIP("10.0.0.1"))
+	if !ok {
+		t.Error("expected to find hostname for 10.0.0.1")
+	}
+	if hostname != "api.anthropic.com" {
+		t.Errorf("expected api.anthropic.com, got %s", hostname)
+	}
+
+	// Lookup by second IP
+	hostname, ok = m.LookupHostname(net.ParseIP("10.0.0.2"))
+	if !ok {
+		t.Error("expected to find hostname for 10.0.0.2")
+	}
+	if hostname != "api.anthropic.com" {
+		t.Errorf("expected api.anthropic.com, got %s", hostname)
+	}
+
+	// Lookup unknown IP
+	_, ok = m.LookupHostname(net.ParseIP("192.168.1.1"))
+	if ok {
+		t.Error("expected not to find hostname for unknown IP")
+	}
+}
+
+func TestCorrelationMap_Expiry(t *testing.T) {
+	m := NewCorrelationMap(10 * time.Millisecond)
+
+	ips := []net.IP{net.ParseIP("10.0.0.1")}
+	m.AddResolution("api.anthropic.com", ips)
+
+	// Should find immediately
+	_, ok := m.LookupHostname(net.ParseIP("10.0.0.1"))
+	if !ok {
+		t.Error("expected to find hostname immediately after adding")
+	}
+
+	// Wait for expiry
+	time.Sleep(20 * time.Millisecond)
+
+	// Should not find after expiry
+	_, ok = m.LookupHostname(net.ParseIP("10.0.0.1"))
+	if ok {
+		t.Error("expected not to find hostname after expiry")
+	}
+}
+
+func TestCorrelationMap_Cleanup(t *testing.T) {
+	m := NewCorrelationMap(10 * time.Millisecond)
+
+	ips := []net.IP{net.ParseIP("10.0.0.1")}
+	m.AddResolution("api.anthropic.com", ips)
+
+	time.Sleep(20 * time.Millisecond)
+	m.Cleanup()
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if len(m.hostnameToIP) != 0 {
+		t.Errorf("expected hostnameToIP to be empty after cleanup, got %d entries", len(m.hostnameToIP))
+	}
+	if len(m.ipToHostname) != 0 {
+		t.Errorf("expected ipToHostname to be empty after cleanup, got %d entries", len(m.ipToHostname))
+	}
+}

--- a/internal/netmonitor/redirect/e2e_test.go
+++ b/internal/netmonitor/redirect/e2e_test.go
@@ -1,0 +1,380 @@
+package redirect
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/policy"
+	"gopkg.in/yaml.v3"
+)
+
+// TestEndToEndDNSToConnectFlow tests the full flow:
+// 1. DNS resolution is intercepted and redirected
+// 2. Correlation map is updated with hostname -> IP
+// 3. Connect redirect can match by hostname using correlation map
+func TestEndToEndDNSToConnectFlow(t *testing.T) {
+	// Create policy with both DNS and connect redirects
+	p := &policy.Policy{
+		Version: 1,
+		Name:    "e2e-test",
+		DnsRedirectRules: []policy.DnsRedirectRule{
+			{
+				Name:       "anthropic-dns",
+				Match:      `api\.anthropic\.com`,
+				ResolveTo:  "10.0.0.50",
+				Visibility: "audit_only",
+			},
+		},
+		ConnectRedirectRules: []policy.ConnectRedirectRule{
+			{
+				Name:       "anthropic-connect",
+				Match:      `api\.anthropic\.com:443`,
+				RedirectTo: "vertex-proxy.internal:443",
+				Message:    "Routed to Vertex AI",
+			},
+		},
+	}
+
+	engine, err := policy.NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("failed to create engine: %v", err)
+	}
+
+	// Step 1: Simulate DNS interception
+	hostname := "api.anthropic.com"
+	dnsResult := engine.EvaluateDnsRedirect(hostname)
+	if !dnsResult.Matched {
+		t.Fatal("DNS redirect should match")
+	}
+
+	// Step 2: Simulate DNS response - correlation map records the mapping
+	correlationMap := NewCorrelationMap(5 * time.Minute)
+	redirectIP := net.ParseIP(dnsResult.ResolveTo)
+	correlationMap.AddResolution(hostname, []net.IP{redirectIP})
+
+	// Step 3: Later, when connect() happens, we only have the IP
+	// Simulate looking up the hostname from the IP
+	foundHostname, found := correlationMap.LookupHostname(redirectIP)
+	if !found {
+		t.Fatal("should find hostname from correlation map")
+	}
+	if foundHostname != hostname {
+		t.Errorf("expected hostname %s, got %s", hostname, foundHostname)
+	}
+
+	// Step 4: Evaluate connect redirect using the correlated hostname
+	hostPort := foundHostname + ":443"
+	connectResult := engine.EvaluateConnectRedirect(hostPort)
+	if !connectResult.Matched {
+		t.Fatal("connect redirect should match")
+	}
+	if connectResult.RedirectTo != "vertex-proxy.internal:443" {
+		t.Errorf("expected redirect to vertex-proxy.internal:443, got %s", connectResult.RedirectTo)
+	}
+	if connectResult.Message != "Routed to Vertex AI" {
+		t.Errorf("expected message 'Routed to Vertex AI', got %s", connectResult.Message)
+	}
+}
+
+// TestMultipleIPsCorrelation tests that all IPs from a DNS response can be correlated
+func TestMultipleIPsCorrelation(t *testing.T) {
+	correlationMap := NewCorrelationMap(5 * time.Minute)
+
+	hostname := "api.anthropic.com"
+	ips := []net.IP{
+		net.ParseIP("10.0.0.1"),
+		net.ParseIP("10.0.0.2"),
+		net.ParseIP("10.0.0.3"),
+	}
+
+	correlationMap.AddResolution(hostname, ips)
+
+	// All IPs should resolve to the same hostname
+	for _, ip := range ips {
+		found, ok := correlationMap.LookupHostname(ip)
+		if !ok {
+			t.Errorf("should find hostname for IP %s", ip)
+		}
+		if found != hostname {
+			t.Errorf("expected hostname %s for IP %s, got %s", hostname, ip, found)
+		}
+	}
+}
+
+// TestIPv6Correlation tests that IPv6 addresses work correctly
+func TestIPv6Correlation(t *testing.T) {
+	correlationMap := NewCorrelationMap(5 * time.Minute)
+
+	hostname := "api.anthropic.com"
+	ipv6 := net.ParseIP("2001:db8::1")
+
+	correlationMap.AddResolution(hostname, []net.IP{ipv6})
+
+	found, ok := correlationMap.LookupHostname(ipv6)
+	if !ok {
+		t.Error("should find hostname for IPv6 address")
+	}
+	if found != hostname {
+		t.Errorf("expected hostname %s, got %s", hostname, found)
+	}
+}
+
+// TestCorrelationMapOverwrite tests that new resolution overwrites old one
+func TestCorrelationMapOverwrite(t *testing.T) {
+	correlationMap := NewCorrelationMap(5 * time.Minute)
+
+	hostname := "api.anthropic.com"
+	oldIP := net.ParseIP("10.0.0.1")
+	newIP := net.ParseIP("10.0.0.2")
+
+	// First resolution
+	correlationMap.AddResolution(hostname, []net.IP{oldIP})
+
+	// Second resolution with new IP
+	correlationMap.AddResolution(hostname, []net.IP{newIP})
+
+	// New IP should work
+	found, ok := correlationMap.LookupHostname(newIP)
+	if !ok {
+		t.Error("should find hostname for new IP")
+	}
+	if found != hostname {
+		t.Errorf("expected hostname %s, got %s", hostname, found)
+	}
+
+	// Old IP should still work (we don't remove old mappings until cleanup)
+	found, ok = correlationMap.LookupHostname(oldIP)
+	if !ok {
+		t.Error("old IP should still be in map until cleanup")
+	}
+}
+
+// TestPolicyYAMLParsing tests that policy can be loaded from YAML
+func TestPolicyYAMLParsing(t *testing.T) {
+	yamlContent := `
+version: 1
+name: yaml-test
+dns_redirects:
+  - name: anthropic-dns
+    match: ".*\\.anthropic\\.com"
+    resolve_to: "10.0.0.50"
+    visibility: audit_only
+    on_failure: fail_closed
+connect_redirects:
+  - name: anthropic-connect
+    match: "api\\.anthropic\\.com:443"
+    redirect_to: "vertex-proxy.internal:443"
+    tls:
+      mode: passthrough
+    visibility: warn
+    message: "Routed through Vertex AI"
+    on_failure: fail_open
+`
+
+	p := &policy.Policy{}
+	err := yaml.Unmarshal([]byte(yamlContent), p)
+	if err != nil {
+		t.Fatalf("failed to parse policy YAML: %v", err)
+	}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("failed to validate policy: %v", err)
+	}
+
+	if len(p.DnsRedirectRules) != 1 {
+		t.Errorf("expected 1 DNS redirect rule, got %d", len(p.DnsRedirectRules))
+	}
+	if len(p.ConnectRedirectRules) != 1 {
+		t.Errorf("expected 1 connect redirect rule, got %d", len(p.ConnectRedirectRules))
+	}
+
+	// Verify DNS rule
+	dnsRule := p.DnsRedirectRules[0]
+	if dnsRule.Name != "anthropic-dns" {
+		t.Errorf("expected DNS rule name 'anthropic-dns', got %s", dnsRule.Name)
+	}
+	if dnsRule.ResolveTo != "10.0.0.50" {
+		t.Errorf("expected resolve_to '10.0.0.50', got %s", dnsRule.ResolveTo)
+	}
+	if dnsRule.Visibility != "audit_only" {
+		t.Errorf("expected visibility 'audit_only', got %s", dnsRule.Visibility)
+	}
+	if dnsRule.OnFailure != "fail_closed" {
+		t.Errorf("expected on_failure 'fail_closed', got %s", dnsRule.OnFailure)
+	}
+
+	// Verify connect rule
+	connectRule := p.ConnectRedirectRules[0]
+	if connectRule.Name != "anthropic-connect" {
+		t.Errorf("expected connect rule name 'anthropic-connect', got %s", connectRule.Name)
+	}
+	if connectRule.RedirectTo != "vertex-proxy.internal:443" {
+		t.Errorf("expected redirect_to 'vertex-proxy.internal:443', got %s", connectRule.RedirectTo)
+	}
+	if connectRule.TLS == nil || connectRule.TLS.Mode != "passthrough" {
+		t.Error("expected TLS mode 'passthrough'")
+	}
+	if connectRule.Visibility != "warn" {
+		t.Errorf("expected visibility 'warn', got %s", connectRule.Visibility)
+	}
+	if connectRule.Message != "Routed through Vertex AI" {
+		t.Errorf("expected message 'Routed through Vertex AI', got %s", connectRule.Message)
+	}
+	if connectRule.OnFailure != "fail_open" {
+		t.Errorf("expected on_failure 'fail_open', got %s", connectRule.OnFailure)
+	}
+
+	// Create engine and test evaluation
+	engine, err := policy.NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("failed to create engine: %v", err)
+	}
+
+	dnsResult := engine.EvaluateDnsRedirect("api.anthropic.com")
+	if !dnsResult.Matched {
+		t.Error("DNS redirect should match")
+	}
+
+	connectResult := engine.EvaluateConnectRedirect("api.anthropic.com:443")
+	if !connectResult.Matched {
+		t.Error("connect redirect should match")
+	}
+}
+
+// TestDefaultValues tests that default values are applied correctly
+func TestDefaultValues(t *testing.T) {
+	p := &policy.Policy{
+		Version: 1,
+		Name:    "defaults-test",
+		DnsRedirectRules: []policy.DnsRedirectRule{
+			{
+				Name:      "no-defaults",
+				Match:     ".*",
+				ResolveTo: "10.0.0.1",
+				// No visibility or on_failure specified
+			},
+		},
+		ConnectRedirectRules: []policy.ConnectRedirectRule{
+			{
+				Name:       "no-defaults",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				// No TLS, visibility, or on_failure specified
+			},
+		},
+	}
+
+	engine, err := policy.NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("failed to create engine: %v", err)
+	}
+
+	// Check DNS defaults
+	dnsResult := engine.EvaluateDnsRedirect("example.com")
+	if dnsResult.Visibility != "audit_only" {
+		t.Errorf("expected default visibility 'audit_only', got %s", dnsResult.Visibility)
+	}
+	if dnsResult.OnFailure != "fail_closed" {
+		t.Errorf("expected default on_failure 'fail_closed', got %s", dnsResult.OnFailure)
+	}
+
+	// Check connect defaults
+	connectResult := engine.EvaluateConnectRedirect("example.com:443")
+	if connectResult.Visibility != "audit_only" {
+		t.Errorf("expected default visibility 'audit_only', got %s", connectResult.Visibility)
+	}
+	if connectResult.OnFailure != "fail_closed" {
+		t.Errorf("expected default on_failure 'fail_closed', got %s", connectResult.OnFailure)
+	}
+	if connectResult.TLSMode != "passthrough" {
+		t.Errorf("expected default TLS mode 'passthrough', got %s", connectResult.TLSMode)
+	}
+}
+
+// TestComplexRegexPatterns tests various regex patterns
+func TestComplexRegexPatterns(t *testing.T) {
+	p := &policy.Policy{
+		Version: 1,
+		Name:    "regex-test",
+		DnsRedirectRules: []policy.DnsRedirectRule{
+			{
+				Name:      "exact-match",
+				Match:     `^api\.anthropic\.com$`,
+				ResolveTo: "10.0.0.1",
+			},
+			{
+				Name:      "subdomain-wildcard",
+				Match:     `.*\.internal\.anthropic\.com`,
+				ResolveTo: "10.0.0.2",
+			},
+			{
+				Name:      "alternation",
+				Match:     `(api|console)\.openai\.com`,
+				ResolveTo: "10.0.0.3",
+			},
+		},
+		ConnectRedirectRules: []policy.ConnectRedirectRule{
+			{
+				Name:       "any-https",
+				Match:      `.*:443`,
+				RedirectTo: "https-proxy:443",
+			},
+			{
+				Name:       "specific-port-range",
+				Match:      `.*:(8080|8443)`,
+				RedirectTo: "alt-proxy:8080",
+			},
+		},
+	}
+
+	engine, err := policy.NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("failed to create engine: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		evalType  string
+		input     string
+		wantMatch bool
+		wantRule  string
+	}{
+		// DNS tests
+		{"exact match", "dns", "api.anthropic.com", true, "exact-match"},
+		{"exact match fails on subdomain", "dns", "v2.api.anthropic.com", false, ""},
+		{"subdomain wildcard", "dns", "test.internal.anthropic.com", true, "subdomain-wildcard"},
+		{"alternation api", "dns", "api.openai.com", true, "alternation"},
+		{"alternation console", "dns", "console.openai.com", true, "alternation"},
+		{"alternation fails", "dns", "other.openai.com", false, ""},
+
+		// Connect tests
+		{"any https", "connect", "example.com:443", true, "any-https"},
+		{"port 8080", "connect", "example.com:8080", true, "specific-port-range"},
+		{"port 8443", "connect", "example.com:8443", true, "specific-port-range"},
+		{"port 80 no match", "connect", "example.com:80", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var matched bool
+			var rule string
+
+			if tt.evalType == "dns" {
+				result := engine.EvaluateDnsRedirect(tt.input)
+				matched = result.Matched
+				rule = result.Rule
+			} else {
+				result := engine.EvaluateConnectRedirect(tt.input)
+				matched = result.Matched
+				rule = result.Rule
+			}
+
+			if matched != tt.wantMatch {
+				t.Errorf("expected matched=%v, got %v", tt.wantMatch, matched)
+			}
+			if matched && rule != tt.wantRule {
+				t.Errorf("expected rule %s, got %s", tt.wantRule, rule)
+			}
+		})
+	}
+}

--- a/internal/netmonitor/redirect/integration_test.go
+++ b/internal/netmonitor/redirect/integration_test.go
@@ -1,0 +1,375 @@
+//go:build integration
+
+package redirect
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+func TestDNSRedirectIntegration(t *testing.T) {
+	// Load test policy with DNS redirects
+	p := &policy.Policy{
+		Version: 1,
+		Name:    "test",
+		DnsRedirectRules: []policy.DnsRedirectRule{
+			{
+				Name:       "anthropic-to-vertex",
+				Match:      ".*\\.anthropic\\.com",
+				ResolveTo:  "10.0.0.50",
+				Visibility: "audit_only",
+			},
+		},
+	}
+
+	engine, err := policy.NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("failed to create engine: %v", err)
+	}
+
+	// Test DNS evaluation
+	result := engine.EvaluateDnsRedirect("api.anthropic.com")
+	if !result.Matched {
+		t.Error("expected DNS redirect to match")
+	}
+	if result.ResolveTo != "10.0.0.50" {
+		t.Errorf("expected resolve_to 10.0.0.50, got %s", result.ResolveTo)
+	}
+}
+
+func TestConnectRedirectIntegration(t *testing.T) {
+	p := &policy.Policy{
+		Version: 1,
+		Name:    "test",
+		ConnectRedirectRules: []policy.ConnectRedirectRule{
+			{
+				Name:       "anthropic-to-vertex",
+				Match:      "api\\.anthropic\\.com:443",
+				RedirectTo: "vertex-proxy.internal:443",
+				Message:    "Routed through Vertex AI",
+			},
+		},
+	}
+
+	engine, err := policy.NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("failed to create engine: %v", err)
+	}
+
+	result := engine.EvaluateConnectRedirect("api.anthropic.com:443")
+	if !result.Matched {
+		t.Error("expected connect redirect to match")
+	}
+	if result.RedirectTo != "vertex-proxy.internal:443" {
+		t.Errorf("expected redirect_to vertex-proxy.internal:443, got %s", result.RedirectTo)
+	}
+}
+
+func TestCombinedRedirectIntegration(t *testing.T) {
+	// Test a policy with both DNS and connect redirects
+	p := &policy.Policy{
+		Version: 1,
+		Name:    "combined-test",
+		DnsRedirectRules: []policy.DnsRedirectRule{
+			{
+				Name:       "anthropic-dns",
+				Match:      ".*\\.anthropic\\.com",
+				ResolveTo:  "10.0.0.50",
+				Visibility: "audit_only",
+				OnFailure:  "fail_closed",
+			},
+			{
+				Name:       "openai-dns",
+				Match:      ".*\\.openai\\.com",
+				ResolveTo:  "10.0.0.51",
+				Visibility: "warn",
+			},
+		},
+		ConnectRedirectRules: []policy.ConnectRedirectRule{
+			{
+				Name:       "anthropic-connect",
+				Match:      ".*\\.anthropic\\.com:443",
+				RedirectTo: "vertex-proxy.internal:443",
+				TLS:        &policy.ConnectRedirectTLSConfig{Mode: "passthrough"},
+				Visibility: "audit_only",
+				Message:    "Routed through Vertex AI",
+			},
+			{
+				Name:       "openai-connect",
+				Match:      ".*\\.openai\\.com:443",
+				RedirectTo: "azure-proxy.internal:443",
+				TLS:        &policy.ConnectRedirectTLSConfig{Mode: "rewrite_sni", SNI: "azure-proxy.internal"},
+				Visibility: "warn",
+				Message:    "Routed through Azure OpenAI",
+			},
+		},
+	}
+
+	engine, err := policy.NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("failed to create engine: %v", err)
+	}
+
+	t.Run("DNS redirect anthropic", func(t *testing.T) {
+		result := engine.EvaluateDnsRedirect("api.anthropic.com")
+		if !result.Matched {
+			t.Error("expected DNS redirect to match")
+		}
+		if result.ResolveTo != "10.0.0.50" {
+			t.Errorf("expected resolve_to 10.0.0.50, got %s", result.ResolveTo)
+		}
+		if result.Rule != "anthropic-dns" {
+			t.Errorf("expected rule anthropic-dns, got %s", result.Rule)
+		}
+		if result.Visibility != "audit_only" {
+			t.Errorf("expected visibility audit_only, got %s", result.Visibility)
+		}
+		if result.OnFailure != "fail_closed" {
+			t.Errorf("expected on_failure fail_closed, got %s", result.OnFailure)
+		}
+	})
+
+	t.Run("DNS redirect openai", func(t *testing.T) {
+		result := engine.EvaluateDnsRedirect("api.openai.com")
+		if !result.Matched {
+			t.Error("expected DNS redirect to match")
+		}
+		if result.ResolveTo != "10.0.0.51" {
+			t.Errorf("expected resolve_to 10.0.0.51, got %s", result.ResolveTo)
+		}
+		if result.Rule != "openai-dns" {
+			t.Errorf("expected rule openai-dns, got %s", result.Rule)
+		}
+		if result.Visibility != "warn" {
+			t.Errorf("expected visibility warn, got %s", result.Visibility)
+		}
+	})
+
+	t.Run("DNS redirect no match", func(t *testing.T) {
+		result := engine.EvaluateDnsRedirect("api.example.com")
+		if result.Matched {
+			t.Error("expected DNS redirect not to match")
+		}
+	})
+
+	t.Run("Connect redirect anthropic", func(t *testing.T) {
+		result := engine.EvaluateConnectRedirect("api.anthropic.com:443")
+		if !result.Matched {
+			t.Error("expected connect redirect to match")
+		}
+		if result.RedirectTo != "vertex-proxy.internal:443" {
+			t.Errorf("expected redirect_to vertex-proxy.internal:443, got %s", result.RedirectTo)
+		}
+		if result.Rule != "anthropic-connect" {
+			t.Errorf("expected rule anthropic-connect, got %s", result.Rule)
+		}
+		if result.TLSMode != "passthrough" {
+			t.Errorf("expected TLS mode passthrough, got %s", result.TLSMode)
+		}
+		if result.Message != "Routed through Vertex AI" {
+			t.Errorf("expected message 'Routed through Vertex AI', got %s", result.Message)
+		}
+	})
+
+	t.Run("Connect redirect openai", func(t *testing.T) {
+		result := engine.EvaluateConnectRedirect("api.openai.com:443")
+		if !result.Matched {
+			t.Error("expected connect redirect to match")
+		}
+		if result.RedirectTo != "azure-proxy.internal:443" {
+			t.Errorf("expected redirect_to azure-proxy.internal:443, got %s", result.RedirectTo)
+		}
+		if result.Rule != "openai-connect" {
+			t.Errorf("expected rule openai-connect, got %s", result.Rule)
+		}
+		if result.TLSMode != "rewrite_sni" {
+			t.Errorf("expected TLS mode rewrite_sni, got %s", result.TLSMode)
+		}
+		if result.SNI != "azure-proxy.internal" {
+			t.Errorf("expected SNI azure-proxy.internal, got %s", result.SNI)
+		}
+		if result.Visibility != "warn" {
+			t.Errorf("expected visibility warn, got %s", result.Visibility)
+		}
+	})
+
+	t.Run("Connect redirect no match (wrong port)", func(t *testing.T) {
+		result := engine.EvaluateConnectRedirect("api.anthropic.com:80")
+		if result.Matched {
+			t.Error("expected connect redirect not to match for port 80")
+		}
+	})
+
+	t.Run("Connect redirect no match (unknown host)", func(t *testing.T) {
+		result := engine.EvaluateConnectRedirect("api.example.com:443")
+		if result.Matched {
+			t.Error("expected connect redirect not to match for unknown host")
+		}
+	})
+}
+
+func TestPolicyValidationIntegration(t *testing.T) {
+	t.Run("Valid policy", func(t *testing.T) {
+		p := &policy.Policy{
+			Version: 1,
+			Name:    "valid-test",
+			DnsRedirectRules: []policy.DnsRedirectRule{
+				{
+					Name:       "test-dns",
+					Match:      ".*\\.example\\.com",
+					ResolveTo:  "10.0.0.1",
+					Visibility: "silent",
+					OnFailure:  "fail_open",
+				},
+			},
+			ConnectRedirectRules: []policy.ConnectRedirectRule{
+				{
+					Name:       "test-connect",
+					Match:      ".*:443",
+					RedirectTo: "proxy:443",
+					TLS:        &policy.ConnectRedirectTLSConfig{Mode: "passthrough"},
+					Visibility: "audit_only",
+					OnFailure:  "retry_original",
+				},
+			},
+		}
+
+		if err := p.Validate(); err != nil {
+			t.Errorf("expected valid policy, got error: %v", err)
+		}
+	})
+
+	t.Run("Invalid DNS redirect - bad regex", func(t *testing.T) {
+		p := &policy.Policy{
+			Version: 1,
+			Name:    "invalid-test",
+			DnsRedirectRules: []policy.DnsRedirectRule{
+				{
+					Name:      "bad-regex",
+					Match:     "[invalid",
+					ResolveTo: "10.0.0.1",
+				},
+			},
+		}
+
+		if err := p.Validate(); err == nil {
+			t.Error("expected validation error for invalid regex")
+		}
+	})
+
+	t.Run("Invalid DNS redirect - bad IP", func(t *testing.T) {
+		p := &policy.Policy{
+			Version: 1,
+			Name:    "invalid-test",
+			DnsRedirectRules: []policy.DnsRedirectRule{
+				{
+					Name:      "bad-ip",
+					Match:     ".*",
+					ResolveTo: "not-an-ip",
+				},
+			},
+		}
+
+		if err := p.Validate(); err == nil {
+			t.Error("expected validation error for invalid IP")
+		}
+	})
+
+	t.Run("Invalid connect redirect - rewrite_sni without SNI", func(t *testing.T) {
+		p := &policy.Policy{
+			Version: 1,
+			Name:    "invalid-test",
+			ConnectRedirectRules: []policy.ConnectRedirectRule{
+				{
+					Name:       "bad-tls",
+					Match:      ".*:443",
+					RedirectTo: "proxy:443",
+					TLS:        &policy.ConnectRedirectTLSConfig{Mode: "rewrite_sni"},
+				},
+			},
+		}
+
+		if err := p.Validate(); err == nil {
+			t.Error("expected validation error for rewrite_sni without SNI")
+		}
+	})
+}
+
+func TestRuleOrderingIntegration(t *testing.T) {
+	// Verify that more specific rules are evaluated before general ones
+	// when placed first in the list
+	p := &policy.Policy{
+		Version: 1,
+		Name:    "ordering-test",
+		DnsRedirectRules: []policy.DnsRedirectRule{
+			{
+				Name:      "specific",
+				Match:     "^api\\.anthropic\\.com$",
+				ResolveTo: "10.0.0.1",
+			},
+			{
+				Name:      "general",
+				Match:     ".*\\.anthropic\\.com",
+				ResolveTo: "10.0.0.2",
+			},
+		},
+		ConnectRedirectRules: []policy.ConnectRedirectRule{
+			{
+				Name:       "specific",
+				Match:      "^api\\.anthropic\\.com:443$",
+				RedirectTo: "specific-proxy:443",
+			},
+			{
+				Name:       "general",
+				Match:      ".*\\.anthropic\\.com:443",
+				RedirectTo: "general-proxy:443",
+			},
+		},
+	}
+
+	engine, err := policy.NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("failed to create engine: %v", err)
+	}
+
+	t.Run("DNS specific rule matches first", func(t *testing.T) {
+		result := engine.EvaluateDnsRedirect("api.anthropic.com")
+		if result.Rule != "specific" {
+			t.Errorf("expected specific rule to match first, got %s", result.Rule)
+		}
+		if result.ResolveTo != "10.0.0.1" {
+			t.Errorf("expected resolve_to 10.0.0.1, got %s", result.ResolveTo)
+		}
+	})
+
+	t.Run("DNS general rule matches other subdomains", func(t *testing.T) {
+		result := engine.EvaluateDnsRedirect("console.anthropic.com")
+		if result.Rule != "general" {
+			t.Errorf("expected general rule to match, got %s", result.Rule)
+		}
+		if result.ResolveTo != "10.0.0.2" {
+			t.Errorf("expected resolve_to 10.0.0.2, got %s", result.ResolveTo)
+		}
+	})
+
+	t.Run("Connect specific rule matches first", func(t *testing.T) {
+		result := engine.EvaluateConnectRedirect("api.anthropic.com:443")
+		if result.Rule != "specific" {
+			t.Errorf("expected specific rule to match first, got %s", result.Rule)
+		}
+		if result.RedirectTo != "specific-proxy:443" {
+			t.Errorf("expected redirect_to specific-proxy:443, got %s", result.RedirectTo)
+		}
+	})
+
+	t.Run("Connect general rule matches other subdomains", func(t *testing.T) {
+		result := engine.EvaluateConnectRedirect("console.anthropic.com:443")
+		if result.Rule != "general" {
+			t.Errorf("expected general rule to match, got %s", result.Rule)
+		}
+		if result.RedirectTo != "general-proxy:443" {
+			t.Errorf("expected redirect_to general-proxy:443, got %s", result.RedirectTo)
+		}
+	})
+}

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -18,10 +18,10 @@ type Engine struct {
 	policy           *Policy
 	enforceApprovals bool
 
-	compiledFileRules    []compiledFileRule
-	compiledNetworkRules []compiledNetworkRule
-	compiledCommandRules []compiledCommandRule
-	compiledUnixRules    []compiledUnixRule
+	compiledFileRules     []compiledFileRule
+	compiledNetworkRules  []compiledNetworkRule
+	compiledCommandRules  []compiledCommandRule
+	compiledUnixRules     []compiledUnixRule
 	compiledRegistryRules []compiledRegistryRule
 
 	// Compiled redirect rules for DNS and connect interception

--- a/internal/policy/model.go
+++ b/internal/policy/model.go
@@ -12,12 +12,14 @@ type Policy struct {
 	Name        string `yaml:"name"`
 	Description string `yaml:"description"`
 
-	FileRules     []FileRule       `yaml:"file_rules"`
-	NetworkRules  []NetworkRule    `yaml:"network_rules"`
-	CommandRules  []CommandRule    `yaml:"command_rules"`
-	UnixRules     []UnixSocketRule `yaml:"unix_socket_rules"`
-	RegistryRules []RegistryRule   `yaml:"registry_rules"`
-	SignalRules   []SignalRule     `yaml:"signal_rules"`
+	FileRules            []FileRule            `yaml:"file_rules"`
+	NetworkRules         []NetworkRule         `yaml:"network_rules"`
+	CommandRules         []CommandRule         `yaml:"command_rules"`
+	UnixRules            []UnixSocketRule      `yaml:"unix_socket_rules"`
+	RegistryRules        []RegistryRule        `yaml:"registry_rules"`
+	SignalRules          []SignalRule          `yaml:"signal_rules"`
+	DnsRedirectRules     []DnsRedirectRule     `yaml:"dns_redirects,omitempty"`
+	ConnectRedirectRules []ConnectRedirectRule `yaml:"connect_redirects,omitempty"`
 
 	ResourceLimits ResourceLimits `yaml:"resource_limits"`
 	EnvPolicy      EnvPolicy      `yaml:"env_policy"`
@@ -140,6 +142,32 @@ type SignalTargetSpec struct {
 	Pattern string `yaml:"pattern,omitempty"` // For process name matching
 	Min     int    `yaml:"min,omitempty"`     // For pid_range
 	Max     int    `yaml:"max,omitempty"`     // For pid_range
+}
+
+// DnsRedirectRule redirects DNS resolution for matching hostnames
+type DnsRedirectRule struct {
+	Name       string `yaml:"name"`
+	Match      string `yaml:"match"`                // regex pattern for hostname
+	ResolveTo  string `yaml:"resolve_to"`           // IP address to return
+	Visibility string `yaml:"visibility,omitempty"` // silent, audit_only, warn
+	OnFailure  string `yaml:"on_failure,omitempty"` // fail_closed, fail_open, retry_original
+}
+
+// ConnectRedirectRule redirects TCP connections for matching host:port
+type ConnectRedirectRule struct {
+	Name       string                    `yaml:"name"`
+	Match      string                    `yaml:"match"`                // regex pattern for host:port
+	RedirectTo string                    `yaml:"redirect_to"`          // new host:port destination
+	TLS        *ConnectRedirectTLSConfig `yaml:"tls,omitempty"`
+	Visibility string                    `yaml:"visibility,omitempty"` // silent, audit_only, warn
+	Message    string                    `yaml:"message,omitempty"`
+	OnFailure  string                    `yaml:"on_failure,omitempty"` // fail_closed, fail_open, retry_original
+}
+
+// ConnectRedirectTLSConfig controls TLS handling for connect redirects
+type ConnectRedirectTLSConfig struct {
+	Mode string `yaml:"mode,omitempty"` // passthrough, rewrite_sni
+	SNI  string `yaml:"sni,omitempty"`  // required if mode is rewrite_sni
 }
 
 type ResourceLimits struct {

--- a/internal/policy/model.go
+++ b/internal/policy/model.go
@@ -30,7 +30,7 @@ type Policy struct {
 	EnvInject map[string]string `yaml:"env_inject"`
 
 	// Process context-based rules (parent-conditional policies)
-	ProcessContexts   map[string]ProcessContext `yaml:"process_contexts,omitempty"`
+	ProcessContexts   map[string]ProcessContext        `yaml:"process_contexts,omitempty"`
 	ProcessIdentities map[string]ProcessIdentityConfig `yaml:"process_identities,omitempty"`
 }
 
@@ -158,8 +158,8 @@ type DnsRedirectRule struct {
 // ConnectRedirectRule redirects TCP connections for matching host:port
 type ConnectRedirectRule struct {
 	Name       string                    `yaml:"name"`
-	Match      string                    `yaml:"match"`                // regex pattern for host:port
-	RedirectTo string                    `yaml:"redirect_to"`          // new host:port destination
+	Match      string                    `yaml:"match"`       // regex pattern for host:port
+	RedirectTo string                    `yaml:"redirect_to"` // new host:port destination
 	TLS        *ConnectRedirectTLSConfig `yaml:"tls,omitempty"`
 	Visibility string                    `yaml:"visibility,omitempty"` // silent, audit_only, warn
 	Message    string                    `yaml:"message,omitempty"`
@@ -213,11 +213,11 @@ type ProcessContext struct {
 	ChainRules []ChainRuleConfig `yaml:"chain_rules,omitempty"`
 
 	// Rules that apply within this context (override global rules)
-	CommandRules  []CommandRule    `yaml:"command_rules,omitempty"`
-	FileRules     []FileRule       `yaml:"file_rules,omitempty"`
-	NetworkRules  []NetworkRule    `yaml:"network_rules,omitempty"`
-	UnixRules     []UnixSocketRule `yaml:"unix_socket_rules,omitempty"`
-	EnvPolicy     *EnvPolicy       `yaml:"env_policy,omitempty"`
+	CommandRules []CommandRule    `yaml:"command_rules,omitempty"`
+	FileRules    []FileRule       `yaml:"file_rules,omitempty"`
+	NetworkRules []NetworkRule    `yaml:"network_rules,omitempty"`
+	UnixRules    []UnixSocketRule `yaml:"unix_socket_rules,omitempty"`
+	EnvPolicy    *EnvPolicy       `yaml:"env_policy,omitempty"`
 
 	// Quick command lists (simpler alternative to full CommandRules)
 	AllowedCommands []string `yaml:"allowed_commands,omitempty"` // Commands allowed without restriction
@@ -279,10 +279,10 @@ type ChainConditionConfig struct {
 	IsAgent   *bool `yaml:"is_agent,omitempty"`   // Is detected as agent
 
 	// Execution context conditions
-	EnvContains  []string `yaml:"env_contains,omitempty"`  // Environment variable patterns
-	ArgsContain  []string `yaml:"args_contain,omitempty"`  // Command argument patterns
-	CommMatches  []string `yaml:"comm_matches,omitempty"`  // Command name patterns
-	PathMatches  []string `yaml:"path_matches,omitempty"`  // Executable path patterns
+	EnvContains []string `yaml:"env_contains,omitempty"` // Environment variable patterns
+	ArgsContain []string `yaml:"args_contain,omitempty"` // Command argument patterns
+	CommMatches []string `yaml:"comm_matches,omitempty"` // Command name patterns
+	PathMatches []string `yaml:"path_matches,omitempty"` // Executable path patterns
 
 	// Source conditions
 	SourceName    []string `yaml:"source_name,omitempty"`    // Source process name patterns

--- a/internal/policy/redirect_test.go
+++ b/internal/policy/redirect_test.go
@@ -30,10 +30,10 @@ func TestPathRedirector_Redirect(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		path       string
-		operation  string
-		wantPath   string
+		name         string
+		path         string
+		operation    string
+		wantPath     string
 		wantRedirect bool
 	}{
 		{

--- a/internal/policy/redirect_test.go
+++ b/internal/policy/redirect_test.go
@@ -277,3 +277,691 @@ func TestDecision_AuditAndSoftDelete(t *testing.T) {
 		t.Errorf("EffectiveDecision = %q, want allow (soft_delete proceeds with trash)", dec.EffectiveDecision)
 	}
 }
+
+// --- DNS and Connect Redirect Tests ---
+
+func TestDnsRedirectRuleValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    DnsRedirectRule
+		wantErr bool
+	}{
+		{
+			name: "valid rule",
+			rule: DnsRedirectRule{
+				Name:      "test",
+				Match:     ".*\\.anthropic\\.com",
+				ResolveTo: "10.0.0.50",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			rule: DnsRedirectRule{
+				Match:     ".*\\.anthropic\\.com",
+				ResolveTo: "10.0.0.50",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing match",
+			rule: DnsRedirectRule{
+				Name:      "test",
+				ResolveTo: "10.0.0.50",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid regex",
+			rule: DnsRedirectRule{
+				Name:      "test",
+				Match:     "[invalid",
+				ResolveTo: "10.0.0.50",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing resolve_to",
+			rule: DnsRedirectRule{
+				Name:  "test",
+				Match: ".*",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid IP",
+			rule: DnsRedirectRule{
+				Name:      "test",
+				Match:     ".*",
+				ResolveTo: "not-an-ip",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid visibility silent",
+			rule: DnsRedirectRule{
+				Name:       "test",
+				Match:      ".*",
+				ResolveTo:  "10.0.0.1",
+				Visibility: "silent",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid visibility audit_only",
+			rule: DnsRedirectRule{
+				Name:       "test",
+				Match:      ".*",
+				ResolveTo:  "10.0.0.1",
+				Visibility: "audit_only",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid visibility warn",
+			rule: DnsRedirectRule{
+				Name:       "test",
+				Match:      ".*",
+				ResolveTo:  "10.0.0.1",
+				Visibility: "warn",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid visibility",
+			rule: DnsRedirectRule{
+				Name:       "test",
+				Match:      ".*",
+				ResolveTo:  "10.0.0.1",
+				Visibility: "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid on_failure fail_closed",
+			rule: DnsRedirectRule{
+				Name:      "test",
+				Match:     ".*",
+				ResolveTo: "10.0.0.1",
+				OnFailure: "fail_closed",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid on_failure fail_open",
+			rule: DnsRedirectRule{
+				Name:      "test",
+				Match:     ".*",
+				ResolveTo: "10.0.0.1",
+				OnFailure: "fail_open",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid on_failure retry_original",
+			rule: DnsRedirectRule{
+				Name:      "test",
+				Match:     ".*",
+				ResolveTo: "10.0.0.1",
+				OnFailure: "retry_original",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid on_failure",
+			rule: DnsRedirectRule{
+				Name:      "test",
+				Match:     ".*",
+				ResolveTo: "10.0.0.1",
+				OnFailure: "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid IPv6 address",
+			rule: DnsRedirectRule{
+				Name:      "test",
+				Match:     ".*",
+				ResolveTo: "::1",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Policy{
+				Version:          1,
+				Name:             "test",
+				DnsRedirectRules: []DnsRedirectRule{tt.rule},
+			}
+			err := p.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestConnectRedirectRuleValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    ConnectRedirectRule
+		wantErr bool
+	}{
+		{
+			name: "valid rule",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      "api\\.anthropic\\.com:443",
+				RedirectTo: "vertex-proxy:443",
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing name",
+			rule: ConnectRedirectRule{
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing match",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				RedirectTo: "proxy:443",
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid regex",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      "[invalid",
+				RedirectTo: "proxy:443",
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing redirect_to",
+			rule: ConnectRedirectRule{
+				Name:  "test",
+				Match: ".*:443",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid with TLS passthrough",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				TLS:        &ConnectRedirectTLSConfig{Mode: "passthrough"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid with TLS rewrite_sni and sni",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				TLS:        &ConnectRedirectTLSConfig{Mode: "rewrite_sni", SNI: "proxy.internal"},
+			},
+			wantErr: false,
+		},
+		{
+			name: "rewrite_sni without sni",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				TLS:        &ConnectRedirectTLSConfig{Mode: "rewrite_sni"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid TLS mode",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				TLS:        &ConnectRedirectTLSConfig{Mode: "invalid"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid visibility silent",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				Visibility: "silent",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid visibility audit_only",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				Visibility: "audit_only",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid visibility warn",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				Visibility: "warn",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid visibility",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				Visibility: "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid on_failure fail_closed",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				OnFailure:  "fail_closed",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid on_failure fail_open",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				OnFailure:  "fail_open",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid on_failure retry_original",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				OnFailure:  "retry_original",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid on_failure",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				OnFailure:  "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid with message",
+			rule: ConnectRedirectRule{
+				Name:       "test",
+				Match:      ".*:443",
+				RedirectTo: "proxy:443",
+				Message:    "Routed through proxy",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Policy{
+				Version:              1,
+				Name:                 "test",
+				ConnectRedirectRules: []ConnectRedirectRule{tt.rule},
+			}
+			err := p.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEvaluateDnsRedirect(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		DnsRedirectRules: []DnsRedirectRule{
+			{
+				Name:       "anthropic-redirect",
+				Match:      ".*\\.anthropic\\.com",
+				ResolveTo:  "10.0.0.50",
+				Visibility: "warn",
+			},
+			{
+				Name:      "exact-match",
+				Match:     "^example\\.com$",
+				ResolveTo: "192.168.1.1",
+			},
+		},
+	}
+
+	engine, err := NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	tests := []struct {
+		hostname       string
+		wantMatch      bool
+		wantIP         string
+		wantRule       string
+		wantVisibility string
+	}{
+		{"api.anthropic.com", true, "10.0.0.50", "anthropic-redirect", "warn"},
+		{"console.anthropic.com", true, "10.0.0.50", "anthropic-redirect", "warn"},
+		{"sub.domain.anthropic.com", true, "10.0.0.50", "anthropic-redirect", "warn"},
+		{"example.com", true, "192.168.1.1", "exact-match", "audit_only"}, // default visibility
+		{"google.com", false, "", "", ""},
+		{"anthropic.com.evil.com", false, "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hostname, func(t *testing.T) {
+			result := engine.EvaluateDnsRedirect(tt.hostname)
+			if result.Matched != tt.wantMatch {
+				t.Errorf("EvaluateDnsRedirect(%s) matched = %v, want %v", tt.hostname, result.Matched, tt.wantMatch)
+			}
+			if result.Matched {
+				if result.ResolveTo != tt.wantIP {
+					t.Errorf("EvaluateDnsRedirect(%s) resolveTo = %v, want %v", tt.hostname, result.ResolveTo, tt.wantIP)
+				}
+				if result.Rule != tt.wantRule {
+					t.Errorf("EvaluateDnsRedirect(%s) rule = %v, want %v", tt.hostname, result.Rule, tt.wantRule)
+				}
+				if result.Visibility != tt.wantVisibility {
+					t.Errorf("EvaluateDnsRedirect(%s) visibility = %v, want %v", tt.hostname, result.Visibility, tt.wantVisibility)
+				}
+			}
+		})
+	}
+}
+
+func TestEvaluateDnsRedirect_Defaults(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		DnsRedirectRules: []DnsRedirectRule{
+			{
+				Name:      "test",
+				Match:     ".*",
+				ResolveTo: "10.0.0.1",
+				// No Visibility or OnFailure set
+			},
+		},
+	}
+
+	engine, err := NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	result := engine.EvaluateDnsRedirect("anything.com")
+	if !result.Matched {
+		t.Fatal("expected match")
+	}
+	if result.Visibility != "audit_only" {
+		t.Errorf("Visibility = %q, want audit_only (default)", result.Visibility)
+	}
+	if result.OnFailure != "fail_closed" {
+		t.Errorf("OnFailure = %q, want fail_closed (default)", result.OnFailure)
+	}
+}
+
+func TestEvaluateDnsRedirect_NoRules(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+	}
+
+	engine, err := NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	result := engine.EvaluateDnsRedirect("example.com")
+	if result.Matched {
+		t.Error("expected no match when no rules defined")
+	}
+}
+
+func TestEvaluateConnectRedirect(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		ConnectRedirectRules: []ConnectRedirectRule{
+			{
+				Name:       "anthropic-redirect",
+				Match:      "api\\.anthropic\\.com:443",
+				RedirectTo: "vertex-proxy.internal:443",
+				Message:    "Routed through Vertex",
+			},
+			{
+				Name:       "all-https",
+				Match:      ".*:443",
+				RedirectTo: "https-proxy.internal:8443",
+				TLS:        &ConnectRedirectTLSConfig{Mode: "rewrite_sni", SNI: "proxy.internal"},
+				Visibility: "silent",
+			},
+		},
+	}
+
+	engine, err := NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	tests := []struct {
+		hostPort       string
+		wantMatch      bool
+		wantTarget     string
+		wantRule       string
+		wantTLSMode    string
+		wantSNI        string
+		wantVisibility string
+		wantMessage    string
+	}{
+		{"api.anthropic.com:443", true, "vertex-proxy.internal:443", "anthropic-redirect", "passthrough", "", "audit_only", "Routed through Vertex"},
+		{"google.com:443", true, "https-proxy.internal:8443", "all-https", "rewrite_sni", "proxy.internal", "silent", ""},
+		{"other.example.com:443", true, "https-proxy.internal:8443", "all-https", "rewrite_sni", "proxy.internal", "silent", ""},
+		{"api.anthropic.com:80", false, "", "", "", "", "", ""},
+		{"google.com:80", false, "", "", "", "", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hostPort, func(t *testing.T) {
+			result := engine.EvaluateConnectRedirect(tt.hostPort)
+			if result.Matched != tt.wantMatch {
+				t.Errorf("EvaluateConnectRedirect(%s) matched = %v, want %v", tt.hostPort, result.Matched, tt.wantMatch)
+			}
+			if result.Matched {
+				if result.RedirectTo != tt.wantTarget {
+					t.Errorf("EvaluateConnectRedirect(%s) redirectTo = %v, want %v", tt.hostPort, result.RedirectTo, tt.wantTarget)
+				}
+				if result.Rule != tt.wantRule {
+					t.Errorf("EvaluateConnectRedirect(%s) rule = %v, want %v", tt.hostPort, result.Rule, tt.wantRule)
+				}
+				if result.TLSMode != tt.wantTLSMode {
+					t.Errorf("EvaluateConnectRedirect(%s) tlsMode = %v, want %v", tt.hostPort, result.TLSMode, tt.wantTLSMode)
+				}
+				if result.SNI != tt.wantSNI {
+					t.Errorf("EvaluateConnectRedirect(%s) sni = %v, want %v", tt.hostPort, result.SNI, tt.wantSNI)
+				}
+				if result.Visibility != tt.wantVisibility {
+					t.Errorf("EvaluateConnectRedirect(%s) visibility = %v, want %v", tt.hostPort, result.Visibility, tt.wantVisibility)
+				}
+				if result.Message != tt.wantMessage {
+					t.Errorf("EvaluateConnectRedirect(%s) message = %v, want %v", tt.hostPort, result.Message, tt.wantMessage)
+				}
+			}
+		})
+	}
+}
+
+func TestEvaluateConnectRedirect_Defaults(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		ConnectRedirectRules: []ConnectRedirectRule{
+			{
+				Name:       "test",
+				Match:      ".*",
+				RedirectTo: "proxy:443",
+				// No TLS, Visibility, or OnFailure set
+			},
+		},
+	}
+
+	engine, err := NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	result := engine.EvaluateConnectRedirect("anything:443")
+	if !result.Matched {
+		t.Fatal("expected match")
+	}
+	if result.TLSMode != "passthrough" {
+		t.Errorf("TLSMode = %q, want passthrough (default)", result.TLSMode)
+	}
+	if result.Visibility != "audit_only" {
+		t.Errorf("Visibility = %q, want audit_only (default)", result.Visibility)
+	}
+	if result.OnFailure != "fail_closed" {
+		t.Errorf("OnFailure = %q, want fail_closed (default)", result.OnFailure)
+	}
+}
+
+func TestEvaluateConnectRedirect_NoRules(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+	}
+
+	engine, err := NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	result := engine.EvaluateConnectRedirect("example.com:443")
+	if result.Matched {
+		t.Error("expected no match when no rules defined")
+	}
+}
+
+func TestEvaluateConnectRedirect_RuleOrder(t *testing.T) {
+	// Test that rules are evaluated in order (first match wins)
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		ConnectRedirectRules: []ConnectRedirectRule{
+			{
+				Name:       "specific",
+				Match:      "api\\.example\\.com:443",
+				RedirectTo: "specific-proxy:443",
+			},
+			{
+				Name:       "wildcard",
+				Match:      ".*:443",
+				RedirectTo: "general-proxy:443",
+			},
+		},
+	}
+
+	engine, err := NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	// Specific rule should match first
+	result := engine.EvaluateConnectRedirect("api.example.com:443")
+	if result.Rule != "specific" {
+		t.Errorf("expected specific rule to match first, got %q", result.Rule)
+	}
+	if result.RedirectTo != "specific-proxy:443" {
+		t.Errorf("redirectTo = %q, want specific-proxy:443", result.RedirectTo)
+	}
+
+	// Other hostnames should hit the wildcard rule
+	result = engine.EvaluateConnectRedirect("other.example.com:443")
+	if result.Rule != "wildcard" {
+		t.Errorf("expected wildcard rule to match, got %q", result.Rule)
+	}
+}
+
+func TestDnsRedirect_ComplexPatterns(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		DnsRedirectRules: []DnsRedirectRule{
+			{
+				Name:      "prefix-match",
+				Match:     "^api-.*\\.example\\.com$",
+				ResolveTo: "10.0.0.1",
+			},
+			{
+				Name:      "suffix-match",
+				Match:     ".*\\.internal$",
+				ResolveTo: "10.0.0.2",
+			},
+			{
+				Name:      "alternation",
+				Match:     "^(dev|staging)\\.myapp\\.com$",
+				ResolveTo: "10.0.0.3",
+			},
+		},
+	}
+
+	engine, err := NewEngine(p, false)
+	if err != nil {
+		t.Fatalf("NewEngine() error = %v", err)
+	}
+
+	tests := []struct {
+		hostname  string
+		wantMatch bool
+		wantIP    string
+	}{
+		{"api-v1.example.com", true, "10.0.0.1"},
+		{"api-v2.example.com", true, "10.0.0.1"},
+		{"api.example.com", false, ""},
+		{"service.internal", true, "10.0.0.2"},
+		{"deep.nested.internal", true, "10.0.0.2"},
+		{"dev.myapp.com", true, "10.0.0.3"},
+		{"staging.myapp.com", true, "10.0.0.3"},
+		{"prod.myapp.com", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hostname, func(t *testing.T) {
+			result := engine.EvaluateDnsRedirect(tt.hostname)
+			if result.Matched != tt.wantMatch {
+				t.Errorf("matched = %v, want %v", result.Matched, tt.wantMatch)
+			}
+			if result.Matched && result.ResolveTo != tt.wantIP {
+				t.Errorf("resolveTo = %v, want %v", result.ResolveTo, tt.wantIP)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds DNS and connect-level redirect capability for agentsh-wrapped processes on Linux. This enables transparent routing of API calls (e.g., Anthropic → Vertex AI) without application changes.

### Features
- **DNS redirect**: Intercept DNS resolution and return configured IP
- **Connect redirect**: Redirect TCP connections to different host:port
- **TLS handling**: Passthrough (default) or SNI rewrite modes
- **Configurable visibility**: silent, audit_only, or warn
- **Configurable failure handling**: fail_closed, fail_open, or retry_original
- **Hostname-to-IP correlation**: Enables connect redirect to match by hostname

### Configuration Example
```yaml
dns_redirects:
  - name: anthropic-to-vertex
    match: ".*\\.anthropic\\.com"
    resolve_to: 10.0.0.50
    visibility: audit_only

connect_redirects:
  - name: anthropic-to-vertex
    match: "api\\.anthropic\\.com:443"
    redirect_to: vertex-proxy.internal:443
    tls:
      mode: passthrough
    visibility: warn
    message: "Routed through Vertex AI"
```

### Files Changed
- `internal/policy/model.go` - DnsRedirectRule, ConnectRedirectRule types
- `internal/policy/engine.go` - Compiled rules and evaluation methods
- `internal/events/types.go`, `schema.go` - Redirect event types
- `internal/netmonitor/redirect/` - Correlation map for DNS→connect matching
- `internal/netmonitor/dns.go` - DNS redirect integration
- `internal/netmonitor/ebpf/collector.go` - Connect redirect integration

### Test Coverage
- 242 tests passing
- Unit tests for validation and evaluation
- E2E tests for full DNS→connect flow
- SNI rewrite configuration tests
- Complex regex pattern tests

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (242 tests)
- [x] `go vet` passes on new code
- [x] `gofmt` applied to all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)