### PR TITLE
fix: ptrace+seccomp deadlock in hybrid mode (#161)

### DIFF
--- a/cmd/agentsh-unixwrap/ack_test.go
+++ b/cmd/agentsh-unixwrap/ack_test.go
@@ -68,3 +68,98 @@ func TestWaitForACK_EINTRRetry(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int32(2), calls.Load(), "should have retried once after EINTR")
 }
+
+// --- READY/GO handshake tests ---
+
+func TestPtraceSync_ReadyGoSuccess(t *testing.T) {
+	// Simulate a successful READY/GO handshake over a socketpair.
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	require.NoError(t, err)
+	defer unix.Close(fds[0]) // wrapper side
+	defer unix.Close(fds[1]) // server side
+
+	// Wrapper sends READY byte.
+	_, err = unix.Write(fds[0], []byte{'R'})
+	require.NoError(t, err)
+
+	// Server reads and validates READY.
+	buf := make([]byte, 1)
+	n, err := unix.Read(fds[1], buf)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	assert.Equal(t, byte('R'), buf[0])
+
+	// Server sends GO byte.
+	_, err = unix.Write(fds[1], []byte{'G'})
+	require.NoError(t, err)
+
+	// Wrapper reads and validates GO.
+	goBuf := make([]byte, 1)
+	err = waitForACK(func(b []byte) (int, error) {
+		n, err := unix.Read(fds[0], b)
+		if n == 1 {
+			goBuf[0] = b[0]
+		}
+		return n, err
+	})
+	assert.NoError(t, err)
+	assert.Equal(t, byte('G'), goBuf[0])
+}
+
+func TestPtraceSync_InvalidReadyByte(t *testing.T) {
+	// If wrapper sends wrong READY byte, server should detect it.
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	require.NoError(t, err)
+	defer unix.Close(fds[0])
+	defer unix.Close(fds[1])
+
+	// Wrapper sends wrong byte.
+	_, err = unix.Write(fds[0], []byte{'X'})
+	require.NoError(t, err)
+
+	// Server reads — byte doesn't match 'R'.
+	buf := make([]byte, 1)
+	n, err := unix.Read(fds[1], buf)
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	assert.NotEqual(t, byte('R'), buf[0], "should detect invalid READY byte")
+}
+
+func TestPtraceSync_InvalidGoByte(t *testing.T) {
+	// If server sends wrong GO byte, wrapper should detect it.
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	require.NoError(t, err)
+	defer unix.Close(fds[0])
+	defer unix.Close(fds[1])
+
+	// Server sends wrong byte.
+	_, err = unix.Write(fds[1], []byte{'X'})
+	require.NoError(t, err)
+
+	// Wrapper reads GO byte.
+	goBuf := make([]byte, 1)
+	err = waitForACK(func(b []byte) (int, error) {
+		n, err := unix.Read(fds[0], b)
+		if n == 1 {
+			goBuf[0] = b[0]
+		}
+		return n, err
+	})
+	assert.NoError(t, err, "waitForACK succeeds (reads 1 byte)")
+	assert.NotEqual(t, byte('G'), goBuf[0], "should detect invalid GO byte")
+}
+
+func TestPtraceSync_GoTimeout(t *testing.T) {
+	// If GO byte never arrives and socket has a timeout, read should fail.
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	require.NoError(t, err)
+	defer unix.Close(fds[0])
+	defer unix.Close(fds[1])
+
+	// Set a very short timeout (10ms) on the wrapper side.
+	_ = unix.SetsockoptTimeval(fds[0], unix.SOL_SOCKET, unix.SO_RCVTIMEO, &unix.Timeval{Usec: 10000})
+
+	err = waitForACK(fdReader(fds[0]))
+	assert.Error(t, err, "should timeout when GO byte never arrives")
+}
+

--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -87,9 +87,6 @@ func main() {
 		}
 	}
 
-	// Close notify socket - we're done with it
-	_ = unix.Close(sockFD)
-
 	// Install signal filter if enabled and we have a signal socket
 	sigSockFD, _ := signalSockFD()
 	if cfg.SignalFilterEnabled && sigSockFD >= 0 {
@@ -110,12 +107,28 @@ func main() {
 	}
 
 	// Apply Landlock filesystem restrictions before exec.
-	// Landlock enforces kernel-level filesystem access control that works even for root.
 	if cfg.LandlockEnabled && cfg.LandlockABI > 0 {
 		if err := applyLandlock(cfg); err != nil {
 			log.Printf("landlock: %v (continuing without)", err)
 		}
 	}
+
+	// Ptrace sync handshake: when the server will attach ptrace after our
+	// seccomp setup, we signal READY and wait for GO before exec. This
+	// prevents ptrace from interfering with seccomp filter installation.
+	// Only runs when notifFD >= 0 (seccomp is active) and AGENTSH_PTRACE_SYNC=1.
+	if notifFD >= 0 && os.Getenv("AGENTSH_PTRACE_SYNC") == "1" {
+		if _, err := unix.Write(sockFD, []byte{'R'}); err != nil {
+			log.Fatalf("send READY byte: %v", err)
+		}
+		// Wait for GO byte, retrying on EINTR.
+		if err := waitForACK(func(b []byte) (int, error) { return unix.Read(sockFD, b) }); err != nil {
+			log.Fatalf("wait for GO byte: %v", err)
+		}
+	}
+
+	// Close notify socket - done with all handshakes
+	_ = unix.Close(sockFD)
 
 	// Exec the real command.
 	cmd := os.Args[2]

--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -121,9 +121,19 @@ func main() {
 		if _, err := unix.Write(sockFD, []byte{'R'}); err != nil {
 			log.Fatalf("send READY byte: %v", err)
 		}
-		// Wait for GO byte, retrying on EINTR.
-		if err := waitForACK(func(b []byte) (int, error) { return unix.Read(sockFD, b) }); err != nil {
+		// Wait for GO byte, retrying on EINTR. Validate the byte value.
+		goBuf := make([]byte, 1)
+		if err := waitForACK(func(b []byte) (int, error) {
+			n, err := unix.Read(sockFD, b)
+			if n == 1 {
+				goBuf[0] = b[0]
+			}
+			return n, err
+		}); err != nil {
 			log.Fatalf("wait for GO byte: %v", err)
+		}
+		if goBuf[0] != 'G' {
+			log.Fatalf("unexpected GO byte: got 0x%02x, expected 'G'", goBuf[0])
 		}
 	}
 

--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -121,6 +121,8 @@ func main() {
 		if _, err := unix.Write(sockFD, []byte{'R'}); err != nil {
 			log.Fatalf("send READY byte: %v", err)
 		}
+		// Set 30s receive timeout to prevent hanging if server crashes.
+		_ = unix.SetsockoptTimeval(sockFD, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &unix.Timeval{Sec: 30})
 		// Wait for GO byte, retrying on EINTR. Validate the byte value.
 		goBuf := make([]byte, 1)
 		if err := waitForACK(func(b []byte) (int, error) {
@@ -130,7 +132,7 @@ func main() {
 			}
 			return n, err
 		}); err != nil {
-			log.Fatalf("wait for GO byte: %v", err)
+			log.Fatalf("wait for GO byte (30s timeout): %v", err)
 		}
 		if goBuf[0] != 'G' {
 			log.Fatalf("unexpected GO byte: got 0x%02x, expected 'G'", goBuf[0])

--- a/docs/superpowers/plans/2026-03-24-ptrace-seccomp-deadlock.md
+++ b/docs/superpowers/plans/2026-03-24-ptrace-seccomp-deadlock.md
@@ -1,0 +1,422 @@
+# Ptrace + Seccomp Deadlock Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the immediate deadlock when both ptrace and seccomp file_monitor are enabled in hybrid mode by delaying ptrace attachment until after the wrapper completes seccomp setup.
+
+**Architecture:** Add a READY/GO handshake to the wrapper-server protocol. The wrapper sends READY after all initialization (seccomp, signal filter, Landlock). The server attaches ptrace, then sends GO. The wrapper exec's only after receiving GO. This separates seccomp setup (untraced) from command execution (ptrace-traced).
+
+**Tech Stack:** Go stdlib (unix sockets, ptrace). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-03-24-ptrace-seccomp-deadlock-design.md`
+
+**Task dependencies:** Tasks 1, 2, 3 are independent and can be done in any order. Task 4 depends on all three. Task 5 depends on Task 4.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `cmd/agentsh-unixwrap/main.go` | Modify | Add READY/GO handshake when `AGENTSH_PTRACE_SYNC=1` |
+| `internal/api/core.go` | Modify | Set `AGENTSH_PTRACE_SYNC=1` in wrapper env when ptrace is active |
+| `internal/api/notify_linux.go` | Modify | Read READY byte after ACK, signal `ptraceReady` channel |
+| `internal/api/notify_stub.go` | Modify | Update signature to match `notify_linux.go` (cross-compile) |
+| `internal/api/exec.go` | Modify | Reorder hybrid mode + update `startWrapperHandlers` signature |
+| `internal/api/exec_stream.go` | Modify | Same reordering as exec.go (parallel hybrid mode block) |
+
+---
+
+### Task 1: Wrapper READY/GO handshake
+
+**Files:**
+- Modify: `cmd/agentsh-unixwrap/main.go:77-118`
+
+- [ ] **Step 1: Add READY/GO handshake and move socket close**
+
+Replace lines 88-118 in `cmd/agentsh-unixwrap/main.go` (from the `}` closing the `if notifFD >= 0` block through the end of Landlock setup). The current code closes `sockFD` at line 91 before signal filter and Landlock. The new code moves the close to after all initialization + READY/GO handshake.
+
+Current lines 89-118:
+```go
+	// Close notify socket - we're done with it
+	_ = unix.Close(sockFD)
+
+	// Install signal filter if enabled...
+	// ... (signal filter + Landlock code)
+```
+
+Replace with:
+```go
+	// Install signal filter if enabled and we have a signal socket
+	sigSockFD, _ := signalSockFD()
+	if cfg.SignalFilterEnabled && sigSockFD >= 0 {
+		sigCfg := signal.DefaultSignalFilterConfig()
+		sigFilter, err := signal.InstallSignalFilter(sigCfg)
+		if err != nil {
+			log.Printf("signal filter: %v (continuing without)", err)
+		} else {
+			defer sigFilter.Close()
+			sigFD := sigFilter.NotifFD()
+			if sigFD >= 0 {
+				if err := sendFD(sigSockFD, sigFD); err != nil {
+					log.Fatalf("send signal fd: %v", err)
+				}
+			}
+		}
+		_ = unix.Close(sigSockFD)
+	}
+
+	// Apply Landlock filesystem restrictions before exec.
+	if cfg.LandlockEnabled && cfg.LandlockABI > 0 {
+		if err := applyLandlock(cfg); err != nil {
+			log.Printf("landlock: %v (continuing without)", err)
+		}
+	}
+
+	// Ptrace sync handshake: when the server will attach ptrace after our
+	// seccomp setup, we signal READY and wait for GO before exec. This
+	// prevents ptrace from interfering with seccomp filter installation.
+	// Only runs when notifFD >= 0 (seccomp is active) and AGENTSH_PTRACE_SYNC=1.
+	if notifFD >= 0 && os.Getenv("AGENTSH_PTRACE_SYNC") == "1" {
+		if _, err := unix.Write(sockFD, []byte{'R'}); err != nil {
+			log.Fatalf("send READY byte: %v", err)
+		}
+		// Wait for GO byte, retrying on EINTR.
+		if err := waitForACK(func(b []byte) (int, error) { return unix.Read(sockFD, b) }); err != nil {
+			log.Fatalf("wait for GO byte: %v", err)
+		}
+	}
+
+	// Close notify socket - done with all handshakes
+	_ = unix.Close(sockFD)
+```
+
+Note: the existing `_ = unix.Close(sockFD)` at line 91 is removed. The signal filter and Landlock code is unchanged — just moved before the new READY/GO block. The READY/GO block is guarded by both `notifFD >= 0` (seccomp is active) and `AGENTSH_PTRACE_SYNC=1`. The `waitForACK` helper is reused for the GO byte read (same 1-byte read with EINTR retry).
+
+- [ ] **Step 2: Verify build**
+
+Run: `go build ./cmd/agentsh-unixwrap/`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/agentsh-unixwrap/main.go
+git commit -m "feat: wrapper READY/GO handshake for ptrace sync"
+```
+
+---
+
+### Task 2: Server sets `AGENTSH_PTRACE_SYNC=1` in hybrid mode
+
+**Files:**
+- Modify: `internal/api/core.go:256`
+
+- [ ] **Step 1: Add env var in the `extraEnv` map**
+
+In `internal/api/core.go`, find the `extraEnv` map construction at line 256:
+
+```go
+	extraEnv := map[string]string{"AGENTSH_NOTIFY_SOCK_FD": strconv.Itoa(envFD)}
+```
+
+Add the ptrace sync flag immediately after:
+
+```go
+	extraEnv := map[string]string{"AGENTSH_NOTIFY_SOCK_FD": strconv.Itoa(envFD)}
+	if a.ptraceTracer != nil {
+		extraEnv["AGENTSH_PTRACE_SYNC"] = "1"
+	}
+```
+
+This is only reachable in hybrid mode because `setupSeccompWrapper` returns early for full ptrace mode at line 128.
+
+- [ ] **Step 2: Verify build**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/api/core.go
+git commit -m "feat: set AGENTSH_PTRACE_SYNC=1 in wrapper env for hybrid mode"
+```
+
+---
+
+### Task 3: Notify handler reads READY byte and signals ptraceReady
+
+**Files:**
+- Modify: `internal/api/notify_linux.go:180` (signature + goroutine body)
+- Modify: `internal/api/notify_stub.go:21` (matching signature)
+- Modify: `internal/api/exec.go:681` (`startWrapperHandlers` signature)
+
+- [ ] **Step 1: Update `startNotifyHandler` signature in `notify_linux.go`**
+
+At line 180, add `ptraceReady chan<- error` parameter:
+
+```go
+func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string, pol *policy.Engine, store eventStore, broker eventBroker, execveHandler any, fileMonitorCfg config.SandboxSeccompFileMonitorConfig, landlockEnabled bool, ptraceReady chan<- error) {
+```
+
+- [ ] **Step 2: Update `startNotifyHandler` signature in `notify_stub.go`**
+
+At line 21, update to match:
+
+```go
+func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string, pol *policy.Engine, store eventStore, broker eventBroker, execveHandler any, fileMonitorCfg config.SandboxSeccompFileMonitorConfig, landlockEnabled bool, ptraceReady chan<- error) {
+```
+
+The stub body stays the same (close parentSock, return). The `ptraceReady` parameter is unused on non-Linux.
+
+- [ ] **Step 3: Replace ServeNotifyWithExecve call with new flow**
+
+In the goroutine inside `startNotifyHandler` (`notify_linux.go`), replace lines 279-286 (from the ACK comment through the `ServeNotifyWithExecve returned` log):
+
+Current:
+```go
+		// Send ACK to wrapper...
+		if _, err := parentSock.Write([]byte{1}); err != nil {
+			slog.Debug("notify: ACK write to wrapper failed", ...)
+		}
+		slog.Debug("starting ServeNotifyWithExecve", ...)
+		unixmon.ServeNotifyWithExecve(ctx, notifyFD, sessID, pol, emitter, h, fileHandler)
+		slog.Debug("ServeNotifyWithExecve returned", ...)
+```
+
+Replace with:
+```go
+		// Send ACK to wrapper so it knows the notify handler is ready before exec.
+		if _, err := parentSock.Write([]byte{1}); err != nil {
+			slog.Debug("notify: ACK write to wrapper failed", "error", err, "session_id", sessID)
+		}
+
+		// Start ServeNotifyWithExecve BEFORE reading READY to ensure notifications
+		// can be processed by the time the wrapper exec's after receiving GO.
+		serveDone := make(chan struct{})
+		go func() {
+			defer close(serveDone)
+			slog.Debug("starting ServeNotifyWithExecve", "session_id", sessID, "has_execve_handler", h != nil, "has_file_handler", fileHandler != nil, "has_policy", pol != nil)
+			unixmon.ServeNotifyWithExecve(ctx, notifyFD, sessID, pol, emitter, h, fileHandler)
+			slog.Debug("ServeNotifyWithExecve returned", "session_id", sessID)
+		}()
+
+		// If ptrace sync is enabled, read the READY byte from the wrapper
+		// and signal the main goroutine that ptrace can now be attached.
+		if ptraceReady != nil {
+			_ = parentSock.SetReadDeadline(time.Time{}) // clear FD-receive deadline
+			_ = parentSock.SetReadDeadline(time.Now().Add(recvFDTimeout))
+			readyBuf := make([]byte, 1)
+			_, readyErr := parentSock.Read(readyBuf)
+			if readyErr != nil {
+				ptraceReady <- fmt.Errorf("read READY byte: %w", readyErr)
+			} else {
+				ptraceReady <- nil
+			}
+			_ = parentSock.SetReadDeadline(time.Time{}) // clear for GO byte
+		}
+
+		<-serveDone // wait for ServeNotifyWithExecve to finish
+```
+
+- [ ] **Step 4: Update `startWrapperHandlers` signature**
+
+In `internal/api/exec.go` at line 681:
+
+```go
+func startWrapperHandlers(ctx context.Context, extra *extraProcConfig, pid, pgid int, ptraceReady chan<- error) {
+```
+
+Update the `startNotifyHandler` call inside to pass `ptraceReady`:
+
+```go
+	if extra.notifyParentSock != nil {
+		startNotifyHandler(ctx, extra.notifyParentSock, extra.notifySessionID, extra.notifyPolicy, extra.notifyStore, extra.notifyBroker, extra.execveHandler, extra.fileMonitorCfg, extra.landlockEnabled, ptraceReady)
+	}
+```
+
+- [ ] **Step 5: Update all non-hybrid callers to pass `nil`**
+
+In `exec.go`, the non-hybrid wrapper call (search for `startWrapperHandlers` outside the hybrid block, around line 447):
+```go
+startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid, nil)
+```
+
+In `exec_stream.go`, the non-hybrid wrapper call (around line 543):
+```go
+startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid, nil)
+```
+
+- [ ] **Step 6: Verify build (including cross-compile)**
+
+Run: `go build ./... && GOOS=windows go build ./... && GOOS=darwin go build ./...`
+Expected: success.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/api/notify_linux.go internal/api/notify_stub.go internal/api/exec.go internal/api/exec_stream.go
+git commit -m "feat: notify handler reads READY byte and signals ptraceReady"
+```
+
+---
+
+### Task 4: Reorder hybrid mode in exec.go and exec_stream.go
+
+**Files:**
+- Modify: `internal/api/exec.go:283-362`
+- Modify: `internal/api/exec_stream.go:387-464`
+
+**Depends on:** Tasks 1, 2, 3
+
+- [ ] **Step 1: Reorder exec.go hybrid mode block**
+
+Replace the hybrid mode block in `internal/api/exec.go` (lines 283-362). Current order: ptrace attach → start handlers → hook → resume → waitExit. New order: start handlers → wait READY → ptrace attach → hook → resume → GO byte → waitExit.
+
+```go
+		if tracer != nil && hasWrapperHandlers {
+			// HYBRID MODE: ptrace for execve interception + seccomp wrapper for sockets/files/Landlock.
+			// The wrapper must complete seccomp setup BEFORE ptrace attaches to prevent deadlock.
+			// Protocol: wrapper does seccomp init → READY byte → server attaches ptrace → GO byte → wrapper exec's.
+			ptraceDone := make(chan struct{})
+			go func() {
+				select {
+				case <-ctx.Done():
+					_ = killProcessGroup(pgid)
+					_ = killProcess(cmd.Process.Pid)
+				case <-ptraceDone:
+				}
+			}()
+
+			// 1. Start wrapper handlers — notify handler receives FD, sends ACK,
+			// starts ServeNotifyWithExecve, then reads READY byte from wrapper.
+			handlerCtx, handlerCancel := context.WithCancel(ctx)
+			ptraceReady := make(chan error, 1)
+			startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid, ptraceReady)
+
+			// 2. Wait for wrapper to signal READY (seccomp setup complete).
+			if readyErr := <-ptraceReady; readyErr != nil {
+				close(ptraceDone)
+				handlerCancel()
+				_ = killProcess(cmd.Process.Pid)
+				_ = killProcessGroup(pgid)
+				pipeWG.Wait()
+				cmd.Process.Release()
+				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid wrapper ready: %w", readyErr)
+			}
+
+			// 3. Attach ptrace NOW — wrapper is idle, waiting for GO byte.
+			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
+			if attachErr != nil {
+				close(ptraceDone)
+				handlerCancel()
+				_ = killProcess(cmd.Process.Pid)
+				_ = killProcessGroup(pgid)
+				pipeWG.Wait()
+				cmd.Process.Release()
+				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid ptrace attach: %w", attachErr)
+			}
+
+			// 4. Run hook while process stopped (cgroup/eBPF setup)
+			if hook != nil {
+				if cleanup, hookErr := hook(cmd.Process.Pid); hookErr != nil {
+					slog.Warn("hybrid mode: cgroup/eBPF hook failed (continuing without resource controls)",
+						"error", hookErr, "pid", cmd.Process.Pid)
+				} else if cleanup != nil {
+					defer func() { _ = cleanup() }()
+				}
+			}
+
+			// 5. Resume wrapper and send GO byte.
+			if resume != nil {
+				if resumeErr := resume(); resumeErr != nil {
+					close(ptraceDone)
+					handlerCancel()
+					_ = killProcess(cmd.Process.Pid)
+					_ = killProcessGroup(pgid)
+					pipeWG.Wait()
+					cmd.Process.Release()
+					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
+				}
+			}
+
+			// 6. Send GO byte — wrapper reads it and calls exec.
+			// Socket access is safe: main goroutine blocked on <-ptraceReady before this,
+			// so notify goroutine's READY read is complete. No concurrent socket access.
+			if _, err := extra.notifyParentSock.Write([]byte{'G'}); err != nil {
+				slog.Warn("hybrid mode: GO byte write failed", "error", err, "pid", cmd.Process.Pid)
+			}
+
+			// 7. Wait for exit via ptrace exit channel
+			waitStart := time.Now()
+			slog.Debug("exec waiting for command (hybrid)", "command", req.Command, "pid", cmd.Process.Pid)
+			result := waitExit()
+			close(ptraceDone)
+			handlerCancel()
+			if result.err != nil {
+				_ = killProcess(cmd.Process.Pid)
+				_ = killProcessGroup(pgid)
+			}
+			waitDuration := time.Since(waitStart)
+			slog.Debug("exec command finished (hybrid)", "command", req.Command, "pid", cmd.Process.Pid, "exit_code", result.exitCode, "wait_duration_ms", waitDuration.Milliseconds())
+			pipeWG.Wait()
+			stdout, stderr = stdoutW.Bytes(), stderrW.Bytes()
+			stdoutTotal, stderrTotal = stdoutW.total, stderrW.total
+			stdoutTrunc, stderrTrunc = stdoutW.truncated, stderrW.truncated
+			resources = result.resources
+			cmd.Process.Release()
+
+			if ctx.Err() != nil {
+				_ = killProcessGroup(pgid)
+			}
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return 124, stdout, append(stderr, []byte("command timed out\n")...), stdoutTotal, stderrTotal + int64(len("command timed out\n")), true, true, resources, ctx.Err()
+			}
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return 127, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, ctx.Err()
+			}
+			return result.exitCode, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, result.err
+		}
+```
+
+- [ ] **Step 2: Apply identical reordering to exec_stream.go**
+
+Replace the hybrid mode block in `internal/api/exec_stream.go` (lines 387-464) with the same pattern. The differences from exec.go:
+- Log `"exec_stream waiting for command (hybrid)"` instead of `"exec waiting for command (hybrid)"`
+- Log `"exec_stream command finished (hybrid)"` instead of `"exec command finished (hybrid)"`
+
+All other code is identical.
+
+- [ ] **Step 3: Verify build**
+
+Run: `go build ./...`
+Expected: success.
+
+- [ ] **Step 4: Run existing tests**
+
+Run: `go test ./internal/api/ -v -count=1 -timeout 120s 2>&1 | tail -20`
+Expected: all existing tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/api/exec.go internal/api/exec_stream.go
+git commit -m "fix: reorder hybrid mode to prevent ptrace+seccomp deadlock"
+```
+
+---
+
+### Task 5: Final verification
+
+**Depends on:** Tasks 1-4
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `go test ./...`
+Expected: all PASS.
+
+- [ ] **Step 2: Verify cross-compilation**
+
+Run: `GOOS=windows go build ./... && GOOS=darwin go build ./...`
+Expected: success.

--- a/docs/superpowers/specs/2026-03-24-ptrace-seccomp-deadlock-design.md
+++ b/docs/superpowers/specs/2026-03-24-ptrace-seccomp-deadlock-design.md
@@ -28,10 +28,14 @@ Delay ptrace attachment until after the wrapper has completed all seccomp setup 
 ### New execution order
 
 ```
-spawn wrapper → start notify handlers → [wrapper: seccomp setup, send FD, ACK] →
-[wrapper: READY byte] → ptrace attach + prefilter → resume → [server: GO byte] →
-wrapper exec's → ptrace intercepts exec → waitExit
+spawn wrapper → start notify handlers + ServeNotifyWithExecve →
+[wrapper: seccomp setup, signal filter, Landlock, send FD, ACK] →
+[wrapper: READY byte] → ptrace attach (SEIZE + INTERRUPT) →
+hook (cgroup/eBPF while stopped) → resume → [server: GO byte] →
+wrapper exec's → first syscall exit → prefilter injected → waitExit
 ```
+
+Note: the prefilter is NOT injected at attach time. It is injected at the first syscall exit after resume (when the wrapper calls `exec`). This is the existing ptrace prefilter injection mechanism — attach just does SEIZE + INTERRUPT.
 
 At exec time, ptrace is attached but the wrapper has already finished all seccomp setup. After exec, both filters are active on the actual command: prefilter (execve → TRACE) + wrapper's filter (file ops → USER_NOTIF). These handle different syscalls and don't interfere.
 
@@ -56,52 +60,80 @@ wrapper: closes socket, exec's → ptrace intercepts exec
 
 The wrapper detects hybrid mode via `AGENTSH_PTRACE_SYNC=1` in its environment, set by the server in `setupSeccompWrapper` when ptrace is active.
 
-### Server-side changes (`internal/api/exec.go`)
+### Server-side changes (`internal/api/exec.go` and `internal/api/exec_stream.go`)
+
+Both `exec.go` (lines 283-362) and `exec_stream.go` (lines 386-464) have identical hybrid mode blocks. Both must be updated with the same reordering.
 
 The hybrid mode block reorders operations:
 
 ```
-1. startWrapperHandlers(ctx, extra)  ← starts notify handler
+1. startWrapperHandlers(ctx, extra)  ← starts notify handler goroutine
    └─ receives FD, sends ACK
-   └─ reads READY byte from wrapper
-   └─ signals ptraceReady channel
-2. <-ptraceReady                     ← wait for wrapper ready
-3. ptraceExecAttach(tracer, pid)     ← attach ptrace NOW
-4. hook (cgroup/eBPF)
-5. resume()                          ← resume ptrace-stopped wrapper
-6. write GO byte to socket           ← wrapper can now exec
-7. waitExit()                        ← wrapper exec's, ptrace intercepts
+   └─ starts ServeNotifyWithExecve (before reading READY, so it's ready for notifications)
+   └─ reads READY byte from wrapper (with 10s timeout)
+   └─ sends nil on ptraceReady channel (or error on failure)
+2. <-ptraceReady                     ← wait for wrapper ready (check error)
+3. ptraceExecAttach(tracer, pid)     ← PTRACE_SEIZE + INTERRUPT (no prefilter yet)
+4. hook (cgroup/eBPF while stopped)
+5. resume()                          ← resume wrapper (still blocked on read for GO)
+6. write GO byte to notifyParentSock ← wrapper reads GO, calls exec
+7. waitExit()                        ← exec triggers prefilter injection at first syscall exit
 ```
 
-A `ptraceReady chan struct{}` is passed to `startNotifyHandler` via a new field on `extraProcConfig`. The notify handler closes it after reading the READY byte.
+The `ptraceReady` channel is `chan error` (not `chan struct{}`), so the notify handler can communicate failure (e.g., wrapper crash, socket error, timeout). The main goroutine checks the error after receiving from the channel.
 
-The GO byte is sent by the main goroutine after `resume()`, not by the notify handler (avoids goroutine coordination).
+**Socket FD ownership:** The notify handler goroutine receives `parentSock` but defers its close until `ServeNotifyWithExecve` returns (after exec/process exit). The main goroutine writes the GO byte to `extra.notifyParentSock` after `resume()`. This is safe because the defer close only fires when the goroutine returns, which is after the process exits. The main goroutine's GO write happens long before that.
+
+**Notify handler ordering within the goroutine:**
+```go
+go func() {
+    defer parentSock.Close()
+    notifyFD := recvFD(parentSock)     // receive notify FD
+    sendACK(parentSock)                // wrapper unblocked
+    go ServeNotifyWithExecve(notifyFD) // start handling notifications NOW
+    readREADY(parentSock, 10s timeout) // wait for wrapper to signal ready
+    ptraceReady <- err                 // signal main goroutine
+    // goroutine continues handling notifications until ctx cancelled
+}()
+```
+
+`ServeNotifyWithExecve` is started in a nested goroutine BEFORE reading the READY byte. This eliminates the race between notification handling startup and wrapper exec after GO. By the time the server sends GO and the wrapper calls exec, `ServeNotifyWithExecve` is already running and ready to handle seccomp notifications.
 
 ### Wrapper-side changes (`cmd/agentsh-unixwrap/main.go`)
 
-After the existing ACK wait, when `AGENTSH_PTRACE_SYNC=1`:
+After ALL existing wrapper initialization (seccomp filter, signal filter, Landlock), when `AGENTSH_PTRACE_SYNC=1`:
 
 ```go
-sendFD(sockFD, notifyFD)
-waitForACK(sockFD)         // server has the notify FD
+// Existing initialization (unchanged):
+installSeccompFilter()           // install BPF with USER_NOTIF
+sendFD(sockFD, notifyFD)        // send notify FD to server
+waitForACK(sockFD)               // server has the notify FD
+installSignalFilter()            // if signal filter enabled
+sendFD(signalSockFD, signalFD)  // send signal FD
+waitForACK(signalSockFD)
+applyLandlock()                  // if Landlock enabled
 
+// NEW: ptrace sync handshake (only when AGENTSH_PTRACE_SYNC=1)
 if os.Getenv("AGENTSH_PTRACE_SYNC") == "1" {
-    sendReadyByte(sockFD)  // seccomp done, about to exec
-    waitForGO(sockFD)      // server attached ptrace
+    sendReadyByte(sockFD)        // all init done, about to exec
+    waitForGO(sockFD)            // server attached ptrace, safe to exec
 }
 
-close(sockFD)
+// NOTE: unix.Close(sockFD) must be moved here (after READY/GO exchange)
+// when AGENTSH_PTRACE_SYNC=1. Currently it's at line 91 before exec.
+unix.Close(sockFD)
 syscall.Exec(...)
 ```
 
-Without `AGENTSH_PTRACE_SYNC=1`, the wrapper behaves exactly as before.
+The READY byte is sent AFTER all initialization (seccomp, signals, Landlock) to ensure the wrapper is fully set up before ptrace attaches. Without `AGENTSH_PTRACE_SYNC=1`, the wrapper behaves exactly as before.
 
 ## Files to modify
 
 1. `internal/api/exec.go` — Reorder hybrid mode: move ptrace attach after wrapper ready signal
-2. `internal/api/notify_linux.go` — Read READY byte after ACK, signal ptraceReady channel
-3. `internal/api/core.go` — Set `AGENTSH_PTRACE_SYNC=1` in wrapper env when ptrace is active
-4. `cmd/agentsh-unixwrap/main.go` — Send READY byte, wait for GO byte when sync enabled
+2. `internal/api/exec_stream.go` — Identical hybrid mode reordering (parallel copy of exec.go hybrid block)
+3. `internal/api/notify_linux.go` — Start ServeNotifyWithExecve before READY read, read READY byte with timeout, signal ptraceReady channel with error
+4. `internal/api/core.go` — Set `AGENTSH_PTRACE_SYNC=1` in wrapper env when ptrace is active
+5. `cmd/agentsh-unixwrap/main.go` — Send READY byte after all init, wait for GO byte, move socket close after handshake
 
 ## Test plan
 

--- a/docs/superpowers/specs/2026-03-24-ptrace-seccomp-deadlock-design.md
+++ b/docs/superpowers/specs/2026-03-24-ptrace-seccomp-deadlock-design.md
@@ -1,0 +1,125 @@
+# Fix: Ptrace + Seccomp Deadlock in Hybrid Mode
+
+## Problem
+
+When both `ptrace.enabled: true` and `seccomp.file_monitor.enabled: true` are configured, the shell shim with `force=true` causes an immediate deadlock on the first command. The agentsh server stops responding to HTTP requests.
+
+The deadlock occurs because ptrace attaches to the wrapper process (`agentsh-unixwrap`) BEFORE the wrapper sets up seccomp. Ptrace intercepts the wrapper's own syscalls during seccomp setup, preventing the wrapper from completing its initialization. The seccomp notify handler in the server can't receive the notify FD, and the system hangs.
+
+**What works:**
+- Ptrace alone + `force=true`: works perfectly (execve interception, blocking)
+- Seccomp file_monitor alone: works perfectly
+- Both together: immediate deadlock on first command
+
+## Root Cause
+
+In hybrid mode (`exec.go:283-362`), the current execution order is:
+
+```
+spawn wrapper → ptrace attach + prefilter injection → start notify handlers → resume → waitExit
+```
+
+Ptrace attaches to the wrapper PID and injects a seccomp prefilter. The wrapper is then resumed. But the wrapper needs to install its own seccomp filter, send the notify FD to the server, and receive an ACK — all while being ptrace-traced. The interaction between ptrace tracing and seccomp filter installation/operation on the same process creates a deadlock.
+
+## Solution
+
+Delay ptrace attachment until after the wrapper has completed all seccomp setup and is about to exec. The wrapper and server coordinate via the existing unix socketpair with two additional bytes.
+
+### New execution order
+
+```
+spawn wrapper → start notify handlers → [wrapper: seccomp setup, send FD, ACK] →
+[wrapper: READY byte] → ptrace attach + prefilter → resume → [server: GO byte] →
+wrapper exec's → ptrace intercepts exec → waitExit
+```
+
+At exec time, ptrace is attached but the wrapper has already finished all seccomp setup. After exec, both filters are active on the actual command: prefilter (execve → TRACE) + wrapper's filter (file ops → USER_NOTIF). These handle different syscalls and don't interfere.
+
+### Protocol change
+
+Existing protocol (unchanged for non-hybrid mode):
+```
+wrapper → server: notify FD (SCM_RIGHTS)
+server → wrapper: ACK byte
+wrapper: closes socket, exec's
+```
+
+New protocol (hybrid mode only, when `AGENTSH_PTRACE_SYNC=1` is set):
+```
+wrapper → server: notify FD (SCM_RIGHTS)
+server → wrapper: ACK byte
+wrapper → server: READY byte ('R')
+server: attaches ptrace, injects prefilter
+server → wrapper: GO byte ('G')
+wrapper: closes socket, exec's → ptrace intercepts exec
+```
+
+The wrapper detects hybrid mode via `AGENTSH_PTRACE_SYNC=1` in its environment, set by the server in `setupSeccompWrapper` when ptrace is active.
+
+### Server-side changes (`internal/api/exec.go`)
+
+The hybrid mode block reorders operations:
+
+```
+1. startWrapperHandlers(ctx, extra)  ← starts notify handler
+   └─ receives FD, sends ACK
+   └─ reads READY byte from wrapper
+   └─ signals ptraceReady channel
+2. <-ptraceReady                     ← wait for wrapper ready
+3. ptraceExecAttach(tracer, pid)     ← attach ptrace NOW
+4. hook (cgroup/eBPF)
+5. resume()                          ← resume ptrace-stopped wrapper
+6. write GO byte to socket           ← wrapper can now exec
+7. waitExit()                        ← wrapper exec's, ptrace intercepts
+```
+
+A `ptraceReady chan struct{}` is passed to `startNotifyHandler` via a new field on `extraProcConfig`. The notify handler closes it after reading the READY byte.
+
+The GO byte is sent by the main goroutine after `resume()`, not by the notify handler (avoids goroutine coordination).
+
+### Wrapper-side changes (`cmd/agentsh-unixwrap/main.go`)
+
+After the existing ACK wait, when `AGENTSH_PTRACE_SYNC=1`:
+
+```go
+sendFD(sockFD, notifyFD)
+waitForACK(sockFD)         // server has the notify FD
+
+if os.Getenv("AGENTSH_PTRACE_SYNC") == "1" {
+    sendReadyByte(sockFD)  // seccomp done, about to exec
+    waitForGO(sockFD)      // server attached ptrace
+}
+
+close(sockFD)
+syscall.Exec(...)
+```
+
+Without `AGENTSH_PTRACE_SYNC=1`, the wrapper behaves exactly as before.
+
+## Files to modify
+
+1. `internal/api/exec.go` — Reorder hybrid mode: move ptrace attach after wrapper ready signal
+2. `internal/api/notify_linux.go` — Read READY byte after ACK, signal ptraceReady channel
+3. `internal/api/core.go` — Set `AGENTSH_PTRACE_SYNC=1` in wrapper env when ptrace is active
+4. `cmd/agentsh-unixwrap/main.go` — Send READY byte, wait for GO byte when sync enabled
+
+## Test plan
+
+**Unit tests:**
+- Wrapper with `AGENTSH_PTRACE_SYNC=1`: sends READY after ACK, waits for GO before exec
+- Wrapper without `AGENTSH_PTRACE_SYNC`: existing protocol unchanged
+
+**Integration tests:**
+- Hybrid mode (ptrace + seccomp file_monitor): command completes without deadlock
+- Execve interception works (blocked command denied)
+- File monitoring works (file operations intercepted)
+
+**Regression tests:**
+- Ptrace-only mode: unchanged behavior
+- Seccomp-only mode: unchanged behavior
+- Wrapper without ptrace: ACK protocol unchanged
+
+**Manual smoke test (exe.dev):**
+- `echo hello` → completes instantly
+- `sudo whoami` → blocked by ptrace execve interception
+- `cat /etc/shadow` → blocked by seccomp file monitor

--- a/docs/superpowers/specs/2026-03-24-ptrace-seccomp-deadlock-design.md
+++ b/docs/superpowers/specs/2026-03-24-ptrace-seccomp-deadlock-design.md
@@ -82,7 +82,9 @@ The hybrid mode block reorders operations:
 
 The `ptraceReady` channel is `chan error` (not `chan struct{}`), so the notify handler can communicate failure (e.g., wrapper crash, socket error, timeout). The main goroutine checks the error after receiving from the channel.
 
-**Socket FD ownership:** The notify handler goroutine receives `parentSock` but defers its close until `ServeNotifyWithExecve` returns (after exec/process exit). The main goroutine writes the GO byte to `extra.notifyParentSock` after `resume()`. This is safe because the defer close only fires when the goroutine returns, which is after the process exits. The main goroutine's GO write happens long before that.
+**Socket FD ownership:** The notify handler goroutine receives `parentSock` but defers its close until `ServeNotifyWithExecve` returns (after exec/process exit). The main goroutine writes the GO byte to `extra.notifyParentSock` after `resume()`. This is safe because the defer close only fires when the goroutine returns, which is after the process exits. The main goroutine's GO write happens long before that. **Sequencing guarantee:** The main goroutine blocks on `<-ptraceReady` before writing GO. Since the READY read in the notify goroutine completes before sending on `ptraceReady`, the socket is never accessed concurrently by both goroutines.
+
+**Signature change:** `startNotifyHandler` (or `startWrapperHandlers`) gains a new `ptraceReady chan<- error` parameter. In hybrid mode, the caller creates and passes the channel; in non-hybrid mode (and in `exec.go`/`exec_stream.go` non-hybrid call sites), it passes `nil` and the handler skips the READY/GO handshake.
 
 **Notify handler ordering within the goroutine:**
 ```go
@@ -116,7 +118,7 @@ applyLandlock()                  // if Landlock enabled
 // NEW: ptrace sync handshake (only when AGENTSH_PTRACE_SYNC=1)
 if os.Getenv("AGENTSH_PTRACE_SYNC") == "1" {
     sendReadyByte(sockFD)        // all init done, about to exec
-    waitForGO(sockFD)            // server attached ptrace, safe to exec
+    waitForGO(sockFD, 30s)       // server attached ptrace, safe to exec (30s timeout, fatal on timeout)
 }
 
 // NOTE: unix.Close(sockFD) must be moved here (after READY/GO exchange)
@@ -132,7 +134,7 @@ The READY byte is sent AFTER all initialization (seccomp, signals, Landlock) to 
 1. `internal/api/exec.go` — Reorder hybrid mode: move ptrace attach after wrapper ready signal
 2. `internal/api/exec_stream.go` — Identical hybrid mode reordering (parallel copy of exec.go hybrid block)
 3. `internal/api/notify_linux.go` — Start ServeNotifyWithExecve before READY read, read READY byte with timeout, signal ptraceReady channel with error
-4. `internal/api/core.go` — Set `AGENTSH_PTRACE_SYNC=1` in wrapper env when ptrace is active
+4. `internal/api/core.go` — Set `AGENTSH_PTRACE_SYNC=1` in wrapper env when ptrace is active. This is only reachable in hybrid mode because `setupSeccompWrapper` returns early for full ptrace mode (when no wrapper is needed). The env var is set in the existing `if a.ptraceTracer != nil` block.
 5. `cmd/agentsh-unixwrap/main.go` — Send READY byte after all init, wait for GO byte, move socket close after handshake
 
 ## Test plan

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -260,6 +260,10 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 	hasNotifyFeatures := seccompCfg.UnixSocketEnabled || seccompCfg.ExecveEnabled || seccompCfg.FileMonitorEnabled || seccompCfg.InterceptMetadata
 	if a.ptraceTracer != nil && hasNotifyFeatures {
 		extraEnv["AGENTSH_PTRACE_SYNC"] = "1"
+	} else {
+		// Explicitly clear to prevent user-injected values from activating
+		// the handshake in non-hybrid mode (would cause a 30s hang).
+		extraEnv["AGENTSH_PTRACE_SYNC"] = "0"
 	}
 	if seccompJSON, ok := wrappedReq.Env["AGENTSH_SECCOMP_CONFIG"]; ok {
 		extraEnv["AGENTSH_SECCOMP_CONFIG"] = seccompJSON

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -258,21 +258,26 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 	// If no seccomp features need USER_NOTIF, the wrapper skips the FD send and
 	// the READY/GO handshake has nothing to synchronize on.
 	hasNotifyFeatures := seccompCfg.UnixSocketEnabled || seccompCfg.ExecveEnabled || seccompCfg.FileMonitorEnabled || seccompCfg.InterceptMetadata
+	// AGENTSH_PTRACE_SYNC goes into envInject (not env) so it overrides any
+	// user-supplied value. envInject deduplicates keys before appending.
+	ptraceSyncValue := "0"
 	if a.ptraceTracer != nil && hasNotifyFeatures {
-		extraEnv["AGENTSH_PTRACE_SYNC"] = "1"
-	} else {
-		// Explicitly clear to prevent user-injected values from activating
-		// the handshake in non-hybrid mode (would cause a 30s hang).
-		extraEnv["AGENTSH_PTRACE_SYNC"] = "0"
+		ptraceSyncValue = "1"
 	}
 	if seccompJSON, ok := wrappedReq.Env["AGENTSH_SECCOMP_CONFIG"]; ok {
 		extraEnv["AGENTSH_SECCOMP_CONFIG"] = seccompJSON
 	}
 
+	envInject := mergeEnvInject(a.cfg, sessionPolicy)
+	if envInject == nil {
+		envInject = make(map[string]string)
+	}
+	envInject["AGENTSH_PTRACE_SYNC"] = ptraceSyncValue
+
 	extraCfg := &extraProcConfig{
 		extraFiles:       []*os.File{sp.child},
 		env:              extraEnv,
-		envInject:        mergeEnvInject(a.cfg, sessionPolicy),
+		envInject:        envInject,
 		notifyParentSock: sp.parent,
 		notifySessionID:  sessionID,
 		notifyPolicy:     sessionPolicy,

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -277,6 +277,7 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 		origCommand:      origCommand, // Store original command for signal registry
 		fileMonitorCfg:   a.cfg.Sandbox.Seccomp.FileMonitor,
 		landlockEnabled:  a.cfg.Landlock.Enabled,
+		ptraceSync:       a.ptraceTracer != nil && hasNotifyFeatures,
 	}
 
 	// Create execve handler if enabled (Linux-specific, will be nil on other platforms)

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -254,6 +254,9 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 	wrappedReq.Args = append([]string{"--", origCommand}, origArgs...)
 
 	extraEnv := map[string]string{"AGENTSH_NOTIFY_SOCK_FD": strconv.Itoa(envFD)}
+	if a.ptraceTracer != nil {
+		extraEnv["AGENTSH_PTRACE_SYNC"] = "1"
+	}
 	if seccompJSON, ok := wrappedReq.Env["AGENTSH_SECCOMP_CONFIG"]; ok {
 		extraEnv["AGENTSH_SECCOMP_CONFIG"] = seccompJSON
 	}

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -254,7 +254,11 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 	wrappedReq.Args = append([]string{"--", origCommand}, origArgs...)
 
 	extraEnv := map[string]string{"AGENTSH_NOTIFY_SOCK_FD": strconv.Itoa(envFD)}
-	if a.ptraceTracer != nil {
+	// Only enable ptrace sync handshake when the wrapper will produce a notify FD.
+	// If no seccomp features need USER_NOTIF, the wrapper skips the FD send and
+	// the READY/GO handshake has nothing to synchronize on.
+	hasNotifyFeatures := seccompCfg.UnixSocketEnabled || seccompCfg.ExecveEnabled || seccompCfg.FileMonitorEnabled
+	if a.ptraceTracer != nil && hasNotifyFeatures {
 		extraEnv["AGENTSH_PTRACE_SYNC"] = "1"
 	}
 	if seccompJSON, ok := wrappedReq.Env["AGENTSH_SECCOMP_CONFIG"]; ok {

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -257,7 +257,7 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 	// Only enable ptrace sync handshake when the wrapper will produce a notify FD.
 	// If no seccomp features need USER_NOTIF, the wrapper skips the FD send and
 	// the READY/GO handshake has nothing to synchronize on.
-	hasNotifyFeatures := seccompCfg.UnixSocketEnabled || seccompCfg.ExecveEnabled || seccompCfg.FileMonitorEnabled
+	hasNotifyFeatures := seccompCfg.UnixSocketEnabled || seccompCfg.ExecveEnabled || seccompCfg.FileMonitorEnabled || seccompCfg.InterceptMetadata
 	if a.ptraceTracer != nil && hasNotifyFeatures {
 		extraEnv["AGENTSH_PTRACE_SYNC"] = "1"
 	}

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -364,7 +364,13 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			// 6. Send GO byte (only when ptrace sync is enabled).
 			if extra.ptraceSync {
 				if _, err := extra.notifyParentSock.Write([]byte{'G'}); err != nil {
-					slog.Warn("hybrid mode: GO byte write failed", "error", err, "pid", cmd.Process.Pid)
+					close(ptraceDone)
+					handlerCancel()
+					_ = killProcess(cmd.Process.Pid)
+					_ = killProcessGroup(pgid)
+					pipeWG.Wait()
+					cmd.Process.Release()
+					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid GO byte write: %w", err)
 				}
 			}
 

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -301,7 +301,13 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid, ptraceReady)
 
 			// 2. Wait for wrapper to signal READY (seccomp setup complete).
-			if readyErr := <-ptraceReady; readyErr != nil {
+			var readyErr error
+			select {
+			case readyErr = <-ptraceReady:
+			case <-ctx.Done():
+				readyErr = ctx.Err()
+			}
+			if readyErr != nil {
 				close(ptraceDone)
 				handlerCancel()
 				_ = killProcess(cmd.Process.Pid)

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -307,7 +307,7 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 				// (via the cancellation goroutine in startNotifyHandler) and
 				// unblocks any stuck NotifReceive ioctl.
 				handlerCtx, handlerCancel := context.WithCancel(ctx)
-				startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid)
+				startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid, nil)
 
 				// 3. Run hook while process stopped (cgroup/eBPF setup)
 				if hook != nil {
@@ -444,7 +444,7 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 		}
 
 		// Start wrapper handlers (wrapper-only path + hybrid fallback).
-		startWrapperHandlers(ctx, extra, cmd.Process.Pid, pgid)
+		startWrapperHandlers(ctx, extra, cmd.Process.Pid, pgid, nil)
 	}
 
 	waitStart := time.Now()
@@ -678,12 +678,12 @@ func mergeEnv(base []string, s *session.Session, overrides map[string]string) []
 
 // startWrapperHandlers starts the seccomp notify handler and signal filter handler
 // if configured. Used by both regular exec and hybrid ptrace+wrapper mode.
-func startWrapperHandlers(ctx context.Context, extra *extraProcConfig, pid, pgid int) {
+func startWrapperHandlers(ctx context.Context, extra *extraProcConfig, pid, pgid int, ptraceReady chan<- error) {
 	if extra == nil {
 		return
 	}
 	if extra.notifyParentSock != nil {
-		startNotifyHandler(ctx, extra.notifyParentSock, extra.notifySessionID, extra.notifyPolicy, extra.notifyStore, extra.notifyBroker, extra.execveHandler, extra.fileMonitorCfg, extra.landlockEnabled)
+		startNotifyHandler(ctx, extra.notifyParentSock, extra.notifySessionID, extra.notifyPolicy, extra.notifyStore, extra.notifyBroker, extra.execveHandler, extra.fileMonitorCfg, extra.landlockEnabled, ptraceReady)
 	}
 	if extra.signalParentSock != nil && extra.signalEngine != nil {
 		if extra.signalRegistry != nil {

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -48,6 +48,10 @@ type extraProcConfig struct {
 
 	// Original command name (before wrapping) for signal registry
 	origCommand string
+
+	// ptraceSync indicates the READY/GO handshake is enabled for hybrid mode.
+	// Only true when ptrace is active AND seccomp notify features are enabled.
+	ptraceSync bool
 }
 
 // eventStore is the interface for storing events.
@@ -297,24 +301,29 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			// 1. Start wrapper handlers — notify handler receives FD, sends ACK,
 			// starts ServeNotifyWithExecve, then reads READY byte from wrapper.
 			handlerCtx, handlerCancel := context.WithCancel(ctx)
-			ptraceReady := make(chan error, 1)
+			var ptraceReady chan error
+			if extra.ptraceSync {
+				ptraceReady = make(chan error, 1)
+			}
 			startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid, ptraceReady)
 
-			// 2. Wait for wrapper to signal READY (seccomp setup complete).
-			var readyErr error
-			select {
-			case readyErr = <-ptraceReady:
-			case <-ctx.Done():
-				readyErr = ctx.Err()
-			}
-			if readyErr != nil {
-				close(ptraceDone)
-				handlerCancel()
-				_ = killProcess(cmd.Process.Pid)
-				_ = killProcessGroup(pgid)
-				pipeWG.Wait()
-				cmd.Process.Release()
-				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid wrapper ready: %w", readyErr)
+			// 2. Wait for wrapper to signal READY (only when ptrace sync is enabled).
+			if extra.ptraceSync {
+				var readyErr error
+				select {
+				case readyErr = <-ptraceReady:
+				case <-ctx.Done():
+					readyErr = ctx.Err()
+				}
+				if readyErr != nil {
+					close(ptraceDone)
+					handlerCancel()
+					_ = killProcess(cmd.Process.Pid)
+					_ = killProcessGroup(pgid)
+					pipeWG.Wait()
+					cmd.Process.Release()
+					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid wrapper ready: %w", readyErr)
+				}
 			}
 
 			// 3. Attach ptrace NOW — wrapper is idle, waiting for GO byte.
@@ -352,11 +361,11 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 				}
 			}
 
-			// 6. Send GO byte — wrapper reads it and calls exec.
-			// Socket access is safe: main goroutine blocked on <-ptraceReady before this,
-			// so notify goroutine's READY read is complete. No concurrent socket access.
-			if _, err := extra.notifyParentSock.Write([]byte{'G'}); err != nil {
-				slog.Warn("hybrid mode: GO byte write failed", "error", err, "pid", cmd.Process.Pid)
+			// 6. Send GO byte (only when ptrace sync is enabled).
+			if extra.ptraceSync {
+				if _, err := extra.notifyParentSock.Write([]byte{'G'}); err != nil {
+					slog.Warn("hybrid mode: GO byte write failed", "error", err, "pid", cmd.Process.Pid)
+				}
 			}
 
 			// 7. Wait for exit via ptrace exit channel

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -282,6 +282,8 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 		hasWrapperHandlers := extra != nil && (extra.notifyParentSock != nil || (extra.signalParentSock != nil && extra.signalEngine != nil))
 		if tracer != nil && hasWrapperHandlers {
 			// HYBRID MODE: ptrace for execve interception + seccomp wrapper for sockets/files/Landlock.
+			// The wrapper must complete seccomp setup BEFORE ptrace attaches to prevent deadlock.
+			// Protocol: wrapper does seccomp init → READY byte → server attaches ptrace → GO byte → wrapper exec's.
 			ptraceDone := make(chan struct{})
 			go func() {
 				select {
@@ -292,74 +294,94 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 				}
 			}()
 
-			// 1. Attach ptrace (prefilter injected at first syscall exit)
+			// 1. Start wrapper handlers — notify handler receives FD, sends ACK,
+			// starts ServeNotifyWithExecve, then reads READY byte from wrapper.
+			handlerCtx, handlerCancel := context.WithCancel(ctx)
+			ptraceReady := make(chan error, 1)
+			startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid, ptraceReady)
+
+			// 2. Wait for wrapper to signal READY (seccomp setup complete).
+			if readyErr := <-ptraceReady; readyErr != nil {
+				close(ptraceDone)
+				handlerCancel()
+				_ = killProcess(cmd.Process.Pid)
+				_ = killProcessGroup(pgid)
+				pipeWG.Wait()
+				cmd.Process.Release()
+				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid wrapper ready: %w", readyErr)
+			}
+
+			// 3. Attach ptrace NOW — wrapper is idle, waiting for GO byte.
 			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
 			if attachErr != nil {
 				close(ptraceDone)
+				handlerCancel()
 				_ = killProcess(cmd.Process.Pid)
 				_ = killProcessGroup(pgid)
 				pipeWG.Wait()
 				cmd.Process.Release()
 				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid ptrace attach: %w", attachErr)
-			} else {
-				// 2. Start wrapper handlers with a child context that we cancel
-				// immediately after the process exits. This closes the notify FD
-				// (via the cancellation goroutine in startNotifyHandler) and
-				// unblocks any stuck NotifReceive ioctl.
-				handlerCtx, handlerCancel := context.WithCancel(ctx)
-				startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid, nil)
+			}
 
-				// 3. Run hook while process stopped (cgroup/eBPF setup)
-				if hook != nil {
-					if cleanup, hookErr := hook(cmd.Process.Pid); hookErr != nil {
-						slog.Warn("hybrid mode: cgroup/eBPF hook failed (continuing without resource controls)",
-							"error", hookErr, "pid", cmd.Process.Pid)
-					} else if cleanup != nil {
-						defer func() { _ = cleanup() }()
-					}
+			// 4. Run hook while process stopped (cgroup/eBPF setup)
+			if hook != nil {
+				if cleanup, hookErr := hook(cmd.Process.Pid); hookErr != nil {
+					slog.Warn("hybrid mode: cgroup/eBPF hook failed (continuing without resource controls)",
+						"error", hookErr, "pid", cmd.Process.Pid)
+				} else if cleanup != nil {
+					defer func() { _ = cleanup() }()
 				}
-				if resume != nil {
-					if resumeErr := resume(); resumeErr != nil {
-						close(ptraceDone)
-						handlerCancel()
-						_ = killProcess(cmd.Process.Pid)
-						_ = killProcessGroup(pgid)
-						pipeWG.Wait()
-						cmd.Process.Release()
-						return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
-					}
-				}
+			}
 
-				// 4. Wait for exit via ptrace exit channel
-				waitStart := time.Now()
-				slog.Debug("exec waiting for command (hybrid)", "command", req.Command, "pid", cmd.Process.Pid)
-				result := waitExit()
-				close(ptraceDone)
-				handlerCancel() // Signal notify handler to exit immediately
-				if result.err != nil {
+			// 5. Resume wrapper and send GO byte.
+			if resume != nil {
+				if resumeErr := resume(); resumeErr != nil {
+					close(ptraceDone)
+					handlerCancel()
 					_ = killProcess(cmd.Process.Pid)
 					_ = killProcessGroup(pgid)
+					pipeWG.Wait()
+					cmd.Process.Release()
+					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
 				}
-				waitDuration := time.Since(waitStart)
-				slog.Debug("exec command finished (hybrid)", "command", req.Command, "pid", cmd.Process.Pid, "exit_code", result.exitCode, "wait_duration_ms", waitDuration.Milliseconds())
-				pipeWG.Wait()
-				stdout, stderr = stdoutW.Bytes(), stderrW.Bytes()
-				stdoutTotal, stderrTotal = stdoutW.total, stderrW.total
-				stdoutTrunc, stderrTrunc = stdoutW.truncated, stderrW.truncated
-				resources = result.resources
-				cmd.Process.Release()
-
-				if ctx.Err() != nil {
-					_ = killProcessGroup(pgid)
-				}
-				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-					return 124, stdout, append(stderr, []byte("command timed out\n")...), stdoutTotal, stderrTotal + int64(len("command timed out\n")), true, true, resources, ctx.Err()
-				}
-				if errors.Is(ctx.Err(), context.Canceled) {
-					return 127, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, ctx.Err()
-				}
-				return result.exitCode, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, result.err
 			}
+
+			// 6. Send GO byte — wrapper reads it and calls exec.
+			// Socket access is safe: main goroutine blocked on <-ptraceReady before this,
+			// so notify goroutine's READY read is complete. No concurrent socket access.
+			if _, err := extra.notifyParentSock.Write([]byte{'G'}); err != nil {
+				slog.Warn("hybrid mode: GO byte write failed", "error", err, "pid", cmd.Process.Pid)
+			}
+
+			// 7. Wait for exit via ptrace exit channel
+			waitStart := time.Now()
+			slog.Debug("exec waiting for command (hybrid)", "command", req.Command, "pid", cmd.Process.Pid)
+			result := waitExit()
+			close(ptraceDone)
+			handlerCancel()
+			if result.err != nil {
+				_ = killProcess(cmd.Process.Pid)
+				_ = killProcessGroup(pgid)
+			}
+			waitDuration := time.Since(waitStart)
+			slog.Debug("exec command finished (hybrid)", "command", req.Command, "pid", cmd.Process.Pid, "exit_code", result.exitCode, "wait_duration_ms", waitDuration.Milliseconds())
+			pipeWG.Wait()
+			stdout, stderr = stdoutW.Bytes(), stderrW.Bytes()
+			stdoutTotal, stderrTotal = stdoutW.total, stderrW.total
+			stdoutTrunc, stderrTrunc = stdoutW.truncated, stderrW.truncated
+			resources = result.resources
+			cmd.Process.Release()
+
+			if ctx.Err() != nil {
+				_ = killProcessGroup(pgid)
+			}
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return 124, stdout, append(stderr, []byte("command timed out\n")...), stdoutTotal, stderrTotal + int64(len("command timed out\n")), true, true, resources, ctx.Err()
+			}
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return 127, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, ctx.Err()
+			}
+			return result.exitCode, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, result.err
 		} else if tracer != nil {
 			// FULL PTRACE MODE: ptrace handles everything (no seccomp wrapper).
 			// Context cancellation watcher: start BEFORE attach so timeout

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -464,7 +464,13 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			// 6. Send GO byte (only when ptrace sync is enabled).
 			if extra.ptraceSync {
 				if _, err := extra.notifyParentSock.Write([]byte{'G'}); err != nil {
-					slog.Warn("hybrid mode: GO byte write failed", "error", err, "pid", cmd.Process.Pid)
+					close(ptraceDone)
+					handlerCancel()
+					_ = killProcess(cmd.Process.Pid)
+					_ = killProcessGroup(pgid)
+					pipeWG.Wait()
+					cmd.Process.Release()
+					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid GO byte write: %w", err)
 				}
 			}
 

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -386,6 +386,8 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 		hasWrapperHandlers := extra != nil && (extra.notifyParentSock != nil || (extra.signalParentSock != nil && extra.signalEngine != nil))
 		if tracer != nil && hasWrapperHandlers {
 			// HYBRID MODE: ptrace for execve interception + seccomp wrapper for sockets/files/Landlock.
+			// The wrapper must complete seccomp setup BEFORE ptrace attaches to prevent deadlock.
+			// Protocol: wrapper does seccomp init → READY byte → server attaches ptrace → GO byte → wrapper exec's.
 			ptraceDone := make(chan struct{})
 			go func() {
 				select {
@@ -396,72 +398,94 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 				}
 			}()
 
-			// 1. Attach ptrace (prefilter injected at first syscall exit)
+			// 1. Start wrapper handlers — notify handler receives FD, sends ACK,
+			// starts ServeNotifyWithExecve, then reads READY byte from wrapper.
+			handlerCtx, handlerCancel := context.WithCancel(ctx)
+			ptraceReady := make(chan error, 1)
+			startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid, ptraceReady)
+
+			// 2. Wait for wrapper to signal READY (seccomp setup complete).
+			if readyErr := <-ptraceReady; readyErr != nil {
+				close(ptraceDone)
+				handlerCancel()
+				_ = killProcess(cmd.Process.Pid)
+				_ = killProcessGroup(pgid)
+				pipeWG.Wait()
+				cmd.Process.Release()
+				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid wrapper ready: %w", readyErr)
+			}
+
+			// 3. Attach ptrace NOW — wrapper is idle, waiting for GO byte.
 			waitExit, resume, attachErr := ptraceExecAttach(tracer, cmd.Process.Pid, sessionID, cmdID, hook != nil)
 			if attachErr != nil {
 				close(ptraceDone)
+				handlerCancel()
 				_ = killProcess(cmd.Process.Pid)
 				_ = killProcessGroup(pgid)
 				pipeWG.Wait()
 				cmd.Process.Release()
 				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid ptrace attach: %w", attachErr)
-			} else {
-				// 2. Start wrapper handlers with a child context that we cancel
-				// immediately after the process exits.
-				handlerCtx, handlerCancel := context.WithCancel(ctx)
-				startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid, nil)
+			}
 
-				// 3. Run hook while process stopped (cgroup/eBPF setup)
-				if hook != nil {
-					if cleanup, hookErr := hook(cmd.Process.Pid); hookErr != nil {
-						slog.Warn("hybrid mode: cgroup/eBPF hook failed (continuing without resource controls)",
-							"error", hookErr, "pid", cmd.Process.Pid)
-					} else if cleanup != nil {
-						defer func() { _ = cleanup() }()
-					}
+			// 4. Run hook while process stopped (cgroup/eBPF setup)
+			if hook != nil {
+				if cleanup, hookErr := hook(cmd.Process.Pid); hookErr != nil {
+					slog.Warn("hybrid mode: cgroup/eBPF hook failed (continuing without resource controls)",
+						"error", hookErr, "pid", cmd.Process.Pid)
+				} else if cleanup != nil {
+					defer func() { _ = cleanup() }()
 				}
-				if resume != nil {
-					if resumeErr := resume(); resumeErr != nil {
-						close(ptraceDone)
-						handlerCancel()
-						_ = killProcess(cmd.Process.Pid)
-						_ = killProcessGroup(pgid)
-						pipeWG.Wait()
-						cmd.Process.Release()
-						return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
-					}
-				}
+			}
 
-				// 4. Wait for exit via ptrace exit channel
-				waitStart := time.Now()
-				slog.Debug("exec_stream waiting for command (hybrid)", "command", req.Command, "pid", cmd.Process.Pid)
-				result := waitExit()
-				close(ptraceDone)
-				handlerCancel() // Signal notify handler to exit immediately
-				if result.err != nil {
+			// 5. Resume wrapper and send GO byte.
+			if resume != nil {
+				if resumeErr := resume(); resumeErr != nil {
+					close(ptraceDone)
+					handlerCancel()
 					_ = killProcess(cmd.Process.Pid)
 					_ = killProcessGroup(pgid)
+					pipeWG.Wait()
+					cmd.Process.Release()
+					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("ptrace resume: %w", resumeErr)
 				}
-				waitDuration := time.Since(waitStart)
-				slog.Debug("exec_stream command finished (hybrid)", "command", req.Command, "pid", cmd.Process.Pid, "exit_code", result.exitCode, "wait_duration_ms", waitDuration.Milliseconds())
-				pipeWG.Wait()
-				stdout, stderr = stdoutW.Bytes(), stderrW.Bytes()
-				stdoutTotal, stderrTotal = stdoutW.total, stderrW.total
-				stdoutTrunc, stderrTrunc = stdoutW.truncated, stderrW.truncated
-				resources = result.resources
-				cmd.Process.Release()
-
-				if ctx.Err() != nil {
-					_ = killProcessGroup(pgid)
-				}
-				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-					return 124, stdout, append(stderr, []byte("command timed out\n")...), stdoutTotal, stderrTotal + int64(len("command timed out\n")), true, true, resources, ctx.Err()
-				}
-				if errors.Is(ctx.Err(), context.Canceled) {
-					return 127, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, ctx.Err()
-				}
-				return result.exitCode, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, result.err
 			}
+
+			// 6. Send GO byte — wrapper reads it and calls exec.
+			// Socket access is safe: main goroutine blocked on <-ptraceReady before this,
+			// so notify goroutine's READY read is complete. No concurrent socket access.
+			if _, err := extra.notifyParentSock.Write([]byte{'G'}); err != nil {
+				slog.Warn("hybrid mode: GO byte write failed", "error", err, "pid", cmd.Process.Pid)
+			}
+
+			// 7. Wait for exit via ptrace exit channel
+			waitStart := time.Now()
+			slog.Debug("exec_stream waiting for command (hybrid)", "command", req.Command, "pid", cmd.Process.Pid)
+			result := waitExit()
+			close(ptraceDone)
+			handlerCancel()
+			if result.err != nil {
+				_ = killProcess(cmd.Process.Pid)
+				_ = killProcessGroup(pgid)
+			}
+			waitDuration := time.Since(waitStart)
+			slog.Debug("exec_stream command finished (hybrid)", "command", req.Command, "pid", cmd.Process.Pid, "exit_code", result.exitCode, "wait_duration_ms", waitDuration.Milliseconds())
+			pipeWG.Wait()
+			stdout, stderr = stdoutW.Bytes(), stderrW.Bytes()
+			stdoutTotal, stderrTotal = stdoutW.total, stderrW.total
+			stdoutTrunc, stderrTrunc = stdoutW.truncated, stderrW.truncated
+			resources = result.resources
+			cmd.Process.Release()
+
+			if ctx.Err() != nil {
+				_ = killProcessGroup(pgid)
+			}
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return 124, stdout, append(stderr, []byte("command timed out\n")...), stdoutTotal, stderrTotal + int64(len("command timed out\n")), true, true, resources, ctx.Err()
+			}
+			if errors.Is(ctx.Err(), context.Canceled) {
+				return 127, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, ctx.Err()
+			}
+			return result.exitCode, stdout, stderr, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, result.err
 		} else if tracer != nil {
 			// FULL PTRACE MODE: ptrace handles everything (no seccomp wrapper).
 			// Context cancellation watcher: start BEFORE attach

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -401,24 +401,29 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			// 1. Start wrapper handlers — notify handler receives FD, sends ACK,
 			// starts ServeNotifyWithExecve, then reads READY byte from wrapper.
 			handlerCtx, handlerCancel := context.WithCancel(ctx)
-			ptraceReady := make(chan error, 1)
+			var ptraceReady chan error
+			if extra.ptraceSync {
+				ptraceReady = make(chan error, 1)
+			}
 			startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid, ptraceReady)
 
-			// 2. Wait for wrapper to signal READY (seccomp setup complete).
-			var readyErr error
-			select {
-			case readyErr = <-ptraceReady:
-			case <-ctx.Done():
-				readyErr = ctx.Err()
-			}
-			if readyErr != nil {
-				close(ptraceDone)
-				handlerCancel()
-				_ = killProcess(cmd.Process.Pid)
-				_ = killProcessGroup(pgid)
-				pipeWG.Wait()
-				cmd.Process.Release()
-				return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid wrapper ready: %w", readyErr)
+			// 2. Wait for wrapper to signal READY (only when ptrace sync is enabled).
+			if extra.ptraceSync {
+				var readyErr error
+				select {
+				case readyErr = <-ptraceReady:
+				case <-ctx.Done():
+					readyErr = ctx.Err()
+				}
+				if readyErr != nil {
+					close(ptraceDone)
+					handlerCancel()
+					_ = killProcess(cmd.Process.Pid)
+					_ = killProcessGroup(pgid)
+					pipeWG.Wait()
+					cmd.Process.Release()
+					return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("hybrid wrapper ready: %w", readyErr)
+				}
 			}
 
 			// 3. Attach ptrace NOW — wrapper is idle, waiting for GO byte.
@@ -456,11 +461,11 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 				}
 			}
 
-			// 6. Send GO byte — wrapper reads it and calls exec.
-			// Socket access is safe: main goroutine blocked on <-ptraceReady before this,
-			// so notify goroutine's READY read is complete. No concurrent socket access.
-			if _, err := extra.notifyParentSock.Write([]byte{'G'}); err != nil {
-				slog.Warn("hybrid mode: GO byte write failed", "error", err, "pid", cmd.Process.Pid)
+			// 6. Send GO byte (only when ptrace sync is enabled).
+			if extra.ptraceSync {
+				if _, err := extra.notifyParentSock.Write([]byte{'G'}); err != nil {
+					slog.Warn("hybrid mode: GO byte write failed", "error", err, "pid", cmd.Process.Pid)
+				}
 			}
 
 			// 7. Wait for exit via ptrace exit channel

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -405,7 +405,13 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid, ptraceReady)
 
 			// 2. Wait for wrapper to signal READY (seccomp setup complete).
-			if readyErr := <-ptraceReady; readyErr != nil {
+			var readyErr error
+			select {
+			case readyErr = <-ptraceReady:
+			case <-ctx.Done():
+				readyErr = ctx.Err()
+			}
+			if readyErr != nil {
 				close(ptraceDone)
 				handlerCancel()
 				_ = killProcess(cmd.Process.Pid)

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -409,7 +409,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 				// 2. Start wrapper handlers with a child context that we cancel
 				// immediately after the process exits.
 				handlerCtx, handlerCancel := context.WithCancel(ctx)
-				startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid)
+				startWrapperHandlers(handlerCtx, extra, cmd.Process.Pid, pgid, nil)
 
 				// 3. Run hook while process stopped (cgroup/eBPF setup)
 				if hook != nil {
@@ -540,7 +540,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 		}
 
 		// Start wrapper handlers (wrapper-only path + hybrid fallback).
-		startWrapperHandlers(ctx, extra, cmd.Process.Pid, pgid)
+		startWrapperHandlers(ctx, extra, cmd.Process.Pid, pgid, nil)
 	}
 
 	waitStart := time.Now()

--- a/internal/api/notify_linux.go
+++ b/internal/api/notify_linux.go
@@ -310,6 +310,8 @@ func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string,
 			_, readyErr := parentSock.Read(readyBuf)
 			if readyErr != nil {
 				ptraceReady <- fmt.Errorf("read READY byte: %w", readyErr)
+			} else if readyBuf[0] != 'R' {
+				ptraceReady <- fmt.Errorf("unexpected READY byte: got 0x%02x, expected 'R'", readyBuf[0])
 			} else {
 				ptraceReady <- nil
 			}

--- a/internal/api/notify_linux.go
+++ b/internal/api/notify_linux.go
@@ -305,7 +305,8 @@ func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string,
 		// and signal the main goroutine that ptrace can now be attached.
 		if ptraceReady != nil {
 			_ = parentSock.SetReadDeadline(time.Time{}) // clear FD-receive deadline
-			_ = parentSock.SetReadDeadline(time.Now().Add(recvFDTimeout))
+			// Use 30s timeout for READY (wrapper does signal filter + Landlock setup after ACK).
+			_ = parentSock.SetReadDeadline(time.Now().Add(30 * time.Second))
 			readyBuf := make([]byte, 1)
 			_, readyErr := parentSock.Read(readyBuf)
 			if readyErr != nil {

--- a/internal/api/notify_linux.go
+++ b/internal/api/notify_linux.go
@@ -4,12 +4,14 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime/debug"
+	"syscall"
 	"time"
 
 	"github.com/agentsh/agentsh/internal/approvals"
@@ -308,7 +310,15 @@ func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string,
 			// Use 30s timeout for READY (wrapper does signal filter + Landlock setup after ACK).
 			_ = parentSock.SetReadDeadline(time.Now().Add(30 * time.Second))
 			readyBuf := make([]byte, 1)
-			_, readyErr := parentSock.Read(readyBuf)
+			// Retry on EINTR (signal interruption during read).
+			var readyErr error
+			for {
+				_, readyErr = parentSock.Read(readyBuf)
+				if readyErr != nil && errors.Is(readyErr, syscall.EINTR) {
+					continue
+				}
+				break
+			}
 			if readyErr != nil {
 				ptraceReady <- fmt.Errorf("read READY byte: %w", readyErr)
 			} else if readyBuf[0] != 'R' {

--- a/internal/api/notify_linux.go
+++ b/internal/api/notify_linux.go
@@ -186,6 +186,16 @@ func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string,
 	go func() {
 		defer notifyHandlerRecover(sessID, store, broker)
 		defer parentSock.Close()
+		// Ensure ptraceReady is always signaled on all exit paths to prevent
+		// the main goroutine from blocking forever in hybrid mode.
+		defer func() {
+			if ptraceReady != nil {
+				select {
+				case ptraceReady <- fmt.Errorf("notify handler exited without signaling READY"):
+				default: // already signaled
+				}
+			}
+		}()
 		slog.Debug("notify handler started", "session_id", sessID)
 
 		// Get the wrapper's PID from socket credentials for session tracking

--- a/internal/api/notify_linux.go
+++ b/internal/api/notify_linux.go
@@ -177,7 +177,7 @@ func notifyHandlerRecover(sessID string, store eventStore, broker eventBroker) {
 // starts the ServeNotify handler in a goroutine. It returns immediately.
 // The handler runs until ctx is cancelled or the fd is closed.
 // If execveHandler is non-nil, uses ServeNotifyWithExecve for execve interception.
-func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string, pol *policy.Engine, store eventStore, broker eventBroker, execveHandler any, fileMonitorCfg config.SandboxSeccompFileMonitorConfig, landlockEnabled bool) {
+func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string, pol *policy.Engine, store eventStore, broker eventBroker, execveHandler any, fileMonitorCfg config.SandboxSeccompFileMonitorConfig, landlockEnabled bool, ptraceReady chan<- error) {
 	if parentSock == nil {
 		return
 	}
@@ -277,12 +277,35 @@ func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string,
 			}
 		}
 		// Send ACK to wrapper so it knows the notify handler is ready before exec.
-		// This mirrors the ACK in internal/cli/wrap_linux.go:133.
 		if _, err := parentSock.Write([]byte{1}); err != nil {
 			slog.Debug("notify: ACK write to wrapper failed", "error", err, "session_id", sessID)
 		}
-		slog.Debug("starting ServeNotifyWithExecve", "session_id", sessID, "has_execve_handler", h != nil, "has_file_handler", fileHandler != nil, "has_policy", pol != nil)
-		unixmon.ServeNotifyWithExecve(ctx, notifyFD, sessID, pol, emitter, h, fileHandler)
-		slog.Debug("ServeNotifyWithExecve returned", "session_id", sessID)
+
+		// Start ServeNotifyWithExecve BEFORE reading READY to ensure notifications
+		// can be processed by the time the wrapper exec's after receiving GO.
+		serveDone := make(chan struct{})
+		go func() {
+			defer close(serveDone)
+			slog.Debug("starting ServeNotifyWithExecve", "session_id", sessID, "has_execve_handler", h != nil, "has_file_handler", fileHandler != nil, "has_policy", pol != nil)
+			unixmon.ServeNotifyWithExecve(ctx, notifyFD, sessID, pol, emitter, h, fileHandler)
+			slog.Debug("ServeNotifyWithExecve returned", "session_id", sessID)
+		}()
+
+		// If ptrace sync is enabled, read the READY byte from the wrapper
+		// and signal the main goroutine that ptrace can now be attached.
+		if ptraceReady != nil {
+			_ = parentSock.SetReadDeadline(time.Time{}) // clear FD-receive deadline
+			_ = parentSock.SetReadDeadline(time.Now().Add(recvFDTimeout))
+			readyBuf := make([]byte, 1)
+			_, readyErr := parentSock.Read(readyBuf)
+			if readyErr != nil {
+				ptraceReady <- fmt.Errorf("read READY byte: %w", readyErr)
+			} else {
+				ptraceReady <- nil
+			}
+			_ = parentSock.SetReadDeadline(time.Time{}) // clear for GO byte
+		}
+
+		<-serveDone // wait for ServeNotifyWithExecve to finish
 	}()
 }

--- a/internal/api/notify_linux_test.go
+++ b/internal/api/notify_linux_test.go
@@ -33,7 +33,7 @@ func TestStartNotifyHandler_GracefulErrorExit(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	startNotifyHandler(ctx, parentSock, "test-graceful", nil, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false)
+	startNotifyHandler(ctx, parentSock, "test-graceful", nil, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false, nil)
 
 	// Poll until the goroutine exits (parentSock gets closed by the deferred Close).
 	deadline := time.After(2 * time.Second)
@@ -378,7 +378,7 @@ func TestNotifyHandler_CancellationGoroutineExitsOnEarlyReturn(t *testing.T) {
 
 	goroutinesBefore := runtime.NumGoroutine()
 
-	startNotifyHandler(ctx, parentSock, "test-cancel-goroutine", nil, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false)
+	startNotifyHandler(ctx, parentSock, "test-cancel-goroutine", nil, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false, nil)
 
 	// Wait for handler goroutine to exit.
 	deadline := time.After(2 * time.Second)
@@ -445,7 +445,7 @@ func TestNotifyHandler_ContextCancelCleansUpFDs(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	startNotifyHandler(ctx, parentSock, "test-fd-cleanup", nil, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false)
+	startNotifyHandler(ctx, parentSock, "test-fd-cleanup", nil, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false, nil)
 
 	// Wait for handler to clean up (close parent socket via defer).
 	deadline := time.After(2 * time.Second)

--- a/internal/api/notify_stub.go
+++ b/internal/api/notify_stub.go
@@ -18,7 +18,7 @@ func createExecveHandler(cfg config.ExecveConfig, pol *policy.Engine, approvalMg
 
 // startNotifyHandler is a no-op on non-Linux platforms or without CGO.
 // Unix socket enforcement via seccomp user-notify is Linux-only.
-func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string, pol *policy.Engine, store eventStore, broker eventBroker, execveHandler any, fileMonitorCfg config.SandboxSeccompFileMonitorConfig, landlockEnabled bool) {
+func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string, pol *policy.Engine, store eventStore, broker eventBroker, execveHandler any, fileMonitorCfg config.SandboxSeccompFileMonitorConfig, landlockEnabled bool, ptraceReady chan<- error) {
 	// Unix socket enforcement not available on this platform
 	if parentSock != nil {
 		_ = parentSock.Close()

--- a/internal/api/notify_test.go
+++ b/internal/api/notify_test.go
@@ -48,7 +48,7 @@ func TestStartNotifyHandler_NilSocket_NoOp(t *testing.T) {
 	pol := &policy.Engine{}
 
 	// Should not panic with nil socket
-	startNotifyHandler(context.Background(), nil, "test-session", pol, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false)
+	startNotifyHandler(context.Background(), nil, "test-session", pol, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false, nil)
 }
 
 func TestStartNotifyHandler_NilPolicy_NoOp(t *testing.T) {
@@ -64,7 +64,7 @@ func TestStartNotifyHandler_NilPolicy_NoOp(t *testing.T) {
 	broker := &notifyMockEventBroker{}
 
 	// Should close the socket and return without panic when policy is nil
-	startNotifyHandler(context.Background(), r, "test-session", nil, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false)
+	startNotifyHandler(context.Background(), r, "test-session", nil, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false, nil)
 }
 
 func TestStartNotifyHandler_NilStore_NoOp(t *testing.T) {
@@ -73,7 +73,7 @@ func TestStartNotifyHandler_NilStore_NoOp(t *testing.T) {
 	pol := &policy.Engine{}
 
 	// Should not panic with nil socket (store doesn't matter if socket is nil)
-	startNotifyHandler(context.Background(), nil, "test-session", pol, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false)
+	startNotifyHandler(context.Background(), nil, "test-session", pol, store, broker, nil, config.SandboxSeccompFileMonitorConfig{}, false, nil)
 }
 
 func TestExtraProcConfig_NotifyFields(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes an immediate deadlock when both `ptrace.enabled: true` and `seccomp.file_monitor.enabled: true` are configured in hybrid mode. The agentsh server stops responding to HTTP requests on the first command through the shell shim with `force=true`.

## Root Cause

In hybrid mode, ptrace attached to the wrapper process (`agentsh-unixwrap`) BEFORE the wrapper completed seccomp setup. Ptrace intercepted the wrapper's own syscalls during seccomp filter installation, preventing initialization from completing.

## Fix

Delay ptrace attachment until after the wrapper completes all initialization. A READY/GO handshake over the existing unix socketpair coordinates the two phases:

```
wrapper: seccomp setup → signal filter → Landlock → READY byte →
server: receives READY → attaches ptrace → GO byte →
wrapper: exec's → ptrace intercepts exec
```

## Key design decisions

- **`AGENTSH_PTRACE_SYNC=1`** env var gates the handshake (only in hybrid mode with notify features)
- **`envInject`** used for the env var to prevent user-supplied values from overriding
- **30s timeouts** on both READY read (server) and GO read (wrapper)
- **EINTR retry** on READY byte read
- **Byte validation** — `'R'` for READY, `'G'` for GO, explicit errors on mismatch
- **`ptraceReady chan error`** signaled on ALL notify handler exit paths (defer) + ctx cancellation
- **GO write failure is fatal** — kills process group, returns error
- **`ptraceSync` field** on `extraProcConfig` gates wait/GO in exec blocks
- **Backwards compatible** — without `AGENTSH_PTRACE_SYNC=1`, wrapper uses existing protocol

## Files changed

| File | Change |
|------|--------|
| `cmd/agentsh-unixwrap/main.go` | READY/GO handshake, SO_RCVTIMEO, byte validation |
| `cmd/agentsh-unixwrap/ack_test.go` | 4 handshake tests |
| `internal/api/core.go` | Set `AGENTSH_PTRACE_SYNC` via envInject, `ptraceSync` field |
| `internal/api/exec.go` | Reorder hybrid mode, ptraceSync gating, GO write fatal |
| `internal/api/exec_stream.go` | Same reordering (parallel hybrid block) |
| `internal/api/notify_linux.go` | READY read with EINTR retry, ptraceReady channel, ServeNotify in nested goroutine |
| `internal/api/notify_stub.go` | Signature update for cross-compile |

## Test plan

- `go test ./...` — all pass
- `GOOS=windows go build ./...` — clean
- `GOOS=darwin go build ./...` — clean
- roborev: Medium/Low only (test quality suggestions, no correctness issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)