### PR TITLE
fix: arm64 enforcement + detect accuracy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,9 +42,11 @@ jobs:
 
       - name: Install build deps (envshim, fuse, seccomp)
         run: |
+          sudo dpkg --add-architecture arm64
           sudo apt-get update
           sudo apt-get install -y \
             libseccomp-dev \
+            libseccomp-dev:arm64 \
             libfuse-dev \
             pkg-config \
             gcc-aarch64-linux-gnu \

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,13 +21,14 @@ builds:
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}}
 
-  # Linux arm64: CGO disabled (cross-compilation complexity)
-  # Users get graceful degradation - seccomp features unavailable
+  # Linux arm64: CGO enabled for seccomp user-notify support (cross-compiled)
   - id: agentsh-linux-arm64
     main: ./cmd/agentsh
     binary: agentsh
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
     goos:
       - linux
     goarch:
@@ -87,9 +88,7 @@ builds:
     ldflags:
       - -s -w
 
-  # unixwrap: seccomp wrapper for Linux (requires CGO + libseccomp)
-  # Only building amd64 - arm64 cross-compilation requires libseccomp-dev:arm64
-  # which is complex to set up in CI. arm64 users get graceful degradation.
+  # unixwrap: seccomp wrapper for Linux amd64 (requires CGO + libseccomp)
   - id: unixwrap-linux-amd64
     main: ./cmd/agentsh-unixwrap
     binary: agentsh-unixwrap
@@ -99,6 +98,21 @@ builds:
       - linux
     goarch:
       - amd64
+    ldflags:
+      - -s -w
+
+  # unixwrap: seccomp wrapper for Linux arm64 (cross-compiled)
+  - id: unixwrap-linux-arm64
+    main: ./cmd/agentsh-unixwrap
+    binary: agentsh-unixwrap
+    env:
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+    goos:
+      - linux
+    goarch:
+      - arm64
     ldflags:
       - -s -w
 
@@ -152,11 +166,10 @@ archives:
       - agentsh-linux-arm64
       - shim-linux
       - unixwrap-linux-amd64
+      - unixwrap-linux-arm64
       - stub-linux
     formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Version }}_linux_{{ .Arch }}"
-    # unixwrap only built for amd64, so binary count differs from arm64
-    allow_different_binary_count: true
     files:
       - README.md
       - LICENSE
@@ -219,8 +232,8 @@ nfpms:
       - agentsh-linux-arm64
       - shim-linux
       - unixwrap-linux-amd64
+      - unixwrap-linux-arm64
       - stub-linux
-      # unixwrap not available for arm64 - users get graceful degradation
     formats:
       - deb
       - rpm

--- a/docs/superpowers/plans/2026-04-10-arm64-enforcement.md
+++ b/docs/superpowers/plans/2026-04-10-arm64-enforcement.md
@@ -1,0 +1,584 @@
+# arm64 Enforcement + Detect Accuracy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix arm64 releases to ship with full seccomp/Landlock enforcement, and make `agentsh detect` report accurate scores when the wrapper binary is missing.
+
+**Architecture:** Two independent changes — (1) cross-compile unixwrap and the server binary for arm64 with CGO enabled using the existing release runner, and (2) add a wrapper-availability check to the detect command that marks seccomp/Landlock backends as unavailable when the wrapper is not on PATH.
+
+**Tech Stack:** GoReleaser, GitHub Actions, Go build tags, libseccomp cross-compilation
+
+**Spec:** `docs/superpowers/specs/2026-04-10-arm64-enforcement-design.md`
+
+---
+
+### Task 1: Add wrapper availability check to detect
+
+**Files:**
+- Modify: `internal/capabilities/detect_linux.go:170-203`
+- Modify: `internal/capabilities/detect_linux_test.go`
+
+The detect change is implemented first (TDD — test, then code) so the regression becomes visible before fixing the build.
+
+- [ ] **Step 1: Add mockable LookPath var to detect_linux.go**
+
+Add a package-level var at the top of the file (after the imports) so tests can override the lookup. This follows the existing pattern used by `checkPtrace`, `checkSeccompUserNotify`, etc. in `check.go`:
+
+```go
+import (
+	"fmt"
+	"os/exec"
+)
+
+// wrapperLookPath is the function used to check if the wrapper binary exists.
+// Package-level var for testability (matches checkPtrace pattern in check.go).
+var wrapperLookPath = exec.LookPath
+```
+
+- [ ] **Step 2: Write failing test for wrapper-missing scenario**
+
+Add to `internal/capabilities/detect_linux_test.go`:
+
+```go
+func TestApplyWrapperAvailability_Missing(t *testing.T) {
+	// Build domains with all backends available
+	caps := &SecurityCapabilities{
+		Seccomp:      true,
+		Landlock:     true,
+		LandlockABI:  5,
+		FUSE:         true,
+		Ptrace:       true,
+	}
+	caps.FileEnforcement = detectFileEnforcementBackend(caps)
+	domains := buildLinuxDomains(caps)
+
+	// Wrapper not found
+	found := applyWrapperAvailability(domains, caps)
+	if found {
+		t.Fatal("applyWrapperAvailability returned true, want false")
+	}
+
+	// Check affected backends are unavailable
+	for _, d := range domains {
+		for _, b := range d.Backends {
+			switch b.Name {
+			case "seccomp-notify", "landlock", "seccomp-execve":
+				if b.Available {
+					t.Errorf("backend %q should be unavailable when wrapper missing", b.Name)
+				}
+			case "fuse", "ptrace":
+				if !b.Available {
+					t.Errorf("backend %q should remain available when wrapper missing", b.Name)
+				}
+			}
+		}
+	}
+
+	// FileEnforcement should fall back to fuse
+	if caps.FileEnforcement != "fuse" {
+		t.Errorf("FileEnforcement = %q, want 'fuse'", caps.FileEnforcement)
+	}
+}
+
+func TestApplyWrapperAvailability_Missing_NoFUSE(t *testing.T) {
+	caps := &SecurityCapabilities{
+		Seccomp:     true,
+		Landlock:    true,
+		LandlockABI: 5,
+		FUSE:        false,
+		Ptrace:      true,
+	}
+	caps.FileEnforcement = detectFileEnforcementBackend(caps)
+	domains := buildLinuxDomains(caps)
+
+	found := applyWrapperAvailability(domains, caps)
+	if found {
+		t.Fatal("applyWrapperAvailability returned true, want false")
+	}
+
+	// FileEnforcement should fall back to none
+	if caps.FileEnforcement != "none" {
+		t.Errorf("FileEnforcement = %q, want 'none'", caps.FileEnforcement)
+	}
+}
+
+func TestApplyWrapperAvailability_Present(t *testing.T) {
+	caps := &SecurityCapabilities{
+		Seccomp:     true,
+		Landlock:    true,
+		LandlockABI: 5,
+		FUSE:        true,
+		Ptrace:      true,
+	}
+	caps.FileEnforcement = detectFileEnforcementBackend(caps)
+	domains := buildLinuxDomains(caps)
+
+	// Simulate wrapper found
+	found := applyWrapperAvailability(domains, caps)
+	// On CI/dev machines, wrapper may or may not be on PATH — just verify consistency
+	if found {
+		// All backends should remain as probed
+		for _, d := range domains {
+			for _, b := range d.Backends {
+				switch b.Name {
+				case "seccomp-notify", "seccomp-execve":
+					if !b.Available {
+						t.Errorf("backend %q should be available when wrapper present", b.Name)
+					}
+				}
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test ./internal/capabilities/ -run TestApplyWrapperAvailability -v`
+Expected: compilation error — `applyWrapperAvailability` not defined.
+
+- [ ] **Step 4: Implement applyWrapperAvailability**
+
+Add to `internal/capabilities/detect_linux.go`, before the `Detect()` function:
+
+```go
+// wrapperDependentBackends lists backends that require agentsh-unixwrap.
+// These are marked unavailable when the wrapper binary is not on PATH.
+var wrapperDependentBackends = map[string]bool{
+	"seccomp-notify": true,
+	"landlock":       true,
+	"seccomp-execve": true,
+}
+
+// applyWrapperAvailability checks if agentsh-unixwrap is on PATH and marks
+// wrapper-dependent backends as unavailable if it's missing. Also updates
+// secCaps.FileEnforcement and domain Active fields for consistency.
+// Returns true if the wrapper was found.
+func applyWrapperAvailability(domains []ProtectionDomain, secCaps *SecurityCapabilities) bool {
+	_, err := wrapperLookPath("agentsh-unixwrap")
+	if err == nil {
+		return true
+	}
+
+	// Wrapper missing — disable dependent backends
+	for i := range domains {
+		activeDisabled := false
+		for j := range domains[i].Backends {
+			if wrapperDependentBackends[domains[i].Backends[j].Name] {
+				if domains[i].Backends[j].Name == domains[i].Active {
+					activeDisabled = true
+				}
+				domains[i].Backends[j].Available = false
+			}
+		}
+		// Fall back Active to next available backend
+		if activeDisabled {
+			domains[i].Active = ""
+			for _, b := range domains[i].Backends {
+				if b.Available {
+					domains[i].Active = b.Name
+					break
+				}
+			}
+		}
+	}
+
+	// Update FileEnforcement to match
+	switch secCaps.FileEnforcement {
+	case "landlock", "seccomp-notify":
+		if secCaps.FUSE {
+			secCaps.FileEnforcement = "fuse"
+		} else {
+			secCaps.FileEnforcement = "none"
+		}
+	}
+
+	return false
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./internal/capabilities/ -run TestApplyWrapperAvailability -v`
+Expected: PASS (all three test functions).
+
+- [ ] **Step 6: Wire applyWrapperAvailability into Detect()**
+
+Modify `internal/capabilities/detect_linux.go`, function `Detect()` (lines 171-203). Insert the wrapper check between `buildLinuxDomains` and `ComputeScore`, and append the wrapper-missing tip after `GenerateTipsFromDomains`:
+
+```go
+func Detect() (*DetectResult, error) {
+	secCaps := DetectSecurityCapabilities()
+	secCaps.FileEnforcement = detectFileEnforcementBackend(secCaps)
+
+	domains := buildLinuxDomains(secCaps)
+
+	// Check wrapper availability before scoring — marks seccomp/landlock
+	// backends unavailable if agentsh-unixwrap is not on PATH.
+	wrapperFound := applyWrapperAvailability(domains, secCaps)
+
+	score := ComputeScore(domains)
+	mode := secCaps.SelectMode()
+
+	caps := backwardCompatCaps(secCaps, domains)
+
+	var available, unavailable []string
+	for _, d := range domains {
+		for _, b := range d.Backends {
+			if b.Available {
+				available = append(available, b.Name)
+			} else {
+				unavailable = append(unavailable, b.Name)
+			}
+		}
+	}
+
+	tips := GenerateTipsFromDomains(domains)
+
+	// Add wrapper-specific tip regardless of domain score (FUSE may keep
+	// File Protection scored, but the missing wrapper is still actionable).
+	if !wrapperFound {
+		tips = append(tips, Tip{
+			Feature: "seccomp-wrapper",
+			Status:  "missing",
+			Impact:  "seccomp and Landlock enforcement disabled — processes run without kernel-level interception",
+			Action:  "install agentsh-unixwrap or rebuild the package with CGO_ENABLED=1",
+		})
+	}
+
+	return &DetectResult{
+		Platform:        "linux",
+		SecurityMode:    mode,
+		ProtectionScore: score,
+		Domains:         domains,
+		Capabilities:    caps,
+		Summary:         DetectSummary{Available: available, Unavailable: unavailable},
+		Tips:            tips,
+	}, nil
+}
+```
+
+- [ ] **Step 7: Add test for wrapper-missing tip in Detect output**
+
+Add to `internal/capabilities/detect_linux_test.go`:
+
+```go
+func TestDetect_WrapperMissing_Tip(t *testing.T) {
+	// Override LookPath to simulate missing wrapper
+	orig := wrapperLookPath
+	wrapperLookPath = func(file string) (string, error) {
+		if file == "agentsh-unixwrap" {
+			return "", exec.ErrNotFound
+		}
+		return exec.LookPath(file)
+	}
+	defer func() { wrapperLookPath = orig }()
+
+	result, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect() error: %v", err)
+	}
+
+	// seccomp-notify, landlock, seccomp-execve should be unavailable
+	for _, d := range result.Domains {
+		for _, b := range d.Backends {
+			switch b.Name {
+			case "seccomp-notify", "landlock", "seccomp-execve":
+				if b.Available {
+					t.Errorf("backend %q should be unavailable when wrapper missing", b.Name)
+				}
+			}
+		}
+	}
+
+	// Wrapper tip should be present
+	found := false
+	for _, tip := range result.Tips {
+		if tip.Feature == "seccomp-wrapper" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected seccomp-wrapper tip when wrapper missing")
+	}
+}
+```
+
+Add `"os/exec"` to the imports at the top of the test file.
+
+- [ ] **Step 8: Run all detect tests**
+
+Run: `go test ./internal/capabilities/ -run TestDetect -v`
+Expected: PASS for all tests (existing + new).
+
+- [ ] **Step 9: Run full test suite**
+
+Run: `go test ./...`
+Expected: PASS — no regressions.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/capabilities/detect_linux.go internal/capabilities/detect_linux_test.go
+git commit -m "fix(detect): mark seccomp/landlock backends unavailable when wrapper binary missing
+
+detect now checks for agentsh-unixwrap on PATH and marks seccomp-notify,
+landlock, and seccomp-execve backends as unavailable when it's not found.
+This makes the protection score reflect actual enforcement state rather
+than just kernel capabilities."
+```
+
+---
+
+### Task 2: Add unixwrap arm64 build target to GoReleaser
+
+**Files:**
+- Modify: `.goreleaser.yml:24-36` (server arm64 build)
+- Modify: `.goreleaser.yml:90-103` (add unixwrap arm64 after existing amd64 target)
+- Modify: `.goreleaser.yml:148-159` (archives)
+- Modify: `.goreleaser.yml:214-223` (nfpms)
+
+- [ ] **Step 1: Flip server arm64 build to CGO_ENABLED=1**
+
+In `.goreleaser.yml`, replace the `agentsh-linux-arm64` build (lines 24-36):
+
+Old:
+```yaml
+  # Linux arm64: CGO disabled (cross-compilation complexity)
+  # Users get graceful degradation - seccomp features unavailable
+  - id: agentsh-linux-arm64
+    main: ./cmd/agentsh
+    binary: agentsh
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}}
+```
+
+New:
+```yaml
+  # Linux arm64: CGO enabled for seccomp user-notify support (cross-compiled)
+  - id: agentsh-linux-arm64
+    main: ./cmd/agentsh
+    binary: agentsh
+    env:
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+    goos:
+      - linux
+    goarch:
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}}
+```
+
+- [ ] **Step 2: Add unixwrap arm64 build target**
+
+In `.goreleaser.yml`, after the `unixwrap-linux-amd64` build (after line 103), add:
+
+```yaml
+  # unixwrap: seccomp wrapper for Linux arm64 (cross-compiled)
+  - id: unixwrap-linux-arm64
+    main: ./cmd/agentsh-unixwrap
+    binary: agentsh-unixwrap
+    env:
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+    goos:
+      - linux
+    goarch:
+      - arm64
+    ldflags:
+      - -s -w
+```
+
+Also update the comment on the existing amd64 target (lines 90-91). Replace:
+```yaml
+  # unixwrap: seccomp wrapper for Linux (requires CGO + libseccomp)
+  # Only building amd64 - arm64 cross-compilation requires libseccomp-dev:arm64
+  # which is complex to set up in CI. arm64 users get graceful degradation.
+```
+With:
+```yaml
+  # unixwrap: seccomp wrapper for Linux amd64 (requires CGO + libseccomp)
+```
+
+- [ ] **Step 3: Add unixwrap-linux-arm64 to archives**
+
+In `.goreleaser.yml`, in the `agentsh-linux` archive section, add `unixwrap-linux-arm64` to the `ids` list and remove `allow_different_binary_count: true`:
+
+Old:
+```yaml
+  - id: agentsh-linux
+    ids:
+      - agentsh-linux-amd64
+      - agentsh-linux-arm64
+      - shim-linux
+      - unixwrap-linux-amd64
+      - stub-linux
+    formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_linux_{{ .Arch }}"
+    # unixwrap only built for amd64, so binary count differs from arm64
+    allow_different_binary_count: true
+```
+
+New:
+```yaml
+  - id: agentsh-linux
+    ids:
+      - agentsh-linux-amd64
+      - agentsh-linux-arm64
+      - shim-linux
+      - unixwrap-linux-amd64
+      - unixwrap-linux-arm64
+      - stub-linux
+    formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_linux_{{ .Arch }}"
+```
+
+- [ ] **Step 4: Add unixwrap-linux-arm64 to nfpms**
+
+In `.goreleaser.yml`, in the `nfpms` section, add `unixwrap-linux-arm64` to the `ids` list and remove the degradation comment:
+
+Old:
+```yaml
+  - id: agentsh
+    package_name: agentsh
+    ids:
+      - agentsh-linux-amd64
+      - agentsh-linux-arm64
+      - shim-linux
+      - unixwrap-linux-amd64
+      - stub-linux
+      # unixwrap not available for arm64 - users get graceful degradation
+```
+
+New:
+```yaml
+  - id: agentsh
+    package_name: agentsh
+    ids:
+      - agentsh-linux-amd64
+      - agentsh-linux-arm64
+      - shim-linux
+      - unixwrap-linux-amd64
+      - unixwrap-linux-arm64
+      - stub-linux
+```
+
+- [ ] **Step 5: Verify GoReleaser config parses**
+
+Run: `goreleaser check` (if goreleaser is installed locally), or validate YAML syntax:
+Run: `go run github.com/goreleaser/goreleaser/v2@v2.13.1 check 2>&1 || echo "goreleaser not available — verify YAML manually"`
+
+If goreleaser is not installed, verify the YAML is valid:
+Run: `python3 -c "import yaml; yaml.safe_load(open('.goreleaser.yml'))" && echo "YAML valid"`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .goreleaser.yml
+git commit -m "build: add arm64 unixwrap target + enable CGO for arm64 server
+
+Cross-compile agentsh-unixwrap and the server binary for arm64 with
+CGO_ENABLED=1 using aarch64-linux-gnu-gcc. Both architectures now ship
+with full seccomp/Landlock/signal enforcement."
+```
+
+---
+
+### Task 3: Add libseccomp-dev:arm64 to release CI
+
+**Files:**
+- Modify: `.github/workflows/release.yml:43-51`
+
+- [ ] **Step 1: Add multi-arch apt and libseccomp-dev:arm64**
+
+In `.github/workflows/release.yml`, replace the "Install build deps" step (lines 43-51):
+
+Old:
+```yaml
+      - name: Install build deps (envshim, fuse, seccomp)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libseccomp-dev \
+            libfuse-dev \
+            pkg-config \
+            gcc-aarch64-linux-gnu \
+            make
+```
+
+New:
+```yaml
+      - name: Install build deps (envshim, fuse, seccomp)
+        run: |
+          sudo dpkg --add-architecture arm64
+          sudo apt-get update
+          sudo apt-get install -y \
+            libseccomp-dev \
+            libseccomp-dev:arm64 \
+            libfuse-dev \
+            pkg-config \
+            gcc-aarch64-linux-gnu \
+            make
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci: add libseccomp-dev:arm64 for arm64 cross-compilation
+
+Enables multi-arch apt and installs the arm64 libseccomp headers so
+GoReleaser can cross-compile agentsh-unixwrap and the server binary
+for arm64 with CGO enabled."
+```
+
+---
+
+### Task 4: Verify cross-compilation locally
+
+- [ ] **Step 1: Verify arm64 server builds with CGO**
+
+Run:
+```bash
+CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig GOOS=linux GOARCH=arm64 go build -o /dev/null ./cmd/agentsh
+```
+Expected: build succeeds (exit 0). If `aarch64-linux-gnu-gcc` or `libseccomp-dev:arm64` is not installed locally, this will fail — that's fine, CI will handle it. Log the result either way.
+
+- [ ] **Step 2: Verify arm64 unixwrap builds with CGO**
+
+Run:
+```bash
+CGO_ENABLED=1 CC=aarch64-linux-gnu-gcc PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig GOOS=linux GOARCH=arm64 go build -o /dev/null ./cmd/agentsh-unixwrap
+```
+Expected: same as above — succeeds if cross-compile toolchain is present.
+
+- [ ] **Step 3: Verify amd64 builds are unaffected**
+
+Run:
+```bash
+go build ./...
+go test ./...
+```
+Expected: PASS — no regressions on the native architecture.
+
+- [ ] **Step 4: Verify Windows cross-compile is unaffected**
+
+Run:
+```bash
+GOOS=windows go build ./...
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit (no code changes — verification only)**
+
+No commit needed. If any verification step surfaced issues, fix them and commit as part of the relevant task.

--- a/docs/superpowers/specs/2026-04-10-arm64-enforcement-design.md
+++ b/docs/superpowers/specs/2026-04-10-arm64-enforcement-design.md
@@ -1,0 +1,180 @@
+# arm64 Enforcement + Detect Accuracy
+
+**Date:** 2026-04-10
+**Status:** Draft
+
+## Problem
+
+arm64 Linux releases ship with kernel-level enforcement effectively off:
+
+1. `agentsh-unixwrap` is not built for arm64 — `.goreleaser.yml` only has an amd64 target because cross-compiling requires `libseccomp-dev:arm64`.
+2. The arm64 server binary is built with `CGO_ENABLED=0`, so seccomp/signal/notify handlers compile as no-op stubs.
+3. On arm64, the server logs "running without seccomp enforcement" at startup and skips seccomp filter installation and Landlock setup.
+4. `agentsh detect` still reports 100/100 because it probes kernel capabilities (seccomp, Landlock, FUSE support), not whether the wrapper binary is present or enforcement is active.
+
+Net effect: arm64 installs have no seccomp interception, no Landlock scoping, and no signal filtering — but the self-test reports full capability.
+
+## Solution
+
+Two changes:
+
+1. **Build unixwrap and server for arm64 with CGO enabled** by cross-compiling on the existing release runner.
+2. **Make `detect` check for the wrapper binary** and mark seccomp/Landlock backends as unavailable when it's missing.
+
+## Part 1: arm64 Cross-Compilation
+
+### CI Changes (`release.yml`)
+
+Add multi-arch apt support and `libseccomp-dev:arm64` to the goreleaser job's "Install build deps" step:
+
+```yaml
+- name: Install build deps (envshim, fuse, seccomp)
+  run: |
+    sudo dpkg --add-architecture arm64
+    sudo apt-get update
+    sudo apt-get install -y \
+      libseccomp-dev \
+      libseccomp-dev:arm64 \
+      libfuse-dev \
+      pkg-config \
+      gcc-aarch64-linux-gnu \
+      make
+```
+
+`gcc-aarch64-linux-gnu` is already installed. The only new package is `libseccomp-dev:arm64` (plus the `dpkg --add-architecture` setup).
+
+The `ci.yml` cross-compile matrix keeps `CGO_ENABLED=0` for arm64 — that job is build-verification, not release.
+
+### GoReleaser Changes (`.goreleaser.yml`)
+
+**New build target — unixwrap for arm64:**
+
+```yaml
+- id: unixwrap-linux-arm64
+  main: ./cmd/agentsh-unixwrap
+  binary: agentsh-unixwrap
+  env:
+    - CGO_ENABLED=1
+    - CC=aarch64-linux-gnu-gcc
+    - PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+  goos:
+    - linux
+  goarch:
+    - arm64
+  ldflags:
+    - -s -w
+```
+
+This mirrors how `build-envshim.sh` and `build-ptracer.sh` already cross-compile for arm64: same `CC=aarch64-linux-gnu-gcc`, with `PKG_CONFIG_PATH` pointing to the arm64 sysroot so `pkg-config` finds the correct `libseccomp.pc`.
+
+**Flip server arm64 build to CGO_ENABLED=1:**
+
+```yaml
+- id: agentsh-linux-arm64
+  main: ./cmd/agentsh
+  binary: agentsh
+  env:
+    - CGO_ENABLED=1
+    - CC=aarch64-linux-gnu-gcc
+    - PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+  goos:
+    - linux
+  goarch:
+    - arm64
+  ldflags:
+    - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}}
+```
+
+The arm64 server binary now compiles with real signal/notify handlers instead of stubs.
+
+**Add unixwrap-linux-arm64 to packaging:**
+
+Archives section — add `unixwrap-linux-arm64` to the `agentsh-linux` archive's `ids` list. Remove `allow_different_binary_count: true` since both architectures now produce the same binary set.
+
+nfpms section — add `unixwrap-linux-arm64` to the `agentsh` package's `ids` list. Remove the "unixwrap not available for arm64" comment.
+
+## Part 2: Detect Wrapper Check
+
+### Location
+
+`internal/capabilities/detect_linux.go`, in the `Detect()` function.
+
+### Logic
+
+After building domains from `buildLinuxDomains()` but before calling `ComputeScore()`, check whether `agentsh-unixwrap` is on PATH via `exec.LookPath`. If not found, mark the following backends as unavailable:
+
+| Domain | Backend | Why |
+|--------|---------|-----|
+| File Protection | `seccomp-notify` | Wrapper installs the BPF user-notify filter |
+| File Protection | `landlock` | Wrapper calls `applyLandlock()` |
+| Command Control | `seccomp-execve` | Wrapper installs the execve BPF filter |
+
+**Backends NOT affected:**
+
+| Domain | Backend | Why |
+|--------|---------|-----|
+| File Protection | `fuse` | Mounted by the server process |
+| Command Control | `ptrace` | Server-side `PTRACE_SEIZE`, independent of wrapper |
+| Network | all | Independent of wrapper |
+| Resource Limits | all | Independent of wrapper |
+| Isolation | all | Independent of wrapper |
+
+### Implementation
+
+Add a helper function `applyWrapperAvailability(domains []ProtectionDomain)` that:
+
+1. Calls `exec.LookPath("agentsh-unixwrap")`.
+2. If the binary is not found, iterates over domains and sets `Available = false` for the three affected backends (`seccomp-notify`, `landlock`, `seccomp-execve`).
+3. Returns a boolean indicating whether the wrapper was found (used for tip generation).
+
+Call this in `Detect()` between `buildLinuxDomains()` and `ComputeScore()`.
+
+The function must also update the `Active` field for affected domains. If the currently active backend is one of the three being disabled, `Active` should fall back to the next available backend in the domain (e.g., Command Control falls back from `seccomp-execve` to `ptrace` if ptrace is available, or to `""` if not). This keeps the `Active` field consistent with backend availability.
+
+### Tip
+
+When the wrapper is missing, add a tip to the result:
+
+```
+Feature: seccomp-wrapper
+Status:  missing
+Impact:  seccomp and Landlock enforcement disabled — processes run without kernel-level interception
+Action:  install agentsh-unixwrap or rebuild the package with CGO_ENABLED=1
+```
+
+### FileEnforcement Update
+
+`SecurityCapabilities.FileEnforcement` is set before `buildLinuxDomains()` by `detectFileEnforcementBackend()`. If the wrapper is missing and `FileEnforcement` is `"landlock"` or `"seccomp-notify"`, `applyWrapperAvailability()` must also update it to the next available backend (`"fuse"` if available, otherwise `"none"`). This keeps the `backwardCompatCaps` output and the domain's `Active` field consistent.
+
+### Score Impact
+
+On a system with full kernel support but no wrapper:
+- File Protection (25): remains 25 if FUSE is available (FUSE is server-side)
+- Command Control (25): remains 25 if ptrace is available (ptrace is server-side)
+- Other domains: unaffected
+
+The main value is per-backend accuracy — `seccomp-notify: -` instead of `seccomp-notify: ✓` — and the explicit tip. The score drops meaningfully only on systems that also lack FUSE and ptrace.
+
+### Test
+
+Add a unit test in `detect_linux_test.go` (or the existing test file for detect) that:
+- Mocks `exec.LookPath` to return an error (wrapper not found)
+- Calls `Detect()`
+- Asserts that `seccomp-notify`, `landlock`, and `seccomp-execve` backends are `Available = false`
+- Asserts that `fuse` and `ptrace` backends retain their probed values
+- Asserts that the tip for `seccomp-wrapper` is present
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `.goreleaser.yml` | New `unixwrap-linux-arm64` build; flip `agentsh-linux-arm64` to CGO=1; update archives + nfpms |
+| `.github/workflows/release.yml` | Add `dpkg --add-architecture arm64` + `libseccomp-dev:arm64` |
+| `internal/capabilities/detect_linux.go` | Add `applyWrapperAvailability()`, call from `Detect()` |
+| `internal/capabilities/detect_linux_test.go` | Test for wrapper-missing scenario |
+
+## Out of Scope
+
+- Build-time CGO flag embedding (checking whether the binary itself was built with CGO)
+- Runtime server health probing from detect
+- Changes to `ci.yml` (build-verification only, not release)

--- a/internal/capabilities/detect_linux.go
+++ b/internal/capabilities/detect_linux.go
@@ -2,7 +2,14 @@
 
 package capabilities
 
-import "fmt"
+import (
+	"fmt"
+	"os/exec"
+)
+
+// wrapperLookPath is the function used to check if the wrapper binary exists.
+// Package-level var for testability (matches checkPtrace pattern in check.go).
+var wrapperLookPath = exec.LookPath
 
 // detectFileEnforcementBackend returns the best available file enforcement backend.
 func detectFileEnforcementBackend(caps *SecurityCapabilities) string {
@@ -118,6 +125,94 @@ func buildLinuxDomains(caps *SecurityCapabilities) []ProtectionDomain {
 	}
 }
 
+// wrapperDependentBackends lists backends that require agentsh-unixwrap.
+// These are marked unavailable when the wrapper binary is not on PATH.
+var wrapperDependentBackends = map[string]bool{
+	"seccomp-notify":  true,
+	"landlock":        true,
+	"seccomp-execve":  true,
+	"landlock-network": true,
+}
+
+// applyWrapperAvailability checks if agentsh-unixwrap is on PATH and marks
+// wrapper-dependent backends as unavailable if it's missing. Also updates
+// secCaps.FileEnforcement and domain Active fields for consistency.
+// Returns true if the wrapper was found.
+//
+// Note: this checks the default wrapper binary name. The server config allows
+// overriding via sandbox.unix_sockets.wrapper_bin, but Detect() is intentionally
+// config-agnostic — it probes system capabilities, not config state. Config-aware
+// validation lives in CheckConfig().
+func applyWrapperAvailability(domains []ProtectionDomain, secCaps *SecurityCapabilities) bool {
+	_, err := wrapperLookPath("agentsh-unixwrap")
+	if err == nil {
+		return true
+	}
+
+	// Wrapper missing — clear secCaps fields for wrapper-dependent capabilities
+	// so SelectMode() and backwardCompatCaps() reflect the real state.
+	// These must be cleared before the domain loop because SelectMode() and
+	// the Active derivation read from secCaps.
+	secCaps.Seccomp = false
+	secCaps.Landlock = false
+	secCaps.LandlockNetwork = false
+
+	// Update FileEnforcement before the domain loop since File Protection
+	// reads it for Active derivation.
+	switch secCaps.FileEnforcement {
+	case "landlock", "seccomp-notify":
+		if secCaps.FUSE {
+			secCaps.FileEnforcement = "fuse"
+		} else {
+			secCaps.FileEnforcement = "none"
+		}
+	}
+
+	// Disable dependent backends in domains and re-derive Active
+	for i := range domains {
+		activeDisabled := false
+		for j := range domains[i].Backends {
+			if wrapperDependentBackends[domains[i].Backends[j].Name] {
+				if domains[i].Backends[j].Name == domains[i].Active {
+					activeDisabled = true
+				}
+				domains[i].Backends[j].Available = false
+			}
+		}
+		if activeDisabled {
+			domains[i].Active = ""
+			// Re-derive Active using capability-aware logic rather than
+			// blindly picking first available (e.g., ptrace should only
+			// be active when PtraceEnabled is true and mode selects it).
+			mode := secCaps.SelectMode()
+			switch domains[i].Name {
+			case "File Protection":
+				domains[i].Active = secCaps.FileEnforcement
+			case "Command Control":
+				if mode == ModePtrace {
+					domains[i].Active = "ptrace"
+				}
+				// otherwise remains "" — no active command control
+			case "Network":
+				if secCaps.EBPFProbe.Available {
+					domains[i].Active = "ebpf"
+				}
+				// landlock-network disabled, so no fallback
+			default:
+				// Other domains: pick first available
+				for _, b := range domains[i].Backends {
+					if b.Available {
+						domains[i].Active = b.Name
+						break
+					}
+				}
+			}
+		}
+	}
+
+	return false
+}
+
 // backwardCompatCaps builds the flat capabilities map for backward compatibility.
 func backwardCompatCaps(caps *SecurityCapabilities, domains []ProtectionDomain) map[string]any {
 	m := map[string]any{
@@ -173,6 +268,18 @@ func Detect() (*DetectResult, error) {
 	secCaps.FileEnforcement = detectFileEnforcementBackend(secCaps)
 
 	domains := buildLinuxDomains(secCaps)
+
+	// Check wrapper availability before scoring — marks seccomp/landlock
+	// backends unavailable if agentsh-unixwrap is not on PATH.
+	//
+	// This check lives in Detect() rather than DetectSecurityCapabilities()
+	// because the server already handles wrapper absence at runtime via
+	// setupSeccompWrapper() in core.go (its own LookPath + graceful
+	// degradation). Moving it into DetectSecurityCapabilities() would change
+	// the contract for all callers. Detect() is the user-facing capability
+	// report where accuracy matters most.
+	wrapperFound := applyWrapperAvailability(domains, secCaps)
+
 	score := ComputeScore(domains)
 	mode := secCaps.SelectMode()
 
@@ -190,6 +297,39 @@ func Detect() (*DetectResult, error) {
 	}
 
 	tips := GenerateTipsFromDomains(domains)
+
+	// When the wrapper is missing, suppress generic backend tips for
+	// wrapper-dependent backends (e.g., "run privileged" for seccomp).
+	// The wrapper-specific tip below is the actionable remediation.
+	//
+	// We build the suppress set from tipsByBackend because tip.Feature
+	// doesn't always match the backend name (e.g., seccomp-execve backend
+	// emits a tip with Feature "seccomp").
+	if !wrapperFound {
+		suppressFeatures := make(map[string]bool)
+		for name := range wrapperDependentBackends {
+			if tip, ok := tipsByBackend[name]; ok {
+				suppressFeatures[tip.Feature] = true
+			}
+		}
+
+		filtered := tips[:0]
+		for _, tip := range tips {
+			if !suppressFeatures[tip.Feature] {
+				filtered = append(filtered, tip)
+			}
+		}
+		tips = filtered
+
+		// Add wrapper-specific tip regardless of domain score (FUSE may keep
+		// File Protection scored, but the missing wrapper is still actionable).
+		tips = append(tips, Tip{
+			Feature: "seccomp-wrapper",
+			Status:  "missing",
+			Impact:  "seccomp and Landlock enforcement disabled — processes run without kernel-level interception",
+			Action:  "install agentsh-unixwrap or rebuild the package with CGO_ENABLED=1",
+		})
+	}
 
 	return &DetectResult{
 		Platform:        "linux",

--- a/internal/capabilities/detect_linux_test.go
+++ b/internal/capabilities/detect_linux_test.go
@@ -3,6 +3,7 @@
 package capabilities
 
 import (
+	"os/exec"
 	"testing"
 )
 
@@ -63,5 +64,201 @@ func TestDetect_Linux_Summary(t *testing.T) {
 		if availSet[u] {
 			t.Errorf("Feature %q in both Available and Unavailable", u)
 		}
+	}
+}
+
+func TestApplyWrapperAvailability_Missing(t *testing.T) {
+	// Override LookPath to simulate missing wrapper
+	orig := wrapperLookPath
+	wrapperLookPath = func(file string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+	defer func() { wrapperLookPath = orig }()
+
+	// Build domains with all backends available
+	caps := &SecurityCapabilities{
+		Seccomp:         true,
+		Landlock:        true,
+		LandlockABI:     5,
+		LandlockNetwork: true,
+		FUSE:            true,
+		Ptrace:          true,
+	}
+	caps.FileEnforcement = detectFileEnforcementBackend(caps)
+	domains := buildLinuxDomains(caps)
+
+	// Wrapper not found
+	found := applyWrapperAvailability(domains, caps)
+	if found {
+		t.Fatal("applyWrapperAvailability returned true, want false")
+	}
+
+	// Check affected backends are unavailable
+	for _, d := range domains {
+		for _, b := range d.Backends {
+			switch b.Name {
+			case "seccomp-notify", "landlock", "seccomp-execve", "landlock-network":
+				if b.Available {
+					t.Errorf("backend %q should be unavailable when wrapper missing", b.Name)
+				}
+			case "fuse", "ptrace":
+				if !b.Available {
+					t.Errorf("backend %q should remain available when wrapper missing", b.Name)
+				}
+			}
+		}
+	}
+
+	// secCaps fields should be cleared for wrapper-dependent capabilities
+	if caps.Seccomp {
+		t.Error("Seccomp should be false when wrapper missing")
+	}
+	if caps.Landlock {
+		t.Error("Landlock should be false when wrapper missing")
+	}
+	if caps.LandlockNetwork {
+		t.Error("LandlockNetwork should be false when wrapper missing")
+	}
+
+	// FileEnforcement should fall back to fuse
+	if caps.FileEnforcement != "fuse" {
+		t.Errorf("FileEnforcement = %q, want 'fuse'", caps.FileEnforcement)
+	}
+}
+
+func TestApplyWrapperAvailability_Missing_NoFUSE(t *testing.T) {
+	// Override LookPath to simulate missing wrapper
+	orig := wrapperLookPath
+	wrapperLookPath = func(file string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+	defer func() { wrapperLookPath = orig }()
+
+	caps := &SecurityCapabilities{
+		Seccomp:     true,
+		Landlock:    true,
+		LandlockABI: 5,
+		FUSE:        false,
+		Ptrace:      true,
+	}
+	caps.FileEnforcement = detectFileEnforcementBackend(caps)
+	domains := buildLinuxDomains(caps)
+
+	found := applyWrapperAvailability(domains, caps)
+	if found {
+		t.Fatal("applyWrapperAvailability returned true, want false")
+	}
+
+	// FileEnforcement should fall back to none
+	if caps.FileEnforcement != "none" {
+		t.Errorf("FileEnforcement = %q, want 'none'", caps.FileEnforcement)
+	}
+
+	// secCaps fields should be cleared for wrapper-dependent capabilities
+	if caps.Seccomp {
+		t.Error("Seccomp should be false when wrapper missing")
+	}
+	if caps.Landlock {
+		t.Error("Landlock should be false when wrapper missing")
+	}
+	if caps.LandlockNetwork {
+		t.Error("LandlockNetwork should be false when wrapper missing")
+	}
+}
+
+func TestApplyWrapperAvailability_Present(t *testing.T) {
+	orig := wrapperLookPath
+	wrapperLookPath = func(file string) (string, error) {
+		return "/usr/local/bin/" + file, nil
+	}
+	defer func() { wrapperLookPath = orig }()
+
+	caps := &SecurityCapabilities{
+		Seccomp:     true,
+		Landlock:    true,
+		LandlockABI: 5,
+		FUSE:        true,
+		Ptrace:      true,
+	}
+	caps.FileEnforcement = detectFileEnforcementBackend(caps)
+	domains := buildLinuxDomains(caps)
+
+	found := applyWrapperAvailability(domains, caps)
+	if !found {
+		t.Fatal("applyWrapperAvailability returned false, want true")
+	}
+
+	// All backends should remain as probed
+	for _, d := range domains {
+		for _, b := range d.Backends {
+			switch b.Name {
+			case "seccomp-notify", "seccomp-execve", "landlock":
+				if !b.Available {
+					t.Errorf("backend %q should be available when wrapper present", b.Name)
+				}
+			}
+		}
+	}
+
+	// FileEnforcement should be unchanged
+	if caps.FileEnforcement != "landlock" {
+		t.Errorf("FileEnforcement = %q, want 'landlock'", caps.FileEnforcement)
+	}
+}
+
+func TestDetect_WrapperMissing_Tip(t *testing.T) {
+	// Override LookPath to simulate missing wrapper
+	orig := wrapperLookPath
+	wrapperLookPath = func(file string) (string, error) {
+		if file == "agentsh-unixwrap" {
+			return "", exec.ErrNotFound
+		}
+		return exec.LookPath(file)
+	}
+	defer func() { wrapperLookPath = orig }()
+
+	result, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect() error: %v", err)
+	}
+
+	// seccomp-notify, landlock, seccomp-execve, landlock-network should be unavailable
+	for _, d := range result.Domains {
+		for _, b := range d.Backends {
+			switch b.Name {
+			case "seccomp-notify", "landlock", "seccomp-execve", "landlock-network":
+				if b.Available {
+					t.Errorf("backend %q should be unavailable when wrapper missing", b.Name)
+				}
+			}
+		}
+	}
+
+	// Wrapper tip should be present
+	found := false
+	for _, tip := range result.Tips {
+		if tip.Feature == "seccomp-wrapper" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected seccomp-wrapper tip when wrapper missing")
+	}
+
+	// Flat capabilities should reflect wrapper absence
+	if seccomp, ok := result.Capabilities["seccomp"].(bool); ok && seccomp {
+		t.Error("capabilities.seccomp should be false when wrapper missing")
+	}
+	if landlock, ok := result.Capabilities["landlock"].(bool); ok && landlock {
+		t.Error("capabilities.landlock should be false when wrapper missing")
+	}
+	if landlockNet, ok := result.Capabilities["landlock_network"].(bool); ok && landlockNet {
+		t.Error("capabilities.landlock_network should be false when wrapper missing")
+	}
+
+	// SecurityMode should not be "full" or "landlock*" without wrapper
+	if result.SecurityMode == "full" || result.SecurityMode == "landlock" {
+		t.Errorf("SecurityMode = %q, should not report full/landlock without wrapper", result.SecurityMode)
 	}
 }


### PR DESCRIPTION
## Summary

- **arm64 releases now ship with full seccomp/Landlock enforcement.** `agentsh-unixwrap` and the server binary are cross-compiled for arm64 with `CGO_ENABLED=1` using the existing release runner.
- **`agentsh detect` now reports accurate scores** when the wrapper binary is missing — seccomp-notify, landlock, landlock-network, and seccomp-execve backends are marked unavailable, and a clear `seccomp-wrapper: missing` tip guides remediation.

## Changes

| Commit | What |
|--------|------|
| `01087619` | `detect` marks wrapper-dependent backends unavailable when `agentsh-unixwrap` is not on PATH; clears secCaps flags for consistent `SelectMode()` and flat capability map; suppresses misleading generic tips |
| `6e6890d6` | New `unixwrap-linux-arm64` GoReleaser target; flips `agentsh-linux-arm64` server to `CGO_ENABLED=1` with cross-compiler |
| `3478491a` | Adds `dpkg --add-architecture arm64` + `libseccomp-dev:arm64` to release CI |

## Test plan

- [ ] `go test ./...` passes (all existing + 4 new detect tests)
- [ ] `GOOS=windows go build ./...` passes (no regression)
- [ ] arm64 cross-compilation works in CI (requires `aarch64-linux-gnu-gcc` + `libseccomp-dev:arm64`)
- [ ] Verify `agentsh detect` on arm64 shows seccomp/landlock backends as available (post-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)