### PR TITLE
fix: resolve Wait4 conflict between ptrace tracer and Go runtime

### DIFF
--- a/docs/plans/2026-03-15-wait4-conflict-design.md
+++ b/docs/plans/2026-03-15-wait4-conflict-design.md
@@ -1,7 +1,7 @@
 # Design: Fix Wait4 Conflict Between Ptrace Tracer and Go Runtime
 
 **Date:** 2026-03-15
-**Status:** Draft
+**Status:** Implemented
 
 ---
 

--- a/docs/ptrace-support.md
+++ b/docs/ptrace-support.md
@@ -1830,7 +1830,22 @@ Phase 4 brings ptrace mode to full feature parity with seccomp+FUSE for redirect
 - Fail-closed guards on all execution paths: HTTP exec, streaming exec, gRPC ExecStream, PTY
 - Cross-platform: `app_ptrace_other.go` stubs, `exec_ptrace_other.go` stubs, `wrap_other.go`/`wrap_windows.go` stubs
 
-**Deliverable:** ptrace tracer is fully wired into the server. When `sandbox.ptrace.enabled: true`, all processes spawned via exec, exec/stream, and wrap are traced. Policy enforcement, audit events, and lifecycle management work end-to-end. Known limitation: brief pre-attach execution window between cmd.Start() and PTRACE_SEIZE (Phase 6 pipe barrier).
+**Deliverable:** ptrace tracer is fully wired into the server. When `sandbox.ptrace.enabled: true`, all processes spawned via exec, exec/stream, and wrap are traced. Policy enforcement, audit events, and lifecycle management work end-to-end. Known limitations: (1) brief pre-attach execution window between cmd.Start() and PTRACE_SEIZE, (2) seccomp prefilter not active in server-wired mode (all syscalls trapped, ~10-50x overhead vs baseline).
+
+### Phase 5b: Wait4 Conflict Fix ✓
+
+- **Problem**: tracer's `Wait4(-1)` races with Go's `cmd.Wait()` — both compete to reap child exit events, causing `cmd.Wait()` to hang indefinitely
+- **Fix**: tracer-managed exit notifications replace `cmd.Wait()` for traced processes
+- `ExitStatus` type with `ExitReason` enum (`ExitNormal`, `ExitVanished`, `ExitTracerDown`)
+- `RegisterExitNotify`/`UnregisterExitNotify` with duplicate-rejection and ownership-checked unregister
+- `handleExit` dispatches on last-thread exit with deep-copied `Rusage`
+- Explicit `os.Pipe()` + `WaitGroup` draining (replaces `os/exec` internal pipe sync)
+- `exec.Command` (not `CommandContext`) with context watcher goroutine gated by done channel
+- `resourcesFromRusage` for resource usage from `Wait4` rusage (replaces `cmd.ProcessState`)
+- Exit code mapping: signaled → `-1`, `ExitVanished` → `-1`, `ExitTracerDown` → `127`, timeout → `124`, cancelled → `127`
+- Force-kill child on `ExitTracerDown` before pipe drain; pre-start `ctx.Err()` fail-fast
+
+**Deliverable:** ptrace exec paths complete reliably without `cmd.Wait()` hangs. Exit codes, signals, and resource usage preserved.
 
 ---
 

--- a/docs/security-modes.md
+++ b/docs/security-modes.md
@@ -209,10 +209,10 @@ Ptrace mode exposes Prometheus metrics at the `/metrics` endpoint:
 
 3. **Performance overhead**
    - Each traced syscall requires two context switches (entry + exit) in TRACESYSGOOD mode
-   - Seccomp prefilter (`seccomp_prefilter: true`) reduces overhead by only trapping traced syscalls
+   - Seccomp prefilter (`seccomp_prefilter: true`) reduces overhead by only trapping traced syscalls; note: the prefilter is currently only active in standalone sidecar mode, not in server-wired mode (requires BPF injection, planned)
+   - Without the prefilter (server-wired mode), overhead is ~10-50x due to trapping all syscalls
    - Single-threaded event loop may become a bottleneck with many concurrent tracees
    - Mitigation: Prometheus metrics (`agentsh_ptrace_tracees_active`, `agentsh_ptrace_timeouts_total`) help identify bottlenecks
-   - **Measured overhead is <3% across all workload types** — see [Performance Benchmarks](#performance-benchmarks) below
 
 4. **Attach race window**
    - In the exec path, a brief window exists between `cmd.Start()` and `PTRACE_SEIZE` where the child is untraced

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -137,7 +137,11 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 	if ns := s.NetNSName(); ns != "" {
 		// Run inside the session network namespace (Linux only; requires iproute2).
 		allArgs := append([]string{"netns", "exec", ns, req.Command}, req.Args...)
-		cmd = exec.CommandContext(ctx, "ip", allArgs...)
+		if tracer != nil {
+			cmd = exec.Command("ip", allArgs...)
+		} else {
+			cmd = exec.CommandContext(ctx, "ip", allArgs...)
+		}
 	} else if strings.TrimSpace(req.Argv0) != "" && len(cmd.Args) > 0 {
 		cmd.Args[0] = req.Argv0
 	}
@@ -283,10 +287,14 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 
 			// Context cancellation watcher: kill process group on timeout/cancel
 			// since we're not using CommandContext in ptrace mode.
+			ptraceDone := make(chan struct{})
 			go func() {
-				<-ctx.Done()
-				_ = killProcessGroup(pgid)
-				_ = killProcess(cmd.Process.Pid)
+				select {
+				case <-ctx.Done():
+					_ = killProcessGroup(pgid)
+					_ = killProcess(cmd.Process.Pid)
+				case <-ptraceDone:
+				}
 			}()
 
 			// Tracer-managed wait: block on exit channel instead of cmd.Wait()
@@ -302,6 +310,7 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			stdoutTrunc, stderrTrunc = stdoutW.truncated, stderrW.truncated
 			resources = result.resources
 			cmd.Process.Release()
+			close(ptraceDone) // stop context watcher — normal completion
 
 			if ctx.Err() != nil {
 				_ = killProcessGroup(pgid)

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -240,6 +240,15 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 		cmd.Stderr = stderrW
 	}
 
+	// Fail fast if context is already cancelled (ptrace mode doesn't use CommandContext)
+	if tracer != nil && ctx.Err() != nil {
+		if stdoutPipeR != nil { stdoutPipeR.Close() }
+		if stderrPipeR != nil { stderrPipeR.Close() }
+		if stdoutPipeW != nil { stdoutPipeW.Close() }
+		if stderrPipeW != nil { stderrPipeW.Close() }
+		return 124, nil, nil, 0, 0, false, false, types.ExecResources{}, ctx.Err()
+	}
+
 	if err := cmd.Start(); err != nil {
 		slog.Debug("exec command start failed", "command", req.Command, "error", err)
 		if stdoutPipeR != nil { stdoutPipeR.Close() }
@@ -311,6 +320,11 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			slog.Debug("exec waiting for command (ptrace)", "command", req.Command, "pid", cmd.Process.Pid)
 			result := waitExit()
 			close(ptraceDone) // stop context watcher immediately after exit
+			// On tracer shutdown, force-kill child before draining pipes
+			if result.err != nil {
+				_ = killProcess(cmd.Process.Pid)
+				_ = killProcessGroup(pgid)
+			}
 			waitDuration := time.Since(waitStart)
 			slog.Debug("exec command finished (ptrace)", "command", req.Command, "pid", cmd.Process.Pid, "exit_code", result.exitCode, "wait_duration_ms", waitDuration.Milliseconds())
 			pipeWG.Wait() // drain pipes before reading capture writers

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -124,7 +124,15 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 		return 2, []byte{}, msg, 0, int64(len(msg)), false, false, types.ExecResources{}, nil
 	}
 
-	cmd := exec.CommandContext(ctx, req.Command, req.Args...)
+	// When ptrace is active, use exec.Command (not CommandContext) because we
+	// skip cmd.Wait() — CommandContext starts an internal goroutine that needs
+	// Wait() for cleanup. We handle timeout/cancellation via killProcessGroup.
+	var cmd *exec.Cmd
+	if tracer != nil {
+		cmd = exec.Command(req.Command, req.Args...)
+	} else {
+		cmd = exec.CommandContext(ctx, req.Command, req.Args...)
+	}
 	slog.Debug("exec command created", "command", req.Command, "args", req.Args, "session_id", s.ID)
 	if ns := s.NetNSName(); ns != "" {
 		// Run inside the session network namespace (Linux only; requires iproute2).

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -219,7 +219,7 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 		// This ensures eBPF/cgroups are attached before the process executes.
 		if tracer != nil {
 			// Ptrace tracer active: attach via PTRACE_SEIZE, run hook while stopped, resume
-			resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
+			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
 			if attachErr != nil {
 				_ = killProcess(cmd.Process.Pid)
 				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace attach: %w", attachErr)
@@ -235,6 +235,27 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
 				}
 			}
+
+			// Tracer-managed wait: block on exit channel instead of cmd.Wait()
+			// to avoid Wait4(-1) race between tracer and Go runtime.
+			waitStart := time.Now()
+			slog.Debug("exec waiting for command (ptrace)", "command", req.Command, "pid", cmd.Process.Pid)
+			result := waitExit()
+			waitDuration := time.Since(waitStart)
+			slog.Debug("exec command finished (ptrace)", "command", req.Command, "pid", cmd.Process.Pid, "exit_code", result.exitCode, "wait_duration_ms", waitDuration.Milliseconds())
+			stdout, stderr = stdoutW.Bytes(), stderrW.Bytes()
+			stdoutTotal, stderrTotal = stdoutW.total, stderrW.total
+			stdoutTrunc, stderrTrunc = stdoutW.truncated, stderrW.truncated
+			resources = result.resources
+			cmd.Process.Release()
+
+			if ctx.Err() != nil {
+				_ = killProcessGroup(pgid)
+			}
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return 124, stdout, append(stderr, []byte("command timed out\n")...), stdoutTotal, stderrTotal + int64(len("command timed out\n")), true, true, resources, ctx.Err()
+			}
+			return result.exitCode, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, err
 		} else if hook != nil {
 			// Seccomp stopped-start: process started with PTRACE_TRACEME
 			if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -207,10 +207,9 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 	// For ptrace mode, use explicit pipes so we can drain them independently
 	// of cmd.Wait() (which we skip to avoid the Wait4 race). For non-ptrace,
 	// set writers directly and let cmd.Wait() handle pipe synchronization.
-	var stdoutPipeR, stderrPipeR *os.File
+	var stdoutPipeR, stderrPipeR, stdoutPipeW, stderrPipeW *os.File
 	var pipeWG sync.WaitGroup
 	if tracer != nil {
-		var stdoutPipeW, stderrPipeW *os.File
 		var pipeErr error
 		stdoutPipeR, stdoutPipeW, pipeErr = os.Pipe()
 		if pipeErr != nil {
@@ -224,7 +223,6 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 		}
 		cmd.Stdout = stdoutPipeW
 		cmd.Stderr = stderrPipeW
-		// Write ends are closed after cmd.Start() below
 	} else {
 		cmd.Stdout = stdoutW
 		cmd.Stderr = stderrW
@@ -234,15 +232,16 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 		slog.Debug("exec command start failed", "command", req.Command, "error", err)
 		if stdoutPipeR != nil { stdoutPipeR.Close() }
 		if stderrPipeR != nil { stderrPipeR.Close() }
+		if stdoutPipeW != nil { stdoutPipeW.Close() }
+		if stderrPipeW != nil { stderrPipeW.Close() }
 		return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("start: %w", err)
 	}
 	slog.Debug("exec command started", "command", req.Command, "pid", cmd.Process.Pid)
 
 	// For ptrace mode: close write ends (now owned by child) and start draining
-	if tracer != nil && stdoutPipeR != nil {
-		// Close write ends in parent — child has inherited them
-		if w, ok := cmd.Stdout.(*os.File); ok { w.Close() }
-		if w, ok := cmd.Stderr.(*os.File); ok { w.Close() }
+	if tracer != nil && stdoutPipeW != nil {
+		stdoutPipeW.Close()
+		stderrPipeW.Close()
 		pipeWG.Add(2)
 		go func() { defer pipeWG.Done(); io.Copy(stdoutW, stdoutPipeR); stdoutPipeR.Close() }()
 		go func() { defer pipeWG.Done(); io.Copy(stderrW, stderrPipeR); stderrPipeR.Close() }()

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -285,6 +285,7 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 				close(ptraceDone)
 				_ = killProcessGroup(pgid)
 				pipeWG.Wait()
+				cmd.Process.Release()
 				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace attach: %w", attachErr)
 			}
 			if hook != nil {
@@ -297,6 +298,7 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 					close(ptraceDone)
 					_ = killProcessGroup(pgid)
 					pipeWG.Wait()
+					cmd.Process.Release()
 					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
 				}
 			}

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -343,6 +343,9 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				return 124, stdout, append(stderr, []byte("command timed out\n")...), stdoutTotal, stderrTotal + int64(len("command timed out\n")), true, true, resources, ctx.Err()
 			}
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return 127, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, ctx.Err()
+			}
 			return result.exitCode, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, result.err
 		} else if hook != nil {
 			// Seccomp stopped-start: process started with PTRACE_TRACEME

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -283,6 +283,7 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
 			if attachErr != nil {
 				close(ptraceDone)
+				_ = killProcess(cmd.Process.Pid)
 				_ = killProcessGroup(pgid)
 				pipeWG.Wait()
 				cmd.Process.Release()
@@ -296,6 +297,7 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			if resume != nil {
 				if resumeErr := resume(); resumeErr != nil {
 					close(ptraceDone)
+					_ = killProcess(cmd.Process.Pid)
 					_ = killProcessGroup(pgid)
 					pipeWG.Wait()
 					cmd.Process.Release()

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -267,26 +267,8 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 		// If we started with ptrace (stopped), run the hook BEFORE resuming.
 		// This ensures eBPF/cgroups are attached before the process executes.
 		if tracer != nil {
-			// Ptrace tracer active: attach via PTRACE_SEIZE, run hook while stopped, resume
-			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
-			if attachErr != nil {
-				_ = killProcess(cmd.Process.Pid)
-				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace attach: %w", attachErr)
-			}
-			if hook != nil {
-				if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {
-					defer func() { _ = cleanup() }()
-				}
-			}
-			if resume != nil {
-				if resumeErr := resume(); resumeErr != nil {
-					_ = killProcess(cmd.Process.Pid)
-					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
-				}
-			}
-
-			// Context cancellation watcher: kill process group on timeout/cancel
-			// since we're not using CommandContext in ptrace mode.
+			// Context cancellation watcher: start BEFORE attach so timeout
+			// is enforced even if WaitAttached stalls.
 			ptraceDone := make(chan struct{})
 			go func() {
 				select {
@@ -296,6 +278,28 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 				case <-ptraceDone:
 				}
 			}()
+
+			// Ptrace tracer active: attach via PTRACE_SEIZE, run hook while stopped, resume
+			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
+			if attachErr != nil {
+				close(ptraceDone)
+				_ = killProcessGroup(pgid)
+				pipeWG.Wait()
+				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace attach: %w", attachErr)
+			}
+			if hook != nil {
+				if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {
+					defer func() { _ = cleanup() }()
+				}
+			}
+			if resume != nil {
+				if resumeErr := resume(); resumeErr != nil {
+					close(ptraceDone)
+					_ = killProcessGroup(pgid)
+					pipeWG.Wait()
+					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
+				}
+			}
 
 			// Tracer-managed wait: block on exit channel instead of cmd.Wait()
 			// to avoid Wait4(-1) race between tracer and Go runtime.

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/agentsh/agentsh/internal/config"
@@ -201,14 +203,50 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 
 	stdoutW := newCaptureWriter(defaultMaxOutputBytes, nil)
 	stderrW := newCaptureWriter(defaultMaxOutputBytes, nil)
-	cmd.Stdout = stdoutW
-	cmd.Stderr = stderrW
+
+	// For ptrace mode, use explicit pipes so we can drain them independently
+	// of cmd.Wait() (which we skip to avoid the Wait4 race). For non-ptrace,
+	// set writers directly and let cmd.Wait() handle pipe synchronization.
+	var stdoutPipeR, stderrPipeR *os.File
+	var pipeWG sync.WaitGroup
+	if tracer != nil {
+		var stdoutPipeW, stderrPipeW *os.File
+		var pipeErr error
+		stdoutPipeR, stdoutPipeW, pipeErr = os.Pipe()
+		if pipeErr != nil {
+			return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("stdout pipe: %w", pipeErr)
+		}
+		stderrPipeR, stderrPipeW, pipeErr = os.Pipe()
+		if pipeErr != nil {
+			stdoutPipeR.Close()
+			stdoutPipeW.Close()
+			return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("stderr pipe: %w", pipeErr)
+		}
+		cmd.Stdout = stdoutPipeW
+		cmd.Stderr = stderrPipeW
+		// Write ends are closed after cmd.Start() below
+	} else {
+		cmd.Stdout = stdoutW
+		cmd.Stderr = stderrW
+	}
 
 	if err := cmd.Start(); err != nil {
 		slog.Debug("exec command start failed", "command", req.Command, "error", err)
+		if stdoutPipeR != nil { stdoutPipeR.Close() }
+		if stderrPipeR != nil { stderrPipeR.Close() }
 		return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("start: %w", err)
 	}
 	slog.Debug("exec command started", "command", req.Command, "pid", cmd.Process.Pid)
+
+	// For ptrace mode: close write ends (now owned by child) and start draining
+	if tracer != nil && stdoutPipeR != nil {
+		// Close write ends in parent — child has inherited them
+		if w, ok := cmd.Stdout.(*os.File); ok { w.Close() }
+		if w, ok := cmd.Stderr.(*os.File); ok { w.Close() }
+		pipeWG.Add(2)
+		go func() { defer pipeWG.Done(); io.Copy(stdoutW, stdoutPipeR); stdoutPipeR.Close() }()
+		go func() { defer pipeWG.Done(); io.Copy(stderrW, stderrPipeR); stderrPipeR.Close() }()
+	}
 
 	pgid := 0
 	if cmd.Process != nil {
@@ -243,6 +281,7 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			result := waitExit()
 			waitDuration := time.Since(waitStart)
 			slog.Debug("exec command finished (ptrace)", "command", req.Command, "pid", cmd.Process.Pid, "exit_code", result.exitCode, "wait_duration_ms", waitDuration.Milliseconds())
+			pipeWG.Wait() // drain pipes before reading capture writers
 			stdout, stderr = stdoutW.Bytes(), stderrW.Bytes()
 			stdoutTotal, stderrTotal = stdoutW.total, stderrW.total
 			stdoutTrunc, stderrTrunc = stdoutW.truncated, stderrW.truncated
@@ -255,7 +294,7 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				return 124, stdout, append(stderr, []byte("command timed out\n")...), stdoutTotal, stderrTotal + int64(len("command timed out\n")), true, true, resources, ctx.Err()
 			}
-			return result.exitCode, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, err
+			return result.exitCode, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, result.err
 		} else if hook != nil {
 			// Seccomp stopped-start: process started with PTRACE_TRACEME
 			if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -281,6 +281,14 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 				}
 			}
 
+			// Context cancellation watcher: kill process group on timeout/cancel
+			// since we're not using CommandContext in ptrace mode.
+			go func() {
+				<-ctx.Done()
+				_ = killProcessGroup(pgid)
+				_ = killProcess(cmd.Process.Pid)
+			}()
+
 			// Tracer-managed wait: block on exit channel instead of cmd.Wait()
 			// to avoid Wait4(-1) race between tracer and Go runtime.
 			waitStart := time.Now()

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -246,7 +246,10 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 		if stderrPipeR != nil { stderrPipeR.Close() }
 		if stdoutPipeW != nil { stdoutPipeW.Close() }
 		if stderrPipeW != nil { stderrPipeW.Close() }
-		return 124, nil, nil, 0, 0, false, false, types.ExecResources{}, ctx.Err()
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return 124, nil, nil, 0, 0, false, false, types.ExecResources{}, ctx.Err()
+		}
+		return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, ctx.Err()
 	}
 
 	if err := cmd.Start(); err != nil {

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -255,8 +255,8 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 		stdoutPipeW.Close()
 		stderrPipeW.Close()
 		pipeWG.Add(2)
-		go func() { defer pipeWG.Done(); io.Copy(stdoutW, stdoutPipeR); stdoutPipeR.Close() }()
-		go func() { defer pipeWG.Done(); io.Copy(stderrW, stderrPipeR); stderrPipeR.Close() }()
+		go func() { defer pipeWG.Done(); if _, err := io.Copy(stdoutW, stdoutPipeR); err != nil { slog.Debug("ptrace stdout drain error", "error", err) }; stdoutPipeR.Close() }()
+		go func() { defer pipeWG.Done(); if _, err := io.Copy(stderrW, stderrPipeR); err != nil { slog.Debug("ptrace stderr drain error", "error", err) }; stderrPipeR.Close() }()
 	}
 
 	pgid := 0
@@ -310,6 +310,7 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			waitStart := time.Now()
 			slog.Debug("exec waiting for command (ptrace)", "command", req.Command, "pid", cmd.Process.Pid)
 			result := waitExit()
+			close(ptraceDone) // stop context watcher immediately after exit
 			waitDuration := time.Since(waitStart)
 			slog.Debug("exec command finished (ptrace)", "command", req.Command, "pid", cmd.Process.Pid, "exit_code", result.exitCode, "wait_duration_ms", waitDuration.Milliseconds())
 			pipeWG.Wait() // drain pipes before reading capture writers
@@ -318,7 +319,6 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			stdoutTrunc, stderrTrunc = stdoutW.truncated, stderrW.truncated
 			resources = result.resources
 			cmd.Process.Release()
-			close(ptraceDone) // stop context watcher — normal completion
 
 			if ctx.Err() != nil {
 				_ = killProcessGroup(pgid)

--- a/internal/api/exec_ptrace_linux.go
+++ b/internal/api/exec_ptrace_linux.go
@@ -32,7 +32,10 @@ func ptraceExecAttach(tracer any, pid int, sessionID, commandID string, keepStop
 
 	// Register exit notify BEFORE attach — process can't exit via tracer
 	// until it's attached, so this is race-free.
-	exitCh := tr.RegisterExitNotify(pid)
+	exitCh, regErr := tr.RegisterExitNotify(pid)
+	if regErr != nil {
+		return nil, nil, fmt.Errorf("register exit notify pid %d: %w", pid, regErr)
+	}
 
 	opts := []ptrace.AttachOption{
 		ptrace.WithSessionID(sessionID),

--- a/internal/api/exec_ptrace_linux.go
+++ b/internal/api/exec_ptrace_linux.go
@@ -14,6 +14,7 @@ import (
 type ptraceExecResult struct {
 	exitCode  int
 	resources types.ExecResources
+	err       error // non-nil for ExitTracerDown
 }
 
 // ptraceExecAttach attaches the ptrace tracer to a running process, waits for
@@ -70,6 +71,7 @@ func ptraceExecAttach(tracer any, pid int, sessionID, commandID string, keepStop
 		return ptraceExecResult{
 			exitCode:  code,
 			resources: resourcesFromRusage(status.Rusage),
+			err:       func() error { if status.Reason == ptrace.ExitTracerDown { return fmt.Errorf("tracer shut down") }; return nil }(),
 		}
 	}
 

--- a/internal/api/exec_ptrace_linux.go
+++ b/internal/api/exec_ptrace_linux.go
@@ -43,11 +43,11 @@ func ptraceExecAttach(tracer any, pid int, sessionID, commandID string, keepStop
 	}
 
 	if err := tr.AttachPID(pid, opts...); err != nil {
-		tr.UnregisterExitNotify(pid)
+		tr.UnregisterExitNotify(pid, exitCh)
 		return nil, nil, fmt.Errorf("attach pid %d: %w", pid, err)
 	}
 	if err := tr.WaitAttached(pid); err != nil {
-		tr.UnregisterExitNotify(pid)
+		tr.UnregisterExitNotify(pid, exitCh)
 		return nil, nil, fmt.Errorf("wait attached pid %d: %w", pid, err)
 	}
 

--- a/internal/api/exec_ptrace_linux.go
+++ b/internal/api/exec_ptrace_linux.go
@@ -4,18 +4,34 @@ package api
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/agentsh/agentsh/internal/ptrace"
+	"github.com/agentsh/agentsh/pkg/types"
 )
+
+// ptraceExecResult holds the result of waiting for a traced process to exit.
+type ptraceExecResult struct {
+	exitCode  int
+	resources types.ExecResources
+}
 
 // ptraceExecAttach attaches the ptrace tracer to a running process, waits for
 // the attachment to complete, and optionally keeps the process stopped (for
-// cgroup hook). Returns a resume function that must be called after the hook.
-func ptraceExecAttach(tracer any, pid int, sessionID, commandID string, keepStopped bool) (resume func() error, err error) {
+// cgroup hook). Returns a waitExit function that blocks until the process exits
+// (replacing cmd.Wait()) and a resume function for keepStopped mode.
+//
+// Registration ordering: RegisterExitNotify is called BEFORE AttachPID to
+// guarantee the channel exists before the tracer can dispatch exit events.
+func ptraceExecAttach(tracer any, pid int, sessionID, commandID string, keepStopped bool) (waitExit func() ptraceExecResult, resume func() error, err error) {
 	tr, ok := tracer.(*ptrace.Tracer)
 	if !ok || tr == nil {
-		return nil, fmt.Errorf("ptraceExecAttach: invalid tracer type %T", tracer)
+		return nil, nil, fmt.Errorf("ptraceExecAttach: invalid tracer type %T", tracer)
 	}
+
+	// Register exit notify BEFORE attach — process can't exit via tracer
+	// until it's attached, so this is race-free.
+	exitCh := tr.RegisterExitNotify(pid)
 
 	opts := []ptrace.AttachOption{
 		ptrace.WithSessionID(sessionID),
@@ -26,16 +42,41 @@ func ptraceExecAttach(tracer any, pid int, sessionID, commandID string, keepStop
 	}
 
 	if err := tr.AttachPID(pid, opts...); err != nil {
-		return nil, fmt.Errorf("attach pid %d: %w", pid, err)
+		tr.UnregisterExitNotify(pid)
+		return nil, nil, fmt.Errorf("attach pid %d: %w", pid, err)
 	}
 	if err := tr.WaitAttached(pid); err != nil {
-		return nil, fmt.Errorf("wait attached pid %d: %w", pid, err)
+		tr.UnregisterExitNotify(pid)
+		return nil, nil, fmt.Errorf("wait attached pid %d: %w", pid, err)
+	}
+
+	waitFn := func() ptraceExecResult {
+		status := <-exitCh
+		var code int
+		switch status.Reason {
+		case ptrace.ExitNormal:
+			if status.Signal != 0 {
+				code = -1 // matches ee.ExitCode() for signaled processes
+			} else {
+				code = status.Code
+			}
+		case ptrace.ExitVanished:
+			code = -1 // process disappeared, treat like signaled
+			slog.Warn("traced process vanished (ESRCH)", "pid", pid)
+		case ptrace.ExitTracerDown:
+			code = 127 // infrastructure failure
+			slog.Error("tracer shut down while process was running", "pid", pid)
+		}
+		return ptraceExecResult{
+			exitCode:  code,
+			resources: resourcesFromRusage(status.Rusage),
+		}
 	}
 
 	if keepStopped {
-		return func() error {
+		return waitFn, func() error {
 			return tr.ResumePID(pid)
 		}, nil
 	}
-	return func() error { return nil }, nil
+	return waitFn, func() error { return nil }, nil
 }

--- a/internal/api/exec_ptrace_other.go
+++ b/internal/api/exec_ptrace_other.go
@@ -2,8 +2,17 @@
 
 package api
 
-import "fmt"
+import (
+	"fmt"
 
-func ptraceExecAttach(tracer any, pid int, sessionID, commandID string, keepStopped bool) (resume func() error, err error) {
-	return nil, fmt.Errorf("ptrace not supported on this platform")
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+type ptraceExecResult struct {
+	exitCode  int
+	resources types.ExecResources
+}
+
+func ptraceExecAttach(tracer any, pid int, sessionID, commandID string, keepStopped bool) (waitExit func() ptraceExecResult, resume func() error, err error) {
+	return nil, nil, fmt.Errorf("ptrace not supported on this platform")
 }

--- a/internal/api/exec_ptrace_other.go
+++ b/internal/api/exec_ptrace_other.go
@@ -11,6 +11,7 @@ import (
 type ptraceExecResult struct {
 	exitCode  int
 	resources types.ExecResources
+	err       error
 }
 
 func ptraceExecAttach(tracer any, pid int, sessionID, commandID string, keepStopped bool) (waitExit func() ptraceExecResult, resume func() error, err error) {

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -389,6 +389,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 				close(ptraceDone)
 				_ = killProcessGroup(pgid)
 				pipeWG.Wait()
+				cmd.Process.Release()
 				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace attach: %w", attachErr)
 			}
 			if hook != nil {
@@ -401,6 +402,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 					close(ptraceDone)
 					_ = killProcessGroup(pgid)
 					pipeWG.Wait()
+					cmd.Process.Release()
 					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
 				}
 			}

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -333,7 +333,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 
 		if tracer != nil {
 			// Ptrace tracer active: attach via PTRACE_SEIZE, run hook while stopped, resume
-			resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
+			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
 			if attachErr != nil {
 				_ = killProcess(cmd.Process.Pid)
 				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace attach: %w", attachErr)
@@ -349,6 +349,26 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
 				}
 			}
+
+			// Tracer-managed wait: block on exit channel instead of cmd.Wait()
+			waitStart := time.Now()
+			slog.Debug("exec_stream waiting for command (ptrace)", "command", req.Command, "pid", cmd.Process.Pid)
+			result := waitExit()
+			waitDuration := time.Since(waitStart)
+			slog.Debug("exec_stream command finished (ptrace)", "command", req.Command, "pid", cmd.Process.Pid, "exit_code", result.exitCode, "wait_duration_ms", waitDuration.Milliseconds())
+			stdout, stderr = stdoutW.Bytes(), stderrW.Bytes()
+			stdoutTotal, stderrTotal = stdoutW.total, stderrW.total
+			stdoutTrunc, stderrTrunc = stdoutW.truncated, stderrW.truncated
+			resources = result.resources
+			cmd.Process.Release()
+
+			if ctx.Err() != nil {
+				_ = killProcessGroup(pgid)
+			}
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return 124, stdout, append(stderr, []byte("command timed out\n")...), stdoutTotal, stderrTotal + int64(len("command timed out\n")), true, true, resources, ctx.Err()
+			}
+			return result.exitCode, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, err
 		} else if hook != nil {
 			// Seccomp stopped-start: process started with PTRACE_TRACEME
 			if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -350,6 +350,14 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 		cmd.Stderr = stderrPipeW
 	}
 
+	if tracer != nil && ctx.Err() != nil {
+		if stdoutPipeR != nil { stdoutPipeR.Close() }
+		if stderrPipeR != nil { stderrPipeR.Close() }
+		if stdoutPipeW != nil { stdoutPipeW.Close() }
+		if stderrPipeW != nil { stderrPipeW.Close() }
+		return 124, nil, nil, 0, 0, false, false, types.ExecResources{}, ctx.Err()
+	}
+
 	if err := cmd.Start(); err != nil {
 		if stdoutPipeR != nil { stdoutPipeR.Close() }
 		if stderrPipeR != nil { stderrPipeR.Close() }
@@ -413,7 +421,11 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			waitStart := time.Now()
 			slog.Debug("exec_stream waiting for command (ptrace)", "command", req.Command, "pid", cmd.Process.Pid)
 			result := waitExit()
-			close(ptraceDone) // stop context watcher immediately after exit
+			close(ptraceDone)
+			if result.err != nil {
+				_ = killProcess(cmd.Process.Pid)
+				_ = killProcessGroup(pgid)
+			}
 			waitDuration := time.Since(waitStart)
 			slog.Debug("exec_stream command finished (ptrace)", "command", req.Command, "pid", cmd.Process.Pid, "exit_code", result.exitCode, "wait_duration_ms", waitDuration.Milliseconds())
 			pipeWG.Wait() // drain pipes before reading capture writers

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -387,6 +387,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
 			if attachErr != nil {
 				close(ptraceDone)
+				_ = killProcess(cmd.Process.Pid)
 				_ = killProcessGroup(pgid)
 				pipeWG.Wait()
 				cmd.Process.Release()
@@ -400,6 +401,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			if resume != nil {
 				if resumeErr := resume(); resumeErr != nil {
 					close(ptraceDone)
+					_ = killProcess(cmd.Process.Pid)
 					_ = killProcessGroup(pgid)
 					pipeWG.Wait()
 					cmd.Process.Release()

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -323,10 +323,9 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 	cmd.Stderr = stderrW
 
 	// For ptrace mode, use explicit pipes for drain synchronization
-	var stdoutPipeR, stderrPipeR *os.File
+	var stdoutPipeR, stderrPipeR, stdoutPipeW, stderrPipeW *os.File
 	var pipeWG sync.WaitGroup
 	if tracer != nil {
-		var stdoutPipeW, stderrPipeW *os.File
 		var pipeErr error
 		stdoutPipeR, stdoutPipeW, pipeErr = os.Pipe()
 		if pipeErr != nil {
@@ -345,13 +344,15 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 	if err := cmd.Start(); err != nil {
 		if stdoutPipeR != nil { stdoutPipeR.Close() }
 		if stderrPipeR != nil { stderrPipeR.Close() }
+		if stdoutPipeW != nil { stdoutPipeW.Close() }
+		if stderrPipeW != nil { stderrPipeW.Close() }
 		return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("start: %w", err)
 	}
 
 	// For ptrace mode: close write ends and start draining
-	if tracer != nil && stdoutPipeR != nil {
-		if w, ok := cmd.Stdout.(*os.File); ok { w.Close() }
-		if w, ok := cmd.Stderr.(*os.File); ok { w.Close() }
+	if tracer != nil && stdoutPipeW != nil {
+		stdoutPipeW.Close()
+		stderrPipeW.Close()
 		pipeWG.Add(2)
 		go func() { defer pipeWG.Done(); io.Copy(stdoutW, stdoutPipeR); stdoutPipeR.Close() }()
 		go func() { defer pipeWG.Done(); io.Copy(stderrW, stderrPipeR); stderrPipeR.Close() }()

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -266,10 +266,19 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 		return 2, []byte{}, msg, 0, int64(len(msg)), false, false, types.ExecResources{}, nil
 	}
 
-	cmd := exec.CommandContext(ctx, req.Command, req.Args...)
+	var cmd *exec.Cmd
+	if tracer != nil {
+		cmd = exec.Command(req.Command, req.Args...)
+	} else {
+		cmd = exec.CommandContext(ctx, req.Command, req.Args...)
+	}
 	if ns := s.NetNSName(); ns != "" {
 		allArgs := append([]string{"netns", "exec", ns, req.Command}, req.Args...)
-		cmd = exec.CommandContext(ctx, "ip", allArgs...)
+		if tracer != nil {
+			cmd = exec.Command("ip", allArgs...)
+		} else {
+			cmd = exec.CommandContext(ctx, "ip", allArgs...)
+		}
 	} else if strings.TrimSpace(req.Argv0) != "" && len(cmd.Args) > 0 {
 		cmd.Args[0] = req.Argv0
 	}

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -363,8 +363,8 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 		stdoutPipeW.Close()
 		stderrPipeW.Close()
 		pipeWG.Add(2)
-		go func() { defer pipeWG.Done(); io.Copy(stdoutW, stdoutPipeR); stdoutPipeR.Close() }()
-		go func() { defer pipeWG.Done(); io.Copy(stderrW, stderrPipeR); stderrPipeR.Close() }()
+		go func() { defer pipeWG.Done(); if _, err := io.Copy(stdoutW, stdoutPipeR); err != nil { slog.Debug("ptrace stdout drain error", "error", err) }; stdoutPipeR.Close() }()
+		go func() { defer pipeWG.Done(); if _, err := io.Copy(stderrW, stderrPipeR); err != nil { slog.Debug("ptrace stderr drain error", "error", err) }; stderrPipeR.Close() }()
 	}
 
 	pgid := 0
@@ -413,6 +413,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			waitStart := time.Now()
 			slog.Debug("exec_stream waiting for command (ptrace)", "command", req.Command, "pid", cmd.Process.Pid)
 			result := waitExit()
+			close(ptraceDone) // stop context watcher immediately after exit
 			waitDuration := time.Since(waitStart)
 			slog.Debug("exec_stream command finished (ptrace)", "command", req.Command, "pid", cmd.Process.Pid, "exit_code", result.exitCode, "wait_duration_ms", waitDuration.Milliseconds())
 			pipeWG.Wait() // drain pipes before reading capture writers
@@ -421,7 +422,6 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			stdoutTrunc, stderrTrunc = stdoutW.truncated, stderrW.truncated
 			resources = result.resources
 			cmd.Process.Release()
-			close(ptraceDone)
 
 			if ctx.Err() != nil {
 				_ = killProcessGroup(pgid)

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -391,6 +391,13 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 				}
 			}
 
+			// Context cancellation watcher
+			go func() {
+				<-ctx.Done()
+				_ = killProcessGroup(pgid)
+				_ = killProcess(cmd.Process.Pid)
+			}()
+
 			// Tracer-managed wait: block on exit channel instead of cmd.Wait()
 			waitStart := time.Now()
 			slog.Debug("exec_stream waiting for command (ptrace)", "command", req.Command, "pid", cmd.Process.Pid)

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -444,6 +444,9 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				return 124, stdout, append(stderr, []byte("command timed out\n")...), stdoutTotal, stderrTotal + int64(len("command timed out\n")), true, true, resources, ctx.Err()
 			}
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return 127, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, ctx.Err()
+			}
 			return result.exitCode, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, result.err
 		} else if hook != nil {
 			// Seccomp stopped-start: process started with PTRACE_TRACEME

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -322,8 +322,39 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 	cmd.Stdout = stdoutW
 	cmd.Stderr = stderrW
 
+	// For ptrace mode, use explicit pipes for drain synchronization
+	var stdoutPipeR, stderrPipeR *os.File
+	var pipeWG sync.WaitGroup
+	if tracer != nil {
+		var stdoutPipeW, stderrPipeW *os.File
+		var pipeErr error
+		stdoutPipeR, stdoutPipeW, pipeErr = os.Pipe()
+		if pipeErr != nil {
+			return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("stdout pipe: %w", pipeErr)
+		}
+		stderrPipeR, stderrPipeW, pipeErr = os.Pipe()
+		if pipeErr != nil {
+			stdoutPipeR.Close()
+			stdoutPipeW.Close()
+			return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("stderr pipe: %w", pipeErr)
+		}
+		cmd.Stdout = stdoutPipeW
+		cmd.Stderr = stderrPipeW
+	}
+
 	if err := cmd.Start(); err != nil {
+		if stdoutPipeR != nil { stdoutPipeR.Close() }
+		if stderrPipeR != nil { stderrPipeR.Close() }
 		return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("start: %w", err)
+	}
+
+	// For ptrace mode: close write ends and start draining
+	if tracer != nil && stdoutPipeR != nil {
+		if w, ok := cmd.Stdout.(*os.File); ok { w.Close() }
+		if w, ok := cmd.Stderr.(*os.File); ok { w.Close() }
+		pipeWG.Add(2)
+		go func() { defer pipeWG.Done(); io.Copy(stdoutW, stdoutPipeR); stdoutPipeR.Close() }()
+		go func() { defer pipeWG.Done(); io.Copy(stderrW, stderrPipeR); stderrPipeR.Close() }()
 	}
 
 	pgid := 0
@@ -356,6 +387,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			result := waitExit()
 			waitDuration := time.Since(waitStart)
 			slog.Debug("exec_stream command finished (ptrace)", "command", req.Command, "pid", cmd.Process.Pid, "exit_code", result.exitCode, "wait_duration_ms", waitDuration.Milliseconds())
+			pipeWG.Wait() // drain pipes before reading capture writers
 			stdout, stderr = stdoutW.Bytes(), stderrW.Bytes()
 			stdoutTotal, stderrTotal = stdoutW.total, stderrW.total
 			stdoutTrunc, stderrTrunc = stdoutW.truncated, stderrW.truncated
@@ -368,7 +400,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				return 124, stdout, append(stderr, []byte("command timed out\n")...), stdoutTotal, stderrTotal + int64(len("command timed out\n")), true, true, resources, ctx.Err()
 			}
-			return result.exitCode, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, err
+			return result.exitCode, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, result.err
 		} else if hook != nil {
 			// Seccomp stopped-start: process started with PTRACE_TRACEME
 			if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -392,10 +392,14 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			}
 
 			// Context cancellation watcher
+			ptraceDone := make(chan struct{})
 			go func() {
-				<-ctx.Done()
-				_ = killProcessGroup(pgid)
-				_ = killProcess(cmd.Process.Pid)
+				select {
+				case <-ctx.Done():
+					_ = killProcessGroup(pgid)
+					_ = killProcess(cmd.Process.Pid)
+				case <-ptraceDone:
+				}
 			}()
 
 			// Tracer-managed wait: block on exit channel instead of cmd.Wait()
@@ -410,6 +414,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			stdoutTrunc, stderrTrunc = stdoutW.truncated, stderrW.truncated
 			resources = result.resources
 			cmd.Process.Release()
+			close(ptraceDone)
 
 			if ctx.Err() != nil {
 				_ = killProcessGroup(pgid)

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -373,25 +373,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 		pgid = getProcessGroupID(cmd.Process.Pid)
 
 		if tracer != nil {
-			// Ptrace tracer active: attach via PTRACE_SEIZE, run hook while stopped, resume
-			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
-			if attachErr != nil {
-				_ = killProcess(cmd.Process.Pid)
-				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace attach: %w", attachErr)
-			}
-			if hook != nil {
-				if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {
-					defer func() { _ = cleanup() }()
-				}
-			}
-			if resume != nil {
-				if resumeErr := resume(); resumeErr != nil {
-					_ = killProcess(cmd.Process.Pid)
-					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
-				}
-			}
-
-			// Context cancellation watcher
+			// Context cancellation watcher: start BEFORE attach
 			ptraceDone := make(chan struct{})
 			go func() {
 				select {
@@ -401,6 +383,27 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 				case <-ptraceDone:
 				}
 			}()
+
+			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
+			if attachErr != nil {
+				close(ptraceDone)
+				_ = killProcessGroup(pgid)
+				pipeWG.Wait()
+				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace attach: %w", attachErr)
+			}
+			if hook != nil {
+				if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {
+					defer func() { _ = cleanup() }()
+				}
+			}
+			if resume != nil {
+				if resumeErr := resume(); resumeErr != nil {
+					close(ptraceDone)
+					_ = killProcessGroup(pgid)
+					pipeWG.Wait()
+					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
+				}
+			}
 
 			// Tracer-managed wait: block on exit channel instead of cmd.Wait()
 			waitStart := time.Now()

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -355,7 +355,10 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 		if stderrPipeR != nil { stderrPipeR.Close() }
 		if stdoutPipeW != nil { stdoutPipeW.Close() }
 		if stderrPipeW != nil { stderrPipeW.Close() }
-		return 124, nil, nil, 0, 0, false, false, types.ExecResources{}, ctx.Err()
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return 124, nil, nil, 0, 0, false, false, types.ExecResources{}, ctx.Err()
+		}
+		return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, ctx.Err()
 	}
 
 	if err := cmd.Start(); err != nil {

--- a/internal/api/process_unix.go
+++ b/internal/api/process_unix.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/agentsh/agentsh/pkg/types"
+	"golang.org/x/sys/unix"
 )
 
 // killProcess sends SIGTERM then SIGKILL to a process and its process group.
@@ -64,6 +65,17 @@ func resourcesFromProcessState(ps *os.ProcessState) types.ExecResources {
 	}
 	ru, ok := ps.SysUsage().(*syscall.Rusage)
 	if !ok || ru == nil {
+		return types.ExecResources{}
+	}
+	return types.ExecResources{
+		CPUUserMs:    int64(ru.Utime.Sec)*1000 + int64(ru.Utime.Usec)/1000,
+		CPUSystemMs:  int64(ru.Stime.Sec)*1000 + int64(ru.Stime.Usec)/1000,
+		MemoryPeakKB: int64(ru.Maxrss),
+	}
+}
+
+func resourcesFromRusage(ru *unix.Rusage) types.ExecResources {
+	if ru == nil {
 		return types.ExecResources{}
 	}
 	return types.ExecResources{

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -217,7 +217,7 @@ func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socket
 	// Clear read deadline for the keepalive phase
 	conn.SetDeadline(time.Time{})
 
-	_, attachErr := ptraceExecAttach(a.ptraceTracer, pid, sessionID, "", false)
+	_, _, attachErr := ptraceExecAttach(a.ptraceTracer, pid, sessionID, "", false)
 	if attachErr != nil {
 		conn.Write([]byte{0}) // NACK
 		conn.Close()

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -207,7 +207,7 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 		if !status.Stopped() {
 			if status.Exited() || status.Signaled() {
 				// Clean up tracee bookkeeping before returning.
-				t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
+				t.handleExit(tid, status, nil, ExitNormal)
 				return fmt.Errorf("tracee %d exited during injection", tid)
 			}
 			continue

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -207,7 +207,7 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 		if !status.Stopped() {
 			if status.Exited() || status.Signaled() {
 				// Clean up tracee bookkeeping before returning.
-				t.handleExit(tid)
+				t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
 				return fmt.Errorf("tracee %d exited during injection", tid)
 			}
 			continue

--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -200,7 +200,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	// PendingExecStubFD cleanup runs on exec failure.
 	if err := unix.PtraceSyscall(tid, 0); err != nil {
 		if errors.Is(err, unix.ESRCH) {
-			t.handleExit(tid)
+			t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
 		} else {
 			slog.Warn("redirectExec: PtraceSyscall failed, cleaning up stub fd",
 				"tid", tid, "error", err)

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -1070,10 +1070,17 @@ func (t *Tracer) handleExit(tid int, status unix.WaitStatus, rusage *unix.Rusage
 	if state != nil && lastThread {
 		if v, ok := t.exitNotify.LoadAndDelete(tgid); ok {
 			ch := v.(chan ExitStatus)
+			// Deep-copy rusage to avoid aliasing the loop-local variable
+			// in Run() which gets reused on subsequent Wait4 iterations.
+			var ruCopy *unix.Rusage
+			if rusage != nil {
+				ru := *rusage
+				ruCopy = &ru
+			}
 			es := ExitStatus{
 				PID:    tgid,
 				Reason: reason,
-				Rusage: rusage,
+				Rusage: ruCopy,
 			}
 			if status.Exited() {
 				es.Code = status.ExitStatus()

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -371,15 +371,14 @@ func (t *Tracer) cancelPendingAttachWaiters() {
 
 // RegisterExitNotify registers an exit notification channel for a PID (TGID).
 // Must be called before AttachPID to ensure no race with fast-exit processes.
-// Returns a channel unique to this registration. If a channel already exists
-// for this PID (should not happen in normal operation), it is returned instead.
-func (t *Tracer) RegisterExitNotify(pid int) <-chan ExitStatus {
+// Returns an error if a channel is already registered for this PID.
+func (t *Tracer) RegisterExitNotify(pid int) (<-chan ExitStatus, error) {
 	ch := make(chan ExitStatus, 1)
-	actual, loaded := t.exitNotify.LoadOrStore(pid, ch)
+	_, loaded := t.exitNotify.LoadOrStore(pid, ch)
 	if loaded {
-		slog.Warn("ptrace: exit notify already registered for PID", "pid", pid)
+		return nil, fmt.Errorf("exit notify already registered for pid %d", pid)
 	}
-	return actual.(chan ExitStatus)
+	return ch, nil
 }
 
 // UnregisterExitNotify removes a pending exit notification only if it matches

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -173,6 +173,24 @@ type resumeRequest struct {
 	Errno int
 }
 
+// ExitReason describes why a process exited.
+type ExitReason int
+
+const (
+	ExitNormal    ExitReason = iota // process exited or was signaled (Code/Signal valid)
+	ExitVanished                    // ESRCH — process disappeared (ptrace call failed)
+	ExitTracerDown                  // tracer shut down while process was running
+)
+
+// ExitStatus carries process exit information for tracer-managed wait.
+type ExitStatus struct {
+	PID    int
+	Code   int
+	Signal int
+	Reason ExitReason
+	Rusage *unix.Rusage
+}
+
 // attachRequest carries a PID and options for the attach queue.
 type attachRequest struct {
 	pid  int
@@ -222,6 +240,7 @@ type Tracer struct {
 	tgidScratch   map[int]*scratchPage
 
 	attachDone sync.Map // pid → chan error
+	exitNotify sync.Map // pid → chan ExitStatus
 
 	readyFileWritten  bool
 	readyFileAttempts int
@@ -350,6 +369,37 @@ func (t *Tracer) cancelPendingAttachWaiters() {
 	})
 }
 
+// RegisterExitNotify registers an exit notification channel for a PID (TGID).
+// Must be called before AttachPID to ensure no race with fast-exit processes.
+// Returns existing channel if already registered (idempotent).
+func (t *Tracer) RegisterExitNotify(pid int) <-chan ExitStatus {
+	if v, ok := t.exitNotify.Load(pid); ok {
+		return v.(chan ExitStatus)
+	}
+	ch := make(chan ExitStatus, 1)
+	actual, _ := t.exitNotify.LoadOrStore(pid, ch)
+	return actual.(chan ExitStatus)
+}
+
+// UnregisterExitNotify removes a pending exit notification (cleanup on failure).
+func (t *Tracer) UnregisterExitNotify(pid int) {
+	t.exitNotify.Delete(pid)
+}
+
+// cancelPendingExitWaiters signals all pending exit notification channels
+// so they don't block indefinitely when the tracer shuts down.
+func (t *Tracer) cancelPendingExitWaiters() {
+	t.exitNotify.Range(func(key, value any) bool {
+		ch := value.(chan ExitStatus)
+		select {
+		case ch <- ExitStatus{Reason: ExitTracerDown}:
+		default:
+		}
+		t.exitNotify.Delete(key)
+		return true
+	})
+}
+
 // ParkTracee marks a tracee as parked (awaiting async approval).
 func (t *Tracer) ParkTracee(tid int) {
 	t.mu.Lock()
@@ -410,7 +460,7 @@ func (t *Tracer) allowSyscall(tid int) {
 		err = unix.PtraceSyscall(tid, 0)
 	}
 	if err != nil && errors.Is(err, unix.ESRCH) {
-		t.handleExit(tid)
+		t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
 	}
 }
 
@@ -419,7 +469,7 @@ func (t *Tracer) denySyscall(tid int, errno int) error {
 	regs, err := t.getRegs(tid)
 	if err != nil {
 		if errors.Is(err, unix.ESRCH) {
-			t.handleExit(tid)
+			t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
 			return nil
 		}
 		return err
@@ -427,7 +477,7 @@ func (t *Tracer) denySyscall(tid int, errno int) error {
 	regs.SetSyscallNr(-1)
 	if err := t.setRegs(tid, regs); err != nil {
 		if errors.Is(err, unix.ESRCH) {
-			t.handleExit(tid)
+			t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
 			return nil
 		}
 		t.mu.Lock()
@@ -450,7 +500,7 @@ func (t *Tracer) denySyscall(tid int, errno int) error {
 
 	if err := unix.PtraceSyscall(tid, 0); err != nil {
 		if errors.Is(err, unix.ESRCH) {
-			t.handleExit(tid)
+			t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
 			return nil
 		}
 		return err
@@ -521,10 +571,10 @@ func (t *Tracer) hasPendingSyscallExit(tid int) bool {
 }
 
 // handleStop dispatches a tracee stop event.
-func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus) {
+func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus, rusage *unix.Rusage) {
 	switch {
 	case status.Exited() || status.Signaled():
-		t.handleExit(tid)
+		t.handleExit(tid, status, rusage, ExitNormal)
 
 	case status.Stopped():
 		sig := status.StopSignal()
@@ -991,7 +1041,7 @@ func (t *Tracer) handleExecEvent(tid int) {
 	t.invalidateScratchPage(tgid)
 }
 
-func (t *Tracer) handleExit(tid int) {
+func (t *Tracer) handleExit(tid int, status unix.WaitStatus, rusage *unix.Rusage, reason ExitReason) {
 	t.mu.Lock()
 	state := t.tracees[tid]
 	var tgid int
@@ -1018,6 +1068,20 @@ func (t *Tracer) handleExit(tid int) {
 	t.mu.Unlock()
 
 	if state != nil && lastThread {
+		if v, ok := t.exitNotify.LoadAndDelete(tgid); ok {
+			ch := v.(chan ExitStatus)
+			es := ExitStatus{
+				PID:    tgid,
+				Reason: reason,
+				Rusage: rusage,
+			}
+			if status.Exited() {
+				es.Code = status.ExitStatus()
+			} else if status.Signaled() {
+				es.Signal = int(status.Signal())
+			}
+			ch <- es
+		}
 		if t.fds != nil {
 			t.fds.clearTGID(tgid)
 		}
@@ -1162,6 +1226,7 @@ func (t *Tracer) Run(ctx context.Context) error {
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()
 	defer t.cancelPendingAttachWaiters()
+	defer t.cancelPendingExitWaiters()
 
 	t.fds = newFdTracker()
 	if t.cfg.TraceNetwork && t.cfg.NetworkHandler != nil {
@@ -1189,7 +1254,8 @@ func (t *Tracer) Run(ctx context.Context) error {
 		}
 
 		var status unix.WaitStatus
-		tid, err := unix.Wait4(-1, &status, unix.WALL|unix.WNOHANG, nil)
+		var rusage unix.Rusage
+		tid, err := unix.Wait4(-1, &status, unix.WALL|unix.WNOHANG, &rusage)
 
 		if err != nil {
 			if err == unix.EINTR {
@@ -1237,7 +1303,7 @@ func (t *Tracer) Run(ctx context.Context) error {
 			continue
 		}
 
-		t.handleStop(ctx, tid, status)
+		t.handleStop(ctx, tid, status, &rusage)
 	}
 }
 
@@ -1319,7 +1385,7 @@ func (t *Tracer) sweepParkedTimeouts() {
 			if err := unix.Tgkill(tgid, tid, unix.SIGKILL); err != nil {
 				if errors.Is(err, unix.ESRCH) {
 					// Tracee already gone.
-					t.handleExit(tid)
+					t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
 					resolved = true
 				} else {
 					slog.Error("ptrace: kill after timeout also failed, will retry",

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -371,19 +371,21 @@ func (t *Tracer) cancelPendingAttachWaiters() {
 
 // RegisterExitNotify registers an exit notification channel for a PID (TGID).
 // Must be called before AttachPID to ensure no race with fast-exit processes.
-// Returns existing channel if already registered (idempotent).
+// Returns a channel unique to this registration.
 func (t *Tracer) RegisterExitNotify(pid int) <-chan ExitStatus {
-	if v, ok := t.exitNotify.Load(pid); ok {
-		return v.(chan ExitStatus)
-	}
 	ch := make(chan ExitStatus, 1)
-	actual, _ := t.exitNotify.LoadOrStore(pid, ch)
-	return actual.(chan ExitStatus)
+	t.exitNotify.Store(pid, ch)
+	return ch
 }
 
-// UnregisterExitNotify removes a pending exit notification (cleanup on failure).
-func (t *Tracer) UnregisterExitNotify(pid int) {
-	t.exitNotify.Delete(pid)
+// UnregisterExitNotify removes a pending exit notification only if it matches
+// the given channel (ownership check). Safe for concurrent flows on different PIDs.
+func (t *Tracer) UnregisterExitNotify(pid int, ch <-chan ExitStatus) {
+	if v, ok := t.exitNotify.Load(pid); ok {
+		if v.(chan ExitStatus) == ch {
+			t.exitNotify.Delete(pid)
+		}
+	}
 }
 
 // cancelPendingExitWaiters signals all pending exit notification channels

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -371,11 +371,15 @@ func (t *Tracer) cancelPendingAttachWaiters() {
 
 // RegisterExitNotify registers an exit notification channel for a PID (TGID).
 // Must be called before AttachPID to ensure no race with fast-exit processes.
-// Returns a channel unique to this registration.
+// Returns a channel unique to this registration. If a channel already exists
+// for this PID (should not happen in normal operation), it is returned instead.
 func (t *Tracer) RegisterExitNotify(pid int) <-chan ExitStatus {
 	ch := make(chan ExitStatus, 1)
-	t.exitNotify.Store(pid, ch)
-	return ch
+	actual, loaded := t.exitNotify.LoadOrStore(pid, ch)
+	if loaded {
+		slog.Warn("ptrace: exit notify already registered for PID", "pid", pid)
+	}
+	return actual.(chan ExitStatus)
 }
 
 // UnregisterExitNotify removes a pending exit notification only if it matches


### PR DESCRIPTION
## Summary

Fixes the `Wait4(-1)` race between the ptrace tracer's event loop and Go's `cmd.Wait()` that caused ptrace exec to hang indefinitely when the tracer was wired into the server process.

**Root cause**: The tracer's `Wait4(-1, WNOHANG)` in `Run()` competes with Go's internal `wait4` used by `cmd.Wait()`. When the tracer reaps a child's exit status, `cmd.Wait()` never sees it and hangs forever.

**Fix**: Replace `cmd.Wait()` with tracer-managed exit notifications for traced processes.

### Changes

- Add `ExitStatus` type with `ExitReason` enum (`ExitNormal`, `ExitVanished`, `ExitTracerDown`)
- Add `RegisterExitNotify`/`UnregisterExitNotify` on Tracer with duplicate-rejection and ownership-checked unregister
- `handleExit` dispatches exit notification on last-thread exit with deep-copied `Rusage`
- Exec paths use explicit `os.Pipe()` for stdout/stderr with `WaitGroup`-synchronized draining
- `exec.Command` (not `CommandContext`) with context watcher goroutine gated by done channel
- Force-kill child on `ExitTracerDown` before pipe drain
- Pre-start `ctx.Err()` check; post-start `Canceled` → 127, `DeadlineExceeded` → 124
- `cmd.Process.Release()` on all error paths
- `resourcesFromRusage` for resource usage reporting via `Wait4` rusage

### Known limitation

Ptrace overhead is ~10-50x without seccomp prefilter (every syscall is trapped). The prefilter requires BPF injection into child processes after attach — tracked as a separate optimization.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go build ./...` + `GOOS=windows go build ./...` — cross-compilation clean
- [x] `make ptrace-test` — 76 Docker ptrace integration tests pass
- [x] Docker sanity test: ptrace exec completes without hanging (30 rapid execs, file I/O, nested shells, policy deny)
- [x] 15 rounds of roborev review — no high severity findings remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)