### PR TITLE
fix: pass user HOME from CLI to server for policy variable expansion

### DIFF
--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -631,6 +631,7 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 	// Set HOME for policy variable expansion (deny rules use ${HOME}/.bashrc etc.).
 	// Prefer the CLI-provided value (the session user's HOME) over the server's
 	// os.Getenv("HOME") which may differ when the server runs as a different user.
+	// Trust model: HOME is trusted from authenticated clients, same as workspace/policy.
 	if req.Home != "" {
 		policyVars["HOME"] = req.Home
 	} else if home := os.Getenv("HOME"); home != "" {

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -628,6 +628,15 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 		policyVars["GIT_ROOT"] = policyVars["PROJECT_ROOT"]
 	}
 
+	// Set HOME for policy variable expansion (deny rules use ${HOME}/.bashrc etc.).
+	// Prefer the CLI-provided value (the session user's HOME) over the server's
+	// os.Getenv("HOME") which may differ when the server runs as a different user.
+	if req.Home != "" {
+		policyVars["HOME"] = req.Home
+	} else if home := os.Getenv("HOME"); home != "" {
+		policyVars["HOME"] = home
+	}
+
 	// Load and expand policy (or use global policy if no policy dir configured)
 	var engine *policy.Engine
 	if a.cfg.Policies.Dir != "" {

--- a/internal/api/grpc.go
+++ b/internal/api/grpc.go
@@ -1043,11 +1043,12 @@ type CreateSessionRequestCompat struct {
 	ID        string `json:"id"`
 	Workspace string `json:"workspace"`
 	Policy    string `json:"policy"`
+	Home      string `json:"home,omitempty"`
 	RealPaths *bool  `json:"real_paths,omitempty"`
 }
 
 func (c CreateSessionRequestCompat) ToTypes() types.CreateSessionRequest {
-	return types.CreateSessionRequest{ID: c.ID, Workspace: c.Workspace, Policy: c.Policy, RealPaths: c.RealPaths}
+	return types.CreateSessionRequest{ID: c.ID, Workspace: c.Workspace, Policy: c.Policy, Home: c.Home, RealPaths: c.RealPaths}
 }
 
 // execRequestCompat matches HTTP ExecRequest plus a session_id field.

--- a/internal/api/grpc.go
+++ b/internal/api/grpc.go
@@ -1040,15 +1040,27 @@ func codeFromHTTP(code int) codes.Code {
 
 // CreateSessionRequestCompat matches the HTTP create session JSON.
 type CreateSessionRequestCompat struct {
-	ID        string `json:"id"`
-	Workspace string `json:"workspace"`
-	Policy    string `json:"policy"`
-	Home      string `json:"home,omitempty"`
-	RealPaths *bool  `json:"real_paths,omitempty"`
+	ID                string `json:"id"`
+	Workspace         string `json:"workspace"`
+	Policy            string `json:"policy"`
+	Profile           string `json:"profile,omitempty"`
+	Home              string `json:"home,omitempty"`
+	DetectProjectRoot *bool  `json:"detect_project_root,omitempty"`
+	ProjectRoot       string `json:"project_root,omitempty"`
+	RealPaths         *bool  `json:"real_paths,omitempty"`
 }
 
 func (c CreateSessionRequestCompat) ToTypes() types.CreateSessionRequest {
-	return types.CreateSessionRequest{ID: c.ID, Workspace: c.Workspace, Policy: c.Policy, Home: c.Home, RealPaths: c.RealPaths}
+	return types.CreateSessionRequest{
+		ID:                c.ID,
+		Workspace:         c.Workspace,
+		Policy:            c.Policy,
+		Profile:           c.Profile,
+		Home:              c.Home,
+		DetectProjectRoot: c.DetectProjectRoot,
+		ProjectRoot:       c.ProjectRoot,
+		RealPaths:         c.RealPaths,
+	}
 }
 
 // execRequestCompat matches HTTP ExecRequest plus a session_id field.

--- a/internal/api/session_create_home_test.go
+++ b/internal/api/session_create_home_test.go
@@ -27,9 +27,18 @@ func TestCreateSession_HomeFieldPropagated(t *testing.T) {
 	app := newTestApp(t, sessions, store)
 	h := app.Router()
 
-	// Create session with explicit home value
-	body := `{"id":"sess_home","workspace":"` + ws + `","policy":"default","home":"/home/testuser"}`
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", strings.NewReader(body))
+	reqBody := map[string]any{
+		"id":        "sess_home",
+		"workspace": ws,
+		"policy":    "default",
+		"home":      "/home/testuser",
+	}
+	bodyBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", strings.NewReader(string(bodyBytes)))
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 	if rr.Code != http.StatusCreated {
@@ -43,6 +52,22 @@ func TestCreateSession_HomeFieldPropagated(t *testing.T) {
 	if out.ID != "sess_home" {
 		t.Fatalf("expected id sess_home, got %q", out.ID)
 	}
+
+	// Verify HOME was used in policy expansion by executing a command that
+	// touches ${HOME}/.bashrc — it should be denied by the default policy.
+	execBody := map[string]any{
+		"command": "touch",
+		"args":    []string{"/home/testuser/.bashrc"},
+	}
+	execBytes, _ := json.Marshal(execBody)
+	execReq := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/sess_home/exec", strings.NewReader(string(execBytes)))
+	execRR := httptest.NewRecorder()
+	h.ServeHTTP(execRR, execReq)
+
+	// The command should either be blocked (403/200 with non-zero exit) or
+	// succeed only if the file monitor is not active. Either way, session
+	// creation must accept the home field without error — that's the core
+	// assertion. The deny behavior depends on runtime enforcement mode.
 }
 
 func TestCreateSessionRequestCompat_HomePropagated(t *testing.T) {
@@ -78,5 +103,43 @@ func TestCreateSessionRequestCompat_HomePropagated(t *testing.T) {
 				t.Errorf("req.Home = %q after ToTypes(), want %q", req.Home, tt.wantHome)
 			}
 		})
+	}
+}
+
+func TestCreateSessionRequestCompat_AllFieldsPropagated(t *testing.T) {
+	input := `{
+		"id": "s1",
+		"workspace": "/tmp",
+		"policy": "default",
+		"profile": "restricted",
+		"home": "/home/testuser",
+		"detect_project_root": false,
+		"project_root": "/opt/project",
+		"real_paths": true
+	}`
+
+	var compat CreateSessionRequestCompat
+	if err := json.Unmarshal([]byte(input), &compat); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+
+	req := compat.ToTypes()
+	if req.ID != "s1" {
+		t.Errorf("ID = %q, want s1", req.ID)
+	}
+	if req.Profile != "restricted" {
+		t.Errorf("Profile = %q, want restricted", req.Profile)
+	}
+	if req.Home != "/home/testuser" {
+		t.Errorf("Home = %q, want /home/testuser", req.Home)
+	}
+	if req.DetectProjectRoot == nil || *req.DetectProjectRoot != false {
+		t.Errorf("DetectProjectRoot = %v, want false", req.DetectProjectRoot)
+	}
+	if req.ProjectRoot != "/opt/project" {
+		t.Errorf("ProjectRoot = %q, want /opt/project", req.ProjectRoot)
+	}
+	if req.RealPaths == nil || *req.RealPaths != true {
+		t.Errorf("RealPaths = %v, want true", req.RealPaths)
 	}
 }

--- a/internal/api/session_create_home_test.go
+++ b/internal/api/session_create_home_test.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/store/composite"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+func TestCreateSession_HomeFieldPropagated(t *testing.T) {
+	st := newSQLiteStore(t)
+	store := composite.New(st, st)
+	sessions := session.NewManager(10)
+
+	ws := filepath.Join(t.TempDir(), "ws")
+	if err := os.MkdirAll(ws, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	app := newTestApp(t, sessions, store)
+	h := app.Router()
+
+	// Create session with explicit home value
+	body := `{"id":"sess_home","workspace":"` + ws + `","policy":"default","home":"/home/testuser"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var out types.Session
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.ID != "sess_home" {
+		t.Fatalf("expected id sess_home, got %q", out.ID)
+	}
+}
+
+func TestCreateSessionRequestCompat_HomePropagated(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		wantHome string
+	}{
+		{
+			name:     "absent",
+			json:     `{"id":"s1","workspace":"/tmp","policy":"default"}`,
+			wantHome: "",
+		},
+		{
+			name:     "explicit value",
+			json:     `{"id":"s1","workspace":"/tmp","policy":"default","home":"/home/testuser"}`,
+			wantHome: "/home/testuser",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var compat CreateSessionRequestCompat
+			if err := json.Unmarshal([]byte(tt.json), &compat); err != nil {
+				t.Fatalf("Unmarshal: %v", err)
+			}
+			if compat.Home != tt.wantHome {
+				t.Errorf("compat.Home = %q, want %q", compat.Home, tt.wantHome)
+			}
+
+			req := compat.ToTypes()
+			if req.Home != tt.wantHome {
+				t.Errorf("req.Home = %q after ToTypes(), want %q", req.Home, tt.wantHome)
+			}
+		})
+	}
+}

--- a/internal/api/session_create_home_test.go
+++ b/internal/api/session_create_home_test.go
@@ -52,22 +52,9 @@ func TestCreateSession_HomeFieldPropagated(t *testing.T) {
 	if out.ID != "sess_home" {
 		t.Fatalf("expected id sess_home, got %q", out.ID)
 	}
-
-	// Verify HOME was used in policy expansion by executing a command that
-	// touches ${HOME}/.bashrc — it should be denied by the default policy.
-	execBody := map[string]any{
-		"command": "touch",
-		"args":    []string{"/home/testuser/.bashrc"},
-	}
-	execBytes, _ := json.Marshal(execBody)
-	execReq := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/sess_home/exec", strings.NewReader(string(execBytes)))
-	execRR := httptest.NewRecorder()
-	h.ServeHTTP(execRR, execReq)
-
-	// The command should either be blocked (403/200 with non-zero exit) or
-	// succeed only if the file monitor is not active. Either way, session
-	// creation must accept the home field without error — that's the core
-	// assertion. The deny behavior depends on runtime enforcement mode.
+	// HOME expansion correctness is verified by policy engine tests in
+	// internal/policy/engine_vars_test.go (TestDenyPrecedenceWhenHomeEqualsProjectRoot).
+	// This test verifies the HTTP plumbing accepts and propagates the field.
 }
 
 func TestCreateSessionRequestCompat_HomePropagated(t *testing.T) {

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -88,6 +88,7 @@ Root directory for auto-creating sessions uses --root flag or AGENTSH_SESSION_RO
 			createReq := types.CreateSessionRequest{
 				ID:        sessionID,
 				Workspace: autoCreateRoot,
+				Home:      os.Getenv("HOME"),
 			}
 			if noDetectRoot {
 				falseVal := false

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -88,7 +88,7 @@ Root directory for auto-creating sessions uses --root flag or AGENTSH_SESSION_RO
 			createReq := types.CreateSessionRequest{
 				ID:        sessionID,
 				Workspace: autoCreateRoot,
-				Home:      os.Getenv("HOME"),
+				Home:      userHomeDir(),
 			}
 			if noDetectRoot {
 				falseVal := false

--- a/internal/cli/exec_pty.go
+++ b/internal/cli/exec_pty.go
@@ -163,7 +163,7 @@ func execPTYWithDeps(ctx context.Context, cfg *clientConfig, sessionID string, r
 				createReq := types.CreateSessionRequest{
 					ID:        sessionID,
 					Workspace: autoCreateRoot,
-					Home:      os.Getenv("HOME"),
+					Home:      userHomeDir(),
 				}
 				if req.NoDetectRoot {
 					falseVal := false

--- a/internal/cli/exec_pty.go
+++ b/internal/cli/exec_pty.go
@@ -163,6 +163,7 @@ func execPTYWithDeps(ctx context.Context, cfg *clientConfig, sessionID string, r
 				createReq := types.CreateSessionRequest{
 					ID:        sessionID,
 					Workspace: autoCreateRoot,
+					Home:      os.Getenv("HOME"),
 				}
 				if req.NoDetectRoot {
 					falseVal := false

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -91,3 +91,12 @@ func getenvDefault(k, def string) string {
 	}
 	return def
 }
+
+// userHomeDir returns the user's home directory, preferring os.UserHomeDir()
+// with a fallback to $HOME for platforms where it may be unset.
+func userHomeDir() string {
+	if h, err := os.UserHomeDir(); err == nil && h != "" {
+		return h
+	}
+	return os.Getenv("HOME")
+}

--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/agentsh/agentsh/internal/client"
@@ -42,7 +41,7 @@ func newSessionCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			req := types.CreateSessionRequest{Workspace: workspace, Policy: policy, Home: os.Getenv("HOME")}
+			req := types.CreateSessionRequest{Workspace: workspace, Policy: policy, Home: userHomeDir()}
 			if cmd.Flags().Changed("real-paths") {
 				req.RealPaths = &realPaths
 			}

--- a/internal/cli/session.go
+++ b/internal/cli/session.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/agentsh/agentsh/internal/client"
@@ -41,7 +42,7 @@ func newSessionCreateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			req := types.CreateSessionRequest{Workspace: workspace, Policy: policy}
+			req := types.CreateSessionRequest{Workspace: workspace, Policy: policy, Home: os.Getenv("HOME")}
 			if cmd.Flags().Changed("real-paths") {
 				req.RealPaths = &realPaths
 			}

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -101,7 +101,11 @@ func runWrap(ctx context.Context, cfg *clientConfig, opts wrapOptions) error {
 		workspaceMount = sess.WorkspaceMount
 		llmProxyURL = sess.LLMProxyURL
 	} else {
-		sess, err := c.CreateSession(ctx, workspace, opts.policy)
+		sess, err := c.CreateSessionWithRequest(ctx, types.CreateSessionRequest{
+			Workspace: workspace,
+			Policy:    opts.policy,
+			Home:      userHomeDir(),
+		})
 		if err != nil {
 			return fmt.Errorf("create session: %w", err)
 		}

--- a/internal/client/grpc_client.go
+++ b/internal/client/grpc_client.go
@@ -76,6 +76,9 @@ func (c *GRPCClient) CreateSessionWithRequest(ctx context.Context, req types.Cre
 	if req.ProjectRoot != "" {
 		reqBody["project_root"] = req.ProjectRoot
 	}
+	if req.Home != "" {
+		reqBody["home"] = req.Home
+	}
 	if req.RealPaths != nil {
 		reqBody["real_paths"] = *req.RealPaths
 	}

--- a/pkg/types/sessions.go
+++ b/pkg/types/sessions.go
@@ -110,6 +110,7 @@ type CreateSessionRequest struct {
 	Workspace         string `json:"workspace,omitempty"`
 	Policy            string `json:"policy,omitempty"`
 	Profile           string `json:"profile,omitempty"`
+	Home              string `json:"home,omitempty"`                 // User's home directory for ${HOME} policy expansion
 	DetectProjectRoot *bool  `json:"detect_project_root,omitempty"` // Override server default
 	ProjectRoot       string `json:"project_root,omitempty"`        // Explicit override
 	RealPaths         *bool  `json:"real_paths,omitempty"`          // Use actual host paths instead of /workspace


### PR DESCRIPTION
## Summary
- Adds `Home` field to `CreateSessionRequest` so the CLI sends the actual user's `$HOME` directory to the server
- Server prefers CLI-provided HOME over its own `os.Getenv("HOME")` when populating `policyVars` for `${HOME}` expansion in policy rules
- Fixes `${HOME}`-based deny rules (e.g., deny writes to `${HOME}/.bashrc`) not matching when the server runs as a different user (e.g., root on Runloop while the session user has `/home/user`)

## Test plan
- [ ] `go build ./...` and `GOOS=windows go build ./...` pass
- [ ] `go test ./...` passes
- [ ] Deploy to Runloop and verify deny rules for `${HOME}/.bashrc`, `${HOME}/.profile`, etc. now match correctly (target: 72/73 test cases passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)