### PR TITLE
feat: real-paths mode to preserve host directory paths in sessions

### DIFF
--- a/docs/plans/2026-03-01-real-paths-design.md
+++ b/docs/plans/2026-03-01-real-paths-design.md
@@ -1,0 +1,207 @@
+# Real Paths: Preserve Host Paths in Agent Sessions
+
+## Overview
+
+Add a `real-paths` option that uses the actual host directory path as the session's virtual root instead of hardcoding `/workspace`. When enabled, an agent (e.g., Claude Code) sees `/home/user/work/myproject` rather than `/workspace`, eliminating confusion around file paths, git operations, and tool output.
+
+## Problem Statement
+
+agentsh virtualizes all workspace access under `/workspace`. This confuses path-aware agents like Claude Code that:
+- Read `git status` output containing real paths
+- Use absolute paths in tool calls
+- Reference file paths in their output
+
+The mismatch between what the agent sees (`/workspace`) and where the code actually lives causes navigation errors and broken path references.
+
+## Solution
+
+Make the virtual root configurable per-session. When `real-paths` is enabled, the session uses the absolute workspace path as its virtual root. Access to paths outside the workspace is governed by the policy engine and enforced by seccomp.
+
+## Configuration
+
+### CLI Flag
+
+```bash
+agentsh session create --workspace /home/user/work/myproject --real-paths
+```
+
+### YAML Config
+
+```yaml
+sessions:
+  real_paths: false  # default: off for backwards compatibility
+```
+
+CLI flag `--real-paths` overrides the config value.
+
+### API Request
+
+```json
+{
+  "workspace": "/home/user/work/myproject",
+  "real_paths": true
+}
+```
+
+## Design
+
+### Session Virtual Root
+
+Add a `VirtualRoot` field to the `Session` struct:
+
+```go
+type Session struct {
+    // ... existing fields ...
+    VirtualRoot string  // "/workspace" or real path
+}
+```
+
+At session creation:
+- `real_paths: false` -> `VirtualRoot = "/workspace"` (current behavior)
+- `real_paths: true` -> `VirtualRoot = Workspace` (absolute real path)
+
+All hardcoded `/workspace` references (~30 runtime occurrences across 8 files) become `s.VirtualRoot`.
+
+### Path Resolution
+
+The `resolvePathForBuiltin` function changes from:
+
+```go
+if !strings.HasPrefix(path, "/workspace") {
+    return error("path must be under /workspace")
+}
+rel := strings.TrimPrefix(path, "/workspace")
+real = filepath.Join(s.WorkspaceMountPath(), rel)
+```
+
+To:
+
+```go
+if strings.HasPrefix(path, s.VirtualRoot) {
+    // Inside workspace - resolve through FUSE mount
+    rel := strings.TrimPrefix(path, s.VirtualRoot)
+    real = filepath.Join(s.WorkspaceMountPath(), rel)
+} else {
+    // Outside workspace - pass through as-is
+    // Seccomp + policy engine enforce access control
+    real = path
+}
+```
+
+Same pattern applies in `exec.go` for `working_dir` resolution.
+
+### Outside-Workspace Path Access
+
+When the agent references a path outside the workspace (e.g., `~/.gitconfig`):
+
+1. The path passes through without FUSE translation
+2. Seccomp traps the syscall (`openat`, etc.)
+3. `FileHandler` sees the path is not under a FUSE mount
+4. `FileHandler` calls `policy.CheckFile(path, operation)`
+5. If denied and `EnforceWithoutFUSE: true` -> returns EACCES
+6. If allowed -> syscall proceeds normally
+
+This requires no new interception code. The seccomp `FileHandler` already has full enforcement for non-FUSE paths (`internal/netmonitor/unix/file_handler.go:69-115`).
+
+### Policy Configuration
+
+The policy engine already uses default-deny with first-match-wins evaluation. A policy for real-paths mode:
+
+```yaml
+file_rules:
+  # Workspace - full access
+  - name: allow-workspace
+    paths: ["${PROJECT_ROOT}/**"]
+    operations: ["*"]
+    decision: allow
+
+  # Additional read-only paths
+  - name: allow-git-config
+    paths: ["${HOME}/.gitconfig"]
+    operations: [read, open, stat]
+    decision: allow
+
+  - name: allow-ssh-known-hosts
+    paths: ["${HOME}/.ssh/known_hosts"]
+    operations: [read, open, stat]
+    decision: allow
+
+  # Default deny covers everything else (implicit in engine)
+```
+
+### FUSE Virtual Path Construction
+
+The FUSE layer constructs virtual paths for events and audit logs. `FSConfig` gets a new field:
+
+```go
+type FSConfig struct {
+    // ... existing fields ...
+    VirtualRoot string
+}
+```
+
+`fuse.go` replaces hardcoded `/workspace` with `cfg.VirtualRoot` in path construction, so events report paths matching what the agent sees.
+
+## Files Changed
+
+| File | Changes |
+|------|---------|
+| `internal/config/config.go` | Add `RealPaths bool` to sessions config |
+| `internal/cli/session.go` | Add `--real-paths` flag |
+| `internal/session/manager.go` | Add `VirtualRoot` field, replace ~11 `/workspace` literals |
+| `internal/api/exec.go` | Replace 3 `/workspace` references with `VirtualRoot` |
+| `internal/api/core.go` | Pass `RealPaths` config when creating sessions |
+| `internal/api/app.go` | Replace 2 `/workspace` references in event validation |
+| `internal/fsmonitor/fuse.go` | Replace 5 `/workspace` references, use `VirtualRoot` from config |
+| `internal/fsmonitor/path.go` | Replace 3 `/workspace` references |
+| `internal/platform/` types | Add `VirtualRoot` to `FSConfig` |
+| `pkg/types/sessions.go` | Add `RealPaths` to `CreateSessionRequest` |
+
+**Not changed:**
+- Policy engine - already supports real paths and default deny
+- Seccomp/FileHandler - already enforces on non-FUSE paths
+- K8s sidecar - separate concern, keeps its own `/workspace` default
+
+## Edge Cases
+
+### Symlinks escaping the workspace
+
+Agent reads a workspace symlink pointing outside. FUSE resolves symlinks before policy checking for workspace paths. For outside-workspace paths, seccomp traps the resolved path. No change needed.
+
+### Relative path traversal
+
+Agent runs `cat ../../etc/passwd` from inside the workspace. Path resolution cleans and resolves to absolute before checking. The resolved path falls outside the workspace, goes through seccomp, and policy denies it.
+
+### Broad workspace paths
+
+If the workspace is `$HOME` or `/`, the workspace prefix is very broad. Policy still controls access, but this is a user footgun. Document that `--real-paths` works best with project-level directories.
+
+### Trailing slashes
+
+Normalize `VirtualRoot` to strip trailing slashes at session creation to prevent prefix-matching bugs.
+
+### EnforceWithoutFUSE interaction
+
+When `real_paths: true` and `EnforceWithoutFUSE: false`, outside-workspace accesses are audit-only (logged but allowed). Emit a warning at startup when this combination is detected.
+
+## Testing Strategy
+
+### Unit tests
+
+- Session creation with `real_paths: true` sets `VirtualRoot` to the workspace path
+- Session creation with `real_paths: false` sets `VirtualRoot` to `/workspace`
+- `resolvePathForBuiltin` with real virtual root: inside-workspace paths resolve through mount, outside-workspace paths pass through
+- `cd` builtin with real paths: navigates within workspace, outside paths handled by policy
+- `working_dir` validation in exec uses `VirtualRoot`
+
+### Integration tests
+
+- Session with `--real-paths`: `pwd` returns real path
+- Outside-workspace access with allowing policy: succeeds
+- Outside-workspace access with no policy rule: gets EACCES
+- Session without `--real-paths`: existing `/workspace` behavior unchanged
+
+### Manual verification
+
+- Run Claude Code through agentsh with `--real-paths`
+- Confirm `git status`, file paths, and navigation all use real paths

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -960,10 +960,6 @@ func guidanceForResponse(req types.ExecRequest, res types.ExecResult, blockedOps
 			})
 		}
 
-		// File policy recourse.
-		if strings.HasPrefix(ev.Type, "file_") || strings.HasPrefix(ev.Type, "dir_") || strings.HasPrefix(ev.Type, "symlink_") {
-		}
-
 		// Generic remediation.
 		g.Suggestions = append(g.Suggestions, types.Suggestion{
 			Action: "inspect_events",

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -81,6 +81,10 @@ func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Stor
 		fmt.Fprintf(os.Stderr, "platform init: %v\n", err)
 	}
 
+	if cfg.Sessions.RealPaths && !cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE {
+		slog.Warn("real_paths enabled but enforce_without_fuse is false: outside-workspace file access will be audit-only (not blocked)")
+	}
+
 	return &App{
 		cfg:          cfg,
 		sessions:     sessions,

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -958,12 +958,6 @@ func guidanceForResponse(req types.ExecRequest, res types.ExecResult, blockedOps
 
 		// File policy recourse.
 		if strings.HasPrefix(ev.Type, "file_") || strings.HasPrefix(ev.Type, "dir_") || strings.HasPrefix(ev.Type, "symlink_") {
-			if ev.Path != "" && !strings.HasPrefix(ev.Path, "/workspace") {
-				g.Suggestions = append(g.Suggestions, types.Suggestion{
-					Action: "move_to_workspace",
-					Reason: "copy/move required inputs under /workspace so the policy can allow access",
-				})
-			}
 		}
 
 		// Generic remediation.

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -861,7 +861,7 @@ func guidanceForPolicyDenied(req types.ExecRequest, pre policy.Decision, preEv t
 	return g
 }
 
-func guidanceForResponse(req types.ExecRequest, res types.ExecResult, blockedOps []types.Event) *types.ExecGuidance {
+func guidanceForResponse(req types.ExecRequest, res types.ExecResult, blockedOps []types.Event, virtualRoot string) *types.ExecGuidance {
 	g := &types.ExecGuidance{}
 
 	if len(blockedOps) > 0 {
@@ -958,6 +958,18 @@ func guidanceForResponse(req types.ExecRequest, res types.ExecResult, blockedOps
 				Command: "https://" + strings.TrimSuffix(target, ":80"),
 				Reason:  "try HTTPS (port 443) instead of HTTP (port 80)",
 			})
+		}
+
+		// File policy recourse (only in default /workspace mode).
+		if virtualRoot == "/workspace" {
+			if strings.HasPrefix(ev.Type, "file_") || strings.HasPrefix(ev.Type, "dir_") || strings.HasPrefix(ev.Type, "symlink_") {
+				if ev.Path != "" && !strings.HasPrefix(ev.Path, "/workspace") {
+					g.Suggestions = append(g.Suggestions, types.Suggestion{
+						Action: "move_to_workspace",
+						Reason: "copy/move required inputs under /workspace so the policy can allow access",
+					})
+				}
+			}
 		}
 
 		// Generic remediation.

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -963,7 +963,7 @@ func guidanceForResponse(req types.ExecRequest, res types.ExecResult, blockedOps
 		// File policy recourse (only in default /workspace mode).
 		if virtualRoot == "/workspace" {
 			if strings.HasPrefix(ev.Type, "file_") || strings.HasPrefix(ev.Type, "dir_") || strings.HasPrefix(ev.Type, "symlink_") {
-				if ev.Path != "" && !strings.HasPrefix(ev.Path, "/workspace") {
+				if ev.Path != "" && !session.IsUnderRoot(ev.Path, "/workspace") {
 					g.Suggestions = append(g.Suggestions, types.Suggestion{
 						Action: "move_to_workspace",
 						Reason: "copy/move required inputs under /workspace so the policy can allow access",

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -427,6 +427,10 @@ func (a *App) createSessionWithProfile(ctx context.Context, req types.CreateSess
 	}
 	if realPaths {
 		s.SetRealPaths(true)
+		if !a.cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE {
+			slog.Warn("session created with real_paths but enforce_without_fuse is false: outside-workspace file access will be audit-only",
+				"session_id", s.ID)
+		}
 	}
 
 	// Generate TOTP secret if TOTP approval mode is enabled
@@ -576,6 +580,10 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 	}
 	if realPaths {
 		s.SetRealPaths(true)
+		if !a.cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE {
+			slog.Warn("session created with real_paths but enforce_without_fuse is false: outside-workspace file access will be audit-only",
+				"session_id", s.ID)
+		}
 	}
 
 	// Generate TOTP secret if TOTP approval mode is enabled

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -1045,9 +1045,10 @@ func (a *App) mountFUSEForSession(ctx context.Context, p fuseMountParams) bool {
 
 	// Build platform FSConfig
 	fsCfg := platform.FSConfig{
-		SourcePath: s.Workspace,
-		MountPoint: mountPoint,
-		SessionID:  s.ID,
+		SourcePath:  s.Workspace,
+		MountPoint:  mountPoint,
+		SessionID:   s.ID,
+		VirtualRoot: s.VirtualRoot,
 		CommandIDFunc: func() string {
 			return s.CurrentCommandID()
 		},

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -421,17 +421,7 @@ func (a *App) createSessionWithProfile(ctx context.Context, req types.CreateSess
 	}
 
 	// Apply real-paths mode if requested
-	realPaths := a.cfg.Sessions.RealPaths // config default
-	if req.RealPaths != nil {
-		realPaths = *req.RealPaths // request override
-	}
-	if realPaths {
-		s.SetRealPaths(true)
-		if !a.cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE {
-			slog.Warn("session created with real_paths but enforce_without_fuse is false: outside-workspace file access will be audit-only",
-				"session_id", s.ID)
-		}
-	}
+	a.applyRealPaths(s, req.RealPaths)
 
 	// Generate TOTP secret if TOTP approval mode is enabled
 	if a.cfg.Approvals.Mode == "totp" {
@@ -574,17 +564,7 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 	s.GitRoot = policyVars["GIT_ROOT"]
 
 	// Apply real-paths mode if requested
-	realPaths := a.cfg.Sessions.RealPaths // config default
-	if req.RealPaths != nil {
-		realPaths = *req.RealPaths // request override
-	}
-	if realPaths {
-		s.SetRealPaths(true)
-		if !a.cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE {
-			slog.Warn("session created with real_paths but enforce_without_fuse is false: outside-workspace file access will be audit-only",
-				"session_id", s.ID)
-		}
-	}
+	a.applyRealPaths(s, req.RealPaths)
 
 	// Generate TOTP secret if TOTP approval mode is enabled
 	if a.cfg.Approvals.Mode == "totp" {
@@ -1414,4 +1394,21 @@ func (a *App) setTraceContext(w http.ResponseWriter, r *http.Request) {
 
 	s.SetCurrentTraceContext(req.TraceID, req.SpanID, req.TraceFlags)
 	writeJSON(w, http.StatusOK, map[string]any{"ok": true})
+}
+
+// applyRealPaths resolves the effective real-paths mode (config default overridden
+// by request) and applies it to the session, emitting a warning when enforcement
+// is incomplete.
+func (a *App) applyRealPaths(s *session.Session, reqRealPaths *bool) {
+	realPaths := a.cfg.Sessions.RealPaths
+	if reqRealPaths != nil {
+		realPaths = *reqRealPaths
+	}
+	if realPaths {
+		s.SetRealPaths(true)
+		if !a.cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE {
+			slog.Warn("session created with real_paths but enforce_without_fuse is false: outside-workspace file access will be audit-only",
+				"session_id", s.ID)
+		}
+	}
 }

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -1035,7 +1035,7 @@ func (a *App) execInSessionCore(ctx context.Context, id string, req types.ExecRe
 			OtherCount:             len(otherOps),
 		},
 		Resources: &resources,
-		Guidance:  guidanceForResponse(req, res, blockedOps, s.VirtualRoot),
+		Guidance:  guidanceForResponse(req, res, blockedOps, s.EffectiveVirtualRoot()),
 	}
 	addRedirectGuidance(resp, pre, originalCmd, originalArgs)
 	if len(softSuggestions) > 0 {
@@ -1082,7 +1082,7 @@ func (a *App) mountFUSEForSession(ctx context.Context, p fuseMountParams) bool {
 		SourcePath:  s.Workspace,
 		MountPoint:  mountPoint,
 		SessionID:   s.ID,
-		VirtualRoot: s.VirtualRoot,
+		VirtualRoot: s.EffectiveVirtualRoot(),
 		CommandIDFunc: func() string {
 			return s.CurrentCommandID()
 		},

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -336,7 +336,9 @@ func (a *App) setupProfileMounts(ctx context.Context, s *session.Session, profil
 					},
 					PolicyEngine: platform.NewPolicyAdapter(policyEngine),
 					EventChannel: eventChan,
-					VirtualRoot:  filepath.ToSlash(mountPath),
+					// Profile mounts use their real path as virtual root regardless of
+					// session mode: profile mounts expose real paths directly (not /workspace).
+					VirtualRoot: filepath.ToSlash(mountPath),
 				}
 
 				m, err := fs.Mount(fsCfg)

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -420,6 +420,15 @@ func (a *App) createSessionWithProfile(ctx context.Context, req types.CreateSess
 		return types.Session{}, code, err
 	}
 
+	// Apply real-paths mode if requested
+	realPaths := a.cfg.Sessions.RealPaths // config default
+	if req.RealPaths != nil {
+		realPaths = *req.RealPaths // request override
+	}
+	if realPaths {
+		s.SetRealPaths(true)
+	}
+
 	// Generate TOTP secret if TOTP approval mode is enabled
 	if a.cfg.Approvals.Mode == "totp" {
 		secret, err := approvals.GenerateTOTPSecret()
@@ -559,6 +568,15 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 	// Store roots in session
 	s.ProjectRoot = policyVars["PROJECT_ROOT"]
 	s.GitRoot = policyVars["GIT_ROOT"]
+
+	// Apply real-paths mode if requested
+	realPaths := a.cfg.Sessions.RealPaths // config default
+	if req.RealPaths != nil {
+		realPaths = *req.RealPaths // request override
+	}
+	if realPaths {
+		s.SetRealPaths(true)
+	}
 
 	// Generate TOTP secret if TOTP approval mode is enabled
 	if a.cfg.Approvals.Mode == "totp" {

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -1406,7 +1406,11 @@ func (a *App) applyRealPaths(s *session.Session, reqRealPaths *bool) {
 		realPaths = *reqRealPaths
 	}
 	if realPaths {
-		s.SetRealPaths(true)
+		if !s.SetRealPaths(true) {
+			slog.Warn("real_paths requested but workspace is empty; falling back to /workspace",
+				"session_id", s.ID)
+			return
+		}
 		if !a.cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE {
 			slog.Warn("session created with real_paths but enforce_without_fuse is false: outside-workspace file access will be audit-only",
 				"session_id", s.ID)

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -1008,7 +1008,7 @@ func (a *App) execInSessionCore(ctx context.Context, id string, req types.ExecRe
 			OtherCount:             len(otherOps),
 		},
 		Resources: &resources,
-		Guidance:  guidanceForResponse(req, res, blockedOps),
+		Guidance:  guidanceForResponse(req, res, blockedOps, s.VirtualRoot),
 	}
 	addRedirectGuidance(resp, pre, originalCmd, originalArgs)
 	if len(softSuggestions) > 0 {

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -320,6 +320,7 @@ func (a *App) setupProfileMounts(ctx context.Context, s *session.Session, profil
 					},
 					PolicyEngine: platform.NewPolicyAdapter(policyEngine),
 					EventChannel: eventChan,
+					VirtualRoot:  s.VirtualRoot,
 				}
 
 				m, err := fs.Mount(fsCfg)

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -336,9 +336,17 @@ func (a *App) setupProfileMounts(ctx context.Context, s *session.Session, profil
 					},
 					PolicyEngine: platform.NewPolicyAdapter(policyEngine),
 					EventChannel: eventChan,
-					// Profile mounts use their real path as virtual root regardless of
-					// session mode: profile mounts expose real paths directly (not /workspace).
-					VirtualRoot: filepath.ToSlash(mountPath),
+					// For the primary workspace mount, use the session's effective virtual
+					// root so FUSE events report paths consistent with the session (e.g.
+					// /workspace in default mode). Non-workspace mounts use their real
+					// path since they aren't mapped under the session's virtual root.
+					VirtualRoot: func() string {
+						wsClean := filepath.Clean(s.WorkspaceMountPath())
+						if filepath.Clean(mountPath) == wsClean {
+							return s.EffectiveVirtualRoot()
+						}
+						return filepath.ToSlash(mountPath)
+					}(),
 				}
 
 				m, err := fs.Mount(fsCfg)

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -320,7 +320,7 @@ func (a *App) setupProfileMounts(ctx context.Context, s *session.Session, profil
 					},
 					PolicyEngine: platform.NewPolicyAdapter(policyEngine),
 					EventChannel: eventChan,
-					VirtualRoot:  s.VirtualRoot,
+					VirtualRoot:  filepath.ToSlash(spec.Path),
 				}
 
 				m, err := fs.Mount(fsCfg)
@@ -395,14 +395,23 @@ func (a *App) createSessionWithProfile(ctx context.Context, req types.CreateSess
 	// Build initial mounts from profile specs (without FUSE yet)
 	var initialMounts []session.ResolvedMount
 	for _, spec := range profile.Mounts {
+		// Normalize to absolute path to avoid CWD-dependent behavior
+		mountPath := spec.Path
+		if !filepath.IsAbs(mountPath) {
+			var err error
+			mountPath, err = filepath.Abs(mountPath)
+			if err != nil {
+				return types.Session{}, http.StatusBadRequest, fmt.Errorf("mount path %q: cannot resolve absolute path: %w", spec.Path, err)
+			}
+		}
 		// Validate path exists
-		if _, err := os.Stat(spec.Path); err != nil {
-			return types.Session{}, http.StatusBadRequest, fmt.Errorf("mount path %q: %w", spec.Path, err)
+		if _, err := os.Stat(mountPath); err != nil {
+			return types.Session{}, http.StatusBadRequest, fmt.Errorf("mount path %q: %w", mountPath, err)
 		}
 		initialMounts = append(initialMounts, session.ResolvedMount{
-			Path:       spec.Path,
+			Path:       mountPath,
 			Policy:     spec.Policy,
-			MountPoint: spec.Path,
+			MountPoint: mountPath,
 		})
 	}
 

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -268,15 +268,31 @@ func (a *App) setupProfileMounts(ctx context.Context, s *session.Session, profil
 	}
 
 	for i, spec := range profile.Mounts {
+		// Normalize to absolute clean path
+		mountPath := spec.Path
+		if !filepath.IsAbs(mountPath) {
+			absPath, err := filepath.Abs(mountPath)
+			if err != nil {
+				for _, m := range mounts {
+					if m.Unmount != nil {
+						_ = m.Unmount()
+					}
+				}
+				return nil, fmt.Errorf("mount path %q: %w", spec.Path, err)
+			}
+			mountPath = absPath
+		}
+		mountPath = filepath.Clean(mountPath)
+
 		// Validate path exists
-		if _, err := os.Stat(spec.Path); err != nil {
+		if _, err := os.Stat(mountPath); err != nil {
 			// Cleanup already-created mounts
 			for _, m := range mounts {
 				if m.Unmount != nil {
 					_ = m.Unmount()
 				}
 			}
-			return nil, fmt.Errorf("mount path %q: %w", spec.Path, err)
+			return nil, fmt.Errorf("mount path %q: %w", mountPath, err)
 		}
 
 		// Load per-mount policy if specified
@@ -291,7 +307,7 @@ func (a *App) setupProfileMounts(ctx context.Context, s *session.Session, profil
 						_ = m.Unmount()
 					}
 				}
-				return nil, fmt.Errorf("load policy %q for mount %q: %w", spec.Policy, spec.Path, err)
+				return nil, fmt.Errorf("load policy %q for mount %q: %w", spec.Policy, mountPath, err)
 			}
 		} else {
 			// Fall back to global policy if no per-mount policy specified
@@ -309,7 +325,7 @@ func (a *App) setupProfileMounts(ctx context.Context, s *session.Session, profil
 				go a.processIOEvents(ctx, eventChan)
 
 				fsCfg := platform.FSConfig{
-					SourcePath: spec.Path,
+					SourcePath: mountPath,
 					MountPoint: mountPoint,
 					SessionID:  s.ID,
 					CommandIDFunc: func() string {
@@ -320,26 +336,26 @@ func (a *App) setupProfileMounts(ctx context.Context, s *session.Session, profil
 					},
 					PolicyEngine: platform.NewPolicyAdapter(policyEngine),
 					EventChannel: eventChan,
-					VirtualRoot:  filepath.ToSlash(spec.Path),
+					VirtualRoot:  filepath.ToSlash(mountPath),
 				}
 
 				m, err := fs.Mount(fsCfg)
 				if err != nil {
 					close(eventChan)
 					// Log but continue - mount failure shouldn't block session
-					a.logMountFailure(ctx, s.ID, spec.Path, mountPoint, err)
+					a.logMountFailure(ctx, s.ID, mountPath, mountPoint, err)
 					continue
 				}
 
 				// Register in MountRegistry so seccomp FileHandler
 				// knows this path is FUSE-managed (audit-only).
-				registerFUSEMount(s.ID, spec.Path)
+				registerFUSEMount(s.ID, mountPath)
 
 				// Capture for closure
 				sessionID := s.ID
-				sourcePath := spec.Path
+				sourcePath := mountPath
 				mounts = append(mounts, session.ResolvedMount{
-					Path:         spec.Path,
+					Path:         mountPath,
 					Policy:       spec.Policy,
 					MountPoint:   mountPoint,
 					PolicyEngine: policyEngine,
@@ -353,9 +369,9 @@ func (a *App) setupProfileMounts(ctx context.Context, s *session.Session, profil
 		} else {
 			// No FUSE, just track the mount without actual mounting
 			mounts = append(mounts, session.ResolvedMount{
-				Path:         spec.Path,
+				Path:         mountPath,
 				Policy:       spec.Policy,
-				MountPoint:   spec.Path, // Direct path when not using FUSE
+				MountPoint:   mountPath, // Direct path when not using FUSE
 				PolicyEngine: policyEngine,
 			})
 		}

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -291,7 +291,11 @@ func resolveWorkingDir(s *session.Session, reqWorkingDir string) (string, error)
 
 	vroot := s.VirtualRoot
 	if virtual != vroot && !strings.HasPrefix(virtual, vroot+"/") {
-		// Outside workspace — pass through as-is for policy/seccomp enforcement
+		if vroot == "/workspace" {
+			// Default mode: reject outside-workspace paths (preserves pre-real-paths behavior)
+			return "", fmt.Errorf("working_dir must be under /workspace")
+		}
+		// Real-paths mode: pass through as-is for policy/seccomp enforcement
 		return virtual, nil
 	}
 	rel := strings.TrimPrefix(virtual, vroot)

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -282,7 +282,9 @@ func resolveWorkingDir(s *session.Session, reqWorkingDir string) (string, error)
 	cwd, _, _ := s.GetCwdEnvHistory()
 	virtual := cwd
 	if reqWorkingDir != "" {
-		if filepath.IsAbs(reqWorkingDir) {
+		// Virtual paths always use "/" prefix; on Windows filepath.IsAbs("/workspace")
+		// returns false, so also check for leading slash.
+		if strings.HasPrefix(reqWorkingDir, "/") || filepath.IsAbs(reqWorkingDir) {
 			virtual = filepath.ToSlash(reqWorkingDir)
 		} else {
 			virtual = filepath.ToSlash(filepath.Join(cwd, reqWorkingDir))

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -288,6 +288,9 @@ func resolveWorkingDir(s *session.Session, reqWorkingDir string) (string, error)
 			virtual = filepath.ToSlash(filepath.Join(cwd, reqWorkingDir))
 		}
 	}
+	// Normalize to resolve ".." before root boundary check, so paths like
+	// /home/u/proj/../tmp are correctly classified as outside-workspace.
+	virtual = filepath.ToSlash(filepath.Clean(filepath.FromSlash(virtual)))
 
 	vroot := s.VirtualRoot
 	if vroot == "" {

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -298,7 +298,7 @@ func resolveWorkingDir(s *session.Session, reqWorkingDir string) (string, error)
 		// Real-paths mode: pass through as-is for policy/seccomp enforcement
 		return virtual, nil
 	}
-	rel := strings.TrimPrefix(virtual, vroot)
+	rel := session.TrimRootPrefix(virtual, vroot)
 	rel = strings.TrimPrefix(rel, "/")
 
 	// Security: Ensure rel is not an absolute path (could escape on Windows)

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -290,6 +290,9 @@ func resolveWorkingDir(s *session.Session, reqWorkingDir string) (string, error)
 	}
 
 	vroot := s.VirtualRoot
+	if vroot == "" {
+		vroot = "/workspace" // fail closed for uninitialized sessions
+	}
 	if !session.IsUnderRoot(virtual, vroot) {
 		if vroot == "/workspace" {
 			// Default mode: reject outside-workspace paths (preserves pre-real-paths behavior)

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -282,8 +282,8 @@ func resolveWorkingDir(s *session.Session, reqWorkingDir string) (string, error)
 	cwd, _, _ := s.GetCwdEnvHistory()
 	virtual := cwd
 	if reqWorkingDir != "" {
-		if strings.HasPrefix(reqWorkingDir, "/") {
-			virtual = reqWorkingDir
+		if filepath.IsAbs(reqWorkingDir) {
+			virtual = filepath.ToSlash(reqWorkingDir)
 		} else {
 			virtual = filepath.ToSlash(filepath.Join(cwd, reqWorkingDir))
 		}

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -290,7 +290,7 @@ func resolveWorkingDir(s *session.Session, reqWorkingDir string) (string, error)
 	}
 
 	vroot := s.VirtualRoot
-	if virtual != vroot && !strings.HasPrefix(virtual, vroot+"/") {
+	if !session.IsUnderRoot(virtual, vroot) {
 		if vroot == "/workspace" {
 			// Default mode: reject outside-workspace paths (preserves pre-real-paths behavior)
 			return "", fmt.Errorf("working_dir must be under /workspace")

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -318,7 +318,35 @@ func resolveWorkingDir(s *session.Session, reqWorkingDir string) (string, error)
 	if !session.IsRealPathUnder(real, rootClean) {
 		return "", fmt.Errorf("working_dir escapes workspace mount")
 	}
-	return real, nil
+
+	// Resolve root symlinks for consistent comparison (macOS /var -> /private/var)
+	rootResolved, err := filepath.EvalSymlinks(rootClean)
+	if err != nil {
+		rootResolved = rootClean
+	}
+
+	// Resolve symlinks to prevent symlink escape (e.g., /workspace/link -> /etc).
+	// If the target doesn't exist yet, evaluate the parent directory instead.
+	resolved, resolveErr := filepath.EvalSymlinks(real)
+	if resolveErr != nil {
+		// Path doesn't exist — evaluate parent to catch symlink escapes in ancestors
+		parent := filepath.Dir(real)
+		resolvedParent, parentErr := filepath.EvalSymlinks(parent)
+		if parentErr != nil {
+			// Parent also doesn't exist — use lexical path (already checked above)
+			return real, nil
+		}
+		resolvedParent = filepath.Clean(resolvedParent)
+		if !session.IsRealPathUnder(resolvedParent, rootResolved) {
+			return "", fmt.Errorf("working_dir symlink escapes workspace mount")
+		}
+		return filepath.Clean(filepath.Join(resolvedParent, filepath.Base(real))), nil
+	}
+	resolved = filepath.Clean(resolved)
+	if !session.IsRealPathUnder(resolved, rootResolved) {
+		return "", fmt.Errorf("working_dir symlink escapes workspace mount")
+	}
+	return resolved, nil
 }
 
 func buildPolicyEnv(pol policy.ResolvedEnvPolicy, hostEnv []string, s *session.Session, overrides map[string]string) ([]string, error) {

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -289,10 +289,12 @@ func resolveWorkingDir(s *session.Session, reqWorkingDir string) (string, error)
 		}
 	}
 
-	if !strings.HasPrefix(virtual, "/workspace") {
-		return "", fmt.Errorf("working_dir must be under /workspace")
+	vroot := s.VirtualRoot
+	if virtual != vroot && !strings.HasPrefix(virtual, vroot+"/") {
+		// Outside workspace — pass through as-is for policy/seccomp enforcement
+		return virtual, nil
 	}
-	rel := strings.TrimPrefix(virtual, "/workspace")
+	rel := strings.TrimPrefix(virtual, vroot)
 	rel = strings.TrimPrefix(rel, "/")
 
 	// Security: Ensure rel is not an absolute path (could escape on Windows)

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -312,7 +312,7 @@ func resolveWorkingDir(s *session.Session, reqWorkingDir string) (string, error)
 	real = filepath.Clean(real)
 
 	rootClean := filepath.Clean(root)
-	if real != rootClean && !strings.HasPrefix(real, rootClean+string(os.PathSeparator)) {
+	if !session.IsRealPathUnder(real, rootClean) {
 		return "", fmt.Errorf("working_dir escapes workspace mount")
 	}
 	return real, nil

--- a/internal/api/exec_real_paths_test.go
+++ b/internal/api/exec_real_paths_test.go
@@ -108,6 +108,35 @@ func TestResolveWorkingDir_EmptyVirtualRoot_FailsClosed(t *testing.T) {
 	}
 }
 
+func TestResolveWorkingDir_WindowsDriveLetter(t *testing.T) {
+	m := session.NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-exec-windrive", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate a Windows-style VirtualRoot with drive letter
+	s.VirtualRoot = "C:/Users/project"
+
+	// Drive-letter absolute path under VirtualRoot should be treated as absolute,
+	// not joined to cwd. This tests that filepath.IsAbs handles drive letters.
+	if runtime.GOOS == "windows" {
+		real, err := resolveWorkingDir(s, "C:/Users/project/sub")
+		if err != nil {
+			t.Fatalf("resolveWorkingDir with Windows drive path: %v", err)
+		}
+		if real == "" {
+			t.Error("expected non-empty resolved path for Windows drive letter")
+		}
+	} else {
+		// On non-Windows, filepath.IsAbs("C:/...") returns false, so the path
+		// gets joined to cwd. This is expected — Windows paths only need to work
+		// on Windows. Verify it doesn't panic.
+		_, _ = resolveWorkingDir(s, "C:/Users/project/sub")
+	}
+}
+
 // Integration test: HTTP exec handler with real_paths=true allows outside-workspace working_dir.
 func TestExec_RealPaths_OutsideWorkspace_Allowed(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/internal/api/exec_real_paths_test.go
+++ b/internal/api/exec_real_paths_test.go
@@ -79,3 +79,21 @@ func TestResolveWorkingDir_RootVirtualRoot(t *testing.T) {
 		t.Fatalf("resolveWorkingDir with VirtualRoot=/: %v", err)
 	}
 }
+
+func TestResolveWorkingDir_EmptyVirtualRoot_FailsClosed(t *testing.T) {
+	m := session.NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-exec-emptyvr", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate uninitialized/restored session with empty VirtualRoot
+	s.VirtualRoot = ""
+
+	// Should fail closed (treat as /workspace mode and reject outside paths)
+	_, err = resolveWorkingDir(s, "/etc")
+	if err == nil {
+		t.Error("expected error for outside-workspace path when VirtualRoot is empty")
+	}
+}

--- a/internal/api/exec_real_paths_test.go
+++ b/internal/api/exec_real_paths_test.go
@@ -61,3 +61,21 @@ func TestResolveWorkingDir_Default_OutsideReject(t *testing.T) {
 		t.Error("expected error for outside-workspace path in default mode")
 	}
 }
+
+func TestResolveWorkingDir_RootVirtualRoot(t *testing.T) {
+	m := session.NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-exec-rootvr", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Simulate VirtualRoot=="/" — paths like "/etc" should be considered
+	// in-root and resolved normally (not passed through as outside)
+	s.VirtualRoot = "/"
+
+	_, err = resolveWorkingDir(s, "/etc")
+	if err != nil {
+		t.Fatalf("resolveWorkingDir with VirtualRoot=/: %v", err)
+	}
+}

--- a/internal/api/exec_real_paths_test.go
+++ b/internal/api/exec_real_paths_test.go
@@ -198,7 +198,43 @@ func TestResolveWorkingDir_SymlinkEscape_RealPathsMode(t *testing.T) {
 	}
 }
 
-// Integration test: HTTP exec handler with real_paths=true allows outside-workspace working_dir.
+func TestResolveWorkingDir_DotDotEscape_RealPaths(t *testing.T) {
+	m := session.NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-dotdot-real", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetRealPaths(true)
+
+	wsClean := filepath.ToSlash(filepath.Clean(ws))
+	// Path with ".." that resolves outside workspace should be treated as
+	// outside-workspace (pass through), not rejected as escape.
+	real, err := resolveWorkingDir(s, wsClean+"/../tmp")
+	if err != nil {
+		t.Fatalf("expected pass-through for dotdot outside workspace in real_paths mode, got: %v", err)
+	}
+	// After normalization, should resolve to the parent's "tmp" sibling
+	if strings.Contains(real, "..") {
+		t.Errorf("result should not contain '..': %q", real)
+	}
+}
+
+func TestResolveWorkingDir_DotDotEscape_Default(t *testing.T) {
+	m := session.NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-dotdot-default", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Default mode: /workspace/./../etc should be rejected
+	_, err = resolveWorkingDir(s, "/workspace/../etc")
+	if err == nil {
+		t.Error("expected error for dotdot escape outside /workspace in default mode")
+	}
+}
 func TestExec_RealPaths_OutsideWorkspace_Allowed(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("exec integration test is POSIX-specific")

--- a/internal/api/exec_real_paths_test.go
+++ b/internal/api/exec_real_paths_test.go
@@ -62,8 +62,10 @@ func TestResolveWorkingDir_RealPaths_OutsideWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveWorkingDir: %v", err)
 	}
-	if real != outsideDir {
-		t.Errorf("real = %q, want %q", real, outsideDir)
+	// resolveWorkingDir normalizes to forward slashes
+	wantDir := filepath.ToSlash(outsideDir)
+	if real != wantDir {
+		t.Errorf("real = %q, want %q", real, wantDir)
 	}
 }
 

--- a/internal/api/exec_real_paths_test.go
+++ b/internal/api/exec_real_paths_test.go
@@ -137,6 +137,67 @@ func TestResolveWorkingDir_WindowsDriveLetter(t *testing.T) {
 	}
 }
 
+func TestResolveWorkingDir_SymlinkEscape_DefaultMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test is POSIX-specific")
+	}
+	m := session.NewManager(10)
+	ws := t.TempDir()
+
+	// Create a symlink inside workspace pointing outside
+	outsideDir := t.TempDir()
+	symlinkPath := filepath.Join(ws, "escape-link")
+	if err := os.Symlink(outsideDir, symlinkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := m.CreateWithID("test-symlink-default", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Default mode: VirtualRoot == "/workspace", workspace mount == ws
+	// The symlink /workspace/escape-link -> outsideDir should be rejected
+	_, err = resolveWorkingDir(s, "/workspace/escape-link")
+	if err == nil {
+		t.Error("expected error for symlink escape in default mode")
+	}
+	if err != nil && !strings.Contains(err.Error(), "symlink escapes") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveWorkingDir_SymlinkEscape_RealPathsMode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test is POSIX-specific")
+	}
+	m := session.NewManager(10)
+	ws := t.TempDir()
+
+	// Create a symlink inside workspace pointing outside
+	outsideDir := t.TempDir()
+	symlinkPath := filepath.Join(ws, "escape-link")
+	if err := os.Symlink(outsideDir, symlinkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := m.CreateWithID("test-symlink-real", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetRealPaths(true)
+
+	// In real-paths mode: VirtualRoot == ws path
+	// A path like <ws>/escape-link is "under root" but resolves outside — should be rejected
+	wsClean := filepath.ToSlash(filepath.Clean(ws))
+	_, err = resolveWorkingDir(s, wsClean+"/escape-link")
+	if err == nil {
+		t.Error("expected error for symlink escape in real_paths mode")
+	}
+	if err != nil && !strings.Contains(err.Error(), "symlink escapes") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 // Integration test: HTTP exec handler with real_paths=true allows outside-workspace working_dir.
 func TestExec_RealPaths_OutsideWorkspace_Allowed(t *testing.T) {
 	if runtime.GOOS == "windows" {

--- a/internal/api/exec_real_paths_test.go
+++ b/internal/api/exec_real_paths_test.go
@@ -1,9 +1,19 @@
 package api
 
 import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/store/composite"
+	"github.com/agentsh/agentsh/pkg/types"
 )
 
 func TestResolveWorkingDir_RealPaths(t *testing.T) {
@@ -95,5 +105,155 @@ func TestResolveWorkingDir_EmptyVirtualRoot_FailsClosed(t *testing.T) {
 	_, err = resolveWorkingDir(s, "/etc")
 	if err == nil {
 		t.Error("expected error for outside-workspace path when VirtualRoot is empty")
+	}
+}
+
+// Integration test: HTTP exec handler with real_paths=true allows outside-workspace working_dir.
+func TestExec_RealPaths_OutsideWorkspace_Allowed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec integration test is POSIX-specific")
+	}
+	st := newSQLiteStore(t)
+	store := composite.New(st, st)
+	sessions := session.NewManager(10)
+
+	ws := filepath.Join(t.TempDir(), "ws")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := sessions.Create(ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess.SetRealPaths(true)
+
+	app := newTestApp(t, sessions, store)
+	h := app.Router()
+
+	// Execute /bin/pwd in an outside dir — should succeed in real_paths mode.
+	// NOTE: Must use /bin/pwd (not "pwd") because "pwd" is a session builtin
+	// that returns s.Cwd without going through resolveWorkingDir.
+	outsideDir := t.TempDir() // use a real existing temp dir
+	body, _ := json.Marshal(map[string]any{
+		"command":        "/bin/pwd",
+		"working_dir":    outsideDir,
+		"include_events": "none",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sess.ID+"/exec", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp types.ExecResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Result.ExitCode != 0 {
+		t.Fatalf("expected exit_code 0, got %d (stderr=%q)", resp.Result.ExitCode, resp.Result.Stderr)
+	}
+	// pwd output should contain the outside dir path
+	if !strings.Contains(resp.Result.Stdout, filepath.Base(outsideDir)) {
+		t.Errorf("stdout=%q, expected to contain outside dir %q", resp.Result.Stdout, outsideDir)
+	}
+}
+
+// Integration test: HTTP exec handler in default mode rejects outside-workspace working_dir.
+func TestExec_Default_OutsideWorkspace_Rejected(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec integration test is POSIX-specific")
+	}
+	st := newSQLiteStore(t)
+	store := composite.New(st, st)
+	sessions := session.NewManager(10)
+
+	ws := filepath.Join(t.TempDir(), "ws")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := sessions.Create(ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Default mode: VirtualRoot == "/workspace"
+
+	app := newTestApp(t, sessions, store)
+	h := app.Router()
+
+	body, _ := json.Marshal(map[string]any{
+		"command":        "/bin/pwd",
+		"working_dir":    "/tmp",
+		"include_events": "none",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sess.ID+"/exec", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp types.ExecResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	// Should fail with non-zero exit code (working_dir rejection)
+	if resp.Result.ExitCode == 0 {
+		t.Error("expected non-zero exit code for outside-workspace working_dir in default mode")
+	}
+	if !strings.Contains(resp.Result.Stderr, "working_dir must be under /workspace") {
+		t.Errorf("stderr=%q, expected working_dir rejection message", resp.Result.Stderr)
+	}
+}
+
+// Integration test: HTTP exec handler with real_paths mode resolves in-workspace
+// commands to real host paths.
+func TestExec_RealPaths_InWorkspace_UsesRealPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exec integration test is POSIX-specific")
+	}
+	st := newSQLiteStore(t)
+	store := composite.New(st, st)
+	sessions := session.NewManager(10)
+
+	ws := filepath.Join(t.TempDir(), "ws")
+	subdir := filepath.Join(ws, "sub")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sess, err := sessions.Create(ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sess.SetRealPaths(true)
+
+	app := newTestApp(t, sessions, store)
+	h := app.Router()
+
+	// Execute /bin/pwd in a workspace subdirectory using the real path.
+	// NOTE: Must use /bin/pwd (not "pwd") to bypass session builtin.
+	wsClean := filepath.ToSlash(filepath.Clean(ws))
+	body, _ := json.Marshal(map[string]any{
+		"command":        "/bin/pwd",
+		"working_dir":    wsClean + "/sub",
+		"include_events": "none",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sess.ID+"/exec", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp types.ExecResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Result.ExitCode != 0 {
+		t.Fatalf("expected exit_code 0, got %d (stderr=%q)", resp.Result.ExitCode, resp.Result.Stderr)
+	}
+	// pwd output should show the real subdirectory path
+	if !strings.Contains(resp.Result.Stdout, "sub") {
+		t.Errorf("stdout=%q, expected to contain 'sub' subdirectory", resp.Result.Stdout)
 	}
 }

--- a/internal/api/exec_real_paths_test.go
+++ b/internal/api/exec_real_paths_test.go
@@ -46,7 +46,7 @@ func TestResolveWorkingDir_RealPaths_OutsideWorkspace(t *testing.T) {
 	}
 }
 
-func TestResolveWorkingDir_Default_OutsidePassthrough(t *testing.T) {
+func TestResolveWorkingDir_Default_OutsideReject(t *testing.T) {
 	m := session.NewManager(10)
 	ws := t.TempDir()
 
@@ -55,12 +55,9 @@ func TestResolveWorkingDir_Default_OutsidePassthrough(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Outside workspace paths pass through for policy/seccomp enforcement
-	real, err := resolveWorkingDir(s, "/etc")
-	if err != nil {
-		t.Fatalf("resolveWorkingDir: %v", err)
-	}
-	if real != "/etc" {
-		t.Errorf("real = %q, want /etc", real)
+	// Default /workspace mode: outside workspace paths should be rejected
+	_, err = resolveWorkingDir(s, "/etc")
+	if err == nil {
+		t.Error("expected error for outside-workspace path in default mode")
 	}
 }

--- a/internal/api/exec_real_paths_test.go
+++ b/internal/api/exec_real_paths_test.go
@@ -56,13 +56,14 @@ func TestResolveWorkingDir_RealPaths_OutsideWorkspace(t *testing.T) {
 	}
 	s.SetRealPaths(true)
 
-	// Outside workspace should pass through
-	real, err := resolveWorkingDir(s, "/tmp")
+	// Use a real outside-workspace path (platform-appropriate absolute path)
+	outsideDir := t.TempDir()
+	real, err := resolveWorkingDir(s, outsideDir)
 	if err != nil {
 		t.Fatalf("resolveWorkingDir: %v", err)
 	}
-	if real != "/tmp" {
-		t.Errorf("real = %q, want /tmp", real)
+	if real != outsideDir {
+		t.Errorf("real = %q, want %q", real, outsideDir)
 	}
 }
 
@@ -75,8 +76,10 @@ func TestResolveWorkingDir_Default_OutsideReject(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Default /workspace mode: outside workspace paths should be rejected
-	_, err = resolveWorkingDir(s, "/etc")
+	// Default /workspace mode: outside workspace paths should be rejected.
+	// Use a real absolute path that's outside /workspace on all platforms.
+	outsideDir := t.TempDir()
+	_, err = resolveWorkingDir(s, outsideDir)
 	if err == nil {
 		t.Error("expected error for outside-workspace path in default mode")
 	}

--- a/internal/api/exec_real_paths_test.go
+++ b/internal/api/exec_real_paths_test.go
@@ -16,6 +16,16 @@ import (
 	"github.com/agentsh/agentsh/pkg/types"
 )
 
+// pwdCommand returns a command and args that print the working directory,
+// bypassing the session builtin. On Windows uses "cmd /c cd", on POSIX
+// uses "/bin/pwd".
+func pwdCommand() (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", []string{"/c", "cd"}
+	}
+	return "/bin/pwd", nil
+}
+
 func TestResolveWorkingDir_RealPaths(t *testing.T) {
 	m := session.NewManager(10)
 	ws := t.TempDir()
@@ -236,9 +246,6 @@ func TestResolveWorkingDir_DotDotEscape_Default(t *testing.T) {
 	}
 }
 func TestExec_RealPaths_OutsideWorkspace_Allowed(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("exec integration test is POSIX-specific")
-	}
 	st := newSQLiteStore(t)
 	store := composite.New(st, st)
 	sessions := session.NewManager(10)
@@ -256,12 +263,12 @@ func TestExec_RealPaths_OutsideWorkspace_Allowed(t *testing.T) {
 	app := newTestApp(t, sessions, store)
 	h := app.Router()
 
-	// Execute /bin/pwd in an outside dir — should succeed in real_paths mode.
-	// NOTE: Must use /bin/pwd (not "pwd") because "pwd" is a session builtin
-	// that returns s.Cwd without going through resolveWorkingDir.
+	// Execute a non-builtin pwd command in an outside dir — should succeed in real_paths mode.
+	cmd, args := pwdCommand()
 	outsideDir := t.TempDir() // use a real existing temp dir
 	body, _ := json.Marshal(map[string]any{
-		"command":        "/bin/pwd",
+		"command":        cmd,
+		"args":           args,
 		"working_dir":    outsideDir,
 		"include_events": "none",
 	})
@@ -287,9 +294,6 @@ func TestExec_RealPaths_OutsideWorkspace_Allowed(t *testing.T) {
 
 // Integration test: HTTP exec handler in default mode rejects outside-workspace working_dir.
 func TestExec_Default_OutsideWorkspace_Rejected(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("exec integration test is POSIX-specific")
-	}
 	st := newSQLiteStore(t)
 	store := composite.New(st, st)
 	sessions := session.NewManager(10)
@@ -307,9 +311,12 @@ func TestExec_Default_OutsideWorkspace_Rejected(t *testing.T) {
 	app := newTestApp(t, sessions, store)
 	h := app.Router()
 
+	cmd, args := pwdCommand()
+	outsideDir := t.TempDir()
 	body, _ := json.Marshal(map[string]any{
-		"command":        "/bin/pwd",
-		"working_dir":    "/tmp",
+		"command":        cmd,
+		"args":           args,
+		"working_dir":    outsideDir,
 		"include_events": "none",
 	})
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+sess.ID+"/exec", bytes.NewReader(body))
@@ -335,9 +342,6 @@ func TestExec_Default_OutsideWorkspace_Rejected(t *testing.T) {
 // Integration test: HTTP exec handler with real_paths mode resolves in-workspace
 // commands to real host paths.
 func TestExec_RealPaths_InWorkspace_UsesRealPath(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("exec integration test is POSIX-specific")
-	}
 	st := newSQLiteStore(t)
 	store := composite.New(st, st)
 	sessions := session.NewManager(10)
@@ -356,11 +360,12 @@ func TestExec_RealPaths_InWorkspace_UsesRealPath(t *testing.T) {
 	app := newTestApp(t, sessions, store)
 	h := app.Router()
 
-	// Execute /bin/pwd in a workspace subdirectory using the real path.
-	// NOTE: Must use /bin/pwd (not "pwd") to bypass session builtin.
+	// Execute pwd in a workspace subdirectory using the real path.
+	cmd, args := pwdCommand()
 	wsClean := filepath.ToSlash(filepath.Clean(ws))
 	body, _ := json.Marshal(map[string]any{
-		"command":        "/bin/pwd",
+		"command":        cmd,
+		"args":           args,
 		"working_dir":    wsClean + "/sub",
 		"include_events": "none",
 	})

--- a/internal/api/exec_real_paths_test.go
+++ b/internal/api/exec_real_paths_test.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/session"
+)
+
+func TestResolveWorkingDir_RealPaths(t *testing.T) {
+	m := session.NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-exec-real", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetRealPaths(true)
+
+	// Absolute path under workspace
+	real, err := resolveWorkingDir(s, ws+"/subdir")
+	if err != nil {
+		t.Fatalf("resolveWorkingDir: %v", err)
+	}
+	if real == "" {
+		t.Error("expected non-empty resolved path")
+	}
+}
+
+func TestResolveWorkingDir_RealPaths_OutsideWorkspace(t *testing.T) {
+	m := session.NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-exec-outside", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetRealPaths(true)
+
+	// Outside workspace should pass through
+	real, err := resolveWorkingDir(s, "/tmp")
+	if err != nil {
+		t.Fatalf("resolveWorkingDir: %v", err)
+	}
+	if real != "/tmp" {
+		t.Errorf("real = %q, want /tmp", real)
+	}
+}
+
+func TestResolveWorkingDir_Default_OutsidePassthrough(t *testing.T) {
+	m := session.NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-exec-default", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Outside workspace paths pass through for policy/seccomp enforcement
+	real, err := resolveWorkingDir(s, "/etc")
+	if err != nil {
+		t.Fatalf("resolveWorkingDir: %v", err)
+	}
+	if real != "/etc" {
+		t.Errorf("real = %q, want /etc", real)
+	}
+}

--- a/internal/api/grpc.go
+++ b/internal/api/grpc.go
@@ -1038,10 +1038,11 @@ type CreateSessionRequestCompat struct {
 	ID        string `json:"id"`
 	Workspace string `json:"workspace"`
 	Policy    string `json:"policy"`
+	RealPaths *bool  `json:"real_paths,omitempty"`
 }
 
 func (c CreateSessionRequestCompat) ToTypes() types.CreateSessionRequest {
-	return types.CreateSessionRequest{ID: c.ID, Workspace: c.Workspace, Policy: c.Policy}
+	return types.CreateSessionRequest{ID: c.ID, Workspace: c.Workspace, Policy: c.Policy, RealPaths: c.RealPaths}
 }
 
 // execRequestCompat matches HTTP ExecRequest plus a session_id field.

--- a/internal/api/grpc_real_paths_test.go
+++ b/internal/api/grpc_real_paths_test.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestCreateSessionRequestCompat_RealPaths_TriState(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		wantNil  bool
+		wantBool bool
+	}{
+		{
+			name:    "absent (nil)",
+			json:    `{"id":"s1","workspace":"/tmp","policy":"default"}`,
+			wantNil: true,
+		},
+		{
+			name:     "explicit true",
+			json:     `{"id":"s1","workspace":"/tmp","policy":"default","real_paths":true}`,
+			wantNil:  false,
+			wantBool: true,
+		},
+		{
+			name:     "explicit false",
+			json:     `{"id":"s1","workspace":"/tmp","policy":"default","real_paths":false}`,
+			wantNil:  false,
+			wantBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var compat CreateSessionRequestCompat
+			if err := json.Unmarshal([]byte(tt.json), &compat); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+
+			if tt.wantNil {
+				if compat.RealPaths != nil {
+					t.Errorf("compat.RealPaths = %v, want nil", *compat.RealPaths)
+				}
+			} else {
+				if compat.RealPaths == nil {
+					t.Fatal("compat.RealPaths = nil, want non-nil")
+				}
+				if *compat.RealPaths != tt.wantBool {
+					t.Errorf("compat.RealPaths = %v, want %v", *compat.RealPaths, tt.wantBool)
+				}
+			}
+
+			// Verify ToTypes preserves the value
+			req := compat.ToTypes()
+			if tt.wantNil {
+				if req.RealPaths != nil {
+					t.Errorf("req.RealPaths = %v, want nil after ToTypes()", *req.RealPaths)
+				}
+			} else {
+				if req.RealPaths == nil {
+					t.Fatal("req.RealPaths = nil after ToTypes(), want non-nil")
+				}
+				if *req.RealPaths != tt.wantBool {
+					t.Errorf("req.RealPaths = %v after ToTypes(), want %v", *req.RealPaths, tt.wantBool)
+				}
+			}
+		})
+	}
+}

--- a/internal/api/guidance_test.go
+++ b/internal/api/guidance_test.go
@@ -110,6 +110,37 @@ func TestGuidance_ApprovalBlocked_IsRetryable(t *testing.T) {
 	}
 }
 
+func TestGuidance_RealPathsMode_NoMoveToWorkspaceSuggestion(t *testing.T) {
+	req := types.ExecRequest{
+		Command: "cat",
+		Args:    []string{"/etc/passwd"},
+	}
+	res := types.ExecResult{ExitCode: 126}
+	blocked := []types.Event{
+		{
+			Type:      "file_open",
+			Operation: "open",
+			Path:      "/etc/passwd",
+			Policy: &types.PolicyInfo{
+				Decision:          types.DecisionDeny,
+				EffectiveDecision: types.DecisionDeny,
+				Rule:              "default-deny-files",
+			},
+		},
+	}
+
+	// In real-paths mode, move_to_workspace should NOT be suggested
+	g := guidanceForResponse(req, res, blocked, "/home/user/project")
+	if g == nil {
+		t.Fatal("expected guidance, got nil")
+	}
+	for _, s := range g.Suggestions {
+		if s.Action == "move_to_workspace" {
+			t.Error("move_to_workspace should not be suggested in real-paths mode")
+		}
+	}
+}
+
 func TestGuidanceForPolicyDenied_PkgApprovalDenied_CommandPolicyAllow(t *testing.T) {
 	// When command policy is "allow" but package approval is denied,
 	// guidance should still show request_approval and be retryable.

--- a/internal/api/guidance_test.go
+++ b/internal/api/guidance_test.go
@@ -28,7 +28,7 @@ func TestGuidance_NetworkBlocked_HTTPToHTTPSSubstitution(t *testing.T) {
 		},
 	}
 
-	g := guidanceForResponse(req, res, blocked)
+	g := guidanceForResponse(req, res, blocked, "/workspace")
 	if g == nil || g.Status != "blocked" || !g.Blocked {
 		t.Fatalf("expected blocked guidance, got %+v", g)
 	}
@@ -57,7 +57,7 @@ func TestGuidance_CommandFailed_PyenvShimSuggestsSystemPython(t *testing.T) {
 		},
 	}
 
-	g := guidanceForResponse(req, res, nil)
+	g := guidanceForResponse(req, res, nil, "/workspace")
 	if g == nil || g.Status != "failed" {
 		t.Fatalf("expected failed guidance, got %+v", g)
 	}
@@ -94,7 +94,7 @@ func TestGuidance_ApprovalBlocked_IsRetryable(t *testing.T) {
 		},
 	}
 
-	g := guidanceForResponse(req, res, blocked)
+	g := guidanceForResponse(req, res, blocked, "/workspace")
 	if g == nil || g.Status != "blocked" || !g.Retryable {
 		t.Fatalf("expected retryable blocked guidance, got %+v", g)
 	}

--- a/internal/api/profile_session_test.go
+++ b/internal/api/profile_session_test.go
@@ -172,6 +172,131 @@ func TestCreateSessionWithProfile_MissingMountPath(t *testing.T) {
 	}
 }
 
+func TestCreateSessionWithProfile_RealPaths(t *testing.T) {
+	st := newSQLiteStore(t)
+	store := composite.New(st, st)
+	sessions := session.NewManager(10)
+
+	// Create temp directories for mount paths
+	temp := t.TempDir()
+	workspace := filepath.Join(temp, "workspace")
+	configDir := filepath.Join(temp, "config")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create config with mount profile and real_paths enabled
+	cfg := &config.Config{}
+	cfg.Development.DisableAuth = true
+	cfg.Metrics.Enabled = false
+	cfg.Health.Path = "/health"
+	cfg.Health.ReadinessPath = "/ready"
+	cfg.Sandbox.FUSE.Enabled = false
+	cfg.Sandbox.Network.Enabled = false
+	cfg.Sandbox.Network.Transparent.Enabled = false
+	cfg.Policies.Default = "default"
+	cfg.Policies.Dir = temp
+	cfg.MountProfiles = map[string]config.MountProfile{
+		"test-profile": {
+			BasePolicy: "default",
+			Mounts: []config.MountSpec{
+				{Path: workspace, Policy: "workspace-rw"},
+				{Path: configDir, Policy: "config-readonly"},
+			},
+		},
+	}
+
+	engine, err := policy.NewEngine(&policy.Policy{Version: 1, Name: "test"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	h := app.Router()
+
+	body := `{"profile":"test-profile","real_paths":true}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var out types.Session
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+
+	// Profile session with real_paths=true should use workspace as VirtualRoot/Cwd
+	absWs, _ := filepath.Abs(workspace)
+	wantCwd := filepath.ToSlash(filepath.Clean(absWs))
+	if out.Cwd != wantCwd {
+		t.Errorf("Cwd = %q, want %q (profile + real_paths)", out.Cwd, wantCwd)
+	}
+}
+
+func TestCreateSessionWithProfile_RealPathsDisabled(t *testing.T) {
+	st := newSQLiteStore(t)
+	store := composite.New(st, st)
+	sessions := session.NewManager(10)
+
+	temp := t.TempDir()
+	workspace := filepath.Join(temp, "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{}
+	cfg.Development.DisableAuth = true
+	cfg.Metrics.Enabled = false
+	cfg.Health.Path = "/health"
+	cfg.Health.ReadinessPath = "/ready"
+	cfg.Sandbox.FUSE.Enabled = false
+	cfg.Sandbox.Network.Enabled = false
+	cfg.Sandbox.Network.Transparent.Enabled = false
+	cfg.Policies.Default = "default"
+	cfg.Policies.Dir = temp
+	cfg.Sessions.RealPaths = true // config default is true
+	cfg.MountProfiles = map[string]config.MountProfile{
+		"test-profile": {
+			BasePolicy: "default",
+			Mounts: []config.MountSpec{
+				{Path: workspace, Policy: "workspace-rw"},
+			},
+		},
+	}
+
+	engine, err := policy.NewEngine(&policy.Policy{Version: 1, Name: "test"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	h := app.Router()
+
+	// Request with real_paths=false overrides config default
+	body := `{"profile":"test-profile","real_paths":false}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var out types.Session
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+
+	// With real_paths=false override, should use /workspace
+	if out.Cwd != "/workspace" {
+		t.Errorf("Cwd = %q, want /workspace (profile + real_paths=false override)", out.Cwd)
+	}
+}
+
 func TestResolveProfile(t *testing.T) {
 	temp := t.TempDir()
 	workspace := filepath.Join(temp, "workspace")

--- a/internal/api/session_create_real_paths_test.go
+++ b/internal/api/session_create_real_paths_test.go
@@ -43,8 +43,9 @@ func TestCreateSession_RealPaths_RequestOverride(t *testing.T) {
 
 	// When real_paths is true, Cwd should be the real workspace path, not /workspace
 	absWs, _ := filepath.Abs(ws)
-	if out.Cwd != absWs {
-		t.Errorf("Cwd = %q, want %q (real workspace path)", out.Cwd, absWs)
+	wantCwd := filepath.ToSlash(filepath.Clean(absWs))
+	if out.Cwd != wantCwd {
+		t.Errorf("Cwd = %q, want %q (real workspace path)", out.Cwd, wantCwd)
 	}
 }
 
@@ -79,8 +80,9 @@ func TestCreateSession_RealPaths_ConfigDefault(t *testing.T) {
 	}
 
 	absWs, _ := filepath.Abs(ws)
-	if out.Cwd != absWs {
-		t.Errorf("Cwd = %q, want %q (config default real_paths=true)", out.Cwd, absWs)
+	wantCwd := filepath.ToSlash(filepath.Clean(absWs))
+	if out.Cwd != wantCwd {
+		t.Errorf("Cwd = %q, want %q (config default real_paths=true)", out.Cwd, wantCwd)
 	}
 }
 

--- a/internal/api/session_create_real_paths_test.go
+++ b/internal/api/session_create_real_paths_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/store/composite"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+func TestCreateSession_RealPaths_RequestOverride(t *testing.T) {
+	st := newSQLiteStore(t)
+	store := composite.New(st, st)
+	sessions := session.NewManager(10)
+
+	ws := filepath.Join(t.TempDir(), "ws")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := newTestApp(t, sessions, store)
+	h := app.Router()
+
+	body := fmt.Sprintf(`{"id":"real-paths-test","workspace":%q,"policy":"default","real_paths":true}`, ws)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var out types.Session
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+
+	// When real_paths is true, Cwd should be the real workspace path, not /workspace
+	absWs, _ := filepath.Abs(ws)
+	if out.Cwd != absWs {
+		t.Errorf("Cwd = %q, want %q (real workspace path)", out.Cwd, absWs)
+	}
+}
+
+func TestCreateSession_RealPaths_ConfigDefault(t *testing.T) {
+	st := newSQLiteStore(t)
+	store := composite.New(st, st)
+	sessions := session.NewManager(10)
+
+	ws := filepath.Join(t.TempDir(), "ws")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create app with RealPaths config default enabled
+	app := newTestApp(t, sessions, store)
+	app.cfg.Sessions.RealPaths = true
+
+	h := app.Router()
+
+	// Request WITHOUT real_paths field — should use config default (true)
+	body := fmt.Sprintf(`{"id":"config-default-test","workspace":%q,"policy":"default"}`, ws)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var out types.Session
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+
+	absWs, _ := filepath.Abs(ws)
+	if out.Cwd != absWs {
+		t.Errorf("Cwd = %q, want %q (config default real_paths=true)", out.Cwd, absWs)
+	}
+}
+
+func TestCreateSession_RealPaths_RequestOverrideFalse(t *testing.T) {
+	st := newSQLiteStore(t)
+	store := composite.New(st, st)
+	sessions := session.NewManager(10)
+
+	ws := filepath.Join(t.TempDir(), "ws")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Config default is true, but request says false
+	app := newTestApp(t, sessions, store)
+	app.cfg.Sessions.RealPaths = true
+
+	h := app.Router()
+
+	body := fmt.Sprintf(`{"id":"override-false-test","workspace":%q,"policy":"default","real_paths":false}`, ws)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var out types.Session
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+
+	// Request override false should keep /workspace
+	if out.Cwd != "/workspace" {
+		t.Errorf("Cwd = %q, want /workspace (request override false)", out.Cwd)
+	}
+}

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -30,6 +30,7 @@ func newExecCmd() *cobra.Command {
 	var noDetectRoot bool
 	var projectRoot string
 	var sessionFile string
+	var realPaths bool
 	c := &cobra.Command{
 		Use:   "exec [SESSION_ID] -- COMMAND [ARGS...]",
 		Short: "Execute a command in a session",
@@ -94,6 +95,10 @@ Root directory for auto-creating sessions uses --root flag or AGENTSH_SESSION_RO
 			}
 			if projectRoot != "" {
 				createReq.ProjectRoot = projectRoot
+			}
+			if realPaths {
+				trueVal := true
+				createReq.RealPaths = &trueVal
 			}
 
 			if pty {
@@ -205,6 +210,7 @@ Root directory for auto-creating sessions uses --root flag or AGENTSH_SESSION_RO
 	c.Flags().BoolVar(&noDetectRoot, "no-detect-root", false, "Disable project root detection when auto-creating session")
 	c.Flags().StringVar(&projectRoot, "project-root", "", "Explicit project root (skips detection) when auto-creating session")
 	c.Flags().StringVar(&sessionFile, "session-file", "", "Path to cached session file (deleted on 404 to invalidate stale sessions)")
+	c.Flags().BoolVar(&realPaths, "real-paths", false, "Use real host paths instead of /workspace")
 	return c
 }
 

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -96,9 +96,8 @@ Root directory for auto-creating sessions uses --root flag or AGENTSH_SESSION_RO
 			if projectRoot != "" {
 				createReq.ProjectRoot = projectRoot
 			}
-			if realPaths {
-				trueVal := true
-				createReq.RealPaths = &trueVal
+			if cmd.Flags().Changed("real-paths") {
+				createReq.RealPaths = &realPaths
 			}
 
 			if pty {
@@ -119,6 +118,7 @@ Root directory for auto-creating sessions uses --root flag or AGENTSH_SESSION_RO
 					AutoCreateRoot: autoCreateRoot,
 					NoDetectRoot:   noDetectRoot,
 					ProjectRoot:    projectRoot,
+					RealPaths:      createReq.RealPaths,
 				})
 			}
 

--- a/internal/cli/exec_pty.go
+++ b/internal/cli/exec_pty.go
@@ -38,6 +38,7 @@ type execPTYRequest struct {
 	AutoCreateRoot string
 	NoDetectRoot   bool
 	ProjectRoot    string
+	RealPaths      *bool
 }
 
 type ptyTermState struct {
@@ -169,6 +170,9 @@ func execPTYWithDeps(ctx context.Context, cfg *clientConfig, sessionID string, r
 				}
 				if req.ProjectRoot != "" {
 					createReq.ProjectRoot = req.ProjectRoot
+				}
+				if req.RealPaths != nil {
+					createReq.RealPaths = req.RealPaths
 				}
 				if _, createErr := cl.CreateSessionWithRequest(ctx, createReq); createErr == nil {
 					err = try()

--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -31,6 +31,7 @@ func newSessionCreateCmd() *cobra.Command {
 	var workspace string
 	var policy string
 	var outputJSON bool
+	var realPaths bool
 	cmd := &cobra.Command{
 		Use:   "create",
 		Short: "Create a new session",
@@ -40,7 +41,12 @@ func newSessionCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			s, err := c.CreateSession(cmd.Context(), workspace, policy)
+			req := types.CreateSessionRequest{Workspace: workspace, Policy: policy}
+			if realPaths {
+				trueVal := true
+				req.RealPaths = &trueVal
+			}
+			s, err := c.CreateSessionWithRequest(cmd.Context(), req)
 			if err != nil {
 				return err
 			}
@@ -56,6 +62,7 @@ func newSessionCreateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&workspace, "workspace", ".", "Workspace directory")
 	cmd.Flags().StringVar(&policy, "policy", "default", "Policy name")
 	cmd.Flags().BoolVar(&outputJSON, "json", false, "Output in JSON format")
+	cmd.Flags().BoolVar(&realPaths, "real-paths", false, "Use real host paths instead of /workspace")
 	return cmd
 }
 

--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -42,9 +42,8 @@ func newSessionCreateCmd() *cobra.Command {
 				return err
 			}
 			req := types.CreateSessionRequest{Workspace: workspace, Policy: policy}
-			if realPaths {
-				trueVal := true
-				req.RealPaths = &trueVal
+			if cmd.Flags().Changed("real-paths") {
+				req.RealPaths = &realPaths
 			}
 			s, err := c.CreateSessionWithRequest(cmd.Context(), req)
 			if err != nil {

--- a/internal/client/grpc_client.go
+++ b/internal/client/grpc_client.go
@@ -76,6 +76,9 @@ func (c *GRPCClient) CreateSessionWithRequest(ctx context.Context, req types.Cre
 	if req.ProjectRoot != "" {
 		reqBody["project_root"] = req.ProjectRoot
 	}
+	if req.RealPaths != nil {
+		reqBody["real_paths"] = *req.RealPaths
+	}
 	in, err := jsonToStruct(reqBody)
 	if err != nil {
 		return out, err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -297,6 +297,11 @@ type SessionsConfig struct {
 	DefaultIdleTimeout string `yaml:"default_idle_timeout"`
 	CleanupInterval    string `yaml:"cleanup_interval"`
 
+	// RealPaths, when true, mounts workspace at its actual host path instead of
+	// virtualizing under /workspace. This preserves path continuity between
+	// host and sandbox environments.
+	RealPaths bool `yaml:"real_paths"`
+
 	// Checkpoints configures workspace checkpoint/rollback functionality.
 	Checkpoints CheckpointConfig `yaml:"checkpoints"`
 }

--- a/internal/config/config_real_paths_test.go
+++ b/internal/config/config_real_paths_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRealPathsConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(cfgPath, []byte(`
+sessions:
+  real_paths: true
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cfg.Sessions.RealPaths {
+		t.Fatal("expected sessions.real_paths to be true")
+	}
+}
+
+func TestRealPathsConfig_DefaultFalse(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(cfgPath, []byte(`
+sessions:
+  max_sessions: 5
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Sessions.RealPaths {
+		t.Fatal("expected sessions.real_paths to default to false")
+	}
+}

--- a/internal/fsmonitor/fuse.go
+++ b/internal/fsmonitor/fuse.go
@@ -35,6 +35,7 @@ type Hooks struct {
 	Emit             Emitter
 	FUSEAudit        *FUSEAuditHooks
 	TraceContextFunc func() (traceID, spanID, traceFlags string)
+	VirtualRoot      string // "/workspace" or real path
 }
 
 func NewMonitoredLoopbackRoot(realRoot string, hooks *Hooks) (fs.InodeEmbedder, error) {
@@ -63,6 +64,13 @@ func NewMonitoredLoopbackRoot(realRoot string, hooks *Hooks) (fs.InodeEmbedder, 
 type node struct {
 	fs.LoopbackNode
 	hooks *Hooks
+}
+
+func (n *node) vroot() string {
+	if n.hooks != nil && n.hooks.VirtualRoot != "" {
+		return n.hooks.VirtualRoot
+	}
+	return "/workspace"
 }
 
 func (n *node) Open(ctx context.Context, flags uint32) (fh fs.FileHandle, fuseFlags uint32, errno syscall.Errno) {
@@ -167,7 +175,7 @@ func (n *node) Mkdir(ctx context.Context, name string, mode uint32, out *fuse.En
 
 func (n *node) Rename(ctx context.Context, name string, newParent fs.InodeEmbedder, newName string, flags uint32) syscall.Errno {
 	virtFrom := n.virtualChildPath(name)
-	virtTo := path.Clean("/workspace/" + sanitizeName(newName))
+	virtTo := path.Clean(n.vroot() + "/" + sanitizeName(newName))
 	newParentNode, ok := newParent.(*node)
 	if ok {
 		virtTo = newParentNode.virtualChildPath(newName)
@@ -382,7 +390,7 @@ func (n *node) checkWithExist(_ context.Context, virtPath string, op string, mus
 		realRoot = n.RootData.Path
 	}
 	if realRoot != "" {
-		if _, err := resolveRealPathUnderRoot(realRoot, virtPath, mustExist, "/workspace"); err != nil {
+		if _, err := resolveRealPathUnderRoot(realRoot, virtPath, mustExist, n.vroot()); err != nil {
 			return policy.Decision{
 				PolicyDecision:    types.DecisionDeny,
 				EffectiveDecision: types.DecisionDeny,
@@ -525,16 +533,18 @@ func (n *node) virtualPath() string {
 	} else {
 		rel = n.Path(nil)
 	}
+	vr := n.vroot()
 	if rel == "" || rel == "." {
-		return "/workspace"
+		return vr
 	}
-	return path.Clean("/workspace/" + filepath.ToSlash(rel))
+	return path.Clean(vr + "/" + filepath.ToSlash(rel))
 }
 
 func (n *node) virtualChildPath(name string) string {
 	base := n.virtualPath()
-	if base == "/workspace" {
-		return path.Clean("/workspace/" + sanitizeName(name))
+	vr := n.vroot()
+	if base == vr {
+		return path.Clean(vr + "/" + sanitizeName(name))
 	}
 	return path.Clean(base + "/" + sanitizeName(name))
 }
@@ -564,7 +574,7 @@ func (n *node) realPath(virt string, mustExist bool) (string, error) {
 	if n.RootData != nil {
 		root = n.RootData.Path
 	}
-	return resolveRealPathUnderRoot(root, virt, mustExist, "/workspace")
+	return resolveRealPathUnderRoot(root, virt, mustExist, n.vroot())
 }
 
 func (n *node) makeDivertFunc(realPath string) func() (*trash.Entry, error) {

--- a/internal/fsmonitor/fuse.go
+++ b/internal/fsmonitor/fuse.go
@@ -382,7 +382,7 @@ func (n *node) checkWithExist(_ context.Context, virtPath string, op string, mus
 		realRoot = n.RootData.Path
 	}
 	if realRoot != "" {
-		if _, err := resolveRealPathUnderRoot(realRoot, virtPath, mustExist); err != nil {
+		if _, err := resolveRealPathUnderRoot(realRoot, virtPath, mustExist, "/workspace"); err != nil {
 			return policy.Decision{
 				PolicyDecision:    types.DecisionDeny,
 				EffectiveDecision: types.DecisionDeny,
@@ -564,7 +564,7 @@ func (n *node) realPath(virt string, mustExist bool) (string, error) {
 	if n.RootData != nil {
 		root = n.RootData.Path
 	}
-	return resolveRealPathUnderRoot(root, virt, mustExist)
+	return resolveRealPathUnderRoot(root, virt, mustExist, "/workspace")
 }
 
 func (n *node) makeDivertFunc(realPath string) func() (*trash.Entry, error) {

--- a/internal/fsmonitor/path.go
+++ b/internal/fsmonitor/path.go
@@ -52,9 +52,20 @@ func trimRootPrefix(path, root string) string {
 func resolveRealPathUnderRoot(realRoot string, virtPath string, mustExist bool, virtualRoot string) (string, error) {
 	virtPath = filepath.ToSlash(virtPath)
 	// Boundary-safe check: handle virtualRoot=="/" where root+"/" would be "//"
+	// On Windows, uses case-insensitive comparison.
 	underRoot := func(path, root string) bool {
+		if root == "" {
+			return false
+		}
 		if root == "/" {
 			return strings.HasPrefix(path, "/")
+		}
+		if runtime.GOOS == "windows" {
+			lp, lr := strings.ToLower(path), strings.ToLower(root)
+			if strings.HasSuffix(lr, "/") {
+				return strings.HasPrefix(lp, lr)
+			}
+			return lp == lr || strings.HasPrefix(lp, lr+"/")
 		}
 		return path == root || strings.HasPrefix(path, root+"/")
 	}

--- a/internal/fsmonitor/path.go
+++ b/internal/fsmonitor/path.go
@@ -7,17 +7,17 @@ import (
 	"strings"
 )
 
-// resolveRealPathUnderRoot maps a virtual "/workspace/..." path to a real path under realRoot and verifies
+// resolveRealPathUnderRoot maps a virtual path (under virtualRoot) to a real path under realRoot and verifies
 // it does not escape via ".." components or symlinks.
 //
 // If mustExist is true, the target is expected to exist and will be evaluated directly.
 // If mustExist is false, the parent directory is evaluated for symlink escape and the final path may not exist yet.
-func resolveRealPathUnderRoot(realRoot string, virtPath string, mustExist bool) (string, error) {
+func resolveRealPathUnderRoot(realRoot string, virtPath string, mustExist bool, virtualRoot string) (string, error) {
 	virtPath = filepath.ToSlash(virtPath)
-	if !strings.HasPrefix(virtPath, "/workspace") {
-		return "", fmt.Errorf("path must be under /workspace")
+	if !strings.HasPrefix(virtPath, virtualRoot) {
+		return "", fmt.Errorf("path must be under %s", virtualRoot)
 	}
-	rel := strings.TrimPrefix(virtPath, "/workspace")
+	rel := strings.TrimPrefix(virtPath, virtualRoot)
 	rel = strings.TrimPrefix(rel, "/")
 
 	// Resolve symlinks on root path to handle macOS /var -> /private/var etc.

--- a/internal/fsmonitor/path.go
+++ b/internal/fsmonitor/path.go
@@ -8,11 +8,16 @@ import (
 )
 
 // isRealPathUnder checks if a real filesystem path is equal to or under root,
-// using os.PathSeparator for boundary checks.  Handles root=="/" or root==sep.
+// using os.PathSeparator for boundary checks.  Handles root=="/" or volume
+// roots like "C:\" where root already ends with the separator.
 func isRealPathUnder(path, root string) bool {
 	sep := string(os.PathSeparator)
 	if root == "/" || root == sep {
 		return true
+	}
+	// Volume roots (e.g. "C:\") already end with separator
+	if strings.HasSuffix(root, sep) {
+		return strings.HasPrefix(path, root)
 	}
 	return path == root || strings.HasPrefix(path, root+sep)
 }

--- a/internal/fsmonitor/path.go
+++ b/internal/fsmonitor/path.go
@@ -14,7 +14,14 @@ import (
 // If mustExist is false, the parent directory is evaluated for symlink escape and the final path may not exist yet.
 func resolveRealPathUnderRoot(realRoot string, virtPath string, mustExist bool, virtualRoot string) (string, error) {
 	virtPath = filepath.ToSlash(virtPath)
-	if virtPath != virtualRoot && !strings.HasPrefix(virtPath, virtualRoot+"/") {
+	// Boundary-safe check: handle virtualRoot=="/" where root+"/" would be "//"
+	underRoot := func(path, root string) bool {
+		if root == "/" {
+			return strings.HasPrefix(path, "/")
+		}
+		return path == root || strings.HasPrefix(path, root+"/")
+	}
+	if !underRoot(virtPath, virtualRoot) {
 		return "", fmt.Errorf("path must be under %s", virtualRoot)
 	}
 	rel := strings.TrimPrefix(virtPath, virtualRoot)

--- a/internal/fsmonitor/path.go
+++ b/internal/fsmonitor/path.go
@@ -4,18 +4,26 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
 // isRealPathUnder checks if a real filesystem path is equal to or under root,
 // using os.PathSeparator for boundary checks.  Handles root=="/" or volume
 // roots like "C:\" where root already ends with the separator.
+// On Windows, comparisons are case-insensitive.
 func isRealPathUnder(path, root string) bool {
 	sep := string(os.PathSeparator)
 	if root == "/" || root == sep {
 		return true
 	}
-	// Volume roots (e.g. "C:\") already end with separator
+	if runtime.GOOS == "windows" {
+		lp, lr := strings.ToLower(path), strings.ToLower(root)
+		if strings.HasSuffix(lr, sep) {
+			return strings.HasPrefix(lp, lr)
+		}
+		return lp == lr || strings.HasPrefix(lp, lr+sep)
+	}
 	if strings.HasSuffix(root, sep) {
 		return strings.HasPrefix(path, root)
 	}

--- a/internal/fsmonitor/path.go
+++ b/internal/fsmonitor/path.go
@@ -7,6 +7,16 @@ import (
 	"strings"
 )
 
+// isRealPathUnder checks if a real filesystem path is equal to or under root,
+// using os.PathSeparator for boundary checks.  Handles root=="/" or root==sep.
+func isRealPathUnder(path, root string) bool {
+	sep := string(os.PathSeparator)
+	if root == "/" || root == sep {
+		return true
+	}
+	return path == root || strings.HasPrefix(path, root+sep)
+}
+
 // resolveRealPathUnderRoot maps a virtual path (under virtualRoot) to a real path under realRoot and verifies
 // it does not escape via ".." components or symlinks.
 //
@@ -36,7 +46,7 @@ func resolveRealPathUnderRoot(realRoot string, virtPath string, mustExist bool, 
 
 	// Fast ".." escape check before touching the filesystem.
 	cleanCandidate := filepath.Clean(candidate)
-	if cleanCandidate != rootClean && !strings.HasPrefix(cleanCandidate, rootClean+string(os.PathSeparator)) {
+	if !isRealPathUnder(cleanCandidate, rootClean) {
 		return "", fmt.Errorf("path escapes workspace root")
 	}
 
@@ -46,7 +56,7 @@ func resolveRealPathUnderRoot(realRoot string, virtPath string, mustExist bool, 
 			return "", err
 		}
 		resolved = filepath.Clean(resolved)
-		if resolved != rootClean && !strings.HasPrefix(resolved, rootClean+string(os.PathSeparator)) {
+		if !isRealPathUnder(resolved, rootClean) {
 			return "", fmt.Errorf("symlink escape outside workspace root")
 		}
 		return resolved, nil
@@ -58,12 +68,12 @@ func resolveRealPathUnderRoot(realRoot string, virtPath string, mustExist bool, 
 		return "", err
 	}
 	resolvedParent = filepath.Clean(resolvedParent)
-	if resolvedParent != rootClean && !strings.HasPrefix(resolvedParent, rootClean+string(os.PathSeparator)) {
+	if !isRealPathUnder(resolvedParent, rootClean) {
 		return "", fmt.Errorf("symlink escape outside workspace root")
 	}
 	out := filepath.Join(resolvedParent, filepath.Base(cleanCandidate))
 	out = filepath.Clean(out)
-	if out != rootClean && !strings.HasPrefix(out, rootClean+string(os.PathSeparator)) {
+	if !isRealPathUnder(out, rootClean) {
 		return "", fmt.Errorf("path escapes workspace root")
 	}
 	return out, nil

--- a/internal/fsmonitor/path.go
+++ b/internal/fsmonitor/path.go
@@ -30,6 +30,17 @@ func isRealPathUnder(path, root string) bool {
 	return path == root || strings.HasPrefix(path, root+sep)
 }
 
+// trimRootPrefix removes root from the front of path, using case-insensitive
+// matching on Windows.
+func trimRootPrefix(path, root string) string {
+	if runtime.GOOS == "windows" && len(path) >= len(root) {
+		if strings.EqualFold(path[:len(root)], root) {
+			return path[len(root):]
+		}
+	}
+	return strings.TrimPrefix(path, root)
+}
+
 // resolveRealPathUnderRoot maps a virtual path (under virtualRoot) to a real path under realRoot and verifies
 // it does not escape via ".." components or symlinks.
 //
@@ -47,7 +58,7 @@ func resolveRealPathUnderRoot(realRoot string, virtPath string, mustExist bool, 
 	if !underRoot(virtPath, virtualRoot) {
 		return "", fmt.Errorf("path must be under %s", virtualRoot)
 	}
-	rel := strings.TrimPrefix(virtPath, virtualRoot)
+	rel := trimRootPrefix(virtPath, virtualRoot)
 	rel = strings.TrimPrefix(rel, "/")
 
 	// Resolve symlinks on root path to handle macOS /var -> /private/var etc.

--- a/internal/fsmonitor/path.go
+++ b/internal/fsmonitor/path.go
@@ -13,6 +13,9 @@ import (
 // roots like "C:\" where root already ends with the separator.
 // On Windows, comparisons are case-insensitive.
 func isRealPathUnder(path, root string) bool {
+	if root == "" {
+		return false
+	}
 	sep := string(os.PathSeparator)
 	if root == "/" || root == sep {
 		return true

--- a/internal/fsmonitor/path.go
+++ b/internal/fsmonitor/path.go
@@ -14,7 +14,7 @@ import (
 // If mustExist is false, the parent directory is evaluated for symlink escape and the final path may not exist yet.
 func resolveRealPathUnderRoot(realRoot string, virtPath string, mustExist bool, virtualRoot string) (string, error) {
 	virtPath = filepath.ToSlash(virtPath)
-	if !strings.HasPrefix(virtPath, virtualRoot) {
+	if virtPath != virtualRoot && !strings.HasPrefix(virtPath, virtualRoot+"/") {
 		return "", fmt.Errorf("path must be under %s", virtualRoot)
 	}
 	rel := strings.TrimPrefix(virtPath, virtualRoot)

--- a/internal/fsmonitor/path.go
+++ b/internal/fsmonitor/path.go
@@ -2,47 +2,11 @@ package fsmonitor
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
+
+	"github.com/agentsh/agentsh/internal/pathutil"
 )
-
-// isRealPathUnder checks if a real filesystem path is equal to or under root,
-// using os.PathSeparator for boundary checks.  Handles root=="/" or volume
-// roots like "C:\" where root already ends with the separator.
-// On Windows, comparisons are case-insensitive.
-func isRealPathUnder(path, root string) bool {
-	if root == "" {
-		return false
-	}
-	sep := string(os.PathSeparator)
-	if root == "/" || root == sep {
-		return true
-	}
-	if runtime.GOOS == "windows" {
-		lp, lr := strings.ToLower(path), strings.ToLower(root)
-		if strings.HasSuffix(lr, sep) {
-			return strings.HasPrefix(lp, lr)
-		}
-		return lp == lr || strings.HasPrefix(lp, lr+sep)
-	}
-	if strings.HasSuffix(root, sep) {
-		return strings.HasPrefix(path, root)
-	}
-	return path == root || strings.HasPrefix(path, root+sep)
-}
-
-// trimRootPrefix removes root from the front of path, using case-insensitive
-// matching on Windows.
-func trimRootPrefix(path, root string) string {
-	if runtime.GOOS == "windows" && len(path) >= len(root) {
-		if strings.EqualFold(path[:len(root)], root) {
-			return path[len(root):]
-		}
-	}
-	return strings.TrimPrefix(path, root)
-}
 
 // resolveRealPathUnderRoot maps a virtual path (under virtualRoot) to a real path under realRoot and verifies
 // it does not escape via ".." components or symlinks.
@@ -51,28 +15,10 @@ func trimRootPrefix(path, root string) string {
 // If mustExist is false, the parent directory is evaluated for symlink escape and the final path may not exist yet.
 func resolveRealPathUnderRoot(realRoot string, virtPath string, mustExist bool, virtualRoot string) (string, error) {
 	virtPath = filepath.ToSlash(virtPath)
-	// Boundary-safe check: handle virtualRoot=="/" where root+"/" would be "//"
-	// On Windows, uses case-insensitive comparison.
-	underRoot := func(path, root string) bool {
-		if root == "" {
-			return false
-		}
-		if root == "/" {
-			return strings.HasPrefix(path, "/")
-		}
-		if runtime.GOOS == "windows" {
-			lp, lr := strings.ToLower(path), strings.ToLower(root)
-			if strings.HasSuffix(lr, "/") {
-				return strings.HasPrefix(lp, lr)
-			}
-			return lp == lr || strings.HasPrefix(lp, lr+"/")
-		}
-		return path == root || strings.HasPrefix(path, root+"/")
-	}
-	if !underRoot(virtPath, virtualRoot) {
+	if !pathutil.IsUnderRoot(virtPath, virtualRoot) {
 		return "", fmt.Errorf("path must be under %s", virtualRoot)
 	}
-	rel := trimRootPrefix(virtPath, virtualRoot)
+	rel := pathutil.TrimRootPrefix(virtPath, virtualRoot)
 	rel = strings.TrimPrefix(rel, "/")
 
 	// Resolve symlinks on root path to handle macOS /var -> /private/var etc.
@@ -84,7 +30,7 @@ func resolveRealPathUnderRoot(realRoot string, virtPath string, mustExist bool, 
 
 	// Fast ".." escape check before touching the filesystem.
 	cleanCandidate := filepath.Clean(candidate)
-	if !isRealPathUnder(cleanCandidate, rootClean) {
+	if !pathutil.IsRealPathUnder(cleanCandidate, rootClean) {
 		return "", fmt.Errorf("path escapes workspace root")
 	}
 
@@ -94,7 +40,7 @@ func resolveRealPathUnderRoot(realRoot string, virtPath string, mustExist bool, 
 			return "", err
 		}
 		resolved = filepath.Clean(resolved)
-		if !isRealPathUnder(resolved, rootClean) {
+		if !pathutil.IsRealPathUnder(resolved, rootClean) {
 			return "", fmt.Errorf("symlink escape outside workspace root")
 		}
 		return resolved, nil
@@ -106,12 +52,12 @@ func resolveRealPathUnderRoot(realRoot string, virtPath string, mustExist bool, 
 		return "", err
 	}
 	resolvedParent = filepath.Clean(resolvedParent)
-	if !isRealPathUnder(resolvedParent, rootClean) {
+	if !pathutil.IsRealPathUnder(resolvedParent, rootClean) {
 		return "", fmt.Errorf("symlink escape outside workspace root")
 	}
 	out := filepath.Join(resolvedParent, filepath.Base(cleanCandidate))
 	out = filepath.Clean(out)
-	if !isRealPathUnder(out, rootClean) {
+	if !pathutil.IsRealPathUnder(out, rootClean) {
 		return "", fmt.Errorf("path escapes workspace root")
 	}
 	return out, nil

--- a/internal/fsmonitor/path_real_paths_test.go
+++ b/internal/fsmonitor/path_real_paths_test.go
@@ -1,0 +1,50 @@
+//go:build !windows
+
+package fsmonitor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveRealPathUnderRoot_CustomVirtualRoot(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveRealPathUnderRoot(root, root+"/sub", true, root)
+	if err != nil {
+		t.Fatalf("resolveRealPathUnderRoot: %v", err)
+	}
+	if got != sub {
+		t.Errorf("got %q, want %q", got, sub)
+	}
+}
+
+func TestResolveRealPathUnderRoot_DefaultWorkspace(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveRealPathUnderRoot(root, "/workspace/sub", true, "/workspace")
+	if err != nil {
+		t.Fatalf("resolveRealPathUnderRoot: %v", err)
+	}
+	if got != sub {
+		t.Errorf("got %q, want %q", got, sub)
+	}
+}
+
+func TestResolveRealPathUnderRoot_EscapeBlocked(t *testing.T) {
+	root := t.TempDir()
+
+	_, err := resolveRealPathUnderRoot(root, "/workspace/../etc/passwd", true, "/workspace")
+	if err == nil {
+		t.Error("expected error for path escape")
+	}
+}

--- a/internal/fsmonitor/path_real_paths_test.go
+++ b/internal/fsmonitor/path_real_paths_test.go
@@ -15,12 +15,18 @@ func TestResolveRealPathUnderRoot_CustomVirtualRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Resolve expected path to handle macOS /var -> /private/var symlink
+	wantSub, _ := filepath.EvalSymlinks(sub)
+	if wantSub == "" {
+		wantSub = sub
+	}
+
 	got, err := resolveRealPathUnderRoot(root, root+"/sub", true, root)
 	if err != nil {
 		t.Fatalf("resolveRealPathUnderRoot: %v", err)
 	}
-	if got != sub {
-		t.Errorf("got %q, want %q", got, sub)
+	if got != wantSub {
+		t.Errorf("got %q, want %q", got, wantSub)
 	}
 }
 
@@ -31,12 +37,17 @@ func TestResolveRealPathUnderRoot_DefaultWorkspace(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	wantSub, _ := filepath.EvalSymlinks(sub)
+	if wantSub == "" {
+		wantSub = sub
+	}
+
 	got, err := resolveRealPathUnderRoot(root, "/workspace/sub", true, "/workspace")
 	if err != nil {
 		t.Fatalf("resolveRealPathUnderRoot: %v", err)
 	}
-	if got != sub {
-		t.Errorf("got %q, want %q", got, sub)
+	if got != wantSub {
+		t.Errorf("got %q, want %q", got, wantSub)
 	}
 }
 
@@ -66,12 +77,17 @@ func TestResolveRealPathUnderRoot_RootVirtualRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	wantSub, _ := filepath.EvalSymlinks(sub)
+	if wantSub == "" {
+		wantSub = sub
+	}
+
 	// When virtualRoot is "/", paths like "/etc" should be accepted
 	got, err := resolveRealPathUnderRoot(root, "/etc", true, "/")
 	if err != nil {
 		t.Fatalf("resolveRealPathUnderRoot with root /: %v", err)
 	}
-	if got != sub {
-		t.Errorf("got %q, want %q", got, sub)
+	if got != wantSub {
+		t.Errorf("got %q, want %q", got, wantSub)
 	}
 }

--- a/internal/fsmonitor/path_real_paths_test.go
+++ b/internal/fsmonitor/path_real_paths_test.go
@@ -58,3 +58,20 @@ func TestResolveRealPathUnderRoot_SiblingPrefix(t *testing.T) {
 		t.Error("expected error for sibling-prefix path")
 	}
 }
+
+func TestResolveRealPathUnderRoot_RootVirtualRoot(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "etc")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// When virtualRoot is "/", paths like "/etc" should be accepted
+	got, err := resolveRealPathUnderRoot(root, "/etc", true, "/")
+	if err != nil {
+		t.Fatalf("resolveRealPathUnderRoot with root /: %v", err)
+	}
+	if got != sub {
+		t.Errorf("got %q, want %q", got, sub)
+	}
+}

--- a/internal/fsmonitor/path_real_paths_test.go
+++ b/internal/fsmonitor/path_real_paths_test.go
@@ -48,3 +48,13 @@ func TestResolveRealPathUnderRoot_EscapeBlocked(t *testing.T) {
 		t.Error("expected error for path escape")
 	}
 }
+
+func TestResolveRealPathUnderRoot_SiblingPrefix(t *testing.T) {
+	root := t.TempDir()
+
+	// Sibling path like /tmp/ws-extra should NOT match virtualRoot /tmp/ws
+	_, err := resolveRealPathUnderRoot(root, root+"-extra/file", true, root)
+	if err == nil {
+		t.Error("expected error for sibling-prefix path")
+	}
+}

--- a/internal/fsmonitor/path_test.go
+++ b/internal/fsmonitor/path_test.go
@@ -12,7 +12,7 @@ func TestResolveRealPathUnderRoot_BlocksSymlinkEscape(t *testing.T) {
 	if err := os.Symlink("/etc/passwd", link); err != nil {
 		t.Skipf("symlink not supported: %v", err)
 	}
-	_, err := resolveRealPathUnderRoot(root, "/workspace/link", true)
+	_, err := resolveRealPathUnderRoot(root, "/workspace/link", true, "/workspace")
 	if err == nil {
 		t.Fatalf("expected escape error")
 	}
@@ -29,7 +29,7 @@ func TestResolveRealPathUnderRoot_AllowsInTreeSymlink(t *testing.T) {
 	if err := os.Symlink("dir/a.txt", filepath.Join(root, "in")); err != nil {
 		t.Skipf("symlink not supported: %v", err)
 	}
-	p, err := resolveRealPathUnderRoot(root, "/workspace/in", true)
+	p, err := resolveRealPathUnderRoot(root, "/workspace/in", true, "/workspace")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestResolveRealPathUnderRoot_UsesParentForCreate(t *testing.T) {
 	if err := os.Symlink("/etc", filepath.Join(root, "p")); err != nil {
 		t.Skipf("symlink not supported: %v", err)
 	}
-	_, err := resolveRealPathUnderRoot(root, "/workspace/p/newfile", false)
+	_, err := resolveRealPathUnderRoot(root, "/workspace/p/newfile", false, "/workspace")
 	if err == nil {
 		t.Fatalf("expected escape error")
 	}

--- a/internal/pathutil/pathutil.go
+++ b/internal/pathutil/pathutil.go
@@ -1,0 +1,65 @@
+// Package pathutil provides path boundary checking helpers shared across
+// packages that need to determine whether a filesystem path is under a root.
+package pathutil
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+// IsUnderRoot checks if a virtual path (using forward slashes) is equal to or
+// under root. Returns false for empty root (fail closed). Handles root=="/"
+// and Windows case-insensitive comparison.
+func IsUnderRoot(path, root string) bool {
+	if root == "" {
+		return false
+	}
+	if root == "/" {
+		return strings.HasPrefix(path, "/")
+	}
+	if runtime.GOOS == "windows" {
+		lp, lr := strings.ToLower(path), strings.ToLower(root)
+		if strings.HasSuffix(lr, "/") {
+			return strings.HasPrefix(lp, lr)
+		}
+		return lp == lr || strings.HasPrefix(lp, lr+"/")
+	}
+	return path == root || strings.HasPrefix(path, root+"/")
+}
+
+// IsRealPathUnder checks if a real filesystem path is equal to or under root,
+// using os.PathSeparator for boundary checks. Returns false for empty root
+// (fail closed). Handles root=="/" or volume roots like "C:\" where root
+// already ends with the separator. On Windows, comparisons are case-insensitive.
+func IsRealPathUnder(path, root string) bool {
+	if root == "" {
+		return false
+	}
+	sep := string(os.PathSeparator)
+	if root == "/" || root == sep {
+		return true
+	}
+	if runtime.GOOS == "windows" {
+		lp, lr := strings.ToLower(path), strings.ToLower(root)
+		if strings.HasSuffix(lr, sep) {
+			return strings.HasPrefix(lp, lr)
+		}
+		return lp == lr || strings.HasPrefix(lp, lr+sep)
+	}
+	if strings.HasSuffix(root, sep) {
+		return strings.HasPrefix(path, root)
+	}
+	return path == root || strings.HasPrefix(path, root+sep)
+}
+
+// TrimRootPrefix removes root from the front of path. On Windows, uses
+// case-insensitive matching.
+func TrimRootPrefix(path, root string) string {
+	if runtime.GOOS == "windows" && len(path) >= len(root) {
+		if strings.EqualFold(path[:len(root)], root) {
+			return path[len(root):]
+		}
+	}
+	return strings.TrimPrefix(path, root)
+}

--- a/internal/pathutil/pathutil_test.go
+++ b/internal/pathutil/pathutil_test.go
@@ -1,0 +1,112 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestIsUnderRoot(t *testing.T) {
+	tests := []struct {
+		path string
+		root string
+		want bool
+	}{
+		{"/workspace/sub", "/workspace", true},
+		{"/workspace", "/workspace", true},
+		{"/workspace2", "/workspace", false},
+		{"/other", "/workspace", false},
+		{"/etc", "/", true},
+		{"/", "/", true},
+		// Empty root must always return false (fail closed)
+		{"/anything", "", false},
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		got := IsUnderRoot(tt.path, tt.root)
+		if got != tt.want {
+			t.Errorf("IsUnderRoot(%q, %q) = %v, want %v", tt.path, tt.root, got, tt.want)
+		}
+	}
+}
+
+func TestIsRealPathUnder(t *testing.T) {
+	tests := []struct {
+		path string
+		root string
+		want bool
+	}{
+		{"/tmp/ws/sub", "/tmp/ws", true},
+		{"/tmp/ws", "/tmp/ws", true},
+		{"/tmp/ws2", "/tmp/ws", false},
+		{"/other", "/tmp/ws", false},
+		{"/etc", "/", true},
+		{"/tmp/foo", "/", true},
+		{"/", "/", true},
+		{"/anything", "", false},
+		{"", "", false},
+	}
+	for _, tt := range tests {
+		path := filepath.FromSlash(tt.path)
+		root := filepath.FromSlash(tt.root)
+		got := IsRealPathUnder(path, root)
+		if got != tt.want {
+			t.Errorf("IsRealPathUnder(%q, %q) = %v, want %v", path, root, got, tt.want)
+		}
+	}
+	if runtime.GOOS == "windows" {
+		winTests := []struct {
+			path string
+			root string
+			want bool
+		}{
+			{`C:\Users\project\sub`, `C:\Users\project`, true},
+			{`C:\Users\project`, `C:\Users\project`, true},
+			{`C:\Users\project2`, `C:\Users\project`, false},
+			{`c:\users\project\sub`, `C:\Users\project`, true},
+			{`D:\other`, `C:\Users\project`, false},
+			{`C:\`, `C:\`, true},
+			{`C:\foo`, `C:\`, true},
+		}
+		for _, tt := range winTests {
+			got := IsRealPathUnder(tt.path, tt.root)
+			if got != tt.want {
+				t.Errorf("IsRealPathUnder(%q, %q) = %v, want %v", tt.path, tt.root, got, tt.want)
+			}
+		}
+	}
+}
+
+func TestTrimRootPrefix(t *testing.T) {
+	tests := []struct {
+		path string
+		root string
+		want string
+	}{
+		{"/workspace/sub/file", "/workspace", "/sub/file"},
+		{"/workspace", "/workspace", ""},
+		{"/other", "/workspace", "/other"},
+	}
+	for _, tt := range tests {
+		got := TrimRootPrefix(tt.path, tt.root)
+		if got != tt.want {
+			t.Errorf("TrimRootPrefix(%q, %q) = %q, want %q", tt.path, tt.root, got, tt.want)
+		}
+	}
+}
+
+func TestIsRealPathUnder_PlatformSeparator(t *testing.T) {
+	// Verify that the function uses os.PathSeparator correctly
+	sep := string(os.PathSeparator)
+	root := sep + "tmp" + sep + "ws"
+	under := root + sep + "sub"
+	sibling := sep + "tmp" + sep + "ws2"
+
+	if !IsRealPathUnder(under, root) {
+		t.Errorf("expected %q under %q", under, root)
+	}
+	if IsRealPathUnder(sibling, root) {
+		t.Errorf("expected %q NOT under %q", sibling, root)
+	}
+}

--- a/internal/platform/interfaces.go
+++ b/internal/platform/interfaces.go
@@ -72,6 +72,9 @@ type FSConfig struct {
 	// SessionID identifies the session this mount belongs to
 	SessionID string
 
+	// VirtualRoot is the virtual path prefix ("/workspace" or real path)
+	VirtualRoot string
+
 	// CommandIDFunc returns the current command ID (called per-operation)
 	CommandIDFunc func() string
 

--- a/internal/platform/linux/filesystem.go
+++ b/internal/platform/linux/filesystem.go
@@ -171,7 +171,8 @@ func (fs *Filesystem) Mount(cfg platform.FSConfig) (platform.FSMount, error) {
 	// Create the fsmonitor hooks
 	// This bridges the new platform.FSConfig to the existing fsmonitor.Hooks
 	hooks := &fsmonitor.Hooks{
-		SessionID: cfg.SessionID,
+		SessionID:   cfg.SessionID,
+		VirtualRoot: cfg.VirtualRoot,
 		// Policy will be wrapped from cfg.PolicyEngine
 		Policy: wrapPolicyEngine(cfg.PolicyEngine),
 		// Event emission bridged to cfg.EventChannel

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -503,9 +504,14 @@ func (s *Session) CloseNetNS() error {
 
 // IsUnderRoot checks if path is equal to or a child of root using
 // path-boundary-aware logic.  Handles root=="/" where root+"/" would be "//".
+// On Windows, comparisons are case-insensitive.
 func IsUnderRoot(path, root string) bool {
 	if root == "/" {
 		return strings.HasPrefix(path, "/")
+	}
+	if runtime.GOOS == "windows" {
+		lp, lr := strings.ToLower(path), strings.ToLower(root)
+		return lp == lr || strings.HasPrefix(lp, lr+"/")
 	}
 	return path == root || strings.HasPrefix(path, root+"/")
 }
@@ -513,12 +519,19 @@ func IsUnderRoot(path, root string) bool {
 // IsRealPathUnder checks if a real filesystem path is equal to or under root,
 // using os.PathSeparator for boundary checks.  Handles root=="/" or volume
 // roots like "C:\" where root already ends with the separator.
+// On Windows, comparisons are case-insensitive.
 func IsRealPathUnder(path, root string) bool {
 	sep := string(os.PathSeparator)
 	if root == "/" || root == sep {
 		return true
 	}
-	// Volume roots (e.g. "C:\") already end with separator
+	if runtime.GOOS == "windows" {
+		lp, lr := strings.ToLower(path), strings.ToLower(root)
+		if strings.HasSuffix(lr, sep) {
+			return strings.HasPrefix(lp, lr)
+		}
+		return lp == lr || strings.HasPrefix(lp, lr+sep)
+	}
 	if strings.HasSuffix(root, sep) {
 		return strings.HasPrefix(path, root)
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -511,6 +511,10 @@ func IsUnderRoot(path, root string) bool {
 	}
 	if runtime.GOOS == "windows" {
 		lp, lr := strings.ToLower(path), strings.ToLower(root)
+		// Handle roots like "C:/" that already end with separator
+		if strings.HasSuffix(lr, "/") {
+			return strings.HasPrefix(lp, lr)
+		}
 		return lp == lr || strings.HasPrefix(lp, lr+"/")
 	}
 	return path == root || strings.HasPrefix(path, root+"/")

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -501,9 +501,9 @@ func (s *Session) CloseNetNS() error {
 	return nil
 }
 
-// isUnderRoot checks if path is equal to or a child of root using
+// IsUnderRoot checks if path is equal to or a child of root using
 // path-boundary-aware logic.  Handles root=="/" where root+"/" would be "//".
-func isUnderRoot(path, root string) bool {
+func IsUnderRoot(path, root string) bool {
 	if root == "/" {
 		return strings.HasPrefix(path, "/")
 	}
@@ -522,7 +522,7 @@ func (s *Session) Builtin(req types.ExecRequest) (handled bool, exitCode int, st
 			}
 			target = filepath.ToSlash(filepath.Clean(t))
 		}
-		if !isUnderRoot(target, s.VirtualRoot) {
+		if !IsUnderRoot(target, s.VirtualRoot) {
 			return true, 1, nil, []byte(fmt.Sprintf("cd: path must be under %s\n", s.VirtualRoot))
 		}
 		s.mu.Lock()
@@ -720,7 +720,7 @@ func (s *Session) ApplyPatch(patch types.SessionPatchRequest) error {
 		if cwd == "." || cwd == "" {
 			cwd = s.VirtualRoot
 		}
-		if !isUnderRoot(cwd, s.VirtualRoot) {
+		if !IsUnderRoot(cwd, s.VirtualRoot) {
 			return fmt.Errorf("cwd must be under %s", s.VirtualRoot)
 		}
 		s.Cwd = cwd
@@ -755,7 +755,7 @@ func (s *Session) resolvePathForBuiltin(arg string) (virt string, real string, e
 	if virt == "." || virt == "" {
 		virt = s.VirtualRoot
 	}
-	if !isUnderRoot(virt, s.VirtualRoot) {
+	if !IsUnderRoot(virt, s.VirtualRoot) {
 		// Outside workspace — reject for builtins (acat/als/astat run in-process
 		// and bypass seccomp). Subprocess commands handle outside paths via
 		// resolveWorkingDir in exec.go where seccomp enforces policy.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -510,20 +510,34 @@ func IsUnderRoot(path, root string) bool {
 	return path == root || strings.HasPrefix(path, root+"/")
 }
 
+// IsRealPathUnder checks if a real filesystem path is equal to or under root,
+// using os.PathSeparator for boundary checks.  Handles root=="/" or root==sep.
+func IsRealPathUnder(path, root string) bool {
+	sep := string(os.PathSeparator)
+	if root == "/" || root == sep {
+		return true
+	}
+	return path == root || strings.HasPrefix(path, root+sep)
+}
+
 func (s *Session) Builtin(req types.ExecRequest) (handled bool, exitCode int, stdout, stderr []byte) {
 	switch req.Command {
 	case "cd":
 		s.Touch()
-		target := s.VirtualRoot
+		s.mu.Lock()
+		vroot := s.VirtualRoot
+		cwd := s.Cwd
+		s.mu.Unlock()
+		target := vroot
 		if len(req.Args) > 0 && req.Args[0] != "" {
 			t := req.Args[0]
 			if !filepath.IsAbs(t) {
-				t = filepath.ToSlash(filepath.Join(s.Cwd, t))
+				t = filepath.ToSlash(filepath.Join(cwd, t))
 			}
 			target = filepath.ToSlash(filepath.Clean(t))
 		}
-		if !IsUnderRoot(target, s.VirtualRoot) {
-			return true, 1, nil, []byte(fmt.Sprintf("cd: path must be under %s\n", s.VirtualRoot))
+		if !IsUnderRoot(target, vroot) {
+			return true, 1, nil, []byte(fmt.Sprintf("cd: path must be under %s\n", vroot))
 		}
 		s.mu.Lock()
 		s.Cwd = target
@@ -766,7 +780,7 @@ func (s *Session) resolvePathForBuiltin(arg string) (virt string, real string, e
 	root := s.WorkspaceMountPath()
 	real = filepath.Clean(filepath.Join(root, filepath.FromSlash(rel)))
 	rootClean := filepath.Clean(root)
-	if real != rootClean && !strings.HasPrefix(real, rootClean+string(os.PathSeparator)) {
+	if !IsRealPathUnder(real, rootClean) {
 		return "", "", fmt.Errorf("path escapes workspace mount")
 	}
 	return virt, real, nil

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -501,13 +501,29 @@ func (s *Session) CloseNetNS() error {
 	return nil
 }
 
+// isUnderRoot checks if path is equal to or a child of root using
+// path-boundary-aware logic.  Handles root=="/" where root+"/" would be "//".
+func isUnderRoot(path, root string) bool {
+	if root == "/" {
+		return strings.HasPrefix(path, "/")
+	}
+	return path == root || strings.HasPrefix(path, root+"/")
+}
+
 func (s *Session) Builtin(req types.ExecRequest) (handled bool, exitCode int, stdout, stderr []byte) {
 	switch req.Command {
 	case "cd":
 		s.Touch()
 		target := s.VirtualRoot
 		if len(req.Args) > 0 && req.Args[0] != "" {
-			target = req.Args[0]
+			t := req.Args[0]
+			if !strings.HasPrefix(t, "/") {
+				t = filepath.ToSlash(filepath.Join(s.Cwd, t))
+			}
+			target = filepath.ToSlash(filepath.Clean(t))
+		}
+		if !isUnderRoot(target, s.VirtualRoot) {
+			return true, 1, nil, []byte(fmt.Sprintf("cd: path must be under %s\n", s.VirtualRoot))
 		}
 		s.mu.Lock()
 		s.Cwd = target
@@ -704,7 +720,7 @@ func (s *Session) ApplyPatch(patch types.SessionPatchRequest) error {
 		if cwd == "." || cwd == "" {
 			cwd = s.VirtualRoot
 		}
-		if cwd != s.VirtualRoot && !strings.HasPrefix(cwd, s.VirtualRoot+"/") {
+		if !isUnderRoot(cwd, s.VirtualRoot) {
 			return fmt.Errorf("cwd must be under %s", s.VirtualRoot)
 		}
 		s.Cwd = cwd
@@ -739,7 +755,7 @@ func (s *Session) resolvePathForBuiltin(arg string) (virt string, real string, e
 	if virt == "." || virt == "" {
 		virt = s.VirtualRoot
 	}
-	if virt != s.VirtualRoot && !strings.HasPrefix(virt, s.VirtualRoot+"/") {
+	if !isUnderRoot(virt, s.VirtualRoot) {
 		// Outside workspace — reject for builtins (acat/als/astat run in-process
 		// and bypass seccomp). Subprocess commands handle outside paths via
 		// resolveWorkingDir in exec.go where seccomp enforces policy.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -241,6 +241,7 @@ func (s *Session) Snapshot() types.Session {
 		Profile:     s.Profile,
 		Mounts:      mounts,
 		Cwd:         s.Cwd,
+		VirtualRoot: s.VirtualRoot,
 		ProxyURL:    s.proxyURL,
 		TOTPSecret:  s.TOTPSecret,
 		ProjectRoot: s.ProjectRoot,

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -34,7 +34,8 @@ type Session struct {
 	WorkspaceMount string
 	Policy         string
 
-	Cwd     string
+	Cwd         string
+	VirtualRoot string // "/workspace" or real workspace path when real_paths enabled
 	Env     map[string]string
 	History []string
 
@@ -131,6 +132,7 @@ func (m *Manager) CreateWithProfile(id, profile, basePolicy string, mounts []Res
 		Profile:      profile,
 		Mounts:       mounts,
 		Cwd:          "/workspace",
+		VirtualRoot:  "/workspace",
 		Env:          map[string]string{},
 	}
 	m.sessions[id] = s
@@ -177,6 +179,7 @@ func (m *Manager) CreateWithID(id, workspace, policy string) (*Session, error) {
 		WorkspaceMount: abs,
 		Policy:         policy,
 		Cwd:            "/workspace",
+		VirtualRoot:    "/workspace",
 		Env:            map[string]string{},
 	}
 	m.sessions[id] = s
@@ -352,6 +355,23 @@ func (s *Session) WorkspaceMountPath() string {
 		return s.WorkspaceMount
 	}
 	return s.Workspace
+}
+
+// SetRealPaths switches the session to use real host paths instead of /workspace.
+func (s *Session) SetRealPaths(enabled bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if enabled {
+		vroot := strings.TrimRight(s.Workspace, "/")
+		if vroot == "" {
+			vroot = "/"
+		}
+		s.VirtualRoot = vroot
+		s.Cwd = vroot
+	} else {
+		s.VirtualRoot = "/workspace"
+		s.Cwd = "/workspace"
+	}
 }
 
 func (s *Session) SetWorkspaceUnmount(fn func() error) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -734,7 +734,7 @@ func (s *Session) ApplyPatch(patch types.SessionPatchRequest) error {
 	if patch.Cwd != "" {
 		cwd := patch.Cwd
 		vroot := s.EffectiveVirtualRoot()
-		if !strings.HasPrefix(cwd, "/") {
+		if !filepath.IsAbs(cwd) {
 			cwd = filepath.ToSlash(filepath.Join(s.Cwd, cwd))
 		}
 		cwd = filepath.ToSlash(filepath.Clean(cwd))
@@ -775,7 +775,7 @@ func (s *Session) resolvePathForBuiltin(arg string) (virt string, real string, e
 	vroot := s.EffectiveVirtualRoot()
 	virt = cwd
 	if strings.TrimSpace(arg) != "" {
-		if strings.HasPrefix(arg, "/") {
+		if filepath.IsAbs(arg) {
 			virt = arg
 		} else {
 			virt = filepath.ToSlash(filepath.Join(cwd, arg))

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -529,8 +529,11 @@ func IsUnderRoot(path, root string) bool {
 // IsRealPathUnder checks if a real filesystem path is equal to or under root,
 // using os.PathSeparator for boundary checks.  Handles root=="/" or volume
 // roots like "C:\" where root already ends with the separator.
-// On Windows, comparisons are case-insensitive.
+// Returns false for empty root.  On Windows, comparisons are case-insensitive.
 func IsRealPathUnder(path, root string) bool {
+	if root == "" {
+		return false
+	}
 	sep := string(os.PathSeparator)
 	if root == "/" || root == sep {
 		return true

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -366,7 +366,7 @@ func (s *Session) SetRealPaths(enabled bool) {
 		if s.Workspace == "" {
 			return // no-op: empty workspace cannot be used as virtual root
 		}
-		vroot := filepath.Clean(s.Workspace)
+		vroot := filepath.ToSlash(filepath.Clean(s.Workspace))
 		s.VirtualRoot = vroot
 		s.Cwd = vroot
 	} else {
@@ -517,7 +517,7 @@ func (s *Session) Builtin(req types.ExecRequest) (handled bool, exitCode int, st
 		target := s.VirtualRoot
 		if len(req.Args) > 0 && req.Args[0] != "" {
 			t := req.Args[0]
-			if !strings.HasPrefix(t, "/") {
+			if !filepath.IsAbs(t) {
 				t = filepath.ToSlash(filepath.Join(s.Cwd, t))
 			}
 			target = filepath.ToSlash(filepath.Clean(t))

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -703,7 +703,7 @@ func (s *Session) ApplyPatch(patch types.SessionPatchRequest) error {
 		if cwd == "." || cwd == "" {
 			cwd = s.VirtualRoot
 		}
-		if !strings.HasPrefix(cwd, s.VirtualRoot) {
+		if cwd != s.VirtualRoot && !strings.HasPrefix(cwd, s.VirtualRoot+"/") {
 			return fmt.Errorf("cwd must be under %s", s.VirtualRoot)
 		}
 		s.Cwd = cwd
@@ -739,8 +739,10 @@ func (s *Session) resolvePathForBuiltin(arg string) (virt string, real string, e
 		virt = s.VirtualRoot
 	}
 	if virt != s.VirtualRoot && !strings.HasPrefix(virt, s.VirtualRoot+"/") {
-		// Outside workspace — pass through as-is for policy/seccomp enforcement
-		return virt, virt, nil
+		// Outside workspace — reject for builtins (acat/als/astat run in-process
+		// and bypass seccomp). Subprocess commands handle outside paths via
+		// resolveWorkingDir in exec.go where seccomp enforces policy.
+		return "", "", fmt.Errorf("path must be under %s", s.VirtualRoot)
 	}
 	rel := strings.TrimPrefix(virt, s.VirtualRoot)
 	rel = strings.TrimPrefix(rel, "/")

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -511,11 +511,16 @@ func IsUnderRoot(path, root string) bool {
 }
 
 // IsRealPathUnder checks if a real filesystem path is equal to or under root,
-// using os.PathSeparator for boundary checks.  Handles root=="/" or root==sep.
+// using os.PathSeparator for boundary checks.  Handles root=="/" or volume
+// roots like "C:\" where root already ends with the separator.
 func IsRealPathUnder(path, root string) bool {
 	sep := string(os.PathSeparator)
 	if root == "/" || root == sep {
 		return true
+	}
+	// Volume roots (e.g. "C:\") already end with separator
+	if strings.HasSuffix(root, sep) {
+		return strings.HasPrefix(path, root)
 	}
 	return path == root || strings.HasPrefix(path, root+sep)
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -504,7 +504,7 @@ func (s *Session) Builtin(req types.ExecRequest) (handled bool, exitCode int, st
 	switch req.Command {
 	case "cd":
 		s.Touch()
-		target := "/workspace"
+		target := s.VirtualRoot
 		if len(req.Args) > 0 && req.Args[0] != "" {
 			target = req.Args[0]
 		}
@@ -648,7 +648,7 @@ func (s *Session) Builtin(req types.ExecRequest) (handled bool, exitCode int, st
 	case "acat":
 		s.Touch()
 		if len(req.Args) < 1 {
-			return true, 2, nil, []byte("usage: acat /workspace/path\n")
+			return true, 2, nil, []byte("usage: acat <path>\n")
 		}
 		virt, real, err := s.resolvePathForBuiltin(req.Args[0])
 		if err != nil {
@@ -701,10 +701,10 @@ func (s *Session) ApplyPatch(patch types.SessionPatchRequest) error {
 		}
 		cwd = filepath.ToSlash(filepath.Clean(cwd))
 		if cwd == "." || cwd == "" {
-			cwd = "/workspace"
+			cwd = s.VirtualRoot
 		}
-		if !strings.HasPrefix(cwd, "/workspace") {
-			return fmt.Errorf("cwd must be under /workspace")
+		if !strings.HasPrefix(cwd, s.VirtualRoot) {
+			return fmt.Errorf("cwd must be under %s", s.VirtualRoot)
 		}
 		s.Cwd = cwd
 	}
@@ -736,12 +736,13 @@ func (s *Session) resolvePathForBuiltin(arg string) (virt string, real string, e
 	}
 	virt = filepath.ToSlash(filepath.Clean(virt))
 	if virt == "." || virt == "" {
-		virt = "/workspace"
+		virt = s.VirtualRoot
 	}
-	if !strings.HasPrefix(virt, "/workspace") {
-		return "", "", fmt.Errorf("path must be under /workspace")
+	if virt != s.VirtualRoot && !strings.HasPrefix(virt, s.VirtualRoot+"/") {
+		// Outside workspace — pass through as-is for policy/seccomp enforcement
+		return virt, virt, nil
 	}
-	rel := strings.TrimPrefix(virt, "/workspace")
+	rel := strings.TrimPrefix(virt, s.VirtualRoot)
 	rel = strings.TrimPrefix(rel, "/")
 	root := s.WorkspaceMountPath()
 	real = filepath.Clean(filepath.Join(root, filepath.FromSlash(rel)))

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -772,7 +772,7 @@ func (s *Session) ApplyPatch(patch types.SessionPatchRequest) error {
 
 	if patch.Cwd != "" {
 		cwd := patch.Cwd
-		vroot := s.effectiveVirtualRoot()
+		vroot := s.EffectiveVirtualRoot()
 		if !strings.HasPrefix(cwd, "/") {
 			cwd = filepath.ToSlash(filepath.Join(s.Cwd, cwd))
 		}
@@ -801,8 +801,8 @@ func (s *Session) ApplyPatch(patch types.SessionPatchRequest) error {
 	return nil
 }
 
-// effectiveVirtualRoot returns VirtualRoot with a safe default for legacy/empty sessions.
-func (s *Session) effectiveVirtualRoot() string {
+// EffectiveVirtualRoot returns VirtualRoot with a safe default for legacy/empty sessions.
+func (s *Session) EffectiveVirtualRoot() string {
 	if s.VirtualRoot == "" {
 		return "/workspace"
 	}
@@ -811,7 +811,7 @@ func (s *Session) effectiveVirtualRoot() string {
 
 func (s *Session) resolvePathForBuiltin(arg string) (virt string, real string, err error) {
 	cwd, _, _ := s.GetCwdEnvHistory()
-	vroot := s.effectiveVirtualRoot()
+	vroot := s.EffectiveVirtualRoot()
 	virt = cwd
 	if strings.TrimSpace(arg) != "" {
 		if strings.HasPrefix(arg, "/") {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -568,6 +568,9 @@ func (s *Session) Builtin(req types.ExecRequest) (handled bool, exitCode int, st
 		s.Touch()
 		s.mu.Lock()
 		vroot := s.VirtualRoot
+		if vroot == "" {
+			vroot = "/workspace"
+		}
 		cwd := s.Cwd
 		s.mu.Unlock()
 		target := vroot
@@ -769,15 +772,16 @@ func (s *Session) ApplyPatch(patch types.SessionPatchRequest) error {
 
 	if patch.Cwd != "" {
 		cwd := patch.Cwd
+		vroot := s.effectiveVirtualRoot()
 		if !strings.HasPrefix(cwd, "/") {
 			cwd = filepath.ToSlash(filepath.Join(s.Cwd, cwd))
 		}
 		cwd = filepath.ToSlash(filepath.Clean(cwd))
 		if cwd == "." || cwd == "" {
-			cwd = s.VirtualRoot
+			cwd = vroot
 		}
-		if !IsUnderRoot(cwd, s.VirtualRoot) {
-			return fmt.Errorf("cwd must be under %s", s.VirtualRoot)
+		if !IsUnderRoot(cwd, vroot) {
+			return fmt.Errorf("cwd must be under %s", vroot)
 		}
 		s.Cwd = cwd
 	}
@@ -797,8 +801,17 @@ func (s *Session) ApplyPatch(patch types.SessionPatchRequest) error {
 	return nil
 }
 
+// effectiveVirtualRoot returns VirtualRoot with a safe default for legacy/empty sessions.
+func (s *Session) effectiveVirtualRoot() string {
+	if s.VirtualRoot == "" {
+		return "/workspace"
+	}
+	return s.VirtualRoot
+}
+
 func (s *Session) resolvePathForBuiltin(arg string) (virt string, real string, err error) {
 	cwd, _, _ := s.GetCwdEnvHistory()
+	vroot := s.effectiveVirtualRoot()
 	virt = cwd
 	if strings.TrimSpace(arg) != "" {
 		if strings.HasPrefix(arg, "/") {
@@ -809,15 +822,15 @@ func (s *Session) resolvePathForBuiltin(arg string) (virt string, real string, e
 	}
 	virt = filepath.ToSlash(filepath.Clean(virt))
 	if virt == "." || virt == "" {
-		virt = s.VirtualRoot
+		virt = vroot
 	}
-	if !IsUnderRoot(virt, s.VirtualRoot) {
+	if !IsUnderRoot(virt, vroot) {
 		// Outside workspace — reject for builtins (acat/als/astat run in-process
 		// and bypass seccomp). Subprocess commands handle outside paths via
 		// resolveWorkingDir in exec.go where seccomp enforces policy.
-		return "", "", fmt.Errorf("path must be under %s", s.VirtualRoot)
+		return "", "", fmt.Errorf("path must be under %s", vroot)
 	}
-	rel := TrimRootPrefix(virt, s.VirtualRoot)
+	rel := TrimRootPrefix(virt, vroot)
 	rel = strings.TrimPrefix(rel, "/")
 	root := s.WorkspaceMountPath()
 	real = filepath.Clean(filepath.Join(root, filepath.FromSlash(rel)))
@@ -825,6 +838,18 @@ func (s *Session) resolvePathForBuiltin(arg string) (virt string, real string, e
 	if !IsRealPathUnder(real, rootClean) {
 		return "", "", fmt.Errorf("path escapes workspace mount")
 	}
+	// Resolve symlinks to prevent escape via workspace symlinks.
+	// Builtins run in-process and bypass seccomp, so we must verify the
+	// resolved real path stays under the workspace root.
+	resolved, resolveErr := filepath.EvalSymlinks(real)
+	if resolveErr == nil {
+		resolved = filepath.Clean(resolved)
+		if !IsRealPathUnder(resolved, rootClean) {
+			return "", "", fmt.Errorf("symlink escape outside workspace root")
+		}
+		real = resolved
+	}
+	// If EvalSymlinks fails (e.g., file doesn't exist), the lexical check above is sufficient
 	return virt, real, nil
 }
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -362,10 +362,10 @@ func (s *Session) SetRealPaths(enabled bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if enabled {
-		vroot := strings.TrimRight(s.Workspace, "/")
-		if vroot == "" {
-			vroot = "/"
+		if s.Workspace == "" {
+			return // no-op: empty workspace cannot be used as virtual root
 		}
+		vroot := filepath.Clean(s.Workspace)
 		s.VirtualRoot = vroot
 		s.Cwd = vroot
 	} else {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -542,6 +542,17 @@ func IsRealPathUnder(path, root string) bool {
 	return path == root || strings.HasPrefix(path, root+sep)
 }
 
+// TrimRootPrefix removes root from the front of path, using case-insensitive
+// matching on Windows.  Returns the remaining suffix (which may start with "/").
+func TrimRootPrefix(path, root string) string {
+	if runtime.GOOS == "windows" && len(path) >= len(root) {
+		if strings.EqualFold(path[:len(root)], root) {
+			return path[len(root):]
+		}
+	}
+	return strings.TrimPrefix(path, root)
+}
+
 func (s *Session) Builtin(req types.ExecRequest) (handled bool, exitCode int, stdout, stderr []byte) {
 	switch req.Command {
 	case "cd":
@@ -797,7 +808,7 @@ func (s *Session) resolvePathForBuiltin(arg string) (virt string, real string, e
 		// resolveWorkingDir in exec.go where seccomp enforces policy.
 		return "", "", fmt.Errorf("path must be under %s", s.VirtualRoot)
 	}
-	rel := strings.TrimPrefix(virt, s.VirtualRoot)
+	rel := TrimRootPrefix(virt, s.VirtualRoot)
 	rel = strings.TrimPrefix(rel, "/")
 	root := s.WorkspaceMountPath()
 	real = filepath.Clean(filepath.Join(root, filepath.FromSlash(rel)))

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -507,8 +507,11 @@ func (s *Session) CloseNetNS() error {
 
 // IsUnderRoot checks if path is equal to or a child of root using
 // path-boundary-aware logic.  Handles root=="/" where root+"/" would be "//".
-// On Windows, comparisons are case-insensitive.
+// Returns false for empty root.  On Windows, comparisons are case-insensitive.
 func IsUnderRoot(path, root string) bool {
+	if root == "" {
+		return false
+	}
 	if root == "/" {
 		return strings.HasPrefix(path, "/")
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -726,6 +726,14 @@ func (s *Session) Builtin(req types.ExecRequest) (handled bool, exitCode int, st
 	}
 }
 
+// isVirtualPathAbs checks if a virtual path (using forward slashes) is absolute.
+// Handles both POSIX paths ("/foo") and Windows drive-letter paths ("C:/foo").
+// On Windows, filepath.IsAbs("/foo") returns false, but virtual paths always
+// use "/" as root, so we also check for a leading slash.
+func isVirtualPathAbs(p string) bool {
+	return strings.HasPrefix(p, "/") || filepath.IsAbs(p)
+}
+
 func (s *Session) ApplyPatch(patch types.SessionPatchRequest) error {
 	s.Touch()
 	s.mu.Lock()
@@ -734,7 +742,7 @@ func (s *Session) ApplyPatch(patch types.SessionPatchRequest) error {
 	if patch.Cwd != "" {
 		cwd := patch.Cwd
 		vroot := s.EffectiveVirtualRoot()
-		if !filepath.IsAbs(cwd) {
+		if !isVirtualPathAbs(cwd) {
 			cwd = filepath.ToSlash(filepath.Join(s.Cwd, cwd))
 		}
 		cwd = filepath.ToSlash(filepath.Clean(cwd))
@@ -775,7 +783,7 @@ func (s *Session) resolvePathForBuiltin(arg string) (virt string, real string, e
 	vroot := s.EffectiveVirtualRoot()
 	virt = cwd
 	if strings.TrimSpace(arg) != "" {
-		if filepath.IsAbs(arg) {
+		if isVirtualPathAbs(arg) {
 			virt = arg
 		} else {
 			virt = filepath.ToSlash(filepath.Join(cwd, arg))
@@ -799,13 +807,18 @@ func (s *Session) resolvePathForBuiltin(arg string) (virt string, real string, e
 	if !IsRealPathUnder(real, rootClean) {
 		return "", "", fmt.Errorf("path escapes workspace mount")
 	}
+	// Resolve root symlinks for consistent comparison (macOS /var -> /private/var)
+	rootResolved, rootErr := filepath.EvalSymlinks(rootClean)
+	if rootErr != nil {
+		rootResolved = rootClean
+	}
 	// Resolve symlinks to prevent escape via workspace symlinks.
 	// Builtins run in-process and bypass seccomp, so we must verify the
 	// resolved real path stays under the workspace root.
 	resolved, resolveErr := filepath.EvalSymlinks(real)
 	if resolveErr == nil {
 		resolved = filepath.Clean(resolved)
-		if !IsRealPathUnder(resolved, rootClean) {
+		if !IsRealPathUnder(resolved, rootResolved) {
 			return "", "", fmt.Errorf("symlink escape outside workspace root")
 		}
 		real = resolved

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -360,12 +360,14 @@ func (s *Session) WorkspaceMountPath() string {
 }
 
 // SetRealPaths switches the session to use real host paths instead of /workspace.
-func (s *Session) SetRealPaths(enabled bool) {
+// Returns false when enabled is true but the workspace is empty (real paths cannot
+// be applied).
+func (s *Session) SetRealPaths(enabled bool) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if enabled {
 		if s.Workspace == "" {
-			return // no-op: empty workspace cannot be used as virtual root
+			return false // empty workspace cannot be used as virtual root
 		}
 		vroot := filepath.ToSlash(filepath.Clean(s.Workspace))
 		s.VirtualRoot = vroot
@@ -374,6 +376,7 @@ func (s *Session) SetRealPaths(enabled bool) {
 		s.VirtualRoot = "/workspace"
 		s.Cwd = "/workspace"
 	}
+	return true
 }
 
 func (s *Session) SetWorkspaceUnmount(fn func() error) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -8,11 +8,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/agentsh/agentsh/internal/pathutil"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/google/uuid"
 )
@@ -506,60 +506,21 @@ func (s *Session) CloseNetNS() error {
 }
 
 // IsUnderRoot checks if path is equal to or a child of root using
-// path-boundary-aware logic.  Handles root=="/" where root+"/" would be "//".
-// Returns false for empty root.  On Windows, comparisons are case-insensitive.
+// path-boundary-aware logic. Delegates to pathutil.IsUnderRoot.
 func IsUnderRoot(path, root string) bool {
-	if root == "" {
-		return false
-	}
-	if root == "/" {
-		return strings.HasPrefix(path, "/")
-	}
-	if runtime.GOOS == "windows" {
-		lp, lr := strings.ToLower(path), strings.ToLower(root)
-		// Handle roots like "C:/" that already end with separator
-		if strings.HasSuffix(lr, "/") {
-			return strings.HasPrefix(lp, lr)
-		}
-		return lp == lr || strings.HasPrefix(lp, lr+"/")
-	}
-	return path == root || strings.HasPrefix(path, root+"/")
+	return pathutil.IsUnderRoot(path, root)
 }
 
 // IsRealPathUnder checks if a real filesystem path is equal to or under root,
-// using os.PathSeparator for boundary checks.  Handles root=="/" or volume
-// roots like "C:\" where root already ends with the separator.
-// Returns false for empty root.  On Windows, comparisons are case-insensitive.
+// using os.PathSeparator for boundary checks. Delegates to pathutil.IsRealPathUnder.
 func IsRealPathUnder(path, root string) bool {
-	if root == "" {
-		return false
-	}
-	sep := string(os.PathSeparator)
-	if root == "/" || root == sep {
-		return true
-	}
-	if runtime.GOOS == "windows" {
-		lp, lr := strings.ToLower(path), strings.ToLower(root)
-		if strings.HasSuffix(lr, sep) {
-			return strings.HasPrefix(lp, lr)
-		}
-		return lp == lr || strings.HasPrefix(lp, lr+sep)
-	}
-	if strings.HasSuffix(root, sep) {
-		return strings.HasPrefix(path, root)
-	}
-	return path == root || strings.HasPrefix(path, root+sep)
+	return pathutil.IsRealPathUnder(path, root)
 }
 
 // TrimRootPrefix removes root from the front of path, using case-insensitive
-// matching on Windows.  Returns the remaining suffix (which may start with "/").
+// matching on Windows. Delegates to pathutil.TrimRootPrefix.
 func TrimRootPrefix(path, root string) string {
-	if runtime.GOOS == "windows" && len(path) >= len(root) {
-		if strings.EqualFold(path[:len(root)], root) {
-			return path[len(root):]
-		}
-	}
-	return strings.TrimPrefix(path, root)
+	return pathutil.TrimRootPrefix(path, root)
 }
 
 func (s *Session) Builtin(req types.ExecRequest) (handled bool, exitCode int, stdout, stderr []byte) {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -346,16 +346,10 @@ func TestResolvePathForBuiltin_RealPaths_OutsideWorkspace(t *testing.T) {
 	}
 	s.SetRealPaths(true)
 
-	// Outside workspace path should pass through
-	virt, real, err := s.resolvePathForBuiltin("/etc/hosts")
-	if err != nil {
-		t.Fatalf("resolvePathForBuiltin: %v", err)
-	}
-	if virt != "/etc/hosts" {
-		t.Errorf("virt = %q, want /etc/hosts", virt)
-	}
-	if real != "/etc/hosts" {
-		t.Errorf("real = %q, want /etc/hosts", real)
+	// Outside workspace path should be rejected for builtins
+	_, _, err = s.resolvePathForBuiltin("/etc/hosts")
+	if err == nil {
+		t.Error("expected error for path outside workspace in builtins")
 	}
 }
 
@@ -369,17 +363,27 @@ func TestResolvePathForBuiltin_SiblingPath_NotConfused(t *testing.T) {
 	}
 	s.SetRealPaths(true)
 
-	// A sibling path like /tmp/TestXXX123-extra should NOT match
+	// A sibling path like /tmp/TestXXX123-extra should NOT match — rejected by builtins
 	sibling := ws + "-extra/file.txt"
-	virt, real, err := s.resolvePathForBuiltin(sibling)
+	_, _, err = s.resolvePathForBuiltin(sibling)
+	if err == nil {
+		t.Error("expected error for sibling path outside workspace")
+	}
+}
+
+func TestApplyPatch_RealPaths_SiblingPath(t *testing.T) {
+	m := NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-patch-sibling", ws, "default")
 	if err != nil {
-		t.Fatalf("resolvePathForBuiltin: %v", err)
+		t.Fatal(err)
 	}
-	// Should be treated as outside workspace (pass through)
-	if virt != sibling {
-		t.Errorf("virt = %q, want %q", virt, sibling)
-	}
-	if real != sibling {
-		t.Errorf("real = %q, want %q", real, sibling)
+	s.SetRealPaths(true)
+
+	// Sibling path should be rejected
+	err = s.ApplyPatch(types.SessionPatchRequest{Cwd: ws + "-extra"})
+	if err == nil {
+		t.Error("expected error patching cwd to sibling path")
 	}
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -168,3 +168,84 @@ func TestCreateWithProfile_InvalidSessionID(t *testing.T) {
 		t.Errorf("CreateWithProfile with invalid ID: got %v, want ErrInvalidSessionID", err)
 	}
 }
+
+func TestCreateWithID_DefaultVirtualRoot(t *testing.T) {
+	m := NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-default-vroot", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.VirtualRoot != "/workspace" {
+		t.Errorf("VirtualRoot = %q, want /workspace", s.VirtualRoot)
+	}
+	if s.Cwd != "/workspace" {
+		t.Errorf("Cwd = %q, want /workspace", s.Cwd)
+	}
+}
+
+func TestSetRealPaths_Enable(t *testing.T) {
+	m := NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-real-enable", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetRealPaths(true)
+	if s.VirtualRoot != ws {
+		t.Errorf("VirtualRoot = %q, want %q", s.VirtualRoot, ws)
+	}
+	if s.Cwd != ws {
+		t.Errorf("Cwd = %q, want %q", s.Cwd, ws)
+	}
+}
+
+func TestSetRealPaths_Disable(t *testing.T) {
+	m := NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-real-disable", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetRealPaths(true)
+	s.SetRealPaths(false)
+	if s.VirtualRoot != "/workspace" {
+		t.Errorf("VirtualRoot = %q, want /workspace", s.VirtualRoot)
+	}
+	if s.Cwd != "/workspace" {
+		t.Errorf("Cwd = %q, want /workspace", s.Cwd)
+	}
+}
+
+func TestCreateWithProfile_DefaultVirtualRoot(t *testing.T) {
+	m := NewManager(10)
+	mounts := []ResolvedMount{
+		{Path: "/tmp/test-project", Policy: "workspace-rw"},
+	}
+	s, err := m.CreateWithProfile("test-profile-vroot", "my-profile", "default", mounts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.VirtualRoot != "/workspace" {
+		t.Errorf("VirtualRoot = %q, want /workspace", s.VirtualRoot)
+	}
+}
+
+func TestSetRealPaths_TrailingSlash(t *testing.T) {
+	m := NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-trailing", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Manually set workspace with trailing slash to test normalization
+	s.Workspace = ws + "/"
+	s.SetRealPaths(true)
+	if s.VirtualRoot != ws {
+		t.Errorf("VirtualRoot = %q, want %q (no trailing slash)", s.VirtualRoot, ws)
+	}
+}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -265,7 +265,9 @@ func TestSetRealPaths_EmptyWorkspace(t *testing.T) {
 	}
 	// Manually set workspace to empty to test defensive behavior
 	s.Workspace = ""
-	s.SetRealPaths(true)
+	if s.SetRealPaths(true) {
+		t.Error("SetRealPaths(true) returned true on empty workspace, want false")
+	}
 	// Should be a no-op: VirtualRoot stays at default
 	if s.VirtualRoot != "/workspace" {
 		t.Errorf("VirtualRoot = %q, want /workspace (no-op on empty workspace)", s.VirtualRoot)

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -196,11 +197,12 @@ func TestSetRealPaths_Enable(t *testing.T) {
 		t.Fatal(err)
 	}
 	s.SetRealPaths(true)
-	if s.VirtualRoot != ws {
-		t.Errorf("VirtualRoot = %q, want %q", s.VirtualRoot, ws)
+	want := filepath.ToSlash(filepath.Clean(ws))
+	if s.VirtualRoot != want {
+		t.Errorf("VirtualRoot = %q, want %q", s.VirtualRoot, want)
 	}
-	if s.Cwd != ws {
-		t.Errorf("Cwd = %q, want %q", s.Cwd, ws)
+	if s.Cwd != want {
+		t.Errorf("Cwd = %q, want %q", s.Cwd, want)
 	}
 }
 
@@ -247,8 +249,9 @@ func TestSetRealPaths_TrailingSlash(t *testing.T) {
 	// Manually set workspace with trailing slash to test normalization
 	s.Workspace = ws + "/"
 	s.SetRealPaths(true)
-	if s.VirtualRoot != ws {
-		t.Errorf("VirtualRoot = %q, want %q (no trailing slash)", s.VirtualRoot, ws)
+	want := filepath.ToSlash(filepath.Clean(ws))
+	if s.VirtualRoot != want {
+		t.Errorf("VirtualRoot = %q, want %q (no trailing slash)", s.VirtualRoot, want)
 	}
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -411,9 +411,9 @@ func TestIsUnderRoot(t *testing.T) {
 		{"/home/user/worker", "/home/user/work", false},
 	}
 	for _, tt := range tests {
-		got := isUnderRoot(tt.path, tt.root)
+		got := IsUnderRoot(tt.path, tt.root)
 		if got != tt.want {
-			t.Errorf("isUnderRoot(%q, %q) = %v, want %v", tt.path, tt.root, got, tt.want)
+			t.Errorf("IsUnderRoot(%q, %q) = %v, want %v", tt.path, tt.root, got, tt.want)
 		}
 	}
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -3,6 +3,8 @@ package session
 import (
 	"testing"
 	"time"
+
+	"github.com/agentsh/agentsh/pkg/types"
 )
 
 func TestManager_ReapExpired_IdleTimeout(t *testing.T) {
@@ -247,5 +249,120 @@ func TestSetRealPaths_TrailingSlash(t *testing.T) {
 	s.SetRealPaths(true)
 	if s.VirtualRoot != ws {
 		t.Errorf("VirtualRoot = %q, want %q (no trailing slash)", s.VirtualRoot, ws)
+	}
+}
+
+func TestBuiltin_Cd_RealPaths(t *testing.T) {
+	m := NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-cd-real", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetRealPaths(true)
+
+	// cd with no args should go to VirtualRoot
+	handled, code, _, _ := s.Builtin(types.ExecRequest{Command: "cd"})
+	if !handled || code != 0 {
+		t.Fatalf("cd: handled=%v code=%d", handled, code)
+	}
+	cwd, _, _ := s.GetCwdEnvHistory()
+	if cwd != ws {
+		t.Errorf("after cd: Cwd = %q, want %q", cwd, ws)
+	}
+}
+
+func TestBuiltin_Cd_DefaultWorkspace(t *testing.T) {
+	m := NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-cd-default", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handled, code, _, _ := s.Builtin(types.ExecRequest{Command: "cd"})
+	if !handled || code != 0 {
+		t.Fatalf("cd: handled=%v code=%d", handled, code)
+	}
+	cwd, _, _ := s.GetCwdEnvHistory()
+	if cwd != "/workspace" {
+		t.Errorf("after cd: Cwd = %q, want /workspace", cwd)
+	}
+}
+
+func TestApplyPatch_RealPaths(t *testing.T) {
+	m := NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-patch-real", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetRealPaths(true)
+
+	// Patch cwd to subdir under workspace
+	err = s.ApplyPatch(types.SessionPatchRequest{Cwd: ws + "/subdir"})
+	if err != nil {
+		t.Fatalf("ApplyPatch: %v", err)
+	}
+	cwd, _, _ := s.GetCwdEnvHistory()
+	if cwd != ws+"/subdir" {
+		t.Errorf("Cwd = %q, want %q", cwd, ws+"/subdir")
+	}
+
+	// Patch cwd outside workspace should fail
+	err = s.ApplyPatch(types.SessionPatchRequest{Cwd: "/etc"})
+	if err == nil {
+		t.Error("expected error patching cwd outside workspace")
+	}
+}
+
+func TestResolvePathForBuiltin_RealPaths_OutsideWorkspace(t *testing.T) {
+	m := NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-resolve-outside", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetRealPaths(true)
+
+	// Outside workspace path should pass through
+	virt, real, err := s.resolvePathForBuiltin("/etc/hosts")
+	if err != nil {
+		t.Fatalf("resolvePathForBuiltin: %v", err)
+	}
+	if virt != "/etc/hosts" {
+		t.Errorf("virt = %q, want /etc/hosts", virt)
+	}
+	if real != "/etc/hosts" {
+		t.Errorf("real = %q, want /etc/hosts", real)
+	}
+}
+
+func TestResolvePathForBuiltin_SiblingPath_NotConfused(t *testing.T) {
+	m := NewManager(10)
+	ws := t.TempDir() // e.g., /tmp/TestXXX123
+
+	s, err := m.CreateWithID("test-sibling", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetRealPaths(true)
+
+	// A sibling path like /tmp/TestXXX123-extra should NOT match
+	sibling := ws + "-extra/file.txt"
+	virt, real, err := s.resolvePathForBuiltin(sibling)
+	if err != nil {
+		t.Fatalf("resolvePathForBuiltin: %v", err)
+	}
+	// Should be treated as outside workspace (pass through)
+	if virt != sibling {
+		t.Errorf("virt = %q, want %q", virt, sibling)
+	}
+	if real != sibling {
+		t.Errorf("real = %q, want %q", real, sibling)
 	}
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -414,6 +414,9 @@ func TestIsUnderRoot(t *testing.T) {
 		{"/home/user/work/src", "/home/user/work", true},
 		{"/home/user/work2", "/home/user/work", false},
 		{"/home/user/worker", "/home/user/work", false},
+		// Empty root must always return false
+		{"/anything", "", false},
+		{"", "", false},
 	}
 	for _, tt := range tests {
 		got := IsUnderRoot(tt.path, tt.root)

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -519,6 +519,9 @@ func TestIsRealPathUnder(t *testing.T) {
 		{"/etc", "/", true},
 		{"/tmp/foo", "/", true},
 		{"/", "/", true},
+		// Empty root must always return false
+		{"/anything", "", false},
+		{"", "", false},
 	}
 	for _, tt := range tests {
 		got := IsRealPathUnder(tt.path, tt.root)

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -293,8 +293,10 @@ func TestBuiltin_Cd_RealPaths(t *testing.T) {
 		t.Fatalf("cd: handled=%v code=%d", handled, code)
 	}
 	cwd, _, _ := s.GetCwdEnvHistory()
-	if cwd != ws {
-		t.Errorf("after cd: Cwd = %q, want %q", cwd, ws)
+	// VirtualRoot uses forward slashes; compare accordingly
+	want := filepath.ToSlash(filepath.Clean(ws))
+	if cwd != want {
+		t.Errorf("after cd: Cwd = %q, want %q", cwd, want)
 	}
 }
 
@@ -333,11 +335,13 @@ func TestApplyPatch_RealPaths(t *testing.T) {
 		t.Fatalf("ApplyPatch: %v", err)
 	}
 	cwd, _, _ := s.GetCwdEnvHistory()
-	if cwd != ws+"/subdir" {
-		t.Errorf("Cwd = %q, want %q", cwd, ws+"/subdir")
+	// VirtualRoot uses forward slashes; compare accordingly
+	wantCwd := filepath.ToSlash(filepath.Clean(ws)) + "/subdir"
+	if cwd != wantCwd {
+		t.Errorf("Cwd = %q, want %q", cwd, wantCwd)
 	}
 
-	// Patch cwd outside workspace should fail
+	// Patch cwd outside workspace should fail (use a virtual absolute path)
 	err = s.ApplyPatch(types.SessionPatchRequest{Cwd: "/etc"})
 	if err == nil {
 		t.Error("expected error patching cwd outside workspace")

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -1,7 +1,9 @@
 package session
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -502,6 +504,42 @@ func TestBuiltin_Cd_NoArgs_ResetsToVirtualRoot(t *testing.T) {
 	cwd, _, _ := s.GetCwdEnvHistory()
 	if cwd != s.VirtualRoot {
 		t.Errorf("after cd (no args): cwd=%q want %q", cwd, s.VirtualRoot)
+	}
+}
+
+func TestBuiltin_Acat_SymlinkEscape(t *testing.T) {
+	m := NewManager(10)
+	ws := t.TempDir()
+
+	// Create a symlink inside workspace pointing outside
+	target := t.TempDir()
+	secretFile := filepath.Join(target, "secret.txt")
+	if err := os.WriteFile(secretFile, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	linkPath := filepath.Join(ws, "escape")
+	if err := os.Symlink(target, linkPath); err != nil {
+		t.Skip("symlinks not supported")
+	}
+
+	s, err := m.CreateWithID("test-symlink-escape", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// acat through symlink should be rejected
+	handled, code, _, stderr := s.Builtin(types.ExecRequest{
+		Command: "acat",
+		Args:    []string{"/workspace/escape/secret.txt"},
+	})
+	if !handled {
+		t.Fatal("acat should be handled as builtin")
+	}
+	if code == 0 {
+		t.Errorf("acat through symlink escape should fail, but got code=0")
+	}
+	if !strings.Contains(string(stderr), "symlink escape") {
+		t.Logf("stderr: %s", stderr)
 	}
 }
 

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -387,3 +387,112 @@ func TestApplyPatch_RealPaths_SiblingPath(t *testing.T) {
 		t.Error("expected error patching cwd to sibling path")
 	}
 }
+
+func TestIsUnderRoot(t *testing.T) {
+	tests := []struct {
+		path string
+		root string
+		want bool
+	}{
+		{"/workspace", "/workspace", true},
+		{"/workspace/foo", "/workspace", true},
+		{"/workspace/foo/bar", "/workspace", true},
+		{"/workspace2", "/workspace", false},
+		{"/workspacefoo", "/workspace", false},
+		{"/other", "/workspace", false},
+		// Root == "/" edge case
+		{"/anything", "/", true},
+		{"/workspace", "/", true},
+		{"/", "/", true},
+		// Real-paths style roots
+		{"/home/user/work", "/home/user/work", true},
+		{"/home/user/work/src", "/home/user/work", true},
+		{"/home/user/work2", "/home/user/work", false},
+		{"/home/user/worker", "/home/user/work", false},
+	}
+	for _, tt := range tests {
+		got := isUnderRoot(tt.path, tt.root)
+		if got != tt.want {
+			t.Errorf("isUnderRoot(%q, %q) = %v, want %v", tt.path, tt.root, got, tt.want)
+		}
+	}
+}
+
+func TestBuiltin_Cd_RelativePath(t *testing.T) {
+	m := NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-cd-rel", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetRealPaths(true)
+
+	// cd to a subdirectory (relative)
+	handled, code, _, _ := s.Builtin(types.ExecRequest{Command: "cd", Args: []string{"subdir"}})
+	if !handled || code != 0 {
+		t.Fatalf("cd subdir: handled=%v code=%d", handled, code)
+	}
+	cwd, _, _ := s.GetCwdEnvHistory()
+	want := s.VirtualRoot + "/subdir"
+	if cwd != want {
+		t.Errorf("after cd subdir: cwd=%q want %q", cwd, want)
+	}
+
+	// cd to parent with .. — should resolve back to VirtualRoot
+	handled, code, _, _ = s.Builtin(types.ExecRequest{Command: "cd", Args: []string{".."}})
+	if !handled || code != 0 {
+		t.Fatalf("cd ..: handled=%v code=%d", handled, code)
+	}
+	cwd, _, _ = s.GetCwdEnvHistory()
+	if cwd != s.VirtualRoot {
+		t.Errorf("after cd ..: cwd=%q want %q", cwd, s.VirtualRoot)
+	}
+}
+
+func TestBuiltin_Cd_EscapeWithDotDot(t *testing.T) {
+	m := NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-cd-escape", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetRealPaths(true)
+
+	// Try to escape with ..
+	handled, code, _, stderr := s.Builtin(types.ExecRequest{Command: "cd", Args: []string{".."}})
+	if !handled {
+		t.Fatal("cd should be handled")
+	}
+	if code == 0 {
+		t.Error("cd .. from VirtualRoot should fail")
+	}
+	if len(stderr) == 0 {
+		t.Error("expected error message in stderr")
+	}
+}
+
+func TestBuiltin_Cd_NoArgs_ResetsToVirtualRoot(t *testing.T) {
+	m := NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-cd-noargs", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.SetRealPaths(true)
+
+	// First cd into a subdirectory
+	s.Builtin(types.ExecRequest{Command: "cd", Args: []string{"sub"}})
+
+	// cd with no args should reset to VirtualRoot
+	handled, code, _, _ := s.Builtin(types.ExecRequest{Command: "cd"})
+	if !handled || code != 0 {
+		t.Fatalf("cd (no args): handled=%v code=%d", handled, code)
+	}
+	cwd, _, _ := s.GetCwdEnvHistory()
+	if cwd != s.VirtualRoot {
+		t.Errorf("after cd (no args): cwd=%q want %q", cwd, s.VirtualRoot)
+	}
+}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -562,9 +563,34 @@ func TestIsRealPathUnder(t *testing.T) {
 		{"", "", false},
 	}
 	for _, tt := range tests {
-		got := IsRealPathUnder(tt.path, tt.root)
+		// Normalize to platform separators since IsRealPathUnder uses os.PathSeparator
+		path := filepath.FromSlash(tt.path)
+		root := filepath.FromSlash(tt.root)
+		got := IsRealPathUnder(path, root)
 		if got != tt.want {
-			t.Errorf("IsRealPathUnder(%q, %q) = %v, want %v", tt.path, tt.root, got, tt.want)
+			t.Errorf("IsRealPathUnder(%q, %q) = %v, want %v", path, root, got, tt.want)
+		}
+	}
+	// Windows-specific: drive-letter roots
+	if runtime.GOOS == "windows" {
+		winTests := []struct {
+			path string
+			root string
+			want bool
+		}{
+			{`C:\Users\project\sub`, `C:\Users\project`, true},
+			{`C:\Users\project`, `C:\Users\project`, true},
+			{`C:\Users\project2`, `C:\Users\project`, false},
+			{`c:\users\project\sub`, `C:\Users\project`, true}, // case-insensitive
+			{`D:\other`, `C:\Users\project`, false},
+			{`C:\`, `C:\`, true},      // volume root
+			{`C:\foo`, `C:\`, true},    // under volume root
+		}
+		for _, tt := range winTests {
+			got := IsRealPathUnder(tt.path, tt.root)
+			if got != tt.want {
+				t.Errorf("IsRealPathUnder(%q, %q) = %v, want %v", tt.path, tt.root, got, tt.want)
+			}
 		}
 	}
 }

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -252,6 +252,23 @@ func TestSetRealPaths_TrailingSlash(t *testing.T) {
 	}
 }
 
+func TestSetRealPaths_EmptyWorkspace(t *testing.T) {
+	m := NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-empty-ws", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Manually set workspace to empty to test defensive behavior
+	s.Workspace = ""
+	s.SetRealPaths(true)
+	// Should be a no-op: VirtualRoot stays at default
+	if s.VirtualRoot != "/workspace" {
+		t.Errorf("VirtualRoot = %q, want /workspace (no-op on empty workspace)", s.VirtualRoot)
+	}
+}
+
 func TestBuiltin_Cd_RealPaths(t *testing.T) {
 	m := NewManager(10)
 	ws := t.TempDir()

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -496,3 +496,26 @@ func TestBuiltin_Cd_NoArgs_ResetsToVirtualRoot(t *testing.T) {
 		t.Errorf("after cd (no args): cwd=%q want %q", cwd, s.VirtualRoot)
 	}
 }
+
+func TestIsRealPathUnder(t *testing.T) {
+	tests := []struct {
+		path string
+		root string
+		want bool
+	}{
+		{"/tmp/ws/sub", "/tmp/ws", true},
+		{"/tmp/ws", "/tmp/ws", true},
+		{"/tmp/ws2", "/tmp/ws", false},
+		{"/other", "/tmp/ws", false},
+		// Root == "/" — everything is under root
+		{"/etc", "/", true},
+		{"/tmp/foo", "/", true},
+		{"/", "/", true},
+	}
+	for _, tt := range tests {
+		got := IsRealPathUnder(tt.path, tt.root)
+		if got != tt.want {
+			t.Errorf("IsRealPathUnder(%q, %q) = %v, want %v", tt.path, tt.root, got, tt.want)
+		}
+	}
+}

--- a/pkg/types/sessions.go
+++ b/pkg/types/sessions.go
@@ -109,6 +109,7 @@ type CreateSessionRequest struct {
 	Profile           string `json:"profile,omitempty"`
 	DetectProjectRoot *bool  `json:"detect_project_root,omitempty"` // Override server default
 	ProjectRoot       string `json:"project_root,omitempty"`        // Explicit override
+	RealPaths         *bool  `json:"real_paths,omitempty"`          // Use actual host paths instead of /workspace
 }
 
 type SessionPatchRequest struct {

--- a/pkg/types/sessions.go
+++ b/pkg/types/sessions.go
@@ -49,6 +49,7 @@ type Session struct {
 	Profile     string       `json:"profile,omitempty"`
 	Mounts      []MountInfo  `json:"mounts,omitempty"`
 	Cwd         string       `json:"cwd"`
+	VirtualRoot string       `json:"virtual_root,omitempty"`
 	ProxyURL    string       `json:"proxy_url,omitempty"`
 	TOTPSecret  string       `json:"-"` // Hidden from JSON/API, used for TOTP approval mode
 	ProjectRoot string       `json:"project_root,omitempty"`


### PR DESCRIPTION
## Summary

- Add configurable `real_paths` mode (config/API/CLI/gRPC) that uses real host directory paths instead of virtualizing under `/workspace`
- Replace hardcoded `/workspace` assumptions with `VirtualRoot` field throughout session, exec, FUSE, guidance, and builtin handling
- Centralize path boundary helpers (`IsUnderRoot`, `IsRealPathUnder`, `TrimRootPrefix`) in shared `internal/pathutil` package with empty-root fail-closed guards, Windows case-insensitive support, and symlink escape prevention
- Harden `resolveWorkingDir` and `resolvePathForBuiltin` with `filepath.IsAbs`, `filepath.EvalSymlinks`, and `..` normalization to prevent path escape attacks

## Test plan
- [ ] `go test ./...` passes (all packages)
- [ ] `GOOS=windows go build ./...` cross-compiles cleanly
- [ ] Unit tests cover: tri-state `*bool` JSON decode, `SetRealPaths`, `IsUnderRoot`, `IsRealPathUnder`, `TrimRootPrefix`, `EffectiveVirtualRoot`, symlink escape in builtins, empty root guards, Windows drive-letter paths, `..` escape normalization
- [ ] Integration tests cover: HTTP exec with real_paths outside-workspace allowed, default mode outside-workspace rejected, real_paths in-workspace resolves to real path, guidance suppresses `move_to_workspace` in real-paths mode
- [ ] Roborev branch review passed with no findings (Job 943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)