### PR TITLE
feat(netmonitor): MCP connection tagging

### DIFF
--- a/internal/netmonitor/transparent_tcp.go
+++ b/internal/netmonitor/transparent_tcp.go
@@ -115,6 +115,8 @@ func (t *TransparentTCP) handle(conn net.Conn) error {
 		return nil
 	}
 
+	emitMCPConnectionIfMatched(context.Background(), t.sess, t.emit, t.sessionID, commandID, domain, remote, dstPort)
+
 	up, err := net.DialTimeout("tcp", remote, 20*time.Second)
 	if err != nil {
 		return nil


### PR DESCRIPTION
## Summary

- Emit `mcp_network_connection` events when the network monitor detects outbound connections to registered MCP server addresses
- Checks the session's MCP registry (`ServerAddrs()`) on each connection via a lazy pull through a small `mcpAddrSource` interface
- Matches by `domain:port` (primary) with `IP:port` fallback, covering both explicit proxy and transparent TCP paths

## Design

Shared package-level `emitMCPConnectionIfMatched()` function used by both `Proxy` and `TransparentTCP` handlers. Lazy pull from session avoids startup ordering issues — connections before registry creation simply skip MCP tagging.

## Files changed

| File | Change |
|------|--------|
| `internal/netmonitor/proxy.go` | `mcpAddrSource` interface, shared `emitMCPConnectionIfMatched` function, wired into `handleConnect` and `handleHTTP` |
| `internal/netmonitor/transparent_tcp.go` | Call shared function in `handle()` after deny check |
| `internal/netmonitor/proxy_test.go` | 6 unit tests: domain match, IP:port match, no-match skip, nil session, no registry, nil emitter |

## Test plan

- [x] `go test ./internal/netmonitor/ -v -run TestMCP` — all 6 MCP tests pass
- [x] `go test ./internal/netmonitor/` — full suite (44 tests) passes, no regressions
- [x] `go build ./...` — builds clean
- [x] `GOOS=windows go build ./...` — cross-compile passes
- [x] Code review (code-reviewer agent) — all findings addressed
- [x] Independent security review (fresheyes/Codex) — all findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)