### PR TITLE
fix(fuse): allow unprivileged access to FUSE session directories

### DIFF
--- a/internal/platform/fuse/mount_cgo.go
+++ b/internal/platform/fuse/mount_cgo.go
@@ -6,6 +6,7 @@ package fuse
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"time"
 
@@ -39,9 +40,14 @@ func Mount(cfg Config) (platform.FSMount, error) {
 	}
 
 	// Create mount point if needed
-	if err := os.MkdirAll(cfg.MountPoint, 0755); err != nil {
+	if err := os.MkdirAll(cfg.MountPoint, 0o755); err != nil {
 		return nil, fmt.Errorf("create mount point: %w", err)
 	}
+	// Explicitly chmod the per-session directory and mount point to 0755
+	// regardless of the process umask, so unprivileged clients (e.g. agentsh
+	// exec running as the agent user) can traverse these root-created paths.
+	_ = os.Chmod(filepath.Dir(cfg.MountPoint), 0o755)
+	_ = os.Chmod(cfg.MountPoint, 0o755)
 
 	// Create the policy-enforcing filesystem
 	fuseFS := newFuseFS(cfg)
@@ -109,6 +115,9 @@ func mountOptions(cfg Config) []string {
 		}
 		return opts
 	default:
-		return nil
+		// On Linux, allow_other lets unprivileged users (the agent user running
+		// agentsh exec) access a FUSE mount created by root. Without it, only
+		// the mounting process can traverse the mount point.
+		return []string{"-o", "allow_other"}
 	}
 }


### PR DESCRIPTION
## Summary

Two issues prevented unprivileged clients (`agentsh exec` running as the agent user) from accessing FUSE session directories created by the root-running server:

- **Umask restriction**: `os.MkdirAll` respects the process umask. If root's umask is `027` or `077`, the per-session `<sid>/` directory gets mode `0730` or `0700`, blocking unprivileged traversal to `workspace-mnt`. Fix: explicitly `os.Chmod` the per-session directory and mount point to `0755` after creation — umask does not affect `chmod`.

- **No `allow_other` on Linux**: Without `allow_other`, only the mounting process (root) can access a FUSE mount. Unprivileged clients get `EACCES` even when the parent directory is traversable. Fix: add `-o allow_other` to Linux cgofuse mount options, consistent with the `go-fuse`-based `fsmonitor` mount which already sets `AllowOther: true`.

## Test plan

- [ ] All existing tests pass
- [ ] On E2B/Daytona/Cloudflare: `agentsh exec <session> -- ls` succeeds as the agent user when FUSE is enabled
- [ ] Docker FUSE tests pass (`make dns-test` or equivalent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)