### PR TITLE
feat(llmproxy): persist MCP tool call intercept events

### DIFF
--- a/internal/api/mcp_event.go
+++ b/internal/api/mcp_event.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"github.com/agentsh/agentsh/internal/mcpinspect"
+	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/google/uuid"
+)
+
+// mcpInterceptedToEvent converts an MCPToolCallInterceptedEvent from the LLM
+// proxy into a types.Event suitable for the event store and broker.
+func mcpInterceptedToEvent(ev mcpinspect.MCPToolCallInterceptedEvent) types.Event {
+	decision := types.DecisionAllow
+	if ev.Action == "block" {
+		decision = types.DecisionDeny
+	}
+
+	// Derive a rule identifier from the action. The proxy-level event doesn't
+	// carry the matched config.MCPToolRule, so we synthesise a short label.
+	rule := "mcp-" + ev.Action // "mcp-allow" or "mcp-block"
+
+	return types.Event{
+		ID:        uuid.NewString(),
+		Timestamp: ev.Timestamp,
+		Type:      "mcp_tool_call_intercepted",
+		SessionID: ev.SessionID,
+		Source:    "llm_proxy",
+		Path:      ev.ToolName,
+		Domain:    ev.ServerID,
+		EffectiveAction: ev.Action,
+		Policy: &types.PolicyInfo{
+			Decision:          decision,
+			EffectiveDecision: decision,
+			Rule:              rule,
+			Message:           ev.Reason,
+		},
+		Fields: map[string]any{
+			"request_id":  ev.RequestID,
+			"dialect":     ev.Dialect,
+			"tool_name":   ev.ToolName,
+			"tool_call_id": ev.ToolCallID,
+			"server_id":   ev.ServerID,
+			"server_type": ev.ServerType,
+			"server_addr": ev.ServerAddr,
+			"tool_hash":   ev.ToolHash,
+			"action":      ev.Action,
+			"reason":      ev.Reason,
+		},
+	}
+}

--- a/internal/api/mcp_event_test.go
+++ b/internal/api/mcp_event_test.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/mcpinspect"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+func TestMCPInterceptedToEvent_Allow(t *testing.T) {
+	ts := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	ev := mcpinspect.MCPToolCallInterceptedEvent{
+		Type:       "mcp_tool_call_intercepted",
+		Timestamp:  ts,
+		SessionID:  "sess-1",
+		RequestID:  "req_abc123",
+		Dialect:    "anthropic",
+		ToolName:   "get_weather",
+		ToolCallID: "toolu_01",
+		Input:      json.RawMessage(`{"city":"NYC"}`),
+		ServerID:   "weather-server",
+		ServerType: "stdio",
+		ServerAddr: "",
+		ToolHash:   "sha256:deadbeef",
+		Action:     "allow",
+		Reason:     "",
+	}
+
+	out := mcpInterceptedToEvent(ev)
+
+	if out.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if out.Timestamp != ts {
+		t.Errorf("timestamp: got %v, want %v", out.Timestamp, ts)
+	}
+	if out.Type != "mcp_tool_call_intercepted" {
+		t.Errorf("type: got %q, want %q", out.Type, "mcp_tool_call_intercepted")
+	}
+	if out.SessionID != "sess-1" {
+		t.Errorf("session_id: got %q, want %q", out.SessionID, "sess-1")
+	}
+	if out.Source != "llm_proxy" {
+		t.Errorf("source: got %q, want %q", out.Source, "llm_proxy")
+	}
+	if out.Path != "get_weather" {
+		t.Errorf("path: got %q, want %q", out.Path, "get_weather")
+	}
+	if out.Domain != "weather-server" {
+		t.Errorf("domain: got %q, want %q", out.Domain, "weather-server")
+	}
+	if out.EffectiveAction != "allow" {
+		t.Errorf("effective_action: got %q, want %q", out.EffectiveAction, "allow")
+	}
+	if out.Policy == nil {
+		t.Fatal("expected non-nil Policy")
+	}
+	if out.Policy.Decision != types.DecisionAllow {
+		t.Errorf("policy.decision: got %q, want %q", out.Policy.Decision, types.DecisionAllow)
+	}
+	if out.Policy.EffectiveDecision != types.DecisionAllow {
+		t.Errorf("policy.effective_decision: got %q, want %q", out.Policy.EffectiveDecision, types.DecisionAllow)
+	}
+	if out.Policy.Rule != "mcp-allow" {
+		t.Errorf("policy.rule: got %q, want %q", out.Policy.Rule, "mcp-allow")
+	}
+
+	// Verify Fields contains expected keys
+	expectedKeys := []string{"request_id", "dialect", "tool_name", "tool_call_id", "server_id", "server_type", "server_addr", "tool_hash", "action", "reason"}
+	for _, k := range expectedKeys {
+		if _, ok := out.Fields[k]; !ok {
+			t.Errorf("fields missing key %q", k)
+		}
+	}
+
+	// Verify Input is NOT in Fields (plan explicitly excludes it)
+	if _, ok := out.Fields["input"]; ok {
+		t.Error("fields should not contain 'input'")
+	}
+}
+
+func TestMCPInterceptedToEvent_Block(t *testing.T) {
+	ts := time.Date(2025, 6, 15, 12, 0, 0, 0, time.UTC)
+	ev := mcpinspect.MCPToolCallInterceptedEvent{
+		Type:       "mcp_tool_call_intercepted",
+		Timestamp:  ts,
+		SessionID:  "sess-2",
+		RequestID:  "req_xyz789",
+		Dialect:    "openai",
+		ToolName:   "delete_all",
+		ToolCallID: "call_01",
+		Input:      json.RawMessage(`{}`),
+		ServerID:   "danger-server",
+		ServerType: "http",
+		ServerAddr: "localhost:8080",
+		ToolHash:   "sha256:cafebabe",
+		Action:     "block",
+		Reason:     "tool not in allowlist",
+	}
+
+	out := mcpInterceptedToEvent(ev)
+
+	if out.EffectiveAction != "block" {
+		t.Errorf("effective_action: got %q, want %q", out.EffectiveAction, "block")
+	}
+	if out.Policy == nil {
+		t.Fatal("expected non-nil Policy")
+	}
+	if out.Policy.Decision != types.DecisionDeny {
+		t.Errorf("policy.decision: got %q, want %q", out.Policy.Decision, types.DecisionDeny)
+	}
+	if out.Policy.Rule != "mcp-block" {
+		t.Errorf("policy.rule: got %q, want %q", out.Policy.Rule, "mcp-block")
+	}
+	if out.Policy.Message != "tool not in allowlist" {
+		t.Errorf("policy.message: got %q, want %q", out.Policy.Message, "tool not in allowlist")
+	}
+
+	if out.Fields["server_addr"] != "localhost:8080" {
+		t.Errorf("fields.server_addr: got %v, want %q", out.Fields["server_addr"], "localhost:8080")
+	}
+	if out.Fields["dialect"] != "openai" {
+		t.Errorf("fields.dialect: got %v, want %q", out.Fields["dialect"], "openai")
+	}
+}


### PR DESCRIPTION
## Summary

- Wire a callback from the LLM proxy to the event store and broker so `MCPToolCallInterceptedEvent` instances are persisted to SQLite and published to the live SSE event stream
- Previously these events were only logged via `slog.Info()` — now they can be queried via the events API, displayed in the UI, and exported via webhook/OTEL
- Follow the existing `SetRegistry` callback injection pattern to keep the proxy decoupled from `pkg/types` and `internal/store`

## Changes

| File | Change |
|------|--------|
| `internal/llmproxy/proxy.go` | Add `onInterceptEvent` field, `SetEventCallback`/`getEventCallback`, invoke callback in both SSE and non-SSE paths |
| `internal/api/mcp_event.go` | New: `mcpInterceptedToEvent` conversion function |
| `internal/api/mcp_event_test.go` | New: unit tests for allow/block conversion paths |
| `internal/api/app.go` | Wire callback in `startLLMProxy` with 5s timeout and error logging |
| `internal/llmproxy/proxy_test.go` | New: `TestProxyEventCallback` (non-SSE) and `TestProxyEventCallback_SSE` integration tests |

## Test plan

- [x] `go test ./internal/llmproxy/ -race` — proxy callback tests pass (non-SSE + SSE)
- [x] `go test ./internal/api/ -race` — conversion tests pass
- [x] `go build ./...` — builds clean
- [x] `GOOS=windows go build ./...` — cross-compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)