### PR TITLE
Add flag to disable SQLite audit storage (#181)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,6 +156,7 @@ type AuditConfig struct {
 }
 
 type AuditStorageConfig struct {
+	Enabled       *bool         `yaml:"enabled"`         // defaults to true; set false to skip SQLite
 	SQLitePath    string        `yaml:"sqlite_path"`
 	BatchSize     int           `yaml:"batch_size"`      // events per batch (default 64)
 	FlushInterval time.Duration `yaml:"flush_interval"`  // max time before flush (default 50ms)
@@ -1218,6 +1219,9 @@ func applyDefaultsWithSource(cfg *Config, source ConfigSource, configPath string
 	}
 
 	// Use source-aware data directory for SQLite
+	if cfg.Audit.Storage.Enabled == nil {
+		cfg.Audit.Storage.Enabled = boolPtr(true)
+	}
 	if cfg.Audit.Storage.SQLitePath == "" {
 		cfg.Audit.Storage.SQLitePath = filepath.Join(dataDir, "events.db")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1562,3 +1562,43 @@ sandbox:
 		})
 	}
 }
+
+func TestAuditStorageEnabledDefault(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(cfgPath, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Audit.Storage.Enabled == nil {
+		t.Fatal("Audit.Storage.Enabled should not be nil after defaults")
+	}
+	if !*cfg.Audit.Storage.Enabled {
+		t.Error("Audit.Storage.Enabled should default to true")
+	}
+}
+
+func TestAuditStorageDisabled(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(cfgPath, []byte(`
+audit:
+  storage:
+    enabled: false
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Audit.Storage.Enabled == nil {
+		t.Fatal("Audit.Storage.Enabled should not be nil")
+	}
+	if *cfg.Audit.Storage.Enabled {
+		t.Error("Audit.Storage.Enabled should be false when explicitly set")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -146,24 +146,31 @@ func New(cfg *config.Config) (*Server, error) {
 
 	metricsCollector := metrics.New()
 
-	sqlitePath := cfg.Audit.Storage.SQLitePath
-	if sqlitePath == "" {
-		sqlitePath = filepath.Join(filepath.Dir(cfg.Sessions.BaseDir), "events.db")
-	}
-	db, err := sqlite.Open(sqlitePath, sqlite.BatchConfig{
-		BatchSize:     cfg.Audit.Storage.BatchSize,
-		FlushInterval: cfg.Audit.Storage.FlushInterval,
-		ChannelSize:   cfg.Audit.Storage.ChannelSize,
-	})
-	if err != nil {
-		return nil, err
+	var db *sqlite.Store
+	if cfg.Audit.Storage.Enabled == nil || *cfg.Audit.Storage.Enabled {
+		sqlitePath := cfg.Audit.Storage.SQLitePath
+		if sqlitePath == "" {
+			sqlitePath = filepath.Join(filepath.Dir(cfg.Sessions.BaseDir), "events.db")
+		}
+		db, err = sqlite.Open(sqlitePath, sqlite.BatchConfig{
+			BatchSize:     cfg.Audit.Storage.BatchSize,
+			FlushInterval: cfg.Audit.Storage.FlushInterval,
+			ChannelSize:   cfg.Audit.Storage.ChannelSize,
+		})
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		slog.Warn("SQLite audit storage disabled; event queries, output storage, and MCP tool tracking are unavailable")
 	}
 
 	var jsonlStore *jsonl.Store
 	if cfg.Audit.Output != "" {
 		jsonlStore, err = jsonl.New(cfg.Audit.Output, cfg.Audit.Rotation.MaxSizeMB, cfg.Audit.Rotation.MaxBackups)
 		if err != nil {
-			_ = db.Close()
+			if db != nil {
+				_ = db.Close()
+			}
 			return nil, err
 		}
 	}
@@ -179,7 +186,9 @@ func New(cfg *config.Config) (*Server, error) {
 			if jsonlStore != nil {
 				_ = jsonlStore.Close()
 			}
-			_ = db.Close()
+			if db != nil {
+				_ = db.Close()
+			}
 			return nil, fmt.Errorf("audit integrity chain: %w", err)
 		}
 		kmsProvider = provider
@@ -196,17 +205,23 @@ func New(cfg *config.Config) (*Server, error) {
 	if cfg.Audit.Webhook.URL != "" {
 		flushEvery, err := time.ParseDuration(cfg.Audit.Webhook.FlushInterval)
 		if err != nil {
-			_ = db.Close()
+			if db != nil {
+				_ = db.Close()
+			}
 			return nil, fmt.Errorf("parse audit.webhook.flush_interval: %w", err)
 		}
 		timeout, err := time.ParseDuration(cfg.Audit.Webhook.Timeout)
 		if err != nil {
-			_ = db.Close()
+			if db != nil {
+				_ = db.Close()
+			}
 			return nil, fmt.Errorf("parse audit.webhook.timeout: %w", err)
 		}
 		webhookStore, err = webhook.New(cfg.Audit.Webhook.URL, cfg.Audit.Webhook.BatchSize, flushEvery, timeout, cfg.Audit.Webhook.Headers)
 		if err != nil {
-			_ = db.Close()
+			if db != nil {
+				_ = db.Close()
+			}
 			return nil, err
 		}
 	}
@@ -218,12 +233,16 @@ func New(cfg *config.Config) (*Server, error) {
 		}
 		otelTimeout, err := time.ParseDuration(cfg.Audit.OTEL.Timeout)
 		if err != nil {
-			_ = db.Close()
+			if db != nil {
+				_ = db.Close()
+			}
 			return nil, fmt.Errorf("parse audit.otel.timeout: %w", err)
 		}
 		otelBatchTimeout, err := time.ParseDuration(cfg.Audit.OTEL.Batch.Timeout)
 		if err != nil {
-			_ = db.Close()
+			if db != nil {
+				_ = db.Close()
+			}
 			return nil, fmt.Errorf("parse audit.otel.batch.timeout: %w", err)
 		}
 		otelStore, err = otelstore.New(context.Background(), otelstore.Config{
@@ -270,9 +289,13 @@ func New(cfg *config.Config) (*Server, error) {
 	if otelStore != nil {
 		eventStores = append(eventStores, otelStore)
 	}
-	// Wrap primary event store so metrics count each event exactly once.
-	primary := metrics.WrapEventStore(db, metricsCollector)
-	store := composite.New(primary, db, eventStores...)
+	var primary storepkg.EventStore
+	var output storepkg.OutputStore
+	if db != nil {
+		primary = metrics.WrapEventStore(db, metricsCollector)
+		output = db
+	}
+	store := composite.New(primary, output, eventStores...)
 
 	sessions := session.NewManager(cfg.Sessions.MaxSessions)
 	broker := events.NewBroker()

--- a/internal/store/composite/composite.go
+++ b/internal/store/composite/composite.go
@@ -22,8 +22,10 @@ func New(primary store.EventStore, output store.OutputStore, others ...store.Eve
 
 func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
 	var firstErr error
-	if err := s.primary.AppendEvent(ctx, ev); err != nil && firstErr == nil {
-		firstErr = err
+	if s.primary != nil {
+		if err := s.primary.AppendEvent(ctx, ev); err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
 	for _, o := range s.others {
 		if err := o.AppendEvent(ctx, ev); err != nil && firstErr == nil {
@@ -34,6 +36,9 @@ func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
 }
 
 func (s *Store) QueryEvents(ctx context.Context, q types.EventQuery) ([]types.Event, error) {
+	if s.primary == nil {
+		return nil, nil
+	}
 	return s.primary.QueryEvents(ctx, q)
 }
 
@@ -53,8 +58,10 @@ func (s *Store) ReadOutputChunk(ctx context.Context, commandID string, stream st
 
 func (s *Store) Close() error {
 	var firstErr error
-	if err := s.primary.Close(); err != nil && firstErr == nil {
-		firstErr = err
+	if s.primary != nil {
+		if err := s.primary.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
 	}
 	for _, o := range s.others {
 		if err := o.Close(); err != nil && firstErr == nil {

--- a/internal/store/composite/composite_test.go
+++ b/internal/store/composite/composite_test.go
@@ -115,3 +115,39 @@ func TestUpsertMCPToolFromEvent_SkipsNonSQLiteStore(t *testing.T) {
 		t.Fatalf("expected nil error for non-SQLite store, got %v", err)
 	}
 }
+
+func TestComposite_NilPrimary_AppendEvent(t *testing.T) {
+	other := &fakeEventStore{}
+	s := New(nil, nil, other)
+
+	if err := s.AppendEvent(context.Background(), types.Event{ID: "1"}); err != nil {
+		t.Fatalf("AppendEvent with nil primary: %v", err)
+	}
+	if other.appended != 1 {
+		t.Fatalf("expected other store to receive event, got %d appends", other.appended)
+	}
+}
+
+func TestComposite_NilPrimary_QueryEvents(t *testing.T) {
+	s := New(nil, nil)
+
+	events, err := s.QueryEvents(context.Background(), types.EventQuery{})
+	if err != nil {
+		t.Fatalf("QueryEvents with nil primary: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected empty results, got %d", len(events))
+	}
+}
+
+func TestComposite_NilPrimary_Close(t *testing.T) {
+	other := &fakeEventStore{}
+	s := New(nil, nil, other)
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("Close with nil primary: %v", err)
+	}
+	if !other.closed {
+		t.Fatal("expected other store to be closed")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `audit.storage.enabled` config flag (`*bool`, defaults `true`) to skip SQLite entirely
- Make composite store nil-safe so JSONL/webhook/OTEL stores work independently without SQLite
- Log warning at startup when SQLite is disabled so operators know which features are unavailable

## Config

```yaml
audit:
  storage:
    enabled: false  # skip SQLite entirely
  output: /var/log/agentsh/audit.jsonl  # JSONL still works
```

## Known limitations

- Event metrics (`agentsh_events_total`) not counted when SQLite is disabled (metrics wrap the primary store only)
- MCP tool queries and output storage return errors when SQLite is disabled
- These are intentional trade-offs for the JSONL-only deployment use case

## Test plan

- [x] `TestAuditStorageEnabledDefault` — defaults to `true`
- [x] `TestAuditStorageDisabled` — parses `enabled: false` correctly
- [x] `TestComposite_NilPrimary_AppendEvent` — events written to `others` with nil primary
- [x] `TestComposite_NilPrimary_QueryEvents` — returns empty results, no panic
- [x] `TestComposite_NilPrimary_Close` — closes cleanly with nil primary
- [x] `go test ./...` — all pass
- [x] `GOOS=windows go build ./...` — cross-compile clean

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)