### PR TITLE
feat: dynamic seatbelt — policy-driven macOS sandbox enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 agentsh sits *under* your agent/tooling—intercepting **file**, **network**, **process**, and **signal** activity (including subprocess trees), enforcing the policy you define, and emitting **structured audit events**.
 
-> **Platform note:** Linux provides full enforcement (100% security score). macOS supports two tiers: **ESF+NE** (90% score, requires Apple entitlements) for enterprise deployments, and **FUSE-T** (70% score) as a fallback. Windows supports native enforcement via minifilter driver with **AppContainer** sandbox isolation (85% score). See the [Platform Comparison Matrix](docs/platform-comparison.md) for details.
+> **Platform note:** Linux provides full enforcement (100% security score). macOS supports multiple tiers: **ESF+NE** (90% score, requires Apple entitlements) for enterprise deployments, **Dynamic Seatbelt + FUSE-T** (75% score) for development with automatic policy-driven sandbox profiles, **FUSE-T** (70% score) as a static sandbox fallback, and **Dynamic Seatbelt only** (65% score) without FUSE-T. Windows supports native enforcement via minifilter driver with **AppContainer** sandbox isolation (85% score). See the [Platform Comparison Matrix](docs/platform-comparison.md) for details.
 
 ---
 

--- a/cmd/agentsh-macwrap/config.go
+++ b/cmd/agentsh-macwrap/config.go
@@ -8,12 +8,17 @@ import (
 	"os"
 )
 
-// WrapperConfig is passed via AGENTSH_SANDBOX_CONFIG env var.
+// WrapperConfig is passed via AGENTSH_SANDBOX_CONFIG env var
+// or AGENTSH_SANDBOX_CONFIG_FILE (for large payloads >64KB).
 type WrapperConfig struct {
 	WorkspacePath string             `json:"workspace_path"`
 	AllowedPaths  []string           `json:"allowed_paths"`
 	AllowNetwork  bool               `json:"allow_network"`
 	MachServices  MachServicesConfig `json:"mach_services"`
+
+	// New fields for dynamic seatbelt
+	CompiledProfile string   `json:"compiled_profile,omitempty"`
+	ExtensionTokens []string `json:"extension_tokens,omitempty"`
 }
 
 // MachServicesConfig controls mach-lookup restrictions.
@@ -25,8 +30,23 @@ type MachServicesConfig struct {
 	BlockPrefixes []string `json:"block_prefixes"`
 }
 
-// loadConfig reads wrapper config from environment.
 func loadConfig() (*WrapperConfig, error) {
+	// Check AGENTSH_SANDBOX_CONFIG_FILE first (for large payloads)
+	if filePath := os.Getenv("AGENTSH_SANDBOX_CONFIG_FILE"); filePath != "" {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("read config file %s: %w", filePath, err)
+		}
+		os.Remove(filePath) // best-effort cleanup
+
+		var cfg WrapperConfig
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return nil, fmt.Errorf("parse config file: %w", err)
+		}
+		return &cfg, nil
+	}
+
+	// Existing env var loading
 	val := os.Getenv("AGENTSH_SANDBOX_CONFIG")
 	if val == "" {
 		return &WrapperConfig{

--- a/cmd/agentsh-macwrap/config_test.go
+++ b/cmd/agentsh-macwrap/config_test.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -57,5 +58,109 @@ func TestLoadConfig_InvalidJSON(t *testing.T) {
 	_, err := loadConfig()
 	if err == nil {
 		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestLoadConfig_CompiledProfile(t *testing.T) {
+	os.Setenv("AGENTSH_SANDBOX_CONFIG", `{
+		"workspace_path": "/tmp/ws",
+		"compiled_profile": "(version 1)(allow default)",
+		"extension_tokens": ["com.apple.app-sandbox.read:/tmp/extra", "com.apple.app-sandbox.write:/tmp/out"]
+	}`)
+	defer os.Unsetenv("AGENTSH_SANDBOX_CONFIG")
+	os.Unsetenv("AGENTSH_SANDBOX_CONFIG_FILE")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+
+	if cfg.CompiledProfile != "(version 1)(allow default)" {
+		t.Errorf("compiled_profile = %q, want %q", cfg.CompiledProfile, "(version 1)(allow default)")
+	}
+	if len(cfg.ExtensionTokens) != 2 {
+		t.Fatalf("extension_tokens len = %d, want 2", len(cfg.ExtensionTokens))
+	}
+	if cfg.ExtensionTokens[0] != "com.apple.app-sandbox.read:/tmp/extra" {
+		t.Errorf("extension_tokens[0] = %q, want %q", cfg.ExtensionTokens[0], "com.apple.app-sandbox.read:/tmp/extra")
+	}
+	if cfg.ExtensionTokens[1] != "com.apple.app-sandbox.write:/tmp/out" {
+		t.Errorf("extension_tokens[1] = %q, want %q", cfg.ExtensionTokens[1], "com.apple.app-sandbox.write:/tmp/out")
+	}
+}
+
+func TestLoadConfig_FromFile(t *testing.T) {
+	os.Unsetenv("AGENTSH_SANDBOX_CONFIG")
+
+	dir := t.TempDir()
+	cfgFile := filepath.Join(dir, "config.json")
+	data := []byte(`{
+		"workspace_path": "/tmp/file-ws",
+		"compiled_profile": "(version 1)(deny default)",
+		"allow_network": true
+	}`)
+	if err := os.WriteFile(cfgFile, data, 0600); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	os.Setenv("AGENTSH_SANDBOX_CONFIG_FILE", cfgFile)
+	defer os.Unsetenv("AGENTSH_SANDBOX_CONFIG_FILE")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+
+	if cfg.WorkspacePath != "/tmp/file-ws" {
+		t.Errorf("workspace_path = %q, want /tmp/file-ws", cfg.WorkspacePath)
+	}
+	if cfg.CompiledProfile != "(version 1)(deny default)" {
+		t.Errorf("compiled_profile = %q, want %q", cfg.CompiledProfile, "(version 1)(deny default)")
+	}
+	if !cfg.AllowNetwork {
+		t.Error("allow_network should be true")
+	}
+
+	// File should be deleted after loading
+	if _, err := os.Stat(cfgFile); !os.IsNotExist(err) {
+		t.Error("config file should be deleted after loading")
+	}
+}
+
+func TestLoadConfig_BackwardsCompatible(t *testing.T) {
+	os.Unsetenv("AGENTSH_SANDBOX_CONFIG_FILE")
+	os.Setenv("AGENTSH_SANDBOX_CONFIG", `{
+		"workspace_path": "/tmp/old",
+		"allowed_paths": ["/usr/bin"],
+		"allow_network": false,
+		"mach_services": {
+			"default_action": "deny",
+			"allow": ["com.apple.system.logger"]
+		}
+	}`)
+	defer os.Unsetenv("AGENTSH_SANDBOX_CONFIG")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+
+	if cfg.WorkspacePath != "/tmp/old" {
+		t.Errorf("workspace_path = %q, want /tmp/old", cfg.WorkspacePath)
+	}
+	if len(cfg.AllowedPaths) != 1 || cfg.AllowedPaths[0] != "/usr/bin" {
+		t.Errorf("allowed_paths = %v, want [/usr/bin]", cfg.AllowedPaths)
+	}
+	if cfg.AllowNetwork {
+		t.Error("allow_network should be false")
+	}
+	if cfg.MachServices.DefaultAction != "deny" {
+		t.Errorf("default_action = %q, want deny", cfg.MachServices.DefaultAction)
+	}
+	if cfg.CompiledProfile != "" {
+		t.Errorf("compiled_profile should be empty for old config, got %q", cfg.CompiledProfile)
+	}
+	if len(cfg.ExtensionTokens) != 0 {
+		t.Errorf("extension_tokens should be empty for old config, got %v", cfg.ExtensionTokens)
 	}
 }

--- a/cmd/agentsh-macwrap/main.go
+++ b/cmd/agentsh-macwrap/main.go
@@ -27,6 +27,9 @@ void free_error(char *errorbuf) {
     // The error buffer is just malloc'd memory, so free() works
     free(errorbuf);
 }
+
+// sandbox_extension_consume consumes an extension token.
+extern int64_t sandbox_extension_consume(const char *token);
 */
 import "C"
 
@@ -51,7 +54,16 @@ func main() {
 		log.Fatalf("load config: %v", err)
 	}
 
-	profile := generateProfile(cfg)
+	// Consume extension tokens before sandbox_init
+	if len(cfg.ExtensionTokens) > 0 {
+		consumeTokens(cfg.ExtensionTokens)
+	}
+
+	// Use compiled profile if provided, otherwise fall back to legacy generation
+	profile := cfg.CompiledProfile
+	if profile == "" {
+		profile = generateProfile(cfg)
+	}
 
 	if err := applySandbox(profile); err != nil {
 		log.Fatalf("apply sandbox: %v", err)
@@ -78,4 +90,17 @@ func applySandbox(profile string) error {
 		return fmt.Errorf("sandbox_init failed (rc=%d): %s", rc, errMsg)
 	}
 	return nil
+}
+
+// consumeTokens consumes sandbox extension tokens before sandbox_init
+// so the child process inherits the consumed extensions through exec().
+func consumeTokens(tokens []string) {
+	for _, token := range tokens {
+		cToken := C.CString(token)
+		handle := C.sandbox_extension_consume(cToken)
+		C.free(unsafe.Pointer(cToken))
+		if handle == -1 {
+			log.Printf("warning: failed to consume extension token (continuing)")
+		}
+	}
 }

--- a/docs/macos-xpc-sandbox.md
+++ b/docs/macos-xpc-sandbox.md
@@ -65,3 +65,14 @@ log stream --predicate 'subsystem == "com.apple.sandbox"' --level debug
 ## Audit Events
 
 XPC sandbox violations generate `xpc_sandbox_violation` events in the audit log.
+
+## Dynamic Seatbelt (Policy-Driven Profiles)
+
+Starting with dynamic seatbelt mode, sandbox profiles are no longer generated locally by `agentsh-macwrap`. Instead, they are built server-side from policy YAML using the SBPL builder.
+
+### How It Works
+
+1. **Server-side compilation**: When a session starts, the server reads the active policy and compiles an SBPL profile using the SBPL builder. The profile encodes deny-default rules with specific allows for file paths, exec paths, Mach services, and network access derived from policy.
+2. **Extension tokens**: Runtime file access grants are issued as sandbox extension tokens. These allow the sandboxed process to access paths not in the original profile (e.g., newly created temp files or workspace expansions) without regenerating the full profile.
+3. **Pre-compiled delivery**: The compiled SBPL profile is sent to `agentsh-macwrap` as part of the exec request. macwrap applies the pre-compiled profile via `sandbox_init_with_parameters()` instead of generating one locally.
+4. **Backwards compatibility**: If `CompiledProfile` is empty in the exec request, macwrap falls back to legacy local profile generation. This ensures older servers or configurations continue to work without changes.

--- a/docs/platform-comparison.md
+++ b/docs/platform-comparison.md
@@ -88,6 +88,7 @@ This document provides a comprehensive comparison of agentsh capabilities across
 | **macOS + Lima (inside VM)** | 100% | Yes | Yes | Block | Full | Yes | Full |
 | **macOS + Lima (orchestrated)** | 85% | Yes | Yes | Block | Full | Yes | Full |
 | **macOS FUSE-T** | 70% | Yes | Yes | Audit | Minimal | No | None |
+| **macOS Dynamic Seatbelt** | 65-75% | Partial | Best-effort | Audit | Deny-default | Exec paths | None |
 | **Windows Native** | 85% | Yes | Yes | Audit | Partial | No | Partial |
 
 ## Security Feature Coverage
@@ -122,6 +123,10 @@ macOS + Lima (orch)   ███████████████████�
 macOS FUSE-T + pf     ██████████████████████████████████░░░░░░░░░░░░░░░░░░░░░░   70%
                       File✓   Net✓    Sig⚠    Iso⚠      Sys✗     Res✗
                       (Minimal isolation via sandbox-exec, no syscall filter)
+
+macOS Dyn Seatbelt     █████████████████████████████████████░░░░░░░░░░░░░░░░░░░  65-75%
+                       File⚠   Net⚠    Sig⚠    Iso✓      Sys⚠     Res✗
+                       (Policy-driven SBPL; +FUSE-T for file interception → 75%)
 
 Windows Native        ██████████████████████████████████████████░░░░░░░░░░░░░░   85%
                       File✓   Net✓    Sig⚠    Iso⚠      Sys✗     Res⚠
@@ -264,7 +269,7 @@ Lima/virtiofs   █████████████████████�
 | Production - Windows Server | Windows WSL2 | 100% | Full Linux security in VM |
 | Production - macOS | macOS + Lima (inside VM) | 100% | Run agentsh inside Lima = native Linux |
 | Enterprise Security Product | macOS ESF+NE | 90% | ESF requires Apple approval; NE is standard |
-| Development - macOS | macOS FUSE-T | 70% | Easy setup, good monitoring |
+| Development - macOS | macOS Dynamic Seatbelt + FUSE-T | 75% | Policy-driven sandbox with file interception |
 | Development - Windows | Windows Native | 75% | Registry monitoring + WinDivert network |
 | CI/CD Pipeline | Linux Native | 100% | Containers supported |
 | Air-gapped/Offline | Linux Native | 100% | No external dependencies |
@@ -319,6 +324,8 @@ sandbox:
 | Configuration | File Interception | Network | Isolation | Ease of Setup | Security |
 |---------------|:-----------------:|:-------:|:---------:|:-------------:|:--------:|
 | ESF + NE | Endpoint Security | Network Extension | Minimal (sandbox-exec) | Medium (ESF needs approval) | 90% |
+| Dynamic Seatbelt + FUSE-T | FUSE-T (NFS) | Best-effort (SBPL port rules) | Deny-default (dynamic SBPL) | Easy (agentsh-macwrap in PATH) | 75% |
+| Dynamic Seatbelt only | Policy-derived SBPL paths | Best-effort (SBPL port rules) | Deny-default (dynamic SBPL) | Easy (agentsh-macwrap in PATH) | 65% |
 | FUSE-T + pf | FUSE-T (NFS) | pf packet filter | Minimal (sandbox-exec) | Easy (`brew install`) | 70% |
 | Lima VM (inside) | FUSE3 in VM | iptables in VM | Full | Medium | 100% |
 | Lima VM (orchestrated) | FUSE3 in VM | iptables in VM | Full | Medium | 85% |
@@ -327,6 +334,8 @@ sandbox:
 **When to use each:**
 - **ESF + NE**: Building a commercial security product, have Apple Developer relationship
 - **FUSE-T + pf**: Development, testing, personal use - best balance of features/simplicity
+- **Dynamic Seatbelt + FUSE-T**: Default for development — automatic policy-driven sandbox with file interception
+- **Dynamic Seatbelt only**: When FUSE-T isn't installed — still provides exec path restriction, Mach service deny-default, and file path boundaries
 - **Lima VM (inside)**: Production on macOS - run agentsh inside VM for full Linux security
 - **Lima VM (orchestrated)**: When you need macOS-native CLI experience with Lima backend
 - **Degraded**: Quick testing, observation-only use cases
@@ -364,13 +373,14 @@ See [Known Limitations - macOS + Lima](#macos--lima) for detailed comparison.
 - Best option for commercial security products
 
 ### macOS FUSE-T + pf
-- **Minimal process isolation** - sandbox-exec with SBPL profiles provides file/network restrictions
+- **Minimal process isolation** - sandbox-exec with SBPL profiles provides file/network restrictions; when agentsh-macwrap is available, dynamic seatbelt provides deny-default + policy-driven SBPL
 - **No namespace isolation** - macOS has no namespace equivalent; agents can see all processes
 - **No resource limits** - cannot enforce CPU/memory limits
 - **Resource monitoring available** - native Mach API monitoring for memory, CPU, and thread count
 - **No syscall filtering** - cannot block dangerous syscalls
 - **Requires root for pf** - network interception needs sudo
 - **Signal interception**: Audit only via Endpoint Security; cannot block or redirect signals
+- With dynamic seatbelt: policy-driven SBPL profiles provide exec path restriction, Mach service deny-default, and file path boundaries
 - Best option for development and personal use
 
 ### macOS + Lima

--- a/docs/security-modes.md
+++ b/docs/security-modes.md
@@ -22,6 +22,19 @@ Security enforcement is provided through a combination of:
 | `landlock-only` | Landlock | ~80% | Landlock without FUSE granularity |
 | `minimal` | (none) | ~50% | Capability dropping and shim policy only |
 
+### macOS Modes
+
+| Mode | Requirements | Protection Level | Description |
+|------|--------------|------------------|-------------|
+| `esf` | ESF entitlement (Apple approval) | ~90% | Endpoint Security Framework |
+| `lima` | limactl available | ~85% | Full Linux enforcement inside Lima VM |
+| `dynamic-seatbelt-fuse` | agentsh-macwrap + FUSE-T | ~75% | Policy-driven seatbelt + FUSE-T file interception |
+| `fuse-t` | FUSE-T installed | ~70% | FUSE-T with static sandbox profile |
+| `dynamic-seatbelt` | agentsh-macwrap | ~65% | Policy-driven seatbelt without FUSE-T |
+| `sandbox-exec` | (built-in) | ~60% | Static sandbox profile only |
+
+Dynamic seatbelt modes generate SBPL profiles from policy at session start — replacing blanket allows with deny-default + specific allows for file paths, exec paths, Mach services, and network. Extension tokens provide runtime file access grants. See `docs/superpowers/specs/2026-03-23-dynamic-seatbelt-design.md` for details.
+
 ### Mode Selection
 
 By default, agentsh auto-detects the best available mode at startup.

--- a/docs/superpowers/plans/2026-03-23-dynamic-seatbelt.md
+++ b/docs/superpowers/plans/2026-03-23-dynamic-seatbelt.md
@@ -256,54 +256,6 @@ func matchStr(m PathMatch) string {
 }
 
 func quotePath(path string) string {
-	if strings.HasPrefix(path, "#\"") {
-		// Already a regex pattern
-		return path
-	}
-	escaped := strings.ReplaceAll(path, "\\", "\\\\")
-	escaped = strings.ReplaceAll(escaped, "\"", "\\\"")
-	return fmt.Sprintf("%q", escaped)
-}
-
-func validateRule(r rule) error {
-	// Extract path from the SBPL string for validation
-	// Rules with regex paths use #"..."# syntax and don't need absolute path check
-	sbpl := r.sbpl
-	if strings.Contains(sbpl, "regex") {
-		return nil
-	}
-
-	// Find quoted path in the rule
-	// Format: (allow/deny ... (literal/subpath "path"))
-	start := strings.LastIndex(sbpl, `"`)
-	if start == -1 {
-		return nil // no path to validate
-	}
-	// Find the opening quote
-	pathEnd := start
-	pathStart := strings.LastIndex(sbpl[:pathEnd], `"`)
-	if pathStart == -1 {
-		return nil
-	}
-
-	path := sbpl[pathStart+1 : pathEnd]
-	// Unescape for validation
-	path = strings.ReplaceAll(path, "\\\"", "\"")
-	path = strings.ReplaceAll(path, "\\\\", "\\")
-
-	if path != "" && !strings.HasPrefix(path, "/") {
-		return fmt.Errorf("sbpl: path must be absolute, got %q", path)
-	}
-	return nil
-}
-```
-
-Note: the `quotePath` function double-escapes because `fmt.Sprintf("%q", ...)` adds its own escaping. We need to handle this more carefully. Let me fix that:
-
-Replace the `quotePath` function with:
-
-```go
-func quotePath(path string) string {
 	if strings.HasPrefix(path, `#"`) {
 		// Already a regex pattern like #"^/dev/ttys[0-9]+$"#
 		return path
@@ -312,11 +264,7 @@ func quotePath(path string) string {
 	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
 	return `"` + escaped + `"`
 }
-```
 
-And update `validateRule` to properly extract the path:
-
-```go
 func validateRule(r rule) error {
 	sbpl := r.sbpl
 	if strings.Contains(sbpl, "regex") {
@@ -495,6 +443,14 @@ func (p *Profile) DenyMachLookup(serviceName string) {
 	p.rules = append(p.rules, rule{
 		kind: kindMachDeny,
 		sbpl: fmt.Sprintf("(deny mach-lookup (global-name %q))", serviceName),
+	})
+}
+
+// DenyMachLookupPrefix denies lookup of Mach services by prefix.
+func (p *Profile) DenyMachLookupPrefix(prefix string) {
+	p.rules = append(p.rules, rule{
+		kind: kindMachDeny,
+		sbpl: fmt.Sprintf("(deny mach-lookup (global-name-prefix %q))", prefix),
 	})
 }
 
@@ -1422,10 +1378,17 @@ Expected: FAIL — `CompileDarwinSandbox` not defined.
 
 - [ ] **Step 3: Implement CompileDarwinSandbox**
 
-Add to `internal/platform/darwin/sandbox.go`, after the existing code:
+The `CompileDarwinSandbox` function imports `sandboxext` which requires CGo. Create a new file `internal/platform/darwin/sandbox_compile.go` with `//go:build darwin && cgo` rather than adding to `sandbox.go` (which is `//go:build darwin` without cgo). This keeps the existing `SandboxManager` usable without CGo.
+
+Create `internal/platform/darwin/sandbox_compile.go`:
 
 ```go
+//go:build darwin && cgo
+
+package darwin
+
 import (
+	"fmt"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -1569,9 +1532,7 @@ func CompileDarwinSandbox(pol *policy.Policy, workspacePath string) (*SandboxCon
 		p.DenyMachLookup(svc)
 	}
 	for _, prefix := range defaultMachBlockPrefixes {
-		// DenyMachLookup doesn't support prefix — use the builder's deny support
-		// For now, individual deny entries. Prefix deny requires adding DenyMachLookupPrefix.
-		p.DenyMachLookup(prefix + "*") // This won't work in SBPL — see step below
+		p.DenyMachLookupPrefix(prefix)
 	}
 	// Essential allows
 	for _, svc := range defaultMachAllow {
@@ -1628,26 +1589,6 @@ func containsAny(slice []string, values ...string) bool {
 }
 ```
 
-Note: We need to add `DenyMachLookupPrefix` to the builder. Add this quick method to `sbpl/builder.go`:
-
-```go
-// DenyMachLookupPrefix denies lookup of Mach services by prefix.
-func (p *Profile) DenyMachLookupPrefix(prefix string) {
-	p.rules = append(p.rules, rule{
-		kind: kindMachDeny,
-		sbpl: fmt.Sprintf("(deny mach-lookup (global-name-prefix %q))", prefix),
-	})
-}
-```
-
-Then fix the compilation code to use `DenyMachLookupPrefix` instead of the wildcard hack:
-
-```go
-	for _, prefix := range defaultMachBlockPrefixes {
-		p.DenyMachLookupPrefix(prefix)
-	}
-```
-
 - [ ] **Step 4: Run tests to verify they pass**
 
 Run: `go test ./internal/platform/darwin/... -v -run TestCompileDarwinSandbox`
@@ -1671,10 +1612,65 @@ git commit -m "feat(darwin): add CompileDarwinSandbox policy-to-SBPL compiler"
 
 **Files:**
 - Modify: `internal/api/core.go`
+- Create: `internal/api/sandbox_compile_darwin.go`
+- Create: `internal/api/sandbox_compile_other.go`
 
-- [ ] **Step 1: Read current wrapWithMacSandbox to understand the call site**
+**Important context:**
+- `a.policy` is `*policy.Engine` (not `*policy.Policy`). Call `a.policy.Policy()` to get `*policy.Policy`.
+- `core.go` is not build-tagged. Darwin-specific code must be in build-tagged helper files.
+- The helper modifies `macSandboxWrapperConfig` in-place to avoid cross-compilation type mismatches.
 
-Check `internal/api/core.go` lines 1401-1458 for the current implementation. The method modifies a `types.ExecRequest` in place: sets `req.Env["AGENTSH_SANDBOX_CONFIG"]`, replaces `req.Command` with the wrapper binary, and prepends `--` to args.
+- [ ] **Step 1: Create build-tagged helper files**
+
+Create `internal/api/sandbox_compile_darwin.go`:
+
+```go
+//go:build darwin && cgo
+
+package api
+
+import (
+	"log/slog"
+
+	"github.com/agentsh/agentsh/internal/platform/darwin"
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+// compileDarwinSandboxProfile compiles a policy-driven SBPL profile and populates
+// the wrapper config's CompiledProfile and ExtensionTokens fields.
+// Returns true if compilation succeeded, false to fall back to legacy profile.
+func compileDarwinSandboxProfile(cfg *macSandboxWrapperConfig, engine *policy.Engine, workspace string) bool {
+	pol := engine.Policy()
+	if pol == nil {
+		return false
+	}
+
+	sandboxCfg, err := darwin.CompileDarwinSandbox(pol, workspace)
+	if err != nil {
+		slog.Warn("failed to compile darwin sandbox profile, falling back to legacy",
+			"error", err)
+		return false
+	}
+
+	cfg.CompiledProfile = sandboxCfg.Profile
+	cfg.ExtensionTokens = sandboxCfg.TokenValues
+	return true
+}
+```
+
+Create `internal/api/sandbox_compile_other.go`:
+
+```go
+//go:build !darwin || !cgo
+
+package api
+
+import "github.com/agentsh/agentsh/internal/policy"
+
+func compileDarwinSandboxProfile(cfg *macSandboxWrapperConfig, engine *policy.Engine, workspace string) bool {
+	return false
+}
+```
 
 - [ ] **Step 2: Update macSandboxWrapperConfig with new fields**
 
@@ -1693,9 +1689,9 @@ type macSandboxWrapperConfig struct {
 }
 ```
 
-- [ ] **Step 3: Update wrapWithMacSandbox to compile profile from policy**
+- [ ] **Step 3: Update wrapWithMacSandbox to use the helper**
 
-Replace the body of `wrapWithMacSandbox` (lines 1401-1458) to call `CompileDarwinSandbox`. The method already has access to `sess` (session) which has the workspace path, and `a.policy` which has the loaded policy:
+In `wrapWithMacSandbox`, add the `compileDarwinSandboxProfile` call after building the config and before marshaling:
 
 ```go
 func (a *App) wrapWithMacSandbox(
@@ -1713,44 +1709,34 @@ func (a *App) wrapWithMacSandbox(
 		return
 	}
 
-	// Compile policy-driven SBPL profile
-	sandboxCfg, err := darwin.CompileDarwinSandbox(a.policy, sess.Workspace)
-	if err != nil {
-		slog.Warn("failed to compile darwin sandbox profile, falling back to legacy",
-			"error", err, "session", sess.ID)
-		// Fall back to legacy config (no compiled profile)
-		sandboxCfg = nil
+	// Build mach services config with defaults
+	machCfg := macSandboxMachServicesConfig{
+		DefaultAction: a.cfg.Sandbox.XPC.MachServices.DefaultAction,
+		Allow:         a.cfg.Sandbox.XPC.MachServices.Allow,
+		Block:         a.cfg.Sandbox.XPC.MachServices.Block,
+		AllowPrefixes: a.cfg.Sandbox.XPC.MachServices.AllowPrefixes,
+		BlockPrefixes: a.cfg.Sandbox.XPC.MachServices.BlockPrefixes,
 	}
 
-	// Build wrapper config
+	if machCfg.DefaultAction == "" {
+		machCfg.DefaultAction = "deny"
+	}
+	if len(machCfg.Allow) == 0 && machCfg.DefaultAction == "deny" {
+		machCfg.Allow = DefaultXPCAllowList
+	}
+	if len(machCfg.BlockPrefixes) == 0 && machCfg.DefaultAction == "allow" {
+		machCfg.BlockPrefixes = DefaultXPCBlockPrefixes
+	}
+
 	cfg := macSandboxWrapperConfig{
 		WorkspacePath: sess.Workspace,
 		AllowedPaths:  []string{os.Getenv("HOME")},
 		AllowNetwork:  true,
-		MachServices: macSandboxMachServicesConfig{
-			DefaultAction: a.cfg.Sandbox.XPC.MachServices.DefaultAction,
-			Allow:         a.cfg.Sandbox.XPC.MachServices.Allow,
-			Block:         a.cfg.Sandbox.XPC.MachServices.Block,
-			AllowPrefixes: a.cfg.Sandbox.XPC.MachServices.AllowPrefixes,
-			BlockPrefixes: a.cfg.Sandbox.XPC.MachServices.BlockPrefixes,
-		},
+		MachServices:  machCfg,
 	}
 
-	if sandboxCfg != nil {
-		cfg.CompiledProfile = sandboxCfg.Profile
-		cfg.ExtensionTokens = sandboxCfg.TokenValues
-	}
-
-	// Apply mach defaults if not configured
-	if cfg.MachServices.DefaultAction == "" {
-		cfg.MachServices.DefaultAction = "deny"
-	}
-	if len(cfg.MachServices.Allow) == 0 && cfg.MachServices.DefaultAction == "deny" {
-		cfg.MachServices.Allow = DefaultXPCAllowList
-	}
-	if len(cfg.MachServices.BlockPrefixes) == 0 && cfg.MachServices.DefaultAction == "allow" {
-		cfg.MachServices.BlockPrefixes = DefaultXPCBlockPrefixes
-	}
+	// Compile policy-driven SBPL profile (darwin+cgo only, no-op on other platforms)
+	compileDarwinSandboxProfile(&cfg, a.policy, sess.Workspace)
 
 	cfgJSON, err := json.Marshal(cfg)
 	if err != nil {
@@ -1779,52 +1765,10 @@ func (a *App) wrapWithMacSandbox(
 }
 ```
 
-Note: You'll need to add the import for the darwin package. Since `core.go` is not build-tagged, and `CompileDarwinSandbox` is darwin-only, you'll need to either:
-- Add a build-tagged helper file `internal/api/sandbox_darwin.go` that wraps the call, OR
-- Use a compile-time interface
-
-The cleanest approach: create `internal/api/sandbox_darwin.go` and `internal/api/sandbox_other.go`:
-
-`sandbox_darwin.go`:
-```go
-//go:build darwin
-
-package api
-
-import (
-	"github.com/agentsh/agentsh/internal/platform/darwin"
-	"github.com/agentsh/agentsh/internal/policy"
-)
-
-func compileDarwinSandbox(pol *policy.Policy, workspace string) (*darwin.SandboxConfig, error) {
-	return darwin.CompileDarwinSandbox(pol, workspace)
-}
-```
-
-`sandbox_other.go`:
-```go
-//go:build !darwin
-
-package api
-
-import "github.com/agentsh/agentsh/internal/policy"
-
-type darwinSandboxConfig struct {
-	Profile     string
-	TokenValues []string
-}
-
-func compileDarwinSandbox(pol *policy.Policy, workspace string) (*darwinSandboxConfig, error) {
-	return nil, nil
-}
-```
-
-Then in `wrapWithMacSandbox`, call `compileDarwinSandbox(a.policy, sess.Workspace)`.
-
 - [ ] **Step 4: Verify build compiles on all platforms**
 
 Run: `go build ./...` and `GOOS=linux go build ./...` and `GOOS=windows go build ./...`
-Expected: all pass.
+Expected: all pass. The `sandbox_compile_other.go` stub ensures non-darwin platforms compile.
 
 - [ ] **Step 5: Run existing server tests**
 
@@ -1834,7 +1778,7 @@ Expected: all existing tests PASS (backwards compatible).
 - [ ] **Step 6: Commit**
 
 ```bash
-git add internal/api/core.go internal/api/sandbox_darwin.go internal/api/sandbox_other.go
+git add internal/api/core.go internal/api/sandbox_compile_darwin.go internal/api/sandbox_compile_other.go
 git commit -m "feat(api): wire CompileDarwinSandbox into wrapWithMacSandbox"
 ```
 

--- a/docs/superpowers/plans/2026-03-23-dynamic-seatbelt.md
+++ b/docs/superpowers/plans/2026-03-23-dynamic-seatbelt.md
@@ -1,0 +1,2034 @@
+# Dynamic Seatbelt Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace static blanket-allow seatbelt profiles with policy-driven SBPL generation, extension tokens, and Mach service restriction on macOS.
+
+**Architecture:** Three new packages (`sbpl/`, `sandboxext/`), one enhanced server method (`wrapWithMacSandbox`), and updated macwrap consumer. Profile generation moves from macwrap to the server where the policy engine lives. Macwrap becomes a thin applier: consume tokens, apply compiled profile, exec.
+
+**Tech Stack:** Go, CGo (sandbox extension API), SBPL (Sandbox Profile Language), Apple private sandbox API
+
+**Spec:** `docs/superpowers/specs/2026-03-23-dynamic-seatbelt-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `internal/platform/darwin/sbpl/builder.go` | New — typed SBPL profile builder, no CGo |
+| `internal/platform/darwin/sbpl/builder_test.go` | New — builder unit tests (pure Go, any OS) |
+| `internal/platform/darwin/sandboxext/manager.go` | New — CGo wrapper for sandbox extension token API |
+| `internal/platform/darwin/sandboxext/manager_test.go` | New — token manager tests (darwin-only) |
+| `internal/platform/darwin/sandbox.go` | Modify — add `CompileDarwinSandbox()` orchestrator |
+| `internal/platform/darwin/sandbox_test.go` | New — compilation integration tests (darwin-only) |
+| `internal/api/core.go` | Modify — update `wrapWithMacSandbox()` to use compiled profiles |
+| `cmd/agentsh-macwrap/config.go` | Modify — add `CompiledProfile`, `ExtensionTokens` fields |
+| `cmd/agentsh-macwrap/main.go` | Modify — add `consumeTokens()`, use compiled profile |
+| `cmd/agentsh-macwrap/profile.go` | Unchanged — kept as legacy fallback |
+| `internal/capabilities/detect_darwin.go` | Modify — add dynamic seatbelt tiers |
+
+---
+
+### Task 1: SBPL Builder — Core Types and File Rules
+
+**Files:**
+- Create: `internal/platform/darwin/sbpl/builder.go`
+- Create: `internal/platform/darwin/sbpl/builder_test.go`
+
+- [ ] **Step 1: Write failing tests for core types and file read rules**
+
+Create `internal/platform/darwin/sbpl/builder_test.go`:
+
+```go
+package sbpl
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNew_ProducesValidEmptyProfile(t *testing.T) {
+	p := New()
+	got, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !strings.HasPrefix(got, "(version 1)") {
+		t.Errorf("profile should start with (version 1), got: %s", got[:40])
+	}
+	if !strings.Contains(got, "(deny default)") {
+		t.Error("profile should contain (deny default)")
+	}
+}
+
+func TestAllowFileRead_Subpath(t *testing.T) {
+	p := New()
+	p.AllowFileRead(Subpath, "/usr/lib")
+	got, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !strings.Contains(got, `(allow file-read* (subpath "/usr/lib"))`) {
+		t.Errorf("missing file-read subpath rule in:\n%s", got)
+	}
+}
+
+func TestAllowFileRead_Literal(t *testing.T) {
+	p := New()
+	p.AllowFileRead(Literal, "/etc/hosts")
+	got, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !strings.Contains(got, `(allow file-read* (literal "/etc/hosts"))`) {
+		t.Errorf("missing file-read literal rule in:\n%s", got)
+	}
+}
+
+func TestAllowFileReadWrite_Subpath(t *testing.T) {
+	p := New()
+	p.AllowFileReadWrite(Subpath, "/workspace/project")
+	got, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !strings.Contains(got, `(allow file-read* file-write* (subpath "/workspace/project"))`) {
+		t.Errorf("missing file-read-write subpath rule in:\n%s", got)
+	}
+}
+
+func TestBuild_RejectsRelativePath(t *testing.T) {
+	p := New()
+	p.AllowFileRead(Subpath, "relative/path")
+	_, err := p.Build()
+	if err == nil {
+		t.Error("expected error for relative path")
+	}
+}
+
+func TestBuild_EscapesQuotesInPaths(t *testing.T) {
+	p := New()
+	p.AllowFileRead(Subpath, `/Users/test/path with "quotes"`)
+	got, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !strings.Contains(got, `path with \"quotes\"`) {
+		t.Errorf("quotes not escaped in:\n%s", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/platform/darwin/sbpl/... -v`
+Expected: compilation error — package doesn't exist yet.
+
+- [ ] **Step 3: Implement core types and file rule methods**
+
+Create `internal/platform/darwin/sbpl/builder.go`:
+
+```go
+package sbpl
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PathMatch specifies how a path is matched in SBPL.
+type PathMatch int
+
+const (
+	Literal PathMatch = iota // (literal "/exact/path")
+	Subpath                  // (subpath "/dir")
+	Regex                    // (regex #"/pattern"#)
+)
+
+// ruleKind groups rules for ordering (deny before allow per category).
+type ruleKind int
+
+const (
+	kindFileAllow ruleKind = iota
+	kindFileDeny
+	kindExecAllow
+	kindExecDeny
+	kindMachAllow
+	kindMachDeny
+	kindNetworkAllow
+	kindNetworkDeny
+	kindOther
+)
+
+type rule struct {
+	kind ruleKind
+	sbpl string
+}
+
+// Profile builds an SBPL sandbox profile.
+type Profile struct {
+	rules []rule
+}
+
+// New creates a new Profile with (version 1) and (deny default).
+func New() *Profile {
+	return &Profile{}
+}
+
+// AllowFileRead adds a file-read* allow rule.
+func (p *Profile) AllowFileRead(match PathMatch, path string) {
+	p.rules = append(p.rules, rule{
+		kind: kindFileAllow,
+		sbpl: fmt.Sprintf("(allow file-read* (%s %s))", matchStr(match), quotePath(path)),
+	})
+}
+
+// AllowFileReadWrite adds a file-read* file-write* allow rule.
+func (p *Profile) AllowFileReadWrite(match PathMatch, path string) {
+	p.rules = append(p.rules, rule{
+		kind: kindFileAllow,
+		sbpl: fmt.Sprintf("(allow file-read* file-write* (%s %s))", matchStr(match), quotePath(path)),
+	})
+}
+
+// AllowFileReadWriteIOctl adds a file-read* file-write* file-ioctl allow rule (for workspace).
+func (p *Profile) AllowFileReadWriteIOctl(match PathMatch, path string) {
+	p.rules = append(p.rules, rule{
+		kind: kindFileAllow,
+		sbpl: fmt.Sprintf("(allow file-read* file-write* file-ioctl (%s %s))", matchStr(match), quotePath(path)),
+	})
+}
+
+// Build produces the complete SBPL profile string.
+func (p *Profile) Build() (string, error) {
+	// Validate all rules
+	for _, r := range p.rules {
+		if err := validateRule(r); err != nil {
+			return "", err
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString("(version 1)\n")
+	sb.WriteString("(deny default)\n\n")
+
+	// Emit deny rules before allow rules within each category for readability.
+	// SBPL deny rules override allow rules regardless of order, but this makes
+	// the profile easier to read and audit.
+	var denyRules, allowRules []rule
+	for _, r := range p.rules {
+		switch r.kind {
+		case kindFileDeny, kindExecDeny, kindMachDeny, kindNetworkDeny:
+			denyRules = append(denyRules, r)
+		default:
+			allowRules = append(allowRules, r)
+		}
+	}
+
+	if len(denyRules) > 0 {
+		for _, r := range denyRules {
+			sb.WriteString(r.sbpl)
+			sb.WriteString("\n")
+		}
+		sb.WriteString("\n")
+	}
+
+	for _, r := range allowRules {
+		sb.WriteString(r.sbpl)
+		sb.WriteString("\n")
+	}
+
+	return sb.String(), nil
+}
+
+func matchStr(m PathMatch) string {
+	switch m {
+	case Literal:
+		return "literal"
+	case Subpath:
+		return "subpath"
+	case Regex:
+		return "regex"
+	default:
+		return "literal"
+	}
+}
+
+func quotePath(path string) string {
+	if strings.HasPrefix(path, "#\"") {
+		// Already a regex pattern
+		return path
+	}
+	escaped := strings.ReplaceAll(path, "\\", "\\\\")
+	escaped = strings.ReplaceAll(escaped, "\"", "\\\"")
+	return fmt.Sprintf("%q", escaped)
+}
+
+func validateRule(r rule) error {
+	// Extract path from the SBPL string for validation
+	// Rules with regex paths use #"..."# syntax and don't need absolute path check
+	sbpl := r.sbpl
+	if strings.Contains(sbpl, "regex") {
+		return nil
+	}
+
+	// Find quoted path in the rule
+	// Format: (allow/deny ... (literal/subpath "path"))
+	start := strings.LastIndex(sbpl, `"`)
+	if start == -1 {
+		return nil // no path to validate
+	}
+	// Find the opening quote
+	pathEnd := start
+	pathStart := strings.LastIndex(sbpl[:pathEnd], `"`)
+	if pathStart == -1 {
+		return nil
+	}
+
+	path := sbpl[pathStart+1 : pathEnd]
+	// Unescape for validation
+	path = strings.ReplaceAll(path, "\\\"", "\"")
+	path = strings.ReplaceAll(path, "\\\\", "\\")
+
+	if path != "" && !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("sbpl: path must be absolute, got %q", path)
+	}
+	return nil
+}
+```
+
+Note: the `quotePath` function double-escapes because `fmt.Sprintf("%q", ...)` adds its own escaping. We need to handle this more carefully. Let me fix that:
+
+Replace the `quotePath` function with:
+
+```go
+func quotePath(path string) string {
+	if strings.HasPrefix(path, `#"`) {
+		// Already a regex pattern like #"^/dev/ttys[0-9]+$"#
+		return path
+	}
+	escaped := strings.ReplaceAll(path, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	return `"` + escaped + `"`
+}
+```
+
+And update `validateRule` to properly extract the path:
+
+```go
+func validateRule(r rule) error {
+	sbpl := r.sbpl
+	if strings.Contains(sbpl, "regex") {
+		return nil
+	}
+	// Extract path between the last pair of quotes
+	lastClose := strings.LastIndex(sbpl, `"`)
+	if lastClose <= 0 {
+		return nil
+	}
+	// Search backward from lastClose-1 for the opening quote
+	sub := sbpl[:lastClose]
+	lastOpen := strings.LastIndex(sub, `"`)
+	if lastOpen == -1 {
+		return nil
+	}
+	path := sbpl[lastOpen+1 : lastClose]
+	path = strings.ReplaceAll(path, `\"`, `"`)
+	path = strings.ReplaceAll(path, `\\`, `\`)
+
+	if path != "" && !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("sbpl: path must be absolute, got %q", path)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/platform/darwin/sbpl/... -v`
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/platform/darwin/sbpl/
+git commit -m "feat(sbpl): add SBPL builder with file rule support"
+```
+
+---
+
+### Task 2: SBPL Builder — Exec, Mach, and Network Rules
+
+**Files:**
+- Modify: `internal/platform/darwin/sbpl/builder.go`
+- Modify: `internal/platform/darwin/sbpl/builder_test.go`
+
+- [ ] **Step 1: Write failing tests for exec, Mach, and network rules**
+
+Add to `builder_test.go`:
+
+```go
+func TestAllowProcessExec_Subpath(t *testing.T) {
+	p := New()
+	p.AllowProcessExec(Subpath, "/usr/bin")
+	got, _ := p.Build()
+	if !strings.Contains(got, `(allow process-exec (subpath "/usr/bin"))`) {
+		t.Errorf("missing exec subpath rule in:\n%s", got)
+	}
+}
+
+func TestDenyProcessExec_Literal(t *testing.T) {
+	p := New()
+	p.DenyProcessExec(Literal, "/usr/bin/osascript")
+	got, _ := p.Build()
+	if !strings.Contains(got, `(deny process-exec (literal "/usr/bin/osascript"))`) {
+		t.Errorf("missing exec deny rule in:\n%s", got)
+	}
+}
+
+func TestDenyBeforeAllow_Ordering(t *testing.T) {
+	p := New()
+	p.AllowProcessExec(Subpath, "/usr/bin")
+	p.DenyProcessExec(Literal, "/usr/bin/osascript")
+	got, _ := p.Build()
+	denyIdx := strings.Index(got, "(deny process-exec")
+	allowIdx := strings.Index(got, "(allow process-exec")
+	if denyIdx == -1 || allowIdx == -1 {
+		t.Fatalf("missing rules in:\n%s", got)
+	}
+	if denyIdx > allowIdx {
+		t.Error("deny rules should be emitted before allow rules")
+	}
+}
+
+func TestAllowMachLookup(t *testing.T) {
+	p := New()
+	p.AllowMachLookup("com.apple.system.logger")
+	got, _ := p.Build()
+	if !strings.Contains(got, `(allow mach-lookup (global-name "com.apple.system.logger"))`) {
+		t.Errorf("missing mach-lookup rule in:\n%s", got)
+	}
+}
+
+func TestAllowMachLookupPrefix(t *testing.T) {
+	p := New()
+	p.AllowMachLookupPrefix("com.apple.system.")
+	got, _ := p.Build()
+	if !strings.Contains(got, `(allow mach-lookup (global-name-prefix "com.apple.system."))`) {
+		t.Errorf("missing mach-lookup prefix rule in:\n%s", got)
+	}
+}
+
+func TestDenyMachLookup(t *testing.T) {
+	p := New()
+	p.DenyMachLookup("com.apple.security.authtrampoline")
+	got, _ := p.Build()
+	if !strings.Contains(got, `(deny mach-lookup (global-name "com.apple.security.authtrampoline"))`) {
+		t.Errorf("missing mach deny rule in:\n%s", got)
+	}
+}
+
+func TestAllowNetworkAll(t *testing.T) {
+	p := New()
+	p.AllowNetworkAll()
+	got, _ := p.Build()
+	if !strings.Contains(got, "(allow network*)") {
+		t.Errorf("missing network allow-all in:\n%s", got)
+	}
+}
+
+func TestAllowNetworkOutbound(t *testing.T) {
+	p := New()
+	p.AllowNetworkOutbound("tcp", "*:443")
+	got, _ := p.Build()
+	if !strings.Contains(got, `(allow network-outbound (remote tcp "*:443"))`) {
+		t.Errorf("missing network outbound rule in:\n%s", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/platform/darwin/sbpl/... -v -run 'TestAllow(Process|Mach|Network)|TestDeny'`
+Expected: compilation errors for undefined methods.
+
+- [ ] **Step 3: Add exec, Mach, and network methods to builder.go**
+
+Add to `builder.go`:
+
+```go
+// AllowProcessExec adds a process-exec allow rule.
+func (p *Profile) AllowProcessExec(match PathMatch, path string) {
+	p.rules = append(p.rules, rule{
+		kind: kindExecAllow,
+		sbpl: fmt.Sprintf("(allow process-exec (%s %s))", matchStr(match), quotePath(path)),
+	})
+}
+
+// DenyProcessExec adds a process-exec deny rule.
+func (p *Profile) DenyProcessExec(match PathMatch, path string) {
+	p.rules = append(p.rules, rule{
+		kind: kindExecDeny,
+		sbpl: fmt.Sprintf("(deny process-exec (%s %s))", matchStr(match), quotePath(path)),
+	})
+}
+
+// AllowMachLookup allows lookup of a specific Mach service.
+func (p *Profile) AllowMachLookup(serviceName string) {
+	p.rules = append(p.rules, rule{
+		kind: kindMachAllow,
+		sbpl: fmt.Sprintf("(allow mach-lookup (global-name %q))", serviceName),
+	})
+}
+
+// AllowMachLookupPrefix allows lookup of Mach services by prefix.
+func (p *Profile) AllowMachLookupPrefix(prefix string) {
+	p.rules = append(p.rules, rule{
+		kind: kindMachAllow,
+		sbpl: fmt.Sprintf("(allow mach-lookup (global-name-prefix %q))", prefix),
+	})
+}
+
+// DenyMachLookup denies lookup of a specific Mach service.
+func (p *Profile) DenyMachLookup(serviceName string) {
+	p.rules = append(p.rules, rule{
+		kind: kindMachDeny,
+		sbpl: fmt.Sprintf("(deny mach-lookup (global-name %q))", serviceName),
+	})
+}
+
+// AllowNetworkAll allows all network operations.
+func (p *Profile) AllowNetworkAll() {
+	p.rules = append(p.rules, rule{
+		kind: kindNetworkAllow,
+		sbpl: "(allow network*)",
+	})
+}
+
+// AllowNetworkOutbound allows outbound connections on a specific protocol/port.
+// Note: port-level filtering has limited reliability on macOS 12+.
+func (p *Profile) AllowNetworkOutbound(proto, hostPort string) {
+	p.rules = append(p.rules, rule{
+		kind: kindNetworkAllow,
+		sbpl: fmt.Sprintf(`(allow network-outbound (remote %s "%s"))`, proto, hostPort),
+	})
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/platform/darwin/sbpl/... -v`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/platform/darwin/sbpl/
+git commit -m "feat(sbpl): add exec, mach-lookup, and network rule methods"
+```
+
+---
+
+### Task 3: SBPL Builder — System Essentials
+
+**Files:**
+- Modify: `internal/platform/darwin/sbpl/builder.go`
+- Modify: `internal/platform/darwin/sbpl/builder_test.go`
+
+- [ ] **Step 1: Write failing test for AllowSystemEssentials**
+
+Add to `builder_test.go`:
+
+```go
+func TestAllowSystemEssentials_ContainsRequiredPaths(t *testing.T) {
+	p := New()
+	p.AllowSystemEssentials()
+	got, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	required := []string{
+		// Dev files
+		`(literal "/dev/null")`,
+		`(literal "/dev/random")`,
+		`(literal "/dev/urandom")`,
+		`(literal "/dev/zero")`,
+		// System libraries
+		`(subpath "/usr/lib")`,
+		`(subpath "/usr/share")`,
+		`(subpath "/System/Library")`,
+		`(subpath "/Library/Frameworks")`,
+		`(subpath "/private/var/db/dyld")`,
+		// Process ops
+		"(allow process-fork)",
+		"(allow signal (target self))",
+		"(allow sysctl-read)",
+		// TTY
+		`(literal "/dev/tty")`,
+		// Common tool paths (read-only)
+		`(subpath "/usr/bin")`,
+		`(subpath "/usr/sbin")`,
+		`(subpath "/bin")`,
+		`(subpath "/sbin")`,
+		`(subpath "/usr/local/bin")`,
+		`(subpath "/opt/homebrew/bin")`,
+		`(subpath "/opt/homebrew/Cellar")`,
+		// Temp
+		`(subpath "/tmp")`,
+		`(subpath "/private/tmp")`,
+		`(subpath "/var/folders")`,
+		// IPC
+		"(allow ipc-posix*)",
+		"(allow mach-register)",
+	}
+
+	for _, s := range required {
+		if !strings.Contains(got, s) {
+			t.Errorf("AllowSystemEssentials missing: %s", s)
+		}
+	}
+}
+
+func TestAllowSystemEssentials_ContainsTTYRegex(t *testing.T) {
+	p := New()
+	p.AllowSystemEssentials()
+	got, _ := p.Build()
+	if !strings.Contains(got, `^/dev/ttys[0-9]+$`) {
+		t.Error("missing TTY regex pattern")
+	}
+	if !strings.Contains(got, `^/dev/pty[pqrs][0-9a-f]$`) {
+		t.Error("missing PTY regex pattern")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/platform/darwin/sbpl/... -v -run TestAllowSystemEssentials`
+Expected: FAIL — `AllowSystemEssentials` not defined.
+
+- [ ] **Step 3: Implement AllowSystemEssentials**
+
+Add to `builder.go`:
+
+```go
+// AllowSystemEssentials adds all rules needed for basic process operation.
+// Mirrors the paths in cmd/agentsh-macwrap/profile.go generateProfile().
+func (p *Profile) AllowSystemEssentials() {
+	// Process operations
+	p.rules = append(p.rules,
+		rule{kind: kindOther, sbpl: "(allow process-fork)"},
+		rule{kind: kindOther, sbpl: "(allow signal (target self))"},
+		rule{kind: kindOther, sbpl: "(allow sysctl-read)"},
+	)
+
+	// Dev files + system libraries (combined file-read* rule)
+	p.rules = append(p.rules, rule{
+		kind: kindFileAllow,
+		sbpl: "(allow file-read*\n" +
+			"    (subpath \"/usr/lib\")\n" +
+			"    (subpath \"/usr/share\")\n" +
+			"    (subpath \"/System/Library\")\n" +
+			"    (subpath \"/Library/Frameworks\")\n" +
+			"    (subpath \"/private/var/db/dyld\")\n" +
+			"    (literal \"/dev/null\")\n" +
+			"    (literal \"/dev/random\")\n" +
+			"    (literal \"/dev/urandom\")\n" +
+			"    (literal \"/dev/zero\"))",
+	})
+
+	// Common tool paths (read-only)
+	p.rules = append(p.rules, rule{
+		kind: kindFileAllow,
+		sbpl: "(allow file-read*\n" +
+			"    (subpath \"/usr/bin\")\n" +
+			"    (subpath \"/usr/sbin\")\n" +
+			"    (subpath \"/bin\")\n" +
+			"    (subpath \"/sbin\")\n" +
+			"    (subpath \"/usr/local/bin\")\n" +
+			"    (subpath \"/opt/homebrew/bin\")\n" +
+			"    (subpath \"/opt/homebrew/Cellar\"))",
+	})
+
+	// TTY access
+	p.rules = append(p.rules, rule{
+		kind: kindFileAllow,
+		sbpl: "(allow file-read* file-write*\n" +
+			"    (regex #\"^/dev/ttys[0-9]+$\"#)\n" +
+			"    (regex #\"^/dev/pty[pqrs][0-9a-f]$\"#)\n" +
+			"    (literal \"/dev/tty\"))",
+	})
+
+	// Temp files
+	p.rules = append(p.rules, rule{
+		kind: kindFileAllow,
+		sbpl: "(allow file-read* file-write*\n" +
+			"    (subpath \"/private/tmp\")\n" +
+			"    (subpath \"/tmp\")\n" +
+			"    (subpath \"/var/folders\"))",
+	})
+
+	// IPC
+	p.rules = append(p.rules,
+		rule{kind: kindOther, sbpl: "(allow ipc-posix*)"},
+		rule{kind: kindOther, sbpl: "(allow mach-register)"},
+	)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/platform/darwin/sbpl/... -v`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/platform/darwin/sbpl/
+git commit -m "feat(sbpl): add AllowSystemEssentials with all required paths"
+```
+
+---
+
+### Task 4: Extension Token Manager
+
+**Files:**
+- Create: `internal/platform/darwin/sandboxext/manager.go`
+- Create: `internal/platform/darwin/sandboxext/manager_test.go`
+
+Note: This package requires CGo and darwin. Tests will only run on macOS. The `sandbox_extension_issue_file` and `sandbox_extension_consume` functions are from the private sandbox API — they work without entitlements when called from an unsandboxed process.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/platform/darwin/sandboxext/manager_test.go`:
+
+```go
+//go:build darwin && cgo
+
+package sandboxext
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIssue_ReturnsToken(t *testing.T) {
+	mgr := NewManager()
+	defer mgr.RevokeAll()
+
+	// Create a real temp file to issue a token for
+	dir := t.TempDir()
+	tok, err := mgr.Issue(dir, ReadWrite)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+	if tok.Value == "" {
+		t.Error("token value should not be empty")
+	}
+	if tok.Path != dir {
+		t.Errorf("token path = %q, want %q", tok.Path, dir)
+	}
+	if tok.Class != ReadWrite {
+		t.Errorf("token class = %q, want %q", tok.Class, ReadWrite)
+	}
+}
+
+func TestActiveTokens_ReturnsIssuedTokens(t *testing.T) {
+	mgr := NewManager()
+	defer mgr.RevokeAll()
+
+	dir := t.TempDir()
+	mgr.Issue(dir, ReadOnly)
+
+	tokens := mgr.ActiveTokens()
+	if len(tokens) != 1 {
+		t.Fatalf("ActiveTokens len = %d, want 1", len(tokens))
+	}
+	if tokens[0].Path != dir {
+		t.Errorf("token path = %q, want %q", tokens[0].Path, dir)
+	}
+}
+
+func TestRevoke_RemovesToken(t *testing.T) {
+	mgr := NewManager()
+	defer mgr.RevokeAll()
+
+	dir := t.TempDir()
+	mgr.Issue(dir, ReadOnly)
+
+	if err := mgr.Revoke(dir); err != nil {
+		t.Fatalf("Revoke: %v", err)
+	}
+	if len(mgr.ActiveTokens()) != 0 {
+		t.Error("token should be removed after revoke")
+	}
+}
+
+func TestRevokeAll_ClearsAll(t *testing.T) {
+	mgr := NewManager()
+
+	d1 := t.TempDir()
+	d2 := t.TempDir()
+	mgr.Issue(d1, ReadOnly)
+	mgr.Issue(d2, ReadWrite)
+
+	mgr.RevokeAll()
+	if len(mgr.ActiveTokens()) != 0 {
+		t.Error("all tokens should be cleared")
+	}
+}
+
+func TestRevoke_DoubleRevoke_NoError(t *testing.T) {
+	mgr := NewManager()
+	defer mgr.RevokeAll()
+
+	dir := t.TempDir()
+	mgr.Issue(dir, ReadOnly)
+	mgr.Revoke(dir)
+
+	// Second revoke should not error
+	if err := mgr.Revoke(dir); err != nil {
+		t.Errorf("double revoke should not error, got: %v", err)
+	}
+}
+
+func TestIssue_NonexistentPath(t *testing.T) {
+	mgr := NewManager()
+	defer mgr.RevokeAll()
+
+	_, err := mgr.Issue("/nonexistent/path/that/does/not/exist", ReadOnly)
+	// sandbox_extension_issue may succeed for nonexistent paths (it issues a token
+	// for the capability, not the file). If it errors, that's also acceptable.
+	// This test just documents the behavior.
+	if err != nil {
+		t.Logf("Issue for nonexistent path returned error (acceptable): %v", err)
+	}
+}
+
+func TestConsumeToken_ValidToken(t *testing.T) {
+	mgr := NewManager()
+	defer mgr.RevokeAll()
+
+	dir := t.TempDir()
+	// Create a file to verify access
+	testFile := filepath.Join(dir, "test.txt")
+	os.WriteFile(testFile, []byte("hello"), 0644)
+
+	tok, err := mgr.Issue(dir, ReadOnly)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	// Consume should succeed
+	handle, err := ConsumeToken(tok.Value)
+	if err != nil {
+		t.Fatalf("ConsumeToken: %v", err)
+	}
+	if handle < 0 {
+		t.Errorf("handle should be >= 0, got %d", handle)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/platform/darwin/sandboxext/... -v`
+Expected: compilation error — package doesn't exist.
+
+- [ ] **Step 3: Implement the token manager**
+
+Create `internal/platform/darwin/sandboxext/manager.go`:
+
+```go
+//go:build darwin && cgo
+
+package sandboxext
+
+/*
+#include <sandbox.h>
+#include <stdlib.h>
+
+// sandbox_extension_issue_file is a private API for issuing sandbox extension tokens.
+extern char *sandbox_extension_issue_file(const char *extension_class, const char *path, uint32_t flags);
+
+// sandbox_extension_consume consumes a token, granting the calling process access.
+extern int64_t sandbox_extension_consume(const char *token);
+
+// sandbox_extension_release releases a previously consumed extension.
+extern int sandbox_extension_release(int64_t handle);
+*/
+import "C"
+
+import (
+	"fmt"
+	"sync"
+	"time"
+	"unsafe"
+)
+
+// ExtClass represents a sandbox extension class.
+type ExtClass string
+
+const (
+	ReadOnly  ExtClass = "com.apple.app-sandbox.read"
+	ReadWrite ExtClass = "com.apple.app-sandbox.read-write"
+)
+
+// Token represents an issued sandbox extension token.
+type Token struct {
+	Path   string
+	Class  ExtClass
+	Value  string // opaque token string from sandbox_extension_issue
+	Issued time.Time
+	handle int64 // internal handle from consume, -1 if not consumed
+}
+
+// Manager tracks sandbox extension tokens.
+type Manager struct {
+	mu     sync.Mutex
+	tokens map[string]*Token
+}
+
+// NewManager creates a new token manager.
+func NewManager() *Manager {
+	return &Manager{
+		tokens: make(map[string]*Token),
+	}
+}
+
+// Issue creates a sandbox extension token for the given path and class.
+// Must be called from an unsandboxed process.
+func (m *Manager) Issue(path string, class ExtClass) (*Token, error) {
+	cClass := C.CString(string(class))
+	defer C.free(unsafe.Pointer(cClass))
+
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	cToken := C.sandbox_extension_issue_file(cClass, cPath, 0)
+	if cToken == nil {
+		return nil, fmt.Errorf("sandbox_extension_issue_file failed for %q", path)
+	}
+
+	tokenStr := C.GoString(cToken)
+	C.free(unsafe.Pointer(cToken))
+
+	tok := &Token{
+		Path:   path,
+		Class:  class,
+		Value:  tokenStr,
+		Issued: time.Now(),
+		handle: -1,
+	}
+
+	m.mu.Lock()
+	m.tokens[path] = tok
+	m.mu.Unlock()
+
+	return tok, nil
+}
+
+// ActiveTokens returns all currently issued tokens.
+func (m *Manager) ActiveTokens() []Token {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	tokens := make([]Token, 0, len(m.tokens))
+	for _, t := range m.tokens {
+		tokens = append(tokens, *t)
+	}
+	return tokens
+}
+
+// Revoke releases a token for the given path.
+func (m *Manager) Revoke(path string) error {
+	m.mu.Lock()
+	tok, ok := m.tokens[path]
+	if !ok {
+		m.mu.Unlock()
+		return nil // already revoked, no error
+	}
+	delete(m.tokens, path)
+	m.mu.Unlock()
+
+	if tok.handle >= 0 {
+		C.sandbox_extension_release(C.int64_t(tok.handle))
+	}
+	return nil
+}
+
+// RevokeAll releases all tokens.
+func (m *Manager) RevokeAll() {
+	m.mu.Lock()
+	tokens := m.tokens
+	m.tokens = make(map[string]*Token)
+	m.mu.Unlock()
+
+	for _, tok := range tokens {
+		if tok.handle >= 0 {
+			C.sandbox_extension_release(C.int64_t(tok.handle))
+		}
+	}
+}
+
+// ConsumeToken consumes an opaque token string, granting the calling process access.
+// Returns the handle (>= 0 on success) or error.
+// This is called by macwrap before sandbox_init.
+func ConsumeToken(tokenStr string) (int64, error) {
+	cToken := C.CString(tokenStr)
+	defer C.free(unsafe.Pointer(cToken))
+
+	handle := int64(C.sandbox_extension_consume(cToken))
+	if handle == -1 {
+		return -1, fmt.Errorf("sandbox_extension_consume failed")
+	}
+	return handle, nil
+}
+
+// TokenValues returns just the opaque token strings (for serialization into WrapperConfig).
+func (m *Manager) TokenValues() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	values := make([]string, 0, len(m.tokens))
+	for _, t := range m.tokens {
+		values = append(values, t.Value)
+	}
+	return values
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/platform/darwin/sandboxext/... -v`
+Expected: all tests PASS. (Tests run on macOS with CGo enabled.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/platform/darwin/sandboxext/
+git commit -m "feat(sandboxext): add sandbox extension token manager"
+```
+
+---
+
+### Task 5: macwrap — WrapperConfig and Token Consumption
+
+**Files:**
+- Modify: `cmd/agentsh-macwrap/config.go`
+- Modify: `cmd/agentsh-macwrap/main.go`
+- Modify: `cmd/agentsh-macwrap/config_test.go`
+
+- [ ] **Step 1: Write failing tests for new config fields and file-based config**
+
+Add to `cmd/agentsh-macwrap/config_test.go`:
+
+```go
+func TestLoadConfig_CompiledProfile(t *testing.T) {
+	os.Setenv("AGENTSH_SANDBOX_CONFIG", `{
+		"workspace_path": "/tmp/test",
+		"compiled_profile": "(version 1)\n(deny default)\n",
+		"extension_tokens": ["token1", "token2"]
+	}`)
+	defer os.Unsetenv("AGENTSH_SANDBOX_CONFIG")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+
+	if cfg.CompiledProfile != "(version 1)\n(deny default)\n" {
+		t.Errorf("compiled_profile = %q", cfg.CompiledProfile)
+	}
+	if len(cfg.ExtensionTokens) != 2 {
+		t.Errorf("extension_tokens len = %d, want 2", len(cfg.ExtensionTokens))
+	}
+}
+
+func TestLoadConfig_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	cfgFile := dir + "/config.json"
+	os.WriteFile(cfgFile, []byte(`{
+		"workspace_path": "/from/file",
+		"compiled_profile": "(version 1)\n(deny default)"
+	}`), 0600)
+
+	os.Setenv("AGENTSH_SANDBOX_CONFIG_FILE", cfgFile)
+	os.Unsetenv("AGENTSH_SANDBOX_CONFIG")
+	defer os.Unsetenv("AGENTSH_SANDBOX_CONFIG_FILE")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.WorkspacePath != "/from/file" {
+		t.Errorf("workspace_path = %q, want /from/file", cfg.WorkspacePath)
+	}
+	// File should be deleted after read
+	if _, err := os.Stat(cfgFile); !os.IsNotExist(err) {
+		t.Error("config file should be deleted after read")
+	}
+}
+
+func TestLoadConfig_BackwardsCompatible(t *testing.T) {
+	// Old-style config without compiled_profile should still work
+	os.Setenv("AGENTSH_SANDBOX_CONFIG", `{
+		"workspace_path": "/tmp/old",
+		"allow_network": true,
+		"mach_services": {"default_action": "allow"}
+	}`)
+	defer os.Unsetenv("AGENTSH_SANDBOX_CONFIG")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.CompiledProfile != "" {
+		t.Error("compiled_profile should be empty for old config")
+	}
+	if cfg.WorkspacePath != "/tmp/old" {
+		t.Errorf("workspace_path = %q", cfg.WorkspacePath)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/agentsh-macwrap/... -v -run 'TestLoadConfig_(CompiledProfile|FromFile|BackwardsCompatible)'`
+Expected: FAIL — `CompiledProfile` field doesn't exist, `AGENTSH_SANDBOX_CONFIG_FILE` not handled.
+
+- [ ] **Step 3: Update config.go with new fields and file loading**
+
+Update `cmd/agentsh-macwrap/config.go`:
+
+```go
+//go:build darwin
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// WrapperConfig is passed via AGENTSH_SANDBOX_CONFIG env var
+// or AGENTSH_SANDBOX_CONFIG_FILE (for large payloads >64KB).
+type WrapperConfig struct {
+	WorkspacePath string            `json:"workspace_path"`
+	AllowedPaths  []string          `json:"allowed_paths"`
+	AllowNetwork  bool              `json:"allow_network"`
+	MachServices  MachServicesConfig `json:"mach_services"`
+
+	// New fields for dynamic seatbelt
+	CompiledProfile string   `json:"compiled_profile,omitempty"`
+	ExtensionTokens []string `json:"extension_tokens,omitempty"`
+}
+
+// MachServicesConfig controls mach-lookup restrictions.
+type MachServicesConfig struct {
+	DefaultAction string   `json:"default_action"`
+	Allow         []string `json:"allow"`
+	Block         []string `json:"block"`
+	AllowPrefixes []string `json:"allow_prefixes"`
+	BlockPrefixes []string `json:"block_prefixes"`
+}
+
+// loadConfig reads wrapper config from environment or file.
+func loadConfig() (*WrapperConfig, error) {
+	// Check for file-based config first (used for large payloads)
+	if filePath := os.Getenv("AGENTSH_SANDBOX_CONFIG_FILE"); filePath != "" {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("read config file %s: %w", filePath, err)
+		}
+		// Delete file after reading (best-effort)
+		os.Remove(filePath)
+
+		var cfg WrapperConfig
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			return nil, fmt.Errorf("parse config file: %w", err)
+		}
+		return &cfg, nil
+	}
+
+	val := os.Getenv("AGENTSH_SANDBOX_CONFIG")
+	if val == "" {
+		return &WrapperConfig{
+			MachServices: MachServicesConfig{
+				DefaultAction: "allow",
+			},
+		}, nil
+	}
+
+	var cfg WrapperConfig
+	if err := json.Unmarshal([]byte(val), &cfg); err != nil {
+		return nil, fmt.Errorf("parse AGENTSH_SANDBOX_CONFIG: %w", err)
+	}
+	return &cfg, nil
+}
+```
+
+- [ ] **Step 4: Run config tests to verify they pass**
+
+Run: `go test ./cmd/agentsh-macwrap/... -v -run TestLoadConfig`
+Expected: all PASS.
+
+- [ ] **Step 5: Update main.go to use compiled profile and consume tokens**
+
+Update `cmd/agentsh-macwrap/main.go`. Add `consumeTokens` function and update `main()` to check `CompiledProfile`:
+
+Add token consumption CGo declaration to the existing `import "C"` block — add after the `free_error` function:
+
+```c
+// sandbox_extension_consume consumes an extension token.
+extern int64_t sandbox_extension_consume(const char *token);
+```
+
+Then add Go function and update `main()`:
+
+```go
+// consumeTokens consumes sandbox extension tokens before sandbox_init.
+// Failures are warnings — the SBPL rule still provides access.
+func consumeTokens(tokens []string) {
+	for _, token := range tokens {
+		cToken := C.CString(token)
+		handle := C.sandbox_extension_consume(cToken)
+		C.free(unsafe.Pointer(cToken))
+		if handle == -1 {
+			log.Printf("warning: failed to consume extension token (continuing)")
+		}
+	}
+}
+
+func main() {
+	log.SetFlags(0)
+
+	cmd, args, err := validateArgs(os.Args)
+	if err != nil {
+		log.Fatalf("usage: %s -- <command> [args...]\nerror: %v", os.Args[0], err)
+	}
+
+	cfg, err := loadConfig()
+	if err != nil {
+		log.Fatalf("load config: %v", err)
+	}
+
+	// Consume extension tokens before sandbox_init
+	if len(cfg.ExtensionTokens) > 0 {
+		consumeTokens(cfg.ExtensionTokens)
+	}
+
+	// Use compiled profile if provided, otherwise fall back to legacy generation
+	profile := cfg.CompiledProfile
+	if profile == "" {
+		profile = generateProfile(cfg)
+	}
+
+	if err := applySandbox(profile); err != nil {
+		log.Fatalf("apply sandbox: %v", err)
+	}
+
+	if err := syscall.Exec(cmd, args, os.Environ()); err != nil {
+		log.Fatalf("exec %s failed: %v", cmd, err)
+	}
+}
+```
+
+- [ ] **Step 6: Run all macwrap tests**
+
+Run: `go test ./cmd/agentsh-macwrap/... -v`
+Expected: all tests PASS (including existing profile tests — legacy path still works).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/agentsh-macwrap/
+git commit -m "feat(macwrap): add compiled profile support and token consumption"
+```
+
+---
+
+### Task 6: Policy-to-Sandbox Compilation
+
+**Files:**
+- Modify: `internal/platform/darwin/sandbox.go`
+- Create: `internal/platform/darwin/sandbox_compile_test.go`
+
+- [ ] **Step 1: Write failing tests for CompileDarwinSandbox**
+
+Create `internal/platform/darwin/sandbox_compile_test.go`:
+
+```go
+//go:build darwin
+
+package darwin
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+func TestCompileDarwinSandbox_EmptyPolicy(t *testing.T) {
+	pol := &policy.Policy{}
+	cfg, err := CompileDarwinSandbox(pol, "/workspace")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox: %v", err)
+	}
+	if !strings.Contains(cfg.Profile, "(deny default)") {
+		t.Error("empty policy should produce deny-default profile")
+	}
+	if !strings.Contains(cfg.Profile, "(allow process-fork)") {
+		t.Error("should contain system essentials")
+	}
+}
+
+func TestCompileDarwinSandbox_FileRules(t *testing.T) {
+	pol := &policy.Policy{
+		FileRules: []policy.FileRule{
+			{Paths: []string{"/data"}, Operations: []string{"read"}, Decision: "allow"},
+			{Paths: []string{"/logs"}, Operations: []string{"write"}, Decision: "allow"},
+		},
+	}
+	cfg, err := CompileDarwinSandbox(pol, "/workspace")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox: %v", err)
+	}
+	if !strings.Contains(cfg.Profile, `(subpath "/data")`) {
+		t.Error("missing /data subpath rule")
+	}
+	if !strings.Contains(cfg.Profile, `file-write*`) {
+		t.Error("write rule should include file-write*")
+	}
+	if len(cfg.TokenValues) < 2 {
+		t.Errorf("expected at least 2 tokens, got %d", len(cfg.TokenValues))
+	}
+}
+
+func TestCompileDarwinSandbox_CommandRules(t *testing.T) {
+	pol := &policy.Policy{
+		CommandRules: []policy.CommandRule{
+			{Commands: []string{"/usr/bin/git"}, Decision: "allow"},
+			{Commands: []string{"osascript"}, Decision: "deny"},
+		},
+	}
+	cfg, err := CompileDarwinSandbox(pol, "/workspace")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox: %v", err)
+	}
+	if !strings.Contains(cfg.Profile, `(allow process-exec (literal "/usr/bin/git"))`) {
+		t.Error("missing git exec allow")
+	}
+	if !strings.Contains(cfg.Profile, `(deny process-exec`) {
+		t.Error("missing osascript exec deny")
+	}
+}
+
+func TestCompileDarwinSandbox_NetworkAllowAll(t *testing.T) {
+	pol := &policy.Policy{
+		NetworkRules: []policy.NetworkRule{
+			{Decision: "allow"},
+		},
+	}
+	cfg, err := CompileDarwinSandbox(pol, "/workspace")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox: %v", err)
+	}
+	if !strings.Contains(cfg.Profile, "(allow network*)") {
+		t.Error("should have network allow-all")
+	}
+}
+
+func TestCompileDarwinSandbox_WorkspaceFullAccess(t *testing.T) {
+	pol := &policy.Policy{}
+	cfg, err := CompileDarwinSandbox(pol, "/Users/dev/project")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox: %v", err)
+	}
+	if !strings.Contains(cfg.Profile, `(subpath "/Users/dev/project")`) {
+		t.Error("workspace path should be in profile")
+	}
+	if !strings.Contains(cfg.Profile, "file-ioctl") {
+		t.Error("workspace should have file-ioctl")
+	}
+}
+
+func TestCompileDarwinSandbox_DefaultExecBlocklist(t *testing.T) {
+	pol := &policy.Policy{}
+	cfg, err := CompileDarwinSandbox(pol, "/workspace")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox: %v", err)
+	}
+	for _, blocked := range []string{"osascript", "security", "systemsetup", "tccutil", "csrutil"} {
+		if !strings.Contains(cfg.Profile, blocked) {
+			t.Errorf("default exec blocklist should contain %s", blocked)
+		}
+	}
+}
+
+func TestCompileDarwinSandbox_DefaultExecAllowPaths(t *testing.T) {
+	pol := &policy.Policy{}
+	cfg, err := CompileDarwinSandbox(pol, "/workspace")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox: %v", err)
+	}
+	for _, path := range []string{"/usr/bin", "/bin", "/usr/sbin", "/sbin", "/usr/local/bin", "/opt/homebrew/bin"} {
+		if !strings.Contains(cfg.Profile, `(allow process-exec (subpath "`+path+`"))`) {
+			t.Errorf("default exec allow should contain %s", path)
+		}
+	}
+}
+
+func TestCompileDarwinSandbox_MachEssentials(t *testing.T) {
+	pol := &policy.Policy{}
+	cfg, err := CompileDarwinSandbox(pol, "/workspace")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox: %v", err)
+	}
+	if !strings.Contains(cfg.Profile, "com.apple.system.logger") {
+		t.Error("mach essentials should include system.logger")
+	}
+	if !strings.Contains(cfg.Profile, "com.apple.security.authtrampoline") {
+		t.Error("mach blocklist should include authtrampoline")
+	}
+}
+
+func TestCompileDarwinSandbox_DenyFileRuleOmitted(t *testing.T) {
+	pol := &policy.Policy{
+		FileRules: []policy.FileRule{
+			{Paths: []string{"/secret"}, Decision: "deny"},
+		},
+	}
+	cfg, err := CompileDarwinSandbox(pol, "/workspace")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox: %v", err)
+	}
+	// Deny rules are handled by omission (deny-default)
+	if strings.Contains(cfg.Profile, "/secret") {
+		t.Error("deny file rules should be omitted from profile (deny-default handles them)")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/platform/darwin/... -v -run TestCompileDarwinSandbox`
+Expected: FAIL — `CompileDarwinSandbox` not defined.
+
+- [ ] **Step 3: Implement CompileDarwinSandbox**
+
+Add to `internal/platform/darwin/sandbox.go`, after the existing code:
+
+```go
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/agentsh/agentsh/internal/platform/darwin/sbpl"
+	"github.com/agentsh/agentsh/internal/platform/darwin/sandboxext"
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+// SandboxConfig holds the compiled SBPL profile and extension tokens.
+type SandboxConfig struct {
+	Profile     string   // compiled SBPL string
+	TokenValues []string // opaque token strings for macwrap
+}
+
+// Default exec blocklist — macOS tools that enable privilege escalation.
+var defaultExecBlocklist = []string{
+	"/usr/bin/osascript",
+	"/usr/bin/security",
+	"/usr/sbin/systemsetup",
+	"/usr/bin/tccutil",
+	"/usr/sbin/csrutil",
+}
+
+// Default exec path allowlist — standard tool directories.
+var defaultExecAllowPaths = []string{
+	"/usr/bin", "/bin", "/usr/sbin", "/sbin",
+	"/usr/local/bin", "/opt/homebrew/bin",
+}
+
+// Default essential Mach services.
+var defaultMachAllow = []string{
+	"com.apple.system.logger",
+	"com.apple.SecurityServer",
+	"com.apple.distributed_notifications@Gv0",
+	"com.apple.system.notification_center",
+	"com.apple.CoreServices.coreservicesd",
+	"com.apple.DiskArbitration.diskarbitrationd",
+	"com.apple.xpc.launchd.domain.system",
+}
+
+// Default dangerous Mach services.
+var defaultMachBlock = []string{
+	"com.apple.security.authtrampoline",
+	"com.apple.coreservices.launchservicesd",
+	"com.apple.securityd",
+}
+
+// Default dangerous Mach prefixes.
+var defaultMachBlockPrefixes = []string{
+	"com.apple.pasteboard.",
+}
+
+// CompileDarwinSandbox builds an SBPL profile and extension tokens from a policy.
+func CompileDarwinSandbox(pol *policy.Policy, workspacePath string) (*SandboxConfig, error) {
+	p := sbpl.New()
+	mgr := sandboxext.NewManager()
+	defer mgr.RevokeAll() // Manager is only used for issuing; tokens are serialized out
+
+	// System essentials
+	p.AllowSystemEssentials()
+
+	// Workspace (full access)
+	if workspacePath != "" {
+		absWs, err := filepath.Abs(workspacePath)
+		if err == nil {
+			workspacePath = absWs
+		}
+		p.AllowFileReadWriteIOctl(sbpl.Subpath, workspacePath)
+		mgr.Issue(workspacePath, sandboxext.ReadWrite)
+	}
+
+	// File rules from policy
+	for _, rule := range pol.FileRules {
+		if rule.Decision != "allow" {
+			continue // deny = omission (deny-default handles it)
+		}
+		for _, path := range rule.Paths {
+			isWrite := containsAny(rule.Operations, "write", "*", "delete")
+			match := classifyPath(path)
+
+			if isWrite {
+				p.AllowFileReadWrite(match, path)
+				mgr.Issue(path, sandboxext.ReadWrite)
+			} else {
+				p.AllowFileRead(match, path)
+				mgr.Issue(path, sandboxext.ReadOnly)
+			}
+		}
+	}
+
+	// Command rules — default exec blocklist
+	for _, blocked := range defaultExecBlocklist {
+		p.DenyProcessExec(sbpl.Literal, blocked)
+	}
+
+	// Default exec allow paths
+	for _, allowPath := range defaultExecAllowPaths {
+		p.AllowProcessExec(sbpl.Subpath, allowPath)
+	}
+	if workspacePath != "" {
+		p.AllowProcessExec(sbpl.Subpath, workspacePath)
+	}
+
+	// Policy command rules
+	for _, rule := range pol.CommandRules {
+		for _, cmd := range rule.Commands {
+			switch rule.Decision {
+			case "allow":
+				resolved := resolveCommand(cmd)
+				p.AllowProcessExec(sbpl.Literal, resolved)
+			case "deny":
+				resolved := resolveCommand(cmd)
+				p.DenyProcessExec(sbpl.Literal, resolved)
+			// "approve", "redirect" — not mapped to SBPL (handled by shim/ESF)
+			}
+		}
+	}
+
+	// Network rules
+	hasNetwork := false
+	for _, rule := range pol.NetworkRules {
+		if rule.Decision != "allow" {
+			continue
+		}
+		if len(rule.Domains) > 0 || (len(rule.Ports) == 0 && len(rule.CIDRs) == 0) {
+			// Domain rules or unrestricted allow → allow all network
+			p.AllowNetworkAll()
+			hasNetwork = true
+			break
+		}
+		for _, port := range rule.Ports {
+			p.AllowNetworkOutbound("tcp", fmt.Sprintf("*:%d", port))
+			hasNetwork = true
+		}
+	}
+	_ = hasNetwork // used if we need to log
+
+	// Mach services — blocklist first
+	for _, svc := range defaultMachBlock {
+		p.DenyMachLookup(svc)
+	}
+	for _, prefix := range defaultMachBlockPrefixes {
+		// DenyMachLookup doesn't support prefix — use the builder's deny support
+		// For now, individual deny entries. Prefix deny requires adding DenyMachLookupPrefix.
+		p.DenyMachLookup(prefix + "*") // This won't work in SBPL — see step below
+	}
+	// Essential allows
+	for _, svc := range defaultMachAllow {
+		p.AllowMachLookup(svc)
+	}
+
+	profile, err := p.Build()
+	if err != nil {
+		return nil, fmt.Errorf("build SBPL profile: %w", err)
+	}
+
+	return &SandboxConfig{
+		Profile:     profile,
+		TokenValues: mgr.TokenValues(),
+	}, nil
+}
+
+// classifyPath determines whether a path should use Subpath or Literal matching.
+func classifyPath(path string) sbpl.PathMatch {
+	if strings.HasSuffix(path, "/*") || strings.HasSuffix(path, "/") {
+		return sbpl.Subpath
+	}
+	// Check if path looks like a directory (no file extension in the last component)
+	base := filepath.Base(path)
+	if !strings.Contains(base, ".") {
+		return sbpl.Subpath
+	}
+	return sbpl.Literal
+}
+
+// resolveCommand resolves a command name to an absolute path.
+func resolveCommand(cmd string) string {
+	if filepath.IsAbs(cmd) {
+		return cmd
+	}
+	// Try to resolve via PATH
+	if resolved, err := exec.LookPath(cmd); err == nil {
+		return resolved
+	}
+	// Fallback: assume /usr/bin
+	return "/usr/bin/" + cmd
+}
+
+// containsAny returns true if the slice contains any of the values.
+func containsAny(slice []string, values ...string) bool {
+	for _, s := range slice {
+		for _, v := range values {
+			if s == v {
+				return true
+			}
+		}
+	}
+	return false
+}
+```
+
+Note: We need to add `DenyMachLookupPrefix` to the builder. Add this quick method to `sbpl/builder.go`:
+
+```go
+// DenyMachLookupPrefix denies lookup of Mach services by prefix.
+func (p *Profile) DenyMachLookupPrefix(prefix string) {
+	p.rules = append(p.rules, rule{
+		kind: kindMachDeny,
+		sbpl: fmt.Sprintf("(deny mach-lookup (global-name-prefix %q))", prefix),
+	})
+}
+```
+
+Then fix the compilation code to use `DenyMachLookupPrefix` instead of the wildcard hack:
+
+```go
+	for _, prefix := range defaultMachBlockPrefixes {
+		p.DenyMachLookupPrefix(prefix)
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/platform/darwin/... -v -run TestCompileDarwinSandbox`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Verify full build**
+
+Run: `go build ./...`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/platform/darwin/sbpl/ internal/platform/darwin/sandbox*.go
+git commit -m "feat(darwin): add CompileDarwinSandbox policy-to-SBPL compiler"
+```
+
+---
+
+### Task 7: Server Integration — wrapWithMacSandbox
+
+**Files:**
+- Modify: `internal/api/core.go`
+
+- [ ] **Step 1: Read current wrapWithMacSandbox to understand the call site**
+
+Check `internal/api/core.go` lines 1401-1458 for the current implementation. The method modifies a `types.ExecRequest` in place: sets `req.Env["AGENTSH_SANDBOX_CONFIG"]`, replaces `req.Command` with the wrapper binary, and prepends `--` to args.
+
+- [ ] **Step 2: Update macSandboxWrapperConfig with new fields**
+
+In `internal/api/core.go`, update the `macSandboxWrapperConfig` struct (line 76):
+
+```go
+type macSandboxWrapperConfig struct {
+	WorkspacePath string                       `json:"workspace_path"`
+	AllowedPaths  []string                     `json:"allowed_paths"`
+	AllowNetwork  bool                         `json:"allow_network"`
+	MachServices  macSandboxMachServicesConfig `json:"mach_services"`
+
+	// Dynamic seatbelt fields
+	CompiledProfile string   `json:"compiled_profile,omitempty"`
+	ExtensionTokens []string `json:"extension_tokens,omitempty"`
+}
+```
+
+- [ ] **Step 3: Update wrapWithMacSandbox to compile profile from policy**
+
+Replace the body of `wrapWithMacSandbox` (lines 1401-1458) to call `CompileDarwinSandbox`. The method already has access to `sess` (session) which has the workspace path, and `a.policy` which has the loaded policy:
+
+```go
+func (a *App) wrapWithMacSandbox(
+	req *types.ExecRequest,
+	origCommand string,
+	origArgs []string,
+	sess *session.Session,
+) {
+	wrapperBin := strings.TrimSpace(a.cfg.Sandbox.XPC.WrapperBin)
+	if wrapperBin == "" {
+		wrapperBin = "agentsh-macwrap"
+	}
+
+	if _, err := exec.LookPath(wrapperBin); err != nil {
+		return
+	}
+
+	// Compile policy-driven SBPL profile
+	sandboxCfg, err := darwin.CompileDarwinSandbox(a.policy, sess.Workspace)
+	if err != nil {
+		slog.Warn("failed to compile darwin sandbox profile, falling back to legacy",
+			"error", err, "session", sess.ID)
+		// Fall back to legacy config (no compiled profile)
+		sandboxCfg = nil
+	}
+
+	// Build wrapper config
+	cfg := macSandboxWrapperConfig{
+		WorkspacePath: sess.Workspace,
+		AllowedPaths:  []string{os.Getenv("HOME")},
+		AllowNetwork:  true,
+		MachServices: macSandboxMachServicesConfig{
+			DefaultAction: a.cfg.Sandbox.XPC.MachServices.DefaultAction,
+			Allow:         a.cfg.Sandbox.XPC.MachServices.Allow,
+			Block:         a.cfg.Sandbox.XPC.MachServices.Block,
+			AllowPrefixes: a.cfg.Sandbox.XPC.MachServices.AllowPrefixes,
+			BlockPrefixes: a.cfg.Sandbox.XPC.MachServices.BlockPrefixes,
+		},
+	}
+
+	if sandboxCfg != nil {
+		cfg.CompiledProfile = sandboxCfg.Profile
+		cfg.ExtensionTokens = sandboxCfg.TokenValues
+	}
+
+	// Apply mach defaults if not configured
+	if cfg.MachServices.DefaultAction == "" {
+		cfg.MachServices.DefaultAction = "deny"
+	}
+	if len(cfg.MachServices.Allow) == 0 && cfg.MachServices.DefaultAction == "deny" {
+		cfg.MachServices.Allow = DefaultXPCAllowList
+	}
+	if len(cfg.MachServices.BlockPrefixes) == 0 && cfg.MachServices.DefaultAction == "allow" {
+		cfg.MachServices.BlockPrefixes = DefaultXPCBlockPrefixes
+	}
+
+	cfgJSON, err := json.Marshal(cfg)
+	if err != nil {
+		return
+	}
+
+	if req.Env == nil {
+		req.Env = map[string]string{}
+	}
+
+	// Use file-based config if payload is too large for env var
+	cfgStr := string(cfgJSON)
+	if len(cfgStr) > 64*1024 {
+		tmpFile := fmt.Sprintf("/tmp/agentsh-sandbox-%s.json", sess.ID)
+		if err := os.WriteFile(tmpFile, cfgJSON, 0600); err != nil {
+			slog.Warn("failed to write sandbox config file", "error", err)
+			return
+		}
+		req.Env["AGENTSH_SANDBOX_CONFIG_FILE"] = tmpFile
+	} else {
+		req.Env["AGENTSH_SANDBOX_CONFIG"] = cfgStr
+	}
+
+	req.Command = wrapperBin
+	req.Args = append([]string{"--", origCommand}, origArgs...)
+}
+```
+
+Note: You'll need to add the import for the darwin package. Since `core.go` is not build-tagged, and `CompileDarwinSandbox` is darwin-only, you'll need to either:
+- Add a build-tagged helper file `internal/api/sandbox_darwin.go` that wraps the call, OR
+- Use a compile-time interface
+
+The cleanest approach: create `internal/api/sandbox_darwin.go` and `internal/api/sandbox_other.go`:
+
+`sandbox_darwin.go`:
+```go
+//go:build darwin
+
+package api
+
+import (
+	"github.com/agentsh/agentsh/internal/platform/darwin"
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+func compileDarwinSandbox(pol *policy.Policy, workspace string) (*darwin.SandboxConfig, error) {
+	return darwin.CompileDarwinSandbox(pol, workspace)
+}
+```
+
+`sandbox_other.go`:
+```go
+//go:build !darwin
+
+package api
+
+import "github.com/agentsh/agentsh/internal/policy"
+
+type darwinSandboxConfig struct {
+	Profile     string
+	TokenValues []string
+}
+
+func compileDarwinSandbox(pol *policy.Policy, workspace string) (*darwinSandboxConfig, error) {
+	return nil, nil
+}
+```
+
+Then in `wrapWithMacSandbox`, call `compileDarwinSandbox(a.policy, sess.Workspace)`.
+
+- [ ] **Step 4: Verify build compiles on all platforms**
+
+Run: `go build ./...` and `GOOS=linux go build ./...` and `GOOS=windows go build ./...`
+Expected: all pass.
+
+- [ ] **Step 5: Run existing server tests**
+
+Run: `go test ./internal/api/... -v -count=1`
+Expected: all existing tests PASS (backwards compatible).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/api/core.go internal/api/sandbox_darwin.go internal/api/sandbox_other.go
+git commit -m "feat(api): wire CompileDarwinSandbox into wrapWithMacSandbox"
+```
+
+---
+
+### Task 8: Capability Detection Updates
+
+**Files:**
+- Modify: `internal/capabilities/detect_darwin.go`
+
+- [ ] **Step 1: Read current detection logic for context**
+
+Review `internal/capabilities/detect_darwin.go` (already read). Key changes:
+- `selectDarwinMode` needs new tiers for dynamic seatbelt
+- `buildDarwinDomains` needs command_control and isolation to be always-available
+- Check if `agentsh-macwrap` is in PATH for dynamic seatbelt detection
+
+- [ ] **Step 2: Update selectDarwinMode with new tiers**
+
+```go
+func selectDarwinMode(caps map[string]any) (string, int) {
+	if esf, _ := caps["esf"].(bool); esf {
+		return "esf", 90
+	}
+	if lima, _ := caps["lima_available"].(bool); lima {
+		return "lima", 85
+	}
+
+	hasMacwrap := checkMacwrap()
+	fuset, _ := caps["fuse_t"].(bool)
+
+	if hasMacwrap && fuset {
+		return "dynamic-seatbelt-fuse", 75
+	}
+	if fuset {
+		return "fuse-t", 70
+	}
+	if hasMacwrap {
+		return "dynamic-seatbelt", 65
+	}
+	return "sandbox-exec", 60
+}
+
+func checkMacwrap() bool {
+	_, err := exec.LookPath("agentsh-macwrap")
+	return err == nil
+}
+```
+
+- [ ] **Step 3: Update buildDarwinDomains to reflect dynamic seatbelt**
+
+```go
+func buildDarwinDomains(caps map[string]any) []ProtectionDomain {
+	fuseT, _ := caps["fuse_t"].(bool)
+	esf, _ := caps["esf"].(bool)
+	networkExt, _ := caps["network_extension"].(bool)
+	hasMacwrap := checkMacwrap()
+
+	fuseDetail := "not installed"
+	if fuseT {
+		fuseDetail = "FUSE-T"
+	}
+
+	macwrapDetail := "not found"
+	if hasMacwrap {
+		macwrapDetail = "dynamic seatbelt"
+	}
+
+	return []ProtectionDomain{
+		{
+			Name: "File Protection", Weight: WeightFileProtection,
+			Backends: []DetectedBackend{
+				{Name: "fuse-t", Available: fuseT, Detail: fuseDetail, Description: "filesystem interception", CheckMethod: "binary"},
+				{Name: "esf", Available: esf, Detail: "", Description: "Endpoint Security Framework", CheckMethod: "entitlement"},
+			},
+		},
+		{
+			Name: "Command Control", Weight: WeightCommandControl,
+			Backends: []DetectedBackend{
+				{Name: "esf", Available: esf, Detail: "", Description: "process execution control", CheckMethod: "entitlement"},
+				{Name: "dynamic-seatbelt", Available: hasMacwrap, Detail: macwrapDetail, Description: "policy-driven exec restriction", CheckMethod: "binary"},
+				{Name: "sandbox-exec", Available: true, Detail: "", Description: "macOS sandbox", CheckMethod: "builtin"},
+			},
+			Active: func() string {
+				if esf { return "esf" }
+				if hasMacwrap { return "dynamic-seatbelt" }
+				return "sandbox-exec"
+			}(),
+		},
+		{
+			Name: "Network", Weight: WeightNetwork,
+			Backends: []DetectedBackend{
+				{Name: "network-extension", Available: networkExt, Detail: "", Description: "network filtering", CheckMethod: "entitlement"},
+			},
+		},
+		{
+			Name: "Resource Limits", Weight: WeightResourceLimits,
+			Backends: []DetectedBackend{
+				{Name: "launchd-limits", Available: true, Detail: "", Description: "launchd resource limits", CheckMethod: "builtin"},
+			},
+			Active: "launchd-limits",
+		},
+		{
+			Name: "Isolation", Weight: WeightIsolation,
+			Backends: []DetectedBackend{
+				{Name: "dynamic-seatbelt", Available: hasMacwrap, Detail: macwrapDetail, Description: "deny-default sandbox", CheckMethod: "binary"},
+				{Name: "sandbox-exec", Available: true, Detail: "", Description: "process isolation", CheckMethod: "builtin"},
+			},
+			Active: func() string {
+				if hasMacwrap { return "dynamic-seatbelt" }
+				return "sandbox-exec"
+			}(),
+		},
+	}
+}
+```
+
+- [ ] **Step 4: Build and run existing capability tests**
+
+Run: `go test ./internal/capabilities/... -v`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/capabilities/detect_darwin.go
+git commit -m "feat(capabilities): add dynamic seatbelt tiers for macOS"
+```
+
+---
+
+### Task 9: Profile Artifact — Debug File
+
+**Files:**
+- Modify: `internal/api/core.go` (or the new `sandbox_darwin.go`)
+
+- [ ] **Step 1: Add profile artifact writing to wrapWithMacSandbox**
+
+After building the compiled profile, write it to the session directory for debugging. Add to `wrapWithMacSandbox` after the profile is compiled:
+
+```go
+	// Write profile artifact for debugging/inspection
+	if sandboxCfg != nil && sandboxCfg.Profile != "" && sess.ID != "" {
+		artifactDir := filepath.Join(os.Getenv("HOME"), ".agentsh", "sessions", sess.ID)
+		os.MkdirAll(artifactDir, 0700)
+		artifactPath := filepath.Join(artifactDir, "sandbox.sb")
+		if err := os.WriteFile(artifactPath, []byte(sandboxCfg.Profile), 0600); err != nil {
+			slog.Debug("failed to write sandbox profile artifact", "error", err)
+		}
+	}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `go build ./...`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/api/
+git commit -m "feat(api): write sandbox profile artifact to session directory"
+```
+
+---
+
+### Task 10: Cross-Compilation Verification and Full Test
+
+**Files:** All
+
+- [ ] **Step 1: Verify cross-compilation**
+
+Run: `GOOS=windows go build ./...`
+Expected: no errors (new darwin-only packages should not affect other platforms).
+
+Run: `GOOS=linux go build ./...`
+Expected: no errors.
+
+- [ ] **Step 2: Run all tests**
+
+Run: `go test ./...`
+Expected: all tests PASS.
+
+- [ ] **Step 3: Verify the SBPL builder tests run on any platform**
+
+The `sbpl/` package has no build tags — its tests should run everywhere.
+
+Run: `go test ./internal/platform/darwin/sbpl/... -v`
+Expected: PASS (pure Go, no CGo dependency).
+
+- [ ] **Step 4: Final commit if any cleanup needed**
+
+```bash
+git add -A
+git status  # verify no unexpected files
+# Only commit if there are changes
+```

--- a/docs/superpowers/specs/2026-03-23-dynamic-seatbelt-design.md
+++ b/docs/superpowers/specs/2026-03-23-dynamic-seatbelt-design.md
@@ -10,7 +10,9 @@ Replace the static, blanket-allow seatbelt profile in agentsh-macwrap with polic
 
 ## Context
 
-The macOS sandbox implementation (`darwin/sandbox.go`, `agentsh-macwrap`) uses seatbelt via `sandbox_init_with_parameters`. The SBPL profile is generated from a static template with blanket `(allow mach-lookup)`, `(allow process-exec)`, and binary network (`allow network*` or nothing). The policy engine's file/command/network rules are not reflected in the sandbox profile.
+The macOS sandbox implementation (`darwin/sandbox.go`, `agentsh-macwrap`) uses seatbelt via `sandbox_init_with_parameters` (private C API). The SBPL profile is generated from a static template with blanket `(allow mach-lookup)`, `(allow process-exec)`, and binary network (`allow network*` or nothing). The policy engine's file/command/network rules are not reflected in the sandbox profile.
+
+Note: `sandbox-exec` is deprecated by Apple, but `sandbox_init_with_parameters` remains functional on all current macOS versions. The long-term migration path is ESF + Network Extension (Spec B) for enforcement, with seatbelt as a defense-in-depth layer. This spec strengthens seatbelt enforcement while it remains available.
 
 On Linux, seccomp user-notify, ptrace, Landlock, and eBPF provide fine-grained enforcement. This spec brings macOS closer to parity by making the seatbelt profile enforce the same policy rules the rest of the stack uses.
 
@@ -51,9 +53,13 @@ Policy YAML
 └─────────────────────────────┘
 ```
 
-Profile generation moves out of macwrap into the parent Go process where the policy engine lives. Macwrap becomes a thin applier: consume tokens, apply profile, exec.
+Profile generation moves out of macwrap into the **server process** (`internal/api/core.go`), where the policy engine already lives. Today, `wrapWithMacSandbox()` in `core.go` builds a `macSandboxWrapperConfig` and passes it to macwrap via `AGENTSH_SANDBOX_CONFIG`. In the new design, this method calls `CompileDarwinSandbox()` to produce the full SBPL string and extension tokens, then passes both through the same env var. Macwrap becomes a thin applier: consume tokens, apply profile, exec.
 
 The compiled SBPL is also written to `~/.agentsh/sessions/<id>/sandbox.sb` for inspection/debugging. This file is informational — macwrap receives the profile via `WrapperConfig`, never from disk.
+
+**Token issuance:** `sandbox_extension_issue_file()` must be called from an **unsandboxed process**. The server process (which runs unsandboxed) issues all tokens and serializes the opaque token strings into the `WrapperConfig`. Macwrap (which is also unsandboxed at the time of token consumption — it consumes tokens before calling `sandbox_init`) calls `sandbox_extension_consume()` for each token, granting access to itself and its future child process.
+
+**Environment variable size:** The compiled SBPL + serialized tokens will be larger than the current simple JSON config. For policies with many rules, the combined payload could approach shell environment limits (~128KB). If the payload exceeds 64KB, the server writes it to a temp file (`/tmp/agentsh-sandbox-<session>.json`) and passes the file path via `AGENTSH_SANDBOX_CONFIG_FILE` instead. Macwrap reads and deletes the file atomically.
 
 ### Layered Perimeter Model
 
@@ -114,16 +120,21 @@ sbplString, err := p.Build()
 
 ### `AllowSystemEssentials()` includes
 
-- `/dev/null`, `/dev/random`, `/dev/urandom`, `/dev/zero`
-- `/usr/lib`, `/System/Library`, dyld shared cache
-- `process-fork`, `signal (target self)`, `sysctl-read`
-- TTY access (`/dev/ttys*`, `/dev/pty*`)
-- `/tmp`, `/private/tmp`, `/var/folders`
-- `ipc-posix*`
+Mirrors all paths currently in `profile.go`'s `generateProfile()`:
+
+- **Dev files:** `/dev/null`, `/dev/random`, `/dev/urandom`, `/dev/zero`
+- **System libraries:** `/usr/lib`, `/usr/share`, `/System/Library`, `/Library/Frameworks`, `/private/var/db/dyld` (dyld shared cache)
+- **Process operations:** `process-fork`, `signal (target self)`, `sysctl-read`
+- **TTY access:** `/dev/ttys*` (regex), `/dev/pty*` (regex), `/dev/tty` (literal)
+- **Common tool paths (read-only):** `/usr/bin`, `/usr/sbin`, `/bin`, `/sbin`, `/usr/local/bin`, `/opt/homebrew/bin`, `/opt/homebrew/Cellar`
+- **Temp files:** `/tmp`, `/private/tmp`, `/var/folders`
+- **IPC:** `ipc-posix*`, `mach-register` (needed for own XPC services)
 
 ### Rule ordering
 
-SBPL evaluates first-match. Builder enforces deny-before-allow within each category. `DenyProcessExec(osascript)` is emitted before `AllowProcessExec(Subpath, /usr/bin)`.
+SBPL with `(deny default)` denies anything not explicitly allowed. Explicit `(deny ...)` rules override `(allow ...)` rules for the same operation regardless of order, because the sandbox evaluates deny rules with higher priority. However, the builder emits deny rules before allow rules within each category for readability and to make the intent clear when inspecting the profile.
+
+For the exec blocklist, this means `(deny process-exec (literal "/usr/bin/osascript"))` takes precedence over `(allow process-exec (subpath "/usr/bin"))` regardless of emission order — the kernel enforces the deny.
 
 ### Validation in `Build()`
 
@@ -178,38 +189,47 @@ Belt and suspenders. The SBPL `subpath` rule declares structural permission. The
 
 ### File rule mapping
 
-| Policy YAML | SBPL | Extension token |
-|---|---|---|
-| `path: /x, access: read` | `AllowFileRead(Subpath, "/x")` | `Issue("/x", ReadOnly)` |
-| `path: /x, access: write` | `AllowFileReadWrite(Subpath, "/x")` | `Issue("/x", ReadWrite)` |
-| `path: /x/file.txt, access: read` | `AllowFileRead(Literal, "/x/file.txt")` | `Issue("/x/file.txt", ReadOnly)` |
-| No rule for path | Omitted (deny-default) | No token |
+Policy file rules use `FileRule{Paths: []string, Operations: []string, Decision: string}` from `internal/policy/model.go`.
 
-Path type: directory or `/*` suffix → `Subpath`. Specific file → `Literal`.
+| `FileRule` fields | SBPL | Extension token |
+|---|---|---|
+| `Paths: ["/x"], Operations: ["read"], Decision: "allow"` | `AllowFileRead(Subpath, "/x")` | `Issue("/x", ReadOnly)` |
+| `Paths: ["/x"], Operations: ["write", "read"], Decision: "allow"` | `AllowFileReadWrite(Subpath, "/x")` | `Issue("/x", ReadWrite)` |
+| `Paths: ["/x/file.txt"], Operations: ["read"], Decision: "allow"` | `AllowFileRead(Literal, "/x/file.txt")` | `Issue("/x/file.txt", ReadOnly)` |
+| `Paths: ["/x"], Decision: "deny"` | Omitted (deny-default handles it) | No token |
+| No matching rule | Omitted (deny-default) | No token |
+
+Path type detection: glob patterns or directory paths → `Subpath`. Paths with a file extension or no trailing `/` that resolve to a file → `Literal`. The `Operations` field determines read-only vs read-write: if operations include `"write"`, `"*"`, or `"delete"` → `ReadWrite` token and `AllowFileReadWrite`; otherwise → `ReadOnly` and `AllowFileRead`.
 
 ### Command rule mapping
 
-| Policy YAML | SBPL |
+Policy command rules use `CommandRule{Commands: []string, Decision: string}` from `internal/policy/model.go`.
+
+| `CommandRule` fields | SBPL |
 |---|---|
-| `command: /usr/bin/git, action: allow` | `AllowProcessExec(Literal, "/usr/bin/git")` |
-| `command: python*, action: allow` | Resolve to full path, `AllowProcessExec(Literal, resolved)` |
-| `command: osascript, action: deny` | `DenyProcessExec(Literal, "/usr/bin/osascript")` |
+| `Commands: ["/usr/bin/git"], Decision: "allow"` | `AllowProcessExec(Literal, "/usr/bin/git")` |
+| `Commands: ["python*"], Decision: "allow"` | Resolve to full path, `AllowProcessExec(Literal, resolved)` |
+| `Commands: ["osascript"], Decision: "deny"` | `DenyProcessExec(Literal, "/usr/bin/osascript")` |
+| `Decision: "approve"` or `"redirect"` | Not mapped to SBPL (handled by shell shim/ESF) |
 
 Default exec path allowlist (always emitted):
 - `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`, `/usr/local/bin`, `/opt/homebrew/bin`, workspace path
 
-Default exec blocklist (always emitted, deny-before-allow):
+Default exec blocklist (always emitted):
 - `osascript`, `security`, `systemsetup`, `tccutil`, `csrutil`
 
 ### Network rule mapping
 
-| Policy YAML | SBPL |
+Policy network rules use `NetworkRule{Domains: []string, Ports: []int, CIDRs: []string, Decision: string}` from `internal/policy/model.go`.
+
+| `NetworkRule` fields | SBPL |
 |---|---|
-| `ports: [443]` | `AllowNetworkOutbound("tcp", "*:443")` |
-| `allow_all: true` | `(allow network*)` |
+| `Ports: [443], Decision: "allow"` | `(allow network-outbound (remote tcp "*:443"))` |
+| `Decision: "allow"` (no port/domain restriction) | `(allow network*)` |
+| `Domains: ["*.github.com"], Decision: "allow"` | `(allow network*)` + log warning |
 | No network rules | Deny-default blocks all |
 
-SBPL cannot express domain-based rules. Domain filtering requires Network Extension (Spec B). If the policy has domain-specific rules, the port is allowed and a log notes that domain filtering requires NE.
+**Caveat:** SBPL port-level network filtering (`network-outbound` with `remote` filters) has limited reliability on macOS 12+. The primary enforcement model is binary: `(allow network*)` or deny-default. Port-level rules are emitted as best-effort defense-in-depth. Domain-based filtering is not expressible in SBPL and requires Network Extension (Spec B). If the policy has domain-specific rules, network is allowed at the SBPL level and a log notes that domain filtering requires NE.
 
 ### Mach service mapping
 
@@ -287,6 +307,10 @@ Command control and isolation become always-available because dynamic seatbelt p
 
 Scoring is conservative (75 with FUSE-T, 65 without) pending real-world validation.
 
+### Detection criteria
+
+"Dynamic seatbelt" is a code capability, not a system dependency — it's always available when the updated server code is running. Detection in `selectDarwinMode()`: if `agentsh-macwrap` is available in PATH (existing check), select dynamic seatbelt mode. The distinction from the old "sandbox-exec" mode is code-level: the server now sends `CompiledProfile` in the config. No runtime probe needed — the mode is determined by server version, not system capabilities. FUSE-T detection remains unchanged (library file check).
+
 ### Seatbelt-only mode
 
 When FUSE-T is not installed, dynamic seatbelt is a standalone supported mode at score ~65. Provides: kernel-enforced exec path restriction, Mach service restriction, file path boundaries. Does not provide: per-operation file policy, file redirect, soft-delete, dynamic mid-session file grants.
@@ -299,7 +323,7 @@ Pure Go, no CGo, runs on any OS. Tests SBPL string output for given inputs: corr
 
 ### Layer 2: Token manager unit tests (`sandboxext/manager_test.go`)
 
-CGo, darwin-only. Tests real `sandbox_extension_issue/release` calls: issue returns valid token, revoke removes from active set, RevokeAll clears, double-revoke is safe, issue for nonexistent path returns error.
+CGo, darwin-only. Tests real `sandbox_extension_issue/consume/release` calls: issue returns valid token, consume succeeds for valid token, revoke removes from active set, RevokeAll clears, double-revoke is safe, issue for nonexistent path returns error, consume of invalid token string returns -1 handle.
 
 ### Layer 3: Policy compilation integration tests (`darwin/sandbox_test.go`)
 
@@ -319,11 +343,11 @@ Darwin-only, `integration` build tag. Launches macwrap with compiled profile: ex
 | `internal/platform/darwin/sandboxext/manager_test.go` | New — token manager tests |
 | `internal/platform/darwin/sandbox.go` | Add `CompileDarwinSandbox()` method |
 | `internal/platform/darwin/sandbox_test.go` | Add compilation integration tests |
+| `internal/api/core.go` | Update `wrapWithMacSandbox()` to call `CompileDarwinSandbox()`, populate `CompiledProfile` and `ExtensionTokens` in config |
 | `cmd/agentsh-macwrap/main.go` | Add `consumeTokens()`, use `CompiledProfile` |
-| `cmd/agentsh-macwrap/config.go` | Add `CompiledProfile`, `ExtensionTokens` fields |
+| `cmd/agentsh-macwrap/config.go` | Add `CompiledProfile`, `ExtensionTokens` fields to `WrapperConfig` |
 | `cmd/agentsh-macwrap/profile.go` | Keep as legacy fallback |
 | `internal/capabilities/detect_darwin.go` | Add dynamic seatbelt tiers, update domain availability |
-| `internal/cli/wrap_darwin.go` | Call `CompileDarwinSandbox()`, populate new WrapperConfig fields |
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-03-23-dynamic-seatbelt-design.md
+++ b/docs/superpowers/specs/2026-03-23-dynamic-seatbelt-design.md
@@ -1,0 +1,334 @@
+# Dynamic Seatbelt: Policy-Driven macOS Sandbox Enforcement
+
+**Date:** 2026-03-23
+**Status:** Spec
+**Scope:** macOS enforcement — SBPL generation, extension tokens, Mach service restriction
+
+## Summary
+
+Replace the static, blanket-allow seatbelt profile in agentsh-macwrap with policy-driven SBPL generation. Add sandbox extension tokens for runtime file access grants. Restrict Mach service access. This closes the macOS enforcement gap for command control, isolation, and Mach service restriction without requiring ESF or Network Extension entitlements.
+
+## Context
+
+The macOS sandbox implementation (`darwin/sandbox.go`, `agentsh-macwrap`) uses seatbelt via `sandbox_init_with_parameters`. The SBPL profile is generated from a static template with blanket `(allow mach-lookup)`, `(allow process-exec)`, and binary network (`allow network*` or nothing). The policy engine's file/command/network rules are not reflected in the sandbox profile.
+
+On Linux, seccomp user-notify, ptrace, Landlock, and eBPF provide fine-grained enforcement. This spec brings macOS closer to parity by making the seatbelt profile enforce the same policy rules the rest of the stack uses.
+
+This is Spec A of two. Spec B (Network Extension) covers domain-level network filtering and is independent.
+
+## Architecture
+
+Three new components, one enhanced:
+
+```
+Policy YAML
+    │
+    ▼
+┌─────────────────────────────┐
+│  sandbox.go                 │
+│  CompileDarwinSandbox()     │  ← existing file, new method
+└──────┬──────────┬───────────┘
+       │          │
+       ▼          ▼
+┌────────────┐  ┌──────────────────┐
+│ sbpl/      │  │ sandboxext/      │
+│ Builder    │  │ TokenManager     │
+└────────────┘  └──────────────────┘
+       │          │
+       ▼          ▼
+┌─────────────────────────────┐
+│  WrapperConfig (enhanced)   │
+│  .CompiledProfile  string   │
+│  .ExtensionTokens  []string │
+└──────────────┬──────────────┘
+               │ JSON via AGENTSH_SANDBOX_CONFIG env var
+               ▼
+┌─────────────────────────────┐
+│  agentsh-macwrap            │
+│  consumeTokens() →         │
+│  sandbox_init(profile) →   │
+│  exec(child)               │
+└─────────────────────────────┘
+```
+
+Profile generation moves out of macwrap into the parent Go process where the policy engine lives. Macwrap becomes a thin applier: consume tokens, apply profile, exec.
+
+The compiled SBPL is also written to `~/.agentsh/sessions/<id>/sandbox.sb` for inspection/debugging. This file is informational — macwrap receives the profile via `WrapperConfig`, never from disk.
+
+### Layered Perimeter Model
+
+- **Seatbelt = outer perimeter.** Generated at session start from the policy snapshot. Deny-default base. Immutable — cannot be modified after `sandbox_init`.
+- **Extension tokens = runtime file access.** Static policy paths: tokens consumed by macwrap before exec, inherited by child. Dynamic approvals mid-session: only possible via FUSE-T.
+- **FUSE-T = fine-grained file policy.** Per-operation decisions, soft-delete, redirect. Seatbelt allows the FUSE mount point; FUSE makes the real decision.
+- **Shell shim = command policy.** Fine-grained command control (redirect, approval). Seatbelt provides kernel-level backstop for exec path restriction.
+
+Mid-session policy changes for file paths are handled by FUSE-T. Command and Mach service policy changes require a new session (seatbelt is immutable). This is acceptable — policy changes to commands/services typically apply to new sessions.
+
+## Component 1: SBPL Builder (`internal/platform/darwin/sbpl/`)
+
+Pure Go package. No CGo, no templates. Constructs valid SBPL via a typed API.
+
+### Types
+
+```go
+type Profile struct {
+    rules []rule
+}
+
+type PathMatch int
+const (
+    Literal PathMatch = iota  // (literal "/exact/path")
+    Subpath                   // (subpath "/dir")
+    Regex                     // (regex #"/pattern"#)
+)
+```
+
+### API
+
+```go
+p := sbpl.New()  // starts with (version 1) (deny default)
+
+// File access
+p.AllowFileRead(Subpath, "/usr/lib")
+p.AllowFileReadWrite(Subpath, "/workspace/project")
+p.AllowFileRead(Literal, "/etc/hosts")
+
+// Process exec
+p.AllowProcessExec(Subpath, "/usr/bin")
+p.DenyProcessExec(Literal, "/usr/bin/osascript")
+
+// Mach services
+p.AllowMachLookup("com.apple.system.logger")
+p.AllowMachLookupPrefix("com.apple.system.")
+p.DenyMachLookup("com.apple.security.authtrampoline")
+
+// Network (static, port-level only)
+p.AllowNetworkOutbound("tcp", "*:443")
+
+// System essentials (convenience)
+p.AllowSystemEssentials()
+
+// Build
+sbplString, err := p.Build()
+```
+
+### `AllowSystemEssentials()` includes
+
+- `/dev/null`, `/dev/random`, `/dev/urandom`, `/dev/zero`
+- `/usr/lib`, `/System/Library`, dyld shared cache
+- `process-fork`, `signal (target self)`, `sysctl-read`
+- TTY access (`/dev/ttys*`, `/dev/pty*`)
+- `/tmp`, `/private/tmp`, `/var/folders`
+- `ipc-posix*`
+
+### Rule ordering
+
+SBPL evaluates first-match. Builder enforces deny-before-allow within each category. `DenyProcessExec(osascript)` is emitted before `AllowProcessExec(Subpath, /usr/bin)`.
+
+### Validation in `Build()`
+
+- All paths must be absolute
+- No contradictory rules (allow and deny same literal)
+- Deny-default always present
+- Returns error on invalid profile
+
+## Component 2: Extension Token Manager (`internal/platform/darwin/sandboxext/`)
+
+CGo package wrapping Apple's sandbox extension C API.
+
+### Types
+
+```go
+type ExtClass string
+const (
+    ReadOnly  ExtClass = "com.apple.app-sandbox.read"
+    ReadWrite ExtClass = "com.apple.app-sandbox.read-write"
+)
+
+type Token struct {
+    Path    string
+    Class   ExtClass
+    Value   string    // opaque token from sandbox_extension_issue
+    Issued  time.Time
+}
+
+type Manager struct {
+    mu     sync.Mutex
+    tokens map[string]*Token
+}
+```
+
+### API
+
+```go
+mgr := sandboxext.NewManager()
+token, err := mgr.Issue("/workspace/src", ReadWrite)
+tokens := mgr.ActiveTokens()
+err := mgr.Revoke("/workspace/src")
+mgr.RevokeAll()  // session cleanup
+```
+
+### Why both SBPL rules AND tokens for the same path
+
+Belt and suspenders. The SBPL `subpath` rule declares structural permission. The extension token activates runtime access. Some macOS versions enforce one or both. Cost is negligible (one C call per path at session start).
+
+## Component 3: Policy-to-Sandbox Compilation
+
+`CompileDarwinSandbox()` in `internal/platform/darwin/sandbox.go` orchestrates the builder and token manager.
+
+### File rule mapping
+
+| Policy YAML | SBPL | Extension token |
+|---|---|---|
+| `path: /x, access: read` | `AllowFileRead(Subpath, "/x")` | `Issue("/x", ReadOnly)` |
+| `path: /x, access: write` | `AllowFileReadWrite(Subpath, "/x")` | `Issue("/x", ReadWrite)` |
+| `path: /x/file.txt, access: read` | `AllowFileRead(Literal, "/x/file.txt")` | `Issue("/x/file.txt", ReadOnly)` |
+| No rule for path | Omitted (deny-default) | No token |
+
+Path type: directory or `/*` suffix → `Subpath`. Specific file → `Literal`.
+
+### Command rule mapping
+
+| Policy YAML | SBPL |
+|---|---|
+| `command: /usr/bin/git, action: allow` | `AllowProcessExec(Literal, "/usr/bin/git")` |
+| `command: python*, action: allow` | Resolve to full path, `AllowProcessExec(Literal, resolved)` |
+| `command: osascript, action: deny` | `DenyProcessExec(Literal, "/usr/bin/osascript")` |
+
+Default exec path allowlist (always emitted):
+- `/usr/bin`, `/bin`, `/usr/sbin`, `/sbin`, `/usr/local/bin`, `/opt/homebrew/bin`, workspace path
+
+Default exec blocklist (always emitted, deny-before-allow):
+- `osascript`, `security`, `systemsetup`, `tccutil`, `csrutil`
+
+### Network rule mapping
+
+| Policy YAML | SBPL |
+|---|---|
+| `ports: [443]` | `AllowNetworkOutbound("tcp", "*:443")` |
+| `allow_all: true` | `(allow network*)` |
+| No network rules | Deny-default blocks all |
+
+SBPL cannot express domain-based rules. Domain filtering requires Network Extension (Spec B). If the policy has domain-specific rules, the port is allowed and a log notes that domain filtering requires NE.
+
+### Mach service mapping
+
+Essential allowlist (always emitted):
+- `com.apple.system.logger`
+- `com.apple.SecurityServer`
+- `com.apple.distributed_notifications@Gv0`
+- `com.apple.system.notification_center`
+- `com.apple.CoreServices.coreservicesd`
+- `com.apple.DiskArbitration.diskarbitrationd`
+- `com.apple.xpc.launchd.domain.system`
+
+Dangerous blocklist (always emitted, deny-before-allow):
+- `com.apple.security.authtrampoline`
+- `com.apple.coreservices.launchservicesd`
+- `com.apple.pasteboard.*` (clipboard)
+- `com.apple.securityd` (keychain direct)
+
+Policy YAML can override with explicit allows for agents that need clipboard or keychain access.
+
+## Component 4: WrapperConfig Changes
+
+### Enhanced struct
+
+```go
+type WrapperConfig struct {
+    // Existing fields (kept for backwards compatibility)
+    WorkspacePath string
+    AllowedPaths  []string
+    AllowNetwork  bool
+    MachServices  MachServicesConfig
+
+    // New fields
+    CompiledProfile string   // pre-compiled SBPL string
+    ExtensionTokens []string // token strings to consume before sandbox_init
+}
+```
+
+### macwrap flow
+
+```
+loadConfig() → consumeTokens(config.ExtensionTokens) → sandbox_init(config.CompiledProfile) → exec(child)
+```
+
+If `CompiledProfile` is empty, macwrap falls back to current `generateProfile()` behavior (backwards compatible with old server versions).
+
+### Token consumption
+
+Token consumption failures are warnings, not errors. The SBPL rule still provides access even if the token fails. Tokens must be consumed before `sandbox_init`. Child inherits consumed extensions through exec.
+
+## Capability Detection & Scoring
+
+### New tiers in `detect_darwin.go`
+
+```
+ESF:                        90  (unchanged)
+Lima:                       85  (unchanged)
+Dynamic seatbelt + FUSE-T:  75  (new)
+Dynamic seatbelt only:      65  (new)
+FUSE-T (legacy profile):    70  (existing, fallback)
+Sandbox-exec (legacy):      60  (existing, fallback)
+```
+
+### Protection domain changes
+
+| Domain | Weight | Before | After |
+|---|---|---|---|
+| file_protection | 25 | Requires FUSE-T | Requires FUSE-T (unchanged) |
+| command_control | 25 | Requires ESF | Always available (dynamic seatbelt) |
+| network | 20 | Requires NE | Requires NE (unchanged, Spec B) |
+| resource_limits | 15 | Always (launchd) | Always (unchanged) |
+| isolation | 15 | Requires ESF | Always available (deny-default seatbelt) |
+
+Command control and isolation become always-available because dynamic seatbelt provides real enforcement (exec path restriction + deny-default + Mach restriction).
+
+Scoring is conservative (75 with FUSE-T, 65 without) pending real-world validation.
+
+### Seatbelt-only mode
+
+When FUSE-T is not installed, dynamic seatbelt is a standalone supported mode at score ~65. Provides: kernel-enforced exec path restriction, Mach service restriction, file path boundaries. Does not provide: per-operation file policy, file redirect, soft-delete, dynamic mid-session file grants.
+
+## Testing Strategy
+
+### Layer 1: SBPL builder unit tests (`sbpl/builder_test.go`)
+
+Pure Go, no CGo, runs on any OS. Tests SBPL string output for given inputs: correct syntax per rule type, deny-before-allow ordering, rejects relative paths, rejects contradictory rules, system essentials completeness, empty builder produces valid deny-default profile.
+
+### Layer 2: Token manager unit tests (`sandboxext/manager_test.go`)
+
+CGo, darwin-only. Tests real `sandbox_extension_issue/release` calls: issue returns valid token, revoke removes from active set, RevokeAll clears, double-revoke is safe, issue for nonexistent path returns error.
+
+### Layer 3: Policy compilation integration tests (`darwin/sandbox_test.go`)
+
+Darwin-only. Full policy-to-SandboxConfig pipeline with YAML fixtures: file rules produce correct SBPL + tokens, command rules produce correct exec allow/deny, Mach essential allowlist always present, Mach blocklist emitted before allowlist, empty policy produces minimal valid profile.
+
+### Layer 4: Sandbox enforcement integration tests (`darwin/sandbox_integration_test.go`)
+
+Darwin-only, `integration` build tag. Launches macwrap with compiled profile: exec denied outside allowed paths, blocked exec denied even within /usr/bin, extension token grants file access, Mach service deny prevents lookup, backwards compatibility with empty CompiledProfile.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `internal/platform/darwin/sbpl/builder.go` | New — SBPL builder |
+| `internal/platform/darwin/sbpl/builder_test.go` | New — builder tests |
+| `internal/platform/darwin/sandboxext/manager.go` | New — token manager |
+| `internal/platform/darwin/sandboxext/manager_test.go` | New — token manager tests |
+| `internal/platform/darwin/sandbox.go` | Add `CompileDarwinSandbox()` method |
+| `internal/platform/darwin/sandbox_test.go` | Add compilation integration tests |
+| `cmd/agentsh-macwrap/main.go` | Add `consumeTokens()`, use `CompiledProfile` |
+| `cmd/agentsh-macwrap/config.go` | Add `CompiledProfile`, `ExtensionTokens` fields |
+| `cmd/agentsh-macwrap/profile.go` | Keep as legacy fallback |
+| `internal/capabilities/detect_darwin.go` | Add dynamic seatbelt tiers, update domain availability |
+| `internal/cli/wrap_darwin.go` | Call `CompileDarwinSandbox()`, populate new WrapperConfig fields |
+
+## Out of Scope
+
+- **Network Extension** — Spec B, independent
+- **ESF integration** — requires Apple entitlement approval, orthogonal
+- **SBPL hot-reload** — not possible (kernel limitation). Layered perimeter handles this.
+- **Dynamic mid-session file grants without FUSE-T** — would require DYLD_INSERT_LIBRARIES injection, blocked by SIP for system binaries. Accepted limitation of seatbelt-only mode.
+- **Per-binary exec allowlists** — too fragile. Path-based restriction provides sufficient defense-in-depth alongside the shell shim.

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -78,6 +78,10 @@ type macSandboxWrapperConfig struct {
 	AllowedPaths  []string                     `json:"allowed_paths"`
 	AllowNetwork  bool                         `json:"allow_network"`
 	MachServices  macSandboxMachServicesConfig `json:"mach_services"`
+
+	// Dynamic seatbelt fields
+	CompiledProfile string   `json:"compiled_profile,omitempty"`
+	ExtensionTokens []string `json:"extension_tokens,omitempty"`
 }
 
 type macSandboxMachServicesConfig struct {
@@ -1410,9 +1414,7 @@ func (a *App) wrapWithMacSandbox(
 		wrapperBin = "agentsh-macwrap"
 	}
 
-	// Check if wrapper exists
 	if _, err := exec.LookPath(wrapperBin); err != nil {
-		// Wrapper not found, skip sandbox
 		return
 	}
 
@@ -1425,7 +1427,6 @@ func (a *App) wrapWithMacSandbox(
 		BlockPrefixes: a.cfg.Sandbox.XPC.MachServices.BlockPrefixes,
 	}
 
-	// Apply defaults if not configured
 	if machCfg.DefaultAction == "" {
 		machCfg.DefaultAction = "deny"
 	}
@@ -1439,20 +1440,35 @@ func (a *App) wrapWithMacSandbox(
 	cfg := macSandboxWrapperConfig{
 		WorkspacePath: sess.Workspace,
 		AllowedPaths:  []string{os.Getenv("HOME")},
-		AllowNetwork:  true, // Default allow, can be policy-controlled
+		AllowNetwork:  true,
 		MachServices:  machCfg,
 	}
 
+	// Compile policy-driven SBPL profile (darwin+cgo only, no-op on other platforms)
+	compileDarwinSandboxProfile(&cfg, a.policy, sess.Workspace)
+
 	cfgJSON, err := json.Marshal(cfg)
 	if err != nil {
-		// Failed to marshal config, skip sandbox
 		return
 	}
 
 	if req.Env == nil {
 		req.Env = map[string]string{}
 	}
-	req.Env["AGENTSH_SANDBOX_CONFIG"] = string(cfgJSON)
+
+	// Use file-based config if payload is too large for env var
+	cfgStr := string(cfgJSON)
+	if len(cfgStr) > 64*1024 {
+		tmpFile := fmt.Sprintf("/tmp/agentsh-sandbox-%s.json", sess.ID)
+		if err := os.WriteFile(tmpFile, cfgJSON, 0600); err != nil {
+			slog.Warn("failed to write sandbox config file", "error", err)
+			return
+		}
+		req.Env["AGENTSH_SANDBOX_CONFIG_FILE"] = tmpFile
+	} else {
+		req.Env["AGENTSH_SANDBOX_CONFIG"] = cfgStr
+	}
+
 	req.Command = wrapperBin
 	req.Args = append([]string{"--", origCommand}, origArgs...)
 }

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -1447,6 +1447,16 @@ func (a *App) wrapWithMacSandbox(
 	// Compile policy-driven SBPL profile (darwin+cgo only, no-op on other platforms)
 	compileDarwinSandboxProfile(&cfg, a.policy, sess.Workspace)
 
+	// Write profile artifact for debugging/inspection
+	if cfg.CompiledProfile != "" && sess.ID != "" {
+		artifactDir := filepath.Join(os.Getenv("HOME"), ".agentsh", "sessions", sess.ID)
+		os.MkdirAll(artifactDir, 0700)
+		artifactPath := filepath.Join(artifactDir, "sandbox.sb")
+		if err := os.WriteFile(artifactPath, []byte(cfg.CompiledProfile), 0600); err != nil {
+			slog.Debug("failed to write sandbox profile artifact", "error", err)
+		}
+	}
+
 	cfgJSON, err := json.Marshal(cfg)
 	if err != nil {
 		return

--- a/internal/api/sandbox_compile_darwin.go
+++ b/internal/api/sandbox_compile_darwin.go
@@ -1,0 +1,31 @@
+//go:build darwin && cgo
+
+package api
+
+import (
+	"log/slog"
+
+	"github.com/agentsh/agentsh/internal/platform/darwin"
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+// compileDarwinSandboxProfile compiles a policy-driven SBPL profile and populates
+// the wrapper config's CompiledProfile and ExtensionTokens fields.
+// Returns true if compilation succeeded, false to fall back to legacy profile.
+func compileDarwinSandboxProfile(cfg *macSandboxWrapperConfig, engine *policy.Engine, workspace string) bool {
+	pol := engine.Policy()
+	if pol == nil {
+		return false
+	}
+
+	sandboxCfg, err := darwin.CompileDarwinSandbox(pol, workspace)
+	if err != nil {
+		slog.Warn("failed to compile darwin sandbox profile, falling back to legacy",
+			"error", err)
+		return false
+	}
+
+	cfg.CompiledProfile = sandboxCfg.Profile
+	cfg.ExtensionTokens = sandboxCfg.TokenValues
+	return true
+}

--- a/internal/api/sandbox_compile_other.go
+++ b/internal/api/sandbox_compile_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin || !cgo
+
+package api
+
+import "github.com/agentsh/agentsh/internal/policy"
+
+func compileDarwinSandboxProfile(cfg *macSandboxWrapperConfig, engine *policy.Engine, workspace string) bool {
+	return false
+}

--- a/internal/capabilities/detect_darwin.go
+++ b/internal/capabilities/detect_darwin.go
@@ -11,10 +11,16 @@ func buildDarwinDomains(caps map[string]any) []ProtectionDomain {
 	fuseT, _ := caps["fuse_t"].(bool)
 	esf, _ := caps["esf"].(bool)
 	networkExt, _ := caps["network_extension"].(bool)
+	hasMacwrap := checkMacwrap()
 
 	fuseDetail := "not installed"
 	if fuseT {
 		fuseDetail = "FUSE-T"
+	}
+
+	macwrapDetail := "not found"
+	if hasMacwrap {
+		macwrapDetail = "dynamic seatbelt"
 	}
 
 	return []ProtectionDomain{
@@ -29,9 +35,18 @@ func buildDarwinDomains(caps map[string]any) []ProtectionDomain {
 			Name: "Command Control", Weight: WeightCommandControl,
 			Backends: []DetectedBackend{
 				{Name: "esf", Available: esf, Detail: "", Description: "process execution control", CheckMethod: "entitlement"},
+				{Name: "dynamic-seatbelt", Available: hasMacwrap, Detail: macwrapDetail, Description: "policy-driven exec restriction", CheckMethod: "binary"},
 				{Name: "sandbox-exec", Available: true, Detail: "", Description: "macOS sandbox", CheckMethod: "builtin"},
 			},
-			Active: "sandbox-exec",
+			Active: func() string {
+				if esf {
+					return "esf"
+				}
+				if hasMacwrap {
+					return "dynamic-seatbelt"
+				}
+				return "sandbox-exec"
+			}(),
 		},
 		{
 			Name: "Network", Weight: WeightNetwork,
@@ -49,9 +64,15 @@ func buildDarwinDomains(caps map[string]any) []ProtectionDomain {
 		{
 			Name: "Isolation", Weight: WeightIsolation,
 			Backends: []DetectedBackend{
+				{Name: "dynamic-seatbelt", Available: hasMacwrap, Detail: macwrapDetail, Description: "deny-default sandbox", CheckMethod: "binary"},
 				{Name: "sandbox-exec", Available: true, Detail: "", Description: "process isolation", CheckMethod: "builtin"},
 			},
-			Active: "sandbox-exec",
+			Active: func() string {
+				if hasMacwrap {
+					return "dynamic-seatbelt"
+				}
+				return "sandbox-exec"
+			}(),
 		},
 	}
 }
@@ -123,15 +144,30 @@ func checkLima() bool {
 	return err == nil
 }
 
+func checkMacwrap() bool {
+	_, err := exec.LookPath("agentsh-macwrap")
+	return err == nil
+}
+
 func selectDarwinMode(caps map[string]any) (string, int) {
 	if esf, _ := caps["esf"].(bool); esf {
 		return "esf", 90
 	}
-	if fuset, _ := caps["fuse_t"].(bool); fuset {
-		return "fuse-t", 70
-	}
 	if lima, _ := caps["lima_available"].(bool); lima {
 		return "lima", 85
+	}
+
+	hasMacwrap := checkMacwrap()
+	fuset, _ := caps["fuse_t"].(bool)
+
+	if hasMacwrap && fuset {
+		return "dynamic-seatbelt-fuse", 75
+	}
+	if fuset {
+		return "fuse-t", 70
+	}
+	if hasMacwrap {
+		return "dynamic-seatbelt", 65
 	}
 	return "sandbox-exec", 60
 }

--- a/internal/capabilities/detect_darwin_test.go
+++ b/internal/capabilities/detect_darwin_test.go
@@ -6,6 +6,49 @@ import (
 	"testing"
 )
 
+func TestSelectDarwinMode(t *testing.T) {
+	hasMacwrap := checkMacwrap()
+
+	tests := []struct {
+		name         string
+		caps         map[string]any
+		wantMode     string
+		wantScore    int
+		needsMacwrap bool
+	}{
+		{"esf wins", map[string]any{"esf": true, "fuse_t": true, "lima_available": true}, "esf", 90, false},
+		{"lima second", map[string]any{"esf": false, "fuse_t": true, "lima_available": true}, "lima", 85, false},
+		// These depend on macwrap availability
+		{"dynamic seatbelt + fuse", map[string]any{"esf": false, "fuse_t": true, "lima_available": false}, "dynamic-seatbelt-fuse", 75, true},
+		{"dynamic seatbelt only", map[string]any{"esf": false, "fuse_t": false, "lima_available": false}, "dynamic-seatbelt", 65, true},
+		// These only apply when macwrap is NOT available
+		{"fuse-t only", map[string]any{"esf": false, "fuse_t": true, "lima_available": false}, "fuse-t", 70, false},
+		{"sandbox-exec fallback", map[string]any{"esf": false, "fuse_t": false, "lima_available": false}, "sandbox-exec", 60, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.needsMacwrap && !hasMacwrap {
+				t.Skip("agentsh-macwrap not in PATH")
+			}
+			if !tt.needsMacwrap && hasMacwrap {
+				// When macwrap IS available, "fuse-t only" becomes "dynamic-seatbelt-fuse"
+				// and "sandbox-exec fallback" becomes "dynamic-seatbelt"
+				// Skip these as they test the no-macwrap path
+				if tt.wantMode == "fuse-t" || tt.wantMode == "sandbox-exec" {
+					t.Skip("macwrap is in PATH, this tests the no-macwrap path")
+				}
+			}
+			mode, score := selectDarwinMode(tt.caps)
+			if mode != tt.wantMode {
+				t.Errorf("selectDarwinMode() mode = %q, want %q", mode, tt.wantMode)
+			}
+			if score != tt.wantScore {
+				t.Errorf("selectDarwinMode() score = %d, want %d", score, tt.wantScore)
+			}
+		})
+	}
+}
+
 func TestDetect_Darwin(t *testing.T) {
 	result, err := Detect()
 	if err != nil {

--- a/internal/platform/darwin/sandbox_compile.go
+++ b/internal/platform/darwin/sandbox_compile.go
@@ -4,6 +4,7 @@ package darwin
 
 import (
 	"fmt"
+	"log/slog"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -58,6 +59,9 @@ var defaultMachBlockPrefixes = []string{
 func CompileDarwinSandbox(pol *policy.Policy, workspacePath string) (*SandboxConfig, error) {
 	p := sbpl.New()
 	mgr := sandboxext.NewManager()
+	// RevokeAll is a safety net. Since we only Issue (never Consume) tokens here,
+	// all handles are -1 and release is a no-op. The opaque token Values are
+	// captured into SandboxConfig before this deferred call runs.
 	defer mgr.RevokeAll()
 
 	// 1. System essentials
@@ -120,7 +124,13 @@ func CompileDarwinSandbox(pol *policy.Policy, workspacePath string) (*SandboxCon
 		if rule.Decision != "allow" {
 			continue
 		}
-		if len(rule.Domains) > 0 || (len(rule.Ports) == 0 && len(rule.CIDRs) == 0) {
+		if len(rule.Domains) > 0 {
+			slog.Warn("domain-based network filtering requires Network Extension; allowing all network at SBPL level",
+				"domains", rule.Domains)
+			p.AllowNetworkAll()
+			break
+		}
+		if len(rule.Ports) == 0 && len(rule.CIDRs) == 0 {
 			p.AllowNetworkAll()
 			break
 		}

--- a/internal/platform/darwin/sandbox_compile.go
+++ b/internal/platform/darwin/sandbox_compile.go
@@ -1,0 +1,193 @@
+//go:build darwin && cgo
+
+package darwin
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/agentsh/agentsh/internal/platform/darwin/sbpl"
+	"github.com/agentsh/agentsh/internal/platform/darwin/sandboxext"
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+// SandboxConfig holds the compiled SBPL profile and extension tokens.
+type SandboxConfig struct {
+	Profile     string   // compiled SBPL string
+	TokenValues []string // opaque token strings for macwrap
+}
+
+var defaultExecBlocklist = []string{
+	"/usr/bin/osascript",
+	"/usr/bin/security",
+	"/usr/sbin/systemsetup",
+	"/usr/bin/tccutil",
+	"/usr/sbin/csrutil",
+}
+
+var defaultExecAllowPaths = []string{
+	"/usr/bin", "/bin", "/usr/sbin", "/sbin",
+	"/usr/local/bin", "/opt/homebrew/bin",
+}
+
+var defaultMachAllow = []string{
+	"com.apple.system.logger",
+	"com.apple.SecurityServer",
+	"com.apple.distributed_notifications@Gv0",
+	"com.apple.system.notification_center",
+	"com.apple.CoreServices.coreservicesd",
+	"com.apple.DiskArbitration.diskarbitrationd",
+	"com.apple.xpc.launchd.domain.system",
+}
+
+var defaultMachBlock = []string{
+	"com.apple.security.authtrampoline",
+	"com.apple.coreservices.launchservicesd",
+	"com.apple.securityd",
+}
+
+var defaultMachBlockPrefixes = []string{
+	"com.apple.pasteboard.",
+}
+
+// CompileDarwinSandbox orchestrates the SBPL builder and token manager to
+// compile a policy.Policy into a sandbox configuration with an SBPL profile
+// and extension tokens.
+func CompileDarwinSandbox(pol *policy.Policy, workspacePath string) (*SandboxConfig, error) {
+	p := sbpl.New()
+	mgr := sandboxext.NewManager()
+	defer mgr.RevokeAll()
+
+	// 1. System essentials
+	p.AllowSystemEssentials()
+
+	// 2. Workspace (full access with ioctl)
+	if workspacePath != "" {
+		absWs, err := filepath.Abs(workspacePath)
+		if err == nil {
+			workspacePath = absWs
+		}
+		p.AllowFileReadWriteIOctl(sbpl.Subpath, workspacePath)
+		mgr.Issue(workspacePath, sandboxext.ReadWrite)
+	}
+
+	// 3. File rules from policy (only "allow" decision, deny = omission)
+	for _, rule := range pol.FileRules {
+		if rule.Decision != "allow" {
+			continue
+		}
+		for _, path := range rule.Paths {
+			isWrite := containsAny(rule.Operations, "write", "*", "delete")
+			match := classifyPath(path)
+			if isWrite {
+				p.AllowFileReadWrite(match, path)
+				mgr.Issue(path, sandboxext.ReadWrite)
+			} else {
+				p.AllowFileRead(match, path)
+				mgr.Issue(path, sandboxext.ReadOnly)
+			}
+		}
+	}
+
+	// 4. Exec blocklist (deny before allow)
+	for _, blocked := range defaultExecBlocklist {
+		p.DenyProcessExec(sbpl.Literal, blocked)
+	}
+	// Default exec allow paths
+	for _, allowPath := range defaultExecAllowPaths {
+		p.AllowProcessExec(sbpl.Subpath, allowPath)
+	}
+	if workspacePath != "" {
+		p.AllowProcessExec(sbpl.Subpath, workspacePath)
+	}
+
+	// 5. Policy command rules
+	for _, rule := range pol.CommandRules {
+		for _, cmd := range rule.Commands {
+			switch rule.Decision {
+			case "allow":
+				p.AllowProcessExec(sbpl.Literal, resolveCommand(cmd))
+			case "deny":
+				p.DenyProcessExec(sbpl.Literal, resolveCommand(cmd))
+			}
+		}
+	}
+
+	// 6. Network rules
+	for _, rule := range pol.NetworkRules {
+		if rule.Decision != "allow" {
+			continue
+		}
+		if len(rule.Domains) > 0 || (len(rule.Ports) == 0 && len(rule.CIDRs) == 0) {
+			p.AllowNetworkAll()
+			break
+		}
+		for _, port := range rule.Ports {
+			p.AllowNetworkOutbound("tcp", fmt.Sprintf("*:%d", port))
+		}
+	}
+
+	// 7. Mach services (deny first)
+	for _, svc := range defaultMachBlock {
+		p.DenyMachLookup(svc)
+	}
+	for _, prefix := range defaultMachBlockPrefixes {
+		p.DenyMachLookupPrefix(prefix)
+	}
+	for _, svc := range defaultMachAllow {
+		p.AllowMachLookup(svc)
+	}
+
+	// Build profile
+	profile, err := p.Build()
+	if err != nil {
+		return nil, fmt.Errorf("build SBPL profile: %w", err)
+	}
+
+	return &SandboxConfig{
+		Profile:     profile,
+		TokenValues: mgr.TokenValues(),
+	}, nil
+}
+
+// classifyPath determines the SBPL path match type based on the path pattern.
+// Paths ending in /* or / are treated as subpaths (directories).
+// Paths whose base name has no extension are treated as subpaths (directories).
+// All others are treated as literals (exact files).
+func classifyPath(path string) sbpl.PathMatch {
+	if strings.HasSuffix(path, "/*") || strings.HasSuffix(path, "/") {
+		return sbpl.Subpath
+	}
+	base := filepath.Base(path)
+	if !strings.Contains(base, ".") {
+		return sbpl.Subpath
+	}
+	return sbpl.Literal
+}
+
+// resolveCommand resolves a command name to an absolute path. If the command
+// is already absolute, it is returned as-is. Otherwise, exec.LookPath is
+// tried, falling back to /usr/bin/<cmd>.
+func resolveCommand(cmd string) string {
+	if filepath.IsAbs(cmd) {
+		return cmd
+	}
+	if resolved, err := exec.LookPath(cmd); err == nil {
+		return resolved
+	}
+	return "/usr/bin/" + cmd
+}
+
+// containsAny returns true if any element in slice equals any of the values.
+func containsAny(slice []string, values ...string) bool {
+	for _, s := range slice {
+		for _, v := range values {
+			if s == v {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/platform/darwin/sandbox_compile_test.go
+++ b/internal/platform/darwin/sandbox_compile_test.go
@@ -201,6 +201,124 @@ func TestCompileDarwinSandbox_MachEssentials(t *testing.T) {
 	}
 }
 
+func TestCompileDarwinSandbox_NetworkWithSpecificPorts(t *testing.T) {
+	pol := &policy.Policy{
+		NetworkRules: []policy.NetworkRule{
+			{Decision: "allow", Ports: []int{443, 8080}},
+		},
+	}
+	cfg, err := CompileDarwinSandbox(pol, "/workspace")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox: %v", err)
+	}
+	if !strings.Contains(cfg.Profile, "443") {
+		t.Error("should contain port 443 rule")
+	}
+	if !strings.Contains(cfg.Profile, "8080") {
+		t.Error("should contain port 8080 rule")
+	}
+	if strings.Contains(cfg.Profile, "(allow network*)") {
+		t.Error("should NOT have blanket network allow when specific ports given")
+	}
+}
+
+func TestCompileDarwinSandbox_NetworkWithDomains(t *testing.T) {
+	pol := &policy.Policy{
+		NetworkRules: []policy.NetworkRule{
+			{Decision: "allow", Domains: []string{"github.com"}},
+		},
+	}
+	cfg, err := CompileDarwinSandbox(pol, "/workspace")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox: %v", err)
+	}
+	// Domain rules should fall back to allow-all (SBPL can't filter by domain)
+	if !strings.Contains(cfg.Profile, "(allow network*)") {
+		t.Error("domain rules should trigger allow-all network")
+	}
+}
+
+func TestCompileDarwinSandbox_MixedAllowDenyFileRules(t *testing.T) {
+	pol := &policy.Policy{
+		FileRules: []policy.FileRule{
+			{Paths: []string{"/allowed"}, Operations: []string{"read"}, Decision: "allow"},
+			{Paths: []string{"/denied"}, Operations: []string{"read"}, Decision: "deny"},
+		},
+	}
+	cfg, err := CompileDarwinSandbox(pol, "/workspace")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox: %v", err)
+	}
+	if !strings.Contains(cfg.Profile, "/allowed") {
+		t.Error("allow rule should be in profile")
+	}
+	if strings.Contains(cfg.Profile, "/denied") {
+		t.Error("deny rule should NOT be in profile (handled by deny-default)")
+	}
+}
+
+func TestClassifyPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string // "subpath" or "literal"
+	}{
+		{"/dir/*", "subpath"},
+		{"/dir/", "subpath"},
+		{"/dir/subdir", "subpath"},       // no extension = directory
+		{"/dir/file.txt", "literal"},
+		{"/dir/file.tar.gz", "literal"},
+		{"/usr/bin/python3", "subpath"},   // no extension = directory heuristic
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := classifyPath(tt.path)
+			// sbpl.Subpath == 1, sbpl.Literal == 0
+			if tt.want == "subpath" && got != 1 {
+				t.Errorf("classifyPath(%q) = %d, want Subpath (1)", tt.path, got)
+			}
+			if tt.want == "literal" && got != 0 {
+				t.Errorf("classifyPath(%q) = %d, want Literal (0)", tt.path, got)
+			}
+		})
+	}
+}
+
+func TestResolveCommand_AbsolutePath(t *testing.T) {
+	got := resolveCommand("/usr/bin/git")
+	if got != "/usr/bin/git" {
+		t.Errorf("resolveCommand(/usr/bin/git) = %q, want /usr/bin/git", got)
+	}
+}
+
+func TestResolveCommand_NotFound_Fallback(t *testing.T) {
+	got := resolveCommand("nonexistent-binary-xyz-12345")
+	if got != "/usr/bin/nonexistent-binary-xyz-12345" {
+		t.Errorf("resolveCommand(nonexistent) = %q, want /usr/bin/ prefix fallback", got)
+	}
+}
+
+func TestContainsAny(t *testing.T) {
+	tests := []struct {
+		name   string
+		slice  []string
+		values []string
+		want   bool
+	}{
+		{"match", []string{"read", "write"}, []string{"write", "*"}, true},
+		{"no match", []string{"read"}, []string{"write", "*"}, false},
+		{"wildcard match", []string{"*"}, []string{"write", "*"}, true},
+		{"empty slice", []string{}, []string{"write"}, false},
+		{"empty values", []string{"read"}, []string{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsAny(tt.slice, tt.values...); got != tt.want {
+				t.Errorf("containsAny(%v, %v...) = %v, want %v", tt.slice, tt.values, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCompileDarwinSandbox_DenyFileRuleOmitted(t *testing.T) {
 	pol := &policy.Policy{
 		FileRules: []policy.FileRule{

--- a/internal/platform/darwin/sandbox_compile_test.go
+++ b/internal/platform/darwin/sandbox_compile_test.go
@@ -1,0 +1,223 @@
+//go:build darwin && cgo
+
+package darwin
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+func TestCompileDarwinSandbox_EmptyPolicy(t *testing.T) {
+	pol := &policy.Policy{}
+	cfg, err := CompileDarwinSandbox(pol, "")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox() error = %v", err)
+	}
+	if !strings.Contains(cfg.Profile, "(version 1)") {
+		t.Error("profile should contain (version 1)")
+	}
+	if !strings.Contains(cfg.Profile, "(deny default)") {
+		t.Error("profile should contain (deny default)")
+	}
+	// System essentials should be present
+	if !strings.Contains(cfg.Profile, "(allow process-fork)") {
+		t.Error("profile should contain system essentials (process-fork)")
+	}
+	if !strings.Contains(cfg.Profile, `(subpath "/usr/lib")`) {
+		t.Error("profile should contain system essentials (/usr/lib)")
+	}
+}
+
+func TestCompileDarwinSandbox_FileRules(t *testing.T) {
+	pol := &policy.Policy{
+		FileRules: []policy.FileRule{
+			{
+				Paths:      []string{"/etc/config.json"},
+				Operations: []string{"read"},
+				Decision:   "allow",
+			},
+			{
+				Paths:      []string{"/var/data/"},
+				Operations: []string{"read", "write"},
+				Decision:   "allow",
+			},
+		},
+	}
+	cfg, err := CompileDarwinSandbox(pol, "/workspace")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox() error = %v", err)
+	}
+
+	// Read-only rule should produce file-read*
+	if !strings.Contains(cfg.Profile, "file-read*") {
+		t.Error("profile should contain file-read* for read-only rule")
+	}
+	if !strings.Contains(cfg.Profile, "/etc/config.json") {
+		t.Error("profile should contain the read-only path")
+	}
+
+	// Write rule should produce file-write*
+	if !strings.Contains(cfg.Profile, "file-write*") {
+		t.Error("profile should contain file-write* for write rule")
+	}
+	if !strings.Contains(cfg.Profile, "/var/data") {
+		t.Error("profile should contain the write path")
+	}
+
+	// Should have tokens: at least workspace + file rules
+	if len(cfg.TokenValues) < 2 {
+		t.Errorf("expected at least 2 tokens (workspace + file rules), got %d", len(cfg.TokenValues))
+	}
+}
+
+func TestCompileDarwinSandbox_CommandRules(t *testing.T) {
+	pol := &policy.Policy{
+		CommandRules: []policy.CommandRule{
+			{
+				Commands: []string{"/usr/bin/git"},
+				Decision: "allow",
+			},
+			{
+				Commands: []string{"/usr/bin/curl"},
+				Decision: "deny",
+			},
+		},
+	}
+	cfg, err := CompileDarwinSandbox(pol, "")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox() error = %v", err)
+	}
+
+	// Allow rule should produce allow process-exec
+	if !strings.Contains(cfg.Profile, `(allow process-exec (literal "/usr/bin/git"))`) {
+		t.Errorf("profile should contain allow process-exec for git, got:\n%s", cfg.Profile)
+	}
+
+	// Deny rule should produce deny process-exec
+	if !strings.Contains(cfg.Profile, `(deny process-exec (literal "/usr/bin/curl"))`) {
+		t.Errorf("profile should contain deny process-exec for curl, got:\n%s", cfg.Profile)
+	}
+}
+
+func TestCompileDarwinSandbox_NetworkAllowAll(t *testing.T) {
+	pol := &policy.Policy{
+		NetworkRules: []policy.NetworkRule{
+			{
+				Decision: "allow",
+				// No ports, no domains, no CIDRs => allow all
+			},
+		},
+	}
+	cfg, err := CompileDarwinSandbox(pol, "")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox() error = %v", err)
+	}
+	if !strings.Contains(cfg.Profile, "(allow network*)") {
+		t.Errorf("profile should contain (allow network*), got:\n%s", cfg.Profile)
+	}
+}
+
+func TestCompileDarwinSandbox_WorkspaceFullAccess(t *testing.T) {
+	pol := &policy.Policy{}
+	cfg, err := CompileDarwinSandbox(pol, "/tmp/test-workspace")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox() error = %v", err)
+	}
+
+	// Workspace should have file-ioctl
+	if !strings.Contains(cfg.Profile, "file-ioctl") {
+		t.Error("profile should contain file-ioctl for workspace")
+	}
+	// Workspace path should be in profile
+	if !strings.Contains(cfg.Profile, "/tmp/test-workspace") {
+		// Might be resolved to /private/tmp/test-workspace on macOS
+		if !strings.Contains(cfg.Profile, "/private/tmp/test-workspace") {
+			t.Errorf("profile should contain workspace path, got:\n%s", cfg.Profile)
+		}
+	}
+}
+
+func TestCompileDarwinSandbox_DefaultExecBlocklist(t *testing.T) {
+	pol := &policy.Policy{}
+	cfg, err := CompileDarwinSandbox(pol, "")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox() error = %v", err)
+	}
+
+	blocklist := []string{
+		"osascript",
+		"security",
+		"systemsetup",
+		"tccutil",
+		"csrutil",
+	}
+	for _, name := range blocklist {
+		if !strings.Contains(cfg.Profile, name) {
+			t.Errorf("profile should contain blocked command %q", name)
+		}
+	}
+}
+
+func TestCompileDarwinSandbox_DefaultExecAllowPaths(t *testing.T) {
+	pol := &policy.Policy{}
+	cfg, err := CompileDarwinSandbox(pol, "")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox() error = %v", err)
+	}
+
+	allowPaths := []string{
+		"/usr/bin",
+		"/bin",
+		"/usr/sbin",
+		"/sbin",
+		"/usr/local/bin",
+		"/opt/homebrew/bin",
+	}
+	for _, path := range allowPaths {
+		expected := `(allow process-exec (subpath "` + path + `"))`
+		if !strings.Contains(cfg.Profile, expected) {
+			t.Errorf("profile should contain %q, got:\n%s", expected, cfg.Profile)
+		}
+	}
+}
+
+func TestCompileDarwinSandbox_MachEssentials(t *testing.T) {
+	pol := &policy.Policy{}
+	cfg, err := CompileDarwinSandbox(pol, "")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox() error = %v", err)
+	}
+
+	// Allowed mach services
+	if !strings.Contains(cfg.Profile, "com.apple.system.logger") {
+		t.Error("profile should contain allowed mach service com.apple.system.logger")
+	}
+
+	// Blocked mach services
+	if !strings.Contains(cfg.Profile, "com.apple.security.authtrampoline") {
+		t.Error("profile should contain blocked mach service com.apple.security.authtrampoline")
+	}
+}
+
+func TestCompileDarwinSandbox_DenyFileRuleOmitted(t *testing.T) {
+	pol := &policy.Policy{
+		FileRules: []policy.FileRule{
+			{
+				Paths:      []string{"/secret/data"},
+				Operations: []string{"read"},
+				Decision:   "deny",
+			},
+		},
+	}
+	cfg, err := CompileDarwinSandbox(pol, "")
+	if err != nil {
+		t.Fatalf("CompileDarwinSandbox() error = %v", err)
+	}
+
+	// Deny file rules should be omitted (deny = default, so just don't allow)
+	if strings.Contains(cfg.Profile, "/secret/data") {
+		t.Error("profile should NOT contain denied file path /secret/data")
+	}
+}

--- a/internal/platform/darwin/sandboxext/manager.go
+++ b/internal/platform/darwin/sandboxext/manager.go
@@ -1,0 +1,161 @@
+//go:build darwin && cgo
+
+package sandboxext
+
+/*
+#include <sandbox.h>
+#include <stdlib.h>
+
+// sandbox_extension_issue_file is a private API for issuing sandbox extension tokens.
+extern char *sandbox_extension_issue_file(const char *extension_class, const char *path, uint32_t flags);
+
+// sandbox_extension_consume consumes a token, granting the calling process access.
+extern int64_t sandbox_extension_consume(const char *token);
+
+// sandbox_extension_release releases a previously consumed extension.
+extern int sandbox_extension_release(int64_t handle);
+*/
+import "C"
+
+import (
+	"fmt"
+	"sync"
+	"time"
+	"unsafe"
+)
+
+// ExtClass represents a sandbox extension class that determines the access level.
+type ExtClass string
+
+const (
+	// ReadOnly grants read-only access to the path.
+	ReadOnly ExtClass = "com.apple.app-sandbox.read"
+	// ReadWrite grants read-write access to the path.
+	ReadWrite ExtClass = "com.apple.app-sandbox.read-write"
+)
+
+// Token represents a sandbox extension token for a specific path.
+type Token struct {
+	Path   string
+	Class  ExtClass
+	Value  string    // opaque token string from sandbox_extension_issue_file
+	Issued time.Time
+	handle int64 // internal handle from consume, -1 if not consumed
+}
+
+// Manager manages sandbox extension tokens. It lives server-side and issues
+// tokens that grant path-specific access to sandboxed processes.
+type Manager struct {
+	mu     sync.Mutex
+	tokens map[string]*Token
+}
+
+// NewManager creates a new Manager with an empty token map.
+func NewManager() *Manager {
+	return &Manager{
+		tokens: make(map[string]*Token),
+	}
+}
+
+// Issue calls sandbox_extension_issue_file to create a token granting access
+// to path at the given extension class. The token is stored internally keyed
+// by path.
+func (m *Manager) Issue(path string, class ExtClass) (*Token, error) {
+	cClass := C.CString(string(class))
+	defer C.free(unsafe.Pointer(cClass))
+
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	cToken := C.sandbox_extension_issue_file(cClass, cPath, 0)
+	if cToken == nil {
+		return nil, fmt.Errorf("sandbox_extension_issue_file failed for path %q class %q", path, class)
+	}
+	defer C.free(unsafe.Pointer(cToken))
+
+	tok := &Token{
+		Path:   path,
+		Class:  class,
+		Value:  C.GoString(cToken),
+		Issued: time.Now(),
+		handle: -1,
+	}
+
+	m.mu.Lock()
+	m.tokens[path] = tok
+	m.mu.Unlock()
+
+	return tok, nil
+}
+
+// ActiveTokens returns copies of all active tokens.
+func (m *Manager) ActiveTokens() []Token {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	result := make([]Token, 0, len(m.tokens))
+	for _, tok := range m.tokens {
+		result = append(result, *tok)
+	}
+	return result
+}
+
+// Revoke removes the token for the given path. If the token was consumed,
+// sandbox_extension_release is called. Returns nil if the path has no active
+// token (double-revoke is safe).
+func (m *Manager) Revoke(path string) error {
+	m.mu.Lock()
+	tok, ok := m.tokens[path]
+	if !ok {
+		m.mu.Unlock()
+		return nil
+	}
+	delete(m.tokens, path)
+	m.mu.Unlock()
+
+	if tok.handle >= 0 {
+		C.sandbox_extension_release(C.int64_t(tok.handle))
+	}
+	return nil
+}
+
+// RevokeAll revokes all active tokens.
+func (m *Manager) RevokeAll() {
+	m.mu.Lock()
+	tokens := m.tokens
+	m.tokens = make(map[string]*Token)
+	m.mu.Unlock()
+
+	for _, tok := range tokens {
+		if tok.handle >= 0 {
+			C.sandbox_extension_release(C.int64_t(tok.handle))
+		}
+	}
+}
+
+// TokenValues returns just the opaque token strings for all active tokens.
+// This is useful for serialization into WrapperConfig JSON.
+func (m *Manager) TokenValues() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	result := make([]string, 0, len(m.tokens))
+	for _, tok := range m.tokens {
+		result = append(result, tok.Value)
+	}
+	return result
+}
+
+// ConsumeToken is a standalone function (not a Manager method) that calls
+// sandbox_extension_consume. It is used client-side in macwrap to consume
+// tokens received from the server. Returns a handle >= 0 on success.
+func ConsumeToken(tokenStr string) (int64, error) {
+	cToken := C.CString(tokenStr)
+	defer C.free(unsafe.Pointer(cToken))
+
+	handle := int64(C.sandbox_extension_consume(cToken))
+	if handle < 0 {
+		return handle, fmt.Errorf("sandbox_extension_consume failed (handle=%d)", handle)
+	}
+	return handle, nil
+}

--- a/internal/platform/darwin/sandboxext/manager_test.go
+++ b/internal/platform/darwin/sandboxext/manager_test.go
@@ -138,6 +138,72 @@ func TestConsumeToken_ValidToken(t *testing.T) {
 	}
 }
 
+func TestConsumeToken_InvalidToken(t *testing.T) {
+	_, err := ConsumeToken("this-is-not-a-valid-token")
+	if err == nil {
+		t.Error("ConsumeToken with invalid token should return error")
+	}
+}
+
+func TestConsumeToken_EmptyString(t *testing.T) {
+	_, err := ConsumeToken("")
+	if err == nil {
+		t.Error("ConsumeToken with empty string should return error")
+	}
+}
+
+func TestIssue_Consume_Revoke_FullLifecycle(t *testing.T) {
+	mgr := NewManager()
+	defer mgr.RevokeAll()
+
+	dir := t.TempDir()
+
+	// Issue
+	tok, err := mgr.Issue(dir, ReadOnly)
+	if err != nil {
+		t.Fatalf("Issue: %v", err)
+	}
+
+	// Consume the token
+	handle, err := ConsumeToken(tok.Value)
+	if err != nil {
+		t.Fatalf("ConsumeToken: %v", err)
+	}
+	if handle < 0 {
+		t.Fatalf("handle should be >= 0, got %d", handle)
+	}
+
+	// Revoke should still work (manager tracks by path, not by consumption)
+	if err := mgr.Revoke(dir); err != nil {
+		t.Fatalf("Revoke after consume: %v", err)
+	}
+
+	// Should be removed
+	if len(mgr.ActiveTokens()) != 0 {
+		t.Error("token should be removed after revoke")
+	}
+}
+
+func TestTokenValues_ExcludesRevokedTokens(t *testing.T) {
+	mgr := NewManager()
+	defer mgr.RevokeAll()
+
+	d1 := t.TempDir()
+	d2 := t.TempDir()
+	mgr.Issue(d1, ReadOnly)
+	mgr.Issue(d2, ReadWrite)
+
+	if len(mgr.TokenValues()) != 2 {
+		t.Fatalf("expected 2 token values, got %d", len(mgr.TokenValues()))
+	}
+
+	mgr.Revoke(d1)
+	values := mgr.TokenValues()
+	if len(values) != 1 {
+		t.Errorf("after revoking one, expected 1 token value, got %d", len(values))
+	}
+}
+
 func TestTokenValues_ReturnsStrings(t *testing.T) {
 	m := NewManager()
 	dir1 := t.TempDir()

--- a/internal/platform/darwin/sandboxext/manager_test.go
+++ b/internal/platform/darwin/sandboxext/manager_test.go
@@ -1,0 +1,176 @@
+//go:build darwin && cgo
+
+package sandboxext
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIssue_ReturnsToken(t *testing.T) {
+	m := NewManager()
+	dir := t.TempDir()
+
+	tok, err := m.Issue(dir, ReadOnly)
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+	if tok.Value == "" {
+		t.Fatal("Issue() returned token with empty Value")
+	}
+	if tok.Path != dir {
+		t.Errorf("Token.Path = %q, want %q", tok.Path, dir)
+	}
+	if tok.Class != ReadOnly {
+		t.Errorf("Token.Class = %q, want %q", tok.Class, ReadOnly)
+	}
+	if tok.Issued.IsZero() {
+		t.Error("Token.Issued should not be zero")
+	}
+}
+
+func TestActiveTokens_ReturnsIssuedTokens(t *testing.T) {
+	m := NewManager()
+	dir := t.TempDir()
+
+	_, err := m.Issue(dir, ReadOnly)
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+
+	active := m.ActiveTokens()
+	if len(active) != 1 {
+		t.Fatalf("ActiveTokens() len = %d, want 1", len(active))
+	}
+	if active[0].Path != dir {
+		t.Errorf("ActiveTokens()[0].Path = %q, want %q", active[0].Path, dir)
+	}
+}
+
+func TestRevoke_RemovesToken(t *testing.T) {
+	m := NewManager()
+	dir := t.TempDir()
+
+	_, err := m.Issue(dir, ReadWrite)
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+
+	if err := m.Revoke(dir); err != nil {
+		t.Fatalf("Revoke() error = %v", err)
+	}
+
+	active := m.ActiveTokens()
+	if len(active) != 0 {
+		t.Errorf("ActiveTokens() len = %d after Revoke, want 0", len(active))
+	}
+}
+
+func TestRevokeAll_ClearsAll(t *testing.T) {
+	m := NewManager()
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	if _, err := m.Issue(dir1, ReadOnly); err != nil {
+		t.Fatalf("Issue(dir1) error = %v", err)
+	}
+	if _, err := m.Issue(dir2, ReadWrite); err != nil {
+		t.Fatalf("Issue(dir2) error = %v", err)
+	}
+
+	m.RevokeAll()
+
+	active := m.ActiveTokens()
+	if len(active) != 0 {
+		t.Errorf("ActiveTokens() len = %d after RevokeAll, want 0", len(active))
+	}
+}
+
+func TestRevoke_DoubleRevoke_NoError(t *testing.T) {
+	m := NewManager()
+	dir := t.TempDir()
+
+	if _, err := m.Issue(dir, ReadOnly); err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+
+	if err := m.Revoke(dir); err != nil {
+		t.Fatalf("first Revoke() error = %v", err)
+	}
+
+	if err := m.Revoke(dir); err != nil {
+		t.Errorf("second Revoke() should not error, got %v", err)
+	}
+}
+
+func TestIssue_NonexistentPath(t *testing.T) {
+	m := NewManager()
+	path := "/tmp/sandboxext-test-nonexistent-" + t.Name()
+	// Ensure it doesn't exist
+	os.RemoveAll(path)
+
+	// The sandbox_extension_issue_file API may succeed even for non-existent
+	// paths (it issues a capability token, not a file handle). We document
+	// whichever behavior the system exhibits.
+	tok, err := m.Issue(path, ReadOnly)
+	if err != nil {
+		t.Logf("Issue() on non-existent path returned error: %v (this is acceptable)", err)
+		return
+	}
+	t.Logf("Issue() on non-existent path succeeded with token Value=%q (this is acceptable)", tok.Value)
+}
+
+func TestConsumeToken_ValidToken(t *testing.T) {
+	m := NewManager()
+	dir := t.TempDir()
+
+	tok, err := m.Issue(dir, ReadOnly)
+	if err != nil {
+		t.Fatalf("Issue() error = %v", err)
+	}
+
+	handle, err := ConsumeToken(tok.Value)
+	if err != nil {
+		t.Fatalf("ConsumeToken() error = %v", err)
+	}
+	if handle < 0 {
+		t.Errorf("ConsumeToken() handle = %d, want >= 0", handle)
+	}
+}
+
+func TestTokenValues_ReturnsStrings(t *testing.T) {
+	m := NewManager()
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+
+	tok1, err := m.Issue(dir1, ReadOnly)
+	if err != nil {
+		t.Fatalf("Issue(dir1) error = %v", err)
+	}
+	tok2, err := m.Issue(dir2, ReadWrite)
+	if err != nil {
+		t.Fatalf("Issue(dir2) error = %v", err)
+	}
+
+	values := m.TokenValues()
+	if len(values) != 2 {
+		t.Fatalf("TokenValues() len = %d, want 2", len(values))
+	}
+
+	// Values should contain the token strings (order not guaranteed by map)
+	found1, found2 := false, false
+	for _, v := range values {
+		if v == tok1.Value {
+			found1 = true
+		}
+		if v == tok2.Value {
+			found2 = true
+		}
+	}
+	if !found1 {
+		t.Error("TokenValues() missing token for dir1")
+	}
+	if !found2 {
+		t.Error("TokenValues() missing token for dir2")
+	}
+}

--- a/internal/platform/darwin/sbpl/builder.go
+++ b/internal/platform/darwin/sbpl/builder.go
@@ -142,6 +142,70 @@ func (p *Profile) AllowNetworkOutbound(proto, hostPort string) {
 	})
 }
 
+// AllowSystemEssentials adds all rules needed for basic macOS process
+// operation: process ops, system libraries, dev files, common tool paths,
+// TTY access, temp files, and IPC.
+func (p *Profile) AllowSystemEssentials() {
+	// Process operations
+	p.rules = append(p.rules,
+		rule{kind: kindOther, sbpl: "(allow process-fork)"},
+		rule{kind: kindOther, sbpl: "(allow signal (target self))"},
+		rule{kind: kindOther, sbpl: "(allow sysctl-read)"},
+	)
+
+	// Dev files + system libraries (combined file-read* rule)
+	p.rules = append(p.rules, rule{
+		kind: kindFileAllow,
+		sbpl: "(allow file-read*\n" +
+			"    (subpath \"/usr/lib\")\n" +
+			"    (subpath \"/usr/share\")\n" +
+			"    (subpath \"/System/Library\")\n" +
+			"    (subpath \"/Library/Frameworks\")\n" +
+			"    (subpath \"/private/var/db/dyld\")\n" +
+			"    (literal \"/dev/null\")\n" +
+			"    (literal \"/dev/random\")\n" +
+			"    (literal \"/dev/urandom\")\n" +
+			"    (literal \"/dev/zero\"))",
+	})
+
+	// Common tool paths (read-only)
+	p.rules = append(p.rules, rule{
+		kind: kindFileAllow,
+		sbpl: "(allow file-read*\n" +
+			"    (subpath \"/usr/bin\")\n" +
+			"    (subpath \"/usr/sbin\")\n" +
+			"    (subpath \"/bin\")\n" +
+			"    (subpath \"/sbin\")\n" +
+			"    (subpath \"/usr/local/bin\")\n" +
+			"    (subpath \"/opt/homebrew/bin\")\n" +
+			"    (subpath \"/opt/homebrew/Cellar\"))",
+	})
+
+	// TTY access
+	p.rules = append(p.rules, rule{
+		kind: kindFileAllow,
+		sbpl: "(allow file-read* file-write*\n" +
+			"    (regex #\"^/dev/ttys[0-9]+$\"#)\n" +
+			"    (regex #\"^/dev/pty[pqrs][0-9a-f]$\"#)\n" +
+			"    (literal \"/dev/tty\"))",
+	})
+
+	// Temp files
+	p.rules = append(p.rules, rule{
+		kind: kindFileAllow,
+		sbpl: "(allow file-read* file-write*\n" +
+			"    (subpath \"/private/tmp\")\n" +
+			"    (subpath \"/tmp\")\n" +
+			"    (subpath \"/var/folders\"))",
+	})
+
+	// IPC
+	p.rules = append(p.rules,
+		rule{kind: kindOther, sbpl: "(allow ipc-posix*)"},
+		rule{kind: kindOther, sbpl: "(allow mach-register)"},
+	)
+}
+
 // Build renders the accumulated rules into a complete SBPL profile string.
 // It returns an error if any non-regex path is relative.
 func (p *Profile) Build() (string, error) {

--- a/internal/platform/darwin/sbpl/builder.go
+++ b/internal/platform/darwin/sbpl/builder.go
@@ -53,7 +53,7 @@ func New() *Profile {
 func (p *Profile) AllowFileRead(match PathMatch, path string) {
 	p.rules = append(p.rules, rule{
 		kind: kindFileAllow,
-		sbpl: fmt.Sprintf("(allow file-read* (%s %s))", matchStr(match), quotePath(path)),
+		sbpl: fmt.Sprintf("(allow file-read* (%s %s))", matchStr(match), quotePathForMatch(match, path)),
 	})
 }
 
@@ -62,7 +62,7 @@ func (p *Profile) AllowFileRead(match PathMatch, path string) {
 func (p *Profile) AllowFileReadWrite(match PathMatch, path string) {
 	p.rules = append(p.rules, rule{
 		kind: kindFileAllow,
-		sbpl: fmt.Sprintf("(allow file-read* file-write* (%s %s))", matchStr(match), quotePath(path)),
+		sbpl: fmt.Sprintf("(allow file-read* file-write* (%s %s))", matchStr(match), quotePathForMatch(match, path)),
 	})
 }
 
@@ -71,7 +71,7 @@ func (p *Profile) AllowFileReadWrite(match PathMatch, path string) {
 func (p *Profile) AllowFileReadWriteIOctl(match PathMatch, path string) {
 	p.rules = append(p.rules, rule{
 		kind: kindFileAllow,
-		sbpl: fmt.Sprintf("(allow file-read* file-write* file-ioctl (%s %s))", matchStr(match), quotePath(path)),
+		sbpl: fmt.Sprintf("(allow file-read* file-write* file-ioctl (%s %s))", matchStr(match), quotePathForMatch(match, path)),
 	})
 }
 
@@ -79,7 +79,7 @@ func (p *Profile) AllowFileReadWriteIOctl(match PathMatch, path string) {
 func (p *Profile) AllowProcessExec(match PathMatch, path string) {
 	p.rules = append(p.rules, rule{
 		kind: kindExecAllow,
-		sbpl: fmt.Sprintf("(allow process-exec (%s %s))", matchStr(match), quotePath(path)),
+		sbpl: fmt.Sprintf("(allow process-exec (%s %s))", matchStr(match), quotePathForMatch(match, path)),
 	})
 }
 
@@ -87,7 +87,7 @@ func (p *Profile) AllowProcessExec(match PathMatch, path string) {
 func (p *Profile) DenyProcessExec(match PathMatch, path string) {
 	p.rules = append(p.rules, rule{
 		kind: kindExecDeny,
-		sbpl: fmt.Sprintf("(deny process-exec (%s %s))", matchStr(match), quotePath(path)),
+		sbpl: fmt.Sprintf("(deny process-exec (%s %s))", matchStr(match), quotePathForMatch(match, path)),
 	})
 }
 
@@ -134,11 +134,12 @@ func (p *Profile) AllowNetworkAll() {
 }
 
 // AllowNetworkOutbound adds a rule allowing outbound network connections
-// for the given protocol and host:port.
+// for the given protocol and host:port. The proto parameter must be a valid
+// SBPL protocol identifier (e.g., "tcp", "udp").
 func (p *Profile) AllowNetworkOutbound(proto, hostPort string) {
 	p.rules = append(p.rules, rule{
 		kind: kindNetworkAllow,
-		sbpl: fmt.Sprintf("(allow network-outbound (remote %s %q))", proto, hostPort),
+		sbpl: fmt.Sprintf("(allow network-outbound (remote %q %q))", proto, hostPort),
 	})
 }
 
@@ -260,12 +261,14 @@ func matchStr(m PathMatch) string {
 	}
 }
 
-// quotePath escapes backslashes and quotes in a path and wraps it in
-// double quotes. Regex patterns (starting with #") are passed through
-// unchanged.
-func quotePath(path string) string {
-	if strings.HasPrefix(path, `#"`) {
-		return path // regex pattern, pass through
+// quotePathForMatch escapes and quotes a path based on its PathMatch type.
+// For Regex, the path is passed through unchanged (caller must provide valid
+// SBPL regex syntax like #"pattern"#). For Literal and Subpath, backslashes
+// and quotes are escaped and the result is wrapped in double quotes.
+// This function never content-sniffs — the match type alone determines quoting.
+func quotePathForMatch(match PathMatch, path string) string {
+	if match == Regex {
+		return path
 	}
 	escaped := strings.ReplaceAll(path, `\`, `\\`)
 	escaped = strings.ReplaceAll(escaped, `"`, `\"`)

--- a/internal/platform/darwin/sbpl/builder.go
+++ b/internal/platform/darwin/sbpl/builder.go
@@ -75,6 +75,73 @@ func (p *Profile) AllowFileReadWriteIOctl(match PathMatch, path string) {
 	})
 }
 
+// AllowProcessExec adds a rule allowing process-exec for the given path.
+func (p *Profile) AllowProcessExec(match PathMatch, path string) {
+	p.rules = append(p.rules, rule{
+		kind: kindExecAllow,
+		sbpl: fmt.Sprintf("(allow process-exec (%s %s))", matchStr(match), quotePath(path)),
+	})
+}
+
+// DenyProcessExec adds a rule denying process-exec for the given path.
+func (p *Profile) DenyProcessExec(match PathMatch, path string) {
+	p.rules = append(p.rules, rule{
+		kind: kindExecDeny,
+		sbpl: fmt.Sprintf("(deny process-exec (%s %s))", matchStr(match), quotePath(path)),
+	})
+}
+
+// AllowMachLookup adds a rule allowing mach-lookup for the given service name.
+func (p *Profile) AllowMachLookup(serviceName string) {
+	p.rules = append(p.rules, rule{
+		kind: kindMachAllow,
+		sbpl: fmt.Sprintf("(allow mach-lookup (global-name %q))", serviceName),
+	})
+}
+
+// AllowMachLookupPrefix adds a rule allowing mach-lookup for services
+// matching the given prefix.
+func (p *Profile) AllowMachLookupPrefix(prefix string) {
+	p.rules = append(p.rules, rule{
+		kind: kindMachAllow,
+		sbpl: fmt.Sprintf("(allow mach-lookup (global-name-prefix %q))", prefix),
+	})
+}
+
+// DenyMachLookup adds a rule denying mach-lookup for the given service name.
+func (p *Profile) DenyMachLookup(serviceName string) {
+	p.rules = append(p.rules, rule{
+		kind: kindMachDeny,
+		sbpl: fmt.Sprintf("(deny mach-lookup (global-name %q))", serviceName),
+	})
+}
+
+// DenyMachLookupPrefix adds a rule denying mach-lookup for services
+// matching the given prefix.
+func (p *Profile) DenyMachLookupPrefix(prefix string) {
+	p.rules = append(p.rules, rule{
+		kind: kindMachDeny,
+		sbpl: fmt.Sprintf("(deny mach-lookup (global-name-prefix %q))", prefix),
+	})
+}
+
+// AllowNetworkAll adds a rule allowing all network operations.
+func (p *Profile) AllowNetworkAll() {
+	p.rules = append(p.rules, rule{
+		kind: kindNetworkAllow,
+		sbpl: "(allow network*)",
+	})
+}
+
+// AllowNetworkOutbound adds a rule allowing outbound network connections
+// for the given protocol and host:port.
+func (p *Profile) AllowNetworkOutbound(proto, hostPort string) {
+	p.rules = append(p.rules, rule{
+		kind: kindNetworkAllow,
+		sbpl: fmt.Sprintf("(allow network-outbound (remote %s %q))", proto, hostPort),
+	})
+}
+
 // Build renders the accumulated rules into a complete SBPL profile string.
 // It returns an error if any non-regex path is relative.
 func (p *Profile) Build() (string, error) {
@@ -142,10 +209,16 @@ func quotePath(path string) string {
 }
 
 // validateRule checks that non-regex paths in a rule are absolute.
+// Only file and exec rules contain filesystem paths that must be absolute;
+// mach-lookup and network rules use service names / host:port strings.
 func validateRule(r rule) error {
-	// Extract the path from the SBPL string for validation.
-	// Rules follow the pattern: (allow ... (match "path"))
-	// or for regex: (allow ... (regex #"pattern"#))
+	// Only validate path-based rule kinds.
+	switch r.kind {
+	case kindFileAllow, kindFileDeny, kindExecAllow, kindExecDeny:
+		// These contain filesystem paths; validate below.
+	default:
+		return nil
+	}
 
 	// If it's a regex rule, skip validation.
 	if strings.Contains(r.sbpl, "(regex ") {

--- a/internal/platform/darwin/sbpl/builder.go
+++ b/internal/platform/darwin/sbpl/builder.go
@@ -1,0 +1,183 @@
+// Package sbpl constructs valid SBPL (Sandbox Profile Language) strings
+// via a typed Go API. It is pure Go with no CGo or build tags so that
+// tests can run on any OS.
+package sbpl
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PathMatch controls how a path argument is matched in an SBPL rule.
+type PathMatch int
+
+const (
+	Literal PathMatch = iota // (literal "/exact/path")
+	Subpath                  // (subpath "/dir")
+	Regex                    // (regex #"/pattern"#)
+)
+
+// ruleKind groups rules for deterministic ordering in the output.
+type ruleKind int
+
+const (
+	kindFileAllow ruleKind = iota
+	kindFileDeny
+	kindExecAllow
+	kindExecDeny
+	kindMachAllow
+	kindMachDeny
+	kindNetworkAllow
+	kindNetworkDeny
+	kindOther
+)
+
+// rule is a single SBPL statement with its kind for ordering.
+type rule struct {
+	kind ruleKind
+	sbpl string
+}
+
+// Profile accumulates SBPL rules and renders them into a complete
+// sandbox profile string.
+type Profile struct {
+	rules []rule
+}
+
+// New creates an empty Profile.
+func New() *Profile {
+	return &Profile{}
+}
+
+// AllowFileRead adds a rule allowing file-read* for the given path.
+func (p *Profile) AllowFileRead(match PathMatch, path string) {
+	p.rules = append(p.rules, rule{
+		kind: kindFileAllow,
+		sbpl: fmt.Sprintf("(allow file-read* (%s %s))", matchStr(match), quotePath(path)),
+	})
+}
+
+// AllowFileReadWrite adds a rule allowing file-read* and file-write*
+// for the given path.
+func (p *Profile) AllowFileReadWrite(match PathMatch, path string) {
+	p.rules = append(p.rules, rule{
+		kind: kindFileAllow,
+		sbpl: fmt.Sprintf("(allow file-read* file-write* (%s %s))", matchStr(match), quotePath(path)),
+	})
+}
+
+// AllowFileReadWriteIOctl adds a rule allowing file-read*, file-write*,
+// and file-ioctl for the given path.
+func (p *Profile) AllowFileReadWriteIOctl(match PathMatch, path string) {
+	p.rules = append(p.rules, rule{
+		kind: kindFileAllow,
+		sbpl: fmt.Sprintf("(allow file-read* file-write* file-ioctl (%s %s))", matchStr(match), quotePath(path)),
+	})
+}
+
+// Build renders the accumulated rules into a complete SBPL profile string.
+// It returns an error if any non-regex path is relative.
+func (p *Profile) Build() (string, error) {
+	for _, r := range p.rules {
+		if err := validateRule(r); err != nil {
+			return "", err
+		}
+	}
+
+	var b strings.Builder
+	b.WriteString("(version 1)\n")
+	b.WriteString("(deny default)\n")
+
+	// Emit deny rules before allow rules for readability.
+	for _, r := range p.rules {
+		if isDeny(r.kind) {
+			b.WriteString(r.sbpl)
+			b.WriteByte('\n')
+		}
+	}
+	for _, r := range p.rules {
+		if !isDeny(r.kind) {
+			b.WriteString(r.sbpl)
+			b.WriteByte('\n')
+		}
+	}
+
+	return b.String(), nil
+}
+
+// isDeny returns true for deny-class rule kinds.
+func isDeny(k ruleKind) bool {
+	switch k {
+	case kindFileDeny, kindExecDeny, kindMachDeny, kindNetworkDeny:
+		return true
+	default:
+		return false
+	}
+}
+
+// matchStr returns the SBPL match keyword for the given PathMatch.
+func matchStr(m PathMatch) string {
+	switch m {
+	case Literal:
+		return "literal"
+	case Subpath:
+		return "subpath"
+	case Regex:
+		return "regex"
+	default:
+		return "literal"
+	}
+}
+
+// quotePath escapes backslashes and quotes in a path and wraps it in
+// double quotes. Regex patterns (starting with #") are passed through
+// unchanged.
+func quotePath(path string) string {
+	if strings.HasPrefix(path, `#"`) {
+		return path // regex pattern, pass through
+	}
+	escaped := strings.ReplaceAll(path, `\`, `\\`)
+	escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+	return `"` + escaped + `"`
+}
+
+// validateRule checks that non-regex paths in a rule are absolute.
+func validateRule(r rule) error {
+	// Extract the path from the SBPL string for validation.
+	// Rules follow the pattern: (allow ... (match "path"))
+	// or for regex: (allow ... (regex #"pattern"#))
+
+	// If it's a regex rule, skip validation.
+	if strings.Contains(r.sbpl, "(regex ") {
+		return nil
+	}
+
+	// Extract the quoted path from the rule.
+	// Find the last quoted string in the rule.
+	lastQuote := strings.LastIndex(r.sbpl, `"`)
+	if lastQuote < 0 {
+		return nil
+	}
+
+	// Walk backward to find the opening quote.
+	openQuote := -1
+	for i := lastQuote - 1; i >= 0; i-- {
+		if r.sbpl[i] == '"' && (i == 0 || r.sbpl[i-1] != '\\') {
+			openQuote = i
+			break
+		}
+	}
+	if openQuote < 0 {
+		return nil
+	}
+
+	path := r.sbpl[openQuote+1 : lastQuote]
+	// Unescape for validation.
+	path = strings.ReplaceAll(path, `\"`, `"`)
+	path = strings.ReplaceAll(path, `\\`, `\`)
+
+	if !strings.HasPrefix(path, "/") {
+		return fmt.Errorf("sbpl: path must be absolute, got %q", path)
+	}
+	return nil
+}

--- a/internal/platform/darwin/sbpl/builder.go
+++ b/internal/platform/darwin/sbpl/builder.go
@@ -135,11 +135,18 @@ func (p *Profile) AllowNetworkAll() {
 
 // AllowNetworkOutbound adds a rule allowing outbound network connections
 // for the given protocol and host:port. The proto parameter must be a valid
-// SBPL protocol identifier (e.g., "tcp", "udp").
+// SBPL protocol identifier containing only lowercase letters (e.g., "tcp", "udp").
 func (p *Profile) AllowNetworkOutbound(proto, hostPort string) {
+	// Validate proto contains only [a-z] to prevent SBPL injection
+	for _, c := range proto {
+		if c < 'a' || c > 'z' {
+			// Invalid proto — skip silently (will be caught by sandbox_init if wrong)
+			return
+		}
+	}
 	p.rules = append(p.rules, rule{
 		kind: kindNetworkAllow,
-		sbpl: fmt.Sprintf("(allow network-outbound (remote %q %q))", proto, hostPort),
+		sbpl: fmt.Sprintf(`(allow network-outbound (remote %s "%s"))`, proto, hostPort),
 	})
 }
 

--- a/internal/platform/darwin/sbpl/builder_test.go
+++ b/internal/platform/darwin/sbpl/builder_test.go
@@ -116,22 +116,24 @@ func TestBuild_RegexPathNotRejected(t *testing.T) {
 	}
 }
 
-func TestQuotePath(t *testing.T) {
+func TestQuotePathForMatch(t *testing.T) {
 	tests := []struct {
 		name     string
+		match    PathMatch
 		input    string
 		expected string
 	}{
-		{"simple path", "/usr/lib", `"/usr/lib"`},
-		{"path with quotes", `/path"quoted`, `"/path\"quoted"`},
-		{"path with backslash", `/path\slash`, `"/path\\slash"`},
-		{"regex passthrough", `#"/pattern"#`, `#"/pattern"#`},
+		{"simple path", Subpath, "/usr/lib", `"/usr/lib"`},
+		{"path with quotes", Literal, `/path"quoted`, `"/path\"quoted"`},
+		{"path with backslash", Literal, `/path\slash`, `"/path\\slash"`},
+		{"regex passthrough", Regex, `#"/pattern"#`, `#"/pattern"#`},
+		{"hash prefix NOT treated as regex when match is Literal", Literal, `#"not-regex`, `"#\"not-regex"`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := quotePath(tt.input)
+			got := quotePathForMatch(tt.match, tt.input)
 			if got != tt.expected {
-				t.Errorf("quotePath(%q) = %q, want %q", tt.input, got, tt.expected)
+				t.Errorf("quotePathForMatch(%v, %q) = %q, want %q", tt.match, tt.input, got, tt.expected)
 			}
 		})
 	}
@@ -296,7 +298,7 @@ func TestAllowNetworkOutbound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
 	}
-	expected := `(allow network-outbound (remote tcp "*:443"))`
+	expected := `(allow network-outbound (remote "tcp" "*:443"))`
 	if !strings.Contains(out, expected) {
 		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
 	}

--- a/internal/platform/darwin/sbpl/builder_test.go
+++ b/internal/platform/darwin/sbpl/builder_test.go
@@ -1,0 +1,172 @@
+package sbpl
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNew_ProducesValidEmptyProfile(t *testing.T) {
+	p := New()
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if !strings.HasPrefix(out, "(version 1)") {
+		t.Errorf("Build() output should start with (version 1), got:\n%s", out)
+	}
+	if !strings.Contains(out, "(deny default)") {
+		t.Error("Build() output should contain (deny default)")
+	}
+}
+
+func TestAllowFileRead_Subpath(t *testing.T) {
+	p := New()
+	p.AllowFileRead(Subpath, "/usr/lib")
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	expected := `(allow file-read* (subpath "/usr/lib"))`
+	if !strings.Contains(out, expected) {
+		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
+	}
+}
+
+func TestAllowFileRead_Literal(t *testing.T) {
+	p := New()
+	p.AllowFileRead(Literal, "/etc/hosts")
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	expected := `(allow file-read* (literal "/etc/hosts"))`
+	if !strings.Contains(out, expected) {
+		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
+	}
+}
+
+func TestAllowFileReadWrite_Subpath(t *testing.T) {
+	p := New()
+	p.AllowFileReadWrite(Subpath, "/workspace/project")
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	expected := `(allow file-read* file-write* (subpath "/workspace/project"))`
+	if !strings.Contains(out, expected) {
+		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
+	}
+}
+
+func TestBuild_RejectsRelativePath(t *testing.T) {
+	p := New()
+	p.AllowFileRead(Subpath, "relative/path")
+	_, err := p.Build()
+	if err == nil {
+		t.Error("Build() should return error for relative path")
+	}
+}
+
+func TestBuild_EscapesQuotesInPaths(t *testing.T) {
+	p := New()
+	p.AllowFileRead(Literal, `/path/with"quotes`)
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	expected := `(allow file-read* (literal "/path/with\"quotes"))`
+	if !strings.Contains(out, expected) {
+		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
+	}
+}
+
+func TestAllowFileReadWriteIOctl_Subpath(t *testing.T) {
+	p := New()
+	p.AllowFileReadWriteIOctl(Subpath, "/dev/tty")
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	expected := `(allow file-read* file-write* file-ioctl (subpath "/dev/tty"))`
+	if !strings.Contains(out, expected) {
+		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
+	}
+}
+
+func TestAllowFileRead_Regex(t *testing.T) {
+	p := New()
+	p.AllowFileRead(Regex, `#"/usr/lib/.*\.dylib"#`)
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	expected := `(allow file-read* (regex #"/usr/lib/.*\.dylib"#))`
+	if !strings.Contains(out, expected) {
+		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
+	}
+}
+
+func TestBuild_RegexPathNotRejected(t *testing.T) {
+	p := New()
+	// Regex paths don't need to be absolute
+	p.AllowFileRead(Regex, `#"relative/.*"#`)
+	_, err := p.Build()
+	if err != nil {
+		t.Errorf("Build() should not reject regex paths, got error: %v", err)
+	}
+}
+
+func TestQuotePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"simple path", "/usr/lib", `"/usr/lib"`},
+		{"path with quotes", `/path"quoted`, `"/path\"quoted"`},
+		{"path with backslash", `/path\slash`, `"/path\\slash"`},
+		{"regex passthrough", `#"/pattern"#`, `#"/pattern"#`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := quotePath(tt.input)
+			if got != tt.expected {
+				t.Errorf("quotePath(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuild_DenyBeforeAllow(t *testing.T) {
+	p := New()
+	p.AllowFileRead(Subpath, "/usr/lib")
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	denyIdx := strings.Index(out, "(deny default)")
+	allowIdx := strings.Index(out, "(allow file-read*")
+	if denyIdx > allowIdx {
+		t.Error("deny rules should appear before allow rules")
+	}
+}
+
+func TestBuild_MultipleRules(t *testing.T) {
+	p := New()
+	p.AllowFileRead(Subpath, "/usr/lib")
+	p.AllowFileReadWrite(Subpath, "/workspace")
+	p.AllowFileRead(Literal, "/etc/hosts")
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if !strings.Contains(out, `(allow file-read* (subpath "/usr/lib"))`) {
+		t.Error("missing file-read subpath rule")
+	}
+	if !strings.Contains(out, `(allow file-read* file-write* (subpath "/workspace"))`) {
+		t.Error("missing file-read-write subpath rule")
+	}
+	if !strings.Contains(out, `(allow file-read* (literal "/etc/hosts"))`) {
+		t.Error("missing file-read literal rule")
+	}
+}

--- a/internal/platform/darwin/sbpl/builder_test.go
+++ b/internal/platform/darwin/sbpl/builder_test.go
@@ -298,7 +298,7 @@ func TestAllowNetworkOutbound(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Build() error = %v", err)
 	}
-	expected := `(allow network-outbound (remote "tcp" "*:443"))`
+	expected := `(allow network-outbound (remote tcp "*:443"))`
 	if !strings.Contains(out, expected) {
 		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
 	}

--- a/internal/platform/darwin/sbpl/builder_test.go
+++ b/internal/platform/darwin/sbpl/builder_test.go
@@ -301,3 +301,75 @@ func TestAllowNetworkOutbound(t *testing.T) {
 		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
 	}
 }
+
+// --- AllowSystemEssentials tests ---
+
+func TestAllowSystemEssentials_ContainsRequiredPaths(t *testing.T) {
+	p := New()
+	p.AllowSystemEssentials()
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	required := []string{
+		// Dev files
+		`(literal "/dev/null")`,
+		`(literal "/dev/random")`,
+		`(literal "/dev/urandom")`,
+		`(literal "/dev/zero")`,
+		// System libs
+		`(subpath "/usr/lib")`,
+		`(subpath "/usr/share")`,
+		`(subpath "/System/Library")`,
+		`(subpath "/Library/Frameworks")`,
+		`(subpath "/private/var/db/dyld")`,
+		// Process ops
+		`(allow process-fork)`,
+		`(allow signal (target self))`,
+		`(allow sysctl-read)`,
+		// TTY
+		`(literal "/dev/tty")`,
+		// Tool paths
+		`(subpath "/usr/bin")`,
+		`(subpath "/usr/sbin")`,
+		`(subpath "/bin")`,
+		`(subpath "/sbin")`,
+		`(subpath "/usr/local/bin")`,
+		`(subpath "/opt/homebrew/bin")`,
+		`(subpath "/opt/homebrew/Cellar")`,
+		// Temp
+		`(subpath "/tmp")`,
+		`(subpath "/private/tmp")`,
+		`(subpath "/var/folders")`,
+		// IPC
+		`(allow ipc-posix*)`,
+		`(allow mach-register)`,
+	}
+
+	for _, s := range required {
+		if !strings.Contains(out, s) {
+			t.Errorf("AllowSystemEssentials output missing %q", s)
+		}
+	}
+}
+
+func TestAllowSystemEssentials_ContainsTTYRegex(t *testing.T) {
+	p := New()
+	p.AllowSystemEssentials()
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	ttyPatterns := []string{
+		`^/dev/ttys[0-9]+$`,
+		`^/dev/pty[pqrs][0-9a-f]$`,
+	}
+
+	for _, pat := range ttyPatterns {
+		if !strings.Contains(out, pat) {
+			t.Errorf("AllowSystemEssentials output missing TTY regex %q", pat)
+		}
+	}
+}

--- a/internal/platform/darwin/sbpl/builder_test.go
+++ b/internal/platform/darwin/sbpl/builder_test.go
@@ -170,3 +170,134 @@ func TestBuild_MultipleRules(t *testing.T) {
 		t.Error("missing file-read literal rule")
 	}
 }
+
+// --- Process exec tests ---
+
+func TestAllowProcessExec_Subpath(t *testing.T) {
+	p := New()
+	p.AllowProcessExec(Subpath, "/usr/bin")
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	expected := `(allow process-exec (subpath "/usr/bin"))`
+	if !strings.Contains(out, expected) {
+		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
+	}
+}
+
+func TestDenyProcessExec_Literal(t *testing.T) {
+	p := New()
+	p.DenyProcessExec(Literal, "/usr/bin/osascript")
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	expected := `(deny process-exec (literal "/usr/bin/osascript"))`
+	if !strings.Contains(out, expected) {
+		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
+	}
+}
+
+func TestDenyBeforeAllow_ExecOrdering(t *testing.T) {
+	p := New()
+	p.AllowProcessExec(Subpath, "/usr/bin")
+	p.DenyProcessExec(Literal, "/usr/bin/osascript")
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	denyIdx := strings.Index(out, `(deny process-exec`)
+	allowIdx := strings.Index(out, `(allow process-exec`)
+	if denyIdx < 0 {
+		t.Fatal("deny process-exec rule not found in output")
+	}
+	if allowIdx < 0 {
+		t.Fatal("allow process-exec rule not found in output")
+	}
+	if denyIdx > allowIdx {
+		t.Errorf("deny exec rules should appear before allow exec rules, deny at %d, allow at %d", denyIdx, allowIdx)
+	}
+}
+
+// --- Mach-lookup tests ---
+
+func TestAllowMachLookup(t *testing.T) {
+	p := New()
+	p.AllowMachLookup("com.apple.system.logger")
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	expected := `(allow mach-lookup (global-name "com.apple.system.logger"))`
+	if !strings.Contains(out, expected) {
+		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
+	}
+}
+
+func TestAllowMachLookupPrefix(t *testing.T) {
+	p := New()
+	p.AllowMachLookupPrefix("com.apple.system.")
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	expected := `(allow mach-lookup (global-name-prefix "com.apple.system."))`
+	if !strings.Contains(out, expected) {
+		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
+	}
+}
+
+func TestDenyMachLookup(t *testing.T) {
+	p := New()
+	p.DenyMachLookup("com.apple.security.authtrampoline")
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	expected := `(deny mach-lookup (global-name "com.apple.security.authtrampoline"))`
+	if !strings.Contains(out, expected) {
+		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
+	}
+}
+
+func TestDenyMachLookupPrefix(t *testing.T) {
+	p := New()
+	p.DenyMachLookupPrefix("com.apple.pasteboard.")
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	expected := `(deny mach-lookup (global-name-prefix "com.apple.pasteboard."))`
+	if !strings.Contains(out, expected) {
+		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
+	}
+}
+
+// --- Network tests ---
+
+func TestAllowNetworkAll(t *testing.T) {
+	p := New()
+	p.AllowNetworkAll()
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	expected := `(allow network*)`
+	if !strings.Contains(out, expected) {
+		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
+	}
+}
+
+func TestAllowNetworkOutbound(t *testing.T) {
+	p := New()
+	p.AllowNetworkOutbound("tcp", "*:443")
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	expected := `(allow network-outbound (remote tcp "*:443"))`
+	if !strings.Contains(out, expected) {
+		t.Errorf("Build() output should contain %q, got:\n%s", expected, out)
+	}
+}

--- a/internal/platform/darwin/sbpl/builder_test.go
+++ b/internal/platform/darwin/sbpl/builder_test.go
@@ -201,6 +201,33 @@ func TestDenyProcessExec_Literal(t *testing.T) {
 	}
 }
 
+func TestAllowNetworkOutbound_InvalidProto_Dropped(t *testing.T) {
+	p := New()
+	p.AllowNetworkOutbound("TCP", "*:443")  // uppercase = invalid
+	p.AllowNetworkOutbound("t1p", "*:80")   // digit = invalid
+	p.AllowNetworkOutbound("tcp)", "*:80")  // paren = invalid
+	out, _ := p.Build()
+	if strings.Contains(out, "network-outbound") {
+		t.Error("invalid proto should be silently dropped, but found network-outbound rule")
+	}
+}
+
+func TestAllowFileRead_LiteralWithHashQuotePrefix(t *testing.T) {
+	p := New()
+	p.AllowFileRead(Literal, `/#"not-a-regex`)
+	out, err := p.Build()
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	// Should be escaped, not passed through as regex
+	if strings.Contains(out, `(literal #"`) {
+		t.Error("literal path starting with #\" should be quoted, not passed through as regex")
+	}
+	if !strings.Contains(out, `(literal "`) {
+		t.Error("literal path should be properly quoted with double quotes")
+	}
+}
+
 func TestDenyBeforeAllow_ExecOrdering(t *testing.T) {
 	p := New()
 	p.AllowProcessExec(Subpath, "/usr/bin")


### PR DESCRIPTION
## Summary

- Replace static blanket-allow seatbelt profiles with policy-driven SBPL generation on macOS
- Add sandbox extension tokens for runtime file access grants
- Restrict Mach service access with deny-default + essential allowlist
- Add path-based exec restriction with blocklist for dangerous macOS tools
- New capability detection tiers: `dynamic-seatbelt` (65) and `dynamic-seatbelt-fuse` (75)

## Architecture

Three new packages, one enhanced server method:

- **`internal/platform/darwin/sbpl/`** — Pure Go SBPL builder with typed API (no CGo, tests run on any OS)
- **`internal/platform/darwin/sandboxext/`** — CGo wrapper for Apple's `sandbox_extension_issue/consume/release` APIs
- **`internal/platform/darwin/sandbox_compile.go`** — Orchestrator mapping `policy.Policy` → SBPL profile + extension tokens
- **`internal/api/core.go`** — `wrapWithMacSandbox()` now compiles policy-driven profiles server-side; macwrap becomes a thin applier

Profile generation moves from macwrap to the server where the policy engine lives. macwrap receives the pre-compiled SBPL via `WrapperConfig.CompiledProfile`, consumes extension tokens, applies sandbox, execs child. Falls back to legacy `generateProfile()` if `CompiledProfile` is empty (backwards compatible).

## Security hardening

- `quotePath` → `quotePathForMatch`: No content-sniffing — regex passthrough gated on explicit `PathMatch == Regex` type
- Network outbound proto: `[a-z]` input validation prevents SBPL injection
- Exec path restriction: allow from `/usr/bin`, `/bin`, etc.; deny `osascript`, `security`, `systemsetup`, `tccutil`, `csrutil`
- Mach services: deny-default with essential allowlist; block `authtrampoline`, `pasteboard.*`, `securityd`

## Test plan

- [ ] All 81 test packages pass (`go test ./...`)
- [ ] Cross-compilation clean: `GOOS=windows go build ./...`, `GOOS=linux go build ./...`
- [ ] SBPL builder tests run on any OS (no build tags)
- [ ] Token manager tests verify real `sandbox_extension_issue/consume/release` calls
- [ ] Compilation integration tests verify policy → SBPL mapping
- [ ] macwrap backwards compatibility tested (empty `CompiledProfile` uses legacy path)
- [ ] Security review passed — no high-confidence vulnerabilities

**Spec:** `docs/superpowers/specs/2026-03-23-dynamic-seatbelt-design.md`
**Plan:** `docs/superpowers/plans/2026-03-23-dynamic-seatbelt.md`

This is Spec A of two. Spec B (Network Extension) covers domain-level network filtering and is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)