### PR TITLE
fix: prevent notify handler goroutine leak in hybrid mode

### DIFF
--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -302,8 +302,12 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 				cmd.Process.Release()
 				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid ptrace attach: %w", attachErr)
 			} else {
-				// 2. Start wrapper handlers (receives FD, sends ACK)
-				startWrapperHandlers(ctx, extra, cmd.Process.Pid, pgid)
+				// 2. Start wrapper handlers with a child context that we cancel
+				// immediately after the process exits. This closes the notify FD
+				// (via the cancellation goroutine in startNotifyHandler) and
+				// unblocks any stuck NotifReceive ioctl.
+				handlerCtx, handlerCancel := context.WithCancel(ctx)
+				startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid)
 
 				// 3. Run hook while process stopped (cgroup/eBPF setup)
 				if hook != nil {
@@ -317,6 +321,7 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 				if resume != nil {
 					if resumeErr := resume(); resumeErr != nil {
 						close(ptraceDone)
+						handlerCancel()
 						_ = killProcess(cmd.Process.Pid)
 						_ = killProcessGroup(pgid)
 						pipeWG.Wait()
@@ -330,6 +335,7 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 				slog.Debug("exec waiting for command (hybrid)", "command", req.Command, "pid", cmd.Process.Pid)
 				result := waitExit()
 				close(ptraceDone)
+				handlerCancel() // Signal notify handler to exit immediately
 				if result.err != nil {
 					_ = killProcess(cmd.Process.Pid)
 					_ = killProcessGroup(pgid)

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -406,8 +406,10 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 				cmd.Process.Release()
 				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid ptrace attach: %w", attachErr)
 			} else {
-				// 2. Start wrapper handlers (receives FD, sends ACK)
-				startWrapperHandlers(ctx, extra, cmd.Process.Pid, pgid)
+				// 2. Start wrapper handlers with a child context that we cancel
+				// immediately after the process exits.
+				handlerCtx, handlerCancel := context.WithCancel(ctx)
+				startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid)
 
 				// 3. Run hook while process stopped (cgroup/eBPF setup)
 				if hook != nil {
@@ -421,6 +423,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 				if resume != nil {
 					if resumeErr := resume(); resumeErr != nil {
 						close(ptraceDone)
+						handlerCancel()
 						_ = killProcess(cmd.Process.Pid)
 						_ = killProcessGroup(pgid)
 						pipeWG.Wait()
@@ -434,6 +437,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 				slog.Debug("exec_stream waiting for command (hybrid)", "command", req.Command, "pid", cmd.Process.Pid)
 				result := waitExit()
 				close(ptraceDone)
+				handlerCancel() // Signal notify handler to exit immediately
 				if result.err != nil {
 					_ = killProcess(cmd.Process.Pid)
 					_ = killProcessGroup(pgid)

--- a/internal/api/notify_linux.go
+++ b/internal/api/notify_linux.go
@@ -224,12 +224,17 @@ func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string,
 		defer notifyFD.Close()
 
 		// Close the notify FD when context is cancelled to unblock any stuck
-		// NotifReceive ioctl. Without this, the handler goroutine can hang
-		// indefinitely after the monitored process exits if no ENOENT is
-		// delivered by the kernel.
+		// NotifReceive ioctl. The done channel ensures this goroutine exits
+		// if the handler returns early (error/setup failure) while context
+		// is still active.
+		handlerDone := make(chan struct{})
+		defer close(handlerDone)
 		go func() {
-			<-ctx.Done()
-			notifyFD.Close()
+			select {
+			case <-ctx.Done():
+				notifyFD.Close()
+			case <-handlerDone:
+			}
 		}()
 
 		emitter := &notifyEmitterAdapter{store: store, broker: broker}

--- a/internal/api/notify_linux.go
+++ b/internal/api/notify_linux.go
@@ -223,6 +223,15 @@ func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string,
 		slog.Debug("received notify fd from wrapper", "fd", notifyFD.Fd(), "session_id", sessID)
 		defer notifyFD.Close()
 
+		// Close the notify FD when context is cancelled to unblock any stuck
+		// NotifReceive ioctl. Without this, the handler goroutine can hang
+		// indefinitely after the monitored process exits if no ENOENT is
+		// delivered by the kernel.
+		go func() {
+			<-ctx.Done()
+			notifyFD.Close()
+		}()
+
 		emitter := &notifyEmitterAdapter{store: store, broker: broker}
 
 		// Create file handler if configured

--- a/internal/api/notify_linux_test.go
+++ b/internal/api/notify_linux_test.go
@@ -406,12 +406,14 @@ func TestNotifyHandler_CancellationGoroutineExitsOnEarlyReturn(t *testing.T) {
 }
 
 func TestNotifyHandler_ContextCancelCleansUpFDs(t *testing.T) {
-	// Verify that cancelling the context causes the handler goroutine
-	// to clean up and close the parent socket. We send a pipe FD through
-	// the socketpair so RecvFD succeeds, then the handler enters the
-	// serve loop. NotifReceive on a pipe FD returns an error immediately
-	// (wrong ioctl), causing the handler to exit. We then cancel the
-	// context and verify that all cleanup happened (parent socket closed).
+	// Verify that handler goroutine cleans up (closes parent socket) after
+	// the serve loop exits. We send a pipe FD so RecvFD succeeds, then
+	// NotifReceive fails immediately (wrong ioctl type). The handler exits
+	// and defer-closes the parent socket.
+	//
+	// Note: with pipe FDs, the handler exits via ioctl error, not via
+	// ctx.Done(). Testing cancellation-driven FD cleanup requires real
+	// seccomp notify FDs (integration test with CAP_SYS_ADMIN).
 
 	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
 	if err != nil {
@@ -430,7 +432,6 @@ func TestNotifyHandler_ContextCancelCleansUpFDs(t *testing.T) {
 	}
 	defer pipeW.Close()
 
-	// Send pipeR FD via SCM_RIGHTS.
 	rights := unix.UnixRights(int(pipeR.Fd()))
 	if err := unix.Sendmsg(int(childSock.Fd()), []byte{0}, rights, nil, 0); err != nil {
 		pipeR.Close()
@@ -444,14 +445,20 @@ func TestNotifyHandler_ContextCancelCleansUpFDs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	startNotifyHandler(ctx, parentSock, "test-ctx-cancel", nil, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false)
+	startNotifyHandler(ctx, parentSock, "test-fd-cleanup", nil, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false)
 
-	// Wait for handler to clean up (close parent socket).
+	// Wait for handler to clean up (close parent socket via defer).
 	deadline := time.After(2 * time.Second)
 	for {
 		select {
 		case <-deadline:
-			t.Fatal("timed out: handler didn't clean up parent socket")
+			// Last resort: cancel context to unblock if handler is stuck.
+			cancel()
+			time.Sleep(100 * time.Millisecond)
+			if int(parentSock.Fd()) != -1 {
+				t.Fatal("timed out: handler didn't clean up parent socket")
+			}
+			return
 		default:
 		}
 		if int(parentSock.Fd()) == -1 {

--- a/internal/api/notify_linux_test.go
+++ b/internal/api/notify_linux_test.go
@@ -452,13 +452,7 @@ func TestNotifyHandler_ContextCancelCleansUpFDs(t *testing.T) {
 	for {
 		select {
 		case <-deadline:
-			// Last resort: cancel context to unblock if handler is stuck.
-			cancel()
-			time.Sleep(100 * time.Millisecond)
-			if int(parentSock.Fd()) != -1 {
-				t.Fatal("timed out: handler didn't clean up parent socket")
-			}
-			return
+			t.Fatal("timed out: handler didn't clean up parent socket")
 		default:
 		}
 		if int(parentSock.Fd()) == -1 {

--- a/internal/api/notify_linux_test.go
+++ b/internal/api/notify_linux_test.go
@@ -5,6 +5,7 @@ package api
 import (
 	"context"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -347,6 +348,119 @@ func TestNotifyHandlerRecover_BlockingBroker_BoundedReturn(t *testing.T) {
 		case <-deadline:
 			t.Fatal("timed out waiting for store event")
 		default:
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestNotifyHandler_CancellationGoroutineExitsOnEarlyReturn(t *testing.T) {
+	// Verify that the cancellation goroutine (which closes the notify FD on
+	// ctx.Done) doesn't leak when the handler exits early (e.g., RecvFD fails).
+	// The handlerDone channel should signal the cancellation goroutine to exit
+	// even though the context is never cancelled.
+
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+	parentSock := os.NewFile(uintptr(fds[0]), "parent")
+	writeSock := os.NewFile(uintptr(fds[1]), "child")
+
+	store := &notifyMockEventStore{}
+	broker := &notifyMockEventBroker{}
+
+	// Close write end immediately so RecvFD fails → handler exits early.
+	writeSock.Close()
+
+	// Use a context that is NEVER cancelled — the cancellation goroutine
+	// must exit via the handlerDone channel, not ctx.Done().
+	ctx := context.Background()
+
+	goroutinesBefore := runtime.NumGoroutine()
+
+	startNotifyHandler(ctx, parentSock, "test-cancel-goroutine", nil, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false)
+
+	// Wait for handler goroutine to exit.
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for handler goroutine to exit")
+		default:
+		}
+		if int(parentSock.Fd()) == -1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// Allow goroutines to settle.
+	time.Sleep(50 * time.Millisecond)
+
+	goroutinesAfter := runtime.NumGoroutine()
+	// Tolerate ±2 for GC/runtime goroutines.
+	if goroutinesAfter > goroutinesBefore+2 {
+		t.Errorf("goroutine leak: before=%d after=%d (expected ≤%d)",
+			goroutinesBefore, goroutinesAfter, goroutinesBefore+2)
+	}
+}
+
+func TestNotifyHandler_ContextCancelCleansUpFDs(t *testing.T) {
+	// Verify that cancelling the context causes the handler to clean up
+	// (close parent socket). This tests the path where RecvFD succeeds
+	// but the serve loop exits due to a non-seccomp FD.
+
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+	parentSock := os.NewFile(uintptr(fds[0]), "parent")
+	childSock := os.NewFile(uintptr(fds[1]), "child")
+
+	store := &notifyMockEventStore{}
+	broker := &notifyMockEventBroker{}
+
+	// Send a pipe FD through the socketpair so RecvFD succeeds.
+	// The handler will try NotifReceive on the pipe, which fails (wrong ioctl)
+	// and exits the serve loop.
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer pipeW.Close()
+
+	// Send pipeR FD via SCM_RIGHTS.
+	rights := unix.UnixRights(int(pipeR.Fd()))
+	if err := unix.Sendmsg(int(childSock.Fd()), []byte{0}, rights, nil, 0); err != nil {
+		pipeR.Close()
+		childSock.Close()
+		parentSock.Close()
+		t.Fatalf("sendmsg: %v", err)
+	}
+	pipeR.Close()
+	childSock.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	startNotifyHandler(ctx, parentSock, "test-ctx-cancel", nil, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false)
+
+	// Wait for handler to exit (NotifReceive on pipe FD fails immediately).
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case <-deadline:
+			// Handler might be waiting — cancel context to unblock.
+			cancel()
+			time.Sleep(100 * time.Millisecond)
+			if int(parentSock.Fd()) != -1 {
+				t.Fatal("timed out: handler didn't clean up after context cancel")
+			}
+			return
+		default:
+		}
+		if int(parentSock.Fd()) == -1 {
+			cancel()
+			return
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/internal/api/notify_linux_test.go
+++ b/internal/api/notify_linux_test.go
@@ -406,9 +406,12 @@ func TestNotifyHandler_CancellationGoroutineExitsOnEarlyReturn(t *testing.T) {
 }
 
 func TestNotifyHandler_ContextCancelCleansUpFDs(t *testing.T) {
-	// Verify that cancelling the context causes the handler to clean up
-	// (close parent socket). This tests the path where RecvFD succeeds
-	// but the serve loop exits due to a non-seccomp FD.
+	// Verify that cancelling the context causes the handler goroutine
+	// to clean up and close the parent socket. We send a pipe FD through
+	// the socketpair so RecvFD succeeds, then the handler enters the
+	// serve loop. NotifReceive on a pipe FD returns an error immediately
+	// (wrong ioctl), causing the handler to exit. We then cancel the
+	// context and verify that all cleanup happened (parent socket closed).
 
 	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM|unix.SOCK_CLOEXEC, 0)
 	if err != nil {
@@ -421,8 +424,6 @@ func TestNotifyHandler_ContextCancelCleansUpFDs(t *testing.T) {
 	broker := &notifyMockEventBroker{}
 
 	// Send a pipe FD through the socketpair so RecvFD succeeds.
-	// The handler will try NotifReceive on the pipe, which fails (wrong ioctl)
-	// and exits the serve loop.
 	pipeR, pipeW, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("pipe: %v", err)
@@ -441,25 +442,19 @@ func TestNotifyHandler_ContextCancelCleansUpFDs(t *testing.T) {
 	childSock.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	startNotifyHandler(ctx, parentSock, "test-ctx-cancel", nil, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false)
 
-	// Wait for handler to exit (NotifReceive on pipe FD fails immediately).
+	// Wait for handler to clean up (close parent socket).
 	deadline := time.After(2 * time.Second)
 	for {
 		select {
 		case <-deadline:
-			// Handler might be waiting — cancel context to unblock.
-			cancel()
-			time.Sleep(100 * time.Millisecond)
-			if int(parentSock.Fd()) != -1 {
-				t.Fatal("timed out: handler didn't clean up after context cancel")
-			}
-			return
+			t.Fatal("timed out: handler didn't clean up parent socket")
 		default:
 		}
 		if int(parentSock.Fd()) == -1 {
-			cancel()
 			return
 		}
 		time.Sleep(10 * time.Millisecond)

--- a/internal/netmonitor/unix/handler.go
+++ b/internal/netmonitor/unix/handler.go
@@ -45,8 +45,14 @@ func ServeNotify(ctx context.Context, fd *os.File, sessID string, pol *policy.En
 				continue
 			}
 			if isENOENT(err) {
-				// Target process was killed — non-fatal, continue serving
-				continue
+				// Target process was killed. Check context before retrying.
+				select {
+				case <-ctx.Done():
+					return
+				default:
+					time.Sleep(1 * time.Millisecond)
+					continue
+				}
 			}
 			return
 		}
@@ -169,12 +175,19 @@ func ServeNotifyWithExecve(ctx context.Context, fd *os.File, sessID string, pol 
 				continue
 			}
 			if isENOENT(err) {
-				// Target process was killed or notification cancelled — non-fatal.
-				// Sleep briefly to avoid tight spin.
-				time.Sleep(1 * time.Millisecond)
-				continue
+				// Target process was killed or notification cancelled.
+				// Check if context is done; if so, exit immediately.
+				// Otherwise sleep briefly and retry (another process may still be alive).
+				select {
+				case <-ctx.Done():
+					slog.Debug("ServeNotifyWithExecve: ENOENT + context done, exiting", "session_id", sessID, "total_notifications", notifCount)
+					return
+				default:
+					time.Sleep(1 * time.Millisecond)
+					continue
+				}
 			}
-			slog.Error("ServeNotifyWithExecve: NotifReceive error (exiting)", "session_id", sessID, "error", err, "total_notifications", notifCount)
+			slog.Debug("ServeNotifyWithExecve: NotifReceive error (exiting)", "session_id", sessID, "error", err, "total_notifications", notifCount)
 			return
 		}
 		notifCount++

--- a/internal/netmonitor/unix/handler_test.go
+++ b/internal/netmonitor/unix/handler_test.go
@@ -59,8 +59,10 @@ func (e *handlerTestEmitter) AppendEvent(_ context.Context, _ types.Event) error
 func (e *handlerTestEmitter) Publish(_ types.Event)                              {}
 
 func TestServeNotifyWithExecve_ExitsOnCancelledContext(t *testing.T) {
-	// ServeNotifyWithExecve should exit immediately when given an
-	// already-cancelled context, even with a valid FD.
+	// With a pre-cancelled context, the select { case <-ctx.Done(): return }
+	// at the top of the first loop iteration should fire immediately,
+	// BEFORE NotifReceive is ever called. We verify this by checking the
+	// function returns in < 50ms (the EAGAIN retry path sleeps 10ms).
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("pipe: %v", err)
@@ -71,6 +73,7 @@ func TestServeNotifyWithExecve_ExitsOnCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel before calling
 
+	start := time.Now()
 	done := make(chan struct{})
 	go func() {
 		ServeNotifyWithExecve(ctx, r, "test-cancelled", nil, &handlerTestEmitter{}, nil, nil)
@@ -79,7 +82,10 @@ func TestServeNotifyWithExecve_ExitsOnCancelledContext(t *testing.T) {
 
 	select {
 	case <-done:
-		// Good — exited promptly.
+		elapsed := time.Since(start)
+		if elapsed > 50*time.Millisecond {
+			t.Errorf("took %v — likely went through NotifReceive instead of ctx.Done() path", elapsed)
+		}
 	case <-time.After(1 * time.Second):
 		t.Fatal("ServeNotifyWithExecve did not exit with cancelled context")
 	}
@@ -93,6 +99,7 @@ func TestServeNotifyWithExecve_ExitsOnNonSeccompFD(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pipe: %v", err)
 	}
+	defer r.Close()
 	defer w.Close()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -113,7 +120,7 @@ func TestServeNotifyWithExecve_ExitsOnNonSeccompFD(t *testing.T) {
 }
 
 func TestServeNotify_ExitsOnCancelledContext(t *testing.T) {
-	// Same test for the non-execve ServeNotify variant.
+	// Same pre-cancelled context test for the non-execve ServeNotify variant.
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("pipe: %v", err)
@@ -124,6 +131,7 @@ func TestServeNotify_ExitsOnCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
+	start := time.Now()
 	done := make(chan struct{})
 	go func() {
 		ServeNotify(ctx, r, "test-cancelled", nil, &handlerTestEmitter{})
@@ -132,6 +140,10 @@ func TestServeNotify_ExitsOnCancelledContext(t *testing.T) {
 
 	select {
 	case <-done:
+		elapsed := time.Since(start)
+		if elapsed > 50*time.Millisecond {
+			t.Errorf("took %v — likely went through NotifReceive instead of ctx.Done() path", elapsed)
+		}
 	case <-time.After(1 * time.Second):
 		t.Fatal("ServeNotify did not exit with cancelled context")
 	}

--- a/internal/netmonitor/unix/handler_test.go
+++ b/internal/netmonitor/unix/handler_test.go
@@ -3,8 +3,12 @@
 package unix
 
 import (
+	"context"
+	"os"
 	"testing"
+	"time"
 
+	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
 )
@@ -46,4 +50,89 @@ func TestServeNotify_RoutesNewFileSyscalls(t *testing.T) {
 	assert.True(t, isFileSyscall(unix.SYS_FACCESSAT2))
 	assert.True(t, isFileSyscall(unix.SYS_READLINKAT))
 	assert.True(t, isFileSyscall(unix.SYS_MKNODAT))
+}
+
+// handlerTestEmitter is a no-op emitter for handler lifecycle tests.
+type handlerTestEmitter struct{}
+
+func (e *handlerTestEmitter) AppendEvent(_ context.Context, _ types.Event) error { return nil }
+func (e *handlerTestEmitter) Publish(_ types.Event)                              {}
+
+func TestServeNotifyWithExecve_ExitsOnCancelledContext(t *testing.T) {
+	// ServeNotifyWithExecve should exit immediately when given an
+	// already-cancelled context, even with a valid FD.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel before calling
+
+	done := make(chan struct{})
+	go func() {
+		ServeNotifyWithExecve(ctx, r, "test-cancelled", nil, &handlerTestEmitter{}, nil, nil)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good — exited promptly.
+	case <-time.After(1 * time.Second):
+		t.Fatal("ServeNotifyWithExecve did not exit with cancelled context")
+	}
+}
+
+func TestServeNotifyWithExecve_ExitsOnNonSeccompFD(t *testing.T) {
+	// When given a pipe FD (not a real seccomp notify FD), NotifReceive
+	// returns an error. The handler should exit via the error branch,
+	// not spin forever.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer w.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		ServeNotifyWithExecve(ctx, r, "test-bad-fd", nil, &handlerTestEmitter{}, nil, nil)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Good — exited on ioctl error.
+	case <-time.After(1 * time.Second):
+		t.Fatal("ServeNotifyWithExecve did not exit with non-seccomp FD")
+	}
+}
+
+func TestServeNotify_ExitsOnCancelledContext(t *testing.T) {
+	// Same test for the non-execve ServeNotify variant.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	done := make(chan struct{})
+	go func() {
+		ServeNotify(ctx, r, "test-cancelled", nil, &handlerTestEmitter{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("ServeNotify did not exit with cancelled context")
+	}
 }

--- a/internal/netmonitor/unix/handler_test.go
+++ b/internal/netmonitor/unix/handler_test.go
@@ -59,10 +59,11 @@ func (e *handlerTestEmitter) AppendEvent(_ context.Context, _ types.Event) error
 func (e *handlerTestEmitter) Publish(_ types.Event)                              {}
 
 func TestServeNotifyWithExecve_ExitsOnCancelledContext(t *testing.T) {
-	// With a pre-cancelled context, the select { case <-ctx.Done(): return }
-	// at the top of the first loop iteration should fire immediately,
-	// BEFORE NotifReceive is ever called. We verify this by checking the
-	// function returns in < 50ms (the EAGAIN retry path sleeps 10ms).
+	// With a pre-cancelled context, the handler should exit promptly.
+	// Note: NotifReceive is a cgo/ioctl call that can't be mocked, so we
+	// can't deterministically prove the exit is via ctx.Done() vs ioctl error.
+	// This test verifies the handler doesn't hang — the ctx.Done() select
+	// path is tested indirectly (it fires before NotifReceive is called).
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("pipe: %v", err)
@@ -73,7 +74,6 @@ func TestServeNotifyWithExecve_ExitsOnCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel before calling
 
-	start := time.Now()
 	done := make(chan struct{})
 	go func() {
 		ServeNotifyWithExecve(ctx, r, "test-cancelled", nil, &handlerTestEmitter{}, nil, nil)
@@ -82,10 +82,7 @@ func TestServeNotifyWithExecve_ExitsOnCancelledContext(t *testing.T) {
 
 	select {
 	case <-done:
-		elapsed := time.Since(start)
-		if elapsed > 50*time.Millisecond {
-			t.Errorf("took %v — likely went through NotifReceive instead of ctx.Done() path", elapsed)
-		}
+		// Good — exited promptly.
 	case <-time.After(1 * time.Second):
 		t.Fatal("ServeNotifyWithExecve did not exit with cancelled context")
 	}
@@ -120,7 +117,7 @@ func TestServeNotifyWithExecve_ExitsOnNonSeccompFD(t *testing.T) {
 }
 
 func TestServeNotify_ExitsOnCancelledContext(t *testing.T) {
-	// Same pre-cancelled context test for the non-execve ServeNotify variant.
+	// Same as above for the non-execve ServeNotify variant.
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("pipe: %v", err)
@@ -131,7 +128,6 @@ func TestServeNotify_ExitsOnCancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	start := time.Now()
 	done := make(chan struct{})
 	go func() {
 		ServeNotify(ctx, r, "test-cancelled", nil, &handlerTestEmitter{})
@@ -140,10 +136,6 @@ func TestServeNotify_ExitsOnCancelledContext(t *testing.T) {
 
 	select {
 	case <-done:
-		elapsed := time.Since(start)
-		if elapsed > 50*time.Millisecond {
-			t.Errorf("took %v — likely went through NotifReceive instead of ctx.Done() path", elapsed)
-		}
 	case <-time.After(1 * time.Second):
 		t.Fatal("ServeNotify did not exit with cancelled context")
 	}

--- a/internal/netmonitor/unix/handler_test.go
+++ b/internal/netmonitor/unix/handler_test.go
@@ -58,12 +58,11 @@ type handlerTestEmitter struct{}
 func (e *handlerTestEmitter) AppendEvent(_ context.Context, _ types.Event) error { return nil }
 func (e *handlerTestEmitter) Publish(_ types.Event)                              {}
 
-func TestServeNotifyWithExecve_ExitsOnCancelledContext(t *testing.T) {
-	// With a pre-cancelled context, the handler should exit promptly.
-	// Note: NotifReceive is a cgo/ioctl call that can't be mocked, so we
-	// can't deterministically prove the exit is via ctx.Done() vs ioctl error.
-	// This test verifies the handler doesn't hang — the ctx.Done() select
-	// path is tested indirectly (it fires before NotifReceive is called).
+func TestServeNotifyWithExecve_DoesNotHangOnCancelledContext(t *testing.T) {
+	// Verify the serve loop does not hang when given a pre-cancelled context.
+	// Note: with pipe FDs, NotifReceive returns an ioctl error immediately,
+	// so this also exits via the error branch. Testing the ctx.Done() select
+	// path specifically requires real seccomp notify FDs (privileged integration test).
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("pipe: %v", err)
@@ -88,7 +87,7 @@ func TestServeNotifyWithExecve_ExitsOnCancelledContext(t *testing.T) {
 	}
 }
 
-func TestServeNotifyWithExecve_ExitsOnNonSeccompFD(t *testing.T) {
+func TestServeNotifyWithExecve_DoesNotHangOnNonSeccompFD(t *testing.T) {
 	// When given a pipe FD (not a real seccomp notify FD), NotifReceive
 	// returns an error. The handler should exit via the error branch,
 	// not spin forever.
@@ -116,7 +115,7 @@ func TestServeNotifyWithExecve_ExitsOnNonSeccompFD(t *testing.T) {
 	}
 }
 
-func TestServeNotify_ExitsOnCancelledContext(t *testing.T) {
+func TestServeNotify_DoesNotHangOnCancelledContext(t *testing.T) {
 	// Same as above for the non-execve ServeNotify variant.
 	r, w, err := os.Pipe()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix session instability after ~10-15 exec calls in hybrid ptrace+seccomp mode
- Root cause: `seccomp.NotifReceive()` is a blocking ioctl that context cancellation can't interrupt, causing notify handler goroutines to leak

## Changes

**Notify handler lifecycle** (`internal/api/notify_linux.go`):
- Add cancellation goroutine that closes notify FD on ctx.Done(), unblocking stuck NotifReceive
- Add `handlerDone` channel to prevent cancellation goroutine leak on early handler exit

**Hybrid exec cleanup** (`internal/api/exec.go`, `exec_stream.go`):
- Use child context (`handlerCtx`) for wrapper handlers, cancelled immediately after waitExit()
- Call `handlerCancel()` on all exit paths (normal + resume error)

**Serve loop** (`internal/netmonitor/unix/handler.go`):
- ENOENT errors now check ctx.Done() before retrying (prevents spin after process exit)
- Demote unexpected error logging from Error to Debug (expected during FD close)

**Tests** (`notify_linux_test.go`, `handler_test.go`):
- `TestNotifyHandler_CancellationGoroutineExitsOnEarlyReturn` — goroutine leak detection
- `TestNotifyHandler_ContextCancelCleansUpFDs` — FD cleanup via SCM_RIGHTS pipe
- `TestServeNotifyWithExecve_DoesNotHangOnCancelledContext` — no-hang on cancelled ctx
- `TestServeNotifyWithExecve_DoesNotHangOnNonSeccompFD` — exits on bad FD
- `TestServeNotify_DoesNotHangOnCancelledContext` — same for non-execve variant

## Test plan
- [x] All new tests pass
- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [x] roborev review — pass (no findings)
- [ ] Deploy to exe.dev VM and run 76-test security suite


🤖 Generated with [Claude Code](https://claude.com/claude-code)