### PR TITLE
feat(secrets): Vault KV v2 provider + provider registry (Plan 4)

### DIFF
--- a/docs/superpowers/plans/2026-04-09-plan-04-vault-provider-registry.md
+++ b/docs/superpowers/plans/2026-04-09-plan-04-vault-provider-registry.md
@@ -1,0 +1,2113 @@
+# Vault Provider + Provider Registry (Plan 4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the provider registry (dependency-resolving construction of providers) and a Vault KV v2 SecretProvider, with auth chaining from keyring, token/AppRole/Kubernetes auth, and zero call sites in the daemon.
+
+**Architecture:** A `Registry` type in `internal/proxy/secrets/` uses Kahn's topological sort to construct providers in dependency order, enabling auth chaining (e.g., Vault reads its token from the keyring provider). The Vault provider in `internal/proxy/secrets/vault/` wraps `hashicorp/vault/api` for KV v2 reads. Both `ProviderConfig` interface methods (`TypeName()`, `Dependencies()`) are added to the parent package.
+
+**Tech Stack:** Go stdlib + `github.com/hashicorp/vault/api` (already in go.mod) + `github.com/hashicorp/vault/api/auth/approle` (new) + `github.com/hashicorp/vault/api/auth/kubernetes` (already in go.mod). Tests use `net/http/httptest` for mock Vault HTTP handlers.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-09-plan-04-vault-provider-registry-design.md`
+
+**Parent spec reference:** `docs/superpowers/specs/2026-04-07-external-secrets-design.md` (Sections 2, 5, 7).
+
+---
+
+## Architectural notes (read before starting tasks)
+
+### Import paths
+
+Module path: `github.com/agentsh/agentsh`. The secrets parent package is imported as:
+
+```go
+secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
+```
+
+Vault subpackage: `github.com/agentsh/agentsh/internal/proxy/secrets/vault`.
+
+### ProviderConfig interface evolution
+
+Plan 3 shipped `ProviderConfig` with one unexported method (`providerConfig()`) and a `ProviderConfigMarker` embed helper. Plan 4 adds two exported methods:
+
+- `TypeName() string` — NO default on marker. Each config must implement it. Compile-time enforcement.
+- `Dependencies() []SecretRef` — default on marker returning `nil`. Providers with no auth chaining get this for free.
+
+### Registry scheme mapping
+
+The registry maps URI schemes to providers via `TypeName()`. When a config's `Dependencies()` returns refs, the registry looks up which config has a matching `TypeName()` for each ref's `Scheme`. This is how `vault.Config` with `TokenRef: keyring://...` creates an edge to the keyring provider.
+
+### Vault KV v2 URI semantics
+
+The `vault/api` KV v2 helper adds the `data/` prefix internally. So:
+- URI `vault://kv/github#token` → `client.KVv2("kv").Get(ctx, "github")` → field `token`
+- Host = mount name, Path = secret path within mount, Field = key in KV data map
+- If path starts with `data/`, the provider strips it and logs a warning.
+
+### httptest mock pattern for Vault
+
+Tests create an `httptest.Server` with a `http.ServeMux` that handles Vault API paths. The `vault/api.Client` is configured with `api.Config{Address: server.URL}`. No TLS in tests — httptest serves plain HTTP and the vault client is configured to skip TLS verification.
+
+### Concurrency model
+
+Same pattern as keyring provider: `atomic.Bool` closed flag + `sync.RWMutex`. Fetch holds RLock, Close stores closed flag then acquires exclusive Lock. Test seam hooks for deterministic race testing.
+
+### Vault `New()` takes `context.Context`
+
+Unlike keyring (whose `New` is synchronous and fast), Vault's `New` needs to authenticate over HTTP, which requires a context for timeout/cancellation. The `ConstructorFunc` signature does NOT carry a context — instead, `NewRegistry` passes its own `ctx` argument to the constructor via a closure.
+
+Correction: the `ConstructorFunc` should carry a context. Revise:
+
+```go
+type ConstructorFunc func(ctx context.Context, cfg ProviderConfig, resolver RefResolver) (SecretProvider, error)
+```
+
+This way each constructor can honor the registry's context for timeouts.
+
+---
+
+## File Structure
+
+**Files created by this plan:**
+
+- `internal/proxy/secrets/registry.go` — `RefResolver`, `ConstructorFunc`, `Registry`, `NewRegistry` (topo sort), `Provider`, `Fetch`, `Close`.
+- `internal/proxy/secrets/registry_test.go` — dependency resolution, cycle detection, cleanup, dispatch tests.
+- `internal/proxy/secrets/vault/doc.go` — package doc (OpenBao note, URI format).
+- `internal/proxy/secrets/vault/config.go` — `Config`, `AuthConfig`, `TypeName`, `Dependencies`, compile-time assertions.
+- `internal/proxy/secrets/vault/provider.go` — `Provider`, `New`, `Fetch`, `Close`.
+- `internal/proxy/secrets/vault/provider_test.go` — httptest mock + contract tests.
+
+**Files modified by this plan:**
+
+- `internal/proxy/secrets/provider.go` — add `TypeName() string` and `Dependencies() []SecretRef` to `ProviderConfig` interface. Add default `Dependencies()` to `ProviderConfigMarker`.
+- `internal/proxy/secrets/provider_test.go` — update `testConfig` to implement `TypeName()`.
+- `internal/proxy/secrets/errors.go` — add `ErrCyclicDependency` sentinel.
+- `internal/proxy/secrets/errors_test.go` — add `ErrCyclicDependency` to sentinel tests.
+- `internal/proxy/secrets/doc.go` — mention vault subpackage and registry.
+- `internal/proxy/secrets/keyring/config.go` — add `TypeName()` method.
+- `go.mod` — add `github.com/hashicorp/vault/api/auth/approle`.
+- `go.sum` — regenerated by `go mod tidy`.
+
+**Files NOT modified (explicitly verify unchanged before merge):**
+
+- Anything under `pkg/secrets/`.
+- Anything under `internal/session/`, `internal/api/`, `cmd/`.
+- Anything under `internal/proxy/credsub/`.
+
+---
+
+## Task 1: Interface changes and error sentinel
+
+**Files:**
+- Modify: `internal/proxy/secrets/errors.go`
+- Modify: `internal/proxy/secrets/errors_test.go`
+- Modify: `internal/proxy/secrets/provider.go`
+- Modify: `internal/proxy/secrets/provider_test.go`
+- Modify: `internal/proxy/secrets/keyring/config.go`
+
+- [ ] **Step 1: Add `ErrCyclicDependency` to errors.go**
+
+Add after the existing `ErrKeyringUnavailable` line in `internal/proxy/secrets/errors.go`:
+
+```go
+// ErrCyclicDependency is returned by NewRegistry when the provider
+// dependency graph contains a cycle (e.g. provider A depends on B,
+// B depends on A). The error message includes the cycle path.
+var ErrCyclicDependency = errors.New("secrets: cyclic provider dependency")
+```
+
+- [ ] **Step 2: Update errors_test.go to include `ErrCyclicDependency`**
+
+In `internal/proxy/secrets/errors_test.go`, add `ErrCyclicDependency` to all three test functions:
+
+In `TestSentinelErrors_AreDistinct`, add to the `sentinels` slice:
+```go
+ErrCyclicDependency,
+```
+
+In `TestSentinelErrors_AreWrappable`, add to the `sentinels` map:
+```go
+"ErrCyclicDependency": ErrCyclicDependency,
+```
+
+In `TestSentinelErrors_MessagesStartWithPrefix`, add to the `sentinels` slice:
+```go
+ErrCyclicDependency,
+```
+
+- [ ] **Step 3: Run error tests**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/proxy/secrets/ -run TestSentinel -v`
+
+Expected: PASS — all sentinel tests pass with the new error.
+
+- [ ] **Step 4: Add `TypeName()` and `Dependencies()` to `ProviderConfig` interface**
+
+In `internal/proxy/secrets/provider.go`, replace the `ProviderConfig` interface definition:
+
+```go
+// ProviderConfig is the marker interface that every provider's
+// config struct must satisfy. The registry type-switches on
+// ProviderConfig to dispatch to the right constructor at
+// policy-load time.
+//
+// TypeName returns the provider type name, which doubles as the
+// URI scheme this provider handles (e.g. "vault", "keyring").
+// Each config MUST implement TypeName explicitly — there is no
+// default on ProviderConfigMarker.
+//
+// Dependencies returns the SecretRefs that must be resolved from
+// other providers before this provider can be constructed (auth
+// chaining). Providers with no dependencies inherit the default
+// nil return from ProviderConfigMarker.
+//
+// Types outside package secrets satisfy ProviderConfig by
+// embedding ProviderConfigMarker. Embedding is required because
+// Go's unexported-method sealing does not work across package
+// boundaries: an unexported method's identity is qualified by
+// the declaring package, so a type in another package cannot
+// directly implement a sealed interface from this one. Embedding
+// ProviderConfigMarker gives the outer type a promoted
+// providerConfig() method whose identity lives in package
+// secrets, which is what satisfies the interface.
+//
+// The seal is strong-by-convention: anyone can embed
+// ProviderConfigMarker, but doing so is a deliberate opt-in, and
+// the registry only dispatches on config types it already knows
+// about.
+type ProviderConfig interface {
+	providerConfig()
+	TypeName() string
+	Dependencies() []SecretRef
+}
+```
+
+Add the default `Dependencies()` to `ProviderConfigMarker` (after the existing `providerConfig()` method):
+
+```go
+// Dependencies returns nil. Providers with no auth chaining
+// inherit this default. Providers that need auth chaining (e.g.
+// Vault with a keyring-backed token) override this method on
+// their own Config type.
+func (ProviderConfigMarker) Dependencies() []SecretRef { return nil }
+```
+
+- [ ] **Step 5: Update `testConfig` in provider_test.go**
+
+In `internal/proxy/secrets/provider_test.go`, add `TypeName()` to the existing `testConfig`:
+
+```go
+type testConfig struct {
+	ProviderConfigMarker
+}
+
+func (testConfig) TypeName() string { return "test" }
+```
+
+- [ ] **Step 6: Add `TypeName()` to `keyring.Config`**
+
+In `internal/proxy/secrets/keyring/config.go`, add after the `Config` struct definition and before the compile-time assertions:
+
+```go
+// TypeName returns "keyring". Used by the registry to map
+// keyring:// URI scheme refs to this provider.
+func (Config) TypeName() string { return "keyring" }
+```
+
+- [ ] **Step 7: Build and test**
+
+Run: `cd /home/eran/work/agentsh && go build ./internal/proxy/secrets/... && go test ./internal/proxy/secrets/ -v`
+
+Expected: PASS — everything compiles and tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/eran/work/agentsh
+git add internal/proxy/secrets/errors.go internal/proxy/secrets/errors_test.go internal/proxy/secrets/provider.go internal/proxy/secrets/provider_test.go internal/proxy/secrets/keyring/config.go
+git commit -m "feat(secrets): add TypeName/Dependencies to ProviderConfig + ErrCyclicDependency (Plan 4)"
+```
+
+---
+
+## Task 2: Provider Registry
+
+**Files:**
+- Create: `internal/proxy/secrets/registry.go`
+- Create: `internal/proxy/secrets/registry_test.go`
+
+- [ ] **Step 1: Write registry tests**
+
+Create `internal/proxy/secrets/registry_test.go`:
+
+```go
+package secrets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+)
+
+// testProviderConfig is a minimal ProviderConfig for registry tests.
+type testProviderConfig struct {
+	ProviderConfigMarker
+	typeName string
+	deps     []SecretRef
+}
+
+func (c testProviderConfig) TypeName() string          { return c.typeName }
+func (c testProviderConfig) Dependencies() []SecretRef { return c.deps }
+
+// testProvider is a minimal SecretProvider for registry tests.
+type testProvider struct {
+	name     string
+	closeCt  atomic.Int32
+	fetchErr error
+	fetchVal SecretValue
+}
+
+func (p *testProvider) Name() string { return p.name }
+func (p *testProvider) Fetch(_ context.Context, _ SecretRef) (SecretValue, error) {
+	if p.fetchErr != nil {
+		return SecretValue{}, p.fetchErr
+	}
+	cp := make([]byte, len(p.fetchVal.Value))
+	copy(cp, p.fetchVal.Value)
+	return SecretValue{Value: cp, FetchedAt: p.fetchVal.FetchedAt}, nil
+}
+func (p *testProvider) Close() error {
+	p.closeCt.Add(1)
+	return nil
+}
+
+func TestNewRegistry_NoDependencies(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, cfg ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: cfg.TypeName()}, nil
+		},
+	}
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.Close()
+
+	p, ok := reg.Provider("kr")
+	if !ok {
+		t.Fatal("Provider('kr') not found")
+	}
+	if p.Name() != "keyring" {
+		t.Errorf("Provider name = %q, want 'keyring'", p.Name())
+	}
+}
+
+func TestNewRegistry_LinearChain(t *testing.T) {
+	// vault depends on keyring via a token_ref
+	tokenRef := SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-token"}
+	configs := map[string]ProviderConfig{
+		"vault-prod": testProviderConfig{
+			typeName: "vault",
+			deps:     []SecretRef{tokenRef},
+		},
+		"kr": testProviderConfig{typeName: "keyring"},
+	}
+
+	var constructionOrder []string
+	var resolvedToken []byte
+
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, cfg ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			constructionOrder = append(constructionOrder, cfg.TypeName())
+			return &testProvider{
+				name:     "keyring",
+				fetchVal: SecretValue{Value: []byte("real-vault-token")},
+			}, nil
+		},
+		"vault": func(ctx context.Context, cfg ProviderConfig, resolver RefResolver) (SecretProvider, error) {
+			constructionOrder = append(constructionOrder, cfg.TypeName())
+			// Resolve the chained ref
+			sv, err := resolver(ctx, tokenRef)
+			if err != nil {
+				return nil, fmt.Errorf("resolving token: %w", err)
+			}
+			resolvedToken = sv.Value
+			return &testProvider{name: "vault"}, nil
+		},
+	}
+
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.Close()
+
+	// keyring must be constructed before vault
+	if len(constructionOrder) != 2 {
+		t.Fatalf("construction order length = %d, want 2", len(constructionOrder))
+	}
+	if constructionOrder[0] != "keyring" || constructionOrder[1] != "vault" {
+		t.Errorf("construction order = %v, want [keyring vault]", constructionOrder)
+	}
+	if string(resolvedToken) != "real-vault-token" {
+		t.Errorf("resolved token = %q, want 'real-vault-token'", resolvedToken)
+	}
+}
+
+func TestNewRegistry_CycleDetected(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"a": testProviderConfig{
+			typeName: "atype",
+			deps:     []SecretRef{{Scheme: "btype"}},
+		},
+		"b": testProviderConfig{
+			typeName: "btype",
+			deps:     []SecretRef{{Scheme: "atype"}},
+		},
+	}
+	constructors := map[string]ConstructorFunc{
+		"atype": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "a"}, nil
+		},
+		"btype": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "b"}, nil
+		},
+	}
+
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if err == nil {
+		t.Fatal("expected ErrCyclicDependency, got nil")
+	}
+	if !errors.Is(err, ErrCyclicDependency) {
+		t.Errorf("error = %v, want wrapping ErrCyclicDependency", err)
+	}
+}
+
+func TestNewRegistry_SelfCycle(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"a": testProviderConfig{
+			typeName: "atype",
+			deps:     []SecretRef{{Scheme: "atype"}},
+		},
+	}
+	constructors := map[string]ConstructorFunc{
+		"atype": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "a"}, nil
+		},
+	}
+
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if !errors.Is(err, ErrCyclicDependency) {
+		t.Errorf("self-cycle: error = %v, want wrapping ErrCyclicDependency", err)
+	}
+}
+
+func TestNewRegistry_MissingConstructor(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"v": testProviderConfig{typeName: "vault"},
+	}
+	constructors := map[string]ConstructorFunc{
+		// no "vault" constructor
+	}
+
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if err == nil {
+		t.Fatal("expected error for missing constructor, got nil")
+	}
+}
+
+func TestNewRegistry_ConstructorFailure_CleansUp(t *testing.T) {
+	var krProvider testProvider
+
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+		"v":  testProviderConfig{typeName: "vault", deps: []SecretRef{{Scheme: "keyring"}}},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			krProvider.name = "keyring"
+			return &krProvider, nil
+		},
+		"vault": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return nil, fmt.Errorf("vault init failed")
+		},
+	}
+
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// keyring must have been closed during cleanup
+	if krProvider.closeCt.Load() != 1 {
+		t.Errorf("keyring Close count = %d, want 1", krProvider.closeCt.Load())
+	}
+}
+
+func TestNewRegistry_UnresolvedDependency(t *testing.T) {
+	// vault depends on a scheme "op" that has no provider config
+	configs := map[string]ProviderConfig{
+		"v": testProviderConfig{typeName: "vault", deps: []SecretRef{{Scheme: "op"}}},
+	}
+	constructors := map[string]ConstructorFunc{
+		"vault": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "vault"}, nil
+		},
+	}
+
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if err == nil {
+		t.Fatal("expected error for unresolved dep, got nil")
+	}
+}
+
+func TestRegistry_Fetch_Dispatches(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{
+				name:     "keyring",
+				fetchVal: SecretValue{Value: []byte("secret-val")},
+			}, nil
+		},
+	}
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.Close()
+
+	ref := SecretRef{Scheme: "keyring", Host: "svc", Path: "user"}
+	sv, err := reg.Fetch(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if string(sv.Value) != "secret-val" {
+		t.Errorf("Fetch value = %q, want 'secret-val'", sv.Value)
+	}
+}
+
+func TestRegistry_Fetch_UnknownScheme(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "keyring"}, nil
+		},
+	}
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.Close()
+
+	ref := SecretRef{Scheme: "vault", Host: "kv", Path: "x"}
+	_, err = reg.Fetch(context.Background(), ref)
+	if err == nil {
+		t.Fatal("Fetch with unknown scheme should fail")
+	}
+}
+
+func TestRegistry_Close_ClosesAll(t *testing.T) {
+	var p1, p2 testProvider
+
+	configs := map[string]ProviderConfig{
+		"a": testProviderConfig{typeName: "atype"},
+		"b": testProviderConfig{typeName: "btype"},
+	}
+	constructors := map[string]ConstructorFunc{
+		"atype": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			p1.name = "a"
+			return &p1, nil
+		},
+		"btype": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			p2.name = "b"
+			return &p2, nil
+		},
+	}
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	if err := reg.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if p1.closeCt.Load() != 1 {
+		t.Errorf("p1 Close count = %d, want 1", p1.closeCt.Load())
+	}
+	if p2.closeCt.Load() != 1 {
+		t.Errorf("p2 Close count = %d, want 1", p2.closeCt.Load())
+	}
+}
+
+func TestRegistry_Close_Idempotent(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "keyring"}, nil
+		},
+	}
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	if err := reg.Close(); err != nil {
+		t.Errorf("first Close: %v", err)
+	}
+	if err := reg.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/proxy/secrets/ -run TestNewRegistry -v 2>&1 | head -20`
+
+Expected: FAIL — `NewRegistry`, `ConstructorFunc`, `RefResolver` not defined.
+
+- [ ] **Step 3: Implement registry.go**
+
+Create `internal/proxy/secrets/registry.go`:
+
+```go
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// RefResolver lets a provider constructor fetch a secret from an
+// already-constructed provider during auth chaining.
+type RefResolver func(ctx context.Context, ref SecretRef) (SecretValue, error)
+
+// ConstructorFunc builds a SecretProvider from its config. The
+// resolver can fetch secrets from providers that have already been
+// constructed (for auth chaining like vault's token_ref pointing
+// at keyring://...).
+type ConstructorFunc func(ctx context.Context, cfg ProviderConfig, resolver RefResolver) (SecretProvider, error)
+
+// Registry holds constructed providers keyed by their config name.
+// It is constructed by NewRegistry, which resolves auth-chaining
+// dependencies via topological sort and builds providers in the
+// right order.
+type Registry struct {
+	mu sync.Mutex
+
+	// providers keyed by config name (e.g. "kr", "vault-prod").
+	providers map[string]SecretProvider
+
+	// schemeToName maps URI scheme → config name for Fetch dispatch.
+	schemeToName map[string]string
+
+	closed bool
+}
+
+// NewRegistry constructs all providers in dependency order.
+//
+// configs maps config names to their ProviderConfig. constructors
+// maps provider type names (from TypeName()) to their constructor
+// functions. Every config's TypeName() must have a matching entry
+// in constructors.
+//
+// Dependencies are resolved via topological sort. Cyclic
+// dependencies return ErrCyclicDependency. If any constructor
+// fails, all already-constructed providers are closed before the
+// error is returned.
+func NewRegistry(ctx context.Context, configs map[string]ProviderConfig, constructors map[string]ConstructorFunc) (*Registry, error) {
+	// Validate all configs have constructors.
+	for name, cfg := range configs {
+		if _, ok := constructors[cfg.TypeName()]; !ok {
+			return nil, fmt.Errorf("no constructor registered for provider type %q (config %q)", cfg.TypeName(), name)
+		}
+	}
+
+	// Build scheme → config-name map and check for duplicate schemes.
+	schemeToName := make(map[string]string, len(configs))
+	for name, cfg := range configs {
+		scheme := cfg.TypeName()
+		if existing, dup := schemeToName[scheme]; dup {
+			return nil, fmt.Errorf("duplicate provider type %q: configs %q and %q", scheme, existing, name)
+		}
+		schemeToName[scheme] = name
+	}
+
+	// Build dependency graph: configName → list of configNames it depends on.
+	graph := make(map[string][]string, len(configs))
+	inDegree := make(map[string]int, len(configs))
+	for name := range configs {
+		graph[name] = nil
+		inDegree[name] = 0
+	}
+
+	for name, cfg := range configs {
+		for _, dep := range cfg.Dependencies() {
+			depName, ok := schemeToName[dep.Scheme]
+			if !ok {
+				return nil, fmt.Errorf("config %q depends on scheme %q, but no provider handles that scheme", name, dep.Scheme)
+			}
+			graph[depName] = append(graph[depName], name)
+			inDegree[name]++
+		}
+	}
+
+	// Kahn's algorithm for topological sort.
+	var queue []string
+	for name, deg := range inDegree {
+		if deg == 0 {
+			queue = append(queue, name)
+		}
+	}
+	// Sort the initial queue for deterministic ordering.
+	sort.Strings(queue)
+
+	var order []string
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		order = append(order, cur)
+
+		// Sort neighbors for deterministic ordering.
+		neighbors := graph[cur]
+		sort.Strings(neighbors)
+		for _, next := range neighbors {
+			inDegree[next]--
+			if inDegree[next] == 0 {
+				queue = append(queue, next)
+			}
+		}
+	}
+
+	if len(order) != len(configs) {
+		// Cycle detected — find which configs are in the cycle.
+		var inCycle []string
+		for name, deg := range inDegree {
+			if deg > 0 {
+				inCycle = append(inCycle, name)
+			}
+		}
+		sort.Strings(inCycle)
+		return nil, fmt.Errorf("%w: %v", ErrCyclicDependency, inCycle)
+	}
+
+	// Construct providers in topological order.
+	providers := make(map[string]SecretProvider, len(order))
+	for _, name := range order {
+		cfg := configs[name]
+		ctor := constructors[cfg.TypeName()]
+
+		// Build a resolver that can fetch from already-constructed providers.
+		resolver := func(fetchCtx context.Context, ref SecretRef) (SecretValue, error) {
+			provName, ok := schemeToName[ref.Scheme]
+			if !ok {
+				return SecretValue{}, fmt.Errorf("no provider handles scheme %q", ref.Scheme)
+			}
+			p, ok := providers[provName]
+			if !ok {
+				return SecretValue{}, fmt.Errorf("provider %q not yet constructed (dependency ordering bug)", provName)
+			}
+			return p.Fetch(fetchCtx, ref)
+		}
+
+		p, err := ctor(ctx, cfg, resolver)
+		if err != nil {
+			// Cleanup already-constructed providers.
+			for _, constructed := range order[:len(providers)] {
+				_ = providers[constructed].Close()
+			}
+			return nil, fmt.Errorf("constructing provider %q (type %q): %w", name, cfg.TypeName(), err)
+		}
+		providers[name] = p
+	}
+
+	return &Registry{
+		providers:    providers,
+		schemeToName: schemeToName,
+	}, nil
+}
+
+// Provider returns a named provider, or false if not found.
+func (r *Registry) Provider(name string) (SecretProvider, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	p, ok := r.providers[name]
+	return p, ok
+}
+
+// Fetch resolves a SecretRef by finding the provider that handles
+// its scheme and delegating to that provider's Fetch.
+func (r *Registry) Fetch(ctx context.Context, ref SecretRef) (SecretValue, error) {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return SecretValue{}, fmt.Errorf("registry closed")
+	}
+	name, ok := r.schemeToName[ref.Scheme]
+	if !ok {
+		r.mu.Unlock()
+		return SecretValue{}, fmt.Errorf("no provider handles scheme %q", ref.Scheme)
+	}
+	p := r.providers[name]
+	r.mu.Unlock()
+	return p.Fetch(ctx, ref)
+}
+
+// Close calls Close() on every provider. Safe to call multiple
+// times; subsequent calls are no-ops.
+func (r *Registry) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return nil
+	}
+	r.closed = true
+	var firstErr error
+	for _, p := range r.providers {
+		if err := p.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+```
+
+- [ ] **Step 4: Run registry tests**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/proxy/secrets/ -run "TestNewRegistry|TestRegistry_" -v`
+
+Expected: PASS — all registry tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/eran/work/agentsh
+git add internal/proxy/secrets/registry.go internal/proxy/secrets/registry_test.go
+git commit -m "feat(secrets): provider registry with topo sort + auth chaining (Plan 4)"
+```
+
+---
+
+## Task 3: Add `vault/api/auth/approle` dependency
+
+**Files:**
+- Modify: `go.mod`
+- Modify: `go.sum`
+
+- [ ] **Step 1: Add the approle auth module**
+
+Run: `cd /home/eran/work/agentsh && go get github.com/hashicorp/vault/api/auth/approle@latest`
+
+- [ ] **Step 2: Tidy**
+
+Run: `cd /home/eran/work/agentsh && go mod tidy`
+
+- [ ] **Step 3: Inspect go.sum delta for surprises**
+
+Run: `cd /home/eran/work/agentsh && git diff go.sum | head -40`
+
+Verify that any new transitive dependencies are from the `hashicorp` ecosystem and not surprising third-party modules. The `auth/approle` module is small and shares transitive deps with the already-present `vault/api` and `vault/api/auth/kubernetes`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/eran/work/agentsh
+git add go.mod go.sum
+git commit -m "deps: add hashicorp/vault/api/auth/approle (Plan 4)"
+```
+
+---
+
+## Task 4: Vault package skeleton — doc.go and config.go
+
+**Files:**
+- Create: `internal/proxy/secrets/vault/doc.go`
+- Create: `internal/proxy/secrets/vault/config.go`
+
+- [ ] **Step 1: Create vault/doc.go**
+
+Create `internal/proxy/secrets/vault/doc.go`:
+
+```go
+// Package vault implements secrets.SecretProvider using HashiCorp
+// Vault's KV v2 secrets engine. It wraps github.com/hashicorp/vault/api.
+//
+// Vault URIs take the form
+//
+//	vault://<mount>/<path>[#<field>]
+//
+// where <mount> is the KV v2 mount name, <path> is the secret path
+// within the mount, and the optional <field> selects one key from
+// the KV data map.
+//
+// The vault/api KV v2 helper adds the "data/" prefix internally.
+// If a URI path starts with "data/", the provider strips it and
+// logs a warning (common mistake when copying from the raw Vault
+// HTTP API).
+//
+// OpenBao is a wire-compatible Vault fork. This provider works
+// with OpenBao by pointing Address at the OpenBao server. No code
+// changes are needed.
+//
+// Supported auth methods: token, approle, kubernetes.
+//
+// Auth chaining is supported: bootstrap credentials (e.g. the
+// Vault token) can be fetched from another provider via the
+// RefResolver passed to New.
+package vault
+```
+
+- [ ] **Step 2: Create vault/config.go**
+
+Create `internal/proxy/secrets/vault/config.go`:
+
+```go
+package vault
+
+import (
+	secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
+)
+
+// Config configures the Vault provider.
+type Config struct {
+	secrets.ProviderConfigMarker
+
+	// Address is the Vault server address (e.g. "https://vault.corp.internal").
+	// Required.
+	Address string
+
+	// Namespace is the Vault enterprise namespace. Empty for open-source
+	// Vault and OpenBao.
+	Namespace string
+
+	// Auth configures how the provider authenticates to Vault.
+	Auth AuthConfig
+}
+
+// TypeName returns "vault". Used by the registry to map vault://
+// URI scheme refs to this provider.
+func (Config) TypeName() string { return "vault" }
+
+// Dependencies returns all *Ref fields that need resolution from
+// other providers before this provider can be constructed.
+func (c Config) Dependencies() []SecretRef {
+	var deps []SecretRef
+	if c.Auth.TokenRef != nil {
+		deps = append(deps, *c.Auth.TokenRef)
+	}
+	if c.Auth.RoleIDRef != nil {
+		deps = append(deps, *c.Auth.RoleIDRef)
+	}
+	if c.Auth.SecretIDRef != nil {
+		deps = append(deps, *c.Auth.SecretIDRef)
+	}
+	return deps
+}
+
+// SecretRef is an alias for secrets.SecretRef used in AuthConfig
+// so callers do not need to import the parent package just for
+// config construction.
+type SecretRef = secrets.SecretRef
+
+// AuthConfig configures how the provider authenticates to Vault.
+type AuthConfig struct {
+	// Method is the auth method: "token", "approle", or "kubernetes".
+	Method string
+
+	// Token auth. Exactly one of Token (literal) or TokenRef (chained)
+	// must be set when Method == "token".
+	Token    string
+	TokenRef *SecretRef
+
+	// AppRole auth. Each of RoleID/RoleIDRef and SecretID/SecretIDRef
+	// is a literal-or-ref pair. Exactly one form per field must be set
+	// when Method == "approle".
+	RoleID      string
+	RoleIDRef   *SecretRef
+	SecretID    string
+	SecretIDRef *SecretRef
+
+	// Kubernetes auth.
+	KubeRole      string // required when Method == "kubernetes"
+	KubeMountPath string // default "kubernetes"
+	KubeTokenPath string // default "/var/run/secrets/kubernetes.io/serviceaccount/token"
+}
+
+// Compile-time assertions. These fail to build if Config ever
+// drifts away from the interfaces it's expected to satisfy.
+var (
+	_ secrets.ProviderConfig = Config{}
+	_ secrets.SecretProvider = (*Provider)(nil)
+)
+```
+
+Note: The `_ secrets.SecretProvider = (*Provider)(nil)` assertion will cause a build failure until Task 5 creates `Provider`. That is expected — do NOT remove this line. Task 5 will define `Provider` and the build will succeed then.
+
+- [ ] **Step 3: Write config tests**
+
+Create a temporary test to verify Config methods (these will be expanded in Task 5 once Provider exists). Add to the top of what will become `internal/proxy/secrets/vault/provider_test.go`:
+
+```go
+package vault
+
+import (
+	"testing"
+
+	secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
+)
+
+func TestConfig_TypeName(t *testing.T) {
+	c := Config{}
+	if got := c.TypeName(); got != "vault" {
+		t.Errorf("TypeName() = %q, want 'vault'", got)
+	}
+}
+
+func TestConfig_Dependencies_Empty(t *testing.T) {
+	c := Config{Auth: AuthConfig{Method: "token", Token: "literal"}}
+	if deps := c.Dependencies(); len(deps) != 0 {
+		t.Errorf("Dependencies() = %v, want empty", deps)
+	}
+}
+
+func TestConfig_Dependencies_WithRefs(t *testing.T) {
+	tokenRef := secrets.SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-token"}
+	roleRef := secrets.SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-role"}
+	secretRef := secrets.SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-secret"}
+
+	c := Config{
+		Auth: AuthConfig{
+			Method:      "approle",
+			RoleIDRef:   &roleRef,
+			SecretIDRef: &secretRef,
+			TokenRef:    &tokenRef, // unusual but legal to set for testing
+		},
+	}
+	deps := c.Dependencies()
+	if len(deps) != 3 {
+		t.Fatalf("Dependencies() length = %d, want 3", len(deps))
+	}
+}
+```
+
+- [ ] **Step 4: Run config test (expect build failure for now)**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/proxy/secrets/vault/ -run TestConfig -v 2>&1 | head -10`
+
+Expected: Build failure mentioning `Provider` undefined. This is fine — the compile-time assertion in config.go references `Provider` which doesn't exist yet. Comment out the `_ secrets.SecretProvider = (*Provider)(nil)` line temporarily to verify config tests pass, then uncomment it.
+
+Alternative: just verify the doc.go and config.go compile in isolation by temporarily commenting the `Provider` assertion:
+
+Run: `cd /home/eran/work/agentsh && go vet ./internal/proxy/secrets/vault/ 2>&1 | head -10`
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/eran/work/agentsh
+git add internal/proxy/secrets/vault/doc.go internal/proxy/secrets/vault/config.go internal/proxy/secrets/vault/provider_test.go
+git commit -m "feat(secrets/vault): package skeleton — doc.go, config.go, config tests (Plan 4)"
+```
+
+---
+
+## Task 5: Vault provider — construction, Fetch, Close
+
+**Files:**
+- Create: `internal/proxy/secrets/vault/provider.go`
+- Modify: `internal/proxy/secrets/vault/provider_test.go`
+
+- [ ] **Step 1: Write httptest mock helper and happy-path test**
+
+Add to `internal/proxy/secrets/vault/provider_test.go` (below the existing config tests):
+
+```go
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
+	"github.com/agentsh/agentsh/internal/proxy/secrets/secretstest"
+)
+
+// mockVaultServer returns an httptest.Server that simulates Vault
+// KV v2 endpoints. kvData maps "mount/path" → field → value.
+func mockVaultServer(t *testing.T, token string, kvData map[string]map[string]string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	// Token lookup-self for connectivity check.
+	mux.HandleFunc("/v1/auth/token/lookup-self", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Vault-Token") != token {
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprintf(w, `{"errors":["permission denied"]}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"data":{"id":"%s","ttl":3600}}`, token)
+	})
+
+	// Token revoke-self.
+	mux.HandleFunc("/v1/auth/token/revoke-self", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	// AppRole login.
+	mux.HandleFunc("/v1/auth/approle/login", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			RoleID   string `json:"role_id"`
+			SecretID string `json:"secret_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if body.RoleID == "" || body.SecretID == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, `{"errors":["missing role_id or secret_id"]}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"auth":{"client_token":"%s","lease_duration":3600,"renewable":true}}`, token)
+	})
+
+	// Kubernetes login.
+	mux.HandleFunc("/v1/auth/kubernetes/login", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Role string `json:"role"`
+			JWT  string `json:"jwt"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if body.Role == "" || body.JWT == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprintf(w, `{"errors":["missing role or jwt"]}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"auth":{"client_token":"%s","lease_duration":3600,"renewable":true}}`, token)
+	})
+
+	// KV v2 read: /v1/{mount}/data/{path}
+	mux.HandleFunc("/v1/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Vault-Token") != token {
+			w.WriteHeader(http.StatusForbidden)
+			fmt.Fprintf(w, `{"errors":["permission denied"]}`)
+			return
+		}
+
+		// Parse /v1/{mount}/data/{path}
+		path := strings.TrimPrefix(r.URL.Path, "/v1/")
+		parts := strings.SplitN(path, "/data/", 2)
+		if len(parts) != 2 {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintf(w, `{"errors":["no handler for route"]}`)
+			return
+		}
+		key := parts[0] + "/" + parts[1]
+
+		fields, ok := kvData[key]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			fmt.Fprintf(w, `{"errors":[]}`)
+			return
+		}
+
+		// Build KV v2 response.
+		dataMap := make(map[string]interface{})
+		for k, v := range fields {
+			dataMap[k] = v
+		}
+		resp := map[string]interface{}{
+			"data": map[string]interface{}{
+				"data": dataMap,
+				"metadata": map[string]interface{}{
+					"version":      3,
+					"created_time": "2026-04-09T10:00:00Z",
+				},
+			},
+			"lease_id":       "",
+			"lease_duration": 0,
+			"renewable":      false,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// noopResolver is a RefResolver that always returns an error.
+// Used when the Vault config has no chained refs.
+func noopResolver(_ context.Context, ref secrets.SecretRef) (secrets.SecretValue, error) {
+	return secrets.SecretValue{}, fmt.Errorf("noopResolver: unexpected resolve call for %s", ref.String())
+}
+
+func TestNew_TokenAuth_HappyPath(t *testing.T) {
+	const testToken = "hvs.test-token-12345"
+	srv := mockVaultServer(t, testToken, nil)
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth: AuthConfig{
+			Method: "token",
+			Token:  testToken,
+		},
+	}
+	p, err := New(context.Background(), cfg, noopResolver)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+
+	if p.Name() != "vault" {
+		t.Errorf("Name() = %q, want 'vault'", p.Name())
+	}
+}
+
+func TestFetch_KVv2_WithField(t *testing.T) {
+	const testToken = "hvs.test-token-12345"
+	kvData := map[string]map[string]string{
+		"kv/github": {"token": "ghp_real123", "endpoint": "https://api.github.com"},
+	}
+	srv := mockVaultServer(t, testToken, kvData)
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth:    AuthConfig{Method: "token", Token: testToken},
+	}
+	p, err := New(context.Background(), cfg, noopResolver)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: "github", Field: "token"}
+	sv, err := p.Fetch(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if string(sv.Value) != "ghp_real123" {
+		t.Errorf("Fetch value = %q, want 'ghp_real123'", sv.Value)
+	}
+	if sv.Version != "3" {
+		t.Errorf("Version = %q, want '3'", sv.Version)
+	}
+	if sv.FetchedAt.IsZero() {
+		t.Error("FetchedAt not set")
+	}
+}
+
+func TestFetch_KVv2_SingleFieldAutoResolve(t *testing.T) {
+	const testToken = "hvs.test-token-12345"
+	kvData := map[string]map[string]string{
+		"secret/api-key": {"value": "sk-12345"},
+	}
+	srv := mockVaultServer(t, testToken, kvData)
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth:    AuthConfig{Method: "token", Token: testToken},
+	}
+	p, err := New(context.Background(), cfg, noopResolver)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+
+	ref := secrets.SecretRef{Scheme: "vault", Host: "secret", Path: "api-key"}
+	sv, err := p.Fetch(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if string(sv.Value) != "sk-12345" {
+		t.Errorf("Fetch value = %q, want 'sk-12345'", sv.Value)
+	}
+}
+
+func TestFetch_KVv2_MultiFieldNoFragment_Error(t *testing.T) {
+	const testToken = "hvs.test-token-12345"
+	kvData := map[string]map[string]string{
+		"kv/multi": {"user": "admin", "pass": "secret"},
+	}
+	srv := mockVaultServer(t, testToken, kvData)
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth:    AuthConfig{Method: "token", Token: testToken},
+	}
+	p, err := New(context.Background(), cfg, noopResolver)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: "multi"}
+	_, err = p.Fetch(context.Background(), ref)
+	if err == nil {
+		t.Fatal("expected error for multi-field without fragment")
+	}
+	if !errors.Is(err, secrets.ErrInvalidURI) {
+		t.Errorf("error = %v, want wrapping ErrInvalidURI", err)
+	}
+}
+
+func TestFetch_KVv2_MissingField(t *testing.T) {
+	const testToken = "hvs.test-token-12345"
+	kvData := map[string]map[string]string{
+		"kv/github": {"token": "ghp_real123"},
+	}
+	srv := mockVaultServer(t, testToken, kvData)
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth:    AuthConfig{Method: "token", Token: testToken},
+	}
+	p, err := New(context.Background(), cfg, noopResolver)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: "github", Field: "nonexistent"}
+	_, err = p.Fetch(context.Background(), ref)
+	if !errors.Is(err, secrets.ErrNotFound) {
+		t.Errorf("missing field error = %v, want wrapping ErrNotFound", err)
+	}
+}
+
+func TestFetch_SecretNotFound(t *testing.T) {
+	const testToken = "hvs.test-token-12345"
+	srv := mockVaultServer(t, testToken, nil)
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth:    AuthConfig{Method: "token", Token: testToken},
+	}
+	p, err := New(context.Background(), cfg, noopResolver)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer p.Close()
+
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: "nonexistent", Field: "x"}
+	_, err = p.Fetch(context.Background(), ref)
+	if !errors.Is(err, secrets.ErrNotFound) {
+		t.Errorf("not found error = %v, want wrapping ErrNotFound", err)
+	}
+}
+
+func TestFetch_WrongScheme(t *testing.T) {
+	p := &Provider{} // zero-value, not connected
+	ref := secrets.SecretRef{Scheme: "keyring", Host: "kv", Path: "x"}
+	_, err := p.Fetch(context.Background(), ref)
+	if !errors.Is(err, secrets.ErrInvalidURI) {
+		t.Errorf("wrong scheme error = %v, want wrapping ErrInvalidURI", err)
+	}
+}
+
+func TestFetch_MissingHost(t *testing.T) {
+	p := &Provider{}
+	ref := secrets.SecretRef{Scheme: "vault", Host: "", Path: "x"}
+	_, err := p.Fetch(context.Background(), ref)
+	if !errors.Is(err, secrets.ErrInvalidURI) {
+		t.Errorf("missing host error = %v, want wrapping ErrInvalidURI", err)
+	}
+}
+
+func TestFetch_MissingPath(t *testing.T) {
+	p := &Provider{}
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: ""}
+	_, err := p.Fetch(context.Background(), ref)
+	if !errors.Is(err, secrets.ErrInvalidURI) {
+		t.Errorf("missing path error = %v, want wrapping ErrInvalidURI", err)
+	}
+}
+
+func TestFetch_ContextCanceled(t *testing.T) {
+	p := &Provider{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: "x"}
+	_, err := p.Fetch(ctx, ref)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("canceled ctx error = %v, want context.Canceled", err)
+	}
+}
+
+func TestFetch_AfterClose(t *testing.T) {
+	const testToken = "hvs.test-token-12345"
+	srv := mockVaultServer(t, testToken, nil)
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth:    AuthConfig{Method: "token", Token: testToken},
+	}
+	p, err := New(context.Background(), cfg, noopResolver)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_ = p.Close()
+
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: "x"}
+	_, err = p.Fetch(context.Background(), ref)
+	if err == nil {
+		t.Fatal("Fetch after Close returned nil error")
+	}
+}
+
+func TestClose_Idempotent(t *testing.T) {
+	const testToken = "hvs.test-token-12345"
+	srv := mockVaultServer(t, testToken, nil)
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth:    AuthConfig{Method: "token", Token: testToken},
+	}
+	p, err := New(context.Background(), cfg, noopResolver)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := p.Close(); err != nil {
+		t.Errorf("first Close: %v", err)
+	}
+	if err := p.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/proxy/secrets/vault/ -run "TestNew_TokenAuth|TestFetch_|TestClose_" -v 2>&1 | head -10`
+
+Expected: FAIL — `Provider` type and `New` function not defined.
+
+- [ ] **Step 3: Implement vault/provider.go**
+
+Create `internal/proxy/secrets/vault/provider.go`:
+
+```go
+package vault
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	vaultapi "github.com/hashicorp/vault/api"
+	approleauth "github.com/hashicorp/vault/api/auth/approle"
+	kubeauth "github.com/hashicorp/vault/api/auth/kubernetes"
+
+	secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
+)
+
+// Provider is a Vault-backed secrets.SecretProvider.
+//
+// It reads KV v2 secrets using the hashicorp/vault/api client.
+// Supported auth methods: token, approle, kubernetes.
+//
+// Provider is safe for concurrent Fetch and Close.
+type Provider struct {
+	mu     sync.RWMutex
+	closed atomic.Bool
+	client *vaultapi.Client
+
+	// ownedToken is true when the provider created the token via
+	// AppRole or Kubernetes auth. If true, Close revokes the token.
+	ownedToken bool
+}
+
+// New constructs a Vault Provider.
+//
+// It validates the config, resolves any chained secret refs via the
+// resolver, creates a vault/api.Client, authenticates, and verifies
+// connectivity with a token self-lookup.
+func New(ctx context.Context, cfg Config, resolver secrets.RefResolver) (*Provider, error) {
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	// Resolve chained refs.
+	token, roleID, secretID, err := resolveAuthRefs(ctx, cfg.Auth, resolver)
+	if err != nil {
+		return nil, fmt.Errorf("resolving auth refs: %w", err)
+	}
+
+	// Create vault/api client.
+	apiCfg := vaultapi.DefaultConfig()
+	apiCfg.Address = cfg.Address
+	apiCfg.Timeout = 30 * time.Second
+
+	client, err := vaultapi.NewClient(apiCfg)
+	if err != nil {
+		return nil, fmt.Errorf("creating vault client: %w", err)
+	}
+	if cfg.Namespace != "" {
+		client.SetNamespace(cfg.Namespace)
+	}
+
+	var ownedToken bool
+
+	// Authenticate.
+	switch cfg.Auth.Method {
+	case "token":
+		client.SetToken(token)
+	case "approle":
+		appRole, err := approleauth.NewAppRoleAuth(roleID, &approleauth.SecretID{FromString: secretID})
+		if err != nil {
+			return nil, fmt.Errorf("creating approle auth: %w", err)
+		}
+		authInfo, err := client.Auth().Login(ctx, appRole)
+		if err != nil {
+			return nil, fmt.Errorf("%w: approle login: %s", secrets.ErrUnauthorized, err)
+		}
+		if authInfo == nil || authInfo.Auth == nil {
+			return nil, fmt.Errorf("%w: approle login returned no auth info", secrets.ErrUnauthorized)
+		}
+		ownedToken = true
+	case "kubernetes":
+		mountPath := cfg.Auth.KubeMountPath
+		if mountPath == "" {
+			mountPath = "kubernetes"
+		}
+		tokenPath := cfg.Auth.KubeTokenPath
+		if tokenPath == "" {
+			tokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+		}
+		kubeAuth, err := kubeauth.NewKubernetesAuth(
+			cfg.Auth.KubeRole,
+			kubeauth.WithServiceAccountTokenPath(tokenPath),
+			kubeauth.WithMountPath(mountPath),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("creating kubernetes auth: %w", err)
+		}
+		authInfo, err := client.Auth().Login(ctx, kubeAuth)
+		if err != nil {
+			return nil, fmt.Errorf("%w: kubernetes login: %s", secrets.ErrUnauthorized, err)
+		}
+		if authInfo == nil || authInfo.Auth == nil {
+			return nil, fmt.Errorf("%w: kubernetes login returned no auth info", secrets.ErrUnauthorized)
+		}
+		ownedToken = true
+	}
+
+	// Verify connectivity.
+	_, err = client.Auth().Token().LookupSelfWithContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: token self-lookup failed: %s", secrets.ErrUnauthorized, err)
+	}
+
+	return &Provider{
+		client:     client,
+		ownedToken: ownedToken,
+	}, nil
+}
+
+// Name returns "vault".
+func (p *Provider) Name() string { return "vault" }
+
+// Fetch retrieves a secret from Vault KV v2.
+func (p *Provider) Fetch(ctx context.Context, ref secrets.SecretRef) (secrets.SecretValue, error) {
+	if p.closed.Load() {
+		return secrets.SecretValue{}, fmt.Errorf("vault provider closed")
+	}
+	if err := ctx.Err(); err != nil {
+		return secrets.SecretValue{}, err
+	}
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.closed.Load() {
+		return secrets.SecretValue{}, fmt.Errorf("vault provider closed")
+	}
+
+	// Validate ref.
+	if ref.Scheme != "vault" {
+		return secrets.SecretValue{}, fmt.Errorf("%w: wrong scheme %q", secrets.ErrInvalidURI, ref.Scheme)
+	}
+	if ref.Host == "" {
+		return secrets.SecretValue{}, fmt.Errorf("%w: vault URI missing mount (host)", secrets.ErrInvalidURI)
+	}
+	if ref.Path == "" {
+		return secrets.SecretValue{}, fmt.Errorf("%w: vault URI missing path", secrets.ErrInvalidURI)
+	}
+
+	// Strip accidental "data/" prefix with a warning.
+	path := ref.Path
+	if strings.HasPrefix(path, "data/") {
+		log.Printf("WARNING: vault URI path %q starts with 'data/' — stripping (KV v2 helper adds it automatically)", path)
+		path = strings.TrimPrefix(path, "data/")
+	}
+
+	// Read from KV v2.
+	kvSecret, err := p.client.KVv2(ref.Host).Get(ctx, path)
+	if err != nil {
+		var respErr *vaultapi.ResponseError
+		if errors.As(err, &respErr) {
+			switch respErr.StatusCode {
+			case http.StatusNotFound:
+				return secrets.SecretValue{}, fmt.Errorf("%w: %s", secrets.ErrNotFound, ref.String())
+			case http.StatusForbidden:
+				return secrets.SecretValue{}, fmt.Errorf("%w: %s", secrets.ErrUnauthorized, ref.String())
+			}
+		}
+		return secrets.SecretValue{}, fmt.Errorf("vault read %s: %w", ref.String(), err)
+	}
+	if kvSecret == nil || kvSecret.Data == nil {
+		return secrets.SecretValue{}, fmt.Errorf("%w: %s returned nil data", secrets.ErrNotFound, ref.String())
+	}
+
+	// Extract field.
+	var value []byte
+	if ref.Field != "" {
+		raw, ok := kvSecret.Data[ref.Field]
+		if !ok {
+			return secrets.SecretValue{}, fmt.Errorf("%w: field %q not found in %s", secrets.ErrNotFound, ref.Field, ref.String())
+		}
+		value = toBytes(raw)
+	} else {
+		switch len(kvSecret.Data) {
+		case 0:
+			return secrets.SecretValue{}, fmt.Errorf("%w: %s has no fields", secrets.ErrNotFound, ref.String())
+		case 1:
+			for _, raw := range kvSecret.Data {
+				value = toBytes(raw)
+			}
+		default:
+			var fields []string
+			for k := range kvSecret.Data {
+				fields = append(fields, k)
+			}
+			return secrets.SecretValue{}, fmt.Errorf("%w: %s has multiple fields (%s) — use #field to select one", secrets.ErrInvalidURI, ref.String(), strings.Join(fields, ", "))
+		}
+	}
+
+	sv := secrets.SecretValue{
+		Value:     value,
+		FetchedAt: time.Now(),
+	}
+
+	// Extract version metadata.
+	if kvSecret.VersionMetadata != nil {
+		sv.Version = strconv.Itoa(kvSecret.VersionMetadata.Version)
+	}
+
+	// Extract lease info from raw secret.
+	if kvSecret.Raw != nil {
+		if kvSecret.Raw.LeaseDuration > 0 {
+			sv.TTL = time.Duration(kvSecret.Raw.LeaseDuration) * time.Second
+		}
+		sv.LeaseID = kvSecret.Raw.LeaseID
+	}
+
+	return sv, nil
+}
+
+// Close marks the provider closed and optionally revokes the token.
+func (p *Provider) Close() error {
+	if !p.closed.CompareAndSwap(false, true) {
+		return nil // already closed
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.client != nil && p.ownedToken {
+		// Best-effort token revocation for tokens we created.
+		_ = p.client.Auth().Token().RevokeSelf("")
+	}
+	p.client = nil
+	return nil
+}
+
+// validateConfig checks that the Config is well-formed.
+func validateConfig(cfg Config) error {
+	if cfg.Address == "" {
+		return fmt.Errorf("vault: address required")
+	}
+
+	switch cfg.Auth.Method {
+	case "token":
+		hasLiteral := cfg.Auth.Token != ""
+		hasRef := cfg.Auth.TokenRef != nil
+		if hasLiteral == hasRef {
+			if hasLiteral {
+				return fmt.Errorf("vault: token auth: set Token or TokenRef, not both")
+			}
+			return fmt.Errorf("vault: token auth: Token or TokenRef required")
+		}
+	case "approle":
+		hasRoleIDLiteral := cfg.Auth.RoleID != ""
+		hasRoleIDRef := cfg.Auth.RoleIDRef != nil
+		if hasRoleIDLiteral == hasRoleIDRef {
+			if hasRoleIDLiteral {
+				return fmt.Errorf("vault: approle auth: set RoleID or RoleIDRef, not both")
+			}
+			return fmt.Errorf("vault: approle auth: RoleID or RoleIDRef required")
+		}
+		hasSecretIDLiteral := cfg.Auth.SecretID != ""
+		hasSecretIDRef := cfg.Auth.SecretIDRef != nil
+		if hasSecretIDLiteral == hasSecretIDRef {
+			if hasSecretIDLiteral {
+				return fmt.Errorf("vault: approle auth: set SecretID or SecretIDRef, not both")
+			}
+			return fmt.Errorf("vault: approle auth: SecretID or SecretIDRef required")
+		}
+	case "kubernetes":
+		if cfg.Auth.KubeRole == "" {
+			return fmt.Errorf("vault: kubernetes auth: KubeRole required")
+		}
+	default:
+		return fmt.Errorf("vault: unsupported auth method %q (expected token, approle, or kubernetes)", cfg.Auth.Method)
+	}
+	return nil
+}
+
+// resolveAuthRefs resolves chained secret refs and returns the
+// literal values for token, roleID, and secretID. Resolved
+// SecretValues are zeroed after extracting the string.
+func resolveAuthRefs(ctx context.Context, auth AuthConfig, resolver secrets.RefResolver) (token, roleID, secretID string, err error) {
+	switch auth.Method {
+	case "token":
+		if auth.TokenRef != nil {
+			sv, err := resolver(ctx, *auth.TokenRef)
+			if err != nil {
+				return "", "", "", fmt.Errorf("resolving token_ref: %w", err)
+			}
+			token = string(sv.Value)
+			sv.Zero()
+		} else {
+			token = auth.Token
+		}
+	case "approle":
+		if auth.RoleIDRef != nil {
+			sv, err := resolver(ctx, *auth.RoleIDRef)
+			if err != nil {
+				return "", "", "", fmt.Errorf("resolving role_id_ref: %w", err)
+			}
+			roleID = string(sv.Value)
+			sv.Zero()
+		} else {
+			roleID = auth.RoleID
+		}
+		if auth.SecretIDRef != nil {
+			sv, err := resolver(ctx, *auth.SecretIDRef)
+			if err != nil {
+				return "", "", "", fmt.Errorf("resolving secret_id_ref: %w", err)
+			}
+			secretID = string(sv.Value)
+			sv.Zero()
+		} else {
+			secretID = auth.SecretID
+		}
+	case "kubernetes":
+		// Kubernetes auth does not use chained refs — it reads the
+		// SA token from the filesystem directly.
+	}
+	return token, roleID, secretID, nil
+}
+
+// toBytes converts an interface{} to []byte. String values are
+// converted directly; other types are JSON-encoded.
+func toBytes(v interface{}) []byte {
+	switch val := v.(type) {
+	case string:
+		return []byte(val)
+	case []byte:
+		cp := make([]byte, len(val))
+		copy(cp, val)
+		return cp
+	default:
+		b, _ := json.Marshal(v)
+		return b
+	}
+}
+```
+
+Note: Add `"encoding/json"`, `"errors"`, and `"net/http"` to the imports.
+
+The final import block for `provider.go` should be:
+
+```go
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	vaultapi "github.com/hashicorp/vault/api"
+	approleauth "github.com/hashicorp/vault/api/auth/approle"
+	kubeauth "github.com/hashicorp/vault/api/auth/kubernetes"
+
+	secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
+)
+```
+
+- [ ] **Step 4: Fix the provider_test.go import block**
+
+The test file needs a single unified import block at the top. Merge the two import blocks into one:
+
+```go
+package vault
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
+	"github.com/agentsh/agentsh/internal/proxy/secrets/secretstest"
+)
+```
+
+Remove the earlier `import` block that only had `testing` and `secrets`.
+
+- [ ] **Step 5: Run all vault tests**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/proxy/secrets/vault/ -v -count=1`
+
+Expected: PASS — all tests pass. The Vault error checking uses `errors.As(err, &vaultapi.ResponseError{})` to match HTTP status codes from the mock server. If the KV v2 helper wraps errors differently than expected, adjust the error type assertion in `Fetch`.
+
+Fix any compilation issues. Common ones:
+- `http.StatusNotFound` and `http.StatusForbidden` require `"net/http"` import in `provider.go`.
+- `json.Marshal` requires `"encoding/json"` import in `provider.go`.
+- `errors.As` requires `"errors"` import in `provider.go`.
+
+- [ ] **Step 6: Run full secrets test suite**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/proxy/secrets/... -v -count=1`
+
+Expected: PASS — vault tests and existing keyring/credsub tests all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/eran/work/agentsh
+git add internal/proxy/secrets/vault/provider.go internal/proxy/secrets/vault/provider_test.go
+git commit -m "feat(secrets/vault): Vault KV v2 provider — token/approle/k8s auth, field extraction (Plan 4)"
+```
+
+---
+
+## Task 6: Auth chaining, config validation, and contract tests
+
+**Files:**
+- Modify: `internal/proxy/secrets/vault/provider_test.go`
+
+- [ ] **Step 1: Write auth chaining test**
+
+Add to `internal/proxy/secrets/vault/provider_test.go`:
+
+```go
+func TestNew_AuthChaining_TokenFromResolver(t *testing.T) {
+	const testToken = "hvs.chained-token-67890"
+	srv := mockVaultServer(t, testToken, nil)
+
+	tokenRef := secrets.SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-token"}
+	memProvider := secretstest.NewMemoryProvider("keyring", map[string][]byte{
+		"keyring://agentsh/vault-token": []byte(testToken),
+	})
+	resolver := func(ctx context.Context, ref secrets.SecretRef) (secrets.SecretValue, error) {
+		return memProvider.Fetch(ctx, ref)
+	}
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth: AuthConfig{
+			Method:   "token",
+			TokenRef: &tokenRef,
+		},
+	}
+	p, err := New(context.Background(), cfg, resolver)
+	if err != nil {
+		t.Fatalf("New with chained token: %v", err)
+	}
+	defer p.Close()
+}
+
+func TestNew_AppRoleAuth(t *testing.T) {
+	const testToken = "hvs.approle-token"
+	srv := mockVaultServer(t, testToken, nil)
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth: AuthConfig{
+			Method:   "approle",
+			RoleID:   "my-role-id",
+			SecretID: "my-secret-id",
+		},
+	}
+	p, err := New(context.Background(), cfg, noopResolver)
+	if err != nil {
+		t.Fatalf("New with approle: %v", err)
+	}
+	defer p.Close()
+}
+
+func TestNew_AppRoleAuth_ChainedRefs(t *testing.T) {
+	const testToken = "hvs.approle-chained"
+	srv := mockVaultServer(t, testToken, nil)
+
+	roleRef := secrets.SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-role"}
+	secretRef := secrets.SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-secret"}
+	memProvider := secretstest.NewMemoryProvider("keyring", map[string][]byte{
+		"keyring://agentsh/vault-role":   []byte("my-role-id"),
+		"keyring://agentsh/vault-secret": []byte("my-secret-id"),
+	})
+	resolver := func(ctx context.Context, ref secrets.SecretRef) (secrets.SecretValue, error) {
+		return memProvider.Fetch(ctx, ref)
+	}
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth: AuthConfig{
+			Method:      "approle",
+			RoleIDRef:   &roleRef,
+			SecretIDRef: &secretRef,
+		},
+	}
+	p, err := New(context.Background(), cfg, resolver)
+	if err != nil {
+		t.Fatalf("New with chained approle: %v", err)
+	}
+	defer p.Close()
+}
+```
+
+- [ ] **Step 2: Write config validation tests**
+
+Add to `internal/proxy/secrets/vault/provider_test.go`:
+
+```go
+func TestNew_MissingAddress(t *testing.T) {
+	cfg := Config{Auth: AuthConfig{Method: "token", Token: "x"}}
+	_, err := New(context.Background(), cfg, noopResolver)
+	if err == nil {
+		t.Fatal("expected error for missing address")
+	}
+}
+
+func TestNew_BadAuthMethod(t *testing.T) {
+	cfg := Config{Address: "http://localhost", Auth: AuthConfig{Method: "ldap"}}
+	_, err := New(context.Background(), cfg, noopResolver)
+	if err == nil {
+		t.Fatal("expected error for bad auth method")
+	}
+}
+
+func TestNew_TokenAuth_BothLiteralAndRef(t *testing.T) {
+	ref := secrets.SecretRef{Scheme: "keyring", Host: "a", Path: "b"}
+	cfg := Config{
+		Address: "http://localhost",
+		Auth:    AuthConfig{Method: "token", Token: "x", TokenRef: &ref},
+	}
+	_, err := New(context.Background(), cfg, noopResolver)
+	if err == nil {
+		t.Fatal("expected error for both Token and TokenRef")
+	}
+}
+
+func TestNew_TokenAuth_NeitherLiteralNorRef(t *testing.T) {
+	cfg := Config{
+		Address: "http://localhost",
+		Auth:    AuthConfig{Method: "token"},
+	}
+	_, err := New(context.Background(), cfg, noopResolver)
+	if err == nil {
+		t.Fatal("expected error for neither Token nor TokenRef")
+	}
+}
+
+func TestNew_AppRole_MissingSecretID(t *testing.T) {
+	cfg := Config{
+		Address: "http://localhost",
+		Auth:    AuthConfig{Method: "approle", RoleID: "x"},
+	}
+	_, err := New(context.Background(), cfg, noopResolver)
+	if err == nil {
+		t.Fatal("expected error for missing SecretID")
+	}
+}
+
+func TestNew_Kubernetes_MissingRole(t *testing.T) {
+	cfg := Config{
+		Address: "http://localhost",
+		Auth:    AuthConfig{Method: "kubernetes"},
+	}
+	_, err := New(context.Background(), cfg, noopResolver)
+	if err == nil {
+		t.Fatal("expected error for missing KubeRole")
+	}
+}
+```
+
+- [ ] **Step 3: Write contract test**
+
+Add to `internal/proxy/secrets/vault/provider_test.go`:
+
+```go
+func TestProviderContract_AppliedToVaultProvider(t *testing.T) {
+	const testToken = "hvs.contract-test-token"
+	srv := mockVaultServer(t, testToken, nil)
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth:    AuthConfig{Method: "token", Token: testToken},
+	}
+	p, err := New(context.Background(), cfg, noopResolver)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	probeRef := secrets.SecretRef{
+		Scheme: "vault",
+		Host:   "kv",
+		Path:   "definitely-does-not-exist-contract-probe",
+		Field:  "x",
+	}
+	secretstest.ProviderContract(t, "vault", p, probeRef)
+}
+```
+
+- [ ] **Step 4: Run all vault tests**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/proxy/secrets/vault/ -v -count=1`
+
+Expected: PASS — all tests including auth chaining, validation, and contract.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/eran/work/agentsh
+git add internal/proxy/secrets/vault/provider_test.go
+git commit -m "test(secrets/vault): auth chaining, config validation, contract tests (Plan 4)"
+```
+
+---
+
+## Task 7: Update doc.go and final verification
+
+**Files:**
+- Modify: `internal/proxy/secrets/doc.go`
+
+- [ ] **Step 1: Update secrets/doc.go to mention vault and registry**
+
+Replace the content of `internal/proxy/secrets/doc.go`:
+
+```go
+// Package secrets defines the SecretProvider interface that agentsh
+// uses to fetch real credentials from external secret stores at
+// session start, plus the URI grammar, sentinel errors, and the
+// provider Registry shared by all provider implementations.
+//
+// The Registry (registry.go) constructs providers in dependency
+// order via topological sort, enabling auth chaining where one
+// provider's bootstrap credentials come from another (e.g. Vault
+// reads its token from the OS keyring).
+//
+// Provider implementations live in subpackages, one per backend:
+//
+//   - internal/proxy/secrets/keyring — OS keyring (Keychain / Secret
+//     Service / Credential Manager) via github.com/zalando/go-keyring.
+//   - internal/proxy/secrets/vault — HashiCorp Vault / OpenBao KV v2
+//     via github.com/hashicorp/vault/api.
+//
+// Future plans add awssm, gcpsm, azurekv, and op subpackages.
+// Every provider imports this package for the interface and types;
+// this package imports none of them.
+//
+// Test doubles live in the sibling secretstest package. Production
+// code must not import secretstest.
+//
+// The design is documented in
+// docs/superpowers/specs/2026-04-09-plan-04-vault-provider-registry-design.md
+// and the parent migration spec
+// docs/superpowers/specs/2026-04-07-external-secrets-design.md.
+package secrets
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/proxy/secrets/... -v -count=1`
+
+Expected: PASS — all packages (secrets, secrets/keyring, secrets/secretstest, secrets/vault) pass.
+
+- [ ] **Step 3: Build all**
+
+Run: `cd /home/eran/work/agentsh && go build ./...`
+
+Expected: PASS.
+
+- [ ] **Step 4: Cross-compile for Windows**
+
+Run: `cd /home/eran/work/agentsh && GOOS=windows go build ./...`
+
+Expected: PASS. The vault/api library is pure Go. No cgo issues.
+
+- [ ] **Step 5: Verify no changes to out-of-scope files**
+
+Run: `cd /home/eran/work/agentsh && git diff --name-only HEAD~6` (or however many commits back Plan 4 started)
+
+Verify that ONLY these paths were modified:
+- `internal/proxy/secrets/` (errors.go, provider.go, provider_test.go, errors_test.go, doc.go, registry.go, registry_test.go)
+- `internal/proxy/secrets/keyring/config.go`
+- `internal/proxy/secrets/vault/` (new files)
+- `go.mod`, `go.sum`
+
+No changes to: `pkg/secrets/`, `internal/session/`, `internal/api/`, `cmd/`, `internal/proxy/credsub/`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/eran/work/agentsh
+git add internal/proxy/secrets/doc.go
+git commit -m "docs(secrets): update package doc for vault provider and registry (Plan 4)"
+```
+
+- [ ] **Step 7: Run full project tests**
+
+Run: `cd /home/eran/work/agentsh && go test ./... 2>&1 | tail -20`
+
+Expected: PASS for all packages. If any existing tests break, investigate — Plan 4 should not affect anything outside `internal/proxy/secrets/`.

--- a/docs/superpowers/specs/2026-04-09-plan-04-vault-provider-registry-design.md
+++ b/docs/superpowers/specs/2026-04-09-plan-04-vault-provider-registry-design.md
@@ -1,0 +1,396 @@
+# Plan 4: Vault Provider + Provider Registry — Design
+
+**Date:** 2026-04-09
+**Status:** Design (pre-implementation)
+**Owner:** Eran Sandler
+
+## Problem
+
+Plan 3 shipped the `SecretProvider` interface, URI parser, and keyring provider. The keyring provider is self-contained — it needs no credentials from another provider to bootstrap. The Vault provider is the first provider that needs auth credentials which may themselves come from another provider (e.g., the Vault token lives in the OS keyring). This creates a construction-ordering problem that requires a provider registry with dependency resolution.
+
+Plan 4 ships two things together:
+
+1. **Provider registry** — resolves auth-chaining dependencies via topological sort, constructs providers in the right order, and exposes them by name.
+2. **Vault provider** — fetches secrets from HashiCorp Vault (and OpenBao) KV v2 engine, using the official `hashicorp/vault/api` client library.
+
+## Goals
+
+- A `Registry` type in `internal/proxy/secrets/` that constructs providers in dependency order with cycle detection.
+- A Vault provider supporting token, AppRole, and Kubernetes auth methods.
+- Auth chaining: Vault's bootstrap credentials can reference another provider (e.g., `keyring://agentsh/vault_token`).
+- KV v2 secret reads with field extraction via URI fragment (`vault://kv/github#token`).
+- Zero call sites inside the daemon — wiring happens in Plan 10.
+
+## Non-goals
+
+- KV v1 support (v2 only in this plan).
+- Generic secret engine reads (only KV v2).
+- Vault dynamic secrets or lease renewal.
+- Session wiring, credsub.Table integration, or policy YAML parsing.
+- Deletion of dormant `pkg/secrets/` (happens after Plans 4-5 both land).
+- Integration tests against a real Vault server.
+
+## Parent spec reference
+
+`docs/superpowers/specs/2026-04-07-external-secrets-design.md`, Sections 2, 5, 7.
+
+---
+
+## Section 1 — Provider Registry
+
+### Location
+
+`internal/proxy/secrets/registry.go` (and `registry_test.go`).
+
+### Core types
+
+```go
+// RefResolver lets a provider constructor fetch a secret from an
+// already-constructed provider during auth chaining.
+type RefResolver func(ctx context.Context, ref SecretRef) (SecretValue, error)
+
+// ConstructorFunc builds a SecretProvider from its config. The
+// resolver can fetch secrets from providers that have already been
+// constructed (for auth chaining like vault's token_ref pointing
+// at keyring://...).
+type ConstructorFunc func(cfg ProviderConfig, resolver RefResolver) (SecretProvider, error)
+
+// Registry holds constructed providers keyed by their config name.
+type Registry struct {
+    providers map[string]SecretProvider
+}
+```
+
+### Dependencies() on ProviderConfig
+
+The `ProviderConfig` interface gains a new method:
+
+```go
+type ProviderConfig interface {
+    providerConfig()
+    Dependencies() []SecretRef
+}
+```
+
+`ProviderConfigMarker` gets a default implementation returning `nil`, so existing configs (`keyring.Config`) don't break without code changes.
+
+Each provider config implements `Dependencies()` by returning the `*_ref` fields it needs resolved before construction. For example, `vault.Config` with `TokenRef: keyring://agentsh/vault_token` returns `[]SecretRef{{Scheme: "keyring", Host: "agentsh", Path: "vault_token"}}`.
+
+### Construction flow
+
+`NewRegistry(ctx context.Context, configs map[string]ProviderConfig, constructors map[string]ConstructorFunc) (*Registry, error)`:
+
+1. **Validate** all configs have a matching constructor (keyed by provider type extracted from the config — each config knows its own type name).
+2. **Build dependency graph.** For each config, call `Dependencies()`. Each returned `SecretRef`'s scheme maps to the provider config that handles that scheme. Node = config name, edge = "this config depends on the provider handling scheme X."
+3. **Topological sort** (Kahn's algorithm). If cycle detected → return `ErrCyclicDependency` listing the cycle path.
+4. **Construct in order.** For each config in topological order:
+   - Build a `RefResolver` that dispatches to already-constructed providers by matching the ref's scheme to the provider that registered for it.
+   - Call the `ConstructorFunc` with the config and resolver.
+   - Store the resulting provider.
+5. **Cleanup on failure.** If any constructor fails, `Close()` every already-constructed provider, then return the error.
+
+### Registry API
+
+```go
+func NewRegistry(ctx context.Context, configs map[string]ProviderConfig, constructors map[string]ConstructorFunc) (*Registry, error)
+
+// Provider returns a named provider. Used by the future session-start
+// flow to fetch secrets for each service.
+func (r *Registry) Provider(name string) (SecretProvider, bool)
+
+// Fetch resolves a SecretRef by finding the provider that handles its
+// scheme and delegating to that provider's Fetch.
+func (r *Registry) Fetch(ctx context.Context, ref SecretRef) (SecretValue, error)
+
+// Close calls Close() on every provider. Safe to call multiple times.
+func (r *Registry) Close() error
+```
+
+### Scheme-to-provider mapping
+
+The registry needs to know which provider handles which URI scheme. Each `ProviderConfig` has a `TypeName() string` method that returns the provider type name, which doubles as the URI scheme it handles. For example, `vault.Config.TypeName()` returns `"vault"`, and the registry maps `vault://` URIs to that provider.
+
+The full revised `ProviderConfig` interface:
+
+```go
+type ProviderConfig interface {
+    providerConfig()
+    TypeName() string          // "keyring", "vault", etc.
+    Dependencies() []SecretRef
+}
+```
+
+`ProviderConfigMarker` provides a default `Dependencies()` returning `nil` (for providers with no auth chaining). It does NOT provide a default `TypeName()` — each config must implement it explicitly. This is a compile-time enforcement that every provider config declares its type.
+
+### Error sentinel
+
+New in `errors.go`:
+
+```go
+var ErrCyclicDependency = errors.New("secrets: cyclic provider dependency")
+```
+
+---
+
+## Section 2 — Vault Provider
+
+### Location
+
+`internal/proxy/secrets/vault/` — `doc.go`, `config.go`, `provider.go`, `provider_test.go`.
+
+### Config
+
+```go
+// Config configures the Vault provider.
+type Config struct {
+    secrets.ProviderConfigMarker
+
+    // Address is the Vault server address (e.g. "https://vault.corp.internal").
+    // Required.
+    Address string
+
+    // Namespace is the Vault enterprise namespace. Empty for open-source
+    // Vault and OpenBao.
+    Namespace string
+
+    // Auth configures how the provider authenticates to Vault.
+    Auth AuthConfig
+}
+
+// TypeName returns "vault".
+func (Config) TypeName() string { return "vault" }
+
+// Dependencies returns all *Ref fields that need resolution before
+// construction.
+func (c Config) Dependencies() []SecretRef {
+    var deps []SecretRef
+    if c.Auth.TokenRef != nil {
+        deps = append(deps, *c.Auth.TokenRef)
+    }
+    if c.Auth.RoleIDRef != nil {
+        deps = append(deps, *c.Auth.RoleIDRef)
+    }
+    if c.Auth.SecretIDRef != nil {
+        deps = append(deps, *c.Auth.SecretIDRef)
+    }
+    return deps
+}
+
+type AuthConfig struct {
+    // Method is the auth method: "token", "approle", or "kubernetes".
+    Method string
+
+    // Token auth. Exactly one of Token (literal) or TokenRef (chained)
+    // must be set when Method == "token".
+    Token    string
+    TokenRef *secrets.SecretRef
+
+    // AppRole auth. Each of RoleID/RoleIDRef and SecretID/SecretIDRef
+    // is a literal-or-ref pair. At least one form must be set per field
+    // when Method == "approle".
+    RoleID      string
+    RoleIDRef   *secrets.SecretRef
+    SecretID    string
+    SecretIDRef *secrets.SecretRef
+
+    // Kubernetes auth.
+    KubeRole      string // required when Method == "kubernetes"
+    KubeMountPath string // default "kubernetes"
+    KubeTokenPath string // default "/var/run/secrets/kubernetes.io/serviceaccount/token"
+}
+```
+
+### URI format
+
+**Deviation from parent spec:** The parent spec uses `vault://kv/data/github#token`. However, `vault/api`'s KV v2 helper (`client.KVv2(mount).Get(ctx, path)`) adds the `data/` prefix internally. To avoid double-prefixing, the Vault provider's URI format omits `data/`:
+
+| URI | Mount (Host) | Path | Field |
+|-----|--------------|------|-------|
+| `vault://kv/github#token` | `kv` | `github` | `token` |
+| `vault://secret/prod/api-key` | `secret` | `prod/api-key` | (auto if single-field) |
+| `vault://kv/db#password` | `kv` | `db` | `password` |
+
+If the user supplies a path starting with `data/`, the provider strips it with a warning log (common mistake when copying from the raw Vault HTTP API).
+
+### Provider construction
+
+`New(cfg Config, resolver secrets.RefResolver) (*Provider, error)`:
+
+**Note on ConstructorFunc:** The generic `ConstructorFunc` receives a `ProviderConfig` interface. The Vault constructor function registered with the registry type-asserts to `vault.Config`:
+
+```go
+func vaultConstructor(cfg secrets.ProviderConfig, resolver secrets.RefResolver) (secrets.SecretProvider, error) {
+    vc, ok := cfg.(vault.Config)
+    if !ok {
+        return nil, fmt.Errorf("expected vault.Config, got %T", cfg)
+    }
+    return vault.New(vc, resolver)
+}
+```
+
+1. **Validate config:**
+   - `Address` required.
+   - `Auth.Method` must be `"token"`, `"approle"`, or `"kubernetes"`.
+   - For token auth: exactly one of `Token` or `TokenRef` (not both, not neither).
+   - For approle auth: RoleID or RoleIDRef (not both), SecretID or SecretIDRef (not both).
+   - For kubernetes: `KubeRole` required.
+2. **Resolve chained refs** via `resolver`:
+   - If `TokenRef` is set, call `resolver(ctx, *TokenRef)` and use the value. Zero the SecretValue after extracting the string.
+   - Same for `RoleIDRef`, `SecretIDRef`.
+3. **Create `vault/api.Client`:**
+   - Set address, namespace, TLS from system defaults.
+   - Configure a reasonable timeout (30s default, matching the existing dormant code).
+4. **Authenticate:**
+   - **Token:** `client.SetToken(token)`.
+   - **AppRole:** `client.Auth().Login(ctx, approle.NewAppRoleAuth(roleID, &approle.SecretID{FromString: secretID}))`. Requires new dep: `github.com/hashicorp/vault/api/auth/approle`.
+   - **Kubernetes:** `client.Auth().Login(ctx, kubernetes.NewKubernetesAuth(role, kubernetes.WithServiceAccountTokenPath(path), kubernetes.WithMountPath(mount)))`. Already in `go.mod`.
+5. **Verify connectivity:** `client.Auth().Token().LookupSelf()`. If this fails → `ErrUnauthorized`.
+6. **Zero all resolved secret values.**
+
+### Fetch
+
+`Fetch(ctx context.Context, ref secrets.SecretRef) (secrets.SecretValue, error)`:
+
+1. Check closed flag (same pattern as keyring: `atomic.Bool` + `sync.RWMutex`).
+2. Validate: `ref.Scheme == "vault"`, `ref.Host` non-empty (KV v2 mount name), `ref.Path` non-empty (secret path).
+3. Read secret: `client.KVv2(ref.Host).Get(ctx, ref.Path)`.
+4. **Field extraction:**
+   - If `ref.Field` is set: look up that key in the KV data map. Missing field → `ErrNotFound`.
+   - If `ref.Field` is empty and data has exactly one field: return that field's value.
+   - If `ref.Field` is empty and data has zero or multiple fields: `ErrInvalidURI` with message listing available fields.
+5. Convert the value to `[]byte`. The Vault KV v2 helper returns `map[string]interface{}`; we `fmt.Sprintf("%s", val)` for string values, or `json.Marshal` for non-string values.
+6. Build and return `SecretValue`:
+   - `Value`: the extracted bytes.
+   - `TTL`: from the Vault secret's `LeaseDuration` if available.
+   - `LeaseID`: from the Vault secret's `LeaseID`.
+   - `Version`: from the KV v2 metadata version.
+   - `FetchedAt`: `time.Now()`.
+
+### Error mapping
+
+| Vault condition | Mapped error |
+|---|---|
+| 404 / secret not found | `ErrNotFound` |
+| 403 / permission denied | `ErrUnauthorized` |
+| Wrong scheme in ref | `ErrInvalidURI` |
+| Missing host or path in ref | `ErrInvalidURI` |
+| Field not found in KV data | `ErrNotFound` |
+| Ambiguous (no field, multiple keys) | `ErrInvalidURI` |
+| Network / timeout | Wrapped transport error |
+
+### Close
+
+1. If the provider authenticated via AppRole or Kubernetes (i.e., it created the token), call `client.Auth().Token().RevokeSelf()` best-effort. Token-auth tokens are not revoked (not ours).
+2. Set closed flag.
+3. Acquire write lock (wait for in-flight Fetches).
+4. Nil the client.
+
+### Concurrency
+
+Same pattern as keyring: `atomic.Bool` for closed flag, `sync.RWMutex` for Fetch/Close synchronization. Same test seam hooks for race testing.
+
+### OpenBao compatibility
+
+OpenBao is a Vault API fork. The `vault/api` client works with OpenBao by pointing `Address` at the OpenBao server. No code changes needed. Documented in the package doc.
+
+---
+
+## Section 3 — Testing Strategy
+
+### Vault provider tests (`vault/provider_test.go`)
+
+Uses `net/http/httptest.Server` with mock Vault HTTP handlers. No new test dependencies — mock the Vault API responses directly. The `vault/api.Client` is configured to talk to the httptest server.
+
+**Mock handler coverage:**
+- `/v1/auth/token/lookup-self` — returns token metadata (for connectivity check).
+- `/v1/auth/approle/login` — accepts role_id + secret_id, returns client_token.
+- `/v1/auth/kubernetes/login` — accepts role + jwt, returns client_token.
+- `/v1/{mount}/data/{path}` — KV v2 read, returns data + metadata.
+- `/v1/auth/token/revoke-self` — accepts POST, returns 204.
+
+**Test cases:**
+- Happy path: token auth, KV v2 read with field, verify value + version.
+- Field extraction: multi-field with `#field`, missing field, single-field auto-resolve, zero-field error.
+- AppRole auth: mock login, verify token is used for subsequent reads.
+- Kubernetes auth: mock login with JWT from temp file.
+- Auth chaining: `secretstest.MemoryProvider` as RefResolver source, verify Vault gets chained token.
+- Error mapping: 404 → `ErrNotFound`, 403 → `ErrUnauthorized`, wrong scheme → `ErrInvalidURI`.
+- Close: Fetch after Close fails. Close is idempotent. AppRole tokens revoked on Close.
+- Context cancellation: canceled ctx → immediate error.
+- Config validation: missing address, conflicting literal+ref, bad auth method.
+
+### Contract tests
+
+`secretstest.ProviderContract(t, "vault", provider, probeRef)` with `probeRef` pointing at a non-existent KV path.
+
+### Registry tests (`secrets/registry_test.go`)
+
+Uses `secretstest.MemoryProvider` for all tests (no Vault needed):
+- **Linear chain:** "keyring" → "vault" (memory provider simulating both). Construct in order. Verify resolver works.
+- **Cycle detection:** A depends on B depends on A → `ErrCyclicDependency`.
+- **Self-cycle:** A depends on itself → `ErrCyclicDependency`.
+- **Missing constructor:** Config references a type with no constructor → error.
+- **Constructor failure:** Second provider's constructor fails → first gets `Close()`d.
+- **No dependencies:** All providers independent → all construct (order irrelevant).
+- **Registry.Fetch dispatches correctly.**
+- **Registry.Close closes all providers.**
+
+---
+
+## Section 4 — File Layout
+
+### New files
+
+```
+internal/proxy/secrets/
+    registry.go              # Registry, NewRegistry, topo sort, RefResolver, ConstructorFunc
+    registry_test.go         # dependency resolution + lifecycle tests
+
+internal/proxy/secrets/vault/
+    doc.go                   # package doc (OpenBao note)
+    config.go                # Config, AuthConfig, TypeName, Dependencies, compile-time assertions
+    provider.go              # Provider, New, Fetch, Close
+    provider_test.go         # httptest mock + contract tests
+```
+
+### Modified files
+
+- `internal/proxy/secrets/provider.go` — add `TypeName() string` and `Dependencies() []SecretRef` to `ProviderConfig` interface. Add default `Dependencies()` to `ProviderConfigMarker`.
+- `internal/proxy/secrets/errors.go` — add `ErrCyclicDependency` sentinel.
+- `internal/proxy/secrets/keyring/config.go` — add `TypeName() string` returning `"keyring"`. (`Dependencies()` is inherited from the `ProviderConfigMarker` default.)
+- `go.mod` — add `github.com/hashicorp/vault/api/auth/approle`.
+- `go.sum` — regenerated.
+
+### NOT modified
+
+- `internal/session/`, `internal/api/`, `cmd/` — no session wiring.
+- `internal/proxy/credsub/` — no credsub.Table connection.
+- `pkg/secrets/` — dormant code untouched.
+
+### Scope boundary
+
+This plan produces a working Registry + Vault provider with zero call sites inside the daemon. Plan 10 wires the registry into session start.
+
+---
+
+## Section 5 — Dependency Hygiene
+
+### New direct dependency
+
+`github.com/hashicorp/vault/api/auth/approle` — needed for AppRole auth. This is a small module in the vault/api family, likely sharing most transitive deps with the already-present `vault/api` and `vault/api/auth/kubernetes`.
+
+### Inspection required
+
+The implementer must inspect the `go.sum` delta after `go mod tidy` and report any surprising transitive dependencies not already in the module graph.
+
+### OpenBao
+
+No `openbao` dependency needed. The `vault/api` client is wire-compatible with OpenBao's API.
+
+---
+
+## Open questions for the implementation plan
+
+1. **TypeName() vs constructor-map key:** The design adds `TypeName()` to `ProviderConfig` and also has constructors keyed by type name in the constructor map. These must match. The implementation plan should validate this at `NewRegistry` time.
+2. **Vault API version detection:** `client.KVv2()` assumes the mount is KV v2. If the mount is v1, the call fails. Should we attempt v2 first and fall back to v1, or just fail with a clear error? Decision: fail with a clear error — Plan 4 is KV v2 only.
+3. **Token self-revocation on Close:** If the process crashes, the token is not revoked. This is acceptable for v1 — the spec explicitly defers lease management.

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,8 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.4
 	github.com/aws/aws-sdk-go-v2/config v1.32.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.6
+	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.64.1
+	github.com/aws/aws-sdk-go-v2/service/ecs v1.73.2
 	github.com/aws/aws-sdk-go-v2/service/kms v1.49.4
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.5
@@ -28,6 +30,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/hanwen/go-fuse/v2 v2.9.0
 	github.com/hashicorp/vault/api v1.22.0
+	github.com/hashicorp/vault/api/auth/approle v0.12.0
 	github.com/hashicorp/vault/api/auth/kubernetes v0.10.0
 	github.com/miekg/dns v1.1.62
 	github.com/pquerna/otp v1.5.0
@@ -46,6 +49,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.40.0
 	go.opentelemetry.io/otel/sdk/log v0.16.0
 	go.opentelemetry.io/otel/trace v1.40.0
+	golang.org/x/net v0.49.0
 	golang.org/x/sys v0.40.0
 	golang.org/x/term v0.39.0
 	google.golang.org/grpc v1.78.0
@@ -74,8 +78,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
-	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.64.1 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ecs v1.73.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.4 // indirect
@@ -167,7 +169,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/mod v0.31.0 // indirect
-	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/text v0.33.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ github.com/hashicorp/hcl v1.0.1-vault-7 h1:ag5OxFVy3QYTFTJODRzTKVZ6xvdfLLCA1cy/Y
 github.com/hashicorp/hcl v1.0.1-vault-7/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/vault/api v1.22.0 h1:+HYFquE35/B74fHoIeXlZIP2YADVboaPjaSicHEZiH0=
 github.com/hashicorp/vault/api v1.22.0/go.mod h1:IUZA2cDvr4Ok3+NtK2Oq/r+lJeXkeCrHRmqdyWfpmGM=
+github.com/hashicorp/vault/api/auth/approle v0.12.0 h1:PhF7jrQjydK1DC05EboosXmZg31GDUIKL8bjyilsJ+E=
+github.com/hashicorp/vault/api/auth/approle v0.12.0/go.mod h1:J7BJLpXeQXhuMAWi31Puunu5QOeCoRAgLh2iDti7OLA=
 github.com/hashicorp/vault/api/auth/kubernetes v0.10.0 h1:5rqWmUFxnu3S7XYq9dafURwBgabYDFzo2Wv+AMopPHs=
 github.com/hashicorp/vault/api/auth/kubernetes v0.10.0/go.mod h1:cZZmhF6xboMDmDbMY52oj2DKW6gS0cQ9g0pJ5XIXQ5U=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/internal/proxy/secrets/doc.go
+++ b/internal/proxy/secrets/doc.go
@@ -1,14 +1,21 @@
 // Package secrets defines the SecretProvider interface that agentsh
 // uses to fetch real credentials from external secret stores at
-// session start, plus the URI grammar and sentinel errors shared by
-// all provider implementations.
+// session start, plus the URI grammar, sentinel errors, and the
+// provider Registry shared by all provider implementations.
+//
+// The Registry (registry.go) constructs providers in dependency
+// order via topological sort, enabling auth chaining where one
+// provider's bootstrap credentials come from another (e.g. Vault
+// reads its token from the OS keyring).
 //
 // Provider implementations live in subpackages, one per backend:
 //
 //   - internal/proxy/secrets/keyring — OS keyring (Keychain / Secret
 //     Service / Credential Manager) via github.com/zalando/go-keyring.
+//   - internal/proxy/secrets/vault — HashiCorp Vault / OpenBao KV v2
+//     via github.com/hashicorp/vault/api.
 //
-// Future plans add vault, awssm, gcpsm, azurekv, and op subpackages.
+// Future plans add awssm, gcpsm, azurekv, and op subpackages.
 // Every provider imports this package for the interface and types;
 // this package imports none of them.
 //
@@ -16,7 +23,7 @@
 // code must not import secretstest.
 //
 // The design is documented in
-// docs/superpowers/specs/2026-04-08-plan-03-secret-provider-keyring-design.md
+// docs/superpowers/specs/2026-04-09-plan-04-vault-provider-registry-design.md
 // and the parent migration spec
 // docs/superpowers/specs/2026-04-07-external-secrets-design.md.
 package secrets

--- a/internal/proxy/secrets/errors.go
+++ b/internal/proxy/secrets/errors.go
@@ -40,6 +40,7 @@ var ErrFieldNotSupported = errors.New("secrets: field not supported")
 var ErrKeyringUnavailable = errors.New("secrets: keyring unavailable")
 
 // ErrCyclicDependency is returned by NewRegistry when the provider
-// dependency graph contains a cycle (e.g. provider A depends on B,
-// B depends on A). The error message includes the cycle path.
+// dependency graph contains a cycle. The error message lists all
+// configs that could not be resolved (cycle members and their
+// downstream dependents).
 var ErrCyclicDependency = errors.New("secrets: cyclic provider dependency")

--- a/internal/proxy/secrets/errors.go
+++ b/internal/proxy/secrets/errors.go
@@ -38,3 +38,8 @@ var ErrFieldNotSupported = errors.New("secrets: field not supported")
 // error; the operator must either set up the keyring or use a
 // different provider.
 var ErrKeyringUnavailable = errors.New("secrets: keyring unavailable")
+
+// ErrCyclicDependency is returned by NewRegistry when the provider
+// dependency graph contains a cycle (e.g. provider A depends on B,
+// B depends on A). The error message includes the cycle path.
+var ErrCyclicDependency = errors.New("secrets: cyclic provider dependency")

--- a/internal/proxy/secrets/errors_test.go
+++ b/internal/proxy/secrets/errors_test.go
@@ -14,6 +14,7 @@ func TestSentinelErrors_AreDistinct(t *testing.T) {
 		ErrUnsupportedScheme,
 		ErrFieldNotSupported,
 		ErrKeyringUnavailable,
+		ErrCyclicDependency,
 	}
 	for i, a := range sentinels {
 		for j, b := range sentinels {
@@ -35,6 +36,7 @@ func TestSentinelErrors_AreWrappable(t *testing.T) {
 		"ErrUnsupportedScheme":  ErrUnsupportedScheme,
 		"ErrFieldNotSupported":  ErrFieldNotSupported,
 		"ErrKeyringUnavailable": ErrKeyringUnavailable,
+		"ErrCyclicDependency":   ErrCyclicDependency,
 	}
 	for name, sentinel := range sentinels {
 		wrapped := fmt.Errorf("%w: context detail", sentinel)
@@ -52,6 +54,7 @@ func TestSentinelErrors_MessagesStartWithPrefix(t *testing.T) {
 		ErrUnsupportedScheme,
 		ErrFieldNotSupported,
 		ErrKeyringUnavailable,
+		ErrCyclicDependency,
 	}
 	const prefix = "secrets:"
 	for _, s := range sentinels {

--- a/internal/proxy/secrets/keyring/config.go
+++ b/internal/proxy/secrets/keyring/config.go
@@ -18,6 +18,10 @@ type Config struct {
 	secrets.ProviderConfigMarker
 }
 
+// TypeName returns "keyring". Used by the registry to map
+// keyring:// URI scheme refs to this provider.
+func (Config) TypeName() string { return "keyring" }
+
 // Compile-time assertions. These fail to build if Provider or
 // Config ever drift away from the interfaces they're expected to
 // satisfy.

--- a/internal/proxy/secrets/provider.go
+++ b/internal/proxy/secrets/provider.go
@@ -112,9 +112,19 @@ func (sv *SecretValue) Zero() {
 }
 
 // ProviderConfig is the marker interface that every provider's
-// config struct must satisfy. The registry — to be added in a
-// later plan — type-switches on ProviderConfig to dispatch to the
-// right constructor at policy-load time.
+// config struct must satisfy. The registry type-switches on
+// ProviderConfig to dispatch to the right constructor at
+// policy-load time.
+//
+// TypeName returns the provider type name, which doubles as the
+// URI scheme this provider handles (e.g. "vault", "keyring").
+// Each config MUST implement TypeName explicitly — there is no
+// default on ProviderConfigMarker.
+//
+// Dependencies returns the SecretRefs that must be resolved from
+// other providers before this provider can be constructed (auth
+// chaining). Providers with no dependencies inherit the default
+// nil return from ProviderConfigMarker.
 //
 // Types outside package secrets satisfy ProviderConfig by
 // embedding ProviderConfigMarker. Embedding is required because
@@ -132,6 +142,8 @@ func (sv *SecretValue) Zero() {
 // about.
 type ProviderConfig interface {
 	providerConfig()
+	TypeName() string
+	Dependencies() []SecretRef
 }
 
 // ProviderConfigMarker is a zero-size struct that provider config
@@ -148,3 +160,9 @@ type ProviderConfig interface {
 type ProviderConfigMarker struct{}
 
 func (ProviderConfigMarker) providerConfig() {}
+
+// Dependencies returns nil. Providers with no auth chaining
+// inherit this default. Providers that need auth chaining (e.g.
+// Vault with a keyring-backed token) override this method on
+// their own Config type.
+func (ProviderConfigMarker) Dependencies() []SecretRef { return nil }

--- a/internal/proxy/secrets/provider_test.go
+++ b/internal/proxy/secrets/provider_test.go
@@ -62,4 +62,6 @@ type testConfig struct {
 	ProviderConfigMarker
 }
 
+func (testConfig) TypeName() string { return "test" }
+
 var _ ProviderConfig = testConfig{}

--- a/internal/proxy/secrets/registry.go
+++ b/internal/proxy/secrets/registry.go
@@ -1,0 +1,269 @@
+package secrets
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"sync"
+)
+
+// RefResolver lets a provider constructor fetch a secret from an
+// already-constructed provider during auth chaining.
+type RefResolver func(ctx context.Context, ref SecretRef) (SecretValue, error)
+
+// ConstructorFunc builds a SecretProvider from its config. The
+// resolver can fetch secrets from providers that have already been
+// constructed (for auth chaining like vault's token_ref pointing
+// at keyring://...).
+type ConstructorFunc func(ctx context.Context, cfg ProviderConfig, resolver RefResolver) (SecretProvider, error)
+
+// Registry holds constructed providers keyed by their config name.
+// It is constructed by NewRegistry, which resolves auth-chaining
+// dependencies via topological sort and builds providers in the
+// right order.
+type Registry struct {
+	mu sync.Mutex
+
+	// providers keyed by config name (e.g. "kr", "vault-prod").
+	providers map[string]SecretProvider
+
+	// order records construction order for deterministic reverse teardown.
+	order []string
+
+	// schemeToName maps URI scheme → config name for Fetch dispatch.
+	schemeToName map[string]string
+
+	closed bool
+}
+
+// NewRegistry constructs all providers in dependency order.
+//
+// configs maps config names to their ProviderConfig. constructors
+// maps provider type names (from TypeName()) to their constructor
+// functions. Every config's TypeName() must have a matching entry
+// in constructors.
+//
+// Dependencies are resolved via topological sort. Cyclic
+// dependencies return ErrCyclicDependency. If any constructor
+// fails, all already-constructed providers are closed before the
+// error is returned.
+func NewRegistry(ctx context.Context, configs map[string]ProviderConfig, constructors map[string]ConstructorFunc) (*Registry, error) {
+	// Validate inputs: no nil configs or constructors.
+	for name, cfg := range configs {
+		if cfg == nil || isNilInterface(cfg) {
+			return nil, fmt.Errorf("nil config for %q", name)
+		}
+	}
+	for typeName, ctor := range constructors {
+		if ctor == nil {
+			return nil, fmt.Errorf("nil constructor for type %q", typeName)
+		}
+	}
+
+	// Validate all configs have constructors and non-empty type names.
+	for name, cfg := range configs {
+		if cfg.TypeName() == "" {
+			return nil, fmt.Errorf("config %q has empty TypeName", name)
+		}
+		if _, ok := constructors[cfg.TypeName()]; !ok {
+			return nil, fmt.Errorf("no constructor registered for provider type %q (config %q)", cfg.TypeName(), name)
+		}
+	}
+
+	// Build scheme → config-name map and check for duplicate schemes.
+	schemeToName := make(map[string]string, len(configs))
+	for name, cfg := range configs {
+		scheme := cfg.TypeName()
+		if existing, dup := schemeToName[scheme]; dup {
+			return nil, fmt.Errorf("duplicate provider type %q: configs %q and %q", scheme, existing, name)
+		}
+		schemeToName[scheme] = name
+	}
+
+	// Build dependency graph: configName → list of configNames it depends on.
+	graph := make(map[string][]string, len(configs))
+	inDegree := make(map[string]int, len(configs))
+	for name := range configs {
+		graph[name] = nil
+		inDegree[name] = 0
+	}
+
+	for name, cfg := range configs {
+		for _, dep := range cfg.Dependencies() {
+			depName, ok := schemeToName[dep.Scheme]
+			if !ok {
+				return nil, fmt.Errorf("config %q depends on scheme %q, but no provider handles that scheme", name, dep.Scheme)
+			}
+			graph[depName] = append(graph[depName], name)
+			inDegree[name]++
+		}
+	}
+
+	// Kahn's algorithm for topological sort.
+	var queue []string
+	for name, deg := range inDegree {
+		if deg == 0 {
+			queue = append(queue, name)
+		}
+	}
+	// Sort the initial queue for deterministic ordering.
+	sort.Strings(queue)
+
+	var order []string
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		order = append(order, cur)
+
+		// Sort neighbors for deterministic ordering.
+		neighbors := graph[cur]
+		sort.Strings(neighbors)
+		for _, next := range neighbors {
+			inDegree[next]--
+			if inDegree[next] == 0 {
+				queue = append(queue, next)
+			}
+		}
+	}
+
+	if len(order) != len(configs) {
+		// Cycle detected. Kahn's algorithm leaves nodes with inDegree > 0
+		// for both cycle members and downstream dependents. We report all
+		// unresolvable configs without claiming which are cycle members.
+		var blocked []string
+		for name, deg := range inDegree {
+			if deg > 0 {
+				blocked = append(blocked, name)
+			}
+		}
+		sort.Strings(blocked)
+		return nil, fmt.Errorf("%w: unresolvable configs: %v", ErrCyclicDependency, blocked)
+	}
+
+	// Construct providers in topological order.
+	providers := make(map[string]SecretProvider, len(order))
+	for _, name := range order {
+		cfg := configs[name]
+		ctor := constructors[cfg.TypeName()]
+
+		// Build a scoped resolver that only allows resolving exact declared dependencies.
+		declaredRefs := make(map[string]bool, len(cfg.Dependencies()))
+		for _, dep := range cfg.Dependencies() {
+			declaredRefs[refKey(dep)] = true
+		}
+		resolver := func(fetchCtx context.Context, ref SecretRef) (SecretValue, error) {
+			if !declaredRefs[refKey(ref)] {
+				return SecretValue{}, fmt.Errorf("ref %s://%s/%s not declared in Dependencies() for config %q", ref.Scheme, ref.Host, ref.Path, name)
+			}
+			provName, ok := schemeToName[ref.Scheme]
+			if !ok {
+				return SecretValue{}, fmt.Errorf("no provider handles scheme %q", ref.Scheme)
+			}
+			p, ok := providers[provName]
+			if !ok {
+				return SecretValue{}, fmt.Errorf("provider %q not yet constructed (dependency ordering bug)", provName)
+			}
+			return p.Fetch(fetchCtx, ref)
+		}
+
+		p, err := ctor(ctx, cfg, resolver)
+		if err != nil {
+			// Cleanup already-constructed providers in reverse order.
+			for i := len(providers) - 1; i >= 0; i-- {
+				_ = providers[order[i]].Close()
+			}
+			return nil, fmt.Errorf("constructing provider %q (type %q): %w", name, cfg.TypeName(), err)
+		}
+		if p == nil || isNilInterface(p) {
+			// A constructor returning (nil, nil) or a typed-nil is a bug; fail loudly.
+			for i := len(providers) - 1; i >= 0; i-- {
+				_ = providers[order[i]].Close()
+			}
+			return nil, fmt.Errorf("constructor for provider %q (type %q) returned a nil provider", name, cfg.TypeName())
+		}
+		providers[name] = p
+	}
+
+	return &Registry{
+		providers:    providers,
+		order:        order,
+		schemeToName: schemeToName,
+	}, nil
+}
+
+// Provider returns a named provider, or false if the name is unknown
+// or the registry has been closed.
+func (r *Registry) Provider(name string) (SecretProvider, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return nil, false
+	}
+	p, ok := r.providers[name]
+	return p, ok
+}
+
+// Fetch resolves a SecretRef by finding the provider that handles
+// its scheme and delegating to that provider's Fetch.
+func (r *Registry) Fetch(ctx context.Context, ref SecretRef) (SecretValue, error) {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return SecretValue{}, fmt.Errorf("registry closed")
+	}
+	name, ok := r.schemeToName[ref.Scheme]
+	if !ok {
+		r.mu.Unlock()
+		return SecretValue{}, fmt.Errorf("no provider handles scheme %q", ref.Scheme)
+	}
+	p := r.providers[name]
+	r.mu.Unlock()
+	return p.Fetch(ctx, ref)
+}
+
+// Close calls Close() on every provider in reverse construction order.
+// Safe to call multiple times; subsequent calls are no-ops. The lock
+// is released before calling provider Close methods so that concurrent
+// Fetch calls observe the closed flag immediately rather than blocking
+// on a slow provider teardown.
+func (r *Registry) Close() error {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil
+	}
+	r.closed = true
+	// Snapshot what we need, then release the lock.
+	order := r.order
+	providers := r.providers
+	r.mu.Unlock()
+
+	var firstErr error
+	for i := len(order) - 1; i >= 0; i-- {
+		name := order[i]
+		if err := providers[name].Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// isNilInterface reports whether v is an interface holding a typed-nil
+// value (e.g. (*Provider)(nil) stored in a SecretProvider interface).
+// It handles all nilable kinds: ptr, map, slice, func, chan, interface.
+func isNilInterface(v interface{}) bool {
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan, reflect.Interface:
+		return rv.IsNil()
+	default:
+		return false
+	}
+}
+
+// refKey returns a canonical string for a SecretRef, used to match
+// exact declared dependencies in the scoped resolver.
+func refKey(ref SecretRef) string {
+	return ref.Scheme + "://" + ref.Host + "/" + ref.Path + "#" + ref.Field
+}

--- a/internal/proxy/secrets/registry_test.go
+++ b/internal/proxy/secrets/registry_test.go
@@ -1,0 +1,585 @@
+package secrets
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+)
+
+// testProviderConfig is a minimal ProviderConfig for registry tests.
+type testProviderConfig struct {
+	ProviderConfigMarker
+	typeName string
+	deps     []SecretRef
+}
+
+func (c testProviderConfig) TypeName() string          { return c.typeName }
+func (c testProviderConfig) Dependencies() []SecretRef { return c.deps }
+
+// testProvider is a minimal SecretProvider for registry tests.
+type testProvider struct {
+	name     string
+	closeCt  atomic.Int32
+	fetchErr error
+	fetchVal SecretValue
+}
+
+func (p *testProvider) Name() string { return p.name }
+func (p *testProvider) Fetch(_ context.Context, _ SecretRef) (SecretValue, error) {
+	if p.fetchErr != nil {
+		return SecretValue{}, p.fetchErr
+	}
+	cp := make([]byte, len(p.fetchVal.Value))
+	copy(cp, p.fetchVal.Value)
+	return SecretValue{Value: cp, FetchedAt: p.fetchVal.FetchedAt}, nil
+}
+func (p *testProvider) Close() error {
+	p.closeCt.Add(1)
+	return nil
+}
+
+func TestNewRegistry_NoDependencies(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, cfg ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: cfg.TypeName()}, nil
+		},
+	}
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.Close()
+
+	p, ok := reg.Provider("kr")
+	if !ok {
+		t.Fatal("Provider('kr') not found")
+	}
+	if p.Name() != "keyring" {
+		t.Errorf("Provider name = %q, want 'keyring'", p.Name())
+	}
+}
+
+func TestNewRegistry_LinearChain(t *testing.T) {
+	// vault depends on keyring via a token_ref
+	tokenRef := SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-token"}
+	configs := map[string]ProviderConfig{
+		"vault-prod": testProviderConfig{
+			typeName: "vault",
+			deps:     []SecretRef{tokenRef},
+		},
+		"kr": testProviderConfig{typeName: "keyring"},
+	}
+
+	var constructionOrder []string
+	var resolvedToken []byte
+
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, cfg ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			constructionOrder = append(constructionOrder, cfg.TypeName())
+			return &testProvider{
+				name:     "keyring",
+				fetchVal: SecretValue{Value: []byte("real-vault-token")},
+			}, nil
+		},
+		"vault": func(ctx context.Context, cfg ProviderConfig, resolver RefResolver) (SecretProvider, error) {
+			constructionOrder = append(constructionOrder, cfg.TypeName())
+			// Resolve the chained ref
+			sv, err := resolver(ctx, tokenRef)
+			if err != nil {
+				return nil, fmt.Errorf("resolving token: %w", err)
+			}
+			resolvedToken = sv.Value
+			return &testProvider{name: "vault"}, nil
+		},
+	}
+
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.Close()
+
+	// keyring must be constructed before vault
+	if len(constructionOrder) != 2 {
+		t.Fatalf("construction order length = %d, want 2", len(constructionOrder))
+	}
+	if constructionOrder[0] != "keyring" || constructionOrder[1] != "vault" {
+		t.Errorf("construction order = %v, want [keyring vault]", constructionOrder)
+	}
+	if string(resolvedToken) != "real-vault-token" {
+		t.Errorf("resolved token = %q, want 'real-vault-token'", resolvedToken)
+	}
+}
+
+func TestNewRegistry_CycleDetected(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"a": testProviderConfig{
+			typeName: "atype",
+			deps:     []SecretRef{{Scheme: "btype"}},
+		},
+		"b": testProviderConfig{
+			typeName: "btype",
+			deps:     []SecretRef{{Scheme: "atype"}},
+		},
+	}
+	constructors := map[string]ConstructorFunc{
+		"atype": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "a"}, nil
+		},
+		"btype": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "b"}, nil
+		},
+	}
+
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if err == nil {
+		t.Fatal("expected ErrCyclicDependency, got nil")
+	}
+	if !errors.Is(err, ErrCyclicDependency) {
+		t.Errorf("error = %v, want wrapping ErrCyclicDependency", err)
+	}
+}
+
+func TestNewRegistry_SelfCycle(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"a": testProviderConfig{
+			typeName: "atype",
+			deps:     []SecretRef{{Scheme: "atype"}},
+		},
+	}
+	constructors := map[string]ConstructorFunc{
+		"atype": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "a"}, nil
+		},
+	}
+
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if !errors.Is(err, ErrCyclicDependency) {
+		t.Errorf("self-cycle: error = %v, want wrapping ErrCyclicDependency", err)
+	}
+}
+
+func TestNewRegistry_MissingConstructor(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"v": testProviderConfig{typeName: "vault"},
+	}
+	constructors := map[string]ConstructorFunc{
+		// no "vault" constructor
+	}
+
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if err == nil {
+		t.Fatal("expected error for missing constructor, got nil")
+	}
+}
+
+func TestNewRegistry_ConstructorFailure_CleansUp(t *testing.T) {
+	var krProvider testProvider
+
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+		"v":  testProviderConfig{typeName: "vault", deps: []SecretRef{{Scheme: "keyring"}}},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			krProvider.name = "keyring"
+			return &krProvider, nil
+		},
+		"vault": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return nil, fmt.Errorf("vault init failed")
+		},
+	}
+
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// keyring must have been closed during cleanup
+	if krProvider.closeCt.Load() != 1 {
+		t.Errorf("keyring Close count = %d, want 1", krProvider.closeCt.Load())
+	}
+}
+
+func TestNewRegistry_UnresolvedDependency(t *testing.T) {
+	// vault depends on a scheme "op" that has no provider config
+	configs := map[string]ProviderConfig{
+		"v": testProviderConfig{typeName: "vault", deps: []SecretRef{{Scheme: "op"}}},
+	}
+	constructors := map[string]ConstructorFunc{
+		"vault": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "vault"}, nil
+		},
+	}
+
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if err == nil {
+		t.Fatal("expected error for unresolved dep, got nil")
+	}
+}
+
+func TestRegistry_Fetch_Dispatches(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{
+				name:     "keyring",
+				fetchVal: SecretValue{Value: []byte("secret-val")},
+			}, nil
+		},
+	}
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.Close()
+
+	ref := SecretRef{Scheme: "keyring", Host: "svc", Path: "user"}
+	sv, err := reg.Fetch(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if string(sv.Value) != "secret-val" {
+		t.Errorf("Fetch value = %q, want 'secret-val'", sv.Value)
+	}
+}
+
+func TestRegistry_Fetch_UnknownScheme(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "keyring"}, nil
+		},
+	}
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.Close()
+
+	ref := SecretRef{Scheme: "vault", Host: "kv", Path: "x"}
+	_, err = reg.Fetch(context.Background(), ref)
+	if err == nil {
+		t.Fatal("Fetch with unknown scheme should fail")
+	}
+}
+
+func TestRegistry_Close_ClosesAll(t *testing.T) {
+	var p1, p2 testProvider
+
+	configs := map[string]ProviderConfig{
+		"a": testProviderConfig{typeName: "atype"},
+		"b": testProviderConfig{typeName: "btype"},
+	}
+	constructors := map[string]ConstructorFunc{
+		"atype": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			p1.name = "a"
+			return &p1, nil
+		},
+		"btype": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			p2.name = "b"
+			return &p2, nil
+		},
+	}
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	if err := reg.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if p1.closeCt.Load() != 1 {
+		t.Errorf("p1 Close count = %d, want 1", p1.closeCt.Load())
+	}
+	if p2.closeCt.Load() != 1 {
+		t.Errorf("p2 Close count = %d, want 1", p2.closeCt.Load())
+	}
+}
+
+func TestRegistry_Close_Idempotent(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "keyring"}, nil
+		},
+	}
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	if err := reg.Close(); err != nil {
+		t.Errorf("first Close: %v", err)
+	}
+	if err := reg.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+}
+
+func TestNewRegistry_NilProvider_ReturnsError(t *testing.T) {
+	var krProvider testProvider
+
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+		"v":  testProviderConfig{typeName: "vault", deps: []SecretRef{{Scheme: "keyring"}}},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			krProvider.name = "keyring"
+			return &krProvider, nil
+		},
+		// Buggy constructor: returns (nil, nil).
+		"vault": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return nil, nil
+		},
+	}
+
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if err == nil {
+		t.Fatal("expected error for nil provider, got nil")
+	}
+	// The already-constructed keyring provider must have been cleaned up.
+	if krProvider.closeCt.Load() != 1 {
+		t.Errorf("keyring Close count = %d, want 1 (cleanup on nil provider)", krProvider.closeCt.Load())
+	}
+}
+
+func TestNewRegistry_DuplicateTypeName(t *testing.T) {
+	// Two configs sharing the same TypeName should be rejected.
+	configs := map[string]ProviderConfig{
+		"kr1": testProviderConfig{typeName: "keyring"},
+		"kr2": testProviderConfig{typeName: "keyring"},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "keyring"}, nil
+		},
+	}
+
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if err == nil {
+		t.Fatal("expected error for duplicate TypeName, got nil")
+	}
+}
+
+// orderTrackingProvider records its name into a shared slice on Close,
+// allowing tests to assert teardown order.
+type orderTrackingProvider struct {
+	name       string
+	closeOrder *[]string
+}
+
+func (p *orderTrackingProvider) Name() string { return p.name }
+func (p *orderTrackingProvider) Fetch(_ context.Context, _ SecretRef) (SecretValue, error) {
+	return SecretValue{}, nil
+}
+func (p *orderTrackingProvider) Close() error {
+	*p.closeOrder = append(*p.closeOrder, p.name)
+	return nil
+}
+
+func TestNewRegistry_TypedNilProvider_ReturnsError(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return (*testProvider)(nil), nil // typed-nil
+		},
+	}
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if err == nil {
+		t.Fatal("expected error for typed-nil provider, got nil")
+	}
+}
+
+func TestRegistry_Close_ReverseOrder(t *testing.T) {
+	var closeOrder []string
+	// keyring has no deps, vault depends on keyring.
+	// construction: keyring first, vault second.
+	// teardown should be: vault first, keyring second.
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+		"v":  testProviderConfig{typeName: "vault", deps: []SecretRef{{Scheme: "keyring"}}},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &orderTrackingProvider{name: "keyring", closeOrder: &closeOrder}, nil
+		},
+		"vault": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &orderTrackingProvider{name: "vault", closeOrder: &closeOrder}, nil
+		},
+	}
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	reg.Close()
+	// vault (dependent) should close before keyring (dependency)
+	if len(closeOrder) != 2 || closeOrder[0] != "vault" || closeOrder[1] != "keyring" {
+		t.Errorf("close order = %v, want [vault keyring]", closeOrder)
+	}
+}
+
+func TestRegistry_Provider_AfterClose(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "keyring"}, nil
+		},
+	}
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	reg.Close()
+
+	_, ok := reg.Provider("kr")
+	if ok {
+		t.Error("Provider() returned true after Close")
+	}
+}
+
+// mapProvider is a non-pointer typed-nil provider for testing the
+// broadened nil guard (covers map, slice, func, chan kinds).
+type mapProvider map[string]string
+
+func (mapProvider) Name() string                                              { return "map" }
+func (mapProvider) Fetch(_ context.Context, _ SecretRef) (SecretValue, error) { return SecretValue{}, nil }
+func (mapProvider) Close() error                                              { return nil }
+
+func TestNewRegistry_NonPointerTypedNilProvider_ReturnsError(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"m": testProviderConfig{typeName: "maptype"},
+	}
+	constructors := map[string]ConstructorFunc{
+		"maptype": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return (mapProvider)(nil), nil // non-pointer typed-nil
+		},
+	}
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if err == nil {
+		t.Fatal("expected error for non-pointer typed-nil provider, got nil")
+	}
+}
+
+func TestNewRegistry_NilConfig(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"kr": nil,
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "keyring"}, nil
+		},
+	}
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if err == nil {
+		t.Fatal("expected error for nil config, got nil")
+	}
+}
+
+func TestNewRegistry_NilConstructor(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": nil,
+	}
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if err == nil {
+		t.Fatal("expected error for nil constructor, got nil")
+	}
+}
+
+func TestNewRegistry_EmptyTypeName(t *testing.T) {
+	configs := map[string]ProviderConfig{
+		"bad": testProviderConfig{typeName: ""},
+	}
+	constructors := map[string]ConstructorFunc{
+		"": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{name: "bad"}, nil
+		},
+	}
+	_, err := NewRegistry(context.Background(), configs, constructors)
+	if err == nil {
+		t.Fatal("expected error for empty TypeName, got nil")
+	}
+}
+
+func TestNewRegistry_ResolverRejectsUndeclaredDependency(t *testing.T) {
+	// vault declares no dependencies but tries to resolve from keyring.
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+		"v":  testProviderConfig{typeName: "vault"}, // no deps declared
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{
+				name:     "keyring",
+				fetchVal: SecretValue{Value: []byte("token")},
+			}, nil
+		},
+		"vault": func(ctx context.Context, _ ProviderConfig, resolver RefResolver) (SecretProvider, error) {
+			// Try to resolve an undeclared dependency — should fail.
+			_, err := resolver(ctx, SecretRef{Scheme: "keyring", Host: "a", Path: "b"})
+			if err == nil {
+				return nil, fmt.Errorf("resolver should have rejected undeclared dependency")
+			}
+			return &testProvider{name: "vault"}, nil
+		},
+	}
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.Close()
+}
+
+func TestNewRegistry_ResolverRejectsSameSchemeWrongRef(t *testing.T) {
+	// vault declares keyring://agentsh/vault-token but tries to resolve
+	// keyring://agentsh/other-secret — same scheme, different ref.
+	declaredRef := SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-token"}
+	wrongRef := SecretRef{Scheme: "keyring", Host: "agentsh", Path: "other-secret"}
+
+	configs := map[string]ProviderConfig{
+		"kr": testProviderConfig{typeName: "keyring"},
+		"v":  testProviderConfig{typeName: "vault", deps: []SecretRef{declaredRef}},
+	}
+	constructors := map[string]ConstructorFunc{
+		"keyring": func(_ context.Context, _ ProviderConfig, _ RefResolver) (SecretProvider, error) {
+			return &testProvider{
+				name:     "keyring",
+				fetchVal: SecretValue{Value: []byte("token")},
+			}, nil
+		},
+		"vault": func(ctx context.Context, _ ProviderConfig, resolver RefResolver) (SecretProvider, error) {
+			// Resolving the declared ref should work.
+			_, err := resolver(ctx, declaredRef)
+			if err != nil {
+				return nil, fmt.Errorf("declared ref should resolve: %w", err)
+			}
+			// Resolving a different ref on the same scheme should fail.
+			_, err = resolver(ctx, wrongRef)
+			if err == nil {
+				return nil, fmt.Errorf("resolver should have rejected wrong ref on same scheme")
+			}
+			return &testProvider{name: "vault"}, nil
+		},
+	}
+	reg, err := NewRegistry(context.Background(), configs, constructors)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	defer reg.Close()
+}

--- a/internal/proxy/secrets/vault/config.go
+++ b/internal/proxy/secrets/vault/config.go
@@ -76,5 +76,5 @@ type AuthConfig struct {
 // Compile-time assertion that Config satisfies ProviderConfig.
 var _ secrets.ProviderConfig = Config{}
 
-// Note: The SecretProvider compile-time assertion for *Provider will be
-// added in Task 5 when Provider is defined.
+// Compile-time assertion that *Provider satisfies SecretProvider.
+var _ secrets.SecretProvider = (*Provider)(nil)

--- a/internal/proxy/secrets/vault/config.go
+++ b/internal/proxy/secrets/vault/config.go
@@ -1,0 +1,80 @@
+package vault
+
+import (
+	secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
+)
+
+// Config configures the Vault provider.
+type Config struct {
+	secrets.ProviderConfigMarker
+
+	// Address is the Vault server address (e.g. "https://vault.corp.internal").
+	// Required.
+	Address string
+
+	// Namespace is the Vault enterprise namespace. Empty for open-source
+	// Vault and OpenBao.
+	Namespace string
+
+	// Auth configures how the provider authenticates to Vault.
+	Auth AuthConfig
+}
+
+// TypeName returns "vault". Used by the registry to map vault://
+// URI scheme refs to this provider.
+func (Config) TypeName() string { return "vault" }
+
+// Dependencies returns the *Ref fields relevant to the configured
+// Auth.Method that need resolution from other providers before this
+// provider can be constructed. A ref is only included when the
+// corresponding literal field is empty — if both are set, the
+// constructor will reject the config during validation.
+func (c Config) Dependencies() []secrets.SecretRef {
+	var deps []secrets.SecretRef
+	switch c.Auth.Method {
+	case "token":
+		if c.Auth.TokenRef != nil && c.Auth.Token == "" {
+			deps = append(deps, *c.Auth.TokenRef)
+		}
+	case "approle":
+		if c.Auth.RoleIDRef != nil && c.Auth.RoleID == "" {
+			deps = append(deps, *c.Auth.RoleIDRef)
+		}
+		if c.Auth.SecretIDRef != nil && c.Auth.SecretID == "" {
+			deps = append(deps, *c.Auth.SecretIDRef)
+		}
+	case "kubernetes":
+		// No chained refs — uses service account token file.
+	}
+	return deps
+}
+
+// AuthConfig configures how the provider authenticates to Vault.
+type AuthConfig struct {
+	// Method is the auth method: "token", "approle", or "kubernetes".
+	Method string
+
+	// Token auth. Exactly one of Token (literal) or TokenRef (chained)
+	// must be set when Method == "token".
+	Token    string
+	TokenRef *secrets.SecretRef
+
+	// AppRole auth. Each of RoleID/RoleIDRef and SecretID/SecretIDRef
+	// is a literal-or-ref pair. Exactly one form per field must be set
+	// when Method == "approle".
+	RoleID      string
+	RoleIDRef   *secrets.SecretRef
+	SecretID    string
+	SecretIDRef *secrets.SecretRef
+
+	// Kubernetes auth.
+	KubeRole      string // required when Method == "kubernetes"
+	KubeMountPath string // default "kubernetes"
+	KubeTokenPath string // default "/var/run/secrets/kubernetes.io/serviceaccount/token"
+}
+
+// Compile-time assertion that Config satisfies ProviderConfig.
+var _ secrets.ProviderConfig = Config{}
+
+// Note: The SecretProvider compile-time assertion for *Provider will be
+// added in Task 5 when Provider is defined.

--- a/internal/proxy/secrets/vault/doc.go
+++ b/internal/proxy/secrets/vault/doc.go
@@ -10,9 +10,9 @@
 // the KV data map.
 //
 // The vault/api KV v2 helper adds the "data/" prefix internally.
-// If a URI path starts with "data/", the provider strips it and
-// logs a warning (common mistake when copying from the raw Vault
-// HTTP API).
+// If a URI path starts with "data/", the provider strips it for
+// compatibility with the parent spec format (e.g.
+// vault://kv/data/github → vault://kv/github).
 //
 // OpenBao is a wire-compatible Vault fork. This provider works
 // with OpenBao by pointing Address at the OpenBao server. No code

--- a/internal/proxy/secrets/vault/doc.go
+++ b/internal/proxy/secrets/vault/doc.go
@@ -1,0 +1,26 @@
+// Package vault implements secrets.SecretProvider using HashiCorp
+// Vault's KV v2 secrets engine. It wraps github.com/hashicorp/vault/api.
+//
+// Vault URIs take the form
+//
+//	vault://<mount>/<path>[#<field>]
+//
+// where <mount> is the KV v2 mount name, <path> is the secret path
+// within the mount, and the optional <field> selects one key from
+// the KV data map.
+//
+// The vault/api KV v2 helper adds the "data/" prefix internally.
+// If a URI path starts with "data/", the provider strips it and
+// logs a warning (common mistake when copying from the raw Vault
+// HTTP API).
+//
+// OpenBao is a wire-compatible Vault fork. This provider works
+// with OpenBao by pointing Address at the OpenBao server. No code
+// changes are needed.
+//
+// Supported auth methods: token, approle, kubernetes.
+//
+// Auth chaining is supported: bootstrap credentials (e.g. the
+// Vault token) can be fetched from another provider via the
+// RefResolver passed to New.
+package vault

--- a/internal/proxy/secrets/vault/provider.go
+++ b/internal/proxy/secrets/vault/provider.go
@@ -1,0 +1,415 @@
+package vault
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	vaultapi "github.com/hashicorp/vault/api"
+	approleauth "github.com/hashicorp/vault/api/auth/approle"
+	kubeauth "github.com/hashicorp/vault/api/auth/kubernetes"
+
+	secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
+)
+
+// Provider is a Vault-backed secrets.SecretProvider using KV v2.
+//
+// Provider is safe for concurrent Fetch and Close. Close waits for
+// any in-flight Fetch to finish before returning, so the contract
+// "after Close returns, Fetch returns an error" holds even under
+// concurrent access.
+//
+// Concurrency design mirrors keyring.Provider:
+//   - closed is an atomic flag checked lock-free on the Fetch fast
+//     path.
+//   - mu is an RWMutex held for read by Fetch for its entire duration
+//     (including the Vault HTTP call) and for write by Close. The
+//     write lock ensures Close waits for any in-flight Fetch to
+//     finish before returning.
+type Provider struct {
+	mu         sync.RWMutex
+	closed     atomic.Bool
+	client     *vaultapi.Client
+	ownedToken bool // true if we created the token via AppRole/K8s
+}
+
+// New constructs a Vault provider.
+//
+// Steps:
+//  1. Validate the config.
+//  2. Resolve any chained auth refs via resolver.
+//  3. Create the vault/api client.
+//  4. Authenticate.
+//  5. Verify connectivity via token lookup-self.
+//  6. Zero resolved secrets.
+func New(ctx context.Context, cfg Config, resolver secrets.RefResolver) (*Provider, error) {
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+
+	token, roleID, secretID, err := resolveAuthRefs(ctx, cfg.Auth, resolver)
+	if err != nil {
+		return nil, fmt.Errorf("vault: resolving auth refs: %w", err)
+	}
+
+	// Create vault/api client.
+	vaultCfg := vaultapi.DefaultConfig()
+	vaultCfg.Address = cfg.Address
+	vaultCfg.Timeout = 30 * time.Second
+
+	client, err := vaultapi.NewClient(vaultCfg)
+	if err != nil {
+		return nil, fmt.Errorf("vault: creating client: %w", err)
+	}
+	if cfg.Namespace != "" {
+		client.SetNamespace(cfg.Namespace)
+	}
+
+	// Authenticate.
+	var ownedToken bool
+	switch cfg.Auth.Method {
+	case "token":
+		client.SetToken(token)
+
+	case "approle":
+		appRoleAuth, authErr := approleauth.NewAppRoleAuth(roleID, &approleauth.SecretID{FromString: secretID})
+		if authErr != nil {
+			return nil, fmt.Errorf("vault: creating approle auth: %w", authErr)
+		}
+		authSecret, authErr := client.Auth().Login(ctx, appRoleAuth)
+		if authErr != nil {
+			return nil, fmt.Errorf("approle login: %w", mapVaultError(authErr))
+		}
+		if authSecret == nil || authSecret.Auth == nil {
+			return nil, fmt.Errorf("%w: approle login returned nil auth", secrets.ErrUnauthorized)
+		}
+		ownedToken = true
+
+	case "kubernetes":
+		mountPath := cfg.Auth.KubeMountPath
+		if mountPath == "" {
+			mountPath = "kubernetes"
+		}
+		tokenPath := cfg.Auth.KubeTokenPath
+		if tokenPath == "" {
+			// Default Kubernetes service account token path. This is a
+			// Linux-only path because Kubernetes auth is used exclusively
+			// inside Kubernetes pods (which run Linux). Callers on other
+			// platforms must set KubeTokenPath explicitly.
+			tokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+		}
+		kubeAuth, authErr := kubeauth.NewKubernetesAuth(
+			cfg.Auth.KubeRole,
+			kubeauth.WithServiceAccountTokenPath(tokenPath),
+			kubeauth.WithMountPath(mountPath),
+		)
+		if authErr != nil {
+			return nil, fmt.Errorf("vault: creating kubernetes auth: %w", authErr)
+		}
+		authSecret, authErr := client.Auth().Login(ctx, kubeAuth)
+		if authErr != nil {
+			return nil, fmt.Errorf("kubernetes login: %w", mapVaultError(authErr))
+		}
+		if authSecret == nil || authSecret.Auth == nil {
+			return nil, fmt.Errorf("%w: kubernetes login returned nil auth", secrets.ErrUnauthorized)
+		}
+		ownedToken = true
+
+	default:
+		return nil, fmt.Errorf("vault: unsupported auth method %q", cfg.Auth.Method)
+	}
+
+	// Verify connectivity. If this fails after AppRole/K8s login,
+	// revoke the freshly issued token to prevent leaks.
+	_, err = client.Auth().Token().LookupSelfWithContext(ctx)
+	if err != nil {
+		if ownedToken {
+			_ = client.Auth().Token().RevokeSelf("")
+		}
+		return nil, fmt.Errorf("token lookup-self: %w", mapVaultError(err))
+	}
+
+	// Clear resolved credential variables. Note: Go strings are immutable,
+	// so we cannot wipe their backing memory. We clear the variables to
+	// prevent accidental reuse; the SecretValue.Zero() calls in
+	// resolveAuthRefs handle the byte-level wiping of the resolver output.
+	token = ""
+	roleID = ""
+	secretID = ""
+
+	return &Provider{
+		client:     client,
+		ownedToken: ownedToken,
+	}, nil
+}
+
+// Name returns "vault". Used in audit events.
+func (p *Provider) Name() string { return "vault" }
+
+// Fetch retrieves a secret from Vault KV v2.
+//
+// The SecretRef must have:
+//   - Scheme == "vault"
+//   - Host    (the KV v2 mount name)
+//   - Path    (the secret path within the mount)
+//   - Field   (optional) selects one key from the data map
+//
+// If Field is empty and the data map has exactly one key, the single
+// value is auto-resolved. If Field is empty and the map has zero or
+// more than one key, ErrInvalidURI is returned.
+func (p *Provider) Fetch(ctx context.Context, ref secrets.SecretRef) (secrets.SecretValue, error) {
+	// Lock-free closed check first, so a closed provider always
+	// reports an error regardless of the caller's context state.
+	if p.closed.Load() {
+		return secrets.SecretValue{}, fmt.Errorf("vault: provider closed")
+	}
+
+	// Honor an already-canceled context before mutex acquisition.
+	if err := ctx.Err(); err != nil {
+		return secrets.SecretValue{}, err
+	}
+
+	// Validate ref fields before touching the client, so that
+	// zero-value providers (nil client) still report validation
+	// errors correctly.
+	if ref.Scheme != "vault" {
+		return secrets.SecretValue{}, fmt.Errorf("%w: wrong scheme %q", secrets.ErrInvalidURI, ref.Scheme)
+	}
+	if ref.Host == "" {
+		return secrets.SecretValue{}, fmt.Errorf("%w: vault URI missing mount (host)", secrets.ErrInvalidURI)
+	}
+	if ref.Path == "" {
+		return secrets.SecretValue{}, fmt.Errorf("%w: vault URI missing secret path", secrets.ErrInvalidURI)
+	}
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	// Re-check closed after acquiring RLock to close the TOCTOU gap.
+	if p.closed.Load() {
+		return secrets.SecretValue{}, fmt.Errorf("vault: provider closed")
+	}
+
+	// The KV v2 helper adds the "data/" prefix internally, so callers
+	// should pass the logical path (e.g. "github", not "data/github").
+	// However, the parent spec and existing ParseRef tests use the
+	// "data/" form, so we strip it for compatibility.
+	path := ref.Path
+	if strings.HasPrefix(path, "data/") {
+		path = strings.TrimPrefix(path, "data/")
+	}
+
+	kvSecret, err := p.client.KVv2(ref.Host).Get(ctx, path)
+	if err != nil {
+		return secrets.SecretValue{}, mapVaultError(err)
+	}
+
+	data := kvSecret.Data
+	if data == nil {
+		return secrets.SecretValue{}, fmt.Errorf("%w: vault returned nil data", secrets.ErrNotFound)
+	}
+
+	// Field extraction.
+	var rawVal interface{}
+	if ref.Field != "" {
+		val, ok := data[ref.Field]
+		if !ok {
+			return secrets.SecretValue{}, fmt.Errorf("%w: field %q not found in vault secret", secrets.ErrNotFound, ref.Field)
+		}
+		rawVal = val
+	} else {
+		switch len(data) {
+		case 0:
+			return secrets.SecretValue{}, fmt.Errorf("%w: vault secret has no fields and no field specified", secrets.ErrInvalidURI)
+		case 1:
+			for _, v := range data {
+				rawVal = v
+			}
+		default:
+			return secrets.SecretValue{}, fmt.Errorf("%w: vault secret has %d fields; specify #field in the URI", secrets.ErrInvalidURI, len(data))
+		}
+	}
+
+	// Build version string from metadata.
+	var version string
+	if kvSecret.VersionMetadata != nil {
+		version = strconv.Itoa(kvSecret.VersionMetadata.Version)
+	}
+
+	// Extract lease info from the raw secret if available.
+	var ttl time.Duration
+	var leaseID string
+	if kvSecret.Raw != nil {
+		if kvSecret.Raw.LeaseDuration > 0 {
+			ttl = time.Duration(kvSecret.Raw.LeaseDuration) * time.Second
+		}
+		leaseID = kvSecret.Raw.LeaseID
+	}
+
+	return secrets.SecretValue{
+		Value:     toBytes(rawVal),
+		TTL:       ttl,
+		LeaseID:   leaseID,
+		Version:   version,
+		FetchedAt: time.Now(),
+	}, nil
+}
+
+// Close marks the provider as closed and, if we own the token,
+// revokes it. Safe to call concurrently — all callers block until
+// shutdown completes, then subsequent calls are no-ops.
+func (p *Provider) Close() error {
+	// Set the closed flag so Fetch rejects new calls immediately.
+	p.closed.Store(true)
+
+	// Acquire write lock to wait for any in-flight Fetch to finish.
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Only do cleanup once (idempotent).
+	if p.client == nil {
+		return nil
+	}
+
+	var revokeErr error
+	if p.ownedToken {
+		revokeErr = p.client.Auth().Token().RevokeSelf("")
+		if revokeErr != nil {
+			revokeErr = fmt.Errorf("vault: revoking owned token: %w", revokeErr)
+		}
+	}
+	p.client = nil
+	return revokeErr
+}
+
+// validateConfig validates the Config at construction time.
+func validateConfig(cfg Config) error {
+	if cfg.Address == "" {
+		return fmt.Errorf("vault: address is required")
+	}
+	switch cfg.Auth.Method {
+	case "token":
+		if cfg.Auth.Token != "" && cfg.Auth.TokenRef != nil {
+			return fmt.Errorf("vault: token and token_ref are mutually exclusive")
+		}
+		if cfg.Auth.Token == "" && cfg.Auth.TokenRef == nil {
+			return fmt.Errorf("vault: token or token_ref is required for token auth")
+		}
+	case "approle":
+		if cfg.Auth.RoleID != "" && cfg.Auth.RoleIDRef != nil {
+			return fmt.Errorf("vault: role_id and role_id_ref are mutually exclusive")
+		}
+		if cfg.Auth.RoleID == "" && cfg.Auth.RoleIDRef == nil {
+			return fmt.Errorf("vault: role_id or role_id_ref is required for approle auth")
+		}
+		if cfg.Auth.SecretID != "" && cfg.Auth.SecretIDRef != nil {
+			return fmt.Errorf("vault: secret_id and secret_id_ref are mutually exclusive")
+		}
+		if cfg.Auth.SecretID == "" && cfg.Auth.SecretIDRef == nil {
+			return fmt.Errorf("vault: secret_id or secret_id_ref is required for approle auth")
+		}
+	case "kubernetes":
+		if cfg.Auth.KubeRole == "" {
+			return fmt.Errorf("vault: kube_role is required for kubernetes auth")
+		}
+	case "":
+		return fmt.Errorf("vault: auth method is required")
+	default:
+		return fmt.Errorf("vault: unsupported auth method %q", cfg.Auth.Method)
+	}
+	return nil
+}
+
+// resolveAuthRefs resolves any chained SecretRef fields in the auth
+// config via the provided resolver. Literal values are returned
+// as-is. Resolved values are zeroed after extraction.
+func resolveAuthRefs(ctx context.Context, auth AuthConfig, resolver secrets.RefResolver) (token, roleID, secretID string, err error) {
+	// Check if auth chaining is needed but no resolver was provided.
+	needsResolver := (auth.TokenRef != nil && auth.Token == "") ||
+		(auth.RoleIDRef != nil && auth.RoleID == "") ||
+		(auth.SecretIDRef != nil && auth.SecretID == "")
+	if needsResolver && resolver == nil {
+		return "", "", "", fmt.Errorf("vault: auth config uses chained refs but no resolver was provided")
+	}
+
+	switch auth.Method {
+	case "token":
+		if auth.Token != "" {
+			token = auth.Token
+		} else if auth.TokenRef != nil {
+			sv, resolveErr := resolver(ctx, *auth.TokenRef)
+			if resolveErr != nil {
+				return "", "", "", fmt.Errorf("resolving token ref: %w", resolveErr)
+			}
+			token = string(sv.Value)
+			sv.Zero()
+		}
+
+	case "approle":
+		if auth.RoleID != "" {
+			roleID = auth.RoleID
+		} else if auth.RoleIDRef != nil {
+			sv, resolveErr := resolver(ctx, *auth.RoleIDRef)
+			if resolveErr != nil {
+				return "", "", "", fmt.Errorf("resolving role_id ref: %w", resolveErr)
+			}
+			roleID = string(sv.Value)
+			sv.Zero()
+		}
+		if auth.SecretID != "" {
+			secretID = auth.SecretID
+		} else if auth.SecretIDRef != nil {
+			sv, resolveErr := resolver(ctx, *auth.SecretIDRef)
+			if resolveErr != nil {
+				return "", "", "", fmt.Errorf("resolving secret_id ref: %w", resolveErr)
+			}
+			secretID = string(sv.Value)
+			sv.Zero()
+		}
+
+	case "kubernetes":
+		// No chained refs; uses service account token file.
+	}
+	return token, roleID, secretID, nil
+}
+
+// mapVaultError translates a vault/api error to the appropriate
+// secrets sentinel error.
+func mapVaultError(err error) error {
+	// The KV v2 helper returns ErrSecretNotFound when the secret
+	// path does not exist (nil response from Logical().Read).
+	if errors.Is(err, vaultapi.ErrSecretNotFound) {
+		return fmt.Errorf("%w: %s", secrets.ErrNotFound, err.Error())
+	}
+
+	var respErr *vaultapi.ResponseError
+	if errors.As(err, &respErr) {
+		switch respErr.StatusCode {
+		case http.StatusNotFound:
+			return fmt.Errorf("%w: %s", secrets.ErrNotFound, respErr.Error())
+		case http.StatusForbidden:
+			return fmt.Errorf("%w: %s", secrets.ErrUnauthorized, respErr.Error())
+		}
+	}
+	return fmt.Errorf("vault: %w", err)
+}
+
+// toBytes converts a value to []byte. Strings are converted
+// directly; everything else is JSON-marshaled.
+func toBytes(v interface{}) []byte {
+	if s, ok := v.(string); ok {
+		return []byte(s)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return []byte(fmt.Sprintf("%v", v))
+	}
+	return b
+}

--- a/internal/proxy/secrets/vault/provider.go
+++ b/internal/proxy/secrets/vault/provider.go
@@ -85,7 +85,7 @@ func New(ctx context.Context, cfg Config, resolver secrets.RefResolver) (*Provid
 		}
 		authSecret, authErr := client.Auth().Login(ctx, appRoleAuth)
 		if authErr != nil {
-			return nil, fmt.Errorf("approle login: %w", mapVaultError(authErr))
+			return nil, fmt.Errorf("approle login: %w", mapAuthError(authErr))
 		}
 		if authSecret == nil || authSecret.Auth == nil {
 			return nil, fmt.Errorf("%w: approle login returned nil auth", secrets.ErrUnauthorized)
@@ -115,7 +115,7 @@ func New(ctx context.Context, cfg Config, resolver secrets.RefResolver) (*Provid
 		}
 		authSecret, authErr := client.Auth().Login(ctx, kubeAuth)
 		if authErr != nil {
-			return nil, fmt.Errorf("kubernetes login: %w", mapVaultError(authErr))
+			return nil, fmt.Errorf("kubernetes login: %w", mapAuthError(authErr))
 		}
 		if authSecret == nil || authSecret.Auth == nil {
 			return nil, fmt.Errorf("%w: kubernetes login returned nil auth", secrets.ErrUnauthorized)
@@ -133,7 +133,7 @@ func New(ctx context.Context, cfg Config, resolver secrets.RefResolver) (*Provid
 		if ownedToken {
 			_ = client.Auth().Token().RevokeSelf("")
 		}
-		return nil, fmt.Errorf("token lookup-self: %w", mapVaultError(err))
+		return nil, fmt.Errorf("token lookup-self: %w", mapAuthError(err))
 	}
 
 	// Clear resolved credential variables. Note: Go strings are immutable,
@@ -395,6 +395,20 @@ func mapVaultError(err error) error {
 		case http.StatusNotFound:
 			return fmt.Errorf("%w: %s", secrets.ErrNotFound, respErr.Error())
 		case http.StatusForbidden:
+			return fmt.Errorf("%w: %s", secrets.ErrUnauthorized, respErr.Error())
+		}
+	}
+	return fmt.Errorf("vault: %w", err)
+}
+
+// mapAuthError is like mapVaultError but also treats HTTP 400 as
+// ErrUnauthorized, since Vault auth endpoints return 400 for bad
+// credentials (e.g. invalid AppRole role_id/secret_id).
+func mapAuthError(err error) error {
+	var respErr *vaultapi.ResponseError
+	if errors.As(err, &respErr) {
+		switch respErr.StatusCode {
+		case http.StatusBadRequest, http.StatusForbidden:
 			return fmt.Errorf("%w: %s", secrets.ErrUnauthorized, respErr.Error())
 		}
 	}

--- a/internal/proxy/secrets/vault/provider_test.go
+++ b/internal/proxy/secrets/vault/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -444,6 +445,96 @@ func TestClose_Idempotent(t *testing.T) {
 	}
 	if err := p.Close(); err != nil {
 		t.Fatalf("second Close() error = %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auth error mapping tests (HTTP 400 → ErrUnauthorized)
+// ---------------------------------------------------------------------------
+
+func TestNew_TokenAuth_LookupSelf_400(t *testing.T) {
+	// Server returns 400 on lookup-self to simulate an invalid token.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/auth/token/lookup-self" {
+			writeVaultError(w, http.StatusBadRequest, "missing client token")
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth:    AuthConfig{Method: "token", Token: "bad-token"},
+	}
+	_, err := New(context.Background(), cfg, noopResolver)
+	if err == nil {
+		t.Fatal("expected error for 400 lookup-self")
+	}
+	if !errors.Is(err, secrets.ErrUnauthorized) {
+		t.Errorf("error = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestNew_AppRoleAuth_400(t *testing.T) {
+	// Server returns 400 on approle login (bad role_id/secret_id).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/auth/approle/login" {
+			writeVaultError(w, http.StatusBadRequest, "invalid role or secret ID")
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth: AuthConfig{
+			Method:   "approle",
+			RoleID:   "bad-role",
+			SecretID: "bad-secret",
+		},
+	}
+	_, err := New(context.Background(), cfg, noopResolver)
+	if err == nil {
+		t.Fatal("expected error for 400 approle login")
+	}
+	if !errors.Is(err, secrets.ErrUnauthorized) {
+		t.Errorf("error = %v, want ErrUnauthorized", err)
+	}
+}
+
+func TestNew_KubernetesAuth_400(t *testing.T) {
+	// Server returns 400 on kubernetes login (bad JWT).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/auth/kubernetes/login" {
+			writeVaultError(w, http.StatusBadRequest, "invalid JWT")
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	// Create a temp file for the service account token.
+	tokenFile := t.TempDir() + "/token"
+	if err := os.WriteFile(tokenFile, []byte("fake-jwt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth: AuthConfig{
+			Method:        "kubernetes",
+			KubeRole:      "my-role",
+			KubeTokenPath: tokenFile,
+		},
+	}
+	_, err := New(context.Background(), cfg, noopResolver)
+	if err == nil {
+		t.Fatal("expected error for 400 kubernetes login")
+	}
+	if !errors.Is(err, secrets.ErrUnauthorized) {
+		t.Errorf("error = %v, want ErrUnauthorized", err)
 	}
 }
 

--- a/internal/proxy/secrets/vault/provider_test.go
+++ b/internal/proxy/secrets/vault/provider_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -516,7 +517,7 @@ func TestNew_KubernetesAuth_400(t *testing.T) {
 	defer srv.Close()
 
 	// Create a temp file for the service account token.
-	tokenFile := t.TempDir() + "/token"
+	tokenFile := filepath.Join(t.TempDir(), "token")
 	if err := os.WriteFile(tokenFile, []byte("fake-jwt"), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/proxy/secrets/vault/provider_test.go
+++ b/internal/proxy/secrets/vault/provider_test.go
@@ -135,6 +135,11 @@ func mockVaultServer(t *testing.T, expectedToken string, kvData map[string]map[s
 
 		// AppRole login
 		case r.Method == http.MethodPut && r.URL.Path == "/v1/auth/approle/login":
+			var body map[string]string
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body["role_id"] == "" || body["secret_id"] == "" {
+				writeVaultError(w, http.StatusBadRequest, "missing role_id or secret_id")
+				return
+			}
 			writeJSON(w, http.StatusOK, map[string]interface{}{
 				"auth": map[string]interface{}{
 					"client_token": expectedToken,

--- a/internal/proxy/secrets/vault/provider_test.go
+++ b/internal/proxy/secrets/vault/provider_test.go
@@ -1,6 +1,13 @@
 package vault
 
 import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
@@ -91,4 +98,411 @@ func TestConfig_Dependencies_LiteralOverridesRef(t *testing.T) {
 	if deps := c.Dependencies(); len(deps) != 0 {
 		t.Errorf("Dependencies() = %v, want empty when literal is set", deps)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Mock Vault server
+// ---------------------------------------------------------------------------
+
+// mockVaultServer returns an httptest.Server that simulates a minimal
+// Vault HTTP API sufficient for the Provider tests.
+func mockVaultServer(t *testing.T, expectedToken string, kvData map[string]map[string]interface{}) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify token on all KV/lookup calls.
+		gotToken := r.Header.Get("X-Vault-Token")
+
+		switch {
+		// Token lookup-self
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/auth/token/lookup-self":
+			if gotToken != expectedToken {
+				writeVaultError(w, http.StatusForbidden, "permission denied")
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]interface{}{
+				"data": map[string]interface{}{
+					"id":       expectedToken,
+					"policies": []string{"default"},
+				},
+			})
+
+		// Token revoke-self
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/auth/token/revoke-self":
+			w.WriteHeader(http.StatusNoContent)
+
+		// AppRole login
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/auth/approle/login":
+			writeJSON(w, http.StatusOK, map[string]interface{}{
+				"auth": map[string]interface{}{
+					"client_token": expectedToken,
+					"policies":     []string{"default"},
+				},
+			})
+
+		// Kubernetes login
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/auth/kubernetes/login":
+			writeJSON(w, http.StatusOK, map[string]interface{}{
+				"auth": map[string]interface{}{
+					"client_token": expectedToken,
+					"policies":     []string{"default"},
+				},
+			})
+
+		// KV v2 read: /v1/{mount}/data/{path}
+		default:
+			if gotToken != expectedToken {
+				writeVaultError(w, http.StatusForbidden, "permission denied")
+				return
+			}
+			// Parse mount and path from the URL.
+			// URL pattern: /v1/{mount}/data/{path...}
+			parts := strings.SplitN(strings.TrimPrefix(r.URL.Path, "/v1/"), "/data/", 2)
+			if len(parts) != 2 {
+				writeVaultError(w, http.StatusNotFound, "no handler for route")
+				return
+			}
+			secretPath := parts[1]
+			secretData, ok := kvData[secretPath]
+			if !ok {
+				writeVaultError(w, http.StatusNotFound, "secret not found")
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]interface{}{
+				"data": map[string]interface{}{
+					"data": secretData,
+					"metadata": map[string]interface{}{
+						"version": 3,
+					},
+				},
+				"lease_duration": 0,
+				"lease_id":       "",
+			})
+		}
+	}))
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeVaultError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"errors": []string{msg},
+	})
+}
+
+// noopResolver is a RefResolver that always returns an error.
+// Used for configs with no chained refs.
+func noopResolver(_ context.Context, ref secrets.SecretRef) (secrets.SecretValue, error) {
+	return secrets.SecretValue{}, fmt.Errorf("noopResolver: unexpected resolve call for %s://%s/%s#%s",
+		ref.Scheme, ref.Host, ref.Path, ref.Field)
+}
+
+// ---------------------------------------------------------------------------
+// Provider constructor tests
+// ---------------------------------------------------------------------------
+
+func TestNew_TokenAuth_HappyPath(t *testing.T) {
+	srv := mockVaultServer(t, "test-token", nil)
+	defer srv.Close()
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth: AuthConfig{
+			Method: "token",
+			Token:  "test-token",
+		},
+	}
+
+	p, err := New(context.Background(), cfg, noopResolver)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer p.Close()
+
+	if p.Name() != "vault" {
+		t.Errorf("Name() = %q, want 'vault'", p.Name())
+	}
+	if p.ownedToken {
+		t.Error("ownedToken should be false for token auth")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fetch tests
+// ---------------------------------------------------------------------------
+
+func TestFetch_KVv2_WithField(t *testing.T) {
+	kvData := map[string]map[string]interface{}{
+		"github": {"token": "ghp_secret123", "user": "bot"},
+	}
+	srv := mockVaultServer(t, "test-token", kvData)
+	defer srv.Close()
+
+	p := newTestProvider(t, srv.URL, "test-token")
+	defer p.Close()
+
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: "github", Field: "token"}
+	sv, err := p.Fetch(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Fetch() error = %v", err)
+	}
+	defer sv.Zero()
+
+	if got := string(sv.Value); got != "ghp_secret123" {
+		t.Errorf("Fetch() value = %q, want 'ghp_secret123'", got)
+	}
+	if sv.Version != "3" {
+		t.Errorf("Fetch() version = %q, want '3'", sv.Version)
+	}
+	if sv.FetchedAt.IsZero() {
+		t.Error("Fetch() FetchedAt is zero")
+	}
+}
+
+func TestFetch_KVv2_SingleFieldAutoResolve(t *testing.T) {
+	kvData := map[string]map[string]interface{}{
+		"api-key": {"value": "sk-secret"},
+	}
+	srv := mockVaultServer(t, "test-token", kvData)
+	defer srv.Close()
+
+	p := newTestProvider(t, srv.URL, "test-token")
+	defer p.Close()
+
+	// No field specified; single field should auto-resolve.
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: "api-key"}
+	sv, err := p.Fetch(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Fetch() error = %v", err)
+	}
+	defer sv.Zero()
+
+	if got := string(sv.Value); got != "sk-secret" {
+		t.Errorf("Fetch() value = %q, want 'sk-secret'", got)
+	}
+}
+
+func TestFetch_KVv2_MultiFieldNoFragment_Error(t *testing.T) {
+	kvData := map[string]map[string]interface{}{
+		"multi": {"a": "1", "b": "2"},
+	}
+	srv := mockVaultServer(t, "test-token", kvData)
+	defer srv.Close()
+
+	p := newTestProvider(t, srv.URL, "test-token")
+	defer p.Close()
+
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: "multi"}
+	_, err := p.Fetch(context.Background(), ref)
+	if err == nil {
+		t.Fatal("Fetch() expected error for multi-field without #field")
+	}
+	if !errors.Is(err, secrets.ErrInvalidURI) {
+		t.Errorf("Fetch() error = %v, want ErrInvalidURI", err)
+	}
+}
+
+func TestFetch_KVv2_MissingField(t *testing.T) {
+	kvData := map[string]map[string]interface{}{
+		"github": {"token": "ghp_secret123"},
+	}
+	srv := mockVaultServer(t, "test-token", kvData)
+	defer srv.Close()
+
+	p := newTestProvider(t, srv.URL, "test-token")
+	defer p.Close()
+
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: "github", Field: "nonexistent"}
+	_, err := p.Fetch(context.Background(), ref)
+	if err == nil {
+		t.Fatal("Fetch() expected error for missing field")
+	}
+	if !errors.Is(err, secrets.ErrNotFound) {
+		t.Errorf("Fetch() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestFetch_SecretNotFound(t *testing.T) {
+	// No data in the server for this path.
+	srv := mockVaultServer(t, "test-token", nil)
+	defer srv.Close()
+
+	p := newTestProvider(t, srv.URL, "test-token")
+	defer p.Close()
+
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: "does-not-exist", Field: "key"}
+	_, err := p.Fetch(context.Background(), ref)
+	if err == nil {
+		t.Fatal("Fetch() expected error for missing secret")
+	}
+	if !errors.Is(err, secrets.ErrNotFound) {
+		t.Errorf("Fetch() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestFetch_DataPrefixStripped(t *testing.T) {
+	kvData := map[string]map[string]interface{}{
+		"github": {"token": "ghp_secret123"},
+	}
+	srv := mockVaultServer(t, "test-token", kvData)
+	defer srv.Close()
+
+	p := newTestProvider(t, srv.URL, "test-token")
+	defer p.Close()
+
+	// Path "data/github" should be stripped to "github" for the KV v2 call.
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: "data/github", Field: "token"}
+	sv, err := p.Fetch(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Fetch() with data/ prefix error = %v", err)
+	}
+	if got := string(sv.Value); got != "ghp_secret123" {
+		t.Errorf("Fetch() value = %q, want 'ghp_secret123'", got)
+	}
+}
+
+func TestFetch_WrongScheme(t *testing.T) {
+	p := &Provider{} // zero-value, no client needed
+	ref := secrets.SecretRef{Scheme: "keyring", Host: "svc", Path: "acct"}
+	_, err := p.Fetch(context.Background(), ref)
+	if err == nil {
+		t.Fatal("Fetch() expected error for wrong scheme")
+	}
+	if !errors.Is(err, secrets.ErrInvalidURI) {
+		t.Errorf("Fetch() error = %v, want ErrInvalidURI", err)
+	}
+}
+
+func TestFetch_MissingHost(t *testing.T) {
+	p := &Provider{} // zero-value, no client needed
+	ref := secrets.SecretRef{Scheme: "vault", Host: "", Path: "secret"}
+	_, err := p.Fetch(context.Background(), ref)
+	if err == nil {
+		t.Fatal("Fetch() expected error for missing host")
+	}
+	if !errors.Is(err, secrets.ErrInvalidURI) {
+		t.Errorf("Fetch() error = %v, want ErrInvalidURI", err)
+	}
+}
+
+func TestFetch_MissingPath(t *testing.T) {
+	p := &Provider{} // zero-value, no client needed
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: ""}
+	_, err := p.Fetch(context.Background(), ref)
+	if err == nil {
+		t.Fatal("Fetch() expected error for missing path")
+	}
+	if !errors.Is(err, secrets.ErrInvalidURI) {
+		t.Errorf("Fetch() error = %v, want ErrInvalidURI", err)
+	}
+}
+
+func TestFetch_ContextCanceled(t *testing.T) {
+	p := &Provider{} // zero-value; ctx check happens before client access
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: "secret"}
+	_, err := p.Fetch(ctx, ref)
+	if err == nil {
+		t.Fatal("Fetch() expected error for canceled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Fetch() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestFetch_AfterClose(t *testing.T) {
+	srv := mockVaultServer(t, "test-token", nil)
+	defer srv.Close()
+
+	p := newTestProvider(t, srv.URL, "test-token")
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	ref := secrets.SecretRef{Scheme: "vault", Host: "kv", Path: "secret", Field: "key"}
+	_, err := p.Fetch(context.Background(), ref)
+	if err == nil {
+		t.Fatal("Fetch() expected error after Close")
+	}
+}
+
+func TestClose_Idempotent(t *testing.T) {
+	srv := mockVaultServer(t, "test-token", nil)
+	defer srv.Close()
+
+	p := newTestProvider(t, srv.URL, "test-token")
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("first Close() error = %v", err)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatalf("second Close() error = %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Validation tests
+// ---------------------------------------------------------------------------
+
+func TestValidateConfig_MissingAddress(t *testing.T) {
+	cfg := Config{Auth: AuthConfig{Method: "token", Token: "t"}}
+	if err := validateConfig(cfg); err == nil {
+		t.Fatal("expected error for missing address")
+	}
+}
+
+func TestValidateConfig_MissingMethod(t *testing.T) {
+	cfg := Config{Address: "http://vault:8200"}
+	if err := validateConfig(cfg); err == nil {
+		t.Fatal("expected error for missing auth method")
+	}
+}
+
+func TestValidateConfig_TokenBothLiteralAndRef(t *testing.T) {
+	ref := secrets.SecretRef{Scheme: "keyring", Host: "svc", Path: "token"}
+	cfg := Config{
+		Address: "http://vault:8200",
+		Auth:    AuthConfig{Method: "token", Token: "lit", TokenRef: &ref},
+	}
+	if err := validateConfig(cfg); err == nil {
+		t.Fatal("expected error for both token and token_ref")
+	}
+}
+
+func TestValidateConfig_TokenNeitherLiteralNorRef(t *testing.T) {
+	cfg := Config{
+		Address: "http://vault:8200",
+		Auth:    AuthConfig{Method: "token"},
+	}
+	if err := validateConfig(cfg); err == nil {
+		t.Fatal("expected error for missing token and token_ref")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// newTestProvider creates a Provider connected to the mock server.
+func newTestProvider(t *testing.T, addr, token string) *Provider {
+	t.Helper()
+	cfg := Config{
+		Address: addr,
+		Auth: AuthConfig{
+			Method: "token",
+			Token:  token,
+		},
+	}
+	p, err := New(context.Background(), cfg, noopResolver)
+	if err != nil {
+		t.Fatalf("newTestProvider: New() error = %v", err)
+	}
+	return p
 }

--- a/internal/proxy/secrets/vault/provider_test.go
+++ b/internal/proxy/secrets/vault/provider_test.go
@@ -1,0 +1,94 @@
+package vault
+
+import (
+	"testing"
+
+	secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
+)
+
+func TestConfig_TypeName(t *testing.T) {
+	c := Config{}
+	if got := c.TypeName(); got != "vault" {
+		t.Errorf("TypeName() = %q, want 'vault'", got)
+	}
+}
+
+func TestConfig_Dependencies_TokenLiteral(t *testing.T) {
+	c := Config{Auth: AuthConfig{Method: "token", Token: "literal"}}
+	if deps := c.Dependencies(); len(deps) != 0 {
+		t.Errorf("Dependencies() = %v, want empty", deps)
+	}
+}
+
+func TestConfig_Dependencies_TokenRef(t *testing.T) {
+	tokenRef := secrets.SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-token"}
+	c := Config{Auth: AuthConfig{Method: "token", TokenRef: &tokenRef}}
+	deps := c.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("Dependencies() length = %d, want 1", len(deps))
+	}
+	if deps[0].Scheme != tokenRef.Scheme || deps[0].Host != tokenRef.Host || deps[0].Path != tokenRef.Path {
+		t.Errorf("Dependencies()[0] = {%s, %s, %s}, want {%s, %s, %s}",
+			deps[0].Scheme, deps[0].Host, deps[0].Path,
+			tokenRef.Scheme, tokenRef.Host, tokenRef.Path)
+	}
+}
+
+func TestConfig_Dependencies_AppRole(t *testing.T) {
+	roleRef := secrets.SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-role"}
+	secretRef := secrets.SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-secret"}
+
+	c := Config{
+		Auth: AuthConfig{
+			Method:      "approle",
+			RoleIDRef:   &roleRef,
+			SecretIDRef: &secretRef,
+		},
+	}
+	deps := c.Dependencies()
+	if len(deps) != 2 {
+		t.Fatalf("Dependencies() length = %d, want 2", len(deps))
+	}
+}
+
+func TestConfig_Dependencies_AppRoleIgnoresTokenRef(t *testing.T) {
+	// TokenRef should be ignored for approle method.
+	tokenRef := secrets.SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-token"}
+	roleRef := secrets.SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-role"}
+
+	c := Config{
+		Auth: AuthConfig{
+			Method:    "approle",
+			RoleIDRef: &roleRef,
+			TokenRef:  &tokenRef, // irrelevant for approle
+		},
+	}
+	deps := c.Dependencies()
+	if len(deps) != 1 {
+		t.Fatalf("Dependencies() length = %d, want 1 (only RoleIDRef)", len(deps))
+	}
+}
+
+func TestConfig_Dependencies_Kubernetes(t *testing.T) {
+	// Kubernetes uses a service account token file, no chained refs.
+	c := Config{Auth: AuthConfig{Method: "kubernetes", KubeRole: "my-role"}}
+	if deps := c.Dependencies(); len(deps) != 0 {
+		t.Errorf("Dependencies() = %v, want empty", deps)
+	}
+}
+
+func TestConfig_Dependencies_LiteralOverridesRef(t *testing.T) {
+	// When both literal and ref are set, the ref is not declared as a
+	// dependency. The constructor will reject the config later.
+	tokenRef := secrets.SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-token"}
+	c := Config{
+		Auth: AuthConfig{
+			Method:   "token",
+			Token:    "literal-value",
+			TokenRef: &tokenRef,
+		},
+	}
+	if deps := c.Dependencies(); len(deps) != 0 {
+		t.Errorf("Dependencies() = %v, want empty when literal is set", deps)
+	}
+}

--- a/internal/proxy/secrets/vault/provider_test.go
+++ b/internal/proxy/secrets/vault/provider_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
+	secretstest "github.com/agentsh/agentsh/internal/proxy/secrets/secretstest"
 )
 
 func TestConfig_TypeName(t *testing.T) {
@@ -231,6 +232,89 @@ func TestNew_TokenAuth_HappyPath(t *testing.T) {
 	}
 	if p.ownedToken {
 		t.Error("ownedToken should be false for token auth")
+	}
+}
+
+func TestNew_AuthChaining_TokenFromResolver(t *testing.T) {
+	const testToken = "hvs.chained-token-67890"
+	srv := mockVaultServer(t, testToken, nil)
+	defer srv.Close()
+
+	tokenRef := secrets.SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-token"}
+	memProvider := secretstest.NewMemoryProvider("keyring", map[string][]byte{
+		"keyring://agentsh/vault-token": []byte(testToken),
+	})
+	resolver := func(ctx context.Context, ref secrets.SecretRef) (secrets.SecretValue, error) {
+		return memProvider.Fetch(ctx, ref)
+	}
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth: AuthConfig{
+			Method:   "token",
+			TokenRef: &tokenRef,
+		},
+	}
+	p, err := New(context.Background(), cfg, resolver)
+	if err != nil {
+		t.Fatalf("New with chained token: %v", err)
+	}
+	defer p.Close()
+}
+
+func TestNew_AppRoleAuth(t *testing.T) {
+	const testToken = "hvs.approle-token"
+	srv := mockVaultServer(t, testToken, nil)
+	defer srv.Close()
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth: AuthConfig{
+			Method:   "approle",
+			RoleID:   "my-role-id",
+			SecretID: "my-secret-id",
+		},
+	}
+	p, err := New(context.Background(), cfg, noopResolver)
+	if err != nil {
+		t.Fatalf("New with approle: %v", err)
+	}
+	defer p.Close()
+	if !p.ownedToken {
+		t.Error("ownedToken should be true for approle auth")
+	}
+}
+
+func TestNew_AppRoleAuth_ChainedRefs(t *testing.T) {
+	const testToken = "hvs.approle-chained"
+	srv := mockVaultServer(t, testToken, nil)
+	defer srv.Close()
+
+	roleRef := secrets.SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-role"}
+	secretRef := secrets.SecretRef{Scheme: "keyring", Host: "agentsh", Path: "vault-secret"}
+	memProvider := secretstest.NewMemoryProvider("keyring", map[string][]byte{
+		"keyring://agentsh/vault-role":   []byte("my-role-id"),
+		"keyring://agentsh/vault-secret": []byte("my-secret-id"),
+	})
+	resolver := func(ctx context.Context, ref secrets.SecretRef) (secrets.SecretValue, error) {
+		return memProvider.Fetch(ctx, ref)
+	}
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth: AuthConfig{
+			Method:      "approle",
+			RoleIDRef:   &roleRef,
+			SecretIDRef: &secretRef,
+		},
+	}
+	p, err := New(context.Background(), cfg, resolver)
+	if err != nil {
+		t.Fatalf("New with chained approle: %v", err)
+	}
+	defer p.Close()
+	if !p.ownedToken {
+		t.Error("ownedToken should be true for approle auth")
 	}
 }
 
@@ -576,6 +660,94 @@ func TestValidateConfig_TokenNeitherLiteralNorRef(t *testing.T) {
 	if err := validateConfig(cfg); err == nil {
 		t.Fatal("expected error for missing token and token_ref")
 	}
+}
+
+func TestNew_MissingAddress(t *testing.T) {
+	cfg := Config{Auth: AuthConfig{Method: "token", Token: "x"}}
+	_, err := New(context.Background(), cfg, noopResolver)
+	if err == nil {
+		t.Fatal("expected error for missing address")
+	}
+}
+
+func TestNew_BadAuthMethod(t *testing.T) {
+	cfg := Config{Address: "http://localhost", Auth: AuthConfig{Method: "ldap"}}
+	_, err := New(context.Background(), cfg, noopResolver)
+	if err == nil {
+		t.Fatal("expected error for bad auth method")
+	}
+}
+
+func TestNew_TokenAuth_BothLiteralAndRef(t *testing.T) {
+	ref := secrets.SecretRef{Scheme: "keyring", Host: "a", Path: "b"}
+	cfg := Config{
+		Address: "http://localhost",
+		Auth:    AuthConfig{Method: "token", Token: "x", TokenRef: &ref},
+	}
+	_, err := New(context.Background(), cfg, noopResolver)
+	if err == nil {
+		t.Fatal("expected error for both Token and TokenRef")
+	}
+}
+
+func TestNew_TokenAuth_NeitherLiteralNorRef(t *testing.T) {
+	cfg := Config{
+		Address: "http://localhost",
+		Auth:    AuthConfig{Method: "token"},
+	}
+	_, err := New(context.Background(), cfg, noopResolver)
+	if err == nil {
+		t.Fatal("expected error for neither Token nor TokenRef")
+	}
+}
+
+func TestNew_AppRole_MissingSecretID(t *testing.T) {
+	cfg := Config{
+		Address: "http://localhost",
+		Auth:    AuthConfig{Method: "approle", RoleID: "x"},
+	}
+	_, err := New(context.Background(), cfg, noopResolver)
+	if err == nil {
+		t.Fatal("expected error for missing SecretID")
+	}
+}
+
+func TestNew_Kubernetes_MissingRole(t *testing.T) {
+	cfg := Config{
+		Address: "http://localhost",
+		Auth:    AuthConfig{Method: "kubernetes"},
+	}
+	_, err := New(context.Background(), cfg, noopResolver)
+	if err == nil {
+		t.Fatal("expected error for missing KubeRole")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Contract test
+// ---------------------------------------------------------------------------
+
+func TestProviderContract_AppliedToVaultProvider(t *testing.T) {
+	const testToken = "hvs.contract-test-token"
+	srv := mockVaultServer(t, testToken, nil)
+	defer srv.Close()
+
+	cfg := Config{
+		Address: srv.URL,
+		Auth:    AuthConfig{Method: "token", Token: testToken},
+	}
+	p, err := New(context.Background(), cfg, noopResolver)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	probeRef := secrets.SecretRef{
+		Scheme: "vault",
+		Host:   "kv",
+		Path:   "definitely-does-not-exist-contract-probe",
+		Field:  "x",
+	}
+	secretstest.ProviderContract(t, "vault", p, probeRef)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Provider Registry** (`registry.go`): Constructs providers in dependency order via Kahn's topological sort, enabling auth chaining where one provider's bootstrap credentials come from another (e.g. Vault reads its token from the OS keyring). Scoped resolver enforces exact declared-dependency matching. Reverse-order teardown on Close and constructor failure.

- **Vault KV v2 Provider** (`vault/`): Full `SecretProvider` implementation supporting token, AppRole, and Kubernetes auth methods. Field extraction with single-field auto-resolve. Auth chaining via `RefResolver`. Token leak prevention (revokes owned tokens on connectivity failure). Concurrency-safe with atomic closed flag + RWMutex.

- **Interface additions**: `ProviderConfig` gains `TypeName()` and `Dependencies()` methods. New `ErrCyclicDependency` sentinel. `ConstructorFunc` and `RefResolver` types for the registry.

## Key design decisions

- Auth error mapping: `mapAuthError` treats HTTP 400 as `ErrUnauthorized` (Vault auth endpoints return 400 for bad credentials)
- `data/` prefix stripping for compatibility with existing URI format (`vault://kv/data/github` → `vault://kv/github`)
- OpenBao compatible — wire-compatible Vault fork, no code changes needed
- Typed-nil detection via `reflect` covers all nilable kinds (Ptr, Map, Slice, Func, Chan, Interface)

## Test plan

- [x] Registry: 27+ tests — topo sort, cycle detection, self-cycle, missing constructor, constructor failure cleanup, nil/typed-nil provider, duplicate TypeName, scoped resolver, reverse-order teardown
- [x] Vault provider: 36+ tests — all auth methods (token/approle/k8s), auth chaining via MemoryProvider, KV v2 field extraction, error mapping (400/403/404), config validation, contract test via `secretstest.ProviderContract`
- [x] `go test ./...` — full project suite green
- [x] `GOOS=windows go build ./...` — cross-compilation verified
- [x] Roborev reviews passed clean on all commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)