### PR TITLE
fix(ptrace): check domain not resolver IP for DNS policy evaluation

### DIFF
--- a/internal/api/ptrace_handlers.go
+++ b/internal/api/ptrace_handlers.go
@@ -177,7 +177,16 @@ func (r *ptraceHandlerRouter) HandleNetwork(ctx context.Context, nc ptrace.Netwo
 		return ptrace.NetworkResult{Allow: false, Action: "deny", Errno: int32(syscall.EACCES)}
 	}
 
-	decision := pe.CheckNetwork(nc.Address, nc.Port)
+	// For DNS operations, evaluate the domain being queried rather than
+	// the resolver address (which is often a private IP like 172.x.x.x
+	// and would be blocked by private-network rules).
+	checkAddr := nc.Address
+	checkPort := nc.Port
+	if nc.Operation == "dns" && nc.Domain != "" {
+		checkAddr = nc.Domain
+		checkPort = 443 // evaluate as if connecting to the domain on HTTPS
+	}
+	decision := pe.CheckNetwork(checkAddr, checkPort)
 
 	ev := types.Event{
 		ID:        uuid.NewString(),
@@ -189,6 +198,7 @@ func (r *ptraceHandlerRouter) HandleNetwork(ctx context.Context, nc ptrace.Netwo
 			"address":   nc.Address,
 			"port":      nc.Port,
 			"operation": nc.Operation,
+			"domain":    nc.Domain,
 			"decision":  string(decision.EffectiveDecision),
 			"rule":      decision.Rule,
 		},


### PR DESCRIPTION
## Summary
- Use `nc.Domain` instead of `nc.Address` when evaluating DNS operations against network policy
- The resolver IP (e.g. `172.21.0.1`) was hitting `block-private-networks` CIDR rules, denying ALL DNS queries regardless of domain
- Also log `domain` field in audit events for DNS operations

## Test plan
- [x] `go build ./...` + `GOOS=windows go build ./...`
- [x] `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)