### PR TITLE
fix(capabilities): use functional probe for ptrace detection

### DIFF
--- a/internal/capabilities/check.go
+++ b/internal/capabilities/check.go
@@ -46,7 +46,7 @@ func realCheckPtrace() CheckResult {
 	available := checkPtraceCapability()
 	r := CheckResult{Feature: "ptrace", Available: available}
 	if !available {
-		r.Error = fmt.Errorf("SYS_PTRACE capability not available or ptrace blocked by seccomp")
+		r.Error = fmt.Errorf("ptrace not available (PTRACE_SEIZE probe failed — blocked by seccomp, gVisor, or missing CAP_SYS_PTRACE)")
 	}
 	return r
 }

--- a/internal/capabilities/check_ptrace_linux.go
+++ b/internal/capabilities/check_ptrace_linux.go
@@ -34,15 +34,11 @@ func parseCapEff(content string) (uint64, error) {
 	return 0, fmt.Errorf("CapEff not found in /proc/self/status")
 }
 
-// checkPtraceCapability checks if ptrace is available and functional.
+// checkPtraceCapability checks if ptrace is available and functional
+// by forking a child and attempting PTRACE_SEIZE. This is more reliable
+// than checking CAP_SYS_PTRACE because some runtimes (e.g. gVisor)
+// report the capability but block the actual syscall.
 func checkPtraceCapability() bool {
-	capEff, err := readCapEff()
-	if err != nil {
-		return false
-	}
-	if capEff&(1<<capSysPtrace) == 0 {
-		return false
-	}
 	return probePtraceAttach()
 }
 


### PR DESCRIPTION
## Summary
- Skip `CAP_SYS_PTRACE` capability check, go straight to functional probe (fork + `PTRACE_SEIZE`)
- gVisor reports `CAP_SYS_PTRACE` in `CapEff` but blocks the actual ptrace syscall, causing false positives
- Updated error message to reflect probe-based detection

## Test plan
- [x] `go build ./...` + `GOOS=windows go build ./...`
- [x] `go test ./internal/capabilities/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)