### PR TITLE
feat: add Ed25519 policy file signing

### DIFF
--- a/docs/superpowers/plans/2026-03-18-policy-signing.md
+++ b/docs/superpowers/plans/2026-03-18-policy-signing.md
@@ -1,0 +1,1798 @@
+# Policy File Signing Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Ed25519 detached signature support for agentsh policy files with configurable verification modes.
+
+**Architecture:** New `internal/policy/signing` package containing all signing logic (types, keygen, sign, verify, trust store). Integration hooks into `Manager.Get()` and `DefaultPolicyLoader.Load()` for verification at load time. Three new CLI subcommands under `agentsh policy`.
+
+**Tech Stack:** Go stdlib only — `crypto/ed25519`, `crypto/sha256`, `encoding/json`
+
+**Spec:** `docs/superpowers/specs/2026-03-18-policy-signing-design.md`
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|------|---------------|
+| `internal/policy/signing/types.go` | Data structures: `SigFile`, `PublicKeyFile`, `PrivateKeyFile`, `KeyID` derivation |
+| `internal/policy/signing/types_test.go` | Type validation and KeyID derivation tests |
+| `internal/policy/signing/keygen.go` | `GenerateKeypair()` — produces Ed25519 keypair, writes key files |
+| `internal/policy/signing/keygen_test.go` | Keygen tests |
+| `internal/policy/signing/sign.go` | `Sign()` — signs policy bytes; `SignFile()` — signs a file on disk |
+| `internal/policy/signing/sign_test.go` | Signing tests |
+| `internal/policy/signing/truststore.go` | `TrustStore` — loads `*.json` keys from dir, looks up by key_id, permission checks |
+| `internal/policy/signing/truststore_test.go` | Trust store loading, lookup, expiry, permission tests |
+| `internal/policy/signing/verify.go` | `Verify()` — verifies signature; `VerifyPolicy()` — full pipeline (load sig, trust store, verify) |
+| `internal/policy/signing/verify_test.go` | Verification tests (valid, tampered, wrong key, expired, missing sig, schema validation) |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `internal/config/config.go` | Add `SigningConfig` struct and `Signing` field to `PoliciesConfig` |
+| `internal/policy/manager.go` | Add signature verification to `Get()` between hash check and YAML parse |
+| `internal/policy/manager_test.go` | Add tests for signing verification in Manager |
+| `internal/cli/policy_cmd.go` | Add `keygen`, `sign`, `verify` subcommands |
+| `internal/api/app.go` | Pass signing config to `DefaultPolicyLoader`, add verification to `Load()` |
+| `internal/api/core.go` | Add verification to inline policy loading path |
+
+---
+
+## Task 1: Core Types
+
+**Files:**
+- Create: `internal/policy/signing/types.go`
+- Create: `internal/policy/signing/types_test.go`
+
+- [ ] **Step 1: Write failing tests for types and KeyID derivation**
+
+```go
+// internal/policy/signing/types_test.go
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"strings"
+	"testing"
+)
+
+func TestKeyID(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kid := KeyID(pub)
+	if len(kid) != 64 {
+		t.Fatalf("expected 64 hex chars, got %d", len(kid))
+	}
+	// Deterministic
+	if kid != KeyID(pub) {
+		t.Fatal("expected deterministic key ID")
+	}
+}
+
+func TestSigFileValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		sig     SigFile
+		wantErr string
+	}{
+		{"valid", SigFile{Version: 1, Algorithm: "ed25519", KeyID: "abc", SignedAt: "2026-01-01T00:00:00Z", Signature: "AAAA"}, ""},
+		{"bad version", SigFile{Version: 2, Algorithm: "ed25519", KeyID: "abc", SignedAt: "2026-01-01T00:00:00Z", Signature: "AAAA"}, "unsupported version"},
+		{"bad algorithm", SigFile{Version: 1, Algorithm: "rsa", KeyID: "abc", SignedAt: "2026-01-01T00:00:00Z", Signature: "AAAA"}, "unsupported algorithm"},
+		{"missing key_id", SigFile{Version: 1, Algorithm: "ed25519", SignedAt: "2026-01-01T00:00:00Z", Signature: "AAAA"}, "missing key_id"},
+		{"missing signature", SigFile{Version: 1, Algorithm: "ed25519", KeyID: "abc", SignedAt: "2026-01-01T00:00:00Z"}, "missing signature"},
+		{"missing signed_at", SigFile{Version: 1, Algorithm: "ed25519", KeyID: "abc", Signature: "AAAA"}, "missing signed_at"},
+		{"non-empty cert_chain", SigFile{Version: 1, Algorithm: "ed25519", KeyID: "abc", SignedAt: "2026-01-01T00:00:00Z", Signature: "AAAA", CertChain: []string{"x"}}, "unsupported_cert_chain"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.sig.Validate()
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/policy/signing/ -v -run 'TestKeyID|TestSigFileValidate'`
+Expected: FAIL — package does not exist
+
+- [ ] **Step 3: Write types implementation**
+
+```go
+// internal/policy/signing/types.go
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// SigFile represents a detached signature file (.sig) in JSON format.
+type SigFile struct {
+	Version   int      `json:"version"`
+	Algorithm string   `json:"algorithm"`
+	KeyID     string   `json:"key_id"`
+	Signer    string   `json:"signer,omitempty"`
+	SignedAt  string   `json:"signed_at"`
+	Signature string   `json:"signature"`
+	CertChain []string `json:"cert_chain"`
+}
+
+// Validate checks that the sig file conforms to the v1 schema.
+func (s *SigFile) Validate() error {
+	if s.Version != 1 {
+		return fmt.Errorf("unsupported version: %d", s.Version)
+	}
+	if s.Algorithm != "ed25519" {
+		return fmt.Errorf("unsupported algorithm: %s", s.Algorithm)
+	}
+	if s.KeyID == "" {
+		return fmt.Errorf("missing key_id")
+	}
+	if s.Signature == "" {
+		return fmt.Errorf("missing signature")
+	}
+	if s.SignedAt == "" {
+		return fmt.Errorf("missing signed_at")
+	}
+	if len(s.CertChain) > 0 {
+		return fmt.Errorf("unsupported_cert_chain: v1 does not support certificate chains")
+	}
+	return nil
+}
+
+// PublicKeyFile represents a public key in the trust store.
+type PublicKeyFile struct {
+	KeyID        string `json:"key_id"`
+	Algorithm    string `json:"algorithm"`
+	PublicKey    string `json:"public_key"`
+	Label        string `json:"label,omitempty"`
+	TrustedSince string `json:"trusted_since,omitempty"`
+	ExpiresAt    string `json:"expires_at,omitempty"`
+}
+
+// IsExpired returns true if the key has an expiry time that has passed.
+func (k *PublicKeyFile) IsExpired() bool {
+	if k.ExpiresAt == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, k.ExpiresAt)
+	if err != nil {
+		return false
+	}
+	return time.Now().After(t)
+}
+
+// PrivateKeyFile represents a private signing key.
+type PrivateKeyFile struct {
+	KeyID      string `json:"key_id"`
+	Algorithm  string `json:"algorithm"`
+	PrivateKey string `json:"private_key"`
+	Label      string `json:"label,omitempty"`
+	CreatedAt  string `json:"created_at,omitempty"`
+}
+
+// KeyID computes the deterministic key identifier from an Ed25519 public key.
+// Returns the full hex-encoded SHA256 hash (64 chars).
+func KeyID(pub ed25519.PublicKey) string {
+	h := sha256.Sum256([]byte(pub))
+	return hex.EncodeToString(h[:])
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/policy/signing/ -v -run 'TestKeyID|TestSigFileValidate'`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/policy/signing/types.go internal/policy/signing/types_test.go
+git commit -m "feat(signing): add core types — SigFile, PublicKeyFile, PrivateKeyFile, KeyID"
+```
+
+---
+
+## Task 2: Key Generation
+
+**Files:**
+- Create: `internal/policy/signing/keygen.go`
+- Create: `internal/policy/signing/keygen_test.go`
+
+- [ ] **Step 1: Write failing tests for keygen**
+
+```go
+// internal/policy/signing/keygen_test.go
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateKeypair(t *testing.T) {
+	dir := t.TempDir()
+	kid, err := GenerateKeypair(dir, "test-signer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(kid) != 64 {
+		t.Fatalf("expected 64 hex char key_id, got %d", len(kid))
+	}
+
+	// Check private key file
+	privData, err := os.ReadFile(filepath.Join(dir, "private.key.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var priv PrivateKeyFile
+	if err := json.Unmarshal(privData, &priv); err != nil {
+		t.Fatal(err)
+	}
+	if priv.KeyID != kid {
+		t.Fatalf("key_id mismatch: %s != %s", priv.KeyID, kid)
+	}
+	if priv.Algorithm != "ed25519" {
+		t.Fatalf("expected ed25519, got %s", priv.Algorithm)
+	}
+	privKeyBytes, err := base64.StdEncoding.DecodeString(priv.PrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(privKeyBytes) != ed25519.PrivateKeySize {
+		t.Fatalf("expected %d byte private key, got %d", ed25519.PrivateKeySize, len(privKeyBytes))
+	}
+
+	// Check public key file
+	pubData, err := os.ReadFile(filepath.Join(dir, "public.key.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pub PublicKeyFile
+	if err := json.Unmarshal(pubData, &pub); err != nil {
+		t.Fatal(err)
+	}
+	if pub.KeyID != kid {
+		t.Fatalf("key_id mismatch: %s != %s", pub.KeyID, kid)
+	}
+	pubKeyBytes, err := base64.StdEncoding.DecodeString(pub.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pubKeyBytes) != ed25519.PublicKeySize {
+		t.Fatalf("expected %d byte public key, got %d", ed25519.PublicKeySize, len(pubKeyBytes))
+	}
+
+	// Verify private key file permissions
+	info, err := os.Stat(filepath.Join(dir, "private.key.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected 0600 permissions, got %o", info.Mode().Perm())
+	}
+}
+
+func TestGenerateKeypair_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	_, err := GenerateKeypair(dir, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	priv, err := LoadPrivateKey(filepath.Join(dir, "private.key.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := []byte("hello world")
+	sig := ed25519.Sign(priv, msg)
+
+	pubData, err := os.ReadFile(filepath.Join(dir, "public.key.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pubFile PublicKeyFile
+	if err := json.Unmarshal(pubData, &pubFile); err != nil {
+		t.Fatal(err)
+	}
+	pubBytes, _ := base64.StdEncoding.DecodeString(pubFile.PublicKey)
+	pub := ed25519.PublicKey(pubBytes)
+
+	if !ed25519.Verify(pub, msg, sig) {
+		t.Fatal("generated keypair does not round-trip")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/policy/signing/ -v -run 'TestGenerateKeypair'`
+Expected: FAIL — `GenerateKeypair` and `LoadPrivateKey` undefined
+
+- [ ] **Step 3: Write keygen implementation**
+
+```go
+// internal/policy/signing/keygen.go
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// GenerateKeypair creates an Ed25519 keypair and writes both key files to dir.
+// Returns the key_id. The private key is written with mode 0600.
+func GenerateKeypair(dir, label string) (string, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", fmt.Errorf("generate key: %w", err)
+	}
+
+	kid := KeyID(pub)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	privFile := PrivateKeyFile{
+		KeyID:      kid,
+		Algorithm:  "ed25519",
+		PrivateKey: base64.StdEncoding.EncodeToString(priv),
+		Label:      label,
+		CreatedAt:  now,
+	}
+	privJSON, err := json.MarshalIndent(privFile, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal private key: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "private.key.json"), privJSON, 0o600); err != nil {
+		return "", fmt.Errorf("write private key: %w", err)
+	}
+
+	pubFile := PublicKeyFile{
+		KeyID:        kid,
+		Algorithm:    "ed25519",
+		PublicKey:    base64.StdEncoding.EncodeToString(pub),
+		Label:        label,
+		TrustedSince: now,
+	}
+	pubJSON, err := json.MarshalIndent(pubFile, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal public key: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "public.key.json"), pubJSON, 0o644); err != nil {
+		return "", fmt.Errorf("write public key: %w", err)
+	}
+
+	return kid, nil
+}
+
+// LoadPrivateKey reads an Ed25519 private key from a JSON key file.
+func LoadPrivateKey(path string) (ed25519.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read private key: %w", err)
+	}
+	var kf PrivateKeyFile
+	if err := json.Unmarshal(data, &kf); err != nil {
+		return nil, fmt.Errorf("parse private key: %w", err)
+	}
+	if kf.Algorithm != "ed25519" {
+		return nil, fmt.Errorf("unsupported algorithm: %s", kf.Algorithm)
+	}
+	keyBytes, err := base64.StdEncoding.DecodeString(kf.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("decode private key: %w", err)
+	}
+	if len(keyBytes) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("invalid private key size: %d", len(keyBytes))
+	}
+	return ed25519.PrivateKey(keyBytes), nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/policy/signing/ -v -run 'TestGenerateKeypair'`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/policy/signing/keygen.go internal/policy/signing/keygen_test.go
+git commit -m "feat(signing): add Ed25519 keypair generation"
+```
+
+---
+
+## Task 3: Signing
+
+**Files:**
+- Create: `internal/policy/signing/sign.go`
+- Create: `internal/policy/signing/sign_test.go`
+
+- [ ] **Step 1: Write failing tests for signing**
+
+```go
+// internal/policy/signing/sign_test.go
+package signing
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSign(t *testing.T) {
+	dir := t.TempDir()
+	kid, err := GenerateKeypair(dir, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	priv, err := LoadPrivateKey(filepath.Join(dir, "private.key.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	policyBytes := []byte("version: 1\nname: test\n")
+	sig, err := Sign(policyBytes, priv, "test-signer")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sig.Version != 1 {
+		t.Fatalf("expected version 1, got %d", sig.Version)
+	}
+	if sig.Algorithm != "ed25519" {
+		t.Fatalf("expected ed25519, got %s", sig.Algorithm)
+	}
+	if sig.KeyID != kid {
+		t.Fatalf("key_id mismatch")
+	}
+	if sig.Signer != "test-signer" {
+		t.Fatalf("expected signer test-signer, got %s", sig.Signer)
+	}
+	if sig.Signature == "" {
+		t.Fatal("empty signature")
+	}
+	if sig.SignedAt == "" {
+		t.Fatal("empty signed_at")
+	}
+	if err := sig.Validate(); err != nil {
+		t.Fatalf("sig validation: %v", err)
+	}
+}
+
+func TestSignFile(t *testing.T) {
+	dir := t.TempDir()
+	_, err := GenerateKeypair(dir, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	policyPath := filepath.Join(dir, "test.yaml")
+	if err := os.WriteFile(policyPath, []byte("version: 1\nname: test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	privPath := filepath.Join(dir, "private.key.json")
+	if err := SignFile(policyPath, privPath, "", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check .sig file was created
+	sigPath := policyPath + ".sig"
+	sigData, err := os.ReadFile(sigPath)
+	if err != nil {
+		t.Fatalf("sig file not created: %v", err)
+	}
+	var sig SigFile
+	if err := json.Unmarshal(sigData, &sig); err != nil {
+		t.Fatalf("parse sig: %v", err)
+	}
+	if err := sig.Validate(); err != nil {
+		t.Fatalf("sig validation: %v", err)
+	}
+}
+
+func TestSignFile_CustomOutput(t *testing.T) {
+	dir := t.TempDir()
+	_, err := GenerateKeypair(dir, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	policyPath := filepath.Join(dir, "test.yaml")
+	if err := os.WriteFile(policyPath, []byte("version: 1\nname: test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	customSig := filepath.Join(dir, "custom.sig")
+	if err := SignFile(policyPath, filepath.Join(dir, "private.key.json"), customSig, "custom-signer"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(customSig); err != nil {
+		t.Fatalf("custom sig not created: %v", err)
+	}
+	// Default location should not exist
+	if _, err := os.Stat(policyPath + ".sig"); err == nil {
+		t.Fatal("default sig should not exist when custom output specified")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/policy/signing/ -v -run 'TestSign'`
+Expected: FAIL — `Sign` and `SignFile` undefined
+
+- [ ] **Step 3: Write signing implementation**
+
+```go
+// internal/policy/signing/sign.go
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+// Sign creates a SigFile from raw policy bytes and an Ed25519 private key.
+func Sign(policyBytes []byte, privKey ed25519.PrivateKey, signer string) (*SigFile, error) {
+	sig := ed25519.Sign(privKey, policyBytes)
+	pub := privKey.Public().(ed25519.PublicKey)
+
+	return &SigFile{
+		Version:   1,
+		Algorithm: "ed25519",
+		KeyID:     KeyID(pub),
+		Signer:    signer,
+		SignedAt:  time.Now().UTC().Format(time.RFC3339),
+		Signature: base64.StdEncoding.EncodeToString(sig),
+		CertChain: []string{},
+	}, nil
+}
+
+// SignFile reads a policy file, signs it, and writes the .sig file.
+// If outputPath is empty, writes to <policyPath>.sig.
+// If signer is empty, the signer field is omitted.
+func SignFile(policyPath, privKeyPath, outputPath, signer string) error {
+	policyBytes, err := os.ReadFile(policyPath)
+	if err != nil {
+		return fmt.Errorf("read policy: %w", err)
+	}
+
+	privKey, err := LoadPrivateKey(privKeyPath)
+	if err != nil {
+		return err
+	}
+
+	sigFile, err := Sign(policyBytes, privKey, signer)
+	if err != nil {
+		return err
+	}
+
+	sigJSON, err := json.MarshalIndent(sigFile, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal signature: %w", err)
+	}
+
+	dest := outputPath
+	if dest == "" {
+		dest = policyPath + ".sig"
+	}
+
+	if err := os.WriteFile(dest, sigJSON, 0o644); err != nil {
+		return fmt.Errorf("write signature: %w", err)
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/policy/signing/ -v -run 'TestSign'`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/policy/signing/sign.go internal/policy/signing/sign_test.go
+git commit -m "feat(signing): add policy signing — Sign() and SignFile()"
+```
+
+---
+
+## Task 4: Trust Store
+
+**Files:**
+- Create: `internal/policy/signing/truststore.go`
+- Create: `internal/policy/signing/truststore_test.go`
+
+- [ ] **Step 1: Write failing tests for trust store**
+
+```go
+// internal/policy/signing/truststore_test.go
+package signing
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestTrustStore_LoadAndFind(t *testing.T) {
+	dir := t.TempDir()
+	kid, err := GenerateKeypair(dir, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Move public key to a trust store directory
+	tsDir := t.TempDir()
+	pubData, _ := os.ReadFile(filepath.Join(dir, "public.key.json"))
+	os.WriteFile(filepath.Join(tsDir, "key1.json"), pubData, 0o644)
+
+	ts, err := LoadTrustStore(tsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key, err := ts.FindKey(kid)
+	if err != nil {
+		t.Fatalf("expected to find key: %v", err)
+	}
+	if key.KeyID != kid {
+		t.Fatalf("key_id mismatch")
+	}
+}
+
+func TestTrustStore_UnknownKey(t *testing.T) {
+	tsDir := t.TempDir()
+	ts, err := LoadTrustStore(tsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ts.FindKey("nonexistent")
+	if err == nil {
+		t.Fatal("expected error for unknown key")
+	}
+}
+
+func TestTrustStore_ExpiredKey(t *testing.T) {
+	tsDir := t.TempDir()
+	pubFile := PublicKeyFile{
+		KeyID:     "expired-key-id",
+		Algorithm: "ed25519",
+		PublicKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", // 32 bytes
+		Label:     "expired",
+		ExpiresAt: time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339),
+	}
+	data, _ := json.MarshalIndent(pubFile, "", "  ")
+	os.WriteFile(filepath.Join(tsDir, "expired.json"), data, 0o644)
+
+	ts, err := LoadTrustStore(tsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ts.FindKey("expired-key-id")
+	if err == nil {
+		t.Fatal("expected error for expired key")
+	}
+}
+
+func TestTrustStore_IgnoresNonJSON(t *testing.T) {
+	tsDir := t.TempDir()
+	os.WriteFile(filepath.Join(tsDir, "README.txt"), []byte("ignore me"), 0o644)
+	os.WriteFile(filepath.Join(tsDir, ".gitkeep"), []byte(""), 0o644)
+
+	ts, err := LoadTrustStore(tsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ts.Keys) != 0 {
+		t.Fatalf("expected 0 keys, got %d", len(ts.Keys))
+	}
+}
+
+func TestTrustStore_MultipleKeys(t *testing.T) {
+	tsDir := t.TempDir()
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	kid1, _ := GenerateKeypair(dir1, "key1")
+	kid2, _ := GenerateKeypair(dir2, "key2")
+
+	pub1, _ := os.ReadFile(filepath.Join(dir1, "public.key.json"))
+	pub2, _ := os.ReadFile(filepath.Join(dir2, "public.key.json"))
+
+	os.WriteFile(filepath.Join(tsDir, "key1.json"), pub1, 0o644)
+	os.WriteFile(filepath.Join(tsDir, "key2.json"), pub2, 0o644)
+
+	ts, err := LoadTrustStore(tsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ts.Keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(ts.Keys))
+	}
+
+	if _, err := ts.FindKey(kid1); err != nil {
+		t.Fatalf("key1 not found: %v", err)
+	}
+	if _, err := ts.FindKey(kid2); err != nil {
+		t.Fatalf("key2 not found: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/policy/signing/ -v -run 'TestTrustStore'`
+Expected: FAIL — `TrustStore`, `LoadTrustStore`, `FindKey` undefined
+
+- [ ] **Step 3: Write trust store implementation**
+
+```go
+// internal/policy/signing/truststore.go
+package signing
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// TrustStore holds a set of trusted public keys loaded from a directory.
+type TrustStore struct {
+	Keys map[string]*PublicKeyFile // keyed by key_id
+}
+
+// LoadTrustStore reads all *.json files from dir and parses them as public key files.
+func LoadTrustStore(dir string) (*TrustStore, error) {
+	ts := &TrustStore{Keys: make(map[string]*PublicKeyFile)}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read trust store dir: %w", err)
+	}
+
+	// Check directory permissions
+	info, err := os.Stat(dir)
+	if err == nil && info.Mode().Perm()&0o002 != 0 {
+		fmt.Fprintf(os.Stderr, "WARNING: trust store directory %s is world-writable\n", dir)
+	}
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+
+		// Check file permissions
+		fi, err := os.Stat(path)
+		if err == nil && fi.Mode().Perm()&0o002 != 0 {
+			fmt.Fprintf(os.Stderr, "WARNING: trust store key file %s is world-writable\n", path)
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read key file %s: %w", e.Name(), err)
+		}
+		var kf PublicKeyFile
+		if err := json.Unmarshal(data, &kf); err != nil {
+			return nil, fmt.Errorf("parse key file %s: %w", e.Name(), err)
+		}
+		ts.Keys[kf.KeyID] = &kf
+	}
+
+	return ts, nil
+}
+
+// FindKey looks up a public key by key_id. Returns an error if the key is
+// not found or has expired.
+func (ts *TrustStore) FindKey(keyID string) (*PublicKeyFile, error) {
+	kf, ok := ts.Keys[keyID]
+	if !ok {
+		return nil, fmt.Errorf("unknown_key: %s", keyID)
+	}
+	if kf.IsExpired() {
+		return nil, fmt.Errorf("expired_key: %s", keyID)
+	}
+	return kf, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/policy/signing/ -v -run 'TestTrustStore'`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/policy/signing/truststore.go internal/policy/signing/truststore_test.go
+git commit -m "feat(signing): add trust store — load keys from dir, lookup, expiry check"
+```
+
+---
+
+## Task 5: Verification
+
+**Files:**
+- Create: `internal/policy/signing/verify.go`
+- Create: `internal/policy/signing/verify_test.go`
+
+- [ ] **Step 1: Write failing tests for verification**
+
+```go
+// internal/policy/signing/verify_test.go
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupSignedPolicy(t *testing.T) (policyPath, tsDir string) {
+	t.Helper()
+	keyDir := t.TempDir()
+	_, err := GenerateKeypair(keyDir, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	policyDir := t.TempDir()
+	policyPath = filepath.Join(policyDir, "test.yaml")
+	os.WriteFile(policyPath, []byte("version: 1\nname: test\n"), 0o644)
+
+	if err := SignFile(policyPath, filepath.Join(keyDir, "private.key.json"), "", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	tsDir = t.TempDir()
+	pubData, _ := os.ReadFile(filepath.Join(keyDir, "public.key.json"))
+	os.WriteFile(filepath.Join(tsDir, "key.json"), pubData, 0o644)
+	return
+}
+
+func TestVerify_Valid(t *testing.T) {
+	policyPath, tsDir := setupSignedPolicy(t)
+
+	ts, err := LoadTrustStore(tsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	policyBytes, _ := os.ReadFile(policyPath)
+	sigData, _ := os.ReadFile(policyPath + ".sig")
+	var sig SigFile
+	json.Unmarshal(sigData, &sig)
+
+	if err := Verify(policyBytes, &sig, ts); err != nil {
+		t.Fatalf("expected valid: %v", err)
+	}
+}
+
+func TestVerify_TamperedPolicy(t *testing.T) {
+	policyPath, tsDir := setupSignedPolicy(t)
+
+	ts, _ := LoadTrustStore(tsDir)
+
+	// Tamper with the policy
+	tamperedBytes := []byte("version: 1\nname: TAMPERED\n")
+	sigData, _ := os.ReadFile(policyPath + ".sig")
+	var sig SigFile
+	json.Unmarshal(sigData, &sig)
+
+	err := Verify(tamperedBytes, &sig, ts)
+	if err == nil {
+		t.Fatal("expected error for tampered policy")
+	}
+}
+
+func TestVerify_WrongKey(t *testing.T) {
+	policyPath, _ := setupSignedPolicy(t)
+
+	// Create a different trust store with a different key
+	otherDir := t.TempDir()
+	GenerateKeypair(otherDir, "other")
+	tsDir2 := t.TempDir()
+	pubData, _ := os.ReadFile(filepath.Join(otherDir, "public.key.json"))
+	os.WriteFile(filepath.Join(tsDir2, "other.json"), pubData, 0o644)
+
+	ts, _ := LoadTrustStore(tsDir2)
+	policyBytes, _ := os.ReadFile(policyPath)
+	sigData, _ := os.ReadFile(policyPath + ".sig")
+	var sig SigFile
+	json.Unmarshal(sigData, &sig)
+
+	err := Verify(policyBytes, &sig, ts)
+	if err == nil {
+		t.Fatal("expected error for wrong key")
+	}
+}
+
+func TestVerifyPolicy_Valid(t *testing.T) {
+	policyPath, tsDir := setupSignedPolicy(t)
+	ts, _ := LoadTrustStore(tsDir)
+
+	result, err := VerifyPolicy(policyPath, ts)
+	if err != nil {
+		t.Fatalf("expected valid: %v", err)
+	}
+	if result.KeyID == "" {
+		t.Fatal("expected key_id in result")
+	}
+}
+
+func TestVerifyPolicy_MissingSig(t *testing.T) {
+	policyPath := filepath.Join(t.TempDir(), "test.yaml")
+	os.WriteFile(policyPath, []byte("version: 1\nname: test\n"), 0o644)
+
+	ts := &TrustStore{Keys: make(map[string]*PublicKeyFile)}
+	_, err := VerifyPolicy(policyPath, ts)
+	if err == nil {
+		t.Fatal("expected error for missing sig")
+	}
+}
+
+func TestVerify_InvalidSigSchema(t *testing.T) {
+	ts := &TrustStore{Keys: make(map[string]*PublicKeyFile)}
+	bad := &SigFile{Version: 2, Algorithm: "ed25519", KeyID: "x", Signature: "x", SignedAt: "x"}
+	err := Verify([]byte("test"), bad, ts)
+	if err == nil {
+		t.Fatal("expected error for bad version")
+	}
+}
+
+func TestVerify_KeyRotation(t *testing.T) {
+	// Generate two keypairs
+	keyDir1 := t.TempDir()
+	keyDir2 := t.TempDir()
+	_, err := GenerateKeypair(keyDir1, "key1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = GenerateKeypair(keyDir2, "key2")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign policy with key1
+	policyDir := t.TempDir()
+	policyPath := filepath.Join(policyDir, "test.yaml")
+	os.WriteFile(policyPath, []byte("version: 1\nname: test\n"), 0o644)
+	if err := SignFile(policyPath, filepath.Join(keyDir1, "private.key.json"), "", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// Trust store has BOTH keys
+	tsDir := t.TempDir()
+	pub1, _ := os.ReadFile(filepath.Join(keyDir1, "public.key.json"))
+	pub2, _ := os.ReadFile(filepath.Join(keyDir2, "public.key.json"))
+	os.WriteFile(filepath.Join(tsDir, "key1.json"), pub1, 0o644)
+	os.WriteFile(filepath.Join(tsDir, "key2.json"), pub2, 0o644)
+
+	ts, _ := LoadTrustStore(tsDir)
+
+	// Policy signed with key1 should verify with both keys in trust store
+	result, err := VerifyPolicy(policyPath, ts)
+	if err != nil {
+		t.Fatalf("expected valid with key rotation: %v", err)
+	}
+	if result.KeyID == "" {
+		t.Fatal("expected key_id in result")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/policy/signing/ -v -run 'TestVerify'`
+Expected: FAIL — `Verify`, `VerifyPolicy` undefined
+
+- [ ] **Step 3: Write verification implementation**
+
+```go
+// internal/policy/signing/verify.go
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// VerifyResult holds the outcome of a successful policy verification.
+type VerifyResult struct {
+	KeyID    string
+	Signer   string
+	SignedAt string
+}
+
+// Verify checks an Ed25519 signature against policy bytes using the trust store.
+func Verify(policyBytes []byte, sig *SigFile, ts *TrustStore) error {
+	if err := sig.Validate(); err != nil {
+		return fmt.Errorf("invalid signature file: %w", err)
+	}
+
+	kf, err := ts.FindKey(sig.KeyID)
+	if err != nil {
+		return err
+	}
+
+	pubBytes, err := base64.StdEncoding.DecodeString(kf.PublicKey)
+	if err != nil {
+		return fmt.Errorf("decode public key: %w", err)
+	}
+	if len(pubBytes) != ed25519.PublicKeySize {
+		return fmt.Errorf("invalid public key size: %d", len(pubBytes))
+	}
+	pub := ed25519.PublicKey(pubBytes)
+
+	sigBytes, err := base64.StdEncoding.DecodeString(sig.Signature)
+	if err != nil {
+		return fmt.Errorf("decode signature: %w", err)
+	}
+
+	if !ed25519.Verify(pub, policyBytes, sigBytes) {
+		return fmt.Errorf("invalid_signature: Ed25519 verification failed")
+	}
+
+	return nil
+}
+
+// VerifyPolicy reads a policy file and its .sig file, then verifies against the trust store.
+// Returns VerifyResult on success or an error describing the failure.
+func VerifyPolicy(policyPath string, ts *TrustStore) (*VerifyResult, error) {
+	policyBytes, err := os.ReadFile(policyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read policy: %w", err)
+	}
+	return VerifyPolicyBytes(policyBytes, policyPath+".sig", ts)
+}
+
+// VerifyPolicyBytes verifies raw policy bytes against a sig file and trust store.
+// This is the shared verification function used by all policy loading paths.
+func VerifyPolicyBytes(policyBytes []byte, sigPath string, ts *TrustStore) (*VerifyResult, error) {
+	sigData, err := os.ReadFile(sigPath)
+	if err != nil {
+		return nil, fmt.Errorf("missing_signature: %w", err)
+	}
+
+	var sig SigFile
+	if err := json.Unmarshal(sigData, &sig); err != nil {
+		return nil, fmt.Errorf("parse signature file: %w", err)
+	}
+
+	if err := Verify(policyBytes, &sig, ts); err != nil {
+		return nil, err
+	}
+
+	return &VerifyResult{
+		KeyID:    sig.KeyID,
+		Signer:   sig.Signer,
+		SignedAt:  sig.SignedAt,
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/policy/signing/ -v -run 'TestVerify'`
+Expected: PASS
+
+- [ ] **Step 5: Run all signing package tests**
+
+Run: `go test ./internal/policy/signing/ -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/policy/signing/verify.go internal/policy/signing/verify_test.go
+git commit -m "feat(signing): add verification — Verify() and VerifyPolicy()"
+```
+
+---
+
+## Task 6: Configuration
+
+**Files:**
+- Modify: `internal/config/config.go:691-701`
+
+- [ ] **Step 1: Add SigningConfig to PoliciesConfig**
+
+In `internal/config/config.go`, add a `SigningConfig` struct before `PoliciesConfig` and a new field:
+
+```go
+// SigningConfig configures policy signature verification.
+type SigningConfig struct {
+	TrustStore string `yaml:"trust_store"` // Directory of trusted public keys
+	Mode       string `yaml:"mode"`        // "enforce", "warn", or "off" (default: "off")
+}
+
+// SigningMode returns the effective signing mode, defaulting to "off".
+func (c *SigningConfig) SigningMode() string {
+	if c.Mode == "" {
+		return "off"
+	}
+	return c.Mode
+}
+
+// Validate checks that the signing config has valid values.
+func (c *SigningConfig) Validate() error {
+	switch c.Mode {
+	case "", "off", "warn", "enforce":
+		// valid
+	default:
+		return fmt.Errorf("invalid signing mode %q: must be \"enforce\", \"warn\", or \"off\"", c.Mode)
+	}
+	if (c.Mode == "enforce" || c.Mode == "warn") && c.TrustStore == "" {
+		return fmt.Errorf("signing.trust_store is required when signing.mode is %q", c.Mode)
+	}
+	return nil
+}
+```
+
+Add `Signing SigningConfig` field to `PoliciesConfig`:
+
+```go
+type PoliciesConfig struct {
+	Dir               string          `yaml:"dir"`
+	Default           string          `yaml:"default"`
+	Allowed           []string        `yaml:"allowed"`
+	ManifestPath      string          `yaml:"manifest_path"`
+	Signing           SigningConfig   `yaml:"signing"`
+	EnvPolicy         EnvPolicyConfig `yaml:"env_policy"`
+	EnvShimPath       string          `yaml:"env_shim_path"`
+	ReloadInterval    string          `yaml:"reload_interval"`
+	DetectProjectRoot *bool           `yaml:"detect_project_root"`
+	ProjectMarkers    []string        `yaml:"project_markers"`
+}
+```
+
+- [ ] **Step 2: Build to verify no compilation errors**
+
+Run: `go build ./...`
+Expected: Success
+
+- [ ] **Step 3: Run existing tests to verify no regressions**
+
+Run: `go test ./internal/config/... -v -count=1`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/config/config.go
+git commit -m "feat(signing): add SigningConfig to PoliciesConfig"
+```
+
+---
+
+## Task 7: Manager Integration
+
+**Files:**
+- Modify: `internal/policy/manager.go`
+- Modify: `internal/policy/manager_test.go`
+
+- [ ] **Step 1: Write failing tests for signing verification in Manager**
+
+Add to `internal/policy/manager_test.go`. First, update the import block to include the signing package:
+
+```go
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy/signing"
+)
+```
+
+Then add the tests:
+
+```go
+func TestManager_SigningEnforce_Valid(t *testing.T) {
+	dir := t.TempDir()
+	writePolicy(t, dir, "p.yaml", "version: 1\nname: p\n")
+
+	// Generate key and sign
+	keyDir := t.TempDir()
+	kid, err := signing.GenerateKeypair(keyDir, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = kid
+	if err := signing.SignFile(
+		filepath.Join(dir, "p.yaml"),
+		filepath.Join(keyDir, "private.key.json"),
+		"", "",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Setup trust store
+	tsDir := t.TempDir()
+	pubData, _ := os.ReadFile(filepath.Join(keyDir, "public.key.json"))
+	os.WriteFile(filepath.Join(tsDir, "key.json"), pubData, 0o644)
+
+	m := NewManager(dir, "p", []string{"p"}, "", "p")
+	m.SetSigningConfig("enforce", tsDir)
+	p, err := m.Get()
+	if err != nil {
+		t.Fatalf("expected load ok, got %v", err)
+	}
+	if p.Name != "p" {
+		t.Fatalf("expected p, got %s", p.Name)
+	}
+}
+
+func TestManager_SigningEnforce_MissingSig(t *testing.T) {
+	dir := t.TempDir()
+	writePolicy(t, dir, "p.yaml", "version: 1\nname: p\n")
+
+	tsDir := t.TempDir()
+	m := NewManager(dir, "p", []string{"p"}, "", "p")
+	m.SetSigningConfig("enforce", tsDir)
+	_, err := m.Get()
+	if err == nil {
+		t.Fatal("expected error for missing signature in enforce mode")
+	}
+}
+
+func TestManager_SigningWarn_MissingSig(t *testing.T) {
+	dir := t.TempDir()
+	writePolicy(t, dir, "p.yaml", "version: 1\nname: p\n")
+
+	tsDir := t.TempDir()
+	m := NewManager(dir, "p", []string{"p"}, "", "p")
+	m.SetSigningConfig("warn", tsDir)
+	p, err := m.Get()
+	if err != nil {
+		t.Fatalf("warn mode should still load, got %v", err)
+	}
+	if p.Name != "p" {
+		t.Fatalf("expected p, got %s", p.Name)
+	}
+}
+
+func TestManager_SigningOff(t *testing.T) {
+	dir := t.TempDir()
+	writePolicy(t, dir, "p.yaml", "version: 1\nname: p\n")
+
+	m := NewManager(dir, "p", []string{"p"}, "", "p")
+	m.SetSigningConfig("off", "")
+	p, err := m.Get()
+	if err != nil {
+		t.Fatalf("off mode should always load, got %v", err)
+	}
+	if p.Name != "p" {
+		t.Fatalf("expected p, got %s", p.Name)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/policy/ -v -run 'TestManager_Signing'`
+Expected: FAIL — `SetSigningConfig` undefined
+
+- [ ] **Step 3: Add signing verification to Manager**
+
+Modify `internal/policy/manager.go`:
+
+1. Add `signingMode` and `trustStorePath` fields to `Manager` struct
+2. Add `SetSigningConfig(mode, trustStorePath string)` method
+3. Insert verification between hash check and YAML parse in `Get()`
+
+Add fields to Manager:
+```go
+type Manager struct {
+	selectedName   string
+	dir            string
+	manifestPath   string
+	signingMode    string
+	trustStorePath string
+	once           sync.Once
+	policy         *Policy
+	err            error
+}
+```
+
+Add method:
+```go
+// SetSigningConfig sets the signing verification mode and trust store path.
+func (m *Manager) SetSigningConfig(mode, trustStorePath string) {
+	m.signingMode = mode
+	m.trustStorePath = trustStorePath
+}
+```
+
+In `Get()`, after the manifest hash check block (`if m.manifestPath != "" { ... }`) and before the YAML decode, add:
+
+```go
+		if m.signingMode != "" && m.signingMode != "off" {
+			if err := m.verifySigning(path, data); err != nil {
+				if m.signingMode == "enforce" {
+					m.err = fmt.Errorf("signing verification: %w", err)
+					return
+				}
+				// warn mode: log and continue
+				fmt.Fprintf(os.Stderr, "WARNING: policy signing verification failed: %v\n", err)
+			}
+		}
+```
+
+Add the `verifySigning` method (uses shared `VerifyPolicyBytes`):
+```go
+func (m *Manager) verifySigning(path string, data []byte) error {
+	ts, err := signing.LoadTrustStore(m.trustStorePath)
+	if err != nil {
+		return fmt.Errorf("load trust store: %w", err)
+	}
+	_, err = signing.VerifyPolicyBytes(data, path+".sig", ts)
+	return err
+}
+```
+
+Add imports: `"github.com/agentsh/agentsh/internal/policy/signing"`
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/policy/ -v -run 'TestManager_Signing'`
+Expected: PASS
+
+- [ ] **Step 5: Run all existing manager tests to verify no regressions**
+
+Run: `go test ./internal/policy/ -v`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/policy/manager.go internal/policy/manager_test.go
+git commit -m "feat(signing): integrate signature verification into policy.Manager"
+```
+
+---
+
+## Task 8: CLI Commands
+
+**Files:**
+- Modify: `internal/cli/policy_cmd.go`
+
+- [ ] **Step 1: Add keygen subcommand**
+
+In `newPolicyCmd()`, after the existing `cmd.AddCommand(generateCmd)` line, add:
+
+```go
+	// Keygen subcommand
+	var keygenOutput string
+	var keygenLabel string
+
+	keygenCmd := &cobra.Command{
+		Use:   "keygen",
+		Short: "Generate an Ed25519 signing keypair",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outDir := keygenOutput
+			if outDir == "" {
+				outDir = "."
+			}
+			kid, err := signing.GenerateKeypair(outDir, keygenLabel)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", kid)
+			fmt.Fprintf(cmd.ErrOrStderr(), "Keypair written to %s/\n", outDir)
+			return nil
+		},
+	}
+	keygenCmd.Flags().StringVar(&keygenOutput, "output", "", "Output directory (default: current dir)")
+	keygenCmd.Flags().StringVar(&keygenLabel, "label", "", "Human-readable label for the key")
+	cmd.AddCommand(keygenCmd)
+```
+
+- [ ] **Step 2: Add sign subcommand**
+
+```go
+	// Sign subcommand
+	var signKey string
+	var signOutput string
+	var signSigner string
+
+	signCmd := &cobra.Command{
+		Use:   "sign POLICY_FILE",
+		Short: "Sign a policy file with an Ed25519 private key",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if signKey == "" {
+				return fmt.Errorf("--key is required")
+			}
+			if err := signing.SignFile(args[0], signKey, signOutput, signSigner); err != nil {
+				return err
+			}
+			dest := signOutput
+			if dest == "" {
+				dest = args[0] + ".sig"
+			}
+			fmt.Fprintf(cmd.ErrOrStderr(), "Signature written to %s\n", dest)
+			return nil
+		},
+	}
+	signCmd.Flags().StringVar(&signKey, "key", "", "Path to private key file (required)")
+	signCmd.Flags().StringVar(&signOutput, "output", "", "Output path for .sig file (default: <policy>.sig)")
+	signCmd.Flags().StringVar(&signSigner, "signer", "", "Human-readable signer label")
+	cmd.AddCommand(signCmd)
+```
+
+- [ ] **Step 3: Add verify subcommand**
+
+```go
+	// Verify subcommand
+	var verifyKeyDir string
+
+	verifyCmd := &cobra.Command{
+		Use:   "verify POLICY_FILE",
+		Short: "Verify a policy file signature",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if verifyKeyDir == "" {
+				return fmt.Errorf("--key-dir is required")
+			}
+			ts, err := signing.LoadTrustStore(verifyKeyDir)
+			if err != nil {
+				return fmt.Errorf("load trust store: %w", err)
+			}
+			result, err := signing.VerifyPolicy(args[0], ts)
+			if err != nil {
+				return fmt.Errorf("verification failed: %w", err)
+			}
+			return printJSON(cmd, map[string]any{
+				"status":    "valid",
+				"key_id":    result.KeyID,
+				"signer":    result.Signer,
+				"signed_at": result.SignedAt,
+			})
+		},
+	}
+	verifyCmd.Flags().StringVar(&verifyKeyDir, "key-dir", "", "Path to trust store directory (required)")
+	cmd.AddCommand(verifyCmd)
+```
+
+Add import for `"github.com/agentsh/agentsh/internal/policy/signing"` to the file.
+
+- [ ] **Step 4: Write CLI tests**
+
+Create `internal/cli/policy_signing_test.go`:
+
+```go
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPolicyKeygen(t *testing.T) {
+	dir := t.TempDir()
+	cmd := newPolicyCmd()
+	cmd.SetArgs([]string{"keygen", "--output", dir, "--label", "test"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("keygen failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "private.key.json")); err != nil {
+		t.Fatal("private key not created")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "public.key.json")); err != nil {
+		t.Fatal("public key not created")
+	}
+}
+
+func TestPolicySignAndVerify(t *testing.T) {
+	dir := t.TempDir()
+
+	// Generate keys
+	cmd := newPolicyCmd()
+	cmd.SetArgs([]string{"keygen", "--output", dir, "--label", "test"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a policy
+	policyPath := filepath.Join(dir, "test.yaml")
+	os.WriteFile(policyPath, []byte("version: 1\nname: test\n"), 0o644)
+
+	// Sign
+	cmd = newPolicyCmd()
+	cmd.SetArgs([]string{"sign", policyPath, "--key", filepath.Join(dir, "private.key.json")})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("sign failed: %v", err)
+	}
+	if _, err := os.Stat(policyPath + ".sig"); err != nil {
+		t.Fatal("sig file not created")
+	}
+
+	// Verify
+	cmd = newPolicyCmd()
+	cmd.SetArgs([]string{"verify", policyPath, "--key-dir", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+}
+
+func TestPolicyVerify_MissingSig(t *testing.T) {
+	dir := t.TempDir()
+	policyPath := filepath.Join(dir, "test.yaml")
+	os.WriteFile(policyPath, []byte("version: 1\nname: test\n"), 0o644)
+
+	cmd := newPolicyCmd()
+	cmd.SetArgs([]string{"verify", policyPath, "--key-dir", dir})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for missing sig")
+	}
+}
+```
+
+- [ ] **Step 5: Run CLI tests**
+
+Run: `go test ./internal/cli/ -v -run 'TestPolicyKeygen|TestPolicySign'`
+Expected: PASS
+
+- [ ] **Step 6: Build to verify compilation**
+
+Run: `go build ./...`
+Expected: Success
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/cli/policy_cmd.go internal/cli/policy_signing_test.go
+git commit -m "feat(signing): add CLI commands — keygen, sign, verify"
+```
+
+---
+
+## Task 9: API Integration
+
+**Files:**
+- Modify: `internal/api/app.go:1407-1441`
+- Modify: `internal/api/core.go:575-596`
+
+- [ ] **Step 1: Add signing config to DefaultPolicyLoader**
+
+In `internal/api/app.go`, add signing fields to `DefaultPolicyLoader`:
+
+```go
+type DefaultPolicyLoader struct {
+	policyDir        string
+	enforceApprovals bool
+	enforceRedirects bool
+	signingMode      string
+	trustStorePath   string
+}
+```
+
+Update `NewDefaultPolicyLoader`:
+```go
+func NewDefaultPolicyLoader(policyDir string, enforceApprovals, enforceRedirects bool, signingMode, trustStorePath string) *DefaultPolicyLoader {
+	return &DefaultPolicyLoader{
+		policyDir:        policyDir,
+		enforceApprovals: enforceApprovals,
+		enforceRedirects: enforceRedirects,
+		signingMode:      signingMode,
+		trustStorePath:   trustStorePath,
+	}
+}
+```
+
+Add verification to `Load()` using the shared `VerifyPolicyBytes`:
+
+```go
+func (l *DefaultPolicyLoader) Load(name string) (*policy.Engine, error) {
+	if name == "" {
+		return nil, fmt.Errorf("policy name is empty")
+	}
+	path, err := policy.ResolvePolicyPath(l.policyDir, name)
+	if err != nil {
+		return nil, fmt.Errorf("resolve policy %q: %w", name, err)
+	}
+	p, err := policy.LoadFromFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("load policy %q: %w", name, err)
+	}
+
+	// Signature verification (shared function — no duplication)
+	if l.signingMode != "" && l.signingMode != "off" && l.trustStorePath != "" {
+		ts, tsErr := signing.LoadTrustStore(l.trustStorePath)
+		if tsErr != nil {
+			if l.signingMode == "enforce" {
+				return nil, fmt.Errorf("load trust store for %q: %w", name, tsErr)
+			}
+			fmt.Fprintf(os.Stderr, "WARNING: policy %q: failed to load trust store: %v\n", name, tsErr)
+		} else {
+			policyBytes, _ := os.ReadFile(path) // already validated by LoadFromFile above
+			if _, vErr := signing.VerifyPolicyBytes(policyBytes, path+".sig", ts); vErr != nil {
+				if l.signingMode == "enforce" {
+					return nil, fmt.Errorf("signing verification for %q: %w", name, vErr)
+				}
+				fmt.Fprintf(os.Stderr, "WARNING: policy %q signing verification failed: %v\n", name, vErr)
+			}
+		}
+	}
+
+	engine, err := policy.NewEngine(p, l.enforceApprovals, l.enforceRedirects)
+	if err != nil {
+		return nil, fmt.Errorf("create policy engine for %q: %w", name, err)
+	}
+	return engine, nil
+}
+```
+
+Add import for `"github.com/agentsh/agentsh/internal/policy/signing"`.
+
+- [ ] **Step 2: Update the single caller of NewDefaultPolicyLoader**
+
+In `internal/server/server.go:313`, change:
+
+```go
+// Before:
+policyLoader := api.NewDefaultPolicyLoader(cfg.Policies.Dir, enforceApprovals, true)
+
+// After:
+policyLoader := api.NewDefaultPolicyLoader(
+	cfg.Policies.Dir, enforceApprovals, true,
+	cfg.Policies.Signing.SigningMode(), cfg.Policies.Signing.TrustStore,
+)
+```
+
+- [ ] **Step 3: Add verification to inline policy loading in core.go**
+
+In `internal/api/core.go:575-596`, after `LoadFromFile` and before `NewEngineWithVariables`, add verification using the shared function:
+
+```go
+		// Signature verification (shared function — no duplication)
+		sigMode := a.cfg.Policies.Signing.SigningMode()
+		if sigMode != "off" && a.cfg.Policies.Signing.TrustStore != "" {
+			ts, tsErr := signing.LoadTrustStore(a.cfg.Policies.Signing.TrustStore)
+			if tsErr != nil {
+				if sigMode == "enforce" {
+					return types.Session{}, http.StatusInternalServerError, fmt.Errorf("load trust store: %w", tsErr)
+				}
+				fmt.Fprintf(os.Stderr, "WARNING: failed to load trust store: %v\n", tsErr)
+			} else {
+				if _, vErr := signing.VerifyPolicyBytes(data, policyPath+".sig", ts); vErr != nil {
+					if sigMode == "enforce" {
+						return types.Session{}, http.StatusForbidden, fmt.Errorf("policy signing: %w", vErr)
+					}
+					fmt.Fprintf(os.Stderr, "WARNING: policy signing verification failed: %v\n", vErr)
+				}
+			}
+		}
+```
+
+Note: This requires reading the raw policy bytes before parsing. The existing code at `core.go:583` calls `policy.LoadFromFile(policyPath)` which reads and parses in one step. Refactor to read bytes first (for verification), then parse:
+
+```go
+		data, err := os.ReadFile(policyPath)
+		if err != nil {
+			return types.Session{}, http.StatusInternalServerError, fmt.Errorf("read policy: %w", err)
+		}
+
+		// Signature verification (insert here, using data bytes)
+
+		pol, err := policy.LoadFromBytes(data) // or parse inline
+```
+
+If `LoadFromBytes` does not exist, add it as a thin wrapper in `internal/policy/load.go` that accepts `[]byte` instead of a file path. This avoids double-reading the file.
+
+Add import for `"github.com/agentsh/agentsh/internal/policy/signing"`.
+
+- [ ] **Step 4: Build to verify compilation**
+
+Run: `go build ./...`
+Expected: Success
+
+- [ ] **Step 5: Run all tests**
+
+Run: `go test ./...`
+Expected: All PASS
+
+- [ ] **Step 6: Verify cross-compilation**
+
+Run: `GOOS=windows go build ./...`
+Expected: Success
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/api/app.go internal/api/core.go internal/server/server.go
+git commit -m "feat(signing): integrate verification into API policy loading paths"
+```
+
+---
+
+## Task 10: End-to-End Verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `go test ./... -count=1`
+Expected: All PASS
+
+- [ ] **Step 2: Verify cross-compilation**
+
+Run: `GOOS=windows go build ./...`
+Expected: Success
+
+- [ ] **Step 3: Manual smoke test of CLI commands**
+
+```bash
+# Generate a keypair
+go run ./cmd/agentsh policy keygen --output /tmp/agentsh-keys --label test
+
+# Sign a policy
+go run ./cmd/agentsh policy sign configs/policies/default.yaml --key /tmp/agentsh-keys/private.key.json --signer test
+
+# Verify the signed policy
+go run ./cmd/agentsh policy verify configs/policies/default.yaml --key-dir /tmp/agentsh-keys
+
+# Clean up
+rm -rf /tmp/agentsh-keys configs/policies/default.yaml.sig
+```
+
+- [ ] **Step 4: Final commit if any cleanup needed**

--- a/docs/superpowers/specs/2026-03-18-policy-signing-design.md
+++ b/docs/superpowers/specs/2026-03-18-policy-signing-design.md
@@ -28,10 +28,10 @@ For a policy file `<name>.yaml`, the detached signature lives at `<name>.yaml.si
 {
   "version": 1,
   "algorithm": "ed25519",
-  "key_id": "a1b2c3d4e5f67890",
+  "key_id": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890",
   "signer": "watchtower-prod",
   "signed_at": "2026-03-18T12:00:00Z",
-  "signature": "base64-raw-url-encoded-ed25519-signature",
+  "signature": "standard-base64-ed25519-signature",
   "cert_chain": []
 }
 ```
@@ -40,10 +40,10 @@ For a policy file `<name>.yaml`, the detached signature lives at `<name>.yaml.si
 |-------|-------------|
 | `version` | Schema version, currently `1`. Allows future evolution. |
 | `algorithm` | Always `"ed25519"` for v1. Present for forward-compat. |
-| `key_id` | Identifies which public key to verify against. Derived deterministically: `hex(SHA256(public_key_bytes))[:16]`. |
+| `key_id` | Identifies which public key to verify against. Derived deterministically: full `hex(SHA256(public_key_bytes))` (64 hex chars). |
 | `signer` | Optional human-readable label (e.g., `"watchtower-prod"`). Informational only, not used for verification. |
-| `signed_at` | RFC 3339 timestamp of when the signature was produced. Used for audit trails and optional expiry checks. |
-| `signature` | Ed25519 signature over the raw bytes of the policy file, base64-raw-url encoded. |
+| `signed_at` | RFC 3339 timestamp of when the signature was produced. V1 does not enforce any time-based validation on this field; it is recorded for audit purposes only. Future versions may add signature freshness checks. |
+| `signature` | Ed25519 signature over the raw bytes of the policy file, standard base64 encoded (RFC 4648 section 4, with padding). |
 | `cert_chain` | Empty array in v1. Reserved for future CA hierarchy (intermediate certificates). |
 
 **What gets signed:** The exact bytes of the policy YAML file as read from disk. No normalization, no parsing. Ed25519 handles its own internal hashing.
@@ -62,20 +62,20 @@ For a policy file `<name>.yaml`, the detached signature lives at `<name>.yaml.si
 **Key ID derivation:**
 
 ```
-key_id = hex(SHA256(ed25519_public_key_bytes))[:16]
+key_id = hex(SHA256(ed25519_public_key_bytes))
 ```
 
-Deterministic from the public key. No ambiguity about which key a `key_id` refers to.
+Full 64-character hex SHA256 of the public key bytes. No truncation — avoids collision risks entirely. Deterministic from the public key.
 
 **Trust store:**
 
-A directory of trusted public keys (default: `/etc/agentsh/keys/`). Each file contains one key:
+A directory of trusted public keys (default: `/etc/agentsh/keys/`). Only files matching `*.json` are loaded. Each file contains one key:
 
 ```json
 {
-  "key_id": "a1b2c3d4e5f67890",
+  "key_id": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890",
   "algorithm": "ed25519",
-  "public_key": "base64-encoded-32-byte-public-key",
+  "public_key": "standard-base64-encoded-32-byte-public-key",
   "label": "watchtower-prod",
   "trusted_since": "2026-03-18T00:00:00Z",
   "expires_at": "2027-03-18T00:00:00Z"
@@ -84,7 +84,25 @@ A directory of trusted public keys (default: `/etc/agentsh/keys/`). Each file co
 
 The `expires_at` field is optional. If present, the key is rejected after expiry even if still in the trust store — defense-in-depth against forgotten keys.
 
+**Trust store permissions:** The trust store directory and key files should be writable only by root/admin. The verifier should log a warning if the trust store directory or any key file is world-writable, similar to SSH's `StrictModes`.
+
 **Key rotation:** Deploy the new public key to the trust store *before* signing with the new private key. Both old and new keys coexist. The `key_id` in the `.sig` file tells the verifier which key to use. Remove old keys once all policies are re-signed.
+
+**Private key format:**
+
+The private key file is a JSON file containing the Ed25519 seed (mode 0600):
+
+```json
+{
+  "key_id": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890",
+  "algorithm": "ed25519",
+  "private_key": "standard-base64-encoded-64-byte-ed25519-private-key",
+  "label": "watchtower-prod",
+  "created_at": "2026-03-18T00:00:00Z"
+}
+```
+
+The `private_key` field contains the full 64-byte Ed25519 private key (seed + public key, as returned by Go's `crypto/ed25519.GenerateKey`), standard base64 encoded.
 
 ### Configuration
 
@@ -102,6 +120,12 @@ policies:
 | `off` | Skip signature verification entirely. |
 
 **Relationship to existing manifest:** The SHA256 manifest (`policies.sha256`) becomes redundant when signing is in `enforce` mode. In `warn` or `off` mode, the manifest still provides integrity checking as a fallback. Both mechanisms coexist; no removal needed.
+
+**Implementation note:** The `Signing` sub-struct must be added to `PoliciesConfig` in `internal/config/config.go`. The `mode` field must be validated at config load time to be one of `"enforce"`, `"warn"`, or `"off"`.
+
+### Scope: Which Policy Loading Paths
+
+Signing applies to the monolithic policy loading path (`internal/policy/Manager` via `ResolvePolicyPath`). The split/directory-based policy loader (`internal/config/LoadPolicyFiles`) is not covered in v1. If split policy loading needs signing in the future, each individual YAML file in the directory would get its own `.sig` file, following the same format.
 
 ### CLI Commands
 
@@ -145,16 +169,19 @@ agentsh policy verify <policy-file> [--key-dir <trust-store>]
 When `PolicyManager` loads a policy:
 
 1. Read policy bytes from disk
-2. Check `policies.signing.mode` — if `"off"`, skip to step 8
+2. Check `policies.signing.mode` — if `"off"`, skip to step 10
 3. Look for `<policy-path>.sig`
-4. Parse sig JSON, extract `key_id`
-5. Find matching public key in `trust_store` directory
-6. Check key expiry if `expires_at` is set
-7. Verify Ed25519 signature over raw policy bytes
-8. On success: log verification event, proceed with loading
-9. On failure:
-   - `"enforce"` mode: refuse to load, return error
-   - `"warn"` mode: log warning, proceed with loading
+4. **If `.sig` is missing:**
+   - `"enforce"` mode: refuse to load, return error `"missing_signature"`
+   - `"warn"` mode: log warning, skip to step 10 (load without verification)
+5. Parse sig JSON and validate: reject if `version` is not `1`, `algorithm` is not `"ed25519"`, or `key_id`/`signature`/`signed_at` are missing/empty. If `cert_chain` is non-empty in v1, reject with `"unsupported_cert_chain"`
+6. Extract `key_id`, find matching public key in `trust_store` directory
+7. Check key expiry if `expires_at` is set
+8. Verify Ed25519 signature over raw policy bytes
+9. On success: log verification event, proceed with loading
+10. On failure:
+    - `"enforce"` mode: refuse to load, return error
+    - `"warn"` mode: log warning, proceed with loading
 
 ### Watchtower Delivery Flow
 
@@ -164,7 +191,7 @@ When watchtower distributes a policy update:
 2. Delivers both files: `<policy>.yaml` + `<policy>.yaml.sig`
 3. Agent writes both to a **staging directory** (`/etc/agentsh/policies/.staging/`) — not directly into the live policy dir
 4. Agent verifies the signature against its trust store
-5. **On success:** atomically moves both files into the live policy directory, logs the update
+5. **On success:** move the `.sig` file first, then the `.yaml` file into the live policy directory. This ordering ensures the policy manager always sees a signature if it sees the policy. Log the update with `key_id`, `signer`, `signed_at`.
 6. **On failure:** rejects the update, logs the failure with details (unknown key, bad signature, missing sig), keeps existing policy
 7. The existing `reload_interval` timer picks up the new policy — or watchtower triggers an immediate reload
 
@@ -180,7 +207,7 @@ Every signature verification produces an audit event:
 {
   "event": "policy.signature.verified",
   "policy": "agent-sandbox",
-  "key_id": "a1b2c3d4e5f67890",
+  "key_id": "a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890a1b2c3d4e5f67890",
   "signer": "watchtower-prod",
   "signed_at": "2026-03-18T12:00:00Z",
   "verified_at": "2026-03-18T12:05:00Z",

--- a/docs/superpowers/specs/2026-03-18-policy-signing-design.md
+++ b/docs/superpowers/specs/2026-03-18-policy-signing-design.md
@@ -82,7 +82,7 @@ A directory of trusted public keys (default: `/etc/agentsh/keys/`). Only files m
 }
 ```
 
-The `expires_at` field is optional. If present, the key is rejected after expiry even if still in the trust store — defense-in-depth against forgotten keys.
+The `expires_at` field is optional. If present, the key is rejected after expiry even if still in the trust store — defense-in-depth against forgotten keys. The `trusted_since` field is recorded for audit purposes in v1 and is not enforced during verification.
 
 **Trust store permissions:** The trust store directory and key files should be writable only by root/admin. The verifier should log a warning if the trust store directory or any key file is world-writable, similar to SSH's `StrictModes`.
 
@@ -121,7 +121,7 @@ policies:
 
 **Relationship to existing manifest:** The SHA256 manifest (`policies.sha256`) becomes redundant when signing is in `enforce` mode. In `warn` or `off` mode, the manifest still provides integrity checking as a fallback. Both mechanisms coexist; no removal needed.
 
-**Implementation note:** The `Signing` sub-struct must be added to `PoliciesConfig` in `internal/config/config.go`. The `mode` field must be validated at config load time to be one of `"enforce"`, `"warn"`, or `"off"`.
+**Implementation note:** The `Signing` sub-struct must be added to `PoliciesConfig` in `internal/config/config.go`. The `mode` field must be validated at config load time to be one of `"enforce"`, `"warn"`, or `"off"`. The default mode is `"off"` when the `signing` configuration block is omitted.
 
 ### Scope: Which Policy Loading Paths
 
@@ -136,7 +136,7 @@ agentsh policy keygen --output <dir>
 ```
 
 - Generates an Ed25519 keypair
-- Writes private key to `<dir>/private.key` (mode 0600)
+- Writes private key to `<dir>/private.key.json` (mode 0600)
 - Writes public key in trust store format to `<dir>/public.key.json`
 - Prints the `key_id` to stdout
 
@@ -166,22 +166,25 @@ agentsh policy verify <policy-file> [--key-dir <trust-store>]
 
 ### Verification at Load Time
 
-When `PolicyManager` loads a policy:
+When `policy.Manager` loads a policy:
 
 1. Read policy bytes from disk
-2. Check `policies.signing.mode` — if `"off"`, skip to step 10
+2. Check `policies.signing.mode` — if `"off"`, skip to step 11
 3. Look for `<policy-path>.sig`
 4. **If `.sig` is missing:**
    - `"enforce"` mode: refuse to load, return error `"missing_signature"`
-   - `"warn"` mode: log warning, skip to step 10 (load without verification)
+   - `"warn"` mode: log warning, skip to step 11 (load without verification)
 5. Parse sig JSON and validate: reject if `version` is not `1`, `algorithm` is not `"ed25519"`, or `key_id`/`signature`/`signed_at` are missing/empty. If `cert_chain` is non-empty in v1, reject with `"unsupported_cert_chain"`
 6. Extract `key_id`, find matching public key in `trust_store` directory
 7. Check key expiry if `expires_at` is set
 8. Verify Ed25519 signature over raw policy bytes
-9. On success: log verification event, proceed with loading
+9. On success: log verification event, proceed to step 11
 10. On failure:
     - `"enforce"` mode: refuse to load, return error
-    - `"warn"` mode: log warning, proceed with loading
+    - `"warn"` mode: log warning, proceed to step 11
+11. Load the policy
+
+**Centralization note:** All policy loading call sites (including direct callers of `ResolvePolicyPath` such as session creation in `internal/api/core.go` and `DefaultPolicyLoader.Load` in `internal/api/app.go`) must be refactored to go through a shared verification function. The verification logic should not be duplicated.
 
 ### Watchtower Delivery Flow
 

--- a/docs/superpowers/specs/2026-03-18-policy-signing-design.md
+++ b/docs/superpowers/specs/2026-03-18-policy-signing-design.md
@@ -1,0 +1,227 @@
+# Policy File Signing Design
+
+## Summary
+
+Add Ed25519 detached signature support for agentsh policy files, enabling cryptographic proof of authorship and integrity. Signatures live in separate `.sig` files (JSON) alongside policy YAML files. Verification is configurable per-deployment (`enforce`, `warn`, `off`). The design is CA-ready: the format reserves fields for future certificate chain support without requiring it in v1.
+
+## Motivation
+
+Policy files control security-critical behavior: file access, network rules, command restrictions, signal handling, resource limits. The current integrity mechanism (SHA256 manifest) proves a file matches what an admin placed on disk, but cannot prove *who* authored it or protect against a compromised delivery channel.
+
+With watchtower policy distribution on the roadmap, signing becomes essential: agents must verify that policies came from a trusted authority, not a MITM or compromised server.
+
+### Threat Model
+
+1. **Tampered policies on disk** — an attacker modifies a policy after deployment
+2. **Untrusted delivery channel** — watchtower (or other transport) delivers policies over a network; signing proves provenance
+3. **Auditability** — verifiable chain of who signed what, when, and whether the signing key is still trusted
+
+## Design
+
+### Signature File Format
+
+For a policy file `<name>.yaml`, the detached signature lives at `<name>.yaml.sig` in the same directory.
+
+**Schema (JSON):**
+
+```json
+{
+  "version": 1,
+  "algorithm": "ed25519",
+  "key_id": "a1b2c3d4e5f67890",
+  "signer": "watchtower-prod",
+  "signed_at": "2026-03-18T12:00:00Z",
+  "signature": "base64-raw-url-encoded-ed25519-signature",
+  "cert_chain": []
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `version` | Schema version, currently `1`. Allows future evolution. |
+| `algorithm` | Always `"ed25519"` for v1. Present for forward-compat. |
+| `key_id` | Identifies which public key to verify against. Derived deterministically: `hex(SHA256(public_key_bytes))[:16]`. |
+| `signer` | Optional human-readable label (e.g., `"watchtower-prod"`). Informational only, not used for verification. |
+| `signed_at` | RFC 3339 timestamp of when the signature was produced. Used for audit trails and optional expiry checks. |
+| `signature` | Ed25519 signature over the raw bytes of the policy file, base64-raw-url encoded. |
+| `cert_chain` | Empty array in v1. Reserved for future CA hierarchy (intermediate certificates). |
+
+**What gets signed:** The exact bytes of the policy YAML file as read from disk. No normalization, no parsing. Ed25519 handles its own internal hashing.
+
+**Why JSON for sig files:** The sig file is machine-produced and machine-consumed. JSON is unambiguous to parse, has no YAML footguns (comments, anchors, aliases), and is the standard for structured metadata in signing systems. The policy stays YAML (human-authored). The sig is JSON (machine-authored).
+
+**Why detached (not inline):** Embedding a signature in YAML requires stripping the signature block before verification, which requires YAML canonicalization — a notoriously unreliable process. Detached signatures sign raw bytes, avoiding this entirely.
+
+### Key Management
+
+**Key types:**
+
+- **Signing key** — Ed25519 private key. Held by the signing authority (admin workstation, watchtower server, CI pipeline). Never distributed to agents.
+- **Verification key** — Ed25519 public key. Distributed to every agent as the trust anchor.
+
+**Key ID derivation:**
+
+```
+key_id = hex(SHA256(ed25519_public_key_bytes))[:16]
+```
+
+Deterministic from the public key. No ambiguity about which key a `key_id` refers to.
+
+**Trust store:**
+
+A directory of trusted public keys (default: `/etc/agentsh/keys/`). Each file contains one key:
+
+```json
+{
+  "key_id": "a1b2c3d4e5f67890",
+  "algorithm": "ed25519",
+  "public_key": "base64-encoded-32-byte-public-key",
+  "label": "watchtower-prod",
+  "trusted_since": "2026-03-18T00:00:00Z",
+  "expires_at": "2027-03-18T00:00:00Z"
+}
+```
+
+The `expires_at` field is optional. If present, the key is rejected after expiry even if still in the trust store — defense-in-depth against forgotten keys.
+
+**Key rotation:** Deploy the new public key to the trust store *before* signing with the new private key. Both old and new keys coexist. The `key_id` in the `.sig` file tells the verifier which key to use. Remove old keys once all policies are re-signed.
+
+### Configuration
+
+```yaml
+policies:
+  signing:
+    trust_store: "/etc/agentsh/keys/"
+    mode: "warn"  # "enforce" | "warn" | "off"
+```
+
+| Mode | Behavior |
+|------|----------|
+| `enforce` | Reject policies with missing or invalid signatures. Hard security boundary. |
+| `warn` | Verify if `.sig` exists, log warning on failure, load the policy anyway. |
+| `off` | Skip signature verification entirely. |
+
+**Relationship to existing manifest:** The SHA256 manifest (`policies.sha256`) becomes redundant when signing is in `enforce` mode. In `warn` or `off` mode, the manifest still provides integrity checking as a fallback. Both mechanisms coexist; no removal needed.
+
+### CLI Commands
+
+**Key generation:**
+
+```bash
+agentsh policy keygen --output <dir>
+```
+
+- Generates an Ed25519 keypair
+- Writes private key to `<dir>/private.key` (mode 0600)
+- Writes public key in trust store format to `<dir>/public.key.json`
+- Prints the `key_id` to stdout
+
+**Signing:**
+
+```bash
+agentsh policy sign <policy-file> --key <private-key-file>
+```
+
+- Reads raw bytes of `<policy-file>`
+- Signs with the Ed25519 private key
+- Writes `<policy-file>.sig` alongside it
+- Overwrites existing `.sig` (re-signing after edits)
+- Optional: `--output <path>` for custom sig path, `--signer <label>` for the signer field
+
+**Verification:**
+
+```bash
+agentsh policy verify <policy-file> [--key-dir <trust-store>]
+```
+
+- Reads `<policy-file>` and `<policy-file>.sig`
+- Looks up `key_id` in the trust store
+- Verifies Ed25519 signature against raw file bytes
+- Prints result and exits 0 on valid, non-zero otherwise
+- Useful for CI pipelines and manual checks
+
+### Verification at Load Time
+
+When `PolicyManager` loads a policy:
+
+1. Read policy bytes from disk
+2. Check `policies.signing.mode` — if `"off"`, skip to step 8
+3. Look for `<policy-path>.sig`
+4. Parse sig JSON, extract `key_id`
+5. Find matching public key in `trust_store` directory
+6. Check key expiry if `expires_at` is set
+7. Verify Ed25519 signature over raw policy bytes
+8. On success: log verification event, proceed with loading
+9. On failure:
+   - `"enforce"` mode: refuse to load, return error
+   - `"warn"` mode: log warning, proceed with loading
+
+### Watchtower Delivery Flow
+
+When watchtower distributes a policy update:
+
+1. Watchtower signs the policy (holds the private key, runs the same signing logic as `agentsh policy sign`)
+2. Delivers both files: `<policy>.yaml` + `<policy>.yaml.sig`
+3. Agent writes both to a **staging directory** (`/etc/agentsh/policies/.staging/`) — not directly into the live policy dir
+4. Agent verifies the signature against its trust store
+5. **On success:** atomically moves both files into the live policy directory, logs the update
+6. **On failure:** rejects the update, logs the failure with details (unknown key, bad signature, missing sig), keeps existing policy
+7. The existing `reload_interval` timer picks up the new policy — or watchtower triggers an immediate reload
+
+**Why staging:** The agent never loads an unverified policy, even transiently. Writing directly to the policy dir risks a race where the policy manager reads the new YAML before the `.sig` arrives.
+
+**Trust bootstrapping:** The trust store must be provisioned during agent installation. The watchtower server's public key is part of the agent's initial configuration.
+
+### Audit Trail
+
+Every signature verification produces an audit event:
+
+```json
+{
+  "event": "policy.signature.verified",
+  "policy": "agent-sandbox",
+  "key_id": "a1b2c3d4e5f67890",
+  "signer": "watchtower-prod",
+  "signed_at": "2026-03-18T12:00:00Z",
+  "verified_at": "2026-03-18T12:05:00Z",
+  "result": "valid"
+}
+```
+
+Failure events include the reason: `"invalid_signature"`, `"unknown_key"`, `"missing_signature"`, `"expired_key"`.
+
+This integrates with the existing audit system — `PolicyVersion()` can incorporate `key_id` and `signed_at` to detect re-signing events, not just content changes.
+
+### Key Revocation
+
+**V1 (simple):** Remove the public key file from the trust store. On next policy load, policies signed with that key fail with `"unknown_key"`.
+
+**Key expiry (optional):** The `expires_at` field provides time-based revocation. A forgotten key eventually stops being trusted without manual intervention.
+
+**Future:** V2 could add CRL or OCSP-like mechanisms if the CA hierarchy is implemented.
+
+### Future: CA Hierarchy
+
+The format is designed to support this without breaking changes:
+
+- `cert_chain` in the sig file would contain intermediate certificates
+- Trust store would hold root CA public keys
+- Verification would walk the chain: sig → intermediate → root
+- V1 requires `cert_chain` to be empty; v2 adds chain validation logic
+
+No work needed now — the extension points are in place.
+
+## Testing Strategy
+
+- Unit tests for signing and verification (valid, tampered, wrong key, expired key, missing sig)
+- Unit tests for trust store loading and key lookup
+- Integration tests for policy manager verification at load time (all three modes)
+- Integration tests for the CLI commands (keygen, sign, verify)
+- Test key rotation scenario (two keys in trust store, sign with new, verify both)
+
+## Dependencies
+
+- `crypto/ed25519` (Go stdlib) — signing and verification
+- `crypto/sha256` (Go stdlib) — key ID derivation
+- `encoding/json` (Go stdlib) — sig file and trust store parsing
+- No external dependencies required

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -1441,19 +1441,26 @@ func (l *DefaultPolicyLoader) Load(name string) (*policy.Engine, error) {
 	}
 
 	// Signature verification
-	if l.signingMode != "" && l.signingMode != "off" && l.trustStorePath != "" {
-		ts, tsErr := signing.LoadTrustStore(l.trustStorePath)
-		if tsErr != nil {
+	if l.signingMode != "" && l.signingMode != "off" {
+		if l.trustStorePath == "" {
 			if l.signingMode == "enforce" {
-				return nil, fmt.Errorf("load trust store for %q: %w", name, tsErr)
+				return nil, fmt.Errorf("signing verification for %q: trust_store not configured", name)
 			}
-			fmt.Fprintf(os.Stderr, "WARNING: policy %q: failed to load trust store: %v\n", name, tsErr)
+			fmt.Fprintf(os.Stderr, "WARNING: policy %q: signing mode is %q but trust_store not configured\n", name, l.signingMode)
 		} else {
-			if _, vErr := signing.VerifyPolicyBytes(policyBytes, path+".sig", ts); vErr != nil {
+			ts, tsErr := signing.LoadTrustStore(l.trustStorePath)
+			if tsErr != nil {
 				if l.signingMode == "enforce" {
-					return nil, fmt.Errorf("signing verification for %q: %w", name, vErr)
+					return nil, fmt.Errorf("load trust store for %q: %w", name, tsErr)
 				}
-				fmt.Fprintf(os.Stderr, "WARNING: policy %q signing verification failed: %v\n", name, vErr)
+				fmt.Fprintf(os.Stderr, "WARNING: policy %q: failed to load trust store: %v\n", name, tsErr)
+			} else {
+				if _, vErr := signing.VerifyPolicyBytes(policyBytes, path+".sig", ts); vErr != nil {
+					if l.signingMode == "enforce" {
+						return nil, fmt.Errorf("signing verification for %q: %w", name, vErr)
+					}
+					fmt.Fprintf(os.Stderr, "WARNING: policy %q signing verification failed: %v\n", name, vErr)
+				}
 			}
 		}
 	}

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -1448,7 +1448,7 @@ func (l *DefaultPolicyLoader) Load(name string) (*policy.Engine, error) {
 			}
 			fmt.Fprintf(os.Stderr, "WARNING: policy %q: signing mode is %q but trust_store not configured\n", name, l.signingMode)
 		} else {
-			ts, tsErr := signing.LoadTrustStore(l.trustStorePath)
+			ts, tsErr := signing.LoadTrustStore(l.trustStorePath, l.signingMode == "enforce")
 			if tsErr != nil {
 				if l.signingMode == "enforce" {
 					return nil, fmt.Errorf("load trust store for %q: %w", name, tsErr)

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -28,6 +28,7 @@ import (
 	"github.com/agentsh/agentsh/internal/platform"
 	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/internal/pkgcheck"
+	"github.com/agentsh/agentsh/internal/policy/signing"
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/internal/store/composite"
 	"github.com/agentsh/agentsh/internal/trash"
@@ -1409,14 +1410,18 @@ type DefaultPolicyLoader struct {
 	policyDir        string
 	enforceApprovals bool
 	enforceRedirects bool
+	signingMode      string
+	trustStorePath   string
 }
 
 // NewDefaultPolicyLoader creates a policy loader that loads from the given directory.
-func NewDefaultPolicyLoader(policyDir string, enforceApprovals bool, enforceRedirects bool) *DefaultPolicyLoader {
+func NewDefaultPolicyLoader(policyDir string, enforceApprovals, enforceRedirects bool, signingMode, trustStorePath string) *DefaultPolicyLoader {
 	return &DefaultPolicyLoader{
 		policyDir:        policyDir,
 		enforceApprovals: enforceApprovals,
 		enforceRedirects: enforceRedirects,
+		signingMode:      signingMode,
+		trustStorePath:   trustStorePath,
 	}
 }
 
@@ -1433,6 +1438,26 @@ func (l *DefaultPolicyLoader) Load(name string) (*policy.Engine, error) {
 	if err != nil {
 		return nil, fmt.Errorf("load policy %q: %w", name, err)
 	}
+
+	// Signature verification
+	if l.signingMode != "" && l.signingMode != "off" && l.trustStorePath != "" {
+		ts, tsErr := signing.LoadTrustStore(l.trustStorePath)
+		if tsErr != nil {
+			if l.signingMode == "enforce" {
+				return nil, fmt.Errorf("load trust store for %q: %w", name, tsErr)
+			}
+			fmt.Fprintf(os.Stderr, "WARNING: policy %q: failed to load trust store: %v\n", name, tsErr)
+		} else {
+			policyBytes, _ := os.ReadFile(path)
+			if _, vErr := signing.VerifyPolicyBytes(policyBytes, path+".sig", ts); vErr != nil {
+				if l.signingMode == "enforce" {
+					return nil, fmt.Errorf("signing verification for %q: %w", name, vErr)
+				}
+				fmt.Fprintf(os.Stderr, "WARNING: policy %q signing verification failed: %v\n", name, vErr)
+			}
+		}
+	}
+
 	engine, err := policy.NewEngine(p, l.enforceApprovals, l.enforceRedirects)
 	if err != nil {
 		return nil, fmt.Errorf("create policy engine for %q: %w", name, err)

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -1434,9 +1434,10 @@ func (l *DefaultPolicyLoader) Load(name string) (*policy.Engine, error) {
 	if err != nil {
 		return nil, fmt.Errorf("resolve policy %q: %w", name, err)
 	}
-	p, err := policy.LoadFromFile(path)
+
+	policyBytes, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("load policy %q: %w", name, err)
+		return nil, fmt.Errorf("read policy %q: %w", name, err)
 	}
 
 	// Signature verification
@@ -1448,7 +1449,6 @@ func (l *DefaultPolicyLoader) Load(name string) (*policy.Engine, error) {
 			}
 			fmt.Fprintf(os.Stderr, "WARNING: policy %q: failed to load trust store: %v\n", name, tsErr)
 		} else {
-			policyBytes, _ := os.ReadFile(path)
 			if _, vErr := signing.VerifyPolicyBytes(policyBytes, path+".sig", ts); vErr != nil {
 				if l.signingMode == "enforce" {
 					return nil, fmt.Errorf("signing verification for %q: %w", name, vErr)
@@ -1458,6 +1458,10 @@ func (l *DefaultPolicyLoader) Load(name string) (*policy.Engine, error) {
 		}
 	}
 
+	p, err := policy.LoadFromBytes(policyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("load policy %q: %w", name, err)
+	}
 	engine, err := policy.NewEngine(p, l.enforceApprovals, l.enforceRedirects)
 	if err != nil {
 		return nil, fmt.Errorf("create policy engine for %q: %w", name, err)

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -1321,15 +1321,19 @@ func (a *App) ensureFUSEMount(ctx context.Context, s *session.Session) {
 								slog.Error("ensureFUSEMount: trust store load failed", "error", tsErr)
 								return
 							}
+							slog.Warn("ensureFUSEMount: trust store load failed", "error", tsErr)
 						} else if _, vErr := signing.VerifyPolicyBytes(policyData, policyPath+".sig", ts); vErr != nil {
 							if sigMode == "enforce" {
 								slog.Error("ensureFUSEMount: policy signing verification failed", "error", vErr)
 								return
 							}
+							slog.Warn("ensureFUSEMount: policy signing verification failed", "error", vErr)
 						}
 					} else if sigMode == "enforce" {
 						slog.Error("ensureFUSEMount: signing mode is enforce but trust_store not configured")
 						return
+					} else {
+						slog.Warn("ensureFUSEMount: signing mode is set but trust_store not configured", "mode", sigMode)
 					}
 				}
 

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -1309,15 +1309,40 @@ func (a *App) ensureFUSEMount(ctx context.Context, s *session.Session) {
 	if a.cfg.Policies.Dir != "" {
 		policyPath, pErr := policy.ResolvePolicyPath(a.cfg.Policies.Dir, s.Policy)
 		if pErr == nil {
-			pol, lErr := policy.LoadFromFile(policyPath)
-			if lErr == nil {
-				policyVars := map[string]string{
-					"PROJECT_ROOT": s.Workspace,
-					"GIT_ROOT":     s.Workspace,
-					"HOME":         os.Getenv("HOME"),
+			policyData, rErr := os.ReadFile(policyPath)
+			if rErr == nil {
+				// Signature verification (same flow as session creation)
+				sigMode := a.cfg.Policies.Signing.SigningMode()
+				if sigMode != "off" {
+					if a.cfg.Policies.Signing.TrustStore != "" {
+						ts, tsErr := signing.LoadTrustStore(a.cfg.Policies.Signing.TrustStore, sigMode == "enforce")
+						if tsErr != nil {
+							if sigMode == "enforce" {
+								slog.Error("ensureFUSEMount: trust store load failed", "error", tsErr)
+								return
+							}
+						} else if _, vErr := signing.VerifyPolicyBytes(policyData, policyPath+".sig", ts); vErr != nil {
+							if sigMode == "enforce" {
+								slog.Error("ensureFUSEMount: policy signing verification failed", "error", vErr)
+								return
+							}
+						}
+					} else if sigMode == "enforce" {
+						slog.Error("ensureFUSEMount: signing mode is enforce but trust_store not configured")
+						return
+					}
 				}
-				enforceApprovals := a.cfg.Approvals.Enabled && a.cfg.Approvals.Mode != ""
-				engine, _ = policy.NewEngineWithVariables(pol, enforceApprovals, true, policyVars)
+
+				pol, lErr := policy.LoadFromBytes(policyData)
+				if lErr == nil {
+					policyVars := map[string]string{
+						"PROJECT_ROOT": s.Workspace,
+						"GIT_ROOT":     s.Workspace,
+						"HOME":         os.Getenv("HOME"),
+					}
+					enforceApprovals := a.cfg.Approvals.Enabled && a.cfg.Approvals.Mode != ""
+					engine, _ = policy.NewEngineWithVariables(pol, enforceApprovals, true, policyVars)
+				}
 			}
 		}
 	}

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -589,19 +589,26 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 
 		// Signature verification
 		sigMode := a.cfg.Policies.Signing.SigningMode()
-		if sigMode != "off" && a.cfg.Policies.Signing.TrustStore != "" {
-			ts, tsErr := signing.LoadTrustStore(a.cfg.Policies.Signing.TrustStore)
-			if tsErr != nil {
+		if sigMode != "off" {
+			if a.cfg.Policies.Signing.TrustStore == "" {
 				if sigMode == "enforce" {
-					return types.Session{}, http.StatusInternalServerError, fmt.Errorf("load trust store: %w", tsErr)
+					return types.Session{}, http.StatusInternalServerError, fmt.Errorf("signing mode is enforce but trust_store not configured")
 				}
-				fmt.Fprintf(os.Stderr, "WARNING: failed to load trust store: %v\n", tsErr)
+				fmt.Fprintf(os.Stderr, "WARNING: signing mode is %q but trust_store not configured\n", sigMode)
 			} else {
-				if _, vErr := signing.VerifyPolicyBytes(policyData, policyPath+".sig", ts); vErr != nil {
+				ts, tsErr := signing.LoadTrustStore(a.cfg.Policies.Signing.TrustStore)
+				if tsErr != nil {
 					if sigMode == "enforce" {
-						return types.Session{}, http.StatusForbidden, fmt.Errorf("policy signing: %w", vErr)
+						return types.Session{}, http.StatusInternalServerError, fmt.Errorf("load trust store: %w", tsErr)
 					}
-					fmt.Fprintf(os.Stderr, "WARNING: policy signing verification failed: %v\n", vErr)
+					fmt.Fprintf(os.Stderr, "WARNING: failed to load trust store: %v\n", tsErr)
+				} else {
+					if _, vErr := signing.VerifyPolicyBytes(policyData, policyPath+".sig", ts); vErr != nil {
+						if sigMode == "enforce" {
+							return types.Session{}, http.StatusForbidden, fmt.Errorf("policy signing: %w", vErr)
+						}
+						fmt.Fprintf(os.Stderr, "WARNING: policy signing verification failed: %v\n", vErr)
+					}
 				}
 			}
 		}

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -606,7 +606,7 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 			}
 		}
 
-		pol, err := policy.LoadFromFile(policyPath)
+		pol, err := policy.LoadFromBytes(policyData)
 		if err != nil {
 			return types.Session{}, http.StatusInternalServerError, fmt.Errorf("load policy: %w", err)
 		}

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -596,7 +596,7 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 				}
 				fmt.Fprintf(os.Stderr, "WARNING: signing mode is %q but trust_store not configured\n", sigMode)
 			} else {
-				ts, tsErr := signing.LoadTrustStore(a.cfg.Policies.Signing.TrustStore)
+				ts, tsErr := signing.LoadTrustStore(a.cfg.Policies.Signing.TrustStore, sigMode == "enforce")
 				if tsErr != nil {
 					if sigMode == "enforce" {
 						return types.Session{}, http.StatusInternalServerError, fmt.Errorf("load trust store: %w", tsErr)

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -23,6 +23,7 @@ import (
 	"github.com/agentsh/agentsh/internal/pkgcheck"
 	"github.com/agentsh/agentsh/internal/platform"
 	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/policy/signing"
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/internal/signal"
 	"github.com/agentsh/agentsh/pkg/types"
@@ -578,6 +579,31 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 		policyPath, err := policy.ResolvePolicyPath(a.cfg.Policies.Dir, policyName)
 		if err != nil {
 			return types.Session{}, http.StatusBadRequest, fmt.Errorf("resolve policy: %w", err)
+		}
+
+		// Read raw bytes for signing verification
+		policyData, err := os.ReadFile(policyPath)
+		if err != nil {
+			return types.Session{}, http.StatusInternalServerError, fmt.Errorf("read policy: %w", err)
+		}
+
+		// Signature verification
+		sigMode := a.cfg.Policies.Signing.SigningMode()
+		if sigMode != "off" && a.cfg.Policies.Signing.TrustStore != "" {
+			ts, tsErr := signing.LoadTrustStore(a.cfg.Policies.Signing.TrustStore)
+			if tsErr != nil {
+				if sigMode == "enforce" {
+					return types.Session{}, http.StatusInternalServerError, fmt.Errorf("load trust store: %w", tsErr)
+				}
+				fmt.Fprintf(os.Stderr, "WARNING: failed to load trust store: %v\n", tsErr)
+			} else {
+				if _, vErr := signing.VerifyPolicyBytes(policyData, policyPath+".sig", ts); vErr != nil {
+					if sigMode == "enforce" {
+						return types.Session{}, http.StatusForbidden, fmt.Errorf("policy signing: %w", vErr)
+					}
+					fmt.Fprintf(os.Stderr, "WARNING: policy signing verification failed: %v\n", vErr)
+				}
+			}
 		}
 
 		pol, err := policy.LoadFromFile(policyPath)

--- a/internal/cli/policy_cmd.go
+++ b/internal/cli/policy_cmd.go
@@ -256,7 +256,7 @@ Examples:
 			if verifyKeyDir == "" {
 				return fmt.Errorf("--key-dir is required")
 			}
-			ts, err := signing.LoadTrustStore(verifyKeyDir)
+			ts, err := signing.LoadTrustStore(verifyKeyDir, false)
 			if err != nil {
 				return fmt.Errorf("load trust store: %w", err)
 			}

--- a/internal/cli/policy_cmd.go
+++ b/internal/cli/policy_cmd.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/internal/policygen"
+	"github.com/agentsh/agentsh/internal/policy/signing"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -192,6 +193,87 @@ Examples:
 	generateCmd.Flags().StringVar(&genDBPath, "db-path", "", "Path to events database")
 
 	cmd.AddCommand(generateCmd)
+
+	// Keygen subcommand
+	var keygenOutput string
+	var keygenLabel string
+	keygenCmd := &cobra.Command{
+		Use:   "keygen",
+		Short: "Generate an Ed25519 signing keypair",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outDir := keygenOutput
+			if outDir == "" {
+				outDir = "."
+			}
+			kid, err := signing.GenerateKeypair(outDir, keygenLabel)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\n", kid)
+			fmt.Fprintf(cmd.ErrOrStderr(), "Keypair written to %s/\n", outDir)
+			return nil
+		},
+	}
+	keygenCmd.Flags().StringVar(&keygenOutput, "output", "", "Output directory (default: current dir)")
+	keygenCmd.Flags().StringVar(&keygenLabel, "label", "", "Human-readable label for the key")
+	cmd.AddCommand(keygenCmd)
+
+	// Sign subcommand
+	var signKey string
+	var signOutput string
+	var signSigner string
+	signCmd := &cobra.Command{
+		Use:   "sign POLICY_FILE",
+		Short: "Sign a policy file with an Ed25519 private key",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if signKey == "" {
+				return fmt.Errorf("--key is required")
+			}
+			if err := signing.SignFile(args[0], signKey, signOutput, signSigner); err != nil {
+				return err
+			}
+			dest := signOutput
+			if dest == "" {
+				dest = args[0] + ".sig"
+			}
+			fmt.Fprintf(cmd.ErrOrStderr(), "Signature written to %s\n", dest)
+			return nil
+		},
+	}
+	signCmd.Flags().StringVar(&signKey, "key", "", "Path to private key file (required)")
+	signCmd.Flags().StringVar(&signOutput, "output", "", "Output path for .sig file (default: <policy>.sig)")
+	signCmd.Flags().StringVar(&signSigner, "signer", "", "Human-readable signer label")
+	cmd.AddCommand(signCmd)
+
+	// Verify subcommand
+	var verifyKeyDir string
+	verifyCmd := &cobra.Command{
+		Use:   "verify POLICY_FILE",
+		Short: "Verify a policy file signature",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if verifyKeyDir == "" {
+				return fmt.Errorf("--key-dir is required")
+			}
+			ts, err := signing.LoadTrustStore(verifyKeyDir)
+			if err != nil {
+				return fmt.Errorf("load trust store: %w", err)
+			}
+			result, err := signing.VerifyPolicy(args[0], ts)
+			if err != nil {
+				return fmt.Errorf("verification failed: %w", err)
+			}
+			return printJSON(cmd, map[string]any{
+				"status":    "valid",
+				"key_id":    result.KeyID,
+				"signer":    result.Signer,
+				"signed_at": result.SignedAt,
+			})
+		},
+	}
+	verifyCmd.Flags().StringVar(&verifyKeyDir, "key-dir", "", "Path to trust store directory (required)")
+	cmd.AddCommand(verifyCmd)
 
 	return cmd
 }

--- a/internal/cli/policy_signing_test.go
+++ b/internal/cli/policy_signing_test.go
@@ -38,8 +38,12 @@ func TestPolicySignAndVerify(t *testing.T) {
 	if _, err := os.Stat(policyPath + ".sig"); err != nil {
 		t.Fatal("sig file not created")
 	}
+	// Use a separate trust store dir with only the public key
+	tsDir := t.TempDir()
+	pubData, _ := os.ReadFile(filepath.Join(dir, "public.key.json"))
+	os.WriteFile(filepath.Join(tsDir, "key.json"), pubData, 0o644)
 	cmd = newPolicyCmd()
-	cmd.SetArgs([]string{"verify", policyPath, "--key-dir", dir})
+	cmd.SetArgs([]string{"verify", policyPath, "--key-dir", tsDir})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("verify failed: %v", err)
 	}

--- a/internal/cli/policy_signing_test.go
+++ b/internal/cli/policy_signing_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPolicyKeygen(t *testing.T) {
+	dir := t.TempDir()
+	cmd := newPolicyCmd()
+	cmd.SetArgs([]string{"keygen", "--output", dir, "--label", "test"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("keygen failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "private.key.json")); err != nil {
+		t.Fatal("private key not created")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "public.key.json")); err != nil {
+		t.Fatal("public key not created")
+	}
+}
+
+func TestPolicySignAndVerify(t *testing.T) {
+	dir := t.TempDir()
+	cmd := newPolicyCmd()
+	cmd.SetArgs([]string{"keygen", "--output", dir, "--label", "test"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	policyPath := filepath.Join(dir, "test.yaml")
+	os.WriteFile(policyPath, []byte("version: 1\nname: test\n"), 0o644)
+	cmd = newPolicyCmd()
+	cmd.SetArgs([]string{"sign", policyPath, "--key", filepath.Join(dir, "private.key.json")})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("sign failed: %v", err)
+	}
+	if _, err := os.Stat(policyPath + ".sig"); err != nil {
+		t.Fatal("sig file not created")
+	}
+	cmd = newPolicyCmd()
+	cmd.SetArgs([]string{"verify", policyPath, "--key-dir", dir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("verify failed: %v", err)
+	}
+}
+
+func TestPolicyVerify_MissingSig(t *testing.T) {
+	dir := t.TempDir()
+	policyPath := filepath.Join(dir, "test.yaml")
+	os.WriteFile(policyPath, []byte("version: 1\nname: test\n"), 0o644)
+	cmd := newPolicyCmd()
+	cmd.SetArgs([]string{"verify", policyPath, "--key-dir", dir})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for missing sig")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -687,12 +687,41 @@ type CapabilitiesConfig struct {
 	Allow []string `yaml:"allow"` // Capabilities to keep (empty = drop all droppable)
 }
 
+// SigningConfig configures policy signature verification.
+type SigningConfig struct {
+	TrustStore string `yaml:"trust_store"` // Directory of trusted public keys
+	Mode       string `yaml:"mode"`        // "enforce", "warn", or "off" (default: "off")
+}
+
+// SigningMode returns the effective signing mode, defaulting to "off".
+func (c *SigningConfig) SigningMode() string {
+	if c.Mode == "" {
+		return "off"
+	}
+	return c.Mode
+}
+
+// Validate checks that the signing config has valid values.
+func (c *SigningConfig) Validate() error {
+	switch c.Mode {
+	case "", "off", "warn", "enforce":
+		// valid
+	default:
+		return fmt.Errorf("invalid signing mode %q: must be \"enforce\", \"warn\", or \"off\"", c.Mode)
+	}
+	if (c.Mode == "enforce" || c.Mode == "warn") && c.TrustStore == "" {
+		return fmt.Errorf("signing.trust_store is required when signing.mode is %q", c.Mode)
+	}
+	return nil
+}
+
 // PoliciesConfig configures policy loading.
 type PoliciesConfig struct {
 	Dir               string          `yaml:"dir"`
 	Default           string          `yaml:"default"`
 	Allowed           []string        `yaml:"allowed"`
 	ManifestPath      string          `yaml:"manifest_path"`
+	Signing           SigningConfig   `yaml:"signing"`
 	EnvPolicy         EnvPolicyConfig `yaml:"env_policy"`
 	EnvShimPath       string          `yaml:"env_shim_path"`
 	ReloadInterval    string          `yaml:"reload_interval"`

--- a/internal/config/signing_test.go
+++ b/internal/config/signing_test.go
@@ -1,0 +1,48 @@
+package config
+
+import "testing"
+
+func TestSigningConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     SigningConfig
+		wantErr bool
+	}{
+		{"empty is valid", SigningConfig{}, false},
+		{"off is valid", SigningConfig{Mode: "off"}, false},
+		{"warn with trust store", SigningConfig{Mode: "warn", TrustStore: "/keys"}, false},
+		{"enforce with trust store", SigningConfig{Mode: "enforce", TrustStore: "/keys"}, false},
+		{"invalid mode", SigningConfig{Mode: "strict"}, true},
+		{"enforce without trust store", SigningConfig{Mode: "enforce"}, true},
+		{"warn without trust store", SigningConfig{Mode: "warn"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestSigningConfig_SigningMode(t *testing.T) {
+	tests := []struct {
+		mode string
+		want string
+	}{
+		{"", "off"},
+		{"off", "off"},
+		{"warn", "warn"},
+		{"enforce", "enforce"},
+	}
+	for _, tt := range tests {
+		cfg := SigningConfig{Mode: tt.mode}
+		if got := cfg.SigningMode(); got != tt.want {
+			t.Errorf("SigningMode(%q) = %q, want %q", tt.mode, got, tt.want)
+		}
+	}
+}

--- a/internal/policy/load.go
+++ b/internal/policy/load.go
@@ -14,7 +14,11 @@ func LoadFromFile(path string) (*Policy, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read policy: %w", err)
 	}
+	return LoadFromBytes(b)
+}
 
+// LoadFromBytes parses and validates a policy from raw YAML bytes.
+func LoadFromBytes(b []byte) (*Policy, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(b))
 	dec.KnownFields(true)
 	var p Policy

--- a/internal/policy/manager.go
+++ b/internal/policy/manager.go
@@ -86,7 +86,13 @@ func (m *Manager) Get() (*Policy, error) {
 			}
 		}
 		if m.signingMode != "" && m.signingMode != "off" {
-			if err := m.verifySigning(path, data); err != nil {
+			if m.trustStorePath == "" {
+				if m.signingMode == "enforce" {
+					m.err = fmt.Errorf("signing verification: trust_store not configured")
+					return
+				}
+				fmt.Fprintf(os.Stderr, "WARNING: signing mode is %q but trust_store not configured\n", m.signingMode)
+			} else if err := m.verifySigning(path, data); err != nil {
 				if m.signingMode == "enforce" {
 					m.err = fmt.Errorf("signing verification: %w", err)
 					return

--- a/internal/policy/manager.go
+++ b/internal/policy/manager.go
@@ -111,7 +111,7 @@ func (m *Manager) Get() (*Policy, error) {
 }
 
 func (m *Manager) verifySigning(path string, data []byte) error {
-	ts, err := signing.LoadTrustStore(m.trustStorePath)
+	ts, err := signing.LoadTrustStore(m.trustStorePath, m.signingMode == "enforce")
 	if err != nil {
 		return fmt.Errorf("load trust store: %w", err)
 	}

--- a/internal/policy/manager.go
+++ b/internal/policy/manager.go
@@ -11,16 +11,20 @@ import (
 	"sync"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/agentsh/agentsh/internal/policy/signing"
 )
 
 // Manager selects and loads a policy once, based on config and env.
 type Manager struct {
-	selectedName string
-	dir          string
-	manifestPath string
-	once         sync.Once
-	policy       *Policy
-	err          error
+	selectedName   string
+	dir            string
+	manifestPath   string
+	signingMode    string
+	trustStorePath string
+	once           sync.Once
+	policy         *Policy
+	err            error
 }
 
 var nameRe = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
@@ -55,6 +59,13 @@ func (m *Manager) SelectedName() string {
 	return m.selectedName
 }
 
+// SetSigningConfig configures signature verification for this manager.
+// mode is "enforce", "warn", or "off". trustStorePath is a directory of public key JSON files.
+func (m *Manager) SetSigningConfig(mode, trustStorePath string) {
+	m.signingMode = mode
+	m.trustStorePath = trustStorePath
+}
+
 // Get loads and returns the active policy, caching the result.
 func (m *Manager) Get() (*Policy, error) {
 	m.once.Do(func() {
@@ -74,6 +85,15 @@ func (m *Manager) Get() (*Policy, error) {
 				return
 			}
 		}
+		if m.signingMode != "" && m.signingMode != "off" {
+			if err := m.verifySigning(path, data); err != nil {
+				if m.signingMode == "enforce" {
+					m.err = fmt.Errorf("signing verification: %w", err)
+					return
+				}
+				fmt.Fprintf(os.Stderr, "WARNING: policy signing verification failed: %v\n", err)
+			}
+		}
 		dec := yaml.NewDecoder(bytes.NewReader(data))
 		dec.KnownFields(true)
 		var p Policy
@@ -88,6 +108,15 @@ func (m *Manager) Get() (*Policy, error) {
 		m.policy = &p
 	})
 	return m.policy, m.err
+}
+
+func (m *Manager) verifySigning(path string, data []byte) error {
+	ts, err := signing.LoadTrustStore(m.trustStorePath)
+	if err != nil {
+		return fmt.Errorf("load trust store: %w", err)
+	}
+	_, err = signing.VerifyPolicyBytes(data, path+".sig", ts)
+	return err
 }
 
 func verifyHash(path string, data []byte, manifestPath string) error {

--- a/internal/policy/manager_test.go
+++ b/internal/policy/manager_test.go
@@ -186,3 +186,106 @@ func TestManager_SigningOff(t *testing.T) {
 		t.Fatalf("expected p, got %s", p.Name)
 	}
 }
+
+// setupSignedPolicyDir creates a policy, signs it, and returns (policyDir, trustStoreDir).
+func setupSignedPolicyDir(t *testing.T, policyName, policyContent string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	writePolicy(t, dir, policyName+".yaml", policyContent)
+	keyDir := t.TempDir()
+	_, err := signing.GenerateKeypair(keyDir, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := signing.SignFile(filepath.Join(dir, policyName+".yaml"), filepath.Join(keyDir, "private.key.json"), "", ""); err != nil {
+		t.Fatal(err)
+	}
+	tsDir := t.TempDir()
+	pubData, _ := os.ReadFile(filepath.Join(keyDir, "public.key.json"))
+	os.WriteFile(filepath.Join(tsDir, "key.json"), pubData, 0o644)
+	return dir, tsDir
+}
+
+func TestManager_SigningEnforce_TamperedPolicy(t *testing.T) {
+	dir, tsDir := setupSignedPolicyDir(t, "p", "version: 1\nname: p\n")
+	// Tamper with the policy after signing
+	os.WriteFile(filepath.Join(dir, "p.yaml"), []byte("version: 1\nname: tampered\n"), 0o644)
+	m := NewManager(dir, "p", []string{"p"}, "", "p")
+	m.SetSigningConfig("enforce", tsDir)
+	_, err := m.Get()
+	if err == nil {
+		t.Fatal("expected error for tampered policy in enforce mode")
+	}
+}
+
+func TestManager_SigningWarn_TamperedPolicy(t *testing.T) {
+	dir, tsDir := setupSignedPolicyDir(t, "p", "version: 1\nname: p\n")
+	// Tamper with the policy after signing
+	os.WriteFile(filepath.Join(dir, "p.yaml"), []byte("version: 1\nname: tampered\n"), 0o644)
+	m := NewManager(dir, "p", []string{"p"}, "", "p")
+	m.SetSigningConfig("warn", tsDir)
+	p, err := m.Get()
+	if err != nil {
+		t.Fatalf("warn mode should still load tampered policy, got %v", err)
+	}
+	if p.Name != "tampered" {
+		t.Fatalf("expected tampered, got %s", p.Name)
+	}
+}
+
+func TestManager_SigningEnforce_WrongKey(t *testing.T) {
+	dir, _ := setupSignedPolicyDir(t, "p", "version: 1\nname: p\n")
+	// Create a different trust store with unrelated key
+	otherKeyDir := t.TempDir()
+	signing.GenerateKeypair(otherKeyDir, "other")
+	otherTsDir := t.TempDir()
+	pubData, _ := os.ReadFile(filepath.Join(otherKeyDir, "public.key.json"))
+	os.WriteFile(filepath.Join(otherTsDir, "key.json"), pubData, 0o644)
+
+	m := NewManager(dir, "p", []string{"p"}, "", "p")
+	m.SetSigningConfig("enforce", otherTsDir)
+	_, err := m.Get()
+	if err == nil {
+		t.Fatal("expected error for wrong key in enforce mode")
+	}
+}
+
+func TestManager_SigningEnforce_EmptyTrustStore(t *testing.T) {
+	dir := t.TempDir()
+	writePolicy(t, dir, "p.yaml", "version: 1\nname: p\n")
+	m := NewManager(dir, "p", []string{"p"}, "", "p")
+	m.SetSigningConfig("enforce", "")
+	_, err := m.Get()
+	if err == nil {
+		t.Fatal("expected error for enforce mode with empty trust store")
+	}
+}
+
+func TestManager_SigningWarn_EmptyTrustStore(t *testing.T) {
+	dir := t.TempDir()
+	writePolicy(t, dir, "p.yaml", "version: 1\nname: p\n")
+	m := NewManager(dir, "p", []string{"p"}, "", "p")
+	m.SetSigningConfig("warn", "")
+	p, err := m.Get()
+	if err != nil {
+		t.Fatalf("warn mode with empty trust store should still load, got %v", err)
+	}
+	if p.Name != "p" {
+		t.Fatalf("expected p, got %s", p.Name)
+	}
+}
+
+func TestManager_SigningOff_UnsignedPolicy(t *testing.T) {
+	dir := t.TempDir()
+	writePolicy(t, dir, "p.yaml", "version: 1\nname: p\n")
+	// No signing, no sig file — off mode should not care
+	m := NewManager(dir, "p", []string{"p"}, "", "p")
+	m.SetSigningConfig("off", "/nonexistent")
+	p, err := m.Get()
+	if err != nil {
+		t.Fatalf("off mode should always load, got %v", err)
+	}
+	if p.Name != "p" {
+		t.Fatalf("expected p, got %s", p.Name)
+	}
+}

--- a/internal/policy/manager_test.go
+++ b/internal/policy/manager_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy/signing"
 )
 
 func TestManager_SelectsAllowedEnv(t *testing.T) {
@@ -116,4 +118,71 @@ func hashFile(t *testing.T, path string) string {
 	}
 	h := sha256.Sum256(data)
 	return hex.EncodeToString(h[:])
+}
+
+func TestManager_SigningEnforce_Valid(t *testing.T) {
+	dir := t.TempDir()
+	writePolicy(t, dir, "p.yaml", "version: 1\nname: p\n")
+	keyDir := t.TempDir()
+	kid, err := signing.GenerateKeypair(keyDir, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = kid
+	if err := signing.SignFile(filepath.Join(dir, "p.yaml"), filepath.Join(keyDir, "private.key.json"), "", ""); err != nil {
+		t.Fatal(err)
+	}
+	tsDir := t.TempDir()
+	pubData, _ := os.ReadFile(filepath.Join(keyDir, "public.key.json"))
+	os.WriteFile(filepath.Join(tsDir, "key.json"), pubData, 0o644)
+	m := NewManager(dir, "p", []string{"p"}, "", "p")
+	m.SetSigningConfig("enforce", tsDir)
+	p, err := m.Get()
+	if err != nil {
+		t.Fatalf("expected load ok, got %v", err)
+	}
+	if p.Name != "p" {
+		t.Fatalf("expected p, got %s", p.Name)
+	}
+}
+
+func TestManager_SigningEnforce_MissingSig(t *testing.T) {
+	dir := t.TempDir()
+	writePolicy(t, dir, "p.yaml", "version: 1\nname: p\n")
+	tsDir := t.TempDir()
+	m := NewManager(dir, "p", []string{"p"}, "", "p")
+	m.SetSigningConfig("enforce", tsDir)
+	_, err := m.Get()
+	if err == nil {
+		t.Fatal("expected error for missing signature in enforce mode")
+	}
+}
+
+func TestManager_SigningWarn_MissingSig(t *testing.T) {
+	dir := t.TempDir()
+	writePolicy(t, dir, "p.yaml", "version: 1\nname: p\n")
+	tsDir := t.TempDir()
+	m := NewManager(dir, "p", []string{"p"}, "", "p")
+	m.SetSigningConfig("warn", tsDir)
+	p, err := m.Get()
+	if err != nil {
+		t.Fatalf("warn mode should still load, got %v", err)
+	}
+	if p.Name != "p" {
+		t.Fatalf("expected p, got %s", p.Name)
+	}
+}
+
+func TestManager_SigningOff(t *testing.T) {
+	dir := t.TempDir()
+	writePolicy(t, dir, "p.yaml", "version: 1\nname: p\n")
+	m := NewManager(dir, "p", []string{"p"}, "", "p")
+	m.SetSigningConfig("off", "")
+	p, err := m.Get()
+	if err != nil {
+		t.Fatalf("off mode should always load, got %v", err)
+	}
+	if p.Name != "p" {
+		t.Fatalf("expected p, got %s", p.Name)
+	}
 }

--- a/internal/policy/signing/keygen.go
+++ b/internal/policy/signing/keygen.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 )
 
@@ -60,7 +61,17 @@ func GenerateKeypair(dir, label string) (string, error) {
 }
 
 // LoadPrivateKey reads an Ed25519 private key from a JSON key file.
+// On Unix, rejects files readable by group or others.
 func LoadPrivateKey(path string) (ed25519.PrivateKey, error) {
+	if runtime.GOOS != "windows" {
+		fi, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("stat private key: %w", err)
+		}
+		if fi.Mode().Perm()&0o077 != 0 {
+			return nil, fmt.Errorf("private key %s has insecure permissions %o (expected 0600)", path, fi.Mode().Perm())
+		}
+	}
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read private key: %w", err)

--- a/internal/policy/signing/keygen.go
+++ b/internal/policy/signing/keygen.go
@@ -1,0 +1,79 @@
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// GenerateKeypair creates an Ed25519 keypair and writes both key files to dir.
+// Returns the key_id. The private key is written with mode 0600.
+func GenerateKeypair(dir, label string) (string, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return "", fmt.Errorf("generate key: %w", err)
+	}
+
+	kid := KeyID(pub)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	privFile := PrivateKeyFile{
+		KeyID:      kid,
+		Algorithm:  "ed25519",
+		PrivateKey: base64.StdEncoding.EncodeToString(priv),
+		Label:      label,
+		CreatedAt:  now,
+	}
+	privJSON, err := json.MarshalIndent(privFile, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal private key: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "private.key.json"), privJSON, 0o600); err != nil {
+		return "", fmt.Errorf("write private key: %w", err)
+	}
+
+	pubFile := PublicKeyFile{
+		KeyID:        kid,
+		Algorithm:    "ed25519",
+		PublicKey:    base64.StdEncoding.EncodeToString(pub),
+		Label:        label,
+		TrustedSince: now,
+	}
+	pubJSON, err := json.MarshalIndent(pubFile, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal public key: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "public.key.json"), pubJSON, 0o644); err != nil {
+		return "", fmt.Errorf("write public key: %w", err)
+	}
+
+	return kid, nil
+}
+
+// LoadPrivateKey reads an Ed25519 private key from a JSON key file.
+func LoadPrivateKey(path string) (ed25519.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read private key: %w", err)
+	}
+	var kf PrivateKeyFile
+	if err := json.Unmarshal(data, &kf); err != nil {
+		return nil, fmt.Errorf("parse private key: %w", err)
+	}
+	if kf.Algorithm != "ed25519" {
+		return nil, fmt.Errorf("unsupported algorithm: %s", kf.Algorithm)
+	}
+	keyBytes, err := base64.StdEncoding.DecodeString(kf.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("decode private key: %w", err)
+	}
+	if len(keyBytes) != ed25519.PrivateKeySize {
+		return nil, fmt.Errorf("invalid private key size: %d", len(keyBytes))
+	}
+	return ed25519.PrivateKey(keyBytes), nil
+}

--- a/internal/policy/signing/keygen.go
+++ b/internal/policy/signing/keygen.go
@@ -33,8 +33,12 @@ func GenerateKeypair(dir, label string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("marshal private key: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "private.key.json"), privJSON, 0o600); err != nil {
+	privPath := filepath.Join(dir, "private.key.json")
+	if err := os.WriteFile(privPath, privJSON, 0o600); err != nil {
 		return "", fmt.Errorf("write private key: %w", err)
+	}
+	if err := os.Chmod(privPath, 0o600); err != nil {
+		return "", fmt.Errorf("chmod private key: %w", err)
 	}
 
 	pubFile := PublicKeyFile{

--- a/internal/policy/signing/keygen_test.go
+++ b/internal/policy/signing/keygen_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -62,13 +63,15 @@ func TestGenerateKeypair(t *testing.T) {
 		t.Fatalf("expected %d byte public key, got %d", ed25519.PublicKeySize, len(pubKeyBytes))
 	}
 
-	// Verify private key file permissions
-	info, err := os.Stat(filepath.Join(dir, "private.key.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm() != 0o600 {
-		t.Fatalf("expected 0600 permissions, got %o", info.Mode().Perm())
+	// Verify private key file permissions (Unix only)
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(dir, "private.key.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("expected 0600 permissions, got %o", info.Mode().Perm())
+		}
 	}
 }
 

--- a/internal/policy/signing/keygen_test.go
+++ b/internal/policy/signing/keygen_test.go
@@ -1,0 +1,104 @@
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGenerateKeypair(t *testing.T) {
+	dir := t.TempDir()
+	kid, err := GenerateKeypair(dir, "test-signer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(kid) != 64 {
+		t.Fatalf("expected 64 hex char key_id, got %d", len(kid))
+	}
+
+	// Check private key file
+	privData, err := os.ReadFile(filepath.Join(dir, "private.key.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var priv PrivateKeyFile
+	if err := json.Unmarshal(privData, &priv); err != nil {
+		t.Fatal(err)
+	}
+	if priv.KeyID != kid {
+		t.Fatalf("key_id mismatch: %s != %s", priv.KeyID, kid)
+	}
+	if priv.Algorithm != "ed25519" {
+		t.Fatalf("expected ed25519, got %s", priv.Algorithm)
+	}
+	privKeyBytes, err := base64.StdEncoding.DecodeString(priv.PrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(privKeyBytes) != ed25519.PrivateKeySize {
+		t.Fatalf("expected %d byte private key, got %d", ed25519.PrivateKeySize, len(privKeyBytes))
+	}
+
+	// Check public key file
+	pubData, err := os.ReadFile(filepath.Join(dir, "public.key.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pub PublicKeyFile
+	if err := json.Unmarshal(pubData, &pub); err != nil {
+		t.Fatal(err)
+	}
+	if pub.KeyID != kid {
+		t.Fatalf("key_id mismatch: %s != %s", pub.KeyID, kid)
+	}
+	pubKeyBytes, err := base64.StdEncoding.DecodeString(pub.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(pubKeyBytes) != ed25519.PublicKeySize {
+		t.Fatalf("expected %d byte public key, got %d", ed25519.PublicKeySize, len(pubKeyBytes))
+	}
+
+	// Verify private key file permissions
+	info, err := os.Stat(filepath.Join(dir, "private.key.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("expected 0600 permissions, got %o", info.Mode().Perm())
+	}
+}
+
+func TestGenerateKeypair_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	_, err := GenerateKeypair(dir, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	priv, err := LoadPrivateKey(filepath.Join(dir, "private.key.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg := []byte("hello world")
+	sig := ed25519.Sign(priv, msg)
+
+	pubData, err := os.ReadFile(filepath.Join(dir, "public.key.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pubFile PublicKeyFile
+	if err := json.Unmarshal(pubData, &pubFile); err != nil {
+		t.Fatal(err)
+	}
+	pubBytes, _ := base64.StdEncoding.DecodeString(pubFile.PublicKey)
+	pub := ed25519.PublicKey(pubBytes)
+
+	if !ed25519.Verify(pub, msg, sig) {
+		t.Fatal("generated keypair does not round-trip")
+	}
+}

--- a/internal/policy/signing/sign.go
+++ b/internal/policy/signing/sign.go
@@ -1,0 +1,48 @@
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+func Sign(policyBytes []byte, privKey ed25519.PrivateKey, signer string) (*SigFile, error) {
+	sig := ed25519.Sign(privKey, policyBytes)
+	pub := privKey.Public().(ed25519.PublicKey)
+	return &SigFile{
+		Version: 1, Algorithm: "ed25519", KeyID: KeyID(pub), Signer: signer,
+		SignedAt:  time.Now().UTC().Format(time.RFC3339),
+		Signature: base64.StdEncoding.EncodeToString(sig),
+		CertChain: []string{},
+	}, nil
+}
+
+func SignFile(policyPath, privKeyPath, outputPath, signer string) error {
+	policyBytes, err := os.ReadFile(policyPath)
+	if err != nil {
+		return fmt.Errorf("read policy: %w", err)
+	}
+	privKey, err := LoadPrivateKey(privKeyPath)
+	if err != nil {
+		return err
+	}
+	sigFile, err := Sign(policyBytes, privKey, signer)
+	if err != nil {
+		return err
+	}
+	sigJSON, err := json.MarshalIndent(sigFile, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal signature: %w", err)
+	}
+	dest := outputPath
+	if dest == "" {
+		dest = policyPath + ".sig"
+	}
+	if err := os.WriteFile(dest, sigJSON, 0o644); err != nil {
+		return fmt.Errorf("write signature: %w", err)
+	}
+	return nil
+}

--- a/internal/policy/signing/sign_test.go
+++ b/internal/policy/signing/sign_test.go
@@ -1,0 +1,60 @@
+package signing
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSign(t *testing.T) {
+	dir := t.TempDir()
+	kid, err := GenerateKeypair(dir, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	priv, err := LoadPrivateKey(filepath.Join(dir, "private.key.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	policyBytes := []byte("version: 1\nname: test\n")
+	sig, err := Sign(policyBytes, priv, "test-signer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sig.Version != 1 { t.Fatalf("expected version 1, got %d", sig.Version) }
+	if sig.Algorithm != "ed25519" { t.Fatalf("expected ed25519, got %s", sig.Algorithm) }
+	if sig.KeyID != kid { t.Fatalf("key_id mismatch") }
+	if sig.Signer != "test-signer" { t.Fatalf("expected signer test-signer, got %s", sig.Signer) }
+	if sig.Signature == "" { t.Fatal("empty signature") }
+	if sig.SignedAt == "" { t.Fatal("empty signed_at") }
+	if err := sig.Validate(); err != nil { t.Fatalf("sig validation: %v", err) }
+}
+
+func TestSignFile(t *testing.T) {
+	dir := t.TempDir()
+	GenerateKeypair(dir, "test")
+	policyPath := filepath.Join(dir, "test.yaml")
+	os.WriteFile(policyPath, []byte("version: 1\nname: test\n"), 0o644)
+	if err := SignFile(policyPath, filepath.Join(dir, "private.key.json"), "", ""); err != nil {
+		t.Fatal(err)
+	}
+	sigData, err := os.ReadFile(policyPath + ".sig")
+	if err != nil { t.Fatalf("sig file not created: %v", err) }
+	var sig SigFile
+	if err := json.Unmarshal(sigData, &sig); err != nil { t.Fatalf("parse sig: %v", err) }
+	if err := sig.Validate(); err != nil { t.Fatalf("sig validation: %v", err) }
+}
+
+func TestSignFile_CustomOutput(t *testing.T) {
+	dir := t.TempDir()
+	GenerateKeypair(dir, "test")
+	policyPath := filepath.Join(dir, "test.yaml")
+	os.WriteFile(policyPath, []byte("version: 1\nname: test\n"), 0o644)
+	customSig := filepath.Join(dir, "custom.sig")
+	if err := SignFile(policyPath, filepath.Join(dir, "private.key.json"), customSig, "custom-signer"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(customSig); err != nil { t.Fatalf("custom sig not created: %v", err) }
+	if _, err := os.Stat(policyPath + ".sig"); err == nil { t.Fatal("default sig should not exist") }
+}

--- a/internal/policy/signing/truststore.go
+++ b/internal/policy/signing/truststore.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // TrustStore holds trusted public keys indexed by key_id.
@@ -45,8 +46,9 @@ func LoadTrustStore(dir string) (*TrustStore, error) {
 		if err := json.Unmarshal(data, &kf); err != nil {
 			return nil, fmt.Errorf("parse key file %s: %w", e.Name(), err)
 		}
+		// Skip JSON files that aren't public key records
 		if kf.KeyID == "" || kf.Algorithm == "" || kf.PublicKey == "" {
-			return nil, fmt.Errorf("key file %s: missing required field (key_id, algorithm, or public_key)", e.Name())
+			continue
 		}
 		pubBytes, err := base64.StdEncoding.DecodeString(kf.PublicKey)
 		if err != nil {
@@ -54,6 +56,11 @@ func LoadTrustStore(dir string) (*TrustStore, error) {
 		}
 		if len(pubBytes) != ed25519.PublicKeySize {
 			return nil, fmt.Errorf("key file %s: invalid public key size %d (expected %d)", e.Name(), len(pubBytes), ed25519.PublicKeySize)
+		}
+		if kf.ExpiresAt != "" {
+			if _, err := time.Parse(time.RFC3339, kf.ExpiresAt); err != nil {
+				return nil, fmt.Errorf("key file %s: invalid expires_at: %w", e.Name(), err)
+			}
 		}
 		if _, exists := ts.Keys[kf.KeyID]; exists {
 			return nil, fmt.Errorf("key file %s: duplicate key_id %s", e.Name(), kf.KeyID)

--- a/internal/policy/signing/truststore.go
+++ b/internal/policy/signing/truststore.go
@@ -18,8 +18,9 @@ type TrustStore struct {
 
 // LoadTrustStore reads all .json files from dir and populates a TrustStore.
 // Non-JSON files and subdirectories are silently skipped.
-// Emits a warning to stderr if the directory or any key file is world-writable.
-func LoadTrustStore(dir string) (*TrustStore, error) {
+// If strict is true, world-writable directories/files cause an error (for enforce mode).
+// If strict is false, world-writable paths emit a warning to stderr.
+func LoadTrustStore(dir string, strict bool) (*TrustStore, error) {
 	ts := &TrustStore{Keys: make(map[string]*PublicKeyFile)}
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -27,6 +28,9 @@ func LoadTrustStore(dir string) (*TrustStore, error) {
 	}
 	info, err := os.Stat(dir)
 	if err == nil && info.Mode().Perm()&0o002 != 0 {
+		if strict {
+			return nil, fmt.Errorf("trust store directory %s is world-writable", dir)
+		}
 		fmt.Fprintf(os.Stderr, "WARNING: trust store directory %s is world-writable\n", dir)
 	}
 	for _, e := range entries {
@@ -36,6 +40,9 @@ func LoadTrustStore(dir string) (*TrustStore, error) {
 		path := filepath.Join(dir, e.Name())
 		fi, err := os.Stat(path)
 		if err == nil && fi.Mode().Perm()&0o002 != 0 {
+			if strict {
+				return nil, fmt.Errorf("trust store key file %s is world-writable", path)
+			}
 			fmt.Fprintf(os.Stderr, "WARNING: trust store key file %s is world-writable\n", path)
 		}
 		data, err := os.ReadFile(path)

--- a/internal/policy/signing/truststore.go
+++ b/internal/policy/signing/truststore.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -26,24 +27,29 @@ func LoadTrustStore(dir string, strict bool) (*TrustStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read trust store dir: %w", err)
 	}
-	info, err := os.Stat(dir)
-	if err == nil && info.Mode().Perm()&0o002 != 0 {
-		if strict {
-			return nil, fmt.Errorf("trust store directory %s is world-writable", dir)
+	// Permission checks are Unix-only; Windows mode bits don't reflect ACLs reliably
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(dir)
+		if err == nil && info.Mode().Perm()&0o002 != 0 {
+			if strict {
+				return nil, fmt.Errorf("trust store directory %s is world-writable", dir)
+			}
+			fmt.Fprintf(os.Stderr, "WARNING: trust store directory %s is world-writable\n", dir)
 		}
-		fmt.Fprintf(os.Stderr, "WARNING: trust store directory %s is world-writable\n", dir)
 	}
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
 			continue
 		}
 		path := filepath.Join(dir, e.Name())
-		fi, err := os.Stat(path)
-		if err == nil && fi.Mode().Perm()&0o002 != 0 {
-			if strict {
-				return nil, fmt.Errorf("trust store key file %s is world-writable", path)
+		if runtime.GOOS != "windows" {
+			fi, err := os.Stat(path)
+			if err == nil && fi.Mode().Perm()&0o002 != 0 {
+				if strict {
+					return nil, fmt.Errorf("trust store key file %s is world-writable", path)
+				}
+				fmt.Fprintf(os.Stderr, "WARNING: trust store key file %s is world-writable\n", path)
 			}
-			fmt.Fprintf(os.Stderr, "WARNING: trust store key file %s is world-writable\n", path)
 		}
 		data, err := os.ReadFile(path)
 		if err != nil {

--- a/internal/policy/signing/truststore.go
+++ b/internal/policy/signing/truststore.go
@@ -50,12 +50,19 @@ func LoadTrustStore(dir string) (*TrustStore, error) {
 		if kf.KeyID == "" || kf.Algorithm == "" || kf.PublicKey == "" {
 			continue
 		}
+		if kf.Algorithm != "ed25519" {
+			return nil, fmt.Errorf("key file %s: unsupported algorithm %q", e.Name(), kf.Algorithm)
+		}
 		pubBytes, err := base64.StdEncoding.DecodeString(kf.PublicKey)
 		if err != nil {
 			return nil, fmt.Errorf("key file %s: decode public_key: %w", e.Name(), err)
 		}
 		if len(pubBytes) != ed25519.PublicKeySize {
 			return nil, fmt.Errorf("key file %s: invalid public key size %d (expected %d)", e.Name(), len(pubBytes), ed25519.PublicKeySize)
+		}
+		derivedID := KeyID(ed25519.PublicKey(pubBytes))
+		if kf.KeyID != derivedID {
+			return nil, fmt.Errorf("key file %s: key_id %q does not match derived key_id %q", e.Name(), kf.KeyID, derivedID)
 		}
 		if kf.ExpiresAt != "" {
 			if _, err := time.Parse(time.RFC3339, kf.ExpiresAt); err != nil {

--- a/internal/policy/signing/truststore.go
+++ b/internal/policy/signing/truststore.go
@@ -1,6 +1,8 @@
 package signing
 
 import (
+	"crypto/ed25519"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -42,6 +44,19 @@ func LoadTrustStore(dir string) (*TrustStore, error) {
 		var kf PublicKeyFile
 		if err := json.Unmarshal(data, &kf); err != nil {
 			return nil, fmt.Errorf("parse key file %s: %w", e.Name(), err)
+		}
+		if kf.KeyID == "" || kf.Algorithm == "" || kf.PublicKey == "" {
+			return nil, fmt.Errorf("key file %s: missing required field (key_id, algorithm, or public_key)", e.Name())
+		}
+		pubBytes, err := base64.StdEncoding.DecodeString(kf.PublicKey)
+		if err != nil {
+			return nil, fmt.Errorf("key file %s: decode public_key: %w", e.Name(), err)
+		}
+		if len(pubBytes) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("key file %s: invalid public key size %d (expected %d)", e.Name(), len(pubBytes), ed25519.PublicKeySize)
+		}
+		if _, exists := ts.Keys[kf.KeyID]; exists {
+			return nil, fmt.Errorf("key file %s: duplicate key_id %s", e.Name(), kf.KeyID)
 		}
 		ts.Keys[kf.KeyID] = &kf
 	}

--- a/internal/policy/signing/truststore.go
+++ b/internal/policy/signing/truststore.go
@@ -1,0 +1,61 @@
+package signing
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// TrustStore holds trusted public keys indexed by key_id.
+type TrustStore struct {
+	Keys map[string]*PublicKeyFile
+}
+
+// LoadTrustStore reads all .json files from dir and populates a TrustStore.
+// Non-JSON files and subdirectories are silently skipped.
+// Emits a warning to stderr if the directory or any key file is world-writable.
+func LoadTrustStore(dir string) (*TrustStore, error) {
+	ts := &TrustStore{Keys: make(map[string]*PublicKeyFile)}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read trust store dir: %w", err)
+	}
+	info, err := os.Stat(dir)
+	if err == nil && info.Mode().Perm()&0o002 != 0 {
+		fmt.Fprintf(os.Stderr, "WARNING: trust store directory %s is world-writable\n", dir)
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		fi, err := os.Stat(path)
+		if err == nil && fi.Mode().Perm()&0o002 != 0 {
+			fmt.Fprintf(os.Stderr, "WARNING: trust store key file %s is world-writable\n", path)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read key file %s: %w", e.Name(), err)
+		}
+		var kf PublicKeyFile
+		if err := json.Unmarshal(data, &kf); err != nil {
+			return nil, fmt.Errorf("parse key file %s: %w", e.Name(), err)
+		}
+		ts.Keys[kf.KeyID] = &kf
+	}
+	return ts, nil
+}
+
+// FindKey looks up a key by key_id and returns an error if not found or expired.
+func (ts *TrustStore) FindKey(keyID string) (*PublicKeyFile, error) {
+	kf, ok := ts.Keys[keyID]
+	if !ok {
+		return nil, fmt.Errorf("unknown_key: %s", keyID)
+	}
+	if kf.IsExpired() {
+		return nil, fmt.Errorf("expired_key: %s", keyID)
+	}
+	return kf, nil
+}

--- a/internal/policy/signing/truststore_test.go
+++ b/internal/policy/signing/truststore_test.go
@@ -30,18 +30,27 @@ func TestTrustStore_UnknownKey(t *testing.T) {
 }
 
 func TestTrustStore_ExpiredKey(t *testing.T) {
-	tsDir := t.TempDir()
-	pubFile := PublicKeyFile{
-		KeyID: "expired-key-id", Algorithm: "ed25519",
-		PublicKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
-		Label: "expired",
-		ExpiresAt: time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339),
-	}
+	// Generate a real keypair to get valid key_id and public_key
+	keyDir := t.TempDir()
+	kid, _ := GenerateKeypair(keyDir, "test")
+	pubData, _ := os.ReadFile(filepath.Join(keyDir, "public.key.json"))
+
+	// Modify the public key file to add an expired timestamp
+	var pubFile PublicKeyFile
+	json.Unmarshal(pubData, &pubFile)
+	pubFile.ExpiresAt = time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
 	data, _ := json.MarshalIndent(pubFile, "", "  ")
+
+	tsDir := t.TempDir()
 	os.WriteFile(filepath.Join(tsDir, "expired.json"), data, 0o644)
-	ts, _ := LoadTrustStore(tsDir)
-	_, err := ts.FindKey("expired-key-id")
-	if err == nil { t.Fatal("expected error for expired key") }
+	ts, err := LoadTrustStore(tsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ts.FindKey(kid)
+	if err == nil {
+		t.Fatal("expected error for expired key")
+	}
 }
 
 func TestTrustStore_IgnoresNonJSON(t *testing.T) {

--- a/internal/policy/signing/truststore_test.go
+++ b/internal/policy/signing/truststore_test.go
@@ -14,7 +14,7 @@ func TestTrustStore_LoadAndFind(t *testing.T) {
 	tsDir := t.TempDir()
 	pubData, _ := os.ReadFile(filepath.Join(dir, "public.key.json"))
 	os.WriteFile(filepath.Join(tsDir, "key1.json"), pubData, 0o644)
-	ts, err := LoadTrustStore(tsDir)
+	ts, err := LoadTrustStore(tsDir, false)
 	if err != nil { t.Fatal(err) }
 	key, err := ts.FindKey(kid)
 	if err != nil { t.Fatalf("expected to find key: %v", err) }
@@ -23,7 +23,7 @@ func TestTrustStore_LoadAndFind(t *testing.T) {
 
 func TestTrustStore_UnknownKey(t *testing.T) {
 	tsDir := t.TempDir()
-	ts, err := LoadTrustStore(tsDir)
+	ts, err := LoadTrustStore(tsDir, false)
 	if err != nil { t.Fatal(err) }
 	_, err = ts.FindKey("nonexistent")
 	if err == nil { t.Fatal("expected error for unknown key") }
@@ -43,7 +43,7 @@ func TestTrustStore_ExpiredKey(t *testing.T) {
 
 	tsDir := t.TempDir()
 	os.WriteFile(filepath.Join(tsDir, "expired.json"), data, 0o644)
-	ts, err := LoadTrustStore(tsDir)
+	ts, err := LoadTrustStore(tsDir, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func TestTrustStore_IgnoresNonJSON(t *testing.T) {
 	tsDir := t.TempDir()
 	os.WriteFile(filepath.Join(tsDir, "README.txt"), []byte("ignore"), 0o644)
 	os.WriteFile(filepath.Join(tsDir, ".gitkeep"), []byte(""), 0o644)
-	ts, _ := LoadTrustStore(tsDir)
+	ts, _ := LoadTrustStore(tsDir, false)
 	if len(ts.Keys) != 0 { t.Fatalf("expected 0 keys, got %d", len(ts.Keys)) }
 }
 
@@ -70,7 +70,7 @@ func TestTrustStore_MultipleKeys(t *testing.T) {
 	pub2, _ := os.ReadFile(filepath.Join(dir2, "public.key.json"))
 	os.WriteFile(filepath.Join(tsDir, "key1.json"), pub1, 0o644)
 	os.WriteFile(filepath.Join(tsDir, "key2.json"), pub2, 0o644)
-	ts, _ := LoadTrustStore(tsDir)
+	ts, _ := LoadTrustStore(tsDir, false)
 	if len(ts.Keys) != 2 { t.Fatalf("expected 2 keys, got %d", len(ts.Keys)) }
 	if _, err := ts.FindKey(kid1); err != nil { t.Fatalf("key1 not found: %v", err) }
 	if _, err := ts.FindKey(kid2); err != nil { t.Fatalf("key2 not found: %v", err) }

--- a/internal/policy/signing/truststore_test.go
+++ b/internal/policy/signing/truststore_test.go
@@ -1,0 +1,68 @@
+package signing
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestTrustStore_LoadAndFind(t *testing.T) {
+	dir := t.TempDir()
+	kid, _ := GenerateKeypair(dir, "test")
+	tsDir := t.TempDir()
+	pubData, _ := os.ReadFile(filepath.Join(dir, "public.key.json"))
+	os.WriteFile(filepath.Join(tsDir, "key1.json"), pubData, 0o644)
+	ts, err := LoadTrustStore(tsDir)
+	if err != nil { t.Fatal(err) }
+	key, err := ts.FindKey(kid)
+	if err != nil { t.Fatalf("expected to find key: %v", err) }
+	if key.KeyID != kid { t.Fatalf("key_id mismatch") }
+}
+
+func TestTrustStore_UnknownKey(t *testing.T) {
+	tsDir := t.TempDir()
+	ts, err := LoadTrustStore(tsDir)
+	if err != nil { t.Fatal(err) }
+	_, err = ts.FindKey("nonexistent")
+	if err == nil { t.Fatal("expected error for unknown key") }
+}
+
+func TestTrustStore_ExpiredKey(t *testing.T) {
+	tsDir := t.TempDir()
+	pubFile := PublicKeyFile{
+		KeyID: "expired-key-id", Algorithm: "ed25519",
+		PublicKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+		Label: "expired",
+		ExpiresAt: time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339),
+	}
+	data, _ := json.MarshalIndent(pubFile, "", "  ")
+	os.WriteFile(filepath.Join(tsDir, "expired.json"), data, 0o644)
+	ts, _ := LoadTrustStore(tsDir)
+	_, err := ts.FindKey("expired-key-id")
+	if err == nil { t.Fatal("expected error for expired key") }
+}
+
+func TestTrustStore_IgnoresNonJSON(t *testing.T) {
+	tsDir := t.TempDir()
+	os.WriteFile(filepath.Join(tsDir, "README.txt"), []byte("ignore"), 0o644)
+	os.WriteFile(filepath.Join(tsDir, ".gitkeep"), []byte(""), 0o644)
+	ts, _ := LoadTrustStore(tsDir)
+	if len(ts.Keys) != 0 { t.Fatalf("expected 0 keys, got %d", len(ts.Keys)) }
+}
+
+func TestTrustStore_MultipleKeys(t *testing.T) {
+	tsDir := t.TempDir()
+	dir1, dir2 := t.TempDir(), t.TempDir()
+	kid1, _ := GenerateKeypair(dir1, "key1")
+	kid2, _ := GenerateKeypair(dir2, "key2")
+	pub1, _ := os.ReadFile(filepath.Join(dir1, "public.key.json"))
+	pub2, _ := os.ReadFile(filepath.Join(dir2, "public.key.json"))
+	os.WriteFile(filepath.Join(tsDir, "key1.json"), pub1, 0o644)
+	os.WriteFile(filepath.Join(tsDir, "key2.json"), pub2, 0o644)
+	ts, _ := LoadTrustStore(tsDir)
+	if len(ts.Keys) != 2 { t.Fatalf("expected 2 keys, got %d", len(ts.Keys)) }
+	if _, err := ts.FindKey(kid1); err != nil { t.Fatalf("key1 not found: %v", err) }
+	if _, err := ts.FindKey(kid2); err != nil { t.Fatalf("key2 not found: %v", err) }
+}

--- a/internal/policy/signing/types.go
+++ b/internal/policy/signing/types.go
@@ -1,0 +1,81 @@
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// SigFile represents a detached signature file (.sig) in JSON format.
+type SigFile struct {
+	Version   int      `json:"version"`
+	Algorithm string   `json:"algorithm"`
+	KeyID     string   `json:"key_id"`
+	Signer    string   `json:"signer,omitempty"`
+	SignedAt  string   `json:"signed_at"`
+	Signature string   `json:"signature"`
+	CertChain []string `json:"cert_chain"`
+}
+
+// Validate checks that the sig file conforms to the v1 schema.
+func (s *SigFile) Validate() error {
+	if s.Version != 1 {
+		return fmt.Errorf("unsupported version: %d", s.Version)
+	}
+	if s.Algorithm != "ed25519" {
+		return fmt.Errorf("unsupported algorithm: %s", s.Algorithm)
+	}
+	if s.KeyID == "" {
+		return fmt.Errorf("missing key_id")
+	}
+	if s.Signature == "" {
+		return fmt.Errorf("missing signature")
+	}
+	if s.SignedAt == "" {
+		return fmt.Errorf("missing signed_at")
+	}
+	if len(s.CertChain) > 0 {
+		return fmt.Errorf("unsupported_cert_chain: v1 does not support certificate chains")
+	}
+	return nil
+}
+
+// PublicKeyFile represents a public key in the trust store.
+type PublicKeyFile struct {
+	KeyID        string `json:"key_id"`
+	Algorithm    string `json:"algorithm"`
+	PublicKey    string `json:"public_key"`
+	Label        string `json:"label,omitempty"`
+	TrustedSince string `json:"trusted_since,omitempty"`
+	ExpiresAt    string `json:"expires_at,omitempty"`
+}
+
+// IsExpired returns true if the key has an expiry time that has passed.
+func (k *PublicKeyFile) IsExpired() bool {
+	if k.ExpiresAt == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, k.ExpiresAt)
+	if err != nil {
+		return false
+	}
+	return time.Now().After(t)
+}
+
+// PrivateKeyFile represents a private signing key.
+type PrivateKeyFile struct {
+	KeyID      string `json:"key_id"`
+	Algorithm  string `json:"algorithm"`
+	PrivateKey string `json:"private_key"`
+	Label      string `json:"label,omitempty"`
+	CreatedAt  string `json:"created_at,omitempty"`
+}
+
+// KeyID computes the deterministic key identifier from an Ed25519 public key.
+// Returns the full hex-encoded SHA256 hash (64 chars).
+func KeyID(pub ed25519.PublicKey) string {
+	h := sha256.Sum256([]byte(pub))
+	return hex.EncodeToString(h[:])
+}

--- a/internal/policy/signing/types_test.go
+++ b/internal/policy/signing/types_test.go
@@ -1,0 +1,55 @@
+package signing
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"strings"
+	"testing"
+)
+
+func TestKeyID(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	kid := KeyID(pub)
+	if len(kid) != 64 {
+		t.Fatalf("expected 64 hex chars, got %d", len(kid))
+	}
+	// Deterministic
+	if kid != KeyID(pub) {
+		t.Fatal("expected deterministic key ID")
+	}
+}
+
+func TestSigFileValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		sig     SigFile
+		wantErr string
+	}{
+		{"valid", SigFile{Version: 1, Algorithm: "ed25519", KeyID: "abc", SignedAt: "2026-01-01T00:00:00Z", Signature: "AAAA"}, ""},
+		{"bad version", SigFile{Version: 2, Algorithm: "ed25519", KeyID: "abc", SignedAt: "2026-01-01T00:00:00Z", Signature: "AAAA"}, "unsupported version"},
+		{"bad algorithm", SigFile{Version: 1, Algorithm: "rsa", KeyID: "abc", SignedAt: "2026-01-01T00:00:00Z", Signature: "AAAA"}, "unsupported algorithm"},
+		{"missing key_id", SigFile{Version: 1, Algorithm: "ed25519", SignedAt: "2026-01-01T00:00:00Z", Signature: "AAAA"}, "missing key_id"},
+		{"missing signature", SigFile{Version: 1, Algorithm: "ed25519", KeyID: "abc", SignedAt: "2026-01-01T00:00:00Z"}, "missing signature"},
+		{"missing signed_at", SigFile{Version: 1, Algorithm: "ed25519", KeyID: "abc", Signature: "AAAA"}, "missing signed_at"},
+		{"non-empty cert_chain", SigFile{Version: 1, Algorithm: "ed25519", KeyID: "abc", SignedAt: "2026-01-01T00:00:00Z", Signature: "AAAA", CertChain: []string{"x"}}, "unsupported_cert_chain"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.sig.Validate()
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+			}
+		})
+	}
+}

--- a/internal/policy/signing/verify.go
+++ b/internal/policy/signing/verify.go
@@ -1,0 +1,70 @@
+package signing
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// VerifyResult holds the outcome of a successful signature verification.
+type VerifyResult struct {
+	KeyID    string
+	Signer   string
+	SignedAt string
+}
+
+// Verify checks that policyBytes was signed by a key in the trust store
+// using the signature described by sig.
+func Verify(policyBytes []byte, sig *SigFile, ts *TrustStore) error {
+	if err := sig.Validate(); err != nil {
+		return fmt.Errorf("invalid signature file: %w", err)
+	}
+	kf, err := ts.FindKey(sig.KeyID)
+	if err != nil {
+		return err
+	}
+	pubBytes, err := base64.StdEncoding.DecodeString(kf.PublicKey)
+	if err != nil {
+		return fmt.Errorf("decode public key: %w", err)
+	}
+	if len(pubBytes) != ed25519.PublicKeySize {
+		return fmt.Errorf("invalid public key size: %d", len(pubBytes))
+	}
+	pub := ed25519.PublicKey(pubBytes)
+	sigBytes, err := base64.StdEncoding.DecodeString(sig.Signature)
+	if err != nil {
+		return fmt.Errorf("decode signature: %w", err)
+	}
+	if !ed25519.Verify(pub, policyBytes, sigBytes) {
+		return fmt.Errorf("invalid_signature: Ed25519 verification failed")
+	}
+	return nil
+}
+
+// VerifyPolicy reads policyPath and its companion .sig file, then verifies
+// the signature against the trust store.
+func VerifyPolicy(policyPath string, ts *TrustStore) (*VerifyResult, error) {
+	policyBytes, err := os.ReadFile(policyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read policy: %w", err)
+	}
+	return VerifyPolicyBytes(policyBytes, policyPath+".sig", ts)
+}
+
+// VerifyPolicyBytes verifies policyBytes using a signature file at sigPath.
+func VerifyPolicyBytes(policyBytes []byte, sigPath string, ts *TrustStore) (*VerifyResult, error) {
+	sigData, err := os.ReadFile(sigPath)
+	if err != nil {
+		return nil, fmt.Errorf("missing_signature: %w", err)
+	}
+	var sig SigFile
+	if err := json.Unmarshal(sigData, &sig); err != nil {
+		return nil, fmt.Errorf("parse signature file: %w", err)
+	}
+	if err := Verify(policyBytes, &sig, ts); err != nil {
+		return nil, err
+	}
+	return &VerifyResult{KeyID: sig.KeyID, Signer: sig.Signer, SignedAt: sig.SignedAt}, nil
+}

--- a/internal/policy/signing/verify_test.go
+++ b/internal/policy/signing/verify_test.go
@@ -1,0 +1,99 @@
+package signing
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupSignedPolicy(t *testing.T) (policyPath, tsDir string) {
+	t.Helper()
+	keyDir := t.TempDir()
+	_, err := GenerateKeypair(keyDir, "test")
+	if err != nil { t.Fatal(err) }
+	policyDir := t.TempDir()
+	policyPath = filepath.Join(policyDir, "test.yaml")
+	os.WriteFile(policyPath, []byte("version: 1\nname: test\n"), 0o644)
+	if err := SignFile(policyPath, filepath.Join(keyDir, "private.key.json"), "", ""); err != nil { t.Fatal(err) }
+	tsDir = t.TempDir()
+	pubData, _ := os.ReadFile(filepath.Join(keyDir, "public.key.json"))
+	os.WriteFile(filepath.Join(tsDir, "key.json"), pubData, 0o644)
+	return
+}
+
+func TestVerify_Valid(t *testing.T) {
+	policyPath, tsDir := setupSignedPolicy(t)
+	ts, _ := LoadTrustStore(tsDir)
+	policyBytes, _ := os.ReadFile(policyPath)
+	sigData, _ := os.ReadFile(policyPath + ".sig")
+	var sig SigFile
+	json.Unmarshal(sigData, &sig)
+	if err := Verify(policyBytes, &sig, ts); err != nil { t.Fatalf("expected valid: %v", err) }
+}
+
+func TestVerify_TamperedPolicy(t *testing.T) {
+	policyPath, tsDir := setupSignedPolicy(t)
+	ts, _ := LoadTrustStore(tsDir)
+	tamperedBytes := []byte("version: 1\nname: TAMPERED\n")
+	sigData, _ := os.ReadFile(policyPath + ".sig")
+	var sig SigFile
+	json.Unmarshal(sigData, &sig)
+	if err := Verify(tamperedBytes, &sig, ts); err == nil { t.Fatal("expected error for tampered policy") }
+}
+
+func TestVerify_WrongKey(t *testing.T) {
+	policyPath, _ := setupSignedPolicy(t)
+	otherDir := t.TempDir()
+	GenerateKeypair(otherDir, "other")
+	tsDir2 := t.TempDir()
+	pubData, _ := os.ReadFile(filepath.Join(otherDir, "public.key.json"))
+	os.WriteFile(filepath.Join(tsDir2, "other.json"), pubData, 0o644)
+	ts, _ := LoadTrustStore(tsDir2)
+	policyBytes, _ := os.ReadFile(policyPath)
+	sigData, _ := os.ReadFile(policyPath + ".sig")
+	var sig SigFile
+	json.Unmarshal(sigData, &sig)
+	if err := Verify(policyBytes, &sig, ts); err == nil { t.Fatal("expected error for wrong key") }
+}
+
+func TestVerifyPolicy_Valid(t *testing.T) {
+	policyPath, tsDir := setupSignedPolicy(t)
+	ts, _ := LoadTrustStore(tsDir)
+	result, err := VerifyPolicy(policyPath, ts)
+	if err != nil { t.Fatalf("expected valid: %v", err) }
+	if result.KeyID == "" { t.Fatal("expected key_id in result") }
+}
+
+func TestVerifyPolicy_MissingSig(t *testing.T) {
+	policyPath := filepath.Join(t.TempDir(), "test.yaml")
+	os.WriteFile(policyPath, []byte("version: 1\nname: test\n"), 0o644)
+	ts := &TrustStore{Keys: make(map[string]*PublicKeyFile)}
+	_, err := VerifyPolicy(policyPath, ts)
+	if err == nil { t.Fatal("expected error for missing sig") }
+}
+
+func TestVerify_InvalidSigSchema(t *testing.T) {
+	ts := &TrustStore{Keys: make(map[string]*PublicKeyFile)}
+	bad := &SigFile{Version: 2, Algorithm: "ed25519", KeyID: "x", Signature: "x", SignedAt: "x"}
+	if err := Verify([]byte("test"), bad, ts); err == nil { t.Fatal("expected error for bad version") }
+}
+
+func TestVerify_KeyRotation(t *testing.T) {
+	keyDir1, keyDir2 := t.TempDir(), t.TempDir()
+	GenerateKeypair(keyDir1, "key1")
+	GenerateKeypair(keyDir2, "key2")
+	policyDir := t.TempDir()
+	policyPath := filepath.Join(policyDir, "test.yaml")
+	os.WriteFile(policyPath, []byte("version: 1\nname: test\n"), 0o644)
+	SignFile(policyPath, filepath.Join(keyDir1, "private.key.json"), "", "")
+	tsDir := t.TempDir()
+	pub1, _ := os.ReadFile(filepath.Join(keyDir1, "public.key.json"))
+	pub2, _ := os.ReadFile(filepath.Join(keyDir2, "public.key.json"))
+	os.WriteFile(filepath.Join(tsDir, "key1.json"), pub1, 0o644)
+	os.WriteFile(filepath.Join(tsDir, "key2.json"), pub2, 0o644)
+	ts, _ := LoadTrustStore(tsDir)
+	result, err := VerifyPolicy(policyPath, ts)
+	if err != nil { t.Fatalf("expected valid with key rotation: %v", err) }
+	if result.KeyID == "" { t.Fatal("expected key_id in result") }
+}

--- a/internal/policy/signing/verify_test.go
+++ b/internal/policy/signing/verify_test.go
@@ -24,7 +24,7 @@ func setupSignedPolicy(t *testing.T) (policyPath, tsDir string) {
 
 func TestVerify_Valid(t *testing.T) {
 	policyPath, tsDir := setupSignedPolicy(t)
-	ts, _ := LoadTrustStore(tsDir)
+	ts, _ := LoadTrustStore(tsDir, false)
 	policyBytes, _ := os.ReadFile(policyPath)
 	sigData, _ := os.ReadFile(policyPath + ".sig")
 	var sig SigFile
@@ -34,7 +34,7 @@ func TestVerify_Valid(t *testing.T) {
 
 func TestVerify_TamperedPolicy(t *testing.T) {
 	policyPath, tsDir := setupSignedPolicy(t)
-	ts, _ := LoadTrustStore(tsDir)
+	ts, _ := LoadTrustStore(tsDir, false)
 	tamperedBytes := []byte("version: 1\nname: TAMPERED\n")
 	sigData, _ := os.ReadFile(policyPath + ".sig")
 	var sig SigFile
@@ -49,7 +49,7 @@ func TestVerify_WrongKey(t *testing.T) {
 	tsDir2 := t.TempDir()
 	pubData, _ := os.ReadFile(filepath.Join(otherDir, "public.key.json"))
 	os.WriteFile(filepath.Join(tsDir2, "other.json"), pubData, 0o644)
-	ts, _ := LoadTrustStore(tsDir2)
+	ts, _ := LoadTrustStore(tsDir2, false)
 	policyBytes, _ := os.ReadFile(policyPath)
 	sigData, _ := os.ReadFile(policyPath + ".sig")
 	var sig SigFile
@@ -59,7 +59,7 @@ func TestVerify_WrongKey(t *testing.T) {
 
 func TestVerifyPolicy_Valid(t *testing.T) {
 	policyPath, tsDir := setupSignedPolicy(t)
-	ts, _ := LoadTrustStore(tsDir)
+	ts, _ := LoadTrustStore(tsDir, false)
 	result, err := VerifyPolicy(policyPath, ts)
 	if err != nil { t.Fatalf("expected valid: %v", err) }
 	if result.KeyID == "" { t.Fatal("expected key_id in result") }
@@ -92,7 +92,7 @@ func TestVerify_KeyRotation(t *testing.T) {
 	pub2, _ := os.ReadFile(filepath.Join(keyDir2, "public.key.json"))
 	os.WriteFile(filepath.Join(tsDir, "key1.json"), pub1, 0o644)
 	os.WriteFile(filepath.Join(tsDir, "key2.json"), pub2, 0o644)
-	ts, _ := LoadTrustStore(tsDir)
+	ts, _ := LoadTrustStore(tsDir, false)
 	result, err := VerifyPolicy(policyPath, ts)
 	if err != nil { t.Fatalf("expected valid with key rotation: %v", err) }
 	if result.KeyID == "" { t.Fatal("expected key_id in result") }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -106,6 +106,7 @@ func New(cfg *config.Config) (*Server, error) {
 		cfg.Policies.ManifestPath,
 		os.Getenv("AGENTSH_POLICY_NAME"),
 	)
+	pm.SetSigningConfig(cfg.Policies.Signing.SigningMode(), cfg.Policies.Signing.TrustStore)
 	p, err := pm.Get()
 	if err != nil {
 		return nil, err

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -95,6 +95,10 @@ func New(cfg *config.Config) (*Server, error) {
 		return nil, fmt.Errorf("sandbox config: %w", err)
 	}
 
+	if err := cfg.Policies.Signing.Validate(); err != nil {
+		return nil, fmt.Errorf("signing config: %w", err)
+	}
+
 	pm := policy.NewManager(
 		cfg.Policies.Dir,
 		cfg.Policies.Default,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -310,7 +310,10 @@ func New(cfg *config.Config) (*Server, error) {
 		}
 	}
 
-	policyLoader := api.NewDefaultPolicyLoader(cfg.Policies.Dir, enforceApprovals, true)
+	policyLoader := api.NewDefaultPolicyLoader(
+		cfg.Policies.Dir, enforceApprovals, true,
+		cfg.Policies.Signing.SigningMode(), cfg.Policies.Signing.TrustStore,
+	)
 	app := api.NewApp(cfg, sessions, store, engine, broker, apiKeyAuth, oidcAuth, approvalsMgr, metricsCollector, policyLoader)
 	appCloser := app.Close // ensure cleanup on error paths below
 	defer func() {


### PR DESCRIPTION
## Summary

- Add Ed25519 detached signature support for policy files with configurable verification modes (`enforce`, `warn`, `off`)
- New `internal/policy/signing` package: types, key generation, signing, trust store, verification — all Go stdlib, no external deps
- Three new CLI commands: `policy keygen`, `policy sign`, `policy verify`
- Signature verification integrated into all policy loading paths: `Manager.Get()`, `DefaultPolicyLoader.Load()`, session creation, and FUSE mount
- Trust store validates key identity (SHA256 derivation), algorithm, expiry, permissions (Unix), and rejects duplicates
- Private key files enforced at 0600 with permission check on load
- Platform-aware: Unix permission checks skipped on Windows where mode bits are unreliable

## Design

- **Detached signatures** (`.sig` JSON files alongside policy YAML) — avoids YAML canonicalization issues
- **Full SHA256 key IDs** (64 hex chars) — no truncation, no collision risk
- **CA-ready format** — `cert_chain` field reserved for future certificate hierarchy
- **Shared verification function** (`VerifyPolicyBytes`) used by all loading paths — no logic duplication

## Test plan

- [x] 18 unit tests in `internal/policy/signing/` (types, keygen, sign, trust store, verify)
- [x] 10 Manager integration tests covering all mode × failure combinations
- [x] 9 config validation tests (`SigningConfig.Validate()` and `SigningMode()`)
- [x] 3 CLI integration tests (keygen, sign+verify round-trip, missing sig)
- [x] Full test suite passes (81 packages)
- [x] Windows cross-compilation clean
- [x] 5 rounds of roborev — all high/medium findings resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)