### PR TITLE
feat: MCP tool call interception and policy enforcement

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -499,11 +499,30 @@ type SandboxXPCESFConfig struct {
 type SandboxMCPConfig struct {
 	EnforcePolicy  bool                    `yaml:"enforce_policy"`
 	FailClosed     bool                    `yaml:"fail_closed"` // Block unknown tools if true
+	Servers        []MCPServerDeclaration  `yaml:"servers"`
+	ServerPolicy   string                  `yaml:"server_policy"` // allowlist, denylist, none
+	AllowedServers []MCPServerRule         `yaml:"allowed_servers"`
+	DeniedServers  []MCPServerRule         `yaml:"denied_servers"`
 	ToolPolicy     string                  `yaml:"tool_policy"` // allowlist, denylist, none
 	AllowedTools   []MCPToolRule           `yaml:"allowed_tools"`
 	DeniedTools    []MCPToolRule           `yaml:"denied_tools"`
 	VersionPinning MCPVersionPinningConfig `yaml:"version_pinning"`
 	RateLimits     MCPRateLimitsConfig     `yaml:"rate_limits"`
+}
+
+// MCPServerDeclaration defines an MCP server and how to connect to it.
+type MCPServerDeclaration struct {
+	ID             string   `yaml:"id"`
+	Type           string   `yaml:"type"`            // "stdio" | "http" | "sse"
+	Command        string   `yaml:"command"`          // For stdio servers
+	Args           []string `yaml:"args"`             // For stdio servers
+	URL            string   `yaml:"url"`              // For http/sse servers
+	TLSFingerprint string   `yaml:"tls_fingerprint"`  // Optional TLS cert pin
+}
+
+// MCPServerRule matches servers by ID (supports "*" wildcard).
+type MCPServerRule struct {
+	ID string `yaml:"id"`
 }
 
 // MCPToolRule defines a tool matching rule.

--- a/internal/config/proxy.go
+++ b/internal/config/proxy.go
@@ -12,6 +12,11 @@ type ProxyProvidersConfig struct {
 	OpenAI    string `yaml:"openai"`
 }
 
+// IsMCPOnly returns true if the proxy runs in MCP-interception-only mode.
+func (c ProxyConfig) IsMCPOnly() bool {
+	return c.Mode == "mcp-only"
+}
+
 // IsCustomOpenAI returns true if a non-default OpenAI URL is configured.
 func (c ProxyProvidersConfig) IsCustomOpenAI() bool {
 	return c.OpenAI != "" && c.OpenAI != "https://api.openai.com"

--- a/internal/config/proxy_test.go
+++ b/internal/config/proxy_test.go
@@ -16,6 +16,47 @@ func TestProxyConfigDefaults(t *testing.T) {
 	}
 }
 
+func TestProxyConfig_IsMCPOnly(t *testing.T) {
+	tests := []struct {
+		name string
+		mode string
+		want bool
+	}{
+		{"mcp-only mode", "mcp-only", true},
+		{"embedded mode", "embedded", false},
+		{"disabled mode", "disabled", false},
+		{"empty mode", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := ProxyConfig{Mode: tt.mode}
+			if got := cfg.IsMCPOnly(); got != tt.want {
+				t.Errorf("ProxyConfig{Mode: %q}.IsMCPOnly() = %v, want %v", tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProxyConfig_IsMCPOnly_YAMLParse(t *testing.T) {
+	yamlData := `
+proxy:
+  mode: mcp-only
+  port: 8080
+`
+	var cfg struct {
+		Proxy ProxyConfig `yaml:"proxy"`
+	}
+	if err := yaml.Unmarshal([]byte(yamlData), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !cfg.Proxy.IsMCPOnly() {
+		t.Errorf("expected IsMCPOnly() = true for mode %q", cfg.Proxy.Mode)
+	}
+	if cfg.Proxy.Port != 8080 {
+		t.Errorf("expected port 8080, got %d", cfg.Proxy.Port)
+	}
+}
+
 func TestDLPConfigParse(t *testing.T) {
 	yamlData := `
 dlp:

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -103,10 +103,11 @@ const (
 
 // MCP inspection events.
 const (
-	EventMCPToolSeen    EventType = "mcp_tool_seen"
-	EventMCPToolChanged EventType = "mcp_tool_changed"
-	EventMCPToolCalled  EventType = "mcp_tool_called"
-	EventMCPDetection   EventType = "mcp_detection"
+	EventMCPToolSeen            EventType = "mcp_tool_seen"
+	EventMCPToolChanged         EventType = "mcp_tool_changed"
+	EventMCPToolCalled          EventType = "mcp_tool_called"
+	EventMCPDetection           EventType = "mcp_detection"
+	EventMCPToolCallIntercepted EventType = "mcp_tool_call_intercepted"
 )
 
 // Policy events.
@@ -211,10 +212,11 @@ var EventCategory = map[EventType]string{
 	EventSignalWouldDeny:  "signal",
 
 	// MCP
-	EventMCPToolSeen:    "mcp",
-	EventMCPToolChanged: "mcp",
-	EventMCPToolCalled:  "mcp",
-	EventMCPDetection:   "mcp",
+	EventMCPToolSeen:            "mcp",
+	EventMCPToolChanged:         "mcp",
+	EventMCPToolCalled:          "mcp",
+	EventMCPDetection:           "mcp",
+	EventMCPToolCallIntercepted: "mcp",
 
 	// Policy
 	EventPolicyLoaded:  "policy",
@@ -251,7 +253,7 @@ var AllEventTypes = []EventType{
 	EventSignalSent, EventSignalBlocked, EventSignalRedirected,
 	EventSignalAbsorbed, EventSignalApproved, EventSignalWouldDeny,
 	// MCP
-	EventMCPToolSeen, EventMCPToolChanged, EventMCPToolCalled, EventMCPDetection,
+	EventMCPToolSeen, EventMCPToolChanged, EventMCPToolCalled, EventMCPDetection, EventMCPToolCallIntercepted,
 	// Policy
 	EventPolicyLoaded, EventPolicyChanged,
 }

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -105,6 +105,7 @@ const (
 const (
 	EventMCPToolSeen    EventType = "mcp_tool_seen"
 	EventMCPToolChanged EventType = "mcp_tool_changed"
+	EventMCPToolCalled  EventType = "mcp_tool_called"
 	EventMCPDetection   EventType = "mcp_detection"
 )
 
@@ -212,6 +213,7 @@ var EventCategory = map[EventType]string{
 	// MCP
 	EventMCPToolSeen:    "mcp",
 	EventMCPToolChanged: "mcp",
+	EventMCPToolCalled:  "mcp",
 	EventMCPDetection:   "mcp",
 
 	// Policy
@@ -249,7 +251,7 @@ var AllEventTypes = []EventType{
 	EventSignalSent, EventSignalBlocked, EventSignalRedirected,
 	EventSignalAbsorbed, EventSignalApproved, EventSignalWouldDeny,
 	// MCP
-	EventMCPToolSeen, EventMCPToolChanged, EventMCPDetection,
+	EventMCPToolSeen, EventMCPToolChanged, EventMCPToolCalled, EventMCPDetection,
 	// Policy
 	EventPolicyLoaded, EventPolicyChanged,
 }

--- a/internal/llmproxy/mcp_intercept.go
+++ b/internal/llmproxy/mcp_intercept.go
@@ -106,10 +106,14 @@ func extractOpenAIToolCalls(body []byte) []ToolCall {
 			continue
 		}
 		for _, tc := range choice.Message.ToolCalls {
+			args := []byte(tc.Function.Arguments)
+			if !json.Valid(args) {
+				continue
+			}
 			calls = append(calls, ToolCall{
 				ID:    tc.ID,
 				Name:  tc.Function.Name,
-				Input: json.RawMessage(tc.Function.Arguments),
+				Input: json.RawMessage(args),
 			})
 		}
 	}

--- a/internal/llmproxy/mcp_intercept.go
+++ b/internal/llmproxy/mcp_intercept.go
@@ -1,0 +1,117 @@
+package llmproxy
+
+import "encoding/json"
+
+// ToolCall represents a tool invocation extracted from an LLM response.
+type ToolCall struct {
+	ID    string          // "toolu_..." or "call_..."
+	Name  string          // tool name
+	Input json.RawMessage // arguments
+}
+
+// ExtractToolCalls parses tool call blocks from an LLM response body.
+// It returns nil if no tool calls are found or the body is malformed.
+func ExtractToolCalls(body []byte, dialect Dialect) []ToolCall {
+	switch dialect {
+	case DialectAnthropic:
+		return extractAnthropicToolCalls(body)
+	case DialectOpenAI:
+		return extractOpenAIToolCalls(body)
+	}
+	return nil
+}
+
+// extractAnthropicToolCalls parses content blocks where type == "tool_use".
+// It checks stop_reason == "tool_use" first and extracts id, name, input
+// from each tool_use content block.
+//
+// Anthropic response format:
+//
+//	{
+//	  "stop_reason": "tool_use",
+//	  "content": [
+//	    {"type": "text", "text": "..."},
+//	    {"type": "tool_use", "id": "toolu_01A09q90qw90lq917835lq9", "name": "get_weather", "input": {"location": "San Francisco, CA"}}
+//	  ]
+//	}
+func extractAnthropicToolCalls(body []byte) []ToolCall {
+	var resp struct {
+		StopReason string `json:"stop_reason"`
+		Content    []struct {
+			Type  string          `json:"type"`
+			ID    string          `json:"id"`
+			Name  string          `json:"name"`
+			Input json.RawMessage `json:"input"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil
+	}
+	if resp.StopReason != "tool_use" {
+		return nil
+	}
+	var calls []ToolCall
+	for _, block := range resp.Content {
+		if block.Type == "tool_use" {
+			calls = append(calls, ToolCall{
+				ID:    block.ID,
+				Name:  block.Name,
+				Input: block.Input,
+			})
+		}
+	}
+	return calls
+}
+
+// extractOpenAIToolCalls parses choices[].message.tool_calls[] where
+// finish_reason == "tool_calls". It extracts id, function.name, and
+// function.arguments from each tool call entry. Note that OpenAI sends
+// arguments as a JSON string, which is converted to json.RawMessage.
+//
+// OpenAI response format:
+//
+//	{
+//	  "choices": [{
+//	    "finish_reason": "tool_calls",
+//	    "message": {
+//	      "tool_calls": [{
+//	        "id": "call_KlZ3...",
+//	        "type": "function",
+//	        "function": {"name": "get_weather", "arguments": "{\"location\": \"San Francisco, CA\"}"}
+//	      }]
+//	    }
+//	  }]
+//	}
+func extractOpenAIToolCalls(body []byte) []ToolCall {
+	var resp struct {
+		Choices []struct {
+			FinishReason string `json:"finish_reason"`
+			Message      struct {
+				ToolCalls []struct {
+					ID       string `json:"id"`
+					Function struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"` // JSON string
+					} `json:"function"`
+				} `json:"tool_calls"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil
+	}
+	var calls []ToolCall
+	for _, choice := range resp.Choices {
+		if choice.FinishReason != "tool_calls" {
+			continue
+		}
+		for _, tc := range choice.Message.ToolCalls {
+			calls = append(calls, ToolCall{
+				ID:    tc.ID,
+				Name:  tc.Function.Name,
+				Input: json.RawMessage(tc.Function.Arguments),
+			})
+		}
+	}
+	return calls
+}

--- a/internal/llmproxy/mcp_intercept_test.go
+++ b/internal/llmproxy/mcp_intercept_test.go
@@ -1,0 +1,524 @@
+package llmproxy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestExtractToolCalls_AnthropicSingleTool(t *testing.T) {
+	body := []byte(`{
+		"id": "msg_01XFDUDYJgAACzvnptvVoYEL",
+		"type": "message",
+		"role": "assistant",
+		"stop_reason": "tool_use",
+		"content": [
+			{"type": "text", "text": "I'll check the weather for you."},
+			{
+				"type": "tool_use",
+				"id": "toolu_01A09q90qw90lq917835lq9",
+				"name": "get_weather",
+				"input": {"location": "San Francisco, CA"}
+			}
+		]
+	}`)
+
+	calls := ExtractToolCalls(body, DialectAnthropic)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+
+	tc := calls[0]
+	if tc.ID != "toolu_01A09q90qw90lq917835lq9" {
+		t.Errorf("expected ID %q, got %q", "toolu_01A09q90qw90lq917835lq9", tc.ID)
+	}
+	if tc.Name != "get_weather" {
+		t.Errorf("expected Name %q, got %q", "get_weather", tc.Name)
+	}
+
+	var input map[string]string
+	if err := json.Unmarshal(tc.Input, &input); err != nil {
+		t.Fatalf("failed to unmarshal input: %v", err)
+	}
+	if input["location"] != "San Francisco, CA" {
+		t.Errorf("expected location %q, got %q", "San Francisco, CA", input["location"])
+	}
+}
+
+func TestExtractToolCalls_AnthropicParallelTools(t *testing.T) {
+	body := []byte(`{
+		"id": "msg_01XFDUDYJgAACzvnptvVoYEL",
+		"type": "message",
+		"role": "assistant",
+		"stop_reason": "tool_use",
+		"content": [
+			{"type": "text", "text": "I'll check both locations."},
+			{
+				"type": "tool_use",
+				"id": "toolu_01AAA",
+				"name": "get_weather",
+				"input": {"location": "San Francisco, CA"}
+			},
+			{
+				"type": "tool_use",
+				"id": "toolu_01BBB",
+				"name": "get_weather",
+				"input": {"location": "New York, NY"}
+			}
+		]
+	}`)
+
+	calls := ExtractToolCalls(body, DialectAnthropic)
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 tool calls, got %d", len(calls))
+	}
+
+	if calls[0].ID != "toolu_01AAA" {
+		t.Errorf("first call: expected ID %q, got %q", "toolu_01AAA", calls[0].ID)
+	}
+	if calls[0].Name != "get_weather" {
+		t.Errorf("first call: expected Name %q, got %q", "get_weather", calls[0].Name)
+	}
+
+	if calls[1].ID != "toolu_01BBB" {
+		t.Errorf("second call: expected ID %q, got %q", "toolu_01BBB", calls[1].ID)
+	}
+	if calls[1].Name != "get_weather" {
+		t.Errorf("second call: expected Name %q, got %q", "get_weather", calls[1].Name)
+	}
+
+	// Verify the inputs are different
+	var input0, input1 map[string]string
+	if err := json.Unmarshal(calls[0].Input, &input0); err != nil {
+		t.Fatalf("failed to unmarshal first input: %v", err)
+	}
+	if err := json.Unmarshal(calls[1].Input, &input1); err != nil {
+		t.Fatalf("failed to unmarshal second input: %v", err)
+	}
+	if input0["location"] != "San Francisco, CA" {
+		t.Errorf("first call: expected location %q, got %q", "San Francisco, CA", input0["location"])
+	}
+	if input1["location"] != "New York, NY" {
+		t.Errorf("second call: expected location %q, got %q", "New York, NY", input1["location"])
+	}
+}
+
+func TestExtractToolCalls_OpenAISingleTool(t *testing.T) {
+	body := []byte(`{
+		"id": "chatcmpl-abc123",
+		"object": "chat.completion",
+		"choices": [{
+			"index": 0,
+			"finish_reason": "tool_calls",
+			"message": {
+				"role": "assistant",
+				"content": null,
+				"tool_calls": [{
+					"id": "call_KlZ3abc123",
+					"type": "function",
+					"function": {
+						"name": "get_weather",
+						"arguments": "{\"location\": \"San Francisco, CA\"}"
+					}
+				}]
+			}
+		}]
+	}`)
+
+	calls := ExtractToolCalls(body, DialectOpenAI)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+
+	tc := calls[0]
+	if tc.ID != "call_KlZ3abc123" {
+		t.Errorf("expected ID %q, got %q", "call_KlZ3abc123", tc.ID)
+	}
+	if tc.Name != "get_weather" {
+		t.Errorf("expected Name %q, got %q", "get_weather", tc.Name)
+	}
+
+	var input map[string]string
+	if err := json.Unmarshal(tc.Input, &input); err != nil {
+		t.Fatalf("failed to unmarshal input: %v", err)
+	}
+	if input["location"] != "San Francisco, CA" {
+		t.Errorf("expected location %q, got %q", "San Francisco, CA", input["location"])
+	}
+}
+
+func TestExtractToolCalls_OpenAIParallelTools(t *testing.T) {
+	body := []byte(`{
+		"id": "chatcmpl-abc123",
+		"object": "chat.completion",
+		"choices": [{
+			"index": 0,
+			"finish_reason": "tool_calls",
+			"message": {
+				"role": "assistant",
+				"content": null,
+				"tool_calls": [
+					{
+						"id": "call_AAA",
+						"type": "function",
+						"function": {
+							"name": "get_weather",
+							"arguments": "{\"location\": \"San Francisco, CA\"}"
+						}
+					},
+					{
+						"id": "call_BBB",
+						"type": "function",
+						"function": {
+							"name": "get_time",
+							"arguments": "{\"timezone\": \"America/Los_Angeles\"}"
+						}
+					}
+				]
+			}
+		}]
+	}`)
+
+	calls := ExtractToolCalls(body, DialectOpenAI)
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 tool calls, got %d", len(calls))
+	}
+
+	if calls[0].ID != "call_AAA" {
+		t.Errorf("first call: expected ID %q, got %q", "call_AAA", calls[0].ID)
+	}
+	if calls[0].Name != "get_weather" {
+		t.Errorf("first call: expected Name %q, got %q", "get_weather", calls[0].Name)
+	}
+
+	if calls[1].ID != "call_BBB" {
+		t.Errorf("second call: expected ID %q, got %q", "call_BBB", calls[1].ID)
+	}
+	if calls[1].Name != "get_time" {
+		t.Errorf("second call: expected Name %q, got %q", "get_time", calls[1].Name)
+	}
+}
+
+func TestExtractToolCalls_NonToolResponseReturnsNil(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect Dialect
+		body    string
+	}{
+		{
+			name:    "Anthropic text-only response",
+			dialect: DialectAnthropic,
+			body: `{
+				"id": "msg_01XFDUDYJgAACzvnptvVoYEL",
+				"type": "message",
+				"role": "assistant",
+				"stop_reason": "end_turn",
+				"content": [
+					{"type": "text", "text": "Hello! How can I help you today?"}
+				]
+			}`,
+		},
+		{
+			name:    "OpenAI text-only response",
+			dialect: DialectOpenAI,
+			body: `{
+				"id": "chatcmpl-abc123",
+				"object": "chat.completion",
+				"choices": [{
+					"index": 0,
+					"finish_reason": "stop",
+					"message": {
+						"role": "assistant",
+						"content": "Hello! How can I help you today?"
+					}
+				}]
+			}`,
+		},
+		{
+			name:    "Anthropic stop_reason is not tool_use",
+			dialect: DialectAnthropic,
+			body: `{
+				"stop_reason": "max_tokens",
+				"content": [
+					{"type": "text", "text": "I was saying..."}
+				]
+			}`,
+		},
+		{
+			name:    "OpenAI finish_reason is not tool_calls",
+			dialect: DialectOpenAI,
+			body: `{
+				"choices": [{
+					"finish_reason": "stop",
+					"message": {
+						"role": "assistant",
+						"content": "The weather is nice."
+					}
+				}]
+			}`,
+		},
+		{
+			name:    "Unknown dialect",
+			dialect: DialectUnknown,
+			body:    `{"some": "data"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := ExtractToolCalls([]byte(tt.body), tt.dialect)
+			if calls != nil {
+				t.Errorf("expected nil, got %v", calls)
+			}
+		})
+	}
+}
+
+func TestExtractToolCalls_MalformedJSONReturnsNil(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect Dialect
+		body    string
+	}{
+		{
+			name:    "Anthropic malformed JSON",
+			dialect: DialectAnthropic,
+			body:    `{not valid json`,
+		},
+		{
+			name:    "OpenAI malformed JSON",
+			dialect: DialectOpenAI,
+			body:    `{not valid json`,
+		},
+		{
+			name:    "Anthropic empty body",
+			dialect: DialectAnthropic,
+			body:    ``,
+		},
+		{
+			name:    "OpenAI empty body",
+			dialect: DialectOpenAI,
+			body:    ``,
+		},
+		{
+			name:    "Anthropic null body",
+			dialect: DialectAnthropic,
+			body:    `null`,
+		},
+		{
+			name:    "OpenAI null body",
+			dialect: DialectOpenAI,
+			body:    `null`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			calls := ExtractToolCalls([]byte(tt.body), tt.dialect)
+			if calls != nil {
+				t.Errorf("expected nil, got %v", calls)
+			}
+		})
+	}
+}
+
+func TestExtractToolCalls_OpenAIArgumentsConversion(t *testing.T) {
+	// OpenAI sends arguments as a JSON string. Verify it is correctly
+	// stored as json.RawMessage and can be parsed back.
+	body := []byte(`{
+		"choices": [{
+			"finish_reason": "tool_calls",
+			"message": {
+				"tool_calls": [{
+					"id": "call_test123",
+					"type": "function",
+					"function": {
+						"name": "create_file",
+						"arguments": "{\"path\": \"/tmp/test.txt\", \"content\": \"hello world\", \"overwrite\": true}"
+					}
+				}]
+			}
+		}]
+	}`)
+
+	calls := ExtractToolCalls(body, DialectOpenAI)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+
+	tc := calls[0]
+
+	// Verify Input is valid JSON
+	if !json.Valid(tc.Input) {
+		t.Fatalf("Input is not valid JSON: %s", string(tc.Input))
+	}
+
+	// Parse the arguments and verify all fields
+	var args struct {
+		Path      string `json:"path"`
+		Content   string `json:"content"`
+		Overwrite bool   `json:"overwrite"`
+	}
+	if err := json.Unmarshal(tc.Input, &args); err != nil {
+		t.Fatalf("failed to unmarshal arguments: %v", err)
+	}
+
+	if args.Path != "/tmp/test.txt" {
+		t.Errorf("expected path %q, got %q", "/tmp/test.txt", args.Path)
+	}
+	if args.Content != "hello world" {
+		t.Errorf("expected content %q, got %q", "hello world", args.Content)
+	}
+	if !args.Overwrite {
+		t.Error("expected overwrite to be true")
+	}
+}
+
+func TestExtractToolCalls_AnthropicMixedContentBlocks(t *testing.T) {
+	// Verify that non-tool_use content blocks are skipped
+	body := []byte(`{
+		"stop_reason": "tool_use",
+		"content": [
+			{"type": "text", "text": "Let me help with that."},
+			{
+				"type": "tool_use",
+				"id": "toolu_01CCC",
+				"name": "read_file",
+				"input": {"path": "/etc/hosts"}
+			},
+			{"type": "text", "text": "And also..."},
+			{
+				"type": "tool_use",
+				"id": "toolu_01DDD",
+				"name": "write_file",
+				"input": {"path": "/tmp/out.txt", "content": "data"}
+			}
+		]
+	}`)
+
+	calls := ExtractToolCalls(body, DialectAnthropic)
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 tool calls, got %d", len(calls))
+	}
+
+	if calls[0].Name != "read_file" {
+		t.Errorf("first call: expected Name %q, got %q", "read_file", calls[0].Name)
+	}
+	if calls[1].Name != "write_file" {
+		t.Errorf("second call: expected Name %q, got %q", "write_file", calls[1].Name)
+	}
+}
+
+func TestExtractToolCalls_OpenAIEmptyToolCallsArray(t *testing.T) {
+	// finish_reason is tool_calls but tool_calls array is empty
+	body := []byte(`{
+		"choices": [{
+			"finish_reason": "tool_calls",
+			"message": {
+				"tool_calls": []
+			}
+		}]
+	}`)
+
+	calls := ExtractToolCalls(body, DialectOpenAI)
+	if calls != nil {
+		t.Errorf("expected nil for empty tool_calls array, got %v", calls)
+	}
+}
+
+func TestExtractToolCalls_AnthropicEmptyContentArray(t *testing.T) {
+	// stop_reason is tool_use but content array has no tool_use blocks
+	body := []byte(`{
+		"stop_reason": "tool_use",
+		"content": [
+			{"type": "text", "text": "Just some text."}
+		]
+	}`)
+
+	calls := ExtractToolCalls(body, DialectAnthropic)
+	if calls != nil {
+		t.Errorf("expected nil when no tool_use blocks found, got %v", calls)
+	}
+}
+
+func TestExtractToolCalls_OpenAIMultipleChoices(t *testing.T) {
+	// Only the choice with finish_reason "tool_calls" should yield tool calls.
+	body := []byte(`{
+		"choices": [
+			{
+				"index": 0,
+				"finish_reason": "stop",
+				"message": {
+					"role": "assistant",
+					"content": "Hello"
+				}
+			},
+			{
+				"index": 1,
+				"finish_reason": "tool_calls",
+				"message": {
+					"tool_calls": [{
+						"id": "call_from_choice_1",
+						"type": "function",
+						"function": {
+							"name": "search",
+							"arguments": "{\"query\": \"test\"}"
+						}
+					}]
+				}
+			}
+		]
+	}`)
+
+	calls := ExtractToolCalls(body, DialectOpenAI)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].ID != "call_from_choice_1" {
+		t.Errorf("expected ID %q, got %q", "call_from_choice_1", calls[0].ID)
+	}
+}
+
+func TestExtractToolCalls_AnthropicComplexInput(t *testing.T) {
+	// Verify nested JSON objects in input are preserved
+	body := []byte(`{
+		"stop_reason": "tool_use",
+		"content": [{
+			"type": "tool_use",
+			"id": "toolu_complex",
+			"name": "api_call",
+			"input": {
+				"method": "POST",
+				"url": "https://api.example.com/data",
+				"headers": {"Content-Type": "application/json"},
+				"body": {"key": "value", "nested": {"deep": true}}
+			}
+		}]
+	}`)
+
+	calls := ExtractToolCalls(body, DialectAnthropic)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+
+	// Verify the complex input is preserved as valid JSON
+	if !json.Valid(calls[0].Input) {
+		t.Fatalf("Input is not valid JSON: %s", string(calls[0].Input))
+	}
+
+	var input map[string]any
+	if err := json.Unmarshal(calls[0].Input, &input); err != nil {
+		t.Fatalf("failed to unmarshal complex input: %v", err)
+	}
+
+	if input["method"] != "POST" {
+		t.Errorf("expected method %q, got %v", "POST", input["method"])
+	}
+
+	headers, ok := input["headers"].(map[string]any)
+	if !ok {
+		t.Fatal("expected headers to be a map")
+	}
+	if headers["Content-Type"] != "application/json" {
+		t.Errorf("expected Content-Type header, got %v", headers["Content-Type"])
+	}
+}

--- a/internal/mcpinspect/events.go
+++ b/internal/mcpinspect/events.go
@@ -1,7 +1,10 @@
 // internal/mcpinspect/events.go
 package mcpinspect
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // MCPToolSeenEvent is logged when a tool definition is observed.
 type MCPToolSeenEvent struct {
@@ -47,6 +50,20 @@ type MCPToolChangedEvent struct {
 
 	// New detection results
 	Detections []DetectionResult `json:"detections,omitempty"`
+}
+
+// MCPToolCalledEvent is logged when a tools/call JSON-RPC request is observed
+// on an MCP server's stdin.
+type MCPToolCalledEvent struct {
+	Type      string    `json:"type"` // "mcp_tool_called"
+	Timestamp time.Time `json:"timestamp"`
+	SessionID string    `json:"session_id"`
+	ServerID  string    `json:"server_id"`
+
+	// From JSON-RPC request
+	ToolName  string          `json:"tool_name"`
+	JSONRPCID json.RawMessage `json:"jsonrpc_id"`
+	Input     json.RawMessage `json:"input,omitempty"`
 }
 
 // MCPDetectionEvent is logged when suspicious patterns are detected.

--- a/internal/mcpinspect/events.go
+++ b/internal/mcpinspect/events.go
@@ -83,6 +83,31 @@ type MCPDetectionEvent struct {
 	Action string `json:"action"` // "alert" | "warn" | "block"
 }
 
+// MCPToolCallInterceptedEvent is logged when the LLM proxy detects a
+// tool_use/tool_calls block that matches a registered MCP tool.
+type MCPToolCallInterceptedEvent struct {
+	Type      string    `json:"type"`       // "mcp_tool_call_intercepted"
+	Timestamp time.Time `json:"timestamp"`
+	SessionID string    `json:"session_id"`
+	RequestID string    `json:"request_id"` // LLM proxy request ID
+	Dialect   string    `json:"dialect"`    // "anthropic" | "openai"
+
+	// From LLM response
+	ToolName   string          `json:"tool_name"`
+	ToolCallID string          `json:"tool_call_id"` // "toolu_..." or "call_..."
+	Input      json.RawMessage `json:"input"`
+
+	// From registry lookup
+	ServerID   string `json:"server_id"`
+	ServerType string `json:"server_type"` // "stdio" | "http" | "sse"
+	ServerAddr string `json:"server_addr,omitempty"`
+	ToolHash   string `json:"tool_hash"`
+
+	// Policy decision
+	Action string `json:"action"`           // "allow" | "block"
+	Reason string `json:"reason,omitempty"`
+}
+
 // FieldChange describes what changed in a tool definition.
 type FieldChange struct {
 	Field    string `json:"field"`

--- a/internal/mcpinspect/inspector.go
+++ b/internal/mcpinspect/inspector.go
@@ -2,7 +2,6 @@
 package mcpinspect
 
 import (
-	"encoding/json"
 	"time"
 
 	"github.com/agentsh/agentsh/internal/config"
@@ -147,19 +146,13 @@ func (i *Inspector) handleToolsCall(data []byte) error {
 		return err
 	}
 
-	// Marshal the JSON-RPC ID to json.RawMessage for the event.
-	idJSON, err := json.Marshal(req.ID)
-	if err != nil {
-		return err
-	}
-
 	event := MCPToolCalledEvent{
 		Type:      "mcp_tool_called",
 		Timestamp: time.Now(),
 		SessionID: i.sessionID,
 		ServerID:  i.serverID,
 		ToolName:  req.Params.Name,
-		JSONRPCID: idJSON,
+		JSONRPCID: req.ID,
 		Input:     req.Params.Arguments,
 	}
 	i.emitEvent(event)

--- a/internal/mcpinspect/policy.go
+++ b/internal/mcpinspect/policy.go
@@ -57,7 +57,7 @@ func (p *PolicyEvaluator) Evaluate(serverID, toolName, hash string) PolicyDecisi
 		return p.evaluateAllowlist(serverID, toolName, hash)
 	case "denylist":
 		return p.evaluateDenylist(serverID, toolName, hash)
-	case "":
+	case "", "none":
 		return PolicyDecision{Allowed: true, Reason: "no tool policy configured"}
 	default:
 		return PolicyDecision{Allowed: false, Reason: fmt.Sprintf("unknown tool_policy %q; denying", p.cfg.ToolPolicy)}
@@ -86,7 +86,7 @@ func (p *PolicyEvaluator) evaluateServerPolicy(serverID string) (PolicyDecision,
 		// Server not denied — pass through to tool-level check
 		return PolicyDecision{}, false
 
-	case "":
+	case "", "none":
 		// No server policy — skip to tool-level
 		return PolicyDecision{}, false
 

--- a/internal/mcpinspect/policy_test.go
+++ b/internal/mcpinspect/policy_test.go
@@ -88,3 +88,192 @@ func TestPolicyEvaluator_HashVerification(t *testing.T) {
 		t.Error("Expected denied with different hash")
 	}
 }
+
+func TestPolicyEvaluator_ServerAllowlist(t *testing.T) {
+	cfg := config.SandboxMCPConfig{
+		EnforcePolicy: true,
+		ServerPolicy:  "allowlist",
+		AllowedServers: []config.MCPServerRule{
+			{ID: "filesystem"},
+			{ID: "github"},
+		},
+		ToolPolicy: "denylist", // no denied tools — all tools allowed if server passes
+	}
+
+	eval := NewPolicyEvaluator(cfg)
+
+	tests := []struct {
+		name     string
+		server   string
+		tool     string
+		expected bool
+		reason   string
+	}{
+		{"allowed server", "filesystem", "read_file", true, ""},
+		{"allowed server any tool", "github", "create_issue", true, ""},
+		{"blocked server", "unknown-server", "any_tool", false, "server not in allowlist"},
+		{"blocked server case insensitive", "FILESYSTEM", "read_file", true, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			decision := eval.Evaluate(tc.server, tc.tool, "")
+			if decision.Allowed != tc.expected {
+				t.Errorf("Evaluate(%q, %q) allowed=%v, want %v (reason: %s)",
+					tc.server, tc.tool, decision.Allowed, tc.expected, decision.Reason)
+			}
+			if tc.reason != "" && decision.Reason != tc.reason {
+				t.Errorf("Evaluate(%q, %q) reason=%q, want %q",
+					tc.server, tc.tool, decision.Reason, tc.reason)
+			}
+		})
+	}
+}
+
+func TestPolicyEvaluator_ServerDenylist(t *testing.T) {
+	cfg := config.SandboxMCPConfig{
+		EnforcePolicy: true,
+		ServerPolicy:  "denylist",
+		DeniedServers: []config.MCPServerRule{
+			{ID: "untrusted-server"},
+			{ID: "risky-server"},
+		},
+	}
+
+	eval := NewPolicyEvaluator(cfg)
+
+	tests := []struct {
+		name     string
+		server   string
+		tool     string
+		expected bool
+	}{
+		{"denied server", "untrusted-server", "any_tool", false},
+		{"denied server 2", "risky-server", "read_file", false},
+		{"allowed server", "filesystem", "read_file", true},
+		{"allowed server 2", "github", "create_issue", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			decision := eval.Evaluate(tc.server, tc.tool, "")
+			if decision.Allowed != tc.expected {
+				t.Errorf("Evaluate(%q, %q) allowed=%v, want %v (reason: %s)",
+					tc.server, tc.tool, decision.Allowed, tc.expected, decision.Reason)
+			}
+		})
+	}
+}
+
+func TestPolicyEvaluator_ServerPolicyBeforeToolPolicy(t *testing.T) {
+	// Server is denied, but tool would be allowed — server should win
+	cfg := config.SandboxMCPConfig{
+		EnforcePolicy: true,
+		ServerPolicy:  "denylist",
+		DeniedServers: []config.MCPServerRule{
+			{ID: "blocked-server"},
+		},
+		ToolPolicy: "allowlist",
+		AllowedTools: []config.MCPToolRule{
+			{Server: "*", Tool: "*"}, // allow all tools
+		},
+	}
+
+	eval := NewPolicyEvaluator(cfg)
+
+	decision := eval.Evaluate("blocked-server", "read_file", "")
+	if decision.Allowed {
+		t.Error("Expected blocked — server denylist should run before tool allowlist")
+	}
+	if decision.Reason != "server in denylist" {
+		t.Errorf("Expected reason 'server in denylist', got %q", decision.Reason)
+	}
+}
+
+func TestPolicyEvaluator_ServerAllowlistWithToolDenylist(t *testing.T) {
+	// Org approves certain servers, but denies specific dangerous tools
+	cfg := config.SandboxMCPConfig{
+		EnforcePolicy: true,
+		ServerPolicy:  "allowlist",
+		AllowedServers: []config.MCPServerRule{
+			{ID: "filesystem"},
+			{ID: "github"},
+		},
+		ToolPolicy: "denylist",
+		DeniedTools: []config.MCPToolRule{
+			{Server: "*", Tool: "execute_command"},
+		},
+	}
+
+	eval := NewPolicyEvaluator(cfg)
+
+	tests := []struct {
+		name     string
+		server   string
+		tool     string
+		expected bool
+	}{
+		{"approved server, safe tool", "filesystem", "read_file", true},
+		{"approved server, dangerous tool", "filesystem", "execute_command", false},
+		{"unapproved server", "unknown", "read_file", false},
+		{"unapproved server, any tool", "rogue-mcp", "safe_tool", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			decision := eval.Evaluate(tc.server, tc.tool, "")
+			if decision.Allowed != tc.expected {
+				t.Errorf("Evaluate(%q, %q) allowed=%v, want %v (reason: %s)",
+					tc.server, tc.tool, decision.Allowed, tc.expected, decision.Reason)
+			}
+		})
+	}
+}
+
+func TestPolicyEvaluator_ServerWildcardDeny(t *testing.T) {
+	// Deny all servers (lockdown mode), allow specific ones
+	cfg := config.SandboxMCPConfig{
+		EnforcePolicy: true,
+		ServerPolicy:  "allowlist",
+		AllowedServers: []config.MCPServerRule{
+			{ID: "filesystem"},
+		},
+	}
+
+	eval := NewPolicyEvaluator(cfg)
+
+	// Only filesystem should be allowed
+	d1 := eval.Evaluate("filesystem", "read_file", "")
+	if !d1.Allowed {
+		t.Error("Expected filesystem to be allowed")
+	}
+
+	d2 := eval.Evaluate("anything-else", "any_tool", "")
+	if d2.Allowed {
+		t.Error("Expected non-filesystem server to be blocked")
+	}
+}
+
+func TestPolicyEvaluator_NoServerPolicySkipsToToolPolicy(t *testing.T) {
+	// No server_policy set — should fall through to tool policy
+	cfg := config.SandboxMCPConfig{
+		EnforcePolicy: true,
+		// ServerPolicy not set (empty string)
+		ToolPolicy: "allowlist",
+		AllowedTools: []config.MCPToolRule{
+			{Server: "filesystem", Tool: "read_file"},
+		},
+	}
+
+	eval := NewPolicyEvaluator(cfg)
+
+	d1 := eval.Evaluate("filesystem", "read_file", "")
+	if !d1.Allowed {
+		t.Error("Expected allowed — no server policy, tool matches allowlist")
+	}
+
+	d2 := eval.Evaluate("filesystem", "write_file", "")
+	if d2.Allowed {
+		t.Error("Expected blocked — tool not in allowlist")
+	}
+}

--- a/internal/mcpinspect/protocol.go
+++ b/internal/mcpinspect/protocol.go
@@ -31,6 +31,26 @@ func ParseToolsListResponse(data []byte) (*ToolsListResponse, error) {
 	return &resp, nil
 }
 
+// ToolsCallRequest is the JSON-RPC request for tools/call.
+type ToolsCallRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      any    `json:"id"`
+	Method  string `json:"method"` // "tools/call"
+	Params  struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	} `json:"params"`
+}
+
+// ParseToolsCallRequest parses a tools/call request from raw JSON.
+func ParseToolsCallRequest(data []byte) (*ToolsCallRequest, error) {
+	var req ToolsCallRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, fmt.Errorf("parse tools/call request: %w", err)
+	}
+	return &req, nil
+}
+
 // MessageType identifies the type of MCP message.
 type MessageType int
 

--- a/internal/mcpinspect/protocol.go
+++ b/internal/mcpinspect/protocol.go
@@ -15,8 +15,8 @@ type ToolDefinition struct {
 
 // ToolsListResponse is the JSON-RPC response to tools/list.
 type ToolsListResponse struct {
-	JSONRPC string `json:"jsonrpc"`
-	ID      any    `json:"id"`
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
 	Result  struct {
 		Tools []ToolDefinition `json:"tools"`
 	} `json:"result"`
@@ -33,9 +33,9 @@ func ParseToolsListResponse(data []byte) (*ToolsListResponse, error) {
 
 // ToolsCallRequest is the JSON-RPC request for tools/call.
 type ToolsCallRequest struct {
-	JSONRPC string `json:"jsonrpc"`
-	ID      any    `json:"id"`
-	Method  string `json:"method"` // "tools/call"
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"` // "tools/call"
 	Params  struct {
 		Name      string          `json:"name"`
 		Arguments json.RawMessage `json:"arguments"`

--- a/internal/mcpinspect/tools_call_test.go
+++ b/internal/mcpinspect/tools_call_test.go
@@ -1,0 +1,328 @@
+package mcpinspect
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseToolsCallRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantName  string
+		wantArgs  string
+		wantID    any
+		wantErr   bool
+	}{
+		{
+			name: "valid tools/call with numeric ID",
+			input: `{
+				"jsonrpc": "2.0",
+				"id": 42,
+				"method": "tools/call",
+				"params": {
+					"name": "get_weather",
+					"arguments": {"city": "London"}
+				}
+			}`,
+			wantName: "get_weather",
+			wantArgs: `{"city": "London"}`,
+			wantID:   float64(42),
+		},
+		{
+			name: "valid tools/call with string ID",
+			input: `{
+				"jsonrpc": "2.0",
+				"id": "req-123",
+				"method": "tools/call",
+				"params": {
+					"name": "read_file",
+					"arguments": {"path": "/tmp/test.txt"}
+				}
+			}`,
+			wantName: "read_file",
+			wantArgs: `{"path": "/tmp/test.txt"}`,
+			wantID:   "req-123",
+		},
+		{
+			name: "tools/call with no arguments",
+			input: `{
+				"jsonrpc": "2.0",
+				"id": 1,
+				"method": "tools/call",
+				"params": {
+					"name": "list_files"
+				}
+			}`,
+			wantName: "list_files",
+			wantArgs: "",
+			wantID:   float64(1),
+		},
+		{
+			name: "tools/call with complex arguments",
+			input: `{
+				"jsonrpc": "2.0",
+				"id": 7,
+				"method": "tools/call",
+				"params": {
+					"name": "execute_query",
+					"arguments": {
+						"query": "SELECT * FROM users",
+						"params": [1, 2, 3],
+						"options": {"timeout": 30}
+					}
+				}
+			}`,
+			wantName: "execute_query",
+			wantArgs: `{"query": "SELECT * FROM users", "params": [1, 2, 3], "options": {"timeout": 30}}`,
+			wantID:   float64(7),
+		},
+		{
+			name:    "invalid JSON",
+			input:   `{invalid}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := ParseToolsCallRequest([]byte(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if req.Params.Name != tt.wantName {
+				t.Errorf("tool name = %q, want %q", req.Params.Name, tt.wantName)
+			}
+
+			if req.ID != tt.wantID {
+				t.Errorf("ID = %v (%T), want %v (%T)", req.ID, req.ID, tt.wantID, tt.wantID)
+			}
+
+			if tt.wantArgs == "" {
+				if len(req.Params.Arguments) > 0 {
+					t.Errorf("expected nil/empty arguments, got %s", req.Params.Arguments)
+				}
+			} else {
+				// Compare as normalized JSON.
+				var wantParsed, gotParsed any
+				if err := json.Unmarshal([]byte(tt.wantArgs), &wantParsed); err != nil {
+					t.Fatalf("bad test wantArgs: %v", err)
+				}
+				if err := json.Unmarshal(req.Params.Arguments, &gotParsed); err != nil {
+					t.Fatalf("failed to parse got arguments: %v", err)
+				}
+				wantBytes, _ := json.Marshal(wantParsed)
+				gotBytes, _ := json.Marshal(gotParsed)
+				if string(wantBytes) != string(gotBytes) {
+					t.Errorf("arguments = %s, want %s", gotBytes, wantBytes)
+				}
+			}
+		})
+	}
+}
+
+func TestDetectMessageType_ToolsCall(t *testing.T) {
+	data := []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "tools/call",
+		"params": {
+			"name": "get_weather",
+			"arguments": {"city": "London"}
+		}
+	}`)
+
+	msgType, err := DetectMessageType(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msgType != MessageToolsCall {
+		t.Errorf("message type = %v, want %v", msgType, MessageToolsCall)
+	}
+}
+
+func TestInspector_HandleToolsCall_EmitsEvent(t *testing.T) {
+	var emitted []interface{}
+	emitter := func(event interface{}) {
+		emitted = append(emitted, event)
+	}
+
+	inspector := NewInspector("session-1", "server-1", emitter)
+
+	data := []byte(`{
+		"jsonrpc": "2.0",
+		"id": 42,
+		"method": "tools/call",
+		"params": {
+			"name": "get_weather",
+			"arguments": {"city": "London"}
+		}
+	}`)
+
+	err := inspector.Inspect(data, DirectionRequest)
+	if err != nil {
+		t.Fatalf("Inspect returned error: %v", err)
+	}
+
+	if len(emitted) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(emitted))
+	}
+
+	event, ok := emitted[0].(MCPToolCalledEvent)
+	if !ok {
+		t.Fatalf("expected MCPToolCalledEvent, got %T", emitted[0])
+	}
+
+	if event.Type != "mcp_tool_called" {
+		t.Errorf("event.Type = %q, want %q", event.Type, "mcp_tool_called")
+	}
+	if event.SessionID != "session-1" {
+		t.Errorf("event.SessionID = %q, want %q", event.SessionID, "session-1")
+	}
+	if event.ServerID != "server-1" {
+		t.Errorf("event.ServerID = %q, want %q", event.ServerID, "server-1")
+	}
+	if event.ToolName != "get_weather" {
+		t.Errorf("event.ToolName = %q, want %q", event.ToolName, "get_weather")
+	}
+
+	// Check JSONRPC ID
+	var id float64
+	if err := json.Unmarshal(event.JSONRPCID, &id); err != nil {
+		t.Fatalf("failed to unmarshal JSONRPCID: %v", err)
+	}
+	if id != 42 {
+		t.Errorf("event.JSONRPCID = %v, want 42", id)
+	}
+
+	// Check Input
+	var input map[string]interface{}
+	if err := json.Unmarshal(event.Input, &input); err != nil {
+		t.Fatalf("failed to unmarshal Input: %v", err)
+	}
+	if input["city"] != "London" {
+		t.Errorf("event.Input city = %v, want London", input["city"])
+	}
+
+	if event.Timestamp.IsZero() {
+		t.Error("event.Timestamp is zero")
+	}
+}
+
+func TestInspector_HandleToolsCall_NoArgsEmitsEvent(t *testing.T) {
+	var emitted []interface{}
+	emitter := func(event interface{}) {
+		emitted = append(emitted, event)
+	}
+
+	inspector := NewInspector("session-2", "server-2", emitter)
+
+	data := []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "tools/call",
+		"params": {
+			"name": "list_tools"
+		}
+	}`)
+
+	err := inspector.Inspect(data, DirectionRequest)
+	if err != nil {
+		t.Fatalf("Inspect returned error: %v", err)
+	}
+
+	if len(emitted) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(emitted))
+	}
+
+	event, ok := emitted[0].(MCPToolCalledEvent)
+	if !ok {
+		t.Fatalf("expected MCPToolCalledEvent, got %T", emitted[0])
+	}
+
+	if event.ToolName != "list_tools" {
+		t.Errorf("event.ToolName = %q, want %q", event.ToolName, "list_tools")
+	}
+
+	// Input should be nil/empty when no arguments provided
+	if len(event.Input) > 0 {
+		t.Errorf("expected nil/empty Input, got %s", event.Input)
+	}
+}
+
+func TestInspector_HandleToolsCall_StringID(t *testing.T) {
+	var emitted []interface{}
+	emitter := func(event interface{}) {
+		emitted = append(emitted, event)
+	}
+
+	inspector := NewInspector("session-3", "server-3", emitter)
+
+	data := []byte(`{
+		"jsonrpc": "2.0",
+		"id": "req-abc",
+		"method": "tools/call",
+		"params": {
+			"name": "read_file",
+			"arguments": {"path": "/etc/hosts"}
+		}
+	}`)
+
+	err := inspector.Inspect(data, DirectionRequest)
+	if err != nil {
+		t.Fatalf("Inspect returned error: %v", err)
+	}
+
+	if len(emitted) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(emitted))
+	}
+
+	event := emitted[0].(MCPToolCalledEvent)
+
+	// String ID should be marshaled as a JSON string
+	var id string
+	if err := json.Unmarshal(event.JSONRPCID, &id); err != nil {
+		t.Fatalf("failed to unmarshal JSONRPCID as string: %v", err)
+	}
+	if id != "req-abc" {
+		t.Errorf("event.JSONRPCID = %q, want %q", id, "req-abc")
+	}
+}
+
+func TestMCPToolCalledEvent_JSON(t *testing.T) {
+	event := MCPToolCalledEvent{
+		Type:      "mcp_tool_called",
+		SessionID: "sess-1",
+		ServerID:  "srv-1",
+		ToolName:  "test_tool",
+		JSONRPCID: json.RawMessage(`42`),
+		Input:     json.RawMessage(`{"key":"value"}`),
+	}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		t.Fatalf("failed to marshal event: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal event JSON: %v", err)
+	}
+
+	if decoded["type"] != "mcp_tool_called" {
+		t.Errorf("type = %v, want mcp_tool_called", decoded["type"])
+	}
+	if decoded["tool_name"] != "test_tool" {
+		t.Errorf("tool_name = %v, want test_tool", decoded["tool_name"])
+	}
+	if decoded["jsonrpc_id"] != float64(42) {
+		t.Errorf("jsonrpc_id = %v, want 42", decoded["jsonrpc_id"])
+	}
+}

--- a/internal/mcpregistry/registry.go
+++ b/internal/mcpregistry/registry.go
@@ -1,0 +1,139 @@
+// Package mcpregistry provides an in-memory registry that maps MCP tool names
+// to their server metadata. It is the central data structure shared by the LLM
+// proxy, shim, and network monitor for tool call interception.
+//
+// The registry is safe for concurrent use. Lookups use a read lock for minimal
+// contention on the hot path (every LLM response).
+package mcpregistry
+
+import (
+	"sync"
+	"time"
+)
+
+// ToolEntry describes a single MCP tool and the server that provides it.
+type ToolEntry struct {
+	ToolName     string
+	ServerID     string
+	ServerType   string // "stdio" | "http" | "sse"
+	ServerAddr   string // "" for stdio, "host:port" for network
+	ToolHash     string
+	RegisteredAt time.Time
+}
+
+// ToolInfo carries the minimal information needed to register a tool.
+// The server identity fields (serverID, serverType, serverAddr) are provided
+// separately in the Register call.
+type ToolInfo struct {
+	Name string
+	Hash string
+}
+
+// Registry maps tool names to their MCP server metadata.
+type Registry struct {
+	mu    sync.RWMutex
+	tools map[string]*ToolEntry // keyed by tool name
+	addrs map[string]string     // server addr -> server ID (for network monitor)
+}
+
+// NewRegistry creates an empty, ready-to-use registry.
+func NewRegistry() *Registry {
+	return &Registry{
+		tools: make(map[string]*ToolEntry),
+		addrs: make(map[string]string),
+	}
+}
+
+// Register bulk-registers tools from a server. If a tool name already exists
+// in the registry (from a different server), the new entry overwrites it
+// (last-write-wins). If tools is empty, this is a no-op.
+//
+// For network servers (non-empty serverAddr), the address is also recorded in
+// the address map so the network monitor can look it up.
+func (r *Registry) Register(serverID, serverType, serverAddr string, tools []ToolInfo) {
+	if len(tools) == 0 {
+		return
+	}
+
+	now := time.Now()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, t := range tools {
+		r.tools[t.Name] = &ToolEntry{
+			ToolName:     t.Name,
+			ServerID:     serverID,
+			ServerType:   serverType,
+			ServerAddr:   serverAddr,
+			ToolHash:     t.Hash,
+			RegisteredAt: now,
+		}
+	}
+
+	// Record network server addresses for the network monitor.
+	if serverAddr != "" {
+		r.addrs[serverAddr] = serverID
+	}
+}
+
+// Lookup returns the registry entry for a tool name, or nil if not found.
+// This is the hot-path call used by the LLM proxy on every tool_use block.
+func (r *Registry) Lookup(toolName string) *ToolEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.tools[toolName]
+}
+
+// LookupBatch returns entries for multiple tool names at once. Only found
+// entries are included in the returned map; missing tools are omitted.
+// Used when an LLM response contains parallel tool calls.
+func (r *Registry) LookupBatch(toolNames []string) map[string]*ToolEntry {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make(map[string]*ToolEntry, len(toolNames))
+	for _, name := range toolNames {
+		if entry, ok := r.tools[name]; ok {
+			result[name] = entry
+		}
+	}
+	return result
+}
+
+// ServerAddrs returns a copy of all known network MCP server addresses.
+// The returned map is addr -> serverID. Stdio servers (which have empty
+// addresses) are never included. Used by the network monitor to build its
+// watch list.
+func (r *Registry) ServerAddrs() map[string]string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make(map[string]string, len(r.addrs))
+	for addr, id := range r.addrs {
+		result[addr] = id
+	}
+	return result
+}
+
+// Remove deletes all tools that were registered by the given server and
+// removes the server's address from the address map. Used for cleanup when
+// a server disconnects or is removed from the session.
+func (r *Registry) Remove(serverID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Remove tools belonging to this server.
+	for name, entry := range r.tools {
+		if entry.ServerID == serverID {
+			delete(r.tools, name)
+		}
+	}
+
+	// Remove address entries for this server.
+	for addr, id := range r.addrs {
+		if id == serverID {
+			delete(r.addrs, addr)
+		}
+	}
+}

--- a/internal/mcpregistry/registry_test.go
+++ b/internal/mcpregistry/registry_test.go
@@ -1,0 +1,482 @@
+package mcpregistry
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestNewRegistry(t *testing.T) {
+	r := NewRegistry()
+	if r == nil {
+		t.Fatal("NewRegistry returned nil")
+	}
+	if r.tools == nil {
+		t.Fatal("tools map not initialized")
+	}
+	if r.addrs == nil {
+		t.Fatal("addrs map not initialized")
+	}
+}
+
+func TestRegisterAndLookup(t *testing.T) {
+	r := NewRegistry()
+
+	tools := []ToolInfo{
+		{Name: "get_weather", Hash: "abc123"},
+		{Name: "list_files", Hash: "def456"},
+	}
+	r.Register("server-1", "stdio", "", tools)
+
+	entry := r.Lookup("get_weather")
+	if entry == nil {
+		t.Fatal("Lookup returned nil for registered tool")
+	}
+	if entry.ToolName != "get_weather" {
+		t.Errorf("ToolName = %q, want %q", entry.ToolName, "get_weather")
+	}
+	if entry.ServerID != "server-1" {
+		t.Errorf("ServerID = %q, want %q", entry.ServerID, "server-1")
+	}
+	if entry.ServerType != "stdio" {
+		t.Errorf("ServerType = %q, want %q", entry.ServerType, "stdio")
+	}
+	if entry.ServerAddr != "" {
+		t.Errorf("ServerAddr = %q, want empty string", entry.ServerAddr)
+	}
+	if entry.ToolHash != "abc123" {
+		t.Errorf("ToolHash = %q, want %q", entry.ToolHash, "abc123")
+	}
+	if entry.RegisteredAt.IsZero() {
+		t.Error("RegisteredAt is zero")
+	}
+
+	entry2 := r.Lookup("list_files")
+	if entry2 == nil {
+		t.Fatal("Lookup returned nil for second registered tool")
+	}
+	if entry2.ToolHash != "def456" {
+		t.Errorf("ToolHash = %q, want %q", entry2.ToolHash, "def456")
+	}
+}
+
+func TestLookupUnknownTool(t *testing.T) {
+	r := NewRegistry()
+
+	r.Register("server-1", "stdio", "", []ToolInfo{
+		{Name: "known_tool", Hash: "h1"},
+	})
+
+	entry := r.Lookup("unknown_tool")
+	if entry != nil {
+		t.Errorf("Lookup for unknown tool returned %+v, want nil", entry)
+	}
+}
+
+func TestLookupEmptyRegistry(t *testing.T) {
+	r := NewRegistry()
+
+	entry := r.Lookup("anything")
+	if entry != nil {
+		t.Errorf("Lookup on empty registry returned %+v, want nil", entry)
+	}
+}
+
+func TestRegisterEmptyTools(t *testing.T) {
+	r := NewRegistry()
+
+	// Should be a no-op; no panic, no entries.
+	r.Register("server-1", "stdio", "", nil)
+	r.Register("server-2", "http", "host:8080", []ToolInfo{})
+
+	if len(r.tools) != 0 {
+		t.Errorf("tools map has %d entries, want 0", len(r.tools))
+	}
+	if len(r.addrs) != 0 {
+		t.Errorf("addrs map has %d entries, want 0", len(r.addrs))
+	}
+}
+
+func TestDuplicateToolNameLastWriteWins(t *testing.T) {
+	r := NewRegistry()
+
+	// First server registers "get_weather".
+	r.Register("server-1", "stdio", "", []ToolInfo{
+		{Name: "get_weather", Hash: "hash-v1"},
+	})
+
+	// Second server also registers "get_weather" — should overwrite.
+	r.Register("server-2", "http", "weather.example.com:443", []ToolInfo{
+		{Name: "get_weather", Hash: "hash-v2"},
+	})
+
+	entry := r.Lookup("get_weather")
+	if entry == nil {
+		t.Fatal("Lookup returned nil")
+	}
+	if entry.ServerID != "server-2" {
+		t.Errorf("ServerID = %q, want %q (last-write-wins)", entry.ServerID, "server-2")
+	}
+	if entry.ToolHash != "hash-v2" {
+		t.Errorf("ToolHash = %q, want %q", entry.ToolHash, "hash-v2")
+	}
+	if entry.ServerType != "http" {
+		t.Errorf("ServerType = %q, want %q", entry.ServerType, "http")
+	}
+	if entry.ServerAddr != "weather.example.com:443" {
+		t.Errorf("ServerAddr = %q, want %q", entry.ServerAddr, "weather.example.com:443")
+	}
+}
+
+func TestLookupBatch(t *testing.T) {
+	r := NewRegistry()
+
+	r.Register("server-1", "stdio", "", []ToolInfo{
+		{Name: "tool_a", Hash: "ha"},
+		{Name: "tool_b", Hash: "hb"},
+	})
+	r.Register("server-2", "http", "host:80", []ToolInfo{
+		{Name: "tool_c", Hash: "hc"},
+	})
+
+	result := r.LookupBatch([]string{"tool_a", "tool_c", "tool_missing"})
+
+	if len(result) != 2 {
+		t.Fatalf("LookupBatch returned %d entries, want 2", len(result))
+	}
+	if result["tool_a"] == nil {
+		t.Error("tool_a missing from batch result")
+	}
+	if result["tool_c"] == nil {
+		t.Error("tool_c missing from batch result")
+	}
+	if _, ok := result["tool_missing"]; ok {
+		t.Error("tool_missing should not be in batch result")
+	}
+}
+
+func TestLookupBatchEmpty(t *testing.T) {
+	r := NewRegistry()
+	r.Register("s1", "stdio", "", []ToolInfo{{Name: "t1", Hash: "h1"}})
+
+	result := r.LookupBatch(nil)
+	if len(result) != 0 {
+		t.Errorf("LookupBatch(nil) returned %d entries, want 0", len(result))
+	}
+
+	result = r.LookupBatch([]string{})
+	if len(result) != 0 {
+		t.Errorf("LookupBatch([]) returned %d entries, want 0", len(result))
+	}
+}
+
+func TestServerAddrsOnlyNetwork(t *testing.T) {
+	r := NewRegistry()
+
+	// Stdio server: empty addr should NOT appear in ServerAddrs.
+	r.Register("stdio-server", "stdio", "", []ToolInfo{
+		{Name: "stdio_tool", Hash: "h1"},
+	})
+
+	// Network server: non-empty addr should appear.
+	r.Register("http-server", "http", "mcp.example.com:443", []ToolInfo{
+		{Name: "http_tool", Hash: "h2"},
+	})
+
+	// SSE server: also network, should appear.
+	r.Register("sse-server", "sse", "sse.example.com:8080", []ToolInfo{
+		{Name: "sse_tool", Hash: "h3"},
+	})
+
+	addrs := r.ServerAddrs()
+	if len(addrs) != 2 {
+		t.Fatalf("ServerAddrs returned %d entries, want 2", len(addrs))
+	}
+	if addrs["mcp.example.com:443"] != "http-server" {
+		t.Errorf("addrs[mcp.example.com:443] = %q, want %q", addrs["mcp.example.com:443"], "http-server")
+	}
+	if addrs["sse.example.com:8080"] != "sse-server" {
+		t.Errorf("addrs[sse.example.com:8080] = %q, want %q", addrs["sse.example.com:8080"], "sse-server")
+	}
+}
+
+func TestServerAddrsReturnsCopy(t *testing.T) {
+	r := NewRegistry()
+
+	r.Register("s1", "http", "host:80", []ToolInfo{
+		{Name: "t1", Hash: "h1"},
+	})
+
+	addrs := r.ServerAddrs()
+	addrs["mutated"] = "bad" // mutate the returned map
+
+	// Original should be unaffected.
+	addrsAgain := r.ServerAddrs()
+	if _, ok := addrsAgain["mutated"]; ok {
+		t.Error("ServerAddrs did not return a copy; mutation leaked back")
+	}
+}
+
+func TestServerAddrsEmpty(t *testing.T) {
+	r := NewRegistry()
+
+	addrs := r.ServerAddrs()
+	if addrs == nil {
+		t.Fatal("ServerAddrs on empty registry returned nil, want empty map")
+	}
+	if len(addrs) != 0 {
+		t.Errorf("ServerAddrs returned %d entries, want 0", len(addrs))
+	}
+}
+
+func TestRemove(t *testing.T) {
+	r := NewRegistry()
+
+	r.Register("server-1", "stdio", "", []ToolInfo{
+		{Name: "tool_a", Hash: "ha"},
+		{Name: "tool_b", Hash: "hb"},
+	})
+	r.Register("server-2", "http", "host:443", []ToolInfo{
+		{Name: "tool_c", Hash: "hc"},
+	})
+
+	// Verify tools exist before removal.
+	if r.Lookup("tool_a") == nil {
+		t.Fatal("tool_a should exist before Remove")
+	}
+	if r.Lookup("tool_c") == nil {
+		t.Fatal("tool_c should exist before Remove")
+	}
+
+	// Remove server-1.
+	r.Remove("server-1")
+
+	if entry := r.Lookup("tool_a"); entry != nil {
+		t.Errorf("tool_a should be nil after removing server-1, got %+v", entry)
+	}
+	if entry := r.Lookup("tool_b"); entry != nil {
+		t.Errorf("tool_b should be nil after removing server-1, got %+v", entry)
+	}
+
+	// server-2's tool should still exist.
+	if entry := r.Lookup("tool_c"); entry == nil {
+		t.Error("tool_c should still exist after removing server-1")
+	}
+
+	// server-2's address should still be in the address map.
+	addrs := r.ServerAddrs()
+	if addrs["host:443"] != "server-2" {
+		t.Errorf("server-2 addr should still be present, got %v", addrs)
+	}
+}
+
+func TestRemoveNetworkServer(t *testing.T) {
+	r := NewRegistry()
+
+	r.Register("net-server", "http", "mcp.host:8080", []ToolInfo{
+		{Name: "net_tool", Hash: "h1"},
+	})
+
+	addrs := r.ServerAddrs()
+	if len(addrs) != 1 {
+		t.Fatalf("expected 1 addr before remove, got %d", len(addrs))
+	}
+
+	r.Remove("net-server")
+
+	if entry := r.Lookup("net_tool"); entry != nil {
+		t.Error("net_tool should be nil after removing net-server")
+	}
+	addrs = r.ServerAddrs()
+	if len(addrs) != 0 {
+		t.Errorf("expected 0 addrs after remove, got %d", len(addrs))
+	}
+}
+
+func TestRemoveNonexistentServer(t *testing.T) {
+	r := NewRegistry()
+
+	r.Register("server-1", "stdio", "", []ToolInfo{
+		{Name: "tool_a", Hash: "ha"},
+	})
+
+	// Removing a server that doesn't exist should be a no-op.
+	r.Remove("nonexistent")
+
+	if entry := r.Lookup("tool_a"); entry == nil {
+		t.Error("tool_a should still exist after removing nonexistent server")
+	}
+}
+
+func TestConcurrentAccess(t *testing.T) {
+	r := NewRegistry()
+
+	const (
+		numWriters = 10
+		numReaders = 20
+		numTools   = 50
+	)
+
+	var wg sync.WaitGroup
+
+	// Spawn writers: each registers tools under its own server.
+	for w := range numWriters {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			serverID := fmt.Sprintf("server-%d", w)
+			tools := make([]ToolInfo, numTools)
+			for i := range numTools {
+				tools[i] = ToolInfo{
+					Name: fmt.Sprintf("tool_%d_%d", w, i),
+					Hash: fmt.Sprintf("hash_%d_%d", w, i),
+				}
+			}
+			r.Register(serverID, "stdio", "", tools)
+		}()
+	}
+
+	// Spawn readers: each does Lookup and LookupBatch concurrently.
+	for range numReaders {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				r.Lookup("tool_0_0")
+				r.LookupBatch([]string{"tool_1_0", "tool_2_0", "nonexistent"})
+				r.ServerAddrs()
+			}
+		}()
+	}
+
+	// Also do concurrent removes.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 50 {
+			r.Remove("server-999") // nonexistent, but exercises the lock path
+		}
+	}()
+
+	wg.Wait()
+
+	// After all writers complete, verify each writer's tools are present.
+	for w := range numWriters {
+		for i := range numTools {
+			toolName := fmt.Sprintf("tool_%d_%d", w, i)
+			entry := r.Lookup(toolName)
+			if entry == nil {
+				t.Errorf("tool %q not found after concurrent writes", toolName)
+				return // avoid flooding
+			}
+		}
+	}
+}
+
+func TestConcurrentRegisterAndRemove(t *testing.T) {
+	r := NewRegistry()
+
+	var wg sync.WaitGroup
+
+	// Writer goroutine registers tools for server-1.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := range 100 {
+			r.Register("server-1", "http", "host:80", []ToolInfo{
+				{Name: fmt.Sprintf("tool_%d", i), Hash: "h"},
+			})
+		}
+	}()
+
+	// Remover goroutine removes server-1 concurrently.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 100 {
+			r.Remove("server-1")
+		}
+	}()
+
+	// Reader goroutine.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 200 {
+			r.Lookup("tool_50")
+			r.ServerAddrs()
+		}
+	}()
+
+	// Should not panic or deadlock.
+	wg.Wait()
+}
+
+func TestMultipleNetworkServersShareNoAddr(t *testing.T) {
+	r := NewRegistry()
+
+	// Two stdio servers: neither should add to addrs.
+	r.Register("stdio-1", "stdio", "", []ToolInfo{{Name: "t1", Hash: "h1"}})
+	r.Register("stdio-2", "stdio", "", []ToolInfo{{Name: "t2", Hash: "h2"}})
+
+	addrs := r.ServerAddrs()
+	if len(addrs) != 0 {
+		t.Errorf("expected 0 addrs for stdio-only servers, got %d", len(addrs))
+	}
+}
+
+func TestRegisterSameAddrDifferentServers(t *testing.T) {
+	r := NewRegistry()
+
+	// Two servers at the same address: last one wins in the addrs map.
+	r.Register("server-a", "http", "shared-host:443", []ToolInfo{{Name: "ta", Hash: "ha"}})
+	r.Register("server-b", "http", "shared-host:443", []ToolInfo{{Name: "tb", Hash: "hb"}})
+
+	addrs := r.ServerAddrs()
+	if addrs["shared-host:443"] != "server-b" {
+		t.Errorf("addr should map to server-b (last write), got %q", addrs["shared-host:443"])
+	}
+}
+
+func TestRegisterPreservesOtherServerTools(t *testing.T) {
+	r := NewRegistry()
+
+	r.Register("server-1", "stdio", "", []ToolInfo{
+		{Name: "exclusive_tool", Hash: "h1"},
+	})
+
+	// Registering tools for a different server should not affect server-1's tools.
+	r.Register("server-2", "http", "host:80", []ToolInfo{
+		{Name: "other_tool", Hash: "h2"},
+	})
+
+	entry := r.Lookup("exclusive_tool")
+	if entry == nil {
+		t.Fatal("exclusive_tool should still exist")
+	}
+	if entry.ServerID != "server-1" {
+		t.Errorf("exclusive_tool ServerID = %q, want %q", entry.ServerID, "server-1")
+	}
+}
+
+func TestRegisteredAtTimestamp(t *testing.T) {
+	r := NewRegistry()
+
+	r.Register("s1", "stdio", "", []ToolInfo{
+		{Name: "tool_1", Hash: "h1"},
+		{Name: "tool_2", Hash: "h2"},
+	})
+
+	e1 := r.Lookup("tool_1")
+	e2 := r.Lookup("tool_2")
+
+	if e1 == nil || e2 == nil {
+		t.Fatal("both tools should be found")
+	}
+
+	// Tools registered in the same Register call should share the same timestamp.
+	if !e1.RegisteredAt.Equal(e2.RegisteredAt) {
+		t.Errorf("tools in same batch have different timestamps: %v vs %v",
+			e1.RegisteredAt, e2.RegisteredAt)
+	}
+}


### PR DESCRIPTION
## Summary

- **Shim extension**: Intercept `tools/call` JSON-RPC requests on MCP server stdin, emit `mcp_tool_called` audit events
- **Config extensions**: Add MCP server declarations, server-level allow/deny policy, and proxy `mcp-only` passthrough mode
- **MCP Tool Registry**: In-memory concurrent registry mapping tool names to server metadata, used by LLM proxy and network monitor
- **LLM Proxy detection**: Extract tool calls from Anthropic (`tool_use`) and OpenAI (`tool_calls`) LLM responses, emit `mcp_tool_call_intercepted` events
- **Org-level MCP approval**: Server-level allowlist/denylist policy that runs before tool-level policy, enabling orgs to restrict which MCP servers are permitted
- **Security hardening**: Validate OpenAI arguments as JSON, return registry copies (not mutable pointers), glob pattern matching in policy rules, fail-closed on invalid config, `json.RawMessage` for JSON-RPC IDs to preserve precision, overwrite detection

## Test plan

- [ ] `go test ./internal/mcpinspect/` — policy evaluator (allowlist, denylist, glob, server-level, invalid config), inspector tools/call handling, JSON-RPC ID precision
- [ ] `go test ./internal/mcpregistry/` — register, lookup, batch, remove, concurrent access, copy semantics, overwrite detection, empty tools addr recording
- [ ] `go test ./internal/llmproxy/` — Anthropic/OpenAI tool call extraction, invalid JSON arguments skipped, parallel tools, mixed content blocks
- [ ] `go test ./internal/config/` — MCP server declarations, server rules, proxy mcp-only mode
- [ ] `go build ./...` and `GOOS=windows go build ./...` — cross-compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)