### PR TITLE
fix: implement real seccomp probes and always render flat capabilities

### DIFF
--- a/internal/capabilities/check.go
+++ b/internal/capabilities/check.go
@@ -33,13 +33,13 @@ var (
 	checkWrapperBinary     = realCheckWrapperBinary
 )
 
-// Stub implementations - real implementations will be in separate files.
-
 func realCheckSeccompUserNotify() CheckResult {
-	return CheckResult{
-		Feature:   "seccomp-user-notify",
-		Available: true,
+	probe := probeSeccompUserNotify()
+	r := CheckResult{Feature: "seccomp-user-notify", Available: probe.Available}
+	if !probe.Available {
+		r.Error = fmt.Errorf("kernel does not support SECCOMP_RET_USER_NOTIF: %s", probe.Detail)
 	}
+	return r
 }
 
 func realCheckPtrace() CheckResult {

--- a/internal/capabilities/check_seccomp_linux.go
+++ b/internal/capabilities/check_seccomp_linux.go
@@ -1,0 +1,66 @@
+//go:build linux
+
+package capabilities
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// probeSeccompBasic checks whether the seccomp() syscall supports BPF filtering
+// by querying SECCOMP_GET_ACTION_AVAIL for SECCOMP_RET_KILL_PROCESS.
+// This is a read-only probe — no filter is installed.
+func probeSeccompBasic() ProbeResult {
+	action := uint32(unix.SECCOMP_RET_KILL_PROCESS)
+	_, _, errno := unix.Syscall(
+		unix.SYS_SECCOMP,
+		unix.SECCOMP_GET_ACTION_AVAIL, // op = 2
+		0,
+		uintptr(unsafe.Pointer(&action)),
+	)
+	switch errno {
+	case 0:
+		return ProbeResult{Available: true, Detail: "seccomp-bpf"}
+	case unix.ENOSYS:
+		return ProbeResult{Available: false, Detail: "ENOSYS (seccomp syscall not available)"}
+	case unix.EPERM:
+		// Seccomp syscall exists but is blocked (e.g. by outer seccomp filter).
+		// The kernel supports it; the runtime blocks it.
+		return ProbeResult{Available: false, Detail: "EPERM (seccomp blocked by runtime)"}
+	default:
+		return ProbeResult{Available: false, Detail: fmt.Sprintf("%s (errno %d)", errno, errno)}
+	}
+}
+
+// seccompNotifSizes mirrors struct seccomp_notif_sizes from <linux/seccomp.h>.
+type seccompNotifSizes struct {
+	Notif     uint16
+	NotifResp uint16
+	Data      uint16
+}
+
+// probeSeccompUserNotify checks whether the kernel supports seccomp user-notify
+// by calling seccomp(SECCOMP_GET_NOTIF_SIZES). This is a read-only probe.
+func probeSeccompUserNotify() ProbeResult {
+	var sizes seccompNotifSizes
+	_, _, errno := unix.Syscall(
+		unix.SYS_SECCOMP,
+		unix.SECCOMP_GET_NOTIF_SIZES, // op = 3
+		0,
+		uintptr(unsafe.Pointer(&sizes)),
+	)
+	switch errno {
+	case 0:
+		return ProbeResult{Available: true, Detail: "user-notify"}
+	case unix.ENOSYS:
+		return ProbeResult{Available: false, Detail: "ENOSYS (seccomp syscall not available)"}
+	case unix.EINVAL:
+		return ProbeResult{Available: false, Detail: "EINVAL (user-notify not supported, kernel < 5.0)"}
+	case unix.EPERM:
+		return ProbeResult{Available: false, Detail: "EPERM (seccomp blocked by runtime)"}
+	default:
+		return ProbeResult{Available: false, Detail: fmt.Sprintf("%s (errno %d)", errno, errno)}
+	}
+}

--- a/internal/capabilities/check_seccomp_linux_test.go
+++ b/internal/capabilities/check_seccomp_linux_test.go
@@ -1,0 +1,48 @@
+//go:build linux
+
+package capabilities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProbeSeccompBasic(t *testing.T) {
+	result := probeSeccompBasic()
+	assert.NotEmpty(t, result.Detail, "probe should always return a detail string")
+	// On a modern Linux kernel, basic seccomp should be available.
+	// If this test runs on a system where seccomp is blocked, it's OK to fail.
+	t.Logf("seccomp basic: available=%v detail=%q", result.Available, result.Detail)
+}
+
+func TestProbeSeccompUserNotify(t *testing.T) {
+	result := probeSeccompUserNotify()
+	assert.NotEmpty(t, result.Detail, "probe should always return a detail string")
+	t.Logf("seccomp user-notify: available=%v detail=%q", result.Available, result.Detail)
+}
+
+func TestCheckSeccompBasicIndependent(t *testing.T) {
+	// checkSeccompBasic should use probeSeccompBasic, not delegate to checkSeccompUserNotify.
+	// Verify they can return different results by checking they call different probes.
+	basic := probeSeccompBasic()
+	notify := probeSeccompUserNotify()
+	t.Logf("basic=%v notify=%v", basic.Available, notify.Available)
+	// On a kernel with user-notify, both should be true.
+	// On a kernel without user-notify, basic could be true while notify is false.
+	if notify.Available {
+		assert.True(t, basic.Available, "if user-notify is available, basic must also be available")
+	}
+}
+
+func TestRealCheckSeccompUserNotify(t *testing.T) {
+	result := realCheckSeccompUserNotify()
+	assert.Equal(t, "seccomp-user-notify", result.Feature)
+	if result.Available {
+		assert.Nil(t, result.Error)
+	} else {
+		assert.NotNil(t, result.Error)
+		assert.Contains(t, result.Error.Error(), "SECCOMP_RET_USER_NOTIF")
+	}
+	t.Logf("realCheckSeccompUserNotify: available=%v err=%v", result.Available, result.Error)
+}

--- a/internal/capabilities/detect_result.go
+++ b/internal/capabilities/detect_result.go
@@ -130,10 +130,11 @@ func (r *DetectResult) Table() string {
 			}
 			sb.WriteString("\n")
 		}
-	} else {
-		// Fallback: flat capabilities (backward compat for platforms not yet converted)
+	}
+
+	// Always render flat capabilities for scripting/grep compatibility.
+	if len(r.Capabilities) > 0 {
 		sb.WriteString("CAPABILITIES\n")
-		sb.WriteString(strings.Repeat("-", 40) + "\n")
 		keys := make([]string, 0, len(r.Capabilities))
 		for k := range r.Capabilities {
 			keys = append(keys, k)

--- a/internal/capabilities/security_caps.go
+++ b/internal/capabilities/security_caps.go
@@ -101,9 +101,7 @@ func (c *SecurityCapabilities) SelectMode() string {
 
 // checkSeccompBasic checks if basic seccomp-bpf is available (without user-notify).
 func checkSeccompBasic() bool {
-	// For now, assume basic seccomp is available if full seccomp is available
-	// A more thorough check could probe for SECCOMP_SET_MODE_FILTER
-	return checkSeccompUserNotify().Available
+	return probeSeccompBasic().Available
 }
 
 func checkFUSE() bool {


### PR DESCRIPTION
## Summary
- Always render flat CAPABILITIES section in `agentsh detect` table output (alongside domain-grouped view), so scripts/tests that grep for keys like `seccomp`, `cgroups_v2`, `ebpf` work correctly
- Replace `checkSeccompUserNotify()` stub (always returned true) with real `seccomp(SECCOMP_GET_NOTIF_SIZES)` probe
- Replace `checkSeccompBasic()` delegation to user-notify with independent `seccomp(SECCOMP_GET_ACTION_AVAIL)` probe — can now correctly differentiate basic seccomp-bpf from user-notify support

## Context
E2B sandbox tests grep for flat capability keys in `agentsh detect` output. The table format only rendered the domain-grouped view, hiding the flat keys. Additionally, the seccomp probes were stubs that always reported available, masking actual kernel capabilities.

## Test plan
- [ ] `go test ./internal/capabilities/...` passes
- [ ] `go build ./...` succeeds
- [ ] `GOOS=windows go build ./...` cross-compiles
- [ ] New `TestProbeSeccompBasic`, `TestProbeSeccompUserNotify`, `TestCheckSeccompBasicIndependent`, `TestRealCheckSeccompUserNotify` tests validate probe behavior
- [ ] Verify E2B sandbox `agentsh detect` output includes flat CAPABILITIES section

🤖 Generated with [Claude Code](https://claude.com/claude-code)