### PR TITLE
fix: use /proc/mem fallback only for write path resolution

### DIFF
--- a/internal/netmonitor/unix/execve_reader.go
+++ b/internal/netmonitor/unix/execve_reader.go
@@ -123,9 +123,12 @@ func readPointer(pid int, ptr uint64) (uint64, error) {
 	liov := unix.Iovec{Base: &buf[0], Len: 8}
 	riov := unix.RemoteIovec{Base: uintptr(ptr), Len: 8}
 
-	_, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
+	n, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
 	if err != nil {
 		return 0, fmt.Errorf("%w: %v", ErrReadMemory, err)
+	}
+	if n != 8 {
+		return 0, fmt.Errorf("%w: short read (%d/8 bytes)", ErrReadMemory, n)
 	}
 	return val, nil
 }

--- a/internal/netmonitor/unix/execve_reader.go
+++ b/internal/netmonitor/unix/execve_reader.go
@@ -62,9 +62,8 @@ func IsExecveSyscall(nr int32) bool {
 	return nr == unix.SYS_EXECVE || nr == unix.SYS_EXECVEAT
 }
 
-// readString reads a null-terminated string from the tracee's memory.
-// Tries ProcessVMReadv first, then falls back to /proc/<pid>/mem pread
-// (which may succeed under different Yama ptrace_scope configurations).
+// readString reads a null-terminated string from the tracee's memory
+// using ProcessVMReadv. Returns ErrReadMemory if the read fails.
 func readString(pid int, ptr uint64, maxLen int) (string, error) {
 	if ptr == 0 {
 		return "", ErrNullPtr
@@ -76,9 +75,30 @@ func readString(pid int, ptr uint64, maxLen int) (string, error) {
 
 	n, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
 	if err != nil {
-		// Fallback: read via /proc/<pid>/mem. This uses a different kernel
-		// permission check (PTRACE_MODE_ATTACH_FSCREDS vs _REALCREDS) and
-		// may succeed when ProcessVMReadv is blocked by Yama ptrace_scope.
+		return "", fmt.Errorf("%w: %v", ErrReadMemory, err)
+	}
+
+	// Find null terminator
+	if idx := bytes.IndexByte(buf[:n], 0); idx >= 0 {
+		return string(buf[:idx]), nil
+	}
+	return string(buf[:n]), nil
+}
+
+// readStringWithFallback is like readString but falls back to /proc/<pid>/mem
+// when ProcessVMReadv fails. Use this only for write operations where failing
+// to resolve the path means deny rules cannot be evaluated.
+func readStringWithFallback(pid int, ptr uint64, maxLen int) (string, error) {
+	if ptr == 0 {
+		return "", ErrNullPtr
+	}
+
+	buf := make([]byte, maxLen)
+	liov := unix.Iovec{Base: &buf[0], Len: uint64(maxLen)}
+	riov := unix.RemoteIovec{Base: uintptr(ptr), Len: maxLen}
+
+	n, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
+	if err != nil {
 		n, err = readProcMem(pid, ptr, buf)
 		if err != nil {
 			return "", fmt.Errorf("%w: %v", ErrReadMemory, err)
@@ -103,15 +123,9 @@ func readPointer(pid int, ptr uint64) (uint64, error) {
 	liov := unix.Iovec{Base: &buf[0], Len: 8}
 	riov := unix.RemoteIovec{Base: uintptr(ptr), Len: 8}
 
-	n, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
-	if err != nil || n != 8 {
-		n, ferr := readProcMemStrict(pid, ptr, buf)
-		if ferr != nil {
-			return 0, fmt.Errorf("%w: process_vm_readv: %v, /proc/mem: %v", ErrReadMemory, err, ferr)
-		}
-		if n != 8 {
-			return 0, fmt.Errorf("%w: short read from /proc/mem (%d/8 bytes)", ErrReadMemory, n)
-		}
+	_, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %v", ErrReadMemory, err)
 	}
 	return val, nil
 }

--- a/internal/netmonitor/unix/execve_reader.go
+++ b/internal/netmonitor/unix/execve_reader.go
@@ -133,6 +133,32 @@ func readPointer(pid int, ptr uint64) (uint64, error) {
 	return val, nil
 }
 
+// readPointerWithFallback is like readPointer but falls back to /proc/<pid>/mem
+// when ProcessVMReadv fails. Use for execve argv parsing where failure means
+// denying legitimate exec calls.
+func readPointerWithFallback(pid int, ptr uint64) (uint64, error) {
+	if ptr == 0 {
+		return 0, ErrNullPtr
+	}
+
+	var val uint64
+	buf := (*[8]byte)(unsafe.Pointer(&val))[:]
+	liov := unix.Iovec{Base: &buf[0], Len: 8}
+	riov := unix.RemoteIovec{Base: uintptr(ptr), Len: 8}
+
+	n, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
+	if err != nil || n != 8 {
+		n, ferr := readProcMemStrict(pid, ptr, buf)
+		if ferr != nil {
+			return 0, fmt.Errorf("%w: process_vm_readv: %v, /proc/mem: %v", ErrReadMemory, err, ferr)
+		}
+		if n != 8 {
+			return 0, fmt.Errorf("%w: short read from /proc/mem (%d/8 bytes)", ErrReadMemory, n)
+		}
+	}
+	return val, nil
+}
+
 // readProcMem reads from /proc/<pid>/mem at the given offset.
 // Partial reads are accepted — callers reading strings find the NUL terminator.
 func readProcMem(pid int, offset uint64, buf []byte) (int, error) {
@@ -191,6 +217,20 @@ type ExecveReaderConfig struct {
 // ReadArgv reads the argv array from tracee memory.
 // Returns the arguments, whether truncation occurred, and any error.
 func ReadArgv(pid int, argvPtr uint64, cfg ExecveReaderConfig) ([]string, bool, error) {
+	return readArgvImpl(pid, argvPtr, cfg, readPointer, readString)
+}
+
+// ReadArgvWithFallback is like ReadArgv but uses /proc/<pid>/mem fallback
+// when ProcessVMReadv fails. Use for execve handling where failure means
+// denying legitimate exec calls.
+func ReadArgvWithFallback(pid int, argvPtr uint64, cfg ExecveReaderConfig) ([]string, bool, error) {
+	return readArgvImpl(pid, argvPtr, cfg, readPointerWithFallback, readStringWithFallback)
+}
+
+func readArgvImpl(pid int, argvPtr uint64, cfg ExecveReaderConfig,
+	ptrReader func(int, uint64) (uint64, error),
+	strReader func(int, uint64, int) (string, error),
+) ([]string, bool, error) {
 	if argvPtr == 0 {
 		return nil, false, ErrNullPtr
 	}
@@ -201,7 +241,7 @@ func ReadArgv(pid int, argvPtr uint64, cfg ExecveReaderConfig) ([]string, bool, 
 
 	for i := 0; i < cfg.MaxArgc; i++ {
 		// Read pointer at argvPtr + i*8
-		ptr, err := readPointer(pid, argvPtr+uint64(i*8))
+		ptr, err := ptrReader(pid, argvPtr+uint64(i*8))
 		if err != nil {
 			return args, truncated, err
 		}
@@ -217,7 +257,7 @@ func ReadArgv(pid int, argvPtr uint64, cfg ExecveReaderConfig) ([]string, bool, 
 			break
 		}
 
-		arg, err := readString(pid, ptr, remaining)
+		arg, err := strReader(pid, ptr, remaining)
 		if err != nil {
 			return args, truncated, err
 		}
@@ -234,7 +274,7 @@ func ReadArgv(pid int, argvPtr uint64, cfg ExecveReaderConfig) ([]string, bool, 
 	// Check if we hit MaxArgc limit
 	if len(args) >= cfg.MaxArgc {
 		// Check if there are more args
-		ptr, _ := readPointer(pid, argvPtr+uint64(cfg.MaxArgc*8))
+		ptr, _ := ptrReader(pid, argvPtr+uint64(cfg.MaxArgc*8))
 		if ptr != 0 {
 			truncated = true
 		}

--- a/internal/netmonitor/unix/file_syscalls.go
+++ b/internal/netmonitor/unix/file_syscalls.go
@@ -233,9 +233,12 @@ func readOpenHow(pid int, howPtr uint64) (flags uint64, mode uint64, err error) 
 	liov := unix.Iovec{Base: &buf[0], Len: 24}
 	riov := unix.RemoteIovec{Base: uintptr(howPtr), Len: 24}
 
-	_, err = unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
-	if err != nil {
-		return 0, 0, fmt.Errorf("%w: open_how: %v", ErrReadMemory, err)
+	n, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
+	if err != nil || n != 24 {
+		if err != nil {
+			return 0, 0, fmt.Errorf("%w: open_how: %v", ErrReadMemory, err)
+		}
+		return 0, 0, fmt.Errorf("%w: open_how: short read (%d/24 bytes)", ErrReadMemory, n)
 	}
 
 	// Parse little-endian uint64s
@@ -256,8 +259,8 @@ func readOpenHowWithFallback(pid int, howPtr uint64) (flags uint64, mode uint64,
 	liov := unix.Iovec{Base: &buf[0], Len: 24}
 	riov := unix.RemoteIovec{Base: uintptr(howPtr), Len: 24}
 
-	_, err = unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
-	if err != nil {
+	n, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
+	if err != nil || n != 24 {
 		n, ferr := readProcMemStrict(pid, howPtr, buf[:])
 		if ferr != nil || n != 24 {
 			return 0, 0, fmt.Errorf("%w: open_how: process_vm_readv: %v, /proc/mem: %v", ErrReadMemory, err, ferr)

--- a/internal/netmonitor/unix/file_syscalls.go
+++ b/internal/netmonitor/unix/file_syscalls.go
@@ -62,6 +62,27 @@ func isReadOnlyOpen(flags uint32) bool {
 	return flags&openatWriteMask == 0
 }
 
+// isReadOnlyFileOp returns true if the syscall+flags combination represents
+// a read-only file operation. For open-family syscalls this checks the open
+// flags; for non-open syscalls it checks whether the syscall itself is
+// inherently read-only (stat, access, readlink) vs mutating.
+func isReadOnlyFileOp(nr int32, flags uint32) bool {
+	switch nr {
+	case unix.SYS_OPENAT, unix.SYS_OPENAT2:
+		return isReadOnlyOpen(flags)
+	case unix.SYS_STATX, unix.SYS_NEWFSTATAT, unix.SYS_FACCESSAT2, unix.SYS_READLINKAT:
+		return true
+	default:
+		if isLegacyOpenSyscallNr(nr) {
+			return isReadOnlyOpen(flags)
+		}
+		// All other file syscalls (unlinkat, mkdirat, renameat2, linkat,
+		// symlinkat, fchmodat, fchownat, mknodat, and legacy equivalents)
+		// are mutating operations.
+		return false
+	}
+}
+
 // shouldFallbackToContinue returns true when an open-family syscall should
 // use CONTINUE instead of AddFD emulation. openat2 is ALWAYS routed to
 // CONTINUE because its extended semantics (RESOLVE_* flags, how_size

--- a/internal/netmonitor/unix/file_syscalls.go
+++ b/internal/netmonitor/unix/file_syscalls.go
@@ -244,6 +244,31 @@ func readOpenHow(pid int, howPtr uint64) (flags uint64, mode uint64, err error) 
 	return flags, mode, nil
 }
 
+// readOpenHowWithFallback is like readOpenHow but falls back to /proc/<pid>/mem
+// when ProcessVMReadv fails. Use when openat2 flag parsing must succeed to
+// evaluate file policy (deny rules cannot be checked without knowing the flags).
+func readOpenHowWithFallback(pid int, howPtr uint64) (flags uint64, mode uint64, err error) {
+	if howPtr == 0 {
+		return 0, 0, ErrNullPtr
+	}
+
+	var buf [24]byte
+	liov := unix.Iovec{Base: &buf[0], Len: 24}
+	riov := unix.RemoteIovec{Base: uintptr(howPtr), Len: 24}
+
+	_, err = unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
+	if err != nil {
+		n, ferr := readProcMemStrict(pid, howPtr, buf[:])
+		if ferr != nil || n != 24 {
+			return 0, 0, fmt.Errorf("%w: open_how: process_vm_readv: %v, /proc/mem: %v", ErrReadMemory, err, ferr)
+		}
+	}
+
+	flags = *(*uint64)(unsafe.Pointer(&buf[0]))
+	mode = *(*uint64)(unsafe.Pointer(&buf[8]))
+	return flags, mode, nil
+}
+
 // readOpenHowResolve reads only the resolve field (offset 16) from the
 // openat2 open_how struct in tracee memory. Returns the resolve flags and
 // an error. On error, the caller must force CONTINUE fallback — never

--- a/internal/netmonitor/unix/file_syscalls.go
+++ b/internal/netmonitor/unix/file_syscalls.go
@@ -327,7 +327,24 @@ func fileSyscallName(nr int32) string {
 //   - /proc/<pid>/cwd when dirfd == AT_FDCWD (-100)
 //   - /proc/<pid>/fd/<dirfd> otherwise
 func resolvePathAt(pid int, dirfd int32, pathPtr uint64) (string, error) {
-	path, err := readString(pid, pathPtr, 4096)
+	return resolvePathAtImpl(pid, dirfd, pathPtr, false)
+}
+
+// resolvePathAtWithFallback is like resolvePathAt but uses /proc/<pid>/mem
+// as a fallback when ProcessVMReadv fails. Use this only for write operations
+// where the path must be resolved to evaluate deny rules.
+func resolvePathAtWithFallback(pid int, dirfd int32, pathPtr uint64) (string, error) {
+	return resolvePathAtImpl(pid, dirfd, pathPtr, true)
+}
+
+func resolvePathAtImpl(pid int, dirfd int32, pathPtr uint64, useFallback bool) (string, error) {
+	var path string
+	var err error
+	if useFallback {
+		path, err = readStringWithFallback(pid, pathPtr, 4096)
+	} else {
+		path, err = readString(pid, pathPtr, 4096)
+	}
 	if err != nil {
 		return "", fmt.Errorf("read path from tracee: %w", err)
 	}

--- a/internal/netmonitor/unix/file_syscalls_legacy_test.go
+++ b/internal/netmonitor/unix/file_syscalls_legacy_test.go
@@ -241,3 +241,34 @@ func TestLegacyFileSyscallList(t *testing.T) {
 		assert.True(t, isFileSyscall(nr), "syscall %d from list not recognized by isFileSyscall", nr)
 	}
 }
+
+func TestIsReadOnlyFileOp_Legacy(t *testing.T) {
+	tests := []struct {
+		name     string
+		nr       int32
+		flags    uint32
+		expected bool
+	}{
+		// Legacy open: delegates to isReadOnlyOpen via isLegacyOpenSyscallNr
+		{"open O_RDONLY", unix.SYS_OPEN, unix.O_RDONLY, true},
+		{"open O_WRONLY", unix.SYS_OPEN, unix.O_WRONLY, false},
+		{"open O_CREAT", unix.SYS_OPEN, unix.O_RDONLY | unix.O_CREAT, false},
+		{"creat (implicit write flags)", unix.SYS_CREAT, unix.O_WRONLY | unix.O_CREAT | unix.O_TRUNC, false},
+
+		// Legacy mutating syscalls (flags=0, still mutating)
+		{"mkdir", unix.SYS_MKDIR, 0, false},
+		{"rmdir", unix.SYS_RMDIR, 0, false},
+		{"unlink", unix.SYS_UNLINK, 0, false},
+		{"rename", unix.SYS_RENAME, 0, false},
+		{"link", unix.SYS_LINK, 0, false},
+		{"symlink", unix.SYS_SYMLINK, 0, false},
+		{"chmod", unix.SYS_CHMOD, 0, false},
+		{"chown", unix.SYS_CHOWN, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isReadOnlyFileOp(tt.nr, tt.flags),
+				"nr=%d flags=0x%x", tt.nr, tt.flags)
+		})
+	}
+}

--- a/internal/netmonitor/unix/file_syscalls_test.go
+++ b/internal/netmonitor/unix/file_syscalls_test.go
@@ -541,3 +541,42 @@ func TestIsReadOnlyOpen(t *testing.T) {
 		})
 	}
 }
+
+func TestIsReadOnlyFileOp(t *testing.T) {
+	tests := []struct {
+		name     string
+		nr       int32
+		flags    uint32
+		expected bool
+	}{
+		// Open-family: delegates to isReadOnlyOpen
+		{"openat O_RDONLY", unix.SYS_OPENAT, unix.O_RDONLY, true},
+		{"openat O_WRONLY", unix.SYS_OPENAT, unix.O_WRONLY, false},
+		{"openat O_CREAT", unix.SYS_OPENAT, unix.O_RDONLY | unix.O_CREAT, false},
+		{"openat2 O_RDONLY", unix.SYS_OPENAT2, unix.O_RDONLY, true},
+		{"openat2 O_RDWR", unix.SYS_OPENAT2, unix.O_RDWR, false},
+
+		// Read-only metadata syscalls
+		{"statx", unix.SYS_STATX, 0, true},
+		{"newfstatat", unix.SYS_NEWFSTATAT, 0, true},
+		{"faccessat2", unix.SYS_FACCESSAT2, 0, true},
+		{"readlinkat", unix.SYS_READLINKAT, 0, true},
+
+		// Mutating syscalls (flags=0, still mutating)
+		{"unlinkat", unix.SYS_UNLINKAT, 0, false},
+		{"unlinkat AT_REMOVEDIR", unix.SYS_UNLINKAT, unix.AT_REMOVEDIR, false},
+		{"mkdirat", unix.SYS_MKDIRAT, 0, false},
+		{"renameat2", unix.SYS_RENAMEAT2, 0, false},
+		{"linkat", unix.SYS_LINKAT, 0, false},
+		{"symlinkat", unix.SYS_SYMLINKAT, 0, false},
+		{"fchmodat", unix.SYS_FCHMODAT, 0, false},
+		{"fchownat", unix.SYS_FCHOWNAT, 0, false},
+		{"mknodat", unix.SYS_MKNODAT, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, isReadOnlyFileOp(tt.nr, tt.flags),
+				"nr=%d flags=0x%x", tt.nr, tt.flags)
+		})
+	}
+}

--- a/internal/netmonitor/unix/handler.go
+++ b/internal/netmonitor/unix/handler.go
@@ -516,21 +516,19 @@ func handleFileNotificationEmulated(goCtx context.Context, fd seccomp.ScmpFd, re
 	forceContinue := !isOpenSyscall(args.Nr) || shouldFallbackToContinue(args.Nr, fileArgs.Flags, resolveFlags)
 
 	// Resolve primary path.
-	// Fall back to CONTINUE on resolution failure for ALL operations (reads
-	// AND writes). Path resolution fails when the supervisor cannot read
-	// tracee memory — e.g., Yama ptrace_scope=1 blocks ProcessVMReadv for
-	// child processes in the `agentsh wrap` path because PR_SET_PTRACER
-	// does not inherit across fork(). When we can't resolve the path we
-	// also can't evaluate policy (neither allow NOR deny rules), so the
-	// only consistent choice is to let the kernel handle the syscall.
+	// Path resolution uses ProcessVMReadv which may fail under Yama
+	// ptrace_scope=1 for child processes in the `agentsh wrap` path
+	// (PR_SET_PTRACER does not inherit across fork()).
 	//
-	// NOTE: this IS an intentional tradeoff. Emulation mode is enabled when
-	// seccomp-notify is the sole enforcement backend, so falling back to
-	// CONTINUE means no file policy enforcement for affected operations.
-	// The alternative — denying ALL writes from ALL child processes — makes
-	// the sandboxed environment completely unusable (can't write to /tmp,
-	// workspace, /dev/null, etc.). A working environment with degraded
-	// monitoring is strictly better than a non-functional one.
+	// For mutating operations (writes, deletes, mkdir, etc.), we retry
+	// with /proc/<pid>/mem which uses PTRACE_MODE_ATTACH_FSCREDS and may
+	// succeed where ProcessVMReadv (PTRACE_MODE_ATTACH_REALCREDS) fails.
+	// This ensures deny rules are evaluated for writes even under Yama.
+	//
+	// For read-only operations (open O_RDONLY, stat, access, readlink),
+	// resolution failure falls back to CONTINUE — the kernel handles the
+	// syscall without policy evaluation. This is safe because reads cannot
+	// mutate the filesystem.
 	path, err := resolvePathAt(pid, fileArgs.Dirfd, fileArgs.PathPtr)
 	if err != nil {
 		// For writes, retry with /proc/<pid>/mem fallback — deny rules

--- a/internal/netmonitor/unix/handler.go
+++ b/internal/netmonitor/unix/handler.go
@@ -287,7 +287,7 @@ func handleExecveNotification(goCtx context.Context, fd seccomp.ScmpFd, req *sec
 		MaxArgvBytes: h.cfg.MaxArgvBytes,
 	}
 
-	filename, err := readString(pid, execveArgs.FilenamePtr, 4096)
+	filename, err := readStringWithFallback(pid, execveArgs.FilenamePtr, 4096)
 	if err != nil {
 		const AT_EMPTY_PATH = 0x1000
 		// For execve, always fail-secure if we can't read the filename
@@ -327,7 +327,7 @@ func handleExecveNotification(goCtx context.Context, fd seccomp.ScmpFd, req *sec
 	}
 	// rawFilename preserved for audit; filename is now canonical
 
-	argv, truncated, err := ReadArgv(pid, execveArgs.ArgvPtr, cfg)
+	argv, truncated, err := ReadArgvWithFallback(pid, execveArgs.ArgvPtr, cfg)
 	if err != nil {
 		// Can't read argv - deny (fail-secure)
 		if err := NotifRespondDeny(int(fd), req.ID, int32(unix.EACCES)); err != nil {

--- a/internal/netmonitor/unix/handler.go
+++ b/internal/netmonitor/unix/handler.go
@@ -419,20 +419,29 @@ func handleFileNotification(goCtx context.Context, fd seccomp.ScmpFd, req *secco
 		fileArgs.Mode = uint32(howMode)
 	}
 
-	// Resolve primary path
+	// Resolve primary path. For mutating operations, retry with /proc/<pid>/mem
+	// fallback when ProcessVMReadv fails (Yama ptrace_scope).
 	path, err := resolvePathAt(pid, fileArgs.Dirfd, fileArgs.PathPtr)
 	if err != nil {
-		slog.Debug("file handler: failed to resolve path, allowing", "pid", pid, "error", err)
-		if err := NotifRespondContinue(int(fd), req.ID); err != nil {
-			slog.Debug("file handler: continue response failed", "pid", pid, "error", err)
+		if !isReadOnlyFileOp(args.Nr, fileArgs.Flags) {
+			path, err = resolvePathAtWithFallback(pid, fileArgs.Dirfd, fileArgs.PathPtr)
 		}
-		return
+		if err != nil {
+			slog.Debug("file handler: failed to resolve path, allowing", "pid", pid, "error", err)
+			if err := NotifRespondContinue(int(fd), req.ID); err != nil {
+				slog.Debug("file handler: continue response failed", "pid", pid, "error", err)
+			}
+			return
+		}
 	}
 
 	// Resolve second path for rename/link
 	var path2 string
 	if fileArgs.HasSecondPath {
 		p2, err := resolvePathAt(pid, fileArgs.Dirfd2, fileArgs.PathPtr2)
+		if err != nil {
+			p2, err = resolvePathAtWithFallback(pid, fileArgs.Dirfd2, fileArgs.PathPtr2)
+		}
 		if err != nil {
 			slog.Debug("file handler: failed to resolve second path, allowing", "pid", pid, "error", err)
 			if err := NotifRespondContinue(int(fd), req.ID); err != nil {

--- a/internal/netmonitor/unix/handler.go
+++ b/internal/netmonitor/unix/handler.go
@@ -533,23 +533,34 @@ func handleFileNotificationEmulated(goCtx context.Context, fd seccomp.ScmpFd, re
 	// monitoring is strictly better than a non-functional one.
 	path, err := resolvePathAt(pid, fileArgs.Dirfd, fileArgs.PathPtr)
 	if err != nil {
+		// For writes, retry with /proc/<pid>/mem fallback — deny rules
+		// must be evaluated even when ProcessVMReadv is blocked by Yama.
 		if !isReadOnlyOpen(fileArgs.Flags) {
-			slog.Warn("emulated file handler: path resolution failed for write, file policy not enforced",
-				"pid", pid, "error", err, "session_id", sessID)
-		} else {
-			slog.Debug("emulated file handler: path resolution failed for read, falling back to CONTINUE",
-				"pid", pid, "error", err)
+			path, err = resolvePathAtWithFallback(pid, fileArgs.Dirfd, fileArgs.PathPtr)
 		}
-		if err := NotifRespondContinue(int(fd), req.ID); err != nil {
-			slog.Debug("emulated file handler: continue response failed", "pid", pid, "error", err)
+		if err != nil {
+			if !isReadOnlyOpen(fileArgs.Flags) {
+				slog.Warn("emulated file handler: path resolution failed for write, file policy not enforced",
+					"pid", pid, "error", err, "session_id", sessID)
+			} else {
+				slog.Debug("emulated file handler: path resolution failed for read, falling back to CONTINUE",
+					"pid", pid, "error", err)
+			}
+			if err := NotifRespondContinue(int(fd), req.ID); err != nil {
+				slog.Debug("emulated file handler: continue response failed", "pid", pid, "error", err)
+			}
+			return
 		}
-		return
 	}
 
 	// Resolve second path for rename/link.
 	var path2 string
 	if fileArgs.HasSecondPath {
 		p2, err := resolvePathAt(pid, fileArgs.Dirfd2, fileArgs.PathPtr2)
+		if err != nil {
+			// Rename/link are always mutating — retry with fallback.
+			p2, err = resolvePathAtWithFallback(pid, fileArgs.Dirfd2, fileArgs.PathPtr2)
+		}
 		if err != nil {
 			slog.Warn("emulated file handler: second path resolution failed for mutating op, file policy not enforced",
 				"pid", pid, "error", err, "syscall", args.Nr, "session_id", sessID)

--- a/internal/netmonitor/unix/handler.go
+++ b/internal/netmonitor/unix/handler.go
@@ -407,7 +407,7 @@ func handleFileNotification(goCtx context.Context, fd seccomp.ScmpFd, req *secco
 
 	// For openat2, resolve actual flags from the open_how struct in tracee memory.
 	if args.Nr == unix.SYS_OPENAT2 && fileArgs.HowPtr != 0 {
-		howFlags, howMode, err := readOpenHow(pid, fileArgs.HowPtr)
+		howFlags, howMode, err := readOpenHowWithFallback(pid, fileArgs.HowPtr)
 		if err != nil {
 			slog.Debug("file handler: failed to read open_how, allowing", "pid", pid, "error", err)
 			if err := NotifRespondContinue(int(fd), req.ID); err != nil {
@@ -508,7 +508,7 @@ func handleFileNotificationEmulated(goCtx context.Context, fd seccomp.ScmpFd, re
 			}
 			return
 		}
-		howFlags, howMode, err := readOpenHow(pid, fileArgs.HowPtr)
+		howFlags, howMode, err := readOpenHowWithFallback(pid, fileArgs.HowPtr)
 		if err != nil {
 			slog.Debug("emulated file handler: failed to read open_how, CONTINUE", "pid", pid, "error", err)
 			if err := NotifRespondContinue(int(fd), req.ID); err != nil {

--- a/internal/netmonitor/unix/handler.go
+++ b/internal/netmonitor/unix/handler.go
@@ -535,11 +535,11 @@ func handleFileNotificationEmulated(goCtx context.Context, fd seccomp.ScmpFd, re
 	if err != nil {
 		// For writes, retry with /proc/<pid>/mem fallback — deny rules
 		// must be evaluated even when ProcessVMReadv is blocked by Yama.
-		if !isReadOnlyOpen(fileArgs.Flags) {
+		if !isReadOnlyFileOp(args.Nr, fileArgs.Flags) {
 			path, err = resolvePathAtWithFallback(pid, fileArgs.Dirfd, fileArgs.PathPtr)
 		}
 		if err != nil {
-			if !isReadOnlyOpen(fileArgs.Flags) {
+			if !isReadOnlyFileOp(args.Nr, fileArgs.Flags) {
 				slog.Warn("emulated file handler: path resolution failed for write, file policy not enforced",
 					"pid", pid, "error", err, "session_id", sessID)
 			} else {


### PR DESCRIPTION
## Summary

- Fixes regression from #174 where `/proc/<pid>/mem` fallback resolved paths for ALL opens, causing read operations to hit policy evaluation and get denied (score dropped from 70/73 to 42/73)
- Splits `readString` into `readString` (ProcessVMReadv only, for reads) and `readStringWithFallback` (with `/proc/mem` fallback, for writes only)
- Handler now retries with fallback only for write operations; reads fall back to CONTINUE as before #174

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/netmonitor/unix/...` passes
- [ ] `GOOS=windows go build ./...` passes
- [ ] Deploy to Runloop and verify score returns to 73/73

🤖 Generated with [Claude Code](https://claude.com/claude-code)