### PR TITLE
Normalize hostnames in DNS/connect redirect matching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,18 @@ jobs:
           restore-keys: |
             ${{ env.GO_CACHE_VERSION }}-${{ runner.os }}-go-
 
+      - name: Free disk space
+        run: |
+          echo "=== Disk space before cleanup ==="
+          df -h /tmp /home/runner
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /usr/local/share/powershell
+          echo "=== Disk space after cleanup ==="
+          df -h /tmp /home/runner
+
       - name: go test
-        run: go test ./...
+        run: go test -p 2 ./...
+        env:
+          GOTMPDIR: ${{ runner.temp }}/go-tmp
 
       - name: smoke
         run: make smoke

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
           df -h /tmp /home/runner
 
       - name: go test
-        run: go test -p 2 ./...
+        run: |
+          mkdir -p "$GOTMPDIR"
+          go test -p 2 ./...
         env:
           GOTMPDIR: ${{ runner.temp }}/go-tmp
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # Increment to bust Go module cache when needed
-  GO_CACHE_VERSION: v1
+  GO_CACHE_VERSION: v2
 
 jobs:
   test-linux:


### PR DESCRIPTION
## Summary

- Normalize hostname inputs in `EvaluateDnsRedirect` and `EvaluateConnectRedirect` (lowercase, trim whitespace, strip trailing dot) to ensure case-insensitive matching consistent with DNS semantics
- Aligns with existing normalization in `CheckNetworkCtx`, which already lowercases domains
- For `EvaluateConnectRedirect`, only the host portion is normalized, preserving the port

Fixes #97

## Test plan

- [x] Added `TestEvaluateDnsRedirect_CaseNormalization` covering mixed case, trailing dot, whitespace, and non-matching inputs
- [x] Added `TestEvaluateConnectRedirect_CaseNormalization` with the same cases for host:port inputs
- [x] All existing tests pass
- [x] Windows cross-compilation verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)