### PR TITLE
fix: resolve workspace symlinks at session creation

### DIFF
--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -452,10 +452,13 @@ func resolveWorkingDir(s *session.Session, reqWorkingDir string) (string, error)
 		return "", fmt.Errorf("working_dir escapes workspace mount")
 	}
 
-	// Resolve root symlinks for consistent comparison (macOS /var -> /private/var)
+	// Resolve root symlinks for consistent comparison (macOS /var -> /private/var).
+	// Since workspace paths are canonicalized at session creation, this should
+	// rarely change the path — but if EvalSymlinks fails, fail closed rather
+	// than comparing an unresolved root against a resolved child path.
 	rootResolved, err := filepath.EvalSymlinks(rootClean)
 	if err != nil {
-		rootResolved = rootClean
+		return "", fmt.Errorf("resolve workspace mount %q: %w", rootClean, err)
 	}
 
 	// Resolve symlinks to prevent symlink escape (e.g., /workspace/link -> /etc).

--- a/internal/api/exec_real_paths_test.go
+++ b/internal/api/exec_real_paths_test.go
@@ -213,6 +213,47 @@ func TestResolveWorkingDir_SymlinkEscape_RealPathsMode(t *testing.T) {
 	}
 }
 
+func TestResolveWorkingDir_SymlinkedWorkspaceRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink test is POSIX-specific")
+	}
+	// Simulate E2B/Daytona: /workspace is a symlink to /home/user.
+	// Session creation should resolve the symlink so boundary checks
+	// compare canonical paths on both sides.
+	realDir := t.TempDir()
+	subdir := filepath.Join(realDir, "project")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a symlink that points to realDir
+	symlinkDir := filepath.Join(t.TempDir(), "workspace-link")
+	if err := os.Symlink(realDir, symlinkDir); err != nil {
+		t.Fatal(err)
+	}
+
+	m := session.NewManager(10)
+	s, err := m.CreateWithID("test-symlink-ws", symlinkDir, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Workspace should have been resolved to the real path
+	if s.Workspace != realDir {
+		t.Fatalf("Workspace = %q, want resolved %q", s.Workspace, realDir)
+	}
+
+	// resolveWorkingDir should succeed for paths under the workspace
+	resolved, err := resolveWorkingDir(s, "/workspace/project")
+	if err != nil {
+		t.Fatalf("resolveWorkingDir through symlinked workspace: %v", err)
+	}
+	want := filepath.Join(realDir, "project")
+	if resolved != want {
+		t.Errorf("resolved = %q, want %q", resolved, want)
+	}
+}
+
 func TestResolveWorkingDir_DotDotEscape_RealPaths(t *testing.T) {
 	m := session.NewManager(10)
 	ws := t.TempDir()

--- a/internal/api/exec_real_paths_test.go
+++ b/internal/api/exec_real_paths_test.go
@@ -238,9 +238,11 @@ func TestResolveWorkingDir_SymlinkedWorkspaceRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Workspace should have been resolved to the real path
-	if s.Workspace != realDir {
-		t.Fatalf("Workspace = %q, want resolved %q", s.Workspace, realDir)
+	// Workspace should have been resolved to the canonical path
+	// (on macOS, t.TempDir() returns /var/... but EvalSymlinks gives /private/var/...)
+	resolvedRealDir, _ := filepath.EvalSymlinks(realDir)
+	if s.Workspace != resolvedRealDir {
+		t.Fatalf("Workspace = %q, want resolved %q", s.Workspace, resolvedRealDir)
 	}
 
 	// resolveWorkingDir should succeed for paths under the workspace
@@ -248,7 +250,7 @@ func TestResolveWorkingDir_SymlinkedWorkspaceRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveWorkingDir through symlinked workspace: %v", err)
 	}
-	want := filepath.Join(realDir, "project")
+	want := filepath.Join(resolvedRealDir, "project")
 	if resolved != want {
 		t.Errorf("resolved = %q, want %q", resolved, want)
 	}

--- a/internal/api/exec_real_paths_test.go
+++ b/internal/api/exec_real_paths_test.go
@@ -201,9 +201,9 @@ func TestResolveWorkingDir_SymlinkEscape_RealPathsMode(t *testing.T) {
 	}
 	s.SetRealPaths(true)
 
-	// In real-paths mode: VirtualRoot == ws path
+	// In real-paths mode: VirtualRoot == resolved ws path
 	// A path like <ws>/escape-link is "under root" but resolves outside — should be rejected
-	wsClean := filepath.ToSlash(filepath.Clean(ws))
+	wsClean := filepath.ToSlash(filepath.Clean(s.Workspace))
 	_, err = resolveWorkingDir(s, wsClean+"/escape-link")
 	if err == nil {
 		t.Error("expected error for symlink escape in real_paths mode")
@@ -264,7 +264,7 @@ func TestResolveWorkingDir_DotDotEscape_RealPaths(t *testing.T) {
 	}
 	s.SetRealPaths(true)
 
-	wsClean := filepath.ToSlash(filepath.Clean(ws))
+	wsClean := filepath.ToSlash(filepath.Clean(s.Workspace))
 	// Path with ".." that resolves outside workspace should be treated as
 	// outside-workspace (pass through), not rejected as escape.
 	real, err := resolveWorkingDir(s, wsClean+"/../tmp")
@@ -408,7 +408,7 @@ func TestExec_RealPaths_InWorkspace_UsesRealPath(t *testing.T) {
 
 	// Execute pwd in a workspace subdirectory using the real path.
 	cmd, args := pwdCommand()
-	wsClean := filepath.ToSlash(filepath.Clean(ws))
+	wsClean := filepath.ToSlash(filepath.Clean(sess.Workspace))
 	body, _ := json.Marshal(map[string]any{
 		"command":        cmd,
 		"args":           args,

--- a/internal/api/profile_session_test.go
+++ b/internal/api/profile_session_test.go
@@ -80,9 +80,11 @@ func TestCreateSessionWithProfile(t *testing.T) {
 		t.Errorf("expected profile=test-profile, got %q", out.Profile)
 	}
 
-	// Session should have primary workspace set from first mount
-	if out.Workspace != workspace {
-		t.Errorf("expected workspace=%q, got %q", workspace, out.Workspace)
+	// Session should have primary workspace set from first mount (resolved)
+	// On macOS /var → /private/var, on Windows short names may be expanded.
+	resolvedWorkspace, _ := filepath.EvalSymlinks(workspace)
+	if out.Workspace != resolvedWorkspace {
+		t.Errorf("expected workspace=%q, got %q", resolvedWorkspace, out.Workspace)
 	}
 }
 
@@ -230,9 +232,9 @@ func TestCreateSessionWithProfile_RealPaths(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Profile session with real_paths=true should use workspace as VirtualRoot/Cwd
-	absWs, _ := filepath.Abs(workspace)
-	wantCwd := filepath.ToSlash(filepath.Clean(absWs))
+	// Profile session with real_paths=true should use resolved workspace as VirtualRoot/Cwd
+	resolvedWs, _ := filepath.EvalSymlinks(workspace)
+	wantCwd := filepath.ToSlash(filepath.Clean(resolvedWs))
 	if out.Cwd != wantCwd {
 		t.Errorf("Cwd = %q, want %q (profile + real_paths)", out.Cwd, wantCwd)
 	}

--- a/internal/api/session_create_real_paths_test.go
+++ b/internal/api/session_create_real_paths_test.go
@@ -41,9 +41,9 @@ func TestCreateSession_RealPaths_RequestOverride(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// When real_paths is true, Cwd should be the real workspace path, not /workspace
-	absWs, _ := filepath.Abs(ws)
-	wantCwd := filepath.ToSlash(filepath.Clean(absWs))
+	// When real_paths is true, Cwd should be the resolved workspace path, not /workspace
+	resolvedWs, _ := filepath.EvalSymlinks(ws)
+	wantCwd := filepath.ToSlash(filepath.Clean(resolvedWs))
 	if out.Cwd != wantCwd {
 		t.Errorf("Cwd = %q, want %q (real workspace path)", out.Cwd, wantCwd)
 	}
@@ -79,8 +79,8 @@ func TestCreateSession_RealPaths_ConfigDefault(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	absWs, _ := filepath.Abs(ws)
-	wantCwd := filepath.ToSlash(filepath.Clean(absWs))
+	resolvedWs, _ := filepath.EvalSymlinks(ws)
+	wantCwd := filepath.ToSlash(filepath.Clean(resolvedWs))
 	if out.Cwd != wantCwd {
 		t.Errorf("Cwd = %q, want %q (config default real_paths=true)", out.Cwd, wantCwd)
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -139,8 +139,12 @@ func (m *Manager) CreateWithProfile(id, profile, basePolicy string, mounts []Res
 		return nil, ErrSessionExists
 	}
 
-	// Use first mount as the "primary" workspace for legacy compatibility
+	// Use first mount as the "primary" workspace for legacy compatibility.
+	// Resolve symlinks so boundary checks use the canonical path.
 	primaryWorkspace := mounts[0].Path
+	if resolved, err := filepath.EvalSymlinks(primaryWorkspace); err == nil {
+		primaryWorkspace = resolved
+	}
 
 	now := time.Now().UTC()
 	s := &Session{
@@ -174,6 +178,11 @@ func (m *Manager) CreateWithID(id, workspace, policy string) (*Session, error) {
 	}
 	if !st.IsDir() {
 		return nil, fmt.Errorf("workspace must be a directory")
+	}
+	// Resolve symlinks so the canonical path is used for FUSE mount
+	// source and workspace boundary checks (e.g. /workspace → /home/user).
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = resolved
 	}
 
 	m.mu.Lock()

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -200,7 +200,9 @@ func TestSetRealPaths_Enable(t *testing.T) {
 		t.Fatal(err)
 	}
 	s.SetRealPaths(true)
-	want := filepath.ToSlash(filepath.Clean(ws))
+	// Use s.Workspace (resolved by CreateWithID) for comparison,
+	// since EvalSymlinks may differ from t.TempDir() (macOS /var → /private/var).
+	want := filepath.ToSlash(filepath.Clean(s.Workspace))
 	if s.VirtualRoot != want {
 		t.Errorf("VirtualRoot = %q, want %q", s.VirtualRoot, want)
 	}
@@ -293,8 +295,8 @@ func TestBuiltin_Cd_RealPaths(t *testing.T) {
 		t.Fatalf("cd: handled=%v code=%d", handled, code)
 	}
 	cwd, _, _ := s.GetCwdEnvHistory()
-	// VirtualRoot uses forward slashes; compare accordingly
-	want := filepath.ToSlash(filepath.Clean(ws))
+	// VirtualRoot uses forward slashes; compare against resolved workspace
+	want := filepath.ToSlash(filepath.Clean(s.Workspace))
 	if cwd != want {
 		t.Errorf("after cd: Cwd = %q, want %q", cwd, want)
 	}
@@ -329,14 +331,14 @@ func TestApplyPatch_RealPaths(t *testing.T) {
 	}
 	s.SetRealPaths(true)
 
-	// Patch cwd to subdir under workspace
-	err = s.ApplyPatch(types.SessionPatchRequest{Cwd: ws + "/subdir"})
+	// Patch cwd to subdir under workspace — use resolved workspace path
+	resolvedWs := s.Workspace
+	err = s.ApplyPatch(types.SessionPatchRequest{Cwd: resolvedWs + "/subdir"})
 	if err != nil {
 		t.Fatalf("ApplyPatch: %v", err)
 	}
 	cwd, _, _ := s.GetCwdEnvHistory()
-	// VirtualRoot uses forward slashes; compare accordingly
-	wantCwd := filepath.ToSlash(filepath.Clean(ws)) + "/subdir"
+	wantCwd := filepath.ToSlash(filepath.Clean(resolvedWs)) + "/subdir"
 	if cwd != wantCwd {
 		t.Errorf("Cwd = %q, want %q", cwd, wantCwd)
 	}


### PR DESCRIPTION
## Summary
- Resolve workspace symlinks via `filepath.EvalSymlinks` at session creation in both `CreateWithID` and `CreateWithProfile`
- Harden `resolveWorkingDir` to fail closed when `EvalSymlinks` fails on the workspace root, instead of silently comparing mismatched paths
- Add test for symlinked workspace root scenario

Fixes `working_dir symlink escapes workspace mount` errors on providers where `/workspace` is a symlink (E2B, Daytona, Cloudflare).

## Test plan
- [x] `go build ./...` and `GOOS=windows go build ./...`
- [x] `go test ./...` — all pass
- [x] New `TestResolveWorkingDir_SymlinkedWorkspaceRoot` validates the fix
- [ ] CI (linux, macOS, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)