### PR TITLE
feat: add AgentSH policy create/edit skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ Ready-to-use snippets for configuring AI coding assistants to use agentsh:
 * Default policy: [`configs/policies/default.yaml`](configs/policies/default.yaml)
 * Example Dockerfile (with shim): [`Dockerfile.example`](Dockerfile.example)
 * **Policy documentation:** [`docs/operations/policies.md`](docs/operations/policies.md) - policy variables, signal rules, network redirect
+* **Policy authoring skills:** [`skills/`](skills/) - AI-assistant skills for creating and editing policies in Claude Code, NanoClaw, etc.
 * **Platform comparison:** [`docs/platform-comparison.md`](docs/platform-comparison.md) - feature support, security scores, performance by platform
 * **Bubblewrap vs agentsh:** [`docs/bubblewrap-vs-agentsh-comparison.md`](docs/bubblewrap-vs-agentsh-comparison.md) - comparison with Bubblewrap for Linux container sandboxing
 * **LLM Proxy & DLP:** [`docs/llm-proxy.md`](docs/llm-proxy.md) - embedded proxy configuration, DLP patterns, usage tracking

--- a/docs/superpowers/plans/2026-03-23-agentsh-policy-skills.md
+++ b/docs/superpowers/plans/2026-03-23-agentsh-policy-skills.md
@@ -1,0 +1,297 @@
+# AgentSH Policy Skills Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create two skills (`policy-create` and `policy-edit`) with a shared schema reference for creating and editing AgentSH policy YAML files from any LLM environment.
+
+**Architecture:** Three markdown files — a shared schema reference read by both skills at invocation time, plus one skill file for each workflow (create vs edit). Skills follow the standard `SKILL.md` format with YAML frontmatter.
+
+**Tech Stack:** Markdown skill files, YAML policy format, `agentsh policy validate` CLI for validation.
+
+**Spec:** `docs/superpowers/specs/2026-03-23-agentsh-policy-skills-design.md`
+
+---
+
+## File Structure
+
+```
+skills/
+  agentsh-policy-create/
+    SKILL.md                     # Create: main skill with flow + guardrails
+  agentsh-policy-edit/
+    SKILL.md                     # Edit: main skill with flow + guardrails
+  agentsh-policy-shared/
+    schema-reference.md          # Shared: full YAML schema reference
+```
+
+All content comes from the spec's "Shared Schema Reference" and "Skill" sections. No Go code changes.
+
+---
+
+### Task 1: Create shared schema reference
+
+**Files:**
+- Create: `skills/agentsh-policy-shared/schema-reference.md`
+
+This is the foundation — both skills read it at invocation time.
+
+- [ ] **Step 1: Create directory**
+
+```bash
+mkdir -p skills/agentsh-policy-shared
+```
+
+- [ ] **Step 2: Write schema-reference.md**
+
+Content comes directly from the spec's "Shared Schema Reference" section. Include:
+- Top-level policy structure (version, name, description + all rule categories)
+- All rule type tables (file_rules, network_rules, command_rules, unix_socket_rules, registry_rules, signal_rules, dns_redirects, connect_redirects, resource_limits, env_policy, audit, env_inject, mcp_rules, package_rules, process_contexts, process_identities, transparent_commands)
+- Evaluation semantics (first-match-wins, default deny, variable expansion, glob/regex/duration syntax)
+- Idiomatic examples (one per common operation: allow domain, block path, approve command, redirect command)
+
+The spec already contains the complete schema tables and examples — transfer them into this file with a brief header explaining the file's purpose.
+
+- [ ] **Step 3: Verify schema against model.go**
+
+Spot-check that the schema reference fields match `internal/policy/model.go` YAML tags. Specifically verify:
+- FileRule fields and valid operations
+- NetworkRule fields
+- CommandRule redirect_to structure
+- SignalRule signal groups and target types
+- ProcessContext advanced fields (stop_at, pass_through, race_policy)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add skills/agentsh-policy-shared/schema-reference.md
+git commit -m "feat: add shared AgentSH policy schema reference"
+```
+
+---
+
+### Task 2: Create policy-create skill
+
+**Files:**
+- Create: `skills/agentsh-policy-create/SKILL.md`
+- Reference: `configs/policies/default.yaml` (template style reference)
+- Reference: `skills/agentsh-policy-shared/schema-reference.md`
+
+- [ ] **Step 1: Create directory**
+
+```bash
+mkdir -p skills/agentsh-policy-create
+```
+
+- [ ] **Step 2: Write SKILL.md**
+
+Structure:
+
+```markdown
+---
+name: agentsh-policy-create
+description: Use when creating a new AgentSH security policy, making a policy for an agent sandbox, CI pipeline, or development environment, or asking for a new policy YAML file
+---
+
+# Create AgentSH Policy
+
+## Overview
+[1-2 sentences: what this skill does]
+
+## When to Use
+[Bullet list of triggers]
+
+## Flow
+[Numbered steps from spec section "Skill: policy-create" → Flow]
+1. Locate policy directory
+2. Understand use case (with template mapping table)
+3. Select template
+4. Customize
+5. Name & write
+6. Validate
+7. Update config reminder
+
+## Template Mapping
+[Table: use case → template name]
+
+## Guardrails
+[From spec: version 1, name+description required, default-deny catch-alls, verb-noun names, section comments]
+
+## Schema Reference
+Read `skills/agentsh-policy-shared/schema-reference.md` for the complete policy YAML schema.
+```
+
+Key details:
+- Frontmatter: name and description only, description starts with "Use when..."
+- Description must NOT summarize the workflow (CSO rule)
+- Flow steps reference `AskUserQuestion` for the use-case question
+- Template mapping table directly from spec
+- Explicit instruction to read schema-reference.md at invocation
+- Include instruction to read the closest template file from the policy directory before customizing
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/agentsh-policy-create/SKILL.md
+git commit -m "feat: add agentsh-policy-create skill"
+```
+
+---
+
+### Task 3: Create policy-edit skill
+
+**Files:**
+- Create: `skills/agentsh-policy-edit/SKILL.md`
+- Reference: `skills/agentsh-policy-shared/schema-reference.md`
+
+- [ ] **Step 1: Create directory**
+
+```bash
+mkdir -p skills/agentsh-policy-edit
+```
+
+- [ ] **Step 2: Write SKILL.md**
+
+Structure:
+
+```markdown
+---
+name: agentsh-policy-edit
+description: Use when adding, removing, or updating rules in an existing AgentSH policy, modifying security permissions, changing resource limits, or editing policy YAML files
+---
+
+# Edit AgentSH Policy
+
+## Overview
+[1-2 sentences: what this skill does]
+
+## When to Use
+[Bullet list of triggers, including "When NOT to use" pointing to policy-create]
+
+## Flow
+[Numbered steps from spec section "Skill: policy-edit" → Flow]
+1. Locate & read the policy
+2. Understand the intent (map to rule category + operation + position)
+3. Determine insertion position (ordering rules)
+4. Make the edit (add/remove/update with Edit tool)
+5. Validate
+6. Summarize
+
+## Insertion Position Rules
+[From spec: deny before allow, allow before default-deny, specific before general]
+
+## Guardrails
+[From spec: minimal edits, preserve formatting, respect ordering, verb-noun names, warn about shadowing]
+
+## Schema Reference
+Read `skills/agentsh-policy-shared/schema-reference.md` for the complete policy YAML schema.
+```
+
+Key details:
+- Same frontmatter conventions as policy-create
+- Explicit instruction about first-match-wins insertion ordering
+- Emphasize minimal edits and formatting preservation
+- Include the summarization format ("Added rule X before Y. Effect: ...")
+- Explicit instruction to read schema-reference.md at invocation
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/agentsh-policy-edit/SKILL.md
+git commit -m "feat: add agentsh-policy-edit skill"
+```
+
+---
+
+### Task 4: Test skills with subagent scenarios
+
+**Files:**
+- Read: `skills/agentsh-policy-create/SKILL.md`
+- Read: `skills/agentsh-policy-edit/SKILL.md`
+- Read: `skills/agentsh-policy-shared/schema-reference.md`
+- Read: `configs/policies/default.yaml` (for edit test)
+
+Test each skill by dispatching a subagent with the skill content loaded, giving it a realistic task, and verifying the output is correct.
+
+- [ ] **Step 1: Test policy-create — basic agent sandbox**
+
+Dispatch subagent with policy-create skill content. Task: "Create a policy for an AI coding agent that needs access to the workspace, npm/pip registries, GitHub, and should block all credential access."
+
+Verify output:
+- Valid YAML structure
+- Correct template choice (agent-default or default)
+- Network rules for npm, pip, GitHub
+- File rules blocking credentials
+- Default-deny catch-alls present
+- verb-noun rule names
+
+- [ ] **Step 2: Test policy-edit — add a network rule**
+
+Dispatch subagent with policy-edit skill content + `configs/policies/default.yaml` loaded. Task: "Allow the agent to connect to api.stripe.com and dashboard.stripe.com on port 443."
+
+Verify output:
+- Rule inserted before `approve-unknown-https` (not appended to end)
+- Correct YAML structure (name, description, domains, ports, decision)
+- Existing rules untouched
+- verb-noun name (e.g., `allow-stripe`)
+
+- [ ] **Step 3: Test policy-edit — remove a rule**
+
+Dispatch subagent with policy-edit skill content + `configs/policies/default.yaml` loaded. Task: "Remove the approval requirement for curl and wget downloads."
+
+Verify output:
+- `approve-curl-wget` rule removed
+- Surrounding rules preserved
+- Comments and formatting intact
+
+- [ ] **Step 4: Test policy-edit — modify resource limits**
+
+Dispatch subagent with policy-edit skill content + `configs/policies/default.yaml` loaded. Task: "Increase the session timeout to 8 hours and raise the memory limit to 4096 MB."
+
+Verify output:
+- Only `session_timeout` and `max_memory_mb` changed
+- Other resource_limits fields untouched
+
+- [ ] **Step 5: Fix any issues found during testing**
+
+If any test reveals gaps (missing schema info, unclear instructions, wrong ordering), update the relevant skill file and re-test.
+
+- [ ] **Step 6: Commit any fixes**
+
+```bash
+git add skills/
+git commit -m "fix: address issues found during skill testing"
+```
+
+---
+
+### Task 5: Final validation and cleanup
+
+- [ ] **Step 1: Word count check**
+
+```bash
+wc -w skills/agentsh-policy-create/SKILL.md
+wc -w skills/agentsh-policy-edit/SKILL.md
+wc -w skills/agentsh-policy-shared/schema-reference.md
+```
+
+Skills should be under 500 words each. Schema reference will be larger (it's heavy reference material — that's fine in a separate file per writing-skills conventions).
+
+- [ ] **Step 2: Verify cross-references**
+
+Confirm both skills reference `skills/agentsh-policy-shared/schema-reference.md` correctly.
+
+- [ ] **Step 3: Verify frontmatter**
+
+Check both SKILL.md files:
+- Only `name` and `description` in frontmatter
+- Name uses only letters, numbers, hyphens
+- Description starts with "Use when..."
+- Description does NOT summarize the workflow
+- Total frontmatter under 1024 characters
+
+- [ ] **Step 4: Final commit if needed**
+
+```bash
+git add skills/
+git commit -m "chore: final cleanup for policy skills"
+```

--- a/docs/superpowers/specs/2026-03-23-agentsh-policy-skills-design.md
+++ b/docs/superpowers/specs/2026-03-23-agentsh-policy-skills-design.md
@@ -114,7 +114,7 @@ Both skills read this file at invocation time. It contains the YAML-author-facin
 
 ```yaml
 version: 1                    # Required. Always 1.
-name: "policy-name"           # Required. Alphanumeric + hyphens.
+name: "policy-name"           # Required. Alphanumeric, hyphens, underscores.
 description: |                # Required. Multi-line description.
   What this policy does.
 
@@ -146,7 +146,7 @@ transparent_commands: {}      # Override transparent command set
 | description | string | yes | Human-readable description |
 | paths | string[] | yes | Glob patterns. Supports `${PROJECT_ROOT}`, `${HOME}`, `${GIT_ROOT}`, `**`, `*` |
 | operations | string[] | yes | `read`, `write`, `delete`, `stat`, `list`, `open`, `create`, `mkdir`, `chmod`, `rename`, `rmdir`, `readlink`, `*` |
-| decision | string | yes | `allow`, `deny`, `approve`, `soft_delete` |
+| decision | string | yes | `allow`, `deny`, `approve`, `redirect`, `soft_delete` |
 | message | string | no | Template string for approve decisions. Variables: `{{.Path}}` |
 | timeout | duration | no | Approval timeout (e.g., `5m`, `30s`) |
 | redirect_to | string | no | Target directory for redirected file operations |

--- a/docs/superpowers/specs/2026-03-23-agentsh-policy-skills-design.md
+++ b/docs/superpowers/specs/2026-03-23-agentsh-policy-skills-design.md
@@ -31,7 +31,7 @@ The skills must work in environments without access to the AgentSH source code (
 
 ### Flow
 
-1. **Locate policy directory** — Look for `config.yml` to find `policies.dir`. If not found, look for a `configs/policies/` directory. Fall back to asking the user for the target path.
+1. **Locate policy directory** — Look for `config.yml` or `config.yaml` to find `policies.dir`. If not found, look for a `configs/policies/` directory. Fall back to asking the user for the target path.
 
 2. **Understand the use case** — Ask one question: "What will this policy protect?" with options:
    - AI agent doing code tasks → template: `default` or `agent-default`
@@ -73,10 +73,10 @@ The skills must work in environments without access to the AgentSH source code (
 
 ### Flow
 
-1. **Locate & read the policy** — Same auto-detect as `policy-create`. If multiple policies exist, list them and ask which one to edit. Read the full YAML into context.
+1. **Locate & read the policy** — Same auto-detect as `policy-create` (check `config.yml`/`config.yaml` for `policies.dir`). If multiple policies exist, list them and ask which one to edit. Read the full YAML into context.
 
 2. **Understand the intent** — Map the user's natural language request to:
-   - **Rule category** — file_rules, network_rules, command_rules, unix_socket_rules, registry_rules, signal_rules, dns_redirects, connect_redirects, resource_limits, env_policy, audit, mcp_rules, package_rules, process_contexts, transparent_commands
+   - **Rule category** — file_rules, network_rules, command_rules, unix_socket_rules, registry_rules, signal_rules, dns_redirects, connect_redirects, resource_limits, env_policy, audit, mcp_rules, package_rules, process_contexts, process_identities, env_inject, transparent_commands
    - **Operation** — add a new rule, remove an existing rule, or modify an existing rule
    - **Insertion position** — where in the rule order (for new rules)
 
@@ -306,6 +306,11 @@ transparent_commands: {}      # Override transparent command set
 | command_overrides | map | Per-command arg filtering |
 | default_decision | string | `allow`, `deny`, `approve` (default: `deny`) |
 | max_depth | int | Max ancestry depth (0 = unlimited) |
+| stop_at | string[] | Stop taint propagation at these process classes |
+| pass_through | string[] | Classes that inherit context but don't count toward depth |
+| race_policy | object | `{on_missing_parent?, on_pid_mismatch?, on_validation_error?, log_race_conditions?}` |
+
+> **Note:** `stop_at`, `pass_through`, and `race_policy` are advanced ancestry-control fields rarely needed by most policy authors.
 
 **process_identities (map[string]ProcessIdentityConfig):**
 | Field | Type | Description |

--- a/docs/superpowers/specs/2026-03-23-agentsh-policy-skills-design.md
+++ b/docs/superpowers/specs/2026-03-23-agentsh-policy-skills-design.md
@@ -1,0 +1,408 @@
+# AgentSH Policy Skills Design
+
+Two skills for creating and editing AgentSH policy files from any LLM-powered environment (Claude Code, NanoClaw, etc.).
+
+## Problem
+
+AgentSH policies are YAML files with ~15 rule categories, first-match-wins evaluation, variable expansion, and specific field constraints. Writing them correctly requires understanding the schema, valid values, and ordering semantics. Users currently hand-edit YAML or copy-paste from templates — error-prone and slow.
+
+## Decision: Two Skills + Shared Schema
+
+**`policy-create`** — Creates a new policy from a built-in template, customized to the user's use case.
+
+**`policy-edit`** — Makes targeted edits (add/remove/update rules) to an existing policy.
+
+**`schema-reference.md`** — Shared schema reference read by both skills at invocation time. Single source of truth for the YAML-facing surface of the policy model.
+
+### Why Two Skills
+
+The create and edit flows are distinct enough that combining them would make a single skill too branchy. Create needs template selection and use-case questions. Edit needs file reading, intent mapping, and insertion-position logic. Splitting keeps each skill focused and shorter.
+
+### Why Embedded Schema
+
+The skills must work in environments without access to the AgentSH source code (NanoClaw, standalone Claude Code). Embedding the schema reference makes them self-contained. The schema covers only the YAML-author-facing surface — no Go types or engine internals.
+
+## Skill: `policy-create`
+
+### Trigger Patterns
+
+- "create a policy", "new agentsh policy", "make a policy for X"
+- "policy for my CI pipeline", "policy for agent sandbox"
+
+### Flow
+
+1. **Locate policy directory** — Look for `config.yml` to find `policies.dir`. If not found, look for a `configs/policies/` directory. Fall back to asking the user for the target path.
+
+2. **Understand the use case** — Ask one question: "What will this policy protect?" with options:
+   - AI agent doing code tasks → template: `default` or `agent-default`
+   - CI/CD pipeline → template: `ci-strict`
+   - Local development → template: `dev-safe`
+   - Strict agent sandbox → template: `agent-sandbox`
+   - Observation/profiling only → template: `agent-observe`
+   - Custom / other → start from `default`
+
+3. **Select template** — Read the closest built-in policy pack from the policy directory. If templates are not available locally, use the schema reference to generate a baseline from scratch.
+
+4. **Customize** — Ask focused follow-up questions based on what the template doesn't cover. Only ask what's relevant:
+   - "Which domains does your app need to reach?" → network rules
+   - "Any paths outside the workspace it needs to access?" → file rules
+   - "Any commands that should be blocked or require approval?" → command rules
+   - Skip categories the template already handles well for the use case.
+
+5. **Name & write** — Ask for a policy name. Generate the YAML file with descriptive section comments matching the style of built-in policies. Write to the policy directory.
+
+6. **Validate** — Run `agentsh policy validate <name>`. If validation fails, fix the issue and re-validate.
+
+7. **Update config reminder** — If `config.yml` has a `policies.allowed` list, remind the user to add the new policy name to it.
+
+### Guardrails
+
+- Always use `version: 1`.
+- Every policy must have `name` and `description`.
+- End each rule category with a default-deny catch-all (following built-in policy conventions).
+- Use descriptive rule names in `verb-noun` format (e.g., `allow-npm`, `deny-ssh-keys`).
+- Include section comment headers matching the style of built-in policies.
+
+## Skill: `policy-edit`
+
+### Trigger Patterns
+
+- "add a network rule", "allow stripe.com", "block file deletes"
+- "remove the curl approval rule", "update the memory limit"
+- "change the session timeout", "add MCP rules"
+
+### Flow
+
+1. **Locate & read the policy** — Same auto-detect as `policy-create`. If multiple policies exist, list them and ask which one to edit. Read the full YAML into context.
+
+2. **Understand the intent** — Map the user's natural language request to:
+   - **Rule category** — file_rules, network_rules, command_rules, unix_socket_rules, registry_rules, signal_rules, dns_redirects, connect_redirects, resource_limits, env_policy, audit, mcp_rules, package_rules, process_contexts, transparent_commands
+   - **Operation** — add a new rule, remove an existing rule, or modify an existing rule
+   - **Insertion position** — where in the rule order (for new rules)
+
+3. **Determine insertion position** (for new rules) — First-match-wins means ordering matters:
+   - Place deny rules before broader allow rules that would shadow them.
+   - Place allow rules before the default-deny catch-all at the end.
+   - Place more specific rules before less specific ones.
+   - When in doubt, insert immediately before the default-deny rule for that category.
+
+4. **Make the edit** — Use the Edit tool to make the targeted YAML change:
+   - **Add**: Insert the new rule at the correct position.
+   - **Remove**: Delete the rule block (name through last field).
+   - **Update**: Modify only the specific fields that need changing.
+   - Preserve existing comments and formatting. Do not reformat or reorganize untouched rules.
+
+5. **Validate** — Run `agentsh policy validate <name>`. If validation fails, fix and re-validate.
+
+6. **Summarize** — Show what changed and explain the effect in terms of what will now be allowed/denied/approved. Example: "Added network rule `allow-stripe` before `approve-unknown-https`. Stripe API traffic on port 443 will now be allowed without approval."
+
+### Guardrails
+
+- **Minimal edits only** — Only touch the specific rules the user asked about.
+- **Preserve formatting** — Keep existing comments, blank lines, section headers.
+- **Respect ordering** — Never blindly append; consider first-match-wins semantics.
+- **Name new rules** consistently — `verb-noun` format matching the existing policy style.
+- **Warn about shadowing** — If adding a rule that would be unreachable because an earlier rule matches the same pattern, warn the user.
+
+## Shared Schema Reference (`schema-reference.md`)
+
+Both skills read this file at invocation time. It contains the YAML-author-facing surface of the policy model.
+
+### Contents
+
+#### Top-Level Structure
+
+```yaml
+version: 1                    # Required. Always 1.
+name: "policy-name"           # Required. Alphanumeric + hyphens.
+description: |                # Required. Multi-line description.
+  What this policy does.
+
+file_rules: []                # File operation rules
+network_rules: []             # Network connection rules
+command_rules: []             # Command execution rules
+unix_socket_rules: []         # Unix socket rules
+registry_rules: []            # Windows registry rules
+signal_rules: []              # Signal sending rules
+dns_redirects: []             # DNS redirect rules
+connect_redirects: []         # TCP connect redirect rules
+resource_limits: {}           # Resource limits
+env_policy: {}                # Environment variable policy
+audit: {}                     # Audit settings
+env_inject: {}                # Injected environment variables
+mcp_rules: {}                 # MCP tool/server rules
+process_contexts: {}          # Parent-conditional policies
+process_identities: {}        # Process identity definitions
+package_rules: []             # Package install check rules
+transparent_commands: {}      # Override transparent command set
+```
+
+#### Rule Types
+
+**file_rules[]:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier (verb-noun) |
+| description | string | yes | Human-readable description |
+| paths | string[] | yes | Glob patterns. Supports `${PROJECT_ROOT}`, `${HOME}`, `${GIT_ROOT}`, `**`, `*` |
+| operations | string[] | yes | `read`, `write`, `delete`, `stat`, `list`, `open`, `create`, `mkdir`, `chmod`, `rename`, `rmdir`, `readlink`, `*` |
+| decision | string | yes | `allow`, `deny`, `approve`, `soft_delete` |
+| message | string | no | Template string for approve decisions. Variables: `{{.Path}}` |
+| timeout | duration | no | Approval timeout (e.g., `5m`, `30s`) |
+| redirect_to | string | no | Target directory for redirected file operations |
+| preserve_tree | bool | no | Preserve directory structure under redirect target |
+
+**network_rules[]:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| description | string | yes | Human-readable description |
+| domains | string[] | no | Domain glob patterns (e.g., `*.stripe.com`). At least one of domains/ports/cidrs required. |
+| ports | int[] | no | Port numbers (e.g., `[443, 80]`) |
+| cidrs | string[] | no | CIDR ranges (e.g., `10.0.0.0/8`) |
+| decision | string | yes | `allow`, `deny`, `approve` |
+| message | string | no | Template. Variables: `{{.RemoteAddr}}`, `{{.RemotePort}}` |
+| timeout | duration | no | Approval timeout |
+
+**command_rules[]:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| description | string | no | Human-readable description |
+| commands | string[] | yes | Command names (basename matching, glob supported) |
+| args_patterns | string[] | no | Regex patterns matched against the full argument string |
+| decision | string | yes | `allow`, `deny`, `approve`, `redirect` |
+| message | string | no | Template. Variables: `{{.Args}}` |
+| redirect_to | object | no | For redirect decision: `{command, args[], args_append[], environment{}}` |
+| context | object | no | Process ancestry context conditions |
+| env_allow | string[] | no | Per-command env allowlist (glob) |
+| env_deny | string[] | no | Per-command env denylist (glob) |
+| env_max_bytes | int | no | Max env size for this command |
+| env_max_keys | int | no | Max env keys for this command |
+| env_block_iteration | bool | no | Block env enumeration for this command |
+
+**unix_socket_rules[]:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| description | string | yes | Human-readable description |
+| paths | string[] | yes | Socket paths. `@name` for abstract namespace. |
+| operations | string[] | no | `connect`, `bind`, `listen`, `sendto`. Empty = all. |
+| decision | string | yes | `allow`, `deny`, `approve` |
+| message | string | no | Approval message |
+| timeout | duration | no | Approval timeout |
+
+**registry_rules[] (Windows only):**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| description | string | yes | Human-readable description |
+| paths | string[] | yes | Registry key paths (e.g., `HKLM\SOFTWARE\...`) |
+| operations | string[] | yes | `read`, `write`, `delete`, `create`, `rename` |
+| decision | string | yes | `allow`, `deny`, `approve` |
+| priority | int | no | Higher = evaluated first |
+| cache_ttl | duration | no | Per-rule cache TTL |
+| notify | bool | no | Always emit notification |
+
+**signal_rules[]:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| description | string | yes | Human-readable description |
+| signals | string[] | yes | Signal names, numbers, or groups: `@all`, `@fatal`, `@job`, `@reload` |
+| target | object | yes | `{type, pattern?, min?, max?}`. Types: `self`, `children`, `parent`, `session`, `external`, `system` |
+| decision | string | yes | `allow`, `deny`, `audit`, `approve`, `redirect`, `absorb` |
+| fallback | string | no | Fallback decision if platform can't enforce |
+| redirect_to | string | no | Target signal name (for redirect decision) |
+| message | string | no | Human-readable message |
+| timeout | duration | no | Approval timeout |
+
+**dns_redirects[]:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| match | string | yes | Regex pattern for hostname |
+| resolve_to | string | yes | IP address to return |
+| visibility | string | no | `silent`, `audit_only`, `warn` |
+| on_failure | string | no | `fail_closed`, `fail_open`, `retry_original` |
+
+**connect_redirects[]:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| match | string | yes | Regex pattern for `host:port` |
+| redirect_to | string | yes | New `host:port` destination |
+| tls | object | no | `{mode, sni?}`. Modes: `passthrough`, `rewrite_sni` |
+| visibility | string | no | `silent`, `audit_only`, `warn` |
+| message | string | no | Human-readable message |
+| on_failure | string | no | `fail_closed`, `fail_open`, `retry_original` |
+
+**resource_limits:**
+| Field | Type | Description |
+|-------|------|-------------|
+| max_memory_mb | int | Max memory in MB |
+| memory_swap_max_mb | int | Max swap in MB (0 = disable) |
+| cpu_quota_percent | int | Max CPU % of one core |
+| disk_read_bps_max | int64 | Max disk read bytes/sec |
+| disk_write_bps_max | int64 | Max disk write bytes/sec |
+| net_bandwidth_mbps | int | Max network bandwidth Mbps |
+| pids_max | int | Max process count |
+| command_timeout | duration | Max time per command |
+| session_timeout | duration | Max session lifetime |
+| idle_timeout | duration | Kill after idle period |
+
+**env_policy:**
+| Field | Type | Description |
+|-------|------|-------------|
+| allow | string[] | Glob patterns for allowed env vars |
+| deny | string[] | Glob patterns for denied env vars |
+| max_bytes | int | Max total env size |
+| max_keys | int | Max number of env vars |
+| block_iteration | bool | Hide env enumeration |
+
+**audit:**
+| Field | Type | Description |
+|-------|------|-------------|
+| log_allowed | bool | Log allowed operations |
+| log_denied | bool | Log denied operations |
+| log_approved | bool | Log approved operations |
+| include_stdout | bool | Include stdout in logs |
+| include_stderr | bool | Include stderr in logs |
+| include_file_content | bool | Include file content in logs |
+| retention_days | int | Log retention period |
+
+**mcp_rules:**
+| Field | Type | Description |
+|-------|------|-------------|
+| enforce_policy | bool | Enable MCP enforcement |
+| tool_policy | string | `allowlist` or `blocklist` |
+| allowed_tools | object[] | `[{server, tool, content_hash?}]` |
+| allowed_servers | object[] | `[{id}]` |
+| server_policy | string | Server list policy |
+| version_pinning | object | `{enabled, on_change?, auto_trust_first?}` |
+| cross_server | object | `{enabled, read_then_send?: {enabled}}` |
+
+**package_rules[]:**
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| match | object | yes | `{packages?, name_patterns?, finding_type?, severity?, reasons?, license_spdx?: {allow?, deny?}, ecosystem?}` |
+| action | string | yes | `allow`, `warn`, `approve`, `block` |
+| reason | string | no | Explanation |
+
+**process_contexts (map[string]ProcessContext):**
+| Field | Type | Description |
+|-------|------|-------------|
+| description | string | Context description |
+| identities | string[] | Process identity names that trigger this context |
+| chain_rules | object[] | Escape-hatch detection rules |
+| command_rules | CommandRule[] | Override command rules |
+| file_rules | FileRule[] | Override file rules |
+| network_rules | NetworkRule[] | Override network rules |
+| unix_socket_rules | UnixSocketRule[] | Override unix socket rules |
+| env_policy | EnvPolicy | Override env policy |
+| allowed_commands | string[] | Quick allow list |
+| denied_commands | string[] | Quick deny list |
+| require_approval | string[] | Quick approval list |
+| command_overrides | map | Per-command arg filtering |
+| default_decision | string | `allow`, `deny`, `approve` (default: `deny`) |
+| max_depth | int | Max ancestry depth (0 = unlimited) |
+
+**process_identities (map[string]ProcessIdentityConfig):**
+| Field | Type | Description |
+|-------|------|-------------|
+| description | string | Identity description |
+| linux | object | `{comm?, exe_path?, cmdline?}` |
+| darwin | object | `{comm?, exe_path?, cmdline?, bundle_id?}` |
+| windows | object | `{comm?, exe_path?, cmdline?, exe_name?}` |
+| all_platforms | object | Same fields, applies everywhere |
+
+**transparent_commands:**
+| Field | Type | Description |
+|-------|------|-------------|
+| add | string[] | Additional transparent commands |
+| remove | string[] | Remove from built-in defaults |
+
+#### Evaluation Semantics
+
+- **First match wins**: Rules within each category are evaluated top-to-bottom. The first rule whose pattern matches determines the decision. Order matters.
+- **Default deny**: Convention is to end each rule category with a catch-all deny rule (e.g., `paths: ["**"]`, `domains: ["*"]`).
+- **Variable expansion**: `${PROJECT_ROOT}`, `${HOME}`, `${GIT_ROOT}` are expanded at load time.
+- **Glob syntax**: `*` matches any characters except `/`. `**` matches any characters including `/`. `?` matches one character.
+- **Regex syntax**: `args_patterns`, `dns_redirects[].match`, and `connect_redirects[].match` use Go regexp syntax.
+- **Duration syntax**: Go duration strings — `5m`, `30s`, `1h`, `4h30m`.
+
+#### Idiomatic Examples
+
+**Allow a specific domain:**
+```yaml
+- name: allow-stripe
+  description: Stripe API access
+  domains:
+    - "api.stripe.com"
+    - "*.stripe.com"
+  ports: [443]
+  decision: allow
+```
+
+**Block a sensitive path:**
+```yaml
+- name: deny-docker-socket
+  description: Block Docker socket access
+  paths:
+    - "/var/run/docker.sock"
+  operations: ["*"]
+  decision: deny
+```
+
+**Require approval for a command with specific args:**
+```yaml
+- name: approve-npm-publish
+  description: Require approval for npm publish
+  commands: [npm]
+  args_patterns: ["publish.*"]
+  decision: approve
+  message: "Agent wants to publish: {{.Args}}"
+```
+
+**Redirect a dangerous command:**
+```yaml
+- name: redirect-rm-rf
+  description: Redirect rm -rf to safe alternative
+  commands: [rm]
+  args_patterns: [".*-rf.*"]
+  decision: redirect
+  redirect_to:
+    command: echo
+    args: ["rm -rf blocked. Use targeted deletes instead."]
+```
+
+## File Layout
+
+```
+skills/
+  agentsh-policy-create/
+    agentsh-policy-create.md     # Skill: trigger, flow, guardrails
+  agentsh-policy-edit/
+    agentsh-policy-edit.md       # Skill: trigger, flow, guardrails
+  agentsh-policy-shared/
+    schema-reference.md          # Shared schema (read by both skills)
+```
+
+## Validation
+
+Both skills run `agentsh policy validate <name>` after every change. If the binary is not available, the skill warns that it cannot validate and advises the user to run validation manually.
+
+## Built-in Templates
+
+The `policy-create` skill maps use cases to templates:
+
+| Use Case | Template |
+|----------|----------|
+| AI agent (code tasks) | `default` or `agent-default` |
+| CI/CD pipeline | `ci-strict` |
+| Local development | `dev-safe` |
+| Strict agent sandbox | `agent-sandbox` |
+| Observation/profiling | `agent-observe` |
+| Custom | Start from `default` |
+
+Templates are read from the local policy directory if available. Otherwise, the schema reference provides enough information to generate a reasonable baseline.

--- a/docs/superpowers/specs/2026-03-23-agentsh-policy-skills-design.md
+++ b/docs/superpowers/specs/2026-03-23-agentsh-policy-skills-design.md
@@ -210,7 +210,7 @@ transparent_commands: {}      # Override transparent command set
 | name | string | yes | Rule identifier |
 | description | string | yes | Human-readable description |
 | signals | string[] | yes | Signal names, numbers, or groups: `@all`, `@fatal`, `@job`, `@reload` |
-| target | object | yes | `{type, pattern?, min?, max?}`. Types: `self`, `children`, `parent`, `session`, `external`, `system` |
+| target | object | yes | `{type, pattern?, min?, max?}`. Types: `self`, `children`, `descendants`, `siblings`, `parent`, `session`, `external`, `system`, `user`, `process`, `pid_range` |
 | decision | string | yes | `allow`, `deny`, `audit`, `approve`, `redirect`, `absorb` |
 | fallback | string | no | Fallback decision if platform can't enforce |
 | redirect_to | string | no | Target signal name (for redirect decision) |

--- a/docs/superpowers/specs/2026-03-23-agentsh-policy-skills-design.md
+++ b/docs/superpowers/specs/2026-03-23-agentsh-policy-skills-design.md
@@ -386,9 +386,9 @@ transparent_commands: {}      # Override transparent command set
 ```
 skills/
   agentsh-policy-create/
-    agentsh-policy-create.md     # Skill: trigger, flow, guardrails
+    SKILL.md                     # Skill: trigger, flow, guardrails
   agentsh-policy-edit/
-    agentsh-policy-edit.md       # Skill: trigger, flow, guardrails
+    SKILL.md                     # Skill: trigger, flow, guardrails
   agentsh-policy-shared/
     schema-reference.md          # Shared schema (read by both skills)
 ```

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,58 @@
+# AgentSH Policy Skills
+
+AI-assistant skills for creating and editing AgentSH security policies. Works in Claude Code, NanoClaw, and other LLM-powered environments.
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| **agentsh-policy-create** | Create new policies from built-in templates (default, dev-safe, ci-strict, agent-sandbox) |
+| **agentsh-policy-edit** | Add, remove, or update rules in existing policies with first-match-wins ordering awareness |
+
+Both skills reference a shared schema in `agentsh-policy-shared/schema-reference.md` covering all 17 rule categories.
+
+## Installation
+
+### Claude Code
+
+Copy the skill directories into your Claude Code skills folder:
+
+```bash
+# Project-level (recommended — other contributors get the skills too)
+cp -r skills/agentsh-policy-create .claude/skills/
+cp -r skills/agentsh-policy-edit .claude/skills/
+cp -r skills/agentsh-policy-shared .claude/skills/
+
+# User-level (available in all your projects)
+cp -r skills/agentsh-policy-create ~/.claude/skills/
+cp -r skills/agentsh-policy-edit ~/.claude/skills/
+cp -r skills/agentsh-policy-shared ~/.claude/skills/
+```
+
+### NanoClaw
+
+Copy the skill directories into your NanoClaw skills folder:
+
+```bash
+cp -r skills/agentsh-policy-create ~/.nanoclaw/skills/
+cp -r skills/agentsh-policy-edit ~/.nanoclaw/skills/
+cp -r skills/agentsh-policy-shared ~/.nanoclaw/skills/
+```
+
+### Other LLM environments
+
+Copy the three directories (`agentsh-policy-create`, `agentsh-policy-edit`, `agentsh-policy-shared`) into whatever skills/prompts directory your environment uses. The skills are standard markdown files with YAML frontmatter — any system that loads skill files will work.
+
+## Usage
+
+Once installed, the skills activate automatically when you ask your AI assistant to work with policies:
+
+**Creating a new policy:**
+> "Create a policy for my CI pipeline that only allows npm registry access and blocks all credential files"
+
+**Editing an existing policy:**
+> "Allow my app to connect to api.stripe.com on port 443"
+> "Remove the approval requirement for curl downloads"
+> "Increase the session timeout to 8 hours"
+
+The skills handle template selection, YAML generation, rule ordering (first-match-wins), and validation via `agentsh policy validate`.

--- a/skills/agentsh-policy-create/SKILL.md
+++ b/skills/agentsh-policy-create/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: agentsh-policy-create
+description: Use when creating a new AgentSH security policy, making a policy for an agent sandbox, CI pipeline, or development environment, or asking for a new policy YAML file
+---
+
+# Create AgentSH Policy
+
+## Overview
+
+Create new AgentSH security policies from built-in templates, customized to the user's use case. Produces valid YAML policy files with correct structure, evaluation semantics, and defensive defaults.
+
+## When to Use
+
+- User asks to create/make/generate a new policy
+- User describes a use case that needs a policy ("policy for my CI pipeline")
+- User wants to set up AgentSH for the first time
+- NOT for editing existing policies (use agentsh-policy-edit)
+
+## Flow
+
+1. **Locate policy directory**
+   - Look for `config.yml` or `config.yaml` in the project root to find `policies.dir`
+   - If not found, look for a `configs/policies/` directory
+   - Fall back to asking the user with AskUserQuestion
+
+2. **Understand the use case**
+   Use AskUserQuestion to ask: "What will this policy protect?"
+
+   | Use Case | Template |
+   |----------|----------|
+   | AI agent (code tasks) | `default` or `agent-default` |
+   | CI/CD pipeline | `ci-strict` |
+   | Local development | `dev-safe` |
+   | Strict agent sandbox | `agent-sandbox` |
+   | Observation/profiling | `agent-observe` |
+   | Custom / other | Start from `default` |
+
+3. **Select template**
+   - Read the matching template from the policy directory (e.g., `configs/policies/default.yaml`)
+   - If templates are not available locally, use the schema reference to generate a baseline
+
+4. **Customize**
+   Based on the template read in Step 3, ask only about gaps — skip categories the template already handles well:
+   - "Which domains does your app need to reach?" → add network rules
+   - "Any paths outside the workspace it needs?" → add file rules
+   - "Any commands to block or require approval?" → add command rules
+
+5. **Name & write**
+   - Ask for a policy name
+   - Generate the YAML with descriptive section comments matching built-in policy style
+   - Write to the policy directory
+
+6. **Validate**
+   Run: `agentsh policy validate <name>`
+   If validation fails, fix and re-validate.
+   If `agentsh` binary is not available, warn the user to validate manually.
+
+7. **Update config reminder**
+   If `config.yml` has a `policies.allowed` list, remind the user to add the new policy name.
+
+## Guardrails
+
+- Always use `version: 1`
+- Every policy must have `name` and `description`
+- End each rule category with a default-deny catch-all
+- Use descriptive rule names in `verb-noun` format (e.g., `allow-npm`, `deny-ssh-keys`)
+- Include section comment headers matching built-in policy style
+- First match wins — place specific rules before general ones
+
+## Schema Reference
+
+Read `skills/agentsh-policy-shared/schema-reference.md` for the complete policy YAML schema before generating any policy content. If this file is not accessible, proceed using only the guardrails above plus the template file read in Step 3. Do not generate policy YAML without either the schema reference or a template.

--- a/skills/agentsh-policy-create/SKILL.md
+++ b/skills/agentsh-policy-create/SKILL.md
@@ -63,7 +63,7 @@ Create new AgentSH security policies from built-in templates, customized to the 
 
 - Always use `version: 1`
 - Every policy must have `name` and `description`
-- End each rule category with a default-deny catch-all
+- End rule-list categories (file_rules, network_rules, command_rules) with a default-deny catch-all
 - Use descriptive rule names in `verb-noun` format (e.g., `allow-npm`, `deny-ssh-keys`)
 - Include section comment headers matching built-in policy style
 - First match wins — place specific rules before general ones

--- a/skills/agentsh-policy-create/SKILL.md
+++ b/skills/agentsh-policy-create/SKILL.md
@@ -37,6 +37,7 @@ Create new AgentSH security policies from built-in templates, customized to the 
 
 3. **Select template**
    - Read the matching template from the policy directory (e.g., `configs/policies/default.yaml`)
+   - On Windows, prefer the `-windows` variant if available (e.g., `default-windows.yaml`, `ci-strict-windows.yaml`)
    - If templates are not available locally, use the schema reference to generate a baseline
 
 4. **Customize**

--- a/skills/agentsh-policy-edit/SKILL.md
+++ b/skills/agentsh-policy-edit/SKILL.md
@@ -31,7 +31,7 @@ Make targeted edits to existing AgentSH security policies — add, remove, or up
 
 3. **Determine insertion position** (for new rules)
    First-match-wins means ordering matters:
-   - Place deny rules before any broader non-deny rules (`allow`, `approve`) that match the same pattern — an earlier permissive rule would shadow a later deny
+   - Place deny rules before any broader matching rule regardless of its decision — any non-deny rule (`allow`, `approve`, `redirect`, `audit`, `absorb`, `soft_delete`) that matches first will shadow the deny
    - Place allow rules before the default-deny catch-all at the end
    - Place more specific rules before less specific ones
    - When in doubt: deny rules go before the first non-deny rule in that category; allow rules go before the default-deny
@@ -56,7 +56,7 @@ Make targeted edits to existing AgentSH security policies — add, remove, or up
 
 | Scenario | Position |
 |----------|----------|
-| New deny rule | Before any non-deny rule (`allow`, `approve`) that matches the same or broader pattern |
+| New deny rule | Before any broader matching non-deny rule in that category |
 | New allow rule | Before the default-deny catch-all |
 | More specific rule | Before less specific rules matching the same pattern |
 | Uncertain (deny) | Before the first non-deny rule in that category |

--- a/skills/agentsh-policy-edit/SKILL.md
+++ b/skills/agentsh-policy-edit/SKILL.md
@@ -31,10 +31,10 @@ Make targeted edits to existing AgentSH security policies — add, remove, or up
 
 3. **Determine insertion position** (for new rules)
    First-match-wins means ordering matters:
-   - Place deny rules before allow rules that match the same or broader pattern — an earlier allow rule would shadow a later deny
+   - Place deny rules before any broader non-deny rules (`allow`, `approve`) that match the same pattern — an earlier permissive rule would shadow a later deny
    - Place allow rules before the default-deny catch-all at the end
    - Place more specific rules before less specific ones
-   - When in doubt: deny rules go before the first allow in that category; allow rules go before the default-deny
+   - When in doubt: deny rules go before the first non-deny rule in that category; allow rules go before the default-deny
 
 4. **Make the edit**
    Use the Edit tool:
@@ -56,10 +56,10 @@ Make targeted edits to existing AgentSH security policies — add, remove, or up
 
 | Scenario | Position |
 |----------|----------|
-| New deny rule | Before allow rules that match the same or broader pattern |
+| New deny rule | Before any non-deny rule (`allow`, `approve`) that matches the same or broader pattern |
 | New allow rule | Before the default-deny catch-all |
 | More specific rule | Before less specific rules matching the same pattern |
-| Uncertain (deny) | Before the first allow rule in that category |
+| Uncertain (deny) | Before the first non-deny rule in that category |
 | Uncertain (allow) | Immediately before the default-deny rule for that category |
 
 ## Guardrails

--- a/skills/agentsh-policy-edit/SKILL.md
+++ b/skills/agentsh-policy-edit/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: agentsh-policy-edit
+description: Use when adding, removing, or updating rules in an existing AgentSH policy, modifying security permissions, changing resource limits, or editing policy YAML files
+---
+
+# Edit AgentSH Policy
+
+## Overview
+Make targeted edits to existing AgentSH security policies — add, remove, or update rules. Understands first-match-wins evaluation semantics and correct insertion ordering.
+
+## When to Use
+- User asks to add/remove/update a policy rule ("allow stripe.com", "block file deletes")
+- User wants to change resource limits or audit settings
+- User mentions modifying an existing policy
+- NOT for creating new policies from scratch (use agentsh-policy-create)
+
+## Flow
+
+1. **Locate & read the policy**
+   - Check `config.yml`/`config.yaml` for `policies.dir`
+   - If not found, look for `configs/policies/` directory
+   - Fall back to asking the user
+   - If multiple policies exist, list them and ask which one to edit
+   - Read the full YAML into context
+
+2. **Understand the intent**
+   Map the user's request to:
+   - **Rule category** — file_rules, network_rules, command_rules, unix_socket_rules, registry_rules, signal_rules, dns_redirects, connect_redirects, resource_limits, env_policy, audit, mcp_rules, package_rules, process_contexts, process_identities, env_inject, transparent_commands
+   - **Operation** — add a new rule, remove an existing rule, or modify an existing rule
+   - **Insertion position** — where in the rule order (for new rules)
+
+3. **Determine insertion position** (for new rules)
+   First-match-wins means ordering matters:
+   - Place deny rules before allow rules that match the same or broader pattern — an earlier allow rule would shadow a later deny
+   - Place allow rules before the default-deny catch-all at the end
+   - Place more specific rules before less specific ones
+   - When in doubt: deny rules go before the first allow in that category; allow rules go before the default-deny
+
+4. **Make the edit**
+   Use the Edit tool:
+   - **Add**: Insert the new rule at the correct position
+   - **Remove**: Delete the entire rule block (name through last field)
+   - **Update**: Modify only the specific fields that need changing
+   - Preserve existing comments and formatting. Do not reformat untouched rules.
+
+5. **Validate**
+   Run: `agentsh policy validate <name>`
+   If validation fails, fix and re-validate.
+   If `agentsh` binary is not available, warn the user to validate manually.
+
+6. **Summarize**
+   Show what changed and explain the effect:
+   "Added network rule `allow-stripe` before `approve-unknown-https`. Stripe API traffic on port 443 will now be allowed without approval."
+
+## Insertion Position Rules
+
+| Scenario | Position |
+|----------|----------|
+| New deny rule | Before allow rules that match the same or broader pattern |
+| New allow rule | Before the default-deny catch-all |
+| More specific rule | Before less specific rules matching the same pattern |
+| Uncertain (deny) | Before the first allow rule in that category |
+| Uncertain (allow) | Immediately before the default-deny rule for that category |
+
+## Guardrails
+
+- **Minimal edits only** — only touch the rules the user asked about
+- **Preserve formatting** — keep existing comments, blank lines, section headers
+- **Respect ordering** — never blindly append; consider first-match-wins
+- **Name new rules** in `verb-noun` format matching the existing policy style
+- **Warn about shadowing** — if a new rule would be unreachable because an earlier rule matches the same pattern, warn the user
+- **Warn about removal side-effects** — removing a deny rule may expose an allow rule that was previously unreachable; removing an allow rule may expose a deny. Explain the ordering impact when summarizing.
+
+## Schema Reference
+
+Read `skills/agentsh-policy-shared/schema-reference.md` for the complete policy YAML schema before making edits. If this file is not accessible, use the existing policy file as your reference for field names and structure. For rule categories not present in the existing file, ask the user for details rather than guessing.

--- a/skills/agentsh-policy-shared/schema-reference.md
+++ b/skills/agentsh-policy-shared/schema-reference.md
@@ -147,7 +147,7 @@ Default (if omitted): all depths (`min_depth: 0`, `max_depth: -1`).
 | name | string | yes | Rule identifier |
 | description | string | yes | Human-readable description |
 | signals | string[] | yes | Signal names, numbers, or groups: `@all`, `@fatal`, `@job`, `@reload` |
-| target | object | yes | `{type, pattern?, min?, max?}`. Types: `self`, `children`, `parent`, `session`, `external`, `system`, `pid_range` |
+| target | object | yes | `{type, pattern?, min?, max?}`. Types: `self`, `children`, `descendants`, `siblings`, `parent`, `session`, `external`, `system`, `user`, `process`, `pid_range` |
 | decision | string | yes | `allow`, `deny`, `audit`, `approve`, `redirect`, `absorb` |
 | fallback | string | no | Fallback decision if platform can't enforce |
 | redirect_to | string | no | Target signal name (for redirect decision) |
@@ -158,8 +158,8 @@ Default (if omitted): all depths (`min_depth: 0`, `max_depth: -1`).
 
 | Field | Type | Description |
 |-------|------|-------------|
-| type | string | `self`, `children`, `parent`, `session`, `external`, `system`, `pid_range` |
-| pattern | string | Process name pattern (optional) |
+| type | string | `self`, `children`, `descendants`, `siblings`, `parent`, `session`, `external`, `system`, `user`, `process`, `pid_range` |
+| pattern | string | Process name pattern (for `process` and `user` types) |
 | min | int | Min PID for pid_range type (optional) |
 | max | int | Max PID for pid_range type (optional) |
 

--- a/skills/agentsh-policy-shared/schema-reference.md
+++ b/skills/agentsh-policy-shared/schema-reference.md
@@ -159,9 +159,9 @@ Default (if omitted): all depths (`min_depth: 0`, `max_depth: -1`).
 | Field | Type | Description |
 |-------|------|-------------|
 | type | string | `self`, `children`, `descendants`, `siblings`, `parent`, `session`, `external`, `system`, `user`, `process`, `pid_range` |
-| pattern | string | Process name pattern (for `process` and `user` types) |
-| min | int | Min PID for pid_range type (optional) |
-| max | int | Max PID for pid_range type (optional) |
+| pattern | string | Process name glob pattern (only for `type: process`) |
+| min | int | Required when `type: pid_range`. Must be > 0, min <= max. |
+| max | int | Required when `type: pid_range`. Must be > 0, min >= min. |
 
 ### dns_redirects[]
 

--- a/skills/agentsh-policy-shared/schema-reference.md
+++ b/skills/agentsh-policy-shared/schema-reference.md
@@ -1,0 +1,389 @@
+# AgentSH Policy Schema Reference
+
+This file is the authoritative YAML-author-facing schema for AgentSH policy files.
+It is read at invocation time by both the `policy-create` and `policy-edit` skills
+and must be self-contained — the reader will not have access to the AgentSH source code.
+
+Field names and types are verified against `internal/policy/model.go`.
+
+---
+
+## Top-Level Structure
+
+```yaml
+version: 1                    # Required. Always 1.
+name: "policy-name"           # Required. Alphanumeric + hyphens.
+description: |                # Required. Multi-line description.
+  What this policy does.
+
+file_rules: []                # File operation rules
+network_rules: []             # Network connection rules
+command_rules: []             # Command execution rules
+unix_socket_rules: []         # Unix socket rules
+registry_rules: []            # Windows registry rules
+signal_rules: []              # Signal sending rules
+dns_redirects: []             # DNS redirect rules
+connect_redirects: []         # TCP connect redirect rules
+resource_limits: {}           # Resource limits
+env_policy: {}                # Environment variable policy
+audit: {}                     # Audit settings
+env_inject: {}                # Injected environment variables (map of key: value)
+mcp_rules: {}                 # MCP tool/server rules
+process_contexts: {}          # Parent-conditional policies
+process_identities: {}        # Process identity definitions
+package_rules: []             # Package install check rules
+transparent_commands: {}      # Override transparent command set
+```
+
+---
+
+## Rule Types
+
+### file_rules[]
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier (verb-noun) |
+| description | string | yes | Human-readable description |
+| paths | string[] | yes | Glob patterns. Supports `${PROJECT_ROOT}`, `${HOME}`, `${GIT_ROOT}`, `**`, `*` |
+| operations | string[] | yes | `read`, `write`, `delete`, `stat`, `list`, `open`, `create`, `mkdir`, `chmod`, `rename`, `rmdir`, `readlink`, `*` |
+| decision | string | yes | `allow`, `deny`, `approve`, `redirect`, `soft_delete` |
+| message | string | no | Template string for approve decisions. Variables: `{{.Path}}` |
+| timeout | duration | no | Approval timeout (e.g., `5m`, `30s`) |
+| redirect_to | string | no | Target directory for redirected file operations |
+| preserve_tree | bool | no | Preserve directory structure under redirect target |
+
+### network_rules[]
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| description | string | yes | Human-readable description |
+| domains | string[] | no | Domain glob patterns (e.g., `*.stripe.com`). At least one of domains/ports/cidrs required. |
+| ports | int[] | no | Port numbers (e.g., `[443, 80]`) |
+| cidrs | string[] | no | CIDR ranges (e.g., `10.0.0.0/8`) |
+| decision | string | yes | `allow`, `deny`, `approve` |
+| message | string | no | Template. Variables: `{{.RemoteAddr}}`, `{{.RemotePort}}` |
+| timeout | duration | no | Approval timeout |
+
+### command_rules[]
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| description | string | no | Human-readable description |
+| commands | string[] | yes | Command names (basename matching, glob supported) |
+| args_patterns | string[] | no | Regex patterns matched against the full argument string |
+| decision | string | yes | `allow`, `deny`, `approve`, `redirect` |
+| message | string | no | Template. Variables: `{{.Args}}` |
+| redirect_to | object | no | For redirect decision: `{command, args[], args_append[], environment{}}` |
+| context | object | no | Process ancestry context (see below) |
+| env_allow | string[] | no | Per-command env allowlist (glob) |
+| env_deny | string[] | no | Per-command env denylist (glob) |
+| env_max_bytes | int | no | Max env size for this command |
+| env_max_keys | int | no | Max env keys for this command |
+| env_block_iteration | bool | no | Block env enumeration for this command |
+
+**command_rules[].context:**
+
+Two syntaxes supported:
+
+Array form (shorthand):
+```yaml
+context: [direct]              # Only processes spawned directly by the agent
+context: [nested]              # Only subprocesses of subprocesses (depth > 0)
+context: [direct, nested]      # All depths (default)
+```
+
+Object form (explicit):
+```yaml
+context:
+  min_depth: 0                 # Minimum process ancestry depth
+  max_depth: -1                # Maximum depth (-1 = unlimited)
+```
+
+Default (if omitted): all depths (`min_depth: 0`, `max_depth: -1`).
+
+**command_rules[].redirect_to object:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| command | string | Replacement command to execute |
+| args | string[] | Arguments prepended before original args |
+| args_append | string[] | Arguments appended after original args |
+| environment | map[string]string | Environment variable overrides |
+
+### unix_socket_rules[]
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| description | string | yes | Human-readable description |
+| paths | string[] | yes | Socket paths. `@name` for abstract namespace. |
+| operations | string[] | no | `connect`, `bind`, `listen`, `sendto`. Empty = all. |
+| decision | string | yes | `allow`, `deny`, `approve` |
+| message | string | no | Approval message |
+| timeout | duration | no | Approval timeout |
+
+### registry_rules[] (Windows only)
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| description | string | yes | Human-readable description |
+| paths | string[] | yes | Registry key paths (e.g., `HKLM\SOFTWARE\...`) |
+| operations | string[] | yes | `read`, `write`, `delete`, `create`, `rename` |
+| decision | string | yes | `allow`, `deny`, `approve` |
+| message | string | no | Approval message |
+| timeout | duration | no | Approval timeout |
+| priority | int | no | Higher = evaluated first |
+| cache_ttl | duration | no | Per-rule cache TTL |
+| notify | bool | no | Always emit notification |
+
+### signal_rules[]
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| description | string | yes | Human-readable description |
+| signals | string[] | yes | Signal names, numbers, or groups: `@all`, `@fatal`, `@job`, `@reload` |
+| target | object | yes | `{type, pattern?, min?, max?}`. Types: `self`, `children`, `parent`, `session`, `external`, `system`, `pid_range` |
+| decision | string | yes | `allow`, `deny`, `audit`, `approve`, `redirect`, `absorb` |
+| fallback | string | no | Fallback decision if platform can't enforce |
+| redirect_to | string | no | Target signal name (for redirect decision) |
+| message | string | no | Human-readable message |
+| timeout | duration | no | Approval timeout |
+
+**signal_rules[].target object:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| type | string | `self`, `children`, `parent`, `session`, `external`, `system` |
+| pattern | string | Process name pattern (optional) |
+| min | int | Min PID for pid_range type (optional) |
+| max | int | Max PID for pid_range type (optional) |
+
+### dns_redirects[]
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| match | string | yes | Regex pattern for hostname |
+| resolve_to | string | yes | IP address to return |
+| visibility | string | no | `silent`, `audit_only`, `warn` |
+| on_failure | string | no | `fail_closed`, `fail_open`, `retry_original` |
+
+### connect_redirects[]
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| match | string | yes | Regex pattern for `host:port` |
+| redirect_to | string | yes | New `host:port` destination |
+| tls | object | no | `{mode, sni?}`. Modes: `passthrough`, `rewrite_sni` |
+| visibility | string | no | `silent`, `audit_only`, `warn` |
+| message | string | no | Human-readable message |
+| on_failure | string | no | `fail_closed`, `fail_open`, `retry_original` |
+
+**connect_redirects[].tls object:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| mode | string | `passthrough` or `rewrite_sni` |
+| sni | string | Required when mode is `rewrite_sni` |
+
+---
+
+## Top-Level Settings
+
+### resource_limits
+
+| Field | Type | Description |
+|-------|------|-------------|
+| max_memory_mb | int | Max memory in MB |
+| memory_swap_max_mb | int | Max swap in MB (0 = disable) |
+| cpu_quota_percent | int | Max CPU % of one core |
+| disk_read_bps_max | int64 | Max disk read bytes/sec |
+| disk_write_bps_max | int64 | Max disk write bytes/sec |
+| net_bandwidth_mbps | int | Max network bandwidth Mbps |
+| pids_max | int | Max process count |
+| command_timeout | duration | Max time per command |
+| session_timeout | duration | Max session lifetime |
+| idle_timeout | duration | Kill after idle period |
+
+### env_policy
+
+| Field | Type | Description |
+|-------|------|-------------|
+| allow | string[] | Glob patterns for allowed env vars |
+| deny | string[] | Glob patterns for denied env vars |
+| max_bytes | int | Max total env size |
+| max_keys | int | Max number of env vars |
+| block_iteration | bool | Hide env enumeration |
+
+### audit
+
+| Field | Type | Description |
+|-------|------|-------------|
+| log_allowed | bool | Log allowed operations |
+| log_denied | bool | Log denied operations |
+| log_approved | bool | Log approved operations |
+| include_stdout | bool | Include stdout in logs |
+| include_stderr | bool | Include stderr in logs |
+| include_file_content | bool | Include file content in logs |
+| retention_days | int | Log retention period |
+
+### env_inject
+
+Simple `map[string]string` — key-value pairs of environment variables to inject into all processes. Example:
+
+```yaml
+env_inject:
+  BASH_ENV: "/etc/agentsh/bash_restricted.sh"
+  NODE_OPTIONS: "--max-old-space-size=512"
+```
+
+### mcp_rules
+
+| Field | Type | Description |
+|-------|------|-------------|
+| enforce_policy | bool | Enable MCP enforcement |
+| tool_policy | string | `allowlist` or `blocklist` |
+| allowed_tools | object[] | `[{server, tool, content_hash?}]` |
+| allowed_servers | object[] | `[{id}]` |
+| server_policy | string | Server list policy |
+| version_pinning | object | `{enabled, on_change?, auto_trust_first?}` |
+| cross_server | object | `{enabled, read_then_send?: {enabled}}` |
+
+### package_rules[]
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| match | object | yes | `{packages?, name_patterns?, finding_type?, severity?, reasons?, license_spdx?: {allow?, deny?}, ecosystem?}` |
+| action | string | yes | `allow`, `warn`, `approve`, `block` |
+| reason | string | no | Explanation |
+
+**package_rules[].match object:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| packages | string[] | Exact package names |
+| name_patterns | string[] | Glob patterns for package names |
+| finding_type | string | `vulnerability`, `license`, etc. |
+| severity | string | `critical`, `high`, `medium`, `low`, `info` |
+| reasons | string[] | Match specific reason codes |
+| license_spdx | object | `{allow?: string[], deny?: string[]}` SPDX license matching |
+| ecosystem | string | `npm`, `pypi` |
+
+### process_contexts (map[string]ProcessContext)
+
+A map where each key is a context name and each value is a `ProcessContext` object.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| description | string | Context description |
+| identities | string[] | Process identity names that trigger this context |
+| chain_rules | object[] | Escape-hatch detection rules (evaluated before context rules) |
+| command_rules | CommandRule[] | Override command rules |
+| file_rules | FileRule[] | Override file rules |
+| network_rules | NetworkRule[] | Override network rules |
+| unix_socket_rules | UnixSocketRule[] | Override unix socket rules |
+| env_policy | EnvPolicy | Override env policy |
+| allowed_commands | string[] | Quick allow list |
+| denied_commands | string[] | Quick deny list |
+| require_approval | string[] | Quick approval list |
+| command_overrides | map | Per-command arg filtering (`{args_allow?, args_deny?, default?}`) |
+| default_decision | string | `allow`, `deny`, `approve` (default: `deny`) |
+| max_depth | int | Max ancestry depth (0 = unlimited) |
+| stop_at | string[] | Stop taint propagation at these process classes |
+| pass_through | string[] | Classes that inherit context but don't count toward depth |
+| race_policy | object | `{on_missing_parent?, on_pid_mismatch?, on_validation_error?, log_race_conditions?}` |
+
+> **Note:** `stop_at`, `pass_through`, and `race_policy` are advanced ancestry-control fields rarely needed by most policy authors.
+
+### process_identities (map[string]ProcessIdentityConfig)
+
+A map where each key is an identity name and each value is a `ProcessIdentityConfig` object.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| description | string | Identity description |
+| linux | object | `{comm?, exe_path?, cmdline?}` |
+| darwin | object | `{comm?, exe_path?, cmdline?, bundle_id?}` |
+| windows | object | `{comm?, exe_path?, cmdline?, exe_name?}` |
+| all_platforms | object | Same fields, applies everywhere |
+
+Each platform object accepts arrays of patterns:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| comm | string[] | Process name patterns |
+| exe_path | string[] | Executable path patterns |
+| cmdline | string[] | Command line patterns |
+| bundle_id | string[] | macOS bundle ID (darwin only) |
+| exe_name | string[] | Windows exe name (windows only) |
+
+### transparent_commands
+
+| Field | Type | Description |
+|-------|------|-------------|
+| add | string[] | Additional transparent commands |
+| remove | string[] | Remove from built-in defaults |
+
+---
+
+## Evaluation Semantics
+
+- **First match wins**: Rules within each category are evaluated top-to-bottom. The first rule whose pattern matches determines the decision. Order matters.
+- **Default deny**: Convention is to end each rule category with a catch-all deny rule (e.g., `paths: ["**"]`, `domains: ["*"]`).
+- **Variable expansion**: `${PROJECT_ROOT}`, `${HOME}`, `${GIT_ROOT}` are expanded at load time.
+- **Glob syntax**: `*` matches any characters except `/`. `**` matches any characters including `/`. `?` matches one character.
+- **Regex syntax**: `args_patterns`, `dns_redirects[].match`, and `connect_redirects[].match` use Go regexp syntax.
+- **Duration syntax**: Go duration strings — `5m`, `30s`, `1h`, `4h30m`.
+
+---
+
+## Idiomatic Examples
+
+**Allow a specific domain:**
+```yaml
+- name: allow-stripe
+  description: Stripe API access
+  domains:
+    - "api.stripe.com"
+    - "*.stripe.com"
+  ports: [443]
+  decision: allow
+```
+
+**Block a sensitive path:**
+```yaml
+- name: deny-docker-socket
+  description: Block Docker socket access
+  paths:
+    - "/var/run/docker.sock"
+  operations: ["*"]
+  decision: deny
+```
+
+**Require approval for a command with specific args:**
+```yaml
+- name: approve-npm-publish
+  description: Require approval for npm publish
+  commands: [npm]
+  args_patterns: ["publish.*"]
+  decision: approve
+  message: "Agent wants to publish: {{.Args}}"
+```
+
+**Redirect a dangerous command:**
+```yaml
+- name: redirect-rm-rf
+  description: Redirect rm -rf to safe alternative
+  commands: [rm]
+  args_patterns: [".*-rf.*"]
+  decision: redirect
+  redirect_to:
+    command: echo
+    args: ["rm -rf blocked. Use targeted deletes instead."]
+```

--- a/skills/agentsh-policy-shared/schema-reference.md
+++ b/skills/agentsh-policy-shared/schema-reference.md
@@ -12,7 +12,7 @@ Field names and types are verified against `internal/policy/model.go`.
 
 ```yaml
 version: 1                    # Required. Always 1.
-name: "policy-name"           # Required. Alphanumeric + hyphens.
+name: "policy-name"           # Required. Alphanumeric, hyphens, underscores.
 description: |                # Required. Multi-line description.
   What this policy does.
 
@@ -161,7 +161,7 @@ Default (if omitted): all depths (`min_depth: 0`, `max_depth: -1`).
 | type | string | `self`, `children`, `descendants`, `siblings`, `parent`, `session`, `external`, `system`, `user`, `process`, `pid_range` |
 | pattern | string | Process name glob pattern (only for `type: process`) |
 | min | int | Required when `type: pid_range`. Must be > 0, min <= max. |
-| max | int | Required when `type: pid_range`. Must be > 0, min >= min. |
+| max | int | Required when `type: pid_range`. Must be > 0, max >= min. |
 
 ### dns_redirects[]
 

--- a/skills/agentsh-policy-shared/schema-reference.md
+++ b/skills/agentsh-policy-shared/schema-reference.md
@@ -158,7 +158,7 @@ Default (if omitted): all depths (`min_depth: 0`, `max_depth: -1`).
 
 | Field | Type | Description |
 |-------|------|-------------|
-| type | string | `self`, `children`, `parent`, `session`, `external`, `system` |
+| type | string | `self`, `children`, `parent`, `session`, `external`, `system`, `pid_range` |
 | pattern | string | Process name pattern (optional) |
 | min | int | Min PID for pid_range type (optional) |
 | max | int | Max PID for pid_range type (optional) |


### PR DESCRIPTION
## Summary

- **Two new skills** for creating and editing AgentSH policy YAML files from any LLM environment (Claude Code, NanoClaw, etc.)
  - `agentsh-policy-create` — template-based new policy creation with use-case mapping and customization
  - `agentsh-policy-edit` — targeted rule add/remove/update with first-match-wins ordering awareness
- **Shared schema reference** (`schema-reference.md`) — self-contained YAML-facing schema covering all 17 rule categories, evaluation semantics, and idiomatic examples
- **Design spec and implementation plan** in `docs/superpowers/`

## Test plan

- [x] Subagent test: create policy for AI coding agent (valid YAML, correct template, credential blocking, default-deny catch-alls)
- [x] Subagent test: add network rule to existing policy (correct insertion before catch-all, minimal edit)
- [x] Subagent test: remove command rule (correct identification, ordering side-effects warned)
- [x] Subagent test: modify resource limits (only target fields changed, others preserved)
- [x] Schema spot-checked against `internal/policy/model.go` and `internal/signal/target.go`
- [x] Roborev branch review passed with no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)