### PR TITLE
feat(pty): add Windows PTY support using ConPTY

### DIFF
--- a/docs/plans/2026-01-30-windows-pty-design.md
+++ b/docs/plans/2026-01-30-windows-pty-design.md
@@ -1,0 +1,274 @@
+# Windows PTY (ConPTY) Implementation Design
+
+**Date:** 2026-01-30
+**Status:** Draft
+**Author:** Claude + Eran
+
+## Overview
+
+Implement Windows PTY support using ConPTY (Windows Pseudo Console) via the `github.com/UserExistsError/conpty` library. This enables interactive terminal sessions on Windows, matching the functionality available on Linux/macOS.
+
+## Library Selection
+
+Using `github.com/UserExistsError/conpty` because it provides:
+- Full ConPTY lifecycle management
+- `io.ReadWriter` interface for input/output
+- `Resize(width, height)` method
+- `Pid()` method
+- Options for dimensions, working directory, environment
+- `IsConPtyAvailable()` for capability detection
+
+## API Mapping
+
+| Session Method | Unix Implementation | Windows Implementation |
+|----------------|---------------------|------------------------|
+| `Start()` | `pty.Open()` + `exec.Command` | `conpty.Start(cmdLine, opts...)` |
+| `Output()` | Read from master FD → channel | Read from ConPTY → channel |
+| `Write()` | Write to master FD | `conpty.Write()` |
+| `Resize()` | `TIOCSWINSZ` ioctl | `conpty.Resize()` |
+| `Signal()` | `syscall.Kill(-pgid, sig)` | See signal handling below |
+| `Wait()` | `cmd.Wait()` | `conpty.Wait(ctx)` |
+| `PID()` | `cmd.Process.Pid` | `conpty.Pid()` |
+
+## Signal Handling
+
+Windows lacks POSIX signals. Mapping strategy:
+
+| Signal | Windows Equivalent |
+|--------|-------------------|
+| `SIGINT` | `GenerateConsoleCtrlEvent(CTRL_C_EVENT)` or write `\x03` to PTY |
+| `SIGTERM` | `TerminateProcess()` with exit code 1 |
+| `SIGKILL` | `TerminateProcess()` with exit code 1 |
+| `SIGHUP` | `TerminateProcess()` with exit code 1 |
+| `SIGQUIT` | Write `\x1c` to PTY (Ctrl+\) |
+| `SIGWINCH` | N/A (use `Resize()` method instead) |
+
+**Note:** For `SIGINT`, writing `\x03` (Ctrl+C) to the PTY input is the most reliable approach as it lets the shell/application handle it naturally.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                         Session                              │
+│  - cpty *conpty.ConPty                                      │
+│  - outCh chan []byte                                         │
+│  - outDone chan struct{}                                     │
+│  - pid int                                                   │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                    conpty.ConPty                             │
+│  - Read()/Write() for I/O                                   │
+│  - Resize() for terminal size                               │
+│  - Wait() for process exit                                  │
+│  - Close() for cleanup                                      │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│                   Windows ConPTY APIs                        │
+│  - CreatePseudoConsole()                                    │
+│  - ResizePseudoConsole()                                    │
+│  - ClosePseudoConsole()                                     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Implementation Details
+
+### Session Struct
+
+```go
+type Session struct {
+    cpty    *conpty.ConPty
+    outCh   chan []byte
+    outDone chan struct{}
+    pid     int
+    closed  bool
+    mu      sync.Mutex
+}
+```
+
+### Start Implementation
+
+```go
+func (e *Engine) Start(ctx context.Context, req StartRequest) (*Session, error) {
+    if !conpty.IsConPtyAvailable() {
+        return nil, ErrConPtyUnavailable
+    }
+
+    // Build command line (Windows requires single string)
+    cmdLine := buildCommandLine(req.Command, req.Args)
+
+    // Build options
+    opts := []conpty.ConPtyOption{}
+    if req.InitialSize.Rows > 0 && req.InitialSize.Cols > 0 {
+        opts = append(opts, conpty.ConPtyDimensions(
+            int(req.InitialSize.Cols),
+            int(req.InitialSize.Rows),
+        ))
+    }
+    if req.Dir != "" {
+        opts = append(opts, conpty.ConPtyWorkDir(req.Dir))
+    }
+    if len(req.Env) > 0 {
+        opts = append(opts, conpty.ConPtyEnv(req.Env))
+    }
+
+    cpty, err := conpty.Start(cmdLine, opts...)
+    if err != nil {
+        return nil, err
+    }
+
+    sess := &Session{
+        cpty:    cpty,
+        outCh:   make(chan []byte, 16),
+        outDone: make(chan struct{}),
+        pid:     cpty.Pid(),
+    }
+
+    // Start output reader goroutine
+    go sess.readOutput()
+
+    return sess, nil
+}
+```
+
+### Output Reading
+
+```go
+func (s *Session) readOutput() {
+    defer close(s.outDone)
+    defer close(s.outCh)
+
+    buf := make([]byte, 32*1024)
+    for {
+        n, err := s.cpty.Read(buf)
+        if n > 0 {
+            b := make([]byte, n)
+            copy(b, buf[:n])
+            s.outCh <- b
+        }
+        if err != nil {
+            return
+        }
+    }
+}
+```
+
+### Signal Handling
+
+```go
+func (s *Session) Signal(sig syscall.Signal) error {
+    s.mu.Lock()
+    defer s.mu.Unlock()
+
+    if s.closed || s.cpty == nil {
+        return errors.New("session closed")
+    }
+
+    switch sig {
+    case syscall.SIGINT:
+        // Send Ctrl+C character to PTY
+        _, err := s.cpty.Write([]byte{0x03})
+        return err
+    case syscall.SIGQUIT:
+        // Send Ctrl+\ character to PTY
+        _, err := s.cpty.Write([]byte{0x1c})
+        return err
+    case syscall.SIGTERM, syscall.SIGHUP:
+        // Terminate the process
+        return terminateProcess(s.pid)
+    default:
+        // Unsupported signal - terminate as fallback
+        return terminateProcess(s.pid)
+    }
+}
+
+func terminateProcess(pid int) error {
+    proc, err := os.FindProcess(pid)
+    if err != nil {
+        return err
+    }
+    return proc.Kill()
+}
+```
+
+### Wait Implementation
+
+```go
+func (s *Session) Wait() (exitCode int, err error) {
+    if s.cpty == nil {
+        return 127, errors.New("process not started")
+    }
+
+    code, err := s.cpty.Wait(context.Background())
+
+    // Wait for output to drain
+    <-s.outDone
+
+    if err != nil {
+        return 127, err
+    }
+    return int(code), nil
+}
+```
+
+## Command Line Building
+
+Windows requires a single command line string, not separate command/args:
+
+```go
+func buildCommandLine(command string, args []string) string {
+    if len(args) == 0 {
+        return command
+    }
+
+    parts := make([]string, 0, len(args)+1)
+    parts = append(parts, quoteArg(command))
+    for _, arg := range args {
+        parts = append(parts, quoteArg(arg))
+    }
+    return strings.Join(parts, " ")
+}
+
+func quoteArg(arg string) string {
+    if !strings.ContainsAny(arg, " \t\"") {
+        return arg
+    }
+    // Windows command line escaping rules
+    return `"` + strings.ReplaceAll(arg, `"`, `""`) + `"`
+}
+```
+
+## Error Handling
+
+```go
+var (
+    ErrConPtyUnavailable = errors.New("ConPTY not available (requires Windows 10 1809+)")
+)
+```
+
+## Testing Strategy
+
+1. **Unit tests** - Mock conpty for basic flow testing
+2. **Integration tests** - Skip on non-Windows or if ConPTY unavailable
+3. **Manual testing** - Interactive shell sessions via `agentsh exec --pty cmd.exe`
+
+## Requirements
+
+- Windows 10 version 1809 (October 2018 Update) or later
+- `github.com/UserExistsError/conpty` library
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `internal/pty/engine_windows.go` | Replace stub with ConPTY implementation |
+| `go.mod` | Add `github.com/UserExistsError/conpty` dependency |
+
+## Limitations
+
+1. **No process groups** - Windows doesn't have Unix-style process groups, so SIGINT goes to the PTY as Ctrl+C rather than to a process group
+2. **Signal limitations** - Only SIGINT, SIGQUIT, SIGTERM, SIGHUP are meaningfully handled
+3. **Windows 10 1809+** - Older Windows versions not supported

--- a/docs/plans/2026-01-30-windows-pty-plan.md
+++ b/docs/plans/2026-01-30-windows-pty-plan.md
@@ -1,0 +1,617 @@
+# Windows PTY Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Enable interactive terminal sessions on Windows using ConPTY
+
+**Architecture:** Replace the stub Windows PTY implementation with a real ConPTY-based implementation using the `github.com/UserExistsError/conpty` library
+
+**Tech Stack:** Go, ConPTY (Windows API), github.com/UserExistsError/conpty
+
+---
+
+## Task 1: Add conpty dependency
+
+**Files:**
+- Modify: `go.mod`
+- Modify: `go.sum`
+
+**Step 1: Add the dependency**
+
+```bash
+go get github.com/UserExistsError/conpty
+```
+
+**Step 2: Verify it's in go.mod**
+
+Run: `grep conpty go.mod`
+Expected: `github.com/UserExistsError/conpty v0.x.x`
+
+**Step 3: Commit**
+
+```bash
+git add go.mod go.sum
+git commit -m "deps: add github.com/UserExistsError/conpty for Windows PTY"
+```
+
+---
+
+## Task 2: Implement Session struct and basic methods
+
+**Files:**
+- Modify: `internal/pty/engine_windows.go`
+
+**Step 1: Update Session struct**
+
+Replace the stub Session struct with:
+
+```go
+type Session struct {
+	cpty    *conpty.ConPty
+	outCh   chan []byte
+	outDone chan struct{}
+	pid     int
+	mu      sync.Mutex
+	closed  bool
+}
+```
+
+**Step 2: Implement Output() method**
+
+```go
+func (s *Session) Output() <-chan []byte {
+	if s == nil {
+		ch := make(chan []byte)
+		close(ch)
+		return ch
+	}
+	return s.outCh
+}
+```
+
+**Step 3: Implement PID() method**
+
+```go
+func (s *Session) PID() int {
+	if s == nil {
+		return 0
+	}
+	return s.pid
+}
+```
+
+**Step 4: Implement Write() method**
+
+```go
+func (s *Session) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed || s.cpty == nil {
+		return 0, io.ErrClosedPipe
+	}
+	return s.cpty.Write(p)
+}
+```
+
+**Step 5: Verify it compiles**
+
+Run: `GOOS=windows go build ./internal/pty/...`
+Expected: No errors
+
+**Step 6: Commit**
+
+```bash
+git add internal/pty/engine_windows.go
+git commit -m "feat(pty): add Windows Session struct with basic methods"
+```
+
+---
+
+## Task 3: Implement Resize() method
+
+**Files:**
+- Modify: `internal/pty/engine_windows.go`
+
+**Step 1: Implement Resize()**
+
+```go
+func (s *Session) Resize(rows, cols uint16) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed || s.cpty == nil {
+		return io.ErrClosedPipe
+	}
+	return s.cpty.Resize(int(cols), int(rows))
+}
+```
+
+Note: conpty.Resize takes (width, height) = (cols, rows), so we swap the order.
+
+**Step 2: Verify it compiles**
+
+Run: `GOOS=windows go build ./internal/pty/...`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add internal/pty/engine_windows.go
+git commit -m "feat(pty): implement Windows PTY Resize via ConPTY"
+```
+
+---
+
+## Task 4: Implement Signal() method
+
+**Files:**
+- Modify: `internal/pty/engine_windows.go`
+
+**Step 1: Implement Signal()**
+
+```go
+func (s *Session) Signal(sig syscall.Signal) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed || s.cpty == nil {
+		return errors.New("session closed")
+	}
+
+	switch sig {
+	case syscall.SIGINT:
+		// Send Ctrl+C character to PTY
+		_, err := s.cpty.Write([]byte{0x03})
+		return err
+	case syscall.SIGQUIT:
+		// Send Ctrl+\ character to PTY
+		_, err := s.cpty.Write([]byte{0x1c})
+		return err
+	case syscall.SIGTERM, syscall.SIGHUP, syscall.SIGKILL:
+		// Terminate the process
+		return s.terminateProcess()
+	default:
+		// Unsupported signal - terminate as fallback
+		return s.terminateProcess()
+	}
+}
+
+func (s *Session) terminateProcess() error {
+	if s.pid == 0 {
+		return errors.New("no process to terminate")
+	}
+	proc, err := os.FindProcess(s.pid)
+	if err != nil {
+		return err
+	}
+	return proc.Kill()
+}
+```
+
+**Step 2: Add syscall constants if needed**
+
+Windows may not define all signal constants. Add at top of file:
+
+```go
+// Signal constants for Windows compatibility
+const (
+	sigINT  = syscall.Signal(0x2)  // SIGINT
+	sigTERM = syscall.Signal(0xf)  // SIGTERM
+	sigKILL = syscall.Signal(0x9)  // SIGKILL
+	sigHUP  = syscall.Signal(0x1)  // SIGHUP
+	sigQUIT = syscall.Signal(0x3)  // SIGQUIT
+)
+```
+
+Then use these constants in the switch if syscall.SIGXXX is not available.
+
+**Step 3: Verify it compiles**
+
+Run: `GOOS=windows go build ./internal/pty/...`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add internal/pty/engine_windows.go
+git commit -m "feat(pty): implement Windows PTY Signal handling"
+```
+
+---
+
+## Task 5: Implement Wait() method
+
+**Files:**
+- Modify: `internal/pty/engine_windows.go`
+
+**Step 1: Implement Wait()**
+
+```go
+func (s *Session) Wait() (exitCode int, err error) {
+	if s == nil || s.cpty == nil {
+		return 127, errors.New("process not started")
+	}
+
+	code, err := s.cpty.Wait(context.Background())
+
+	// Wait for output to drain
+	if s.outDone != nil {
+		<-s.outDone
+	}
+
+	s.mu.Lock()
+	s.closed = true
+	s.mu.Unlock()
+
+	if err != nil {
+		return 127, err
+	}
+	return int(code), nil
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `GOOS=windows go build ./internal/pty/...`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add internal/pty/engine_windows.go
+git commit -m "feat(pty): implement Windows PTY Wait method"
+```
+
+---
+
+## Task 6: Implement command line building helpers
+
+**Files:**
+- Modify: `internal/pty/engine_windows.go`
+
+**Step 1: Add command line building functions**
+
+```go
+// buildCommandLine combines command and args into a single Windows command line.
+func buildCommandLine(command string, args []string) string {
+	if len(args) == 0 {
+		return command
+	}
+
+	parts := make([]string, 0, len(args)+1)
+	parts = append(parts, quoteArg(command))
+	for _, arg := range args {
+		parts = append(parts, quoteArg(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+// quoteArg quotes an argument if it contains special characters.
+func quoteArg(arg string) string {
+	if arg == "" {
+		return `""`
+	}
+	if !strings.ContainsAny(arg, " \t\"") {
+		return arg
+	}
+	// Escape embedded quotes by doubling them
+	escaped := strings.ReplaceAll(arg, `"`, `""`)
+	return `"` + escaped + `"`
+}
+```
+
+**Step 2: Add strings import if not present**
+
+**Step 3: Verify it compiles**
+
+Run: `GOOS=windows go build ./internal/pty/...`
+Expected: No errors
+
+**Step 4: Commit**
+
+```bash
+git add internal/pty/engine_windows.go
+git commit -m "feat(pty): add Windows command line building helpers"
+```
+
+---
+
+## Task 7: Implement Engine.Start() method
+
+**Files:**
+- Modify: `internal/pty/engine_windows.go`
+
+**Step 1: Add error variable**
+
+```go
+var ErrConPtyUnavailable = errors.New("ConPTY not available (requires Windows 10 1809+)")
+```
+
+**Step 2: Implement Start()**
+
+```go
+func (e *Engine) Start(ctx context.Context, req StartRequest) (*Session, error) {
+	if !conpty.IsConPtyAvailable() {
+		return nil, ErrConPtyUnavailable
+	}
+
+	if req.Command == "" {
+		return nil, errors.New("command is required")
+	}
+
+	// Build command line
+	cmdLine := buildCommandLine(req.Command, req.Args)
+
+	// Build options
+	opts := []conpty.ConPtyOption{}
+	if req.InitialSize.Cols > 0 && req.InitialSize.Rows > 0 {
+		opts = append(opts, conpty.ConPtyDimensions(
+			int(req.InitialSize.Cols),
+			int(req.InitialSize.Rows),
+		))
+	}
+	if req.Dir != "" {
+		opts = append(opts, conpty.ConPtyWorkDir(req.Dir))
+	}
+	if len(req.Env) > 0 {
+		opts = append(opts, conpty.ConPtyEnv(req.Env))
+	}
+
+	cpty, err := conpty.Start(cmdLine, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	sess := &Session{
+		cpty:    cpty,
+		outCh:   make(chan []byte, 16),
+		outDone: make(chan struct{}),
+		pid:     cpty.Pid(),
+	}
+
+	// Start output reader goroutine
+	go sess.readOutput()
+
+	return sess, nil
+}
+```
+
+**Step 3: Implement readOutput()**
+
+```go
+func (s *Session) readOutput() {
+	defer close(s.outDone)
+	defer close(s.outCh)
+
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := s.cpty.Read(buf)
+		if n > 0 {
+			b := make([]byte, n)
+			copy(b, buf[:n])
+			select {
+			case s.outCh <- b:
+			default:
+				// Channel full, drop oldest
+				select {
+				case <-s.outCh:
+				default:
+				}
+				s.outCh <- b
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+```
+
+**Step 4: Add conpty import**
+
+```go
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/UserExistsError/conpty"
+)
+```
+
+**Step 5: Verify it compiles**
+
+Run: `GOOS=windows go build ./internal/pty/...`
+Expected: No errors
+
+**Step 6: Commit**
+
+```bash
+git add internal/pty/engine_windows.go
+git commit -m "feat(pty): implement Windows PTY Engine.Start with ConPTY"
+```
+
+---
+
+## Task 8: Add tests
+
+**Files:**
+- Create: `internal/pty/engine_windows_test.go`
+
+**Step 1: Create test file**
+
+```go
+//go:build windows
+
+package pty
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/UserExistsError/conpty"
+)
+
+func TestBuildCommandLine(t *testing.T) {
+	tests := []struct {
+		command string
+		args    []string
+		want    string
+	}{
+		{"cmd.exe", nil, "cmd.exe"},
+		{"cmd.exe", []string{"/c", "echo", "hello"}, `cmd.exe /c echo hello`},
+		{"cmd.exe", []string{"/c", "echo hello world"}, `cmd.exe /c "echo hello world"`},
+		{"cmd.exe", []string{"/c", `echo "quoted"`}, `cmd.exe /c "echo ""quoted"""`},
+	}
+
+	for _, tt := range tests {
+		got := buildCommandLine(tt.command, tt.args)
+		if got != tt.want {
+			t.Errorf("buildCommandLine(%q, %v) = %q, want %q", tt.command, tt.args, got, tt.want)
+		}
+	}
+}
+
+func TestQuoteArg(t *testing.T) {
+	tests := []struct {
+		arg  string
+		want string
+	}{
+		{"simple", "simple"},
+		{"with space", `"with space"`},
+		{`with"quote`, `"with""quote"`},
+		{"", `""`},
+	}
+
+	for _, tt := range tests {
+		got := quoteArg(tt.arg)
+		if got != tt.want {
+			t.Errorf("quoteArg(%q) = %q, want %q", tt.arg, got, tt.want)
+		}
+	}
+}
+
+func TestEngineStart(t *testing.T) {
+	if !conpty.IsConPtyAvailable() {
+		t.Skip("ConPTY not available")
+	}
+
+	e := New()
+	sess, err := e.Start(context.Background(), StartRequest{
+		Command:     "cmd.exe",
+		Args:        []string{"/c", "echo hello"},
+		InitialSize: Winsize{Rows: 24, Cols: 80},
+	})
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	// Read output
+	var output strings.Builder
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for b := range sess.Output() {
+			output.Write(b)
+		}
+	}()
+
+	// Wait for process
+	exitCode, err := sess.Wait()
+	<-done
+
+	if err != nil {
+		t.Errorf("Wait error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("exit code = %d, want 0", exitCode)
+	}
+	if !strings.Contains(output.String(), "hello") {
+		t.Errorf("output = %q, want to contain 'hello'", output.String())
+	}
+}
+
+func TestEngineStartNotAvailable(t *testing.T) {
+	// This test only makes sense if we could mock IsConPtyAvailable
+	// For now, just verify it doesn't panic
+	e := New()
+	_, _ = e.Start(context.Background(), StartRequest{
+		Command: "cmd.exe",
+	})
+}
+
+func TestSessionResize(t *testing.T) {
+	if !conpty.IsConPtyAvailable() {
+		t.Skip("ConPTY not available")
+	}
+
+	e := New()
+	sess, err := e.Start(context.Background(), StartRequest{
+		Command:     "cmd.exe",
+		InitialSize: Winsize{Rows: 24, Cols: 80},
+	})
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer sess.Wait()
+
+	// Resize should not error
+	if err := sess.Resize(40, 120); err != nil {
+		t.Errorf("Resize failed: %v", err)
+	}
+
+	// Send exit command
+	sess.Write([]byte("exit\r\n"))
+}
+```
+
+**Step 2: Verify tests compile**
+
+Run: `GOOS=windows go build ./internal/pty/...`
+Expected: No errors
+
+**Step 3: Commit**
+
+```bash
+git add internal/pty/engine_windows_test.go
+git commit -m "test(pty): add Windows PTY tests"
+```
+
+---
+
+## Task 9: Final verification and cleanup
+
+**Files:**
+- Review: `internal/pty/engine_windows.go`
+
+**Step 1: Verify full build**
+
+Run: `go build ./...`
+Expected: No errors
+
+Run: `GOOS=windows go build ./...`
+Expected: No errors
+
+**Step 2: Run all tests**
+
+Run: `go test ./...`
+Expected: All pass
+
+**Step 3: Verify the design doc is committed**
+
+```bash
+git add docs/plans/2026-01-30-windows-pty-design.md docs/plans/2026-01-30-windows-pty-plan.md
+git commit -m "docs: add Windows PTY design and implementation plan"
+```
+
+**Step 4: Review git log**
+
+Run: `git log --oneline main..HEAD`
+Expected: ~8-9 commits covering all implementation

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/UserExistsError/conpty v0.1.4 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.16 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgv
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/UserExistsError/conpty v0.1.4 h1:+3FhJhiqhyEJa+K5qaK3/w6w+sN3Nh9O9VbJyBS02to=
+github.com/UserExistsError/conpty v0.1.4/go.mod h1:PDglKIkX3O/2xVk0MV9a6bCWxRmPVfxqZoTG/5sSd9I=
 github.com/aws/aws-sdk-go-v2 v1.41.0 h1:tNvqh1s+v0vFYdA1xq0aOJH+Y5cRyZ5upu6roPgPKd4=
 github.com/aws/aws-sdk-go-v2 v1.41.0/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/config v1.32.6 h1:hFLBGUKjmLAekvi1evLi5hVvFQtSo3GYwi+Bx4lpJf8=

--- a/internal/pty/engine_windows.go
+++ b/internal/pty/engine_windows.go
@@ -6,11 +6,26 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
+	"strings"
+	"sync"
 	"syscall"
+
+	"github.com/UserExistsError/conpty"
 )
 
-// ErrNotSupported is returned when PTY is not supported on Windows.
-var ErrNotSupported = errors.New("pty: not supported on Windows")
+// ErrConPtyUnavailable is returned when ConPTY is not available on the system.
+var ErrConPtyUnavailable = errors.New("ConPTY not available (requires Windows 10 1809+)")
+
+// Signal constants for Windows compatibility.
+// Windows doesn't define POSIX signals, so we use the standard values.
+const (
+	sigHUP  = syscall.Signal(0x1)
+	sigINT  = syscall.Signal(0x2)
+	sigQUIT = syscall.Signal(0x3)
+	sigKILL = syscall.Signal(0x9)
+	sigTERM = syscall.Signal(0xf)
+)
 
 type Winsize struct {
 	Rows uint16
@@ -28,16 +43,27 @@ type StartRequest struct {
 	InitialSize Winsize
 }
 
+// Session represents a PTY session on Windows using ConPTY.
 type Session struct {
-	pid int
+	cpty    *conpty.ConPty
+	outCh   chan []byte
+	outDone chan struct{}
+	pid     int
+	mu      sync.Mutex
+	closed  bool
 }
 
+// Output returns a channel that receives PTY output.
 func (s *Session) Output() <-chan []byte {
-	ch := make(chan []byte)
-	close(ch)
-	return ch
+	if s == nil {
+		ch := make(chan []byte)
+		close(ch)
+		return ch
+	}
+	return s.outCh
 }
 
+// PID returns the process ID of the PTY session.
 func (s *Session) PID() int {
 	if s == nil {
 		return 0
@@ -45,26 +71,197 @@ func (s *Session) PID() int {
 	return s.pid
 }
 
+// Write sends input to the PTY.
 func (s *Session) Write(p []byte) (int, error) {
-	return 0, io.ErrClosedPipe
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed || s.cpty == nil {
+		return 0, io.ErrClosedPipe
+	}
+	return s.cpty.Write(p)
 }
 
+// Resize changes the terminal size.
 func (s *Session) Resize(rows, cols uint16) error {
-	return ErrNotSupported
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed || s.cpty == nil {
+		return io.ErrClosedPipe
+	}
+	// conpty.Resize takes (width, height) = (cols, rows)
+	return s.cpty.Resize(int(cols), int(rows))
 }
 
+// Signal sends a signal to the PTY process.
+// Windows doesn't have POSIX signals, so we emulate them:
+// - SIGINT/SIGQUIT: Send control characters to PTY
+// - SIGTERM/SIGHUP/SIGKILL: Terminate the process
 func (s *Session) Signal(sig syscall.Signal) error {
-	return ErrNotSupported
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed || s.cpty == nil {
+		return errors.New("session closed")
+	}
+
+	switch sig {
+	case sigINT:
+		// Send Ctrl+C character to PTY
+		_, err := s.cpty.Write([]byte{0x03})
+		return err
+	case sigQUIT:
+		// Send Ctrl+\ character to PTY
+		_, err := s.cpty.Write([]byte{0x1c})
+		return err
+	case sigTERM, sigHUP, sigKILL:
+		// Terminate the process
+		return s.terminateProcess()
+	default:
+		// Unsupported signal - terminate as fallback
+		return s.terminateProcess()
+	}
 }
 
+// terminateProcess forcefully terminates the PTY process.
+func (s *Session) terminateProcess() error {
+	if s.pid == 0 {
+		return errors.New("no process to terminate")
+	}
+	proc, err := os.FindProcess(s.pid)
+	if err != nil {
+		return err
+	}
+	return proc.Kill()
+}
+
+// Wait waits for the PTY process to exit and returns the exit code.
 func (s *Session) Wait() (exitCode int, err error) {
-	return 127, ErrNotSupported
+	if s == nil || s.cpty == nil {
+		return 127, errors.New("process not started")
+	}
+
+	code, err := s.cpty.Wait(context.Background())
+
+	// Wait for output to drain
+	if s.outDone != nil {
+		<-s.outDone
+	}
+
+	s.mu.Lock()
+	s.closed = true
+	s.mu.Unlock()
+
+	if err != nil {
+		return 127, err
+	}
+	return int(code), nil
 }
 
+// readOutput continuously reads from the ConPTY and sends to the output channel.
+func (s *Session) readOutput() {
+	defer close(s.outDone)
+	defer close(s.outCh)
+
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := s.cpty.Read(buf)
+		if n > 0 {
+			b := make([]byte, n)
+			copy(b, buf[:n])
+			select {
+			case s.outCh <- b:
+			default:
+				// Channel full, drop oldest and retry
+				select {
+				case <-s.outCh:
+				default:
+				}
+				s.outCh <- b
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// Engine creates and manages PTY sessions.
 type Engine struct{}
 
+// New creates a new PTY engine.
 func New() *Engine { return &Engine{} }
 
+// Start creates a new PTY session with the given command.
 func (e *Engine) Start(ctx context.Context, req StartRequest) (*Session, error) {
-	return nil, ErrNotSupported
+	if !conpty.IsConPtyAvailable() {
+		return nil, ErrConPtyUnavailable
+	}
+
+	if req.Command == "" {
+		return nil, errors.New("command is required")
+	}
+
+	// Build command line (Windows requires single string)
+	cmdLine := buildCommandLine(req.Command, req.Args)
+
+	// Build options
+	var opts []conpty.ConPtyOption
+	if req.InitialSize.Cols > 0 && req.InitialSize.Rows > 0 {
+		opts = append(opts, conpty.ConPtyDimensions(
+			int(req.InitialSize.Cols),
+			int(req.InitialSize.Rows),
+		))
+	}
+	if req.Dir != "" {
+		opts = append(opts, conpty.ConPtyWorkDir(req.Dir))
+	}
+	if len(req.Env) > 0 {
+		opts = append(opts, conpty.ConPtyEnv(req.Env))
+	}
+
+	cpty, err := conpty.Start(cmdLine, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	sess := &Session{
+		cpty:    cpty,
+		outCh:   make(chan []byte, 16),
+		outDone: make(chan struct{}),
+		pid:     cpty.Pid(),
+	}
+
+	// Start output reader goroutine
+	go sess.readOutput()
+
+	return sess, nil
+}
+
+// buildCommandLine combines command and args into a single Windows command line.
+func buildCommandLine(command string, args []string) string {
+	if len(args) == 0 {
+		return command
+	}
+
+	parts := make([]string, 0, len(args)+1)
+	parts = append(parts, quoteArg(command))
+	for _, arg := range args {
+		parts = append(parts, quoteArg(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+// quoteArg quotes an argument if it contains special characters.
+func quoteArg(arg string) string {
+	if arg == "" {
+		return `""`
+	}
+	if !strings.ContainsAny(arg, " \t\"") {
+		return arg
+	}
+	// Escape embedded quotes by doubling them
+	escaped := strings.ReplaceAll(arg, `"`, `""`)
+	return `"` + escaped + `"`
 }

--- a/internal/pty/engine_windows_test.go
+++ b/internal/pty/engine_windows_test.go
@@ -1,0 +1,192 @@
+//go:build windows
+
+package pty
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/UserExistsError/conpty"
+)
+
+func TestBuildCommandLine(t *testing.T) {
+	tests := []struct {
+		command string
+		args    []string
+		want    string
+	}{
+		{"cmd.exe", nil, "cmd.exe"},
+		{"cmd.exe", []string{"/c", "echo", "hello"}, `cmd.exe /c echo hello`},
+		{"cmd.exe", []string{"/c", "echo hello world"}, `cmd.exe /c "echo hello world"`},
+		{"cmd.exe", []string{"/c", `echo "quoted"`}, `cmd.exe /c "echo ""quoted"""`},
+		{"C:\\Program Files\\app.exe", nil, `"C:\Program Files\app.exe"`},
+	}
+
+	for _, tt := range tests {
+		got := buildCommandLine(tt.command, tt.args)
+		if got != tt.want {
+			t.Errorf("buildCommandLine(%q, %v) = %q, want %q", tt.command, tt.args, got, tt.want)
+		}
+	}
+}
+
+func TestQuoteArg(t *testing.T) {
+	tests := []struct {
+		arg  string
+		want string
+	}{
+		{"simple", "simple"},
+		{"with space", `"with space"`},
+		{`with"quote`, `"with""quote"`},
+		{"", `""`},
+		{"path\\to\\file", "path\\to\\file"},
+		{"C:\\Program Files", `"C:\Program Files"`},
+	}
+
+	for _, tt := range tests {
+		got := quoteArg(tt.arg)
+		if got != tt.want {
+			t.Errorf("quoteArg(%q) = %q, want %q", tt.arg, got, tt.want)
+		}
+	}
+}
+
+func TestEngineStart(t *testing.T) {
+	if !conpty.IsConPtyAvailable() {
+		t.Skip("ConPTY not available")
+	}
+
+	e := New()
+	sess, err := e.Start(context.Background(), StartRequest{
+		Command:     "cmd.exe",
+		Args:        []string{"/c", "echo hello"},
+		InitialSize: Winsize{Rows: 24, Cols: 80},
+	})
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	// Read output
+	var output strings.Builder
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for b := range sess.Output() {
+			output.Write(b)
+		}
+	}()
+
+	// Wait for process
+	exitCode, err := sess.Wait()
+	<-done
+
+	if err != nil {
+		t.Errorf("Wait error: %v", err)
+	}
+	if exitCode != 0 {
+		t.Errorf("exit code = %d, want 0", exitCode)
+	}
+	if !strings.Contains(output.String(), "hello") {
+		t.Errorf("output = %q, want to contain 'hello'", output.String())
+	}
+}
+
+func TestEngineStartEmptyCommand(t *testing.T) {
+	e := New()
+	_, err := e.Start(context.Background(), StartRequest{})
+	if err == nil {
+		t.Error("expected error for empty command")
+	}
+}
+
+func TestSessionResize(t *testing.T) {
+	if !conpty.IsConPtyAvailable() {
+		t.Skip("ConPTY not available")
+	}
+
+	e := New()
+	sess, err := e.Start(context.Background(), StartRequest{
+		Command:     "cmd.exe",
+		InitialSize: Winsize{Rows: 24, Cols: 80},
+	})
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	// Resize should not error
+	if err := sess.Resize(40, 120); err != nil {
+		t.Errorf("Resize failed: %v", err)
+	}
+
+	// Send exit command and wait
+	sess.Write([]byte("exit\r\n"))
+	sess.Wait()
+}
+
+func TestSessionPID(t *testing.T) {
+	if !conpty.IsConPtyAvailable() {
+		t.Skip("ConPTY not available")
+	}
+
+	e := New()
+	sess, err := e.Start(context.Background(), StartRequest{
+		Command:     "cmd.exe",
+		Args:        []string{"/c", "echo test"},
+		InitialSize: Winsize{Rows: 24, Cols: 80},
+	})
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	defer sess.Wait()
+
+	pid := sess.PID()
+	if pid == 0 {
+		t.Error("PID() returned 0, expected non-zero")
+	}
+}
+
+func TestSessionSignalINT(t *testing.T) {
+	if !conpty.IsConPtyAvailable() {
+		t.Skip("ConPTY not available")
+	}
+
+	e := New()
+	sess, err := e.Start(context.Background(), StartRequest{
+		Command:     "cmd.exe",
+		InitialSize: Winsize{Rows: 24, Cols: 80},
+	})
+	if err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+
+	// Send SIGINT (should send Ctrl+C)
+	if err := sess.Signal(sigINT); err != nil {
+		t.Errorf("Signal(SIGINT) failed: %v", err)
+	}
+
+	// Clean exit
+	sess.Write([]byte("exit\r\n"))
+	sess.Wait()
+}
+
+func TestNilSession(t *testing.T) {
+	var s *Session
+
+	// These should not panic
+	ch := s.Output()
+	if ch == nil {
+		t.Error("Output() on nil session returned nil channel")
+	}
+
+	pid := s.PID()
+	if pid != 0 {
+		t.Errorf("PID() on nil session = %d, want 0", pid)
+	}
+
+	_, err := s.Write([]byte("test"))
+	if err != io.ErrClosedPipe {
+		t.Errorf("Write() on nil session error = %v, want io.ErrClosedPipe", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Implement Windows PTY support using ConPTY (Windows Pseudo Console)
- Enable interactive terminal sessions on Windows via `agentsh exec --pty`
- Add `github.com/UserExistsError/conpty` dependency

## What's Implemented

| Method | Implementation |
|--------|---------------|
| `Start()` | Creates ConPTY session with dimensions, workdir, env |
| `Output()` | Streams output via channel (32KB buffer) |
| `Write()` | Sends input to PTY |
| `Resize()` | Terminal resize via `ResizePseudoConsole` |
| `Signal()` | SIGINT→Ctrl+C, SIGQUIT→Ctrl+\, SIGTERM/KILL→terminate |
| `Wait()` | Waits for process exit, drains output |

## Signal Handling

Windows lacks POSIX signals. Mapping:
- `SIGINT` → Write `\x03` (Ctrl+C) to PTY
- `SIGQUIT` → Write `\x1c` (Ctrl+\) to PTY  
- `SIGTERM`/`SIGHUP`/`SIGKILL` → `TerminateProcess()`

## Requirements

- Windows 10 version 1809 (October 2018 Update) or later
- Returns `ErrConPtyUnavailable` on older systems

## Test plan

- [x] Unit tests for command line building and quoting
- [x] Integration tests for ConPTY session lifecycle
- [x] Tests skip gracefully if ConPTY unavailable
- [x] Build verification on Linux, macOS, Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)