### PR TITLE
feat(cli/wrap): auto-start agentsh server when running wrap

### DIFF
--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -15,6 +15,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// ensureServerRunningFn is the auto-start hook used by fetchSessionForWrap.
+// Defaults to the real ensureServerRunning helper from auto.go; tests
+// override it to avoid forking a real agentsh server subprocess.
+var ensureServerRunningFn = ensureServerRunning
+
 func newWrapCmd() *cobra.Command {
 	var sessionID string
 	var policy string
@@ -321,4 +326,45 @@ func setupWrapInterception(ctx context.Context, c client.CLIClient, sessID strin
 
 	// Delegate to platform-specific code for socket pair creation and fd management
 	return platformSetupWrap(ctx, wrapResp, sessID, agentPath, agentArgs, cfg)
+}
+
+// fetchSessionForWrap resolves the session for runWrap, either by reusing
+// opts.sessionID (GetSession) or by creating a new session
+// (CreateSessionWithRequest). If the first server call fails with a
+// connection error and auto-start is enabled, it forks the local agentsh
+// server via ensureServerRunningFn and retries once. The behaviour mirrors
+// the auto-start blocks already present in exec.go and exec_pty.go.
+func fetchSessionForWrap(
+	ctx context.Context,
+	c client.CLIClient,
+	cfg *clientConfig,
+	opts wrapOptions,
+	workspace string,
+) (types.Session, error) {
+	fetch := func() (types.Session, error) {
+		if opts.sessionID != "" {
+			return c.GetSession(ctx, opts.sessionID)
+		}
+		return c.CreateSessionWithRequest(ctx, types.CreateSessionRequest{
+			Workspace: workspace,
+			Policy:    opts.policy,
+			Home:      userHomeDir(),
+		})
+	}
+
+	sess, err := fetch()
+	if err != nil && !autoDisabled() && isConnectionError(err) {
+		if startErr := ensureServerRunningFn(ctx, cfg.serverAddr, os.Stderr); startErr == nil {
+			sess, err = fetch()
+		} else {
+			return types.Session{}, fmt.Errorf("server unreachable (%v); auto-start failed: %w", err, startErr)
+		}
+	}
+	if err != nil {
+		if opts.sessionID != "" {
+			return types.Session{}, fmt.Errorf("get session %s: %w", opts.sessionID, err)
+		}
+		return types.Session{}, fmt.Errorf("create session: %w", err)
+	}
+	return sess, nil
 }

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -94,29 +94,14 @@ func runWrap(ctx context.Context, cfg *clientConfig, opts wrapOptions) error {
 		}
 	}
 
-	var sessID string
-	var workspaceMount string
-	var llmProxyURL string
-	if opts.sessionID != "" {
-		sess, err := c.GetSession(ctx, opts.sessionID)
-		if err != nil {
-			return fmt.Errorf("get session %s: %w", opts.sessionID, err)
-		}
-		sessID = sess.ID
-		workspaceMount = sess.WorkspaceMount
-		llmProxyURL = sess.LLMProxyURL
-	} else {
-		sess, err := c.CreateSessionWithRequest(ctx, types.CreateSessionRequest{
-			Workspace: workspace,
-			Policy:    opts.policy,
-			Home:      userHomeDir(),
-		})
-		if err != nil {
-			return fmt.Errorf("create session: %w", err)
-		}
-		sessID = sess.ID
-		workspaceMount = sess.WorkspaceMount
-		llmProxyURL = sess.LLMProxyURL
+	sess, err := fetchSessionForWrap(ctx, c, cfg, opts, workspace)
+	if err != nil {
+		return err
+	}
+	sessID := sess.ID
+	workspaceMount := sess.WorkspaceMount
+	llmProxyURL := sess.LLMProxyURL
+	if opts.sessionID == "" {
 		fmt.Fprintf(os.Stderr, "agentsh: session %s created (policy: %s)\n", sessID, opts.policy)
 	}
 

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/url"
 	"runtime"
+	"syscall"
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/client"
@@ -347,4 +348,41 @@ func TestWrapLaunchConfig_EnvContainsSessionAndWrapper(t *testing.T) {
 			f.Close()
 		}
 	}
+}
+
+func TestFetchSessionForWrap_AutoStartsServerOnConnRefused(t *testing.T) {
+	// Mock client: first GetSession returns ECONNREFUSED, second succeeds.
+	var calls int
+	mc := &mockWrapClient{
+		getSessionFn: func(ctx context.Context, id string) (types.Session, error) {
+			calls++
+			if calls == 1 {
+				return types.Session{}, syscall.ECONNREFUSED
+			}
+			return types.Session{ID: id}, nil
+		},
+	}
+
+	// Stub the auto-start hook so no real subprocess is forked.
+	var autoStartCalls int
+	var autoStartAddr string
+
+	origEnsureFn := ensureServerRunningFn
+	t.Cleanup(func() { ensureServerRunningFn = origEnsureFn })
+	ensureServerRunningFn = func(ctx context.Context, addr string, log io.Writer) error {
+		autoStartCalls++
+		autoStartAddr = addr
+		return nil
+	}
+
+	cfg := &clientConfig{serverAddr: "http://127.0.0.1:18080"}
+	opts := wrapOptions{sessionID: "existing-sess"}
+
+	sess, err := fetchSessionForWrap(context.Background(), mc, cfg, opts, "/tmp/work")
+
+	require.NoError(t, err)
+	assert.Equal(t, "existing-sess", sess.ID)
+	assert.Equal(t, 2, calls, "GetSession should be retried after auto-start")
+	assert.Equal(t, 1, autoStartCalls, "ensureServerRunningFn should be called exactly once")
+	assert.Equal(t, "http://127.0.0.1:18080", autoStartAddr)
 }

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -133,6 +133,8 @@ type mockWrapClient struct {
 	wrapInitErr     error
 	createSessCalled bool
 	getSessionCalled bool
+	getSessionFn     func(ctx context.Context, id string) (types.Session, error)
+	createSessionFn  func(ctx context.Context, req types.CreateSessionRequest) (types.Session, error)
 }
 
 // Ensure mockWrapClient implements CLIClient at compile time.
@@ -153,6 +155,10 @@ func (m *mockWrapClient) CreateSessionWithID(ctx context.Context, id, workspace,
 	return types.Session{ID: id}, nil
 }
 func (m *mockWrapClient) CreateSessionWithRequest(ctx context.Context, req types.CreateSessionRequest) (types.Session, error) {
+	m.createSessCalled = true
+	if m.createSessionFn != nil {
+		return m.createSessionFn(ctx, req)
+	}
 	return types.Session{}, nil
 }
 func (m *mockWrapClient) ListSessions(ctx context.Context) ([]types.Session, error) {
@@ -160,6 +166,9 @@ func (m *mockWrapClient) ListSessions(ctx context.Context) ([]types.Session, err
 }
 func (m *mockWrapClient) GetSession(ctx context.Context, id string) (types.Session, error) {
 	m.getSessionCalled = true
+	if m.getSessionFn != nil {
+		return m.getSessionFn(ctx, id)
+	}
 	return types.Session{ID: id}, nil
 }
 func (m *mockWrapClient) DestroySession(ctx context.Context, id string) error    { return nil }

--- a/internal/integration/agentsh_wrap_test.go
+++ b/internal/integration/agentsh_wrap_test.go
@@ -1,0 +1,163 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const wrapTestConfigYAML = `
+server:
+  http:
+    addr: "127.0.0.1:18080"
+auth:
+  type: "none"
+logging:
+  level: "info"
+  format: "text"
+  output: "stdout"
+audit:
+  enabled: false
+  storage:
+    sqlite_path: "/tmp/events.db"
+sessions:
+  base_dir: "/sessions"
+sandbox:
+  fuse:
+    enabled: false
+  network:
+    enabled: false
+  unix_sockets:
+    enabled: false
+  seccomp:
+    execve:
+      enabled: false
+policies:
+  dir: "/policies"
+  default: "agent-default"
+approvals:
+  enabled: false
+metrics:
+  enabled: false
+health:
+  path: "/health"
+`
+
+const wrapTestPolicyYAML = `
+version: 1
+name: agent-default
+description: permissive policy for wrap integration test
+command_rules:
+  - name: allow-all
+    commands: ["*"]
+    decision: allow
+resource_limits:
+  command_timeout: 30s
+  session_timeout: 1h
+  idle_timeout: 30m
+`
+
+func TestWrapAutoStart(t *testing.T) {
+	ctx := context.Background()
+
+	// Build the agentsh binary (CGO_ENABLED=0, same as policy tests).
+	// Without CGO, seccomp is unavailable — wrap falls back to direct launch.
+	// This test targets autostart + session + child execution, not seccomp.
+	bin := buildAgentshBinary(t)
+
+	temp := t.TempDir()
+
+	// Write config and policy files
+	configPath := filepath.Join(temp, "config.yaml")
+	writeFile(t, configPath, wrapTestConfigYAML)
+
+	policiesDir := filepath.Join(temp, "policies")
+	mustMkdir(t, policiesDir)
+	writeFile(t, filepath.Join(policiesDir, "agent-default.yaml"), wrapTestPolicyYAML)
+
+	workspace := filepath.Join(temp, "workspace")
+	mustMkdir(t, workspace)
+
+	binds := []testcontainers.ContainerMount{
+		testcontainers.BindMount(bin, "/usr/local/bin/agentsh"),
+		testcontainers.BindMount(configPath, "/config.yaml"),
+		testcontainers.BindMount(policiesDir, "/policies"),
+		testcontainers.BindMount(workspace, "/workspace"),
+	}
+
+	// Run "agentsh wrap -- echo hello" with no pre-started server.
+	// The wrap command should autostart the server, create a session,
+	// run "echo hello", and exit cleanly.
+	req := testcontainers.ContainerRequest{
+		Image:  "debian:bookworm-slim",
+		Cmd:    []string{"/usr/local/bin/agentsh", "wrap", "--", "echo", "hello"},
+		Mounts: binds,
+		Env:    map[string]string{"AGENTSH_CONFIG": "/config.yaml"},
+		HostConfigModifier: func(hc *container.HostConfig) {
+			hc.SecurityOpt = []string{"apparmor:unconfined", "seccomp:unconfined"}
+		},
+		WaitingFor: wait.ForExit().WithExitTimeout(30 * time.Second),
+	}
+
+	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		if ctr != nil {
+			if logs, logErr := ctr.Logs(ctx); logErr == nil {
+				defer logs.Close()
+				b, _ := io.ReadAll(logs)
+				t.Logf("container logs:\n%s", string(b))
+			}
+		}
+		t.Fatalf("start container: %v", err)
+	}
+	defer func() { _ = ctr.Terminate(context.Background()) }()
+
+	// Read container logs for assertions
+	logs, err := ctr.Logs(ctx)
+	if err != nil {
+		t.Fatalf("get container logs: %v", err)
+	}
+	defer logs.Close()
+	logBytes, err := io.ReadAll(logs)
+	if err != nil {
+		t.Fatalf("read container logs: %v", err)
+	}
+	logOutput := string(logBytes)
+	t.Logf("container logs:\n%s", logOutput)
+
+	// Check exit code
+	state, err := ctr.State(ctx)
+	if err != nil {
+		t.Fatalf("get container state: %v", err)
+	}
+	if state.ExitCode != 0 {
+		t.Fatalf("container exited with code %d, expected 0", state.ExitCode)
+	}
+
+	// Verify autostart fired
+	if !strings.Contains(logOutput, "auto-starting server") {
+		t.Error("expected log line containing 'auto-starting server' (autostart should have fired)")
+	}
+
+	// Verify session was created
+	if !strings.Contains(logOutput, "session") || !strings.Contains(logOutput, "created") {
+		t.Error("expected log output containing 'session' and 'created' (session should have been established)")
+	}
+
+	// Verify the child command produced output
+	if !strings.Contains(logOutput, "hello") {
+		t.Error("expected 'hello' in output (echo command should have run)")
+	}
+}


### PR DESCRIPTION
## Summary

- `agentsh wrap` now auto-starts the local agentsh server on connection-refused, matching `agentsh exec`
- Extracts session-fetch logic into `fetchSessionForWrap` helper with auto-start-and-retry
- Adds `ensureServerRunningFn` test seam so the retry path is unit-testable without forking a real server

## Details

When users run `agentsh wrap -- <agent>` without a running server on `127.0.0.1:18080`, the first session call (GetSession or CreateSessionWithRequest) now triggers `ensureServerRunning` to fork `agentsh server --config <path>`, poll `/health` for up to 5s, then retry. Same gates as `exec`: loopback + default port only, `AGENTSH_NO_AUTO=1` disables it.

Two files changed: `internal/cli/wrap.go` (+54/-23), `internal/cli/wrap_test.go` (+47).

## Test plan

- [ ] `go test ./internal/cli/ -run TestFetchSessionForWrap -v` passes (unit test for retry path)
- [ ] `go test ./...` passes (full suite)
- [ ] `GOOS=windows go build ./...` succeeds (cross-compile)
- [ ] Manual smoke: `pkill -f 'agentsh server'; agentsh wrap -- bash -c true` prints `auto-starting server` and exits cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)