### PR TITLE
fix: build envshim from shim/linux (policy-based filtering)

### DIFF
--- a/scripts/build-envshim.sh
+++ b/scripts/build-envshim.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 OUT="$ROOT/build/envshim"
-SRC="$ROOT/internal/policy/envshim"
+SRC="$ROOT/shim/linux"
 
 build_one() {
   arch="$1"

--- a/shim/linux/Makefile
+++ b/shim/linux/Makefile
@@ -2,10 +2,10 @@
 # Build the environment variable interception shim for Linux
 
 CC ?= gcc
-CFLAGS = -shared -fPIC -Wall -Wextra -O2 -D_GNU_SOURCE
+CFLAGS = -shared -fPIC -Wall -Wextra -O2
 LDFLAGS = -ldl -lpthread
 
-TARGET = libenvshim.so
+TARGET ?= libenvshim.so
 SRC = envshim.c
 
 .PHONY: all clean install test


### PR DESCRIPTION
## Summary

- The build script (`scripts/build-envshim.sh`) compiled from `internal/policy/envshim/envshim.c` which replaces `environ` with an empty array when `block_iteration` is enabled — this breaks ALL `getenv()` calls (PATH, HOME, etc.), not just iteration
- Switches to `shim/linux/envshim.c` which properly intercepts individual `getenv()` with per-variable allow/deny policy
- Fixes `shim/linux/Makefile` to accept `TARGET` override from build script (`?=` instead of `=`)

## Test plan

- [ ] `scripts/build-envshim.sh` builds successfully
- [ ] Built `libenvshim.so` exports correct symbols (getenv, secure_getenv, setenv, putenv, unsetenv)
- [ ] Smoke test: `LD_PRELOAD=libenvshim.so` with blocklist policy blocks SECRET_* but allows PATH/HOME

🤖 Generated with [Claude Code](https://claude.com/claude-code)