### PR TITLE
feat: env var injection + per-service scrub toggle (Plan 7)

### DIFF
--- a/docs/superpowers/plans/2026-04-09-plan-07-env-injection-scrub-toggle.md
+++ b/docs/superpowers/plans/2026-04-09-plan-07-env-injection-scrub-toggle.md
@@ -1,0 +1,1090 @@
+# Plan 7: Env Var Injection & Per-Service Scrub Toggle
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire service fake credentials into the spawned agent's environment via `inject.env`, with collision detection against `env_inject`, and make response scrubbing conditional per service via `scrub_response`.
+
+**Architecture:** Extend the resolver to extract `inject.env` and `scrub_response` from policy YAML, build a service env var map from the credsub.Table after bootstrap, store the map on the Session, and inject into the spawned process env (bypassing policy filtering since vars like `GITHUB_TOKEN` are in the default-deny list). Make `CredsSubHook.PostHook` conditional on the service's `scrub_response` flag.
+
+**Tech Stack:** Go 1.24, internal packages (`session`, `proxy`, `policy`, `api`)
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|----------------|
+| `internal/session/secretsconfig.go` | Add `ServiceEnvVar`, `ScrubServices` to resolver output |
+| `internal/session/secretsconfig_test.go` | Tests for resolver changes |
+| `internal/session/secrets.go` | New `BuildServiceEnvVars` function |
+| `internal/session/secrets_test.go` | Tests for env var builder |
+| `internal/session/envcheck.go` | New `CheckEnvCollisions` function |
+| `internal/session/envcheck_test.go` | Tests for collision detection |
+| `internal/session/manager.go` | Add `serviceEnvVars` field + setter/getter |
+| `internal/session/llmproxy.go` | Wire env vars + scrub config through `StartLLMProxy` |
+| `internal/session/llmproxy_test.go` | Tests for session wiring |
+| `internal/policy/secrets.go` | Validate `inject.env` names in `ValidateSecrets` |
+| `internal/policy/secrets_test.go` | Tests for validation |
+| `internal/proxy/credshook.go` | Make `CredsSubHook` per-service scrub-aware |
+| `internal/proxy/credshook_test.go` | Tests for scrub toggle |
+| `internal/api/exec.go` | Inject service env vars into spawned process |
+| `internal/session/secrets_integration_test.go` | End-to-end integration test |
+
+---
+
+### Task 1: Extend Resolver to Extract inject.env and scrub_response
+
+**Files:**
+- Modify: `internal/session/secretsconfig.go:22-27` (ResolvedServices struct)
+- Modify: `internal/session/secretsconfig.go:49-80` (ResolveServiceConfigs function)
+- Modify: `internal/session/secretsconfig_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Add two tests to `internal/session/secretsconfig_test.go`:
+
+```go
+func TestResolveServiceConfigs_InjectEnv(t *testing.T) {
+	svcs := []policy.ServiceYAML{
+		{
+			Name:   "github",
+			Match:  policy.ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret: policy.ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:   policy.ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: policy.ServiceInjectYAML{
+				Env: []policy.ServiceInjectEnvYAML{{Name: "GITHUB_TOKEN"}},
+			},
+		},
+	}
+	result, err := ResolveServiceConfigs(svcs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.EnvVars) != 1 {
+		t.Fatalf("expected 1 env var, got %d", len(result.EnvVars))
+	}
+	if result.EnvVars[0].ServiceName != "github" {
+		t.Errorf("ServiceName = %q, want github", result.EnvVars[0].ServiceName)
+	}
+	if result.EnvVars[0].VarName != "GITHUB_TOKEN" {
+		t.Errorf("VarName = %q, want GITHUB_TOKEN", result.EnvVars[0].VarName)
+	}
+}
+
+func TestResolveServiceConfigs_ScrubResponse(t *testing.T) {
+	svcs := []policy.ServiceYAML{
+		{
+			Name:          "github",
+			Match:         policy.ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret:        policy.ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:          policy.ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			ScrubResponse: true,
+		},
+		{
+			Name:   "stripe",
+			Match:  policy.ServiceMatchYAML{Hosts: []string{"api.stripe.com"}},
+			Secret: policy.ServiceSecretYAML{Ref: "keyring://agentsh/stripe"},
+			Fake:   policy.ServiceFakeYAML{Format: "xk_test_{rand:24}"},
+		},
+	}
+	result, err := ResolveServiceConfigs(svcs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.ScrubServices["github"] {
+		t.Error("expected github in ScrubServices")
+	}
+	if result.ScrubServices["stripe"] {
+		t.Error("stripe should not be in ScrubServices")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/session/ -run TestResolveServiceConfigs_InjectEnv -v && go test ./internal/session/ -run TestResolveServiceConfigs_ScrubResponse -v`
+Expected: FAIL — `result.EnvVars` and `result.ScrubServices` do not exist
+
+- [ ] **Step 3: Add ServiceEnvVar type and extend ResolvedServices**
+
+In `internal/session/secretsconfig.go`, add after the `InjectHeaderConfig` type (after line 20):
+
+```go
+// ServiceEnvVar maps a service name to an env var that should receive
+// the service's fake credential.
+type ServiceEnvVar struct {
+	ServiceName string
+	VarName     string
+}
+```
+
+Modify `ResolvedServices` (lines 22-27) to:
+
+```go
+// ResolvedServices holds the parsed outputs needed by the bootstrap flow.
+type ResolvedServices struct {
+	ServiceConfigs []ServiceConfig
+	Patterns       []services.ServicePattern
+	InjectHeaders  []InjectHeaderConfig
+	EnvVars        []ServiceEnvVar    // inject.env entries
+	ScrubServices  map[string]bool    // service name -> scrub_response flag
+}
+```
+
+- [ ] **Step 4: Extract inject.env and scrub_response in ResolveServiceConfigs**
+
+In `ResolveServiceConfigs`, after the `InjectHeaders` block (after line 77), add:
+
+```go
+		for _, ev := range svc.Inject.Env {
+			result.EnvVars = append(result.EnvVars, ServiceEnvVar{
+				ServiceName: svc.Name,
+				VarName:     ev.Name,
+			})
+		}
+		if svc.ScrubResponse {
+			if result.ScrubServices == nil {
+				result.ScrubServices = make(map[string]bool)
+			}
+			result.ScrubServices[svc.Name] = true
+		}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/session/ -run TestResolveServiceConfigs -v`
+Expected: All PASS (including existing tests + two new ones)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/session/secretsconfig.go internal/session/secretsconfig_test.go
+git commit -m "feat(session): resolve inject.env and scrub_response from service YAML (Plan 7)"
+```
+
+---
+
+### Task 2: BuildServiceEnvVars Function
+
+**Files:**
+- Modify: `internal/session/secrets.go` (add function after BootstrapCredentials)
+- Modify: `internal/session/secrets_test.go` (add tests)
+
+- [ ] **Step 1: Write failing test**
+
+Add to `internal/session/secrets_test.go`:
+
+```go
+func TestBuildServiceEnvVars(t *testing.T) {
+	mp := &memoryProvider{
+		secrets: map[string][]byte{
+			"github/token": []byte("ghp_realABCDEFGHIJKLMNOPQRSTUVWXYZ123456"),
+		},
+	}
+	services := []ServiceConfig{
+		{
+			Name:       "github",
+			SecretRef:  secrets.SecretRef{Scheme: "memory", Host: "github", Path: "token"},
+			FakeFormat: "ghp_{rand:36}",
+		},
+	}
+	table, cleanup, err := BootstrapCredentials(context.Background(), mp, services)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	envVars := []ServiceEnvVar{
+		{ServiceName: "github", VarName: "GITHUB_TOKEN"},
+	}
+	result := BuildServiceEnvVars(envVars, table)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 env var, got %d", len(result))
+	}
+	val, ok := result["GITHUB_TOKEN"]
+	if !ok {
+		t.Fatal("GITHUB_TOKEN not in result")
+	}
+	if len(val) != 40 {
+		t.Errorf("value length = %d, want 40", len(val))
+	}
+	if val[:4] != "ghp_" {
+		t.Errorf("value prefix = %q, want ghp_", val[:4])
+	}
+}
+
+func TestBuildServiceEnvVars_UnknownService(t *testing.T) {
+	table := credsub.New()
+	envVars := []ServiceEnvVar{
+		{ServiceName: "nonexistent", VarName: "FOO"},
+	}
+	result := BuildServiceEnvVars(envVars, table)
+	if len(result) != 0 {
+		t.Errorf("expected empty map, got %v", result)
+	}
+}
+
+func TestBuildServiceEnvVars_Empty(t *testing.T) {
+	table := credsub.New()
+	result := BuildServiceEnvVars(nil, table)
+	if result != nil {
+		t.Errorf("expected nil, got %v", result)
+	}
+}
+```
+
+Add the `credsub` import to the test file:
+
+```go
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/proxy/credsub"
+	"github.com/agentsh/agentsh/internal/proxy/secrets"
+)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/session/ -run TestBuildServiceEnvVars -v`
+Expected: FAIL — `BuildServiceEnvVars` undefined
+
+- [ ] **Step 3: Implement BuildServiceEnvVars**
+
+Add to `internal/session/secrets.go` after `LogSecretsInitialized`:
+
+```go
+// BuildServiceEnvVars builds a map of env var name -> fake credential
+// for services that declare inject.env. Looks up each service's fake
+// from the table; services not found in the table are silently skipped.
+func BuildServiceEnvVars(envVars []ServiceEnvVar, table *credsub.Table) map[string]string {
+	if len(envVars) == 0 {
+		return nil
+	}
+	result := make(map[string]string, len(envVars))
+	for _, ev := range envVars {
+		fake, ok := table.FakeForService(ev.ServiceName)
+		if !ok {
+			continue
+		}
+		result[ev.VarName] = string(fake)
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+```
+
+Add `"github.com/agentsh/agentsh/internal/proxy/credsub"` to the imports if not already present (it already is via the `credsub.New()` usage in `BootstrapCredentials`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/session/ -run TestBuildServiceEnvVars -v`
+Expected: All 3 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/session/secrets.go internal/session/secrets_test.go
+git commit -m "feat(session): BuildServiceEnvVars maps service fakes to env var names (Plan 7)"
+```
+
+---
+
+### Task 3: Validate inject.env Names in ValidateSecrets
+
+**Files:**
+- Modify: `internal/policy/secrets.go:66-144` (ValidateSecrets function)
+- Modify: `internal/policy/secrets_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `internal/policy/secrets_test.go`:
+
+```go
+func TestValidateSecrets_InjectEnvEmptyName(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"kr": mustNode(t, "type: keyring"),
+	}
+	services := []policy.ServiceYAML{
+		{
+			Name:   "github",
+			Match:  policy.ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret: policy.ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:   policy.ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: policy.ServiceInjectYAML{
+				Env: []policy.ServiceInjectEnvYAML{{Name: ""}},
+			},
+		},
+	}
+	_, err := policy.ValidateSecrets(providers, services)
+	if err == nil {
+		t.Fatal("expected error for empty inject.env name")
+	}
+}
+
+func TestValidateSecrets_InjectEnvDuplicateAcrossServices(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"kr": mustNode(t, "type: keyring"),
+	}
+	services := []policy.ServiceYAML{
+		{
+			Name:   "github",
+			Match:  policy.ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret: policy.ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:   policy.ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: policy.ServiceInjectYAML{
+				Env: []policy.ServiceInjectEnvYAML{{Name: "MY_TOKEN"}},
+			},
+		},
+		{
+			Name:   "stripe",
+			Match:  policy.ServiceMatchYAML{Hosts: []string{"api.stripe.com"}},
+			Secret: policy.ServiceSecretYAML{Ref: "keyring://agentsh/stripe"},
+			Fake:   policy.ServiceFakeYAML{Format: "xk_test_{rand:24}"},
+			Inject: policy.ServiceInjectYAML{
+				Env: []policy.ServiceInjectEnvYAML{{Name: "MY_TOKEN"}},
+			},
+		},
+	}
+	_, err := policy.ValidateSecrets(providers, services)
+	if err == nil {
+		t.Fatal("expected error for duplicate env var name across services")
+	}
+}
+
+func TestValidateSecrets_InjectEnvValid(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"kr": mustNode(t, "type: keyring"),
+	}
+	services := []policy.ServiceYAML{
+		{
+			Name:   "github",
+			Match:  policy.ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret: policy.ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:   policy.ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: policy.ServiceInjectYAML{
+				Env: []policy.ServiceInjectEnvYAML{{Name: "GITHUB_TOKEN"}},
+			},
+		},
+	}
+	_, err := policy.ValidateSecrets(providers, services)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+```
+
+Note: Existing tests use a helper `mustNode`. Check the test file for the exact helper name — it may be `mustNode` or `mustYAMLNode`. Use whatever the existing tests use. If the helper parses a YAML string into a `yaml.Node`, the above code should work. Adapt the helper name if needed.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/policy/ -run TestValidateSecrets_InjectEnv -v`
+Expected: FAIL — EmptyName and DuplicateAcrossServices tests pass (should fail), Valid test passes
+
+Actually: the first two tests should pass through validation without error since the validation doesn't exist yet. So they will fail (`expected error` but got nil).
+
+- [ ] **Step 3: Add inject.env validation to ValidateSecrets**
+
+In `internal/policy/secrets.go`, inside the `ValidateSecrets` function, add a `envOwner` map alongside the existing `hostOwner` map (around line 85):
+
+```go
+	envOwner := make(map[string]string) // env var name -> first service name
+```
+
+Then, inside the per-service loop (after the `inject.header.template` validation block ending around line 140), add:
+
+```go
+		// inject.env validation
+		for j, ev := range svc.Inject.Env {
+			if ev.Name == "" {
+				return nil, fmt.Errorf("services[%d] %q: inject.env[%d].name is required", i, svc.Name, j)
+			}
+			if prev, dup := envOwner[ev.Name]; dup {
+				return nil, fmt.Errorf("services[%d] %q: inject.env name %q already declared by service %q", i, svc.Name, ev.Name, prev)
+			}
+			envOwner[ev.Name] = svc.Name
+		}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/policy/ -run TestValidateSecrets -v`
+Expected: All PASS (existing + 3 new)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/policy/secrets.go internal/policy/secrets_test.go
+git commit -m "feat(policy): validate inject.env names in ValidateSecrets (Plan 7)"
+```
+
+---
+
+### Task 4: CheckEnvCollisions Function
+
+**Files:**
+- Create: `internal/session/envcheck.go`
+- Create: `internal/session/envcheck_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/session/envcheck_test.go`:
+
+```go
+package session
+
+import "testing"
+
+func TestCheckEnvCollisions_NoCollision(t *testing.T) {
+	serviceEnv := map[string]string{
+		"GITHUB_TOKEN": "fake_gh",
+	}
+	envInject := map[string]string{
+		"MY_VAR": "value",
+	}
+	if err := CheckEnvCollisions(serviceEnv, envInject); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCheckEnvCollisions_Collision(t *testing.T) {
+	serviceEnv := map[string]string{
+		"GITHUB_TOKEN": "fake_gh",
+	}
+	envInject := map[string]string{
+		"GITHUB_TOKEN": "other_value",
+	}
+	err := CheckEnvCollisions(serviceEnv, envInject)
+	if err == nil {
+		t.Fatal("expected error for collision")
+	}
+}
+
+func TestCheckEnvCollisions_BothNil(t *testing.T) {
+	if err := CheckEnvCollisions(nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCheckEnvCollisions_MultipleCollisions(t *testing.T) {
+	serviceEnv := map[string]string{
+		"A": "1",
+		"B": "2",
+	}
+	envInject := map[string]string{
+		"A": "x",
+		"B": "y",
+		"C": "z",
+	}
+	err := CheckEnvCollisions(serviceEnv, envInject)
+	if err == nil {
+		t.Fatal("expected error for collisions")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/session/ -run TestCheckEnvCollisions -v`
+Expected: FAIL — `CheckEnvCollisions` undefined
+
+- [ ] **Step 3: Implement CheckEnvCollisions**
+
+Create `internal/session/envcheck.go`:
+
+```go
+package session
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// CheckEnvCollisions returns an error if any service env var name
+// collides with an env_inject key. Both maps use env var names as keys.
+func CheckEnvCollisions(serviceEnv, envInject map[string]string) error {
+	if len(serviceEnv) == 0 || len(envInject) == 0 {
+		return nil
+	}
+	var collisions []string
+	for name := range serviceEnv {
+		if _, ok := envInject[name]; ok {
+			collisions = append(collisions, name)
+		}
+	}
+	if len(collisions) == 0 {
+		return nil
+	}
+	sort.Strings(collisions)
+	return fmt.Errorf("env_inject_service_collision: %s", strings.Join(collisions, ", "))
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/session/ -run TestCheckEnvCollisions -v`
+Expected: All 4 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/session/envcheck.go internal/session/envcheck_test.go
+git commit -m "feat(session): CheckEnvCollisions detects env_inject vs service env var conflicts (Plan 7)"
+```
+
+---
+
+### Task 5: Wire Env Vars and Scrub Config Through StartLLMProxy
+
+**Files:**
+- Modify: `internal/session/manager.go:86-92` (add serviceEnvVars field)
+- Modify: `internal/session/llmproxy.go:25-162` (StartLLMProxy signature + env wiring)
+- Modify: `internal/session/llmproxy_test.go` (tests)
+- Modify: `internal/api/app.go:466-475` (update call site)
+
+- [ ] **Step 1: Write failing test**
+
+Add to `internal/session/llmproxy_test.go`:
+
+```go
+func TestSession_ServiceEnvVars_Nil(t *testing.T) {
+	sess := &Session{ID: "test"}
+	result := sess.ServiceEnvVars()
+	if result != nil {
+		t.Errorf("expected nil, got %v", result)
+	}
+}
+
+func TestSession_ServiceEnvVars_Set(t *testing.T) {
+	sess := &Session{ID: "test"}
+	envMap := map[string]string{"GITHUB_TOKEN": "fake_gh"}
+	sess.SetServiceEnvVars(envMap)
+	result := sess.ServiceEnvVars()
+	if len(result) != 1 {
+		t.Fatalf("expected 1 var, got %d", len(result))
+	}
+	if result["GITHUB_TOKEN"] != "fake_gh" {
+		t.Errorf("GITHUB_TOKEN = %q", result["GITHUB_TOKEN"])
+	}
+}
+
+func TestSession_ServiceEnvVars_DeepCopy(t *testing.T) {
+	sess := &Session{ID: "test"}
+	original := map[string]string{"K": "V"}
+	sess.SetServiceEnvVars(original)
+	result := sess.ServiceEnvVars()
+	result["K"] = "mutated"
+	result2 := sess.ServiceEnvVars()
+	if result2["K"] != "V" {
+		t.Error("ServiceEnvVars should return a copy")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/session/ -run TestSession_ServiceEnvVars -v`
+Expected: FAIL — `SetServiceEnvVars` and `ServiceEnvVars` undefined
+
+- [ ] **Step 3: Add serviceEnvVars field and methods to Session**
+
+In `internal/session/manager.go`, after the `secretsClose` field (line 91), add:
+
+```go
+	// serviceEnvVars holds fake credentials keyed by env var name.
+	// Injected into spawned processes bypassing policy filtering.
+	// Nil if no services declare inject.env.
+	serviceEnvVars map[string]string
+```
+
+Add setter and getter methods (near the other Set* methods, e.g., after `SetCredsTable`):
+
+```go
+// SetServiceEnvVars stores the service env var map on the session.
+func (s *Session) SetServiceEnvVars(env map[string]string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.serviceEnvVars = env
+}
+
+// ServiceEnvVars returns a copy of the service env var map.
+// Returns nil if no services declare inject.env.
+func (s *Session) ServiceEnvVars() map[string]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.serviceEnvVars == nil {
+		return nil
+	}
+	out := make(map[string]string, len(s.serviceEnvVars))
+	for k, v := range s.serviceEnvVars {
+		out[k] = v
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/session/ -run TestSession_ServiceEnvVars -v`
+Expected: All 3 PASS
+
+- [ ] **Step 5: Modify StartLLMProxy to accept envInject and wire env vars**
+
+In `internal/session/llmproxy.go`, change the `StartLLMProxy` signature (line 25-35) to add `envInject`:
+
+```go
+func StartLLMProxy(
+	sess *Session,
+	proxyCfg config.ProxyConfig,
+	dlpCfg config.DLPConfig,
+	storageCfg config.LLMStorageConfig,
+	mcpCfg config.SandboxMCPConfig,
+	storagePath string,
+	logger *slog.Logger,
+	providers map[string]yaml.Node,
+	policyServices []policy.ServiceYAML,
+	envInject map[string]string,
+) (string, func() error, error) {
+```
+
+Inside the `if len(policyServices) > 0` block, after `BootstrapCredentials` (after line 129), add the env var wiring before the hook registration:
+
+```go
+		// Build and validate service env vars.
+		svcEnv := BuildServiceEnvVars(resolved.EnvVars, table)
+		if err := CheckEnvCollisions(svcEnv, envInject); err != nil {
+			secretsCleanup()
+			_ = registry.Close()
+			_ = p.Stop(ctx)
+			return "", nil, fmt.Errorf("service env collision: %w", err)
+		}
+		sess.SetServiceEnvVars(svcEnv)
+```
+
+- [ ] **Step 6: Update app.go call site**
+
+In `internal/api/app.go`, update the `StartLLMProxy` call (around line 466-475) to pass `nil` for `envInject`:
+
+```go
+	proxyURL, closeFn, err := session.StartLLMProxy(
+		s,
+		a.cfg.Proxy,
+		a.cfg.DLP,
+		a.cfg.LLMStorage,
+		a.cfg.Sandbox.MCP,
+		storagePath,
+		slog.Default(),
+		nil, nil, nil,
+	)
+```
+
+- [ ] **Step 7: Run all tests to verify nothing broke**
+
+Run: `go test ./internal/session/ ./internal/api/ -v -count=1`
+Expected: All PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/session/manager.go internal/session/llmproxy.go internal/session/llmproxy_test.go internal/api/app.go
+git commit -m "feat(session): wire service env vars through StartLLMProxy with collision detection (Plan 7)"
+```
+
+---
+
+### Task 6: Inject Service Env Vars Into Spawned Process
+
+**Files:**
+- Modify: `internal/api/exec.go:199-222` (add service env var block)
+
+- [ ] **Step 1: Understand the injection point**
+
+In `internal/api/exec.go`, the function `runCommandWithResources` (called from multiple exec paths) builds the process environment at lines 177-222:
+
+1. `buildPolicyEnv()` (line 177) — applies allow/deny filtering
+2. `extra.env` (lines 194-198) — seccomp wrapper vars
+3. `extra.envInject` (lines 199-221) — operator-trusted, bypasses policy
+
+Service env vars like `GITHUB_TOKEN` are in the default-deny list (`defaultSecretDeny` in `env_policy.go`), so they MUST bypass policy filtering. Add them after `envInject` using the same override pattern.
+
+- [ ] **Step 2: Add service env var injection block**
+
+In `internal/api/exec.go`, after the `env_inject` block (after line 221, before `cmd.Env = env`), add:
+
+```go
+	// Add service env vars (fake credentials, bypass policy filtering).
+	// These must come after env_inject; collisions are caught at session start.
+	if svcEnv := s.ServiceEnvVars(); len(svcEnv) > 0 {
+		svcKeys := make(map[string]bool, len(svcEnv))
+		for k := range svcEnv {
+			svcKeys[k] = true
+		}
+		filtered := env[:0]
+		for _, e := range env {
+			if k, _, ok := strings.Cut(e, "="); ok && svcKeys[k] {
+				continue
+			}
+			filtered = append(filtered, e)
+		}
+		env = filtered
+		for k, v := range svcEnv {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `go test ./internal/api/ -v -count=1`
+Expected: All PASS (the change is injected into the existing flow; existing tests still work)
+
+Run: `go build ./...`
+Expected: Compiles cleanly
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/api/exec.go
+git commit -m "feat(api): inject service fake credentials into spawned process env (Plan 7)"
+```
+
+---
+
+### Task 7: Per-Service scrub_response in CredsSubHook
+
+**Files:**
+- Modify: `internal/proxy/credshook.go:16-82` (CredsSubHook struct + PostHook)
+- Modify: `internal/proxy/credshook_test.go`
+- Modify: `internal/session/llmproxy.go` (pass scrub config to NewCredsSubHook)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `internal/proxy/credshook_test.go`:
+
+```go
+func TestCredsSubHook_PostHook_ScrubDisabled(t *testing.T) {
+	table := credsub.New()
+	_ = table.Add("github", []byte("fake_cred_ABCDEFGHIJKLMNO"), []byte("real_cred_ABCDEFGHIJKLMNO"))
+
+	// scrubServices does not include "github" -> PostHook should be a no-op
+	hook := NewCredsSubHook(table, map[string]bool{"other": true})
+
+	body := []byte(`{"key":"real_cred_ABCDEFGHIJKLMNO"}`)
+	resp := &http.Response{
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+	ctx := &RequestContext{ServiceName: "github"}
+
+	err := hook.PostHook(resp, ctx)
+	if err != nil {
+		t.Fatalf("PostHook error: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if !bytes.Contains(got, []byte("real_cred_ABCDEFGHIJKLMNO")) {
+		t.Error("expected real credential to remain (scrub disabled for this service)")
+	}
+}
+
+func TestCredsSubHook_PostHook_ScrubEnabled(t *testing.T) {
+	table := credsub.New()
+	_ = table.Add("github", []byte("fake_cred_ABCDEFGHIJKLMNO"), []byte("real_cred_ABCDEFGHIJKLMNO"))
+
+	hook := NewCredsSubHook(table, map[string]bool{"github": true})
+
+	body := []byte(`{"key":"real_cred_ABCDEFGHIJKLMNO"}`)
+	resp := &http.Response{
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+	ctx := &RequestContext{ServiceName: "github"}
+
+	err := hook.PostHook(resp, ctx)
+	if err != nil {
+		t.Fatalf("PostHook error: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if bytes.Contains(got, []byte("real_cred_ABCDEFGHIJKLMNO")) {
+		t.Error("expected real credential to be scrubbed")
+	}
+	if !bytes.Contains(got, []byte("fake_cred_ABCDEFGHIJKLMNO")) {
+		t.Error("expected fake credential in scrubbed output")
+	}
+}
+
+func TestCredsSubHook_PostHook_NilScrubMap_ScrubsAll(t *testing.T) {
+	table := credsub.New()
+	_ = table.Add("github", []byte("fake_cred_ABCDEFGHIJKLMNO"), []byte("real_cred_ABCDEFGHIJKLMNO"))
+
+	// nil scrubServices = backward compat, scrub everything
+	hook := NewCredsSubHook(table, nil)
+
+	body := []byte(`{"key":"real_cred_ABCDEFGHIJKLMNO"}`)
+	resp := &http.Response{
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+	ctx := &RequestContext{ServiceName: "github"}
+
+	err := hook.PostHook(resp, ctx)
+	if err != nil {
+		t.Fatalf("PostHook error: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if bytes.Contains(got, []byte("real_cred_ABCDEFGHIJKLMNO")) {
+		t.Error("expected real credential to be scrubbed (nil map = scrub all)")
+	}
+}
+```
+
+These tests need `bytes`, `io`, `net/http` imports. Check the test file's existing imports and add if needed.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/proxy/ -run TestCredsSubHook_PostHook_Scrub -v`
+Expected: FAIL — `NewCredsSubHook` only takes 1 argument
+
+- [ ] **Step 3: Modify CredsSubHook to accept scrubServices**
+
+In `internal/proxy/credshook.go`, change the struct and constructor (lines 16-23):
+
+```go
+// CredsSubHook performs credential substitution using a credsub.Table.
+// PreHook replaces fake credentials with real ones in request bodies.
+// PostHook replaces real credentials with fakes in response bodies
+// for services listed in scrubServices. If scrubServices is nil,
+// all responses are scrubbed (backward compatibility).
+type CredsSubHook struct {
+	table         *credsub.Table
+	scrubServices map[string]bool
+}
+
+// NewCredsSubHook returns a CredsSubHook that uses the given table.
+// scrubServices controls which services get response scrubbing.
+// Pass nil to scrub all responses (backward compatibility).
+func NewCredsSubHook(table *credsub.Table, scrubServices map[string]bool) *CredsSubHook {
+	return &CredsSubHook{table: table, scrubServices: scrubServices}
+}
+```
+
+Modify `PostHook` (lines 68-82) to check the scrub config:
+
+```go
+// PostHook replaces real credentials with fakes in the response body.
+// Only scrubs if the service is in scrubServices (or if scrubServices is nil).
+func (h *CredsSubHook) PostHook(resp *http.Response, ctx *RequestContext) error {
+	if resp.Body == nil {
+		return nil
+	}
+	// Check per-service scrub config.
+	if h.scrubServices != nil && !h.scrubServices[ctx.ServiceName] {
+		return nil
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil // best-effort
+	}
+
+	replaced := h.table.ReplaceRealToFake(body)
+	resp.Body = io.NopCloser(bytes.NewReader(replaced))
+	resp.ContentLength = int64(len(replaced))
+	return nil
+}
+```
+
+- [ ] **Step 4: Fix existing NewCredsSubHook call sites**
+
+Update `internal/session/llmproxy.go` line 133 to pass `resolved.ScrubServices`:
+
+```go
+		credsSub := proxy.NewCredsSubHook(table, resolved.ScrubServices)
+```
+
+Search for any other `NewCredsSubHook` call sites in tests and update them. They likely pass only the table — add `nil` as the second argument for backward-compatible behavior:
+
+Run: `grep -rn 'NewCredsSubHook' internal/`
+
+For each call site in test files, change `NewCredsSubHook(table)` to `NewCredsSubHook(table, nil)`.
+
+- [ ] **Step 5: Run all proxy + session tests**
+
+Run: `go test ./internal/proxy/ ./internal/session/ -v -count=1`
+Expected: All PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/proxy/credshook.go internal/proxy/credshook_test.go internal/session/llmproxy.go
+git commit -m "feat(proxy): per-service scrub_response toggle in CredsSubHook (Plan 7)"
+```
+
+---
+
+### Task 8: Integration Test
+
+**Files:**
+- Modify: `internal/session/secrets_integration_test.go`
+
+- [ ] **Step 1: Write the integration test**
+
+Add to `internal/session/secrets_integration_test.go`:
+
+```go
+func TestIntegration_EnvVarInjection_FullFlow(t *testing.T) {
+	// 1. Define service YAML with inject.env and scrub_response.
+	svcs := []policy.ServiceYAML{
+		{
+			Name:          "github",
+			Match:         policy.ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret:        policy.ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:          policy.ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			ScrubResponse: true,
+			Inject: policy.ServiceInjectYAML{
+				Header: &policy.ServiceInjectHeaderYAML{
+					Name: "Authorization", Template: "Bearer {{secret}}",
+				},
+				Env: []policy.ServiceInjectEnvYAML{
+					{Name: "GITHUB_TOKEN"},
+					{Name: "GH_TOKEN"},
+				},
+			},
+		},
+		{
+			Name:   "stripe",
+			Match:  policy.ServiceMatchYAML{Hosts: []string{"api.stripe.com"}},
+			Secret: policy.ServiceSecretYAML{Ref: "keyring://agentsh/stripe"},
+			Fake:   policy.ServiceFakeYAML{Format: "xk_test_{rand:24}"},
+			Inject: policy.ServiceInjectYAML{
+				Env: []policy.ServiceInjectEnvYAML{
+					{Name: "STRIPE_API_KEY"},
+				},
+			},
+			// scrub_response intentionally false
+		},
+	}
+
+	// 2. Resolve services.
+	resolved, err := ResolveServiceConfigs(svcs)
+	if err != nil {
+		t.Fatalf("ResolveServiceConfigs: %v", err)
+	}
+
+	// Verify env vars resolved.
+	if len(resolved.EnvVars) != 3 {
+		t.Fatalf("expected 3 env vars, got %d", len(resolved.EnvVars))
+	}
+
+	// Verify scrub config.
+	if !resolved.ScrubServices["github"] {
+		t.Error("github should be in ScrubServices")
+	}
+	if resolved.ScrubServices["stripe"] {
+		t.Error("stripe should NOT be in ScrubServices")
+	}
+
+	// 3. Bootstrap credentials with a memory provider.
+	mp := &memoryProvider{
+		secrets: map[string][]byte{
+			"agentsh/gh":     []byte("ghp_realABCDEFGHIJKLMNOPQRSTUVWXYZ123456"),
+			"agentsh/stripe": []byte("xk_test_realABCDEFGHIJKLMNOPQRST"),
+		},
+	}
+	table, cleanup, err := BootstrapCredentials(context.Background(), mp, resolved.ServiceConfigs)
+	if err != nil {
+		t.Fatalf("BootstrapCredentials: %v", err)
+	}
+	defer cleanup()
+
+	// 4. Build service env vars.
+	svcEnv := BuildServiceEnvVars(resolved.EnvVars, table)
+	if len(svcEnv) != 3 {
+		t.Fatalf("expected 3 service env vars, got %d", len(svcEnv))
+	}
+	if _, ok := svcEnv["GITHUB_TOKEN"]; !ok {
+		t.Error("GITHUB_TOKEN missing from service env vars")
+	}
+	if _, ok := svcEnv["GH_TOKEN"]; !ok {
+		t.Error("GH_TOKEN missing from service env vars")
+	}
+	if _, ok := svcEnv["STRIPE_API_KEY"]; !ok {
+		t.Error("STRIPE_API_KEY missing from service env vars")
+	}
+
+	// Verify env var values are the fake credentials.
+	ghFake, _ := table.FakeForService("github")
+	if svcEnv["GITHUB_TOKEN"] != string(ghFake) {
+		t.Errorf("GITHUB_TOKEN value doesn't match fake")
+	}
+	// Both GITHUB_TOKEN and GH_TOKEN should have the same fake (same service).
+	if svcEnv["GH_TOKEN"] != string(ghFake) {
+		t.Errorf("GH_TOKEN value doesn't match fake")
+	}
+
+	// 5. Collision detection: no collision.
+	envInject := map[string]string{"PATH": "/usr/bin"}
+	if err := CheckEnvCollisions(svcEnv, envInject); err != nil {
+		t.Fatalf("unexpected collision: %v", err)
+	}
+
+	// 6. Collision detection: collision.
+	envInjectBad := map[string]string{"GITHUB_TOKEN": "something_else"}
+	if err := CheckEnvCollisions(svcEnv, envInjectBad); err == nil {
+		t.Error("expected collision error")
+	}
+}
+```
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `go test ./internal/session/ -run TestIntegration_EnvVarInjection_FullFlow -v`
+Expected: PASS
+
+- [ ] **Step 3: Run all tests**
+
+Run: `go test ./... -count=1`
+Expected: All PASS
+
+Run: `GOOS=windows go build ./...`
+Expected: Cross-compilation succeeds
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/session/secrets_integration_test.go
+git commit -m "test(session): integration test for env var injection + collision detection (Plan 7)"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- [x] `inject.env` parsed → Task 1 (resolver)
+- [x] Fake values mapped to env var names → Task 2 (BuildServiceEnvVars)
+- [x] `inject.env.name` validation → Task 3 (ValidateSecrets)
+- [x] Collision detection with `env_inject` → Task 4 (CheckEnvCollisions)
+- [x] Env vars stored on Session → Task 5 (manager.go + StartLLMProxy)
+- [x] Env vars injected into spawned process (bypass policy) → Task 6 (exec.go)
+- [x] Per-service `scrub_response` toggle → Task 7 (CredsSubHook)
+- [x] Integration test → Task 8
+
+**Placeholder scan:** No TBD, TODO, or vague steps. All steps have concrete code.
+
+**Type consistency:**
+- `ServiceEnvVar` — used consistently in Tasks 1, 2, 5, 8
+- `ResolvedServices.ScrubServices` — map[string]bool, used in Tasks 1, 7, 8
+- `BuildServiceEnvVars` signature — `([]ServiceEnvVar, *credsub.Table) map[string]string` throughout
+- `CheckEnvCollisions` signature — `(map[string]string, map[string]string) error` throughout
+- `NewCredsSubHook` — `(*credsub.Table, map[string]bool)` after Task 7, all call sites updated
+
+**Deferred to Plan 8+:**
+- Process context `secrets:` scoping
+- Additional providers (AWS SM, GCP SM, Azure KV, 1Password)
+- Go service plugins (AWS SigV4, GCP OAuth)
+- SSE streaming substitution
+- Distinct audit event names (split `secret_leak_blocked`)

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -36,6 +36,7 @@ import (
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
+	"gopkg.in/yaml.v3"
 )
 
 // PolicyLoader loads a policy by name and returns a policy engine.
@@ -463,6 +464,19 @@ func (a *App) startLLMProxy(ctx context.Context, s *session.Session) {
 	// Pass the sessions base directory - NewStorage will create <base>/<session-id>/llm-requests.jsonl
 	storagePath := a.cfg.Sessions.BaseDir
 
+	// Resolve policy-driven providers, services, and env injection.
+	pol := a.policyEngineFor(s)
+	var providers map[string]yaml.Node
+	var policyServices []policy.ServiceYAML
+	var envInject map[string]string
+	if pol != nil {
+		if p := pol.Policy(); p != nil {
+			providers = p.Providers
+			policyServices = p.Services
+		}
+		envInject = mergeEnvInject(a.cfg, pol)
+	}
+
 	proxyURL, closeFn, err := session.StartLLMProxy(
 		s,
 		a.cfg.Proxy,
@@ -471,7 +485,7 @@ func (a *App) startLLMProxy(ctx context.Context, s *session.Session) {
 		a.cfg.Sandbox.MCP,
 		storagePath,
 		slog.Default(),
-		nil, nil,
+		providers, policyServices, envInject,
 	)
 	if err != nil {
 		fail := types.Event{

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -219,6 +219,25 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 			env = append(env, fmt.Sprintf("%s=%s", k, v))
 		}
 	}
+	// Add service env vars (fake credentials, bypass policy filtering).
+	// These must come after env_inject; collisions are caught at session start.
+	if svcEnv := s.ServiceEnvVars(); len(svcEnv) > 0 {
+		svcKeys := make(map[string]bool, len(svcEnv))
+		for k := range svcEnv {
+			svcKeys[k] = true
+		}
+		filtered := env[:0]
+		for _, e := range env {
+			if k, _, ok := strings.Cut(e, "="); ok && svcKeys[k] {
+				continue
+			}
+			filtered = append(filtered, e)
+		}
+		env = filtered
+		for k, v := range svcEnv {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
 	cmd.Env = env
 	slog.Debug("exec env final", "command", req.Command, "env_count", len(env), "has_extra", extra != nil, "envInject_count", func() int { if extra != nil { return len(extra.envInject) }; return 0 }())
 	if extra != nil && len(extra.extraFiles) > 0 {

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -300,6 +300,24 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 			env = append(env, fmt.Sprintf("%s=%s", k, v))
 		}
 	}
+	// Add service env vars (fake credentials, bypass policy filtering).
+	if svcEnv := s.ServiceEnvVars(); len(svcEnv) > 0 {
+		svcKeys := make(map[string]bool, len(svcEnv))
+		for k := range svcEnv {
+			svcKeys[k] = true
+		}
+		filtered := env[:0]
+		for _, e := range env {
+			if k, _, ok := strings.Cut(e, "="); ok && svcKeys[k] {
+				continue
+			}
+			filtered = append(filtered, e)
+		}
+		env = filtered
+		for k, v := range svcEnv {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
 	cmd.Env = env
 
 	// Add extra files (socket fds for seccomp notify/signal)

--- a/internal/api/pty_core.go
+++ b/internal/api/pty_core.go
@@ -155,6 +155,24 @@ func (a *App) startPTY(ctx context.Context, sessionID string, req ptyStartParams
 		return nil, http.StatusBadRequest, err
 	}
 	env, _ := buildPolicyEnv(policy.ResolvedEnvPolicy{}, os.Environ(), sess, req.Env)
+	// Add service env vars (fake credentials, bypass policy filtering).
+	if svcEnv := sess.ServiceEnvVars(); len(svcEnv) > 0 {
+		svcKeys := make(map[string]bool, len(svcEnv))
+		for k := range svcEnv {
+			svcKeys[k] = true
+		}
+		filtered := env[:0]
+		for _, e := range env {
+			if k, _, ok := strings.Cut(e, "="); ok && svcKeys[k] {
+				continue
+			}
+			filtered = append(filtered, e)
+		}
+		env = filtered
+		for k, v := range svcEnv {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
 
 	rows := req.Rows
 	cols := req.Cols

--- a/internal/policy/secrets.go
+++ b/internal/policy/secrets.go
@@ -3,6 +3,7 @@ package policy
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 
 	"github.com/agentsh/agentsh/internal/proxy/secrets"
@@ -83,6 +84,7 @@ func ValidateSecrets(providers map[string]yaml.Node, services []ServiceYAML) (wa
 	// Validate services.
 	seen := make(map[string]bool)
 	hostOwner := make(map[string]string) // host pattern -> first service name (for overlap warnings)
+	envOwner := make(map[string]string)  // env var name -> first service name
 	for i, svc := range services {
 		if svc.Name == "" {
 			return nil, fmt.Errorf("services[%d]: name is required", i)
@@ -138,9 +140,35 @@ func ValidateSecrets(providers map[string]yaml.Node, services []ServiceYAML) (wa
 				return nil, fmt.Errorf("services[%d] %q: inject.header.template must contain {{secret}}", i, svc.Name)
 			}
 		}
+
+		// inject.env validation
+		for j, ev := range svc.Inject.Env {
+			if ev.Name == "" {
+				return nil, fmt.Errorf("services[%d] %q: inject.env[%d].name is required", i, svc.Name, j)
+			}
+			if strings.ContainsAny(ev.Name, "=\x00") {
+				return nil, fmt.Errorf("services[%d] %q: inject.env[%d].name %q contains invalid character", i, svc.Name, j, ev.Name)
+			}
+			if strings.HasPrefix(strings.ToUpper(ev.Name), "AGENTSH_") {
+				return nil, fmt.Errorf("services[%d] %q: inject.env[%d].name %q uses reserved AGENTSH_ prefix", i, svc.Name, j, ev.Name)
+			}
+			if prev, dup := envOwner[envVarNormalizedKey(ev.Name)]; dup {
+				return nil, fmt.Errorf("services[%d] %q: inject.env name %q already declared by service %q", i, svc.Name, ev.Name, prev)
+			}
+			envOwner[envVarNormalizedKey(ev.Name)] = svc.Name
+		}
 	}
 
 	return warnings, nil
+}
+
+// envVarNormalizedKey returns the env var name normalized for duplicate
+// detection. On Windows env vars are case-insensitive, so fold to upper.
+func envVarNormalizedKey(name string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToUpper(name)
+	}
+	return name
 }
 
 // extractProviderType decodes just the "type" field from a provider yaml.Node.

--- a/internal/policy/secrets_test.go
+++ b/internal/policy/secrets_test.go
@@ -184,3 +184,143 @@ func TestValidateSecrets_NoProviders_ServiceNeedsProvider(t *testing.T) {
 		t.Errorf("expected no matching provider error, got: %v", err)
 	}
 }
+
+func TestValidateSecrets_InjectEnvEmptyName(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"kr": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{
+			Name:   "github",
+			Match:  ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret: ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:   ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: ServiceInjectYAML{
+				Env: []ServiceInjectEnvYAML{{Name: ""}},
+			},
+		},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil {
+		t.Fatal("expected error for empty inject.env name")
+	}
+}
+
+func TestValidateSecrets_InjectEnvInvalidChar(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"kr": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{
+			Name:   "github",
+			Match:  ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret: ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:   ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: ServiceInjectYAML{
+				Env: []ServiceInjectEnvYAML{{Name: "PATH=/tmp"}},
+			},
+		},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil {
+		t.Fatal("expected error for name containing =")
+	}
+}
+
+func TestValidateSecrets_InjectEnvDuplicateAcrossServices(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"kr": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{
+			Name:   "github",
+			Match:  ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret: ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:   ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: ServiceInjectYAML{
+				Env: []ServiceInjectEnvYAML{{Name: "MY_TOKEN"}},
+			},
+		},
+		{
+			Name:   "stripe",
+			Match:  ServiceMatchYAML{Hosts: []string{"api.stripe.com"}},
+			Secret: ServiceSecretYAML{Ref: "keyring://agentsh/stripe"},
+			Fake:   ServiceFakeYAML{Format: "xk_test_{rand:24}"},
+			Inject: ServiceInjectYAML{
+				Env: []ServiceInjectEnvYAML{{Name: "MY_TOKEN"}},
+			},
+		},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil {
+		t.Fatal("expected error for duplicate env var name across services")
+	}
+}
+
+func TestValidateSecrets_InjectEnvValid(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"kr": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{
+			Name:   "github",
+			Match:  ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret: ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:   ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: ServiceInjectYAML{
+				Env: []ServiceInjectEnvYAML{{Name: "GITHUB_TOKEN"}},
+			},
+		},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateSecrets_InjectEnvReservedPrefixCaseInsensitive(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"kr": mustNode(t, "type: keyring"),
+	}
+	for _, name := range []string{"agentsh_foo", "Agentsh_Bar", "AGENTSH_BAZ"} {
+		services := []ServiceYAML{
+			{
+				Name:   "github",
+				Match:  ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+				Secret: ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+				Fake:   ServiceFakeYAML{Format: "ghp_{rand:36}"},
+				Inject: ServiceInjectYAML{
+					Env: []ServiceInjectEnvYAML{{Name: name}},
+				},
+			},
+		}
+		_, err := ValidateSecrets(providers, services)
+		if err == nil {
+			t.Errorf("expected error for reserved prefix in name %q", name)
+		}
+	}
+}
+
+func TestValidateSecrets_InjectEnvReservedPrefix(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"kr": mustNode(t, "type: keyring"),
+	}
+	services := []ServiceYAML{
+		{
+			Name:   "github",
+			Match:  ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret: ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:   ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: ServiceInjectYAML{
+				Env: []ServiceInjectEnvYAML{{Name: "AGENTSH_SESSION_ID"}},
+			},
+		},
+	}
+	_, err := ValidateSecrets(providers, services)
+	if err == nil {
+		t.Fatal("expected error for reserved AGENTSH_ prefix")
+	}
+	if !strings.Contains(err.Error(), "reserved AGENTSH_ prefix") {
+		t.Errorf("error should mention reserved prefix, got: %v", err)
+	}
+}

--- a/internal/proxy/credshook.go
+++ b/internal/proxy/credshook.go
@@ -14,12 +14,15 @@ import (
 // PreHook replaces fake credentials with real ones in request bodies.
 // PostHook replaces real credentials with fakes in response bodies.
 type CredsSubHook struct {
-	table *credsub.Table
+	table         *credsub.Table
+	scrubServices map[string]bool
 }
 
 // NewCredsSubHook returns a CredsSubHook that uses the given table.
-func NewCredsSubHook(table *credsub.Table) *CredsSubHook {
-	return &CredsSubHook{table: table}
+// scrubServices controls which services have response scrubbing enabled.
+// Pass nil to scrub all responses (backward-compatible default).
+func NewCredsSubHook(table *credsub.Table, scrubServices map[string]bool) *CredsSubHook {
+	return &CredsSubHook{table: table, scrubServices: scrubServices}
 }
 
 func (h *CredsSubHook) Name() string { return "creds-sub" }
@@ -66,8 +69,13 @@ func (h *CredsSubHook) PreHook(r *http.Request, _ *RequestContext) error {
 }
 
 // PostHook replaces real credentials with fakes in the response body.
-func (h *CredsSubHook) PostHook(resp *http.Response, _ *RequestContext) error {
+// When scrubServices is non-nil, scrubbing is skipped for services not in the map.
+func (h *CredsSubHook) PostHook(resp *http.Response, ctx *RequestContext) error {
 	if resp.Body == nil {
+		return nil
+	}
+	// Check per-service scrub config.
+	if h.scrubServices != nil && !h.scrubServices[ctx.ServiceName] {
 		return nil
 	}
 	body, err := io.ReadAll(resp.Body)

--- a/internal/proxy/credshook_test.go
+++ b/internal/proxy/credshook_test.go
@@ -26,7 +26,7 @@ func newTestTable(t *testing.T) *credsub.Table {
 }
 
 func TestCredsSubHook_Name(t *testing.T) {
-	h := NewCredsSubHook(credsub.New())
+	h := NewCredsSubHook(credsub.New(), nil)
 	if h.Name() != "creds-sub" {
 		t.Errorf("Name() = %q, want %q", h.Name(), "creds-sub")
 	}
@@ -34,7 +34,7 @@ func TestCredsSubHook_Name(t *testing.T) {
 
 func TestCredsSubHook_PreHook_ReplacesFakeToReal(t *testing.T) {
 	tbl := newTestTable(t)
-	h := NewCredsSubHook(tbl)
+	h := NewCredsSubHook(tbl, nil)
 
 	body := []byte(`{"token":"ghp_FAKE1234567890abcdef"}`)
 	req := httptest.NewRequest(http.MethodPost, "http://api.example.com/v1/test", bytes.NewReader(body))
@@ -57,7 +57,7 @@ func TestCredsSubHook_PreHook_ReplacesFakeToReal(t *testing.T) {
 
 func TestCredsSubHook_PostHook_ReplacesRealToFake(t *testing.T) {
 	tbl := newTestTable(t)
-	h := NewCredsSubHook(tbl)
+	h := NewCredsSubHook(tbl, nil)
 
 	body := []byte(`{"echoed":"ghp_REAL1234567890abcdef"}`)
 	resp := &http.Response{
@@ -83,7 +83,7 @@ func TestCredsSubHook_PostHook_ReplacesRealToFake(t *testing.T) {
 
 func TestCredsSubHook_PreHook_NoFakes_BodyUnchanged(t *testing.T) {
 	tbl := newTestTable(t)
-	h := NewCredsSubHook(tbl)
+	h := NewCredsSubHook(tbl, nil)
 
 	body := []byte(`{"query":"hello world"}`)
 	req := httptest.NewRequest(http.MethodPost, "http://api.example.com/v1/test", bytes.NewReader(body))
@@ -101,7 +101,7 @@ func TestCredsSubHook_PreHook_NoFakes_BodyUnchanged(t *testing.T) {
 
 func TestCredsSubHook_NilBody(t *testing.T) {
 	tbl := newTestTable(t)
-	h := NewCredsSubHook(tbl)
+	h := NewCredsSubHook(tbl, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "http://api.example.com/", nil)
 	if err := h.PreHook(req, &RequestContext{}); err != nil {
@@ -340,7 +340,7 @@ func TestHeaderInjectionHook_PostHook_IsNoOp(t *testing.T) {
 
 func TestCredsSubHook_PreHook_ReplacesInHeaders(t *testing.T) {
 	tbl := newTestTable(t)
-	h := NewCredsSubHook(tbl)
+	h := NewCredsSubHook(tbl, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "http://api.example.com/v1/test", nil)
 	req.Header.Set("Authorization", "Bearer ghp_FAKE1234567890abcdef")
@@ -359,7 +359,7 @@ func TestCredsSubHook_PreHook_ReplacesInHeaders(t *testing.T) {
 
 func TestCredsSubHook_PreHook_ReplacesInQuery(t *testing.T) {
 	tbl := newTestTable(t)
-	h := NewCredsSubHook(tbl)
+	h := NewCredsSubHook(tbl, nil)
 
 	req := httptest.NewRequest(http.MethodGet,
 		"http://api.example.com/v1/test?key=ghp_FAKE1234567890abcdef", nil)
@@ -378,7 +378,7 @@ func TestCredsSubHook_PreHook_ReplacesInQuery(t *testing.T) {
 
 func TestCredsSubHook_PreHook_ReplacesInPath(t *testing.T) {
 	tbl := newTestTable(t)
-	h := NewCredsSubHook(tbl)
+	h := NewCredsSubHook(tbl, nil)
 
 	req := httptest.NewRequest(http.MethodGet,
 		"http://api.example.com/v1/ghp_FAKE1234567890abcdef/info", nil)
@@ -468,6 +468,74 @@ func TestLeakGuardHook_FakeInPath_Returns403(t *testing.T) {
 	var abortErr *HookAbortError
 	if !errors.As(err, &abortErr) || abortErr.StatusCode != 403 {
 		t.Errorf("expected HookAbortError 403, got: %v", err)
+	}
+}
+
+func TestCredsSubHook_PostHook_ScrubDisabled(t *testing.T) {
+	tbl := newTestTable(t) // has "github" -> fake/real pair
+	// scrubServices does not include "github" -> PostHook should be a no-op
+	hook := NewCredsSubHook(tbl, map[string]bool{"other": true})
+
+	body := []byte(`{"key":"ghp_REAL1234567890abcdef"}`)
+	resp := &http.Response{
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+	ctx := &RequestContext{ServiceName: "github"}
+
+	err := hook.PostHook(resp, ctx)
+	if err != nil {
+		t.Fatalf("PostHook error: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if !bytes.Contains(got, []byte("ghp_REAL1234567890abcdef")) {
+		t.Error("expected real credential to remain (scrub disabled for this service)")
+	}
+}
+
+func TestCredsSubHook_PostHook_ScrubEnabled(t *testing.T) {
+	tbl := newTestTable(t)
+	hook := NewCredsSubHook(tbl, map[string]bool{"github": true})
+
+	body := []byte(`{"key":"ghp_REAL1234567890abcdef"}`)
+	resp := &http.Response{
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+	ctx := &RequestContext{ServiceName: "github"}
+
+	err := hook.PostHook(resp, ctx)
+	if err != nil {
+		t.Fatalf("PostHook error: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if bytes.Contains(got, []byte("ghp_REAL1234567890abcdef")) {
+		t.Error("expected real credential to be scrubbed")
+	}
+	if !bytes.Contains(got, []byte("ghp_FAKE1234567890abcdef")) {
+		t.Error("expected fake credential in scrubbed output")
+	}
+}
+
+func TestCredsSubHook_PostHook_NilScrubMap_ScrubsAll(t *testing.T) {
+	tbl := newTestTable(t)
+	// nil scrubServices = backward compat, scrub everything
+	hook := NewCredsSubHook(tbl, nil)
+
+	body := []byte(`{"key":"ghp_REAL1234567890abcdef"}`)
+	resp := &http.Response{
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+	ctx := &RequestContext{ServiceName: "github"}
+
+	err := hook.PostHook(resp, ctx)
+	if err != nil {
+		t.Fatalf("PostHook error: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	if bytes.Contains(got, []byte("ghp_REAL1234567890abcdef")) {
+		t.Error("expected real credential to be scrubbed (nil map = scrub all)")
 	}
 }
 

--- a/internal/session/envcheck.go
+++ b/internal/session/envcheck.go
@@ -1,0 +1,31 @@
+package session
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// CheckEnvCollisions returns an error if any service env var name
+// collides with an env_inject key. Both maps use env var names as keys.
+func CheckEnvCollisions(serviceEnv, envInject map[string]string) error {
+	if len(serviceEnv) == 0 || len(envInject) == 0 {
+		return nil
+	}
+	// Build normalized key set from envInject.
+	injectKeys := make(map[string]bool, len(envInject))
+	for k := range envInject {
+		injectKeys[envVarKey(k)] = true
+	}
+	var collisions []string
+	for name := range serviceEnv {
+		if injectKeys[envVarKey(name)] {
+			collisions = append(collisions, name)
+		}
+	}
+	if len(collisions) == 0 {
+		return nil
+	}
+	sort.Strings(collisions)
+	return fmt.Errorf("env_inject_service_collision: %s", strings.Join(collisions, ", "))
+}

--- a/internal/session/envcheck_test.go
+++ b/internal/session/envcheck_test.go
@@ -1,0 +1,65 @@
+package session
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCheckEnvCollisions_NoCollision(t *testing.T) {
+	serviceEnv := map[string]string{"GITHUB_TOKEN": "fake_gh"}
+	envInject := map[string]string{"MY_VAR": "value"}
+	if err := CheckEnvCollisions(serviceEnv, envInject); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCheckEnvCollisions_Collision(t *testing.T) {
+	serviceEnv := map[string]string{"GITHUB_TOKEN": "fake_gh"}
+	envInject := map[string]string{"GITHUB_TOKEN": "other_value"}
+	err := CheckEnvCollisions(serviceEnv, envInject)
+	if err == nil {
+		t.Fatal("expected error for collision")
+	}
+	if !strings.HasPrefix(err.Error(), "env_inject_service_collision:") {
+		t.Errorf("expected env_inject_service_collision prefix, got: %v", err)
+	}
+}
+
+func TestCheckEnvCollisions_BothNil(t *testing.T) {
+	if err := CheckEnvCollisions(nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCheckEnvCollisions_MultipleCollisions(t *testing.T) {
+	serviceEnv := map[string]string{"A": "1", "B": "2"}
+	envInject := map[string]string{"A": "x", "B": "y", "C": "z"}
+	err := CheckEnvCollisions(serviceEnv, envInject)
+	if err == nil {
+		t.Fatal("expected error for collisions")
+	}
+	if !strings.HasPrefix(err.Error(), "env_inject_service_collision:") {
+		t.Errorf("expected env_inject_service_collision prefix, got: %v", err)
+	}
+	// Verify both colliding names are in the error message
+	errStr := err.Error()
+	if !strings.Contains(errStr, "A") || !strings.Contains(errStr, "B") {
+		t.Errorf("error should mention both A and B: %v", err)
+	}
+}
+
+func TestCheckEnvCollisions_CaseInsensitiveWindows(t *testing.T) {
+	serviceEnv := map[string]string{"GITHUB_TOKEN": "fake"}
+	envInject := map[string]string{"github_token": "value"}
+	err := CheckEnvCollisions(serviceEnv, envInject)
+	if runtime.GOOS == "windows" {
+		if err == nil {
+			t.Fatal("expected collision on Windows")
+		}
+	} else {
+		if err != nil {
+			t.Fatalf("unexpected collision on POSIX: %v", err)
+		}
+	}
+}

--- a/internal/session/llmproxy.go
+++ b/internal/session/llmproxy.go
@@ -32,6 +32,7 @@ func StartLLMProxy(
 	logger *slog.Logger,
 	providers map[string]yaml.Node,
 	policyServices []policy.ServiceYAML,
+	envInject map[string]string,
 ) (string, func() error, error) {
 	if sess == nil {
 		return "", nil, fmt.Errorf("session is nil")
@@ -128,9 +129,25 @@ func StartLLMProxy(
 			return "", nil, fmt.Errorf("bootstrap credentials: %w", bsErr)
 		}
 
+		// Build and validate service env vars.
+		svcEnv, envErr := BuildServiceEnvVars(resolved.EnvVars, table)
+		if envErr != nil {
+			secretsCleanup()
+			_ = registry.Close()
+			_ = p.Stop(ctx)
+			return "", nil, fmt.Errorf("build service env vars: %w", envErr)
+		}
+		if err := CheckEnvCollisions(svcEnv, envInject); err != nil {
+			secretsCleanup()
+			_ = registry.Close()
+			_ = p.Stop(ctx)
+			return "", nil, fmt.Errorf("service env collision: %w", err)
+		}
+		sess.SetServiceEnvVars(svcEnv)
+
 		// Register hooks: leak guard first, then creds substitution (both global).
 		leakGuard := proxy.NewLeakGuardHook(table, logger)
-		credsSub := proxy.NewCredsSubHook(table)
+		credsSub := proxy.NewCredsSubHook(table, resolved.ScrubServices)
 		p.HookRegistry().Register("", leakGuard)
 		p.HookRegistry().Register("", credsSub)
 

--- a/internal/session/llmproxy_test.go
+++ b/internal/session/llmproxy_test.go
@@ -57,7 +57,7 @@ func TestStartLLMProxy(t *testing.T) {
 
 	// Start the proxy
 	mcpCfg := config.SandboxMCPConfig{}
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, storagePath, logger, nil, nil)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, storagePath, logger, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestStartLLMProxy_NilSession(t *testing.T) {
 	storageCfg := config.DefaultLLMStorageConfig()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	_, _, err := StartLLMProxy(nil, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger, nil, nil)
+	_, _, err := StartLLMProxy(nil, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger, nil, nil, nil)
 	if err == nil {
 		t.Error("expected error for nil session")
 	}
@@ -213,7 +213,7 @@ func TestSession_LLMProxyEnvVars_Integration(t *testing.T) {
 	storageCfg := config.DefaultLLMStorageConfig()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger, nil, nil)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestSession_CloseProxy(t *testing.T) {
 	storageCfg := config.DefaultLLMStorageConfig()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, _, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger, nil, nil)
+	proxyURL, _, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -361,7 +361,7 @@ func TestStartLLMProxy_WithDLP(t *testing.T) {
 	storageCfg := config.DefaultLLMStorageConfig()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger, nil, nil)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -423,7 +423,7 @@ func TestStartLLMProxy_SessionIDInEnvVars(t *testing.T) {
 	storageCfg := config.DefaultLLMStorageConfig()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	_, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger, nil, nil)
+	_, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, config.SandboxMCPConfig{}, t.TempDir(), logger, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -518,7 +518,7 @@ func TestStartLLMProxy_MCPOnlyMode(t *testing.T) {
 	storagePath := t.TempDir()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, storagePath, logger, nil, nil)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, storagePath, logger, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -604,7 +604,7 @@ func TestStartLLMProxy_MCPConfigPassedThrough(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -669,7 +669,7 @@ func TestStartLLMProxy_CreatesRegistry(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -769,7 +769,7 @@ func TestStartLLMProxy_MCPOnlyWithoutPolicy(t *testing.T) {
 			storageCfg := config.DefaultLLMStorageConfig()
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-			proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, tt.mcpCfg, t.TempDir(), logger, nil, nil)
+			proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, tt.mcpCfg, t.TempDir(), logger, nil, nil, nil)
 			if err != nil {
 				t.Fatalf("StartLLMProxy failed: %v", err)
 			}
@@ -836,7 +836,7 @@ func TestStartLLMProxy_NoRegistryWhenPolicyDisabled(t *testing.T) {
 	mcpCfg := config.SandboxMCPConfig{}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -887,7 +887,7 @@ func TestSession_MCPRegistryClearedOnClose(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	_, _, err = StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil)
+	_, _, err = StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -1017,7 +1017,7 @@ func TestStartLLMProxy_NetworkServerDeclarations(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -1097,7 +1097,7 @@ func TestStartLLMProxy_StdioPreRegistrationNoMultiServerCallback(t *testing.T) {
 	}
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil)
+	proxyURL, closeFn, err := StartLLMProxy(sess, proxyCfg, dlpCfg, storageCfg, mcpCfg, t.TempDir(), logger, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("StartLLMProxy failed: %v", err)
 	}
@@ -1128,5 +1128,38 @@ func TestStartLLMProxy_StdioPreRegistrationNoMultiServerCallback(t *testing.T) {
 
 	if multiServerFired {
 		t.Error("OnMultiServer should not fire: only one server (network) was pre-registered; stdio was skipped")
+	}
+}
+
+func TestSession_ServiceEnvVars_Nil(t *testing.T) {
+	sess := &Session{ID: "test"}
+	result := sess.ServiceEnvVars()
+	if result != nil {
+		t.Errorf("expected nil, got %v", result)
+	}
+}
+
+func TestSession_ServiceEnvVars_Set(t *testing.T) {
+	sess := &Session{ID: "test"}
+	envMap := map[string]string{"GITHUB_TOKEN": "fake_gh"}
+	sess.SetServiceEnvVars(envMap)
+	result := sess.ServiceEnvVars()
+	if len(result) != 1 {
+		t.Fatalf("expected 1 var, got %d", len(result))
+	}
+	if result["GITHUB_TOKEN"] != "fake_gh" {
+		t.Errorf("GITHUB_TOKEN = %q", result["GITHUB_TOKEN"])
+	}
+}
+
+func TestSession_ServiceEnvVars_DeepCopy(t *testing.T) {
+	sess := &Session{ID: "test"}
+	original := map[string]string{"K": "V"}
+	sess.SetServiceEnvVars(original)
+	result := sess.ServiceEnvVars()
+	result["K"] = "mutated"
+	result2 := sess.ServiceEnvVars()
+	if result2["K"] != "V" {
+		t.Error("ServiceEnvVars should return a copy")
 	}
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -89,6 +89,11 @@ type Session struct {
 
 	// secretsClose zeros the credsTable on session close. Nil if no secrets.
 	secretsClose func()
+
+	// serviceEnvVars holds fake credentials keyed by env var name.
+	// Injected into spawned processes bypassing policy filtering.
+	// Nil if no services declare inject.env.
+	serviceEnvVars map[string]string
 }
 
 // SetPolicyEngine stores the session-specific policy engine with expanded variables.
@@ -120,6 +125,28 @@ func (s *Session) SetCredsTable(t *credsub.Table, closeFn func()) {
 	defer s.mu.Unlock()
 	s.credsTable = t
 	s.secretsClose = closeFn
+}
+
+// SetServiceEnvVars stores the service env var map on the session.
+func (s *Session) SetServiceEnvVars(env map[string]string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.serviceEnvVars = env
+}
+
+// ServiceEnvVars returns a copy of the service env var map.
+// Returns nil if no services declare inject.env.
+func (s *Session) ServiceEnvVars() map[string]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.serviceEnvVars == nil {
+		return nil
+	}
+	out := make(map[string]string, len(s.serviceEnvVars))
+	for k, v := range s.serviceEnvVars {
+		out[k] = v
+	}
+	return out
 }
 
 type Manager struct {
@@ -535,6 +562,7 @@ func (s *Session) CloseLLMProxy() error {
 	s.mcpRegistry = nil
 	s.credsTable = nil
 	s.secretsClose = nil
+	s.serviceEnvVars = nil
 	s.mu.Unlock()
 	// Stop proxy first so in-flight requests finish with a populated table.
 	var proxyErr error

--- a/internal/session/secrets.go
+++ b/internal/session/secrets.go
@@ -4,10 +4,23 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"runtime"
+	"strings"
 
 	"github.com/agentsh/agentsh/internal/proxy/credsub"
 	"github.com/agentsh/agentsh/internal/proxy/secrets"
 )
+
+// envVarKey returns the map key for duplicate env-var detection.
+// On Windows, environment variable names are case-insensitive,
+// so we fold to upper-case. On POSIX systems, names are
+// case-sensitive and used as-is.
+func envVarKey(name string) string {
+	if runtime.GOOS == "windows" {
+		return strings.ToUpper(name)
+	}
+	return name
+}
 
 // ServiceConfig describes one secret-backed service for credential
 // substitution. Plan 5 uses this struct directly; future plans will
@@ -85,4 +98,45 @@ func LogSecretsInitialized(logger *slog.Logger, sessionID string, serviceCount i
 		"session_id", sessionID,
 		"service_count", serviceCount,
 	)
+}
+
+// BuildServiceEnvVars builds a map of env var name -> fake credential
+// for services that declare inject.env. Looks up each service's fake
+// from the table; services not found in the table are silently skipped.
+// Returns an error if two different services declare the same env var name.
+func BuildServiceEnvVars(envVars []ServiceEnvVar, table *credsub.Table) (map[string]string, error) {
+	if len(envVars) == 0 {
+		return nil, nil
+	}
+
+	// Validate names and detect duplicates first (no table access needed).
+	owner := make(map[string]string, len(envVars))
+	for _, ev := range envVars {
+		if ev.VarName == "" || strings.ContainsAny(ev.VarName, "=\x00") {
+			return nil, fmt.Errorf("invalid service env var name %q for service %q", ev.VarName, ev.ServiceName)
+		}
+		key := envVarKey(ev.VarName)
+		if prev, dup := owner[key]; dup {
+			return nil, fmt.Errorf("duplicate service env var %q (services %q and %q)", ev.VarName, prev, ev.ServiceName)
+		}
+		owner[key] = ev.ServiceName
+	}
+
+	if table == nil {
+		return nil, nil
+	}
+
+	// Build the env var map from table lookups.
+	result := make(map[string]string, len(envVars))
+	for _, ev := range envVars {
+		fake, ok := table.FakeForService(ev.ServiceName)
+		if !ok {
+			continue
+		}
+		result[ev.VarName] = string(fake)
+	}
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result, nil
 }

--- a/internal/session/secrets_integration_test.go
+++ b/internal/session/secrets_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -175,5 +176,146 @@ func TestIntegration_PolicyYAML_FullFlow(t *testing.T) {
 	err = leakGuard.PreHook(leakReq2, &proxy.RequestContext{})
 	if err == nil {
 		t.Error("LeakGuard should block fakes to unmatched hosts")
+	}
+}
+
+func TestEnvVarInjection_CompositionFlow(t *testing.T) {
+	// 1. Define service YAML with inject.env and scrub_response.
+	svcs := []policy.ServiceYAML{
+		{
+			Name:          "github",
+			Match:         policy.ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret:        policy.ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:          policy.ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			ScrubResponse: true,
+			Inject: policy.ServiceInjectYAML{
+				Header: &policy.ServiceInjectHeaderYAML{
+					Name: "Authorization", Template: "Bearer {{secret}}",
+				},
+				Env: []policy.ServiceInjectEnvYAML{
+					{Name: "GITHUB_TOKEN"},
+					{Name: "GH_TOKEN"},
+				},
+			},
+		},
+		{
+			Name:   "stripe",
+			Match:  policy.ServiceMatchYAML{Hosts: []string{"api.stripe.com"}},
+			Secret: policy.ServiceSecretYAML{Ref: "keyring://agentsh/stripe"},
+			Fake:   policy.ServiceFakeYAML{Format: "xk_test_{rand:24}"},
+			Inject: policy.ServiceInjectYAML{
+				Env: []policy.ServiceInjectEnvYAML{
+					{Name: "STRIPE_API_KEY"},
+				},
+			},
+			// ScrubResponse intentionally false
+		},
+	}
+
+	// 2. Resolve services.
+	resolved, err := ResolveServiceConfigs(svcs)
+	if err != nil {
+		t.Fatalf("ResolveServiceConfigs: %v", err)
+	}
+
+	// Verify env vars resolved.
+	if len(resolved.EnvVars) != 3 {
+		t.Fatalf("expected 3 env vars, got %d", len(resolved.EnvVars))
+	}
+
+	// Verify scrub config.
+	if !resolved.ScrubServices["github"] {
+		t.Error("github should be in ScrubServices")
+	}
+	if resolved.ScrubServices["stripe"] {
+		t.Error("stripe should NOT be in ScrubServices")
+	}
+	// ScrubServices should be non-nil (services are configured).
+	if resolved.ScrubServices == nil {
+		t.Fatal("ScrubServices should be non-nil")
+	}
+
+	// 3. Bootstrap credentials with a memory provider.
+	mp := &memoryProvider{
+		secrets: map[string][]byte{
+			"agentsh/gh":     []byte("ghp_realABCDEFGHIJKLMNOPQRSTUVWXYZ123456"),
+			"agentsh/stripe": []byte("xk_test_realABCDEFGHIJKLMNOPQRST"),
+		},
+	}
+	table, cleanup, err := BootstrapCredentials(context.Background(), mp, resolved.ServiceConfigs)
+	if err != nil {
+		t.Fatalf("BootstrapCredentials: %v", err)
+	}
+	defer cleanup()
+
+	// 4. Build service env vars.
+	svcEnv, envErr := BuildServiceEnvVars(resolved.EnvVars, table)
+	if envErr != nil {
+		t.Fatalf("BuildServiceEnvVars: %v", envErr)
+	}
+	if len(svcEnv) != 3 {
+		t.Fatalf("expected 3 service env vars, got %d", len(svcEnv))
+	}
+	if _, ok := svcEnv["GITHUB_TOKEN"]; !ok {
+		t.Error("GITHUB_TOKEN missing from service env vars")
+	}
+	if _, ok := svcEnv["GH_TOKEN"]; !ok {
+		t.Error("GH_TOKEN missing from service env vars")
+	}
+	if _, ok := svcEnv["STRIPE_API_KEY"]; !ok {
+		t.Error("STRIPE_API_KEY missing from service env vars")
+	}
+
+	// Verify env var values are the fake credentials.
+	ghFake, _ := table.FakeForService("github")
+	if svcEnv["GITHUB_TOKEN"] != string(ghFake) {
+		t.Errorf("GITHUB_TOKEN value doesn't match fake")
+	}
+	// Both GITHUB_TOKEN and GH_TOKEN should have the same fake (same service).
+	if svcEnv["GH_TOKEN"] != string(ghFake) {
+		t.Errorf("GH_TOKEN value doesn't match fake")
+	}
+
+	// 5. Collision detection: no collision.
+	envInject := map[string]string{"PATH": "/usr/bin"}
+	if err := CheckEnvCollisions(svcEnv, envInject); err != nil {
+		t.Fatalf("unexpected collision: %v", err)
+	}
+
+	// 6. Collision detection: collision.
+	envInjectBad := map[string]string{"GITHUB_TOKEN": "something_else"}
+	if err := CheckEnvCollisions(svcEnv, envInjectBad); err == nil {
+		t.Error("expected collision error")
+	}
+
+	// 7. Scrub toggle: github has scrub_response=true, stripe does not.
+	credsHook := proxy.NewCredsSubHook(table, resolved.ScrubServices)
+
+	// Response from github should be scrubbed (real -> fake).
+	ghRespBody := []byte(`{"echoed":"ghp_realABCDEFGHIJKLMNOPQRSTUVWXYZ123456"}`)
+	ghResp := &http.Response{
+		Body:          io.NopCloser(bytes.NewReader(ghRespBody)),
+		ContentLength: int64(len(ghRespBody)),
+	}
+	if err := credsHook.PostHook(ghResp, &proxy.RequestContext{ServiceName: "github"}); err != nil {
+		t.Fatalf("PostHook github: %v", err)
+	}
+	ghGot, _ := io.ReadAll(ghResp.Body)
+	if bytes.Contains(ghGot, []byte("ghp_realABCDEFGHIJKLMNOPQRSTUVWXYZ123456")) {
+		t.Error("github response should have real credential scrubbed")
+	}
+
+	// Response from stripe should NOT be scrubbed (scrub_response not set).
+	stripeRespBody := []byte(`{"echoed":"xk_test_realABCDEFGHIJKLMNOPQRST"}`)
+	stripeResp := &http.Response{
+		Body:          io.NopCloser(bytes.NewReader(stripeRespBody)),
+		ContentLength: int64(len(stripeRespBody)),
+	}
+	if err := credsHook.PostHook(stripeResp, &proxy.RequestContext{ServiceName: "stripe"}); err != nil {
+		t.Fatalf("PostHook stripe: %v", err)
+	}
+	stripeGot, _ := io.ReadAll(stripeResp.Body)
+	if !bytes.Contains(stripeGot, []byte("xk_test_realABCDEFGHIJKLMNOPQRST")) {
+		t.Error("stripe response should NOT be scrubbed (scrub_response not set)")
 	}
 }

--- a/internal/session/secrets_test.go
+++ b/internal/session/secrets_test.go
@@ -3,8 +3,10 @@ package session
 import (
 	"context"
 	"errors"
+	"runtime"
 	"testing"
 
+	"github.com/agentsh/agentsh/internal/proxy/credsub"
 	"github.com/agentsh/agentsh/internal/proxy/secrets"
 )
 
@@ -197,5 +199,217 @@ func TestBootstrapCredentials_Cleanup_ZerosTable(t *testing.T) {
 
 	if table.Len() != 0 {
 		t.Errorf("table.Len() = %d after cleanup, want 0", table.Len())
+	}
+}
+
+func TestBuildServiceEnvVars(t *testing.T) {
+	mp := &memoryProvider{
+		secrets: map[string][]byte{
+			"github/token": []byte("ghp_realABCDEFGHIJKLMNOPQRSTUVWXYZ123456"),
+		},
+	}
+	services := []ServiceConfig{
+		{
+			Name:       "github",
+			SecretRef:  secrets.SecretRef{Scheme: "memory", Host: "github", Path: "token"},
+			FakeFormat: "ghp_{rand:36}",
+		},
+	}
+	table, cleanup, err := BootstrapCredentials(context.Background(), mp, services)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	envVars := []ServiceEnvVar{
+		{ServiceName: "github", VarName: "GITHUB_TOKEN"},
+	}
+	result, err := BuildServiceEnvVars(envVars, table)
+	if err != nil {
+		t.Fatalf("BuildServiceEnvVars returned error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("expected 1 env var, got %d", len(result))
+	}
+	val, ok := result["GITHUB_TOKEN"]
+	if !ok {
+		t.Fatal("GITHUB_TOKEN not in result")
+	}
+	if len(val) != 40 {
+		t.Errorf("value length = %d, want 40", len(val))
+	}
+	if val[:4] != "ghp_" {
+		t.Errorf("value prefix = %q, want ghp_", val[:4])
+	}
+}
+
+func TestBuildServiceEnvVars_UnknownService(t *testing.T) {
+	table := credsub.New()
+	envVars := []ServiceEnvVar{
+		{ServiceName: "nonexistent", VarName: "FOO"},
+	}
+	result, err := BuildServiceEnvVars(envVars, table)
+	if err != nil {
+		t.Fatalf("BuildServiceEnvVars returned error: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %v", result)
+	}
+}
+
+func TestBuildServiceEnvVars_Empty(t *testing.T) {
+	table := credsub.New()
+	result, err := BuildServiceEnvVars(nil, table)
+	if err != nil {
+		t.Fatalf("BuildServiceEnvVars returned error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil, got %v", result)
+	}
+}
+
+func TestBuildServiceEnvVars_DuplicateName(t *testing.T) {
+	mp := &memoryProvider{
+		secrets: map[string][]byte{
+			"github/token": []byte("ghp_realABCDEFGHIJKLMNOPQRSTUVWXYZ123456"),
+			"gitlab/token": []byte("glpat-realABCDEFGHIJKLMNOPQRSTUVWXYZ12345"),
+		},
+	}
+	services := []ServiceConfig{
+		{
+			Name:       "github",
+			SecretRef:  secrets.SecretRef{Scheme: "memory", Host: "github", Path: "token"},
+			FakeFormat: "ghp_{rand:36}",
+		},
+		{
+			Name:       "gitlab",
+			SecretRef:  secrets.SecretRef{Scheme: "memory", Host: "gitlab", Path: "token"},
+			FakeFormat: "glpat-{rand:35}",
+		},
+	}
+	table, cleanup, err := BootstrapCredentials(context.Background(), mp, services)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	envVars := []ServiceEnvVar{
+		{ServiceName: "github", VarName: "TOKEN"},
+		{ServiceName: "gitlab", VarName: "TOKEN"},
+	}
+	_, err = BuildServiceEnvVars(envVars, table)
+	if err == nil {
+		t.Fatal("expected error for duplicate env var name")
+	}
+	want := `duplicate service env var "TOKEN" (services "github" and "gitlab")`
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestBuildServiceEnvVars_CaseDifferentNames(t *testing.T) {
+	table := credsub.New()
+	_ = table.Add("svc1", []byte("fake1_ABCDEFGHIJKLMNOPQRSTUVWX"), []byte("real1_ABCDEFGHIJKLMNOPQRSTUVWX"))
+	_ = table.Add("svc2", []byte("fake2_ABCDEFGHIJKLMNOPQRSTUVWX"), []byte("real2_ABCDEFGHIJKLMNOPQRSTUVWX"))
+
+	envVars := []ServiceEnvVar{
+		{ServiceName: "svc1", VarName: "TOKEN"},
+		{ServiceName: "svc2", VarName: "token"},
+	}
+	result, err := BuildServiceEnvVars(envVars, table)
+	if runtime.GOOS == "windows" {
+		// Windows: case-insensitive, should collide
+		if err == nil {
+			t.Fatal("expected collision on Windows")
+		}
+	} else {
+		// POSIX: case-sensitive, both should work
+		if err != nil {
+			t.Fatalf("unexpected error on POSIX: %v", err)
+		}
+		if len(result) != 2 {
+			t.Errorf("expected 2 vars, got %d", len(result))
+		}
+	}
+}
+
+func TestBuildServiceEnvVars_DuplicateName_MissingFromTable(t *testing.T) {
+	// Only github is in the table; gitlab is missing.
+	// The duplicate should still be detected even though gitlab
+	// would be skipped during table lookup.
+	mp := &memoryProvider{
+		secrets: map[string][]byte{
+			"github/token": []byte("ghp_realABCDEFGHIJKLMNOPQRSTUVWXYZ123456"),
+		},
+	}
+	services := []ServiceConfig{
+		{
+			Name:       "github",
+			SecretRef:  secrets.SecretRef{Scheme: "memory", Host: "github", Path: "token"},
+			FakeFormat: "ghp_{rand:36}",
+		},
+	}
+	table, cleanup, err := BootstrapCredentials(context.Background(), mp, services)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	envVars := []ServiceEnvVar{
+		{ServiceName: "github", VarName: "TOKEN"},
+		{ServiceName: "gitlab", VarName: "TOKEN"}, // gitlab not in table
+	}
+	_, err = BuildServiceEnvVars(envVars, table)
+	if err == nil {
+		t.Fatal("expected error for duplicate env var name even when service is missing from table")
+	}
+	want := `duplicate service env var "TOKEN" (services "github" and "gitlab")`
+	if err.Error() != want {
+		t.Errorf("error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestBuildServiceEnvVars_NilTable(t *testing.T) {
+	envVars := []ServiceEnvVar{
+		{ServiceName: "github", VarName: "GITHUB_TOKEN"},
+	}
+	result, err := BuildServiceEnvVars(envVars, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil, got %v", result)
+	}
+}
+
+func TestBuildServiceEnvVars_NilTable_StillValidates(t *testing.T) {
+	envVars := []ServiceEnvVar{
+		{ServiceName: "svc", VarName: ""},
+	}
+	_, err := BuildServiceEnvVars(envVars, nil)
+	if err == nil {
+		t.Fatal("expected validation error even with nil table")
+	}
+}
+
+func TestBuildServiceEnvVars_InvalidName_Empty(t *testing.T) {
+	table := credsub.New()
+	envVars := []ServiceEnvVar{
+		{ServiceName: "svc", VarName: ""},
+	}
+	_, err := BuildServiceEnvVars(envVars, table)
+	if err == nil {
+		t.Fatal("expected error for empty name")
+	}
+}
+
+func TestBuildServiceEnvVars_InvalidName_ContainsEquals(t *testing.T) {
+	table := credsub.New()
+	envVars := []ServiceEnvVar{
+		{ServiceName: "svc", VarName: "PATH=/tmp"},
+	}
+	_, err := BuildServiceEnvVars(envVars, table)
+	if err == nil {
+		t.Fatal("expected error for name containing =")
 	}
 }

--- a/internal/session/secretsconfig.go
+++ b/internal/session/secretsconfig.go
@@ -19,11 +19,20 @@ type InjectHeaderConfig struct {
 	Template    string
 }
 
+// ServiceEnvVar maps a service name to an env var that should receive
+// the service's fake credential.
+type ServiceEnvVar struct {
+	ServiceName string
+	VarName     string
+}
+
 // ResolvedServices holds the parsed outputs needed by the bootstrap flow.
 type ResolvedServices struct {
 	ServiceConfigs []ServiceConfig
 	Patterns       []services.ServicePattern
 	InjectHeaders  []InjectHeaderConfig
+	EnvVars        []ServiceEnvVar // inject.env entries
+	ScrubServices  map[string]bool // service name -> scrub_response flag
 }
 
 // ResolveProviderConfigs decodes policy YAML provider nodes into
@@ -53,6 +62,7 @@ func ResolveServiceConfigs(svcs []policy.ServiceYAML) (*ResolvedServices, error)
 	result := &ResolvedServices{
 		ServiceConfigs: make([]ServiceConfig, 0, len(svcs)),
 		Patterns:       make([]services.ServicePattern, 0, len(svcs)),
+		ScrubServices:  make(map[string]bool),
 	}
 	for _, svc := range svcs {
 		ref, err := secrets.ParseRef(svc.Secret.Ref)
@@ -74,6 +84,15 @@ func ResolveServiceConfigs(svcs []policy.ServiceYAML) (*ResolvedServices, error)
 				HeaderName:  svc.Inject.Header.Name,
 				Template:    svc.Inject.Header.Template,
 			})
+		}
+		for _, ev := range svc.Inject.Env {
+			result.EnvVars = append(result.EnvVars, ServiceEnvVar{
+				ServiceName: svc.Name,
+				VarName:     ev.Name,
+			})
+		}
+		if svc.ScrubResponse {
+			result.ScrubServices[svc.Name] = true
 		}
 	}
 	return result, nil

--- a/internal/session/secretsconfig_test.go
+++ b/internal/session/secretsconfig_test.go
@@ -108,3 +108,82 @@ func TestResolveServiceConfigs_Empty(t *testing.T) {
 		t.Error("expected nil")
 	}
 }
+
+func TestResolveServiceConfigs_InjectEnv(t *testing.T) {
+	svcs := []policy.ServiceYAML{
+		{
+			Name:   "github",
+			Match:  policy.ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret: policy.ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:   policy.ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			Inject: policy.ServiceInjectYAML{
+				Env: []policy.ServiceInjectEnvYAML{{Name: "GITHUB_TOKEN"}},
+			},
+		},
+	}
+	result, err := ResolveServiceConfigs(svcs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.EnvVars) != 1 {
+		t.Fatalf("expected 1 env var, got %d", len(result.EnvVars))
+	}
+	if result.EnvVars[0].ServiceName != "github" {
+		t.Errorf("ServiceName = %q, want github", result.EnvVars[0].ServiceName)
+	}
+	if result.EnvVars[0].VarName != "GITHUB_TOKEN" {
+		t.Errorf("VarName = %q, want GITHUB_TOKEN", result.EnvVars[0].VarName)
+	}
+}
+
+func TestResolveServiceConfigs_ScrubResponse_NoneEnabled(t *testing.T) {
+	svcs := []policy.ServiceYAML{
+		{
+			Name:   "github",
+			Match:  policy.ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret: policy.ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:   policy.ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			// ScrubResponse intentionally NOT set (defaults to false)
+		},
+	}
+	result, err := ResolveServiceConfigs(svcs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// ScrubServices must be non-nil (empty map), NOT nil.
+	// nil would mean "scrub all" in CredsSubHook.
+	if result.ScrubServices == nil {
+		t.Fatal("ScrubServices should be non-nil empty map, got nil")
+	}
+	if len(result.ScrubServices) != 0 {
+		t.Errorf("ScrubServices should be empty, got %v", result.ScrubServices)
+	}
+}
+
+func TestResolveServiceConfigs_ScrubResponse(t *testing.T) {
+	svcs := []policy.ServiceYAML{
+		{
+			Name:          "github",
+			Match:         policy.ServiceMatchYAML{Hosts: []string{"api.github.com"}},
+			Secret:        policy.ServiceSecretYAML{Ref: "keyring://agentsh/gh"},
+			Fake:          policy.ServiceFakeYAML{Format: "ghp_{rand:36}"},
+			ScrubResponse: true,
+		},
+		{
+			Name:   "stripe",
+			Match:  policy.ServiceMatchYAML{Hosts: []string{"api.stripe.com"}},
+			Secret: policy.ServiceSecretYAML{Ref: "keyring://agentsh/stripe"},
+			Fake:   policy.ServiceFakeYAML{Format: "xk_test_{rand:24}"},
+		},
+	}
+	result, err := ResolveServiceConfigs(svcs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.ScrubServices["github"] {
+		t.Error("expected github in ScrubServices")
+	}
+	if result.ScrubServices["stripe"] {
+		t.Error("stripe should not be in ScrubServices")
+	}
+}


### PR DESCRIPTION
## Summary
- Wire service fake credentials into spawned agent environments via `inject.env` policy config, with collision detection against operator `env_inject`
- Make response body scrubbing conditional per-service via `scrub_response` flag in `CredsSubHook`
- Validate `inject.env` names at policy load time (empty, invalid chars, cross-service duplicates, reserved `AGENTSH_` prefix with case-insensitive check)
- Inject service env vars in all three exec paths (exec, streaming exec, PTY) bypassing policy filtering since vars like `GITHUB_TOKEN` are in the default-deny list

## Test plan
- [x] Unit tests for `BuildServiceEnvVars` (happy path, unknown service, empty input, duplicate name, OS-aware case folding, nil table, invalid name)
- [x] Unit tests for `CheckEnvCollisions` (no collision, single/multiple collisions, both nil, case-insensitive on Windows)
- [x] Unit tests for `ValidateSecrets` inject.env validation (empty name, invalid char, duplicate, valid, reserved prefix case-insensitive)
- [x] Unit tests for `CredsSubHook` scrub toggle (disabled, enabled, nil map backward compat)
- [x] Unit tests for `Session.ServiceEnvVars` (nil, set, deep copy)
- [x] Composition test for full injection + collision detection + scrub flow
- [x] `go test ./...` passes
- [x] `GOOS=windows go build ./...` cross-compile passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)