### PR TITLE
feat: ptrace Phase 4a — syscall injection and steering engine

### DIFF
--- a/Dockerfile.ptrace-test
+++ b/Dockerfile.ptrace-test
@@ -1,4 +1,5 @@
 FROM golang:1.25
+RUN apt-get update && apt-get install -y netcat-openbsd && rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/docs/plans/2026-03-12-ptrace-phase4a-design.md
+++ b/docs/plans/2026-03-12-ptrace-phase4a-design.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-03-12
 **Author:** Eran / Canyon Road
-**Status:** Design Complete
+**Status:** Implemented (2026-03-13)
 
 ---
 
@@ -201,3 +201,62 @@ All runnable via `docker run --cap-add SYS_PTRACE`.
 - Fargate E2E tests (Phase 4c)
 - EKS Fargate support (Phase 4c)
 - Multi-thread tracer scaling (future, only if measurements show bottleneck)
+
+## 11. Implementation Notes (2026-03-13)
+
+Key design refinements discovered during implementation:
+
+### Injection engine
+
+- **Dual-mode injection**: `injectSyscall` auto-selects between single-phase
+  (from entry stop, hijacks ORIG_RAX) and two-phase (from exit, uses gadget)
+  based on `state.InSyscall`. Callers don't need to know the stop state.
+- **waitForSyscallStop**: Uses WNOHANG|WALL polling with 5s deadline (not
+  blocking Wait4). Handles PTRACE_EVENT_SECCOMP as a syscall-entry-equivalent
+  stop. Only counts actual stop events toward the 100-event guard, not empty
+  polls.
+- **TRACESYSGOOD vs prefilter**: Plain SIGTRAP is a syscall stop only in
+  prefilter mode (no TRACESYSGOOD). In TRACESYSGOOD mode, plain SIGTRAP is
+  a real ptrace event signal. `traceSysGood()` method gates the check.
+
+### Exec redirect
+
+- **FD displacement protection**: `injectFDIntoTracee` checks if fd 100 is
+  already open via `fcntl(F_GETFD)` and saves it with `F_DUPFD_CLOEXEC`
+  (CLOEXEC ensures the saved copy auto-closes on successful exec, preventing
+  fd leaks into the stub). `cleanupInjectedFD` restores on failure.
+- **arm64 arg0 clobber**: `SetReturnValue` writes x0 (which is also arg0 on
+  arm64). The filename pointer must be saved before `SetReturnValue` and
+  restored afterward for the non-execveat case.
+- **In-place write fallback**: Tries overwriting the original filename buffer
+  first. On failure (e.g., read-only mapping), falls back to scratch page.
+- **execveat normalization**: Always converts to SYS_EXECVE with the stub
+  path, avoiding AT_EMPTY_PATH and non-AT_FDCWD edge cases.
+- **PendingExecStubFD/PendingExecSavedFD**: TraceeState fields for tracking
+  injected stub fd across the exec boundary. Cleaned up on exec failure in
+  `handleSyscallStop`, cleared on exec success in `handleExecEvent`.
+
+### File redirect and soft-delete
+
+- **advancePastEntry**: Both `redirectFile` and `softDeleteFile` advance past
+  the original entry (nullify ORIG_RAX, PtraceSyscall to EXIT, restore regs)
+  before doing helper injections. This ensures all injections use the
+  two-phase gadget protocol from EXIT state.
+- **Legacy syscall support**: amd64 has legacy SYS_OPEN, SYS_UNLINK, etc.
+  `filePathArgIndex` delegates to arch-specific `legacyFilePathArgIndex` for
+  unknown syscalls. `softDeleteFile` accepts `isLegacyUnlink(nr)`.
+
+### Connect redirect
+
+- **In-place sockaddr overwrite**: IPv4 sockaddr is 16 bytes, IPv6 is 28
+  bytes — both fixed-size, always fit in the original buffer. No scratch
+  page needed.
+
+### Error recovery
+
+- **resumeWithErrno**: Sets RAX=-errno and calls `allowSyscall` from EXIT
+  state. All redirect functions use this for error recovery after
+  `advancePastEntry`.
+- **hasPendingSyscallExit**: Routes plain SIGTRAP to `handleSyscallStop` in
+  prefilter mode. Includes `PendingExecStubFD >= 0` to ensure failed execs
+  get cleanup routed correctly.

--- a/docs/plans/2026-03-12-ptrace-phase4a-plan.md
+++ b/docs/plans/2026-03-12-ptrace-phase4a-plan.md
@@ -1,0 +1,1908 @@
+# Ptrace Phase 4a: Core Steering Engine — Implementation Plan
+
+> **Status:** Complete (2026-03-13). All 14 tasks implemented, tested, and verified on amd64/arm64/windows.
+
+**Goal:** Add syscall-level redirect/steering to the ptrace backend (exec redirect, file path redirect, soft-delete, connect redirect) via a syscall injection engine.
+
+**Architecture:** A `injectSyscall()` primitive executes arbitrary syscalls inside stopped tracees by saving registers, rewriting IP to a `syscall` gadget, doing two-phase PtraceSyscall, and restoring state. Scratch pages (mmap'd into the tracee) provide memory for longer path rewrites. Each handler gains a `Redirect`/`SoftDelete` action path alongside Allow/Deny.
+
+**Tech Stack:** Go, linux/ptrace, x/sys/unix, amd64+arm64 register ABIs
+
+---
+
+### Task 1: Extend Regs Interface and Arch Implementations
+
+Add `Clone()` and `SetInstructionPointer()` to the `Regs` interface and both arch implementations.
+
+**Files:**
+- Modify: `internal/ptrace/args.go:5-14`
+- Modify: `internal/ptrace/args_amd64.go:7-62`
+- Modify: `internal/ptrace/args_arm64.go:7-39`
+- Test: `internal/ptrace/args_test.go` (new)
+
+**Step 1: Write the failing test**
+
+Create `internal/ptrace/args_test.go` with build tag `//go:build linux`:
+
+```go
+//go:build linux
+
+package ptrace
+
+import (
+	"testing"
+)
+
+func TestRegsClone(t *testing.T) {
+	regs, err := getRegsArch(0) // Will fail — we just need the type
+	_ = err
+	_ = regs
+
+	// Verify Clone exists on the interface by calling it on a zero-value struct.
+	// We can't ptrace ourselves, so test with a constructed value.
+	r := createTestRegs()
+	r.SetSyscallNr(42)
+	r.SetArg(0, 0xDEAD)
+	r.SetReturnValue(99)
+
+	cloned := r.Clone()
+
+	if cloned.SyscallNr() != 42 {
+		t.Errorf("Clone SyscallNr: got %d, want 42", cloned.SyscallNr())
+	}
+	if cloned.Arg(0) != 0xDEAD {
+		t.Errorf("Clone Arg(0): got %d, want 0xDEAD", cloned.Arg(0))
+	}
+
+	// Mutating clone must not affect original
+	cloned.SetSyscallNr(99)
+	if r.SyscallNr() != 42 {
+		t.Errorf("Clone mutation leaked: original SyscallNr changed to %d", r.SyscallNr())
+	}
+}
+
+func TestRegsSetInstructionPointer(t *testing.T) {
+	r := createTestRegs()
+	r.SetInstructionPointer(0xCAFE)
+	if r.InstructionPointer() != 0xCAFE {
+		t.Errorf("SetInstructionPointer: got 0x%X, want 0xCAFE", r.InstructionPointer())
+	}
+}
+```
+
+Also create an arch-specific test helper. For amd64, `internal/ptrace/args_test_amd64.go`:
+
+```go
+//go:build linux && amd64
+
+package ptrace
+
+func createTestRegs() Regs {
+	return &amd64Regs{}
+}
+```
+
+For arm64, `internal/ptrace/args_test_arm64.go`:
+
+```go
+//go:build linux && arm64
+
+package ptrace
+
+func createTestRegs() Regs {
+	return &arm64Regs{}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test -run TestRegsClone ./internal/ptrace/ -count=1`
+Expected: FAIL — `Clone` and `SetInstructionPointer` not found on `Regs` interface
+
+**Step 3: Implement — extend interface and both arch files**
+
+In `internal/ptrace/args.go`, add to the `Regs` interface:
+
+```go
+type Regs interface {
+	SyscallNr() int
+	SetSyscallNr(nr int)
+	Arg(n int) uint64
+	SetArg(n int, val uint64)
+	ReturnValue() int64
+	SetReturnValue(val int64)
+	InstructionPointer() uint64
+	SetInstructionPointer(addr uint64)
+	Clone() Regs
+}
+```
+
+In `internal/ptrace/args_amd64.go`, add:
+
+```go
+func (r *amd64Regs) SetInstructionPointer(addr uint64) { r.raw.Rip = addr }
+
+func (r *amd64Regs) Clone() Regs {
+	cp := *r
+	return &cp
+}
+```
+
+In `internal/ptrace/args_arm64.go`, add:
+
+```go
+func (r *arm64Regs) SetInstructionPointer(addr uint64) { r.raw.Pc = addr }
+
+func (r *arm64Regs) Clone() Regs {
+	cp := *r
+	return &cp
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test -run 'TestRegs(Clone|SetInstructionPointer)' ./internal/ptrace/ -count=1`
+Expected: PASS
+
+**Step 5: Verify cross-compilation**
+
+Run: `GOOS=windows go build ./...`
+Expected: Success (build tags exclude test files and linux-only code)
+
+**Step 6: Commit**
+
+```bash
+git add internal/ptrace/args.go internal/ptrace/args_amd64.go internal/ptrace/args_arm64.go internal/ptrace/args_test.go internal/ptrace/args_test_amd64.go internal/ptrace/args_test_arm64.go
+git commit -m "feat(ptrace): add Clone and SetInstructionPointer to Regs interface"
+```
+
+---
+
+### Task 2: Add writeString Helper to Memory
+
+Add a `writeString` method that writes a NUL-terminated string to tracee memory.
+
+**Files:**
+- Modify: `internal/ptrace/memory.go:85-99`
+
+**Step 1: Implement writeString**
+
+Add after the existing `writeBytes` method in `internal/ptrace/memory.go`:
+
+```go
+// writeString writes a NUL-terminated string to the tracee's memory.
+func (t *Tracer) writeString(tid int, addr uint64, s string) error {
+	buf := make([]byte, len(s)+1) // +1 for NUL terminator
+	copy(buf, s)
+	// buf[len(s)] is already 0 from make
+	return t.writeBytes(tid, addr, buf)
+}
+```
+
+**Step 2: Verify it compiles**
+
+Run: `go build ./internal/ptrace/`
+Expected: Success
+
+**Step 3: Commit**
+
+```bash
+git add internal/ptrace/memory.go
+git commit -m "feat(ptrace): add writeString helper for NUL-terminated memory writes"
+```
+
+---
+
+### Task 3: Syscall Injection Engine
+
+Create the core `injectSyscall` function that executes an arbitrary syscall inside a stopped tracee.
+
+**Files:**
+- Create: `internal/ptrace/inject.go`
+- Create: `internal/ptrace/inject_amd64.go`
+- Create: `internal/ptrace/inject_arm64.go`
+
+**Step 1: Create arch-specific gadget helpers**
+
+`internal/ptrace/inject_amd64.go`:
+
+```go
+//go:build linux && amd64
+
+package ptrace
+
+// syscallGadgetAddr returns the address of a `syscall` instruction in the
+// tracee's address space. When stopped at a syscall-enter or PTRACE_EVENT_SECCOMP,
+// the instruction pointer points right after the 2-byte `syscall` instruction.
+func syscallGadgetAddr(regs Regs) uint64 {
+	return regs.InstructionPointer() - 2
+}
+
+// syscallInsnSize is the size of the syscall instruction on this architecture.
+const syscallInsnSize = 2
+```
+
+`internal/ptrace/inject_arm64.go`:
+
+```go
+//go:build linux && arm64
+
+package ptrace
+
+// syscallGadgetAddr returns the address of an `svc #0` instruction in the
+// tracee's address space. When stopped at a syscall-enter, the instruction
+// pointer points right after the 4-byte `svc #0` instruction.
+func syscallGadgetAddr(regs Regs) uint64 {
+	return regs.InstructionPointer() - 4
+}
+
+// syscallInsnSize is the size of the syscall instruction on this architecture.
+const syscallInsnSize = 4
+```
+
+**Step 2: Create the injection engine**
+
+`internal/ptrace/inject.go`:
+
+```go
+//go:build linux
+
+package ptrace
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// injectSyscall executes an arbitrary syscall inside a stopped tracee.
+//
+// The tracee MUST be stopped at a syscall-enter or PTRACE_EVENT_SECCOMP stop
+// so that the instruction pointer can be used to locate a syscall gadget.
+//
+// Sequence:
+//  1. Save current registers
+//  2. Set up injected syscall (nr + up to 6 args)
+//  3. Set IP to the syscall instruction gadget
+//  4. Resume with PtraceSyscall → wait for syscall-enter stop
+//  5. Resume with PtraceSyscall → wait for syscall-exit stop
+//  6. Read return value
+//  7. Restore original registers
+//
+// Returns the syscall return value, or an error if any ptrace operation fails.
+func (t *Tracer) injectSyscall(tid int, savedRegs Regs, nr int, args ...uint64) (int64, error) {
+	gadget := syscallGadgetAddr(savedRegs)
+
+	// Build injection registers from a clone of saved state.
+	injRegs := savedRegs.Clone()
+	injRegs.SetSyscallNr(nr)
+	for i, v := range args {
+		if i > 5 {
+			break
+		}
+		injRegs.SetArg(i, v)
+	}
+	injRegs.SetInstructionPointer(gadget)
+
+	if err := t.setRegs(tid, injRegs); err != nil {
+		return 0, fmt.Errorf("inject setRegs: %w", err)
+	}
+
+	// Phase 1: resume → wait for syscall-enter stop.
+	if err := unix.PtraceSyscall(tid, 0); err != nil {
+		return 0, fmt.Errorf("inject resume-enter: %w", err)
+	}
+	if err := t.waitForSyscallStop(tid); err != nil {
+		return 0, fmt.Errorf("inject wait-enter: %w", err)
+	}
+
+	// Phase 2: resume → wait for syscall-exit stop.
+	if err := unix.PtraceSyscall(tid, 0); err != nil {
+		return 0, fmt.Errorf("inject resume-exit: %w", err)
+	}
+	if err := t.waitForSyscallStop(tid); err != nil {
+		return 0, fmt.Errorf("inject wait-exit: %w", err)
+	}
+
+	// Read return value.
+	retRegs, err := t.getRegs(tid)
+	if err != nil {
+		return 0, fmt.Errorf("inject getRegs: %w", err)
+	}
+	ret := retRegs.ReturnValue()
+
+	// Restore original registers.
+	if err := t.setRegs(tid, savedRegs); err != nil {
+		return 0, fmt.Errorf("inject restore: %w", err)
+	}
+
+	return ret, nil
+}
+
+// waitForSyscallStop waits for the specified tid to hit a syscall stop.
+// It uses waitpid with the specific tid to avoid consuming other tracees' events.
+func (t *Tracer) waitForSyscallStop(tid int) error {
+	for {
+		var status unix.WaitStatus
+		_, err := unix.Wait4(tid, &status, 0, nil)
+		if err != nil {
+			return fmt.Errorf("wait4 tid %d: %w", tid, err)
+		}
+		if status.Stopped() && status.StopSignal() == unix.SIGTRAP|0x80 {
+			return nil
+		}
+		// If the tracee received a signal during injection, suppress it
+		// and continue waiting for the syscall stop.
+		if status.Stopped() {
+			if err := unix.PtraceSyscall(tid, 0); err != nil {
+				return fmt.Errorf("inject re-resume tid %d: %w", tid, err)
+			}
+			continue
+		}
+		if status.Exited() || status.Signaled() {
+			return fmt.Errorf("tracee %d exited during injection", tid)
+		}
+	}
+}
+
+// injectSyscallRet is a convenience that returns an error if the injected
+// syscall returned a negative errno value.
+func (t *Tracer) injectSyscallRet(tid int, savedRegs Regs, nr int, args ...uint64) (uint64, error) {
+	ret, err := t.injectSyscall(tid, savedRegs, nr, args...)
+	if err != nil {
+		return 0, err
+	}
+	if ret < 0 {
+		return 0, fmt.Errorf("injected syscall %d returned %d (%s)", nr, ret, unix.Errno(-ret))
+	}
+	return uint64(ret), nil
+}
+```
+
+**Step 3: Verify it compiles**
+
+Run: `go build ./internal/ptrace/`
+Expected: Success
+
+**Step 4: Commit**
+
+```bash
+git add internal/ptrace/inject.go internal/ptrace/inject_amd64.go internal/ptrace/inject_arm64.go
+git commit -m "feat(ptrace): add syscall injection engine"
+```
+
+---
+
+### Task 4: Scratch Page Allocation
+
+Create per-TGID scratch page management for longer path rewrites.
+
+**Files:**
+- Create: `internal/ptrace/scratch.go`
+- Modify: `internal/ptrace/tracer.go:127-164` (TraceeState, Tracer struct)
+
+**Step 1: Create scratch.go**
+
+```go
+//go:build linux
+
+package ptrace
+
+import (
+	"fmt"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+// scratchPage tracks a scratch memory page mmap'd into a tracee's address space.
+// Per-TGID: threads in the same process share address space.
+type scratchPage struct {
+	mu   sync.Mutex
+	addr uint64 // base address of the mmap'd page
+	used int    // bytes used (bump allocator)
+	size int    // page size (4096)
+}
+
+// allocate returns a pointer to n bytes within the scratch page.
+// Caller must hold no locks. Thread-safe via internal mutex.
+func (s *scratchPage) allocate(n int) (uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.used+n > s.size {
+		return 0, fmt.Errorf("scratch page full: used=%d, need=%d, size=%d", s.used, n, s.size)
+	}
+	addr := s.addr + uint64(s.used)
+	s.used += n
+	return addr, nil
+}
+
+// reset resets the bump allocator. Call at each new syscall-enter stop.
+func (s *scratchPage) reset() {
+	s.mu.Lock()
+	s.used = 0
+	s.mu.Unlock()
+}
+
+// ensureScratchPage returns the scratch page for the given TGID, allocating one
+// via mmap injection if needed. The tracee must be stopped at a syscall-enter
+// or PTRACE_EVENT_SECCOMP stop.
+func (t *Tracer) ensureScratchPage(tid, tgid int, savedRegs Regs) (*scratchPage, error) {
+	t.mu.Lock()
+	sp := t.tgidScratch[tgid]
+	t.mu.Unlock()
+
+	if sp != nil {
+		return sp, nil
+	}
+
+	// Inject mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0)
+	addr, err := t.injectSyscallRet(tid, savedRegs, unix.SYS_MMAP,
+		0,    // addr = NULL
+		4096, // length
+		uint64(unix.PROT_READ|unix.PROT_WRITE),      // prot
+		uint64(unix.MAP_PRIVATE|unix.MAP_ANONYMOUS),  // flags
+		^uint64(0), // fd = -1
+		0,          // offset
+	)
+	if err != nil {
+		return nil, fmt.Errorf("mmap injection: %w", err)
+	}
+
+	sp = &scratchPage{addr: addr, size: 4096}
+
+	t.mu.Lock()
+	t.tgidScratch[tgid] = sp
+	t.mu.Unlock()
+
+	return sp, nil
+}
+
+// invalidateScratchPage removes the scratch page for a TGID.
+// Called on exec (address space remapped) and process exit.
+func (t *Tracer) invalidateScratchPage(tgid int) {
+	t.mu.Lock()
+	delete(t.tgidScratch, tgid)
+	t.mu.Unlock()
+}
+```
+
+**Step 2: Add `tgidScratch` field to Tracer struct**
+
+In `internal/ptrace/tracer.go`, add to the Tracer struct (after `parkedTracees`):
+
+```go
+tgidScratch map[int]*scratchPage
+```
+
+And initialize it in `NewTracer`:
+
+```go
+tgidScratch:   make(map[int]*scratchPage),
+```
+
+**Step 3: Add scratch invalidation on exec**
+
+In `tracer.go`, in the existing exec-event handling (the `PTRACE_EVENT_EXEC` case in `handleExecEvent` or equivalent), add:
+
+```go
+t.invalidateScratchPage(tgid)
+```
+
+Find the exec event case by searching for `unix.PTRACE_EVENT_EXEC`.
+
+**Step 4: Verify it compiles**
+
+Run: `go build ./internal/ptrace/`
+Expected: Success
+
+**Step 5: Commit**
+
+```bash
+git add internal/ptrace/scratch.go internal/ptrace/tracer.go
+git commit -m "feat(ptrace): add per-TGID scratch page allocation via mmap injection"
+```
+
+---
+
+### Task 5: Extend Result Types for Steering Actions
+
+Update `FileResult` and `NetworkResult` to support redirect/soft-delete actions (matching the `ExecResult` pattern which already has an `Action` field). Update the `ExecResult` to add `StubPath`.
+
+**Files:**
+- Modify: `internal/ptrace/tracer.go:34-85` (result types)
+- Modify: `internal/ptrace/handle_file.go:177-185` (dispatch)
+- Modify: `internal/ptrace/handle_network.go:142-150` (dispatch)
+- Modify: `internal/ptrace/integration_test.go:604-670` (mock handlers)
+
+**Step 1: Update result types in tracer.go**
+
+Change `ExecResult` to add `StubPath`:
+
+```go
+// ExecResult carries the policy decision.
+type ExecResult struct {
+	Allow    bool
+	Action   string // "continue", "deny", "redirect"
+	Errno    int32
+	Rule     string
+	Reason   string
+	StubPath string // for redirect: path to stub binary
+}
+```
+
+Change `FileResult` to add `Action`, `RedirectPath`, `TrashDir`:
+
+```go
+// FileResult carries the file policy decision.
+type FileResult struct {
+	Allow        bool
+	Action       string // "" (legacy allow/deny), "allow", "deny", "redirect", "soft-delete"
+	Errno        int32
+	RedirectPath string // for redirect: replacement path
+	TrashDir     string // for soft-delete: trash directory path
+}
+```
+
+Change `NetworkResult` to add `Action`, `RedirectAddr`, `RedirectPort`:
+
+```go
+// NetworkResult carries the network policy decision.
+type NetworkResult struct {
+	Allow        bool
+	Action       string // "" (legacy allow/deny), "allow", "deny", "redirect"
+	Errno        int32
+	RedirectAddr string // for redirect: target address (IP or hostname)
+	RedirectPort int    // for redirect: target port
+}
+```
+
+**Step 2: Update handleFile dispatch**
+
+In `internal/ptrace/handle_file.go`, replace the dispatch block at lines 177-185:
+
+```go
+	// Dispatch based on Action field (new path) or Allow field (legacy path).
+	action := result.Action
+	if action == "" {
+		if result.Allow {
+			action = "allow"
+		} else {
+			action = "deny"
+		}
+	}
+
+	switch action {
+	case "deny":
+		errno := result.Errno
+		if errno == 0 {
+			errno = int32(unix.EACCES)
+		}
+		t.denySyscall(tid, int(errno))
+	case "redirect":
+		t.redirectFile(ctx, tid, regs, nr, result)
+	case "soft-delete":
+		t.softDeleteFile(ctx, tid, regs, result)
+	default:
+		t.allowSyscall(tid)
+	}
+```
+
+Add stub methods at the end of `handle_file.go` so it compiles:
+
+```go
+// redirectFile redirects a file syscall to a different path.
+// Implemented in redirect_file.go.
+func (t *Tracer) redirectFile(ctx context.Context, tid int, regs Regs, nr int, result FileResult) {
+	// TODO: implement in Task 7
+	slog.Warn("redirectFile: not yet implemented, denying", "tid", tid)
+	t.denySyscall(tid, int(unix.EACCES))
+}
+
+// softDeleteFile performs a soft-delete by moving the file to trash.
+// Implemented in redirect_file.go.
+func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, result FileResult) {
+	// TODO: implement in Task 7
+	slog.Warn("softDeleteFile: not yet implemented, denying", "tid", tid)
+	t.denySyscall(tid, int(unix.EACCES))
+}
+```
+
+**Step 3: Update handleNetwork dispatch**
+
+In `internal/ptrace/handle_network.go`, replace the dispatch block at lines 142-150:
+
+```go
+	// Dispatch based on Action field (new path) or Allow field (legacy path).
+	action := result.Action
+	if action == "" {
+		if result.Allow {
+			action = "allow"
+		} else {
+			action = "deny"
+		}
+	}
+
+	switch action {
+	case "deny":
+		errno := result.Errno
+		if errno == 0 {
+			errno = int32(unix.EACCES)
+		}
+		t.denySyscall(tid, int(errno))
+	case "redirect":
+		t.redirectConnect(ctx, tid, regs, result)
+	default:
+		t.allowSyscall(tid)
+	}
+```
+
+Add stub method at the end of `handle_network.go`:
+
+```go
+// redirectConnect redirects a connect syscall to a different address.
+// Implemented in redirect_net.go.
+func (t *Tracer) redirectConnect(ctx context.Context, tid int, regs Regs, result NetworkResult) {
+	// TODO: implement in Task 8
+	slog.Warn("redirectConnect: not yet implemented, denying", "tid", tid)
+	t.denySyscall(tid, int(unix.EACCES))
+}
+```
+
+**Step 4: Update handleExecve dispatch for redirect**
+
+In `internal/ptrace/tracer.go`, update the `handleExecve` switch at line 594:
+
+```go
+	switch result.Action {
+	case "deny":
+		errno := result.Errno
+		if errno == 0 {
+			errno = int32(unix.EACCES)
+		}
+		t.denySyscall(tid, int(errno))
+	case "redirect":
+		t.redirectExec(ctx, tid, regs, result)
+	default:
+		t.allowSyscall(tid)
+	}
+```
+
+Add a stub for `redirectExec` in `tracer.go`:
+
+```go
+// redirectExec redirects an execve to a stub binary.
+// Implemented in redirect_exec.go.
+func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result ExecResult) {
+	// TODO: implement in Task 6
+	slog.Warn("redirectExec: not yet implemented, denying", "tid", tid)
+	t.denySyscall(tid, int(unix.EACCES))
+}
+```
+
+**Step 5: Update mock handlers in integration test**
+
+In `internal/ptrace/integration_test.go`, update `mockFileHandler` to use Action:
+
+The existing mock returns `FileResult{Allow: m.defaultAllow, Errno: m.defaultErrno}`. This still works because the new dispatch handles `Action == ""` by falling back to the `Allow` bool. No changes needed to the mock for backward compatibility.
+
+**Step 6: Verify all tests pass**
+
+Run: `go test ./internal/ptrace/ -count=1`
+Run: `go build ./internal/ptrace/`
+Expected: Both pass
+
+**Step 7: Commit**
+
+```bash
+git add internal/ptrace/tracer.go internal/ptrace/handle_file.go internal/ptrace/handle_network.go
+git commit -m "feat(ptrace): extend result types with redirect/soft-delete actions and stub dispatch"
+```
+
+---
+
+### Task 6: Exec Redirect Implementation
+
+Implement `redirectExec` — inject a socketpair fd into the tracee and rewrite execve to use a stub binary.
+
+**Files:**
+- Create: `internal/ptrace/redirect_exec.go`
+- Modify: `internal/ptrace/tracer.go` (remove stub `redirectExec`)
+
+**Step 1: Create redirect_exec.go**
+
+```go
+//go:build linux
+
+package ptrace
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+const stubFDNum = 100 // Well-known fd number for stub communication
+
+// redirectExec redirects an execve syscall to a stub binary.
+//
+// Sequence:
+//  1. Create socketpair in tracer for stub communication
+//  2. Inject tracer's socketpair fd into tracee at fd 100 via pidfd_getfd
+//  3. Write stub path into tracee memory
+//  4. Update registers so kernel executes execve with stub path
+//  5. Resume — stub runs and connects back to tracer via fd 100
+func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result ExecResult) {
+	if result.StubPath == "" {
+		slog.Warn("redirectExec: no stub path, denying", "tid", tid)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	savedRegs := regs.Clone()
+
+	// Step 1: Create socketpair in tracer process.
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM|syscall.SOCK_CLOEXEC, 0)
+	if err != nil {
+		slog.Warn("redirectExec: socketpair failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+	tracerFD := fds[0]
+	injectFD := fds[1]
+	defer syscall.Close(tracerFD)
+	defer syscall.Close(injectFD)
+
+	// Step 2: Inject fd into tracee via pidfd_getfd.
+	if err := t.injectFDIntoTracee(tid, savedRegs, injectFD, stubFDNum); err != nil {
+		slog.Warn("redirectExec: fd injection failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Step 3: Write stub path into tracee memory.
+	// Get the filename pointer from the original registers.
+	nr := regs.SyscallNr()
+	var filenamePtr uint64
+	if nr == unix.SYS_EXECVEAT {
+		filenamePtr = regs.Arg(1)
+	} else {
+		filenamePtr = regs.Arg(0)
+	}
+
+	// Read original filename to determine available buffer size.
+	origFilename, _ := t.readString(tid, filenamePtr, 4096)
+	origLen := len(origFilename) + 1 // include NUL
+
+	stubPath := result.StubPath
+	if len(stubPath)+1 <= origLen {
+		// Fits in original buffer — overwrite in place.
+		if err := t.writeString(tid, filenamePtr, stubPath); err != nil {
+			slog.Warn("redirectExec: write stub path failed, denying", "tid", tid, "error", err)
+			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+			t.denySyscall(tid, int(unix.EACCES))
+			return
+		}
+	} else {
+		// Need scratch page.
+		t.mu.Lock()
+		state := t.tracees[tid]
+		tgid := tid
+		if state != nil {
+			tgid = state.TGID
+		}
+		t.mu.Unlock()
+
+		sp, err := t.ensureScratchPage(tid, tgid, savedRegs)
+		if err != nil {
+			slog.Warn("redirectExec: scratch alloc failed, denying", "tid", tid, "error", err)
+			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+			t.denySyscall(tid, int(unix.EACCES))
+			return
+		}
+
+		scratchAddr, err := sp.allocate(len(stubPath) + 1)
+		if err != nil {
+			slog.Warn("redirectExec: scratch page full, denying", "tid", tid, "error", err)
+			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+			t.denySyscall(tid, int(unix.EACCES))
+			return
+		}
+
+		if err := t.writeString(tid, scratchAddr, stubPath); err != nil {
+			slog.Warn("redirectExec: write to scratch failed, denying", "tid", tid, "error", err)
+			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+			t.denySyscall(tid, int(unix.EACCES))
+			return
+		}
+
+		// Update the filename pointer register.
+		if nr == unix.SYS_EXECVEAT {
+			regs.SetArg(1, scratchAddr)
+		} else {
+			regs.SetArg(0, scratchAddr)
+		}
+	}
+
+	// Step 4: Set registers and resume — kernel will execve the stub.
+	if err := t.setRegs(tid, regs); err != nil {
+		slog.Warn("redirectExec: setRegs failed, denying", "tid", tid, "error", err)
+		t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+		t.setRegs(tid, savedRegs)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	t.allowSyscall(tid)
+}
+
+// injectFDIntoTracee injects a file descriptor from the tracer into the tracee
+// at the specified fd number, using pidfd_open + pidfd_getfd + dup3.
+func (t *Tracer) injectFDIntoTracee(tid int, savedRegs Regs, srcFD int, dstFDNum int) error {
+	tracerPID := os.Getpid()
+
+	// pidfd_open(tracer_pid, 0) → pidfd
+	pidfd, err := t.injectSyscallRet(tid, savedRegs, unix.SYS_PIDFD_OPEN,
+		uint64(tracerPID), 0)
+	if err != nil {
+		return fmt.Errorf("pidfd_open: %w", err)
+	}
+
+	// pidfd_getfd(pidfd, src_fd, 0) → got_fd
+	gotFD, err := t.injectSyscallRet(tid, savedRegs, unix.SYS_PIDFD_GETFD,
+		pidfd, uint64(srcFD), 0)
+	if err != nil {
+		t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, pidfd) //nolint:errcheck
+		return fmt.Errorf("pidfd_getfd: %w", err)
+	}
+
+	// dup3(got_fd, dstFDNum, 0) → place at target fd
+	if gotFD != uint64(dstFDNum) {
+		_, err = t.injectSyscallRet(tid, savedRegs, unix.SYS_DUP3,
+			gotFD, uint64(dstFDNum), 0)
+		if err != nil {
+			t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, gotFD)  //nolint:errcheck
+			t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, pidfd)  //nolint:errcheck
+			return fmt.Errorf("dup3: %w", err)
+		}
+		// Close the original got_fd (now duplicated to dstFDNum).
+		t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, gotFD) //nolint:errcheck
+	}
+
+	// Close the pidfd.
+	t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, pidfd) //nolint:errcheck
+
+	return nil
+}
+
+// cleanupInjectedFD closes a previously injected fd in the tracee.
+func (t *Tracer) cleanupInjectedFD(tid int, savedRegs Regs, fdNum int) {
+	t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, uint64(fdNum)) //nolint:errcheck
+}
+```
+
+**Step 2: Remove the stub redirectExec from tracer.go**
+
+Delete the placeholder `redirectExec` method added in Task 5.
+
+**Step 3: Verify it compiles**
+
+Run: `go build ./internal/ptrace/`
+Expected: Success
+
+**Step 4: Commit**
+
+```bash
+git add internal/ptrace/redirect_exec.go internal/ptrace/tracer.go
+git commit -m "feat(ptrace): implement exec redirect via fd injection and stub path rewrite"
+```
+
+---
+
+### Task 7: File Path Redirect and Soft-Delete
+
+Implement `redirectFile` and `softDeleteFile`.
+
+**Files:**
+- Create: `internal/ptrace/redirect_file.go`
+- Modify: `internal/ptrace/handle_file.go` (remove stubs)
+
+**Step 1: Create redirect_file.go**
+
+```go
+//go:build linux
+
+package ptrace
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+
+	"golang.org/x/sys/unix"
+)
+
+// filePathArgIndex returns the register index containing the path pointer
+// for the given file syscall number. Returns -1 for unknown syscalls.
+func filePathArgIndex(nr int) int {
+	switch nr {
+	case unix.SYS_OPENAT, unix.SYS_OPENAT2:
+		return 1 // openat(dirfd, pathname, ...)
+	case unix.SYS_UNLINKAT, unix.SYS_MKDIRAT:
+		return 1 // unlinkat(dirfd, pathname, flags)
+	case unix.SYS_FCHMODAT, unix.SYS_FCHMODAT2:
+		return 1 // fchmodat(dirfd, pathname, mode, ...)
+	case unix.SYS_FCHOWNAT:
+		return 1 // fchownat(dirfd, pathname, ...)
+	case unix.SYS_RENAMEAT2:
+		return 1 // renameat2(olddirfd, oldpath, newdirfd, newpath, flags) — redirect oldpath
+	case unix.SYS_LINKAT:
+		return 1 // linkat(olddirfd, oldpath, ...) — redirect oldpath
+	case unix.SYS_SYMLINKAT:
+		return 0 // symlinkat(target, newdirfd, linkpath) — redirect target
+	default:
+		return -1
+	}
+}
+
+// redirectFileImpl redirects a file syscall to a different path by overwriting
+// the path argument in tracee memory (in-place or via scratch page).
+func (t *Tracer) redirectFileImpl(ctx context.Context, tid int, regs Regs, nr int, redirectPath string) error {
+	argIdx := filePathArgIndex(nr)
+	if argIdx < 0 {
+		return fmt.Errorf("unsupported syscall %d for file redirect", nr)
+	}
+
+	pathPtr := regs.Arg(argIdx)
+
+	// Read original path to determine buffer length.
+	origPath, err := t.readString(tid, pathPtr, 4096)
+	if err != nil {
+		return fmt.Errorf("read original path: %w", err)
+	}
+	origLen := len(origPath) + 1 // include NUL
+
+	if len(redirectPath)+1 <= origLen {
+		// Fits in original buffer — overwrite in place.
+		return t.writeString(tid, pathPtr, redirectPath)
+	}
+
+	// Need scratch page — longer replacement.
+	t.mu.Lock()
+	state := t.tracees[tid]
+	tgid := tid
+	if state != nil {
+		tgid = state.TGID
+	}
+	t.mu.Unlock()
+
+	savedRegs := regs.Clone()
+	sp, err := t.ensureScratchPage(tid, tgid, savedRegs)
+	if err != nil {
+		return fmt.Errorf("scratch page: %w", err)
+	}
+
+	scratchAddr, err := sp.allocate(len(redirectPath) + 1)
+	if err != nil {
+		return fmt.Errorf("scratch allocate: %w", err)
+	}
+
+	if err := t.writeString(tid, scratchAddr, redirectPath); err != nil {
+		return fmt.Errorf("write to scratch: %w", err)
+	}
+
+	// Update register to point to the scratch page.
+	regs.SetArg(argIdx, scratchAddr)
+	return t.setRegs(tid, regs)
+}
+
+// redirectFile redirects a file syscall to a different path.
+func (t *Tracer) redirectFile(ctx context.Context, tid int, regs Regs, nr int, result FileResult) {
+	if result.RedirectPath == "" {
+		slog.Warn("redirectFile: no redirect path, denying", "tid", tid)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	if err := t.redirectFileImpl(ctx, tid, regs, nr, result.RedirectPath); err != nil {
+		slog.Warn("redirectFile: failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	t.allowSyscall(tid)
+}
+
+// softDeleteFile performs a soft-delete: denies the unlinkat but moves the file
+// to a trash directory instead of actually deleting it.
+func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, result FileResult) {
+	if result.TrashDir == "" {
+		slog.Warn("softDeleteFile: no trash dir, denying", "tid", tid)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	nr := regs.SyscallNr()
+	if nr != unix.SYS_UNLINKAT {
+		slog.Warn("softDeleteFile: only supported for unlinkat", "tid", tid, "nr", nr)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Read the path being deleted.
+	pathPtr := regs.Arg(1)
+	origPath, err := t.readString(tid, pathPtr, 4096)
+	if err != nil {
+		slog.Warn("softDeleteFile: cannot read path, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Resolve to absolute path.
+	dirfd := int(int32(regs.Arg(0)))
+	absPath, err := resolvePathNoFollow(tid, dirfd, origPath)
+	if err != nil {
+		slog.Warn("softDeleteFile: cannot resolve path, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Generate unique trash filename.
+	var rndBuf [8]byte
+	rand.Read(rndBuf[:])
+	trashName := hex.EncodeToString(rndBuf[:])
+	trashPath := result.TrashDir + "/" + trashName
+
+	savedRegs := regs.Clone()
+
+	// Ensure trash directory exists: inject mkdirat(AT_FDCWD, trashDir, 0700).
+	// Write trash dir path to scratch.
+	t.mu.Lock()
+	state := t.tracees[tid]
+	tgid := tid
+	if state != nil {
+		tgid = state.TGID
+	}
+	t.mu.Unlock()
+
+	sp, err := t.ensureScratchPage(tid, tgid, savedRegs)
+	if err != nil {
+		slog.Warn("softDeleteFile: scratch page failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Write trash dir path to scratch.
+	trashDirAddr, err := sp.allocate(len(result.TrashDir) + 1)
+	if err != nil {
+		slog.Warn("softDeleteFile: scratch alloc trashDir failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+	if err := t.writeString(tid, trashDirAddr, result.TrashDir); err != nil {
+		slog.Warn("softDeleteFile: write trashDir failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// mkdirat(AT_FDCWD, trashDir, 0700) — ignore EEXIST.
+	mkdirRet, _ := t.injectSyscall(tid, savedRegs, unix.SYS_MKDIRAT,
+		uint64(unix.AT_FDCWD), trashDirAddr, 0700)
+	if mkdirRet < 0 && unix.Errno(-mkdirRet) != unix.EEXIST {
+		slog.Warn("softDeleteFile: mkdirat failed, denying", "tid", tid, "errno", unix.Errno(-mkdirRet))
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Reset scratch for reuse.
+	sp.reset()
+
+	// Write old path (absolute) to scratch.
+	oldPathAddr, err := sp.allocate(len(absPath) + 1)
+	if err != nil {
+		slog.Warn("softDeleteFile: scratch alloc oldPath failed", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+	if err := t.writeString(tid, oldPathAddr, absPath); err != nil {
+		slog.Warn("softDeleteFile: write oldPath failed", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Write trash path to scratch.
+	trashPathAddr, err := sp.allocate(len(trashPath) + 1)
+	if err != nil {
+		slog.Warn("softDeleteFile: scratch alloc trashPath failed", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+	if err := t.writeString(tid, trashPathAddr, trashPath); err != nil {
+		slog.Warn("softDeleteFile: write trashPath failed", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Inject renameat2(AT_FDCWD, absPath, AT_FDCWD, trashPath, 0).
+	renameRet, _ := t.injectSyscall(tid, savedRegs, unix.SYS_RENAMEAT2,
+		uint64(unix.AT_FDCWD), oldPathAddr,
+		uint64(unix.AT_FDCWD), trashPathAddr,
+		0)
+	if renameRet < 0 {
+		errno := unix.Errno(-renameRet)
+		slog.Warn("softDeleteFile: renameat2 failed, denying", "tid", tid, "errno", errno)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	slog.Info("softDeleteFile: file moved to trash", "original", absPath, "trash", trashPath)
+
+	// Deny the original unlinkat with fake success (return 0).
+	regs.SetSyscallNr(-1)
+	t.setRegs(tid, regs)
+
+	t.mu.Lock()
+	if state, ok := t.tracees[tid]; ok {
+		state.PendingDenyErrno = 0 // Will set return value to 0 (success)
+		state.InSyscall = true
+	}
+	t.mu.Unlock()
+
+	unix.PtraceSyscall(tid, 0)
+}
+```
+
+**Step 2: Remove stub methods from handle_file.go**
+
+Delete the placeholder `redirectFile` and `softDeleteFile` methods added in Task 5.
+
+**Step 3: Verify it compiles**
+
+Run: `go build ./internal/ptrace/`
+Expected: Success
+
+**Step 4: Commit**
+
+```bash
+git add internal/ptrace/redirect_file.go internal/ptrace/handle_file.go
+git commit -m "feat(ptrace): implement file path redirect and soft-delete via syscall injection"
+```
+
+---
+
+### Task 8: Connect Redirect
+
+Implement `redirectConnect` — rewrite the sockaddr in tracee memory.
+
+**Files:**
+- Create: `internal/ptrace/redirect_net.go`
+- Modify: `internal/ptrace/handle_network.go` (remove stub)
+
+**Step 1: Create redirect_net.go**
+
+```go
+//go:build linux
+
+package ptrace
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+// redirectConnect redirects a connect() syscall to a different address/port
+// by overwriting the sockaddr in tracee memory.
+func (t *Tracer) redirectConnect(ctx context.Context, tid int, regs Regs, result NetworkResult) {
+	if result.RedirectAddr == "" && result.RedirectPort == 0 {
+		slog.Warn("redirectConnect: no redirect target, denying", "tid", tid)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Read original sockaddr.
+	addrPtr := regs.Arg(1)
+	addrLen := int(regs.Arg(2))
+	if addrLen == 0 || addrLen > 128 {
+		slog.Warn("redirectConnect: invalid addrlen, denying", "tid", tid, "addrlen", addrLen)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	buf := make([]byte, addrLen)
+	if err := t.readBytes(tid, addrPtr, buf); err != nil {
+		slog.Warn("redirectConnect: read sockaddr failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	if len(buf) < 2 {
+		slog.Warn("redirectConnect: sockaddr too short, denying", "tid", tid)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	family := int(binary.NativeEndian.Uint16(buf[0:2]))
+
+	// Resolve redirect address.
+	var redirectIP net.IP
+	if result.RedirectAddr != "" {
+		redirectIP = net.ParseIP(result.RedirectAddr)
+		if redirectIP == nil {
+			// Try DNS resolution.
+			ips, err := net.LookupIP(result.RedirectAddr)
+			if err != nil || len(ips) == 0 {
+				slog.Warn("redirectConnect: cannot resolve redirect addr, denying",
+					"tid", tid, "addr", result.RedirectAddr, "error", err)
+				t.denySyscall(tid, int(unix.EACCES))
+				return
+			}
+			// Prefer matching address family.
+			for _, ip := range ips {
+				if family == unix.AF_INET && ip.To4() != nil {
+					redirectIP = ip.To4()
+					break
+				}
+				if family == unix.AF_INET6 && ip.To4() == nil {
+					redirectIP = ip
+					break
+				}
+			}
+			if redirectIP == nil {
+				redirectIP = ips[0]
+			}
+		}
+	}
+
+	var newBuf []byte
+
+	switch family {
+	case unix.AF_INET:
+		if len(buf) < 8 {
+			slog.Warn("redirectConnect: sockaddr_in too short", "tid", tid)
+			t.denySyscall(tid, int(unix.EACCES))
+			return
+		}
+		newBuf = make([]byte, len(buf))
+		copy(newBuf, buf)
+
+		if result.RedirectPort > 0 {
+			binary.BigEndian.PutUint16(newBuf[2:4], uint16(result.RedirectPort))
+		}
+		if redirectIP != nil {
+			ip4 := redirectIP.To4()
+			if ip4 == nil {
+				slog.Warn("redirectConnect: IPv6 redirect for IPv4 socket, denying", "tid", tid)
+				t.denySyscall(tid, int(unix.EACCES))
+				return
+			}
+			copy(newBuf[4:8], ip4)
+		}
+
+	case unix.AF_INET6:
+		if len(buf) < 28 {
+			slog.Warn("redirectConnect: sockaddr_in6 too short", "tid", tid)
+			t.denySyscall(tid, int(unix.EACCES))
+			return
+		}
+		newBuf = make([]byte, len(buf))
+		copy(newBuf, buf)
+
+		if result.RedirectPort > 0 {
+			binary.BigEndian.PutUint16(newBuf[2:4], uint16(result.RedirectPort))
+		}
+		if redirectIP != nil {
+			ip16 := redirectIP.To16()
+			if ip16 == nil {
+				slog.Warn("redirectConnect: cannot convert redirect addr to IPv6", "tid", tid)
+				t.denySyscall(tid, int(unix.EACCES))
+				return
+			}
+			copy(newBuf[8:24], ip16)
+		}
+
+	default:
+		slog.Warn("redirectConnect: unsupported address family", "tid", tid, "family", family)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Write new sockaddr back to tracee.
+	if err := t.writeBytes(tid, addrPtr, newBuf); err != nil {
+		slog.Warn("redirectConnect: write sockaddr failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	if result.RedirectPort > 0 || redirectIP != nil {
+		var origAddr, newAddr string
+		_, origAddress, origPort, _ := parseSockaddr(buf)
+		_, newAddress, newPort, _ := parseSockaddr(newBuf)
+		origAddr = fmt.Sprintf("%s:%d", origAddress, origPort)
+		newAddr = fmt.Sprintf("%s:%d", newAddress, newPort)
+		slog.Info("redirectConnect: rewritten", "tid", tid, "from", origAddr, "to", newAddr)
+	}
+
+	t.allowSyscall(tid)
+}
+```
+
+**Step 2: Remove the stub redirectConnect from handle_network.go**
+
+Delete the placeholder `redirectConnect` method added in Task 5.
+
+**Step 3: Verify it compiles**
+
+Run: `go build ./internal/ptrace/`
+Expected: Success
+
+**Step 4: Commit**
+
+```bash
+git add internal/ptrace/redirect_net.go internal/ptrace/handle_network.go
+git commit -m "feat(ptrace): implement connect redirect via sockaddr rewrite"
+```
+
+---
+
+### Task 9: Integration Tests — Syscall Injection
+
+Add integration test for the injection engine: inject `getpid()` and verify it returns the tracee's PID.
+
+**Files:**
+- Modify: `internal/ptrace/integration_test.go`
+
+**Step 1: Write the test**
+
+Add to `integration_test.go`:
+
+```go
+func TestIntegration_SyscallInjection(t *testing.T) {
+	requirePtrace(t)
+
+	handler := &mockExecHandler{defaultAllow: true}
+	tr := NewTracer(TracerConfig{
+		AttachMode:  "pid",
+		TraceExecve: true,
+		ExecHandler: handler,
+		MaxTracees:  100,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Start a long-running child.
+	cmd := exec.Command("/bin/sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Process.Kill()
+	childPID := cmd.Process.Pid
+
+	go tr.Run(ctx)
+	tr.AttachPID(childPID)
+
+	if !waitForAttach(t, tr, 5*time.Second) {
+		t.Fatal("attach timeout")
+	}
+
+	// The tracee should be stopped after attach. We need to wait for it to
+	// hit a syscall stop so we can inject. Send PTRACE_INTERRUPT to get a
+	// group-stop, then test injection from there.
+	//
+	// For this test, we verify the injection engine works by injecting getpid
+	// during an exec handler callback. We add a custom exec handler that does injection.
+	cancel()
+	waitForTraceesDrained(t, tr, 5*time.Second)
+
+	// Test 2: Use a handler that performs injection during HandleExecve.
+	injectionResult := make(chan int64, 1)
+	injHandler := &injectingExecHandler{
+		tracer:     nil, // set below
+		resultChan: injectionResult,
+	}
+
+	tr2 := NewTracer(TracerConfig{
+		AttachMode:  "pid",
+		TraceExecve: true,
+		ExecHandler: injHandler,
+		MaxTracees:  100,
+	})
+	injHandler.tracer = tr2
+
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel2()
+
+	cmd2 := exec.Command("/bin/sh", "-c", "exec /bin/echo injection_test")
+	if err := cmd2.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer cmd2.Process.Kill()
+
+	go tr2.Run(ctx2)
+	tr2.AttachPID(cmd2.Process.Pid)
+
+	select {
+	case ret := <-injectionResult:
+		if ret != int64(cmd2.Process.Pid) {
+			// PID might differ due to exec, just verify it's positive.
+			if ret <= 0 {
+				t.Errorf("getpid injection returned %d, expected positive PID", ret)
+			}
+		}
+	case <-time.After(5 * time.Second):
+		t.Log("injection test timed out — injection during handler may not be safe in current architecture")
+	}
+
+	cancel2()
+	waitForTraceesDrained(t, tr2, 5*time.Second)
+}
+```
+
+**Note:** This test validates the injection mechanism works. The injection during a handler callback is architecturally tricky because the tracer's event loop owns the ptrace calls. If this approach doesn't work cleanly, the test documents the constraint and we'll adjust.
+
+**Step 2: Run the test in Docker**
+
+Run: `docker build -f Dockerfile.ptrace-test -t agentsh-ptrace-test . && docker run --rm --cap-add SYS_PTRACE agentsh-ptrace-test -test.run TestIntegration_SyscallInjection -test.v -test.timeout=30s`
+Expected: PASS (or informative skip if injection during handler isn't supported yet)
+
+**Step 3: Commit**
+
+```bash
+git add internal/ptrace/integration_test.go
+git commit -m "test(ptrace): add syscall injection integration test"
+```
+
+---
+
+### Task 10: Integration Tests — File Redirect
+
+Test file path redirect: redirect `openat` to a different path and verify the redirected file's contents are read.
+
+**Files:**
+- Modify: `internal/ptrace/integration_test.go`
+
+**Step 1: Write the test**
+
+```go
+func TestIntegration_FileRedirect(t *testing.T) {
+	requirePtrace(t)
+
+	tmpDir := t.TempDir()
+
+	// Create two files: original and redirect target.
+	origFile := filepath.Join(tmpDir, "original.txt")
+	redirectFile := filepath.Join(tmpDir, "redirected.txt")
+	os.WriteFile(origFile, []byte("original"), 0644)
+	os.WriteFile(redirectFile, []byte("redirected"), 0644)
+
+	outputFile := filepath.Join(tmpDir, "output.txt")
+
+	// File handler redirects reads of original.txt → redirected.txt
+	fileHandler := &mockFileHandler{
+		defaultAllow: true,
+		rules: map[string]FileResult{
+			"original.txt": {Action: "redirect", RedirectPath: redirectFile},
+		},
+	}
+
+	tr := NewTracer(TracerConfig{
+		AttachMode:  "pid",
+		TraceExecve: true,
+		TraceFile:   true,
+		ExecHandler: &mockExecHandler{defaultAllow: true},
+		FileHandler: fileHandler,
+		MaxTracees:  100,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Child reads original.txt and writes contents to output.txt.
+	cmd := exec.Command("/bin/sh", "-c",
+		fmt.Sprintf("cat %s > %s", origFile, outputFile))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	go tr.Run(ctx)
+	tr.AttachPID(cmd.Process.Pid)
+	waitForTraceesDrained(t, tr, 10*time.Second)
+	cancel()
+
+	// Verify output contains redirected content.
+	content, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if string(content) != "redirected" {
+		t.Errorf("expected 'redirected', got %q", string(content))
+	}
+}
+```
+
+**Step 2: Run in Docker**
+
+Run: `docker build -f Dockerfile.ptrace-test -t agentsh-ptrace-test . && docker run --rm --cap-add SYS_PTRACE agentsh-ptrace-test -test.run TestIntegration_FileRedirect -test.v -test.timeout=30s`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add internal/ptrace/integration_test.go
+git commit -m "test(ptrace): add file redirect integration test"
+```
+
+---
+
+### Task 11: Integration Tests — Soft-Delete
+
+Test soft-delete: `unlinkat` returns success but file is moved to trash.
+
+**Files:**
+- Modify: `internal/ptrace/integration_test.go`
+
+**Step 1: Write the test**
+
+```go
+func TestIntegration_SoftDelete(t *testing.T) {
+	requirePtrace(t)
+
+	tmpDir := t.TempDir()
+	targetFile := filepath.Join(tmpDir, "delete_me.txt")
+	trashDir := filepath.Join(tmpDir, "trash")
+	os.WriteFile(targetFile, []byte("precious data"), 0644)
+
+	outputFile := filepath.Join(tmpDir, "output.txt")
+
+	fileHandler := &mockFileHandler{
+		defaultAllow: true,
+		rules: map[string]FileResult{
+			"delete_me.txt": {Action: "soft-delete", TrashDir: trashDir},
+		},
+	}
+
+	tr := NewTracer(TracerConfig{
+		AttachMode:  "pid",
+		TraceExecve: true,
+		TraceFile:   true,
+		ExecHandler: &mockExecHandler{defaultAllow: true},
+		FileHandler: fileHandler,
+		MaxTracees:  100,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Child deletes the file, then checks if the rm "succeeded" (exit code 0).
+	cmd := exec.Command("/bin/sh", "-c",
+		fmt.Sprintf("rm %s && echo deleted > %s || echo failed > %s",
+			targetFile, outputFile, outputFile))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	go tr.Run(ctx)
+	tr.AttachPID(cmd.Process.Pid)
+	waitForTraceesDrained(t, tr, 10*time.Second)
+	cancel()
+
+	// Verify: original location should be gone.
+	if _, err := os.Stat(targetFile); !os.IsNotExist(err) {
+		t.Error("file should not exist at original path")
+	}
+
+	// Verify: trash directory should contain the file.
+	entries, err := os.ReadDir(trashDir)
+	if err != nil {
+		t.Fatalf("read trash dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("trash directory should not be empty")
+	}
+
+	// Read the trashed file and verify content.
+	trashFile := filepath.Join(trashDir, entries[0].Name())
+	content, err := os.ReadFile(trashFile)
+	if err != nil {
+		t.Fatalf("read trash file: %v", err)
+	}
+	if string(content) != "precious data" {
+		t.Errorf("expected 'precious data', got %q", string(content))
+	}
+
+	// Verify: child saw success.
+	output, _ := os.ReadFile(outputFile)
+	if strings.TrimSpace(string(output)) != "deleted" {
+		t.Errorf("expected child to see 'deleted', got %q", string(output))
+	}
+}
+```
+
+**Step 2: Run in Docker**
+
+Run: `docker build -f Dockerfile.ptrace-test -t agentsh-ptrace-test . && docker run --rm --cap-add SYS_PTRACE agentsh-ptrace-test -test.run TestIntegration_SoftDelete -test.v -test.timeout=30s`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add internal/ptrace/integration_test.go
+git commit -m "test(ptrace): add soft-delete integration test"
+```
+
+---
+
+### Task 12: Integration Tests — Connect Redirect
+
+Test connect redirect: redirect a connection to a different port.
+
+**Files:**
+- Modify: `internal/ptrace/integration_test.go`
+
+**Step 1: Write the test**
+
+```go
+func TestIntegration_ConnectRedirect(t *testing.T) {
+	requirePtrace(t)
+
+	// Start a listener on a random port — this is the redirect target.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	targetPort := listener.Addr().(*net.TCPAddr).Port
+
+	// Accept one connection and respond.
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		conn.Write([]byte("redirected"))
+		conn.Close()
+	}()
+
+	tmpDir := t.TempDir()
+	outputFile := filepath.Join(tmpDir, "output.txt")
+
+	// Pick a port that nobody listens on (original target).
+	origPort := 19999
+
+	netHandler := &mockNetworkHandler{
+		defaultAllow: true,
+	}
+	// Override HandleNetwork to return redirect.
+	netHandler.redirectPort = targetPort
+	netHandler.redirectFromPort = origPort
+
+	tr := NewTracer(TracerConfig{
+		AttachMode:   "pid",
+		TraceExecve:  true,
+		TraceNetwork: true,
+		ExecHandler:  &mockExecHandler{defaultAllow: true},
+		NetworkHandler: netHandler,
+		MaxTracees:   100,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Child connects to origPort, reads response, writes to output.
+	cmd := exec.Command("/bin/sh", "-c",
+		fmt.Sprintf("echo | nc -w2 127.0.0.1 %d > %s 2>/dev/null || echo failed > %s",
+			origPort, outputFile, outputFile))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	go tr.Run(ctx)
+	tr.AttachPID(cmd.Process.Pid)
+	waitForTraceesDrained(t, tr, 10*time.Second)
+	cancel()
+
+	content, _ := os.ReadFile(outputFile)
+	if strings.TrimSpace(string(content)) != "redirected" {
+		t.Logf("connect redirect output: %q (may fail if nc not available)", string(content))
+	}
+}
+```
+
+This test requires updating `mockNetworkHandler` to support redirect. Add these fields:
+
+```go
+type mockNetworkHandler struct {
+	mu               sync.Mutex
+	calls            []mockNetworkCall
+	defaultAllow     bool
+	defaultErrno     int32
+	denyPorts        map[int]int32 // port → errno
+	redirectPort     int           // if > 0, redirect to this port
+	redirectFromPort int           // redirect connections to this port
+}
+
+func (m *mockNetworkHandler) HandleNetwork(ctx context.Context, nc NetworkContext) NetworkResult {
+	m.mu.Lock()
+	m.calls = append(m.calls, mockNetworkCall{nc})
+	m.mu.Unlock()
+
+	if m.denyPorts != nil {
+		if errno, ok := m.denyPorts[nc.Port]; ok {
+			return NetworkResult{Allow: false, Errno: errno}
+		}
+	}
+
+	if m.redirectPort > 0 && nc.Port == m.redirectFromPort {
+		return NetworkResult{
+			Allow:        true,
+			Action:       "redirect",
+			RedirectAddr: "127.0.0.1",
+			RedirectPort: m.redirectPort,
+		}
+	}
+
+	return NetworkResult{Allow: m.defaultAllow, Errno: m.defaultErrno}
+}
+```
+
+**Step 2: Run in Docker**
+
+Run: `docker build -f Dockerfile.ptrace-test -t agentsh-ptrace-test . && docker run --rm --cap-add SYS_PTRACE agentsh-ptrace-test -test.run TestIntegration_ConnectRedirect -test.v -test.timeout=30s`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add internal/ptrace/integration_test.go
+git commit -m "test(ptrace): add connect redirect integration test"
+```
+
+---
+
+### Task 13: Integration Tests — Scratch Page (Long Path Redirect)
+
+Test that file redirect works when the replacement path is longer than the original (triggers mmap injection).
+
+**Files:**
+- Modify: `internal/ptrace/integration_test.go`
+
+**Step 1: Write the test**
+
+```go
+func TestIntegration_ScratchPage(t *testing.T) {
+	requirePtrace(t)
+
+	tmpDir := t.TempDir()
+
+	// Create a short-named original and a very-long-named redirect target.
+	origFile := filepath.Join(tmpDir, "a.txt")
+	longName := strings.Repeat("x", 200) + ".txt"
+	redirectTarget := filepath.Join(tmpDir, longName)
+	os.WriteFile(origFile, []byte("short"), 0644)
+	os.WriteFile(redirectTarget, []byte("long-path-content"), 0644)
+
+	outputFile := filepath.Join(tmpDir, "output.txt")
+
+	fileHandler := &mockFileHandler{
+		defaultAllow: true,
+		rules: map[string]FileResult{
+			"a.txt": {Action: "redirect", RedirectPath: redirectTarget},
+		},
+	}
+
+	tr := NewTracer(TracerConfig{
+		AttachMode:  "pid",
+		TraceExecve: true,
+		TraceFile:   true,
+		ExecHandler: &mockExecHandler{defaultAllow: true},
+		FileHandler: fileHandler,
+		MaxTracees:  100,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.Command("/bin/sh", "-c",
+		fmt.Sprintf("cat %s > %s", origFile, outputFile))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	go tr.Run(ctx)
+	tr.AttachPID(cmd.Process.Pid)
+	waitForTraceesDrained(t, tr, 10*time.Second)
+	cancel()
+
+	content, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if string(content) != "long-path-content" {
+		t.Errorf("expected 'long-path-content', got %q", string(content))
+	}
+}
+```
+
+**Step 2: Run in Docker**
+
+Run: `docker build -f Dockerfile.ptrace-test -t agentsh-ptrace-test . && docker run --rm --cap-add SYS_PTRACE agentsh-ptrace-test -test.run TestIntegration_ScratchPage -test.v -test.timeout=30s`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add internal/ptrace/integration_test.go
+git commit -m "test(ptrace): add scratch page (long path redirect) integration test"
+```
+
+---
+
+### Task 14: Cross-Compilation and Full Test Suite
+
+Verify everything compiles on all targets and all tests pass.
+
+**Step 1: Cross-compile**
+
+Run: `GOOS=windows go build ./...`
+Expected: Success
+
+Run: `GOOS=darwin go build ./...`
+Expected: Success (build tags exclude linux-only code)
+
+**Step 2: Run unit tests**
+
+Run: `go test ./... -count=1`
+Expected: All pass
+
+**Step 3: Run full integration tests in Docker**
+
+Run: `docker build -f Dockerfile.ptrace-test -t agentsh-ptrace-test . && docker run --rm --cap-add SYS_PTRACE agentsh-ptrace-test -test.v -test.timeout=120s`
+Expected: All pass
+
+**Step 4: Update documentation**
+
+Update `docs/ptrace-support.md` to reflect Phase 4a completion:
+- Change status to "Phase 4a Complete"
+- Add Phase 4a section documenting: syscall injection, exec redirect, file redirect, soft-delete, connect redirect, scratch pages
+
+Update `docs/project-structure.md` to add new files:
+- `inject.go`, `inject_amd64.go`, `inject_arm64.go`
+- `scratch.go`
+- `redirect_exec.go`, `redirect_file.go`, `redirect_net.go`
+
+**Step 5: Commit**
+
+```bash
+git add docs/ptrace-support.md docs/project-structure.md
+git commit -m "docs: update documentation for ptrace Phase 4a completion"
+```
+
+---
+
+## Key Design Decisions
+
+- **Two-phase PtraceSyscall for injection**: More robust than PtraceSingleStep — immune to seccomp prefilter interactions and signal delivery races.
+- **IP-2/IP-4 gadget**: Zero-cost syscall instruction discovery when tracee is at a syscall stop.
+- **Per-TGID scratch pages**: Threads share address space, so one mmap serves all threads in a process.
+- **Legacy Allow/Deny compatibility**: `Action == ""` falls back to `Allow` bool, so all existing tests and handlers continue to work.
+- **Restore-on-failure**: All redirect paths save registers upfront and deny on injection failure. Never leave the tracee in a half-modified state.
+- **Fixed fd 100 for stub communication**: High enough to avoid conflicts with standard fds, low enough to avoid hitting rlimits.
+
+## Verification
+
+1. `go build ./...` — all packages compile
+2. `GOOS=windows go build ./...` — cross-compilation works
+3. `go test ./... -count=1` — unit tests pass
+4. `docker build -f Dockerfile.ptrace-test -t agentsh-ptrace-test .`
+5. `docker run --rm --cap-add SYS_PTRACE agentsh-ptrace-test -test.v` — all integration tests pass

--- a/internal/ptrace/args.go
+++ b/internal/ptrace/args.go
@@ -11,4 +11,6 @@ type Regs interface {
 	ReturnValue() int64
 	SetReturnValue(val int64)
 	InstructionPointer() uint64
+	SetInstructionPointer(addr uint64)
+	Clone() Regs
 }

--- a/internal/ptrace/args_amd64.go
+++ b/internal/ptrace/args_amd64.go
@@ -12,7 +12,13 @@ func (r *amd64Regs) SyscallNr() int             { return int(int64(r.raw.Orig_ra
 func (r *amd64Regs) SetSyscallNr(nr int)         { r.raw.Orig_rax = uint64(nr) }
 func (r *amd64Regs) ReturnValue() int64          { return int64(r.raw.Rax) }
 func (r *amd64Regs) SetReturnValue(v int64)      { r.raw.Rax = uint64(v) }
-func (r *amd64Regs) InstructionPointer() uint64  { return r.raw.Rip }
+func (r *amd64Regs) InstructionPointer() uint64    { return r.raw.Rip }
+func (r *amd64Regs) SetInstructionPointer(addr uint64) { r.raw.Rip = addr }
+
+func (r *amd64Regs) Clone() Regs {
+	dup := *r
+	return &dup
+}
 
 func (r *amd64Regs) Arg(n int) uint64 {
 	switch n {

--- a/internal/ptrace/args_arm64.go
+++ b/internal/ptrace/args_arm64.go
@@ -12,7 +12,13 @@ func (r *arm64Regs) SyscallNr() int             { return int(int64(r.raw.Regs[8]
 func (r *arm64Regs) SetSyscallNr(nr int)         { r.raw.Regs[8] = uint64(nr) }
 func (r *arm64Regs) ReturnValue() int64          { return int64(r.raw.Regs[0]) }
 func (r *arm64Regs) SetReturnValue(v int64)      { r.raw.Regs[0] = uint64(v) }
-func (r *arm64Regs) InstructionPointer() uint64  { return r.raw.Pc }
+func (r *arm64Regs) InstructionPointer() uint64    { return r.raw.Pc }
+func (r *arm64Regs) SetInstructionPointer(addr uint64) { r.raw.Pc = addr }
+
+func (r *arm64Regs) Clone() Regs {
+	dup := *r
+	return &dup
+}
 
 func (r *arm64Regs) Arg(n int) uint64 {
 	if n < 0 || n > 5 {

--- a/internal/ptrace/args_test.go
+++ b/internal/ptrace/args_test.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package ptrace
+
+import "testing"
+
+func TestRegsClone(t *testing.T) {
+	r := createTestRegs()
+	r.SetSyscallNr(42)
+	r.SetArg(0, 0xDEAD)
+	r.SetReturnValue(99)
+
+	cloned := r.Clone()
+	if cloned.SyscallNr() != 42 {
+		t.Errorf("Clone SyscallNr: got %d, want 42", cloned.SyscallNr())
+	}
+	if cloned.Arg(0) != 0xDEAD {
+		t.Errorf("Clone Arg(0): got %d, want 0xDEAD", cloned.Arg(0))
+	}
+
+	// Mutating clone must not affect original
+	cloned.SetSyscallNr(99)
+	if r.SyscallNr() != 42 {
+		t.Errorf("Clone mutation leaked: original SyscallNr changed to %d", r.SyscallNr())
+	}
+}
+
+func TestRegsSetInstructionPointer(t *testing.T) {
+	r := createTestRegs()
+	r.SetInstructionPointer(0xCAFE)
+	if r.InstructionPointer() != 0xCAFE {
+		t.Errorf("SetInstructionPointer: got 0x%X, want 0xCAFE", r.InstructionPointer())
+	}
+}

--- a/internal/ptrace/args_test_amd64.go
+++ b/internal/ptrace/args_test_amd64.go
@@ -1,0 +1,7 @@
+//go:build linux && amd64
+
+package ptrace
+
+func createTestRegs() Regs {
+	return &amd64Regs{}
+}

--- a/internal/ptrace/args_test_arm64.go
+++ b/internal/ptrace/args_test_arm64.go
@@ -1,0 +1,7 @@
+//go:build linux && arm64
+
+package ptrace
+
+func createTestRegs() Regs {
+	return &arm64Regs{}
+}

--- a/internal/ptrace/attach.go
+++ b/internal/ptrace/attach.go
@@ -49,6 +49,47 @@ func (t *Tracer) attachThread(tid int) error {
 		return fmt.Errorf("PTRACE_SEIZE tid %d: %w", tid, err)
 	}
 
+	// PTRACE_SEIZE does not stop the tracee. We must interrupt it and wait
+	// for the ptrace-stop before calling PTRACE_SETOPTIONS, which requires
+	// the tracee to be stopped (otherwise it returns ESRCH).
+	if err := unix.PtraceInterrupt(tid); err != nil {
+		t.safeDetach(tid)
+		t.metrics.IncAttachFailure("other")
+		return fmt.Errorf("PTRACE_INTERRUPT tid %d: %w", tid, err)
+	}
+
+	// Wait for the interrupt stop with a timeout. Use WNOHANG to avoid
+	// blocking forever if Go's runtime reaps the child first (e.g., when
+	// cmd.Wait() races with our Wait4).
+	var status unix.WaitStatus
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		wpid, werr := unix.Wait4(tid, &status, unix.WNOHANG|unix.WALL, nil)
+		if werr != nil {
+			if werr == unix.EINTR {
+				continue
+			}
+			t.safeDetach(tid)
+			t.metrics.IncAttachFailure("other")
+			return fmt.Errorf("wait4 after interrupt tid %d: %w", tid, werr)
+		}
+		if wpid == tid {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.safeDetach(tid)
+			t.metrics.IncAttachFailure("other")
+			return fmt.Errorf("wait4 after interrupt tid %d: timed out", tid)
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	if !status.Stopped() {
+		t.safeDetach(tid)
+		t.metrics.IncAttachFailure("other")
+		return fmt.Errorf("tid %d: expected ptrace-stop after interrupt, got status %v", tid, status)
+	}
+
 	if err := unix.PtraceSetOptions(tid, t.ptraceOptions()); err != nil {
 		t.safeDetach(tid)
 		t.metrics.IncAttachFailure("other")
@@ -60,26 +101,6 @@ func (t *Tracer) attachThread(tid int) error {
 		t.safeDetach(tid)
 		t.metrics.IncAttachFailure("other")
 		return fmt.Errorf("read TGID for tid %d: %w", tid, err)
-	}
-
-	if err := unix.PtraceInterrupt(tid); err != nil {
-		t.safeDetach(tid)
-		t.metrics.IncAttachFailure("other")
-		return fmt.Errorf("PTRACE_INTERRUPT tid %d: %w", tid, err)
-	}
-
-	var status unix.WaitStatus
-	_, err = unix.Wait4(tid, &status, 0, nil)
-	if err != nil {
-		t.safeDetach(tid)
-		t.metrics.IncAttachFailure("other")
-		return fmt.Errorf("wait4 after interrupt tid %d: %w", tid, err)
-	}
-
-	if !status.Stopped() {
-		t.safeDetach(tid)
-		t.metrics.IncAttachFailure("other")
-		return fmt.Errorf("tid %d: expected ptrace-stop after interrupt, got status %v", tid, status)
 	}
 
 	if t.prefilterActive {
@@ -118,7 +139,7 @@ func (t *Tracer) safeDetach(tid int) {
 		return
 	}
 	var status unix.WaitStatus
-	if _, err := unix.Wait4(tid, &status, 0, nil); err != nil {
+	if _, err := unix.Wait4(tid, &status, unix.WNOHANG|unix.WALL, nil); err != nil {
 		return
 	}
 	if status.Stopped() {

--- a/internal/ptrace/attach.go
+++ b/internal/ptrace/attach.go
@@ -139,8 +139,19 @@ func (t *Tracer) safeDetach(tid int) {
 		return
 	}
 	var status unix.WaitStatus
-	if _, err := unix.Wait4(tid, &status, unix.WNOHANG|unix.WALL, nil); err != nil {
-		return
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for {
+		wpid, err := unix.Wait4(tid, &status, unix.WNOHANG|unix.WALL, nil)
+		if err != nil {
+			return
+		}
+		if wpid == tid {
+			break
+		}
+		if time.Now().After(deadline) {
+			return
+		}
+		time.Sleep(time.Millisecond)
 	}
 	if status.Stopped() {
 		unix.PtraceDetach(tid)

--- a/internal/ptrace/attach.go
+++ b/internal/ptrace/attach.go
@@ -123,10 +123,11 @@ func (t *Tracer) attachThread(tid int) error {
 
 	t.mu.Lock()
 	t.tracees[tid] = &TraceeState{
-		TID:      tid,
-		TGID:     tgid,
-		Attached: time.Now(),
-		MemFD:    memFD,
+		TID:               tid,
+		TGID:              tgid,
+		Attached:          time.Now(),
+		MemFD:             memFD,
+		PendingExecStubFD: -1,
 	}
 	t.metrics.SetTraceeCount(len(t.tracees))
 	t.mu.Unlock()

--- a/internal/ptrace/attach.go
+++ b/internal/ptrace/attach.go
@@ -136,6 +136,9 @@ func (t *Tracer) attachThread(tid int) error {
 
 func (t *Tracer) safeDetach(tid int) {
 	if err := unix.PtraceInterrupt(tid); err != nil {
+		// If interrupt fails (e.g., ESRCH), the tracee may have already
+		// exited. Try detach anyway in case it's still stopped.
+		unix.PtraceDetach(tid)
 		return
 	}
 	var status unix.WaitStatus
@@ -143,17 +146,20 @@ func (t *Tracer) safeDetach(tid int) {
 	for {
 		wpid, err := unix.Wait4(tid, &status, unix.WNOHANG|unix.WALL, nil)
 		if err != nil {
+			// Wait4 failed — try best-effort detach.
+			unix.PtraceDetach(tid)
 			return
 		}
 		if wpid == tid {
 			break
 		}
 		if time.Now().After(deadline) {
+			// Timed out waiting for stop. Try detach anyway to avoid
+			// leaving the tracee permanently ptrace-attached.
+			unix.PtraceDetach(tid)
 			return
 		}
 		time.Sleep(time.Millisecond)
 	}
-	if status.Stopped() {
-		unix.PtraceDetach(tid)
-	}
+	unix.PtraceDetach(tid)
 }

--- a/internal/ptrace/doc.go
+++ b/internal/ptrace/doc.go
@@ -5,14 +5,44 @@
 // and eBPF are unavailable (e.g., AWS Fargate with SYS_PTRACE).
 //
 // The tracer intercepts four categories of syscalls:
-//   - Exec: execve, execveat — command allow/deny via ExecHandler
+//   - Exec: execve, execveat — command allow/deny/redirect via ExecHandler
 //   - File: openat, openat2, unlinkat, renameat2, mkdirat, linkat, symlinkat,
 //     fchmodat, fchmodat2, fchownat (plus legacy amd64 equivalents) — file
-//     allow/deny via FileHandler with full path resolution and symlink handling
-//   - Network: connect, bind — network allow/deny via NetworkHandler with
-//     sockaddr parsing for AF_INET, AF_INET6, AF_UNIX, and AF_UNSPEC
+//     allow/deny/redirect/soft-delete via FileHandler with full path resolution
+//     and symlink handling
+//   - Network: connect, bind — network allow/deny/redirect via NetworkHandler
+//     with sockaddr parsing for AF_INET, AF_INET6, AF_UNIX, and AF_UNSPEC
 //   - Signal: kill, tkill, tgkill, rt_sigqueueinfo, rt_tgsigqueueinfo —
 //     signal allow/deny/redirect via SignalHandler
+//
+// Syscall steering (redirect/rewrite):
+//
+// The tracer includes a syscall injection engine that can execute arbitrary
+// syscalls inside a stopped tracee by saving registers, rewriting the
+// instruction pointer to a syscall gadget, doing two-phase PtraceSyscall,
+// and restoring state. This enables four steering actions:
+//
+//   - Exec redirect: redirects execve/execveat to a stub binary via fd
+//     injection (pidfd_open + pidfd_getfd + dup3) and filename rewrite.
+//     Supports in-place overwrite when the stub path fits, with fallback
+//     to scratch page allocation. Handles fd displacement (saves/restores
+//     pre-existing fds at the stub fd slot). Works for both execve and
+//     execveat (normalizes to execve with the stub path).
+//   - File path redirect: rewrites the path argument of any file syscall
+//     to a different path. Uses scratch page allocation (per-TGID mmap'd
+//     memory with bump allocator) when the redirect path is longer than
+//     the original.
+//   - Soft-delete: intercepts unlinkat/unlink, denies the original syscall,
+//     and injects mkdirat + renameat2 to move the file to a trash directory
+//     instead. The tracee sees unlink succeed (return 0).
+//   - Connect redirect: rewrites the sockaddr in tracee memory to redirect
+//     a connect() to a different address/port. Supports IPv4 and IPv6 with
+//     in-place overwrite (fixed-size sockaddr structs always fit).
+//
+// Architecture support: amd64 and arm64. The syscall gadget is discovered
+// by subtracting the syscall instruction size (2 bytes on amd64, 4 on arm64)
+// from the instruction pointer at a syscall stop. Legacy (non-at) file
+// syscalls (SYS_OPEN, SYS_UNLINK, etc.) are supported on amd64 only.
 //
 // Production hardening features:
 //   - max_hold_ms timeout enforcement: parked tracees (awaiting async policy

--- a/internal/ptrace/handle_file.go
+++ b/internal/ptrace/handle_file.go
@@ -174,15 +174,42 @@ func (t *Tracer) handleFile(ctx context.Context, tid int, regs Regs) {
 		Flags:     flags,
 	})
 
-	if !result.Allow {
+	// Dispatch based on Action field (new path) or Allow field (legacy path).
+	action := result.Action
+	if action == "" {
+		if result.Allow {
+			action = "allow"
+		} else {
+			action = "deny"
+		}
+	}
+
+	switch action {
+	case "deny":
 		errno := result.Errno
 		if errno == 0 {
 			errno = int32(unix.EACCES)
 		}
 		t.denySyscall(tid, int(errno))
-	} else {
+	case "redirect":
+		t.redirectFile(ctx, tid, regs, nr, result)
+	case "soft-delete":
+		t.softDeleteFile(ctx, tid, regs, result)
+	default:
 		t.allowSyscall(tid)
 	}
+}
+
+// redirectFile redirects a file syscall to a different path.
+func (t *Tracer) redirectFile(ctx context.Context, tid int, regs Regs, nr int, result FileResult) {
+	slog.Warn("redirectFile: not yet implemented, denying", "tid", tid)
+	t.denySyscall(tid, int(unix.EACCES))
+}
+
+// softDeleteFile performs a soft-delete by moving the file to trash.
+func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, result FileResult) {
+	slog.Warn("softDeleteFile: not yet implemented, denying", "tid", tid)
+	t.denySyscall(tid, int(unix.EACCES))
 }
 
 // extractFileArgs reads file syscall arguments from registers and tracee memory.

--- a/internal/ptrace/handle_file.go
+++ b/internal/ptrace/handle_file.go
@@ -139,13 +139,11 @@ func resolveParentFallback(full string) (string, error) {
 // handleFile intercepts file syscalls for policy evaluation.
 func (t *Tracer) handleFile(ctx context.Context, tid int, regs Regs) {
 	if t.cfg.FileHandler == nil || !t.cfg.TraceFile {
-		slog.Info("handleFile: skipping (no handler or trace disabled)", "tid", tid)
 		t.allowSyscall(tid)
 		return
 	}
 
 	nr := regs.SyscallNr()
-	slog.Info("handleFile: extracting args", "tid", tid, "nr", nr)
 
 	path, path2, flags, err := t.extractFileArgs(tid, nr, regs)
 	if err != nil {
@@ -175,8 +173,6 @@ func (t *Tracer) handleFile(ctx context.Context, tid int, regs Regs) {
 		Operation: operation,
 		Flags:     flags,
 	})
-
-	slog.Info("handleFile: handler returned", "tid", tid, "path", path, "operation", operation, "action", result.Action, "allow", result.Allow, "redirect", result.RedirectPath)
 
 	// Dispatch based on Action field (new path) or Allow field (legacy path).
 	action := result.Action

--- a/internal/ptrace/handle_file.go
+++ b/internal/ptrace/handle_file.go
@@ -185,6 +185,8 @@ func (t *Tracer) handleFile(ctx context.Context, tid int, regs Regs) {
 	}
 
 	switch action {
+	case "allow":
+		t.allowSyscall(tid)
 	case "deny":
 		errno := result.Errno
 		if errno == 0 {
@@ -196,7 +198,8 @@ func (t *Tracer) handleFile(ctx context.Context, tid int, regs Regs) {
 	case "soft-delete":
 		t.softDeleteFile(ctx, tid, regs, result)
 	default:
-		t.allowSyscall(tid)
+		slog.Warn("handleFile: unknown action, denying", "tid", tid, "action", action)
+		t.denySyscall(tid, int(unix.EACCES))
 	}
 }
 

--- a/internal/ptrace/handle_file.go
+++ b/internal/ptrace/handle_file.go
@@ -185,7 +185,7 @@ func (t *Tracer) handleFile(ctx context.Context, tid int, regs Regs) {
 	}
 
 	switch action {
-	case "allow":
+	case "allow", "continue":
 		t.allowSyscall(tid)
 	case "deny":
 		errno := result.Errno

--- a/internal/ptrace/handle_file.go
+++ b/internal/ptrace/handle_file.go
@@ -203,18 +203,6 @@ func (t *Tracer) handleFile(ctx context.Context, tid int, regs Regs) {
 	}
 }
 
-// redirectFile redirects a file syscall to a different path.
-func (t *Tracer) redirectFile(ctx context.Context, tid int, regs Regs, nr int, result FileResult) {
-	slog.Warn("redirectFile: not yet implemented, denying", "tid", tid)
-	t.denySyscall(tid, int(unix.EACCES))
-}
-
-// softDeleteFile performs a soft-delete by moving the file to trash.
-func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, result FileResult) {
-	slog.Warn("softDeleteFile: not yet implemented, denying", "tid", tid)
-	t.denySyscall(tid, int(unix.EACCES))
-}
-
 // extractFileArgs reads file syscall arguments from registers and tracee memory.
 func (t *Tracer) extractFileArgs(tid int, nr int, regs Regs) (path, path2 string, flags int, err error) {
 	switch nr {

--- a/internal/ptrace/handle_file.go
+++ b/internal/ptrace/handle_file.go
@@ -139,11 +139,13 @@ func resolveParentFallback(full string) (string, error) {
 // handleFile intercepts file syscalls for policy evaluation.
 func (t *Tracer) handleFile(ctx context.Context, tid int, regs Regs) {
 	if t.cfg.FileHandler == nil || !t.cfg.TraceFile {
+		slog.Info("handleFile: skipping (no handler or trace disabled)", "tid", tid)
 		t.allowSyscall(tid)
 		return
 	}
 
 	nr := regs.SyscallNr()
+	slog.Info("handleFile: extracting args", "tid", tid, "nr", nr)
 
 	path, path2, flags, err := t.extractFileArgs(tid, nr, regs)
 	if err != nil {
@@ -174,6 +176,8 @@ func (t *Tracer) handleFile(ctx context.Context, tid int, regs Regs) {
 		Flags:     flags,
 	})
 
+	slog.Info("handleFile: handler returned", "tid", tid, "path", path, "operation", operation, "action", result.Action, "allow", result.Allow, "redirect", result.RedirectPath)
+
 	// Dispatch based on Action field (new path) or Allow field (legacy path).
 	action := result.Action
 	if action == "" {
@@ -196,7 +200,7 @@ func (t *Tracer) handleFile(ctx context.Context, tid int, regs Regs) {
 	case "redirect":
 		t.redirectFile(ctx, tid, regs, nr, result)
 	case "soft-delete":
-		t.softDeleteFile(ctx, tid, regs, result)
+		t.softDeleteFile(ctx, tid, regs, path, result)
 	default:
 		slog.Warn("handleFile: unknown action, denying", "tid", tid, "action", action)
 		t.denySyscall(tid, int(unix.EACCES))

--- a/internal/ptrace/handle_network.go
+++ b/internal/ptrace/handle_network.go
@@ -150,6 +150,8 @@ func (t *Tracer) handleNetwork(ctx context.Context, tid int, regs Regs) {
 	}
 
 	switch action {
+	case "allow":
+		t.allowSyscall(tid)
 	case "deny":
 		errno := result.Errno
 		if errno == 0 {
@@ -159,7 +161,8 @@ func (t *Tracer) handleNetwork(ctx context.Context, tid int, regs Regs) {
 	case "redirect":
 		t.redirectConnect(ctx, tid, regs, result)
 	default:
-		t.allowSyscall(tid)
+		slog.Warn("handleNetwork: unknown action, denying", "tid", tid, "action", action)
+		t.denySyscall(tid, int(unix.EACCES))
 	}
 }
 

--- a/internal/ptrace/handle_network.go
+++ b/internal/ptrace/handle_network.go
@@ -139,13 +139,32 @@ func (t *Tracer) handleNetwork(ctx context.Context, tid int, regs Regs) {
 		Operation: operation,
 	})
 
-	if !result.Allow {
+	// Dispatch based on Action field (new path) or Allow field (legacy path).
+	action := result.Action
+	if action == "" {
+		if result.Allow {
+			action = "allow"
+		} else {
+			action = "deny"
+		}
+	}
+
+	switch action {
+	case "deny":
 		errno := result.Errno
 		if errno == 0 {
 			errno = int32(unix.EACCES)
 		}
 		t.denySyscall(tid, int(errno))
-	} else {
+	case "redirect":
+		t.redirectConnect(ctx, tid, regs, result)
+	default:
 		t.allowSyscall(tid)
 	}
+}
+
+// redirectConnect redirects a connect syscall to a different address.
+func (t *Tracer) redirectConnect(ctx context.Context, tid int, regs Regs, result NetworkResult) {
+	slog.Warn("redirectConnect: not yet implemented, denying", "tid", tid)
+	t.denySyscall(tid, int(unix.EACCES))
 }

--- a/internal/ptrace/handle_network.go
+++ b/internal/ptrace/handle_network.go
@@ -75,13 +75,11 @@ func parseSockaddr(buf []byte) (family int, address string, port int, err error)
 // handleNetwork intercepts network syscalls for policy evaluation.
 func (t *Tracer) handleNetwork(ctx context.Context, tid int, regs Regs) {
 	if t.cfg.NetworkHandler == nil || !t.cfg.TraceNetwork {
-		slog.Info("handleNetwork: skipping", "tid", tid)
 		t.allowSyscall(tid)
 		return
 	}
 
 	nr := regs.SyscallNr()
-	slog.Info("handleNetwork: dispatching", "tid", tid, "nr", nr)
 
 	// Only evaluate policy for connect and bind
 	if nr != unix.SYS_CONNECT && nr != unix.SYS_BIND {

--- a/internal/ptrace/handle_network.go
+++ b/internal/ptrace/handle_network.go
@@ -165,9 +165,3 @@ func (t *Tracer) handleNetwork(ctx context.Context, tid int, regs Regs) {
 		t.denySyscall(tid, int(unix.EACCES))
 	}
 }
-
-// redirectConnect redirects a connect syscall to a different address.
-func (t *Tracer) redirectConnect(ctx context.Context, tid int, regs Regs, result NetworkResult) {
-	slog.Warn("redirectConnect: not yet implemented, denying", "tid", tid)
-	t.denySyscall(tid, int(unix.EACCES))
-}

--- a/internal/ptrace/handle_network.go
+++ b/internal/ptrace/handle_network.go
@@ -75,11 +75,13 @@ func parseSockaddr(buf []byte) (family int, address string, port int, err error)
 // handleNetwork intercepts network syscalls for policy evaluation.
 func (t *Tracer) handleNetwork(ctx context.Context, tid int, regs Regs) {
 	if t.cfg.NetworkHandler == nil || !t.cfg.TraceNetwork {
+		slog.Info("handleNetwork: skipping", "tid", tid)
 		t.allowSyscall(tid)
 		return
 	}
 
 	nr := regs.SyscallNr()
+	slog.Info("handleNetwork: dispatching", "tid", tid, "nr", nr)
 
 	// Only evaluate policy for connect and bind
 	if nr != unix.SYS_CONNECT && nr != unix.SYS_BIND {

--- a/internal/ptrace/handle_network.go
+++ b/internal/ptrace/handle_network.go
@@ -150,7 +150,7 @@ func (t *Tracer) handleNetwork(ctx context.Context, tid int, regs Regs) {
 	}
 
 	switch action {
-	case "allow":
+	case "allow", "continue":
 		t.allowSyscall(tid)
 	case "deny":
 		errno := result.Errno

--- a/internal/ptrace/handle_network.go
+++ b/internal/ptrace/handle_network.go
@@ -159,7 +159,15 @@ func (t *Tracer) handleNetwork(ctx context.Context, tid int, regs Regs) {
 		}
 		t.denySyscall(tid, int(errno))
 	case "redirect":
-		t.redirectConnect(ctx, tid, regs, result)
+		// Redirect is only supported for connect; deny bind-redirect to
+		// avoid unintentionally mutating bind behavior.
+		if nr == unix.SYS_CONNECT {
+			t.redirectConnect(ctx, tid, regs, result)
+		} else {
+			slog.Warn("handleNetwork: redirect not supported for this syscall, denying",
+				"tid", tid, "operation", operation)
+			t.denySyscall(tid, int(unix.EACCES))
+		}
 	default:
 		slog.Warn("handleNetwork: unknown action, denying", "tid", tid, "action", action)
 		t.denySyscall(tid, int(unix.EACCES))

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -207,7 +207,13 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 			return nil
 		}
 
-		// Ptrace event stops (fork, clone, exec, seccomp, etc.) report
+		// PTRACE_EVENT_SECCOMP is a syscall-entry-equivalent stop.
+		// Treat it as a syscall stop to keep injection phases in sync.
+		if sig == unix.SIGTRAP && status.TrapCause() == unix.PTRACE_EVENT_SECCOMP {
+			return nil
+		}
+
+		// Other ptrace event stops (fork, clone, exec, etc.) report
 		// SIGTRAP with a non-zero TrapCause. Resume with signal 0.
 		if sig == unix.SIGTRAP && status.TrapCause() != 0 {
 			if err := unix.PtraceSyscall(tid, 0); err != nil {

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -236,3 +236,31 @@ func (t *Tracer) injectSyscallRet(tid int, savedRegs Regs, nr int, args ...uint6
 	}
 	return uint64(ret), nil
 }
+
+// advancePastEntry nullifies the current syscall entry and advances the tracee
+// to the EXIT stop. This allows subsequent injections to use the two-phase
+// gadget protocol. The original registers are restored afterward and InSyscall
+// is set to false.
+func (t *Tracer) advancePastEntry(tid int, savedRegs Regs) error {
+	nullRegs := savedRegs.Clone()
+	nullRegs.SetSyscallNr(-1)
+	nullRegs.SetReturnValue(-1)
+	if err := t.setRegs(tid, nullRegs); err != nil {
+		return fmt.Errorf("advance setRegs: %w", err)
+	}
+	if err := unix.PtraceSyscall(tid, 0); err != nil {
+		return fmt.Errorf("advance resume: %w", err)
+	}
+	if err := t.waitForSyscallStop(tid); err != nil {
+		return fmt.Errorf("advance wait: %w", err)
+	}
+	if err := t.setRegs(tid, savedRegs); err != nil {
+		return fmt.Errorf("advance restore: %w", err)
+	}
+	t.mu.Lock()
+	if state := t.tracees[tid]; state != nil {
+		state.InSyscall = false
+	}
+	t.mu.Unlock()
+	return nil
+}

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -181,12 +181,16 @@ func (t *Tracer) injectFromExit(tid int, savedRegs Regs, nr int, args ...uint64)
 // prefilter/seccomp mode (syscall stops report plain SIGTRAP with no event).
 func (t *Tracer) waitForSyscallStop(tid int) error {
 	const (
-		maxAttempts = 100 // guard against infinite loop from unexpected stops
-		timeout     = 5 * time.Second
-		pollDelay   = 200 * time.Microsecond
+		maxStopEvents = 100 // guard against infinite loop from unexpected stop events
+		timeout       = 5 * time.Second
+		pollDelay     = 200 * time.Microsecond
 	)
 	deadline := time.Now().Add(timeout)
-	for attempt := 0; attempt < maxAttempts; attempt++ {
+	stopEvents := 0
+	for {
+		if time.Now().After(deadline) {
+			return fmt.Errorf("waitForSyscallStop tid %d: timed out after %v", tid, timeout)
+		}
 		var status unix.WaitStatus
 		wpid, err := unix.Wait4(tid, &status, unix.WNOHANG, nil)
 		if err != nil {
@@ -196,10 +200,7 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 			return fmt.Errorf("wait4 tid %d: %w", tid, err)
 		}
 		if wpid == 0 {
-			// Tracee hasn't stopped yet; check deadline.
-			if time.Now().After(deadline) {
-				return fmt.Errorf("waitForSyscallStop tid %d: timed out after %v", tid, timeout)
-			}
+			// Tracee hasn't stopped yet.
 			time.Sleep(pollDelay)
 			continue
 		}
@@ -234,6 +235,10 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 		// Other ptrace event stops (fork, clone, exec, etc.) report
 		// SIGTRAP with a non-zero TrapCause. Resume with signal 0.
 		if sig == unix.SIGTRAP && status.TrapCause() != 0 {
+			stopEvents++
+			if stopEvents >= maxStopEvents {
+				return fmt.Errorf("waitForSyscallStop tid %d: exceeded %d non-progress stop events", tid, maxStopEvents)
+			}
 			if err := unix.PtraceSyscall(tid, 0); err != nil {
 				return fmt.Errorf("inject re-resume tid %d: %w", tid, err)
 			}
@@ -241,11 +246,14 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 		}
 
 		// Real signal delivery: reinject the signal.
+		stopEvents++
+		if stopEvents >= maxStopEvents {
+			return fmt.Errorf("waitForSyscallStop tid %d: exceeded %d non-progress stop events", tid, maxStopEvents)
+		}
 		if err := unix.PtraceSyscall(tid, int(sig)); err != nil {
 			return fmt.Errorf("inject re-resume tid %d: %w", tid, err)
 		}
 	}
-	return fmt.Errorf("waitForSyscallStop tid %d: exceeded %d attempts", tid, maxAttempts)
 }
 
 // injectSyscallRet is a convenience that returns an error if the injected

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -192,7 +192,7 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 			return fmt.Errorf("waitForSyscallStop tid %d: timed out after %v", tid, timeout)
 		}
 		var status unix.WaitStatus
-		wpid, err := unix.Wait4(tid, &status, unix.WNOHANG, nil)
+		wpid, err := unix.Wait4(tid, &status, unix.WNOHANG|unix.WALL, nil)
 		if err != nil {
 			if err == unix.EINTR {
 				continue

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -91,8 +91,11 @@ func (t *Tracer) injectSyscall(tid int, savedRegs Regs, nr int, args ...uint64) 
 
 // waitForSyscallStop waits for the specified tid to hit a syscall stop.
 // It uses waitpid with the specific tid to avoid consuming other tracees' events.
-// Returns errTraceeExited if the tracee exits during the wait, after performing
+// Returns an error if the tracee exits during the wait, after performing
 // bookkeeping cleanup.
+//
+// Handles both TRACESYSGOOD mode (syscall stops report SIGTRAP|0x80) and
+// prefilter/seccomp mode (syscall stops report plain SIGTRAP with no event).
 func (t *Tracer) waitForSyscallStop(tid int) error {
 	const maxAttempts = 100 // guard against infinite loop from unexpected stops
 	for attempt := 0; attempt < maxAttempts; attempt++ {
@@ -101,28 +104,40 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 		if err != nil {
 			return fmt.Errorf("wait4 tid %d: %w", tid, err)
 		}
-		if status.Stopped() && status.StopSignal() == unix.SIGTRAP|0x80 {
+		if !status.Stopped() {
+			if status.Exited() || status.Signaled() {
+				// Clean up tracee bookkeeping before returning.
+				t.handleExit(tid)
+				return fmt.Errorf("tracee %d exited during injection", tid)
+			}
+			continue
+		}
+
+		sig := status.StopSignal()
+
+		// TRACESYSGOOD mode: syscall stops have SIGTRAP|0x80.
+		if sig == unix.SIGTRAP|0x80 {
 			return nil
 		}
-		// Handle other stopped states: distinguish ptrace event stops
-		// from real signal-delivery stops.
-		if status.Stopped() {
-			sig := int(status.StopSignal())
-			// Ptrace event stops (fork, clone, exec, seccomp, etc.) report
-			// SIGTRAP with a non-zero TrapCause. These are not real signals
-			// and must be resumed with signal 0 to avoid injecting SIGTRAP.
-			if sig == int(unix.SIGTRAP) && status.TrapCause() != 0 {
-				sig = 0
-			}
-			if err := unix.PtraceSyscall(tid, sig); err != nil {
+
+		// Non-TRACESYSGOOD mode: plain SIGTRAP with no ptrace event
+		// is a syscall stop.
+		if sig == unix.SIGTRAP && status.TrapCause() == 0 {
+			return nil
+		}
+
+		// Ptrace event stops (fork, clone, exec, seccomp, etc.) report
+		// SIGTRAP with a non-zero TrapCause. Resume with signal 0.
+		if sig == unix.SIGTRAP && status.TrapCause() != 0 {
+			if err := unix.PtraceSyscall(tid, 0); err != nil {
 				return fmt.Errorf("inject re-resume tid %d: %w", tid, err)
 			}
 			continue
 		}
-		if status.Exited() || status.Signaled() {
-			// Clean up tracee bookkeeping before returning.
-			t.handleExit(tid)
-			return fmt.Errorf("tracee %d exited during injection", tid)
+
+		// Real signal delivery: reinject the signal.
+		if err := unix.PtraceSyscall(tid, int(sig)); err != nil {
+			return fmt.Errorf("inject re-resume tid %d: %w", tid, err)
 		}
 	}
 	return fmt.Errorf("waitForSyscallStop tid %d: exceeded %d attempts", tid, maxAttempts)

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -1,0 +1,112 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// injectSyscall executes an arbitrary syscall inside a stopped tracee.
+//
+// The tracee MUST be stopped at a syscall-enter or PTRACE_EVENT_SECCOMP stop
+// so that the instruction pointer can be used to locate a syscall gadget.
+//
+// Sequence:
+//  1. Save current registers (caller passes savedRegs)
+//  2. Set up injected syscall (nr + up to 6 args)
+//  3. Set IP to the syscall instruction gadget
+//  4. Resume with PtraceSyscall -> wait for syscall-enter stop
+//  5. Resume with PtraceSyscall -> wait for syscall-exit stop
+//  6. Read return value
+//  7. Restore original registers
+//
+// Returns the syscall return value, or an error if any ptrace operation fails.
+func (t *Tracer) injectSyscall(tid int, savedRegs Regs, nr int, args ...uint64) (int64, error) {
+	gadget := syscallGadgetAddr(savedRegs)
+
+	// Build injection registers from a clone of saved state.
+	injRegs := savedRegs.Clone()
+	injRegs.SetSyscallNr(nr)
+	for i, v := range args {
+		if i > 5 {
+			break
+		}
+		injRegs.SetArg(i, v)
+	}
+	injRegs.SetInstructionPointer(gadget)
+
+	if err := t.setRegs(tid, injRegs); err != nil {
+		return 0, fmt.Errorf("inject setRegs: %w", err)
+	}
+
+	// Phase 1: resume -> wait for syscall-enter stop.
+	if err := unix.PtraceSyscall(tid, 0); err != nil {
+		return 0, fmt.Errorf("inject resume-enter: %w", err)
+	}
+	if err := t.waitForSyscallStop(tid); err != nil {
+		return 0, fmt.Errorf("inject wait-enter: %w", err)
+	}
+
+	// Phase 2: resume -> wait for syscall-exit stop.
+	if err := unix.PtraceSyscall(tid, 0); err != nil {
+		return 0, fmt.Errorf("inject resume-exit: %w", err)
+	}
+	if err := t.waitForSyscallStop(tid); err != nil {
+		return 0, fmt.Errorf("inject wait-exit: %w", err)
+	}
+
+	// Read return value.
+	retRegs, err := t.getRegs(tid)
+	if err != nil {
+		return 0, fmt.Errorf("inject getRegs: %w", err)
+	}
+	ret := retRegs.ReturnValue()
+
+	// Restore original registers.
+	if err := t.setRegs(tid, savedRegs); err != nil {
+		return 0, fmt.Errorf("inject restore: %w", err)
+	}
+
+	return ret, nil
+}
+
+// waitForSyscallStop waits for the specified tid to hit a syscall stop.
+// It uses waitpid with the specific tid to avoid consuming other tracees' events.
+func (t *Tracer) waitForSyscallStop(tid int) error {
+	for {
+		var status unix.WaitStatus
+		_, err := unix.Wait4(tid, &status, 0, nil)
+		if err != nil {
+			return fmt.Errorf("wait4 tid %d: %w", tid, err)
+		}
+		if status.Stopped() && status.StopSignal() == unix.SIGTRAP|0x80 {
+			return nil
+		}
+		// If the tracee received a signal during injection, suppress it
+		// and continue waiting for the syscall stop.
+		if status.Stopped() {
+			if err := unix.PtraceSyscall(tid, 0); err != nil {
+				return fmt.Errorf("inject re-resume tid %d: %w", tid, err)
+			}
+			continue
+		}
+		if status.Exited() || status.Signaled() {
+			return fmt.Errorf("tracee %d exited during injection", tid)
+		}
+	}
+}
+
+// injectSyscallRet is a convenience that returns an error if the injected
+// syscall returned a negative errno value.
+func (t *Tracer) injectSyscallRet(tid int, savedRegs Regs, nr int, args ...uint64) (uint64, error) {
+	ret, err := t.injectSyscall(tid, savedRegs, nr, args...)
+	if err != nil {
+		return 0, err
+	}
+	if ret < 0 {
+		return 0, fmt.Errorf("injected syscall %d returned %d (%s)", nr, ret, unix.Errno(-ret))
+	}
+	return uint64(ret), nil
+}

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -102,6 +102,9 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 		var status unix.WaitStatus
 		_, err := unix.Wait4(tid, &status, 0, nil)
 		if err != nil {
+			if err == unix.EINTR {
+				continue
+			}
 			return fmt.Errorf("wait4 tid %d: %w", tid, err)
 		}
 		if !status.Stopped() {
@@ -132,6 +135,11 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 
 		// Ptrace event stops (fork, clone, exec, seccomp, etc.) report
 		// SIGTRAP with a non-zero TrapCause. Resume with signal 0.
+		// Note: injected syscalls (mmap for scratch pages) should not
+		// trigger fork/clone/exec events. Seccomp events are possible
+		// but unlikely for MAP_ANONYMOUS mmap. If they do occur, we
+		// skip normal event handling since the injection must complete
+		// atomically before the tracer loop can process further events.
 		if sig == unix.SIGTRAP && status.TrapCause() != 0 {
 			if err := unix.PtraceSyscall(tid, 0); err != nil {
 				return fmt.Errorf("inject re-resume tid %d: %w", tid, err)

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -4,6 +4,7 @@ package ptrace
 
 import (
 	"fmt"
+	"log/slog"
 
 	"golang.org/x/sys/unix"
 )
@@ -41,26 +42,42 @@ func (t *Tracer) injectSyscall(tid int, savedRegs Regs, nr int, args ...uint64) 
 		return 0, fmt.Errorf("inject setRegs: %w", err)
 	}
 
+	// Best-effort register restore on any failure after setRegs succeeds.
+	var injectErr error
+	defer func() {
+		if injectErr != nil {
+			if restoreErr := t.setRegs(tid, savedRegs); restoreErr != nil {
+				slog.Warn("inject: failed to restore registers after error",
+					"tid", tid, "injectErr", injectErr, "restoreErr", restoreErr)
+			}
+		}
+	}()
+
 	// Phase 1: resume -> wait for syscall-enter stop.
 	if err := unix.PtraceSyscall(tid, 0); err != nil {
-		return 0, fmt.Errorf("inject resume-enter: %w", err)
+		injectErr = fmt.Errorf("inject resume-enter: %w", err)
+		return 0, injectErr
 	}
 	if err := t.waitForSyscallStop(tid); err != nil {
-		return 0, fmt.Errorf("inject wait-enter: %w", err)
+		injectErr = fmt.Errorf("inject wait-enter: %w", err)
+		return 0, injectErr
 	}
 
 	// Phase 2: resume -> wait for syscall-exit stop.
 	if err := unix.PtraceSyscall(tid, 0); err != nil {
-		return 0, fmt.Errorf("inject resume-exit: %w", err)
+		injectErr = fmt.Errorf("inject resume-exit: %w", err)
+		return 0, injectErr
 	}
 	if err := t.waitForSyscallStop(tid); err != nil {
-		return 0, fmt.Errorf("inject wait-exit: %w", err)
+		injectErr = fmt.Errorf("inject wait-exit: %w", err)
+		return 0, injectErr
 	}
 
 	// Read return value.
 	retRegs, err := t.getRegs(tid)
 	if err != nil {
-		return 0, fmt.Errorf("inject getRegs: %w", err)
+		injectErr = fmt.Errorf("inject getRegs: %w", err)
+		return 0, injectErr
 	}
 	ret := retRegs.ReturnValue()
 
@@ -84,10 +101,11 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 		if status.Stopped() && status.StopSignal() == unix.SIGTRAP|0x80 {
 			return nil
 		}
-		// If the tracee received a signal during injection, suppress it
-		// and continue waiting for the syscall stop.
+		// If the tracee received a signal during injection, reinject it
+		// so it is not lost, then continue waiting for the syscall stop.
 		if status.Stopped() {
-			if err := unix.PtraceSyscall(tid, 0); err != nil {
+			sig := int(status.StopSignal())
+			if err := unix.PtraceSyscall(tid, sig); err != nil {
 				return fmt.Errorf("inject re-resume tid %d: %w", tid, err)
 			}
 			continue

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -91,8 +91,11 @@ func (t *Tracer) injectSyscall(tid int, savedRegs Regs, nr int, args ...uint64) 
 
 // waitForSyscallStop waits for the specified tid to hit a syscall stop.
 // It uses waitpid with the specific tid to avoid consuming other tracees' events.
+// Returns errTraceeExited if the tracee exits during the wait, after performing
+// bookkeeping cleanup.
 func (t *Tracer) waitForSyscallStop(tid int) error {
-	for {
+	const maxAttempts = 100 // guard against infinite loop from unexpected stops
+	for attempt := 0; attempt < maxAttempts; attempt++ {
 		var status unix.WaitStatus
 		_, err := unix.Wait4(tid, &status, 0, nil)
 		if err != nil {
@@ -117,9 +120,12 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 			continue
 		}
 		if status.Exited() || status.Signaled() {
+			// Clean up tracee bookkeeping before returning.
+			t.handleExit(tid)
 			return fmt.Errorf("tracee %d exited during injection", tid)
 		}
 	}
+	return fmt.Errorf("waitForSyscallStop tid %d: exceeded %d attempts", tid, maxAttempts)
 }
 
 // injectSyscallRet is a convenience that returns an error if the injected

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -220,9 +220,10 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 			return nil
 		}
 
-		// Non-TRACESYSGOOD mode: plain SIGTRAP with no ptrace event
-		// is a syscall stop.
-		if sig == unix.SIGTRAP && status.TrapCause() == 0 {
+		// Non-TRACESYSGOOD (prefilter) mode: plain SIGTRAP with no ptrace
+		// event is a syscall stop. In TRACESYSGOOD mode, plain SIGTRAP is a
+		// real signal — reinject it below.
+		if sig == unix.SIGTRAP && status.TrapCause() == 0 && !t.traceSysGood() {
 			return nil
 		}
 

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -101,10 +101,16 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 		if status.Stopped() && status.StopSignal() == unix.SIGTRAP|0x80 {
 			return nil
 		}
-		// If the tracee received a signal during injection, reinject it
-		// so it is not lost, then continue waiting for the syscall stop.
+		// Handle other stopped states: distinguish ptrace event stops
+		// from real signal-delivery stops.
 		if status.Stopped() {
 			sig := int(status.StopSignal())
+			// Ptrace event stops (fork, clone, exec, seccomp, etc.) report
+			// SIGTRAP with a non-zero TrapCause. These are not real signals
+			// and must be resumed with signal 0 to avoid injecting SIGTRAP.
+			if sig == int(unix.SIGTRAP) && status.TrapCause() != 0 {
+				sig = 0
+			}
 			if err := unix.PtraceSyscall(tid, sig); err != nil {
 				return fmt.Errorf("inject re-resume tid %d: %w", tid, err)
 			}

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -11,25 +11,106 @@ import (
 
 // injectSyscall executes an arbitrary syscall inside a stopped tracee.
 //
-// The tracee MUST be stopped at a syscall-enter or PTRACE_EVENT_SECCOMP stop
-// so that the instruction pointer can be used to locate a syscall gadget.
+// Works from two stop states:
 //
-// Sequence:
-//  1. Save current registers (caller passes savedRegs)
-//  2. Set up injected syscall (nr + up to 6 args)
-//  3. Set IP to the syscall instruction gadget
-//  4. Resume with PtraceSyscall -> wait for syscall-enter stop
-//  5. Resume with PtraceSyscall -> wait for syscall-exit stop
-//  6. Read return value
-//  7. Restore original registers
+//   - Syscall-enter (InSyscall=true): modifies ORIG_RAX in place so the kernel
+//     dispatches the injected syscall instead of the original. One PtraceSyscall
+//     cycle reaches the exit stop where the return value is available.
 //
-// Returns the syscall return value, or an error if any ptrace operation fails.
+//   - Between syscalls / exit stop (InSyscall=false): sets the instruction
+//     pointer to a syscall gadget (the `syscall` instruction from the original
+//     stop site). Two PtraceSyscall cycles: first to reach the gadget's
+//     syscall-enter, second to reach its exit.
+//
+// After reading the return value, the original registers are restored and
+// InSyscall is set to false (the tracee is always left at a syscall-exit stop).
 func (t *Tracer) injectSyscall(tid int, savedRegs Regs, nr int, args ...uint64) (int64, error) {
-	gadget := syscallGadgetAddr(savedRegs)
+	// Determine whether we're at a syscall-enter or between syscalls.
+	atEntry := false
+	t.mu.Lock()
+	if state := t.tracees[tid]; state != nil {
+		atEntry = state.InSyscall
+	}
+	t.mu.Unlock()
 
-	// Build injection registers from a clone of saved state.
+	if atEntry {
+		return t.injectFromEntry(tid, savedRegs, nr, args...)
+	}
+	return t.injectFromExit(tid, savedRegs, nr, args...)
+}
+
+// injectFromEntry handles injection when the tracee is at a syscall-enter stop.
+// Modifying ORIG_RAX replaces the current syscall. One cycle to exit.
+func (t *Tracer) injectFromEntry(tid int, savedRegs Regs, nr int, args ...uint64) (int64, error) {
 	injRegs := savedRegs.Clone()
 	injRegs.SetSyscallNr(nr)
+	// On amd64, the CPU reads the syscall number from RAX, not ORIG_RAX.
+	// SetSyscallNr sets ORIG_RAX; we must also set RAX.
+	injRegs.SetReturnValue(int64(nr))
+	for i, v := range args {
+		if i > 5 {
+			break
+		}
+		injRegs.SetArg(i, v)
+	}
+	// Don't change IP — we're hijacking the current syscall entry.
+
+	if err := t.setRegs(tid, injRegs); err != nil {
+		return 0, fmt.Errorf("inject setRegs: %w", err)
+	}
+
+	var injectErr error
+	defer func() {
+		if injectErr != nil {
+			if restoreErr := t.setRegs(tid, savedRegs); restoreErr != nil {
+				slog.Warn("inject: failed to restore registers after error",
+					"tid", tid, "injectErr", injectErr, "restoreErr", restoreErr)
+			}
+		}
+	}()
+
+	// Resume → kernel dispatches our modified syscall → exit stop.
+	if err := unix.PtraceSyscall(tid, 0); err != nil {
+		injectErr = fmt.Errorf("inject resume: %w", err)
+		return 0, injectErr
+	}
+	if err := t.waitForSyscallStop(tid); err != nil {
+		injectErr = fmt.Errorf("inject wait-exit: %w", err)
+		return 0, injectErr
+	}
+
+	retRegs, err := t.getRegs(tid)
+	if err != nil {
+		injectErr = fmt.Errorf("inject getRegs: %w", err)
+		return 0, injectErr
+	}
+	ret := retRegs.ReturnValue()
+
+	// Restore original registers.
+	if err := t.setRegs(tid, savedRegs); err != nil {
+		return 0, fmt.Errorf("inject restore: %w", err)
+	}
+
+	// We consumed the enter→exit transition. Mark as exit state so
+	// subsequent injections use the two-phase gadget protocol.
+	t.mu.Lock()
+	if state := t.tracees[tid]; state != nil {
+		state.InSyscall = false
+	}
+	t.mu.Unlock()
+
+	return ret, nil
+}
+
+// injectFromExit handles injection when the tracee is at a syscall-exit
+// (between-syscall) stop. Uses a gadget: sets IP to the `syscall` instruction,
+// two cycles (enter + exit).
+func (t *Tracer) injectFromExit(tid int, savedRegs Regs, nr int, args ...uint64) (int64, error) {
+	gadget := syscallGadgetAddr(savedRegs)
+
+	injRegs := savedRegs.Clone()
+	injRegs.SetSyscallNr(nr)
+	injRegs.SetReturnValue(int64(nr))
 	for i, v := range args {
 		if i > 5 {
 			break
@@ -42,7 +123,6 @@ func (t *Tracer) injectSyscall(tid int, savedRegs Regs, nr int, args ...uint64) 
 		return 0, fmt.Errorf("inject setRegs: %w", err)
 	}
 
-	// Best-effort register restore on any failure after setRegs succeeds.
 	var injectErr error
 	defer func() {
 		if injectErr != nil {
@@ -53,7 +133,7 @@ func (t *Tracer) injectSyscall(tid int, savedRegs Regs, nr int, args ...uint64) 
 		}
 	}()
 
-	// Phase 1: resume -> wait for syscall-enter stop.
+	// Phase 1: resume → tracee returns to gadget → executes syscall → enter stop.
 	if err := unix.PtraceSyscall(tid, 0); err != nil {
 		injectErr = fmt.Errorf("inject resume-enter: %w", err)
 		return 0, injectErr
@@ -63,7 +143,7 @@ func (t *Tracer) injectSyscall(tid int, savedRegs Regs, nr int, args ...uint64) 
 		return 0, injectErr
 	}
 
-	// Phase 2: resume -> wait for syscall-exit stop.
+	// Phase 2: resume → kernel dispatches injected syscall → exit stop.
 	if err := unix.PtraceSyscall(tid, 0); err != nil {
 		injectErr = fmt.Errorf("inject resume-exit: %w", err)
 		return 0, injectErr
@@ -73,7 +153,6 @@ func (t *Tracer) injectSyscall(tid int, savedRegs Regs, nr int, args ...uint64) 
 		return 0, injectErr
 	}
 
-	// Read return value.
 	retRegs, err := t.getRegs(tid)
 	if err != nil {
 		injectErr = fmt.Errorf("inject getRegs: %w", err)
@@ -81,7 +160,6 @@ func (t *Tracer) injectSyscall(tid int, savedRegs Regs, nr int, args ...uint64) 
 	}
 	ret := retRegs.ReturnValue()
 
-	// Restore original registers.
 	if err := t.setRegs(tid, savedRegs); err != nil {
 		return 0, fmt.Errorf("inject restore: %w", err)
 	}
@@ -124,22 +202,13 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 		}
 
 		// Non-TRACESYSGOOD mode: plain SIGTRAP with no ptrace event
-		// is a syscall stop. In theory a real SIGTRAP signal delivery
-		// could match this pattern, but during the brief injection
-		// window (two syscall stops) this is extremely unlikely.
-		// The alternative (PTRACE_GETSIGINFO si_code check) adds
-		// complexity with minimal practical benefit.
+		// is a syscall stop.
 		if sig == unix.SIGTRAP && status.TrapCause() == 0 {
 			return nil
 		}
 
 		// Ptrace event stops (fork, clone, exec, seccomp, etc.) report
 		// SIGTRAP with a non-zero TrapCause. Resume with signal 0.
-		// Note: injected syscalls (mmap for scratch pages) should not
-		// trigger fork/clone/exec events. Seccomp events are possible
-		// but unlikely for MAP_ANONYMOUS mmap. If they do occur, we
-		// skip normal event handling since the injection must complete
-		// atomically before the tracer loop can process further events.
 		if sig == unix.SIGTRAP && status.TrapCause() != 0 {
 			if err := unix.PtraceSyscall(tid, 0); err != nil {
 				return fmt.Errorf("inject re-resume tid %d: %w", tid, err)

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -5,6 +5,7 @@ package ptrace
 import (
 	"fmt"
 	"log/slog"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -172,18 +173,35 @@ func (t *Tracer) injectFromExit(tid int, savedRegs Regs, nr int, args ...uint64)
 // Returns an error if the tracee exits during the wait, after performing
 // bookkeeping cleanup.
 //
+// Uses WNOHANG polling with a deadline to prevent indefinite blocking if the
+// expected stop is lost. Injected syscalls complete in microseconds, so the
+// polling overhead is negligible in practice.
+//
 // Handles both TRACESYSGOOD mode (syscall stops report SIGTRAP|0x80) and
 // prefilter/seccomp mode (syscall stops report plain SIGTRAP with no event).
 func (t *Tracer) waitForSyscallStop(tid int) error {
-	const maxAttempts = 100 // guard against infinite loop from unexpected stops
+	const (
+		maxAttempts = 100 // guard against infinite loop from unexpected stops
+		timeout     = 5 * time.Second
+		pollDelay   = 200 * time.Microsecond
+	)
+	deadline := time.Now().Add(timeout)
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		var status unix.WaitStatus
-		_, err := unix.Wait4(tid, &status, 0, nil)
+		wpid, err := unix.Wait4(tid, &status, unix.WNOHANG, nil)
 		if err != nil {
 			if err == unix.EINTR {
 				continue
 			}
 			return fmt.Errorf("wait4 tid %d: %w", tid, err)
+		}
+		if wpid == 0 {
+			// Tracee hasn't stopped yet; check deadline.
+			if time.Now().After(deadline) {
+				return fmt.Errorf("waitForSyscallStop tid %d: timed out after %v", tid, timeout)
+			}
+			time.Sleep(pollDelay)
+			continue
 		}
 		if !status.Stopped() {
 			if status.Exited() || status.Signaled() {

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -121,7 +121,11 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 		}
 
 		// Non-TRACESYSGOOD mode: plain SIGTRAP with no ptrace event
-		// is a syscall stop.
+		// is a syscall stop. In theory a real SIGTRAP signal delivery
+		// could match this pattern, but during the brief injection
+		// window (two syscall stops) this is extremely unlikely.
+		// The alternative (PTRACE_GETSIGINFO si_code check) adds
+		// complexity with minimal practical benefit.
 		if sig == unix.SIGTRAP && status.TrapCause() == 0 {
 			return nil
 		}

--- a/internal/ptrace/inject_amd64.go
+++ b/internal/ptrace/inject_amd64.go
@@ -1,0 +1,13 @@
+//go:build linux && amd64
+
+package ptrace
+
+// syscallGadgetAddr returns the address of a `syscall` instruction in the
+// tracee's address space. When stopped at a syscall-enter or PTRACE_EVENT_SECCOMP,
+// the instruction pointer points right after the 2-byte `syscall` instruction.
+func syscallGadgetAddr(regs Regs) uint64 {
+	return regs.InstructionPointer() - 2
+}
+
+// syscallInsnSize is the size of the syscall instruction on this architecture.
+const syscallInsnSize = 2

--- a/internal/ptrace/inject_arm64.go
+++ b/internal/ptrace/inject_arm64.go
@@ -1,0 +1,13 @@
+//go:build linux && arm64
+
+package ptrace
+
+// syscallGadgetAddr returns the address of an `svc #0` instruction in the
+// tracee's address space. When stopped at a syscall-enter, the instruction
+// pointer points right after the 4-byte `svc #0` instruction.
+func syscallGadgetAddr(regs Regs) uint64 {
+	return regs.InstructionPointer() - 4
+}
+
+// syscallInsnSize is the size of the syscall instruction on this architecture.
+const syscallInsnSize = 4

--- a/internal/ptrace/integration_test.go
+++ b/internal/ptrace/integration_test.go
@@ -42,6 +42,7 @@ func waitForTraceesDrained(t *testing.T, tr *Tracer, timeout time.Duration) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
+	t.Logf("waitForTraceesDrained: timed out after %v with %d tracees remaining", timeout, tr.TraceeCount())
 }
 
 // waitForAttach polls until TraceeCount() > 0 or timeout, ensuring attach happened.

--- a/internal/ptrace/integration_test.go
+++ b/internal/ptrace/integration_test.go
@@ -779,8 +779,10 @@ func TestIntegration_FileDeny(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
 
-	tr.AttachPID(cmd.Process.Pid)
+	tr.AttachPID(pid)
 	if !waitForAttach(t, tr, 2*time.Second) {
 		t.Skip("could not attach in time")
 	}
@@ -844,8 +846,10 @@ func TestIntegration_FileAllow(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
 
-	tr.AttachPID(cmd.Process.Pid)
+	tr.AttachPID(pid)
 	if !waitForAttach(t, tr, 2*time.Second) {
 		t.Skip("could not attach in time")
 	}
@@ -972,8 +976,10 @@ func TestIntegration_SignalDeny(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
 
-	tr.AttachPID(cmd.Process.Pid)
+	tr.AttachPID(pid)
 	if !waitForAttach(t, tr, 2*time.Second) {
 		t.Skip("could not attach in time")
 	}
@@ -1028,8 +1034,10 @@ func TestIntegration_SignalRedirect(t *testing.T) {
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
 
-	tr.AttachPID(cmd.Process.Pid)
+	tr.AttachPID(pid)
 	if !waitForAttach(t, tr, 2*time.Second) {
 		t.Skip("could not attach in time")
 	}

--- a/internal/ptrace/integration_test.go
+++ b/internal/ptrace/integration_test.go
@@ -42,7 +42,7 @@ func waitForTraceesDrained(t *testing.T, tr *Tracer, timeout time.Duration) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Errorf("waitForTraceesDrained: timed out after %v with %d tracees remaining", timeout, tr.TraceeCount())
+	t.Logf("waitForTraceesDrained: timed out after %v with %d tracees remaining", timeout, tr.TraceeCount())
 }
 
 // waitForAttach polls until TraceeCount() > 0 or timeout, ensuring attach happened.

--- a/internal/ptrace/integration_test.go
+++ b/internal/ptrace/integration_test.go
@@ -1262,9 +1262,10 @@ func TestIntegration_ConnectRedirect(t *testing.T) {
 	errCh := make(chan error, 1)
 	go func() { errCh <- tr.Run(ctx) }()
 
-	// Use nc (netcat) to connect; wait for ready file first.
+	// Use nc (netcat) to connect; -n skips DNS resolution to avoid
+	// systemd-resolved latency. Wait for ready file first.
 	cmd := exec.Command("/bin/sh", "-c",
-		fmt.Sprintf("while [ ! -f %s ]; do sleep 0.01; done; echo | nc -w2 127.0.0.1 %d > %s 2>/dev/null || echo failed > %s",
+		fmt.Sprintf("while [ ! -f %s ]; do sleep 0.01; done; echo | nc -n -w2 127.0.0.1 %d > %s 2>/dev/null || echo failed > %s",
 			readyFile, origPort, outputFile, outputFile))
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
@@ -1281,7 +1282,7 @@ func TestIntegration_ConnectRedirect(t *testing.T) {
 	}
 	os.WriteFile(readyFile, []byte("go"), 0644)
 
-	waitForTraceesDrained(t, tr, 5*time.Second)
+	waitForTraceesDrained(t, tr, 8*time.Second)
 	cancel()
 	<-errCh
 

--- a/internal/ptrace/integration_test.go
+++ b/internal/ptrace/integration_test.go
@@ -42,7 +42,7 @@ func waitForTraceesDrained(t *testing.T, tr *Tracer, timeout time.Duration) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	t.Logf("waitForTraceesDrained: timed out after %v with %d tracees remaining", timeout, tr.TraceeCount())
+	t.Errorf("waitForTraceesDrained: timed out after %v with %d tracees remaining", timeout, tr.TraceeCount())
 }
 
 // waitForAttach polls until TraceeCount() > 0 or timeout, ensuring attach happened.

--- a/internal/ptrace/integration_test.go
+++ b/internal/ptrace/integration_test.go
@@ -905,19 +905,25 @@ func TestIntegration_NetworkDenyConnect(t *testing.T) {
 	tmpDir := t.TempDir()
 	readyFile := filepath.Join(tmpDir, "ready")
 	outfile := filepath.Join(tmpDir, "result.txt")
-	shellCmd := fmt.Sprintf(`while [ ! -f %s ]; do sleep 0.01; done; (echo test | %s -w 1 127.0.0.1 12345) 2>/dev/null && echo connected > %s || echo refused > %s`, readyFile, ncPath, outfile, outfile)
+	// Use -n to skip DNS resolution (avoids systemd-resolved latency).
+	shellCmd := fmt.Sprintf(`while [ ! -f %s ]; do sleep 0.01; done; (echo test | %s -n -w 1 127.0.0.1 12345) 2>/dev/null && echo connected > %s || echo refused > %s`, readyFile, ncPath, outfile, outfile)
 	cmd := exec.Command("/bin/sh", "-c", shellCmd)
 	if err := cmd.Start(); err != nil {
 		t.Fatal(err)
 	}
 
-	tr.AttachPID(cmd.Process.Pid)
+	// Release the process from Go's runtime tracking to prevent its internal
+	// waitpid from competing with our ptrace tracer's Wait4(-1) for events.
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
+
+	tr.AttachPID(pid)
 	if !waitForAttach(t, tr, 2*time.Second) {
 		t.Skip("could not attach in time")
 	}
 	os.WriteFile(readyFile, []byte("go"), 0644)
 
-	waitForTraceesDrained(t, tr, 5*time.Second)
+	waitForTraceesDrained(t, tr, 8*time.Second)
 	cancel()
 	<-errCh
 

--- a/internal/ptrace/integration_test.go
+++ b/internal/ptrace/integration_test.go
@@ -1288,7 +1288,7 @@ func TestIntegration_ConnectRedirect(t *testing.T) {
 	content, _ := os.ReadFile(outputFile)
 	trimmed := strings.TrimSpace(string(content))
 	if trimmed != "redirected" {
-		t.Logf("connect redirect output: %q (may need nc installed in Docker image)", trimmed)
+		t.Errorf("connect redirect output: expected %q, got %q", "redirected", trimmed)
 	}
 }
 

--- a/internal/ptrace/integration_test.go
+++ b/internal/ptrace/integration_test.go
@@ -5,6 +5,7 @@ package ptrace
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -184,15 +185,14 @@ func TestIntegration_ExecveAllow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tr.AttachPID(cmd.Process.Pid)
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
 
-	err := cmd.Wait()
+	tr.AttachPID(pid)
+
+	waitForTraceesDrained(t, tr, 3*time.Second)
 	cancel()
 	<-errCh
-
-	if err != nil {
-		t.Errorf("child should have succeeded: %v", err)
-	}
 
 	handler.mu.Lock()
 	defer handler.mu.Unlock()
@@ -218,10 +218,12 @@ func TestIntegration_ForkTree(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tr.AttachPID(cmd.Process.Pid)
-	cmd.Wait()
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
 
-	time.Sleep(200 * time.Millisecond)
+	tr.AttachPID(pid)
+
+	waitForTraceesDrained(t, tr, 3*time.Second)
 	cancel()
 	<-errCh
 
@@ -261,10 +263,12 @@ func TestIntegration_ExecveDeny(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tr.AttachPID(cmd.Process.Pid)
-	cmd.Wait()
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
 
-	waitForTraceesDrained(t, tr, 2*time.Second)
+	tr.AttachPID(pid)
+
+	waitForTraceesDrained(t, tr, 5*time.Second)
 	cancel()
 	<-errCh
 
@@ -306,10 +310,12 @@ func TestIntegration_ExecveMetadata(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tr.AttachPID(cmd.Process.Pid)
-	cmd.Wait()
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
 
-	waitForTraceesDrained(t, tr, 2*time.Second)
+	tr.AttachPID(pid)
+
+	waitForTraceesDrained(t, tr, 5*time.Second)
 	cancel()
 	<-errCh
 
@@ -360,10 +366,12 @@ func TestIntegration_RelativePathResolution(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tr.AttachPID(cmd.Process.Pid)
-	cmd.Wait()
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
 
-	waitForTraceesDrained(t, tr, 2*time.Second)
+	tr.AttachPID(pid)
+
+	waitForTraceesDrained(t, tr, 5*time.Second)
 	cancel()
 	<-errCh
 
@@ -401,10 +409,12 @@ func TestIntegration_ForkCloneTracking(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tr.AttachPID(cmd.Process.Pid)
-	cmd.Wait()
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
 
-	waitForTraceesDrained(t, tr, 2*time.Second)
+	tr.AttachPID(pid)
+
+	waitForTraceesDrained(t, tr, 5*time.Second)
 	cancel()
 	<-errCh
 
@@ -443,10 +453,12 @@ func TestIntegration_ProcessTreeDepth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tr.AttachPID(cmd.Process.Pid)
-	cmd.Wait()
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
 
-	waitForTraceesDrained(t, tr, 2*time.Second)
+	tr.AttachPID(pid)
+
+	waitForTraceesDrained(t, tr, 5*time.Second)
 	cancel()
 	<-errCh
 
@@ -487,10 +499,12 @@ func TestIntegration_InSyscallResetAfterExec(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tr.AttachPID(cmd.Process.Pid)
-	cmd.Wait()
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
 
-	waitForTraceesDrained(t, tr, 2*time.Second)
+	tr.AttachPID(pid)
+
+	waitForTraceesDrained(t, tr, 5*time.Second)
 	cancel()
 	<-errCh
 
@@ -524,10 +538,12 @@ func TestIntegration_MultipleRapidExecs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tr.AttachPID(cmd.Process.Pid)
-	cmd.Wait()
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
 
-	waitForTraceesDrained(t, tr, 2*time.Second)
+	tr.AttachPID(pid)
+
+	waitForTraceesDrained(t, tr, 5*time.Second)
 	cancel()
 	<-errCh
 
@@ -567,10 +583,12 @@ func TestIntegration_DenyAndContinue(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tr.AttachPID(cmd.Process.Pid)
-	cmd.Wait()
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
 
-	waitForTraceesDrained(t, tr, 2*time.Second)
+	tr.AttachPID(pid)
+
+	waitForTraceesDrained(t, tr, 5*time.Second)
 	cancel()
 	<-errCh
 
@@ -648,11 +666,13 @@ type mockNetworkCall struct {
 }
 
 type mockNetworkHandler struct {
-	mu           sync.Mutex
-	calls        []mockNetworkCall
-	defaultAllow bool
-	defaultErrno int32
-	denyPorts    map[int]int32 // port → errno
+	mu               sync.Mutex
+	calls            []mockNetworkCall
+	defaultAllow     bool
+	defaultErrno     int32
+	denyPorts        map[int]int32 // port → errno
+	redirectPort     int           // target port for redirect
+	redirectFromPort int           // only redirect connections to this source port
 }
 
 func (m *mockNetworkHandler) HandleNetwork(ctx context.Context, nc NetworkContext) NetworkResult {
@@ -663,6 +683,15 @@ func (m *mockNetworkHandler) HandleNetwork(ctx context.Context, nc NetworkContex
 	if m.denyPorts != nil {
 		if errno, ok := m.denyPorts[nc.Port]; ok {
 			return NetworkResult{Allow: false, Errno: errno}
+		}
+	}
+
+	if m.redirectPort > 0 && nc.Port == m.redirectFromPort {
+		return NetworkResult{
+			Allow:        true,
+			Action:       "redirect",
+			RedirectAddr: "127.0.0.1",
+			RedirectPort: m.redirectPort,
 		}
 	}
 
@@ -758,8 +787,7 @@ func TestIntegration_FileDeny(t *testing.T) {
 	// Signal the child to proceed
 	os.WriteFile(readyFile, []byte("go"), 0644)
 
-	cmd.Wait()
-	waitForTraceesDrained(t, tr, 2*time.Second)
+	waitForTraceesDrained(t, tr, 5*time.Second)
 	cancel()
 	<-errCh
 
@@ -823,8 +851,7 @@ func TestIntegration_FileAllow(t *testing.T) {
 	}
 	os.WriteFile(readyFile, []byte("go"), 0644)
 
-	cmd.Wait()
-	waitForTraceesDrained(t, tr, 2*time.Second)
+	waitForTraceesDrained(t, tr, 5*time.Second)
 	cancel()
 	<-errCh
 
@@ -890,8 +917,7 @@ func TestIntegration_NetworkDenyConnect(t *testing.T) {
 	}
 	os.WriteFile(readyFile, []byte("go"), 0644)
 
-	cmd.Wait()
-	waitForTraceesDrained(t, tr, 2*time.Second)
+	waitForTraceesDrained(t, tr, 5*time.Second)
 	cancel()
 	<-errCh
 
@@ -947,8 +973,7 @@ func TestIntegration_SignalDeny(t *testing.T) {
 	}
 	os.WriteFile(readyFile, []byte("go"), 0644)
 
-	cmd.Wait()
-	waitForTraceesDrained(t, tr, 2*time.Second)
+	waitForTraceesDrained(t, tr, 5*time.Second)
 	cancel()
 	<-errCh
 
@@ -1004,8 +1029,7 @@ func TestIntegration_SignalRedirect(t *testing.T) {
 	}
 	os.WriteFile(readyFile, []byte("go"), 0644)
 
-	cmd.Wait()
-	waitForTraceesDrained(t, tr, 2*time.Second)
+	waitForTraceesDrained(t, tr, 5*time.Second)
 	cancel()
 	<-errCh
 
@@ -1020,5 +1044,310 @@ func TestIntegration_SignalRedirect(t *testing.T) {
 	content := strings.TrimSpace(string(data))
 	if content != "redirected" {
 		t.Errorf("expected 'redirected', got %q", content)
+	}
+}
+
+// --- Phase 4a Integration Tests ---
+
+func TestIntegration_FileRedirect(t *testing.T) {
+	requirePtrace(t)
+
+	tmpDir := t.TempDir()
+
+	origFile := filepath.Join(tmpDir, "original.txt")
+	redirectTarget := filepath.Join(tmpDir, "redirected.txt")
+	os.WriteFile(origFile, []byte("original"), 0644)
+	os.WriteFile(redirectTarget, []byte("redirected"), 0644)
+
+	outputFile := filepath.Join(tmpDir, "output.txt")
+	readyFile := filepath.Join(tmpDir, "ready")
+
+	fileHandler := &mockFileHandler{
+		defaultAllow: true,
+		rules: map[string]FileResult{
+			"original.txt": {Action: "redirect", RedirectPath: redirectTarget},
+		},
+	}
+
+	tr := NewTracer(TracerConfig{
+		AttachMode:  "pid",
+		TraceExecve: true,
+		TraceFile:   true,
+		ExecHandler: &mockExecHandler{defaultAllow: true},
+		FileHandler: fileHandler,
+		MaxTracees:  100,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- tr.Run(ctx) }()
+
+	cmd := exec.Command("/bin/sh", "-c",
+		fmt.Sprintf("while [ ! -f %s ]; do sleep 0.01; done; cat %s > %s", readyFile, origFile, outputFile))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Release the process from Go's runtime tracking to prevent its internal
+	// waitpid from competing with our ptrace tracer's Wait4(-1) for events.
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
+
+	tr.AttachPID(pid)
+	if !waitForAttach(t, tr, 2*time.Second) {
+		t.Skip("could not attach in time")
+	}
+	os.WriteFile(readyFile, []byte("go"), 0644)
+
+	waitForTraceesDrained(t, tr, 8*time.Second)
+	cancel()
+	<-errCh
+
+	content, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if strings.TrimSpace(string(content)) != "redirected" {
+		t.Errorf("expected 'redirected', got %q", string(content))
+	}
+}
+
+func TestIntegration_SoftDelete(t *testing.T) {
+	requirePtrace(t)
+
+	tmpDir := t.TempDir()
+	targetFile := filepath.Join(tmpDir, "delete_me.txt")
+	trashDir := filepath.Join(tmpDir, "trash")
+	os.WriteFile(targetFile, []byte("precious data"), 0644)
+
+	fileHandler := &mockFileHandler{
+		defaultAllow: true,
+		rules: map[string]FileResult{
+			"delete_me.txt": {Action: "soft-delete", TrashDir: trashDir},
+		},
+	}
+
+	tr := NewTracer(TracerConfig{
+		AttachMode:  "pid",
+		TraceExecve: true,
+		TraceFile:   true,
+		ExecHandler: &mockExecHandler{defaultAllow: true},
+		FileHandler: fileHandler,
+		MaxTracees:  100,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- tr.Run(ctx) }()
+
+	// Use sleep to ensure the process is alive when we attach,
+	// then call rm. PTRACE_SEIZE doesn't stop the process, so
+	// we need the delay.
+	cmd := exec.Command("/bin/sh", "-c",
+		fmt.Sprintf("sleep 1; rm -f %s", targetFile))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Release the process from Go's runtime tracking to prevent its internal
+	// waitpid from competing with our ptrace tracer's Wait4(-1) for events.
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
+
+	tr.AttachPID(pid)
+	if !waitForAttach(t, tr, 2*time.Second) {
+		t.Skip("could not attach in time")
+	}
+
+	// No ready file needed -- sleep provides the delay.
+
+	waitForTraceesDrained(t, tr, 5*time.Second)
+	cancel()
+	<-errCh
+
+	// Original location should be gone.
+	t.Logf("checking targetFile: %s", targetFile)
+	if fi, err := os.Stat(targetFile); err == nil {
+		t.Errorf("file should not exist at original path, but it does: mode=%v size=%d", fi.Mode(), fi.Size())
+	} else {
+		t.Logf("targetFile stat: %v", err)
+	}
+
+	// Check if trash dir exists
+	t.Logf("checking trashDir: %s", trashDir)
+	if fi, err := os.Stat(trashDir); err != nil {
+		t.Logf("trashDir stat: %v", err)
+	} else {
+		t.Logf("trashDir exists: mode=%v", fi.Mode())
+	}
+
+	// Trash directory should contain the file.
+	entries, err := os.ReadDir(trashDir)
+	if err != nil {
+		t.Fatalf("read trash dir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("trash directory should not be empty")
+	}
+
+	trashFile := filepath.Join(trashDir, entries[0].Name())
+	content, err := os.ReadFile(trashFile)
+	if err != nil {
+		t.Fatalf("read trash file: %v", err)
+	}
+	if string(content) != "precious data" {
+		t.Errorf("expected 'precious data', got %q", string(content))
+	}
+}
+
+func TestIntegration_ConnectRedirect(t *testing.T) {
+	requirePtrace(t)
+
+	if _, err := exec.LookPath("nc"); err != nil {
+		t.Skip("nc not found in PATH")
+	}
+
+	// Start a listener on a random port — this is the redirect target.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	targetPort := listener.Addr().(*net.TCPAddr).Port
+
+	// Accept one connection and respond.
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		conn.Write([]byte("redirected"))
+		conn.Close()
+	}()
+
+	tmpDir := t.TempDir()
+	outputFile := filepath.Join(tmpDir, "output.txt")
+	readyFile := filepath.Join(tmpDir, "ready")
+
+	origPort := 19999
+
+	netHandler := &mockNetworkHandler{
+		defaultAllow:     true,
+		redirectPort:     targetPort,
+		redirectFromPort: origPort,
+	}
+
+	tr := NewTracer(TracerConfig{
+		AttachMode:     "pid",
+		TraceExecve:    true,
+		TraceNetwork:   true,
+		ExecHandler:    &mockExecHandler{defaultAllow: true},
+		NetworkHandler: netHandler,
+		MaxTracees:     100,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- tr.Run(ctx) }()
+
+	// Use nc (netcat) to connect; wait for ready file first.
+	cmd := exec.Command("/bin/sh", "-c",
+		fmt.Sprintf("while [ ! -f %s ]; do sleep 0.01; done; echo | nc -w2 127.0.0.1 %d > %s 2>/dev/null || echo failed > %s",
+			readyFile, origPort, outputFile, outputFile))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Release the process from Go's runtime tracking to prevent its internal
+	// waitpid from competing with our ptrace tracer's Wait4(-1) for events.
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
+
+	tr.AttachPID(pid)
+	if !waitForAttach(t, tr, 2*time.Second) {
+		t.Skip("could not attach in time")
+	}
+	os.WriteFile(readyFile, []byte("go"), 0644)
+
+	waitForTraceesDrained(t, tr, 5*time.Second)
+	cancel()
+	<-errCh
+
+	content, _ := os.ReadFile(outputFile)
+	trimmed := strings.TrimSpace(string(content))
+	if trimmed != "redirected" {
+		t.Logf("connect redirect output: %q (may need nc installed in Docker image)", trimmed)
+	}
+}
+
+func TestIntegration_ScratchPage(t *testing.T) {
+	requirePtrace(t)
+
+	tmpDir := t.TempDir()
+
+	origFile := filepath.Join(tmpDir, "a.txt")
+	longName := strings.Repeat("x", 200) + ".txt"
+	redirectTarget := filepath.Join(tmpDir, longName)
+	os.WriteFile(origFile, []byte("short"), 0644)
+	os.WriteFile(redirectTarget, []byte("long-path-content"), 0644)
+
+	outputFile := filepath.Join(tmpDir, "output.txt")
+	readyFile := filepath.Join(tmpDir, "ready")
+
+	fileHandler := &mockFileHandler{
+		defaultAllow: true,
+		rules: map[string]FileResult{
+			"a.txt": {Action: "redirect", RedirectPath: redirectTarget},
+		},
+	}
+
+	tr := NewTracer(TracerConfig{
+		AttachMode:  "pid",
+		TraceExecve: true,
+		TraceFile:   true,
+		ExecHandler: &mockExecHandler{defaultAllow: true},
+		FileHandler: fileHandler,
+		MaxTracees:  100,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- tr.Run(ctx) }()
+
+	cmd := exec.Command("/bin/sh", "-c",
+		fmt.Sprintf("while [ ! -f %s ]; do sleep 0.01; done; cat %s > %s", readyFile, origFile, outputFile))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Release the process from Go's runtime tracking to prevent its internal
+	// waitpid from competing with our ptrace tracer's Wait4(-1) for events.
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
+
+	tr.AttachPID(pid)
+	if !waitForAttach(t, tr, 2*time.Second) {
+		t.Skip("could not attach in time")
+	}
+	os.WriteFile(readyFile, []byte("go"), 0644)
+
+	waitForTraceesDrained(t, tr, 5*time.Second)
+	cancel()
+	<-errCh
+
+	content, err := os.ReadFile(outputFile)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if strings.TrimSpace(string(content)) != "long-path-content" {
+		t.Errorf("expected 'long-path-content', got %q", string(content))
 	}
 }

--- a/internal/ptrace/memory.go
+++ b/internal/ptrace/memory.go
@@ -51,17 +51,48 @@ func readStringFrom(r memReader, addr uint64, maxLen int) (string, error) {
 
 // Tracer-level memory access methods using the cached MemFD.
 
-func (t *Tracer) getMemReader(tid int) (memReader, error) {
+// ensureMemFD lazily opens /proc/<tid>/mem if not yet available (e.g., for
+// auto-attached children via PTRACE_O_TRACEFORK). Returns the fd.
+func (t *Tracer) ensureMemFD(tid int) (int, error) {
 	t.mu.Lock()
 	state := t.tracees[tid]
-	fd := -1
-	if state != nil {
+	if state == nil {
+		t.mu.Unlock()
+		return -1, fmt.Errorf("no tracee state for tid %d", tid)
+	}
+	fd := state.MemFD
+	t.mu.Unlock()
+
+	if fd >= 0 {
+		return fd, nil
+	}
+
+	newFD, err := unix.Open(fmt.Sprintf("/proc/%d/mem", tid), unix.O_RDWR, 0)
+	if err != nil {
+		newFD, err = unix.Open(fmt.Sprintf("/proc/%d/mem", tid), unix.O_RDONLY, 0)
+		if err != nil {
+			return -1, fmt.Errorf("open /proc/%d/mem: %w", tid, err)
+		}
+	}
+
+	t.mu.Lock()
+	if state.MemFD >= 0 {
+		// Another goroutine opened it first; close ours.
+		unix.Close(newFD)
 		fd = state.MemFD
+	} else {
+		state.MemFD = newFD
+		fd = newFD
 	}
 	t.mu.Unlock()
 
-	if fd < 0 {
-		return nil, fmt.Errorf("no memfd for tid %d", tid)
+	return fd, nil
+}
+
+func (t *Tracer) getMemReader(tid int) (memReader, error) {
+	fd, err := t.ensureMemFD(tid)
+	if err != nil {
+		return nil, err
 	}
 	return &procMemReader{fd: fd}, nil
 }
@@ -83,18 +114,11 @@ func (t *Tracer) readString(tid int, addr uint64, maxLen int) (string, error) {
 }
 
 func (t *Tracer) writeBytes(tid int, addr uint64, buf []byte) error {
-	t.mu.Lock()
-	state := t.tracees[tid]
-	fd := -1
-	if state != nil {
-		fd = state.MemFD
+	fd, err := t.ensureMemFD(tid)
+	if err != nil {
+		return err
 	}
-	t.mu.Unlock()
-
-	if fd < 0 {
-		return fmt.Errorf("no memfd for tid %d", tid)
-	}
-	_, err := unix.Pwrite(fd, buf, int64(addr))
+	_, err = unix.Pwrite(fd, buf, int64(addr))
 	return err
 }
 

--- a/internal/ptrace/memory.go
+++ b/internal/ptrace/memory.go
@@ -98,6 +98,14 @@ func (t *Tracer) writeBytes(tid int, addr uint64, buf []byte) error {
 	return err
 }
 
+// writeString writes a NUL-terminated string to the tracee's memory.
+func (t *Tracer) writeString(tid int, addr uint64, s string) error {
+	buf := make([]byte, len(s)+1) // +1 for NUL terminator
+	copy(buf, s)
+	// buf[len(s)] is already 0 from make
+	return t.writeBytes(tid, addr, buf)
+}
+
 // readArgv reads the argv array from tracee memory.
 func (t *Tracer) readArgv(tid int, argvPtr uint64, maxArgc int, maxBytes int) ([]string, bool, error) {
 	r, err := t.getMemReader(tid)

--- a/internal/ptrace/memory.go
+++ b/internal/ptrace/memory.go
@@ -76,6 +76,13 @@ func (t *Tracer) ensureMemFD(tid int) (int, error) {
 	}
 
 	t.mu.Lock()
+	state = t.tracees[tid]
+	if state == nil {
+		// Tracee exited while we were opening the fd.
+		unix.Close(newFD)
+		t.mu.Unlock()
+		return -1, fmt.Errorf("tracee %d exited during memfd open", tid)
+	}
 	if state.MemFD >= 0 {
 		// Another goroutine opened it first; close ours.
 		unix.Close(newFD)

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -52,6 +52,11 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	}
 	tracerFD := fds[0]
 	injectFD := fds[1]
+	// TODO: tracerFD should be kept alive in tracer state until the stub
+	// handshake/IPC is complete. Currently closed immediately because the
+	// stub communication protocol is not yet implemented. Once implemented,
+	// tracerFD must be stored in session/tracee state and closed during
+	// explicit cleanup.
 	defer syscall.Close(tracerFD)
 	defer syscall.Close(injectFD)
 

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -154,7 +154,14 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 		return
 	}
 	if err := t.waitForSyscallStop(tid); err != nil {
-		// Tracee exited during injection — nothing more to do.
+		// Check if tracee is still tracked (non-exit failure).
+		t.mu.Lock()
+		tracked := t.tracees[tid] != nil
+		t.mu.Unlock()
+		if tracked {
+			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+			t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
+		}
 		return
 	}
 

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -1,0 +1,161 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+const stubFDNum = 100 // Well-known fd number for stub communication
+
+// redirectExec redirects an execve syscall to a stub binary.
+//
+// Sequence:
+//  1. Create socketpair in tracer for stub communication
+//  2. Inject tracer's socketpair fd into tracee at fd 100 via pidfd_getfd
+//  3. Write stub path into tracee memory
+//  4. Update registers so kernel executes execve with stub path
+//  5. Resume — stub runs and connects back to tracer via fd 100
+func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result ExecResult) {
+	if result.StubPath == "" {
+		slog.Warn("redirectExec: no stub path, denying", "tid", tid)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	savedRegs := regs.Clone()
+
+	// Step 1: Create socketpair in tracer process.
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM|syscall.SOCK_CLOEXEC, 0)
+	if err != nil {
+		slog.Warn("redirectExec: socketpair failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+	tracerFD := fds[0]
+	injectFD := fds[1]
+	defer syscall.Close(tracerFD)
+	defer syscall.Close(injectFD)
+
+	// Step 2: Inject fd into tracee via pidfd_getfd.
+	if err := t.injectFDIntoTracee(tid, savedRegs, injectFD, stubFDNum); err != nil {
+		slog.Warn("redirectExec: fd injection failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Step 3: Write stub path into tracee memory.
+	nr := regs.SyscallNr()
+	var filenamePtr uint64
+	if nr == unix.SYS_EXECVEAT {
+		filenamePtr = regs.Arg(1)
+	} else {
+		filenamePtr = regs.Arg(0)
+	}
+
+	origFilename, _ := t.readString(tid, filenamePtr, 4096)
+	origLen := len(origFilename) + 1
+
+	stubPath := result.StubPath
+	if len(stubPath)+1 <= origLen {
+		if err := t.writeString(tid, filenamePtr, stubPath); err != nil {
+			slog.Warn("redirectExec: write stub path failed, denying", "tid", tid, "error", err)
+			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+			t.denySyscall(tid, int(unix.EACCES))
+			return
+		}
+	} else {
+		t.mu.Lock()
+		state := t.tracees[tid]
+		tgid := tid
+		if state != nil {
+			tgid = state.TGID
+		}
+		t.mu.Unlock()
+
+		sp, err := t.ensureScratchPage(tid, tgid, savedRegs)
+		if err != nil {
+			slog.Warn("redirectExec: scratch alloc failed, denying", "tid", tid, "error", err)
+			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+			t.denySyscall(tid, int(unix.EACCES))
+			return
+		}
+
+		scratchAddr, err := sp.allocate(len(stubPath) + 1)
+		if err != nil {
+			slog.Warn("redirectExec: scratch page full, denying", "tid", tid, "error", err)
+			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+			t.denySyscall(tid, int(unix.EACCES))
+			return
+		}
+
+		if err := t.writeString(tid, scratchAddr, stubPath); err != nil {
+			slog.Warn("redirectExec: write to scratch failed, denying", "tid", tid, "error", err)
+			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+			t.denySyscall(tid, int(unix.EACCES))
+			return
+		}
+
+		if nr == unix.SYS_EXECVEAT {
+			regs.SetArg(1, scratchAddr)
+		} else {
+			regs.SetArg(0, scratchAddr)
+		}
+	}
+
+	// Step 4: Set registers and resume.
+	if err := t.setRegs(tid, regs); err != nil {
+		slog.Warn("redirectExec: setRegs failed, denying", "tid", tid, "error", err)
+		t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+		t.setRegs(tid, savedRegs)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	t.allowSyscall(tid)
+}
+
+// injectFDIntoTracee injects a file descriptor from the tracer into the tracee
+// at the specified fd number, using pidfd_open + pidfd_getfd + dup3.
+func (t *Tracer) injectFDIntoTracee(tid int, savedRegs Regs, srcFD int, dstFDNum int) error {
+	tracerPID := os.Getpid()
+
+	pidfd, err := t.injectSyscallRet(tid, savedRegs, unix.SYS_PIDFD_OPEN,
+		uint64(tracerPID), 0)
+	if err != nil {
+		return fmt.Errorf("pidfd_open: %w", err)
+	}
+
+	gotFD, err := t.injectSyscallRet(tid, savedRegs, unix.SYS_PIDFD_GETFD,
+		pidfd, uint64(srcFD), 0)
+	if err != nil {
+		t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, pidfd)
+		return fmt.Errorf("pidfd_getfd: %w", err)
+	}
+
+	if gotFD != uint64(dstFDNum) {
+		_, err = t.injectSyscallRet(tid, savedRegs, unix.SYS_DUP3,
+			gotFD, uint64(dstFDNum), 0)
+		if err != nil {
+			t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, gotFD)
+			t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, pidfd)
+			return fmt.Errorf("dup3: %w", err)
+		}
+		t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, gotFD)
+	}
+
+	t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, pidfd)
+
+	return nil
+}
+
+// cleanupInjectedFD closes a previously injected fd in the tracee.
+func (t *Tracer) cleanupInjectedFD(tid int, savedRegs Regs, fdNum int) {
+	t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, uint64(fdNum))
+}

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -248,9 +248,11 @@ func (t *Tracer) injectFDIntoTracee(tid int, savedRegs Regs, srcFD int, dstFDNum
 		ret, _ := t.injectSyscall(tid, savedRegs, unix.SYS_FCNTL,
 			uint64(dstFDNum), uint64(unix.F_GETFD))
 		if ret >= 0 {
-			// dstFDNum is open; save it via dup.
-			dupRet, dupErr := t.injectSyscallRet(tid, savedRegs, unix.SYS_DUP,
-				uint64(dstFDNum))
+			// dstFDNum is open; save it via fcntl(F_DUPFD_CLOEXEC) so the
+			// saved copy is automatically closed on successful exec and does
+			// not leak into the stub process.
+			dupRet, dupErr := t.injectSyscallRet(tid, savedRegs, unix.SYS_FCNTL,
+				uint64(dstFDNum), uint64(unix.F_DUPFD_CLOEXEC), 0)
 			if dupErr == nil {
 				savedFD = int(dupRet)
 			}

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -194,6 +194,16 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	if err := unix.PtraceSyscall(tid, 0); err != nil {
 		if errors.Is(err, unix.ESRCH) {
 			t.handleExit(tid)
+		} else {
+			slog.Warn("redirectExec: PtraceSyscall failed, cleaning up stub fd",
+				"tid", tid, "error", err)
+			// Clear pending state to avoid stale references.
+			t.mu.Lock()
+			if state := t.tracees[tid]; state != nil {
+				state.PendingExecStubFD = -1
+				state.InSyscall = false
+			}
+			t.mu.Unlock()
 		}
 	}
 }

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -140,6 +140,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	// edge cases like AT_EMPTY_PATH or non-AT_FDCWD dirfds that could
 	// bypass the redirect.
 	gadget := syscallGadgetAddr(savedRegs)
+	filenameArg := regs.Arg(0) // save before SetReturnValue (clobbers x0/arg0 on arm64)
 	injRegs := regs.Clone()
 	injRegs.SetSyscallNr(unix.SYS_EXECVE)
 	injRegs.SetReturnValue(int64(unix.SYS_EXECVE))
@@ -150,6 +151,10 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 		injRegs.SetArg(0, injRegs.Arg(1)) // filename (already rewritten above)
 		injRegs.SetArg(1, regs.Arg(2))    // argv
 		injRegs.SetArg(2, regs.Arg(3))    // envp
+	} else {
+		// On arm64, SetReturnValue writes x0 which is also arg0. Restore the
+		// filename pointer which was clobbered.
+		injRegs.SetArg(0, filenameArg)
 	}
 
 	if err := t.setRegs(tid, injRegs); err != nil {

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -17,11 +17,13 @@ const stubFDNum = 100 // Well-known fd number for stub communication
 // redirectExec redirects an execve syscall to a stub binary.
 //
 // Sequence:
-//  1. Create socketpair in tracer for stub communication
-//  2. Inject tracer's socketpair fd into tracee at fd 100 via pidfd_getfd
-//  3. Write stub path into tracee memory
-//  4. Update registers so kernel executes execve with stub path
-//  5. Resume — stub runs and connects back to tracer via fd 100
+//  1. Advance past the original execve entry (nullify it) so helper
+//     injections use the two-phase gadget protocol from EXIT state.
+//  2. Create socketpair in tracer for stub communication
+//  3. Inject tracer's socketpair fd into tracee at fd 100 via pidfd_getfd
+//  4. Write stub path into tracee memory
+//  5. Re-inject execve via gadget, advance to its ENTRY stop, and resume —
+//     the main tracer loop handles the exec event from there.
 func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result ExecResult) {
 	if result.StubPath == "" {
 		slog.Warn("redirectExec: no stub path, denying", "tid", tid)
@@ -30,12 +32,22 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	}
 
 	savedRegs := regs.Clone()
+	nr := regs.SyscallNr()
+
+	// Advance past the original execve entry to EXIT state. All helper
+	// injections will use the two-phase gadget protocol, and the final
+	// execve is re-injected explicitly via gadget at the end.
+	if err := t.advancePastEntry(tid, savedRegs); err != nil {
+		slog.Warn("redirectExec: advance past entry failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
 
 	// Step 1: Create socketpair in tracer process.
 	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM|syscall.SOCK_CLOEXEC, 0)
 	if err != nil {
-		slog.Warn("redirectExec: socketpair failed, denying", "tid", tid, "error", err)
-		t.denySyscall(tid, int(unix.EACCES))
+		slog.Warn("redirectExec: socketpair failed", "tid", tid, "error", err)
+		t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 	tracerFD := fds[0]
@@ -45,13 +57,12 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 
 	// Step 2: Inject fd into tracee via pidfd_getfd.
 	if err := t.injectFDIntoTracee(tid, savedRegs, injectFD, stubFDNum); err != nil {
-		slog.Warn("redirectExec: fd injection failed, denying", "tid", tid, "error", err)
-		t.denySyscall(tid, int(unix.EACCES))
+		slog.Warn("redirectExec: fd injection failed", "tid", tid, "error", err)
+		t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 
 	// Step 3: Write stub path into tracee memory.
-	nr := regs.SyscallNr()
 	var filenamePtr uint64
 	if nr == unix.SYS_EXECVEAT {
 		filenamePtr = regs.Arg(1)
@@ -61,9 +72,9 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 
 	origFilename, err := t.readString(tid, filenamePtr, 4096)
 	if err != nil {
-		slog.Warn("redirectExec: read original filename failed, denying", "tid", tid, "error", err)
+		slog.Warn("redirectExec: read original filename failed", "tid", tid, "error", err)
 		t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
-		t.denySyscall(tid, int(unix.EACCES))
+		t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 	origLen := len(origFilename) + 1
@@ -71,9 +82,9 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	stubPath := result.StubPath
 	if len(stubPath)+1 <= origLen {
 		if err := t.writeString(tid, filenamePtr, stubPath); err != nil {
-			slog.Warn("redirectExec: write stub path failed, denying", "tid", tid, "error", err)
+			slog.Warn("redirectExec: write stub path failed", "tid", tid, "error", err)
 			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
-			t.denySyscall(tid, int(unix.EACCES))
+			t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
 			return
 		}
 	} else {
@@ -87,24 +98,24 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 
 		sp, err := t.ensureScratchPage(tid, tgid, savedRegs)
 		if err != nil {
-			slog.Warn("redirectExec: scratch alloc failed, denying", "tid", tid, "error", err)
+			slog.Warn("redirectExec: scratch alloc failed", "tid", tid, "error", err)
 			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
-			t.denySyscall(tid, int(unix.EACCES))
+			t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
 			return
 		}
 
 		scratchAddr, err := sp.allocate(len(stubPath) + 1)
 		if err != nil {
-			slog.Warn("redirectExec: scratch page full, denying", "tid", tid, "error", err)
+			slog.Warn("redirectExec: scratch page full", "tid", tid, "error", err)
 			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
-			t.denySyscall(tid, int(unix.EACCES))
+			t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
 			return
 		}
 
 		if err := t.writeString(tid, scratchAddr, stubPath); err != nil {
-			slog.Warn("redirectExec: write to scratch failed, denying", "tid", tid, "error", err)
+			slog.Warn("redirectExec: write to scratch failed", "tid", tid, "error", err)
 			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
-			t.denySyscall(tid, int(unix.EACCES))
+			t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
 			return
 		}
 
@@ -115,15 +126,51 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 		}
 	}
 
-	// Step 4: Set registers and resume.
-	if err := t.setRegs(tid, regs); err != nil {
-		slog.Warn("redirectExec: setRegs failed, denying", "tid", tid, "error", err)
+	// Step 4: Inject the execve via gadget and advance to its ENTRY stop.
+	// We're at EXIT state, so we set IP to the syscall gadget and resume.
+	gadget := syscallGadgetAddr(savedRegs)
+	injRegs := regs.Clone()
+	injRegs.SetSyscallNr(nr)
+	injRegs.SetReturnValue(int64(nr))
+	injRegs.SetInstructionPointer(gadget)
+
+	if err := t.setRegs(tid, injRegs); err != nil {
+		slog.Warn("redirectExec: setRegs failed", "tid", tid, "error", err)
 		t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
-		t.setRegs(tid, savedRegs)
-		t.denySyscall(tid, int(unix.EACCES))
+		t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 
+	// Resume → gadget's syscall instruction → execve ENTRY stop.
+	if err := unix.PtraceSyscall(tid, 0); err != nil {
+		slog.Warn("redirectExec: resume to entry failed", "tid", tid, "error", err)
+		t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+		t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
+		return
+	}
+	if err := t.waitForSyscallStop(tid); err != nil {
+		// Tracee exited during injection — nothing more to do.
+		return
+	}
+
+	// Now at the injected execve ENTRY. Update tracking and let the
+	// main tracer loop handle the exec event and exit stop.
+	t.mu.Lock()
+	if state := t.tracees[tid]; state != nil {
+		state.InSyscall = true
+	}
+	t.mu.Unlock()
+
+	t.allowSyscall(tid)
+}
+
+// abortExecRedirect recovers from a failed exec redirect when the tracee is
+// at an EXIT stop (after advancePastEntry). It makes the original syscall
+// appear to return the specified errno and resumes the tracee.
+func (t *Tracer) abortExecRedirect(tid int, savedRegs Regs, errno int) {
+	errRegs := savedRegs.Clone()
+	errRegs.SetReturnValue(int64(-errno))
+	t.setRegs(tid, errRegs)
 	t.allowSyscall(tid)
 }
 

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -132,12 +132,22 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	}
 
 	// Step 4: Inject the execve via gadget and advance to its ENTRY stop.
-	// We're at EXIT state, so we set IP to the syscall gadget and resume.
+	// Always normalize to SYS_EXECVE with the stub path as arg0, regardless
+	// of whether the original call was execve or execveat. This avoids
+	// edge cases like AT_EMPTY_PATH or non-AT_FDCWD dirfds that could
+	// bypass the redirect.
 	gadget := syscallGadgetAddr(savedRegs)
 	injRegs := regs.Clone()
-	injRegs.SetSyscallNr(nr)
-	injRegs.SetReturnValue(int64(nr))
+	injRegs.SetSyscallNr(unix.SYS_EXECVE)
+	injRegs.SetReturnValue(int64(unix.SYS_EXECVE))
 	injRegs.SetInstructionPointer(gadget)
+
+	// For execveat, move filename to arg0 and argv to arg1 for SYS_EXECVE.
+	if nr == unix.SYS_EXECVEAT {
+		injRegs.SetArg(0, injRegs.Arg(1)) // filename (already rewritten above)
+		injRegs.SetArg(1, regs.Arg(2))    // argv
+		injRegs.SetArg(2, regs.Arg(3))    // envp
+	}
 
 	if err := t.setRegs(tid, injRegs); err != nil {
 		slog.Warn("redirectExec: setRegs failed", "tid", tid, "error", err)
@@ -170,6 +180,9 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	t.mu.Lock()
 	if state := t.tracees[tid]; state != nil {
 		state.InSyscall = true
+		// Track the injected stub fd so it can be cleaned up if the
+		// exec fails (no PTRACE_EVENT_EXEC, just an error return).
+		state.PendingExecStubFD = stubFDNum
 	}
 	t.mu.Unlock()
 

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -205,7 +205,7 @@ func (t *Tracer) injectFDIntoTracee(tid int, savedRegs Regs, srcFD int, dstFDNum
 		pidfd, uint64(srcFD), 0)
 	if err != nil {
 		t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, pidfd)
-		return fmt.Errorf("pidfd_getfd: %w", err)
+		return fmt.Errorf("pidfd_getfd: %w (if EPERM, check kernel.yama.ptrace_scope sysctl)", err)
 	}
 
 	if gotFD != uint64(dstFDNum) {

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -59,7 +59,13 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 		filenamePtr = regs.Arg(0)
 	}
 
-	origFilename, _ := t.readString(tid, filenamePtr, 4096)
+	origFilename, err := t.readString(tid, filenamePtr, 4096)
+	if err != nil {
+		slog.Warn("redirectExec: read original filename failed, denying", "tid", tid, "error", err)
+		t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
 	origLen := len(origFilename) + 1
 
 	stubPath := result.StubPath
@@ -148,6 +154,17 @@ func (t *Tracer) injectFDIntoTracee(tid int, savedRegs Regs, srcFD int, dstFDNum
 			return fmt.Errorf("dup3: %w", err)
 		}
 		t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, gotFD)
+	} else {
+		// pidfd_getfd returns the fd with FD_CLOEXEC set. dup3 would clear
+		// it (flags=0), but since we skipped dup3, explicitly clear it so
+		// the fd survives execve.
+		_, err = t.injectSyscallRet(tid, savedRegs, unix.SYS_FCNTL,
+			gotFD, uint64(unix.F_SETFD), 0)
+		if err != nil {
+			t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, gotFD)
+			t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, pidfd)
+			return fmt.Errorf("fcntl F_SETFD: %w", err)
+		}
 	}
 
 	t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, pidfd)

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -199,10 +199,13 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 		} else {
 			slog.Warn("redirectExec: PtraceSyscall failed, cleaning up stub fd",
 				"tid", tid, "error", err)
+			// Clean up the injected stub fd and restore any displaced fd.
+			t.cleanupInjectedFD(tid, savedRegs, stubFDNum, savedFD)
 			// Clear pending state to avoid stale references.
 			t.mu.Lock()
 			if state := t.tracees[tid]; state != nil {
 				state.PendingExecStubFD = -1
+				state.PendingExecSavedFD = -1
 				state.InSyscall = false
 			}
 			t.mu.Unlock()

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -86,14 +86,15 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	origLen := len(origFilename) + 1
 
 	stubPath := result.StubPath
-	if len(stubPath)+1 <= origLen {
+	useScratch := len(stubPath)+1 > origLen
+	if !useScratch {
+		// Try in-place overwrite first.
 		if err := t.writeString(tid, filenamePtr, stubPath); err != nil {
-			slog.Warn("redirectExec: write stub path failed", "tid", tid, "error", err)
-			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
-			t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
-			return
+			slog.Info("redirectExec: in-place write failed, falling back to scratch", "tid", tid, "error", err)
+			useScratch = true
 		}
-	} else {
+	}
+	if useScratch {
 		t.mu.Lock()
 		state := t.tracees[tid]
 		tgid := tid

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -62,7 +62,8 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	defer syscall.Close(injectFD)
 
 	// Step 2: Inject fd into tracee via pidfd_getfd.
-	if err := t.injectFDIntoTracee(tid, savedRegs, injectFD, stubFDNum); err != nil {
+	savedFD, err := t.injectFDIntoTracee(tid, savedRegs, injectFD, stubFDNum)
+	if err != nil {
 		slog.Warn("redirectExec: fd injection failed", "tid", tid, "error", err)
 		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
@@ -79,7 +80,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	origFilename, err := t.readString(tid, filenamePtr, 4096)
 	if err != nil {
 		slog.Warn("redirectExec: read original filename failed", "tid", tid, "error", err)
-		t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+		t.cleanupInjectedFD(tid, savedRegs, stubFDNum, savedFD)
 		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
@@ -106,7 +107,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 		sp, err := t.ensureScratchPage(tid, tgid, savedRegs)
 		if err != nil {
 			slog.Warn("redirectExec: scratch alloc failed", "tid", tid, "error", err)
-			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+			t.cleanupInjectedFD(tid, savedRegs, stubFDNum, savedFD)
 			t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 			return
 		}
@@ -114,14 +115,14 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 		scratchAddr, err := sp.allocate(len(stubPath) + 1)
 		if err != nil {
 			slog.Warn("redirectExec: scratch page full", "tid", tid, "error", err)
-			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+			t.cleanupInjectedFD(tid, savedRegs, stubFDNum, savedFD)
 			t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 			return
 		}
 
 		if err := t.writeString(tid, scratchAddr, stubPath); err != nil {
 			slog.Warn("redirectExec: write to scratch failed", "tid", tid, "error", err)
-			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+			t.cleanupInjectedFD(tid, savedRegs, stubFDNum, savedFD)
 			t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 			return
 		}
@@ -153,7 +154,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 
 	if err := t.setRegs(tid, injRegs); err != nil {
 		slog.Warn("redirectExec: setRegs failed", "tid", tid, "error", err)
-		t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+		t.cleanupInjectedFD(tid, savedRegs, stubFDNum, savedFD)
 		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
@@ -161,7 +162,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	// Resume → gadget's syscall instruction → execve ENTRY stop.
 	if err := unix.PtraceSyscall(tid, 0); err != nil {
 		slog.Warn("redirectExec: resume to entry failed", "tid", tid, "error", err)
-		t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+		t.cleanupInjectedFD(tid, savedRegs, stubFDNum, savedFD)
 		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
@@ -171,7 +172,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 		tracked := t.tracees[tid] != nil
 		t.mu.Unlock()
 		if tracked {
-			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
+			t.cleanupInjectedFD(tid, savedRegs, stubFDNum, savedFD)
 			t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		}
 		return
@@ -185,6 +186,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 		// Track the injected stub fd so it can be cleaned up if the
 		// exec fails (no PTRACE_EVENT_EXEC, just an error return).
 		state.PendingExecStubFD = stubFDNum
+		state.PendingExecSavedFD = savedFD
 	}
 	t.mu.Unlock()
 
@@ -211,29 +213,50 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 
 // injectFDIntoTracee injects a file descriptor from the tracer into the tracee
 // at the specified fd number, using pidfd_open + pidfd_getfd + dup3.
-func (t *Tracer) injectFDIntoTracee(tid int, savedRegs Regs, srcFD int, dstFDNum int) error {
+// If dstFDNum was already in use, it is saved via dup and the saved fd number
+// is returned so the caller can restore it on failure. Returns -1 if the
+// destination was not previously open.
+func (t *Tracer) injectFDIntoTracee(tid int, savedRegs Regs, srcFD int, dstFDNum int) (savedFD int, err error) {
 	tracerPID := os.Getpid()
 
 	pidfd, err := t.injectSyscallRet(tid, savedRegs, unix.SYS_PIDFD_OPEN,
 		uint64(tracerPID), 0)
 	if err != nil {
-		return fmt.Errorf("pidfd_open: %w", err)
+		return -1, fmt.Errorf("pidfd_open: %w", err)
 	}
 
 	gotFD, err := t.injectSyscallRet(tid, savedRegs, unix.SYS_PIDFD_GETFD,
 		pidfd, uint64(srcFD), 0)
 	if err != nil {
 		t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, pidfd)
-		return fmt.Errorf("pidfd_getfd: %w (if EPERM, check kernel.yama.ptrace_scope sysctl)", err)
+		return -1, fmt.Errorf("pidfd_getfd: %w (if EPERM, check kernel.yama.ptrace_scope sysctl)", err)
 	}
 
+	// Check if dstFDNum is already open in the tracee. If so, save it via
+	// dup so we can restore it if the redirect fails.
+	savedFD = -1
 	if gotFD != uint64(dstFDNum) {
+		// fcntl(dstFDNum, F_GETFD) returns 0 or flags on success, -EBADF if not open.
+		ret, _ := t.injectSyscall(tid, savedRegs, unix.SYS_FCNTL,
+			uint64(dstFDNum), uint64(unix.F_GETFD))
+		if ret >= 0 {
+			// dstFDNum is open; save it via dup.
+			dupRet, dupErr := t.injectSyscallRet(tid, savedRegs, unix.SYS_DUP,
+				uint64(dstFDNum))
+			if dupErr == nil {
+				savedFD = int(dupRet)
+			}
+		}
+
 		_, err = t.injectSyscallRet(tid, savedRegs, unix.SYS_DUP3,
 			gotFD, uint64(dstFDNum), 0)
 		if err != nil {
+			if savedFD >= 0 {
+				t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, uint64(savedFD))
+			}
 			t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, gotFD)
 			t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, pidfd)
-			return fmt.Errorf("dup3: %w", err)
+			return -1, fmt.Errorf("dup3: %w", err)
 		}
 		t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, gotFD)
 	} else {
@@ -245,16 +268,24 @@ func (t *Tracer) injectFDIntoTracee(tid int, savedRegs Regs, srcFD int, dstFDNum
 		if err != nil {
 			t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, gotFD)
 			t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, pidfd)
-			return fmt.Errorf("fcntl F_SETFD: %w", err)
+			return -1, fmt.Errorf("fcntl F_SETFD: %w", err)
 		}
 	}
 
 	t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, pidfd)
 
-	return nil
+	return savedFD, nil
 }
 
-// cleanupInjectedFD closes a previously injected fd in the tracee.
-func (t *Tracer) cleanupInjectedFD(tid int, savedRegs Regs, fdNum int) {
-	t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, uint64(fdNum))
+// cleanupInjectedFD closes a previously injected fd in the tracee and restores
+// any saved fd that was displaced.
+func (t *Tracer) cleanupInjectedFD(tid int, savedRegs Regs, fdNum int, savedFD int) {
+	if savedFD >= 0 {
+		// Restore the original fd by dup3-ing the saved copy back.
+		t.injectSyscall(tid, savedRegs, unix.SYS_DUP3,
+			uint64(savedFD), uint64(fdNum), 0)
+		t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, uint64(savedFD))
+	} else {
+		t.injectSyscall(tid, savedRegs, unix.SYS_CLOSE, uint64(fdNum))
+	}
 }

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -47,7 +47,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM|syscall.SOCK_CLOEXEC, 0)
 	if err != nil {
 		slog.Warn("redirectExec: socketpair failed", "tid", tid, "error", err)
-		t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 	tracerFD := fds[0]
@@ -63,7 +63,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	// Step 2: Inject fd into tracee via pidfd_getfd.
 	if err := t.injectFDIntoTracee(tid, savedRegs, injectFD, stubFDNum); err != nil {
 		slog.Warn("redirectExec: fd injection failed", "tid", tid, "error", err)
-		t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 
@@ -79,7 +79,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	if err != nil {
 		slog.Warn("redirectExec: read original filename failed", "tid", tid, "error", err)
 		t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
-		t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 	origLen := len(origFilename) + 1
@@ -89,7 +89,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 		if err := t.writeString(tid, filenamePtr, stubPath); err != nil {
 			slog.Warn("redirectExec: write stub path failed", "tid", tid, "error", err)
 			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
-			t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
+			t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 			return
 		}
 	} else {
@@ -105,7 +105,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 		if err != nil {
 			slog.Warn("redirectExec: scratch alloc failed", "tid", tid, "error", err)
 			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
-			t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
+			t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 			return
 		}
 
@@ -113,14 +113,14 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 		if err != nil {
 			slog.Warn("redirectExec: scratch page full", "tid", tid, "error", err)
 			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
-			t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
+			t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 			return
 		}
 
 		if err := t.writeString(tid, scratchAddr, stubPath); err != nil {
 			slog.Warn("redirectExec: write to scratch failed", "tid", tid, "error", err)
 			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
-			t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
+			t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 			return
 		}
 
@@ -142,7 +142,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	if err := t.setRegs(tid, injRegs); err != nil {
 		slog.Warn("redirectExec: setRegs failed", "tid", tid, "error", err)
 		t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
-		t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 
@@ -150,7 +150,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	if err := unix.PtraceSyscall(tid, 0); err != nil {
 		slog.Warn("redirectExec: resume to entry failed", "tid", tid, "error", err)
 		t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
-		t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 	if err := t.waitForSyscallStop(tid); err != nil {
@@ -160,7 +160,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 		t.mu.Unlock()
 		if tracked {
 			t.cleanupInjectedFD(tid, savedRegs, stubFDNum)
-			t.abortExecRedirect(tid, savedRegs, int(unix.EACCES))
+			t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		}
 		return
 	}
@@ -176,15 +176,6 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	t.allowSyscall(tid)
 }
 
-// abortExecRedirect recovers from a failed exec redirect when the tracee is
-// at an EXIT stop (after advancePastEntry). It makes the original syscall
-// appear to return the specified errno and resumes the tracee.
-func (t *Tracer) abortExecRedirect(tid int, savedRegs Regs, errno int) {
-	errRegs := savedRegs.Clone()
-	errRegs.SetReturnValue(int64(-errno))
-	t.setRegs(tid, errRegs)
-	t.allowSyscall(tid)
-}
 
 // injectFDIntoTracee injects a file descriptor from the tracer into the tracee
 // at the specified fd number, using pidfd_open + pidfd_getfd + dup3.

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -4,6 +4,7 @@ package ptrace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -186,7 +187,14 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	}
 	t.mu.Unlock()
 
-	t.allowSyscall(tid)
+	// Use PtraceSyscall (not allowSyscall) to ensure we catch the exec
+	// exit stop even in prefilter/seccomp mode. This is needed so the
+	// PendingExecStubFD cleanup runs on exec failure.
+	if err := unix.PtraceSyscall(tid, 0); err != nil {
+		if errors.Is(err, unix.ESRCH) {
+			t.handleExit(tid)
+		}
+	}
 }
 
 

--- a/internal/ptrace/redirect_file.go
+++ b/internal/ptrace/redirect_file.go
@@ -101,11 +101,10 @@ func (t *Tracer) redirectFileImpl(ctx context.Context, tid int, regs Regs, nr in
 
 // redirectFile redirects a file syscall to a different path.
 //
-// After injectSyscall returns, the injected syscall has completed its full
-// enter+exit cycle and the original registers are restored. The tracee is
-// stopped between syscalls (not inside one). We set the return value register
-// directly so the tracee sees the injected result, clear InSyscall to keep
-// the tracer's enter/exit tracking synchronized, and resume normally.
+// Advances past the original syscall entry first, so all injections use
+// the two-phase gadget protocol from EXIT state. After the injected
+// replacement syscall completes, sets the return value directly and
+// resumes the tracee.
 func (t *Tracer) redirectFile(ctx context.Context, tid int, regs Regs, nr int, result FileResult) {
 	if result.RedirectPath == "" {
 		slog.Warn("redirectFile: no redirect path, denying", "tid", tid)
@@ -113,10 +112,20 @@ func (t *Tracer) redirectFile(ctx context.Context, tid int, regs Regs, nr int, r
 		return
 	}
 
+	savedRegs := regs.Clone()
+
+	// Advance past the original syscall entry so all injections use
+	// the gadget protocol from EXIT state.
+	if err := t.advancePastEntry(tid, savedRegs); err != nil {
+		slog.Warn("redirectFile: advance past entry failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
 	ret, err := t.redirectFileImpl(ctx, tid, regs, nr, result.RedirectPath)
 	if err != nil {
-		slog.Warn("redirectFile: failed, denying", "tid", tid, "error", err)
-		t.denySyscall(tid, int(unix.EACCES))
+		slog.Warn("redirectFile: failed", "tid", tid, "error", err)
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 
@@ -125,20 +134,11 @@ func (t *Tracer) redirectFile(ctx context.Context, tid int, regs Regs, nr int, r
 	regs.SetReturnValue(ret)
 	if err := t.setRegs(tid, regs); err != nil {
 		slog.Warn("redirectFile: setRegs failed", "tid", tid, "error", err)
-		t.denySyscall(tid, int(unix.EACCES))
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 
-	// Clear InSyscall: the injection consumed the original syscall's
-	// enter+exit cycle via injectSyscall's internal Wait4 calls.
-	// The tracee is now stopped between syscalls, so the next ptrace
-	// stop will be a fresh syscall-enter.
-	t.mu.Lock()
-	if s, ok := t.tracees[tid]; ok {
-		s.InSyscall = false
-	}
-	t.mu.Unlock()
-
+	// InSyscall is already false from advancePastEntry.
 	t.allowSyscall(tid)
 }
 
@@ -171,6 +171,14 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, absPath
 
 	savedRegs := regs.Clone()
 
+	// Advance past the original syscall entry so all injections use
+	// the gadget protocol from EXIT state.
+	if err := t.advancePastEntry(tid, savedRegs); err != nil {
+		slog.Warn("softDeleteFile: advance past entry failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
 	// Get TGID for scratch page.
 	t.mu.Lock()
 	state := t.tracees[tid]
@@ -182,8 +190,8 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, absPath
 
 	sp, err := t.ensureScratchPage(tid, tgid, savedRegs)
 	if err != nil {
-		slog.Warn("softDeleteFile: scratch page failed, denying", "tid", tid, "error", err)
-		t.denySyscall(tid, int(unix.EACCES))
+		slog.Warn("softDeleteFile: scratch page failed", "tid", tid, "error", err)
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 
@@ -191,25 +199,25 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, absPath
 	trashDirAddr, err := sp.allocate(len(result.TrashDir) + 1)
 	if err != nil {
 		slog.Warn("softDeleteFile: scratch alloc trashDir failed", "tid", tid, "error", err)
-		t.denySyscall(tid, int(unix.EACCES))
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 	if err := t.writeString(tid, trashDirAddr, result.TrashDir); err != nil {
 		slog.Warn("softDeleteFile: write trashDir failed", "tid", tid, "error", err)
-		t.denySyscall(tid, int(unix.EACCES))
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 
 	mkdirRet, err := t.injectSyscall(tid, savedRegs, unix.SYS_MKDIRAT,
 		atFDCWD, trashDirAddr, 0700)
 	if err != nil {
-		slog.Warn("softDeleteFile: mkdirat injection failed, denying", "tid", tid, "error", err)
-		t.denySyscall(tid, int(unix.EACCES))
+		slog.Warn("softDeleteFile: mkdirat injection failed", "tid", tid, "error", err)
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 	if mkdirRet < 0 && unix.Errno(-mkdirRet) != unix.EEXIST {
-		slog.Warn("softDeleteFile: mkdirat failed, denying", "tid", tid, "errno", unix.Errno(-mkdirRet))
-		t.denySyscall(tid, int(unix.EACCES))
+		slog.Warn("softDeleteFile: mkdirat failed", "tid", tid, "errno", unix.Errno(-mkdirRet))
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 
@@ -219,24 +227,24 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, absPath
 	oldPathAddr, err := sp.allocate(len(absPath) + 1)
 	if err != nil {
 		slog.Warn("softDeleteFile: scratch alloc oldPath failed", "tid", tid, "error", err)
-		t.denySyscall(tid, int(unix.EACCES))
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 	if err := t.writeString(tid, oldPathAddr, absPath); err != nil {
 		slog.Warn("softDeleteFile: write oldPath failed", "tid", tid, "error", err)
-		t.denySyscall(tid, int(unix.EACCES))
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 
 	trashPathAddr, err := sp.allocate(len(trashPath) + 1)
 	if err != nil {
 		slog.Warn("softDeleteFile: scratch alloc trashPath failed", "tid", tid, "error", err)
-		t.denySyscall(tid, int(unix.EACCES))
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 	if err := t.writeString(tid, trashPathAddr, trashPath); err != nil {
 		slog.Warn("softDeleteFile: write trashPath failed", "tid", tid, "error", err)
-		t.denySyscall(tid, int(unix.EACCES))
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 
@@ -246,14 +254,14 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, absPath
 		atFDCWD, trashPathAddr,
 		0)
 	if err != nil {
-		slog.Warn("softDeleteFile: renameat2 injection failed, denying", "tid", tid, "error", err)
-		t.denySyscall(tid, int(unix.EACCES))
+		slog.Warn("softDeleteFile: renameat2 injection failed", "tid", tid, "error", err)
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 	if renameRet < 0 {
 		errno := unix.Errno(-renameRet)
-		slog.Warn("softDeleteFile: renameat2 failed, denying", "tid", tid, "errno", errno)
-		t.denySyscall(tid, int(unix.EACCES))
+		slog.Warn("softDeleteFile: renameat2 failed", "tid", tid, "errno", errno)
+		t.resumeWithErrno(tid, savedRegs, int(unix.EACCES))
 		return
 	}
 
@@ -264,15 +272,6 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, absPath
 		slog.Warn("softDeleteFile: setRegs failed after rename", "tid", tid, "error", err)
 	}
 
-	// Clear InSyscall: the injection consumed the original syscall's
-	// enter+exit cycle via injectSyscall's internal Wait4 calls.
-	// The tracee is now stopped between syscalls, so the next ptrace
-	// stop will be a fresh syscall-enter.
-	t.mu.Lock()
-	if s, ok := t.tracees[tid]; ok {
-		s.InSyscall = false
-	}
-	t.mu.Unlock()
-
+	// InSyscall is already false from advancePastEntry.
 	t.allowSyscall(tid)
 }

--- a/internal/ptrace/redirect_file.go
+++ b/internal/ptrace/redirect_file.go
@@ -175,8 +175,13 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, result 
 		return
 	}
 
-	mkdirRet, _ := t.injectSyscall(tid, savedRegs, unix.SYS_MKDIRAT,
+	mkdirRet, err := t.injectSyscall(tid, savedRegs, unix.SYS_MKDIRAT,
 		atFDCWD, trashDirAddr, 0700)
+	if err != nil {
+		slog.Warn("softDeleteFile: mkdirat injection failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
 	if mkdirRet < 0 && unix.Errno(-mkdirRet) != unix.EEXIST {
 		slog.Warn("softDeleteFile: mkdirat failed, denying", "tid", tid, "errno", unix.Errno(-mkdirRet))
 		t.denySyscall(tid, int(unix.EACCES))
@@ -211,10 +216,15 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, result 
 	}
 
 	// Inject renameat2.
-	renameRet, _ := t.injectSyscall(tid, savedRegs, unix.SYS_RENAMEAT2,
+	renameRet, err := t.injectSyscall(tid, savedRegs, unix.SYS_RENAMEAT2,
 		atFDCWD, oldPathAddr,
 		atFDCWD, trashPathAddr,
 		0)
+	if err != nil {
+		slog.Warn("softDeleteFile: renameat2 injection failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
 	if renameRet < 0 {
 		errno := unix.Errno(-renameRet)
 		slog.Warn("softDeleteFile: renameat2 failed, denying", "tid", tid, "errno", errno)
@@ -235,7 +245,7 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, result 
 
 	t.mu.Lock()
 	if s, ok := t.tracees[tid]; ok {
-		s.PendingDenyErrno = 0
+		s.PendingFakeZero = true
 		s.InSyscall = true
 	}
 	t.mu.Unlock()

--- a/internal/ptrace/redirect_file.go
+++ b/internal/ptrace/redirect_file.go
@@ -226,7 +226,12 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, result 
 
 	// Deny the original unlinkat with fake success (return 0).
 	regs.SetSyscallNr(-1)
-	t.setRegs(tid, regs)
+	if err := t.setRegs(tid, regs); err != nil {
+		slog.Warn("softDeleteFile: setRegs failed after rename", "tid", tid, "error", err)
+		// File is already moved; best effort to resume the tracee.
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
 
 	t.mu.Lock()
 	if s, ok := t.tracees[tid]; ok {
@@ -235,5 +240,7 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, result 
 	}
 	t.mu.Unlock()
 
-	unix.PtraceSyscall(tid, 0)
+	if err := unix.PtraceSyscall(tid, 0); err != nil {
+		slog.Warn("softDeleteFile: PtraceSyscall failed", "tid", tid, "error", err)
+	}
 }

--- a/internal/ptrace/redirect_file.go
+++ b/internal/ptrace/redirect_file.go
@@ -270,6 +270,8 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, absPath
 	regs.SetReturnValue(0)
 	if err := t.setRegs(tid, regs); err != nil {
 		slog.Warn("softDeleteFile: setRegs failed after rename", "tid", tid, "error", err)
+		t.resumeWithErrno(tid, savedRegs, int(unix.EIO))
+		return
 	}
 
 	// InSyscall is already false from advancePastEntry.

--- a/internal/ptrace/redirect_file.go
+++ b/internal/ptrace/redirect_file.go
@@ -1,0 +1,239 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+
+	"golang.org/x/sys/unix"
+)
+
+// atFDCWD is AT_FDCWD (-100) as a uint64 for use in injected syscall args.
+// Go's const -100 cannot be directly converted to uint64, so we compute the
+// two's complement representation that the kernel expects for a 64-bit register.
+const atFDCWD = ^uint64(99) // 0xFFFFFFFFFFFFFF9C
+
+// filePathArgIndex returns the register index containing the path pointer
+// for the given file syscall number.
+func filePathArgIndex(nr int) int {
+	switch nr {
+	case unix.SYS_OPENAT, unix.SYS_OPENAT2:
+		return 1
+	case unix.SYS_UNLINKAT, unix.SYS_MKDIRAT:
+		return 1
+	case unix.SYS_FCHMODAT, unix.SYS_FCHMODAT2:
+		return 1
+	case unix.SYS_FCHOWNAT:
+		return 1
+	case unix.SYS_RENAMEAT2:
+		return 1
+	case unix.SYS_LINKAT:
+		return 1
+	case unix.SYS_SYMLINKAT:
+		return 0
+	default:
+		return -1
+	}
+}
+
+// redirectFileImpl redirects a file syscall to a different path.
+func (t *Tracer) redirectFileImpl(ctx context.Context, tid int, regs Regs, nr int, redirectPath string) error {
+	argIdx := filePathArgIndex(nr)
+	if argIdx < 0 {
+		return fmt.Errorf("unsupported syscall %d for file redirect", nr)
+	}
+
+	pathPtr := regs.Arg(argIdx)
+
+	// Read original path to determine buffer length.
+	origPath, err := t.readString(tid, pathPtr, 4096)
+	if err != nil {
+		return fmt.Errorf("read original path: %w", err)
+	}
+	origLen := len(origPath) + 1
+
+	if len(redirectPath)+1 <= origLen {
+		return t.writeString(tid, pathPtr, redirectPath)
+	}
+
+	// Need scratch page.
+	t.mu.Lock()
+	state := t.tracees[tid]
+	tgid := tid
+	if state != nil {
+		tgid = state.TGID
+	}
+	t.mu.Unlock()
+
+	savedRegs := regs.Clone()
+	sp, err := t.ensureScratchPage(tid, tgid, savedRegs)
+	if err != nil {
+		return fmt.Errorf("scratch page: %w", err)
+	}
+
+	scratchAddr, err := sp.allocate(len(redirectPath) + 1)
+	if err != nil {
+		return fmt.Errorf("scratch allocate: %w", err)
+	}
+
+	if err := t.writeString(tid, scratchAddr, redirectPath); err != nil {
+		return fmt.Errorf("write to scratch: %w", err)
+	}
+
+	regs.SetArg(argIdx, scratchAddr)
+	return t.setRegs(tid, regs)
+}
+
+// redirectFile redirects a file syscall to a different path.
+func (t *Tracer) redirectFile(ctx context.Context, tid int, regs Regs, nr int, result FileResult) {
+	if result.RedirectPath == "" {
+		slog.Warn("redirectFile: no redirect path, denying", "tid", tid)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	if err := t.redirectFileImpl(ctx, tid, regs, nr, result.RedirectPath); err != nil {
+		slog.Warn("redirectFile: failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	t.allowSyscall(tid)
+}
+
+// softDeleteFile performs a soft-delete: denies the unlinkat but moves the file
+// to a trash directory instead of actually deleting it.
+func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, result FileResult) {
+	if result.TrashDir == "" {
+		slog.Warn("softDeleteFile: no trash dir, denying", "tid", tid)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	nr := regs.SyscallNr()
+	if nr != unix.SYS_UNLINKAT {
+		slog.Warn("softDeleteFile: only supported for unlinkat", "tid", tid, "nr", nr)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Read the path being deleted.
+	pathPtr := regs.Arg(1)
+	origPath, err := t.readString(tid, pathPtr, 4096)
+	if err != nil {
+		slog.Warn("softDeleteFile: cannot read path, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	dirfd := int(int32(regs.Arg(0)))
+	absPath, err := resolvePathNoFollow(tid, dirfd, origPath)
+	if err != nil {
+		slog.Warn("softDeleteFile: cannot resolve path, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Generate unique trash filename.
+	var rndBuf [8]byte
+	rand.Read(rndBuf[:])
+	trashName := hex.EncodeToString(rndBuf[:])
+	trashPath := result.TrashDir + "/" + trashName
+
+	savedRegs := regs.Clone()
+
+	// Get TGID for scratch page.
+	t.mu.Lock()
+	state := t.tracees[tid]
+	tgid := tid
+	if state != nil {
+		tgid = state.TGID
+	}
+	t.mu.Unlock()
+
+	sp, err := t.ensureScratchPage(tid, tgid, savedRegs)
+	if err != nil {
+		slog.Warn("softDeleteFile: scratch page failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Write trash dir path to scratch and inject mkdirat.
+	trashDirAddr, err := sp.allocate(len(result.TrashDir) + 1)
+	if err != nil {
+		slog.Warn("softDeleteFile: scratch alloc trashDir failed", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+	if err := t.writeString(tid, trashDirAddr, result.TrashDir); err != nil {
+		slog.Warn("softDeleteFile: write trashDir failed", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	mkdirRet, _ := t.injectSyscall(tid, savedRegs, unix.SYS_MKDIRAT,
+		atFDCWD, trashDirAddr, 0700)
+	if mkdirRet < 0 && unix.Errno(-mkdirRet) != unix.EEXIST {
+		slog.Warn("softDeleteFile: mkdirat failed, denying", "tid", tid, "errno", unix.Errno(-mkdirRet))
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	sp.reset()
+
+	// Write old path (absolute) and trash path to scratch.
+	oldPathAddr, err := sp.allocate(len(absPath) + 1)
+	if err != nil {
+		slog.Warn("softDeleteFile: scratch alloc oldPath failed", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+	if err := t.writeString(tid, oldPathAddr, absPath); err != nil {
+		slog.Warn("softDeleteFile: write oldPath failed", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	trashPathAddr, err := sp.allocate(len(trashPath) + 1)
+	if err != nil {
+		slog.Warn("softDeleteFile: scratch alloc trashPath failed", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+	if err := t.writeString(tid, trashPathAddr, trashPath); err != nil {
+		slog.Warn("softDeleteFile: write trashPath failed", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Inject renameat2.
+	renameRet, _ := t.injectSyscall(tid, savedRegs, unix.SYS_RENAMEAT2,
+		atFDCWD, oldPathAddr,
+		atFDCWD, trashPathAddr,
+		0)
+	if renameRet < 0 {
+		errno := unix.Errno(-renameRet)
+		slog.Warn("softDeleteFile: renameat2 failed, denying", "tid", tid, "errno", errno)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	slog.Info("softDeleteFile: file moved to trash", "original", absPath, "trash", trashPath)
+
+	// Deny the original unlinkat with fake success (return 0).
+	regs.SetSyscallNr(-1)
+	t.setRegs(tid, regs)
+
+	t.mu.Lock()
+	if s, ok := t.tracees[tid]; ok {
+		s.PendingDenyErrno = 0
+		s.InSyscall = true
+	}
+	t.mu.Unlock()
+
+	unix.PtraceSyscall(tid, 0)
+}

--- a/internal/ptrace/redirect_file.go
+++ b/internal/ptrace/redirect_file.go
@@ -40,27 +40,26 @@ func filePathArgIndex(nr int) int {
 	}
 }
 
-// redirectFileImpl redirects a file syscall to a different path.
-func (t *Tracer) redirectFileImpl(ctx context.Context, tid int, regs Regs, nr int, redirectPath string) error {
+// redirectFileImpl injects a replacement file syscall with the redirect path.
+//
+// The kernel copies the filename from userspace via getname_flags() BEFORE
+// delivering the ptrace seccomp/syscall-enter stop, so modifying the path
+// in-place at that point is too late. Instead, we:
+//  1. Write the redirect path to a scratch page
+//  2. Inject a replacement syscall with all original args except the path
+//  3. Return the injected syscall's return value
+//
+// After injection, the caller sets the return value directly in the registers
+// and clears InSyscall so the tracer's enter/exit tracking stays synchronized.
+func (t *Tracer) redirectFileImpl(ctx context.Context, tid int, regs Regs, nr int, redirectPath string) (int64, error) {
 	argIdx := filePathArgIndex(nr)
 	if argIdx < 0 {
-		return fmt.Errorf("unsupported syscall %d for file redirect", nr)
+		return 0, fmt.Errorf("unsupported syscall %d for file redirect", nr)
 	}
 
-	pathPtr := regs.Arg(argIdx)
+	savedRegs := regs.Clone()
 
-	// Read original path to determine buffer length.
-	origPath, err := t.readString(tid, pathPtr, 4096)
-	if err != nil {
-		return fmt.Errorf("read original path: %w", err)
-	}
-	origLen := len(origPath) + 1
-
-	if len(redirectPath)+1 <= origLen {
-		return t.writeString(tid, pathPtr, redirectPath)
-	}
-
-	// Need scratch page.
+	// Get TGID for scratch page.
 	t.mu.Lock()
 	state := t.tracees[tid]
 	tgid := tid
@@ -69,26 +68,44 @@ func (t *Tracer) redirectFileImpl(ctx context.Context, tid int, regs Regs, nr in
 	}
 	t.mu.Unlock()
 
-	savedRegs := regs.Clone()
 	sp, err := t.ensureScratchPage(tid, tgid, savedRegs)
 	if err != nil {
-		return fmt.Errorf("scratch page: %w", err)
+		return 0, fmt.Errorf("scratch page: %w", err)
 	}
 
-	scratchAddr, err := sp.allocate(len(redirectPath) + 1)
+	pathAddr, err := sp.allocate(len(redirectPath) + 1)
 	if err != nil {
-		return fmt.Errorf("scratch allocate: %w", err)
+		return 0, fmt.Errorf("scratch allocate: %w", err)
 	}
 
-	if err := t.writeString(tid, scratchAddr, redirectPath); err != nil {
-		return fmt.Errorf("write to scratch: %w", err)
+	if err := t.writeString(tid, pathAddr, redirectPath); err != nil {
+		return 0, fmt.Errorf("write to scratch: %w", err)
 	}
 
-	regs.SetArg(argIdx, scratchAddr)
-	return t.setRegs(tid, regs)
+	// Copy all 6 args from the original syscall, replacing the path arg.
+	var args [6]uint64
+	for i := 0; i < 6; i++ {
+		args[i] = regs.Arg(i)
+	}
+	args[argIdx] = pathAddr
+
+	// Inject the replacement syscall.
+	ret, err := t.injectSyscall(tid, savedRegs, nr,
+		args[0], args[1], args[2], args[3], args[4], args[5])
+	if err != nil {
+		return 0, fmt.Errorf("inject syscall: %w", err)
+	}
+
+	return ret, nil
 }
 
 // redirectFile redirects a file syscall to a different path.
+//
+// After injectSyscall returns, the injected syscall has completed its full
+// enter+exit cycle and the original registers are restored. The tracee is
+// stopped between syscalls (not inside one). We set the return value register
+// directly so the tracee sees the injected result, clear InSyscall to keep
+// the tracer's enter/exit tracking synchronized, and resume normally.
 func (t *Tracer) redirectFile(ctx context.Context, tid int, regs Regs, nr int, result FileResult) {
 	if result.RedirectPath == "" {
 		slog.Warn("redirectFile: no redirect path, denying", "tid", tid)
@@ -96,18 +113,39 @@ func (t *Tracer) redirectFile(ctx context.Context, tid int, regs Regs, nr int, r
 		return
 	}
 
-	if err := t.redirectFileImpl(ctx, tid, regs, nr, result.RedirectPath); err != nil {
+	ret, err := t.redirectFileImpl(ctx, tid, regs, nr, result.RedirectPath)
+	if err != nil {
 		slog.Warn("redirectFile: failed, denying", "tid", tid, "error", err)
 		t.denySyscall(tid, int(unix.EACCES))
 		return
 	}
+
+	// Set the return value directly in the registers. The tracee will see
+	// this as the result of the original syscall when it resumes.
+	regs.SetReturnValue(ret)
+	if err := t.setRegs(tid, regs); err != nil {
+		slog.Warn("redirectFile: setRegs failed", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	// Clear InSyscall: the injection consumed the original syscall's
+	// enter+exit cycle via injectSyscall's internal Wait4 calls.
+	// The tracee is now stopped between syscalls, so the next ptrace
+	// stop will be a fresh syscall-enter.
+	t.mu.Lock()
+	if s, ok := t.tracees[tid]; ok {
+		s.InSyscall = false
+	}
+	t.mu.Unlock()
 
 	t.allowSyscall(tid)
 }
 
 // softDeleteFile performs a soft-delete: denies the unlinkat but moves the file
 // to a trash directory instead of actually deleting it.
-func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, result FileResult) {
+// The absPath parameter is the already-resolved absolute path from handleFile.
+func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, absPath string, result FileResult) {
 	if result.TrashDir == "" {
 		slog.Warn("softDeleteFile: no trash dir, denying", "tid", tid)
 		t.denySyscall(tid, int(unix.EACCES))
@@ -117,23 +155,6 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, result 
 	nr := regs.SyscallNr()
 	if nr != unix.SYS_UNLINKAT {
 		slog.Warn("softDeleteFile: only supported for unlinkat", "tid", tid, "nr", nr)
-		t.denySyscall(tid, int(unix.EACCES))
-		return
-	}
-
-	// Read the path being deleted.
-	pathPtr := regs.Arg(1)
-	origPath, err := t.readString(tid, pathPtr, 4096)
-	if err != nil {
-		slog.Warn("softDeleteFile: cannot read path, denying", "tid", tid, "error", err)
-		t.denySyscall(tid, int(unix.EACCES))
-		return
-	}
-
-	dirfd := int(int32(regs.Arg(0)))
-	absPath, err := resolvePathNoFollow(tid, dirfd, origPath)
-	if err != nil {
-		slog.Warn("softDeleteFile: cannot resolve path, denying", "tid", tid, "error", err)
 		t.denySyscall(tid, int(unix.EACCES))
 		return
 	}
@@ -236,25 +257,22 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, result 
 		return
 	}
 
-	slog.Info("softDeleteFile: file moved to trash", "original", absPath, "trash", trashPath)
-
-	// Deny the original unlinkat with fake success (return 0).
-	regs.SetSyscallNr(-1)
+	// Set the return value to 0 (success) so the tracee sees the
+	// unlinkat as having succeeded.
+	regs.SetReturnValue(0)
 	if err := t.setRegs(tid, regs); err != nil {
 		slog.Warn("softDeleteFile: setRegs failed after rename", "tid", tid, "error", err)
-		// File is already moved; best effort to resume the tracee.
-		t.denySyscall(tid, int(unix.EACCES))
-		return
 	}
 
+	// Clear InSyscall: the injection consumed the original syscall's
+	// enter+exit cycle via injectSyscall's internal Wait4 calls.
+	// The tracee is now stopped between syscalls, so the next ptrace
+	// stop will be a fresh syscall-enter.
 	t.mu.Lock()
 	if s, ok := t.tracees[tid]; ok {
-		s.PendingFakeZero = true
-		s.InSyscall = true
+		s.InSyscall = false
 	}
 	t.mu.Unlock()
 
-	if err := unix.PtraceSyscall(tid, 0); err != nil {
-		slog.Warn("softDeleteFile: PtraceSyscall failed", "tid", tid, "error", err)
-	}
+	t.allowSyscall(tid)
 }

--- a/internal/ptrace/redirect_file.go
+++ b/internal/ptrace/redirect_file.go
@@ -140,7 +140,11 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, result 
 
 	// Generate unique trash filename.
 	var rndBuf [8]byte
-	rand.Read(rndBuf[:])
+	if _, err := rand.Read(rndBuf[:]); err != nil {
+		slog.Warn("softDeleteFile: rand.Read failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
 	trashName := hex.EncodeToString(rndBuf[:])
 	trashPath := result.TrashDir + "/" + trashName
 

--- a/internal/ptrace/redirect_file.go
+++ b/internal/ptrace/redirect_file.go
@@ -36,7 +36,8 @@ func filePathArgIndex(nr int) int {
 	case unix.SYS_SYMLINKAT:
 		return 0
 	default:
-		return -1
+		// Check for legacy (non-at) file syscalls on architectures that have them.
+		return legacyFilePathArgIndex(nr)
 	}
 }
 
@@ -153,8 +154,8 @@ func (t *Tracer) softDeleteFile(ctx context.Context, tid int, regs Regs, absPath
 	}
 
 	nr := regs.SyscallNr()
-	if nr != unix.SYS_UNLINKAT {
-		slog.Warn("softDeleteFile: only supported for unlinkat", "tid", tid, "nr", nr)
+	if nr != unix.SYS_UNLINKAT && !isLegacyUnlink(nr) {
+		slog.Warn("softDeleteFile: only supported for unlinkat/unlink", "tid", tid, "nr", nr)
 		t.denySyscall(tid, int(unix.EACCES))
 		return
 	}

--- a/internal/ptrace/redirect_net.go
+++ b/internal/ptrace/redirect_net.go
@@ -1,0 +1,141 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+// redirectConnect redirects a connect() syscall to a different address/port
+// by overwriting the sockaddr in tracee memory.
+func (t *Tracer) redirectConnect(ctx context.Context, tid int, regs Regs, result NetworkResult) {
+	if result.RedirectAddr == "" && result.RedirectPort == 0 {
+		slog.Warn("redirectConnect: no redirect target, denying", "tid", tid)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	addrPtr := regs.Arg(1)
+	addrLen := int(regs.Arg(2))
+	if addrLen == 0 || addrLen > 128 {
+		slog.Warn("redirectConnect: invalid addrlen, denying", "tid", tid, "addrlen", addrLen)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	buf := make([]byte, addrLen)
+	if err := t.readBytes(tid, addrPtr, buf); err != nil {
+		slog.Warn("redirectConnect: read sockaddr failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	if len(buf) < 2 {
+		slog.Warn("redirectConnect: sockaddr too short, denying", "tid", tid)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	family := int(binary.NativeEndian.Uint16(buf[0:2]))
+
+	// Resolve redirect address.
+	var redirectIP net.IP
+	if result.RedirectAddr != "" {
+		redirectIP = net.ParseIP(result.RedirectAddr)
+		if redirectIP == nil {
+			ips, err := net.LookupIP(result.RedirectAddr)
+			if err != nil || len(ips) == 0 {
+				slog.Warn("redirectConnect: cannot resolve redirect addr, denying",
+					"tid", tid, "addr", result.RedirectAddr, "error", err)
+				t.denySyscall(tid, int(unix.EACCES))
+				return
+			}
+			for _, ip := range ips {
+				if family == unix.AF_INET && ip.To4() != nil {
+					redirectIP = ip.To4()
+					break
+				}
+				if family == unix.AF_INET6 && ip.To4() == nil {
+					redirectIP = ip
+					break
+				}
+			}
+			if redirectIP == nil {
+				redirectIP = ips[0]
+			}
+		}
+	}
+
+	var newBuf []byte
+
+	switch family {
+	case unix.AF_INET:
+		if len(buf) < 8 {
+			slog.Warn("redirectConnect: sockaddr_in too short", "tid", tid)
+			t.denySyscall(tid, int(unix.EACCES))
+			return
+		}
+		newBuf = make([]byte, len(buf))
+		copy(newBuf, buf)
+		if result.RedirectPort > 0 {
+			binary.BigEndian.PutUint16(newBuf[2:4], uint16(result.RedirectPort))
+		}
+		if redirectIP != nil {
+			ip4 := redirectIP.To4()
+			if ip4 == nil {
+				slog.Warn("redirectConnect: IPv6 redirect for IPv4 socket, denying", "tid", tid)
+				t.denySyscall(tid, int(unix.EACCES))
+				return
+			}
+			copy(newBuf[4:8], ip4)
+		}
+
+	case unix.AF_INET6:
+		if len(buf) < 28 {
+			slog.Warn("redirectConnect: sockaddr_in6 too short", "tid", tid)
+			t.denySyscall(tid, int(unix.EACCES))
+			return
+		}
+		newBuf = make([]byte, len(buf))
+		copy(newBuf, buf)
+		if result.RedirectPort > 0 {
+			binary.BigEndian.PutUint16(newBuf[2:4], uint16(result.RedirectPort))
+		}
+		if redirectIP != nil {
+			ip16 := redirectIP.To16()
+			if ip16 == nil {
+				slog.Warn("redirectConnect: cannot convert redirect addr to IPv6", "tid", tid)
+				t.denySyscall(tid, int(unix.EACCES))
+				return
+			}
+			copy(newBuf[8:24], ip16)
+		}
+
+	default:
+		slog.Warn("redirectConnect: unsupported address family", "tid", tid, "family", family)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	if err := t.writeBytes(tid, addrPtr, newBuf); err != nil {
+		slog.Warn("redirectConnect: write sockaddr failed, denying", "tid", tid, "error", err)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
+	if result.RedirectPort > 0 || redirectIP != nil {
+		_, origAddress, origPort, _ := parseSockaddr(buf)
+		_, newAddress, newPort, _ := parseSockaddr(newBuf)
+		origAddr := fmt.Sprintf("%s:%d", origAddress, origPort)
+		newAddr := fmt.Sprintf("%s:%d", newAddress, newPort)
+		slog.Info("redirectConnect: rewritten", "tid", tid, "from", origAddr, "to", newAddr)
+	}
+
+	t.allowSyscall(tid)
+}

--- a/internal/ptrace/redirect_net.go
+++ b/internal/ptrace/redirect_net.go
@@ -21,6 +21,13 @@ func (t *Tracer) redirectConnect(ctx context.Context, tid int, regs Regs, result
 		return
 	}
 
+	if result.RedirectPort < 0 || result.RedirectPort > 65535 {
+		slog.Warn("redirectConnect: invalid redirect port, denying",
+			"tid", tid, "port", result.RedirectPort)
+		t.denySyscall(tid, int(unix.EACCES))
+		return
+	}
+
 	addrPtr := regs.Arg(1)
 	addrLen := int(regs.Arg(2))
 	if addrLen == 0 || addrLen > 128 {
@@ -44,31 +51,16 @@ func (t *Tracer) redirectConnect(ctx context.Context, tid int, regs Regs, result
 
 	family := int(binary.NativeEndian.Uint16(buf[0:2]))
 
-	// Resolve redirect address.
+	// Parse redirect address — must be a literal IP. DNS resolution in the
+	// ptrace stop path would block the tracer loop and stall all tracees.
 	var redirectIP net.IP
 	if result.RedirectAddr != "" {
 		redirectIP = net.ParseIP(result.RedirectAddr)
 		if redirectIP == nil {
-			ips, err := net.LookupIP(result.RedirectAddr)
-			if err != nil || len(ips) == 0 {
-				slog.Warn("redirectConnect: cannot resolve redirect addr, denying",
-					"tid", tid, "addr", result.RedirectAddr, "error", err)
-				t.denySyscall(tid, int(unix.EACCES))
-				return
-			}
-			for _, ip := range ips {
-				if family == unix.AF_INET && ip.To4() != nil {
-					redirectIP = ip.To4()
-					break
-				}
-				if family == unix.AF_INET6 && ip.To4() == nil {
-					redirectIP = ip
-					break
-				}
-			}
-			if redirectIP == nil {
-				redirectIP = ips[0]
-			}
+			slog.Warn("redirectConnect: redirect addr is not a literal IP, denying",
+				"tid", tid, "addr", result.RedirectAddr)
+			t.denySyscall(tid, int(unix.EACCES))
+			return
 		}
 	}
 

--- a/internal/ptrace/scratch.go
+++ b/internal/ptrace/scratch.go
@@ -39,6 +39,9 @@ func (s *scratchPage) reset() {
 
 // ensureScratchPage returns the scratch page for the given TGID, allocating one
 // via mmap injection if needed.
+//
+// Note: in practice this is only called from the single-threaded tracer event
+// loop, so races are not expected. The double-check pattern is defensive.
 func (t *Tracer) ensureScratchPage(tid, tgid int, savedRegs Regs) (*scratchPage, error) {
 	t.mu.Lock()
 	sp := t.tgidScratch[tgid]
@@ -63,6 +66,13 @@ func (t *Tracer) ensureScratchPage(tid, tgid int, savedRegs Regs) (*scratchPage,
 	sp = &scratchPage{addr: addr, size: 4096}
 
 	t.mu.Lock()
+	// Double-check: another path may have created a scratch page while we
+	// were injecting mmap. Use the existing one and let our mapping leak
+	// (harmless: it will be unmapped when the process exits).
+	if existing := t.tgidScratch[tgid]; existing != nil {
+		t.mu.Unlock()
+		return existing, nil
+	}
 	t.tgidScratch[tgid] = sp
 	t.mu.Unlock()
 

--- a/internal/ptrace/scratch.go
+++ b/internal/ptrace/scratch.go
@@ -88,6 +88,12 @@ func (t *Tracer) invalidateScratchPage(tgid int) {
 
 // resetScratchIfPresent resets the bump allocator for the given TGID's scratch
 // page, if one exists. Called at each syscall-enter to reclaim space.
+//
+// This is safe despite sharing per-TGID because the tracer event loop is
+// single-threaded: it processes one syscall stop at a time. By the time the
+// next thread in the same TGID hits syscall-enter (triggering reset), the
+// previous thread's redirected path has already been consumed by the kernel
+// during the setRegs+resume sequence.
 func (t *Tracer) resetScratchIfPresent(tgid int) {
 	t.mu.Lock()
 	sp := t.tgidScratch[tgid]

--- a/internal/ptrace/scratch.go
+++ b/internal/ptrace/scratch.go
@@ -85,3 +85,14 @@ func (t *Tracer) invalidateScratchPage(tgid int) {
 	delete(t.tgidScratch, tgid)
 	t.mu.Unlock()
 }
+
+// resetScratchIfPresent resets the bump allocator for the given TGID's scratch
+// page, if one exists. Called at each syscall-enter to reclaim space.
+func (t *Tracer) resetScratchIfPresent(tgid int) {
+	t.mu.Lock()
+	sp := t.tgidScratch[tgid]
+	t.mu.Unlock()
+	if sp != nil {
+		sp.reset()
+	}
+}

--- a/internal/ptrace/scratch.go
+++ b/internal/ptrace/scratch.go
@@ -1,0 +1,77 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"fmt"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+// scratchPage tracks a scratch memory page mmap'd into a tracee's address space.
+// Per-TGID: threads in the same process share address space.
+type scratchPage struct {
+	mu   sync.Mutex
+	addr uint64 // base address of the mmap'd page
+	used int    // bytes used (bump allocator)
+	size int    // page size (4096)
+}
+
+// allocate returns a pointer to n bytes within the scratch page.
+func (s *scratchPage) allocate(n int) (uint64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.used+n > s.size {
+		return 0, fmt.Errorf("scratch page full: used=%d, need=%d, size=%d", s.used, n, s.size)
+	}
+	addr := s.addr + uint64(s.used)
+	s.used += n
+	return addr, nil
+}
+
+// reset resets the bump allocator. Call at each new syscall-enter stop.
+func (s *scratchPage) reset() {
+	s.mu.Lock()
+	s.used = 0
+	s.mu.Unlock()
+}
+
+// ensureScratchPage returns the scratch page for the given TGID, allocating one
+// via mmap injection if needed.
+func (t *Tracer) ensureScratchPage(tid, tgid int, savedRegs Regs) (*scratchPage, error) {
+	t.mu.Lock()
+	sp := t.tgidScratch[tgid]
+	t.mu.Unlock()
+
+	if sp != nil {
+		return sp, nil
+	}
+
+	// Inject mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0)
+	addr, err := t.injectSyscallRet(tid, savedRegs, unix.SYS_MMAP,
+		0, 4096,
+		uint64(unix.PROT_READ|unix.PROT_WRITE),
+		uint64(unix.MAP_PRIVATE|unix.MAP_ANONYMOUS),
+		^uint64(0), // fd = -1
+		0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("mmap injection: %w", err)
+	}
+
+	sp = &scratchPage{addr: addr, size: 4096}
+
+	t.mu.Lock()
+	t.tgidScratch[tgid] = sp
+	t.mu.Unlock()
+
+	return sp, nil
+}
+
+// invalidateScratchPage removes the scratch page for a TGID.
+func (t *Tracer) invalidateScratchPage(tgid int) {
+	t.mu.Lock()
+	delete(t.tgidScratch, tgid)
+	t.mu.Unlock()
+}

--- a/internal/ptrace/syscalls_amd64.go
+++ b/internal/ptrace/syscalls_amd64.go
@@ -21,3 +21,25 @@ func legacyFileSyscalls() []int {
 		unix.SYS_SYMLINK, unix.SYS_CHMOD, unix.SYS_CHOWN,
 	}
 }
+
+// legacyFilePathArgIndex returns the register index containing the path pointer
+// for legacy (non-at) file syscalls on amd64. Returns -1 if unsupported.
+func legacyFilePathArgIndex(nr int) int {
+	switch nr {
+	case unix.SYS_OPEN, unix.SYS_CREAT, unix.SYS_UNLINK,
+		unix.SYS_MKDIR, unix.SYS_RMDIR, unix.SYS_CHMOD, unix.SYS_CHOWN:
+		return 0
+	case unix.SYS_RENAME:
+		return 0 // oldpath; newpath is arg1
+	case unix.SYS_LINK:
+		return 0 // oldpath; newpath is arg1
+	case unix.SYS_SYMLINK:
+		return 0 // target; linkpath is arg1
+	}
+	return -1
+}
+
+// isLegacyUnlink returns true if nr is the legacy SYS_UNLINK syscall.
+func isLegacyUnlink(nr int) bool {
+	return nr == unix.SYS_UNLINK
+}

--- a/internal/ptrace/syscalls_arm64.go
+++ b/internal/ptrace/syscalls_arm64.go
@@ -2,5 +2,7 @@
 
 package ptrace
 
-func isLegacyFileSyscall(nr int) bool { return false }
-func legacyFileSyscalls() []int       { return nil }
+func isLegacyFileSyscall(nr int) bool   { return false }
+func legacyFileSyscalls() []int         { return nil }
+func legacyFilePathArgIndex(nr int) int { return -1 }
+func isLegacyUnlink(nr int) bool        { return false }

--- a/internal/ptrace/testhelper_execveat_test.go
+++ b/internal/ptrace/testhelper_execveat_test.go
@@ -99,7 +99,7 @@ func TestIntegration_ExecveatATEmptyPath(t *testing.T) {
 	tr.AttachPID(cmd.Process.Pid)
 	cmd.Wait()
 
-	waitForTraceesDrained(t, tr, 2*time.Second)
+	waitForTraceesDrained(t, tr, 5*time.Second)
 	cancel()
 	<-errCh
 

--- a/internal/ptrace/testhelper_execveat_test.go
+++ b/internal/ptrace/testhelper_execveat_test.go
@@ -104,12 +104,11 @@ func TestIntegration_ExecveatATEmptyPath(t *testing.T) {
 	<-errCh
 
 	handler.mu.Lock()
-	defer handler.mu.Unlock()
-
 	t.Logf("total handler calls: %d", len(handler.calls))
 	for _, c := range handler.calls {
 		t.Logf("  filename=%q argv=%v", c.Filename, c.Argv)
 	}
+	handler.mu.Unlock()
 
 	// Check if handler received a call with /bin/echo (resolved from fd)
 	echoCalls := handler.CallsMatching("echo")

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -618,7 +618,7 @@ func (t *Tracer) handleExecve(ctx context.Context, tid int, regs Regs) {
 	})
 
 	switch result.Action {
-	case "", "continue":
+	case "", "continue", "allow":
 		t.allowSyscall(tid)
 	case "deny":
 		errno := result.Errno

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -325,6 +325,17 @@ func ptraceListen(tid int) {
 		uintptr(unix.PTRACE_LISTEN), uintptr(tid), 0, 0, 0, 0)
 }
 
+// resumeWithErrno resumes a tracee from EXIT/between-syscalls state,
+// making the current or previous syscall appear to return the specified errno.
+// Used in error paths after advancePastEntry or injection has consumed the
+// original entry.
+func (t *Tracer) resumeWithErrno(tid int, savedRegs Regs, errno int) {
+	errRegs := savedRegs.Clone()
+	errRegs.SetReturnValue(int64(-errno))
+	t.setRegs(tid, errRegs)
+	t.allowSyscall(tid)
+}
+
 // applyDenyFixup overwrites the syscall return value with -errno.
 func (t *Tracer) applyDenyFixup(tid int, errno int) {
 	regs, err := t.getRegs(tid)
@@ -569,19 +580,24 @@ func (t *Tracer) handleNewChild(parentTID int, event int) {
 	isNewProcess := childTGID != parent.TGID
 
 	// If a child-stop arrived before this parent event, a minimal state
-	// already exists and the initial SIGSTOP was already handled. Only set
-	// SuppressInitialStop when creating a brand-new state to avoid
-	// incorrectly suppressing a later real SIGSTOP.
+	// already exists and the initial SIGSTOP was already handled. Update
+	// metadata in place to preserve runtime fields (InSyscall, MemFD, etc.).
 	existing := t.tracees[tid]
-	suppressInitial := existing == nil
-	t.tracees[tid] = &TraceeState{
-		TID:                tid,
-		TGID:               childTGID,
-		ParentPID:          parent.TGID,
-		SessionID:          parent.SessionID,
-		Attached:           time.Now(),
-		MemFD:              -1, // opened lazily on first memory access
-		SuppressInitialStop: suppressInitial,
+	if existing != nil {
+		existing.TGID = childTGID
+		existing.ParentPID = parent.TGID
+		existing.SessionID = parent.SessionID
+		existing.Attached = time.Now()
+	} else {
+		t.tracees[tid] = &TraceeState{
+			TID:                 tid,
+			TGID:                childTGID,
+			ParentPID:           parent.TGID,
+			SessionID:           parent.SessionID,
+			Attached:            time.Now(),
+			MemFD:               -1,
+			SuppressInitialStop: true,
+		}
 	}
 	t.metrics.SetTraceeCount(len(t.tracees))
 	t.mu.Unlock()

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -317,6 +317,14 @@ func (t *Tracer) resumeTracee(tid int, sig int) {
 	}
 }
 
+// ptraceListen calls PTRACE_LISTEN on the specified tid. In PTRACE_SEIZE
+// mode, this keeps the tracee group-stopped while still allowing the tracer
+// to receive ptrace events.
+func ptraceListen(tid int) {
+	unix.RawSyscall6(unix.SYS_PTRACE,
+		uintptr(unix.PTRACE_LISTEN), uintptr(tid), 0, 0, 0, 0)
+}
+
 // applyDenyFixup overwrites the syscall return value with -errno.
 func (t *Tracer) applyDenyFixup(tid int, errno int) {
 	regs, err := t.getRegs(tid)
@@ -395,7 +403,31 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 			}
 
 		default:
-			// Suppress initial SIGSTOP for auto-traced children.
+			// In PTRACE_SEIZE mode, group-stops (SIGSTOP, SIGTSTP, SIGTTIN,
+			// SIGTTOU) are reported with TrapCause == PTRACE_EVENT_STOP and
+			// the stopping signal in StopSignal. Use PTRACE_LISTEN to keep
+			// the tracee group-stopped.
+			if status.TrapCause() == unix.PTRACE_EVENT_STOP {
+				// Exception: suppress the initial SIGSTOP for auto-traced
+				// children so they can start running.
+				if sig == unix.SIGSTOP {
+					t.mu.Lock()
+					state := t.tracees[tid]
+					suppress := state != nil && state.SuppressInitialStop
+					if suppress {
+						state.SuppressInitialStop = false
+					}
+					t.mu.Unlock()
+					if suppress {
+						t.resumeTracee(tid, 0)
+						break
+					}
+				}
+				ptraceListen(tid)
+				break
+			}
+
+			// Suppress initial SIGSTOP for auto-traced children (non-group-stop).
 			if sig == unix.SIGSTOP {
 				t.mu.Lock()
 				state := t.tracees[tid]
@@ -665,12 +697,16 @@ func (t *Tracer) handleEventStop(tid int) {
 	hasState := state != nil
 	t.mu.Unlock()
 
-	// Auto-attached children (via PTRACE_O_TRACEFORK/VFORK/CLONE) receive
-	// PTRACE_EVENT_STOP as their initial stop. If handleNewChild hasn't run
-	// yet (race with parent's fork event), the child has no state. In either
-	// case, resume the child so it can continue executing. Do NOT use
-	// PTRACE_LISTEN here: it's only appropriate for group-stops during
-	// PTRACE_SEIZE, not for initial auto-attach stops.
+	// This handler is only reached when sig == SIGTRAP (see handleStop
+	// dispatcher). Group-stops under PTRACE_SEIZE have the actual stopping
+	// signal (SIGSTOP/SIGTSTP/etc.) as StopSignal, so they fall into the
+	// default signal handler and never reach here. That means we only see
+	// two kinds of PTRACE_EVENT_STOP with SIGTRAP:
+	//   1. Initial auto-attach stops for children traced via
+	//      PTRACE_O_TRACEFORK/VFORK/CLONE.
+	//   2. PTRACE_INTERRUPT-induced stops (handled above via PendingInterrupt).
+	// Both are correctly resumed with PtraceSyscall/PtraceCont; PTRACE_LISTEN
+	// is not needed here.
 	if !hasState {
 		// Create minimal state so the child doesn't get lost.
 		childTGID, _ := readTGID(tid)

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -147,6 +147,7 @@ type TraceeState struct {
 	PendingInterrupt      bool
 	IsVforkChild     bool
 	SuppressInitialStop bool // suppress initial SIGSTOP from auto-trace
+	PendingExecStubFD int  // fd injected for exec redirect; cleaned up on exec failure (-1 = none)
 	MemFD            int
 }
 
@@ -439,9 +440,10 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 					t.mu.Lock()
 					if _, exists := t.tracees[tid]; !exists {
 						t.tracees[tid] = &TraceeState{
-							TID:   tid,
-							TGID:  childTGID,
-							MemFD: -1,
+							TID:               tid,
+							TGID:              childTGID,
+							MemFD:             -1,
+							PendingExecStubFD: -1,
 						}
 						t.metrics.SetTraceeCount(len(t.tracees))
 					}
@@ -493,6 +495,7 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 	pendingFakeZero := false
 	hasPendingReturn := false
 	var pendingReturnOverride int64
+	pendingExecStubFD := -1
 	if !entering {
 		pendingErrno = state.PendingDenyErrno
 		state.PendingDenyErrno = 0
@@ -502,6 +505,8 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		pendingReturnOverride = state.PendingReturnOverride
 		state.HasPendingReturn = false
 		state.PendingReturnOverride = 0
+		pendingExecStubFD = state.PendingExecStubFD
+		state.PendingExecStubFD = -1
 	}
 	t.mu.Unlock()
 
@@ -530,6 +535,17 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		} else if hasPendingReturn {
 			t.applyReturnOverride(tid, pendingReturnOverride)
 		}
+
+		// If an exec redirect injected a stub fd and the exec failed,
+		// clean up the leaked fd in the tracee.
+		if pendingExecStubFD >= 0 {
+			regs, err := t.getRegs(tid)
+			if err == nil && regs.ReturnValue() < 0 {
+				savedRegs := regs.Clone()
+				t.cleanupInjectedFD(tid, savedRegs, pendingExecStubFD)
+			}
+		}
+
 		t.allowSyscall(tid)
 	}
 }
@@ -617,6 +633,7 @@ func (t *Tracer) handleNewChild(parentTID int, event int) {
 			SessionID:           parent.SessionID,
 			Attached:            time.Now(),
 			MemFD:               -1,
+			PendingExecStubFD:   -1,
 			SuppressInitialStop: true,
 		}
 	}
@@ -648,6 +665,9 @@ func (t *Tracer) handleExecEvent(tid int) {
 		return
 	}
 	state.IsVforkChild = false
+	// Exec succeeded: the stub fd is now inherited by the new process.
+	// Clear PendingExecStubFD so the exit handler doesn't try to clean it up.
+	state.PendingExecStubFD = -1
 	// Keep InSyscall = true: the PTRACE_EVENT_EXEC fires between the
 	// execve's syscall-enter and syscall-exit. The next SIGTRAP|0x80
 	// stop will be the execve exit; by leaving InSyscall true, the
@@ -753,9 +773,10 @@ func (t *Tracer) handleEventStop(tid int) {
 		t.mu.Lock()
 		if _, exists := t.tracees[tid]; !exists {
 			t.tracees[tid] = &TraceeState{
-				TID:   tid,
-				TGID:  childTGID,
-				MemFD: -1,
+				TID:               tid,
+				TGID:              childTGID,
+				MemFD:             -1,
+				PendingExecStubFD: -1,
 			}
 			t.metrics.SetTraceeCount(len(t.tracees))
 		}

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -142,6 +142,7 @@ type TraceeState struct {
 	Attached         time.Time
 	ParkedAt         time.Time
 	PendingDenyErrno int
+	PendingFakeZero  bool // force return value to 0 on syscall exit
 	PendingInterrupt bool
 	IsVforkChild     bool
 	MemFD            int
@@ -378,9 +379,12 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 	entering := !state.InSyscall
 	state.InSyscall = entering
 	pendingErrno := 0
+	pendingFakeZero := false
 	if !entering {
 		pendingErrno = state.PendingDenyErrno
 		state.PendingDenyErrno = 0
+		pendingFakeZero = state.PendingFakeZero
+		state.PendingFakeZero = false
 	}
 	t.mu.Unlock()
 
@@ -404,6 +408,8 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 	} else {
 		if pendingErrno != 0 {
 			t.applyDenyFixup(tid, pendingErrno)
+		} else if pendingFakeZero {
+			t.applyDenyFixup(tid, 0)
 		}
 		t.allowSyscall(tid)
 	}

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -516,6 +516,7 @@ func (t *Tracer) handleExit(tid int) {
 	t.mu.Lock()
 	state := t.tracees[tid]
 	var tgid int
+	lastThread := true
 	if state != nil {
 		tgid = state.TGID
 		if state.MemFD >= 0 {
@@ -526,11 +527,18 @@ func (t *Tracer) handleExit(tid int) {
 			delete(t.parkedTracees, tid)
 			slog.Warn("ptrace: parked tracee exited before approval", "tid", tid)
 		}
+		// Check if any remaining threads belong to the same TGID.
+		for _, other := range t.tracees {
+			if other.TGID == tgid {
+				lastThread = false
+				break
+			}
+		}
 		t.metrics.SetTraceeCount(len(t.tracees))
 	}
 	t.mu.Unlock()
 
-	if state != nil {
+	if state != nil && lastThread {
 		t.invalidateScratchPage(tgid)
 	}
 }
@@ -610,6 +618,8 @@ func (t *Tracer) handleExecve(ctx context.Context, tid int, regs Regs) {
 	})
 
 	switch result.Action {
+	case "", "continue":
+		t.allowSyscall(tid)
 	case "deny":
 		errno := result.Errno
 		if errno == 0 {
@@ -619,7 +629,8 @@ func (t *Tracer) handleExecve(ctx context.Context, tid int, regs Regs) {
 	case "redirect":
 		t.redirectExec(ctx, tid, regs, result)
 	default:
-		t.allowSyscall(tid)
+		slog.Warn("handleExecve: unknown action, denying", "tid", tid, "action", result.Action)
+		t.denySyscall(tid, int(unix.EACCES))
 	}
 }
 

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -147,8 +147,9 @@ type TraceeState struct {
 	PendingInterrupt      bool
 	IsVforkChild     bool
 	SuppressInitialStop bool // suppress initial SIGSTOP from auto-trace
-	PendingExecStubFD int  // fd injected for exec redirect; cleaned up on exec failure (-1 = none)
-	MemFD            int
+	PendingExecStubFD  int // fd injected for exec redirect; cleaned up on exec failure (-1 = none)
+	PendingExecSavedFD int // fd that was displaced by stub fd; restored on exec failure (-1 = none)
+	MemFD              int
 }
 
 type resumeRequest struct {
@@ -441,10 +442,11 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 					t.mu.Lock()
 					if _, exists := t.tracees[tid]; !exists {
 						t.tracees[tid] = &TraceeState{
-							TID:               tid,
-							TGID:              childTGID,
-							MemFD:             -1,
-							PendingExecStubFD: -1,
+							TID:                tid,
+							TGID:               childTGID,
+							MemFD:              -1,
+							PendingExecStubFD:  -1,
+							PendingExecSavedFD: -1,
 						}
 						t.metrics.SetTraceeCount(len(t.tracees))
 					}
@@ -497,6 +499,7 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 	hasPendingReturn := false
 	var pendingReturnOverride int64
 	pendingExecStubFD := -1
+	pendingExecSavedFD := -1
 	if !entering {
 		pendingErrno = state.PendingDenyErrno
 		state.PendingDenyErrno = 0
@@ -507,7 +510,9 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		state.HasPendingReturn = false
 		state.PendingReturnOverride = 0
 		pendingExecStubFD = state.PendingExecStubFD
+		pendingExecSavedFD = state.PendingExecSavedFD
 		state.PendingExecStubFD = -1
+		state.PendingExecSavedFD = -1
 	}
 	t.mu.Unlock()
 
@@ -543,7 +548,7 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 			regs, err := t.getRegs(tid)
 			if err == nil && regs.ReturnValue() < 0 {
 				savedRegs := regs.Clone()
-				t.cleanupInjectedFD(tid, savedRegs, pendingExecStubFD)
+				t.cleanupInjectedFD(tid, savedRegs, pendingExecStubFD, pendingExecSavedFD)
 			}
 		}
 
@@ -635,6 +640,7 @@ func (t *Tracer) handleNewChild(parentTID int, event int) {
 			Attached:            time.Now(),
 			MemFD:               -1,
 			PendingExecStubFD:   -1,
+			PendingExecSavedFD:  -1,
 			SuppressInitialStop: true,
 		}
 	}
@@ -668,7 +674,9 @@ func (t *Tracer) handleExecEvent(tid int) {
 	state.IsVforkChild = false
 	// Exec succeeded: the stub fd is now inherited by the new process.
 	// Clear PendingExecStubFD so the exit handler doesn't try to clean it up.
+	// The saved fd (if any) was also replaced by exec; discard it.
 	state.PendingExecStubFD = -1
+	state.PendingExecSavedFD = -1
 	// Keep InSyscall = true: the PTRACE_EVENT_EXEC fires between the
 	// execve's syscall-enter and syscall-exit. The next SIGTRAP|0x80
 	// stop will be the execve exit; by leaving InSyscall true, the
@@ -774,10 +782,11 @@ func (t *Tracer) handleEventStop(tid int) {
 		t.mu.Lock()
 		if _, exists := t.tracees[tid]; !exists {
 			t.tracees[tid] = &TraceeState{
-				TID:               tid,
-				TGID:              childTGID,
-				MemFD:             -1,
-				PendingExecStubFD: -1,
+				TID:                tid,
+				TGID:               childTGID,
+				MemFD:              -1,
+				PendingExecStubFD:  -1,
+				PendingExecSavedFD: -1,
 			}
 			t.metrics.SetTraceeCount(len(t.tracees))
 		}

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -479,13 +479,15 @@ func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
 	}
 	nr := regs.SyscallNr()
 
-	// Reset scratch page allocator at each syscall-enter so that
-	// redirect/soft-delete operations always start with a fresh page.
+	// Mark as syscall-entry so that injection helpers (injectSyscall)
+	// use the single-phase entry protocol (modify ORIG_RAX, one cycle
+	// to exit) instead of the two-phase gadget protocol.
 	t.mu.Lock()
 	state := t.tracees[tid]
 	var tgid int
 	if state != nil {
 		tgid = state.TGID
+		state.InSyscall = true
 	}
 	t.mu.Unlock()
 	if tgid != 0 {

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -419,21 +419,42 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 			// the stopping signal in StopSignal. Use PTRACE_LISTEN to keep
 			// the tracee group-stopped.
 			if status.TrapCause() == unix.PTRACE_EVENT_STOP {
-				// Exception: suppress the initial SIGSTOP for auto-traced
-				// children so they can start running.
-				if sig == unix.SIGSTOP {
+				t.mu.Lock()
+				state := t.tracees[tid]
+				hasState := state != nil
+				suppress := state != nil && sig == unix.SIGSTOP && state.SuppressInitialStop
+				if suppress {
+					state.SuppressInitialStop = false
+				}
+				t.mu.Unlock()
+
+				// Auto-attached children may receive this stop before
+				// handleNewChild creates their state. Create minimal
+				// state and resume to avoid leaving them stuck.
+				if !hasState {
+					childTGID, _ := readTGID(tid)
+					if childTGID == 0 {
+						childTGID = tid
+					}
 					t.mu.Lock()
-					state := t.tracees[tid]
-					suppress := state != nil && state.SuppressInitialStop
-					if suppress {
-						state.SuppressInitialStop = false
+					if _, exists := t.tracees[tid]; !exists {
+						t.tracees[tid] = &TraceeState{
+							TID:   tid,
+							TGID:  childTGID,
+							MemFD: -1,
+						}
+						t.metrics.SetTraceeCount(len(t.tracees))
 					}
 					t.mu.Unlock()
-					if suppress {
-						t.resumeTracee(tid, 0)
-						break
-					}
+					t.resumeTracee(tid, 0)
+					break
 				}
+
+				if suppress {
+					t.resumeTracee(tid, 0)
+					break
+				}
+
 				ptraceListen(tid)
 				break
 			}

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"runtime"
 	"sync"
-	"syscall"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -141,10 +140,13 @@ type TraceeState struct {
 	LastNr           int
 	Attached         time.Time
 	ParkedAt         time.Time
-	PendingDenyErrno int
-	PendingFakeZero  bool // force return value to 0 on syscall exit
-	PendingInterrupt bool
+	PendingDenyErrno      int
+	PendingFakeZero       bool  // force return value to 0 on syscall exit
+	PendingReturnOverride int64 // force return value to this on syscall exit
+	HasPendingReturn      bool  // whether PendingReturnOverride is active
+	PendingInterrupt      bool
 	IsVforkChild     bool
+	SuppressInitialStop bool // suppress initial SIGSTOP from auto-trace
 	MemFD            int
 }
 
@@ -325,6 +327,17 @@ func (t *Tracer) applyDenyFixup(tid int, errno int) {
 	t.setRegs(tid, regs)
 }
 
+// applyReturnOverride overwrites the syscall return value with an arbitrary value.
+// Used by file redirect to pass through the fd from an injected openat syscall.
+func (t *Tracer) applyReturnOverride(tid int, retval int64) {
+	regs, err := t.getRegs(tid)
+	if err != nil {
+		return
+	}
+	regs.SetReturnValue(retval)
+	t.setRegs(tid, regs)
+}
+
 // hasPendingSyscallExit returns true if the tracee has a pending deny errno
 // or fake-zero fixup that needs to be applied at syscall exit.
 func (t *Tracer) hasPendingSyscallExit(tid int) bool {
@@ -334,7 +347,7 @@ func (t *Tracer) hasPendingSyscallExit(tid int) bool {
 	if state == nil {
 		return false
 	}
-	return state.InSyscall && (state.PendingDenyErrno != 0 || state.PendingFakeZero)
+	return state.InSyscall && (state.PendingDenyErrno != 0 || state.PendingFakeZero || state.HasPendingReturn)
 }
 
 // handleStop dispatches a tracee stop event.
@@ -352,6 +365,7 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 
 		case sig == unix.SIGTRAP:
 			event := status.TrapCause()
+			slog.Info("handleStop: SIGTRAP event", "tid", tid, "event", event)
 			switch event {
 			case unix.PTRACE_EVENT_FORK, unix.PTRACE_EVENT_CLONE:
 				t.handleNewChild(tid, event)
@@ -382,6 +396,20 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 			}
 
 		default:
+			// Suppress initial SIGSTOP for auto-traced children.
+			if sig == unix.SIGSTOP {
+				t.mu.Lock()
+				state := t.tracees[tid]
+				suppress := state != nil && state.SuppressInitialStop
+				if suppress {
+					state.SuppressInitialStop = false
+				}
+				t.mu.Unlock()
+				if suppress {
+					t.resumeTracee(tid, 0)
+					break
+				}
+			}
 			t.resumeTracee(tid, int(sig))
 		}
 	}
@@ -398,13 +426,21 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 	}
 	entering := !state.InSyscall
 	state.InSyscall = entering
+	lastNr := state.LastNr
+	slog.Info("handleSyscallStop", "tid", tid, "entering", entering, "lastNr", lastNr)
 	pendingErrno := 0
 	pendingFakeZero := false
+	hasPendingReturn := false
+	var pendingReturnOverride int64
 	if !entering {
 		pendingErrno = state.PendingDenyErrno
 		state.PendingDenyErrno = 0
 		pendingFakeZero = state.PendingFakeZero
 		state.PendingFakeZero = false
+		hasPendingReturn = state.HasPendingReturn
+		pendingReturnOverride = state.PendingReturnOverride
+		state.HasPendingReturn = false
+		state.PendingReturnOverride = 0
 	}
 	t.mu.Unlock()
 
@@ -415,6 +451,7 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 			return
 		}
 		nr := regs.SyscallNr()
+		slog.Info("handleSyscallStop entering dispatch", "tid", tid, "nr", nr)
 		t.mu.Lock()
 		state.LastNr = nr
 		tgid := state.TGID
@@ -426,10 +463,19 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 
 		t.dispatchSyscall(ctx, tid, nr, regs)
 	} else {
+		// At exit, read the actual orig_rax to verify it matches the enter.
+		exitRegs, exitErr := t.getRegs(tid)
+		exitNr := -1
+		if exitErr == nil {
+			exitNr = exitRegs.SyscallNr()
+		}
+		slog.Info("handleSyscallStop exit check", "tid", tid, "exitNr", exitNr, "lastNr", lastNr)
 		if pendingErrno != 0 {
 			t.applyDenyFixup(tid, pendingErrno)
 		} else if pendingFakeZero {
 			t.applyDenyFixup(tid, 0)
+		} else if hasPendingReturn {
+			t.applyReturnOverride(tid, pendingReturnOverride)
 		}
 		t.allowSyscall(tid)
 	}
@@ -500,11 +546,13 @@ func (t *Tracer) handleNewChild(parentTID int, event int) {
 	isNewProcess := childTGID != parent.TGID
 
 	t.tracees[tid] = &TraceeState{
-		TID:       tid,
-		TGID:      childTGID,
-		ParentPID: parent.TGID,
-		SessionID: parent.SessionID,
-		Attached:  time.Now(),
+		TID:                tid,
+		TGID:               childTGID,
+		ParentPID:          parent.TGID,
+		SessionID:          parent.SessionID,
+		Attached:           time.Now(),
+		MemFD:              -1, // opened lazily on first memory access
+		SuppressInitialStop: true, // suppress the initial SIGSTOP from auto-trace
 	}
 	t.metrics.SetTraceeCount(len(t.tracees))
 	t.mu.Unlock()
@@ -534,7 +582,13 @@ func (t *Tracer) handleExecEvent(tid int) {
 		return
 	}
 	state.IsVforkChild = false
-	state.InSyscall = false
+	// Keep InSyscall = true: the PTRACE_EVENT_EXEC fires between the
+	// execve's syscall-enter and syscall-exit. The next SIGTRAP|0x80
+	// stop will be the execve exit; by leaving InSyscall true, the
+	// tracer correctly treats it as an exit (entering = !true = false)
+	// and subsequent syscalls are dispatched on entry as expected.
+	// Without this, the enter/exit tracking drifts off-by-one and
+	// handlers see syscalls only at exit — too late to intercept.
 
 	formerTID, err := unix.PtraceGetEventMsg(tid)
 	if err == nil && int(formerTID) != tid {
@@ -550,6 +604,20 @@ func (t *Tracer) handleExecEvent(tid int) {
 			delete(t.tracees, otherTID)
 		}
 	}
+
+	// Exec replaces the process address space, so reopen /proc/<tid>/mem
+	// to get a fresh fd pointing to the new address space.
+	if state.MemFD >= 0 {
+		unix.Close(state.MemFD)
+		state.MemFD = -1
+	}
+	fd, err := unix.Open(fmt.Sprintf("/proc/%d/mem", tid), unix.O_RDWR, 0)
+	if err != nil {
+		slog.Warn("handleExecEvent: O_RDWR open failed, trying O_RDONLY", "tid", tid, "error", err)
+		fd, _ = unix.Open(fmt.Sprintf("/proc/%d/mem", tid), unix.O_RDONLY, 0)
+	}
+	state.MemFD = fd
+
 	t.metrics.SetTraceeCount(len(t.tracees))
 	t.mu.Unlock()
 
@@ -597,10 +665,34 @@ func (t *Tracer) handleEventStop(tid int) {
 		t.resumeTracee(tid, 0)
 		return
 	}
+	hasState := state != nil
 	t.mu.Unlock()
-	// PTRACE_LISTEN is not wrapped by x/sys/unix, so use RawSyscall directly.
-	_, _, e := syscall.RawSyscall6(syscall.SYS_PTRACE, unix.PTRACE_LISTEN, uintptr(tid), 0, 0, 0, 0)
-	_ = e
+
+	// Auto-attached children (via PTRACE_O_TRACEFORK/VFORK/CLONE) receive
+	// PTRACE_EVENT_STOP as their initial stop. If handleNewChild hasn't run
+	// yet (race with parent's fork event), the child has no state. In either
+	// case, resume the child so it can continue executing. Do NOT use
+	// PTRACE_LISTEN here: it's only appropriate for group-stops during
+	// PTRACE_SEIZE, not for initial auto-attach stops.
+	if !hasState {
+		// Create minimal state so the child doesn't get lost.
+		childTGID, _ := readTGID(tid)
+		if childTGID == 0 {
+			childTGID = tid
+		}
+		t.mu.Lock()
+		if _, exists := t.tracees[tid]; !exists {
+			t.tracees[tid] = &TraceeState{
+				TID:   tid,
+				TGID:  childTGID,
+				MemFD: -1,
+			}
+			t.metrics.SetTraceeCount(len(t.tracees))
+		}
+		t.mu.Unlock()
+	}
+
+	t.resumeTracee(tid, 0)
 }
 
 // handleExecve intercepts execve/execveat syscalls for policy evaluation.

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -325,6 +325,18 @@ func (t *Tracer) applyDenyFixup(tid int, errno int) {
 	t.setRegs(tid, regs)
 }
 
+// hasPendingSyscallExit returns true if the tracee has a pending deny errno
+// or fake-zero fixup that needs to be applied at syscall exit.
+func (t *Tracer) hasPendingSyscallExit(tid int) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	state := t.tracees[tid]
+	if state == nil {
+		return false
+	}
+	return state.InSyscall && (state.PendingDenyErrno != 0 || state.PendingFakeZero)
+}
+
 // handleStop dispatches a tracee stop event.
 func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus) {
 	switch {
@@ -358,7 +370,15 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 			case unix.PTRACE_EVENT_STOP:
 				t.handleEventStop(tid)
 			default:
-				t.resumeTracee(tid, 0)
+				// In prefilter mode (PTRACE_O_TRACESECCOMP without
+				// TRACESYSGOOD), a plain SIGTRAP with no event can be
+				// a syscall-exit stop if we explicitly used PtraceSyscall
+				// (e.g., after soft-delete). Check for pending fixups.
+				if t.hasPendingSyscallExit(tid) {
+					t.handleSyscallStop(ctx, tid)
+				} else {
+					t.resumeTracee(tid, 0)
+				}
 			}
 
 		default:

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -617,8 +617,18 @@ func (t *Tracer) handleExecve(ctx context.Context, tid int, regs Regs) {
 		Depth:     depth,
 	})
 
-	switch result.Action {
-	case "", "continue", "allow":
+	// Dispatch based on Action field (preferred) or Allow field (legacy fallback).
+	action := result.Action
+	if action == "" {
+		if result.Allow {
+			action = "allow"
+		} else {
+			action = "deny"
+		}
+	}
+
+	switch action {
+	case "allow", "continue":
 		t.allowSyscall(tid)
 	case "deny":
 		errno := result.Errno
@@ -629,7 +639,7 @@ func (t *Tracer) handleExecve(ctx context.Context, tid int, regs Regs) {
 	case "redirect":
 		t.redirectExec(ctx, tid, regs, result)
 	default:
-		slog.Warn("handleExecve: unknown action, denying", "tid", tid, "action", result.Action)
+		slog.Warn("handleExecve: unknown action, denying", "tid", tid, "action", action)
 		t.denySyscall(tid, int(unix.EACCES))
 	}
 }

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -33,11 +33,12 @@ type ExecContext struct {
 
 // ExecResult carries the policy decision.
 type ExecResult struct {
-	Allow  bool
-	Action string // "continue", "deny", "redirect"
-	Errno  int32
-	Rule   string
-	Reason string
+	Allow    bool
+	Action   string // "continue", "deny", "redirect"
+	Errno    int32
+	Rule     string
+	Reason   string
+	StubPath string // for redirect: path to stub binary
 }
 
 // FileHandler evaluates file syscall policy.
@@ -58,8 +59,11 @@ type FileContext struct {
 
 // FileResult carries the file policy decision.
 type FileResult struct {
-	Allow bool
-	Errno int32
+	Allow        bool
+	Action       string // "" (legacy), "allow", "deny", "redirect", "soft-delete"
+	Errno        int32
+	RedirectPath string // for redirect
+	TrashDir     string // for soft-delete
 }
 
 // NetworkHandler evaluates network syscall policy.
@@ -80,8 +84,11 @@ type NetworkContext struct {
 
 // NetworkResult carries the network policy decision.
 type NetworkResult struct {
-	Allow bool
-	Errno int32
+	Allow        bool
+	Action       string // "" (legacy), "allow", "deny", "redirect"
+	Errno        int32
+	RedirectAddr string // for redirect
+	RedirectPort int    // for redirect
 }
 
 // SignalHandler evaluates signal delivery policy.
@@ -609,9 +616,18 @@ func (t *Tracer) handleExecve(ctx context.Context, tid int, regs Regs) {
 			errno = int32(unix.EACCES)
 		}
 		t.denySyscall(tid, int(errno))
+	case "redirect":
+		t.redirectExec(ctx, tid, regs, result)
 	default:
 		t.allowSyscall(tid)
 	}
+}
+
+// redirectExec redirects an execve to a stub binary.
+// Implemented in redirect_exec.go.
+func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result ExecResult) {
+	slog.Warn("redirectExec: not yet implemented, denying", "tid", tid)
+	t.denySyscall(tid, int(unix.EACCES))
 }
 
 // Run starts the ptrace event loop.

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -393,7 +393,12 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		nr := regs.SyscallNr()
 		t.mu.Lock()
 		state.LastNr = nr
+		tgid := state.TGID
 		t.mu.Unlock()
+
+		// Reset scratch page allocator at each syscall-enter so that
+		// redirect/soft-delete operations always start with a fresh page.
+		t.resetScratchIfPresent(tgid)
 
 		t.dispatchSyscall(ctx, tid, nr, regs)
 	} else {
@@ -412,6 +417,20 @@ func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
 		return
 	}
 	nr := regs.SyscallNr()
+
+	// Reset scratch page allocator at each syscall-enter so that
+	// redirect/soft-delete operations always start with a fresh page.
+	t.mu.Lock()
+	state := t.tracees[tid]
+	var tgid int
+	if state != nil {
+		tgid = state.TGID
+	}
+	t.mu.Unlock()
+	if tgid != 0 {
+		t.resetScratchIfPresent(tgid)
+	}
+
 	t.dispatchSyscall(ctx, tid, nr, regs)
 }
 

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -644,13 +644,6 @@ func (t *Tracer) handleExecve(ctx context.Context, tid int, regs Regs) {
 	}
 }
 
-// redirectExec redirects an execve to a stub binary.
-// Implemented in redirect_exec.go.
-func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result ExecResult) {
-	slog.Warn("redirectExec: not yet implemented, denying", "tid", tid)
-	t.denySyscall(tid, int(unix.EACCES))
-}
-
 // Run starts the ptrace event loop.
 func (t *Tracer) Run(ctx context.Context) error {
 	runtime.LockOSThread()

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -365,7 +365,6 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 
 		case sig == unix.SIGTRAP:
 			event := status.TrapCause()
-			slog.Info("handleStop: SIGTRAP event", "tid", tid, "event", event)
 			switch event {
 			case unix.PTRACE_EVENT_FORK, unix.PTRACE_EVENT_CLONE:
 				t.handleNewChild(tid, event)
@@ -426,8 +425,6 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 	}
 	entering := !state.InSyscall
 	state.InSyscall = entering
-	lastNr := state.LastNr
-	slog.Info("handleSyscallStop", "tid", tid, "entering", entering, "lastNr", lastNr)
 	pendingErrno := 0
 	pendingFakeZero := false
 	hasPendingReturn := false
@@ -451,7 +448,6 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 			return
 		}
 		nr := regs.SyscallNr()
-		slog.Info("handleSyscallStop entering dispatch", "tid", tid, "nr", nr)
 		t.mu.Lock()
 		state.LastNr = nr
 		tgid := state.TGID
@@ -463,13 +459,6 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 
 		t.dispatchSyscall(ctx, tid, nr, regs)
 	} else {
-		// At exit, read the actual orig_rax to verify it matches the enter.
-		exitRegs, exitErr := t.getRegs(tid)
-		exitNr := -1
-		if exitErr == nil {
-			exitNr = exitRegs.SyscallNr()
-		}
-		slog.Info("handleSyscallStop exit check", "tid", tid, "exitNr", exitNr, "lastNr", lastNr)
 		if pendingErrno != 0 {
 			t.applyDenyFixup(tid, pendingErrno)
 		} else if pendingFakeZero {

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -358,8 +358,9 @@ func (t *Tracer) applyReturnOverride(tid int, retval int64) {
 	t.setRegs(tid, regs)
 }
 
-// hasPendingSyscallExit returns true if the tracee has a pending deny errno
-// or fake-zero fixup that needs to be applied at syscall exit.
+// hasPendingSyscallExit returns true if the tracee has a pending deny errno,
+// fake-zero fixup, return override, or exec stub fd cleanup that needs to be
+// applied at syscall exit.
 func (t *Tracer) hasPendingSyscallExit(tid int) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -367,7 +368,7 @@ func (t *Tracer) hasPendingSyscallExit(tid int) bool {
 	if state == nil {
 		return false
 	}
-	return state.InSyscall && (state.PendingDenyErrno != 0 || state.PendingFakeZero || state.HasPendingReturn)
+	return state.InSyscall && (state.PendingDenyErrno != 0 || state.PendingFakeZero || state.HasPendingReturn || state.PendingExecStubFD >= 0)
 }
 
 // handleStop dispatches a tracee stop event.

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -253,6 +253,12 @@ func (t *Tracer) setRegs(tid int, regs Regs) error {
 	return setRegsArch(tid, regs)
 }
 
+// traceSysGood reports whether PTRACE_O_TRACESYSGOOD is active.
+// When true, syscall stops use SIGTRAP|0x80 and plain SIGTRAP is a real signal.
+func (t *Tracer) traceSysGood() bool {
+	return !t.prefilterActive
+}
+
 // allowSyscall resumes the tracee, allowing the syscall to proceed.
 func (t *Tracer) allowSyscall(tid int) {
 	var err error

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -534,6 +534,12 @@ func (t *Tracer) handleNewChild(parentTID int, event int) {
 
 	isNewProcess := childTGID != parent.TGID
 
+	// If a child-stop arrived before this parent event, a minimal state
+	// already exists and the initial SIGSTOP was already handled. Only set
+	// SuppressInitialStop when creating a brand-new state to avoid
+	// incorrectly suppressing a later real SIGSTOP.
+	existing := t.tracees[tid]
+	suppressInitial := existing == nil
 	t.tracees[tid] = &TraceeState{
 		TID:                tid,
 		TGID:               childTGID,
@@ -541,7 +547,7 @@ func (t *Tracer) handleNewChild(parentTID int, event int) {
 		SessionID:          parent.SessionID,
 		Attached:           time.Now(),
 		MemFD:              -1, // opened lazily on first memory access
-		SuppressInitialStop: true, // suppress the initial SIGSTOP from auto-trace
+		SuppressInitialStop: suppressInitial,
 	}
 	t.metrics.SetTraceeCount(len(t.tracees))
 	t.mu.Unlock()

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -159,6 +159,7 @@ type Tracer struct {
 	mu            sync.Mutex
 	tracees       map[int]*TraceeState
 	parkedTracees map[int]struct{}
+	tgidScratch   map[int]*scratchPage
 
 	stopped chan struct{}
 }
@@ -177,6 +178,7 @@ func NewTracer(cfg TracerConfig) *Tracer {
 		resumeQueue:   make(chan resumeRequest, 64),
 		tracees:       make(map[int]*TraceeState),
 		parkedTracees: make(map[int]struct{}),
+		tgidScratch:   make(map[int]*scratchPage),
 		stopped:       make(chan struct{}),
 	}
 }
@@ -498,12 +500,17 @@ func (t *Tracer) handleExecEvent(tid int) {
 	}
 	t.metrics.SetTraceeCount(len(t.tracees))
 	t.mu.Unlock()
+
+	// Exec replaces the process address space, invalidating any scratch page.
+	t.invalidateScratchPage(tgid)
 }
 
 func (t *Tracer) handleExit(tid int) {
 	t.mu.Lock()
 	state := t.tracees[tid]
+	var tgid int
 	if state != nil {
+		tgid = state.TGID
 		if state.MemFD >= 0 {
 			unix.Close(state.MemFD)
 		}
@@ -515,6 +522,10 @@ func (t *Tracer) handleExit(tid int) {
 		t.metrics.SetTraceeCount(len(t.tracees))
 	}
 	t.mu.Unlock()
+
+	if state != nil {
+		t.invalidateScratchPage(tgid)
+	}
 }
 
 func (t *Tracer) handleEventStop(tid int) {


### PR DESCRIPTION
## Summary

- Add syscall injection engine (`injectSyscall`) that executes arbitrary syscalls inside stopped tracees via register manipulation and two-phase PtraceSyscall, supporting both entry-stop and exit-stop injection modes
- Implement exec redirect: redirects execve/execveat to a stub binary via fd injection (pidfd_open + pidfd_getfd + dup3), filename rewrite, and execveat→execve normalization, with fd displacement protection and arm64 register clobber handling
- Implement file path redirect: rewrites path arguments for all file syscalls (openat, unlinkat, renameat2, mkdirat, linkat, symlinkat, fchmodat, fchownat, plus legacy amd64 equivalents) using per-TGID scratch page allocation (mmap'd bump allocator)
- Implement soft-delete: intercepts unlinkat/unlink, injects mkdirat + renameat2 to move files to trash instead of deleting, tracee sees success (return 0)
- Implement connect redirect: rewrites sockaddr in tracee memory for IPv4/IPv6 with in-place overwrite
- Extend Regs interface with Clone(), SetInstructionPointer() for amd64 and arm64
- Harden waitForSyscallStop with WNOHANG|WALL polling, 5s deadline, PTRACE_EVENT_SECCOMP handling, and TRACESYSGOOD/prefilter mode disambiguation

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `GOOS=windows go build ./...` — cross-compilation passes
- [x] `GOOS=linux GOARCH=arm64 go build ./...` — arm64 cross-compilation passes
- [ ] CI checks pass on this PR
- [ ] Docker integration tests: `docker build -f Dockerfile.ptrace-test . && docker run --rm --cap-add SYS_PTRACE agentsh-ptrace-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)