### PR TITLE
feat(darwin): exec redirect phase 2 — socketpair, TTY capture, path muting

### DIFF
--- a/internal/platform/darwin/es_exec_test.go
+++ b/internal/platform/darwin/es_exec_test.go
@@ -68,7 +68,7 @@ func TestESExecHandler_PolicyMapping(t *testing.T) {
 				message:           "test message",
 			}
 			handler := NewESExecHandler(checker, "")
-			result := handler.CheckExec("/usr/bin/test", []string{"/usr/bin/test", "-f", "foo"}, 1234, 1233, "sess-1")
+			result := handler.CheckExec("/usr/bin/test", []string{"/usr/bin/test", "-f", "foo"}, 1234, 1233, "sess-1", xpc.ExecContext{})
 
 			assert.Equal(t, tt.wantAction, result.Action, "action mismatch")
 			assert.Equal(t, tt.wantDecision, result.Decision, "decision mismatch")
@@ -80,7 +80,7 @@ func TestESExecHandler_PolicyMapping(t *testing.T) {
 
 func TestESExecHandler_NilPolicyChecker(t *testing.T) {
 	handler := NewESExecHandler(nil, "")
-	result := handler.CheckExec("/usr/bin/test", nil, 1234, 1233, "sess-1")
+	result := handler.CheckExec("/usr/bin/test", nil, 1234, 1233, "sess-1", xpc.ExecContext{})
 
 	assert.Equal(t, "continue", result.Action)
 	assert.Equal(t, "allow", result.Decision)
@@ -95,7 +95,7 @@ func TestESExecHandler_UnknownDecision(t *testing.T) {
 		rule:              "weird-rule",
 		message:           "weird message",
 	}, "")
-	result := handler.CheckExec("/usr/bin/test", nil, 1234, 1233, "sess-1")
+	result := handler.CheckExec("/usr/bin/test", nil, 1234, 1233, "sess-1", xpc.ExecContext{})
 
 	// Unknown decisions should fail-secure (deny).
 	assert.Equal(t, "deny", result.Action)
@@ -111,7 +111,7 @@ func TestESExecHandler_EffectiveDecisionFallback(t *testing.T) {
 		effectiveDecision: "", // empty
 		rule:              "fallback-rule",
 	}, "")
-	result := handler.CheckExec("/usr/bin/ls", nil, 100, 99, "sess-2")
+	result := handler.CheckExec("/usr/bin/ls", nil, 100, 99, "sess-2", xpc.ExecContext{})
 
 	assert.Equal(t, "continue", result.Action)
 	assert.Equal(t, "allow", result.Decision)
@@ -127,7 +127,7 @@ func TestESExecHandler_PassesArgsToChecker(t *testing.T) {
 	handler := NewESExecHandler(checker, "")
 
 	args := []string{"/usr/bin/curl", "-s", "https://example.com"}
-	handler.CheckExec("/usr/bin/curl", args, 5678, 5677, "sess-3")
+	handler.CheckExec("/usr/bin/curl", args, 5678, 5677, "sess-3", xpc.ExecContext{})
 
 	assert.Equal(t, "/usr/bin/curl", checker.lastCmd)
 	assert.Equal(t, args, checker.lastArgs)
@@ -144,7 +144,7 @@ func TestESExecHandler_RedirectSpawnsStub(t *testing.T) {
 		message:           "redirecting",
 	}, "/usr/local/bin/agentsh-stub")
 
-	result := handler.CheckExec("/usr/bin/git", []string{"/usr/bin/git", "push"}, 9999, 9998, "sess-4")
+	result := handler.CheckExec("/usr/bin/git", []string{"/usr/bin/git", "push"}, 9999, 9998, "sess-4", xpc.ExecContext{})
 
 	assert.Equal(t, "redirect", result.Action)
 	assert.Equal(t, "redirect", result.Decision)
@@ -160,7 +160,7 @@ func TestESExecHandler_ApproveSpawnsStub(t *testing.T) {
 		message:           "needs approval",
 	}, "/usr/local/bin/agentsh-stub")
 
-	result := handler.CheckExec("/usr/bin/rm", []string{"/usr/bin/rm", "-rf", "/"}, 1111, 1110, "sess-5")
+	result := handler.CheckExec("/usr/bin/rm", []string{"/usr/bin/rm", "-rf", "/"}, 1111, 1110, "sess-5", xpc.ExecContext{})
 
 	assert.Equal(t, "redirect", result.Action)
 	assert.Equal(t, "approve", result.Decision)

--- a/internal/platform/darwin/xpc/handler.go
+++ b/internal/platform/darwin/xpc/handler.go
@@ -68,7 +68,7 @@ func (a *PolicyAdapter) ResolveSession(pid int32) string {
 
 // CheckExec evaluates a command through the exec pipeline, returning
 // the full decision and action for the ESF client to act on.
-func (a *PolicyAdapter) CheckExec(executable string, args []string, pid int32, parentPID int32, sessionID string) ExecCheckResult {
+func (a *PolicyAdapter) CheckExec(executable string, args []string, pid int32, parentPID int32, sessionID string, _ ExecContext) ExecCheckResult {
 	if a.engine == nil {
 		return ExecCheckResult{
 			Decision: "allow",

--- a/internal/platform/darwin/xpc/handler_test.go
+++ b/internal/platform/darwin/xpc/handler_test.go
@@ -196,7 +196,7 @@ func TestPolicyAdapter_CheckExec(t *testing.T) {
 		}
 
 		adapter := NewPolicyAdapter(engine, nil)
-		result := adapter.CheckExec("ls", []string{"-la"}, 1234, 1, "session-1")
+		result := adapter.CheckExec("ls", []string{"-la"}, 1234, 1, "session-1", ExecContext{})
 
 		if result.Decision != "allow" {
 			t.Errorf("decision: got %q, want %q", result.Decision, "allow")
@@ -224,7 +224,7 @@ func TestPolicyAdapter_CheckExec(t *testing.T) {
 		}
 
 		adapter := NewPolicyAdapter(engine, nil)
-		result := adapter.CheckExec("rm", []string{"-rf", "/"}, 5678, 1, "session-1")
+		result := adapter.CheckExec("rm", []string{"-rf", "/"}, 5678, 1, "session-1", ExecContext{})
 
 		if result.Decision != "deny" {
 			t.Errorf("decision: got %q, want %q", result.Decision, "deny")
@@ -254,7 +254,7 @@ func TestPolicyAdapter_CheckExec(t *testing.T) {
 		}
 
 		adapter := NewPolicyAdapter(engine, nil)
-		result := adapter.CheckExec("git", []string{"push"}, 9999, 1, "session-1")
+		result := adapter.CheckExec("git", []string{"push"}, 9999, 1, "session-1", ExecContext{})
 
 		if result.Decision != "redirect" {
 			t.Errorf("decision: got %q, want %q", result.Decision, "redirect")
@@ -282,7 +282,7 @@ func TestPolicyAdapter_CheckExec(t *testing.T) {
 		}
 
 		adapter := NewPolicyAdapter(engine, nil)
-		result := adapter.CheckExec("curl", []string{"https://example.com"}, 2222, 1, "session-1")
+		result := adapter.CheckExec("curl", []string{"https://example.com"}, 2222, 1, "session-1", ExecContext{})
 
 		if result.Decision != "audit" {
 			t.Errorf("decision: got %q, want %q", result.Decision, "audit")
@@ -312,7 +312,7 @@ func TestPolicyAdapter_CheckExec(t *testing.T) {
 		}
 
 		adapter := NewPolicyAdapter(engine, nil)
-		result := adapter.CheckExec("sudo", []string{"ls"}, 3333, 1, "session-1")
+		result := adapter.CheckExec("sudo", []string{"ls"}, 3333, 1, "session-1", ExecContext{})
 
 		if result.Decision != "approve" {
 			t.Errorf("decision: got %q, want %q", result.Decision, "approve")
@@ -342,7 +342,7 @@ func TestPolicyAdapter_CheckExec(t *testing.T) {
 		}
 
 		adapter := NewPolicyAdapter(engine, nil)
-		result := adapter.CheckExec("sudo", []string{"ls"}, 3333, 1, "session-1")
+		result := adapter.CheckExec("sudo", []string{"ls"}, 3333, 1, "session-1", ExecContext{})
 
 		if result.Decision != "approve" {
 			t.Errorf("decision: got %q, want %q", result.Decision, "approve")
@@ -446,7 +446,7 @@ func TestPolicyAdapter_NilEngine(t *testing.T) {
 	})
 
 	t.Run("CheckExec returns no-policy", func(t *testing.T) {
-		result := adapter.CheckExec("/usr/bin/ls", []string{"-la"}, 1234, 1, "session-1")
+		result := adapter.CheckExec("/usr/bin/ls", []string{"-la"}, 1234, 1, "session-1", ExecContext{})
 		if result.Decision != "allow" {
 			t.Errorf("decision: got %q, want %q", result.Decision, "allow")
 		}

--- a/internal/platform/darwin/xpc/protocol.go
+++ b/internal/platform/darwin/xpc/protocol.go
@@ -68,6 +68,10 @@ type PolicyRequest struct {
 
 	// Session management fields
 	RootPID int32 `json:"root_pid,omitempty"` // Root PID for session registration
+
+	// Exec context fields (from ESF event)
+	TTYPath string `json:"tty_path,omitempty"` // Controlling terminal path
+	CWDPath string `json:"cwd_path,omitempty"` // Working directory of the exec'ing process
 }
 
 // PolicyResponse is returned from the Go policy server.
@@ -86,6 +90,12 @@ type PolicyResponse struct {
 	RuleID    string             `json:"rule_id,omitempty"`   // Matched rule identifier
 	Success   bool               `json:"success,omitempty"`   // For operations that return success/fail
 	Approvals []ApprovalResponse `json:"approvals,omitempty"` // Pending approval requests
+}
+
+// ExecContext carries process context from the ESF event for exec redirect.
+type ExecContext struct {
+	TTYPath string // Controlling terminal path (e.g. /dev/ttys001)
+	CWDPath string // Working directory of the exec'ing process
 }
 
 // ApprovalResponse represents a pending approval request returned to the client.

--- a/internal/platform/darwin/xpc/protocol.go
+++ b/internal/platform/darwin/xpc/protocol.go
@@ -24,6 +24,9 @@ const (
 
 	// Process muting request type
 	RequestTypeMuteProcess RequestType = "mute_process"
+
+	// Path muting request type (for es_mute_path_literal)
+	RequestTypeMutePath RequestType = "mute_path"
 )
 
 // PolicyRequest is sent from the XPC bridge to the Go policy server.

--- a/internal/platform/darwin/xpc/server.go
+++ b/internal/platform/darwin/xpc/server.go
@@ -40,7 +40,7 @@ type PNACLHandler interface {
 
 // ExecHandler handles exec pipeline checks from the ESF client.
 type ExecHandler interface {
-	CheckExec(executable string, args []string, pid int32, parentPID int32, sessionID string) ExecCheckResult
+	CheckExec(executable string, args []string, pid int32, parentPID int32, sessionID string, execCtx ExecContext) ExecCheckResult
 }
 
 // SessionRegistrar handles session lifecycle events.
@@ -327,7 +327,10 @@ func (s *Server) handleExecCheck(req *PolicyRequest) PolicyResponse {
 		return PolicyResponse{Allow: allow, Rule: rule, Action: action, ExecDecision: execDecision}
 	}
 
-	result := h.CheckExec(req.Path, req.Args, req.PID, req.ParentPID, req.SessionID)
+	result := h.CheckExec(req.Path, req.Args, req.PID, req.ParentPID, req.SessionID, ExecContext{
+		TTYPath: req.TTYPath,
+		CWDPath: req.CWDPath,
+	})
 	return PolicyResponse{
 		Allow:        result.Action == "continue",
 		Rule:         result.Rule,

--- a/internal/platform/darwin/xpc/server_test.go
+++ b/internal/platform/darwin/xpc/server_test.go
@@ -634,7 +634,7 @@ type testExecHandler struct {
 	result ExecCheckResult
 }
 
-func (h *testExecHandler) CheckExec(executable string, args []string, pid int32, parentPID int32, sessionID string) ExecCheckResult {
+func (h *testExecHandler) CheckExec(executable string, args []string, pid int32, parentPID int32, sessionID string, _ ExecContext) ExecCheckResult {
 	return h.result
 }
 

--- a/internal/platform/darwin/xpc/server_test.go
+++ b/internal/platform/darwin/xpc/server_test.go
@@ -898,6 +898,7 @@ type testSessionRegistrar struct {
 	unregisteredPID     int32
 	registerCalled      bool
 	unregisterCalled    bool
+	mutedPaths          []string
 }
 
 func (r *testSessionRegistrar) RegisterSession(rootPID int32, sessionID string) {
@@ -913,6 +914,12 @@ func (r *testSessionRegistrar) UnregisterSession(rootPID int32) {
 	defer r.mu.Unlock()
 	r.unregisteredPID = rootPID
 	r.unregisterCalled = true
+}
+
+func (r *testSessionRegistrar) MutePath(path string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.mutedPaths = append(r.mutedPaths, path)
 }
 
 func TestServer_RegisterSession(t *testing.T) {

--- a/macos/Shared/XPCProtocol.swift
+++ b/macos/Shared/XPCProtocol.swift
@@ -56,6 +56,8 @@ import Foundation
         pid: pid_t,
         parentPID: pid_t,
         sessionID: String?,
+        ttyPath: String?,
+        cwdPath: String?,
         reply: @escaping (String, String, String?) -> Void  // (decision, action, rule)
     )
 

--- a/macos/XPCService/PolicyBridge.swift
+++ b/macos/XPCService/PolicyBridge.swift
@@ -89,6 +89,8 @@ class PolicyBridge: NSObject, AgentshXPCProtocol {
         pid: pid_t,
         parentPID: pid_t,
         sessionID: String?,
+        ttyPath: String?,
+        cwdPath: String?,
         reply: @escaping (String, String, String?) -> Void
     ) {
         let request: [String: Any] = [
@@ -97,7 +99,9 @@ class PolicyBridge: NSObject, AgentshXPCProtocol {
             "args": args,
             "pid": pid,
             "parent_pid": parentPID,
-            "session_id": sessionID ?? ""
+            "session_id": sessionID ?? "",
+            "tty_path": ttyPath ?? "",
+            "cwd_path": cwdPath ?? ""
         ]
         sendRequest(request) { [weak self] response in
             // Check if this was an error response from sendRequest.


### PR DESCRIPTION
## Summary

- Pass TTY path and CWD from ESF `es_message_t` through XPC to the Go exec handler via new `ExecContext` struct
- Replace `net.Pipe` with Unix socketpair (`unix.Socketpair`) so the fd can be passed to the stub subprocess via `ExtraFiles`
- Implement real `launchStub` — spawns `agentsh-stub` with socketpair as fd 3, stdout/stderr connected to the denied process's TTY device
- Add `es_mute_path_literal` at ESF client startup for agentsh-stub/agentsh binaries, with fast-path fallback for macOS < 12.0
- Add `RequestTypeMutePath` and `handleMutePath` for dynamic path muting via XPC
- Extend `SessionRegistrar` interface with `MutePath(path string)`

## Test Plan

- [x] `go build ./...` — Linux native build passes
- [x] `GOOS=windows go build ./...` — Windows cross-compile passes
- [x] `GOOS=darwin CGO_ENABLED=0 go build ./...` — macOS cross-compile passes
- [x] `go test ./... -count=1` — full test suite passes
- [x] New tests: `TestCreateSocketPair`, `TestLaunchStub_NoTTY`, `TestLaunchStub_MissingBinary`, `TestServer_MutePath`
- [ ] End-to-end on macOS: `agentsh wrap` intercepts exec, denies, stub output appears in original terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)