### PR TITLE
fix: use background context for FUSE event persistence

### DIFF
--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -392,7 +392,7 @@ func (a *App) setupProfileMounts(ctx context.Context, s *session.Session, profil
 			fs := a.platform.Filesystem()
 			if fs != nil && fs.Available() {
 				eventChan := make(chan platform.IOEvent, 1000)
-				go a.processIOEvents(ctx, eventChan)
+				go a.processIOEvents(eventChan)
 
 				fsCfg := platform.FSConfig{
 					SourcePath: mountPath,
@@ -1200,7 +1200,7 @@ func (a *App) mountFUSEForSession(ctx context.Context, p fuseMountParams) bool {
 	eventChan := make(chan platform.IOEvent, 1000)
 
 	// Start goroutine to process events from the channel
-	go a.processIOEvents(ctx, eventChan)
+	go a.processIOEvents(eventChan)
 
 	// Build platform FSConfig
 	fsCfg := platform.FSConfig{
@@ -1300,7 +1300,9 @@ func (a *App) mountFUSEForSession(ctx context.Context, p fuseMountParams) bool {
 
 // processIOEvents reads events from the platform event channel and forwards
 // them to the event store and broker. It runs until the channel is closed.
-func (a *App) processIOEvents(ctx context.Context, eventChan <-chan platform.IOEvent) {
+// Uses a per-event background context instead of a caller-provided context
+// to avoid silent event drops when the HTTP request context is canceled.
+func (a *App) processIOEvents(eventChan <-chan platform.IOEvent) {
 	for ioEvent := range eventChan {
 		// Convert platform.IOEvent to types.Event
 		ev := ioEvent.ToEvent()
@@ -1312,7 +1314,12 @@ func (a *App) processIOEvents(ctx context.Context, eventChan <-chan platform.IOE
 		}
 
 		// Store and publish the event
-		_ = a.store.AppendEvent(ctx, ev)
+		persistCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		err := a.store.AppendEvent(persistCtx, ev)
+		cancel()
+		if err != nil {
+			slog.Error("persist fuse io event", "error", err, "event_type", ev.Type, "event_id", ev.ID)
+		}
 		a.broker.Publish(ev)
 	}
 }

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -1238,7 +1238,12 @@ func (a *App) mountFUSEForSession(ctx context.Context, p fuseMountParams) bool {
 					"restore_hint": fmt.Sprintf("agentsh trash restore %s", token),
 				},
 			}
-			_ = a.store.AppendEvent(ctx, ev)
+			persistCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			err := a.store.AppendEvent(persistCtx, ev)
+			cancel()
+			if err != nil {
+				slog.Error("persist fuse soft-delete event", "error", err, "event_type", ev.Type, "path", path)
+			}
 			a.broker.Publish(ev)
 		}
 	}

--- a/internal/api/core_fuse_ctx_test.go
+++ b/internal/api/core_fuse_ctx_test.go
@@ -1,0 +1,81 @@
+package api
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/events"
+	"github.com/agentsh/agentsh/internal/platform"
+	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/store/composite"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// ctxAwareEventStore respects context cancellation, like the real SQLite store.
+type ctxAwareEventStore struct {
+	mu     sync.Mutex
+	events []types.Event
+}
+
+func (f *ctxAwareEventStore) AppendEvent(ctx context.Context, ev types.Event) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, ev)
+	return nil
+}
+
+func (f *ctxAwareEventStore) QueryEvents(_ context.Context, _ types.EventQuery) ([]types.Event, error) {
+	return nil, nil
+}
+
+func (f *ctxAwareEventStore) Close() error { return nil }
+
+func (f *ctxAwareEventStore) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.events)
+}
+
+// TestProcessIOEvents_PersistsAfterContextCancellation verifies that
+// processIOEvents uses its own background context, not a caller-provided
+// context that may already be canceled. This is a regression test for a bug
+// where the HTTP request context was captured and used for event persistence,
+// causing silent drops after the first exec response was sent.
+func TestProcessIOEvents_PersistsAfterContextCancellation(t *testing.T) {
+	fake := &ctxAwareEventStore{}
+	cStore := composite.New(fake, nil)
+	broker := events.NewBroker()
+	app := &App{
+		store:    cStore,
+		broker:   broker,
+		sessions: session.NewManager(0),
+	}
+
+	ch := make(chan platform.IOEvent, 10)
+
+	// Send 3 events
+	for i := 0; i < 3; i++ {
+		ch <- platform.IOEvent{
+			Timestamp: time.Now(),
+			SessionID: "test-session",
+			Type:      platform.EventFileWrite,
+			Path:      "/tmp/test",
+		}
+	}
+	close(ch)
+
+	// processIOEvents no longer takes a context — it creates its own
+	// background context per event. All 3 events should be persisted.
+	app.processIOEvents(ch)
+
+	if got := fake.count(); got != 3 {
+		t.Fatalf("expected 3 events persisted, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary
- `processIOEvents` and `NotifySoftDelete` captured the HTTP request context, which cancels after the first exec response. All subsequent FUSE events silently failed because `AppendEvent` returned `ctx.Err()` and callers discarded errors with `_ =`
- Now uses per-event `context.WithTimeout(context.Background(), 5s)` matching the existing MCP event callback pattern
- Errors are logged with `slog.Error` instead of discarded

## Test plan
- [x] `TestProcessIOEvents_PersistsAfterContextCancellation` — regression test with context-aware fake store
- [x] `go build ./...` and `GOOS=windows go build ./...` clean
- [x] roborev branch review passed (no findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)