### PR TITLE
Wire HMAC integrity chain into JSONL audit output (#182)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/agentsh/agentsh/internal/api"
 	"github.com/agentsh/agentsh/internal/approvals"
+	"github.com/agentsh/agentsh/internal/audit"
 	"github.com/agentsh/agentsh/internal/auth"
 	"github.com/agentsh/agentsh/internal/capabilities"
 	"github.com/agentsh/agentsh/internal/config"
@@ -69,9 +71,14 @@ type Server struct {
 	threatStore  *threatfeed.Store
 
 	app *api.App // for lifecycle management (ptrace tracer shutdown)
+
+	kmsProvider io.Closer // audit/kms.Provider for HMAC key lifecycle
 }
 
 func New(cfg *config.Config) (*Server, error) {
+	var kmsProvider io.Closer
+	var kmsCloser func() error
+
 	if cfg == nil {
 		return nil, fmt.Errorf("config is nil")
 	}
@@ -161,6 +168,27 @@ func New(cfg *config.Config) (*Server, error) {
 		}
 	}
 
+	var jsonlEventStore storepkg.EventStore
+	if jsonlStore != nil {
+		jsonlEventStore = jsonlStore
+	}
+	if jsonlStore != nil && cfg.Audit.Integrity.Enabled {
+		chain, provider, err := audit.NewIntegrityChainFromConfig(
+			context.Background(), cfg.Audit.Integrity)
+		if err != nil {
+			_ = db.Close()
+			return nil, fmt.Errorf("audit integrity chain: %w", err)
+		}
+		kmsProvider = provider
+		kmsCloser = provider.Close
+		defer func() {
+			if kmsCloser != nil {
+				kmsCloser()
+			}
+		}()
+		jsonlEventStore = storepkg.NewIntegrityStore(jsonlStore, chain)
+	}
+
 	var webhookStore *webhook.Store
 	if cfg.Audit.Webhook.URL != "" {
 		flushEvery, err := time.ParseDuration(cfg.Audit.Webhook.FlushInterval)
@@ -230,8 +258,8 @@ func New(cfg *config.Config) (*Server, error) {
 	}
 
 	var eventStores []storepkg.EventStore
-	if jsonlStore != nil {
-		eventStores = append(eventStores, jsonlStore)
+	if jsonlEventStore != nil {
+		eventStores = append(eventStores, jsonlEventStore)
 	}
 	if webhookStore != nil {
 		eventStores = append(eventStores, webhookStore)
@@ -436,6 +464,7 @@ func New(cfg *config.Config) (*Server, error) {
 		threatSyncer:   threatSyncer,
 		threatStore:    threatStore,
 		app:            app,
+		kmsProvider:    kmsProvider,
 	}
 
 	ln, err := listenHTTP(cfg)
@@ -554,6 +583,7 @@ unixDone:
 	}
 
 	appCloser = nil // success — don't close app on defer
+	kmsCloser = nil
 	return srv, nil
 }
 
@@ -809,6 +839,9 @@ func (s *Server) Close() error {
 	}
 	if s.store != nil {
 		_ = s.store.Close()
+	}
+	if s.kmsProvider != nil {
+		_ = s.kmsProvider.Close()
 	}
 	return nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -176,6 +176,9 @@ func New(cfg *config.Config) (*Server, error) {
 		chain, provider, err := audit.NewIntegrityChainFromConfig(
 			context.Background(), cfg.Audit.Integrity)
 		if err != nil {
+			if jsonlStore != nil {
+				_ = jsonlStore.Close()
+			}
 			_ = db.Close()
 			return nil, fmt.Errorf("audit integrity chain: %w", err)
 		}

--- a/internal/store/integrity_wrapper.go
+++ b/internal/store/integrity_wrapper.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/agentsh/agentsh/internal/audit"
 	"github.com/agentsh/agentsh/pkg/types"
@@ -13,6 +14,7 @@ var _ EventStore = (*IntegrityStore)(nil)
 
 // IntegrityStore wraps an EventStore and adds integrity metadata to events.
 type IntegrityStore struct {
+	mu    sync.Mutex
 	inner EventStore
 	chain *audit.IntegrityChain
 }
@@ -26,22 +28,35 @@ func NewIntegrityStore(inner EventStore, chain *audit.IntegrityChain) *Integrity
 // and writes the signed bytes via RawWriter if the inner store supports it.
 // Falls back to unsigned inner.AppendEvent otherwise.
 func (s *IntegrityStore) AppendEvent(ctx context.Context, ev types.Event) error {
+	rw, ok := s.inner.(RawWriter)
+	if !ok {
+		// Inner store does not support raw writes; delegate unsigned
+		// without advancing chain state.
+		return s.inner.AppendEvent(ctx, ev)
+	}
+
 	payload, err := json.Marshal(ev)
 	if err != nil {
 		return fmt.Errorf("integrity marshal: %w", err)
 	}
 
+	// Serialize wrap+write so chain state stays consistent with on-disk order.
+	s.mu.Lock()
+	prevState := s.chain.State()
 	wrapped, err := s.chain.Wrap(payload)
 	if err != nil {
+		s.mu.Unlock()
 		return fmt.Errorf("integrity wrap: %w", err)
 	}
 
-	if rw, ok := s.inner.(RawWriter); ok {
-		return rw.WriteRaw(ctx, wrapped)
+	if writeErr := rw.WriteRaw(ctx, wrapped); writeErr != nil {
+		// Roll back chain state so the next call can retry cleanly.
+		s.chain.Restore(prevState.Sequence, prevState.PrevHash)
+		s.mu.Unlock()
+		return writeErr
 	}
-
-	// Fallback: delegate unsigned
-	return s.inner.AppendEvent(ctx, ev)
+	s.mu.Unlock()
+	return nil
 }
 
 // QueryEvents delegates to the inner store.

--- a/internal/store/integrity_wrapper.go
+++ b/internal/store/integrity_wrapper.go
@@ -2,6 +2,8 @@ package store
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	"github.com/agentsh/agentsh/internal/audit"
 	"github.com/agentsh/agentsh/pkg/types"
@@ -20,8 +22,25 @@ func NewIntegrityStore(inner EventStore, chain *audit.IntegrityChain) *Integrity
 	return &IntegrityStore{inner: inner, chain: chain}
 }
 
-// AppendEvent delegates to the inner store. Integrity wrapping is handled at the serialization layer.
+// AppendEvent marshals the event, wraps it with HMAC integrity metadata,
+// and writes the signed bytes via RawWriter if the inner store supports it.
+// Falls back to unsigned inner.AppendEvent otherwise.
 func (s *IntegrityStore) AppendEvent(ctx context.Context, ev types.Event) error {
+	payload, err := json.Marshal(ev)
+	if err != nil {
+		return fmt.Errorf("integrity marshal: %w", err)
+	}
+
+	wrapped, err := s.chain.Wrap(payload)
+	if err != nil {
+		return fmt.Errorf("integrity wrap: %w", err)
+	}
+
+	if rw, ok := s.inner.(RawWriter); ok {
+		return rw.WriteRaw(ctx, wrapped)
+	}
+
+	// Fallback: delegate unsigned
 	return s.inner.AppendEvent(ctx, ev)
 }
 

--- a/internal/store/integrity_wrapper.go
+++ b/internal/store/integrity_wrapper.go
@@ -50,8 +50,13 @@ func (s *IntegrityStore) AppendEvent(ctx context.Context, ev types.Event) error 
 	}
 
 	if writeErr := rw.WriteRaw(ctx, wrapped); writeErr != nil {
-		// Roll back chain state so the next call can retry cleanly.
-		s.chain.Restore(prevState.Sequence, prevState.PrevHash)
+		// Only roll back chain state if the write was fully rolled back
+		// (no partial data on disk). A PartialWriteError means truncate
+		// failed and data may be on disk — we must NOT restore.
+		type partialWriter interface{ IsPartialWrite() bool }
+		if pw, ok := writeErr.(partialWriter); !ok || !pw.IsPartialWrite() {
+			s.chain.Restore(prevState.Sequence, prevState.PrevHash)
+		}
 		s.mu.Unlock()
 		return writeErr
 	}

--- a/internal/store/integrity_wrapper_test.go
+++ b/internal/store/integrity_wrapper_test.go
@@ -98,6 +98,34 @@ func (m *mockFailingRawWriter) QueryEvents(_ context.Context, _ types.EventQuery
 
 func (m *mockFailingRawWriter) Close() error { return nil }
 
+// mockPartialFailRawWriter returns a partial-write error (truncate failed).
+type mockPartialFailRawWriter struct {
+	mu       sync.Mutex
+	rawCalls int
+}
+
+type testPartialWriteError struct{ msg string }
+
+func (e *testPartialWriteError) Error() string      { return e.msg }
+func (e *testPartialWriteError) IsPartialWrite() bool { return true }
+
+func (m *mockPartialFailRawWriter) WriteRaw(_ context.Context, _ []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rawCalls++
+	return &testPartialWriteError{msg: "partial write: disk full (truncate failed: read-only fs)"}
+}
+
+func (m *mockPartialFailRawWriter) AppendEvent(_ context.Context, _ types.Event) error {
+	return nil
+}
+
+func (m *mockPartialFailRawWriter) QueryEvents(_ context.Context, _ types.EventQuery) ([]types.Event, error) {
+	return nil, nil
+}
+
+func (m *mockPartialFailRawWriter) Close() error { return nil }
+
 func TestIntegrityChain_StateAdvances(t *testing.T) {
 	chain, err := audit.NewIntegrityChain(testKey)
 	if err != nil {
@@ -319,6 +347,33 @@ func TestIntegrityStore_AppendEvent_WriteFailureRollsBackChain(t *testing.T) {
 	seq := int64(integrity["sequence"].(float64))
 	if seq != 1 {
 		t.Errorf("sequence after retry = %d, want 1", seq)
+	}
+}
+
+func TestIntegrityStore_PartialWriteDoesNotRollBack(t *testing.T) {
+	chain, err := audit.NewIntegrityChain(testKey)
+	if err != nil {
+		t.Fatalf("create chain: %v", err)
+	}
+
+	mock := &mockPartialFailRawWriter{}
+	s := NewIntegrityStore(mock, chain)
+
+	ev := types.Event{ID: "ev-1", Type: "test"}
+
+	err = s.AppendEvent(context.Background(), ev)
+	if err == nil {
+		t.Fatal("expected error from partial-write failure")
+	}
+
+	// Chain state should NOT be rolled back because partial data
+	// may be on disk (truncate failed).
+	state := chain.State()
+	if state.Sequence != 1 {
+		t.Errorf("chain sequence = %d after partial write, want 1 (NOT rolled back)", state.Sequence)
+	}
+	if state.PrevHash == "" {
+		t.Error("chain prev_hash should be non-empty after partial write (NOT rolled back)")
 	}
 }
 

--- a/internal/store/integrity_wrapper_test.go
+++ b/internal/store/integrity_wrapper_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -69,6 +70,33 @@ func (m *mockPlainStore) QueryEvents(_ context.Context, _ types.EventQuery) ([]t
 }
 
 func (m *mockPlainStore) Close() error { return nil }
+
+// mockFailingRawWriter implements RawWriter but always fails on WriteRaw.
+type mockFailingRawWriter struct {
+	mu       sync.Mutex
+	rawCalls int
+	events   []types.Event
+}
+
+func (m *mockFailingRawWriter) WriteRaw(_ context.Context, _ []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rawCalls++
+	return errors.New("disk full")
+}
+
+func (m *mockFailingRawWriter) AppendEvent(_ context.Context, ev types.Event) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, ev)
+	return nil
+}
+
+func (m *mockFailingRawWriter) QueryEvents(_ context.Context, _ types.EventQuery) ([]types.Event, error) {
+	return nil, nil
+}
+
+func (m *mockFailingRawWriter) Close() error { return nil }
 
 func TestIntegrityChain_StateAdvances(t *testing.T) {
 	chain, err := audit.NewIntegrityChain(testKey)
@@ -243,6 +271,54 @@ func TestIntegrityStore_ChainContinuity(t *testing.T) {
 			t.Errorf("entry %d: prev_hash = %q, want %q", i, prevHash, prevEntryHash)
 		}
 		prevEntryHash = entryHash
+	}
+}
+
+func TestIntegrityStore_AppendEvent_WriteFailureRollsBackChain(t *testing.T) {
+	chain, err := audit.NewIntegrityChain(testKey)
+	if err != nil {
+		t.Fatalf("create chain: %v", err)
+	}
+
+	mock := &mockFailingRawWriter{}
+	s := NewIntegrityStore(mock, chain)
+
+	ev := types.Event{ID: "ev-1", Type: "test"}
+
+	// First call should fail
+	err = s.AppendEvent(context.Background(), ev)
+	if err == nil {
+		t.Fatal("expected error from failing WriteRaw")
+	}
+
+	// Chain state should be rolled back to initial (sequence=0)
+	state := chain.State()
+	if state.Sequence != 0 {
+		t.Errorf("chain sequence = %d after failed write, want 0 (rolled back)", state.Sequence)
+	}
+	if state.PrevHash != "" {
+		t.Errorf("chain prev_hash = %q after failed write, want empty", state.PrevHash)
+	}
+
+	// Now retry with a working mock — chain should start fresh at sequence 1
+	goodMock := &mockRawWriter{}
+	s2 := NewIntegrityStore(goodMock, chain)
+	if err := s2.AppendEvent(context.Background(), ev); err != nil {
+		t.Fatalf("retry AppendEvent: %v", err)
+	}
+
+	if len(goodMock.rawCalls) != 1 {
+		t.Fatalf("expected 1 WriteRaw call, got %d", len(goodMock.rawCalls))
+	}
+
+	var result map[string]any
+	if err := json.Unmarshal(goodMock.rawCalls[0], &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	integrity := result["integrity"].(map[string]any)
+	seq := int64(integrity["sequence"].(float64))
+	if seq != 1 {
+		t.Errorf("sequence after retry = %d, want 1", seq)
 	}
 }
 

--- a/internal/store/integrity_wrapper_test.go
+++ b/internal/store/integrity_wrapper_test.go
@@ -1,19 +1,73 @@
 package store
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/agentsh/agentsh/internal/audit"
+	"github.com/agentsh/agentsh/pkg/types"
 )
 
+var testKey = []byte("test-key-32-bytes-for-hmac-sha!!")
+
+// mockRawWriter implements both EventStore and RawWriter.
+type mockRawWriter struct {
+	mu       sync.Mutex
+	rawCalls [][]byte
+	events   []types.Event
+}
+
+func (m *mockRawWriter) WriteRaw(_ context.Context, data []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]byte, len(data))
+	copy(cp, data)
+	m.rawCalls = append(m.rawCalls, cp)
+	return nil
+}
+
+func (m *mockRawWriter) AppendEvent(_ context.Context, ev types.Event) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, ev)
+	return nil
+}
+
+func (m *mockRawWriter) QueryEvents(_ context.Context, _ types.EventQuery) ([]types.Event, error) {
+	return nil, nil
+}
+
+func (m *mockRawWriter) Close() error { return nil }
+
+// mockPlainStore implements EventStore only (no RawWriter).
+type mockPlainStore struct {
+	mu     sync.Mutex
+	events []types.Event
+}
+
+func (m *mockPlainStore) AppendEvent(_ context.Context, ev types.Event) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, ev)
+	return nil
+}
+
+func (m *mockPlainStore) QueryEvents(_ context.Context, _ types.EventQuery) ([]types.Event, error) {
+	return nil, nil
+}
+
+func (m *mockPlainStore) Close() error { return nil }
+
 func TestIntegrityChain_StateAdvances(t *testing.T) {
-	key := []byte("test-key-32-bytes-for-hmac-sha!!")
-	chain, err := audit.NewIntegrityChain(key)
+	chain, err := audit.NewIntegrityChain(testKey)
 	if err != nil {
 		t.Fatalf("failed to create chain: %v", err)
 	}
 
-	// Test that chain state advances
 	state1 := chain.State()
 	if state1.Sequence != 0 {
 		t.Errorf("initial sequence should be 0, got %d", state1.Sequence)
@@ -34,18 +88,152 @@ func TestIntegrityChain_StateAdvances(t *testing.T) {
 }
 
 func TestNewIntegrityStore(t *testing.T) {
-	key := []byte("test-key-32-bytes-for-hmac-sha!!")
-	chain, err := audit.NewIntegrityChain(key)
+	chain, err := audit.NewIntegrityChain(testKey)
 	if err != nil {
 		t.Fatalf("failed to create chain: %v", err)
 	}
 
-	// Create wrapper with nil inner store (just testing construction)
 	wrapper := NewIntegrityStore(nil, chain)
 	if wrapper == nil {
 		t.Fatal("expected non-nil wrapper")
 	}
 	if wrapper.Chain() != chain {
 		t.Error("Chain() should return the same chain")
+	}
+}
+
+func TestIntegrityStore_AppendEvent_WrapsPayload(t *testing.T) {
+	chain, err := audit.NewIntegrityChain(testKey)
+	if err != nil {
+		t.Fatalf("create chain: %v", err)
+	}
+
+	mock := &mockRawWriter{}
+	s := NewIntegrityStore(mock, chain)
+
+	ev := types.Event{
+		ID:        "ev-1",
+		Timestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Type:      "test_event",
+		SessionID: "sess-1",
+	}
+
+	if err := s.AppendEvent(context.Background(), ev); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	// Should have called WriteRaw, not AppendEvent
+	if len(mock.rawCalls) != 1 {
+		t.Fatalf("expected 1 WriteRaw call, got %d", len(mock.rawCalls))
+	}
+	if len(mock.events) != 0 {
+		t.Fatalf("expected 0 AppendEvent calls, got %d", len(mock.events))
+	}
+
+	// Parse the raw bytes and verify integrity field
+	var result map[string]any
+	if err := json.Unmarshal(mock.rawCalls[0], &result); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+
+	integrity, ok := result["integrity"].(map[string]any)
+	if !ok {
+		t.Fatal("integrity field missing")
+	}
+
+	seq, _ := integrity["sequence"].(float64)
+	if seq != 1 {
+		t.Errorf("sequence = %v, want 1", seq)
+	}
+
+	prevHash, _ := integrity["prev_hash"].(string)
+	if prevHash != "" {
+		t.Errorf("prev_hash = %q, want empty (first entry)", prevHash)
+	}
+
+	entryHash, _ := integrity["entry_hash"].(string)
+	if entryHash == "" {
+		t.Error("entry_hash should not be empty")
+	}
+
+	// Verify original event fields are preserved
+	if result["id"] != "ev-1" {
+		t.Errorf("id = %v, want ev-1", result["id"])
+	}
+	if result["type"] != "test_event" {
+		t.Errorf("type = %v, want test_event", result["type"])
+	}
+}
+
+func TestIntegrityStore_AppendEvent_FallbackWithoutRawWriter(t *testing.T) {
+	chain, err := audit.NewIntegrityChain(testKey)
+	if err != nil {
+		t.Fatalf("create chain: %v", err)
+	}
+
+	mock := &mockPlainStore{}
+	s := NewIntegrityStore(mock, chain)
+
+	ev := types.Event{
+		ID:   "ev-1",
+		Type: "test_event",
+	}
+
+	if err := s.AppendEvent(context.Background(), ev); err != nil {
+		t.Fatalf("AppendEvent: %v", err)
+	}
+
+	// Should have called AppendEvent on the inner store (unsigned fallback)
+	if len(mock.events) != 1 {
+		t.Fatalf("expected 1 AppendEvent call, got %d", len(mock.events))
+	}
+	if mock.events[0].ID != "ev-1" {
+		t.Errorf("event ID = %q, want ev-1", mock.events[0].ID)
+	}
+}
+
+func TestIntegrityStore_ChainContinuity(t *testing.T) {
+	chain, err := audit.NewIntegrityChain(testKey)
+	if err != nil {
+		t.Fatalf("create chain: %v", err)
+	}
+
+	mock := &mockRawWriter{}
+	s := NewIntegrityStore(mock, chain)
+
+	// Append 3 events
+	for i := 0; i < 3; i++ {
+		ev := types.Event{
+			ID:   fmt.Sprintf("ev-%d", i),
+			Type: "test",
+		}
+		if err := s.AppendEvent(context.Background(), ev); err != nil {
+			t.Fatalf("AppendEvent %d: %v", i, err)
+		}
+	}
+
+	if len(mock.rawCalls) != 3 {
+		t.Fatalf("expected 3 WriteRaw calls, got %d", len(mock.rawCalls))
+	}
+
+	// Verify chain links
+	var prevEntryHash string
+	for i, raw := range mock.rawCalls {
+		var result map[string]any
+		if err := json.Unmarshal(raw, &result); err != nil {
+			t.Fatalf("unmarshal %d: %v", i, err)
+		}
+		integrity := result["integrity"].(map[string]any)
+		prevHash := integrity["prev_hash"].(string)
+		entryHash := integrity["entry_hash"].(string)
+		seq := int64(integrity["sequence"].(float64))
+
+		if seq != int64(i+1) {
+			t.Errorf("entry %d: sequence = %d, want %d", i, seq, i+1)
+		}
+		if prevHash != prevEntryHash {
+			t.Errorf("entry %d: prev_hash = %q, want %q", i, prevHash, prevEntryHash)
+		}
+		prevEntryHash = entryHash
 	}
 }

--- a/internal/store/integrity_wrapper_test.go
+++ b/internal/store/integrity_wrapper_test.go
@@ -2,13 +2,21 @@ package store
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/agentsh/agentsh/internal/audit"
+	"github.com/agentsh/agentsh/internal/store/jsonl"
 	"github.com/agentsh/agentsh/pkg/types"
 )
 
@@ -236,4 +244,90 @@ func TestIntegrityStore_ChainContinuity(t *testing.T) {
 		}
 		prevEntryHash = entryHash
 	}
+}
+
+func TestIntegrityStore_EndToEnd_VerifyWithAuditVerify(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "audit.jsonl")
+
+	// Create JSONL store → wrap with IntegrityStore
+	jsonlStore, err := jsonl.New(logPath, 100, 3)
+	if err != nil {
+		t.Fatalf("jsonl.New: %v", err)
+	}
+
+	chain, err := audit.NewIntegrityChain(testKey)
+	if err != nil {
+		t.Fatalf("NewIntegrityChain: %v", err)
+	}
+	wrapped := NewIntegrityStore(jsonlStore, chain)
+
+	// Append events
+	events := []types.Event{
+		{ID: "1", Type: "session_start", SessionID: "s1", Timestamp: time.Now()},
+		{ID: "2", Type: "command_executed", SessionID: "s1", Timestamp: time.Now(), Fields: map[string]any{"command": "ls"}},
+		{ID: "3", Type: "file_read", SessionID: "s1", Timestamp: time.Now(), Fields: map[string]any{"path": "/etc/hosts"}},
+	}
+	for _, ev := range events {
+		if err := wrapped.AppendEvent(context.Background(), ev); err != nil {
+			t.Fatalf("AppendEvent: %v", err)
+		}
+	}
+	if err := wrapped.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Verify by reading back and checking the integrity chain manually.
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d", len(lines))
+	}
+
+	var prevEntryHash string
+	for i, line := range lines {
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("line %d unmarshal: %v", i, err)
+		}
+
+		integrity, ok := entry["integrity"].(map[string]any)
+		if !ok {
+			t.Fatalf("line %d: missing integrity field", i)
+		}
+
+		prevHash := integrity["prev_hash"].(string)
+		entryHash := integrity["entry_hash"].(string)
+
+		if prevHash != prevEntryHash {
+			t.Errorf("line %d: prev_hash = %q, want %q", i, prevHash, prevEntryHash)
+		}
+
+		// Verify HMAC by recomputing
+		delete(entry, "integrity")
+		canonical, _ := json.Marshal(entry)
+		seq := int64(integrity["sequence"].(float64))
+		computed := computeHMAC(testKey, seq, prevHash, canonical)
+		if computed != entryHash {
+			t.Errorf("line %d: entry_hash mismatch: computed %q, got %q", i, computed, entryHash)
+		}
+
+		prevEntryHash = entryHash
+	}
+}
+
+// computeHMAC replicates the HMAC computation from audit.IntegrityChain.computeHash
+// for verification in tests.
+func computeHMAC(key []byte, sequence int64, prevHash string, payload []byte) string {
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(strconv.FormatInt(sequence, 10)))
+	h.Write([]byte("|"))
+	h.Write([]byte(prevHash))
+	h.Write([]byte("|"))
+	h.Write(payload)
+	return hex.EncodeToString(h.Sum(nil))
 }

--- a/internal/store/jsonl/jsonl.go
+++ b/internal/store/jsonl/jsonl.go
@@ -11,6 +11,23 @@ import (
 	"github.com/agentsh/agentsh/pkg/types"
 )
 
+// PartialWriteError indicates a write failed and partial data may remain
+// on disk because truncate also failed. Callers must NOT assume rollback
+// is safe when they receive this error. Use IsPartialWrite() to detect.
+type PartialWriteError struct {
+	WriteErr    error
+	TruncateErr error
+}
+
+func (e *PartialWriteError) Error() string {
+	return "partial write: " + e.WriteErr.Error() + " (truncate failed: " + e.TruncateErr.Error() + ")"
+}
+
+func (e *PartialWriteError) Unwrap() error { return e.WriteErr }
+
+// IsPartialWrite implements the interface checked by IntegrityStore.
+func (e *PartialWriteError) IsPartialWrite() bool { return true }
+
 type Store struct {
 	path       string
 	maxBytes   int64
@@ -91,12 +108,14 @@ func (s *Store) WriteRaw(_ context.Context, data []byte) error {
 	buf[len(data)] = '\n'
 	n, writeErr := s.file.Write(buf)
 	if writeErr != nil || n != len(buf) {
-		// Truncate back to remove any partial data.
-		_ = s.file.Truncate(preSize)
-		if writeErr != nil {
-			return fmt.Errorf("write jsonl raw: %w", writeErr)
+		if writeErr == nil {
+			writeErr = fmt.Errorf("short write (%d/%d bytes)", n, len(buf))
 		}
-		return fmt.Errorf("write jsonl raw: short write (%d/%d bytes)", n, len(buf))
+		// Truncate back to remove any partial data.
+		if truncErr := s.file.Truncate(preSize); truncErr != nil {
+			return &PartialWriteError{WriteErr: writeErr, TruncateErr: truncErr}
+		}
+		return fmt.Errorf("write jsonl raw: %w", writeErr)
 	}
 	return nil
 }

--- a/internal/store/jsonl/jsonl.go
+++ b/internal/store/jsonl/jsonl.go
@@ -68,6 +68,8 @@ func (s *Store) AppendEvent(_ context.Context, ev types.Event) error {
 
 // WriteRaw writes pre-serialized bytes as a single JSONL line.
 // It uses the same locking and rotation logic as AppendEvent.
+// The write is performed as a single os.File.Write call so that
+// failure means no partial data was committed.
 func (s *Store) WriteRaw(_ context.Context, data []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -76,11 +78,13 @@ func (s *Store) WriteRaw(_ context.Context, data []byte) error {
 		return err
 	}
 
-	if _, err := s.file.Write(data); err != nil {
+	// Allocate a new buffer to avoid mutating the caller's slice
+	// and to ensure a single atomic write of data + newline.
+	buf := make([]byte, len(data)+1)
+	copy(buf, data)
+	buf[len(data)] = '\n'
+	if _, err := s.file.Write(buf); err != nil {
 		return fmt.Errorf("write jsonl raw: %w", err)
-	}
-	if _, err := s.file.Write([]byte{'\n'}); err != nil {
-		return fmt.Errorf("write jsonl raw newline: %w", err)
 	}
 	return nil
 }

--- a/internal/store/jsonl/jsonl.go
+++ b/internal/store/jsonl/jsonl.go
@@ -76,8 +76,11 @@ func (s *Store) WriteRaw(_ context.Context, data []byte) error {
 		return err
 	}
 
-	if _, err := s.file.Write(append(data, '\n')); err != nil {
+	if _, err := s.file.Write(data); err != nil {
 		return fmt.Errorf("write jsonl raw: %w", err)
+	}
+	if _, err := s.file.Write([]byte{'\n'}); err != nil {
+		return fmt.Errorf("write jsonl raw newline: %w", err)
 	}
 	return nil
 }

--- a/internal/store/jsonl/jsonl.go
+++ b/internal/store/jsonl/jsonl.go
@@ -68,8 +68,8 @@ func (s *Store) AppendEvent(_ context.Context, ev types.Event) error {
 
 // WriteRaw writes pre-serialized bytes as a single JSONL line.
 // It uses the same locking and rotation logic as AppendEvent.
-// The write is performed as a single os.File.Write call so that
-// failure means no partial data was committed.
+// On partial write or error, the file is truncated back to the
+// pre-write size so callers can safely roll back chain state.
 func (s *Store) WriteRaw(_ context.Context, data []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -78,13 +78,25 @@ func (s *Store) WriteRaw(_ context.Context, data []byte) error {
 		return err
 	}
 
-	// Allocate a new buffer to avoid mutating the caller's slice
-	// and to ensure a single atomic write of data + newline.
+	// Record file size before write so we can truncate on failure.
+	// We use Stat rather than Seek because the file is opened with O_APPEND.
+	st, err := s.file.Stat()
+	if err != nil {
+		return fmt.Errorf("write jsonl raw stat: %w", err)
+	}
+	preSize := st.Size()
+
 	buf := make([]byte, len(data)+1)
 	copy(buf, data)
 	buf[len(data)] = '\n'
-	if _, err := s.file.Write(buf); err != nil {
-		return fmt.Errorf("write jsonl raw: %w", err)
+	n, writeErr := s.file.Write(buf)
+	if writeErr != nil || n != len(buf) {
+		// Truncate back to remove any partial data.
+		_ = s.file.Truncate(preSize)
+		if writeErr != nil {
+			return fmt.Errorf("write jsonl raw: %w", writeErr)
+		}
+		return fmt.Errorf("write jsonl raw: short write (%d/%d bytes)", n, len(buf))
 	}
 	return nil
 }

--- a/internal/store/jsonl/jsonl.go
+++ b/internal/store/jsonl/jsonl.go
@@ -66,6 +66,22 @@ func (s *Store) AppendEvent(_ context.Context, ev types.Event) error {
 	return nil
 }
 
+// WriteRaw writes pre-serialized bytes as a single JSONL line.
+// It uses the same locking and rotation logic as AppendEvent.
+func (s *Store) WriteRaw(_ context.Context, data []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.rotateIfNeededLocked(); err != nil {
+		return err
+	}
+
+	if _, err := s.file.Write(append(data, '\n')); err != nil {
+		return fmt.Errorf("write jsonl raw: %w", err)
+	}
+	return nil
+}
+
 func (s *Store) QueryEvents(_ context.Context, _ types.EventQuery) ([]types.Event, error) {
 	return nil, fmt.Errorf("jsonl store does not support queries")
 }

--- a/internal/store/jsonl/jsonl.go
+++ b/internal/store/jsonl/jsonl.go
@@ -85,8 +85,10 @@ func (s *Store) AppendEvent(_ context.Context, ev types.Event) error {
 
 // WriteRaw writes pre-serialized bytes as a single JSONL line.
 // It uses the same locking and rotation logic as AppendEvent.
-// On partial write or error, the file is truncated back to the
-// pre-write size so callers can safely roll back chain state.
+// On write failure, it attempts to truncate back to the pre-write size.
+// If truncate succeeds, a normal error is returned and callers may safely
+// roll back chain state. If truncate fails, a PartialWriteError is returned
+// and callers must NOT roll back (partial data may be on disk).
 func (s *Store) WriteRaw(_ context.Context, data []byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/store/jsonl/jsonl_test.go
+++ b/internal/store/jsonl/jsonl_test.go
@@ -39,6 +39,57 @@ func TestAppendAndRotate(t *testing.T) {
 	}
 }
 
+func TestWriteRaw(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.log")
+
+	store, err := New(path, 1, 2)
+	if err != nil {
+		t.Fatalf("New error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	raw := []byte(`{"id":"1","type":"test","integrity":{"sequence":1,"prev_hash":"","entry_hash":"abc123"}}`)
+	if err := store.WriteRaw(context.Background(), raw); err != nil {
+		t.Fatalf("WriteRaw: %v", err)
+	}
+
+	// Read back the file and verify exact bytes + newline
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	expected := string(raw) + "\n"
+	if string(data) != expected {
+		t.Errorf("file content = %q, want %q", string(data), expected)
+	}
+}
+
+func TestWriteRaw_TriggersRotation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "events.log")
+
+	store, err := New(path, 1, 2) // 1 MB limit
+	if err != nil {
+		t.Fatalf("New error: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Write >1MB via WriteRaw to trigger rotation
+	big := []byte(strings.Repeat("x", 2<<20))
+	if err := store.WriteRaw(context.Background(), big); err != nil {
+		t.Fatalf("WriteRaw large: %v", err)
+	}
+	// Next write should trigger rotation
+	if err := store.WriteRaw(context.Background(), []byte(`{"after":"rotate"}`)); err != nil {
+		t.Fatalf("WriteRaw post-rotate: %v", err)
+	}
+
+	if _, err := os.Stat(path + ".1"); err != nil {
+		t.Fatalf("expected rotated backup .1, got err: %v", err)
+	}
+}
+
 func TestQueryNotSupported(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "events.log")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -12,6 +12,11 @@ type EventStore interface {
 	Close() error
 }
 
+// RawWriter can write pre-serialized bytes as a single JSONL line.
+type RawWriter interface {
+	WriteRaw(ctx context.Context, data []byte) error
+}
+
 type OutputStore interface {
 	SaveOutput(ctx context.Context, sessionID, commandID string, stdout, stderr []byte, stdoutTotal, stderrTotal int64, stdoutTrunc, stderrTrunc bool) error
 	ReadOutputChunk(ctx context.Context, commandID string, stream string, offset, limit int64) (chunk []byte, total int64, truncated bool, err error)


### PR DESCRIPTION
## Summary

- Wire existing HMAC integrity chain into JSONL audit output so `agentsh audit verify` works against the live log when `audit.integrity.enabled: true`
- Add `RawWriter` interface and `jsonl.Store.WriteRaw` for pre-serialized byte writes with truncate-on-failure rollback safety
- Make `IntegrityStore.AppendEvent` actually wrap events with HMAC chain metadata via `chain.Wrap()`, with serialized wrap+write and chain state rollback on failure
- Wire `NewIntegrityChainFromConfig` into `server.New()` with KMS provider lifecycle management

## Changes

- `internal/store/store.go` — add `RawWriter` interface
- `internal/store/jsonl/jsonl.go` — add `WriteRaw` with atomic write + truncate-on-failure, `PartialWriteError` type
- `internal/store/integrity_wrapper.go` — replace pass-through with real HMAC wrapping, mutex serialization, rollback on failure
- `internal/server/server.go` — wire integrity chain on startup, KMS provider cleanup in `Close()`

## Test plan

- [x] `TestWriteRaw` — raw bytes written + read back exact match
- [x] `TestWriteRaw_TriggersRotation` — rotation works with raw writes
- [x] `TestIntegrityStore_AppendEvent_WrapsPayload` — verify integrity field with sequence/prev_hash/entry_hash
- [x] `TestIntegrityStore_AppendEvent_FallbackWithoutRawWriter` — unsigned fallback without chain advancement
- [x] `TestIntegrityStore_ChainContinuity` — 3-event chain links correctly
- [x] `TestIntegrityStore_AppendEvent_WriteFailureRollsBackChain` — chain state restored on write failure
- [x] `TestIntegrityStore_PartialWriteDoesNotRollBack` — chain state NOT restored on partial write (truncate failure)
- [x] `TestIntegrityStore_EndToEnd_VerifyWithAuditVerify` — write via IntegrityStore + JSONL, read back, recompute HMAC, verify chain
- [x] `go test ./...` — all pass
- [x] `GOOS=windows go build ./...` — cross-compile clean

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)