### PR TITLE
feat: threat intelligence feed integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,9 +300,10 @@ See [SECURITY.md](SECURITY.md) for configuration details.
 
 - **Tool Whitelisting**: Control which MCP tools can be invoked via allowlist/denylist policies
 - **Version Pinning**: Detect tool definition changes (rug pull protection) with configurable responses
+- **Cross-Server Detection**: Block data exfiltration patterns (read from Server A → send via Server B)
 - **Rate Limiting**: Token bucket rate limiting for MCP servers and network domains
 
-See [SECURITY.md](SECURITY.md) for full configuration options.
+See [SECURITY.md](SECURITY.md) for full configuration options, or run the **[MCP Protection Demo](https://github.com/canyonroad/agentsh-mcp-protection-demo)** to see these detections in action.
 
 ---
 
@@ -641,6 +642,7 @@ Ready-to-use snippets for configuring AI coding assistants to use agentsh:
 
 ## References
 
+* **MCP Protection Demo:** [`agentsh-mcp-protection-demo`](https://github.com/canyonroad/agentsh-mcp-protection-demo) - live demo of cross-server exfiltration detection, rug pull blocking, and policy generation
 * **Security & threat model:** [`SECURITY.md`](SECURITY.md) - what agentsh protects against, known limitations, operator checklist
 * **External KMS:** [`SECURITY.md#external-kms-integration`](SECURITY.md#external-kms-integration) - AWS KMS, Azure Key Vault, HashiCorp Vault, GCP Cloud KMS for audit integrity keys
 * Config template: [`configs/server-config.yaml`](configs/server-config.yaml)

--- a/docs/plans/2026-02-24-threat-feed-design.md
+++ b/docs/plans/2026-02-24-threat-feed-design.md
@@ -1,0 +1,354 @@
+# Threat Intelligence Feed Integration — Design
+
+**Date:** 2026-02-24
+**Status:** Draft
+
+## Overview
+
+Add a threat intelligence feed system to agentsh that blocks connections to known-malicious domains. External feeds (URLhaus, phishing lists, custom blocklists) are synced periodically into an in-memory store and checked on every network connection via the existing policy engine.
+
+**Use cases:**
+- Block agent connections to known malware distribution, phishing, and C2 domains
+- Audit-mode monitoring to discover if agents are reaching suspicious destinations
+- Custom enterprise blocklists alongside public feeds
+- Future paid tier: real-time API-based lookups (Google Web Risk, VirusTotal)
+
+## Architecture
+
+```
+server.New()
+├── threatfeed.NewStore(cacheDir, allowlist)
+│   └── LoadFromDisk()              ← immediate protection from cache
+├── policy.NewEngine(..., WithThreatStore(store))
+└── server.Run()
+    └── go syncer.Run(ctx)          ← background goroutine
+        ├── syncAll()               ← immediate first fetch
+        └── ticker loop             ← periodic refresh
+            ├── fetch remote feeds
+            ├── parse local lists
+            ├── store.Update()      ← atomic swap
+            └── store.SaveToDisk()
+
+Network connection arrives:
+    netmonitor.Proxy → policy.Engine.CheckNetworkCtx()
+        1. threatStore.Check(domain)    ← NEW pre-check
+        2. network_rules evaluation     ← existing, unchanged
+        3. default deny                 ← existing, unchanged
+```
+
+**New package:** `internal/threatfeed/`
+**Modified packages:** `internal/config/`, `internal/policy/`, `internal/server/`
+**No changes to:** `internal/netmonitor/`, `internal/llmproxy/`, `internal/session/`
+
+## Configuration
+
+New `threat_feeds` section in server config (`internal/config/config.go`):
+
+```yaml
+threat_feeds:
+  enabled: true
+  action: deny                    # deny | audit
+  feeds:
+    - name: urlhaus
+      url: https://urlhaus.abuse.ch/downloads/hostfile/
+      format: hostfile            # hostfile | domain-list
+    - name: phishing-database
+      url: https://raw.githubusercontent.com/mitchellkrogza/Phishing.Database/master/active-domains.txt
+      format: domain-list
+  local_lists:
+    - /etc/agentsh/custom-blocklist.txt
+  allowlist:
+    - legit-domain.example.com
+  sync_interval: 6h
+  cache_dir: ""                   # defaults to GetDataDir()/threat-feeds/
+  realtime:                       # paid tier — not implemented in v1
+    provider: ""                  # webrisk | virustotal
+    api_key: ""
+    timeout: 500ms
+    cache_ttl: 1h
+    on_timeout: local-only        # local-only | allow | deny
+```
+
+**Key decisions:**
+
+- `action: deny` blocks connections; `action: audit` logs without blocking — lets users trial before enforcing
+- `allowlist` overrides feed matches (false positive handling), evaluated before the feed check
+- `sync_interval` defaults to 6h; the syncer fetches immediately on startup after loading disk cache
+- `realtime` section is defined in the config struct but gated — returns an error if `provider` is set without a license, reserving the config shape for later
+- `local_lists` are parsed on the same schedule as remote feeds using the same parser interface
+
+## Components
+
+### Store (`internal/threatfeed/store.go`)
+
+Thread-safe in-memory hash set with disk persistence:
+
+```go
+type Store struct {
+    mu        sync.RWMutex
+    domains   map[string]FeedEntry  // domain → which feed flagged it
+    allowlist map[string]struct{}
+    cacheDir  string
+}
+
+type FeedEntry struct {
+    FeedName string
+    AddedAt  time.Time
+}
+```
+
+**Methods:**
+
+- `Check(domain string) (FeedEntry, bool)` — checks allowlist first, then the domain map. Also checks parent domains (e.g., `sub.evil.com` queries also check `evil.com`). Read-locked, zero allocation on the hot path.
+- `Update(domains map[string]FeedEntry)` — atomic swap under write lock. Old map is dropped for GC.
+- `LoadFromDisk() error` — loads gob-encoded cache from `cacheDir/feeds.cache`. Called synchronously during `server.New()` so protection is active before any sessions start.
+- `SaveToDisk() error` — persists current state. Called after each sync and on graceful shutdown.
+
+### Syncer (`internal/threatfeed/syncer.go`)
+
+Background goroutine that downloads and parses feeds:
+
+```go
+type Syncer struct {
+    store    *Store
+    feeds    []FeedConfig
+    locals   []string
+    interval time.Duration
+    client   *http.Client
+    logger   *slog.Logger
+}
+```
+
+**Lifecycle:**
+
+```go
+func (s *Syncer) Run(ctx context.Context) {
+    s.syncAll()                    // immediate first fetch
+    ticker := time.NewTicker(s.interval)
+    defer ticker.Stop()
+    for {
+        select {
+        case <-ctx.Done():
+            s.store.SaveToDisk()   // persist before exit
+            return
+        case <-ticker.C:
+            s.syncAll()
+        }
+    }
+}
+```
+
+- `syncAll()` — iterates all remote feeds and local lists, merges results, calls `store.Update()` then `store.SaveToDisk()`
+- `fetchFeed(feed FeedConfig) ([]string, error)` — downloads a single feed URL, passes body to the appropriate parser. Uses `If-Modified-Since` / `ETag` headers to skip re-downloading unchanged feeds.
+- On any fetch error: logs a warning, keeps using previous data. Never clears the store because a single feed is temporarily unavailable.
+
+### Parsers (`internal/threatfeed/parser.go`)
+
+```go
+type Parser interface {
+    Parse(r io.Reader) ([]string, error)
+}
+```
+
+Two implementations for v1:
+
+- **`HostfileParser`** — skips comments (`#`), splits on whitespace, takes the second field (the domain), lowercases, deduplicates. Handles both `127.0.0.1` and `0.0.0.0` prefixes.
+- **`DomainListParser`** — one domain per line, skips comments and blanks, lowercases, deduplicates.
+
+### Provider Interface (`internal/threatfeed/provider.go`)
+
+Defined for the future real-time paid tier:
+
+```go
+type Provider interface {
+    Check(ctx context.Context, domain string) (ThreatResult, error)
+    Name() string
+}
+
+type ThreatResult struct {
+    Matched    bool
+    FeedName   string
+    ThreatType string   // malware, phishing, unwanted, etc.
+}
+```
+
+Not implemented in v1 — serves as the extension point for Web Risk / VirusTotal integration.
+
+## Policy Engine Integration
+
+### Check Flow
+
+The `Engine` struct gets a new optional field:
+
+```go
+type Engine struct {
+    // ... existing fields
+    threatStore  *threatfeed.Store
+    threatAction string  // "deny" or "audit"
+}
+```
+
+Set via `WithThreatStore(*threatfeed.Store)` and `WithThreatAction(string)` options at construction time. If `threatStore` is nil, the check is skipped entirely — all existing behavior is unchanged.
+
+In `CheckNetworkCtx()`, the threat feed check inserts before the existing rule loop:
+
+```go
+func (e *Engine) CheckNetworkCtx(ctx context.Context, domain string, port int) Decision {
+    // 1. Threat feed check (new)
+    if e.threatStore != nil {
+        if entry, matched := e.threatStore.Check(domain); matched {
+            return Decision{
+                PolicyDecision: e.threatAction,
+                Rule:           "threat-feed:" + entry.FeedName,
+                Message:        "domain matched threat feed: " + entry.FeedName,
+                Fields: map[string]string{
+                    "threat_feed":  entry.FeedName,
+                    "threat_match": domain,
+                },
+            }
+        }
+    }
+
+    // 2. Existing network_rules evaluation (unchanged)
+    for _, rule := range e.networkRules {
+        // ...
+    }
+
+    // 3. Default deny
+}
+```
+
+### Event Data
+
+No new event types needed. Blocked connections produce standard `net_connect` events with structured threat metadata in the `Fields` map:
+
+```json
+{
+    "type": "net_connect",
+    "domain": "sub.evil.example.com",
+    "fields": {
+        "threat_feed": "urlhaus",
+        "threat_match": "evil.example.com"
+    },
+    "policy": {
+        "decision": "deny",
+        "rule": "threat-feed:urlhaus",
+        "message": "domain matched threat feed: urlhaus"
+    }
+}
+```
+
+- `threat_feed` — which feed matched (e.g., `urlhaus`, `phishing-database`, or a custom list name)
+- `threat_match` — the actual domain that matched, which may differ from the requested domain if a parent domain was matched
+
+This means reports, `policygen`, event tailing, and webhooks all work with no changes — they already process `net_connect` events. The `threat-feed:` prefix in the rule name distinguishes these from user-defined network rules.
+
+## Server Wiring
+
+### Initialization (`server.New()`)
+
+Created alongside the policy engine:
+
+```go
+var threatStore *threatfeed.Store
+if cfg.ThreatFeeds.Enabled {
+    cacheDir := cfg.ThreatFeeds.CacheDir
+    if cacheDir == "" {
+        cacheDir = filepath.Join(config.GetDataDir(), "threat-feeds")
+    }
+    threatStore = threatfeed.NewStore(cacheDir, cfg.ThreatFeeds.Allowlist)
+    threatStore.LoadFromDisk()
+}
+
+engine, err := policy.NewEngine(p, enforceApprovals,
+    policy.WithThreatStore(threatStore),
+    policy.WithThreatAction(cfg.ThreatFeeds.Action),
+)
+```
+
+### Goroutine Startup (`server.Run()`)
+
+Starts alongside existing goroutines (session reaper, HTTP server):
+
+```go
+if cfg.ThreatFeeds.Enabled && threatStore != nil {
+    syncer := threatfeed.NewSyncer(threatStore, cfg.ThreatFeeds, s.logger)
+    s.wg.Add(1)
+    go func() {
+        defer s.wg.Done()
+        syncer.Run(ctx)
+    }()
+}
+```
+
+### Shutdown
+
+Context cancellation triggers `syncer.Run()` to exit the ticker loop and call `store.SaveToDisk()` before returning. The server's `sync.WaitGroup` ensures the save completes before process exit.
+
+## Future: Real-Time API Tier
+
+When implementing the paid `realtime` section, the check flow extends to:
+
+```
+1. Check local feed store          (always, ~microseconds)
+2. Check API result cache          (always, ~microseconds)
+3. Cache miss? → API lookup        (paid tier only, ~50-200ms)
+4. Evaluate network_rules
+5. Default deny
+```
+
+The `Provider` interface slots in here. Key design decisions for that phase:
+- Configurable timeout with `on_timeout` fallback policy (`local-only`, `allow`, `deny`)
+- Local LRU cache with configurable TTL to minimize API calls
+- Agents hit the same domains repeatedly, so cache hit rate will be very high after startup
+
+## Feed Licensing Notes
+
+| Feed | License | Commercial OK |
+|------|---------|---------------|
+| URLhaus (abuse.ch) | CC0 (public domain) | Yes |
+| Phishing.Database (mitchellkrogza) | MIT | Yes |
+| StevenBlack/hosts | MIT | Yes |
+| OpenPhish community | Free community feed | Yes |
+| Google Safe Browsing | Restrictive ToS | No (use Web Risk API for commercial) |
+| Google Web Risk API | Commercial GCP service | Yes (paid) |
+| VirusTotal | Commercial API tiers | Yes (paid) |
+| Spamhaus | Free for non-commercial | Requires license for commercial |
+
+Default bundled feed configuration should use CC0/MIT-licensed feeds only.
+
+## Testing Strategy
+
+### Unit Tests (`internal/threatfeed/`)
+
+**`store_test.go`:**
+- Exact domain match
+- Parent domain match (`sub.evil.com` matches `evil.com` in store)
+- Allowlist override (domain in feed + allowlist → no match)
+- Concurrent read/write safety (goroutines calling `Check` while `Update` swaps)
+- `SaveToDisk` / `LoadFromDisk` round-trip
+- Empty store returns no matches
+
+**`parser_test.go`:**
+- Hostfile: standard lines, comments, blank lines, `0.0.0.0` vs `127.0.0.1`, trailing comments, duplicates
+- Domain list: one per line, comments, whitespace, mixed case → lowercase
+- Malformed input: binary garbage, extremely long lines, empty input → no panic, returns empty
+
+**`syncer_test.go`:**
+- `httptest.Server` serving fake feeds → store populated after `syncAll()`
+- `If-Modified-Since` header sent on second fetch
+- Fetch failure keeps previous data (serve feed, then 500, verify store unchanged)
+- Context cancellation stops loop and triggers `SaveToDisk`
+- Local file lists parsed alongside remote feeds
+
+### Integration Test (`internal/policy/`)
+
+**`engine_threat_test.go`:**
+- `CheckNetworkCtx` with populated threat store → deny with correct rule, fields
+- Action set to `audit` → audit decision, connection proceeds
+- Threat store is nil → skipped, falls through to `network_rules`
+- Domain in threat store checked before `network_rules`
+
+### Existing Tests
+
+No changes needed. The threat store is optional (nil = skipped), so all existing policy engine tests pass without modification.

--- a/docs/plans/2026-02-24-threat-feed-impl.md
+++ b/docs/plans/2026-02-24-threat-feed-impl.md
@@ -1,0 +1,1436 @@
+# Threat Intelligence Feed Integration — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a threat intelligence feed system that blocks agent connections to known-malicious domains by integrating with the existing policy engine.
+
+**Architecture:** New `internal/threatfeed/` package with three components: `Store` (in-memory hash set + gob disk cache), `Syncer` (background goroutine fetching feeds), and `Parser` (hostfile + domain-list formats). The store is created in `server.New()`, passed to `policy.Engine` via a setter method, and checked as a pre-step in `CheckNetworkCtx()` before existing `network_rules`. The syncer goroutine starts in `server.Run()` alongside existing goroutines.
+
+**Tech Stack:** Go stdlib (`sync`, `net/http`, `encoding/gob`, `time`), `github.com/stretchr/testify`, `net/http/httptest`
+
+---
+
+## Context
+
+The policy engine (`internal/policy/engine.go`) evaluates network rules in `CheckNetworkCtx()` (line 695) using first-match-wins semantics against compiled domain globs and CIDRs. The proxy (`internal/netmonitor/proxy.go`) calls `checkNetwork()` (line 330) which delegates to the engine. Events are emitted as `net_connect` with `Fields map[string]any` and `Policy *PolicyInfo`.
+
+The server (`internal/server/server.go`) creates the policy engine in `New()` (line 99) and starts goroutines in `Run()` (line 599) using an `errCh` channel pattern. Config is defined in `internal/config/config.go` with the top-level `Config` struct (line 13).
+
+This plan adds threat feed checking as a transparent pre-step inside the engine — no changes to the proxy, events, or report packages.
+
+---
+
+### Task 1: Add config structs for threat feeds
+
+Add `ThreatFeedsConfig` and related types to the config package, and wire the new field into the top-level `Config` struct.
+
+**Files:**
+- Create: `internal/config/threatfeeds.go`
+- Modify: `internal/config/config.go:13-33` (add field to Config struct)
+- Modify: `internal/config/config.go:799` (wire defaults in `applyDefaultsWithSource`)
+
+**Step 1: Create the config types**
+
+Create `internal/config/threatfeeds.go`:
+
+```go
+package config
+
+import "time"
+
+// ThreatFeedsConfig configures external threat intelligence feed integration.
+type ThreatFeedsConfig struct {
+	Enabled      bool              `yaml:"enabled"`
+	Action       string            `yaml:"action"`
+	Feeds        []ThreatFeedEntry `yaml:"feeds"`
+	LocalLists   []string          `yaml:"local_lists"`
+	Allowlist    []string          `yaml:"allowlist"`
+	SyncInterval time.Duration     `yaml:"sync_interval"`
+	CacheDir     string            `yaml:"cache_dir"`
+	Realtime     RealtimeConfig    `yaml:"realtime"`
+}
+
+// ThreatFeedEntry defines a single remote threat feed.
+type ThreatFeedEntry struct {
+	Name   string `yaml:"name"`
+	URL    string `yaml:"url"`
+	Format string `yaml:"format"` // "hostfile" or "domain-list"
+}
+
+// RealtimeConfig defines the paid real-time API tier (reserved, not implemented in v1).
+type RealtimeConfig struct {
+	Provider  string        `yaml:"provider"`
+	APIKey    string        `yaml:"api_key"`
+	Timeout   time.Duration `yaml:"timeout"`
+	CacheTTL  time.Duration `yaml:"cache_ttl"`
+	OnTimeout string        `yaml:"on_timeout"`
+}
+```
+
+**Step 2: Add field to Config struct**
+
+In `internal/config/config.go`, add `ThreatFeeds` to the `Config` struct (after line 32, before the closing brace):
+
+```go
+ThreatFeeds       ThreatFeedsConfig       `yaml:"threat_feeds"`
+```
+
+**Step 3: Wire defaults in `applyDefaultsWithSource`**
+
+In `internal/config/config.go`, add after existing defaults in `applyDefaultsWithSource()`:
+
+```go
+if cfg.ThreatFeeds.Action == "" {
+	cfg.ThreatFeeds.Action = "deny"
+}
+if cfg.ThreatFeeds.SyncInterval == 0 {
+	cfg.ThreatFeeds.SyncInterval = 6 * time.Hour
+}
+if cfg.ThreatFeeds.Realtime.Timeout == 0 {
+	cfg.ThreatFeeds.Realtime.Timeout = 500 * time.Millisecond
+}
+if cfg.ThreatFeeds.Realtime.CacheTTL == 0 {
+	cfg.ThreatFeeds.Realtime.CacheTTL = 1 * time.Hour
+}
+if cfg.ThreatFeeds.Realtime.OnTimeout == "" {
+	cfg.ThreatFeeds.Realtime.OnTimeout = "local-only"
+}
+```
+
+**Step 4: Verify build**
+
+Run: `go build ./...`
+Expected: clean build
+
+**Step 5: Commit**
+
+```
+feat(config): add ThreatFeedsConfig for threat intelligence feeds
+```
+
+---
+
+### Task 2: Implement parsers with tests
+
+Create the `Parser` interface and two implementations: `HostfileParser` and `DomainListParser`.
+
+**Files:**
+- Create: `internal/threatfeed/parser.go`
+- Create: `internal/threatfeed/parser_test.go`
+
+**Step 1: Write the failing tests**
+
+Create `internal/threatfeed/parser_test.go`:
+
+```go
+package threatfeed
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostfileParser_Standard(t *testing.T) {
+	input := `# comment line
+127.0.0.1 localhost
+0.0.0.0 malware.example.com
+127.0.0.1 phishing.bad.org  # trailing comment
+`
+	p := &HostfileParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"malware.example.com", "phishing.bad.org"}, domains)
+}
+
+func TestHostfileParser_SkipsLocalhost(t *testing.T) {
+	input := "127.0.0.1 localhost\n0.0.0.0 localhost\n0.0.0.0 evil.com\n"
+	p := &HostfileParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evil.com"}, domains)
+}
+
+func TestHostfileParser_Deduplicates(t *testing.T) {
+	input := "0.0.0.0 evil.com\n127.0.0.1 evil.com\n0.0.0.0 EVIL.COM\n"
+	p := &HostfileParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evil.com"}, domains)
+}
+
+func TestHostfileParser_EmptyInput(t *testing.T) {
+	p := &HostfileParser{}
+	domains, err := p.Parse(strings.NewReader(""))
+	require.NoError(t, err)
+	assert.Empty(t, domains)
+}
+
+func TestHostfileParser_CommentsOnly(t *testing.T) {
+	input := "# This is a comment\n# Another comment\n"
+	p := &HostfileParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Empty(t, domains)
+}
+
+func TestDomainListParser_Standard(t *testing.T) {
+	input := `# Phishing domains
+evil.com
+bad.org
+
+UPPER.NET
+`
+	p := &DomainListParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evil.com", "bad.org", "upper.net"}, domains)
+}
+
+func TestDomainListParser_Deduplicates(t *testing.T) {
+	input := "evil.com\nevil.com\nEVIL.COM\n"
+	p := &DomainListParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evil.com"}, domains)
+}
+
+func TestDomainListParser_EmptyInput(t *testing.T) {
+	p := &DomainListParser{}
+	domains, err := p.Parse(strings.NewReader(""))
+	require.NoError(t, err)
+	assert.Empty(t, domains)
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/threatfeed/ -v`
+Expected: compilation failure — package doesn't exist yet
+
+**Step 3: Implement the parsers**
+
+Create `internal/threatfeed/parser.go`:
+
+```go
+package threatfeed
+
+import (
+	"bufio"
+	"io"
+	"sort"
+	"strings"
+)
+
+// Parser extracts domain names from a threat feed format.
+type Parser interface {
+	Parse(r io.Reader) ([]string, error)
+}
+
+// HostfileParser parses hosts-file format: "127.0.0.1 domain" or "0.0.0.0 domain".
+type HostfileParser struct{}
+
+func (p *HostfileParser) Parse(r io.Reader) ([]string, error) {
+	seen := make(map[string]struct{})
+	var domains []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// Strip trailing comments.
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			line = strings.TrimSpace(line[:idx])
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		domain := strings.ToLower(fields[1])
+		if domain == "localhost" || domain == "localhost.localdomain" ||
+			domain == "broadcasthost" || domain == "local" {
+			continue
+		}
+		if _, ok := seen[domain]; ok {
+			continue
+		}
+		seen[domain] = struct{}{}
+		domains = append(domains, domain)
+	}
+	return domains, scanner.Err()
+}
+
+// DomainListParser parses one-domain-per-line format.
+type DomainListParser struct{}
+
+func (p *DomainListParser) Parse(r io.Reader) ([]string, error) {
+	seen := make(map[string]struct{})
+	var domains []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		domain := strings.ToLower(line)
+		if _, ok := seen[domain]; ok {
+			continue
+		}
+		seen[domain] = struct{}{}
+		domains = append(domains, domain)
+	}
+	return domains, scanner.Err()
+}
+
+// ParserForFormat returns the appropriate parser for a feed format string.
+func ParserForFormat(format string) Parser {
+	switch strings.ToLower(format) {
+	case "hostfile":
+		return &HostfileParser{}
+	case "domain-list":
+		return &DomainListParser{}
+	default:
+		return &DomainListParser{}
+	}
+}
+
+// dedupSorted returns a sorted, deduplicated copy of the input.
+func dedupSorted(domains []string) []string {
+	if len(domains) == 0 {
+		return nil
+	}
+	sort.Strings(domains)
+	result := domains[:1]
+	for _, d := range domains[1:] {
+		if d != result[len(result)-1] {
+			result = append(result, d)
+		}
+	}
+	return result
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/threatfeed/ -v`
+Expected: all PASS
+
+**Step 5: Commit**
+
+```
+feat(threatfeed): add hostfile and domain-list parsers
+```
+
+---
+
+### Task 3: Implement the store with tests
+
+Create the thread-safe in-memory domain store with disk cache persistence.
+
+**Files:**
+- Create: `internal/threatfeed/store.go`
+- Create: `internal/threatfeed/store_test.go`
+
+**Step 1: Write the failing tests**
+
+Create `internal/threatfeed/store_test.go`:
+
+```go
+package threatfeed
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore_ExactMatch(t *testing.T) {
+	s := NewStore("", nil)
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	entry, matched := s.Check("evil.com")
+	assert.True(t, matched)
+	assert.Equal(t, "urlhaus", entry.FeedName)
+}
+
+func TestStore_NoMatch(t *testing.T) {
+	s := NewStore("", nil)
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	_, matched := s.Check("safe.com")
+	assert.False(t, matched)
+}
+
+func TestStore_ParentDomainMatch(t *testing.T) {
+	s := NewStore("", nil)
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	entry, matched := s.Check("sub.evil.com")
+	assert.True(t, matched)
+	assert.Equal(t, "evil.com", entry.MatchedDomain)
+}
+
+func TestStore_DeepSubdomainMatch(t *testing.T) {
+	s := NewStore("", nil)
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	entry, matched := s.Check("a.b.c.evil.com")
+	assert.True(t, matched)
+	assert.Equal(t, "evil.com", entry.MatchedDomain)
+}
+
+func TestStore_AllowlistOverride(t *testing.T) {
+	s := NewStore("", []string{"legit.evil.com"})
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	_, matched := s.Check("legit.evil.com")
+	assert.False(t, matched, "allowlisted domain should not match")
+
+	// Non-allowlisted subdomain still matches via parent.
+	_, matched = s.Check("other.evil.com")
+	assert.True(t, matched)
+}
+
+func TestStore_CaseInsensitive(t *testing.T) {
+	s := NewStore("", nil)
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	_, matched := s.Check("EVIL.COM")
+	assert.True(t, matched)
+}
+
+func TestStore_EmptyStore(t *testing.T) {
+	s := NewStore("", nil)
+	_, matched := s.Check("anything.com")
+	assert.False(t, matched)
+}
+
+func TestStore_AtomicUpdate(t *testing.T) {
+	s := NewStore("", nil)
+	s.Update(map[string]FeedEntry{
+		"old.com": {FeedName: "feed1", AddedAt: time.Now()},
+	})
+	s.Update(map[string]FeedEntry{
+		"new.com": {FeedName: "feed2", AddedAt: time.Now()},
+	})
+	_, matched := s.Check("old.com")
+	assert.False(t, matched, "old entries should be gone after update")
+	_, matched = s.Check("new.com")
+	assert.True(t, matched)
+}
+
+func TestStore_ConcurrentAccess(t *testing.T) {
+	s := NewStore("", nil)
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			s.Check("evil.com")
+		}()
+		go func() {
+			defer wg.Done()
+			s.Update(map[string]FeedEntry{
+				"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+			})
+		}()
+	}
+	wg.Wait()
+}
+
+func TestStore_DiskRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s1 := NewStore(dir, []string{"safe.com"})
+	s1.Update(map[string]FeedEntry{
+		"evil.com":    {FeedName: "urlhaus", AddedAt: time.Now()},
+		"phishing.io": {FeedName: "phishdb", AddedAt: time.Now()},
+	})
+	err := s1.SaveToDisk()
+	require.NoError(t, err)
+
+	// Verify cache file exists.
+	_, err = os.Stat(filepath.Join(dir, "feeds.cache"))
+	require.NoError(t, err)
+
+	// Load into fresh store.
+	s2 := NewStore(dir, []string{"safe.com"})
+	err = s2.LoadFromDisk()
+	require.NoError(t, err)
+
+	entry, matched := s2.Check("evil.com")
+	assert.True(t, matched)
+	assert.Equal(t, "urlhaus", entry.FeedName)
+
+	entry, matched = s2.Check("phishing.io")
+	assert.True(t, matched)
+	assert.Equal(t, "phishdb", entry.FeedName)
+}
+
+func TestStore_LoadFromDisk_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir, nil)
+	err := s.LoadFromDisk()
+	assert.NoError(t, err, "missing cache file should not be an error")
+}
+
+func TestStore_Size(t *testing.T) {
+	s := NewStore("", nil)
+	assert.Equal(t, 0, s.Size())
+	s.Update(map[string]FeedEntry{
+		"a.com": {FeedName: "f1", AddedAt: time.Now()},
+		"b.com": {FeedName: "f2", AddedAt: time.Now()},
+	})
+	assert.Equal(t, 2, s.Size())
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/threatfeed/ -v -run TestStore`
+Expected: compilation failure — `Store`, `FeedEntry`, `NewStore` not defined
+
+**Step 3: Implement the store**
+
+Create `internal/threatfeed/store.go`:
+
+```go
+package threatfeed
+
+import (
+	"encoding/gob"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// FeedEntry records which feed flagged a domain and when.
+type FeedEntry struct {
+	FeedName      string
+	AddedAt       time.Time
+	MatchedDomain string // set by Check() — the actual domain that matched
+}
+
+// Store is a thread-safe in-memory set of blocked domains with disk persistence.
+type Store struct {
+	mu        sync.RWMutex
+	domains   map[string]FeedEntry
+	allowlist map[string]struct{}
+	cacheDir  string
+}
+
+// NewStore creates a new threat feed store.
+// cacheDir is the directory for disk persistence (empty string disables persistence).
+// allowlist is a list of domains that should never be blocked.
+func NewStore(cacheDir string, allowlist []string) *Store {
+	al := make(map[string]struct{}, len(allowlist))
+	for _, d := range allowlist {
+		al[strings.ToLower(d)] = struct{}{}
+	}
+	return &Store{
+		domains:   make(map[string]FeedEntry),
+		allowlist: al,
+		cacheDir:  cacheDir,
+	}
+}
+
+// Check returns the matching FeedEntry if the domain (or a parent domain) is in
+// the threat feed store and not in the allowlist.
+func (s *Store) Check(domain string) (FeedEntry, bool) {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	if domain == "" {
+		return FeedEntry{}, false
+	}
+
+	// Check allowlist first (exact match).
+	if _, ok := s.allowlist[domain]; ok {
+		return FeedEntry{}, false
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Exact match.
+	if entry, ok := s.domains[domain]; ok {
+		entry.MatchedDomain = domain
+		return entry, true
+	}
+
+	// Walk parent domains: sub.evil.com → evil.com → com
+	d := domain
+	for {
+		idx := strings.Index(d, ".")
+		if idx < 0 {
+			break
+		}
+		d = d[idx+1:]
+		if d == "" {
+			break
+		}
+		// Don't match bare TLDs.
+		if !strings.Contains(d, ".") {
+			break
+		}
+		if _, ok := s.allowlist[domain]; ok {
+			return FeedEntry{}, false
+		}
+		if entry, ok := s.domains[d]; ok {
+			entry.MatchedDomain = d
+			return entry, true
+		}
+	}
+
+	return FeedEntry{}, false
+}
+
+// Update atomically replaces the entire domain set.
+func (s *Store) Update(domains map[string]FeedEntry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.domains = domains
+}
+
+// Size returns the number of domains in the store.
+func (s *Store) Size() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.domains)
+}
+
+// diskCache is the serializable form persisted to disk.
+type diskCache struct {
+	Domains map[string]FeedEntry
+}
+
+const cacheFileName = "feeds.cache"
+
+// SaveToDisk persists the current domain set to a gob-encoded file.
+func (s *Store) SaveToDisk() error {
+	if s.cacheDir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(s.cacheDir, 0o755); err != nil {
+		return err
+	}
+
+	s.mu.RLock()
+	cache := diskCache{Domains: s.domains}
+	s.mu.RUnlock()
+
+	path := filepath.Join(s.cacheDir, cacheFileName)
+	tmp := path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	if err := gob.NewEncoder(f).Encode(&cache); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// LoadFromDisk loads a previously persisted domain set from disk.
+// Returns nil if the cache file does not exist.
+func (s *Store) LoadFromDisk() error {
+	if s.cacheDir == "" {
+		return nil
+	}
+	path := filepath.Join(s.cacheDir, cacheFileName)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	var cache diskCache
+	if err := gob.NewDecoder(f).Decode(&cache); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.domains = cache.Domains
+	s.mu.Unlock()
+	return nil
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/threatfeed/ -v -run TestStore -race`
+Expected: all PASS (the `-race` flag validates concurrent access safety)
+
+**Step 5: Commit**
+
+```
+feat(threatfeed): add thread-safe domain store with disk cache
+```
+
+---
+
+### Task 4: Implement the syncer with tests
+
+Create the background syncer that periodically downloads feeds and updates the store.
+
+**Files:**
+- Create: `internal/threatfeed/syncer.go`
+- Create: `internal/threatfeed/syncer_test.go`
+
+**Step 1: Write the failing tests**
+
+Create `internal/threatfeed/syncer_test.go`:
+
+```go
+package threatfeed
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+func TestSyncer_FetchesAndPopulatesStore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "0.0.0.0 evil.com")
+		fmt.Fprintln(w, "0.0.0.0 bad.org")
+	}))
+	defer srv.Close()
+
+	store := NewStore("", nil)
+	cfg := config.ThreatFeedsConfig{
+		Feeds: []config.ThreatFeedEntry{
+			{Name: "test-feed", URL: srv.URL, Format: "hostfile"},
+		},
+		SyncInterval: time.Hour, // won't tick in this test
+	}
+	syncer := NewSyncer(store, cfg, nil)
+	syncer.syncAll()
+
+	assert.Equal(t, 2, store.Size())
+	_, matched := store.Check("evil.com")
+	assert.True(t, matched)
+	_, matched = store.Check("bad.org")
+	assert.True(t, matched)
+}
+
+func TestSyncer_DomainListFormat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "# comment")
+		fmt.Fprintln(w, "phish.net")
+	}))
+	defer srv.Close()
+
+	store := NewStore("", nil)
+	cfg := config.ThreatFeedsConfig{
+		Feeds: []config.ThreatFeedEntry{
+			{Name: "phish", URL: srv.URL, Format: "domain-list"},
+		},
+		SyncInterval: time.Hour,
+	}
+	syncer := NewSyncer(store, cfg, nil)
+	syncer.syncAll()
+
+	_, matched := store.Check("phish.net")
+	assert.True(t, matched)
+}
+
+func TestSyncer_MergesMultipleFeeds(t *testing.T) {
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "0.0.0.0 evil.com")
+	}))
+	defer srv1.Close()
+
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "phish.net")
+	}))
+	defer srv2.Close()
+
+	store := NewStore("", nil)
+	cfg := config.ThreatFeedsConfig{
+		Feeds: []config.ThreatFeedEntry{
+			{Name: "feed1", URL: srv1.URL, Format: "hostfile"},
+			{Name: "feed2", URL: srv2.URL, Format: "domain-list"},
+		},
+		SyncInterval: time.Hour,
+	}
+	syncer := NewSyncer(store, cfg, nil)
+	syncer.syncAll()
+
+	assert.Equal(t, 2, store.Size())
+}
+
+func TestSyncer_FetchFailureKeepsPreviousData(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			fmt.Fprintln(w, "0.0.0.0 evil.com")
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	store := NewStore("", nil)
+	cfg := config.ThreatFeedsConfig{
+		Feeds: []config.ThreatFeedEntry{
+			{Name: "flaky", URL: srv.URL, Format: "hostfile"},
+		},
+		SyncInterval: time.Hour,
+	}
+	syncer := NewSyncer(store, cfg, nil)
+
+	syncer.syncAll()
+	assert.Equal(t, 1, store.Size())
+
+	// Second sync fails — store should keep previous data.
+	syncer.syncAll()
+	assert.Equal(t, 1, store.Size())
+	_, matched := store.Check("evil.com")
+	assert.True(t, matched)
+}
+
+func TestSyncer_LocalListFile(t *testing.T) {
+	dir := t.TempDir()
+	listPath := filepath.Join(dir, "custom.txt")
+	err := os.WriteFile(listPath, []byte("custom-bad.com\n"), 0o644)
+	require.NoError(t, err)
+
+	store := NewStore("", nil)
+	cfg := config.ThreatFeedsConfig{
+		LocalLists:   []string{listPath},
+		SyncInterval: time.Hour,
+	}
+	syncer := NewSyncer(store, cfg, nil)
+	syncer.syncAll()
+
+	_, matched := store.Check("custom-bad.com")
+	assert.True(t, matched)
+}
+
+func TestSyncer_RunRespectsContextCancellation(t *testing.T) {
+	store := NewStore("", nil)
+	cfg := config.ThreatFeedsConfig{
+		SyncInterval: time.Hour,
+	}
+	syncer := NewSyncer(store, cfg, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		syncer.Run(ctx)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+		// success
+	case <-time.After(2 * time.Second):
+		t.Fatal("syncer did not stop after context cancellation")
+	}
+}
+
+func TestSyncer_SavesToDiskOnShutdown(t *testing.T) {
+	dir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "0.0.0.0 evil.com")
+	}))
+	defer srv.Close()
+
+	store := NewStore(dir, nil)
+	cfg := config.ThreatFeedsConfig{
+		Feeds: []config.ThreatFeedEntry{
+			{Name: "test", URL: srv.URL, Format: "hostfile"},
+		},
+		SyncInterval: time.Hour,
+	}
+	syncer := NewSyncer(store, cfg, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		syncer.Run(ctx)
+		close(done)
+	}()
+
+	// Wait for initial sync, then cancel.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-done
+
+	// Verify disk cache was written.
+	_, err := os.Stat(filepath.Join(dir, "feeds.cache"))
+	assert.NoError(t, err)
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/threatfeed/ -v -run TestSyncer`
+Expected: compilation failure — `Syncer`, `NewSyncer` not defined
+
+**Step 3: Implement the syncer**
+
+Create `internal/threatfeed/syncer.go`:
+
+```go
+package threatfeed
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+// Syncer periodically downloads threat feeds and updates the store.
+type Syncer struct {
+	store    *Store
+	feeds    []config.ThreatFeedEntry
+	locals   []string
+	interval time.Duration
+	client   *http.Client
+	logger   *slog.Logger
+	etags    map[string]string // feed URL → last ETag
+}
+
+// NewSyncer creates a new feed syncer. Pass nil for logger to disable logging.
+func NewSyncer(store *Store, cfg config.ThreatFeedsConfig, logger *slog.Logger) *Syncer {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &Syncer{
+		store:    store,
+		feeds:    cfg.Feeds,
+		locals:   cfg.LocalLists,
+		interval: cfg.SyncInterval,
+		client:   &http.Client{Timeout: 30 * time.Second},
+		logger:   logger,
+		etags:    make(map[string]string),
+	}
+}
+
+// Run starts the periodic sync loop. It blocks until ctx is cancelled.
+func (s *Syncer) Run(ctx context.Context) {
+	s.syncAll()
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			s.store.SaveToDisk()
+			return
+		case <-ticker.C:
+			s.syncAll()
+		}
+	}
+}
+
+// syncAll fetches all feeds and local lists, merges results, and updates the store.
+func (s *Syncer) syncAll() {
+	merged := make(map[string]FeedEntry)
+	allFailed := true
+
+	for _, feed := range s.feeds {
+		domains, err := s.fetchFeed(feed)
+		if err != nil {
+			s.logger.Warn("threat feed fetch failed",
+				"feed", feed.Name, "url", feed.URL, "error", err)
+			continue
+		}
+		allFailed = false
+		now := time.Now()
+		for _, d := range domains {
+			if _, exists := merged[d]; !exists {
+				merged[d] = FeedEntry{FeedName: feed.Name, AddedAt: now}
+			}
+		}
+		s.logger.Info("threat feed synced",
+			"feed", feed.Name, "domains", len(domains))
+	}
+
+	for _, path := range s.locals {
+		domains, err := s.parseLocalFile(path)
+		if err != nil {
+			s.logger.Warn("local threat list failed",
+				"path", path, "error", err)
+			continue
+		}
+		allFailed = false
+		now := time.Now()
+		for _, d := range domains {
+			if _, exists := merged[d]; !exists {
+				merged[d] = FeedEntry{FeedName: "local:" + path, AddedAt: now}
+			}
+		}
+	}
+
+	// Only update if at least one source succeeded, to avoid wiping the store
+	// when all sources are temporarily down.
+	if !allFailed || (len(s.feeds) == 0 && len(s.locals) == 0) {
+		s.store.Update(merged)
+		s.store.SaveToDisk()
+	}
+}
+
+func (s *Syncer) fetchFeed(feed config.ThreatFeedEntry) ([]string, error) {
+	req, err := http.NewRequest("GET", feed.URL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if etag, ok := s.etags[feed.URL]; ok {
+		req.Header.Set("If-None-Match", etag)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotModified {
+		return nil, nil // no changes
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	if etag := resp.Header.Get("ETag"); etag != "" {
+		s.etags[feed.URL] = etag
+	}
+
+	parser := ParserForFormat(feed.Format)
+	return parser.Parse(resp.Body)
+}
+
+func (s *Syncer) parseLocalFile(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	p := &DomainListParser{}
+	return p.Parse(f)
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/threatfeed/ -v -run TestSyncer -race`
+Expected: all PASS
+
+**Step 5: Commit**
+
+```
+feat(threatfeed): add background syncer with periodic feed refresh
+```
+
+---
+
+### Task 5: Integrate threat store into the policy engine
+
+Add the threat feed pre-check to `CheckNetworkCtx()` using a setter method on Engine.
+
+**Files:**
+- Modify: `internal/policy/engine.go:17-37` (add fields to Engine struct)
+- Modify: `internal/policy/engine.go:695-769` (add pre-check in CheckNetworkCtx)
+- Create: `internal/policy/engine_threat_test.go`
+
+**Step 1: Write the failing tests**
+
+Create `internal/policy/engine_threat_test.go`:
+
+```go
+package policy
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentsh/agentsh/internal/threatfeed"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+func TestCheckNetworkCtx_ThreatFeedDeny(t *testing.T) {
+	p := &Policy{Version: 1, Name: "test", NetworkRules: []NetworkRule{
+		{Name: "allow-all", Domains: []string{"*"}, Decision: "allow"},
+	}}
+	e, err := NewEngine(p, false)
+	require.NoError(t, err)
+
+	store := threatfeed.NewStore("", nil)
+	store.Update(map[string]threatfeed.FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	e.SetThreatStore(store, "deny")
+
+	dec := e.CheckNetworkCtx(context.Background(), "evil.com", 443)
+	assert.Equal(t, types.DecisionDeny, dec.EffectiveDecision)
+	assert.Equal(t, "threat-feed:urlhaus", dec.Rule)
+}
+
+func TestCheckNetworkCtx_ThreatFeedAudit(t *testing.T) {
+	p := &Policy{Version: 1, Name: "test", NetworkRules: []NetworkRule{
+		{Name: "allow-all", Domains: []string{"*"}, Decision: "allow"},
+	}}
+	e, err := NewEngine(p, false)
+	require.NoError(t, err)
+
+	store := threatfeed.NewStore("", nil)
+	store.Update(map[string]threatfeed.FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	e.SetThreatStore(store, "audit")
+
+	dec := e.CheckNetworkCtx(context.Background(), "evil.com", 443)
+	assert.Equal(t, types.DecisionAudit, dec.PolicyDecision)
+	// Audit = allow effective (log but don't block).
+	assert.Equal(t, types.DecisionAllow, dec.EffectiveDecision)
+	assert.Equal(t, "threat-feed:urlhaus", dec.Rule)
+}
+
+func TestCheckNetworkCtx_ThreatFeedNoMatchFallsThrough(t *testing.T) {
+	p := &Policy{Version: 1, Name: "test", NetworkRules: []NetworkRule{
+		{Name: "deny-bad", Domains: []string{"bad.org"}, Decision: "deny"},
+		{Name: "allow-all", Domains: []string{"*"}, Decision: "allow"},
+	}}
+	e, err := NewEngine(p, false)
+	require.NoError(t, err)
+
+	store := threatfeed.NewStore("", nil)
+	store.Update(map[string]threatfeed.FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	e.SetThreatStore(store, "deny")
+
+	// safe.com not in threat feed → falls through to network_rules → allow-all.
+	dec := e.CheckNetworkCtx(context.Background(), "safe.com", 443)
+	assert.Equal(t, types.DecisionAllow, dec.EffectiveDecision)
+	assert.Equal(t, "allow-all", dec.Rule)
+}
+
+func TestCheckNetworkCtx_NilThreatStoreSkipsCheck(t *testing.T) {
+	p := &Policy{Version: 1, Name: "test", NetworkRules: []NetworkRule{
+		{Name: "allow-all", Domains: []string{"*"}, Decision: "allow"},
+	}}
+	e, err := NewEngine(p, false)
+	require.NoError(t, err)
+	// No SetThreatStore call — threatStore is nil.
+
+	dec := e.CheckNetworkCtx(context.Background(), "evil.com", 443)
+	assert.Equal(t, types.DecisionAllow, dec.EffectiveDecision)
+	assert.Equal(t, "allow-all", dec.Rule)
+}
+
+func TestCheckNetworkCtx_ThreatFeedParentDomainMatch(t *testing.T) {
+	p := &Policy{Version: 1, Name: "test", NetworkRules: []NetworkRule{
+		{Name: "allow-all", Domains: []string{"*"}, Decision: "allow"},
+	}}
+	e, err := NewEngine(p, false)
+	require.NoError(t, err)
+
+	store := threatfeed.NewStore("", nil)
+	store.Update(map[string]threatfeed.FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	e.SetThreatStore(store, "deny")
+
+	dec := e.CheckNetworkCtx(context.Background(), "sub.evil.com", 443)
+	assert.Equal(t, types.DecisionDeny, dec.EffectiveDecision)
+	assert.Equal(t, "threat-feed:urlhaus", dec.Rule)
+	assert.Contains(t, dec.Message, "evil.com")
+}
+
+func TestCheckNetworkCtx_ThreatFeedFields(t *testing.T) {
+	p := &Policy{Version: 1, Name: "test", NetworkRules: []NetworkRule{
+		{Name: "allow-all", Domains: []string{"*"}, Decision: "allow"},
+	}}
+	e, err := NewEngine(p, false)
+	require.NoError(t, err)
+
+	store := threatfeed.NewStore("", nil)
+	store.Update(map[string]threatfeed.FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	e.SetThreatStore(store, "deny")
+
+	dec := e.CheckNetworkCtx(context.Background(), "sub.evil.com", 443)
+	assert.Equal(t, "urlhaus", dec.ThreatFeed)
+	assert.Equal(t, "evil.com", dec.ThreatMatch)
+}
+```
+
+**Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/policy/ -v -run TestCheckNetworkCtx_Threat`
+Expected: compilation failure — `SetThreatStore`, `ThreatFeed`, `ThreatMatch` not defined
+
+**Step 3: Add threat fields to Decision and Engine structs**
+
+In `internal/policy/engine.go`, add fields to the `Engine` struct (after line 36):
+
+```go
+// Threat intelligence feed store (optional).
+threatStore  *threatfeed.Store
+threatAction string // "deny" or "audit"
+```
+
+Add import for `"github.com/agentsh/agentsh/internal/threatfeed"` at the top.
+
+Add the `SetThreatStore` method after `NewEngine`:
+
+```go
+// SetThreatStore configures an optional threat feed store for domain checking.
+// action should be "deny" or "audit".
+func (e *Engine) SetThreatStore(store *threatfeed.Store, action string) {
+	e.threatStore = store
+	e.threatAction = action
+}
+```
+
+Add fields to the `Decision` struct (after line 104):
+
+```go
+ThreatFeed  string // feed name that matched (empty if not a threat feed decision)
+ThreatMatch string // the actual domain that matched in the feed
+```
+
+**Step 4: Add the pre-check in CheckNetworkCtx**
+
+In `internal/policy/engine.go`, insert the threat feed check at line 697, after the domain normalization and before the lazy DNS resolver:
+
+```go
+// Threat feed pre-check: block known-malicious domains before evaluating rules.
+if e.threatStore != nil {
+	if entry, matched := e.threatStore.Check(domain); matched {
+		dec := e.wrapDecision(e.threatAction, "threat-feed:"+entry.FeedName,
+			"domain matched threat feed: "+entry.FeedName+" (matched: "+entry.MatchedDomain+")", nil)
+		dec.ThreatFeed = entry.FeedName
+		dec.ThreatMatch = entry.MatchedDomain
+		return dec
+	}
+}
+```
+
+**Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/policy/ -v -run TestCheckNetworkCtx_Threat -race`
+Expected: all PASS
+
+Also verify existing tests still pass:
+Run: `go test ./internal/policy/ -race`
+Expected: all PASS
+
+**Step 6: Commit**
+
+```
+feat(policy): integrate threat feed store into CheckNetworkCtx
+```
+
+---
+
+### Task 6: Wire threat feed into the server lifecycle
+
+Create the store in `server.New()`, pass it to the engine, and start the syncer in `server.Run()`.
+
+**Files:**
+- Modify: `internal/server/server.go:44-65` (add fields to Server struct)
+- Modify: `internal/server/server.go:87-102` (create store and configure engine in New)
+- Modify: `internal/server/server.go:599-641` (start syncer goroutine in Run)
+- Modify: `internal/server/server.go:643-672` (save to disk on shutdown)
+
+**Step 1: Add fields to Server struct**
+
+In `internal/server/server.go`, add after the existing fields (around line 63):
+
+```go
+threatSyncer *threatfeed.Syncer
+threatStore  *threatfeed.Store
+```
+
+Add import for `"github.com/agentsh/agentsh/internal/threatfeed"`.
+
+**Step 2: Create store and syncer in New()**
+
+In `internal/server/server.go`, insert after the engine is created (after line 102, before `limits := engine.Limits()`):
+
+```go
+// Threat feed store (optional).
+var threatStore *threatfeed.Store
+var threatSyncer *threatfeed.Syncer
+if cfg.ThreatFeeds.Enabled {
+	cacheDir := cfg.ThreatFeeds.CacheDir
+	if cacheDir == "" {
+		cacheDir = filepath.Join(config.GetDataDir(), "threat-feeds")
+	}
+	threatStore = threatfeed.NewStore(cacheDir, cfg.ThreatFeeds.Allowlist)
+	if err := threatStore.LoadFromDisk(); err != nil {
+		slog.Warn("threat feed cache load failed", "error", err)
+	} else if threatStore.Size() > 0 {
+		slog.Info("threat feed loaded from cache", "domains", threatStore.Size())
+	}
+	engine.SetThreatStore(threatStore, cfg.ThreatFeeds.Action)
+	threatSyncer = threatfeed.NewSyncer(threatStore, cfg.ThreatFeeds, slog.Default())
+}
+```
+
+**Step 3: Store references on Server struct**
+
+In the `srv := &Server{...}` block (around line 358), add:
+
+```go
+threatSyncer: threatSyncer,
+threatStore:  threatStore,
+```
+
+**Step 4: Start syncer goroutine in Run()**
+
+In `server.Run()`, insert after the session reaper goroutine (after line 619) and before `errCh`:
+
+```go
+// Start threat feed syncer.
+if s.threatSyncer != nil {
+	go s.threatSyncer.Run(ctx)
+}
+```
+
+The syncer's `Run()` already respects `ctx.Done()` and calls `SaveToDisk()` on exit, so no additional shutdown logic is needed — context cancellation at line 644 propagates to the syncer.
+
+**Step 5: Verify build**
+
+Run: `go build ./...`
+Expected: clean build
+
+Run: `go test ./... -short`
+Expected: all existing tests pass
+
+**Step 6: Commit**
+
+```
+feat(server): wire threat feed store and syncer into server lifecycle
+```
+
+---
+
+### Task 7: Define the Provider interface for future real-time tier
+
+Define the interface and types for the paid real-time API tier. No implementation — just the contract.
+
+**Files:**
+- Create: `internal/threatfeed/provider.go`
+
+**Step 1: Create the provider interface**
+
+Create `internal/threatfeed/provider.go`:
+
+```go
+package threatfeed
+
+import "context"
+
+// Provider defines the interface for real-time domain threat checking.
+// This is reserved for the paid tier (Web Risk API, VirusTotal, etc.)
+// and is not implemented in v1.
+type Provider interface {
+	// Check queries the provider for a domain's threat status.
+	Check(ctx context.Context, domain string) (ThreatResult, error)
+
+	// Name returns the provider's identifier (e.g., "webrisk", "virustotal").
+	Name() string
+}
+
+// ThreatResult holds the result of a real-time threat check.
+type ThreatResult struct {
+	Matched    bool
+	FeedName   string
+	ThreatType string // "malware", "phishing", "unwanted", etc.
+}
+```
+
+**Step 2: Verify build**
+
+Run: `go build ./...`
+Expected: clean build
+
+**Step 3: Commit**
+
+```
+feat(threatfeed): define Provider interface for future real-time tier
+```
+
+---
+
+## Key Files Reference
+
+| File | Role | Lines |
+|------|------|-------|
+| `internal/config/config.go` | Top-level Config struct | 13-33 (add field) |
+| `internal/config/config.go` | Default wiring | ~799 (add defaults) |
+| `internal/config/threatfeeds.go` | New: config types | — |
+| `internal/threatfeed/parser.go` | New: feed parsers | — |
+| `internal/threatfeed/store.go` | New: in-memory store + disk cache | — |
+| `internal/threatfeed/syncer.go` | New: background sync goroutine | — |
+| `internal/threatfeed/provider.go` | New: future real-time interface | — |
+| `internal/policy/engine.go` | Engine struct | 17-37 (add fields) |
+| `internal/policy/engine.go` | CheckNetworkCtx pre-check | 695-697 (insert) |
+| `internal/policy/engine.go` | Decision struct | 96-105 (add fields) |
+| `internal/server/server.go` | Server struct | 44-65 (add fields) |
+| `internal/server/server.go` | New() — create store | 99-102 (insert after) |
+| `internal/server/server.go` | Run() — start syncer | 619 (insert after) |
+
+## Task Summary
+
+| # | Task | Files | Depends On |
+|---|------|-------|------------|
+| 1 | Config structs | config/threatfeeds.go, config/config.go | — |
+| 2 | Parsers | threatfeed/parser.go, parser_test.go | — |
+| 3 | Store | threatfeed/store.go, store_test.go | — |
+| 4 | Syncer | threatfeed/syncer.go, syncer_test.go | 1, 2, 3 |
+| 5 | Policy engine integration | policy/engine.go, engine_threat_test.go | 3 |
+| 6 | Server wiring | server/server.go | 1, 3, 4, 5 |
+| 7 | Provider interface | threatfeed/provider.go | — |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1294,8 +1294,8 @@ func validateConfig(cfg *Config) error {
 			return fmt.Errorf("threat_feeds.feeds[%d].url must not be empty", i)
 		}
 		u, err := url.Parse(f.URL)
-		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
-			return fmt.Errorf("invalid threat_feeds.feeds[%d].url %q (must be http or https)", i, f.URL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			return fmt.Errorf("invalid threat_feeds.feeds[%d].url %q (must be http or https with a valid host)", i, f.URL)
 		}
 		switch f.Format {
 		case "hostfile", "domain-list":

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1277,5 +1277,29 @@ func validateConfig(cfg *Config) error {
 			return fmt.Errorf("invalid audit.otel.filter.min_risk_level %q", cfg.Audit.OTEL.Filter.MinRiskLevel)
 		}
 	}
+	// Validate threat_feeds config
+	if cfg.ThreatFeeds.Action != "" {
+		switch cfg.ThreatFeeds.Action {
+		case "deny", "audit":
+		default:
+			return fmt.Errorf("invalid threat_feeds.action %q (must be \"deny\" or \"audit\")", cfg.ThreatFeeds.Action)
+		}
+	}
+	for i, f := range cfg.ThreatFeeds.Feeds {
+		if f.Format != "" {
+			switch f.Format {
+			case "hostfile", "domain-list":
+			default:
+				return fmt.Errorf("invalid threat_feeds.feeds[%d].format %q (must be \"hostfile\" or \"domain-list\")", i, f.Format)
+			}
+		}
+	}
+	if cfg.ThreatFeeds.Realtime.OnTimeout != "" {
+		switch cfg.ThreatFeeds.Realtime.OnTimeout {
+		case "local-only", "allow", "deny":
+		default:
+			return fmt.Errorf("invalid threat_feeds.realtime.on_timeout %q (must be \"local-only\", \"allow\", or \"deny\")", cfg.ThreatFeeds.Realtime.OnTimeout)
+		}
+	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1286,6 +1286,9 @@ func validateConfig(cfg *Config) error {
 		}
 	}
 	for i, f := range cfg.ThreatFeeds.Feeds {
+		if f.Name == "" {
+			return fmt.Errorf("threat_feeds.feeds[%d].name must not be empty", i)
+		}
 		if f.Format != "" {
 			switch f.Format {
 			case "hostfile", "domain-list":
@@ -1293,6 +1296,13 @@ func validateConfig(cfg *Config) error {
 				return fmt.Errorf("invalid threat_feeds.feeds[%d].format %q (must be \"hostfile\" or \"domain-list\")", i, f.Format)
 			}
 		}
+	}
+	feedNames := make(map[string]struct{}, len(cfg.ThreatFeeds.Feeds))
+	for i, f := range cfg.ThreatFeeds.Feeds {
+		if _, dup := feedNames[f.Name]; dup {
+			return fmt.Errorf("duplicate threat_feeds.feeds name %q at index %d", f.Name, i)
+		}
+		feedNames[f.Name] = struct{}{}
 	}
 	if cfg.ThreatFeeds.Realtime.OnTimeout != "" {
 		switch cfg.ThreatFeeds.Realtime.OnTimeout {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -1288,6 +1289,13 @@ func validateConfig(cfg *Config) error {
 	for i, f := range cfg.ThreatFeeds.Feeds {
 		if f.Name == "" {
 			return fmt.Errorf("threat_feeds.feeds[%d].name must not be empty", i)
+		}
+		if f.URL == "" {
+			return fmt.Errorf("threat_feeds.feeds[%d].url must not be empty", i)
+		}
+		u, err := url.Parse(f.URL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			return fmt.Errorf("invalid threat_feeds.feeds[%d].url %q (must be http or https)", i, f.URL)
 		}
 		switch f.Format {
 		case "hostfile", "domain-list":

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	Security          SecurityConfig          `yaml:"security"`
 	Landlock          LandlockConfig          `yaml:"landlock"`
 	LinuxCapabilities CapabilitiesConfig      `yaml:"capabilities"`
+	ThreatFeeds       ThreatFeedsConfig       `yaml:"threat_feeds"`
 }
 
 // PlatformConfig configures cross-platform selection and fallback behavior.
@@ -1149,6 +1150,23 @@ func applyDefaultsWithSource(cfg *Config, source ConfigSource, configPath string
 		// Only set default if not explicitly set
 		// Since we can't distinguish false from unset, default to true for new configs
 		cfg.Security.WarnDegraded = true
+	}
+
+	// Threat feeds defaults
+	if cfg.ThreatFeeds.Action == "" {
+		cfg.ThreatFeeds.Action = "deny"
+	}
+	if cfg.ThreatFeeds.SyncInterval == 0 {
+		cfg.ThreatFeeds.SyncInterval = 6 * time.Hour
+	}
+	if cfg.ThreatFeeds.Realtime.Timeout == 0 {
+		cfg.ThreatFeeds.Realtime.Timeout = 500 * time.Millisecond
+	}
+	if cfg.ThreatFeeds.Realtime.CacheTTL == 0 {
+		cfg.ThreatFeeds.Realtime.CacheTTL = 1 * time.Hour
+	}
+	if cfg.ThreatFeeds.Realtime.OnTimeout == "" {
+		cfg.ThreatFeeds.Realtime.OnTimeout = "local-only"
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1325,6 +1325,9 @@ func validateConfig(cfg *Config) error {
 		}
 		feedNames[f.Name] = struct{}{}
 	}
+	if cfg.ThreatFeeds.Realtime.Provider != "" {
+		return fmt.Errorf("threat_feeds.realtime.provider %q is not supported in this version", cfg.ThreatFeeds.Realtime.Provider)
+	}
 	if cfg.ThreatFeeds.Realtime.OnTimeout != "" {
 		switch cfg.ThreatFeeds.Realtime.OnTimeout {
 		case "local-only", "allow", "deny":

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1216,6 +1216,16 @@ func applyEnvOverrides(cfg *Config) {
 	}
 }
 
+// isSafeFeedName checks that a feed name contains only safe characters.
+func isSafeFeedName(name string) bool {
+	for _, c := range name {
+		if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '.' || c == '_' || c == '-') {
+			return false
+		}
+	}
+	return true
+}
+
 func validateConfig(cfg *Config) error {
 	switch cfg.Sandbox.FUSE.Audit.Mode {
 	case "monitor", "soft_block", "soft_delete", "strict":
@@ -1289,6 +1299,9 @@ func validateConfig(cfg *Config) error {
 	for i, f := range cfg.ThreatFeeds.Feeds {
 		if f.Name == "" {
 			return fmt.Errorf("threat_feeds.feeds[%d].name must not be empty", i)
+		}
+		if !isSafeFeedName(f.Name) {
+			return fmt.Errorf("invalid threat_feeds.feeds[%d].name %q (must match [A-Za-z0-9._-]+)", i, f.Name)
 		}
 		if f.URL == "" {
 			return fmt.Errorf("threat_feeds.feeds[%d].url must not be empty", i)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1289,12 +1289,12 @@ func validateConfig(cfg *Config) error {
 		if f.Name == "" {
 			return fmt.Errorf("threat_feeds.feeds[%d].name must not be empty", i)
 		}
-		if f.Format != "" {
-			switch f.Format {
-			case "hostfile", "domain-list":
-			default:
-				return fmt.Errorf("invalid threat_feeds.feeds[%d].format %q (must be \"hostfile\" or \"domain-list\")", i, f.Format)
-			}
+		switch f.Format {
+		case "hostfile", "domain-list":
+		case "":
+			return fmt.Errorf("threat_feeds.feeds[%d].format must not be empty (use \"hostfile\" or \"domain-list\")", i)
+		default:
+			return fmt.Errorf("invalid threat_feeds.feeds[%d].format %q (must be \"hostfile\" or \"domain-list\")", i, f.Format)
 		}
 	}
 	feedNames := make(map[string]struct{}, len(cfg.ThreatFeeds.Feeds))

--- a/internal/config/threatfeeds.go
+++ b/internal/config/threatfeeds.go
@@ -1,0 +1,31 @@
+package config
+
+import "time"
+
+// ThreatFeedsConfig configures external threat intelligence feed integration.
+type ThreatFeedsConfig struct {
+	Enabled      bool              `yaml:"enabled"`
+	Action       string            `yaml:"action"`
+	Feeds        []ThreatFeedEntry `yaml:"feeds"`
+	LocalLists   []string          `yaml:"local_lists"`
+	Allowlist    []string          `yaml:"allowlist"`
+	SyncInterval time.Duration     `yaml:"sync_interval"`
+	CacheDir     string            `yaml:"cache_dir"`
+	Realtime     RealtimeConfig    `yaml:"realtime"`
+}
+
+// ThreatFeedEntry defines a single remote threat feed.
+type ThreatFeedEntry struct {
+	Name   string `yaml:"name"`
+	URL    string `yaml:"url"`
+	Format string `yaml:"format"` // "hostfile" or "domain-list"
+}
+
+// RealtimeConfig defines the paid real-time API tier (reserved, not implemented in v1).
+type RealtimeConfig struct {
+	Provider  string        `yaml:"provider"`
+	APIKey    string        `yaml:"api_key"`
+	Timeout   time.Duration `yaml:"timeout"`
+	CacheTTL  time.Duration `yaml:"cache_ttl"`
+	OnTimeout string        `yaml:"on_timeout"`
+}

--- a/internal/config/threatfeeds_test.go
+++ b/internal/config/threatfeeds_test.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"testing"
+	"time"
+)
+
+func TestThreatFeedsDefaults(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+
+	if cfg.ThreatFeeds.Action != "deny" {
+		t.Errorf("expected default Action %q, got %q", "deny", cfg.ThreatFeeds.Action)
+	}
+	if cfg.ThreatFeeds.SyncInterval != 6*time.Hour {
+		t.Errorf("expected default SyncInterval %v, got %v", 6*time.Hour, cfg.ThreatFeeds.SyncInterval)
+	}
+	if cfg.ThreatFeeds.Realtime.Timeout != 500*time.Millisecond {
+		t.Errorf("expected default Realtime.Timeout %v, got %v", 500*time.Millisecond, cfg.ThreatFeeds.Realtime.Timeout)
+	}
+	if cfg.ThreatFeeds.Realtime.CacheTTL != 1*time.Hour {
+		t.Errorf("expected default Realtime.CacheTTL %v, got %v", 1*time.Hour, cfg.ThreatFeeds.Realtime.CacheTTL)
+	}
+	if cfg.ThreatFeeds.Realtime.OnTimeout != "local-only" {
+		t.Errorf("expected default Realtime.OnTimeout %q, got %q", "local-only", cfg.ThreatFeeds.Realtime.OnTimeout)
+	}
+}
+
+func TestThreatFeedsDefaultsNotOverridden(t *testing.T) {
+	cfg := &Config{}
+	cfg.ThreatFeeds.Action = "log"
+	cfg.ThreatFeeds.SyncInterval = 1 * time.Hour
+	cfg.ThreatFeeds.Realtime.Timeout = 200 * time.Millisecond
+	cfg.ThreatFeeds.Realtime.CacheTTL = 30 * time.Minute
+	cfg.ThreatFeeds.Realtime.OnTimeout = "allow"
+
+	applyDefaults(cfg)
+
+	if cfg.ThreatFeeds.Action != "log" {
+		t.Errorf("expected Action %q to not be overridden, got %q", "log", cfg.ThreatFeeds.Action)
+	}
+	if cfg.ThreatFeeds.SyncInterval != 1*time.Hour {
+		t.Errorf("expected SyncInterval %v to not be overridden, got %v", 1*time.Hour, cfg.ThreatFeeds.SyncInterval)
+	}
+	if cfg.ThreatFeeds.Realtime.Timeout != 200*time.Millisecond {
+		t.Errorf("expected Realtime.Timeout %v to not be overridden, got %v", 200*time.Millisecond, cfg.ThreatFeeds.Realtime.Timeout)
+	}
+	if cfg.ThreatFeeds.Realtime.CacheTTL != 30*time.Minute {
+		t.Errorf("expected Realtime.CacheTTL %v to not be overridden, got %v", 30*time.Minute, cfg.ThreatFeeds.Realtime.CacheTTL)
+	}
+	if cfg.ThreatFeeds.Realtime.OnTimeout != "allow" {
+		t.Errorf("expected Realtime.OnTimeout %q to not be overridden, got %q", "allow", cfg.ThreatFeeds.Realtime.OnTimeout)
+	}
+}
+
+func TestThreatFeedsConfigStruct(t *testing.T) {
+	cfg := ThreatFeedsConfig{
+		Enabled: true,
+		Action:  "deny",
+		Feeds: []ThreatFeedEntry{
+			{Name: "test", URL: "https://example.com/hosts", Format: "hostfile"},
+		},
+		LocalLists:   []string{"/etc/agentsh/blocklist.txt"},
+		Allowlist:     []string{"safe.example.com"},
+		SyncInterval:  6 * time.Hour,
+		CacheDir:      "/tmp/feeds",
+		Realtime: RealtimeConfig{
+			Provider:  "virustotal",
+			APIKey:    "test-key",
+			Timeout:   500 * time.Millisecond,
+			CacheTTL:  1 * time.Hour,
+			OnTimeout: "local-only",
+		},
+	}
+
+	if !cfg.Enabled {
+		t.Error("expected Enabled to be true")
+	}
+	if len(cfg.Feeds) != 1 {
+		t.Errorf("expected 1 feed entry, got %d", len(cfg.Feeds))
+	}
+	if cfg.Feeds[0].Format != "hostfile" {
+		t.Errorf("expected feed format %q, got %q", "hostfile", cfg.Feeds[0].Format)
+	}
+	if cfg.Realtime.Provider != "virustotal" {
+		t.Errorf("expected provider %q, got %q", "virustotal", cfg.Realtime.Provider)
+	}
+}

--- a/internal/config/threatfeeds_test.go
+++ b/internal/config/threatfeeds_test.go
@@ -86,3 +86,49 @@ func TestThreatFeedsConfigStruct(t *testing.T) {
 		t.Errorf("expected provider %q, got %q", "virustotal", cfg.Realtime.Provider)
 	}
 }
+
+func TestThreatFeedsValidation_InvalidAction(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.ThreatFeeds.Action = "typo"
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid threat_feeds.action")
+	}
+}
+
+func TestThreatFeedsValidation_InvalidFormat(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.ThreatFeeds.Feeds = []ThreatFeedEntry{
+		{Name: "test", URL: "https://example.com", Format: "csv"},
+	}
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid feed format")
+	}
+}
+
+func TestThreatFeedsValidation_InvalidOnTimeout(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.ThreatFeeds.Realtime.OnTimeout = "crash"
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid realtime.on_timeout")
+	}
+}
+
+func TestThreatFeedsValidation_ValidConfig(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.ThreatFeeds.Action = "audit"
+	cfg.ThreatFeeds.Feeds = []ThreatFeedEntry{
+		{Name: "test", URL: "https://example.com", Format: "domain-list"},
+	}
+	cfg.ThreatFeeds.Realtime.OnTimeout = "allow"
+	err := validateConfig(cfg)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}

--- a/internal/config/threatfeeds_test.go
+++ b/internal/config/threatfeeds_test.go
@@ -193,3 +193,15 @@ func TestThreatFeedsValidation_InvalidFeedURL(t *testing.T) {
 		t.Fatal("expected error for non-http(s) feed URL")
 	}
 }
+
+func TestThreatFeedsValidation_FeedURLMissingHost(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.ThreatFeeds.Feeds = []ThreatFeedEntry{
+		{Name: "test", URL: "https:///path", Format: "hostfile"},
+	}
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for feed URL with no host")
+	}
+}

--- a/internal/config/threatfeeds_test.go
+++ b/internal/config/threatfeeds_test.go
@@ -205,3 +205,27 @@ func TestThreatFeedsValidation_FeedURLMissingHost(t *testing.T) {
 		t.Fatal("expected error for feed URL with no host")
 	}
 }
+
+func TestThreatFeedsValidation_UnsafeFeedName(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.ThreatFeeds.Feeds = []ThreatFeedEntry{
+		{Name: "bad name!", URL: "https://example.com", Format: "hostfile"},
+	}
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for feed name with unsafe characters")
+	}
+}
+
+func TestThreatFeedsValidation_SafeFeedName(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.ThreatFeeds.Feeds = []ThreatFeedEntry{
+		{Name: "my-feed_v2.0", URL: "https://example.com", Format: "hostfile"},
+	}
+	err := validateConfig(cfg)
+	if err != nil {
+		t.Fatalf("expected no error for safe feed name, got: %v", err)
+	}
+}

--- a/internal/config/threatfeeds_test.go
+++ b/internal/config/threatfeeds_test.go
@@ -229,3 +229,13 @@ func TestThreatFeedsValidation_SafeFeedName(t *testing.T) {
 		t.Fatalf("expected no error for safe feed name, got: %v", err)
 	}
 }
+
+func TestThreatFeedsValidation_RealtimeProviderRejected(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.ThreatFeeds.Realtime.Provider = "virustotal"
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error when realtime.provider is set")
+	}
+}

--- a/internal/config/threatfeeds_test.go
+++ b/internal/config/threatfeeds_test.go
@@ -132,3 +132,28 @@ func TestThreatFeedsValidation_ValidConfig(t *testing.T) {
 		t.Fatalf("expected no error, got: %v", err)
 	}
 }
+
+func TestThreatFeedsValidation_DuplicateFeedNames(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.ThreatFeeds.Feeds = []ThreatFeedEntry{
+		{Name: "dup", URL: "https://a.com", Format: "hostfile"},
+		{Name: "dup", URL: "https://b.com", Format: "hostfile"},
+	}
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for duplicate feed names")
+	}
+}
+
+func TestThreatFeedsValidation_EmptyFeedName(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.ThreatFeeds.Feeds = []ThreatFeedEntry{
+		{Name: "", URL: "https://a.com", Format: "hostfile"},
+	}
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for empty feed name")
+	}
+}

--- a/internal/config/threatfeeds_test.go
+++ b/internal/config/threatfeeds_test.go
@@ -157,3 +157,15 @@ func TestThreatFeedsValidation_EmptyFeedName(t *testing.T) {
 		t.Fatal("expected error for empty feed name")
 	}
 }
+
+func TestThreatFeedsValidation_EmptyFeedFormat(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.ThreatFeeds.Feeds = []ThreatFeedEntry{
+		{Name: "test", URL: "https://a.com", Format: ""},
+	}
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for empty feed format")
+	}
+}

--- a/internal/config/threatfeeds_test.go
+++ b/internal/config/threatfeeds_test.go
@@ -169,3 +169,27 @@ func TestThreatFeedsValidation_EmptyFeedFormat(t *testing.T) {
 		t.Fatal("expected error for empty feed format")
 	}
 }
+
+func TestThreatFeedsValidation_EmptyFeedURL(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.ThreatFeeds.Feeds = []ThreatFeedEntry{
+		{Name: "test", URL: "", Format: "hostfile"},
+	}
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for empty feed URL")
+	}
+}
+
+func TestThreatFeedsValidation_InvalidFeedURL(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.ThreatFeeds.Feeds = []ThreatFeedEntry{
+		{Name: "test", URL: "ftp://example.com/list", Format: "hostfile"},
+	}
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for non-http(s) feed URL")
+	}
+}

--- a/internal/netmonitor/dns.go
+++ b/internal/netmonitor/dns.go
@@ -113,7 +113,9 @@ func (d *DNSInterceptor) handle(clientAddr net.Addr, query []byte) error {
 	// Default deny policies are typically intended for outbound TCP/UDP connects, not DNS lookups.
 	// If the only match is default-deny, treat DNS as monitor-only unless the policy explicitly matches port 53.
 	if dec.PolicyDecision == types.DecisionDeny && dec.Rule == "default-deny-network" {
-		dec = policy.Decision{PolicyDecision: types.DecisionAllow, EffectiveDecision: types.DecisionAllow, Rule: "dns-monitor-only"}
+		dec.PolicyDecision = types.DecisionAllow
+		dec.EffectiveDecision = types.DecisionAllow
+		dec.Rule = "dns-monitor-only"
 	}
 	dec = d.maybeApprove(ctx, commandID, dec, "dns", domain)
 
@@ -133,6 +135,9 @@ func (d *DNSInterceptor) handle(clientAddr net.Addr, query []byte) error {
 			Rule:              dec.Rule,
 			Message:           dec.Message,
 			Approval:          dec.Approval,
+			ThreatFeed:        dec.ThreatFeed,
+			ThreatMatch:       dec.ThreatMatch,
+			ThreatAction:      dec.ThreatAction,
 		},
 	}
 	if d.emit != nil {

--- a/internal/netmonitor/proxy.go
+++ b/internal/netmonitor/proxy.go
@@ -479,7 +479,9 @@ func (p *Proxy) resolveAndEmitDNS(ctx context.Context, commandID string, host st
 	dec := p.checkNetwork(ctx, host, 53)
 	// Mirror dns.go behavior: treat default deny as monitor-only unless explicitly matching DNS.
 	if dec.PolicyDecision == types.DecisionDeny && dec.Rule == "default-deny-network" {
-		dec = policy.Decision{PolicyDecision: types.DecisionAllow, EffectiveDecision: types.DecisionAllow, Rule: "dns-monitor-only"}
+		dec.PolicyDecision = types.DecisionAllow
+		dec.EffectiveDecision = types.DecisionAllow
+		dec.Rule = "dns-monitor-only"
 	}
 	dec = p.maybeApprove(ctx, commandID, dec, "dns", host)
 
@@ -501,6 +503,9 @@ func (p *Proxy) resolveAndEmitDNS(ctx context.Context, commandID string, host st
 				Rule:              dec.Rule,
 				Message:           dec.Message,
 				Approval:          dec.Approval,
+				ThreatFeed:        dec.ThreatFeed,
+				ThreatMatch:       dec.ThreatMatch,
+				ThreatAction:      dec.ThreatAction,
 			},
 		}
 		if err != nil {

--- a/internal/netmonitor/proxy.go
+++ b/internal/netmonitor/proxy.go
@@ -378,6 +378,9 @@ func (p *Proxy) emitNetEvent(ctx context.Context, evType string, commandID strin
 			Rule:              dec.Rule,
 			Message:           dec.Message,
 			Approval:          dec.Approval,
+			ThreatFeed:        dec.ThreatFeed,
+			ThreatMatch:       dec.ThreatMatch,
+			ThreatAction:      dec.ThreatAction,
 		},
 	}
 	return ev

--- a/internal/netmonitor/proxy_test.go
+++ b/internal/netmonitor/proxy_test.go
@@ -265,6 +265,58 @@ func TestMCPConnectionTaggingNoRegistry(t *testing.T) {
 	}
 }
 
+func TestProxyEmitNetEventThreatMetadata(t *testing.T) {
+	em := &stubEmitter{}
+	p := &Proxy{
+		sessionID: "test-session",
+		emit:      em,
+	}
+	dec := policy.Decision{
+		PolicyDecision:    types.DecisionDeny,
+		EffectiveDecision: types.DecisionDeny,
+		Rule:              "threat-feed:urlhaus",
+		ThreatFeed:        "urlhaus",
+		ThreatMatch:       "evil.com",
+		ThreatAction:      "deny",
+	}
+	ev := p.emitNetEvent(context.Background(), "net_connect", "cmd-1", "evil.com", "1.2.3.4:443", 443, dec, nil)
+	if ev.Policy == nil {
+		t.Fatal("expected Policy to be set")
+	}
+	if ev.Policy.ThreatFeed != "urlhaus" {
+		t.Errorf("expected ThreatFeed %q, got %q", "urlhaus", ev.Policy.ThreatFeed)
+	}
+	if ev.Policy.ThreatMatch != "evil.com" {
+		t.Errorf("expected ThreatMatch %q, got %q", "evil.com", ev.Policy.ThreatMatch)
+	}
+	if ev.Policy.ThreatAction != "deny" {
+		t.Errorf("expected ThreatAction %q, got %q", "deny", ev.Policy.ThreatAction)
+	}
+}
+
+func TestProxyEmitNetEventNoThreatMetadata(t *testing.T) {
+	em := &stubEmitter{}
+	p := &Proxy{
+		sessionID: "test-session",
+		emit:      em,
+	}
+	dec := policy.Decision{
+		PolicyDecision:    types.DecisionAllow,
+		EffectiveDecision: types.DecisionAllow,
+		Rule:              "allow-all",
+	}
+	ev := p.emitNetEvent(context.Background(), "net_connect", "cmd-1", "safe.com", "1.2.3.4:443", 443, dec, nil)
+	if ev.Policy == nil {
+		t.Fatal("expected Policy to be set")
+	}
+	if ev.Policy.ThreatFeed != "" {
+		t.Errorf("expected empty ThreatFeed, got %q", ev.Policy.ThreatFeed)
+	}
+	if ev.Policy.ThreatAction != "" {
+		t.Errorf("expected empty ThreatAction, got %q", ev.Policy.ThreatAction)
+	}
+}
+
 func TestMCPConnectionTaggingNilEmitter(t *testing.T) {
 	sess := newSessionWithRegistry(map[string]string{
 		"mcp.example.com:443": "test-server",

--- a/internal/netmonitor/transparent_tcp.go
+++ b/internal/netmonitor/transparent_tcp.go
@@ -195,6 +195,9 @@ func (t *TransparentTCP) netEvent(evType string, commandID string, domain string
 			Rule:              dec.Rule,
 			Message:           dec.Message,
 			Approval:          dec.Approval,
+			ThreatFeed:        dec.ThreatFeed,
+			ThreatMatch:       dec.ThreatMatch,
+			ThreatAction:      dec.ThreatAction,
 		},
 	}
 	return ev

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -755,9 +755,9 @@ func (e *Engine) CheckNetwork(domain string, port int) Decision {
 func (e *Engine) CheckNetworkCtx(ctx context.Context, domain string, port int) Decision {
 	domain = strings.ToLower(strings.TrimSpace(domain))
 
-	// Threat feed pre-check.
+	// Threat feed pre-check (skip for empty domain, consistent with CheckNetworkIP).
 	var threatResult *ThreatCheckResult
-	if e.threatStore != nil {
+	if e.threatStore != nil && domain != "" {
 		if entry, matched := e.threatStore.Check(domain); matched {
 			if e.threatAction == "deny" {
 				dec := e.wrapDecision("deny", "threat-feed:"+entry.FeedName,

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -120,6 +120,7 @@ type Decision struct {
 	EnvPolicy         ResolvedEnvPolicy
 	ThreatFeed        string
 	ThreatMatch       string
+	ThreatAction      string // "deny" or "audit" — set when a threat feed matched
 }
 
 func NewEngine(p *Policy, enforceApprovals bool) (*Engine, error) {
@@ -440,6 +441,7 @@ func (e *Engine) CheckNetworkIP(domain string, ip net.IP, port int) Decision {
 					"domain matched threat feed: "+result.FeedName+" (matched: "+result.MatchedDomain+")", nil)
 				dec.ThreatFeed = result.FeedName
 				dec.ThreatMatch = result.MatchedDomain
+				dec.ThreatAction = "deny"
 				return dec
 			}
 			// Audit mode: record threat metadata, continue normal rule evaluation.
@@ -496,6 +498,7 @@ func (e *Engine) CheckNetworkIP(domain string, ip net.IP, port int) Decision {
 		if threatResult != nil {
 			dec.ThreatFeed = threatResult.FeedName
 			dec.ThreatMatch = threatResult.MatchedDomain
+			dec.ThreatAction = "audit"
 		}
 		return dec
 	}
@@ -504,6 +507,7 @@ func (e *Engine) CheckNetworkIP(domain string, ip net.IP, port int) Decision {
 	if threatResult != nil {
 		dec.ThreatFeed = threatResult.FeedName
 		dec.ThreatMatch = threatResult.MatchedDomain
+		dec.ThreatAction = "audit"
 	}
 	return dec
 }
@@ -760,6 +764,7 @@ func (e *Engine) CheckNetworkCtx(ctx context.Context, domain string, port int) D
 					"domain matched threat feed: "+entry.FeedName+" (matched: "+entry.MatchedDomain+")", nil)
 				dec.ThreatFeed = entry.FeedName
 				dec.ThreatMatch = entry.MatchedDomain
+				dec.ThreatAction = "deny"
 				return dec
 			}
 			// Audit mode: record threat metadata, continue normal rule evaluation.
@@ -839,6 +844,7 @@ func (e *Engine) CheckNetworkCtx(ctx context.Context, domain string, port int) D
 		if threatResult != nil {
 			dec.ThreatFeed = threatResult.FeedName
 			dec.ThreatMatch = threatResult.MatchedDomain
+			dec.ThreatAction = "audit"
 		}
 		return dec
 	}
@@ -847,6 +853,7 @@ func (e *Engine) CheckNetworkCtx(ctx context.Context, domain string, port int) D
 	if threatResult != nil {
 		dec.ThreatFeed = threatResult.FeedName
 		dec.ThreatMatch = threatResult.MatchedDomain
+		dec.ThreatAction = "audit"
 	}
 	return dec
 }

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -21,7 +21,7 @@ type ThreatCheckResult struct {
 }
 
 // ThreatChecker is an optional interface for domain-level threat feed lookups.
-// *threatfeed.Store satisfies this interface.
+// threatfeed.PolicyAdapter satisfies this interface, bridging the Store to the policy engine.
 type ThreatChecker interface {
 	Check(domain string) (ThreatCheckResult, bool)
 }

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -334,9 +334,15 @@ func NewEngineWithVariables(p *Policy, enforceApprovals bool, vars map[string]st
 }
 
 // SetThreatStore configures an optional threat feed store for domain checking.
+// action must be "deny" or "audit"; defaults to "deny" if invalid.
 func (e *Engine) SetThreatStore(store ThreatChecker, action string) {
 	e.threatStore = store
-	e.threatAction = action
+	switch action {
+	case "deny", "audit":
+		e.threatAction = action
+	default:
+		e.threatAction = "deny"
+	}
 }
 
 // expandPolicy creates a copy of the policy with all variables expanded.

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -425,6 +425,17 @@ func (e *Engine) CheckNetworkIP(domain string, ip net.IP, port int) Decision {
 	}
 	domain = strings.ToLower(strings.TrimSpace(domain))
 
+	// Threat feed pre-check.
+	if e.threatStore != nil && domain != "" {
+		if result, matched := e.threatStore.Check(domain); matched {
+			dec := e.wrapDecision(e.threatAction, "threat-feed:"+result.FeedName,
+				"domain matched threat feed: "+result.FeedName+" (matched: "+result.MatchedDomain+")", nil)
+			dec.ThreatFeed = result.FeedName
+			dec.ThreatMatch = result.MatchedDomain
+			return dec
+		}
+	}
+
 	var ips []net.IP
 	if ip != nil {
 		ips = []net.IP{ip}

--- a/internal/policy/engine_threat_test.go
+++ b/internal/policy/engine_threat_test.go
@@ -70,6 +70,7 @@ func TestCheckNetworkCtx_ThreatFeedDeny(t *testing.T) {
 	dec := e.CheckNetworkCtx(context.Background(), "evil.com", 443)
 	assert.Equal(t, types.DecisionDeny, dec.EffectiveDecision)
 	assert.Equal(t, "threat-feed:urlhaus", dec.Rule)
+	assert.Equal(t, "deny", dec.ThreatAction)
 }
 
 func TestCheckNetworkCtx_ThreatFeedAudit(t *testing.T) {
@@ -91,6 +92,7 @@ func TestCheckNetworkCtx_ThreatFeedAudit(t *testing.T) {
 	assert.Equal(t, "allow-all", dec.Rule)
 	assert.Equal(t, "urlhaus", dec.ThreatFeed)
 	assert.Equal(t, "evil.com", dec.ThreatMatch)
+	assert.Equal(t, "audit", dec.ThreatAction)
 }
 
 func TestCheckNetworkCtx_ThreatFeedNoMatchFallsThrough(t *testing.T) {
@@ -109,6 +111,7 @@ func TestCheckNetworkCtx_ThreatFeedNoMatchFallsThrough(t *testing.T) {
 	dec := e.CheckNetworkCtx(context.Background(), "safe.com", 443)
 	assert.Equal(t, types.DecisionAllow, dec.EffectiveDecision)
 	assert.Equal(t, "allow-all", dec.Rule)
+	assert.Empty(t, dec.ThreatAction, "non-matching domain should have empty ThreatAction")
 }
 
 func TestCheckNetworkCtx_NilThreatStoreSkipsCheck(t *testing.T) {
@@ -156,6 +159,7 @@ func TestCheckNetworkCtx_ThreatFeedFields(t *testing.T) {
 	dec := e.CheckNetworkCtx(context.Background(), "sub.evil.com", 443)
 	assert.Equal(t, "urlhaus", dec.ThreatFeed)
 	assert.Equal(t, "evil.com", dec.ThreatMatch)
+	assert.Equal(t, "deny", dec.ThreatAction)
 }
 
 func TestCheckNetworkIP_ThreatFeedDeny(t *testing.T) {
@@ -173,6 +177,7 @@ func TestCheckNetworkIP_ThreatFeedDeny(t *testing.T) {
 	dec := e.CheckNetworkIP("evil.com", nil, 443)
 	assert.Equal(t, types.DecisionDeny, dec.EffectiveDecision)
 	assert.Equal(t, "threat-feed:urlhaus", dec.Rule)
+	assert.Equal(t, "deny", dec.ThreatAction)
 }
 
 func TestSetThreatStore_InvalidActionDefaultsToDeny(t *testing.T) {
@@ -210,6 +215,7 @@ func TestCheckNetworkCtx_ThreatFeedAuditRespectsExplicitDenyRule(t *testing.T) {
 	assert.Equal(t, "deny-evil", dec.Rule)
 	assert.Equal(t, "urlhaus", dec.ThreatFeed)
 	assert.Equal(t, "evil.com", dec.ThreatMatch)
+	assert.Equal(t, "audit", dec.ThreatAction)
 }
 
 func TestCheckNetworkCtx_ThreatFeedAuditRespectsDefaultDeny(t *testing.T) {
@@ -227,4 +233,5 @@ func TestCheckNetworkCtx_ThreatFeedAuditRespectsDefaultDeny(t *testing.T) {
 	assert.Equal(t, types.DecisionDeny, dec.EffectiveDecision)
 	assert.Equal(t, "default-deny-network", dec.Rule)
 	assert.Equal(t, "urlhaus", dec.ThreatFeed)
+	assert.Equal(t, "audit", dec.ThreatAction)
 }

--- a/internal/policy/engine_threat_test.go
+++ b/internal/policy/engine_threat_test.go
@@ -1,0 +1,156 @@
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// mockThreatStore implements ThreatChecker for testing.
+type mockThreatStore struct {
+	domains map[string]ThreatCheckResult
+}
+
+func (m *mockThreatStore) Check(domain string) (ThreatCheckResult, bool) {
+	// Exact match first
+	if entry, ok := m.domains[domain]; ok {
+		return entry, true
+	}
+	// Walk parent domains (same logic as threatfeed.Store)
+	d := domain
+	for {
+		idx := 0
+		for i, c := range d {
+			if c == '.' {
+				idx = i
+				break
+			}
+		}
+		if idx == 0 {
+			break
+		}
+		d = d[idx+1:]
+		if d == "" {
+			break
+		}
+		// Skip bare TLDs
+		hasDot := false
+		for _, c := range d {
+			if c == '.' {
+				hasDot = true
+				break
+			}
+		}
+		if !hasDot {
+			break
+		}
+		if entry, ok := m.domains[d]; ok {
+			return entry, true
+		}
+	}
+	return ThreatCheckResult{}, false
+}
+
+func TestCheckNetworkCtx_ThreatFeedDeny(t *testing.T) {
+	p := &Policy{Version: 1, Name: "test", NetworkRules: []NetworkRule{
+		{Name: "allow-all", Domains: []string{"**"}, Decision: "allow"},
+	}}
+	e, err := NewEngine(p, false)
+	require.NoError(t, err)
+
+	store := &mockThreatStore{domains: map[string]ThreatCheckResult{
+		"evil.com": {FeedName: "urlhaus", MatchedDomain: "evil.com"},
+	}}
+	e.SetThreatStore(store, "deny")
+
+	dec := e.CheckNetworkCtx(context.Background(), "evil.com", 443)
+	assert.Equal(t, types.DecisionDeny, dec.EffectiveDecision)
+	assert.Equal(t, "threat-feed:urlhaus", dec.Rule)
+}
+
+func TestCheckNetworkCtx_ThreatFeedAudit(t *testing.T) {
+	p := &Policy{Version: 1, Name: "test", NetworkRules: []NetworkRule{
+		{Name: "allow-all", Domains: []string{"**"}, Decision: "allow"},
+	}}
+	e, err := NewEngine(p, false)
+	require.NoError(t, err)
+
+	store := &mockThreatStore{domains: map[string]ThreatCheckResult{
+		"evil.com": {FeedName: "urlhaus", MatchedDomain: "evil.com"},
+	}}
+	e.SetThreatStore(store, "audit")
+
+	dec := e.CheckNetworkCtx(context.Background(), "evil.com", 443)
+	assert.Equal(t, types.DecisionAudit, dec.PolicyDecision)
+	assert.Equal(t, types.DecisionAllow, dec.EffectiveDecision)
+	assert.Equal(t, "threat-feed:urlhaus", dec.Rule)
+}
+
+func TestCheckNetworkCtx_ThreatFeedNoMatchFallsThrough(t *testing.T) {
+	p := &Policy{Version: 1, Name: "test", NetworkRules: []NetworkRule{
+		{Name: "deny-bad", Domains: []string{"bad.org"}, Decision: "deny"},
+		{Name: "allow-all", Domains: []string{"**"}, Decision: "allow"},
+	}}
+	e, err := NewEngine(p, false)
+	require.NoError(t, err)
+
+	store := &mockThreatStore{domains: map[string]ThreatCheckResult{
+		"evil.com": {FeedName: "urlhaus", MatchedDomain: "evil.com"},
+	}}
+	e.SetThreatStore(store, "deny")
+
+	dec := e.CheckNetworkCtx(context.Background(), "safe.com", 443)
+	assert.Equal(t, types.DecisionAllow, dec.EffectiveDecision)
+	assert.Equal(t, "allow-all", dec.Rule)
+}
+
+func TestCheckNetworkCtx_NilThreatStoreSkipsCheck(t *testing.T) {
+	p := &Policy{Version: 1, Name: "test", NetworkRules: []NetworkRule{
+		{Name: "allow-all", Domains: []string{"**"}, Decision: "allow"},
+	}}
+	e, err := NewEngine(p, false)
+	require.NoError(t, err)
+
+	dec := e.CheckNetworkCtx(context.Background(), "evil.com", 443)
+	assert.Equal(t, types.DecisionAllow, dec.EffectiveDecision)
+	assert.Equal(t, "allow-all", dec.Rule)
+}
+
+func TestCheckNetworkCtx_ThreatFeedParentDomainMatch(t *testing.T) {
+	p := &Policy{Version: 1, Name: "test", NetworkRules: []NetworkRule{
+		{Name: "allow-all", Domains: []string{"**"}, Decision: "allow"},
+	}}
+	e, err := NewEngine(p, false)
+	require.NoError(t, err)
+
+	store := &mockThreatStore{domains: map[string]ThreatCheckResult{
+		"evil.com": {FeedName: "urlhaus", MatchedDomain: "evil.com"},
+	}}
+	e.SetThreatStore(store, "deny")
+
+	dec := e.CheckNetworkCtx(context.Background(), "sub.evil.com", 443)
+	assert.Equal(t, types.DecisionDeny, dec.EffectiveDecision)
+	assert.Equal(t, "threat-feed:urlhaus", dec.Rule)
+	assert.Contains(t, dec.Message, "evil.com")
+}
+
+func TestCheckNetworkCtx_ThreatFeedFields(t *testing.T) {
+	p := &Policy{Version: 1, Name: "test", NetworkRules: []NetworkRule{
+		{Name: "allow-all", Domains: []string{"**"}, Decision: "allow"},
+	}}
+	e, err := NewEngine(p, false)
+	require.NoError(t, err)
+
+	store := &mockThreatStore{domains: map[string]ThreatCheckResult{
+		"evil.com": {FeedName: "urlhaus", MatchedDomain: "evil.com"},
+	}}
+	e.SetThreatStore(store, "deny")
+
+	dec := e.CheckNetworkCtx(context.Background(), "sub.evil.com", 443)
+	assert.Equal(t, "urlhaus", dec.ThreatFeed)
+	assert.Equal(t, "evil.com", dec.ThreatMatch)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -648,8 +648,13 @@ func (s *Server) Run(ctx context.Context) error {
 	if s.threatSyncer != nil {
 		syncerDone = make(chan struct{})
 		go func() {
+			defer close(syncerDone)
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("threat feed syncer panicked", "panic", r)
+				}
+			}()
 			s.threatSyncer.Run(ctx)
-			close(syncerDone)
 		}()
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -692,6 +692,7 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 		return s.httpServer.Shutdown(shutdownCtx)
 	case err := <-errCh:
+		stop() // cancel context so syncer can exit
 		if syncerDone != nil {
 			<-syncerDone
 		}

--- a/internal/threatfeed/adapter.go
+++ b/internal/threatfeed/adapter.go
@@ -29,9 +29,26 @@ func (a *PolicyAdapter) Check(domain string) (policy.ThreatCheckResult, bool) {
 
 // redactFeedName strips directory paths from local list feed names so that
 // filesystem paths are not exposed in policy decisions, logs, or events.
+// The basename is also sanitized to the safe charset [A-Za-z0-9._-] to
+// prevent unusual filenames from injecting into rule/message fields.
 func redactFeedName(name string) string {
 	if strings.HasPrefix(name, "local:") {
-		return "local:" + filepath.Base(strings.TrimPrefix(name, "local:"))
+		base := filepath.Base(strings.TrimPrefix(name, "local:"))
+		return "local:" + sanitizeBasename(base)
 	}
 	return name
+}
+
+// sanitizeBasename replaces characters outside [A-Za-z0-9._-] with underscores.
+func sanitizeBasename(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, c := range s {
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '.' || c == '_' || c == '-' {
+			b.WriteRune(c)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
 }

--- a/internal/threatfeed/adapter.go
+++ b/internal/threatfeed/adapter.go
@@ -1,0 +1,20 @@
+package threatfeed
+
+import "github.com/agentsh/agentsh/internal/policy"
+
+// PolicyAdapter adapts a Store to the policy.ThreatChecker interface.
+type PolicyAdapter struct {
+	Store *Store
+}
+
+// Check implements policy.ThreatChecker.
+func (a *PolicyAdapter) Check(domain string) (policy.ThreatCheckResult, bool) {
+	entry, matched := a.Store.Check(domain)
+	if !matched {
+		return policy.ThreatCheckResult{}, false
+	}
+	return policy.ThreatCheckResult{
+		FeedName:      entry.FeedName,
+		MatchedDomain: entry.MatchedDomain,
+	}, true
+}

--- a/internal/threatfeed/adapter.go
+++ b/internal/threatfeed/adapter.go
@@ -1,6 +1,11 @@
 package threatfeed
 
-import "github.com/agentsh/agentsh/internal/policy"
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
 
 // PolicyAdapter adapts a Store to the policy.ThreatChecker interface.
 type PolicyAdapter struct {
@@ -14,7 +19,16 @@ func (a *PolicyAdapter) Check(domain string) (policy.ThreatCheckResult, bool) {
 		return policy.ThreatCheckResult{}, false
 	}
 	return policy.ThreatCheckResult{
-		FeedName:      entry.FeedName,
+		FeedName:      redactFeedName(entry.FeedName),
 		MatchedDomain: entry.MatchedDomain,
 	}, true
+}
+
+// redactFeedName strips directory paths from local list feed names so that
+// filesystem paths are not exposed in policy decisions, logs, or events.
+func redactFeedName(name string) string {
+	if strings.HasPrefix(name, "local:") {
+		return "local:" + filepath.Base(strings.TrimPrefix(name, "local:"))
+	}
+	return name
 }

--- a/internal/threatfeed/adapter.go
+++ b/internal/threatfeed/adapter.go
@@ -14,6 +14,9 @@ type PolicyAdapter struct {
 
 // Check implements policy.ThreatChecker.
 func (a *PolicyAdapter) Check(domain string) (policy.ThreatCheckResult, bool) {
+	if a == nil || a.Store == nil {
+		return policy.ThreatCheckResult{}, false
+	}
 	entry, matched := a.Store.Check(domain)
 	if !matched {
 		return policy.ThreatCheckResult{}, false

--- a/internal/threatfeed/adapter_test.go
+++ b/internal/threatfeed/adapter_test.go
@@ -17,7 +17,7 @@ func TestPolicyAdapter_RedactsLocalListPath(t *testing.T) {
 	adapter := &PolicyAdapter{Store: store}
 	result, matched := adapter.Check("evil.com")
 	require.True(t, matched)
-	assert.Equal(t, "local:blocklist.txt", result.FeedName, "adapter should redact directory path")
+	assert.Equal(t, "local:blocklist.txt.1fb68369", result.FeedName, "adapter should redact directory path and append hash")
 }
 
 func TestPolicyAdapter_PreservesRemoteFeedName(t *testing.T) {
@@ -53,5 +53,5 @@ func TestPolicyAdapter_SanitizesLocalBasename(t *testing.T) {
 	adapter := &PolicyAdapter{Store: store}
 	result, matched := adapter.Check("evil.com")
 	require.True(t, matched)
-	assert.Equal(t, "local:my_list__v2_.txt", result.FeedName, "special chars in basename should be replaced with underscores")
+	assert.Equal(t, "local:my_list__v2_.txt.2fbd3502", result.FeedName, "special chars in basename should be replaced with underscores and hash appended")
 }

--- a/internal/threatfeed/adapter_test.go
+++ b/internal/threatfeed/adapter_test.go
@@ -1,0 +1,33 @@
+package threatfeed
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicyAdapter_RedactsLocalListPath(t *testing.T) {
+	store := NewStore("", nil)
+	store.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "local:/etc/agentsh/lists/blocklist.txt", AddedAt: time.Now()},
+	})
+
+	adapter := &PolicyAdapter{Store: store}
+	result, matched := adapter.Check("evil.com")
+	require.True(t, matched)
+	assert.Equal(t, "local:blocklist.txt", result.FeedName, "adapter should redact directory path")
+}
+
+func TestPolicyAdapter_PreservesRemoteFeedName(t *testing.T) {
+	store := NewStore("", nil)
+	store.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+
+	adapter := &PolicyAdapter{Store: store}
+	result, matched := adapter.Check("evil.com")
+	require.True(t, matched)
+	assert.Equal(t, "urlhaus", result.FeedName, "remote feed names should not be modified")
+}

--- a/internal/threatfeed/adapter_test.go
+++ b/internal/threatfeed/adapter_test.go
@@ -43,3 +43,15 @@ func TestPolicyAdapter_NilAdapterDoesNotPanic(t *testing.T) {
 	_, matched := adapter.Check("evil.com")
 	assert.False(t, matched, "nil adapter should return no match")
 }
+
+func TestPolicyAdapter_SanitizesLocalBasename(t *testing.T) {
+	store := NewStore("", nil)
+	store.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "local:/tmp/my list (v2).txt", AddedAt: time.Now()},
+	})
+
+	adapter := &PolicyAdapter{Store: store}
+	result, matched := adapter.Check("evil.com")
+	require.True(t, matched)
+	assert.Equal(t, "local:my_list__v2_.txt", result.FeedName, "special chars in basename should be replaced with underscores")
+}

--- a/internal/threatfeed/adapter_test.go
+++ b/internal/threatfeed/adapter_test.go
@@ -31,3 +31,15 @@ func TestPolicyAdapter_PreservesRemoteFeedName(t *testing.T) {
 	require.True(t, matched)
 	assert.Equal(t, "urlhaus", result.FeedName, "remote feed names should not be modified")
 }
+
+func TestPolicyAdapter_NilStoreDoesNotPanic(t *testing.T) {
+	adapter := &PolicyAdapter{Store: nil}
+	_, matched := adapter.Check("evil.com")
+	assert.False(t, matched, "nil store should return no match")
+}
+
+func TestPolicyAdapter_NilAdapterDoesNotPanic(t *testing.T) {
+	var adapter *PolicyAdapter
+	_, matched := adapter.Check("evil.com")
+	assert.False(t, matched, "nil adapter should return no match")
+}

--- a/internal/threatfeed/parser.go
+++ b/internal/threatfeed/parser.go
@@ -31,19 +31,21 @@ func (p *HostfileParser) Parse(r io.Reader) ([]string, error) {
 		if len(fields) < 2 {
 			continue
 		}
-		domain := strings.ToLower(strings.TrimRight(fields[1], "."))
-		if domain == "" {
-			continue
+		for _, f := range fields[1:] {
+			domain := strings.ToLower(strings.TrimRight(f, "."))
+			if domain == "" {
+				continue
+			}
+			if domain == "localhost" || domain == "localhost.localdomain" ||
+				domain == "broadcasthost" || domain == "local" {
+				continue
+			}
+			if _, ok := seen[domain]; ok {
+				continue
+			}
+			seen[domain] = struct{}{}
+			domains = append(domains, domain)
 		}
-		if domain == "localhost" || domain == "localhost.localdomain" ||
-			domain == "broadcasthost" || domain == "local" {
-			continue
-		}
-		if _, ok := seen[domain]; ok {
-			continue
-		}
-		seen[domain] = struct{}{}
-		domains = append(domains, domain)
 	}
 	return domains, scanner.Err()
 }

--- a/internal/threatfeed/parser.go
+++ b/internal/threatfeed/parser.go
@@ -1,0 +1,77 @@
+package threatfeed
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// Parser extracts domain names from a threat feed format.
+type Parser interface {
+	Parse(r io.Reader) ([]string, error)
+}
+
+// HostfileParser parses hosts-file format: "127.0.0.1 domain" or "0.0.0.0 domain".
+type HostfileParser struct{}
+
+func (p *HostfileParser) Parse(r io.Reader) ([]string, error) {
+	seen := make(map[string]struct{})
+	var domains []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			line = strings.TrimSpace(line[:idx])
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		domain := strings.ToLower(fields[1])
+		if domain == "localhost" || domain == "localhost.localdomain" ||
+			domain == "broadcasthost" || domain == "local" {
+			continue
+		}
+		if _, ok := seen[domain]; ok {
+			continue
+		}
+		seen[domain] = struct{}{}
+		domains = append(domains, domain)
+	}
+	return domains, scanner.Err()
+}
+
+// DomainListParser parses one-domain-per-line format.
+type DomainListParser struct{}
+
+func (p *DomainListParser) Parse(r io.Reader) ([]string, error) {
+	seen := make(map[string]struct{})
+	var domains []string
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		domain := strings.ToLower(line)
+		if _, ok := seen[domain]; ok {
+			continue
+		}
+		seen[domain] = struct{}{}
+		domains = append(domains, domain)
+	}
+	return domains, scanner.Err()
+}
+
+// ParserForFormat returns the appropriate parser for a feed format string.
+func ParserForFormat(format string) Parser {
+	switch strings.ToLower(format) {
+	case "hostfile":
+		return &HostfileParser{}
+	default:
+		return &DomainListParser{}
+	}
+}

--- a/internal/threatfeed/parser.go
+++ b/internal/threatfeed/parser.go
@@ -18,6 +18,7 @@ func (p *HostfileParser) Parse(r io.Reader) ([]string, error) {
 	seen := make(map[string]struct{})
 	var domains []string
 	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // allow lines up to 1 MB
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" || strings.HasPrefix(line, "#") {
@@ -54,6 +55,7 @@ func (p *DomainListParser) Parse(r io.Reader) ([]string, error) {
 	seen := make(map[string]struct{})
 	var domains []string
 	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024) // allow lines up to 1 MB
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" || strings.HasPrefix(line, "#") {

--- a/internal/threatfeed/parser.go
+++ b/internal/threatfeed/parser.go
@@ -30,7 +30,10 @@ func (p *HostfileParser) Parse(r io.Reader) ([]string, error) {
 		if len(fields) < 2 {
 			continue
 		}
-		domain := strings.ToLower(fields[1])
+		domain := strings.ToLower(strings.TrimRight(fields[1], "."))
+		if domain == "" {
+			continue
+		}
 		if domain == "localhost" || domain == "localhost.localdomain" ||
 			domain == "broadcasthost" || domain == "local" {
 			continue
@@ -62,7 +65,10 @@ func (p *DomainListParser) Parse(r io.Reader) ([]string, error) {
 		if line == "" {
 			continue
 		}
-		domain := strings.ToLower(line)
+		domain := strings.ToLower(strings.TrimRight(line, "."))
+		if domain == "" {
+			continue
+		}
 		if _, ok := seen[domain]; ok {
 			continue
 		}

--- a/internal/threatfeed/parser.go
+++ b/internal/threatfeed/parser.go
@@ -56,6 +56,12 @@ func (p *DomainListParser) Parse(r io.Reader) ([]string, error) {
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			line = strings.TrimSpace(line[:idx])
+		}
+		if line == "" {
+			continue
+		}
 		domain := strings.ToLower(line)
 		if _, ok := seen[domain]; ok {
 			continue

--- a/internal/threatfeed/parser_test.go
+++ b/internal/threatfeed/parser_test.go
@@ -77,3 +77,19 @@ func TestDomainListParser_InlineComments(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evil.com", "bad.org", "good.net"}, domains)
 }
+
+func TestHostfileParser_TrailingDot(t *testing.T) {
+	input := "0.0.0.0 evil.com.\n0.0.0.0 bad.org\n"
+	p := &HostfileParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evil.com", "bad.org"}, domains)
+}
+
+func TestDomainListParser_TrailingDot(t *testing.T) {
+	input := "evil.com.\nbad.org\n"
+	p := &DomainListParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evil.com", "bad.org"}, domains)
+}

--- a/internal/threatfeed/parser_test.go
+++ b/internal/threatfeed/parser_test.go
@@ -1,0 +1,71 @@
+package threatfeed
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostfileParser_Standard(t *testing.T) {
+	input := "# comment line\n127.0.0.1 localhost\n0.0.0.0 malware.example.com\n127.0.0.1 phishing.bad.org  # trailing comment\n"
+	p := &HostfileParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"malware.example.com", "phishing.bad.org"}, domains)
+}
+
+func TestHostfileParser_SkipsLocalhost(t *testing.T) {
+	input := "127.0.0.1 localhost\n0.0.0.0 localhost\n0.0.0.0 evil.com\n"
+	p := &HostfileParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evil.com"}, domains)
+}
+
+func TestHostfileParser_Deduplicates(t *testing.T) {
+	input := "0.0.0.0 evil.com\n127.0.0.1 evil.com\n0.0.0.0 EVIL.COM\n"
+	p := &HostfileParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evil.com"}, domains)
+}
+
+func TestHostfileParser_EmptyInput(t *testing.T) {
+	p := &HostfileParser{}
+	domains, err := p.Parse(strings.NewReader(""))
+	require.NoError(t, err)
+	assert.Empty(t, domains)
+}
+
+func TestHostfileParser_CommentsOnly(t *testing.T) {
+	input := "# This is a comment\n# Another comment\n"
+	p := &HostfileParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Empty(t, domains)
+}
+
+func TestDomainListParser_Standard(t *testing.T) {
+	input := "# Phishing domains\nevil.com\nbad.org\n\nUPPER.NET\n"
+	p := &DomainListParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evil.com", "bad.org", "upper.net"}, domains)
+}
+
+func TestDomainListParser_Deduplicates(t *testing.T) {
+	input := "evil.com\nevil.com\nEVIL.COM\n"
+	p := &DomainListParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evil.com"}, domains)
+}
+
+func TestDomainListParser_EmptyInput(t *testing.T) {
+	p := &DomainListParser{}
+	domains, err := p.Parse(strings.NewReader(""))
+	require.NoError(t, err)
+	assert.Empty(t, domains)
+}

--- a/internal/threatfeed/parser_test.go
+++ b/internal/threatfeed/parser_test.go
@@ -69,3 +69,11 @@ func TestDomainListParser_EmptyInput(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, domains)
 }
+
+func TestDomainListParser_InlineComments(t *testing.T) {
+	input := "evil.com # known malware\nbad.org#phishing\n# full comment\ngood.net\n"
+	p := &DomainListParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evil.com", "bad.org", "good.net"}, domains)
+}

--- a/internal/threatfeed/parser_test.go
+++ b/internal/threatfeed/parser_test.go
@@ -93,3 +93,25 @@ func TestDomainListParser_TrailingDot(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"evil.com", "bad.org"}, domains)
 }
+
+func TestHostfileParser_LongLine(t *testing.T) {
+	// Line longer than default bufio.Scanner token size (64 KiB).
+	longComment := strings.Repeat("x", 100*1024)
+	input := "0.0.0.0 evil.com # " + longComment + "\n0.0.0.0 bad.org\n"
+	p := &HostfileParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Contains(t, domains, "evil.com")
+	assert.Contains(t, domains, "bad.org")
+}
+
+func TestDomainListParser_LongLine(t *testing.T) {
+	// Line longer than default bufio.Scanner token size (64 KiB).
+	longComment := strings.Repeat("x", 100*1024)
+	input := "evil.com # " + longComment + "\nbad.org\n"
+	p := &DomainListParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Contains(t, domains, "evil.com")
+	assert.Contains(t, domains, "bad.org")
+}

--- a/internal/threatfeed/parser_test.go
+++ b/internal/threatfeed/parser_test.go
@@ -94,8 +94,15 @@ func TestDomainListParser_TrailingDot(t *testing.T) {
 	assert.Equal(t, []string{"evil.com", "bad.org"}, domains)
 }
 
-func TestHostfileParser_LongLine(t *testing.T) {
-	// Line longer than default bufio.Scanner token size (64 KiB).
+func TestHostfileParser_MultipleHostsPerLine(t *testing.T) {
+	input := "0.0.0.0 evil.com bad.org phishing.net\n"
+	p := &HostfileParser{}
+	domains, err := p.Parse(strings.NewReader(input))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"evil.com", "bad.org", "phishing.net"}, domains)
+}
+
+func TestHostfileParser_LongLine(t *testing.T) {	// Line longer than default bufio.Scanner token size (64 KiB).
 	longComment := strings.Repeat("x", 100*1024)
 	input := "0.0.0.0 evil.com # " + longComment + "\n0.0.0.0 bad.org\n"
 	p := &HostfileParser{}

--- a/internal/threatfeed/provider.go
+++ b/internal/threatfeed/provider.go
@@ -1,0 +1,18 @@
+package threatfeed
+
+import "context"
+
+// Provider defines the interface for real-time domain threat checking.
+// This is reserved for the paid tier (Web Risk API, VirusTotal, etc.)
+// and is not implemented in v1.
+type Provider interface {
+	Check(ctx context.Context, domain string) (ThreatResult, error)
+	Name() string
+}
+
+// ThreatResult holds the result of a real-time threat check.
+type ThreatResult struct {
+	Matched    bool
+	FeedName   string
+	ThreatType string // "malware", "phishing", "unwanted", etc.
+}

--- a/internal/threatfeed/store.go
+++ b/internal/threatfeed/store.go
@@ -28,7 +28,10 @@ type Store struct {
 func NewStore(cacheDir string, allowlist []string) *Store {
 	al := make(map[string]struct{}, len(allowlist))
 	for _, d := range allowlist {
-		al[strings.ToLower(d)] = struct{}{}
+		d = strings.ToLower(strings.TrimRight(strings.TrimSpace(d), "."))
+		if d != "" {
+			al[d] = struct{}{}
+		}
 	}
 	return &Store{
 		domains:   make(map[string]FeedEntry),

--- a/internal/threatfeed/store.go
+++ b/internal/threatfeed/store.go
@@ -96,6 +96,17 @@ func (s *Store) Size() int {
 	return len(s.domains)
 }
 
+// Snapshot returns a copy of the current domain map grouped by feed name.
+func (s *Store) Snapshot() map[string][]string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	grouped := make(map[string][]string)
+	for domain, entry := range s.domains {
+		grouped[entry.FeedName] = append(grouped[entry.FeedName], domain)
+	}
+	return grouped
+}
+
 type diskCache struct {
 	Domains map[string]FeedEntry
 }

--- a/internal/threatfeed/store.go
+++ b/internal/threatfeed/store.go
@@ -1,0 +1,159 @@
+package threatfeed
+
+import (
+	"encoding/gob"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// FeedEntry records which feed flagged a domain and when.
+type FeedEntry struct {
+	FeedName      string
+	AddedAt       time.Time
+	MatchedDomain string // set by Check() — the actual domain that matched
+}
+
+// Store is a thread-safe in-memory set of blocked domains with disk persistence.
+type Store struct {
+	mu        sync.RWMutex
+	domains   map[string]FeedEntry
+	allowlist map[string]struct{}
+	cacheDir  string
+}
+
+// NewStore creates a new threat feed store.
+func NewStore(cacheDir string, allowlist []string) *Store {
+	al := make(map[string]struct{}, len(allowlist))
+	for _, d := range allowlist {
+		al[strings.ToLower(d)] = struct{}{}
+	}
+	return &Store{
+		domains:   make(map[string]FeedEntry),
+		allowlist: al,
+		cacheDir:  cacheDir,
+	}
+}
+
+// Check returns the matching FeedEntry if the domain (or a parent domain) is in
+// the threat feed store and not in the allowlist.
+func (s *Store) Check(domain string) (FeedEntry, bool) {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	if domain == "" {
+		return FeedEntry{}, false
+	}
+
+	if _, ok := s.allowlist[domain]; ok {
+		return FeedEntry{}, false
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if entry, ok := s.domains[domain]; ok {
+		entry.MatchedDomain = domain
+		return entry, true
+	}
+
+	d := domain
+	for {
+		idx := strings.Index(d, ".")
+		if idx < 0 {
+			break
+		}
+		d = d[idx+1:]
+		if d == "" {
+			break
+		}
+		if !strings.Contains(d, ".") {
+			break
+		}
+		if _, ok := s.allowlist[domain]; ok {
+			return FeedEntry{}, false
+		}
+		if entry, ok := s.domains[d]; ok {
+			entry.MatchedDomain = d
+			return entry, true
+		}
+	}
+
+	return FeedEntry{}, false
+}
+
+// Update atomically replaces the entire domain set.
+func (s *Store) Update(domains map[string]FeedEntry) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.domains = domains
+}
+
+// Size returns the number of domains in the store.
+func (s *Store) Size() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.domains)
+}
+
+type diskCache struct {
+	Domains map[string]FeedEntry
+}
+
+const cacheFileName = "feeds.cache"
+
+// SaveToDisk persists the current domain set to a gob-encoded file.
+func (s *Store) SaveToDisk() error {
+	if s.cacheDir == "" {
+		return nil
+	}
+	if err := os.MkdirAll(s.cacheDir, 0o755); err != nil {
+		return err
+	}
+
+	s.mu.RLock()
+	cache := diskCache{Domains: s.domains}
+	s.mu.RUnlock()
+
+	path := filepath.Join(s.cacheDir, cacheFileName)
+	tmp := path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	if err := gob.NewEncoder(f).Encode(&cache); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// LoadFromDisk loads a previously persisted domain set from disk.
+func (s *Store) LoadFromDisk() error {
+	if s.cacheDir == "" {
+		return nil
+	}
+	path := filepath.Join(s.cacheDir, cacheFileName)
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+
+	var cache diskCache
+	if err := gob.NewDecoder(f).Decode(&cache); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.domains = cache.Domains
+	s.mu.Unlock()
+	return nil
+}

--- a/internal/threatfeed/store.go
+++ b/internal/threatfeed/store.go
@@ -40,7 +40,7 @@ func NewStore(cacheDir string, allowlist []string) *Store {
 // Check returns the matching FeedEntry if the domain (or a parent domain) is in
 // the threat feed store and not in the allowlist.
 func (s *Store) Check(domain string) (FeedEntry, bool) {
-	domain = strings.ToLower(strings.TrimSpace(domain))
+	domain = strings.ToLower(strings.TrimRight(strings.TrimSpace(domain), "."))
 	if domain == "" {
 		return FeedEntry{}, false
 	}
@@ -70,7 +70,7 @@ func (s *Store) Check(domain string) (FeedEntry, bool) {
 		if !strings.Contains(d, ".") {
 			break
 		}
-		if _, ok := s.allowlist[domain]; ok {
+		if _, ok := s.allowlist[d]; ok {
 			return FeedEntry{}, false
 		}
 		if entry, ok := s.domains[d]; ok {

--- a/internal/threatfeed/store.go
+++ b/internal/threatfeed/store.go
@@ -4,6 +4,7 @@ import (
 	"encoding/gob"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -143,6 +144,10 @@ func (s *Store) SaveToDisk() error {
 	if err := f.Close(); err != nil {
 		os.Remove(tmp)
 		return err
+	}
+	// On Windows, os.Rename fails if the destination exists. Remove it first.
+	if runtime.GOOS == "windows" {
+		os.Remove(path)
 	}
 	return os.Rename(tmp, path)
 }

--- a/internal/threatfeed/store_test.go
+++ b/internal/threatfeed/store_test.go
@@ -173,3 +173,19 @@ func TestStore_TrailingDot(t *testing.T) {
 	_, matched := s.Check("evil.com.")
 	assert.True(t, matched, "trailing dot should be stripped")
 }
+
+func TestStore_AllowlistNormalization(t *testing.T) {
+	// Allowlist entries with trailing dots, spaces, and mixed case should still match.
+	s := NewStore("", []string{" Safe.Example.Com. ", "OTHER.NET."})
+	s.Update(map[string]FeedEntry{
+		"safe.example.com": {FeedName: "test", AddedAt: time.Now()},
+		"other.net":        {FeedName: "test", AddedAt: time.Now()},
+		"evil.com":         {FeedName: "test", AddedAt: time.Now()},
+	})
+	_, matched := s.Check("safe.example.com")
+	assert.False(t, matched, "allowlisted domain with trailing dot should be excluded")
+	_, matched = s.Check("other.net")
+	assert.False(t, matched, "allowlisted domain with trailing dot should be excluded")
+	_, matched = s.Check("evil.com")
+	assert.True(t, matched, "non-allowlisted domain should still match")
+}

--- a/internal/threatfeed/store_test.go
+++ b/internal/threatfeed/store_test.go
@@ -1,0 +1,157 @@
+package threatfeed
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStore_ExactMatch(t *testing.T) {
+	s := NewStore("", nil)
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	entry, matched := s.Check("evil.com")
+	assert.True(t, matched)
+	assert.Equal(t, "urlhaus", entry.FeedName)
+}
+
+func TestStore_NoMatch(t *testing.T) {
+	s := NewStore("", nil)
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	_, matched := s.Check("safe.com")
+	assert.False(t, matched)
+}
+
+func TestStore_ParentDomainMatch(t *testing.T) {
+	s := NewStore("", nil)
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	entry, matched := s.Check("sub.evil.com")
+	assert.True(t, matched)
+	assert.Equal(t, "evil.com", entry.MatchedDomain)
+}
+
+func TestStore_DeepSubdomainMatch(t *testing.T) {
+	s := NewStore("", nil)
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	entry, matched := s.Check("a.b.c.evil.com")
+	assert.True(t, matched)
+	assert.Equal(t, "evil.com", entry.MatchedDomain)
+}
+
+func TestStore_AllowlistOverride(t *testing.T) {
+	s := NewStore("", []string{"legit.evil.com"})
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	_, matched := s.Check("legit.evil.com")
+	assert.False(t, matched, "allowlisted domain should not match")
+
+	_, matched = s.Check("other.evil.com")
+	assert.True(t, matched)
+}
+
+func TestStore_CaseInsensitive(t *testing.T) {
+	s := NewStore("", nil)
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	_, matched := s.Check("EVIL.COM")
+	assert.True(t, matched)
+}
+
+func TestStore_EmptyStore(t *testing.T) {
+	s := NewStore("", nil)
+	_, matched := s.Check("anything.com")
+	assert.False(t, matched)
+}
+
+func TestStore_AtomicUpdate(t *testing.T) {
+	s := NewStore("", nil)
+	s.Update(map[string]FeedEntry{
+		"old.com": {FeedName: "feed1", AddedAt: time.Now()},
+	})
+	s.Update(map[string]FeedEntry{
+		"new.com": {FeedName: "feed2", AddedAt: time.Now()},
+	})
+	_, matched := s.Check("old.com")
+	assert.False(t, matched, "old entries should be gone after update")
+	_, matched = s.Check("new.com")
+	assert.True(t, matched)
+}
+
+func TestStore_ConcurrentAccess(t *testing.T) {
+	s := NewStore("", nil)
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			s.Check("evil.com")
+		}()
+		go func() {
+			defer wg.Done()
+			s.Update(map[string]FeedEntry{
+				"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+			})
+		}()
+	}
+	wg.Wait()
+}
+
+func TestStore_DiskRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s1 := NewStore(dir, []string{"safe.com"})
+	s1.Update(map[string]FeedEntry{
+		"evil.com":    {FeedName: "urlhaus", AddedAt: time.Now()},
+		"phishing.io": {FeedName: "phishdb", AddedAt: time.Now()},
+	})
+	err := s1.SaveToDisk()
+	require.NoError(t, err)
+
+	_, err = os.Stat(filepath.Join(dir, "feeds.cache"))
+	require.NoError(t, err)
+
+	s2 := NewStore(dir, []string{"safe.com"})
+	err = s2.LoadFromDisk()
+	require.NoError(t, err)
+
+	entry, matched := s2.Check("evil.com")
+	assert.True(t, matched)
+	assert.Equal(t, "urlhaus", entry.FeedName)
+
+	entry, matched = s2.Check("phishing.io")
+	assert.True(t, matched)
+	assert.Equal(t, "phishdb", entry.FeedName)
+}
+
+func TestStore_LoadFromDisk_NoFile(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir, nil)
+	err := s.LoadFromDisk()
+	assert.NoError(t, err, "missing cache file should not be an error")
+}
+
+func TestStore_Size(t *testing.T) {
+	s := NewStore("", nil)
+	assert.Equal(t, 0, s.Size())
+	s.Update(map[string]FeedEntry{
+		"a.com": {FeedName: "f1", AddedAt: time.Now()},
+		"b.com": {FeedName: "f2", AddedAt: time.Now()},
+	})
+	assert.Equal(t, 2, s.Size())
+}

--- a/internal/threatfeed/store_test.go
+++ b/internal/threatfeed/store_test.go
@@ -155,3 +155,21 @@ func TestStore_Size(t *testing.T) {
 	})
 	assert.Equal(t, 2, s.Size())
 }
+
+func TestStore_AllowlistOverridesParentDomain(t *testing.T) {
+	s := NewStore("", []string{"evil.com"})
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	_, matched := s.Check("sub.evil.com")
+	assert.False(t, matched, "parent domain is allowlisted, child should not match")
+}
+
+func TestStore_TrailingDot(t *testing.T) {
+	s := NewStore("", nil)
+	s.Update(map[string]FeedEntry{
+		"evil.com": {FeedName: "urlhaus", AddedAt: time.Now()},
+	})
+	_, matched := s.Check("evil.com.")
+	assert.True(t, matched, "trailing dot should be stripped")
+}

--- a/internal/threatfeed/syncer.go
+++ b/internal/threatfeed/syncer.go
@@ -1,0 +1,141 @@
+package threatfeed
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+// Syncer periodically downloads threat feeds and updates the store.
+type Syncer struct {
+	store    *Store
+	feeds    []config.ThreatFeedEntry
+	locals   []string
+	interval time.Duration
+	client   *http.Client
+	logger   *slog.Logger
+	etags    map[string]string
+}
+
+// NewSyncer creates a new feed syncer. Pass nil for logger to disable logging.
+func NewSyncer(store *Store, cfg config.ThreatFeedsConfig, logger *slog.Logger) *Syncer {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &Syncer{
+		store:    store,
+		feeds:    cfg.Feeds,
+		locals:   cfg.LocalLists,
+		interval: cfg.SyncInterval,
+		client:   &http.Client{Timeout: 30 * time.Second},
+		logger:   logger,
+		etags:    make(map[string]string),
+	}
+}
+
+// Run starts the periodic sync loop. It blocks until ctx is cancelled.
+func (s *Syncer) Run(ctx context.Context) {
+	s.syncAll()
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			s.store.SaveToDisk()
+			return
+		case <-ticker.C:
+			s.syncAll()
+		}
+	}
+}
+
+// syncAll fetches all feeds and local lists, merges results, and updates the store.
+func (s *Syncer) syncAll() {
+	merged := make(map[string]FeedEntry)
+	allFailed := true
+
+	for _, feed := range s.feeds {
+		domains, err := s.fetchFeed(feed)
+		if err != nil {
+			s.logger.Warn("threat feed fetch failed",
+				"feed", feed.Name, "url", feed.URL, "error", err)
+			continue
+		}
+		allFailed = false
+		now := time.Now()
+		for _, d := range domains {
+			if _, exists := merged[d]; !exists {
+				merged[d] = FeedEntry{FeedName: feed.Name, AddedAt: now}
+			}
+		}
+		s.logger.Info("threat feed synced",
+			"feed", feed.Name, "domains", len(domains))
+	}
+
+	for _, path := range s.locals {
+		domains, err := s.parseLocalFile(path)
+		if err != nil {
+			s.logger.Warn("local threat list failed",
+				"path", path, "error", err)
+			continue
+		}
+		allFailed = false
+		now := time.Now()
+		for _, d := range domains {
+			if _, exists := merged[d]; !exists {
+				merged[d] = FeedEntry{FeedName: "local:" + path, AddedAt: now}
+			}
+		}
+	}
+
+	if !allFailed || (len(s.feeds) == 0 && len(s.locals) == 0) {
+		s.store.Update(merged)
+		s.store.SaveToDisk()
+	}
+}
+
+func (s *Syncer) fetchFeed(feed config.ThreatFeedEntry) ([]string, error) {
+	req, err := http.NewRequest("GET", feed.URL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if etag, ok := s.etags[feed.URL]; ok {
+		req.Header.Set("If-None-Match", etag)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotModified {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+
+	if etag := resp.Header.Get("ETag"); etag != "" {
+		s.etags[feed.URL] = etag
+	}
+
+	parser := ParserForFormat(feed.Format)
+	return parser.Parse(resp.Body)
+}
+
+func (s *Syncer) parseLocalFile(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	p := &DomainListParser{}
+	return p.Parse(f)
+}

--- a/internal/threatfeed/syncer.go
+++ b/internal/threatfeed/syncer.go
@@ -121,20 +121,21 @@ func (s *Syncer) syncAll(ctx context.Context) {
 	}
 
 	for _, path := range s.locals {
-		key := "local:" + filepath.Base(path)
+		cacheKey := "local:" + path                  // unique key for lastGood
+		displayName := "local:" + filepath.Base(path) // safe name for logs/events
 		domains, err := s.parseLocalFile(path)
 		if err != nil {
 			s.logger.Warn("local threat list failed, using cached data",
 				"path", path, "error", err)
-			domains = s.lastGood[key]
+			domains = s.lastGood[cacheKey]
 		} else {
-			s.lastGood[key] = domains
+			s.lastGood[cacheKey] = domains
 			anySucceeded = true
 		}
 		now := time.Now()
 		for _, d := range domains {
 			if _, exists := merged[d]; !exists {
-				merged[d] = FeedEntry{FeedName: key, AddedAt: now}
+				merged[d] = FeedEntry{FeedName: displayName, AddedAt: now}
 			}
 		}
 	}

--- a/internal/threatfeed/syncer.go
+++ b/internal/threatfeed/syncer.go
@@ -222,14 +222,12 @@ func (s *Syncer) configuredFeedKeys() map[string]struct{} {
 	return keys
 }
 
-// sanitizeURL strips userinfo and query parameters from a URL for safe logging.
+// sanitizeURL strips everything except scheme and host from a URL for safe
+// logging. Path segments may contain tokens or secrets in some feed URLs.
 func sanitizeURL(rawURL string) string {
 	u, err := url.Parse(rawURL)
 	if err != nil {
 		return "<invalid-url>"
 	}
-	u.User = nil
-	u.RawQuery = ""
-	u.Fragment = ""
-	return u.String()
+	return u.Scheme + "://" + u.Host
 }

--- a/internal/threatfeed/syncer.go
+++ b/internal/threatfeed/syncer.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/agentsh/agentsh/internal/config"
@@ -121,8 +120,7 @@ func (s *Syncer) syncAll(ctx context.Context) {
 	}
 
 	for _, path := range s.locals {
-		cacheKey := "local:" + path                  // unique key for lastGood
-		displayName := "local:" + filepath.Base(path) // safe name for logs/events
+		cacheKey := "local:" + path // unique key for lastGood and FeedEntry
 		domains, err := s.parseLocalFile(path)
 		if err != nil {
 			s.logger.Warn("local threat list failed, using cached data",
@@ -135,7 +133,7 @@ func (s *Syncer) syncAll(ctx context.Context) {
 		now := time.Now()
 		for _, d := range domains {
 			if _, exists := merged[d]; !exists {
-				merged[d] = FeedEntry{FeedName: displayName, AddedAt: now}
+				merged[d] = FeedEntry{FeedName: cacheKey, AddedAt: now}
 			}
 		}
 	}

--- a/internal/threatfeed/syncer_test.go
+++ b/internal/threatfeed/syncer_test.go
@@ -1,0 +1,188 @@
+package threatfeed
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+func TestSyncer_FetchesAndPopulatesStore(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "0.0.0.0 evil.com")
+		fmt.Fprintln(w, "0.0.0.0 bad.org")
+	}))
+	defer srv.Close()
+
+	store := NewStore("", nil)
+	cfg := config.ThreatFeedsConfig{
+		Feeds: []config.ThreatFeedEntry{
+			{Name: "test-feed", URL: srv.URL, Format: "hostfile"},
+		},
+		SyncInterval: time.Hour,
+	}
+	syncer := NewSyncer(store, cfg, nil)
+	syncer.syncAll()
+
+	assert.Equal(t, 2, store.Size())
+	_, matched := store.Check("evil.com")
+	assert.True(t, matched)
+	_, matched = store.Check("bad.org")
+	assert.True(t, matched)
+}
+
+func TestSyncer_DomainListFormat(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "# comment")
+		fmt.Fprintln(w, "phish.net")
+	}))
+	defer srv.Close()
+
+	store := NewStore("", nil)
+	cfg := config.ThreatFeedsConfig{
+		Feeds: []config.ThreatFeedEntry{
+			{Name: "phish", URL: srv.URL, Format: "domain-list"},
+		},
+		SyncInterval: time.Hour,
+	}
+	syncer := NewSyncer(store, cfg, nil)
+	syncer.syncAll()
+
+	_, matched := store.Check("phish.net")
+	assert.True(t, matched)
+}
+
+func TestSyncer_MergesMultipleFeeds(t *testing.T) {
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "0.0.0.0 evil.com")
+	}))
+	defer srv1.Close()
+
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "phish.net")
+	}))
+	defer srv2.Close()
+
+	store := NewStore("", nil)
+	cfg := config.ThreatFeedsConfig{
+		Feeds: []config.ThreatFeedEntry{
+			{Name: "feed1", URL: srv1.URL, Format: "hostfile"},
+			{Name: "feed2", URL: srv2.URL, Format: "domain-list"},
+		},
+		SyncInterval: time.Hour,
+	}
+	syncer := NewSyncer(store, cfg, nil)
+	syncer.syncAll()
+
+	assert.Equal(t, 2, store.Size())
+}
+
+func TestSyncer_FetchFailureKeepsPreviousData(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			fmt.Fprintln(w, "0.0.0.0 evil.com")
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	store := NewStore("", nil)
+	cfg := config.ThreatFeedsConfig{
+		Feeds: []config.ThreatFeedEntry{
+			{Name: "flaky", URL: srv.URL, Format: "hostfile"},
+		},
+		SyncInterval: time.Hour,
+	}
+	syncer := NewSyncer(store, cfg, nil)
+
+	syncer.syncAll()
+	assert.Equal(t, 1, store.Size())
+
+	syncer.syncAll()
+	assert.Equal(t, 1, store.Size())
+	_, matched := store.Check("evil.com")
+	assert.True(t, matched)
+}
+
+func TestSyncer_LocalListFile(t *testing.T) {
+	dir := t.TempDir()
+	listPath := filepath.Join(dir, "custom.txt")
+	err := os.WriteFile(listPath, []byte("custom-bad.com\n"), 0o644)
+	require.NoError(t, err)
+
+	store := NewStore("", nil)
+	cfg := config.ThreatFeedsConfig{
+		LocalLists:   []string{listPath},
+		SyncInterval: time.Hour,
+	}
+	syncer := NewSyncer(store, cfg, nil)
+	syncer.syncAll()
+
+	_, matched := store.Check("custom-bad.com")
+	assert.True(t, matched)
+}
+
+func TestSyncer_RunRespectsContextCancellation(t *testing.T) {
+	store := NewStore("", nil)
+	cfg := config.ThreatFeedsConfig{
+		SyncInterval: time.Hour,
+	}
+	syncer := NewSyncer(store, cfg, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		syncer.Run(ctx)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("syncer did not stop after context cancellation")
+	}
+}
+
+func TestSyncer_SavesToDiskOnShutdown(t *testing.T) {
+	dir := t.TempDir()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "0.0.0.0 evil.com")
+	}))
+	defer srv.Close()
+
+	store := NewStore(dir, nil)
+	cfg := config.ThreatFeedsConfig{
+		Feeds: []config.ThreatFeedEntry{
+			{Name: "test", URL: srv.URL, Format: "hostfile"},
+		},
+		SyncInterval: time.Hour,
+	}
+	syncer := NewSyncer(store, cfg, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		syncer.Run(ctx)
+		close(done)
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-done
+
+	_, err := os.Stat(filepath.Join(dir, "feeds.cache"))
+	assert.NoError(t, err)
+}

--- a/pkg/types/events.go
+++ b/pkg/types/events.go
@@ -9,6 +9,9 @@ type PolicyInfo struct {
 	Message           string        `json:"message,omitempty"`
 	Approval          *ApprovalInfo `json:"approval,omitempty"`
 	Redirect          *RedirectInfo `json:"redirect,omitempty"`
+	ThreatFeed        string        `json:"threat_feed,omitempty"`
+	ThreatMatch       string        `json:"threat_match,omitempty"`
+	ThreatAction      string        `json:"threat_action,omitempty"`
 }
 
 type ApprovalInfo struct {


### PR DESCRIPTION
## Summary

- Add threat intelligence feed system that blocks agent connections to known-malicious domains
- Integrate external feeds (URLhaus, phishing lists, custom blocklists) into the existing policy engine as a pre-check in `CheckNetworkCtx()` and `CheckNetworkIP()`
- New `internal/threatfeed/` package with in-memory store (+ gob disk cache), background syncer goroutine, hostfile/domain-list parsers, and `ThreatChecker` interface
- Config section `threat_feeds` with `deny`/`audit` action modes, allowlist overrides, and reserved `realtime` block for future paid API tier
- Per-feed last-known-good snapshots preserve protection when individual feeds fail or return 304

## Test plan

- [x] 22 store tests: exact match, parent domain, allowlist (including parent-domain allowlist), concurrent access, disk round-trip, trailing dots
- [x] 8 parser tests: hostfile + domain-list formats, dedup, comments, empty input
- [x] 11 syncer tests: fetch, merge, 304 preservation, partial failure, local lists, shutdown save, interval validation
- [x] 7 policy engine tests: deny, audit, fallthrough, nil store, parent domain, fields, CheckNetworkIP
- [x] 3 config tests: defaults, non-override, struct population
- [x] All tests pass with `-race` flag
- [x] `go build ./...` and `GOOS=windows go build ./...` clean
- [x] Code reviewed by roborev and code reviewer subagent; all critical/important findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)