### PR TITLE
fix(ptrace): symlink verification + vfork fast-path

### DIFF
--- a/docs/superpowers/plans/2026-03-19-ptrace-symlink-vfork-fixes.md
+++ b/docs/superpowers/plans/2026-03-19-ptrace-symlink-vfork-fixes.md
@@ -1,0 +1,499 @@
+# Ptrace Symlink Verification + vfork Fast-path Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two ptrace tracer gaps: exit-time openat path verification to catch symlink bypasses, and vfork child fast-path to prevent deadlocks with Python subprocess.run.
+
+**Architecture:** Defense-in-depth exit-time fd verification for openat/openat2 catches any entry-time symlink resolution failure. vfork children skip policy evaluation for all non-exec syscalls, with the exit-time verification acting as a safety net.
+
+**Tech Stack:** Go, Linux ptrace, seccomp-BPF, `/proc` filesystem
+
+---
+
+### Task 1: Fix PTRACE_GET_SYSCALL_INFO Op check for seccomp stops
+
+**Files:**
+- Modify: `internal/ptrace/syscall_context.go:45-77`
+- Test: `internal/ptrace/syscall_context_test.go`
+
+- [ ] **Step 1: Write test for Op=3 acceptance**
+
+Add to `internal/ptrace/syscall_context_test.go`:
+
+```go
+func TestGetSyscallEntryInfoAcceptsSeccompOp(t *testing.T) {
+	// Op=3 (PTRACE_SYSCALL_INFO_SECCOMP) has the same nr+args layout
+	// as Op=1 (ENTRY) and must be accepted by getSyscallEntryInfo.
+	// This is a unit-level assertion on the Op check logic.
+	// The actual PTRACE_GET_SYSCALL_INFO call requires a traced process,
+	// so we verify the constant used in the check.
+	const ptraceSyscallInfoEntry = 1
+	const ptraceSyscallInfoSeccomp = 3
+	if ptraceSyscallInfoEntry == ptraceSyscallInfoSeccomp {
+		t.Fatal("entry and seccomp op values should differ")
+	}
+	// Verify Op=2 (EXIT) is still rejected by the check logic.
+	const ptraceSyscallInfoExit = 2
+	op := uint8(ptraceSyscallInfoExit)
+	if op == 1 || op == 3 {
+		t.Fatal("exit op should not match entry or seccomp")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes (baseline)**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/ptrace/ -run TestGetSyscallEntryInfoAcceptsSeccompOp -v`
+
+- [ ] **Step 3: Fix the Op check and update struct comment**
+
+In `internal/ptrace/syscall_context.go`, make two changes:
+
+1. Update the struct comment (line 45-47):
+```go
+// ptraceSyscallInfo mirrors struct ptrace_syscall_info (Linux 5.3+).
+// The kernel struct is a union; we use the entry/seccomp fields (op==1 or op==3).
+// Both variants share the same nr + args[6] layout at the same offset.
+// We request ptraceSyscallInfoSize bytes; the kernel writes min(requested, actual).
+```
+
+2. Update the Op check (line 75-76):
+```go
+	if info.Op != 1 && info.Op != 3 {
+		return nil, fmt.Errorf("PTRACE_GET_SYSCALL_INFO: unexpected op %d (want entry=1 or seccomp=3)", info.Op)
+	}
+```
+
+- [ ] **Step 4: Run all syscall_context tests**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/ptrace/ -run TestSyscallContext -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ptrace/syscall_context.go internal/ptrace/syscall_context_test.go
+git commit -m "fix(ptrace): accept Op=3 (seccomp) in PTRACE_GET_SYSCALL_INFO
+
+getSyscallEntryInfo rejected Op=3 (PTRACE_SYSCALL_INFO_SECCOMP), forcing
+a fallback to full getRegs on every seccomp stop. The seccomp variant
+has the same nr+args layout as entry — accept both."
+```
+
+---
+
+### Task 2: Always require exit stops for openat/openat2
+
+**Files:**
+- Modify: `internal/ptrace/tracer.go:468-480`
+- Test: `internal/ptrace/tracer_test.go:65-96`
+
+- [ ] **Step 1: Update the existing needsExitStop tests**
+
+The existing test at `tracer_test.go:74-75` expects `openat with mask off → false` and `openat2 with mask off → false`. These must change to `true`. Update `internal/ptrace/tracer_test.go`:
+
+Change the test cases:
+```go
+{"openat with mask on", unix.SYS_OPENAT, true, true, true},
+{"openat with mask off", unix.SYS_OPENAT, false, true, true},   // was false
+{"openat2 with mask off", unix.SYS_OPENAT2, false, true, true}, // was false
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/ptrace/ -run TestNeedsExitStop -v`
+Expected: FAIL — the two changed cases now expect `true` but get `false`
+
+- [ ] **Step 3: Update needsExitStop**
+
+In `internal/ptrace/tracer.go`, change the openat/openat2 case (line 472-473):
+
+```go
+	case unix.SYS_OPENAT, unix.SYS_OPENAT2:
+		return true // exit-time path verification for symlink defense-in-depth
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/ptrace/ -run TestNeedsExitStop -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ptrace/tracer.go internal/ptrace/tracer_test.go
+git commit -m "fix(ptrace): always require exit stops for openat/openat2
+
+Exit stops are now unconditional for openat/openat2, not just when
+MaskTracerPid is set. This enables exit-time path verification to
+catch symlink bypasses that evade entry-time resolution."
+```
+
+---
+
+### Task 3: Exit-time path verification in handleOpenatExit
+
+**Files:**
+- Modify: `internal/ptrace/tracer.go:993-1036` (handleSyscallExit + handleOpenatExit)
+- Modify: `internal/ptrace/handle_file.go` (add verifyOpenatPath)
+- Test: `internal/ptrace/handle_file_test.go`
+
+- [ ] **Step 1: Write test for symlink resolution through resolvePath**
+
+Add to `internal/ptrace/handle_file_test.go`:
+
+```go
+func TestResolvePath_FollowsSymlink(t *testing.T) {
+	// resolvePath must resolve symlinks to their targets.
+	// If /tmp/link -> /etc/hostname, resolvePath should return /etc/hostname.
+	tid := os.Getpid()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	os.WriteFile(target, []byte("x"), 0o644)
+	link := filepath.Join(dir, "link")
+	os.Symlink(target, link)
+
+	resolved, err := resolvePath(tid, unix.AT_FDCWD, link)
+	if err != nil {
+		t.Fatalf("resolvePath: %v", err)
+	}
+	if resolved != target {
+		t.Errorf("resolvePath(%q) = %q, want %q", link, resolved, target)
+	}
+}
+
+func TestResolvePath_ChainedSymlinks(t *testing.T) {
+	tid := os.Getpid()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "final")
+	os.WriteFile(target, []byte("x"), 0o644)
+	link1 := filepath.Join(dir, "link1")
+	link2 := filepath.Join(dir, "link2")
+	os.Symlink(target, link1)
+	os.Symlink(link1, link2)
+
+	resolved, err := resolvePath(tid, unix.AT_FDCWD, link2)
+	if err != nil {
+		t.Fatalf("resolvePath: %v", err)
+	}
+	if resolved != target {
+		t.Errorf("resolvePath(%q) = %q, want %q (through chain)", link2, resolved, target)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass (confirming entry-time resolution works)**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/ptrace/ -run "TestResolvePath_FollowsSymlink|TestResolvePath_ChainedSymlinks" -v`
+Expected: PASS — confirms existing entry-time resolution works in unit tests
+
+- [ ] **Step 3: Refactor handleOpenatExit to always read fd path**
+
+In `internal/ptrace/tracer.go`, refactor `handleOpenatExit` to: (a) always run (not gated on MaskTracerPid), (b) read the fd path once, (c) use it for both TracerPid masking and the new verification. The function now takes `context.Context` for policy evaluation.
+
+Replace the existing `handleOpenatExit` (lines 1005-1036) and update `handleSyscallExit` (line 999) to pass `ctx`:
+
+First, update `handleSyscallExit` signature and the openat case:
+```go
+func (t *Tracer) handleSyscallExit(ctx context.Context, tid int, nr int, regs Regs) {
+	switch {
+	case isReadSyscall(nr):
+		t.handleReadExit(tid, regs)
+	case nr == unix.SYS_OPENAT || nr == unix.SYS_OPENAT2:
+		t.handleOpenatExit(ctx, tid, regs)
+	case nr == unix.SYS_CONNECT:
+		t.handleConnectExit(tid, regs)
+	}
+}
+```
+
+Update the caller at line 932:
+```go
+			t.handleSyscallExit(ctx, tid, nr, exitRegs)
+```
+
+And for the seccomp path — since `handleSyscallStop` receives `ctx`, this just threads it through. The exit path in `handleSyscallStop` already has access to `ctx` from the function parameter.
+
+Now replace `handleOpenatExit`:
+```go
+// handleOpenatExit verifies the opened path against policy and tracks
+// /proc/*/status fds for TracerPid masking.
+func (t *Tracer) handleOpenatExit(ctx context.Context, tid int, regs Regs) {
+	retVal := regs.ReturnValue()
+	if retVal < 0 {
+		return // open failed
+	}
+	fd := int(retVal)
+
+	t.mu.Lock()
+	state := t.tracees[tid]
+	var tgid int
+	var sessionID string
+	if state != nil {
+		tgid = state.TGID
+		sessionID = state.SessionID
+	}
+	t.mu.Unlock()
+
+	// Read the real path the kernel opened.
+	path, err := os.Readlink(fmt.Sprintf("/proc/%d/fd/%d", tid, fd))
+	if err != nil {
+		// Cannot verify — fail closed. Close the fd and deny.
+		slog.Warn("handleOpenatExit: cannot read fd path, denying",
+			"tid", tid, "fd", fd, "error", err)
+		savedRegs := regs.Clone()
+		t.cleanupInjectedFD(tid, savedRegs, fd, -1)
+		t.applyReturnOverride(tid, -int64(unix.EACCES))
+		return
+	}
+
+	// TracerPid masking: track fds opened on /proc/*/status.
+	if t.fds != nil && t.cfg.MaskTracerPid && isProcStatus(path) {
+		t.fds.trackStatusFd(tgid, fd)
+		t.escalateReadForTGID(tgid, tid)
+	}
+
+	// Exit-time path verification: evaluate policy against the real path.
+	if t.cfg.FileHandler != nil && t.cfg.TraceFile && sessionID != "" {
+		result := t.cfg.FileHandler.HandleFile(ctx, FileContext{
+			PID:       tgid,
+			SessionID: sessionID,
+			Syscall:   unix.SYS_OPENAT,
+			Path:      path,
+			Operation: "open",
+		})
+		action := result.Action
+		if action == "" {
+			if result.Allow {
+				action = "allow"
+			} else {
+				action = "deny"
+			}
+		}
+		if action == "deny" {
+			slog.Warn("handleOpenatExit: exit-time verification denied",
+				"tid", tid, "fd", fd, "path", path)
+			savedRegs := regs.Clone()
+			t.cleanupInjectedFD(tid, savedRegs, fd, -1)
+			t.applyReturnOverride(tid, -int64(unix.EACCES))
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run all tests to verify nothing is broken**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/ptrace/ -v -count=1 2>&1 | tail -20`
+Expected: All existing tests PASS
+
+- [ ] **Step 5: Run full build including cross-compilation**
+
+Run: `cd /home/eran/work/agentsh && go build ./... && GOOS=windows go build ./...`
+Expected: Both succeed
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/ptrace/tracer.go internal/ptrace/handle_file.go internal/ptrace/handle_file_test.go
+git commit -m "fix(ptrace): add exit-time path verification for openat/openat2
+
+After a successful openat, read /proc/<tid>/fd/<fd> to verify the real
+path against policy. If denied (e.g. symlink resolved to a forbidden
+target), close the fd and override the return to -EACCES.
+
+This is defense-in-depth: catches symlink bypasses regardless of whether
+entry-time resolution via resolveViaProc fails due to environmental
+issues. Also refactors handleOpenatExit to always run (not gated on
+MaskTracerPid) and share the readlink result for both verification
+and TracerPid masking."
+```
+
+---
+
+### Task 4: vfork child fast-path in handleSeccompStop
+
+**Files:**
+- Modify: `internal/ptrace/tracer.go:940-969` (handleSeccompStop)
+- Test: `internal/ptrace/tracer_test.go`
+
+- [ ] **Step 1: Write test for vfork fast-path logic**
+
+Add to `internal/ptrace/tracer_test.go`:
+
+```go
+func TestIsVforkFastPathSkipsNonExec(t *testing.T) {
+	// Verify the fast-path condition: IsVforkChild && !isExecveSyscall
+	tests := []struct {
+		name      string
+		isVfork   bool
+		nr        int
+		wantFast  bool
+	}{
+		{"vfork child close", true, unix.SYS_CLOSE, true},
+		{"vfork child openat", true, unix.SYS_OPENAT, true},
+		{"vfork child execve", true, unix.SYS_EXECVE, false},
+		{"vfork child execveat", true, unix.SYS_EXECVEAT, false},
+		{"non-vfork close", false, unix.SYS_CLOSE, false},
+		{"non-vfork openat", false, unix.SYS_OPENAT, false},
+		{"non-vfork execve", false, unix.SYS_EXECVE, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.isVfork && !isExecveSyscall(tt.nr)
+			if got != tt.wantFast {
+				t.Errorf("fastPath(%v, %d) = %v, want %v",
+					tt.isVfork, tt.nr, got, tt.wantFast)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes (logic test)**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/ptrace/ -run TestIsVforkFastPathSkipsNonExec -v`
+Expected: PASS
+
+- [ ] **Step 3: Add vfork fast-path to handleSeccompStop**
+
+In `internal/ptrace/tracer.go`, modify `handleSeccompStop` (lines 940-969). Insert the fast-path check after the mutex unlock, before `dispatchSyscall`:
+
+```go
+func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
+	sc, err := t.buildSyscallContext(tid)
+	if err != nil {
+		t.allowSyscall(tid)
+		return
+	}
+	nr := sc.Info.Nr
+
+	t.mu.Lock()
+	state := t.tracees[tid]
+	isVfork := state != nil && state.IsVforkChild
+	if state != nil {
+		state.InSyscall = true
+		state.LastNr = nr
+		state.NeedExitStop = t.needsExitStop(nr)
+		// Seccomp stops are entry-only. Defer escalation to next exit stop.
+		if state.NeedsReadEscalation && !state.ThreadHasReadEscalation {
+			state.PendingReadEscalation = true
+		}
+		if state.NeedsWriteEscalation && !state.ThreadHasWriteEscalation {
+			state.PendingWriteEscalation = true
+		}
+	}
+	t.mu.Unlock()
+
+	// Fast-path: vfork children only need policy evaluation at execve.
+	// All other syscalls between vfork and exec are async-signal-safe
+	// setup operations (close, dup2, sigaction, etc.) — safe to allow.
+	// For openat/openat2, NeedExitStop is already set above, so
+	// exit-time path verification still runs as a safety net.
+	if isVfork && !isExecveSyscall(nr) {
+		t.allowSyscall(tid)
+		return
+	}
+
+	t.dispatchSyscall(ctx, tid, nr, sc)
+}
+```
+
+- [ ] **Step 4: Run all tests**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/ptrace/ -v -count=1 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ptrace/tracer.go internal/ptrace/tracer_test.go
+git commit -m "fix(ptrace): fast-path vfork children in handleSeccompStop
+
+Skip policy evaluation for non-execve syscalls when IsVforkChild is set.
+Between vfork and exec, only async-signal-safe operations occur (close,
+dup2, sigaction, etc.) which are safe to allow without policy evaluation.
+
+Execve still gets full policy evaluation. For openat (undefined behavior
+between vfork/exec), NeedExitStop is set before the fast-path check,
+so exit-time path verification still catches policy violations."
+```
+
+---
+
+### Task 5: vfork child fast-path in handleSyscallStop
+
+**Files:**
+- Modify: `internal/ptrace/tracer.go:886-904` (handleSyscallStop entry path)
+
+- [ ] **Step 1: Add vfork fast-path to handleSyscallStop entry path**
+
+In `internal/ptrace/tracer.go`, modify the `entering` branch (lines 890-903). Insert the fast-path check after setting `NeedExitStop` and before `dispatchSyscall`:
+
+```go
+	if entering {
+		sc, err := t.buildSyscallContext(tid)
+		if err != nil {
+			t.allowSyscall(tid)
+			return
+		}
+		nr := sc.Info.Nr
+		state.LastNr = nr
+		state.NeedExitStop = t.needsExitStop(nr)
+
+		// Fast-path vfork children (same logic as handleSeccompStop).
+		if state.IsVforkChild && !isExecveSyscall(nr) {
+			t.allowSyscall(tid)
+			return
+		}
+
+		t.dispatchSyscall(ctx, tid, nr, sc)
+	} else {
+```
+
+- [ ] **Step 2: Run all tests**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/ptrace/ -v -count=1 2>&1 | tail -20`
+Expected: PASS
+
+- [ ] **Step 3: Run full build including cross-compilation**
+
+Run: `cd /home/eran/work/agentsh && go build ./... && GOOS=windows go build ./...`
+Expected: Both succeed
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/ptrace/tracer.go
+git commit -m "fix(ptrace): fast-path vfork children in handleSyscallStop
+
+Mirror the handleSeccompStop fast-path for the TRACESYSGOOD code path
+(used when seccomp prefilter is disabled). Same logic: skip policy
+evaluation for non-execve syscalls when IsVforkChild is set."
+```
+
+---
+
+### Task 6: Final verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd /home/eran/work/agentsh && go test ./... -count=1 2>&1 | tail -30`
+Expected: All tests PASS
+
+- [ ] **Step 2: Verify cross-compilation**
+
+Run: `cd /home/eran/work/agentsh && GOOS=windows go build ./...`
+Expected: SUCCESS
+
+- [ ] **Step 3: Review all changes on the branch**
+
+Run: `cd /home/eran/work/agentsh && git log --oneline main..HEAD`
+
+Expected commits (oldest to newest):
+1. `fix(ptrace): accept Op=3 (seccomp) in PTRACE_GET_SYSCALL_INFO`
+2. `fix(ptrace): always require exit stops for openat/openat2`
+3. `fix(ptrace): add exit-time path verification for openat/openat2`
+4. `fix(ptrace): fast-path vfork children in handleSeccompStop`
+5. `fix(ptrace): fast-path vfork children in handleSyscallStop`

--- a/docs/superpowers/specs/2026-03-19-ptrace-symlink-vfork-fixes-design.md
+++ b/docs/superpowers/specs/2026-03-19-ptrace-symlink-vfork-fixes-design.md
@@ -1,0 +1,225 @@
+# Ptrace Tracer: Symlink Verification + vfork Fast-path
+
+**Date:** 2026-03-19
+**Status:** Design
+**Context:** Vercel Sandbox testing (Firecracker VM, ptrace-only enforcement) found 2 gaps: symlink escape via openat and vfork+ptrace deadlock with Python subprocess.run.
+
+---
+
+## Gap 1: Symlink Resolution Bypass — Exit-time Verification
+
+### Problem
+
+When a tracee opens a file through a symlink (e.g., `cat /tmp/shadow_link` where the symlink points to `/etc/shadow`), the policy should evaluate against the resolved target (`/etc/shadow`), not the symlink path (`/tmp/shadow_link`).
+
+The tracer already has entry-time symlink resolution via `resolveViaProc()` which walks components through `/proc/<tid>/root`. However, the bypass is still reproducible on `main`, suggesting an environmental or edge-case failure in the resolution pipeline. The exact root cause has not been isolated.
+
+### Solution
+
+Defense-in-depth: add exit-time path verification for openat/openat2. After the kernel completes the open, read what was actually opened and verify it against policy.
+
+#### 1.1 Fix PTRACE_GET_SYSCALL_INFO Op check
+
+**File:** `internal/ptrace/syscall_context.go`
+
+`getSyscallEntryInfo` currently rejects any `Op != 1`. For PTRACE_EVENT_SECCOMP stops, the kernel returns `Op = 3` (PTRACE_SYSCALL_INFO_SECCOMP). The seccomp variant has the same struct layout as entry for `nr` and `args[6]`, so the data is valid. The strict check forces a fallback to full `getRegs()` on every seccomp stop.
+
+Fix: accept `Op == 1` (entry) or `Op == 3` (seccomp). Both have identical `nr + args[6]` layout.
+
+```go
+// Before:
+if info.Op != 1 {
+    return nil, fmt.Errorf("unexpected op %d (want entry=1)", info.Op)
+}
+
+// After:
+if info.Op != 1 && info.Op != 3 {
+    return nil, fmt.Errorf("unexpected op %d (want entry=1 or seccomp=3)", info.Op)
+}
+```
+
+#### 1.2 Always require exit stops for openat/openat2
+
+**File:** `internal/ptrace/tracer.go`
+
+Change `needsExitStop()` to always return true for `SYS_OPENAT` and `SYS_OPENAT2`:
+
+```go
+// Before:
+case unix.SYS_OPENAT, unix.SYS_OPENAT2:
+    return t.cfg.MaskTracerPid
+
+// After:
+case unix.SYS_OPENAT, unix.SYS_OPENAT2:
+    return true
+```
+
+This ensures the tracer catches the exit stop so `handleOpenatExit` can verify the opened path.
+
+#### 1.3 Exit-time path verification
+
+**File:** `internal/ptrace/handle_file.go` (in `handleOpenatExit` or new function called from it)
+
+After a successful openat (retVal >= 0):
+
+1. Read the real path: `os.Readlink(fmt.Sprintf("/proc/%d/fd/%d", tid, fd))`
+2. If the path read fails, skip verification (the fd may have been closed already by another thread)
+3. Evaluate policy against the real path using `t.cfg.FileHandler.HandleFile(ctx, FileContext{...})`
+4. If denied:
+   a. Inject `close(fd)` into the tracee using existing `injectSyscall` / register manipulation
+   b. Override the return value to `-EACCES` using `setRegs` to modify the return register
+
+The existing `handleOpenatExit` already reads `/proc/<tid>/fd/<fd>` for TracerPid masking. The verification piggybacks on this read.
+
+**Implementation detail for fd cleanup:** The tracer needs to close the fd in the tracee's fd table before overriding the return. The simplest approach:
+
+1. Read current regs
+2. Save current regs
+3. Set syscall nr to `SYS_CLOSE`, arg0 to `fd`
+4. `PtraceSyscall` to execute the close
+5. Wait for exit stop
+6. Restore saved regs with return value set to `-EACCES`
+7. Resume
+
+This pattern is already used by `cleanupInjectedFD` for exec redirect cleanup.
+
+**SessionID for policy evaluation:** The exit-time handler needs the session ID and TGID. These are already available via `t.tracees[tid]` (same as `handleOpenatExit` uses today).
+
+### Performance impact
+
+Adds one extra ptrace stop cycle per openat/openat2 (exit stop). For file-heavy workloads this is measurable but acceptable given the security criticality. The exit path is lightweight when the path is allowed (just a `Readlink` + policy check, no fd injection needed).
+
+---
+
+## Gap 2: vfork + ptrace Deadlock — Fast-path vfork Children
+
+### Problem
+
+Python's `subprocess.run()` with `capture_output=True` uses `vfork()` on Linux since Python 3.9. With vfork:
+
+1. Parent is kernel-frozen until the child calls `execve()` or `_exit()`
+2. Child makes setup syscalls (close, dup2, etc.) between vfork and exec
+3. Each syscall generates a ptrace stop (seccomp or TRACESYSGOOD)
+4. Each stop requires: read syscall info, read tracee memory, resolve paths, evaluate policy, resume
+5. Accumulated latency keeps the parent frozen longer
+6. External timeouts trigger, causing empty API responses
+
+`os.system()` works because it uses `fork()` (not vfork) — the parent is not frozen.
+
+### Solution
+
+Fast-path all syscalls for vfork children except execve/execveat. Between vfork and exec, POSIX restricts the child to async-signal-safe operations only. These don't access controlled resources and are safe to allow without policy evaluation.
+
+#### 2.1 Fast-path in handleSeccompStop
+
+**File:** `internal/ptrace/tracer.go`
+
+After reading state and before `dispatchSyscall`, check `IsVforkChild`:
+
+```go
+func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
+    sc, err := t.buildSyscallContext(tid)
+    if err != nil {
+        t.allowSyscall(tid)
+        return
+    }
+    nr := sc.Info.Nr
+
+    t.mu.Lock()
+    state := t.tracees[tid]
+    isVfork := state != nil && state.IsVforkChild
+    if state != nil {
+        state.InSyscall = true
+        state.LastNr = nr
+        state.NeedExitStop = t.needsExitStop(nr)
+        // ... existing escalation logic ...
+    }
+    t.mu.Unlock()
+
+    // Fast-path: vfork children only need policy evaluation at execve.
+    // All other syscalls between vfork and exec are async-signal-safe
+    // setup operations (close, dup2, sigaction, etc.) — safe to allow.
+    if isVfork && !isExecveSyscall(nr) {
+        t.allowSyscall(tid)
+        return
+    }
+
+    t.dispatchSyscall(ctx, tid, nr, sc)
+}
+```
+
+#### 2.2 Fast-path in handleSyscallStop (entry path)
+
+**File:** `internal/ptrace/tracer.go`
+
+In the `entering` branch of `handleSyscallStop`, add the same check after `buildSyscallContext`:
+
+```go
+if entering {
+    sc, err := t.buildSyscallContext(tid)
+    if err != nil {
+        t.allowSyscall(tid)
+        return
+    }
+    nr := sc.Info.Nr
+    state.LastNr = nr
+    state.NeedExitStop = t.needsExitStop(nr)
+
+    // Fast-path vfork children (same logic as handleSeccompStop).
+    if state.IsVforkChild && !isExecveSyscall(nr) {
+        t.allowSyscall(tid)
+        return
+    }
+
+    t.dispatchSyscall(ctx, tid, nr, sc)
+}
+```
+
+#### 2.3 Existing lifecycle (no changes needed)
+
+- `IsVforkChild = true`: set by `markVforkChild()` after PTRACE_EVENT_VFORK (line 1235)
+- `IsVforkChild = false`: cleared by `handleExecEvent()` after PTRACE_EVENT_EXEC (line 1247)
+- After exec, the process is no longer a vfork child and gets full policy enforcement for all subsequent syscalls
+
+### Security analysis
+
+**What's allowed without policy check:** close, dup2/dup3, sigaction, sigprocmask, setsid, setpgid, chdir, _exit. These are:
+- fd management (close, dup2) — rearranging already-open fds
+- Signal management — no security implications
+- Process group management — no security implications
+- _exit — terminates the child
+
+**What still gets full policy check:** execve/execveat — the actual security boundary where the child starts a new program. This is where path resolution, argument inspection, and policy evaluation matter.
+
+**Risk:** A malicious vfork child could call `openat()` between vfork and exec, which would be allowed without policy check. However, this is undefined behavior (POSIX only allows async-signal-safe functions after vfork), and the kernel may not support it reliably. Additionally, the exit-time verification from Gap 1 would catch any policy-violating opens.
+
+### Performance impact
+
+Eliminates all policy evaluation overhead between vfork and exec. The ptrace stop/resume cycle itself (kernel context switch) remains, but per-stop processing drops from ~50us (memory read + path resolution + policy eval) to ~1us (check flag + allow).
+
+---
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `internal/ptrace/syscall_context.go` | Accept Op=1 and Op=3 in `getSyscallEntryInfo` |
+| `internal/ptrace/tracer.go` | `needsExitStop`: always true for openat/openat2. Fast-path vfork children in `handleSeccompStop` and `handleSyscallStop` |
+| `internal/ptrace/handle_file.go` | `handleOpenatExit`: exit-time path verification with policy check, fd close + return override on deny |
+| `internal/ptrace/handle_file_test.go` | Tests for exit-time symlink verification |
+| `internal/ptrace/tracer_test.go` | Tests for vfork fast-path behavior |
+
+## Test plan
+
+### Gap 1 tests
+- Symlink to denied path: create symlink `/tmp/link` → `/etc/shadow`, verify openat through symlink is denied
+- Chained symlinks: `/tmp/link2` → `/tmp/link1` → `/etc/shadow`, verify denied
+- Symlink to allowed path: `/tmp/link` → `/etc/os-release`, verify allowed
+- O_NOFOLLOW: openat with O_NOFOLLOW on symlink, verify resolvePathNoFollow is used
+- Exit-time verification unit test: mock a scenario where entry-time resolution returns wrong path, verify exit-time catch
+
+### Gap 2 tests
+- vfork child close/dup2: verify allowed without policy evaluation
+- vfork child execve: verify full policy evaluation occurs
+- IsVforkChild lifecycle: verify flag set at vfork, cleared at exec
+- Non-vfork child: verify normal policy evaluation for all syscalls

--- a/docs/superpowers/specs/2026-03-19-ptrace-symlink-vfork-fixes-design.md
+++ b/docs/superpowers/specs/2026-03-19-ptrace-symlink-vfork-fixes-design.md
@@ -38,6 +38,8 @@ if info.Op != 1 && info.Op != 3 {
 }
 ```
 
+Also update the `ptraceSyscallInfo` struct comment to document that both Op=1 (entry) and Op=3 (seccomp) share the same `nr + args[6]` layout in the union.
+
 #### 1.2 Always require exit stops for openat/openat2
 
 **File:** `internal/ptrace/tracer.go`
@@ -63,25 +65,24 @@ This ensures the tracer catches the exit stop so `handleOpenatExit` can verify t
 After a successful openat (retVal >= 0):
 
 1. Read the real path: `os.Readlink(fmt.Sprintf("/proc/%d/fd/%d", tid, fd))`
-2. If the path read fails, skip verification (the fd may have been closed already by another thread)
+2. If the path read fails (EBADF, ENOENT, or any error), deny the syscall — fail closed. Override the return value to `-EACCES` and inject `close(fd)`. Rationale: if we cannot verify the opened path, we cannot confirm it's allowed by policy.
 3. Evaluate policy against the real path using `t.cfg.FileHandler.HandleFile(ctx, FileContext{...})`
 4. If denied:
-   a. Inject `close(fd)` into the tracee using existing `injectSyscall` / register manipulation
-   b. Override the return value to `-EACCES` using `setRegs` to modify the return register
+   a. Inject `close(fd)` into the tracee to clean up the leaked fd
+   b. Override the return value to `-EACCES`
 
-The existing `handleOpenatExit` already reads `/proc/<tid>/fd/<fd>` for TracerPid masking. The verification piggybacks on this read.
+The existing `handleOpenatExit` already reads `/proc/<tid>/fd/<fd>` for TracerPid masking. The verification piggybacks on this read — do the Readlink once, use for both TracerPid masking and policy verification.
 
-**Implementation detail for fd cleanup:** The tracer needs to close the fd in the tracee's fd table before overriding the return. The simplest approach:
+**Implementation detail for fd cleanup:** Use the existing `cleanupInjectedFD` pattern (used for exec redirect cleanup at `tracer.go:915-920`). This function:
 
-1. Read current regs
-2. Save current regs
-3. Set syscall nr to `SYS_CLOSE`, arg0 to `fd`
-4. `PtraceSyscall` to execute the close
-5. Wait for exit stop
-6. Restore saved regs with return value set to `-EACCES`
-7. Resume
+1. Reads current regs and saves a clone
+2. Sets syscall nr to `SYS_CLOSE`, arg0 to `fd`
+3. Resumes with `PtraceSyscall` to execute the close
+4. Waits for exit stop (the close completes)
+5. Restores saved regs with return value overridden to `-EACCES`
+6. Resumes
 
-This pattern is already used by `cleanupInjectedFD` for exec redirect cleanup.
+**InSyscall state:** At exit-time, `state.InSyscall` is `false` (the entry/exit toggle already flipped it). The `cleanupInjectedFD` pattern handles this correctly — it injects from the exit state, which uses the entry-phase injection protocol (modify ORIG_RAX, one cycle to exit). Follow the exact same calling convention as the exec redirect cleanup path.
 
 **SessionID for policy evaluation:** The exit-time handler needs the session ID and TGID. These are already available via `t.tracees[tid]` (same as `handleOpenatExit` uses today).
 
@@ -183,7 +184,7 @@ if entering {
 
 ### Security analysis
 
-**What's allowed without policy check:** close, dup2/dup3, sigaction, sigprocmask, setsid, setpgid, chdir, _exit. These are:
+**What's allowed without policy check:** close, dup2/dup3, sigaction, sigprocmask, setsid, setpgid, _exit. These are:
 - fd management (close, dup2) — rearranging already-open fds
 - Signal management — no security implications
 - Process group management — no security implications
@@ -191,7 +192,18 @@ if entering {
 
 **What still gets full policy check:** execve/execveat — the actual security boundary where the child starts a new program. This is where path resolution, argument inspection, and policy evaluation matter.
 
-**Risk:** A malicious vfork child could call `openat()` between vfork and exec, which would be allowed without policy check. However, this is undefined behavior (POSIX only allows async-signal-safe functions after vfork), and the kernel may not support it reliably. Additionally, the exit-time verification from Gap 1 would catch any policy-violating opens.
+**openat between vfork and exec:** A vfork child calling `openat()` is undefined behavior per POSIX (only async-signal-safe functions allowed). However, the fast-path does allow it without entry-time policy evaluation. This is caught by the exit-time verification from Gap 1:
+
+- The fast-path sets `NeedExitStop = true` for openat (via `needsExitStop()` before the vfork check)
+- `allowSyscall()` checks `mustCatchExit()` → true → resumes with `PtraceSyscall`
+- The exit stop is caught → `handleSyscallExit` → `handleOpenatExit` → exit-time path verification runs
+- If the real path is denied by policy, the fd is closed and return overridden to -EACCES
+
+This means the Gap 1 exit-time verification acts as a safety net for any openat calls fast-pathed by Gap 2.
+
+**chdir between vfork and exec:** Python's subprocess module uses `fchdir()` (on a pre-opened fd) rather than `chdir()` for the `cwd` parameter. `fchdir` operates on an already-open fd and doesn't take a path argument, so it doesn't need path-based policy evaluation. A bare `chdir()` call between vfork and exec is both unusual and undefined behavior. It's allowed by the fast-path but has minimal security impact — it only affects the working directory for the subsequent exec, which gets full policy evaluation including path resolution relative to the new cwd.
+
+**Signal delivery during vfork:** Signals to the vfork child are constrained by the kernel (the child shares the parent's signal handlers and stack). This is not a new constraint introduced by the fast-path.
 
 ### Performance impact
 
@@ -223,3 +235,8 @@ Eliminates all policy evaluation overhead between vfork and exec. The ptrace sto
 - vfork child execve: verify full policy evaluation occurs
 - IsVforkChild lifecycle: verify flag set at vfork, cleared at exec
 - Non-vfork child: verify normal policy evaluation for all syscalls
+- vfork child openat to denied path: verify exit-time verification catches the violation (NeedExitStop is set, exit handler runs, fd closed, return overridden)
+
+### Cross-gap interaction tests
+- vfork child openat through symlink to denied path: verify the Gap 1 exit-time verification catches the bypass even though the Gap 2 fast-path skipped entry-time policy evaluation
+- Both prefilter and non-prefilter modes: verify fast-path works correctly with both `handleSeccompStop` and `handleSyscallStop` code paths

--- a/internal/ptrace/handle_file.go
+++ b/internal/ptrace/handle_file.go
@@ -262,6 +262,17 @@ func (t *Tracer) handleFile(ctx context.Context, tid int, sc *SyscallContext) {
 		}
 	}
 
+	// Stash entry-time action for exit-time verification (event-loop-only).
+	// Exit-time verification only re-checks when entry allowed, since
+	// redirect/soft-delete modify the syscall and the exit path reflects
+	// the modified operation, not a symlink bypass.
+	if nr == unix.SYS_OPENAT || nr == unix.SYS_OPENAT2 {
+		// state was read above under mutex; LastFileAction is event-loop-only.
+		if state != nil {
+			state.LastFileAction = action
+		}
+	}
+
 	switch action {
 	case "allow", "continue":
 		t.allowSyscall(tid)

--- a/internal/ptrace/handle_file.go
+++ b/internal/ptrace/handle_file.go
@@ -231,6 +231,11 @@ func (t *Tracer) handleFile(ctx context.Context, tid int, sc *SyscallContext) {
 	if state != nil {
 		tgid = state.TGID
 		sessionID = state.SessionID
+		// Stash flags/operation for exit-time verification (event-loop-only fields).
+		if nr == unix.SYS_OPENAT || nr == unix.SYS_OPENAT2 {
+			state.LastOpenFlags = flags
+			state.LastOpenOp = operation
+		}
 	}
 	t.mu.Unlock()
 

--- a/internal/ptrace/handle_file_test.go
+++ b/internal/ptrace/handle_file_test.go
@@ -93,6 +93,42 @@ func TestResolvePath_NotDir(t *testing.T) {
 	}
 }
 
+func TestResolvePath_FollowsSymlink(t *testing.T) {
+	tid := os.Getpid()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	os.WriteFile(target, []byte("x"), 0o644)
+	link := filepath.Join(dir, "link")
+	os.Symlink(target, link)
+
+	resolved, err := resolvePath(tid, unix.AT_FDCWD, link)
+	if err != nil {
+		t.Fatalf("resolvePath: %v", err)
+	}
+	if resolved != target {
+		t.Errorf("resolvePath(%q) = %q, want %q", link, resolved, target)
+	}
+}
+
+func TestResolvePath_ChainedSymlinks(t *testing.T) {
+	tid := os.Getpid()
+	dir := t.TempDir()
+	target := filepath.Join(dir, "final")
+	os.WriteFile(target, []byte("x"), 0o644)
+	link1 := filepath.Join(dir, "link1")
+	link2 := filepath.Join(dir, "link2")
+	os.Symlink(target, link1)
+	os.Symlink(link1, link2)
+
+	resolved, err := resolvePath(tid, unix.AT_FDCWD, link2)
+	if err != nil {
+		t.Fatalf("resolvePath: %v", err)
+	}
+	if resolved != target {
+		t.Errorf("resolvePath(%q) = %q, want %q (through chain)", link2, resolved, target)
+	}
+}
+
 func TestResolvePath_DanglingSymlink(t *testing.T) {
 	// A dangling symlink should cause resolvePath to fail, not silently
 	// return the symlink path. The kernel would follow the symlink on

--- a/internal/ptrace/syscall_context.go
+++ b/internal/ptrace/syscall_context.go
@@ -42,8 +42,9 @@ func (sc *SyscallContext) Regs() (Regs, error) {
 	return sc.regs, nil
 }
 
-// ptraceSyscallInfo mirrors the entry variant of struct ptrace_syscall_info (Linux 5.3+).
-// The kernel struct is a union; we only use the entry fields (op==1).
+// ptraceSyscallInfo mirrors struct ptrace_syscall_info (Linux 5.3+).
+// The kernel struct is a union; we use the entry/seccomp fields (op==1 or op==3).
+// Both variants share the same nr + args[6] layout at the same offset.
 // We request ptraceSyscallInfoSize bytes; the kernel writes min(requested, actual).
 type ptraceSyscallInfo struct {
 	Op                 uint8
@@ -72,8 +73,8 @@ func (t *Tracer) getSyscallEntryInfo(tid int) (*SyscallEntryInfo, error) {
 	if errno != 0 {
 		return nil, fmt.Errorf("PTRACE_GET_SYSCALL_INFO: %w", errno)
 	}
-	if info.Op != 1 {
-		return nil, fmt.Errorf("PTRACE_GET_SYSCALL_INFO: unexpected op %d (want entry=1)", info.Op)
+	if info.Op != 1 && info.Op != 3 {
+		return nil, fmt.Errorf("PTRACE_GET_SYSCALL_INFO: unexpected op %d (want entry=1 or seccomp=3)", info.Op)
 	}
 	return &SyscallEntryInfo{
 		Nr:   int(info.EntryNr),

--- a/internal/ptrace/syscall_context_test.go
+++ b/internal/ptrace/syscall_context_test.go
@@ -8,6 +8,25 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func TestGetSyscallEntryInfoAcceptsSeccompOp(t *testing.T) {
+	// Op=3 (PTRACE_SYSCALL_INFO_SECCOMP) has the same nr+args layout
+	// as Op=1 (ENTRY) and must be accepted by getSyscallEntryInfo.
+	// This is a unit-level assertion on the Op check logic.
+	// The actual PTRACE_GET_SYSCALL_INFO call requires a traced process,
+	// so we verify the constant used in the check.
+	const ptraceSyscallInfoEntry = 1
+	const ptraceSyscallInfoSeccomp = 3
+	if ptraceSyscallInfoEntry == ptraceSyscallInfoSeccomp {
+		t.Fatal("entry and seccomp op values should differ")
+	}
+	// Verify Op=2 (EXIT) is still rejected by the check logic.
+	const ptraceSyscallInfoExit = 2
+	op := uint8(ptraceSyscallInfoExit)
+	if op == 1 || op == 3 {
+		t.Fatal("exit op should not match entry or seccomp")
+	}
+}
+
 func TestSyscallContextLazyRegs(t *testing.T) {
 	sc := &SyscallContext{
 		Info: SyscallEntryInfo{

--- a/internal/ptrace/syscalls.go
+++ b/internal/ptrace/syscalls.go
@@ -111,7 +111,7 @@ func AllFileSyscalls() []int {
 func isVforkSafeSyscall(nr int) bool {
 	switch nr {
 	case unix.SYS_CLOSE,
-		unix.SYS_DUP2, unix.SYS_DUP3,
+		unix.SYS_DUP3,
 		unix.SYS_FCNTL,
 		unix.SYS_RT_SIGACTION, unix.SYS_RT_SIGPROCMASK, unix.SYS_RT_SIGRETURN,
 		unix.SYS_SETSID, unix.SYS_SETPGID, unix.SYS_GETPID, unix.SYS_GETPPID,

--- a/internal/ptrace/syscalls.go
+++ b/internal/ptrace/syscalls.go
@@ -104,6 +104,24 @@ func AllFileSyscalls() []int {
 	return nums
 }
 
+// isVforkSafeSyscall returns true for syscalls that are safe to allow without
+// policy evaluation in a vfork child. These are async-signal-safe operations
+// used by subprocess setup (close, dup2, sigaction, etc.). Anything not in
+// this allowlist goes through normal policy evaluation.
+func isVforkSafeSyscall(nr int) bool {
+	switch nr {
+	case unix.SYS_CLOSE,
+		unix.SYS_DUP2, unix.SYS_DUP3,
+		unix.SYS_FCNTL,
+		unix.SYS_RT_SIGACTION, unix.SYS_RT_SIGPROCMASK, unix.SYS_RT_SIGRETURN,
+		unix.SYS_SETSID, unix.SYS_SETPGID, unix.SYS_GETPID, unix.SYS_GETPPID,
+		unix.SYS_EXIT_GROUP, unix.SYS_EXIT,
+		unix.SYS_CLOSE_RANGE:
+		return true
+	}
+	return false
+}
+
 // AllNetworkSyscalls returns all network-related syscall numbers that the
 // tracer intercepts (connect, bind, sendto). Exported for use by
 // StaticAllowChecker implementations.

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -470,7 +470,7 @@ func (t *Tracer) needsExitStop(nr int) bool {
 	case unix.SYS_READ, unix.SYS_PREAD64:
 		return true // only traced when escalated — always needs exit
 	case unix.SYS_OPENAT, unix.SYS_OPENAT2:
-		return t.cfg.MaskTracerPid // fd tracking for TracerPid masking
+		return true // exit-time path verification for symlink defense-in-depth
 	case unix.SYS_CONNECT:
 		return t.cfg.TraceNetwork // inline skip in handleNetwork handles port granularity
 	case unix.SYS_EXECVE, unix.SYS_EXECVEAT:

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -929,7 +929,7 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		if needExitHandler && nr >= 0 {
 			exitRegs, err := t.getRegs(tid)
 			if err == nil {
-				t.handleSyscallExit(tid, nr, exitRegs)
+				t.handleSyscallExit(ctx, tid, nr, exitRegs)
 			}
 		}
 
@@ -991,23 +991,20 @@ func (t *Tracer) dispatchSyscall(ctx context.Context, tid int, nr int, sc *Sysca
 }
 
 // handleSyscallExit runs exit-time handlers for syscalls that need post-processing.
-func (t *Tracer) handleSyscallExit(tid int, nr int, regs Regs) {
+func (t *Tracer) handleSyscallExit(ctx context.Context, tid int, nr int, regs Regs) {
 	switch {
 	case isReadSyscall(nr):
 		t.handleReadExit(tid, regs)
 	case nr == unix.SYS_OPENAT || nr == unix.SYS_OPENAT2:
-		t.handleOpenatExit(tid, regs)
+		t.handleOpenatExit(ctx, tid, regs)
 	case nr == unix.SYS_CONNECT:
 		t.handleConnectExit(tid, regs)
 	}
 }
 
-// handleOpenatExit tracks fds opened on /proc/*/status for TracerPid masking.
-func (t *Tracer) handleOpenatExit(tid int, regs Regs) {
-	if t.fds == nil || !t.cfg.MaskTracerPid {
-		return
-	}
-
+// handleOpenatExit verifies the opened path against policy and tracks
+// /proc/*/status fds for TracerPid masking.
+func (t *Tracer) handleOpenatExit(ctx context.Context, tid int, regs Regs) {
 	retVal := regs.ReturnValue()
 	if retVal < 0 {
 		return // open failed
@@ -1017,21 +1014,55 @@ func (t *Tracer) handleOpenatExit(tid int, regs Regs) {
 	t.mu.Lock()
 	state := t.tracees[tid]
 	var tgid int
+	var sessionID string
 	if state != nil {
 		tgid = state.TGID
+		sessionID = state.SessionID
 	}
 	t.mu.Unlock()
 
-	// Read the path from /proc/<tid>/fd/<fd> to check if it's a status file.
+	// Read the real path the kernel opened.
 	path, err := os.Readlink(fmt.Sprintf("/proc/%d/fd/%d", tid, fd))
 	if err != nil {
+		// Cannot verify — fail closed. Close the fd and deny.
+		slog.Warn("handleOpenatExit: cannot read fd path, denying",
+			"tid", tid, "fd", fd, "error", err)
+		savedRegs := regs.Clone()
+		t.cleanupInjectedFD(tid, savedRegs, fd, -1)
+		t.applyReturnOverride(tid, -int64(unix.EACCES))
 		return
 	}
 
-	if isProcStatus(path) {
+	// TracerPid masking: track fds opened on /proc/*/status.
+	if t.fds != nil && t.cfg.MaskTracerPid && isProcStatus(path) {
 		t.fds.trackStatusFd(tgid, fd)
-		// Escalate BPF to trace read/pread64 for this TGID.
 		t.escalateReadForTGID(tgid, tid)
+	}
+
+	// Exit-time path verification: evaluate policy against the real path.
+	if t.cfg.FileHandler != nil && t.cfg.TraceFile && sessionID != "" {
+		result := t.cfg.FileHandler.HandleFile(ctx, FileContext{
+			PID:       tgid,
+			SessionID: sessionID,
+			Syscall:   unix.SYS_OPENAT,
+			Path:      path,
+			Operation: "open",
+		})
+		action := result.Action
+		if action == "" {
+			if result.Allow {
+				action = "allow"
+			} else {
+				action = "deny"
+			}
+		}
+		if action == "deny" {
+			slog.Warn("handleOpenatExit: exit-time verification denied",
+				"tid", tid, "fd", fd, "path", path)
+			savedRegs := regs.Clone()
+			t.cleanupInjectedFD(tid, savedRegs, fd, -1)
+			t.applyReturnOverride(tid, -int64(unix.EACCES))
+		}
 	}
 }
 

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -1071,7 +1071,9 @@ func (t *Tracer) handleOpenatExit(ctx context.Context, tid int, regs Regs) {
 	}
 
 	// Exit-time path verification: evaluate policy against the real path.
-	if t.cfg.FileHandler != nil && t.cfg.TraceFile && sessionID != "" {
+	// No sessionID gate — consistent with entry-time handleFile which also
+	// calls HandleFile regardless of session state.
+	if t.cfg.FileHandler != nil && t.cfg.TraceFile {
 		result := t.cfg.FileHandler.HandleFile(ctx, FileContext{
 			PID:       tgid,
 			SessionID: sessionID,

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -951,6 +951,7 @@ func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
 	// to exit) instead of the two-phase gadget protocol.
 	t.mu.Lock()
 	state := t.tracees[tid]
+	isVfork := state != nil && state.IsVforkChild
 	if state != nil {
 		state.InSyscall = true
 		state.LastNr = nr
@@ -964,6 +965,16 @@ func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
 		}
 	}
 	t.mu.Unlock()
+
+	// Fast-path: vfork children only need policy evaluation at execve.
+	// All other syscalls between vfork and exec are async-signal-safe
+	// setup operations (close, dup2, sigaction, etc.) — safe to allow.
+	// For openat/openat2, NeedExitStop is already set above, so
+	// exit-time path verification still runs as a safety net.
+	if isVfork && !isExecveSyscall(nr) {
+		t.allowSyscall(tid)
+		return
+	}
 
 	t.dispatchSyscall(ctx, tid, nr, sc)
 }

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -175,6 +175,8 @@ type TraceeState struct {
 	PendingWriteEscalation bool
 	IsVforkChild     bool
 	SuppressInitialStop bool // suppress initial SIGSTOP from auto-trace
+	LastOpenFlags    int    // flags from last openat/openat2 entry (event-loop-only)
+	LastOpenOp       string // operation from last openat/openat2 entry (event-loop-only)
 	PendingExecStubFD  int // fd injected for exec redirect; cleaned up on exec failure (-1 = none)
 	PendingExecSavedFD int // fd that was displaced by stub fd; restored on exec failure (-1 = none)
 	MemFD              int
@@ -900,8 +902,8 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		state.LastNr = nr
 		state.NeedExitStop = t.needsExitStop(nr)
 
-		// Fast-path vfork children (same logic as handleSeccompStop).
-		if state.IsVforkChild && !isExecveSyscall(nr) {
+		// Fast-path vfork children for known safe setup syscalls.
+		if state.IsVforkChild && !isExecveSyscall(nr) && isVforkSafeSyscall(nr) {
 			t.allowSyscall(tid)
 			return
 		}
@@ -972,12 +974,12 @@ func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
 	}
 	t.mu.Unlock()
 
-	// Fast-path: vfork children only need policy evaluation at execve.
-	// All other syscalls between vfork and exec are async-signal-safe
-	// setup operations (close, dup2, sigaction, etc.) — safe to allow.
-	// For openat/openat2, NeedExitStop is already set above, so
-	// exit-time path verification still runs as a safety net.
-	if isVfork && !isExecveSyscall(nr) {
+	// Fast-path: vfork children skip policy for known safe setup syscalls.
+	// Between vfork and exec, only async-signal-safe operations should occur.
+	// Safe syscalls (close, dup2, sigaction, etc.) are allowed immediately.
+	// Execve gets full policy evaluation. Anything else (file, network,
+	// signal) goes through normal dispatch for policy enforcement.
+	if isVfork && !isExecveSyscall(nr) && isVforkSafeSyscall(nr) {
 		t.allowSyscall(tid)
 		return
 	}
@@ -1038,21 +1040,27 @@ func (t *Tracer) handleOpenatExit(ctx context.Context, tid int, regs Regs) {
 	}
 	t.mu.Unlock()
 
-	// LastNr is event-loop-only — no mutex needed.
+	// Event-loop-only fields — no mutex needed.
 	nr := unix.SYS_OPENAT
+	openFlags := 0
+	openOp := "open"
 	if state != nil {
 		nr = state.LastNr
+		openFlags = state.LastOpenFlags
+		openOp = state.LastOpenOp
 	}
 
 	// Read the real path the kernel opened.
 	path, err := os.Readlink(fmt.Sprintf("/proc/%d/fd/%d", tid, fd))
 	if err != nil {
-		// Cannot verify — fail closed. Close the fd and deny.
-		slog.Warn("handleOpenatExit: cannot read fd path, denying",
-			"tid", tid, "fd", fd, "error", err)
-		savedRegs := regs.Clone()
-		t.cleanupInjectedFD(tid, savedRegs, fd, -1)
-		t.applyReturnOverride(tid, -int64(unix.EACCES))
+		// Cannot verify — fail closed only when file policy is active.
+		if t.cfg.FileHandler != nil && t.cfg.TraceFile {
+			slog.Warn("handleOpenatExit: cannot read fd path, denying",
+				"tid", tid, "fd", fd, "error", err)
+			savedRegs := regs.Clone()
+			t.cleanupInjectedFD(tid, savedRegs, fd, -1)
+			t.applyReturnOverride(tid, -int64(unix.EACCES))
+		}
 		return
 	}
 
@@ -1069,7 +1077,8 @@ func (t *Tracer) handleOpenatExit(ctx context.Context, tid int, regs Regs) {
 			SessionID: sessionID,
 			Syscall:   nr,
 			Path:      path,
-			Operation: "open",
+			Operation: openOp,
+			Flags:     openFlags,
 		})
 		action := result.Action
 		if action == "" {
@@ -1079,12 +1088,18 @@ func (t *Tracer) handleOpenatExit(ctx context.Context, tid int, regs Regs) {
 				action = "deny"
 			}
 		}
-		if action == "deny" {
+		// At exit time, only "allow" and "continue" are valid passes.
+		// Redirect/soft-delete cannot be enforced post-open — treat as deny.
+		if action != "allow" && action != "continue" {
+			errno := result.Errno
+			if errno == 0 {
+				errno = int32(unix.EACCES)
+			}
 			slog.Warn("handleOpenatExit: exit-time verification denied",
-				"tid", tid, "fd", fd, "path", path)
+				"tid", tid, "fd", fd, "path", path, "action", action)
 			savedRegs := regs.Clone()
 			t.cleanupInjectedFD(tid, savedRegs, fd, -1)
-			t.applyReturnOverride(tid, -int64(unix.EACCES))
+			t.applyReturnOverride(tid, -int64(errno))
 		}
 	}
 }

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -177,6 +177,7 @@ type TraceeState struct {
 	SuppressInitialStop bool // suppress initial SIGSTOP from auto-trace
 	LastOpenFlags    int    // flags from last openat/openat2 entry (event-loop-only)
 	LastOpenOp       string // operation from last openat/openat2 entry (event-loop-only)
+	LastFileAction   string // action from last file entry-time policy check (event-loop-only)
 	PendingExecStubFD  int // fd injected for exec redirect; cleaned up on exec failure (-1 = none)
 	PendingExecSavedFD int // fd that was displaced by stub fd; restored on exec failure (-1 = none)
 	MemFD              int
@@ -1046,10 +1047,12 @@ func (t *Tracer) handleOpenatExit(ctx context.Context, tid int, regs Regs) {
 	nr := unix.SYS_OPENAT
 	openFlags := 0
 	openOp := "open"
+	entryAction := ""
 	if state != nil {
 		nr = state.LastNr
 		openFlags = state.LastOpenFlags
 		openOp = state.LastOpenOp
+		entryAction = state.LastFileAction
 	}
 
 	// Read the real path the kernel opened.
@@ -1072,10 +1075,14 @@ func (t *Tracer) handleOpenatExit(ctx context.Context, tid int, regs Regs) {
 		t.escalateReadForTGID(tgid, tid)
 	}
 
-	// Exit-time path verification: evaluate policy against the real path.
+	// Exit-time path verification: only re-check when entry-time allowed.
+	// If entry denied, the syscall was already blocked. If entry redirected
+	// or soft-deleted, the kernel operated on the modified path — exit-time
+	// readlink reflects that modified path, not a symlink bypass.
 	// No sessionID gate — consistent with entry-time handleFile which also
 	// calls HandleFile regardless of session state.
-	if t.cfg.FileHandler != nil && t.cfg.TraceFile {
+	if t.cfg.FileHandler != nil && t.cfg.TraceFile &&
+		(entryAction == "allow" || entryAction == "continue" || entryAction == "") {
 		result := t.cfg.FileHandler.HandleFile(ctx, FileContext{
 			PID:       tgid,
 			SessionID: sessionID,

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -906,7 +906,9 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		state.NeedExitStop = t.needsExitStop(nr)
 
 		// Fast-path vfork children for known safe setup syscalls.
-		if state.IsVforkChild && !isExecveSyscall(nr) && isVforkSafeSyscall(nr) {
+		// Exclude SYS_CLOSE when fd tracking is active (same as handleSeccompStop).
+		if state.IsVforkChild && !isExecveSyscall(nr) && isVforkSafeSyscall(nr) &&
+			!(nr == unix.SYS_CLOSE && t.fds != nil) {
 			t.allowSyscall(tid)
 			return
 		}
@@ -979,10 +981,13 @@ func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
 
 	// Fast-path: vfork children skip policy for known safe setup syscalls.
 	// Between vfork and exec, only async-signal-safe operations should occur.
-	// Safe syscalls (close, dup2, sigaction, etc.) are allowed immediately.
+	// Safe syscalls (close, dup3, sigaction, etc.) are allowed immediately.
 	// Execve gets full policy evaluation. Anything else (file, network,
 	// signal) goes through normal dispatch for policy enforcement.
-	if isVfork && !isExecveSyscall(nr) && isVforkSafeSyscall(nr) {
+	// Exception: SYS_CLOSE must go through handleClose when fd tracking
+	// is active (t.fds != nil) to clean up statusFds/dnsRedirects/tlsWatched.
+	if isVfork && !isExecveSyscall(nr) && isVforkSafeSyscall(nr) &&
+		!(nr == unix.SYS_CLOSE && t.fds != nil) {
 		t.allowSyscall(tid)
 		return
 	}

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -1069,12 +1069,6 @@ func (t *Tracer) handleOpenatExit(ctx context.Context, tid int, regs Regs) {
 		return
 	}
 
-	// TracerPid masking: track fds opened on /proc/*/status.
-	if t.fds != nil && t.cfg.MaskTracerPid && isProcStatus(path) {
-		t.fds.trackStatusFd(tgid, fd)
-		t.escalateReadForTGID(tgid, tid)
-	}
-
 	// Exit-time path verification: only re-check when entry-time allowed.
 	// If entry denied, the syscall was already blocked. If entry redirected
 	// or soft-deleted, the kernel operated on the modified path — exit-time
@@ -1111,7 +1105,16 @@ func (t *Tracer) handleOpenatExit(ctx context.Context, tid int, regs Regs) {
 			savedRegs := regs.Clone()
 			t.cleanupInjectedFD(tid, savedRegs, fd, -1)
 			t.applyReturnOverride(tid, -int64(errno))
+			return // fd closed — skip TracerPid tracking
 		}
+	}
+
+	// TracerPid masking: track fds opened on /proc/*/status.
+	// Placed after exit-time verification to avoid stale entries if the
+	// fd is denied and closed above.
+	if t.fds != nil && t.cfg.MaskTracerPid && isProcStatus(path) {
+		t.fds.trackStatusFd(tgid, fd)
+		t.escalateReadForTGID(tgid, tid)
 	}
 }
 

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -472,7 +472,9 @@ func (t *Tracer) needsExitStop(nr int) bool {
 	case unix.SYS_READ, unix.SYS_PREAD64:
 		return true // only traced when escalated — always needs exit
 	case unix.SYS_OPENAT, unix.SYS_OPENAT2:
-		return true // exit-time path verification for symlink defense-in-depth
+		// Exit-time path verification (symlink defense-in-depth) or
+		// TracerPid fd tracking. Skip when neither is active.
+		return (t.cfg.TraceFile && t.cfg.FileHandler != nil) || t.cfg.MaskTracerPid
 	case unix.SYS_CONNECT:
 		return t.cfg.TraceNetwork // inline skip in handleNetwork handles port granularity
 	case unix.SYS_EXECVE, unix.SYS_EXECVEAT:

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -1038,6 +1038,12 @@ func (t *Tracer) handleOpenatExit(ctx context.Context, tid int, regs Regs) {
 	}
 	t.mu.Unlock()
 
+	// LastNr is event-loop-only — no mutex needed.
+	nr := unix.SYS_OPENAT
+	if state != nil {
+		nr = state.LastNr
+	}
+
 	// Read the real path the kernel opened.
 	path, err := os.Readlink(fmt.Sprintf("/proc/%d/fd/%d", tid, fd))
 	if err != nil {
@@ -1061,7 +1067,7 @@ func (t *Tracer) handleOpenatExit(ctx context.Context, tid int, regs Regs) {
 		result := t.cfg.FileHandler.HandleFile(ctx, FileContext{
 			PID:       tgid,
 			SessionID: sessionID,
-			Syscall:   unix.SYS_OPENAT,
+			Syscall:   nr,
 			Path:      path,
 			Operation: "open",
 		})

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -900,6 +900,12 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		state.LastNr = nr
 		state.NeedExitStop = t.needsExitStop(nr)
 
+		// Fast-path vfork children (same logic as handleSeccompStop).
+		if state.IsVforkChild && !isExecveSyscall(nr) {
+			t.allowSyscall(tid)
+			return
+		}
+
 		t.dispatchSyscall(ctx, tid, nr, sc)
 	} else {
 		if pendingErrno != 0 {

--- a/internal/ptrace/tracer_test.go
+++ b/internal/ptrace/tracer_test.go
@@ -71,8 +71,8 @@ func TestNeedsExitStop(t *testing.T) {
 		want          bool
 	}{
 		{"openat with mask on", unix.SYS_OPENAT, true, true, true},
-		{"openat with mask off", unix.SYS_OPENAT, false, true, false},
-		{"openat2 with mask off", unix.SYS_OPENAT2, false, true, false},
+		{"openat with mask off", unix.SYS_OPENAT, false, true, true},
+		{"openat2 with mask off", unix.SYS_OPENAT2, false, true, true},
 		{"connect with network on", unix.SYS_CONNECT, false, true, true},
 		{"connect with network off", unix.SYS_CONNECT, false, false, false},
 		{"read always true", unix.SYS_READ, false, false, true},

--- a/internal/ptrace/tracer_test.go
+++ b/internal/ptrace/tracer_test.go
@@ -71,7 +71,6 @@ func TestIsVforkFastPathSkipsNonExec(t *testing.T) {
 		wantFast bool
 	}{
 		{"vfork child close", true, unix.SYS_CLOSE, true},
-		{"vfork child dup2", true, unix.SYS_DUP2, true},
 		{"vfork child dup3", true, unix.SYS_DUP3, true},
 		{"vfork child sigaction", true, unix.SYS_RT_SIGACTION, true},
 		{"vfork child exit_group", true, unix.SYS_EXIT_GROUP, true},

--- a/internal/ptrace/tracer_test.go
+++ b/internal/ptrace/tracer_test.go
@@ -94,30 +94,39 @@ func TestIsVforkFastPathSkipsNonExec(t *testing.T) {
 }
 
 func TestNeedsExitStop(t *testing.T) {
+	// stubFileHandler is a minimal FileHandler for testing needsExitStop.
+	type stubFileHandler struct{ FileHandler }
+
 	tests := []struct {
 		name          string
 		nr            int
 		maskTracerPid bool
 		traceNetwork  bool
+		traceFile     bool
+		fileHandler   FileHandler
 		want          bool
 	}{
-		{"openat with mask on", unix.SYS_OPENAT, true, true, true},
-		{"openat with mask off", unix.SYS_OPENAT, false, true, true},
-		{"openat2 with mask off", unix.SYS_OPENAT2, false, true, true},
-		{"connect with network on", unix.SYS_CONNECT, false, true, true},
-		{"connect with network off", unix.SYS_CONNECT, false, false, false},
-		{"read always true", unix.SYS_READ, false, false, true},
-		{"pread64 always true", unix.SYS_PREAD64, false, false, true},
-		{"execve always true", unix.SYS_EXECVE, false, false, true},
-		{"execveat always true", unix.SYS_EXECVEAT, false, false, true},
-		{"unlinkat never needs exit", unix.SYS_UNLINKAT, true, true, false},
-		{"write never needs exit", unix.SYS_WRITE, true, true, false},
+		{"openat with mask on", unix.SYS_OPENAT, true, true, false, nil, true},
+		{"openat with file policy", unix.SYS_OPENAT, false, true, true, stubFileHandler{}, true},
+		{"openat with neither", unix.SYS_OPENAT, false, true, false, nil, false},
+		{"openat2 with neither", unix.SYS_OPENAT2, false, true, false, nil, false},
+		{"openat2 with mask on", unix.SYS_OPENAT2, true, false, false, nil, true},
+		{"connect with network on", unix.SYS_CONNECT, false, true, false, nil, true},
+		{"connect with network off", unix.SYS_CONNECT, false, false, false, nil, false},
+		{"read always true", unix.SYS_READ, false, false, false, nil, true},
+		{"pread64 always true", unix.SYS_PREAD64, false, false, false, nil, true},
+		{"execve always true", unix.SYS_EXECVE, false, false, false, nil, true},
+		{"execveat always true", unix.SYS_EXECVEAT, false, false, false, nil, true},
+		{"unlinkat never needs exit", unix.SYS_UNLINKAT, true, true, true, stubFileHandler{}, false},
+		{"write never needs exit", unix.SYS_WRITE, true, true, true, stubFileHandler{}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tr := &Tracer{cfg: TracerConfig{
 				MaskTracerPid: tt.maskTracerPid,
 				TraceNetwork:  tt.traceNetwork,
+				TraceFile:     tt.traceFile,
+				FileHandler:   tt.fileHandler,
 			}}
 			if got := tr.needsExitStop(tt.nr); got != tt.want {
 				t.Errorf("needsExitStop(%d) = %v, want %v", tt.nr, got, tt.want)

--- a/internal/ptrace/tracer_test.go
+++ b/internal/ptrace/tracer_test.go
@@ -63,7 +63,7 @@ func TestTracerConfig_HandlerFields(t *testing.T) {
 }
 
 func TestIsVforkFastPathSkipsNonExec(t *testing.T) {
-	// Verify the fast-path condition: IsVforkChild && !isExecveSyscall
+	// Verify the fast-path condition: IsVforkChild && !isExecveSyscall && isVforkSafeSyscall
 	tests := []struct {
 		name     string
 		isVfork  bool
@@ -71,16 +71,20 @@ func TestIsVforkFastPathSkipsNonExec(t *testing.T) {
 		wantFast bool
 	}{
 		{"vfork child close", true, unix.SYS_CLOSE, true},
-		{"vfork child openat", true, unix.SYS_OPENAT, true},
-		{"vfork child execve", true, unix.SYS_EXECVE, false},
-		{"vfork child execveat", true, unix.SYS_EXECVEAT, false},
+		{"vfork child dup2", true, unix.SYS_DUP2, true},
+		{"vfork child dup3", true, unix.SYS_DUP3, true},
+		{"vfork child sigaction", true, unix.SYS_RT_SIGACTION, true},
+		{"vfork child exit_group", true, unix.SYS_EXIT_GROUP, true},
+		{"vfork child openat", true, unix.SYS_OPENAT, false},     // not in safe list
+		{"vfork child connect", true, unix.SYS_CONNECT, false},   // not in safe list
+		{"vfork child execve", true, unix.SYS_EXECVE, false},     // exec gets full eval
+		{"vfork child execveat", true, unix.SYS_EXECVEAT, false}, // exec gets full eval
 		{"non-vfork close", false, unix.SYS_CLOSE, false},
 		{"non-vfork openat", false, unix.SYS_OPENAT, false},
-		{"non-vfork execve", false, unix.SYS_EXECVE, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.isVfork && !isExecveSyscall(tt.nr)
+			got := tt.isVfork && !isExecveSyscall(tt.nr) && isVforkSafeSyscall(tt.nr)
 			if got != tt.wantFast {
 				t.Errorf("fastPath(%v, %d) = %v, want %v",
 					tt.isVfork, tt.nr, got, tt.wantFast)

--- a/internal/ptrace/tracer_test.go
+++ b/internal/ptrace/tracer_test.go
@@ -62,6 +62,33 @@ func TestTracerConfig_HandlerFields(t *testing.T) {
 	}
 }
 
+func TestIsVforkFastPathSkipsNonExec(t *testing.T) {
+	// Verify the fast-path condition: IsVforkChild && !isExecveSyscall
+	tests := []struct {
+		name     string
+		isVfork  bool
+		nr       int
+		wantFast bool
+	}{
+		{"vfork child close", true, unix.SYS_CLOSE, true},
+		{"vfork child openat", true, unix.SYS_OPENAT, true},
+		{"vfork child execve", true, unix.SYS_EXECVE, false},
+		{"vfork child execveat", true, unix.SYS_EXECVEAT, false},
+		{"non-vfork close", false, unix.SYS_CLOSE, false},
+		{"non-vfork openat", false, unix.SYS_OPENAT, false},
+		{"non-vfork execve", false, unix.SYS_EXECVE, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.isVfork && !isExecveSyscall(tt.nr)
+			if got != tt.wantFast {
+				t.Errorf("fastPath(%v, %d) = %v, want %v",
+					tt.isVfork, tt.nr, got, tt.wantFast)
+			}
+		})
+	}
+}
+
 func TestNeedsExitStop(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
## Summary

Fixes two ptrace tracer gaps found in Vercel Sandbox testing (Firecracker VM, ptrace-only enforcement):

- **Symlink bypass defense-in-depth**: Exit-time path verification for openat/openat2. After the kernel completes an open, reads `/proc/<tid>/fd/<fd>` to verify the real path against policy. If denied (e.g. symlink resolved to a forbidden target), closes the fd and overrides the return to `-EACCES`.
- **vfork deadlock fix**: Fast-path for vfork children using an allowlist of known safe syscalls (close, dup3, sigaction, etc.). Eliminates policy evaluation overhead between vfork and exec, preventing deadlocks with Python's `subprocess.run(capture_output=True)`.
- **PTRACE_GET_SYSCALL_INFO Op fix**: Accepts Op=3 (seccomp stops) alongside Op=1 (entry), eliminating unnecessary fallback to full `getRegs()` on every seccomp stop.

## Key design decisions

- Exit-time verification only re-checks when entry-time allowed. Redirected/soft-deleted opens are skipped (the kernel operated on the modified path, not a symlink bypass).
- Exit stops for openat/openat2 are conditional on active features (`TraceFile && FileHandler != nil` or `MaskTracerPid`) to avoid unnecessary overhead.
- vfork fast-path uses a strict allowlist rather than blanket allow, and excludes `SYS_CLOSE` when fd tracking is active to prevent stale tracking entries.
- Non-allow/continue actions (redirect, soft-delete) at exit time are treated as deny since they cannot be enforced post-open.

## Test plan

- [x] Unit tests for symlink resolution (single + chained symlinks)
- [x] Unit tests for `needsExitStop` with all feature flag combinations
- [x] Unit tests for vfork fast-path allowlist logic
- [x] Full test suite passes (`go test ./...`)
- [x] Windows cross-compilation passes
- [x] Roborev branch review: only Low severity findings (test coverage depth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)