### PR TITLE
feat: P2+P3 MCP attack coverage (transport, rate limit, binary pin, TLS, similarity)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -115,9 +115,9 @@ type OIDCConfig struct {
 	JWKSCacheTTL     string            `yaml:"jwks_cache_ttl"`    // e.g., "1h"
 	DiscoveryTimeout string            `yaml:"discovery_timeout"` // Timeout for OIDC discovery (default: "5s")
 	ClaimMappings    OIDCClaimMappings `yaml:"claim_mappings"`
-	AllowedGroups    []string          `yaml:"allowed_groups"`    // Groups allowed to access
-	GroupPolicyMap   map[string]string `yaml:"group_policy_map"`  // group -> policy name
-	GroupRoleMap     map[string]string `yaml:"group_role_map"`    // group -> role (admin, approver, agent)
+	AllowedGroups    []string          `yaml:"allowed_groups"`   // Groups allowed to access
+	GroupPolicyMap   map[string]string `yaml:"group_policy_map"` // group -> policy name
+	GroupRoleMap     map[string]string `yaml:"group_role_map"`   // group -> role (admin, approver, agent)
 }
 
 // OIDCClaimMappings maps OIDC claims to agentsh fields.
@@ -207,14 +207,14 @@ type AzureKeyVaultConfig struct {
 
 // HashiCorpVaultConfig configures HashiCorp Vault integration.
 type HashiCorpVaultConfig struct {
-	Address    string `yaml:"address"`     // Vault address
-	AuthMethod string `yaml:"auth_method"` // token, kubernetes, approle
-	TokenFile  string `yaml:"token_file"`  // Path to token file (for token auth)
+	Address    string `yaml:"address"`         // Vault address
+	AuthMethod string `yaml:"auth_method"`     // token, kubernetes, approle
+	TokenFile  string `yaml:"token_file"`      // Path to token file (for token auth)
 	K8sRole    string `yaml:"kubernetes_role"` // Role name (for kubernetes auth)
-	AppRoleID  string `yaml:"approle_id"`  // Role ID (for approle auth)
-	SecretID   string `yaml:"secret_id"`   // Secret ID (for approle auth, or use VAULT_SECRET_ID env)
-	SecretPath string `yaml:"secret_path"` // Path to secret (e.g., secret/data/agentsh/audit-key)
-	KeyField   string `yaml:"key_field"`   // Field name within secret (default: "key")
+	AppRoleID  string `yaml:"approle_id"`      // Role ID (for approle auth)
+	SecretID   string `yaml:"secret_id"`       // Secret ID (for approle auth, or use VAULT_SECRET_ID env)
+	SecretPath string `yaml:"secret_path"`     // Path to secret (e.g., secret/data/agentsh/audit-key)
+	KeyField   string `yaml:"key_field"`       // Field name within secret (default: "key")
 }
 
 // GCPKMSConfig configures GCP Cloud KMS integration.
@@ -233,15 +233,15 @@ type AuditEncryptionConfig struct {
 
 // AuditOTELConfig configures OpenTelemetry event export.
 type AuditOTELConfig struct {
-	Enabled  bool              `yaml:"enabled"`
-	Endpoint string            `yaml:"endpoint"`
-	Protocol string            `yaml:"protocol"` // "grpc" or "http"
-	TLS      OTELTLSConfig     `yaml:"tls"`
-	Headers  map[string]string `yaml:"headers"`
-	Timeout  string            `yaml:"timeout"`
-	Signals  OTELSignalsConfig `yaml:"signals"`
-	Batch    OTELBatchConfig   `yaml:"batch"`
-	Filter   OTELFilterConfig  `yaml:"filter"`
+	Enabled  bool               `yaml:"enabled"`
+	Endpoint string             `yaml:"endpoint"`
+	Protocol string             `yaml:"protocol"` // "grpc" or "http"
+	TLS      OTELTLSConfig      `yaml:"tls"`
+	Headers  map[string]string  `yaml:"headers"`
+	Timeout  string             `yaml:"timeout"`
+	Signals  OTELSignalsConfig  `yaml:"signals"`
+	Batch    OTELBatchConfig    `yaml:"batch"`
+	Filter   OTELFilterConfig   `yaml:"filter"`
 	Resource OTELResourceConfig `yaml:"resource"`
 }
 
@@ -302,12 +302,12 @@ type SessionsConfig struct {
 
 // CheckpointConfig configures workspace checkpoint and rollback.
 type CheckpointConfig struct {
-	Enabled       bool                    `yaml:"enabled"`
-	StorageDir    string                  `yaml:"storage_dir"`    // Directory for checkpoint storage
-	MaxPerSession int                     `yaml:"max_per_session"` // Max checkpoints per session (0 = unlimited)
-	MaxSizeMB     int                     `yaml:"max_size_mb"`     // Max total size per session (0 = unlimited)
-	AutoCheckpoint AutoCheckpointConfig   `yaml:"auto_checkpoint"`
-	Retention     CheckpointRetentionConfig `yaml:"retention"`
+	Enabled        bool                      `yaml:"enabled"`
+	StorageDir     string                    `yaml:"storage_dir"`     // Directory for checkpoint storage
+	MaxPerSession  int                       `yaml:"max_per_session"` // Max checkpoints per session (0 = unlimited)
+	MaxSizeMB      int                       `yaml:"max_size_mb"`     // Max total size per session (0 = unlimited)
+	AutoCheckpoint AutoCheckpointConfig      `yaml:"auto_checkpoint"`
+	Retention      CheckpointRetentionConfig `yaml:"retention"`
 }
 
 // AutoCheckpointConfig configures automatic checkpointing before risky commands.
@@ -447,10 +447,10 @@ type SandboxUnixSocketsConfig struct {
 
 // SandboxSeccompConfig configures seccomp-bpf filtering.
 type SandboxSeccompConfig struct {
-	Enabled    bool                        `yaml:"enabled"`
-	Mode       string                      `yaml:"mode"` // enforce, audit, disabled
-	UnixSocket SandboxSeccompUnixConfig    `yaml:"unix_socket"`
-	Syscalls   SandboxSeccompSyscallConfig `yaml:"syscalls"`
+	Enabled     bool                            `yaml:"enabled"`
+	Mode        string                          `yaml:"mode"` // enforce, audit, disabled
+	UnixSocket  SandboxSeccompUnixConfig        `yaml:"unix_socket"`
+	Syscalls    SandboxSeccompSyscallConfig     `yaml:"syscalls"`
 	Execve      ExecveConfig                    `yaml:"execve"`
 	FileMonitor SandboxSeccompFileMonitorConfig `yaml:"file_monitor"`
 }
@@ -500,20 +500,21 @@ type SandboxXPCESFConfig struct {
 
 // SandboxMCPConfig configures MCP security policies.
 type SandboxMCPConfig struct {
-	EnforcePolicy    bool                    `yaml:"enforce_policy"`
-	FailClosed       bool                    `yaml:"fail_closed"` // Block unknown tools if true
-	Servers          []MCPServerDeclaration  `yaml:"servers"`
-	ServerPolicy     string                  `yaml:"server_policy"` // allowlist, denylist, none
-	AllowedServers   []MCPServerRule         `yaml:"allowed_servers"`
-	DeniedServers    []MCPServerRule         `yaml:"denied_servers"`
-	ToolPolicy       string                  `yaml:"tool_policy"` // allowlist, denylist, none
-	AllowedTools     []MCPToolRule           `yaml:"allowed_tools"`
-	DeniedTools      []MCPToolRule           `yaml:"denied_tools"`
-	VersionPinning   MCPVersionPinningConfig `yaml:"version_pinning"`
-	RateLimits       MCPRateLimitsConfig     `yaml:"rate_limits"`
-	CrossServer      CrossServerConfig       `yaml:"cross_server"`
-	OutputInspection OutputInspectionConfig  `yaml:"output_inspection"`
-	Sampling         SamplingConfig          `yaml:"sampling"`
+	EnforcePolicy     bool                    `yaml:"enforce_policy"`
+	FailClosed        bool                    `yaml:"fail_closed"`        // Block unknown tools if true
+	AllowedTransports []string                `yaml:"allowed_transports"` // "stdio", "http", "sse"; empty = all allowed
+	Servers           []MCPServerDeclaration  `yaml:"servers"`
+	ServerPolicy      string                  `yaml:"server_policy"` // allowlist, denylist, none
+	AllowedServers    []MCPServerRule         `yaml:"allowed_servers"`
+	DeniedServers     []MCPServerRule         `yaml:"denied_servers"`
+	ToolPolicy        string                  `yaml:"tool_policy"` // allowlist, denylist, none
+	AllowedTools      []MCPToolRule           `yaml:"allowed_tools"`
+	DeniedTools       []MCPToolRule           `yaml:"denied_tools"`
+	VersionPinning    MCPVersionPinningConfig `yaml:"version_pinning"`
+	RateLimits        MCPRateLimitsConfig     `yaml:"rate_limits"`
+	CrossServer       CrossServerConfig       `yaml:"cross_server"`
+	OutputInspection  OutputInspectionConfig  `yaml:"output_inspection"`
+	Sampling          SamplingConfig          `yaml:"sampling"`
 }
 
 // OutputInspectionConfig configures scanning of MCP tool call responses.
@@ -528,16 +529,37 @@ type SamplingConfig struct {
 	PerServer map[string]string `yaml:"per_server"` // server_id → policy override
 }
 
+// ValidateMCPTransports checks that all declared MCP servers use allowed transports.
+func ValidateMCPTransports(cfg SandboxMCPConfig) error {
+	if len(cfg.AllowedTransports) == 0 {
+		return nil
+	}
+	allowed := make(map[string]bool, len(cfg.AllowedTransports))
+	for _, t := range cfg.AllowedTransports {
+		allowed[t] = true
+	}
+	for _, srv := range cfg.Servers {
+		srvType := srv.Type
+		if srvType == "" {
+			srvType = "stdio"
+		}
+		if !allowed[srvType] {
+			return fmt.Errorf("MCP server %q uses transport %q which is not in allowed_transports %v", srv.ID, srvType, cfg.AllowedTransports)
+		}
+	}
+	return nil
+}
+
 // MCPServerDeclaration defines an MCP server and how to connect to it.
 type MCPServerDeclaration struct {
 	ID             string   `yaml:"id"`
 	Type           string   `yaml:"type"`            // "stdio" | "http" | "sse"
-	Command        string   `yaml:"command"`          // For stdio servers
-	Args           []string `yaml:"args"`             // For stdio servers
-	URL            string   `yaml:"url"`              // For http/sse servers
-	TLSFingerprint string   `yaml:"tls_fingerprint"`  // Optional TLS cert pin
-	AllowedEnv     []string `yaml:"allowed_env"`      // If set, only these env vars (plus standard ones) are passed
-	DeniedEnv      []string `yaml:"denied_env"`       // If set, these env vars are stripped
+	Command        string   `yaml:"command"`         // For stdio servers
+	Args           []string `yaml:"args"`            // For stdio servers
+	URL            string   `yaml:"url"`             // For http/sse servers
+	TLSFingerprint string   `yaml:"tls_fingerprint"` // Optional TLS cert pin
+	AllowedEnv     []string `yaml:"allowed_env"`     // If set, only these env vars (plus standard ones) are passed
+	DeniedEnv      []string `yaml:"denied_env"`      // If set, these env vars are stripped
 }
 
 // MCPServerRule matches servers by ID (supports "*" wildcard).
@@ -562,7 +584,7 @@ type MCPVersionPinningConfig struct {
 // MCPRateLimitsConfig configures MCP rate limiting.
 type MCPRateLimitsConfig struct {
 	Enabled      bool                    `yaml:"enabled"`
-	DefaultRPM   int                     `yaml:"default_rpm"`   // Default calls per minute
+	DefaultRPM   int                     `yaml:"default_rpm"` // Default calls per minute
 	DefaultBurst int                     `yaml:"default_burst"`
 	PerServer    map[string]MCPRateLimit `yaml:"per_server"`
 }
@@ -601,7 +623,7 @@ type BurstConfig struct {
 type CrossServerFlowConfig struct {
 	Enabled      bool          `yaml:"enabled"`
 	SameTurnOnly *bool         `yaml:"same_turn_only"` // default: true
-	Window       time.Duration `yaml:"window"`          // default: 30s
+	Window       time.Duration `yaml:"window"`         // default: 30s
 }
 
 // ShadowToolConfig detects tool names that shadow/mimic tools from other servers.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -557,6 +557,7 @@ type MCPVersionPinningConfig struct {
 	Enabled        bool   `yaml:"enabled"`
 	OnChange       string `yaml:"on_change"`        // block, alert, allow
 	AutoTrustFirst bool   `yaml:"auto_trust_first"` // Pin on first use
+	PinBinary      bool   `yaml:"pin_binary"`
 }
 
 // MCPRateLimitsConfig configures MCP rate limiting.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1430,6 +1430,14 @@ func validateConfig(cfg *Config) error {
 			return fmt.Errorf("invalid sandbox.mcp.sampling.per_server[%q] %q (must be \"allow\", \"alert\", or \"block\")", serverID, policy)
 		}
 	}
+	// Validate version_pinning.on_change enum
+	if cfg.Sandbox.MCP.VersionPinning.OnChange != "" {
+		switch cfg.Sandbox.MCP.VersionPinning.OnChange {
+		case "block", "alert", "allow":
+		default:
+			return fmt.Errorf("invalid sandbox.mcp.version_pinning.on_change %q (must be \"block\", \"alert\", or \"allow\")", cfg.Sandbox.MCP.VersionPinning.OnChange)
+		}
+	}
 	// Validate SimilarityThreshold bounds
 	if t := cfg.Sandbox.MCP.CrossServer.ShadowTool.SimilarityThreshold; t != nil {
 		if *t < 0 || *t > 1 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -534,8 +534,13 @@ func ValidateMCPTransports(cfg SandboxMCPConfig) error {
 	if len(cfg.AllowedTransports) == 0 {
 		return nil
 	}
+	// Validate enum values first.
+	validTransports := map[string]bool{"stdio": true, "http": true, "sse": true}
 	allowed := make(map[string]bool, len(cfg.AllowedTransports))
 	for _, t := range cfg.AllowedTransports {
+		if !validTransports[t] {
+			return fmt.Errorf("invalid allowed_transports value %q (valid: stdio, http, sse)", t)
+		}
 		allowed[t] = true
 	}
 	for _, srv := range cfg.Servers {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -606,7 +606,9 @@ type CrossServerFlowConfig struct {
 
 // ShadowToolConfig detects tool names that shadow/mimic tools from other servers.
 type ShadowToolConfig struct {
-	Enabled *bool `yaml:"enabled"` // default: true
+	Enabled             *bool   `yaml:"enabled"`              // default: true
+	SimilarityCheck     *bool   `yaml:"similarity_check"`     // default: false
+	SimilarityThreshold float64 `yaml:"similarity_threshold"` // default: 0.85
 }
 
 // SecurityConfig controls security mode selection and strictness.
@@ -1041,6 +1043,13 @@ func applyDefaultsWithSource(cfg *Config, source ConfigSource, configPath string
 	if cfg.Sandbox.MCP.CrossServer.ShadowTool.Enabled == nil {
 		t := true
 		cfg.Sandbox.MCP.CrossServer.ShadowTool.Enabled = &t
+	}
+	if cfg.Sandbox.MCP.CrossServer.ShadowTool.SimilarityCheck == nil {
+		f := false
+		cfg.Sandbox.MCP.CrossServer.ShadowTool.SimilarityCheck = &f
+	}
+	if cfg.Sandbox.MCP.CrossServer.ShadowTool.SimilarityThreshold == 0 {
+		cfg.Sandbox.MCP.CrossServer.ShadowTool.SimilarityThreshold = 0.85
 	}
 
 	// macOS XPC defaults

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1406,6 +1406,30 @@ func validateConfig(cfg *Config) error {
 			}
 		}
 	}
+	// Validate output_inspection.on_detection enum
+	if cfg.Sandbox.MCP.OutputInspection.OnDetection != "" {
+		switch cfg.Sandbox.MCP.OutputInspection.OnDetection {
+		case "allow", "alert", "block":
+		default:
+			return fmt.Errorf("invalid sandbox.mcp.output_inspection.on_detection %q (must be \"allow\", \"alert\", or \"block\")", cfg.Sandbox.MCP.OutputInspection.OnDetection)
+		}
+	}
+	// Validate sampling.policy enum
+	if cfg.Sandbox.MCP.Sampling.Policy != "" {
+		switch cfg.Sandbox.MCP.Sampling.Policy {
+		case "allow", "alert", "block":
+		default:
+			return fmt.Errorf("invalid sandbox.mcp.sampling.policy %q (must be \"allow\", \"alert\", or \"block\")", cfg.Sandbox.MCP.Sampling.Policy)
+		}
+	}
+	// Validate sampling.per_server enum values
+	for serverID, policy := range cfg.Sandbox.MCP.Sampling.PerServer {
+		switch policy {
+		case "allow", "alert", "block":
+		default:
+			return fmt.Errorf("invalid sandbox.mcp.sampling.per_server[%q] %q (must be \"allow\", \"alert\", or \"block\")", serverID, policy)
+		}
+	}
 	// Validate SimilarityThreshold bounds
 	if t := cfg.Sandbox.MCP.CrossServer.ShadowTool.SimilarityThreshold; t != nil {
 		if *t < 0 || *t > 1 {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1412,5 +1412,24 @@ func validateConfig(cfg *Config) error {
 			return fmt.Errorf("sandbox.mcp.cross_server.shadow_tool.similarity_threshold must be in [0, 1], got %v", *t)
 		}
 	}
+	// Validate proxy rate limits
+	rl := cfg.Proxy.RateLimits
+	if rl.Enabled {
+		if rl.RequestsPerMinute < 0 {
+			return fmt.Errorf("proxy.rate_limits.requests_per_minute must be >= 0, got %d", rl.RequestsPerMinute)
+		}
+		if rl.RequestBurst < 0 {
+			return fmt.Errorf("proxy.rate_limits.request_burst must be >= 0, got %d", rl.RequestBurst)
+		}
+		if rl.TokensPerMinute < 0 {
+			return fmt.Errorf("proxy.rate_limits.tokens_per_minute must be >= 0, got %d", rl.TokensPerMinute)
+		}
+		if rl.TokenBurst < 0 {
+			return fmt.Errorf("proxy.rate_limits.token_burst must be >= 0, got %d", rl.TokenBurst)
+		}
+		if rl.RequestsPerMinute == 0 && rl.TokensPerMinute == 0 {
+			return fmt.Errorf("proxy.rate_limits: enabled but neither requests_per_minute nor tokens_per_minute is set")
+		}
+	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1520,6 +1520,26 @@ sandbox:
 `,
 			wantErr: "",
 		},
+		{
+			name: "valid version_pinning on_change",
+			yaml: `
+sandbox:
+  mcp:
+    version_pinning:
+      on_change: block
+`,
+			wantErr: "",
+		},
+		{
+			name: "invalid version_pinning on_change",
+			yaml: `
+sandbox:
+  mcp:
+    version_pinning:
+      on_change: deny
+`,
+			wantErr: `invalid sandbox.mcp.version_pinning.on_change "deny"`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1141,7 +1141,7 @@ sandbox:
       - id: internal-tools
         type: http
         url: https://mcp.internal.corp:8443/mcp
-        tls_fingerprint: "sha256:abc123"
+        tls_fingerprint: "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
     server_policy: allowlist
     allowed_servers:
       - id: filesystem
@@ -1196,7 +1196,7 @@ sandbox:
 	assert.Empty(t, mcp.Servers[1].Command)
 
 	assert.Equal(t, "internal-tools", mcp.Servers[2].ID)
-	assert.Equal(t, "sha256:abc123", mcp.Servers[2].TLSFingerprint)
+	assert.Equal(t, "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", mcp.Servers[2].TLSFingerprint)
 
 	// Verify server-level policy
 	assert.Equal(t, "allowlist", mcp.ServerPolicy)
@@ -1259,7 +1259,7 @@ func TestMCPServerDeclaration_YAMLRoundTrip(t *testing.T) {
 				ID:             "api",
 				Type:           "http",
 				URL:            "https://mcp.example.com",
-				TLSFingerprint: "sha256:deadbeef",
+				TLSFingerprint: "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
 			},
 		},
 		ServerPolicy: "allowlist",
@@ -1315,7 +1315,7 @@ func TestMCPServerDeclaration_YAMLRoundTrip(t *testing.T) {
 	assert.Equal(t, "api", roundTripped.Servers[1].ID)
 	assert.Equal(t, "http", roundTripped.Servers[1].Type)
 	assert.Equal(t, "https://mcp.example.com", roundTripped.Servers[1].URL)
-	assert.Equal(t, "sha256:deadbeef", roundTripped.Servers[1].TLSFingerprint)
+	assert.Equal(t, "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", roundTripped.Servers[1].TLSFingerprint)
 
 	// Server rules
 	assert.Equal(t, len(original.AllowedServers), len(roundTripped.AllowedServers))

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1345,6 +1345,8 @@ func TestMCPAllowedTransportsValidation(t *testing.T) {
 		{"stdio only rejects http", []string{"stdio"}, "http", true},
 		{"stdio only allows stdio", []string{"stdio"}, "stdio", false},
 		{"explicit all allows sse", []string{"stdio", "http", "sse"}, "sse", false},
+		{"invalid transport value", []string{"stdio", "grpc"}, "stdio", true},
+		{"typo in transport", []string{"stdoi"}, "stdio", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/config/proxy.go
+++ b/internal/config/proxy.go
@@ -2,9 +2,10 @@ package config
 
 // ProxyConfig configures the embedded LLM proxy.
 type ProxyConfig struct {
-	Mode      string               `yaml:"mode"`
-	Port      int                  `yaml:"port"`
-	Providers ProxyProvidersConfig `yaml:"providers"`
+	Mode       string               `yaml:"mode"`
+	Port       int                  `yaml:"port"`
+	Providers  ProxyProvidersConfig `yaml:"providers"`
+	RateLimits LLMRateLimitsConfig  `yaml:"rate_limits"`
 }
 
 type ProxyProvidersConfig struct {
@@ -51,6 +52,15 @@ type LLMStorageRetentionConfig struct {
 	MaxAgeDays int    `yaml:"max_age_days"`
 	MaxSizeMB  int    `yaml:"max_size_mb"`
 	Eviction   string `yaml:"eviction"`
+}
+
+// LLMRateLimitsConfig configures rate limiting for LLM API calls.
+type LLMRateLimitsConfig struct {
+	Enabled           bool `yaml:"enabled"`
+	RequestsPerMinute int  `yaml:"requests_per_minute"`
+	RequestBurst      int  `yaml:"request_burst"`
+	TokensPerMinute   int  `yaml:"tokens_per_minute"`
+	TokenBurst        int  `yaml:"token_burst"`
 }
 
 func DefaultProxyConfig() ProxyConfig {

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -103,13 +103,14 @@ const (
 
 // MCP inspection events.
 const (
-	EventMCPToolSeen            EventType = "mcp_tool_seen"
-	EventMCPToolChanged         EventType = "mcp_tool_changed"
-	EventMCPToolCalled          EventType = "mcp_tool_called"
-	EventMCPDetection           EventType = "mcp_detection"
-	EventMCPToolCallIntercepted EventType = "mcp_tool_call_intercepted"
-	EventMCPCrossServerBlocked  EventType = "mcp_cross_server_blocked"
-	EventMCPNetworkConnection   EventType = "mcp_network_connection"
+	EventMCPToolSeen              EventType = "mcp_tool_seen"
+	EventMCPToolChanged           EventType = "mcp_tool_changed"
+	EventMCPToolCalled            EventType = "mcp_tool_called"
+	EventMCPDetection             EventType = "mcp_detection"
+	EventMCPToolCallIntercepted   EventType = "mcp_tool_call_intercepted"
+	EventMCPCrossServerBlocked    EventType = "mcp_cross_server_blocked"
+	EventMCPNetworkConnection     EventType = "mcp_network_connection"
+	EventMCPServerNameSimilarity  EventType = "mcp_server_name_similarity"
 )
 
 // Policy events.
@@ -214,13 +215,14 @@ var EventCategory = map[EventType]string{
 	EventSignalWouldDeny:  "signal",
 
 	// MCP
-	EventMCPToolSeen:            "mcp",
-	EventMCPToolChanged:         "mcp",
-	EventMCPToolCalled:          "mcp",
-	EventMCPDetection:           "mcp",
-	EventMCPToolCallIntercepted: "mcp",
-	EventMCPCrossServerBlocked:  "mcp",
-	EventMCPNetworkConnection:   "mcp",
+	EventMCPToolSeen:             "mcp",
+	EventMCPToolChanged:          "mcp",
+	EventMCPToolCalled:           "mcp",
+	EventMCPDetection:            "mcp",
+	EventMCPToolCallIntercepted:  "mcp",
+	EventMCPCrossServerBlocked:   "mcp",
+	EventMCPNetworkConnection:    "mcp",
+	EventMCPServerNameSimilarity: "mcp",
 
 	// Policy
 	EventPolicyLoaded:  "policy",
@@ -259,6 +261,7 @@ var AllEventTypes = []EventType{
 	// MCP
 	EventMCPToolSeen, EventMCPToolChanged, EventMCPToolCalled, EventMCPDetection,
 	EventMCPToolCallIntercepted, EventMCPCrossServerBlocked, EventMCPNetworkConnection,
+	EventMCPServerNameSimilarity,
 	// Policy
 	EventPolicyLoaded, EventPolicyChanged,
 }

--- a/internal/llmproxy/llm_ratelimit.go
+++ b/internal/llmproxy/llm_ratelimit.go
@@ -1,0 +1,63 @@
+package llmproxy
+
+import (
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/pkg/ratelimit"
+)
+
+// LLMRateLimiter enforces RPM (requests per minute) and TPM (tokens per minute)
+// rate limits on LLM API calls to prevent denial-of-wallet attacks.
+type LLMRateLimiter struct {
+	enabled  bool
+	reqLimit *ratelimit.Limiter
+	tpmLimit *ratelimit.Limiter
+}
+
+// NewLLMRateLimiter creates a new LLM rate limiter from configuration.
+func NewLLMRateLimiter(cfg config.LLMRateLimitsConfig) *LLMRateLimiter {
+	l := &LLMRateLimiter{enabled: cfg.Enabled}
+	if !cfg.Enabled {
+		return l
+	}
+	if cfg.RequestsPerMinute > 0 {
+		rate := float64(cfg.RequestsPerMinute) / 60.0
+		burst := cfg.RequestBurst
+		if burst <= 0 {
+			burst = max(cfg.RequestsPerMinute/6, 1)
+		}
+		l.reqLimit = ratelimit.NewLimiter(rate, burst)
+	}
+	if cfg.TokensPerMinute > 0 {
+		rate := float64(cfg.TokensPerMinute) / 60.0
+		burst := cfg.TokenBurst
+		if burst <= 0 {
+			burst = max(cfg.TokensPerMinute/6, 1)
+		}
+		l.tpmLimit = ratelimit.NewLimiter(rate, burst)
+	}
+	return l
+}
+
+// AllowRequest checks whether a new request is allowed under the RPM limit.
+func (l *LLMRateLimiter) AllowRequest() bool {
+	if !l.enabled || l.reqLimit == nil {
+		return true
+	}
+	return l.reqLimit.Allow()
+}
+
+// AllowTokens checks whether the given number of tokens is allowed under the TPM limit.
+func (l *LLMRateLimiter) AllowTokens(n int) bool {
+	if !l.enabled || l.tpmLimit == nil {
+		return true
+	}
+	return l.tpmLimit.AllowN(n)
+}
+
+// ConsumeTokens deducts tokens from the TPM budget after a response is received.
+func (l *LLMRateLimiter) ConsumeTokens(n int) {
+	if !l.enabled || l.tpmLimit == nil || n <= 0 {
+		return
+	}
+	l.tpmLimit.AllowN(n)
+}

--- a/internal/llmproxy/llm_ratelimit.go
+++ b/internal/llmproxy/llm_ratelimit.go
@@ -83,6 +83,11 @@ func (l *LLMRateLimiter) ConsumeTokens(n int) {
 	l.tpmLimit.ForceConsumeN(n)
 }
 
+// TPMEnabled returns true if tokens-per-minute limiting is active.
+func (l *LLMRateLimiter) TPMEnabled() bool {
+	return l.enabled && l.tpmLimit != nil
+}
+
 // inFlightEnabled returns true if the in-flight concurrency limiter is active.
 func (l *LLMRateLimiter) inFlightEnabled() bool {
 	return l.inFlight != nil

--- a/internal/llmproxy/llm_ratelimit.go
+++ b/internal/llmproxy/llm_ratelimit.go
@@ -55,9 +55,10 @@ func (l *LLMRateLimiter) AllowTokens(n int) bool {
 }
 
 // ConsumeTokens deducts tokens from the TPM budget after a response is received.
+// Uses force-consume since the operation already happened and must be accounted for.
 func (l *LLMRateLimiter) ConsumeTokens(n int) {
 	if !l.enabled || l.tpmLimit == nil || n <= 0 {
 		return
 	}
-	l.tpmLimit.AllowN(n)
+	l.tpmLimit.ForceConsumeN(n)
 }

--- a/internal/llmproxy/llm_ratelimit.go
+++ b/internal/llmproxy/llm_ratelimit.go
@@ -46,6 +46,17 @@ func (l *LLMRateLimiter) AllowRequest() bool {
 	return l.reqLimit.Allow()
 }
 
+// TokenBudgetAvailable returns true if the TPM bucket is not depleted.
+// Use this as a pre-request gate: if previous responses have driven the
+// token bucket negative (via ForceConsumeN), block new requests until
+// tokens replenish.
+func (l *LLMRateLimiter) TokenBudgetAvailable() bool {
+	if !l.enabled || l.tpmLimit == nil {
+		return true
+	}
+	return l.tpmLimit.Tokens() > 0
+}
+
 // AllowTokens checks whether the given number of tokens is allowed under the TPM limit.
 func (l *LLMRateLimiter) AllowTokens(n int) bool {
 	if !l.enabled || l.tpmLimit == nil {

--- a/internal/llmproxy/proxy.go
+++ b/internal/llmproxy/proxy.go
@@ -511,12 +511,12 @@ func (p *Proxy) logResponseDirect(requestID, sessionID string, dialect Dialect, 
 	}
 
 	// Consume tokens from the TPM budget for rate limiting.
-	// When TPM is enabled but usage is missing/unparseable, apply a
+	// When TPM is enabled but usage is absent/unparseable, apply a
 	// conservative fallback charge to prevent fail-open bypass.
 	totalTokens := usage.InputTokens + usage.OutputTokens
 	if totalTokens > 0 {
 		p.llmRateLimiter.ConsumeTokens(totalTokens)
-	} else if p.llmRateLimiter.TPMEnabled() {
+	} else if p.llmRateLimiter.TPMEnabled() && !usage.HasUsage {
 		p.llmRateLimiter.ConsumeTokens(tpmFallbackTokenCharge)
 	}
 

--- a/internal/llmproxy/proxy.go
+++ b/internal/llmproxy/proxy.go
@@ -482,9 +482,9 @@ func (p *Proxy) logResponse(requestID, sessionID string, dialect Dialect, resp *
 // logResponseDirect logs a response with a pre-read body (used for SSE streams).
 func (p *Proxy) logResponseDirect(requestID, sessionID string, dialect Dialect, resp *http.Response, respBody []byte, startTime time.Time) {
 	// Extract token usage from the response.
-	// SSE bodies start with "event:" or "data:" lines; use SSE-aware extraction.
+	// Use Content-Type to detect SSE streams rather than body prefix heuristics.
 	var usage Usage
-	if bytes.HasPrefix(respBody, []byte("event:")) || bytes.HasPrefix(respBody, []byte("data:")) {
+	if IsSSEResponse(resp) {
 		usage = ExtractSSEUsage(respBody, dialect)
 	} else {
 		usage = ExtractUsage(respBody, dialect)

--- a/internal/llmproxy/proxy_ratelimit_test.go
+++ b/internal/llmproxy/proxy_ratelimit_test.go
@@ -1,7 +1,14 @@
 package llmproxy
 
 import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/agentsh/agentsh/internal/config"
 )
@@ -126,5 +133,106 @@ func TestLLMRateLimiter_OnlyTPM(t *testing.T) {
 	// TPM should work
 	if !lim.AllowTokens(40) {
 		t.Fatal("40 tokens should be allowed")
+	}
+}
+
+func TestLLMRateLimiter_TokenBudgetAvailable(t *testing.T) {
+	lim := NewLLMRateLimiter(config.LLMRateLimitsConfig{
+		Enabled:         true,
+		TokensPerMinute: 100,
+		TokenBurst:      50,
+	})
+
+	// Initially budget should be available
+	if !lim.TokenBudgetAvailable() {
+		t.Fatal("token budget should be available initially")
+	}
+
+	// Force-consume more than the burst to drive bucket negative
+	lim.ConsumeTokens(100)
+
+	// Now budget should be depleted
+	if lim.TokenBudgetAvailable() {
+		t.Fatal("token budget should be depleted after consuming 100 tokens (burst was 50)")
+	}
+}
+
+func TestProxy_RPM_Returns429(t *testing.T) {
+	// Create a mock upstream that returns a valid Anthropic response
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-sonnet-4-20250514","usage":{"input_tokens":5,"output_tokens":2}}`))
+	}))
+	defer upstream.Close()
+
+	storageDir := t.TempDir()
+	cfg := Config{
+		SessionID: "test-ratelimit",
+		Proxy: config.ProxyConfig{
+			Mode: "embedded",
+			Port: 0,
+			Providers: config.ProxyProvidersConfig{
+				Anthropic: upstream.URL,
+			},
+			RateLimits: config.LLMRateLimitsConfig{
+				Enabled:           true,
+				RequestsPerMinute: 60,
+				RequestBurst:      1, // Only allow 1 request
+			},
+		},
+		DLP: config.DefaultDLPConfig(),
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	proxy, err := New(cfg, storageDir, logger)
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := proxy.Start(ctx); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		proxy.Stop(shutdownCtx)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	addr := proxy.Addr()
+	if addr == nil {
+		t.Fatal("proxy address is nil")
+	}
+	proxyURL := "http://" + addr.String()
+
+	makeRequest := func() *http.Response {
+		req, _ := http.NewRequest("POST", proxyURL+"/v1/messages",
+			strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("x-api-key", "test-key")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return resp
+	}
+
+	// First request should succeed (uses the 1 burst token)
+	resp1 := makeRequest()
+	if resp1.StatusCode == http.StatusTooManyRequests {
+		t.Fatal("first request should not be rate limited")
+	}
+
+	// Second request should be rate limited (429)
+	resp2 := makeRequest()
+	if resp2.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("second request should be 429, got %d", resp2.StatusCode)
+	}
+	if resp2.Header.Get("Retry-After") == "" {
+		t.Error("rate limited response should include Retry-After header")
 	}
 }

--- a/internal/llmproxy/proxy_ratelimit_test.go
+++ b/internal/llmproxy/proxy_ratelimit_test.go
@@ -157,6 +157,87 @@ func TestLLMRateLimiter_TokenBudgetAvailable(t *testing.T) {
 	}
 }
 
+func TestProxy_TPM_Returns429(t *testing.T) {
+	// Upstream returns a response with high token usage to deplete TPM budget.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Report 500 input + 500 output = 1000 total tokens
+		w.Write([]byte(`{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-sonnet-4-20250514","usage":{"input_tokens":500,"output_tokens":500}}`))
+	}))
+	defer upstream.Close()
+
+	storageDir := t.TempDir()
+	cfg := Config{
+		SessionID: "test-tpm-ratelimit",
+		Proxy: config.ProxyConfig{
+			Mode: "embedded",
+			Port: 0,
+			Providers: config.ProxyProvidersConfig{
+				Anthropic: upstream.URL,
+			},
+			RateLimits: config.LLMRateLimitsConfig{
+				Enabled:         true,
+				TokensPerMinute: 6000,
+				TokenBurst:      100, // First response (1000 tokens) will exceed burst
+			},
+		},
+		DLP: config.DefaultDLPConfig(),
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	proxy, err := New(cfg, storageDir, logger)
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := proxy.Start(ctx); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		proxy.Stop(shutdownCtx)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+
+	addr := proxy.Addr()
+	if addr == nil {
+		t.Fatal("proxy address is nil")
+	}
+	proxyURL := "http://" + addr.String()
+
+	makeRequest := func() *http.Response {
+		req, _ := http.NewRequest("POST", proxyURL+"/v1/messages",
+			strings.NewReader(`{"model":"claude-sonnet-4-20250514","messages":[{"role":"user","content":"hi"}]}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("x-api-key", "test-key")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return resp
+	}
+
+	// First request succeeds; upstream reports 1000 tokens which depletes the 100-token burst budget.
+	resp1 := makeRequest()
+	if resp1.StatusCode == http.StatusTooManyRequests {
+		t.Fatal("first request should not be rate limited")
+	}
+
+	// Second request should be rate limited (429) because token budget is depleted.
+	resp2 := makeRequest()
+	if resp2.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("second request should be 429 (TPM depleted), got %d", resp2.StatusCode)
+	}
+	if resp2.Header.Get("Retry-After") == "" {
+		t.Error("TPM rate limited response should include Retry-After header")
+	}
+}
+
 func TestProxy_RPM_Returns429(t *testing.T) {
 	// Create a mock upstream that returns a valid Anthropic response
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/llmproxy/proxy_ratelimit_test.go
+++ b/internal/llmproxy/proxy_ratelimit_test.go
@@ -1,0 +1,130 @@
+package llmproxy
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+func TestLLMRateLimiter_RPM(t *testing.T) {
+	lim := NewLLMRateLimiter(config.LLMRateLimitsConfig{
+		Enabled:           true,
+		RequestsPerMinute: 10,
+		RequestBurst:      2,
+	})
+	for i := 0; i < 2; i++ {
+		if !lim.AllowRequest() {
+			t.Fatalf("request %d should be allowed (within burst)", i)
+		}
+	}
+	if lim.AllowRequest() {
+		t.Fatal("request 3 should be blocked (burst exceeded)")
+	}
+}
+
+func TestLLMRateLimiter_TPM(t *testing.T) {
+	lim := NewLLMRateLimiter(config.LLMRateLimitsConfig{
+		Enabled:         true,
+		TokensPerMinute: 100,
+		TokenBurst:      50,
+	})
+	if !lim.AllowTokens(40) {
+		t.Fatal("40 tokens should be allowed")
+	}
+	if lim.AllowTokens(20) {
+		t.Fatal("20 more should be blocked (only ~10 left)")
+	}
+}
+
+func TestLLMRateLimiter_Disabled(t *testing.T) {
+	lim := NewLLMRateLimiter(config.LLMRateLimitsConfig{Enabled: false})
+	for i := 0; i < 100; i++ {
+		if !lim.AllowRequest() {
+			t.Fatal("should always allow when disabled")
+		}
+	}
+}
+
+func TestLLMRateLimiter_DefaultBurst(t *testing.T) {
+	// When burst is not set, it should default to max(RPM/6, 1)
+	lim := NewLLMRateLimiter(config.LLMRateLimitsConfig{
+		Enabled:           true,
+		RequestsPerMinute: 60,
+		// RequestBurst not set, should default to 60/6 = 10
+	})
+	// Should allow up to 10 requests (default burst)
+	for i := 0; i < 10; i++ {
+		if !lim.AllowRequest() {
+			t.Fatalf("request %d should be allowed (within default burst of 10)", i)
+		}
+	}
+	if lim.AllowRequest() {
+		t.Fatal("request 11 should be blocked (default burst exceeded)")
+	}
+}
+
+func TestLLMRateLimiter_ConsumeTokens(t *testing.T) {
+	lim := NewLLMRateLimiter(config.LLMRateLimitsConfig{
+		Enabled:         true,
+		TokensPerMinute: 100,
+		TokenBurst:      50,
+	})
+	// Consume tokens, then check remaining budget
+	lim.ConsumeTokens(30)
+	if !lim.AllowTokens(15) {
+		t.Fatal("15 tokens should be allowed after consuming 30 of 50 burst")
+	}
+	if lim.AllowTokens(10) {
+		t.Fatal("10 more tokens should be blocked (only ~5 left)")
+	}
+}
+
+func TestLLMRateLimiter_ConsumeTokensZero(t *testing.T) {
+	lim := NewLLMRateLimiter(config.LLMRateLimitsConfig{
+		Enabled:         true,
+		TokensPerMinute: 100,
+		TokenBurst:      50,
+	})
+	// Consuming zero or negative should be a no-op
+	lim.ConsumeTokens(0)
+	lim.ConsumeTokens(-5)
+	if !lim.AllowTokens(50) {
+		t.Fatal("full burst should still be available after consuming 0 tokens")
+	}
+}
+
+func TestLLMRateLimiter_OnlyRPM(t *testing.T) {
+	lim := NewLLMRateLimiter(config.LLMRateLimitsConfig{
+		Enabled:           true,
+		RequestsPerMinute: 10,
+		RequestBurst:      2,
+		// No TPM configured
+	})
+	// RPM should work
+	if !lim.AllowRequest() {
+		t.Fatal("request should be allowed")
+	}
+	// TPM should always allow (not configured)
+	if !lim.AllowTokens(1000000) {
+		t.Fatal("tokens should always be allowed when TPM not configured")
+	}
+}
+
+func TestLLMRateLimiter_OnlyTPM(t *testing.T) {
+	lim := NewLLMRateLimiter(config.LLMRateLimitsConfig{
+		Enabled:         true,
+		TokensPerMinute: 100,
+		TokenBurst:      50,
+		// No RPM configured
+	})
+	// RPM should always allow (not configured)
+	for i := 0; i < 100; i++ {
+		if !lim.AllowRequest() {
+			t.Fatal("requests should always be allowed when RPM not configured")
+		}
+	}
+	// TPM should work
+	if !lim.AllowTokens(40) {
+		t.Fatal("40 tokens should be allowed")
+	}
+}

--- a/internal/llmproxy/usage.go
+++ b/internal/llmproxy/usage.go
@@ -126,13 +126,14 @@ func usageHasTokenFields(body []byte, dialect Dialect) bool {
 	}
 }
 
-// isJSONNumber returns true if raw is a valid JSON number (not null, string, etc.).
+// isJSONNumber returns true if raw is a non-negative JSON number.
+// Rejects null, strings, booleans, and negative numbers — only values
+// starting with a digit are accepted as valid token counts.
 func isJSONNumber(raw json.RawMessage) bool {
 	if len(raw) == 0 {
 		return false
 	}
-	// JSON numbers start with a digit or '-'.
-	return raw[0] == '-' || (raw[0] >= '0' && raw[0] <= '9')
+	return raw[0] >= '0' && raw[0] <= '9'
 }
 
 // sseEvent is a minimal structure for extracting usage from SSE event data lines.

--- a/internal/llmproxy/usage_test.go
+++ b/internal/llmproxy/usage_test.go
@@ -260,6 +260,31 @@ func TestExtractUsage_HasUsage_DecimalTokenValues(t *testing.T) {
 	}
 }
 
+func TestExtractUsage_HasUsage_DecimalTokenValues_OpenAI(t *testing.T) {
+	body := []byte(`{"usage": {"prompt_tokens": 0.5, "completion_tokens": 1.5}}`)
+	usage := ExtractUsage(body, DialectOpenAI)
+	if usage.HasUsage {
+		t.Error("HasUsage should be false for OpenAI when token values are decimals")
+	}
+}
+
+func TestExtractUsage_HasUsage_ExponentTokenValues(t *testing.T) {
+	// Scientific notation like 1e6 is not a valid integer literal.
+	body := []byte(`{"usage": {"input_tokens": 1e6, "output_tokens": 2e3}}`)
+	usage := ExtractUsage(body, DialectAnthropic)
+	if usage.HasUsage {
+		t.Error("HasUsage should be false when token values use scientific notation")
+	}
+}
+
+func TestExtractUsage_HasUsage_ExponentTokenValues_OpenAI(t *testing.T) {
+	body := []byte(`{"usage": {"prompt_tokens": 1e6, "completion_tokens": 2e3}}`)
+	usage := ExtractUsage(body, DialectOpenAI)
+	if usage.HasUsage {
+		t.Error("HasUsage should be false for OpenAI when token values use scientific notation")
+	}
+}
+
 func TestExtractSSEUsage_OpenAI_NegativeTokenUsage(t *testing.T) {
 	// OpenAI SSE chunk with negative token values — HasUsage should be false.
 	body := []byte(

--- a/internal/llmproxy/usage_test.go
+++ b/internal/llmproxy/usage_test.go
@@ -130,3 +130,56 @@ func TestExtractUsage_UnknownDialect(t *testing.T) {
 		t.Errorf("expected OutputTokens=0, got %d", usage.OutputTokens)
 	}
 }
+
+func TestExtractSSEUsage_Anthropic(t *testing.T) {
+	body := []byte(
+		"event: message_start\n" +
+			`data: {"type":"message_start","message":{"id":"msg_01","type":"message","role":"assistant","content":[],"model":"claude-sonnet-4-20250514","stop_reason":null,"usage":{"input_tokens":150,"output_tokens":0}}}` + "\n\n" +
+			"event: content_block_delta\n" +
+			`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}` + "\n\n" +
+			"event: message_delta\n" +
+			`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":42}}` + "\n\n" +
+			"event: message_stop\n" +
+			`data: {"type":"message_stop"}` + "\n\n",
+	)
+
+	usage := ExtractSSEUsage(body, DialectAnthropic)
+	if usage.InputTokens != 150 {
+		t.Errorf("InputTokens = %d, want 150", usage.InputTokens)
+	}
+	if usage.OutputTokens != 42 {
+		t.Errorf("OutputTokens = %d, want 42", usage.OutputTokens)
+	}
+}
+
+func TestExtractSSEUsage_AnthropicEmpty(t *testing.T) {
+	usage := ExtractSSEUsage(nil, DialectAnthropic)
+	if usage.InputTokens != 0 || usage.OutputTokens != 0 {
+		t.Errorf("expected zero usage for nil body, got %+v", usage)
+	}
+}
+
+func TestExtractSSEUsage_OpenAI(t *testing.T) {
+	body := []byte(
+		`data: {"id":"chatcmpl-1","choices":[{"delta":{"content":"Hi"}}]}` + "\n\n" +
+			`data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":100,"completion_tokens":25}}` + "\n\n" +
+			"data: [DONE]\n\n",
+	)
+
+	usage := ExtractSSEUsage(body, DialectOpenAI)
+	if usage.InputTokens != 100 {
+		t.Errorf("InputTokens = %d, want 100", usage.InputTokens)
+	}
+	if usage.OutputTokens != 25 {
+		t.Errorf("OutputTokens = %d, want 25", usage.OutputTokens)
+	}
+}
+
+func TestExtractSSEUsage_PlainJSON(t *testing.T) {
+	// Non-SSE JSON body should return zero from ExtractSSEUsage
+	body := []byte(`{"usage":{"input_tokens":50,"output_tokens":10}}`)
+	usage := ExtractSSEUsage(body, DialectAnthropic)
+	if usage.InputTokens != 0 || usage.OutputTokens != 0 {
+		t.Errorf("expected zero from ExtractSSEUsage on non-SSE body, got %+v", usage)
+	}
+}

--- a/internal/llmproxy/usage_test.go
+++ b/internal/llmproxy/usage_test.go
@@ -190,6 +190,24 @@ func TestExtractUsage_HasUsage_NullUsage(t *testing.T) {
 	}
 }
 
+func TestExtractUsage_HasUsage_PartialAnthropic(t *testing.T) {
+	// Only input_tokens present — incomplete schema should not count as valid usage.
+	body := []byte(`{"usage": {"input_tokens": 0}}`)
+	usage := ExtractUsage(body, DialectAnthropic)
+	if usage.HasUsage {
+		t.Error("HasUsage should be false when only input_tokens is present (partial)")
+	}
+}
+
+func TestExtractUsage_HasUsage_PartialOpenAI(t *testing.T) {
+	// Only prompt_tokens present — incomplete schema should not count as valid usage.
+	body := []byte(`{"usage": {"prompt_tokens": 0}}`)
+	usage := ExtractUsage(body, DialectOpenAI)
+	if usage.HasUsage {
+		t.Error("HasUsage should be false when only prompt_tokens is present (partial)")
+	}
+}
+
 func TestExtractSSEUsage_OpenAI_ZeroTokenUsage(t *testing.T) {
 	// OpenAI SSE chunk with usage present but zero tokens — HasUsage should be true.
 	body := []byte(

--- a/internal/llmproxy/usage_test.go
+++ b/internal/llmproxy/usage_test.go
@@ -234,6 +234,23 @@ func TestExtractUsage_HasUsage_StringTokenValues(t *testing.T) {
 	}
 }
 
+func TestExtractUsage_HasUsage_NegativeTokenValues(t *testing.T) {
+	// Negative token values — should NOT count as valid usage.
+	body := []byte(`{"usage": {"input_tokens": -1, "output_tokens": -1}}`)
+	usage := ExtractUsage(body, DialectAnthropic)
+	if usage.HasUsage {
+		t.Error("HasUsage should be false when token values are negative")
+	}
+}
+
+func TestExtractUsage_HasUsage_NegativeTokenValues_OpenAI(t *testing.T) {
+	body := []byte(`{"usage": {"prompt_tokens": -5, "completion_tokens": -3}}`)
+	usage := ExtractUsage(body, DialectOpenAI)
+	if usage.HasUsage {
+		t.Error("HasUsage should be false for OpenAI when token values are negative")
+	}
+}
+
 func TestExtractSSEUsage_OpenAI_NullTokenUsage(t *testing.T) {
 	// OpenAI SSE chunk with usage keys but null values — HasUsage should be false.
 	body := []byte(

--- a/internal/mcpclient/tls.go
+++ b/internal/mcpclient/tls.go
@@ -1,0 +1,51 @@
+// Package mcpclient provides helpers for connecting to HTTP/SSE MCP servers.
+package mcpclient
+
+import (
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+// ValidateTLSFingerprint checks that a fingerprint string has the correct format.
+// Valid format: "sha256:<64-hex-chars>" or empty string.
+func ValidateTLSFingerprint(fingerprint string) error {
+	if fingerprint == "" {
+		return nil
+	}
+	if !strings.HasPrefix(fingerprint, "sha256:") {
+		return fmt.Errorf("TLS fingerprint must start with 'sha256:', got %q", fingerprint)
+	}
+	hexPart := strings.TrimPrefix(fingerprint, "sha256:")
+	if len(hexPart) != 64 {
+		return fmt.Errorf("TLS fingerprint hex must be 64 characters (SHA-256), got %d", len(hexPart))
+	}
+	if _, err := hex.DecodeString(hexPart); err != nil {
+		return fmt.Errorf("TLS fingerprint contains invalid hex: %w", err)
+	}
+	return nil
+}
+
+// VerifyTLSFingerprint checks that a TLS connection's peer certificate
+// matches the expected SPKI SHA-256 fingerprint.
+// Call this after the TLS handshake completes.
+func VerifyTLSFingerprint(conn *tls.Conn, expected string) error {
+	if expected == "" {
+		return nil
+	}
+	state := conn.ConnectionState()
+	if len(state.PeerCertificates) == 0 {
+		return fmt.Errorf("no peer certificates presented")
+	}
+
+	leaf := state.PeerCertificates[0]
+	spkiHash := sha256.Sum256(leaf.RawSubjectPublicKeyInfo)
+	actual := "sha256:" + hex.EncodeToString(spkiHash[:])
+
+	if actual != expected {
+		return fmt.Errorf("TLS fingerprint mismatch: expected %s, got %s", expected, actual)
+	}
+	return nil
+}

--- a/internal/mcpclient/tls.go
+++ b/internal/mcpclient/tls.go
@@ -35,6 +35,9 @@ func VerifyTLSFingerprint(conn *tls.Conn, expected string) error {
 	if expected == "" {
 		return nil
 	}
+	// Normalize to lowercase so uppercase hex in config still matches
+	expected = strings.ToLower(expected)
+
 	state := conn.ConnectionState()
 	if len(state.PeerCertificates) == 0 {
 		return fmt.Errorf("no peer certificates presented")

--- a/internal/mcpclient/tls_test.go
+++ b/internal/mcpclient/tls_test.go
@@ -1,0 +1,28 @@
+package mcpclient
+
+import (
+	"testing"
+)
+
+func TestValidateTLSFingerprint_Format(t *testing.T) {
+	tests := []struct {
+		name        string
+		fingerprint string
+		wantErr     bool
+	}{
+		{"valid sha256", "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", false},
+		{"empty is ok", "", false},
+		{"missing prefix", "a1b2c3d4e5f6", true},
+		{"wrong prefix", "md5:abc123", true},
+		{"wrong hex length", "sha256:tooshort", true},
+		{"invalid hex chars", "sha256:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateTLSFingerprint(tt.fingerprint)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateTLSFingerprint(%q) error = %v, wantErr %v", tt.fingerprint, err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/mcpclient/tls_test.go
+++ b/internal/mcpclient/tls_test.go
@@ -1,7 +1,19 @@
 package mcpclient
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"math/big"
+	"net"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestValidateTLSFingerprint_Format(t *testing.T) {
@@ -24,5 +36,154 @@ func TestValidateTLSFingerprint_Format(t *testing.T) {
 				t.Errorf("ValidateTLSFingerprint(%q) error = %v, wantErr %v", tt.fingerprint, err, tt.wantErr)
 			}
 		})
+	}
+}
+
+// generateSelfSignedCert creates a self-signed TLS certificate for testing.
+func generateSelfSignedCert(t *testing.T) (tls.Certificate, string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compute expected SPKI fingerprint
+	spkiHash := sha256.Sum256(cert.RawSubjectPublicKeyInfo)
+	fingerprint := "sha256:" + hex.EncodeToString(spkiHash[:])
+
+	tlsCert := tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  key,
+	}
+
+	return tlsCert, fingerprint
+}
+
+func TestVerifyTLSFingerprint_Match(t *testing.T) {
+	tlsCert, expectedFP := generateSelfSignedCert(t)
+
+	// Start a TLS server
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		// Keep connection open until test completes handshake
+		buf := make([]byte, 1)
+		conn.Read(buf)
+		conn.Close()
+	}()
+
+	// Connect and verify fingerprint matches
+	conn, err := tls.Dial("tcp", listener.Addr().String(), &tls.Config{
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	if err := VerifyTLSFingerprint(conn, expectedFP); err != nil {
+		t.Errorf("expected match, got error: %v", err)
+	}
+}
+
+func TestVerifyTLSFingerprint_Mismatch(t *testing.T) {
+	tlsCert, _ := generateSelfSignedCert(t)
+
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		buf := make([]byte, 1)
+		conn.Read(buf)
+		conn.Close()
+	}()
+
+	conn, err := tls.Dial("tcp", listener.Addr().String(), &tls.Config{
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	wrongFP := "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	err = VerifyTLSFingerprint(conn, wrongFP)
+	if err == nil {
+		t.Error("expected mismatch error, got nil")
+	}
+}
+
+func TestVerifyTLSFingerprint_UppercaseMatch(t *testing.T) {
+	tlsCert, expectedFP := generateSelfSignedCert(t)
+
+	listener, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{tlsCert},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		buf := make([]byte, 1)
+		conn.Read(buf)
+		conn.Close()
+	}()
+
+	conn, err := tls.Dial("tcp", listener.Addr().String(), &tls.Config{
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Use uppercase hex — should still match after normalization
+	upperFP := "sha256:" + strings.ToUpper(expectedFP[7:])
+
+	if err := VerifyTLSFingerprint(conn, upperFP); err != nil {
+		t.Errorf("uppercase fingerprint should match after normalization, got: %v", err)
 	}
 }

--- a/internal/mcpinspect/events.go
+++ b/internal/mcpinspect/events.go
@@ -200,6 +200,19 @@ type MCPServerEnvFilteredEvent struct {
 	PassedCount  int       `json:"passed_count"`
 }
 
+// MCPServerNameSimilarityEvent is logged when a new MCP server's name is
+// suspiciously similar to an existing server (possible typosquatting).
+type MCPServerNameSimilarityEvent struct {
+	Type      string    `json:"type"` // "mcp_server_name_similarity"
+	Timestamp time.Time `json:"timestamp"`
+	SessionID string    `json:"session_id"`
+
+	NewServerID     string  `json:"new_server_id"`
+	SimilarServerID string  `json:"similar_server_id"`
+	SimilarityScore float64 `json:"similarity_score"`
+	Severity        string  `json:"severity"` // "warning"
+}
+
 // FieldChange describes what changed in a tool definition.
 type FieldChange struct {
 	Field    string `json:"field"`

--- a/internal/mcpinspect/inspector.go
+++ b/internal/mcpinspect/inspector.go
@@ -105,8 +105,12 @@ func (i *Inspector) Inspect(data []byte, dir Direction) (*InspectResult, error) 
 		return i.handleSamplingRequest(data)
 	case MessageUnknown:
 		// Clean up pending-call entries for unrecognised responses (e.g.
-		// JSON-RPC error responses that lack result.content).
-		i.cleanupPendingCall(data)
+		// JSON-RPC error responses that lack result.content). Only run for
+		// response direction to avoid accidentally deleting entries when an
+		// unknown request happens to carry an id field.
+		if dir == DirectionResponse {
+			i.cleanupPendingCall(data)
+		}
 	}
 
 	return nil, nil

--- a/internal/mcpinspect/inspector_test.go
+++ b/internal/mcpinspect/inspector_test.go
@@ -264,3 +264,54 @@ func TestInspector_ToolsListChanged_WithParams(t *testing.T) {
 		t.Fatalf("expected MCPToolsListChangedEvent, got %T", capturedEvents[0])
 	}
 }
+
+func TestInspector_ErrorResponse_CleansPendingCall(t *testing.T) {
+	var capturedEvents []interface{}
+	emitter := func(event interface{}) {
+		capturedEvents = append(capturedEvents, event)
+	}
+
+	inspector := NewInspector("sess_err", "srv1", emitter)
+
+	// 1. Send a tools/call request to register a pending call.
+	callReq := `{"jsonrpc":"2.0","id":42,"method":"tools/call","params":{"name":"read_file","arguments":{}}}`
+	_, err := inspector.Inspect([]byte(callReq), DirectionRequest)
+	if err != nil {
+		t.Fatalf("Inspect call request failed: %v", err)
+	}
+
+	// Verify pending call was recorded.
+	inspector.mu.Lock()
+	if _, ok := inspector.pendingCalls["42"]; !ok {
+		inspector.mu.Unlock()
+		t.Fatal("expected pending call for id 42")
+	}
+	inspector.mu.Unlock()
+
+	// 2. Send a JSON-RPC error response for that ID.
+	errResp := `{"jsonrpc":"2.0","id":42,"error":{"code":-32600,"message":"tool failed"}}`
+	capturedEvents = nil
+	result, err := inspector.Inspect([]byte(errResp), DirectionResponse)
+	if err != nil {
+		t.Fatalf("Inspect error response failed: %v", err)
+	}
+
+	// Should not block.
+	if result != nil {
+		t.Errorf("error response should not block, got %+v", result)
+	}
+
+	// Should NOT emit mcp_tool_result_inspected (not a tools/call response).
+	for _, ev := range capturedEvents {
+		if e, ok := ev.(MCPToolResultInspectedEvent); ok {
+			t.Errorf("unexpected MCPToolResultInspectedEvent: %+v", e)
+		}
+	}
+
+	// Pending call should be cleaned up.
+	inspector.mu.Lock()
+	if _, ok := inspector.pendingCalls["42"]; ok {
+		t.Error("pending call for id 42 should have been cleaned up")
+	}
+	inspector.mu.Unlock()
+}

--- a/internal/mcpinspect/name_similarity.go
+++ b/internal/mcpinspect/name_similarity.go
@@ -1,0 +1,73 @@
+package mcpinspect
+
+// levenshtein computes the edit distance between two strings.
+func levenshtein(a, b string) int {
+	la, lb := len(a), len(b)
+	if la == 0 {
+		return lb
+	}
+	if lb == 0 {
+		return la
+	}
+	prev := make([]int, lb+1)
+	for j := 0; j <= lb; j++ {
+		prev[j] = j
+	}
+	for i := 1; i <= la; i++ {
+		curr := make([]int, lb+1)
+		curr[0] = i
+		for j := 1; j <= lb; j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			del := prev[j] + 1
+			ins := curr[j-1] + 1
+			sub := prev[j-1] + cost
+			m := del
+			if ins < m {
+				m = ins
+			}
+			if sub < m {
+				m = sub
+			}
+			curr[j] = m
+		}
+		prev = curr
+	}
+	return prev[lb]
+}
+
+// NormalizedSimilarity returns a similarity score between 0.0 and 1.0.
+func NormalizedSimilarity(a, b string) float64 {
+	if a == b {
+		return 1.0
+	}
+	maxLen := max(len(a), len(b))
+	if maxLen == 0 {
+		return 1.0
+	}
+	dist := levenshtein(a, b)
+	return 1.0 - float64(dist)/float64(maxLen)
+}
+
+// CheckServerNameSimilarity checks a new server ID against existing IDs.
+// Returns (similarID, score) or ("", 0) if none exceed the threshold.
+func CheckServerNameSimilarity(newID string, existingIDs []string, threshold float64) (match string, score float64) {
+	var bestMatch string
+	var bestScore float64
+	for _, existing := range existingIDs {
+		if existing == newID {
+			return existing, 1.0
+		}
+		s := NormalizedSimilarity(newID, existing)
+		if s > bestScore {
+			bestScore = s
+			bestMatch = existing
+		}
+	}
+	if bestScore >= threshold {
+		return bestMatch, bestScore
+	}
+	return "", 0
+}

--- a/internal/mcpinspect/name_similarity_test.go
+++ b/internal/mcpinspect/name_similarity_test.go
@@ -1,0 +1,69 @@
+package mcpinspect
+
+import (
+	"testing"
+)
+
+func TestLevenshtein(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"", "", 0},
+		{"abc", "", 3},
+		{"", "abc", 3},
+		{"abc", "abc", 0},
+		{"abc", "abd", 1},
+		{"kitten", "sitting", 3},
+		{"server-git", "server-glt", 1},
+	}
+	for _, tt := range tests {
+		got := levenshtein(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("levenshtein(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestNormalizedSimilarity(t *testing.T) {
+	tests := []struct {
+		a, b      string
+		wantAbove float64
+		wantBelow float64
+	}{
+		{"server-git", "server-git", 1.0, 1.01},
+		{"server-git", "server-glt", 0.89, 0.91},
+		{"modelcontextprotocol", "modelcontextprotoco1", 0.94, 0.96},
+		{"abc", "xyz", -0.01, 0.01},
+	}
+	for _, tt := range tests {
+		got := NormalizedSimilarity(tt.a, tt.b)
+		if got < tt.wantAbove || got > tt.wantBelow {
+			t.Errorf("NormalizedSimilarity(%q, %q) = %f, want [%f, %f]", tt.a, tt.b, got, tt.wantAbove, tt.wantBelow)
+		}
+	}
+}
+
+func TestCheckServerNameSimilarity(t *testing.T) {
+	existing := []string{"server-git", "server-postgres", "weather-api"}
+
+	tests := []struct {
+		name      string
+		newID     string
+		threshold float64
+		wantMatch string
+	}{
+		{"exact match", "server-git", 0.85, "server-git"},
+		{"typo", "server-glt", 0.85, "server-git"},
+		{"no match", "totally-different", 0.85, ""},
+		{"similar to postgres", "server-postgras", 0.85, "server-postgres"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match, _ := CheckServerNameSimilarity(tt.newID, existing, tt.threshold)
+			if match != tt.wantMatch {
+				t.Errorf("match = %q, want %q", match, tt.wantMatch)
+			}
+		})
+	}
+}

--- a/internal/mcpinspect/pins_test.go
+++ b/internal/mcpinspect/pins_test.go
@@ -113,28 +113,28 @@ func TestPinStore_BinaryTrust(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := store.VerifyBinary("server-git", "sha256:abc123")
+	status, _, err := store.VerifyBinary("server-git", "sha256:abc123")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Status != PinStatusMatch {
-		t.Errorf("expected match, got %s", result.Status)
+	if status != "match" {
+		t.Errorf("expected match, got %s", status)
 	}
 
-	result, err = store.VerifyBinary("server-git", "sha256:different")
+	status, _, err = store.VerifyBinary("server-git", "sha256:different")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Status != PinStatusMismatch {
-		t.Errorf("expected mismatch, got %s", result.Status)
+	if status != "mismatch" {
+		t.Errorf("expected mismatch, got %s", status)
 	}
 
-	result, err = store.VerifyBinary("unknown", "sha256:abc")
+	status, _, err = store.VerifyBinary("unknown", "sha256:abc")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.Status != PinStatusNotPinned {
-		t.Errorf("expected not_pinned, got %s", result.Status)
+	if status != "not_pinned" {
+		t.Errorf("expected not_pinned, got %s", status)
 	}
 }
 

--- a/internal/mcpinspect/pins_test.go
+++ b/internal/mcpinspect/pins_test.go
@@ -99,3 +99,64 @@ func TestPinStore_Reset(t *testing.T) {
 		t.Errorf("Expected PinStatusNotPinned after reset, got %v", result.Status)
 	}
 }
+
+func TestPinStore_BinaryTrust(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewPinStore(filepath.Join(dir, "pins.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	err = store.TrustBinary("server-git", "/usr/bin/mcp-server-git", "sha256:abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := store.VerifyBinary("server-git", "sha256:abc123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != PinStatusMatch {
+		t.Errorf("expected match, got %s", result.Status)
+	}
+
+	result, err = store.VerifyBinary("server-git", "sha256:different")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != PinStatusMismatch {
+		t.Errorf("expected mismatch, got %s", result.Status)
+	}
+
+	result, err = store.VerifyBinary("unknown", "sha256:abc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != PinStatusNotPinned {
+		t.Errorf("expected not_pinned, got %s", result.Status)
+	}
+}
+
+func TestPinStore_ListBinaryPins(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewPinStore(filepath.Join(dir, "pins.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	store.TrustBinary("a-server", "/bin/a", "sha256:aaa")
+	store.TrustBinary("b-server", "/bin/b", "sha256:bbb")
+
+	pins, err := store.ListBinaryPins()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pins) != 2 {
+		t.Fatalf("expected 2 pins, got %d", len(pins))
+	}
+	if pins[0].ServerID != "a-server" {
+		t.Errorf("expected a-server first, got %s", pins[0].ServerID)
+	}
+}

--- a/internal/mcpinspect/protocol.go
+++ b/internal/mcpinspect/protocol.go
@@ -176,11 +176,11 @@ func DetectMessageType(data []byte) (MessageType, error) {
 			return MessageToolsListResponse, nil
 		}
 
-		// Classify as tools/call response when content is present (even empty)
-		// or when the response is an error. This ensures pending-call cleanup
-		// for all response shapes. Non-tool error responses may also match here
-		// but are handled gracefully (lookup misses use "unknown" tool name).
-		if msg.Result.Content != nil || len(msg.Error) > 0 {
+		// Classify as tools/call response only when result.content is present
+		// (even empty). Error responses are left as MessageUnknown because
+		// JSON-RPC errors don't indicate which method they belong to —
+		// misclassifying them causes incorrect event emission.
+		if msg.Result.Content != nil {
 			return MessageToolsCallResponse, nil
 		}
 	}

--- a/internal/mcpinspect/protocol_test.go
+++ b/internal/mcpinspect/protocol_test.go
@@ -64,9 +64,9 @@ func TestDetectMessageType(t *testing.T) {
 			expected: MessageToolsCallResponse,
 		},
 		{
-			name:     "tools/call error response",
+			name:     "tools/call error response is unknown (no result.content)",
 			input:    `{"jsonrpc":"2.0","id":4,"error":{"code":-1,"message":"tool failed"}}`,
-			expected: MessageToolsCallResponse,
+			expected: MessageUnknown,
 		},
 		{
 			name:     "sampling request",

--- a/internal/shim/binary_hash.go
+++ b/internal/shim/binary_hash.go
@@ -7,14 +7,19 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 // HashBinary computes SHA-256 of the binary at the given path.
 // If path is not absolute, resolves via exec.LookPath.
 func HashBinary(path string) (absPath string, hash string, err error) {
-	absPath, err = exec.LookPath(path)
-	if err != nil {
-		return "", "", fmt.Errorf("resolve binary path: %w", err)
+	if filepath.IsAbs(path) {
+		absPath = path
+	} else {
+		absPath, err = exec.LookPath(path)
+		if err != nil {
+			return "", "", fmt.Errorf("resolve binary path: %w", err)
+		}
 	}
 	f, err := os.Open(absPath)
 	if err != nil {

--- a/internal/shim/binary_hash.go
+++ b/internal/shim/binary_hash.go
@@ -1,0 +1,29 @@
+package shim
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+)
+
+// HashBinary computes SHA-256 of the binary at the given path.
+// If path is not absolute, resolves via exec.LookPath.
+func HashBinary(path string) (absPath string, hash string, err error) {
+	absPath, err = exec.LookPath(path)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve binary path: %w", err)
+	}
+	f, err := os.Open(absPath)
+	if err != nil {
+		return absPath, "", fmt.Errorf("open binary: %w", err)
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return absPath, "", fmt.Errorf("hash binary: %w", err)
+	}
+	return absPath, "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/shim/binary_hash_test.go
+++ b/internal/shim/binary_hash_test.go
@@ -37,7 +37,9 @@ func TestHashBinary(t *testing.T) {
 }
 
 func TestHashBinary_NotFound(t *testing.T) {
-	_, _, err := HashBinary("/nonexistent/binary")
+	// Use a path in a temp directory that definitely doesn't exist (portable).
+	missing := filepath.Join(t.TempDir(), "nonexistent-binary")
+	_, _, err := HashBinary(missing)
 	if err == nil {
 		t.Fatal("expected error for missing binary")
 	}

--- a/internal/shim/binary_hash_test.go
+++ b/internal/shim/binary_hash_test.go
@@ -1,0 +1,44 @@
+package shim
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHashBinary(t *testing.T) {
+	// Create a temp file to hash
+	dir := t.TempDir()
+	binPath := filepath.Join(dir, "test-binary")
+	if err := os.WriteFile(binPath, []byte("hello world"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	absPath, hash, err := HashBinary(binPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if absPath != binPath {
+		t.Errorf("absPath = %q, want %q", absPath, binPath)
+	}
+	if !strings.HasPrefix(hash, "sha256:") {
+		t.Errorf("hash should start with sha256:, got %q", hash)
+	}
+	if len(hash) != 7+64 { // "sha256:" + 64 hex chars
+		t.Errorf("hash length = %d, want %d", len(hash), 7+64)
+	}
+
+	// Same content = same hash
+	_, hash2, _ := HashBinary(binPath)
+	if hash != hash2 {
+		t.Error("same file should produce same hash")
+	}
+}
+
+func TestHashBinary_NotFound(t *testing.T) {
+	_, _, err := HashBinary("/nonexistent/binary")
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+}

--- a/internal/shim/mcp_env.go
+++ b/internal/shim/mcp_env.go
@@ -7,16 +7,38 @@ import (
 
 // standardVars are environment variables that are always passed through to MCP
 // server processes, even when an allowlist is configured. These are required
-// for basic process operation.
-var standardVars = map[string]bool{
-	"PATH":            true,
-	"HOME":            true,
-	"USER":            true,
-	"SHELL":           true,
-	"TERM":            true,
-	"LANG":            true,
-	"TMPDIR":          true,
-	"XDG_RUNTIME_DIR": true,
+// for basic process operation. The set is OS-aware: on Windows, critical
+// system variables (SYSTEMROOT, COMSPEC, etc.) are included.
+var standardVars = buildStandardVars()
+
+func buildStandardVars() map[string]bool {
+	vars := map[string]bool{
+		"PATH":            true,
+		"HOME":            true,
+		"USER":            true,
+		"SHELL":           true,
+		"TERM":            true,
+		"LANG":            true,
+		"TMPDIR":          true,
+		"XDG_RUNTIME_DIR": true,
+	}
+	if runtime.GOOS == "windows" {
+		for _, v := range []string{
+			"SYSTEMROOT",
+			"COMSPEC",
+			"TEMP",
+			"TMP",
+			"USERPROFILE",
+			"PATHEXT",
+			"APPDATA",
+			"LOCALAPPDATA",
+			"PROGRAMDATA",
+			"SYSTEMDRIVE",
+		} {
+			vars[v] = true
+		}
+	}
+	return vars
 }
 
 // sensitivePatterns are suffix patterns that are stripped by default when an

--- a/internal/shim/mcp_exec.go
+++ b/internal/shim/mcp_exec.go
@@ -62,6 +62,9 @@ func BuildMCPExecWrapper(cfg MCPExecConfig) (*MCPExecWrapper, error) {
 				case "not_pinned":
 					if cfg.AutoTrustFirst {
 						if trustErr := cfg.PinStore.TrustBinary(cfg.ServerID, absPath, hash); trustErr != nil {
+							if cfg.OnChange == "block" {
+								return nil, fmt.Errorf("binary pin: failed to persist trust for %s: %w", cfg.ServerID, trustErr)
+							}
 							log.Printf("binary pin: failed to trust %s: %v", cfg.ServerID, trustErr)
 						}
 					}

--- a/internal/shim/mcp_exec.go
+++ b/internal/shim/mcp_exec.go
@@ -192,6 +192,9 @@ func (w *MCPExecWrapper) WrapCommand(cmd *exec.Cmd) (cleanup func(), err error) 
 		if len(cmd.Args) > 0 {
 			cmd.Args[0] = w.resolvedCommand
 		}
+		// Clear any lookup error from exec.Command — the original command
+		// may not have been in PATH, but we have a verified absolute path.
+		cmd.Err = nil
 	}
 
 	// Apply environment filtering before process launch.

--- a/internal/shim/mcp_exec_test.go
+++ b/internal/shim/mcp_exec_test.go
@@ -28,7 +28,10 @@ func TestBuildMCPExecWrapper(t *testing.T) {
 		},
 	}
 
-	wrapper := BuildMCPExecWrapper(cfg)
+	wrapper, err := BuildMCPExecWrapper(cfg)
+	if err != nil {
+		t.Fatalf("BuildMCPExecWrapper failed: %v", err)
+	}
 	if wrapper == nil {
 		t.Fatal("BuildMCPExecWrapper returned nil")
 	}
@@ -47,7 +50,10 @@ func TestMCPExecWrapper_WrapCommand(t *testing.T) {
 		EventEmitter:    emitter,
 	}
 
-	wrapper := BuildMCPExecWrapper(cfg)
+	wrapper, err := BuildMCPExecWrapper(cfg)
+	if err != nil {
+		t.Fatalf("BuildMCPExecWrapper failed: %v", err)
+	}
 
 	// Create a simple command
 	cmd := exec.Command("cat")

--- a/internal/shim/mcp_integration_test.go
+++ b/internal/shim/mcp_integration_test.go
@@ -25,7 +25,7 @@ func TestMCPIntegration_FullPipeline(t *testing.T) {
 	input := bytes.NewBufferString(serverOutput)
 	output := &bytes.Buffer{}
 
-	err := ForwardWithInspection(input, output, MCPDirectionResponse, bridge.InspectorFunc())
+	err := ForwardWithInspection(input, output, MCPDirectionResponse, bridge.InspectorFunc(), nil)
 	if err != nil {
 		t.Fatalf("ForwardWithInspection failed: %v", err)
 	}

--- a/internal/shim/mcp_wrapper.go
+++ b/internal/shim/mcp_wrapper.go
@@ -3,6 +3,8 @@ package shim
 
 import (
 	"bufio"
+	"encoding/json"
+	"fmt"
 	"io"
 )
 
@@ -32,8 +34,12 @@ type MCPInspector func(data []byte, dir MCPDirection) bool
 
 // ForwardWithInspection copies data from src to dst while calling inspector
 // for each line (JSON-RPC message). If the inspector returns true (blocked),
-// the line is not forwarded. Returns when src is exhausted.
-func ForwardWithInspection(src io.Reader, dst io.Writer, dir MCPDirection, inspector MCPInspector) error {
+// a JSON-RPC error response is written so the caller does not hang waiting
+// for a reply that never arrives. For blocked requests, the error is sent to
+// replyWriter (the client); for blocked responses, it replaces the original
+// in dst. If replyWriter is nil, blocked requests are dropped silently
+// (backward compatible). Returns when src is exhausted.
+func ForwardWithInspection(src io.Reader, dst io.Writer, dir MCPDirection, inspector MCPInspector, replyWriter io.Writer) error {
 	scanner := bufio.NewScanner(src)
 	// Increase buffer size for large messages
 	buf := make([]byte, 64*1024)
@@ -45,7 +51,8 @@ func ForwardWithInspection(src io.Reader, dst io.Writer, dir MCPDirection, inspe
 		// Inspect and check if blocked
 		if inspector != nil && len(line) > 0 {
 			if inspector(line, dir) {
-				continue // blocked, do not forward
+				writeBlockError(line, dir, dst, replyWriter)
+				continue
 			}
 		}
 
@@ -59,4 +66,41 @@ func ForwardWithInspection(src io.Reader, dst io.Writer, dir MCPDirection, inspe
 	}
 
 	return scanner.Err()
+}
+
+// writeBlockError synthesizes a JSON-RPC error response for a blocked message.
+// For request direction, the error is sent to replyWriter (the client).
+// For response direction, the error replaces the blocked message in dst.
+func writeBlockError(blockedMsg []byte, dir MCPDirection, dst, replyWriter io.Writer) {
+	id := extractJSONRPCID(blockedMsg)
+	if id == nil {
+		return // notification or unparseable — no response needed
+	}
+
+	target := dst
+	if dir == MCPDirectionRequest {
+		if replyWriter == nil {
+			return
+		}
+		target = replyWriter
+	}
+
+	errResp := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"error":{"code":-32600,"message":"blocked by security policy"}}`, string(id))
+	target.Write([]byte(errResp))  //nolint:errcheck
+	target.Write([]byte("\n"))     //nolint:errcheck
+}
+
+// extractJSONRPCID extracts the "id" field from a JSON-RPC message.
+// Returns the raw JSON value, or nil if no id is present (e.g. notifications).
+func extractJSONRPCID(data []byte) json.RawMessage {
+	var msg struct {
+		ID json.RawMessage `json:"id"`
+	}
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return nil
+	}
+	if len(msg.ID) == 0 || string(msg.ID) == "null" {
+		return nil
+	}
+	return msg.ID
 }

--- a/internal/shim/mcp_wrapper_test.go
+++ b/internal/shim/mcp_wrapper_test.go
@@ -3,6 +3,7 @@ package shim
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"strings"
 	"testing"
@@ -20,7 +21,7 @@ func TestMCPWrapper_ForwardData(t *testing.T) {
 	}
 
 	// Run wrapper (forwards input to output)
-	err := ForwardWithInspection(input, output, MCPDirectionRequest, inspector)
+	err := ForwardWithInspection(input, output, MCPDirectionRequest, inspector, nil)
 	if err != nil && err != io.EOF {
 		t.Fatalf("ForwardWithInspection failed: %v", err)
 	}
@@ -58,7 +59,7 @@ func TestMCPWrapper_BlockedMessageNotForwarded(t *testing.T) {
 		return bytes.Contains(data, []byte("sampling/createMessage"))
 	}
 
-	err := ForwardWithInspection(input, output, MCPDirectionRequest, inspector)
+	err := ForwardWithInspection(input, output, MCPDirectionRequest, inspector, nil)
 	if err != nil && err != io.EOF {
 		t.Fatalf("ForwardWithInspection failed: %v", err)
 	}
@@ -67,10 +68,141 @@ func TestMCPWrapper_BlockedMessageNotForwarded(t *testing.T) {
 	if !strings.Contains(out, `"id":1`) {
 		t.Error("expected first message (id:1) to be forwarded")
 	}
-	if strings.Contains(out, `"id":2`) {
-		t.Error("expected second message (id:2) to be blocked (not forwarded)")
+	if strings.Contains(out, `"sampling/createMessage"`) {
+		t.Error("expected second message (sampling) to be blocked (not forwarded)")
 	}
 	if !strings.Contains(out, `"id":3`) {
 		t.Error("expected third message (id:3) to be forwarded")
+	}
+}
+
+func TestMCPWrapper_BlockedRequest_WritesErrorToReplyWriter(t *testing.T) {
+	input := bytes.NewBufferString(
+		`{"jsonrpc":"2.0","id":42,"method":"sampling/createMessage","params":{}}` + "\n",
+	)
+	dst := &bytes.Buffer{}
+	replyWriter := &bytes.Buffer{}
+
+	inspector := func(data []byte, dir MCPDirection) bool {
+		return true // block everything
+	}
+
+	err := ForwardWithInspection(input, dst, MCPDirectionRequest, inspector, replyWriter)
+	if err != nil {
+		t.Fatalf("ForwardWithInspection failed: %v", err)
+	}
+
+	// The original message must not be forwarded to dst (server stdin).
+	if dst.Len() > 0 {
+		t.Error("blocked request should not be forwarded to dst")
+	}
+
+	// A JSON-RPC error should appear on the replyWriter (client stdout).
+	reply := replyWriter.String()
+	if !strings.Contains(reply, `"error"`) {
+		t.Fatalf("expected JSON-RPC error in replyWriter, got: %s", reply)
+	}
+
+	var errResp struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Error   struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(reply)), &errResp); err != nil {
+		t.Fatalf("failed to parse error response: %v", err)
+	}
+	if string(errResp.ID) != "42" {
+		t.Errorf("error response id = %s, want 42", errResp.ID)
+	}
+	if errResp.Error.Code != -32600 {
+		t.Errorf("error code = %d, want -32600", errResp.Error.Code)
+	}
+	if !strings.Contains(errResp.Error.Message, "blocked") {
+		t.Errorf("error message = %q, want to contain 'blocked'", errResp.Error.Message)
+	}
+}
+
+func TestMCPWrapper_BlockedResponse_WritesErrorToDst(t *testing.T) {
+	input := bytes.NewBufferString(
+		`{"jsonrpc":"2.0","id":7,"result":{"content":[{"type":"text","text":"evil"}]}}` + "\n",
+	)
+	dst := &bytes.Buffer{}
+
+	inspector := func(data []byte, dir MCPDirection) bool {
+		return true // block everything
+	}
+
+	err := ForwardWithInspection(input, dst, MCPDirectionResponse, inspector, nil)
+	if err != nil {
+		t.Fatalf("ForwardWithInspection failed: %v", err)
+	}
+
+	// For response direction, the error should be written to dst.
+	out := dst.String()
+	if !strings.Contains(out, `"error"`) {
+		t.Fatalf("expected JSON-RPC error in dst for blocked response, got: %s", out)
+	}
+	if !strings.Contains(out, `"id":7`) {
+		t.Error("error response should contain the original message id")
+	}
+}
+
+func TestMCPWrapper_BlockedNotification_NoError(t *testing.T) {
+	// Notifications have no "id" field — blocking them should not produce an error.
+	input := bytes.NewBufferString(
+		`{"jsonrpc":"2.0","method":"notifications/tools/list_changed"}` + "\n",
+	)
+	dst := &bytes.Buffer{}
+	replyWriter := &bytes.Buffer{}
+
+	inspector := func(data []byte, dir MCPDirection) bool {
+		return true // block
+	}
+
+	err := ForwardWithInspection(input, dst, MCPDirectionRequest, inspector, replyWriter)
+	if err != nil {
+		t.Fatalf("ForwardWithInspection failed: %v", err)
+	}
+
+	if dst.Len() > 0 {
+		t.Error("blocked notification should not produce output on dst")
+	}
+	if replyWriter.Len() > 0 {
+		t.Error("blocked notification should not produce output on replyWriter")
+	}
+}
+
+func TestExtractJSONRPCID(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		wantID string
+		wantOK bool
+	}{
+		{"numeric id", `{"jsonrpc":"2.0","id":42,"method":"foo"}`, "42", true},
+		{"string id", `{"jsonrpc":"2.0","id":"abc","method":"foo"}`, `"abc"`, true},
+		{"null id", `{"jsonrpc":"2.0","id":null,"method":"foo"}`, "", false},
+		{"no id", `{"jsonrpc":"2.0","method":"foo"}`, "", false},
+		{"invalid json", `not json`, "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id := extractJSONRPCID([]byte(tt.input))
+			if tt.wantOK {
+				if id == nil {
+					t.Fatal("expected non-nil id")
+				}
+				if string(id) != tt.wantID {
+					t.Errorf("id = %s, want %s", id, tt.wantID)
+				}
+			} else {
+				if id != nil {
+					t.Errorf("expected nil id, got %s", id)
+				}
+			}
+		})
 	}
 }

--- a/pkg/ratelimit/limiter.go
+++ b/pkg/ratelimit/limiter.go
@@ -262,3 +262,21 @@ func (l *Limiter) SetBurst(burst int) {
 		l.tokens = float64(burst)
 	}
 }
+
+// ForceConsumeN unconditionally deducts n tokens, allowing the bucket to go negative.
+// Use this for post-fact accounting where the operation already happened.
+func (l *Limiter) ForceConsumeN(n int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(l.lastTime).Seconds()
+	l.lastTime = now
+
+	l.tokens += elapsed * l.rate
+	if l.tokens > float64(l.burst) {
+		l.tokens = float64(l.burst)
+	}
+
+	l.tokens -= float64(n)
+}


### PR DESCRIPTION
## Summary

Closes the remaining MCP attack coverage gaps identified in the gap analysis (P2 + P3 items). P0+P1 were shipped in #111.

- **Transport policy** — `allowed_transports` field on `SandboxMCPConfig` restricts MCP servers to specific transports (stdio/http/sse), validated at config load
- **LLM API rate limiting** — RPM and TPM token-bucket limiters in the proxy with 429 responses and post-response token accounting via `ForceConsumeN`
- **Server binary pinning** — SHA-256 hash pinning of MCP server binaries at launch time, extending PinStore with `mcp_server_pins` table; block/alert/allow on mismatch
- **TLS fingerprint validation** — `ValidateTLSFingerprint` format check + `VerifyTLSFingerprint` SPKI verification helper for future HTTP/SSE transport
- **Name similarity detection** — Levenshtein-based typosquatting detection for MCP server names with configurable threshold (default 0.85)

## Test plan
- [x] All 73 packages pass (`go test ./... -count=1`)
- [x] Windows cross-compilation (`GOOS=windows go build ./...`)
- [x] Spec compliance review — all 5 tasks verified against plan
- [x] Code quality review — critical/important issues fixed (interface mismatch, config validation wiring, force-consume tokens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)