### PR TITLE
fix: cgroup subtree_control fail-closed enforcement (#197)

### DIFF
--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -18,6 +18,7 @@ import (
 	"github.com/agentsh/agentsh/internal/auth"
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/events"
+	"github.com/agentsh/agentsh/internal/limits"
 	"github.com/agentsh/agentsh/internal/mcpinspect"
 	"github.com/agentsh/agentsh/internal/mcpregistry"
 	"github.com/agentsh/agentsh/internal/metrics"
@@ -48,6 +49,8 @@ type App struct {
 	store    *composite.Store
 	policy   *policy.Engine
 	broker   *events.Broker
+
+	cgroupMgr *limits.CgroupManager // issue #197: per-process cgroup manager, nil on non-Linux
 
 	apiKeyAuth *auth.APIKeyAuth
 	oidcAuth   *auth.OIDCAuth
@@ -87,7 +90,7 @@ type App struct {
 	}
 }
 
-func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Store, engine *policy.Engine, broker *events.Broker, apiKeyAuth *auth.APIKeyAuth, oidcAuth *auth.OIDCAuth, approvalsMgr *approvals.Manager, metricsCollector *metrics.Collector, policyLoader PolicyLoader) *App {
+func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Store, engine *policy.Engine, broker *events.Broker, apiKeyAuth *auth.APIKeyAuth, oidcAuth *auth.OIDCAuth, approvalsMgr *approvals.Manager, metricsCollector *metrics.Collector, policyLoader PolicyLoader, cgroupMgr *limits.CgroupManager) *App {
 	// Apply EBPF map size overrides once per process (global maps); no-op if zero values.
 	ebpftrace.SetMapSizeOverrides(
 		uint32(cfg.Sandbox.Network.EBPF.MapAllowEntries),
@@ -114,6 +117,7 @@ func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Stor
 		store:        store,
 		policy:       engine,
 		broker:       broker,
+		cgroupMgr:    cgroupMgr,
 		apiKeyAuth:   apiKeyAuth,
 		oidcAuth:     oidcAuth,
 		approvals:    approvalsMgr,
@@ -824,7 +828,7 @@ func (a *App) cgroupHook(sessionID string, cmdID string, limits policy.Limits) p
 	}
 	return func(pid int) (func() error, error) {
 		em := storeEmitter{store: a.store, broker: a.broker}
-		return applyCgroupV2(context.Background(), em, a.cfg, sessionID, cmdID, pid, limits, a.metrics, a.policy)
+		return applyCgroupV2(context.Background(), em, a, sessionID, cmdID, pid, limits, a.metrics, a.policy)
 	}
 }
 

--- a/internal/api/app_destroy_test.go
+++ b/internal/api/app_destroy_test.go
@@ -53,7 +53,7 @@ func TestDestroySessionPurgesTrash(t *testing.T) {
 		t.Fatalf("expected trash entry before destroy")
 	}
 
-	app := NewApp(cfg, mgr, composite.New(memEventStore{}, nil), nil, events.NewBroker(), nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, composite.New(memEventStore{}, nil), nil, events.NewBroker(), nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("DELETE", "/api/v1/sessions/sess1", nil)
 	rctx := chi.NewRouteContext()

--- a/internal/api/authz_test.go
+++ b/internal/api/authz_test.go
@@ -49,7 +49,7 @@ func TestApprovalsEndpointsRequireApproverRole(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), apiKeyAuth, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), apiKeyAuth, nil, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	// Agent key: forbidden.
@@ -83,7 +83,7 @@ func TestApprovalsEndpointsForbiddenWhenAuthDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/approvals", nil)
@@ -114,7 +114,7 @@ func TestApprovalsEndpointsForbiddenWhenDevelopmentDisableAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/approvals", nil)
@@ -155,7 +155,7 @@ func TestOIDCAuthModeWithValidToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	// Agent token: forbidden for approvals endpoint
@@ -200,7 +200,7 @@ func TestOIDCAuthMissingToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	// No Authorization header
@@ -226,7 +226,7 @@ func TestOIDCAuthEmptyToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	// Empty Bearer token
@@ -262,7 +262,7 @@ func TestOIDCAuthInvalidToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	// Token not in cache (invalid)
@@ -314,7 +314,7 @@ func TestHybridAuthModeAPIKeyFirst(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), apiKeyAuth, oidcAuth, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), apiKeyAuth, oidcAuth, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	// API key takes precedence in hybrid mode
@@ -362,7 +362,7 @@ func TestHybridAuthModeOIDCFallback(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	// OIDC should work when API key not provided
@@ -400,7 +400,7 @@ func TestHybridAuthModeNeitherSucceeds(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	// No valid credentials - should fail

--- a/internal/api/cgroups.go
+++ b/internal/api/cgroups.go
@@ -40,7 +40,13 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 	}
 
 	if app.cgroupMgr == nil {
-		return nil, fmt.Errorf("cgroup manager not initialized")
+		if cgLimits.IsEmpty() {
+			return func() error { return nil }, nil
+		}
+		return nil, &limits.CgroupUnavailableError{
+			Reason: "cgroup manager not initialized",
+			Limits: cgLimits,
+		}
 	}
 
 	cg, err := app.cgroupMgr.Apply("agentsh-"+sanitizeCgroupTag(sessionID)+"-"+sanitizeCgroupTag(cmdID), pid, cgLimits)

--- a/internal/api/cgroups.go
+++ b/internal/api/cgroups.go
@@ -2,14 +2,14 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/cilium/ebpf"
 
-	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/events"
 	"github.com/agentsh/agentsh/internal/limits"
 	"github.com/agentsh/agentsh/internal/metrics"
 	ebpftrace "github.com/agentsh/agentsh/internal/netmonitor/ebpf"
@@ -18,7 +18,8 @@ import (
 	"github.com/google/uuid"
 )
 
-func applyCgroupV2(ctx context.Context, emit storeEmitter, cfg *config.Config, sessionID, cmdID string, pid int, lim policy.Limits, m *metrics.Collector, pol *policy.Engine) (func() error, error) {
+func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, cmdID string, pid int, lim policy.Limits, m *metrics.Collector, pol *policy.Engine) (func() error, error) {
+	cfg := app.cfg
 	if cfg == nil || !cfg.Sandbox.Cgroups.Enabled {
 		return nil, nil
 	}
@@ -28,23 +29,41 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, cfg *config.Config, s
 	ebpfEnforce := cfg.Sandbox.Network.EBPF.Enforce
 	enforceNoDNS := cfg.Sandbox.Network.EBPF.EnforceWithoutDNS
 
-	parent := strings.TrimSpace(cfg.Sandbox.Cgroups.BasePath)
-	if parent != "" && !filepath.IsAbs(parent) {
-		if cur, err := limits.CurrentCgroupDir(); err == nil {
-			parent = filepath.Join(cur, parent)
-		}
-	}
-
 	memBytes := int64(0)
 	if lim.MaxMemoryMB > 0 {
 		memBytes = int64(lim.MaxMemoryMB) * 1024 * 1024
 	}
-	cg, err := limits.ApplyCgroupV2(parent, "agentsh-"+sanitizeCgroupTag(sessionID)+"-"+sanitizeCgroupTag(cmdID), pid, limits.CgroupV2Limits{
+	cgLimits := limits.CgroupV2Limits{
 		MaxMemoryBytes: memBytes,
 		CPUQuotaPct:    lim.CPUQuotaPercent,
 		PidsMax:        lim.PidsMax,
-	})
+	}
+
+	if app.cgroupMgr == nil {
+		return nil, fmt.Errorf("cgroup manager not initialized")
+	}
+
+	cg, err := app.cgroupMgr.Apply("agentsh-"+sanitizeCgroupTag(sessionID)+"-"+sanitizeCgroupTag(cmdID), pid, cgLimits)
 	if err != nil {
+		var ue *limits.CgroupUnavailableError
+		if errors.As(err, &ue) {
+			ev := types.Event{
+				ID:        uuid.NewString(),
+				Timestamp: time.Now().UTC(),
+				Type:      string(events.EventCgroupUnavailableRefusal),
+				SessionID: sessionID,
+				CommandID: cmdID,
+				Fields: map[string]any{
+					"reason":        ue.Reason,
+					"max_memory_mb": lim.MaxMemoryMB,
+					"cpu_quota_pct": lim.CPUQuotaPercent,
+					"pids_max":      lim.PidsMax,
+				},
+			}
+			_ = emit.AppendEvent(ctx, ev)
+			emit.Publish(ev)
+			return nil, err
+		}
 		ev := types.Event{
 			ID:        uuid.NewString(),
 			Timestamp: time.Now().UTC(),
@@ -60,6 +79,11 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, cfg *config.Config, s
 		return nil, err
 	}
 
+	// If unavailable mode allowed us (empty limits), cg is nil. Treat as no-op.
+	if cg == nil {
+		return func() error { return nil }, nil
+	}
+
 	ev := types.Event{
 		ID:        uuid.NewString(),
 		Timestamp: time.Now().UTC(),
@@ -67,11 +91,11 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, cfg *config.Config, s
 		SessionID: sessionID,
 		CommandID: cmdID,
 		Fields: map[string]any{
-			"path":           cg.Path,
-			"max_memory_mb":  lim.MaxMemoryMB,
-			"cpu_quota_pct":  lim.CPUQuotaPercent,
-			"pids_max":       lim.PidsMax,
-			"base_path_used": parent,
+			"path":          cg.Path,
+			"mode":          string(app.cgroupMgr.Probe().Mode),
+			"max_memory_mb": lim.MaxMemoryMB,
+			"cpu_quota_pct": lim.CPUQuotaPercent,
+			"pids_max":      lim.PidsMax,
 		},
 	}
 	_ = emit.AppendEvent(ctx, ev)

--- a/internal/api/deferred_fuse_test.go
+++ b/internal/api/deferred_fuse_test.go
@@ -113,7 +113,7 @@ func newDeferredTestApp(t *testing.T, sessions *session.Manager, store *composit
 	if err != nil {
 		t.Fatal(err)
 	}
-	return NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	return NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 }
 
 func newDeferredTestSession(t *testing.T, mgr *session.Manager) *session.Session {
@@ -313,7 +313,7 @@ func TestEnsureFUSEMount_NilPolicyAndEmitter(t *testing.T) {
 		},
 	}, false, true)
 
-	app := NewApp(cfg, mgr, store, engine, events.NewBroker(), nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, engine, events.NewBroker(), nil, nil, nil, nil, nil, nil)
 
 	mfs := &mockFilesystem{}
 	mfs.available.Store(true)
@@ -354,7 +354,7 @@ func TestMountFUSEForSession_DeferredEventField(t *testing.T) {
 		},
 	}, false, true)
 
-	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, metrics.New(), nil, nil)
 
 	mfs := &mockFilesystem{}
 	mfs.available.Store(true)

--- a/internal/api/ebpf_integration_test.go
+++ b/internal/api/ebpf_integration_test.go
@@ -49,7 +49,7 @@ func TestEBPFConnectEventFlow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 
 	// Create command cgroup and attach ebpf via hook.
 	hook := app.cgroupHook(sess.ID, "cmd-test", policy.Limits{})

--- a/internal/api/exec_include_events_test.go
+++ b/internal/api/exec_include_events_test.go
@@ -100,7 +100,7 @@ func TestExec_IncludeEventsSummary_CapsBlockedOps(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	// Trigger a command policy deny (rm -rf) which returns blocked_operations in response.

--- a/internal/api/file_monitor_linux_test.go
+++ b/internal/api/file_monitor_linux_test.go
@@ -199,7 +199,7 @@ func TestMountFUSEForSession_RegistersMountPointNotSourcePath(t *testing.T) {
 	}, false, true)
 	require.NoError(t, err)
 
-	app := NewApp(cfg, mgr, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, mgr, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 
 	mfs := &mockFilesystem{}
 	mfs.available.Store(true)

--- a/internal/api/llmproxy_integration_test.go
+++ b/internal/api/llmproxy_integration_test.go
@@ -67,7 +67,7 @@ func TestIntegration_LLMProxyStartedOnSessionCreate(t *testing.T) {
 	}
 
 	broker := events.NewBroker()
-	app := NewApp(cfg, sessions, store, engine, broker, nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, broker, nil, nil, nil, metrics.New(), nil, nil)
 
 	// Create a session - this should start the LLM proxy
 	ctx := context.Background()
@@ -183,7 +183,7 @@ func TestIntegration_LLMProxyEnvVarsInSession(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 
 	ctx := context.Background()
 	req := types.CreateSessionRequest{Workspace: ws}
@@ -244,7 +244,7 @@ func TestIntegration_LLMProxyNotStartedWhenDisabled(t *testing.T) {
 	}
 
 	broker := events.NewBroker()
-	app := NewApp(cfg, sessions, store, engine, broker, nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, broker, nil, nil, nil, metrics.New(), nil, nil)
 
 	ctx := context.Background()
 	req := types.CreateSessionRequest{Workspace: ws}
@@ -323,7 +323,7 @@ func TestIntegration_LLMProxyBothDialects(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 
 	ctx := context.Background()
 	snap, _, err := app.createSessionCore(ctx, types.CreateSessionRequest{Workspace: t.TempDir()})

--- a/internal/api/mcp_query_test.go
+++ b/internal/api/mcp_query_test.go
@@ -25,7 +25,7 @@ func newMCPTestApp(t *testing.T, st *sqlite.Store) http.Handler {
 	cfg.Metrics.Enabled = false
 	cfg.Health.Path = "/health"
 	cfg.Health.ReadinessPath = "/ready"
-	app := NewApp(cfg, sessions, store, nil, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, nil, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 	return app.Router()
 }
 

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -27,7 +27,7 @@ func TestRouter_MetricsEnabledServesPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rr := httptest.NewRecorder()

--- a/internal/api/policies_test.go
+++ b/internal/api/policies_test.go
@@ -30,7 +30,7 @@ func newTestAppForPolicies(t *testing.T) *App {
 	mgr := session.NewManager(5)
 	store := composite.New(mockEventStore{}, nil)
 	broker := events.NewBroker()
-	return NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil)
+	return NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil)
 }
 
 func TestValidatePolicyRules(t *testing.T) {

--- a/internal/api/profile_session_test.go
+++ b/internal/api/profile_session_test.go
@@ -59,7 +59,7 @@ func TestCreateSessionWithProfile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	body := `{"profile":"test-profile"}`
@@ -108,7 +108,7 @@ func TestCreateSessionWithProfile_ProfileNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	body := `{"profile":"nonexistent-profile"}`
@@ -155,7 +155,7 @@ func TestCreateSessionWithProfile_MissingMountPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	body := `{"profile":"bad-path-profile"}`
@@ -215,7 +215,7 @@ func TestCreateSessionWithProfile_RealPaths(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	body := `{"profile":"test-profile","real_paths":true}`
@@ -275,7 +275,7 @@ func TestCreateSessionWithProfile_RealPathsDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	// Request with real_paths=false overrides config default

--- a/internal/api/profiles_test.go
+++ b/internal/api/profiles_test.go
@@ -33,7 +33,7 @@ func TestListProfiles_Empty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/profiles", nil)
@@ -94,7 +94,7 @@ func TestListProfiles_MultipleProfiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/profiles", nil)
@@ -172,7 +172,7 @@ func TestListProfiles_ContentType(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 	h := app.Router()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/profiles", nil)

--- a/internal/api/pty_grpc_policy_test.go
+++ b/internal/api/pty_grpc_policy_test.go
@@ -62,7 +62,7 @@ func TestGRPC_PTY_RespectsCommandPolicyDeny(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 
 	lis := bufconn.Listen(1024 * 1024)
 	t.Cleanup(func() { _ = lis.Close() })

--- a/internal/api/pty_ws_policy_test.go
+++ b/internal/api/pty_ws_policy_test.go
@@ -57,7 +57,7 @@ func TestPTYWebSocket_RespectsCommandPolicyDeny(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 
 	srv := newHTTPTestServerOrSkip(t, app.Router())
 

--- a/internal/api/seccomp_wrapper_test.go
+++ b/internal/api/seccomp_wrapper_test.go
@@ -16,7 +16,7 @@ func newTestAppForSeccomp(t *testing.T, cfg *config.Config) *App {
 	mgr := session.NewManager(5)
 	store := composite.New(mockEventStore{}, nil)
 	broker := events.NewBroker()
-	return NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil)
+	return NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil)
 }
 
 func TestSetupSeccompWrapper_DisabledByConfig(t *testing.T) {

--- a/internal/api/session_patch_kill_test.go
+++ b/internal/api/session_patch_kill_test.go
@@ -49,7 +49,7 @@ func newTestApp(t *testing.T, sessions *session.Manager, store *composite.Store)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil)
+	return NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
 }
 
 func newSQLiteStore(t *testing.T) *sqlite.Store {

--- a/internal/api/session_policy_integration_test.go
+++ b/internal/api/session_policy_integration_test.go
@@ -76,7 +76,7 @@ func TestExecInSessionCore_PrecheckConsultsSessionPolicy(t *testing.T) {
 	broker := events.NewBroker()
 
 	cfg := &config.Config{}
-	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil, nil)
 
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
@@ -172,7 +172,7 @@ func newSessionPolicyFixture(t *testing.T) *sessionPolicyFixture {
 	broker := events.NewBroker()
 
 	cfg := &config.Config{}
-	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil, nil)
 
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
@@ -558,7 +558,7 @@ func TestPolicyTest_HonorsSessionID(t *testing.T) {
 	store := composite.New(captured, nil)
 	broker := events.NewBroker()
 	cfg := &config.Config{}
-	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil, nil)
 
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
@@ -661,7 +661,7 @@ func TestGRPCPolicyTest_HonorsSessionID(t *testing.T) {
 	store := composite.New(captured, nil)
 	broker := events.NewBroker()
 	cfg := &config.Config{}
-	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil, nil)
 
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -21,7 +21,7 @@ func newTestAppForWrap(t *testing.T, cfg *config.Config) (*App, *session.Manager
 	mgr := session.NewManager(5)
 	store := composite.New(mockEventStore{}, nil)
 	broker := events.NewBroker()
-	app := NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil)
 	return app, mgr
 }
 
@@ -304,7 +304,7 @@ func newTestAppForWrapWithSignalPolicy(t *testing.T, cfg *config.Config) (*App, 
 	if err != nil {
 		t.Fatalf("create policy engine: %v", err)
 	}
-	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
 	return app, mgr
 }
 

--- a/internal/capabilities/check_cgroups_linux.go
+++ b/internal/capabilities/check_cgroups_linux.go
@@ -3,14 +3,31 @@
 package capabilities
 
 import (
-	"os"
+	"context"
 
+	"github.com/agentsh/agentsh/internal/limits"
 	"golang.org/x/sys/unix"
 )
 
 const cgroup2SuperMagic = 0x63677270
 
+// cgroupProbeCache stores the most recent rich probe result so that
+// detect_linux.go can pull structured fields into the flat capabilities map.
+// Updated by probeCgroupsV2; read by backwardCompatCaps via LastCgroupProbe.
+var cgroupProbeCache *limits.CgroupProbeResult
+
+func cacheCgroupProbe(r *limits.CgroupProbeResult) {
+	cgroupProbeCache = r
+}
+
+// LastCgroupProbe returns the most recent probe result, or nil if the probe
+// has not been run in this process. Exposed for detect output formatting.
+func LastCgroupProbe() *limits.CgroupProbeResult {
+	return cgroupProbeCache
+}
+
 func probeCgroupsV2() ProbeResult {
+	// Quick sanity: is cgroup2 even mounted?
 	var statfs unix.Statfs_t
 	if err := unix.Statfs("/sys/fs/cgroup", &statfs); err != nil {
 		return ProbeResult{Available: false, Detail: "not mounted"}
@@ -18,10 +35,18 @@ func probeCgroupsV2() ProbeResult {
 	if statfs.Type != cgroup2SuperMagic {
 		return ProbeResult{Available: false, Detail: "cgroup v1"}
 	}
-	f, err := os.OpenFile("/sys/fs/cgroup/cgroup.procs", os.O_RDONLY, 0)
-	if err != nil {
-		return ProbeResult{Available: false, Detail: "not readable"}
+
+	// Run the full probe from the limits package.
+	if !limits.DetectCgroupV2() {
+		return ProbeResult{Available: false, Detail: "cgroup2 not mounted"}
 	}
-	f.Close()
-	return ProbeResult{Available: true, Detail: "cgroup2"}
+	res, err := limits.ProbeCgroupsV2Default(context.Background())
+	if err != nil {
+		return ProbeResult{Available: false, Detail: "probe error: " + err.Error()}
+	}
+	cacheCgroupProbe(res)
+	return ProbeResult{
+		Available: res.Mode != limits.ModeUnavailable,
+		Detail:    string(res.Mode) + ": " + res.Reason,
+	}
 }

--- a/internal/capabilities/detect_linux.go
+++ b/internal/capabilities/detect_linux.go
@@ -152,6 +152,18 @@ func backwardCompatCaps(caps *SecurityCapabilities, domains []ProtectionDomain) 
 	if _, ok := m["fuse_mount_method"]; !ok {
 		m["fuse_mount_method"] = "none"
 	}
+
+	// Enrich the cgroups_v2 view with probe details (issue #197).
+	if p := LastCgroupProbe(); p != nil {
+		m["cgroups_v2_mode"] = string(p.Mode)
+		m["cgroups_v2_reason"] = p.Reason
+		m["cgroups_v2_own_cgroup"] = p.OwnCgroup
+		if p.SliceDir != "" {
+			m["cgroups_v2_slice_dir"] = p.SliceDir
+		}
+		m["cgroups_v2_io_available"] = p.IOAvailable
+	}
+
 	return m
 }
 

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -129,6 +129,13 @@ const (
 	EventPolicyChanged EventType = "policy_changed"
 )
 
+// Cgroup v2 probe and enforcement events (see issue #197).
+const (
+	EventCgroupMode               EventType = "cgroup_mode"
+	EventCgroupOrphansReaped      EventType = "cgroup_orphans_reaped"
+	EventCgroupUnavailableRefusal EventType = "cgroup_unavailable_refusal"
+)
+
 // PolicyLoadedEvent is emitted when a policy is loaded.
 type PolicyLoadedEvent struct {
 	PolicyName    string `json:"policy_name"`
@@ -245,6 +252,11 @@ var EventCategory = map[EventType]string{
 	// Policy
 	EventPolicyLoaded:  "policy",
 	EventPolicyChanged: "policy",
+
+	// Cgroup
+	EventCgroupMode:               "cgroup",
+	EventCgroupOrphansReaped:      "cgroup",
+	EventCgroupUnavailableRefusal: "cgroup",
 }
 
 // AllEventTypes lists all event types.
@@ -285,4 +297,6 @@ var AllEventTypes = []EventType{
 	EventPackageApproved, EventPackageWarning, EventProviderError,
 	// Policy
 	EventPolicyLoaded, EventPolicyChanged,
+	// Cgroup
+	EventCgroupMode, EventCgroupOrphansReaped, EventCgroupUnavailableRefusal,
 }

--- a/internal/limits/cgroup_fs_fake_test.go
+++ b/internal/limits/cgroup_fs_fake_test.go
@@ -162,16 +162,19 @@ func (w *fakeWriter) WriteString(s string) (int, error) {
 	}
 	w.buf.WriteString(s)
 	// Append to the underlying file content on every write, mimicking
-	// cgroup subtree_control semantics (each write appends a token).
+	// cgroup subtree_control semantics: the kernel stores the controller
+	// name without the leading "+"/"-" prefix.
 	e := w.fs.files[w.path]
 	if e == nil {
 		return 0, &fs.PathError{Op: "write", Path: w.path, Err: syscall.ENOENT}
 	}
+	token := strings.TrimPrefix(s, "+")
+	token = strings.TrimPrefix(token, "-")
 	sep := ""
 	if len(e.content) > 0 && !bytes.HasSuffix(e.content, []byte(" ")) {
 		sep = " "
 	}
-	e.content = append(e.content, []byte(sep+s)...)
+	e.content = append(e.content, []byte(sep+token)...)
 	return len(s), nil
 }
 

--- a/internal/limits/cgroup_fs_fake_test.go
+++ b/internal/limits/cgroup_fs_fake_test.go
@@ -1,0 +1,263 @@
+//go:build linux
+
+package limits
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// fakeCgroupFS is an in-memory cgroupFS used by unit tests.
+// Paths are treated as a flat map; parent directories are auto-created on Mkdir.
+type fakeCgroupFS struct {
+	// files maps absolute path -> entry. An entry with isDir=true represents a directory.
+	files map[string]*fakeEntry
+	// writeErrs optionally returns a specific error for WriteFile(path) or OpenFile(path) calls.
+	writeErrs map[string]error
+	// openErrs mirrors writeErrs but for OpenFile (subtree_control writes).
+	openErrs map[string]error
+}
+
+type fakeEntry struct {
+	content []byte
+	isDir   bool
+}
+
+func newFakeCgroupFS() *fakeCgroupFS {
+	return &fakeCgroupFS{
+		files:     map[string]*fakeEntry{"/sys/fs/cgroup": {isDir: true}},
+		writeErrs: map[string]error{},
+		openErrs:  map[string]error{},
+	}
+}
+
+// seedDir creates a directory and its parents.
+func (f *fakeCgroupFS) seedDir(p string) {
+	p = path.Clean(p)
+	parts := strings.Split(strings.TrimPrefix(p, "/"), "/")
+	cur := ""
+	for _, part := range parts {
+		cur = cur + "/" + part
+		if _, ok := f.files[cur]; !ok {
+			f.files[cur] = &fakeEntry{isDir: true}
+		}
+	}
+}
+
+// seedFile writes content at an absolute path, creating parent dirs.
+func (f *fakeCgroupFS) seedFile(p string, content string) {
+	f.seedDir(path.Dir(p))
+	f.files[path.Clean(p)] = &fakeEntry{content: []byte(content)}
+}
+
+func (f *fakeCgroupFS) ReadFile(p string) ([]byte, error) {
+	e, ok := f.files[path.Clean(p)]
+	if !ok {
+		return nil, &fs.PathError{Op: "open", Path: p, Err: syscall.ENOENT}
+	}
+	if e.isDir {
+		return nil, &fs.PathError{Op: "read", Path: p, Err: syscall.EISDIR}
+	}
+	return append([]byte(nil), e.content...), nil
+}
+
+func (f *fakeCgroupFS) WriteFile(p string, data []byte, perm os.FileMode) error {
+	p = path.Clean(p)
+	if err, ok := f.writeErrs[p]; ok {
+		return &fs.PathError{Op: "write", Path: p, Err: err}
+	}
+	if e, ok := f.files[p]; ok && e.isDir {
+		return &fs.PathError{Op: "write", Path: p, Err: syscall.EISDIR}
+	}
+	if _, ok := f.files[path.Dir(p)]; !ok {
+		return &fs.PathError{Op: "write", Path: p, Err: syscall.ENOENT}
+	}
+	f.files[p] = &fakeEntry{content: append([]byte(nil), data...)}
+	return nil
+}
+
+func (f *fakeCgroupFS) Mkdir(p string, perm os.FileMode) error {
+	p = path.Clean(p)
+	if _, ok := f.files[p]; ok {
+		return &fs.PathError{Op: "mkdir", Path: p, Err: syscall.EEXIST}
+	}
+	if _, ok := f.files[path.Dir(p)]; !ok {
+		return &fs.PathError{Op: "mkdir", Path: p, Err: syscall.ENOENT}
+	}
+	f.files[p] = &fakeEntry{isDir: true}
+	return nil
+}
+
+func (f *fakeCgroupFS) Remove(p string) error {
+	p = path.Clean(p)
+	if _, ok := f.files[p]; !ok {
+		return &fs.PathError{Op: "remove", Path: p, Err: syscall.ENOENT}
+	}
+	delete(f.files, p)
+	return nil
+}
+
+func (f *fakeCgroupFS) Stat(p string) (os.FileInfo, error) {
+	p = path.Clean(p)
+	e, ok := f.files[p]
+	if !ok {
+		return nil, &fs.PathError{Op: "stat", Path: p, Err: syscall.ENOENT}
+	}
+	return &fakeFileInfo{name: path.Base(p), size: int64(len(e.content)), isDir: e.isDir}, nil
+}
+
+func (f *fakeCgroupFS) ReadDir(p string) ([]os.DirEntry, error) {
+	p = path.Clean(p)
+	if e, ok := f.files[p]; !ok || !e.isDir {
+		return nil, &fs.PathError{Op: "readdir", Path: p, Err: syscall.ENOENT}
+	}
+	var names []string
+	prefix := p + "/"
+	for k := range f.files {
+		if k == p {
+			continue
+		}
+		if strings.HasPrefix(k, prefix) && !strings.Contains(strings.TrimPrefix(k, prefix), "/") {
+			names = append(names, path.Base(k))
+		}
+	}
+	sort.Strings(names)
+	out := make([]os.DirEntry, 0, len(names))
+	for _, n := range names {
+		full := path.Join(p, n)
+		e := f.files[full]
+		out = append(out, &fakeDirEntry{name: n, isDir: e.isDir})
+	}
+	return out, nil
+}
+
+func (f *fakeCgroupFS) OpenFile(p string, flag int, perm os.FileMode) (cgroupFile, error) {
+	p = path.Clean(p)
+	if err, ok := f.openErrs[p]; ok {
+		return nil, &fs.PathError{Op: "open", Path: p, Err: err}
+	}
+	if _, ok := f.files[p]; !ok {
+		return nil, &fs.PathError{Op: "open", Path: p, Err: syscall.ENOENT}
+	}
+	return &fakeWriter{fs: f, path: p}, nil
+}
+
+type fakeWriter struct {
+	fs   *fakeCgroupFS
+	path string
+	buf  bytes.Buffer
+}
+
+func (w *fakeWriter) WriteString(s string) (int, error) {
+	if err, ok := w.fs.openErrs[w.path+":write"]; ok {
+		return 0, &fs.PathError{Op: "write", Path: w.path, Err: err}
+	}
+	w.buf.WriteString(s)
+	// Append to the underlying file content on every write, mimicking
+	// cgroup subtree_control semantics (each write appends a token).
+	e := w.fs.files[w.path]
+	if e == nil {
+		return 0, &fs.PathError{Op: "write", Path: w.path, Err: syscall.ENOENT}
+	}
+	sep := ""
+	if len(e.content) > 0 && !bytes.HasSuffix(e.content, []byte(" ")) {
+		sep = " "
+	}
+	e.content = append(e.content, []byte(sep+s)...)
+	return len(s), nil
+}
+
+func (w *fakeWriter) Close() error { return nil }
+
+type fakeFileInfo struct {
+	name  string
+	size  int64
+	isDir bool
+}
+
+func (f *fakeFileInfo) Name() string      { return f.name }
+func (f *fakeFileInfo) Size() int64       { return f.size }
+func (f *fakeFileInfo) Mode() os.FileMode {
+	if f.isDir {
+		return os.ModeDir | 0o755
+	}
+	return 0o644
+}
+func (f *fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f *fakeFileInfo) IsDir() bool        { return f.isDir }
+func (f *fakeFileInfo) Sys() any           { return nil }
+
+type fakeDirEntry struct {
+	name  string
+	isDir bool
+}
+
+func (d *fakeDirEntry) Name() string               { return d.name }
+func (d *fakeDirEntry) IsDir() bool                { return d.isDir }
+func (d *fakeDirEntry) Type() os.FileMode {
+	if d.isDir {
+		return os.ModeDir
+	}
+	return 0
+}
+func (d *fakeDirEntry) Info() (os.FileInfo, error) {
+	return &fakeFileInfo{name: d.name, isDir: d.isDir}, nil
+}
+
+// assertSubtreeControl returns an error unless path's content contains all of
+// the given controllers (used in tests).
+func (f *fakeCgroupFS) assertSubtreeControl(p string, want ...string) error {
+	e, ok := f.files[path.Clean(p)]
+	if !ok {
+		return fmt.Errorf("%s does not exist", p)
+	}
+	have := strings.Fields(string(e.content))
+	set := map[string]bool{}
+	for _, h := range have {
+		set[strings.TrimPrefix(h, "+")] = true
+	}
+	for _, w := range want {
+		if !set[w] {
+			return fmt.Errorf("%s missing controller %q (have %q)", p, w, string(e.content))
+		}
+	}
+	return nil
+}
+
+// TestFakeCgroupFS_Smoke covers basic behaviors of the fake itself.
+func TestFakeCgroupFS_Smoke(t *testing.T) {
+	f := newFakeCgroupFS()
+	f.seedFile("/sys/fs/cgroup/cgroup.controllers", "cpuset cpu io memory pids")
+	data, err := f.ReadFile("/sys/fs/cgroup/cgroup.controllers")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != "cpuset cpu io memory pids" {
+		t.Fatalf("unexpected content: %q", data)
+	}
+
+	if err := f.Mkdir("/sys/fs/cgroup/agentsh.slice", 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	entries, err := f.ReadDir("/sys/fs/cgroup")
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	found := false
+	for _, e := range entries {
+		if e.Name() == "agentsh.slice" && e.IsDir() {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected agentsh.slice in readdir, got %v", entries)
+	}
+}

--- a/internal/limits/cgroup_fs_linux.go
+++ b/internal/limits/cgroup_fs_linux.go
@@ -1,0 +1,57 @@
+//go:build linux
+
+package limits
+
+import (
+	"os"
+)
+
+// cgroupFile is the write handle returned by cgroupFS.OpenFile.
+// It abstracts over *os.File for testing.
+type cgroupFile interface {
+	WriteString(s string) (int, error)
+	Close() error
+}
+
+// cgroupFS abstracts filesystem operations on the cgroup hierarchy.
+// The real implementation delegates to the os package; tests use fakeCgroupFS.
+type cgroupFS interface {
+	ReadFile(path string) ([]byte, error)
+	WriteFile(path string, data []byte, perm os.FileMode) error
+	Mkdir(path string, perm os.FileMode) error
+	Remove(path string) error
+	Stat(path string) (os.FileInfo, error)
+	ReadDir(path string) ([]os.DirEntry, error)
+	OpenFile(path string, flag int, perm os.FileMode) (cgroupFile, error)
+}
+
+// osCgroupFS is the production cgroupFS backed by the real OS.
+type osCgroupFS struct{}
+
+func (osCgroupFS) ReadFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+func (osCgroupFS) WriteFile(path string, data []byte, perm os.FileMode) error {
+	return os.WriteFile(path, data, perm)
+}
+
+func (osCgroupFS) Mkdir(path string, perm os.FileMode) error {
+	return os.Mkdir(path, perm)
+}
+
+func (osCgroupFS) Remove(path string) error {
+	return os.Remove(path)
+}
+
+func (osCgroupFS) Stat(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}
+
+func (osCgroupFS) ReadDir(path string) ([]os.DirEntry, error) {
+	return os.ReadDir(path)
+}
+
+func (osCgroupFS) OpenFile(path string, flag int, perm os.FileMode) (cgroupFile, error) {
+	return os.OpenFile(path, flag, perm)
+}

--- a/internal/limits/cgroupv2_errors.go
+++ b/internal/limits/cgroupv2_errors.go
@@ -1,0 +1,71 @@
+//go:build linux
+
+package limits
+
+import "fmt"
+
+// EnableControllersError is returned by enableControllers (and enableControllersFS)
+// when writing to cgroup.subtree_control fails. It carries the parent cgroup
+// directory, the controller that failed (or "*" when the file could not be
+// opened at all), and the underlying OS error.
+type EnableControllersError struct {
+	ParentDir  string
+	Controller string
+	Err        error
+}
+
+func (e *EnableControllersError) Error() string {
+	return fmt.Sprintf("enable cgroup controller %q in %s: %v", e.Controller, e.ParentDir, e.Err)
+}
+
+func (e *EnableControllersError) Unwrap() error { return e.Err }
+
+// CgroupUnavailableError is returned by CgroupManager.Apply when the manager's
+// probed mode is ModeUnavailable and the caller's policy requires one or more
+// non-zero resource limits. The error carries the probe reason and the
+// requested limits so that audit events can record the refusal context.
+type CgroupUnavailableError struct {
+	Reason string
+	Limits CgroupV2Limits
+}
+
+func (e *CgroupUnavailableError) Error() string {
+	return fmt.Sprintf(
+		"cgroup enforcement unavailable (%s); policy requires %s — refusing command",
+		e.Reason, e.Limits.Summary())
+}
+
+// Summary returns a compact human-readable description of non-zero limits.
+func (l CgroupV2Limits) Summary() string {
+	parts := []string{}
+	if l.MaxMemoryBytes > 0 {
+		parts = append(parts, fmt.Sprintf("memory.max=%d", l.MaxMemoryBytes))
+	}
+	if l.PidsMax > 0 {
+		parts = append(parts, fmt.Sprintf("pids.max=%d", l.PidsMax))
+	}
+	if l.CPUQuotaPct > 0 {
+		parts = append(parts, fmt.Sprintf("cpu.quota=%d%%", l.CPUQuotaPct))
+	}
+	if len(parts) == 0 {
+		return "no limits"
+	}
+	return joinComma(parts)
+}
+
+func joinComma(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += ", "
+		}
+		out += p
+	}
+	return out
+}
+
+// IsEmpty reports whether the limits struct contains no enforceable values.
+// A caller can skip cgroup creation entirely when IsEmpty is true.
+func (l CgroupV2Limits) IsEmpty() bool {
+	return l.MaxMemoryBytes <= 0 && l.CPUQuotaPct <= 0 && l.PidsMax <= 0
+}

--- a/internal/limits/cgroupv2_integration_test.go
+++ b/internal/limits/cgroupv2_integration_test.go
@@ -1,0 +1,110 @@
+//go:build linux && cgroup_integration
+
+package limits
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Run with:
+//   go test -tags cgroup_integration ./internal/limits/... -v
+// on a Linux host with privileges to write /sys/fs/cgroup.
+
+func TestIntegration_ProbeReal(t *testing.T) {
+	if !DetectCgroupV2() {
+		t.Skip("cgroup v2 not mounted")
+	}
+	m, err := NewCgroupManager(context.Background(), "")
+	if err != nil {
+		t.Fatalf("NewCgroupManager: %v", err)
+	}
+	p := m.Probe()
+	t.Logf("probe: mode=%s reason=%s own=%s slice=%s io=%v",
+		p.Mode, p.Reason, p.OwnCgroup, p.SliceDir, p.IOAvailable)
+	switch p.Mode {
+	case ModeNested, ModeTopLevel, ModeUnavailable:
+	default:
+		t.Fatalf("unexpected mode %q", p.Mode)
+	}
+}
+
+func TestIntegration_TopLevelApplyAndEnforce(t *testing.T) {
+	if !DetectCgroupV2() {
+		t.Skip("cgroup v2 not mounted")
+	}
+	m, err := NewCgroupManager(context.Background(), "")
+	if err != nil {
+		t.Fatalf("NewCgroupManager: %v", err)
+	}
+	if m.Probe().Mode != ModeTopLevel {
+		t.Skipf("not in top-level mode (got %s)", m.Probe().Mode)
+	}
+
+	cmd := exec.Command("sleep", "0.2")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot start sleep: %v", err)
+	}
+	defer func() { _ = cmd.Process.Kill() }()
+
+	cg, err := m.Apply("agentsh-integ-top-level", cmd.Process.Pid, CgroupV2Limits{
+		MaxMemoryBytes: 8 << 20,
+	})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = cg.Close(ctx)
+	}()
+	if !strings.HasPrefix(cg.Path, DefaultSliceDir) {
+		t.Fatalf("expected top-level path under %s, got %q", DefaultSliceDir, cg.Path)
+	}
+	data, err := os.ReadFile(filepath.Join(cg.Path, "memory.max"))
+	if err != nil {
+		t.Fatalf("read memory.max: %v", err)
+	}
+	if strings.TrimSpace(string(data)) != "8388608" {
+		t.Fatalf("memory.max: got %q, want 8388608", data)
+	}
+	_ = cmd.Wait()
+}
+
+func TestIntegration_OrphanReap(t *testing.T) {
+	if !DetectCgroupV2() {
+		t.Skip("cgroup v2 not mounted")
+	}
+	// This test only runs meaningfully in top-level mode.
+	probe, err := ProbeCgroupsV2(context.Background(), osCgroupFS{}, "")
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if probe.Mode != ModeTopLevel {
+		t.Skipf("not in top-level mode (got %s)", probe.Mode)
+	}
+
+	orphan := filepath.Join(DefaultSliceDir, "integ-orphan")
+	if err := os.Mkdir(orphan, 0o755); err != nil && !os.IsExist(err) {
+		t.Fatalf("mkdir orphan: %v", err)
+	}
+	// Pre-verify the orphan is unpopulated.
+	if _, err := os.ReadFile(filepath.Join(orphan, "cgroup.events")); err != nil {
+		t.Fatalf("read events on orphan: %v", err)
+	}
+
+	// Re-probe to trigger reap.
+	probe2, err := ProbeCgroupsV2(context.Background(), osCgroupFS{}, "")
+	if err != nil {
+		t.Fatalf("re-probe: %v", err)
+	}
+	_ = probe2
+	if _, err := os.Stat(orphan); err == nil {
+		t.Fatalf("orphan %s should have been reaped", orphan)
+	}
+}

--- a/internal/limits/cgroupv2_linux.go
+++ b/internal/limits/cgroupv2_linux.go
@@ -52,6 +52,9 @@ func CurrentCgroupDir() (string, error) {
 	return filepath.Join("/sys/fs/cgroup", strings.TrimPrefix(p, "/")), nil
 }
 
+// Deprecated: Use CgroupManager.Apply instead. ApplyCgroupV2 does not probe the
+// cgroup hierarchy and silently discards enableControllers errors. It is retained
+// only for callers that have not yet migrated (limiter_linux.go, platform/linux).
 func ApplyCgroupV2(parentDir string, name string, pid int, lim CgroupV2Limits) (*CgroupV2, error) {
 	if pid <= 0 {
 		return nil, fmt.Errorf("invalid pid %d", pid)

--- a/internal/limits/cgroupv2_linux.go
+++ b/internal/limits/cgroupv2_linux.go
@@ -168,17 +168,33 @@ func sanitizeCgroupName(s string) string {
 	return out
 }
 
+// enableControllers writes "+<ctrl>" to parentDir/cgroup.subtree_control for each
+// controller in ctrls. On the first write failure it returns a wrapped
+// *EnableControllersError; on success it returns nil. This is a change from
+// prior behavior, which silently continued past per-controller errors and
+// masked delegation issues (issue #197).
 func enableControllers(parentDir string, ctrls []string) error {
+	return enableControllersFS(osCgroupFS{}, parentDir, ctrls)
+}
+
+func enableControllersFS(fsys cgroupFS, parentDir string, ctrls []string) error {
 	path := filepath.Join(parentDir, "cgroup.subtree_control")
-	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	f, err := fsys.OpenFile(path, os.O_WRONLY, 0)
 	if err != nil {
-		return err
+		return &EnableControllersError{
+			ParentDir:  parentDir,
+			Controller: "*",
+			Err:        err,
+		}
 	}
 	defer f.Close()
 	for _, c := range ctrls {
 		if _, err := f.WriteString("+" + c); err != nil {
-			// Ignore EBUSY etc; best effort.
-			continue
+			return &EnableControllersError{
+				ParentDir:  parentDir,
+				Controller: c,
+				Err:        err,
+			}
 		}
 	}
 	return nil

--- a/internal/limits/cgroupv2_linux_test.go
+++ b/internal/limits/cgroupv2_linux_test.go
@@ -72,6 +72,29 @@ func TestEnableControllers_ReturnsError(t *testing.T) {
 	}
 }
 
+func TestEnableControllers_OpenFileFailure(t *testing.T) {
+	// When OpenFile itself fails (subtree_control doesn't exist or is inaccessible),
+	// the error should use Controller:"*" and wrap the OS error.
+	f := newFakeCgroupFS()
+	f.seedDir("/sys/fs/cgroup/system.slice/agentsh.service")
+	// Do NOT seed cgroup.subtree_control — OpenFile will return ENOENT.
+
+	err := enableControllersFS(f, "/sys/fs/cgroup/system.slice/agentsh.service", []string{"cpu", "memory", "pids"})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	var ece *EnableControllersError
+	if !errors.As(err, &ece) {
+		t.Fatalf("expected *EnableControllersError, got %T: %v", err, err)
+	}
+	if ece.Controller != "*" {
+		t.Fatalf("expected Controller='*' for open failure, got %q", ece.Controller)
+	}
+	if !errors.Is(err, syscall.ENOENT) {
+		t.Fatalf("expected wrapped ENOENT, got %v", err)
+	}
+}
+
 func TestManagerApply_CreatesAndCleansUp_Integration(t *testing.T) {
 	if !DetectCgroupV2() {
 		t.Skip("cgroup v2 not available")

--- a/internal/limits/cgroupv2_linux_test.go
+++ b/internal/limits/cgroupv2_linux_test.go
@@ -4,9 +4,11 @@ package limits
 
 import (
 	"context"
+	"errors"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -45,5 +47,27 @@ func TestApplyCgroupV2_CreatesAndCleansUp(t *testing.T) {
 	defer cancel()
 	if err := cg.Close(ctx); err != nil {
 		t.Fatalf("close cgroup: %v", err)
+	}
+}
+
+func TestEnableControllers_ReturnsError(t *testing.T) {
+	// Create a fake FS where subtree_control exists but WriteString injects EBUSY.
+	f := newFakeCgroupFS()
+	f.seedFile("/sys/fs/cgroup/system.slice/agentsh.service/cgroup.subtree_control", "")
+	f.openErrs["/sys/fs/cgroup/system.slice/agentsh.service/cgroup.subtree_control:write"] = syscall.EBUSY
+
+	err := enableControllersFS(f, "/sys/fs/cgroup/system.slice/agentsh.service", []string{"cpu", "memory", "pids"})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	var ece *EnableControllersError
+	if !errors.As(err, &ece) {
+		t.Fatalf("expected *EnableControllersError, got %T: %v", err, err)
+	}
+	if ece.Controller != "cpu" {
+		t.Fatalf("expected first failing controller to be 'cpu', got %q", ece.Controller)
+	}
+	if !errors.Is(err, syscall.EBUSY) {
+		t.Fatalf("expected wrapped EBUSY, got %v", err)
 	}
 }

--- a/internal/limits/cgroupv2_linux_test.go
+++ b/internal/limits/cgroupv2_linux_test.go
@@ -71,3 +71,47 @@ func TestEnableControllers_ReturnsError(t *testing.T) {
 		t.Fatalf("expected wrapped EBUSY, got %v", err)
 	}
 }
+
+func TestManagerApply_CreatesAndCleansUp_Integration(t *testing.T) {
+	if !DetectCgroupV2() {
+		t.Skip("cgroup v2 not available")
+	}
+
+	cmd := exec.Command("sleep", "0.2")
+	if err := cmd.Start(); err != nil {
+		t.Skipf("cannot start sleep: %v", err)
+	}
+	defer func() { _ = cmd.Process.Kill() }()
+
+	m, err := NewCgroupManager(context.Background(), "")
+	if err != nil {
+		t.Skipf("cannot construct cgroup manager: %v", err)
+	}
+	if m.Probe().Mode == ModeUnavailable {
+		t.Skipf("cgroup enforcement unavailable: %s", m.Probe().Reason)
+	}
+
+	cg, err := m.Apply("agentsh-test-"+strings.ReplaceAll(t.Name(), "/", "_"), cmd.Process.Pid, CgroupV2Limits{
+		PidsMax: 100,
+	})
+	if err != nil {
+		t.Skipf("cannot apply cgroup limits in this environment: %v", err)
+	}
+	if cg == nil || cg.Path == "" {
+		t.Fatalf("expected cgroup path")
+	}
+	if !strings.HasPrefix(cg.Path, "/sys/fs/cgroup") {
+		t.Fatalf("unexpected cgroup path: %q", cg.Path)
+	}
+	if filepath.Base(cg.Path) == "" {
+		t.Fatalf("expected basename for cgroup path: %q", cg.Path)
+	}
+
+	_ = cmd.Wait()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := cg.Close(ctx); err != nil {
+		t.Fatalf("close cgroup: %v", err)
+	}
+}

--- a/internal/limits/cgroupv2_manager.go
+++ b/internal/limits/cgroupv2_manager.go
@@ -1,0 +1,106 @@
+//go:build linux
+
+package limits
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"syscall"
+)
+
+// CgroupManager is the production entry point for per-command cgroup v2 enforcement.
+// Construct one at server startup via NewCgroupManager; all per-exec calls go through Apply.
+//
+// The manager captures an immutable probe result at construction time. If the
+// environment changes mid-run, restart agentsh.
+type CgroupManager struct {
+	fs    cgroupFS
+	probe *CgroupProbeResult
+}
+
+// NewCgroupManager runs ProbeCgroupsV2 once and returns a manager bound to the result.
+// ownHint is the optional user-configured cgroup base path (cfg.Sandbox.Cgroups.BasePath).
+// Pass an empty string to have the probe discover the process's own cgroup.
+//
+// NewCgroupManager never fails for expected reasons — environment gaps are reflected
+// in the probed mode, not in the return error. An error is only returned if the
+// process cannot even determine its own cgroup path.
+func NewCgroupManager(ctx context.Context, ownHint string) (*CgroupManager, error) {
+	return newCgroupManagerFS(ctx, osCgroupFS{}, ownHint)
+}
+
+// newCgroupManagerFS is the FS-injectable form used by unit tests.
+func newCgroupManagerFS(ctx context.Context, fs cgroupFS, ownHint string) (*CgroupManager, error) {
+	probe, err := ProbeCgroupsV2(ctx, fs, ownHint)
+	if err != nil {
+		return nil, fmt.Errorf("probe cgroups v2: %w", err)
+	}
+	return &CgroupManager{fs: fs, probe: probe}, nil
+}
+
+// Probe returns the immutable probe result captured at construction.
+func (m *CgroupManager) Probe() *CgroupProbeResult { return m.probe }
+
+// Apply creates a per-command cgroup (named `name`), writes the non-zero limits,
+// and attaches `pid`. It returns a handle whose Close() removes the cgroup when
+// the command exits.
+//
+// If the manager's probed mode is ModeUnavailable and any limit in lim is non-zero,
+// Apply returns *CgroupUnavailableError without creating anything. This is the
+// fail-closed path.
+func (m *CgroupManager) Apply(name string, pid int, lim CgroupV2Limits) (*CgroupV2, error) {
+	if pid <= 0 {
+		return nil, fmt.Errorf("invalid pid %d", pid)
+	}
+
+	// Fail-closed: if limits are required but enforcement is unavailable, refuse.
+	if m.probe.Mode == ModeUnavailable {
+		if !lim.IsEmpty() {
+			return nil, &CgroupUnavailableError{Reason: m.probe.Reason, Limits: lim}
+		}
+		// No limits requested: allow the command but create no cgroup.
+		return nil, nil
+	}
+
+	parent := m.parentDir()
+	safe := sanitizeCgroupName(name)
+	dir := filepath.Join(parent, safe)
+
+	if err := m.fs.Mkdir(dir, 0o755); err != nil && !errors.Is(err, syscall.EEXIST) {
+		return nil, fmt.Errorf("mkdir cgroup (mode=%s, dir=%s): %w", m.probe.Mode, dir, err)
+	}
+
+	if lim.MaxMemoryBytes > 0 {
+		if err := m.fs.WriteFile(filepath.Join(dir, "memory.max"), []byte(strconv.FormatInt(lim.MaxMemoryBytes, 10)), 0o644); err != nil {
+			return nil, fmt.Errorf("write memory.max (mode=%s, dir=%s): %w", m.probe.Mode, dir, err)
+		}
+	}
+	if lim.PidsMax > 0 {
+		if err := m.fs.WriteFile(filepath.Join(dir, "pids.max"), []byte(strconv.Itoa(lim.PidsMax)), 0o644); err != nil {
+			return nil, fmt.Errorf("write pids.max (mode=%s, dir=%s): %w", m.probe.Mode, dir, err)
+		}
+	}
+	if lim.CPUQuotaPct > 0 {
+		q, p := cpuMaxFromPct(lim.CPUQuotaPct)
+		if err := m.fs.WriteFile(filepath.Join(dir, "cpu.max"), []byte(fmt.Sprintf("%d %d", q, p)), 0o644); err != nil {
+			return nil, fmt.Errorf("write cpu.max (mode=%s, dir=%s): %w", m.probe.Mode, dir, err)
+		}
+	}
+
+	if err := m.fs.WriteFile(filepath.Join(dir, "cgroup.procs"), []byte(strconv.Itoa(pid)), 0o644); err != nil {
+		return nil, fmt.Errorf("attach pid (mode=%s, dir=%s): %w", m.probe.Mode, dir, err)
+	}
+
+	return &CgroupV2{Path: dir}, nil
+}
+
+// parentDir returns the directory under which per-command cgroups are created.
+func (m *CgroupManager) parentDir() string {
+	if m.probe.Mode == ModeTopLevel {
+		return m.probe.SliceDir
+	}
+	return m.probe.OwnCgroup
+}

--- a/internal/limits/cgroupv2_manager_test.go
+++ b/internal/limits/cgroupv2_manager_test.go
@@ -1,0 +1,120 @@
+//go:build linux
+
+package limits
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+func TestManagerApply_NestedWritesLimits(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "cpu memory pids")
+
+	m, err := newCgroupManagerFS(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	if m.Probe().Mode != ModeNested {
+		t.Fatalf("mode: %q", m.Probe().Mode)
+	}
+
+	cg, err := m.Apply("agentsh-sess-cmd", 4242, CgroupV2Limits{MaxMemoryBytes: 16 << 20, PidsMax: 64})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if cg == nil || !strings.HasPrefix(cg.Path, own+"/") {
+		t.Fatalf("nested cgroup path: %q (want prefix %q)", cg.Path, own)
+	}
+	data, _ := f.ReadFile(cg.Path + "/memory.max")
+	if string(data) != "16777216" {
+		t.Fatalf("memory.max: got %q, want 16777216", data)
+	}
+	data, _ = f.ReadFile(cg.Path + "/pids.max")
+	if string(data) != "64" {
+		t.Fatalf("pids.max: got %q, want 64", data)
+	}
+	data, _ = f.ReadFile(cg.Path + "/cgroup.procs")
+	if string(data) != "4242" {
+		t.Fatalf("cgroup.procs: got %q, want 4242", data)
+	}
+}
+
+func TestManagerApply_TopLevelWritesUnderSlice(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+	f.openErrs[own+"/cgroup.subtree_control:write"] = syscall.EBUSY
+	f.seedFile("/sys/fs/cgroup/agentsh.slice/memory.max", "max")
+
+	m, err := newCgroupManagerFS(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	if m.Probe().Mode != ModeTopLevel {
+		t.Fatalf("mode: %q", m.Probe().Mode)
+	}
+
+	cg, err := m.Apply("agentsh-sess-cmd", 1234, CgroupV2Limits{MaxMemoryBytes: 8 << 20})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !strings.HasPrefix(cg.Path, DefaultSliceDir+"/") {
+		t.Fatalf("top-level cgroup path: %q (want prefix %q)", cg.Path, DefaultSliceDir)
+	}
+}
+
+func TestManagerApply_UnavailableNoLimitsAllows(t *testing.T) {
+	f := newFakeCgroupFS()
+	f.seedFile("/sys/fs/cgroup/cgroup.controllers", "cpu pids") // no memory
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu pids")
+
+	m, err := newCgroupManagerFS(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	if m.Probe().Mode != ModeUnavailable {
+		t.Fatalf("mode: %q", m.Probe().Mode)
+	}
+
+	cg, err := m.Apply("agentsh-sess-cmd", 1234, CgroupV2Limits{})
+	if err != nil {
+		t.Fatalf("apply with empty limits should succeed, got %v", err)
+	}
+	if cg != nil {
+		t.Fatalf("expected nil cgroup in unavailable mode with no limits, got %+v", cg)
+	}
+}
+
+func TestManagerApply_UnavailableWithLimitsRefuses(t *testing.T) {
+	f := newFakeCgroupFS()
+	f.seedFile("/sys/fs/cgroup/cgroup.controllers", "cpu pids")
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu pids")
+
+	m, err := newCgroupManagerFS(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	_, err = m.Apply("agentsh-sess-cmd", 1234, CgroupV2Limits{MaxMemoryBytes: 8 << 20})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	var ue *CgroupUnavailableError
+	if !errors.As(err, &ue) {
+		t.Fatalf("expected *CgroupUnavailableError, got %T: %v", err, err)
+	}
+	if !strings.Contains(ue.Reason, "memory") {
+		t.Fatalf("reason should mention missing memory: %q", ue.Reason)
+	}
+}

--- a/internal/limits/cgroupv2_other.go
+++ b/internal/limits/cgroupv2_other.go
@@ -26,3 +26,73 @@ func ApplyCgroupV2(parentDir string, name string, pid int, lim CgroupV2Limits) (
 }
 
 func (c *CgroupV2) Close(ctx context.Context) error { return nil }
+
+// CgroupMode names an operating mode for cgroup v2 enforcement.
+type CgroupMode string
+
+const (
+	ModeNested      CgroupMode = "nested"
+	ModeTopLevel    CgroupMode = "top-level"
+	ModeUnavailable CgroupMode = "unavailable"
+)
+
+// CgroupProbeResult is the output of ProbeCgroupsV2.
+type CgroupProbeResult struct {
+	Mode          CgroupMode
+	Reason        string
+	OwnCgroup     string
+	SliceDir      string
+	IOAvailable   bool
+	OrphansReaped []string
+}
+
+// CgroupManager is the per-process cgroup v2 enforcement manager.
+type CgroupManager struct{}
+
+// NewCgroupManager is not supported on non-Linux platforms.
+func NewCgroupManager(ctx context.Context, ownHint string) (*CgroupManager, error) {
+	return nil, fmt.Errorf("cgroups not supported on this platform")
+}
+
+// Probe returns the immutable probe result captured at construction.
+func (m *CgroupManager) Probe() *CgroupProbeResult { return nil }
+
+// Apply creates a per-command cgroup and attaches the given pid.
+func (m *CgroupManager) Apply(name string, pid int, lim CgroupV2Limits) (*CgroupV2, error) {
+	return nil, fmt.Errorf("cgroups not supported on this platform")
+}
+
+// ProbeCgroupsV2Default runs the default probe (not supported on non-Linux).
+func ProbeCgroupsV2Default(ctx context.Context) (*CgroupProbeResult, error) {
+	return nil, fmt.Errorf("cgroups not supported on this platform")
+}
+
+// CgroupUnavailableError is returned when cgroup enforcement is unavailable
+// but the policy requires resource limits.
+type CgroupUnavailableError struct {
+	Reason string
+	Limits CgroupV2Limits
+}
+
+func (e *CgroupUnavailableError) Error() string {
+	return fmt.Sprintf("cgroup enforcement unavailable (%s)", e.Reason)
+}
+
+// Summary returns a compact human-readable description of non-zero limits.
+func (l CgroupV2Limits) Summary() string { return "no limits" }
+
+// IsEmpty reports whether the limits struct contains no enforceable values.
+func (l CgroupV2Limits) IsEmpty() bool { return true }
+
+// EnableControllersError is returned when writing to cgroup.subtree_control fails.
+type EnableControllersError struct {
+	ParentDir  string
+	Controller string
+	Err        error
+}
+
+func (e *EnableControllersError) Error() string {
+	return fmt.Sprintf("enable controller %q in %s: %v", e.Controller, e.ParentDir, e.Err)
+}
+
+func (e *EnableControllersError) Unwrap() error { return e.Err }

--- a/internal/limits/cgroupv2_probe.go
+++ b/internal/limits/cgroupv2_probe.go
@@ -1,0 +1,281 @@
+//go:build linux
+
+package limits
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// CgroupMode names an operating mode for cgroup v2 enforcement.
+type CgroupMode string
+
+const (
+	ModeNested      CgroupMode = "nested"
+	ModeTopLevel    CgroupMode = "top-level"
+	ModeUnavailable CgroupMode = "unavailable"
+)
+
+// requiredControllers are the cgroup v2 controllers the probe insists on.
+// io is tracked separately as a best-effort flag (see CgroupProbeResult.IOAvailable).
+var requiredControllers = []string{"cpu", "memory", "pids"}
+
+// CgroupProbeResult is the output of ProbeCgroupsV2. Callers store it on
+// a CgroupManager or pass it to the detect command.
+type CgroupProbeResult struct {
+	Mode        CgroupMode
+	Reason      string
+	OwnCgroup   string // absolute path to the process's own cgroup dir
+	SliceDir    string // absolute path to /sys/fs/cgroup/agentsh.slice (top-level mode only; empty otherwise)
+	IOAvailable bool   // true if the io controller is usable in the chosen mode
+	// OrphansReaped is populated in top-level mode when the probe removed
+	// leftover unpopulated child cgroups from a prior agentsh run.
+	OrphansReaped []string
+}
+
+// DefaultSliceDir is the stable top-level parent used when nested enforcement
+// is not reachable. Exported so tests and the detect command can reference it.
+const DefaultSliceDir = "/sys/fs/cgroup/agentsh.slice"
+
+// ProbeCgroupsV2 runs the decision tree described in the design spec:
+//
+//  1. Resolve the "own" cgroup (ownHint overrides /proc/self/cgroup if non-empty).
+//  2. If the own cgroup's cgroup.controllers lacks any required controller, try top-level.
+//  3. If the own cgroup's cgroup.subtree_control already delegates the required set, return nested.
+//  4. Try to enable the required set in subtree_control; on success, return nested.
+//  5. On EBUSY / EACCES / other enable error, fall through to top-level.
+//  6. Top-level: verify root controllers, ensure DefaultSliceDir exists with controller files,
+//     reap orphans, return top-level.
+//  7. Otherwise return unavailable with a structured reason.
+//
+// fs is the filesystem abstraction (osCgroupFS in production, fakeCgroupFS in tests).
+// ownHint is an optional override for the "own" cgroup path used in step 1
+// (intended to honor cfg.Sandbox.Cgroups.BasePath). Empty means "discover via /proc/self/cgroup".
+func ProbeCgroupsV2(ctx context.Context, fs cgroupFS, ownHint string) (*CgroupProbeResult, error) {
+	own := ownHint
+	if own == "" {
+		discovered, err := CurrentCgroupDir()
+		if err != nil {
+			return nil, fmt.Errorf("discover own cgroup: %w", err)
+		}
+		own = discovered
+	} else if !filepath.IsAbs(own) {
+		// Relative paths are joined with the process's current cgroup dir, matching
+		// the prior behavior of internal/api/cgroups.go.
+		cur, err := CurrentCgroupDir()
+		if err != nil {
+			return nil, fmt.Errorf("discover own cgroup for relative base path: %w", err)
+		}
+		own = filepath.Join(cur, own)
+	}
+
+	// Step 2: does the own cgroup even expose the required controllers?
+	ownAvailable, err := readControllerSet(fs, filepath.Join(own, "cgroup.controllers"))
+	if err != nil {
+		// If we cannot read own controllers, fall through to top-level as a defensive measure.
+		return tryTopLevel(ctx, fs, own, fmt.Sprintf("read own cgroup.controllers: %v", err))
+	}
+	if !containsAll(ownAvailable, requiredControllers) {
+		missing := missingControllers(ownAvailable, requiredControllers)
+		return tryTopLevel(ctx, fs, own,
+			fmt.Sprintf("own cgroup missing controllers %v", missing))
+	}
+
+	// Step 3: already delegated?
+	ownDelegated, err := readControllerSet(fs, filepath.Join(own, "cgroup.subtree_control"))
+	if err == nil && containsAll(ownDelegated, requiredControllers) {
+		return &CgroupProbeResult{
+			Mode:        ModeNested,
+			Reason:      "already delegated",
+			OwnCgroup:   own,
+			IOAvailable: contains(ownDelegated, "io"),
+		}, nil
+	}
+
+	// Step 4: try to enable the required set.
+	enableErr := enableControllersFS(fs, own, requiredControllers)
+	if enableErr == nil {
+		// Re-read to confirm and to pick up the io flag.
+		delegatedNow, _ := readControllerSet(fs, filepath.Join(own, "cgroup.subtree_control"))
+		return &CgroupProbeResult{
+			Mode:        ModeNested,
+			Reason:      "enabled by probe",
+			OwnCgroup:   own,
+			IOAvailable: contains(delegatedNow, "io"),
+		}, nil
+	}
+
+	// Step 5: classify the enable failure and fall through to top-level.
+	reason := classifyEnableError(enableErr)
+	return tryTopLevel(ctx, fs, own, reason)
+}
+
+// ProbeCgroupsV2Default is a convenience wrapper that runs ProbeCgroupsV2 with
+// the production cgroupFS and no ownHint. It is intended for callers outside
+// the limits package (e.g. the capabilities probe).
+func ProbeCgroupsV2Default(ctx context.Context) (*CgroupProbeResult, error) {
+	return ProbeCgroupsV2(ctx, osCgroupFS{}, "")
+}
+
+// tryTopLevel runs steps 5b through 5f of the decision tree.
+func tryTopLevel(ctx context.Context, fs cgroupFS, own, nestedFailureReason string) (*CgroupProbeResult, error) {
+	rootAvailable, err := readControllerSet(fs, "/sys/fs/cgroup/cgroup.controllers")
+	if err != nil {
+		return &CgroupProbeResult{
+			Mode:      ModeUnavailable,
+			Reason:    fmt.Sprintf("%s; read root cgroup.controllers: %v", nestedFailureReason, err),
+			OwnCgroup: own,
+		}, nil
+	}
+	if !containsAll(rootAvailable, requiredControllers) {
+		missing := missingControllers(rootAvailable, requiredControllers)
+		return &CgroupProbeResult{
+			Mode:      ModeUnavailable,
+			Reason:    fmt.Sprintf("%s; root cgroup missing controllers %v", nestedFailureReason, missing),
+			OwnCgroup: own,
+		}, nil
+	}
+
+	rootDelegated, _ := readControllerSet(fs, "/sys/fs/cgroup/cgroup.subtree_control")
+	if !containsAll(rootDelegated, requiredControllers) {
+		if err := enableControllersFS(fs, "/sys/fs/cgroup", requiredControllers); err != nil {
+			return &CgroupProbeResult{
+				Mode:      ModeUnavailable,
+				Reason:    fmt.Sprintf("%s; root subtree_control not writable: %v", nestedFailureReason, err),
+				OwnCgroup: own,
+			}, nil
+		}
+		rootDelegated, _ = readControllerSet(fs, "/sys/fs/cgroup/cgroup.subtree_control")
+	}
+
+	// Ensure the slice exists with controller files populated.
+	if err := fs.Mkdir(DefaultSliceDir, 0o755); err != nil && !errors.Is(err, syscall.EEXIST) {
+		return &CgroupProbeResult{
+			Mode:      ModeUnavailable,
+			Reason:    fmt.Sprintf("%s; mkdir %s: %v", nestedFailureReason, DefaultSliceDir, err),
+			OwnCgroup: own,
+		}, nil
+	}
+	if _, err := fs.Stat(filepath.Join(DefaultSliceDir, "memory.max")); err != nil {
+		// memory.max is the canary: if it's missing, controller files weren't created
+		// even though mkdir succeeded — enforcement is not possible here.
+		return &CgroupProbeResult{
+			Mode:      ModeUnavailable,
+			Reason:    fmt.Sprintf("%s; %s missing controller files after mkdir", nestedFailureReason, DefaultSliceDir),
+			OwnCgroup: own,
+			SliceDir:  DefaultSliceDir,
+		}, nil
+	}
+
+	// Reap orphans left behind by a prior agentsh crash.
+	reaped := reapOrphansFS(fs, DefaultSliceDir)
+
+	return &CgroupProbeResult{
+		Mode:          ModeTopLevel,
+		Reason:        fmt.Sprintf("%s; using %s", nestedFailureReason, DefaultSliceDir),
+		OwnCgroup:     own,
+		SliceDir:      DefaultSliceDir,
+		IOAvailable:   contains(rootDelegated, "io"),
+		OrphansReaped: reaped,
+	}, nil
+}
+
+// reapOrphansFS removes empty (unpopulated) children of the slice directory.
+// It returns the names of the removed children. Errors on individual children
+// are logged to stderr and skipped; this function never returns an error.
+func reapOrphansFS(fs cgroupFS, sliceDir string) []string {
+	entries, err := fs.ReadDir(sliceDir)
+	if err != nil {
+		return nil
+	}
+	var reaped []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		child := filepath.Join(sliceDir, e.Name())
+		data, err := fs.ReadFile(filepath.Join(child, "cgroup.events"))
+		if err != nil {
+			// Skip children whose events file is unreadable — they may be actively used.
+			continue
+		}
+		if !isUnpopulated(data) {
+			continue
+		}
+		if err := fs.Remove(child); err != nil {
+			fmt.Fprintf(os.Stderr, "agentsh: reap orphan %s: %v\n", child, err)
+			continue
+		}
+		reaped = append(reaped, e.Name())
+	}
+	return reaped
+}
+
+// classifyEnableError turns an enableControllersFS error into a short human string.
+func classifyEnableError(err error) string {
+	var ece *EnableControllersError
+	if !errors.As(err, &ece) {
+		return fmt.Sprintf("enable controllers: %v", err)
+	}
+	switch {
+	case errors.Is(err, syscall.EBUSY):
+		return "parent cgroup has internal processes (EBUSY)"
+	case errors.Is(err, syscall.EACCES), errors.Is(err, syscall.EPERM):
+		return "parent cgroup subtree_control not writable (EACCES)"
+	default:
+		return fmt.Sprintf("enable controller %q failed: %v", ece.Controller, ece.Err)
+	}
+}
+
+// readControllerSet reads a cgroup.controllers or cgroup.subtree_control file and
+// returns the whitespace-separated controller names it contains.
+func readControllerSet(fs cgroupFS, path string) ([]string, error) {
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return strings.Fields(strings.TrimSpace(string(data))), nil
+}
+
+func contains(set []string, want string) bool {
+	for _, s := range set {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsAll(set, want []string) bool {
+	for _, w := range want {
+		if !contains(set, w) {
+			return false
+		}
+	}
+	return true
+}
+
+func missingControllers(have, want []string) []string {
+	var out []string
+	for _, w := range want {
+		if !contains(have, w) {
+			out = append(out, w)
+		}
+	}
+	return out
+}
+
+func isUnpopulated(eventsFileContent []byte) bool {
+	for _, line := range strings.Split(string(eventsFileContent), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "populated ") {
+			return strings.TrimPrefix(line, "populated ") == "0"
+		}
+	}
+	return false
+}

--- a/internal/limits/cgroupv2_probe_test.go
+++ b/internal/limits/cgroupv2_probe_test.go
@@ -1,0 +1,201 @@
+//go:build linux
+
+package limits
+
+import (
+	"context"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// seedHealthyRoot seeds the root cgroup with all needed controllers already
+// delegated. Used as a starting point for tests that then adjust own-cgroup state.
+func seedHealthyRoot(f *fakeCgroupFS) {
+	f.seedFile("/sys/fs/cgroup/cgroup.controllers", "cpuset cpu io memory pids")
+	f.seedFile("/sys/fs/cgroup/cgroup.subtree_control", "cpuset cpu io memory pids")
+}
+
+func TestProbe_NestedAlreadyDelegated(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu io memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "cpu io memory pids")
+
+	res, err := ProbeCgroupsV2(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeNested {
+		t.Fatalf("mode: got %q, want nested", res.Mode)
+	}
+	if res.Reason != "already delegated" {
+		t.Fatalf("reason: got %q, want 'already delegated'", res.Reason)
+	}
+	if !res.IOAvailable {
+		t.Fatalf("expected io_available=true")
+	}
+}
+
+func TestProbe_NestedEnableSucceeds(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+
+	res, err := ProbeCgroupsV2(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeNested || res.Reason != "enabled by probe" {
+		t.Fatalf("mode/reason: got %q/%q, want nested/enabled by probe", res.Mode, res.Reason)
+	}
+	if err := f.assertSubtreeControl(own+"/cgroup.subtree_control", "cpu", "memory", "pids"); err != nil {
+		t.Fatalf("expected subtree_control populated: %v", err)
+	}
+}
+
+func TestProbe_EnableEBUSY_FallbackToTopLevel(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+	// Injected: the enable write fails with EBUSY.
+	f.openErrs[own+"/cgroup.subtree_control:write"] = syscall.EBUSY
+	// Top-level needs to be ready: slice dir will be created by probe, but we
+	// must seed memory.max to appear after mkdir (our fake doesn't auto-create
+	// controller files, so we prepopulate the file at the expected path).
+	f.seedFile("/sys/fs/cgroup/agentsh.slice/memory.max", "max")
+
+	res, err := ProbeCgroupsV2(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeTopLevel {
+		t.Fatalf("mode: got %q, want top-level", res.Mode)
+	}
+	if !strings.Contains(res.Reason, "EBUSY") {
+		t.Fatalf("reason missing EBUSY: %q", res.Reason)
+	}
+	if res.SliceDir != DefaultSliceDir {
+		t.Fatalf("slice dir: got %q", res.SliceDir)
+	}
+}
+
+func TestProbe_EnableEACCES_FallbackToTopLevel(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+	f.openErrs[own+"/cgroup.subtree_control:write"] = syscall.EACCES
+	f.seedFile("/sys/fs/cgroup/agentsh.slice/memory.max", "max")
+
+	res, err := ProbeCgroupsV2(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeTopLevel {
+		t.Fatalf("mode: got %q, want top-level", res.Mode)
+	}
+	if !strings.Contains(res.Reason, "EACCES") {
+		t.Fatalf("reason missing EACCES: %q", res.Reason)
+	}
+}
+
+func TestProbe_TopLevelMissingMemoryController(t *testing.T) {
+	f := newFakeCgroupFS()
+	// Root is missing memory.
+	f.seedFile("/sys/fs/cgroup/cgroup.controllers", "cpu pids")
+	f.seedFile("/sys/fs/cgroup/cgroup.subtree_control", "")
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+
+	res, err := ProbeCgroupsV2(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeUnavailable {
+		t.Fatalf("mode: got %q, want unavailable", res.Mode)
+	}
+	if !strings.Contains(res.Reason, "memory") {
+		t.Fatalf("reason should name missing memory: %q", res.Reason)
+	}
+}
+
+func TestProbe_TopLevelSliceMissingControllerFiles(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+	f.openErrs[own+"/cgroup.subtree_control:write"] = syscall.EBUSY
+	// Do NOT seed agentsh.slice/memory.max — our fake mkdir won't auto-create it.
+
+	res, err := ProbeCgroupsV2(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeUnavailable {
+		t.Fatalf("mode: got %q, want unavailable", res.Mode)
+	}
+	if !strings.Contains(res.Reason, "missing controller files") {
+		t.Fatalf("reason should name missing controller files: %q", res.Reason)
+	}
+}
+
+func TestProbe_TopLevelOrphanReap(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+	f.openErrs[own+"/cgroup.subtree_control:write"] = syscall.EBUSY
+	f.seedFile("/sys/fs/cgroup/agentsh.slice/memory.max", "max")
+	// Orphan A is unpopulated -> should be reaped.
+	f.seedFile("/sys/fs/cgroup/agentsh.slice/orphan-A/cgroup.events", "populated 0\nfrozen 0\n")
+	// Orphan B is populated -> should be left alone.
+	f.seedFile("/sys/fs/cgroup/agentsh.slice/orphan-B/cgroup.events", "populated 1\nfrozen 0\n")
+
+	res, err := ProbeCgroupsV2(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeTopLevel {
+		t.Fatalf("mode: got %q, want top-level", res.Mode)
+	}
+	if len(res.OrphansReaped) != 1 || res.OrphansReaped[0] != "orphan-A" {
+		t.Fatalf("expected orphan-A reaped, got %v", res.OrphansReaped)
+	}
+	if _, err := f.Stat("/sys/fs/cgroup/agentsh.slice/orphan-A"); err == nil {
+		t.Fatalf("orphan-A should have been removed")
+	}
+	if _, err := f.Stat("/sys/fs/cgroup/agentsh.slice/orphan-B"); err != nil {
+		t.Fatalf("orphan-B should still exist: %v", err)
+	}
+}
+
+func TestProbe_IOControllerOptional(t *testing.T) {
+	f := newFakeCgroupFS()
+	// Root has everything except io.
+	f.seedFile("/sys/fs/cgroup/cgroup.controllers", "cpu memory pids")
+	f.seedFile("/sys/fs/cgroup/cgroup.subtree_control", "cpu memory pids")
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "cpu memory pids")
+
+	res, err := ProbeCgroupsV2(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeNested {
+		t.Fatalf("mode: got %q, want nested", res.Mode)
+	}
+	if res.IOAvailable {
+		t.Fatalf("expected io_available=false")
+	}
+}

--- a/internal/limits/cgroupv2_probe_test.go
+++ b/internal/limits/cgroupv2_probe_test.go
@@ -199,3 +199,34 @@ func TestProbe_IOControllerOptional(t *testing.T) {
 		t.Fatalf("expected io_available=false")
 	}
 }
+
+func TestProbe_AllOrphansPopulated(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+	f.openErrs[own+"/cgroup.subtree_control:write"] = syscall.EBUSY
+	f.seedFile("/sys/fs/cgroup/agentsh.slice/memory.max", "max")
+	// All orphans are populated (active) — none should be reaped.
+	f.seedFile("/sys/fs/cgroup/agentsh.slice/child-A/cgroup.events", "populated 1\nfrozen 0\n")
+	f.seedFile("/sys/fs/cgroup/agentsh.slice/child-B/cgroup.events", "populated 1\nfrozen 0\n")
+
+	res, err := ProbeCgroupsV2(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeTopLevel {
+		t.Fatalf("mode: got %q, want top-level", res.Mode)
+	}
+	if len(res.OrphansReaped) != 0 {
+		t.Fatalf("expected no orphans reaped, got %v", res.OrphansReaped)
+	}
+	// Both children should still exist.
+	if _, err := f.Stat("/sys/fs/cgroup/agentsh.slice/child-A"); err != nil {
+		t.Fatalf("child-A should still exist: %v", err)
+	}
+	if _, err := f.Stat("/sys/fs/cgroup/agentsh.slice/child-B"); err != nil {
+		t.Fatalf("child-B should still exist: %v", err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -25,6 +26,7 @@ import (
 	"github.com/agentsh/agentsh/internal/capabilities"
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/events"
+	limitspkg "github.com/agentsh/agentsh/internal/limits"
 	"github.com/agentsh/agentsh/internal/mcpregistry"
 	"github.com/agentsh/agentsh/internal/metrics"
 	"github.com/agentsh/agentsh/internal/pkgcheck"
@@ -409,7 +411,45 @@ func New(cfg *config.Config) (*Server, error) {
 		cfg.Policies.Dir, enforceApprovals, true,
 		cfg.Policies.Signing.SigningMode(), cfg.Policies.Signing.TrustStore,
 	)
-	app := api.NewApp(cfg, sessions, store, engine, broker, apiKeyAuth, oidcAuth, approvalsMgr, metricsCollector, policyLoader)
+
+	var cgroupMgr *limitspkg.CgroupManager
+	if runtime.GOOS == "linux" {
+		mgr, err := limitspkg.NewCgroupManager(context.Background(), cfg.Sandbox.Cgroups.BasePath)
+		if err != nil {
+			slog.Warn("cgroup v2 probe failed; per-command limits unavailable", "error", err)
+		} else {
+			cgroupMgr = mgr
+			modeEvent := types.Event{
+				ID:        uuid.NewString(),
+				Timestamp: time.Now().UTC(),
+				Type:      string(events.EventCgroupMode),
+				Fields: map[string]any{
+					"mode":         string(mgr.Probe().Mode),
+					"reason":       mgr.Probe().Reason,
+					"own_cgroup":   mgr.Probe().OwnCgroup,
+					"slice_dir":    mgr.Probe().SliceDir,
+					"io_available": mgr.Probe().IOAvailable,
+				},
+			}
+			_ = store.AppendEvent(context.Background(), modeEvent)
+			broker.Publish(modeEvent)
+			if reaped := mgr.Probe().OrphansReaped; len(reaped) > 0 {
+				reapEvent := types.Event{
+					ID:        uuid.NewString(),
+					Timestamp: time.Now().UTC(),
+					Type:      string(events.EventCgroupOrphansReaped),
+					Fields: map[string]any{
+						"count": len(reaped),
+						"names": reaped,
+					},
+				}
+				_ = store.AppendEvent(context.Background(), reapEvent)
+				broker.Publish(reapEvent)
+			}
+		}
+	}
+
+	app := api.NewApp(cfg, sessions, store, engine, broker, apiKeyAuth, oidcAuth, approvalsMgr, metricsCollector, policyLoader, cgroupMgr)
 	appCloser := app.Close // ensure cleanup on error paths below
 	defer func() {
 		if appCloser != nil {


### PR DESCRIPTION
## Summary

- **Probe at startup:** `ProbeCgroupsV2` inspects the cgroup v2 hierarchy and selects one of three modes: `nested` (delegated by systemd), `top-level` (`/sys/fs/cgroup/agentsh.slice` fallback), or `unavailable`
- **Fail-closed per-command:** `CgroupManager.Apply` refuses execution with `CgroupUnavailableError` when policy requires resource limits but enforcement is unavailable — no more silent no-ops
- **`enableControllers` now surfaces errors** instead of silently swallowing them (`continue` on error → return `*EnableControllersError` on first failure)
- **Orphan reaping:** top-level mode cleans up unpopulated child cgroups from prior crashes
- **Startup events:** emits `cgroup_mode`, `cgroup_orphans_reaped`, `cgroup_unavailable_refusal` for observability
- **Non-Linux stubs** in `cgroupv2_other.go` for cross-compilation (Windows/Darwin)

Closes #197

## Test Plan

- [ ] `go test ./internal/limits/` — 22 unit tests covering probe decision tree, manager apply, enableControllers errors, fake FS, orphan reaping
- [ ] `go test ./...` — full suite passes
- [ ] `GOOS=windows go build ./...` — cross-compilation clean
- [ ] Integration tests gated behind `//go:build linux && cgroup_integration` for CI environments with real cgroup access

🤖 Generated with [Claude Code](https://claude.com/claude-code)