### PR TITLE
feat: redesign detect output with domain grouping and real probes

### DIFF
--- a/docs/superpowers/plans/2026-03-21-detect-redesign.md
+++ b/docs/superpowers/plans/2026-03-21-detect-redesign.md
@@ -1,0 +1,824 @@
+# Detect Output Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace stub detections with real probes, group capabilities by protection domain, and compute a weighted score based on actual feature availability across all platforms.
+
+**Architecture:** Add `ProtectionDomain` and `DetectedBackend` types to the detection result. Each platform's `Detect()` builds domains from its capability probes. The score is computed as the sum of domain weights where any backend is available. The flat `Capabilities` map is preserved for backward compatibility.
+
+**Tech Stack:** Go, golang.org/x/sys/unix (Linux probes), golang.org/x/sys/windows (Windows probes)
+
+**Spec:** `docs/superpowers/specs/2026-03-21-detect-redesign-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `internal/capabilities/detect_result.go` | Modify | Add ProtectionDomain, DetectedBackend, ProbeResult types; new Table() format; weighted score |
+| `internal/capabilities/detect_result_test.go` | Create | Score computation tests (all/none/4 partial combos), format tests (table + JSON), integration |
+| `internal/capabilities/check.go` | Modify | Replace eBPF/cgroups stubs with real probes; wire SecurityCapabilities |
+| `internal/capabilities/check_ebpf_linux.go` | Create | eBPF BPF_PROG_LOAD probe |
+| `internal/capabilities/check_cgroups_linux.go` | Create | cgroups v2 statfs probe |
+| `internal/capabilities/check_pidns_linux.go` | Create | PID namespace NSpid probe |
+| `internal/capabilities/check_caps_linux.go` | Create | Capability drop capget+prctl probe |
+| `internal/capabilities/check_test.go` | Modify | Tests for new probes |
+| `internal/capabilities/detect_linux.go` | Modify | Build domains, weighted score, backward compat map |
+| `internal/capabilities/detect_linux_test.go` | Modify | Update existing tests for new Domains field |
+| `internal/capabilities/detect_darwin.go` | Modify | Build domains for Darwin |
+| `internal/capabilities/detect_windows.go` | Modify | Build domains for Windows |
+| `internal/capabilities/tips.go` | Modify | Generate tips from domains (only for 0-score domains); add lookupTip + tests |
+| `internal/capabilities/security_caps.go` | Modify | Wire new probe functions, cache results on SecurityCapabilities |
+
+---
+
+### Task 1: Data Model — ProtectionDomain + DetectedBackend
+
+**Files:**
+- Modify: `internal/capabilities/detect_result.go`
+- Create: `internal/capabilities/detect_result_test.go`
+
+- [ ] **Step 1: Add new types to detect_result.go**
+
+Add after the existing `Tip` struct (NOTE: `ProbeResult` goes here, not in check_ebpf_linux.go, since all probe files and detect_linux.go use it):
+
+```go
+// ProbeResult holds the result of a capability probe.
+type ProbeResult struct {
+	Available bool   `json:"available" yaml:"available"`
+	Detail    string `json:"detail" yaml:"detail"`
+}
+
+// ProtectionDomain groups related security backends by what they protect.
+type ProtectionDomain struct {
+	Name     string            `json:"name" yaml:"name"`
+	Weight   int               `json:"weight" yaml:"weight"`
+	Score    int               `json:"score" yaml:"score"`
+	Backends []DetectedBackend `json:"backends" yaml:"backends"`
+	Active   string            `json:"active" yaml:"active"`
+}
+
+// DetectedBackend represents a single security mechanism within a domain.
+type DetectedBackend struct {
+	Name        string `json:"name" yaml:"name"`
+	Available   bool   `json:"available" yaml:"available"`
+	Detail      string `json:"detail" yaml:"detail"`
+	Description string `json:"description" yaml:"description"`
+	CheckMethod string `json:"check_method" yaml:"check_method"`
+}
+
+// Domain weight constants.
+const (
+	WeightFileProtection = 25
+	WeightCommandControl = 25
+	WeightNetwork        = 20
+	WeightResourceLimits = 15
+	WeightIsolation      = 15
+)
+```
+
+Add `Domains` field to `DetectResult`:
+
+```go
+type DetectResult struct {
+	Platform        string             `json:"platform" yaml:"platform"`
+	SecurityMode    string             `json:"security_mode" yaml:"security_mode"`
+	ProtectionScore int                `json:"protection_score" yaml:"protection_score"`
+	Domains         []ProtectionDomain `json:"domains" yaml:"domains"`
+	Capabilities    map[string]any     `json:"capabilities" yaml:"capabilities"`
+	Summary         DetectSummary      `json:"summary" yaml:"summary"`
+	Tips            []Tip              `json:"tips" yaml:"tips"`
+}
+```
+
+Add score computation:
+
+```go
+// ComputeScore calculates the protection score from domain availability.
+func ComputeScore(domains []ProtectionDomain) int {
+	score := 0
+	for i := range domains {
+		hasAny := false
+		for _, b := range domains[i].Backends {
+			if b.Available {
+				hasAny = true
+				break
+			}
+		}
+		if hasAny {
+			domains[i].Score = domains[i].Weight
+		} else {
+			domains[i].Score = 0
+		}
+		score += domains[i].Score
+	}
+	return score
+}
+```
+
+- [ ] **Step 2: Write tests**
+
+Create `internal/capabilities/detect_result_test.go`:
+
+```go
+//go:build linux || darwin || windows
+
+package capabilities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeScore_AllAvailable(t *testing.T) {
+	domains := []ProtectionDomain{
+		{Name: "File Protection", Weight: 25, Backends: []DetectedBackend{{Available: true}}},
+		{Name: "Command Control", Weight: 25, Backends: []DetectedBackend{{Available: true}}},
+		{Name: "Network", Weight: 20, Backends: []DetectedBackend{{Available: true}}},
+		{Name: "Resource Limits", Weight: 15, Backends: []DetectedBackend{{Available: true}}},
+		{Name: "Isolation", Weight: 15, Backends: []DetectedBackend{{Available: true}}},
+	}
+	assert.Equal(t, 100, ComputeScore(domains))
+}
+
+func TestComputeScore_NoneAvailable(t *testing.T) {
+	domains := []ProtectionDomain{
+		{Name: "File Protection", Weight: 25, Backends: []DetectedBackend{{Available: false}}},
+		{Name: "Command Control", Weight: 25, Backends: []DetectedBackend{{Available: false}}},
+		{Name: "Network", Weight: 20, Backends: []DetectedBackend{{Available: false}}},
+		{Name: "Resource Limits", Weight: 15, Backends: []DetectedBackend{{Available: false}}},
+		{Name: "Isolation", Weight: 15, Backends: []DetectedBackend{{Available: false}}},
+	}
+	assert.Equal(t, 0, ComputeScore(domains))
+}
+
+func TestComputeScore_Partial(t *testing.T) {
+	domains := []ProtectionDomain{
+		{Name: "File Protection", Weight: 25, Backends: []DetectedBackend{
+			{Name: "fuse", Available: false},
+			{Name: "landlock", Available: true}, // one backend enough
+		}},
+		{Name: "Command Control", Weight: 25, Backends: []DetectedBackend{{Available: false}}},
+		{Name: "Network", Weight: 20, Backends: []DetectedBackend{{Available: true}}},
+		{Name: "Resource Limits", Weight: 15, Backends: []DetectedBackend{{Available: false}}},
+		{Name: "Isolation", Weight: 15, Backends: []DetectedBackend{{Available: true}}},
+	}
+	assert.Equal(t, 60, ComputeScore(domains)) // 25 + 20 + 15
+}
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `go build ./internal/capabilities/... && go test ./internal/capabilities/... -run TestComputeScore -v -count=1`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/capabilities/detect_result.go internal/capabilities/detect_result_test.go
+git commit -m "feat(detect): add ProtectionDomain data model and weighted score computation
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Linux Real Probes — eBPF, cgroups v2, PID namespace, capabilities
+
+**Files:**
+- Create: `internal/capabilities/check_ebpf_linux.go`
+- Create: `internal/capabilities/check_cgroups_linux.go`
+- Create: `internal/capabilities/check_pidns_linux.go`
+- Create: `internal/capabilities/check_caps_linux.go`
+- Modify: `internal/capabilities/check.go` (wire new probes)
+- Modify: `internal/capabilities/security_caps.go` (use new probes)
+- Modify: `internal/capabilities/check_test.go`
+
+- [ ] **Step 1: Write probe test stubs**
+
+In `check_test.go`, add:
+
+```go
+func TestProbeEBPF(t *testing.T) {
+	result := probeEBPF()
+	// Result depends on environment — just verify no panic and valid structure
+	assert.NotEmpty(t, result.Detail)
+}
+
+func TestProbeCgroupsV2(t *testing.T) {
+	result := probeCgroupsV2()
+	assert.NotEmpty(t, result.Detail)
+}
+
+func TestProbePIDNamespace(t *testing.T) {
+	result := probePIDNamespace()
+	assert.NotEmpty(t, result.Detail)
+}
+
+func TestProbeCapabilityDrop(t *testing.T) {
+	result := probeCapabilityDrop()
+	assert.NotEmpty(t, result.Detail)
+}
+```
+
+- [ ] **Step 2: Implement eBPF probe**
+
+Create `check_ebpf_linux.go`:
+
+```go
+//go:build linux
+
+package capabilities
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// probeEBPF checks if BPF cgroup_skb programs can be loaded.
+func probeEBPF() ProbeResult {
+	// Minimal BPF program: single BPF_EXIT instruction
+	insn := [8]byte{0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	license := [4]byte{'G', 'P', 'L', 0}
+
+	// bpf_attr for BPF_PROG_LOAD
+	type bpfProgLoadAttr struct {
+		progType    uint32
+		insnCnt     uint32
+		insns       uint64
+		license     uint64
+		logLevel    uint32
+		logSize     uint32
+		logBuf      uint64
+		kernVersion uint32
+	}
+
+	attr := bpfProgLoadAttr{
+		progType: 13, // BPF_PROG_TYPE_CGROUP_SKB
+		insnCnt:  1,
+		insns:    uint64(uintptr(unsafe.Pointer(&insn[0]))),
+		license:  uint64(uintptr(unsafe.Pointer(&license[0]))),
+	}
+
+	fd, _, errno := unix.Syscall(
+		unix.SYS_BPF,
+		5, // BPF_PROG_LOAD
+		uintptr(unsafe.Pointer(&attr)),
+		unsafe.Sizeof(attr),
+	)
+	if errno == 0 {
+		unix.Close(int(fd))
+		return ProbeResult{Available: true, Detail: "cgroup_skb"}
+	}
+	switch errno {
+	case unix.EPERM:
+		return ProbeResult{Available: false, Detail: "EPERM (missing CAP_BPF)"}
+	case unix.ENOSYS:
+		return ProbeResult{Available: false, Detail: "ENOSYS (kernel too old)"}
+	default:
+		return ProbeResult{Available: false, Detail: errno.Error()}
+	}
+}
+```
+
+- [ ] **Step 3: Implement cgroups v2 probe**
+
+Create `check_cgroups_linux.go`:
+
+```go
+//go:build linux
+
+package capabilities
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+const cgroup2SuperMagic = 0x63677270
+
+// probeCgroupsV2 checks if cgroups v2 is mounted and accessible.
+func probeCgroupsV2() ProbeResult {
+	var statfs unix.Statfs_t
+	if err := unix.Statfs("/sys/fs/cgroup", &statfs); err != nil {
+		return ProbeResult{Available: false, Detail: "not mounted"}
+	}
+	if statfs.Type != cgroup2SuperMagic {
+		return ProbeResult{Available: false, Detail: "cgroup v1"}
+	}
+	f, err := os.OpenFile("/sys/fs/cgroup/cgroup.procs", os.O_RDONLY, 0)
+	if err != nil {
+		return ProbeResult{Available: false, Detail: "not readable"}
+	}
+	f.Close()
+	return ProbeResult{Available: true, Detail: "cgroup2"}
+}
+```
+
+- [ ] **Step 4: Implement PID namespace probe**
+
+Create `check_pidns_linux.go`:
+
+```go
+//go:build linux
+
+package capabilities
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// probePIDNamespace checks if the process is in a PID namespace.
+func probePIDNamespace() ProbeResult {
+	data, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return ProbeResult{Available: false, Detail: "cannot read /proc/self/status"}
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "NSpid:") {
+			fields := strings.Fields(line)
+			levels := len(fields) - 1 // subtract "NSpid:" label
+			if levels > 1 {
+				return ProbeResult{Available: true, Detail: fmt.Sprintf("NSpid: %d levels", levels)}
+			}
+			return ProbeResult{Available: false, Detail: "host namespace"}
+		}
+	}
+	return ProbeResult{Available: false, Detail: "NSpid not supported"}
+}
+```
+
+- [ ] **Step 5: Implement capability drop probe**
+
+Create `check_caps_linux.go`:
+
+```go
+//go:build linux
+
+package capabilities
+
+import "golang.org/x/sys/unix"
+
+// probeCapabilityDrop checks if capabilities can be read and dropped.
+func probeCapabilityDrop() ProbeResult {
+	// NOTE: LINUX_CAPABILITY_VERSION_3 requires two CapUserData structs
+	// (one per 32-bit word of capabilities). Using a single struct is a
+	// known footgun — use an array of two.
+	hdr := unix.CapUserHeader{Version: unix.LINUX_CAPABILITY_VERSION_3}
+	var data [2]unix.CapUserData
+	if err := unix.Capget(&hdr, &data[0]); err != nil {
+		return ProbeResult{Available: false, Detail: "capget failed: " + err.Error()}
+	}
+	_, _, errno := unix.Syscall6(unix.SYS_PRCTL, unix.PR_CAPBSET_READ, 0, 0, 0, 0, 0)
+	if errno != 0 {
+		return ProbeResult{Available: false, Detail: "prctl failed: " + errno.Error()}
+	}
+	return ProbeResult{Available: true, Detail: "capget+prctl"}
+}
+```
+
+- [ ] **Step 6: Wire probes into check.go and security_caps.go**
+
+In `check.go`, replace the stub implementations:
+
+```go
+func realCheckCgroupsV2() CheckResult {
+	probe := probeCgroupsV2()
+	return CheckResult{Feature: "cgroups-v2", Available: probe.Available}
+}
+
+func realCheckeBPF() CheckResult {
+	probe := probeEBPF()
+	return CheckResult{Feature: "ebpf", Available: probe.Available}
+}
+```
+
+In `security_caps.go`, update `DetectSecurityCapabilities()` to run probes once and store results:
+
+```go
+// Run probes once and cache results on the struct
+ebpfProbe := probeEBPF()
+cgroupProbe := probeCgroupsV2()
+pidnsProbe := probePIDNamespace()
+capProbe := probeCapabilityDrop()
+
+caps.EBPF = ebpfProbe.Available
+caps.PIDNamespace = pidnsProbe.Available
+caps.Capabilities = capProbe.Available
+// Store ProbeResults for buildLinuxDomains to reuse (avoid double-probing)
+caps.EBPFProbe = ebpfProbe
+caps.CgroupProbe = cgroupProbe
+caps.PIDNSProbe = pidnsProbe
+caps.CapProbe = capProbe
+```
+
+Add corresponding `ProbeResult` fields to `SecurityCapabilities` struct. The `buildLinuxDomains` function should read these cached results instead of re-running probes.
+
+And update `checkSeccompBasic()` if it's still a stub mirroring seccomp.
+
+- [ ] **Step 7: Build and test**
+
+Run: `go build ./internal/capabilities/... && go test ./internal/capabilities/... -run "TestProbe" -v -count=1`
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/capabilities/check_ebpf_linux.go internal/capabilities/check_cgroups_linux.go internal/capabilities/check_pidns_linux.go internal/capabilities/check_caps_linux.go internal/capabilities/check.go internal/capabilities/security_caps.go internal/capabilities/check_test.go
+git commit -m "feat(detect): replace stub probes with real eBPF/cgroups/pidns/caps detection
+
+eBPF: BPF_PROG_LOAD with BPF_PROG_TYPE_CGROUP_SKB
+cgroups v2: statfs + cgroup.procs readability
+PID namespace: /proc/self/status NSpid field
+Capabilities: capget + prctl(PR_CAPBSET_READ)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Linux Domain Builder — Build domains from SecurityCapabilities
+
+**Files:**
+- Modify: `internal/capabilities/detect_linux.go`
+
+- [ ] **Step 1: Add buildLinuxDomains function**
+
+```go
+// buildLinuxDomains constructs protection domains from detected capabilities.
+func buildLinuxDomains(caps *SecurityCapabilities) []ProtectionDomain {
+	ebpfProbe := probeEBPF()
+	cgroupProbe := probeCgroupsV2()
+	pidnsProbe := probePIDNamespace()
+	capProbe := probeCapabilityDrop()
+
+	fuseMountMethod := "none"
+	if caps.FUSE {
+		if hasFusermount() {
+			fuseMountMethod = "fusermount"
+		} else if checkNewMountAPIAvailable() {
+			fuseMountMethod = "new-api"
+		} else {
+			fuseMountMethod = "direct"
+		}
+	}
+
+	landlockDetail := "not available"
+	if caps.Landlock {
+		landlockDetail = fmt.Sprintf("ABI v%d", caps.LandlockABI)
+	}
+
+	return []ProtectionDomain{
+		{
+			Name: "File Protection", Weight: WeightFileProtection,
+			Backends: []DetectedBackend{
+				{Name: "fuse", Available: caps.FUSE, Detail: fuseMountMethod, Description: "file interception, soft-delete, redirect", CheckMethod: "probe"},
+				{Name: "landlock", Available: caps.Landlock, Detail: landlockDetail, Description: "kernel path restrictions", CheckMethod: "syscall"},
+				{Name: "seccomp-notify", Available: caps.Seccomp, Detail: "", Description: "openat/stat enforcement", CheckMethod: "probe"},
+			},
+			Active: caps.FileEnforcement,
+		},
+		{
+			Name: "Command Control", Weight: WeightCommandControl,
+			Backends: []DetectedBackend{
+				{Name: "seccomp-execve", Available: caps.Seccomp, Detail: "", Description: "execve interception", CheckMethod: "probe"},
+				{Name: "ptrace", Available: caps.Ptrace, Detail: "", Description: "syscall tracing", CheckMethod: "probe"},
+			},
+		},
+		{
+			Name: "Network", Weight: WeightNetwork,
+			Backends: []DetectedBackend{
+				{Name: "ebpf", Available: ebpfProbe.Available, Detail: ebpfProbe.Detail, Description: "network monitoring", CheckMethod: "probe"},
+				{Name: "landlock-network", Available: caps.LandlockNetwork, Detail: "", Description: "TCP bind/connect filtering", CheckMethod: "syscall"},
+			},
+		},
+		{
+			Name: "Resource Limits", Weight: WeightResourceLimits,
+			Backends: []DetectedBackend{
+				{Name: "cgroups-v2", Available: cgroupProbe.Available, Detail: cgroupProbe.Detail, Description: "CPU/memory/process limits", CheckMethod: "probe"},
+			},
+		},
+		{
+			Name: "Isolation", Weight: WeightIsolation,
+			Backends: []DetectedBackend{
+				{Name: "pid-namespace", Available: pidnsProbe.Available, Detail: pidnsProbe.Detail, Description: "process isolation", CheckMethod: "probe"},
+				{Name: "capability-drop", Available: capProbe.Available, Detail: capProbe.Detail, Description: "privilege reduction", CheckMethod: "probe"},
+			},
+		},
+	}
+}
+```
+
+- [ ] **Step 2: Update Detect() to use domains and weighted score**
+
+Replace the `Detect()` function body to:
+1. Call `buildLinuxDomains(secCaps)`
+2. Call `ComputeScore(domains)` instead of `modeToScore`
+3. Build the backward compat `caps` map from domains
+4. Still use `SelectMode()` for `SecurityMode`
+
+```go
+func Detect() (*DetectResult, error) {
+	secCaps := DetectSecurityCapabilities()
+	secCaps.FileEnforcement = detectFileEnforcementBackend(secCaps)
+
+	domains := buildLinuxDomains(secCaps)
+	score := ComputeScore(domains)
+	mode := secCaps.SelectMode()
+
+	// Backward compat: populate flat capabilities map from domains
+	caps := backwardCompatCaps(secCaps, domains)
+
+	// Build summary from domains
+	var available, unavailable []string
+	for _, d := range domains {
+		for _, b := range d.Backends {
+			if b.Available {
+				available = append(available, b.Name)
+			} else {
+				unavailable = append(unavailable, b.Name)
+			}
+		}
+	}
+
+	tips := GenerateTipsFromDomains(domains)
+
+	return &DetectResult{
+		Platform:        "linux",
+		SecurityMode:    mode,
+		ProtectionScore: score,
+		Domains:         domains,
+		Capabilities:    caps,
+		Summary:         DetectSummary{Available: available, Unavailable: unavailable},
+		Tips:            tips,
+	}, nil
+}
+
+// backwardCompatCaps builds the flat capabilities map for JSON backward compat.
+func backwardCompatCaps(caps *SecurityCapabilities, domains []ProtectionDomain) map[string]any {
+	m := map[string]any{
+		"seccomp":             caps.Seccomp,
+		"seccomp_user_notify": caps.Seccomp,
+		"seccomp_basic":       caps.SeccompBasic,
+		"landlock":            caps.Landlock,
+		"landlock_abi":        caps.LandlockABI,
+		"landlock_network":    caps.LandlockNetwork,
+		"fuse":                caps.FUSE,
+		"ptrace":              caps.Ptrace,
+		"file_enforcement":    caps.FileEnforcement,
+	}
+	// Add probe-based values from domains
+	for _, d := range domains {
+		for _, b := range d.Backends {
+			switch b.Name {
+			case "ebpf":
+				m["ebpf"] = b.Available
+			case "cgroups-v2":
+				m["cgroups_v2"] = b.Available
+			case "pid-namespace":
+				m["pid_namespace"] = b.Available
+			case "capability-drop":
+				m["capabilities_drop"] = b.Available
+			}
+		}
+	}
+	// FUSE mount method
+	for _, b := range domains[0].Backends {
+		if b.Name == "fuse" && b.Available {
+			m["fuse_mount_method"] = b.Detail
+		}
+	}
+	return m
+}
+```
+
+Remove the old `modeToScore()` function.
+
+- [ ] **Step 3: Build and test**
+
+Run: `go build ./internal/capabilities/... && go test ./internal/capabilities/... -v -count=1`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/capabilities/detect_linux.go
+git commit -m "feat(detect): build Linux domains with weighted score and backward compat
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Output Formatting — Grouped table
+
+**Files:**
+- Modify: `internal/capabilities/detect_result.go` (Table method)
+- Modify: `internal/capabilities/detect_result_test.go`
+
+- [ ] **Step 1: Replace Table() method**
+
+```go
+func (r *DetectResult) Table() string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("Platform:         %s\n", r.Platform))
+	sb.WriteString(fmt.Sprintf("Security Mode:    %s\n", r.SecurityMode))
+	sb.WriteString(fmt.Sprintf("Protection Score: %d/100\n", r.ProtectionScore))
+	sb.WriteString("\n")
+
+	for _, d := range r.Domains {
+		sb.WriteString(fmt.Sprintf("%-40s %d/%d\n", strings.ToUpper(d.Name), d.Score, d.Weight))
+		for _, b := range d.Backends {
+			status := "-"
+			if b.Available {
+				status = "✓"
+			}
+			detail := b.Detail
+			if detail == "" {
+				detail = " "
+			}
+			sb.WriteString(fmt.Sprintf("  %-20s %s  %-16s %s\n", b.Name, status, detail, b.Description))
+		}
+		if d.Active != "" && d.Active != "none" {
+			sb.WriteString(fmt.Sprintf("  active backend:    %s\n", d.Active))
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(r.Tips) > 0 {
+		sb.WriteString("TIPS\n")
+		for _, tip := range r.Tips {
+			sb.WriteString(fmt.Sprintf("  %s: %s\n", tip.Feature, tip.Impact))
+			sb.WriteString(fmt.Sprintf("    -> %s\n", tip.Action))
+		}
+	}
+
+	sb.WriteString("\nRun 'agentsh detect config' to generate an optimized configuration.\n")
+	return sb.String()
+}
+```
+
+- [ ] **Step 2: Add format test**
+
+```go
+func TestTableFormat_Grouped(t *testing.T) {
+	result := &DetectResult{
+		Platform:        "linux",
+		SecurityMode:    "full",
+		ProtectionScore: 85,
+		Domains: []ProtectionDomain{
+			{Name: "File Protection", Weight: 25, Score: 25, Backends: []DetectedBackend{
+				{Name: "fuse", Available: true, Detail: "fusermount3", Description: "file interception"},
+			}, Active: "fuse"},
+		},
+	}
+	table := result.Table()
+	assert.Contains(t, table, "FILE PROTECTION")
+	assert.Contains(t, table, "25/25")
+	assert.Contains(t, table, "fuse")
+	assert.Contains(t, table, "✓")
+	assert.Contains(t, table, "active backend:")
+}
+```
+
+- [ ] **Step 3: Build and test**
+
+Run: `go test ./internal/capabilities/... -run TestTableFormat -v -count=1`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/capabilities/detect_result.go internal/capabilities/detect_result_test.go
+git commit -m "feat(detect): grouped domain table output
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Tips — Generate from domains
+
+**Files:**
+- Modify: `internal/capabilities/tips.go`
+
+- [ ] **Step 1: Add GenerateTipsFromDomains**
+
+```go
+// GenerateTipsFromDomains generates tips only for domains that score 0.
+func GenerateTipsFromDomains(domains []ProtectionDomain) []Tip {
+	var tips []Tip
+	for _, d := range domains {
+		if d.Score > 0 {
+			continue // domain already covered
+		}
+		for _, b := range d.Backends {
+			if b.Available {
+				continue
+			}
+			tip := lookupTip(b.Name)
+			if tip != nil {
+				tip.Impact = fmt.Sprintf("%s (+%d pts)", tip.Impact, d.Weight)
+				tips = append(tips, *tip)
+			}
+		}
+	}
+	return tips
+}
+```
+
+Add a `lookupTip(backendName string) *Tip` helper that maps backend names to tip definitions, combining the existing platform tip lists.
+
+- [ ] **Step 2: Build and test**
+
+Run: `go build ./internal/capabilities/... && go test ./internal/capabilities/... -v -count=1`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/capabilities/tips.go
+git commit -m "feat(detect): generate tips from domains with point impact
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Darwin + Windows — Domain builders
+
+**Files:**
+- Modify: `internal/capabilities/detect_darwin.go`
+- Modify: `internal/capabilities/detect_windows.go`
+
+- [ ] **Step 1: Darwin domain builder**
+
+Add `buildDarwinDomains(caps map[string]any)` that maps the existing Darwin checks into the five protection domains. Use `CheckMethod: "binary"` for file checks and `CheckMethod: "entitlement"` for ESF/NetworkExtension stubs.
+
+Update `Detect()` to build domains, compute weighted score, populate backward compat caps.
+
+- [ ] **Step 2: Windows domain builder**
+
+Same pattern for Windows: `buildWindowsDomains(caps map[string]any)`.
+
+- [ ] **Step 3: Build and test**
+
+Run: `go build ./... && GOOS=darwin go build ./internal/capabilities/... && GOOS=windows go build ./internal/capabilities/...`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/capabilities/detect_darwin.go internal/capabilities/detect_windows.go
+git commit -m "feat(detect): add domain builders for Darwin and Windows
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Full build + cross-compile + test
+
+- [ ] **Step 1: Full build**
+
+Run: `go build ./...`
+
+- [ ] **Step 2: Cross-compile**
+
+Run: `GOOS=windows go build ./... && GOOS=darwin go build ./internal/capabilities/...`
+
+- [ ] **Step 3: Full test suite**
+
+Run: `go test ./...`
+
+- [ ] **Step 4: Run detect manually**
+
+Run: `go run ./cmd/agentsh detect` and verify the new grouped output.
+
+- [ ] **Step 5: Commit any fixups**
+
+---
+
+## Implementation Notes
+
+These apply across all tasks — implementers should follow these:
+
+1. **`ProbeResult` type lives in `detect_result.go`** (not in individual probe files) since all probe files and `detect_linux.go` depend on it.
+
+2. **Avoid double-probing**: `DetectSecurityCapabilities()` runs probes and caches `ProbeResult` values on the `SecurityCapabilities` struct. `buildLinuxDomains` reads cached results — never re-runs probes.
+
+3. **Capget requires two structs**: `LINUX_CAPABILITY_VERSION_3` uses 64-bit capability masks split across two `CapUserData` structs. Use `var data [2]unix.CapUserData` and pass `&data[0]`.
+
+4. **`Active` field**: Set for all five domains, not just File Protection. Derive from: File→`FileEnforcement`, Command→`SelectMode()` result, Network→first available backend, Resource→`"cgroups-v2"` if available, Isolation→first available backend.
+
+5. **Existing tests need updates**: `TestDetectResult_Table` checks for the old flat "CAPABILITIES" header. `TestDetect_Linux` asserts `capabilities_drop: true` which may now fail. Update both in the task that changes their file.
+
+6. **`lookupTip` mapping**: Backend names use hyphens (`"cgroups-v2"`, `"pid-namespace"`) but existing tip CheckKeys use underscores (`"cgroups_v2"`). The `lookupTip` helper must map between them. Add tip definitions for new backends that have no existing tip (`"capability-drop"`, `"pid-namespace"`, `"seccomp-execve"`, `"seccomp-notify"`, `"landlock-network"`).
+
+7. **`GenerateTipsFromDomains` needs a test**: Add `TestGenerateTipsFromDomains` verifying: tips generated for 0-score domains only, no tips for domains with any available backend, point impact text included.
+
+8. **Darwin/Windows domain builders**: Must replace `GenerateTips("darwin", caps)` with `GenerateTipsFromDomains(domains)`. Provide concrete domain mappings (which existing check functions map to which backends in which domains). The implementer should read the existing `detect_darwin.go` and `detect_windows.go` functions and map them.
+
+9. **JSON backward compat test**: Add `TestJSONFormat_Domains` verifying both `domains` (new) and `capabilities` (old) fields are present in JSON output.
+

--- a/docs/superpowers/specs/2026-03-21-detect-redesign-design.md
+++ b/docs/superpowers/specs/2026-03-21-detect-redesign-design.md
@@ -1,0 +1,220 @@
+# Detect Output Redesign: Feature Inventory + Weighted Score
+
+**Date:** 2026-03-21
+**Status:** Draft
+**Scope:** All platforms (Linux, Darwin, Windows)
+
+## Background
+
+The current `agentsh detect` output has several weaknesses:
+
+1. **Stub detections**: eBPF (always true), cgroups v2 (always true), PID namespace (always false), capability drop (always true) — these report hardcoded values instead of probing the actual system.
+2. **Mode-based score**: The protection score is a fixed lookup from the mode name (full=100, ptrace=90, etc.) — it doesn't reflect which individual features are actually working.
+3. **Flat capability list**: Features are listed alphabetically with no grouping by what they protect. An operator can't quickly see "do I have file protection?" without knowing which capabilities map to which enforcement domains.
+
+This design replaces stub detections with real probes, groups features by protection domain, and computes a weighted score based on actual feature availability.
+
+## What Changes
+
+### 1. Protection Domains and Weight Model
+
+Five protection domains, each with a weight reflecting its security importance:
+
+| Domain | Weight | What it covers |
+|--------|--------|---------------|
+| File Protection | 25 | Read/write/create/delete enforcement on filesystem |
+| Command Control | 25 | Execution policy — allow/deny/redirect commands |
+| Network | 20 | Outbound/inbound traffic monitoring and filtering |
+| Resource Limits | 15 | CPU, memory, process count constraints |
+| Isolation | 15 | Process namespace isolation, capability dropping |
+
+Within each domain, multiple backends can provide coverage. The domain score is the full weight if **any** backend is available, 0 if none. Score = sum of available domain weights (0-100).
+
+### 2. Feature Inventory Per Domain (Linux)
+
+**File Protection** (25 pts)
+
+| Backend | Detection Method | Enables |
+|---------|-----------------|---------|
+| FUSE | Open `/dev/fuse` + fusermount/fsopen/mount probe | Full file interception, soft-delete, redirect |
+| Landlock | `landlock_create_ruleset` syscall probe (ABI 1-5) | Kernel-level path restrictions |
+| Seccomp-notify file_monitor | seccomp API >= 6 + config check | openat/stat/unlink interception via user-notify |
+
+**Command Control** (25 pts)
+
+| Backend | Detection Method | Enables |
+|---------|-----------------|---------|
+| Seccomp execve | seccomp API >= 6 | execve/execveat interception via user-notify |
+| Ptrace | `PTRACE_SEIZE` on forked child | Syscall-level exec interception + redirect |
+
+**Network** (20 pts)
+
+| Backend | Detection Method | Enables |
+|---------|-----------------|---------|
+| eBPF | `BPF_PROG_LOAD` syscall with `BPF_PROG_TYPE_CGROUP_SKB` | cgroup-level network monitoring |
+| Landlock network | Landlock ABI >= 4 (from existing probe) | Kernel-level TCP bind/connect filtering |
+
+**Resource Limits** (15 pts)
+
+| Backend | Detection Method | Enables |
+|---------|-----------------|---------|
+| cgroups v2 | Stat `/sys/fs/cgroup` for type `cgroup2fs` + read test | CPU, memory, process count limits |
+
+**Isolation** (15 pts)
+
+| Backend | Detection Method | Enables |
+|---------|-----------------|---------|
+| PID namespace | Read `/proc/self/status` NSpid field (multiple entries = namespaced) | Process isolation |
+| Capability drop | `capget()` succeeds | Privilege reduction |
+
+### 3. Real Detection Probes
+
+Replace four stubs with actual probes:
+
+**eBPF probe**: Call `unix.Syscall(SYS_BPF, BPF_PROG_LOAD, ...)` with a minimal program (type `BPF_PROG_TYPE_CGROUP_SKB`, single `BPF_EXIT` instruction). Valid fd → works (close immediately). `EPERM` → missing capability. `ENOSYS` → no BPF support. This is a functional test, not a file check.
+
+**cgroups v2 probe**: `unix.Statfs("/sys/fs/cgroup", &statfs)` and check `statfs.Type == CGROUP2_SUPER_MAGIC` (0x63677270). Then `os.OpenFile("/sys/fs/cgroup/cgroup.procs", O_RDONLY, 0)` to verify readability. Confirms the cgroup2 hierarchy is mounted and accessible.
+
+**PID namespace probe**: Read `/proc/self/status` and find the `NSpid:` line. Multiple tab-separated values (e.g., `NSpid: 1234 1`) → process is in a PID namespace. One value → host namespace. Reliable and doesn't require root.
+
+**Capability drop probe**: Call `unix.Capget()` — success means we can read capabilities (and therefore drop them). Makes the existing assumption explicit.
+
+All probes are fast, side-effect-free, and run at detection time.
+
+### 4. Output Format
+
+The table output changes from a flat list to grouped domains:
+
+```
+Platform:         linux
+Security Mode:    full
+Protection Score: 85/100
+
+FILE PROTECTION                                    25/25
+  fuse               ✓  fusermount3      file interception, soft-delete
+  landlock           ✓  ABI v5           kernel path restrictions
+  seccomp-notify     ✓  file_monitor     openat/stat enforcement
+  active backend:    fuse
+
+COMMAND CONTROL                                    25/25
+  seccomp-execve     ✓                   execve interception
+  ptrace             -  EPERM            syscall tracing
+  active backend:    seccomp-execve
+
+NETWORK                                            20/20
+  ebpf               ✓  cgroup_skb       network monitoring
+  landlock-network   ✓  ABI v4+          TCP bind/connect filtering
+
+RESOURCE LIMITS                                    0/15
+  cgroups-v2         -  not mounted      CPU/memory/process limits
+
+ISOLATION                                          15/15
+  pid-namespace      ✓  NSpid: 2 levels  process isolation
+  capability-drop    ✓                   privilege reduction
+
+TIPS
+  cgroups-v2: Enable cgroup v2 for resource limiting (+15 pts)
+    -> Mount cgroup2 or run with --cgroupns=host
+```
+
+Key changes from current output:
+- Grouped by domain with per-domain subtotal
+- Each feature shows: name, status (✓/-), detection detail, what it enables
+- Domain shows which backend is active (from config)
+- Tips show point impact
+- JSON/YAML output uses the same structure (nested by domain)
+
+### 5. Cross-Platform Parity
+
+Same domain model applied to Darwin and Windows with platform-specific backends:
+
+**Darwin:**
+
+| Domain | Backends | Detection |
+|--------|----------|-----------|
+| File Protection | FUSE-T | dylib path check + `dlopen` probe |
+| | ESF | `codesign --display --entitlements` check |
+| Command Control | ESF | Same entitlement check |
+| | sandbox-exec | Always available (macOS built-in) |
+| Network | Network Extension | Entitlement check |
+| Resource Limits | launchd limits | Always available |
+| Isolation | sandbox-exec | Always available |
+
+**Windows:**
+
+| Domain | Backends | Detection |
+|--------|----------|-----------|
+| File Protection | WinFsp | Registry query + `LoadLibrary` probe |
+| | Minifilter | `OpenSCManager` + query minifilter driver service |
+| Command Control | AppContainer | `CreateAppContainerProfile` API probe |
+| Network | WinDivert | `LoadLibrary` probe |
+| Resource Limits | Job Objects | Always available (Win8+) |
+| Isolation | AppContainer | Same as command control probe |
+
+Weight model (25/25/20/15/15) is identical across platforms. Score is always 0-100 computed the same way.
+
+For stubs that can't easily become real probes (e.g., ESF requires entitlements that detection code won't have), keep the stub but mark detection as `"check": "entitlement"` rather than `"check": "probe"` so the output is honest about detection fidelity.
+
+### 6. Testing
+
+**Probe tests** (behind platform build tags):
+1. `TestProbeEBPF` — verify BPF syscall runs without panic.
+2. `TestProbeCgroupsV2` — verify statfs check runs.
+3. `TestProbePIDNamespace` — parse NSpid from `/proc/self/status`.
+4. `TestProbeCapabilityDrop` — verify capget succeeds.
+
+**Score tests** (cross-platform, mock capabilities):
+5. `TestWeightedScore` — all-available (100), none (0), partial combinations.
+6. `TestDomainScoring` — each domain returns weight when any backend available.
+
+**Format tests** (cross-platform):
+7. `TestTableFormat_Grouped` — domain headers with subtotals.
+8. `TestJSONFormat_Domains` — nested JSON structure by domain.
+
+**Integration:**
+9. `TestDetectFullCycle` — call `Detect()`, verify all fields, score 0-100, no panics.
+
+## Data Model Changes
+
+The `DetectResult` struct adds domain-level structure:
+
+```go
+type DetectResult struct {
+    Platform        string
+    SecurityMode    string
+    ProtectionScore int              // now computed from domains
+    Domains         []ProtectionDomain
+    Capabilities    map[string]any   // kept for backward compat (JSON consumers)
+    Summary         DetectSummary
+    Tips            []Tip
+}
+
+type ProtectionDomain struct {
+    Name     string           // "File Protection", "Command Control", etc.
+    Weight   int              // 25, 25, 20, 15, 15
+    Score    int              // weight if any backend available, else 0
+    Backends []DetectedBackend
+    Active   string           // which backend is currently in use
+}
+
+type DetectedBackend struct {
+    Name        string // "fuse", "landlock", "ebpf", etc.
+    Available   bool
+    Detail      string // "fusermount3", "ABI v5", "EPERM", "not mounted"
+    Description string // "file interception, soft-delete"
+    CheckMethod string // "probe", "syscall", "binary", "entitlement"
+}
+```
+
+The flat `Capabilities` map is still populated for backward compatibility with JSON consumers. The `Domains` field is the new structured representation.
+
+## Dependencies
+
+- `golang.org/x/sys/unix` (existing) — for BPF, statfs, capget syscalls
+- No new dependencies
+
+## Out of Scope
+
+- Changing the `agentsh detect config` subcommand (it still generates config based on mode)
+- Changing how modes are selected at runtime (SelectMode stays the same)
+- Per-feature scoring within domains (domain is all-or-nothing based on any backend)

--- a/docs/superpowers/specs/2026-03-21-detect-redesign-design.md
+++ b/docs/superpowers/specs/2026-03-21-detect-redesign-design.md
@@ -36,22 +36,22 @@ Within each domain, multiple backends can provide coverage. The domain score is 
 
 | Backend | Detection Method | Enables |
 |---------|-----------------|---------|
-| FUSE | Open `/dev/fuse` + fusermount/fsopen/mount probe | Full file interception, soft-delete, redirect |
+| FUSE | Open `/dev/fuse` (O_RDWR, close immediately) + fusermount/fsopen/mount probe. Detail shows method: "fusermount3", "new-api", or "direct" | Full file interception, soft-delete, redirect |
 | Landlock | `landlock_create_ruleset` syscall probe (ABI 1-5) | Kernel-level path restrictions |
-| Seccomp-notify file_monitor | seccomp API >= 6 + config check | openat/stat/unlink interception via user-notify |
+| Seccomp-notify file_monitor | Seccomp user-notify available (libseccomp `GetAPI() >= 6`, which maps to `SECCOMP_FILTER_FLAG_NEW_LISTENER` support) | openat/stat/unlink interception via user-notify |
 
 **Command Control** (25 pts)
 
 | Backend | Detection Method | Enables |
 |---------|-----------------|---------|
-| Seccomp execve | seccomp API >= 6 | execve/execveat interception via user-notify |
-| Ptrace | `PTRACE_SEIZE` on forked child | Syscall-level exec interception + redirect |
+| Seccomp execve | Same seccomp user-notify check as above | execve/execveat interception via user-notify |
+| Ptrace | `PTRACE_SEIZE` on forked child (existing functional probe) | Syscall-level exec interception + redirect |
 
 **Network** (20 pts)
 
 | Backend | Detection Method | Enables |
 |---------|-----------------|---------|
-| eBPF | `BPF_PROG_LOAD` syscall with `BPF_PROG_TYPE_CGROUP_SKB` | cgroup-level network monitoring |
+| eBPF | `BPF_PROG_LOAD` syscall with `BPF_PROG_TYPE_CGROUP_SKB` (see section 3 for details) | cgroup-level network monitoring |
 | Landlock network | Landlock ABI >= 4 (from existing probe) | Kernel-level TCP bind/connect filtering |
 
 **Resource Limits** (15 pts)
@@ -64,20 +64,40 @@ Within each domain, multiple backends can provide coverage. The domain score is 
 
 | Backend | Detection Method | Enables |
 |---------|-----------------|---------|
-| PID namespace | Read `/proc/self/status` NSpid field (multiple entries = namespaced) | Process isolation |
-| Capability drop | `capget()` succeeds | Privilege reduction |
+| PID namespace | Read `/proc/self/status` NSpid field (see section 3) | Process isolation |
+| Capability drop | `capget()` + `prctl(PR_CAPBSET_READ, 0)` both succeed (see section 3) | Privilege reduction |
 
 ### 3. Real Detection Probes
 
 Replace four stubs with actual probes:
 
-**eBPF probe**: Call `unix.Syscall(SYS_BPF, BPF_PROG_LOAD, ...)` with a minimal program (type `BPF_PROG_TYPE_CGROUP_SKB`, single `BPF_EXIT` instruction). Valid fd → works (close immediately). `EPERM` → missing capability. `ENOSYS` → no BPF support. This is a functional test, not a file check.
+**eBPF probe**: Construct a minimal `bpf_attr` struct for `BPF_PROG_LOAD`:
+- `prog_type`: `BPF_PROG_TYPE_CGROUP_SKB` (13)
+- `insns`: pointer to a single `BPF_EXIT` instruction (2 bytes: `0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00`)
+- `insn_cnt`: 1
+- `license`: pointer to `"GPL\0"` (required by kernel for cgroup programs)
 
-**cgroups v2 probe**: `unix.Statfs("/sys/fs/cgroup", &statfs)` and check `statfs.Type == CGROUP2_SUPER_MAGIC` (0x63677270). Then `os.OpenFile("/sys/fs/cgroup/cgroup.procs", O_RDONLY, 0)` to verify readability. Confirms the cgroup2 hierarchy is mounted and accessible.
+Call `unix.Syscall(SYS_BPF, BPF_PROG_LOAD, uintptr(unsafe.Pointer(&attr)), size)`. Classify result:
+- Valid fd → available (close immediately). Detail: `"cgroup_skb"`
+- `EPERM` → unavailable. Detail: `"EPERM (missing CAP_BPF)"`
+- `ENOSYS` → unavailable. Detail: `"ENOSYS (kernel too old)"`
+- Other error → unavailable. Detail: the error string
 
-**PID namespace probe**: Read `/proc/self/status` and find the `NSpid:` line. Multiple tab-separated values (e.g., `NSpid: 1234 1`) → process is in a PID namespace. One value → host namespace. Reliable and doesn't require root.
+**cgroups v2 probe**: `unix.Statfs("/sys/fs/cgroup", &statfs)` and check `statfs.Type == CGROUP2_SUPER_MAGIC` (0x63677270). Then `os.OpenFile("/sys/fs/cgroup/cgroup.procs", O_RDONLY, 0)` to verify readability (close immediately). Classify:
+- Both succeed → available. Detail: `"cgroup2"`
+- Statfs fails or wrong type → unavailable. Detail: `"not mounted"` or `"cgroup v1"`
+- File not readable → unavailable. Detail: `"not readable"`
 
-**Capability drop probe**: Call `unix.Capget()` — success means we can read capabilities (and therefore drop them). Makes the existing assumption explicit.
+**PID namespace probe**: Read `/proc/self/status` and find the `NSpid:` line. Classify:
+- Multiple tab-separated values (e.g., `NSpid:\t1234\t1`) → available. Detail: `"NSpid: <N> levels"`
+- Single value → unavailable. Detail: `"host namespace"`
+- `NSpid` field absent (kernel < 4.1) → unavailable. Detail: `"NSpid not supported"`
+
+**Capability drop probe**: Two checks:
+1. `unix.Capget()` succeeds (can read capabilities)
+2. `unix.Prctl(unix.PR_CAPBSET_READ, 0, 0, 0, 0)` succeeds (can read bounding set, prerequisite for dropping)
+
+If both succeed → available. Detail: `"capget+prctl"`. Otherwise → unavailable with the failing syscall as detail. Note: this is a stronger check than the previous stub (`return true`) because `prctl(PR_CAPBSET_READ)` can fail in some container runtimes.
 
 All probes are fast, side-effect-free, and run at detection time.
 
@@ -120,8 +140,8 @@ TIPS
 Key changes from current output:
 - Grouped by domain with per-domain subtotal
 - Each feature shows: name, status (✓/-), detection detail, what it enables
-- Domain shows which backend is active (from config)
-- Tips show point impact
+- Domain shows which backend is active (derived from `SecurityCapabilities.FileEnforcement`, `SelectMode()`, and related existing fields — detection already computes this)
+- Tips show point impact — only generated for backends in domains that score 0 (domains already scoring full weight don't generate tips since additional backends provide redundancy, not extra points)
 - JSON/YAML output uses the same structure (nested by domain)
 
 ### 5. Cross-Platform Parity
@@ -153,19 +173,27 @@ Same domain model applied to Darwin and Windows with platform-specific backends:
 
 Weight model (25/25/20/15/15) is identical across platforms. Score is always 0-100 computed the same way.
 
-For stubs that can't easily become real probes (e.g., ESF requires entitlements that detection code won't have), keep the stub but mark detection as `"check": "entitlement"` rather than `"check": "probe"` so the output is honest about detection fidelity.
+For stubs that can't easily become real probes (e.g., ESF requires entitlements that detection code won't have), keep the stub but set `CheckMethod: "entitlement"` (not `"probe"`) so the output is honest about detection fidelity. On Darwin, `sandbox-exec` appears under both Command Control (execution sandboxing) and Isolation (process isolation) — these are distinct uses of the same underlying mechanism and both report as available.
+
+On Windows, the existing `os.Stat` check for WinFsp DLL should be upgraded to `syscall.LoadLibrary` to verify the DLL actually loads (not just exists). This is deferred to platform-specific implementation — the spec defines the intent, not the exact Windows API calls.
 
 ### 6. Testing
 
 **Probe tests** (behind platform build tags):
-1. `TestProbeEBPF` — verify BPF syscall runs without panic.
-2. `TestProbeCgroupsV2` — verify statfs check runs.
-3. `TestProbePIDNamespace` — parse NSpid from `/proc/self/status`.
-4. `TestProbeCapabilityDrop` — verify capget succeeds.
+1. `TestProbeEBPF` — verify BPF syscall runs. Classify EPERM vs ENOSYS vs success.
+2. `TestProbeCgroupsV2` — verify statfs check. Test CGROUP2_SUPER_MAGIC match and mismatch.
+3. `TestProbePIDNamespace` — parse NSpid. Test single-value (host), multi-value (namespaced), and absent field (old kernel).
+4. `TestProbeCapabilityDrop` — verify capget + prctl both succeed.
 
 **Score tests** (cross-platform, mock capabilities):
-5. `TestWeightedScore` — all-available (100), none (0), partial combinations.
-6. `TestDomainScoring` — each domain returns weight when any backend available.
+5. `TestWeightedScore_AllAvailable` — all domains score full → 100.
+6. `TestWeightedScore_NoneAvailable` — all domains empty → 0.
+7. `TestWeightedScore_PartialCombinations`:
+   - File + Command only → 50
+   - Network + Resource + Isolation only → 50
+   - Single backend in multi-backend domain (e.g., only Landlock in File) → domain still scores 25
+   - All backends unavailable in one domain, rest available → 100 minus that domain's weight
+8. `TestDomainScoring` — each domain returns weight when any single backend available, 0 when none.
 
 **Format tests** (cross-platform):
 7. `TestTableFormat_Grouped` — domain headers with subtotals.
@@ -194,7 +222,12 @@ type ProtectionDomain struct {
     Weight   int              // 25, 25, 20, 15, 15
     Score    int              // weight if any backend available, else 0
     Backends []DetectedBackend
-    Active   string           // which backend is currently in use
+    Active   string           // which backend is in use, derived from:
+                              // File: SecurityCapabilities.FileEnforcement
+                              // Command: SelectMode() result (seccomp vs ptrace)
+                              // Network: "ebpf" if available, else "landlock-network"
+                              // Resource: "cgroups-v2" if available
+                              // Isolation: first available backend
 }
 
 type DetectedBackend struct {
@@ -206,7 +239,25 @@ type DetectedBackend struct {
 }
 ```
 
-The flat `Capabilities` map is still populated for backward compatibility with JSON consumers. The `Domains` field is the new structured representation.
+The flat `Capabilities` map is still populated for backward compatibility with JSON consumers. Mapping from new to old keys:
+
+| Old key | Populated from |
+|---------|---------------|
+| `seccomp`, `seccomp_user_notify` | seccomp-execve backend available |
+| `seccomp_basic` | same as `seccomp` |
+| `landlock` | landlock backend available |
+| `landlock_abi` | landlock backend detail (ABI version number) |
+| `landlock_network` | landlock-network backend available |
+| `fuse` | fuse backend available |
+| `fuse_mount_method` | fuse backend detail |
+| `ebpf` | ebpf backend available |
+| `cgroups_v2` | cgroups-v2 backend available |
+| `ptrace` | ptrace backend available |
+| `pid_namespace` | pid-namespace backend available |
+| `capabilities_drop` | capability-drop backend available |
+| `file_enforcement` | File Protection domain active backend |
+
+The `Domains` field is the new structured representation.
 
 ## Dependencies
 

--- a/docs/superpowers/specs/2026-03-21-detect-redesign-design.md
+++ b/docs/superpowers/specs/2026-03-21-detect-redesign-design.md
@@ -1,7 +1,7 @@
 # Detect Output Redesign: Feature Inventory + Weighted Score
 
 **Date:** 2026-03-21
-**Status:** Draft
+**Status:** Implemented
 **Scope:** All platforms (Linux, Darwin, Windows)
 
 ## Background

--- a/internal/capabilities/check.go
+++ b/internal/capabilities/check.go
@@ -52,17 +52,13 @@ func realCheckPtrace() CheckResult {
 }
 
 func realCheckCgroupsV2() CheckResult {
-	return CheckResult{
-		Feature:   "cgroups-v2",
-		Available: true,
-	}
+	probe := probeCgroupsV2()
+	return CheckResult{Feature: "cgroups-v2", Available: probe.Available}
 }
 
 func realCheckeBPF() CheckResult {
-	return CheckResult{
-		Feature:   "ebpf",
-		Available: true,
-	}
+	probe := probeEBPF()
+	return CheckResult{Feature: "ebpf", Available: probe.Available}
 }
 
 func realCheckWrapperBinary(binaryPath string) CheckResult {

--- a/internal/capabilities/check_caps_linux.go
+++ b/internal/capabilities/check_caps_linux.go
@@ -1,0 +1,18 @@
+//go:build linux
+
+package capabilities
+
+import "golang.org/x/sys/unix"
+
+func probeCapabilityDrop() ProbeResult {
+	hdr := unix.CapUserHeader{Version: unix.LINUX_CAPABILITY_VERSION_3}
+	var data [2]unix.CapUserData
+	if err := unix.Capget(&hdr, &data[0]); err != nil {
+		return ProbeResult{Available: false, Detail: "capget failed: " + err.Error()}
+	}
+	_, _, errno := unix.Syscall6(unix.SYS_PRCTL, unix.PR_CAPBSET_READ, 0, 0, 0, 0, 0)
+	if errno != 0 {
+		return ProbeResult{Available: false, Detail: "prctl failed: " + errno.Error()}
+	}
+	return ProbeResult{Available: true, Detail: "capget+prctl"}
+}

--- a/internal/capabilities/check_cgroups_linux.go
+++ b/internal/capabilities/check_cgroups_linux.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package capabilities
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+const cgroup2SuperMagic = 0x63677270
+
+func probeCgroupsV2() ProbeResult {
+	var statfs unix.Statfs_t
+	if err := unix.Statfs("/sys/fs/cgroup", &statfs); err != nil {
+		return ProbeResult{Available: false, Detail: "not mounted"}
+	}
+	if statfs.Type != cgroup2SuperMagic {
+		return ProbeResult{Available: false, Detail: "cgroup v1"}
+	}
+	f, err := os.OpenFile("/sys/fs/cgroup/cgroup.procs", os.O_RDONLY, 0)
+	if err != nil {
+		return ProbeResult{Available: false, Detail: "not readable"}
+	}
+	f.Close()
+	return ProbeResult{Available: true, Detail: "cgroup2"}
+}

--- a/internal/capabilities/check_ebpf_linux.go
+++ b/internal/capabilities/check_ebpf_linux.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+package capabilities
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func probeEBPF() ProbeResult {
+	insn := [8]byte{0x95, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00} // BPF_EXIT
+	license := [4]byte{'G', 'P', 'L', 0}
+	type bpfProgLoadAttr struct {
+		progType    uint32
+		insnCnt     uint32
+		insns       uint64
+		license     uint64
+		logLevel    uint32
+		logSize     uint32
+		logBuf      uint64
+		kernVersion uint32
+	}
+	attr := bpfProgLoadAttr{
+		progType: 13, // BPF_PROG_TYPE_CGROUP_SKB
+		insnCnt:  1,
+		insns:    uint64(uintptr(unsafe.Pointer(&insn[0]))),
+		license:  uint64(uintptr(unsafe.Pointer(&license[0]))),
+	}
+	fd, _, errno := unix.Syscall(unix.SYS_BPF, 5, uintptr(unsafe.Pointer(&attr)), unsafe.Sizeof(attr))
+	if errno == 0 {
+		unix.Close(int(fd))
+		return ProbeResult{Available: true, Detail: "cgroup_skb"}
+	}
+	switch errno {
+	case unix.EPERM:
+		return ProbeResult{Available: false, Detail: "EPERM (missing CAP_BPF)"}
+	case unix.ENOSYS:
+		return ProbeResult{Available: false, Detail: "ENOSYS (kernel too old)"}
+	default:
+		return ProbeResult{Available: false, Detail: errno.Error()}
+	}
+}

--- a/internal/capabilities/check_pidns_linux.go
+++ b/internal/capabilities/check_pidns_linux.go
@@ -1,0 +1,27 @@
+//go:build linux
+
+package capabilities
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func probePIDNamespace() ProbeResult {
+	data, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return ProbeResult{Available: false, Detail: "cannot read /proc/self/status"}
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "NSpid:") {
+			fields := strings.Fields(line)
+			levels := len(fields) - 1
+			if levels > 1 {
+				return ProbeResult{Available: true, Detail: fmt.Sprintf("NSpid: %d levels", levels)}
+			}
+			return ProbeResult{Available: false, Detail: "host namespace"}
+		}
+	}
+	return ProbeResult{Available: false, Detail: "NSpid not supported"}
+}

--- a/internal/capabilities/check_test.go
+++ b/internal/capabilities/check_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/config"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCheckAll_NoConfig(t *testing.T) {
@@ -759,4 +760,24 @@ func TestCheckAll_WrapperBinary_CustomPath(t *testing.T) {
 	if checkedPath != "/custom/path/to/wrapper" {
 		t.Errorf("expected custom path to be checked, got: %q", checkedPath)
 	}
+}
+
+func TestProbeEBPF(t *testing.T) {
+	result := probeEBPF()
+	assert.NotEmpty(t, result.Detail)
+}
+
+func TestProbeCgroupsV2(t *testing.T) {
+	result := probeCgroupsV2()
+	assert.NotEmpty(t, result.Detail)
+}
+
+func TestProbePIDNamespace(t *testing.T) {
+	result := probePIDNamespace()
+	assert.NotEmpty(t, result.Detail)
+}
+
+func TestProbeCapabilityDrop(t *testing.T) {
+	result := probeCapabilityDrop()
+	assert.NotEmpty(t, result.Detail)
 }

--- a/internal/capabilities/detect_darwin.go
+++ b/internal/capabilities/detect_darwin.go
@@ -7,42 +7,90 @@ import (
 	"os/exec"
 )
 
+func buildDarwinDomains(caps map[string]any) []ProtectionDomain {
+	fuseT, _ := caps["fuse_t"].(bool)
+	esf, _ := caps["esf"].(bool)
+	networkExt, _ := caps["network_extension"].(bool)
+
+	fuseDetail := "not installed"
+	if fuseT {
+		fuseDetail = "FUSE-T"
+	}
+
+	return []ProtectionDomain{
+		{
+			Name: "File Protection", Weight: WeightFileProtection,
+			Backends: []DetectedBackend{
+				{Name: "fuse-t", Available: fuseT, Detail: fuseDetail, Description: "filesystem interception", CheckMethod: "binary"},
+				{Name: "esf", Available: esf, Detail: "", Description: "Endpoint Security Framework", CheckMethod: "entitlement"},
+			},
+		},
+		{
+			Name: "Command Control", Weight: WeightCommandControl,
+			Backends: []DetectedBackend{
+				{Name: "esf", Available: esf, Detail: "", Description: "process execution control", CheckMethod: "entitlement"},
+				{Name: "sandbox-exec", Available: true, Detail: "", Description: "macOS sandbox", CheckMethod: "builtin"},
+			},
+			Active: "sandbox-exec",
+		},
+		{
+			Name: "Network", Weight: WeightNetwork,
+			Backends: []DetectedBackend{
+				{Name: "network-extension", Available: networkExt, Detail: "", Description: "network filtering", CheckMethod: "entitlement"},
+			},
+		},
+		{
+			Name: "Resource Limits", Weight: WeightResourceLimits,
+			Backends: []DetectedBackend{
+				{Name: "launchd-limits", Available: true, Detail: "", Description: "launchd resource limits", CheckMethod: "builtin"},
+			},
+			Active: "launchd-limits",
+		},
+		{
+			Name: "Isolation", Weight: WeightIsolation,
+			Backends: []DetectedBackend{
+				{Name: "sandbox-exec", Available: true, Detail: "", Description: "process isolation", CheckMethod: "builtin"},
+			},
+			Active: "sandbox-exec",
+		},
+	}
+}
+
 // Detect runs platform-specific detection and returns unified result.
 func Detect() (*DetectResult, error) {
 	caps := map[string]any{
-		"sandbox_exec":      true, // Always available on macOS
+		"sandbox_exec":      true,
 		"fuse_t":            checkFuseT(),
 		"esf":               checkESF(),
 		"network_extension": checkNetworkExtension(),
 		"lima_available":    checkLima(),
 	}
 
-	mode, score := selectDarwinMode(caps)
+	mode, _ := selectDarwinMode(caps)
+	domains := buildDarwinDomains(caps)
+	score := ComputeScore(domains)
 
-	// Build summary
 	var available, unavailable []string
-	for k, v := range caps {
-		if val, ok := v.(bool); ok {
-			if val {
-				available = append(available, k)
+	for _, d := range domains {
+		for _, b := range d.Backends {
+			if b.Available {
+				available = append(available, b.Name)
 			} else {
-				unavailable = append(unavailable, k)
+				unavailable = append(unavailable, b.Name)
 			}
 		}
 	}
 
-	tips := GenerateTips("darwin", caps)
+	tips := GenerateTipsFromDomains(domains)
 
 	return &DetectResult{
 		Platform:        "darwin",
 		SecurityMode:    mode,
 		ProtectionScore: score,
+		Domains:         domains,
 		Capabilities:    caps,
-		Summary: DetectSummary{
-			Available:   available,
-			Unavailable: unavailable,
-		},
-		Tips: tips,
+		Summary:         DetectSummary{Available: available, Unavailable: unavailable},
+		Tips:            tips,
 	}, nil
 }
 

--- a/internal/capabilities/detect_linux.go
+++ b/internal/capabilities/detect_linux.go
@@ -165,7 +165,7 @@ func Detect() (*DetectResult, error) {
 		}
 	}
 
-	tips := GenerateTips("linux", caps)
+	tips := GenerateTipsFromDomains(domains)
 
 	return &DetectResult{
 		Platform:        "linux",

--- a/internal/capabilities/detect_linux.go
+++ b/internal/capabilities/detect_linux.go
@@ -2,6 +2,8 @@
 
 package capabilities
 
+import "fmt"
+
 // detectFileEnforcementBackend returns the best available file enforcement backend.
 func detectFileEnforcementBackend(caps *SecurityCapabilities) string {
 	if caps.Landlock {
@@ -16,31 +18,10 @@ func detectFileEnforcementBackend(caps *SecurityCapabilities) string {
 	return "none"
 }
 
-// Detect runs platform-specific detection and returns unified result.
-func Detect() (*DetectResult, error) {
-	// Use existing detection
-	secCaps := DetectSecurityCapabilities()
-	secCaps.FileEnforcement = detectFileEnforcementBackend(secCaps)
-
-	caps := map[string]any{
-		"seccomp":             secCaps.Seccomp,
-		"seccomp_user_notify": secCaps.Seccomp,
-		"seccomp_basic":       secCaps.SeccompBasic,
-		"landlock":            secCaps.Landlock,
-		"landlock_abi":        secCaps.LandlockABI,
-		"landlock_network":    secCaps.LandlockNetwork,
-		"ebpf":                secCaps.EBPF,
-		"fuse":                secCaps.FUSE,
-		"cgroups_v2":          checkCgroupsV2().Available,
-		"pid_namespace":       secCaps.PIDNamespace,
-		"capabilities_drop":   secCaps.Capabilities,
-		"ptrace":              secCaps.Ptrace,
-		"file_enforcement":    secCaps.FileEnforcement,
-	}
-
-	// Determine FUSE mount method for observability
+// buildLinuxDomains builds the five protection domains from cached probe results and capability flags.
+func buildLinuxDomains(caps *SecurityCapabilities) []ProtectionDomain {
 	fuseMountMethod := "none"
-	if secCaps.FUSE {
+	if caps.FUSE {
 		if hasFusermount() {
 			fuseMountMethod = "fusermount"
 		} else if checkNewMountAPIAvailable() {
@@ -49,29 +30,137 @@ func Detect() (*DetectResult, error) {
 			fuseMountMethod = "direct"
 		}
 	}
-	caps["fuse_mount_method"] = fuseMountMethod
 
-	mode := secCaps.SelectMode()
-	score := modeToScore(mode)
+	landlockDetail := "not available"
+	if caps.Landlock {
+		landlockDetail = fmt.Sprintf("ABI v%d", caps.LandlockABI)
+	}
 
-	// Build summary
-	var available, unavailable []string
-	for k, v := range caps {
-		if k == "landlock_abi" {
-			continue // Skip ABI version in summary
-		}
-		switch val := v.(type) {
-		case bool:
-			if val {
-				available = append(available, k)
-			} else {
-				unavailable = append(unavailable, k)
+	mode := caps.SelectMode()
+	commandActive := "seccomp-execve"
+	if mode == ModePtrace {
+		commandActive = "ptrace"
+	}
+
+	networkActive := ""
+	if caps.EBPFProbe.Available {
+		networkActive = "ebpf"
+	} else if caps.LandlockNetwork {
+		networkActive = "landlock-network"
+	}
+
+	resourceActive := ""
+	if caps.CgroupProbe.Available {
+		resourceActive = "cgroups-v2"
+	}
+
+	isoActive := ""
+	if caps.CapProbe.Available {
+		isoActive = "capability-drop"
+	}
+	if caps.PIDNSProbe.Available {
+		isoActive = "pid-namespace"
+	}
+
+	return []ProtectionDomain{
+		{
+			Name: "File Protection", Weight: WeightFileProtection,
+			Backends: []DetectedBackend{
+				{Name: "fuse", Available: caps.FUSE, Detail: fuseMountMethod, Description: "file interception, soft-delete, redirect", CheckMethod: "probe"},
+				{Name: "landlock", Available: caps.Landlock, Detail: landlockDetail, Description: "kernel path restrictions", CheckMethod: "syscall"},
+				{Name: "seccomp-notify", Available: caps.Seccomp, Detail: "", Description: "openat/stat enforcement", CheckMethod: "probe"},
+			},
+			Active: caps.FileEnforcement,
+		},
+		{
+			Name: "Command Control", Weight: WeightCommandControl,
+			Backends: []DetectedBackend{
+				{Name: "seccomp-execve", Available: caps.Seccomp, Detail: "", Description: "execve interception", CheckMethod: "probe"},
+				{Name: "ptrace", Available: caps.Ptrace, Detail: "", Description: "syscall tracing", CheckMethod: "probe"},
+			},
+			Active: commandActive,
+		},
+		{
+			Name: "Network", Weight: WeightNetwork,
+			Backends: []DetectedBackend{
+				{Name: "ebpf", Available: caps.EBPFProbe.Available, Detail: caps.EBPFProbe.Detail, Description: "network monitoring", CheckMethod: "probe"},
+				{Name: "landlock-network", Available: caps.LandlockNetwork, Detail: "", Description: "TCP bind/connect filtering", CheckMethod: "syscall"},
+			},
+			Active: networkActive,
+		},
+		{
+			Name: "Resource Limits", Weight: WeightResourceLimits,
+			Backends: []DetectedBackend{
+				{Name: "cgroups-v2", Available: caps.CgroupProbe.Available, Detail: caps.CgroupProbe.Detail, Description: "CPU/memory/process limits", CheckMethod: "probe"},
+			},
+			Active: resourceActive,
+		},
+		{
+			Name: "Isolation", Weight: WeightIsolation,
+			Backends: []DetectedBackend{
+				{Name: "pid-namespace", Available: caps.PIDNSProbe.Available, Detail: caps.PIDNSProbe.Detail, Description: "process isolation", CheckMethod: "probe"},
+				{Name: "capability-drop", Available: caps.CapProbe.Available, Detail: caps.CapProbe.Detail, Description: "privilege reduction", CheckMethod: "probe"},
+			},
+			Active: isoActive,
+		},
+	}
+}
+
+// backwardCompatCaps builds the flat capabilities map for backward compatibility.
+func backwardCompatCaps(caps *SecurityCapabilities, domains []ProtectionDomain) map[string]any {
+	m := map[string]any{
+		"seccomp":             caps.Seccomp,
+		"seccomp_user_notify": caps.Seccomp,
+		"seccomp_basic":       caps.SeccompBasic,
+		"landlock":            caps.Landlock,
+		"landlock_abi":        caps.LandlockABI,
+		"landlock_network":    caps.LandlockNetwork,
+		"fuse":                caps.FUSE,
+		"ptrace":              caps.Ptrace,
+		"file_enforcement":    caps.FileEnforcement,
+	}
+	for _, d := range domains {
+		for _, b := range d.Backends {
+			switch b.Name {
+			case "ebpf":
+				m["ebpf"] = b.Available
+			case "cgroups-v2":
+				m["cgroups_v2"] = b.Available
+			case "pid-namespace":
+				m["pid_namespace"] = b.Available
+			case "capability-drop":
+				m["capabilities_drop"] = b.Available
+			case "fuse":
+				if b.Available {
+					m["fuse_mount_method"] = b.Detail
+				}
 			}
-		case int:
-			if val > 0 {
-				available = append(available, k)
+		}
+	}
+	if _, ok := m["fuse_mount_method"]; !ok {
+		m["fuse_mount_method"] = "none"
+	}
+	return m
+}
+
+// Detect runs platform-specific detection and returns unified result.
+func Detect() (*DetectResult, error) {
+	secCaps := DetectSecurityCapabilities()
+	secCaps.FileEnforcement = detectFileEnforcementBackend(secCaps)
+
+	domains := buildLinuxDomains(secCaps)
+	score := ComputeScore(domains)
+	mode := secCaps.SelectMode()
+
+	caps := backwardCompatCaps(secCaps, domains)
+
+	var available, unavailable []string
+	for _, d := range domains {
+		for _, b := range d.Backends {
+			if b.Available {
+				available = append(available, b.Name)
 			} else {
-				unavailable = append(unavailable, k)
+				unavailable = append(unavailable, b.Name)
 			}
 		}
 	}
@@ -82,28 +171,9 @@ func Detect() (*DetectResult, error) {
 		Platform:        "linux",
 		SecurityMode:    mode,
 		ProtectionScore: score,
+		Domains:         domains,
 		Capabilities:    caps,
-		Summary: DetectSummary{
-			Available:   available,
-			Unavailable: unavailable,
-		},
-		Tips: tips,
+		Summary:         DetectSummary{Available: available, Unavailable: unavailable},
+		Tips:            tips,
 	}, nil
-}
-
-func modeToScore(mode string) int {
-	switch mode {
-	case ModeFull:
-		return 100
-	case ModePtrace:
-		return 90
-	case ModeLandlock:
-		return 85
-	case ModeLandlockOnly:
-		return 80
-	case ModeMinimal:
-		return 50
-	default:
-		return 0
-	}
 }

--- a/internal/capabilities/detect_linux_test.go
+++ b/internal/capabilities/detect_linux_test.go
@@ -18,7 +18,7 @@ func TestDetect_Linux(t *testing.T) {
 
 	// SecurityMode should be one of the valid modes
 	validModes := map[string]bool{
-		"full": true, "landlock": true, "landlock-only": true, "minimal": true,
+		"full": true, "ptrace": true, "landlock": true, "landlock-only": true, "minimal": true,
 	}
 	if !validModes[result.SecurityMode] {
 		t.Errorf("SecurityMode = %q, not a valid mode", result.SecurityMode)

--- a/internal/capabilities/detect_result.go
+++ b/internal/capabilities/detect_result.go
@@ -105,33 +105,50 @@ func (r *DetectResult) YAML() ([]byte, error) {
 func (r *DetectResult) Table() string {
 	var sb strings.Builder
 
-	// Header
-	sb.WriteString(fmt.Sprintf("Platform: %s\n", r.Platform))
-	sb.WriteString(fmt.Sprintf("Security Mode: %s\n", r.SecurityMode))
-	sb.WriteString(fmt.Sprintf("Protection Score: %d%%\n", r.ProtectionScore))
+	sb.WriteString(fmt.Sprintf("Platform:         %s\n", r.Platform))
+	sb.WriteString(fmt.Sprintf("Security Mode:    %s\n", r.SecurityMode))
+	sb.WriteString(fmt.Sprintf("Protection Score: %d/100\n", r.ProtectionScore))
 	sb.WriteString("\n")
 
-	// Capabilities table
-	sb.WriteString("CAPABILITIES\n")
-	sb.WriteString(strings.Repeat("-", 40) + "\n")
-
-	// Sort capability keys for consistent output
-	keys := make([]string, 0, len(r.Capabilities))
-	for k := range r.Capabilities {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	for _, k := range keys {
-		v := r.Capabilities[k]
-		status := formatCapabilityValue(v)
-		sb.WriteString(fmt.Sprintf("  %-24s %s\n", k, status))
-	}
-
-	// Tips section
-	if len(r.Tips) > 0 {
-		sb.WriteString("\nTIPS\n")
+	// Render domains if available (new format)
+	if len(r.Domains) > 0 {
+		for _, d := range r.Domains {
+			sb.WriteString(fmt.Sprintf("%-40s %d/%d\n", strings.ToUpper(d.Name), d.Score, d.Weight))
+			for _, b := range d.Backends {
+				status := "-"
+				if b.Available {
+					status = "✓"
+				}
+				detail := b.Detail
+				if detail == "" {
+					detail = " "
+				}
+				sb.WriteString(fmt.Sprintf("  %-20s %s  %-16s %s\n", b.Name, status, detail, b.Description))
+			}
+			if d.Active != "" && d.Active != "none" {
+				sb.WriteString(fmt.Sprintf("  active backend:    %s\n", d.Active))
+			}
+			sb.WriteString("\n")
+		}
+	} else {
+		// Fallback: flat capabilities (backward compat for platforms not yet converted)
+		sb.WriteString("CAPABILITIES\n")
 		sb.WriteString(strings.Repeat("-", 40) + "\n")
+		keys := make([]string, 0, len(r.Capabilities))
+		for k := range r.Capabilities {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			v := r.Capabilities[k]
+			status := formatCapabilityValue(v)
+			sb.WriteString(fmt.Sprintf("  %-24s %s\n", k, status))
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(r.Tips) > 0 {
+		sb.WriteString("TIPS\n")
 		for _, tip := range r.Tips {
 			sb.WriteString(fmt.Sprintf("  %s: %s\n", tip.Feature, tip.Impact))
 			sb.WriteString(fmt.Sprintf("    -> %s\n", tip.Action))
@@ -139,7 +156,6 @@ func (r *DetectResult) Table() string {
 	}
 
 	sb.WriteString("\nRun 'agentsh detect config' to generate an optimized configuration.\n")
-
 	return sb.String()
 }
 

--- a/internal/capabilities/detect_result.go
+++ b/internal/capabilities/detect_result.go
@@ -13,12 +13,13 @@ import (
 
 // DetectResult is the unified cross-platform detection result.
 type DetectResult struct {
-	Platform        string         `json:"platform" yaml:"platform"`
-	SecurityMode    string         `json:"security_mode" yaml:"security_mode"`
-	ProtectionScore int            `json:"protection_score" yaml:"protection_score"`
-	Capabilities    map[string]any `json:"capabilities" yaml:"capabilities"`
-	Summary         DetectSummary  `json:"summary" yaml:"summary"`
-	Tips            []Tip          `json:"tips" yaml:"tips"`
+	Platform        string             `json:"platform" yaml:"platform"`
+	SecurityMode    string             `json:"security_mode" yaml:"security_mode"`
+	ProtectionScore int                `json:"protection_score" yaml:"protection_score"`
+	Domains         []ProtectionDomain `json:"domains" yaml:"domains"`
+	Capabilities    map[string]any     `json:"capabilities" yaml:"capabilities"`
+	Summary         DetectSummary      `json:"summary" yaml:"summary"`
+	Tips            []Tip              `json:"tips" yaml:"tips"`
 }
 
 // DetectSummary provides a quick overview of available/unavailable features.
@@ -33,6 +34,61 @@ type Tip struct {
 	Status  string `json:"status" yaml:"status"`
 	Impact  string `json:"impact" yaml:"impact"`
 	Action  string `json:"action" yaml:"action"`
+}
+
+// ProbeResult holds the result of a capability probe.
+type ProbeResult struct {
+	Available bool   `json:"available" yaml:"available"`
+	Detail    string `json:"detail" yaml:"detail"`
+}
+
+// ProtectionDomain groups related security backends by what they protect.
+type ProtectionDomain struct {
+	Name     string            `json:"name" yaml:"name"`
+	Weight   int               `json:"weight" yaml:"weight"`
+	Score    int               `json:"score" yaml:"score"`
+	Backends []DetectedBackend `json:"backends" yaml:"backends"`
+	Active   string            `json:"active" yaml:"active"`
+}
+
+// DetectedBackend represents a single security mechanism within a domain.
+type DetectedBackend struct {
+	Name        string `json:"name" yaml:"name"`
+	Available   bool   `json:"available" yaml:"available"`
+	Detail      string `json:"detail" yaml:"detail"`
+	Description string `json:"description" yaml:"description"`
+	CheckMethod string `json:"check_method" yaml:"check_method"`
+}
+
+// Domain weight constants.
+const (
+	WeightFileProtection = 25
+	WeightCommandControl = 25
+	WeightNetwork        = 20
+	WeightResourceLimits = 15
+	WeightIsolation      = 15
+)
+
+// ComputeScore calculates the protection score from domain availability.
+// Each domain scores its full weight if ANY backend is available, 0 otherwise.
+func ComputeScore(domains []ProtectionDomain) int {
+	score := 0
+	for i := range domains {
+		hasAny := false
+		for _, b := range domains[i].Backends {
+			if b.Available {
+				hasAny = true
+				break
+			}
+		}
+		if hasAny {
+			domains[i].Score = domains[i].Weight
+		} else {
+			domains[i].Score = 0
+		}
+		score += domains[i].Score
+	}
+	return score
 }
 
 // JSON returns the detection result as JSON bytes.

--- a/internal/capabilities/detect_result_test.go
+++ b/internal/capabilities/detect_result_test.go
@@ -176,6 +176,48 @@ func TestComputeScore_SetsScoreOnDomains(t *testing.T) {
 	assert.Equal(t, 0, domains[1].Score)
 }
 
+func TestTableFormat_Grouped(t *testing.T) {
+	result := &DetectResult{
+		Platform:        "linux",
+		SecurityMode:    "full",
+		ProtectionScore: 85,
+		Domains: []ProtectionDomain{
+			{Name: "File Protection", Weight: 25, Score: 25, Backends: []DetectedBackend{
+				{Name: "fuse", Available: true, Detail: "fusermount3", Description: "file interception"},
+				{Name: "landlock", Available: false, Detail: "not available", Description: "kernel path restrictions"},
+			}, Active: "fuse"},
+			{Name: "Network", Weight: 20, Score: 0, Backends: []DetectedBackend{
+				{Name: "ebpf", Available: false, Detail: "EPERM", Description: "network monitoring"},
+			}},
+		},
+		Capabilities: map[string]any{"fuse": true},
+	}
+	table := result.Table()
+	assert.Contains(t, table, "FILE PROTECTION")
+	assert.Contains(t, table, "25/25")
+	assert.Contains(t, table, "fuse")
+	assert.Contains(t, table, "✓")
+	assert.Contains(t, table, "fusermount3")
+	assert.Contains(t, table, "active backend:")
+	assert.Contains(t, table, "NETWORK")
+	assert.Contains(t, table, "0/20")
+	assert.Contains(t, table, "EPERM")
+	assert.Contains(t, table, "85/100")
+}
+
+func TestTableFormat_FallbackFlat(t *testing.T) {
+	// No domains → falls back to flat capabilities
+	result := &DetectResult{
+		Platform:        "darwin",
+		SecurityMode:    "sandbox-exec",
+		ProtectionScore: 60,
+		Capabilities:    map[string]any{"sandbox_exec": true, "fuse_t": false},
+	}
+	table := result.Table()
+	assert.Contains(t, table, "CAPABILITIES")
+	assert.Contains(t, table, "sandbox_exec")
+}
+
 func TestDetectResult_JSONContainsDomains(t *testing.T) {
 	result := &DetectResult{
 		Platform:        "linux",

--- a/internal/capabilities/detect_result_test.go
+++ b/internal/capabilities/detect_result_test.go
@@ -3,8 +3,11 @@
 package capabilities
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDetectResult_JSON(t *testing.T) {
@@ -98,4 +101,97 @@ func TestDetectResult_Table(t *testing.T) {
 	if !strings.Contains(table, "fuse") {
 		t.Error("Table() missing tip about fuse")
 	}
+}
+
+func TestComputeScore_AllAvailable(t *testing.T) {
+	domains := []ProtectionDomain{
+		{Name: "File Protection", Weight: 25, Backends: []DetectedBackend{{Available: true}}},
+		{Name: "Command Control", Weight: 25, Backends: []DetectedBackend{{Available: true}}},
+		{Name: "Network", Weight: 20, Backends: []DetectedBackend{{Available: true}}},
+		{Name: "Resource Limits", Weight: 15, Backends: []DetectedBackend{{Available: true}}},
+		{Name: "Isolation", Weight: 15, Backends: []DetectedBackend{{Available: true}}},
+	}
+	assert.Equal(t, 100, ComputeScore(domains))
+}
+
+func TestComputeScore_NoneAvailable(t *testing.T) {
+	domains := []ProtectionDomain{
+		{Name: "File Protection", Weight: 25, Backends: []DetectedBackend{{Available: false}}},
+		{Name: "Command Control", Weight: 25, Backends: []DetectedBackend{{Available: false}}},
+		{Name: "Network", Weight: 20, Backends: []DetectedBackend{{Available: false}}},
+		{Name: "Resource Limits", Weight: 15, Backends: []DetectedBackend{{Available: false}}},
+		{Name: "Isolation", Weight: 15, Backends: []DetectedBackend{{Available: false}}},
+	}
+	assert.Equal(t, 0, ComputeScore(domains))
+}
+
+func TestComputeScore_Partial(t *testing.T) {
+	tests := []struct {
+		name     string
+		file     bool
+		cmd      bool
+		net      bool
+		res      bool
+		iso      bool
+		expected int
+	}{
+		{"File+Command only", true, true, false, false, false, 50},
+		{"Network+Resource+Isolation", false, false, true, true, true, 50},
+		{"All except Network", true, true, false, true, true, 80},
+		{"Only Isolation", false, false, false, false, true, 15},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			domains := []ProtectionDomain{
+				{Weight: 25, Backends: []DetectedBackend{{Available: tt.file}}},
+				{Weight: 25, Backends: []DetectedBackend{{Available: tt.cmd}}},
+				{Weight: 20, Backends: []DetectedBackend{{Available: tt.net}}},
+				{Weight: 15, Backends: []DetectedBackend{{Available: tt.res}}},
+				{Weight: 15, Backends: []DetectedBackend{{Available: tt.iso}}},
+			}
+			assert.Equal(t, tt.expected, ComputeScore(domains))
+		})
+	}
+}
+
+func TestComputeScore_SingleBackendInMultiBackendDomain(t *testing.T) {
+	// One backend available in a multi-backend domain should still score full weight
+	domains := []ProtectionDomain{
+		{Weight: 25, Backends: []DetectedBackend{
+			{Name: "fuse", Available: false},
+			{Name: "landlock", Available: true},
+			{Name: "seccomp-notify", Available: false},
+		}},
+	}
+	assert.Equal(t, 25, ComputeScore(domains))
+}
+
+func TestComputeScore_SetsScoreOnDomains(t *testing.T) {
+	domains := []ProtectionDomain{
+		{Weight: 25, Backends: []DetectedBackend{{Available: true}}},
+		{Weight: 20, Backends: []DetectedBackend{{Available: false}}},
+	}
+	ComputeScore(domains)
+	assert.Equal(t, 25, domains[0].Score)
+	assert.Equal(t, 0, domains[1].Score)
+}
+
+func TestDetectResult_JSONContainsDomains(t *testing.T) {
+	result := &DetectResult{
+		Platform:        "linux",
+		SecurityMode:    "full",
+		ProtectionScore: 100,
+		Domains: []ProtectionDomain{
+			{Name: "File Protection", Weight: 25, Score: 25, Backends: []DetectedBackend{
+				{Name: "fuse", Available: true, Detail: "fusermount3"},
+			}},
+		},
+		Capabilities: map[string]any{"fuse": true},
+	}
+	data, err := result.JSON()
+	assert.NoError(t, err)
+	var parsed map[string]any
+	assert.NoError(t, json.Unmarshal(data, &parsed))
+	assert.Contains(t, parsed, "domains")
+	assert.Contains(t, parsed, "capabilities")
 }

--- a/internal/capabilities/detect_windows.go
+++ b/internal/capabilities/detect_windows.go
@@ -9,6 +9,49 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+func buildWindowsDomains(caps map[string]any) []ProtectionDomain {
+	appContainer, _ := caps["app_container"].(bool)
+	winfsp, _ := caps["winfsp"].(bool)
+	minifilter, _ := caps["minifilter"].(bool)
+	windivert, _ := caps["windivert"].(bool)
+	jobObjects, _ := caps["job_objects"].(bool)
+
+	return []ProtectionDomain{
+		{
+			Name: "File Protection", Weight: WeightFileProtection,
+			Backends: []DetectedBackend{
+				{Name: "winfsp", Available: winfsp, Detail: "", Description: "filesystem interception", CheckMethod: "binary"},
+				{Name: "minifilter", Available: minifilter, Detail: "", Description: "kernel file filtering", CheckMethod: "probe"},
+			},
+		},
+		{
+			Name: "Command Control", Weight: WeightCommandControl,
+			Backends: []DetectedBackend{
+				{Name: "app-container", Available: appContainer, Detail: "", Description: "AppContainer process isolation", CheckMethod: "probe"},
+			},
+		},
+		{
+			Name: "Network", Weight: WeightNetwork,
+			Backends: []DetectedBackend{
+				{Name: "windivert", Available: windivert, Detail: "", Description: "network interception", CheckMethod: "binary"},
+			},
+		},
+		{
+			Name: "Resource Limits", Weight: WeightResourceLimits,
+			Backends: []DetectedBackend{
+				{Name: "job-objects", Available: jobObjects, Detail: "", Description: "process resource limits", CheckMethod: "builtin"},
+			},
+			Active: "job-objects",
+		},
+		{
+			Name: "Isolation", Weight: WeightIsolation,
+			Backends: []DetectedBackend{
+				{Name: "app-container", Available: appContainer, Detail: "", Description: "AppContainer isolation", CheckMethod: "probe"},
+			},
+		},
+	}
+}
+
 // Detect runs platform-specific detection and returns unified result.
 func Detect() (*DetectResult, error) {
 	caps := map[string]any{
@@ -19,32 +62,31 @@ func Detect() (*DetectResult, error) {
 		"job_objects":   true, // Always available
 	}
 
-	mode, score := selectWindowsMode(caps)
+	mode, _ := selectWindowsMode(caps)
+	domains := buildWindowsDomains(caps)
+	score := ComputeScore(domains)
 
-	// Build summary
 	var available, unavailable []string
-	for k, v := range caps {
-		if val, ok := v.(bool); ok {
-			if val {
-				available = append(available, k)
+	for _, d := range domains {
+		for _, b := range d.Backends {
+			if b.Available {
+				available = append(available, b.Name)
 			} else {
-				unavailable = append(unavailable, k)
+				unavailable = append(unavailable, b.Name)
 			}
 		}
 	}
 
-	tips := GenerateTips("windows", caps)
+	tips := GenerateTipsFromDomains(domains)
 
 	return &DetectResult{
 		Platform:        "windows",
 		SecurityMode:    mode,
 		ProtectionScore: score,
+		Domains:         domains,
 		Capabilities:    caps,
-		Summary: DetectSummary{
-			Available:   available,
-			Unavailable: unavailable,
-		},
-		Tips: tips,
+		Summary:         DetectSummary{Available: available, Unavailable: unavailable},
+		Tips:            tips,
 	}, nil
 }
 

--- a/internal/capabilities/security_caps.go
+++ b/internal/capabilities/security_caps.go
@@ -23,6 +23,12 @@ type SecurityCapabilities struct {
 	Ptrace          bool   // SYS_PTRACE capability available
 	PtraceEnabled   bool   // ptrace enforcement enabled in config
 	FileEnforcement string // "landlock", "fuse", "seccomp-notify", "none"
+
+	// Cached probe results (populated by DetectSecurityCapabilities, reused by buildLinuxDomains)
+	EBPFProbe   ProbeResult
+	CgroupProbe ProbeResult
+	PIDNSProbe  ProbeResult
+	CapProbe    ProbeResult
 }
 
 // SecurityMode represents the security enforcement mode.
@@ -36,9 +42,7 @@ const (
 
 // DetectSecurityCapabilities probes the system for available security primitives.
 func DetectSecurityCapabilities() *SecurityCapabilities {
-	caps := &SecurityCapabilities{
-		Capabilities: true, // Can always drop capabilities
-	}
+	caps := &SecurityCapabilities{}
 
 	// Detect Landlock
 	llResult := DetectLandlock()
@@ -46,13 +50,25 @@ func DetectSecurityCapabilities() *SecurityCapabilities {
 	caps.LandlockABI = llResult.ABI
 	caps.LandlockNetwork = llResult.NetworkSupport
 
-	// Detect other capabilities (use existing checks)
+	// Detect other capabilities via probes
 	caps.Seccomp = checkSeccompUserNotify().Available
 	caps.SeccompBasic = checkSeccompBasic()
-	caps.EBPF = checkeBPF().Available
 	caps.FUSE = checkFUSE()
-	caps.PIDNamespace = checkPIDNamespace()
 	caps.Ptrace = checkPtraceCapability()
+
+	// Run real probes and cache results
+	ebpfProbe := probeEBPF()
+	cgroupProbe := probeCgroupsV2()
+	pidnsProbe := probePIDNamespace()
+	capProbe := probeCapabilityDrop()
+
+	caps.EBPF = ebpfProbe.Available
+	caps.PIDNamespace = pidnsProbe.Available
+	caps.Capabilities = capProbe.Available
+	caps.EBPFProbe = ebpfProbe
+	caps.CgroupProbe = cgroupProbe
+	caps.PIDNSProbe = pidnsProbe
+	caps.CapProbe = capProbe
 
 	return caps
 }
@@ -178,9 +194,3 @@ func probeMountSyscall() bool {
 	}
 }
 
-// checkPIDNamespace checks if we're in a PID namespace (isolated process space).
-func checkPIDNamespace() bool {
-	// Check if PID 1 is not init/systemd (would indicate PID namespace)
-	// For now, return false - we can refine this check later
-	return false
-}

--- a/internal/capabilities/security_caps_other.go
+++ b/internal/capabilities/security_caps_other.go
@@ -16,6 +16,12 @@ type SecurityCapabilities struct {
 	Ptrace          bool   // SYS_PTRACE capability available
 	PtraceEnabled   bool   // ptrace enforcement enabled in config
 	FileEnforcement string // "landlock", "fuse", "seccomp-notify", "none"
+
+	// Cached probe results (populated by DetectSecurityCapabilities, reused by buildLinuxDomains)
+	EBPFProbe   ProbeResult
+	CgroupProbe ProbeResult
+	PIDNSProbe  ProbeResult
+	CapProbe    ProbeResult
 }
 
 // SecurityMode represents the security enforcement mode.

--- a/internal/capabilities/tips.go
+++ b/internal/capabilities/tips.go
@@ -2,6 +2,8 @@
 
 package capabilities
 
+import "fmt"
+
 // tipDefinition defines a tip for a missing capability.
 type tipDefinition struct {
 	Feature  string
@@ -132,5 +134,58 @@ func GenerateTips(platform string, caps map[string]any) []Tip {
 		}
 	}
 
+	return tips
+}
+
+// tipsByBackend maps backend names to tip definitions.
+var tipsByBackend = map[string]Tip{
+	// Linux
+	"fuse":             {Feature: "fuse", Impact: "Fine-grained filesystem control disabled", Action: "Install FUSE3: apt install fuse3 (Debian/Ubuntu), dnf install fuse3 (Fedora)"},
+	"seccomp-execve":   {Feature: "seccomp", Impact: "Syscall filtering disabled (likely nested container)", Action: "Run in privileged container or on host for full seccomp support"},
+	"seccomp-notify":   {Feature: "seccomp-notify", Impact: "Seccomp-based file enforcement disabled", Action: "Run in privileged container or on host for seccomp support"},
+	"landlock-network": {Feature: "landlock-network", Impact: "Kernel-level network restrictions disabled", Action: "Requires kernel 6.7+ (Landlock ABI v4)"},
+	"ebpf":             {Feature: "ebpf", Impact: "Network monitoring disabled", Action: "Requires CAP_BPF and cgroups v2. Run as root or with elevated privileges."},
+	"cgroups-v2":       {Feature: "cgroups-v2", Impact: "Resource limits unavailable", Action: "Enable cgroups v2 in kernel or container runtime"},
+	"ptrace":           {Feature: "ptrace", Impact: "Syscall-level enforcement via ptrace unavailable", Action: "Add SYS_PTRACE capability"},
+	"pid-namespace":    {Feature: "pid-namespace", Impact: "Process isolation unavailable", Action: "Run in a PID namespace (docker run --pid=host or unshare -p)"},
+	"capability-drop":  {Feature: "capability-drop", Impact: "Privilege reduction unavailable", Action: "Run with standard Linux capabilities support"},
+	// Darwin
+	"fuse-t":            {Feature: "fuse-t", Impact: "Filesystem interception unavailable", Action: "Install FUSE-T: brew install fuse-t"},
+	"esf":               {Feature: "esf", Impact: "Endpoint Security Framework unavailable", Action: "Requires system extension entitlement from Apple"},
+	"network-extension": {Feature: "network-extension", Impact: "Network filtering unavailable", Action: "Requires network extension entitlement from Apple"},
+	// Windows
+	"winfsp":     {Feature: "winfsp", Impact: "Filesystem interception unavailable", Action: "Install WinFsp: https://winfsp.dev/"},
+	"minifilter": {Feature: "minifilter", Impact: "Kernel-level file filtering unavailable", Action: "Install agentsh minifilter driver"},
+	"windivert":  {Feature: "windivert", Impact: "Network interception unavailable", Action: "Install WinDivert: https://reqrypt.org/windivert.html"},
+}
+
+func lookupTip(backendName string) *Tip {
+	if tip, ok := tipsByBackend[backendName]; ok {
+		copy := tip // don't modify the map entry
+		return &copy
+	}
+	return nil
+}
+
+// GenerateTipsFromDomains generates tips only for domains that score 0.
+// Domains that already have at least one available backend don't generate tips
+// (additional backends provide redundancy, not extra points).
+func GenerateTipsFromDomains(domains []ProtectionDomain) []Tip {
+	var tips []Tip
+	for _, d := range domains {
+		if d.Score > 0 {
+			continue // domain already covered
+		}
+		for _, b := range d.Backends {
+			if b.Available {
+				continue
+			}
+			tip := lookupTip(b.Name)
+			if tip != nil {
+				tip.Impact = fmt.Sprintf("%s (+%d pts)", tip.Impact, d.Weight)
+				tips = append(tips, *tip)
+			}
+		}
+	}
 	return tips
 }

--- a/internal/capabilities/tips_test.go
+++ b/internal/capabilities/tips_test.go
@@ -5,6 +5,8 @@ package capabilities
 import (
 	"runtime"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateTips_Linux(t *testing.T) {
@@ -89,4 +91,38 @@ func TestGenerateTips_Windows(t *testing.T) {
 	if !hasWinfspTip {
 		t.Error("missing winfsp tip")
 	}
+}
+
+func TestGenerateTipsFromDomains_ZeroScoreOnly(t *testing.T) {
+	domains := []ProtectionDomain{
+		{Name: "File Protection", Weight: 25, Score: 25, Backends: []DetectedBackend{
+			{Name: "fuse", Available: true},
+		}},
+		{Name: "Network", Weight: 20, Score: 0, Backends: []DetectedBackend{
+			{Name: "ebpf", Available: false},
+		}},
+	}
+	tips := GenerateTipsFromDomains(domains)
+	// Only Network (score 0) should generate tips, not File (score 25)
+	assert.Len(t, tips, 1)
+	assert.Equal(t, "ebpf", tips[0].Feature)
+	assert.Contains(t, tips[0].Impact, "+20 pts")
+}
+
+func TestGenerateTipsFromDomains_NoTipsWhenAllScored(t *testing.T) {
+	domains := []ProtectionDomain{
+		{Name: "File Protection", Weight: 25, Score: 25, Backends: []DetectedBackend{{Available: true}}},
+		{Name: "Network", Weight: 20, Score: 20, Backends: []DetectedBackend{{Available: true}}},
+	}
+	tips := GenerateTipsFromDomains(domains)
+	assert.Empty(t, tips)
+}
+
+func TestLookupTip(t *testing.T) {
+	tip := lookupTip("ebpf")
+	assert.NotNil(t, tip)
+	assert.Equal(t, "ebpf", tip.Feature)
+
+	tip2 := lookupTip("nonexistent")
+	assert.Nil(t, tip2)
 }


### PR DESCRIPTION
## Summary

- Groups capabilities by protection domain (File, Command, Network, Resource, Isolation) with per-domain scoring
- Replaces 4 stub detections with real probes: eBPF (BPF_PROG_LOAD), cgroups v2 (statfs), PID namespace (NSpid), capabilities (capget+prctl)
- Computes weighted score from actual feature availability (25+25+20+15+15 = 100) instead of fixed mode-based lookup
- Applies same domain model to all three platforms (Linux, Darwin, Windows)

### New detect output

```
Platform:         linux
Security Mode:    full
Protection Score: 100/100

FILE PROTECTION                          25/25
  fuse               ✓  fusermount3      file interception, soft-delete
  landlock           ✓  ABI v5           kernel path restrictions
  seccomp-notify     ✓                   openat/stat enforcement
  active backend:    fuse

COMMAND CONTROL                          25/25
  seccomp-execve     ✓                   execve interception
  ptrace             ✓                   syscall tracing

NETWORK                                  20/20
  ebpf               ✓  cgroup_skb       network monitoring
  landlock-network   ✓                   TCP bind/connect filtering

RESOURCE LIMITS                          15/15
  cgroups-v2         ✓  cgroup2          CPU/memory/process limits

ISOLATION                                15/15
  pid-namespace      ✓  NSpid: 2 levels  process isolation
  capability-drop    ✓  capget+prctl     privilege reduction
```

### Real probes replacing stubs

| Probe | Method | Old behavior |
|-------|--------|-------------|
| eBPF | `BPF_PROG_LOAD` with `BPF_PROG_TYPE_CGROUP_SKB` | Always true |
| cgroups v2 | `statfs` for `CGROUP2_SUPER_MAGIC` + readability | Always true |
| PID namespace | `/proc/self/status` NSpid field parsing | Always false |
| Capabilities | `capget()` + `prctl(PR_CAPBSET_READ)` | Always true |

### Backward compatibility

The flat `Capabilities` map is preserved in JSON/YAML output alongside the new `Domains` field. All old keys (`seccomp`, `landlock`, `fuse`, `ebpf`, etc.) are still populated.

## Test plan

- [x] Score computation: all-available (100), none (0), 4 partial combinations, single-backend-in-multi-backend domain
- [x] Probe tests for all 4 new probes (environment-dependent results)
- [x] Table format: grouped domains with subtotals, fallback flat format
- [x] JSON format: both `domains` and `capabilities` fields present
- [x] Tips: only generated for 0-score domains with point impact
- [x] Full build + Windows cross-compile + all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)