### PR TITLE
feat: add Homebrew Cask distribution for macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -395,6 +395,55 @@ jobs:
             --repo "${{ github.repository }}" \
             --clobber
 
+  # Publish Homebrew cask to canyonroad/homebrew-tap (stable releases only).
+  publish-homebrew-cask:
+    runs-on: ubuntu-latest
+    needs: [build-macos-app]
+    if: "!contains(github.ref_name, '-')"
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download DMG and compute SHA256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          gh release download "$VERSION" \
+            --pattern "AgentSH-*.dmg" \
+            --repo "${{ github.repository }}" \
+            --dir .
+          DMG_FILE=$(ls AgentSH-*.dmg)
+          if [ "$(echo "$DMG_FILE" | wc -l)" -ne 1 ]; then
+            echo "::error::Expected exactly one DMG file, found: $DMG_FILE"
+            exit 1
+          fi
+          SHA256=$(sha256sum "$DMG_FILE" | awk '{print $1}')
+          echo "SHA256=$SHA256" >> "$GITHUB_ENV"
+          echo "CLEAN_VERSION=${VERSION#v}" >> "$GITHUB_ENV"
+
+      - name: Generate cask formula from template
+        run: |
+          sed -e "s/__VERSION__/$CLEAN_VERSION/g" \
+              -e "s/__SHA256__/$SHA256/g" \
+              scripts/homebrew-cask.rb.tmpl > agentsh.rb
+          echo "--- Generated cask formula ---"
+          cat agentsh.rb
+
+      - name: Push to homebrew-tap
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        run: |
+          git clone "https://x-access-token:${TAP_TOKEN}@github.com/canyonroad/homebrew-tap.git" tap
+          mkdir -p tap/Casks
+          cp agentsh.rb tap/Casks/agentsh.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Casks/agentsh.rb
+          git diff --cached --quiet || git commit -m "Update agentsh cask to ${CLEAN_VERSION}"
+          git push
+
   # Run integration tests across all supported Linux distros.
   docker-test:
     runs-on: ubuntu-latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -303,44 +303,5 @@ release:
   draft: false
   prerelease: auto
 
-homebrew_casks:
-  - name: agentsh
-    ids:
-      - agentsh-darwin
-      - shim-darwin
-      - stub-darwin
-      # macwrap-darwin excluded - requires native macOS build
-    # Repository to push the cask to
-    repository:
-      owner: agentsh
-      name: homebrew-tap
-      branch: main
-      # Use index to safely get env var (empty string if not set)
-      token: '{{ index .Env "HOMEBREW_TAP_GITHUB_TOKEN" }}'
-    # Skip if no token (allows local builds without pushing)
-    skip_upload: true  # Temporarily disabled - no homebrew tap set up yet
-    # Cask metadata
-    homepage: "https://github.com/agentsh/agentsh"
-    description: "Secure sandboxed shell for AI agents"
-    # Binaries to symlink
-    binaries:
-      - agentsh
-      - agentsh-shell-shim
-      - agentsh-stub
-      # agentsh-macwrap excluded - requires native macOS build
-    # Post-install hook to remove quarantine (unsigned binary)
-    hooks:
-      post:
-        install: |
-          system_command "/usr/bin/xattr",
-            args: ["-dr", "com.apple.quarantine", "#{staged_path}"]
-    # Caveats shown after installation
-    caveats: |
-      To start using agentsh:
-        agentsh server &
-        agentsh session create --workspace .
-
-      To create a config file:
-        mkdir -p /usr/local/etc/agentsh
-        agentsh config init > /usr/local/etc/agentsh/config.yaml
-
+# Homebrew cask is published by the publish-homebrew-cask job in release.yml
+# (not managed by GoReleaser — the cask installs the signed DMG, not raw binaries)

--- a/scripts/homebrew-cask.rb.tmpl
+++ b/scripts/homebrew-cask.rb.tmpl
@@ -1,0 +1,30 @@
+cask "agentsh" do
+  version "__VERSION__"
+  sha256 "__SHA256__"
+
+  url "https://github.com/canyonroad/agentsh/releases/download/v#{version}/AgentSH-v#{version}.dmg"
+  name "AgentSH"
+  desc "Secure sandboxed shell for AI agents"
+  homepage "https://github.com/canyonroad/agentsh"
+
+  depends_on macos: ">= :sonoma"
+
+  app "AgentSH.app"
+
+  uninstall quit:      "ai.canyonroad.agentsh",
+            signal:    ["TERM", "agentsh"],
+            launchctl: "ai.canyonroad.agentsh.daemon"
+
+  zap trash: [
+    "~/Library/Application Support/agentsh",
+    "~/Library/Preferences/ai.canyonroad.agentsh.plist",
+    "~/Library/Caches/ai.canyonroad.agentsh",
+    "~/Library/LaunchAgents/ai.canyonroad.agentsh.daemon.plist",
+  ]
+
+  caveats <<~EOS
+    After installation, open AgentSH.app to activate the system extension:
+      open /Applications/AgentSH.app
+    You will be prompted in System Settings to approve the extension.
+  EOS
+end


### PR DESCRIPTION
## Summary

- Add Homebrew cask template (`scripts/homebrew-cask.rb.tmpl`) for macOS AgentSH.app distribution
- Add `publish-homebrew-cask` job to release pipeline that auto-publishes the cask formula to `canyonroad/homebrew-tap` on stable releases
- Remove disabled GoReleaser `homebrew_casks` config (replaced by the workflow job)

After merge, users install with:
```
brew tap canyonroad/tap
brew install --cask agentsh
```

## Prerequisites

Before testing end-to-end:
- [ ] Create `canyonroad/homebrew-tap` public repo on GitHub
- [ ] Create PAT with `repo` scope for that repo
- [ ] Add `HOMEBREW_TAP_GITHUB_TOKEN` secret in `canyonroad/agentsh`

## Test plan

- [ ] Merge and tag a stable release (e.g. `v0.16.11`)
- [ ] Verify `publish-homebrew-cask` job runs and pushes formula to tap repo
- [ ] Verify `brew tap canyonroad/tap && brew install --cask agentsh` installs AgentSH.app
- [ ] Verify `brew uninstall --cask agentsh` cleans up correctly

🤖 Generated with [Claude Code](https://claude.ai/code)