### PR TITLE
fix: stop injecting AGENTSH_ENV_BLOCK_ITERATION=1

### DIFF
--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -671,22 +671,26 @@ func mapToEnvSlice(m map[string]string) []string {
 	return out
 }
 
-// maybeAddShimEnv injects the env-iteration blocking shim (LD_PRELOAD) and flag
-// when block_iteration is enabled. It tolerates missing/invalid shim path to
+// maybeAddShimEnv injects the env policy shim (LD_PRELOAD) for getenv
+// interception and logging. It tolerates missing/invalid shim path to
 // avoid breaking command execution, but emits a warning.
+//
+// Note: AGENTSH_ENV_BLOCK_ITERATION is intentionally NOT set. Replacing
+// environ with an empty array is incompatible with shells (bash reads
+// environ directly during startup, not via getenv). Server-side
+// buildPolicyEnv filtering is the real security boundary.
 func maybeAddShimEnv(env []string, pol policy.ResolvedEnvPolicy, cfg *config.Config) []string {
 	_ = pol
 	out := append([]string{}, env...)
-	out = append(out, "AGENTSH_ENV_BLOCK_ITERATION=1")
 
 	shim := strings.TrimSpace(cfg.Policies.EnvShimPath)
 	if shim == "" {
-		slog.Warn("block_iteration enabled but policies.env_shim_path is not set")
+		slog.Warn("env shim enabled but policies.env_shim_path is not set")
 		return out
 	}
 	info, err := os.Stat(shim)
 	if err != nil || info.IsDir() {
-		slog.Warn("block_iteration enabled but env shim missing", "path", shim, "err", err)
+		slog.Warn("env shim enabled but shim binary missing", "path", shim, "err", err)
 		return out
 	}
 

--- a/internal/api/exec_env_test.go
+++ b/internal/api/exec_env_test.go
@@ -113,8 +113,9 @@ func TestMaybeAddShimEnv_AddsShimAndFlag(t *testing.T) {
 	out := maybeAddShimEnv(in, policy.ResolvedEnvPolicy{BlockIteration: true}, cfg)
 	m := envSliceToMap(out)
 
-	if m["AGENTSH_ENV_BLOCK_ITERATION"] != "1" {
-		t.Fatalf("expected AGENTSH_ENV_BLOCK_ITERATION=1, got %q", m["AGENTSH_ENV_BLOCK_ITERATION"])
+	// AGENTSH_ENV_BLOCK_ITERATION should NOT be set (environ replacement breaks shells)
+	if _, ok := m["AGENTSH_ENV_BLOCK_ITERATION"]; ok {
+		t.Fatalf("AGENTSH_ENV_BLOCK_ITERATION should not be set, got %q", m["AGENTSH_ENV_BLOCK_ITERATION"])
 	}
 	if got := m["LD_PRELOAD"]; got != shimPath {
 		t.Fatalf("expected LD_PRELOAD to be shim path, got %q", got)


### PR DESCRIPTION
## Summary
- Stop setting `AGENTSH_ENV_BLOCK_ITERATION=1` in `maybeAddShimEnv()` — replacing `environ` with an empty array is incompatible with shells (bash reads `environ` directly during startup, not via `getenv()`)
- Server-side `buildPolicyEnv()` already strips secrets before exec, making block_iteration redundant
- LD_PRELOAD shim injection preserved for policy-mode getenv interception and logging

## Test plan
- [x] `TestMaybeAddShimEnv_AddsShimAndFlag` updated to assert `AGENTSH_ENV_BLOCK_ITERATION` is absent
- [x] `TestMaybeAddShimEnv_PrependsExistingLDPreload` still passes
- [x] `go build ./...` and `GOOS=windows go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)