### PR TITLE
feat: add FUSE new mount API fallback for Firecracker VMs

### DIFF
--- a/Dockerfile.bench
+++ b/Dockerfile.bench
@@ -1,4 +1,4 @@
-# Performance benchmark: ptrace vs full mode vs baseline.
+# Performance benchmark: ptrace vs full mode vs seccomp-notify vs baseline.
 #
 # Build & run:
 #   make bench
@@ -212,12 +212,19 @@ write_config() {
   local ptrace_enabled=false
   local static_allow_file=false
   local static_allow_network=false
+  local seccomp_file_monitor=false
+  local seccomp_enforce_without_fuse=false
 
   case "$mode" in
     baseline) ;;
     full)
       fuse_enabled=true
       seccomp_execve_enabled=true
+      ;;
+    seccomp-notify)
+      seccomp_execve_enabled=true
+      seccomp_file_monitor=true
+      seccomp_enforce_without_fuse=true
       ;;
     ptrace)
       ptrace_enabled=true
@@ -272,6 +279,9 @@ sandbox:
   seccomp:
     execve:
       enabled: ${seccomp_execve_enabled}
+    file_monitor:
+      enabled: ${seccomp_file_monitor}
+      enforce_without_fuse: ${seccomp_enforce_without_fuse}
   ptrace:
     enabled: ${ptrace_enabled}
     attach_mode: "children"
@@ -374,7 +384,7 @@ sleep 0.3
 
 declare -A results_files
 
-for mode in baseline full ptrace ptrace-allow; do
+for mode in baseline full seccomp-notify ptrace ptrace-allow; do
   echo "bench: running mode=$mode ..."
   results_files[$mode]="$(run_mode "$mode")"
 done
@@ -384,7 +394,7 @@ phases=(spawn fileio git network deny redirect tree_deep tree_wide)
 phase_labels=("Process spawn (120)" "File I/O (1000 ops)" "Git workflow" "Network (10 curl)" "Deny enforcement (50)" "Redirect enforce (50)" "Deep tree (20x4-lvl)" "Wide tree (10x10-fan)")
 
 declare -A medians
-for mode in baseline full ptrace ptrace-allow; do
+for mode in baseline full seccomp-notify ptrace ptrace-allow; do
   for phase in "${phases[@]}"; do
     vals=( $(extract_phase "${results_files[$mode]}" "$phase") )
     if [[ ${#vals[@]} -lt 3 ]]; then
@@ -396,7 +406,7 @@ for mode in baseline full ptrace ptrace-allow; do
 done
 
 # Compute totals
-for mode in baseline full ptrace ptrace-allow; do
+for mode in baseline full seccomp-notify ptrace ptrace-allow; do
   total=0
   for phase in "${phases[@]}"; do
     total=$(( total + ${medians["${mode}_${phase}"]} ))
@@ -417,13 +427,15 @@ overhead() {
 echo ""
 echo "=== agentsh mode benchmark (median of 3 runs) ==="
 echo ""
-printf "| %-22s | %8s | %9s | %13s | %7s | %15s | %12s | %20s |\n" \
-  "Phase" "Baseline" "Full mode" "Full overhead" "Ptrace" "Ptrace overhead" "Ptrace-allow" "Ptrace-allow overhead"
-printf "|-%s-|-%s-|-%s-|-%s-|-%s-|-%s-|-%s-|-%s-|\n" \
+printf "| %-22s | %8s | %9s | %13s | %14s | %20s | %7s | %15s | %12s | %20s |\n" \
+  "Phase" "Baseline" "Full mode" "Full overhead" "Seccomp-notify" "Seccomp-notify ohead" "Ptrace" "Ptrace overhead" "Ptrace-allow" "Ptrace-allow overhead"
+printf "|-%s-|-%s-|-%s-|-%s-|-%s-|-%s-|-%s-|-%s-|-%s-|-%s-|\n" \
   "$(printf '%0.s-' {1..22})" \
   "$(printf '%0.s-' {1..8})" \
   "$(printf '%0.s-' {1..9})" \
   "$(printf '%0.s-' {1..13})" \
+  "$(printf '%0.s-' {1..14})" \
+  "$(printf '%0.s-' {1..20})" \
   "$(printf '%0.s-' {1..7})" \
   "$(printf '%0.s-' {1..15})" \
   "$(printf '%0.s-' {1..12})" \
@@ -434,25 +446,29 @@ for i in "${!phases[@]}"; do
   label="${phase_labels[$i]}"
   bval="${medians[baseline_${phase}]}"
   fval="${medians[full_${phase}]}"
+  sval="${medians[seccomp-notify_${phase}]}"
   pval="${medians[ptrace_${phase}]}"
   aval="${medians[ptrace-allow_${phase}]}"
   foh="$(overhead "$bval" "$fval")"
+  soh="$(overhead "$bval" "$sval")"
   poh="$(overhead "$bval" "$pval")"
   aoh="$(overhead "$bval" "$aval")"
-  printf "| %-22s | %6sms | %7sms | %13s | %5sms | %15s | %10sms | %20s |\n" \
-    "$label" "$bval" "$fval" "$foh" "$pval" "$poh" "$aval" "$aoh"
+  printf "| %-22s | %6sms | %7sms | %13s | %12sms | %20s | %5sms | %15s | %10sms | %20s |\n" \
+    "$label" "$bval" "$fval" "$foh" "$sval" "$soh" "$pval" "$poh" "$aval" "$aoh"
 done
 
 # Total row
 bval="${medians[baseline_total]}"
 fval="${medians[full_total]}"
+sval="${medians[seccomp-notify_total]}"
 pval="${medians[ptrace_total]}"
 aval="${medians[ptrace-allow_total]}"
 foh="$(overhead "$bval" "$fval")"
+soh="$(overhead "$bval" "$sval")"
 poh="$(overhead "$bval" "$pval")"
 aoh="$(overhead "$bval" "$aval")"
-printf "| %-22s | %6sms | %7sms | %13s | %5sms | %15s | %10sms | %20s |\n" \
-  "**TOTAL**" "$bval" "$fval" "$foh" "$pval" "$poh" "$aval" "$aoh"
+printf "| %-22s | %6sms | %7sms | %13s | %12sms | %20s | %5sms | %15s | %10sms | %20s |\n" \
+  "**TOTAL**" "$bval" "$fval" "$foh" "$sval" "$soh" "$pval" "$poh" "$aval" "$aoh"
 
 echo ""
 echo "bench: done"

--- a/docs/superpowers/plans/2026-03-20-fuse-new-mount-api.md
+++ b/docs/superpowers/plans/2026-03-20-fuse-new-mount-api.md
@@ -1,0 +1,636 @@
+# FUSE New Mount API Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a FUSE mount fallback using the Linux new mount API (fsopen/fsconfig/fsmount/move_mount) for Firecracker VMs where the legacy mount() syscall hangs.
+
+**Architecture:** Add `detectMountMethod()` to replace `canMountFUSE()` with a three-way fallback chain (fusermount → new-api → direct mount). When `new-api` is selected, `mountFUSEViaNewAPI()` performs the mount and returns a `/dev/fuse` fd that go-fuse uses via its `/dev/fd/N` magic mountpoint path. Unmount uses `unix.Unmount()` directly since go-fuse refuses to unmount `/dev/fd/N` paths.
+
+**Tech Stack:** Go, golang.org/x/sys/unix (v0.40.0), go-fuse v2.9.0
+
+**Spec:** `docs/superpowers/specs/2026-03-20-fuse-new-mount-api-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `internal/platform/linux/filesystem.go` | Modify | Add mountMethod field, detectMountMethod, mountFUSEViaNewAPI, unmount dispatch |
+| `internal/platform/linux/filesystem_test.go` | Modify | Tests for detection, fsopen probe, error cleanup, integration |
+| `internal/fsmonitor/mount.go` | Modify | Guard MkdirAll for /dev/fd/N mountpoints |
+| `internal/capabilities/security_caps.go` | Modify | Add new mount API probe to checkFUSE |
+| `internal/capabilities/detect_linux.go` | Modify | Add fuse_mount_method to capabilities map |
+
+---
+
+### Task 1: detectMountMethod — Replace canMountFUSE
+
+**Files:**
+- Modify: `internal/platform/linux/filesystem.go:22-67`
+- Modify: `internal/platform/linux/filesystem_test.go`
+
+- [ ] **Step 1: Add mountMethod field to Filesystem struct**
+
+In `internal/platform/linux/filesystem.go`, add to the struct:
+
+```go
+type Filesystem struct {
+	available      bool
+	implementation string
+	mountMethod    string // "fusermount", "new-api", "direct", ""
+	mu             sync.Mutex
+	mounts         map[string]*Mount
+}
+```
+
+Add accessor:
+```go
+// MountMethod returns which FUSE mount strategy is available.
+func (fs *Filesystem) MountMethod() string {
+	return fs.mountMethod
+}
+```
+
+- [ ] **Step 2: Implement detectMountMethod**
+
+Replace `canMountFUSE()` with `detectMountMethod()`:
+
+```go
+// detectMountMethod determines which FUSE mount strategy is available.
+// Tries: fusermount → new mount API → direct mount().
+// Returns "", "fusermount", "new-api", or "direct".
+func detectMountMethod() string {
+	// Shared prerequisite: /dev/fuse must be openable
+	fd, err := unix.Open("/dev/fuse", unix.O_RDWR, 0)
+	if err != nil {
+		slog.Debug("fuse: /dev/fuse not available", "error", err)
+		return ""
+	}
+	unix.Close(fd)
+
+	// Priority 1: fusermount suid binary
+	if hasFusermount() {
+		slog.Info("fuse: mount method selected", "method", "fusermount")
+		return "fusermount"
+	}
+	slog.Debug("fuse: fusermount not found, trying new mount API")
+
+	// Priority 2: new mount API (fsopen/fsmount/move_mount)
+	if checkNewMountAPI() {
+		slog.Info("fuse: mount method selected", "method", "new-api")
+		return "new-api"
+	}
+	slog.Debug("fuse: new mount API not available, trying direct mount")
+
+	// Priority 3: direct mount() with CAP_SYS_ADMIN
+	if checkDirectMount() {
+		slog.Info("fuse: mount method selected", "method", "direct")
+		return "direct"
+	}
+	slog.Debug("fuse: no mount method available")
+
+	return ""
+}
+
+// checkNewMountAPI probes whether the new mount API works for FUSE.
+// Tries fsopen("fuse", 0) — success means the kernel supports the new API
+// and the fuse module is loaded. ENOSYS = kernel too old, ENODEV = fuse not loaded.
+func checkNewMountAPI() bool {
+	fd, err := unix.Fsopen("fuse", 0)
+	if err != nil {
+		return false
+	}
+	unix.Close(fd)
+	return true
+}
+```
+
+Add `"log/slog"` to imports.
+
+- [ ] **Step 3: Wire into NewFilesystem and checkAvailable**
+
+Update `NewFilesystem`:
+```go
+func NewFilesystem() *Filesystem {
+	fs := &Filesystem{
+		mounts: make(map[string]*Mount),
+	}
+	fs.mountMethod = detectMountMethod()
+	fs.available = fs.mountMethod != ""
+	fs.implementation = fs.detectImplementation()
+	return fs
+}
+```
+
+Update `checkAvailable` (still used by `Recheck`):
+```go
+func (fs *Filesystem) checkAvailable() bool {
+	fs.mountMethod = detectMountMethod()
+	return fs.mountMethod != ""
+}
+```
+
+Remove the old `canMountFUSE()` function (lines 45-67).
+
+- [ ] **Step 4: Write tests**
+
+In `internal/platform/linux/filesystem_test.go`:
+
+```go
+func TestDetectMountMethod(t *testing.T) {
+	method := detectMountMethod()
+	// On any Linux system with /dev/fuse, at least one method should work
+	if _, err := os.Open("/dev/fuse"); err == nil {
+		assert.NotEmpty(t, method, "should detect a mount method when /dev/fuse exists")
+		assert.Contains(t, []string{"fusermount", "new-api", "direct"}, method)
+	}
+}
+
+func TestCheckNewMountAPI(t *testing.T) {
+	result := checkNewMountAPI()
+	// Just verify it doesn't panic — result depends on kernel version
+	_ = result
+}
+
+func TestFilesystem_MountMethod(t *testing.T) {
+	fs := NewFilesystem()
+	if fs.Available() {
+		assert.NotEmpty(t, fs.MountMethod())
+	} else {
+		assert.Empty(t, fs.MountMethod())
+	}
+}
+```
+
+- [ ] **Step 5: Build and test**
+
+Run: `go build ./internal/platform/linux/... && go test ./internal/platform/linux/... -v -count=1`
+Expected: Compiles cleanly, tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/platform/linux/filesystem.go internal/platform/linux/filesystem_test.go
+git commit -m "feat(fuse): add detectMountMethod with new mount API probe
+
+Replace canMountFUSE with three-way detection: fusermount → new-api
+(fsopen probe) → direct mount. Add MountMethod() accessor and logging.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: mountFUSEViaNewAPI — New mount implementation
+
+**Files:**
+- Modify: `internal/platform/linux/filesystem.go`
+- Modify: `internal/platform/linux/filesystem_test.go`
+
+- [ ] **Step 1: Write failing test for error cleanup**
+
+In `internal/platform/linux/filesystem_test.go`:
+
+```go
+func TestMountFUSEViaNewAPI_ErrorCleanup(t *testing.T) {
+	// Verify that partial failures close fds without leaking.
+	// Pass an invalid mountpoint — the fsopen/fsconfig should succeed
+	// but move_mount should fail, and all fds should be cleaned up.
+	if !checkNewMountAPI() {
+		t.Skip("new mount API not available")
+	}
+	_, err := mountFUSEViaNewAPI("/nonexistent/path/that/cannot/exist", true, 0)
+	assert.Error(t, err, "should fail with nonexistent mountpoint")
+	// The test verifies no panic and no fd leak (defer cleanup in the function).
+}
+
+func TestMountFUSEViaNewAPI_FsopenProbe(t *testing.T) {
+	if !checkNewMountAPI() {
+		t.Skip("new mount API not available")
+	}
+	fd, err := unix.Fsopen("fuse", 0)
+	if err != nil {
+		t.Fatalf("fsopen failed: %v", err)
+	}
+	unix.Close(fd)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail (mountFUSEViaNewAPI not yet implemented)**
+
+Run: `go test ./internal/platform/linux/... -run "TestMountFUSEViaNewAPI" -v -count=1`
+Expected: FAIL — `mountFUSEViaNewAPI` not defined.
+
+- [ ] **Step 3: Implement mountFUSEViaNewAPI**
+
+In `internal/platform/linux/filesystem.go`, add:
+
+```go
+// mountFUSEViaNewAPI mounts a FUSE filesystem using the Linux new mount API
+// (fsopen/fsconfig/fsmount/move_mount). Returns the /dev/fuse fd for go-fuse.
+// The caller is responsible for closing the fd when the FUSE server shuts down.
+func mountFUSEViaNewAPI(mountPoint string, allowOther bool, maxRead int) (fuseFD int, err error) {
+	// Open /dev/fuse — this is the fd go-fuse will use for the FUSE protocol.
+	fuseDev, err := unix.Open("/dev/fuse", unix.O_RDWR|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, fmt.Errorf("open /dev/fuse: %w", err)
+	}
+
+	success := false
+	defer func() {
+		if !success {
+			unix.Close(fuseDev)
+		}
+	}()
+
+	// Create filesystem context
+	fsctx, err := unix.Fsopen("fuse", 0)
+	if err != nil {
+		return -1, fmt.Errorf("fsopen fuse: %w", err)
+	}
+	defer unix.Close(fsctx)
+
+	// Configure the FUSE mount (same options as go-fuse's mountDirect)
+	configs := []struct{ key, val string }{
+		{"fd", fmt.Sprintf("%d", fuseDev)},
+		{"rootmode", "40000"},
+		{"user_id", fmt.Sprintf("%d", os.Geteuid())},
+		{"group_id", fmt.Sprintf("%d", os.Getegid())},
+	}
+	if maxRead > 0 {
+		configs = append(configs, struct{ key, val string }{"max_read", fmt.Sprintf("%d", maxRead)})
+	}
+	for _, c := range configs {
+		if err := unix.FsconfigSetString(fsctx, c.key, c.val); err != nil {
+			return -1, fmt.Errorf("fsconfig %s=%s: %w", c.key, c.val, err)
+		}
+	}
+	if allowOther {
+		if err := unix.FsconfigSetFlag(fsctx, "allow_other"); err != nil {
+			return -1, fmt.Errorf("fsconfig allow_other: %w", err)
+		}
+	}
+
+	// Finalize the superblock
+	if err := unix.FsconfigCreate(fsctx); err != nil {
+		return -1, fmt.Errorf("fsconfig create: %w", err)
+	}
+
+	// Create mount fd
+	mntFD, err := unix.Fsmount(fsctx, 0, 0)
+	if err != nil {
+		return -1, fmt.Errorf("fsmount: %w", err)
+	}
+	defer unix.Close(mntFD)
+
+	// Attach to the target mountpoint
+	if err := unix.MoveMount(mntFD, "", unix.AT_FDCWD, mountPoint, unix.MOVE_MOUNT_F_EMPTY_PATH); err != nil {
+		return -1, fmt.Errorf("move_mount to %s: %w", mountPoint, err)
+	}
+
+	success = true
+	return fuseDev, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go build ./internal/platform/linux/... && go test ./internal/platform/linux/... -v -count=1 -run TestMountFUSEViaNewAPI`
+Expected: Compiles, tests pass (or skip on old kernels).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/platform/linux/filesystem.go internal/platform/linux/filesystem_test.go
+git commit -m "feat(fuse): implement mountFUSEViaNewAPI
+
+Uses fsopen → fsconfig → fsmount → move_mount to mount FUSE
+without fusermount or legacy mount() syscall. Returns /dev/fuse
+fd for go-fuse's /dev/fd/N integration path.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: go-fuse integration — /dev/fd/N passthrough + unmount
+
+**Files:**
+- Modify: `internal/platform/linux/filesystem.go:157-280` (Mount, Unmount, Close methods)
+- Modify: `internal/fsmonitor/mount.go:26-38` (guard MkdirAll)
+
+- [ ] **Step 1: Guard MkdirAll in MountWorkspace for /dev/fd/N**
+
+In `internal/fsmonitor/mount.go`, the `MountWorkspace` function calls `os.MkdirAll` on the mountpoint. When the mountpoint is `/dev/fd/42`, this will fail. Add a guard:
+
+```go
+func MountWorkspace(ctx context.Context, backingDir string, mountPoint string, hooks *Hooks) (*Mount, error) {
+	if backingDir == "" {
+		return nil, fmt.Errorf("backingDir is empty")
+	}
+	if mountPoint == "" {
+		return nil, fmt.Errorf("mountPoint is empty")
+	}
+	// Skip MkdirAll for /dev/fd/N magic mountpoints (pre-mounted FUSE fd)
+	if !strings.HasPrefix(mountPoint, "/dev/fd/") {
+		if err := os.MkdirAll(filepath.Dir(mountPoint), 0o755); err != nil {
+			return nil, fmt.Errorf("mkdir mount parent: %w", err)
+		}
+		if err := os.MkdirAll(mountPoint, 0o755); err != nil {
+			return nil, fmt.Errorf("mkdir mount: %w", err)
+		}
+	}
+```
+
+Add `"strings"` to imports.
+
+- [ ] **Step 2: Add fuseFD and mountedViaNewAPI fields to Mount struct**
+
+In `internal/platform/linux/filesystem.go`, update the `Mount` struct:
+
+```go
+type Mount struct {
+	fsMount          *fsmonitor.Mount
+	sourcePath       string
+	mountPoint       string // always the real mount point
+	mountedAt        time.Time
+	hooks            *fsmonitor.Hooks
+	mountedViaNewAPI bool // true if mounted via new mount API
+	fuseFD           int  // /dev/fuse fd to close on unmount (new-api only, -1 if unused)
+
+	// Stats tracking
+	mu            sync.Mutex
+	totalOps      int64
+	allowedOps    int64
+	deniedOps     int64
+	redirectedOps int64
+	bytesRead     int64
+	bytesWritten  int64
+}
+```
+
+- [ ] **Step 3: Modify Filesystem.Mount to use new API when selected**
+
+In `Filesystem.Mount()`, before calling `fsmonitor.MountWorkspace`:
+
+```go
+effectiveMountPoint := cfg.MountPoint
+mountedViaNewAPI := false
+fuseFD := -1
+
+if fs.mountMethod == "new-api" {
+	var err error
+	fuseFD, err = mountFUSEViaNewAPI(cfg.MountPoint, true, 0)
+	if err != nil {
+		return nil, fmt.Errorf("new mount API failed: %w", err)
+	}
+	effectiveMountPoint = fmt.Sprintf("/dev/fd/%d", fuseFD)
+	mountedViaNewAPI = true
+}
+
+fsMount, err := fsmonitor.MountWorkspace(ctx, cfg.SourcePath, effectiveMountPoint, hooks)
+if err != nil {
+	if mountedViaNewAPI {
+		unix.Unmount(cfg.MountPoint, 0)
+		unix.Close(fuseFD)
+	}
+	return nil, fmt.Errorf("failed to mount FUSE filesystem: %w", err)
+}
+
+mount := &Mount{
+	fsMount:          fsMount,
+	sourcePath:       cfg.SourcePath,
+	mountPoint:       cfg.MountPoint,
+	mountedAt:        time.Now(),
+	hooks:            hooks,
+	mountedViaNewAPI: mountedViaNewAPI,
+	fuseFD:           fuseFD,
+}
+```
+
+- [ ] **Step 4: Modify Unmount and Close for new-api path**
+
+Update `Filesystem.Unmount()`:
+
+```go
+func (fs *Filesystem) Unmount(mount platform.FSMount) error {
+	m, ok := mount.(*Mount)
+	if !ok {
+		return fmt.Errorf("invalid mount type: expected *linux.Mount")
+	}
+
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+
+	delete(fs.mounts, m.mountPoint)
+
+	if m.mountedViaNewAPI {
+		err := unix.Unmount(m.mountPoint, 0)
+		if m.fuseFD >= 0 {
+			unix.Close(m.fuseFD)
+			m.fuseFD = -1
+		}
+		return err
+	}
+	return m.fsMount.Unmount()
+}
+```
+
+Also update `Mount.Close()` (find it in the file — it's part of the `platform.FSMount` interface):
+
+```go
+func (m *Mount) Close() error {
+	if m.mountedViaNewAPI {
+		err := unix.Unmount(m.mountPoint, 0)
+		if m.fuseFD >= 0 {
+			unix.Close(m.fuseFD)
+			m.fuseFD = -1
+		}
+		return err
+	}
+	return m.fsMount.Unmount()
+}
+```
+
+- [ ] **Step 5: Build and test**
+
+Run: `go build ./... && go test ./internal/platform/linux/... -v -count=1`
+Expected: Compiles, all existing tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/platform/linux/filesystem.go internal/fsmonitor/mount.go
+git commit -m "feat(fuse): wire new mount API into Mount/Unmount with /dev/fd/N passthrough
+
+- Guard MkdirAll in MountWorkspace for /dev/fd/N mountpoints
+- Store fuseFD on Mount for cleanup at unmount
+- Unmount and Close use unix.Unmount + close fd for new-api path
+- go-fuse receives /dev/fd/N, real mountpoint preserved on Mount struct
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Update capabilities detection
+
+**Files:**
+- Modify: `internal/capabilities/security_caps.go:93-117`
+- Modify: `internal/capabilities/detect_linux.go`
+
+- [ ] **Step 1: Update checkFUSE to include new mount API**
+
+In `internal/capabilities/security_caps.go`, update `checkFUSE()`:
+
+```go
+func checkFUSE() bool {
+	fd, err := unix.Open("/dev/fuse", unix.O_RDWR, 0)
+	if err != nil {
+		return false
+	}
+	unix.Close(fd)
+
+	// Priority 1: fusermount
+	if hasFusermount() {
+		return true
+	}
+
+	// Priority 2: new mount API (fsopen probe)
+	if checkNewMountAPIAvailable() {
+		return true
+	}
+
+	// Priority 3: direct mount
+	return checkDirectMount()
+}
+
+// checkNewMountAPIAvailable probes for new mount API support via fsopen.
+func checkNewMountAPIAvailable() bool {
+	fd, err := unix.Fsopen("fuse", 0)
+	if err != nil {
+		return false
+	}
+	unix.Close(fd)
+	return true
+}
+```
+
+Note: This duplicates the `checkNewMountAPI()` from `filesystem.go`, but `security_caps.go` is in the `capabilities` package and can't import `linux` (circular dependency). The function is 5 lines — duplication is acceptable.
+
+- [ ] **Step 2: Add fuse_mount_method to detect output**
+
+In `internal/capabilities/detect_linux.go`, in `Detect()`, after the capabilities map is built:
+
+```go
+// Determine FUSE mount method for observability
+fuseMountMethod := "none"
+if secCaps.FUSE {
+	if hasFusermount() {
+		fuseMountMethod = "fusermount"
+	} else if checkNewMountAPIAvailable() {
+		fuseMountMethod = "new-api"
+	} else {
+		fuseMountMethod = "direct"
+	}
+}
+caps["fuse_mount_method"] = fuseMountMethod
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `go build ./... && go test ./internal/capabilities/... -v -count=1`
+Expected: Compiles, existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/capabilities/security_caps.go internal/capabilities/detect_linux.go
+git commit -m "feat(detect): add fuse_mount_method to capabilities detection
+
+checkFUSE now includes new mount API probe. agentsh detect reports
+fuse_mount_method: fusermount|new-api|direct|none.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Integration test — full mount/write/unmount cycle
+
+**Files:**
+- Modify: `internal/platform/linux/filesystem_test.go`
+
+- [ ] **Step 1: Write integration test**
+
+```go
+func TestMountFUSEViaNewAPI_Integration(t *testing.T) {
+	if !checkNewMountAPI() {
+		t.Skip("new mount API not available")
+	}
+	if os.Getuid() != 0 {
+		t.Skip("requires root for FUSE mount")
+	}
+
+	// Create a temp directory as the mount point
+	mountDir, err := os.MkdirTemp("", "fuse-newapi-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(mountDir)
+
+	// Mount FUSE via new API
+	fuseFD, err := mountFUSEViaNewAPI(mountDir, true, 0)
+	require.NoError(t, err)
+	defer unix.Close(fuseFD)
+
+	// Verify mount appears in /proc/mounts
+	mounts, err := os.ReadFile("/proc/mounts")
+	require.NoError(t, err)
+	assert.Contains(t, string(mounts), mountDir, "mount should appear in /proc/mounts")
+
+	// Unmount
+	err = unix.Unmount(mountDir, 0)
+	assert.NoError(t, err)
+
+	// Verify unmounted
+	mounts2, _ := os.ReadFile("/proc/mounts")
+	assert.NotContains(t, string(mounts2), mountDir, "mount should be gone after unmount")
+}
+```
+
+Note: This test requires root + /dev/fuse + kernel >= 5.2. It will skip in most CI environments but runs in Docker with `--cap-add SYS_ADMIN --device /dev/fuse`.
+
+- [ ] **Step 2: Run test**
+
+Run: `go test ./internal/platform/linux/... -run TestMountFUSEViaNewAPI_Integration -v -count=1`
+Expected: PASS (or skip if not root / no /dev/fuse / old kernel).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/platform/linux/filesystem_test.go
+git commit -m "test(fuse): add integration test for new mount API full cycle
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Full build + cross-compile + test
+
+- [ ] **Step 1: Full build**
+
+Run: `go build ./...`
+Expected: Clean.
+
+- [ ] **Step 2: Cross-compile**
+
+Run: `GOOS=windows go build ./...`
+Expected: Clean (new code behind `//go:build linux`).
+
+- [ ] **Step 3: Full test suite**
+
+Run: `go test ./...`
+Expected: All pass.
+
+- [ ] **Step 4: Commit any fixups**

--- a/docs/superpowers/specs/2026-03-20-fuse-new-mount-api-design.md
+++ b/docs/superpowers/specs/2026-03-20-fuse-new-mount-api-design.md
@@ -56,8 +56,8 @@ New function `mountFUSEViaNewAPI(mountPoint string, opts *fuse.MountOptions) (fu
 7. `unix.FsconfigSetString(fsctx, "max_read", strconv.Itoa(opts.MaxWrite))` — match go-fuse's behavior
 8. If `opts.AllowOther`: `unix.FsconfigSetFlag(fsctx, "allow_other")`
 9. `unix.FsconfigCreate(fsctx)` — finalize the superblock
-10. Close `fsctx` (no longer needed after create)
-11. `unix.Fsmount(fsctx_result, 0, 0)` → `mntFD`
+10. `unix.Fsmount(fsctx, 0, 0)` → `mntFD`
+11. Close `fsctx` (no longer needed after fsmount)
 12. `unix.MoveMount(mntFD, "", unix.AT_FDCWD, mountPoint, unix.MOVE_MOUNT_F_EMPTY_PATH)`
 13. Close `mntFD` (no longer needed after move_mount)
 14. Return `fuseDev` — this is the fd go-fuse will use

--- a/docs/superpowers/specs/2026-03-20-fuse-new-mount-api-design.md
+++ b/docs/superpowers/specs/2026-03-20-fuse-new-mount-api-design.md
@@ -1,0 +1,119 @@
+# FUSE New Mount API Fallback
+
+**Date:** 2026-03-20
+**Status:** Draft
+**Scope:** Linux only
+
+## Background
+
+On Cloudflare Firecracker VMs, the traditional `mount()` syscall hangs. This is not a seccomp issue (there is no seccomp filter in the guest) — it appears to be a Firecracker virtio/kernel-level issue specific to the `mount()` syscall.
+
+The existing `probeMountSyscall()` in agentsh detects this (500ms timeout → returns false), but when fusermount is also unavailable, FUSE is reported as unavailable — even though `/dev/fuse` opens fine and the kernel supports FUSE.
+
+The Linux new mount API (kernel 5.2+) works perfectly in these environments: `fsopen`, `fsconfig`, `fsmount`, and `move_mount` all succeed. This design adds the new mount API as a fallback between fusermount and legacy mount().
+
+## What Changes
+
+### 1. Detection — Mount Method Selection
+
+**File:** `internal/platform/linux/filesystem.go`
+
+The `Filesystem` struct gets a new field `mountMethod string` recording which mount path is available:
+
+- `"fusermount"` — fusermount3/fusermount suid binary found
+- `"new-api"` — kernel >= 5.2, `/dev/fuse` opens, `fsopen("fuse")` succeeds
+- `"direct"` — CAP_SYS_ADMIN + mount() probe passes
+- `""` — nothing works (FUSE unavailable)
+
+`canMountFUSE()` becomes `detectMountMethod() string` and tries each in order:
+
+1. `/dev/fuse` open check (shared prerequisite — if this fails, all paths fail)
+2. `hasFusermount()` → return `"fusermount"`
+3. `checkNewMountAPI()` → kernel >= 5.2 via uname, then `unix.Fsopen("fuse", 0)` as a probe (close immediately) → return `"new-api"`
+4. `checkDirectMount()` → existing CAP_SYS_ADMIN + mount probe → return `"direct"`
+5. Return `""` (unavailable)
+
+`MountMethod() string` is exposed on the `Filesystem` struct for `agentsh detect` output.
+
+### 2. New Mount API Implementation
+
+**File:** `internal/platform/linux/filesystem.go`
+
+New function `mountFUSEViaNewAPI(mountPoint string, opts *fuse.MountOptions) (fuseFD int, err error)`:
+
+1. Open `/dev/fuse` → `fuseDev` fd
+2. `unix.Fsopen("fuse", 0)` → `fsctx` fd
+3. `unix.FsconfigSetString(fsctx, "fd", strconv.Itoa(fuseDev))`
+4. `unix.FsconfigSetString(fsctx, "rootmode", "40000")` (directory)
+5. `unix.FsconfigSetString(fsctx, "user_id", strconv.Itoa(os.Geteuid()))`
+6. `unix.FsconfigSetString(fsctx, "group_id", strconv.Itoa(os.Getegid()))`
+7. If `opts.AllowOther`: `unix.FsconfigSetFlag(fsctx, "allow_other")`
+8. `unix.FsconfigCreate(fsctx)` — finalize the superblock
+9. `unix.Fsmount(fsctx, 0, 0)` → `mntFD`
+10. `unix.MoveMount(mntFD, "", unix.AT_FDCWD, mountPoint, unix.MOVE_MOUNT_F_EMPTY_PATH)`
+11. Close `fsctx` and `mntFD` (no longer needed after move_mount)
+12. Return `fuseDev` — this is the fd go-fuse will use
+
+On any error, close all opened fds and return a descriptive error.
+
+### 3. go-fuse Integration via /dev/fd/N
+
+**File:** `internal/platform/linux/filesystem.go` (in `Filesystem.Mount()`)
+
+When `mountMethod == "new-api"`:
+
+1. Call `mountFUSEViaNewAPI(mountPoint, opts)` → get `fuseFD`
+2. Pass `/dev/fd/<fuseFD>` as the mountpoint to go-fuse's `fs.Mount()` instead of the real mountpoint
+3. go-fuse detects the `/dev/fd/N` magic path, uses the fd directly, skips its own mount logic
+
+The existing `MountWorkspace` in `internal/fsmonitor/mount.go` receives either the real path (fusermount/direct) or `/dev/fd/N` (new API). From go-fuse's perspective, `/dev/fd/N` is a pre-mounted FUSE connection — it reads/writes the FUSE protocol on it directly.
+
+For fusermount and direct mount paths, the flow is unchanged — the real mountpoint is passed through.
+
+**Unmount**: `unix.Unmount(mountPoint, 0)` works normally since `move_mount` created a real VFS mount entry. go-fuse's `server.Unmount()` handles this.
+
+### 4. Detection Output
+
+**Files:** `internal/capabilities/detect_linux.go`, `internal/cli/detect.go`
+
+Add `fuse_mount_method` to the capabilities map:
+
+```
+caps["fuse_mount_method"] = "fusermount" | "new-api" | "direct" | "none"
+```
+
+Derived from `Filesystem.MountMethod()`. The existing `fuse: true/false` capability is unchanged; `fuse_mount_method` is a companion field providing detail.
+
+**No config changes.** The mount method is auto-detected, not configurable.
+
+### 5. Testing
+
+**Unit tests** in `internal/platform/linux/filesystem_test.go`:
+
+1. `TestDetectMountMethod` — verify the function returns a valid method string on the current system.
+2. `TestCheckNewMountAPI_KernelVersion` — verify kernel >= 5.2 detection via `parseKernelVersion`.
+3. `TestMountFUSEViaNewAPI_FsopenProbe` — if kernel >= 5.2, verify `unix.Fsopen("fuse", 0)` succeeds. Skip on older kernels.
+
+**Integration test** (requires Docker with `--device /dev/fuse`):
+
+4. Full mount cycle: `mountFUSEViaNewAPI` → verify in `/proc/mounts` → write through mount → `unix.Unmount` → verify clean teardown. Only when `/dev/fuse` available and kernel >= 5.2.
+
+## Fallback Chain Summary
+
+| Priority | Method | Requirements | Works on Firecracker |
+|----------|--------|-------------|---------------------|
+| 1 | fusermount3/fusermount | suid binary in PATH | Yes (if installed) |
+| 2 | New mount API | Kernel >= 5.2, /dev/fuse | Yes |
+| 3 | Direct mount() | CAP_SYS_ADMIN, no seccomp block | No (hangs) |
+
+## Dependencies
+
+- `golang.org/x/sys v0.40.0` (already in go.mod) — provides `Fsopen`, `FsconfigSetString`, `FsconfigSetFlag`, `FsconfigCreate`, `Fsmount`, `MoveMount`
+- `github.com/hanwen/go-fuse/v2 v2.9.0` (already in go.mod) — `/dev/fd/N` magic mountpoint support
+- Linux 5.2+ for the new mount API syscalls
+
+## Out of Scope
+
+- Removing the legacy mount() fallback — it still works on non-Firecracker environments
+- Configurable mount method selection — auto-detection is sufficient
+- macOS/Windows changes — this is Linux-only

--- a/docs/superpowers/specs/2026-03-20-fuse-new-mount-api-design.md
+++ b/docs/superpowers/specs/2026-03-20-fuse-new-mount-api-design.md
@@ -29,11 +29,17 @@ The `Filesystem` struct gets a new field `mountMethod string` recording which mo
 
 1. `/dev/fuse` open check (shared prerequisite — if this fails, all paths fail)
 2. `hasFusermount()` → return `"fusermount"`
-3. `checkNewMountAPI()` → kernel >= 5.2 via uname, then `unix.Fsopen("fuse", 0)` as a probe (close immediately) → return `"new-api"`
+3. `checkNewMountAPI()` → try `unix.Fsopen("fuse", 0)` as a probe (close immediately). If ENOSYS, the kernel doesn't support the new mount API; if ENODEV, the fuse module isn't loaded. On success → return `"new-api"`. No kernel version parsing needed — `fsopen` is the ground truth.
 4. `checkDirectMount()` → existing CAP_SYS_ADMIN + mount probe → return `"direct"`
 5. Return `""` (unavailable)
 
 `MountMethod() string` is exposed on the `Filesystem` struct for `agentsh detect` output.
+
+**Recheck()**: `Recheck()` must also re-detect and store `mountMethod` (not just `available`), since deferred FUSE detection (E2B sandbox case) may discover a new mount method after startup.
+
+**Logging**: `detectMountMethod` logs at info level which method was selected, and at debug level which methods were tried and why they failed. This is critical for debugging Firecracker environments.
+
+**`checkFUSE()` in `security_caps.go`**: The parallel `checkFUSE()` in `internal/capabilities/security_caps.go` must delegate to the same detection logic (or call `Filesystem.MountMethod() != ""`), so that `agentsh detect` correctly reports `fuse: true` when the new-api path is available.
 
 ### 2. New Mount API Implementation
 
@@ -41,20 +47,24 @@ The `Filesystem` struct gets a new field `mountMethod string` recording which mo
 
 New function `mountFUSEViaNewAPI(mountPoint string, opts *fuse.MountOptions) (fuseFD int, err error)`:
 
-1. Open `/dev/fuse` → `fuseDev` fd
+1. Open `/dev/fuse` with `O_RDWR|O_CLOEXEC` → `fuseDev` fd
 2. `unix.Fsopen("fuse", 0)` → `fsctx` fd
 3. `unix.FsconfigSetString(fsctx, "fd", strconv.Itoa(fuseDev))`
 4. `unix.FsconfigSetString(fsctx, "rootmode", "40000")` (directory)
 5. `unix.FsconfigSetString(fsctx, "user_id", strconv.Itoa(os.Geteuid()))`
 6. `unix.FsconfigSetString(fsctx, "group_id", strconv.Itoa(os.Getegid()))`
-7. If `opts.AllowOther`: `unix.FsconfigSetFlag(fsctx, "allow_other")`
-8. `unix.FsconfigCreate(fsctx)` — finalize the superblock
-9. `unix.Fsmount(fsctx, 0, 0)` → `mntFD`
-10. `unix.MoveMount(mntFD, "", unix.AT_FDCWD, mountPoint, unix.MOVE_MOUNT_F_EMPTY_PATH)`
-11. Close `fsctx` and `mntFD` (no longer needed after move_mount)
-12. Return `fuseDev` — this is the fd go-fuse will use
+7. `unix.FsconfigSetString(fsctx, "max_read", strconv.Itoa(opts.MaxWrite))` — match go-fuse's behavior
+8. If `opts.AllowOther`: `unix.FsconfigSetFlag(fsctx, "allow_other")`
+9. `unix.FsconfigCreate(fsctx)` — finalize the superblock
+10. Close `fsctx` (no longer needed after create)
+11. `unix.Fsmount(fsctx_result, 0, 0)` → `mntFD`
+12. `unix.MoveMount(mntFD, "", unix.AT_FDCWD, mountPoint, unix.MOVE_MOUNT_F_EMPTY_PATH)`
+13. Close `mntFD` (no longer needed after move_mount)
+14. Return `fuseDev` — this is the fd go-fuse will use
 
-On any error, close all opened fds and return a descriptive error.
+**Error cleanup sequence**: Each step checks the previous step's error. On failure, close fds in reverse order of opening: `mntFD` (if opened), `fsctx` (if opened), `fuseDev` (if opened). Use `defer` with a success flag to ensure no fd leaks on any partial failure path.
+
+**O_CLOEXEC**: The `fuseDev` fd is opened with `O_CLOEXEC` (Go's `unix.Open` sets this by default). This matches go-fuse's behavior with fusermount. The fd is returned to go-fuse and must survive for the lifetime of the FUSE connection but not leak across exec.
 
 ### 3. go-fuse Integration via /dev/fd/N
 
@@ -63,14 +73,19 @@ On any error, close all opened fds and return a descriptive error.
 When `mountMethod == "new-api"`:
 
 1. Call `mountFUSEViaNewAPI(mountPoint, opts)` → get `fuseFD`
-2. Pass `/dev/fd/<fuseFD>` as the mountpoint to go-fuse's `fs.Mount()` instead of the real mountpoint
-3. go-fuse detects the `/dev/fd/N` magic path, uses the fd directly, skips its own mount logic
+2. Store the real `mountPoint` for later unmount and logging
+3. Pass `/dev/fd/<fuseFD>` as the mountpoint to go-fuse's `fs.Mount()` instead of the real mountpoint
+4. go-fuse detects the `/dev/fd/N` magic path, uses the fd directly, skips its own mount logic
 
 The existing `MountWorkspace` in `internal/fsmonitor/mount.go` receives either the real path (fusermount/direct) or `/dev/fd/N` (new API). From go-fuse's perspective, `/dev/fd/N` is a pre-mounted FUSE connection — it reads/writes the FUSE protocol on it directly.
 
+**Real mountpoint preservation**: The `Mount` struct returned by `MountWorkspace` stores `mountPoint`. When the new-api path is used, the caller must ensure the *real* mountpoint (not `/dev/fd/N`) is stored for display, logging, `/proc/mounts` lookups, and unmount. This is done at the `Filesystem.Mount()` level — it passes `/dev/fd/N` to go-fuse but stores the real path in the returned `FSMount`.
+
 For fusermount and direct mount paths, the flow is unchanged — the real mountpoint is passed through.
 
-**Unmount**: `unix.Unmount(mountPoint, 0)` works normally since `move_mount` created a real VFS mount entry. go-fuse's `server.Unmount()` handles this.
+**Unmount**: go-fuse's `Server.Unmount()` refuses to unmount `/dev/fd/N` magic mountpoints (returns an error). For the new-api path, unmount is performed by calling `unix.Unmount(realMountPoint, 0)` directly, bypassing `Server.Unmount()`. The `Filesystem.Unmount()` method checks the mount method and dispatches accordingly:
+- fusermount/direct: `server.Unmount()` (existing path)
+- new-api: `unix.Unmount(realMountPoint, 0)` + close the FUSE fd
 
 ### 4. Detection Output
 
@@ -91,8 +106,8 @@ Derived from `Filesystem.MountMethod()`. The existing `fuse: true/false` capabil
 **Unit tests** in `internal/platform/linux/filesystem_test.go`:
 
 1. `TestDetectMountMethod` — verify the function returns a valid method string on the current system.
-2. `TestCheckNewMountAPI_KernelVersion` — verify kernel >= 5.2 detection via `parseKernelVersion`.
-3. `TestMountFUSEViaNewAPI_FsopenProbe` — if kernel >= 5.2, verify `unix.Fsopen("fuse", 0)` succeeds. Skip on older kernels.
+2. `TestCheckNewMountAPI_FsopenProbe` — verify `unix.Fsopen("fuse", 0)` succeeds on kernels that support it. Skip if ENOSYS.
+3. `TestMountFUSEViaNewAPI_ErrorCleanup` — verify that partial failures (e.g., fsconfig error) close all fds without leaking.
 
 **Integration test** (requires Docker with `--device /dev/fuse`):
 
@@ -103,14 +118,14 @@ Derived from `Filesystem.MountMethod()`. The existing `fuse: true/false` capabil
 | Priority | Method | Requirements | Works on Firecracker |
 |----------|--------|-------------|---------------------|
 | 1 | fusermount3/fusermount | suid binary in PATH | Yes (if installed) |
-| 2 | New mount API | Kernel >= 5.2, /dev/fuse | Yes |
+| 2 | New mount API | /dev/fuse, fsopen succeeds | Yes |
 | 3 | Direct mount() | CAP_SYS_ADMIN, no seccomp block | No (hangs) |
 
 ## Dependencies
 
 - `golang.org/x/sys v0.40.0` (already in go.mod) — provides `Fsopen`, `FsconfigSetString`, `FsconfigSetFlag`, `FsconfigCreate`, `Fsmount`, `MoveMount`
 - `github.com/hanwen/go-fuse/v2 v2.9.0` (already in go.mod) — `/dev/fd/N` magic mountpoint support
-- Linux 5.2+ for the new mount API syscalls
+- Linux 5.2+ for the new mount API syscalls (detected at runtime via `fsopen` probe, not version parsing)
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-03-20-fuse-new-mount-api-design.md
+++ b/docs/superpowers/specs/2026-03-20-fuse-new-mount-api-design.md
@@ -1,7 +1,7 @@
 # FUSE New Mount API Fallback
 
 **Date:** 2026-03-20
-**Status:** Draft
+**Status:** Implemented
 **Scope:** Linux only
 
 ## Background

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -98,14 +98,29 @@ type wrapperSetupResult struct {
 // Returns the wrapped request and extra process config, or nil extraCfg if wrapping is disabled.
 // Note: agentsh-unixwrap is Linux-only; this function returns early on other platforms.
 func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *session.Session) *wrapperSetupResult {
+	// Helper: return early without seccomp wrapping but with envInject applied.
+	earlyReturn := func() *wrapperSetupResult {
+		sessionPolicy := a.policy
+		if s != nil {
+			if sp := s.PolicyEngine(); sp != nil {
+				sessionPolicy = sp
+			}
+		}
+		envInject := mergeEnvInject(a.cfg, sessionPolicy)
+		if len(envInject) > 0 {
+			return &wrapperSetupResult{wrappedReq: req, extraCfg: &extraProcConfig{envInject: envInject}}
+		}
+		return &wrapperSetupResult{wrappedReq: req, extraCfg: nil}
+	}
+
 	// agentsh-unixwrap is Linux-only (uses seccomp-bpf)
 	if runtime.GOOS != "linux" {
-		return &wrapperSetupResult{wrappedReq: req, extraCfg: nil}
+		return earlyReturn()
 	}
 
 	// Ptrace mode: no wrapper, no seccomp notify sockets
 	if a.ptraceTracer != nil {
-		return &wrapperSetupResult{wrappedReq: req, extraCfg: nil}
+		return earlyReturn()
 	}
 
 	origCommand := req.Command
@@ -113,7 +128,7 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 
 	unixEnabled := a.cfg.Sandbox.UnixSockets.Enabled != nil && *a.cfg.Sandbox.UnixSockets.Enabled
 	if !unixEnabled {
-		return &wrapperSetupResult{wrappedReq: req, extraCfg: nil}
+		return earlyReturn()
 	}
 
 	wrapperBin := strings.TrimSpace(a.cfg.Sandbox.UnixSockets.WrapperBin)
@@ -126,7 +141,7 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 		slog.Warn("seccomp wrapper unavailable: wrapper binary not found (running without seccomp enforcement)",
 			"wrapper_bin", wrapperBin,
 			"session_id", sessionID)
-		return &wrapperSetupResult{wrappedReq: req, extraCfg: nil}
+		return earlyReturn()
 	}
 
 	sp := createUnixSocketPair()
@@ -135,7 +150,7 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 		slog.Warn("seccomp wrapper disabled: failed to create notify socket pair",
 			"session_id", sessionID,
 			"command", origCommand)
-		return &wrapperSetupResult{wrappedReq: req, extraCfg: nil}
+		return earlyReturn()
 	}
 
 	wrappedReq := req

--- a/internal/capabilities/detect_linux.go
+++ b/internal/capabilities/detect_linux.go
@@ -38,6 +38,19 @@ func Detect() (*DetectResult, error) {
 		"file_enforcement":    secCaps.FileEnforcement,
 	}
 
+	// Determine FUSE mount method for observability
+	fuseMountMethod := "none"
+	if secCaps.FUSE {
+		if hasFusermount() {
+			fuseMountMethod = "fusermount"
+		} else if checkNewMountAPIAvailable() {
+			fuseMountMethod = "new-api"
+		} else {
+			fuseMountMethod = "direct"
+		}
+	}
+	caps["fuse_mount_method"] = fuseMountMethod
+
 	mode := secCaps.SelectMode()
 	score := modeToScore(mode)
 

--- a/internal/capabilities/security_caps.go
+++ b/internal/capabilities/security_caps.go
@@ -90,30 +90,35 @@ func checkSeccompBasic() bool {
 	return checkSeccompUserNotify().Available
 }
 
-// checkFUSE checks if FUSE is usable for filesystem interception.
-// It supports two mount paths:
-//   - fusermount (suid helper): works without CAP_SYS_ADMIN, used by go-fuse by default.
-//     This is the path used in Cloudflare Containers and similar environments.
-//   - direct mount (syscall.Mount): requires CAP_SYS_ADMIN and unblocked mount() syscall.
 func checkFUSE() bool {
-	// Check that /dev/fuse can be opened (not just that it exists)
 	fd, err := unix.Open("/dev/fuse", unix.O_RDWR, 0)
 	if err != nil {
 		return false
 	}
 	unix.Close(fd)
 
-	// Preferred path: check if fusermount is available.
-	// Since agentsh uses go-fuse without DirectMount, it will use the fusermount
-	// suid binary which handles mount() in its own privileged context. This works
-	// even when the calling process lacks CAP_SYS_ADMIN or seccomp blocks mount().
+	// Priority 1: fusermount
 	if hasFusermount() {
 		return true
 	}
 
-	// Fallback: check for direct mount capability (CAP_SYS_ADMIN + mount probe).
-	// This path is only reached if fusermount is not installed.
+	// Priority 2: new mount API (fsopen probe)
+	if checkNewMountAPIAvailable() {
+		return true
+	}
+
+	// Priority 3: direct mount
 	return checkDirectMount()
+}
+
+// checkNewMountAPIAvailable probes for new mount API support via fsopen.
+func checkNewMountAPIAvailable() bool {
+	fd, err := unix.Fsopen("fuse", 0)
+	if err != nil {
+		return false
+	}
+	unix.Close(fd)
+	return true
 }
 
 // hasFusermount checks if the fusermount suid binary is available in PATH.

--- a/internal/fsmonitor/mount.go
+++ b/internal/fsmonitor/mount.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/hanwen/go-fuse/v2/fs"
@@ -30,11 +31,14 @@ func MountWorkspace(ctx context.Context, backingDir string, mountPoint string, h
 	if mountPoint == "" {
 		return nil, fmt.Errorf("mountPoint is empty")
 	}
-	if err := os.MkdirAll(filepath.Dir(mountPoint), 0o755); err != nil {
-		return nil, fmt.Errorf("mkdir mount parent: %w", err)
-	}
-	if err := os.MkdirAll(mountPoint, 0o755); err != nil {
-		return nil, fmt.Errorf("mkdir mount: %w", err)
+	// Skip MkdirAll for /dev/fd/N magic mountpoints (pre-mounted FUSE fd)
+	if !strings.HasPrefix(mountPoint, "/dev/fd/") {
+		if err := os.MkdirAll(filepath.Dir(mountPoint), 0o755); err != nil {
+			return nil, fmt.Errorf("mkdir mount parent: %w", err)
+		}
+		if err := os.MkdirAll(mountPoint, 0o755); err != nil {
+			return nil, fmt.Errorf("mkdir mount: %w", err)
+		}
 	}
 
 	root, err := NewMonitoredLoopbackRoot(backingDir, hooks)

--- a/internal/platform/linux/filesystem.go
+++ b/internal/platform/linux/filesystem.go
@@ -284,20 +284,40 @@ func (fs *Filesystem) Mount(cfg platform.FSConfig) (platform.FSMount, error) {
 
 	// Create the FUSE mount using existing fsmonitor with a timeout
 	// to prevent hanging if mount is blocked (e.g., by seccomp)
+	effectiveMountPoint := cfg.MountPoint
+	mountedViaNewAPI := false
+	fuseFD := -1
+
+	if fs.mountMethod == "new-api" {
+		var err error
+		fuseFD, err = mountFUSEViaNewAPI(cfg.MountPoint, true, 0)
+		if err != nil {
+			return nil, fmt.Errorf("new mount API failed: %w", err)
+		}
+		effectiveMountPoint = fmt.Sprintf("/dev/fd/%d", fuseFD)
+		mountedViaNewAPI = true
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	fsMount, err := fsmonitor.MountWorkspace(ctx, cfg.SourcePath, cfg.MountPoint, hooks)
+	fsMount, err := fsmonitor.MountWorkspace(ctx, cfg.SourcePath, effectiveMountPoint, hooks)
 	if err != nil {
+		if mountedViaNewAPI {
+			unix.Unmount(cfg.MountPoint, 0)
+			unix.Close(fuseFD)
+		}
 		return nil, fmt.Errorf("failed to mount FUSE filesystem: %w", err)
 	}
 
 	// Wrap in our Mount type
 	mount := &Mount{
-		fsMount:    fsMount,
-		sourcePath: cfg.SourcePath,
-		mountPoint: cfg.MountPoint,
-		mountedAt:  time.Now(),
-		hooks:      hooks,
+		fsMount:          fsMount,
+		sourcePath:       cfg.SourcePath,
+		mountPoint:       cfg.MountPoint, // always real path
+		mountedAt:        time.Now(),
+		hooks:            hooks,
+		mountedViaNewAPI: mountedViaNewAPI,
+		fuseFD:           fuseFD,
 	}
 
 	fs.mounts[cfg.MountPoint] = mount
@@ -317,16 +337,26 @@ func (fs *Filesystem) Unmount(mount platform.FSMount) error {
 
 	delete(fs.mounts, m.mountPoint)
 
+	if m.mountedViaNewAPI {
+		err := unix.Unmount(m.mountPoint, 0)
+		if m.fuseFD >= 0 {
+			unix.Close(m.fuseFD)
+			m.fuseFD = -1
+		}
+		return err
+	}
 	return m.fsMount.Unmount()
 }
 
 // Mount wraps fsmonitor.Mount to implement platform.FSMount.
 type Mount struct {
-	fsMount    *fsmonitor.Mount
-	sourcePath string
-	mountPoint string
-	mountedAt  time.Time
-	hooks      *fsmonitor.Hooks
+	fsMount          *fsmonitor.Mount
+	sourcePath       string
+	mountPoint       string
+	mountedAt        time.Time
+	hooks            *fsmonitor.Hooks
+	mountedViaNewAPI bool // true if mounted via new mount API
+	fuseFD           int  // /dev/fuse fd to close on unmount (new-api only, -1 if unused)
 
 	// Stats tracking
 	mu            sync.Mutex
@@ -366,6 +396,14 @@ func (m *Mount) Stats() platform.FSStats {
 
 // Close unmounts the filesystem.
 func (m *Mount) Close() error {
+	if m.mountedViaNewAPI {
+		err := unix.Unmount(m.mountPoint, 0)
+		if m.fuseFD >= 0 {
+			unix.Close(m.fuseFD)
+			m.fuseFD = -1
+		}
+		return err
+	}
 	return m.fsMount.Unmount()
 }
 

--- a/internal/platform/linux/filesystem.go
+++ b/internal/platform/linux/filesystem.go
@@ -312,8 +312,9 @@ func (fs *Filesystem) Mount(cfg platform.FSConfig) (platform.FSMount, error) {
 	fsMount, err := fsmonitor.MountWorkspace(ctx, cfg.SourcePath, effectiveMountPoint, hooks)
 	if err != nil {
 		if mountedViaNewAPI {
+			// Unmount the VFS mount we created. Don't close fuseFD —
+			// go-fuse may have taken ownership during partial init.
 			unix.Unmount(cfg.MountPoint, 0)
-			unix.Close(fuseFD)
 		}
 		return nil, fmt.Errorf("failed to mount FUSE filesystem: %w", err)
 	}

--- a/internal/platform/linux/filesystem.go
+++ b/internal/platform/linux/filesystem.go
@@ -102,6 +102,66 @@ func hasFusermount() bool {
 	return false
 }
 
+// mountFUSEViaNewAPI mounts a FUSE filesystem using the Linux new mount API
+// (fsopen/fsconfig/fsmount/move_mount). Returns the /dev/fuse fd for go-fuse.
+// The caller is responsible for closing the fd when the FUSE server shuts down.
+func mountFUSEViaNewAPI(mountPoint string, allowOther bool, maxRead int) (fuseFD int, err error) {
+	fuseDev, err := unix.Open("/dev/fuse", unix.O_RDWR|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return -1, fmt.Errorf("open /dev/fuse: %w", err)
+	}
+
+	success := false
+	defer func() {
+		if !success {
+			unix.Close(fuseDev)
+		}
+	}()
+
+	fsctx, err := unix.Fsopen("fuse", 0)
+	if err != nil {
+		return -1, fmt.Errorf("fsopen fuse: %w", err)
+	}
+	defer unix.Close(fsctx)
+
+	configs := []struct{ key, val string }{
+		{"fd", fmt.Sprintf("%d", fuseDev)},
+		{"rootmode", "40000"},
+		{"user_id", fmt.Sprintf("%d", os.Geteuid())},
+		{"group_id", fmt.Sprintf("%d", os.Getegid())},
+	}
+	if maxRead > 0 {
+		configs = append(configs, struct{ key, val string }{"max_read", fmt.Sprintf("%d", maxRead)})
+	}
+	for _, c := range configs {
+		if err := unix.FsconfigSetString(fsctx, c.key, c.val); err != nil {
+			return -1, fmt.Errorf("fsconfig %s=%s: %w", c.key, c.val, err)
+		}
+	}
+	if allowOther {
+		if err := unix.FsconfigSetFlag(fsctx, "allow_other"); err != nil {
+			return -1, fmt.Errorf("fsconfig allow_other: %w", err)
+		}
+	}
+
+	if err := unix.FsconfigCreate(fsctx); err != nil {
+		return -1, fmt.Errorf("fsconfig create: %w", err)
+	}
+
+	mntFD, err := unix.Fsmount(fsctx, 0, 0)
+	if err != nil {
+		return -1, fmt.Errorf("fsmount: %w", err)
+	}
+	defer unix.Close(mntFD)
+
+	if err := unix.MoveMount(mntFD, "", unix.AT_FDCWD, mountPoint, unix.MOVE_MOUNT_F_EMPTY_PATH); err != nil {
+		return -1, fmt.Errorf("move_mount to %s: %w", mountPoint, err)
+	}
+
+	success = true
+	return fuseDev, nil
+}
+
 // checkDirectMount checks if direct mount() is possible (CAP_SYS_ADMIN + unblocked syscall).
 func checkDirectMount() bool {
 	// Check for CAP_SYS_ADMIN in the effective capability set.

--- a/internal/platform/linux/filesystem.go
+++ b/internal/platform/linux/filesystem.go
@@ -348,8 +348,15 @@ func (fs *Filesystem) Unmount(mount platform.FSMount) error {
 
 	if m.mountedViaNewAPI {
 		// go-fuse owns the FUSE fd — do NOT close it here.
-		// Just unmount the VFS mount.
-		return unix.Unmount(m.mountPoint, 0)
+		// Unmount the VFS, then wait for go-fuse server to shut down.
+		// After unix.Unmount, go-fuse's Serve() loop will get an error
+		// reading from the FUSE fd and exit, closing the fd and calling
+		// fileSystem.OnUnmount().
+		err := unix.Unmount(m.mountPoint, 0)
+		if err == nil && m.fsMount != nil && m.fsMount.Server != nil {
+			m.fsMount.Server.Wait()
+		}
+		return err
 	}
 	return m.fsMount.Unmount()
 }
@@ -404,8 +411,15 @@ func (m *Mount) Stats() platform.FSStats {
 func (m *Mount) Close() error {
 	if m.mountedViaNewAPI {
 		// go-fuse owns the FUSE fd — do NOT close it here.
-		// Just unmount the VFS mount.
-		return unix.Unmount(m.mountPoint, 0)
+		// Unmount the VFS, then wait for go-fuse server to shut down.
+		// After unix.Unmount, go-fuse's Serve() loop will get an error
+		// reading from the FUSE fd and exit, closing the fd and calling
+		// fileSystem.OnUnmount().
+		err := unix.Unmount(m.mountPoint, 0)
+		if err == nil && m.fsMount != nil && m.fsMount.Server != nil {
+			m.fsMount.Server.Wait()
+		}
+		return err
 	}
 	return m.fsMount.Unmount()
 }

--- a/internal/platform/linux/filesystem.go
+++ b/internal/platform/linux/filesystem.go
@@ -289,13 +289,22 @@ func (fs *Filesystem) Mount(cfg platform.FSConfig) (platform.FSMount, error) {
 	fuseFD := -1
 
 	if fs.mountMethod == "new-api" {
+		// Ensure mountpoint directory exists — MountWorkspace skips MkdirAll
+		// for /dev/fd/N, and move_mount needs the target to exist.
+		if err := os.MkdirAll(cfg.MountPoint, 0o755); err != nil {
+			return nil, fmt.Errorf("mkdir mount point %s: %w", cfg.MountPoint, err)
+		}
 		var err error
 		fuseFD, err = mountFUSEViaNewAPI(cfg.MountPoint, true, 0)
 		if err != nil {
-			return nil, fmt.Errorf("new mount API failed: %w", err)
+			// New mount API failed at runtime despite detection passing.
+			// Fall through to let go-fuse try its own mount strategies.
+			slog.Warn("fuse: new mount API failed at mount time, falling back to go-fuse default",
+				"mount_point", cfg.MountPoint, "error", err)
+		} else {
+			effectiveMountPoint = fmt.Sprintf("/dev/fd/%d", fuseFD)
+			mountedViaNewAPI = true
 		}
-		effectiveMountPoint = fmt.Sprintf("/dev/fd/%d", fuseFD)
-		mountedViaNewAPI = true
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -338,12 +347,9 @@ func (fs *Filesystem) Unmount(mount platform.FSMount) error {
 	delete(fs.mounts, m.mountPoint)
 
 	if m.mountedViaNewAPI {
-		err := unix.Unmount(m.mountPoint, 0)
-		if m.fuseFD >= 0 {
-			unix.Close(m.fuseFD)
-			m.fuseFD = -1
-		}
-		return err
+		// go-fuse owns the FUSE fd — do NOT close it here.
+		// Just unmount the VFS mount.
+		return unix.Unmount(m.mountPoint, 0)
 	}
 	return m.fsMount.Unmount()
 }
@@ -397,12 +403,9 @@ func (m *Mount) Stats() platform.FSStats {
 // Close unmounts the filesystem.
 func (m *Mount) Close() error {
 	if m.mountedViaNewAPI {
-		err := unix.Unmount(m.mountPoint, 0)
-		if m.fuseFD >= 0 {
-			unix.Close(m.fuseFD)
-			m.fuseFD = -1
-		}
-		return err
+		// go-fuse owns the FUSE fd — do NOT close it here.
+		// Just unmount the VFS mount.
+		return unix.Unmount(m.mountPoint, 0)
 	}
 	return m.fsMount.Unmount()
 }

--- a/internal/platform/linux/filesystem.go
+++ b/internal/platform/linux/filesystem.go
@@ -5,6 +5,7 @@ package linux
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"sync"
@@ -23,6 +24,7 @@ import (
 type Filesystem struct {
 	available      bool
 	implementation string
+	mountMethod    string // "fusermount", "new-api", "direct", ""
 	mu             sync.Mutex
 	mounts         map[string]*Mount
 }
@@ -32,38 +34,62 @@ func NewFilesystem() *Filesystem {
 	fs := &Filesystem{
 		mounts: make(map[string]*Mount),
 	}
-	fs.available = fs.checkAvailable()
+	fs.mountMethod = detectMountMethod()
+	fs.available = fs.mountMethod != ""
 	fs.implementation = fs.detectImplementation()
 	return fs
 }
 
 // checkAvailable checks if FUSE is available and mountable.
 func (fs *Filesystem) checkAvailable() bool {
-	return canMountFUSE()
+	fs.mountMethod = detectMountMethod()
+	return fs.mountMethod != ""
 }
 
-// canMountFUSE checks if FUSE can actually be mounted by verifying:
-// 1. /dev/fuse can be opened with O_RDWR
-// 2. fusermount suid binary is available (preferred), OR
-// 3. The process has CAP_SYS_ADMIN and mount() is not blocked by seccomp (fallback)
-func canMountFUSE() bool {
-	// Check that /dev/fuse can be opened (not just that it exists)
+// detectMountMethod determines which FUSE mount strategy is available.
+// Tries: fusermount → new mount API → direct mount().
+func detectMountMethod() string {
 	fd, err := unix.Open("/dev/fuse", unix.O_RDWR, 0)
+	if err != nil {
+		slog.Debug("fuse: /dev/fuse not available", "error", err)
+		return ""
+	}
+	unix.Close(fd)
+
+	if hasFusermount() {
+		slog.Info("fuse: mount method selected", "method", "fusermount")
+		return "fusermount"
+	}
+	slog.Debug("fuse: fusermount not found, trying new mount API")
+
+	if checkNewMountAPI() {
+		slog.Info("fuse: mount method selected", "method", "new-api")
+		return "new-api"
+	}
+	slog.Debug("fuse: new mount API not available, trying direct mount")
+
+	if checkDirectMount() {
+		slog.Info("fuse: mount method selected", "method", "direct")
+		return "direct"
+	}
+	slog.Debug("fuse: no mount method available")
+
+	return ""
+}
+
+// checkNewMountAPI probes whether the new mount API works for FUSE.
+func checkNewMountAPI() bool {
+	fd, err := unix.Fsopen("fuse", 0)
 	if err != nil {
 		return false
 	}
 	unix.Close(fd)
+	return true
+}
 
-	// Preferred path: check if fusermount is available.
-	// Since agentsh uses go-fuse without DirectMount, it will use the fusermount
-	// suid binary which handles mount() in its own privileged context. This works
-	// even when the calling process lacks CAP_SYS_ADMIN or seccomp blocks mount().
-	if hasFusermount() {
-		return true
-	}
-
-	// Fallback: check for direct mount capability (CAP_SYS_ADMIN + mount probe).
-	return checkDirectMount()
+// MountMethod returns the detected FUSE mount method.
+func (fs *Filesystem) MountMethod() string {
+	return fs.mountMethod
 }
 
 // hasFusermount checks if the fusermount suid binary is available in PATH.

--- a/internal/platform/linux/filesystem_test.go
+++ b/internal/platform/linux/filesystem_test.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package linux
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDetectMountMethod(t *testing.T) {
+	method := detectMountMethod()
+	if _, err := os.Open("/dev/fuse"); err == nil {
+		assert.NotEmpty(t, method, "should detect a mount method when /dev/fuse exists")
+		assert.Contains(t, []string{"fusermount", "new-api", "direct"}, method)
+	}
+}
+
+func TestCheckNewMountAPI(t *testing.T) {
+	result := checkNewMountAPI()
+	_ = result // just verify no panic
+}
+
+func TestFilesystem_MountMethod(t *testing.T) {
+	fs := NewFilesystem()
+	if fs.Available() {
+		assert.NotEmpty(t, fs.MountMethod())
+	} else {
+		assert.Empty(t, fs.MountMethod())
+	}
+}

--- a/internal/platform/linux/filesystem_test.go
+++ b/internal/platform/linux/filesystem_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
 )
 
 func TestDetectMountMethod(t *testing.T) {
@@ -29,4 +30,23 @@ func TestFilesystem_MountMethod(t *testing.T) {
 	} else {
 		assert.Empty(t, fs.MountMethod())
 	}
+}
+
+func TestMountFUSEViaNewAPI_ErrorCleanup(t *testing.T) {
+	if !checkNewMountAPI() {
+		t.Skip("new mount API not available")
+	}
+	_, err := mountFUSEViaNewAPI("/nonexistent/path/that/cannot/exist", true, 0)
+	assert.Error(t, err, "should fail with nonexistent mountpoint")
+}
+
+func TestMountFUSEViaNewAPI_FsopenProbe(t *testing.T) {
+	if !checkNewMountAPI() {
+		t.Skip("new mount API not available")
+	}
+	fd, err := unix.Fsopen("fuse", 0)
+	if err != nil {
+		t.Fatalf("fsopen failed: %v", err)
+	}
+	unix.Close(fd)
 }

--- a/internal/platform/linux/filesystem_test.go
+++ b/internal/platform/linux/filesystem_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
 
@@ -49,4 +50,36 @@ func TestMountFUSEViaNewAPI_FsopenProbe(t *testing.T) {
 		t.Fatalf("fsopen failed: %v", err)
 	}
 	unix.Close(fd)
+}
+
+func TestMountFUSEViaNewAPI_Integration(t *testing.T) {
+	if !checkNewMountAPI() {
+		t.Skip("new mount API not available")
+	}
+	if os.Getuid() != 0 {
+		t.Skip("requires root for FUSE mount")
+	}
+
+	// Create a temp directory as the mount point
+	mountDir, err := os.MkdirTemp("", "fuse-newapi-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(mountDir)
+
+	// Mount FUSE via new API
+	fuseFD, err := mountFUSEViaNewAPI(mountDir, true, 0)
+	require.NoError(t, err)
+	defer unix.Close(fuseFD)
+
+	// Verify mount appears in /proc/mounts
+	mounts, err := os.ReadFile("/proc/mounts")
+	require.NoError(t, err)
+	assert.Contains(t, string(mounts), mountDir, "mount should appear in /proc/mounts")
+
+	// Unmount
+	err = unix.Unmount(mountDir, 0)
+	assert.NoError(t, err)
+
+	// Verify unmounted
+	mounts2, _ := os.ReadFile("/proc/mounts")
+	assert.NotContains(t, string(mounts2), mountDir, "mount should be gone after unmount")
 }

--- a/internal/platform/linux/linux_test.go
+++ b/internal/platform/linux/linux_test.go
@@ -23,13 +23,11 @@ func TestNewFilesystem(t *testing.T) {
 func TestFilesystem_Available(t *testing.T) {
 	fs := NewFilesystem()
 
-	// Available() now checks both O_RDWR access to /dev/fuse and
-	// CAP_SYS_ADMIN capability via canMountFUSE(), so the expected
-	// value must match that same logic, not just /dev/fuse existence.
-	expectAvailable := canMountFUSE()
+	// Available() checks whether a FUSE mount method was detected.
+	expectAvailable := detectMountMethod() != ""
 
 	if fs.Available() != expectAvailable {
-		t.Errorf("Available() = %v, expected %v from canMountFUSE()", fs.Available(), expectAvailable)
+		t.Errorf("Available() = %v, expected %v from detectMountMethod()", fs.Available(), expectAvailable)
 	}
 }
 

--- a/internal/platform/linux/platform.go
+++ b/internal/platform/linux/platform.go
@@ -107,7 +107,7 @@ func (p *Platform) detectCapabilities() platform.Capabilities {
 
 // checkFUSE checks if FUSE is available and mountable.
 func (p *Platform) checkFUSE() bool {
-	return canMountFUSE()
+	return detectMountMethod() != ""
 }
 
 // detectFUSEVersion returns the FUSE implementation version.

--- a/scripts/bench-modes.sh
+++ b/scripts/bench-modes.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Build and run the agentsh performance benchmark.
-# Compares baseline (no sandbox) vs full mode (seccomp+FUSE) vs ptrace.
+# Compares baseline vs full mode (seccomp+FUSE) vs seccomp-notify vs ptrace.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"


### PR DESCRIPTION
## Summary

- Adds a FUSE mount fallback using the Linux new mount API (`fsopen`/`fsconfig`/`fsmount`/`move_mount`) for environments where the traditional `mount()` syscall hangs (Cloudflare Firecracker VMs)
- Three-way detection: fusermount (suid) → new mount API (kernel 5.2+) → direct mount (CAP_SYS_ADMIN)
- go-fuse integration via `/dev/fd/N` magic mountpoint — no library fork needed
- `agentsh detect` reports `fuse_mount_method: fusermount|new-api|direct|none`

### How it works

1. **Detection**: `detectMountMethod()` probes `fsopen("fuse", 0)` to check if the new mount API works. This is the ground truth — no kernel version parsing needed.

2. **Mount**: `mountFUSEViaNewAPI()` performs the full sequence:
   - `unix.Open("/dev/fuse")` → fuse fd
   - `unix.Fsopen("fuse", 0)` → filesystem context
   - `unix.FsconfigSetString()` for fd, rootmode, user_id, group_id, max_read
   - `unix.FsconfigCreate()` → finalize superblock
   - `unix.Fsmount()` → mount fd
   - `unix.MoveMount()` → attach to target mountpoint

3. **go-fuse**: Receives `/dev/fd/N` as the mountpoint, which it recognizes as a pre-mounted FUSE connection. Skips its own mount logic entirely.

4. **Unmount**: Uses `unix.Unmount(realMountPoint, 0)` directly (go-fuse refuses to unmount `/dev/fd/N` paths), then waits for go-fuse server shutdown via `Server.Wait()`.

5. **Fallback**: If the new mount API fails at mount time despite detection passing, falls back to go-fuse's default mount path (fusermount/direct).

### Key design decisions

- fd ownership transfers to go-fuse once `/dev/fd/N` is passed — we never close it ourselves
- Real mountpoint preserved on `linux.Mount` struct for display/logging/unmount (not `/dev/fd/N`)
- `MkdirAll` guarded in `fsmonitor.MountWorkspace` to skip for `/dev/fd/N` paths
- Detection also added to `capabilities.checkFUSE()` so `agentsh detect` correctly reports FUSE availability

## Test plan

- [x] Unit tests for detectMountMethod, checkNewMountAPI
- [x] Unit test for mountFUSEViaNewAPI error cleanup (partial failure fd handling)
- [x] Integration test for full mount/unmount cycle (skips without root + /dev/fuse)
- [x] Full build + Windows cross-compile + all test packages pass
- [x] 4 rounds of roborev — all High findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)