### PR TITLE
fix(ptrace): make DNS proxy IPv6 listener best-effort

### DIFF
--- a/internal/ptrace/dns_proxy.go
+++ b/internal/ptrace/dns_proxy.go
@@ -34,17 +34,22 @@ func newDNSProxy(handler NetworkHandler, fds *fdTracker) (*dnsProxy, error) {
 	}
 	port4 := conn4.LocalAddr().(*net.UDPAddr).Port
 
+	// IPv6 listener is best-effort — gVisor and some container runtimes
+	// block UDP6, so we fall back to IPv4-only DNS proxying.
+	var conn6 *net.UDPConn
+	var port6 int
 	udpAddr6, err := net.ResolveUDPAddr("udp6", "[::1]:0")
-	if err != nil {
-		conn4.Close()
-		return nil, fmt.Errorf("resolve UDP6 addr: %w", err)
+	if err == nil {
+		conn6, err = net.ListenUDP("udp6", udpAddr6)
+		if err != nil {
+			slog.Warn("dns_proxy: IPv6 listener unavailable, IPv4 only", "error", err)
+			conn6 = nil
+		} else {
+			port6 = conn6.LocalAddr().(*net.UDPAddr).Port
+		}
+	} else {
+		slog.Warn("dns_proxy: IPv6 resolve failed, IPv4 only", "error", err)
 	}
-	conn6, err := net.ListenUDP("udp6", udpAddr6)
-	if err != nil {
-		conn4.Close()
-		return nil, fmt.Errorf("listen UDP6: %w", err)
-	}
-	port6 := conn6.LocalAddr().(*net.UDPAddr).Port
 
 	return &dnsProxy{
 		handler:  handler,
@@ -57,16 +62,27 @@ func newDNSProxy(handler NetworkHandler, fds *fdTracker) (*dnsProxy, error) {
 }
 
 func (p *dnsProxy) addr4() string { return fmt.Sprintf("127.0.0.1:%d", p.port4) }
-func (p *dnsProxy) addr6() string { return fmt.Sprintf("[::1]:%d", p.port6) }
+func (p *dnsProxy) addr6() string {
+	if p.udpConn6 == nil {
+		return "<disabled>"
+	}
+	return fmt.Sprintf("[::1]:%d", p.port6)
+}
 
 func (p *dnsProxy) run(ctx context.Context) {
 	go func() {
 		<-ctx.Done()
 		p.udpConn4.Close()
-		p.udpConn6.Close()
+		if p.udpConn6 != nil {
+			p.udpConn6.Close()
+		}
 	}()
-	go p.listenUDP(ctx, p.udpConn4, unix.AF_INET)
-	p.listenUDP(ctx, p.udpConn6, unix.AF_INET6)
+	if p.udpConn6 != nil {
+		go p.listenUDP(ctx, p.udpConn4, unix.AF_INET)
+		p.listenUDP(ctx, p.udpConn6, unix.AF_INET6)
+	} else {
+		p.listenUDP(ctx, p.udpConn4, unix.AF_INET)
+	}
 }
 
 func (p *dnsProxy) listenUDP(ctx context.Context, conn *net.UDPConn, family int) {

--- a/internal/ptrace/handle_network.go
+++ b/internal/ptrace/handle_network.go
@@ -97,15 +97,18 @@ func (t *Tracer) handleNetwork(ctx context.Context, tid int, regs Regs) {
 					var newDest []byte
 					if destFamily == unix.AF_INET {
 						newDest = buildSockaddrIn4(net.ParseIP("127.0.0.1").To4(), t.dnsProxy.port4)
-					} else {
+					} else if t.dnsProxy.port6 > 0 {
 						newDest = buildSockaddrIn6(net.ParseIP("::1"), t.dnsProxy.port6)
 						regs.SetArg(5, 28) // update addrlen
 						t.setRegs(tid, regs)
 					}
-					if err := t.writeBytes(tid, destAddrPtr, newDest); err == nil {
-						t.allowSyscall(tid)
-						return
+					if newDest != nil {
+						if err := t.writeBytes(tid, destAddrPtr, newDest); err == nil {
+							t.allowSyscall(tid)
+							return
+						}
 					}
+					// No IPv6 proxy or write failed — fall through to normal handling
 				}
 			}
 		}
@@ -172,13 +175,17 @@ func (t *Tracer) handleNetwork(ctx context.Context, tid int, regs Regs) {
 		var newSockaddr []byte
 		if family == unix.AF_INET {
 			newSockaddr = buildSockaddrIn4(net.ParseIP("127.0.0.1").To4(), t.dnsProxy.port4)
-		} else {
+		} else if t.dnsProxy.port6 > 0 {
 			newSockaddr = buildSockaddrIn6(net.ParseIP("::1"), t.dnsProxy.port6)
 			// Update addrlen register for larger sockaddr_in6
 			regs.SetArg(2, 28)
 			if err := t.setRegs(tid, regs); err != nil {
 				slog.Warn("handleNetwork: DNS redirect setRegs failed", "tid", tid, "error", err)
 			}
+		} else {
+			// No IPv6 proxy — let DNS connect proceed unmodified
+			t.allowSyscall(tid)
+			return
 		}
 		if err := t.writeBytes(tid, addrPtr, newSockaddr); err != nil {
 			slog.Warn("handleNetwork: DNS redirect write failed", "tid", tid, "error", err)


### PR DESCRIPTION
## Summary
- Make IPv6 UDP listener best-effort in DNS proxy — if it fails (e.g. gVisor blocks UDP6), log a warning and continue with IPv4-only
- When no IPv6 listener exists, IPv6 DNS connect/sendto syscalls proceed unmodified instead of being redirected
- Fixes DNS proxy startup failure on Modal (gVisor) sandboxes

## Context
On gVisor-based runtimes (Modal), `ListenUDP("udp6", "[::1]:0")` fails because gVisor blocks UDP6. Previously this was treated as fatal, closing the IPv4 listener and returning an error, which disabled the entire DNS proxy.

## Test plan
- [x] `go build ./...`
- [x] `GOOS=windows go build ./...`
- [x] `go test ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)