### PR TITLE
feat: wire ptrace tracer into server exec and wrap paths

### DIFF
--- a/docs/plans/2026-03-14-ptrace-server-wiring-design.md
+++ b/docs/plans/2026-03-14-ptrace-server-wiring-design.md
@@ -1,7 +1,7 @@
 # Design: Wire ptrace Tracer into Server Exec and Wrap Paths
 
 **Date:** 2026-03-14
-**Status:** Draft
+**Status:** Implemented
 
 ---
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -20,7 +20,7 @@ agentsh/
 ## `internal/` packages (where to change what)
 
 - `internal/server/` — Wires configuration into HTTP + unix-socket servers and session lifecycle.
-- `internal/api/` — HTTP routing + handlers (`/sessions`, `/exec`, `/events`, `/metrics`), exec responses (`include_events`, `guidance`).
+- `internal/api/` — HTTP routing + handlers (`/sessions`, `/exec`, `/events`, `/metrics`), exec responses (`include_events`, `guidance`). Ptrace wiring: `ptrace_handlers.go` (policy adapter routing syscall events to session-level engines), `app_ptrace_linux.go` (tracer lifecycle), `exec_ptrace_linux.go` (attach helper for exec path).
 - `internal/cli/` — Cobra CLI commands (`agentsh exec`, `agentsh session …`, `agentsh events …`).
 - `internal/client/` — HTTP + gRPC clients used by the CLI (and tests) to call the server API.
 - `internal/config/` — Config structs, load/validate helpers.
@@ -29,7 +29,7 @@ agentsh/
 - `internal/fsmonitor/` — FUSE workspace view + file operation capture.
 - `internal/netmonitor/` — Network proxy + DNS cache/resolver and optional netns/transparent plumbing.
 - `internal/limits/` — Optional cgroups v2 enforcement (Linux-only; wired from exec hooks).
-- `internal/ptrace/` — Ptrace-based syscall tracer for restricted containers (Linux-only, requires SYS_PTRACE). Intercepts exec, file, network, and signal syscalls via PTRACE_SEIZE. Architecture-specific register access (amd64, arm64). Includes `Metrics` interface with Prometheus adapter (`metrics.go`, `metrics_prometheus.go`) and overhead benchmarks (`benchmark_test.go`).
+- `internal/ptrace/` — Ptrace-based syscall tracer for restricted containers (Linux-only, requires SYS_PTRACE). Intercepts exec, file, network, and signal syscalls via PTRACE_SEIZE. Architecture-specific register access (amd64, arm64). Wired into the server via `internal/api/` for both exec and wrap paths. Includes `AttachOption` functional options for session/command association and keepStopped control, `WaitAttached`/`ResumePID` for synchronous attach flow. `Metrics` interface with Prometheus adapter (`metrics.go`, `metrics_prometheus.go`) and overhead benchmarks (`benchmark_test.go`).
 - `internal/events/` — In-memory event broker for SSE.
 - `internal/store/` — Event sinks (SQLite, JSONL, webhook) and composition.
 - `internal/auth/` — API key auth implementation.

--- a/docs/ptrace-support.md
+++ b/docs/ptrace-support.md
@@ -3,7 +3,7 @@
 **Version:** 0.1 — Draft  
 **Date:** 2026-03-11  
 **Author:** Eran / Canyon Road  
-**Status:** Phase 4c Complete
+**Status:** Phase 5 Complete (Server Wiring)
 
 ---
 
@@ -1816,6 +1816,21 @@ Phase 4 brings ptrace mode to full feature parity with seccomp+FUSE for redirect
 - Sidecar auto-discovery (`sidecar` attach mode) based on real Fargate E2E testing
 - Research spike: seccomp prefilter injection for `pid`/`sidecar` mode (via syscall injection)
 - EKS Fargate support (pending AWS `SYS_PTRACE` for EKS) (§20)
+
+### Phase 5: Server Wiring ✓
+
+- Config validation: ptrace + seccomp.execve and ptrace + unix_sockets mutual exclusion (`SandboxConfig.Validate()`)
+- Ptrace API extensions: `AttachOption` (WithSessionID, WithCommandID, WithKeepStopped), `WaitAttached` (10s timeout), `ResumePID` (TGID-aware multi-thread resume), `attachDone` sync.Map for attach completion signaling
+- Handler router (`internal/api/ptrace_handlers.go`): `ptraceHandlerRouter` implementing all four handler interfaces, routing syscall events to session-level policy engines. Fail-closed on nil PolicyEngine, nil redirect payloads, soft-delete (no trash dir in ptrace context). Depth clamped to 0 for directly-attached processes.
+- App lifecycle (`internal/api/app_ptrace_linux.go`): tracer field on App, init in NewApp, Close method, `ptraceFailed` atomic flag for fail-closed on tracer crash
+- Server shutdown: App.Close() in both Run() graceful shutdown and Server.Close()
+- Exec path: three-path refactor in `runCommandWithResources` (ptrace/seccomp/none), `ptraceExecAttach` helper for AttachPID/WaitAttached/ResumePID flow, both regular and streaming exec wired
+- Wrap path: `PtraceMode` in WrapInitResponse, explicit child PID handshake (4-byte LE, not SO_PEERCRED) with ACK/NACK, `acceptPtracePID` with accept/read deadlines, process tree root seeding
+- CLI wrap: `ptracePostStart` callback with child PID, signal cleanup on handshake failure
+- Fail-closed guards on all execution paths: HTTP exec, streaming exec, gRPC ExecStream, PTY
+- Cross-platform: `app_ptrace_other.go` stubs, `exec_ptrace_other.go` stubs, `wrap_other.go`/`wrap_windows.go` stubs
+
+**Deliverable:** ptrace tracer is fully wired into the server. When `sandbox.ptrace.enabled: true`, all processes spawned via exec, exec/stream, and wrap are traced. Policy enforcement, audit events, and lifecycle management work end-to-end. Known limitation: brief pre-attach execution window between cmd.Start() and PTRACE_SEIZE (Phase 6 pipe barrier).
 
 ---
 

--- a/docs/security-modes.md
+++ b/docs/security-modes.md
@@ -129,14 +129,17 @@ ptrace:
     signal: true        # Signal syscall tracing (kill, tkill, tgkill, rt_sigqueueinfo)
 
   # Anti-detection: mask TracerPid in /proc/*/status reads (default: false)
-  mask_tracer_pid: false
+  mask_tracer_pid: "off"
 
   performance:
     max_tracees: 1024           # Maximum concurrent traced threads
     max_hold_ms: 5000           # Maximum time to hold a syscall for policy (fail-closed: deny with EACCES)
     seccomp_prefilter: true     # Use seccomp-BPF to filter non-traced syscalls
-    on_attach_failure: "warn"   # "warn" or "fail"
+
+  on_attach_failure: fail_open  # "fail_open" or "fail_closed"
 ```
+
+**Note:** Ptrace mode is mutually exclusive with `seccomp.execve` and `unix_sockets`. Enabling ptrace with either of these will cause a startup validation error.
 
 **How it works:**
 - Uses `PTRACE_SEIZE` (non-stopping) to attach to child processes and their descendants
@@ -212,9 +215,10 @@ Ptrace mode exposes Prometheus metrics at the `/metrics` endpoint:
    - **Measured overhead is <3% across all workload types** — see [Performance Benchmarks](#performance-benchmarks) below
 
 4. **Attach race window**
-   - Between `fork()` and `PTRACE_SEIZE`, a brief window exists where the child is untraced
+   - In the exec path, a brief window exists between `cmd.Start()` and `PTRACE_SEIZE` where the child is untraced
    - Ptrace auto-attaches to fork/clone/vfork children via `PTRACE_O_TRACECLONE` etc.
-   - The initial attach to the root process has a small race if the process execs immediately
+   - The initial exec target is typically a known-safe binary; a pipe-based start barrier is planned for a follow-up
+   - In the wrap path, the CLI connects to the server after the shell starts, sends the child PID, and waits for an ACK confirming attach before proceeding
 
 5. **Timeout behavior is fail-closed**
    - When `max_hold_ms` expires on a parked tracee, the syscall is denied with `EACCES`
@@ -364,22 +368,32 @@ Explicit `landlock.allow_execute` paths are merged with derived paths.
 
 ## Session Enforcement Flow
 
-When a command is executed in a session:
+When a command is executed in a session, the enforcement path depends on the active security mode:
+
+### Seccomp/Full Mode
 
 ```
 1. Pre-fork policy check (shim validates command)
-2. Fork child process
+2. Fork child process (with seccomp wrapper)
 3. Set PR_SET_NO_NEW_PRIVS
 4. Drop capabilities
 5. Apply Landlock ruleset
 6. Apply cgroup limits (if available)
-7. Execute actual command
+7. Execute actual command (seccomp user-notify intercepts syscalls)
 ```
 
-This ordering ensures:
-- No privilege escalation after restrictions are applied
-- Landlock is enforced before the untrusted command runs
-- Multiple layers of protection work together
+### Ptrace Mode
+
+```
+1. Pre-fork policy check (shim validates command)
+2. Fork child process (normal start, no seccomp wrapper)
+3. Tracer attaches via PTRACE_SEIZE + PTRACE_INTERRUPT (stops process)
+4. Apply cgroup limits while process is stopped
+5. Tracer resumes process
+6. Tracer intercepts syscalls for ongoing enforcement
+```
+
+Note: In ptrace mode, there is a brief pre-attach window between fork and PTRACE_SEIZE where the child process may execute a few instructions untraced. This is acceptable for Phase 1 since the initial exec target is typically a known-safe binary path, and the seccomp prefilter auto-attaches to fork/clone descendants.
 
 ## Performance Benchmarks
 

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -67,6 +67,10 @@ type App struct {
 	// Type is any because ptrace package is Linux-only.
 	ptraceTracer any
 	ptraceCancel context.CancelFunc
+	// ptraceFailed is set when the tracer exits unexpectedly while ptrace mode
+	// is configured. When true, command execution is blocked to prevent running
+	// without syscall enforcement (fail-closed).
+	ptraceFailed bool
 }
 
 func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Store, engine *policy.Engine, broker *events.Broker, apiKeyAuth *auth.APIKeyAuth, oidcAuth *auth.OIDCAuth, approvalsMgr *approvals.Manager, metricsCollector *metrics.Collector, policyLoader PolicyLoader) *App {

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/agentsh/agentsh/internal/approvals"
@@ -70,7 +71,7 @@ type App struct {
 	// ptraceFailed is set when the tracer exits unexpectedly while ptrace mode
 	// is configured. When true, command execution is blocked to prevent running
 	// without syscall enforcement (fail-closed).
-	ptraceFailed bool
+	ptraceFailed atomic.Bool
 }
 
 func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Store, engine *policy.Engine, broker *events.Broker, apiKeyAuth *auth.APIKeyAuth, oidcAuth *auth.OIDCAuth, approvalsMgr *approvals.Manager, metricsCollector *metrics.Collector, policyLoader PolicyLoader) *App {

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -62,6 +62,11 @@ type App struct {
 
 	// pkgChecker is the optional package install checker; nil when package_checks.enabled=false
 	pkgChecker *pkgcheck.Checker
+
+	// ptraceTracer holds the ptrace.Tracer on Linux (nil on other platforms or when disabled).
+	// Type is any because ptrace package is Linux-only.
+	ptraceTracer any
+	ptraceCancel context.CancelFunc
 }
 
 func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Store, engine *policy.Engine, broker *events.Broker, apiKeyAuth *auth.APIKeyAuth, oidcAuth *auth.OIDCAuth, approvalsMgr *approvals.Manager, metricsCollector *metrics.Collector, policyLoader PolicyLoader) *App {
@@ -85,7 +90,7 @@ func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Stor
 		slog.Warn("real_paths enabled but enforce_without_fuse is false: outside-workspace file access will be audit-only (not blocked)")
 	}
 
-	return &App{
+	app := &App{
 		cfg:          cfg,
 		sessions:     sessions,
 		store:        store,
@@ -98,6 +103,8 @@ func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Stor
 		platform:     plat,
 		policyLoader: policyLoader,
 	}
+	app.initPtraceTracer()
+	return app
 }
 
 // SetPlatformForTest replaces the platform implementation. Test-only.
@@ -108,6 +115,11 @@ func (a *App) SetPlatformForTest(p platform.Platform) {
 // SetPackageChecker attaches a package install checker to the app.
 func (a *App) SetPackageChecker(c *pkgcheck.Checker) {
 	a.pkgChecker = c
+}
+
+// Close releases resources held by the app (e.g., ptrace tracer).
+func (a *App) Close() {
+	a.closePtraceTracer()
 }
 
 type ctxKey string

--- a/internal/api/app_ptrace_linux.go
+++ b/internal/api/app_ptrace_linux.go
@@ -42,7 +42,12 @@ func (a *App) initPtraceTracer() {
 	ctx, cancel := context.WithCancel(context.Background())
 	a.ptraceTracer = tr
 	a.ptraceCancel = cancel
-	go tr.Run(ctx)
+	go func() {
+		if err := tr.Run(ctx); err != nil && ctx.Err() == nil {
+			slog.Error("ptrace tracer exited unexpectedly, clearing tracer to fail closed", "error", err)
+			a.ptraceTracer = nil
+		}
+	}()
 	slog.Info("ptrace tracer started", "attach_mode", cfg.AttachMode)
 }
 

--- a/internal/api/app_ptrace_linux.go
+++ b/internal/api/app_ptrace_linux.go
@@ -45,7 +45,7 @@ func (a *App) initPtraceTracer() {
 	go func() {
 		if err := tr.Run(ctx); err != nil && ctx.Err() == nil {
 			slog.Error("ptrace tracer exited unexpectedly, blocking commands (fail-closed)", "error", err)
-			a.ptraceFailed = true
+			a.ptraceFailed.Store(true)
 		}
 	}()
 	slog.Info("ptrace tracer started", "attach_mode", cfg.AttachMode)

--- a/internal/api/app_ptrace_linux.go
+++ b/internal/api/app_ptrace_linux.go
@@ -1,0 +1,55 @@
+//go:build linux
+
+package api
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/agentsh/agentsh/internal/ptrace"
+)
+
+// initPtraceTracer initializes the ptrace tracer if configured.
+// Called from NewApp on Linux when sandbox.ptrace.enabled is true.
+func (a *App) initPtraceTracer() {
+	cfg := a.cfg.Sandbox.Ptrace
+	if !cfg.Enabled {
+		return
+	}
+
+	router := &ptraceHandlerRouter{
+		sessions: a.sessions,
+		store:    a.store,
+		broker:   a.broker,
+	}
+	tr := ptrace.NewTracer(ptrace.TracerConfig{
+		AttachMode:       cfg.AttachMode,
+		TraceExecve:      cfg.Trace.Execve,
+		TraceFile:        cfg.Trace.File,
+		TraceNetwork:     cfg.Trace.Network,
+		TraceSignal:      cfg.Trace.Signal,
+		MaskTracerPid:    false, // validation rejects non-"off" values for now
+		SeccompPrefilter: cfg.Performance.SeccompPrefilter,
+		MaxTracees:       cfg.Performance.MaxTracees,
+		MaxHoldMs:        cfg.Performance.MaxHoldMs,
+		OnAttachFailure:  cfg.OnAttachFailure,
+		ExecHandler:      router,
+		FileHandler:      router,
+		NetworkHandler:   router,
+		SignalHandler:    router,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	a.ptraceTracer = tr
+	a.ptraceCancel = cancel
+	go tr.Run(ctx)
+	slog.Info("ptrace tracer started", "attach_mode", cfg.AttachMode)
+}
+
+// closePtraceTracer stops the ptrace tracer if running.
+func (a *App) closePtraceTracer() {
+	if a.ptraceCancel != nil {
+		a.ptraceCancel()
+		a.ptraceCancel = nil
+	}
+}

--- a/internal/api/app_ptrace_linux.go
+++ b/internal/api/app_ptrace_linux.go
@@ -44,8 +44,8 @@ func (a *App) initPtraceTracer() {
 	a.ptraceCancel = cancel
 	go func() {
 		if err := tr.Run(ctx); err != nil && ctx.Err() == nil {
-			slog.Error("ptrace tracer exited unexpectedly, clearing tracer to fail closed", "error", err)
-			a.ptraceTracer = nil
+			slog.Error("ptrace tracer exited unexpectedly, blocking commands (fail-closed)", "error", err)
+			a.ptraceFailed = true
 		}
 	}()
 	slog.Info("ptrace tracer started", "attach_mode", cfg.AttachMode)

--- a/internal/api/app_ptrace_other.go
+++ b/internal/api/app_ptrace_other.go
@@ -1,0 +1,6 @@
+//go:build !linux
+
+package api
+
+func (a *App) initPtraceTracer()  {}
+func (a *App) closePtraceTracer() {}

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -702,6 +702,9 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 }
 
 func (a *App) execInSessionCore(ctx context.Context, id string, req types.ExecRequest) (*types.ExecResponse, int, error) {
+	if a.ptraceFailed {
+		return nil, http.StatusServiceUnavailable, errors.New("ptrace tracer exited unexpectedly; refusing to execute commands without enforcement")
+	}
 	s, ok := a.sessions.Get(id)
 	if !ok {
 		return nil, http.StatusNotFound, errors.New("session not found")

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -98,6 +98,11 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 		return &wrapperSetupResult{wrappedReq: req, extraCfg: nil}
 	}
 
+	// Ptrace mode: no wrapper, no seccomp notify sockets
+	if a.ptraceTracer != nil {
+		return &wrapperSetupResult{wrappedReq: req, extraCfg: nil}
+	}
+
 	origCommand := req.Command
 	origArgs := append([]string{}, req.Args...)
 

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -702,7 +702,7 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 }
 
 func (a *App) execInSessionCore(ctx context.Context, id string, req types.ExecRequest) (*types.ExecResponse, int, error) {
-	if a.ptraceFailed {
+	if a.ptraceFailed.Load() {
 		return nil, http.StatusServiceUnavailable, errors.New("ptrace tracer exited unexpectedly; refusing to execute commands without enforcement")
 	}
 	s, ok := a.sessions.Get(id)

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -948,7 +948,7 @@ func (a *App) execInSessionCore(ctx context.Context, id string, req types.ExecRe
 
 	limits := a.policy.Limits()
 	cmdDecision := a.policy.CheckCommand(wrappedReq.Command, wrappedReq.Args)
-	exitCode, stdoutB, stderrB, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, execErr := runCommandWithResources(ctx, s, cmdID, wrappedReq, a.cfg, cmdDecision.EnvPolicy, limits.CommandTimeout, a.cgroupHook(id, cmdID, limits), extraCfg)
+	exitCode, stdoutB, stderrB, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, execErr := runCommandWithResources(ctx, s, cmdID, wrappedReq, a.cfg, cmdDecision.EnvPolicy, limits.CommandTimeout, a.cgroupHook(id, cmdID, limits), extraCfg, a.ptraceTracer, id)
 
 	// Check if process was killed by seccomp (SIGSYS) and emit event
 	emitSeccompBlockedIfSIGSYS(ctx, a.store, a.broker, id, cmdID, execErr)

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -105,7 +105,7 @@ func chooseCommandTimeout(req types.ExecRequest, policyLimit time.Duration) time
 	return d
 }
 
-func runCommandWithResources(ctx context.Context, s *session.Session, cmdID string, req types.ExecRequest, cfg *config.Config, envPol policy.ResolvedEnvPolicy, policyLimit time.Duration, hook postStartHook, extra *extraProcConfig) (exitCode int, stdout []byte, stderr []byte, stdoutTotal int64, stderrTotal int64, stdoutTrunc bool, stderrTrunc bool, resources types.ExecResources, err error) {
+func runCommandWithResources(ctx context.Context, s *session.Session, cmdID string, req types.ExecRequest, cfg *config.Config, envPol policy.ResolvedEnvPolicy, policyLimit time.Duration, hook postStartHook, extra *extraProcConfig, tracer any, sessionID string) (exitCode int, stdout []byte, stderr []byte, stdoutTotal int64, stderrTotal int64, stdoutTrunc bool, stderrTrunc bool, resources types.ExecResources, err error) {
 	timeout := chooseCommandTimeout(req, policyLimit)
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -133,11 +133,13 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 	}
 	cmd.Dir = workdir
 
-	// If we have a post-start hook (e.g., eBPF/cgroup), start the process in a
-	// stopped state using ptrace. This closes the race condition window where
-	// the process could make network connections before eBPF is attached.
-	startStopped := hook != nil
-	if startStopped {
+	// Determine process start mode:
+	// - ptrace tracer active: start normally, tracer attaches via PTRACE_SEIZE
+	// - cgroup hook without tracer: start stopped via PTRACE_TRACEME
+	// - no interception: start normally
+	if tracer != nil {
+		cmd.SysProcAttr = getSysProcAttr()
+	} else if hook != nil {
 		cmd.SysProcAttr = getSysProcAttrStopped()
 	} else {
 		cmd.SysProcAttr = getSysProcAttr()
@@ -215,7 +217,26 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 
 		// If we started with ptrace (stopped), run the hook BEFORE resuming.
 		// This ensures eBPF/cgroups are attached before the process executes.
-		if startStopped && hook != nil {
+		if tracer != nil {
+			// Ptrace tracer active: attach via PTRACE_SEIZE, run hook while stopped, resume
+			resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
+			if attachErr != nil {
+				_ = killProcess(cmd.Process.Pid)
+				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace attach: %w", attachErr)
+			}
+			if hook != nil {
+				if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {
+					defer func() { _ = cleanup() }()
+				}
+			}
+			if resume != nil {
+				if resumeErr := resume(); resumeErr != nil {
+					_ = killProcess(cmd.Process.Pid)
+					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
+				}
+			}
+		} else if hook != nil {
+			// Seccomp stopped-start: process started with PTRACE_TRACEME
 			if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {
 				defer func() { _ = cleanup() }()
 			}
@@ -224,11 +245,6 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 				// Failed to resume - kill the process and return error
 				_ = killProcess(cmd.Process.Pid)
 				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("resume traced process: %w", resumeErr)
-			}
-		} else if hook != nil {
-			// Non-stopped mode (fallback) - just run the hook
-			if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {
-				defer func() { _ = cleanup() }()
 			}
 		}
 

--- a/internal/api/exec_process_group_test.go
+++ b/internal/api/exec_process_group_test.go
@@ -40,7 +40,7 @@ func TestRunCommandTimeoutKillsProcessGroup(t *testing.T) {
 		Timeout: "100ms",
 	}
 
-	exitCode, _, _, _, _, _, _, _, err := runCommandWithResources(context.Background(), s, "cmd-timeout", req, cfg, policy.ResolvedEnvPolicy{}, 0, nil, nil)
+	exitCode, _, _, _, _, _, _, _, err := runCommandWithResources(context.Background(), s, "cmd-timeout", req, cfg, policy.ResolvedEnvPolicy{}, 0, nil, nil, nil, "")
 	if exitCode != 124 {
 		t.Fatalf("expected exit code 124 on timeout, got %d (err=%v)", exitCode, err)
 	}
@@ -63,7 +63,7 @@ func TestRunCommandTimeoutKillsProcessGroup_Streaming(t *testing.T) {
 		Timeout: "100ms",
 	}
 
-	exitCode, _, _, _, _, _, _, _, err := runCommandWithResourcesStreamingEmit(context.Background(), s, "cmd-timeout-stream", req, cfg, 0, nil, nil, nil)
+	exitCode, _, _, _, _, _, _, _, err := runCommandWithResourcesStreamingEmit(context.Background(), s, "cmd-timeout-stream", req, cfg, 0, nil, nil, nil, nil, "")
 	if exitCode != 124 {
 		t.Fatalf("expected exit code 124 on timeout, got %d (err=%v)", exitCode, err)
 	}

--- a/internal/api/exec_ptrace_linux.go
+++ b/internal/api/exec_ptrace_linux.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package api
+
+import (
+	"fmt"
+
+	"github.com/agentsh/agentsh/internal/ptrace"
+)
+
+// ptraceExecAttach attaches the ptrace tracer to a running process, waits for
+// the attachment to complete, and optionally keeps the process stopped (for
+// cgroup hook). Returns a resume function that must be called after the hook.
+func ptraceExecAttach(tracer any, pid int, sessionID, commandID string, keepStopped bool) (resume func() error, err error) {
+	tr, ok := tracer.(*ptrace.Tracer)
+	if !ok || tr == nil {
+		return nil, fmt.Errorf("ptraceExecAttach: invalid tracer type %T", tracer)
+	}
+
+	opts := []ptrace.AttachOption{
+		ptrace.WithSessionID(sessionID),
+		ptrace.WithCommandID(commandID),
+	}
+	if keepStopped {
+		opts = append(opts, ptrace.WithKeepStopped())
+	}
+
+	if err := tr.AttachPID(pid, opts...); err != nil {
+		return nil, fmt.Errorf("attach pid %d: %w", pid, err)
+	}
+	if err := tr.WaitAttached(pid); err != nil {
+		return nil, fmt.Errorf("wait attached pid %d: %w", pid, err)
+	}
+
+	if keepStopped {
+		return func() error {
+			return tr.ResumePID(pid)
+		}, nil
+	}
+	return func() error { return nil }, nil
+}

--- a/internal/api/exec_ptrace_other.go
+++ b/internal/api/exec_ptrace_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package api
+
+import "fmt"
+
+func ptraceExecAttach(tracer any, pid int, sessionID, commandID string, keepStopped bool) (resume func() error, err error) {
+	return nil, fmt.Errorf("ptrace not supported on this platform")
+}

--- a/internal/api/exec_resources_test.go
+++ b/internal/api/exec_resources_test.go
@@ -30,7 +30,7 @@ func TestRunCommand_ReturnsResourcesForExternalCommand(t *testing.T) {
 	cfg := &config.Config{}
 	req := types.ExecRequest{Command: "sh", Args: []string{"-c", "echo hi"}}
 
-	_, _, _, _, _, _, _, res, err := runCommandWithResources(context.Background(), s, "cmd-test", req, cfg, policy.ResolvedEnvPolicy{}, 0, nil, nil)
+	_, _, _, _, _, _, _, res, err := runCommandWithResources(context.Background(), s, "cmd-test", req, cfg, policy.ResolvedEnvPolicy{}, 0, nil, nil, nil, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -24,7 +24,7 @@ import (
 )
 
 func (a *App) execInSessionStream(w http.ResponseWriter, r *http.Request) {
-	if a.ptraceFailed {
+	if a.ptraceFailed.Load() {
 		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "ptrace tracer exited unexpectedly; refusing to execute commands without enforcement"})
 		return
 	}

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -24,6 +24,10 @@ import (
 )
 
 func (a *App) execInSessionStream(w http.ResponseWriter, r *http.Request) {
+	if a.ptraceFailed {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]any{"error": "ptrace tracer exited unexpectedly; refusing to execute commands without enforcement"})
+		return
+	}
 	id := chi.URLParam(r, "id")
 	s, ok := a.sessions.Get(id)
 	if !ok {

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -198,7 +198,7 @@ func (a *App) execInSessionStream(w http.ResponseWriter, r *http.Request) {
 	emit := func(event string, payload map[string]any) error {
 		return writeSSE(w, flusher, event, payload)
 	}
-	exitCode, stdoutB, stderrB, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, execErr := runCommandWithResourcesStreamingEmit(r.Context(), s, cmdID, wrappedReq, a.cfg, limits.CommandTimeout, emit, a.cgroupHook(id, cmdID, limits), extraCfg)
+	exitCode, stdoutB, stderrB, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, execErr := runCommandWithResourcesStreamingEmit(r.Context(), s, cmdID, wrappedReq, a.cfg, limits.CommandTimeout, emit, a.cgroupHook(id, cmdID, limits), extraCfg, a.ptraceTracer, id)
 	_ = a.store.SaveOutput(r.Context(), id, cmdID, stdoutB, stderrB, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc)
 
 	// Check if process was killed by seccomp (SIGSYS) and emit event
@@ -238,7 +238,7 @@ func (a *App) execInSessionStream(w http.ResponseWriter, r *http.Request) {
 
 type emitFunc func(event string, payload map[string]any) error
 
-func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Session, cmdID string, req types.ExecRequest, cfg *config.Config, policyLimit time.Duration, emit emitFunc, hook postStartHook, extra *extraProcConfig) (exitCode int, stdout []byte, stderr []byte, stdoutTotal int64, stderrTotal int64, stdoutTrunc bool, stderrTrunc bool, resources types.ExecResources, err error) {
+func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Session, cmdID string, req types.ExecRequest, cfg *config.Config, policyLimit time.Duration, emit emitFunc, hook postStartHook, extra *extraProcConfig, tracer any, sessionID string) (exitCode int, stdout []byte, stderr []byte, stdoutTotal int64, stderrTotal int64, stdoutTrunc bool, stderrTrunc bool, resources types.ExecResources, err error) {
 	timeout := chooseCommandTimeout(req, policyLimit)
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -271,11 +271,10 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 	}
 	cmd.Dir = workdir
 
-	// If we have a post-start hook (e.g., eBPF/cgroup), start the process in a
-	// stopped state using ptrace. This closes the race condition window where
-	// the process could make network connections before eBPF is attached.
-	startStopped := hook != nil
-	if startStopped {
+	// Determine process start mode (same as non-streaming path)
+	if tracer != nil {
+		cmd.SysProcAttr = getSysProcAttr()
+	} else if hook != nil {
 		cmd.SysProcAttr = getSysProcAttrStopped()
 	} else {
 		cmd.SysProcAttr = getSysProcAttr()
@@ -328,22 +327,32 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 		s.SetCurrentProcessPID(cmd.Process.Pid)
 		pgid = getProcessGroupID(cmd.Process.Pid)
 
-		// If we started with ptrace (stopped), run the hook BEFORE resuming.
-		// This ensures eBPF/cgroups are attached before the process executes.
-		if startStopped && hook != nil {
-			if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {
-				defer func() { _ = cleanup() }()
-			}
-			// Resume the traced process - it was stopped at first instruction
-			if resumeErr := resumeTracedProcess(cmd.Process.Pid); resumeErr != nil {
-				// Failed to resume - kill the process and return error
+		if tracer != nil {
+			// Ptrace tracer active: attach via PTRACE_SEIZE, run hook while stopped, resume
+			resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
+			if attachErr != nil {
 				_ = killProcess(cmd.Process.Pid)
-				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("resume traced process: %w", resumeErr)
+				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace attach: %w", attachErr)
+			}
+			if hook != nil {
+				if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {
+					defer func() { _ = cleanup() }()
+				}
+			}
+			if resume != nil {
+				if resumeErr := resume(); resumeErr != nil {
+					_ = killProcess(cmd.Process.Pid)
+					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
+				}
 			}
 		} else if hook != nil {
-			// Non-stopped mode (fallback) - just run the hook
+			// Seccomp stopped-start: process started with PTRACE_TRACEME
 			if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {
 				defer func() { _ = cleanup() }()
+			}
+			if resumeErr := resumeTracedProcess(cmd.Process.Pid); resumeErr != nil {
+				_ = killProcess(cmd.Process.Pid)
+				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("resume traced process: %w", resumeErr)
 			}
 		}
 

--- a/internal/api/grpc.go
+++ b/internal/api/grpc.go
@@ -419,6 +419,8 @@ func (s *grpcServer) ExecStream(in *structpb.Struct, stream grpc.ServerStream) e
 		emit,
 		s.app.cgroupHook(req.SessionID, cmdID, limits),
 		extraCfg,
+		s.app.ptraceTracer,
+		req.SessionID,
 	)
 	_ = s.app.store.SaveOutput(stream.Context(), req.SessionID, cmdID, stdoutB, stderrB, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc)
 

--- a/internal/api/grpc.go
+++ b/internal/api/grpc.go
@@ -249,6 +249,9 @@ func (s *grpcServer) ExecStream(in *structpb.Struct, stream grpc.ServerStream) e
 	if s == nil || s.app == nil {
 		return status.Error(codes.Internal, "server not initialized")
 	}
+	if s.app.ptraceFailed.Load() {
+		return status.Error(codes.Unavailable, "ptrace tracer exited unexpectedly; refusing to execute commands without enforcement")
+	}
 	var reqMap map[string]any
 	if err := json.Unmarshal(mustProtoJSON(in), &reqMap); err != nil {
 		return status.Error(codes.InvalidArgument, "invalid request")

--- a/internal/api/ptrace_handlers.go
+++ b/internal/api/ptrace_handlers.go
@@ -1,0 +1,204 @@
+//go:build linux
+
+package api
+
+import (
+	"context"
+	"log/slog"
+	"syscall"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/events"
+	"github.com/agentsh/agentsh/internal/ptrace"
+	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/store/composite"
+	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/google/uuid"
+)
+
+// ptraceHandlerRouter routes ptrace syscall events to session-level policy
+// engines. It implements all four ptrace handler interfaces.
+type ptraceHandlerRouter struct {
+	sessions *session.Manager
+	store    *composite.Store
+	broker   *events.Broker
+}
+
+var _ ptrace.ExecHandler = (*ptraceHandlerRouter)(nil)
+var _ ptrace.FileHandler = (*ptraceHandlerRouter)(nil)
+var _ ptrace.NetworkHandler = (*ptraceHandlerRouter)(nil)
+var _ ptrace.SignalHandler = (*ptraceHandlerRouter)(nil)
+
+func (r *ptraceHandlerRouter) HandleExecve(ctx context.Context, ec ptrace.ExecContext) ptrace.ExecResult {
+	s, ok := r.sessions.Get(ec.SessionID)
+	if !ok {
+		slog.Warn("ptrace: unknown session for execve", "session_id", ec.SessionID, "pid", ec.PID)
+		return ptrace.ExecResult{Allow: false, Action: "deny", Errno: int32(syscall.EACCES), Rule: "unknown_session"}
+	}
+
+	pe := s.PolicyEngine()
+	if pe == nil {
+		return ptrace.ExecResult{Allow: true, Action: "continue"}
+	}
+
+	decision := pe.CheckExecve(ec.Filename, ec.Argv, ec.Depth)
+
+	// Emit audit event
+	ev := types.Event{
+		ID:        uuid.NewString(),
+		Timestamp: time.Now().UTC(),
+		Type:      "ptrace_execve",
+		SessionID: ec.SessionID,
+		Fields: map[string]any{
+			"pid":       ec.PID,
+			"filename":  ec.Filename,
+			"argv":      ec.Argv,
+			"depth":     ec.Depth,
+			"decision":  string(decision.EffectiveDecision),
+			"rule":      decision.Rule,
+			"truncated": ec.Truncated,
+		},
+	}
+	_ = r.store.AppendEvent(ctx, ev)
+	r.broker.Publish(ev)
+
+	switch decision.EffectiveDecision {
+	case types.DecisionDeny:
+		return ptrace.ExecResult{
+			Action: "deny",
+			Allow:  false,
+			Errno:  int32(syscall.EACCES),
+			Rule:   decision.Rule,
+		}
+	case types.DecisionRedirect:
+		if decision.Redirect != nil {
+			return ptrace.ExecResult{
+				Action:   "redirect",
+				StubPath: decision.Redirect.Command,
+				Rule:     decision.Rule,
+			}
+		}
+		return ptrace.ExecResult{Allow: true, Action: "continue", Rule: decision.Rule}
+	case types.DecisionApprove:
+		// Approval-required decisions cannot be handled synchronously via ptrace.
+		// Deny with a descriptive rule for audit visibility.
+		return ptrace.ExecResult{
+			Action: "deny",
+			Allow:  false,
+			Errno:  int32(syscall.EACCES),
+			Rule:   decision.Rule + " (approval required, denied in ptrace mode)",
+		}
+	default:
+		return ptrace.ExecResult{Allow: true, Action: "continue", Rule: decision.Rule}
+	}
+}
+
+func (r *ptraceHandlerRouter) HandleFile(ctx context.Context, fc ptrace.FileContext) ptrace.FileResult {
+	s, ok := r.sessions.Get(fc.SessionID)
+	if !ok {
+		slog.Warn("ptrace: unknown session for file", "session_id", fc.SessionID, "pid", fc.PID)
+		return ptrace.FileResult{Allow: false, Action: "deny", Errno: int32(syscall.EACCES)}
+	}
+
+	pe := s.PolicyEngine()
+	if pe == nil {
+		return ptrace.FileResult{Allow: true, Action: "allow"}
+	}
+
+	decision := pe.CheckFile(fc.Path, fc.Operation)
+
+	ev := types.Event{
+		ID:        uuid.NewString(),
+		Timestamp: time.Now().UTC(),
+		Type:      "ptrace_file",
+		SessionID: fc.SessionID,
+		Fields: map[string]any{
+			"pid":       fc.PID,
+			"path":      fc.Path,
+			"operation": fc.Operation,
+			"decision":  string(decision.EffectiveDecision),
+			"rule":      decision.Rule,
+		},
+	}
+	_ = r.store.AppendEvent(ctx, ev)
+	r.broker.Publish(ev)
+
+	switch decision.EffectiveDecision {
+	case types.DecisionDeny:
+		return ptrace.FileResult{
+			Allow:  false,
+			Action: "deny",
+			Errno:  int32(syscall.EACCES),
+		}
+	case types.DecisionRedirect:
+		if decision.FileRedirect != nil {
+			return ptrace.FileResult{
+				Action:       "redirect",
+				RedirectPath: decision.FileRedirect.RedirectPath,
+			}
+		}
+		return ptrace.FileResult{Allow: true, Action: "allow"}
+	case types.DecisionSoftDelete:
+		return ptrace.FileResult{
+			Action:   "soft-delete",
+			TrashDir: "", // trash dir resolved by caller
+		}
+	default:
+		return ptrace.FileResult{Allow: true, Action: "allow"}
+	}
+}
+
+func (r *ptraceHandlerRouter) HandleNetwork(ctx context.Context, nc ptrace.NetworkContext) ptrace.NetworkResult {
+	s, ok := r.sessions.Get(nc.SessionID)
+	if !ok {
+		slog.Warn("ptrace: unknown session for network", "session_id", nc.SessionID, "pid", nc.PID)
+		return ptrace.NetworkResult{Allow: false, Action: "deny", Errno: int32(syscall.EACCES)}
+	}
+
+	pe := s.PolicyEngine()
+	if pe == nil {
+		return ptrace.NetworkResult{Allow: true, Action: "allow"}
+	}
+
+	decision := pe.CheckNetwork(nc.Address, nc.Port)
+
+	ev := types.Event{
+		ID:        uuid.NewString(),
+		Timestamp: time.Now().UTC(),
+		Type:      "ptrace_network",
+		SessionID: nc.SessionID,
+		Fields: map[string]any{
+			"pid":       nc.PID,
+			"address":   nc.Address,
+			"port":      nc.Port,
+			"operation": nc.Operation,
+			"decision":  string(decision.EffectiveDecision),
+			"rule":      decision.Rule,
+		},
+	}
+	_ = r.store.AppendEvent(ctx, ev)
+	r.broker.Publish(ev)
+
+	switch decision.EffectiveDecision {
+	case types.DecisionDeny:
+		return ptrace.NetworkResult{
+			Allow:  false,
+			Action: "deny",
+			Errno:  int32(syscall.EACCES),
+		}
+	default:
+		return ptrace.NetworkResult{Allow: true, Action: "allow"}
+	}
+}
+
+func (r *ptraceHandlerRouter) HandleSignal(ctx context.Context, sc ptrace.SignalContext) ptrace.SignalResult {
+	_, ok := r.sessions.Get(sc.SessionID)
+	if !ok {
+		slog.Warn("ptrace: unknown session for signal", "session_id", sc.SessionID, "pid", sc.PID)
+		return ptrace.SignalResult{Allow: false, Errno: int32(syscall.EACCES)}
+	}
+
+	// Signal filtering via ptrace — allow all signals for now.
+	// Per-signal policy requires signal engine integration (future work).
+	return ptrace.SignalResult{Allow: true}
+}

--- a/internal/api/ptrace_handlers.go
+++ b/internal/api/ptrace_handlers.go
@@ -76,14 +76,20 @@ func (r *ptraceHandlerRouter) HandleExecve(ctx context.Context, ec ptrace.ExecCo
 			Rule:   decision.Rule,
 		}
 	case types.DecisionRedirect:
-		if decision.Redirect != nil {
+		if decision.Redirect != nil && decision.Redirect.Command != "" {
 			return ptrace.ExecResult{
 				Action:   "redirect",
 				StubPath: decision.Redirect.Command,
 				Rule:     decision.Rule,
 			}
 		}
-		return ptrace.ExecResult{Allow: true, Action: "continue", Rule: decision.Rule}
+		// Invalid redirect payload — deny to fail closed.
+		return ptrace.ExecResult{
+			Action: "deny",
+			Allow:  false,
+			Errno:  int32(syscall.EACCES),
+			Rule:   decision.Rule + " (redirect with no target, denied)",
+		}
 	case types.DecisionApprove:
 		// Approval-required decisions cannot be handled synchronously via ptrace.
 		// Deny with a descriptive rule for audit visibility.
@@ -137,13 +143,14 @@ func (r *ptraceHandlerRouter) HandleFile(ctx context.Context, fc ptrace.FileCont
 			Errno:  int32(syscall.EACCES),
 		}
 	case types.DecisionRedirect:
-		if decision.FileRedirect != nil {
+		if decision.FileRedirect != nil && decision.FileRedirect.RedirectPath != "" {
 			return ptrace.FileResult{
 				Action:       "redirect",
 				RedirectPath: decision.FileRedirect.RedirectPath,
 			}
 		}
-		return ptrace.FileResult{Allow: true, Action: "allow"}
+		// Invalid redirect payload — deny to fail closed.
+		return ptrace.FileResult{Allow: false, Action: "deny", Errno: int32(syscall.EACCES)}
 	case types.DecisionSoftDelete:
 		// Soft-delete requires a trash directory which is not available in the
 		// ptrace handler context. Deny with audit visibility.

--- a/internal/api/ptrace_handlers.go
+++ b/internal/api/ptrace_handlers.go
@@ -38,10 +38,15 @@ func (r *ptraceHandlerRouter) HandleExecve(ctx context.Context, ec ptrace.ExecCo
 
 	pe := s.PolicyEngine()
 	if pe == nil {
-		return ptrace.ExecResult{Allow: true, Action: "continue"}
+		slog.Warn("ptrace: no policy engine for session, denying execve", "session_id", ec.SessionID, "pid", ec.PID)
+		return ptrace.ExecResult{Allow: false, Action: "deny", Errno: int32(syscall.EACCES), Rule: "no_policy_engine"}
 	}
 
-	decision := pe.CheckExecve(ec.Filename, ec.Argv, ec.Depth)
+	depth := ec.Depth
+	if depth < 0 {
+		depth = 0
+	}
+	decision := pe.CheckExecve(ec.Filename, ec.Argv, depth)
 
 	// Emit audit event
 	ev := types.Event{
@@ -102,7 +107,8 @@ func (r *ptraceHandlerRouter) HandleFile(ctx context.Context, fc ptrace.FileCont
 
 	pe := s.PolicyEngine()
 	if pe == nil {
-		return ptrace.FileResult{Allow: true, Action: "allow"}
+		slog.Warn("ptrace: no policy engine for session, denying file op", "session_id", fc.SessionID, "pid", fc.PID)
+		return ptrace.FileResult{Allow: false, Action: "deny", Errno: int32(syscall.EACCES)}
 	}
 
 	decision := pe.CheckFile(fc.Path, fc.Operation)
@@ -139,9 +145,12 @@ func (r *ptraceHandlerRouter) HandleFile(ctx context.Context, fc ptrace.FileCont
 		}
 		return ptrace.FileResult{Allow: true, Action: "allow"}
 	case types.DecisionSoftDelete:
+		// Soft-delete requires a trash directory which is not available in the
+		// ptrace handler context. Deny with audit visibility.
 		return ptrace.FileResult{
-			Action:   "soft-delete",
-			TrashDir: "", // trash dir resolved by caller
+			Allow:  false,
+			Action: "deny",
+			Errno:  int32(syscall.EACCES),
 		}
 	default:
 		return ptrace.FileResult{Allow: true, Action: "allow"}
@@ -157,7 +166,8 @@ func (r *ptraceHandlerRouter) HandleNetwork(ctx context.Context, nc ptrace.Netwo
 
 	pe := s.PolicyEngine()
 	if pe == nil {
-		return ptrace.NetworkResult{Allow: true, Action: "allow"}
+		slog.Warn("ptrace: no policy engine for session, denying network op", "session_id", nc.SessionID, "pid", nc.PID)
+		return ptrace.NetworkResult{Allow: false, Action: "deny", Errno: int32(syscall.EACCES)}
 	}
 
 	decision := pe.CheckNetwork(nc.Address, nc.Port)

--- a/internal/api/pty_core.go
+++ b/internal/api/pty_core.go
@@ -41,6 +41,9 @@ func (a *App) startPTY(ctx context.Context, sessionID string, req ptyStartParams
 	if a == nil {
 		return nil, http.StatusServiceUnavailable, errors.New("server not initialized")
 	}
+	if a.ptraceFailed.Load() {
+		return nil, http.StatusServiceUnavailable, errors.New("ptrace tracer exited unexpectedly; refusing to execute commands without enforcement")
+	}
 	sess, ok := a.sessions.Get(sessionID)
 	if !ok {
 		return nil, http.StatusNotFound, errors.New("session not found")

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -68,6 +68,10 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 
 	// Ptrace mode: skip seccomp wrapper entirely. Create a socket for PID handshake.
 	if a.ptraceTracer != nil {
+		if a.ptraceFailed.Load() {
+			return types.WrapInitResponse{}, http.StatusServiceUnavailable,
+				fmt.Errorf("ptrace tracer is not healthy; refusing wrap-init")
+		}
 		notifyDir, err := os.MkdirTemp("", "agentsh-wrap-*")
 		if err != nil {
 			return types.WrapInitResponse{}, http.StatusInternalServerError, err
@@ -76,8 +80,26 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 			os.RemoveAll(notifyDir)
 			return types.WrapInitResponse{}, http.StatusInternalServerError, err
 		}
+		// Apply same path-budget + hash truncation as seccomp wrap path
 		safeID := filepath.Base(sessionID)
-		notifySocketPath := filepath.Join(notifyDir, "ptrace-"+safeID+".sock")
+		const socketPathLimit = 104
+		prefix := "ptrace-"
+		suffix := ".sock"
+		budget := socketPathLimit - len(notifyDir) - 1 - len(prefix) - len(suffix)
+		if budget < 1 {
+			os.RemoveAll(notifyDir)
+			return types.WrapInitResponse{}, http.StatusInternalServerError,
+				fmt.Errorf("temp directory path too long for Unix socket (%d bytes remaining)", budget)
+		}
+		if len(safeID) > budget {
+			h := sha256.Sum256([]byte(safeID))
+			hashStr := hex.EncodeToString(h[:])
+			if budget > len(hashStr) {
+				budget = len(hashStr)
+			}
+			safeID = hashStr[:budget]
+		}
+		notifySocketPath := filepath.Join(notifyDir, prefix+safeID+suffix)
 
 		listener, err := net.Listen("unix", notifySocketPath)
 		if err != nil {

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -66,6 +66,48 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 		return types.WrapInitResponse{}, http.StatusBadRequest, errWrapNotSupported
 	}
 
+	// Ptrace mode: skip seccomp wrapper entirely. Create a socket for PID handshake.
+	if a.ptraceTracer != nil {
+		notifyDir, err := os.MkdirTemp("", "agentsh-wrap-*")
+		if err != nil {
+			return types.WrapInitResponse{}, http.StatusInternalServerError, err
+		}
+		if err := os.Chmod(notifyDir, 0700); err != nil {
+			os.RemoveAll(notifyDir)
+			return types.WrapInitResponse{}, http.StatusInternalServerError, err
+		}
+		safeID := filepath.Base(sessionID)
+		notifySocketPath := filepath.Join(notifyDir, "ptrace-"+safeID+".sock")
+
+		listener, err := net.Listen("unix", notifySocketPath)
+		if err != nil {
+			os.RemoveAll(notifyDir)
+			return types.WrapInitResponse{}, http.StatusInternalServerError, err
+		}
+
+		go a.acceptPtracePID(ctx, listener, notifySocketPath, sessionID)
+
+		ev := types.Event{
+			ID:        uuid.NewString(),
+			Timestamp: time.Now().UTC(),
+			Type:      "wrap_init",
+			SessionID: sessionID,
+			Fields: map[string]any{
+				"ptrace_mode":   true,
+				"agent_command": req.AgentCommand,
+				"agent_args":    req.AgentArgs,
+				"notify_socket": notifySocketPath,
+			},
+		}
+		_ = a.store.AppendEvent(ctx, ev)
+		a.broker.Publish(ev)
+
+		return types.WrapInitResponse{
+			PtraceMode:   true,
+			NotifySocket: notifySocketPath,
+		}, http.StatusOK, nil
+	}
+
 	// Resolve wrapper binary
 	wrapperBin := strings.TrimSpace(a.cfg.Sandbox.UnixSockets.WrapperBin)
 	if wrapperBin == "" {

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	unixmon "github.com/agentsh/agentsh/internal/netmonitor/unix"
 	"github.com/agentsh/agentsh/internal/session"
@@ -173,11 +174,19 @@ func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socket
 	defer listener.Close()
 	defer os.RemoveAll(filepath.Dir(socketPath))
 
+	// Set accept deadline to prevent indefinite goroutine leak
+	if ul, ok := listener.(*net.UnixListener); ok {
+		ul.SetDeadline(time.Now().Add(30 * time.Second))
+	}
+
 	conn, err := listener.Accept()
 	if err != nil {
 		slog.Error("ptrace wrap: accept failed", "error", err, "session_id", sessionID)
 		return
 	}
+
+	// Set read deadline for the handshake
+	conn.SetDeadline(time.Now().Add(10 * time.Second))
 
 	// Read child PID from client (4-byte little-endian).
 	// The CLI sends the spawned shell's PID explicitly rather than relying
@@ -196,6 +205,17 @@ func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socket
 		slog.Error("ptrace wrap: invalid PID", "pid", pid, "session_id", sessionID)
 		return
 	}
+
+	// Basic validation: verify the PID exists
+	if _, err := os.Stat(fmt.Sprintf("/proc/%d", pid)); err != nil {
+		conn.Write([]byte{0}) // NACK
+		conn.Close()
+		slog.Error("ptrace wrap: PID does not exist", "pid", pid, "error", err, "session_id", sessionID)
+		return
+	}
+
+	// Clear read deadline for the keepalive phase
+	conn.SetDeadline(time.Time{})
 
 	_, attachErr := ptraceExecAttach(a.ptraceTracer, pid, sessionID, "", false)
 	if attachErr != nil {

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -186,6 +186,7 @@ func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socket
 
 	pid := getConnPeerPID(unixConn)
 	if pid <= 0 {
+		conn.Write([]byte{0}) // NACK
 		conn.Close()
 		slog.Error("ptrace wrap: invalid peer PID", "pid", pid, "session_id", sessionID)
 		return
@@ -193,15 +194,17 @@ func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socket
 
 	_, attachErr := ptraceExecAttach(a.ptraceTracer, pid, sessionID, "", false)
 	if attachErr != nil {
+		conn.Write([]byte{0}) // NACK
 		conn.Close()
 		slog.Error("ptrace wrap: attach failed", "pid", pid, "error", attachErr, "session_id", sessionID)
 		return
 	}
 
+	// ACK: attach succeeded, CLI can proceed
+	conn.Write([]byte{1})
 	slog.Info("ptrace wrap: attached to shell", "pid", pid, "session_id", sessionID)
 
 	// Keep connection open until context is cancelled or shell exits.
-	// When the shell exits, the connection closes and Read returns.
 	go func() {
 		defer conn.Close()
 		buf := make([]byte, 1)

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -177,18 +177,21 @@ func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socket
 		return
 	}
 
-	unixConn, ok := conn.(*net.UnixConn)
-	if !ok {
+	// Read child PID from client (4-byte little-endian).
+	// The CLI sends the spawned shell's PID explicitly rather than relying
+	// on SO_PEERCRED, which would give the CLI's PID instead.
+	pidBuf := make([]byte, 4)
+	if _, err := conn.Read(pidBuf); err != nil {
+		conn.Write([]byte{0}) // NACK
 		conn.Close()
-		slog.Error("ptrace wrap: expected Unix connection", "type", fmt.Sprintf("%T", conn), "session_id", sessionID)
+		slog.Error("ptrace wrap: failed to read PID", "error", err, "session_id", sessionID)
 		return
 	}
-
-	pid := getConnPeerPID(unixConn)
+	pid := int(pidBuf[0]) | int(pidBuf[1])<<8 | int(pidBuf[2])<<16 | int(pidBuf[3])<<24
 	if pid <= 0 {
 		conn.Write([]byte{0}) // NACK
 		conn.Close()
-		slog.Error("ptrace wrap: invalid peer PID", "pid", pid, "session_id", sessionID)
+		slog.Error("ptrace wrap: invalid PID", "pid", pid, "session_id", sessionID)
 		return
 	}
 

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -4,8 +4,10 @@ package api
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -181,13 +183,13 @@ func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socket
 	// The CLI sends the spawned shell's PID explicitly rather than relying
 	// on SO_PEERCRED, which would give the CLI's PID instead.
 	pidBuf := make([]byte, 4)
-	if _, err := conn.Read(pidBuf); err != nil {
+	if _, err := io.ReadFull(conn, pidBuf); err != nil {
 		conn.Write([]byte{0}) // NACK
 		conn.Close()
 		slog.Error("ptrace wrap: failed to read PID", "error", err, "session_id", sessionID)
 		return
 	}
-	pid := int(pidBuf[0]) | int(pidBuf[1])<<8 | int(pidBuf[2])<<16 | int(pidBuf[3])<<24
+	pid := int(binary.LittleEndian.Uint32(pidBuf))
 	if pid <= 0 {
 		conn.Write([]byte{0}) // NACK
 		conn.Close()

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -163,3 +163,56 @@ func getConnPeerPID(conn *net.UnixConn) int {
 	})
 	return pid
 }
+
+// acceptPtracePID accepts a connection on the notify socket, extracts the peer
+// PID via SO_PEERCRED, and attaches the ptrace tracer. The connection is kept
+// open as a keepalive — when the shell exits, the connection closes.
+func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string) {
+	defer listener.Close()
+	defer os.RemoveAll(filepath.Dir(socketPath))
+
+	conn, err := listener.Accept()
+	if err != nil {
+		slog.Error("ptrace wrap: accept failed", "error", err, "session_id", sessionID)
+		return
+	}
+
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		conn.Close()
+		slog.Error("ptrace wrap: expected Unix connection", "type", fmt.Sprintf("%T", conn), "session_id", sessionID)
+		return
+	}
+
+	pid := getConnPeerPID(unixConn)
+	if pid <= 0 {
+		conn.Close()
+		slog.Error("ptrace wrap: invalid peer PID", "pid", pid, "session_id", sessionID)
+		return
+	}
+
+	_, attachErr := ptraceExecAttach(a.ptraceTracer, pid, sessionID, "", false)
+	if attachErr != nil {
+		conn.Close()
+		slog.Error("ptrace wrap: attach failed", "pid", pid, "error", attachErr, "session_id", sessionID)
+		return
+	}
+
+	slog.Info("ptrace wrap: attached to shell", "pid", pid, "session_id", sessionID)
+
+	// Keep connection open until context is cancelled or shell exits.
+	// When the shell exits, the connection closes and Read returns.
+	go func() {
+		defer conn.Close()
+		buf := make([]byte, 1)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				conn.Read(buf) // blocks until close or error
+				return
+			}
+		}
+	}()
+}

--- a/internal/api/wrap_other.go
+++ b/internal/api/wrap_other.go
@@ -39,3 +39,7 @@ func (a *App) wrapInitWindows(ctx context.Context, s *session.Session, sessionID
 func getConnPeerPID(conn *net.UnixConn) int {
 	return 0
 }
+
+func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string) {
+	listener.Close()
+}

--- a/internal/api/wrap_windows.go
+++ b/internal/api/wrap_windows.go
@@ -43,6 +43,10 @@ func getConnPeerPID(conn *net.UnixConn) int {
 	return 0
 }
 
+func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string) {
+	listener.Close()
+}
+
 func startSignalHandlerForWrap(ctx context.Context, signalFD *os.File, sessionID string, a *App) {
 	if signalFD != nil {
 		signalFD.Close()

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -219,6 +219,9 @@ func runWrap(ctx context.Context, cfg *clientConfig, opts wrapOptions) error {
 			if err := wrapCfg.ptracePostStart(agentProc.Process.Pid); err != nil {
 				_ = agentProc.Process.Kill()
 				_ = agentProc.Wait()
+				signal.Stop(sigCh)
+				close(sigCh)
+				<-sigDone
 				return fmt.Errorf("ptrace handshake failed: %w", err)
 			}
 		}

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -213,11 +213,24 @@ func runWrap(ctx context.Context, cfg *clientConfig, opts wrapOptions) error {
 	}
 
 	if wrapCfg != nil {
+		// Ptrace handshake: send child PID to server and wait for attach ACK
+		// before allowing the child to proceed. Must happen before postStart.
+		if wrapCfg.ptracePostStart != nil {
+			if err := wrapCfg.ptracePostStart(agentProc.Process.Pid); err != nil {
+				_ = agentProc.Process.Kill()
+				_ = agentProc.Wait()
+				return fmt.Errorf("ptrace handshake failed: %w", err)
+			}
+		}
+
 		mechanism := "seccomp"
 		if runtime.GOOS == "darwin" {
 			mechanism = "ES"
 		} else if runtime.GOOS == "windows" {
 			mechanism = "driver"
+		}
+		if wrapCfg.ptracePostStart != nil {
+			mechanism = "ptrace"
 		}
 		fmt.Fprintf(os.Stderr, "agentsh: agent %s started with %s interception (pid: %d)\n", opts.agentCmd, mechanism, agentProc.Process.Pid)
 		// Forward the notify fd to the server in the background
@@ -273,6 +286,9 @@ type wrapLaunchConfig struct {
 	postStart   func() // Called after the process starts (e.g., to forward notify fd)
 	postWait    func() // Called after the process exits (e.g., to reclaim terminal)
 	keepAlive   io.Closer // Held open during shell lifetime (e.g., ptrace handshake conn)
+	// ptracePostStart is called after the child is started with the child PID.
+	// It performs the ptrace handshake (send PID, wait for ACK).
+	ptracePostStart func(childPID int) error
 }
 
 // setupWrapInterception initializes seccomp interception via the server and returns

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -234,6 +235,9 @@ func runWrap(ctx context.Context, cfg *clientConfig, opts wrapOptions) error {
 	if wrapCfg != nil && wrapCfg.postWait != nil {
 		wrapCfg.postWait()
 	}
+	if wrapCfg != nil && wrapCfg.keepAlive != nil {
+		wrapCfg.keepAlive.Close()
+	}
 
 	signal.Stop(sigCh)
 	close(sigCh)
@@ -268,6 +272,7 @@ type wrapLaunchConfig struct {
 	sysProcAttr *syscall.SysProcAttr
 	postStart   func() // Called after the process starts (e.g., to forward notify fd)
 	postWait    func() // Called after the process exits (e.g., to reclaim terminal)
+	keepAlive   io.Closer // Held open during shell lifetime (e.g., ptrace handshake conn)
 }
 
 // setupWrapInterception initializes seccomp interception via the server and returns
@@ -283,10 +288,11 @@ func setupWrapInterception(ctx context.Context, c client.CLIClient, sessID strin
 		return nil, fmt.Errorf("wrap-init: %w", err)
 	}
 
-	// On Linux, the server must provide a wrapper binary for seccomp interception.
+	// On Linux, the server must provide a wrapper binary for seccomp interception,
+	// unless ptrace mode is active (no wrapper needed).
 	// On macOS and Windows, an empty WrapperBinary is valid — interception is
 	// system-wide via the System Extension (macOS) or driver (Windows).
-	if wrapResp.WrapperBinary == "" && runtime.GOOS == "linux" {
+	if !wrapResp.PtraceMode && wrapResp.WrapperBinary == "" && runtime.GOOS == "linux" {
 		return nil, fmt.Errorf("server returned empty wrapper binary")
 	}
 

--- a/internal/cli/wrap_linux.go
+++ b/internal/cli/wrap_linux.go
@@ -22,28 +22,16 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 	// Ptrace mode: no wrapper binary needed. Connect to the server's socket
 	// for PID handshake via SO_PEERCRED, then launch the shell directly.
 	if wrapResp.PtraceMode {
-		conn, err := net.Dial("unix", wrapResp.NotifySocket)
-		if err != nil {
-			return nil, fmt.Errorf("ptrace handshake: %w", err)
-		}
-
-		// Wait for server to attach and ACK. The server reads our PID via
-		// SO_PEERCRED, attaches the tracer, then sends 1 (ACK) or 0 (NACK).
-		ack := make([]byte, 1)
-		if _, err := conn.Read(ack); err != nil {
-			conn.Close()
-			return nil, fmt.Errorf("ptrace handshake: read ACK: %w", err)
-		}
-		if ack[0] != 1 {
-			conn.Close()
-			return nil, fmt.Errorf("ptrace handshake: server rejected attach")
-		}
+		notifySocket := wrapResp.NotifySocket
 
 		env := os.Environ()
 		env = append(env,
 			fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessID),
 			fmt.Sprintf("AGENTSH_SERVER=%s", cfg.serverAddr),
 		)
+
+		// connHolder stores the keepalive connection set by ptracePostStart.
+		var connHolder net.Conn
 
 		return &wrapLaunchConfig{
 			command: agentPath,
@@ -57,8 +45,43 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 				}
 				return attr
 			}(),
-			keepAlive: conn,
+			ptracePostStart: func(childPID int) error {
+				// Connect after child starts, send the child PID explicitly
+				// (SO_PEERCRED would give our parent PID, not the child's).
+				conn, err := net.Dial("unix", notifySocket)
+				if err != nil {
+					return fmt.Errorf("dial: %w", err)
+				}
+
+				// Send child PID as 4-byte little-endian
+				pidBytes := make([]byte, 4)
+				pidBytes[0] = byte(childPID)
+				pidBytes[1] = byte(childPID >> 8)
+				pidBytes[2] = byte(childPID >> 16)
+				pidBytes[3] = byte(childPID >> 24)
+				if _, err := conn.Write(pidBytes); err != nil {
+					conn.Close()
+					return fmt.Errorf("send PID: %w", err)
+				}
+
+				// Wait for server ACK/NACK
+				ack := make([]byte, 1)
+				if _, err := conn.Read(ack); err != nil {
+					conn.Close()
+					return fmt.Errorf("read ACK: %w", err)
+				}
+				if ack[0] != 1 {
+					conn.Close()
+					return fmt.Errorf("server rejected attach")
+				}
+
+				connHolder = conn
+				return nil
+			},
 			postWait: func() {
+				if connHolder != nil {
+					connHolder.Close()
+				}
 				if isTerminal(os.Stdin.Fd()) {
 					reclaimTerminal()
 				}

--- a/internal/cli/wrap_linux.go
+++ b/internal/cli/wrap_linux.go
@@ -19,6 +19,41 @@ import (
 // returns a postStart function that receives the notify fd from the wrapper and
 // forwards it to the server's Unix listener socket.
 func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, sessID string, agentPath string, agentArgs []string, cfg *clientConfig) (*wrapLaunchConfig, error) {
+	// Ptrace mode: no wrapper binary needed. Connect to the server's socket
+	// for PID handshake via SO_PEERCRED, then launch the shell directly.
+	if wrapResp.PtraceMode {
+		conn, err := net.Dial("unix", wrapResp.NotifySocket)
+		if err != nil {
+			return nil, fmt.Errorf("ptrace handshake: %w", err)
+		}
+
+		env := os.Environ()
+		env = append(env,
+			fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessID),
+			fmt.Sprintf("AGENTSH_SERVER=%s", cfg.serverAddr),
+		)
+
+		return &wrapLaunchConfig{
+			command: agentPath,
+			args:    agentArgs,
+			env:     env,
+			sysProcAttr: func() *syscall.SysProcAttr {
+				attr := &syscall.SysProcAttr{Setpgid: true}
+				if isTerminal(os.Stdin.Fd()) {
+					attr.Foreground = true
+					attr.Ctty = int(os.Stdin.Fd())
+				}
+				return attr
+			}(),
+			keepAlive: conn,
+			postWait: func() {
+				if isTerminal(os.Stdin.Fd()) {
+					reclaimTerminal()
+				}
+			},
+		}, nil
+	}
+
 	// Create a socket pair for the notify fd exchange between the wrapper and this CLI process.
 	// The child end (fds[1]) is inherited by agentsh-unixwrap as ExtraFiles[0] (fd 3).
 	// The parent end (fds[0]) receives the seccomp notify fd from the wrapper.

--- a/internal/cli/wrap_linux.go
+++ b/internal/cli/wrap_linux.go
@@ -27,6 +27,18 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 			return nil, fmt.Errorf("ptrace handshake: %w", err)
 		}
 
+		// Wait for server to attach and ACK. The server reads our PID via
+		// SO_PEERCRED, attaches the tracer, then sends 1 (ACK) or 0 (NACK).
+		ack := make([]byte, 1)
+		if _, err := conn.Read(ack); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("ptrace handshake: read ACK: %w", err)
+		}
+		if ack[0] != 1 {
+			conn.Close()
+			return nil, fmt.Errorf("ptrace handshake: server rejected attach")
+		}
+
 		env := os.Environ()
 		env = append(env,
 			fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessID),

--- a/internal/cli/wrap_linux.go
+++ b/internal/cli/wrap_linux.go
@@ -4,6 +4,7 @@ package cli
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"log/slog"
 	"net"
@@ -55,10 +56,7 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 
 				// Send child PID as 4-byte little-endian
 				pidBytes := make([]byte, 4)
-				pidBytes[0] = byte(childPID)
-				pidBytes[1] = byte(childPID >> 8)
-				pidBytes[2] = byte(childPID >> 16)
-				pidBytes[3] = byte(childPID >> 24)
+				binary.LittleEndian.PutUint32(pidBytes, uint32(childPID))
 				if _, err := conn.Write(pidBytes); err != nil {
 					conn.Close()
 					return fmt.Errorf("send PID: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -352,6 +352,17 @@ type SandboxConfig struct {
 	EnvInject map[string]string `yaml:"env_inject"`
 }
 
+// Validate checks cross-field constraints in the sandbox configuration.
+func (c *SandboxConfig) Validate() error {
+	if c.Ptrace.Enabled && c.Seccomp.Execve.Enabled {
+		return fmt.Errorf("sandbox.ptrace and sandbox.seccomp.execve are mutually exclusive")
+	}
+	if c.Ptrace.Enabled && c.UnixSockets.Enabled != nil && *c.UnixSockets.Enabled {
+		return fmt.Errorf("sandbox.ptrace and sandbox.unix_sockets are mutually exclusive")
+	}
+	return c.Ptrace.Validate()
+}
+
 // SandboxLimitsConfig configures resource limits.
 type SandboxLimitsConfig struct {
 	MaxMemoryMB    int `yaml:"max_memory_mb"`

--- a/internal/config/ptrace_test.go
+++ b/internal/config/ptrace_test.go
@@ -2,6 +2,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -56,6 +57,101 @@ func TestPtraceConfig_YAMLRoundTrip(t *testing.T) {
 	}
 	if !decoded.Enabled {
 		t.Error("enabled not preserved")
+	}
+}
+
+func TestSandboxConfig_Validate_MutualExclusion(t *testing.T) {
+	boolPtr := func(v bool) *bool { return &v }
+
+	tests := []struct {
+		name    string
+		cfg     SandboxConfig
+		wantErr string
+	}{
+		{
+			name: "ptrace alone is valid",
+			cfg: SandboxConfig{
+				Ptrace: func() SandboxPtraceConfig {
+					c := DefaultPtraceConfig()
+					c.Enabled = true
+					return c
+				}(),
+			},
+		},
+		{
+			name: "ptrace + seccomp.execve rejected",
+			cfg: SandboxConfig{
+				Ptrace: func() SandboxPtraceConfig {
+					c := DefaultPtraceConfig()
+					c.Enabled = true
+					return c
+				}(),
+				Seccomp: SandboxSeccompConfig{
+					Execve: ExecveConfig{Enabled: true},
+				},
+			},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name: "ptrace + unix_sockets rejected",
+			cfg: SandboxConfig{
+				Ptrace: func() SandboxPtraceConfig {
+					c := DefaultPtraceConfig()
+					c.Enabled = true
+					return c
+				}(),
+				UnixSockets: SandboxUnixSocketsConfig{Enabled: boolPtr(true)},
+			},
+			wantErr: "mutually exclusive",
+		},
+		{
+			name: "ptrace + unix_sockets nil is valid",
+			cfg: SandboxConfig{
+				Ptrace: func() SandboxPtraceConfig {
+					c := DefaultPtraceConfig()
+					c.Enabled = true
+					return c
+				}(),
+				UnixSockets: SandboxUnixSocketsConfig{Enabled: nil},
+			},
+		},
+		{
+			name: "ptrace + unix_sockets false is valid",
+			cfg: SandboxConfig{
+				Ptrace: func() SandboxPtraceConfig {
+					c := DefaultPtraceConfig()
+					c.Enabled = true
+					return c
+				}(),
+				UnixSockets: SandboxUnixSocketsConfig{Enabled: boolPtr(false)},
+			},
+		},
+		{
+			name: "ptrace disabled + seccomp.execve is valid",
+			cfg: SandboxConfig{
+				Seccomp: SandboxSeccompConfig{
+					Execve: ExecveConfig{Enabled: true},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/internal/ptrace/attach.go
+++ b/internal/ptrace/attach.go
@@ -13,11 +13,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func (t *Tracer) attachProcess(pid int) error {
+func (t *Tracer) attachProcess(pid int, opts attachOpts) error {
 	taskDir := fmt.Sprintf("/proc/%d/task", pid)
 	entries, err := os.ReadDir(taskDir)
 	if err != nil {
-		return t.attachThread(pid)
+		return t.attachThread(pid, opts)
 	}
 
 	var firstErr error
@@ -26,7 +26,7 @@ func (t *Tracer) attachProcess(pid int) error {
 		if err != nil {
 			continue
 		}
-		if err := t.attachThread(tid); err != nil {
+		if err := t.attachThread(tid, opts); err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
@@ -36,7 +36,7 @@ func (t *Tracer) attachProcess(pid int) error {
 	return firstErr
 }
 
-func (t *Tracer) attachThread(tid int) error {
+func (t *Tracer) attachThread(tid int, opts attachOpts) error {
 	err := unix.PtraceSeize(tid)
 	if err != nil {
 		reason := "other"
@@ -103,7 +103,10 @@ func (t *Tracer) attachThread(tid int) error {
 		return fmt.Errorf("read TGID for tid %d: %w", tid, err)
 	}
 
-	if t.prefilterActive {
+	if opts.keepStopped {
+		// Leave tracee stopped for cgroup hook; register in parkedTracees
+		// so ResumePID (via handleResumeRequest) can find and resume it.
+	} else if t.prefilterActive {
 		err = unix.PtraceCont(tid, 0)
 	} else {
 		err = unix.PtraceSyscall(tid, 0)
@@ -125,11 +128,16 @@ func (t *Tracer) attachThread(tid int) error {
 	t.tracees[tid] = &TraceeState{
 		TID:                tid,
 		TGID:               tgid,
+		SessionID:          opts.sessionID,
+		CommandID:          opts.commandID,
 		Attached:           time.Now(),
 		LastNr:             -1,
 		MemFD:              memFD,
 		PendingExecStubFD:  -1,
 		PendingExecSavedFD: -1,
+	}
+	if opts.keepStopped {
+		t.parkedTracees[tid] = struct{}{}
 	}
 	t.metrics.SetTraceeCount(len(t.tracees))
 	t.mu.Unlock()

--- a/internal/ptrace/attach.go
+++ b/internal/ptrace/attach.go
@@ -14,6 +14,10 @@ import (
 )
 
 func (t *Tracer) attachProcess(pid int, opts attachOpts) error {
+	// Seed directly-attached processes as roots in the process tree so
+	// depth-based policy rules work correctly (depth 0 for direct attaches).
+	t.processTree.AddRoot(pid)
+
 	taskDir := fmt.Sprintf("/proc/%d/task", pid)
 	entries, err := os.ReadDir(taskDir)
 	if err != nil {

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -287,15 +287,21 @@ func (t *Tracer) AttachPID(pid int, opts ...AttachOption) error {
 }
 
 // WaitAttached blocks until the process has been attached (or attach failed).
+// Times out after 10 seconds to avoid indefinite blocking when the tracer is down.
 func (t *Tracer) WaitAttached(pid int) error {
 	v, ok := t.attachDone.Load(pid)
 	if !ok {
 		return fmt.Errorf("no pending attach for pid %d", pid)
 	}
 	done := v.(chan error)
-	err := <-done
-	t.attachDone.Delete(pid)
-	return err
+	select {
+	case err := <-done:
+		t.attachDone.Delete(pid)
+		return err
+	case <-time.After(10 * time.Second):
+		t.attachDone.Delete(pid)
+		return fmt.Errorf("attach timed out for pid %d", pid)
+	}
 }
 
 // ResumePID resumes all keepStopped threads of a process via the resume queue.

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -298,9 +298,28 @@ func (t *Tracer) WaitAttached(pid int) error {
 	return err
 }
 
-// ResumePID resumes a keepStopped tracee via the resume queue.
+// ResumePID resumes all keepStopped threads of a process via the resume queue.
+// For freshly-started processes (exec path), only one thread exists.
+// For multi-threaded processes, all threads sharing the TGID are resumed.
 func (t *Tracer) ResumePID(pid int) error {
-	t.resumeQueue <- resumeRequest{TID: pid, Allow: true}
+	t.mu.Lock()
+	var tids []int
+	for tid := range t.parkedTracees {
+		state := t.tracees[tid]
+		if state != nil && (state.TGID == pid || tid == pid) {
+			tids = append(tids, tid)
+		}
+	}
+	t.mu.Unlock()
+
+	if len(tids) == 0 {
+		// Fallback: send resume for the pid directly
+		t.resumeQueue <- resumeRequest{TID: pid, Allow: true}
+		return nil
+	}
+	for _, tid := range tids {
+		t.resumeQueue <- resumeRequest{TID: tid, Allow: true}
+	}
 	return nil
 }
 
@@ -309,6 +328,20 @@ func (t *Tracer) signalAttachDone(pid int, err error) {
 	if v, ok := t.attachDone.Load(pid); ok {
 		v.(chan error) <- err
 	}
+}
+
+// cancelPendingAttachWaiters signals all pending WaitAttached callers with an
+// error so they don't block indefinitely when the tracer shuts down.
+func (t *Tracer) cancelPendingAttachWaiters() {
+	t.attachDone.Range(func(key, value any) bool {
+		ch := value.(chan error)
+		select {
+		case ch <- fmt.Errorf("tracer shutting down"):
+		default:
+		}
+		t.attachDone.Delete(key)
+		return true
+	})
 }
 
 // ParkTracee marks a tracee as parked (awaiting async approval).
@@ -1122,6 +1155,7 @@ func (t *Tracer) handleExecve(ctx context.Context, tid int, regs Regs) {
 func (t *Tracer) Run(ctx context.Context) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
+	defer t.cancelPendingAttachWaiters()
 
 	t.fds = newFdTracker()
 	if t.cfg.TraceNetwork && t.cfg.NetworkHandler != nil {

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -150,6 +150,7 @@ type TraceeState struct {
 	TGID             int
 	ParentPID        int
 	SessionID        string
+	CommandID        string
 	InSyscall        bool
 	LastNr           int
 	Attached         time.Time
@@ -172,6 +173,36 @@ type resumeRequest struct {
 	Errno int
 }
 
+// attachRequest carries a PID and options for the attach queue.
+type attachRequest struct {
+	pid  int
+	opts attachOpts
+}
+
+type attachOpts struct {
+	sessionID   string
+	commandID   string
+	keepStopped bool
+}
+
+// AttachOption configures how a process is attached.
+type AttachOption func(*attachOpts)
+
+// WithSessionID associates a session ID with the attached process.
+func WithSessionID(id string) AttachOption {
+	return func(o *attachOpts) { o.sessionID = id }
+}
+
+// WithCommandID associates a command ID with the attached process.
+func WithCommandID(id string) AttachOption {
+	return func(o *attachOpts) { o.commandID = id }
+}
+
+// WithKeepStopped keeps the tracee stopped after attach (for cgroup hook).
+func WithKeepStopped() AttachOption {
+	return func(o *attachOpts) { o.keepStopped = true }
+}
+
 // Tracer implements a ptrace-based syscall tracer.
 type Tracer struct {
 	cfg             TracerConfig
@@ -179,7 +210,7 @@ type Tracer struct {
 	processTree     *ProcessTree
 	prefilterActive bool
 
-	attachQueue chan int
+	attachQueue chan attachRequest
 	resumeQueue chan resumeRequest
 
 	fds      *fdTracker
@@ -189,6 +220,8 @@ type Tracer struct {
 	tracees       map[int]*TraceeState
 	parkedTracees map[int]struct{}
 	tgidScratch   map[int]*scratchPage
+
+	attachDone sync.Map // pid → chan error
 
 	readyFileWritten  bool
 	readyFileAttempts int
@@ -206,7 +239,7 @@ func NewTracer(cfg TracerConfig) *Tracer {
 		cfg:           cfg,
 		metrics:       metrics,
 		processTree:   NewProcessTree(),
-		attachQueue:   make(chan int, 64),
+		attachQueue:   make(chan attachRequest, 64),
 		resumeQueue:   make(chan resumeRequest, 64),
 		tracees:       make(map[int]*TraceeState),
 		parkedTracees: make(map[int]struct{}),
@@ -242,9 +275,40 @@ func (t *Tracer) writeReadyFile() {
 }
 
 // AttachPID enqueues attachment to a process.
-func (t *Tracer) AttachPID(pid int) error {
-	t.attachQueue <- pid
+func (t *Tracer) AttachPID(pid int, opts ...AttachOption) error {
+	var o attachOpts
+	for _, fn := range opts {
+		fn(&o)
+	}
+	done := make(chan error, 1)
+	t.attachDone.Store(pid, done)
+	t.attachQueue <- attachRequest{pid: pid, opts: o}
 	return nil
+}
+
+// WaitAttached blocks until the process has been attached (or attach failed).
+func (t *Tracer) WaitAttached(pid int) error {
+	v, ok := t.attachDone.Load(pid)
+	if !ok {
+		return fmt.Errorf("no pending attach for pid %d", pid)
+	}
+	done := v.(chan error)
+	err := <-done
+	t.attachDone.Delete(pid)
+	return err
+}
+
+// ResumePID resumes a keepStopped tracee via the resume queue.
+func (t *Tracer) ResumePID(pid int) error {
+	t.resumeQueue <- resumeRequest{TID: pid, Allow: true}
+	return nil
+}
+
+// signalAttachDone signals the WaitAttached channel for a PID, if one exists.
+func (t *Tracer) signalAttachDone(pid int, err error) {
+	if v, ok := t.attachDone.Load(pid); ok {
+		v.(chan error) <- err
+	}
 }
 
 // ParkTracee marks a tracee as parked (awaiting async approval).
@@ -1097,9 +1161,12 @@ func (t *Tracer) Run(ctx context.Context) error {
 					return ctx.Err()
 				case <-t.stopped:
 					return nil
-				case pid := <-t.attachQueue:
-					if err := t.attachProcess(pid); err != nil {
-						slog.Error("attach from queue failed", "pid", pid, "error", err)
+				case req := <-t.attachQueue:
+					if err := t.attachProcess(req.pid, req.opts); err != nil {
+						slog.Error("attach from queue failed", "pid", req.pid, "error", err)
+						t.signalAttachDone(req.pid, err)
+					} else {
+						t.signalAttachDone(req.pid, nil)
 					}
 					continue
 				case req := <-t.resumeQueue:
@@ -1116,9 +1183,12 @@ func (t *Tracer) Run(ctx context.Context) error {
 				return ctx.Err()
 			case <-t.stopped:
 				return nil
-			case pid := <-t.attachQueue:
-				if err := t.attachProcess(pid); err != nil {
-					slog.Error("attach from queue failed", "pid", pid, "error", err)
+			case req := <-t.attachQueue:
+				if err := t.attachProcess(req.pid, req.opts); err != nil {
+					slog.Error("attach from queue failed", "pid", req.pid, "error", err)
+					t.signalAttachDone(req.pid, err)
+				} else {
+					t.signalAttachDone(req.pid, nil)
 				}
 			case req := <-t.resumeQueue:
 				t.handleResumeRequest(req)
@@ -1152,9 +1222,12 @@ func (t *Tracer) drainQueues(ctx context.Context) error {
 			return ctx.Err()
 		case <-t.stopped:
 			return fmt.Errorf("tracer stopped")
-		case pid := <-t.attachQueue:
-			if err := t.attachProcess(pid); err != nil {
-				slog.Error("attach from queue failed", "pid", pid, "error", err)
+		case req := <-t.attachQueue:
+			if err := t.attachProcess(req.pid, req.opts); err != nil {
+				slog.Error("attach from queue failed", "pid", req.pid, "error", err)
+				t.signalAttachDone(req.pid, err)
+			} else {
+				t.signalAttachDone(req.pid, nil)
 			}
 		case req := <-t.resumeQueue:
 			t.handleResumeRequest(req)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -89,6 +89,10 @@ func New(cfg *config.Config) (*Server, error) {
 		return nil, err
 	}
 
+	if err := cfg.Sandbox.Validate(); err != nil {
+		return nil, fmt.Errorf("sandbox config: %w", err)
+	}
+
 	pm := policy.NewManager(
 		cfg.Policies.Dir,
 		cfg.Policies.Default,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -67,6 +67,8 @@ type Server struct {
 
 	threatSyncer *threatfeed.Syncer
 	threatStore  *threatfeed.Store
+
+	app *api.App // for lifecycle management (ptrace tracer shutdown)
 }
 
 func New(cfg *config.Config) (*Server, error) {
@@ -415,6 +417,7 @@ func New(cfg *config.Config) (*Server, error) {
 		reapInterval:   reapInterval,
 		threatSyncer:   threatSyncer,
 		threatStore:    threatStore,
+		app:            app,
 	}
 
 	ln, err := listenHTTP(cfg)
@@ -721,6 +724,9 @@ func (s *Server) Run(ctx context.Context) error {
 			s.grpcServer.GracefulStop()
 		}
 		httpErr := s.httpServer.Shutdown(shutdownCtx)
+		if s.app != nil {
+			s.app.Close()
+		}
 		if syncerDone != nil {
 			<-syncerDone
 		}
@@ -771,6 +777,9 @@ func (s *Server) Close() error {
 	if s.pprofLn != nil {
 		_ = s.pprofLn.Close()
 		s.pprofLn = nil
+	}
+	if s.app != nil {
+		s.app.Close()
 	}
 	if s.sessions != nil {
 		for _, sess := range s.sessions.List() {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -312,6 +312,12 @@ func New(cfg *config.Config) (*Server, error) {
 
 	policyLoader := api.NewDefaultPolicyLoader(cfg.Policies.Dir, enforceApprovals, true)
 	app := api.NewApp(cfg, sessions, store, engine, broker, apiKeyAuth, oidcAuth, approvalsMgr, metricsCollector, policyLoader)
+	appCloser := app.Close // ensure cleanup on error paths below
+	defer func() {
+		if appCloser != nil {
+			appCloser()
+		}
+	}()
 
 	// Initialize package checker (optional).
 	if cfg.PackageChecks.Enabled {
@@ -535,6 +541,7 @@ unixDone:
 		srv.pprofServer = &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
 	}
 
+	appCloser = nil // success — don't close app on defer
 	return srv, nil
 }
 

--- a/pkg/types/sessions.go
+++ b/pkg/types/sessions.go
@@ -129,6 +129,7 @@ type WrapInitRequest struct {
 
 // WrapInitResponse returns the seccomp wrapper configuration to the CLI.
 type WrapInitResponse struct {
+	PtraceMode    bool              `json:"ptrace_mode,omitempty"`
 	WrapperBinary string            `json:"wrapper_binary"`
 	StubBinary    string            `json:"stub_binary,omitempty"`
 	SeccompConfig string            `json:"seccomp_config"`          // JSON-encoded seccomp config


### PR DESCRIPTION
## Summary

- Wire the existing `ptrace.Tracer` into the server so that `sandbox.ptrace.enabled: true` actually traces processes via ptrace instead of seccomp
- Add `SandboxConfig.Validate()` enforcing ptrace/seccomp/unix_sockets mutual exclusion
- Extend ptrace API with `AttachOption`, `WaitAttached`, `ResumePID` for synchronous attach flow
- Add `ptraceHandlerRouter` routing syscall events to session-level policy engines
- Wire tracer into exec, exec/stream, gRPC, PTY, and wrap paths with three-path refactor
- Fail-closed on tracer crash (`ptraceFailed` atomic flag blocks all exec endpoints with 503)
- Wrap path uses explicit child PID handshake (4-byte LE + ACK/NACK) instead of SO_PEERCRED
- Seed process tree roots on attach for correct depth-based policy evaluation
- Update docs: ptrace-support.md (Phase 5), security-modes.md, project-structure.md

## Test plan

- [x] `go test ./...` — all 80 packages pass
- [x] `go build ./...` + `GOOS=windows go build ./...` — cross-compilation clean
- [x] `make smoke` — Docker smoke tests pass
- [x] `make ptrace-test` — 76 Docker ptrace integration tests pass
- [x] 6 rounds of roborev review with all medium+ findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)