### PR TITLE
fix(cli): preserve nested -- in exec child command args

### DIFF
--- a/internal/cli/exec_parse.go
+++ b/internal/cli/exec_parse.go
@@ -47,10 +47,14 @@ func parseExecInputWithEnv(args []string, jsonStr string, timeoutFlag string, st
 		return sessionID, req, nil
 	}
 
-	// Find "--" separator if present
+	// Find "--" separator if present.
+	// Only check positions 0 and 1: the format is [SESSION_ID] -- COMMAND,
+	// so "--" can only appear at index 0 (no session arg) or index 1 (after
+	// session ID). Any "--" beyond that is part of the child command's
+	// arguments and must be preserved.
 	dashDashIdx := -1
-	for i, arg := range args {
-		if arg == "--" {
+	for i := 0; i < len(args) && i < 2; i++ {
+		if args[i] == "--" {
 			dashDashIdx = i
 			break
 		}

--- a/internal/cli/exec_parse_test.go
+++ b/internal/cli/exec_parse_test.go
@@ -21,3 +21,58 @@ func TestParseExecInput_JSON(t *testing.T) {
 		t.Fatalf("unexpected parse result: sid=%q cmd=%q", sid, req.Command)
 	}
 }
+
+// Regression test: nested "--" inside the child command must be preserved
+// as a regular argument, not treated as the agentsh separator.
+// e.g. agentsh exec SESSION -- opencode run --format json -- "prompt"
+// After Cobra strips the first "--", args is:
+//   ["opencode", "run", "--format", "json", "--", "prompt"]
+// The inner "--" belongs to opencode, not agentsh.
+func TestParseExecInput_NestedDoubleDash(t *testing.T) {
+	// Simulate what Cobra passes after stripping the outer "--":
+	// agentsh exec SESSION -- opencode run --attach http://x --format json -- "prompt"
+	args := []string{"opencode", "run", "--attach", "http://x", "--format", "json", "--", "Reply with VM_OK"}
+	sid, req, err := parseExecInputWithEnv(args, "", "", false, "session-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sid != "session-1" {
+		t.Errorf("session = %q, want session-1", sid)
+	}
+	if req.Command != "opencode" {
+		t.Errorf("Command = %q, want opencode", req.Command)
+	}
+	wantArgs := []string{"run", "--attach", "http://x", "--format", "json", "--", "Reply with VM_OK"}
+	if len(req.Args) != len(wantArgs) {
+		t.Fatalf("Args = %v, want %v", req.Args, wantArgs)
+	}
+	for i, a := range wantArgs {
+		if req.Args[i] != a {
+			t.Errorf("Args[%d] = %q, want %q", i, req.Args[i], a)
+		}
+	}
+}
+
+// Same as above but with session ID in args (no env var).
+func TestParseExecInput_NestedDoubleDash_WithSessionArg(t *testing.T) {
+	// Format after Cobra: SESSION_ID opencode run ... -- prompt
+	// (Cobra stripped the first --, so no "--" at position 1)
+	args := []string{"session-1", "opencode", "run", "--format", "json", "--", "prompt"}
+	sid, req, err := parseExecInput(args, "", "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sid != "session-1" {
+		t.Errorf("session = %q, want session-1", sid)
+	}
+	if req.Command != "opencode" {
+		t.Errorf("Command = %q, want opencode", req.Command)
+	}
+	// The inner "--" and "prompt" should be part of args
+	if len(req.Args) != 5 {
+		t.Fatalf("Args = %v, want 5 elements", req.Args)
+	}
+	if req.Args[3] != "--" || req.Args[4] != "prompt" {
+		t.Errorf("Args = %v, expected '--' and 'prompt' at end", req.Args)
+	}
+}


### PR DESCRIPTION
## Summary
- Only recognize `--` as the agentsh separator at arg positions 0-1, not anywhere in the args array
- Any `--` beyond position 1 is part of the child command's arguments and is passed through

Fixes a bug where `agentsh exec SESSION -- opencode run ... -- "prompt"` would misparse the inner `--` and try to execute the prompt string as the command.

## Test plan
- [x] `go build ./...` and `GOOS=windows go build ./...`
- [x] `go test ./...` — all pass
- [x] New tests: `TestParseExecInput_NestedDoubleDash` and `TestParseExecInput_NestedDoubleDash_WithSessionArg`
- [ ] CI (linux, macOS, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)