### PR TITLE
feat: per-syscall PtraceCont/PtraceSyscall resume optimization

### DIFF
--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -476,7 +476,7 @@ func (t *Tracer) allowSyscall(tid int) {
 	needExit := false
 	if s := t.tracees[tid]; s != nil {
 		hasPrefilter = s.HasPrefilter
-		needExit = s.NeedExitStop
+		needExit = s.NeedExitStop || s.PendingDenyErrno != 0 || s.PendingFakeZero || s.HasPendingReturn || s.PendingExecStubFD >= 0
 	}
 	t.mu.Unlock()
 
@@ -543,7 +543,7 @@ func (t *Tracer) resumeTracee(tid int, sig int) {
 	needExit := false
 	if s := t.tracees[tid]; s != nil {
 		hasPrefilter = s.HasPrefilter
-		needExit = s.NeedExitStop
+		needExit = s.NeedExitStop || s.PendingDenyErrno != 0 || s.PendingFakeZero || s.HasPendingReturn || s.PendingExecStubFD >= 0
 	}
 	t.mu.Unlock()
 
@@ -594,6 +594,18 @@ func (t *Tracer) applyReturnOverride(tid int, retval int64) {
 	t.setRegs(tid, regs)
 }
 
+// hasNeedExitStop returns true if the tracee needs an exit stop for exit-time
+// handlers (read masking, fd tracking, TLS watch, exec failure reset).
+func (t *Tracer) hasNeedExitStop(tid int) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	state := t.tracees[tid]
+	if state == nil {
+		return false
+	}
+	return state.InSyscall && state.NeedExitStop
+}
+
 // hasPendingSyscallExit returns true if the tracee has a pending deny errno,
 // fake-zero fixup, return override, or exec stub fd cleanup that needs to be
 // applied at syscall exit.
@@ -640,11 +652,10 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 			case unix.PTRACE_EVENT_STOP:
 				t.handleEventStop(tid)
 			default:
-				// In prefilter mode (PTRACE_O_TRACESECCOMP without
-				// TRACESYSGOOD), a plain SIGTRAP with no event can be
+				// In prefilter mode, a plain SIGTRAP with no event can be
 				// a syscall-exit stop if we explicitly used PtraceSyscall
-				// (e.g., after soft-delete). Check for pending fixups.
-				if t.hasPendingSyscallExit(tid) {
+				// (e.g., for exit-needing syscalls or pending fixups).
+				if t.hasPendingSyscallExit(tid) || t.hasNeedExitStop(tid) {
 					t.handleSyscallStop(ctx, tid)
 				} else {
 					t.resumeTracee(tid, 0)

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -162,6 +162,7 @@ type TraceeState struct {
 	PendingInterrupt      bool
 	HasPrefilter     bool // true if seccomp prefilter is installed for this tracee
 	PendingPrefilter bool // inject seccomp filter on next syscall stop
+	NeedExitStop     bool // resume with PtraceSyscall to catch exit
 	IsVforkChild     bool
 	SuppressInitialStop bool // suppress initial SIGSTOP from auto-trace
 	PendingExecStubFD  int // fd injected for exec redirect; cleaned up on exec failure (-1 = none)
@@ -448,15 +449,43 @@ func (t *Tracer) setRegs(tid int, regs Regs) error {
 	return setRegsArch(tid, regs)
 }
 
+// needsExitStop returns true for syscalls that need exit-time processing.
+// These syscalls must be resumed with PtraceSyscall (not PtraceCont) so the
+// tracer catches the exit stop. All other traced syscalls are entry-only and
+// can use PtraceCont to skip directly to the next seccomp event.
+func needsExitStop(nr int) bool {
+	switch nr {
+	case unix.SYS_READ, unix.SYS_PREAD64: // handleReadExit (TracerPid masking)
+		return true
+	case unix.SYS_OPENAT: // handleOpenatExit (fd tracking)
+		return true
+	case unix.SYS_OPENAT2: // handleOpenatExit (fd tracking)
+		return true
+	case unix.SYS_CONNECT: // handleConnectExit (TLS fd watch)
+		return true
+	case unix.SYS_EXECVE, unix.SYS_EXECVEAT: // failed exec needs exit to reset InSyscall
+		return true
+	}
+	return false
+}
+
 // allowSyscall resumes the tracee, allowing the syscall to proceed.
 func (t *Tracer) allowSyscall(tid int) {
-	// Always use PtraceSyscall to catch syscall-exit stops, which are needed
-	// for exit-time handlers (TracerPid masking, fd tracking, TLS SNI, etc.).
-	// In prefilter mode, the BPF filter ensures only traced syscalls generate
-	// entry stops; PtraceSyscall then catches their exits. Non-traced syscalls
-	// don't stop at all (BPF returns ALLOW), so this is still efficient.
+	t.mu.Lock()
+	hasPrefilter := false
+	needExit := false
+	if s := t.tracees[tid]; s != nil {
+		hasPrefilter = s.HasPrefilter
+		needExit = s.NeedExitStop
+	}
+	t.mu.Unlock()
+
 	var err error
-	err = unix.PtraceSyscall(tid, 0)
+	if hasPrefilter && !needExit {
+		err = unix.PtraceCont(tid, 0)
+	} else {
+		err = unix.PtraceSyscall(tid, 0)
+	}
 	if err != nil && errors.Is(err, unix.ESRCH) {
 		t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
 	}
@@ -509,7 +538,20 @@ func (t *Tracer) denySyscall(tid int, errno int) error {
 // resumeTracee resumes a tracee with an optional signal to deliver.
 // Always uses PtraceSyscall to catch exit-time stops (see allowSyscall).
 func (t *Tracer) resumeTracee(tid int, sig int) {
-	unix.PtraceSyscall(tid, sig)
+	t.mu.Lock()
+	hasPrefilter := false
+	needExit := false
+	if s := t.tracees[tid]; s != nil {
+		hasPrefilter = s.HasPrefilter
+		needExit = s.NeedExitStop
+	}
+	t.mu.Unlock()
+
+	if hasPrefilter && !needExit {
+		unix.PtraceCont(tid, sig)
+	} else {
+		unix.PtraceSyscall(tid, sig)
+	}
 }
 
 // ptraceListen calls PTRACE_LISTEN on the specified tid. In PTRACE_SEIZE
@@ -763,6 +805,7 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		nr := regs.SyscallNr()
 		t.mu.Lock()
 		state.LastNr = nr
+		state.NeedExitStop = needsExitStop(nr)
 		tgid := state.TGID
 		t.mu.Unlock()
 
@@ -795,6 +838,7 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		t.mu.Lock()
 		if state != nil {
 			nr = state.LastNr
+			state.NeedExitStop = false
 		}
 		t.mu.Unlock()
 
@@ -828,6 +872,7 @@ func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
 		tgid = state.TGID
 		state.InSyscall = true
 		state.LastNr = nr
+		state.NeedExitStop = needsExitStop(nr)
 	}
 	t.mu.Unlock()
 	if tgid != 0 {

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -469,6 +469,17 @@ func needsExitStop(nr int) bool {
 	return false
 }
 
+// mustCatchExit returns true if the tracee must be resumed with PtraceSyscall
+// to catch the syscall exit stop. True when NeedExitStop is set or when
+// pending fixups (deny errno, fake zero, return override, exec stub) require
+// exit-time processing.
+func mustCatchExit(s *TraceeState) bool {
+	if s == nil {
+		return false
+	}
+	return s.NeedExitStop || s.PendingDenyErrno != 0 || s.PendingFakeZero || s.HasPendingReturn || s.PendingExecStubFD >= 0
+}
+
 // allowSyscall resumes the tracee, allowing the syscall to proceed.
 func (t *Tracer) allowSyscall(tid int) {
 	t.mu.Lock()
@@ -476,7 +487,7 @@ func (t *Tracer) allowSyscall(tid int) {
 	needExit := false
 	if s := t.tracees[tid]; s != nil {
 		hasPrefilter = s.HasPrefilter
-		needExit = s.NeedExitStop || s.PendingDenyErrno != 0 || s.PendingFakeZero || s.HasPendingReturn || s.PendingExecStubFD >= 0
+		needExit = mustCatchExit(s)
 	}
 	t.mu.Unlock()
 
@@ -544,7 +555,7 @@ func (t *Tracer) resumeTracee(tid int, sig int) {
 	needExit := false
 	if s := t.tracees[tid]; s != nil {
 		hasPrefilter = s.HasPrefilter
-		needExit = s.NeedExitStop || s.PendingDenyErrno != 0 || s.PendingFakeZero || s.HasPendingReturn || s.PendingExecStubFD >= 0
+		needExit = mustCatchExit(s)
 	}
 	t.mu.Unlock()
 

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -640,22 +640,10 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 			case unix.PTRACE_EVENT_STOP:
 				t.handleEventStop(tid)
 			default:
-				// In prefilter mode, a plain SIGTRAP with no event can be
-				// a syscall-exit stop if we explicitly used PtraceSyscall
-				// (e.g., for exit-needing syscalls or pending fixups).
-				// Only treat as syscall-exit when the tracee has a prefilter
-				// AND is in a syscall. Otherwise, it's a real SIGTRAP signal.
-				t.mu.Lock()
-				isSyscallExit := false
-				if s := t.tracees[tid]; s != nil && s.HasPrefilter && s.InSyscall {
-					isSyscallExit = s.NeedExitStop || s.PendingDenyErrno != 0 || s.PendingFakeZero || s.HasPendingReturn || s.PendingExecStubFD >= 0
-				}
-				t.mu.Unlock()
-				if isSyscallExit {
-					t.handleSyscallStop(ctx, tid)
-				} else {
-					t.resumeTracee(tid, int(sig))
-				}
+				// With TRACESYSGOOD always set, syscall stops are SIGTRAP|0x80.
+				// Seccomp entries are PTRACE_EVENT_SECCOMP. A plain SIGTRAP
+				// with no event is always a real signal — reinject it.
+				t.resumeTracee(tid, int(sig))
 			}
 
 		default:

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -536,7 +536,8 @@ func (t *Tracer) denySyscall(tid int, errno int) error {
 }
 
 // resumeTracee resumes a tracee with an optional signal to deliver.
-// Always uses PtraceSyscall to catch exit-time stops (see allowSyscall).
+// Uses PtraceCont when prefilter is active and no exit stop is needed,
+// PtraceSyscall otherwise.
 func (t *Tracer) resumeTracee(tid int, sig int) {
 	t.mu.Lock()
 	hasPrefilter := false

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -595,19 +595,6 @@ func (t *Tracer) applyReturnOverride(tid int, retval int64) {
 	t.setRegs(tid, regs)
 }
 
-// hasPendingSyscallExit returns true if the tracee has a pending deny errno,
-// fake-zero fixup, return override, or exec stub fd cleanup that needs to be
-// applied at syscall exit.
-func (t *Tracer) hasPendingSyscallExit(tid int) bool {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	state := t.tracees[tid]
-	if state == nil {
-		return false
-	}
-	return state.InSyscall && (state.PendingDenyErrno != 0 || state.PendingFakeZero || state.HasPendingReturn || state.PendingExecStubFD >= 0)
-}
-
 // handleStop dispatches a tracee stop event.
 func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus, rusage *unix.Rusage) {
 	switch {

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -594,18 +594,6 @@ func (t *Tracer) applyReturnOverride(tid int, retval int64) {
 	t.setRegs(tid, regs)
 }
 
-// hasNeedExitStop returns true if the tracee needs an exit stop for exit-time
-// handlers (read masking, fd tracking, TLS watch, exec failure reset).
-func (t *Tracer) hasNeedExitStop(tid int) bool {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	state := t.tracees[tid]
-	if state == nil {
-		return false
-	}
-	return state.InSyscall && state.NeedExitStop
-}
-
 // hasPendingSyscallExit returns true if the tracee has a pending deny errno,
 // fake-zero fixup, return override, or exec stub fd cleanup that needs to be
 // applied at syscall exit.
@@ -655,10 +643,18 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 				// In prefilter mode, a plain SIGTRAP with no event can be
 				// a syscall-exit stop if we explicitly used PtraceSyscall
 				// (e.g., for exit-needing syscalls or pending fixups).
-				if t.hasPendingSyscallExit(tid) || t.hasNeedExitStop(tid) {
+				// Only treat as syscall-exit when the tracee has a prefilter
+				// AND is in a syscall. Otherwise, it's a real SIGTRAP signal.
+				t.mu.Lock()
+				isSyscallExit := false
+				if s := t.tracees[tid]; s != nil && s.HasPrefilter && s.InSyscall {
+					isSyscallExit = s.NeedExitStop || s.PendingDenyErrno != 0 || s.PendingFakeZero || s.HasPendingReturn || s.PendingExecStubFD >= 0
+				}
+				t.mu.Unlock()
+				if isSyscallExit {
 					t.handleSyscallStop(ctx, tid)
 				} else {
-					t.resumeTracee(tid, 0)
+					t.resumeTracee(tid, int(sig))
 				}
 			}
 

--- a/internal/ptrace/tracer_test.go
+++ b/internal/ptrace/tracer_test.go
@@ -61,3 +61,28 @@ func TestTracerConfig_HandlerFields(t *testing.T) {
 		t.Error("SignalHandler should be nil by default")
 	}
 }
+
+func TestNeedsExitStop(t *testing.T) {
+	exitNeeded := []int{
+		unix.SYS_READ, unix.SYS_PREAD64,
+		unix.SYS_OPENAT, unix.SYS_OPENAT2,
+		unix.SYS_CONNECT,
+		unix.SYS_EXECVE, unix.SYS_EXECVEAT,
+	}
+	for _, nr := range exitNeeded {
+		if !needsExitStop(nr) {
+			t.Errorf("needsExitStop(%d) = false, want true", nr)
+		}
+	}
+
+	entryOnly := []int{
+		unix.SYS_WRITE, unix.SYS_CLOSE, unix.SYS_KILL,
+		unix.SYS_BIND, unix.SYS_SOCKET, unix.SYS_SENDTO,
+		unix.SYS_UNLINKAT, unix.SYS_MKDIRAT,
+	}
+	for _, nr := range entryOnly {
+		if needsExitStop(nr) {
+			t.Errorf("needsExitStop(%d) = true, want false", nr)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Use `PtraceCont` for entry-only syscalls (~23) and `PtraceSyscall` only for the 7 syscalls needing exit processing. This realizes the seccomp prefilter's benefit by skipping exit stops for syscalls that don't need them.

### Changes (tracer.go only, ~50 lines)

- `needsExitStop(nr)`: returns true for read, pread64, openat, openat2, connect, execve, execveat
- `mustCatchExit(state)`: shared predicate checking NeedExitStop + all pending fixup flags
- `NeedExitStop bool` on TraceeState, set at entry, cleared at exit
- `allowSyscall`/`resumeTracee`: `PtraceCont` when `HasPrefilter && !mustCatchExit`
- Plain SIGTRAP always reinjected as real signal (TRACESYSGOOD guarantees syscall stops are SIGTRAP|0x80)
- Remove unused `hasPendingSyscallExit` helper

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go build ./...` + `GOOS=windows go build ./...` — clean
- [x] `TestNeedsExitStop` — validates 7 positive and 8 negative cases
- [x] 7 rounds of roborev — no high findings remain
- [ ] `make ptrace-test` — Docker integration tests (76 tests)
- [ ] Benchmark: 4-mode comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)