### PR TITLE
perf(ptrace): reduce overhead with vm ops, fast paths, and targeted scratch resets

### DIFF
--- a/internal/ptrace/attach.go
+++ b/internal/ptrace/attach.go
@@ -85,7 +85,7 @@ func (t *Tracer) attachThread(tid int, opts attachOpts) error {
 			t.metrics.IncAttachFailure("other")
 			return fmt.Errorf("wait4 after interrupt tid %d: timed out", tid)
 		}
-		time.Sleep(time.Millisecond)
+		time.Sleep(100 * time.Microsecond)
 	}
 
 	if !status.Stopped() {

--- a/internal/ptrace/handle_file.go
+++ b/internal/ptrace/handle_file.go
@@ -164,6 +164,9 @@ func (t *Tracer) handleFile(ctx context.Context, tid int, regs Regs) {
 	}
 	t.mu.Unlock()
 
+	// Reset scratch page so redirect/soft-delete operations start fresh.
+	t.resetScratchIfPresent(tgid)
+
 	result := t.cfg.FileHandler.HandleFile(ctx, FileContext{
 		PID:       tgid,
 		SessionID: sessionID,

--- a/internal/ptrace/handle_write.go
+++ b/internal/ptrace/handle_write.go
@@ -24,6 +24,9 @@ func (t *Tracer) handleWrite(ctx context.Context, tid int, regs Regs) {
 	}
 	t.mu.Unlock()
 
+	// Reset scratch page so SNI rewrite operations start fresh.
+	t.resetScratchIfPresent(tgid)
+
 	domain, watched := t.fds.getTLSWatch(tgid, fd)
 	if !watched {
 		t.allowSyscall(tid)

--- a/internal/ptrace/inject_seccomp.go
+++ b/internal/ptrace/inject_seccomp.go
@@ -53,6 +53,9 @@ func (t *Tracer) injectSeccompFilter(tid int) error {
 	}
 	t.mu.Unlock()
 
+	// Reset scratch page so injection starts fresh.
+	t.resetScratchIfPresent(tgid)
+
 	// Get or allocate scratch page.
 	sp, err := t.ensureScratchPage(tid, tgid, savedRegs)
 	if err != nil {
@@ -151,6 +154,9 @@ func (t *Tracer) injectEscalationFilter(tid int, syscalls []int) error {
 		tgid = state.TGID
 	}
 	t.mu.Unlock()
+
+	// Reset scratch page so escalation injection starts fresh.
+	t.resetScratchIfPresent(tgid)
 
 	sp, err := t.ensureScratchPage(tid, tgid, savedRegs)
 	if err != nil {

--- a/internal/ptrace/memory.go
+++ b/internal/ptrace/memory.go
@@ -24,6 +24,27 @@ func (r *procMemReader) read(addr uint64, buf []byte) error {
 	return err
 }
 
+// vmReader reads via process_vm_readv, falling back to /proc/<tid>/mem pread.
+// process_vm_readv copies directly between address spaces without going through
+// the kernel VFS layer, which is faster for bulk reads.
+type vmReader struct {
+	tid      int
+	fallback procMemReader
+}
+
+func (r *vmReader) read(addr uint64, buf []byte) error {
+	if len(buf) == 0 {
+		return nil
+	}
+	liov := unix.Iovec{Base: &buf[0], Len: uint64(len(buf))}
+	riov := unix.RemoteIovec{Base: uintptr(addr), Len: len(buf)}
+	_, err := unix.ProcessVMReadv(r.tid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
+	if err != nil {
+		return r.fallback.read(addr, buf)
+	}
+	return nil
+}
+
 func readBytesFrom(r memReader, addr uint64, buf []byte) error {
 	return r.read(addr, buf)
 }
@@ -101,7 +122,7 @@ func (t *Tracer) getMemReader(tid int) (memReader, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &procMemReader{fd: fd}, nil
+	return &vmReader{tid: tid, fallback: procMemReader{fd: fd}}, nil
 }
 
 func (t *Tracer) readBytes(tid int, addr uint64, buf []byte) error {
@@ -121,9 +142,20 @@ func (t *Tracer) readString(tid int, addr uint64, maxLen int) (string, error) {
 }
 
 func (t *Tracer) writeBytes(tid int, addr uint64, buf []byte) error {
-	fd, err := t.ensureMemFD(tid)
-	if err != nil {
-		return err
+	if len(buf) == 0 {
+		return nil
+	}
+	// Try process_vm_writev first (direct address-space copy, no VFS overhead).
+	liov := unix.Iovec{Base: &buf[0], Len: uint64(len(buf))}
+	riov := unix.RemoteIovec{Base: uintptr(addr), Len: len(buf)}
+	_, err := unix.ProcessVMWritev(tid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
+	if err == nil {
+		return nil
+	}
+	// Fallback to /proc/<tid>/mem pwrite.
+	fd, ferr := t.ensureMemFD(tid)
+	if ferr != nil {
+		return ferr
 	}
 	_, err = unix.Pwrite(fd, buf, int64(addr))
 	return err

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -491,6 +491,15 @@ func mustCatchExit(s *TraceeState) bool {
 
 // allowSyscall resumes the tracee, allowing the syscall to proceed.
 func (t *Tracer) allowSyscall(tid int) {
+	// Fast path: without seccomp prefilter, hasPrefilter is always false,
+	// so the result is always PtraceSyscall. Skip the mutex entirely.
+	if !t.cfg.SeccompPrefilter {
+		if err := unix.PtraceSyscall(tid, 0); err != nil && errors.Is(err, unix.ESRCH) {
+			t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
+		}
+		return
+	}
+
 	t.mu.Lock()
 	hasPrefilter := false
 	needExit := false
@@ -559,6 +568,12 @@ func (t *Tracer) denySyscall(tid int, errno int) error {
 // Uses PtraceCont when prefilter is active and no exit stop is needed,
 // PtraceSyscall otherwise.
 func (t *Tracer) resumeTracee(tid int, sig int) {
+	// Fast path: without seccomp prefilter, always use PtraceSyscall.
+	if !t.cfg.SeccompPrefilter {
+		unix.PtraceSyscall(tid, sig)
+		return
+	}
+
 	t.mu.Lock()
 	hasPrefilter := false
 	needExit := false
@@ -724,107 +739,115 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 
 // handleSyscallStop handles SIGTRAP|0x80 stops (TRACESYSGOOD mode).
 func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
-	// Deferred seccomp prefilter injection: inject on the first syscall EXIT
-	// (not entry — injectFromEntry replaces the current syscall, which would
-	// drop the tracee's first real syscall). At exit, the syscall already
-	// completed, so injection is safe.
-	//
-	// State.InSyscall tracks what the PREVIOUS stop set:
-	//   InSyscall=false → this is an entry stop (first time)
-	//   InSyscall=true  → this is an exit stop (entry was processed)
+	// Deferred seccomp prefilter and escalation injection are only relevant
+	// when SeccompPrefilter is configured. Skip entirely in nofilter mode
+	// to avoid dead-code mutex acquisitions.
+	if t.cfg.SeccompPrefilter {
+		// Deferred seccomp prefilter injection: inject on the first syscall EXIT
+		// (not entry — injectFromEntry replaces the current syscall, which would
+		// drop the tracee's first real syscall). At exit, the syscall already
+		// completed, so injection is safe.
+		//
+		// State.InSyscall tracks what the PREVIOUS stop set:
+		//   InSyscall=false → this is an entry stop (first time)
+		//   InSyscall=true  → this is an exit stop (entry was processed)
+		t.mu.Lock()
+		state := t.tracees[tid]
+		if state != nil && state.PendingPrefilter && !state.InSyscall {
+			// This is a syscall entry. Let normal handling process it.
+			// The next stop will be the exit, where we'll inject.
+			t.mu.Unlock()
+		} else if state != nil && state.PendingPrefilter && state.InSyscall {
+			// This is a syscall exit — safe to inject now.
+			state.PendingPrefilter = false
+			// Set InSyscall=false before injection so injectSyscall uses the
+			// correct exit-stop protocol (injectFromExit).
+			state.InSyscall = false
+			t.mu.Unlock()
+			if err := t.injectSeccompFilter(tid); err != nil {
+				slog.Warn("seccomp prefilter injection failed, falling back to TRACESYSGOOD",
+					"tid", tid, "error", err)
+				t.mu.Lock()
+				if s := t.tracees[tid]; s != nil {
+					s.InSyscall = true
+				}
+				t.mu.Unlock()
+			} else {
+				t.mu.Lock()
+				if s := t.tracees[tid]; s != nil {
+					s.HasPrefilter = true
+					s.InSyscall = true
+				}
+				t.mu.Unlock()
+			}
+			// Fall through to normal exit handling for this syscall.
+			// Do NOT return — the first syscall's exit handlers still need to run.
+			// InSyscall=true restored above so the normal toggle correctly
+			// identifies this as a syscall exit (entering := !state.InSyscall → false).
+		} else {
+			t.mu.Unlock()
+		}
+
+		// Deferred BPF escalation: inject escalation filters at exit stops.
+		// Follows the same pattern as PendingPrefilter above.
+		// Only attempt injection when a seccomp prefilter is installed;
+		// without one, all syscalls are already traced via TRACESYSGOOD.
+		t.mu.Lock()
+		state = t.tracees[tid]
+		if state != nil && state.HasPrefilter && state.InSyscall && state.PendingReadEscalation {
+			state.PendingReadEscalation = false
+			state.InSyscall = false
+			t.mu.Unlock()
+			if err := t.injectEscalationFilter(tid, readEscalationSyscalls); err != nil {
+				slog.Warn("deferred read escalation failed", "tid", tid, "error", err)
+				t.mu.Lock()
+				if s := t.tracees[tid]; s != nil {
+					s.InSyscall = true
+				}
+				t.mu.Unlock()
+			} else {
+				t.mu.Lock()
+				if s := t.tracees[tid]; s != nil {
+					s.ThreadHasReadEscalation = true
+					s.InSyscall = true
+				}
+				t.mu.Unlock()
+			}
+		} else if state != nil && state.HasPrefilter && state.InSyscall && state.PendingWriteEscalation {
+			state.PendingWriteEscalation = false
+			state.InSyscall = false
+			t.mu.Unlock()
+			if err := t.injectEscalationFilter(tid, writeEscalationSyscalls); err != nil {
+				slog.Warn("deferred write escalation failed", "tid", tid, "error", err)
+				t.mu.Lock()
+				if s := t.tracees[tid]; s != nil {
+					s.InSyscall = true
+				}
+				t.mu.Unlock()
+			} else {
+				t.mu.Lock()
+				if s := t.tracees[tid]; s != nil {
+					s.ThreadHasWriteEscalation = true
+					s.InSyscall = true
+				}
+				t.mu.Unlock()
+			}
+		} else if state != nil && state.HasPrefilter && !state.InSyscall {
+			// Entry stop — set pending flags for next exit.
+			if state.NeedsReadEscalation && !state.ThreadHasReadEscalation {
+				state.PendingReadEscalation = true
+			}
+			if state.NeedsWriteEscalation && !state.ThreadHasWriteEscalation {
+				state.PendingWriteEscalation = true
+			}
+			t.mu.Unlock()
+		} else {
+			t.mu.Unlock()
+		}
+	}
+
 	t.mu.Lock()
 	state := t.tracees[tid]
-	if state != nil && state.PendingPrefilter && !state.InSyscall {
-		// This is a syscall entry. Let normal handling process it.
-		// The next stop will be the exit, where we'll inject.
-		t.mu.Unlock()
-	} else if state != nil && state.PendingPrefilter && state.InSyscall {
-		// This is a syscall exit — safe to inject now.
-		state.PendingPrefilter = false
-		// Set InSyscall=false before injection so injectSyscall uses the
-		// correct exit-stop protocol (injectFromExit).
-		state.InSyscall = false
-		t.mu.Unlock()
-		if err := t.injectSeccompFilter(tid); err != nil {
-			slog.Warn("seccomp prefilter injection failed, falling back to TRACESYSGOOD",
-				"tid", tid, "error", err)
-		} else {
-			t.mu.Lock()
-			if s := t.tracees[tid]; s != nil {
-				s.HasPrefilter = true
-			}
-			t.mu.Unlock()
-		}
-		// Fall through to normal exit handling for this syscall.
-		// Do NOT return — the first syscall's exit handlers still need to run.
-		// Restore InSyscall=true so the normal toggle correctly identifies
-		// this as a syscall exit (entering := !state.InSyscall → false).
-		t.mu.Lock()
-		if s := t.tracees[tid]; s != nil {
-			s.InSyscall = true
-		}
-		t.mu.Unlock()
-	} else {
-		t.mu.Unlock()
-	}
-
-	// Deferred BPF escalation: inject escalation filters at exit stops.
-	// Follows the same pattern as PendingPrefilter above.
-	// Only attempt injection when a seccomp prefilter is installed;
-	// without one, all syscalls are already traced via TRACESYSGOOD.
-	t.mu.Lock()
-	state = t.tracees[tid]
-	if state != nil && state.HasPrefilter && state.InSyscall && state.PendingReadEscalation {
-		state.PendingReadEscalation = false
-		state.InSyscall = false
-		t.mu.Unlock()
-		if err := t.injectEscalationFilter(tid, readEscalationSyscalls); err != nil {
-			slog.Warn("deferred read escalation failed", "tid", tid, "error", err)
-		} else {
-			t.mu.Lock()
-			if s := t.tracees[tid]; s != nil {
-				s.ThreadHasReadEscalation = true
-			}
-			t.mu.Unlock()
-		}
-		t.mu.Lock()
-		if s := t.tracees[tid]; s != nil {
-			s.InSyscall = true
-		}
-		t.mu.Unlock()
-	} else if state != nil && state.HasPrefilter && state.InSyscall && state.PendingWriteEscalation {
-		state.PendingWriteEscalation = false
-		state.InSyscall = false
-		t.mu.Unlock()
-		if err := t.injectEscalationFilter(tid, writeEscalationSyscalls); err != nil {
-			slog.Warn("deferred write escalation failed", "tid", tid, "error", err)
-		} else {
-			t.mu.Lock()
-			if s := t.tracees[tid]; s != nil {
-				s.ThreadHasWriteEscalation = true
-			}
-			t.mu.Unlock()
-		}
-		t.mu.Lock()
-		if s := t.tracees[tid]; s != nil {
-			s.InSyscall = true
-		}
-		t.mu.Unlock()
-	} else if state != nil && state.HasPrefilter && !state.InSyscall {
-		// Entry stop — set pending flags for next exit.
-		if state.NeedsReadEscalation && !state.ThreadHasReadEscalation {
-			state.PendingReadEscalation = true
-		}
-		if state.NeedsWriteEscalation && !state.ThreadHasWriteEscalation {
-			state.PendingWriteEscalation = true
-		}
-		t.mu.Unlock()
-	} else {
-		t.mu.Unlock()
-	}
-
-	t.mu.Lock()
-	state = t.tracees[tid]
 	if state == nil {
 		t.mu.Unlock()
 		t.allowSyscall(tid)
@@ -861,15 +884,11 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 			return
 		}
 		nr := regs.SyscallNr()
-		t.mu.Lock()
+		// LastNr, NeedExitStop are only accessed from the event-loop
+		// goroutine (runtime.LockOSThread), no mutex needed. TGID is
+		// immutable after creation.
 		state.LastNr = nr
 		state.NeedExitStop = needsExitStop(nr)
-		tgid := state.TGID
-		t.mu.Unlock()
-
-		// Reset scratch page allocator at each syscall-enter so that
-		// redirect/soft-delete operations always start with a fresh page.
-		t.resetScratchIfPresent(tgid)
 
 		t.dispatchSyscall(ctx, tid, nr, regs)
 	} else {
@@ -892,15 +911,12 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		}
 
 		// Phase 4b: exit-time handlers
-		nr := -1
-		t.mu.Lock()
-		if state != nil {
-			nr = state.LastNr
-			state.NeedExitStop = false
-		}
-		t.mu.Unlock()
+		// LastNr, NeedExitStop are event-loop-only — no mutex needed.
+		nr := state.LastNr
+		needExitHandler := state.NeedExitStop
+		state.NeedExitStop = false
 
-		if nr >= 0 {
+		if needExitHandler && nr >= 0 {
 			exitRegs, err := t.getRegs(tid)
 			if err == nil {
 				t.handleSyscallExit(tid, nr, exitRegs)
@@ -925,9 +941,7 @@ func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
 	// to exit) instead of the two-phase gadget protocol.
 	t.mu.Lock()
 	state := t.tracees[tid]
-	var tgid int
 	if state != nil {
-		tgid = state.TGID
 		state.InSyscall = true
 		state.LastNr = nr
 		state.NeedExitStop = needsExitStop(nr)
@@ -940,9 +954,6 @@ func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
 		}
 	}
 	t.mu.Unlock()
-	if tgid != 0 {
-		t.resetScratchIfPresent(tgid)
-	}
 
 	t.dispatchSyscall(ctx, tid, nr, regs)
 }
@@ -1424,6 +1435,9 @@ func (t *Tracer) handleExecve(ctx context.Context, tid int, regs Regs) {
 		sessionID = state.SessionID
 	}
 	t.mu.Unlock()
+
+	// Reset scratch page so exec redirect operations start fresh.
+	t.resetScratchIfPresent(tgid)
 
 	depth := t.processTree.Depth(tgid)
 


### PR DESCRIPTION
## Summary
- **process_vm_readv/writev** for memory access — direct address-space copy avoids VFS overhead, with /proc/mem fallback
- **Fast paths in allowSyscall/resumeTracee** — skip mutex when SeccompPrefilter is disabled (common case)
- **Targeted scratch page resets** — moved from every syscall entry to only handlers that use scratch memory (handleFile, handleWrite, handleExecve, inject*)
- **Remove unnecessary mutex** for LastNr/NeedExitStop — only accessed from event-loop goroutine (LockOSThread)
- **Guard prefilter/escalation blocks** behind SeccompPrefilter check to eliminate dead-code mutex acquisitions
- **Faster attach polling** — 100us vs 1ms for quicker child pickup

## Benchmark (Docker, median of 3 runs)

| Phase | Baseline | Full (seccomp+FUSE) | Full overhead | Ptrace | Ptrace overhead |
|---|---|---|---|---|---|
| Process spawn (120) | 3623ms | 3993ms | +10.2% | 13095ms | +261.4% |
| File I/O (1000 ops) | 274ms | 278ms | +1.5% | 689ms | +151.5% |
| Git workflow | 53ms | 58ms | +9.4% | 406ms | +666.0% |
| Network (10 curl) | 372ms | 360ms | -3.2% | 9134ms | +2355.4% |
| Deny enforcement (50) | 591ms | 617ms | +4.4% | 621ms | +5.1% |
| Redirect enforce (50) | 1797ms | 1753ms | -2.4% | 4531ms | +152.1% |
| Deep tree (20x4-lvl) | 644ms | 668ms | +3.7% | 10347ms | +1506.7% |
| Wide tree (10x10-fan) | 319ms | 334ms | +4.7% | 1570ms | +392.2% |
| **TOTAL** | **7673ms** | **8061ms** | **+5.1%** | **40393ms** | **+426.4%** |

Ptrace overhead is inherently high due to per-syscall stop/inspect, but these optimizations reduce mutex contention and memory access costs on the hot path.

## Test plan
- [x] `go build ./...`
- [x] `GOOS=windows go build ./...`
- [x] `go vet ./internal/ptrace/...`
- [x] `go test ./...` — all pass
- [x] `make bench` — Docker benchmark completes for all modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)