### PR TITLE
feat: MCP tool call interception in LLM proxy

### DIFF
--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -398,6 +398,7 @@ func (a *App) startLLMProxy(ctx context.Context, s *session.Session) {
 		a.cfg.Proxy,
 		a.cfg.DLP,
 		a.cfg.LLMStorage,
+		a.cfg.Sandbox.MCP,
 		storagePath,
 		slog.Default(),
 	)

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -615,7 +615,7 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 	}
 
 	// Start embedded LLM proxy if configured
-	if a.cfg.Proxy.Mode == "embedded" {
+	if a.cfg.Proxy.Mode == "embedded" || a.cfg.Proxy.IsMCPOnly() {
 		a.startLLMProxy(ctx, s)
 	}
 

--- a/internal/llmproxy/mcp_intercept.go
+++ b/internal/llmproxy/mcp_intercept.go
@@ -168,8 +168,10 @@ func interceptMCPToolCalls(
 		decision := policy.Evaluate(entry.ServerID, call.Name, entry.ToolHash)
 
 		action := "allow"
+		var reason string
 		if !decision.Allowed {
 			action = "block"
+			reason = decision.Reason
 			result.HasBlocked = true
 			blockedNames[call.Name] = true
 		}
@@ -187,8 +189,8 @@ func interceptMCPToolCalls(
 			ServerType: entry.ServerType,
 			ServerAddr: entry.ServerAddr,
 			ToolHash:   entry.ToolHash,
-			Action:     action,
-			Reason:     decision.Reason,
+			Action: action,
+			Reason: reason,
 		})
 	}
 

--- a/internal/llmproxy/mcp_intercept.go
+++ b/internal/llmproxy/mcp_intercept.go
@@ -1,6 +1,13 @@
 package llmproxy
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/mcpinspect"
+	"github.com/agentsh/agentsh/internal/mcpregistry"
+)
 
 // ToolCall represents a tool invocation extracted from an LLM response.
 type ToolCall struct {
@@ -118,4 +125,264 @@ func extractOpenAIToolCalls(body []byte) []ToolCall {
 		}
 	}
 	return calls
+}
+
+// InterceptResult holds the outcome of MCP tool call interception.
+type InterceptResult struct {
+	Events        []mcpinspect.MCPToolCallInterceptedEvent
+	HasBlocked    bool
+	RewrittenBody []byte // Non-nil only if tool calls were blocked
+}
+
+// interceptMCPToolCalls extracts tool calls from an LLM response body,
+// looks them up in the registry, evaluates policy, and returns events plus
+// an optional rewritten body for blocked tools.
+func interceptMCPToolCalls(
+	body []byte,
+	dialect Dialect,
+	registry *mcpregistry.Registry,
+	policy *mcpinspect.PolicyEvaluator,
+	requestID, sessionID string,
+) *InterceptResult {
+	result := &InterceptResult{}
+
+	if registry == nil || policy == nil {
+		return result
+	}
+
+	calls := ExtractToolCalls(body, dialect)
+	if len(calls) == 0 {
+		return result
+	}
+
+	now := time.Now()
+	blockedNames := make(map[string]bool) // tool names that were blocked
+
+	for _, call := range calls {
+		entry := registry.Lookup(call.Name)
+		if entry == nil {
+			// Not an MCP tool (not in registry) — skip, no event.
+			continue
+		}
+
+		decision := policy.Evaluate(entry.ServerID, call.Name, entry.ToolHash)
+
+		action := "allow"
+		if !decision.Allowed {
+			action = "block"
+			result.HasBlocked = true
+			blockedNames[call.Name] = true
+		}
+
+		result.Events = append(result.Events, mcpinspect.MCPToolCallInterceptedEvent{
+			Type:       "mcp_tool_call_intercepted",
+			Timestamp:  now,
+			SessionID:  sessionID,
+			RequestID:  requestID,
+			Dialect:    string(dialect),
+			ToolName:   call.Name,
+			ToolCallID: call.ID,
+			Input:      call.Input,
+			ServerID:   entry.ServerID,
+			ServerType: entry.ServerType,
+			ServerAddr: entry.ServerAddr,
+			ToolHash:   entry.ToolHash,
+			Action:     action,
+			Reason:     decision.Reason,
+		})
+	}
+
+	if result.HasBlocked {
+		switch dialect {
+		case DialectAnthropic:
+			result.RewrittenBody = rewriteAnthropicResponse(body, blockedNames)
+		case DialectOpenAI:
+			result.RewrittenBody = rewriteOpenAIResponse(body, blockedNames)
+		}
+	}
+
+	return result
+}
+
+// rewriteAnthropicResponse replaces blocked tool_use content blocks with text
+// blocks saying the tool was blocked. If ALL tool_use blocks are blocked, the
+// stop_reason is changed to "end_turn". If only some are blocked, stop_reason
+// remains "tool_use".
+func rewriteAnthropicResponse(body []byte, blockedNames map[string]bool) []byte {
+	// Parse preserving unknown fields.
+	var resp map[string]json.RawMessage
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil
+	}
+
+	// Parse content array.
+	var content []json.RawMessage
+	if err := json.Unmarshal(resp["content"], &content); err != nil {
+		return nil
+	}
+
+	var newContent []json.RawMessage
+	remainingToolUse := 0
+
+	for _, block := range content {
+		var info struct {
+			Type string `json:"type"`
+			Name string `json:"name"`
+		}
+		if err := json.Unmarshal(block, &info); err != nil {
+			// Keep blocks we can't parse.
+			newContent = append(newContent, block)
+			continue
+		}
+
+		if info.Type == "tool_use" && blockedNames[info.Name] {
+			// Replace with a text block.
+			replacement := map[string]string{
+				"type": "text",
+				"text": fmt.Sprintf("[agentsh] Tool '%s' blocked by policy", info.Name),
+			}
+			raw, err := json.Marshal(replacement)
+			if err != nil {
+				newContent = append(newContent, block)
+				continue
+			}
+			newContent = append(newContent, json.RawMessage(raw))
+		} else {
+			if info.Type == "tool_use" {
+				remainingToolUse++
+			}
+			newContent = append(newContent, block)
+		}
+	}
+
+	// Update content.
+	contentRaw, err := json.Marshal(newContent)
+	if err != nil {
+		return nil
+	}
+	resp["content"] = json.RawMessage(contentRaw)
+
+	// Update stop_reason: "end_turn" if all tool_use blocks were blocked.
+	if remainingToolUse == 0 {
+		resp["stop_reason"] = json.RawMessage(`"end_turn"`)
+	}
+
+	out, err := json.Marshal(resp)
+	if err != nil {
+		return nil
+	}
+	return out
+}
+
+// rewriteOpenAIResponse removes blocked tool calls from
+// choices[].message.tool_calls[]. If all tool calls are removed, sets
+// message.content to a blocked message string and changes finish_reason
+// to "stop".
+func rewriteOpenAIResponse(body []byte, blockedNames map[string]bool) []byte {
+	// Parse top-level preserving unknown fields.
+	var resp map[string]json.RawMessage
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil
+	}
+
+	// Parse choices.
+	var choices []json.RawMessage
+	if err := json.Unmarshal(resp["choices"], &choices); err != nil {
+		return nil
+	}
+
+	var newChoices []json.RawMessage
+	for _, choiceRaw := range choices {
+		var choice map[string]json.RawMessage
+		if err := json.Unmarshal(choiceRaw, &choice); err != nil {
+			newChoices = append(newChoices, choiceRaw)
+			continue
+		}
+
+		// Parse message.
+		var msg map[string]json.RawMessage
+		if err := json.Unmarshal(choice["message"], &msg); err != nil {
+			newChoices = append(newChoices, choiceRaw)
+			continue
+		}
+
+		// Parse tool_calls from message.
+		var toolCalls []json.RawMessage
+		if msg["tool_calls"] != nil {
+			if err := json.Unmarshal(msg["tool_calls"], &toolCalls); err != nil {
+				newChoices = append(newChoices, choiceRaw)
+				continue
+			}
+		}
+
+		// Filter out blocked tool calls.
+		var kept []json.RawMessage
+		var blockedMessages []string
+		for _, tcRaw := range toolCalls {
+			var tc struct {
+				Function struct {
+					Name string `json:"name"`
+				} `json:"function"`
+			}
+			if err := json.Unmarshal(tcRaw, &tc); err != nil {
+				kept = append(kept, tcRaw)
+				continue
+			}
+			if blockedNames[tc.Function.Name] {
+				blockedMessages = append(blockedMessages, fmt.Sprintf("[agentsh] Tool '%s' blocked by policy", tc.Function.Name))
+			} else {
+				kept = append(kept, tcRaw)
+			}
+		}
+
+		if len(kept) == 0 && len(blockedMessages) > 0 {
+			// All tool calls blocked: set content to blocked message and
+			// change finish_reason to "stop".
+			combinedMsg := blockedMessages[0]
+			if len(blockedMessages) > 1 {
+				combinedMsg = ""
+				for _, m := range blockedMessages {
+					if combinedMsg != "" {
+						combinedMsg += "\n"
+					}
+					combinedMsg += m
+				}
+			}
+			contentRaw, _ := json.Marshal(combinedMsg)
+			msg["content"] = json.RawMessage(contentRaw)
+			// Remove tool_calls.
+			delete(msg, "tool_calls")
+			choice["finish_reason"] = json.RawMessage(`"stop"`)
+		} else if len(kept) < len(toolCalls) {
+			// Partial block: keep remaining tool calls.
+			keptRaw, _ := json.Marshal(kept)
+			msg["tool_calls"] = json.RawMessage(keptRaw)
+		}
+		// else: no blocking needed, keep as is.
+
+		msgRaw, _ := json.Marshal(msg)
+		choice["message"] = json.RawMessage(msgRaw)
+
+		choiceResult, _ := json.Marshal(choice)
+		newChoices = append(newChoices, json.RawMessage(choiceResult))
+	}
+
+	choicesRaw, err := json.Marshal(newChoices)
+	if err != nil {
+		return nil
+	}
+	resp["choices"] = json.RawMessage(choicesRaw)
+
+	out, err := json.Marshal(resp)
+	if err != nil {
+		return nil
+	}
+	return out
+}
+
+// getRegistry returns the MCP tool registry in a thread-safe manner.
+func (p *Proxy) getRegistry() *mcpregistry.Registry {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.registry
 }

--- a/internal/llmproxy/mcp_intercept.go
+++ b/internal/llmproxy/mcp_intercept.go
@@ -113,14 +113,16 @@ func extractOpenAIToolCalls(body []byte) []ToolCall {
 			continue
 		}
 		for _, tc := range choice.Message.ToolCalls {
-			args := []byte(tc.Function.Arguments)
-			if !json.Valid(args) {
-				continue
+			var input json.RawMessage
+			if args := []byte(tc.Function.Arguments); json.Valid(args) {
+				input = args
 			}
+			// Always extract the tool call even with invalid args — policy
+			// evaluation is based on tool name, not arguments.
 			calls = append(calls, ToolCall{
 				ID:    tc.ID,
 				Name:  tc.Function.Name,
-				Input: json.RawMessage(args),
+				Input: input,
 			})
 		}
 	}

--- a/internal/llmproxy/mcp_intercept_test.go
+++ b/internal/llmproxy/mcp_intercept_test.go
@@ -2,7 +2,12 @@ package llmproxy
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/mcpinspect"
+	"github.com/agentsh/agentsh/internal/mcpregistry"
 )
 
 func TestExtractToolCalls_AnthropicSingleTool(t *testing.T) {
@@ -565,5 +570,619 @@ func TestExtractToolCalls_AnthropicComplexInput(t *testing.T) {
 	}
 	if headers["Content-Type"] != "application/json" {
 		t.Errorf("expected Content-Type header, got %v", headers["Content-Type"])
+	}
+}
+
+// --- interceptMCPToolCalls tests ---
+
+// newTestRegistry creates a registry with the given tools registered under serverID.
+func newTestRegistry(serverID, serverType string, tools []mcpregistry.ToolInfo) *mcpregistry.Registry {
+	reg := mcpregistry.NewRegistry()
+	reg.Register(serverID, serverType, "", tools)
+	return reg
+}
+
+// newBlockingPolicy creates a policy that blocks the specified tool via allowlist
+// (the tool won't match the allowlist, so it will be blocked).
+func newBlockingPolicy() *mcpinspect.PolicyEvaluator {
+	return mcpinspect.NewPolicyEvaluator(config.SandboxMCPConfig{
+		EnforcePolicy: true,
+		ToolPolicy:    "allowlist",
+		AllowedTools:  []config.MCPToolRule{}, // empty allowlist = block everything
+	})
+}
+
+// newAllowingPolicy creates a policy that allows everything.
+func newAllowingPolicy() *mcpinspect.PolicyEvaluator {
+	return mcpinspect.NewPolicyEvaluator(config.SandboxMCPConfig{
+		EnforcePolicy: true,
+		ToolPolicy:    "allowlist",
+		AllowedTools: []config.MCPToolRule{
+			{Server: "*", Tool: "*"},
+		},
+	})
+}
+
+func TestInterceptMCPToolCalls_NilRegistryReturnsEmpty(t *testing.T) {
+	body := []byte(`{
+		"stop_reason": "tool_use",
+		"content": [
+			{"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"location": "NYC"}}
+		]
+	}`)
+
+	result := interceptMCPToolCalls(body, DialectAnthropic, nil, newAllowingPolicy(), "req_1", "sess_1")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.Events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(result.Events))
+	}
+	if result.HasBlocked {
+		t.Error("expected HasBlocked to be false")
+	}
+	if result.RewrittenBody != nil {
+		t.Error("expected RewrittenBody to be nil")
+	}
+}
+
+func TestInterceptMCPToolCalls_NilPolicyReturnsEmpty(t *testing.T) {
+	reg := newTestRegistry("my-server", "stdio", []mcpregistry.ToolInfo{
+		{Name: "get_weather", Hash: "abc123"},
+	})
+
+	body := []byte(`{
+		"stop_reason": "tool_use",
+		"content": [
+			{"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"location": "NYC"}}
+		]
+	}`)
+
+	result := interceptMCPToolCalls(body, DialectAnthropic, reg, nil, "req_1", "sess_1")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.Events) != 0 {
+		t.Errorf("expected 0 events, got %d", len(result.Events))
+	}
+	if result.HasBlocked {
+		t.Error("expected HasBlocked to be false")
+	}
+	if result.RewrittenBody != nil {
+		t.Error("expected RewrittenBody to be nil")
+	}
+}
+
+func TestInterceptMCPToolCalls_UnknownToolSkipped(t *testing.T) {
+	// Registry has no tools registered, so get_weather is unknown.
+	reg := mcpregistry.NewRegistry()
+	policy := newAllowingPolicy()
+
+	body := []byte(`{
+		"stop_reason": "tool_use",
+		"content": [
+			{"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"location": "NYC"}}
+		]
+	}`)
+
+	result := interceptMCPToolCalls(body, DialectAnthropic, reg, policy, "req_1", "sess_1")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	// Unknown tools (not in registry) should not emit events.
+	if len(result.Events) != 0 {
+		t.Errorf("expected 0 events for unknown tool, got %d", len(result.Events))
+	}
+	if result.HasBlocked {
+		t.Error("expected HasBlocked to be false")
+	}
+	if result.RewrittenBody != nil {
+		t.Error("expected RewrittenBody to be nil")
+	}
+}
+
+func TestInterceptMCPToolCalls_AllowedToolPassesThrough(t *testing.T) {
+	reg := newTestRegistry("my-server", "stdio", []mcpregistry.ToolInfo{
+		{Name: "get_weather", Hash: "abc123"},
+	})
+	policy := newAllowingPolicy()
+
+	body := []byte(`{
+		"stop_reason": "tool_use",
+		"content": [
+			{"type": "text", "text": "Let me check the weather."},
+			{"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"location": "NYC"}}
+		]
+	}`)
+
+	result := interceptMCPToolCalls(body, DialectAnthropic, reg, policy, "req_1", "sess_1")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(result.Events))
+	}
+
+	evt := result.Events[0]
+	if evt.Type != "mcp_tool_call_intercepted" {
+		t.Errorf("expected event type %q, got %q", "mcp_tool_call_intercepted", evt.Type)
+	}
+	if evt.Action != "allow" {
+		t.Errorf("expected action %q, got %q", "allow", evt.Action)
+	}
+	if evt.ToolName != "get_weather" {
+		t.Errorf("expected tool name %q, got %q", "get_weather", evt.ToolName)
+	}
+	if evt.ToolCallID != "toolu_01" {
+		t.Errorf("expected tool call ID %q, got %q", "toolu_01", evt.ToolCallID)
+	}
+	if evt.ServerID != "my-server" {
+		t.Errorf("expected server ID %q, got %q", "my-server", evt.ServerID)
+	}
+	if evt.SessionID != "sess_1" {
+		t.Errorf("expected session ID %q, got %q", "sess_1", evt.SessionID)
+	}
+	if evt.RequestID != "req_1" {
+		t.Errorf("expected request ID %q, got %q", "req_1", evt.RequestID)
+	}
+	if evt.Dialect != "anthropic" {
+		t.Errorf("expected dialect %q, got %q", "anthropic", evt.Dialect)
+	}
+
+	if result.HasBlocked {
+		t.Error("expected HasBlocked to be false")
+	}
+	if result.RewrittenBody != nil {
+		t.Error("expected RewrittenBody to be nil for allowed tool")
+	}
+}
+
+func TestInterceptMCPToolCalls_BlockedToolRewritten(t *testing.T) {
+	reg := newTestRegistry("my-server", "stdio", []mcpregistry.ToolInfo{
+		{Name: "get_weather", Hash: "abc123"},
+	})
+	policy := newBlockingPolicy()
+
+	body := []byte(`{
+		"id": "msg_01XFDUDYJgAACzvnptvVoYEL",
+		"type": "message",
+		"role": "assistant",
+		"stop_reason": "tool_use",
+		"content": [
+			{"type": "text", "text": "Let me check the weather."},
+			{"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"location": "NYC"}}
+		]
+	}`)
+
+	result := interceptMCPToolCalls(body, DialectAnthropic, reg, policy, "req_1", "sess_1")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Should have 1 event with action=block
+	if len(result.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(result.Events))
+	}
+	evt := result.Events[0]
+	if evt.Action != "block" {
+		t.Errorf("expected action %q, got %q", "block", evt.Action)
+	}
+	if evt.ToolName != "get_weather" {
+		t.Errorf("expected tool name %q, got %q", "get_weather", evt.ToolName)
+	}
+
+	if !result.HasBlocked {
+		t.Error("expected HasBlocked to be true")
+	}
+	if result.RewrittenBody == nil {
+		t.Fatal("expected RewrittenBody to be non-nil")
+	}
+
+	// Parse the rewritten body and verify:
+	// 1. tool_use block replaced with text block
+	// 2. stop_reason changed to "end_turn" (all tool_use blocks blocked)
+	var rewritten map[string]json.RawMessage
+	if err := json.Unmarshal(result.RewrittenBody, &rewritten); err != nil {
+		t.Fatalf("failed to unmarshal rewritten body: %v", err)
+	}
+
+	// Check stop_reason
+	var stopReason string
+	if err := json.Unmarshal(rewritten["stop_reason"], &stopReason); err != nil {
+		t.Fatalf("failed to unmarshal stop_reason: %v", err)
+	}
+	if stopReason != "end_turn" {
+		t.Errorf("expected stop_reason %q, got %q", "end_turn", stopReason)
+	}
+
+	// Check content blocks
+	var content []map[string]json.RawMessage
+	if err := json.Unmarshal(rewritten["content"], &content); err != nil {
+		t.Fatalf("failed to unmarshal content: %v", err)
+	}
+
+	// Should have 2 blocks (original text + replacement text for blocked tool)
+	if len(content) != 2 {
+		t.Fatalf("expected 2 content blocks, got %d", len(content))
+	}
+
+	// First block should be original text
+	var firstType string
+	json.Unmarshal(content[0]["type"], &firstType)
+	if firstType != "text" {
+		t.Errorf("expected first block type %q, got %q", "text", firstType)
+	}
+
+	// Second block should be replacement text (not tool_use)
+	var secondType string
+	json.Unmarshal(content[1]["type"], &secondType)
+	if secondType != "text" {
+		t.Errorf("expected second block type %q, got %q (should be text, not tool_use)", "text", secondType)
+	}
+
+	var secondText string
+	json.Unmarshal(content[1]["text"], &secondText)
+	if !strings.Contains(secondText, "get_weather") {
+		t.Errorf("expected replacement text to mention tool name, got %q", secondText)
+	}
+	if !strings.Contains(secondText, "blocked") {
+		t.Errorf("expected replacement text to mention 'blocked', got %q", secondText)
+	}
+}
+
+func TestInterceptMCPToolCalls_FailClosedBlocksViaAllowlist(t *testing.T) {
+	// Tool IS in the registry but the allowlist has a specific hash that won't match.
+	// With fail_closed=true and an allowlist, tools not matching get blocked.
+	reg := newTestRegistry("my-server", "stdio", []mcpregistry.ToolInfo{
+		{Name: "get_weather", Hash: "abc123"},
+	})
+
+	policy := mcpinspect.NewPolicyEvaluator(config.SandboxMCPConfig{
+		EnforcePolicy: true,
+		FailClosed:    true,
+		ToolPolicy:    "allowlist",
+		AllowedTools: []config.MCPToolRule{
+			// Only allow a different tool on the same server
+			{Server: "my-server", Tool: "some_other_tool"},
+		},
+	})
+
+	body := []byte(`{
+		"stop_reason": "tool_use",
+		"content": [
+			{"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"location": "NYC"}}
+		]
+	}`)
+
+	result := interceptMCPToolCalls(body, DialectAnthropic, reg, policy, "req_1", "sess_1")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if len(result.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(result.Events))
+	}
+	if result.Events[0].Action != "block" {
+		t.Errorf("expected action %q, got %q", "block", result.Events[0].Action)
+	}
+	if !result.HasBlocked {
+		t.Error("expected HasBlocked to be true")
+	}
+	if result.RewrittenBody == nil {
+		t.Error("expected RewrittenBody to be non-nil")
+	}
+}
+
+func TestInterceptMCPToolCalls_PartialBlockAnthropic(t *testing.T) {
+	// Two tool calls: one allowed, one blocked.
+	// stop_reason should remain "tool_use" because some tool_use blocks remain.
+	reg := newTestRegistry("my-server", "stdio", []mcpregistry.ToolInfo{
+		{Name: "get_weather", Hash: "abc123"},
+		{Name: "read_file", Hash: "def456"},
+	})
+
+	policy := mcpinspect.NewPolicyEvaluator(config.SandboxMCPConfig{
+		EnforcePolicy: true,
+		ToolPolicy:    "allowlist",
+		AllowedTools: []config.MCPToolRule{
+			{Server: "my-server", Tool: "get_weather"}, // allow get_weather
+			// read_file not allowed -> blocked
+		},
+	})
+
+	body := []byte(`{
+		"id": "msg_123",
+		"type": "message",
+		"role": "assistant",
+		"stop_reason": "tool_use",
+		"content": [
+			{"type": "text", "text": "Let me do both."},
+			{"type": "tool_use", "id": "toolu_01", "name": "get_weather", "input": {"location": "NYC"}},
+			{"type": "tool_use", "id": "toolu_02", "name": "read_file", "input": {"path": "/etc/passwd"}}
+		]
+	}`)
+
+	result := interceptMCPToolCalls(body, DialectAnthropic, reg, policy, "req_1", "sess_1")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Should have 2 events
+	if len(result.Events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(result.Events))
+	}
+
+	// Verify actions
+	var allowCount, blockCount int
+	for _, evt := range result.Events {
+		switch evt.Action {
+		case "allow":
+			allowCount++
+		case "block":
+			blockCount++
+		}
+	}
+	if allowCount != 1 || blockCount != 1 {
+		t.Errorf("expected 1 allow and 1 block, got %d allow and %d block", allowCount, blockCount)
+	}
+
+	if !result.HasBlocked {
+		t.Error("expected HasBlocked to be true")
+	}
+	if result.RewrittenBody == nil {
+		t.Fatal("expected RewrittenBody to be non-nil")
+	}
+
+	// Parse rewritten body
+	var rewritten map[string]json.RawMessage
+	if err := json.Unmarshal(result.RewrittenBody, &rewritten); err != nil {
+		t.Fatalf("failed to unmarshal rewritten body: %v", err)
+	}
+
+	// stop_reason should remain "tool_use" because get_weather is still allowed
+	var stopReason string
+	if err := json.Unmarshal(rewritten["stop_reason"], &stopReason); err != nil {
+		t.Fatalf("failed to unmarshal stop_reason: %v", err)
+	}
+	if stopReason != "tool_use" {
+		t.Errorf("expected stop_reason %q for partial block, got %q", "tool_use", stopReason)
+	}
+
+	// Content should have 3 blocks: text, tool_use (allowed), text (blocked replacement)
+	var content []map[string]json.RawMessage
+	if err := json.Unmarshal(rewritten["content"], &content); err != nil {
+		t.Fatalf("failed to unmarshal content: %v", err)
+	}
+	if len(content) != 3 {
+		t.Fatalf("expected 3 content blocks, got %d", len(content))
+	}
+
+	// The first remaining tool_use should be get_weather
+	var secondType string
+	json.Unmarshal(content[1]["type"], &secondType)
+	if secondType != "tool_use" {
+		t.Errorf("expected second block to be tool_use, got %q", secondType)
+	}
+	var secondName string
+	json.Unmarshal(content[1]["name"], &secondName)
+	if secondName != "get_weather" {
+		t.Errorf("expected second block name %q, got %q", "get_weather", secondName)
+	}
+
+	// Third block should be text replacement for blocked read_file
+	var thirdType string
+	json.Unmarshal(content[2]["type"], &thirdType)
+	if thirdType != "text" {
+		t.Errorf("expected third block to be text (blocked replacement), got %q", thirdType)
+	}
+}
+
+func TestInterceptMCPToolCalls_OpenAIBlockedToolRewritten(t *testing.T) {
+	reg := newTestRegistry("my-server", "stdio", []mcpregistry.ToolInfo{
+		{Name: "get_weather", Hash: "abc123"},
+	})
+	policy := newBlockingPolicy()
+
+	body := []byte(`{
+		"id": "chatcmpl-abc123",
+		"object": "chat.completion",
+		"choices": [{
+			"index": 0,
+			"finish_reason": "tool_calls",
+			"message": {
+				"role": "assistant",
+				"content": null,
+				"tool_calls": [{
+					"id": "call_KlZ3abc123",
+					"type": "function",
+					"function": {
+						"name": "get_weather",
+						"arguments": "{\"location\": \"San Francisco, CA\"}"
+					}
+				}]
+			}
+		}]
+	}`)
+
+	result := interceptMCPToolCalls(body, DialectOpenAI, reg, policy, "req_1", "sess_1")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if len(result.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(result.Events))
+	}
+	if result.Events[0].Action != "block" {
+		t.Errorf("expected action %q, got %q", "block", result.Events[0].Action)
+	}
+	if !result.HasBlocked {
+		t.Error("expected HasBlocked to be true")
+	}
+	if result.RewrittenBody == nil {
+		t.Fatal("expected RewrittenBody to be non-nil")
+	}
+
+	// Parse rewritten body
+	var rewritten struct {
+		Choices []struct {
+			FinishReason string `json:"finish_reason"`
+			Message      struct {
+				Content   string          `json:"content"`
+				ToolCalls json.RawMessage `json:"tool_calls"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(result.RewrittenBody, &rewritten); err != nil {
+		t.Fatalf("failed to unmarshal rewritten body: %v", err)
+	}
+
+	if len(rewritten.Choices) != 1 {
+		t.Fatalf("expected 1 choice, got %d", len(rewritten.Choices))
+	}
+
+	choice := rewritten.Choices[0]
+	// All tool calls blocked -> finish_reason should be "stop"
+	if choice.FinishReason != "stop" {
+		t.Errorf("expected finish_reason %q, got %q", "stop", choice.FinishReason)
+	}
+	// Content should mention the blocked tool
+	if !strings.Contains(choice.Message.Content, "get_weather") {
+		t.Errorf("expected content to mention blocked tool, got %q", choice.Message.Content)
+	}
+	if !strings.Contains(choice.Message.Content, "blocked") {
+		t.Errorf("expected content to mention 'blocked', got %q", choice.Message.Content)
+	}
+	// tool_calls should be empty or null
+	if choice.Message.ToolCalls != nil && string(choice.Message.ToolCalls) != "[]" && string(choice.Message.ToolCalls) != "null" {
+		t.Errorf("expected tool_calls to be empty/null, got %s", string(choice.Message.ToolCalls))
+	}
+}
+
+func TestInterceptMCPToolCalls_OpenAIPartialBlock(t *testing.T) {
+	reg := newTestRegistry("my-server", "stdio", []mcpregistry.ToolInfo{
+		{Name: "get_weather", Hash: "abc123"},
+		{Name: "read_file", Hash: "def456"},
+	})
+
+	policy := mcpinspect.NewPolicyEvaluator(config.SandboxMCPConfig{
+		EnforcePolicy: true,
+		ToolPolicy:    "allowlist",
+		AllowedTools: []config.MCPToolRule{
+			{Server: "my-server", Tool: "get_weather"}, // allow get_weather only
+		},
+	})
+
+	body := []byte(`{
+		"id": "chatcmpl-abc123",
+		"object": "chat.completion",
+		"choices": [{
+			"index": 0,
+			"finish_reason": "tool_calls",
+			"message": {
+				"role": "assistant",
+				"content": null,
+				"tool_calls": [
+					{
+						"id": "call_AAA",
+						"type": "function",
+						"function": {
+							"name": "get_weather",
+							"arguments": "{\"location\": \"NYC\"}"
+						}
+					},
+					{
+						"id": "call_BBB",
+						"type": "function",
+						"function": {
+							"name": "read_file",
+							"arguments": "{\"path\": \"/etc/passwd\"}"
+						}
+					}
+				]
+			}
+		}]
+	}`)
+
+	result := interceptMCPToolCalls(body, DialectOpenAI, reg, policy, "req_1", "sess_1")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if len(result.Events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(result.Events))
+	}
+
+	if !result.HasBlocked {
+		t.Error("expected HasBlocked to be true")
+	}
+	if result.RewrittenBody == nil {
+		t.Fatal("expected RewrittenBody to be non-nil")
+	}
+
+	// Parse rewritten body
+	var rewritten struct {
+		Choices []struct {
+			FinishReason string `json:"finish_reason"`
+			Message      struct {
+				Content   *string `json:"content"`
+				ToolCalls []struct {
+					ID       string `json:"id"`
+					Function struct {
+						Name string `json:"name"`
+					} `json:"function"`
+				} `json:"tool_calls"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(result.RewrittenBody, &rewritten); err != nil {
+		t.Fatalf("failed to unmarshal rewritten body: %v", err)
+	}
+
+	choice := rewritten.Choices[0]
+	// Partial block -> finish_reason should remain "tool_calls"
+	if choice.FinishReason != "tool_calls" {
+		t.Errorf("expected finish_reason %q for partial block, got %q", "tool_calls", choice.FinishReason)
+	}
+
+	// Only the allowed tool call should remain
+	if len(choice.Message.ToolCalls) != 1 {
+		t.Fatalf("expected 1 remaining tool call, got %d", len(choice.Message.ToolCalls))
+	}
+	if choice.Message.ToolCalls[0].Function.Name != "get_weather" {
+		t.Errorf("expected remaining tool to be %q, got %q", "get_weather", choice.Message.ToolCalls[0].Function.Name)
+	}
+}
+
+func TestInterceptMCPToolCalls_MixedMCPAndNonMCP(t *testing.T) {
+	// One tool is in the registry (MCP), one is not (non-MCP).
+	// Only the MCP tool should generate an event.
+	reg := newTestRegistry("my-server", "stdio", []mcpregistry.ToolInfo{
+		{Name: "mcp_tool", Hash: "abc123"},
+		// "native_tool" is NOT registered
+	})
+	policy := newAllowingPolicy()
+
+	body := []byte(`{
+		"stop_reason": "tool_use",
+		"content": [
+			{"type": "tool_use", "id": "toolu_01", "name": "mcp_tool", "input": {"key": "value"}},
+			{"type": "tool_use", "id": "toolu_02", "name": "native_tool", "input": {"key": "value"}}
+		]
+	}`)
+
+	result := interceptMCPToolCalls(body, DialectAnthropic, reg, policy, "req_1", "sess_1")
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// Only 1 event (for the MCP tool), native_tool is skipped
+	if len(result.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(result.Events))
+	}
+	if result.Events[0].ToolName != "mcp_tool" {
+		t.Errorf("expected event for %q, got %q", "mcp_tool", result.Events[0].ToolName)
+	}
+	if result.HasBlocked {
+		t.Error("expected no blocking")
 	}
 }

--- a/internal/llmproxy/mcp_streaming.go
+++ b/internal/llmproxy/mcp_streaming.go
@@ -1,0 +1,120 @@
+package llmproxy
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// ExtractToolCallsFromSSE parses tool calls from a buffered SSE response body.
+// It dispatches to dialect-specific extractors based on the dialect parameter.
+// Returns nil if no tool calls are found.
+//
+// For SSE extraction, ToolCall.Input will be nil because we do not accumulate
+// streamed argument deltas -- we only need the tool name and ID for policy
+// evaluation.
+func ExtractToolCallsFromSSE(sseBody []byte, dialect Dialect) []ToolCall {
+	switch dialect {
+	case DialectAnthropic:
+		return extractAnthropicSSEToolCalls(sseBody)
+	case DialectOpenAI:
+		return extractOpenAISSEToolCalls(sseBody)
+	}
+	return nil
+}
+
+// extractAnthropicSSEToolCalls scans SSE data lines for content_block_start
+// events where content_block.type == "tool_use". It extracts content_block.id
+// and content_block.name from each such event.
+//
+// Example SSE data line:
+//
+//	data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01","name":"get_weather"}}
+func extractAnthropicSSEToolCalls(sseBody []byte) []ToolCall {
+	var calls []ToolCall
+
+	scanner := bufio.NewScanner(bytes.NewReader(sseBody))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := line[len("data: "):]
+
+		var evt struct {
+			Type         string `json:"type"`
+			ContentBlock struct {
+				Type string `json:"type"`
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			} `json:"content_block"`
+		}
+		if err := json.Unmarshal([]byte(data), &evt); err != nil {
+			continue
+		}
+		if evt.Type == "content_block_start" && evt.ContentBlock.Type == "tool_use" {
+			calls = append(calls, ToolCall{
+				ID:   evt.ContentBlock.ID,
+				Name: evt.ContentBlock.Name,
+			})
+		}
+	}
+
+	return calls
+}
+
+// extractOpenAISSEToolCalls scans SSE data lines for
+// choices[].delta.tool_calls[] entries that contain both an id and a
+// function.name (the first delta chunk for each tool call). It deduplicates
+// by tool call ID to avoid counting subsequent argument-streaming chunks.
+//
+// Example SSE data line:
+//
+//	data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_abc","type":"function","function":{"name":"get_weather","arguments":""}}]}}]}
+func extractOpenAISSEToolCalls(sseBody []byte) []ToolCall {
+	var calls []ToolCall
+	seen := make(map[string]bool)
+
+	scanner := bufio.NewScanner(bytes.NewReader(sseBody))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := line[len("data: "):]
+		if data == "[DONE]" {
+			continue
+		}
+
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					ToolCalls []struct {
+						ID       string `json:"id"`
+						Function struct {
+							Name string `json:"name"`
+						} `json:"function"`
+					} `json:"tool_calls"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(data), &chunk); err != nil {
+			continue
+		}
+
+		for _, choice := range chunk.Choices {
+			for _, tc := range choice.Delta.ToolCalls {
+				if tc.ID != "" && tc.Function.Name != "" && !seen[tc.ID] {
+					seen[tc.ID] = true
+					calls = append(calls, ToolCall{
+						ID:   tc.ID,
+						Name: tc.Function.Name,
+					})
+				}
+			}
+		}
+	}
+
+	return calls
+}

--- a/internal/llmproxy/mcp_streaming_test.go
+++ b/internal/llmproxy/mcp_streaming_test.go
@@ -1,0 +1,167 @@
+package llmproxy
+
+import (
+	"testing"
+)
+
+func TestExtractToolCallsFromSSE_Anthropic(t *testing.T) {
+	// Full Anthropic SSE stream with text + tool_use content blocks.
+	sseBody := []byte("event: message_start\n" +
+		`data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null}}` + "\n\n" +
+		"event: content_block_start\n" +
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Let me check the weather."}}` + "\n\n" +
+		"event: content_block_stop\n" +
+		`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+		"event: content_block_start\n" +
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01A09q90qw90lq917835lq9","name":"get_weather"}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"location\": \"San"}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":" Francisco\"}"}}` + "\n\n" +
+		"event: content_block_stop\n" +
+		`data: {"type":"content_block_stop","index":1}` + "\n\n" +
+		"event: message_delta\n" +
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}` + "\n\n" +
+		"event: message_stop\n" +
+		`data: {"type":"message_stop"}` + "\n\n")
+
+	calls := ExtractToolCallsFromSSE(sseBody, DialectAnthropic)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+
+	tc := calls[0]
+	if tc.ID != "toolu_01A09q90qw90lq917835lq9" {
+		t.Errorf("expected ID %q, got %q", "toolu_01A09q90qw90lq917835lq9", tc.ID)
+	}
+	if tc.Name != "get_weather" {
+		t.Errorf("expected Name %q, got %q", "get_weather", tc.Name)
+	}
+	if tc.Input != nil {
+		t.Errorf("expected Input to be nil, got %s", string(tc.Input))
+	}
+}
+
+func TestExtractToolCallsFromSSE_OpenAI(t *testing.T) {
+	// Full OpenAI SSE stream with tool call deltas.
+	sseBody := []byte("data: " + `{"id":"chatcmpl-abc123","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_abc123","type":"function","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}` + "\n\n" +
+		"data: " + `{"id":"chatcmpl-abc123","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"lo"}}]},"finish_reason":null}]}` + "\n\n" +
+		"data: " + `{"id":"chatcmpl-abc123","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"cation\": \"NYC\"}"}}]},"finish_reason":null}]}` + "\n\n" +
+		"data: " + `{"id":"chatcmpl-abc123","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n" +
+		"data: [DONE]\n\n")
+
+	calls := ExtractToolCallsFromSSE(sseBody, DialectOpenAI)
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+
+	tc := calls[0]
+	if tc.ID != "call_abc123" {
+		t.Errorf("expected ID %q, got %q", "call_abc123", tc.ID)
+	}
+	if tc.Name != "get_weather" {
+		t.Errorf("expected Name %q, got %q", "get_weather", tc.Name)
+	}
+	if tc.Input != nil {
+		t.Errorf("expected Input to be nil, got %s", string(tc.Input))
+	}
+}
+
+func TestExtractToolCallsFromSSE_NoToolCalls(t *testing.T) {
+	// Anthropic SSE stream with only text content.
+	sseBody := []byte("event: message_start\n" +
+		`data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null}}` + "\n\n" +
+		"event: content_block_start\n" +
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello! How can I help you today?"}}` + "\n\n" +
+		"event: content_block_stop\n" +
+		`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+		"event: message_delta\n" +
+		`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}` + "\n\n" +
+		"event: message_stop\n" +
+		`data: {"type":"message_stop"}` + "\n\n")
+
+	calls := ExtractToolCallsFromSSE(sseBody, DialectAnthropic)
+	if len(calls) != 0 {
+		t.Fatalf("expected 0 tool calls, got %d", len(calls))
+	}
+}
+
+func TestExtractToolCallsFromSSE_MultipleTools(t *testing.T) {
+	// Anthropic SSE stream with 2 tool_use content blocks.
+	sseBody := []byte("event: message_start\n" +
+		`data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null}}` + "\n\n" +
+		"event: content_block_start\n" +
+		`data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I'll check both."}}` + "\n\n" +
+		"event: content_block_stop\n" +
+		`data: {"type":"content_block_stop","index":0}` + "\n\n" +
+		"event: content_block_start\n" +
+		`data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01AAA","name":"get_weather"}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"location\": \"NYC\"}"}}` + "\n\n" +
+		"event: content_block_stop\n" +
+		`data: {"type":"content_block_stop","index":1}` + "\n\n" +
+		"event: content_block_start\n" +
+		`data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_01BBB","name":"get_time"}}` + "\n\n" +
+		"event: content_block_delta\n" +
+		`data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"timezone\": \"America/New_York\"}"}}` + "\n\n" +
+		"event: content_block_stop\n" +
+		`data: {"type":"content_block_stop","index":2}` + "\n\n" +
+		"event: message_delta\n" +
+		`data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}` + "\n\n" +
+		"event: message_stop\n" +
+		`data: {"type":"message_stop"}` + "\n\n")
+
+	calls := ExtractToolCallsFromSSE(sseBody, DialectAnthropic)
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 tool calls, got %d", len(calls))
+	}
+
+	if calls[0].ID != "toolu_01AAA" {
+		t.Errorf("first call: expected ID %q, got %q", "toolu_01AAA", calls[0].ID)
+	}
+	if calls[0].Name != "get_weather" {
+		t.Errorf("first call: expected Name %q, got %q", "get_weather", calls[0].Name)
+	}
+
+	if calls[1].ID != "toolu_01BBB" {
+		t.Errorf("second call: expected ID %q, got %q", "toolu_01BBB", calls[1].ID)
+	}
+	if calls[1].Name != "get_time" {
+		t.Errorf("second call: expected Name %q, got %q", "get_time", calls[1].Name)
+	}
+}
+
+func TestExtractToolCallsFromSSE_OpenAIMultipleTools(t *testing.T) {
+	// OpenAI SSE stream with 2 parallel tool calls.
+	// The first chunk for each tool call contains both id and function.name.
+	sseBody := []byte("data: " + `{"id":"chatcmpl-abc123","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_AAA","type":"function","function":{"name":"get_weather","arguments":""}},{"index":1,"id":"call_BBB","type":"function","function":{"name":"get_time","arguments":""}}]},"finish_reason":null}]}` + "\n\n" +
+		"data: " + `{"id":"chatcmpl-abc123","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"location\": \"NYC\"}"}}]},"finish_reason":null}]}` + "\n\n" +
+		"data: " + `{"id":"chatcmpl-abc123","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\"timezone\": \"EST\"}"}}]},"finish_reason":null}]}` + "\n\n" +
+		"data: " + `{"id":"chatcmpl-abc123","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n" +
+		"data: [DONE]\n\n")
+
+	calls := ExtractToolCallsFromSSE(sseBody, DialectOpenAI)
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 tool calls, got %d", len(calls))
+	}
+
+	if calls[0].ID != "call_AAA" {
+		t.Errorf("first call: expected ID %q, got %q", "call_AAA", calls[0].ID)
+	}
+	if calls[0].Name != "get_weather" {
+		t.Errorf("first call: expected Name %q, got %q", "get_weather", calls[0].Name)
+	}
+
+	if calls[1].ID != "call_BBB" {
+		t.Errorf("second call: expected ID %q, got %q", "call_BBB", calls[1].ID)
+	}
+	if calls[1].Name != "get_time" {
+		t.Errorf("second call: expected Name %q, got %q", "get_time", calls[1].Name)
+	}
+}

--- a/internal/llmproxy/proxy.go
+++ b/internal/llmproxy/proxy.go
@@ -50,8 +50,9 @@ type Proxy struct {
 	logger          *slog.Logger
 	isCustomOpenAI  bool
 	chatGPTUpstream *url.URL
-	registry        *mcpregistry.Registry
-	policy          *mcpinspect.PolicyEvaluator
+	registry *mcpregistry.Registry
+	// policy is immutable after construction — set once in New(), never changed.
+	policy *mcpinspect.PolicyEvaluator
 
 	server   *http.Server
 	listener net.Listener

--- a/internal/session/llmproxy.go
+++ b/internal/session/llmproxy.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/llmproxy"
+	"github.com/agentsh/agentsh/internal/mcpregistry"
 )
 
 // StartLLMProxy creates and starts an embedded LLM proxy for the session.
@@ -48,6 +49,13 @@ func StartLLMProxy(
 	proxy, err := llmproxy.New(cfg, storagePath, logger)
 	if err != nil {
 		return "", nil, fmt.Errorf("create llm proxy: %w", err)
+	}
+
+	// Create MCP registry and inject into proxy if MCP policy is configured
+	if mcpCfg.EnforcePolicy {
+		registry := mcpregistry.NewRegistry()
+		proxy.SetRegistry(registry)
+		sess.SetMCPRegistry(registry)
 	}
 
 	// Start the proxy

--- a/internal/session/llmproxy.go
+++ b/internal/session/llmproxy.go
@@ -21,11 +21,18 @@ func StartLLMProxy(
 	proxyCfg config.ProxyConfig,
 	dlpCfg config.DLPConfig,
 	storageCfg config.LLMStorageConfig,
+	mcpCfg config.SandboxMCPConfig,
 	storagePath string,
 	logger *slog.Logger,
 ) (string, func() error, error) {
 	if sess == nil {
 		return "", nil, fmt.Errorf("session is nil")
+	}
+
+	// In mcp-only mode, force DLP disabled and body storage on.
+	if proxyCfg.IsMCPOnly() {
+		dlpCfg.Mode = "disabled"
+		storageCfg.StoreBodies = true
 	}
 
 	// Build the proxy config
@@ -34,6 +41,7 @@ func StartLLMProxy(
 		Proxy:     proxyCfg,
 		DLP:       dlpCfg,
 		Storage:   storageCfg,
+		MCP:       mcpCfg,
 	}
 
 	// Create the proxy

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -55,6 +55,8 @@ type Session struct {
 	llmProxyClose func() error
 	llmProxy      interface{}   // *llmproxy.Proxy - stored as interface to avoid import cycle
 
+	mcpRegistry interface{} // *mcpregistry.Registry — stored as interface to avoid import cycle
+
 	netnsName  string
 	netnsClose func() error
 
@@ -353,6 +355,21 @@ func (s *Session) ProxyInstance() interface{} {
 	return s.llmProxy
 }
 
+// SetMCPRegistry stores the MCP tool registry instance in the session.
+// The registry is stored as interface{} to avoid an import cycle with mcpregistry.
+func (s *Session) SetMCPRegistry(r interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mcpRegistry = r
+}
+
+// MCPRegistry returns the MCP tool registry instance, if any.
+func (s *Session) MCPRegistry() interface{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mcpRegistry
+}
+
 func (s *Session) ProxyURL() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -393,6 +410,7 @@ func (s *Session) CloseLLMProxy() error {
 	s.llmProxyClose = nil
 	s.llmProxyURL = ""
 	s.llmProxy = nil
+	s.mcpRegistry = nil
 	s.mu.Unlock()
 	if fn != nil {
 		return fn()


### PR DESCRIPTION
## Summary

- **MCP tool call interception**: Extracts tool calls from LLM responses (Anthropic `tool_use` blocks, OpenAI `tool_calls`), looks them up in the MCP registry, and evaluates policy to allow or block
- **Response rewriting**: Blocked tool calls are replaced with text messages in non-SSE responses; partial blocks preserve remaining allowed calls
- **SSE streaming support**: Audit-only extraction from SSE streams (Anthropic `content_block_start`, OpenAI `delta.tool_calls`) — real-time stream termination is future work
- **Session wiring**: MCP config flows through session startup, registry created when policy enforcement enabled, `mcp-only` proxy mode supported
- 2,390 lines added across 11 files with comprehensive test coverage (~1,700 lines of tests)

## Test plan

- [x] `go test ./internal/llmproxy/ -v` — all MCP interception, streaming, rewriting, and proxy integration tests pass
- [x] `go test ./internal/session/ -v` — all session lifecycle, MCP config, and registry tests pass
- [x] `GOOS=windows go build ./...` — cross-compilation verified
- [x] Independent security review (Fresh Eyes) completed and findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)