### PR TITLE
fix(exec): tolerate EACCES on FUSE workspace mount root in resolveWorkingDir

### DIFF
--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -454,11 +454,15 @@ func resolveWorkingDir(s *session.Session, reqWorkingDir string) (string, error)
 
 	// Resolve root symlinks for consistent comparison (macOS /var -> /private/var).
 	// Since workspace paths are canonicalized at session creation, this should
-	// rarely change the path — but if EvalSymlinks fails, fail closed rather
-	// than comparing an unresolved root against a resolved child path.
+	// rarely change the path. On FUSE mounts (E2B/Daytona/Cloudflare), the mount
+	// root is owned by root and EvalSymlinks fails with EACCES — fall back to
+	// rootClean, which is safe because FUSE mount paths have no symlinks at the root.
 	rootResolved, err := filepath.EvalSymlinks(rootClean)
 	if err != nil {
-		return "", fmt.Errorf("resolve workspace mount %q: %w", rootClean, err)
+		if !os.IsPermission(err) {
+			return "", fmt.Errorf("resolve workspace mount %q: %w", rootClean, err)
+		}
+		rootResolved = rootClean
 	}
 
 	// Resolve symlinks to prevent symlink escape (e.g., /workspace/link -> /etc).

--- a/internal/api/exec_real_paths_test.go
+++ b/internal/api/exec_real_paths_test.go
@@ -279,6 +279,56 @@ func TestResolveWorkingDir_DotDotEscape_RealPaths(t *testing.T) {
 	}
 }
 
+// Regression test: FUSE mount roots (E2B/Daytona/Cloudflare) deny lstat access
+// when the FUSE server runs as a different user and allow_other is not set.
+// resolveWorkingDir must succeed by falling back to the lexical path instead
+// of returning a permission error.
+func TestResolveWorkingDir_FUSEMountPermissionDenied(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod test is POSIX-specific")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses permission checks")
+	}
+
+	m := session.NewManager(10)
+	ws := t.TempDir()
+
+	s, err := m.CreateWithID("test-fuse-perm", ws, "default")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate FUSE: create a mount point inside a parent whose execute bit
+	// is removed, so EvalSymlinks on the mount root fails with EACCES.
+	restrictedParent := t.TempDir()
+	mountPath := filepath.Join(restrictedParent, "workspace-mnt")
+	if err := os.Mkdir(mountPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	subInMount := filepath.Join(mountPath, "sub")
+	if err := os.Mkdir(subInMount, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Remove execute from restrictedParent → lstat(mountPath) fails with EACCES
+	if err := os.Chmod(restrictedParent, 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Restore before cleanup so t.TempDir() can remove it
+	t.Cleanup(func() { os.Chmod(restrictedParent, 0755) })
+
+	// Point session at the FUSE-like mount
+	s.WorkspaceMount = mountPath
+	s.VirtualRoot = "/workspace"
+
+	// resolveWorkingDir should succeed despite EACCES on the mount root
+	_, err = resolveWorkingDir(s, "/workspace/sub")
+	if err != nil {
+		t.Errorf("resolveWorkingDir failed with FUSE-like mount permission denied: %v", err)
+	}
+}
+
 func TestResolveWorkingDir_DotDotEscape_Default(t *testing.T) {
 	m := session.NewManager(10)
 	ws := t.TempDir()


### PR DESCRIPTION
## Summary

- On E2B/Daytona/Cloudflare, the workspace FUSE mount is owned by root without `allow_other`, so `filepath.EvalSymlinks` on the mount root fails with `EACCES`
- The v0.16.2 hardening changed this from a silent fallback to a hard error, breaking `exec` on all FUSE-enabled platforms
- This fix restores the fallback to `rootClean` specifically for `os.IsPermission` errors — safe because FUSE mount roots are programmatically-created paths with no symlinks
- All other `EvalSymlinks` failures (broken symlinks, missing paths) continue to fail closed

## Test plan

- [ ] All existing tests pass
- [ ] New `TestResolveWorkingDir_FUSEMountPermissionDenied` simulates FUSE-like EACCES via a 000-parent directory and verifies `resolveWorkingDir` succeeds
- [ ] Verify on E2B/Daytona by running `agentsh exec` with FUSE enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)