### PR TITLE
feat(ptrace): wire DNS proxy session attribution via last-redirect fallback

### DIFF
--- a/Dockerfile.dns-test
+++ b/Dockerfile.dns-test
@@ -1,0 +1,14 @@
+FROM golang:1.25 AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN make build
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y python3 curl ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /src/bin/agentsh /usr/local/bin/
+COPY --from=builder /src/bin/agentsh-shell-shim /usr/local/bin/
+COPY scripts/test-dns.sh /test-dns.sh
+RUN chmod +x /test-dns.sh
+ENTRYPOINT ["/test-dns.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build build-shim test lint clean proto ebpf
-.PHONY: smoke ptrace-test seccomp-probe bench
+.PHONY: smoke ptrace-test dns-test seccomp-probe bench
 .PHONY: completions package-snapshot package-release
 .PHONY: build-macos-enterprise build-macos-go build-swift assemble-bundle sign-bundle
 .PHONY: build-driver build-driver-debug install-driver uninstall-driver build-windows-full
@@ -44,6 +44,10 @@ smoke:
 ptrace-test:
 	docker build -f Dockerfile.ptrace-test -t agentsh-ptrace-test .
 	docker run --rm --cap-add SYS_PTRACE agentsh-ptrace-test
+
+dns-test:
+	docker build -f Dockerfile.dns-test -t agentsh-dns-test .
+	docker run --rm --cap-add SYS_PTRACE agentsh-dns-test
 
 seccomp-probe:
 	mkdir -p build

--- a/internal/ptrace/dns_proxy.go
+++ b/internal/ptrace/dns_proxy.go
@@ -123,9 +123,10 @@ func (p *dnsProxy) handleQuery(ctx context.Context, conn *net.UDPConn, raw []byt
 	q := msg.Questions[0]
 	domain := strings.TrimSuffix(q.Name.String(), ".")
 
-	// TODO(Task 9): Wire proper TGID+fd attribution from the redirected
-	// UDP socket so PID, SessionID, and originalResolver are populated.
-	redirectInfo := dnsRedirectInfo{}
+	// Use the most recently recorded DNS redirect info for session attribution.
+	// This covers the common single-session case; full per-port attribution
+	// (Task 9) can be added later for multi-session scenarios.
+	redirectInfo, _ := p.fds.getLastDNSRedirect()
 
 	result := p.handler.HandleNetwork(ctx, NetworkContext{
 		PID:       redirectInfo.pid,
@@ -162,6 +163,9 @@ func (p *dnsProxy) handleQuery(ctx context.Context, conn *net.UDPConn, raw []byt
 
 	if err != nil {
 		slog.Warn("dns_proxy: failed to build response", "error", err, "domain", domain)
+		if fallback, ferr := p.buildSERVFAIL(msg); ferr == nil {
+			conn.WriteToUDP(fallback, remoteAddr)
+		}
 		return
 	}
 

--- a/internal/ptrace/dns_proxy_test.go
+++ b/internal/ptrace/dns_proxy_test.go
@@ -21,6 +21,22 @@ func (m *mockDNSNetworkHandler) HandleNetwork(_ context.Context, nc NetworkConte
 	return m.result
 }
 
+// capturingDNSNetworkHandler captures the NetworkContext for inspection.
+type capturingDNSNetworkHandler struct {
+	result  NetworkResult
+	lastCtx NetworkContext
+	called  chan struct{}
+}
+
+func (h *capturingDNSNetworkHandler) HandleNetwork(_ context.Context, nc NetworkContext) NetworkResult {
+	h.lastCtx = nc
+	select {
+	case h.called <- struct{}{}:
+	default:
+	}
+	return h.result
+}
+
 func buildDNSQuery(t *testing.T, domain string, qtype dnsmessage.Type) []byte {
 	t.Helper()
 	msg := dnsmessage.Message{
@@ -312,5 +328,110 @@ func TestParseResolvConf_Missing(t *testing.T) {
 	got := parseResolvConf("/nonexistent/resolv.conf")
 	if got != nil {
 		t.Fatalf("expected nil for missing file, got %v", got)
+	}
+}
+
+func TestDNSProxy_AllowWithLastRedirect(t *testing.T) {
+	// Start a fake upstream DNS that returns a canned A record
+	upstream, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer upstream.Close()
+
+	go func() {
+		buf := make([]byte, 512)
+		n, addr, err := upstream.ReadFrom(buf)
+		if err != nil {
+			return
+		}
+		var msg dnsmessage.Message
+		if err := msg.Unpack(buf[:n]); err != nil {
+			return
+		}
+		msg.Header.Response = true
+		msg.Answers = []dnsmessage.Resource{
+			{
+				Header: dnsmessage.ResourceHeader{
+					Name:  msg.Questions[0].Name,
+					Type:  dnsmessage.TypeA,
+					Class: dnsmessage.ClassINET,
+					TTL:   300,
+				},
+				Body: &dnsmessage.AResource{A: [4]byte{140, 82, 112, 4}},
+			},
+		}
+		resp, _ := msg.Pack()
+		upstream.WriteTo(resp, addr)
+	}()
+
+	ft := newFdTracker()
+	// Pre-record a DNS redirect — simulates what ptrace does at connect/sendto time
+	ft.recordDNSRedirect(42, 3, 42, "test-session-123", "8.8.8.8:53")
+
+	handler := &capturingDNSNetworkHandler{
+		result: NetworkResult{
+			Allow:            true,
+			RedirectUpstream: upstream.LocalAddr().String(),
+		},
+		called: make(chan struct{}, 1),
+	}
+
+	proxy, err := newDNSProxy(handler, ft)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go proxy.run(ctx)
+
+	conn, err := net.Dial("udp", proxy.addr4())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	query := buildDNSQuery(t, "github.com", dnsmessage.TypeA)
+	conn.Write(query)
+
+	// Wait for handler to be called
+	select {
+	case <-handler.called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler was not called within timeout")
+	}
+
+	// Verify session attribution was passed through
+	if handler.lastCtx.SessionID != "test-session-123" {
+		t.Fatalf("expected SessionID 'test-session-123', got %q", handler.lastCtx.SessionID)
+	}
+	if handler.lastCtx.PID != 42 {
+		t.Fatalf("expected PID 42, got %d", handler.lastCtx.PID)
+	}
+	if handler.lastCtx.Address != "8.8.8.8:53" {
+		t.Fatalf("expected Address '8.8.8.8:53', got %q", handler.lastCtx.Address)
+	}
+	if handler.lastCtx.Operation != "dns" {
+		t.Fatalf("expected Operation 'dns', got %q", handler.lastCtx.Operation)
+	}
+	if handler.lastCtx.Domain != "github.com" {
+		t.Fatalf("expected Domain 'github.com', got %q", handler.lastCtx.Domain)
+	}
+
+	// Also verify we got a valid response
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	resp := make([]byte, 512)
+	n, err := conn.Read(resp)
+	if err != nil {
+		t.Fatalf("no response from DNS proxy: %v", err)
+	}
+
+	var msg dnsmessage.Message
+	if err := msg.Unpack(resp[:n]); err != nil {
+		t.Fatalf("failed to unpack DNS response: %v", err)
+	}
+	if len(msg.Answers) == 0 {
+		t.Fatal("expected at least one answer")
 	}
 }

--- a/internal/ptrace/fd_tracker.go
+++ b/internal/ptrace/fd_tracker.go
@@ -33,6 +33,11 @@ type fdTracker struct {
 
 	// IP -> domain mapping (populated by DNS proxy on resolution)
 	ipToDomain map[string]string
+
+	// Last DNS redirect recorded — fallback for proxy session attribution
+	// when per-port lookup isn't available (covers single-session case).
+	lastDNSRedirect    dnsRedirectInfo
+	hasLastDNSRedirect bool
 }
 
 func newFdTracker() *fdTracker {
@@ -113,11 +118,14 @@ func (ft *fdTracker) clearTGID(tgid int) {
 
 func (ft *fdTracker) recordDNSRedirect(tgid, fd, pid int, sessionID, originalResolver string) {
 	ft.mu.Lock()
-	ft.dnsRedirects[tgidFd{tgid, fd}] = dnsRedirectInfo{
+	info := dnsRedirectInfo{
 		pid:              pid,
 		sessionID:        sessionID,
 		originalResolver: originalResolver,
 	}
+	ft.dnsRedirects[tgidFd{tgid, fd}] = info
+	ft.lastDNSRedirect = info
+	ft.hasLastDNSRedirect = true
 	ft.mu.Unlock()
 }
 
@@ -132,6 +140,12 @@ func (ft *fdTracker) removeDNSRedirect(tgid, fd int) {
 	ft.mu.Lock()
 	delete(ft.dnsRedirects, tgidFd{tgid, fd})
 	ft.mu.Unlock()
+}
+
+func (ft *fdTracker) getLastDNSRedirect() (dnsRedirectInfo, bool) {
+	ft.mu.Lock()
+	defer ft.mu.Unlock()
+	return ft.lastDNSRedirect, ft.hasLastDNSRedirect
 }
 
 func (ft *fdTracker) recordDNSResolution(ip, domain string) {

--- a/internal/ptrace/fd_tracker_test.go
+++ b/internal/ptrace/fd_tracker_test.go
@@ -117,3 +117,62 @@ func TestFdTracker_NoWatchOnEmptyDomain(t *testing.T) {
 		t.Fatal("TLS watch should not be armed for unknown domain")
 	}
 }
+
+func TestFdTracker_GetLastDNSRedirect_Empty(t *testing.T) {
+	ft := newFdTracker()
+	_, ok := ft.getLastDNSRedirect()
+	if ok {
+		t.Fatal("expected no last redirect on fresh fdTracker")
+	}
+}
+
+func TestFdTracker_GetLastDNSRedirect_Single(t *testing.T) {
+	ft := newFdTracker()
+	ft.recordDNSRedirect(100, 3, 100, "sess-1", "8.8.8.8:53")
+
+	info, ok := ft.getLastDNSRedirect()
+	if !ok {
+		t.Fatal("expected last redirect to be set")
+	}
+	if info.pid != 100 {
+		t.Fatalf("expected pid 100, got %d", info.pid)
+	}
+	if info.sessionID != "sess-1" {
+		t.Fatalf("expected session sess-1, got %q", info.sessionID)
+	}
+	if info.originalResolver != "8.8.8.8:53" {
+		t.Fatalf("expected resolver 8.8.8.8:53, got %q", info.originalResolver)
+	}
+}
+
+func TestFdTracker_GetLastDNSRedirect_Overwrites(t *testing.T) {
+	ft := newFdTracker()
+	ft.recordDNSRedirect(100, 3, 100, "sess-1", "8.8.8.8:53")
+	ft.recordDNSRedirect(200, 5, 200, "sess-2", "1.1.1.1:53")
+
+	info, ok := ft.getLastDNSRedirect()
+	if !ok {
+		t.Fatal("expected last redirect to be set")
+	}
+	if info.sessionID != "sess-2" {
+		t.Fatalf("expected latest session sess-2, got %q", info.sessionID)
+	}
+	if info.pid != 200 {
+		t.Fatalf("expected pid 200, got %d", info.pid)
+	}
+}
+
+func TestFdTracker_GetLastDNSRedirect_SurvivesPerKeyRemoval(t *testing.T) {
+	ft := newFdTracker()
+	ft.recordDNSRedirect(100, 3, 100, "sess-1", "8.8.8.8:53")
+	ft.removeDNSRedirect(100, 3)
+
+	// lastDNSRedirect should still be set even after per-key removal
+	info, ok := ft.getLastDNSRedirect()
+	if !ok {
+		t.Fatal("expected last redirect to survive per-key removal")
+	}
+	if info.sessionID != "sess-1" {
+		t.Fatalf("expected session sess-1, got %q", info.sessionID)
+	}
+}

--- a/internal/ptrace/handle_network.go
+++ b/internal/ptrace/handle_network.go
@@ -88,7 +88,7 @@ func (t *Tracer) handleNetwork(ctx context.Context, tid int, regs Regs) {
 		if destAddrPtr != 0 && destAddrLen > 0 && destAddrLen <= 128 {
 			destBuf := make([]byte, destAddrLen)
 			if err := t.readBytes(tid, destAddrPtr, destBuf); err == nil {
-				destFamily, _, destPort, err := parseSockaddr(destBuf)
+				destFamily, destAddr, destPort, err := parseSockaddr(destBuf)
 				if err == nil && destPort == 53 &&
 					(destFamily == unix.AF_INET || destFamily == unix.AF_INET6) &&
 					((destFamily == unix.AF_INET && destAddrLen >= 16) ||
@@ -104,6 +104,14 @@ func (t *Tracer) handleNetwork(ctx context.Context, tid int, regs Regs) {
 					}
 					if newDest != nil {
 						if err := t.writeBytes(tid, destAddrPtr, newDest); err == nil {
+							// Record redirect info for DNS proxy session attribution
+							t.mu.Lock()
+							state := t.tracees[tid]
+							if state != nil {
+								fd := int(int32(regs.Arg(0)))
+								t.fds.recordDNSRedirect(state.TGID, fd, state.TGID, state.SessionID, fmt.Sprintf("%s:%d", destAddr, destPort))
+							}
+							t.mu.Unlock()
 							t.allowSyscall(tid)
 							return
 						}

--- a/scripts/test-dns.sh
+++ b/scripts/test-dns.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# DNS integration test for agentsh
+# Tests that DNS resolution works correctly through the ptrace DNS proxy:
+#   - Allowed domains resolve successfully
+#   - Denied domains are blocked
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+pass() { echo "  PASS: $1"; ((PASS++)); }
+fail() { echo "  FAIL: $1"; ((FAIL++)); ERRORS="${ERRORS}\n  - $1"; }
+
+tmp="$(mktemp -d)"
+cleanup() {
+  set +e
+  if [[ -n "${SERVER_PID:-}" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    sleep 0.2
+    kill -9 "$SERVER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+# --- Config ---
+mkdir -p "$tmp/policies" "$tmp/sessions"
+
+cat >"$tmp/config.yml" <<YAML
+server:
+  http:
+    addr: "127.0.0.1:9876"
+  grpc:
+    enabled: false
+  unix_socket:
+    enabled: false
+
+auth:
+  type: "none"
+
+metrics:
+  enabled: false
+
+health:
+  path: "/health"
+  readiness_path: "/ready"
+
+policies:
+  dir: "$tmp/policies"
+  default: "dns-test"
+
+sessions:
+  base_dir: "$tmp/sessions"
+  max_sessions: 10
+
+audit:
+  enabled: false
+
+sandbox:
+  ptrace:
+    enabled: true
+    attach_mode: children
+    trace:
+      execve: true
+      file: false
+      network: true
+      signal: false
+    performance:
+      seccomp_prefilter: true
+      max_tracees: 500
+      max_hold_ms: 5000
+    mask_tracer_pid: "off"
+    on_attach_failure: fail_open
+  fuse:
+    enabled: false
+  network:
+    enabled: false
+  unix_sockets:
+    enabled: false
+  seccomp:
+    execve:
+      enabled: false
+YAML
+
+cat >"$tmp/policies/dns-test.yaml" <<YAML
+version: 1
+name: dns-test
+description: DNS integration test policy
+
+network_rules:
+  - name: allow-github
+    description: Allow github.com DNS and connections
+    domains:
+      - "github.com"
+      - "*.github.com"
+    ports: [443, 80, 53]
+    decision: allow
+
+  - name: allow-localhost
+    description: Allow localhost connections (for proxy)
+    cidrs:
+      - "127.0.0.1/32"
+    decision: allow
+
+  - name: deny-evil
+    description: Block evil.com
+    domains:
+      - "evil.com"
+      - "*.evil.com"
+    decision: deny
+
+  - name: default-deny
+    description: Deny everything else
+    domains:
+      - "*"
+    decision: deny
+
+command_rules:
+  - name: allow-all
+    description: Allow all commands for testing
+    commands:
+      - "*"
+    decision: allow
+YAML
+
+# --- Start server ---
+echo "Starting agentsh server..."
+export AGENTSH_SERVER="http://127.0.0.1:9876"
+agentsh server --config "$tmp/config.yml" >"$tmp/server.log" 2>&1 &
+SERVER_PID="$!"
+
+# Wait for health
+for _ in $(seq 1 200); do
+  if curl -fsS "${AGENTSH_SERVER}/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.05
+done
+if ! curl -fsS "${AGENTSH_SERVER}/health" >/dev/null 2>&1; then
+  echo "FATAL: server failed to become ready"
+  cat "$tmp/server.log" >&2 || true
+  exit 1
+fi
+echo "Server ready."
+
+# --- Create session ---
+sid_json="$(agentsh session create --workspace /root --json)"
+sid="$(python3 -c 'import json,sys; print(json.loads(sys.stdin.read())["id"])' <<<"$sid_json")"
+if [[ -z "$sid" ]]; then
+  echo "FATAL: failed to parse session id"
+  echo "$sid_json" >&2
+  exit 1
+fi
+echo "Session created: $sid"
+echo ""
+
+# --- Test 1: DNS resolution for allowed domain ---
+echo "Test 1: DNS resolution for allowed domain (github.com)"
+set +e
+dns_allow_out="$(agentsh exec "$sid" -- python3 -c "
+import socket
+try:
+    result = socket.getaddrinfo('github.com', 443)
+    print('RESOLVED:' + result[0][4][0])
+except Exception as e:
+    print('ERROR:' + str(e))
+" 2>&1)"
+dns_allow_rc=$?
+set -e
+
+if echo "$dns_allow_out" | grep -q "^RESOLVED:"; then
+  ip="$(echo "$dns_allow_out" | grep "^RESOLVED:" | head -1 | cut -d: -f2)"
+  pass "github.com resolved to $ip"
+else
+  fail "github.com DNS resolution failed: $dns_allow_out (rc=$dns_allow_rc)"
+fi
+
+# --- Test 2: DNS resolution for denied domain ---
+echo "Test 2: DNS resolution for denied domain (evil.com)"
+set +e
+dns_deny_out="$(agentsh exec "$sid" -- python3 -c "
+import socket
+try:
+    result = socket.getaddrinfo('evil.com', 443)
+    print('RESOLVED:' + result[0][4][0])
+except socket.gaierror as e:
+    print('BLOCKED:' + str(e))
+except Exception as e:
+    print('ERROR:' + str(e))
+" 2>&1)"
+dns_deny_rc=$?
+set -e
+
+if echo "$dns_deny_out" | grep -q "^BLOCKED:"; then
+  pass "evil.com correctly blocked"
+elif echo "$dns_deny_out" | grep -q "^RESOLVED:"; then
+  fail "evil.com should have been blocked but resolved: $dns_deny_out"
+else
+  fail "evil.com test returned unexpected output: $dns_deny_out (rc=$dns_deny_rc)"
+fi
+
+# --- Summary ---
+echo ""
+echo "========================================="
+echo "DNS Integration Test Results"
+echo "========================================="
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+if [[ $FAIL -gt 0 ]]; then
+  echo -e "\nFailures:$ERRORS"
+  echo ""
+  echo "Server log (last 50 lines):"
+  tail -n 50 "$tmp/server.log" 2>/dev/null || true
+  exit 1
+fi
+echo ""
+echo "All tests passed!"


### PR DESCRIPTION
## Summary
- Replace empty `dnsRedirectInfo{}` with `getLastDNSRedirect()` fallback so the DNS proxy passes PID, SessionID, and originalResolver to the policy handler
- Record DNS redirect info from the sendto intercept path so the fd tracker has data for attribution
- Return SERVFAIL to client on upstream forwarding errors instead of silently dropping the query
- Add `make dns-test` Docker test harness for end-to-end DNS proxy testing

## Test plan
- [x] `go build ./...` + `GOOS=windows go build ./...`
- [x] `go test ./internal/ptrace/...` — all pass including new tests
- [x] `TestDNSProxy_AllowWithLastRedirect` — verifies session attribution
- [x] `TestFdTracker_GetLastDNSRedirect_*` — 4 new fd tracker tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)