### PR TITLE
feat(hotreload): add staged policy validation and promotion

### DIFF
--- a/pkg/hotreload/staging_integration_test.go
+++ b/pkg/hotreload/staging_integration_test.go
@@ -1,0 +1,339 @@
+package hotreload
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/policy/signing"
+)
+
+// signingLoader implements PolicyLoader with real Ed25519 signature verification.
+type signingLoader struct {
+	mu         sync.Mutex
+	trustStore *signing.TrustStore
+	mode       string // "enforce", "warn", "off"
+	loaded     []string
+}
+
+func (l *signingLoader) Validate(path string) error {
+	switch l.mode {
+	case "enforce":
+		_, err := signing.VerifyPolicy(path, l.trustStore)
+		if err != nil {
+			return fmt.Errorf("signature verification failed: %w", err)
+		}
+		return nil
+	case "warn":
+		if _, err := os.Stat(path + ".sig"); err == nil {
+			if _, err := signing.VerifyPolicy(path, l.trustStore); err != nil {
+				fmt.Fprintf(os.Stderr, "WARNING: signature verification failed for %s: %v\n", path, err)
+			}
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (l *signingLoader) LoadFromPath(path string) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.loaded = append(l.loaded, path)
+	return nil
+}
+
+func (l *signingLoader) Loaded() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return append([]string(nil), l.loaded...)
+}
+
+// TestStagingIntegration_SignStagePromoteReload exercises the full flow:
+//  1. Generate Ed25519 keypair
+//  2. Create trust store with public key
+//  3. Write and sign a policy
+//  4. Drop .sig then .yaml into .staging/
+//  5. Watcher validates signature, promotes to live dir
+//  6. Live dir change triggers reload (LoadFromPath called)
+func TestStagingIntegration_SignStagePromoteReload(t *testing.T) {
+	// --- Setup: keys and trust store ---
+	keysDir := t.TempDir()
+	_, err := signing.GenerateKeypair(keysDir, "integration-test")
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+
+	trustStore, err := signing.LoadTrustStore(keysDir, true)
+	if err != nil {
+		t.Fatalf("load trust store: %v", err)
+	}
+
+	priv, err := signing.LoadPrivateKey(filepath.Join(keysDir, "private.key.json"))
+	if err != nil {
+		t.Fatalf("load private key: %v", err)
+	}
+
+	// --- Setup: policy directory ---
+	policyDir := t.TempDir()
+	stagingDir := filepath.Join(policyDir, ".staging")
+	os.MkdirAll(stagingDir, 0755)
+
+	// --- Setup: loader with enforce mode ---
+	loader := &signingLoader{
+		trustStore: trustStore,
+		mode:       "enforce",
+	}
+
+	// --- Setup: watcher ---
+	stagingDone := make(chan string, 1)
+	reloadDone := make(chan string, 1)
+
+	watcher, err := NewPolicyWatcher(WatcherConfig{
+		PolicyDir:       policyDir,
+		Loader:          loader,
+		Debounce:        50 * time.Millisecond,
+		StagingDebounce: 200 * time.Millisecond,
+		OnStaging: func(path string, err error) {
+			if err != nil {
+				t.Errorf("staging error: %v", err)
+			}
+			select {
+			case stagingDone <- path:
+			default:
+			}
+		},
+		OnChange: func(path string, err error) {
+			select {
+			case reloadDone <- path:
+			default:
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewPolicyWatcher: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := watcher.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer watcher.Stop()
+
+	// --- Sign the policy ---
+	policyContent := []byte("name: integration-test\nversion: 1\nrules:\n  - allow: all\n")
+	sig, err := signing.Sign(policyContent, priv, "integration-test")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	sigJSON, err := json.MarshalIndent(sig, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal sig: %v", err)
+	}
+
+	// --- Stage: write .sig first, then .yaml (recommended order) ---
+	if err := os.WriteFile(filepath.Join(stagingDir, "test-policy.yaml.sig"), sigJSON, 0644); err != nil {
+		t.Fatalf("write sig: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if err := os.WriteFile(filepath.Join(stagingDir, "test-policy.yaml"), policyContent, 0644); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+
+	// --- Verify: staging promotion ---
+	select {
+	case promotedPath := <-stagingDone:
+		expected := filepath.Join(policyDir, "test-policy.yaml")
+		if promotedPath != expected {
+			t.Fatalf("promoted path = %q, want %q", promotedPath, expected)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for staging promotion")
+	}
+
+	// --- Verify: files moved to live dir ---
+	livePolicy := filepath.Join(policyDir, "test-policy.yaml")
+	data, err := os.ReadFile(livePolicy)
+	if err != nil {
+		t.Fatalf("policy not in live dir: %v", err)
+	}
+	if string(data) != string(policyContent) {
+		t.Fatalf("policy content mismatch")
+	}
+
+	liveSig := filepath.Join(policyDir, "test-policy.yaml.sig")
+	if _, err := os.Stat(liveSig); err != nil {
+		t.Fatalf(".sig not in live dir: %v", err)
+	}
+
+	// --- Verify: staging dir is clean ---
+	if _, err := os.Stat(filepath.Join(stagingDir, "test-policy.yaml")); !os.IsNotExist(err) {
+		t.Fatal("policy still in staging")
+	}
+	if _, err := os.Stat(filepath.Join(stagingDir, "test-policy.yaml.sig")); !os.IsNotExist(err) {
+		t.Fatal(".sig still in staging")
+	}
+
+	// --- Verify: live reload triggered ---
+	select {
+	case reloadPath := <-reloadDone:
+		if reloadPath != livePolicy {
+			t.Fatalf("reload path = %q, want %q", reloadPath, livePolicy)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for live reload")
+	}
+
+	// --- Verify: loader was called ---
+	loaded := loader.Loaded()
+	if len(loaded) == 0 {
+		t.Fatal("LoadFromPath never called")
+	}
+
+	// --- Verify: stats ---
+	stats := watcher.Stats()
+	if stats.StagingTotal == 0 {
+		t.Error("StagingTotal should be > 0")
+	}
+	if stats.StagingSuccess == 0 {
+		t.Error("StagingSuccess should be > 0")
+	}
+	if stats.StagingFailed != 0 {
+		t.Errorf("StagingFailed should be 0, got %d", stats.StagingFailed)
+	}
+}
+
+// TestStagingIntegration_TamperedPolicyRejected verifies that a policy with
+// a tampered signature is rejected in enforce mode and stays in staging.
+func TestStagingIntegration_TamperedPolicyRejected(t *testing.T) {
+	// --- Setup: keys ---
+	keysDir := t.TempDir()
+	_, err := signing.GenerateKeypair(keysDir, "test")
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+
+	trustStore, err := signing.LoadTrustStore(keysDir, true)
+	if err != nil {
+		t.Fatalf("load trust store: %v", err)
+	}
+
+	priv, err := signing.LoadPrivateKey(filepath.Join(keysDir, "private.key.json"))
+	if err != nil {
+		t.Fatalf("load private key: %v", err)
+	}
+
+	// --- Setup: policy dir and watcher ---
+	policyDir := t.TempDir()
+	stagingDir := filepath.Join(policyDir, ".staging")
+	os.MkdirAll(stagingDir, 0755)
+
+	loader := &signingLoader{trustStore: trustStore, mode: "enforce"}
+
+	stagingDone := make(chan error, 1)
+	watcher, err := NewPolicyWatcher(WatcherConfig{
+		PolicyDir:       policyDir,
+		Loader:          loader,
+		Debounce:        50 * time.Millisecond,
+		StagingDebounce: 200 * time.Millisecond,
+		OnStaging: func(path string, err error) {
+			stagingDone <- err
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewPolicyWatcher: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watcher.Start(ctx)
+	defer watcher.Stop()
+
+	// --- Sign the original policy ---
+	originalContent := []byte("name: original\n")
+	sig, _ := signing.Sign(originalContent, priv, "test")
+	sigJSON, _ := json.MarshalIndent(sig, "", "  ")
+
+	// --- Tamper: write signature for original but different policy content ---
+	tamperedContent := []byte("name: tampered\n")
+	os.WriteFile(filepath.Join(stagingDir, "tampered.yaml.sig"), sigJSON, 0644)
+	time.Sleep(10 * time.Millisecond)
+	os.WriteFile(filepath.Join(stagingDir, "tampered.yaml"), tamperedContent, 0644)
+
+	// --- Verify: rejected ---
+	select {
+	case err := <-stagingDone:
+		if err == nil {
+			t.Fatal("expected tampered policy to be rejected")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	// File stays in staging
+	if _, err := os.Stat(filepath.Join(stagingDir, "tampered.yaml")); err != nil {
+		t.Fatal("tampered file should remain in staging")
+	}
+
+	// Not promoted
+	if _, err := os.Stat(filepath.Join(policyDir, "tampered.yaml")); !os.IsNotExist(err) {
+		t.Fatal("tampered policy should NOT be in live dir")
+	}
+
+	stats := watcher.Stats()
+	if stats.StagingFailed == 0 {
+		t.Error("StagingFailed should be > 0")
+	}
+}
+
+// TestStagingIntegration_EnforceModeRejectsMissingSig verifies that enforce mode
+// rejects a policy without a .sig file.
+func TestStagingIntegration_EnforceModeRejectsMissingSig(t *testing.T) {
+	keysDir := t.TempDir()
+	signing.GenerateKeypair(keysDir, "test")
+	trustStore, _ := signing.LoadTrustStore(keysDir, true)
+
+	policyDir := t.TempDir()
+	stagingDir := filepath.Join(policyDir, ".staging")
+	os.MkdirAll(stagingDir, 0755)
+
+	loader := &signingLoader{trustStore: trustStore, mode: "enforce"}
+
+	stagingDone := make(chan error, 1)
+	watcher, _ := NewPolicyWatcher(WatcherConfig{
+		PolicyDir:       policyDir,
+		Loader:          loader,
+		Debounce:        50 * time.Millisecond,
+		StagingDebounce: 200 * time.Millisecond,
+		OnStaging: func(path string, err error) {
+			stagingDone <- err
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watcher.Start(ctx)
+	defer watcher.Stop()
+
+	// Drop policy without .sig
+	os.WriteFile(filepath.Join(stagingDir, "unsigned.yaml"), []byte("unsigned: true"), 0644)
+
+	select {
+	case err := <-stagingDone:
+		if err == nil {
+			t.Fatal("expected missing sig to be rejected in enforce mode")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	if _, err := os.Stat(filepath.Join(policyDir, "unsigned.yaml")); !os.IsNotExist(err) {
+		t.Fatal("unsigned policy should NOT be promoted")
+	}
+}

--- a/pkg/hotreload/watcher.go
+++ b/pkg/hotreload/watcher.go
@@ -44,6 +44,9 @@ type WatcherStats struct {
 	LastReload     time.Time `json:"last_reload,omitempty"`
 	LastError      string    `json:"last_error,omitempty"`
 	LastErrorTime  time.Time `json:"last_error_time,omitempty"`
+	StagingTotal   int64     `json:"staging_total"`
+	StagingSuccess int64     `json:"staging_success"`
+	StagingFailed  int64     `json:"staging_failed"`
 }
 
 // WatcherConfig configures the policy watcher.
@@ -228,12 +231,87 @@ func (w *PolicyWatcher) processReloads(ctx context.Context) {
 func (w *PolicyWatcher) processStagingReloads(ctx context.Context) {
 	for {
 		select {
-		case <-w.stagingChan:
-			// TODO: implement in Task 4
+		case path := <-w.stagingChan:
+			w.handleStagingFile(path)
 		case <-ctx.Done():
 			return
 		}
 	}
+}
+
+// handleStagingFile validates a staged policy and promotes it to the live directory.
+func (w *PolicyWatcher) handleStagingFile(policyPath string) {
+	// Ensure the policy file actually exists (might have been a .sig-only event)
+	if _, err := os.Stat(policyPath); err != nil {
+		return
+	}
+
+	w.stats.mu.Lock()
+	w.stats.StagingTotal++
+	w.stats.mu.Unlock()
+
+	// Validate using the same loader as live reloads — this handles
+	// signature verification based on the signing mode config.
+	// Signing metadata logging (key_id, signer, signed_at) is the
+	// responsibility of the Validate implementation, not the watcher.
+	if err := w.loader.Validate(policyPath); err != nil {
+		w.recordStagingError(fmt.Sprintf("staging validation failed %s: %v", filepath.Base(policyPath), err))
+		if w.onStaging != nil {
+			w.onStaging(policyPath, err)
+		}
+		return
+	}
+
+	// Promote to live directory: move .sig first (per design spec),
+	// then .yaml. This ensures the live watcher always sees a .sig
+	// if it sees the policy.
+	baseName := filepath.Base(policyPath)
+	sigName := baseName + ".sig"
+	stagingDir := filepath.Dir(policyPath)
+
+	stagingSig := filepath.Join(stagingDir, sigName)
+	liveSig := filepath.Join(w.policyDir, sigName)
+	livePolicy := filepath.Join(w.policyDir, baseName)
+
+	// Move .sig first (may not exist in warn/off mode)
+	if _, err := os.Stat(stagingSig); err == nil {
+		if err := moveFile(stagingSig, liveSig); err != nil {
+			w.recordStagingError(fmt.Sprintf("staging move sig %s: %v", sigName, err))
+			if w.onStaging != nil {
+				w.onStaging(policyPath, err)
+			}
+			return
+		}
+	}
+
+	// Move policy file
+	if err := moveFile(policyPath, livePolicy); err != nil {
+		w.recordStagingError(fmt.Sprintf("staging move policy %s: %v", baseName, err))
+		if w.onStaging != nil {
+			w.onStaging(policyPath, err)
+		}
+		return
+	}
+
+	w.stats.mu.Lock()
+	w.stats.StagingSuccess++
+	w.stats.mu.Unlock()
+
+	if w.onStaging != nil {
+		w.onStaging(livePolicy, nil)
+	}
+}
+
+// moveFile renames src to dst, replacing dst if it exists.
+// src and dst must be on the same filesystem (guaranteed when .staging/
+// is a subdirectory of the policy dir).
+func moveFile(src, dst string) error {
+	if err := os.Rename(src, dst); err != nil {
+		// Windows: Rename fails if dst exists. Remove and retry.
+		os.Remove(dst)
+		return os.Rename(src, dst)
+	}
+	return nil
 }
 
 // handleReload processes a reload for a specific file.
@@ -279,6 +357,15 @@ func (w *PolicyWatcher) recordError(err string) {
 	w.stats.mu.Unlock()
 }
 
+// recordStagingError records a staging error in stats without incrementing ReloadsFailed.
+func (w *PolicyWatcher) recordStagingError(err string) {
+	w.stats.mu.Lock()
+	w.stats.StagingFailed++
+	w.stats.LastError = err
+	w.stats.LastErrorTime = time.Now()
+	w.stats.mu.Unlock()
+}
+
 // Stop stops the watcher.
 func (w *PolicyWatcher) Stop() error {
 	if !w.running.CompareAndSwap(true, false) {
@@ -302,6 +389,9 @@ func (w *PolicyWatcher) Stats() WatcherStats {
 		LastReload:     w.stats.LastReload,
 		LastError:      w.stats.LastError,
 		LastErrorTime:  w.stats.LastErrorTime,
+		StagingTotal:   w.stats.StagingTotal,
+		StagingSuccess: w.stats.StagingSuccess,
+		StagingFailed:  w.stats.StagingFailed,
 	}
 }
 

--- a/pkg/hotreload/watcher.go
+++ b/pkg/hotreload/watcher.go
@@ -101,6 +101,14 @@ func (w *PolicyWatcher) Start(ctx context.Context) error {
 	}
 	w.watcher = watcher
 
+	// Ensure .staging directory exists for policy delivery
+	stagingDir := filepath.Join(w.policyDir, stagingDirName)
+	if err := os.MkdirAll(stagingDir, 0755); err != nil {
+		watcher.Close()
+		w.running.Store(false)
+		return fmt.Errorf("creating staging directory: %w", err)
+	}
+
 	// Watch the policy directory
 	if err := w.addWatchRecursive(w.policyDir); err != nil {
 		watcher.Close()
@@ -113,6 +121,9 @@ func (w *PolicyWatcher) Start(ctx context.Context) error {
 
 	// Start the reload goroutine
 	go w.processReloads(ctx)
+
+	// Start the staging reload goroutine
+	go w.processStagingReloads(ctx)
 
 	return nil
 }
@@ -213,6 +224,18 @@ func (w *PolicyWatcher) processReloads(ctx context.Context) {
 	}
 }
 
+// processStagingReloads handles staging reload requests.
+func (w *PolicyWatcher) processStagingReloads(ctx context.Context) {
+	for {
+		select {
+		case <-w.stagingChan:
+			// TODO: implement in Task 4
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
 // handleReload processes a reload for a specific file.
 func (w *PolicyWatcher) handleReload(path string) {
 	w.stats.mu.Lock()
@@ -288,10 +311,13 @@ func (w *PolicyWatcher) TriggerReload() error {
 		return fmt.Errorf("watcher not running")
 	}
 
-	// Reload all policy files in the directory
 	return filepath.Walk(w.policyDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+		// Skip staging directory
+		if info.IsDir() && info.Name() == stagingDirName {
+			return filepath.SkipDir
 		}
 		if !info.IsDir() && isPolicyFile(path) {
 			select {

--- a/pkg/hotreload/watcher.go
+++ b/pkg/hotreload/watcher.go
@@ -133,6 +133,7 @@ func (w *PolicyWatcher) addWatchRecursive(dir string) error {
 // processEvents handles fsnotify events.
 func (w *PolicyWatcher) processEvents(ctx context.Context) {
 	pending := make(map[string]time.Time)
+	stagingPending := make(map[string]time.Time)
 	ticker := time.NewTicker(50 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -145,7 +146,13 @@ func (w *PolicyWatcher) processEvents(ctx context.Context) {
 
 			// Only process write and create events for policy files
 			if event.Op&(fsnotify.Write|fsnotify.Create) != 0 {
-				if isPolicyFile(event.Name) {
+				if isInStagingDir(event.Name, w.policyDir) {
+					// Staging events: track by policy base name
+					if isStagingRelevant(event.Name) {
+						policyPath := stagingPolicyPath(event.Name)
+						stagingPending[policyPath] = time.Now()
+					}
+				} else if isPolicyFile(event.Name) {
 					pending[event.Name] = time.Now()
 				}
 			}
@@ -173,6 +180,17 @@ func (w *PolicyWatcher) processEvents(ctx context.Context) {
 					case w.reloadChan <- path:
 					default:
 						// Channel full, skip
+					}
+				}
+			}
+
+			// Staging debounce
+			for path, lastChange := range stagingPending {
+				if now.Sub(lastChange) >= w.stagingDebounce {
+					delete(stagingPending, path)
+					select {
+					case w.stagingChan <- path:
+					default:
 					}
 				}
 			}

--- a/pkg/hotreload/watcher.go
+++ b/pkg/hotreload/watcher.go
@@ -286,6 +286,10 @@ func (w *PolicyWatcher) handleStagingFile(policyPath string) {
 
 	// Move policy file
 	if err := moveFile(policyPath, livePolicy); err != nil {
+		// Rollback: move .sig back to staging to avoid orphaned sig in live dir
+		if _, statErr := os.Stat(liveSig); statErr == nil {
+			os.Rename(liveSig, stagingSig) // best-effort
+		}
 		w.recordStagingError(fmt.Sprintf("staging move policy %s: %v", baseName, err))
 		if w.onStaging != nil {
 			w.onStaging(policyPath, err)

--- a/pkg/hotreload/watcher.go
+++ b/pkg/hotreload/watcher.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -20,15 +21,18 @@ type PolicyLoader interface {
 
 // PolicyWatcher watches policy files for changes and triggers reloads.
 type PolicyWatcher struct {
-	policyDir  string
-	loader     PolicyLoader
-	watcher    *fsnotify.Watcher
-	debounce   time.Duration
-	onChange   func(path string, err error)
-	mu         sync.RWMutex
-	running    atomic.Bool
-	reloadChan chan string
-	stats      WatcherStats
+	policyDir       string
+	loader          PolicyLoader
+	watcher         *fsnotify.Watcher
+	debounce        time.Duration
+	stagingDebounce time.Duration
+	onChange        func(path string, err error)
+	onStaging       func(path string, err error)
+	mu              sync.RWMutex
+	running         atomic.Bool
+	reloadChan      chan string
+	stagingChan     chan string
+	stats           WatcherStats
 }
 
 // WatcherStats tracks reload statistics.
@@ -44,10 +48,12 @@ type WatcherStats struct {
 
 // WatcherConfig configures the policy watcher.
 type WatcherConfig struct {
-	PolicyDir string
-	Loader    PolicyLoader
-	Debounce  time.Duration // Debounce period for rapid changes
-	OnChange  func(path string, err error)
+	PolicyDir       string
+	Loader          PolicyLoader
+	Debounce        time.Duration // Debounce period for rapid changes
+	StagingDebounce time.Duration // Debounce for staging (longer, to allow .sig to arrive)
+	OnChange        func(path string, err error)
+	OnStaging       func(path string, err error) // Called after staging validation attempt
 }
 
 // NewPolicyWatcher creates a new policy watcher.
@@ -65,12 +71,20 @@ func NewPolicyWatcher(config WatcherConfig) (*PolicyWatcher, error) {
 		debounce = 100 * time.Millisecond
 	}
 
+	stagingDebounce := config.StagingDebounce
+	if stagingDebounce == 0 {
+		stagingDebounce = 2 * time.Second
+	}
+
 	return &PolicyWatcher{
-		policyDir:  config.PolicyDir,
-		loader:     config.Loader,
-		debounce:   debounce,
-		onChange:   config.OnChange,
-		reloadChan: make(chan string, 100),
+		policyDir:       config.PolicyDir,
+		loader:          config.Loader,
+		debounce:        debounce,
+		stagingDebounce: stagingDebounce,
+		onChange:        config.OnChange,
+		onStaging:       config.OnStaging,
+		reloadChan:      make(chan string, 100),
+		stagingChan:     make(chan string, 100),
 	}, nil
 }
 
@@ -270,6 +284,38 @@ func (w *PolicyWatcher) TriggerReload() error {
 		}
 		return nil
 	})
+}
+
+const stagingDirName = ".staging"
+
+// isInStagingDir reports whether path is inside the .staging subdirectory of policyDir.
+func isInStagingDir(path, policyDir string) bool {
+	stagingPrefix := filepath.Join(policyDir, stagingDirName) + string(filepath.Separator)
+	return strings.HasPrefix(path, stagingPrefix)
+}
+
+// isStagingRelevant reports whether a file in .staging/ should trigger staging processing.
+// Matches policy files (.yaml, .yml, .json) and their companion .sig files.
+func isStagingRelevant(path string) bool {
+	if isPolicyFile(path) {
+		return true
+	}
+	if strings.HasSuffix(path, ".sig") {
+		return isPolicyFile(strings.TrimSuffix(path, ".sig"))
+	}
+	return false
+}
+
+// stagingPolicyPath returns the policy file path for a staging event.
+// If path ends in .sig, strips the .sig suffix to get the policy path.
+func stagingPolicyPath(path string) string {
+	if strings.HasSuffix(path, ".sig") {
+		base := strings.TrimSuffix(path, ".sig")
+		if isPolicyFile(base) {
+			return base
+		}
+	}
+	return path
 }
 
 // isPolicyFile checks if a file is a policy file.

--- a/pkg/hotreload/watcher.go
+++ b/pkg/hotreload/watcher.go
@@ -286,10 +286,9 @@ func (w *PolicyWatcher) handleStagingFile(policyPath string) {
 
 	// Move policy file
 	if err := moveFile(policyPath, livePolicy); err != nil {
-		// Rollback: move .sig back to staging to avoid orphaned sig in live dir
-		if _, statErr := os.Stat(liveSig); statErr == nil {
-			os.Rename(liveSig, stagingSig) // best-effort
-		}
+		// Remove orphaned .sig from live dir (don't move back to staging —
+		// that would trigger another staging event and retry loop).
+		os.Remove(liveSig) // best-effort
 		w.recordStagingError(fmt.Sprintf("staging move policy %s: %v", baseName, err))
 		if w.onStaging != nil {
 			w.onStaging(policyPath, err)

--- a/pkg/hotreload/watcher_test.go
+++ b/pkg/hotreload/watcher_test.go
@@ -2,6 +2,7 @@ package hotreload
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -472,6 +473,216 @@ func TestPolicyWatcher_StagingPromotesValidPolicy(t *testing.T) {
 	}
 	if stats.StagingSuccess == 0 {
 		t.Error("expected StagingSuccess > 0")
+	}
+}
+
+func TestPolicyWatcher_StagingValidationFailureLeavesFile(t *testing.T) {
+	dir := t.TempDir()
+	stagingDir := filepath.Join(dir, ".staging")
+	os.MkdirAll(stagingDir, 0755)
+
+	loader := &mockLoader{
+		validateFn: func(path string) error {
+			return fmt.Errorf("missing_signature: no .sig file")
+		},
+	}
+
+	stagingDone := make(chan error, 1)
+	watcher, err := NewPolicyWatcher(WatcherConfig{
+		PolicyDir:       dir,
+		Loader:          loader,
+		Debounce:        50 * time.Millisecond,
+		StagingDebounce: 100 * time.Millisecond,
+		OnStaging: func(path string, err error) {
+			stagingDone <- err
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watcher.Start(ctx)
+	defer watcher.Stop()
+
+	stagedFile := filepath.Join(stagingDir, "bad.yaml")
+	os.WriteFile(stagedFile, []byte("bad: true"), 0644)
+
+	select {
+	case err := <-stagingDone:
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	// File should remain in staging (not moved)
+	if _, err := os.Stat(stagedFile); err != nil {
+		t.Fatal("staged file should remain after validation failure")
+	}
+
+	// File should NOT appear in live dir
+	if _, err := os.Stat(filepath.Join(dir, "bad.yaml")); !os.IsNotExist(err) {
+		t.Fatal("failed policy should not appear in live dir")
+	}
+}
+
+func TestPolicyWatcher_StagingPromotesSigFile(t *testing.T) {
+	dir := t.TempDir()
+	stagingDir := filepath.Join(dir, ".staging")
+	os.MkdirAll(stagingDir, 0755)
+
+	loader := &mockLoader{}
+	stagingDone := make(chan struct{}, 1)
+
+	watcher, err := NewPolicyWatcher(WatcherConfig{
+		PolicyDir:       dir,
+		Loader:          loader,
+		Debounce:        50 * time.Millisecond,
+		StagingDebounce: 100 * time.Millisecond,
+		OnStaging: func(path string, err error) {
+			select {
+			case stagingDone <- struct{}{}:
+			default:
+			}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watcher.Start(ctx)
+	defer watcher.Stop()
+
+	// Write .sig first, then .yaml (recommended order)
+	os.WriteFile(filepath.Join(stagingDir, "signed.yaml.sig"), []byte(`{"version":1}`), 0644)
+	time.Sleep(10 * time.Millisecond)
+	os.WriteFile(filepath.Join(stagingDir, "signed.yaml"), []byte("signed: true"), 0644)
+
+	select {
+	case <-stagingDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	// Both files should be in live dir
+	if _, err := os.Stat(filepath.Join(dir, "signed.yaml")); err != nil {
+		t.Fatal("policy not promoted")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "signed.yaml.sig")); err != nil {
+		t.Fatal(".sig not promoted")
+	}
+
+	// Both should be gone from staging
+	if _, err := os.Stat(filepath.Join(stagingDir, "signed.yaml")); !os.IsNotExist(err) {
+		t.Fatal("staged policy should be removed")
+	}
+	if _, err := os.Stat(filepath.Join(stagingDir, "signed.yaml.sig")); !os.IsNotExist(err) {
+		t.Fatal("staged .sig should be removed")
+	}
+}
+
+func TestPolicyWatcher_StagingYamlFirstThenSig(t *testing.T) {
+	dir := t.TempDir()
+	stagingDir := filepath.Join(dir, ".staging")
+	os.MkdirAll(stagingDir, 0755)
+
+	loader := &mockLoader{}
+	stagingDone := make(chan struct{}, 1)
+
+	watcher, err := NewPolicyWatcher(WatcherConfig{
+		PolicyDir:       dir,
+		Loader:          loader,
+		Debounce:        50 * time.Millisecond,
+		StagingDebounce: 500 * time.Millisecond, // Long enough for .sig to arrive
+		OnStaging: func(path string, err error) {
+			select {
+			case stagingDone <- struct{}{}:
+			default:
+			}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watcher.Start(ctx)
+	defer watcher.Stop()
+
+	// Write .yaml first
+	os.WriteFile(filepath.Join(stagingDir, "delayed.yaml"), []byte("delayed: true"), 0644)
+	// .sig arrives 100ms later (within 500ms staging debounce)
+	time.Sleep(100 * time.Millisecond)
+	os.WriteFile(filepath.Join(stagingDir, "delayed.yaml.sig"), []byte(`{"version":1}`), 0644)
+
+	select {
+	case <-stagingDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	// Both files should be promoted
+	if _, err := os.Stat(filepath.Join(dir, "delayed.yaml")); err != nil {
+		t.Fatal("policy not promoted")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "delayed.yaml.sig")); err != nil {
+		t.Fatal(".sig not promoted")
+	}
+}
+
+func TestPolicyWatcher_StagingOverwritesExistingPolicy(t *testing.T) {
+	dir := t.TempDir()
+	stagingDir := filepath.Join(dir, ".staging")
+	os.MkdirAll(stagingDir, 0755)
+
+	// Pre-existing live policy
+	os.WriteFile(filepath.Join(dir, "existing.yaml"), []byte("version: 1"), 0644)
+
+	loader := &mockLoader{}
+	stagingDone := make(chan struct{}, 1)
+
+	watcher, err := NewPolicyWatcher(WatcherConfig{
+		PolicyDir:       dir,
+		Loader:          loader,
+		Debounce:        50 * time.Millisecond,
+		StagingDebounce: 100 * time.Millisecond,
+		OnStaging: func(path string, err error) {
+			select {
+			case stagingDone <- struct{}{}:
+			default:
+			}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watcher.Start(ctx)
+	defer watcher.Stop()
+
+	// Stage updated version
+	os.WriteFile(filepath.Join(stagingDir, "existing.yaml"), []byte("version: 2"), 0644)
+
+	select {
+	case <-stagingDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout")
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "existing.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "version: 2" {
+		t.Fatalf("expected overwritten content, got %q", data)
 	}
 }
 

--- a/pkg/hotreload/watcher_test.go
+++ b/pkg/hotreload/watcher_test.go
@@ -277,6 +277,62 @@ func TestPolicyWatcher_TriggerReload(t *testing.T) {
 	}
 }
 
+func TestIsInStagingDir(t *testing.T) {
+	tests := []struct {
+		path      string
+		policyDir string
+		want      bool
+	}{
+		{"/etc/agentsh/policies/.staging/foo.yaml", "/etc/agentsh/policies", true},
+		{"/etc/agentsh/policies/.staging/foo.yaml.sig", "/etc/agentsh/policies", true},
+		{"/etc/agentsh/policies/foo.yaml", "/etc/agentsh/policies", false},
+		{"/etc/agentsh/policies/subdir/foo.yaml", "/etc/agentsh/policies", false},
+		{"/other/.staging/foo.yaml", "/etc/agentsh/policies", false},
+	}
+	for _, tt := range tests {
+		if got := isInStagingDir(tt.path, tt.policyDir); got != tt.want {
+			t.Errorf("isInStagingDir(%q, %q) = %v, want %v", tt.path, tt.policyDir, got, tt.want)
+		}
+	}
+}
+
+func TestIsStagingRelevant(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"foo.yaml", true},
+		{"foo.yml", true},
+		{"foo.json", true},
+		{"foo.yaml.sig", true},
+		{"foo.yml.sig", true},
+		{"foo.json.sig", true},
+		{"foo.txt", false},
+		{"foo.sig", false},
+	}
+	for _, tt := range tests {
+		if got := isStagingRelevant(tt.path); got != tt.want {
+			t.Errorf("isStagingRelevant(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestStagingPolicyPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/staging/foo.yaml", "/staging/foo.yaml"},
+		{"/staging/foo.yaml.sig", "/staging/foo.yaml"},
+		{"/staging/foo.yml.sig", "/staging/foo.yml"},
+	}
+	for _, tt := range tests {
+		if got := stagingPolicyPath(tt.path); got != tt.want {
+			t.Errorf("stagingPolicyPath(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
 func TestIsPolicyFile(t *testing.T) {
 	tests := []struct {
 		path string

--- a/pkg/hotreload/watcher_test.go
+++ b/pkg/hotreload/watcher_test.go
@@ -339,14 +339,20 @@ func TestPolicyWatcher_StagingFileDoesNotTriggerLiveReload(t *testing.T) {
 	os.MkdirAll(stagingDir, 0755)
 
 	loader := &mockLoader{}
-	changed := make(chan struct{}, 1)
+	var onChangePaths []string
+	var onChangeMu sync.Mutex
+	changed := make(chan struct{}, 10)
 
+	// Use a long staging debounce so promotion doesn't happen during the test window
 	watcher, err := NewPolicyWatcher(WatcherConfig{
 		PolicyDir:       dir,
 		Loader:          loader,
 		Debounce:        50 * time.Millisecond,
-		StagingDebounce: 50 * time.Millisecond,
+		StagingDebounce: 10 * time.Second,
 		OnChange: func(path string, err error) {
+			onChangeMu.Lock()
+			onChangePaths = append(onChangePaths, path)
+			onChangeMu.Unlock()
 			select {
 			case changed <- struct{}{}:
 			default:
@@ -362,14 +368,16 @@ func TestPolicyWatcher_StagingFileDoesNotTriggerLiveReload(t *testing.T) {
 	watcher.Start(ctx)
 	defer watcher.Stop()
 
-	// Write a policy file to .staging/ — should NOT trigger onChange
+	// Write a policy file to .staging/ — should NOT trigger onChange directly
 	os.WriteFile(filepath.Join(stagingDir, "test.yaml"), []byte("test: true"), 0644)
 
 	select {
 	case <-changed:
-		t.Error("staging file should not trigger live reload onChange")
+		onChangeMu.Lock()
+		t.Errorf("staging file should not trigger live reload onChange, got paths: %v", onChangePaths)
+		onChangeMu.Unlock()
 	case <-time.After(300 * time.Millisecond):
-		// Expected: no change event
+		// Expected: no change event within the window (staging debounce is 10s)
 	}
 
 	if loader.LoadCount() != 0 {
@@ -401,6 +409,69 @@ func TestPolicyWatcher_CreatesStagingDirOnStart(t *testing.T) {
 	}
 	if !info.IsDir() {
 		t.Fatal(".staging is not a directory")
+	}
+}
+
+func TestPolicyWatcher_StagingPromotesValidPolicy(t *testing.T) {
+	dir := t.TempDir()
+	stagingDir := filepath.Join(dir, ".staging")
+	os.MkdirAll(stagingDir, 0755)
+
+	loader := &mockLoader{}
+
+	stagingDone := make(chan struct{}, 1)
+	watcher, err := NewPolicyWatcher(WatcherConfig{
+		PolicyDir:       dir,
+		Loader:          loader,
+		Debounce:        50 * time.Millisecond,
+		StagingDebounce: 100 * time.Millisecond,
+		OnStaging: func(path string, err error) {
+			select {
+			case stagingDone <- struct{}{}:
+			default:
+			}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watcher.Start(ctx)
+	defer watcher.Stop()
+
+	// Write policy to staging
+	os.WriteFile(filepath.Join(stagingDir, "test.yaml"), []byte("test: true"), 0644)
+
+	select {
+	case <-stagingDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for staging processing")
+	}
+
+	// Policy should have been moved to live dir
+	liveFile := filepath.Join(dir, "test.yaml")
+	data, err := os.ReadFile(liveFile)
+	if err != nil {
+		t.Fatalf("policy not promoted to live dir: %v", err)
+	}
+	if string(data) != "test: true" {
+		t.Fatalf("policy content mismatch: %q", data)
+	}
+
+	// Staging file should be gone
+	if _, err := os.Stat(filepath.Join(stagingDir, "test.yaml")); !os.IsNotExist(err) {
+		t.Fatal("staged policy should have been removed after promotion")
+	}
+
+	// Check staging stats
+	stats := watcher.Stats()
+	if stats.StagingTotal == 0 {
+		t.Error("expected StagingTotal > 0")
+	}
+	if stats.StagingSuccess == 0 {
+		t.Error("expected StagingSuccess > 0")
 	}
 }
 

--- a/pkg/hotreload/watcher_test.go
+++ b/pkg/hotreload/watcher_test.go
@@ -377,6 +377,33 @@ func TestPolicyWatcher_StagingFileDoesNotTriggerLiveReload(t *testing.T) {
 	}
 }
 
+func TestPolicyWatcher_CreatesStagingDirOnStart(t *testing.T) {
+	dir := t.TempDir()
+	loader := &mockLoader{}
+
+	watcher, err := NewPolicyWatcher(WatcherConfig{
+		PolicyDir: dir,
+		Loader:    loader,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watcher.Start(ctx)
+	defer watcher.Stop()
+
+	stagingDir := filepath.Join(dir, ".staging")
+	info, err := os.Stat(stagingDir)
+	if err != nil {
+		t.Fatalf(".staging dir not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatal(".staging is not a directory")
+	}
+}
+
 func TestIsPolicyFile(t *testing.T) {
 	tests := []struct {
 		path string

--- a/pkg/hotreload/watcher_test.go
+++ b/pkg/hotreload/watcher_test.go
@@ -279,16 +279,17 @@ func TestPolicyWatcher_TriggerReload(t *testing.T) {
 }
 
 func TestIsInStagingDir(t *testing.T) {
+	policyDir := filepath.Join("etc", "agentsh", "policies")
 	tests := []struct {
 		path      string
 		policyDir string
 		want      bool
 	}{
-		{"/etc/agentsh/policies/.staging/foo.yaml", "/etc/agentsh/policies", true},
-		{"/etc/agentsh/policies/.staging/foo.yaml.sig", "/etc/agentsh/policies", true},
-		{"/etc/agentsh/policies/foo.yaml", "/etc/agentsh/policies", false},
-		{"/etc/agentsh/policies/subdir/foo.yaml", "/etc/agentsh/policies", false},
-		{"/other/.staging/foo.yaml", "/etc/agentsh/policies", false},
+		{filepath.Join(policyDir, ".staging", "foo.yaml"), policyDir, true},
+		{filepath.Join(policyDir, ".staging", "foo.yaml.sig"), policyDir, true},
+		{filepath.Join(policyDir, "foo.yaml"), policyDir, false},
+		{filepath.Join(policyDir, "subdir", "foo.yaml"), policyDir, false},
+		{filepath.Join("other", ".staging", "foo.yaml"), policyDir, false},
 	}
 	for _, tt := range tests {
 		if got := isInStagingDir(tt.path, tt.policyDir); got != tt.want {

--- a/pkg/hotreload/watcher_test.go
+++ b/pkg/hotreload/watcher_test.go
@@ -333,6 +333,50 @@ func TestStagingPolicyPath(t *testing.T) {
 	}
 }
 
+func TestPolicyWatcher_StagingFileDoesNotTriggerLiveReload(t *testing.T) {
+	dir := t.TempDir()
+	stagingDir := filepath.Join(dir, ".staging")
+	os.MkdirAll(stagingDir, 0755)
+
+	loader := &mockLoader{}
+	changed := make(chan struct{}, 1)
+
+	watcher, err := NewPolicyWatcher(WatcherConfig{
+		PolicyDir:       dir,
+		Loader:          loader,
+		Debounce:        50 * time.Millisecond,
+		StagingDebounce: 50 * time.Millisecond,
+		OnChange: func(path string, err error) {
+			select {
+			case changed <- struct{}{}:
+			default:
+			}
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	watcher.Start(ctx)
+	defer watcher.Stop()
+
+	// Write a policy file to .staging/ — should NOT trigger onChange
+	os.WriteFile(filepath.Join(stagingDir, "test.yaml"), []byte("test: true"), 0644)
+
+	select {
+	case <-changed:
+		t.Error("staging file should not trigger live reload onChange")
+	case <-time.After(300 * time.Millisecond):
+		// Expected: no change event
+	}
+
+	if loader.LoadCount() != 0 {
+		t.Error("loader should not be called for staging files")
+	}
+}
+
 func TestIsPolicyFile(t *testing.T) {
 	tests := []struct {
 		path string


### PR DESCRIPTION
## Summary

- Adds `.staging/` subdirectory support to `PolicyWatcher` — policies dropped there are validated (including signature verification based on signing mode config), then atomically promoted to the live policy directory
- `.sig` is moved first, then `.yaml`, ensuring the live watcher always sees a signature if it sees the policy
- Separate 2s staging debounce (vs 100ms for live) allows `.sig` to arrive after `.yaml`
- Staging stats tracked separately (`StagingTotal`/`StagingSuccess`/`StagingFailed`) — never miscounted as reload errors
- Integration tests exercise the full sign → stage → validate → promote → reload pipeline with real Ed25519 signing

## Spec reference

Implements the "Watchtower Delivery Flow" from `docs/superpowers/specs/2026-03-18-policy-signing-design.md` (lines 189-201).

## Test plan

- [x] Helper function tests (isInStagingDir, isStagingRelevant, stagingPolicyPath)
- [x] Staging files do NOT trigger live reload
- [x] `.staging/` directory created on Start
- [x] Valid policy promoted to live dir
- [x] Validation failure leaves file in staging
- [x] `.sig` co-promoted alongside policy
- [x] `.yaml`-first then `.sig`-within-debounce ordering works
- [x] Overwrite of existing live policy
- [x] Integration: real keygen → sign → stage → verify → promote → reload
- [x] Integration: tampered policy rejected
- [x] Integration: missing sig rejected in enforce mode
- [x] Cross-compile: `GOOS=windows go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)