### PR TITLE
feat: seccomp prefilter injection for server-wired ptrace mode

### DIFF
--- a/docs/plans/2026-03-04-execve-hardening-design.md
+++ b/docs/plans/2026-03-04-execve-hardening-design.md
@@ -1,0 +1,215 @@
+# Execve Hardening: Path Canonicalization & Transparent Command Unwrapping
+
+**Date:** 2026-03-04
+**Status:** Design
+**Motivation:** Ona's research on Claude Code sandbox bypasses exposed two attack classes that apply to any string-based command policy: path manipulation (e.g., `/proc/self/root/usr/bin/npx`) and dynamic linker/interpreter bypasses (e.g., `ld-linux ... /usr/bin/wget`). This design hardens AgentSH's execve pipeline against both.
+
+---
+
+## Improvement 1: Path Canonicalization
+
+### Location
+
+`handleExecveNotification()` in `internal/netmonitor/unix/handler.go`, after `resolveExecveatPath()` and before building `ExecveContext`.
+
+### Approach
+
+Call `filepath.EvalSymlinks(filename)` on the resolved filename:
+
+- If it succeeds, use the canonical path going forward.
+- If it fails (file doesn't exist, permission error, etc.), keep the raw filename — default-deny handles unrecognized commands.
+- Store the raw filename in a new `ExecveContext.RawFilename` field for audit.
+
+### Pipeline
+
+```
+filename (raw from tracee memory)
+    → resolveExecveatPath()       [existing, handles execveat special cases]
+    → filepath.EvalSymlinks()     [NEW]
+    → ExecveContext.Filename
+```
+
+### Attack Vectors Addressed
+
+| Attack | Resolution |
+|--------|-----------|
+| `/proc/self/root/usr/bin/npx` | Resolves to `/usr/bin/npx` → matches basename rule `npx` |
+| `/tmp/link-to-wget` (symlink) | Resolves to `/usr/bin/wget` → matches |
+| `../../usr/bin/curl` | Cleans and resolves to `/usr/bin/curl` |
+
+### Not Addressed
+
+Binary copies (`cp /usr/bin/wget /tmp/myfetcher`) — different inode, no symlink. Still handled by network/file enforcement as backstop.
+
+---
+
+## Improvement 2: Transparent Command Unwrapping
+
+### Concept
+
+"Transparent commands" are wrappers/interpreters/loaders that don't define the action — the real command is in their arguments. When the execve target is a transparent command, AgentSH unwraps the payload and evaluates it against command policy.
+
+### File Structure
+
+```
+internal/netmonitor/transparent_commands.go          — common set + unwrap logic
+internal/netmonitor/transparent_commands_linux.go     — linux-specific (build tag)
+internal/netmonitor/transparent_commands_darwin.go    — darwin-specific (build tag)
+internal/netmonitor/transparent_commands_windows.go   — windows-specific (build tag)
+```
+
+### Platform-Specific Defaults
+
+**Common (Linux + macOS):**
+```
+env, nice, nohup, sudo, time, xargs
+```
+
+**Linux-only:**
+```
+ld-linux-x86-64.so.2, ld-linux-aarch64.so.1, ld-linux.so.2,
+busybox, doas, strace, ltrace
+```
+Plus prefix match for `ld-linux*` variants.
+
+**macOS-only:**
+```
+(empty for now)
+```
+
+**Windows-only:**
+```
+cmd.exe, powershell.exe, pwsh.exe, wsl.exe
+```
+
+### Initialization
+
+```go
+func init() {
+    transparentCommands = make(map[string]bool)
+    for k := range commonTransparentCommands {
+        transparentCommands[k] = true
+    }
+    for k := range platformTransparentCommands {
+        transparentCommands[k] = true
+    }
+}
+```
+
+### Unwrap Algorithm
+
+```
+func unwrapTransparentCommand(filename string, argv []string) (payloadCmd string, payloadArgs []string, depth int)
+
+1. Set current = basename(filename), args = argv[1:]
+2. Loop (max 5 iterations):
+   a. If current is not in transparent set → return current, args, depth
+   b. Scan args left-to-right:
+      - Skip args starting with "-"
+      - Skip args containing "="
+      - On Windows: also skip short "/" args (1-3 chars, e.g. /c, /k)
+      - First remaining arg = new payload command
+   c. If no payload found → return current, args, depth (nothing to unwrap)
+   d. current = basename(payload), args = remaining args after payload
+   e. depth++
+3. Return current, args, depth (hit limit)
+```
+
+### Policy Evaluation
+
+Both the wrapper and payload are evaluated. Most restrictive decision wins:
+
+| Wrapper | Payload | Result |
+|---------|---------|--------|
+| `env` allowed | `wget` denied | **denied** |
+| `env` denied | `wget` allowed | **denied** |
+| `env` allowed | `wget` allowed | **allowed** |
+
+When the payload triggers denial, audit info references the payload:
+```
+Rule: "deny-wget"
+Reason: "denied: wget (unwrapped from: env)"
+```
+
+### Policy Schema Extension
+
+New optional field in policy YAML:
+
+```yaml
+transparent_commands:
+  add: ["myrunner", "custom-wrapper"]
+  remove: ["sudo"]
+```
+
+- `add` — additional commands treated as transparent (merged with built-in defaults)
+- `remove` — remove from built-in defaults
+- Omitting entirely → use defaults as-is
+
+Parsed at `NewEngine()` time, merged set stored on engine and passed to execve handler.
+
+---
+
+## Integration into Execve Pipeline
+
+### handleExecveNotification (handler.go)
+
+```
+1. Read filename from tracee memory        [existing]
+2. Resolve execveat special cases           [existing]
+3. EvalSymlinks(filename)                   [NEW]
+4. Read argv                                [existing]
+5. Build ExecveContext with:
+   - Filename = canonical path
+   - RawFilename = original string          [NEW]
+   - Argv = full argv
+6. Pass to ExecveHandler.Handle()
+```
+
+### ExecveHandler.Handle (execve_handler.go)
+
+```
+1. Depth tracking                           [existing]
+2. Internal bypass check                    [existing]
+3. Truncation check                         [existing]
+4. Unwrap transparent command               [NEW]
+   - Input: ctx.Filename, ctx.Argv
+   - Output: payloadCmd, payloadArgs, unwrapDepth
+   - If unwrapped (unwrapDepth > 0):
+     a. Check policy on PAYLOAD: CheckExecve(payloadCmd, payloadArgs, depth)
+     b. If payload denied → deny with enriched info
+     c. If payload allowed → also check wrapper
+5. Check policy on original command         [existing]
+6. Return most restrictive decision
+```
+
+---
+
+## ExecveContext Additions
+
+```go
+type ExecveContext struct {
+    // ... existing fields ...
+    RawFilename    string   // pre-canonicalization filename
+    UnwrappedFrom  string   // if unwrapped: the transparent wrapper command
+    PayloadCommand string   // if unwrapped: the real command being evaluated
+}
+```
+
+---
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| `env -i` (no payload) | Unwrap finds nothing, evaluates `env` normally |
+| `ld-linux /tmp/nonexistent` | Unwrap extracts path, EvalSymlinks fails, raw path used, default-deny blocks |
+| `sudo nice env nohup ld-linux /usr/bin/wget` | Recursive unwrap (5 layers), lands on `wget` |
+| `grep -r /usr/bin/wget /var/log` | `grep` not transparent → no unwrapping |
+| `/tmp/mywrapper wget` | Not transparent → default-deny blocks; operator can add to `transparent_commands.add` |
+| `/proc/self/root/usr/bin/env wget` | EvalSymlinks → `/usr/bin/env`, then unwrap detects `env` → extracts `wget` |
+
+## Performance
+
+- `EvalSymlinks` — one `lstat` per path component (~3-4 syscalls). Negligible vs seccomp round-trip.
+- Unwrap — string operations on argv, no I/O. Essentially free.
+- No measurable latency added to execve hot path.

--- a/docs/plans/2026-03-11-ptrace-tracer-phase1.md
+++ b/docs/plans/2026-03-11-ptrace-tracer-phase1.md
@@ -1,0 +1,2946 @@
+# ptrace Tracer Backend — Phase 1 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a ptrace-based syscall tracer that can enforce command allow/deny on Linux environments where seccomp user-notify is unavailable (e.g., AWS Fargate with SYS_PTRACE).
+
+**Architecture:** A single-threaded ptrace event loop (runtime.LockOSThread) attaches to tracee processes via PTRACE_SEIZE, intercepts syscalls at enter/exit, and dispatches to the existing ExecveHandler for policy decisions. Two attach modes: `children` (fork + prefilter) and `pid` (attach to running process). All ptrace operations happen on one locked OS thread; policy evaluation and event emission happen asynchronously via channels.
+
+**Tech Stack:** Go, `golang.org/x/sys/unix` (ptrace, seccomp, wait4), Linux kernel ptrace API, seccomp-BPF (for prefilter in children mode)
+
+**Spec:** `docs/ptrace-support.md` — sections 1-8, 10, 13-14
+
+---
+
+## Task 1: PtraceConfig struct with defaults
+
+**Files:**
+- Create: `internal/config/ptrace.go`
+- Create: `internal/config/ptrace_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// internal/config/ptrace_test.go
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestDefaultPtraceConfig(t *testing.T) {
+	cfg := DefaultPtraceConfig()
+
+	if cfg.Enabled {
+		t.Error("ptrace should be disabled by default")
+	}
+	if cfg.AttachMode != "children" {
+		t.Errorf("attach_mode: got %q, want %q", cfg.AttachMode, "children")
+	}
+	if !cfg.Trace.Execve || !cfg.Trace.File || !cfg.Trace.Network || !cfg.Trace.Signal {
+		t.Error("all trace classes should be enabled by default")
+	}
+	if !cfg.Performance.SeccompPrefilter {
+		t.Error("seccomp_prefilter should be enabled by default")
+	}
+	if cfg.Performance.MaxTracees != 500 {
+		t.Errorf("max_tracees: got %d, want 500", cfg.Performance.MaxTracees)
+	}
+	if cfg.Performance.MaxHoldMs != 5000 {
+		t.Errorf("max_hold_ms: got %d, want 5000", cfg.Performance.MaxHoldMs)
+	}
+	if cfg.MaskTracerPid != "off" {
+		t.Errorf("mask_tracer_pid: got %q, want %q", cfg.MaskTracerPid, "off")
+	}
+	if cfg.OnAttachFailure != "fail_open" {
+		t.Errorf("on_attach_failure: got %q, want %q", cfg.OnAttachFailure, "fail_open")
+	}
+}
+
+func TestPtraceConfig_YAMLRoundTrip(t *testing.T) {
+	orig := DefaultPtraceConfig()
+	orig.Enabled = true
+	orig.TargetPID = 42
+
+	data, err := yaml.Marshal(orig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded SandboxPtraceConfig
+	if err := yaml.Unmarshal(data, &decoded); err != nil {
+		t.Fatal(err)
+	}
+
+	if decoded.TargetPID != 42 {
+		t.Errorf("target_pid: got %d, want 42", decoded.TargetPID)
+	}
+	if !decoded.Enabled {
+		t.Error("enabled not preserved")
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/config/ -run TestDefaultPtraceConfig -v`
+Expected: FAIL — `SandboxPtraceConfig` not defined
+
+**Step 3: Write minimal implementation**
+
+```go
+// internal/config/ptrace.go
+package config
+
+// SandboxPtraceConfig configures the ptrace-based syscall tracer backend.
+// This is an alternative to seccomp user-notify for restricted environments
+// like AWS Fargate where SYS_PTRACE is available but seccomp user-notify is not.
+type SandboxPtraceConfig struct {
+	Enabled         bool                    `yaml:"enabled"`
+	AttachMode      string                  `yaml:"attach_mode"`
+	TargetPID       int                     `yaml:"target_pid"`
+	TargetPIDFile   string                  `yaml:"target_pid_file"`
+	Trace           PtraceTraceConfig       `yaml:"trace"`
+	Performance     PtracePerformanceConfig `yaml:"performance"`
+	MaskTracerPid   string                  `yaml:"mask_tracer_pid"`
+	OnAttachFailure string                  `yaml:"on_attach_failure"`
+}
+
+// PtraceTraceConfig controls which syscall classes are traced.
+type PtraceTraceConfig struct {
+	Execve  bool `yaml:"execve"`
+	File    bool `yaml:"file"`
+	Network bool `yaml:"network"`
+	Signal  bool `yaml:"signal"`
+}
+
+// PtracePerformanceConfig contains performance tuning options.
+type PtracePerformanceConfig struct {
+	SeccompPrefilter bool `yaml:"seccomp_prefilter"`
+	MaxTracees       int  `yaml:"max_tracees"`
+	MaxHoldMs        int  `yaml:"max_hold_ms"`
+}
+
+// DefaultPtraceConfig returns secure defaults for ptrace configuration.
+func DefaultPtraceConfig() SandboxPtraceConfig {
+	return SandboxPtraceConfig{
+		Enabled:    false,
+		AttachMode: "children",
+		Trace: PtraceTraceConfig{
+			Execve:  true,
+			File:    true,
+			Network: true,
+			Signal:  true,
+		},
+		Performance: PtracePerformanceConfig{
+			SeccompPrefilter: true,
+			MaxTracees:       500,
+			MaxHoldMs:        5000,
+		},
+		MaskTracerPid:   "off",
+		OnAttachFailure: "fail_open",
+	}
+}
+```
+
+**Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/config/ -run TestPtrace -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/config/ptrace.go internal/config/ptrace_test.go
+git commit -m "feat(config): add SandboxPtraceConfig struct with defaults"
+```
+
+---
+
+## Task 2: PtraceConfig validation
+
+**Files:**
+- Modify: `internal/config/ptrace.go`
+- Modify: `internal/config/ptrace_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// Append to internal/config/ptrace_test.go
+func TestPtraceConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		modify  func(*SandboxPtraceConfig)
+		wantErr bool
+	}{
+		{"defaults are valid", func(c *SandboxPtraceConfig) {}, false},
+		{"pid mode with target_pid", func(c *SandboxPtraceConfig) {
+			c.AttachMode = "pid"
+			c.TargetPID = 123
+		}, false},
+		{"pid mode with target_pid_file", func(c *SandboxPtraceConfig) {
+			c.AttachMode = "pid"
+			c.TargetPIDFile = "/shared/workload.pid"
+		}, false},
+		{"pid mode without target", func(c *SandboxPtraceConfig) {
+			c.AttachMode = "pid"
+		}, true},
+		{"invalid attach_mode", func(c *SandboxPtraceConfig) {
+			c.AttachMode = "sidecar"
+		}, true},
+		{"invalid on_attach_failure", func(c *SandboxPtraceConfig) {
+			c.OnAttachFailure = "panic"
+		}, true},
+		{"invalid mask_tracer_pid", func(c *SandboxPtraceConfig) {
+			c.MaskTracerPid = "ptrace"
+		}, true},
+		{"max_hold_ms zero", func(c *SandboxPtraceConfig) {
+			c.Performance.MaxHoldMs = 0
+		}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := DefaultPtraceConfig()
+			cfg.Enabled = true
+			tt.modify(&cfg)
+			err := cfg.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/config/ -run TestPtraceConfig_Validate -v`
+Expected: FAIL — `Validate` method not defined
+
+**Step 3: Write minimal implementation**
+
+```go
+// Append to internal/config/ptrace.go
+import "fmt"
+
+// Validate checks that the ptrace configuration is internally consistent.
+func (c *SandboxPtraceConfig) Validate() error {
+	if !c.Enabled {
+		return nil // Nothing to validate when disabled
+	}
+
+	switch c.AttachMode {
+	case "children", "pid":
+	default:
+		return fmt.Errorf("sandbox.ptrace.attach_mode: invalid value %q (must be \"children\" or \"pid\")", c.AttachMode)
+	}
+
+	if c.AttachMode == "pid" && c.TargetPID <= 0 && c.TargetPIDFile == "" {
+		return fmt.Errorf("sandbox.ptrace: attach_mode \"pid\" requires target_pid or target_pid_file")
+	}
+
+	switch c.OnAttachFailure {
+	case "fail_open", "fail_closed":
+	default:
+		return fmt.Errorf("sandbox.ptrace.on_attach_failure: invalid value %q", c.OnAttachFailure)
+	}
+
+	// Phase 1: only "off" is supported for mask_tracer_pid
+	if c.MaskTracerPid != "off" {
+		return fmt.Errorf("sandbox.ptrace.mask_tracer_pid: %q not supported in this version (use \"off\")", c.MaskTracerPid)
+	}
+
+	if c.Performance.MaxHoldMs <= 0 {
+		return fmt.Errorf("sandbox.ptrace.performance.max_hold_ms must be > 0")
+	}
+
+	return nil
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/config/ -run TestPtrace -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/config/ptrace.go internal/config/ptrace_test.go
+git commit -m "feat(config): add ptrace config validation"
+```
+
+---
+
+## Task 3: Wire PtraceConfig into SandboxConfig
+
+**Files:**
+- Modify: `internal/config/config.go:347`
+
+**Step 1: Add field**
+
+In `SandboxConfig` struct (after the `MCP` field at line 347), add:
+
+```go
+Ptrace  SandboxPtraceConfig  `yaml:"ptrace"`
+```
+
+**Step 2: Run all config tests**
+
+Run: `go test ./internal/config/... -v`
+Expected: PASS (zero value of SandboxPtraceConfig is disabled, which is correct)
+
+**Step 3: Run full build**
+
+Run: `go build ./...`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add internal/config/config.go
+git commit -m "feat(config): wire SandboxPtraceConfig into SandboxConfig"
+```
+
+---
+
+## Task 4: ptrace capability detection — readCapEff
+
+**Files:**
+- Create: `internal/capabilities/check_ptrace_linux.go`
+- Create: `internal/capabilities/check_ptrace_linux_test.go`
+
+**Step 1: Write the failing test**
+
+```go
+// internal/capabilities/check_ptrace_linux_test.go
+//go:build linux
+
+package capabilities
+
+import "testing"
+
+func TestReadCapEff(t *testing.T) {
+	capEff, err := readCapEff()
+	if err != nil {
+		t.Fatalf("readCapEff() error: %v", err)
+	}
+	// Every Linux process has at least some capabilities in effective set
+	// (even unprivileged processes have bits like CAP_SETUID in permitted
+	// but effective may be 0 for unprivileged). Just check no error.
+	t.Logf("CapEff = 0x%016x", capEff)
+}
+
+func TestReadCapEffParsing(t *testing.T) {
+	// Test the parsing logic with known input
+	tests := []struct {
+		name    string
+		input   string
+		want    uint64
+		wantErr bool
+	}{
+		{
+			name:  "standard format",
+			input: "Name:\ttest\nCapEff:\t000001ffffffffff\nPPid:\t1\n",
+			want:  0x000001ffffffffff,
+		},
+		{
+			name:    "missing CapEff",
+			input:   "Name:\ttest\nPPid:\t1\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCapEff(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseCapEff() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("parseCapEff() = 0x%x, want 0x%x", got, tt.want)
+			}
+		})
+	}
+}
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/capabilities/ -run TestReadCapEff -v`
+Expected: FAIL — functions not defined
+
+**Step 3: Write minimal implementation**
+
+```go
+// internal/capabilities/check_ptrace_linux.go
+//go:build linux
+
+package capabilities
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// readCapEff reads the effective capability set from /proc/self/status.
+func readCapEff() (uint64, error) {
+	data, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return 0, err
+	}
+	return parseCapEff(string(data))
+}
+
+// parseCapEff extracts the CapEff value from /proc/self/status content.
+func parseCapEff(content string) (uint64, error) {
+	for _, line := range strings.Split(content, "\n") {
+		if strings.HasPrefix(line, "CapEff:\t") {
+			hex := strings.TrimSpace(strings.TrimPrefix(line, "CapEff:\t"))
+			return strconv.ParseUint(hex, 16, 64)
+		}
+	}
+	return 0, fmt.Errorf("CapEff not found in /proc/self/status")
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/capabilities/ -run TestReadCapEff -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/capabilities/check_ptrace_linux.go internal/capabilities/check_ptrace_linux_test.go
+git commit -m "feat(capabilities): add readCapEff for ptrace capability detection"
+```
+
+---
+
+## Task 5: ptrace capability detection — probePtraceAttach + checkPtraceCapability
+
+**Files:**
+- Modify: `internal/capabilities/check_ptrace_linux.go`
+- Modify: `internal/capabilities/check_ptrace_linux_test.go`
+
+**Step 1: Write the test**
+
+```go
+// Append to check_ptrace_linux_test.go
+func TestProbePtraceAttach(t *testing.T) {
+	// Just verify it doesn't panic. The actual result depends on SYS_PTRACE availability.
+	result := probePtraceAttach()
+	t.Logf("probePtraceAttach() = %v", result)
+}
+
+func TestCheckPtraceCapability(t *testing.T) {
+	result := checkPtraceCapability()
+	t.Logf("checkPtraceCapability() = %v", result)
+}
+```
+
+**Step 2: Implement**
+
+```go
+// Append to internal/capabilities/check_ptrace_linux.go
+import (
+	"os/exec"
+
+	"golang.org/x/sys/unix"
+)
+
+const capSysPtrace = 19
+
+// checkPtraceCapability checks if ptrace is available and functional.
+func checkPtraceCapability() bool {
+	capEff, err := readCapEff()
+	if err != nil {
+		return false
+	}
+	if capEff&(1<<capSysPtrace) == 0 {
+		return false
+	}
+	return probePtraceAttach()
+}
+
+// probePtraceAttach forks a short-lived child and attempts PTRACE_SEIZE.
+func probePtraceAttach() bool {
+	cmd := exec.Command("/bin/sleep", "0.1")
+	if err := cmd.Start(); err != nil {
+		return false
+	}
+
+	pid := cmd.Process.Pid
+
+	err := unix.PtraceSeize(pid, 0)
+	if err != nil {
+		cmd.Process.Kill()
+		cmd.Wait()
+		return false
+	}
+
+	// Seize succeeded. Clean up: interrupt, wait, detach.
+	if err := unix.PtraceInterrupt(pid); err != nil {
+		cmd.Process.Kill()
+		cmd.Wait()
+		return true
+	}
+
+	var status unix.WaitStatus
+	_, err = unix.Wait4(pid, &status, 0, nil)
+	if err == nil && status.Stopped() {
+		unix.PtraceDetach(pid)
+	}
+
+	cmd.Process.Kill()
+	cmd.Wait()
+	return true
+}
+```
+
+**Step 3: Run tests**
+
+Run: `go test ./internal/capabilities/ -run TestProbe -v`
+Expected: PASS (may show false on machines without SYS_PTRACE, that's OK)
+
+**Step 4: Commit**
+
+```bash
+git add internal/capabilities/check_ptrace_linux.go internal/capabilities/check_ptrace_linux_test.go
+git commit -m "feat(capabilities): add probePtraceAttach for functional ptrace probing"
+```
+
+---
+
+## Task 6: Wire real ptrace detection into check.go and SecurityCapabilities
+
+**Files:**
+- Modify: `internal/capabilities/check.go` — replace `realCheckPtrace` stub
+- Modify: `internal/capabilities/security_caps.go` — add Ptrace/PtraceEnabled fields, ModePtrace, update SelectMode and DetectSecurityCapabilities
+- Modify: `internal/capabilities/detect_linux.go` — add ptrace to caps map, update modeToScore
+- Modify: `internal/capabilities/tips.go` — add ptrace tip to linuxTips
+
+**Step 1: Write failing tests**
+
+```go
+// Add to internal/capabilities/security_caps_test.go (create if needed)
+// //go:build linux
+
+func TestSelectMode_Ptrace(t *testing.T) {
+	tests := []struct {
+		name string
+		caps SecurityCapabilities
+		want string
+	}{
+		{
+			name: "ptrace available and enabled, no seccomp",
+			caps: SecurityCapabilities{Ptrace: true, PtraceEnabled: true, Capabilities: true},
+			want: ModePtrace,
+		},
+		{
+			name: "ptrace available but not enabled",
+			caps: SecurityCapabilities{Ptrace: true, PtraceEnabled: false, Capabilities: true},
+			want: ModeMinimal,
+		},
+		{
+			name: "ptrace not available but enabled",
+			caps: SecurityCapabilities{Ptrace: false, PtraceEnabled: true, Capabilities: true},
+			want: ModeMinimal,
+		},
+		{
+			name: "full mode takes priority over ptrace",
+			caps: SecurityCapabilities{Seccomp: true, EBPF: true, FUSE: true, Ptrace: true, PtraceEnabled: true},
+			want: ModeFull,
+		},
+		{
+			name: "ptrace takes priority over landlock",
+			caps: SecurityCapabilities{Ptrace: true, PtraceEnabled: true, Landlock: true, FUSE: true},
+			want: ModePtrace,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.caps.SelectMode()
+			if got != tt.want {
+				t.Errorf("SelectMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+```
+
+**Step 2: Run to verify failure**
+
+Run: `go test ./internal/capabilities/ -run TestSelectMode_Ptrace -v`
+Expected: FAIL — ModePtrace not defined, Ptrace field not on struct
+
+**Step 3: Implement changes**
+
+In `internal/capabilities/security_caps.go`:
+- Add `Ptrace bool` and `PtraceEnabled bool` fields to `SecurityCapabilities`
+- Add `ModePtrace = "ptrace"` constant
+- Insert in `SelectMode()` after the ModeFull check:
+  ```go
+  if c.Ptrace && c.PtraceEnabled {
+      return ModePtrace
+  }
+  ```
+- In `DetectSecurityCapabilities()`, add: `caps.Ptrace = checkPtraceCapability()`
+
+In `internal/capabilities/check.go`:
+- Replace `realCheckPtrace` body:
+  ```go
+  func realCheckPtrace() CheckResult {
+      available := checkPtraceCapability()
+      r := CheckResult{Feature: "ptrace", Available: available}
+      if !available {
+          r.Error = fmt.Errorf("SYS_PTRACE capability not available or ptrace blocked by seccomp")
+      }
+      return r
+  }
+  ```
+- Add ptrace check block to `CheckAll` for when `cfg.Sandbox.Ptrace.Enabled`:
+  ```go
+  if cfg.Sandbox.Ptrace.Enabled {
+      result := checkPtrace()
+      result.ConfigKey = "sandbox.ptrace.enabled"
+      result.Suggestion = "Set 'sandbox.ptrace.enabled: false' or add SYS_PTRACE capability"
+      if !result.Available {
+          failures = append(failures, result)
+      }
+  }
+  ```
+
+In `internal/capabilities/detect_linux.go`:
+- Add `"ptrace": secCaps.Ptrace` to the caps map in `Detect()`
+- Add `case ModePtrace: return 90` to `modeToScore()`
+
+In `internal/capabilities/tips.go`:
+- Add to `linuxTips`:
+  ```go
+  {
+      Feature:  "ptrace",
+      CheckKey: "ptrace",
+      Impact:   "Syscall-level enforcement via ptrace unavailable",
+      Action:   "Add SYS_PTRACE capability to enable ptrace-based enforcement for restricted runtimes",
+  },
+  ```
+
+**Step 4: Run all capability tests**
+
+Run: `go test ./internal/capabilities/... -v`
+Expected: PASS
+
+**Step 5: Run full build including cross-compile**
+
+Run: `go build ./... && GOOS=windows go build ./...`
+Expected: PASS (non-Linux builds use stubs from security_caps_other.go)
+
+Note: If `security_caps_other.go` needs updating for the new fields/constant, add them there too (zero-value defaults are fine — Ptrace: false, PtraceEnabled: false; ModePtrace constant; SelectMode() with the same logic).
+
+**Step 6: Commit**
+
+```bash
+git add internal/capabilities/security_caps.go internal/capabilities/security_caps_other.go \
+  internal/capabilities/check.go internal/capabilities/detect_linux.go \
+  internal/capabilities/tips.go
+git commit -m "feat(capabilities): add ModePtrace, ptrace detection, and detect/tips integration"
+```
+
+---
+
+## Task 7: Add HasPtrace to platform Capabilities + SyscallTracer interface
+
+**Files:**
+- Modify: `internal/platform/types.go`
+- Modify: `internal/platform/interfaces.go`
+
+**Step 1: Add HasPtrace field**
+
+In `internal/platform/types.go`, after `HasSeccomp bool`:
+```go
+HasPtrace bool `json:"has_ptrace"`
+```
+
+**Step 2: Add SyscallTracer interface**
+
+In `internal/platform/interfaces.go`, after the existing interfaces:
+```go
+// SyscallTracer provides syscall-level interception via ptrace or equivalent.
+type SyscallTracer interface {
+	Start(ctx context.Context) error
+	AttachPID(pid int) error
+	TraceeCount() int
+	Available() bool
+	Implementation() string
+}
+```
+
+**Step 3: Verify build**
+
+Run: `go build ./... && GOOS=windows go build ./...`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add internal/platform/types.go internal/platform/interfaces.go
+git commit -m "feat(platform): add HasPtrace and SyscallTracer interface"
+```
+
+---
+
+## Task 8: ptrace package — doc.go, Regs interface, amd64/arm64 implementations
+
+**Files:**
+- Create: `internal/ptrace/doc.go`
+- Create: `internal/ptrace/args.go`
+- Create: `internal/ptrace/args_amd64.go`
+- Create: `internal/ptrace/args_amd64_test.go`
+- Create: `internal/ptrace/args_arm64.go`
+
+**Step 1: Write failing test for amd64 regs**
+
+```go
+// internal/ptrace/args_amd64_test.go
+//go:build linux && amd64
+
+package ptrace
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestAmd64Regs_SyscallNr(t *testing.T) {
+	r := &amd64Regs{}
+	r.raw.Orig_rax = 59 // SYS_EXECVE
+	if r.SyscallNr() != 59 {
+		t.Errorf("SyscallNr() = %d, want 59", r.SyscallNr())
+	}
+	r.SetSyscallNr(-1)
+	if r.SyscallNr() != -1 {
+		t.Errorf("SetSyscallNr(-1): got %d", r.SyscallNr())
+	}
+}
+
+func TestAmd64Regs_Args(t *testing.T) {
+	r := &amd64Regs{}
+	// Set each arg and verify correct register mapping
+	r.SetArg(0, 100)
+	if r.raw.Rdi != 100 {
+		t.Errorf("Arg(0) maps to Rdi: got %d", r.raw.Rdi)
+	}
+	r.SetArg(1, 200)
+	if r.raw.Rsi != 200 {
+		t.Errorf("Arg(1) maps to Rsi: got %d", r.raw.Rsi)
+	}
+	r.SetArg(2, 300)
+	if r.raw.Rdx != 300 {
+		t.Errorf("Arg(2) maps to Rdx: got %d", r.raw.Rdx)
+	}
+	r.SetArg(3, 400)
+	if r.raw.R10 != 400 {
+		t.Errorf("Arg(3) maps to R10: got %d", r.raw.R10)
+	}
+	r.SetArg(4, 500)
+	if r.raw.R8 != 500 {
+		t.Errorf("Arg(4) maps to R8: got %d", r.raw.R8)
+	}
+	r.SetArg(5, 600)
+	if r.raw.R9 != 600 {
+		t.Errorf("Arg(5) maps to R9: got %d", r.raw.R9)
+	}
+
+	// Round-trip
+	for i := 0; i < 6; i++ {
+		expected := uint64((i + 1) * 100)
+		if r.Arg(i) != expected {
+			t.Errorf("Arg(%d) = %d, want %d", i, r.Arg(i), expected)
+		}
+	}
+
+	// Out-of-range
+	if r.Arg(6) != 0 {
+		t.Error("Arg(6) should return 0")
+	}
+	if r.Arg(-1) != 0 {
+		t.Error("Arg(-1) should return 0")
+	}
+}
+
+func TestAmd64Regs_ReturnValue(t *testing.T) {
+	r := &amd64Regs{}
+	r.SetReturnValue(-int64(unix.EACCES))
+	if r.ReturnValue() != -int64(unix.EACCES) {
+		t.Errorf("ReturnValue() = %d, want %d", r.ReturnValue(), -int64(unix.EACCES))
+	}
+}
+```
+
+**Step 2: Run to verify failure**
+
+Run: `go test ./internal/ptrace/ -run TestAmd64 -v`
+Expected: FAIL — package doesn't exist
+
+**Step 3: Create the files**
+
+```go
+// internal/ptrace/doc.go
+//go:build linux
+
+// Package ptrace implements a ptrace-based syscall tracer backend for agentsh.
+// It provides syscall-level interception for environments where seccomp user-notify
+// and eBPF are unavailable (e.g., AWS Fargate with SYS_PTRACE).
+//
+// This package is Linux-only and requires the SYS_PTRACE capability.
+package ptrace
+```
+
+```go
+// internal/ptrace/args.go
+//go:build linux
+
+package ptrace
+
+// Regs abstracts architecture-specific register access for ptrace.
+type Regs interface {
+	SyscallNr() int
+	SetSyscallNr(nr int)
+	Arg(n int) uint64
+	SetArg(n int, val uint64)
+	ReturnValue() int64
+	SetReturnValue(val int64)
+	InstructionPointer() uint64
+}
+```
+
+```go
+// internal/ptrace/args_amd64.go
+//go:build linux && amd64
+
+package ptrace
+
+import "golang.org/x/sys/unix"
+
+type amd64Regs struct {
+	raw unix.PtraceRegsAmd64
+}
+
+func (r *amd64Regs) SyscallNr() int        { return int(int64(r.raw.Orig_rax)) }
+func (r *amd64Regs) SetSyscallNr(nr int)   { r.raw.Orig_rax = uint64(nr) }
+func (r *amd64Regs) ReturnValue() int64    { return int64(r.raw.Rax) }
+func (r *amd64Regs) SetReturnValue(v int64) { r.raw.Rax = uint64(v) }
+func (r *amd64Regs) InstructionPointer() uint64 { return r.raw.Rip }
+
+func (r *amd64Regs) Arg(n int) uint64 {
+	switch n {
+	case 0:
+		return r.raw.Rdi
+	case 1:
+		return r.raw.Rsi
+	case 2:
+		return r.raw.Rdx
+	case 3:
+		return r.raw.R10
+	case 4:
+		return r.raw.R8
+	case 5:
+		return r.raw.R9
+	default:
+		return 0
+	}
+}
+
+func (r *amd64Regs) SetArg(n int, val uint64) {
+	switch n {
+	case 0:
+		r.raw.Rdi = val
+	case 1:
+		r.raw.Rsi = val
+	case 2:
+		r.raw.Rdx = val
+	case 3:
+		r.raw.R10 = val
+	case 4:
+		r.raw.R8 = val
+	case 5:
+		r.raw.R9 = val
+	}
+}
+
+func getRegsArch(tid int) (Regs, error) {
+	r := &amd64Regs{}
+	err := unix.PtraceGetRegsAmd64(tid, &r.raw)
+	return r, err
+}
+
+func setRegsArch(tid int, regs Regs) error {
+	r := regs.(*amd64Regs)
+	return unix.PtraceSetRegsAmd64(tid, &r.raw)
+}
+```
+
+```go
+// internal/ptrace/args_arm64.go
+//go:build linux && arm64
+
+package ptrace
+
+import "golang.org/x/sys/unix"
+
+type arm64Regs struct {
+	raw unix.PtraceRegsArm64
+}
+
+func (r *arm64Regs) SyscallNr() int        { return int(int64(r.raw.Regs[8])) }
+func (r *arm64Regs) SetSyscallNr(nr int)   { r.raw.Regs[8] = uint64(nr) }
+func (r *arm64Regs) ReturnValue() int64    { return int64(r.raw.Regs[0]) }
+func (r *arm64Regs) SetReturnValue(v int64) { r.raw.Regs[0] = uint64(v) }
+func (r *arm64Regs) InstructionPointer() uint64 { return r.raw.Pc }
+
+func (r *arm64Regs) Arg(n int) uint64 {
+	if n < 0 || n > 5 {
+		return 0
+	}
+	return r.raw.Regs[n]
+}
+
+func (r *arm64Regs) SetArg(n int, val uint64) {
+	if n >= 0 && n <= 5 {
+		r.raw.Regs[n] = val
+	}
+}
+
+func getRegsArch(tid int) (Regs, error) {
+	r := &arm64Regs{}
+	err := unix.PtraceGetRegsArm64(tid, &r.raw)
+	return r, err
+}
+
+func setRegsArch(tid int, regs Regs) error {
+	r := regs.(*arm64Regs)
+	return unix.PtraceSetRegsArm64(tid, &r.raw)
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/ptrace/ -run TestAmd64 -v`
+Expected: PASS
+
+Run: `GOARCH=arm64 go build ./internal/ptrace/`
+Expected: PASS (cross-compile check)
+
+**Step 5: Commit**
+
+```bash
+git add internal/ptrace/
+git commit -m "feat(ptrace): add Regs interface with amd64 and arm64 implementations"
+```
+
+---
+
+## Task 9: Process tree
+
+**Files:**
+- Create: `internal/ptrace/process_tree.go`
+- Create: `internal/ptrace/process_tree_test.go`
+
+**Step 1: Write failing tests**
+
+```go
+// internal/ptrace/process_tree_test.go
+//go:build linux
+
+package ptrace
+
+import "testing"
+
+func TestProcessTree_AddRoot(t *testing.T) {
+	pt := NewProcessTree()
+	pt.AddRoot(100)
+
+	if pt.Depth(100) != 0 {
+		t.Errorf("root depth = %d, want 0", pt.Depth(100))
+	}
+	if _, ok := pt.Parent(100); ok {
+		t.Error("root should have no parent")
+	}
+	if pt.Size() != 1 {
+		t.Errorf("size = %d, want 1", pt.Size())
+	}
+}
+
+func TestProcessTree_AddChild(t *testing.T) {
+	pt := NewProcessTree()
+	pt.AddRoot(100)
+	pt.AddChild(100, 200)
+	pt.AddChild(200, 300)
+
+	if pt.Depth(200) != 1 {
+		t.Errorf("child depth = %d, want 1", pt.Depth(200))
+	}
+	if pt.Depth(300) != 2 {
+		t.Errorf("grandchild depth = %d, want 2", pt.Depth(300))
+	}
+	parent, ok := pt.Parent(200)
+	if !ok || parent != 100 {
+		t.Errorf("parent of 200 = %d, ok=%v; want 100, true", parent, ok)
+	}
+	if pt.Size() != 3 {
+		t.Errorf("size = %d, want 3", pt.Size())
+	}
+}
+
+func TestProcessTree_Remove(t *testing.T) {
+	pt := NewProcessTree()
+	pt.AddRoot(100)
+	pt.AddChild(100, 200)
+
+	pt.Remove(200)
+	if pt.Size() != 1 {
+		t.Errorf("size after remove = %d, want 1", pt.Size())
+	}
+	if pt.Depth(200) != -1 {
+		t.Error("removed node should return depth -1")
+	}
+}
+
+func TestProcessTree_IsDescendantOf(t *testing.T) {
+	pt := NewProcessTree()
+	pt.AddRoot(1)
+	pt.AddChild(1, 10)
+	pt.AddChild(10, 100)
+
+	if !pt.IsDescendantOf(100, 1) {
+		t.Error("100 should be descendant of 1")
+	}
+	if pt.IsDescendantOf(1, 100) {
+		t.Error("1 should not be descendant of 100")
+	}
+	if pt.IsDescendantOf(100, 999) {
+		t.Error("100 should not be descendant of non-existent 999")
+	}
+}
+
+func TestProcessTree_ConcurrentAccess(t *testing.T) {
+	pt := NewProcessTree()
+	pt.AddRoot(1)
+
+	done := make(chan struct{})
+	for i := 0; i < 10; i++ {
+		go func(id int) {
+			defer func() { done <- struct{}{} }()
+			tgid := id + 100
+			pt.AddChild(1, tgid)
+			pt.Depth(tgid)
+			pt.Parent(tgid)
+			pt.Size()
+			pt.Remove(tgid)
+		}(i)
+	}
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+}
+```
+
+**Step 2: Run to verify failure**
+
+Run: `go test ./internal/ptrace/ -run TestProcessTree -v -race`
+Expected: FAIL — NewProcessTree not defined
+
+**Step 3: Implement**
+
+```go
+// internal/ptrace/process_tree.go
+//go:build linux
+
+package ptrace
+
+import "sync"
+
+// ProcessTree tracks TGID-to-TGID parent-child relationships.
+// All operations are goroutine-safe.
+type ProcessTree struct {
+	mu    sync.RWMutex
+	nodes map[int]*processNode
+}
+
+type processNode struct {
+	tgid     int
+	parent   int
+	children []int
+	depth    int
+}
+
+// NewProcessTree creates an empty process tree.
+func NewProcessTree() *ProcessTree {
+	return &ProcessTree{nodes: make(map[int]*processNode)}
+}
+
+// AddRoot adds a root process (depth 0, no parent).
+func (pt *ProcessTree) AddRoot(tgid int) {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
+	pt.nodes[tgid] = &processNode{tgid: tgid, parent: -1, depth: 0}
+}
+
+// AddChild adds a child process under the given parent.
+func (pt *ProcessTree) AddChild(parentTGID, childTGID int) {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
+
+	parentNode := pt.nodes[parentTGID]
+	depth := 0
+	if parentNode != nil {
+		depth = parentNode.depth + 1
+		parentNode.children = append(parentNode.children, childTGID)
+	}
+
+	pt.nodes[childTGID] = &processNode{
+		tgid:   childTGID,
+		parent: parentTGID,
+		depth:  depth,
+	}
+}
+
+// Remove removes a process from the tree.
+func (pt *ProcessTree) Remove(tgid int) {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
+
+	node := pt.nodes[tgid]
+	if node == nil {
+		return
+	}
+
+	// Remove from parent's children list
+	if parent := pt.nodes[node.parent]; parent != nil {
+		for i, c := range parent.children {
+			if c == tgid {
+				parent.children = append(parent.children[:i], parent.children[i+1:]...)
+				break
+			}
+		}
+	}
+
+	delete(pt.nodes, tgid)
+}
+
+// Depth returns the depth of a process. Returns -1 if not found.
+func (pt *ProcessTree) Depth(tgid int) int {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
+	if node := pt.nodes[tgid]; node != nil {
+		return node.depth
+	}
+	return -1
+}
+
+// Parent returns the parent TGID. Returns (0, false) if not found or root.
+func (pt *ProcessTree) Parent(tgid int) (int, bool) {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
+	node := pt.nodes[tgid]
+	if node == nil || node.parent == -1 {
+		return 0, false
+	}
+	return node.parent, true
+}
+
+// Children returns the child TGIDs of a process.
+func (pt *ProcessTree) Children(tgid int) []int {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
+	node := pt.nodes[tgid]
+	if node == nil {
+		return nil
+	}
+	result := make([]int, len(node.children))
+	copy(result, node.children)
+	return result
+}
+
+// Size returns the number of processes in the tree.
+func (pt *ProcessTree) Size() int {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
+	return len(pt.nodes)
+}
+
+// IsDescendantOf returns true if tgid is a descendant of ancestorTGID.
+func (pt *ProcessTree) IsDescendantOf(tgid, ancestorTGID int) bool {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
+
+	current := tgid
+	for {
+		node := pt.nodes[current]
+		if node == nil || node.parent == -1 {
+			return false
+		}
+		if node.parent == ancestorTGID {
+			return true
+		}
+		current = node.parent
+	}
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/ptrace/ -run TestProcessTree -v -race`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/ptrace/process_tree.go internal/ptrace/process_tree_test.go
+git commit -m "feat(ptrace): add TGID-based process tree tracking"
+```
+
+---
+
+## Task 10: /proc helpers — readTGID, readPPID
+
+**Files:**
+- Create: `internal/ptrace/proc_helpers.go`
+- Create: `internal/ptrace/proc_helpers_test.go`
+
+**Step 1: Write failing tests**
+
+```go
+// internal/ptrace/proc_helpers_test.go
+//go:build linux
+
+package ptrace
+
+import (
+	"os"
+	"testing"
+)
+
+func TestReadTGID(t *testing.T) {
+	tgid, err := readTGID(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tgid != os.Getpid() {
+		t.Errorf("readTGID(self) = %d, want %d", tgid, os.Getpid())
+	}
+}
+
+func TestReadPPID(t *testing.T) {
+	ppid, err := readPPID(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ppid != os.Getppid() {
+		t.Errorf("readPPID(self) = %d, want %d", ppid, os.Getppid())
+	}
+}
+```
+
+**Step 2: Run to verify failure**
+
+Run: `go test ./internal/ptrace/ -run TestRead -v`
+Expected: FAIL
+
+**Step 3: Implement**
+
+```go
+// internal/ptrace/proc_helpers.go
+//go:build linux
+
+package ptrace
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// readTGID reads the thread group ID from /proc/<tid>/status.
+func readTGID(tid int) (int, error) {
+	return readProcStatusField(tid, "Tgid:")
+}
+
+// readPPID reads the parent PID from /proc/<tid>/status.
+func readPPID(tid int) (int, error) {
+	return readProcStatusField(tid, "PPid:")
+}
+
+func readProcStatusField(tid int, field string) (int, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", tid))
+	if err != nil {
+		return 0, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, field) {
+			val := strings.TrimSpace(strings.TrimPrefix(line, field))
+			return strconv.Atoi(val)
+		}
+	}
+	return 0, fmt.Errorf("%s not found in /proc/%d/status", field, tid)
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/ptrace/ -run TestRead -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/ptrace/proc_helpers.go internal/ptrace/proc_helpers_test.go
+git commit -m "feat(ptrace): add /proc status parsing helpers (readTGID, readPPID)"
+```
+
+---
+
+## Task 11: Memory access helpers
+
+**Files:**
+- Create: `internal/ptrace/memory.go`
+- Create: `internal/ptrace/memory_test.go`
+
+**Step 1: Write failing tests**
+
+```go
+// internal/ptrace/memory_test.go
+//go:build linux
+
+package ptrace
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestReadStringFromBuffer(t *testing.T) {
+	tests := []struct {
+		name   string
+		data   []byte
+		maxLen int
+		want   string
+	}{
+		{
+			name:   "simple",
+			data:   []byte("hello\x00world"),
+			maxLen: 100,
+			want:   "hello",
+		},
+		{
+			name:   "max length truncation",
+			data:   []byte("abcdefgh\x00"),
+			maxLen: 5,
+			want:   "abcde",
+		},
+		{
+			name:   "empty string",
+			data:   []byte("\x00rest"),
+			maxLen: 100,
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Use a bufferReader to simulate readBytes
+			reader := &mockMemReader{data: tt.data}
+			got, err := readStringFrom(reader, 0, tt.maxLen)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("readString = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// mockMemReader simulates reading from a flat byte buffer.
+type mockMemReader struct {
+	data []byte
+}
+
+func (m *mockMemReader) read(addr uint64, buf []byte) error {
+	start := int(addr)
+	if start >= len(m.data) {
+		return fmt.Errorf("read past end")
+	}
+	end := start + len(buf)
+	if end > len(m.data) {
+		end = len(m.data)
+	}
+	copy(buf, m.data[start:end])
+	// Zero-fill remainder if read was short
+	for i := end - start; i < len(buf); i++ {
+		buf[i] = 0
+	}
+	return nil
+}
+```
+
+**Step 2: Run to verify failure**
+
+Run: `go test ./internal/ptrace/ -run TestReadString -v`
+Expected: FAIL
+
+**Step 3: Implement**
+
+```go
+// internal/ptrace/memory.go
+//go:build linux
+
+package ptrace
+
+import (
+	"bytes"
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// memReader is an interface for reading bytes from an address space.
+// Abstracted for testability — production uses /proc/<tid>/mem.
+type memReader interface {
+	read(addr uint64, buf []byte) error
+}
+
+// procMemReader reads via /proc/<tid>/mem using a cached fd.
+type procMemReader struct {
+	fd int
+}
+
+func (r *procMemReader) read(addr uint64, buf []byte) error {
+	_, err := unix.Pread(r.fd, buf, int64(addr))
+	return err
+}
+
+// readBytesFrom reads len(buf) bytes from the given reader at addr.
+func readBytesFrom(r memReader, addr uint64, buf []byte) error {
+	return r.read(addr, buf)
+}
+
+// readStringFrom reads a NUL-terminated string from a memReader.
+// Reads in 256-byte chunks. Returns at most maxLen bytes.
+func readStringFrom(r memReader, addr uint64, maxLen int) (string, error) {
+	var result []byte
+	chunk := make([]byte, 256)
+	for len(result) < maxLen {
+		n := 256
+		if maxLen-len(result) < n {
+			n = maxLen - len(result)
+		}
+		if err := r.read(addr+uint64(len(result)), chunk[:n]); err != nil {
+			return "", err
+		}
+		if idx := bytes.IndexByte(chunk[:n], 0); idx >= 0 {
+			result = append(result, chunk[:idx]...)
+			return string(result), nil
+		}
+		result = append(result, chunk[:n]...)
+	}
+	return string(result), nil
+}
+
+// Tracer-level memory access methods using the cached MemFD.
+
+func (t *Tracer) getMemReader(tid int) (memReader, error) {
+	t.mu.Lock()
+	state := t.tracees[tid]
+	fd := -1
+	if state != nil {
+		fd = state.MemFD
+	}
+	t.mu.Unlock()
+
+	if fd < 0 {
+		return nil, fmt.Errorf("no memfd for tid %d", tid)
+	}
+	return &procMemReader{fd: fd}, nil
+}
+
+func (t *Tracer) readBytes(tid int, addr uint64, buf []byte) error {
+	r, err := t.getMemReader(tid)
+	if err != nil {
+		return err
+	}
+	return readBytesFrom(r, addr, buf)
+}
+
+func (t *Tracer) readString(tid int, addr uint64, maxLen int) (string, error) {
+	r, err := t.getMemReader(tid)
+	if err != nil {
+		return "", err
+	}
+	return readStringFrom(r, addr, maxLen)
+}
+
+func (t *Tracer) writeBytes(tid int, addr uint64, buf []byte) error {
+	t.mu.Lock()
+	state := t.tracees[tid]
+	fd := -1
+	if state != nil {
+		fd = state.MemFD
+	}
+	t.mu.Unlock()
+
+	if fd < 0 {
+		return fmt.Errorf("no memfd for tid %d", tid)
+	}
+	_, err := unix.Pwrite(fd, buf, int64(addr))
+	return err
+}
+
+// readArgv reads the argv array from tracee memory.
+// Returns the argument list and whether it was truncated.
+func (t *Tracer) readArgv(tid int, argvPtr uint64, maxArgc int, maxBytes int) ([]string, bool, error) {
+	r, err := t.getMemReader(tid)
+	if err != nil {
+		return nil, false, err
+	}
+
+	var args []string
+	totalBytes := 0
+	ptrBuf := make([]byte, 8)
+
+	for i := 0; i < maxArgc; i++ {
+		if err := r.read(argvPtr+uint64(i*8), ptrBuf); err != nil {
+			return args, false, err
+		}
+		ptr := nativeEndianUint64(ptrBuf)
+		if ptr == 0 {
+			break // NULL terminator
+		}
+
+		s, err := readStringFrom(r, ptr, 4096)
+		if err != nil {
+			return args, false, err
+		}
+
+		totalBytes += len(s) + 1
+		if totalBytes > maxBytes {
+			return args, true, nil // truncated
+		}
+		args = append(args, s)
+	}
+	return args, false, nil
+}
+
+func nativeEndianUint64(b []byte) uint64 {
+	// Little-endian (both amd64 and arm64 in Linux are LE)
+	return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24 |
+		uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56
+}
+```
+
+Note: The `readArgv` and `writeBytes` methods reference `t *Tracer` which will be defined in Task 12. Add a forward reference comment if needed, or move them there. The test only tests the reader abstraction directly.
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/ptrace/ -run TestReadString -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/ptrace/memory.go internal/ptrace/memory_test.go
+git commit -m "feat(ptrace): add memory access helpers via /proc/<tid>/mem"
+```
+
+---
+
+## Task 12: Syscall classification
+
+**Files:**
+- Create: `internal/ptrace/syscalls.go`
+- Create: `internal/ptrace/syscalls_test.go`
+
+**Step 1: Write failing tests**
+
+```go
+// internal/ptrace/syscalls_test.go
+//go:build linux
+
+package ptrace
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestIsExecveSyscall(t *testing.T) {
+	if !isExecveSyscall(unix.SYS_EXECVE) {
+		t.Error("SYS_EXECVE should be classified as execve")
+	}
+	if !isExecveSyscall(unix.SYS_EXECVEAT) {
+		t.Error("SYS_EXECVEAT should be classified as execve")
+	}
+	if isExecveSyscall(unix.SYS_READ) {
+		t.Error("SYS_READ should not be classified as execve")
+	}
+}
+
+func TestIsFileSyscall(t *testing.T) {
+	if !isFileSyscall(unix.SYS_OPENAT) {
+		t.Error("SYS_OPENAT should be a file syscall")
+	}
+	if !isFileSyscall(unix.SYS_UNLINKAT) {
+		t.Error("SYS_UNLINKAT should be a file syscall")
+	}
+	if isFileSyscall(unix.SYS_READ) {
+		t.Error("SYS_READ should not be a file syscall")
+	}
+}
+
+func TestIsNetworkSyscall(t *testing.T) {
+	if !isNetworkSyscall(unix.SYS_CONNECT) {
+		t.Error("SYS_CONNECT should be a network syscall")
+	}
+	if !isNetworkSyscall(unix.SYS_SOCKET) {
+		t.Error("SYS_SOCKET should be a network syscall")
+	}
+	if isNetworkSyscall(unix.SYS_READ) {
+		t.Error("SYS_READ should not be a network syscall")
+	}
+}
+
+func TestIsSignalSyscall(t *testing.T) {
+	if !isSignalSyscall(unix.SYS_KILL) {
+		t.Error("SYS_KILL should be a signal syscall")
+	}
+	if !isSignalSyscall(unix.SYS_TGKILL) {
+		t.Error("SYS_TGKILL should be a signal syscall")
+	}
+	if isSignalSyscall(unix.SYS_READ) {
+		t.Error("SYS_READ should not be a signal syscall")
+	}
+}
+
+func TestTracedSyscallNumbers(t *testing.T) {
+	nums := tracedSyscallNumbers()
+	if len(nums) < 10 {
+		t.Errorf("expected at least 10 traced syscalls, got %d", len(nums))
+	}
+	// Verify execve is in the list
+	found := false
+	for _, n := range nums {
+		if n == unix.SYS_EXECVE {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("SYS_EXECVE missing from traced syscalls")
+	}
+}
+```
+
+**Step 2: Run to verify failure**
+
+Run: `go test ./internal/ptrace/ -run TestIs -v`
+Expected: FAIL
+
+**Step 3: Implement**
+
+```go
+// internal/ptrace/syscalls.go
+//go:build linux
+
+package ptrace
+
+import "golang.org/x/sys/unix"
+
+func isExecveSyscall(nr int) bool {
+	return nr == unix.SYS_EXECVE || nr == unix.SYS_EXECVEAT
+}
+
+func isFileSyscall(nr int) bool {
+	switch nr {
+	case unix.SYS_OPENAT, unix.SYS_UNLINKAT, unix.SYS_MKDIRAT,
+		unix.SYS_RENAMEAT2, unix.SYS_LINKAT, unix.SYS_SYMLINKAT,
+		unix.SYS_FCHMODAT, unix.SYS_FCHOWNAT:
+		return true
+	}
+	return isLegacyFileSyscall(nr)
+}
+
+func isNetworkSyscall(nr int) bool {
+	switch nr {
+	case unix.SYS_CONNECT, unix.SYS_SOCKET, unix.SYS_BIND,
+		unix.SYS_SENDTO, unix.SYS_LISTEN:
+		return true
+	}
+	return false
+}
+
+func isSignalSyscall(nr int) bool {
+	switch nr {
+	case unix.SYS_KILL, unix.SYS_TGKILL, unix.SYS_TKILL,
+		unix.SYS_RT_SIGQUEUEINFO, unix.SYS_RT_TGSIGQUEUEINFO:
+		return true
+	}
+	return false
+}
+
+// tracedSyscallNumbers returns all syscall numbers that should be traced.
+// Used to build the seccomp prefilter BPF program.
+func tracedSyscallNumbers() []int {
+	nums := []int{
+		// Exec
+		unix.SYS_EXECVE, unix.SYS_EXECVEAT,
+		// File
+		unix.SYS_OPENAT, unix.SYS_UNLINKAT, unix.SYS_MKDIRAT,
+		unix.SYS_RENAMEAT2, unix.SYS_LINKAT, unix.SYS_SYMLINKAT,
+		unix.SYS_FCHMODAT, unix.SYS_FCHOWNAT,
+		// Network
+		unix.SYS_CONNECT, unix.SYS_SOCKET, unix.SYS_BIND,
+		unix.SYS_SENDTO, unix.SYS_LISTEN,
+		// Signal
+		unix.SYS_KILL, unix.SYS_TGKILL, unix.SYS_TKILL,
+		unix.SYS_RT_SIGQUEUEINFO, unix.SYS_RT_TGSIGQUEUEINFO,
+	}
+	nums = append(nums, legacyFileSyscalls()...)
+	return nums
+}
+```
+
+```go
+// internal/ptrace/syscalls_amd64.go
+//go:build linux && amd64
+
+package ptrace
+
+import "golang.org/x/sys/unix"
+
+func isLegacyFileSyscall(nr int) bool {
+	switch nr {
+	case unix.SYS_OPEN, unix.SYS_UNLINK, unix.SYS_RENAME,
+		unix.SYS_MKDIR, unix.SYS_RMDIR, unix.SYS_LINK,
+		unix.SYS_SYMLINK, unix.SYS_CHMOD, unix.SYS_CHOWN:
+		return true
+	}
+	return false
+}
+
+func legacyFileSyscalls() []int {
+	return []int{
+		unix.SYS_OPEN, unix.SYS_UNLINK, unix.SYS_RENAME,
+		unix.SYS_MKDIR, unix.SYS_RMDIR, unix.SYS_LINK,
+		unix.SYS_SYMLINK, unix.SYS_CHMOD, unix.SYS_CHOWN,
+	}
+}
+```
+
+```go
+// internal/ptrace/syscalls_arm64.go
+//go:build linux && arm64
+
+package ptrace
+
+// arm64 has no legacy file syscalls (only *at variants).
+func isLegacyFileSyscall(nr int) bool { return false }
+func legacyFileSyscalls() []int       { return nil }
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/ptrace/ -run "TestIs|TestTraced" -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/ptrace/syscalls.go internal/ptrace/syscalls_amd64.go internal/ptrace/syscalls_arm64.go internal/ptrace/syscalls_test.go
+git commit -m "feat(ptrace): add syscall classification for dispatch routing"
+```
+
+---
+
+## Task 13: Tracer struct, TraceeState, constructor, and ptrace options
+
+**Files:**
+- Create: `internal/ptrace/tracer.go`
+
+**Step 1: Write failing test**
+
+```go
+// internal/ptrace/tracer_test.go
+//go:build linux
+
+package ptrace
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestNewTracer(t *testing.T) {
+	cfg := TracerConfig{}
+	tr := NewTracer(cfg)
+	if tr == nil {
+		t.Fatal("NewTracer returned nil")
+	}
+	if tr.TraceeCount() != 0 {
+		t.Error("new tracer should have 0 tracees")
+	}
+}
+
+func TestPtraceOptions_WithPrefilter(t *testing.T) {
+	tr := &Tracer{prefilterActive: true}
+	opts := tr.ptraceOptions()
+	if opts&unix.PTRACE_O_EXITKILL == 0 {
+		t.Error("PTRACE_O_EXITKILL must always be set")
+	}
+	if opts&unix.PTRACE_O_TRACESECCOMP == 0 {
+		t.Error("PTRACE_O_TRACESECCOMP must be set when prefilter active")
+	}
+	if opts&unix.PTRACE_O_TRACESYSGOOD != 0 {
+		t.Error("PTRACE_O_TRACESYSGOOD must not be set when prefilter active")
+	}
+}
+
+func TestPtraceOptions_WithoutPrefilter(t *testing.T) {
+	tr := &Tracer{prefilterActive: false}
+	opts := tr.ptraceOptions()
+	if opts&unix.PTRACE_O_EXITKILL == 0 {
+		t.Error("PTRACE_O_EXITKILL must always be set")
+	}
+	if opts&unix.PTRACE_O_TRACESYSGOOD == 0 {
+		t.Error("PTRACE_O_TRACESYSGOOD must be set when no prefilter")
+	}
+	if opts&unix.PTRACE_O_TRACESECCOMP != 0 {
+		t.Error("PTRACE_O_TRACESECCOMP must not be set when no prefilter")
+	}
+}
+```
+
+**Step 2: Run to verify failure**
+
+Run: `go test ./internal/ptrace/ -run "TestNewTracer|TestPtraceOptions" -v`
+Expected: FAIL
+
+**Step 3: Implement**
+
+```go
+// internal/ptrace/tracer.go
+//go:build linux
+
+package ptrace
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// TracerConfig holds configuration for the ptrace tracer.
+type TracerConfig struct {
+	AttachMode       string
+	TargetPID        int
+	TargetPIDFile    string
+	TraceExecve      bool
+	TraceFile        bool
+	TraceNetwork     bool
+	TraceSignal      bool
+	SeccompPrefilter bool
+	MaxTracees       int
+	MaxHoldMs        int
+	OnAttachFailure  string
+}
+
+// TraceeState tracks the state of a single traced thread.
+type TraceeState struct {
+	TID              int
+	TGID             int
+	ParentPID        int
+	SessionID        string
+	InSyscall        bool
+	LastNr           int
+	Attached         time.Time
+	PendingDenyErrno int
+	PendingInterrupt bool
+	IsVforkChild     bool
+	MemFD            int
+}
+
+type resumeRequest struct {
+	TID   int
+	Allow bool
+	Errno int
+}
+
+// Tracer implements a ptrace-based syscall tracer.
+type Tracer struct {
+	cfg             TracerConfig
+	processTree     *ProcessTree
+	prefilterActive bool
+
+	attachQueue  chan int
+	resumeQueue  chan resumeRequest
+
+	mu            sync.Mutex
+	tracees       map[int]*TraceeState
+	parkedTracees map[int]struct{}
+
+	stopped chan struct{}
+}
+
+// NewTracer creates a new ptrace tracer.
+func NewTracer(cfg TracerConfig) *Tracer {
+	return &Tracer{
+		cfg:           cfg,
+		processTree:   NewProcessTree(),
+		attachQueue:   make(chan int, 64),
+		resumeQueue:   make(chan resumeRequest, 64),
+		tracees:       make(map[int]*TraceeState),
+		parkedTracees: make(map[int]struct{}),
+		stopped:       make(chan struct{}),
+	}
+}
+
+// TraceeCount returns the number of currently traced threads.
+func (t *Tracer) TraceeCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.tracees)
+}
+
+// AttachPID enqueues attachment to a process.
+// Safe to call from any goroutine.
+func (t *Tracer) AttachPID(pid int) error {
+	t.attachQueue <- pid
+	return nil
+}
+
+// Available returns whether ptrace tracing is available.
+func (t *Tracer) Available() bool {
+	return true // If Tracer was created, ptrace is available
+}
+
+// Implementation returns "ptrace".
+func (t *Tracer) Implementation() string {
+	return "ptrace"
+}
+
+func (t *Tracer) ptraceOptions() int {
+	opts := unix.PTRACE_O_TRACECLONE |
+		unix.PTRACE_O_TRACEFORK |
+		unix.PTRACE_O_TRACEVFORK |
+		unix.PTRACE_O_TRACEEXEC |
+		unix.PTRACE_O_TRACEEXIT |
+		unix.PTRACE_O_EXITKILL
+
+	if t.prefilterActive {
+		opts |= unix.PTRACE_O_TRACESECCOMP
+	} else {
+		opts |= unix.PTRACE_O_TRACESYSGOOD
+	}
+
+	return opts
+}
+
+func (t *Tracer) getRegs(tid int) (Regs, error) {
+	return getRegsArch(tid)
+}
+
+func (t *Tracer) setRegs(tid int, regs Regs) error {
+	return setRegsArch(tid, regs)
+}
+```
+
+**Step 4: Run tests**
+
+Run: `go test ./internal/ptrace/ -run "TestNewTracer|TestPtraceOptions" -v`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add internal/ptrace/tracer.go internal/ptrace/tracer_test.go
+git commit -m "feat(ptrace): add Tracer struct, TraceeState, constructor, and ptrace options"
+```
+
+---
+
+## Task 14: Attachment — attachThread, attachProcess, safeDetach
+
+**Files:**
+- Create: `internal/ptrace/attach.go`
+
+**Step 1: Implement** (tests require SYS_PTRACE — deferred to integration tests in Task 18)
+
+```go
+// internal/ptrace/attach.go
+//go:build linux
+
+package ptrace
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// attachProcess attaches to all threads of a process.
+func (t *Tracer) attachProcess(pid int) error {
+	taskDir := fmt.Sprintf("/proc/%d/task", pid)
+	entries, err := os.ReadDir(taskDir)
+	if err != nil {
+		return t.attachThread(pid)
+	}
+
+	var firstErr error
+	for _, e := range entries {
+		tid, err := strconv.Atoi(e.Name())
+		if err != nil {
+			continue
+		}
+		if err := t.attachThread(tid); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			slog.Warn("failed to attach thread", "tid", tid, "pid", pid, "error", err)
+		}
+	}
+	return firstErr
+}
+
+// attachThread attaches to a single thread via PTRACE_SEIZE.
+func (t *Tracer) attachThread(tid int) error {
+	err := unix.PtraceSeize(tid, t.ptraceOptions())
+	if err != nil {
+		return fmt.Errorf("PTRACE_SEIZE tid %d: %w", tid, err)
+	}
+
+	tgid, err := readTGID(tid)
+	if err != nil {
+		t.safeDetach(tid)
+		return fmt.Errorf("read TGID for tid %d: %w", tid, err)
+	}
+
+	if err := unix.PtraceInterrupt(tid); err != nil {
+		t.safeDetach(tid)
+		return fmt.Errorf("PTRACE_INTERRUPT tid %d: %w", tid, err)
+	}
+
+	var status unix.WaitStatus
+	_, err = unix.Wait4(tid, &status, 0, nil)
+	if err != nil {
+		t.safeDetach(tid)
+		return fmt.Errorf("wait4 after interrupt tid %d: %w", tid, err)
+	}
+
+	if !status.Stopped() {
+		t.safeDetach(tid)
+		return fmt.Errorf("tid %d: expected ptrace-stop after interrupt, got status %v", tid, status)
+	}
+
+	// Restart in the appropriate tracing mode
+	if t.prefilterActive {
+		err = unix.PtraceCont(tid, 0)
+	} else {
+		err = unix.PtraceSyscall(tid, 0)
+	}
+	if err != nil {
+		unix.PtraceDetach(tid)
+		return fmt.Errorf("restart tid %d: %w", tid, err)
+	}
+
+	// Open /proc/<tid>/mem for memory reads
+	memFD := -1
+	fd, err := unix.Open(fmt.Sprintf("/proc/%d/mem", tid), unix.O_RDWR, 0)
+	if err != nil {
+		fd, _ = unix.Open(fmt.Sprintf("/proc/%d/mem", tid), unix.O_RDONLY, 0)
+	}
+	memFD = fd
+
+	t.mu.Lock()
+	t.tracees[tid] = &TraceeState{
+		TID:      tid,
+		TGID:     tgid,
+		Attached: time.Now(),
+		MemFD:    memFD,
+	}
+	t.mu.Unlock()
+
+	return nil
+}
+
+// safeDetach detaches from a seized tracee that may not be in ptrace-stop.
+func (t *Tracer) safeDetach(tid int) {
+	if err := unix.PtraceInterrupt(tid); err != nil {
+		return
+	}
+	var status unix.WaitStatus
+	if _, err := unix.Wait4(tid, &status, 0, nil); err != nil {
+		return
+	}
+	if status.Stopped() {
+		unix.PtraceDetach(tid)
+	}
+}
+```
+
+**Step 2: Verify build**
+
+Run: `go build ./internal/ptrace/`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add internal/ptrace/attach.go
+git commit -m "feat(ptrace): add process/thread attachment via PTRACE_SEIZE"
+```
+
+---
+
+## Task 15: allow/deny/resume primitives and stop event dispatcher
+
+**Files:**
+- Modify: `internal/ptrace/tracer.go`
+
+**Step 1: Add syscall primitives and event handlers**
+
+Append to `tracer.go`:
+
+```go
+// allowSyscall resumes the tracee, allowing the syscall to proceed.
+func (t *Tracer) allowSyscall(tid int) {
+	if t.prefilterActive {
+		unix.PtraceCont(tid, 0)
+	} else {
+		unix.PtraceSyscall(tid, 0)
+	}
+}
+
+// denySyscall invalidates the current syscall and arranges for return value fixup.
+func (t *Tracer) denySyscall(tid int, errno int) error {
+	regs, err := t.getRegs(tid)
+	if err != nil {
+		return err
+	}
+	regs.SetSyscallNr(-1)
+	if err := t.setRegs(tid, regs); err != nil {
+		// Cannot deny — kill the tracee to prevent the syscall from executing.
+		t.mu.Lock()
+		state := t.tracees[tid]
+		tgid := tid
+		if state != nil {
+			tgid = state.TGID
+		}
+		t.mu.Unlock()
+		unix.Tgkill(tgid, tid, unix.SIGKILL)
+		return fmt.Errorf("deny failed, killed tid %d: %w", tid, err)
+	}
+
+	t.mu.Lock()
+	if state, ok := t.tracees[tid]; ok {
+		state.PendingDenyErrno = errno
+		state.InSyscall = true
+	}
+	t.mu.Unlock()
+
+	return unix.PtraceSyscall(tid, 0)
+}
+
+// resumeTracee resumes a tracee with an optional signal to deliver.
+func (t *Tracer) resumeTracee(tid int, sig int) {
+	if t.prefilterActive {
+		unix.PtraceCont(tid, sig)
+	} else {
+		unix.PtraceSyscall(tid, sig)
+	}
+}
+
+// applyDenyFixup overwrites the syscall return value with -errno.
+func (t *Tracer) applyDenyFixup(tid int, errno int) {
+	regs, err := t.getRegs(tid)
+	if err != nil {
+		return
+	}
+	regs.SetReturnValue(-int64(errno))
+	t.setRegs(tid, regs)
+}
+
+// handleStop dispatches a tracee stop event.
+func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus) {
+	switch {
+	case status.Exited() || status.Signaled():
+		t.handleExit(tid)
+
+	case status.Stopped():
+		sig := status.StopSignal()
+
+		switch {
+		case sig == unix.SIGTRAP|0x80:
+			t.handleSyscallStop(ctx, tid)
+
+		case sig == unix.SIGTRAP:
+			event := status.TrapCause()
+			switch event {
+			case unix.PTRACE_EVENT_FORK, unix.PTRACE_EVENT_CLONE:
+				t.handleNewChild(tid, event)
+				t.resumeTracee(tid, 0)
+			case unix.PTRACE_EVENT_VFORK:
+				t.handleNewChild(tid, event)
+				t.markVforkChild(tid)
+				t.resumeTracee(tid, 0)
+			case unix.PTRACE_EVENT_EXEC:
+				t.handleExecEvent(tid)
+				t.resumeTracee(tid, 0)
+			case unix.PTRACE_EVENT_SECCOMP:
+				t.handleSeccompStop(ctx, tid)
+			case unix.PTRACE_EVENT_EXIT:
+				t.resumeTracee(tid, 0)
+			case unix.PTRACE_EVENT_STOP:
+				t.handleEventStop(tid)
+			default:
+				t.resumeTracee(tid, 0)
+			}
+
+		default:
+			t.resumeTracee(tid, int(sig))
+		}
+	}
+}
+
+// handleSyscallStop handles SIGTRAP|0x80 stops (TRACESYSGOOD mode).
+func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
+	t.mu.Lock()
+	state := t.tracees[tid]
+	if state == nil {
+		t.mu.Unlock()
+		t.allowSyscall(tid)
+		return
+	}
+	entering := !state.InSyscall
+	state.InSyscall = entering
+	pendingErrno := 0
+	if !entering {
+		pendingErrno = state.PendingDenyErrno
+		state.PendingDenyErrno = 0
+	}
+	t.mu.Unlock()
+
+	if entering {
+		regs, err := t.getRegs(tid)
+		if err != nil {
+			t.allowSyscall(tid)
+			return
+		}
+		nr := regs.SyscallNr()
+		t.mu.Lock()
+		state.LastNr = nr
+		t.mu.Unlock()
+
+		t.dispatchSyscall(ctx, tid, nr, regs)
+	} else {
+		if pendingErrno != 0 {
+			t.applyDenyFixup(tid, pendingErrno)
+		}
+		t.allowSyscall(tid)
+	}
+}
+
+// handleSeccompStop handles PTRACE_EVENT_SECCOMP stops (prefilter mode).
+func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
+	regs, err := t.getRegs(tid)
+	if err != nil {
+		t.allowSyscall(tid)
+		return
+	}
+	nr := regs.SyscallNr()
+	t.dispatchSyscall(ctx, tid, nr, regs)
+}
+
+// dispatchSyscall routes a syscall to the appropriate handler.
+func (t *Tracer) dispatchSyscall(ctx context.Context, tid int, nr int, regs Regs) {
+	switch {
+	case isExecveSyscall(nr):
+		t.handleExecve(ctx, tid, regs)
+	// Phase 1: file, network, signal handlers are stubs that allow
+	case isFileSyscall(nr):
+		t.allowSyscall(tid)
+	case isNetworkSyscall(nr):
+		t.allowSyscall(tid)
+	case isSignalSyscall(nr):
+		t.allowSyscall(tid)
+	default:
+		t.allowSyscall(tid)
+	}
+}
+
+// handleNewChild processes a fork/clone/vfork event.
+func (t *Tracer) handleNewChild(parentTID int, event int) {
+	childTID, err := unix.PtraceGetEventMsg(parentTID)
+	if err != nil {
+		return
+	}
+	tid := int(childTID)
+
+	childTGID, err := readTGID(tid)
+	if err != nil {
+		slog.Warn("handleNewChild: cannot read TGID", "tid", tid, "error", err)
+		return
+	}
+
+	t.mu.Lock()
+	parent := t.tracees[parentTID]
+	if parent == nil {
+		t.mu.Unlock()
+		return
+	}
+
+	isNewProcess := childTGID != parent.TGID
+
+	t.tracees[tid] = &TraceeState{
+		TID:       tid,
+		TGID:      childTGID,
+		ParentPID: parent.TGID,
+		SessionID: parent.SessionID,
+		Attached:  time.Now(),
+	}
+	t.mu.Unlock()
+
+	if isNewProcess {
+		t.processTree.AddChild(parent.TGID, childTGID)
+	}
+}
+
+// markVforkChild marks the child as a vfork child.
+func (t *Tracer) markVforkChild(parentTID int) {
+	childTID, err := unix.PtraceGetEventMsg(parentTID)
+	if err != nil {
+		return
+	}
+	t.mu.Lock()
+	if state, ok := t.tracees[int(childTID)]; ok {
+		state.IsVforkChild = true
+	}
+	t.mu.Unlock()
+}
+
+// handleExecEvent handles PTRACE_EVENT_EXEC.
+func (t *Tracer) handleExecEvent(tid int) {
+	t.mu.Lock()
+	state := t.tracees[tid]
+	if state == nil {
+		t.mu.Unlock()
+		return
+	}
+	state.IsVforkChild = false
+
+	formerTID, err := unix.PtraceGetEventMsg(tid)
+	if err == nil && int(formerTID) != tid {
+		delete(t.tracees, int(formerTID))
+	}
+
+	tgid := state.TGID
+	for otherTID, otherState := range t.tracees {
+		if otherState.TGID == tgid && otherTID != tid {
+			if otherState.MemFD >= 0 {
+				unix.Close(otherState.MemFD)
+			}
+			delete(t.tracees, otherTID)
+		}
+	}
+	t.mu.Unlock()
+}
+
+// handleExit removes a tracee from the map.
+func (t *Tracer) handleExit(tid int) {
+	t.mu.Lock()
+	state := t.tracees[tid]
+	if state != nil {
+		if state.MemFD >= 0 {
+			unix.Close(state.MemFD)
+		}
+		delete(t.tracees, tid)
+	}
+	t.mu.Unlock()
+}
+
+// handleEventStop distinguishes PTRACE_INTERRUPT responses from group-stops.
+func (t *Tracer) handleEventStop(tid int) {
+	t.mu.Lock()
+	state := t.tracees[tid]
+	if state != nil && state.PendingInterrupt {
+		state.PendingInterrupt = false
+		t.mu.Unlock()
+		t.resumeTracee(tid, 0)
+		return
+	}
+	t.mu.Unlock()
+	unix.PtraceListen(tid)
+}
+
+// handleExecve is a stub for Phase 1 — to be replaced in Task 17.
+func (t *Tracer) handleExecve(ctx context.Context, tid int, regs Regs) {
+	t.allowSyscall(tid)
+}
+```
+
+**Step 2: Verify build**
+
+Run: `go build ./internal/ptrace/`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add internal/ptrace/tracer.go
+git commit -m "feat(ptrace): add allow/deny primitives, stop dispatcher, and event handlers"
+```
+
+---
+
+## Task 16: Main event loop — Run()
+
+**Files:**
+- Modify: `internal/ptrace/tracer.go`
+
+**Step 1: Implement Run(), drainQueues(), handleResumeRequest()**
+
+Append to `tracer.go`:
+
+```go
+// Run starts the ptrace event loop. Blocks until ctx is cancelled or all tracees exit.
+func (t *Tracer) Run(ctx context.Context) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	for {
+		if err := t.drainQueues(ctx); err != nil {
+			return err
+		}
+
+		var status unix.WaitStatus
+		tid, err := unix.Wait4(-1, &status, unix.WALL|unix.WNOHANG, nil)
+
+		if err != nil {
+			if err == unix.EINTR {
+				continue
+			}
+			if err == unix.ECHILD {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-t.stopped:
+					return nil
+				case pid := <-t.attachQueue:
+					if err := t.attachProcess(pid); err != nil {
+						slog.Error("attach from queue failed", "pid", pid, "error", err)
+					}
+					continue
+				case req := <-t.resumeQueue:
+					t.handleResumeRequest(req)
+					continue
+				}
+			}
+			return fmt.Errorf("wait4: %w", err)
+		}
+
+		if tid == 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-t.stopped:
+				return nil
+			case pid := <-t.attachQueue:
+				if err := t.attachProcess(pid); err != nil {
+					slog.Error("attach from queue failed", "pid", pid, "error", err)
+				}
+			case req := <-t.resumeQueue:
+				t.handleResumeRequest(req)
+			case <-time.After(5 * time.Millisecond):
+			}
+			continue
+		}
+
+		t.handleStop(ctx, tid, status)
+	}
+}
+
+// Start implements the SyscallTracer interface.
+func (t *Tracer) Start(ctx context.Context) error {
+	return t.Run(ctx)
+}
+
+// Stop signals the event loop to exit.
+func (t *Tracer) Stop() {
+	select {
+	case <-t.stopped:
+	default:
+		close(t.stopped)
+	}
+}
+
+func (t *Tracer) drainQueues(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-t.stopped:
+			return fmt.Errorf("tracer stopped")
+		case pid := <-t.attachQueue:
+			if err := t.attachProcess(pid); err != nil {
+				slog.Error("attach from queue failed", "pid", pid, "error", err)
+			}
+		case req := <-t.resumeQueue:
+			t.handleResumeRequest(req)
+		default:
+			return nil
+		}
+	}
+}
+
+func (t *Tracer) handleResumeRequest(req resumeRequest) {
+	t.mu.Lock()
+	_, parked := t.parkedTracees[req.TID]
+	if parked {
+		delete(t.parkedTracees, req.TID)
+	}
+	t.mu.Unlock()
+
+	if !parked {
+		slog.Warn("resume request for non-parked tracee", "tid", req.TID)
+		return
+	}
+
+	if req.Allow {
+		t.allowSyscall(req.TID)
+	} else {
+		t.denySyscall(req.TID, req.Errno)
+	}
+}
+```
+
+Add `"runtime"` to imports.
+
+**Step 2: Verify build**
+
+Run: `go build ./internal/ptrace/`
+Expected: PASS
+
+**Step 3: Commit**
+
+```bash
+git add internal/ptrace/tracer.go
+git commit -m "feat(ptrace): implement main event loop with WNOHANG + channel select"
+```
+
+---
+
+## Task 17: ExecveHandler integration
+
+**Files:**
+- Modify: `internal/ptrace/tracer.go` — add ExecHandler interface and field
+- Modify the stub `handleExecve` from Task 15
+
+**Step 1: Define local ExecHandler interface**
+
+This avoids coupling to the CGO-dependent `internal/netmonitor/unix` package:
+
+```go
+// ExecHandler evaluates execve policy. Implemented by an adapter wrapping
+// the existing internal/netmonitor/unix.ExecveHandler.
+type ExecHandler interface {
+	HandleExecve(ctx context.Context, ec ExecContext) ExecResult
+}
+
+// ExecContext carries execve information for policy evaluation.
+type ExecContext struct {
+	PID       int
+	ParentPID int
+	Filename  string
+	Argv      []string
+	Truncated bool
+	SessionID string
+	Depth     int
+}
+
+// ExecResult carries the policy decision.
+type ExecResult struct {
+	Allow  bool
+	Action string // "continue", "deny", "redirect"
+	Errno  int32
+	Rule   string
+	Reason string
+}
+```
+
+Add `execHandler ExecHandler` field to `Tracer` struct. Accept it in `TracerConfig`.
+
+**Step 2: Replace the stub handleExecve**
+
+```go
+func (t *Tracer) handleExecve(ctx context.Context, tid int, regs Regs) {
+	if t.cfg.ExecHandler == nil || !t.cfg.TraceExecve {
+		t.allowSyscall(tid)
+		return
+	}
+
+	nr := regs.SyscallNr()
+	var filenamePtr uint64
+	if nr == unix.SYS_EXECVEAT {
+		filenamePtr = regs.Arg(1)
+	} else {
+		filenamePtr = regs.Arg(0)
+	}
+
+	filename, err := t.readString(tid, filenamePtr, 4096)
+	if err != nil {
+		slog.Warn("handleExecve: cannot read filename", "tid", tid, "error", err)
+		t.allowSyscall(tid)
+		return
+	}
+
+	var argvPtr uint64
+	if nr == unix.SYS_EXECVEAT {
+		argvPtr = regs.Arg(2)
+	} else {
+		argvPtr = regs.Arg(1)
+	}
+
+	argv, truncated, err := t.readArgv(tid, argvPtr, 1000, 65536)
+	if err != nil {
+		slog.Warn("handleExecve: cannot read argv", "tid", tid, "error", err)
+		t.allowSyscall(tid)
+		return
+	}
+
+	t.mu.Lock()
+	state := t.tracees[tid]
+	var tgid, parentPID int
+	var sessionID string
+	if state != nil {
+		tgid = state.TGID
+		parentPID = state.ParentPID
+		sessionID = state.SessionID
+	}
+	t.mu.Unlock()
+
+	depth := t.processTree.Depth(tgid)
+
+	result := t.cfg.ExecHandler.HandleExecve(ctx, ExecContext{
+		PID:       tgid,
+		ParentPID: parentPID,
+		Filename:  filename,
+		Argv:      argv,
+		Truncated: truncated,
+		SessionID: sessionID,
+		Depth:     depth,
+	})
+
+	switch result.Action {
+	case "deny":
+		errno := result.Errno
+		if errno == 0 {
+			errno = int32(unix.EACCES)
+		}
+		t.denySyscall(tid, int(errno))
+	default:
+		t.allowSyscall(tid)
+	}
+}
+```
+
+Update `TracerConfig`:
+```go
+type TracerConfig struct {
+	// ... existing fields ...
+	ExecHandler ExecHandler
+}
+```
+
+And store it:
+```go
+func NewTracer(cfg TracerConfig) *Tracer {
+	return &Tracer{
+		cfg:           cfg,
+		// ... rest unchanged ...
+	}
+}
+```
+
+**Step 3: Verify build**
+
+Run: `go build ./internal/ptrace/`
+Expected: PASS
+
+**Step 4: Commit**
+
+```bash
+git add internal/ptrace/tracer.go
+git commit -m "feat(ptrace): integrate ExecHandler for command allow/deny policy"
+```
+
+---
+
+## Task 18: Integration tests
+
+**Files:**
+- Create: `internal/ptrace/integration_test.go`
+
+Build tag: `//go:build integration && linux`
+
+These tests require `SYS_PTRACE` capability. Run with:
+```bash
+go test -tags integration -v ./internal/ptrace/ -run TestIntegration -count=1
+```
+
+Or in Docker:
+```bash
+docker run --cap-add SYS_PTRACE --security-opt seccomp=unconfined -v $(pwd):/src -w /src golang:1.23 \
+  go test -tags integration -v ./internal/ptrace/ -run TestIntegration -count=1
+```
+
+```go
+// internal/ptrace/integration_test.go
+//go:build integration && linux
+
+package ptrace
+
+import (
+	"context"
+	"os/exec"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func requirePtrace(t *testing.T) {
+	t.Helper()
+	cmd := exec.Command("/bin/sleep", "0.01")
+	if err := cmd.Start(); err != nil {
+		t.Skip("cannot start child process")
+	}
+	pid := cmd.Process.Pid
+	err := unix.PtraceSeize(pid, 0)
+	cmd.Process.Kill()
+	cmd.Wait()
+	if err != nil {
+		t.Skipf("ptrace not available: %v", err)
+	}
+	// Clean up: interrupt + wait + detach would be needed if seize succeeded,
+	// but we killed the process above, so the tracee is gone.
+}
+
+func TestIntegration_AttachDetach(t *testing.T) {
+	requirePtrace(t)
+
+	cmd := exec.Command("/bin/sleep", "5")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Process.Kill()
+	defer cmd.Wait()
+
+	cfg := TracerConfig{TraceExecve: true}
+	tr := NewTracer(cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Run tracer in background
+	errCh := make(chan error, 1)
+	go func() { errCh <- tr.Run(ctx) }()
+
+	// Send attach request
+	tr.AttachPID(cmd.Process.Pid)
+
+	// Wait a bit for attachment
+	time.Sleep(200 * time.Millisecond)
+
+	if tr.TraceeCount() == 0 {
+		t.Error("expected at least 1 tracee after attach")
+	}
+
+	cancel()
+	<-errCh
+}
+
+type mockExecHandler struct {
+	mu      sync.Mutex
+	calls   []ExecContext
+	allow   bool
+	errno   int32
+}
+
+func (m *mockExecHandler) HandleExecve(ctx context.Context, ec ExecContext) ExecResult {
+	m.mu.Lock()
+	m.calls = append(m.calls, ec)
+	m.mu.Unlock()
+
+	action := "continue"
+	if !m.allow {
+		action = "deny"
+	}
+	return ExecResult{
+		Allow:  m.allow,
+		Action: action,
+		Errno:  m.errno,
+	}
+}
+
+func TestIntegration_ExecveAllow(t *testing.T) {
+	requirePtrace(t)
+
+	handler := &mockExecHandler{allow: true}
+	cfg := TracerConfig{
+		TraceExecve: true,
+		ExecHandler: handler,
+	}
+	tr := NewTracer(cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- tr.Run(ctx) }()
+
+	cmd := exec.Command("/bin/echo", "hello")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	tr.AttachPID(cmd.Process.Pid)
+
+	err := cmd.Wait()
+	cancel()
+	<-errCh
+
+	if err != nil {
+		t.Errorf("child should have succeeded: %v", err)
+	}
+
+	handler.mu.Lock()
+	defer handler.mu.Unlock()
+	if len(handler.calls) == 0 {
+		t.Log("Note: execve handler may not have been called if attach happened after exec")
+	}
+}
+
+func TestIntegration_ForkTree(t *testing.T) {
+	requirePtrace(t)
+
+	cfg := TracerConfig{TraceExecve: true}
+	tr := NewTracer(cfg)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- tr.Run(ctx) }()
+
+	// Shell that forks a child
+	cmd := exec.Command("/bin/sh", "-c", "echo parent; /bin/sh -c 'echo child'")
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	tr.AttachPID(cmd.Process.Pid)
+	cmd.Wait()
+
+	// Give tracer a moment to process events
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+	<-errCh
+
+	if tr.processTree.Size() > 0 {
+		t.Logf("process tree tracked %d processes", tr.processTree.Size())
+	}
+}
+```
+
+**Step 1: Run tests (in Docker or with SYS_PTRACE)**
+
+Run: `go test -tags integration -v ./internal/ptrace/ -run TestIntegration -count=1 -timeout 30s`
+Expected: Tests pass (or skip if SYS_PTRACE unavailable)
+
+**Step 2: Commit**
+
+```bash
+git add internal/ptrace/integration_test.go
+git commit -m "test(ptrace): add integration tests for attach, execve, and fork tree"
+```
+
+---
+
+## Task 19: Cross-compilation and full build verification
+
+**Files:** None — verification only
+
+**Step 1: Run all unit tests**
+
+Run: `go test ./internal/ptrace/... -v`
+Expected: PASS
+
+**Step 2: Run all capability tests**
+
+Run: `go test ./internal/capabilities/... -v`
+Expected: PASS
+
+**Step 3: Run all config tests**
+
+Run: `go test ./internal/config/... -v`
+Expected: PASS
+
+**Step 4: Full build**
+
+Run: `go build ./...`
+Expected: PASS
+
+**Step 5: Cross-compile check**
+
+Run: `GOOS=windows go build ./... && GOARCH=arm64 go build ./internal/ptrace/`
+Expected: PASS (non-Linux platforms skip ptrace package via build tags)
+
+**Step 6: Commit (if any fixups needed)**
+
+```bash
+git commit -m "fix: resolve cross-compilation issues for ptrace package"
+```
+
+---
+
+## Verification
+
+After completing all tasks:
+
+1. **Unit tests:** `go test ./internal/ptrace/... ./internal/capabilities/... ./internal/config/... -v -race`
+2. **Integration tests (Docker):**
+   ```bash
+   docker run --cap-add SYS_PTRACE --security-opt seccomp=unconfined \
+     -v $(pwd):/src -w /src golang:1.23 \
+     go test -tags integration -v ./internal/ptrace/ -run TestIntegration -count=1 -timeout 30s
+   ```
+3. **Cross-compile:** `GOOS=windows go build ./... && GOOS=darwin go build ./...`
+4. **Full test suite:** `go test ./... -count=1`

--- a/docs/plans/2026-03-15-seccomp-prefilter-injection-design.md
+++ b/docs/plans/2026-03-15-seccomp-prefilter-injection-design.md
@@ -1,7 +1,7 @@
 # Design: Seccomp Prefilter Injection for Server-Wired Ptrace Mode
 
 **Date:** 2026-03-15
-**Status:** Draft
+**Status:** Implemented
 
 ---
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -29,7 +29,7 @@ agentsh/
 - `internal/fsmonitor/` — FUSE workspace view + file operation capture.
 - `internal/netmonitor/` — Network proxy + DNS cache/resolver and optional netns/transparent plumbing.
 - `internal/limits/` — Optional cgroups v2 enforcement (Linux-only; wired from exec hooks).
-- `internal/ptrace/` — Ptrace-based syscall tracer for restricted containers (Linux-only, requires SYS_PTRACE). Intercepts exec, file, network, and signal syscalls via PTRACE_SEIZE. Architecture-specific register access (amd64, arm64). Wired into the server via `internal/api/` for both exec and wrap paths. Includes `AttachOption` functional options for session/command association and keepStopped control, `WaitAttached`/`ResumePID` for synchronous attach flow. `Metrics` interface with Prometheus adapter (`metrics.go`, `metrics_prometheus.go`) and overhead benchmarks (`benchmark_test.go`).
+- `internal/ptrace/` — Ptrace-based syscall tracer for restricted containers (Linux-only, requires SYS_PTRACE). Intercepts exec, file, network, and signal syscalls via PTRACE_SEIZE. Architecture-specific register access (amd64, arm64). Wired into the server via `internal/api/` for both exec and wrap paths. Includes `AttachOption` functional options for session/command association and keepStopped control, `WaitAttached`/`ResumePID` for synchronous attach flow. Seccomp prefilter injection (`inject_seccomp.go`, `seccomp_filter.go`) for reduced overhead. `Metrics` interface with Prometheus adapter (`metrics.go`, `metrics_prometheus.go`) and overhead benchmarks (`benchmark_test.go`).
 - `internal/events/` — In-memory event broker for SSE.
 - `internal/store/` — Event sinks (SQLite, JSONL, webhook) and composition.
 - `internal/auth/` — API key auth implementation.

--- a/docs/ptrace-support.md
+++ b/docs/ptrace-support.md
@@ -1847,6 +1847,20 @@ Phase 4 brings ptrace mode to full feature parity with seccomp+FUSE for redirect
 
 **Deliverable:** ptrace exec paths complete reliably without `cmd.Wait()` hangs. Exit codes, signals, and resource usage preserved.
 
+### Phase 5c: Seccomp Prefilter Injection ✓
+
+- **Problem**: without the seccomp prefilter, every syscall generates a ptrace stop (~10-50x overhead)
+- **Fix**: inject seccomp-BPF filter into traced processes at attach time via `injectSyscall` engine
+- `buildPrefilterBPF()` generates BPF from `tracedSyscallNumbers()` — single source of truth, architecture-validated (AUDIT_ARCH check, fail-closed on mismatch)
+- `injectSeccompFilter(tid)` writes BPF to tracee scratch page, injects `prctl(PR_SET_NO_NEW_PRIVS)` + `seccomp(SECCOMP_SET_MODE_FILTER)`. Non-fatal on failure.
+- Per-tracee `HasPrefilter`/`PendingPrefilter` replacing global `prefilterActive`. Children inherit via `handleNewChild`.
+- Deferred injection at first syscall EXIT (not at attach interrupt stop). `InSyscall` state managed around injection.
+- `handleSeccompStop` sets `LastNr` for exit-time handlers
+- `ptraceOptions` conditionally sets `PTRACE_O_TRACESECCOMP` when prefilter enabled
+- Known limitation: `PtraceSyscall` used uniformly (not `PtraceCont`) to preserve exit-time handlers; per-syscall resume optimization planned
+
+**Deliverable:** seccomp prefilter infrastructure in place. BPF filter injected into traced processes. Foundation for per-syscall resume optimization.
+
 ---
 
 ## 15. Phase 4 Design: Exec Redirect via ptrace

--- a/docs/security-modes.md
+++ b/docs/security-modes.md
@@ -209,8 +209,9 @@ Ptrace mode exposes Prometheus metrics at the `/metrics` endpoint:
 
 3. **Performance overhead**
    - Each traced syscall requires two context switches (entry + exit) in TRACESYSGOOD mode
-   - Seccomp prefilter (`seccomp_prefilter: true`) reduces overhead by only trapping traced syscalls; note: the prefilter is currently only active in standalone sidecar mode, not in server-wired mode (requires BPF injection, planned)
-   - Without the prefilter (server-wired mode), overhead is ~10-50x due to trapping all syscalls
+   - Seccomp prefilter (`seccomp_prefilter: true`) injects a BPF filter that returns `SECCOMP_RET_TRACE` only for traced syscalls; non-traced syscalls pass through at kernel speed
+   - The prefilter is injected via ptrace syscall injection at attach time; injection failure falls back to TRACESYSGOOD (all syscalls trapped)
+   - Note: exit-time handlers (TracerPid masking, fd tracking, TLS SNI) require `PtraceSyscall` after entry, so non-traced syscalls still generate exit stops in prefilter mode. A per-syscall resume optimization is planned.
    - Single-threaded event loop may become a bottleneck with many concurrent tracees
    - Mitigation: Prometheus metrics (`agentsh_ptrace_tracees_active`, `agentsh_ptrace_timeouts_total`) help identify bottlenecks
 

--- a/internal/ptrace/attach.go
+++ b/internal/ptrace/attach.go
@@ -107,22 +107,9 @@ func (t *Tracer) attachThread(tid int, opts attachOpts) error {
 		return fmt.Errorf("read TGID for tid %d: %w", tid, err)
 	}
 
-	if opts.keepStopped {
-		// Leave tracee stopped for cgroup hook; register in parkedTracees
-		// so ResumePID (via handleResumeRequest) can find and resume it.
-	} else {
-		// HasPrefilter is always false for freshly attached threads
-		// (injection hasn't happened yet), so this takes the PtraceSyscall
-		// path. When injection is wired in, HasPrefilter will be set to
-		// true and this will use PtraceCont instead.
-		err = unix.PtraceSyscall(tid, 0)
-	}
-	if err != nil {
-		unix.PtraceDetach(tid)
-		t.metrics.IncAttachFailure("other")
-		return fmt.Errorf("restart tid %d: %w", tid, err)
-	}
-
+	// Open MemFD and create TraceeState BEFORE injection and resume.
+	// The injection engine needs TraceeState (for scratch page) and MemFD
+	// (for register read/write during injectSyscall).
 	memFD := -1
 	fd, err := unix.Open(fmt.Sprintf("/proc/%d/mem", tid), unix.O_RDWR, 0)
 	if err != nil {
@@ -147,6 +134,44 @@ func (t *Tracer) attachThread(tid int, opts attachOpts) error {
 	}
 	t.metrics.SetTraceeCount(len(t.tracees))
 	t.mu.Unlock()
+
+	// Inject seccomp prefilter for explicitly-attached processes.
+	// Only inject when sessionID is set (exec/wrap path), not for
+	// auto-traced children (which inherit the filter via fork).
+	if t.cfg.SeccompPrefilter && opts.sessionID != "" {
+		if injErr := t.injectSeccompFilter(tid); injErr != nil {
+			slog.Warn("seccomp prefilter injection failed, falling back to TRACESYSGOOD",
+				"tid", tid, "error", injErr)
+		} else {
+			t.mu.Lock()
+			if s := t.tracees[tid]; s != nil {
+				s.HasPrefilter = true
+			}
+			t.mu.Unlock()
+		}
+	}
+
+	// Resume the tracee (unless keepStopped for cgroup hook).
+	if opts.keepStopped {
+		// Already registered in parkedTracees above.
+	} else {
+		t.mu.Lock()
+		hasPrefilter := false
+		if s := t.tracees[tid]; s != nil {
+			hasPrefilter = s.HasPrefilter
+		}
+		t.mu.Unlock()
+		if hasPrefilter {
+			err = unix.PtraceCont(tid, 0)
+		} else {
+			err = unix.PtraceSyscall(tid, 0)
+		}
+	}
+	if err != nil {
+		unix.PtraceDetach(tid)
+		t.metrics.IncAttachFailure("other")
+		return fmt.Errorf("restart tid %d: %w", tid, err)
+	}
 
 	return nil
 }

--- a/internal/ptrace/attach.go
+++ b/internal/ptrace/attach.go
@@ -168,6 +168,17 @@ func (t *Tracer) attachThread(tid int, opts attachOpts) error {
 		}
 	}
 	if err != nil {
+		// Rollback: clean up TraceeState and MemFD on resume failure
+		t.mu.Lock()
+		if s := t.tracees[tid]; s != nil {
+			if s.MemFD >= 0 {
+				unix.Close(s.MemFD)
+			}
+			delete(t.tracees, tid)
+			delete(t.parkedTracees, tid)
+			t.metrics.SetTraceeCount(len(t.tracees))
+		}
+		t.mu.Unlock()
 		unix.PtraceDetach(tid)
 		t.metrics.IncAttachFailure("other")
 		return fmt.Errorf("restart tid %d: %w", tid, err)

--- a/internal/ptrace/attach.go
+++ b/internal/ptrace/attach.go
@@ -110,9 +110,11 @@ func (t *Tracer) attachThread(tid int, opts attachOpts) error {
 	if opts.keepStopped {
 		// Leave tracee stopped for cgroup hook; register in parkedTracees
 		// so ResumePID (via handleResumeRequest) can find and resume it.
-	} else if t.prefilterActive {
-		err = unix.PtraceCont(tid, 0)
 	} else {
+		// HasPrefilter is always false for freshly attached threads
+		// (injection hasn't happened yet), so this takes the PtraceSyscall
+		// path. When injection is wired in, HasPrefilter will be set to
+		// true and this will use PtraceCont instead.
 		err = unix.PtraceSyscall(tid, 0)
 	}
 	if err != nil {

--- a/internal/ptrace/attach.go
+++ b/internal/ptrace/attach.go
@@ -135,37 +135,25 @@ func (t *Tracer) attachThread(tid int, opts attachOpts) error {
 	t.metrics.SetTraceeCount(len(t.tracees))
 	t.mu.Unlock()
 
-	// Inject seccomp prefilter for explicitly-attached processes.
-	// Only inject when sessionID is set (exec/wrap path), not for
-	// auto-traced children (which inherit the filter via fork).
+	// Mark for deferred seccomp prefilter injection on the first syscall stop.
+	// Injection can't happen here (interrupt stop — RIP is arbitrary, not at
+	// a syscall boundary). The tracer's handleSyscallStop will check
+	// PendingPrefilter and inject on the first syscall entry.
 	if t.cfg.SeccompPrefilter && opts.sessionID != "" {
-		if injErr := t.injectSeccompFilter(tid); injErr != nil {
-			slog.Warn("seccomp prefilter injection failed, falling back to TRACESYSGOOD",
-				"tid", tid, "error", injErr)
-		} else {
-			t.mu.Lock()
-			if s := t.tracees[tid]; s != nil {
-				s.HasPrefilter = true
-			}
-			t.mu.Unlock()
+		t.mu.Lock()
+		if s := t.tracees[tid]; s != nil {
+			s.PendingPrefilter = true
 		}
+		t.mu.Unlock()
 	}
 
 	// Resume the tracee (unless keepStopped for cgroup hook).
+	// Always use PtraceSyscall here — HasPrefilter is never true at attach
+	// time (injection is deferred to the first syscall stop).
 	if opts.keepStopped {
 		// Already registered in parkedTracees above.
 	} else {
-		t.mu.Lock()
-		hasPrefilter := false
-		if s := t.tracees[tid]; s != nil {
-			hasPrefilter = s.HasPrefilter
-		}
-		t.mu.Unlock()
-		if hasPrefilter {
-			err = unix.PtraceCont(tid, 0)
-		} else {
-			err = unix.PtraceSyscall(tid, 0)
-		}
+		err = unix.PtraceSyscall(tid, 0)
 	}
 	if err != nil {
 		// Rollback: clean up TraceeState and MemFD on resume failure

--- a/internal/ptrace/attach.go
+++ b/internal/ptrace/attach.go
@@ -111,11 +111,12 @@ func (t *Tracer) attachThread(tid int, opts attachOpts) error {
 	// The injection engine needs TraceeState (for scratch page) and MemFD
 	// (for register read/write during injectSyscall).
 	memFD := -1
-	fd, err := unix.Open(fmt.Sprintf("/proc/%d/mem", tid), unix.O_RDWR, 0)
-	if err != nil {
+	if fd, openErr := unix.Open(fmt.Sprintf("/proc/%d/mem", tid), unix.O_RDWR, 0); openErr != nil {
 		fd, _ = unix.Open(fmt.Sprintf("/proc/%d/mem", tid), unix.O_RDONLY, 0)
+		memFD = fd
+	} else {
+		memFD = fd
 	}
-	memFD = fd
 
 	t.mu.Lock()
 	t.tracees[tid] = &TraceeState{
@@ -150,12 +151,13 @@ func (t *Tracer) attachThread(tid int, opts attachOpts) error {
 	// Resume the tracee (unless keepStopped for cgroup hook).
 	// Always use PtraceSyscall here — HasPrefilter is never true at attach
 	// time (injection is deferred to the first syscall stop).
+	var resumeErr error
 	if opts.keepStopped {
 		// Already registered in parkedTracees above.
 	} else {
-		err = unix.PtraceSyscall(tid, 0)
+		resumeErr = unix.PtraceSyscall(tid, 0)
 	}
-	if err != nil {
+	if resumeErr != nil {
 		// Rollback: clean up TraceeState and MemFD on resume failure
 		t.mu.Lock()
 		if s := t.tracees[tid]; s != nil {
@@ -169,7 +171,7 @@ func (t *Tracer) attachThread(tid int, opts attachOpts) error {
 		t.mu.Unlock()
 		unix.PtraceDetach(tid)
 		t.metrics.IncAttachFailure("other")
-		return fmt.Errorf("restart tid %d: %w", tid, err)
+		return fmt.Errorf("restart tid %d: %w", tid, resumeErr)
 	}
 
 	return nil

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -220,19 +220,6 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 			return nil
 		}
 
-		// Non-TRACESYSGOOD (prefilter) mode: plain SIGTRAP with no ptrace
-		// event is a syscall stop. In TRACESYSGOOD mode, plain SIGTRAP is a
-		// real signal — reinject it below.
-		t.mu.Lock()
-		hasPrefilter := false
-		if s := t.tracees[tid]; s != nil {
-			hasPrefilter = s.HasPrefilter
-		}
-		t.mu.Unlock()
-		if sig == unix.SIGTRAP && status.TrapCause() == 0 && hasPrefilter {
-			return nil
-		}
-
 		// PTRACE_EVENT_SECCOMP is a syscall-entry-equivalent stop.
 		// Treat it as a syscall stop to keep injection phases in sync.
 		if sig == unix.SIGTRAP && status.TrapCause() == unix.PTRACE_EVENT_SECCOMP {

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -223,7 +223,13 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 		// Non-TRACESYSGOOD (prefilter) mode: plain SIGTRAP with no ptrace
 		// event is a syscall stop. In TRACESYSGOOD mode, plain SIGTRAP is a
 		// real signal — reinject it below.
-		if sig == unix.SIGTRAP && status.TrapCause() == 0 && !t.traceSysGood() {
+		t.mu.Lock()
+		hasPrefilter := false
+		if s := t.tracees[tid]; s != nil {
+			hasPrefilter = s.HasPrefilter
+		}
+		t.mu.Unlock()
+		if sig == unix.SIGTRAP && status.TrapCause() == 0 && hasPrefilter {
 			return nil
 		}
 

--- a/internal/ptrace/inject_seccomp.go
+++ b/internal/ptrace/inject_seccomp.go
@@ -93,6 +93,10 @@ func (t *Tracer) injectSeccompFilter(tid int) error {
 	}
 
 	// Inject prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0).
+	// Note: PR_SET_NO_NEW_PRIVS is irreversible — it persists even if the
+	// subsequent seccomp() call fails. This is acceptable for agentsh
+	// workloads (sandboxed agent commands should not escalate privileges;
+	// the non-ptrace seccomp wrapper path also sets this flag).
 	ret, err := t.injectSyscall(tid, savedRegs, unix.SYS_PRCTL,
 		prSetNoNewPrivs, 1, 0, 0, 0, 0)
 	if err != nil {

--- a/internal/ptrace/inject_seccomp.go
+++ b/internal/ptrace/inject_seccomp.go
@@ -102,8 +102,7 @@ func (t *Tracer) injectSeccompFilter(tid int) error {
 	if err != nil {
 		return fmt.Errorf("inject prctl: %w", err)
 	}
-	if ret != 0 && ret != -int64(unix.EINVAL) {
-		// EINVAL is acceptable (already set). Other errors are real failures.
+	if ret != 0 {
 		return fmt.Errorf("prctl(PR_SET_NO_NEW_PRIVS) returned %d (%s)", ret, unix.Errno(-ret))
 	}
 

--- a/internal/ptrace/inject_seccomp.go
+++ b/internal/ptrace/inject_seccomp.go
@@ -1,0 +1,115 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"encoding/binary"
+	"fmt"
+	"log/slog"
+
+	"golang.org/x/sys/unix"
+)
+
+// prSetNoNewPrivs is the prctl option that prevents privilege escalation.
+// Required before installing a seccomp filter without CAP_SYS_ADMIN.
+const prSetNoNewPrivs = 38
+
+// seccompSetModeFilter is the seccomp operation for installing a BPF filter.
+const seccompSetModeFilter = 1
+
+// sockFprogSize is the size of struct sock_fprog on amd64/arm64 (16 bytes).
+// Layout: { uint16 len; [6]byte pad; uint64 filter; }
+const sockFprogSize = 16
+
+// sockFilterSize is the size of a single BPF instruction (struct sock_filter).
+// Layout: { uint16 Code; uint8 Jt; uint8 Jf; uint32 K; }
+const sockFilterSize = 8
+
+// injectSeccompFilter injects a seccomp-BPF prefilter into a stopped tracee.
+// The tracee must be in a ptrace-stop (e.g., after PTRACE_INTERRUPT).
+// Returns nil on success. Failure is non-fatal — caller falls back to TRACESYSGOOD.
+func (t *Tracer) injectSeccompFilter(tid int) error {
+	// Build the BPF program.
+	filters := buildPrefilterBPF()
+	if len(filters) == 0 {
+		return fmt.Errorf("empty BPF program")
+	}
+
+	// Get current registers for injection.
+	savedRegs, err := t.getRegs(tid)
+	if err != nil {
+		return fmt.Errorf("getRegs: %w", err)
+	}
+
+	// Get TGID for scratch page.
+	t.mu.Lock()
+	state := t.tracees[tid]
+	tgid := tid
+	if state != nil {
+		tgid = state.TGID
+	}
+	t.mu.Unlock()
+
+	// Get or allocate scratch page.
+	sp, err := t.ensureScratchPage(tid, tgid, savedRegs)
+	if err != nil {
+		return fmt.Errorf("scratch page: %w", err)
+	}
+
+	// Calculate total size needed: sock_fprog (16 bytes) + filters.
+	totalSize := sockFprogSize + len(filters)*sockFilterSize
+	scratchAddr, err := sp.allocate(totalSize)
+	if err != nil {
+		return fmt.Errorf("scratch allocate: %w", err)
+	}
+
+	// Serialize the BPF filter array.
+	filterBuf := make([]byte, len(filters)*sockFilterSize)
+	for i, f := range filters {
+		off := i * sockFilterSize
+		binary.LittleEndian.PutUint16(filterBuf[off:], f.Code)
+		filterBuf[off+2] = f.Jt
+		filterBuf[off+3] = f.Jf
+		binary.LittleEndian.PutUint32(filterBuf[off+4:], f.K)
+	}
+
+	// Build sock_fprog struct.
+	// On amd64/arm64: { uint16 len, [6]byte pad, uint64 filter_ptr }
+	filterArrayAddr := scratchAddr + sockFprogSize
+	fprogBuf := make([]byte, sockFprogSize)
+	binary.LittleEndian.PutUint16(fprogBuf[0:], uint16(len(filters)))
+	// bytes 2..7 are padding (zero from make)
+	binary.LittleEndian.PutUint64(fprogBuf[8:], filterArrayAddr)
+
+	// Write sock_fprog + filter array to tracee memory.
+	payload := make([]byte, 0, totalSize)
+	payload = append(payload, fprogBuf...)
+	payload = append(payload, filterBuf...)
+	if err := t.writeBytes(tid, scratchAddr, payload); err != nil {
+		return fmt.Errorf("write BPF to tracee: %w", err)
+	}
+
+	// Inject prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0).
+	ret, err := t.injectSyscall(tid, savedRegs, unix.SYS_PRCTL,
+		prSetNoNewPrivs, 1, 0, 0, 0, 0)
+	if err != nil {
+		return fmt.Errorf("inject prctl: %w", err)
+	}
+	if ret != 0 && ret != -int64(unix.EINVAL) {
+		// EINVAL is acceptable (already set). Other errors are real failures.
+		return fmt.Errorf("prctl(PR_SET_NO_NEW_PRIVS) returned %d (%s)", ret, unix.Errno(-ret))
+	}
+
+	// Inject seccomp(SECCOMP_SET_MODE_FILTER, 0, &prog).
+	ret, err = t.injectSyscall(tid, savedRegs, unix.SYS_SECCOMP,
+		seccompSetModeFilter, 0, scratchAddr, 0, 0, 0)
+	if err != nil {
+		return fmt.Errorf("inject seccomp: %w", err)
+	}
+	if ret != 0 {
+		return fmt.Errorf("seccomp(SECCOMP_SET_MODE_FILTER) returned %d (%s)", ret, unix.Errno(-ret))
+	}
+
+	slog.Info("seccomp prefilter installed", "tid", tid, "filters", len(filters))
+	return nil
+}

--- a/internal/ptrace/inject_seccomp.go
+++ b/internal/ptrace/inject_seccomp.go
@@ -30,7 +30,10 @@ const sockFilterSize = 8
 // Returns nil on success. Failure is non-fatal — caller falls back to TRACESYSGOOD.
 func (t *Tracer) injectSeccompFilter(tid int) error {
 	// Build the BPF program.
-	filters := buildPrefilterBPF()
+	filters, bpfErr := buildPrefilterBPF()
+	if bpfErr != nil {
+		return bpfErr
+	}
 	if len(filters) == 0 {
 		return fmt.Errorf("empty BPF program")
 	}

--- a/internal/ptrace/seccomp_filter.go
+++ b/internal/ptrace/seccomp_filter.go
@@ -3,6 +3,7 @@
 package ptrace
 
 import (
+	"fmt"
 	"runtime"
 
 	"golang.org/x/sys/unix"
@@ -32,7 +33,7 @@ const (
 // buildPrefilterBPF generates a seccomp-BPF filter that returns
 // SECCOMP_RET_TRACE for syscalls the tracer handles and
 // SECCOMP_RET_ALLOW for everything else.
-func buildPrefilterBPF() []unix.SockFilter {
+func buildPrefilterBPF() ([]unix.SockFilter, error) {
 	var auditArch uint32
 	switch runtime.GOARCH {
 	case "amd64":
@@ -40,10 +41,7 @@ func buildPrefilterBPF() []unix.SockFilter {
 	case "arm64":
 		auditArch = auditArchAarch64
 	default:
-		// Unsupported architecture: allow everything.
-		return []unix.SockFilter{
-			{Code: bpfRET | bpfK, K: seccompRetAllow},
-		}
+		return nil, fmt.Errorf("seccomp prefilter: unsupported architecture %s", runtime.GOARCH)
 	}
 
 	syscalls := tracedSyscallNumbers()
@@ -91,5 +89,5 @@ func buildPrefilterBPF() []unix.SockFilter {
 	// Matched: trace.
 	prog = append(prog, unix.SockFilter{Code: bpfRET | bpfK, K: seccompRetTrace})
 
-	return prog
+	return prog, nil
 }

--- a/internal/ptrace/seccomp_filter.go
+++ b/internal/ptrace/seccomp_filter.go
@@ -1,0 +1,95 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+// BPF instruction classes and fields.
+const (
+	bpfLD  = 0x00
+	bpfW   = 0x00
+	bpfABS = 0x20
+	bpfJMP = 0x05
+	bpfJEQ = 0x10
+	bpfK   = 0x00
+	bpfRET = 0x06
+
+	seccompRetAllow = 0x7FFF0000
+	seccompRetTrace = 0x7FF00000
+
+	// seccomp_data offsets.
+	offsetNr   = 0 // offsetof(struct seccomp_data, nr)
+	offsetArch = 4 // offsetof(struct seccomp_data, arch)
+
+	auditArchX86_64  = 0xC000003E
+	auditArchAarch64 = 0xC00000B7
+)
+
+// buildPrefilterBPF generates a seccomp-BPF filter that returns
+// SECCOMP_RET_TRACE for syscalls the tracer handles and
+// SECCOMP_RET_ALLOW for everything else.
+func buildPrefilterBPF() []unix.SockFilter {
+	var auditArch uint32
+	switch runtime.GOARCH {
+	case "amd64":
+		auditArch = auditArchX86_64
+	case "arm64":
+		auditArch = auditArchAarch64
+	default:
+		// Unsupported architecture: allow everything.
+		return []unix.SockFilter{
+			{Code: bpfRET | bpfK, K: seccompRetAllow},
+		}
+	}
+
+	syscalls := tracedSyscallNumbers()
+
+	// Program layout:
+	//   [0] LD arch
+	//   [1] JEQ auditArch -> skip ALLOW (jt=1), fall through (jf=0)
+	//   [2] RET ALLOW  (wrong arch)
+	//   [3] LD nr
+	//   [4..4+len-1] JEQ for each syscall
+	//   [4+len] RET ALLOW  (default, no match)
+	//   [4+len+1] RET TRACE (matched)
+
+	n := len(syscalls)
+	prog := make([]unix.SockFilter, 0, 4+n+2)
+
+	// Load architecture.
+	prog = append(prog, unix.SockFilter{Code: bpfLD | bpfW | bpfABS, K: offsetArch})
+
+	// Check architecture: if match jump over the ALLOW, otherwise fall through to ALLOW.
+	prog = append(prog, unix.SockFilter{Code: bpfJMP | bpfJEQ | bpfK, Jt: 1, Jf: 0, K: auditArch})
+
+	// Wrong architecture: allow.
+	prog = append(prog, unix.SockFilter{Code: bpfRET | bpfK, K: seccompRetAllow})
+
+	// Load syscall number.
+	prog = append(prog, unix.SockFilter{Code: bpfLD | bpfW | bpfABS, K: offsetNr})
+
+	// Compare each traced syscall. On match, jump to the RET TRACE
+	// instruction at the end. On mismatch, fall through to the next compare.
+	for i, nr := range syscalls {
+		remaining := n - i - 1 // remaining compare instructions after this one
+		jumpToTrace := uint8(remaining + 1) // +1 for the default RET ALLOW
+		prog = append(prog, unix.SockFilter{
+			Code: bpfJMP | bpfJEQ | bpfK,
+			Jt:   jumpToTrace,
+			Jf:   0,
+			K:    uint32(nr),
+		})
+	}
+
+	// Default: allow.
+	prog = append(prog, unix.SockFilter{Code: bpfRET | bpfK, K: seccompRetAllow})
+
+	// Matched: trace.
+	prog = append(prog, unix.SockFilter{Code: bpfRET | bpfK, K: seccompRetTrace})
+
+	return prog
+}

--- a/internal/ptrace/seccomp_filter.go
+++ b/internal/ptrace/seccomp_filter.go
@@ -64,8 +64,9 @@ func buildPrefilterBPF() ([]unix.SockFilter, error) {
 	// Check architecture: if match jump over the ALLOW, otherwise fall through to ALLOW.
 	prog = append(prog, unix.SockFilter{Code: bpfJMP | bpfJEQ | bpfK, Jt: 1, Jf: 0, K: auditArch})
 
-	// Wrong architecture: allow.
-	prog = append(prog, unix.SockFilter{Code: bpfRET | bpfK, K: seccompRetAllow})
+	// Wrong architecture: trace (fail closed). This ensures compat/x32
+	// tracees still generate ptrace stops rather than silently bypassing.
+	prog = append(prog, unix.SockFilter{Code: bpfRET | bpfK, K: seccompRetTrace})
 
 	// Load syscall number.
 	prog = append(prog, unix.SockFilter{Code: bpfLD | bpfW | bpfABS, K: offsetNr})

--- a/internal/ptrace/seccomp_filter_test.go
+++ b/internal/ptrace/seccomp_filter_test.go
@@ -1,0 +1,65 @@
+//go:build linux
+
+package ptrace
+
+import "testing"
+
+func TestPrefilterBPFNonEmpty(t *testing.T) {
+	prog := buildPrefilterBPF()
+	if len(prog) == 0 {
+		t.Fatal("buildPrefilterBPF returned empty filter")
+	}
+}
+
+func TestPrefilterBPFInstructionCount(t *testing.T) {
+	syscalls := tracedSyscallNumbers()
+	prog := buildPrefilterBPF()
+
+	// 4 header instructions + len(syscalls) comparisons + 2 return instructions.
+	want := 4 + len(syscalls) + 2
+	if len(prog) != want {
+		t.Errorf("instruction count = %d, want %d (4 header + %d comparisons + 2 returns)",
+			len(prog), want, len(syscalls))
+	}
+}
+
+func TestPrefilterBPFContainsAllSyscalls(t *testing.T) {
+	syscalls := tracedSyscallNumbers()
+	prog := buildPrefilterBPF()
+
+	// Collect all K values from JEQ instructions.
+	jeqValues := make(map[uint32]bool)
+	for _, inst := range prog {
+		if inst.Code == bpfJMP|bpfJEQ|bpfK {
+			// Skip the architecture check instruction.
+			if inst.K == auditArchX86_64 || inst.K == auditArchAarch64 {
+				continue
+			}
+			jeqValues[inst.K] = true
+		}
+	}
+
+	for _, nr := range syscalls {
+		if !jeqValues[uint32(nr)] {
+			t.Errorf("syscall %d not found as JEQ instruction in filter", nr)
+		}
+	}
+}
+
+func TestPrefilterBPFArchCheck(t *testing.T) {
+	prog := buildPrefilterBPF()
+
+	// First instruction must load the architecture field.
+	if prog[0].Code != bpfLD|bpfW|bpfABS || prog[0].K != offsetArch {
+		t.Errorf("first instruction should load arch (offset %d), got Code=0x%x K=%d",
+			offsetArch, prog[0].Code, prog[0].K)
+	}
+
+	// Second instruction must be a JEQ comparing the audit arch.
+	if prog[1].Code != bpfJMP|bpfJEQ|bpfK {
+		t.Errorf("second instruction should be JEQ, got Code=0x%x", prog[1].Code)
+	}
+	if prog[1].K != auditArchX86_64 && prog[1].K != auditArchAarch64 {
+		t.Errorf("arch check compares unexpected value 0x%X", prog[1].K)
+	}
+}

--- a/internal/ptrace/seccomp_filter_test.go
+++ b/internal/ptrace/seccomp_filter_test.go
@@ -5,7 +5,10 @@ package ptrace
 import "testing"
 
 func TestPrefilterBPFNonEmpty(t *testing.T) {
-	prog := buildPrefilterBPF()
+	prog, err := buildPrefilterBPF()
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(prog) == 0 {
 		t.Fatal("buildPrefilterBPF returned empty filter")
 	}
@@ -13,7 +16,10 @@ func TestPrefilterBPFNonEmpty(t *testing.T) {
 
 func TestPrefilterBPFInstructionCount(t *testing.T) {
 	syscalls := tracedSyscallNumbers()
-	prog := buildPrefilterBPF()
+	prog, err := buildPrefilterBPF()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// 4 header instructions + len(syscalls) comparisons + 2 return instructions.
 	want := 4 + len(syscalls) + 2
@@ -25,7 +31,10 @@ func TestPrefilterBPFInstructionCount(t *testing.T) {
 
 func TestPrefilterBPFContainsAllSyscalls(t *testing.T) {
 	syscalls := tracedSyscallNumbers()
-	prog := buildPrefilterBPF()
+	prog, err := buildPrefilterBPF()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Collect all K values from JEQ instructions.
 	jeqValues := make(map[uint32]bool)
@@ -47,7 +56,10 @@ func TestPrefilterBPFContainsAllSyscalls(t *testing.T) {
 }
 
 func TestPrefilterBPFArchCheck(t *testing.T) {
-	prog := buildPrefilterBPF()
+	prog, err := buildPrefilterBPF()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// First instruction must load the architecture field.
 	if prog[0].Code != bpfLD|bpfW|bpfABS || prog[0].K != offsetArch {

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -427,14 +427,17 @@ func (t *Tracer) Implementation() string {
 }
 
 func (t *Tracer) ptraceOptions() int {
-	return unix.PTRACE_O_TRACECLONE |
+	opts := unix.PTRACE_O_TRACECLONE |
 		unix.PTRACE_O_TRACEFORK |
 		unix.PTRACE_O_TRACEVFORK |
 		unix.PTRACE_O_TRACEEXEC |
 		unix.PTRACE_O_TRACEEXIT |
 		unix.PTRACE_O_EXITKILL |
-		unix.PTRACE_O_TRACESECCOMP |
 		unix.PTRACE_O_TRACESYSGOOD
+	if t.cfg.SeccompPrefilter {
+		opts |= unix.PTRACE_O_TRACESECCOMP
+	}
+	return opts
 }
 
 func (t *Tracer) getRegs(tid int) (Regs, error) {
@@ -702,11 +705,18 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		state.PendingPrefilter = false
 		// Mark as entering syscall so injectSyscall uses the correct
 		// entry-stop protocol (the first syscall stop is always an entry).
+		prevInSyscall := state.InSyscall
 		state.InSyscall = true
 		t.mu.Unlock()
 		if err := t.injectSeccompFilter(tid); err != nil {
 			slog.Warn("seccomp prefilter injection failed, falling back to TRACESYSGOOD",
 				"tid", tid, "error", err)
+			// Restore InSyscall on failure so entry/exit tracking stays correct
+			t.mu.Lock()
+			if s := t.tracees[tid]; s != nil {
+				s.InSyscall = prevInSyscall
+			}
+			t.mu.Unlock()
 		} else {
 			t.mu.Lock()
 			if s := t.tracees[tid]; s != nil {

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -712,6 +712,13 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		}
 		// Fall through to normal exit handling for this syscall.
 		// Do NOT return — the first syscall's exit handlers still need to run.
+		// Restore InSyscall=true so the normal toggle correctly identifies
+		// this as a syscall exit (entering := !state.InSyscall → false).
+		t.mu.Lock()
+		if s := t.tracees[tid]; s != nil {
+			s.InSyscall = true
+		}
+		t.mu.Unlock()
 	} else {
 		t.mu.Unlock()
 	}

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -679,28 +679,22 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 
 // handleSyscallStop handles SIGTRAP|0x80 stops (TRACESYSGOOD mode).
 func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
-	// Deferred seccomp prefilter injection: inject on the first syscall stop
-	// (not at attach time, where RIP is arbitrary and injectSyscall would fail).
-	// After injection, fall through to normal syscall handling so the current
-	// syscall is still evaluated by policy (no enforcement gap).
+	// Deferred seccomp prefilter injection: inject on the first syscall EXIT
+	// (not entry — injectFromEntry replaces the current syscall, which would
+	// drop the tracee's first real syscall). At exit, the syscall already
+	// completed, so injection is safe.
 	t.mu.Lock()
 	state := t.tracees[tid]
-	if state != nil && state.PendingPrefilter {
+	if state != nil && state.PendingPrefilter && state.InSyscall {
+		// We're at a syscall entry. Wait for the exit.
+		// (InSyscall will be toggled by the normal handling below.)
+	} else if state != nil && state.PendingPrefilter && !state.InSyscall {
+		// We're at a syscall exit — safe to inject.
 		state.PendingPrefilter = false
-		// Mark as entering syscall so injectSyscall uses the correct
-		// entry-stop protocol (the first syscall stop is always an entry).
-		prevInSyscall := state.InSyscall
-		state.InSyscall = true
 		t.mu.Unlock()
 		if err := t.injectSeccompFilter(tid); err != nil {
 			slog.Warn("seccomp prefilter injection failed, falling back to TRACESYSGOOD",
 				"tid", tid, "error", err)
-			// Restore InSyscall on failure so entry/exit tracking stays correct
-			t.mu.Lock()
-			if s := t.tracees[tid]; s != nil {
-				s.InSyscall = prevInSyscall
-			}
-			t.mu.Unlock()
 		} else {
 			t.mu.Lock()
 			if s := t.tracees[tid]; s != nil {
@@ -708,8 +702,12 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 			}
 			t.mu.Unlock()
 		}
-		// Fall through to normal syscall handling below — do NOT return.
-		// The current syscall still needs policy evaluation.
+		// Resume — the tracee will now generate PTRACE_EVENT_SECCOMP stops.
+		t.allowSyscall(tid)
+		return
+	}
+	if state != nil && !state.PendingPrefilter {
+		t.mu.Unlock()
 	} else {
 		t.mu.Unlock()
 	}
@@ -818,6 +816,7 @@ func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
 	if state != nil {
 		tgid = state.TGID
 		state.InSyscall = true
+		state.LastNr = nr
 	}
 	t.mu.Unlock()
 	if tgid != 0 {

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -683,13 +683,18 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 	// (not entry — injectFromEntry replaces the current syscall, which would
 	// drop the tracee's first real syscall). At exit, the syscall already
 	// completed, so injection is safe.
+	//
+	// State.InSyscall tracks what the PREVIOUS stop set:
+	//   InSyscall=false → this is an entry stop (first time)
+	//   InSyscall=true  → this is an exit stop (entry was processed)
 	t.mu.Lock()
 	state := t.tracees[tid]
-	if state != nil && state.PendingPrefilter && state.InSyscall {
-		// We're at a syscall entry. Wait for the exit.
-		// (InSyscall will be toggled by the normal handling below.)
-	} else if state != nil && state.PendingPrefilter && !state.InSyscall {
-		// We're at a syscall exit — safe to inject.
+	if state != nil && state.PendingPrefilter && !state.InSyscall {
+		// This is a syscall entry. Let normal handling process it.
+		// The next stop will be the exit, where we'll inject.
+		t.mu.Unlock()
+	} else if state != nil && state.PendingPrefilter && state.InSyscall {
+		// This is a syscall exit — safe to inject now.
 		state.PendingPrefilter = false
 		t.mu.Unlock()
 		if err := t.injectSeccompFilter(tid); err != nil {
@@ -705,9 +710,6 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		// Resume — the tracee will now generate PTRACE_EVENT_SECCOMP stops.
 		t.allowSyscall(tid)
 		return
-	}
-	if state != nil && !state.PendingPrefilter {
-		t.mu.Unlock()
 	} else {
 		t.mu.Unlock()
 	}

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -700,6 +700,9 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 	state := t.tracees[tid]
 	if state != nil && state.PendingPrefilter {
 		state.PendingPrefilter = false
+		// Mark as entering syscall so injectSyscall uses the correct
+		// entry-stop protocol (the first syscall stop is always an entry).
+		state.InSyscall = true
 		t.mu.Unlock()
 		if err := t.injectSeccompFilter(tid); err != nil {
 			slog.Warn("seccomp prefilter injection failed, falling back to TRACESYSGOOD",

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -161,6 +161,7 @@ type TraceeState struct {
 	HasPendingReturn      bool  // whether PendingReturnOverride is active
 	PendingInterrupt      bool
 	HasPrefilter     bool // true if seccomp prefilter is installed for this tracee
+	PendingPrefilter bool // inject seccomp filter on next syscall stop
 	IsVforkChild     bool
 	SuppressInitialStop bool // suppress initial SIGSTOP from auto-trace
 	PendingExecStubFD  int // fd injected for exec redirect; cleaned up on exec failure (-1 = none)
@@ -691,8 +692,32 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 
 // handleSyscallStop handles SIGTRAP|0x80 stops (TRACESYSGOOD mode).
 func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
+	// Deferred seccomp prefilter injection: inject on the first syscall stop
+	// (not at attach time, where RIP is arbitrary and injectSyscall would fail).
 	t.mu.Lock()
 	state := t.tracees[tid]
+	if state != nil && state.PendingPrefilter {
+		state.PendingPrefilter = false
+		t.mu.Unlock()
+		if err := t.injectSeccompFilter(tid); err != nil {
+			slog.Warn("seccomp prefilter injection failed, falling back to TRACESYSGOOD",
+				"tid", tid, "error", err)
+		} else {
+			t.mu.Lock()
+			if s := t.tracees[tid]; s != nil {
+				s.HasPrefilter = true
+			}
+			t.mu.Unlock()
+		}
+		// Resume — if injection succeeded, the tracee now has the filter and
+		// will generate PTRACE_EVENT_SECCOMP stops going forward.
+		t.allowSyscall(tid)
+		return
+	}
+	t.mu.Unlock()
+
+	t.mu.Lock()
+	state = t.tracees[tid]
 	if state == nil {
 		t.mu.Unlock()
 		t.allowSyscall(tid)

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -160,6 +160,7 @@ type TraceeState struct {
 	PendingReturnOverride int64 // force return value to this on syscall exit
 	HasPendingReturn      bool  // whether PendingReturnOverride is active
 	PendingInterrupt      bool
+	HasPrefilter     bool // true if seccomp prefilter is installed for this tracee
 	IsVforkChild     bool
 	SuppressInitialStop bool // suppress initial SIGSTOP from auto-trace
 	PendingExecStubFD  int // fd injected for exec redirect; cleaned up on exec failure (-1 = none)
@@ -226,7 +227,6 @@ type Tracer struct {
 	cfg             TracerConfig
 	metrics         Metrics
 	processTree     *ProcessTree
-	prefilterActive bool
 
 	attachQueue chan attachRequest
 	resumeQueue chan resumeRequest
@@ -426,20 +426,14 @@ func (t *Tracer) Implementation() string {
 }
 
 func (t *Tracer) ptraceOptions() int {
-	opts := unix.PTRACE_O_TRACECLONE |
+	return unix.PTRACE_O_TRACECLONE |
 		unix.PTRACE_O_TRACEFORK |
 		unix.PTRACE_O_TRACEVFORK |
 		unix.PTRACE_O_TRACEEXEC |
 		unix.PTRACE_O_TRACEEXIT |
-		unix.PTRACE_O_EXITKILL
-
-	if t.prefilterActive {
-		opts |= unix.PTRACE_O_TRACESECCOMP
-	} else {
-		opts |= unix.PTRACE_O_TRACESYSGOOD
-	}
-
-	return opts
+		unix.PTRACE_O_EXITKILL |
+		unix.PTRACE_O_TRACESECCOMP |
+		unix.PTRACE_O_TRACESYSGOOD
 }
 
 func (t *Tracer) getRegs(tid int) (Regs, error) {
@@ -450,16 +444,17 @@ func (t *Tracer) setRegs(tid int, regs Regs) error {
 	return setRegsArch(tid, regs)
 }
 
-// traceSysGood reports whether PTRACE_O_TRACESYSGOOD is active.
-// When true, syscall stops use SIGTRAP|0x80 and plain SIGTRAP is a real signal.
-func (t *Tracer) traceSysGood() bool {
-	return !t.prefilterActive
-}
-
 // allowSyscall resumes the tracee, allowing the syscall to proceed.
 func (t *Tracer) allowSyscall(tid int) {
+	t.mu.Lock()
+	hasPrefilter := false
+	if s := t.tracees[tid]; s != nil {
+		hasPrefilter = s.HasPrefilter
+	}
+	t.mu.Unlock()
+
 	var err error
-	if t.prefilterActive {
+	if hasPrefilter {
 		err = unix.PtraceCont(tid, 0)
 	} else {
 		err = unix.PtraceSyscall(tid, 0)
@@ -515,7 +510,14 @@ func (t *Tracer) denySyscall(tid int, errno int) error {
 
 // resumeTracee resumes a tracee with an optional signal to deliver.
 func (t *Tracer) resumeTracee(tid int, sig int) {
-	if t.prefilterActive {
+	t.mu.Lock()
+	hasPrefilter := false
+	if s := t.tracees[tid]; s != nil {
+		hasPrefilter = s.HasPrefilter
+	}
+	t.mu.Unlock()
+
+	if hasPrefilter {
 		unix.PtraceCont(tid, sig)
 	} else {
 		unix.PtraceSyscall(tid, sig)
@@ -950,6 +952,7 @@ func (t *Tracer) handleNewChild(parentTID int, event int) {
 		existing.TGID = childTGID
 		existing.ParentPID = parent.TGID
 		existing.SessionID = parent.SessionID
+		existing.HasPrefilter = parent.HasPrefilter
 		existing.Attached = time.Now()
 	} else {
 		t.tracees[tid] = &TraceeState{
@@ -957,6 +960,7 @@ func (t *Tracer) handleNewChild(parentTID int, event int) {
 			TGID:                childTGID,
 			ParentPID:           parent.TGID,
 			SessionID:           parent.SessionID,
+			HasPrefilter:        parent.HasPrefilter,
 			Attached:            time.Now(),
 			LastNr:              -1,
 			MemFD:               -1,

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -696,6 +696,9 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 	} else if state != nil && state.PendingPrefilter && state.InSyscall {
 		// This is a syscall exit — safe to inject now.
 		state.PendingPrefilter = false
+		// Set InSyscall=false before injection so injectSyscall uses the
+		// correct exit-stop protocol (injectFromExit).
+		state.InSyscall = false
 		t.mu.Unlock()
 		if err := t.injectSeccompFilter(tid); err != nil {
 			slog.Warn("seccomp prefilter injection failed, falling back to TRACESYSGOOD",
@@ -977,6 +980,7 @@ func (t *Tracer) handleNewChild(parentTID int, event int) {
 		existing.ParentPID = parent.TGID
 		existing.SessionID = parent.SessionID
 		existing.HasPrefilter = parent.HasPrefilter
+		existing.PendingPrefilter = parent.PendingPrefilter
 		existing.Attached = time.Now()
 	} else {
 		t.tracees[tid] = &TraceeState{
@@ -985,6 +989,7 @@ func (t *Tracer) handleNewChild(parentTID int, event int) {
 			ParentPID:           parent.TGID,
 			SessionID:           parent.SessionID,
 			HasPrefilter:        parent.HasPrefilter,
+			PendingPrefilter:    parent.PendingPrefilter,
 			Attached:            time.Now(),
 			LastNr:              -1,
 			MemFD:               -1,

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -710,9 +710,8 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 			}
 			t.mu.Unlock()
 		}
-		// Resume — the tracee will now generate PTRACE_EVENT_SECCOMP stops.
-		t.allowSyscall(tid)
-		return
+		// Fall through to normal exit handling for this syscall.
+		// Do NOT return — the first syscall's exit handlers still need to run.
 	} else {
 		t.mu.Unlock()
 	}

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -694,6 +694,8 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 	// Deferred seccomp prefilter injection: inject on the first syscall stop
 	// (not at attach time, where RIP is arbitrary and injectSyscall would fail).
+	// After injection, fall through to normal syscall handling so the current
+	// syscall is still evaluated by policy (no enforcement gap).
 	t.mu.Lock()
 	state := t.tracees[tid]
 	if state != nil && state.PendingPrefilter {
@@ -709,12 +711,11 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 			}
 			t.mu.Unlock()
 		}
-		// Resume — if injection succeeded, the tracee now has the filter and
-		// will generate PTRACE_EVENT_SECCOMP stops going forward.
-		t.allowSyscall(tid)
-		return
+		// Fall through to normal syscall handling below — do NOT return.
+		// The current syscall still needs policy evaluation.
+	} else {
+		t.mu.Unlock()
 	}
-	t.mu.Unlock()
 
 	t.mu.Lock()
 	state = t.tracees[tid]

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -450,19 +450,13 @@ func (t *Tracer) setRegs(tid int, regs Regs) error {
 
 // allowSyscall resumes the tracee, allowing the syscall to proceed.
 func (t *Tracer) allowSyscall(tid int) {
-	t.mu.Lock()
-	hasPrefilter := false
-	if s := t.tracees[tid]; s != nil {
-		hasPrefilter = s.HasPrefilter
-	}
-	t.mu.Unlock()
-
+	// Always use PtraceSyscall to catch syscall-exit stops, which are needed
+	// for exit-time handlers (TracerPid masking, fd tracking, TLS SNI, etc.).
+	// In prefilter mode, the BPF filter ensures only traced syscalls generate
+	// entry stops; PtraceSyscall then catches their exits. Non-traced syscalls
+	// don't stop at all (BPF returns ALLOW), so this is still efficient.
 	var err error
-	if hasPrefilter {
-		err = unix.PtraceCont(tid, 0)
-	} else {
-		err = unix.PtraceSyscall(tid, 0)
-	}
+	err = unix.PtraceSyscall(tid, 0)
 	if err != nil && errors.Is(err, unix.ESRCH) {
 		t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
 	}
@@ -513,19 +507,9 @@ func (t *Tracer) denySyscall(tid int, errno int) error {
 }
 
 // resumeTracee resumes a tracee with an optional signal to deliver.
+// Always uses PtraceSyscall to catch exit-time stops (see allowSyscall).
 func (t *Tracer) resumeTracee(tid int, sig int) {
-	t.mu.Lock()
-	hasPrefilter := false
-	if s := t.tracees[tid]; s != nil {
-		hasPrefilter = s.HasPrefilter
-	}
-	t.mu.Unlock()
-
-	if hasPrefilter {
-		unix.PtraceCont(tid, sig)
-	} else {
-		unix.PtraceSyscall(tid, sig)
-	}
+	unix.PtraceSyscall(tid, sig)
 }
 
 // ptraceListen calls PTRACE_LISTEN on the specified tid. In PTRACE_SEIZE

--- a/internal/ptrace/tracer_test.go
+++ b/internal/ptrace/tracer_test.go
@@ -19,17 +19,28 @@ func TestNewTracer(t *testing.T) {
 	}
 }
 
-func TestPtraceOptions_AlwaysSetsBoth(t *testing.T) {
-	tr := &Tracer{}
+func TestPtraceOptions_WithPrefilter(t *testing.T) {
+	tr := &Tracer{cfg: TracerConfig{SeccompPrefilter: true}}
 	opts := tr.ptraceOptions()
 	if opts&unix.PTRACE_O_EXITKILL == 0 {
-		t.Error("PTRACE_O_EXITKILL must always be set")
+		t.Error("PTRACE_O_EXITKILL must be set")
 	}
 	if opts&unix.PTRACE_O_TRACESECCOMP == 0 {
-		t.Error("PTRACE_O_TRACESECCOMP must always be set")
+		t.Error("PTRACE_O_TRACESECCOMP must be set when prefilter enabled")
 	}
 	if opts&unix.PTRACE_O_TRACESYSGOOD == 0 {
-		t.Error("PTRACE_O_TRACESYSGOOD must always be set")
+		t.Error("PTRACE_O_TRACESYSGOOD must be set")
+	}
+}
+
+func TestPtraceOptions_WithoutPrefilter(t *testing.T) {
+	tr := &Tracer{cfg: TracerConfig{SeccompPrefilter: false}}
+	opts := tr.ptraceOptions()
+	if opts&unix.PTRACE_O_TRACESECCOMP != 0 {
+		t.Error("PTRACE_O_TRACESECCOMP must not be set when prefilter disabled")
+	}
+	if opts&unix.PTRACE_O_TRACESYSGOOD == 0 {
+		t.Error("PTRACE_O_TRACESYSGOOD must be set")
 	}
 }
 

--- a/internal/ptrace/tracer_test.go
+++ b/internal/ptrace/tracer_test.go
@@ -19,31 +19,17 @@ func TestNewTracer(t *testing.T) {
 	}
 }
 
-func TestPtraceOptions_WithPrefilter(t *testing.T) {
-	tr := &Tracer{prefilterActive: true}
+func TestPtraceOptions_AlwaysSetsBoth(t *testing.T) {
+	tr := &Tracer{}
 	opts := tr.ptraceOptions()
 	if opts&unix.PTRACE_O_EXITKILL == 0 {
 		t.Error("PTRACE_O_EXITKILL must always be set")
 	}
 	if opts&unix.PTRACE_O_TRACESECCOMP == 0 {
-		t.Error("PTRACE_O_TRACESECCOMP must be set when prefilter active")
-	}
-	if opts&unix.PTRACE_O_TRACESYSGOOD != 0 {
-		t.Error("PTRACE_O_TRACESYSGOOD must not be set when prefilter active")
-	}
-}
-
-func TestPtraceOptions_WithoutPrefilter(t *testing.T) {
-	tr := &Tracer{prefilterActive: false}
-	opts := tr.ptraceOptions()
-	if opts&unix.PTRACE_O_EXITKILL == 0 {
-		t.Error("PTRACE_O_EXITKILL must always be set")
+		t.Error("PTRACE_O_TRACESECCOMP must always be set")
 	}
 	if opts&unix.PTRACE_O_TRACESYSGOOD == 0 {
-		t.Error("PTRACE_O_TRACESYSGOOD must be set when no prefilter")
-	}
-	if opts&unix.PTRACE_O_TRACESECCOMP != 0 {
-		t.Error("PTRACE_O_TRACESECCOMP must not be set when no prefilter")
+		t.Error("PTRACE_O_TRACESYSGOOD must always be set")
 	}
 }
 


### PR DESCRIPTION
## Summary

Inject seccomp-BPF prefilter into traced child processes at attach time via ptrace syscall injection. The BPF returns `SECCOMP_RET_TRACE` for ~30 traced syscalls and `SECCOMP_RET_ALLOW` for all others, so only traced syscalls generate ptrace stops.

### Changes

- **BPF builder**: `buildPrefilterBPF()` generates filter from `tracedSyscallNumbers()` with architecture validation (AUDIT_ARCH check, fail-closed on mismatch)
- **Injection**: `injectSeccompFilter(tid)` writes BPF to tracee scratch page, injects `prctl(PR_SET_NO_NEW_PRIVS)` + `seccomp(SECCOMP_SET_MODE_FILTER)`. Non-fatal on failure.
- **Per-tracee state**: Replace global `prefilterActive` with per-tracee `HasPrefilter`/`PendingPrefilter`. Children inherit via `handleNewChild`.
- **Deferred injection**: Inject at first syscall EXIT (not at attach interrupt stop where RIP is arbitrary). `InSyscall` carefully managed around injection.
- **Lifecycle reorder**: `attachThread` creates `TraceeState`/`MemFD` before injection and resume, with rollback cleanup on failure.
- **handleSeccompStop**: Sets `LastNr` for exit-time handlers.
- **ptraceOptions**: `PTRACE_O_TRACESECCOMP` only when `SeccompPrefilter` enabled.

### Known limitation

`PtraceSyscall` is used uniformly (not `PtraceCont`) to preserve exit-time handlers (TracerPid masking, fd tracking, TLS SNI). This means non-traced syscalls still generate exit stops in prefilter mode. A per-syscall resume optimization is planned as a follow-up.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go build ./...` + `GOOS=windows go build ./...` — cross-compilation clean
- [x] `make ptrace-test` — 76 Docker ptrace integration tests pass
- [x] BPF builder tests: instruction count, syscall parity, arch check
- [x] 12 rounds of roborev review with all high findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)