### PR TITLE
feat: AWS Secrets Manager provider (Plan 8)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,14 +10,14 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets v1.4.0
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/UserExistsError/conpty v0.1.4
-	github.com/aws/aws-sdk-go-v2 v1.41.4
+	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.6
 	github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.64.1
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.73.2
 	github.com/aws/aws-sdk-go-v2/service/kms v1.49.4
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0
-	github.com/aws/aws-sdk-go-v2/service/sts v1.41.5
+	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10
 	github.com/cilium/ebpf v0.20.0
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/creack/pty v1.1.18
@@ -75,11 +75,11 @@ require (
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.16 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/UserExistsError/conpty v0.1.4 h1:+3FhJhiqhyEJa+K5qaK3/w6w+sN3Nh9O9VbJ
 github.com/UserExistsError/conpty v0.1.4/go.mod h1:PDglKIkX3O/2xVk0MV9a6bCWxRmPVfxqZoTG/5sSd9I=
 github.com/aws/aws-sdk-go-v2 v1.41.4 h1:10f50G7WyU02T56ox1wWXq+zTX9I1zxG46HYuG1hH/k=
 github.com/aws/aws-sdk-go-v2 v1.41.4/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
+github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
+github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7 h1:3kGOqnh1pPeddVa/E37XNTaWJ8W6vrbYV9lJEkCnhuY=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
 github.com/aws/aws-sdk-go-v2/config v1.32.6 h1:hFLBGUKjmLAekvi1evLi5hVvFQtSo3GYwi+Bx4lpJf8=
@@ -50,8 +52,12 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16 h1:80+uETIWS1BqjnN9uJ0dBU
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.16/go.mod h1:wOOsYuxYuB/7FlnVtzeBYRcjSRtQpAW0hCP7tIULMwo=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 h1:CNXO7mvgThFGqOFgbNAP2nol2qAWBOGfqR/7tQlvLmc=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20/go.mod h1:oydPDJKcfMhgfcgBUZaG+toBbwy8yPWubJXBVERtI4o=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 h1:tN6W/hg+pkM+tf9XDkWUbDEjGLb+raoBMFsTodcoYKw=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20/go.mod h1:YJ898MhD067hSHA6xYCx5ts/jEd8BSOLtQDL3iZsvbc=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 h1:PEgGVtPoB6NTpPrBgqSE5hE/o47Ij9qk/SEZFbUOe9A=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21/go.mod h1:p+hz+PRAYlY3zcpJhPwXlLC4C+kqn70WIHwnzAfs6ps=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4 h1:WKuaxf++XKWlHWu9ECbMlha8WOEGm0OUEZqm4K/Gcfk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.4/go.mod h1:ZWy7j6v1vWGmPReu0iSGvRiise4YI5SkR3OHKTZ6Wuc=
 github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs v1.64.1 h1:O0hE9Wepd/nkAKdbgGpHRrOBH6Dy2CNn+ZHoOumm5TA=
@@ -60,8 +66,12 @@ github.com/aws/aws-sdk-go-v2/service/ecs v1.73.2 h1:ENHzo6/jTaaNgaetLNujQsiZIYSQ
 github.com/aws/aws-sdk-go-v2/service/ecs v1.73.2/go.mod h1:10kBgdaNJz0FO/+JWDUH+0rtSjkn5yafgavDDmmhFzs=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4 h1:0ryTNEdJbzUCEWkVXEXoqlXV72J5keC1GvILMOuD00E=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.4/go.mod h1:HQ4qwNZh32C3CBeO6iJLQlgtMzqeG17ziAA/3KDJFow=
+github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 h1:5EniKhLZe4xzL7a+fU3C2tfUN4nWIqlLesfrjkuPFTY=
+github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7/go.mod h1:x0nZssQ3qZSnIcePWLvcoFisRXJzcTVvYpAAdYX8+GI=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.16 h1:oHjJHeUy0ImIV0bsrX0X91GkV5nJAyv1l1CC9lnO0TI=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.16/go.mod h1:iRSNGgOYmiYwSCXxXaKb9HfOEj40+oTKn8pTxMlYkRM=
+github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21 h1:c31//R3xgIJMSC8S6hEVq+38DcvUlgFY0FM6mSI5oto=
+github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.21/go.mod h1:r6+pf23ouCB718FUxaqzZdbpYFyDtehyZcmP5KL9FkA=
 github.com/aws/aws-sdk-go-v2/service/kms v1.49.4 h1:2gom8MohxN0SnhHZBYAC4S8jHG+ENEnXjyJ5xKe3vLc=
 github.com/aws/aws-sdk-go-v2/service/kms v1.49.4/go.mod h1:HO31s0qt0lso/ADvZQyzKs8js/ku0fMHsfyXW8OPVYc=
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.0 h1:vL6rQXcGtFv9q/9eRPdI+lL+dvTm7xKGZYSHEvmrpDk=
@@ -74,6 +84,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.12 h1:AHDr0DaHIAo8c9t1emrzAlV
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.12/go.mod h1:GQ73XawFFiWxyWXMHWfhiomvP3tXtdNar/fi8z18sx0=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.5 h1:SciGFVNZ4mHdm7gpD1dgZYnCuVdX1s+lFTg4+4DOy70=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.5/go.mod h1:iW40X4QBmUxdP+fZNOpfmkdMZqsovezbAeO+Ubiv2pk=
+github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 h1:p8ogvvLugcR/zLBXTXrTkj0RYBUdErbMnAFFp12Lm/U=
+github.com/aws/aws-sdk-go-v2/service/sts v1.41.10/go.mod h1:60dv0eZJfeVXfbT1tFJinbHrDfSJ2GZl4Q//OSSNAVw=
 github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
 github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=

--- a/internal/policy/secrets.go
+++ b/internal/policy/secrets.go
@@ -59,6 +59,7 @@ type ServiceInjectEnvYAML struct {
 var knownProviderTypes = map[string]bool{
 	"keyring": true,
 	"vault":   true,
+	"aws-sm":  true,
 }
 
 // ValidateSecrets validates the providers and services sections of a Policy.

--- a/internal/policy/secrets_test.go
+++ b/internal/policy/secrets_test.go
@@ -324,3 +324,27 @@ func TestValidateSecrets_InjectEnvReservedPrefix(t *testing.T) {
 		t.Errorf("error should mention reserved prefix, got: %v", err)
 	}
 }
+
+func TestValidateSecrets_AWSProvider(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"aws_sm": mustNode(t, "type: aws-sm\nregion: us-east-1"),
+	}
+	services := []ServiceYAML{
+		{
+			Name:   "myservice",
+			Match:  ServiceMatchYAML{Hosts: []string{"api.example.com"}},
+			Secret: ServiceSecretYAML{Ref: "aws-sm://prod/my-secret#token"},
+			Fake:   ServiceFakeYAML{Format: "tok_{rand:36}"},
+			Inject: ServiceInjectYAML{Header: &ServiceInjectHeaderYAML{
+				Name: "Authorization", Template: "Bearer {{secret}}",
+			}},
+		},
+	}
+	warnings, err := ValidateSecrets(providers, services)
+	if err != nil {
+		t.Fatalf("ValidateSecrets error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+}

--- a/internal/proxy/secrets/awssm/config.go
+++ b/internal/proxy/secrets/awssm/config.go
@@ -1,0 +1,26 @@
+package awssm
+
+import (
+	secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
+)
+
+// Config configures the AWS Secrets Manager provider.
+//
+// Config satisfies secrets.ProviderConfig by embedding
+// secrets.ProviderConfigMarker.
+type Config struct {
+	secrets.ProviderConfigMarker
+
+	// Region is the AWS region to use (e.g. "us-east-1"). Required.
+	Region string
+}
+
+// TypeName returns "aws-sm". Used by the registry to map aws-sm://
+// URI scheme refs to this provider.
+func (Config) TypeName() string { return "aws-sm" }
+
+// Compile-time assertions.
+var (
+	_ secrets.ProviderConfig = Config{}
+	_ secrets.SecretProvider = (*Provider)(nil)
+)

--- a/internal/proxy/secrets/awssm/doc.go
+++ b/internal/proxy/secrets/awssm/doc.go
@@ -1,0 +1,16 @@
+// Package awssm implements secrets.SecretProvider using AWS Secrets
+// Manager. It wraps github.com/aws/aws-sdk-go-v2/service/secretsmanager.
+//
+// AWS SM URIs take the form
+//
+//	aws-sm://<name-or-prefix>[/<path>][#<field>]
+//
+// where <name-or-prefix> is the first segment of the secret name
+// (the URI host), <path> is the rest of the name joined with "/",
+// and the optional <field> selects one key from a JSON-valued
+// secret.
+//
+// Auth uses the standard AWS SDK default credential chain: env vars,
+// shared credentials file, IRSA, ECS task role, or EC2 instance
+// profile. No explicit credentials in config.
+package awssm

--- a/internal/proxy/secrets/awssm/provider.go
+++ b/internal/proxy/secrets/awssm/provider.go
@@ -82,15 +82,14 @@ func New(ctx context.Context, cfg Config, _ secrets.RefResolver) (*Provider, err
 
 	// Probe connectivity: STS GetCallerIdentity is permission-neutral —
 	// it verifies credentials are valid without requiring access to any
-	// specific Secrets Manager resource. This works even in least-privilege
-	// IAM setups that restrict GetSecretValue to specific ARN prefixes.
+	// specific Secrets Manager resource. Auth failures are fatal (bad
+	// credentials will never self-heal). Non-auth failures (e.g. STS
+	// endpoint unreachable in a VPC-endpoint-only deployment) are
+	// non-fatal — the SM endpoint may still work.
 	stsClient := sts.NewFromConfig(awsCfg)
 	_, probeErr := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
-	if probeErr != nil {
-		if isAuthError(probeErr) {
-			return nil, fmt.Errorf("%w: aws-sm connectivity probe: %s", secrets.ErrUnauthorized, probeErr.Error())
-		}
-		return nil, fmt.Errorf("aws-sm: connectivity probe failed: %w", probeErr)
+	if probeErr != nil && isAuthError(probeErr) {
+		return nil, fmt.Errorf("%w: aws-sm connectivity probe: %s", secrets.ErrUnauthorized, probeErr.Error())
 	}
 
 	return &Provider{client: client}, nil
@@ -261,6 +260,8 @@ func isAuthError(err error) bool {
 		case "AccessDeniedException",
 			"UnrecognizedClientException",
 			"InvalidSignatureException",
+			"InvalidClientTokenId",
+			"SignatureDoesNotMatch",
 			"ExpiredTokenException",
 			"IncompleteSignature":
 			return true

--- a/internal/proxy/secrets/awssm/provider.go
+++ b/internal/proxy/secrets/awssm/provider.go
@@ -82,14 +82,21 @@ func New(ctx context.Context, cfg Config, _ secrets.RefResolver) (*Provider, err
 
 	// Probe connectivity: STS GetCallerIdentity is permission-neutral —
 	// it verifies credentials are valid without requiring access to any
-	// specific Secrets Manager resource. Auth failures are fatal (bad
-	// credentials will never self-heal). Non-auth failures (e.g. STS
-	// endpoint unreachable in a VPC-endpoint-only deployment) are
-	// non-fatal — the SM endpoint may still work.
+	// specific Secrets Manager resource. Auth failures and context
+	// cancellation are fatal. Non-auth failures (e.g. STS endpoint
+	// unreachable in a VPC-endpoint-only deployment) are non-fatal —
+	// the SM endpoint may still work.
 	stsClient := sts.NewFromConfig(awsCfg)
 	_, probeErr := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
-	if probeErr != nil && isAuthError(probeErr) {
-		return nil, fmt.Errorf("%w: aws-sm connectivity probe: %s", secrets.ErrUnauthorized, probeErr.Error())
+	if probeErr != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if isAuthError(probeErr) {
+			return nil, fmt.Errorf("%w: aws-sm connectivity probe: %s", secrets.ErrUnauthorized, probeErr.Error())
+		}
+		// Non-auth, non-context failure (e.g. STS endpoint unreachable):
+		// swallow — the SM endpoint may still work.
 	}
 
 	return &Provider{client: client}, nil

--- a/internal/proxy/secrets/awssm/provider.go
+++ b/internal/proxy/secrets/awssm/provider.go
@@ -1,0 +1,279 @@
+package awssm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	smithy "github.com/aws/smithy-go"
+
+	secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
+)
+
+// smClient is the subset of the AWS Secrets Manager API that the
+// provider uses. The real *secretsmanager.Client satisfies it;
+// tests inject a mock.
+type smClient interface {
+	GetSecretValue(ctx context.Context, input *secretsmanager.GetSecretValueInput,
+		opts ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
+}
+
+// Provider is an AWS Secrets Manager-backed secrets.SecretProvider.
+//
+// Provider is safe for concurrent Fetch and Close. Close waits for
+// any in-flight Fetch to finish before returning, so the contract
+// "after Close returns, Fetch returns an error" holds even under
+// concurrent access.
+//
+// Concurrency design mirrors keyring.Provider and vault.Provider:
+//   - closed is an atomic flag checked lock-free on the Fetch fast
+//     path.
+//   - mu is an RWMutex held for read by Fetch for its entire duration
+//     (including the AWS HTTP call) and for write by Close. The
+//     write lock ensures Close waits for any in-flight Fetch to
+//     finish before returning.
+type Provider struct {
+	mu     sync.RWMutex
+	closed atomic.Bool
+	client smClient
+}
+
+// probeSecretID is the sentinel secret name used by New to verify
+// that AWS credentials are valid and the endpoint is reachable. A
+// GetSecretValue that returns ResourceNotFoundException proves auth
+// and connectivity work. Any other error means credentials are
+// invalid or the endpoint is unreachable.
+const probeSecretID = "agentsh-probe-nonexistent"
+
+// testFetchPreLockHook is a test-only seam invoked (when non-nil)
+// between Fetch's fast-path closed check and its RLock acquisition.
+var testFetchPreLockHook func()
+
+// testFetchPostRLockHook is a test-only seam invoked (when non-nil)
+// immediately after Fetch has acquired its RLock and re-verified closed.
+var testFetchPostRLockHook func()
+
+// testClosePreLockHook is a test-only seam invoked (when non-nil)
+// after Close has stored the closed flag and before it acquires
+// the exclusive Lock.
+var testClosePreLockHook func()
+
+// New constructs an AWS Secrets Manager provider.
+//
+// Steps:
+//  1. Validate the config (region required).
+//  2. Load default AWS config with the specified region.
+//  3. Create the Secrets Manager client.
+//  4. Probe connectivity via GetSecretValue of a nonexistent secret.
+func New(ctx context.Context, cfg Config, _ secrets.RefResolver) (*Provider, error) {
+	if cfg.Region == "" {
+		return nil, fmt.Errorf("aws-sm: region is required")
+	}
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(cfg.Region))
+	if err != nil {
+		return nil, fmt.Errorf("aws-sm: loading AWS config: %w", err)
+	}
+
+	client := secretsmanager.NewFromConfig(awsCfg)
+
+	// Probe connectivity: a ResourceNotFoundException proves auth
+	// and endpoint work. Any other error fails construction.
+	_, probeErr := client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(probeSecretID),
+	})
+	if probeErr != nil {
+		var rnf *types.ResourceNotFoundException
+		if !errors.As(probeErr, &rnf) {
+			return nil, fmt.Errorf("aws-sm: connectivity probe failed: %w", probeErr)
+		}
+		// ResourceNotFoundException is success — backend is reachable.
+	}
+
+	return &Provider{client: client}, nil
+}
+
+// newFromClient constructs a Provider with an injected smClient.
+// Used by tests to bypass AWS SDK initialization.
+func newFromClient(client smClient) *Provider {
+	return &Provider{client: client}
+}
+
+// Name returns "aws-sm". Used in audit events.
+func (p *Provider) Name() string { return "aws-sm" }
+
+// Fetch retrieves a secret from AWS Secrets Manager.
+//
+// The SecretRef must have:
+//   - Scheme == "aws-sm"
+//   - Host    (the secret name or first path segment)
+//   - Path    (optional additional path segments, joined with "/")
+//   - Field   (optional) selects one key from a JSON-valued secret
+//
+// If Field is empty and the value is a JSON object with exactly one
+// key, the single value is auto-resolved. If the value is not JSON
+// or has multiple keys, it is returned as-is (plain string).
+func (p *Provider) Fetch(ctx context.Context, ref secrets.SecretRef) (secrets.SecretValue, error) {
+	if p.closed.Load() {
+		return secrets.SecretValue{}, fmt.Errorf("aws-sm: provider closed")
+	}
+
+	if err := ctx.Err(); err != nil {
+		return secrets.SecretValue{}, err
+	}
+
+	if ref.Scheme != "aws-sm" {
+		return secrets.SecretValue{}, fmt.Errorf("%w: wrong scheme %q", secrets.ErrInvalidURI, ref.Scheme)
+	}
+	if ref.Host == "" {
+		return secrets.SecretValue{}, fmt.Errorf("%w: aws-sm URI missing secret name (host)", secrets.ErrInvalidURI)
+	}
+
+	if hook := testFetchPreLockHook; hook != nil {
+		hook()
+	}
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.closed.Load() {
+		return secrets.SecretValue{}, fmt.Errorf("aws-sm: provider closed")
+	}
+
+	if hook := testFetchPostRLockHook; hook != nil {
+		hook()
+	}
+
+	if err := ctx.Err(); err != nil {
+		return secrets.SecretValue{}, err
+	}
+
+	// Build SecretId from host + path.
+	secretID := ref.Host
+	if ref.Path != "" {
+		secretID = ref.Host + "/" + ref.Path
+	}
+
+	output, err := p.client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(secretID),
+	})
+	if err != nil {
+		return secrets.SecretValue{}, mapAWSError(err)
+	}
+
+	// Extract raw value: prefer SecretString, fall back to SecretBinary.
+	var raw []byte
+	if output.SecretString != nil {
+		raw = []byte(*output.SecretString)
+	} else if output.SecretBinary != nil {
+		raw = output.SecretBinary
+	} else {
+		return secrets.SecretValue{}, fmt.Errorf("%w: secret has no value", secrets.ErrNotFound)
+	}
+
+	// Field extraction.
+	value, err := extractField(raw, ref.Field)
+	if err != nil {
+		return secrets.SecretValue{}, err
+	}
+
+	var version string
+	if output.VersionId != nil {
+		version = *output.VersionId
+	}
+
+	return secrets.SecretValue{
+		Value:     value,
+		Version:   version,
+		FetchedAt: time.Now(),
+	}, nil
+}
+
+// Close marks the provider as closed. Safe to call concurrently and
+// multiple times — subsequent calls are no-ops.
+func (p *Provider) Close() error {
+	p.closed.Store(true)
+
+	if hook := testClosePreLockHook; hook != nil {
+		hook()
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.client = nil
+	return nil
+}
+
+// extractField handles field extraction from the raw secret bytes.
+//
+// If field is non-empty: parse as JSON, look up key, return value.
+// If field is empty and value is a JSON object with exactly one key:
+// auto-resolve to that key's value. Otherwise return raw bytes as-is.
+func extractField(raw []byte, field string) ([]byte, error) {
+	if field != "" {
+		var m map[string]interface{}
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return nil, fmt.Errorf("%w: cannot extract field %q: value is not JSON: %s",
+				secrets.ErrInvalidURI, field, err)
+		}
+		v, ok := m[field]
+		if !ok {
+			return nil, fmt.Errorf("%w: field %q not found in secret", secrets.ErrNotFound, field)
+		}
+		return toBytes(v), nil
+	}
+
+	// No field specified — try auto-resolve for single-key JSON objects.
+	var m map[string]interface{}
+	if err := json.Unmarshal(raw, &m); err == nil && len(m) == 1 {
+		for _, v := range m {
+			return toBytes(v), nil
+		}
+	}
+
+	// Not JSON or multiple keys — return raw.
+	return raw, nil
+}
+
+// toBytes converts a value to []byte. Strings are converted
+// directly; everything else is JSON-marshaled.
+func toBytes(v interface{}) []byte {
+	if s, ok := v.(string); ok {
+		return []byte(s)
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return []byte(fmt.Sprintf("%v", v))
+	}
+	return b
+}
+
+// mapAWSError translates AWS SDK errors to the appropriate secrets
+// sentinel errors.
+func mapAWSError(err error) error {
+	var rnf *types.ResourceNotFoundException
+	if errors.As(err, &rnf) {
+		return fmt.Errorf("%w: %s", secrets.ErrNotFound, err.Error())
+	}
+
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "AccessDeniedException" {
+		return fmt.Errorf("%w: %s", secrets.ErrUnauthorized, err.Error())
+	}
+
+	var ire *types.InvalidRequestException
+	if errors.As(err, &ire) {
+		return fmt.Errorf("%w: %s", secrets.ErrInvalidURI, err.Error())
+	}
+
+	return fmt.Errorf("aws-sm: %w", err)
+}

--- a/internal/proxy/secrets/awssm/provider.go
+++ b/internal/proxy/secrets/awssm/provider.go
@@ -87,6 +87,9 @@ func New(ctx context.Context, cfg Config, _ secrets.RefResolver) (*Provider, err
 	stsClient := sts.NewFromConfig(awsCfg)
 	_, probeErr := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if probeErr != nil {
+		if isAuthError(probeErr) {
+			return nil, fmt.Errorf("%w: aws-sm connectivity probe: %s", secrets.ErrUnauthorized, probeErr.Error())
+		}
 		return nil, fmt.Errorf("aws-sm: connectivity probe failed: %w", probeErr)
 	}
 
@@ -249,14 +252,9 @@ func toBytes(v interface{}) []byte {
 	return b
 }
 
-// mapAWSError translates AWS SDK errors to the appropriate secrets
-// sentinel errors.
-func mapAWSError(err error) error {
-	var rnf *types.ResourceNotFoundException
-	if errors.As(err, &rnf) {
-		return fmt.Errorf("%w: %s", secrets.ErrNotFound, err.Error())
-	}
-
+// isAuthError reports whether err is an AWS auth/credential error.
+// Used by both the constructor's STS probe and Fetch's error mapper.
+func isAuthError(err error) bool {
 	var apiErr smithy.APIError
 	if errors.As(err, &apiErr) {
 		switch apiErr.ErrorCode() {
@@ -265,13 +263,22 @@ func mapAWSError(err error) error {
 			"InvalidSignatureException",
 			"ExpiredTokenException",
 			"IncompleteSignature":
-			return fmt.Errorf("%w: %s", secrets.ErrUnauthorized, err.Error())
+			return true
 		}
 	}
+	return false
+}
 
-	var ire *types.InvalidRequestException
-	if errors.As(err, &ire) {
-		return fmt.Errorf("%w: %s", secrets.ErrInvalidURI, err.Error())
+// mapAWSError translates AWS SDK errors to the appropriate secrets
+// sentinel errors.
+func mapAWSError(err error) error {
+	var rnf *types.ResourceNotFoundException
+	if errors.As(err, &rnf) {
+		return fmt.Errorf("%w: %s", secrets.ErrNotFound, err.Error())
+	}
+
+	if isAuthError(err) {
+		return fmt.Errorf("%w: %s", secrets.ErrUnauthorized, err.Error())
 	}
 
 	return fmt.Errorf("aws-sm: %w", err)

--- a/internal/proxy/secrets/awssm/provider.go
+++ b/internal/proxy/secrets/awssm/provider.go
@@ -13,6 +13,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	smithy "github.com/aws/smithy-go"
 
 	secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
@@ -46,12 +47,6 @@ type Provider struct {
 	client smClient
 }
 
-// probeSecretID is the sentinel secret name used by New to verify
-// that AWS credentials are valid and the endpoint is reachable. A
-// GetSecretValue that returns ResourceNotFoundException proves auth
-// and connectivity work. Any other error means credentials are
-// invalid or the endpoint is unreachable.
-const probeSecretID = "agentsh-probe-nonexistent"
 
 // testFetchPreLockHook is a test-only seam invoked (when non-nil)
 // between Fetch's fast-path closed check and its RLock acquisition.
@@ -72,7 +67,7 @@ var testClosePreLockHook func()
 //  1. Validate the config (region required).
 //  2. Load default AWS config with the specified region.
 //  3. Create the Secrets Manager client.
-//  4. Probe connectivity via GetSecretValue of a nonexistent secret.
+//  4. Probe connectivity via STS GetCallerIdentity.
 func New(ctx context.Context, cfg Config, _ secrets.RefResolver) (*Provider, error) {
 	if cfg.Region == "" {
 		return nil, fmt.Errorf("aws-sm: region is required")
@@ -85,17 +80,14 @@ func New(ctx context.Context, cfg Config, _ secrets.RefResolver) (*Provider, err
 
 	client := secretsmanager.NewFromConfig(awsCfg)
 
-	// Probe connectivity: a ResourceNotFoundException proves auth
-	// and endpoint work. Any other error fails construction.
-	_, probeErr := client.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{
-		SecretId: aws.String(probeSecretID),
-	})
+	// Probe connectivity: STS GetCallerIdentity is permission-neutral —
+	// it verifies credentials are valid without requiring access to any
+	// specific Secrets Manager resource. This works even in least-privilege
+	// IAM setups that restrict GetSecretValue to specific ARN prefixes.
+	stsClient := sts.NewFromConfig(awsCfg)
+	_, probeErr := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
 	if probeErr != nil {
-		var rnf *types.ResourceNotFoundException
-		if !errors.As(probeErr, &rnf) {
-			return nil, fmt.Errorf("aws-sm: connectivity probe failed: %w", probeErr)
-		}
-		// ResourceNotFoundException is success — backend is reachable.
+		return nil, fmt.Errorf("aws-sm: connectivity probe failed: %w", probeErr)
 	}
 
 	return &Provider{client: client}, nil
@@ -266,8 +258,15 @@ func mapAWSError(err error) error {
 	}
 
 	var apiErr smithy.APIError
-	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "AccessDeniedException" {
-		return fmt.Errorf("%w: %s", secrets.ErrUnauthorized, err.Error())
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "AccessDeniedException",
+			"UnrecognizedClientException",
+			"InvalidSignatureException",
+			"ExpiredTokenException",
+			"IncompleteSignature":
+			return fmt.Errorf("%w: %s", secrets.ErrUnauthorized, err.Error())
+		}
 	}
 
 	var ire *types.InvalidRequestException

--- a/internal/proxy/secrets/awssm/provider_test.go
+++ b/internal/proxy/secrets/awssm/provider_test.go
@@ -1,0 +1,502 @@
+package awssm
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	smithy "github.com/aws/smithy-go"
+
+	secrets "github.com/agentsh/agentsh/internal/proxy/secrets"
+	"github.com/agentsh/agentsh/internal/proxy/secrets/secretstest"
+)
+
+// mockSMClient implements smClient for testing.
+type mockSMClient struct {
+	GetSecretValueFunc func(ctx context.Context, input *secretsmanager.GetSecretValueInput,
+		opts ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
+}
+
+func (m *mockSMClient) GetSecretValue(ctx context.Context, input *secretsmanager.GetSecretValueInput,
+	opts ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	return m.GetSecretValueFunc(ctx, input, opts...)
+}
+
+// mockAPIError implements smithy.APIError for testing auth error code mapping.
+type mockAPIError struct {
+	code    string
+	message string
+}
+
+func (e *mockAPIError) Error() string                 { return e.message }
+func (e *mockAPIError) ErrorCode() string              { return e.code }
+func (e *mockAPIError) ErrorMessage() string           { return e.message }
+func (e *mockAPIError) ErrorFault() smithy.ErrorFault  { return smithy.FaultServer }
+
+func TestName(t *testing.T) {
+	p := &Provider{}
+	if got := p.Name(); got != "aws-sm" {
+		t.Errorf("Name() = %q, want %q", got, "aws-sm")
+	}
+}
+
+func TestFetch_WrongScheme(t *testing.T) {
+	p := newFromClient(&mockSMClient{})
+	ref := secrets.SecretRef{Scheme: "vault", Host: "my-secret"}
+	_, err := p.Fetch(context.Background(), ref)
+	if !errors.Is(err, secrets.ErrInvalidURI) {
+		t.Errorf("Fetch wrong scheme = %v, want wrapping ErrInvalidURI", err)
+	}
+}
+
+func TestFetch_EmptyHost(t *testing.T) {
+	p := newFromClient(&mockSMClient{})
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: ""}
+	_, err := p.Fetch(context.Background(), ref)
+	if !errors.Is(err, secrets.ErrInvalidURI) {
+		t.Errorf("Fetch empty host = %v, want wrapping ErrInvalidURI", err)
+	}
+}
+
+func TestFetch_ContextCanceled(t *testing.T) {
+	p := newFromClient(&mockSMClient{})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "my-secret"}
+	_, err := p.Fetch(ctx, ref)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Fetch with canceled ctx = %v, want context.Canceled", err)
+	}
+}
+
+func TestFetch_StringSecret(t *testing.T) {
+	mock := &mockSMClient{
+		GetSecretValueFunc: func(_ context.Context, input *secretsmanager.GetSecretValueInput,
+			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+			if *input.SecretId != "my-secret" {
+				t.Errorf("SecretId = %q, want %q", *input.SecretId, "my-secret")
+			}
+			return &secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String("hunter2"),
+				VersionId:    aws.String("v1"),
+			}, nil
+		},
+	}
+	p := newFromClient(mock)
+
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "my-secret"}
+	sv, err := p.Fetch(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if string(sv.Value) != "hunter2" {
+		t.Errorf("Value = %q, want %q", sv.Value, "hunter2")
+	}
+	if sv.Version != "v1" {
+		t.Errorf("Version = %q, want %q", sv.Version, "v1")
+	}
+	if sv.FetchedAt.IsZero() {
+		t.Error("FetchedAt not set")
+	}
+}
+
+func TestFetch_BinarySecret(t *testing.T) {
+	want := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	mock := &mockSMClient{
+		GetSecretValueFunc: func(_ context.Context, _ *secretsmanager.GetSecretValueInput,
+			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+			return &secretsmanager.GetSecretValueOutput{
+				SecretBinary: want,
+			}, nil
+		},
+	}
+	p := newFromClient(mock)
+
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "bin-secret"}
+	sv, err := p.Fetch(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if string(sv.Value) != string(want) {
+		t.Errorf("Value = %x, want %x", sv.Value, want)
+	}
+}
+
+func TestFetch_SecretIdFromHostAndPath(t *testing.T) {
+	var gotID string
+	mock := &mockSMClient{
+		GetSecretValueFunc: func(_ context.Context, input *secretsmanager.GetSecretValueInput,
+			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+			gotID = *input.SecretId
+			return &secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String("val"),
+			}, nil
+		},
+	}
+	p := newFromClient(mock)
+
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "prod", Path: "github-token"}
+	_, err := p.Fetch(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if gotID != "prod/github-token" {
+		t.Errorf("SecretId = %q, want %q", gotID, "prod/github-token")
+	}
+}
+
+func TestFetch_JSONFieldExtraction(t *testing.T) {
+	mock := &mockSMClient{
+		GetSecretValueFunc: func(_ context.Context, _ *secretsmanager.GetSecretValueInput,
+			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+			return &secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String(`{"token":"ghp_abc123","endpoint":"https://api.github.com"}`),
+			}, nil
+		},
+	}
+	p := newFromClient(mock)
+
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "my-secret", Field: "token"}
+	sv, err := p.Fetch(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if string(sv.Value) != "ghp_abc123" {
+		t.Errorf("Value = %q, want %q", sv.Value, "ghp_abc123")
+	}
+}
+
+func TestFetch_JSONFieldNotFound(t *testing.T) {
+	mock := &mockSMClient{
+		GetSecretValueFunc: func(_ context.Context, _ *secretsmanager.GetSecretValueInput,
+			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+			return &secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String(`{"token":"ghp_abc123"}`),
+			}, nil
+		},
+	}
+	p := newFromClient(mock)
+
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "my-secret", Field: "missing"}
+	_, err := p.Fetch(context.Background(), ref)
+	if !errors.Is(err, secrets.ErrNotFound) {
+		t.Errorf("Fetch missing field = %v, want wrapping ErrNotFound", err)
+	}
+}
+
+func TestFetch_FieldOnNonJSON(t *testing.T) {
+	mock := &mockSMClient{
+		GetSecretValueFunc: func(_ context.Context, _ *secretsmanager.GetSecretValueInput,
+			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+			return &secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String("plain-string-not-json"),
+			}, nil
+		},
+	}
+	p := newFromClient(mock)
+
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "my-secret", Field: "key"}
+	_, err := p.Fetch(context.Background(), ref)
+	if !errors.Is(err, secrets.ErrInvalidURI) {
+		t.Errorf("Fetch field on non-JSON = %v, want wrapping ErrInvalidURI", err)
+	}
+}
+
+func TestFetch_AutoResolveSingleKeyJSON(t *testing.T) {
+	mock := &mockSMClient{
+		GetSecretValueFunc: func(_ context.Context, _ *secretsmanager.GetSecretValueInput,
+			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+			return &secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String(`{"token":"ghp_abc123"}`),
+			}, nil
+		},
+	}
+	p := newFromClient(mock)
+
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "my-secret"}
+	sv, err := p.Fetch(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if string(sv.Value) != "ghp_abc123" {
+		t.Errorf("Value = %q, want %q", sv.Value, "ghp_abc123")
+	}
+}
+
+func TestFetch_PlainStringNoField(t *testing.T) {
+	mock := &mockSMClient{
+		GetSecretValueFunc: func(_ context.Context, _ *secretsmanager.GetSecretValueInput,
+			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+			return &secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String("just-a-token"),
+			}, nil
+		},
+	}
+	p := newFromClient(mock)
+
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "my-secret"}
+	sv, err := p.Fetch(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if string(sv.Value) != "just-a-token" {
+		t.Errorf("Value = %q, want %q", sv.Value, "just-a-token")
+	}
+}
+
+func TestFetch_MultiKeyJSONNoField(t *testing.T) {
+	mock := &mockSMClient{
+		GetSecretValueFunc: func(_ context.Context, _ *secretsmanager.GetSecretValueInput,
+			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+			return &secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String(`{"user":"admin","pass":"secret"}`),
+			}, nil
+		},
+	}
+	p := newFromClient(mock)
+
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "my-secret"}
+	sv, err := p.Fetch(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if string(sv.Value) != `{"user":"admin","pass":"secret"}` {
+		t.Errorf("Value = %q, want raw JSON", sv.Value)
+	}
+}
+
+func TestFetch_NoValue(t *testing.T) {
+	mock := &mockSMClient{
+		GetSecretValueFunc: func(_ context.Context, _ *secretsmanager.GetSecretValueInput,
+			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+			return &secretsmanager.GetSecretValueOutput{}, nil
+		},
+	}
+	p := newFromClient(mock)
+
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "my-secret"}
+	_, err := p.Fetch(context.Background(), ref)
+	if !errors.Is(err, secrets.ErrNotFound) {
+		t.Errorf("Fetch with no value = %v, want wrapping ErrNotFound", err)
+	}
+}
+
+func TestFetch_NilVersionId(t *testing.T) {
+	mock := &mockSMClient{
+		GetSecretValueFunc: func(_ context.Context, _ *secretsmanager.GetSecretValueInput,
+			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+			return &secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String("val"),
+				VersionId:    nil,
+			}, nil
+		},
+	}
+	p := newFromClient(mock)
+
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "my-secret"}
+	sv, err := p.Fetch(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Fetch error: %v", err)
+	}
+	if sv.Version != "" {
+		t.Errorf("Version = %q, want empty", sv.Version)
+	}
+}
+
+func TestFetch_ResourceNotFound(t *testing.T) {
+	mock := &mockSMClient{
+		GetSecretValueFunc: func(_ context.Context, _ *secretsmanager.GetSecretValueInput,
+			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+			return nil, &types.ResourceNotFoundException{Message: aws.String("not found")}
+		},
+	}
+	p := newFromClient(mock)
+
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "missing"}
+	_, err := p.Fetch(context.Background(), ref)
+	if !errors.Is(err, secrets.ErrNotFound) {
+		t.Errorf("Fetch not found = %v, want wrapping ErrNotFound", err)
+	}
+}
+
+// TestMapAWSError_AuthCodes verifies that all five auth-related AWS error codes
+// are mapped to secrets.ErrUnauthorized via the smithy.APIError interface.
+func TestMapAWSError_AuthCodes(t *testing.T) {
+	authCodes := []string{
+		"AccessDeniedException",
+		"UnrecognizedClientException",
+		"InvalidSignatureException",
+		"ExpiredTokenException",
+		"IncompleteSignature",
+	}
+
+	for _, code := range authCodes {
+		code := code
+		t.Run(code, func(t *testing.T) {
+			mock := &mockSMClient{
+				GetSecretValueFunc: func(_ context.Context, _ *secretsmanager.GetSecretValueInput,
+					_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+					return nil, &mockAPIError{code: code, message: "auth error: " + code}
+				},
+			}
+			p := newFromClient(mock)
+
+			ref := secrets.SecretRef{Scheme: "aws-sm", Host: "my-secret"}
+			_, err := p.Fetch(context.Background(), ref)
+			if !errors.Is(err, secrets.ErrUnauthorized) {
+				t.Errorf("Fetch with %s = %v, want wrapping ErrUnauthorized", code, err)
+			}
+		})
+	}
+}
+
+func TestFetch_InvalidRequest(t *testing.T) {
+	mock := &mockSMClient{
+		GetSecretValueFunc: func(_ context.Context, _ *secretsmanager.GetSecretValueInput,
+			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+			return nil, &types.InvalidRequestException{Message: aws.String("bad id")}
+		},
+	}
+	p := newFromClient(mock)
+
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "bad"}
+	_, err := p.Fetch(context.Background(), ref)
+	if !errors.Is(err, secrets.ErrInvalidURI) {
+		t.Errorf("Fetch invalid request = %v, want wrapping ErrInvalidURI", err)
+	}
+}
+
+func TestClose_Idempotent(t *testing.T) {
+	p := newFromClient(&mockSMClient{})
+	if err := p.Close(); err != nil {
+		t.Errorf("first Close: %v", err)
+	}
+	if err := p.Close(); err != nil {
+		t.Errorf("second Close: %v", err)
+	}
+}
+
+func TestFetch_AfterClose(t *testing.T) {
+	p := newFromClient(&mockSMClient{})
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "my-secret"}
+	_, err := p.Fetch(context.Background(), ref)
+	if err == nil {
+		t.Fatal("Fetch after Close returned nil error")
+	}
+}
+
+func TestFetch_ClosedBetweenLoadAndRLock(t *testing.T) {
+	p := newFromClient(&mockSMClient{})
+
+	hookRan := false
+	t.Cleanup(func() { testFetchPreLockHook = nil })
+	testFetchPreLockHook = func() {
+		hookRan = true
+		if err := p.Close(); err != nil {
+			t.Errorf("hook Close: %v", err)
+		}
+	}
+
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "my-secret"}
+	_, err := p.Fetch(context.Background(), ref)
+
+	if !hookRan {
+		t.Fatal("testFetchPreLockHook never fired")
+	}
+	if err == nil {
+		t.Fatal("Fetch succeeded despite Close between Load and RLock")
+	}
+}
+
+func TestProvider_CloseWaitsForInFlightFetch(t *testing.T) {
+	mock := &mockSMClient{
+		GetSecretValueFunc: func(_ context.Context, _ *secretsmanager.GetSecretValueInput,
+			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+			return &secretsmanager.GetSecretValueOutput{
+				SecretString: aws.String("val"),
+			}, nil
+		},
+	}
+	p := newFromClient(mock)
+
+	inFlight := make(chan struct{})
+	release := make(chan struct{})
+	var fetchHookOnce sync.Once
+	var releaseOnce sync.Once
+	releaseHook := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseHook)
+
+	t.Cleanup(func() { testFetchPostRLockHook = nil })
+	testFetchPostRLockHook = func() {
+		fetchHookOnce.Do(func() {
+			close(inFlight)
+			<-release
+		})
+	}
+
+	closeAtLock := make(chan struct{})
+	t.Cleanup(func() { testClosePreLockHook = nil })
+	testClosePreLockHook = func() { close(closeAtLock) }
+
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "my-secret"}
+
+	fetchDone := make(chan struct{})
+	go func() {
+		defer close(fetchDone)
+		_, _ = p.Fetch(context.Background(), ref)
+	}()
+
+	<-inFlight
+
+	closeDone := make(chan struct{})
+	go func() {
+		defer close(closeDone)
+		_ = p.Close()
+	}()
+
+	<-closeAtLock
+
+	select {
+	case <-closeDone:
+		t.Fatal("Close returned while an in-flight Fetch still held the read lock")
+	default:
+	}
+
+	releaseHook()
+
+	select {
+	case <-closeDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return after the in-flight Fetch was released")
+	}
+	<-fetchDone
+
+	_, err := p.Fetch(context.Background(), ref)
+	if err == nil {
+		t.Error("post-Close Fetch should return error")
+	}
+}
+
+func TestProviderContract(t *testing.T) {
+	mock := &mockSMClient{
+		GetSecretValueFunc: func(_ context.Context, _ *secretsmanager.GetSecretValueInput,
+			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+			return nil, &types.ResourceNotFoundException{Message: aws.String("not found")}
+		},
+	}
+	p := newFromClient(mock)
+
+	probeRef := secrets.SecretRef{
+		Scheme: "aws-sm",
+		Host:   "contract-probe-nonexistent",
+	}
+	secretstest.ProviderContract(t, "aws-sm", p, probeRef)
+}

--- a/internal/proxy/secrets/awssm/provider_test.go
+++ b/internal/proxy/secrets/awssm/provider_test.go
@@ -356,18 +356,30 @@ func TestMapAWSError_AuthCodes(t *testing.T) {
 }
 
 func TestFetch_InvalidRequest(t *testing.T) {
+	// InvalidRequestException (e.g. secret pending deletion) is a
+	// resource-state error, not a malformed URI. It falls through
+	// to the generic aws-sm wrapper, NOT ErrInvalidURI.
 	mock := &mockSMClient{
 		GetSecretValueFunc: func(_ context.Context, _ *secretsmanager.GetSecretValueInput,
 			_ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
-			return nil, &types.InvalidRequestException{Message: aws.String("bad id")}
+			return nil, &types.InvalidRequestException{Message: aws.String("secret pending deletion")}
 		},
 	}
 	p := newFromClient(mock)
 
-	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "bad"}
+	ref := secrets.SecretRef{Scheme: "aws-sm", Host: "pending-delete"}
 	_, err := p.Fetch(context.Background(), ref)
-	if !errors.Is(err, secrets.ErrInvalidURI) {
-		t.Errorf("Fetch invalid request = %v, want wrapping ErrInvalidURI", err)
+	if err == nil {
+		t.Fatal("Fetch with InvalidRequestException returned nil error")
+	}
+	if errors.Is(err, secrets.ErrInvalidURI) {
+		t.Error("InvalidRequestException should NOT map to ErrInvalidURI")
+	}
+	if errors.Is(err, secrets.ErrNotFound) {
+		t.Error("InvalidRequestException should NOT map to ErrNotFound")
+	}
+	if errors.Is(err, secrets.ErrUnauthorized) {
+		t.Error("InvalidRequestException should NOT map to ErrUnauthorized")
 	}
 }
 

--- a/internal/proxy/secrets/awssm/provider_test.go
+++ b/internal/proxy/secrets/awssm/provider_test.go
@@ -331,6 +331,8 @@ func TestMapAWSError_AuthCodes(t *testing.T) {
 		"AccessDeniedException",
 		"UnrecognizedClientException",
 		"InvalidSignatureException",
+		"InvalidClientTokenId",
+		"SignatureDoesNotMatch",
 		"ExpiredTokenException",
 		"IncompleteSignature",
 	}

--- a/internal/session/secretsconfig.go
+++ b/internal/session/secretsconfig.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/internal/proxy/secrets"
+	"github.com/agentsh/agentsh/internal/proxy/secrets/awssm"
 	"github.com/agentsh/agentsh/internal/proxy/secrets/keyring"
 	"github.com/agentsh/agentsh/internal/proxy/secrets/vault"
 	"github.com/agentsh/agentsh/internal/proxy/services"
@@ -116,6 +117,13 @@ func DefaultConstructors() map[string]secrets.ConstructorFunc {
 			}
 			return vault.New(ctx, vc, resolver)
 		},
+		"aws-sm": func(ctx context.Context, cfg secrets.ProviderConfig, _ secrets.RefResolver) (secrets.SecretProvider, error) {
+			ac, ok := cfg.(awssm.Config)
+			if !ok {
+				return nil, fmt.Errorf("expected awssm.Config, got %T", cfg)
+			}
+			return awssm.New(ctx, ac, nil)
+		},
 	}
 }
 
@@ -133,6 +141,8 @@ func decodeProviderConfig(_ string, node yaml.Node) (secrets.ProviderConfig, err
 		return keyring.Config{}, nil
 	case "vault":
 		return decodeVaultConfig(node)
+	case "aws-sm":
+		return decodeAWSConfig(node)
 	default:
 		return nil, fmt.Errorf("unknown provider type %q", base.Type)
 	}
@@ -200,6 +210,22 @@ func decodeVaultConfig(node yaml.Node) (secrets.ProviderConfig, error) {
 		cfg.Auth.SecretIDRef = &ref
 	}
 	return cfg, nil
+}
+
+// awssmYAML is the YAML representation of an AWS SM provider config.
+type awssmYAML struct {
+	Type   string `yaml:"type"`
+	Region string `yaml:"region"`
+}
+
+func decodeAWSConfig(node yaml.Node) (secrets.ProviderConfig, error) {
+	var raw awssmYAML
+	if err := node.Decode(&raw); err != nil {
+		return nil, fmt.Errorf("decode aws-sm config: %w", err)
+	}
+	return awssm.Config{
+		Region: raw.Region,
+	}, nil
 }
 
 // BuildSecretsRegistry creates a provider registry from the resolved

--- a/internal/session/secretsconfig_test.go
+++ b/internal/session/secretsconfig_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/proxy/secrets/awssm"
 	"github.com/agentsh/agentsh/internal/proxy/secrets/vault"
 	"gopkg.in/yaml.v3"
 )
@@ -185,5 +186,28 @@ func TestResolveServiceConfigs_ScrubResponse(t *testing.T) {
 	}
 	if result.ScrubServices["stripe"] {
 		t.Error("stripe should not be in ScrubServices")
+	}
+}
+
+func TestResolveProviderConfigs_AWSSM(t *testing.T) {
+	providers := map[string]yaml.Node{
+		"aws": mustYAMLNode(t, "type: aws-sm\nregion: us-west-2"),
+	}
+	configs, err := ResolveProviderConfigs(providers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(configs) != 1 {
+		t.Fatalf("expected 1 config, got %d", len(configs))
+	}
+	if configs["aws"].TypeName() != "aws-sm" {
+		t.Errorf("TypeName = %q, want aws-sm", configs["aws"].TypeName())
+	}
+	ac, ok := configs["aws"].(awssm.Config)
+	if !ok {
+		t.Fatalf("expected awssm.Config, got %T", configs["aws"])
+	}
+	if ac.Region != "us-west-2" {
+		t.Errorf("Region = %q, want us-west-2", ac.Region)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `internal/proxy/secrets/awssm/` package: Config, Provider (`smClient` interface, `New`, `Fetch`, `Close`), error mapping with `isAuthError` helper
- STS `GetCallerIdentity` connectivity probe (auth-fatal, non-auth non-fatal for VPC-endpoint deployments)
- JSON field extraction + single-key auto-resolve for `aws-sm://host/path#field` URIs
- Wire `aws-sm` into `knownProviderTypes`, `DefaultConstructors`, and `decodeProviderConfig`
- 26 unit tests (30 subtests) with mock `smClient`, race-clean, `ProviderContract` compliance

## Test Plan
- [x] `go test ./internal/proxy/secrets/awssm/... -race` — all pass
- [x] `go test ./internal/policy/...` — `TestValidateSecrets_AWSProvider` passes
- [x] `go test ./internal/session/...` — `TestResolveProviderConfigs_AWSSM` passes
- [x] `go test ./...` — full suite green
- [x] `GOOS=windows go build ./...` — cross-compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)