### PR TITLE
fix: file_monitor write denials in wrap path

### DIFF
--- a/cmd/agentsh-unixwrap/config.go
+++ b/cmd/agentsh-unixwrap/config.go
@@ -29,6 +29,9 @@ type WrapperConfig struct {
 	DenyPaths       []string `json:"deny_paths,omitempty"`
 	AllowNetwork    bool     `json:"allow_network,omitempty"`
 	AllowBind       bool     `json:"allow_bind,omitempty"`
+
+	// Server PID for PR_SET_PTRACER (Yama ptrace_scope=1 workaround)
+	ServerPID int `json:"server_pid,omitempty"`
 }
 
 // loadConfig reads the wrapper config from environment.

--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -42,6 +42,17 @@ func main() {
 		log.Fatalf("load config: %v", err)
 	}
 
+	// Authorize the server process to read our memory via ProcessVMReadv.
+	// Under Yama ptrace_scope=1 (Ubuntu/Debian default), only ancestor
+	// processes can use ProcessVMReadv. In the wrap path the server is NOT
+	// our ancestor, so this prctl authorizes it specifically.
+	// Must run before any seccomp notifications can be processed.
+	if cfg.ServerPID > 0 {
+		if err := unix.Prctl(unix.PR_SET_PTRACER, uintptr(cfg.ServerPID), 0, 0, 0); err != nil {
+			log.Printf("PR_SET_PTRACER(%d): %v (ProcessVMReadv may fail under Yama)", cfg.ServerPID, err)
+		}
+	}
+
 	// Resolve syscall names to numbers.
 	blockedNrs, skipped := seccompkg.ResolveSyscalls(cfg.BlockedSyscalls)
 	if len(skipped) > 0 {

--- a/docs/superpowers/plans/2026-03-28-fix-filemonitor-writes.md
+++ b/docs/superpowers/plans/2026-03-28-fix-filemonitor-writes.md
@@ -1,0 +1,259 @@
+# Fix file_monitor Write Denials Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix two bugs causing the seccomp file_monitor to deny all writes in the `agentsh wrap` path (63/73 → 73/73).
+
+**Architecture:** Two independent fixes: (1) add `prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY)` in the wrapper before exec so the server can read tracee memory under Yama ptrace_scope=1, and (2) thread the session-specific policy engine (with expanded `${PROJECT_ROOT}`) through to the wrap path's notify handler.
+
+**Tech Stack:** Go, Linux seccomp user-notify, prctl/Yama LSM, testcontainers (Docker integration tests)
+
+---
+
+### Task 1: Add PR_SET_PTRACER_ANY to wrapper
+
+**Files:**
+- Modify: `cmd/agentsh-unixwrap/main.go:142-153`
+
+- [ ] **Step 1: Add the prctl call before exec**
+
+After `unix.Close(sockFD)` at line 143 and before the `// Exec the real command` comment at line 145, add:
+
+```go
+	// Allow the server process to read our memory via ProcessVMReadv.
+	// Under Yama ptrace_scope=1 (Ubuntu/Debian default), only ancestor
+	// processes can use ProcessVMReadv. In the wrap path the server is NOT
+	// our ancestor, so this prctl authorizes any process to read us.
+	// Security: the child is already sandboxed via seccomp BPF.
+	if err := unix.Prctl(unix.PR_SET_PTRACER, uintptr(unix.PR_SET_PTRACER_ANY), 0, 0, 0); err != nil {
+		log.Printf("PR_SET_PTRACER_ANY: %v (ProcessVMReadv may fail under Yama)", err)
+	}
+```
+
+Reference: `golang.org/x/sys/unix` provides both `Prctl`, `PR_SET_PTRACER`, and `PR_SET_PTRACER_ANY` constants.
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `go build ./cmd/agentsh-unixwrap/`
+Expected: success, no errors
+
+- [ ] **Step 3: Verify cross-compilation**
+
+Run: `GOOS=windows go build ./...`
+Expected: success (wrapper is linux-only, build-tagged)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/agentsh-unixwrap/main.go
+git commit -m "fix: add PR_SET_PTRACER_ANY to wrapper for Yama ptrace_scope=1
+
+Under Yama ptrace_scope=1 (Ubuntu/Debian default), the server cannot use
+ProcessVMReadv on the sandboxed child in the wrap path because the server
+is not an ancestor. This caused all file writes to be denied (EACCES)
+before policy evaluation.
+
+prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY) authorizes any process to read
+the child's memory. The child is already sandboxed via seccomp BPF, so
+this is a minimal security relaxation."
+```
+
+---
+
+### Task 2: Thread session policy engine to wrap path
+
+**Files:**
+- Modify: `internal/api/wrap.go:345` (pass session to startNotifyHandlerForWrap)
+- Modify: `internal/api/wrap_linux.go:61` (accept session, use session policy)
+- Modify: `internal/api/wrap_windows.go:38` (update stub signature)
+- Modify: `internal/api/wrap_other.go:25` (update stub signature)
+
+- [ ] **Step 1: Update `startNotifyHandlerForWrap` signature in wrap_linux.go**
+
+At line 61, change the function signature to accept `s *session.Session`:
+
+```go
+func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session) {
+```
+
+At the top of the function body (after the emitter line 62), add the session policy resolution:
+
+```go
+	// Prefer session-specific policy engine (has expanded ${PROJECT_ROOT} etc.)
+	// over app-level engine, matching the exec path pattern in core.go.
+	sessionPolicy := a.policy
+	if s != nil {
+		if sp := s.PolicyEngine(); sp != nil {
+			sessionPolicy = sp
+		}
+	}
+```
+
+Then replace the three uses of `a.policy` with `sessionPolicy`:
+- Line 68: `createExecveHandler(a.cfg.Sandbox.Seccomp.Execve, sessionPolicy, a.approvals)`
+- Line 109: `createFileHandler(a.cfg.Sandbox.Seccomp.FileMonitor, sessionPolicy, emitter, a.cfg.Landlock.Enabled)`
+- Line 117: `unixmon.ServeNotifyWithExecve(ctx, notifyFD, sessionID, sessionPolicy, emitter, execveHandler, fileHandler)`
+
+- [ ] **Step 2: Update stub in wrap_windows.go**
+
+At line 38, update the signature to match:
+
+```go
+func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session) {
+```
+
+The function body stays empty (no-op on Windows).
+
+- [ ] **Step 3: Update stub in wrap_other.go**
+
+At line 25, update the signature to match:
+
+```go
+func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session) {
+```
+
+The function body stays a no-op comment.
+
+- [ ] **Step 4: Update callsite in wrap.go**
+
+At line 345, pass the session `s`:
+
+```go
+	startNotifyHandlerForWrap(ctx, notifyFD, sessionID, a, execveEnabled, wrapperPID, s)
+```
+
+Note: `acceptNotifyFD` already receives `s *session.Session` as a parameter (line 293).
+
+- [ ] **Step 5: Verify it compiles on all platforms**
+
+Run: `go build ./... && GOOS=windows go build ./...`
+Expected: success
+
+- [ ] **Step 6: Run existing tests**
+
+Run: `go test ./internal/api/...`
+Expected: all pass (existing tests use nil sessions or test infrastructure that doesn't exercise this path directly)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/api/wrap.go internal/api/wrap_linux.go internal/api/wrap_windows.go internal/api/wrap_other.go
+git commit -m "fix: use session-specific policy engine in wrap path
+
+The wrap path was using a.policy (app-level engine, no variable expansion)
+instead of the session-specific engine. Policy rules with \${PROJECT_ROOT}
+were never expanded, so workspace write-allow rules never matched.
+
+Thread the session through acceptNotifyFD → startNotifyHandlerForWrap and
+prefer s.PolicyEngine() with fallback to a.policy, matching the exec path."
+```
+
+---
+
+### Task 3: Integration test for write operations
+
+**Files:**
+- Modify: `internal/integration/file_monitor_test.go`
+
+- [ ] **Step 1: Add write test cases to TestFileMonitor_ReadAllowed**
+
+After the existing `write_denied_path` subtest (around line 160), add these subtests inside `TestFileMonitor_ReadAllowed`:
+
+```go
+	// Write to workspace: should succeed (allowed by allow-workspace rule)
+	t.Run("write_workspace_file", func(t *testing.T) {
+		execCtx, cancel := context.WithTimeout(ctx, execTimeout)
+		defer cancel()
+
+		result, err := cli.Exec(execCtx, sess.ID, types.ExecRequest{
+			Command:    "sh",
+			Args:       []string{"-c", "echo test_content > /workspace/write_test.txt && cat /workspace/write_test.txt"},
+			WorkingDir: "/workspace",
+		})
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				t.Skip("command timeout")
+			}
+			t.Fatalf("Exec write workspace: %v", err)
+		}
+		if result.Result.ExitCode != 0 {
+			t.Errorf("write to /workspace should succeed: exit=%d stderr=%q",
+				result.Result.ExitCode, result.Result.Stderr)
+		} else {
+			stdout := strings.TrimSpace(result.Result.Stdout)
+			if stdout != "test_content" {
+				t.Errorf("expected 'test_content', got %q", stdout)
+			}
+		}
+	})
+
+	// Write to /tmp: should succeed (allowed by allow-tmp rule)
+	t.Run("write_tmp_file", func(t *testing.T) {
+		execCtx, cancel := context.WithTimeout(ctx, execTimeout)
+		defer cancel()
+
+		result, err := cli.Exec(execCtx, sess.ID, types.ExecRequest{
+			Command:    "sh",
+			Args:       []string{"-c", "echo tmp_content > /tmp/write_test.txt && cat /tmp/write_test.txt"},
+			WorkingDir: "/workspace",
+		})
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				t.Skip("command timeout")
+			}
+			t.Fatalf("Exec write tmp: %v", err)
+		}
+		if result.Result.ExitCode != 0 {
+			t.Errorf("write to /tmp should succeed: exit=%d stderr=%q",
+				result.Result.ExitCode, result.Result.Stderr)
+		} else {
+			stdout := strings.TrimSpace(result.Result.Stdout)
+			if stdout != "tmp_content" {
+				t.Errorf("expected 'tmp_content', got %q", stdout)
+			}
+		}
+	})
+```
+
+- [ ] **Step 2: Verify test compiles**
+
+Run: `go test -c -tags integration ./internal/integration/`
+Expected: compiles without errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/integration/file_monitor_test.go
+git commit -m "test: add write-allowed integration tests for file_monitor
+
+Adds subtests verifying that writes to /workspace and /tmp succeed when
+policy allows them. These would have caught the wrap path write denial bug."
+```
+
+---
+
+### Task 4: Verify full build and existing tests
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Build all targets**
+
+Run: `go build ./...`
+Expected: success
+
+- [ ] **Step 2: Cross-compile for Windows**
+
+Run: `GOOS=windows go build ./...`
+Expected: success
+
+- [ ] **Step 3: Run all unit tests**
+
+Run: `go test ./...`
+Expected: all pass
+
+- [ ] **Step 4: Run integration tests (if Docker available)**
+
+Run: `go test -tags integration -run TestFileMonitor -v ./internal/integration/ -timeout 300s`
+Expected: all file_monitor tests pass including the new write tests
+
+**Note on PR_SET_PTRACER exec survival:** The integration tests validate this implicitly. The Docker containers run with Yama ptrace_scope=1. If `PR_SET_PTRACER_ANY` did NOT survive exec, the write tests would fail with the same EACCES errors as before. If the integration tests pass with writes succeeding, exec survival is confirmed. If they fail, the contingency `/proc/PID/mem` fallback from the spec would be needed as a follow-up.

--- a/docs/superpowers/specs/2026-03-28-fix-filemonitor-writes-design.md
+++ b/docs/superpowers/specs/2026-03-28-fix-filemonitor-writes-design.md
@@ -1,0 +1,87 @@
+# Fix file_monitor Write Denials in Wrap Path
+
+## Goal
+
+Make `seccomp.file_monitor.enabled: true` correctly allow writes to workspace, `/tmp`, and other policy-allowed paths in the `agentsh wrap` execution path. Current score: 63/73. Target: 73/73.
+
+## Root Causes
+
+Two independent bugs cause all writes to be denied when file_monitor is enabled in the wrap path:
+
+### 1. ProcessVMReadv fails under Yama ptrace_scope=1
+
+In the wrap path, the CLI spawns the sandboxed child independently of the server. The server is NOT an ancestor of the child. On Ubuntu/Debian with `kernel.yama.ptrace_scope=1` (the default), `ProcessVMReadv` requires the caller to be an ancestor of the target — so it fails with EPERM.
+
+`resolvePathAt` calls `readString` → `ProcessVMReadv` → EPERM → error. In `handleFileNotificationEmulated`, when path resolution fails for a non-read-only open, the handler responds with EACCES. This blocks ALL writes before policy is even consulted — including writes to `/tmp` (literal path, no variable expansion needed).
+
+PR #168 fixed the read case by checking `isReadOnlyOpen(flags)` and returning CONTINUE. Writes remain blocked.
+
+### 2. Wrap path uses unexpanded policy engine
+
+`startNotifyHandlerForWrap` (wrap_linux.go:109) creates the file handler with `a.policy` — the app-level engine created via `NewEngine()` with NO variable expansion. Policy rules using `${PROJECT_ROOT}/**` contain the literal string `${PROJECT_ROOT}` as a glob pattern, which never matches real paths like `/home/user/project/file.txt`.
+
+The exec path correctly uses a session-specific engine created via `NewEngineWithVariables()` with `PROJECT_ROOT`, `GIT_ROOT`, and `HOME` expanded. The wrap path has the session object available (it's passed through `acceptNotifyFD`) but never uses its policy engine.
+
+## Design
+
+### Fix 1: PR_SET_PTRACER_ANY in the wrapper
+
+Add `prctl(PR_SET_PTRACER, PR_SET_PTRACER_ANY)` in `cmd/agentsh-unixwrap/main.go` before exec.
+
+This authorizes any process (including the server) to call `ProcessVMReadv` on the sandboxed child, bypassing the Yama ancestor check. The call goes after all handshakes complete and before `syscall.Exec`, alongside the existing pre-exec setup (landlock, ptrace sync).
+
+**Security consideration:** The child is already sandboxed via seccomp BPF. Allowing non-ancestor processes to read its memory is a minor relaxation — the sandbox itself is the security boundary, not Yama's ptrace restriction. The server needs this access to enforce file policy.
+
+**Scope:** The prctl fixes ALL `ProcessVMReadv`/`ProcessVMWritev` callsites simultaneously — not just `readString` but also `readPointer`, `writeString`, `ReadSockaddr`, `readOpenHow`, and `readOpenHowResolve`. No per-function changes needed.
+
+**Exec survival:** `PR_SET_PTRACER` is stored per-task in the Yama LSM, separate from credentials. It is NOT cleared by `yama_task_free` on exec — only on task exit. It should survive exec for non-setuid binaries. If it doesn't (needs verification), add a `/proc/PID/mem` pread fallback to ALL ProcessVMReadv callsites in the seccomp handler path (`execve_reader.go` and `file_syscalls.go`), matching the pattern in `internal/ptrace/memory.go:35-46`.
+
+**Files:**
+- Modify: `cmd/agentsh-unixwrap/main.go` — add prctl call before exec
+- Contingent: `internal/netmonitor/unix/execve_reader.go` and `file_syscalls.go` — add `/proc/PID/mem` fallback (only if prctl doesn't survive exec)
+
+### Fix 2: Use session-specific policy engine in wrap path
+
+Thread the session's policy engine through to the notify handler.
+
+**Changes:**
+- `acceptNotifyFD` (wrap.go:293): already receives `s *session.Session` — pass it to `startNotifyHandlerForWrap`
+- `startNotifyHandlerForWrap` (wrap_linux.go:61): add `s *session.Session` parameter; prefer `s.PolicyEngine()` over `a.policy` with fallback (same pattern as exec path in core.go:167-174)
+- Three callsites use `a.policy` at lines 68, 109, 117 — all three should use the session engine
+
+**Pattern (from exec path):**
+```go
+sessionPolicy := a.policy
+if s != nil {
+    if sp := s.PolicyEngine(); sp != nil {
+        sessionPolicy = sp
+    }
+}
+```
+
+**Files:**
+- Modify: `internal/api/wrap.go` — pass session to `startNotifyHandlerForWrap`
+- Modify: `internal/api/wrap_linux.go` — accept session, use session policy engine
+- Modify: `internal/api/wrap_windows.go` — update `startNotifyHandlerForWrap` signature (stub)
+- Modify: `internal/api/wrap_other.go` — update `startNotifyHandlerForWrap` signature (stub)
+
+**Out of scope:** `startSignalHandlerForWrap` also uses `a.policy`, but signal rules don't use path variables — they match on signal names/numbers. No change needed there.
+
+## Testing
+
+### Unit tests
+- Verify `PR_SET_PTRACER` survives exec: fork, child calls prctl + exec, parent tries ProcessVMReadv on grandchild
+- Existing `TestFilePolicyEngineWrapper_CheckFile` already validates the policy engine path
+
+### Integration tests
+- Extend `internal/integration/file_monitor_test.go`:
+  - Add write-allowed test: `echo test > /workspace/test.txt` should succeed
+  - Add `/tmp` write test: `echo test > /tmp/test.txt` should succeed
+  - Add write-denied test: `echo test > /etc/test.txt` should be denied
+  - Test with `${PROJECT_ROOT}` variable expansion active
+
+## Affected paths
+
+Only the wrap path is affected. The exec path already:
+1. Has the server as ancestor of the child (ProcessVMReadv works)
+2. Uses session-specific policy engine (variables expanded)

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -69,6 +69,9 @@ type seccompWrapperConfig struct {
 	DenyPaths       []string `json:"deny_paths,omitempty"`
 	AllowNetwork    bool     `json:"allow_network,omitempty"`
 	AllowBind       bool     `json:"allow_bind,omitempty"`
+
+	// Server PID for PR_SET_PTRACER (Yama ptrace_scope=1 workaround)
+	ServerPID int `json:"server_pid,omitempty"`
 }
 
 // macSandboxWrapperConfig is passed to agentsh-macwrap via
@@ -202,6 +205,7 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 		SignalFilterEnabled: signalFilterEnabled, // Only true if signal socket succeeded
 		ExecveEnabled:       execveEnabled,
 		FileMonitorEnabled:  config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.Enabled, false),
+		ServerPID:           os.Getpid(),
 	}
 
 	// Bridge file monitor sub-options using EnforceWithoutFUSE as the default

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -343,7 +343,7 @@ func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketP
 	slog.Info("wrap: received notify fd", "session_id", sessionID, "fd", notifyFD.Fd())
 
 	// Start the notify handler using existing infrastructure
-	startNotifyHandlerForWrap(ctx, notifyFD, sessionID, a, execveEnabled, wrapperPID)
+	startNotifyHandlerForWrap(ctx, notifyFD, sessionID, a, execveEnabled, wrapperPID, s)
 }
 
 // acceptSignalFD listens on the Unix socket for a single connection from the CLI,

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -152,6 +152,7 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 		UnixSocketEnabled: a.cfg.Sandbox.Seccomp.UnixSocket.Enabled,
 		BlockedSyscalls:   a.cfg.Sandbox.Seccomp.Syscalls.Block,
 		ExecveEnabled:     execveEnabled,
+		ServerPID:         os.Getpid(),
 	}
 
 	// Add Landlock config if enabled

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -58,14 +58,23 @@ func recvFDFromConn(sock *os.File) (*os.File, error) {
 // startNotifyHandlerForWrap starts the seccomp notify handler for a wrap session.
 // Unlike the exec path where the notify fd comes from a socketpair, here it comes
 // from the CLI via a Unix socket connection.
-func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int) {
+func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session) {
 	emitter := &notifyEmitterAdapter{store: a.store, broker: a.broker}
+
+	// Prefer session-specific policy engine (has expanded ${PROJECT_ROOT} etc.)
+	// over app-level engine, matching the exec path pattern in core.go.
+	sessionPolicy := a.policy
+	if s != nil {
+		if sp := s.PolicyEngine(); sp != nil {
+			sessionPolicy = sp
+		}
+	}
 
 	// Create execve handler if enabled
 	var execveHandler *unixmon.ExecveHandler
 	var cleanupSymlink func()
 	if execveEnabled {
-		if h := createExecveHandler(a.cfg.Sandbox.Seccomp.Execve, a.policy, a.approvals); h != nil {
+		if h := createExecveHandler(a.cfg.Sandbox.Seccomp.Execve, sessionPolicy, a.approvals); h != nil {
 			execveHandler, _ = h.(*unixmon.ExecveHandler)
 			if execveHandler != nil {
 				execveHandler.SetEmitter(emitter)
@@ -106,7 +115,7 @@ func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID
 	}
 
 	// Create file handler if configured
-	fileHandler := createFileHandler(a.cfg.Sandbox.Seccomp.FileMonitor, a.policy, emitter, a.cfg.Landlock.Enabled)
+	fileHandler := createFileHandler(a.cfg.Sandbox.Seccomp.FileMonitor, sessionPolicy, emitter, a.cfg.Landlock.Enabled)
 
 	go func() {
 		defer notifyFD.Close()
@@ -114,7 +123,7 @@ func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID
 			defer cleanupSymlink()
 		}
 		slog.Info("wrap: starting notify handler", "session_id", sessionID, "has_execve", execveHandler != nil, "has_file_handler", fileHandler != nil)
-		unixmon.ServeNotifyWithExecve(ctx, notifyFD, sessionID, a.policy, emitter, execveHandler, fileHandler)
+		unixmon.ServeNotifyWithExecve(ctx, notifyFD, sessionID, sessionPolicy, emitter, execveHandler, fileHandler)
 		slog.Info("wrap: notify handler returned", "session_id", sessionID)
 	}()
 }

--- a/internal/api/wrap_other.go
+++ b/internal/api/wrap_other.go
@@ -22,7 +22,7 @@ func recvFDFromConn(sock *os.File) (*os.File, error) {
 	return nil, errWrapNotSupported
 }
 
-func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int) {
+func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session) {
 	// No-op on non-Linux platforms
 }
 

--- a/internal/api/wrap_windows.go
+++ b/internal/api/wrap_windows.go
@@ -35,7 +35,7 @@ func recvFDFromConn(sock *os.File) (*os.File, error) {
 	return nil, fmt.Errorf("SCM_RIGHTS not available on Windows")
 }
 
-func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int) {
+func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session) {
 	// Not used on Windows — the driver handles exec interception directly.
 }
 

--- a/internal/integration/file_monitor_test.go
+++ b/internal/integration/file_monitor_test.go
@@ -181,6 +181,60 @@ func TestFileMonitor_ReadAllowed(t *testing.T) {
 		}
 	})
 
+	// Test 5: write to workspace should succeed (allowed by allow-workspace rule)
+	t.Run("write_workspace_file", func(t *testing.T) {
+		execCtx, cancel := context.WithTimeout(ctx, execTimeout)
+		defer cancel()
+
+		result, err := cli.Exec(execCtx, sess.ID, types.ExecRequest{
+			Command:    "sh",
+			Args:       []string{"-c", "echo test_content > /workspace/write_test.txt && cat /workspace/write_test.txt"},
+			WorkingDir: "/workspace",
+		})
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				t.Skip("command timeout")
+			}
+			t.Fatalf("Exec write workspace: %v", err)
+		}
+		if result.Result.ExitCode != 0 {
+			t.Errorf("write to /workspace should succeed: exit=%d stderr=%q",
+				result.Result.ExitCode, result.Result.Stderr)
+		} else {
+			stdout := strings.TrimSpace(result.Result.Stdout)
+			if stdout != "test_content" {
+				t.Errorf("expected 'test_content', got %q", stdout)
+			}
+		}
+	})
+
+	// Test 6: write to /tmp should succeed (allowed by allow-tmp rule)
+	t.Run("write_tmp_file", func(t *testing.T) {
+		execCtx, cancel := context.WithTimeout(ctx, execTimeout)
+		defer cancel()
+
+		result, err := cli.Exec(execCtx, sess.ID, types.ExecRequest{
+			Command:    "sh",
+			Args:       []string{"-c", "echo tmp_content > /tmp/write_test.txt && cat /tmp/write_test.txt"},
+			WorkingDir: "/workspace",
+		})
+		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				t.Skip("command timeout")
+			}
+			t.Fatalf("Exec write tmp: %v", err)
+		}
+		if result.Result.ExitCode != 0 {
+			t.Errorf("write to /tmp should succeed: exit=%d stderr=%q",
+				result.Result.ExitCode, result.Result.Stderr)
+		} else {
+			stdout := strings.TrimSpace(result.Result.Stdout)
+			if stdout != "tmp_content" {
+				t.Errorf("expected 'tmp_content', got %q", stdout)
+			}
+		}
+	})
+
 	if err := cli.DestroySession(ctx, sess.ID); err != nil {
 		t.Logf("DestroySession: %v (non-fatal)", err)
 	}


### PR DESCRIPTION
## Summary

- **Add PR_SET_PTRACER to wrapper** — Under Yama `ptrace_scope=1` (Ubuntu/Debian default), the server can't use `ProcessVMReadv` on the sandboxed child in the wrap path because the server isn't an ancestor. All writes were denied (EACCES) before policy evaluation. Now the server PID is passed via `AGENTSH_SECCOMP_CONFIG` and the wrapper calls `prctl(PR_SET_PTRACER, server_pid)` early, authorizing only the server to read child memory.

- **Use session-specific policy engine in wrap path** — The wrap path was using `a.policy` (app-level, no variable expansion) instead of the session-specific engine. Policy rules with `${PROJECT_ROOT}` were never expanded, so workspace write-allow rules never matched. Now `startNotifyHandlerForWrap` prefers `s.PolicyEngine()` with fallback to `a.policy`, matching the exec path.

- **Integration tests** — Added write-allowed tests for `/workspace` and `/tmp` paths.

Fixes the 63/73 → 73/73 gap with `file_monitor.enabled: true`.

## Test plan

- [x] `go build ./...` passes
- [x] `GOOS=windows go build ./...` passes
- [x] `go test ./...` all pass
- [x] Integration tests compile (`go test -c -tags integration ./internal/integration/`)
- [ ] CI passes
- [ ] Deploy to devbox and verify 73/73 with file_monitor enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)