### PR TITLE
feat: /etc/agentsh/shim.conf for non-interactive policy enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,21 @@ ENV AGENTSH_SERVER=http://127.0.0.1:18080
 
 Now any `/bin/sh -c ...` or `/bin/bash -lc ...` in the container routes through agentsh.
 
+### Non-interactive enforcement
+
+By default, the shim bypasses policy when stdin is not a TTY (preserving binary data for piped commands). On platforms where commands are always non-interactive but still need enforcement (e.g., exe.dev, sandbox APIs), add `--force`:
+
+```bash
+agentsh shim install-shell \
+  --root / \
+  --shim /usr/bin/agentsh-shell-shim \
+  --bash \
+  --force \
+  --i-understand-this-modifies-the-host
+```
+
+This writes `/etc/agentsh/shim.conf` with `force=true`, which the shim reads at startup. The config file works regardless of how the shell is spawned (unlike env vars or profile scripts). `AGENTSH_SHIM_FORCE=1` in the process environment achieves the same effect per-process.
+
 **Recommended pattern:** run agentsh as a sidecar (or PID 1) in the same pod/service and share a workspace volume; the shim ensures every shell hop stays under policy.
 
 ---

--- a/cmd/agentsh-shell-shim/confroot.go
+++ b/cmd/agentsh-shell-shim/confroot.go
@@ -1,0 +1,7 @@
+//go:build !shimtest
+
+package main
+
+// shimConfRoot returns the root path for reading shim.conf.
+// Production builds always read from the real host filesystem.
+func shimConfRoot() string { return "/" }

--- a/cmd/agentsh-shell-shim/confroot_shimtest.go
+++ b/cmd/agentsh-shell-shim/confroot_shimtest.go
@@ -1,0 +1,15 @@
+//go:build shimtest
+
+package main
+
+import "os"
+
+// shimConfRoot returns the root path for reading shim.conf.
+// Test builds allow AGENTSH_SHIM_CONF_ROOT override for integration testing.
+// This file is only compiled with -tags shimtest.
+func shimConfRoot() string {
+	if v := os.Getenv("AGENTSH_SHIM_CONF_ROOT"); v != "" {
+		return v
+	}
+	return "/"
+}

--- a/cmd/agentsh-shell-shim/main.go
+++ b/cmd/agentsh-shell-shim/main.go
@@ -67,8 +67,11 @@ func main() {
 	// platforms where env vars cannot be injected (e.g. exe.dev).
 	// Precedence: env var > config file > default (false).
 	confRoot := "/"
-	if v := os.Getenv("AGENTSH_SHIM_CONF_ROOT"); v != "" {
-		confRoot = v
+	if strings.TrimSpace(os.Getenv("AGENTSH_SHIM_DEBUG")) == "1" {
+		if v := os.Getenv("AGENTSH_SHIM_CONF_ROOT"); v != "" {
+			confRoot = v
+			debugLog("AGENTSH_SHIM_CONF_ROOT override: %s", v)
+		}
 	}
 	conf, confErr := shim.ReadShimConf(confRoot)
 	if confErr != nil {

--- a/cmd/agentsh-shell-shim/main.go
+++ b/cmd/agentsh-shell-shim/main.go
@@ -83,12 +83,15 @@ func main() {
 		conf.Force = true
 	}
 	forceShim := strings.TrimSpace(os.Getenv("AGENTSH_SHIM_FORCE"))
+	isDebug := strings.TrimSpace(os.Getenv("AGENTSH_SHIM_DEBUG")) == "1"
 	switch {
 	case forceShim == "1":
 		debugLog("AGENTSH_SHIM_FORCE=1: enforcing policy despite non-interactive stdin")
-	case forceShim == "0":
+	case forceShim == "0" && isDebug:
+		// AGENTSH_SHIM_FORCE=0 can only disable enforcement in debug mode.
+		// In production, the config file cannot be overridden by env.
 		if conf.Force {
-			debugLog("AGENTSH_SHIM_FORCE=0: config file force overridden by env")
+			debugLog("AGENTSH_SHIM_FORCE=0 (debug): config file force overridden by env")
 		}
 	case conf.Force:
 		forceShim = "1"

--- a/cmd/agentsh-shell-shim/main.go
+++ b/cmd/agentsh-shell-shim/main.go
@@ -65,15 +65,9 @@ func main() {
 	//
 	// /etc/agentsh/shim.conf with force=true also overrides the bypass, for
 	// platforms where env vars cannot be injected (e.g. exe.dev).
-	// Precedence: env var > config file > default (false).
-	confRoot := "/"
-	if strings.TrimSpace(os.Getenv("AGENTSH_SHIM_DEBUG")) == "1" {
-		if v := os.Getenv("AGENTSH_SHIM_CONF_ROOT"); v != "" {
-			confRoot = v
-			debugLog("AGENTSH_SHIM_CONF_ROOT override: %s", v)
-		}
-	}
-	conf, confErr := shim.ReadShimConf(confRoot)
+	// Precedence: AGENTSH_SHIM_FORCE=1 (env) > config file > default (false).
+	// Note: env can only ADD enforcement, never remove it.
+	conf, confErr := shim.ReadShimConf(shimConfRoot())
 	if confErr != nil {
 		// Fail-closed: if the config file exists but can't be read (permission
 		// denied, I/O error), assume force=true. An operator wrote the file for
@@ -83,16 +77,9 @@ func main() {
 		conf.Force = true
 	}
 	forceShim := strings.TrimSpace(os.Getenv("AGENTSH_SHIM_FORCE"))
-	isDebug := strings.TrimSpace(os.Getenv("AGENTSH_SHIM_DEBUG")) == "1"
 	switch {
 	case forceShim == "1":
 		debugLog("AGENTSH_SHIM_FORCE=1: enforcing policy despite non-interactive stdin")
-	case forceShim == "0" && isDebug:
-		// AGENTSH_SHIM_FORCE=0 can only disable enforcement in debug mode.
-		// In production, the config file cannot be overridden by env.
-		if conf.Force {
-			debugLog("AGENTSH_SHIM_FORCE=0 (debug): config file force overridden by env")
-		}
 	case conf.Force:
 		forceShim = "1"
 		debugLog("shim.conf force=true: enforcing policy despite non-interactive stdin")

--- a/cmd/agentsh-shell-shim/main.go
+++ b/cmd/agentsh-shell-shim/main.go
@@ -72,7 +72,12 @@ func main() {
 	}
 	conf, confErr := shim.ReadShimConf(confRoot)
 	if confErr != nil {
-		debugLog("read shim.conf: %v", confErr)
+		// Fail-closed: if the config file exists but can't be read (permission
+		// denied, I/O error), assume force=true. An operator wrote the file for
+		// a reason — silently bypassing policy is worse than over-enforcing.
+		// Only a missing file (ENOENT) is non-fatal (handled inside ReadShimConf).
+		debugLog("read shim.conf: %v (fail-closed: assuming force=true)", confErr)
+		conf.Force = true
 	}
 	forceShim := strings.TrimSpace(os.Getenv("AGENTSH_SHIM_FORCE"))
 	switch {

--- a/cmd/agentsh-shell-shim/main.go
+++ b/cmd/agentsh-shell-shim/main.go
@@ -62,14 +62,34 @@ func main() {
 	// AGENTSH_SHIM_FORCE=1 overrides this bypass for environments like sandbox
 	// platforms where commands are always non-interactive but still require
 	// policy enforcement (e.g. Blaxel, E2B sandbox APIs).
+	//
+	// /etc/agentsh/shim.conf with force=true also overrides the bypass, for
+	// platforms where env vars cannot be injected (e.g. exe.dev).
+	// Precedence: env var > config file > default (false).
+	confRoot := "/"
+	if v := os.Getenv("AGENTSH_SHIM_CONF_ROOT"); v != "" {
+		confRoot = v
+	}
+	conf, confErr := shim.ReadShimConf(confRoot)
+	if confErr != nil {
+		debugLog("read shim.conf: %v", confErr)
+	}
 	forceShim := strings.TrimSpace(os.Getenv("AGENTSH_SHIM_FORCE"))
+	switch {
+	case forceShim == "1":
+		debugLog("AGENTSH_SHIM_FORCE=1: enforcing policy despite non-interactive stdin")
+	case forceShim == "0":
+		if conf.Force {
+			debugLog("AGENTSH_SHIM_FORCE=0: config file force overridden by env")
+		}
+	case conf.Force:
+		forceShim = "1"
+		debugLog("shim.conf force=true: enforcing policy despite non-interactive stdin")
+	}
 	if !term.IsTerminal(int(os.Stdin.Fd())) && forceShim != "1" {
 		debugLog("non-interactive bypass: stdin is not a tty, executing real shell %s", realShell)
 		execOrExit(realShell, append([]string{argv0}, os.Args[1:]...), os.Environ())
 		return
-	}
-	if forceShim == "1" {
-		debugLog("AGENTSH_SHIM_FORCE=1: enforcing policy despite non-interactive stdin")
 	}
 
 	agentshBin, err := resolveAgentshBin()

--- a/cmd/agentsh-shell-shim/main_test.go
+++ b/cmd/agentsh-shell-shim/main_test.go
@@ -343,6 +343,93 @@ func TestShimPipedStdin_StderrNotContaminated(t *testing.T) {
 	}
 }
 
+func TestShimConfForce_EnforcesWithoutTTY(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-shim tests require Unix")
+	}
+
+	tmp := t.TempDir()
+	shimBin := buildShim(t, tmp)
+	if err := os.Symlink("/bin/sh", filepath.Join(tmp, "sh.real")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write shim.conf with force=true under a temp root.
+	// AGENTSH_SHIM_CONF_ROOT tells the shim to read config from here.
+	confDir := filepath.Join(tmp, "etc", "agentsh")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(confDir, "shim.conf"), []byte("force=true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// No AGENTSH_SHIM_FORCE env var — config file alone should trigger enforce.
+	// The shim will try to find agentsh and fail, proving it didn't bypass.
+	cmd := exec.Command(shimBin, "-c", "echo hello")
+	cmd.Stdin = strings.NewReader("") // non-TTY
+	cmd.Env = []string{
+		"PATH=/usr/bin:/bin",
+		"AGENTSH_SESSION_ID=test-session",
+		"AGENTSH_SHIM_CONF_ROOT=" + tmp,
+		// No AGENTSH_SHIM_FORCE — relying on config file.
+		// No AGENTSH_BIN — agentsh not available, so enforce path will fail.
+	}
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	// Should fail because agentsh is not available (it tried to enforce, not bypass).
+	if err == nil {
+		t.Fatalf("expected error: shim should try to enforce (find agentsh) and fail, not bypass")
+	}
+	// Confirm it didn't bypass by checking stderr for agentsh resolution error.
+	if !strings.Contains(stderr.String(), "agentsh") {
+		t.Fatalf("expected agentsh-related error, got stderr: %s", stderr.String())
+	}
+}
+
+func TestShimConfForce_EnvZeroOverridesConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-shim tests require Unix")
+	}
+
+	tmp := t.TempDir()
+	shimBin := buildShim(t, tmp)
+	if err := os.Symlink("/bin/sh", filepath.Join(tmp, "sh.real")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write config with force=true, but AGENTSH_SHIM_FORCE=0 should override.
+	confDir := filepath.Join(tmp, "etc", "agentsh")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(confDir, "shim.conf"), []byte("force=true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(shimBin, "-c", "echo bypassed")
+	cmd.Stdin = strings.NewReader("") // non-TTY
+	cmd.Env = []string{
+		"PATH=/usr/bin:/bin",
+		"AGENTSH_SESSION_ID=test-session",
+		"AGENTSH_SHIM_CONF_ROOT=" + tmp,
+		"AGENTSH_SHIM_FORCE=0",
+	}
+
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("expected bypass, got error: %v", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "bypassed" {
+		t.Fatalf("expected 'bypassed', got %q", got)
+	}
+}
+
 func TestFatalWithHint(t *testing.T) {
 	// Verify formatting and exit code by forking a subprocess.
 	if os.Getenv("AGENTSH_SHIM_FATAL_TEST") == "1" {

--- a/cmd/agentsh-shell-shim/main_test.go
+++ b/cmd/agentsh-shell-shim/main_test.go
@@ -176,7 +176,7 @@ func TestIsMCPCommand(t *testing.T) {
 func buildShim(t *testing.T, dir string) string {
 	t.Helper()
 	shimBin := filepath.Join(dir, "sh")
-	cmd := exec.Command("go", "build", "-o", shimBin, ".")
+	cmd := exec.Command("go", "build", "-tags", "shimtest", "-o", shimBin, ".")
 	// Resolve the source directory relative to this test file.
 	cmd.Dir = filepath.Join(srcDir(t), "cmd", "agentsh-shell-shim")
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -371,7 +371,6 @@ func TestShimConfForce_EnforcesWithoutTTY(t *testing.T) {
 	cmd.Env = []string{
 		"PATH=/usr/bin:/bin",
 		"AGENTSH_SESSION_ID=test-session",
-		"AGENTSH_SHIM_DEBUG=1",
 		"AGENTSH_SHIM_CONF_ROOT=" + tmp,
 		// No AGENTSH_SHIM_FORCE — relying on config file.
 		// No AGENTSH_BIN — agentsh not available, so enforce path will fail.
@@ -391,7 +390,7 @@ func TestShimConfForce_EnforcesWithoutTTY(t *testing.T) {
 	}
 }
 
-func TestShimConfForce_EnvZeroOverridesConfig(t *testing.T) {
+func TestShimConfForce_EnvZeroCannotOverrideConfig(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-shim tests require Unix")
 	}
@@ -402,7 +401,8 @@ func TestShimConfForce_EnvZeroOverridesConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Write config with force=true, but AGENTSH_SHIM_FORCE=0 should override.
+	// Write config with force=true. AGENTSH_SHIM_FORCE=0 should NOT override —
+	// env can only add enforcement, never remove it.
 	confDir := filepath.Join(tmp, "etc", "agentsh")
 	if err := os.MkdirAll(confDir, 0o755); err != nil {
 		t.Fatal(err)
@@ -411,24 +411,25 @@ func TestShimConfForce_EnvZeroOverridesConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmd := exec.Command(shimBin, "-c", "echo bypassed")
+	cmd := exec.Command(shimBin, "-c", "echo hello")
 	cmd.Stdin = strings.NewReader("") // non-TTY
 	cmd.Env = []string{
 		"PATH=/usr/bin:/bin",
 		"AGENTSH_SESSION_ID=test-session",
-		"AGENTSH_SHIM_DEBUG=1",
 		"AGENTSH_SHIM_CONF_ROOT=" + tmp,
 		"AGENTSH_SHIM_FORCE=0",
 	}
 
-	var stdout bytes.Buffer
-	cmd.Stdout = &stdout
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("expected bypass, got error: %v", err)
+	err := cmd.Run()
+	// Config force=true should win — shim tries to enforce and fails (no agentsh).
+	if err == nil {
+		t.Fatalf("expected error: FORCE=0 should not override config force=true")
 	}
-	if got := strings.TrimSpace(stdout.String()); got != "bypassed" {
-		t.Fatalf("expected 'bypassed', got %q", got)
+	if !strings.Contains(stderr.String(), "agentsh") {
+		t.Fatalf("expected agentsh-related error (enforce path), got stderr: %s", stderr.String())
 	}
 }
 
@@ -461,7 +462,6 @@ func TestShimConfForce_UnreadableConfigFailsClosed(t *testing.T) {
 	cmd.Env = []string{
 		"PATH=/usr/bin:/bin",
 		"AGENTSH_SESSION_ID=test-session",
-		"AGENTSH_SHIM_DEBUG=1",
 		"AGENTSH_SHIM_CONF_ROOT=" + tmp,
 	}
 

--- a/cmd/agentsh-shell-shim/main_test.go
+++ b/cmd/agentsh-shell-shim/main_test.go
@@ -430,6 +430,51 @@ func TestShimConfForce_EnvZeroOverridesConfig(t *testing.T) {
 	}
 }
 
+func TestShimConfForce_UnreadableConfigFailsClosed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-shim tests require Unix")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("test requires non-root")
+	}
+
+	tmp := t.TempDir()
+	shimBin := buildShim(t, tmp)
+	if err := os.Symlink("/bin/sh", filepath.Join(tmp, "sh.real")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write shim.conf but make it unreadable. The shim should fail-closed:
+	// assume force=true and try to enforce (not bypass).
+	confDir := filepath.Join(tmp, "etc", "agentsh")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(confDir, "shim.conf"), []byte("force=true\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(shimBin, "-c", "echo hello")
+	cmd.Stdin = strings.NewReader("") // non-TTY
+	cmd.Env = []string{
+		"PATH=/usr/bin:/bin",
+		"AGENTSH_SESSION_ID=test-session",
+		"AGENTSH_SHIM_CONF_ROOT=" + tmp,
+	}
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	// Should fail because the shim tried to enforce (fail-closed), not bypass.
+	if err == nil {
+		t.Fatalf("expected error: unreadable config should fail-closed and try to enforce, not bypass")
+	}
+	if !strings.Contains(stderr.String(), "agentsh") {
+		t.Fatalf("expected agentsh-related error (enforce path), got stderr: %s", stderr.String())
+	}
+}
+
 func TestFatalWithHint(t *testing.T) {
 	// Verify formatting and exit code by forking a subprocess.
 	if os.Getenv("AGENTSH_SHIM_FATAL_TEST") == "1" {

--- a/cmd/agentsh-shell-shim/main_test.go
+++ b/cmd/agentsh-shell-shim/main_test.go
@@ -371,6 +371,7 @@ func TestShimConfForce_EnforcesWithoutTTY(t *testing.T) {
 	cmd.Env = []string{
 		"PATH=/usr/bin:/bin",
 		"AGENTSH_SESSION_ID=test-session",
+		"AGENTSH_SHIM_DEBUG=1",
 		"AGENTSH_SHIM_CONF_ROOT=" + tmp,
 		// No AGENTSH_SHIM_FORCE — relying on config file.
 		// No AGENTSH_BIN — agentsh not available, so enforce path will fail.
@@ -415,6 +416,7 @@ func TestShimConfForce_EnvZeroOverridesConfig(t *testing.T) {
 	cmd.Env = []string{
 		"PATH=/usr/bin:/bin",
 		"AGENTSH_SESSION_ID=test-session",
+		"AGENTSH_SHIM_DEBUG=1",
 		"AGENTSH_SHIM_CONF_ROOT=" + tmp,
 		"AGENTSH_SHIM_FORCE=0",
 	}
@@ -459,6 +461,7 @@ func TestShimConfForce_UnreadableConfigFailsClosed(t *testing.T) {
 	cmd.Env = []string{
 		"PATH=/usr/bin:/bin",
 		"AGENTSH_SESSION_ID=test-session",
+		"AGENTSH_SHIM_DEBUG=1",
 		"AGENTSH_SHIM_CONF_ROOT=" + tmp,
 	}
 

--- a/docs/ci-and-releases.md
+++ b/docs/ci-and-releases.md
@@ -51,3 +51,4 @@ Open decisions before implementing packages:
   - whether to ship a systemd unit (probably later)
 - Shim activation:
   - do *not* auto-replace `/bin/sh` in packages; provide `agentsh shim install-shell --root /` with explicit `--i-understand-this-modifies-the-host`
+  - for non-interactive enforcement (e.g., sandbox platforms), add `--force` which writes `/etc/agentsh/shim.conf` with `force=true`

--- a/docs/cicd-integration.md
+++ b/docs/cicd-integration.md
@@ -105,6 +105,23 @@ ai-agent-task:
 
 When running agentsh in containers, proper startup sequencing is important to avoid race conditions between the daemon and shell shim.
 
+### Non-Interactive Shell Enforcement
+
+By default, the shell shim bypasses policy when stdin is not a TTY. This preserves binary stdin/stdout for piped data (e.g., `docker exec -i container sh -c "cat > /file" < binary`). In CI/CD environments where all commands are non-interactive but still need enforcement, use `--force` during shim installation:
+
+```bash
+agentsh shim install-shell \
+  --root / \
+  --shim /usr/bin/agentsh-shell-shim \
+  --bash \
+  --force \
+  --i-understand-this-modifies-the-host
+```
+
+This writes `/etc/agentsh/shim.conf` with `force=true`. The shim reads this file at startup, so it works regardless of how the shell is spawned (unlike env vars or profile scripts that may not be sourced for non-interactive SSH sessions).
+
+Alternatively, set `AGENTSH_SHIM_FORCE=1` in the process environment for per-process enforcement.
+
 ### Basic Dockerfile
 
 ```dockerfile

--- a/docs/superpowers/plans/2026-03-24-shim-conf.md
+++ b/docs/superpowers/plans/2026-03-24-shim-conf.md
@@ -1,0 +1,807 @@
+# Shim Configuration File Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `/etc/agentsh/shim.conf` support so the shell shim can read configuration (starting with `force=true`) without relying on environment variables.
+
+**Architecture:** New `internal/shim/conf.go` provides `ShimConfPath`, `ReadShimConf`, `WriteShimConf` shared by the shim binary and the install CLI. The shim binary reads the config before the bypass check with precedence: env var > config file > default. The install CLI gains a `--force` flag that writes the config.
+
+**Tech Stack:** Go stdlib only (os, strings, path/filepath). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-03-24-shim-conf-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `internal/shim/conf.go` | Create | `ShimConf`, `ShimConfPath`, `ReadShimConf`, `WriteShimConf` |
+| `internal/shim/conf_test.go` | Create | Unit tests for config parsing, writing, round-trip, error cases |
+| `cmd/agentsh-shell-shim/main.go` | Modify | Read config, integrate into bypass logic |
+| `cmd/agentsh-shell-shim/main_test.go` | Modify | Integration tests for config + env + TTY precedence |
+| `internal/cli/shim_cmd.go` | Modify | `--force` flag on `install-shell`, write config after install |
+| `internal/shim/shell_shim_plan.go` | Modify | Add `Force` field to `InstallShellShimOptions`, plan config write action |
+| `internal/shim/install.go` | Modify | Write config file when `Force` option is set |
+| `internal/cli/shim_cmd_test.go` | Modify | CLI tests for `--force` and `--force --dry-run` |
+
+---
+
+### Task 1: Config parser — `internal/shim/conf.go` + tests
+
+**Files:**
+- Create: `internal/shim/conf.go`
+- Create: `internal/shim/conf_test.go`
+
+- [ ] **Step 1: Write failing tests for `ShimConfPath`**
+
+```go
+// internal/shim/conf_test.go
+package shim
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestShimConfPath(t *testing.T) {
+	tests := []struct {
+		root string
+		want string
+	}{
+		{"/", "/etc/agentsh/shim.conf"},
+		{"/rootfs", "/rootfs/etc/agentsh/shim.conf"},
+		{"", "/etc/agentsh/shim.conf"},
+	}
+	for _, tt := range tests {
+		got := ShimConfPath(tt.root)
+		if got != tt.want {
+			t.Errorf("ShimConfPath(%q) = %q, want %q", tt.root, got, tt.want)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/shim/ -run TestShimConfPath -v`
+Expected: FAIL — `ShimConfPath` not defined.
+
+- [ ] **Step 3: Write `ShimConfPath` and `ShimConf` type**
+
+```go
+// internal/shim/conf.go
+package shim
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ShimConf is the parsed shim configuration.
+type ShimConf struct {
+	Force bool              // force=true|1
+	Raw   map[string]string // all key=value pairs for forward compat
+}
+
+// ShimConfPath returns the config file path under root.
+func ShimConfPath(root string) string {
+	if root == "" {
+		root = "/"
+	}
+	return filepath.Join(root, "etc", "agentsh", "shim.conf")
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/shim/ -run TestShimConfPath -v`
+Expected: PASS
+
+- [ ] **Step 5: Write failing tests for `ReadShimConf`**
+
+Add to `internal/shim/conf_test.go`:
+
+```go
+func TestReadShimConf_MissingFile(t *testing.T) {
+	root := t.TempDir()
+	conf, err := ReadShimConf(root)
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got %v", err)
+	}
+	if conf.Force {
+		t.Fatalf("expected Force=false for missing file")
+	}
+}
+
+func TestReadShimConf_ForceTrue(t *testing.T) {
+	root := t.TempDir()
+	writeTestConf(t, root, "force=true\n")
+	conf, err := ReadShimConf(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !conf.Force {
+		t.Fatalf("expected Force=true")
+	}
+}
+
+func TestReadShimConf_ForceOne(t *testing.T) {
+	root := t.TempDir()
+	writeTestConf(t, root, "force=1\n")
+	conf, err := ReadShimConf(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !conf.Force {
+		t.Fatalf("expected Force=true for force=1")
+	}
+}
+
+func TestReadShimConf_ForceFalse(t *testing.T) {
+	root := t.TempDir()
+	writeTestConf(t, root, "force=false\n")
+	conf, err := ReadShimConf(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if conf.Force {
+		t.Fatalf("expected Force=false")
+	}
+}
+
+func TestReadShimConf_CommentsAndBlanks(t *testing.T) {
+	root := t.TempDir()
+	writeTestConf(t, root, "# comment\n\n  # indented comment\nforce = true\nextra=value\nmalformed line\n")
+	conf, err := ReadShimConf(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !conf.Force {
+		t.Fatalf("expected Force=true")
+	}
+	if conf.Raw["extra"] != "value" {
+		t.Fatalf("expected Raw[extra]=value, got %q", conf.Raw["extra"])
+	}
+	// malformed line (no =) should be ignored
+	if len(conf.Raw) != 2 {
+		t.Fatalf("expected 2 raw keys, got %d: %v", len(conf.Raw), conf.Raw)
+	}
+}
+
+func TestReadShimConf_Unreadable(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("test requires non-root")
+	}
+	root := t.TempDir()
+	confDir := filepath.Join(root, "etc", "agentsh")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	confPath := filepath.Join(confDir, "shim.conf")
+	if err := os.WriteFile(confPath, []byte("force=true\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	conf, err := ReadShimConf(root)
+	if err == nil {
+		t.Fatalf("expected error for unreadable file")
+	}
+	if conf.Force {
+		t.Fatalf("expected Force=false on read error")
+	}
+}
+
+// writeTestConf writes content to {root}/etc/agentsh/shim.conf.
+func writeTestConf(t *testing.T, root, content string) {
+	t.Helper()
+	dir := filepath.Join(root, "etc", "agentsh")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "shim.conf"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+```
+
+- [ ] **Step 6: Run tests to verify they fail**
+
+Run: `go test ./internal/shim/ -run TestReadShimConf -v`
+Expected: FAIL — `ReadShimConf` not defined.
+
+- [ ] **Step 7: Implement `ReadShimConf`**
+
+Add to `internal/shim/conf.go`:
+
+```go
+// ReadShimConf reads the config file at ShimConfPath(root).
+// Missing file (ENOENT) returns empty conf with nil error.
+// Other read errors return empty conf and the error.
+func ReadShimConf(root string) (ShimConf, error) {
+	conf := ShimConf{Raw: make(map[string]string)}
+	data, err := os.ReadFile(ShimConfPath(root))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return conf, nil
+		}
+		return conf, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		conf.Raw[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	conf.Force = conf.Raw["force"] == "true" || conf.Raw["force"] == "1"
+	return conf, nil
+}
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `go test ./internal/shim/ -run TestReadShimConf -v`
+Expected: PASS
+
+- [ ] **Step 9: Write failing tests for `WriteShimConf`**
+
+Add to `internal/shim/conf_test.go`:
+
+```go
+func TestWriteShimConf_CreatesDirectoryAndFile(t *testing.T) {
+	root := t.TempDir()
+	conf := ShimConf{
+		Force: true,
+		Raw:   map[string]string{"force": "true"},
+	}
+	if err := WriteShimConf(root, conf); err != nil {
+		t.Fatalf("WriteShimConf: %v", err)
+	}
+
+	// Check directory permissions.
+	dirInfo, err := os.Stat(filepath.Join(root, "etc", "agentsh"))
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != 0o755 {
+		t.Fatalf("expected dir perm 0o755, got %o", perm)
+	}
+
+	// Check file permissions.
+	fileInfo, err := os.Stat(ShimConfPath(root))
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if perm := fileInfo.Mode().Perm(); perm != 0o644 {
+		t.Fatalf("expected file perm 0o644, got %o", perm)
+	}
+
+	// Check content contains force=true.
+	data, err := os.ReadFile(ShimConfPath(root))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), "force=true") {
+		t.Fatalf("expected force=true in content, got %q", string(data))
+	}
+}
+
+func TestWriteShimConf_RoundTrip(t *testing.T) {
+	root := t.TempDir()
+	original := ShimConf{
+		Force: true,
+		Raw:   map[string]string{"force": "true", "debug": "1"},
+	}
+	if err := WriteShimConf(root, original); err != nil {
+		t.Fatalf("WriteShimConf: %v", err)
+	}
+	got, err := ReadShimConf(root)
+	if err != nil {
+		t.Fatalf("ReadShimConf: %v", err)
+	}
+	if !got.Force {
+		t.Fatalf("expected Force=true after round-trip")
+	}
+	if got.Raw["debug"] != "1" {
+		t.Fatalf("expected Raw[debug]=1, got %q", got.Raw["debug"])
+	}
+}
+```
+
+- [ ] **Step 10: Run tests to verify they fail**
+
+Run: `go test ./internal/shim/ -run TestWriteShimConf -v`
+Expected: FAIL — `WriteShimConf` not defined.
+
+- [ ] **Step 11: Implement `WriteShimConf`**
+
+Add to `internal/shim/conf.go`:
+
+```go
+// WriteShimConf writes all keys from conf.Raw as key=value lines.
+// Creates /etc/agentsh/ directory (mode 0o755) if needed.
+// File is written atomically with mode 0o644.
+func WriteShimConf(root string, conf ShimConf) error {
+	keys := make([]string, 0, len(conf.Raw))
+	for k := range conf.Raw {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var buf strings.Builder
+	buf.WriteString("# Written by: agentsh shim install-shell\n")
+	for _, k := range keys {
+		fmt.Fprintf(&buf, "%s=%s\n", k, conf.Raw[k])
+	}
+	return writeFileAtomic(ShimConfPath(root), []byte(buf.String()), 0o644)
+}
+```
+
+Note: reuses the existing `writeFileAtomic` from `internal/shim/install.go`. Keys are sorted for deterministic output. Add `"sort"` to the imports in `conf.go`.
+
+- [ ] **Step 12: Run all conf tests to verify they pass**
+
+Run: `go test ./internal/shim/ -run "TestShimConf|TestReadShimConf|TestWriteShimConf" -v`
+Expected: PASS
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add internal/shim/conf.go internal/shim/conf_test.go
+git commit -m "feat: add shim config file parser (internal/shim/conf.go)"
+```
+
+---
+
+### Task 2: Integrate config into shim bypass logic
+
+**Files:**
+- Modify: `cmd/agentsh-shell-shim/main.go:55-73`
+
+**Depends on:** Task 1
+
+- [ ] **Step 1: Modify bypass logic in `main.go`**
+
+Note: `main.go` already imports `"github.com/agentsh/agentsh/internal/shim"` (line 11). No import changes needed.
+
+Replace lines 56–73 (the non-interactive bypass block) with:
+
+```go
+	// Non-interactive bypass: when stdin is not a terminal (piped data, e.g.
+	// docker exec -i container sh -c "cat > /file" < binary), exec the real
+	// shell directly. This preserves binary stdin/stdout integrity — the shim
+	// never touches the data streams. Policy enforcement for commands inside
+	// agentsh sessions is handled by AGENTSH_IN_SESSION (checked above).
+	//
+	// AGENTSH_SHIM_FORCE=1 overrides this bypass for environments like sandbox
+	// platforms where commands are always non-interactive but still require
+	// policy enforcement (e.g. Blaxel, E2B sandbox APIs).
+	//
+	// /etc/agentsh/shim.conf with force=true also overrides the bypass, for
+	// platforms where env vars cannot be injected (e.g. exe.dev).
+	// Precedence: env var > config file > default (false).
+	confRoot := "/"
+	if v := os.Getenv("AGENTSH_SHIM_CONF_ROOT"); v != "" {
+		confRoot = v
+	}
+	conf, confErr := shim.ReadShimConf(confRoot)
+	if confErr != nil {
+		debugLog("read shim.conf: %v", confErr)
+	}
+	forceShim := strings.TrimSpace(os.Getenv("AGENTSH_SHIM_FORCE"))
+	switch {
+	case forceShim == "1":
+		debugLog("AGENTSH_SHIM_FORCE=1: enforcing policy despite non-interactive stdin")
+	case forceShim == "0":
+		if conf.Force {
+			debugLog("AGENTSH_SHIM_FORCE=0: config file force overridden by env")
+		}
+	case conf.Force:
+		forceShim = "1"
+		debugLog("shim.conf force=true: enforcing policy despite non-interactive stdin")
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) && forceShim != "1" {
+		debugLog("non-interactive bypass: stdin is not a tty, executing real shell %s", realShell)
+		execOrExit(realShell, append([]string{argv0}, os.Args[1:]...), os.Environ())
+		return
+	}
+```
+
+Note: `AGENTSH_SHIM_CONF_ROOT` is an internal testing hook — it allows integration tests to point the shim at a temp directory. It is not documented for end users.
+
+- [ ] **Step 2: Verify build**
+
+Run: `go build ./cmd/agentsh-shell-shim/`
+Expected: success, no errors.
+
+- [ ] **Step 3: Run existing shim tests to verify no regressions**
+
+Run: `go test ./cmd/agentsh-shell-shim/ -v`
+Expected: all existing tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/agentsh-shell-shim/main.go
+git commit -m "feat: shell shim reads /etc/agentsh/shim.conf for force setting"
+```
+
+---
+
+### Task 3: Integration tests for config + env + TTY precedence
+
+**Files:**
+- Modify: `cmd/agentsh-shell-shim/main_test.go`
+
+**Depends on:** Task 2
+
+- [ ] **Step 1: Add integration test — config force=true, no env, no TTY → enforce**
+
+Add to `cmd/agentsh-shell-shim/main_test.go`:
+
+```go
+func TestShimConfForce_EnforcesWithoutTTY(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-shim tests require Unix")
+	}
+
+	tmp := t.TempDir()
+	shimBin := buildShim(t, tmp)
+	if err := os.Symlink("/bin/sh", filepath.Join(tmp, "sh.real")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write shim.conf with force=true under a temp root.
+	// AGENTSH_SHIM_CONF_ROOT tells the shim to read config from here.
+	confDir := filepath.Join(tmp, "etc", "agentsh")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(confDir, "shim.conf"), []byte("force=true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// No AGENTSH_SHIM_FORCE env var — config file alone should trigger enforce.
+	// The shim will try to find agentsh and fail, proving it didn't bypass.
+	cmd := exec.Command(shimBin, "-c", "echo hello")
+	cmd.Stdin = strings.NewReader("") // non-TTY
+	cmd.Env = []string{
+		"PATH=/usr/bin:/bin",
+		"AGENTSH_SESSION_ID=test-session",
+		"AGENTSH_SHIM_CONF_ROOT=" + tmp,
+		// No AGENTSH_SHIM_FORCE — relying on config file.
+		// No AGENTSH_BIN — agentsh not available, so enforce path will fail.
+	}
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	// Should fail because agentsh is not available (it tried to enforce, not bypass).
+	if err == nil {
+		t.Fatalf("expected error: shim should try to enforce (find agentsh) and fail, not bypass")
+	}
+	// Confirm it didn't bypass by checking stderr for agentsh resolution error.
+	if !strings.Contains(stderr.String(), "agentsh") {
+		t.Fatalf("expected agentsh-related error, got stderr: %s", stderr.String())
+	}
+}
+
+func TestShimConfForce_EnvZeroOverridesConfig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-shim tests require Unix")
+	}
+
+	tmp := t.TempDir()
+	shimBin := buildShim(t, tmp)
+	if err := os.Symlink("/bin/sh", filepath.Join(tmp, "sh.real")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write config with force=true, but AGENTSH_SHIM_FORCE=0 should override.
+	confDir := filepath.Join(tmp, "etc", "agentsh")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(confDir, "shim.conf"), []byte("force=true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(shimBin, "-c", "echo bypassed")
+	cmd.Stdin = strings.NewReader("") // non-TTY
+	cmd.Env = []string{
+		"PATH=/usr/bin:/bin",
+		"AGENTSH_SESSION_ID=test-session",
+		"AGENTSH_SHIM_CONF_ROOT=" + tmp,
+		"AGENTSH_SHIM_FORCE=0",
+	}
+
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("expected bypass, got error: %v", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "bypassed" {
+		t.Fatalf("expected 'bypassed', got %q", got)
+	}
+}
+```
+
+Note: The "Config force=true, TTY → enforce" case from the spec is covered implicitly: TTY always enforces regardless of config or env (the bypass only triggers for non-TTY). This cannot be meaningfully integration-tested without a PTY allocator.
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `go test ./cmd/agentsh-shell-shim/ -run "TestShimConfForce" -v`
+Expected: PASS
+
+- [ ] **Step 3: Run all shim tests to verify no regressions**
+
+Run: `go test ./cmd/agentsh-shell-shim/ -v`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/agentsh-shell-shim/main_test.go
+git commit -m "test: integration tests for shim.conf force + env precedence"
+```
+
+---
+
+### Task 4: `--force` flag on `install-shell` CLI
+
+**Files:**
+- Modify: `internal/cli/shim_cmd.go:24-72`
+- Modify: `internal/shim/install.go` (add `Force` to options, call `WriteShimConf`)
+- Modify: `internal/shim/shell_shim_plan.go` (plan config write action)
+
+**Depends on:** Task 1
+
+- [ ] **Step 1: Add `Force` field to `InstallShellShimOptions`**
+
+In `internal/shim/install.go`, add to the struct:
+
+```go
+type InstallShellShimOptions struct {
+	// ... existing fields ...
+
+	// Force writes /etc/agentsh/shim.conf with force=true after installing.
+	Force bool
+}
+```
+
+- [ ] **Step 2: Write config file in `InstallShellShim` when `Force` is set**
+
+In `internal/shim/install.go`, add at the end of `InstallShellShim`, before the final `return nil`:
+
+```go
+	if opts.Force {
+		conf := ShimConf{
+			Force: true,
+			Raw:   map[string]string{"force": "true"},
+		}
+		if err := WriteShimConf(root, conf); err != nil {
+			return fmt.Errorf("write shim.conf: %w", err)
+		}
+	}
+```
+
+- [ ] **Step 3: Add config write action to `PlanInstallShellShim`**
+
+In `internal/shim/shell_shim_plan.go`, add before the return in `PlanInstallShellShim`:
+
+```go
+	if opts.Force {
+		actions = append(actions, ShellShimAction{
+			Op:   "write",
+			Path: ShimConfPath(root),
+			Note: "write shim.conf with force=true",
+		})
+	}
+```
+
+- [ ] **Step 4: Add `--force` flag in CLI**
+
+In `internal/cli/shim_cmd.go`, inside `newShimInstallShellCmd`:
+
+Add var declaration alongside the existing ones:
+```go
+	var force bool
+```
+
+Add to `opts` construction:
+```go
+			opts := shim.InstallShellShimOptions{
+				Root:        root,
+				ShimPath:    shimPath,
+				InstallBash: bash || bashOnly,
+				BashOnly:    bashOnly,
+				Force:       force,
+			}
+```
+
+Add flag registration alongside the existing flags:
+```go
+	c.Flags().BoolVar(&force, "force", false, "Write /etc/agentsh/shim.conf with force=true (enforces policy for non-interactive shells)")
+```
+
+- [ ] **Step 5: Verify build**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/shim/install.go internal/shim/shell_shim_plan.go internal/cli/shim_cmd.go
+git commit -m "feat: add --force flag to install-shell, writes shim.conf"
+```
+
+---
+
+### Task 5: CLI tests for `--force` flag
+
+**Files:**
+- Modify: `internal/cli/shim_cmd_test.go`
+
+**Depends on:** Task 4
+
+- [ ] **Step 1: Write test — `--force` writes config file**
+
+Add `"bytes"` to the import list of `internal/cli/shim_cmd_test.go` (needed for `bytes.Buffer` in the dry-run test).
+
+Add to `internal/cli/shim_cmd_test.go`:
+
+```go
+func TestShimInstallShell_ForceWritesConfig(t *testing.T) {
+	tmp := t.TempDir()
+	rootfs := filepath.Join(tmp, "rootfs")
+	if err := os.MkdirAll(filepath.Join(rootfs, "bin"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfs, "bin", "sh"), []byte("REAL\n"), 0o755); err != nil {
+		t.Fatalf("write sh: %v", err)
+	}
+	shimPath := filepath.Join(tmp, "shim.bin")
+	if err := os.WriteFile(shimPath, []byte("SHIM\n"), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+
+	root := NewRoot("test")
+	root.SetArgs([]string{
+		"shim", "install-shell",
+		"--root", rootfs,
+		"--shim", shimPath,
+		"--force",
+	})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	confPath := filepath.Join(rootfs, "etc", "agentsh", "shim.conf")
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("expected shim.conf to exist: %v", err)
+	}
+	if !strings.Contains(string(data), "force=true") {
+		t.Fatalf("expected force=true in shim.conf, got %q", string(data))
+	}
+}
+
+func TestShimInstallShell_NoForceNoConfig(t *testing.T) {
+	tmp := t.TempDir()
+	rootfs := filepath.Join(tmp, "rootfs")
+	if err := os.MkdirAll(filepath.Join(rootfs, "bin"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfs, "bin", "sh"), []byte("REAL\n"), 0o755); err != nil {
+		t.Fatalf("write sh: %v", err)
+	}
+	shimPath := filepath.Join(tmp, "shim.bin")
+	if err := os.WriteFile(shimPath, []byte("SHIM\n"), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+
+	root := NewRoot("test")
+	root.SetArgs([]string{
+		"shim", "install-shell",
+		"--root", rootfs,
+		"--shim", shimPath,
+	})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	confPath := filepath.Join(rootfs, "etc", "agentsh", "shim.conf")
+	if _, err := os.Stat(confPath); err == nil {
+		t.Fatalf("expected shim.conf NOT to exist without --force")
+	}
+}
+
+func TestShimInstallShell_ForceDryRun(t *testing.T) {
+	tmp := t.TempDir()
+	rootfs := filepath.Join(tmp, "rootfs")
+	if err := os.MkdirAll(filepath.Join(rootfs, "bin"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfs, "bin", "sh"), []byte("REAL\n"), 0o755); err != nil {
+		t.Fatalf("write sh: %v", err)
+	}
+	shimPath := filepath.Join(tmp, "shim.bin")
+	if err := os.WriteFile(shimPath, []byte("SHIM\n"), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+
+	root := NewRoot("test")
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetArgs([]string{
+		"shim", "install-shell",
+		"--root", rootfs,
+		"--shim", shimPath,
+		"--force",
+		"--dry-run",
+	})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	// Dry run should NOT write the file.
+	confPath := filepath.Join(rootfs, "etc", "agentsh", "shim.conf")
+	if _, err := os.Stat(confPath); err == nil {
+		t.Fatalf("dry-run should NOT write shim.conf")
+	}
+
+	// Dry run output should mention the config file path.
+	if !strings.Contains(stdout.String(), "shim.conf") {
+		t.Fatalf("expected dry-run output to mention shim.conf, got %q", stdout.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run the new tests**
+
+Run: `go test ./internal/cli/ -run "TestShimInstallShell_Force" -v`
+Expected: PASS
+
+- [ ] **Step 3: Run all CLI tests to verify no regressions**
+
+Run: `go test ./internal/cli/ -run TestShim -v`
+Expected: all PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/cli/shim_cmd_test.go
+git commit -m "test: CLI tests for --force flag on install-shell"
+```
+
+---
+
+### Task 6: Final verification
+
+**Depends on:** Tasks 1–5
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `go test ./...`
+Expected: all PASS.
+
+- [ ] **Step 2: Verify cross-compilation**
+
+Run: `GOOS=windows go build ./...`
+Expected: success.
+
+- [ ] **Step 3: Verify macOS cross-compilation**
+
+Run: `GOOS=darwin go build ./...`
+Expected: success.

--- a/docs/superpowers/specs/2026-03-24-shim-conf-design.md
+++ b/docs/superpowers/specs/2026-03-24-shim-conf-design.md
@@ -17,7 +17,7 @@ Add a config file that the shim reads at startup. The file is written during `ag
 
 ### Config file format
 
-Simple `key=value`, one per line. Blank lines and `#` comments allowed. No quoting, no sections, no nested values.
+Simple `key=value`, one per line. Blank lines and lines where the first non-whitespace character is `#` are ignored. Whitespace around keys and values is trimmed (e.g., `force = true` is equivalent to `force=true`). Trailing inline comments are not supported (`force=true # comment` would set `force` to `true # comment`). Keys are case-sensitive. No quoting, no sections, no nested values.
 
 ```
 # /etc/agentsh/shim.conf
@@ -38,11 +38,15 @@ The config parser lives in `internal/shim/` so both the shim binary and the inst
 func ShimConfPath(root string) string
 
 // ReadShimConf reads the config file at ShimConfPath(root).
-// Missing file returns empty conf, not error.
-func ReadShimConf(root string) ShimConf
+// Missing file (ENOENT) returns empty conf with nil error.
+// Other read errors (permission denied, I/O) return empty conf AND the error,
+// so the caller can log it without crashing.
+func ReadShimConf(root string) (ShimConf, error)
 
-// WriteShimConf writes config to ShimConfPath(root).
-// Creates /etc/agentsh/ directory if needed. Atomic write.
+// WriteShimConf writes all keys from conf.Raw as key=value lines, one per line.
+// Prepends a comment header: "# Written by: agentsh shim install-shell".
+// Creates /etc/agentsh/ directory (mode 0o755) if needed.
+// File is written atomically with mode 0o644.
 func WriteShimConf(root string, conf ShimConf) error
 
 // ShimConf is the parsed config.
@@ -52,20 +56,33 @@ type ShimConf struct {
 }
 ```
 
+### Permissions
+
+The config file is security-relevant (`force=true` enables policy enforcement). A world-writable config would let a local attacker set `force=false` to bypass enforcement.
+
+- Directory `/etc/agentsh/`: mode `0o755`, owned by root. Standard `/etc` subdirectory convention.
+- File `shim.conf`: mode `0o644` (readable by all, writable only by root). Consistent with `/etc/ssh/sshd_config` and similar system configs.
+
+`WriteShimConf` enforces these modes in its atomic write.
+
 ### Shim bypass logic (`cmd/agentsh-shell-shim/main.go`)
 
 Precedence: env var > config file > default (false).
 
 ```go
-conf := shim.ReadShimConf("/")
+conf, confErr := shim.ReadShimConf("/")
+if confErr != nil {
+    debugLog("read shim.conf: %v", confErr)
+}
 forceShim := strings.TrimSpace(os.Getenv("AGENTSH_SHIM_FORCE"))
 switch {
 case forceShim == "1":
-    // env says force
+    debugLog("AGENTSH_SHIM_FORCE=1: enforcing policy despite non-interactive stdin")
 case forceShim == "0":
-    // env says don't force — respect it, ignore config
+    debugLog("AGENTSH_SHIM_FORCE=0: config file force overridden by env")
 case conf.Force:
     forceShim = "1"
+    debugLog("shim.conf force=true: enforcing policy despite non-interactive stdin")
 }
 if !term.IsTerminal(int(os.Stdin.Fd())) && forceShim != "1" {
     // bypass as before
@@ -86,6 +103,8 @@ Dry-run support: `--force --dry-run` includes a `write` action in the plan outpu
 
 Uninstall does not touch the config file. The file is inert without the shim and follows the Unix convention that `/etc` configs survive package removal.
 
+The config file is global. `force=true` applies to all shim invocations regardless of which shell is shimmed. It has no effect on shells where the shim is not installed (e.g., if `--bash-only` was used, `force=true` does not affect `/bin/sh` since the shim is not installed there).
+
 ### Performance
 
 Reading a small file adds ~0.1ms. The shim already does `os.Getenv()`, `term.IsTerminal()` (ioctl), and `os.Stat()` for real shell detection. One more `os.ReadFile()` is negligible.
@@ -103,12 +122,13 @@ Reading a small file adds ~0.1ms. The shim already does `os.Getenv()`, `term.IsT
 
 ### Unit tests (`internal/shim/conf_test.go`)
 
-- `ReadShimConf` with missing file returns empty conf
+- `ReadShimConf` with missing file returns empty conf, nil error
 - `ReadShimConf` with `force=true` returns `Force: true`
 - `ReadShimConf` with `force=1` returns `Force: true`
 - `ReadShimConf` with `force=false` returns `Force: false`
 - `ReadShimConf` with malformed lines, comments, blank lines parses correctly
-- `WriteShimConf` creates directory and file atomically
+- `ReadShimConf` with unreadable file (permission denied) returns empty conf and non-nil error
+- `WriteShimConf` creates directory (0o755) and file (0o644) atomically
 - `WriteShimConf` then `ReadShimConf` round-trip preserves values
 - `ShimConfPath` returns expected path for given root
 

--- a/docs/superpowers/specs/2026-03-24-shim-conf-design.md
+++ b/docs/superpowers/specs/2026-03-24-shim-conf-design.md
@@ -70,7 +70,11 @@ The config file is security-relevant (`force=true` enables policy enforcement). 
 Precedence: env var > config file > default (false).
 
 ```go
-conf, confErr := shim.ReadShimConf("/")
+confRoot := "/"
+if v := os.Getenv("AGENTSH_SHIM_CONF_ROOT"); v != "" {
+    confRoot = v
+}
+conf, confErr := shim.ReadShimConf(confRoot)
 if confErr != nil {
     debugLog("read shim.conf: %v", confErr)
 }
@@ -79,7 +83,9 @@ switch {
 case forceShim == "1":
     debugLog("AGENTSH_SHIM_FORCE=1: enforcing policy despite non-interactive stdin")
 case forceShim == "0":
-    debugLog("AGENTSH_SHIM_FORCE=0: config file force overridden by env")
+    if conf.Force {
+        debugLog("AGENTSH_SHIM_FORCE=0: config file force overridden by env")
+    }
 case conf.Force:
     forceShim = "1"
     debugLog("shim.conf force=true: enforcing policy despite non-interactive stdin")
@@ -88,6 +94,8 @@ if !term.IsTerminal(int(os.Stdin.Fd())) && forceShim != "1" {
     // bypass as before
 }
 ```
+
+`AGENTSH_SHIM_CONF_ROOT` is an internal testing hook (not documented for end users) that allows integration tests to point the shim at a temp directory instead of `/`.
 
 `AGENTSH_SHIM_FORCE=0` explicitly overrides `force=true` in the config, giving operators per-process control.
 

--- a/docs/superpowers/specs/2026-03-24-shim-conf-design.md
+++ b/docs/superpowers/specs/2026-03-24-shim-conf-design.md
@@ -1,0 +1,127 @@
+# Shim Configuration File (`/etc/agentsh/shim.conf`)
+
+## Problem
+
+The shell shim (`agentsh-shell-shim`) bypasses policy enforcement when stdin is not a TTY and `AGENTSH_SHIM_FORCE=1` is not set. This is correct for general use (preserves binary stdin/stdout for piped data), but breaks enforcement on platforms where:
+
+1. Commands are always non-interactive (no TTY)
+2. The platform spawns the shell without a way to inject env vars beforehand
+
+exe.dev is one such platform: `ssh exe.dev ssh vmname "command"` spawns a shell on the VM, but the env var is not in the shell's process environment. `/etc/environment`, `/etc/profile.d/`, and `.bashrc` do not help because the gateway's SSH does not source these for non-interactive commands.
+
+## Solution
+
+Add a config file that the shim reads at startup. The file is written during `agentsh shim install-shell --force` or by the operator manually. Unlike env vars or profile scripts, the shim reads the file directly — it works regardless of how the shell was spawned.
+
+## Design
+
+### Config file format
+
+Simple `key=value`, one per line. Blank lines and `#` comments allowed. No quoting, no sections, no nested values.
+
+```
+# /etc/agentsh/shim.conf
+# Written by: agentsh shim install-shell --force
+force=true
+```
+
+### Config path
+
+`/etc/agentsh/shim.conf` on both Linux and macOS. `/etc` exists on macOS, the config is system-level (not per-user), and using the same path keeps the code simple. `ShimConfPath(root)` is the single place to change this if a platform-specific path is ever needed.
+
+### Shared package: `internal/shim/conf.go`
+
+The config parser lives in `internal/shim/` so both the shim binary and the install command share the same logic.
+
+```go
+// ShimConfPath returns the config file path under root.
+func ShimConfPath(root string) string
+
+// ReadShimConf reads the config file at ShimConfPath(root).
+// Missing file returns empty conf, not error.
+func ReadShimConf(root string) ShimConf
+
+// WriteShimConf writes config to ShimConfPath(root).
+// Creates /etc/agentsh/ directory if needed. Atomic write.
+func WriteShimConf(root string, conf ShimConf) error
+
+// ShimConf is the parsed config.
+type ShimConf struct {
+    Force bool              // force=true|1
+    Raw   map[string]string // all key=value pairs for forward compat
+}
+```
+
+### Shim bypass logic (`cmd/agentsh-shell-shim/main.go`)
+
+Precedence: env var > config file > default (false).
+
+```go
+conf := shim.ReadShimConf("/")
+forceShim := strings.TrimSpace(os.Getenv("AGENTSH_SHIM_FORCE"))
+switch {
+case forceShim == "1":
+    // env says force
+case forceShim == "0":
+    // env says don't force — respect it, ignore config
+case conf.Force:
+    forceShim = "1"
+}
+if !term.IsTerminal(int(os.Stdin.Fd())) && forceShim != "1" {
+    // bypass as before
+}
+```
+
+`AGENTSH_SHIM_FORCE=0` explicitly overrides `force=true` in the config, giving operators per-process control.
+
+### Install command (`internal/cli/shim_cmd.go`)
+
+New `--force` flag on `install-shell`. When set, writes `shim.conf` with `force=true` after installing the shim binary:
+
+```
+agentsh shim install-shell --root / --shim /path/to/shim --bash --force --i-understand-this-modifies-the-host
+```
+
+Dry-run support: `--force --dry-run` includes a `write` action in the plan output for the config file, integrating with the existing `ShellShimPlan`/`ShellShimAction` system.
+
+Uninstall does not touch the config file. The file is inert without the shim and follows the Unix convention that `/etc` configs survive package removal.
+
+### Performance
+
+Reading a small file adds ~0.1ms. The shim already does `os.Getenv()`, `term.IsTerminal()` (ioctl), and `os.Stat()` for real shell detection. One more `os.ReadFile()` is negligible.
+
+## Files to modify
+
+1. `internal/shim/conf.go` (new) — `ShimConfPath`, `ReadShimConf`, `WriteShimConf`, `ShimConf`
+2. `internal/shim/conf_test.go` (new) — unit tests for config parsing and round-trip
+3. `cmd/agentsh-shell-shim/main.go` — read config, integrate into bypass logic
+4. `cmd/agentsh-shell-shim/main_test.go` — integration tests for config + env + TTY precedence
+5. `internal/cli/shim_cmd.go` — `--force` flag on `install-shell`, write config after install
+6. `internal/cli/shim_cmd_test.go` — CLI tests for `--force` and `--force --dry-run`
+
+## Test plan
+
+### Unit tests (`internal/shim/conf_test.go`)
+
+- `ReadShimConf` with missing file returns empty conf
+- `ReadShimConf` with `force=true` returns `Force: true`
+- `ReadShimConf` with `force=1` returns `Force: true`
+- `ReadShimConf` with `force=false` returns `Force: false`
+- `ReadShimConf` with malformed lines, comments, blank lines parses correctly
+- `WriteShimConf` creates directory and file atomically
+- `WriteShimConf` then `ReadShimConf` round-trip preserves values
+- `ShimConfPath` returns expected path for given root
+
+### Integration tests (`cmd/agentsh-shell-shim/main_test.go`)
+
+- No config, no env, no TTY → bypass (existing, unchanged)
+- No config, `AGENTSH_SHIM_FORCE=1`, no TTY → enforce (existing, unchanged)
+- Config `force=true`, no env, no TTY → enforce (new)
+- Config `force=true`, `AGENTSH_SHIM_FORCE=0`, no TTY → bypass (env overrides config)
+- Config `force=true`, TTY → enforce (TTY always enforces)
+
+### CLI tests (`internal/cli/shim_cmd_test.go`)
+
+- `install-shell --force` writes config file
+- `install-shell --force --dry-run` includes config write action in plan
+- `install-shell` without `--force` does not write config file

--- a/internal/cli/shim_cmd.go
+++ b/internal/cli/shim_cmd.go
@@ -29,6 +29,7 @@ func newShimInstallShellCmd() *cobra.Command {
 	var iUnderstand bool
 	var dryRun bool
 	var output string
+	var force bool
 
 	c := &cobra.Command{
 		Use:   "install-shell",
@@ -48,6 +49,7 @@ func newShimInstallShellCmd() *cobra.Command {
 				ShimPath:    shimPath,
 				InstallBash: bash || bashOnly,
 				BashOnly:    bashOnly,
+				Force:       force,
 			}
 			if dryRun {
 				p, err := shim.PlanInstallShellShim(opts)
@@ -68,6 +70,7 @@ func newShimInstallShellCmd() *cobra.Command {
 	c.Flags().BoolVar(&iUnderstand, "i-understand-this-modifies-the-host", false, "Allow modifying the host filesystem when --root=/")
 	c.Flags().BoolVar(&dryRun, "dry-run", false, "Show planned actions without modifying the filesystem")
 	c.Flags().StringVar(&output, "output", "shell", "Output format: shell|json")
+	c.Flags().BoolVar(&force, "force", false, "Write /etc/agentsh/shim.conf with force=true (enforces policy for non-interactive shells)")
 	return c
 }
 

--- a/internal/cli/shim_cmd_test.go
+++ b/internal/cli/shim_cmd_test.go
@@ -297,3 +297,51 @@ func TestShimInstallShell_ReinstallWithoutForceClearsConfig(t *testing.T) {
 		t.Fatalf("expected force=false in shim.conf, got %q", string(data))
 	}
 }
+
+func TestShimInstallShell_ForcePreservesExistingKeys(t *testing.T) {
+	tmp := t.TempDir()
+	rootfs := filepath.Join(tmp, "rootfs")
+	if err := os.MkdirAll(filepath.Join(rootfs, "bin"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfs, "bin", "sh"), []byte("REAL\n"), 0o755); err != nil {
+		t.Fatalf("write sh: %v", err)
+	}
+	shimPath := filepath.Join(tmp, "shim.bin")
+	if err := os.WriteFile(shimPath, []byte("SHIM\n"), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+
+	// Pre-write a config with an extra key.
+	confDir := filepath.Join(rootfs, "etc", "agentsh")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatalf("mkdir conf: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(confDir, "shim.conf"), []byte("# existing\ndebug=1\nforce=false\n"), 0o644); err != nil {
+		t.Fatalf("write existing conf: %v", err)
+	}
+
+	// Install with --force. Should set force=true but preserve debug=1.
+	root := NewRoot("test")
+	root.SetArgs([]string{
+		"shim", "install-shell",
+		"--root", rootfs,
+		"--shim", shimPath,
+		"--force",
+	})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	confPath := filepath.Join(confDir, "shim.conf")
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("read conf: %v", err)
+	}
+	if !strings.Contains(string(data), "force=true") {
+		t.Fatalf("expected force=true, got %q", string(data))
+	}
+	if !strings.Contains(string(data), "debug=1") {
+		t.Fatalf("expected debug=1 preserved, got %q", string(data))
+	}
+}

--- a/internal/cli/shim_cmd_test.go
+++ b/internal/cli/shim_cmd_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -134,5 +135,110 @@ func TestShimInstallShell_BashOnlyAndBash_MutuallyExclusive(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "mutually exclusive") {
 		t.Fatalf("expected mutually exclusive error, got %q", err.Error())
+	}
+}
+
+func TestShimInstallShell_ForceWritesConfig(t *testing.T) {
+	tmp := t.TempDir()
+	rootfs := filepath.Join(tmp, "rootfs")
+	if err := os.MkdirAll(filepath.Join(rootfs, "bin"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfs, "bin", "sh"), []byte("REAL\n"), 0o755); err != nil {
+		t.Fatalf("write sh: %v", err)
+	}
+	shimPath := filepath.Join(tmp, "shim.bin")
+	if err := os.WriteFile(shimPath, []byte("SHIM\n"), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+
+	root := NewRoot("test")
+	root.SetArgs([]string{
+		"shim", "install-shell",
+		"--root", rootfs,
+		"--shim", shimPath,
+		"--force",
+	})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	confPath := filepath.Join(rootfs, "etc", "agentsh", "shim.conf")
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("expected shim.conf to exist: %v", err)
+	}
+	if !strings.Contains(string(data), "force=true") {
+		t.Fatalf("expected force=true in shim.conf, got %q", string(data))
+	}
+}
+
+func TestShimInstallShell_NoForceNoConfig(t *testing.T) {
+	tmp := t.TempDir()
+	rootfs := filepath.Join(tmp, "rootfs")
+	if err := os.MkdirAll(filepath.Join(rootfs, "bin"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfs, "bin", "sh"), []byte("REAL\n"), 0o755); err != nil {
+		t.Fatalf("write sh: %v", err)
+	}
+	shimPath := filepath.Join(tmp, "shim.bin")
+	if err := os.WriteFile(shimPath, []byte("SHIM\n"), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+
+	root := NewRoot("test")
+	root.SetArgs([]string{
+		"shim", "install-shell",
+		"--root", rootfs,
+		"--shim", shimPath,
+	})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	confPath := filepath.Join(rootfs, "etc", "agentsh", "shim.conf")
+	if _, err := os.Stat(confPath); err == nil {
+		t.Fatalf("expected shim.conf NOT to exist without --force")
+	}
+}
+
+func TestShimInstallShell_ForceDryRun(t *testing.T) {
+	tmp := t.TempDir()
+	rootfs := filepath.Join(tmp, "rootfs")
+	if err := os.MkdirAll(filepath.Join(rootfs, "bin"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfs, "bin", "sh"), []byte("REAL\n"), 0o755); err != nil {
+		t.Fatalf("write sh: %v", err)
+	}
+	shimPath := filepath.Join(tmp, "shim.bin")
+	if err := os.WriteFile(shimPath, []byte("SHIM\n"), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+
+	root := NewRoot("test")
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetArgs([]string{
+		"shim", "install-shell",
+		"--root", rootfs,
+		"--shim", shimPath,
+		"--force",
+		"--dry-run",
+	})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+
+	// Dry run should NOT write the file.
+	confPath := filepath.Join(rootfs, "etc", "agentsh", "shim.conf")
+	if _, err := os.Stat(confPath); err == nil {
+		t.Fatalf("dry-run should NOT write shim.conf")
+	}
+
+	// Dry run output should mention the config file path.
+	if !strings.Contains(stdout.String(), "shim.conf") {
+		t.Fatalf("expected dry-run output to mention shim.conf, got %q", stdout.String())
 	}
 }

--- a/internal/cli/shim_cmd_test.go
+++ b/internal/cli/shim_cmd_test.go
@@ -242,3 +242,58 @@ func TestShimInstallShell_ForceDryRun(t *testing.T) {
 		t.Fatalf("expected dry-run output to mention shim.conf, got %q", stdout.String())
 	}
 }
+
+func TestShimInstallShell_ReinstallWithoutForceClearsConfig(t *testing.T) {
+	tmp := t.TempDir()
+	rootfs := filepath.Join(tmp, "rootfs")
+	if err := os.MkdirAll(filepath.Join(rootfs, "bin"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rootfs, "bin", "sh"), []byte("REAL\n"), 0o755); err != nil {
+		t.Fatalf("write sh: %v", err)
+	}
+	shimPath := filepath.Join(tmp, "shim.bin")
+	if err := os.WriteFile(shimPath, []byte("SHIM\n"), 0o755); err != nil {
+		t.Fatalf("write shim: %v", err)
+	}
+
+	// First install with --force.
+	root := NewRoot("test")
+	root.SetArgs([]string{
+		"shim", "install-shell",
+		"--root", rootfs,
+		"--shim", shimPath,
+		"--force",
+	})
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	confPath := filepath.Join(rootfs, "etc", "agentsh", "shim.conf")
+	data, _ := os.ReadFile(confPath)
+	if !strings.Contains(string(data), "force=true") {
+		t.Fatalf("expected force=true after --force install, got %q", string(data))
+	}
+
+	// Reinstall WITHOUT --force. Should clear force=true.
+	root2 := NewRoot("test")
+	root2.SetArgs([]string{
+		"shim", "install-shell",
+		"--root", rootfs,
+		"--shim", shimPath,
+	})
+	if err := root2.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatalf("expected shim.conf to still exist: %v", err)
+	}
+	if strings.Contains(string(data), "force=true") {
+		t.Fatalf("expected force=true to be cleared after reinstall without --force, got %q", string(data))
+	}
+	if !strings.Contains(string(data), "force=false") {
+		t.Fatalf("expected force=false in shim.conf, got %q", string(data))
+	}
+}

--- a/internal/shim/conf.go
+++ b/internal/shim/conf.go
@@ -46,6 +46,16 @@ func ReadShimConf(root string) (ShimConf, error) {
 		conf.Raw[strings.TrimSpace(k)] = strings.TrimSpace(v)
 	}
 	conf.Force = conf.Raw["force"] == "true" || conf.Raw["force"] == "1"
+	// Strict validation: if "force" key is present but not a recognized value,
+	// return an error to prevent silent fail-open from typos like "force=tru".
+	if v, ok := conf.Raw["force"]; ok {
+		switch v {
+		case "true", "1", "false", "0":
+			// valid
+		default:
+			return conf, fmt.Errorf("shim.conf: invalid force value %q (expected true, 1, false, or 0)", v)
+		}
+	}
 	return conf, nil
 }
 

--- a/internal/shim/conf.go
+++ b/internal/shim/conf.go
@@ -1,0 +1,68 @@
+package shim
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ShimConf is the parsed shim configuration.
+type ShimConf struct {
+	Force bool              // force=true|1
+	Raw   map[string]string // all key=value pairs for forward compat
+}
+
+// ShimConfPath returns the config file path under root.
+func ShimConfPath(root string) string {
+	if root == "" {
+		root = "/"
+	}
+	return filepath.Join(root, "etc", "agentsh", "shim.conf")
+}
+
+// ReadShimConf reads the config file at ShimConfPath(root).
+// Missing file (ENOENT) returns empty conf with nil error.
+// Other read errors return empty conf and the error.
+func ReadShimConf(root string) (ShimConf, error) {
+	conf := ShimConf{Raw: make(map[string]string)}
+	data, err := os.ReadFile(ShimConfPath(root))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return conf, nil
+		}
+		return conf, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		k, v, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		conf.Raw[strings.TrimSpace(k)] = strings.TrimSpace(v)
+	}
+	conf.Force = conf.Raw["force"] == "true" || conf.Raw["force"] == "1"
+	return conf, nil
+}
+
+// WriteShimConf writes all keys from conf.Raw as key=value lines.
+// Creates /etc/agentsh/ directory (mode 0o755) if needed.
+// File is written atomically with mode 0o644.
+func WriteShimConf(root string, conf ShimConf) error {
+	keys := make([]string, 0, len(conf.Raw))
+	for k := range conf.Raw {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var buf strings.Builder
+	buf.WriteString("# Written by: agentsh shim install-shell\n")
+	for _, k := range keys {
+		fmt.Fprintf(&buf, "%s=%s\n", k, conf.Raw[k])
+	}
+	return writeFileAtomic(ShimConfPath(root), []byte(buf.String()), 0o644)
+}

--- a/internal/shim/conf_test.go
+++ b/internal/shim/conf_test.go
@@ -1,0 +1,206 @@
+package shim
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestShimConfPath(t *testing.T) {
+	tests := []struct {
+		root string
+		want string
+	}{
+		{"/", "/etc/agentsh/shim.conf"},
+		{"/rootfs", "/rootfs/etc/agentsh/shim.conf"},
+		{"", "/etc/agentsh/shim.conf"},
+	}
+	for _, tt := range tests {
+		got := ShimConfPath(tt.root)
+		if got != tt.want {
+			t.Errorf("ShimConfPath(%q) = %q, want %q", tt.root, got, tt.want)
+		}
+	}
+}
+
+func TestReadShimConf_MissingFile(t *testing.T) {
+	root := t.TempDir()
+	conf, err := ReadShimConf(root)
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got %v", err)
+	}
+	if conf.Force {
+		t.Fatalf("expected Force=false for missing file")
+	}
+}
+
+func TestReadShimConf_ForceTrue(t *testing.T) {
+	root := t.TempDir()
+	writeTestConf(t, root, "force=true\n")
+	conf, err := ReadShimConf(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !conf.Force {
+		t.Fatalf("expected Force=true")
+	}
+}
+
+func TestReadShimConf_ForceOne(t *testing.T) {
+	root := t.TempDir()
+	writeTestConf(t, root, "force=1\n")
+	conf, err := ReadShimConf(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !conf.Force {
+		t.Fatalf("expected Force=true for force=1")
+	}
+}
+
+func TestReadShimConf_ForceFalse(t *testing.T) {
+	root := t.TempDir()
+	writeTestConf(t, root, "force=false\n")
+	conf, err := ReadShimConf(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if conf.Force {
+		t.Fatalf("expected Force=false")
+	}
+}
+
+func TestReadShimConf_CommentsAndBlanks(t *testing.T) {
+	root := t.TempDir()
+	writeTestConf(t, root, "# comment\n\n  # indented comment\nforce = true\nextra=value\nmalformed line\n")
+	conf, err := ReadShimConf(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !conf.Force {
+		t.Fatalf("expected Force=true")
+	}
+	if conf.Raw["extra"] != "value" {
+		t.Fatalf("expected Raw[extra]=value, got %q", conf.Raw["extra"])
+	}
+	// malformed line (no =) should be ignored
+	if len(conf.Raw) != 2 {
+		t.Fatalf("expected 2 raw keys, got %d: %v", len(conf.Raw), conf.Raw)
+	}
+}
+
+func TestReadShimConf_Unreadable(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("test requires non-root")
+	}
+	root := t.TempDir()
+	confDir := filepath.Join(root, "etc", "agentsh")
+	if err := os.MkdirAll(confDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	confPath := filepath.Join(confDir, "shim.conf")
+	if err := os.WriteFile(confPath, []byte("force=true\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	conf, err := ReadShimConf(root)
+	if err == nil {
+		t.Fatalf("expected error for unreadable file")
+	}
+	if conf.Force {
+		t.Fatalf("expected Force=false on read error")
+	}
+	if len(conf.Raw) != 0 {
+		t.Fatalf("expected empty Raw on read error, got %v", conf.Raw)
+	}
+}
+
+func TestWriteShimConf_CreatesDirectoryAndFile(t *testing.T) {
+	root := t.TempDir()
+	conf := ShimConf{
+		Force: true,
+		Raw:   map[string]string{"force": "true"},
+	}
+	if err := WriteShimConf(root, conf); err != nil {
+		t.Fatalf("WriteShimConf: %v", err)
+	}
+
+	// Check directory permissions.
+	dirInfo, err := os.Stat(filepath.Join(root, "etc", "agentsh"))
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if perm := dirInfo.Mode().Perm(); perm != 0o755 {
+		t.Fatalf("expected dir perm 0o755, got %o", perm)
+	}
+
+	// Check file permissions.
+	fileInfo, err := os.Stat(ShimConfPath(root))
+	if err != nil {
+		t.Fatalf("stat file: %v", err)
+	}
+	if perm := fileInfo.Mode().Perm(); perm != 0o644 {
+		t.Fatalf("expected file perm 0o644, got %o", perm)
+	}
+
+	// Check content contains force=true.
+	data, err := os.ReadFile(ShimConfPath(root))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), "force=true") {
+		t.Fatalf("expected force=true in content, got %q", string(data))
+	}
+
+	// Check header comment.
+	if !strings.Contains(string(data), "# Written by: agentsh shim install-shell") {
+		t.Fatalf("expected header in content, got %q", string(data))
+	}
+}
+
+func TestWriteShimConf_RoundTrip(t *testing.T) {
+	root := t.TempDir()
+	original := ShimConf{
+		Force: true,
+		Raw:   map[string]string{"force": "true", "debug": "1"},
+	}
+	if err := WriteShimConf(root, original); err != nil {
+		t.Fatalf("WriteShimConf: %v", err)
+	}
+	got, err := ReadShimConf(root)
+	if err != nil {
+		t.Fatalf("ReadShimConf: %v", err)
+	}
+	if !got.Force {
+		t.Fatalf("expected Force=true after round-trip")
+	}
+	if got.Raw["debug"] != "1" {
+		t.Fatalf("expected Raw[debug]=1, got %q", got.Raw["debug"])
+	}
+
+	// Check that keys are written in alphabetical order (debug before force).
+	raw, err := os.ReadFile(ShimConfPath(root))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	debugIdx := strings.Index(string(raw), "debug=")
+	forceIdx := strings.Index(string(raw), "force=")
+	if debugIdx < 0 || forceIdx < 0 {
+		t.Fatalf("expected both debug= and force= in file, got %q", string(raw))
+	}
+	if debugIdx > forceIdx {
+		t.Fatalf("expected debug= before force= (alphabetical order), got:\n%s", string(raw))
+	}
+}
+
+// writeTestConf writes content to {root}/etc/agentsh/shim.conf.
+func writeTestConf(t *testing.T, root, content string) {
+	t.Helper()
+	dir := filepath.Join(root, "etc", "agentsh")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "shim.conf"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/shim/conf_test.go
+++ b/internal/shim/conf_test.go
@@ -3,6 +3,7 @@ package shim
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -12,9 +13,9 @@ func TestShimConfPath(t *testing.T) {
 		root string
 		want string
 	}{
-		{"/", "/etc/agentsh/shim.conf"},
-		{"/rootfs", "/rootfs/etc/agentsh/shim.conf"},
-		{"", "/etc/agentsh/shim.conf"},
+		{"/", filepath.Join("/", "etc", "agentsh", "shim.conf")},
+		{"/rootfs", filepath.Join("/rootfs", "etc", "agentsh", "shim.conf")},
+		{"", filepath.Join("/", "etc", "agentsh", "shim.conf")},
 	}
 	for _, tt := range tests {
 		got := ShimConfPath(tt.root)
@@ -106,6 +107,9 @@ func TestReadShimConf_InvalidForceValue(t *testing.T) {
 }
 
 func TestReadShimConf_Unreadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix permission semantics required")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("test requires non-root")
 	}
@@ -140,22 +144,24 @@ func TestWriteShimConf_CreatesDirectoryAndFile(t *testing.T) {
 		t.Fatalf("WriteShimConf: %v", err)
 	}
 
-	// Check directory permissions.
-	dirInfo, err := os.Stat(filepath.Join(root, "etc", "agentsh"))
-	if err != nil {
-		t.Fatalf("stat dir: %v", err)
-	}
-	if perm := dirInfo.Mode().Perm(); perm != 0o755 {
-		t.Fatalf("expected dir perm 0o755, got %o", perm)
-	}
+	// Check directory permissions (Unix only — Windows doesn't use POSIX modes).
+	if runtime.GOOS != "windows" {
+		dirInfo, err := os.Stat(filepath.Join(root, "etc", "agentsh"))
+		if err != nil {
+			t.Fatalf("stat dir: %v", err)
+		}
+		if perm := dirInfo.Mode().Perm(); perm != 0o755 {
+			t.Fatalf("expected dir perm 0o755, got %o", perm)
+		}
 
-	// Check file permissions.
-	fileInfo, err := os.Stat(ShimConfPath(root))
-	if err != nil {
-		t.Fatalf("stat file: %v", err)
-	}
-	if perm := fileInfo.Mode().Perm(); perm != 0o644 {
-		t.Fatalf("expected file perm 0o644, got %o", perm)
+		// Check file permissions.
+		fileInfo, err := os.Stat(ShimConfPath(root))
+		if err != nil {
+			t.Fatalf("stat file: %v", err)
+		}
+		if perm := fileInfo.Mode().Perm(); perm != 0o644 {
+			t.Fatalf("expected file perm 0o644, got %o", perm)
+		}
 	}
 
 	// Check content contains force=true.

--- a/internal/shim/conf_test.go
+++ b/internal/shim/conf_test.go
@@ -90,6 +90,21 @@ func TestReadShimConf_CommentsAndBlanks(t *testing.T) {
 	}
 }
 
+func TestReadShimConf_InvalidForceValue(t *testing.T) {
+	root := t.TempDir()
+	writeTestConf(t, root, "force=tru\n")
+	conf, err := ReadShimConf(root)
+	if err == nil {
+		t.Fatalf("expected error for invalid force value 'tru'")
+	}
+	if conf.Force {
+		t.Fatalf("expected Force=false on invalid value")
+	}
+	if !strings.Contains(err.Error(), "invalid force value") {
+		t.Fatalf("expected 'invalid force value' in error, got %q", err.Error())
+	}
+}
+
 func TestReadShimConf_Unreadable(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("test requires non-root")

--- a/internal/shim/install.go
+++ b/internal/shim/install.go
@@ -24,6 +24,9 @@ type InstallShellShimOptions struct {
 	// through it (e.g., docker exec -i container sh -c "cat > /file").
 	// When set, InstallBash must also be true.
 	BashOnly bool
+
+	// Force writes /etc/agentsh/shim.conf with force=true after installing.
+	Force bool
 }
 
 // InstallShellShim installs the agentsh shell shim as /bin/sh (and optionally /bin/bash)
@@ -51,6 +54,15 @@ func InstallShellShim(opts InstallShellShimOptions) error {
 	if opts.InstallBash {
 		if err := installOne(root, "bash", shimBytes); err != nil {
 			return err
+		}
+	}
+	if opts.Force {
+		conf := ShimConf{
+			Force: true,
+			Raw:   map[string]string{"force": "true"},
+		}
+		if err := WriteShimConf(root, conf); err != nil {
+			return fmt.Errorf("write shim.conf: %w", err)
 		}
 	}
 	return nil

--- a/internal/shim/install.go
+++ b/internal/shim/install.go
@@ -55,13 +55,24 @@ func InstallShellShim(opts InstallShellShimOptions) error {
 		return fmt.Errorf("read shim.conf: %w", confReadErr)
 	}
 
-	// When --force is set, preflight that we can write the config directory
-	// before mutating shell binaries, to avoid partial state.
-	if opts.Force {
-		confDir := filepath.Dir(ShimConfPath(root))
+	// Preflight config writability before mutating shell binaries to avoid
+	// partial state. Applies to both --force (writing force=true) and
+	// non-force (may need to clear stale force=true).
+	confPath := ShimConfPath(root)
+	confDir := filepath.Dir(confPath)
+	needsConfigWrite := opts.Force ||
+		existingConf.Raw["force"] == "true" || existingConf.Raw["force"] == "1"
+	if needsConfigWrite {
 		if err := os.MkdirAll(confDir, 0o755); err != nil {
 			return fmt.Errorf("preflight shim.conf dir: %w", err)
 		}
+		// Verify actual write capability with a temp file.
+		tmp, err := os.CreateTemp(confDir, ".shim.conf.preflight-*")
+		if err != nil {
+			return fmt.Errorf("preflight shim.conf write: %w", err)
+		}
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
 	}
 
 	if !opts.BashOnly {

--- a/internal/shim/install.go
+++ b/internal/shim/install.go
@@ -67,7 +67,12 @@ func InstallShellShim(opts InstallShellShimOptions) error {
 	} else {
 		// Clear stale force=true from a prior --force install so the current
 		// flags always define the current state.
-		existing, _ := ReadShimConf(root)
+		existing, readErr := ReadShimConf(root)
+		if readErr != nil {
+			// Config exists but is unreadable — surface the error so the
+			// operator fixes permissions before reinstalling.
+			return fmt.Errorf("read shim.conf: %w", readErr)
+		}
 		if existing.Raw["force"] == "true" || existing.Raw["force"] == "1" {
 			existing.Raw["force"] = "false"
 			existing.Force = false

--- a/internal/shim/install.go
+++ b/internal/shim/install.go
@@ -64,6 +64,17 @@ func InstallShellShim(opts InstallShellShimOptions) error {
 		if err := WriteShimConf(root, conf); err != nil {
 			return fmt.Errorf("write shim.conf: %w", err)
 		}
+	} else {
+		// Clear stale force=true from a prior --force install so the current
+		// flags always define the current state.
+		existing, _ := ReadShimConf(root)
+		if existing.Raw["force"] == "true" || existing.Raw["force"] == "1" {
+			existing.Raw["force"] = "false"
+			existing.Force = false
+			if err := WriteShimConf(root, existing); err != nil {
+				return fmt.Errorf("clear shim.conf force: %w", err)
+			}
+		}
 	}
 	return nil
 }

--- a/internal/shim/install.go
+++ b/internal/shim/install.go
@@ -87,9 +87,10 @@ func InstallShellShim(opts InstallShellShimOptions) error {
 	}
 	if opts.Force {
 		// Merge with existing config to preserve unknown keys (forward compat).
-		if confReadErr != nil {
-			// Can't read existing — start fresh.
-			existingConf = ShimConf{Raw: make(map[string]string)}
+		// ReadShimConf returns partially parsed Raw even on validation errors,
+		// so we preserve those keys. Only on true I/O failure is Raw empty.
+		if existingConf.Raw == nil {
+			existingConf.Raw = make(map[string]string)
 		}
 		existingConf.Raw["force"] = "true"
 		existingConf.Force = true

--- a/internal/shim/install.go
+++ b/internal/shim/install.go
@@ -55,6 +55,15 @@ func InstallShellShim(opts InstallShellShimOptions) error {
 		return fmt.Errorf("read shim.conf: %w", confReadErr)
 	}
 
+	// When --force is set, preflight that we can write the config directory
+	// before mutating shell binaries, to avoid partial state.
+	if opts.Force {
+		confDir := filepath.Dir(ShimConfPath(root))
+		if err := os.MkdirAll(confDir, 0o755); err != nil {
+			return fmt.Errorf("preflight shim.conf dir: %w", err)
+		}
+	}
+
 	if !opts.BashOnly {
 		if err := installOne(root, "sh", shimBytes); err != nil {
 			return err

--- a/internal/shim/install.go
+++ b/internal/shim/install.go
@@ -46,6 +46,15 @@ func InstallShellShim(opts InstallShellShimOptions) error {
 		return fmt.Errorf("read shim: %w", err)
 	}
 
+	// Pre-validate config before mutating shell binaries to avoid partial state.
+	// ReadShimConf returns nil error for missing file (ENOENT).
+	existingConf, confReadErr := ReadShimConf(root)
+	if confReadErr != nil && !opts.Force {
+		// Config exists but is unreadable — surface the error before touching
+		// any files so the operator fixes permissions first.
+		return fmt.Errorf("read shim.conf: %w", confReadErr)
+	}
+
 	if !opts.BashOnly {
 		if err := installOne(root, "sh", shimBytes); err != nil {
 			return err
@@ -57,28 +66,23 @@ func InstallShellShim(opts InstallShellShimOptions) error {
 		}
 	}
 	if opts.Force {
-		conf := ShimConf{
-			Force: true,
-			Raw:   map[string]string{"force": "true"},
+		// Merge with existing config to preserve unknown keys (forward compat).
+		if confReadErr != nil {
+			// Can't read existing — start fresh.
+			existingConf = ShimConf{Raw: make(map[string]string)}
 		}
-		if err := WriteShimConf(root, conf); err != nil {
+		existingConf.Raw["force"] = "true"
+		existingConf.Force = true
+		if err := WriteShimConf(root, existingConf); err != nil {
 			return fmt.Errorf("write shim.conf: %w", err)
 		}
-	} else {
+	} else if existingConf.Raw["force"] == "true" || existingConf.Raw["force"] == "1" {
 		// Clear stale force=true from a prior --force install so the current
 		// flags always define the current state.
-		existing, readErr := ReadShimConf(root)
-		if readErr != nil {
-			// Config exists but is unreadable — surface the error so the
-			// operator fixes permissions before reinstalling.
-			return fmt.Errorf("read shim.conf: %w", readErr)
-		}
-		if existing.Raw["force"] == "true" || existing.Raw["force"] == "1" {
-			existing.Raw["force"] = "false"
-			existing.Force = false
-			if err := WriteShimConf(root, existing); err != nil {
-				return fmt.Errorf("clear shim.conf force: %w", err)
-			}
+		existingConf.Raw["force"] = "false"
+		existingConf.Force = false
+		if err := WriteShimConf(root, existingConf); err != nil {
+			return fmt.Errorf("clear shim.conf force: %w", err)
 		}
 	}
 	return nil

--- a/internal/shim/shell_shim_plan.go
+++ b/internal/shim/shell_shim_plan.go
@@ -44,7 +44,7 @@ func PlanInstallShellShim(opts InstallShellShimOptions) (*ShellShimPlan, error) 
 		actions = append(actions, ShellShimAction{
 			Op:   "write",
 			Path: ShimConfPath(root),
-			Note: "write shim.conf with force=true",
+			Note: "set force=true in shim.conf (preserves existing keys)",
 		})
 	} else {
 		existing, readErr := ReadShimConf(root)

--- a/internal/shim/shell_shim_plan.go
+++ b/internal/shim/shell_shim_plan.go
@@ -49,12 +49,9 @@ func PlanInstallShellShim(opts InstallShellShimOptions) (*ShellShimPlan, error) 
 	} else {
 		existing, readErr := ReadShimConf(root)
 		if readErr != nil {
-			actions = append(actions, ShellShimAction{
-				Op:   "note",
-				Path: ShimConfPath(root),
-				Note: fmt.Sprintf("cannot read shim.conf: %v", readErr),
-			})
-		} else if existing.Raw["force"] == "true" || existing.Raw["force"] == "1" {
+			return nil, fmt.Errorf("read shim.conf: %w", readErr)
+		}
+		if existing.Raw["force"] == "true" || existing.Raw["force"] == "1" {
 			actions = append(actions, ShellShimAction{
 				Op:   "write",
 				Path: ShimConfPath(root),

--- a/internal/shim/shell_shim_plan.go
+++ b/internal/shim/shell_shim_plan.go
@@ -40,6 +40,13 @@ func PlanInstallShellShim(opts InstallShellShimOptions) (*ShellShimPlan, error) 
 	if opts.InstallBash {
 		actions = append(actions, planInstallOne(root, "bash", shimBytes)...)
 	}
+	if opts.Force {
+		actions = append(actions, ShellShimAction{
+			Op:   "write",
+			Path: ShimConfPath(root),
+			Note: "write shim.conf with force=true",
+		})
+	}
 	return &ShellShimPlan{Root: root, Shim: opts.ShimPath, Actions: actions}, nil
 }
 

--- a/internal/shim/shell_shim_plan.go
+++ b/internal/shim/shell_shim_plan.go
@@ -46,6 +46,15 @@ func PlanInstallShellShim(opts InstallShellShimOptions) (*ShellShimPlan, error) 
 			Path: ShimConfPath(root),
 			Note: "write shim.conf with force=true",
 		})
+	} else {
+		existing, _ := ReadShimConf(root)
+		if existing.Raw["force"] == "true" || existing.Raw["force"] == "1" {
+			actions = append(actions, ShellShimAction{
+				Op:   "write",
+				Path: ShimConfPath(root),
+				Note: "clear force=true from shim.conf",
+			})
+		}
 	}
 	return &ShellShimPlan{Root: root, Shim: opts.ShimPath, Actions: actions}, nil
 }

--- a/internal/shim/shell_shim_plan.go
+++ b/internal/shim/shell_shim_plan.go
@@ -47,8 +47,14 @@ func PlanInstallShellShim(opts InstallShellShimOptions) (*ShellShimPlan, error) 
 			Note: "write shim.conf with force=true",
 		})
 	} else {
-		existing, _ := ReadShimConf(root)
-		if existing.Raw["force"] == "true" || existing.Raw["force"] == "1" {
+		existing, readErr := ReadShimConf(root)
+		if readErr != nil {
+			actions = append(actions, ShellShimAction{
+				Op:   "note",
+				Path: ShimConfPath(root),
+				Note: fmt.Sprintf("cannot read shim.conf: %v", readErr),
+			})
+		} else if existing.Raw["force"] == "true" || existing.Raw["force"] == "1" {
 			actions = append(actions, ShellShimAction{
 				Op:   "write",
 				Path: ShimConfPath(root),


### PR DESCRIPTION
## Summary

- Add `/etc/agentsh/shim.conf` support so the shell shim can read configuration at startup without relying on environment variables
- Add `--force` flag to `agentsh shim install-shell` that writes `force=true` to the config
- The shim reads the config file on every invocation, enabling policy enforcement on platforms where env vars cannot be injected (e.g., exe.dev, sandbox APIs)

## Key design decisions

- **Fail-closed**: unreadable config file assumes `force=true` (over-enforce, never silently bypass)
- **No runtime bypass**: `AGENTSH_SHIM_FORCE=0` cannot disable config-based enforcement; env can only add enforcement (`FORCE=1`)
- **Config root override** is build-tag-gated (`-tags shimtest`) — production binaries always read from `/etc/agentsh/shim.conf`
- **Strict validation**: typos like `force=tru` return errors instead of silently treating as `false`
- **Key preservation**: `--force` merges into existing config, preserving unknown keys for forward compat
- **Stale cleanup**: reinstall without `--force` clears prior `force=true`
- **Preflight**: config writability verified before mutating shell binaries

## Files

| File | Change |
|------|--------|
| `internal/shim/conf.go` | New — config parser + writer |
| `internal/shim/conf_test.go` | New — 10 unit tests |
| `cmd/agentsh-shell-shim/main.go` | Read config in bypass logic |
| `cmd/agentsh-shell-shim/confroot.go` | New — production config root (`/`) |
| `cmd/agentsh-shell-shim/confroot_shimtest.go` | New — test-only config root override |
| `cmd/agentsh-shell-shim/main_test.go` | 3 integration tests |
| `internal/cli/shim_cmd.go` | `--force` flag |
| `internal/cli/shim_cmd_test.go` | 4 CLI tests |
| `internal/shim/install.go` | Write/clear config on install |
| `internal/shim/shell_shim_plan.go` | Dry-run plan actions |
| `README.md` | Non-interactive enforcement docs |
| `docs/cicd-integration.md` | CI/CD enforcement guidance |
| `docs/ci-and-releases.md` | Package deployment note |

## Test plan

- `go test ./...` — all pass
- `GOOS=windows go build ./...` — clean
- `GOOS=darwin go build ./...` — clean
- roborev: passed with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)