### PR TITLE
perf(ptrace): reduce ptrace mode overhead from +543% to +394%

### DIFF
--- a/docs/security-modes.md
+++ b/docs/security-modes.md
@@ -399,43 +399,43 @@ Note: In ptrace mode, there is a brief pre-attach window between fork and PTRACE
 
 ## Performance Benchmarks
 
-Measured with `make bench`, which runs a Dockerized workload under each mode (baseline with sandbox disabled, full seccomp+FUSE, ptrace with seccomp prefilter + per-syscall resume + fd-aware exit stops + lazy BPF escalation, ptrace without prefilter) using a realistic policy with deny, redirect, and allow rules plus full audit logging. Results are median of 3 runs.
+Measured with `make bench`, which runs a Dockerized workload under each mode (baseline with sandbox disabled, full seccomp+FUSE, ptrace with seccomp prefilter + config-driven BPF filter + config-aware exit stops + lazy BPF escalation + PTRACE_GET_SYSCALL_INFO) using a realistic policy with deny, redirect, and allow rules plus full audit logging. Results are median of 3 runs.
 
 ### Results
 
-| Phase | Baseline | Full mode | Full overhead | Ptrace | Ptrace overhead | Ptrace (no filter) | No-filter overhead |
-|---|---|---|---|---|---|---|---|
-| Process spawn (120 execs) | 3420ms | 3468ms | +1.4% | 16362ms | +378% | 47838ms | +1299% |
-| File I/O (1000 ops) | 272ms | 517ms | +90.1% | 726ms | +167% | 2671ms | +882% |
-| Git workflow (clone+grep+commit) | 50ms | 58ms | +16.0% | 401ms | +702% | 1607ms | +3114% |
-| Network (10 curl) | 341ms | 335ms | -1.8% | 9552ms | +2701% | 45434ms | +13224% |
-| Deny enforcement (50 blocked) | 552ms | 601ms | +8.9% | 577ms | +4.5% | 596ms | +8.0% |
-| Redirect enforcement (50 redirected) | 1699ms | 1769ms | +4.1% | 6125ms | +261% | 16095ms | +847% |
-| Deep process tree (20x 4-level) | 609ms | 617ms | +1.3% | 11055ms | +1715% | 54294ms | +8815% |
-| Wide process tree (10x 10-fan) | 307ms | 318ms | +3.6% | 1847ms | +502% | 6528ms | +2026% |
-| **Total** | **7250ms** | **7683ms** | **+6.0%** | **46645ms** | **+543%** | **175063ms** | **+2315%** |
+| Phase | Baseline | Full mode | Full overhead | Ptrace | Ptrace overhead |
+|---|---|---|---|---|---|
+| Process spawn (120 execs) | 3423ms | 3458ms | +1.0% | 12633ms | +269% |
+| File I/O (1000 ops) | 277ms | 275ms | -0.7% | 639ms | +131% |
+| Git workflow (clone+grep+commit) | 51ms | 51ms | +0.0% | 369ms | +624% |
+| Network (10 curl) | 346ms | 339ms | -2.0% | 7299ms | +2010% |
+| Deny enforcement (50 blocked) | 555ms | 551ms | -0.7% | 560ms | +0.9% |
+| Redirect enforcement (50 redirected) | 1718ms | 1733ms | +0.9% | 4502ms | +162% |
+| Deep process tree (20x 4-level) | 604ms | 624ms | +3.3% | 8552ms | +1316% |
+| Wide process tree (10x 10-fan) | 320ms | 316ms | -1.2% | 1509ms | +372% |
+| **Total** | **7294ms** | **7347ms** | **+0.7%** | **36063ms** | **+394%** |
 
 ### Analysis
 
-**Full mode** (seccomp+FUSE) adds **~6% total overhead**. File I/O through the FUSE overlay adds ~90% to the file-intensive phase, but this is a small absolute cost (245ms) and is amortized across all phases. Non-file phases show no measurable overhead.
+**Full mode** (seccomp+FUSE) adds **<1% total overhead**. Non-file phases show no measurable overhead.
 
-**Ptrace mode** (with seccomp prefilter + lazy BPF escalation) adds **~5.4x total overhead**. This is expected — ptrace intercepts syscalls via context switches rather than kernel-internal notification. Breakdown:
+**Ptrace mode** adds **~4x total overhead** with all optimizations enabled. This is expected — ptrace intercepts syscalls via context switches rather than kernel-internal notification. Breakdown:
 
 1. **Per-exec RPC dominates.** Each `agentsh exec` call goes through CLI → HTTP → server → fork/exec (~30ms). The ptrace attach (PTRACE_SEIZE + seccomp BPF injection + WaitAttached) adds ~15ms per exec on top.
 
 2. **Deny enforcement is free.** Policy deny short-circuits before fork, so ptrace overhead is zero for denied commands.
 
-3. **File I/O is moderate (~2.7x).** The 1000-op file phase runs inside a single exec through the workspace directory. In full mode, FUSE intercepts each file operation for policy evaluation (+90%). Ptrace traps each `openat`/`unlinkat` at entry; only `openat` needs exit processing (fd tracking). The narrow BPF filter excludes read/write, so file reads pass through untraced.
+3. **File I/O is moderate (~2.3x).** The 1000-op file phase runs inside a single exec through the workspace directory. Ptrace traps each `openat`/`unlinkat` at entry. Config-aware exit stops skip `openat` exit processing when `MaskTracerPid` is off — saving one context switch per file operation. The narrow BPF filter excludes read/write, so file reads pass through untraced.
 
-4. **Network is expensive (~28x).** `curl` generates hundreds of syscalls (DNS, TLS, connect, read/write). The lazy BPF escalation keeps read/write out of the traced set entirely for processes that don't need them — `curl` never opens `/proc/*/status`, so reads are never trapped. Write escalation triggers only after a TLS connect. Combined with fd-aware exit stops, this reduced network overhead from ~37x (original) to ~28x.
+4. **Network is the worst case (~21x).** `curl` generates hundreds of syscalls (DNS, TLS, connect, read/write). The config-driven BPF filter removes `socket`, `listen`, and `close` from the traced set when fd tracking is inactive — saving ~15-25 ptrace stops per curl invocation. Lazy BPF escalation keeps read/write out of the traced set for processes that don't need them.
 
-5. **Git workflow benefits most from lazy escalation (~8x).** Git spawns many short-lived processes that never need read/write tracing. The narrow filter keeps these fast.
+5. **Process trees scale with depth (~14x).** Deep nesting (sh→sh→sh→sh→true) multiplies the per-exec attach cost. Wide fan-out (10 parallel children, ~5x) is better since children inherit the seccomp filter via fork.
 
-6. **Process trees scale with depth (~18x).** Deep nesting (sh→sh→sh→sh→true) multiplies the per-exec attach cost. Wide fan-out (10 parallel children, ~6x) is better since children inherit the seccomp filter via fork. The PendingPrefilter skip for auto-traced children avoids redundant BPF re-injection.
+6. **PTRACE_GET_SYSCALL_INFO** provides a lighter entry path (~96 bytes vs 216 bytes for full register read) for syscall dispatch. Simple handlers (write, close, read) use `SyscallContext.Info.Args` directly without loading full registers.
 
-7. **Seccomp prefilter provides ~3.8x speedup.** Without the prefilter, ptrace traps on every syscall, bringing total overhead to ~23x. The prefilter restricts tracing to policy-relevant syscalls (execve, openat, connect, etc.), reducing total overhead from 175s to 47s. Biggest wins: deep trees (4.9x), network (4.8x), process spawn (2.9x).
+7. **Config-driven BPF filter** removes always-allowed syscalls (`socket`, `listen`) and conditionally-needed syscalls (`sendto`, `close`) from the seccomp filter. This eliminates ptrace stops for syscalls that would always be allowed by the handler.
 
-8. **Lazy BPF escalation provides ~14% additional speedup over the prefilter alone.** By excluding read/pread64/write from the initial BPF filter and lazily escalating per-TGID when TracerPid masking or TLS SNI rewrite is needed, most processes avoid read/write entry stops entirely. Combined with fd-aware exit stops, the two optimizations together reduced total ptrace overhead from +621% (original) to +543% (current). Biggest wins: git workflow (-34%), network (-28%), deep trees (-17%).
+8. **Static deny support** via `SECCOMP_RET_ERRNO` enables BPF-level enforcement for policies that always deny certain syscalls (e.g., all network connections). Denied operations are handled entirely in-kernel without any ptrace stop.
 
 9. **Ptrace mode is designed for restricted environments** (e.g., AWS Fargate) where seccomp user-notify, eBPF, and FUSE are unavailable. The overhead tradeoff is acceptable for these environments where no alternative enforcement mechanism exists.
 
@@ -445,7 +445,7 @@ Measured with `make bench`, which runs a Dockerized workload under each mode (ba
 make bench
 ```
 
-Requires Docker with `--cap-add SYS_ADMIN --cap-add SYS_PTRACE --device /dev/fuse --security-opt seccomp=unconfined`. Total runtime ~20-25 minutes.
+Requires Docker with `--cap-add SYS_ADMIN --cap-add SYS_PTRACE --device /dev/fuse --security-opt seccomp=unconfined`. Total runtime ~15-20 minutes.
 
 ## Related Documentation
 

--- a/docs/superpowers/plans/2026-03-17-ptrace-performance-optimizations.md
+++ b/docs/superpowers/plans/2026-03-17-ptrace-performance-optimizations.md
@@ -1,0 +1,1350 @@
+# Ptrace Performance Optimizations Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce ptrace mode overhead (~621%) through four complementary optimizations: config-aware exit stop elimination, config-driven BPF filter, BPF-level static denies, and PTRACE_GET_SYSCALL_INFO.
+
+**Architecture:** Each optimization reduces the number or cost of ptrace stops. Opt 1 skips unnecessary exit stops based on config. Opt 2 removes always-allowed syscalls from the BPF filter. Opt 3 encodes static deny decisions in BPF. Opt 4 uses a lighter ptrace call for entry info.
+
+**Tech Stack:** Go, Linux ptrace, seccomp-BPF (cBPF), `golang.org/x/sys/unix`
+
+**Spec:** `docs/superpowers/specs/2026-03-17-ptrace-performance-optimizations-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `internal/ptrace/tracer.go` | Modify | `needsExitStop` → method; `SyscallContext` dispatch; capability detection |
+| `internal/ptrace/syscalls.go` | Modify | Config-driven `narrowTracedSyscallNumbers`/`tracedSyscallNumbers` |
+| `internal/ptrace/seccomp_filter.go` | Modify | `buildBPFForActions` with mixed TRACE/ERRNO; config-aware builders |
+| `internal/ptrace/inject_seccomp.go` | Modify | Pass config to builders; `collectStaticDenies`; escalation overlap validation |
+| `internal/ptrace/syscall_context.go` | Create | `SyscallEntryInfo`, `SyscallContext`, `getSyscallEntryInfo` |
+| `internal/ptrace/static_deny.go` | Create | `StaticDenyChecker` interface, `StaticDeny` type, `collectStaticDenies` |
+| `internal/ptrace/seccomp_filter_test.go` | Modify | Tests for config-driven filters, mixed actions BPF |
+| `internal/ptrace/syscalls_test.go` | Modify | Tests for config-driven syscall lists |
+| `internal/ptrace/static_deny_test.go` | Create | Tests for static deny collection and validation |
+| `internal/ptrace/syscall_context_test.go` | Create | Tests for SyscallContext lazy loading |
+| `internal/ptrace/handle_file.go` | Unchanged | Complex handler — gets Regs via dispatchSyscall (Opt 4) |
+| `internal/ptrace/handle_network.go` | Unchanged | Complex handler — gets Regs via dispatchSyscall (Opt 4) |
+| `internal/ptrace/handle_read.go` | Modify | Simple fd handler — accept `*SyscallContext` (Opt 4) |
+| `internal/ptrace/handle_write.go` | Modify | Simple fd handler — accept `*SyscallContext` (Opt 4) |
+| `internal/ptrace/handle_close.go` | Modify | Simple fd handler — accept `*SyscallContext` (Opt 4) |
+
+---
+
+### Task 1: Config-aware exit stop elimination (Optimization 1)
+
+**Files:**
+- Modify: `internal/ptrace/tracer.go:465-479` (needsExitStop function)
+- Modify: `internal/ptrace/tracer.go:900` (handleSyscallStop call site)
+- Modify: `internal/ptrace/tracer.go:956` (handleSeccompStop call site)
+- Test: `internal/ptrace/tracer_test.go`
+
+- [ ] **Step 1: Write test for config-aware needsExitStop**
+
+Add to `internal/ptrace/tracer_test.go`:
+
+```go
+func TestNeedsExitStop(t *testing.T) {
+	tests := []struct {
+		name           string
+		nr             int
+		maskTracerPid  bool
+		traceNetwork   bool
+		want           bool
+	}{
+		{"openat with mask on", unix.SYS_OPENAT, true, true, true},
+		{"openat with mask off", unix.SYS_OPENAT, false, true, false},
+		{"openat2 with mask off", unix.SYS_OPENAT2, false, true, false},
+		{"connect with network on", unix.SYS_CONNECT, false, true, true},
+		{"connect with network off", unix.SYS_CONNECT, false, false, false},
+		{"read always true", unix.SYS_READ, false, false, true},
+		{"pread64 always true", unix.SYS_PREAD64, false, false, true},
+		{"execve always true", unix.SYS_EXECVE, false, false, true},
+		{"execveat always true", unix.SYS_EXECVEAT, false, false, true},
+		{"unlinkat never needs exit", unix.SYS_UNLINKAT, true, true, false},
+		{"write never needs exit", unix.SYS_WRITE, true, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &Tracer{cfg: TracerConfig{
+				MaskTracerPid: tt.maskTracerPid,
+				TraceNetwork:  tt.traceNetwork,
+			}}
+			if got := tr.needsExitStop(tt.nr); got != tt.want {
+				t.Errorf("needsExitStop(%d) = %v, want %v", tt.nr, got, tt.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/ptrace/ -run TestNeedsExitStop -v`
+Expected: FAIL — `needsExitStop` is a function, not a method; `Tracer` struct may not be directly constructable in tests.
+
+- [ ] **Step 3: Convert needsExitStop to method on Tracer**
+
+In `internal/ptrace/tracer.go`, replace lines 465-479:
+
+```go
+// needsExitStop returns true if the given syscall needs an exit-time stop
+// for post-processing. Config-aware: skips exit stops when the relevant
+// feature (MaskTracerPid, TraceNetwork) is disabled.
+func (t *Tracer) needsExitStop(nr int) bool {
+	switch nr {
+	case unix.SYS_READ, unix.SYS_PREAD64: // handleReadExit (TracerPid masking)
+		return true // only traced when escalated — always needs exit
+	case unix.SYS_OPENAT, unix.SYS_OPENAT2: // handleOpenatExit (fd tracking)
+		return t.cfg.MaskTracerPid
+	case unix.SYS_CONNECT: // handleConnectExit (TLS fd watch)
+		return t.cfg.TraceNetwork // inline skip in handleNetwork handles port granularity
+	case unix.SYS_EXECVE, unix.SYS_EXECVEAT: // failed exec needs exit to reset InSyscall
+		return true
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Update call sites**
+
+In `internal/ptrace/tracer.go`, line 900 (inside `handleSyscallStop`):
+Change `state.NeedExitStop = needsExitStop(nr)` → `state.NeedExitStop = t.needsExitStop(nr)`
+
+In `internal/ptrace/tracer.go`, line 956 (inside `handleSeccompStop`):
+Change `state.NeedExitStop = needsExitStop(nr)` → `state.NeedExitStop = t.needsExitStop(nr)`
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./internal/ptrace/ -run TestNeedsExitStop -v`
+Expected: PASS
+
+- [ ] **Step 6: Run full test suite and cross-compile**
+
+Run: `go test ./... && GOOS=windows go build ./...`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/ptrace/tracer.go internal/ptrace/tracer_test.go
+git commit -m "perf(ptrace): config-aware needsExitStop to skip unnecessary exit stops
+
+Convert needsExitStop from standalone function to method on Tracer.
+Skip openat exit stops when MaskTracerPid is off. Skip connect exit
+stops when TraceNetwork is off. Saves one context switch per openat
+in MaskTracerPid=off deployments."
+```
+
+---
+
+### Task 2: Config-driven BPF filter — update syscall lists (Optimization 2a)
+
+**Files:**
+- Modify: `internal/ptrace/syscalls.go:51-83`
+- Modify: `internal/ptrace/syscalls_test.go`
+
+- [ ] **Step 1: Write tests for config-driven narrowTracedSyscallNumbers**
+
+Replace the existing `TestTracedSyscallNumbers` in `internal/ptrace/syscalls_test.go` and add new tests:
+
+```go
+func TestNarrowTracedSyscallNumbers(t *testing.T) {
+	// All features enabled, with handler
+	allOn := &TracerConfig{
+		TraceExecve:  true,
+		TraceFile:    true,
+		TraceNetwork: true,
+		TraceSignal:  true,
+		MaskTracerPid: true,
+		NetworkHandler: mockNetHandler{},
+	}
+	nums := narrowTracedSyscallNumbers(allOn)
+
+	// Must include policy-relevant syscalls
+	assertContains(t, nums, unix.SYS_EXECVE, "SYS_EXECVE")
+	assertContains(t, nums, unix.SYS_OPENAT, "SYS_OPENAT")
+	assertContains(t, nums, unix.SYS_CONNECT, "SYS_CONNECT")
+	assertContains(t, nums, unix.SYS_BIND, "SYS_BIND")
+	assertContains(t, nums, unix.SYS_SENDTO, "SYS_SENDTO")
+	assertContains(t, nums, unix.SYS_KILL, "SYS_KILL")
+	assertContains(t, nums, unix.SYS_CLOSE, "SYS_CLOSE")
+
+	// Must NOT include always-allowed syscalls
+	assertNotContains(t, nums, unix.SYS_SOCKET, "SYS_SOCKET")
+	assertNotContains(t, nums, unix.SYS_LISTEN, "SYS_LISTEN")
+
+	// Must NOT include lazily-escalated syscalls
+	assertNotContains(t, nums, unix.SYS_READ, "SYS_READ")
+	assertNotContains(t, nums, unix.SYS_WRITE, "SYS_WRITE")
+}
+
+func TestNarrowTracedSyscallNumbersNetworkOff(t *testing.T) {
+	cfg := &TracerConfig{TraceExecve: true, TraceFile: true}
+	nums := narrowTracedSyscallNumbers(cfg)
+
+	assertContains(t, nums, unix.SYS_EXECVE, "SYS_EXECVE")
+	assertContains(t, nums, unix.SYS_OPENAT, "SYS_OPENAT")
+	assertNotContains(t, nums, unix.SYS_CONNECT, "SYS_CONNECT")
+	assertNotContains(t, nums, unix.SYS_BIND, "SYS_BIND")
+	assertNotContains(t, nums, unix.SYS_SENDTO, "SYS_SENDTO")
+	assertNotContains(t, nums, unix.SYS_CLOSE, "SYS_CLOSE")
+}
+
+func TestNarrowTracedSyscallNumbersNoHandler(t *testing.T) {
+	cfg := &TracerConfig{TraceNetwork: true, NetworkHandler: nil}
+	nums := narrowTracedSyscallNumbers(cfg)
+
+	assertContains(t, nums, unix.SYS_CONNECT, "SYS_CONNECT")
+	// sendto only with handler (DNS proxy)
+	assertNotContains(t, nums, unix.SYS_SENDTO, "SYS_SENDTO")
+}
+
+func TestNarrowTracedSyscallNumbersCloseOnlyWithFdTracking(t *testing.T) {
+	// No MaskTracerPid, no NetworkHandler → no close
+	cfg := &TracerConfig{TraceFile: true}
+	nums := narrowTracedSyscallNumbers(cfg)
+	assertNotContains(t, nums, unix.SYS_CLOSE, "SYS_CLOSE")
+
+	// MaskTracerPid on → close needed
+	cfg2 := &TracerConfig{TraceFile: true, MaskTracerPid: true}
+	nums2 := narrowTracedSyscallNumbers(cfg2)
+	assertContains(t, nums2, unix.SYS_CLOSE, "SYS_CLOSE")
+}
+
+func TestTracedSyscallNumbersIncludesReadWrite(t *testing.T) {
+	cfg := &TracerConfig{TraceExecve: true, TraceFile: true, TraceNetwork: true}
+	nums := tracedSyscallNumbers(cfg)
+	assertContains(t, nums, unix.SYS_READ, "SYS_READ")
+	assertContains(t, nums, unix.SYS_PREAD64, "SYS_PREAD64")
+	assertContains(t, nums, unix.SYS_WRITE, "SYS_WRITE")
+}
+
+// helpers
+type mockNetHandler struct{}
+func (mockNetHandler) HandleNetwork(_ context.Context, _ NetworkContext) NetworkResult {
+	return NetworkResult{Allow: true}
+}
+
+func assertContains(t *testing.T, nums []int, target int, name string) {
+	t.Helper()
+	for _, n := range nums {
+		if n == target {
+			return
+		}
+	}
+	t.Errorf("%s (%d) missing from syscall list", name, target)
+}
+
+func assertNotContains(t *testing.T, nums []int, target int, name string) {
+	t.Helper()
+	for _, n := range nums {
+		if n == target {
+			t.Errorf("%s (%d) should not be in syscall list", name, target)
+			return
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/ptrace/ -run "TestNarrowTracedSyscallNumbers|TestTracedSyscallNumbers" -v`
+Expected: FAIL — functions don't accept `*TracerConfig`
+
+- [ ] **Step 3: Implement config-driven syscall lists**
+
+Replace `internal/ptrace/syscalls.go:51-83` with:
+
+```go
+func tracedSyscallNumbers(cfg *TracerConfig) []int {
+	nums := narrowTracedSyscallNumbers(cfg)
+	// Full set includes read/write for TRACESYSGOOD fallback mode
+	nums = append(nums, unix.SYS_READ, unix.SYS_PREAD64, unix.SYS_WRITE)
+	return nums
+}
+
+func narrowTracedSyscallNumbers(cfg *TracerConfig) []int {
+	var nums []int
+
+	if cfg.TraceExecve {
+		nums = append(nums, unix.SYS_EXECVE, unix.SYS_EXECVEAT)
+	}
+	if cfg.TraceFile {
+		nums = append(nums,
+			unix.SYS_OPENAT, unix.SYS_OPENAT2, unix.SYS_UNLINKAT, unix.SYS_MKDIRAT,
+			unix.SYS_RENAMEAT2, unix.SYS_LINKAT, unix.SYS_SYMLINKAT,
+			unix.SYS_FCHMODAT, unix.SYS_FCHMODAT2, unix.SYS_FCHOWNAT,
+		)
+		nums = append(nums, legacyFileSyscalls()...)
+	}
+	if cfg.TraceNetwork {
+		nums = append(nums, unix.SYS_CONNECT, unix.SYS_BIND)
+		if cfg.NetworkHandler != nil {
+			nums = append(nums, unix.SYS_SENDTO)
+		}
+		// socket, listen: removed — always allowed by handleNetwork
+	}
+	if cfg.TraceSignal {
+		nums = append(nums,
+			unix.SYS_KILL, unix.SYS_TGKILL, unix.SYS_TKILL,
+			unix.SYS_RT_SIGQUEUEINFO, unix.SYS_RT_TGSIGQUEUEINFO,
+		)
+	}
+	if cfg.MaskTracerPid || (cfg.TraceNetwork && cfg.NetworkHandler != nil) {
+		nums = append(nums, unix.SYS_CLOSE)
+	}
+
+	return nums
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/ptrace/ -run "TestNarrowTracedSyscallNumbers|TestTracedSyscallNumbers" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ptrace/syscalls.go internal/ptrace/syscalls_test.go
+git commit -m "perf(ptrace): config-driven BPF filter syscall lists
+
+narrowTracedSyscallNumbers and tracedSyscallNumbers now accept
+TracerConfig. Removes socket/listen (always allowed), sendto (only
+with DNS proxy), and close (only with fd tracking) from the BPF
+filter when not needed."
+```
+
+---
+
+### Task 3: Config-driven BPF filter — update builders and call sites (Optimization 2b)
+
+**Files:**
+- Modify: `internal/ptrace/seccomp_filter.go:73-89`
+- Modify: `internal/ptrace/inject_seccomp.go:31-35`
+- Modify: `internal/ptrace/seccomp_filter_test.go`
+
+- [ ] **Step 1: Update existing BPF filter tests**
+
+In `internal/ptrace/seccomp_filter_test.go`, update tests to pass config:
+
+```go
+func allEnabledConfig() *TracerConfig {
+	return &TracerConfig{
+		TraceExecve:    true,
+		TraceFile:      true,
+		TraceNetwork:   true,
+		TraceSignal:    true,
+		MaskTracerPid:  true,
+		NetworkHandler: mockNetHandler{},
+	}
+}
+
+func TestPrefilterBPFNonEmpty(t *testing.T) {
+	prog, err := buildPrefilterBPF(allEnabledConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(prog) == 0 {
+		t.Fatal("buildPrefilterBPF returned empty filter")
+	}
+}
+
+func TestPrefilterBPFInstructionCount(t *testing.T) {
+	cfg := allEnabledConfig()
+	syscalls := tracedSyscallNumbers(cfg)
+	prog, err := buildPrefilterBPF(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := 4 + len(syscalls) + 2
+	if len(prog) != want {
+		t.Errorf("instruction count = %d, want %d (4 header + %d comparisons + 2 returns)",
+			len(prog), want, len(syscalls))
+	}
+}
+
+func TestPrefilterBPFContainsAllSyscalls(t *testing.T) {
+	cfg := allEnabledConfig()
+	syscalls := tracedSyscallNumbers(cfg)
+	prog, err := buildPrefilterBPF(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jeqValues := make(map[uint32]bool)
+	for _, inst := range prog {
+		if inst.Code == bpfJMP|bpfJEQ|bpfK {
+			if inst.K == auditArchX86_64 || inst.K == auditArchAarch64 {
+				continue
+			}
+			jeqValues[inst.K] = true
+		}
+	}
+	for _, nr := range syscalls {
+		if !jeqValues[uint32(nr)] {
+			t.Errorf("syscall %d not found as JEQ instruction in filter", nr)
+		}
+	}
+}
+
+func TestPrefilterBPFArchCheck(t *testing.T) {
+	prog, err := buildPrefilterBPF(allEnabledConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prog[0].Code != bpfLD|bpfW|bpfABS || prog[0].K != offsetArch {
+		t.Errorf("first instruction should load arch (offset %d), got Code=0x%x K=%d",
+			offsetArch, prog[0].Code, prog[0].K)
+	}
+	if prog[1].Code != bpfJMP|bpfJEQ|bpfK {
+		t.Errorf("second instruction should be JEQ, got Code=0x%x", prog[1].Code)
+	}
+}
+
+func TestNarrowPrefilterExcludesReadWrite(t *testing.T) {
+	cfg := allEnabledConfig()
+	prog, err := buildNarrowPrefilterBPF(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jeqValues := make(map[uint32]bool)
+	for _, inst := range prog {
+		if inst.Code == bpfJMP|bpfJEQ|bpfK {
+			jeqValues[inst.K] = true
+		}
+	}
+	if jeqValues[uint32(unix.SYS_READ)] {
+		t.Error("narrow prefilter should not contain SYS_READ")
+	}
+	if jeqValues[uint32(unix.SYS_PREAD64)] {
+		t.Error("narrow prefilter should not contain SYS_PREAD64")
+	}
+	if jeqValues[uint32(unix.SYS_WRITE)] {
+		t.Error("narrow prefilter should not contain SYS_WRITE")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/ptrace/ -run "TestPrefilterBPF|TestNarrowPrefilter" -v`
+Expected: FAIL — builders don't accept config
+
+- [ ] **Step 3: Update BPF builder signatures**
+
+In `internal/ptrace/seccomp_filter.go`, replace lines 73-89:
+
+```go
+func buildPrefilterBPF(cfg *TracerConfig) ([]unix.SockFilter, error) {
+	return buildBPFForSyscalls(tracedSyscallNumbers(cfg))
+}
+
+func buildNarrowPrefilterBPF(cfg *TracerConfig) ([]unix.SockFilter, error) {
+	return buildBPFForSyscalls(narrowTracedSyscallNumbers(cfg))
+}
+
+func buildEscalationBPF(syscalls []int) ([]unix.SockFilter, error) {
+	return buildBPFForSyscalls(syscalls)
+}
+```
+
+- [ ] **Step 4: Update injectSeccompFilter to pass config**
+
+In `internal/ptrace/inject_seccomp.go`, line 33:
+Change `filters, bpfErr := buildNarrowPrefilterBPF()` → `filters, bpfErr := buildNarrowPrefilterBPF(&t.cfg)`
+
+- [ ] **Step 5: Fix any remaining compile errors**
+
+Search for other callers of `buildPrefilterBPF()` or `buildNarrowPrefilterBPF()` and update them to pass config. Check `tracedSyscallNumbers()` callers too — the TRACESYSGOOD fallback in tracer.go may call it.
+
+Run: `go build ./internal/ptrace/`
+
+- [ ] **Step 6: Run all tests**
+
+Run: `go test ./internal/ptrace/ -v && GOOS=windows go build ./...`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/ptrace/seccomp_filter.go internal/ptrace/inject_seccomp.go internal/ptrace/seccomp_filter_test.go
+git commit -m "perf(ptrace): config-driven BPF filter builders
+
+buildPrefilterBPF and buildNarrowPrefilterBPF now accept TracerConfig
+to generate filters with only policy-relevant syscalls. Removes
+socket/listen/sendto/close from BPF filter when not needed."
+```
+
+---
+
+### Task 4: BPF-level static denies — types and collection (Optimization 3a)
+
+**Files:**
+- Create: `internal/ptrace/static_deny.go`
+- Create: `internal/ptrace/static_deny_test.go`
+
+- [ ] **Step 1: Write tests for static deny types and collection**
+
+Create `internal/ptrace/static_deny_test.go`:
+
+```go
+//go:build linux
+
+package ptrace
+
+import (
+	"context"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+type denyAllNetHandler struct{}
+
+func (denyAllNetHandler) HandleNetwork(_ context.Context, _ NetworkContext) NetworkResult {
+	return NetworkResult{Allow: false}
+}
+
+func (denyAllNetHandler) StaticDenySyscalls() []StaticDeny {
+	return []StaticDeny{
+		{Nr: unix.SYS_CONNECT, Errno: int(unix.EACCES)},
+		{Nr: unix.SYS_BIND, Errno: int(unix.EACCES)},
+	}
+}
+
+type allowAllNetHandler struct{}
+
+func (allowAllNetHandler) HandleNetwork(_ context.Context, _ NetworkContext) NetworkResult {
+	return NetworkResult{Allow: true}
+}
+
+func TestCollectStaticDeniesNilHandler(t *testing.T) {
+	tr := &Tracer{cfg: TracerConfig{TraceNetwork: true, NetworkHandler: nil}}
+	denies := tr.collectStaticDenies()
+	if len(denies) != 2 {
+		t.Fatalf("expected 2 denies for nil handler, got %d", len(denies))
+	}
+	if denies[0].Nr != unix.SYS_CONNECT || denies[1].Nr != unix.SYS_BIND {
+		t.Error("expected connect and bind denies")
+	}
+}
+
+func TestCollectStaticDeniesWithChecker(t *testing.T) {
+	tr := &Tracer{cfg: TracerConfig{TraceNetwork: true, NetworkHandler: denyAllNetHandler{}}}
+	denies := tr.collectStaticDenies()
+	if len(denies) != 2 {
+		t.Fatalf("expected 2 denies from checker, got %d", len(denies))
+	}
+}
+
+func TestCollectStaticDeniesNoChecker(t *testing.T) {
+	tr := &Tracer{cfg: TracerConfig{TraceNetwork: true, NetworkHandler: allowAllNetHandler{}}}
+	denies := tr.collectStaticDenies()
+	if len(denies) != 0 {
+		t.Fatalf("expected 0 denies for non-checker handler, got %d", len(denies))
+	}
+}
+
+func TestCollectStaticDeniesRejectsZeroErrno(t *testing.T) {
+	denies := validateStaticDenies([]StaticDeny{
+		{Nr: unix.SYS_CONNECT, Errno: int(unix.EACCES)},
+		{Nr: unix.SYS_BIND, Errno: 0}, // invalid
+	})
+	if len(denies) != 1 {
+		t.Fatalf("expected 1 valid deny after filtering, got %d", len(denies))
+	}
+}
+
+func TestCollectStaticDeniesRejectsEscalationOverlap(t *testing.T) {
+	denies := validateStaticDenies([]StaticDeny{
+		{Nr: unix.SYS_READ, Errno: int(unix.EACCES)}, // overlaps escalation
+		{Nr: unix.SYS_CONNECT, Errno: int(unix.EACCES)},
+	})
+	if len(denies) != 1 {
+		t.Fatalf("expected 1 valid deny after filtering overlap, got %d", len(denies))
+	}
+	if denies[0].Nr != unix.SYS_CONNECT {
+		t.Error("expected connect to survive, read to be filtered")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/ptrace/ -run TestCollectStaticDenies -v`
+Expected: FAIL — types and functions don't exist
+
+- [ ] **Step 3: Implement static deny types and collection**
+
+Create `internal/ptrace/static_deny.go`:
+
+```go
+//go:build linux
+
+package ptrace
+
+import (
+	"log/slog"
+
+	"golang.org/x/sys/unix"
+)
+
+// StaticDenyChecker is an optional interface that handlers implement to declare
+// syscalls that are always denied regardless of arguments for the session lifetime.
+// This enables BPF-level enforcement (SECCOMP_RET_ERRNO) without ptrace stops.
+type StaticDenyChecker interface {
+	StaticDenySyscalls() []StaticDeny
+}
+
+// StaticDeny represents a syscall that should be denied at the BPF level.
+type StaticDeny struct {
+	Nr    int
+	Errno int // must be > 0
+}
+
+// collectStaticDenies gathers all static deny declarations from handlers and config.
+func (t *Tracer) collectStaticDenies() []StaticDeny {
+	var denies []StaticDeny
+
+	// Category enabled but handler nil → deny all relevant syscalls
+	if t.cfg.TraceNetwork && t.cfg.NetworkHandler == nil {
+		denies = append(denies,
+			StaticDeny{Nr: unix.SYS_CONNECT, Errno: int(unix.EACCES)},
+			StaticDeny{Nr: unix.SYS_BIND, Errno: int(unix.EACCES)},
+		)
+	}
+
+	// Handler-declared denies
+	if checker, ok := t.cfg.NetworkHandler.(StaticDenyChecker); ok {
+		denies = append(denies, checker.StaticDenySyscalls()...)
+	}
+	if checker, ok := t.cfg.FileHandler.(StaticDenyChecker); ok {
+		denies = append(denies, checker.StaticDenySyscalls()...)
+	}
+	if checker, ok := t.cfg.ExecHandler.(StaticDenyChecker); ok {
+		denies = append(denies, checker.StaticDenySyscalls()...)
+	}
+	if checker, ok := t.cfg.SignalHandler.(StaticDenyChecker); ok {
+		denies = append(denies, checker.StaticDenySyscalls()...)
+	}
+
+	return validateStaticDenies(denies)
+}
+
+// escalationSyscalls returns the set of syscalls used by lazy BPF escalation.
+// Static denies must not overlap with these.
+var escalationSyscalls = map[int]bool{
+	unix.SYS_READ:    true,
+	unix.SYS_PREAD64: true,
+	unix.SYS_WRITE:   true,
+}
+
+// validateStaticDenies filters out invalid entries and logs warnings.
+func validateStaticDenies(denies []StaticDeny) []StaticDeny {
+	valid := make([]StaticDeny, 0, len(denies))
+	for _, d := range denies {
+		if d.Errno <= 0 {
+			slog.Warn("static deny: rejecting entry with invalid errno",
+				"nr", d.Nr, "errno", d.Errno)
+			continue
+		}
+		if escalationSyscalls[d.Nr] {
+			slog.Warn("static deny: rejecting entry that overlaps escalation syscalls",
+				"nr", d.Nr)
+			continue
+		}
+		valid = append(valid, d)
+	}
+	return valid
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/ptrace/ -run TestCollectStaticDenies -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ptrace/static_deny.go internal/ptrace/static_deny_test.go
+git commit -m "perf(ptrace): add StaticDenyChecker interface and collection
+
+Handlers can optionally implement StaticDenyChecker to declare syscalls
+always denied for the session. Validates errno > 0 and rejects overlaps
+with escalation syscalls (read/write/pread64)."
+```
+
+---
+
+### Task 5: BPF-level static denies — extend BPF generation (Optimization 3b)
+
+**Files:**
+- Modify: `internal/ptrace/seccomp_filter.go`
+- Modify: `internal/ptrace/inject_seccomp.go`
+- Modify: `internal/ptrace/seccomp_filter_test.go`
+
+- [ ] **Step 1: Write test for mixed-action BPF generation**
+
+Add to `internal/ptrace/seccomp_filter_test.go`:
+
+```go
+func TestBuildBPFForActions(t *testing.T) {
+	actions := []bpfSyscallAction{
+		{Nr: unix.SYS_OPENAT, Action: seccompRetTrace},
+		{Nr: unix.SYS_CONNECT, Action: seccompRetErrno(int(unix.EACCES))},
+	}
+	prog, err := buildBPFForActions(actions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify both syscalls are in the filter
+	jeqValues := make(map[uint32]bool)
+	for _, inst := range prog {
+		if inst.Code == bpfJMP|bpfJEQ|bpfK {
+			if inst.K == auditArchX86_64 || inst.K == auditArchAarch64 {
+				continue
+			}
+			jeqValues[inst.K] = true
+		}
+	}
+	if !jeqValues[uint32(unix.SYS_OPENAT)] {
+		t.Error("SYS_OPENAT missing from filter")
+	}
+	if !jeqValues[uint32(unix.SYS_CONNECT)] {
+		t.Error("SYS_CONNECT missing from filter")
+	}
+
+	// Verify there are at least 3 distinct return instructions
+	// (ALLOW, TRACE, ERRNO)
+	retInsts := 0
+	for _, inst := range prog {
+		if inst.Code == bpfRET|bpfK {
+			retInsts++
+		}
+	}
+	if retInsts < 3 {
+		t.Errorf("expected at least 3 return instructions (ALLOW, TRACE, ERRNO), got %d", retInsts)
+	}
+}
+
+func TestBuildBPFForActionsErrnoValue(t *testing.T) {
+	errno := int(unix.EPERM)
+	actions := []bpfSyscallAction{
+		{Nr: unix.SYS_CONNECT, Action: seccompRetErrno(errno)},
+	}
+	prog, err := buildBPFForActions(actions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Find the ERRNO return instruction and verify the encoded errno
+	found := false
+	for _, inst := range prog {
+		if inst.Code == bpfRET|bpfK && inst.K != seccompRetAllow && inst.K != seccompRetTrace {
+			if inst.K != uint32(0x00050000|errno) {
+				t.Errorf("ERRNO return has wrong value: 0x%x, want 0x%x", inst.K, 0x00050000|errno)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("no ERRNO return instruction found")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/ptrace/ -run "TestBuildBPFForActions" -v`
+Expected: FAIL — `buildBPFForActions`, `bpfSyscallAction`, `seccompRetErrno` don't exist
+
+- [ ] **Step 3: Implement buildBPFForActions**
+
+Add to `internal/ptrace/seccomp_filter.go`:
+
+```go
+const seccompRetErrnoBase = 0x00050000
+
+// seccompRetErrno returns the SECCOMP_RET_ERRNO value for the given errno.
+func seccompRetErrno(errno int) uint32 {
+	return seccompRetErrnoBase | uint32(errno&0xFFFF)
+}
+
+// bpfSyscallAction pairs a syscall number with its BPF return action.
+type bpfSyscallAction struct {
+	Nr     int
+	Action uint32 // seccompRetTrace or seccompRetErrno(errno)
+}
+
+// buildBPFForActions generates a seccomp-BPF filter with per-syscall return
+// actions. Different syscalls can have different return values (TRACE vs ERRNO).
+func buildBPFForActions(actions []bpfSyscallAction) ([]unix.SockFilter, error) {
+	var auditArch uint32
+	switch runtime.GOARCH {
+	case "amd64":
+		auditArch = auditArchX86_64
+	case "arm64":
+		auditArch = auditArchAarch64
+	default:
+		return nil, fmt.Errorf("seccomp prefilter: unsupported architecture %s", runtime.GOARCH)
+	}
+
+	// Collect unique return actions (deduplicate).
+	retActionSet := make(map[uint32]int) // action → index in retActions slice
+	var retActions []uint32
+	for _, a := range actions {
+		if _, ok := retActionSet[a.Action]; !ok {
+			retActionSet[a.Action] = len(retActions)
+			retActions = append(retActions, a.Action)
+		}
+	}
+
+	n := len(actions)
+	nRet := len(retActions)
+	// Program: 4 header + n comparisons + 1 default ALLOW + nRet action returns
+	prog := make([]unix.SockFilter, 0, 4+n+1+nRet)
+
+	// Header: load arch, check arch, load nr
+	prog = append(prog, unix.SockFilter{Code: bpfLD | bpfW | bpfABS, K: offsetArch})
+	prog = append(prog, unix.SockFilter{Code: bpfJMP | bpfJEQ | bpfK, Jt: 1, Jf: 0, K: auditArch})
+	prog = append(prog, unix.SockFilter{Code: bpfRET | bpfK, K: seccompRetTrace}) // unknown arch → trace
+	prog = append(prog, unix.SockFilter{Code: bpfLD | bpfW | bpfABS, K: offsetNr})
+
+	// Comparisons: each JEQ jumps to its action's return instruction.
+	// Layout after comparisons: [ALLOW ret] [action0 ret] [action1 ret] ...
+	for i, a := range actions {
+		remaining := n - i - 1 // instructions remaining after this JEQ
+		// Jump target = remaining comparisons + 1 (skip ALLOW) + retActionSet[a.Action]
+		jumpTarget := uint8(remaining + 1 + retActionSet[a.Action])
+		prog = append(prog, unix.SockFilter{
+			Code: bpfJMP | bpfJEQ | bpfK,
+			Jt:   jumpTarget,
+			Jf:   0,
+			K:    uint32(a.Nr),
+		})
+	}
+
+	// Default: ALLOW
+	prog = append(prog, unix.SockFilter{Code: bpfRET | bpfK, K: seccompRetAllow})
+
+	// Per-action return instructions
+	for _, action := range retActions {
+		prog = append(prog, unix.SockFilter{Code: bpfRET | bpfK, K: action})
+	}
+
+	return prog, nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/ptrace/ -run "TestBuildBPFForActions" -v`
+Expected: PASS
+
+- [ ] **Step 5: Integrate static denies into injectSeccompFilter**
+
+In `internal/ptrace/inject_seccomp.go`, replace the top of `injectSeccompFilter` (lines 31-38, everything from the function signature through the BPF building) with the following. The remainder of the function (from `if len(filters) == 0` onward — scratch page allocation, BPF serialization, prctl/seccomp injection) stays unchanged, since it operates on the same `filters` variable:
+
+```go
+func (t *Tracer) injectSeccompFilter(tid int) error {
+	// Collect static denies and narrow syscall list.
+	denies := t.collectStaticDenies()
+	narrowNums := narrowTracedSyscallNumbers(&t.cfg)
+
+	var filters []unix.SockFilter
+	var bpfErr error
+
+	if len(denies) > 0 {
+		// Build merged action list: denies get ERRNO, rest get TRACE.
+		denySet := make(map[int]uint32) // nr → ERRNO action
+		for _, d := range denies {
+			denySet[d.Nr] = seccompRetErrno(d.Errno)
+		}
+
+		var actions []bpfSyscallAction
+		for _, nr := range narrowNums {
+			if errnoAction, ok := denySet[nr]; ok {
+				actions = append(actions, bpfSyscallAction{Nr: nr, Action: errnoAction})
+				delete(denySet, nr) // consumed
+			} else {
+				actions = append(actions, bpfSyscallAction{Nr: nr, Action: seccompRetTrace})
+			}
+		}
+		// Add deny-only syscalls not in narrow list
+		for nr, action := range denySet {
+			actions = append(actions, bpfSyscallAction{Nr: nr, Action: action})
+		}
+
+		filters, bpfErr = buildBPFForActions(actions)
+	} else {
+		filters, bpfErr = buildNarrowPrefilterBPF(&t.cfg)
+	}
+
+	if bpfErr != nil {
+		return bpfErr
+	}
+	if len(filters) == 0 {
+		return fmt.Errorf("empty BPF program")
+	}
+	// --- everything below here is unchanged from the original function ---
+```
+
+After the successful `slog.Info("seccomp prefilter installed", ...)` line near the end of the function (line 122), add logging for static denies:
+
+```go
+	slog.Info("seccomp prefilter installed", "tid", tid, "filters", len(filters))
+	for _, d := range denies {
+		slog.Info("seccomp static deny active", "tid", tid, "nr", d.Nr, "errno", d.Errno)
+	}
+	return nil
+```
+
+- [ ] **Step 6: Run all tests and cross-compile**
+
+Run: `go test ./internal/ptrace/ -v && go test ./... && GOOS=windows go build ./...`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/ptrace/seccomp_filter.go internal/ptrace/inject_seccomp.go internal/ptrace/seccomp_filter_test.go
+git commit -m "perf(ptrace): BPF-level SECCOMP_RET_ERRNO for static deny policies
+
+buildBPFForActions generates mixed TRACE/ERRNO filters. Static deny
+syscalls are enforced entirely in-kernel without ptrace stops.
+injectSeccompFilter merges static denies with the narrow filter."
+```
+
+---
+
+### Task 6: PTRACE_GET_SYSCALL_INFO — SyscallContext and capability detection (Optimization 4a)
+
+**Files:**
+- Create: `internal/ptrace/syscall_context.go`
+- Create: `internal/ptrace/syscall_context_test.go`
+- Modify: `internal/ptrace/tracer.go` (add `hasSyscallInfo` field to Tracer)
+
+- [ ] **Step 1: Write tests for SyscallContext**
+
+Create `internal/ptrace/syscall_context_test.go`:
+
+```go
+//go:build linux
+
+package ptrace
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestSyscallContextLazyRegs(t *testing.T) {
+	// SyscallContext should not load regs until Regs() is called
+	sc := &SyscallContext{
+		Info: SyscallEntryInfo{
+			Nr:   unix.SYS_OPENAT,
+			Args: [6]uint64{0xFFFFFF9C, 0x7FFF1234, 0, 0, 0, 0},
+		},
+	}
+	if sc.loaded {
+		t.Error("regs should not be loaded initially")
+	}
+	if sc.Info.Nr != unix.SYS_OPENAT {
+		t.Errorf("Nr = %d, want SYS_OPENAT", sc.Info.Nr)
+	}
+	if sc.Info.Args[0] != 0xFFFFFF9C {
+		t.Errorf("Args[0] = 0x%x, want 0xFFFFFF9C", sc.Info.Args[0])
+	}
+}
+
+func TestSeccompRetErrnoEncoding(t *testing.T) {
+	// SECCOMP_RET_ERRNO is 0x00050000 | errno
+	got := seccompRetErrno(int(unix.EACCES))
+	want := uint32(0x00050000 | unix.EACCES)
+	if got != want {
+		t.Errorf("seccompRetErrno(EACCES) = 0x%x, want 0x%x", got, want)
+	}
+}
+```
+
+- [ ] **Step 2: Implement SyscallContext**
+
+Create `internal/ptrace/syscall_context.go`:
+
+```go
+//go:build linux
+
+package ptrace
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// ptraceGetSyscallInfo is the ptrace request number for PTRACE_GET_SYSCALL_INFO.
+const ptraceGetSyscallInfo = 0x420e
+
+// SyscallEntryInfo holds syscall number and arguments extracted at entry time.
+type SyscallEntryInfo struct {
+	Nr   int
+	Args [6]uint64
+}
+
+// SyscallContext wraps entry info with lazy full-register access.
+// Handlers use Info.Args for the fast allow path and call Regs() only
+// when they need to modify registers (deny/redirect).
+type SyscallContext struct {
+	Info   SyscallEntryInfo
+	tid    int
+	tracer *Tracer
+	regs   Regs
+	loaded bool
+}
+
+// Regs lazily loads the full register set. Cached after first call.
+func (sc *SyscallContext) Regs() (Regs, error) {
+	if !sc.loaded {
+		var err error
+		sc.regs, err = sc.tracer.getRegs(sc.tid)
+		if err != nil {
+			return nil, err
+		}
+		sc.loaded = true
+	}
+	return sc.regs, nil
+}
+
+// ptraceSyscallInfo mirrors struct ptrace_syscall_info (Linux 5.3+).
+// We only parse the entry variant (op == 1).
+type ptraceSyscallInfo struct {
+	Op                  uint8
+	_                   [3]byte // pad
+	Arch                uint32
+	InstructionPointer  uint64
+	StackPointer        uint64
+	// Union: entry is the relevant variant.
+	EntryNr             uint64
+	EntryArgs           [6]uint64
+}
+
+const ptraceSyscallInfoSize = int(unsafe.Sizeof(ptraceSyscallInfo{}))
+
+// getSyscallEntryInfo retrieves syscall entry info via PTRACE_GET_SYSCALL_INFO.
+// Returns nil, errNotSupported on kernels < 5.3.
+func (t *Tracer) getSyscallEntryInfo(tid int) (*SyscallEntryInfo, error) {
+	var info ptraceSyscallInfo
+	_, _, errno := unix.Syscall6(
+		unix.SYS_PTRACE,
+		uintptr(ptraceGetSyscallInfo),
+		uintptr(tid),
+		uintptr(ptraceSyscallInfoSize),
+		uintptr(unsafe.Pointer(&info)),
+		0, 0,
+	)
+	if errno != 0 {
+		return nil, fmt.Errorf("PTRACE_GET_SYSCALL_INFO: %w", errno)
+	}
+	// op == 1 means PTRACE_SYSCALL_INFO_ENTRY
+	if info.Op != 1 {
+		return nil, fmt.Errorf("PTRACE_GET_SYSCALL_INFO: unexpected op %d (want entry=1)", info.Op)
+	}
+	return &SyscallEntryInfo{
+		Nr:   int(info.EntryNr),
+		Args: info.EntryArgs,
+	}, nil
+}
+
+// probePtraceSyscallInfo returns true if PTRACE_GET_SYSCALL_INFO is supported.
+// Must be called from a goroutine locked to an OS thread.
+func probePtraceSyscallInfo() bool {
+	// A simple probe: call with pid=0 (invalid). If the kernel knows the
+	// request, it returns ESRCH. If not, it returns EIO or EINVAL.
+	var info ptraceSyscallInfo
+	_, _, errno := unix.Syscall6(
+		unix.SYS_PTRACE,
+		uintptr(ptraceGetSyscallInfo),
+		0, // invalid pid
+		uintptr(ptraceSyscallInfoSize),
+		uintptr(unsafe.Pointer(&info)),
+		0, 0,
+	)
+	return errno == unix.ESRCH
+}
+```
+
+- [ ] **Step 3: Add hasSyscallInfo to Tracer**
+
+In `internal/ptrace/tracer.go`, add field to Tracer struct (find the struct definition and add):
+
+```go
+hasSyscallInfo bool // set at startup if PTRACE_GET_SYSCALL_INFO is available
+```
+
+In the `Run()` method, before the event loop, add capability detection:
+
+```go
+t.hasSyscallInfo = probePtraceSyscallInfo()
+if t.hasSyscallInfo {
+    slog.Info("ptrace: PTRACE_GET_SYSCALL_INFO supported")
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/ptrace/ -run "TestSyscallContext|TestSeccompRetErrno" -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full suite and cross-compile**
+
+Run: `go test ./... && GOOS=windows go build ./...`
+Expected: PASS (syscall_context.go has `//go:build linux`)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/ptrace/syscall_context.go internal/ptrace/syscall_context_test.go internal/ptrace/tracer.go
+git commit -m "perf(ptrace): add SyscallContext and PTRACE_GET_SYSCALL_INFO support
+
+SyscallContext provides lazy register loading — handlers can read
+syscall args from the lightweight SyscallEntryInfo and only fall
+back to full getRegs when modifying registers. Probes for
+PTRACE_GET_SYSCALL_INFO support at startup."
+```
+
+---
+
+### Task 7: PTRACE_GET_SYSCALL_INFO — integrate into dispatch (Optimization 4b)
+
+**Files:**
+- Modify: `internal/ptrace/tracer.go` (handleSeccompStop, handleSyscallStop, dispatchSyscall)
+- Modify: `internal/ptrace/handle_write.go` (use sc.Info.Args for fd)
+- Modify: `internal/ptrace/handle_close.go` (use sc.Info.Args for fd)
+- Modify: `internal/ptrace/handle_read.go` (use sc.Info.Args for fd)
+
+**Strategy**: Minimize blast radius. Complex handlers (handleFile, handleNetwork, handleExecve, handleSignal) call `sc.Regs()` upfront in `dispatchSyscall` and keep their existing `Regs` signatures. Only simple fd-only handlers (handleWrite, handleClose, handleReadEntry) change to accept `*SyscallContext` and use `sc.Info.Args[0]`. This gets the main benefit (lighter syscall-number extraction in the dispatch path) without touching the complex handler internals.
+
+- [ ] **Step 1: Extract buildSyscallContext helper**
+
+Add to `internal/ptrace/syscall_context.go`:
+
+```go
+// buildSyscallContext constructs a SyscallContext for a stopped tracee.
+// Uses PTRACE_GET_SYSCALL_INFO when available, falls back to full getRegs.
+func (t *Tracer) buildSyscallContext(tid int) (*SyscallContext, error) {
+	sc := &SyscallContext{tid: tid, tracer: t}
+
+	if t.hasSyscallInfo {
+		info, err := t.getSyscallEntryInfo(tid)
+		if err == nil {
+			sc.Info = *info
+			return sc, nil
+		}
+		// Fallback to full register read
+	}
+
+	regs, err := t.getRegs(tid)
+	if err != nil {
+		return nil, err
+	}
+	sc.Info = SyscallEntryInfo{Nr: regs.SyscallNr()}
+	for i := 0; i < 6; i++ {
+		sc.Info.Args[i] = regs.Arg(i)
+	}
+	sc.regs = regs
+	sc.loaded = true
+	return sc, nil
+}
+```
+
+- [ ] **Step 2: Update dispatchSyscall**
+
+In `internal/ptrace/tracer.go`, change `dispatchSyscall` to accept `*SyscallContext`. Complex handlers get `Regs` via `sc.Regs()`, simple handlers get `*SyscallContext`:
+
+```go
+func (t *Tracer) dispatchSyscall(ctx context.Context, tid int, nr int, sc *SyscallContext) {
+	switch {
+	case isExecveSyscall(nr):
+		regs, err := sc.Regs()
+		if err != nil {
+			t.allowSyscall(tid)
+			return
+		}
+		t.handleExecve(ctx, tid, regs)
+	case isFileSyscall(nr):
+		regs, err := sc.Regs()
+		if err != nil {
+			t.allowSyscall(tid)
+			return
+		}
+		t.handleFile(ctx, tid, regs)
+	case isNetworkSyscall(nr):
+		regs, err := sc.Regs()
+		if err != nil {
+			t.allowSyscall(tid)
+			return
+		}
+		t.handleNetwork(ctx, tid, regs)
+	case isSignalSyscall(nr):
+		regs, err := sc.Regs()
+		if err != nil {
+			t.allowSyscall(tid)
+			return
+		}
+		t.handleSignal(ctx, tid, regs)
+	case isWriteSyscall(nr):
+		t.handleWrite(ctx, tid, sc)
+	case isCloseSyscall(nr):
+		t.handleClose(ctx, tid, sc)
+	case isReadSyscall(nr):
+		t.handleReadEntry(tid, sc)
+	default:
+		t.allowSyscall(tid)
+	}
+}
+```
+
+Note: `handleFile`, `handleNetwork`, `handleExecve`, `handleSignal` keep their `Regs` signatures unchanged. `handleWrite`, `handleClose`, `handleReadEntry` change to `*SyscallContext`.
+
+- [ ] **Step 3: Update handleSeccompStop to use buildSyscallContext**
+
+Replace the register-reading block in `handleSeccompStop` (`tracer.go:940`):
+
+```go
+func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
+	sc, err := t.buildSyscallContext(tid)
+	if err != nil {
+		t.allowSyscall(tid)
+		return
+	}
+	nr := sc.Info.Nr
+
+	t.mu.Lock()
+	state := t.tracees[tid]
+	if state != nil {
+		state.InSyscall = true
+		state.LastNr = nr
+		state.NeedExitStop = t.needsExitStop(nr)
+		if state.NeedsReadEscalation && !state.ThreadHasReadEscalation {
+			state.PendingReadEscalation = true
+		}
+		if state.NeedsWriteEscalation && !state.ThreadHasWriteEscalation {
+			state.PendingWriteEscalation = true
+		}
+	}
+	t.mu.Unlock()
+
+	t.dispatchSyscall(ctx, tid, nr, sc)
+}
+```
+
+- [ ] **Step 4: Update handleSyscallStop entry path**
+
+Replace the `entering` branch (around `tracer.go:889`):
+
+```go
+	if entering {
+		sc, err := t.buildSyscallContext(tid)
+		if err != nil {
+			t.allowSyscall(tid)
+			return
+		}
+		nr := sc.Info.Nr
+		state.LastNr = nr
+		state.NeedExitStop = t.needsExitStop(nr)
+
+		t.dispatchSyscall(ctx, tid, nr, sc)
+	}
+```
+
+- [ ] **Step 5: Update handleWrite to accept SyscallContext**
+
+In `internal/ptrace/handle_write.go`, change signature and fd extraction:
+
+```go
+func (t *Tracer) handleWrite(ctx context.Context, tid int, sc *SyscallContext) {
+	if t.fds == nil {
+		t.allowSyscall(tid)
+		return
+	}
+
+	fd := int(int32(sc.Info.Args[0]))
+	// ... rest unchanged (uses t.fds, t.mu, t.tracees — no regs needed)
+```
+
+- [ ] **Step 6: Update handleClose to accept SyscallContext**
+
+In `internal/ptrace/handle_close.go`:
+
+```go
+func (t *Tracer) handleClose(_ context.Context, tid int, sc *SyscallContext) {
+	fd := int(int32(sc.Info.Args[0]))
+	// ... rest unchanged
+```
+
+- [ ] **Step 7: Update handleReadEntry to accept SyscallContext**
+
+In `internal/ptrace/handle_read.go`:
+
+```go
+func (t *Tracer) handleReadEntry(tid int, sc *SyscallContext) {
+	if t.fds != nil && t.cfg.MaskTracerPid {
+		fd := int(int32(sc.Info.Args[0]))
+		// ... rest unchanged
+```
+
+- [ ] **Step 8: Build and verify**
+
+Run: `go build ./internal/ptrace/`
+Expected: PASS. If there are compile errors, they'll be in handler call sites — fix argument mismatches.
+
+- [ ] **Step 9: Run full test suite and cross-compile**
+
+Run: `go test ./... && GOOS=windows go build ./...`
+Expected: PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/ptrace/tracer.go internal/ptrace/syscall_context.go internal/ptrace/handle_write.go internal/ptrace/handle_close.go internal/ptrace/handle_read.go
+git commit -m "perf(ptrace): use PTRACE_GET_SYSCALL_INFO for entry dispatch
+
+handleSeccompStop and handleSyscallStop use buildSyscallContext for
+lighter syscall-number extraction. Simple fd-only handlers (write,
+close, read) use sc.Info.Args directly. Complex handlers (file,
+network, exec, signal) get Regs via lazy loading in dispatchSyscall.
+Falls back to getRegs on kernels without PTRACE_GET_SYSCALL_INFO."
+```
+
+---
+
+### Task 8: Final verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `go test ./... -v`
+Expected: All PASS
+
+- [ ] **Step 2: Cross-compile check**
+
+Run: `GOOS=windows go build ./...`
+Expected: PASS
+
+- [ ] **Step 3: Run benchmark (if Docker available)**
+
+Run: `make bench`
+Expected: Ptrace overhead should be measurably lower than the 621% baseline. Compare results against the table in the spec.
+
+- [ ] **Step 4: Final commit if any fixups needed**
+
+Only if benchmark reveals issues that require fixes.

--- a/docs/superpowers/specs/2026-03-17-ptrace-performance-optimizations-design.md
+++ b/docs/superpowers/specs/2026-03-17-ptrace-performance-optimizations-design.md
@@ -1,0 +1,359 @@
+# Ptrace Performance Optimizations Design
+
+**Date**: 2026-03-17
+**Status**: Draft
+**Goal**: Reduce ptrace mode overhead from ~621% to substantially lower through four complementary optimizations.
+
+## Context
+
+Ptrace mode currently adds ~621% overhead compared to baseline (with seccomp prefilter enabled). Full mode (seccomp user-notify + FUSE + Landlock) adds only ~4%. The gap exists because ptrace requires userspace context switches on every intercepted syscall.
+
+Benchmark data (MaskTracerPid=off, seccomp prefilter on):
+
+| Phase | Baseline | Ptrace | Overhead |
+|---|---|---|---|
+| Process spawn (120) | 3505ms | 17742ms | +406% |
+| File I/O (1000 ops) | 273ms | 841ms | +208% |
+| Git workflow | 56ms | 608ms | +986% |
+| Network (10 curl) | 357ms | 13286ms | +3622% |
+| Deep tree (20x4-lvl) | 626ms | 13251ms | +2017% |
+| Wide tree (10x10-fan) | 329ms | 2047ms | +522% |
+| **Total** | **7509ms** | **54147ms** | **+621%** |
+
+Four optimizations are implemented in priority order, each building on the previous.
+
+## Optimization 1: Config-aware exit stop elimination
+
+### Problem
+
+`needsExitStop()` (`tracer.go:465`) unconditionally returns `true` for `openat`, `openat2`, `connect`, `read`, `pread64`, `execve`, and `execveat`. This causes `allowSyscall()` to use `PtraceSyscall` (generating an exit stop) even when the exit handler would immediately return due to config.
+
+Specifically:
+- `handleOpenatExit` returns immediately when `!t.cfg.MaskTracerPid` (`tracer.go:1006`)
+- `handleConnectExit` only does TLS port tracking when `t.fds != nil` and a connection succeeds
+
+With `MaskTracerPid=off`, every openat/connect generates a wasted exit stop + context switch.
+
+### Solution
+
+Convert `needsExitStop` from a standalone function to a method on `Tracer`:
+
+```go
+func (t *Tracer) needsExitStop(nr int) bool {
+    switch nr {
+    case unix.SYS_READ, unix.SYS_PREAD64:
+        return true // only traced when escalated — always needs exit
+    case unix.SYS_OPENAT, unix.SYS_OPENAT2:
+        return t.cfg.MaskTracerPid // fd tracking for TracerPid masking
+    case unix.SYS_CONNECT:
+        return t.cfg.TraceNetwork && t.fds != nil // TLS port tracking
+    case unix.SYS_EXECVE, unix.SYS_EXECVEAT:
+        return true // exec failure cleanup
+    }
+    return false
+}
+```
+
+### Call site changes
+
+Two locations set `NeedExitStop`:
+- `handleSyscallStop` (`tracer.go:900`): `state.NeedExitStop = needsExitStop(nr)` → `state.NeedExitStop = t.needsExitStop(nr)`
+- `handleSeccompStop` (`tracer.go:956`): same change
+
+No changes needed to `allowSyscall` — it already checks `mustCatchExit(s)` which reads `NeedExitStop`. When `NeedExitStop` is false and no pending fixups exist, `PtraceCont` is used automatically.
+
+### Impact
+
+With `MaskTracerPid=off`: saves 1 context switch per openat and connect syscall. Estimated 15-25% reduction in File I/O overhead, 5-10% in Network overhead.
+
+With `MaskTracerPid=on`: no change — exit stops still fire.
+
+### Risk
+
+Low. The guard conditions exactly match the early-returns already in `handleOpenatExit` and `handleConnectExit`.
+
+## Optimization 2: Config-driven BPF filter construction
+
+### Problem
+
+`narrowTracedSyscallNumbers()` (`syscalls.go:69`) returns a static list of 22+ syscalls. Several are always allowed by handlers and generate wasted entry stops:
+
+- `socket`: always allowed at `handle_network.go:126` ("Only evaluate policy for connect and bind")
+- `listen`: always allowed at `handle_network.go:126`
+- `sendto`: only intercepted for DNS proxy redirect to port 53; all non-53 sendto is allowed
+- `close`: only useful for fd tracker cleanup, which requires MaskTracerPid or TLS SNI
+
+Each of these generates a seccomp stop → ptrace entry → handler immediately calls `allowSyscall`. The context switch is pure waste.
+
+### Solution
+
+Change `narrowTracedSyscallNumbers` to accept `TracerConfig` and build the list dynamically:
+
+```go
+func narrowTracedSyscallNumbers(cfg *TracerConfig) []int {
+    var nums []int
+
+    if cfg.TraceExecve {
+        nums = append(nums, unix.SYS_EXECVE, unix.SYS_EXECVEAT)
+    }
+    if cfg.TraceFile {
+        nums = append(nums,
+            unix.SYS_OPENAT, unix.SYS_OPENAT2, unix.SYS_UNLINKAT,
+            unix.SYS_MKDIRAT, unix.SYS_RENAMEAT2, unix.SYS_LINKAT,
+            unix.SYS_SYMLINKAT, unix.SYS_FCHMODAT, unix.SYS_FCHMODAT2,
+            unix.SYS_FCHOWNAT,
+        )
+        nums = append(nums, legacyFileSyscalls()...)
+    }
+    if cfg.TraceNetwork {
+        nums = append(nums, unix.SYS_CONNECT, unix.SYS_BIND)
+        if cfg.NetworkHandler != nil {
+            nums = append(nums, unix.SYS_SENDTO) // DNS proxy redirect
+        }
+        // socket, listen: removed — always allowed
+    }
+    if cfg.TraceSignal {
+        nums = append(nums,
+            unix.SYS_KILL, unix.SYS_TGKILL, unix.SYS_TKILL,
+            unix.SYS_RT_SIGQUEUEINFO, unix.SYS_RT_TGSIGQUEUEINFO,
+        )
+    }
+    if cfg.MaskTracerPid || (cfg.TraceNetwork && cfg.NetworkHandler != nil) {
+        nums = append(nums, unix.SYS_CLOSE) // fd tracker cleanup
+    }
+
+    return nums
+}
+```
+
+Apply the same pattern to `tracedSyscallNumbers` (the full set including read/write).
+
+### Call site changes
+
+- `buildNarrowPrefilterBPF()` → `buildNarrowPrefilterBPF(cfg *TracerConfig)`, passes config through
+- `buildPrefilterBPF()` → `buildPrefilterBPF(cfg *TracerConfig)`, same
+- `injectSeccompFilter` (`inject_seccomp.go:31`): passes `t.cfg` to filter builder
+- `buildEscalationBPF`: unchanged (takes explicit syscall lists)
+
+### Syscalls removed from default filter
+
+| Syscall | Reason traced | Why safe to remove |
+|---|---|---|
+| `socket` | Network category | Always allowed at `handle_network.go:126` |
+| `listen` | Network category | Always allowed at `handle_network.go:126` |
+| `sendto` | DNS redirect | Only needed when DNS proxy active |
+| `close` | fd tracker | Only needed with MaskTracerPid or TLS SNI |
+
+### Impact
+
+Per `curl` invocation: saves ~15-25 wasted ptrace stops (socket, close, sendto). For 10 curls in the benchmark: ~150-250 fewer context switches. Estimated 10-20% reduction in Network overhead, 5-10% in process tree overhead.
+
+### Risk
+
+Low-medium. The removed syscalls have no policy logic. `close` is the only concern: if fd tracking is off at filter install time but somehow needed later, we'd miss close events. However, fd tracking state is determined at startup from config and doesn't change at runtime. Lazy escalation only adds read/write, not close.
+
+## Optimization 3: BPF-level SECCOMP_RET_ERRNO for static denies
+
+### Problem
+
+When a policy always denies certain syscalls (e.g., all network connections), each denial still requires: seccomp stop → ptrace entry → read args → handler → deny → set errno → exit stop. This is 2 context switches for a decision that could be made entirely in kernel.
+
+### Solution
+
+#### New interface
+
+```go
+type StaticDenyChecker interface {
+    StaticDenySyscalls() []StaticDeny
+}
+
+type StaticDeny struct {
+    Nr    int
+    Errno int
+}
+```
+
+Handlers optionally implement `StaticDenyChecker` to declare syscalls that are always denied regardless of arguments for the lifetime of the session.
+
+#### Extended BPF generation
+
+Change `buildBPFForSyscalls` to support per-syscall return actions:
+
+```go
+type bpfSyscallAction struct {
+    Nr     int
+    Action uint32 // SECCOMP_RET_TRACE or SECCOMP_RET_ERRNO(errno)
+}
+
+func buildBPFForActions(actions []bpfSyscallAction) ([]unix.SockFilter, error)
+```
+
+The BPF program generates different return instructions per syscall:
+
+```
+LOAD nr
+JEQ openat  → RET SECCOMP_RET_TRACE
+JEQ connect → RET SECCOMP_RET_ERRNO|EACCES  (when deny-all)
+...
+RET SECCOMP_RET_ALLOW  (default)
+```
+
+#### Collection at filter install time
+
+```go
+func (t *Tracer) collectStaticDenies() []StaticDeny {
+    var denies []StaticDeny
+
+    // Category enabled but handler nil → deny all
+    if t.cfg.TraceNetwork && t.cfg.NetworkHandler == nil {
+        denies = append(denies,
+            StaticDeny{unix.SYS_CONNECT, int(unix.EACCES)},
+            StaticDeny{unix.SYS_BIND, int(unix.EACCES)},
+        )
+    }
+
+    // Handler-declared denies
+    if checker, ok := t.cfg.NetworkHandler.(StaticDenyChecker); ok {
+        denies = append(denies, checker.StaticDenySyscalls()...)
+    }
+    if checker, ok := t.cfg.FileHandler.(StaticDenyChecker); ok {
+        denies = append(denies, checker.StaticDenySyscalls()...)
+    }
+
+    return denies
+}
+```
+
+#### Merge logic
+
+In `injectSeccompFilter`, after building the narrow syscall list (from Optimization 2), merge with static denies:
+- Syscalls in both the trace list and deny list → use `SECCOMP_RET_ERRNO`
+- Syscalls in the trace list only → use `SECCOMP_RET_TRACE`
+- Syscalls in the deny list but not trace list → add them with `SECCOMP_RET_ERRNO`
+
+### Impact
+
+Policy-dependent. For restrictive deployments (deny-all network, tight file policies): eliminates all ptrace stops for denied operations. For the benchmark (allow-heavy policies): minimal impact.
+
+### Risk
+
+Medium. The `StaticDenyChecker` interface must be conservative. A wrong declaration means silent denial with no ptrace override possible. Mitigations:
+- Interface is opt-in (handlers don't have to implement it)
+- Only for session-lifetime static decisions
+- Log at filter install time which syscalls are BPF-denied
+
+## Optimization 4: PTRACE_GET_SYSCALL_INFO for faster entry handling
+
+### Problem
+
+Every ptrace entry stop does a full `PTRACE_GETREGS` (reads 27 registers, 216 bytes on amd64) even though the entry handler typically only needs the syscall number and 2-3 arguments.
+
+### Solution
+
+#### New entry info retrieval
+
+```go
+type SyscallEntryInfo struct {
+    Nr   int
+    Args [6]uint64
+}
+
+func (t *Tracer) getSyscallEntryInfo(tid int) (*SyscallEntryInfo, error) {
+    // Uses PTRACE_GET_SYSCALL_INFO (ptrace request 0x420e)
+    // Returns ptrace_syscall_info struct with op, nr, args
+    // ~80 bytes vs 216 bytes for full registers
+}
+```
+
+#### Lazy register access via SyscallContext
+
+```go
+type SyscallContext struct {
+    Info    SyscallEntryInfo
+    tid     int
+    tracer  *Tracer
+    regs    Regs
+    loaded  bool
+}
+
+func (sc *SyscallContext) Regs() (Regs, error) {
+    if !sc.loaded {
+        var err error
+        sc.regs, err = sc.tracer.getRegs(sc.tid)
+        if err != nil {
+            return nil, err
+        }
+        sc.loaded = true
+    }
+    return sc.regs, nil
+}
+```
+
+#### Handler refactoring
+
+Handlers receive `*SyscallContext` instead of `Regs`. The allow path reads args from `sc.Info.Args[n]`. The deny/redirect path calls `sc.Regs()` for full register access.
+
+#### Capability detection at startup
+
+```go
+func (t *Tracer) detectCapabilities() {
+    t.hasSyscallInfo = probePtraceSyscallInfo()
+}
+```
+
+Probe at startup, fall back to `getRegs` on older kernels. Linux 5.3+ supports `PTRACE_GET_SYSCALL_INFO`.
+
+### Impact
+
+Saves one full register read per allowed syscall entry. Estimated 5-10% reduction in per-stop latency. The context switch cost still dominates, so overall improvement is modest (~5% total).
+
+### Risk
+
+Low. Full fallback to existing `getRegs` path. `PTRACE_GET_SYSCALL_INFO` is well-supported on Linux 5.3+ (Fargate runs 6.x kernels). The `SyscallContext` refactor changes handler signatures but not logic.
+
+### Dropped: cwd caching
+
+Considered caching `/proc/<tid>/cwd` readlink results per-TGID. Dropped because:
+- Correctness risk: stale cwd after `chdir` without re-tracing chdir
+- Marginal gain: readlink is ~1-2μs, not the bottleneck
+- Would require adding `chdir`/`fchdir` to the BPF filter for invalidation, partially defeating the purpose
+
+## Combined impact estimate
+
+| Optimization | MaskTracerPid=off | MaskTracerPid=on |
+|---|---|---|
+| 1. Config-aware exit stops | 15-25% of File I/O, 5-10% of Network | No change |
+| 2. Smarter BPF filter | 10-20% of Network, 5-10% of trees | Same |
+| 3. BPF-level deny | Policy-dependent | Policy-dependent |
+| 4. PTRACE_GET_SYSCALL_INFO | ~5% overall | ~5% overall |
+
+These are multiplicative — each reduces the number or cost of remaining stops. Conservative estimate: **30-50% total overhead reduction** for MaskTracerPid=off deployments (621% → ~310-430%). More with deny-heavy policies.
+
+## Implementation order
+
+1. **Optimization 1** (config-aware exit stops) — smallest change, immediate impact
+2. **Optimization 2** (smarter BPF filter) — builds on Opt 1, removes more stops
+3. **Optimization 1** (BPF-level deny) — extends BPF generation from Opt 2
+4. **Optimization 4** (PTRACE_GET_SYSCALL_INFO) — independent, can be done in parallel
+
+## Files affected
+
+| File | Optimizations | Changes |
+|---|---|---|
+| `tracer.go` | 1, 4 | `needsExitStop` → method; `SyscallContext` dispatch |
+| `syscalls.go` | 2 | Config-driven filter lists |
+| `seccomp_filter.go` | 2, 3 | Config-aware builder; mixed TRACE/ERRNO BPF |
+| `inject_seccomp.go` | 2, 3 | Pass config to builders; collect static denies |
+| `handle_file.go` | 4 | Accept `SyscallContext` |
+| `handle_network.go` | 4 | Accept `SyscallContext` |
+| `handle_read.go` | 4 | Accept `SyscallContext` |
+| `handle_write.go` | 4 | Accept `SyscallContext` |
+| Handler interfaces | 3, 4 | `StaticDenyChecker`; `SyscallContext` |
+
+## Testing
+
+- Benchmark before/after each optimization with `make bench`
+- Unit tests for BPF filter generation with mixed actions
+- Unit tests for `needsExitStop` with different config combinations
+- Integration tests for static deny (verify EPERM without ptrace stop)
+- Cross-compile check: `GOOS=windows go build ./...`

--- a/docs/superpowers/specs/2026-03-17-ptrace-performance-optimizations-design.md
+++ b/docs/superpowers/specs/2026-03-17-ptrace-performance-optimizations-design.md
@@ -29,10 +29,12 @@ Four optimizations are implemented in priority order, each building on the previ
 `needsExitStop()` (`tracer.go:465`) unconditionally returns `true` for `openat`, `openat2`, `connect`, `read`, `pread64`, `execve`, and `execveat`. This causes `allowSyscall()` to use `PtraceSyscall` (generating an exit stop) even when the exit handler would immediately return due to config.
 
 Specifically:
-- `handleOpenatExit` returns immediately when `!t.cfg.MaskTracerPid` (`tracer.go:1006`)
-- `handleConnectExit` only does TLS port tracking when `t.fds != nil` and a connection succeeds
+- `handleOpenatExit` returns immediately when `!t.cfg.MaskTracerPid` (`tracer.go:1006`). Note: `t.fds` is unconditionally initialized in `Run()` at `tracer.go:1578` so the `t.fds == nil` guard in `handleOpenatExit` is always false during the tracer's lifetime.
+- `handleConnectExit` does TLS fd watching for SNI rewrite after successful connect to TLS ports
 
-With `MaskTracerPid=off`, every openat/connect generates a wasted exit stop + context switch.
+With `MaskTracerPid=off`, every openat generates a wasted exit stop + context switch.
+
+Note: `handleNetwork` already performs inline exit stop skipping for connect to non-TLS ports at `handle_network.go:256-263` (`s.NeedExitStop = false` when `port != 443 && port != 853`). So the connect case in `needsExitStop` provides marginal additional benefit — only covering the initial default before the handler runs. The primary value of this optimization is for **openat**.
 
 ### Solution
 
@@ -46,7 +48,8 @@ func (t *Tracer) needsExitStop(nr int) bool {
     case unix.SYS_OPENAT, unix.SYS_OPENAT2:
         return t.cfg.MaskTracerPid // fd tracking for TracerPid masking
     case unix.SYS_CONNECT:
-        return t.cfg.TraceNetwork && t.fds != nil // TLS port tracking
+        return t.cfg.TraceNetwork // TLS port tracking; inline skip in handleNetwork
+                                  // handles port-level granularity (443/853 only)
     case unix.SYS_EXECVE, unix.SYS_EXECVEAT:
         return true // exec failure cleanup
     }
@@ -64,13 +67,13 @@ No changes needed to `allowSyscall` — it already checks `mustCatchExit(s)` whi
 
 ### Impact
 
-With `MaskTracerPid=off`: saves 1 context switch per openat and connect syscall. Estimated 15-25% reduction in File I/O overhead, 5-10% in Network overhead.
+With `MaskTracerPid=off`: saves 1 context switch per openat syscall. The connect benefit is marginal since the inline skip in `handleNetwork` already handles most cases. Estimated 15-25% reduction in File I/O overhead.
 
-With `MaskTracerPid=on`: no change — exit stops still fire.
+With `MaskTracerPid=on`: no change — exit stops still fire for openat. Connect exit stops are unchanged (already inline-skipped for non-TLS ports).
 
 ### Risk
 
-Low. The guard conditions exactly match the early-returns already in `handleOpenatExit` and `handleConnectExit`.
+Low. The openat guard condition exactly matches the early-return in `handleOpenatExit`. The connect simplification from `t.cfg.TraceNetwork && t.fds != nil` to `t.cfg.TraceNetwork` is safe because `t.fds` is always non-nil.
 
 ## Optimization 2: Config-driven BPF filter construction
 
@@ -126,7 +129,7 @@ func narrowTracedSyscallNumbers(cfg *TracerConfig) []int {
 }
 ```
 
-Apply the same pattern to `tracedSyscallNumbers` (the full set including read/write).
+Apply the same pattern to `tracedSyscallNumbers` (the full set used as fallback when seccomp prefilter is off, i.e., TRACESYSGOOD mode). That function should also be config-driven, adding the same category-based syscall selection plus `SYS_READ`/`SYS_PREAD64`/`SYS_WRITE` unconditionally (since without a prefilter, all traced syscalls need TRACESYSGOOD handling). The escalation BPF lists (`readEscalationSyscalls`, `writeEscalationSyscalls`) remain unchanged — they are explicit static lists used only when stacking additional filters.
 
 ### Call site changes
 
@@ -152,6 +155,8 @@ Per `curl` invocation: saves ~15-25 wasted ptrace stops (socket, close, sendto).
 
 Low-medium. The removed syscalls have no policy logic. `close` is the only concern: if fd tracking is off at filter install time but somehow needed later, we'd miss close events. However, fd tracking state is determined at startup from config and doesn't change at runtime. Lazy escalation only adds read/write, not close.
 
+Known limitation: if the DNS proxy fails to start (`tracer.go:1581`), `t.dnsProxy` will be nil even though `TraceNetwork && NetworkHandler != nil` are set. In this case, `sendto` would be in the BPF filter but the handler would just `allowSyscall` every sendto — wasted stops, not incorrect behavior.
+
 ## Optimization 3: BPF-level SECCOMP_RET_ERRNO for static denies
 
 ### Problem
@@ -173,7 +178,7 @@ type StaticDeny struct {
 }
 ```
 
-Handlers optionally implement `StaticDenyChecker` to declare syscalls that are always denied regardless of arguments for the lifetime of the session.
+Handlers optionally implement `StaticDenyChecker` to declare syscalls that are always denied regardless of arguments for the lifetime of the session. Errno must be > 0; zero or negative values are rejected at filter install time with a warning log.
 
 #### Extended BPF generation
 
@@ -242,6 +247,8 @@ Medium. The `StaticDenyChecker` interface must be conservative. A wrong declarat
 - Only for session-lifetime static decisions
 - Log at filter install time which syscalls are BPF-denied
 
+**Seccomp stacking invariant**: Static deny syscalls must never overlap with escalation syscall lists (`readEscalationSyscalls`, `writeEscalationSyscalls`). In seccomp filter stacking, the kernel returns the action with the lowest value (most restrictive). `SECCOMP_RET_ERRNO` (0x00050000) is lower than `SECCOMP_RET_TRACE` (0x7FF00000), so a BPF-level ERRNO cannot be overridden by a later TRACE escalation filter. Currently the escalation lists only contain `read`/`pread64`/`write`, which would never be statically denied, so there is no conflict. This non-overlap must be maintained as an invariant — validate at filter install time.
+
 ## Optimization 4: PTRACE_GET_SYSCALL_INFO for faster entry handling
 
 ### Problem
@@ -261,7 +268,7 @@ type SyscallEntryInfo struct {
 func (t *Tracer) getSyscallEntryInfo(tid int) (*SyscallEntryInfo, error) {
     // Uses PTRACE_GET_SYSCALL_INFO (ptrace request 0x420e)
     // Returns ptrace_syscall_info struct with op, nr, args
-    // ~80 bytes vs 216 bytes for full registers
+    // ~96 bytes vs 216 bytes for full registers
 }
 ```
 
@@ -293,6 +300,10 @@ func (sc *SyscallContext) Regs() (Regs, error) {
 
 Handlers receive `*SyscallContext` instead of `Regs`. The allow path reads args from `sc.Info.Args[n]`. The deny/redirect path calls `sc.Regs()` for full register access.
 
+**Exit handlers continue using `getRegs`**: `PTRACE_GET_SYSCALL_INFO` at exit time returns `ptrace_syscall_info.exit` (rval + is_error), NOT the entry args. Exit handlers like `handleConnectExit` and `handleOpenatExit` need entry-time arguments (sockaddr pointer, fd number). Two options:
+- (Recommended) Exit handlers call `getRegs()` directly, since registers still contain argument values at exit time. This preserves current behavior with no refactoring.
+- Store `SyscallEntryInfo` in `TraceeState` alongside `LastNr` and carry it to exit handlers. More complex, marginal benefit.
+
 #### Capability detection at startup
 
 ```go
@@ -305,7 +316,7 @@ Probe at startup, fall back to `getRegs` on older kernels. Linux 5.3+ supports `
 
 ### Impact
 
-Saves one full register read per allowed syscall entry. Estimated 5-10% reduction in per-stop latency. The context switch cost still dominates, so overall improvement is modest (~5% total).
+Saves one full register read per allowed syscall entry. Both `PTRACE_GETREGS` and `PTRACE_GET_SYSCALL_INFO` are single ptrace calls; the difference is ~120 bytes less `copy_to_user`. The context switch and ptrace framework overhead dominate. Estimated 1-3% reduction in per-stop latency. Overall improvement is modest (~2-3% total).
 
 ### Risk
 
@@ -322,18 +333,18 @@ Considered caching `/proc/<tid>/cwd` readlink results per-TGID. Dropped because:
 
 | Optimization | MaskTracerPid=off | MaskTracerPid=on |
 |---|---|---|
-| 1. Config-aware exit stops | 15-25% of File I/O, 5-10% of Network | No change |
+| 1. Config-aware exit stops | 15-25% of File I/O | No change (connect inline skip already exists) |
 | 2. Smarter BPF filter | 10-20% of Network, 5-10% of trees | Same |
 | 3. BPF-level deny | Policy-dependent | Policy-dependent |
-| 4. PTRACE_GET_SYSCALL_INFO | ~5% overall | ~5% overall |
+| 4. PTRACE_GET_SYSCALL_INFO | ~2-3% overall | ~2-3% overall |
 
-These are multiplicative — each reduces the number or cost of remaining stops. Conservative estimate: **30-50% total overhead reduction** for MaskTracerPid=off deployments (621% → ~310-430%). More with deny-heavy policies.
+These are multiplicative — each reduces the number or cost of remaining stops. Conservative estimate: **25-40% total overhead reduction** for MaskTracerPid=off deployments (621% → ~370-465%). More with deny-heavy policies.
 
 ## Implementation order
 
 1. **Optimization 1** (config-aware exit stops) — smallest change, immediate impact
 2. **Optimization 2** (smarter BPF filter) — builds on Opt 1, removes more stops
-3. **Optimization 1** (BPF-level deny) — extends BPF generation from Opt 2
+3. **Optimization 3** (BPF-level deny) — extends BPF generation from Opt 2
 4. **Optimization 4** (PTRACE_GET_SYSCALL_INFO) — independent, can be done in parallel
 
 ## Files affected
@@ -355,5 +366,5 @@ These are multiplicative — each reduces the number or cost of remaining stops.
 - Benchmark before/after each optimization with `make bench`
 - Unit tests for BPF filter generation with mixed actions
 - Unit tests for `needsExitStop` with different config combinations
-- Integration tests for static deny (verify EPERM without ptrace stop)
+- Integration tests for static deny (verify configured errno returned without ptrace stop)
 - Cross-compile check: `GOOS=windows go build ./...`

--- a/internal/ptrace/handle_close.go
+++ b/internal/ptrace/handle_close.go
@@ -5,8 +5,8 @@ package ptrace
 import "context"
 
 // handleClose intercepts SYS_CLOSE to clean up fd tracking state.
-func (t *Tracer) handleClose(_ context.Context, tid int, regs Regs) {
-	fd := int(int32(regs.Arg(0)))
+func (t *Tracer) handleClose(_ context.Context, tid int, sc *SyscallContext) {
+	fd := int(int32(sc.Info.Args[0]))
 
 	if t.fds != nil {
 		t.mu.Lock()

--- a/internal/ptrace/handle_read.go
+++ b/internal/ptrace/handle_read.go
@@ -103,9 +103,9 @@ func (t *Tracer) handleReadExit(tid int, regs Regs) {
 // handleReadEntry is called at syscall-entry for SYS_READ/SYS_PREAD64.
 // If the fd is not a tracked /proc/*/status fd, it clears NeedExitStop
 // so the tracee resumes with PtraceCont (skipping the exit stop).
-func (t *Tracer) handleReadEntry(tid int, regs Regs) {
+func (t *Tracer) handleReadEntry(tid int, sc *SyscallContext) {
 	if t.fds != nil && t.cfg.MaskTracerPid {
-		fd := int(int32(regs.Arg(0)))
+		fd := int(int32(sc.Info.Args[0]))
 		t.mu.Lock()
 		state := t.tracees[tid]
 		var tgid int

--- a/internal/ptrace/handle_write.go
+++ b/internal/ptrace/handle_write.go
@@ -8,13 +8,13 @@ import (
 )
 
 // handleWrite intercepts write for SNI rewrite on TLS-watched fds.
-func (t *Tracer) handleWrite(ctx context.Context, tid int, regs Regs) {
+func (t *Tracer) handleWrite(ctx context.Context, tid int, sc *SyscallContext) {
 	if t.fds == nil {
 		t.allowSyscall(tid)
 		return
 	}
 
-	fd := int(int32(regs.Arg(0)))
+	fd := int(int32(sc.Info.Args[0]))
 
 	t.mu.Lock()
 	state := t.tracees[tid]
@@ -34,6 +34,13 @@ func (t *Tracer) handleWrite(ctx context.Context, tid int, regs Regs) {
 	}
 
 	// Read the write buffer to check for ClientHello
+	regs, err := sc.Regs()
+	if err != nil {
+		slog.Warn("handleWrite: cannot load registers", "tid", tid, "error", err)
+		t.fds.unwatchTLS(tgid, fd)
+		t.allowSyscall(tid)
+		return
+	}
 	bufPtr := regs.Arg(1)
 	bufLen := regs.Arg(2)
 

--- a/internal/ptrace/inject_seccomp.go
+++ b/internal/ptrace/inject_seccomp.go
@@ -29,8 +29,36 @@ const sockFilterSize = 8
 // The tracee must be in a ptrace-stop (e.g., after PTRACE_INTERRUPT).
 // Returns nil on success. Failure is non-fatal — caller falls back to TRACESYSGOOD.
 func (t *Tracer) injectSeccompFilter(tid int) error {
-	// Build the BPF program.
-	filters, bpfErr := buildNarrowPrefilterBPF(&t.cfg)
+	denies := t.collectStaticDenies()
+	narrowNums := narrowTracedSyscallNumbers(&t.cfg)
+
+	var filters []unix.SockFilter
+	var bpfErr error
+
+	if len(denies) > 0 {
+		denySet := make(map[int]uint32)
+		for _, d := range denies {
+			denySet[d.Nr] = seccompRetErrno(d.Errno)
+		}
+
+		var actions []bpfSyscallAction
+		for _, nr := range narrowNums {
+			if errnoAction, ok := denySet[nr]; ok {
+				actions = append(actions, bpfSyscallAction{Nr: nr, Action: errnoAction})
+				delete(denySet, nr)
+			} else {
+				actions = append(actions, bpfSyscallAction{Nr: nr, Action: seccompRetTrace})
+			}
+		}
+		for nr, action := range denySet {
+			actions = append(actions, bpfSyscallAction{Nr: nr, Action: action})
+		}
+
+		filters, bpfErr = buildBPFForActions(actions)
+	} else {
+		filters, bpfErr = buildNarrowPrefilterBPF(&t.cfg)
+	}
+
 	if bpfErr != nil {
 		return bpfErr
 	}
@@ -120,6 +148,9 @@ func (t *Tracer) injectSeccompFilter(tid int) error {
 	}
 
 	slog.Info("seccomp prefilter installed", "tid", tid, "filters", len(filters))
+	for _, d := range denies {
+		slog.Info("seccomp static deny active", "tid", tid, "nr", d.Nr, "errno", d.Errno)
+	}
 	return nil
 }
 

--- a/internal/ptrace/inject_seccomp.go
+++ b/internal/ptrace/inject_seccomp.go
@@ -30,7 +30,7 @@ const sockFilterSize = 8
 // Returns nil on success. Failure is non-fatal — caller falls back to TRACESYSGOOD.
 func (t *Tracer) injectSeccompFilter(tid int) error {
 	// Build the BPF program.
-	filters, bpfErr := buildNarrowPrefilterBPF()
+	filters, bpfErr := buildNarrowPrefilterBPF(&t.cfg)
 	if bpfErr != nil {
 		return bpfErr
 	}

--- a/internal/ptrace/seccomp_filter.go
+++ b/internal/ptrace/seccomp_filter.go
@@ -22,6 +22,8 @@ const (
 	seccompRetAllow = 0x7FFF0000
 	seccompRetTrace = 0x7FF00000
 
+	seccompRetErrnoBase = 0x00050000
+
 	// seccomp_data offsets.
 	offsetNr   = 0 // offsetof(struct seccomp_data, nr)
 	offsetArch = 4 // offsetof(struct seccomp_data, arch)
@@ -65,6 +67,74 @@ func buildBPFForSyscalls(syscalls []int) ([]unix.SockFilter, error) {
 
 	prog = append(prog, unix.SockFilter{Code: bpfRET | bpfK, K: seccompRetAllow})
 	prog = append(prog, unix.SockFilter{Code: bpfRET | bpfK, K: seccompRetTrace})
+
+	return prog, nil
+}
+
+// seccompRetErrno returns the SECCOMP_RET_ERRNO value for the given errno.
+func seccompRetErrno(errno int) uint32 {
+	return seccompRetErrnoBase | uint32(errno&0xFFFF)
+}
+
+// bpfSyscallAction pairs a syscall number with its BPF return action.
+type bpfSyscallAction struct {
+	Nr     int
+	Action uint32 // seccompRetTrace or seccompRetErrno(errno)
+}
+
+// buildBPFForActions generates a seccomp-BPF filter with per-syscall return
+// actions. Different syscalls can have different return values (TRACE vs ERRNO).
+func buildBPFForActions(actions []bpfSyscallAction) ([]unix.SockFilter, error) {
+	var auditArch uint32
+	switch runtime.GOARCH {
+	case "amd64":
+		auditArch = auditArchX86_64
+	case "arm64":
+		auditArch = auditArchAarch64
+	default:
+		return nil, fmt.Errorf("seccomp prefilter: unsupported architecture %s", runtime.GOARCH)
+	}
+
+	// Collect unique return actions (deduplicate).
+	retActionSet := make(map[uint32]int) // action → index in retActions slice
+	var retActions []uint32
+	for _, a := range actions {
+		if _, ok := retActionSet[a.Action]; !ok {
+			retActionSet[a.Action] = len(retActions)
+			retActions = append(retActions, a.Action)
+		}
+	}
+
+	n := len(actions)
+	nRet := len(retActions)
+	prog := make([]unix.SockFilter, 0, 4+n+1+nRet)
+
+	// Header: load arch, check arch, load nr
+	prog = append(prog, unix.SockFilter{Code: bpfLD | bpfW | bpfABS, K: offsetArch})
+	prog = append(prog, unix.SockFilter{Code: bpfJMP | bpfJEQ | bpfK, Jt: 1, Jf: 0, K: auditArch})
+	prog = append(prog, unix.SockFilter{Code: bpfRET | bpfK, K: seccompRetTrace})
+	prog = append(prog, unix.SockFilter{Code: bpfLD | bpfW | bpfABS, K: offsetNr})
+
+	// Comparisons: each JEQ jumps to its action's return instruction.
+	// Layout after comparisons: [ALLOW ret] [action0 ret] [action1 ret] ...
+	for i, a := range actions {
+		remaining := n - i - 1
+		jumpTarget := uint8(remaining + 1 + retActionSet[a.Action])
+		prog = append(prog, unix.SockFilter{
+			Code: bpfJMP | bpfJEQ | bpfK,
+			Jt:   jumpTarget,
+			Jf:   0,
+			K:    uint32(a.Nr),
+		})
+	}
+
+	// Default: ALLOW
+	prog = append(prog, unix.SockFilter{Code: bpfRET | bpfK, K: seccompRetAllow})
+
+	// Per-action return instructions
+	for _, action := range retActions {
+		prog = append(prog, unix.SockFilter{Code: bpfRET | bpfK, K: action})
+	}
 
 	return prog, nil
 }

--- a/internal/ptrace/seccomp_filter.go
+++ b/internal/ptrace/seccomp_filter.go
@@ -70,15 +70,15 @@ func buildBPFForSyscalls(syscalls []int) ([]unix.SockFilter, error) {
 }
 
 // buildPrefilterBPF generates the full prefilter (all traced syscalls).
-func buildPrefilterBPF() ([]unix.SockFilter, error) {
-	return buildBPFForSyscalls(tracedSyscallNumbers())
+func buildPrefilterBPF(cfg *TracerConfig) ([]unix.SockFilter, error) {
+	return buildBPFForSyscalls(tracedSyscallNumbers(cfg))
 }
 
 // buildNarrowPrefilterBPF generates a BPF filter that excludes read/write
 // syscalls from the traced set. Used as the initial filter; read/write are
 // lazily escalated per-TGID when needed.
-func buildNarrowPrefilterBPF() ([]unix.SockFilter, error) {
-	return buildBPFForSyscalls(narrowTracedSyscallNumbers())
+func buildNarrowPrefilterBPF(cfg *TracerConfig) ([]unix.SockFilter, error) {
+	return buildBPFForSyscalls(narrowTracedSyscallNumbers(cfg))
 }
 
 // buildEscalationBPF generates a minimal BPF filter that traces only the

--- a/internal/ptrace/seccomp_filter_test.go
+++ b/internal/ptrace/seccomp_filter_test.go
@@ -2,7 +2,11 @@
 
 package ptrace
 
-import "testing"
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
 
 func TestPrefilterBPFNonEmpty(t *testing.T) {
 	prog, err := buildPrefilterBPF(allFeaturesConfig())
@@ -75,5 +79,76 @@ func TestPrefilterBPFArchCheck(t *testing.T) {
 	}
 	if prog[1].K != auditArchX86_64 && prog[1].K != auditArchAarch64 {
 		t.Errorf("arch check compares unexpected value 0x%X", prog[1].K)
+	}
+}
+
+func TestBuildBPFForActions(t *testing.T) {
+	actions := []bpfSyscallAction{
+		{Nr: unix.SYS_OPENAT, Action: seccompRetTrace},
+		{Nr: unix.SYS_CONNECT, Action: seccompRetErrno(int(unix.EACCES))},
+	}
+	prog, err := buildBPFForActions(actions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	jeqValues := make(map[uint32]bool)
+	for _, inst := range prog {
+		if inst.Code == bpfJMP|bpfJEQ|bpfK {
+			if inst.K == auditArchX86_64 || inst.K == auditArchAarch64 {
+				continue
+			}
+			jeqValues[inst.K] = true
+		}
+	}
+	if !jeqValues[uint32(unix.SYS_OPENAT)] {
+		t.Error("SYS_OPENAT missing from filter")
+	}
+	if !jeqValues[uint32(unix.SYS_CONNECT)] {
+		t.Error("SYS_CONNECT missing from filter")
+	}
+
+	retInsts := 0
+	for _, inst := range prog {
+		if inst.Code == bpfRET|bpfK {
+			retInsts++
+		}
+	}
+	// Should have: unknown-arch TRACE, default ALLOW, TRACE, ERRNO = 4 ret instructions
+	if retInsts < 3 {
+		t.Errorf("expected at least 3 return instructions, got %d", retInsts)
+	}
+}
+
+func TestBuildBPFForActionsErrnoValue(t *testing.T) {
+	errno := int(unix.EPERM)
+	actions := []bpfSyscallAction{
+		{Nr: unix.SYS_CONNECT, Action: seccompRetErrno(errno)},
+	}
+	prog, err := buildBPFForActions(actions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, inst := range prog {
+		if inst.Code == bpfRET|bpfK && inst.K != seccompRetAllow && inst.K != seccompRetTrace {
+			want := uint32(0x00050000 | errno)
+			if inst.K != want {
+				t.Errorf("ERRNO return = 0x%x, want 0x%x", inst.K, want)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("no ERRNO return instruction found")
+	}
+}
+
+func TestSeccompRetErrnoEncoding(t *testing.T) {
+	got := seccompRetErrno(int(unix.EACCES))
+	want := uint32(0x00050000 | unix.EACCES)
+	if got != want {
+		t.Errorf("seccompRetErrno(EACCES) = 0x%x, want 0x%x", got, want)
 	}
 }

--- a/internal/ptrace/seccomp_filter_test.go
+++ b/internal/ptrace/seccomp_filter_test.go
@@ -5,7 +5,7 @@ package ptrace
 import "testing"
 
 func TestPrefilterBPFNonEmpty(t *testing.T) {
-	prog, err := buildPrefilterBPF()
+	prog, err := buildPrefilterBPF(allFeaturesConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -15,8 +15,9 @@ func TestPrefilterBPFNonEmpty(t *testing.T) {
 }
 
 func TestPrefilterBPFInstructionCount(t *testing.T) {
-	syscalls := tracedSyscallNumbers()
-	prog, err := buildPrefilterBPF()
+	cfg := allFeaturesConfig()
+	syscalls := tracedSyscallNumbers(cfg)
+	prog, err := buildPrefilterBPF(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,8 +31,9 @@ func TestPrefilterBPFInstructionCount(t *testing.T) {
 }
 
 func TestPrefilterBPFContainsAllSyscalls(t *testing.T) {
-	syscalls := tracedSyscallNumbers()
-	prog, err := buildPrefilterBPF()
+	cfg := allFeaturesConfig()
+	syscalls := tracedSyscallNumbers(cfg)
+	prog, err := buildPrefilterBPF(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -56,7 +58,7 @@ func TestPrefilterBPFContainsAllSyscalls(t *testing.T) {
 }
 
 func TestPrefilterBPFArchCheck(t *testing.T) {
-	prog, err := buildPrefilterBPF()
+	prog, err := buildPrefilterBPF(allFeaturesConfig())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/ptrace/static_deny.go
+++ b/internal/ptrace/static_deny.go
@@ -1,0 +1,79 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"log/slog"
+
+	"golang.org/x/sys/unix"
+)
+
+// StaticDenyChecker is an optional interface that handlers implement to declare
+// syscalls that are always denied regardless of arguments for the session lifetime.
+// This enables BPF-level enforcement (SECCOMP_RET_ERRNO) without ptrace stops.
+type StaticDenyChecker interface {
+	StaticDenySyscalls() []StaticDeny
+}
+
+// StaticDeny represents a syscall that should be denied at the BPF level.
+type StaticDeny struct {
+	Nr    int
+	Errno int // must be > 0
+}
+
+// collectStaticDenies gathers all static deny declarations from handlers and config.
+func (t *Tracer) collectStaticDenies() []StaticDeny {
+	var denies []StaticDeny
+
+	// Category enabled but handler nil → deny all relevant syscalls
+	if t.cfg.TraceNetwork && t.cfg.NetworkHandler == nil {
+		denies = append(denies,
+			StaticDeny{Nr: unix.SYS_CONNECT, Errno: int(unix.EACCES)},
+			StaticDeny{Nr: unix.SYS_BIND, Errno: int(unix.EACCES)},
+		)
+	}
+
+	// Handler-declared denies
+	if checker, ok := t.cfg.NetworkHandler.(StaticDenyChecker); ok {
+		denies = append(denies, checker.StaticDenySyscalls()...)
+	}
+	if checker, ok := t.cfg.FileHandler.(StaticDenyChecker); ok {
+		denies = append(denies, checker.StaticDenySyscalls()...)
+	}
+	if checker, ok := t.cfg.ExecHandler.(StaticDenyChecker); ok {
+		denies = append(denies, checker.StaticDenySyscalls()...)
+	}
+	if checker, ok := t.cfg.SignalHandler.(StaticDenyChecker); ok {
+		denies = append(denies, checker.StaticDenySyscalls()...)
+	}
+
+	return validateStaticDenies(denies)
+}
+
+// escalationSyscalls is the set of syscalls used by lazy BPF escalation.
+// Static denies must not overlap with these (seccomp stacking: lowest-value action wins,
+// SECCOMP_RET_ERRNO < SECCOMP_RET_TRACE, so ERRNO cannot be overridden by later TRACE).
+var escalationSyscalls = map[int]bool{
+	unix.SYS_READ:    true,
+	unix.SYS_PREAD64: true,
+	unix.SYS_WRITE:   true,
+}
+
+// validateStaticDenies filters out invalid entries and logs warnings.
+func validateStaticDenies(denies []StaticDeny) []StaticDeny {
+	valid := make([]StaticDeny, 0, len(denies))
+	for _, d := range denies {
+		if d.Errno <= 0 {
+			slog.Warn("static deny: rejecting entry with invalid errno",
+				"nr", d.Nr, "errno", d.Errno)
+			continue
+		}
+		if escalationSyscalls[d.Nr] {
+			slog.Warn("static deny: rejecting entry that overlaps escalation syscalls",
+				"nr", d.Nr)
+			continue
+		}
+		valid = append(valid, d)
+	}
+	return valid
+}

--- a/internal/ptrace/static_deny_test.go
+++ b/internal/ptrace/static_deny_test.go
@@ -1,0 +1,79 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"context"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+type denyAllNetHandler struct{}
+
+func (denyAllNetHandler) HandleNetwork(_ context.Context, _ NetworkContext) NetworkResult {
+	return NetworkResult{Allow: false}
+}
+
+func (denyAllNetHandler) StaticDenySyscalls() []StaticDeny {
+	return []StaticDeny{
+		{Nr: unix.SYS_CONNECT, Errno: int(unix.EACCES)},
+		{Nr: unix.SYS_BIND, Errno: int(unix.EACCES)},
+	}
+}
+
+type allowAllNetHandler struct{}
+
+func (allowAllNetHandler) HandleNetwork(_ context.Context, _ NetworkContext) NetworkResult {
+	return NetworkResult{Allow: true}
+}
+
+func TestCollectStaticDeniesNilHandler(t *testing.T) {
+	tr := &Tracer{cfg: TracerConfig{TraceNetwork: true, NetworkHandler: nil}}
+	denies := tr.collectStaticDenies()
+	if len(denies) != 2 {
+		t.Fatalf("expected 2 denies for nil handler, got %d", len(denies))
+	}
+	if denies[0].Nr != unix.SYS_CONNECT || denies[1].Nr != unix.SYS_BIND {
+		t.Error("expected connect and bind denies")
+	}
+}
+
+func TestCollectStaticDeniesWithChecker(t *testing.T) {
+	tr := &Tracer{cfg: TracerConfig{TraceNetwork: true, NetworkHandler: denyAllNetHandler{}}}
+	denies := tr.collectStaticDenies()
+	if len(denies) != 2 {
+		t.Fatalf("expected 2 denies from checker, got %d", len(denies))
+	}
+}
+
+func TestCollectStaticDeniesNoChecker(t *testing.T) {
+	tr := &Tracer{cfg: TracerConfig{TraceNetwork: true, NetworkHandler: allowAllNetHandler{}}}
+	denies := tr.collectStaticDenies()
+	if len(denies) != 0 {
+		t.Fatalf("expected 0 denies for non-checker handler, got %d", len(denies))
+	}
+}
+
+func TestValidateStaticDeniesRejectsZeroErrno(t *testing.T) {
+	denies := validateStaticDenies([]StaticDeny{
+		{Nr: unix.SYS_CONNECT, Errno: int(unix.EACCES)},
+		{Nr: unix.SYS_BIND, Errno: 0},
+	})
+	if len(denies) != 1 {
+		t.Fatalf("expected 1 valid deny after filtering, got %d", len(denies))
+	}
+}
+
+func TestValidateStaticDeniesRejectsEscalationOverlap(t *testing.T) {
+	denies := validateStaticDenies([]StaticDeny{
+		{Nr: unix.SYS_READ, Errno: int(unix.EACCES)},
+		{Nr: unix.SYS_CONNECT, Errno: int(unix.EACCES)},
+	})
+	if len(denies) != 1 {
+		t.Fatalf("expected 1 valid deny after filtering overlap, got %d", len(denies))
+	}
+	if denies[0].Nr != unix.SYS_CONNECT {
+		t.Error("expected connect to survive, read to be filtered")
+	}
+}

--- a/internal/ptrace/syscall_context.go
+++ b/internal/ptrace/syscall_context.go
@@ -1,0 +1,124 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// ptraceGetSyscallInfo is the ptrace request for PTRACE_GET_SYSCALL_INFO (Linux 5.3+).
+const ptraceGetSyscallInfo = 0x420e
+
+// SyscallEntryInfo holds syscall number and arguments extracted at entry time.
+type SyscallEntryInfo struct {
+	Nr   int
+	Args [6]uint64
+}
+
+// SyscallContext wraps entry info with lazy full-register access.
+// Handlers use Info.Args for the fast allow path and call Regs() only
+// when they need to modify registers (deny/redirect).
+type SyscallContext struct {
+	Info   SyscallEntryInfo
+	tid    int
+	tracer *Tracer
+	regs   Regs
+	loaded bool
+}
+
+// Regs lazily loads the full register set. Cached after first call.
+func (sc *SyscallContext) Regs() (Regs, error) {
+	if !sc.loaded {
+		var err error
+		sc.regs, err = sc.tracer.getRegs(sc.tid)
+		if err != nil {
+			return nil, err
+		}
+		sc.loaded = true
+	}
+	return sc.regs, nil
+}
+
+// ptraceSyscallInfo mirrors the entry variant of struct ptrace_syscall_info (Linux 5.3+).
+// The kernel struct is a union; we only use the entry fields (op==1).
+// We request ptraceSyscallInfoSize bytes; the kernel writes min(requested, actual).
+type ptraceSyscallInfo struct {
+	Op                 uint8
+	_                  [3]byte // pad
+	Arch               uint32
+	InstructionPointer uint64
+	StackPointer       uint64
+	// Union: entry variant fields follow
+	EntryNr   uint64
+	EntryArgs [6]uint64
+}
+
+const ptraceSyscallInfoSize = int(unsafe.Sizeof(ptraceSyscallInfo{}))
+
+// getSyscallEntryInfo retrieves syscall entry info via PTRACE_GET_SYSCALL_INFO.
+func (t *Tracer) getSyscallEntryInfo(tid int) (*SyscallEntryInfo, error) {
+	var info ptraceSyscallInfo
+	_, _, errno := unix.Syscall6(
+		unix.SYS_PTRACE,
+		uintptr(ptraceGetSyscallInfo),
+		uintptr(tid),
+		uintptr(ptraceSyscallInfoSize),
+		uintptr(unsafe.Pointer(&info)),
+		0, 0,
+	)
+	if errno != 0 {
+		return nil, fmt.Errorf("PTRACE_GET_SYSCALL_INFO: %w", errno)
+	}
+	if info.Op != 1 {
+		return nil, fmt.Errorf("PTRACE_GET_SYSCALL_INFO: unexpected op %d (want entry=1)", info.Op)
+	}
+	return &SyscallEntryInfo{
+		Nr:   int(info.EntryNr),
+		Args: info.EntryArgs,
+	}, nil
+}
+
+// buildSyscallContext constructs a SyscallContext for a stopped tracee.
+// Uses PTRACE_GET_SYSCALL_INFO when available, falls back to full getRegs.
+func (t *Tracer) buildSyscallContext(tid int) (*SyscallContext, error) {
+	sc := &SyscallContext{tid: tid, tracer: t}
+
+	if t.hasSyscallInfo {
+		info, err := t.getSyscallEntryInfo(tid)
+		if err == nil {
+			sc.Info = *info
+			return sc, nil
+		}
+		// Fallback to full register read
+	}
+
+	regs, err := t.getRegs(tid)
+	if err != nil {
+		return nil, err
+	}
+	sc.Info = SyscallEntryInfo{Nr: regs.SyscallNr()}
+	for i := 0; i < 6; i++ {
+		sc.Info.Args[i] = regs.Arg(i)
+	}
+	sc.regs = regs
+	sc.loaded = true
+	return sc, nil
+}
+
+// probePtraceSyscallInfo returns true if PTRACE_GET_SYSCALL_INFO is supported.
+// Probes with pid=0 (invalid): supported kernels return ESRCH, unsupported return EIO/EINVAL.
+func probePtraceSyscallInfo() bool {
+	var info ptraceSyscallInfo
+	_, _, errno := unix.Syscall6(
+		unix.SYS_PTRACE,
+		uintptr(ptraceGetSyscallInfo),
+		0,
+		uintptr(ptraceSyscallInfoSize),
+		uintptr(unsafe.Pointer(&info)),
+		0, 0,
+	)
+	return errno == unix.ESRCH
+}

--- a/internal/ptrace/syscall_context_test.go
+++ b/internal/ptrace/syscall_context_test.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestSyscallContextLazyRegs(t *testing.T) {
+	sc := &SyscallContext{
+		Info: SyscallEntryInfo{
+			Nr:   unix.SYS_OPENAT,
+			Args: [6]uint64{0xFFFFFF9C, 0x7FFF1234, 0, 0, 0, 0},
+		},
+	}
+	if sc.loaded {
+		t.Error("regs should not be loaded initially")
+	}
+	if sc.Info.Nr != unix.SYS_OPENAT {
+		t.Errorf("Nr = %d, want SYS_OPENAT", sc.Info.Nr)
+	}
+	if sc.Info.Args[0] != 0xFFFFFF9C {
+		t.Errorf("Args[0] = 0x%x, want 0xFFFFFF9C", sc.Info.Args[0])
+	}
+}

--- a/internal/ptrace/syscalls.go
+++ b/internal/ptrace/syscalls.go
@@ -48,36 +48,46 @@ func isSignalSyscall(nr int) bool {
 	return false
 }
 
-func tracedSyscallNumbers() []int {
-	nums := []int{
-		unix.SYS_EXECVE, unix.SYS_EXECVEAT,
-		unix.SYS_OPENAT, unix.SYS_OPENAT2, unix.SYS_UNLINKAT, unix.SYS_MKDIRAT,
-		unix.SYS_RENAMEAT2, unix.SYS_LINKAT, unix.SYS_SYMLINKAT,
-		unix.SYS_FCHMODAT, unix.SYS_FCHMODAT2, unix.SYS_FCHOWNAT,
-		unix.SYS_CONNECT, unix.SYS_SOCKET, unix.SYS_BIND,
-		unix.SYS_SENDTO, unix.SYS_LISTEN,
-		unix.SYS_KILL, unix.SYS_TGKILL, unix.SYS_TKILL,
-		unix.SYS_RT_SIGQUEUEINFO, unix.SYS_RT_TGSIGQUEUEINFO,
-		unix.SYS_WRITE, unix.SYS_READ, unix.SYS_PREAD64, unix.SYS_CLOSE,
-	}
-	nums = append(nums, legacyFileSyscalls()...)
+func tracedSyscallNumbers(cfg *TracerConfig) []int {
+	nums := narrowTracedSyscallNumbers(cfg)
+	// Full set includes read/write for TRACESYSGOOD fallback mode
+	nums = append(nums, unix.SYS_READ, unix.SYS_PREAD64, unix.SYS_WRITE)
 	return nums
 }
 
 // narrowTracedSyscallNumbers returns the syscalls for the initial narrow
 // BPF filter, excluding read/pread64/write which are lazily escalated.
-func narrowTracedSyscallNumbers() []int {
-	nums := []int{
-		unix.SYS_EXECVE, unix.SYS_EXECVEAT,
-		unix.SYS_OPENAT, unix.SYS_OPENAT2, unix.SYS_UNLINKAT, unix.SYS_MKDIRAT,
-		unix.SYS_RENAMEAT2, unix.SYS_LINKAT, unix.SYS_SYMLINKAT,
-		unix.SYS_FCHMODAT, unix.SYS_FCHMODAT2, unix.SYS_FCHOWNAT,
-		unix.SYS_CONNECT, unix.SYS_SOCKET, unix.SYS_BIND,
-		unix.SYS_SENDTO, unix.SYS_LISTEN,
-		unix.SYS_KILL, unix.SYS_TGKILL, unix.SYS_TKILL,
-		unix.SYS_RT_SIGQUEUEINFO, unix.SYS_RT_TGSIGQUEUEINFO,
-		unix.SYS_CLOSE,
+// The set is driven by cfg to avoid tracing syscalls for disabled features.
+func narrowTracedSyscallNumbers(cfg *TracerConfig) []int {
+	var nums []int
+
+	if cfg.TraceExecve {
+		nums = append(nums, unix.SYS_EXECVE, unix.SYS_EXECVEAT)
 	}
-	nums = append(nums, legacyFileSyscalls()...)
+	if cfg.TraceFile {
+		nums = append(nums,
+			unix.SYS_OPENAT, unix.SYS_OPENAT2, unix.SYS_UNLINKAT, unix.SYS_MKDIRAT,
+			unix.SYS_RENAMEAT2, unix.SYS_LINKAT, unix.SYS_SYMLINKAT,
+			unix.SYS_FCHMODAT, unix.SYS_FCHMODAT2, unix.SYS_FCHOWNAT,
+		)
+		nums = append(nums, legacyFileSyscalls()...)
+	}
+	if cfg.TraceNetwork {
+		nums = append(nums, unix.SYS_CONNECT, unix.SYS_BIND)
+		if cfg.NetworkHandler != nil {
+			nums = append(nums, unix.SYS_SENDTO)
+		}
+		// socket, listen: removed — always allowed by handleNetwork
+	}
+	if cfg.TraceSignal {
+		nums = append(nums,
+			unix.SYS_KILL, unix.SYS_TGKILL, unix.SYS_TKILL,
+			unix.SYS_RT_SIGQUEUEINFO, unix.SYS_RT_TGSIGQUEUEINFO,
+		)
+	}
+	if cfg.MaskTracerPid || (cfg.TraceNetwork && cfg.NetworkHandler != nil) {
+		nums = append(nums, unix.SYS_CLOSE)
+	}
+
 	return nums
 }

--- a/internal/ptrace/syscalls_test.go
+++ b/internal/ptrace/syscalls_test.go
@@ -3,10 +3,31 @@
 package ptrace
 
 import (
+	"context"
 	"testing"
 
 	"golang.org/x/sys/unix"
 )
+
+// mockNetworkHandler is a minimal NetworkHandler implementation for testing.
+type mockNetworkHandler struct{}
+
+func (m *mockNetworkHandler) HandleNetwork(_ context.Context, _ NetworkContext) NetworkResult {
+	return NetworkResult{Allow: true}
+}
+
+// allFeaturesConfig returns a TracerConfig with every feature enabled and a
+// NetworkHandler set, suitable for testing that all syscalls appear.
+func allFeaturesConfig() *TracerConfig {
+	return &TracerConfig{
+		TraceExecve:    true,
+		TraceFile:      true,
+		TraceNetwork:   true,
+		TraceSignal:    true,
+		MaskTracerPid:  true,
+		NetworkHandler: &mockNetworkHandler{},
+	}
+}
 
 func TestIsExecveSyscall(t *testing.T) {
 	if !isExecveSyscall(unix.SYS_EXECVE) {
@@ -57,7 +78,8 @@ func TestIsSignalSyscall(t *testing.T) {
 }
 
 func TestTracedSyscallNumbers(t *testing.T) {
-	nums := tracedSyscallNumbers()
+	cfg := allFeaturesConfig()
+	nums := tracedSyscallNumbers(cfg)
 	if len(nums) < 10 {
 		t.Errorf("expected at least 10 traced syscalls, got %d", len(nums))
 	}
@@ -71,4 +93,144 @@ func TestTracedSyscallNumbers(t *testing.T) {
 	if !found {
 		t.Error("SYS_EXECVE missing from traced syscalls")
 	}
+	// read/write must be present in the full set
+	contains := func(nr int) bool {
+		for _, n := range nums {
+			if n == nr {
+				return true
+			}
+		}
+		return false
+	}
+	for _, nr := range []int{unix.SYS_READ, unix.SYS_PREAD64, unix.SYS_WRITE} {
+		if !contains(nr) {
+			t.Errorf("syscall %d missing from full traced set", nr)
+		}
+	}
+}
+
+func TestNarrowTracedSyscallNumbers_AllFeatures(t *testing.T) {
+	cfg := allFeaturesConfig()
+	nums := narrowTracedSyscallNumbers(cfg)
+
+	contains := func(nr int) bool {
+		for _, n := range nums {
+			if n == nr {
+				return true
+			}
+		}
+		return false
+	}
+
+	// execve group
+	if !contains(unix.SYS_EXECVE) {
+		t.Error("SYS_EXECVE missing with TraceExecve=true")
+	}
+	// file group
+	if !contains(unix.SYS_OPENAT) {
+		t.Error("SYS_OPENAT missing with TraceFile=true")
+	}
+	// network group
+	if !contains(unix.SYS_CONNECT) {
+		t.Error("SYS_CONNECT missing with TraceNetwork=true")
+	}
+	if !contains(unix.SYS_BIND) {
+		t.Error("SYS_BIND missing with TraceNetwork=true")
+	}
+	if !contains(unix.SYS_SENDTO) {
+		t.Error("SYS_SENDTO missing with NetworkHandler set")
+	}
+	// signal group
+	if !contains(unix.SYS_KILL) {
+		t.Error("SYS_KILL missing with TraceSignal=true")
+	}
+	// close (MaskTracerPid=true)
+	if !contains(unix.SYS_CLOSE) {
+		t.Error("SYS_CLOSE missing with MaskTracerPid=true")
+	}
+	// read/write must NOT be in narrow set
+	for _, nr := range []int{unix.SYS_READ, unix.SYS_PREAD64, unix.SYS_WRITE} {
+		if contains(nr) {
+			t.Errorf("syscall %d should not be in narrow set", nr)
+		}
+	}
+	// socket and listen removed from narrow set
+	if contains(unix.SYS_SOCKET) {
+		t.Error("SYS_SOCKET must not appear in narrow set (always allowed by handleNetwork)")
+	}
+	if contains(unix.SYS_LISTEN) {
+		t.Error("SYS_LISTEN must not appear in narrow set (always allowed by handleNetwork)")
+	}
+}
+
+func TestNarrowTracedSyscallNumbers_NoFeatures(t *testing.T) {
+	cfg := &TracerConfig{}
+	nums := narrowTracedSyscallNumbers(cfg)
+	if len(nums) != 0 {
+		t.Errorf("expected empty list with no features enabled, got %d syscalls", len(nums))
+	}
+}
+
+func TestNarrowTracedSyscallNumbers_NetworkWithoutHandler(t *testing.T) {
+	cfg := &TracerConfig{
+		TraceNetwork:   true,
+		NetworkHandler: nil, // no DNS proxy
+	}
+	nums := narrowTracedSyscallNumbers(cfg)
+
+	contains := func(nr int) bool {
+		for _, n := range nums {
+			if n == nr {
+				return true
+			}
+		}
+		return false
+	}
+
+	if !contains(unix.SYS_CONNECT) {
+		t.Error("SYS_CONNECT missing with TraceNetwork=true")
+	}
+	if !contains(unix.SYS_BIND) {
+		t.Error("SYS_BIND missing with TraceNetwork=true")
+	}
+	// sendto only with handler
+	if contains(unix.SYS_SENDTO) {
+		t.Error("SYS_SENDTO must not appear when NetworkHandler is nil")
+	}
+	// close not needed without MaskTracerPid and without NetworkHandler
+	if contains(unix.SYS_CLOSE) {
+		t.Error("SYS_CLOSE must not appear when MaskTracerPid=false and NetworkHandler=nil")
+	}
+}
+
+func TestNarrowTracedSyscallNumbers_CloseWithMaskTracerPid(t *testing.T) {
+	cfg := &TracerConfig{
+		MaskTracerPid:  true,
+		TraceNetwork:   false,
+		NetworkHandler: nil,
+	}
+	nums := narrowTracedSyscallNumbers(cfg)
+
+	for _, n := range nums {
+		if n == unix.SYS_CLOSE {
+			return
+		}
+	}
+	t.Error("SYS_CLOSE missing when MaskTracerPid=true")
+}
+
+func TestNarrowTracedSyscallNumbers_CloseWithNetworkHandler(t *testing.T) {
+	cfg := &TracerConfig{
+		TraceNetwork:   true,
+		NetworkHandler: &mockNetworkHandler{},
+		MaskTracerPid:  false,
+	}
+	nums := narrowTracedSyscallNumbers(cfg)
+
+	for _, n := range nums {
+		if n == unix.SYS_CLOSE {
+			return
+		}
+	}
+	t.Error("SYS_CLOSE missing when TraceNetwork=true and NetworkHandler is set")
 }

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -462,18 +462,16 @@ func (t *Tracer) setRegs(tid int, regs Regs) error {
 // These syscalls must be resumed with PtraceSyscall (not PtraceCont) so the
 // tracer catches the exit stop. All other traced syscalls are entry-only and
 // can use PtraceCont to skip directly to the next seccomp event.
-func needsExitStop(nr int) bool {
+func (t *Tracer) needsExitStop(nr int) bool {
 	switch nr {
-	case unix.SYS_READ, unix.SYS_PREAD64: // handleReadExit (TracerPid masking)
-		return true
-	case unix.SYS_OPENAT: // handleOpenatExit (fd tracking)
-		return true
-	case unix.SYS_OPENAT2: // handleOpenatExit (fd tracking)
-		return true
-	case unix.SYS_CONNECT: // handleConnectExit (TLS fd watch)
-		return true
-	case unix.SYS_EXECVE, unix.SYS_EXECVEAT: // failed exec needs exit to reset InSyscall
-		return true
+	case unix.SYS_READ, unix.SYS_PREAD64:
+		return true // only traced when escalated — always needs exit
+	case unix.SYS_OPENAT, unix.SYS_OPENAT2:
+		return t.cfg.MaskTracerPid // fd tracking for TracerPid masking
+	case unix.SYS_CONNECT:
+		return t.cfg.TraceNetwork // inline skip in handleNetwork handles port granularity
+	case unix.SYS_EXECVE, unix.SYS_EXECVEAT:
+		return true // exec failure cleanup
 	}
 	return false
 }
@@ -897,7 +895,7 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		// goroutine (runtime.LockOSThread), no mutex needed. TGID is
 		// immutable after creation.
 		state.LastNr = nr
-		state.NeedExitStop = needsExitStop(nr)
+		state.NeedExitStop = t.needsExitStop(nr)
 
 		t.dispatchSyscall(ctx, tid, nr, regs)
 	} else {
@@ -953,7 +951,7 @@ func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
 	if state != nil {
 		state.InSyscall = true
 		state.LastNr = nr
-		state.NeedExitStop = needsExitStop(nr)
+		state.NeedExitStop = t.needsExitStop(nr)
 		// Seccomp stops are entry-only. Defer escalation to next exit stop.
 		if state.NeedsReadEscalation && !state.ThreadHasReadEscalation {
 			state.PendingReadEscalation = true

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -256,6 +256,8 @@ type Tracer struct {
 	readyFileWritten  bool
 	readyFileAttempts int
 
+	hasSyscallInfo bool // true if PTRACE_GET_SYSCALL_INFO is supported (Linux 5.3+)
+
 	stopped chan struct{}
 }
 
@@ -1572,6 +1574,11 @@ func (t *Tracer) Run(ctx context.Context) error {
 	defer runtime.UnlockOSThread()
 	defer t.cancelPendingAttachWaiters()
 	defer t.cancelPendingExitWaiters()
+
+	t.hasSyscallInfo = probePtraceSyscallInfo()
+	if t.hasSyscallInfo {
+		slog.Info("ptrace: PTRACE_GET_SYSCALL_INFO supported")
+	}
 
 	t.fds = newFdTracker()
 	if t.cfg.TraceNetwork && t.cfg.NetworkHandler != nil {

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -887,19 +887,19 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 	t.mu.Unlock()
 
 	if entering {
-		regs, err := t.getRegs(tid)
+		sc, err := t.buildSyscallContext(tid)
 		if err != nil {
 			t.allowSyscall(tid)
 			return
 		}
-		nr := regs.SyscallNr()
+		nr := sc.Info.Nr
 		// LastNr, NeedExitStop are only accessed from the event-loop
 		// goroutine (runtime.LockOSThread), no mutex needed. TGID is
 		// immutable after creation.
 		state.LastNr = nr
 		state.NeedExitStop = t.needsExitStop(nr)
 
-		t.dispatchSyscall(ctx, tid, nr, regs)
+		t.dispatchSyscall(ctx, tid, nr, sc)
 	} else {
 		if pendingErrno != 0 {
 			t.applyDenyFixup(tid, pendingErrno)
@@ -938,12 +938,12 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 
 // handleSeccompStop handles PTRACE_EVENT_SECCOMP stops (prefilter mode).
 func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
-	regs, err := t.getRegs(tid)
+	sc, err := t.buildSyscallContext(tid)
 	if err != nil {
 		t.allowSyscall(tid)
 		return
 	}
-	nr := regs.SyscallNr()
+	nr := sc.Info.Nr
 
 	// Mark as syscall-entry so that injection helpers (injectSyscall)
 	// use the single-phase entry protocol (modify ORIG_RAX, one cycle
@@ -964,26 +964,46 @@ func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
 	}
 	t.mu.Unlock()
 
-	t.dispatchSyscall(ctx, tid, nr, regs)
+	t.dispatchSyscall(ctx, tid, nr, sc)
 }
 
 // dispatchSyscall routes a syscall to the appropriate handler.
-func (t *Tracer) dispatchSyscall(ctx context.Context, tid int, nr int, regs Regs) {
+func (t *Tracer) dispatchSyscall(ctx context.Context, tid int, nr int, sc *SyscallContext) {
 	switch {
 	case isExecveSyscall(nr):
+		regs, err := sc.Regs()
+		if err != nil {
+			t.allowSyscall(tid)
+			return
+		}
 		t.handleExecve(ctx, tid, regs)
 	case isFileSyscall(nr):
+		regs, err := sc.Regs()
+		if err != nil {
+			t.allowSyscall(tid)
+			return
+		}
 		t.handleFile(ctx, tid, regs)
 	case isNetworkSyscall(nr):
+		regs, err := sc.Regs()
+		if err != nil {
+			t.allowSyscall(tid)
+			return
+		}
 		t.handleNetwork(ctx, tid, regs)
 	case isSignalSyscall(nr):
+		regs, err := sc.Regs()
+		if err != nil {
+			t.allowSyscall(tid)
+			return
+		}
 		t.handleSignal(ctx, tid, regs)
 	case isWriteSyscall(nr):
-		t.handleWrite(ctx, tid, regs)
+		t.handleWrite(ctx, tid, sc)
 	case isCloseSyscall(nr):
-		t.handleClose(ctx, tid, regs)
+		t.handleClose(ctx, tid, sc)
 	case isReadSyscall(nr):
-		t.handleReadEntry(tid, regs)
+		t.handleReadEntry(tid, sc)
 	default:
 		t.allowSyscall(tid)
 	}

--- a/internal/ptrace/tracer_test.go
+++ b/internal/ptrace/tracer_test.go
@@ -63,26 +63,34 @@ func TestTracerConfig_HandlerFields(t *testing.T) {
 }
 
 func TestNeedsExitStop(t *testing.T) {
-	exitNeeded := []int{
-		unix.SYS_READ, unix.SYS_PREAD64,
-		unix.SYS_OPENAT, unix.SYS_OPENAT2,
-		unix.SYS_CONNECT,
-		unix.SYS_EXECVE, unix.SYS_EXECVEAT,
+	tests := []struct {
+		name          string
+		nr            int
+		maskTracerPid bool
+		traceNetwork  bool
+		want          bool
+	}{
+		{"openat with mask on", unix.SYS_OPENAT, true, true, true},
+		{"openat with mask off", unix.SYS_OPENAT, false, true, false},
+		{"openat2 with mask off", unix.SYS_OPENAT2, false, true, false},
+		{"connect with network on", unix.SYS_CONNECT, false, true, true},
+		{"connect with network off", unix.SYS_CONNECT, false, false, false},
+		{"read always true", unix.SYS_READ, false, false, true},
+		{"pread64 always true", unix.SYS_PREAD64, false, false, true},
+		{"execve always true", unix.SYS_EXECVE, false, false, true},
+		{"execveat always true", unix.SYS_EXECVEAT, false, false, true},
+		{"unlinkat never needs exit", unix.SYS_UNLINKAT, true, true, false},
+		{"write never needs exit", unix.SYS_WRITE, true, true, false},
 	}
-	for _, nr := range exitNeeded {
-		if !needsExitStop(nr) {
-			t.Errorf("needsExitStop(%d) = false, want true", nr)
-		}
-	}
-
-	entryOnly := []int{
-		unix.SYS_WRITE, unix.SYS_CLOSE, unix.SYS_KILL,
-		unix.SYS_BIND, unix.SYS_SOCKET, unix.SYS_SENDTO,
-		unix.SYS_UNLINKAT, unix.SYS_MKDIRAT,
-	}
-	for _, nr := range entryOnly {
-		if needsExitStop(nr) {
-			t.Errorf("needsExitStop(%d) = true, want false", nr)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &Tracer{cfg: TracerConfig{
+				MaskTracerPid: tt.maskTracerPid,
+				TraceNetwork:  tt.traceNetwork,
+			}}
+			if got := tr.needsExitStop(tt.nr); got != tt.want {
+				t.Errorf("needsExitStop(%d) = %v, want %v", tt.nr, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

- Reduce ptrace syscall interception overhead through four complementary optimizations
- Config-aware exit stop elimination — skip openat/connect exit stops when MaskTracerPid/TraceNetwork is off
- Config-driven BPF filter — remove always-allowed syscalls (socket, listen) and conditionally-needed syscalls (sendto, close) from the seccomp prefilter
- BPF-level SECCOMP_RET_ERRNO — encode static deny decisions directly in the BPF program, eliminating ptrace stops for always-denied syscalls
- PTRACE_GET_SYSCALL_INFO — lighter syscall entry dispatch (~96 bytes vs 216 bytes), with lazy register loading via SyscallContext

## Benchmark results

| Phase | Baseline | Ptrace (before) | Ptrace (after) | Improvement |
|---|---|---|---|---|
| Process spawn (120) | 3423ms | +378% | **+269%** | 29% faster |
| File I/O (1000 ops) | 277ms | +167% | **+131%** | 14% faster |
| Git workflow | 51ms | +702% | **+624%** | 8% faster |
| Network (10 curl) | 346ms | +2701% | **+2010%** | 24% faster |
| Deep tree (20x4-lvl) | 604ms | +1715% | **+1316%** | 23% faster |
| Wide tree (10x10-fan) | 320ms | +502% | **+372%** | 18% faster |
| **Total** | **7294ms** | **+543%** | **+394%** | **23% faster** |

Full mode (seccomp+FUSE) unchanged at <1% overhead.

## Test plan

- [x] `go test ./...` — 80 packages pass
- [x] `GOOS=windows go build ./...` — cross-compile clean
- [x] `make bench` — benchmark confirms improvement
- [ ] Test with MaskTracerPid=on to verify no regression
- [ ] Test with StaticDenyChecker-implementing handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)