### PR TITLE
feat: complete MCP remaining features

### DIFF
--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -175,6 +175,10 @@ func (a *App) Router() http.Handler {
 
 		// Policy test endpoint (for debugging)
 		r.Post("/policy/test", a.policyTest)
+
+		// MCP query endpoints
+		r.Get("/mcp/tools", a.listMCPTools)
+		r.Get("/mcp/servers", a.listMCPServers)
 	})
 
 	return r

--- a/internal/api/mcp_query.go
+++ b/internal/api/mcp_query.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/agentsh/agentsh/internal/store/sqlite"
+)
+
+// listMCPTools returns MCP tools, optionally filtered by server and/or detections.
+func (a *App) listMCPTools(w http.ResponseWriter, r *http.Request) {
+	filter := sqlite.MCPToolFilter{
+		ServerID:      r.URL.Query().Get("server"),
+		HasDetections: r.URL.Query().Get("detections") == "true",
+	}
+	tools, err := a.store.ListMCPTools(r.Context(), filter)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		return
+	}
+	if tools == nil {
+		tools = []sqlite.MCPTool{}
+	}
+	writeJSON(w, http.StatusOK, tools)
+}
+
+// listMCPServers returns MCP server summaries aggregated from tool data.
+func (a *App) listMCPServers(w http.ResponseWriter, r *http.Request) {
+	servers, err := a.store.ListMCPServers(r.Context())
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		return
+	}
+	if servers == nil {
+		servers = []sqlite.MCPServerSummary{}
+	}
+	writeJSON(w, http.StatusOK, servers)
+}

--- a/internal/api/mcp_query.go
+++ b/internal/api/mcp_query.go
@@ -1,20 +1,24 @@
 package api
 
 import (
+	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/agentsh/agentsh/internal/store/sqlite"
 )
 
 // listMCPTools returns MCP tools, optionally filtered by server and/or detections.
 func (a *App) listMCPTools(w http.ResponseWriter, r *http.Request) {
+	hasDetections, _ := strconv.ParseBool(r.URL.Query().Get("detections"))
 	filter := sqlite.MCPToolFilter{
 		ServerID:      r.URL.Query().Get("server"),
-		HasDetections: r.URL.Query().Get("detections") == "true",
+		HasDetections: hasDetections,
 	}
 	tools, err := a.store.ListMCPTools(r.Context(), filter)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		slog.Error("list MCP tools", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal server error"})
 		return
 	}
 	if tools == nil {
@@ -27,7 +31,8 @@ func (a *App) listMCPTools(w http.ResponseWriter, r *http.Request) {
 func (a *App) listMCPServers(w http.ResponseWriter, r *http.Request) {
 	servers, err := a.store.ListMCPServers(r.Context())
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": err.Error()})
+		slog.Error("list MCP servers", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]any{"error": "internal server error"})
 		return
 	}
 	if servers == nil {

--- a/internal/api/mcp_query_test.go
+++ b/internal/api/mcp_query_test.go
@@ -1,0 +1,360 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/events"
+	"github.com/agentsh/agentsh/internal/metrics"
+	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/store/composite"
+	"github.com/agentsh/agentsh/internal/store/sqlite"
+)
+
+func newMCPTestApp(t *testing.T, st *sqlite.Store) http.Handler {
+	t.Helper()
+	store := composite.New(st, st)
+	sessions := session.NewManager(10)
+	cfg := &config.Config{}
+	cfg.Development.DisableAuth = true
+	cfg.Metrics.Enabled = false
+	cfg.Health.Path = "/health"
+	cfg.Health.ReadinessPath = "/ready"
+	app := NewApp(cfg, sessions, store, nil, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	return app.Router()
+}
+
+func seedMCPTools(t *testing.T, st *sqlite.Store) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	tools := []sqlite.MCPTool{
+		{
+			ServerID:       "weather-server",
+			ToolName:       "get_weather",
+			ToolHash:       "sha256:aaa",
+			Description:    "Get weather for a city",
+			FirstSeen:      now.Add(-1 * time.Hour),
+			LastSeen:       now,
+			DetectionCount: 0,
+			MaxSeverity:    "",
+		},
+		{
+			ServerID:       "weather-server",
+			ToolName:       "get_forecast",
+			ToolHash:       "sha256:bbb",
+			Description:    "Get 5-day forecast",
+			FirstSeen:      now.Add(-30 * time.Minute),
+			LastSeen:       now,
+			DetectionCount: 2,
+			MaxSeverity:    "high",
+		},
+		{
+			ServerID:       "db-server",
+			ToolName:       "query_db",
+			ToolHash:       "sha256:ccc",
+			Description:    "Run a database query",
+			FirstSeen:      now.Add(-2 * time.Hour),
+			LastSeen:       now.Add(-10 * time.Minute),
+			DetectionCount: 0,
+			MaxSeverity:    "",
+		},
+		{
+			ServerID:       "db-server",
+			ToolName:       "delete_records",
+			ToolHash:       "sha256:ddd",
+			Description:    "Delete records from table",
+			FirstSeen:      now.Add(-2 * time.Hour),
+			LastSeen:       now,
+			DetectionCount: 5,
+			MaxSeverity:    "critical",
+		},
+	}
+
+	for _, tool := range tools {
+		if err := st.UpsertMCPTool(ctx, tool); err != nil {
+			t.Fatalf("seed MCP tool %s/%s: %v", tool.ServerID, tool.ToolName, err)
+		}
+	}
+}
+
+func TestMCPListTools_Empty(t *testing.T) {
+	st := newSQLiteStore(t)
+	h := newMCPTestApp(t, st)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mcp/tools", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var tools []sqlite.MCPTool
+	if err := json.NewDecoder(rr.Body).Decode(&tools); err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 0 {
+		t.Errorf("expected 0 tools, got %d", len(tools))
+	}
+}
+
+func TestMCPListTools_All(t *testing.T) {
+	st := newSQLiteStore(t)
+	seedMCPTools(t, st)
+	h := newMCPTestApp(t, st)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mcp/tools", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Read body once and use for both checks
+	raw := rr.Body.Bytes()
+
+	var tools []sqlite.MCPTool
+	if err := json.Unmarshal(raw, &tools); err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 4 {
+		t.Fatalf("expected 4 tools, got %d", len(tools))
+	}
+
+	// Verify JSON tags work: check that at least one tool has expected fields
+	var rawList []map[string]any
+	if err := json.Unmarshal(raw, &rawList); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := rawList[0]["server_id"]; !ok {
+		t.Error("expected JSON key 'server_id' (json tag), not found")
+	}
+	if _, ok := rawList[0]["tool_name"]; !ok {
+		t.Error("expected JSON key 'tool_name' (json tag), not found")
+	}
+}
+
+func TestMCPListTools_FilterByServer(t *testing.T) {
+	st := newSQLiteStore(t)
+	seedMCPTools(t, st)
+	h := newMCPTestApp(t, st)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mcp/tools?server=weather-server", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var tools []sqlite.MCPTool
+	if err := json.NewDecoder(rr.Body).Decode(&tools); err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools for weather-server, got %d", len(tools))
+	}
+	for _, tool := range tools {
+		if tool.ServerID != "weather-server" {
+			t.Errorf("expected server_id=weather-server, got %q", tool.ServerID)
+		}
+	}
+}
+
+func TestMCPListTools_FilterByDetections(t *testing.T) {
+	st := newSQLiteStore(t)
+	seedMCPTools(t, st)
+	h := newMCPTestApp(t, st)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mcp/tools?detections=true", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var tools []sqlite.MCPTool
+	if err := json.NewDecoder(rr.Body).Decode(&tools); err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools with detections, got %d", len(tools))
+	}
+	for _, tool := range tools {
+		if tool.DetectionCount == 0 {
+			t.Errorf("expected detection_count > 0 for tool %s/%s", tool.ServerID, tool.ToolName)
+		}
+	}
+}
+
+func TestMCPListTools_FilterByServerAndDetections(t *testing.T) {
+	st := newSQLiteStore(t)
+	seedMCPTools(t, st)
+	h := newMCPTestApp(t, st)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mcp/tools?server=weather-server&detections=true", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var tools []sqlite.MCPTool
+	if err := json.NewDecoder(rr.Body).Decode(&tools); err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool for weather-server with detections, got %d", len(tools))
+	}
+	if tools[0].ToolName != "get_forecast" {
+		t.Errorf("expected get_forecast, got %q", tools[0].ToolName)
+	}
+}
+
+func TestMCPListTools_NonexistentServer(t *testing.T) {
+	st := newSQLiteStore(t)
+	seedMCPTools(t, st)
+	h := newMCPTestApp(t, st)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mcp/tools?server=no-such-server", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var tools []sqlite.MCPTool
+	if err := json.NewDecoder(rr.Body).Decode(&tools); err != nil {
+		t.Fatal(err)
+	}
+	if len(tools) != 0 {
+		t.Errorf("expected 0 tools for nonexistent server, got %d", len(tools))
+	}
+}
+
+func TestMCPListServers_Empty(t *testing.T) {
+	st := newSQLiteStore(t)
+	h := newMCPTestApp(t, st)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mcp/servers", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var servers []sqlite.MCPServerSummary
+	if err := json.NewDecoder(rr.Body).Decode(&servers); err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 0 {
+		t.Errorf("expected 0 servers, got %d", len(servers))
+	}
+}
+
+func TestMCPListServers_WithData(t *testing.T) {
+	st := newSQLiteStore(t)
+	seedMCPTools(t, st)
+	h := newMCPTestApp(t, st)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mcp/servers", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Read body once and use for both checks
+	raw := rr.Body.Bytes()
+
+	var servers []sqlite.MCPServerSummary
+	if err := json.Unmarshal(raw, &servers); err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 2 {
+		t.Fatalf("expected 2 servers, got %d", len(servers))
+	}
+
+	// Verify JSON tags work
+	var rawList []map[string]any
+	if err := json.Unmarshal(raw, &rawList); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := rawList[0]["server_id"]; !ok {
+		t.Error("expected JSON key 'server_id' (json tag), not found")
+	}
+	if _, ok := rawList[0]["tool_count"]; !ok {
+		t.Error("expected JSON key 'tool_count' (json tag), not found")
+	}
+
+	// Build map for easier lookup
+	serverByID := make(map[string]sqlite.MCPServerSummary)
+	for _, s := range servers {
+		serverByID[s.ServerID] = s
+	}
+
+	// Check db-server
+	dbSrv, ok := serverByID["db-server"]
+	if !ok {
+		t.Fatal("expected db-server in results")
+	}
+	if dbSrv.ToolCount != 2 {
+		t.Errorf("db-server: expected 2 tools, got %d", dbSrv.ToolCount)
+	}
+	if dbSrv.DetectionCount != 5 {
+		t.Errorf("db-server: expected 5 detections, got %d", dbSrv.DetectionCount)
+	}
+
+	// Check weather-server
+	wSrv, ok := serverByID["weather-server"]
+	if !ok {
+		t.Fatal("expected weather-server in results")
+	}
+	if wSrv.ToolCount != 2 {
+		t.Errorf("weather-server: expected 2 tools, got %d", wSrv.ToolCount)
+	}
+	if wSrv.DetectionCount != 2 {
+		t.Errorf("weather-server: expected 2 detections, got %d", wSrv.DetectionCount)
+	}
+}
+
+func TestMCPListTools_ContentType(t *testing.T) {
+	st := newSQLiteStore(t)
+	h := newMCPTestApp(t, st)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mcp/tools", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	ct := rr.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("expected Content-Type=application/json, got %s", ct)
+	}
+}
+
+func TestMCPListServers_ContentType(t *testing.T) {
+	st := newSQLiteStore(t)
+	h := newMCPTestApp(t, st)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/mcp/servers", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	ct := rr.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("expected Content-Type=application/json, got %s", ct)
+	}
+}

--- a/internal/cli/mcp_cmd.go
+++ b/internal/cli/mcp_cmd.go
@@ -3,7 +3,9 @@ package cli
 
 import (
 	"fmt"
+	"net/url"
 
+	"github.com/agentsh/agentsh/internal/client"
 	"github.com/agentsh/agentsh/internal/store/sqlite"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/spf13/cobra"
@@ -45,48 +47,91 @@ func newMCPToolsCmd() *cobra.Command {
 		Use:   "tools",
 		Short: "List registered MCP tools",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !directDB {
-				return fmt.Errorf("API mode not yet implemented, use --direct-db")
+			if directDB {
+				if dbPath == "" {
+					dbPath = getenvDefault("AGENTSH_DB_PATH", "./data/events.db")
+				}
+				st, err := sqlite.Open(dbPath)
+				if err != nil {
+					return fmt.Errorf("open database: %w", err)
+				}
+				defer st.Close()
+
+				filter := sqlite.MCPToolFilter{ServerID: serverID}
+				tools, err := st.ListMCPTools(cmd.Context(), filter)
+				if err != nil {
+					return err
+				}
+
+				if len(tools) == 0 {
+					cmd.Println("No MCP tools found")
+					return nil
+				}
+
+				if jsonOut {
+					return printJSON(cmd, tools)
+				}
+
+				// Table output
+				cmd.Println("SERVER              TOOL                HASH        LAST SEEN            DETECTIONS")
+				for _, t := range tools {
+					detections := fmt.Sprintf("%d", t.DetectionCount)
+					if t.MaxSeverity != "" {
+						detections = fmt.Sprintf("%d (%s)", t.DetectionCount, t.MaxSeverity)
+					}
+					cmd.Printf("%-19s %-19s %-11s %-20s %s\n",
+						truncate(t.ServerID, 19),
+						truncate(t.ToolName, 19),
+						truncate(t.ToolHash, 11),
+						t.LastSeen.Format("2006-01-02 15:04:05"),
+						detections,
+					)
+				}
+				return nil
 			}
 
-			if dbPath == "" {
-				dbPath = getenvDefault("AGENTSH_DB_PATH", "./data/events.db")
-			}
-			st, err := sqlite.Open(dbPath)
-			if err != nil {
-				return fmt.Errorf("open database: %w", err)
-			}
-			defer st.Close()
-
-			filter := sqlite.MCPToolFilter{ServerID: serverID}
-			tools, err := st.ListMCPTools(cmd.Context(), filter)
+			// API mode
+			cfg := getClientConfig(cmd)
+			c, err := client.NewForCLI(client.CLIOptions{
+				HTTPBaseURL:   cfg.serverAddr,
+				GRPCAddr:      cfg.grpcAddr,
+				APIKey:        cfg.apiKey,
+				Transport:     cfg.transport,
+				ClientTimeout: cfg.getClientTimeout(),
+			})
 			if err != nil {
 				return err
 			}
-
+			q := url.Values{}
+			if serverID != "" {
+				q.Set("server", serverID)
+			}
+			tools, err := c.ListMCPTools(cmd.Context(), q)
+			if err != nil {
+				return err
+			}
 			if len(tools) == 0 {
 				cmd.Println("No MCP tools found")
 				return nil
 			}
-
 			if jsonOut {
 				return printJSON(cmd, tools)
 			}
-
-			// Table output
 			cmd.Println("SERVER              TOOL                HASH        LAST SEEN            DETECTIONS")
 			for _, t := range tools {
-				detections := fmt.Sprintf("%d", t.DetectionCount)
-				if t.MaxSeverity != "" {
-					detections = fmt.Sprintf("%d (%s)", t.DetectionCount, t.MaxSeverity)
+				sid, _ := t["server_id"].(string)
+				tn, _ := t["tool_name"].(string)
+				th, _ := t["tool_hash"].(string)
+				ls, _ := t["last_seen"].(string)
+				dc, _ := t["detection_count"].(float64)
+				ms, _ := t["max_severity"].(string)
+				detections := fmt.Sprintf("%d", int(dc))
+				if ms != "" {
+					detections = fmt.Sprintf("%d (%s)", int(dc), ms)
 				}
 				cmd.Printf("%-19s %-19s %-11s %-20s %s\n",
-					truncate(t.ServerID, 19),
-					truncate(t.ToolName, 19),
-					truncate(t.ToolHash, 11),
-					t.LastSeen.Format("2006-01-02 15:04:05"),
-					detections,
-				)
+					truncate(sid, 19), truncate(tn, 19), truncate(th, 11),
+					truncate(ls, 20), detections)
 			}
 			return nil
 		},
@@ -111,41 +156,73 @@ func newMCPServersCmd() *cobra.Command {
 		Use:   "servers",
 		Short: "List known MCP servers",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !directDB {
-				return fmt.Errorf("API mode not yet implemented, use --direct-db")
+			if directDB {
+				if dbPath == "" {
+					dbPath = getenvDefault("AGENTSH_DB_PATH", "./data/events.db")
+				}
+				st, err := sqlite.Open(dbPath)
+				if err != nil {
+					return fmt.Errorf("open database: %w", err)
+				}
+				defer st.Close()
+
+				servers, err := st.ListMCPServers(cmd.Context())
+				if err != nil {
+					return err
+				}
+
+				if len(servers) == 0 {
+					cmd.Println("No MCP servers found")
+					return nil
+				}
+
+				if jsonOut {
+					return printJSON(cmd, servers)
+				}
+
+				cmd.Println("SERVER              TOOLS  LAST SEEN            DETECTIONS")
+				for _, s := range servers {
+					cmd.Printf("%-19s %-6d %-20s %d\n",
+						truncate(s.ServerID, 19),
+						s.ToolCount,
+						s.LastSeen.Format("2006-01-02 15:04:05"),
+						s.DetectionCount,
+					)
+				}
+				return nil
 			}
 
-			if dbPath == "" {
-				dbPath = getenvDefault("AGENTSH_DB_PATH", "./data/events.db")
-			}
-			st, err := sqlite.Open(dbPath)
-			if err != nil {
-				return fmt.Errorf("open database: %w", err)
-			}
-			defer st.Close()
-
-			servers, err := st.ListMCPServers(cmd.Context())
+			// API mode
+			cfg := getClientConfig(cmd)
+			c, err := client.NewForCLI(client.CLIOptions{
+				HTTPBaseURL:   cfg.serverAddr,
+				GRPCAddr:      cfg.grpcAddr,
+				APIKey:        cfg.apiKey,
+				Transport:     cfg.transport,
+				ClientTimeout: cfg.getClientTimeout(),
+			})
 			if err != nil {
 				return err
 			}
-
+			servers, err := c.ListMCPServers(cmd.Context())
+			if err != nil {
+				return err
+			}
 			if len(servers) == 0 {
 				cmd.Println("No MCP servers found")
 				return nil
 			}
-
 			if jsonOut {
 				return printJSON(cmd, servers)
 			}
-
 			cmd.Println("SERVER              TOOLS  LAST SEEN            DETECTIONS")
 			for _, s := range servers {
+				sid, _ := s["server_id"].(string)
+				tc, _ := s["tool_count"].(float64)
+				ls, _ := s["last_seen"].(string)
+				dc, _ := s["detection_count"].(float64)
 				cmd.Printf("%-19s %-6d %-20s %d\n",
-					truncate(s.ServerID, 19),
-					s.ToolCount,
-					s.LastSeen.Format("2006-01-02 15:04:05"),
-					s.DetectionCount,
-				)
+					truncate(sid, 19), int(tc), truncate(ls, 20), int(dc))
 			}
 			return nil
 		},
@@ -174,46 +251,98 @@ func newMCPEventsCmd() *cobra.Command {
 		Use:   "events",
 		Short: "Query MCP-related events",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !directDB {
-				return fmt.Errorf("API mode not yet implemented, use --direct-db")
-			}
-
-			if dbPath == "" {
-				dbPath = getenvDefault("AGENTSH_DB_PATH", "./data/events.db")
-			}
-			st, err := sqlite.Open(dbPath)
-			if err != nil {
-				return fmt.Errorf("open database: %w", err)
-			}
-			defer st.Close()
-
-			// Build query with MCP event types
-			mcpTypes := []string{"mcp_tool_seen", "mcp_tool_changed", "mcp_detection"}
-			if eventType != "" {
-				mcpTypes = []string{eventType}
-			}
-
-			q := types.EventQuery{
-				SessionID: sessionID,
-				Types:     mcpTypes,
-				Limit:     limit,
-			}
-
-			if since != "" {
-				t, err := parseTimeOrAgo(since)
-				if err != nil {
-					return fmt.Errorf("invalid --since: %w", err)
+			if directDB {
+				if dbPath == "" {
+					dbPath = getenvDefault("AGENTSH_DB_PATH", "./data/events.db")
 				}
-				q.Since = &t
+				st, err := sqlite.Open(dbPath)
+				if err != nil {
+					return fmt.Errorf("open database: %w", err)
+				}
+				defer st.Close()
+
+				// Build query with MCP event types
+				mcpTypes := []string{"mcp_tool_seen", "mcp_tool_changed", "mcp_detection"}
+				if eventType != "" {
+					mcpTypes = []string{eventType}
+				}
+
+				q := types.EventQuery{
+					SessionID: sessionID,
+					Types:     mcpTypes,
+					Limit:     limit,
+				}
+
+				if since != "" {
+					t, err := parseTimeOrAgo(since)
+					if err != nil {
+						return fmt.Errorf("invalid --since: %w", err)
+					}
+					q.Since = &t
+				}
+
+				events, err := st.QueryEvents(cmd.Context(), q)
+				if err != nil {
+					return err
+				}
+
+				// Filter by server if specified (check payload if needed)
+				// For now, just display all matching events
+				_ = serverID // reserved for future filtering
+
+				if len(events) == 0 {
+					cmd.Println("No MCP events found")
+					return nil
+				}
+
+				if jsonOut {
+					return printJSON(cmd, events)
+				}
+
+				// Table output
+				cmd.Println("TIMESTAMP            TYPE                SESSION")
+				for _, e := range events {
+					cmd.Printf("%-20s %-19s %s\n",
+						e.Timestamp.Format("2006-01-02 15:04:05"),
+						truncate(e.Type, 19),
+						truncate(e.SessionID, 20),
+					)
+				}
+				return nil
 			}
 
-			events, err := st.QueryEvents(cmd.Context(), q)
+			// API mode
+			cfg := getClientConfig(cmd)
+			c, err := client.NewForCLI(client.CLIOptions{
+				HTTPBaseURL:   cfg.serverAddr,
+				GRPCAddr:      cfg.grpcAddr,
+				APIKey:        cfg.apiKey,
+				Transport:     cfg.transport,
+				ClientTimeout: cfg.getClientTimeout(),
+			})
+			if err != nil {
+				return err
+			}
+			params := url.Values{}
+			mcpTypes := "mcp_tool_seen,mcp_tool_changed,mcp_detection"
+			if eventType != "" {
+				mcpTypes = eventType
+			}
+			params.Set("type", mcpTypes)
+			if sessionID != "" {
+				params.Set("session_id", sessionID)
+			}
+			if since != "" {
+				params.Set("since", since)
+			}
+			if limit > 0 {
+				params.Set("limit", fmt.Sprintf("%d", limit))
+			}
+			events, err := c.SearchEvents(cmd.Context(), params)
 			if err != nil {
 				return err
 			}
 
-			// Filter by server if specified (check payload if needed)
-			// For now, just display all matching events
 			_ = serverID // reserved for future filtering
 
 			if len(events) == 0 {
@@ -267,56 +396,128 @@ func newMCPCallsCmd() *cobra.Command {
 		Use:   "calls",
 		Short: "Query MCP tool call interceptions",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !directDB {
-				return fmt.Errorf("API mode not yet implemented, use --direct-db")
+			if directDB {
+				if limit <= 0 {
+					return fmt.Errorf("--limit must be a positive integer")
+				}
+
+				if dbPath == "" {
+					dbPath = getenvDefault("AGENTSH_DB_PATH", "./data/events.db")
+				}
+				st, err := sqlite.Open(dbPath)
+				if err != nil {
+					return fmt.Errorf("open database: %w", err)
+				}
+				defer st.Close()
+
+				q := types.EventQuery{
+					SessionID: sessionID,
+					Types:     []string{"mcp_tool_call_intercepted"},
+					Limit:     limit,
+				}
+
+				if toolName != "" {
+					q.PathLike = "%" + toolName + "%"
+				}
+				if serverID != "" {
+					q.DomainLike = "%" + serverID + "%"
+				}
+				if action != "" {
+					switch action {
+					case "allow":
+						d := types.DecisionAllow
+						q.Decision = &d
+					case "block":
+						d := types.DecisionDeny
+						q.Decision = &d
+					default:
+						return fmt.Errorf("invalid --action %q: must be \"allow\" or \"block\"", action)
+					}
+				}
+				if since != "" {
+					t, err := parseTimeOrAgo(since)
+					if err != nil {
+						return fmt.Errorf("invalid --since: %w", err)
+					}
+					q.Since = &t
+				}
+
+				events, err := st.QueryEvents(cmd.Context(), q)
+				if err != nil {
+					return err
+				}
+
+				if len(events) == 0 {
+					cmd.Println("No MCP tool calls found")
+					return nil
+				}
+
+				if jsonOut {
+					return printJSON(cmd, events)
+				}
+
+				// Table output
+				cmd.Println("TIMESTAMP            TOOL                SERVER              ACTION  REASON")
+				for _, e := range events {
+					tool, _ := e.Fields["tool_name"].(string)
+					server, _ := e.Fields["server_id"].(string)
+					act, _ := e.Fields["action"].(string)
+					reason, _ := e.Fields["reason"].(string)
+					cmd.Printf("%-20s %-19s %-19s %-7s %s\n",
+						e.Timestamp.Format("2006-01-02 15:04:05"),
+						truncate(tool, 19),
+						truncate(server, 19),
+						act,
+						reason,
+					)
+				}
+				return nil
 			}
 
+			// API mode
 			if limit <= 0 {
 				return fmt.Errorf("--limit must be a positive integer")
 			}
 
-			if dbPath == "" {
-				dbPath = getenvDefault("AGENTSH_DB_PATH", "./data/events.db")
-			}
-			st, err := sqlite.Open(dbPath)
+			cfg := getClientConfig(cmd)
+			c, err := client.NewForCLI(client.CLIOptions{
+				HTTPBaseURL:   cfg.serverAddr,
+				GRPCAddr:      cfg.grpcAddr,
+				APIKey:        cfg.apiKey,
+				Transport:     cfg.transport,
+				ClientTimeout: cfg.getClientTimeout(),
+			})
 			if err != nil {
-				return fmt.Errorf("open database: %w", err)
+				return err
 			}
-			defer st.Close()
-
-			q := types.EventQuery{
-				SessionID: sessionID,
-				Types:     []string{"mcp_tool_call_intercepted"},
-				Limit:     limit,
+			params := url.Values{}
+			params.Set("type", "mcp_tool_call_intercepted")
+			if sessionID != "" {
+				params.Set("session_id", sessionID)
 			}
-
 			if toolName != "" {
-				q.PathLike = "%" + toolName + "%"
+				params.Set("path_like", "%"+toolName+"%")
 			}
 			if serverID != "" {
-				q.DomainLike = "%" + serverID + "%"
+				params.Set("domain_like", "%"+serverID+"%")
 			}
 			if action != "" {
 				switch action {
 				case "allow":
-					d := types.DecisionAllow
-					q.Decision = &d
+					params.Set("decision", "allow")
 				case "block":
-					d := types.DecisionDeny
-					q.Decision = &d
+					params.Set("decision", "deny")
 				default:
 					return fmt.Errorf("invalid --action %q: must be \"allow\" or \"block\"", action)
 				}
 			}
 			if since != "" {
-				t, err := parseTimeOrAgo(since)
-				if err != nil {
-					return fmt.Errorf("invalid --since: %w", err)
-				}
-				q.Since = &t
+				params.Set("since", since)
 			}
-
-			events, err := st.QueryEvents(cmd.Context(), q)
+			if limit > 0 {
+				params.Set("limit", fmt.Sprintf("%d", limit))
+			}
+			events, err := c.SearchEvents(cmd.Context(), params)
 			if err != nil {
 				return err
 			}
@@ -375,55 +576,107 @@ func newMCPDetectionsCmd() *cobra.Command {
 		Use:   "detections",
 		Short: "Show tools with security detections",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !directDB {
-				return fmt.Errorf("API mode not yet implemented, use --direct-db")
+			if directDB {
+				if dbPath == "" {
+					dbPath = getenvDefault("AGENTSH_DB_PATH", "./data/events.db")
+				}
+				st, err := sqlite.Open(dbPath)
+				if err != nil {
+					return fmt.Errorf("open database: %w", err)
+				}
+				defer st.Close()
+
+				filter := sqlite.MCPToolFilter{
+					ServerID:      serverID,
+					HasDetections: true,
+				}
+				tools, err := st.ListMCPTools(cmd.Context(), filter)
+				if err != nil {
+					return err
+				}
+
+				// Filter by severity if specified
+				if severity != "" {
+					var filtered []sqlite.MCPTool
+					for _, t := range tools {
+						if matchesSeverity(t.MaxSeverity, severity) {
+							filtered = append(filtered, t)
+						}
+					}
+					tools = filtered
+				}
+
+				if len(tools) == 0 {
+					cmd.Println("No tools with detections found")
+					return nil
+				}
+
+				if jsonOut {
+					return printJSON(cmd, tools)
+				}
+
+				cmd.Println("SERVER              TOOL                SEVERITY   DETECTIONS")
+				for _, t := range tools {
+					cmd.Printf("%-19s %-19s %-10s %d\n",
+						truncate(t.ServerID, 19),
+						truncate(t.ToolName, 19),
+						t.MaxSeverity,
+						t.DetectionCount,
+					)
+				}
+				return nil
 			}
 
-			if dbPath == "" {
-				dbPath = getenvDefault("AGENTSH_DB_PATH", "./data/events.db")
-			}
-			st, err := sqlite.Open(dbPath)
-			if err != nil {
-				return fmt.Errorf("open database: %w", err)
-			}
-			defer st.Close()
-
-			filter := sqlite.MCPToolFilter{
-				ServerID:      serverID,
-				HasDetections: true,
-			}
-			tools, err := st.ListMCPTools(cmd.Context(), filter)
+			// API mode
+			cfg := getClientConfig(cmd)
+			c, err := client.NewForCLI(client.CLIOptions{
+				HTTPBaseURL:   cfg.serverAddr,
+				GRPCAddr:      cfg.grpcAddr,
+				APIKey:        cfg.apiKey,
+				Transport:     cfg.transport,
+				ClientTimeout: cfg.getClientTimeout(),
+			})
 			if err != nil {
 				return err
 			}
-
-			// Filter by severity if specified
+			q := url.Values{}
+			q.Set("detections", "true")
+			if serverID != "" {
+				q.Set("server", serverID)
+			}
+			tools, err := c.ListMCPTools(cmd.Context(), q)
+			if err != nil {
+				return err
+			}
+			// Filter by severity client-side if specified
 			if severity != "" {
-				var filtered []sqlite.MCPTool
+				var filtered []map[string]any
 				for _, t := range tools {
-					if matchesSeverity(t.MaxSeverity, severity) {
+					ms, _ := t["max_severity"].(string)
+					if matchesSeverity(ms, severity) {
 						filtered = append(filtered, t)
 					}
 				}
 				tools = filtered
 			}
-
 			if len(tools) == 0 {
 				cmd.Println("No tools with detections found")
 				return nil
 			}
-
 			if jsonOut {
 				return printJSON(cmd, tools)
 			}
-
 			cmd.Println("SERVER              TOOL                SEVERITY   DETECTIONS")
 			for _, t := range tools {
+				sid, _ := t["server_id"].(string)
+				tn, _ := t["tool_name"].(string)
+				ms, _ := t["max_severity"].(string)
+				dc, _ := t["detection_count"].(float64)
 				cmd.Printf("%-19s %-19s %-10s %d\n",
-					truncate(t.ServerID, 19),
-					truncate(t.ToolName, 19),
-					t.MaxSeverity,
-					t.DetectionCount,
+					truncate(sid, 19),
+					truncate(tn, 19),
+					ms,
+					int(dc),
 				)
 			}
 			return nil

--- a/internal/cli/session_test.go
+++ b/internal/cli/session_test.go
@@ -84,6 +84,12 @@ func (m *mockCLIClient) WatchTaints(ctx context.Context, agentOnly bool, handler
 func (m *mockCLIClient) WrapInit(ctx context.Context, sessionID string, req types.WrapInitRequest) (types.WrapInitResponse, error) {
 	return types.WrapInitResponse{}, nil
 }
+func (m *mockCLIClient) ListMCPTools(ctx context.Context, q url.Values) ([]map[string]any, error) {
+	return nil, nil
+}
+func (m *mockCLIClient) ListMCPServers(ctx context.Context) ([]map[string]any, error) {
+	return nil, nil
+}
 
 func TestPrintSessionCreated(t *testing.T) {
 	tests := []struct {

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -209,6 +209,12 @@ func (m *mockWrapClient) GetTaintTrace(ctx context.Context, pid int) (*types.Tai
 func (m *mockWrapClient) WatchTaints(ctx context.Context, agentOnly bool, handler func(types.TaintEvent)) error {
 	return nil
 }
+func (m *mockWrapClient) ListMCPTools(ctx context.Context, q url.Values) ([]map[string]any, error) {
+	return nil, nil
+}
+func (m *mockWrapClient) ListMCPServers(ctx context.Context) ([]map[string]any, error) {
+	return nil, nil
+}
 
 func TestSetupWrapInterception_CallsWrapInit(t *testing.T) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {

--- a/internal/client/cli_client.go
+++ b/internal/client/cli_client.go
@@ -44,6 +44,10 @@ type CLIClient interface {
 
 	// Wrap-related operations
 	WrapInit(ctx context.Context, sessionID string, req types.WrapInitRequest) (types.WrapInitResponse, error)
+
+	// MCP-related operations
+	ListMCPTools(ctx context.Context, q url.Values) ([]map[string]any, error)
+	ListMCPServers(ctx context.Context) ([]map[string]any, error)
 }
 
 type CLIOptions struct {
@@ -244,4 +248,14 @@ func (h *HybridClient) WatchTaints(ctx context.Context, agentOnly bool, handler 
 // WrapInit initializes seccomp wrapping for a session.
 func (h *HybridClient) WrapInit(ctx context.Context, sessionID string, req types.WrapInitRequest) (types.WrapInitResponse, error) {
 	return h.Client.WrapInit(ctx, sessionID, req)
+}
+
+// ListMCPTools lists MCP tools matching the given query parameters.
+func (h *HybridClient) ListMCPTools(ctx context.Context, q url.Values) ([]map[string]any, error) {
+	return h.Client.ListMCPTools(ctx, q)
+}
+
+// ListMCPServers lists MCP server summaries.
+func (h *HybridClient) ListMCPServers(ctx context.Context) ([]map[string]any, error) {
+	return h.Client.ListMCPServers(ctx)
 }

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -228,6 +228,24 @@ func (c *Client) WrapInit(ctx context.Context, sessionID string, req types.WrapI
 	return out, nil
 }
 
+// ListMCPTools lists MCP tools matching the given query parameters.
+func (c *Client) ListMCPTools(ctx context.Context, q url.Values) ([]map[string]any, error) {
+	var out []map[string]any
+	if err := c.doJSON(ctx, http.MethodGet, "/api/v1/mcp/tools", q, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ListMCPServers lists MCP server summaries.
+func (c *Client) ListMCPServers(ctx context.Context) ([]map[string]any, error) {
+	var out []map[string]any
+	if err := c.doJSON(ctx, http.MethodGet, "/api/v1/mcp/servers", nil, nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *Client) StreamSessionEvents(ctx context.Context, sessionID string) (io.ReadCloser, error) {
 	u := c.baseURL + "/api/v1/sessions/" + url.PathEscape(sessionID) + "/events"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)

--- a/internal/client/grpc_client.go
+++ b/internal/client/grpc_client.go
@@ -483,6 +483,16 @@ func (c *GRPCClient) GetProxyStatus(ctx context.Context, sessionID string) (map[
 	return out, nil
 }
 
+// ListMCPTools is not supported via gRPC.
+func (c *GRPCClient) ListMCPTools(ctx context.Context, q url.Values) ([]map[string]any, error) {
+	return nil, fmt.Errorf("ListMCPTools not supported via gRPC")
+}
+
+// ListMCPServers is not supported via gRPC.
+func (c *GRPCClient) ListMCPServers(ctx context.Context) ([]map[string]any, error) {
+	return nil, fmt.Errorf("ListMCPServers not supported via gRPC")
+}
+
 func (c *GRPCClient) invokeUnary(ctx context.Context, method string, in *structpb.Struct, out *structpb.Struct) error {
 	if c == nil || c.conn == nil {
 		return fmt.Errorf("grpc client not initialized")

--- a/internal/session/llmproxy.go
+++ b/internal/session/llmproxy.go
@@ -51,8 +51,13 @@ func StartLLMProxy(
 		return "", nil, fmt.Errorf("create llm proxy: %w", err)
 	}
 
-	// Create MCP registry and inject into proxy if MCP policy is configured
-	if mcpCfg.EnforcePolicy {
+	// Create MCP registry when any MCP feature needs it.
+	needsRegistry := mcpCfg.EnforcePolicy ||
+		proxyCfg.IsMCPOnly() ||
+		mcpCfg.RateLimits.Enabled ||
+		mcpCfg.VersionPinning.Enabled
+
+	if needsRegistry {
 		registry := mcpregistry.NewRegistry()
 		proxy.SetRegistry(registry)
 		sess.SetMCPRegistry(registry)

--- a/internal/session/llmproxy_test.go
+++ b/internal/session/llmproxy_test.go
@@ -705,6 +705,84 @@ func TestStartLLMProxy_CreatesRegistry(t *testing.T) {
 	}
 }
 
+func TestStartLLMProxy_MCPOnlyWithoutPolicy(t *testing.T) {
+	// Verify that registry is created in mcp-only mode even when EnforcePolicy is false,
+	// as long as another MCP feature (rate limits) is enabled.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"id":   "msg_test",
+			"type": "message",
+			"usage": map[string]int{
+				"input_tokens":  5,
+				"output_tokens": 10,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer upstream.Close()
+
+	mgr := NewManager(10)
+	sess, err := mgr.CreateWithID("mcp-only-no-policy-test", t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+
+	proxyCfg := config.ProxyConfig{
+		Mode: "mcp-only",
+		Port: 0,
+		Providers: config.ProxyProvidersConfig{
+			Anthropic: upstream.URL,
+			OpenAI:    upstream.URL,
+		},
+	}
+	dlpCfg := config.DLPConfig{Mode: "disabled"}
+	storageCfg := config.DefaultLLMStorageConfig()
+	mcpCfg := config.SandboxMCPConfig{
+		EnforcePolicy: false,
+		RateLimits: config.MCPRateLimitsConfig{
+			Enabled:    true,
+			DefaultRPM: 60,
+		},
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger)
+	if err != nil {
+		t.Fatalf("StartLLMProxy failed: %v", err)
+	}
+	defer closeFn()
+
+	// Verify proxy started
+	if proxyURL == "" {
+		t.Error("expected non-empty proxy URL")
+	}
+
+	// Verify registry WAS created even though EnforcePolicy is false.
+	// The mcp-only mode + rate limits should trigger registry creation.
+	reg := sess.MCPRegistry()
+	if reg == nil {
+		t.Fatal("expected non-nil MCP registry in mcp-only mode with rate limits enabled")
+	}
+
+	// Verify the registry is functional
+	registry, ok := reg.(*mcpregistry.Registry)
+	if !ok {
+		t.Fatalf("expected *mcpregistry.Registry, got %T", reg)
+	}
+
+	registry.Register("test-server", "stdio", "", []mcpregistry.ToolInfo{
+		{Name: "rate_limited_tool", Hash: "def456"},
+	})
+	entry := registry.Lookup("rate_limited_tool")
+	if entry == nil {
+		t.Error("expected to find registered tool in registry")
+	}
+	if entry != nil && entry.ServerID != "test-server" {
+		t.Errorf("expected server ID 'test-server', got %s", entry.ServerID)
+	}
+}
+
 func TestStartLLMProxy_NoRegistryWhenPolicyDisabled(t *testing.T) {
 	// Create a mock upstream server
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/store/composite/composite.go
+++ b/internal/store/composite/composite.go
@@ -124,3 +124,21 @@ func timeField(m map[string]any, key string) time.Time {
 	}
 	return time.Time{}
 }
+
+// ListMCPTools delegates to the primary SQLite store to query MCP tools.
+func (s *Store) ListMCPTools(ctx context.Context, filter sqlite.MCPToolFilter) ([]sqlite.MCPTool, error) {
+	sqliteStore, ok := s.primary.(*sqlite.Store)
+	if !ok {
+		return nil, fmt.Errorf("MCP queries not supported by primary store")
+	}
+	return sqliteStore.ListMCPTools(ctx, filter)
+}
+
+// ListMCPServers delegates to the primary SQLite store to query MCP server summaries.
+func (s *Store) ListMCPServers(ctx context.Context) ([]sqlite.MCPServerSummary, error) {
+	sqliteStore, ok := s.primary.(*sqlite.Store)
+	if !ok {
+		return nil, fmt.Errorf("MCP queries not supported by primary store")
+	}
+	return sqliteStore.ListMCPServers(ctx)
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -20,29 +20,29 @@ type Store struct {
 
 // MCPTool represents a registered MCP tool.
 type MCPTool struct {
-	ServerID       string
-	ToolName       string
-	ToolHash       string
-	Description    string
-	FirstSeen      time.Time
-	LastSeen       time.Time
-	Pinned         bool
-	DetectionCount int
-	MaxSeverity    string
+	ServerID       string    `json:"server_id"`
+	ToolName       string    `json:"tool_name"`
+	ToolHash       string    `json:"tool_hash"`
+	Description    string    `json:"description"`
+	FirstSeen      time.Time `json:"first_seen"`
+	LastSeen       time.Time `json:"last_seen"`
+	Pinned         bool      `json:"pinned"`
+	DetectionCount int       `json:"detection_count"`
+	MaxSeverity    string    `json:"max_severity"`
 }
 
 // MCPToolFilter for querying tools.
 type MCPToolFilter struct {
-	ServerID      string
-	HasDetections bool
+	ServerID      string `json:"server_id,omitempty"`
+	HasDetections bool   `json:"has_detections,omitempty"`
 }
 
 // MCPServerSummary aggregates tool info per server.
 type MCPServerSummary struct {
-	ServerID       string
-	ToolCount      int
-	LastSeen       time.Time
-	DetectionCount int
+	ServerID       string    `json:"server_id"`
+	ToolCount      int       `json:"tool_count"`
+	LastSeen       time.Time `json:"last_seen"`
+	DetectionCount int       `json:"detection_count"`
 }
 
 func Open(path string) (*Store, error) {


### PR DESCRIPTION
## Summary

- **Fix registry creation for mcp-only mode** — Registry is now created when any MCP feature is active (mcp-only mode, rate limits, or version pinning), not just when `EnforcePolicy` is true
- **Wire network server declarations to registry** — Pre-registers declared HTTP/SSE server addresses in the registry for network connection detection; uses `net.JoinHostPort` for IPv6 support
- **Add MCP API endpoints** — `GET /api/v1/mcp/tools` and `GET /api/v1/mcp/servers` with server/detection filtering
- **Add MCP client methods** — `ListMCPTools` and `ListMCPServers` on the HTTP client (gRPC stubs return unsupported error)
- **Wire MCP CLI commands to API mode** — All 5 MCP subcommands (tools, servers, events, calls, detections) work without `--direct-db`
- **Address code review findings** — IPv6 support via `net.JoinHostPort`, sanitized API error responses, table-driven test isolation, skip stdio pre-registration

## Test plan

- [x] `go test ./...` — all tests pass
- [x] `GOOS=windows go build ./...` — cross-compilation succeeds
- [x] Table-driven tests for each `needsRegistry` trigger independently
- [x] IPv6 test cases for `extractAddr`
- [x] API endpoint tests (10 cases: empty, all, filter, content-type)
- [x] Network server declaration pre-registration verified via `ServerAddrs()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)