### PR TITLE
fix: add /proc/<pid>/mem fallback for seccomp path resolution

### DIFF
--- a/internal/netmonitor/unix/execve_reader.go
+++ b/internal/netmonitor/unix/execve_reader.go
@@ -103,8 +103,8 @@ func readPointer(pid int, ptr uint64) (uint64, error) {
 	liov := unix.Iovec{Base: &buf[0], Len: 8}
 	riov := unix.RemoteIovec{Base: uintptr(ptr), Len: 8}
 
-	_, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
-	if err != nil {
+	n, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
+	if err != nil || n != 8 {
 		n, ferr := readProcMemStrict(pid, ptr, buf)
 		if ferr != nil {
 			return 0, fmt.Errorf("%w: process_vm_readv: %v, /proc/mem: %v", ErrReadMemory, err, ferr)

--- a/internal/netmonitor/unix/execve_reader.go
+++ b/internal/netmonitor/unix/execve_reader.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
 	"unsafe"
 
 	"golang.org/x/sys/unix"
@@ -61,6 +63,8 @@ func IsExecveSyscall(nr int32) bool {
 }
 
 // readString reads a null-terminated string from the tracee's memory.
+// Tries ProcessVMReadv first, then falls back to /proc/<pid>/mem pread
+// (which may succeed under different Yama ptrace_scope configurations).
 func readString(pid int, ptr uint64, maxLen int) (string, error) {
 	if ptr == 0 {
 		return "", ErrNullPtr
@@ -72,7 +76,13 @@ func readString(pid int, ptr uint64, maxLen int) (string, error) {
 
 	n, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
 	if err != nil {
-		return "", fmt.Errorf("%w: %v", ErrReadMemory, err)
+		// Fallback: read via /proc/<pid>/mem. This uses a different kernel
+		// permission check (PTRACE_MODE_ATTACH_FSCREDS vs _REALCREDS) and
+		// may succeed when ProcessVMReadv is blocked by Yama ptrace_scope.
+		n, err = readProcMem(pid, ptr, buf)
+		if err != nil {
+			return "", fmt.Errorf("%w: %v", ErrReadMemory, err)
+		}
 	}
 
 	// Find null terminator
@@ -95,9 +105,31 @@ func readPointer(pid int, ptr uint64) (uint64, error) {
 
 	_, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
 	if err != nil {
-		return 0, fmt.Errorf("%w: %v", ErrReadMemory, err)
+		if _, ferr := readProcMem(pid, ptr, buf); ferr != nil {
+			return 0, fmt.Errorf("%w: %v", ErrReadMemory, err)
+		}
 	}
 	return val, nil
+}
+
+// readProcMem reads from /proc/<pid>/mem at the given offset.
+// This is a fallback for ProcessVMReadv and uses a different kernel permission
+// path (PTRACE_MODE_ATTACH_FSCREDS) which may succeed under Yama ptrace_scope
+// configurations where ProcessVMReadv (PTRACE_MODE_ATTACH_REALCREDS) is blocked.
+func readProcMem(pid int, offset uint64, buf []byte) (int, error) {
+	f, err := os.Open(fmt.Sprintf("/proc/%d/mem", pid))
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	n, err := f.ReadAt(buf, int64(offset))
+	if err != nil && n > 0 {
+		// Partial read is OK — we got some data (common for reads near
+		// page boundaries or EOF). The caller finds the NUL terminator.
+		slog.Debug("readProcMem: partial read", "pid", pid, "offset", offset, "n", n, "err", err)
+		return n, nil
+	}
+	return n, err
 }
 
 // writeString writes a null-terminated string to the tracee's memory at the given address.

--- a/internal/netmonitor/unix/execve_reader.go
+++ b/internal/netmonitor/unix/execve_reader.go
@@ -105,17 +105,19 @@ func readPointer(pid int, ptr uint64) (uint64, error) {
 
 	_, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
 	if err != nil {
-		if _, ferr := readProcMem(pid, ptr, buf); ferr != nil {
-			return 0, fmt.Errorf("%w: %v", ErrReadMemory, err)
+		n, ferr := readProcMemStrict(pid, ptr, buf)
+		if ferr != nil {
+			return 0, fmt.Errorf("%w: process_vm_readv: %v, /proc/mem: %v", ErrReadMemory, err, ferr)
+		}
+		if n != 8 {
+			return 0, fmt.Errorf("%w: short read from /proc/mem (%d/8 bytes)", ErrReadMemory, n)
 		}
 	}
 	return val, nil
 }
 
 // readProcMem reads from /proc/<pid>/mem at the given offset.
-// This is a fallback for ProcessVMReadv and uses a different kernel permission
-// path (PTRACE_MODE_ATTACH_FSCREDS) which may succeed under Yama ptrace_scope
-// configurations where ProcessVMReadv (PTRACE_MODE_ATTACH_REALCREDS) is blocked.
+// Partial reads are accepted — callers reading strings find the NUL terminator.
 func readProcMem(pid int, offset uint64, buf []byte) (int, error) {
 	f, err := os.Open(fmt.Sprintf("/proc/%d/mem", pid))
 	if err != nil {
@@ -124,12 +126,22 @@ func readProcMem(pid int, offset uint64, buf []byte) (int, error) {
 	defer f.Close()
 	n, err := f.ReadAt(buf, int64(offset))
 	if err != nil && n > 0 {
-		// Partial read is OK — we got some data (common for reads near
-		// page boundaries or EOF). The caller finds the NUL terminator.
+		// Partial read is OK for strings — caller finds the NUL terminator.
 		slog.Debug("readProcMem: partial read", "pid", pid, "offset", offset, "n", n, "err", err)
 		return n, nil
 	}
 	return n, err
+}
+
+// readProcMemStrict reads from /proc/<pid>/mem requiring all bytes.
+// Used for fixed-size reads (pointers, structs) where partial reads are invalid.
+func readProcMemStrict(pid int, offset uint64, buf []byte) (int, error) {
+	f, err := os.Open(fmt.Sprintf("/proc/%d/mem", pid))
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	return f.ReadAt(buf, int64(offset))
 }
 
 // writeString writes a null-terminated string to the tracee's memory at the given address.

--- a/internal/netmonitor/unix/execve_reader_test.go
+++ b/internal/netmonitor/unix/execve_reader_test.go
@@ -178,3 +178,48 @@ func TestIsExecveSyscall(t *testing.T) {
 	assert.False(t, IsExecveSyscall(unix.SYS_CONNECT))
 	assert.False(t, IsExecveSyscall(unix.SYS_SOCKET))
 }
+
+func TestReadProcMem_String(t *testing.T) {
+	testStr := "/home/user/.bashrc"
+	strBytes := []byte(testStr + "\x00")
+	strPtr := uintptr(unsafe.Pointer(&strBytes[0]))
+
+	buf := make([]byte, 4096)
+	n, err := readProcMem(os.Getpid(), uint64(strPtr), buf)
+	require.NoError(t, err)
+	require.Greater(t, n, 0)
+
+	idx := 0
+	for idx < n && buf[idx] != 0 {
+		idx++
+	}
+	assert.Equal(t, testStr, string(buf[:idx]))
+}
+
+func TestReadProcMemStrict_Pointer(t *testing.T) {
+	var val uint64 = 0xDEADBEEFCAFE1234
+	buf := (*[8]byte)(unsafe.Pointer(&val))[:]
+	ptr := uintptr(unsafe.Pointer(&val))
+
+	out := make([]byte, 8)
+	n, err := readProcMemStrict(os.Getpid(), uint64(ptr), out)
+	require.NoError(t, err)
+	assert.Equal(t, 8, n)
+	assert.Equal(t, buf[:], out)
+}
+
+func TestReadProcMem_InvalidPID(t *testing.T) {
+	buf := make([]byte, 8)
+	_, err := readProcMem(999999999, 0x1000, buf)
+	require.Error(t, err)
+}
+
+func TestReadPointer_NullPtr(t *testing.T) {
+	_, err := readPointer(os.Getpid(), 0)
+	assert.ErrorIs(t, err, ErrNullPtr)
+}
+
+func TestReadString_NullPtr(t *testing.T) {
+	_, err := readString(os.Getpid(), 0, 4096)
+	assert.ErrorIs(t, err, ErrNullPtr)
+}


### PR DESCRIPTION
## Summary
- Adds `/proc/<pid>/mem` pread fallback to `readString` and `readPointer` in the seccomp file handler when `ProcessVMReadv` fails
- Matches the fallback pattern already used in `internal/ptrace/memory.go`
- `ProcessVMReadv` uses `PTRACE_MODE_ATTACH_REALCREDS`; `/proc/<pid>/mem` uses `PTRACE_MODE_ATTACH_FSCREDS` — different Yama ptrace_scope configurations may allow one but not the other
- Fallback is only tried on ProcessVMReadv failure, zero overhead on the normal path

## Context
On Runloop, writes to `${HOME}/.bashrc` bypass deny rules because `ProcessVMReadv` fails for the bash process, causing the handler to fall back to CONTINUE without evaluating policy. System paths like `/etc/hostname` are denied correctly. The `/proc/<pid>/mem` fallback provides an alternative memory read path that may succeed under the Runloop kernel/Yama configuration.

## Test plan
- [ ] `go build ./...` and `GOOS=windows go build ./...` pass
- [ ] `go test ./...` passes (all existing tests)
- [ ] Deploy to Runloop and verify `${HOME}/.bashrc` writes are now denied (target: 72/73)

🤖 Generated with [Claude Code](https://claude.com/claude-code)