### PR TITLE
fix: allow redirections in agentsh bypass metachar filter (#163)

### DIFF
--- a/cmd/agentsh-shell-shim/main.go
+++ b/cmd/agentsh-shell-shim/main.go
@@ -173,10 +173,12 @@ func isAgentshCommand(args []string) bool {
 		return false
 	}
 
-	// Reject compound commands (shell metacharacters and newlines). Only
-	// bypass for simple single-command invocations to prevent enforcement
+	// Reject compound commands (shell operators that chain multiple commands).
+	// Only bypass for simple single-command invocations to prevent enforcement
 	// bypass for chained commands like "agentsh detect; rm -rf /".
-	if strings.ContainsAny(cmdStr, ";|&`$()\n\r") {
+	// We check for compound OPERATORS, not individual characters, because
+	// characters like & and > appear in legitimate redirections (2>&1).
+	if containsCompoundOperator(cmdStr) {
 		return false
 	}
 
@@ -211,6 +213,32 @@ func isAgentshCommand(args []string) bool {
 		agentshResolved = agentshPath
 	}
 	return cmdResolved == agentshResolved
+}
+
+// containsCompoundOperator checks if a shell command string contains operators
+// that chain multiple commands. Returns false for simple redirections like 2>&1.
+func containsCompoundOperator(s string) bool {
+	// These always indicate compound commands or subshells.
+	if strings.ContainsAny(s, ";`\n\r") {
+		return true
+	}
+	if strings.Contains(s, "&&") || strings.Contains(s, "||") || strings.Contains(s, "$(") {
+		return true
+	}
+	// Check for pipe: | that is NOT preceded by > (which would be >| clobber
+	// or part of a >&| redirect). A bare | chains commands.
+	for i, c := range s {
+		if c == '|' {
+			if i > 0 && s[i-1] == '>' {
+				continue // part of >| or >&| redirect
+			}
+			if i+1 < len(s) && s[i+1] == '|' {
+				continue // || already handled above
+			}
+			return true // bare pipe
+		}
+	}
+	return false
 }
 
 // extractCommand skips shell builtins that don't affect command resolution

--- a/cmd/agentsh-shell-shim/main_test.go
+++ b/cmd/agentsh-shell-shim/main_test.go
@@ -523,10 +523,15 @@ func TestIsAgentshCommand(t *testing.T) {
 		// Compound commands — bypass disabled (could bypass enforcement for chained commands).
 		{"semicolon chain", []string{"-c", "agentsh detect; echo done"}, false},
 		{"and chain", []string{"-c", "agentsh detect && echo done"}, false},
+		{"or chain", []string{"-c", "agentsh detect || echo done"}, false},
 		{"pipe", []string{"-c", "agentsh detect | grep ok"}, false},
 		{"subshell", []string{"-c", "$(agentsh detect)"}, false},
 		{"backtick", []string{"-c", "`agentsh detect`"}, false},
 		{"newline separator", []string{"-c", "agentsh detect\nother-cmd"}, false},
+		// Redirections are NOT compound — they're single commands.
+		{"stderr redirect", []string{"-c", "agentsh detect 2>&1"}, true},
+		{"stdout redirect", []string{"-c", "agentsh detect > /dev/null"}, true},
+		{"stderr to file", []string{"-c", "agentsh detect 2>/dev/null"}, true},
 		{"script with -c arg", []string{"script.sh", "-c", "agentsh detect"}, false},
 		{"no -c flag", []string{"agentsh", "detect"}, false},
 		{"empty command", []string{"-c", ""}, false},


### PR DESCRIPTION
## Summary

The metacharacter filter in `isAgentshCommand` rejected individual characters (`&`, `$`, `(`, `)`) which broke legitimate redirections like `2>&1`. This caused `agentsh detect 2>&1` to deadlock instead of bypassing.

## Fix

Replace individual character check with compound operator detection:
- **Blocked**: `&&`, `||`, `;`, `|` (bare pipe), `` ` ``, `$(`, `\n`, `\r`
- **Allowed**: `2>&1`, `> /dev/null`, `2>/dev/null` (single-command redirections)

New `containsCompoundOperator()` function checks for pipe `|` that is NOT preceded by `>` (which would be part of a redirect).

## Test coverage

36 test cases including 3 new redirect cases (`2>&1`, `> /dev/null`, `2>/dev/null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)