### PR TITLE
feat(otel): rename agentsh.* attributes to canyonroad.* namespace

### DIFF
--- a/internal/store/otel/convert.go
+++ b/internal/store/otel/convert.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// convertToLogRecord converts an agentsh Event to an OTEL log Record.
+// convertToLogRecord converts an Event to an OTEL log Record.
 // The returned record is intended for use with Logger.Emit().
 func convertToLogRecord(ev types.Event) otellog.Record {
 	var rec otellog.Record
@@ -86,7 +86,7 @@ func eventSeverity(ev types.Event) otellog.Severity {
 }
 
 // eventAttributes builds OTEL log attributes from an event using semantic
-// conventions where applicable and the agentsh.* namespace for custom fields.
+// conventions where applicable and the canyonroad.* namespace for custom fields.
 func eventAttributes(ev types.Event) []otellog.KeyValue {
 	var attrs []otellog.KeyValue
 
@@ -101,43 +101,44 @@ func eventAttributes(ev types.Event) []otellog.KeyValue {
 		attrs = append(attrs, otellog.String("process.executable.path", ev.Filename))
 	}
 
-	// agentsh namespace.
+	// canyonroad namespace.
+	attrs = append(attrs, otellog.String("canyonroad.product", "agentsh"))
 	if ev.ID != "" {
-		attrs = append(attrs, otellog.String("agentsh.event.id", ev.ID))
+		attrs = append(attrs, otellog.String("canyonroad.event.id", ev.ID))
 	}
-	attrs = append(attrs, otellog.String("agentsh.event.type", ev.Type))
+	attrs = append(attrs, otellog.String("canyonroad.event.type", ev.Type))
 	if ev.SessionID != "" {
-		attrs = append(attrs, otellog.String("agentsh.session.id", ev.SessionID))
+		attrs = append(attrs, otellog.String("canyonroad.session.id", ev.SessionID))
 	}
 	if ev.CommandID != "" {
-		attrs = append(attrs, otellog.String("agentsh.command.id", ev.CommandID))
+		attrs = append(attrs, otellog.String("canyonroad.command.id", ev.CommandID))
 	}
 	if ev.Source != "" {
-		attrs = append(attrs, otellog.String("agentsh.source", ev.Source))
+		attrs = append(attrs, otellog.String("canyonroad.source", ev.Source))
 	}
 	if ev.Path != "" {
-		attrs = append(attrs, otellog.String("agentsh.path", ev.Path))
+		attrs = append(attrs, otellog.String("canyonroad.path", ev.Path))
 	}
 	if ev.Domain != "" {
-		attrs = append(attrs, otellog.String("agentsh.domain", ev.Domain))
+		attrs = append(attrs, otellog.String("canyonroad.domain", ev.Domain))
 	}
 	if ev.Remote != "" {
-		attrs = append(attrs, otellog.String("agentsh.remote", ev.Remote))
+		attrs = append(attrs, otellog.String("canyonroad.remote", ev.Remote))
 	}
 	if ev.Operation != "" {
-		attrs = append(attrs, otellog.String("agentsh.operation", ev.Operation))
+		attrs = append(attrs, otellog.String("canyonroad.operation", ev.Operation))
 	}
 	if ev.EffectiveAction != "" {
-		attrs = append(attrs, otellog.String("agentsh.effective_action", ev.EffectiveAction))
+		attrs = append(attrs, otellog.String("canyonroad.effective_action", ev.EffectiveAction))
 	}
 
 	// Policy info.
 	if ev.Policy != nil {
 		if ev.Policy.Decision != "" {
-			attrs = append(attrs, otellog.String("agentsh.decision", string(ev.Policy.Decision)))
+			attrs = append(attrs, otellog.String("canyonroad.decision", string(ev.Policy.Decision)))
 		}
 		if ev.Policy.Rule != "" {
-			attrs = append(attrs, otellog.String("agentsh.policy.rule", ev.Policy.Rule))
+			attrs = append(attrs, otellog.String("canyonroad.policy.rule", ev.Policy.Rule))
 		}
 	}
 
@@ -156,14 +157,14 @@ func eventAttributes(ev types.Event) []otellog.KeyValue {
 			switch val := v.(type) {
 			case string:
 				if val != "" {
-					attrs = append(attrs, otellog.String("agentsh."+key, val))
+					attrs = append(attrs, otellog.String("canyonroad."+key, val))
 				}
 			case int:
-				attrs = append(attrs, otellog.Int("agentsh."+key, val))
+				attrs = append(attrs, otellog.Int("canyonroad."+key, val))
 			case int64:
-				attrs = append(attrs, otellog.Int64("agentsh."+key, val))
+				attrs = append(attrs, otellog.Int64("canyonroad."+key, val))
 			case float64:
-				attrs = append(attrs, otellog.Float64("agentsh."+key, val))
+				attrs = append(attrs, otellog.Float64("canyonroad."+key, val))
 			}
 		}
 	}
@@ -207,8 +208,8 @@ func extractSpanID(ev types.Event) (trace.SpanID, bool) {
 	return sid, true
 }
 
-// BuildResource creates an OTEL Resource with the agentsh service name and
-// optional extra attributes.
+// BuildResource creates an OTEL Resource with the service name and optional
+// extra attributes.
 func BuildResource(serviceName string, extraAttrs map[string]string) *resource.Resource {
 	kvs := []attribute.KeyValue{
 		semconv.ServiceName(serviceName),

--- a/internal/store/otel/convert_test.go
+++ b/internal/store/otel/convert_test.go
@@ -153,12 +153,13 @@ func TestConvertToLogRecord_Attributes(t *testing.T) {
 	attrs := logRecordAttrs(rec)
 	assertAttr(t, attrs, "process.pid", int64(100))
 	assertAttr(t, attrs, "process.parent_pid", int64(50))
-	assertAttr(t, attrs, "agentsh.event.type", "file_write")
-	assertAttr(t, attrs, "agentsh.session.id", "sess-1")
-	assertAttr(t, attrs, "agentsh.command.id", "cmd-1")
-	assertAttr(t, attrs, "agentsh.path", "/workspace/test.go")
-	assertAttr(t, attrs, "agentsh.decision", "allow")
-	assertAttr(t, attrs, "agentsh.policy.rule", "allow-workspace")
+	assertAttr(t, attrs, "canyonroad.product", "agentsh")
+	assertAttr(t, attrs, "canyonroad.event.type", "file_write")
+	assertAttr(t, attrs, "canyonroad.session.id", "sess-1")
+	assertAttr(t, attrs, "canyonroad.command.id", "cmd-1")
+	assertAttr(t, attrs, "canyonroad.path", "/workspace/test.go")
+	assertAttr(t, attrs, "canyonroad.decision", "allow")
+	assertAttr(t, attrs, "canyonroad.policy.rule", "allow-workspace")
 }
 
 func TestConvertToLogRecord_FieldsAttributes(t *testing.T) {
@@ -180,14 +181,14 @@ func TestConvertToLogRecord_FieldsAttributes(t *testing.T) {
 	rec := convertToLogRecord(ev)
 	attrs := logRecordAttrs(rec)
 
-	assertAttr(t, attrs, "agentsh.risk_level", "high")
-	assertAttr(t, attrs, "agentsh.agent_id", "agent-1")
-	assertAttr(t, attrs, "agentsh.latency_us", int64(1500))
-	assertAttr(t, attrs, "agentsh.error", "permission denied")
+	assertAttr(t, attrs, "canyonroad.risk_level", "high")
+	assertAttr(t, attrs, "canyonroad.agent_id", "agent-1")
+	assertAttr(t, attrs, "canyonroad.latency_us", int64(1500))
+	assertAttr(t, attrs, "canyonroad.error", "permission denied")
 
 	// Custom fields not in the well-known list should not appear.
-	if _, ok := attrs["agentsh.custom_field"]; ok {
-		t.Error("unexpected attribute agentsh.custom_field")
+	if _, ok := attrs["canyonroad.custom_field"]; ok {
+		t.Error("unexpected attribute canyonroad.custom_field")
 	}
 }
 
@@ -206,8 +207,8 @@ func TestConvertToLogRecord_OptionalFieldsOmitted(t *testing.T) {
 		t.Error("unexpected attribute process.pid when PID=0")
 	}
 	// No policy -> no decision attribute.
-	if _, ok := attrs["agentsh.decision"]; ok {
-		t.Error("unexpected attribute agentsh.decision when no policy")
+	if _, ok := attrs["canyonroad.decision"]; ok {
+		t.Error("unexpected attribute canyonroad.decision when no policy")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Renames all OTEL attribute prefixes from `agentsh.*` to `canyonroad.*` in `internal/store/otel/convert.go`
- Adds `canyonroad.product = "agentsh"` attribute to every log record for product identification
- Updates all test assertions in `convert_test.go` to match the new namespace

## Test plan
- [x] All OTEL package tests pass (`go test ./internal/store/otel/...`)
- [x] Full test suite passes (`go test ./...`)
- [x] Windows cross-compilation passes (`GOOS=windows go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)