### PR TITLE
feat: hybrid ptrace-execve + seccomp wrapper mode for exe.dev

### DIFF
--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -118,8 +118,10 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 		return earlyReturn()
 	}
 
-	// Ptrace mode: no wrapper, no seccomp notify sockets
-	if a.ptraceTracer != nil {
+	// Full ptrace mode: skip wrapper (ptrace handles everything).
+	// Hybrid mode (execve-only ptrace): fall through to use wrapper for
+	// socket/file monitoring and Landlock — ptrace only handles execve.
+	if a.ptraceTracer != nil && !a.cfg.Sandbox.Ptrace.IsExecveOnly() {
 		return earlyReturn()
 	}
 
@@ -187,6 +189,9 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 
 	// Pass seccomp configuration to the wrapper
 	execveEnabled := a.cfg.Sandbox.Seccomp.Execve.Enabled
+	if a.ptraceTracer != nil {
+		execveEnabled = false // ptrace handles execve; don't trap in seccomp USER_NOTIF
+	}
 	seccompCfg := seccompWrapperConfig{
 		UnixSocketEnabled:   a.cfg.Sandbox.Seccomp.UnixSocket.Enabled,
 		BlockedSyscalls:     a.cfg.Sandbox.Seccomp.Syscalls.Block,

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -295,17 +295,12 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			// 1. Attach ptrace (prefilter injected at first syscall exit)
 			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
 			if attachErr != nil {
-				// Keep cancellation watcher alive for the fallback cmd.Wait() path.
-				// Deferred close ensures the goroutine exits when the function returns.
-				defer close(ptraceDone)
-				slog.Warn("hybrid mode: ptrace attach failed, falling back to wrapper-only",
-					"error", attachErr, "pid", cmd.Process.Pid)
-				if hook != nil {
-					slog.Warn("hybrid mode: cgroup/eBPF hook skipped (process not stopped)",
-						"pid", cmd.Process.Pid)
-				}
-				// Fall through: startWrapperHandlers below will start wrapper-only mode.
-				// Process will use cmd.Wait() path at bottom of function.
+				close(ptraceDone)
+				_ = killProcess(cmd.Process.Pid)
+				_ = killProcessGroup(pgid)
+				pipeWG.Wait()
+				cmd.Process.Release()
+				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid ptrace attach: %w", attachErr)
 			} else {
 				// 2. Start wrapper handlers (receives FD, sends ACK)
 				startWrapperHandlers(ctx, extra, cmd.Process.Pid, pgid)

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -307,7 +307,10 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 
 				// 3. Run hook while process stopped (cgroup/eBPF setup)
 				if hook != nil {
-					if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {
+					if cleanup, hookErr := hook(cmd.Process.Pid); hookErr != nil {
+						slog.Warn("hybrid mode: cgroup/eBPF hook failed (continuing without resource controls)",
+							"error", hookErr, "pid", cmd.Process.Pid)
+					} else if cleanup != nil {
 						defer func() { _ = cleanup() }()
 					}
 				}

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -295,7 +295,9 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			// 1. Attach ptrace (prefilter injected at first syscall exit)
 			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
 			if attachErr != nil {
-				close(ptraceDone)
+				// Keep cancellation watcher alive for the fallback cmd.Wait() path.
+				// Deferred close ensures the goroutine exits when the function returns.
+				defer close(ptraceDone)
 				slog.Warn("hybrid mode: ptrace attach failed, falling back to wrapper-only",
 					"error", attachErr, "pid", cmd.Process.Pid)
 				if hook != nil {

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -279,7 +279,8 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 
 		// If we started with ptrace (stopped), run the hook BEFORE resuming.
 		// This ensures eBPF/cgroups are attached before the process executes.
-		if tracer != nil && extra != nil && extra.notifyParentSock != nil {
+		hasWrapperHandlers := extra != nil && (extra.notifyParentSock != nil || (extra.signalParentSock != nil && extra.signalEngine != nil))
+		if tracer != nil && hasWrapperHandlers {
 			// HYBRID MODE: ptrace for execve interception + seccomp wrapper for sockets/files/Landlock.
 			ptraceDone := make(chan struct{})
 			go func() {

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -279,7 +279,78 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 
 		// If we started with ptrace (stopped), run the hook BEFORE resuming.
 		// This ensures eBPF/cgroups are attached before the process executes.
-		if tracer != nil {
+		if tracer != nil && extra != nil && extra.notifyParentSock != nil {
+			// HYBRID MODE: ptrace for execve interception + seccomp wrapper for sockets/files/Landlock.
+			ptraceDone := make(chan struct{})
+			go func() {
+				select {
+				case <-ctx.Done():
+					_ = killProcessGroup(pgid)
+					_ = killProcess(cmd.Process.Pid)
+				case <-ptraceDone:
+				}
+			}()
+
+			// 1. Attach ptrace (prefilter injected at first syscall exit)
+			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
+			if attachErr != nil {
+				close(ptraceDone)
+				slog.Warn("hybrid mode: ptrace attach failed, falling back to wrapper-only",
+					"error", attachErr, "pid", cmd.Process.Pid)
+				// Fall through: startWrapperHandlers below will start wrapper-only mode.
+				// Process will use cmd.Wait() path at bottom of function.
+			} else {
+				// 2. Start wrapper handlers (receives FD, sends ACK)
+				startWrapperHandlers(ctx, extra, cmd.Process.Pid, pgid)
+
+				// 3. Run hook while process stopped (cgroup/eBPF setup)
+				if hook != nil {
+					if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {
+						defer func() { _ = cleanup() }()
+					}
+				}
+				if resume != nil {
+					if resumeErr := resume(); resumeErr != nil {
+						close(ptraceDone)
+						_ = killProcess(cmd.Process.Pid)
+						_ = killProcessGroup(pgid)
+						pipeWG.Wait()
+						cmd.Process.Release()
+						return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
+					}
+				}
+
+				// 4. Wait for exit via ptrace exit channel
+				waitStart := time.Now()
+				slog.Debug("exec waiting for command (hybrid)", "command", req.Command, "pid", cmd.Process.Pid)
+				result := waitExit()
+				close(ptraceDone)
+				if result.err != nil {
+					_ = killProcess(cmd.Process.Pid)
+					_ = killProcessGroup(pgid)
+				}
+				waitDuration := time.Since(waitStart)
+				slog.Debug("exec command finished (hybrid)", "command", req.Command, "pid", cmd.Process.Pid, "exit_code", result.exitCode, "wait_duration_ms", waitDuration.Milliseconds())
+				pipeWG.Wait()
+				stdout, stderr = stdoutW.Bytes(), stderrW.Bytes()
+				stdoutTotal, stderrTotal = stdoutW.total, stderrW.total
+				stdoutTrunc, stderrTrunc = stdoutW.truncated, stderrW.truncated
+				resources = result.resources
+				cmd.Process.Release()
+
+				if ctx.Err() != nil {
+					_ = killProcessGroup(pgid)
+				}
+				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+					return 124, stdout, append(stderr, []byte("command timed out\n")...), stdoutTotal, stderrTotal + int64(len("command timed out\n")), true, true, resources, ctx.Err()
+				}
+				if errors.Is(ctx.Err(), context.Canceled) {
+					return 127, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, ctx.Err()
+				}
+				return result.exitCode, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, result.err
+			}
+		} else if tracer != nil {
+			// FULL PTRACE MODE: ptrace handles everything (no seccomp wrapper).
 			// Context cancellation watcher: start BEFORE attach so timeout
 			// is enforced even if WaitAttached stalls.
 			ptraceDone := make(chan struct{})
@@ -361,23 +432,8 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			}
 		}
 
-		// Start unix socket notify handler if configured (Linux only).
-		// The handler receives the notify fd from the wrapper and runs until ctx is cancelled.
-		if extra != nil && extra.notifyParentSock != nil {
-			startNotifyHandler(ctx, extra.notifyParentSock, extra.notifySessionID, extra.notifyPolicy, extra.notifyStore, extra.notifyBroker, extra.execveHandler, extra.fileMonitorCfg, extra.landlockEnabled)
-		}
-
-		// Start signal filter handler if configured (Linux only).
-		// The handler receives the signal filter fd from the wrapper and runs until ctx is cancelled.
-		if extra != nil && extra.signalParentSock != nil && extra.signalEngine != nil {
-			// Register the spawned process in the signal registry
-			if extra.signalRegistry != nil {
-				extra.signalRegistry.Register(cmd.Process.Pid, pgid, extra.origCommand)
-			}
-			startSignalHandler(ctx, extra.signalParentSock, extra.notifySessionID, cmd.Process.Pid,
-				extra.signalEngine, extra.signalRegistry,
-				extra.notifyStore, extra.notifyBroker, extra.signalCommandID)
-		}
+		// Start wrapper handlers (wrapper-only path + hybrid fallback).
+		startWrapperHandlers(ctx, extra, cmd.Process.Pid, pgid)
 	}
 
 	waitStart := time.Now()
@@ -607,6 +663,25 @@ func mergeEnv(base []string, s *session.Session, overrides map[string]string) []
 		return []string{}
 	}
 	return env
+}
+
+// startWrapperHandlers starts the seccomp notify handler and signal filter handler
+// if configured. Used by both regular exec and hybrid ptrace+wrapper mode.
+func startWrapperHandlers(ctx context.Context, extra *extraProcConfig, pid, pgid int) {
+	if extra == nil {
+		return
+	}
+	if extra.notifyParentSock != nil {
+		startNotifyHandler(ctx, extra.notifyParentSock, extra.notifySessionID, extra.notifyPolicy, extra.notifyStore, extra.notifyBroker, extra.execveHandler, extra.fileMonitorCfg, extra.landlockEnabled)
+	}
+	if extra.signalParentSock != nil && extra.signalEngine != nil {
+		if extra.signalRegistry != nil {
+			extra.signalRegistry.Register(pid, pgid, extra.origCommand)
+		}
+		startSignalHandler(ctx, extra.signalParentSock, extra.notifySessionID, pid,
+			extra.signalEngine, extra.signalRegistry,
+			extra.notifyStore, extra.notifyBroker, extra.signalCommandID)
+	}
 }
 
 // mergeEnvInject merges env_inject from global config and policy.

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -297,6 +297,10 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 				close(ptraceDone)
 				slog.Warn("hybrid mode: ptrace attach failed, falling back to wrapper-only",
 					"error", attachErr, "pid", cmd.Process.Pid)
+				if hook != nil {
+					slog.Warn("hybrid mode: cgroup/eBPF hook skipped (process not stopped)",
+						"pid", cmd.Process.Pid)
+				}
 				// Fall through: startWrapperHandlers below will start wrapper-only mode.
 				// Process will use cmd.Wait() path at bottom of function.
 			} else {

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -399,17 +399,12 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			// 1. Attach ptrace (prefilter injected at first syscall exit)
 			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
 			if attachErr != nil {
-				// Keep cancellation watcher alive for the fallback cmd.Wait() path.
-				// Deferred close ensures the goroutine exits when the function returns.
-				defer close(ptraceDone)
-				slog.Warn("hybrid mode: ptrace attach failed, falling back to wrapper-only",
-					"error", attachErr, "pid", cmd.Process.Pid)
-				if hook != nil {
-					slog.Warn("hybrid mode: cgroup/eBPF hook skipped (process not stopped)",
-						"pid", cmd.Process.Pid)
-				}
-				// Fall through: startWrapperHandlers below will start wrapper-only mode.
-				// Process will use cmd.Wait() path at bottom of function.
+				close(ptraceDone)
+				_ = killProcess(cmd.Process.Pid)
+				_ = killProcessGroup(pgid)
+				pipeWG.Wait()
+				cmd.Process.Release()
+				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid ptrace attach: %w", attachErr)
 			} else {
 				// 2. Start wrapper handlers (receives FD, sends ACK)
 				startWrapperHandlers(ctx, extra, cmd.Process.Pid, pgid)

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -383,7 +383,8 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 		s.SetCurrentProcessPID(cmd.Process.Pid)
 		pgid = getProcessGroupID(cmd.Process.Pid)
 
-		if tracer != nil && extra != nil && extra.notifyParentSock != nil {
+		hasWrapperHandlers := extra != nil && (extra.notifyParentSock != nil || (extra.signalParentSock != nil && extra.signalEngine != nil))
+		if tracer != nil && hasWrapperHandlers {
 			// HYBRID MODE: ptrace for execve interception + seccomp wrapper for sockets/files/Landlock.
 			ptraceDone := make(chan struct{})
 			go func() {

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -401,6 +401,10 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 				close(ptraceDone)
 				slog.Warn("hybrid mode: ptrace attach failed, falling back to wrapper-only",
 					"error", attachErr, "pid", cmd.Process.Pid)
+				if hook != nil {
+					slog.Warn("hybrid mode: cgroup/eBPF hook skipped (process not stopped)",
+						"pid", cmd.Process.Pid)
+				}
 				// Fall through: startWrapperHandlers below will start wrapper-only mode.
 				// Process will use cmd.Wait() path at bottom of function.
 			} else {

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -399,7 +399,9 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			// 1. Attach ptrace (prefilter injected at first syscall exit)
 			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
 			if attachErr != nil {
-				close(ptraceDone)
+				// Keep cancellation watcher alive for the fallback cmd.Wait() path.
+				// Deferred close ensures the goroutine exits when the function returns.
+				defer close(ptraceDone)
 				slog.Warn("hybrid mode: ptrace attach failed, falling back to wrapper-only",
 					"error", attachErr, "pid", cmd.Process.Pid)
 				if hook != nil {

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -411,7 +411,10 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 
 				// 3. Run hook while process stopped (cgroup/eBPF setup)
 				if hook != nil {
-					if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {
+					if cleanup, hookErr := hook(cmd.Process.Pid); hookErr != nil {
+						slog.Warn("hybrid mode: cgroup/eBPF hook failed (continuing without resource controls)",
+							"error", hookErr, "pid", cmd.Process.Pid)
+					} else if cleanup != nil {
 						defer func() { _ = cleanup() }()
 					}
 				}

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -383,7 +383,78 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 		s.SetCurrentProcessPID(cmd.Process.Pid)
 		pgid = getProcessGroupID(cmd.Process.Pid)
 
-		if tracer != nil {
+		if tracer != nil && extra != nil && extra.notifyParentSock != nil {
+			// HYBRID MODE: ptrace for execve interception + seccomp wrapper for sockets/files/Landlock.
+			ptraceDone := make(chan struct{})
+			go func() {
+				select {
+				case <-ctx.Done():
+					_ = killProcessGroup(pgid)
+					_ = killProcess(cmd.Process.Pid)
+				case <-ptraceDone:
+				}
+			}()
+
+			// 1. Attach ptrace (prefilter injected at first syscall exit)
+			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
+			if attachErr != nil {
+				close(ptraceDone)
+				slog.Warn("hybrid mode: ptrace attach failed, falling back to wrapper-only",
+					"error", attachErr, "pid", cmd.Process.Pid)
+				// Fall through: startWrapperHandlers below will start wrapper-only mode.
+				// Process will use cmd.Wait() path at bottom of function.
+			} else {
+				// 2. Start wrapper handlers (receives FD, sends ACK)
+				startWrapperHandlers(ctx, extra, cmd.Process.Pid, pgid)
+
+				// 3. Run hook while process stopped (cgroup/eBPF setup)
+				if hook != nil {
+					if cleanup, hookErr := hook(cmd.Process.Pid); hookErr == nil && cleanup != nil {
+						defer func() { _ = cleanup() }()
+					}
+				}
+				if resume != nil {
+					if resumeErr := resume(); resumeErr != nil {
+						close(ptraceDone)
+						_ = killProcess(cmd.Process.Pid)
+						_ = killProcessGroup(pgid)
+						pipeWG.Wait()
+						cmd.Process.Release()
+						return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
+					}
+				}
+
+				// 4. Wait for exit via ptrace exit channel
+				waitStart := time.Now()
+				slog.Debug("exec_stream waiting for command (hybrid)", "command", req.Command, "pid", cmd.Process.Pid)
+				result := waitExit()
+				close(ptraceDone)
+				if result.err != nil {
+					_ = killProcess(cmd.Process.Pid)
+					_ = killProcessGroup(pgid)
+				}
+				waitDuration := time.Since(waitStart)
+				slog.Debug("exec_stream command finished (hybrid)", "command", req.Command, "pid", cmd.Process.Pid, "exit_code", result.exitCode, "wait_duration_ms", waitDuration.Milliseconds())
+				pipeWG.Wait()
+				stdout, stderr = stdoutW.Bytes(), stderrW.Bytes()
+				stdoutTotal, stderrTotal = stdoutW.total, stderrW.total
+				stdoutTrunc, stderrTrunc = stdoutW.truncated, stderrW.truncated
+				resources = result.resources
+				cmd.Process.Release()
+
+				if ctx.Err() != nil {
+					_ = killProcessGroup(pgid)
+				}
+				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+					return 124, stdout, append(stderr, []byte("command timed out\n")...), stdoutTotal, stderrTotal + int64(len("command timed out\n")), true, true, resources, ctx.Err()
+				}
+				if errors.Is(ctx.Err(), context.Canceled) {
+					return 127, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, ctx.Err()
+				}
+				return result.exitCode, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, result.err
+			}
+		} else if tracer != nil {
+			// FULL PTRACE MODE: ptrace handles everything (no seccomp wrapper).
 			// Context cancellation watcher: start BEFORE attach
 			ptraceDone := make(chan struct{})
 			go func() {
@@ -459,23 +530,8 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			}
 		}
 
-		// Start unix socket notify handler if configured (Linux only).
-		// The handler receives the notify fd from the wrapper and runs until ctx is cancelled.
-		if extra != nil && extra.notifyParentSock != nil {
-			startNotifyHandler(ctx, extra.notifyParentSock, extra.notifySessionID, extra.notifyPolicy, extra.notifyStore, extra.notifyBroker, extra.execveHandler, extra.fileMonitorCfg, extra.landlockEnabled)
-		}
-
-		// Start signal filter handler if configured (Linux only).
-		// The handler receives the signal filter fd from the wrapper and runs until ctx is cancelled.
-		if extra != nil && extra.signalParentSock != nil && extra.signalEngine != nil {
-			// Register the spawned process in the signal registry
-			if extra.signalRegistry != nil {
-				extra.signalRegistry.Register(cmd.Process.Pid, pgid, extra.origCommand)
-			}
-			startSignalHandler(ctx, extra.signalParentSock, extra.notifySessionID, cmd.Process.Pid,
-				extra.signalEngine, extra.signalRegistry,
-				extra.notifyStore, extra.notifyBroker, extra.signalCommandID)
-		}
+		// Start wrapper handlers (wrapper-only path + hybrid fallback).
+		startWrapperHandlers(ctx, extra, cmd.Process.Pid, pgid)
 	}
 
 	waitStart := time.Now()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -359,9 +359,9 @@ func (c *SandboxConfig) Validate() error {
 	}
 	if c.Ptrace.Enabled && c.UnixSockets.Enabled != nil && *c.UnixSockets.Enabled {
 		// Hybrid mode: ptrace for execve + seccomp wrapper for sockets/files is allowed
-		// when ptrace only traces execve (file/network/signal disabled).
-		if c.Ptrace.Trace.File || c.Ptrace.Trace.Network || c.Ptrace.Trace.Signal {
-			return fmt.Errorf("sandbox.ptrace with file/network/signal tracing requires unix_sockets disabled; use ptrace.trace execve-only for hybrid mode")
+		// only when ptrace traces exactly execve (file/network/signal disabled, execve enabled).
+		if !c.Ptrace.IsExecveOnly() {
+			return fmt.Errorf("sandbox.ptrace with unix_sockets requires execve-only tracing (execve=true, file/network/signal=false)")
 		}
 	}
 	return c.Ptrace.Validate()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -358,7 +358,11 @@ func (c *SandboxConfig) Validate() error {
 		return fmt.Errorf("sandbox.ptrace and sandbox.seccomp.execve are mutually exclusive")
 	}
 	if c.Ptrace.Enabled && c.UnixSockets.Enabled != nil && *c.UnixSockets.Enabled {
-		return fmt.Errorf("sandbox.ptrace and sandbox.unix_sockets are mutually exclusive")
+		// Hybrid mode: ptrace for execve + seccomp wrapper for sockets/files is allowed
+		// when ptrace only traces execve (file/network/signal disabled).
+		if c.Ptrace.Trace.File || c.Ptrace.Trace.Network || c.Ptrace.Trace.Signal {
+			return fmt.Errorf("sandbox.ptrace with file/network/signal tracing requires unix_sockets disabled; use ptrace.trace execve-only for hybrid mode")
+		}
 	}
 	return c.Ptrace.Validate()
 }

--- a/internal/config/ptrace.go
+++ b/internal/config/ptrace.go
@@ -15,6 +15,14 @@ type SandboxPtraceConfig struct {
 	OnAttachFailure string                  `yaml:"on_attach_failure"`
 }
 
+// IsExecveOnly returns true when ptrace is enabled and configured to trace
+// only execve syscalls (file, network, signal tracing all disabled).
+// This is the "hybrid mode" where ptrace handles execve and the seccomp
+// wrapper handles everything else.
+func (c SandboxPtraceConfig) IsExecveOnly() bool {
+	return c.Enabled && c.Trace.Execve && !c.Trace.File && !c.Trace.Network && !c.Trace.Signal
+}
+
 type PtraceTraceConfig struct {
 	Execve  bool `yaml:"execve"`
 	File    bool `yaml:"file"`

--- a/internal/config/ptrace_test.go
+++ b/internal/config/ptrace_test.go
@@ -259,3 +259,72 @@ func TestPtraceConfig_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestSandboxPtraceConfig_IsExecveOnly(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  SandboxPtraceConfig
+		want bool
+	}{
+		{
+			name: "disabled is not execve-only",
+			cfg:  DefaultPtraceConfig(),
+			want: false,
+		},
+		{
+			name: "all tracing enabled is not execve-only",
+			cfg: func() SandboxPtraceConfig {
+				c := DefaultPtraceConfig()
+				c.Enabled = true
+				return c
+			}(),
+			want: false,
+		},
+		{
+			name: "execve-only with file/network/signal disabled",
+			cfg: SandboxPtraceConfig{
+				Enabled: true,
+				Trace: PtraceTraceConfig{
+					Execve:  true,
+					File:    false,
+					Network: false,
+					Signal:  false,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "execve true but file also true",
+			cfg: SandboxPtraceConfig{
+				Enabled: true,
+				Trace: PtraceTraceConfig{
+					Execve:  true,
+					File:    true,
+					Network: false,
+					Signal:  false,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "enabled but execve false",
+			cfg: SandboxPtraceConfig{
+				Enabled: true,
+				Trace: PtraceTraceConfig{
+					Execve:  false,
+					File:    false,
+					Network: false,
+					Signal:  false,
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.IsExecveOnly(); got != tt.want {
+				t.Errorf("IsExecveOnly() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/ptrace_test.go
+++ b/internal/config/ptrace_test.go
@@ -162,7 +162,7 @@ func TestSandboxConfig_Validate_MutualExclusion(t *testing.T) {
 				}(),
 				UnixSockets: SandboxUnixSocketsConfig{Enabled: boolPtr(true)},
 			},
-			wantErr: "unix_sockets disabled",
+			wantErr: "execve-only tracing",
 		},
 		{
 			name: "ptrace execve-only + unix_sockets is valid (hybrid mode)",
@@ -201,7 +201,27 @@ func TestSandboxConfig_Validate_MutualExclusion(t *testing.T) {
 				},
 				UnixSockets: SandboxUnixSocketsConfig{Enabled: boolPtr(true)},
 			},
-			wantErr: "unix_sockets disabled",
+			wantErr: "execve-only tracing",
+		},
+		{
+			name: "ptrace no-tracing + unix_sockets rejected",
+			cfg: SandboxConfig{
+				Ptrace: SandboxPtraceConfig{
+					Enabled:    true,
+					AttachMode: "children",
+					Trace: PtraceTraceConfig{
+						Execve:  false,
+						File:    false,
+						Network: false,
+						Signal:  false,
+					},
+					Performance:     PtracePerformanceConfig{SeccompPrefilter: true, MaxTracees: 500, MaxHoldMs: 5000},
+					MaskTracerPid:   "off",
+					OnAttachFailure: "fail_open",
+				},
+				UnixSockets: SandboxUnixSocketsConfig{Enabled: boolPtr(true)},
+			},
+			wantErr: "execve-only tracing",
 		},
 		{
 			name: "ptrace + unix_sockets nil is valid",

--- a/internal/config/ptrace_test.go
+++ b/internal/config/ptrace_test.go
@@ -162,7 +162,46 @@ func TestSandboxConfig_Validate_MutualExclusion(t *testing.T) {
 				}(),
 				UnixSockets: SandboxUnixSocketsConfig{Enabled: boolPtr(true)},
 			},
-			wantErr: "mutually exclusive",
+			wantErr: "unix_sockets disabled",
+		},
+		{
+			name: "ptrace execve-only + unix_sockets is valid (hybrid mode)",
+			cfg: SandboxConfig{
+				Ptrace: SandboxPtraceConfig{
+					Enabled:    true,
+					AttachMode: "children",
+					Trace: PtraceTraceConfig{
+						Execve:  true,
+						File:    false,
+						Network: false,
+						Signal:  false,
+					},
+					Performance:     PtracePerformanceConfig{SeccompPrefilter: true, MaxTracees: 500, MaxHoldMs: 5000},
+					MaskTracerPid:   "off",
+					OnAttachFailure: "fail_open",
+				},
+				UnixSockets: SandboxUnixSocketsConfig{Enabled: boolPtr(true)},
+			},
+		},
+		{
+			name: "ptrace with file tracing + unix_sockets rejected",
+			cfg: SandboxConfig{
+				Ptrace: SandboxPtraceConfig{
+					Enabled:    true,
+					AttachMode: "children",
+					Trace: PtraceTraceConfig{
+						Execve:  true,
+						File:    true,
+						Network: false,
+						Signal:  false,
+					},
+					Performance:     PtracePerformanceConfig{SeccompPrefilter: true, MaxTracees: 500, MaxHoldMs: 5000},
+					MaskTracerPid:   "off",
+					OnAttachFailure: "fail_open",
+				},
+				UnixSockets: SandboxUnixSocketsConfig{Enabled: boolPtr(true)},
+			},
+			wantErr: "unix_sockets disabled",
 		},
 		{
 			name: "ptrace + unix_sockets nil is valid",


### PR DESCRIPTION
## Summary

- Adds hybrid execution mode: ptrace intercepts execve syscalls only, seccomp wrapper handles sockets/files/signals + applies Landlock
- Fixes 14 security test failures on exe.dev VMs (6 child execve bypass + 8 system path writes)
- BPF filter stacking: wrapper filter (USER_NOTIF for sockets/files) + ptrace prefilter (TRACE for execve) coexist without conflicts

## Changes

**Config validation** (`internal/config/`):
- `IsExecveOnly()` helper on `SandboxPtraceConfig`
- Relaxed ptrace + unix_sockets mutual exclusion: allowed when ptrace is execve-only

**Wrapper setup** (`internal/api/core.go`):
- Don't skip seccomp wrapper in hybrid mode
- Force `ExecveEnabled=false` when ptrace tracer is active

**Execution flow** (`internal/api/exec.go`, `exec_stream.go`):
- New hybrid branch: ptrace attach → start wrapper handlers → run hook → wait via ptrace exit channel
- `startWrapperHandlers()` helper extracts shared notify+signal handler startup
- Fail-closed on ptrace attach failure (kill process, return error)
- Log warnings on hook failures

## Test plan
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all pass
- [x] `GOOS=windows go build ./...` — cross-compile clean
- [x] roborev branch review — pass (no findings)
- [ ] Deploy to exe.dev VM and run 76-test security suite


🤖 Generated with [Claude Code](https://claude.com/claude-code)