### PR TITLE
feat: intercept legacy (non-at) file syscalls on amd64

### DIFF
--- a/internal/netmonitor/unix/file_syscalls.go
+++ b/internal/netmonitor/unix/file_syscalls.go
@@ -20,7 +20,7 @@ func isFileSyscall(nr int32) bool {
 		unix.SYS_FCHMODAT, unix.SYS_FCHOWNAT:
 		return true
 	default:
-		return false
+		return isLegacyFileSyscall(nr)
 	}
 }
 
@@ -126,7 +126,7 @@ func extractFileArgs(args SyscallArgs) FileArgs {
 		}
 
 	default:
-		return FileArgs{}
+		return extractLegacyFileArgs(args)
 	}
 }
 
@@ -185,7 +185,7 @@ func syscallToOperation(nr int32, flags uint32) string {
 	case unix.SYS_FCHOWNAT:
 		return "chown"
 	default:
-		return ""
+		return legacySyscallToOperation(nr, flags)
 	}
 }
 
@@ -211,7 +211,7 @@ func fileSyscallName(nr int32) string {
 	case unix.SYS_FCHOWNAT:
 		return "fchownat"
 	default:
-		return ""
+		return legacyFileSyscallName(nr)
 	}
 }
 

--- a/internal/netmonitor/unix/file_syscalls_legacy_amd64.go
+++ b/internal/netmonitor/unix/file_syscalls_legacy_amd64.go
@@ -1,0 +1,189 @@
+//go:build linux && cgo && amd64
+
+package unix
+
+import "golang.org/x/sys/unix"
+
+// legacyFileSyscallList returns the non-at legacy file syscalls present on x86_64.
+// On x86_64, glibc wrappers for mkdir(), rmdir(), etc. issue these directly
+// rather than the -at variants.
+func legacyFileSyscallList() []int32 {
+	return []int32{
+		unix.SYS_OPEN,
+		unix.SYS_CREAT,
+		unix.SYS_MKDIR,
+		unix.SYS_RMDIR,
+		unix.SYS_UNLINK,
+		unix.SYS_RENAME,
+		unix.SYS_LINK,
+		unix.SYS_SYMLINK,
+		unix.SYS_CHMOD,
+		unix.SYS_CHOWN,
+	}
+}
+
+// isLegacyFileSyscall returns true if nr is a legacy (non-at) file syscall.
+func isLegacyFileSyscall(nr int32) bool {
+	switch nr {
+	case unix.SYS_OPEN, unix.SYS_CREAT,
+		unix.SYS_MKDIR, unix.SYS_RMDIR, unix.SYS_UNLINK,
+		unix.SYS_RENAME, unix.SYS_LINK, unix.SYS_SYMLINK,
+		unix.SYS_CHMOD, unix.SYS_CHOWN:
+		return true
+	default:
+		return false
+	}
+}
+
+// extractLegacyFileArgs maps legacy (non-at) syscall arguments to FileArgs.
+// Legacy syscalls have no dirfd argument; AT_FDCWD is used instead.
+func extractLegacyFileArgs(args SyscallArgs) FileArgs {
+	switch args.Nr {
+	case unix.SYS_OPEN:
+		// open(path, flags, mode)
+		return FileArgs{
+			Dirfd:   int32(unix.AT_FDCWD),
+			PathPtr: args.Arg0,
+			Flags:   uint32(args.Arg1),
+			Mode:    uint32(args.Arg2),
+		}
+
+	case unix.SYS_CREAT:
+		// creat(path, mode)
+		return FileArgs{
+			Dirfd:   int32(unix.AT_FDCWD),
+			PathPtr: args.Arg0,
+			Mode:    uint32(args.Arg1),
+		}
+
+	case unix.SYS_MKDIR:
+		// mkdir(path, mode)
+		return FileArgs{
+			Dirfd:   int32(unix.AT_FDCWD),
+			PathPtr: args.Arg0,
+			Mode:    uint32(args.Arg1),
+		}
+
+	case unix.SYS_RMDIR:
+		// rmdir(path)
+		return FileArgs{
+			Dirfd:   int32(unix.AT_FDCWD),
+			PathPtr: args.Arg0,
+		}
+
+	case unix.SYS_UNLINK:
+		// unlink(path)
+		return FileArgs{
+			Dirfd:   int32(unix.AT_FDCWD),
+			PathPtr: args.Arg0,
+		}
+
+	case unix.SYS_RENAME:
+		// rename(oldpath, newpath)
+		return FileArgs{
+			Dirfd:         int32(unix.AT_FDCWD),
+			PathPtr:       args.Arg0,
+			HasSecondPath: true,
+			Dirfd2:        int32(unix.AT_FDCWD),
+			PathPtr2:      args.Arg1,
+		}
+
+	case unix.SYS_LINK:
+		// link(oldpath, newpath)
+		return FileArgs{
+			Dirfd:         int32(unix.AT_FDCWD),
+			PathPtr:       args.Arg0,
+			HasSecondPath: true,
+			Dirfd2:        int32(unix.AT_FDCWD),
+			PathPtr2:      args.Arg1,
+		}
+
+	case unix.SYS_SYMLINK:
+		// symlink(target, linkpath)
+		// Primary path is the linkpath (where the symlink is created).
+		return FileArgs{
+			Dirfd:   int32(unix.AT_FDCWD),
+			PathPtr: args.Arg1, // linkpath
+		}
+
+	case unix.SYS_CHMOD:
+		// chmod(path, mode)
+		return FileArgs{
+			Dirfd:   int32(unix.AT_FDCWD),
+			PathPtr: args.Arg0,
+			Mode:    uint32(args.Arg1),
+		}
+
+	case unix.SYS_CHOWN:
+		// chown(path, owner, group)
+		return FileArgs{
+			Dirfd:   int32(unix.AT_FDCWD),
+			PathPtr: args.Arg0,
+		}
+
+	default:
+		return FileArgs{}
+	}
+}
+
+// legacySyscallToOperation maps a legacy file syscall to a policy operation string.
+func legacySyscallToOperation(nr int32, flags uint32) string {
+	switch nr {
+	case unix.SYS_OPEN:
+		if flags&unix.O_CREAT != 0 || flags&unix.O_TMPFILE == unix.O_TMPFILE {
+			return "create"
+		}
+		if flags&(unix.O_WRONLY|unix.O_RDWR|unix.O_APPEND|unix.O_TRUNC) != 0 {
+			return "write"
+		}
+		return "open"
+	case unix.SYS_CREAT:
+		return "create"
+	case unix.SYS_MKDIR:
+		return "mkdir"
+	case unix.SYS_RMDIR:
+		return "rmdir"
+	case unix.SYS_UNLINK:
+		return "delete"
+	case unix.SYS_RENAME:
+		return "rename"
+	case unix.SYS_LINK:
+		return "link"
+	case unix.SYS_SYMLINK:
+		return "symlink"
+	case unix.SYS_CHMOD:
+		return "chmod"
+	case unix.SYS_CHOWN:
+		return "chown"
+	default:
+		return ""
+	}
+}
+
+// legacyFileSyscallName returns the human-readable name for a legacy file syscall.
+func legacyFileSyscallName(nr int32) string {
+	switch nr {
+	case unix.SYS_OPEN:
+		return "open"
+	case unix.SYS_CREAT:
+		return "creat"
+	case unix.SYS_MKDIR:
+		return "mkdir"
+	case unix.SYS_RMDIR:
+		return "rmdir"
+	case unix.SYS_UNLINK:
+		return "unlink"
+	case unix.SYS_RENAME:
+		return "rename"
+	case unix.SYS_LINK:
+		return "link"
+	case unix.SYS_SYMLINK:
+		return "symlink"
+	case unix.SYS_CHMOD:
+		return "chmod"
+	case unix.SYS_CHOWN:
+		return "chown"
+	default:
+		return ""
+	}
+}

--- a/internal/netmonitor/unix/file_syscalls_legacy_other.go
+++ b/internal/netmonitor/unix/file_syscalls_legacy_other.go
@@ -1,0 +1,19 @@
+//go:build linux && cgo && !amd64
+
+package unix
+
+// legacyFileSyscallList returns nil on non-amd64 architectures.
+// ARM64 and others only have the -at variants.
+func legacyFileSyscallList() []int32 { return nil }
+
+// isLegacyFileSyscall returns false on non-amd64 architectures.
+func isLegacyFileSyscall(nr int32) bool { return false }
+
+// extractLegacyFileArgs returns empty FileArgs on non-amd64 architectures.
+func extractLegacyFileArgs(args SyscallArgs) FileArgs { return FileArgs{} }
+
+// legacySyscallToOperation returns empty string on non-amd64 architectures.
+func legacySyscallToOperation(nr int32, flags uint32) string { return "" }
+
+// legacyFileSyscallName returns empty string on non-amd64 architectures.
+func legacyFileSyscallName(nr int32) string { return "" }

--- a/internal/netmonitor/unix/file_syscalls_legacy_test.go
+++ b/internal/netmonitor/unix/file_syscalls_legacy_test.go
@@ -1,0 +1,238 @@
+//go:build linux && cgo && amd64
+
+package unix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+)
+
+func TestIsLegacyFileSyscall(t *testing.T) {
+	legacySyscalls := []int32{
+		unix.SYS_OPEN,
+		unix.SYS_CREAT,
+		unix.SYS_MKDIR,
+		unix.SYS_RMDIR,
+		unix.SYS_UNLINK,
+		unix.SYS_RENAME,
+		unix.SYS_LINK,
+		unix.SYS_SYMLINK,
+		unix.SYS_CHMOD,
+		unix.SYS_CHOWN,
+	}
+
+	for _, nr := range legacySyscalls {
+		assert.True(t, isLegacyFileSyscall(nr), "expected true for syscall %d", nr)
+		// Also verify the main dispatcher recognizes them
+		assert.True(t, isFileSyscall(nr), "expected isFileSyscall true for legacy syscall %d", nr)
+	}
+
+	// Non-file syscalls should still return false
+	assert.False(t, isLegacyFileSyscall(unix.SYS_READ))
+	assert.False(t, isLegacyFileSyscall(unix.SYS_WRITE))
+}
+
+func TestLegacySyscallToOperation(t *testing.T) {
+	tests := []struct {
+		name     string
+		nr       int32
+		flags    uint32
+		expected string
+	}{
+		{"open read-only", unix.SYS_OPEN, 0, "open"},
+		{"open O_CREAT", unix.SYS_OPEN, unix.O_CREAT, "create"},
+		{"open O_WRONLY", unix.SYS_OPEN, unix.O_WRONLY, "write"},
+		{"open O_RDWR", unix.SYS_OPEN, unix.O_RDWR, "write"},
+		{"open O_APPEND", unix.SYS_OPEN, unix.O_APPEND, "write"},
+		{"open O_TRUNC", unix.SYS_OPEN, unix.O_TRUNC, "write"},
+		{"creat", unix.SYS_CREAT, 0, "create"},
+		{"mkdir", unix.SYS_MKDIR, 0, "mkdir"},
+		{"rmdir", unix.SYS_RMDIR, 0, "rmdir"},
+		{"unlink", unix.SYS_UNLINK, 0, "delete"},
+		{"rename", unix.SYS_RENAME, 0, "rename"},
+		{"link", unix.SYS_LINK, 0, "link"},
+		{"symlink", unix.SYS_SYMLINK, 0, "symlink"},
+		{"chmod", unix.SYS_CHMOD, 0, "chmod"},
+		{"chown", unix.SYS_CHOWN, 0, "chown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test direct legacy function
+			assert.Equal(t, tt.expected, legacySyscallToOperation(tt.nr, tt.flags))
+			// Test through main dispatcher
+			assert.Equal(t, tt.expected, syscallToOperation(tt.nr, tt.flags))
+		})
+	}
+}
+
+func TestLegacyFileSyscallName(t *testing.T) {
+	tests := []struct {
+		nr       int32
+		expected string
+	}{
+		{unix.SYS_OPEN, "open"},
+		{unix.SYS_CREAT, "creat"},
+		{unix.SYS_MKDIR, "mkdir"},
+		{unix.SYS_RMDIR, "rmdir"},
+		{unix.SYS_UNLINK, "unlink"},
+		{unix.SYS_RENAME, "rename"},
+		{unix.SYS_LINK, "link"},
+		{unix.SYS_SYMLINK, "symlink"},
+		{unix.SYS_CHMOD, "chmod"},
+		{unix.SYS_CHOWN, "chown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, legacyFileSyscallName(tt.nr))
+			assert.Equal(t, tt.expected, fileSyscallName(tt.nr))
+		})
+	}
+}
+
+func TestExtractLegacyFileArgs_Open(t *testing.T) {
+	args := SyscallArgs{
+		Nr:   unix.SYS_OPEN,
+		Arg0: 0x7fff1000,            // path
+		Arg1: uint64(unix.O_RDONLY), // flags
+		Arg2: 0644,                  // mode
+	}
+
+	fa := extractFileArgs(args)
+	assert.Equal(t, int32(unix.AT_FDCWD), fa.Dirfd)
+	assert.Equal(t, uint64(0x7fff1000), fa.PathPtr)
+	assert.Equal(t, uint32(unix.O_RDONLY), fa.Flags)
+	assert.Equal(t, uint32(0644), fa.Mode)
+	assert.False(t, fa.HasSecondPath)
+}
+
+func TestExtractLegacyFileArgs_Creat(t *testing.T) {
+	args := SyscallArgs{
+		Nr:   unix.SYS_CREAT,
+		Arg0: 0x7fff2000, // path
+		Arg1: 0644,       // mode
+	}
+
+	fa := extractFileArgs(args)
+	assert.Equal(t, int32(unix.AT_FDCWD), fa.Dirfd)
+	assert.Equal(t, uint64(0x7fff2000), fa.PathPtr)
+	assert.Equal(t, uint32(0644), fa.Mode)
+}
+
+func TestExtractLegacyFileArgs_Mkdir(t *testing.T) {
+	args := SyscallArgs{
+		Nr:   unix.SYS_MKDIR,
+		Arg0: 0x7fff3000, // path
+		Arg1: 0755,       // mode
+	}
+
+	fa := extractFileArgs(args)
+	assert.Equal(t, int32(unix.AT_FDCWD), fa.Dirfd)
+	assert.Equal(t, uint64(0x7fff3000), fa.PathPtr)
+	assert.Equal(t, uint32(0755), fa.Mode)
+}
+
+func TestExtractLegacyFileArgs_Rmdir(t *testing.T) {
+	args := SyscallArgs{
+		Nr:   unix.SYS_RMDIR,
+		Arg0: 0x7fff4000, // path
+	}
+
+	fa := extractFileArgs(args)
+	assert.Equal(t, int32(unix.AT_FDCWD), fa.Dirfd)
+	assert.Equal(t, uint64(0x7fff4000), fa.PathPtr)
+}
+
+func TestExtractLegacyFileArgs_Unlink(t *testing.T) {
+	args := SyscallArgs{
+		Nr:   unix.SYS_UNLINK,
+		Arg0: 0x7fff5000, // path
+	}
+
+	fa := extractFileArgs(args)
+	assert.Equal(t, int32(unix.AT_FDCWD), fa.Dirfd)
+	assert.Equal(t, uint64(0x7fff5000), fa.PathPtr)
+}
+
+func TestExtractLegacyFileArgs_Rename(t *testing.T) {
+	args := SyscallArgs{
+		Nr:   unix.SYS_RENAME,
+		Arg0: 0x7fff6000, // oldpath
+		Arg1: 0x7fff7000, // newpath
+	}
+
+	fa := extractFileArgs(args)
+	assert.Equal(t, int32(unix.AT_FDCWD), fa.Dirfd)
+	assert.Equal(t, uint64(0x7fff6000), fa.PathPtr)
+	assert.True(t, fa.HasSecondPath)
+	assert.Equal(t, int32(unix.AT_FDCWD), fa.Dirfd2)
+	assert.Equal(t, uint64(0x7fff7000), fa.PathPtr2)
+}
+
+func TestExtractLegacyFileArgs_Link(t *testing.T) {
+	args := SyscallArgs{
+		Nr:   unix.SYS_LINK,
+		Arg0: 0x7fff8000, // oldpath
+		Arg1: 0x7fff9000, // newpath
+	}
+
+	fa := extractFileArgs(args)
+	assert.Equal(t, int32(unix.AT_FDCWD), fa.Dirfd)
+	assert.Equal(t, uint64(0x7fff8000), fa.PathPtr)
+	assert.True(t, fa.HasSecondPath)
+	assert.Equal(t, int32(unix.AT_FDCWD), fa.Dirfd2)
+	assert.Equal(t, uint64(0x7fff9000), fa.PathPtr2)
+}
+
+func TestExtractLegacyFileArgs_Symlink(t *testing.T) {
+	// symlink(target, linkpath) — primary path is linkpath (Arg1)
+	args := SyscallArgs{
+		Nr:   unix.SYS_SYMLINK,
+		Arg0: 0x7fffA000, // target
+		Arg1: 0x7fffB000, // linkpath
+	}
+
+	fa := extractFileArgs(args)
+	assert.Equal(t, int32(unix.AT_FDCWD), fa.Dirfd)
+	assert.Equal(t, uint64(0x7fffB000), fa.PathPtr) // linkpath is primary
+	assert.False(t, fa.HasSecondPath)
+}
+
+func TestExtractLegacyFileArgs_Chmod(t *testing.T) {
+	args := SyscallArgs{
+		Nr:   unix.SYS_CHMOD,
+		Arg0: 0x7fffC000, // path
+		Arg1: 0755,       // mode
+	}
+
+	fa := extractFileArgs(args)
+	assert.Equal(t, int32(unix.AT_FDCWD), fa.Dirfd)
+	assert.Equal(t, uint64(0x7fffC000), fa.PathPtr)
+	assert.Equal(t, uint32(0755), fa.Mode)
+}
+
+func TestExtractLegacyFileArgs_Chown(t *testing.T) {
+	args := SyscallArgs{
+		Nr:   unix.SYS_CHOWN,
+		Arg0: 0x7fffD000, // path
+		Arg1: 1000,       // owner
+		Arg2: 1000,       // group
+	}
+
+	fa := extractFileArgs(args)
+	assert.Equal(t, int32(unix.AT_FDCWD), fa.Dirfd)
+	assert.Equal(t, uint64(0x7fffD000), fa.PathPtr)
+}
+
+func TestLegacyFileSyscallList(t *testing.T) {
+	list := legacyFileSyscallList()
+	assert.Len(t, list, 10)
+	// Verify all listed syscalls are recognized
+	for _, nr := range list {
+		assert.True(t, isLegacyFileSyscall(nr), "syscall %d from list not recognized", nr)
+		assert.True(t, isFileSyscall(nr), "syscall %d from list not recognized by isFileSyscall", nr)
+	}
+}

--- a/internal/netmonitor/unix/seccomp_linux.go
+++ b/internal/netmonitor/unix/seccomp_linux.go
@@ -247,6 +247,11 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 				return nil, fmt.Errorf("add file monitor rule %v: %w", sc, err)
 			}
 		}
+		for _, sc := range legacyFileSyscallList() {
+			if err := filt.AddRule(seccomp.ScmpSyscall(sc), trap); err != nil {
+				return nil, fmt.Errorf("add legacy file rule %v: %w", sc, err)
+			}
+		}
 	}
 
 	// Blocked syscalls via kill


### PR DESCRIPTION
## Summary
- On x86_64, glibc wrappers for `mkdir()`, `rmdir()`, `unlink()`, etc. issue legacy syscalls (e.g., `SYS_MKDIR`) rather than the `-at` variants (`SYS_MKDIRAT`), bypassing the seccomp file monitor
- Add amd64-specific handlers for `open`, `creat`, `mkdir`, `rmdir`, `unlink`, `rename`, `link`, `symlink`, `chmod`, and `chown`
- Non-amd64 architectures (ARM64 etc.) get no-op stubs since they only have `-at` variants

## Test plan
- [ ] `go test ./internal/netmonitor/unix/ -run Legacy -v` passes
- [ ] `go build ./...` succeeds
- [ ] `GOOS=windows go build ./...` cross-compiles cleanly
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)