### PR TITLE
feat: declared http_services with /svc routing and fail-closed gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ agentsh sits *under* your agent/tooling—intercepting **file**, **network**, **
   - PTY activity
   - LLM API requests with DLP and usage tracking
   - signal send/block (Linux enforced, macOS/Windows audit)
+  - Route outbound HTTP API calls through declared services (**http_services**) with per-method, per-path rules, approval gating, and fail-closed host enforcement
 - **Two output modes**:
   - human-friendly shell output
   - compact JSON responses for agents/tools
@@ -221,6 +222,7 @@ This writes `/etc/agentsh/shim.conf` with `force=true`, which the shim reads at 
 * environment vars
 * network (DNS/connect)
 * PTY/session settings
+* declared HTTP services
 
 ### Evaluation
 
@@ -466,6 +468,8 @@ dlp:
 
 See [LLM Proxy Documentation](docs/llm-proxy.md) for full configuration options.
 
+The same proxy also dispatches declared `http_services` entries — named API upstreams with per-method, per-path rules. See [Declared HTTP Services](docs/llm-proxy.md#declared-http-services) and the [HTTP Services Cookbook](docs/cookbook/http-services.md) for details.
+
 ---
 
 ### Policy Generation
@@ -679,6 +683,7 @@ Ready-to-use snippets for configuring AI coding assistants to use agentsh:
 * Example Dockerfile (with shim): [`Dockerfile.example`](Dockerfile.example)
 * **Policy documentation:** [`docs/operations/policies.md`](docs/operations/policies.md) - policy variables, signal rules, network redirect
 * **Command policies cookbook:** [`docs/cookbook/command-policies.md`](docs/cookbook/command-policies.md) - how to allow a new binary, when to use `wrap` instead of `exec`, and how to debug a denial
+* **HTTP services cookbook:** [`docs/cookbook/http-services.md`](docs/cookbook/http-services.md) - recipes for routing outbound HTTP API calls through declared services with rules and approval gating
 * **Policy authoring skills:** [`skills/`](skills/) - AI-assistant skills for creating and editing policies in Claude Code, NanoClaw, etc.
 * **Platform comparison:** [`docs/platform-comparison.md`](docs/platform-comparison.md) - feature support, security scores, performance by platform
 * **Bubblewrap vs agentsh:** [`docs/bubblewrap-vs-agentsh-comparison.md`](docs/bubblewrap-vs-agentsh-comparison.md) - comparison with Bubblewrap for Linux container sandboxing

--- a/docs/approval-auth.md
+++ b/docs/approval-auth.md
@@ -957,6 +957,16 @@ func (a *agentsh) verifyApprovalToken(token *ApprovalToken, request *ApprovalReq
 
 ---
 
+## HTTP Service Approvals
+
+Rules in `http_services:` support `decision: approve` the same way `file_rules`, `command_rules`, and `network_rules` do. When a request to a declared service matches a rule with `decision: approve`, the request is held and the approvals manager presents it to the human approver through the configured channel (terminal prompt, TOTP, WebAuthn, or API).
+
+The target shown to the approver is the request path including the query string — for example, `POST /repos/owner/repo/issues?state=open`. This is the path after the `/svc/<name>/` prefix has been stripped. The `message` field from the rule is also displayed, so it is worth writing a human-readable message that explains the operation in context.
+
+All the anti-self-approval protections described in this document apply equally to `http_services` approvals: the agent key cannot access the approval endpoint, and the credential separation model prevents the agent from granting its own approval.
+
+---
+
 ## 7. Configuration
 
 ```yaml

--- a/docs/cookbook/http-services.md
+++ b/docs/cookbook/http-services.md
@@ -1,0 +1,217 @@
+# HTTP Services Cookbook
+
+This page is a practical, recipe-first guide to agentsh's **http_services** policy block:
+how to route an agent's outbound HTTP API calls through the proxy gateway, restrict
+which methods and paths are allowed, gate writes behind an approval prompt, and audit
+sensitive operations without blocking them.
+
+For the full policy language reference (variables, network redirect, signal rules,
+troubleshooting), see [`docs/operations/policies.md`](../operations/policies.md). For the
+complete `http_services:` configuration reference including env var rules and validation
+guarantees, see [Declared HTTP Services](../llm-proxy.md#declared-http-services).
+
+## How http_services routing works
+
+Declaring a service in `http_services:` does two things at once:
+
+1. The proxy exposes `/svc/<name>/` as a gateway for that service. Child processes receive
+   `<NAME>_API_URL=http://127.0.0.1:PORT/svc/<name>/` (or the name set in `expose_as`) in
+   their environment. Code that uses this variable as its base URL automatically routes
+   through the gateway.
+
+2. The netmonitor blocks direct HTTP/HTTPS connections to the upstream hostname and all
+   declared aliases. The agent cannot reach the host except through the gateway, so all
+   traffic is subject to the declared rules.
+
+Rules are evaluated in declaration order; the first rule whose `methods` and `paths` both
+match wins. If no rule matches, the service's `default` applies (`deny` when not set).
+
+## Recipe: allow an agent to read but not write a GitHub repo
+
+An agent that needs to read issues but must not be allowed to create or modify them:
+
+```yaml
+http_services:
+  - name: github
+    upstream: https://api.github.com
+    aliases: [api.github.com]
+    default: deny
+
+    rules:
+      - name: read-issues
+        methods: [GET]
+        paths:
+          - /repos/*/*/issues
+          - /repos/*/*/issues/*
+        decision: allow
+
+      - name: read-repo-meta
+        methods: [GET]
+        paths:
+          - /repos/*/*
+        decision: allow
+```
+
+The agent receives `GITHUB_API_URL=http://127.0.0.1:PORT/svc/github/`. Code that appends
+`repos/owner/repo/issues` to that base URL will be forwarded. Any other method or path
+hits `default: deny` and gets a 403.
+
+**How to verify:** Run the agent and tail the session log:
+
+```bash
+agentsh session logs <session-id> --type=llm
+```
+
+Entries with `"service_kind": "http_service"` and `"service": "github"` appear for each
+proxied request. Direct connections to `api.github.com` appear as
+`http_service_denied_direct` events.
+
+## Recipe: gate writes behind an approval prompt
+
+Add a rule before the catch-all deny that requires a human to approve issue creation:
+
+```yaml
+http_services:
+  - name: github
+    upstream: https://api.github.com
+    aliases: [api.github.com]
+    default: deny
+
+    rules:
+      - name: read-issues
+        methods: [GET]
+        paths:
+          - /repos/*/*/issues
+          - /repos/*/*/issues/*
+        decision: allow
+
+      - name: create-issue-needs-approval
+        methods: [POST]
+        paths:
+          - /repos/*/*/issues
+        decision: approve
+        message: "Agent wants to create an issue in this repo. Approve?"
+        timeout: 5m
+```
+
+When the agent POSTs to `/repos/owner/repo/issues`, the request is held and the approval
+prompt is shown through the configured approval channel (terminal, TOTP, WebAuthn, or
+API). If denied, the agent receives a 403. See [`docs/approval-auth.md`](../approval-auth.md)
+for approval channel configuration.
+
+The `message` field is shown to the approver alongside the request method and path, so
+write something a human can act on without reading raw JSON.
+
+## Recipe: expose an internal microservice at a custom env var
+
+When a service has both a public DNS name and an internal alias, list both. Use `expose_as`
+to choose a meaningful env var name:
+
+```yaml
+http_services:
+  - name: orders
+    upstream: https://orders.internal.example.com
+    expose_as: INTERNAL_ORDERS_URL
+    aliases:
+      - orders.internal.example.com
+      - orders-api.corp.example.com
+    allow_direct: false
+    default: deny
+
+    rules:
+      - name: read-order
+        methods: [GET]
+        paths:
+          - /orders/*
+          - /orders/*/items
+        decision: allow
+
+      - name: update-order-status
+        methods: [PATCH]
+        paths:
+          - /orders/*/status
+        decision: approve
+        message: "Agent wants to update order status. Approve?"
+        timeout: 2m
+```
+
+The agent receives `INTERNAL_ORDERS_URL=http://127.0.0.1:PORT/svc/orders/`. The
+netmonitor blocks direct connections to both `orders.internal.example.com` and
+`orders-api.corp.example.com`, so the agent cannot bypass the gateway by using either
+hostname directly.
+
+## Recipe: audit a third-party API without blocking
+
+When you want full visibility into what an agent does with a third-party API but do not
+need to block individual operations, set `default: allow` and add `decision: audit` rules
+for paths you want to track closely:
+
+```yaml
+http_services:
+  - name: stripe
+    upstream: https://api.stripe.com
+    aliases: [api.stripe.com]
+    default: allow    # allow all paths not matched by a rule below
+
+    rules:
+      - name: audit-charges
+        methods: ["*"]
+        paths:
+          - /v1/charges
+          - /v1/charges/*
+        decision: audit
+
+      - name: audit-payouts
+        methods: ["*"]
+        paths:
+          - /v1/payouts
+          - /v1/payouts/*
+        decision: audit
+```
+
+`decision: audit` forwards the request to the upstream and logs it to `llm-requests.jsonl`
+with `"service_kind": "http_service"`. Paths not matched by any rule fall through to
+`default: allow` and are still logged (without the explicit `audit` tag), because the
+gateway records every proxied request.
+
+## Gotchas
+
+**Paths are globs with `/` as the separator, not regex.**
+`/repos/*/*/issues` matches `/repos/owner/repo/issues` but not
+`/repos/owner/repo/labels`. Use the `gobwas/glob` documentation as reference; the
+key difference from shell globs is that `/` is treated as a separator character.
+
+**`*` does not cross segment boundaries.**
+`/repos/*/issues` matches `/repos/owner/issues` but not `/repos/owner/repo/issues`
+because there are two segments (`owner` and `repo`) between `repos` and `issues`. Use
+`**` for multi-segment matches: `/repos/**/issues` matches both.
+
+**Traversal is rejected before rule matching.**
+Paths containing `//`, `.`, or `..` segments are rejected with 403 before any rule is
+evaluated. Do not write rules intended to match those patterns — they will never fire.
+
+**A single trailing slash is stripped before matching.**
+`/repos/owner/repo/issues/` is treated the same as `/repos/owner/repo/issues` during
+rule evaluation. Write rules without trailing slashes.
+
+**Declaring a service blocks direct access to its host.**
+Setting `allow_direct: false` (the default) means any direct connection to the upstream
+host or its aliases is blocked at the network layer. Set `allow_direct: true` only as an
+escape hatch when a third-party SDK cannot be pointed at a custom base URL.
+
+**Env var names collide with the LLM proxy.**
+The names `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, and `AGENTSH_SESSION_ID` are reserved.
+Using a service name that would derive one of these names (e.g. `name: openai_base`) will
+fail at policy load. Use `expose_as` to choose a different name if your service name would
+collide, or rename the service.
+
+## Cross-references
+
+- **Full http_services reference:** [`docs/llm-proxy.md#declared-http-services`](../llm-proxy.md#declared-http-services)
+  — complete config schema, env var contract, decision flow, fail-closed behavior, logging.
+- **Policy language reference:** [`docs/operations/policies.md`](../operations/policies.md)
+  — variables, network redirect, signal rules, troubleshooting.
+- **Approval channels and auth:** [`docs/approval-auth.md`](../approval-auth.md)
+  — how `decision: approve` reaches a human, anti-self-approval, WebAuthn/TOTP/API modes.
+- **Command policies cookbook:** [`docs/cookbook/command-policies.md`](command-policies.md)
+  — parallel guide for `command_rules`.

--- a/docs/llm-proxy.md
+++ b/docs/llm-proxy.md
@@ -284,6 +284,76 @@ The proxy sets these environment variables for agent processes:
 | `ANTHROPIC_BASE_URL` | `http://127.0.0.1:<port>` | Route Anthropic SDK through proxy |
 | `OPENAI_BASE_URL` | `http://127.0.0.1:<port>` | Route OpenAI SDK through proxy |
 | `AGENTSH_SESSION_ID` | Session ID | Correlate agent requests with session |
+| `<NAME>_API_URL` (or `expose_as`) | `http://127.0.0.1:<port>/svc/<name>/` | Route child code to a declared `http_services` upstream; one variable per service. Names must not collide with the three reserved names above. |
+
+## Declared HTTP Services
+
+`http_services:` is a top-level YAML policy block that lets operators declare named HTTP upstream services a child process can reach through the proxy gateway. Each entry gives a service a URL-safe name, binds it to an upstream HTTPS URL, and defines per-method, per-path rules — so an agent can be allowed to read GitHub issues but blocked from creating them, or gated behind an approval prompt for any write.
+
+The gateway exposes each declared service as a path prefix `/svc/<name>/`. Child processes receive an env var (`<NAME>_API_URL` by default, or the name set in `expose_as`) pointing at that prefix — they treat it as the base URL and append their own paths. The proxy strips the prefix, evaluates the remaining path and method against the rules, and forwards to the upstream on allow.
+
+### Configuration example
+
+```yaml
+http_services:
+  - name: github                          # URL-safe identifier; used in /svc/github/
+    upstream: https://api.github.com      # must be https unless allow_direct is set
+    expose_as: GITHUB_API_URL             # optional; default is GITHUB_API_URL here too
+    aliases: [api.github.com]             # extra hostnames for the fail-closed host check
+    allow_direct: false                   # if false (default), direct calls to the host are blocked
+    default: deny                         # allow | deny; applied when no rule matches
+
+    rules:
+      - name: read-issues
+        methods: [GET]                    # empty or "*" means any method
+        paths:
+          - /repos/*/*/issues
+          - /repos/*/*/issues/*
+        decision: allow
+        message: "reading issues is allowed"
+
+      - name: create-issue-needs-approval
+        methods: [POST]
+        paths:
+          - /repos/*/*/issues
+        decision: approve
+        message: "Agent wants to create an issue: approve?"
+        timeout: 5m
+```
+
+### Env var contract
+
+When the proxy starts, it injects one env var per declared service into the child process environment:
+
+- The name is `<NAME>_API_URL` where `<NAME>` is the uppercased `name` field.
+- If `expose_as` is set, that exact string is used instead.
+- The value is the proxy base URL with the service prefix appended, e.g. `http://127.0.0.1:PORT/svc/github/`.
+- Child code should treat this as the new base URL and append its own path segments — e.g. `/repos/owner/repo/issues` becomes `http://127.0.0.1:PORT/svc/github/repos/owner/repo/issues`.
+- Env var names must match `[A-Za-z_][A-Za-z0-9_]*`, must not be `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, or `AGENTSH_SESSION_ID`, and must be unique across all declared services (comparison is case-insensitive on Windows).
+
+### Decision flow
+
+For each request arriving at `/svc/<name>/...`:
+
+1. The service is looked up by name from the path prefix.
+2. The remaining path is checked for traversal: `//`, `.`, and `..` segments are rejected with 403 before any rule runs. A single trailing slash is stripped before matching.
+3. Rules are evaluated in declaration order. The first rule whose `methods` and `paths` both match wins.
+4. If no rule matches, the service's `default` applies (`deny` if not set).
+5. `allow` forwards the request to the upstream; `deny` returns 403; `approve` gates on the approvals manager; `audit` logs and forwards.
+
+### Fail-closed host enforcement
+
+When a service is declared with `allow_direct: false` (the default), the netmonitor blocks direct HTTP/HTTPS connections to the upstream hostname and all aliases. The child process can only reach that host through the gateway prefix. This ensures all traffic is subject to the declared rules.
+
+When a direct attempt is blocked, an `http_service_denied_direct` event is emitted in the audit stream. Setting `allow_direct: true` opts a single service out of this constraint — use it only as an escape hatch, for example when a third-party SDK cannot be configured to use a custom base URL.
+
+### Logging
+
+HTTP service requests are logged to the same JSONL file as LLM requests (`~/.agentsh/sessions/<session-id>/llm-requests.jsonl`). Log entries carry a `service_kind` discriminator: `"llm"` for LLM proxy traffic and `"http_service"` for declared service traffic. The same storage helpers (`StoreRequestBody`, `StoreResponseBody`) and body-hash recording that apply to LLM entries apply here, so requests and responses are stored and retrievable through the same session-log commands.
+
+### When to use http_services
+
+Use `http_services` when you want to expose a specific, audited surface of a third-party API to an agent, while blocking everything else on that host. If you only need to allow the agent to reach a host without per-path rule enforcement, a `network_rules` allow is simpler. If you need to allow a host but do not want the per-method/path audit trail, use network rules. `http_services` is the right tool when you need the combination of: specific allowed paths, block-everything-else on that host, approval gating for sensitive operations, and a full request/response audit log.
 
 ## Security Considerations
 

--- a/docs/operations/policies.md
+++ b/docs/operations/policies.md
@@ -433,6 +433,65 @@ When transparent unwrapping occurs, audit events include additional fields:
 
 These fields help detect bypass attempts in audit logs.
 
+## HTTP Services
+
+`http_services:` declares named HTTP upstreams that child processes can reach through the proxy gateway. Declaring a service also blocks direct HTTP/HTTPS connections to its upstream host (and any aliases) from the child process — traffic must flow through the gateway where the declared rules are enforced.
+
+### Complete policy example
+
+```yaml
+version: 1
+name: agent-with-github
+
+# Allow agents to use tools
+command_rules:
+  - name: allow-git
+    commands: [git]
+    decision: allow
+
+# Declare one HTTP service: GitHub API read access, approve on writes
+http_services:
+  - name: github
+    upstream: https://api.github.com
+    expose_as: GITHUB_API_URL
+    aliases: [api.github.com]
+    allow_direct: false    # default; blocks direct calls to api.github.com
+    default: deny
+
+    rules:
+      - name: read-issues
+        methods: [GET]
+        paths:
+          - /repos/*/*/issues
+          - /repos/*/*/issues/*
+        decision: allow
+        message: "reading issues is allowed"
+
+      - name: create-issue-needs-approval
+        methods: [POST]
+        paths:
+          - /repos/*/*/issues
+        decision: approve
+        message: "Agent wants to create an issue: approve?"
+        timeout: 5m
+```
+
+Child processes receive `GITHUB_API_URL=http://127.0.0.1:PORT/svc/github/` in their environment. Code that calls the GitHub API should use that variable as its base URL.
+
+### Fail-closed host guard
+
+When `allow_direct: false` is set (the default), any direct outbound connection to the upstream host or its aliases is blocked at the network layer and logged as an `http_service_denied_direct` event. The agent can only reach the service through the `/svc/<name>/` gateway.
+
+Set `allow_direct: true` only as an escape hatch when a third-party SDK cannot be configured to use a custom base URL.
+
+### Approval gating
+
+Rules with `decision: approve` use the same approvals manager as other approve rules in agentsh. The target shown to the approver is the request path including the query string. See [`docs/approval-auth.md`](../approval-auth.md) for approval channel configuration and anti-self-approval protections.
+
+### Rule evaluation order
+
+Rules are evaluated in declaration order. The first rule whose `methods` and `paths` both match wins. If no rule matches, the service's `default` applies (`deny` when not set). `paths` are compiled as glob patterns with `/` as the separator — `*` matches within a single path segment, not across segments; use `**` for multi-segment matches.
+
 ## Troubleshooting
 
 ### Variable Not Expanding

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -24,10 +24,10 @@ agentsh/
 - `internal/cli/` — Cobra CLI commands (`agentsh exec`, `agentsh session …`, `agentsh events …`).
 - `internal/client/` — HTTP + gRPC clients used by the CLI (and tests) to call the server API.
 - `internal/config/` — Config structs, load/validate helpers.
-- `internal/policy/` — Policy parsing + evaluation and derived limits/timeouts.
+- `internal/policy/` — Policy parsing + evaluation and derived limits/timeouts. New in this release: `http_service.go` (YAML types, validation, host canonicalization for declared HTTP services), `http_service_check.go` (the `CheckHTTPService` evaluator with traversal guard and `DeclaredHTTPServiceHost`/`DeclaredHTTPServiceAllowsDirect` helpers used by the netmonitor fail-closed path), `http_service_compile.go` (`compileHTTPServices` builds the name and host lookup tables consumed by the engine), and `http_service_fuzz_test.go` (fuzz targets for the evaluator).
 - `internal/session/` — Session manager and built-in commands (`cd`, `export`, `aenv`, `als`, `acat`, `astat`).
 - `internal/fsmonitor/` — FUSE workspace view + file operation capture.
-- `internal/netmonitor/` — Network proxy + DNS cache/resolver and optional netns/transparent plumbing.
+- `internal/netmonitor/` — Network proxy + DNS cache/resolver and optional netns/transparent plumbing. The netmonitor's fail-closed check calls `DeclaredHTTPServiceHost` and `DeclaredHTTPServiceAllowsDirect` from the policy engine to block direct connections to declared `http_services` upstream hosts.
 - `internal/limits/` — Optional cgroups v2 enforcement (Linux-only; wired from exec hooks).
 - `internal/ptrace/` — Ptrace-based syscall tracer for restricted containers (Linux-only, requires SYS_PTRACE). Intercepts exec, file, network, and signal syscalls via PTRACE_SEIZE. Architecture-specific register access (amd64, arm64). Wired into the server via `internal/api/` for both exec and wrap paths. Includes `AttachOption` functional options for session/command association and keepStopped control, `WaitAttached`/`ResumePID` for synchronous attach flow. Seccomp prefilter injection (`inject_seccomp.go`, `seccomp_filter.go`) for reduced overhead. `Metrics` interface with Prometheus adapter (`metrics.go`, `metrics_prometheus.go`) and overhead benchmarks (`benchmark_test.go`).
 - `internal/events/` — In-memory event broker for SSE.
@@ -43,6 +43,7 @@ agentsh/
 
 - `pkg/types/` is the “schema” layer: keep it stable and versioned when changing API responses.
 - Tests live next to code (`*_test.go`) in `internal/*`.
+- `internal/proxy/proxy.go` dispatches `/svc/<name>/` requests to declared `http_services` entries. It reuses the existing session storage helpers (`StoreRequestBody`, `StoreResponseBody`) and per-service hook plumbing (header injection, credential substitution, URL rewrites) that the LLM proxy path uses, so logging and hook behavior are consistent across both kinds of proxy traffic.
 
 For gRPC:
 - `proto/agentsh/v1/agentsh.proto` defines the service (Struct-based, no codegen required).

--- a/docs/security-modes.md
+++ b/docs/security-modes.md
@@ -188,9 +188,12 @@ Ptrace mode exposes Prometheus metrics at the `/metrics` endpoint:
 | Signal interception | seccomp | ptrace | No* | No* | No* |
 | Network (kernel) | eBPF | ptrace | Landlock** | Landlock** | No |
 | Resource limits | cgroups | cgroups | cgroups | cgroups | cgroups |
+| Declared HTTP services | Yes | Yes | Yes | Yes | Yes |
 
 *Relies on PID namespace isolation + dropped CAP_KILL
 **Requires kernel 6.7+ (Landlock ABI v4)
+
+`http_services` enforcement runs entirely in the userspace proxy layer. It is not tied to any kernel primitive and applies identically on macOS, Linux, and Windows regardless of the active security mode.
 
 ### Landlock ABI Versions
 

--- a/docs/superpowers/plans/2026-04-10-http-path-verb-filtering.md
+++ b/docs/superpowers/plans/2026-04-10-http-path-verb-filtering.md
@@ -1,0 +1,2976 @@
+# HTTP Path/Verb Filtering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let operators declare HTTP services in policy with per-service method/path rules, route cooperating agents through a local gateway that enforces those rules, and fail closed on direct HTTPS to declared hosts.
+
+**Architecture:** A new `http_services:` policy section compiles into the engine and exposes `CheckHTTPService(service, method, path)`. The LLM proxy (`internal/proxy/proxy.go`) gains a path-prefix dispatch (`/svc/<name>/...`) that routes cooperating child processes into a `serveDeclaredService` handler reusing the existing hook registry, storage, and redaction pipelines. `internal/netmonitor/proxy.go` gains a fail-closed check that denies CONNECT and plain-HTTP requests to declared upstream hosts.
+
+**Tech Stack:** Go 1.22+, `gobwas/glob` (already a dependency), `yaml.v3` (already a dependency), existing `internal/policy`, `internal/proxy`, `internal/netmonitor`, `internal/approvals` packages.
+
+**Spec:** `docs/superpowers/specs/2026-04-10-http-path-verb-filtering-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+
+| File | Responsibility |
+|---|---|
+| `internal/policy/http_service.go` | `HTTPService`, `HTTPServiceRule` YAML types; `ValidateHTTPServices`; `validateHTTPServiceName` |
+| `internal/policy/http_service_test.go` | Unit tests for validation |
+| `internal/policy/http_service_compile.go` | `compiledHTTPService`, `compiledHTTPServiceRule`, `compileHTTPServices` |
+| `internal/policy/http_service_check.go` | `CheckHTTPService`, `DeclaredHTTPServiceHost`, `HTTPServices` methods |
+| `internal/policy/http_service_check_test.go` | Table-driven evaluator tests |
+| `internal/policy/http_service_fuzz_test.go` | `FuzzCheckHTTPServicePath` |
+| `internal/proxy/declared_service.go` | `declaredService` lookup, `serveDeclaredService`, request-clone helper |
+| `internal/proxy/declared_service_test.go` | Gateway integration tests |
+
+**Modified files:**
+
+| File | Change |
+|---|---|
+| `internal/policy/model.go` | Add `HTTPServices` field to `Policy`; wire `ValidateHTTPServices` into `Policy.Validate` |
+| `internal/policy/engine.go` | Call `compileHTTPServices` in `NewEngine`; add `Engine.httpServices` and `Engine.httpServiceHosts` fields |
+| `internal/proxy/proxy.go` | Add path-prefix dispatch at the top of `ServeHTTP`; extend `EnvVars()` |
+| `internal/proxy/storage.go` | Extend `RequestLogEntry` with `ServiceKind`, `ServiceName`, `RuleName` (all omitempty) |
+| `internal/proxy/proxy_test.go` | Add `EnvVars()` assertion |
+| `internal/netmonitor/proxy.go` | Add declared-host check in `handleConnect` and `handleHTTP` |
+| `internal/netmonitor/proxy_test.go` | Tests for declared-host fail-closed |
+
+---
+
+## Task 1: Add HTTPService YAML types
+
+**Files:**
+- Create: `internal/policy/http_service.go`
+- Create: `internal/policy/http_service_test.go`
+- Modify: `internal/policy/model.go`
+
+- [ ] **Step 1.1: Create the type file**
+
+Create `internal/policy/http_service.go`:
+
+```go
+package policy
+
+// HTTPService declares an HTTP service that a cooperating child process
+// can reach through the proxy gateway. Requests are matched to the service
+// by a URL path prefix (/svc/<name>/), then evaluated against Rules in
+// declaration order. First-match-wins; if no rule matches, Default applies
+// (empty or "deny" means deny).
+type HTTPService struct {
+	Name        string            `yaml:"name"`
+	Upstream    string            `yaml:"upstream"`                // https://api.github.com
+	ExposeAs    string            `yaml:"expose_as,omitempty"`     // env var name; derived from Name if empty
+	Aliases     []string          `yaml:"aliases,omitempty"`       // extra hostnames for the fail-closed check
+	AllowDirect bool              `yaml:"allow_direct,omitempty"`  // escape hatch; default false
+	Default     string            `yaml:"default,omitempty"`       // allow | deny; default deny
+	Rules       []HTTPServiceRule `yaml:"rules,omitempty"`
+}
+
+// HTTPServiceRule is a single method+path matching rule for an HTTP service.
+type HTTPServiceRule struct {
+	Name     string   `yaml:"name"`
+	Methods  []string `yaml:"methods,omitempty"` // empty or "*" means any method
+	Paths    []string `yaml:"paths"`             // gobwas/glob patterns, '/' separator
+	Decision string   `yaml:"decision"`          // allow | deny | approve | audit
+	Message  string   `yaml:"message,omitempty"`
+	Timeout  duration `yaml:"timeout,omitempty"` // parsed but not wired in v1
+}
+```
+
+- [ ] **Step 1.2: Add the field to Policy**
+
+Edit `internal/policy/model.go`. Find the `Policy` struct and add the field alongside `Services`:
+
+```go
+// External secrets: provider definitions and service declarations.
+// Parsed from YAML but validated by ValidateSecrets in secrets.go.
+Providers map[string]yaml.Node `yaml:"providers,omitempty"`
+Services  []ServiceYAML        `yaml:"services,omitempty"`
+
+// HTTP services for path/verb filtering. Orthogonal to `services:` (Plan 6).
+// See internal/policy/http_service.go and
+// docs/superpowers/specs/2026-04-10-http-path-verb-filtering-design.md
+HTTPServices []HTTPService `yaml:"http_services,omitempty"`
+```
+
+- [ ] **Step 1.3: Write the parsing test**
+
+Create `internal/policy/http_service_test.go`:
+
+```go
+package policy
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestHTTPServiceYAMLUnmarshal(t *testing.T) {
+	src := []byte(`
+http_services:
+  - name: github
+    upstream: https://api.github.com
+    expose_as: GITHUB_API_URL
+    default: deny
+    rules:
+      - name: read-issues
+        methods: [GET]
+        paths:
+          - /repos/*/*/issues
+        decision: allow
+`)
+
+	var p Policy
+	if err := yaml.Unmarshal(src, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(p.HTTPServices) != 1 {
+		t.Fatalf("expected 1 http_service, got %d", len(p.HTTPServices))
+	}
+	svc := p.HTTPServices[0]
+	if svc.Name != "github" {
+		t.Errorf("Name = %q, want github", svc.Name)
+	}
+	if svc.Upstream != "https://api.github.com" {
+		t.Errorf("Upstream = %q, want https://api.github.com", svc.Upstream)
+	}
+	if svc.ExposeAs != "GITHUB_API_URL" {
+		t.Errorf("ExposeAs = %q, want GITHUB_API_URL", svc.ExposeAs)
+	}
+	if svc.Default != "deny" {
+		t.Errorf("Default = %q, want deny", svc.Default)
+	}
+	if len(svc.Rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(svc.Rules))
+	}
+	r := svc.Rules[0]
+	if r.Name != "read-issues" || r.Decision != "allow" {
+		t.Errorf("rule = %+v, want name=read-issues decision=allow", r)
+	}
+	if len(r.Methods) != 1 || r.Methods[0] != "GET" {
+		t.Errorf("Methods = %v, want [GET]", r.Methods)
+	}
+	if len(r.Paths) != 1 || r.Paths[0] != "/repos/*/*/issues" {
+		t.Errorf("Paths = %v, want [/repos/*/*/issues]", r.Paths)
+	}
+}
+```
+
+- [ ] **Step 1.4: Run the test — expect PASS**
+
+```bash
+go test ./internal/policy/ -run TestHTTPServiceYAMLUnmarshal -v
+```
+
+Expected: PASS (the test only exercises unmarshaling, which is driven entirely by YAML struct tags).
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add internal/policy/http_service.go internal/policy/http_service_test.go internal/policy/model.go
+git commit -m "feat(policy): add HTTPService YAML types
+
+Introduces http_services top-level section with HTTPService and
+HTTPServiceRule types for path/verb filtering. No validation or
+enforcement yet - wired in subsequent tasks."
+```
+
+---
+
+## Task 2: Validate HTTPService entries
+
+**Files:**
+- Modify: `internal/policy/http_service.go`
+- Modify: `internal/policy/http_service_test.go`
+- Modify: `internal/policy/model.go`
+
+- [ ] **Step 2.1: Write validation tests first**
+
+Add to `internal/policy/http_service_test.go`:
+
+```go
+func TestValidateHTTPServices(t *testing.T) {
+	tests := []struct {
+		name    string
+		svcs    []HTTPService
+		wantErr string // substring match; empty means no error
+	}{
+		{
+			name: "valid single service",
+			svcs: []HTTPService{{
+				Name: "github", Upstream: "https://api.github.com",
+				Default: "deny",
+				Rules: []HTTPServiceRule{{
+					Name: "read", Methods: []string{"GET"},
+					Paths: []string{"/repos/*"}, Decision: "allow",
+				}},
+			}},
+		},
+		{
+			name:    "empty name rejected",
+			svcs:    []HTTPService{{Upstream: "https://api.github.com"}},
+			wantErr: "name is required",
+		},
+		{
+			name: "duplicate name rejected",
+			svcs: []HTTPService{
+				{Name: "github", Upstream: "https://api.github.com"},
+				{Name: "GITHUB", Upstream: "https://other.example.com"},
+			},
+			wantErr: "duplicate http_service name",
+		},
+		{
+			name:    "non-https upstream rejected",
+			svcs:    []HTTPService{{Name: "x", Upstream: "http://example.com"}},
+			wantErr: "upstream must be https",
+		},
+		{
+			name:    "unparseable upstream rejected",
+			svcs:    []HTTPService{{Name: "x", Upstream: "://broken"}},
+			wantErr: "invalid upstream URL",
+		},
+		{
+			name: "duplicate upstream host rejected",
+			svcs: []HTTPService{
+				{Name: "a", Upstream: "https://api.example.com"},
+				{Name: "b", Upstream: "https://api.example.com"},
+			},
+			wantErr: "duplicate upstream host",
+		},
+		{
+			name: "alias collides with other upstream",
+			svcs: []HTTPService{
+				{Name: "a", Upstream: "https://api.example.com"},
+				{Name: "b", Upstream: "https://other.example.com", Aliases: []string{"api.example.com"}},
+			},
+			wantErr: "duplicate upstream host",
+		},
+		{
+			name: "invalid default rejected",
+			svcs: []HTTPService{{
+				Name: "x", Upstream: "https://api.example.com", Default: "maybe",
+			}},
+			wantErr: "invalid default",
+		},
+		{
+			name: "invalid rule decision rejected",
+			svcs: []HTTPService{{
+				Name: "x", Upstream: "https://api.example.com",
+				Rules: []HTTPServiceRule{{
+					Name: "r", Paths: []string{"/foo"}, Decision: "redirect",
+				}},
+			}},
+			wantErr: "invalid rule decision",
+		},
+		{
+			name: "invalid glob rejected",
+			svcs: []HTTPService{{
+				Name: "x", Upstream: "https://api.example.com",
+				Rules: []HTTPServiceRule{{
+					Name: "r", Paths: []string{"[unterminated"}, Decision: "allow",
+				}},
+			}},
+			wantErr: "invalid path glob",
+		},
+		{
+			name: "empty paths rejected",
+			svcs: []HTTPService{{
+				Name: "x", Upstream: "https://api.example.com",
+				Rules: []HTTPServiceRule{{
+					Name: "r", Paths: nil, Decision: "allow",
+				}},
+			}},
+			wantErr: "rule must have at least one path",
+		},
+		{
+			name: "expose_as invalid rejected",
+			svcs: []HTTPService{{
+				Name: "x", Upstream: "https://api.example.com", ExposeAs: "1_INVALID",
+			}},
+			wantErr: "invalid expose_as",
+		},
+		{
+			name: "expose_as with hyphen derived from name invalid",
+			svcs: []HTTPService{{
+				Name: "my-svc", Upstream: "https://api.example.com",
+			}},
+			wantErr: "derived env var name is invalid",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateHTTPServices(tc.svcs)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !containsString(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
+	}
+}
+
+func containsString(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+```
+
+- [ ] **Step 2.2: Run test — expect FAIL**
+
+```bash
+go test ./internal/policy/ -run TestValidateHTTPServices -v
+```
+
+Expected: FAIL — `ValidateHTTPServices` does not exist yet.
+
+- [ ] **Step 2.3: Implement validation**
+
+Append to `internal/policy/http_service.go`:
+
+```go
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/gobwas/glob"
+)
+
+var envVarNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// ValidateHTTPServices checks an HTTPServices list for well-formedness.
+// It is called from Policy.Validate. Errors include the offending service
+// name (and rule name, when applicable) to aid debugging.
+func ValidateHTTPServices(svcs []HTTPService) error {
+	nameSeen := make(map[string]bool, len(svcs))
+	hostSeen := make(map[string]string, len(svcs)) // host -> owning service name
+	for i := range svcs {
+		s := &svcs[i]
+		if strings.TrimSpace(s.Name) == "" {
+			return fmt.Errorf("http_services[%d]: name is required", i)
+		}
+		lower := strings.ToLower(s.Name)
+		if nameSeen[lower] {
+			return fmt.Errorf("http_services: duplicate http_service name %q", s.Name)
+		}
+		nameSeen[lower] = true
+
+		u, err := url.Parse(s.Upstream)
+		if err != nil || u == nil || u.Host == "" {
+			return fmt.Errorf("http_services[%q]: invalid upstream URL %q", s.Name, s.Upstream)
+		}
+		if u.Scheme != "https" {
+			return fmt.Errorf("http_services[%q]: upstream must be https (got %q)", s.Name, u.Scheme)
+		}
+
+		host := strings.ToLower(u.Hostname())
+		if other, dup := hostSeen[host]; dup {
+			return fmt.Errorf("http_services[%q]: duplicate upstream host %q (also claimed by %q)", s.Name, host, other)
+		}
+		hostSeen[host] = s.Name
+		for _, alias := range s.Aliases {
+			a := strings.ToLower(strings.TrimSpace(alias))
+			if a == "" {
+				return fmt.Errorf("http_services[%q]: empty alias", s.Name)
+			}
+			if other, dup := hostSeen[a]; dup {
+				return fmt.Errorf("http_services[%q]: duplicate upstream host %q via alias (also claimed by %q)", s.Name, a, other)
+			}
+			hostSeen[a] = s.Name
+		}
+
+		switch s.Default {
+		case "", "allow", "deny":
+			// OK
+		default:
+			return fmt.Errorf("http_services[%q]: invalid default %q (want allow|deny)", s.Name, s.Default)
+		}
+
+		exposeAs := s.ExposeAs
+		if exposeAs == "" {
+			// Derive from name: uppercase, add "_API_URL" suffix.
+			exposeAs = strings.ToUpper(s.Name) + "_API_URL"
+			if !envVarNameRe.MatchString(exposeAs) {
+				return fmt.Errorf("http_services[%q]: derived env var name %q is invalid; set expose_as explicitly", s.Name, exposeAs)
+			}
+		} else if !envVarNameRe.MatchString(exposeAs) {
+			return fmt.Errorf("http_services[%q]: invalid expose_as %q", s.Name, exposeAs)
+		}
+
+		for j := range s.Rules {
+			r := &s.Rules[j]
+			if err := validateHTTPServiceRule(s.Name, j, r); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateHTTPServiceRule(svc string, idx int, r *HTTPServiceRule) error {
+	label := fmt.Sprintf("http_services[%q].rules[%d] (%s)", svc, idx, r.Name)
+	switch r.Decision {
+	case "allow", "deny", "approve", "audit":
+		// OK
+	default:
+		return fmt.Errorf("%s: invalid rule decision %q", label, r.Decision)
+	}
+	if len(r.Paths) == 0 {
+		return fmt.Errorf("%s: rule must have at least one path", label)
+	}
+	for _, pat := range r.Paths {
+		if _, err := glob.Compile(pat, '/'); err != nil {
+			return fmt.Errorf("%s: invalid path glob %q: %w", label, pat, err)
+		}
+	}
+	for _, m := range r.Methods {
+		if strings.TrimSpace(m) == "" {
+			return fmt.Errorf("%s: empty method", label)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2.4: Wire into Policy.Validate**
+
+Find `Policy.Validate` in `internal/policy/model.go` (look near line 500 where `ValidateSecrets` is already called). Add a call to `ValidateHTTPServices`:
+
+```go
+if err := ValidateHTTPServices(p.HTTPServices); err != nil {
+	return err
+}
+```
+
+Place it alongside `ValidateSecrets` so both run in the same pass.
+
+- [ ] **Step 2.5: Run tests — expect PASS**
+
+```bash
+go test ./internal/policy/ -run TestValidateHTTPServices -v
+```
+
+Expected: PASS for all table entries.
+
+- [ ] **Step 2.6: Run full policy test suite — nothing should break**
+
+```bash
+go test ./internal/policy/ -v
+```
+
+Expected: PASS. If existing tests break because `Validate` is stricter, investigate — the added call should be a no-op on policies without `http_services:`.
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add internal/policy/http_service.go internal/policy/http_service_test.go internal/policy/model.go
+git commit -m "feat(policy): validate http_services entries
+
+Adds ValidateHTTPServices covering: non-empty names, unique names, https
+upstream URLs, unique upstream hosts (including aliases), allow/deny
+default, allow/deny/approve/audit rule decisions, non-empty paths,
+compiling path globs, and env var name regex checks."
+```
+
+---
+
+## Task 3: Compile HTTPServices on engine construction
+
+**Files:**
+- Create: `internal/policy/http_service_compile.go`
+- Modify: `internal/policy/engine.go`
+
+- [ ] **Step 3.1: Create compile file**
+
+Create `internal/policy/http_service_compile.go`:
+
+```go
+package policy
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/gobwas/glob"
+)
+
+// compiledHTTPServiceRule is an HTTPServiceRule with pre-compiled path
+// globs and a method set for O(1) matching.
+type compiledHTTPServiceRule struct {
+	rule    HTTPServiceRule
+	methods map[string]struct{} // uppercase; empty or containing "*" means any
+	paths   []glob.Glob
+}
+
+// compiledHTTPService holds the compiled form of an HTTPService entry.
+type compiledHTTPService struct {
+	cfg             HTTPService
+	rules           []compiledHTTPServiceRule
+	upstream        *url.URL
+	envVar          string // resolved ExposeAs or derived
+	defaultDecision string // "allow" or "deny" (empty treated as "deny")
+	upstreamHost    string // lowercased for host-based lookup
+}
+
+// compileHTTPServices transforms validated HTTPService entries into the
+// compiled form used by CheckHTTPService. Panics on re-validation failure;
+// callers MUST call ValidateHTTPServices first.
+func compileHTTPServices(svcs []HTTPService) (byName, byHost map[string]*compiledHTTPService, err error) {
+	byName = make(map[string]*compiledHTTPService, len(svcs))
+	byHost = make(map[string]*compiledHTTPService, len(svcs))
+	for i := range svcs {
+		s := svcs[i]
+		u, parseErr := url.Parse(s.Upstream)
+		if parseErr != nil {
+			return nil, nil, parseErr
+		}
+
+		envVar := s.ExposeAs
+		if envVar == "" {
+			envVar = strings.ToUpper(s.Name) + "_API_URL"
+		}
+		defDec := s.Default
+		if defDec == "" {
+			defDec = "deny"
+		}
+		host := strings.ToLower(u.Hostname())
+
+		cs := &compiledHTTPService{
+			cfg:             s,
+			upstream:        u,
+			envVar:          envVar,
+			defaultDecision: defDec,
+			upstreamHost:    host,
+		}
+		for _, r := range s.Rules {
+			cr := compiledHTTPServiceRule{rule: r}
+			if len(r.Methods) > 0 {
+				cr.methods = make(map[string]struct{}, len(r.Methods))
+				for _, m := range r.Methods {
+					cr.methods[strings.ToUpper(strings.TrimSpace(m))] = struct{}{}
+				}
+			}
+			for _, pat := range r.Paths {
+				g, gerr := glob.Compile(pat, '/')
+				if gerr != nil {
+					return nil, nil, gerr
+				}
+				cr.paths = append(cr.paths, g)
+			}
+			cs.rules = append(cs.rules, cr)
+		}
+		byName[strings.ToLower(s.Name)] = cs
+		byHost[host] = cs
+		for _, alias := range s.Aliases {
+			byHost[strings.ToLower(strings.TrimSpace(alias))] = cs
+		}
+	}
+	return byName, byHost, nil
+}
+```
+
+- [ ] **Step 3.2: Wire into NewEngine**
+
+Find `NewEngine` in `internal/policy/engine.go` (around line 127). Add two new fields to the `Engine` struct (find the struct declaration — usually near the top of the file):
+
+```go
+type Engine struct {
+	// ... existing fields ...
+	httpServices     map[string]*compiledHTTPService
+	httpServiceHosts map[string]*compiledHTTPService
+}
+```
+
+Inside `NewEngine`, after validation but before returning, add:
+
+```go
+if byName, byHost, err := compileHTTPServices(p.HTTPServices); err != nil {
+	return nil, err
+} else {
+	e.httpServices = byName
+	e.httpServiceHosts = byHost
+}
+```
+
+Place this alongside other rule compilation calls (`compiledNetworkRule` etc. are built in a similar section — look for patterns like `e.compiledNetworkRules = ...`).
+
+- [ ] **Step 3.3: Write a compilation smoke test**
+
+Add to `internal/policy/http_service_test.go`:
+
+```go
+func TestCompileHTTPServices_Smoke(t *testing.T) {
+	svcs := []HTTPService{{
+		Name: "github", Upstream: "https://api.github.com",
+		Default: "deny",
+		Rules: []HTTPServiceRule{{
+			Name: "read", Methods: []string{"GET"},
+			Paths: []string{"/repos/*/*/issues"}, Decision: "allow",
+		}},
+	}}
+	if err := ValidateHTTPServices(svcs); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	byName, byHost, err := compileHTTPServices(svcs)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	cs, ok := byName["github"]
+	if !ok {
+		t.Fatal("github not in byName map")
+	}
+	if cs.envVar != "GITHUB_API_URL" {
+		t.Errorf("envVar = %q, want GITHUB_API_URL", cs.envVar)
+	}
+	if cs.upstreamHost != "api.github.com" {
+		t.Errorf("upstreamHost = %q", cs.upstreamHost)
+	}
+	if cs.defaultDecision != "deny" {
+		t.Errorf("defaultDecision = %q", cs.defaultDecision)
+	}
+	if len(cs.rules) != 1 {
+		t.Fatalf("rules = %d, want 1", len(cs.rules))
+	}
+	if _, ok := cs.rules[0].methods["GET"]; !ok {
+		t.Errorf("method GET not compiled")
+	}
+	if len(cs.rules[0].paths) != 1 {
+		t.Errorf("paths not compiled")
+	}
+	if _, ok := byHost["api.github.com"]; !ok {
+		t.Error("api.github.com not in byHost map")
+	}
+}
+```
+
+- [ ] **Step 3.4: Run tests**
+
+```bash
+go build ./internal/policy/
+go test ./internal/policy/ -run TestCompileHTTPServices_Smoke -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add internal/policy/http_service_compile.go internal/policy/engine.go internal/policy/http_service_test.go
+git commit -m "feat(policy): compile http_services in NewEngine
+
+Adds compiledHTTPService and compiledHTTPServiceRule with pre-compiled
+path globs and method sets. NewEngine builds byName and byHost maps
+that later tasks use for dispatch and fail-closed checks."
+```
+
+---
+
+## Task 4: Implement CheckHTTPService
+
+**Files:**
+- Create: `internal/policy/http_service_check.go`
+- Create: `internal/policy/http_service_check_test.go`
+
+- [ ] **Step 4.1: Write the evaluator tests first**
+
+Create `internal/policy/http_service_check_test.go`:
+
+```go
+package policy
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+func newTestEngineForHTTP(t *testing.T, svcs []HTTPService) *Engine {
+	t.Helper()
+	p := &Policy{HTTPServices: svcs}
+	if err := ValidateHTTPServices(p.HTTPServices); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	byName, byHost, err := compileHTTPServices(p.HTTPServices)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return &Engine{
+		policy:           p,
+		httpServices:     byName,
+		httpServiceHosts: byHost,
+		enforceApprovals: true,
+	}
+}
+
+func TestCheckHTTPService(t *testing.T) {
+	svcs := []HTTPService{{
+		Name: "github", Upstream: "https://api.github.com",
+		Default: "deny",
+		Rules: []HTTPServiceRule{
+			{Name: "read-issues", Methods: []string{"GET"}, Paths: []string{"/repos/*/*/issues", "/repos/*/*/issues/*"}, Decision: "allow"},
+			{Name: "wildcard-subtree", Methods: []string{"GET"}, Paths: []string{"/orgs/**"}, Decision: "allow"},
+			{Name: "any-method", Methods: []string{"*"}, Paths: []string{"/public/*"}, Decision: "allow"},
+			{Name: "multi-method", Methods: []string{"PUT", "PATCH"}, Paths: []string{"/repos/*/*"}, Decision: "allow"},
+			{Name: "block-delete", Methods: []string{"DELETE"}, Paths: []string{"/repos/**"}, Decision: "deny", Message: "no deletes"},
+		},
+	}, {
+		Name: "open", Upstream: "https://open.example.com",
+		Default: "allow",
+	}}
+
+	e := newTestEngineForHTTP(t, svcs)
+
+	tests := []struct {
+		name         string
+		service      string
+		method       string
+		path         string
+		wantDecision types.Decision
+		wantRule     string
+	}{
+		{"simple allow", "github", "GET", "/repos/a/b/issues", types.DecisionAllow, "read-issues"},
+		{"sub path allow", "github", "GET", "/repos/a/b/issues/42", types.DecisionAllow, "read-issues"},
+		{"wildcard subtree", "github", "GET", "/orgs/acme/members/list", types.DecisionAllow, "wildcard-subtree"},
+		{"method wildcard", "github", "POST", "/public/thing", types.DecisionAllow, "any-method"},
+		{"multi method PUT", "github", "PUT", "/repos/a/b", types.DecisionAllow, "multi-method"},
+		{"multi method PATCH", "github", "PATCH", "/repos/a/b", types.DecisionAllow, "multi-method"},
+		{"delete denied by rule", "github", "DELETE", "/repos/a/b", types.DecisionDeny, "block-delete"},
+		{"wrong method falls through", "github", "POST", "/repos/a/b/issues", types.DecisionDeny, "default"},
+		{"default deny", "github", "GET", "/unmatched", types.DecisionDeny, "default"},
+		{"lowercase method canonicalized", "github", "get", "/repos/a/b/issues", types.DecisionAllow, "read-issues"},
+		{"unknown service deny", "nosuch", "GET", "/anything", types.DecisionDeny, ""},
+		{"empty path coerced", "open", "GET", "", types.DecisionAllow, "default"},
+		{"traversal rejected", "github", "GET", "/repos/../etc/passwd", types.DecisionDeny, ""},
+		{"double slash rejected", "github", "GET", "/repos//a/b/issues", types.DecisionDeny, ""},
+		{"dot segment rejected", "github", "GET", "/repos/./a/b/issues", types.DecisionDeny, ""},
+		{"case sensitive path no match", "github", "GET", "/REPOS/a/b/issues", types.DecisionDeny, "default"},
+		{"query string ignored", "github", "GET", "/repos/a/b/issues?state=open", types.DecisionDeny, ""}, // traversal check is strict — '?' doesn't survive path.Clean
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Strip query string before calling — that's the gateway's job.
+			reqPath := tc.path
+			if idx := strings.Index(reqPath, "?"); idx != -1 {
+				reqPath = reqPath[:idx]
+			}
+			dec := e.CheckHTTPService(tc.service, tc.method, reqPath)
+			if dec.EffectiveDecision != tc.wantDecision {
+				t.Errorf("decision = %q, want %q (rule=%q msg=%q)",
+					dec.EffectiveDecision, tc.wantDecision, dec.Rule, dec.Message)
+			}
+			if tc.wantRule != "" && dec.Rule != tc.wantRule {
+				t.Errorf("rule = %q, want %q", dec.Rule, tc.wantRule)
+			}
+		})
+	}
+}
+```
+
+Note the query-string handling: the gateway itself strips the query before calling `CheckHTTPService`, so the evaluator does not have to. Leave the test entry as a reminder that the gateway owns this.
+
+Add the required imports:
+
+```go
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+```
+
+- [ ] **Step 4.2: Run test — expect FAIL (no method yet)**
+
+```bash
+go test ./internal/policy/ -run TestCheckHTTPService -v
+```
+
+Expected: FAIL (compile error: `e.CheckHTTPService` undefined).
+
+- [ ] **Step 4.3: Implement CheckHTTPService**
+
+Create `internal/policy/http_service_check.go`:
+
+```go
+package policy
+
+import (
+	"path"
+	"strings"
+)
+
+// CheckHTTPService evaluates method+reqPath against the rules for service.
+// reqPath is the path portion AFTER the /svc/<name> prefix has been stripped
+// and the query string removed. The gateway is responsible for stripping
+// both before calling this method.
+//
+// Returns a wrapped Decision in the same shape as CheckNetworkCtx. First-
+// match-wins on rules. If no rule matches, the service's Default applies
+// (empty or "deny" means deny). Unknown services always deny.
+func (e *Engine) CheckHTTPService(service, method, reqPath string) Decision {
+	cs, ok := e.httpServices[strings.ToLower(service)]
+	if !ok {
+		return e.wrapDecision("deny", "", "unknown http_service", nil)
+	}
+
+	if reqPath == "" {
+		reqPath = "/"
+	}
+	// Traversal guard: reject any path that doesn't survive path.Clean.
+	if path.Clean(reqPath) != reqPath {
+		return e.wrapDecision("deny", "", "path traversal rejected", nil)
+	}
+
+	m := strings.ToUpper(method)
+
+	for _, r := range cs.rules {
+		if !methodMatchesHTTPRule(r, m) {
+			continue
+		}
+		if !pathMatchesHTTPRule(r, reqPath) {
+			continue
+		}
+		return e.wrapDecision(r.rule.Decision, r.rule.Name, r.rule.Message, nil)
+	}
+
+	if cs.defaultDecision == "allow" {
+		return e.wrapDecision("allow", "default", "", nil)
+	}
+	return e.wrapDecision("deny", "default", "no rule matched", nil)
+}
+
+func methodMatchesHTTPRule(r compiledHTTPServiceRule, method string) bool {
+	if len(r.methods) == 0 {
+		return true
+	}
+	if _, ok := r.methods["*"]; ok {
+		return true
+	}
+	_, ok := r.methods[method]
+	return ok
+}
+
+func pathMatchesHTTPRule(r compiledHTTPServiceRule, reqPath string) bool {
+	for _, g := range r.paths {
+		if g.Match(reqPath) {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 4.4: Run test — expect PASS**
+
+```bash
+go test ./internal/policy/ -run TestCheckHTTPService -v
+```
+
+Expected: all sub-tests PASS.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add internal/policy/http_service_check.go internal/policy/http_service_check_test.go
+git commit -m "feat(policy): implement CheckHTTPService evaluator
+
+Table-driven tests cover first-match-wins, method/path matching,
+case canonicalization, default fallback, unknown service, empty path
+coercion, and traversal rejection."
+```
+
+---
+
+## Task 5: Implement DeclaredHTTPServiceHost and HTTPServices getters
+
+**Files:**
+- Modify: `internal/policy/http_service_check.go`
+- Modify: `internal/policy/http_service_check_test.go`
+
+- [ ] **Step 5.1: Write the tests first**
+
+Add to `internal/policy/http_service_check_test.go`:
+
+```go
+func TestDeclaredHTTPServiceHost(t *testing.T) {
+	svcs := []HTTPService{{
+		Name:     "github",
+		Upstream: "https://api.github.com",
+		ExposeAs: "GITHUB_API_URL",
+		Aliases:  []string{"api.github.example"},
+	}}
+	e := newTestEngineForHTTP(t, svcs)
+
+	tests := []struct {
+		host    string
+		wantOK  bool
+		wantSvc string
+		wantEnv string
+	}{
+		{"api.github.com", true, "github", "GITHUB_API_URL"},
+		{"API.GITHUB.COM", true, "github", "GITHUB_API_URL"},
+		{"api.github.com:443", true, "github", "GITHUB_API_URL"},
+		{"api.github.example", true, "github", "GITHUB_API_URL"},
+		{"example.com", false, "", ""},
+		{"", false, "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.host, func(t *testing.T) {
+			svc, env, ok := e.DeclaredHTTPServiceHost(tc.host)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if svc != tc.wantSvc || env != tc.wantEnv {
+				t.Errorf("got (%q, %q), want (%q, %q)", svc, env, tc.wantSvc, tc.wantEnv)
+			}
+		})
+	}
+}
+
+func TestHTTPServicesEnumeration(t *testing.T) {
+	svcs := []HTTPService{
+		{Name: "a", Upstream: "https://a.example.com"},
+		{Name: "b", Upstream: "https://b.example.com"},
+	}
+	e := newTestEngineForHTTP(t, svcs)
+	got := e.HTTPServices()
+	if len(got) != 2 {
+		t.Fatalf("got %d, want 2", len(got))
+	}
+	if got[0].Name != "a" || got[1].Name != "b" {
+		t.Errorf("ordering not preserved: %+v", got)
+	}
+}
+```
+
+- [ ] **Step 5.2: Run tests — expect FAIL**
+
+```bash
+go test ./internal/policy/ -run "TestDeclaredHTTPServiceHost|TestHTTPServicesEnumeration" -v
+```
+
+Expected: FAIL (undefined methods).
+
+- [ ] **Step 5.3: Implement the getters**
+
+Append to `internal/policy/http_service_check.go`:
+
+```go
+// DeclaredHTTPServiceHost reports whether host belongs to a declared
+// http_services entry. host may include a port (stripped before lookup)
+// and may be in any case. Returns the canonical service name and the
+// env var name used by the gateway, for inclusion in guidance messages.
+func (e *Engine) DeclaredHTTPServiceHost(host string) (serviceName, envVar string, ok bool) {
+	h := stripHTTPServiceHostPort(host)
+	h = strings.ToLower(strings.TrimSuffix(h, "."))
+	cs, found := e.httpServiceHosts[h]
+	if !found {
+		return "", "", false
+	}
+	return cs.cfg.Name, cs.envVar, true
+}
+
+// HTTPServices returns the source config list. Used by the proxy to
+// enumerate declared services for EnvVars() injection. Returns a shallow
+// copy so callers cannot mutate the engine's state.
+func (e *Engine) HTTPServices() []HTTPService {
+	if len(e.httpServices) == 0 {
+		return nil
+	}
+	out := make([]HTTPService, 0, len(e.policy.HTTPServices))
+	out = append(out, e.policy.HTTPServices...)
+	return out
+}
+
+// stripHTTPServiceHostPort removes the :port suffix, preserving IPv6
+// brackets if present. Mirrors net/http's behavior for Host headers.
+func stripHTTPServiceHostPort(host string) string {
+	if strings.HasPrefix(host, "[") {
+		if i := strings.Index(host, "]:"); i != -1 {
+			return host[:i+1]
+		}
+		return host
+	}
+	if i := strings.LastIndex(host, ":"); i != -1 {
+		return host[:i]
+	}
+	return host
+}
+```
+
+- [ ] **Step 5.4: Run tests**
+
+```bash
+go test ./internal/policy/ -run "TestDeclaredHTTPServiceHost|TestHTTPServicesEnumeration" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add internal/policy/http_service_check.go internal/policy/http_service_check_test.go
+git commit -m "feat(policy): add DeclaredHTTPServiceHost and HTTPServices
+
+DeclaredHTTPServiceHost resolves a Host header (with optional port,
+case, IPv6 brackets) to the owning service name and env var, for
+netmonitor's fail-closed check. HTTPServices returns the source
+config list for gateway env-var plumbing."
+```
+
+---
+
+## Task 6: Extend Proxy.EnvVars() to emit per-service entries
+
+**Files:**
+- Modify: `internal/proxy/proxy.go`
+- Modify: `internal/proxy/proxy_test.go` (or create)
+
+- [ ] **Step 6.1: Find the existing EnvVars method**
+
+Read `internal/proxy/proxy.go` around line 672 (where the summary says `EnvVars()` lives):
+
+```bash
+grep -n "func (p \*Proxy) EnvVars" internal/proxy/proxy.go
+```
+
+The method currently returns a map with `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, and `AGENTSH_SESSION_ID`. You will extend it to also include per-service entries from the policy engine.
+
+- [ ] **Step 6.2: Add an accessor method on Proxy for the policy engine**
+
+Look for whether `p.policy` is already stored on `*Proxy`. If it is — good, use it. If not, add it.
+
+The LLM proxy is constructed in `internal/api/app.go` (around line 433 per the spec). If the policy engine isn't yet passed in, you will need to add it — but in practice, the proxy currently accesses policy via several paths (`p.getRegistry()`, MCP intercept, etc.). Add a `policy *policy.Engine` field on `Proxy` if one doesn't already exist, and wire it through `Config` or a setter.
+
+**Decision point:** if adding a field requires touching many construction sites, instead add a new setter `func (p *Proxy) SetHTTPServices(svcs []policy.HTTPService)` and call it from the construction site in `app.go`. This keeps the blast radius minimal.
+
+- [ ] **Step 6.3: Write the test first**
+
+Add to `internal/proxy/proxy_test.go` (or create if needed):
+
+```go
+func TestEnvVars_IncludesDeclaredServices(t *testing.T) {
+	cfg := Config{SessionID: "test-session"}
+	p, err := New(cfg, "", nil)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	// Simulate the proxy having started with a bound listener.
+	p.setAddrForTest("127.0.0.1:12345")
+
+	p.SetHTTPServices([]policy.HTTPService{
+		{Name: "github", Upstream: "https://api.github.com", ExposeAs: "GITHUB_API_URL"},
+		{Name: "stripe", Upstream: "https://api.stripe.com"},
+	})
+
+	env := p.EnvVars()
+	if got := env["GITHUB_API_URL"]; got != "http://127.0.0.1:12345/svc/github" {
+		t.Errorf("GITHUB_API_URL = %q", got)
+	}
+	if got := env["STRIPE_API_URL"]; got != "http://127.0.0.1:12345/svc/stripe" {
+		t.Errorf("STRIPE_API_URL = %q", got)
+	}
+	if _, ok := env["ANTHROPIC_BASE_URL"]; !ok {
+		t.Error("ANTHROPIC_BASE_URL should still be set")
+	}
+}
+```
+
+Note: `setAddrForTest` does not exist yet; add it in the next step as an unexported-but-accessible-from-test helper.
+
+- [ ] **Step 6.4: Extend EnvVars() and add the test helper**
+
+In `internal/proxy/proxy.go`:
+
+```go
+// SetHTTPServices stores the declared HTTP services for env var injection.
+// Called once during proxy startup in app.go. Thread-safe.
+func (p *Proxy) SetHTTPServices(svcs []policy.HTTPService) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.httpServices = svcs
+}
+
+// EnvVars returns the environment variables that the gateway injects into
+// child processes. In addition to the LLM base URLs, this now includes one
+// entry per declared http_services entry.
+func (p *Proxy) EnvVars() map[string]string {
+	env := map[string]string{
+		// ... existing LLM entries ...
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	addr := p.listenerAddr
+	for _, svc := range p.httpServices {
+		name := svc.ExposeAs
+		if name == "" {
+			name = strings.ToUpper(svc.Name) + "_API_URL"
+		}
+		env[name] = "http://" + addr + "/svc/" + svc.Name
+	}
+	return env
+}
+```
+
+Keep the existing LLM entries in place; the new code appends after them.
+
+Add the test helper at the bottom of `internal/proxy/proxy.go` (or a new `proxy_testing.go` file):
+
+```go
+// setAddrForTest lets tests populate the listener address without
+// actually binding a socket. Unexported to keep it out of the public API.
+func (p *Proxy) setAddrForTest(addr string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.listenerAddr = addr
+}
+```
+
+You will also need a `listenerAddr string` field on the `Proxy` struct, populated from `listener.Addr().String()` when `Start` runs. Look for where `p.listener = listener` happens and add `p.listenerAddr = listener.Addr().String()` right after.
+
+- [ ] **Step 6.5: Run tests**
+
+```bash
+go test ./internal/proxy/ -run TestEnvVars_IncludesDeclaredServices -v
+go test ./internal/proxy/ -v
+```
+
+Expected: new test PASS. Existing tests should still PASS.
+
+- [ ] **Step 6.6: Commit**
+
+```bash
+git add internal/proxy/proxy.go internal/proxy/proxy_test.go
+git commit -m "feat(proxy): extend EnvVars with per-service base URLs
+
+Adds SetHTTPServices and extends EnvVars() to emit <NAME>_API_URL
+entries pointing at /svc/<name> on the proxy listener. Callers inject
+these into child env so SDKs can route via base URL override."
+```
+
+---
+
+## Task 7: Path-prefix dispatch in ServeHTTP
+
+**Files:**
+- Create: `internal/proxy/declared_service.go`
+- Modify: `internal/proxy/proxy.go`
+- Create: `internal/proxy/declared_service_test.go`
+
+- [ ] **Step 7.1: Write the dispatch test first**
+
+Create `internal/proxy/declared_service_test.go`:
+
+```go
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+func newTestProxyWithHTTPService(t *testing.T, upstream string, rules []policy.HTTPServiceRule) *Proxy {
+	t.Helper()
+	cfg := Config{SessionID: "test-session"}
+	p, err := New(cfg, "", nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	svcs := []policy.HTTPService{{
+		Name: "github", Upstream: upstream, Default: "deny", Rules: rules,
+	}}
+	if err := policy.ValidateHTTPServices(svcs); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	pol := &policy.Policy{HTTPServices: svcs}
+	eng, err := policy.NewEngine(pol, true, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	p.SetPolicyEngine(eng) // see step 7.3
+	p.SetHTTPServices(svcs)
+	return p
+}
+
+func TestServeHTTP_PathPrefixDispatch_NoSuchService(t *testing.T) {
+	p := newTestProxyWithHTTPService(t, "https://api.github.com", nil)
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/nosuch/foo", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+	body, _ := io.ReadAll(w.Body)
+	if !strings.Contains(string(body), "no such service") {
+		t.Errorf("body = %q, want 'no such service'", body)
+	}
+}
+```
+
+- [ ] **Step 7.2: Run test — expect FAIL**
+
+```bash
+go test ./internal/proxy/ -run TestServeHTTP_PathPrefixDispatch_NoSuchService -v
+```
+
+Expected: compile error (SetPolicyEngine / dispatch logic not yet added).
+
+- [ ] **Step 7.3: Add SetPolicyEngine and the declaredService helper**
+
+Create `internal/proxy/declared_service.go`:
+
+```go
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+const declaredServicePathPrefix = "/svc/"
+
+// SetPolicyEngine wires the policy engine for http_services dispatch.
+// Called once during startup.
+func (p *Proxy) SetPolicyEngine(e *policy.Engine) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.policyEngine = e
+}
+
+// declaredService resolves a request path to a compiled http_service entry
+// if the path starts with /svc/<name>/. Returns the service name, the
+// remaining path (starting with '/'), and ok=true when resolved.
+//
+// A path that starts with /svc/ but names a service that does not exist
+// returns ok=false with name != "". Callers use the name vs "" distinction
+// to decide between "fall through to LLM path" (no /svc/ prefix) and
+// "return 404 for unknown declared service".
+func (p *Proxy) declaredService(reqPath string) (name, rest string, ok bool) {
+	if !strings.HasPrefix(reqPath, declaredServicePathPrefix) {
+		return "", "", false
+	}
+	tail := strings.TrimPrefix(reqPath, declaredServicePathPrefix)
+	slash := strings.IndexByte(tail, '/')
+	if slash == -1 {
+		name = tail
+		rest = "/"
+	} else {
+		name = tail[:slash]
+		rest = tail[slash:]
+	}
+	if name == "" {
+		return "", "", false
+	}
+
+	p.mu.Lock()
+	eng := p.policyEngine
+	p.mu.Unlock()
+	if eng == nil {
+		// Not yet wired — treat as unknown so tests with no engine don't crash.
+		return name, rest, false
+	}
+	// Look up by calling an Engine method that tells us if the service exists.
+	// We reuse CheckHTTPService to NOT call here; instead just check via a
+	// cheap lookup. For now use the enumeration API: iterate HTTPServices.
+	for _, svc := range eng.HTTPServices() {
+		if strings.EqualFold(svc.Name, name) {
+			return svc.Name, rest, true
+		}
+	}
+	return name, rest, false
+}
+```
+
+Add the new field to the `Proxy` struct in `proxy.go`:
+
+```go
+type Proxy struct {
+	// ... existing fields ...
+	httpServices []policy.HTTPService
+	policyEngine *policy.Engine
+}
+```
+
+- [ ] **Step 7.4: Add the dispatch branch to ServeHTTP**
+
+In `internal/proxy/proxy.go`, at the top of `ServeHTTP` (right after the request-ID generation and startTime), add:
+
+```go
+// Declared HTTP service dispatch — check before LLM dialect detection.
+if name, rest, ok := p.declaredService(r.URL.Path); ok {
+	p.serveDeclaredService(w, r, name, rest, requestID, startTime)
+	return
+} else if name != "" {
+	// Path starts with /svc/<name>/ but the service is not declared.
+	// Return a dedicated 404 instead of falling through to dialect
+	// detection, so operators aren't confused by "unknown LLM dialect".
+	http.Error(w, "no such service", http.StatusNotFound)
+	return
+}
+```
+
+Add a stub `serveDeclaredService` to `declared_service.go` so it compiles:
+
+```go
+// serveDeclaredService handles a request routed to a declared http_service.
+// See docs/superpowers/specs/2026-04-10-http-path-verb-filtering-design.md §2.
+func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svcName, reqPath, requestID string, startTime time.Time) {
+	// TODO: fleshed out in Task 8. For Task 7, just 501 so tests exercising
+	// the dispatch path (not the handler) pass.
+	http.Error(w, "not implemented", http.StatusNotImplemented)
+}
+```
+
+Wait — that TODO violates the "no placeholders" rule. Instead: implement the skeleton that makes the dispatch test pass without body forwarding. Replace the stub with:
+
+```go
+func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svcName, reqPath, requestID string, startTime time.Time) {
+	// Look up the compiled service via the engine (redundant with
+	// declaredService above, but keeps serveDeclaredService self-contained
+	// for later extension).
+	p.mu.Lock()
+	eng := p.policyEngine
+	p.mu.Unlock()
+	if eng == nil {
+		http.Error(w, "http_services not configured", http.StatusInternalServerError)
+		return
+	}
+
+	// Strip query string before evaluation — the evaluator does not look at it.
+	pathForEval := reqPath
+	if idx := strings.IndexByte(pathForEval, '?'); idx != -1 {
+		pathForEval = pathForEval[:idx]
+	}
+
+	dec := eng.CheckHTTPService(svcName, r.Method, pathForEval)
+
+	switch dec.EffectiveDecision {
+	case "deny":
+		msg := dec.Message
+		if msg == "" {
+			msg = "blocked by http_services rule"
+		}
+		http.Error(w, msg, http.StatusForbidden)
+		return
+	case "allow", "audit":
+		// Forwarding implemented in Task 8. For now, return 501 so we
+		// can prove the deny path while Task 8 is in progress.
+		http.Error(w, "forwarding not implemented", http.StatusNotImplemented)
+		return
+	default:
+		http.Error(w, "unsupported decision", http.StatusInternalServerError)
+		return
+	}
+}
+```
+
+Add the required imports (`time`, `io`) as needed. The `io` import is needed only once the full handler lands in Task 8.
+
+- [ ] **Step 7.5: Run the dispatch test**
+
+```bash
+go build ./internal/proxy/
+go test ./internal/proxy/ -run TestServeHTTP_PathPrefixDispatch_NoSuchService -v
+```
+
+Expected: PASS.
+
+Add a deny-path test as well:
+
+```go
+func TestServeDeclaredService_Deny(t *testing.T) {
+	p := newTestProxyWithHTTPService(t, "https://api.github.com", []policy.HTTPServiceRule{
+		{Name: "block-delete", Methods: []string{"DELETE"}, Paths: []string{"/repos/**"}, Decision: "deny", Message: "no deletes"},
+	})
+
+	req := httptest.NewRequest(http.MethodDelete, "http://127.0.0.1/svc/github/repos/a/b", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	body, _ := io.ReadAll(w.Body)
+	if !strings.Contains(string(body), "no deletes") {
+		t.Errorf("body = %q, want 'no deletes'", body)
+	}
+}
+```
+
+Run it:
+
+```bash
+go test ./internal/proxy/ -run TestServeDeclaredService_Deny -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add internal/proxy/declared_service.go internal/proxy/declared_service_test.go internal/proxy/proxy.go
+git commit -m "feat(proxy): /svc/<name>/ dispatch for declared http_services
+
+Adds path-prefix dispatch at the top of ServeHTTP. Unknown service
+under /svc/ returns 404 instead of falling through to LLM dialect
+detection. Deny rule returns 403 with the rule message. Allow/audit
+path returns 501 pending Task 8."
+```
+
+---
+
+## Task 8: Forward allow/audit decisions to the upstream
+
+**Files:**
+- Modify: `internal/proxy/declared_service.go`
+- Modify: `internal/proxy/declared_service_test.go`
+
+- [ ] **Step 8.1: Write the forwarding test**
+
+Add to `internal/proxy/declared_service_test.go`:
+
+```go
+func TestServeDeclaredService_Allow_Forwards(t *testing.T) {
+	// Fake upstream that records the incoming request.
+	var gotMethod, gotPath string
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		io.WriteString(w, `{"ok":true}`)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "post-issues", Methods: []string{"POST"}, Paths: []string{"/repos/*/*/issues"}, Decision: "allow"},
+	})
+
+	body := strings.NewReader(`{"title":"bug"}`)
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github/repos/anthropics/claude-code/issues", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", w.Code)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("upstream method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/repos/anthropics/claude-code/issues" {
+		t.Errorf("upstream path = %q, want /repos/anthropics/claude-code/issues", gotPath)
+	}
+	if string(gotBody) != `{"title":"bug"}` {
+		t.Errorf("upstream body = %q", gotBody)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("response Content-Type = %q, want application/json", ct)
+	}
+}
+```
+
+Note the test uses `upstream.URL` — that's `http://127.0.0.1:<rand>`. For tests, the gateway must accept an `http://` upstream, not just `https://`. To make this work without weakening production validation, add a test-only knob:
+
+- Either skip the `https` validation in `ValidateHTTPServices` when the upstream host is `127.0.0.1` / `localhost` (ugly).
+- Or inject a transport override via a test helper (cleaner).
+
+**Chosen approach:** inject a transport override. Add a test helper `SetUpstreamTransportForTest(rt http.RoundTripper)` on `Proxy`, and relax the `https` check to accept `http://` URLs whose host is `127.0.0.1` or `localhost`. Rationale: test-facing but the relaxation is trivially recognized and documented.
+
+Actually, the cleanest approach: add a build-time test hook (`httpsvcTestAllowInsecure` bool) in `ValidateHTTPServices` that is set only in `_test.go` files via a package-scoped helper. Simpler:
+
+```go
+// In http_service.go, add a package var:
+var httpServiceAllowInsecureUpstreamForTest bool
+
+// In ValidateHTTPServices, replace:
+//   if u.Scheme != "https" { ... }
+// with:
+if u.Scheme != "https" && !(httpServiceAllowInsecureUpstreamForTest && u.Scheme == "http") {
+    return fmt.Errorf("...")
+}
+```
+
+And in the test init:
+
+```go
+func init() {
+    httpServiceAllowInsecureUpstreamForTest = true
+}
+```
+
+Place the `init()` in `internal/proxy/declared_service_test.go` so it only applies during `go test` of that package.
+
+- [ ] **Step 8.2: Relax the validator for tests**
+
+Edit `internal/policy/http_service.go` to add the test toggle:
+
+```go
+// httpServiceAllowInsecureUpstreamForTest, when true, lets ValidateHTTPServices
+// accept http:// upstreams. Set from test init() functions only. Never set in
+// production code.
+var httpServiceAllowInsecureUpstreamForTest bool
+
+// TestAllowInsecureHTTPServiceUpstream enables the test-only relaxation.
+// This function exists so test files in other packages can flip the toggle
+// without touching package-private state. Not thread-safe.
+func TestAllowInsecureHTTPServiceUpstream(v bool) {
+	httpServiceAllowInsecureUpstreamForTest = v
+}
+```
+
+Update the scheme check in `ValidateHTTPServices`:
+
+```go
+if u.Scheme != "https" && !(httpServiceAllowInsecureUpstreamForTest && u.Scheme == "http") {
+    return fmt.Errorf("http_services[%q]: upstream must be https (got %q)", s.Name, u.Scheme)
+}
+```
+
+Add an `init()` to `internal/proxy/declared_service_test.go`:
+
+```go
+func init() {
+	policy.TestAllowInsecureHTTPServiceUpstream(true)
+}
+```
+
+- [ ] **Step 8.3: Run the forwarding test — expect FAIL**
+
+```bash
+go test ./internal/proxy/ -run TestServeDeclaredService_Allow_Forwards -v
+```
+
+Expected: FAIL (current allow branch returns 501).
+
+- [ ] **Step 8.4: Implement forwarding**
+
+Rewrite the allow/audit branch in `serveDeclaredService`. Replace the entire method in `internal/proxy/declared_service.go`:
+
+```go
+func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svcName, reqPath, requestID string, startTime time.Time) {
+	p.mu.Lock()
+	eng := p.policyEngine
+	p.mu.Unlock()
+	if eng == nil {
+		http.Error(w, "http_services not configured", http.StatusInternalServerError)
+		return
+	}
+
+	pathForEval := reqPath
+	if idx := strings.IndexByte(pathForEval, '?'); idx != -1 {
+		pathForEval = pathForEval[:idx]
+	}
+
+	dec := eng.CheckHTTPService(svcName, r.Method, pathForEval)
+
+	switch dec.EffectiveDecision {
+	case "deny":
+		msg := dec.Message
+		if msg == "" {
+			msg = "blocked by http_services rule"
+		}
+		http.Error(w, msg, http.StatusForbidden)
+		return
+	case "allow", "audit":
+		// Proceed to forwarding.
+	default:
+		http.Error(w, "unsupported decision", http.StatusInternalServerError)
+		return
+	}
+
+	svc := p.findHTTPService(eng, svcName)
+	if svc == nil {
+		http.Error(w, "service vanished", http.StatusInternalServerError)
+		return
+	}
+
+	outReq, err := p.buildUpstreamRequest(r, svc.Upstream, reqPath)
+	if err != nil {
+		http.Error(w, "rewrite failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp, err := p.httpServiceTransport().RoundTrip(outReq)
+	if err != nil {
+		http.Error(w, "upstream error: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Copy response headers and status, then body.
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+// findHTTPService looks up a service by name from the engine's enumeration.
+// Used in the serve path to access fields (Upstream, ExposeAs) that are
+// not in the Decision struct.
+func (p *Proxy) findHTTPService(eng *policy.Engine, name string) *policy.HTTPService {
+	for _, s := range eng.HTTPServices() {
+		if strings.EqualFold(s.Name, name) {
+			s := s
+			return &s
+		}
+	}
+	return nil
+}
+
+// buildUpstreamRequest clones the inbound request and retargets it at
+// svcUpstream + reqPath + (optional query string). Preserves method, body,
+// and headers. Does NOT apply hooks — hooks are called by the caller.
+func (p *Proxy) buildUpstreamRequest(r *http.Request, svcUpstream, reqPath string) (*http.Request, error) {
+	u, err := url.Parse(svcUpstream)
+	if err != nil {
+		return nil, err
+	}
+	// Preserve query string if present on the inbound request.
+	rawQuery := r.URL.RawQuery
+	u.Path = singleSlashJoin(u.Path, reqPath)
+	u.RawQuery = rawQuery
+
+	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, u.String(), r.Body)
+	if err != nil {
+		return nil, err
+	}
+	// Copy headers, excluding hop-by-hop.
+	for k, vs := range r.Header {
+		if isHopByHopHeader(k) {
+			continue
+		}
+		for _, v := range vs {
+			outReq.Header.Add(k, v)
+		}
+	}
+	outReq.Host = u.Host
+	outReq.ContentLength = r.ContentLength
+	return outReq, nil
+}
+
+func singleSlashJoin(a, b string) string {
+	aSlash := strings.HasSuffix(a, "/")
+	bSlash := strings.HasPrefix(b, "/")
+	switch {
+	case aSlash && bSlash:
+		return a + b[1:]
+	case !aSlash && !bSlash:
+		return a + "/" + b
+	}
+	return a + b
+}
+
+func isHopByHopHeader(h string) bool {
+	switch strings.ToLower(h) {
+	case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
+		"te", "trailer", "transfer-encoding", "upgrade":
+		return true
+	}
+	return false
+}
+
+// httpServiceTransport returns the transport used to forward declared-service
+// requests. Currently http.DefaultTransport; testable via the setter below.
+func (p *Proxy) httpServiceTransport() http.RoundTripper {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.httpSvcTransport != nil {
+		return p.httpSvcTransport
+	}
+	return http.DefaultTransport
+}
+
+// SetHTTPServiceTransportForTest injects a RoundTripper used for
+// declared-service forwarding. Test-only.
+func (p *Proxy) SetHTTPServiceTransportForTest(rt http.RoundTripper) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.httpSvcTransport = rt
+}
+```
+
+Add the field to the struct in `proxy.go`:
+
+```go
+type Proxy struct {
+	// ... existing fields ...
+	httpSvcTransport http.RoundTripper
+}
+```
+
+Add missing imports to `declared_service.go`: `net/url`, `time`.
+
+- [ ] **Step 8.5: Run the test**
+
+```bash
+go build ./internal/proxy/
+go test ./internal/proxy/ -run TestServeDeclaredService_Allow_Forwards -v
+```
+
+Expected: PASS.
+
+Also run the full proxy test suite to catch regressions:
+
+```bash
+go test ./internal/proxy/ -v
+```
+
+- [ ] **Step 8.6: Commit**
+
+```bash
+git add internal/proxy/declared_service.go internal/proxy/declared_service_test.go internal/proxy/proxy.go internal/policy/http_service.go
+git commit -m "feat(proxy): forward allow decisions to upstream
+
+serveDeclaredService now builds a fresh outbound request targeting the
+service upstream, strips hop-by-hop headers, preserves method/body/
+query/headers, and copies the response back to the caller.
+
+Adds a package-private test toggle in internal/policy that lets tests
+point at an httptest.Server over http://. Production upstreams still
+must be https."
+```
+
+---
+
+## Task 9: Wire hooks into the declared-service path
+
+**Files:**
+- Modify: `internal/proxy/declared_service.go`
+- Modify: `internal/proxy/declared_service_test.go`
+
+- [ ] **Step 9.1: Write the hook test**
+
+Add to `internal/proxy/declared_service_test.go`:
+
+```go
+func TestServeDeclaredService_HooksRunPerService(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "get", Methods: []string{"GET"}, Paths: []string{"/**"}, Decision: "allow"},
+	})
+
+	// Register a hook under "github" that sets the Authorization header.
+	p.HookRegistry().Register("github", &serviceRecorderHook{
+		name: "fake-injector",
+		preFn: func(r *http.Request, ctx *RequestContext) error {
+			r.Header.Set("Authorization", "Bearer real-token")
+			if ctx.ServiceName != "github" {
+				t.Errorf("ctx.ServiceName = %q, want github", ctx.ServiceName)
+			}
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/user", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if gotAuth != "Bearer real-token" {
+		t.Errorf("upstream Authorization = %q, want 'Bearer real-token'", gotAuth)
+	}
+}
+```
+
+`serviceRecorderHook` already exists in `internal/proxy/proxy_hooks_test.go`; reuse it.
+
+- [ ] **Step 9.2: Run test — expect FAIL**
+
+```bash
+go test ./internal/proxy/ -run TestServeDeclaredService_HooksRunPerService -v
+```
+
+Expected: FAIL — hooks are not yet invoked.
+
+- [ ] **Step 9.3: Call hookRegistry from serveDeclaredService**
+
+In `internal/proxy/declared_service.go`, after the decision switch and before `buildUpstreamRequest`, add hook invocation. Replace the allow/audit branch and the forwarding code with:
+
+```go
+case "allow", "audit":
+    // fall through
+default:
+    http.Error(w, "unsupported decision", http.StatusInternalServerError)
+    return
+}
+
+// Build RequestContext for hook dispatch.
+reqCtx := &RequestContext{
+    RequestID:   requestID,
+    SessionID:   p.sessionIDFor(r),
+    ServiceName: svcName,
+    StartTime:   startTime,
+    Attrs:       make(map[string]any),
+}
+
+// Buffer the request body so hooks can read/replace it without
+// exhausting the stream.
+if r.Body != nil {
+    body, err := io.ReadAll(r.Body)
+    if err == nil {
+        r.Body = io.NopCloser(bytes.NewReader(body))
+        r.ContentLength = int64(len(body))
+    }
+}
+
+if p.hookRegistry != nil {
+    if err := p.hookRegistry.ApplyPreHooks(svcName, r, reqCtx); err != nil {
+        var abortErr *HookAbortError
+        if errors.As(err, &abortErr) {
+            code := abortErr.StatusCode
+            if code < 400 || code > 599 {
+                code = http.StatusBadGateway
+            }
+            http.Error(w, abortErr.Message, code)
+            return
+        }
+        http.Error(w, "hook error: "+err.Error(), http.StatusBadGateway)
+        return
+    }
+}
+```
+
+Then continue with `buildUpstreamRequest` / forwarding / response copy as before.
+
+Add `p.sessionIDFor(r)` helper (if one doesn't already exist — look at how the LLM path reads session ID):
+
+```go
+func (p *Proxy) sessionIDFor(r *http.Request) string {
+    if sid := r.Header.Get("X-Session-ID"); sid != "" {
+        return sid
+    }
+    return p.cfg.SessionID
+}
+```
+
+Add imports: `bytes`, `errors`. `HookAbortError` and `RequestContext` already exist in the package.
+
+- [ ] **Step 9.4: Run the test**
+
+```bash
+go test ./internal/proxy/ -run TestServeDeclaredService_HooksRunPerService -v
+```
+
+Expected: PASS.
+
+Also run the full proxy suite:
+
+```bash
+go test ./internal/proxy/ -v
+```
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add internal/proxy/declared_service.go internal/proxy/declared_service_test.go
+git commit -m "feat(proxy): dispatch service-scoped hooks in declared path
+
+serveDeclaredService now invokes hookRegistry.ApplyPreHooks with the
+service name, buffering the request body first so hooks can substitute
+it. Plan 6's HeaderInjectionHook and CredsSubHook both Just Work under
+the new dispatch because they already key on ServiceName."
+```
+
+---
+
+## Task 10: Approval gating for approve decisions
+
+**Files:**
+- Modify: `internal/proxy/declared_service.go`
+- Modify: `internal/proxy/declared_service_test.go`
+
+**Design decision for this task:** do NOT lift `maybeApprove` from netmonitor yet. Duplicate the logic inline in `declared_service.go` with a clear comment referencing the original. A future refactor task can consolidate both call sites into `internal/approvals` or a shared helper; for v1, duplication has the smallest blast radius.
+
+- [ ] **Step 10.1: Write the approval test**
+
+Add to `internal/proxy/declared_service_test.go`:
+
+```go
+type fakeApprovalsManager struct {
+	approve bool
+}
+
+func (f *fakeApprovalsManager) RequestApproval(ctx context.Context, req approvals.Request) (approvals.Result, error) {
+	return approvals.Result{Approved: f.approve}, nil
+}
+
+func TestServeDeclaredService_Approve_Approved(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, "ok")
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "require-approval", Methods: []string{"POST"}, Paths: []string{"/issues"}, Decision: "approve"},
+	})
+	p.SetApprovalsForTest(&fakeApprovalsManager{approve: true})
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github/issues", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestServeDeclaredService_Approve_Denied(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("upstream should not be reached when approval denies")
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "require-approval", Methods: []string{"POST"}, Paths: []string{"/issues"}, Decision: "approve"},
+	})
+	p.SetApprovalsForTest(&fakeApprovalsManager{approve: false})
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github/issues", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+}
+```
+
+`approvals.Request` / `approvals.Result` live in `internal/approvals`; import the package. `fakeApprovalsManager` implements whatever interface the engine expects — confirm by reading `internal/approvals/manager.go` before writing this test and adjust the method signature if needed.
+
+- [ ] **Step 10.2: Run — expect FAIL**
+
+```bash
+go test ./internal/proxy/ -run TestServeDeclaredService_Approve -v
+```
+
+Expected: compile error (`SetApprovalsForTest` / approval logic not implemented).
+
+- [ ] **Step 10.3: Implement approval path**
+
+Add to `internal/proxy/declared_service.go`:
+
+```go
+import (
+	"context"
+	// ... existing imports ...
+
+	"github.com/agentsh/agentsh/internal/approvals"
+	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/google/uuid"
+)
+
+// HTTPServiceApprovalsManager is the subset of approvals.Manager needed by
+// the declared-service path. Declared here as a local interface to keep
+// the import surface narrow and to simplify testing.
+type HTTPServiceApprovalsManager interface {
+	RequestApproval(ctx context.Context, req approvals.Request) (approvals.Result, error)
+}
+
+// SetApprovalsForTest installs an approvals manager for the declared-
+// service path. In production, wiring flows from app.go through
+// SetHTTPServiceApprovals. Kept as an explicit test setter to make the
+// dependency visible.
+func (p *Proxy) SetApprovalsForTest(m HTTPServiceApprovalsManager) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.httpSvcApprovals = m
+}
+
+// SetHTTPServiceApprovals is the production wiring hook, called from
+// app.go alongside SetPolicyEngine and SetHTTPServices.
+func (p *Proxy) SetHTTPServiceApprovals(m HTTPServiceApprovalsManager) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.httpSvcApprovals = m
+}
+```
+
+Add the field to `Proxy`:
+
+```go
+httpSvcApprovals HTTPServiceApprovalsManager
+```
+
+Insert approval gating into `serveDeclaredService` after `CheckHTTPService` and before the deny/allow switch:
+
+```go
+// Gate approve decisions on an interactive approval. This mirrors the
+// logic in internal/netmonitor/proxy.go maybeApprove; see the spec for
+// the plan to consolidate these into a shared helper.
+if dec.PolicyDecision == types.DecisionApprove && dec.EffectiveDecision == types.DecisionApprove {
+	p.mu.Lock()
+	appr := p.httpSvcApprovals
+	p.mu.Unlock()
+	if appr != nil {
+		req := approvals.Request{
+			ID:        "approval-" + uuid.NewString(),
+			SessionID: reqCtx.SessionID, // built after this block in Task 9; move construction earlier
+			CommandID: requestID,
+			Kind:      "http_service",
+			Target:    svcName + " " + r.Method + " " + pathForEval,
+			Rule:      dec.Rule,
+			Message:   dec.Message,
+		}
+		res, err := appr.RequestApproval(r.Context(), req)
+		if dec.Approval != nil {
+			dec.Approval.ID = req.ID
+		}
+		if err != nil || !res.Approved {
+			dec.EffectiveDecision = types.DecisionDeny
+		} else {
+			dec.EffectiveDecision = types.DecisionAllow
+		}
+	}
+}
+```
+
+Note the comment about moving the `RequestContext` construction earlier — Task 9 built it after the decision. Move it before this block so `reqCtx.SessionID` is populated. Restructure as:
+
+```go
+reqCtx := &RequestContext{
+    RequestID:   requestID,
+    SessionID:   p.sessionIDFor(r),
+    ServiceName: svcName,
+    StartTime:   startTime,
+    Attrs:       make(map[string]any),
+}
+
+dec := eng.CheckHTTPService(svcName, r.Method, pathForEval)
+
+// Approval gating (see comment above).
+// ... approval block ...
+
+switch dec.EffectiveDecision {
+case "deny":
+    // ... existing deny handling ...
+case "allow", "audit":
+    // fall through to hook invocation and forwarding
+}
+
+// Hook invocation (Task 9).
+// Body buffering (Task 9).
+// buildUpstreamRequest + forward (Task 8).
+```
+
+- [ ] **Step 10.4: Run the approval tests**
+
+```bash
+go test ./internal/proxy/ -run TestServeDeclaredService_Approve -v
+```
+
+Expected: both PASS.
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add internal/proxy/declared_service.go internal/proxy/declared_service_test.go internal/proxy/proxy.go
+git commit -m "feat(proxy): approval gating for approve decisions
+
+Adds approval flow to serveDeclaredService mirroring netmonitor's
+maybeApprove. Duplicated intentionally for minimal blast radius; a
+future refactor task will consolidate both call sites into a shared
+helper in internal/approvals."
+```
+
+---
+
+## Task 11: Wire startup plumbing in app.go
+
+**Files:**
+- Modify: `internal/api/app.go`
+
+This task wires the proxy's new setters to the real construction path.
+
+- [ ] **Step 11.1: Find the proxy construction**
+
+```bash
+grep -n "proxy.New\|StartLLMProxy\|proxy\.Start" internal/api/app.go
+```
+
+Locate where the LLM proxy is constructed and started. The existing code already passes the policy engine somewhere — find it (`a.policy` is likely the reference).
+
+- [ ] **Step 11.2: Wire the three setters**
+
+After `proxy.New(...)` (or equivalent) and before the proxy is started (`proxy.Start(...)`) or handed to the session launcher, add:
+
+```go
+p.SetPolicyEngine(a.policy)
+p.SetHTTPServices(a.policy.HTTPServices())
+if a.approvals != nil {
+	p.SetHTTPServiceApprovals(a.approvals)
+}
+```
+
+The approvals manager on `a.approvals` already satisfies `HTTPServiceApprovalsManager` (it has a `RequestApproval(ctx, req)` method — confirm by reading `internal/approvals/manager.go`).
+
+- [ ] **Step 11.3: Build everything**
+
+```bash
+go build ./...
+```
+
+Expected: no errors. If there are errors in app.go from mismatched types, investigate — the common issue is `a.approvals` being a concrete type whose `RequestApproval` signature differs slightly from the interface. Adjust the `HTTPServiceApprovalsManager` interface to match.
+
+- [ ] **Step 11.4: Run full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: PASS. Any failing tests probably need `p.SetPolicyEngine` injection in their harness; fix them.
+
+- [ ] **Step 11.5: Commit**
+
+```bash
+git add internal/api/app.go
+git commit -m "feat(api): wire http_services plumbing into proxy construction
+
+Calls SetPolicyEngine, SetHTTPServices, and SetHTTPServiceApprovals
+on the proxy during session setup so declared services are reachable
+via /svc/<name>/ and approve rules gate on the real approval manager."
+```
+
+---
+
+## Task 12: Netmonitor fail-closed CONNECT and HTTP checks
+
+**Files:**
+- Modify: `internal/netmonitor/proxy.go`
+- Modify: `internal/netmonitor/proxy_test.go` (or create)
+
+- [ ] **Step 12.1: Write the fail-closed tests**
+
+Find an existing netmonitor test file and add, or create `internal/netmonitor/declared_services_test.go`:
+
+```go
+package netmonitor
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+func newTestEngineWithGitHubService(t *testing.T) *policy.Engine {
+	t.Helper()
+	pol := &policy.Policy{
+		HTTPServices: []policy.HTTPService{{
+			Name: "github", Upstream: "https://api.github.com", ExposeAs: "GITHUB_API_URL",
+		}},
+	}
+	if err := policy.ValidateHTTPServices(pol.HTTPServices); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	e, err := policy.NewEngine(pol, true, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	return e
+}
+
+func TestHandleConnect_DeniesDeclaredHost(t *testing.T) {
+	// Test harness: construct a minimal netmonitor.Proxy and drive
+	// handleConnect directly with a fake client.
+	eng := newTestEngineWithGitHubService(t)
+	p := newTestNetmonitorProxy(t, eng)
+
+	client, server := newPipedConn(t)
+	go func() {
+		_, _ = client.Write([]byte("CONNECT api.github.com:443 HTTP/1.1\r\nHost: api.github.com:443\r\n\r\n"))
+	}()
+	req, err := http.ReadRequest(bufio.NewReader(server))
+	if err != nil {
+		t.Fatalf("read request: %v", err)
+	}
+
+	p.handleConnect(context.Background(), server, req, /* commandID */ "c1")
+
+	// Read the 403 response.
+	resp, err := http.ReadResponse(bufio.NewReader(client), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "GITHUB_API_URL") {
+		t.Errorf("body = %q, want mention of GITHUB_API_URL", body)
+	}
+}
+```
+
+Test helpers `newTestNetmonitorProxy` and `newPipedConn` need to exist. Look at existing netmonitor tests first; if none exist, write them minimally in the same file:
+
+```go
+// newTestNetmonitorProxy builds a Proxy with just enough fields to
+// exercise handleConnect. Fields that matter: policy engine, emitter.
+// Everything else can be nil or a no-op.
+func newTestNetmonitorProxy(t *testing.T, eng *policy.Engine) *Proxy {
+	t.Helper()
+	return &Proxy{
+		policy:    eng,
+		emit:      newNoOpEmitter(),
+		sessionID: "test-session",
+	}
+}
+
+func newPipedConn(t *testing.T) (client, server net.Conn) {
+	// ...
+}
+```
+
+- [ ] **Step 12.2: Run — expect FAIL**
+
+```bash
+go test ./internal/netmonitor/ -run TestHandleConnect_DeniesDeclaredHost -v
+```
+
+Expected: FAIL or compile error (no check implemented yet).
+
+- [ ] **Step 12.3: Add the fail-closed check in handleConnect**
+
+In `internal/netmonitor/proxy.go`, find `handleConnect` around line 110 and the point where `dec` is computed from `p.policy.CheckNetworkCtx(...)`. Right after that — before `maybeApprove` — add:
+
+```go
+// Fail-closed check: if the target host is declared as an
+// http_services upstream, deny direct HTTPS regardless of the
+// CheckNetworkCtx decision. The only way to reach the upstream is
+// through the gateway via /svc/<name>/.
+if svcName, envVar, ok := p.policy.DeclaredHTTPServiceHost(host); ok {
+	// Respect the allow_direct escape hatch (future work: query the
+	// engine for the flag; for v1, require explicit opt-out elsewhere).
+	msg := "direct HTTPS to " + host + " is blocked; use " + envVar + " to route through the gateway"
+	_, _ = io.WriteString(client, "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: "+strconv.Itoa(len(msg))+"\r\n\r\n"+msg)
+	p.emitHTTPServiceDeniedDirect(ctx, commandID, svcName, envVar, host, resolvedIP)
+	return nil
+}
+```
+
+Add the same check to `handleHTTP` (around line 275) at the analogous point — right after `p.policy.CheckNetworkCtx(...)` and before `maybeApprove`.
+
+Add the event helper to the same file:
+
+```go
+func (p *Proxy) emitHTTPServiceDeniedDirect(ctx context.Context, commandID, svcName, envVar, host, resolvedIP string) {
+	if p.emit == nil {
+		return
+	}
+	ev := types.Event{
+		ID:        uuid.NewString(),
+		Timestamp: time.Now().UTC(),
+		Type:      "http_service_denied_direct",
+		SessionID: p.sessionID,
+		CommandID: commandID,
+		Domain:    strings.ToLower(host),
+		Fields: map[string]any{
+			"service_name": svcName,
+			"env_var":      envVar,
+			"request_host": host,
+			"resolved_ip":  resolvedIP,
+		},
+	}
+	_ = p.emit.AppendEvent(ctx, ev)
+	p.emit.Publish(ev)
+}
+```
+
+Accounting for the `allow_direct` escape hatch: add a method `DeclaredHTTPServiceAllowsDirect(host string) bool` on `policy.Engine` and gate the block:
+
+```go
+if svcName, envVar, ok := p.policy.DeclaredHTTPServiceHost(host); ok && !p.policy.DeclaredHTTPServiceAllowsDirect(host) {
+	// ... deny path ...
+}
+```
+
+Implement the new engine method in `internal/policy/http_service_check.go`:
+
+```go
+// DeclaredHTTPServiceAllowsDirect returns true when the declared service
+// for host has allow_direct: true set. Callers of DeclaredHTTPServiceHost
+// should query this before denying direct access.
+func (e *Engine) DeclaredHTTPServiceAllowsDirect(host string) bool {
+	h := strings.ToLower(strings.TrimSuffix(stripHTTPServiceHostPort(host), "."))
+	cs, ok := e.httpServiceHosts[h]
+	if !ok {
+		return false
+	}
+	return cs.cfg.AllowDirect
+}
+```
+
+- [ ] **Step 12.4: Run tests**
+
+```bash
+go build ./internal/netmonitor/
+go test ./internal/netmonitor/ -run TestHandleConnect_DeniesDeclaredHost -v
+```
+
+Expected: PASS.
+
+Also add a plain-HTTP test:
+
+```go
+func TestHandleHTTP_DeniesDeclaredHost(t *testing.T) {
+	// Similar to TestHandleConnect_DeniesDeclaredHost but uses an HTTP
+	// GET against api.github.com (not a CONNECT). Expect 403 with the
+	// same guidance message.
+}
+```
+
+And a regression test for the escape hatch:
+
+```go
+func TestHandleConnect_AllowDirectSkipsCheck(t *testing.T) {
+	pol := &policy.Policy{
+		HTTPServices: []policy.HTTPService{{
+			Name: "github", Upstream: "https://api.github.com", AllowDirect: true,
+		}},
+	}
+	// ... drive handleConnect and assert it does NOT return 403 at the
+	// fail-closed check (it will likely return 403 from CheckNetworkCtx
+	// unless a permissive network_rules entry is also set — design the
+	// test accordingly).
+}
+```
+
+- [ ] **Step 12.5: Commit**
+
+```bash
+git add internal/netmonitor/proxy.go internal/netmonitor/declared_services_test.go internal/policy/http_service_check.go
+git commit -m "feat(netmonitor): fail-closed CONNECT and HTTP checks
+
+handleConnect and handleHTTP now reject requests targeting a declared
+http_services upstream with 403 and a guidance message pointing at
+the env var name. allow_direct: true opts a service out of the check.
+Emits http_service_denied_direct events for audit."
+```
+
+---
+
+## Task 13: Log declared-service requests to storage
+
+**Files:**
+- Modify: `internal/proxy/storage.go`
+- Modify: `internal/proxy/declared_service.go`
+- Modify: `internal/proxy/declared_service_test.go`
+
+Spec §6 ("Events and Audit") requires that declared-service traffic is auditable with the service/rule name recorded alongside each request. This task extends `RequestLogEntry` with three new fields and adds logging to `serveDeclaredService` so every request+response pair hits the same JSONL store the LLM path already writes to.
+
+Rationale for re-using the existing `Storage` instead of adding a new event emitter: the LLM proxy already uses `Storage.LogRequest` / `LogResponse` / `StoreRequestBody` / `StoreResponseBody` as its audit trail. Declared-service traffic is exactly analogous — request/response pairs through a gateway — so it belongs in the same JSONL. Keeping the two paths on one mechanism avoids a second audit surface and matches the user-facing reality that both paths serve policy-enforced outbound HTTP.
+
+- [ ] **Step 13.1: Extend RequestLogEntry**
+
+Edit `internal/proxy/storage.go`. Replace the `RequestLogEntry` struct with:
+
+```go
+// RequestLogEntry represents a logged request.
+type RequestLogEntry struct {
+	ID          string      `json:"id"`
+	SessionID   string      `json:"session_id"`
+	Timestamp   time.Time   `json:"timestamp"`
+	Dialect     Dialect     `json:"dialect,omitempty"`
+	ServiceKind string      `json:"service_kind,omitempty"` // "llm" or "http_service"
+	ServiceName string      `json:"service_name,omitempty"` // e.g. "github"
+	RuleName    string      `json:"rule_name,omitempty"`    // e.g. "read-issues"
+	Request     RequestInfo `json:"request"`
+	DLP         *DLPInfo    `json:"dlp,omitempty"`
+}
+```
+
+The change is additive: `Dialect` gains `omitempty` (existing LLM entries still carry a dialect; declared-service entries omit it). The three new fields are all optional — LLM entries leave them blank.
+
+- [ ] **Step 13.2: Write the logging test**
+
+Add to `internal/proxy/declared_service_test.go`:
+
+```go
+func TestServeDeclaredService_LogsRequestAndResponseToStorage(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, `{"login":"octocat"}`)
+	}))
+	defer upstream.Close()
+
+	// Point storage at a temp dir so we can read back the JSONL.
+	tmpDir := t.TempDir()
+	storage, err := NewStorage(tmpDir, "test-session", false)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "read-user", Methods: []string{"GET"}, Paths: []string{"/user"}, Decision: "allow"},
+	})
+	p.SetStorageForTest(storage)
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/user", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	entries := readAllRequestLogEntries(t, tmpDir, "test-session")
+	if len(entries) != 1 {
+		t.Fatalf("got %d log entries, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.ServiceKind != "http_service" {
+		t.Errorf("ServiceKind = %q, want http_service", e.ServiceKind)
+	}
+	if e.ServiceName != "github" {
+		t.Errorf("ServiceName = %q, want github", e.ServiceName)
+	}
+	if e.RuleName != "read-user" {
+		t.Errorf("RuleName = %q, want read-user", e.RuleName)
+	}
+	if e.Request.Method != "GET" || e.Request.Path != "/user" {
+		t.Errorf("Request = %+v, want GET /user", e.Request)
+	}
+	if e.Dialect != "" {
+		t.Errorf("Dialect = %q, want empty for http_service", e.Dialect)
+	}
+
+	resps := readAllResponseLogEntries(t, tmpDir, "test-session")
+	if len(resps) != 1 {
+		t.Fatalf("got %d response entries, want 1", len(resps))
+	}
+	if resps[0].Response.Status != http.StatusOK {
+		t.Errorf("response status = %d, want 200", resps[0].Response.Status)
+	}
+}
+
+// readAllRequestLogEntries reads the request JSONL file for a session and
+// returns every RequestLogEntry. Lives next to the test so it can inspect
+// unexported storage internals if needed.
+//
+// Note: Storage writes requests AND responses to the same file
+// (llm-requests.jsonl — see internal/proxy/storage.go). We discriminate by
+// looking at which JSON fields are populated: RequestLogEntry has the
+// "request" object, ResponseLogEntry has the "response" object and a
+// "request_id" field.
+func readAllRequestLogEntries(t *testing.T, basePath, sessionID string) []RequestLogEntry {
+	t.Helper()
+	lines := readLogLines(t, basePath, sessionID)
+	var out []RequestLogEntry
+	for _, line := range lines {
+		// Skip response entries by peeking at field names.
+		var probe map[string]json.RawMessage
+		if err := json.Unmarshal(line, &probe); err != nil {
+			t.Fatalf("unmarshal probe: %v", err)
+		}
+		if _, isResponse := probe["request_id"]; isResponse {
+			continue
+		}
+		var e RequestLogEntry
+		if err := json.Unmarshal(line, &e); err != nil {
+			t.Fatalf("decode request log: %v", err)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func readAllResponseLogEntries(t *testing.T, basePath, sessionID string) []ResponseLogEntry {
+	t.Helper()
+	lines := readLogLines(t, basePath, sessionID)
+	var out []ResponseLogEntry
+	for _, line := range lines {
+		var probe map[string]json.RawMessage
+		if err := json.Unmarshal(line, &probe); err != nil {
+			t.Fatalf("unmarshal probe: %v", err)
+		}
+		if _, isResponse := probe["request_id"]; !isResponse {
+			continue
+		}
+		var e ResponseLogEntry
+		if err := json.Unmarshal(line, &e); err != nil {
+			t.Fatalf("decode response log: %v", err)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// readLogLines reads the shared JSONL log file line-by-line.
+func readLogLines(t *testing.T, basePath, sessionID string) [][]byte {
+	t.Helper()
+	path := filepath.Join(basePath, sessionID, "llm-requests.jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	var lines [][]byte
+	for _, l := range bytes.Split(data, []byte("\n")) {
+		if len(l) == 0 {
+			continue
+		}
+		lines = append(lines, l)
+	}
+	return lines
+}
+```
+
+Add imports if missing: `bytes`, `encoding/json`, `os`, `path/filepath`.
+
+The file is named `llm-requests.jsonl` for historical reasons — it holds every request/response the proxy touches, not just LLM ones. Do NOT rename it in this plan; a rename would break consumers reading the audit log and is out of scope for http_services.
+
+- [ ] **Step 13.3: Add SetStorageForTest**
+
+Add to `internal/proxy/declared_service.go`:
+
+```go
+// SetStorageForTest installs a Storage instance for the declared-service
+// logging path. Production uses the same Storage that the LLM path uses;
+// tests point it at a temp dir. Test-only setter to keep the dependency
+// visible.
+func (p *Proxy) SetStorageForTest(s *Storage) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.storage = s
+}
+```
+
+`p.storage` already exists on `*Proxy` — this setter just exposes it. Confirm by reading `internal/proxy/proxy.go:55`.
+
+- [ ] **Step 13.4: Run test — expect FAIL**
+
+```bash
+go test ./internal/proxy/ -run TestServeDeclaredService_LogsRequestAndResponseToStorage -v
+```
+
+Expected: FAIL — no logging wired into `serveDeclaredService` yet (assertions on service kind/name and log file count will fail).
+
+- [ ] **Step 13.5: Add logging helpers**
+
+Add to `internal/proxy/declared_service.go`:
+
+```go
+// logDeclaredServiceRequest writes a RequestLogEntry for a declared-service
+// request to p.storage, mirroring how logRequest works for the LLM path but
+// without a Dialect and with ServiceKind/ServiceName/RuleName set.
+//
+// Matches the logRequest signature so future refactors can consolidate the
+// two. ruleName is the name of the rule that matched; if the decision came
+// from the service default (no rule matched), ruleName is the empty string.
+func (p *Proxy) logDeclaredServiceRequest(requestID, sessionID, svcName, ruleName string, r *http.Request, body []byte) {
+	if p.storage == nil {
+		return
+	}
+	entry := &RequestLogEntry{
+		ID:          requestID,
+		SessionID:   sessionID,
+		Timestamp:   time.Now().UTC(),
+		ServiceKind: "http_service",
+		ServiceName: svcName,
+		RuleName:    ruleName,
+		Request: RequestInfo{
+			Method:   r.Method,
+			Path:     r.URL.Path,
+			Headers:  sanitizeHeaders(r.Header),
+			BodySize: len(body),
+			BodyHash: HashBody(body),
+		},
+	}
+	if err := p.storage.LogRequest(entry); err != nil {
+		p.logger.Error("log declared-service request", "error", err, "request_id", requestID)
+	}
+	if err := p.storage.StoreRequestBody(requestID, body); err != nil {
+		p.logger.Error("store declared-service request body", "error", err, "request_id", requestID)
+	}
+}
+
+// logDeclaredServiceResponse mirrors logResponseDirect for the declared-
+// service path. resp.Body must already be drained into respBody; the
+// caller is responsible for restoring resp.Body before writing it back
+// to the client.
+func (p *Proxy) logDeclaredServiceResponse(requestID, sessionID string, resp *http.Response, respBody []byte, startTime time.Time) {
+	if p.storage == nil {
+		return
+	}
+	entry := &ResponseLogEntry{
+		RequestID:  requestID,
+		SessionID:  sessionID,
+		Timestamp:  time.Now().UTC(),
+		DurationMs: time.Since(startTime).Milliseconds(),
+		Response: ResponseInfo{
+			Status:   resp.StatusCode,
+			Headers:  sanitizeHeaders(resp.Header),
+			BodySize: len(respBody),
+			BodyHash: HashBody(respBody),
+		},
+	}
+	if err := p.storage.LogResponse(entry); err != nil {
+		p.logger.Error("log declared-service response", "error", err, "request_id", requestID)
+	}
+	if err := p.storage.StoreResponseBody(requestID, respBody); err != nil {
+		p.logger.Error("store declared-service response body", "error", err, "request_id", requestID)
+	}
+}
+```
+
+- [ ] **Step 13.6: Call the helpers from serveDeclaredService**
+
+Edit `internal/proxy/declared_service.go`. The forwarding block from Task 8 / 9 / 10 currently does:
+
+```go
+// ... hook dispatch runs, body already buffered as `body` ...
+
+outReq, err := p.buildUpstreamRequest(r, svc.Upstream, reqPath)
+// ... error handling ...
+
+resp, err := p.httpServiceTransport().RoundTrip(outReq)
+// ... error handling ...
+defer resp.Body.Close()
+
+// Copy response headers and status, then body.
+for k, vs := range resp.Header {
+	for _, v := range vs {
+		w.Header().Add(k, v)
+	}
+}
+w.WriteHeader(resp.StatusCode)
+_, _ = io.Copy(w, resp.Body)
+```
+
+Two changes. First, call `logDeclaredServiceRequest` right after the request body is buffered (which Task 9 already does to feed the hook dispatch). That body buffer is available as the local `body` variable — if Task 9 named it differently, rename for consistency:
+
+```go
+// After Task 9's body-buffering block, and after ApplyPreHooks returns:
+p.logDeclaredServiceRequest(requestID, reqCtx.SessionID, svcName, dec.Rule, r, body)
+```
+
+Pass `dec.Rule` as `ruleName` — it holds the matched rule name from `wrapDecision` (empty string when the default fired).
+
+Second, replace the response-copy block with a buffer-and-log version:
+
+```go
+// Buffer the response body so we can log it and still write it back.
+respBody, err := io.ReadAll(resp.Body)
+if err != nil {
+	http.Error(w, "read upstream response: "+err.Error(), http.StatusBadGateway)
+	return
+}
+p.logDeclaredServiceResponse(requestID, reqCtx.SessionID, resp, respBody, startTime)
+
+for k, vs := range resp.Header {
+	for _, v := range vs {
+		w.Header().Add(k, v)
+	}
+}
+w.WriteHeader(resp.StatusCode)
+_, _ = w.Write(respBody)
+```
+
+This replaces `io.Copy(w, resp.Body)` with a read-then-write. For declared-service traffic this is acceptable because the bodies are bounded by real API responses (not model streams). Streaming is NOT a goal for v1 of http_services — the spec §6 explicitly requires the body be logged, which requires buffering.
+
+If a future task needs to support streaming (e.g., GitHub release asset downloads), the right answer is a `ServiceStream` flag on `HTTPService` that disables logging for that service — not a fork of the log path.
+
+- [ ] **Step 13.7: Run the test**
+
+```bash
+go test ./internal/proxy/ -run TestServeDeclaredService_LogsRequestAndResponseToStorage -v
+```
+
+Expected: PASS.
+
+Also run the full declared-service suite to catch regressions in earlier tasks:
+
+```bash
+go test ./internal/proxy/ -run TestServeDeclaredService -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 13.8: Confirm the LLM path still logs correctly**
+
+The change to `RequestLogEntry` added `omitempty` to `Dialect` and three new optional fields. Existing LLM entries should be unaffected. Run:
+
+```bash
+go test ./internal/proxy/ -v
+```
+
+Expected: PASS. If any LLM test failed because it asserted a JSON key's presence (`dialect` must always appear), that test was over-specified — relax it to allow omitempty or update the expected JSON.
+
+- [ ] **Step 13.9: Commit**
+
+```bash
+git add internal/proxy/storage.go internal/proxy/declared_service.go internal/proxy/declared_service_test.go
+git commit -m "feat(proxy): log declared-service requests to storage
+
+RequestLogEntry gains ServiceKind/ServiceName/RuleName fields (all
+omitempty). serveDeclaredService buffers the request and response
+bodies and writes them through Storage.LogRequest/LogResponse, matching
+the audit shape the LLM path already uses.
+
+Closes spec §6 request/response audit requirement. The approve/deny
+direct event types remain covered by the approvals manager and by
+Task 12 respectively."
+```
+
+---
+
+## Task 14: Path-matching fuzz target
+
+**Files:**
+- Create: `internal/policy/http_service_fuzz_test.go`
+
+- [ ] **Step 14.1: Create the fuzz target**
+
+Create `internal/policy/http_service_fuzz_test.go`:
+
+```go
+package policy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// FuzzCheckHTTPServicePath feeds random method/path combinations into the
+// evaluator and asserts three invariants:
+//
+//  1. It never panics.
+//  2. An allow decision implies the path survived path.Clean unchanged
+//     (traversal attempts cannot reach upstream).
+//  3. Method matching is stable under arbitrary casing.
+func FuzzCheckHTTPServicePath(f *testing.F) {
+	svcs := []HTTPService{{
+		Name: "github", Upstream: "https://api.github.com",
+		Default: "deny",
+		Rules: []HTTPServiceRule{
+			{Name: "read", Methods: []string{"GET"}, Paths: []string{"/repos/*/*"}, Decision: "allow"},
+			{Name: "open", Methods: []string{"*"}, Paths: []string{"/public/**"}, Decision: "allow"},
+		},
+	}}
+	if err := ValidateHTTPServices(svcs); err != nil {
+		f.Fatal(err)
+	}
+	byName, byHost, err := compileHTTPServices(svcs)
+	if err != nil {
+		f.Fatal(err)
+	}
+	e := &Engine{
+		policy:           &Policy{HTTPServices: svcs},
+		httpServices:     byName,
+		httpServiceHosts: byHost,
+		enforceApprovals: true,
+	}
+
+	f.Add("GET", "/repos/a/b")
+	f.Add("get", "/REPOS/a/b")
+	f.Add("GET", "/repos/../etc/passwd")
+	f.Add("GET", "/repos//a/b")
+	f.Add("POST", "/public/\x00bar")
+	f.Add("PUT", "/repos/a/b?%2e%2e")
+
+	f.Fuzz(func(t *testing.T, method, reqPath string) {
+		// Skip inputs with null bytes in the method — invalid HTTP.
+		if strings.ContainsRune(method, 0) {
+			return
+		}
+		dec := e.CheckHTTPService("github", method, reqPath)
+		if dec.EffectiveDecision == types.DecisionAllow {
+			// Invariant 2: allow implies clean path.
+			if reqPath == "" {
+				reqPath = "/"
+			}
+			if got := pathCleanForFuzz(reqPath); got != reqPath {
+				t.Errorf("allow decision with non-canonical path: got=%q clean=%q", reqPath, got)
+			}
+		}
+		// Invariant 3: casing-insensitive method.
+		lower := strings.ToLower(method)
+		upper := strings.ToUpper(method)
+		decL := e.CheckHTTPService("github", lower, reqPath)
+		decU := e.CheckHTTPService("github", upper, reqPath)
+		if decL.EffectiveDecision != decU.EffectiveDecision {
+			t.Errorf("case mismatch: lower=%q upper=%q dec differs", lower, upper)
+		}
+	})
+}
+
+// Use a separate name to make the fuzz target self-contained without
+// importing path here (the eval path already imports it).
+func pathCleanForFuzz(p string) string {
+	return cleanPath(p)
+}
+
+func cleanPath(p string) string {
+	// Mirror of path.Clean, imported via the eval file, but we don't
+	// want to collide package imports. Delegate to the stdlib.
+	if p == "" {
+		return "/"
+	}
+	return p // placeholder; replace with path.Clean(p) — see step 14.2
+}
+```
+
+- [ ] **Step 14.2: Replace the `cleanPath` stub with the stdlib call**
+
+```go
+import (
+	"path"
+	// ...
+)
+
+func cleanPath(p string) string {
+	if p == "" {
+		return "/"
+	}
+	return path.Clean(p)
+}
+```
+
+- [ ] **Step 14.3: Run a quick fuzz pass**
+
+```bash
+go test ./internal/policy/ -run '^FuzzCheckHTTPServicePath$' -fuzz=FuzzCheckHTTPServicePath -fuzztime=20s
+```
+
+Expected: no panics, no invariant failures. 20 seconds is a sanity check; CI can run longer if desired.
+
+- [ ] **Step 14.4: Commit**
+
+```bash
+git add internal/policy/http_service_fuzz_test.go
+git commit -m "test(policy): fuzz target for http_services path handling
+
+FuzzCheckHTTPServicePath feeds random method/path pairs into the
+evaluator and checks: no panics, allow decisions require canonical
+paths, and method matching is case-stable."
+```
+
+---
+
+## Task 15: Cross-compile and final smoke test
+
+**Files:** none (verification only)
+
+- [ ] **Step 15.1: Full build**
+
+```bash
+go build ./...
+```
+
+Expected: success.
+
+- [ ] **Step 15.2: Windows cross-compile**
+
+```bash
+GOOS=windows go build ./...
+```
+
+Expected: success. If it fails, investigate — the new code should be pure Go without `runtime.GOOS` branching, but imports may pull in Linux-only packages via netmonitor.
+
+- [ ] **Step 15.3: Full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: all PASS.
+
+- [ ] **Step 15.4: Smoke test with a real config**
+
+Write a smoke test policy to a temp file and load it, exercising the end-to-end path:
+
+```bash
+cat > /tmp/smoke-http-services.yaml <<'EOF'
+http_services:
+  - name: github
+    upstream: https://api.github.com
+    expose_as: GITHUB_API_URL
+    default: deny
+    rules:
+      - name: read-issues
+        methods: [GET]
+        paths: [/repos/*/*/issues]
+        decision: allow
+EOF
+go run ./cmd/agentsh-... -config /tmp/smoke-http-services.yaml --validate-only  # or whatever the CLI entrypoint is
+```
+
+Confirm the CLI prints no validation errors. (If the CLI doesn't have a `--validate-only` flag, skip this step — it's a nice-to-have, not a gate.)
+
+- [ ] **Step 15.5: Commit a changelog or release note**
+
+Skip unless the project tracks changelogs in-repo. If `CHANGELOG.md` exists:
+
+```bash
+cat >> CHANGELOG.md <<'EOF'
+## Unreleased
+- **http_services**: declare HTTP services in policy with per-service method/path rules; cooperating children reach them via `<NAME>_API_URL` env vars routed through the proxy gateway; direct HTTPS to declared hosts fails closed at netmonitor.
+EOF
+git add CHANGELOG.md
+git commit -m "docs: changelog entry for http_services"
+```
+
+---
+
+## Open sub-decisions for the implementer
+
+These were intentionally left for the implementation plan, not the spec:
+
+1. **Where `sessionIDFor` lives.** I assumed a small helper method on `*Proxy`. If there's an existing helper, use it; do not add a second.
+2. **Whether to lift `maybeApprove`.** The plan duplicates it (Task 10) for minimal blast radius. A follow-up task titled "refactor: lift maybeApprove to shared helper" can consolidate netmonitor and declared-service call sites.
+3. **The `HTTPService.Timeout` field.** Parsed and validated (Task 2) but not wired into the approval flow in Task 10 — the global approval timeout governs for v1. When the rule-level timeout is wired, it should flow through the `approvals.Request` rather than through the `Decision` struct.
+4. **Approvals interface shape.** `HTTPServiceApprovalsManager` in Task 10 is a local interface. If it doesn't match `approvals.Manager`'s real method signature exactly, adjust the interface definition — the point is to have a narrow, testable surface, not to match the concrete manager byte-for-byte.

--- a/docs/superpowers/specs/2026-04-10-http-path-verb-filtering-design.md
+++ b/docs/superpowers/specs/2026-04-10-http-path-verb-filtering-design.md
@@ -1,0 +1,594 @@
+# HTTP Path/Verb Filtering for Declared Services — Design
+
+**Date:** 2026-04-10
+**Status:** Design (pre-implementation)
+**Related specs:**
+- `docs/superpowers/specs/2026-04-09-plan-06-service-config-routing-design.md` (existing `services:` credential-substitution section — overlapping concern, kept separate by design)
+- `docs/superpowers/specs/2026-04-07-external-secrets-design.md` (parent of Plan 6)
+
+## Problem
+
+`agentsh`'s policy engine filters outbound network calls at the host/port/CIDR level via `NetworkRule`, and resolves domains at DNS time. There is no way to say "allow `GET /repos/*`, deny `DELETE /repos/*`" — once a host is allowed, every method and every path on that host is reachable.
+
+Agents are increasingly wired to general HTTP/HTTPS APIs (GitHub, Stripe, internal services) and the operator wants to grant the minimum useful surface: read-only access to some paths, specific verbs on others, deny on destructive operations. Today the only option is binary allow/deny on `api.github.com`, which means an agent that needs to `GET /repos/owner/repo/issues` also has authority to `DELETE /repos/owner/repo` and every other endpoint on the same host.
+
+Two hard constraints rule out the obvious approaches:
+
+- **No MITM.** Terminating TLS with a trusted CA was explicitly rejected — the existing `ConnectRedirectRule` even hard-errors on `mode: mitm`. The design must not depend on intercepting TLS with a proxy CA.
+- **Cannot modify arbitrary upstream SDKs.** The design must work with agents that use ordinary HTTP clients (Python `requests`, Go `net/http`, etc.) by setting an environment variable, the same way `ANTHROPIC_BASE_URL` routes the Anthropic SDK through the LLM proxy today.
+
+## Goal
+
+Let operators declare HTTP services in policy with per-service method/path allow/deny rules. Route cooperating agents through a local gateway that applies the rules before forwarding upstream over real TLS. Fail closed on any attempt to bypass the gateway with direct HTTPS to a declared host.
+
+## Architecture
+
+Three independent enforcement layers that stack:
+
+1. **Gateway evaluator** — cooperating child sets `<NAME>_API_URL=http://127.0.0.1:<port>/svc/<name>`, the gateway reads the plaintext request, evaluates `CheckHTTPService(service, method, path)`, forwards to the real upstream over TLS if allowed.
+2. **Fail-closed CONNECT check** — `internal/netmonitor/proxy.go` denies CONNECT (and plain HTTP) to any hostname that appears as an upstream in `http_services`, catching children that ignore the env var.
+3. **Existing network policy** — unchanged; seccomp-backed `NetworkRule` still gates raw `connect(2)`.
+
+Cooperation is by base-URL env var injection, not by DNS rerouting. There is no trusted CA, no TLS interception, no kernel interposition. Credential material intended for the upstream stays in the gateway (via the existing `HeaderInjectionHook` pattern) and is never handed to the child.
+
+## Scope
+
+**In scope:**
+- New top-level `http_services:` policy YAML section
+- New `policy.Engine` methods: `CheckHTTPService`, `HTTPServices`, `DeclaredHTTPServiceHost`
+- Extend `internal/proxy/proxy.go` `ServeHTTP` with a path-prefix dispatch to declared services, bypassing LLM dialect detection when the request targets `/svc/<name>/...`
+- New `serveDeclaredService` handler that reuses `hookRegistry`, `RequestRewriter`, DLP, storage, redaction
+- Extend `Proxy.EnvVars()` to emit per-service `<NAME>_API_URL` entries
+- Fail-closed CONNECT and plain-HTTP checks in `internal/netmonitor/proxy.go`
+- New event types: `http_service_request`, `http_service_denied_direct`, `http_service_approve`
+- Path-matching fuzz target
+
+**Out of scope:**
+- Unifying with the existing `services:` credential-substitution section (Plan 6) — orthogonal concerns, a follow-up can consolidate
+- Query-string matching in rules (v1 matches method + path only)
+- Per-service rate limiting (existing LLM rate limiter stays LLM-only)
+- Local DNS redirect to force uncooperative clients into the gateway
+- Redirect decisions (v1 supports allow/deny/approve/audit only)
+- Policy hot-reload of `http_services` for already-running children
+- Header-value matching in rules
+
+**Relationship to the existing `services:` section (Plan 6)**
+
+The existing `services:` section declares services for credential substitution: `name`, `match.hosts`, `secret.ref`, `fake.format`, `inject.header`. Its matcher resolves `r.Host` to a service name and dispatches per-service hooks. It does not filter, rewrite paths, or inject env vars for generic HTTP clients.
+
+This design adds `http_services:` as a separate top-level section with different responsibilities: routing by path prefix, filtering by method/path rules, and injecting base-URL env vars. A service can appear under the same name in both sections — they compose, because Plan 6's hook dispatch is driven by `RequestContext.ServiceName` and this design sets that field from the path-prefix resolution. The two surfaces will be merged in a future pass; for v1 they are intentionally separate to avoid disturbing working Plan 6 code.
+
+---
+
+## Section 1 — YAML Schema
+
+New top-level `http_services:` key in `Policy` (`internal/policy/model.go`):
+
+```go
+type Policy struct {
+    // ... existing fields ...
+    HTTPServices []HTTPService `yaml:"http_services,omitempty"`
+}
+
+type HTTPService struct {
+    Name        string            `yaml:"name"`
+    Upstream    string            `yaml:"upstream"`            // https://api.github.com
+    ExposeAs    string            `yaml:"expose_as,omitempty"` // env var name; default <NAME>_API_URL
+    Aliases     []string          `yaml:"aliases,omitempty"`   // extra hostnames for fail-closed check
+    AllowDirect bool              `yaml:"allow_direct,omitempty"` // escape hatch; default false
+    Default     string            `yaml:"default,omitempty"`   // allow | deny; default deny
+    Rules       []HTTPServiceRule `yaml:"rules,omitempty"`
+}
+
+type HTTPServiceRule struct {
+    Name     string   `yaml:"name"`
+    Methods  []string `yaml:"methods,omitempty"` // empty or "*" means any
+    Paths    []string `yaml:"paths"`             // gobwas/glob patterns, '/' separator
+    Decision string   `yaml:"decision"`          // allow | deny | approve | audit
+    Message  string   `yaml:"message,omitempty"`
+    Timeout  duration `yaml:"timeout,omitempty"` // only meaningful for approve
+}
+```
+
+Example:
+
+```yaml
+http_services:
+  - name: github
+    upstream: https://api.github.com
+    expose_as: GITHUB_API_URL
+    default: deny
+    rules:
+      - name: read-issues
+        methods: [GET]
+        paths:
+          - /repos/*/*/issues
+          - /repos/*/*/issues/*
+        decision: allow
+      - name: open-issue
+        methods: [POST]
+        paths:
+          - /repos/*/*/issues
+        decision: approve
+        message: "Agent wants to open an issue in {{path}}"
+        timeout: 30s
+      - name: block-repo-delete
+        methods: [DELETE]
+        paths:
+          - /repos/**
+        decision: deny
+        message: "Repository deletion is never allowed"
+
+  - name: stripe
+    upstream: https://api.stripe.com
+    default: deny
+    rules:
+      - name: read-customers
+        methods: [GET]
+        paths:
+          - /v1/customers
+          - /v1/customers/*
+        decision: allow
+```
+
+Semantics:
+
+- **First-match-wins** on `rules` in declaration order.
+- **Default fallback** applies if no rule matches. Unspecified `default` means `deny`.
+- **Decisions** supported in v1: `allow`, `deny`, `approve`, `audit`. Not supported: `redirect` (requires a different execution path), `soft_delete` (nonsensical for HTTP).
+- **Timeout** applies only to `approve` and governs how long the gateway waits for operator resolution before failing closed.
+
+---
+
+## Section 2 — Component: Generalized Service Gateway
+
+Extend `internal/proxy/proxy.go` rather than building a new proxy. Rationale: reuse `hookRegistry`, `RequestRewriter`, DLP, storage, request logging, redaction, and the existing listener — all of which already do what a declared-service gateway needs.
+
+### Dispatch changes in `ServeHTTP`
+
+```go
+func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    // New: path-prefix dispatch to declared services.
+    if svc, rest, ok := p.declaredService(r.URL.Path); ok {
+        p.serveDeclaredService(w, r, svc, rest)
+        return
+    }
+
+    // Existing LLM dispatch path, unchanged.
+    dialect := p.detector.Detect(r)
+    if dialect == DialectUnknown {
+        http.Error(w, "unknown LLM dialect", http.StatusBadRequest)
+        return
+    }
+    // ... existing flow ...
+}
+```
+
+`declaredService(path)` strips a leading `/svc/<name>` prefix and returns the compiled service + remaining path. Lookup is case-insensitive on the service name. If the path has `/svc/` but no registered service name, return a 404 with `"no such service"` rather than falling through to dialect detection — declared services and LLM services must not mask each other.
+
+### `serveDeclaredService` responsibilities
+
+1. Read and buffer the request body (same as the LLM path).
+2. Build `RequestContext{ServiceName: svc.Name, ...}` and assign a `request_id`.
+3. Validate the path: reject with 400 if `path.Clean(rest) != rest` (traversal guard, see §3).
+4. Call `p.policy.CheckHTTPService(svc.Name, r.Method, rest)`. Apply `maybeApprove`-style approval semantics, reusing the pattern from `netmonitor/proxy.go`.
+5. Dispatch hooks via `hookRegistry.ApplyPreHooks(svc.Name, r, ctx)` — service-scoped, so `HeaderInjectionHook` for this service fires and injects the real credential. Plan 6's `LeakGuardHook` already skips when `ServiceName != ""`.
+6. Rewrite the outbound request to `svc.Upstream + rest` (keeping query string, headers), using `RequestRewriter`.
+7. Forward via the existing upstream transport. Capture response into storage. Apply post-hooks. Emit `http_service_request` event.
+8. Stream the response back to the caller.
+
+### Env var plumbing
+
+`Proxy.EnvVars()` currently returns the LLM env vars. Extend it to append one entry per declared service, using the service's `expose_as` field (or the derived default `<NAME>_API_URL`). The returned map is already consumed at the session spawn point (same path as `ANTHROPIC_BASE_URL`), so no new wiring is needed to reach child processes.
+
+Values are of the form:
+
+```
+GITHUB_API_URL=http://127.0.0.1:<port>/svc/github
+STRIPE_API_URL=http://127.0.0.1:<port>/svc/stripe
+```
+
+### Why path-prefix, not Host-based routing
+
+- Host-based routing (`Host: api.github.com` with the proxy on `127.0.0.1`) only works if the SDK preserves the original Host header under a base-URL override. Most SDKs do not.
+- The path-prefix `/svc/<name>/...` is what SDKs naturally produce when the user sets a base URL ending in `/svc/github` and the SDK joins its own path onto it.
+- A single listener port serves all declared services and the LLM proxy without collision.
+
+### What stays untouched
+
+- Dialect detection, DLP, MCP interception, SSE streaming, LLM rate limiting — all LLM-specific and only run on the LLM path.
+- The existing `services:` credential-substitution path from Plan 6 — still matches by `r.Host` for its own use cases and is not touched.
+- `internal/netmonitor/proxy.go` except for the fail-closed checks in §5.
+
+---
+
+## Section 3 — Path/Verb Rule Evaluator
+
+New evaluator on `policy.Engine`, mirroring the shape of `CheckNetworkCtx`, `CheckFile`, etc.
+
+### Compiled structures
+
+```go
+type compiledHTTPServiceRule struct {
+    rule    HTTPServiceRule
+    methods map[string]struct{} // uppercase; empty or "*" means any
+    paths   []glob.Glob          // gobwas/glob with '/' separator
+}
+
+type compiledHTTPService struct {
+    cfg      HTTPService
+    rules    []compiledHTTPServiceRule
+    upstream *url.URL            // parsed once at compile time
+    envVar   string              // resolved ExposeAs or derived default
+    defaultDecision string       // allow | deny (deny if unspecified)
+}
+
+// On Engine:
+httpServices     map[string]*compiledHTTPService // keyed by lowercase name
+httpServiceHosts map[string]string               // upstream host -> service name
+```
+
+Built in `NewEngine` alongside `compiledNetworkRule`, `compiledFileRule`, etc.
+
+### Check method
+
+```go
+// CheckHTTPService evaluates method+path against the rules for service.
+// path is the path portion AFTER the /svc/<name> prefix has been stripped.
+// Returns a wrapped Decision in the same shape as CheckNetworkCtx.
+func (e *Engine) CheckHTTPService(service, method, path string) Decision {
+    cs, ok := e.httpServices[strings.ToLower(service)]
+    if !ok {
+        return e.wrapDecision("deny", "", "unknown http_service", 0)
+    }
+
+    // Traversal guard: reject any path that doesn't survive path.Clean unchanged.
+    if path == "" {
+        path = "/"
+    }
+    if path.Clean(path) != path {
+        return e.wrapDecision("deny", "", "path traversal rejected", 0)
+    }
+
+    method = strings.ToUpper(method)
+
+    for _, r := range cs.rules {
+        if !methodMatches(r, method) {
+            continue
+        }
+        if !pathMatches(r, path) {
+            continue
+        }
+        return e.wrapDecision(r.rule.Decision, r.rule.Name, r.rule.Message, r.rule.Timeout)
+    }
+
+    // Fallback to the service-level default.
+    if cs.defaultDecision == "allow" {
+        return e.wrapDecision("allow", "default", "", 0)
+    }
+    return e.wrapDecision("deny", "default", "no rule matched", 0)
+}
+```
+
+`methodMatches` returns true if `r.methods` is empty, contains `*`, or contains the canonicalized method. `pathMatches` ORs across the compiled globs.
+
+### Matching semantics
+
+- **Method:** case-insensitive comparison after uppercasing both sides. Empty list or `["*"]` means any method. Multiple methods in a single rule are OR-ed.
+- **Path:** `gobwas/glob` with `/` separator. `*` matches one segment (no `/` in the matched portion). `**` matches a subtree (may span slashes). These are the same semantics used by `FileRule.Paths` today.
+- **Query string:** **not** included in v1 matching. Gateway logs the full path including query string for audit purposes, but the rule matcher sees only the path portion.
+- **Traversal:** `path.Clean(p) != p` rejects `/foo/..`, `/foo//bar`, `/foo/./bar`, and leading-slash variants. This runs before method matching so a traversal attempt never matches an allow rule.
+- **Case on path:** case-sensitive. REST paths are case-sensitive by convention and making rules case-insensitive would cause surprising matches.
+- **First-match-wins:** rule order in YAML is preserved into `compiledHTTPService.rules`.
+
+### Decision wrapping
+
+`e.wrapDecision` is the existing helper that populates `Decision{EffectiveDecision, RuleName, Message, Timeout, ...}`. Reusing it means `http_services` decisions flow through the same approval/audit bus as file, network, and command decisions — no new decision-handling code.
+
+### Gateway call shape
+
+```go
+dec := p.policy.CheckHTTPService(svc.Name, r.Method, rest)
+dec, err := p.maybeApprove(r.Context(), dec, approvalReq)
+if err != nil { /* timeout or error */ }
+
+switch dec.EffectiveDecision {
+case "allow":
+    // proceed to hooks + forward
+case "deny":
+    http.Error(w, dec.Message, http.StatusForbidden)
+    return
+case "audit":
+    // log and proceed
+}
+```
+
+`maybeApprove` is the existing wrapper in `netmonitor/proxy.go`; it will be lifted to a shared location if needed or duplicated if lifting is messy — deferred to the implementation plan.
+
+---
+
+## Section 4 — Cooperation Mechanism
+
+How a child process's HTTP call actually reaches the gateway, without TLS interception or DNS trickery.
+
+### URL shape: path-prefix on the existing proxy port
+
+Each declared service gets a URL under the proxy's existing listen port:
+
+```
+GITHUB_API_URL=http://127.0.0.1:<port>/svc/github
+STRIPE_API_URL=http://127.0.0.1:<port>/svc/stripe
+```
+
+The SDK joins its own path onto that base. For the GitHub example, `client.get("/repos/owner/repo/issues")` becomes `GET http://127.0.0.1:<port>/svc/github/repos/owner/repo/issues`. The gateway strips `/svc/github`, leaving `/repos/owner/repo/issues` as the path passed to `CheckHTTPService` and forwarded upstream.
+
+Host-based routing was rejected: it requires SDKs to preserve the original `Host` header under a base-URL override, which most do not. Path-prefix routing works with any client that joins URLs onto a base.
+
+### Env var injection plumbing
+
+`Proxy.EnvVars()` currently returns `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `AGENTSH_SESSION_ID`. Extend it to append one entry per declared `http_services` entry, using the service's `expose_as` field (or the derived default `<NAME>_API_URL`).
+
+The returned map is already merged into the child process environment at the session spawn point — the existing consumer in `internal/api/app.go` passes these through unchanged. No new injection path, no new config surface.
+
+### Derived env-var name default
+
+If `expose_as` is omitted on a service, the name is derived as:
+
+```
+strings.ToUpper(name) + "_API_URL"
+```
+
+`github` becomes `GITHUB_API_URL`, `stripe-billing` becomes `STRIPE_BILLING_API_URL` (hyphens stay — they're legal in env var names on POSIX shells in practice, though some programs complain; `expose_as` is available for explicit control).
+
+### Plaintext is acceptable
+
+Children speak plaintext HTTP to `127.0.0.1`. The gateway terminates and re-issues the upstream call over real TLS using Go's default transport. Same trust model as the LLM proxy: the gateway runs in the TCB, and localhost plaintext is fine because the egress hop is where encryption matters.
+
+Credentials destined for the upstream (e.g. a real GitHub personal access token) live in the gateway's credential store and are injected by a `HeaderInjectionHook` — never carried by the child. This preserves the property that child processes do not hold upstream credentials in their environment.
+
+### No DNS redirect in v1
+
+Children that ignore the env var and connect to `api.github.com` directly do not reach the gateway via DNS rerouting. They are caught by §5's fail-closed CONNECT check in `netmonitor/proxy.go`. Rerouting DNS would require a second interception layer with its own breakage modes (TTLs, caching resolvers, tools that bypass `/etc/resolv.conf`) for no enforcement benefit that §5 doesn't already provide.
+
+---
+
+## Section 5 — Fail-Closed CONNECT Check
+
+The anti-bypass layer in `internal/netmonitor/proxy.go`. Without this, a child that skips the env var and hits `api.github.com:443` directly would tunnel through netmonitor's opaque CONNECT path, and the gateway would never see the request.
+
+### Where the check lives
+
+`handleConnect` at `internal/netmonitor/proxy.go:110` runs before the CONNECT tunnel is established. Add a check: if the target host matches a declared service upstream, reject with 403 and emit an event.
+
+`handleHTTP` at `internal/netmonitor/proxy.go:230` gets the symmetric check against `req.Host`. Plain HTTP to declared services is rare but the symmetric check is cheap and prevents an asymmetric bypass.
+
+### How netmonitor learns the declared hosts
+
+New method on the policy engine:
+
+```go
+// DeclaredHTTPServiceHost reports whether host belongs to a declared
+// http_services entry and returns the service name and the env-var name
+// used by the gateway (for the guidance message).
+func (e *Engine) DeclaredHTTPServiceHost(host string) (serviceName, envVar string, ok bool)
+```
+
+Built at engine construction time by parsing the host component of each `http_services[i].upstream` URL and merging in any `aliases`. Stored in `Engine.httpServiceHosts` (see §3). `netmonitor.StartProxy` already holds a `*policy.Engine`; no new wiring, just a new method call. Querying at request time (rather than snapshotting in `StartProxy`) keeps the door open for future hot reload.
+
+### Match semantics
+
+- Strip port (bracket-aware for IPv6), lowercase, strip trailing dot.
+- Exact match on registered hosts plus aliases. No wildcards — declared services name concrete upstreams.
+
+### Action on match
+
+- CONNECT: return `HTTP/1.1 403 Forbidden` with body `direct HTTPS to <host> is blocked; use <ENV_VAR_NAME> to route through the gateway`.
+- Plain HTTP: 403 with the same body.
+- Emit `http_service_denied_direct` with `{service_name, env_var, request_host, client_addr, pid}` for audit.
+- The tunnel is never established, so no bytes flow to the upstream.
+
+### Escape hatch
+
+`http_services[i].allow_direct: true` (default `false`) disables the fail-closed check for that service. Use case: the upstream hostname hosts both the API and a user-legitimate web UI on the same host. Documented as weakening the bypass guarantee; not recommended.
+
+### What this does NOT cover
+
+- Raw `connect(2)` to `api.github.com:443` that bypasses netmonitor entirely — handled by the existing `NetworkRule` + seccomp socket filter, not here.
+- IP-literal access (direct connect to the resolved IP) — also caught at the network policy layer.
+
+The CONNECT check is the proxy-layer belt to those existing suspenders.
+
+---
+
+## Section 6 — Events and Audit
+
+### Emission path: mirror the LLM proxy
+
+The LLM side of `internal/proxy/proxy.go` already has the full pipeline for per-request logging: `RequestLogEntry` with `RequestInfo{Method, Path, Headers, BodySize, BodyHash}`, storage persistence via `Config.Storage`, and header redaction for `Authorization`-style fields. Declared services reuse all of it unchanged. The only addition is a discriminator on the log entry:
+
+```go
+type RequestLogEntry struct {
+    // ... existing fields ...
+    ServiceKind string `json:"service_kind"` // "llm" | "http"
+    ServiceName string `json:"service_name"` // e.g. "github"
+    RuleName    string `json:"rule_name"`    // matched rule or "default"
+}
+```
+
+No new storage schema, no new sink.
+
+### New event types
+
+| Event | Source | Fields |
+|---|---|---|
+| `http_service_request` | `serveDeclaredService` | service_name, request_id, method, path, decision, rule_name, status_code, latency_ms, upstream_host |
+| `http_service_denied_direct` | `netmonitor.handleConnect` / `handleHTTP` | service_name, env_var, request_host, client_addr, pid |
+| `http_service_approve` | gateway, when decision = approve | service_name, request_id, method, path, rule_name |
+
+`rule_name` is the `name` field from the matched `HTTPServiceRule`, or the literal string `"default"` when the service's top-level fallback fires. Operators grep the audit log for `"rule_name":"default"` to find traffic that slipped through without an explicit rule.
+
+### Header handling
+
+Request and response headers are logged as `name → length` pairs, with an allowlist of safe headers (`Content-Type`, `User-Agent`, `X-Request-Id`) logged with values. `Authorization`, `Cookie`, `Set-Cookie`, `X-Api-Key`, and anything injected by a `HeaderInjectionHook` are never logged. Reuse the LLM proxy's existing redaction helper — do not reimplement.
+
+### Body hashing
+
+Request and response bodies are hashed (SHA256). Hash and byte count go to storage unconditionally. Full bodies are persisted only when the existing LLM-proxy storage config says to — same knob, no new config surface. This keeps the audit log useful for "did agent X read resource Y?" without turning the store into a credential honeypot.
+
+### Correlation
+
+`request_id` is a stable per-request UUID assigned in `serveDeclaredService`. It threads through every event and log entry for that request. Same pattern as the LLM proxy. The `http_service_denied_direct` event does not have a `request_id` because there is no gateway request — it has the client PID and address so operators can correlate with process tables.
+
+### What is NOT emitted
+
+- Per-byte progress events — too noisy.
+- Per-header-value events unless the value is in the allowlist — credential risk.
+- Any event for requests to undeclared hosts that hit netmonitor's normal allow path — those still emit the existing `net_http_request` event, unchanged.
+
+---
+
+## Section 7 — Config Loading and Layering
+
+### Single source of truth: policy YAML
+
+`http_services:` lives in the same policy file as `network_rules`, `file_rules`, `command_rules`, etc. No separate config file, no server-config duplication, no split ownership. Loaded by `internal/policy.Load()` along with everything else, validated in the same pass, and compiled in `NewEngine` alongside `compiledNetworkRule`.
+
+### Engine additions (`internal/policy/engine.go`)
+
+- `Engine.httpServices map[string]*compiledHTTPService` — keyed by lowercase name, built in `NewEngine`
+- `Engine.httpServiceHosts map[string]*compiledHTTPService` — upstream host → compiled service, for §5 fail-closed lookup
+- `Engine.CheckHTTPService(service, method, path string) Decision` — §3
+- `Engine.HTTPServices() []HTTPService` — enumeration for the gateway's `EnvVars()` plumbing (returns the source config, not the compiled form, so the gateway can read `ExposeAs`, derived env var names, etc.)
+- `Engine.DeclaredHTTPServiceHost(host string) (serviceName, envVar string, ok bool)` — §5
+
+### Compile-time validation
+
+Run in `NewEngine` before the engine is returned, so any error aborts startup:
+
+- Name is non-empty and unique (case-insensitive)
+- `upstream` parses as an `https://` URL with a non-empty host
+- Every upstream host (including aliases) is unique across all `http_services` — no two services can claim the same host
+- `default` is `""`, `"allow"`, or `"deny"` (empty means deny)
+- `rules[i].decision` is `"allow"`, `"deny"`, `"approve"`, or `"audit"`
+- Every `paths` entry compiles as a `gobwas/glob` pattern with `/` separator
+- `methods` entries, if present, are non-empty strings (any casing)
+- `expose_as`, if present, matches `^[A-Za-z_][A-Za-z0-9_]*$`; the derived default from `name` is checked with the same rule after uppercasing
+- `timeout` is non-negative and only meaningful on `approve` rules (warn otherwise, don't error)
+
+Errors include the service name and rule name (if applicable) in the message so operators can grep back to the YAML line.
+
+### Layering with existing network policy
+
+Three independent enforcement points, ordered by proximity to the wire:
+
+1. **Network rule layer** (`CheckNetworkCtx`, socket syscalls via seccomp) — existing deny-at-socket path. If the child is denied by `NetworkRule`, the connection never opens. Unchanged. An operator who wants to fully cut off `api.github.com` at the network layer still can.
+2. **Netmonitor CONNECT/HTTP check** (§5) — catches HTTPS/HTTP proxy clients trying to reach declared hosts directly. Fail-closed.
+3. **Gateway evaluator** (§3) — runs on cooperating clients that use the env-var URL. Rule-based.
+
+These stack. A request must pass every applicable layer. If an operator denies `api.github.com` at layer 1 *and* declares a gateway service for it, the gateway's own upstream fetch must still succeed — the outbound hop runs in the gateway's process context, not the child's. This is already the case because the gateway is in the TCB and runs outside the sandbox's network policy scope for outbound fetches, but document it explicitly so operators don't accidentally break their own gateway with overzealous child-targeted network rules.
+
+### Relationship to `ConnectRedirectRule`
+
+Orthogonal. `http_services` does not use or require `connect_redirect`. Existing redirect rules can still rewrite SNI or redirect TCP destinations. Operators mixing the two should understand that `connect_redirect: rewrite_sni` is transport-level and does not feed the gateway — only the env-var mechanism does. `mitm` mode is still rejected at `internal/policy/model.go:499` and this design does not change that.
+
+### Relationship to Plan 6 `services:`
+
+The two sections can coexist and reference the same logical service (e.g. `github` declared in both). The Plan 6 path uses `r.Host`-based matching and fires per-service `HeaderInjectionHook`. This design's path-prefix dispatch sets `RequestContext.ServiceName` before calling `hookRegistry.ApplyPreHooks`, so if the operator has also declared `github` in `services:` with an `inject.header`, that hook fires for declared-service requests as well. No wiring change in the registry.
+
+A future consolidation pass can merge `services:` and `http_services:` into a single declaration with composable features (secrets + filtering + routing). That pass is explicitly out of scope here to keep Plan 6 undisturbed.
+
+### Hot reload
+
+If `policy.Reload` is added later, rebuilding the compiled `httpServices` map is trivial — everything derives from `Policy.HTTPServices` at compile time. Caveat: already-running child processes keep their injected env vars until they restart, so a reload that adds a service only reaches children spawned after. Document; don't engineer around it in v1.
+
+---
+
+## Section 8 — Testing Strategy
+
+### Unit tests
+
+**`internal/policy/engine_test.go` — `TestCheckHTTPService`** (table-driven):
+
+- Method matching: single method; multiple methods; `*` wildcard; empty list (any); case-insensitive canonicalization on both sides
+- Path matching: literal (`/repos/anthropics/claude-code`); single-segment glob (`/repos/*/claude-code`); subtree glob (`/repos/**`); multiple patterns OR-ed in one rule
+- Traversal rejection: `/repos/../admin`, `/repos//admin`, `/repos/./admin`, and their percent-encoded forms all rejected at `path.Clean` with decision `deny`
+- First-match-wins: earlier rule wins for the same method + path
+- Default fallback: unmatched request falls through to service `default`; unspecified `default` means deny
+- Unknown service: `CheckHTTPService("nope", ...)` returns deny
+- Query string ignored: `/foo?x=1` matches the same rule as `/foo`
+- Empty path coerced to `/`
+
+**`internal/policy/engine_test.go` — `TestDeclaredHTTPServiceHost`**:
+
+- Exact match; port stripping (`api.github.com:443`); lowercase normalization; alias match; IPv6 bracket handling; no-match returns `ok=false`
+- Env var name returned for guidance messages
+
+**`internal/policy/model_test.go` additions**:
+
+- Duplicate service name rejected at load
+- Duplicate upstream host (including across aliases) rejected at load
+- Invalid upstream URL rejected (not https, missing host)
+- Invalid glob in `paths` rejected (error mentions rule name)
+- Invalid decision value rejected
+- Invalid `expose_as` (starts with digit, contains hyphen) rejected
+- Empty `rules` without `default` is allowed (implicit deny-all)
+
+### Gateway integration tests in `internal/proxy/proxy_test.go`
+
+Spin up an `httptest.Server` as fake upstream. Build a `Proxy` with an `http_services` entry pointing at it. Exercise `ServeHTTP` directly:
+
+- `POST /svc/github/repos/anthropics/claude-code/issues` with a matching allow rule → upstream receives the body and headers, response flows back
+- `DELETE /svc/github/repos/anthropics/claude-code` with a deny rule → 403 with the rule's `message`, upstream not contacted
+- `HeaderInjectionHook` populates `Authorization` on the upstream-bound request, credential never visible in the request log
+- `http_service_request` event emitted with `rule_name` set to the matched rule or `"default"`
+- Approve-decision path: request is held until approval resolves; timeout honored; emits `http_service_approve`
+- Path `/svc/nosuchservice/...` returns 404, does NOT fall through to dialect detection
+- LLM path untouched: `POST /v1/messages` with `x-api-key` still routes to the Anthropic dialect handler
+
+### Netmonitor integration tests
+
+Extend existing netmonitor tests (or new file):
+
+- CONNECT to `api.github.com:443` when `github` is declared → 403 with guidance mentioning `GITHUB_API_URL`
+- CONNECT to a non-declared host tunnels through unchanged (regression guard)
+- Plain HTTP to `api.github.com` via `handleHTTP` → 403 with the same guidance
+- `allow_direct: true` service lets CONNECT through (escape hatch proven wired)
+- `http_service_denied_direct` event emitted with expected fields
+
+### Path-matching fuzz target
+
+`internal/policy/engine_fuzz_test.go` — `FuzzCheckHTTPServicePath`. Feeds random strings containing `%2e`, `%2f`, `\x00`, double slashes, Unicode dot variants, mixed slashes, and asserts:
+
+1. Whatever decision comes back, the raw path never reaches the upstream without surviving `path.Clean` unchanged (i.e. allow decisions require traversal-clean paths).
+2. The evaluator never panics.
+3. Method matching is stable under arbitrary casing.
+
+Path handling is the attack surface most likely to grow subtle bugs — the fuzz target is proportionate to the risk.
+
+### Cross-compile gate
+
+`GOOS=windows go build ./...` before commit, per `CLAUDE.md`. All new code is pure Go in `internal/policy` and `internal/proxy` — no `runtime.GOOS` branching expected, but the gate proves it.
+
+### What NOT to retest
+
+- `gobwas/glob` — upstream tested
+- `storage`, `redaction`, `RequestRewriter`, `hookRegistry` — existing LLM-proxy tests cover these; reuse without duplication
+- Network policy layer (`CheckNetworkCtx`, seccomp) — §7 layering is architectural, no new code in those paths
+- Plan 6's existing `services:` matcher — untouched by this design
+
+---
+
+## Open Questions
+
+- **`maybeApprove` location.** Currently lives in `internal/netmonitor/proxy.go` as a private helper. The gateway needs the same behavior. Lift to a shared package (`internal/policy` or `internal/approvals`) or duplicate? Deferred to the implementation plan.
+- **Request-body approval context.** The approval prompt for a write operation should probably show a hash/excerpt of the body, not just the path. Worth a follow-up once the basic approve flow is wired — do not gate v1 on it.
+- **Service-level body size limits.** `http_services[i].max_body_bytes` would be useful (default to the LLM-proxy's existing limit). Not in v1 scope but the schema has room for it.
+
+## Future Work
+
+- Unify `services:` and `http_services:` into a single declaration.
+- Query-string matching in rules (keys and value patterns).
+- Header-value matching in rules.
+- Local DNS redirect for uncooperative clients (with its own trade-offs).
+- Per-service rate limiting, extending the existing LLM rate limiter.
+- `redirect` decisions that swap one upstream for another (requires careful thought about what a redirect means for HTTP semantics).

--- a/docs/superpowers/specs/2026-04-10-http-path-verb-filtering-design.md
+++ b/docs/superpowers/specs/2026-04-10-http-path-verb-filtering-design.md
@@ -37,7 +37,7 @@ Cooperation is by base-URL env var injection, not by DNS rerouting. There is no 
 - New top-level `http_services:` policy YAML section
 - New `policy.Engine` methods: `CheckHTTPService`, `HTTPServices`, `DeclaredHTTPServiceHost`
 - Extend `internal/proxy/proxy.go` `ServeHTTP` with a path-prefix dispatch to declared services, bypassing LLM dialect detection when the request targets `/svc/<name>/...`
-- New `serveDeclaredService` handler that reuses `hookRegistry`, `RequestRewriter`, DLP, storage, redaction
+- New `serveDeclaredService` handler that reuses `hookRegistry`, DLP, storage, redaction (not `RequestRewriter` — see §2)
 - Extend `Proxy.EnvVars()` to emit per-service `<NAME>_API_URL` entries
 - Fail-closed CONNECT and plain-HTTP checks in `internal/netmonitor/proxy.go`
 - New event types: `http_service_request`, `http_service_denied_direct`, `http_service_approve`
@@ -142,7 +142,7 @@ Semantics:
 
 ## Section 2 — Component: Generalized Service Gateway
 
-Extend `internal/proxy/proxy.go` rather than building a new proxy. Rationale: reuse `hookRegistry`, `RequestRewriter`, DLP, storage, request logging, redaction, and the existing listener — all of which already do what a declared-service gateway needs.
+Extend `internal/proxy/proxy.go` rather than building a new proxy. Rationale: reuse `hookRegistry`, DLP, storage, request logging, redaction, and the existing listener — most of what a declared-service gateway needs already exists there. `RequestRewriter` is **not** reused (it is LLM-dialect-specific); a small request-clone helper is added instead (see step 5 below).
 
 ### Dispatch changes in `ServeHTTP`
 
@@ -170,12 +170,11 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 1. Read and buffer the request body (same as the LLM path).
 2. Build `RequestContext{ServiceName: svc.Name, ...}` and assign a `request_id`.
-3. Validate the path: reject with 400 if `path.Clean(rest) != rest` (traversal guard, see §3).
-4. Call `p.policy.CheckHTTPService(svc.Name, r.Method, rest)`. Apply `maybeApprove`-style approval semantics, reusing the pattern from `netmonitor/proxy.go`.
-5. Dispatch hooks via `hookRegistry.ApplyPreHooks(svc.Name, r, ctx)` — service-scoped, so `HeaderInjectionHook` for this service fires and injects the real credential. Plan 6's `LeakGuardHook` already skips when `ServiceName != ""`.
-6. Rewrite the outbound request to `svc.Upstream + rest` (keeping query string, headers), using `RequestRewriter`.
-7. Forward via the existing upstream transport. Capture response into storage. Apply post-hooks. Emit `http_service_request` event.
-8. Stream the response back to the caller.
+3. Call `p.policy.CheckHTTPService(svc.Name, r.Method, rest)`. The evaluator handles traversal rejection and empty-path coercion (see §3) — the gateway does not duplicate those checks. Apply `maybeApprove`-style approval semantics, reusing the pattern from `netmonitor/proxy.go`.
+4. Dispatch hooks via `hookRegistry.ApplyPreHooks(svc.Name, r, ctx)` — service-scoped, so `HeaderInjectionHook` for this service fires and injects the real credential. Plan 6's `LeakGuardHook` already skips when `ServiceName != ""`.
+5. Build a fresh outbound `*http.Request` for `svc.Upstream + rest` (preserving query string, headers, method, body). Do **not** reuse the LLM-side `RequestRewriter` — it takes a `Dialect` parameter and its rewrite logic (auth header swapping, OpenAI OAuth routing) is LLM-specific. A small helper on `Proxy` that clones the request and retargets it to the upstream URL is sufficient.
+6. Forward via the existing upstream transport (`http.DefaultTransport` or whatever the LLM path uses — decide in the implementation plan). Capture response into storage. Apply post-hooks. Emit `http_service_request` event.
+7. Stream the response back to the caller.
 
 ### Env var plumbing
 
@@ -225,7 +224,7 @@ type compiledHTTPService struct {
 
 // On Engine:
 httpServices     map[string]*compiledHTTPService // keyed by lowercase name
-httpServiceHosts map[string]string               // upstream host -> service name
+httpServiceHosts map[string]*compiledHTTPService // upstream host -> compiled service
 ```
 
 Built in `NewEngine` alongside `compiledNetworkRule`, `compiledFileRule`, etc.
@@ -233,20 +232,20 @@ Built in `NewEngine` alongside `compiledNetworkRule`, `compiledFileRule`, etc.
 ### Check method
 
 ```go
-// CheckHTTPService evaluates method+path against the rules for service.
-// path is the path portion AFTER the /svc/<name> prefix has been stripped.
+// CheckHTTPService evaluates method+reqPath against the rules for service.
+// reqPath is the path portion AFTER the /svc/<name> prefix has been stripped.
 // Returns a wrapped Decision in the same shape as CheckNetworkCtx.
-func (e *Engine) CheckHTTPService(service, method, path string) Decision {
+func (e *Engine) CheckHTTPService(service, method, reqPath string) Decision {
     cs, ok := e.httpServices[strings.ToLower(service)]
     if !ok {
         return e.wrapDecision("deny", "", "unknown http_service", 0)
     }
 
     // Traversal guard: reject any path that doesn't survive path.Clean unchanged.
-    if path == "" {
-        path = "/"
+    if reqPath == "" {
+        reqPath = "/"
     }
-    if path.Clean(path) != path {
+    if path.Clean(reqPath) != reqPath {
         return e.wrapDecision("deny", "", "path traversal rejected", 0)
     }
 
@@ -256,7 +255,7 @@ func (e *Engine) CheckHTTPService(service, method, path string) Decision {
         if !methodMatches(r, method) {
             continue
         }
-        if !pathMatches(r, path) {
+        if !pathMatches(r, reqPath) {
             continue
         }
         return e.wrapDecision(r.rule.Decision, r.rule.Name, r.rule.Message, r.rule.Timeout)
@@ -572,7 +571,7 @@ Path handling is the attack surface most likely to grow subtle bugs — the fuzz
 ### What NOT to retest
 
 - `gobwas/glob` — upstream tested
-- `storage`, `redaction`, `RequestRewriter`, `hookRegistry` — existing LLM-proxy tests cover these; reuse without duplication
+- `storage`, `redaction`, `hookRegistry` — existing LLM-proxy tests cover these; reuse without duplication
 - Network policy layer (`CheckNetworkCtx`, seccomp) — §7 layering is architectural, no new code in those paths
 - Plan 6's existing `services:` matcher — untouched by this design
 

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -514,6 +514,9 @@ func (a *App) startLLMProxy(ctx context.Context, s *session.Session) {
 		if p, ok := s.ProxyInstance().(*proxy.Proxy); ok {
 			p.SetPolicyEngine(pol)
 			p.SetHTTPServices(pol.HTTPServices())
+			if a.approvals != nil {
+				p.SetHTTPServiceApprovals(a.approvals)
+			}
 		}
 	}
 

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -502,6 +502,21 @@ func (a *App) startLLMProxy(ctx context.Context, s *session.Session) {
 		return
 	}
 
+	// Wire declared http_services into the freshly started proxy so
+	// /svc/<name>/ requests route through the policy engine. The session
+	// stores the proxy instance as interface{} to avoid a cycle; the
+	// concrete type is *proxy.Proxy in every production path. policyEngineFor
+	// already returned `pol` above, so reuse it directly. This runs BEFORE
+	// any child process can make requests to /svc/<name>/ because
+	// startLLMProxy is called from session creation, before execInSessionCore
+	// spawns the agent child — no race.
+	if pol != nil {
+		if p, ok := s.ProxyInstance().(*proxy.Proxy); ok {
+			p.SetPolicyEngine(pol)
+			p.SetHTTPServices(pol.HTTPServices())
+		}
+	}
+
 	// Store cleanup function (the proxy URL is already set by StartLLMProxy)
 	_ = closeFn // closeFn is stored by StartLLMProxy via sess.SetProxy
 

--- a/internal/cli/llm_logs.go
+++ b/internal/cli/llm_logs.go
@@ -17,8 +17,13 @@ type LLMLogEntry struct {
 	ID        string       `json:"id,omitempty"`
 	Timestamp time.Time    `json:"timestamp"`
 	Dialect   string       `json:"dialect,omitempty"`
-	Request   *LLMRequest  `json:"request,omitempty"`
-	DLP       *LLMDLPInfo  `json:"dlp,omitempty"`
+	// ServiceKind discriminates LLM traffic from declared-service
+	// (http_service) traffic sharing the same JSONL file. Entries with
+	// ServiceKind=="http_service" are skipped by this reader so they
+	// don't show up as "unknown" LLM rows in session reports.
+	ServiceKind string       `json:"service_kind,omitempty"`
+	Request     *LLMRequest  `json:"request,omitempty"`
+	DLP         *LLMDLPInfo  `json:"dlp,omitempty"`
 
 	// Response-specific fields
 	RequestID  string       `json:"request_id,omitempty"`
@@ -133,6 +138,10 @@ func ReadLLMLogsFromFile(path string) ([]LLMLogRow, error) {
 func ReadLLMLogs(r io.Reader) ([]LLMLogRow, error) {
 	// Track requests by ID to correlate with responses
 	requests := make(map[string]*LLMLogEntry)
+	// Track IDs whose request entry was skipped (service_kind=
+	// "http_service"), so the correlated response — which has no
+	// service_kind field of its own — can also be skipped.
+	skipIDs := make(map[string]bool)
 	var rows []LLMLogRow
 
 	scanner := bufio.NewScanner(r)
@@ -147,9 +156,19 @@ func ReadLLMLogs(r io.Reader) ([]LLMLogRow, error) {
 		}
 
 		if entry.isRequest() {
+			// Declared-service traffic is logged to the same file but
+			// must not appear as an LLM row. Record the ID so we can
+			// skip its correlated response below.
+			if entry.ServiceKind == "http_service" {
+				skipIDs[entry.ID] = true
+				continue
+			}
 			// Store request for later correlation
 			requests[entry.ID] = &entry
 		} else if entry.isResponse() {
+			if skipIDs[entry.RequestID] {
+				continue
+			}
 			// Find matching request
 			req, ok := requests[entry.RequestID]
 			if !ok {

--- a/internal/cli/llm_logs_test.go
+++ b/internal/cli/llm_logs_test.go
@@ -134,6 +134,34 @@ func TestReadLLMLogs(t *testing.T) {
 	})
 }
 
+// TestReadLLMLogs_SkipsHTTPServiceEntries pins down that the llm-logs
+// CLI reader skips entries whose service_kind is "http_service".
+// Declared-service traffic is logged to the same JSONL file as LLM
+// traffic but is not "LLM" — including it as an "unknown" dialect
+// row confuses session reporting.
+func TestReadLLMLogs_SkipsHTTPServiceEntries(t *testing.T) {
+	// One LLM pair (anthropic) and one http_service pair (github).
+	input := `{"id":"req_001","timestamp":"2026-01-04T10:30:01Z","dialect":"anthropic","request":{"method":"POST","path":"/v1/messages"}}
+{"request_id":"req_001","timestamp":"2026-01-04T10:30:02Z","duration_ms":1200,"response":{"status":200},"usage":{"input_tokens":150,"output_tokens":892}}
+{"id":"req_http_1","timestamp":"2026-01-04T10:31:00Z","service_kind":"http_service","service_name":"github","request":{"method":"GET","path":"/user"}}
+{"request_id":"req_http_1","timestamp":"2026-01-04T10:31:01Z","duration_ms":500,"response":{"status":200}}
+`
+	rows, err := ReadLLMLogs(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row (LLM only), got %d: %+v", len(rows), rows)
+	}
+	if rows[0].ID != "req_001" {
+		t.Errorf("row ID = %q, want req_001", rows[0].ID)
+	}
+	if rows[0].Dialect != "anthropic" {
+		t.Errorf("row Dialect = %q, want anthropic", rows[0].Dialect)
+	}
+}
+
 func TestFormatLLMLogRow(t *testing.T) {
 	ts, _ := time.Parse(time.RFC3339, "2026-01-04T10:30:01Z")
 

--- a/internal/netmonitor/declared_services_test.go
+++ b/internal/netmonitor/declared_services_test.go
@@ -1,0 +1,185 @@
+package netmonitor
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+// newEngineWithDeclaredGitHub builds a minimal policy.Engine with a
+// declared http_service for api.github.com. A permissive network rule
+// is added so that a direct request would otherwise be permitted; that
+// ensures the test exercises the declared-service fail-closed gate
+// rather than an incidental network_rules deny.
+func newEngineWithDeclaredGitHub(t *testing.T, allowDirect bool) *policy.Engine {
+	t.Helper()
+	pol := &policy.Policy{
+		Version: 1,
+		NetworkRules: []policy.NetworkRule{
+			// Use an explicit glob matching api.github.com so we don't
+			// rely on '*' crossing dot separators. gobwas/glob compiled
+			// with a '.' separator treats '*' as one-segment only.
+			{Name: "allow-github", Decision: "allow", Domains: []string{"*.github.com", "api.github.com"}},
+		},
+		HTTPServices: []policy.HTTPService{{
+			Name:        "github",
+			Upstream:    "https://api.github.com",
+			ExposeAs:    "GITHUB_API_URL",
+			AllowDirect: allowDirect,
+			Default:     "allow",
+		}},
+	}
+	if err := policy.ValidateHTTPServices(pol.HTTPServices); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	e, err := policy.NewEngine(pol, true, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	return e
+}
+
+// TestHandleConnect_DeniesDeclaredHost verifies that CONNECT to a host
+// declared as an http_services upstream is rejected with a 403 and a
+// guidance message pointing at the service's env var, even when
+// network_rules would otherwise permit it.
+func TestHandleConnect_DeniesDeclaredHost(t *testing.T) {
+	eng := newEngineWithDeclaredGitHub(t, false)
+	em := &stubEmitter{}
+	p := &Proxy{sessionID: "s", policy: eng, emit: em}
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	done := make(chan struct{})
+	go func() {
+		_ = p.handleConn(server)
+		close(done)
+	}()
+
+	_, _ = client.Write([]byte("CONNECT api.github.com:443 HTTP/1.1\r\nHost: api.github.com:443\r\n\r\n"))
+	buf := make([]byte, 512)
+	n, _ := client.Read(buf)
+	resp := string(buf[:n])
+
+	if !strings.Contains(resp, "403 Forbidden") {
+		t.Fatalf("expected 403 response, got %q", resp)
+	}
+	if !strings.Contains(resp, "GITHUB_API_URL") {
+		t.Errorf("expected response to mention GITHUB_API_URL, got %q", resp)
+	}
+	client.Close()
+	<-done
+
+	var gotDeniedEvent bool
+	for _, ev := range em.events {
+		if ev.Type != "http_service_denied_direct" {
+			continue
+		}
+		gotDeniedEvent = true
+		if ev.Fields["service_name"] != "github" {
+			t.Errorf("expected service_name=github, got %v", ev.Fields["service_name"])
+		}
+		if ev.Fields["env_var"] != "GITHUB_API_URL" {
+			t.Errorf("expected env_var=GITHUB_API_URL, got %v", ev.Fields["env_var"])
+		}
+		if ev.Domain != "api.github.com" {
+			t.Errorf("expected domain api.github.com, got %q", ev.Domain)
+		}
+	}
+	if !gotDeniedEvent {
+		t.Errorf("expected http_service_denied_direct event, events=%+v", em.events)
+	}
+}
+
+// TestHandleHTTP_DeniesDeclaredHost verifies that a plain HTTP (non-CONNECT)
+// proxy request targeting a declared http_services upstream is also rejected
+// with a 403 and the env var guidance. This is the path used by curl when
+// asked to speak http:// through the proxy.
+func TestHandleHTTP_DeniesDeclaredHost(t *testing.T) {
+	eng := newEngineWithDeclaredGitHub(t, false)
+	em := &stubEmitter{}
+	p := &Proxy{sessionID: "s", policy: eng, emit: em}
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	done := make(chan struct{})
+	go func() {
+		_ = p.handleConn(server)
+		close(done)
+	}()
+
+	req := "GET http://api.github.com/user HTTP/1.1\r\nHost: api.github.com\r\n\r\n"
+	_, _ = client.Write([]byte(req))
+	buf := make([]byte, 512)
+	n, _ := client.Read(buf)
+	resp := string(buf[:n])
+
+	if !strings.Contains(resp, "403 Forbidden") {
+		t.Fatalf("expected 403 response, got %q", resp)
+	}
+	if !strings.Contains(resp, "GITHUB_API_URL") {
+		t.Errorf("expected response to mention GITHUB_API_URL, got %q", resp)
+	}
+	client.Close()
+	<-done
+
+	var gotDeniedEvent bool
+	for _, ev := range em.events {
+		if ev.Type != "http_service_denied_direct" {
+			continue
+		}
+		gotDeniedEvent = true
+		if ev.Fields["service_name"] != "github" {
+			t.Errorf("expected service_name=github, got %v", ev.Fields["service_name"])
+		}
+		if ev.Fields["env_var"] != "GITHUB_API_URL" {
+			t.Errorf("expected env_var=GITHUB_API_URL, got %v", ev.Fields["env_var"])
+		}
+	}
+	if !gotDeniedEvent {
+		t.Errorf("expected http_service_denied_direct event, events=%+v", em.events)
+	}
+}
+
+// TestHandleConnect_AllowDirectSkipsCheck verifies that a declared service
+// with allow_direct: true is NOT blocked by the fail-closed gate. The
+// connection should proceed past the gate; we can't complete a CONNECT
+// in the pipe harness (no upstream listener), but we MUST not see a 403
+// whose body mentions the env var — that's the signature of the
+// fail-closed block we're opting out of.
+func TestHandleConnect_AllowDirectSkipsCheck(t *testing.T) {
+	eng := newEngineWithDeclaredGitHub(t, true)
+	em := &stubEmitter{}
+	p := &Proxy{sessionID: "s", policy: eng, emit: em}
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	done := make(chan struct{})
+	go func() {
+		_ = p.handleConn(server)
+		close(done)
+	}()
+
+	_, _ = client.Write([]byte("CONNECT api.github.com:443 HTTP/1.1\r\nHost: api.github.com:443\r\n\r\n"))
+	buf := make([]byte, 512)
+	n, _ := client.Read(buf)
+	resp := string(buf[:n])
+
+	// Must not be the fail-closed 403 with the env var hint.
+	if strings.Contains(resp, "GITHUB_API_URL") {
+		t.Errorf("allow_direct=true should skip the fail-closed block, got %q", resp)
+	}
+	// A http_service_denied_direct event must NOT be emitted.
+	for _, ev := range em.events {
+		if ev.Type == "http_service_denied_direct" {
+			t.Errorf("unexpected http_service_denied_direct event when allow_direct=true: %+v", ev)
+		}
+	}
+	client.Close()
+	<-done
+}

--- a/internal/netmonitor/declared_services_test.go
+++ b/internal/netmonitor/declared_services_test.go
@@ -2,11 +2,20 @@ package netmonitor
 
 import (
 	"net"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/pkg/types"
 )
+
+func init() {
+	// Allow http:// upstreams in test engines so we can point declared
+	// services at a local httptest.Server.
+	policy.SetAllowInsecureHTTPServiceUpstreamForTest(true)
+}
 
 // newEngineWithDeclaredGitHub builds a minimal policy.Engine with a
 // declared http_service for api.github.com. A permissive network rule
@@ -92,6 +101,35 @@ func TestHandleConnect_DeniesDeclaredHost(t *testing.T) {
 	if !gotDeniedEvent {
 		t.Errorf("expected http_service_denied_direct event, events=%+v", em.events)
 	}
+
+	// Regression: the fail-closed gate must run BEFORE the DNS lookup,
+	// so no dns_query event should be emitted for a declared-service
+	// host that is rejected in the fail-closed path.
+	for _, ev := range em.events {
+		if ev.Type == "dns_query" {
+			t.Errorf("unexpected dns_query event on fail-closed path: %+v", ev)
+		}
+	}
+
+	// Regression: the fail-closed path must also emit a deny net_connect
+	// event so that session reports and blocked-op summaries that count
+	// denials by Policy.EffectiveDecision see this request as denied.
+	var gotDenyNetConnect bool
+	for _, ev := range em.events {
+		if ev.Type != "net_connect" {
+			continue
+		}
+		if ev.Policy == nil || ev.Policy.EffectiveDecision != types.DecisionDeny {
+			continue
+		}
+		if ev.Fields["service_name"] == "github" {
+			gotDenyNetConnect = true
+			break
+		}
+	}
+	if !gotDenyNetConnect {
+		t.Errorf("expected deny net_connect event with service_name=github, events=%+v", em.events)
+	}
 }
 
 // TestHandleHTTP_DeniesDeclaredHost verifies that a plain HTTP (non-CONNECT)
@@ -143,16 +181,77 @@ func TestHandleHTTP_DeniesDeclaredHost(t *testing.T) {
 	if !gotDeniedEvent {
 		t.Errorf("expected http_service_denied_direct event, events=%+v", em.events)
 	}
+
+	// Regression: no DNS side effect on the fail-closed path.
+	for _, ev := range em.events {
+		if ev.Type == "dns_query" {
+			t.Errorf("unexpected dns_query event on fail-closed path: %+v", ev)
+		}
+	}
+
+	// Regression: the fail-closed path emits a synthetic deny
+	// net_connect so blocked-op summaries count this request.
+	var gotDenyNetConnect bool
+	for _, ev := range em.events {
+		if ev.Type != "net_connect" {
+			continue
+		}
+		if ev.Policy == nil || ev.Policy.EffectiveDecision != types.DecisionDeny {
+			continue
+		}
+		if ev.Fields["service_name"] == "github" {
+			gotDenyNetConnect = true
+			break
+		}
+	}
+	if !gotDenyNetConnect {
+		t.Errorf("expected deny net_connect event with service_name=github, events=%+v", em.events)
+	}
 }
 
 // TestHandleConnect_AllowDirectSkipsCheck verifies that a declared service
-// with allow_direct: true is NOT blocked by the fail-closed gate. The
-// connection should proceed past the gate; we can't complete a CONNECT
-// in the pipe harness (no upstream listener), but we MUST not see a 403
-// whose body mentions the env var — that's the signature of the
-// fail-closed block we're opting out of.
+// with allow_direct: true is NOT blocked by the fail-closed gate. Uses a
+// local httptest.Server so the test never reaches for the real internet;
+// the declared host is 127.0.0.1 at the listener's port. The CONNECT
+// target never actually processes HTTP — we only assert the response is
+// not the fail-closed signature and no denied event was emitted.
 func TestHandleConnect_AllowDirectSkipsCheck(t *testing.T) {
-	eng := newEngineWithDeclaredGitHub(t, true)
+	// Start a local listener. The handler is a no-op: CONNECT tunnels
+	// raw bytes and we close the client pipe before the proxy's
+	// io.Copy does anything meaningful.
+	srv := newHTTPServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer srv.Close()
+
+	hostPort := strings.TrimPrefix(srv.URL, "http://")
+	listenerHost, _, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", hostPort, err)
+	}
+
+	// Build a policy engine whose declared service points at the local
+	// listener and opts into allow_direct. A permissive network rule is
+	// added so checkNetwork does not fall back to default-deny.
+	pol := &policy.Policy{
+		Version: 1,
+		NetworkRules: []policy.NetworkRule{
+			{Name: "allow-local", Decision: "allow", Domains: []string{listenerHost}},
+		},
+		HTTPServices: []policy.HTTPService{{
+			Name:        "local",
+			Upstream:    srv.URL,
+			ExposeAs:    "LOCAL_API_URL",
+			AllowDirect: true,
+			Default:     "allow",
+		}},
+	}
+	if err := policy.ValidateHTTPServices(pol.HTTPServices); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	eng, err := policy.NewEngine(pol, true, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
 	em := &stubEmitter{}
 	p := &Proxy{sessionID: "s", policy: eng, emit: em}
 
@@ -165,13 +264,18 @@ func TestHandleConnect_AllowDirectSkipsCheck(t *testing.T) {
 		close(done)
 	}()
 
-	_, _ = client.Write([]byte("CONNECT api.github.com:443 HTTP/1.1\r\nHost: api.github.com:443\r\n\r\n"))
+	connectReq := "CONNECT " + hostPort + " HTTP/1.1\r\nHost: " + hostPort + "\r\n\r\n"
+	_, _ = client.Write([]byte(connectReq))
+
+	// Bound the test: set a read deadline so a misbehaving harness
+	// cannot hang forever on the response read.
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
 	buf := make([]byte, 512)
 	n, _ := client.Read(buf)
 	resp := string(buf[:n])
 
 	// Must not be the fail-closed 403 with the env var hint.
-	if strings.Contains(resp, "GITHUB_API_URL") {
+	if strings.Contains(resp, "LOCAL_API_URL") {
 		t.Errorf("allow_direct=true should skip the fail-closed block, got %q", resp)
 	}
 	// A http_service_denied_direct event must NOT be emitted.

--- a/internal/netmonitor/proxy.go
+++ b/internal/netmonitor/proxy.go
@@ -140,6 +140,18 @@ func (p *Proxy) handleConnect(client net.Conn, req *http.Request) error {
 
 	ctx := req.Context()
 	dec := p.checkNetwork(ctx, host, port)
+	// Fail-closed check: if the target host is declared as an http_services
+	// upstream, deny direct HTTPS regardless of the CheckNetworkCtx decision.
+	// The only way to reach the upstream is through the gateway via
+	// /svc/<name>/. Services opt out by setting allow_direct: true.
+	if p.policy != nil {
+		if svcName, envVar, ok := p.policy.DeclaredHTTPServiceHost(host); ok && !p.policy.DeclaredHTTPServiceAllowsDirect(host) {
+			msg := "direct HTTPS to " + host + " is blocked; use " + envVar + " to route through the gateway"
+			_, _ = io.WriteString(client, "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: "+strconv.Itoa(len(msg))+"\r\n\r\n"+msg)
+			p.emitHTTPServiceDeniedDirect(context.Background(), commandID, svcName, envVar, host, resolvedIP, "CONNECT")
+			return nil
+		}
+	}
 	dec = p.maybeApprove(ctx, commandID, dec, "network", hostPort)
 	eventFields := map[string]any{
 		"method":      "CONNECT",
@@ -272,6 +284,18 @@ func (p *Proxy) handleHTTP(client net.Conn, req *http.Request) error {
 
 	ctx := req.Context()
 	dec := p.checkNetwork(ctx, host, port)
+	// Fail-closed check: if the target host is declared as an http_services
+	// upstream, deny direct HTTP regardless of the CheckNetworkCtx decision.
+	// Matches the analogous block in handleConnect. Services opt out by
+	// setting allow_direct: true.
+	if p.policy != nil {
+		if svcName, envVar, ok := p.policy.DeclaredHTTPServiceHost(host); ok && !p.policy.DeclaredHTTPServiceAllowsDirect(host) {
+			msg := "direct HTTP to " + host + " is blocked; use " + envVar + " to route through the gateway"
+			_, _ = io.WriteString(client, "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: "+strconv.Itoa(len(msg))+"\r\n\r\n"+msg)
+			p.emitHTTPServiceDeniedDirect(context.Background(), commandID, svcName, envVar, host, resolvedIP, req.Method)
+			return nil
+		}
+	}
 	dec = p.maybeApprove(ctx, commandID, dec, "network", host)
 	connectEv := p.emitNetEvent(context.Background(), "net_connect", commandID, host, host, port, dec, map[string]any{
 		"method":      req.Method,
@@ -452,6 +476,35 @@ func emitMCPConnectionIfMatched(ctx context.Context, sess *session.Session, emit
 	}
 	_ = emit.AppendEvent(ctx, ev)
 	emit.Publish(ev)
+}
+
+// emitHTTPServiceDeniedDirect records an audit event when the fail-closed
+// check in handleConnect or handleHTTP refuses a direct request to a
+// declared http_services upstream. These events give operators an
+// observable signal that a child process attempted to bypass the
+// gateway, even though they can take no corrective action in-band.
+func (p *Proxy) emitHTTPServiceDeniedDirect(ctx context.Context, commandID, svcName, envVar, host, resolvedIP, method string) {
+	if p.emit == nil {
+		return
+	}
+	ev := types.Event{
+		ID:        uuid.NewString(),
+		Timestamp: time.Now().UTC(),
+		Type:      "http_service_denied_direct",
+		SessionID: p.sessionID,
+		CommandID: commandID,
+		Domain:    strings.ToLower(host),
+		Remote:    host,
+		Fields: map[string]any{
+			"service_name": svcName,
+			"env_var":      envVar,
+			"request_host": host,
+			"resolved_ip":  resolvedIP,
+			"method":       method,
+		},
+	}
+	_ = p.emit.AppendEvent(ctx, ev)
+	p.emit.Publish(ev)
 }
 
 func (p *Proxy) resolveAndEmitDNS(ctx context.Context, commandID string, host string) string {

--- a/internal/netmonitor/proxy.go
+++ b/internal/netmonitor/proxy.go
@@ -121,6 +121,38 @@ func (p *Proxy) handleConnect(client net.Conn, req *http.Request) error {
 		commandID = p.sess.CurrentCommandID()
 	}
 
+	// Fail-closed check: if the target host is declared as an http_services
+	// upstream, deny direct HTTPS regardless of the CheckNetworkCtx decision.
+	// The only way to reach the upstream is through the gateway via
+	// /svc/<name>/. Services opt out by setting allow_direct: true.
+	//
+	// Runs BEFORE resolveAndEmitDNS and BEFORE EvaluateConnectRedirect so
+	// that blocked requests do not trigger DNS lookups, DNS approval
+	// prompts, or redirect side effects.
+	if p.policy != nil {
+		if svcName, envVar, ok := p.policy.DeclaredHTTPServiceHost(host); ok && !p.policy.DeclaredHTTPServiceAllowsDirect(host) {
+			msg := "direct HTTPS to " + host + " is blocked; use " + envVar + " to route through the gateway"
+			_, _ = io.WriteString(client, "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: "+strconv.Itoa(len(msg))+"\r\n\r\n"+msg)
+			failClosedDec := policy.Decision{
+				PolicyDecision:    types.DecisionDeny,
+				EffectiveDecision: types.DecisionDeny,
+				Rule:              "http_service_declared_fail_closed",
+				Message:           msg,
+			}
+			failClosedFields := map[string]any{
+				"method":       "CONNECT",
+				"resolved_ip":  "",
+				"service_name": svcName,
+				"env_var":      envVar,
+			}
+			netConnectEv := p.emitNetEvent(context.Background(), "net_connect", commandID, host, hostPort, port, failClosedDec, failClosedFields)
+			_ = p.emit.AppendEvent(context.Background(), netConnectEv)
+			p.emit.Publish(netConnectEv)
+			p.emitHTTPServiceDeniedDirect(context.Background(), commandID, svcName, envVar, host, "", "CONNECT")
+			return nil
+		}
+	}
+
 	resolvedIP := p.resolveAndEmitDNS(context.Background(), commandID, host)
 
 	// Check for connect redirect rules
@@ -140,18 +172,6 @@ func (p *Proxy) handleConnect(client net.Conn, req *http.Request) error {
 
 	ctx := req.Context()
 	dec := p.checkNetwork(ctx, host, port)
-	// Fail-closed check: if the target host is declared as an http_services
-	// upstream, deny direct HTTPS regardless of the CheckNetworkCtx decision.
-	// The only way to reach the upstream is through the gateway via
-	// /svc/<name>/. Services opt out by setting allow_direct: true.
-	if p.policy != nil {
-		if svcName, envVar, ok := p.policy.DeclaredHTTPServiceHost(host); ok && !p.policy.DeclaredHTTPServiceAllowsDirect(host) {
-			msg := "direct HTTPS to " + host + " is blocked; use " + envVar + " to route through the gateway"
-			_, _ = io.WriteString(client, "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: "+strconv.Itoa(len(msg))+"\r\n\r\n"+msg)
-			p.emitHTTPServiceDeniedDirect(context.Background(), commandID, svcName, envVar, host, resolvedIP, "CONNECT")
-			return nil
-		}
-	}
 	dec = p.maybeApprove(ctx, commandID, dec, "network", hostPort)
 	eventFields := map[string]any{
 		"method":      "CONNECT",
@@ -260,6 +280,38 @@ func (p *Proxy) handleHTTP(client net.Conn, req *http.Request) error {
 		commandID = p.sess.CurrentCommandID()
 	}
 
+	// Fail-closed check: if the target host is declared as an http_services
+	// upstream, deny direct HTTP regardless of the CheckNetworkCtx decision.
+	// Matches the analogous block in handleConnect. Services opt out by
+	// setting allow_direct: true.
+	//
+	// Runs BEFORE resolveAndEmitDNS and BEFORE net_http_request emission so
+	// that blocked requests do not trigger DNS lookups, DNS approval
+	// prompts, or observable request-tracking side effects.
+	if p.policy != nil {
+		if svcName, envVar, ok := p.policy.DeclaredHTTPServiceHost(host); ok && !p.policy.DeclaredHTTPServiceAllowsDirect(host) {
+			msg := "direct HTTP to " + host + " is blocked; use " + envVar + " to route through the gateway"
+			_, _ = io.WriteString(client, "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: "+strconv.Itoa(len(msg))+"\r\n\r\n"+msg)
+			failClosedDec := policy.Decision{
+				PolicyDecision:    types.DecisionDeny,
+				EffectiveDecision: types.DecisionDeny,
+				Rule:              "http_service_declared_fail_closed",
+				Message:           msg,
+			}
+			failClosedFields := map[string]any{
+				"method":       req.Method,
+				"resolved_ip":  "",
+				"service_name": svcName,
+				"env_var":      envVar,
+			}
+			netConnectEv := p.emitNetEvent(context.Background(), "net_connect", commandID, host, host, port, failClosedDec, failClosedFields)
+			_ = p.emit.AppendEvent(context.Background(), netConnectEv)
+			p.emit.Publish(netConnectEv)
+			p.emitHTTPServiceDeniedDirect(context.Background(), commandID, svcName, envVar, host, "", req.Method)
+			return nil
+		}
+	}
+
 	resolvedIP := p.resolveAndEmitDNS(context.Background(), commandID, host)
 	// Note: For HTTPS URLs via an explicit proxy, curl will use CONNECT which is handled in handleConnect.
 	// This path is for plain HTTP proxy requests, where we can record method/path (but not TLS contents).
@@ -284,18 +336,6 @@ func (p *Proxy) handleHTTP(client net.Conn, req *http.Request) error {
 
 	ctx := req.Context()
 	dec := p.checkNetwork(ctx, host, port)
-	// Fail-closed check: if the target host is declared as an http_services
-	// upstream, deny direct HTTP regardless of the CheckNetworkCtx decision.
-	// Matches the analogous block in handleConnect. Services opt out by
-	// setting allow_direct: true.
-	if p.policy != nil {
-		if svcName, envVar, ok := p.policy.DeclaredHTTPServiceHost(host); ok && !p.policy.DeclaredHTTPServiceAllowsDirect(host) {
-			msg := "direct HTTP to " + host + " is blocked; use " + envVar + " to route through the gateway"
-			_, _ = io.WriteString(client, "HTTP/1.1 403 Forbidden\r\nContent-Type: text/plain\r\nContent-Length: "+strconv.Itoa(len(msg))+"\r\n\r\n"+msg)
-			p.emitHTTPServiceDeniedDirect(context.Background(), commandID, svcName, envVar, host, resolvedIP, req.Method)
-			return nil
-		}
-	}
 	dec = p.maybeApprove(ctx, commandID, dec, "network", host)
 	connectEv := p.emitNetEvent(context.Background(), "net_connect", commandID, host, host, port, dec, map[string]any{
 		"method":      req.Method,

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -37,6 +37,10 @@ type Engine struct {
 	compiledUnixRules     []compiledUnixRule
 	compiledRegistryRules []compiledRegistryRule
 
+	// HTTP service compiled lookup maps
+	httpServices     map[string]*compiledHTTPService // keyed by lowercased name
+	httpServiceHosts map[string]*compiledHTTPService // keyed by canonicalized host
+
 	// Compiled redirect rules for DNS and connect interception
 	dnsRedirectRules     []compiledDnsRedirectRule
 	connectRedirectRules []compiledConnectRedirectRule
@@ -321,6 +325,14 @@ func NewEngine(p *Policy, enforceApprovals bool, enforceRedirects bool) (*Engine
 		return nil, err
 	}
 	e.signalEngine = sigEngine
+
+	// Compile HTTP services (after validation has run in Policy.Validate).
+	byName, byHost, err := compileHTTPServices(p.HTTPServices)
+	if err != nil {
+		return nil, fmt.Errorf("compile http_services: %w", err)
+	}
+	e.httpServices = byName
+	e.httpServiceHosts = byHost
 
 	return e, nil
 }

--- a/internal/policy/http_service.go
+++ b/internal/policy/http_service.go
@@ -65,10 +65,11 @@ func canonicalizeHost(s string) (string, bool) {
 		if rest != "" && !strings.HasPrefix(rest, ":") {
 			return "", false // junk after closing bracket
 		}
-		if inner == "" {
-			return "", false // "[]"
+		canonical := strings.TrimSuffix(strings.ToLower(inner), ".")
+		if canonical == "" {
+			return "", false // "[]" or "[.]"
 		}
-		return strings.TrimSuffix(strings.ToLower(inner), "."), true
+		return canonical, true
 	}
 	// Not bracketed. If there are 2+ colons, it's a bare IPv6 literal — reject.
 	if strings.Count(s, ":") >= 2 {

--- a/internal/policy/http_service.go
+++ b/internal/policy/http_service.go
@@ -36,30 +36,41 @@ type HTTPServiceRule struct {
 
 var envVarNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
-// canonicalizeHost normalizes a hostname for comparison against HTTP Host
-// headers. The rules mirror internal/proxy/services.Matcher.Match so that
-// policy-time duplicate-host detection catches aliases that the proxy layer
-// would treat as identical at request-routing time:
+// canonicalizeHost normalizes a host string for duplicate-detection and
+// matching. It handles three forms:
 //
-//  1. Strip any trailing ":port". IPv6 bracketed forms like "[::1]:443" keep
-//     the closing bracket; non-bracketed forms use the last colon.
-//  2. Lowercase.
-//  3. Strip a trailing "." (FQDN form).
+//  1. bracketed IPv6 with optional port: "[::1]", "[::1]:443"
+//  2. bare IPv6 literal (no brackets, no port): "::1", "fe80::1"
+//  3. hostname with optional port: "api.github.com", "api.github.com:443"
+//
+// Rules: strip any port, strip IPv6 brackets, lowercase, and trim a single
+// trailing dot. After canonicalization, "[::1]" and "::1" both become "::1"
+// so bracketed upstreams and bare aliases compare equal.
 //
 // This helper lives in the policy package by design: the policy package must
 // not import proxy-layer packages, so the normalization logic is duplicated
 // here (with both sites anchored to the same documented rules).
 func canonicalizeHost(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
 	if strings.HasPrefix(s, "[") {
 		// Bracketed IPv6: look for "]:" to find the port separator. Keep the
 		// closing bracket, drop ":port".
 		if i := strings.Index(s, "]:"); i != -1 {
 			s = s[:i+1]
 		}
-	} else {
-		if i := strings.LastIndex(s, ":"); i != -1 {
-			s = s[:i]
+		// Strip the brackets themselves for canonical form.
+		if strings.HasSuffix(s, "]") {
+			s = s[1 : len(s)-1]
 		}
+	} else if strings.Count(s, ":") >= 2 {
+		// Bare IPv6 literal (e.g. "::1", "fe80::1") — no port possible.
+		// Leave as-is apart from lowercase + trailing-dot trim below.
+	} else if i := strings.LastIndex(s, ":"); i != -1 {
+		// host:port
+		s = s[:i]
 	}
 	return strings.TrimSuffix(strings.ToLower(s), ".")
 }
@@ -89,7 +100,7 @@ func ValidateHTTPServices(svcs []HTTPService) error {
 			return fmt.Errorf("http_services[%q]: upstream must be https (got %q)", s.Name, u.Scheme)
 		}
 
-		host := canonicalizeHost(u.Hostname())
+		host := canonicalizeHost(u.Host)
 		if other, dup := hostSeen[host]; dup {
 			return fmt.Errorf("http_services[%q]: duplicate upstream host %q (also claimed by %q)", s.Name, host, other)
 		}

--- a/internal/policy/http_service.go
+++ b/internal/policy/http_service.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"fmt"
+	"net/netip"
 	"net/url"
 	"regexp"
 	"strings"
@@ -45,6 +46,12 @@ var envVarNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 // (internal/proxy/services/matcher.go preserves brackets and matches
 // "[::1]" literally — bare "::1" never matches).
 //
+// Bracketed payloads MUST be valid IPv6 literals per RFC 3986 §3.2.2;
+// any other content (hostnames, IPv4, IPv4-in-IPv6, or malformed text)
+// is rejected. IPv6 literals are canonicalized via netip.Addr.String()
+// so "[::1]", "[::0001]", "[0:0:0:0:0:0:0:1]", and "[FE80::1]" compare
+// equal to their canonical forms.
+//
 // Returns (canonical, true) on success, ("", false) on reject.
 //
 // This helper lives in the policy package by design: the policy package
@@ -65,11 +72,18 @@ func canonicalizeHost(s string) (string, bool) {
 		if rest != "" && !strings.HasPrefix(rest, ":") {
 			return "", false // junk after closing bracket
 		}
-		canonical := strings.TrimSuffix(strings.ToLower(inner), ".")
-		if canonical == "" {
-			return "", false // "[]" or "[.]"
+		// Bracketed hosts must be IPv6 literals per RFC 3986 §3.2.2.
+		// netip.ParseAddr rejects empty strings, "[.]", "[..]", hostnames,
+		// invalid hex, embedded whitespace, etc. We additionally reject
+		// IPv4 (should never be bracketed in HTTP URLs) and IPv4-in-IPv6
+		// forms like "::ffff:192.168.1.1" to keep semantics crisp.
+		addr, err := netip.ParseAddr(inner)
+		if err != nil || !addr.Is6() || addr.Is4In6() {
+			return "", false
 		}
-		return canonical, true
+		// addr.String() returns the canonical form, so "[::0001]" and
+		// "[::1]" both canonicalize to "::1".
+		return addr.String(), true
 	}
 	// Not bracketed. If there are 2+ colons, it's a bare IPv6 literal — reject.
 	if strings.Count(s, ":") >= 2 {

--- a/internal/policy/http_service.go
+++ b/internal/policy/http_service.go
@@ -38,6 +38,10 @@ type HTTPServiceRule struct {
 var envVarNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
 // canonicalizeHost returns the canonical host form for duplicate-detection.
+// It validates bracket contents as IPv6 literals via netip.ParseAddr but
+// uses the lowercased textual form (not addr.String()) so that duplicate
+// detection matches what the runtime host matcher would see.
+//
 // It accepts bracketed IPv6 "[::1]" / "[::1]:443", hostnames, and
 // "host:port" in any case with an optional trailing dot. It REJECTS
 // bare (unbracketed) IPv6 literals because HTTP Host headers require
@@ -46,11 +50,11 @@ var envVarNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 // (internal/proxy/services/matcher.go preserves brackets and matches
 // "[::1]" literally — bare "::1" never matches).
 //
-// Bracketed payloads MUST be valid IPv6 literals per RFC 3986 §3.2.2;
-// any other content (hostnames, IPv4, IPv4-in-IPv6, or malformed text)
-// is rejected. IPv6 literals are canonicalized via netip.Addr.String()
-// so "[::1]", "[::0001]", "[0:0:0:0:0:0:0:1]", and "[FE80::1]" compare
-// equal to their canonical forms.
+// Bracketed payloads MUST parse as valid IPv6 literals per RFC 3986
+// §3.2.2; hostnames, malformed hex, embedded whitespace, "[..]",
+// "[example.com]", and similar garbage are rejected. IPv4-in-IPv6
+// forms like "[::ffff:192.168.1.1]" are syntactically valid IPv6 and
+// accepted (the runtime matcher accepts them too).
 //
 // Returns (canonical, true) on success, ("", false) on reject.
 //
@@ -72,18 +76,19 @@ func canonicalizeHost(s string) (string, bool) {
 		if rest != "" && !strings.HasPrefix(rest, ":") {
 			return "", false // junk after closing bracket
 		}
-		// Bracketed hosts must be IPv6 literals per RFC 3986 §3.2.2.
-		// netip.ParseAddr rejects empty strings, "[.]", "[..]", hostnames,
-		// invalid hex, embedded whitespace, etc. We additionally reject
-		// IPv4 (should never be bracketed in HTTP URLs) and IPv4-in-IPv6
-		// forms like "::ffff:192.168.1.1" to keep semantics crisp.
+		// Validate that the bracket payload is a real IPv6 literal per
+		// RFC 3986 §3.2.2, but don't canonicalize its spelling — the
+		// runtime host matcher compares bracketed literals textually
+		// (only lowercase + port-strip), so we need validation to use
+		// the same domain of equality. IPv4-in-IPv6 forms like
+		// ::ffff:192.168.1.1 are syntactically valid IPv6 and accepted
+		// by the runtime matcher — accept them too.
 		addr, err := netip.ParseAddr(inner)
-		if err != nil || !addr.Is6() || addr.Is4In6() {
+		if err != nil || !addr.Is6() {
 			return "", false
 		}
-		// addr.String() returns the canonical form, so "[::0001]" and
-		// "[::1]" both canonicalize to "::1".
-		return addr.String(), true
+		_ = addr
+		return strings.ToLower(inner), true
 	}
 	// Not bracketed. If there are 2+ colons, it's a bare IPv6 literal — reject.
 	if strings.Count(s, ":") >= 2 {

--- a/internal/policy/http_service.go
+++ b/internal/policy/http_service.go
@@ -36,6 +36,34 @@ type HTTPServiceRule struct {
 
 var envVarNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
+// canonicalizeHost normalizes a hostname for comparison against HTTP Host
+// headers. The rules mirror internal/proxy/services.Matcher.Match so that
+// policy-time duplicate-host detection catches aliases that the proxy layer
+// would treat as identical at request-routing time:
+//
+//  1. Strip any trailing ":port". IPv6 bracketed forms like "[::1]:443" keep
+//     the closing bracket; non-bracketed forms use the last colon.
+//  2. Lowercase.
+//  3. Strip a trailing "." (FQDN form).
+//
+// This helper lives in the policy package by design: the policy package must
+// not import proxy-layer packages, so the normalization logic is duplicated
+// here (with both sites anchored to the same documented rules).
+func canonicalizeHost(s string) string {
+	if strings.HasPrefix(s, "[") {
+		// Bracketed IPv6: look for "]:" to find the port separator. Keep the
+		// closing bracket, drop ":port".
+		if i := strings.Index(s, "]:"); i != -1 {
+			s = s[:i+1]
+		}
+	} else {
+		if i := strings.LastIndex(s, ":"); i != -1 {
+			s = s[:i]
+		}
+	}
+	return strings.TrimSuffix(strings.ToLower(s), ".")
+}
+
 // ValidateHTTPServices checks an HTTPServices list for well-formedness.
 // It is called from Policy.Validate. Errors include the offending service
 // name (and rule name, when applicable) to aid debugging.
@@ -61,14 +89,19 @@ func ValidateHTTPServices(svcs []HTTPService) error {
 			return fmt.Errorf("http_services[%q]: upstream must be https (got %q)", s.Name, u.Scheme)
 		}
 
-		host := strings.ToLower(u.Hostname())
+		host := canonicalizeHost(u.Hostname())
 		if other, dup := hostSeen[host]; dup {
 			return fmt.Errorf("http_services[%q]: duplicate upstream host %q (also claimed by %q)", s.Name, host, other)
 		}
 		hostSeen[host] = s.Name
 		for _, alias := range s.Aliases {
-			a := strings.ToLower(strings.TrimSpace(alias))
+			trimmed := strings.TrimSpace(alias)
+			if trimmed == "" {
+				return fmt.Errorf("http_services[%q]: empty alias", s.Name)
+			}
+			a := canonicalizeHost(trimmed)
 			if a == "" {
+				// canonicalizeHost stripped everything (e.g. ":443").
 				return fmt.Errorf("http_services[%q]: empty alias", s.Name)
 			}
 			if other, dup := hostSeen[a]; dup {
@@ -116,6 +149,9 @@ func validateHTTPServiceRule(svc string, idx int, r *HTTPServiceRule) error {
 		return fmt.Errorf("%s: rule must have at least one path", label)
 	}
 	for _, pat := range r.Paths {
+		if strings.TrimSpace(pat) == "" {
+			return fmt.Errorf("%s: empty path in rule", label)
+		}
 		if _, err := glob.Compile(pat, '/'); err != nil {
 			return fmt.Errorf("%s: invalid path glob %q: %w", label, pat, err)
 		}

--- a/internal/policy/http_service.go
+++ b/internal/policy/http_service.go
@@ -37,6 +37,18 @@ type HTTPServiceRule struct {
 
 var envVarNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
+// reservedEnvVarNames is the set of env var names that http_services must
+// not claim via ExposeAs or via the derived <NAME>_API_URL form, because
+// they are already emitted by Proxy.EnvVars() for the LLM proxy. Allowing
+// collisions would silently overwrite one of the sides in the returned
+// map. Keep additions here conservative — each entry shrinks the space of
+// valid http_service configurations.
+var reservedEnvVarNames = map[string]struct{}{
+	"ANTHROPIC_BASE_URL": {},
+	"OPENAI_BASE_URL":    {},
+	"AGENTSH_SESSION_ID": {},
+}
+
 // canonicalizeHost returns the canonical host form for duplicate-detection.
 // It validates bracket contents as IPv6 literals via netip.ParseAddr but
 // uses the lowercased textual form (not addr.String()) so that duplicate
@@ -110,7 +122,8 @@ func canonicalizeHost(s string) (string, bool) {
 // name (and rule name, when applicable) to aid debugging.
 func ValidateHTTPServices(svcs []HTTPService) error {
 	nameSeen := make(map[string]bool, len(svcs))
-	hostSeen := make(map[string]string, len(svcs)) // host -> owning service name
+	hostSeen := make(map[string]string, len(svcs))   // host -> owning service name
+	envVarSeen := make(map[string]string, len(svcs)) // env var name -> owning service name
 	for i := range svcs {
 		s := &svcs[i]
 		if strings.TrimSpace(s.Name) == "" {
@@ -158,6 +171,11 @@ func ValidateHTTPServices(svcs []HTTPService) error {
 			return fmt.Errorf("http_services[%q]: invalid default %q (want allow|deny)", s.Name, s.Default)
 		}
 
+		// Derive the effective env var name once and use it for both the
+		// regex check and the reserved/duplicate collision checks. This
+		// matches what Proxy.EnvVars() will emit at runtime, so validation
+		// rejects misconfigurations that would cause silent overwrites of
+		// LLM proxy envs or of another http_service's entry.
 		exposeAs := s.ExposeAs
 		if exposeAs == "" {
 			exposeAs = strings.ToUpper(s.Name) + "_API_URL"
@@ -167,6 +185,13 @@ func ValidateHTTPServices(svcs []HTTPService) error {
 		} else if !envVarNameRe.MatchString(exposeAs) {
 			return fmt.Errorf("http_services[%q]: invalid expose_as %q", s.Name, exposeAs)
 		}
+		if _, reserved := reservedEnvVarNames[exposeAs]; reserved {
+			return fmt.Errorf("http_services[%q]: reserved env var name %q (used by LLM proxy)", s.Name, exposeAs)
+		}
+		if other, dup := envVarSeen[exposeAs]; dup {
+			return fmt.Errorf("http_services[%q]: duplicate env var name %q (also claimed by %q)", s.Name, exposeAs, other)
+		}
+		envVarSeen[exposeAs] = s.Name
 
 		for j := range s.Rules {
 			r := &s.Rules[j]

--- a/internal/policy/http_service.go
+++ b/internal/policy/http_service.go
@@ -36,43 +36,53 @@ type HTTPServiceRule struct {
 
 var envVarNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
-// canonicalizeHost normalizes a host string for duplicate-detection and
-// matching. It handles three forms:
+// canonicalizeHost returns the canonical host form for duplicate-detection.
+// It accepts bracketed IPv6 "[::1]" / "[::1]:443", hostnames, and
+// "host:port" in any case with an optional trailing dot. It REJECTS
+// bare (unbracketed) IPv6 literals because HTTP Host headers require
+// IPv6 to be bracketed; treating bare forms as equivalent would create
+// configs whose duplicate detection differs from runtime host matching
+// (internal/proxy/services/matcher.go preserves brackets and matches
+// "[::1]" literally — bare "::1" never matches).
 //
-//  1. bracketed IPv6 with optional port: "[::1]", "[::1]:443"
-//  2. bare IPv6 literal (no brackets, no port): "::1", "fe80::1"
-//  3. hostname with optional port: "api.github.com", "api.github.com:443"
+// Returns (canonical, true) on success, ("", false) on reject.
 //
-// Rules: strip any port, strip IPv6 brackets, lowercase, and trim a single
-// trailing dot. After canonicalization, "[::1]" and "::1" both become "::1"
-// so bracketed upstreams and bare aliases compare equal.
-//
-// This helper lives in the policy package by design: the policy package must
-// not import proxy-layer packages, so the normalization logic is duplicated
-// here (with both sites anchored to the same documented rules).
-func canonicalizeHost(s string) string {
+// This helper lives in the policy package by design: the policy package
+// must not import proxy-layer packages, so the normalization logic is
+// duplicated here (with both sites anchored to the same documented rules).
+func canonicalizeHost(s string) (string, bool) {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		return ""
+		return "", false
 	}
 	if strings.HasPrefix(s, "[") {
-		// Bracketed IPv6: look for "]:" to find the port separator. Keep the
-		// closing bracket, drop ":port".
-		if i := strings.Index(s, "]:"); i != -1 {
-			s = s[:i+1]
+		end := strings.Index(s, "]")
+		if end == -1 {
+			return "", false // unterminated bracket
 		}
-		// Strip the brackets themselves for canonical form.
-		if strings.HasSuffix(s, "]") {
-			s = s[1 : len(s)-1]
+		inner := s[1:end]
+		rest := s[end+1:]
+		if rest != "" && !strings.HasPrefix(rest, ":") {
+			return "", false // junk after closing bracket
 		}
-	} else if strings.Count(s, ":") >= 2 {
-		// Bare IPv6 literal (e.g. "::1", "fe80::1") — no port possible.
-		// Leave as-is apart from lowercase + trailing-dot trim below.
-	} else if i := strings.LastIndex(s, ":"); i != -1 {
-		// host:port
+		if inner == "" {
+			return "", false // "[]"
+		}
+		return strings.TrimSuffix(strings.ToLower(inner), "."), true
+	}
+	// Not bracketed. If there are 2+ colons, it's a bare IPv6 literal — reject.
+	if strings.Count(s, ":") >= 2 {
+		return "", false
+	}
+	// hostname or host:port
+	if i := strings.LastIndex(s, ":"); i != -1 {
 		s = s[:i]
 	}
-	return strings.TrimSuffix(strings.ToLower(s), ".")
+	s = strings.TrimSuffix(strings.ToLower(s), ".")
+	if s == "" {
+		return "", false
+	}
+	return s, true
 }
 
 // ValidateHTTPServices checks an HTTPServices list for well-formedness.
@@ -100,20 +110,20 @@ func ValidateHTTPServices(svcs []HTTPService) error {
 			return fmt.Errorf("http_services[%q]: upstream must be https (got %q)", s.Name, u.Scheme)
 		}
 
-		host := canonicalizeHost(u.Host)
+		// u.Host (not u.Hostname()) preserves brackets for IPv6 literals so
+		// the canonicalizer can distinguish bracketed from bare forms.
+		host, ok := canonicalizeHost(u.Host)
+		if !ok {
+			return fmt.Errorf("http_services[%q]: invalid upstream host %q (IPv6 literals must be bracketed)", s.Name, u.Host)
+		}
 		if other, dup := hostSeen[host]; dup {
 			return fmt.Errorf("http_services[%q]: duplicate upstream host %q (also claimed by %q)", s.Name, host, other)
 		}
 		hostSeen[host] = s.Name
 		for _, alias := range s.Aliases {
-			trimmed := strings.TrimSpace(alias)
-			if trimmed == "" {
-				return fmt.Errorf("http_services[%q]: empty alias", s.Name)
-			}
-			a := canonicalizeHost(trimmed)
-			if a == "" {
-				// canonicalizeHost stripped everything (e.g. ":443").
-				return fmt.Errorf("http_services[%q]: empty alias", s.Name)
+			a, ok := canonicalizeHost(alias)
+			if !ok {
+				return fmt.Errorf("http_services[%q]: invalid alias %q (IPv6 literals must be bracketed, hostnames must be non-empty)", s.Name, alias)
 			}
 			if other, dup := hostSeen[a]; dup {
 				return fmt.Errorf("http_services[%q]: duplicate upstream host %q via alias (also claimed by %q)", s.Name, a, other)

--- a/internal/policy/http_service.go
+++ b/internal/policy/http_service.go
@@ -1,5 +1,14 @@
 package policy
 
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/gobwas/glob"
+)
+
 // HTTPService declares an HTTP service that a cooperating child process
 // can reach through the proxy gateway. Requests are matched to the service
 // by a URL path prefix (/svc/<name>/), then evaluated against Rules in
@@ -23,4 +32,98 @@ type HTTPServiceRule struct {
 	Decision string   `yaml:"decision"`          // allow | deny | approve | audit
 	Message  string   `yaml:"message,omitempty"`
 	Timeout  duration `yaml:"timeout,omitempty"` // parsed but not wired in v1
+}
+
+var envVarNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// ValidateHTTPServices checks an HTTPServices list for well-formedness.
+// It is called from Policy.Validate. Errors include the offending service
+// name (and rule name, when applicable) to aid debugging.
+func ValidateHTTPServices(svcs []HTTPService) error {
+	nameSeen := make(map[string]bool, len(svcs))
+	hostSeen := make(map[string]string, len(svcs)) // host -> owning service name
+	for i := range svcs {
+		s := &svcs[i]
+		if strings.TrimSpace(s.Name) == "" {
+			return fmt.Errorf("http_services[%d]: name is required", i)
+		}
+		lower := strings.ToLower(s.Name)
+		if nameSeen[lower] {
+			return fmt.Errorf("http_services: duplicate http_service name %q", s.Name)
+		}
+		nameSeen[lower] = true
+
+		u, err := url.Parse(s.Upstream)
+		if err != nil || u == nil || u.Host == "" {
+			return fmt.Errorf("http_services[%q]: invalid upstream URL %q", s.Name, s.Upstream)
+		}
+		if u.Scheme != "https" {
+			return fmt.Errorf("http_services[%q]: upstream must be https (got %q)", s.Name, u.Scheme)
+		}
+
+		host := strings.ToLower(u.Hostname())
+		if other, dup := hostSeen[host]; dup {
+			return fmt.Errorf("http_services[%q]: duplicate upstream host %q (also claimed by %q)", s.Name, host, other)
+		}
+		hostSeen[host] = s.Name
+		for _, alias := range s.Aliases {
+			a := strings.ToLower(strings.TrimSpace(alias))
+			if a == "" {
+				return fmt.Errorf("http_services[%q]: empty alias", s.Name)
+			}
+			if other, dup := hostSeen[a]; dup {
+				return fmt.Errorf("http_services[%q]: duplicate upstream host %q via alias (also claimed by %q)", s.Name, a, other)
+			}
+			hostSeen[a] = s.Name
+		}
+
+		switch s.Default {
+		case "", "allow", "deny":
+			// OK
+		default:
+			return fmt.Errorf("http_services[%q]: invalid default %q (want allow|deny)", s.Name, s.Default)
+		}
+
+		exposeAs := s.ExposeAs
+		if exposeAs == "" {
+			exposeAs = strings.ToUpper(s.Name) + "_API_URL"
+			if !envVarNameRe.MatchString(exposeAs) {
+				return fmt.Errorf("http_services[%q]: derived env var name %q is invalid; set expose_as explicitly", s.Name, exposeAs)
+			}
+		} else if !envVarNameRe.MatchString(exposeAs) {
+			return fmt.Errorf("http_services[%q]: invalid expose_as %q", s.Name, exposeAs)
+		}
+
+		for j := range s.Rules {
+			r := &s.Rules[j]
+			if err := validateHTTPServiceRule(s.Name, j, r); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateHTTPServiceRule(svc string, idx int, r *HTTPServiceRule) error {
+	label := fmt.Sprintf("http_services[%q].rules[%d] (%s)", svc, idx, r.Name)
+	switch r.Decision {
+	case "allow", "deny", "approve", "audit":
+		// OK
+	default:
+		return fmt.Errorf("%s: invalid rule decision %q", label, r.Decision)
+	}
+	if len(r.Paths) == 0 {
+		return fmt.Errorf("%s: rule must have at least one path", label)
+	}
+	for _, pat := range r.Paths {
+		if _, err := glob.Compile(pat, '/'); err != nil {
+			return fmt.Errorf("%s: invalid path glob %q: %w", label, pat, err)
+		}
+	}
+	for _, m := range r.Methods {
+		if strings.TrimSpace(m) == "" {
+			return fmt.Errorf("%s: empty method", label)
+		}
+	}
+	return nil
 }

--- a/internal/policy/http_service.go
+++ b/internal/policy/http_service.go
@@ -176,6 +176,13 @@ func ValidateHTTPServices(svcs []HTTPService) error {
 		// matches what Proxy.EnvVars() will emit at runtime, so validation
 		// rejects misconfigurations that would cause silent overwrites of
 		// LLM proxy envs or of another http_service's entry.
+		//
+		// Windows treats environment variables as case-insensitive, so the
+		// reserved-name and duplicate-detection keys are upper-cased before
+		// comparison. The raw form is preserved in error messages so users
+		// see the exact value they wrote in their YAML. The regex check
+		// still runs on the raw name since env var names may be lowercase
+		// on Linux (the regex allows [A-Za-z_]).
 		exposeAs := s.ExposeAs
 		if exposeAs == "" {
 			exposeAs = strings.ToUpper(s.Name) + "_API_URL"
@@ -185,13 +192,14 @@ func ValidateHTTPServices(svcs []HTTPService) error {
 		} else if !envVarNameRe.MatchString(exposeAs) {
 			return fmt.Errorf("http_services[%q]: invalid expose_as %q", s.Name, exposeAs)
 		}
-		if _, reserved := reservedEnvVarNames[exposeAs]; reserved {
+		exposeAsKey := strings.ToUpper(exposeAs)
+		if _, reserved := reservedEnvVarNames[exposeAsKey]; reserved {
 			return fmt.Errorf("http_services[%q]: reserved env var name %q (used by LLM proxy)", s.Name, exposeAs)
 		}
-		if other, dup := envVarSeen[exposeAs]; dup {
+		if other, dup := envVarSeen[exposeAsKey]; dup {
 			return fmt.Errorf("http_services[%q]: duplicate env var name %q (also claimed by %q)", s.Name, exposeAs, other)
 		}
-		envVarSeen[exposeAs] = s.Name
+		envVarSeen[exposeAsKey] = s.Name
 
 		for j := range s.Rules {
 			r := &s.Rules[j]

--- a/internal/policy/http_service.go
+++ b/internal/policy/http_service.go
@@ -1,0 +1,26 @@
+package policy
+
+// HTTPService declares an HTTP service that a cooperating child process
+// can reach through the proxy gateway. Requests are matched to the service
+// by a URL path prefix (/svc/<name>/), then evaluated against Rules in
+// declaration order. First-match-wins; if no rule matches, Default applies
+// (empty or "deny" means deny).
+type HTTPService struct {
+	Name        string            `yaml:"name"`
+	Upstream    string            `yaml:"upstream"`               // https://api.github.com
+	ExposeAs    string            `yaml:"expose_as,omitempty"`    // env var name; derived from Name if empty
+	Aliases     []string          `yaml:"aliases,omitempty"`      // extra hostnames for the fail-closed check
+	AllowDirect bool              `yaml:"allow_direct,omitempty"` // escape hatch; default false
+	Default     string            `yaml:"default,omitempty"`      // allow | deny; default deny
+	Rules       []HTTPServiceRule `yaml:"rules,omitempty"`
+}
+
+// HTTPServiceRule is a single method+path matching rule for an HTTP service.
+type HTTPServiceRule struct {
+	Name     string   `yaml:"name"`
+	Methods  []string `yaml:"methods,omitempty"` // empty or "*" means any method
+	Paths    []string `yaml:"paths"`             // gobwas/glob patterns, '/' separator
+	Decision string   `yaml:"decision"`          // allow | deny | approve | audit
+	Message  string   `yaml:"message,omitempty"`
+	Timeout  duration `yaml:"timeout,omitempty"` // parsed but not wired in v1
+}

--- a/internal/policy/http_service.go
+++ b/internal/policy/http_service.go
@@ -57,6 +57,20 @@ var reservedEnvVarNames = map[string]struct{}{
 	"AGENTSH_SESSION_ID": {},
 }
 
+// httpServiceAllowInsecureUpstreamForTest, when true, lets ValidateHTTPServices
+// accept http:// upstreams. Set from test init() functions only. Never set in
+// production code.
+var httpServiceAllowInsecureUpstreamForTest bool
+
+// SetAllowInsecureHTTPServiceUpstreamForTest enables the test-only relaxation
+// of the upstream scheme check so tests can point declared services at an
+// httptest.Server listening on http://. This function exists so test files
+// in other packages can flip the toggle without touching package-private
+// state. Not thread-safe. Never call from production code.
+func SetAllowInsecureHTTPServiceUpstreamForTest(v bool) {
+	httpServiceAllowInsecureUpstreamForTest = v
+}
+
 // canonicalizeHost returns the canonical host form for duplicate-detection.
 // It validates bracket contents as IPv6 literals via netip.ParseAddr but
 // uses the lowercased textual form (not addr.String()) so that duplicate
@@ -150,7 +164,7 @@ func ValidateHTTPServices(svcs []HTTPService) error {
 		if err != nil || u == nil || u.Host == "" {
 			return fmt.Errorf("http_services[%q]: invalid upstream URL %q", s.Name, s.Upstream)
 		}
-		if u.Scheme != "https" {
+		if u.Scheme != "https" && !(httpServiceAllowInsecureUpstreamForTest && u.Scheme == "http") {
 			return fmt.Errorf("http_services[%q]: upstream must be https (got %q)", s.Name, u.Scheme)
 		}
 

--- a/internal/policy/http_service.go
+++ b/internal/policy/http_service.go
@@ -37,6 +37,14 @@ type HTTPServiceRule struct {
 
 var envVarNameRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
+// httpServiceNameRe restricts http_service.name to URL-safe path segment
+// characters. Routing depends on the name appearing in /svc/<name>/ URLs,
+// so any character the URL parser treats as a segment terminator (/, ?, #)
+// or otherwise reserves must be rejected up front — otherwise the derived
+// *_API_URL would be ambiguous and /svc/<name>/ dispatch would fall through
+// to a 404 or match the wrong service.
+var httpServiceNameRe = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
 // reservedEnvVarNames is the set of env var names that http_services must
 // not claim via ExposeAs or via the derived <NAME>_API_URL form, because
 // they are already emitted by Proxy.EnvVars() for the LLM proxy. Allowing
@@ -128,6 +136,9 @@ func ValidateHTTPServices(svcs []HTTPService) error {
 		s := &svcs[i]
 		if strings.TrimSpace(s.Name) == "" {
 			return fmt.Errorf("http_services[%d]: name is required", i)
+		}
+		if !httpServiceNameRe.MatchString(s.Name) {
+			return fmt.Errorf("http_services[%d]: name %q must match %s (URL-safe segment)", i, s.Name, httpServiceNameRe)
 		}
 		lower := strings.ToLower(s.Name)
 		if nameSeen[lower] {

--- a/internal/policy/http_service_check.go
+++ b/internal/policy/http_service_check.go
@@ -84,11 +84,20 @@ func pathMatchesHTTPRule(r compiledHTTPServiceRule, reqPath string) bool {
 }
 
 // DeclaredHTTPServiceHost reports whether host belongs to a declared
-// http_services entry. host may include a port (stripped via
-// canonicalizeHost), be in any case, or be a bracketed IPv6 literal.
-// Returns the canonical service name and the env var name used by the
-// gateway, for inclusion in guidance messages.
+// http_services entry. host may include a port (bracket-aware strip),
+// be in any case, end in a trailing dot, or be a bracketed IPv6 literal.
+// It also accepts a bare IPv6 literal (e.g. from net.SplitHostPort on
+// a bracketed authority), which callers may produce when dealing with
+// post-parsed HTTP Host headers. Returns the canonical service name
+// and the env var name used by the gateway.
 func (e *Engine) DeclaredHTTPServiceHost(host string) (serviceName, envVar string, ok bool) {
+	// Rewrap bare IPv6 literals so canonicalizeHost can see them.
+	// A hostname never contains a colon, and host:port has exactly
+	// one, so >= 2 colons on an unbracketed string unambiguously
+	// indicates a bare IPv6 literal.
+	if !strings.HasPrefix(host, "[") && strings.Count(host, ":") >= 2 {
+		host = "[" + host + "]"
+	}
 	h, good := canonicalizeHost(host)
 	if !good {
 		return "", "", false
@@ -100,15 +109,34 @@ func (e *Engine) DeclaredHTTPServiceHost(host string) (serviceName, envVar strin
 	return cs.cfg.Name, cs.envVar, true
 }
 
-// HTTPServices returns a shallow copy of the source HTTPService list.
+// HTTPServices returns a deep copy of the source HTTPService list.
 // Used by the proxy to enumerate declared services for EnvVars()
-// injection and by tests. Callers may mutate the returned slice without
-// affecting engine state.
+// injection and by tests. Callers may mutate the returned slice and
+// its contents without affecting engine state.
 func (e *Engine) HTTPServices() []HTTPService {
 	if e == nil || e.policy == nil || len(e.policy.HTTPServices) == 0 {
 		return nil
 	}
 	out := make([]HTTPService, len(e.policy.HTTPServices))
-	copy(out, e.policy.HTTPServices)
+	for i, src := range e.policy.HTTPServices {
+		dst := src // copies scalar fields
+		if len(src.Aliases) > 0 {
+			dst.Aliases = append([]string(nil), src.Aliases...)
+		}
+		if len(src.Rules) > 0 {
+			dst.Rules = make([]HTTPServiceRule, len(src.Rules))
+			for j, r := range src.Rules {
+				rc := r // copies scalar fields
+				if len(r.Methods) > 0 {
+					rc.Methods = append([]string(nil), r.Methods...)
+				}
+				if len(r.Paths) > 0 {
+					rc.Paths = append([]string(nil), r.Paths...)
+				}
+				dst.Rules[j] = rc
+			}
+		}
+		out[i] = dst
+	}
 	return out
 }

--- a/internal/policy/http_service_check.go
+++ b/internal/policy/http_service_check.go
@@ -109,6 +109,30 @@ func (e *Engine) DeclaredHTTPServiceHost(host string) (serviceName, envVar strin
 	return cs.cfg.Name, cs.envVar, true
 }
 
+// DeclaredHTTPServiceAllowsDirect returns true when the declared service
+// matching host has allow_direct: true set in its YAML. Callers of
+// DeclaredHTTPServiceHost should query this before denying direct access
+// in the fail-closed netmonitor path — a true result means the service
+// opted out of the gateway-only constraint.
+//
+// host follows the same canonicalization rules as DeclaredHTTPServiceHost
+// (case, trailing dot, bracketed or bare IPv6, optional port). Returns
+// false for unknown hosts — the caller already gated on DeclaredHTTPServiceHost.
+func (e *Engine) DeclaredHTTPServiceAllowsDirect(host string) bool {
+	if !strings.HasPrefix(host, "[") && strings.Count(host, ":") >= 2 {
+		host = "[" + host + "]"
+	}
+	h, good := canonicalizeHost(host)
+	if !good {
+		return false
+	}
+	cs, found := e.httpServiceHosts[h]
+	if !found {
+		return false
+	}
+	return cs.cfg.AllowDirect
+}
+
 // HTTPServices returns a deep copy of the source HTTPService list.
 // Used by the proxy to enumerate declared services for EnvVars()
 // injection and by tests. Callers may mutate the returned slice and

--- a/internal/policy/http_service_check.go
+++ b/internal/policy/http_service_check.go
@@ -1,0 +1,66 @@
+package policy
+
+import (
+	"path"
+	"strings"
+)
+
+// CheckHTTPService evaluates method+reqPath against the rules for service.
+// reqPath is the path portion AFTER the /svc/<name> prefix has been stripped
+// and the query string removed. The gateway is responsible for stripping
+// both before calling this method.
+//
+// Returns a wrapped Decision in the same shape as CheckNetworkCtx. First-
+// match-wins on rules. If no rule matches, the service's Default applies
+// (the compiler defaults empty to "deny"). Unknown services always deny.
+func (e *Engine) CheckHTTPService(service, method, reqPath string) Decision {
+	cs, ok := e.httpServices[strings.ToLower(service)]
+	if !ok {
+		return e.wrapDecision("deny", "", "unknown http_service", nil)
+	}
+
+	if reqPath == "" {
+		reqPath = "/"
+	}
+	// Traversal guard: reject any path that doesn't survive path.Clean.
+	if path.Clean(reqPath) != reqPath {
+		return e.wrapDecision("deny", "", "path traversal rejected", nil)
+	}
+
+	m := strings.ToUpper(method)
+
+	for _, r := range cs.rules {
+		if !methodMatchesHTTPRule(r, m) {
+			continue
+		}
+		if !pathMatchesHTTPRule(r, reqPath) {
+			continue
+		}
+		return e.wrapDecision(r.rule.Decision, r.rule.Name, r.rule.Message, nil)
+	}
+
+	if cs.defaultDecision == "allow" {
+		return e.wrapDecision("allow", "default", "", nil)
+	}
+	return e.wrapDecision("deny", "default", "no rule matched", nil)
+}
+
+func methodMatchesHTTPRule(r compiledHTTPServiceRule, method string) bool {
+	if len(r.methods) == 0 {
+		return true
+	}
+	if _, ok := r.methods["*"]; ok {
+		return true
+	}
+	_, ok := r.methods[method]
+	return ok
+}
+
+func pathMatchesHTTPRule(r compiledHTTPServiceRule, reqPath string) bool {
+	for _, g := range r.paths {
+		if g.Match(reqPath) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/policy/http_service_check.go
+++ b/internal/policy/http_service_check.go
@@ -82,3 +82,33 @@ func pathMatchesHTTPRule(r compiledHTTPServiceRule, reqPath string) bool {
 	}
 	return false
 }
+
+// DeclaredHTTPServiceHost reports whether host belongs to a declared
+// http_services entry. host may include a port (stripped via
+// canonicalizeHost), be in any case, or be a bracketed IPv6 literal.
+// Returns the canonical service name and the env var name used by the
+// gateway, for inclusion in guidance messages.
+func (e *Engine) DeclaredHTTPServiceHost(host string) (serviceName, envVar string, ok bool) {
+	h, good := canonicalizeHost(host)
+	if !good {
+		return "", "", false
+	}
+	cs, found := e.httpServiceHosts[h]
+	if !found {
+		return "", "", false
+	}
+	return cs.cfg.Name, cs.envVar, true
+}
+
+// HTTPServices returns a shallow copy of the source HTTPService list.
+// Used by the proxy to enumerate declared services for EnvVars()
+// injection and by tests. Callers may mutate the returned slice without
+// affecting engine state.
+func (e *Engine) HTTPServices() []HTTPService {
+	if e == nil || e.policy == nil || len(e.policy.HTTPServices) == 0 {
+		return nil
+	}
+	out := make([]HTTPService, len(e.policy.HTTPServices))
+	copy(out, e.policy.HTTPServices)
+	return out
+}

--- a/internal/policy/http_service_check.go
+++ b/internal/policy/http_service_check.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"path"
 	"strings"
 )
 
@@ -9,6 +8,10 @@ import (
 // reqPath is the path portion AFTER the /svc/<name> prefix has been stripped
 // and the query string removed. The gateway is responsible for stripping
 // both before calling this method.
+//
+// A single trailing slash is permitted on reqPath for usability — the
+// upstream API often accepts both forms — and is stripped before the rule
+// matcher runs so policy authors only have to write the non-slashed form.
 //
 // Returns a wrapped Decision in the same shape as CheckNetworkCtx. First-
 // match-wins on rules. If no rule matches, the service's Default applies
@@ -22,9 +25,24 @@ func (e *Engine) CheckHTTPService(service, method, reqPath string) Decision {
 	if reqPath == "" {
 		reqPath = "/"
 	}
-	// Traversal guard: reject any path that doesn't survive path.Clean.
-	if path.Clean(reqPath) != reqPath {
+
+	// Traversal/canonicalization guard. We reject:
+	//   - any duplicate interior separator ("//")
+	//   - any "." or ".." segment
+	// We permit a single trailing slash for usability (the upstream API
+	// often accepts both forms); it is stripped before rule matching so
+	// policy authors only have to write the non-slashed form.
+	if strings.Contains(reqPath, "//") {
 		return e.wrapDecision("deny", "", "path traversal rejected", nil)
+	}
+	for _, seg := range strings.Split(strings.TrimPrefix(reqPath, "/"), "/") {
+		if seg == "." || seg == ".." {
+			return e.wrapDecision("deny", "", "path traversal rejected", nil)
+		}
+	}
+	matchPath := reqPath
+	if len(matchPath) > 1 && strings.HasSuffix(matchPath, "/") {
+		matchPath = strings.TrimSuffix(matchPath, "/")
 	}
 
 	m := strings.ToUpper(method)
@@ -33,7 +51,7 @@ func (e *Engine) CheckHTTPService(service, method, reqPath string) Decision {
 		if !methodMatchesHTTPRule(r, m) {
 			continue
 		}
-		if !pathMatchesHTTPRule(r, reqPath) {
+		if !pathMatchesHTTPRule(r, matchPath) {
 			continue
 		}
 		return e.wrapDecision(r.rule.Decision, r.rule.Name, r.rule.Message, nil)

--- a/internal/policy/http_service_check_test.go
+++ b/internal/policy/http_service_check_test.go
@@ -93,3 +93,93 @@ func TestCheckHTTPService(t *testing.T) {
 		})
 	}
 }
+
+func TestDeclaredHTTPServiceHost(t *testing.T) {
+	svcs := []HTTPService{{
+		Name:     "github",
+		Upstream: "https://api.github.com",
+		ExposeAs: "GITHUB_API_URL",
+		Aliases:  []string{"api.github.example"},
+		Rules: []HTTPServiceRule{{
+			Name: "any", Paths: []string{"/**"}, Decision: "allow",
+		}},
+	}}
+	e := newTestEngineForHTTP(t, svcs)
+
+	tests := []struct {
+		host    string
+		wantOK  bool
+		wantSvc string
+		wantEnv string
+	}{
+		{"api.github.com", true, "github", "GITHUB_API_URL"},
+		{"API.GITHUB.COM", true, "github", "GITHUB_API_URL"},
+		{"api.github.com:443", true, "github", "GITHUB_API_URL"},
+		{"api.github.com.", true, "github", "GITHUB_API_URL"},
+		{"api.github.example", true, "github", "GITHUB_API_URL"},
+		{"example.com", false, "", ""},
+		{"", false, "", ""},
+		{"::1", false, "", ""}, // bare IPv6 never resolves
+	}
+	for _, tc := range tests {
+		t.Run(tc.host, func(t *testing.T) {
+			svc, env, ok := e.DeclaredHTTPServiceHost(tc.host)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if svc != tc.wantSvc || env != tc.wantEnv {
+				t.Errorf("got (%q, %q), want (%q, %q)", svc, env, tc.wantSvc, tc.wantEnv)
+			}
+		})
+	}
+}
+
+func TestDeclaredHTTPServiceHost_BracketedIPv6(t *testing.T) {
+	svcs := []HTTPService{{
+		Name:     "local",
+		Upstream: "https://[::1]",
+		Rules: []HTTPServiceRule{{
+			Name: "any", Paths: []string{"/**"}, Decision: "allow",
+		}},
+	}}
+	e := newTestEngineForHTTP(t, svcs)
+
+	// All of these should resolve to "local" because canonicalizeHost
+	// strips brackets/ports and the compiler stored the canonical form.
+	for _, h := range []string{"[::1]", "[::1]:443", "[::1]:9999"} {
+		t.Run(h, func(t *testing.T) {
+			svc, _, ok := e.DeclaredHTTPServiceHost(h)
+			if !ok || svc != "local" {
+				t.Errorf("%q → (%q, ok=%v), want (local, ok=true)", h, svc, ok)
+			}
+		})
+	}
+}
+
+func TestHTTPServicesEnumeration(t *testing.T) {
+	svcs := []HTTPService{
+		{
+			Name: "a", Upstream: "https://a.example.com",
+			Rules: []HTTPServiceRule{{Name: "r", Paths: []string{"/**"}, Decision: "allow"}},
+		},
+		{
+			Name: "b", Upstream: "https://b.example.com",
+			Rules: []HTTPServiceRule{{Name: "r", Paths: []string{"/**"}, Decision: "allow"}},
+		},
+	}
+	e := newTestEngineForHTTP(t, svcs)
+	got := e.HTTPServices()
+	if len(got) != 2 {
+		t.Fatalf("got %d, want 2", len(got))
+	}
+	if got[0].Name != "a" || got[1].Name != "b" {
+		t.Errorf("ordering not preserved: %+v", got)
+	}
+
+	// Returned slice must be an independent copy — mutating it should
+	// not affect the engine's stored policy.
+	got[0].Name = "MUTATED"
+	if again := e.HTTPServices(); again[0].Name == "MUTATED" {
+		t.Error("HTTPServices() returned a view, not a copy")
+	}
+}

--- a/internal/policy/http_service_check_test.go
+++ b/internal/policy/http_service_check_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"net"
 	"strings"
 	"testing"
 
@@ -156,11 +157,56 @@ func TestDeclaredHTTPServiceHost_BracketedIPv6(t *testing.T) {
 	}
 }
 
+func TestDeclaredHTTPServiceHost_BareIPv6FromSplitHostPort(t *testing.T) {
+	svcs := []HTTPService{{
+		Name:     "local",
+		Upstream: "https://[::1]",
+		Rules: []HTTPServiceRule{{
+			Name: "any", Paths: []string{"/**"}, Decision: "allow",
+		}},
+	}}
+	e := newTestEngineForHTTP(t, svcs)
+
+	// Simulate net.SplitHostPort("[::1]:443") → host="::1", port="443".
+	host, port, err := net.SplitHostPort("[::1]:443")
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	if port != "443" || host != "::1" {
+		t.Fatalf("unexpected SplitHostPort result: host=%q port=%q", host, port)
+	}
+	svc, _, ok := e.DeclaredHTTPServiceHost(host)
+	if !ok || svc != "local" {
+		t.Errorf("DeclaredHTTPServiceHost(%q) = (%q, ok=%v), want (local, ok=true)", host, svc, ok)
+	}
+
+	// Bare IPv6 with different spelling must also resolve.
+	for _, h := range []string{"::1", "fe80::x"} {
+		svc, _, ok := e.DeclaredHTTPServiceHost(h)
+		if h == "::1" {
+			if !ok || svc != "local" {
+				t.Errorf("%q → (%q, ok=%v), want (local, ok=true)", h, svc, ok)
+			}
+		} else {
+			// Invalid IPv6 — must not resolve, must not panic.
+			if ok {
+				t.Errorf("%q unexpectedly resolved to %q", h, svc)
+			}
+		}
+	}
+}
+
 func TestHTTPServicesEnumeration(t *testing.T) {
 	svcs := []HTTPService{
 		{
 			Name: "a", Upstream: "https://a.example.com",
-			Rules: []HTTPServiceRule{{Name: "r", Paths: []string{"/**"}, Decision: "allow"}},
+			Aliases: []string{"a-alt.example.com"},
+			Rules: []HTTPServiceRule{{
+				Name:     "r",
+				Methods:  []string{"GET", "POST"},
+				Paths:    []string{"/**", "/v1/**"},
+				Decision: "allow",
+			}},
 		},
 		{
 			Name: "b", Upstream: "https://b.example.com",
@@ -176,10 +222,29 @@ func TestHTTPServicesEnumeration(t *testing.T) {
 		t.Errorf("ordering not preserved: %+v", got)
 	}
 
-	// Returned slice must be an independent copy — mutating it should
-	// not affect the engine's stored policy.
+	// Top-level mutation must not leak.
 	got[0].Name = "MUTATED"
 	if again := e.HTTPServices(); again[0].Name == "MUTATED" {
-		t.Error("HTTPServices() returned a view, not a copy")
+		t.Error("HTTPServices(): top-level mutation leaked through")
+	}
+
+	// Nested slice mutations must not leak either.
+	got[0].Aliases[0] = "mutated-alias.example.com"
+	got[0].Rules[0].Name = "MUTATED_RULE"
+	got[0].Rules[0].Methods[0] = "DELETE"
+	got[0].Rules[0].Paths[0] = "/mutated/**"
+
+	again := e.HTTPServices()
+	if again[0].Aliases[0] != "a-alt.example.com" {
+		t.Errorf("Aliases nested mutation leaked: got %q", again[0].Aliases[0])
+	}
+	if again[0].Rules[0].Name != "r" {
+		t.Errorf("Rules nested mutation leaked: got Name=%q", again[0].Rules[0].Name)
+	}
+	if again[0].Rules[0].Methods[0] != "GET" {
+		t.Errorf("Rules[0].Methods nested mutation leaked: got %v", again[0].Rules[0].Methods)
+	}
+	if again[0].Rules[0].Paths[0] != "/**" {
+		t.Errorf("Rules[0].Paths nested mutation leaked: got %v", again[0].Rules[0].Paths)
 	}
 }

--- a/internal/policy/http_service_check_test.go
+++ b/internal/policy/http_service_check_test.go
@@ -68,6 +68,12 @@ func TestCheckHTTPService(t *testing.T) {
 		{"dot segment rejected", "github", "GET", "/repos/./a/b/issues", types.DecisionDeny, ""},
 		{"case sensitive path no match", "github", "GET", "/REPOS/a/b/issues", types.DecisionDeny, "default"},
 		{"query string ignored", "github", "GET", "/repos/a/b/issues?state=open", types.DecisionAllow, "read-issues"},
+		{"trailing slash allowed", "github", "GET", "/repos/a/b/issues/", types.DecisionAllow, "read-issues"},
+		{"trailing slash any-method", "github", "POST", "/public/thing/", types.DecisionAllow, "any-method"},
+		{"trailing slash wildcard-subtree", "github", "GET", "/orgs/acme/members/", types.DecisionAllow, "wildcard-subtree"},
+		{"root slash open service", "open", "GET", "/", types.DecisionAllow, "default"},
+		{"double slash at root", "github", "GET", "//", types.DecisionDeny, ""},
+		{"trailing double slash", "github", "GET", "/repos/a/b/issues//", types.DecisionDeny, ""},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/policy/http_service_check_test.go
+++ b/internal/policy/http_service_check_test.go
@@ -1,0 +1,89 @@
+package policy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+func newTestEngineForHTTP(t *testing.T, svcs []HTTPService) *Engine {
+	t.Helper()
+	p := &Policy{HTTPServices: svcs}
+	if err := ValidateHTTPServices(p.HTTPServices); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	byName, byHost, err := compileHTTPServices(p.HTTPServices)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	return &Engine{
+		policy:           p,
+		httpServices:     byName,
+		httpServiceHosts: byHost,
+		enforceApprovals: true,
+	}
+}
+
+func TestCheckHTTPService(t *testing.T) {
+	svcs := []HTTPService{{
+		Name: "github", Upstream: "https://api.github.com",
+		Default: "deny",
+		Rules: []HTTPServiceRule{
+			{Name: "read-issues", Methods: []string{"GET"}, Paths: []string{"/repos/*/*/issues", "/repos/*/*/issues/*"}, Decision: "allow"},
+			{Name: "wildcard-subtree", Methods: []string{"GET"}, Paths: []string{"/orgs/**"}, Decision: "allow"},
+			{Name: "any-method", Methods: []string{"*"}, Paths: []string{"/public/*"}, Decision: "allow"},
+			{Name: "multi-method", Methods: []string{"PUT", "PATCH"}, Paths: []string{"/repos/*/*"}, Decision: "allow"},
+			{Name: "block-delete", Methods: []string{"DELETE"}, Paths: []string{"/repos/**"}, Decision: "deny", Message: "no deletes"},
+		},
+	}, {
+		Name: "open", Upstream: "https://open.example.com",
+		Default: "allow",
+	}}
+
+	e := newTestEngineForHTTP(t, svcs)
+
+	tests := []struct {
+		name         string
+		service      string
+		method       string
+		path         string
+		wantDecision types.Decision
+		wantRule     string
+	}{
+		{"simple allow", "github", "GET", "/repos/a/b/issues", types.DecisionAllow, "read-issues"},
+		{"sub path allow", "github", "GET", "/repos/a/b/issues/42", types.DecisionAllow, "read-issues"},
+		{"wildcard subtree", "github", "GET", "/orgs/acme/members/list", types.DecisionAllow, "wildcard-subtree"},
+		{"method wildcard", "github", "POST", "/public/thing", types.DecisionAllow, "any-method"},
+		{"multi method PUT", "github", "PUT", "/repos/a/b", types.DecisionAllow, "multi-method"},
+		{"multi method PATCH", "github", "PATCH", "/repos/a/b", types.DecisionAllow, "multi-method"},
+		{"delete denied by rule", "github", "DELETE", "/repos/a/b", types.DecisionDeny, "block-delete"},
+		{"wrong method falls through", "github", "POST", "/repos/a/b/issues", types.DecisionDeny, "default"},
+		{"default deny", "github", "GET", "/unmatched", types.DecisionDeny, "default"},
+		{"lowercase method canonicalized", "github", "get", "/repos/a/b/issues", types.DecisionAllow, "read-issues"},
+		{"unknown service deny", "nosuch", "GET", "/anything", types.DecisionDeny, ""},
+		{"empty path coerced", "open", "GET", "", types.DecisionAllow, "default"},
+		{"traversal rejected", "github", "GET", "/repos/../etc/passwd", types.DecisionDeny, ""},
+		{"double slash rejected", "github", "GET", "/repos//a/b/issues", types.DecisionDeny, ""},
+		{"dot segment rejected", "github", "GET", "/repos/./a/b/issues", types.DecisionDeny, ""},
+		{"case sensitive path no match", "github", "GET", "/REPOS/a/b/issues", types.DecisionDeny, "default"},
+		{"query string ignored", "github", "GET", "/repos/a/b/issues?state=open", types.DecisionAllow, "read-issues"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Strip query string before calling — that's the gateway's job.
+			reqPath := tc.path
+			if idx := strings.Index(reqPath, "?"); idx != -1 {
+				reqPath = reqPath[:idx]
+			}
+			dec := e.CheckHTTPService(tc.service, tc.method, reqPath)
+			if dec.EffectiveDecision != tc.wantDecision {
+				t.Errorf("decision = %q, want %q (rule=%q msg=%q)",
+					dec.EffectiveDecision, tc.wantDecision, dec.Rule, dec.Message)
+			}
+			if tc.wantRule != "" && dec.Rule != tc.wantRule {
+				t.Errorf("rule = %q, want %q", dec.Rule, tc.wantRule)
+			}
+		})
+	}
+}

--- a/internal/policy/http_service_compile.go
+++ b/internal/policy/http_service_compile.go
@@ -1,0 +1,99 @@
+package policy
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/gobwas/glob"
+)
+
+// compiledHTTPServiceRule is an HTTPServiceRule with pre-compiled path
+// globs and a method set for O(1) matching.
+type compiledHTTPServiceRule struct {
+	rule    HTTPServiceRule
+	methods map[string]struct{} // uppercase; empty or containing "*" means any
+	paths   []glob.Glob
+}
+
+// compiledHTTPService holds the compiled form of an HTTPService entry.
+type compiledHTTPService struct {
+	cfg             HTTPService
+	rules           []compiledHTTPServiceRule
+	upstream        *url.URL
+	envVar          string // resolved ExposeAs or derived
+	defaultDecision string // "allow" or "deny" (empty treated as "deny")
+	upstreamHost    string // canonicalizeHost output for upstream (used for host-based lookup)
+}
+
+// compileHTTPServices transforms validated HTTPService entries into the
+// compiled form used by CheckHTTPService and the netmonitor host check.
+// Callers MUST call ValidateHTTPServices first; this function assumes
+// invariants established there (valid URL, non-empty name, canonicalizable
+// aliases, compilable globs).
+func compileHTTPServices(svcs []HTTPService) (byName, byHost map[string]*compiledHTTPService, err error) {
+	byName = make(map[string]*compiledHTTPService, len(svcs))
+	byHost = make(map[string]*compiledHTTPService, len(svcs))
+	for i := range svcs {
+		s := svcs[i]
+		u, parseErr := url.Parse(s.Upstream)
+		if parseErr != nil {
+			return nil, nil, fmt.Errorf("http_services[%q]: parse upstream: %w", s.Name, parseErr)
+		}
+
+		envVar := s.ExposeAs
+		if envVar == "" {
+			envVar = strings.ToUpper(s.Name) + "_API_URL"
+		}
+		defDec := s.Default
+		if defDec == "" {
+			defDec = "deny"
+		}
+
+		// Canonicalize the upstream host the SAME WAY ValidateHTTPServices
+		// did (via canonicalizeHost), so runtime lookups by canonicalized
+		// host string will hit the right service. This uses u.Host (not
+		// u.Hostname()) so the canonicalizer sees IPv6 brackets.
+		host, ok := canonicalizeHost(u.Host)
+		if !ok {
+			return nil, nil, fmt.Errorf("http_services[%q]: canonicalize upstream host %q", s.Name, u.Host)
+		}
+
+		cs := &compiledHTTPService{
+			cfg:             s,
+			upstream:        u,
+			envVar:          envVar,
+			defaultDecision: defDec,
+			upstreamHost:    host,
+		}
+		for _, r := range s.Rules {
+			cr := compiledHTTPServiceRule{rule: r}
+			if len(r.Methods) > 0 {
+				cr.methods = make(map[string]struct{}, len(r.Methods))
+				for _, m := range r.Methods {
+					cr.methods[strings.ToUpper(strings.TrimSpace(m))] = struct{}{}
+				}
+			}
+			for _, pat := range r.Paths {
+				g, gerr := glob.Compile(pat, '/')
+				if gerr != nil {
+					return nil, nil, fmt.Errorf("http_services[%q] rule %q: compile path %q: %w", s.Name, r.Name, pat, gerr)
+				}
+				cr.paths = append(cr.paths, g)
+			}
+			cs.rules = append(cs.rules, cr)
+		}
+
+		byName[strings.ToLower(s.Name)] = cs
+		byHost[host] = cs
+		for _, alias := range s.Aliases {
+			a, ok := canonicalizeHost(alias)
+			if !ok {
+				// Validation should have rejected this. Treat as invariant break.
+				return nil, nil, fmt.Errorf("http_services[%q]: canonicalize alias %q", s.Name, alias)
+			}
+			byHost[a] = cs
+		}
+	}
+	return byName, byHost, nil
+}

--- a/internal/policy/http_service_compile.go
+++ b/internal/policy/http_service_compile.go
@@ -28,9 +28,10 @@ type compiledHTTPService struct {
 
 // compileHTTPServices transforms validated HTTPService entries into the
 // compiled form used by CheckHTTPService and the netmonitor host check.
-// Callers MUST call ValidateHTTPServices first; this function assumes
-// invariants established there (valid URL, non-empty name, canonicalizable
-// aliases, compilable globs).
+// In the normal policy-load path, ValidateHTTPServices runs first and
+// errors are caught there; this compiler is also hardened against
+// duplicate names/hosts and bad aliases so it remains safe if a caller
+// bypasses validation (e.g. constructing a Policy in-memory for tests).
 func compileHTTPServices(svcs []HTTPService) (byName, byHost map[string]*compiledHTTPService, err error) {
 	byName = make(map[string]*compiledHTTPService, len(svcs))
 	byHost = make(map[string]*compiledHTTPService, len(svcs))
@@ -84,13 +85,23 @@ func compileHTTPServices(svcs []HTTPService) (byName, byHost map[string]*compile
 			cs.rules = append(cs.rules, cr)
 		}
 
-		byName[strings.ToLower(s.Name)] = cs
+		nameKey := strings.ToLower(s.Name)
+		if _, exists := byName[nameKey]; exists {
+			return nil, nil, fmt.Errorf("http_services: duplicate service name %q", s.Name)
+		}
+		byName[nameKey] = cs
+		if other, exists := byHost[host]; exists {
+			return nil, nil, fmt.Errorf("http_services[%q]: duplicate upstream host %q (also claimed by %q)", s.Name, host, other.cfg.Name)
+		}
 		byHost[host] = cs
 		for _, alias := range s.Aliases {
 			a, ok := canonicalizeHost(alias)
 			if !ok {
 				// Validation should have rejected this. Treat as invariant break.
 				return nil, nil, fmt.Errorf("http_services[%q]: canonicalize alias %q", s.Name, alias)
+			}
+			if other, exists := byHost[a]; exists {
+				return nil, nil, fmt.Errorf("http_services[%q]: duplicate upstream host %q via alias %q (also claimed by %q)", s.Name, a, alias, other.cfg.Name)
 			}
 			byHost[a] = cs
 		}

--- a/internal/policy/http_service_fuzz_test.go
+++ b/internal/policy/http_service_fuzz_test.go
@@ -1,0 +1,80 @@
+package policy
+
+import (
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// FuzzCheckHTTPServicePath feeds random method/path combinations into the
+// evaluator and asserts three invariants:
+//
+//  1. It never panics.
+//  2. An allow decision implies the path survived path.Clean unchanged
+//     after the evaluator's own trailing-slash normalization (traversal
+//     attempts cannot reach upstream).
+//  3. Method matching is stable under arbitrary casing.
+func FuzzCheckHTTPServicePath(f *testing.F) {
+	svcs := []HTTPService{{
+		Name: "github", Upstream: "https://api.github.com",
+		Default: "deny",
+		Rules: []HTTPServiceRule{
+			{Name: "read", Methods: []string{"GET"}, Paths: []string{"/repos/*/*"}, Decision: "allow"},
+			{Name: "open", Methods: []string{"*"}, Paths: []string{"/public/**"}, Decision: "allow"},
+		},
+	}}
+	if err := ValidateHTTPServices(svcs); err != nil {
+		f.Fatal(err)
+	}
+	byName, byHost, err := compileHTTPServices(svcs)
+	if err != nil {
+		f.Fatal(err)
+	}
+	e := &Engine{
+		policy:           &Policy{HTTPServices: svcs},
+		httpServices:     byName,
+		httpServiceHosts: byHost,
+		enforceApprovals: true,
+	}
+
+	f.Add("GET", "/repos/a/b")
+	f.Add("get", "/REPOS/a/b")
+	f.Add("GET", "/repos/../etc/passwd")
+	f.Add("GET", "/repos//a/b")
+	f.Add("POST", "/public/\x00bar")
+	f.Add("PUT", "/repos/a/b?%2e%2e")
+
+	f.Fuzz(func(t *testing.T, method, reqPath string) {
+		// Skip inputs with null bytes in the method — invalid HTTP.
+		if strings.ContainsRune(method, 0) {
+			return
+		}
+		dec := e.CheckHTTPService("github", method, reqPath)
+		if dec.EffectiveDecision == types.DecisionAllow {
+			// Invariant 2: allow implies the path was canonical AFTER
+			// applying the same trailing-slash normalization the evaluator
+			// itself performs. Without this mirror, a legitimately-allowed
+			// path like "/repos/a/b/" would be reported as non-canonical.
+			normalized := reqPath
+			if normalized == "" {
+				normalized = "/"
+			}
+			if len(normalized) > 1 && strings.HasSuffix(normalized, "/") {
+				normalized = strings.TrimSuffix(normalized, "/")
+			}
+			if got := path.Clean(normalized); got != normalized {
+				t.Errorf("allow decision with non-canonical path: reqPath=%q normalized=%q clean=%q", reqPath, normalized, got)
+			}
+		}
+		// Invariant 3: casing-insensitive method.
+		lower := strings.ToLower(method)
+		upper := strings.ToUpper(method)
+		decL := e.CheckHTTPService("github", lower, reqPath)
+		decU := e.CheckHTTPService("github", upper, reqPath)
+		if decL.EffectiveDecision != decU.EffectiveDecision {
+			t.Errorf("case mismatch: lower=%q upper=%q dec differs", lower, upper)
+		}
+	})
+}

--- a/internal/policy/http_service_fuzz_test.go
+++ b/internal/policy/http_service_fuzz_test.go
@@ -78,3 +78,62 @@ func FuzzCheckHTTPServicePath(f *testing.F) {
 		}
 	})
 }
+
+// FuzzCheckHTTPServiceDefaultAllow exercises a service whose Default is
+// "allow" and no rules, verifying the traversal guard still rejects path
+// traversal attempts. If a future refactor reorders the guard behind the
+// default decision, default-allow services would start forwarding "..",
+// "." and "//" paths upstream — this target will catch that regression.
+func FuzzCheckHTTPServiceDefaultAllow(f *testing.F) {
+	svcs := []HTTPService{{
+		Name: "open", Upstream: "https://open.example.com",
+		Default: "allow",
+	}}
+	if err := ValidateHTTPServices(svcs); err != nil {
+		f.Fatal(err)
+	}
+	byName, byHost, err := compileHTTPServices(svcs)
+	if err != nil {
+		f.Fatal(err)
+	}
+	e := &Engine{
+		policy:           &Policy{HTTPServices: svcs},
+		httpServices:     byName,
+		httpServiceHosts: byHost,
+		enforceApprovals: true,
+	}
+
+	f.Add("GET", "/")
+	f.Add("GET", "/foo/bar")
+	f.Add("GET", "/foo/../bar")
+	f.Add("POST", "/foo//bar")
+	f.Add("DELETE", "/./foo")
+	f.Add("PUT", "/foo/.")
+	f.Add("HEAD", "/foo/..")
+
+	f.Fuzz(func(t *testing.T, method, reqPath string) {
+		if strings.ContainsRune(method, 0) {
+			return
+		}
+		dec := e.CheckHTTPService("open", method, reqPath)
+		if dec.EffectiveDecision != types.DecisionAllow {
+			return
+		}
+		// Mirror the evaluator's own rejection logic. An allow decision
+		// is only correct if reqPath (after the evaluator's "" -> "/"
+		// remap) has neither "//" nor any "." / ".." segment.
+		p := reqPath
+		if p == "" {
+			p = "/"
+		}
+		if strings.Contains(p, "//") {
+			t.Errorf("default-allow leaked path %q containing //", reqPath)
+		}
+		for _, seg := range strings.Split(strings.TrimPrefix(p, "/"), "/") {
+			if seg == "." || seg == ".." {
+				t.Errorf("default-allow leaked path %q with segment %q", reqPath, seg)
+				break
+			}
+		}
+	})
+}

--- a/internal/policy/http_service_test.go
+++ b/internal/policy/http_service_test.go
@@ -57,19 +57,327 @@ http_services:
 	}
 }
 
-func TestHTTPServicesRejectedDuringLoad(t *testing.T) {
+// TestHTTPServicesValidatedDuringLoad verifies that the policy loader rejects
+// a policy file whose http_services entries fail validation (e.g. missing name).
+func TestHTTPServicesValidatedDuringLoad(t *testing.T) {
 	src := []byte(`
 version: 1
 name: test-policy
 http_services:
-  - name: github
+  - name: ""
     upstream: https://api.github.com
 `)
 	_, err := LoadFromBytes(src)
 	if err == nil {
-		t.Fatal("expected http_services to be rejected, got nil")
+		t.Fatal("expected http_services validation error, got nil")
 	}
-	if !strings.Contains(err.Error(), "http_services") {
-		t.Errorf("error = %v, want mention of http_services", err)
+	if !strings.Contains(err.Error(), "name is required") {
+		t.Errorf("error = %v, want mention of \"name is required\"", err)
+	}
+}
+
+func TestValidateHTTPServices(t *testing.T) {
+	validRule := HTTPServiceRule{
+		Name:     "read-repos",
+		Methods:  []string{"GET"},
+		Paths:    []string{"/repos/**"},
+		Decision: "allow",
+	}
+
+	tests := []struct {
+		name    string
+		svcs    []HTTPService
+		wantErr string // substring match; empty means no error
+	}{
+		{
+			name: "valid single service",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Default:  "deny",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "empty name rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "",
+					Upstream: "https://api.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "name is required",
+		},
+		{
+			name: "whitespace-only name rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "   ",
+					Upstream: "https://api.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "name is required",
+		},
+		{
+			name: "duplicate name rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "github",
+					Upstream: "https://api2.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate http_service name",
+		},
+		{
+			name: "duplicate name rejected case-insensitive",
+			svcs: []HTTPService{
+				{
+					Name:     "GitHub",
+					Upstream: "https://api.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "github",
+					Upstream: "https://api2.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate http_service name",
+		},
+		{
+			name: "non-https upstream rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "http://api.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "upstream must be https",
+		},
+		{
+			name: "unparseable upstream rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "://bad-url",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "invalid upstream URL",
+		},
+		{
+			name: "upstream with no host rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "invalid upstream URL",
+		},
+		{
+			name: "duplicate upstream host rejected across services",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "github2",
+					Upstream: "https://api.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate upstream host",
+		},
+		{
+			name: "alias collides with another service upstream host",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "github2",
+					Upstream: "https://api2.github.com",
+					Aliases:  []string{"api.github.com"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate upstream host",
+		},
+		{
+			name: "invalid default value",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Default:  "redirect",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "invalid default",
+		},
+		{
+			name: "invalid rule decision",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules: []HTTPServiceRule{
+						{
+							Name:     "bad-rule",
+							Paths:    []string{"/repos/**"},
+							Decision: "redirect",
+						},
+					},
+				},
+			},
+			wantErr: "invalid rule decision",
+		},
+		{
+			name: "invalid path glob",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules: []HTTPServiceRule{
+						{
+							Name:     "bad-glob",
+							Paths:    []string{"[unterminated"},
+							Decision: "allow",
+						},
+					},
+				},
+			},
+			wantErr: "invalid path glob",
+		},
+		{
+			name: "empty paths list",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules: []HTTPServiceRule{
+						{
+							Name:     "no-paths",
+							Paths:    []string{},
+							Decision: "allow",
+						},
+					},
+				},
+			},
+			wantErr: "rule must have at least one path",
+		},
+		{
+			name: "invalid expose_as",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					ExposeAs: "1_INVALID",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "invalid expose_as",
+		},
+		{
+			name: "derived env var name invalid due to hyphen in service name",
+			svcs: []HTTPService{
+				{
+					Name:     "my-svc",
+					Upstream: "https://api.example.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "derived env var name",
+		},
+		{
+			name: "valid service with explicit expose_as overrides bad derived name",
+			svcs: []HTTPService{
+				{
+					Name:     "my-svc",
+					Upstream: "https://api.example.com",
+					ExposeAs: "MY_SVC_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "valid service with allow default and audit rule",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Default:  "allow",
+					Rules: []HTTPServiceRule{
+						{
+							Name:     "audit-writes",
+							Methods:  []string{"POST", "PUT", "DELETE"},
+							Paths:    []string{"/repos/**"},
+							Decision: "audit",
+						},
+					},
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "valid service with approve rule",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules: []HTTPServiceRule{
+						{
+							Name:     "approve-deletes",
+							Methods:  []string{"DELETE"},
+							Paths:    []string{"/repos/**"},
+							Decision: "approve",
+						},
+					},
+				},
+			},
+			wantErr: "",
+		},
+		{
+			name: "empty http_services list is valid",
+			svcs: []HTTPService{},
+			wantErr: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateHTTPServices(tc.svcs)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %q, want substring %q", err.Error(), tc.wantErr)
+			}
+		})
 	}
 }

--- a/internal/policy/http_service_test.go
+++ b/internal/policy/http_service_test.go
@@ -298,7 +298,7 @@ func TestValidateHTTPServices(t *testing.T) {
 					Rules:    []HTTPServiceRule{validRule},
 				},
 			},
-			wantErr: "empty alias",
+			wantErr: "invalid alias",
 		},
 		{
 			name: "invalid default value",
@@ -506,25 +506,6 @@ func TestValidateHTTPServices(t *testing.T) {
 			wantErr: "duplicate upstream host",
 		},
 		{
-			name: "IPv6 upstream collides with bare alias on another service",
-			svcs: []HTTPService{
-				{
-					Name:     "svc1",
-					Upstream: "https://[::1]",
-					ExposeAs: "SVC1_API_URL",
-					Rules:    []HTTPServiceRule{validRule},
-				},
-				{
-					Name:     "svc2",
-					Upstream: "https://api2.example.com",
-					ExposeAs: "SVC2_API_URL",
-					Aliases:  []string{"::1"},
-					Rules:    []HTTPServiceRule{validRule},
-				},
-			},
-			wantErr: "duplicate upstream host",
-		},
-		{
 			name: "IPv6 upstream with port collides with bracketed alias with port on another service",
 			svcs: []HTTPService{
 				{
@@ -544,7 +525,7 @@ func TestValidateHTTPServices(t *testing.T) {
 			wantErr: "duplicate upstream host",
 		},
 		{
-			name: "IPv6 upstream collides with mixed-case bare alias on another service",
+			name: "IPv6 upstream collides with mixed-case bracketed alias on another service",
 			svcs: []HTTPService{
 				{
 					Name:     "svc1",
@@ -556,11 +537,62 @@ func TestValidateHTTPServices(t *testing.T) {
 					Name:     "svc2",
 					Upstream: "https://api2.example.com",
 					ExposeAs: "SVC2_API_URL",
-					Aliases:  []string{"FE80::1"},
+					Aliases:  []string{"[FE80::1]"},
 					Rules:    []HTTPServiceRule{validRule},
 				},
 			},
 			wantErr: "duplicate upstream host",
+		},
+		{
+			name: "bare IPv6 alias rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "svc1",
+					Upstream: "https://[::1]",
+					ExposeAs: "SVC1_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "svc2",
+					Upstream: "https://api2.example.com",
+					ExposeAs: "SVC2_API_URL",
+					Aliases:  []string{"::1"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "IPv6 literals must be bracketed",
+		},
+		{
+			name: "bare IPv6 alias with different address rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "svc1",
+					Upstream: "https://[::1]",
+					ExposeAs: "SVC1_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "svc2",
+					Upstream: "https://api2.example.com",
+					ExposeAs: "SVC2_API_URL",
+					Aliases:  []string{"fe80::1"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "IPv6 literals must be bracketed",
+		},
+		{
+			name: "bracketed IPv6 alias accepted when no upstream conflict",
+			svcs: []HTTPService{
+				{
+					Name:     "svc1",
+					Upstream: "https://api.github.com",
+					ExposeAs: "SVC1_API_URL",
+					Aliases:  []string{"[::1]"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "",
 		},
 		{
 			name: "distinct IPv6 upstreams both accepted",
@@ -579,6 +611,30 @@ func TestValidateHTTPServices(t *testing.T) {
 				},
 			},
 			wantErr: "",
+		},
+		{
+			name: "unterminated bracket alias rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Aliases:  []string{"[::1"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "IPv6 literals must be bracketed",
+		},
+		{
+			name: "empty brackets alias rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Aliases:  []string{"[]"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "IPv6 literals must be bracketed",
 		},
 		{
 			name: "empty http_services list is valid",

--- a/internal/policy/http_service_test.go
+++ b/internal/policy/http_service_test.go
@@ -797,6 +797,94 @@ func TestValidateHTTPServices(t *testing.T) {
 			wantErr: "",
 		},
 		{
+			name: "duplicate ExposeAs rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "svc1",
+					Upstream: "https://api1.example.com",
+					ExposeAs: "MY_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "svc2",
+					Upstream: "https://api2.example.com",
+					ExposeAs: "MY_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate env var name",
+		},
+		{
+			name: "duplicate derived name rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "other",
+					Upstream: "https://api.other.example.com",
+					ExposeAs: "GITHUB_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate env var name",
+		},
+		{
+			name: "reserved ANTHROPIC_BASE_URL rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "svc",
+					Upstream: "https://api.example.com",
+					ExposeAs: "ANTHROPIC_BASE_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "reserved env var name",
+		},
+		{
+			name: "reserved OPENAI_BASE_URL rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "svc",
+					Upstream: "https://api.example.com",
+					ExposeAs: "OPENAI_BASE_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "reserved env var name",
+		},
+		{
+			name: "reserved AGENTSH_SESSION_ID rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "svc",
+					Upstream: "https://api.example.com",
+					ExposeAs: "AGENTSH_SESSION_ID",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "reserved env var name",
+		},
+		{
+			name: "non-colliding multiple services accepted",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "other",
+					Upstream: "https://api.other.example.com",
+					ExposeAs: "OTHER_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "",
+		},
+		{
 			name: "empty http_services list is valid",
 			svcs: []HTTPService{},
 			wantErr: "",

--- a/internal/policy/http_service_test.go
+++ b/internal/policy/http_service_test.go
@@ -222,6 +222,85 @@ func TestValidateHTTPServices(t *testing.T) {
 			wantErr: "duplicate upstream host",
 		},
 		{
+			name: "alias with trailing dot collides with upstream",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "github2",
+					Upstream: "https://api2.github.com",
+					Aliases:  []string{"api.github.com."},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate upstream host",
+		},
+		{
+			name: "alias with port collides with upstream",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "github2",
+					Upstream: "https://api2.github.com",
+					Aliases:  []string{"api.github.com:443"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate upstream host",
+		},
+		{
+			name: "alias with mixed case collides with upstream",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "github2",
+					Upstream: "https://api2.github.com",
+					Aliases:  []string{"API.GitHub.COM"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate upstream host",
+		},
+		{
+			name: "upstream with trailing dot collides with plain upstream",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "github2",
+					Upstream: "https://api.github.com./",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate upstream host",
+		},
+		{
+			name: "alias that becomes empty after port strip rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Aliases:  []string{":443"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "empty alias",
+		},
+		{
 			name: "invalid default value",
 			svcs: []HTTPService{
 				{
@@ -283,6 +362,57 @@ func TestValidateHTTPServices(t *testing.T) {
 				},
 			},
 			wantErr: "rule must have at least one path",
+		},
+		{
+			name: "blank path entry rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules: []HTTPServiceRule{
+						{
+							Name:     "blank-path",
+							Paths:    []string{""},
+							Decision: "allow",
+						},
+					},
+				},
+			},
+			wantErr: "empty path",
+		},
+		{
+			name: "whitespace-only path entry rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules: []HTTPServiceRule{
+						{
+							Name:     "whitespace-path",
+							Paths:    []string{"   "},
+							Decision: "allow",
+						},
+					},
+				},
+			},
+			wantErr: "empty path",
+		},
+		{
+			name: "mixed valid and blank path entries rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Rules: []HTTPServiceRule{
+						{
+							Name:     "mixed-paths",
+							Paths:    []string{"/api/*", ""},
+							Decision: "allow",
+						},
+					},
+				},
+			},
+			wantErr: "empty path",
 		},
 		{
 			name: "invalid expose_as",

--- a/internal/policy/http_service_test.go
+++ b/internal/policy/http_service_test.go
@@ -900,3 +900,79 @@ func keysOf(m map[string]*compiledHTTPService) []string {
 	}
 	return out
 }
+
+func TestCompileHTTPServices_RejectsDuplicateName(t *testing.T) {
+	svcs := []HTTPService{
+		{
+			Name: "svc", Upstream: "https://api.example.com",
+			Rules: []HTTPServiceRule{{Name: "r", Paths: []string{"/**"}, Decision: "allow"}},
+		},
+		{
+			Name: "svc", Upstream: "https://api.other.example.com",
+			Rules: []HTTPServiceRule{{Name: "r", Paths: []string{"/**"}, Decision: "allow"}},
+		},
+	}
+	if _, _, err := compileHTTPServices(svcs); err == nil || !strings.Contains(err.Error(), "duplicate service name") {
+		t.Fatalf("want duplicate service name error, got %v", err)
+	}
+}
+
+func TestCompileHTTPServices_RejectsDuplicateUpstreamHost(t *testing.T) {
+	svcs := []HTTPService{
+		{
+			Name: "a", Upstream: "https://api.example.com",
+			Rules: []HTTPServiceRule{{Name: "r", Paths: []string{"/**"}, Decision: "allow"}},
+		},
+		{
+			Name: "b", Upstream: "https://api.example.com",
+			Rules: []HTTPServiceRule{{Name: "r", Paths: []string{"/**"}, Decision: "allow"}},
+		},
+	}
+	if _, _, err := compileHTTPServices(svcs); err == nil || !strings.Contains(err.Error(), "duplicate upstream host") {
+		t.Fatalf("want duplicate upstream host error, got %v", err)
+	}
+}
+
+func TestCompileHTTPServices_RejectsDuplicateAliasHost(t *testing.T) {
+	svcs := []HTTPService{
+		{
+			Name: "a", Upstream: "https://api.a.example.com",
+			Aliases: []string{"shared.example.com"},
+			Rules:   []HTTPServiceRule{{Name: "r", Paths: []string{"/**"}, Decision: "allow"}},
+		},
+		{
+			Name: "b", Upstream: "https://api.b.example.com",
+			Aliases: []string{"shared.example.com"},
+			Rules:   []HTTPServiceRule{{Name: "r", Paths: []string{"/**"}, Decision: "allow"}},
+		},
+	}
+	if _, _, err := compileHTTPServices(svcs); err == nil || !strings.Contains(err.Error(), "via alias") {
+		t.Fatalf("want alias collision error, got %v", err)
+	}
+}
+
+func TestNewEngine_PopulatesHTTPServiceMaps(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		HTTPServices: []HTTPService{{
+			Name: "github", Upstream: "https://api.github.com",
+			Rules: []HTTPServiceRule{{
+				Name: "read", Paths: []string{"/repos/**"}, Decision: "allow",
+			}},
+		}},
+	}
+	if err := p.Validate(); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	e, err := NewEngine(p, false, false)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	if _, ok := e.httpServices["github"]; !ok {
+		t.Error("e.httpServices missing github")
+	}
+	if _, ok := e.httpServiceHosts["api.github.com"]; !ok {
+		t.Error("e.httpServiceHosts missing api.github.com")
+	}
+}

--- a/internal/policy/http_service_test.go
+++ b/internal/policy/http_service_test.go
@@ -637,6 +637,18 @@ func TestValidateHTTPServices(t *testing.T) {
 			wantErr: "IPv6 literals must be bracketed",
 		},
 		{
+			name: "bracketed dot alias canonicalizes to empty and is rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Aliases:  []string{"[.]"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "invalid alias",
+		},
+		{
 			name: "empty http_services list is valid",
 			svcs: []HTTPService{},
 			wantErr: "",

--- a/internal/policy/http_service_test.go
+++ b/internal/policy/http_service_test.go
@@ -821,3 +821,82 @@ func TestValidateHTTPServices(t *testing.T) {
 		})
 	}
 }
+
+func TestCompileHTTPServices_Smoke(t *testing.T) {
+	svcs := []HTTPService{{
+		Name: "github", Upstream: "https://api.github.com",
+		Default: "deny",
+		Rules: []HTTPServiceRule{{
+			Name: "read", Methods: []string{"GET"},
+			Paths: []string{"/repos/*/*/issues"}, Decision: "allow",
+		}},
+	}}
+	if err := ValidateHTTPServices(svcs); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	byName, byHost, err := compileHTTPServices(svcs)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	cs, ok := byName["github"]
+	if !ok {
+		t.Fatal("github not in byName map")
+	}
+	if cs.envVar != "GITHUB_API_URL" {
+		t.Errorf("envVar = %q, want GITHUB_API_URL", cs.envVar)
+	}
+	if cs.upstreamHost != "api.github.com" {
+		t.Errorf("upstreamHost = %q", cs.upstreamHost)
+	}
+	if cs.defaultDecision != "deny" {
+		t.Errorf("defaultDecision = %q", cs.defaultDecision)
+	}
+	if len(cs.rules) != 1 {
+		t.Fatalf("rules = %d, want 1", len(cs.rules))
+	}
+	if _, ok := cs.rules[0].methods["GET"]; !ok {
+		t.Errorf("method GET not compiled")
+	}
+	if len(cs.rules[0].paths) != 1 {
+		t.Errorf("paths not compiled")
+	}
+	if _, ok := byHost["api.github.com"]; !ok {
+		t.Error("api.github.com not in byHost map")
+	}
+}
+
+func TestCompileHTTPServices_AliasesIndexedByCanonicalHost(t *testing.T) {
+	svcs := []HTTPService{{
+		Name: "github", Upstream: "https://api.github.com",
+		Aliases: []string{"UPLOADS.GitHub.COM", "raw.githubusercontent.com", "[::1]:443"},
+		Default: "deny",
+		Rules: []HTTPServiceRule{{
+			Name: "any", Paths: []string{"/**"}, Decision: "allow",
+		}},
+	}}
+	if err := ValidateHTTPServices(svcs); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	_, byHost, err := compileHTTPServices(svcs)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	for _, want := range []string{
+		"api.github.com",            // upstream host
+		"uploads.github.com",        // mixed-case alias canonicalizes to lowercase
+		"raw.githubusercontent.com", // plain alias
+		"::1",                       // bracketed IPv6 alias canonicalizes without brackets
+	} {
+		if _, ok := byHost[want]; !ok {
+			t.Errorf("byHost missing %q (keys: %v)", want, keysOf(byHost))
+		}
+	}
+}
+
+func keysOf(m map[string]*compiledHTTPService) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/policy/http_service_test.go
+++ b/internal/policy/http_service_test.go
@@ -685,7 +685,7 @@ func TestValidateHTTPServices(t *testing.T) {
 			wantErr: "invalid alias",
 		},
 		{
-			name: "bracketed IPv4-in-IPv6 alias rejected",
+			name: "bracketed IPv4-in-IPv6 alias accepted",
 			svcs: []HTTPService{
 				{
 					Name:     "github",
@@ -694,7 +694,27 @@ func TestValidateHTTPServices(t *testing.T) {
 					Rules:    []HTTPServiceRule{validRule},
 				},
 			},
-			wantErr: "invalid alias",
+			wantErr: "",
+		},
+		{
+			name: "duplicate bracketed IPv4-in-IPv6 alias across services rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "svc1",
+					Upstream: "https://api1.example.com",
+					ExposeAs: "SVC1_API_URL",
+					Aliases:  []string{"[::ffff:192.168.1.1]"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "svc2",
+					Upstream: "https://api2.example.com",
+					ExposeAs: "SVC2_API_URL",
+					Aliases:  []string{"[::ffff:192.168.1.1]"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate upstream host",
 		},
 		{
 			name: "bracketed invalid hex IPv6 alias rejected",
@@ -721,7 +741,7 @@ func TestValidateHTTPServices(t *testing.T) {
 			wantErr: "invalid alias",
 		},
 		{
-			name: "bracketed IPv6 leading-zero alias canonicalizes to ::1",
+			name: "bracketed IPv6 leading-zero alias treated as distinct textual form",
 			svcs: []HTTPService{
 				{
 					Name:     "svc1",
@@ -737,10 +757,10 @@ func TestValidateHTTPServices(t *testing.T) {
 					Rules:    []HTTPServiceRule{validRule},
 				},
 			},
-			wantErr: "duplicate upstream host",
+			wantErr: "",
 		},
 		{
-			name: "bracketed IPv6 expanded form alias canonicalizes to ::1",
+			name: "bracketed IPv6 expanded form alias treated as distinct textual form",
 			svcs: []HTTPService{
 				{
 					Name:     "svc1",
@@ -756,7 +776,7 @@ func TestValidateHTTPServices(t *testing.T) {
 					Rules:    []HTTPServiceRule{validRule},
 				},
 			},
-			wantErr: "duplicate upstream host",
+			wantErr: "",
 		},
 		{
 			name: "bracketed IPv6 with various spellings all accepted when distinct",

--- a/internal/policy/http_service_test.go
+++ b/internal/policy/http_service_test.go
@@ -487,6 +487,100 @@ func TestValidateHTTPServices(t *testing.T) {
 			wantErr: "",
 		},
 		{
+			name: "IPv6 upstream collides with bracketed alias on another service",
+			svcs: []HTTPService{
+				{
+					Name:     "svc1",
+					Upstream: "https://[::1]",
+					ExposeAs: "SVC1_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "svc2",
+					Upstream: "https://api2.example.com",
+					ExposeAs: "SVC2_API_URL",
+					Aliases:  []string{"[::1]"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate upstream host",
+		},
+		{
+			name: "IPv6 upstream collides with bare alias on another service",
+			svcs: []HTTPService{
+				{
+					Name:     "svc1",
+					Upstream: "https://[::1]",
+					ExposeAs: "SVC1_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "svc2",
+					Upstream: "https://api2.example.com",
+					ExposeAs: "SVC2_API_URL",
+					Aliases:  []string{"::1"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate upstream host",
+		},
+		{
+			name: "IPv6 upstream with port collides with bracketed alias with port on another service",
+			svcs: []HTTPService{
+				{
+					Name:     "svc1",
+					Upstream: "https://[::1]:8443",
+					ExposeAs: "SVC1_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "svc2",
+					Upstream: "https://api2.example.com",
+					ExposeAs: "SVC2_API_URL",
+					Aliases:  []string{"[::1]:443"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate upstream host",
+		},
+		{
+			name: "IPv6 upstream collides with mixed-case bare alias on another service",
+			svcs: []HTTPService{
+				{
+					Name:     "svc1",
+					Upstream: "https://[fe80::1]",
+					ExposeAs: "SVC1_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "svc2",
+					Upstream: "https://api2.example.com",
+					ExposeAs: "SVC2_API_URL",
+					Aliases:  []string{"FE80::1"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate upstream host",
+		},
+		{
+			name: "distinct IPv6 upstreams both accepted",
+			svcs: []HTTPService{
+				{
+					Name:     "svc1",
+					Upstream: "https://[::1]",
+					ExposeAs: "SVC1_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "svc2",
+					Upstream: "https://[::2]",
+					ExposeAs: "SVC2_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "",
+		},
+		{
 			name: "empty http_services list is valid",
 			svcs: []HTTPService{},
 			wantErr: "",

--- a/internal/policy/http_service_test.go
+++ b/internal/policy/http_service_test.go
@@ -649,6 +649,134 @@ func TestValidateHTTPServices(t *testing.T) {
 			wantErr: "invalid alias",
 		},
 		{
+			name: "bracketed double-dot alias rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Aliases:  []string{"[..]"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "invalid alias",
+		},
+		{
+			name: "bracketed hostname alias rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Aliases:  []string{"[example.com]"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "invalid alias",
+		},
+		{
+			name: "bracketed IPv4 alias rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Aliases:  []string{"[192.168.1.1]"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "invalid alias",
+		},
+		{
+			name: "bracketed IPv4-in-IPv6 alias rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Aliases:  []string{"[::ffff:192.168.1.1]"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "invalid alias",
+		},
+		{
+			name: "bracketed invalid hex IPv6 alias rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Aliases:  []string{"[gggg::1]"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "invalid alias",
+		},
+		{
+			name: "bracketed IPv6 with trailing space inside brackets rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "github",
+					Upstream: "https://api.github.com",
+					Aliases:  []string{"[::1 ]"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "invalid alias",
+		},
+		{
+			name: "bracketed IPv6 leading-zero alias canonicalizes to ::1",
+			svcs: []HTTPService{
+				{
+					Name:     "svc1",
+					Upstream: "https://[::1]",
+					ExposeAs: "SVC1_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "svc2",
+					Upstream: "https://api2.example.com",
+					ExposeAs: "SVC2_API_URL",
+					Aliases:  []string{"[::0001]"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate upstream host",
+		},
+		{
+			name: "bracketed IPv6 expanded form alias canonicalizes to ::1",
+			svcs: []HTTPService{
+				{
+					Name:     "svc1",
+					Upstream: "https://[::1]",
+					ExposeAs: "SVC1_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "svc2",
+					Upstream: "https://api2.example.com",
+					ExposeAs: "SVC2_API_URL",
+					Aliases:  []string{"[0:0:0:0:0:0:0:1]"},
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate upstream host",
+		},
+		{
+			name: "bracketed IPv6 with various spellings all accepted when distinct",
+			svcs: []HTTPService{
+				{
+					Name:     "svc1",
+					Upstream: "https://[fe80::1]",
+					ExposeAs: "SVC1_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "svc2",
+					Upstream: "https://[::2]",
+					ExposeAs: "SVC2_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "",
+		},
+		{
 			name: "empty http_services list is valid",
 			svcs: []HTTPService{},
 			wantErr: "",

--- a/internal/policy/http_service_test.go
+++ b/internal/policy/http_service_test.go
@@ -1,0 +1,57 @@
+package policy
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestHTTPServiceYAMLUnmarshal(t *testing.T) {
+	src := []byte(`
+http_services:
+  - name: github
+    upstream: https://api.github.com
+    expose_as: GITHUB_API_URL
+    default: deny
+    rules:
+      - name: read-issues
+        methods: [GET]
+        paths:
+          - /repos/*/*/issues
+        decision: allow
+`)
+
+	var p Policy
+	if err := yaml.Unmarshal(src, &p); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(p.HTTPServices) != 1 {
+		t.Fatalf("expected 1 http_service, got %d", len(p.HTTPServices))
+	}
+	svc := p.HTTPServices[0]
+	if svc.Name != "github" {
+		t.Errorf("Name = %q, want github", svc.Name)
+	}
+	if svc.Upstream != "https://api.github.com" {
+		t.Errorf("Upstream = %q, want https://api.github.com", svc.Upstream)
+	}
+	if svc.ExposeAs != "GITHUB_API_URL" {
+		t.Errorf("ExposeAs = %q, want GITHUB_API_URL", svc.ExposeAs)
+	}
+	if svc.Default != "deny" {
+		t.Errorf("Default = %q, want deny", svc.Default)
+	}
+	if len(svc.Rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(svc.Rules))
+	}
+	r := svc.Rules[0]
+	if r.Name != "read-issues" || r.Decision != "allow" {
+		t.Errorf("rule = %+v, want name=read-issues decision=allow", r)
+	}
+	if len(r.Methods) != 1 || r.Methods[0] != "GET" {
+		t.Errorf("Methods = %v, want [GET]", r.Methods)
+	}
+	if len(r.Paths) != 1 || r.Paths[0] != "/repos/*/*/issues" {
+		t.Errorf("Paths = %v, want [/repos/*/*/issues]", r.Paths)
+	}
+}

--- a/internal/policy/http_service_test.go
+++ b/internal/policy/http_service_test.go
@@ -124,6 +124,66 @@ func TestValidateHTTPServices(t *testing.T) {
 			wantErr: "name is required",
 		},
 		{
+			name: "name with slash rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "foo/bar",
+					Upstream: "https://api.example.com",
+					ExposeAs: "FOO_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "URL-safe segment",
+		},
+		{
+			name: "name with question mark rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "foo?bar",
+					Upstream: "https://api.example.com",
+					ExposeAs: "FOO_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "URL-safe segment",
+		},
+		{
+			name: "name with hash rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "foo#bar",
+					Upstream: "https://api.example.com",
+					ExposeAs: "FOO_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "URL-safe segment",
+		},
+		{
+			name: "name with space rejected",
+			svcs: []HTTPService{
+				{
+					Name:     "foo bar",
+					Upstream: "https://api.example.com",
+					ExposeAs: "FOO_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "URL-safe segment",
+		},
+		{
+			name: "name with valid chars accepted",
+			svcs: []HTTPService{
+				{
+					Name:     "foo.bar-baz_123",
+					Upstream: "https://api.example.com",
+					ExposeAs: "FOO_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "",
+		},
+		{
 			name: "duplicate name rejected",
 			svcs: []HTTPService{
 				{

--- a/internal/policy/http_service_test.go
+++ b/internal/policy/http_service_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -53,5 +54,22 @@ http_services:
 	}
 	if len(r.Paths) != 1 || r.Paths[0] != "/repos/*/*/issues" {
 		t.Errorf("Paths = %v, want [/repos/*/*/issues]", r.Paths)
+	}
+}
+
+func TestHTTPServicesRejectedDuringLoad(t *testing.T) {
+	src := []byte(`
+version: 1
+name: test-policy
+http_services:
+  - name: github
+    upstream: https://api.github.com
+`)
+	_, err := LoadFromBytes(src)
+	if err == nil {
+		t.Fatal("expected http_services to be rejected, got nil")
+	}
+	if !strings.Contains(err.Error(), "http_services") {
+		t.Errorf("error = %v, want mention of http_services", err)
 	}
 }

--- a/internal/policy/http_service_test.go
+++ b/internal/policy/http_service_test.go
@@ -868,6 +868,66 @@ func TestValidateHTTPServices(t *testing.T) {
 			wantErr: "reserved env var name",
 		},
 		{
+			name: "reserved ANTHROPIC_BASE_URL case-insensitive",
+			svcs: []HTTPService{
+				{
+					Name:     "svc",
+					Upstream: "https://api.example.com",
+					ExposeAs: "anthropic_base_url",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "reserved env var name",
+		},
+		{
+			name: "reserved OPENAI_BASE_URL mixed case",
+			svcs: []HTTPService{
+				{
+					Name:     "svc",
+					Upstream: "https://api.example.com",
+					ExposeAs: "Openai_Base_Url",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "reserved env var name",
+		},
+		{
+			name: "duplicate ExposeAs case-insensitive",
+			svcs: []HTTPService{
+				{
+					Name:     "svc1",
+					Upstream: "https://api1.example.com",
+					ExposeAs: "MY_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "svc2",
+					Upstream: "https://api2.example.com",
+					ExposeAs: "my_api_url",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate env var name",
+		},
+		{
+			name: "duplicate ExposeAs mixed case",
+			svcs: []HTTPService{
+				{
+					Name:     "svc1",
+					Upstream: "https://api1.example.com",
+					ExposeAs: "Foo_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+				{
+					Name:     "svc2",
+					Upstream: "https://api2.example.com",
+					ExposeAs: "FOO_API_URL",
+					Rules:    []HTTPServiceRule{validRule},
+				},
+			},
+			wantErr: "duplicate env var name",
+		},
+		{
 			name: "non-colliding multiple services accepted",
 			svcs: []HTTPService{
 				{

--- a/internal/policy/model.go
+++ b/internal/policy/model.go
@@ -524,5 +524,13 @@ func (p Policy) Validate() error {
 		}
 	}
 
+	// http_services: temporary gate. The real validator lands in Task 2 of
+	// the http_services plan (docs/superpowers/specs/2026-04-10-http-path-
+	// verb-filtering-design.md). Until then, reject non-empty http_services
+	// so an in-progress build cannot fail-open on unconsumed rules.
+	if len(p.HTTPServices) > 0 {
+		return fmt.Errorf("http_services: not yet supported in this build (feature under active development)")
+	}
+
 	return nil
 }

--- a/internal/policy/model.go
+++ b/internal/policy/model.go
@@ -524,12 +524,8 @@ func (p Policy) Validate() error {
 		}
 	}
 
-	// http_services: temporary gate. The real validator lands in Task 2 of
-	// the http_services plan (docs/superpowers/specs/2026-04-10-http-path-
-	// verb-filtering-design.md). Until then, reject non-empty http_services
-	// so an in-progress build cannot fail-open on unconsumed rules.
-	if len(p.HTTPServices) > 0 {
-		return fmt.Errorf("http_services: not yet supported in this build (feature under active development)")
+	if err := ValidateHTTPServices(p.HTTPServices); err != nil {
+		return err
 	}
 
 	return nil

--- a/internal/policy/model.go
+++ b/internal/policy/model.go
@@ -47,6 +47,11 @@ type Policy struct {
 	// Parsed from YAML but validated by ValidateSecrets in secrets.go.
 	Providers map[string]yaml.Node `yaml:"providers,omitempty"`
 	Services  []ServiceYAML        `yaml:"services,omitempty"`
+
+	// HTTP services for path/verb filtering. Orthogonal to `services:` (Plan 6).
+	// See internal/policy/http_service.go and
+	// docs/superpowers/specs/2026-04-10-http-path-verb-filtering-design.md
+	HTTPServices []HTTPService `yaml:"http_services,omitempty"`
 }
 
 type FileRule struct {

--- a/internal/proxy/credshook.go
+++ b/internal/proxy/credshook.go
@@ -189,6 +189,11 @@ func NewHeaderInjectionHook(serviceName, headerName, template string, table *cre
 
 func (h *HeaderInjectionHook) Name() string { return "header-inject" }
 
+// HeaderName returns the header that this hook injects. Used by the
+// declared-service log path to redact the injected value from audit
+// records.
+func (h *HeaderInjectionHook) HeaderName() string { return h.headerName }
+
 func (h *HeaderInjectionHook) PreHook(r *http.Request, _ *RequestContext) error {
 	real, ok := h.table.RealForService(h.serviceName)
 	if !ok {

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -53,6 +53,16 @@ func (p *Proxy) SetPolicyEngine(e *policy.Engine) {
 	p.policyEngine = e
 }
 
+// SetStorageForTest installs a Storage instance for the declared-service
+// logging path. Production uses the same Storage that the LLM path uses;
+// tests point it at a temp dir. Test-only setter to keep the dependency
+// visible.
+func (p *Proxy) SetStorageForTest(s *Storage) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.storage = s
+}
+
 // declaredService resolves a request path to a compiled http_service entry
 // if the path starts with /svc/<name>/. Returns the service name AS IT
 // APPEARED IN THE REQUEST (preserving the caller's case), the remaining
@@ -279,12 +289,19 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 	// hooks return. On read error we must fail closed: io.ReadAll may
 	// have already drained part of the stream, so leaving r.Body in
 	// place would hand hooks and the upstream a truncated request.
+	//
+	// body is hoisted to function scope so it remains accessible to
+	// logDeclaredServiceRequest below after the hook dispatch block.
+	// When r.Body is nil we pass a nil slice to the logger — HashBody
+	// handles that by returning an empty string.
+	var body []byte
 	if r.Body != nil {
-		body, err := io.ReadAll(r.Body)
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, "read request body: "+err.Error(), http.StatusBadRequest)
 			return
 		}
+		body = b
 		r.Body = io.NopCloser(bytes.NewReader(body))
 		r.ContentLength = int64(len(body))
 	}
@@ -373,6 +390,12 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 	// before hooks ran is still valid (case 1), or the hook explicitly
 	// owns the encoding (cases 3 and 4).
 
+	// Audit the request AFTER hooks have run and after the RawPath
+	// reconciliation, so the logged path reflects any hook-driven
+	// rewrites. dec.Rule is the name of the matched rule (empty when
+	// the decision came from the service default).
+	p.logDeclaredServiceRequest(requestID, sessionID, canonicalName, dec.Rule, r, body)
+
 	outReq, err := p.buildUpstreamRequest(r, svc.Upstream)
 	if err != nil {
 		http.Error(w, "rewrite failed: "+err.Error(), http.StatusInternalServerError)
@@ -385,6 +408,18 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 		return
 	}
 	defer resp.Body.Close()
+
+	// Buffer the response body so we can log it and still write it
+	// back. Unlike the LLM path, declared-service bodies are bounded
+	// by real API responses (not model streams), so buffering is
+	// acceptable. Spec §6 explicitly requires the body be logged,
+	// which rules out pass-through streaming in v1.
+	respBody, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		http.Error(w, "read upstream response: "+readErr.Error(), http.StatusBadGateway)
+		return
+	}
+	p.logDeclaredServiceResponse(requestID, sessionID, resp, respBody, startTime)
 
 	// Copy response headers and status, then body. Strip hop-by-hop headers
 	// (RFC 7230 §6.1) plus any headers named in the upstream's Connection
@@ -404,7 +439,7 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 		}
 	}
 	w.WriteHeader(resp.StatusCode)
-	_, _ = io.Copy(w, resp.Body)
+	_, _ = w.Write(respBody)
 }
 
 // findHTTPService looks up a service by name from the engine's enumeration.
@@ -559,4 +594,66 @@ func (p *Proxy) SetHTTPServiceTransportForTest(rt http.RoundTripper) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.httpSvcTransport = rt
+}
+
+// logDeclaredServiceRequest writes a RequestLogEntry for a declared-service
+// request to p.storage, mirroring how logRequest works for the LLM path but
+// without a Dialect and with ServiceKind/ServiceName/RuleName set.
+//
+// Matches the logRequest signature so future refactors can consolidate the
+// two. ruleName is the name of the rule that matched; if the decision came
+// from the service default (no rule matched), ruleName is the empty string.
+func (p *Proxy) logDeclaredServiceRequest(requestID, sessionID, svcName, ruleName string, r *http.Request, body []byte) {
+	if p.storage == nil {
+		return
+	}
+	entry := &RequestLogEntry{
+		ID:          requestID,
+		SessionID:   sessionID,
+		Timestamp:   time.Now().UTC(),
+		ServiceKind: "http_service",
+		ServiceName: svcName,
+		RuleName:    ruleName,
+		Request: RequestInfo{
+			Method:   r.Method,
+			Path:     r.URL.Path,
+			Headers:  sanitizeHeaders(r.Header),
+			BodySize: len(body),
+			BodyHash: HashBody(body),
+		},
+	}
+	if err := p.storage.LogRequest(entry); err != nil {
+		p.logger.Error("log declared-service request", "error", err, "request_id", requestID)
+	}
+	if err := p.storage.StoreRequestBody(requestID, body); err != nil {
+		p.logger.Error("store declared-service request body", "error", err, "request_id", requestID)
+	}
+}
+
+// logDeclaredServiceResponse mirrors logResponseDirect for the declared-
+// service path. resp.Body must already be drained into respBody; the
+// caller is responsible for restoring resp.Body before writing it back
+// to the client.
+func (p *Proxy) logDeclaredServiceResponse(requestID, sessionID string, resp *http.Response, respBody []byte, startTime time.Time) {
+	if p.storage == nil {
+		return
+	}
+	entry := &ResponseLogEntry{
+		RequestID:  requestID,
+		SessionID:  sessionID,
+		Timestamp:  time.Now().UTC(),
+		DurationMs: time.Since(startTime).Milliseconds(),
+		Response: ResponseInfo{
+			Status:   resp.StatusCode,
+			Headers:  sanitizeHeaders(resp.Header),
+			BodySize: len(respBody),
+			BodyHash: HashBody(respBody),
+		},
+	}
+	if err := p.storage.LogResponse(entry); err != nil {
+		p.logger.Error("log declared-service response", "error", err, "request_id", requestID)
+	}
+	if err := p.storage.StoreResponseBody(requestID, respBody); err != nil {
+		p.logger.Error("store declared-service response body", "error", err, "request_id", requestID)
+	}
 }

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -75,7 +75,15 @@ func (p *Proxy) declaredService(reqPath string) (name, rest string, ok bool) {
 // serveDeclaredService handles a request routed to a declared http_service.
 // deny returns 403, approve returns 501 (wired in Task 10), allow/audit
 // forward to the configured upstream after running per-service pre-hooks.
-func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svcName, reqPath, requestID string, startTime time.Time) {
+//
+// rawSegment is the service name AS IT APPEARED IN THE REQUEST URL (with
+// its original case preserved). It is used only for the literal
+// escaped-path prefix strip below — the canonical name from the policy
+// config (svc.Name) is used for everything else, including hook dispatch
+// and RequestContext. This split exists because /svc matching is
+// case-insensitive but the byte-level prefix strip against
+// r.URL.EscapedPath() needs the exact request bytes.
+func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, rawSegment, reqPath, requestID string, startTime time.Time) {
 	p.mu.Lock()
 	eng := p.policyEngine
 	p.mu.Unlock()
@@ -90,7 +98,11 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svc
 		pathForEval = pathForEval[:idx]
 	}
 
-	dec := eng.CheckHTTPService(svcName, r.Method, pathForEval)
+	// CheckHTTPService MUST run against the path-below-/svc/<name> that
+	// the policy author wrote their rules against. It runs BEFORE any
+	// pre-hook URL mutation so hooks cannot inadvertently (or
+	// deliberately) sidestep the decision by rewriting the path.
+	dec := eng.CheckHTTPService(rawSegment, r.Method, pathForEval)
 
 	switch dec.EffectiveDecision {
 	case "deny":
@@ -113,11 +125,15 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svc
 		return
 	}
 
-	svc := p.findHTTPService(eng, svcName)
+	svc := p.findHTTPService(eng, rawSegment)
 	if svc == nil {
 		http.Error(w, "service vanished", http.StatusInternalServerError)
 		return
 	}
+	// canonicalName is the service name as written in the policy config.
+	// Hook registration is keyed on this canonical form, so ApplyPreHooks
+	// must use it — not the raw request segment, whose case may differ.
+	canonicalName := svc.Name
 
 	// Recover the original escaped path tail so encoded bytes (e.g. %2F)
 	// reach the upstream unchanged. http.Request.URL.Path has already been
@@ -127,11 +143,13 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svc
 	// re-escaping of Path). The "/svc/<name>" prefix contains no characters
 	// that would be percent-encoded (service names are validated against
 	// ^[A-Za-z0-9._-]+$ in policy.ValidateHTTPServices), so in the common
-	// case a literal prefix strip works. If the client sent percent-encoded
+	// case a literal prefix strip works. The literal strip uses rawSegment
+	// (case-preserved from the request) rather than canonicalName so the
+	// byte-level prefix matches exactly. If the client sent percent-encoded
 	// bytes in the name portion (which decode to the same unencoded name),
 	// fall back to re-escaping the decoded rest — that preserves safety
 	// without preserving the caller's idiosyncratic encoding of the name.
-	prefix := declaredServicePathPrefix + svcName
+	prefix := declaredServicePathPrefix + rawSegment
 	escaped := r.URL.EscapedPath()
 	var escapedPath string
 	if strings.HasPrefix(escaped, prefix) {
@@ -144,9 +162,35 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svc
 		escapedPath = "/"
 	}
 
+	// Buffer the request body before dispatching hooks so they can
+	// inspect it without exhausting the stream. PreHooks may replace
+	// r.Body — buildUpstreamRequest reads whatever body is set after
+	// hooks return. On read error we must fail closed: io.ReadAll may
+	// have already drained part of the stream, so leaving r.Body in
+	// place would hand hooks and the upstream a truncated request.
+	if r.Body != nil {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read request body: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		r.ContentLength = int64(len(body))
+	}
+
+	// Rewrite r.URL to the upstream-bound form BEFORE running hooks so
+	// that any hook-driven URL mutations (e.g. CredsSubHook substituting
+	// credentials in the URL path) are visible to buildUpstreamRequest,
+	// which now reads from r.URL directly rather than captured copies.
+	// The policy decision already ran against the pre-mutation path.
+	r.URL.Path = reqPath
+	r.URL.RawPath = escapedPath
+
 	// Build RequestContext for hook dispatch. The /svc/ path pins
-	// ServiceName to the declared service name so per-service hooks
-	// (e.g. HeaderInjectionHook keyed on the service) fire.
+	// ServiceName to the canonical service name (as written in the
+	// policy config) so per-service hooks registered under that key —
+	// e.g. HeaderInjectionHook — fire even when the caller used a
+	// different case in the URL.
 	sessionID := r.Header.Get("X-Session-ID")
 	if sessionID == "" {
 		sessionID = p.cfg.SessionID
@@ -154,25 +198,13 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svc
 	reqCtx := &RequestContext{
 		RequestID:   requestID,
 		SessionID:   sessionID,
-		ServiceName: svcName,
+		ServiceName: canonicalName,
 		StartTime:   startTime,
 		Attrs:       make(map[string]any),
 	}
 
-	// Buffer the request body before dispatching hooks so they can
-	// inspect it without exhausting the stream. PreHooks may replace
-	// r.Body — buildUpstreamRequest reads whatever body is set after
-	// hooks return.
-	if r.Body != nil {
-		body, err := io.ReadAll(r.Body)
-		if err == nil {
-			r.Body = io.NopCloser(bytes.NewReader(body))
-			r.ContentLength = int64(len(body))
-		}
-	}
-
 	if p.hookRegistry != nil {
-		if err := p.hookRegistry.ApplyPreHooks(svcName, r, reqCtx); err != nil {
+		if err := p.hookRegistry.ApplyPreHooks(canonicalName, r, reqCtx); err != nil {
 			var abortErr *HookAbortError
 			if errors.As(err, &abortErr) {
 				code := abortErr.StatusCode
@@ -187,7 +219,7 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svc
 		}
 	}
 
-	outReq, err := p.buildUpstreamRequest(r, svc.Upstream, reqPath, escapedPath)
+	outReq, err := p.buildUpstreamRequest(r, svc.Upstream)
 	if err != nil {
 		http.Error(w, "rewrite failed: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -235,22 +267,35 @@ func (p *Proxy) findHTTPService(eng *policy.Engine, name string) *policy.HTTPSer
 }
 
 // buildUpstreamRequest clones the inbound request and retargets it at
-// svcUpstream + reqPath + (optional query string). Preserves method, body,
-// and headers. Does NOT apply hooks — hooks are wired in Task 9.
+// svcUpstream + the current r.URL.Path (decoded) and r.URL.RawPath
+// (escaped). Preserves method, body, and headers. Does NOT apply hooks —
+// serveDeclaredService runs pre-hooks before invoking this function, so
+// any hook-driven URL mutation is reflected here.
 //
-// reqPath is the decoded path tail (starting with '/') and escapedPath is
-// the original escaped form with the same meaning. Both are provided so
-// the outbound URL can carry percent-encoded bytes (e.g. %2F) through to
-// the upstream unchanged: Go preserves URL.RawPath only when it differs
-// from URL.Path after decoding, and prefers RawPath in URL.String() when
-// present — so we unconditionally populate both.
-func (p *Proxy) buildUpstreamRequest(r *http.Request, svcUpstream, reqPath, escapedPath string) (*http.Request, error) {
+// The caller is responsible for rewriting r.URL to the upstream-bound
+// form (stripping /svc/<name>) before calling. This function does not
+// take reqPath/escapedPath parameters so it cannot be called with stale
+// captured-before-hooks values — the only source of truth for the path
+// is r.URL at the moment the request is about to be forwarded.
+//
+// Go preserves URL.RawPath only when it differs from URL.Path after
+// decoding, and prefers RawPath in URL.String() when present — so we
+// unconditionally populate both on the outbound URL.
+func (p *Proxy) buildUpstreamRequest(r *http.Request, svcUpstream string) (*http.Request, error) {
 	u, err := url.Parse(svcUpstream)
 	if err != nil {
 		return nil, err
 	}
 	// Preserve query string if present on the inbound request.
 	rawQuery := r.URL.RawQuery
+	// Read the decoded and escaped forms directly from r.URL so any
+	// mutation pre-hooks performed (e.g. CredsSubHook substituting
+	// credentials into the URL path) is carried through to the upstream.
+	reqPath := r.URL.Path
+	escapedPath := r.URL.EscapedPath()
+	if escapedPath == "" {
+		escapedPath = reqPath
+	}
 	// Build the decoded and escaped forms of the joined path. Go prefers
 	// URL.RawPath in String() when it is a valid encoding of Path, so we
 	// populate both: Path carries the decoded form, RawPath carries the

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -138,6 +138,36 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 		pathForEval = pathForEval[:idx]
 	}
 
+	// Recover the original escaped path tail so encoded bytes (e.g. %2F)
+	// are visible downstream unchanged — both for the approval Target (so
+	// approvers see exactly what the client sent, including %2F/%3F) and
+	// for the upstream forwarding path below. http.Request.URL.Path has
+	// already been decoded — deriving either use from it would lose
+	// distinctions like "/items/a%2Fb" vs "/items/a/b". EscapedPath()
+	// returns the canonical escaped form (RawPath if set and valid,
+	// otherwise the re-escaping of Path). The "/svc/<name>" prefix
+	// contains no characters that would be percent-encoded (service names
+	// are validated against ^[A-Za-z0-9._-]+$ in policy.ValidateHTTPServices),
+	// so in the common case a literal prefix strip works. The literal
+	// strip uses rawSegment (case-preserved from the request) rather than
+	// a canonical name so the byte-level prefix matches exactly. If the
+	// client sent percent-encoded bytes in the name portion (which decode
+	// to the same unencoded name), fall back to re-escaping the decoded
+	// rest — that preserves safety without preserving the caller's
+	// idiosyncratic encoding of the name.
+	prefix := declaredServicePathPrefix + rawSegment
+	escaped := r.URL.EscapedPath()
+	var escapedPath string
+	if strings.HasPrefix(escaped, prefix) {
+		escapedPath = strings.TrimPrefix(escaped, prefix)
+	} else {
+		// Name was encoded or case-differs — re-escape the decoded rest.
+		escapedPath = (&url.URL{Path: reqPath}).EscapedPath()
+	}
+	if escapedPath == "" {
+		escapedPath = "/"
+	}
+
 	// CheckHTTPService MUST run against the path-below-/svc/<name> that
 	// the policy author wrote their rules against. It runs BEFORE any
 	// pre-hook URL mutation so hooks cannot inadvertently (or
@@ -158,11 +188,14 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 		appr := p.httpSvcApprovals
 		p.mu.Unlock()
 		if appr != nil {
-			// Target includes the raw query string (unparsed, as
-			// received from the client) when present so approvers see
-			// the full request — hiding ?force=true or similar would
-			// obscure material details about what's being approved.
-			target := rawSegment + " " + r.Method + " " + pathForEval
+			// Target uses the escaped-form path tail and the raw query
+			// string (unparsed, as received from the client) when
+			// present, so approvers see exactly what the client sent —
+			// including encoded bytes like %2F/%3F that would otherwise
+			// collapse to their decoded characters and misrepresent the
+			// resource being approved. Hiding the query string would
+			// similarly obscure material details (e.g. ?force=true).
+			target := rawSegment + " " + r.Method + " " + escapedPath
 			if r.URL.RawQuery != "" {
 				target += "?" + r.URL.RawQuery
 			}
@@ -228,33 +261,6 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 	// Hook registration is keyed on this canonical form, so ApplyPreHooks
 	// must use it — not the raw request segment, whose case may differ.
 	canonicalName := svc.Name
-
-	// Recover the original escaped path tail so encoded bytes (e.g. %2F)
-	// reach the upstream unchanged. http.Request.URL.Path has already been
-	// decoded — rebuilding the upstream URL from it would lose distinctions
-	// like "/items/a%2Fb" vs "/items/a/b". EscapedPath() returns the
-	// canonical escaped form (RawPath if set and valid, otherwise the
-	// re-escaping of Path). The "/svc/<name>" prefix contains no characters
-	// that would be percent-encoded (service names are validated against
-	// ^[A-Za-z0-9._-]+$ in policy.ValidateHTTPServices), so in the common
-	// case a literal prefix strip works. The literal strip uses rawSegment
-	// (case-preserved from the request) rather than canonicalName so the
-	// byte-level prefix matches exactly. If the client sent percent-encoded
-	// bytes in the name portion (which decode to the same unencoded name),
-	// fall back to re-escaping the decoded rest — that preserves safety
-	// without preserving the caller's idiosyncratic encoding of the name.
-	prefix := declaredServicePathPrefix + rawSegment
-	escaped := r.URL.EscapedPath()
-	var escapedPath string
-	if strings.HasPrefix(escaped, prefix) {
-		escapedPath = strings.TrimPrefix(escaped, prefix)
-	} else {
-		// Name was encoded or case-differs — re-escape the decoded rest.
-		escapedPath = (&url.URL{Path: reqPath}).EscapedPath()
-	}
-	if escapedPath == "" {
-		escapedPath = "/"
-	}
 
 	// Buffer the request body before dispatching hooks so they can
 	// inspect it without exhausting the stream. PreHooks may replace

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -107,7 +107,32 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svc
 		return
 	}
 
-	outReq, err := p.buildUpstreamRequest(r, svc.Upstream, reqPath)
+	// Recover the original escaped path tail so encoded bytes (e.g. %2F)
+	// reach the upstream unchanged. http.Request.URL.Path has already been
+	// decoded — rebuilding the upstream URL from it would lose distinctions
+	// like "/items/a%2Fb" vs "/items/a/b". EscapedPath() returns the
+	// canonical escaped form (RawPath if set and valid, otherwise the
+	// re-escaping of Path). The "/svc/<name>" prefix contains no characters
+	// that would be percent-encoded (service names are validated against
+	// ^[A-Za-z0-9._-]+$ in policy.ValidateHTTPServices), so in the common
+	// case a literal prefix strip works. If the client sent percent-encoded
+	// bytes in the name portion (which decode to the same unencoded name),
+	// fall back to re-escaping the decoded rest — that preserves safety
+	// without preserving the caller's idiosyncratic encoding of the name.
+	prefix := declaredServicePathPrefix + svcName
+	escaped := r.URL.EscapedPath()
+	var escapedPath string
+	if strings.HasPrefix(escaped, prefix) {
+		escapedPath = strings.TrimPrefix(escaped, prefix)
+	} else {
+		// Name was encoded or case-differs — re-escape the decoded rest.
+		escapedPath = (&url.URL{Path: reqPath}).EscapedPath()
+	}
+	if escapedPath == "" {
+		escapedPath = "/"
+	}
+
+	outReq, err := p.buildUpstreamRequest(r, svc.Upstream, reqPath, escapedPath)
 	if err != nil {
 		http.Error(w, "rewrite failed: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -120,8 +145,17 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svc
 	}
 	defer resp.Body.Close()
 
-	// Copy response headers and status, then body.
+	// Copy response headers and status, then body. Strip hop-by-hop headers
+	// (RFC 7230 §6.1) plus any headers named in the upstream's Connection
+	// header — real reverse proxies never forward these end-to-end.
+	respDenylist := connectionNominatedDenylist(resp.Header.Get("Connection"))
 	for k, vs := range resp.Header {
+		if isHopByHopHeader(k) {
+			continue
+		}
+		if _, nominated := respDenylist[http.CanonicalHeaderKey(k)]; nominated {
+			continue
+		}
 		for _, v := range vs {
 			w.Header().Add(k, v)
 		}
@@ -146,13 +180,26 @@ func (p *Proxy) findHTTPService(eng *policy.Engine, name string) *policy.HTTPSer
 // buildUpstreamRequest clones the inbound request and retargets it at
 // svcUpstream + reqPath + (optional query string). Preserves method, body,
 // and headers. Does NOT apply hooks — hooks are wired in Task 9.
-func (p *Proxy) buildUpstreamRequest(r *http.Request, svcUpstream, reqPath string) (*http.Request, error) {
+//
+// reqPath is the decoded path tail (starting with '/') and escapedPath is
+// the original escaped form with the same meaning. Both are provided so
+// the outbound URL can carry percent-encoded bytes (e.g. %2F) through to
+// the upstream unchanged: Go preserves URL.RawPath only when it differs
+// from URL.Path after decoding, and prefers RawPath in URL.String() when
+// present — so we unconditionally populate both.
+func (p *Proxy) buildUpstreamRequest(r *http.Request, svcUpstream, reqPath, escapedPath string) (*http.Request, error) {
 	u, err := url.Parse(svcUpstream)
 	if err != nil {
 		return nil, err
 	}
 	// Preserve query string if present on the inbound request.
 	rawQuery := r.URL.RawQuery
+	// Build the decoded and escaped forms of the joined path. Go prefers
+	// URL.RawPath in String() when it is a valid encoding of Path, so we
+	// populate both: Path carries the decoded form, RawPath carries the
+	// original escaped bytes. Use u.EscapedPath() for the upstream side
+	// because the parsed URL may itself contain percent-encoded segments.
+	u.RawPath = singleSlashJoin(u.EscapedPath(), escapedPath)
 	u.Path = singleSlashJoin(u.Path, reqPath)
 	u.RawQuery = rawQuery
 
@@ -160,9 +207,16 @@ func (p *Proxy) buildUpstreamRequest(r *http.Request, svcUpstream, reqPath strin
 	if err != nil {
 		return nil, err
 	}
-	// Copy headers, excluding hop-by-hop.
+	// Copy headers, excluding hop-by-hop and any headers nominated as
+	// connection-scoped by the client's Connection header (RFC 7230 §6.1).
+	// Without this, a client could smuggle arbitrary headers upstream by
+	// declaring them in Connection.
+	reqDenylist := connectionNominatedDenylist(r.Header.Get("Connection"))
 	for k, vs := range r.Header {
 		if isHopByHopHeader(k) {
+			continue
+		}
+		if _, nominated := reqDenylist[http.CanonicalHeaderKey(k)]; nominated {
 			continue
 		}
 		for _, v := range vs {
@@ -193,6 +247,37 @@ func isHopByHopHeader(h string) bool {
 		return true
 	}
 	return false
+}
+
+// connectionNominatedDenylist parses the value of a Connection header into
+// a set of canonicalized header names that this hop must not forward.
+// RFC 7230 §6.1 defines any token listed in Connection as hop-by-hop for
+// this hop — in addition to the fixed hop-by-hop set returned by
+// isHopByHopHeader. Empty tokens and the literal "close" / "keep-alive"
+// control directives are skipped.
+//
+// Returns an empty (non-nil) map when the header is absent so callers can
+// use set lookup without nil-checks.
+func connectionNominatedDenylist(connectionHeader string) map[string]struct{} {
+	out := make(map[string]struct{})
+	if connectionHeader == "" {
+		return out
+	}
+	for _, tok := range strings.Split(connectionHeader, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		// "close" and "keep-alive" are control directives, not header
+		// names — drop them from the denylist so they don't accidentally
+		// match a legitimate request header.
+		switch strings.ToLower(tok) {
+		case "close", "keep-alive":
+			continue
+		}
+		out[http.CanonicalHeaderKey(tok)] = struct{}{}
+	}
+	return out
 }
 
 // httpServiceTransport returns the transport used to forward declared-service

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -90,6 +90,12 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svc
 		// Forwarding implemented in Task 8.
 		http.Error(w, "forwarding not implemented", http.StatusNotImplemented)
 		return
+	case "approve":
+		// Task 10 wires the real approval manager. Until then, fail closed
+		// with a controlled 501 so callers get a semantically correct error
+		// instead of a 500 "unsupported decision".
+		http.Error(w, "approval not yet implemented", http.StatusNotImplemented)
+		return
 	default:
 		http.Error(w, "unsupported decision", http.StatusInternalServerError)
 		return

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -1,7 +1,9 @@
 package proxy
 
 import (
+	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -59,8 +61,8 @@ func (p *Proxy) declaredService(reqPath string) (name, rest string, ok bool) {
 }
 
 // serveDeclaredService handles a request routed to a declared http_service.
-// For Task 7, only the deny path is fully implemented. allow/audit return 501
-// until Task 8 adds upstream forwarding.
+// deny returns 403, approve returns 501 (wired in Task 10), allow/audit
+// forward to the configured upstream. Hooks are wired in Task 9.
 func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svcName, reqPath, requestID string, startTime time.Time) {
 	p.mu.Lock()
 	eng := p.policyEngine
@@ -86,18 +88,128 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svc
 		}
 		http.Error(w, msg, http.StatusForbidden)
 		return
-	case "allow", "audit":
-		// Forwarding implemented in Task 8.
-		http.Error(w, "forwarding not implemented", http.StatusNotImplemented)
-		return
 	case "approve":
 		// Task 10 wires the real approval manager. Until then, fail closed
 		// with a controlled 501 so callers get a semantically correct error
 		// instead of a 500 "unsupported decision".
 		http.Error(w, "approval not yet implemented", http.StatusNotImplemented)
 		return
+	case "allow", "audit":
+		// Proceed to forwarding below.
 	default:
 		http.Error(w, "unsupported decision", http.StatusInternalServerError)
 		return
 	}
+
+	svc := p.findHTTPService(eng, svcName)
+	if svc == nil {
+		http.Error(w, "service vanished", http.StatusInternalServerError)
+		return
+	}
+
+	outReq, err := p.buildUpstreamRequest(r, svc.Upstream, reqPath)
+	if err != nil {
+		http.Error(w, "rewrite failed: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp, err := p.httpServiceTransport().RoundTrip(outReq)
+	if err != nil {
+		http.Error(w, "upstream error: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+	defer resp.Body.Close()
+
+	// Copy response headers and status, then body.
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+	_, _ = io.Copy(w, resp.Body)
+}
+
+// findHTTPService looks up a service by name from the engine's enumeration.
+// Used in the serve path to access fields (Upstream, ExposeAs) that are
+// not in the Decision struct.
+func (p *Proxy) findHTTPService(eng *policy.Engine, name string) *policy.HTTPService {
+	for _, s := range eng.HTTPServices() {
+		if strings.EqualFold(s.Name, name) {
+			s := s
+			return &s
+		}
+	}
+	return nil
+}
+
+// buildUpstreamRequest clones the inbound request and retargets it at
+// svcUpstream + reqPath + (optional query string). Preserves method, body,
+// and headers. Does NOT apply hooks — hooks are wired in Task 9.
+func (p *Proxy) buildUpstreamRequest(r *http.Request, svcUpstream, reqPath string) (*http.Request, error) {
+	u, err := url.Parse(svcUpstream)
+	if err != nil {
+		return nil, err
+	}
+	// Preserve query string if present on the inbound request.
+	rawQuery := r.URL.RawQuery
+	u.Path = singleSlashJoin(u.Path, reqPath)
+	u.RawQuery = rawQuery
+
+	outReq, err := http.NewRequestWithContext(r.Context(), r.Method, u.String(), r.Body)
+	if err != nil {
+		return nil, err
+	}
+	// Copy headers, excluding hop-by-hop.
+	for k, vs := range r.Header {
+		if isHopByHopHeader(k) {
+			continue
+		}
+		for _, v := range vs {
+			outReq.Header.Add(k, v)
+		}
+	}
+	outReq.Host = u.Host
+	outReq.ContentLength = r.ContentLength
+	return outReq, nil
+}
+
+func singleSlashJoin(a, b string) string {
+	aSlash := strings.HasSuffix(a, "/")
+	bSlash := strings.HasPrefix(b, "/")
+	switch {
+	case aSlash && bSlash:
+		return a + b[1:]
+	case !aSlash && !bSlash:
+		return a + "/" + b
+	}
+	return a + b
+}
+
+func isHopByHopHeader(h string) bool {
+	switch strings.ToLower(h) {
+	case "connection", "keep-alive", "proxy-authenticate", "proxy-authorization",
+		"te", "trailer", "transfer-encoding", "upgrade":
+		return true
+	}
+	return false
+}
+
+// httpServiceTransport returns the transport used to forward declared-service
+// requests. Currently http.DefaultTransport; testable via the setter below.
+func (p *Proxy) httpServiceTransport() http.RoundTripper {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.httpSvcTransport != nil {
+		return p.httpSvcTransport
+	}
+	return http.DefaultTransport
+}
+
+// SetHTTPServiceTransportForTest injects a RoundTripper used for
+// declared-service forwarding. Test-only.
+func (p *Proxy) SetHTTPServiceTransportForTest(rt http.RoundTripper) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.httpSvcTransport = rt
 }

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -158,12 +158,30 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 		appr := p.httpSvcApprovals
 		p.mu.Unlock()
 		if appr != nil {
+			// Target includes the raw query string (unparsed, as
+			// received from the client) when present so approvers see
+			// the full request — hiding ?force=true or similar would
+			// obscure material details about what's being approved.
+			target := rawSegment + " " + r.Method + " " + pathForEval
+			if r.URL.RawQuery != "" {
+				target += "?" + r.URL.RawQuery
+			}
+			// CommandID is intentionally left empty. Declared-service
+			// requests aren't tied to a specific session command —
+			// they come from arbitrary HTTP calls the agent makes, not
+			// from a single tracked command. Populating this field
+			// with the proxy's per-request UUID (which is NOT a real
+			// session command ID) corrupts downstream command-level
+			// correlation and indexes approval events under a command
+			// ID that doesn't correspond to any real command. A future
+			// improvement could attach a command ID if agentsh tracks
+			// an "active command" per session.
 			req := approvals.Request{
 				ID:        "approval-" + uuid.NewString(),
 				SessionID: sessionID,
-				CommandID: requestID,
+				CommandID: "",
 				Kind:      "http_service",
-				Target:    rawSegment + " " + r.Method + " " + pathForEval,
+				Target:    target,
 				Rule:      dec.Rule,
 				Message:   dec.Message,
 			}

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -21,8 +21,16 @@ func (p *Proxy) SetPolicyEngine(e *policy.Engine) {
 }
 
 // declaredService resolves a request path to a compiled http_service entry
-// if the path starts with /svc/<name>/. Returns the service name, the
-// remaining path (starting with '/'), and ok=true when resolved.
+// if the path starts with /svc/<name>/. Returns the service name AS IT
+// APPEARED IN THE REQUEST (preserving the caller's case), the remaining
+// path (starting with '/'), and ok=true when resolved.
+//
+// The name is deliberately returned in the request's case (not the
+// configured canonical form) so downstream callers can strip the exact
+// prefix from r.URL.EscapedPath() — a case-insensitive lookup here paired
+// with a case-sensitive strip later would corrupt requests whose service
+// name case differs from the declared one. Downstream lookups
+// (CheckHTTPService, findHTTPService) are themselves case-insensitive.
 //
 // A path that starts with /svc/ but names a service that does not exist
 // returns ok=false with name != "". Callers use the name vs "" distinction
@@ -54,7 +62,9 @@ func (p *Proxy) declaredService(reqPath string) (name, rest string, ok bool) {
 	}
 	for _, svc := range eng.HTTPServices() {
 		if strings.EqualFold(svc.Name, name) {
-			return svc.Name, rest, true
+			// Return the request's segment (case-preserved), not svc.Name.
+			// See doc comment for why.
+			return name, rest, true
 		}
 	}
 	return name, rest, false
@@ -148,7 +158,9 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svc
 	// Copy response headers and status, then body. Strip hop-by-hop headers
 	// (RFC 7230 §6.1) plus any headers named in the upstream's Connection
 	// header — real reverse proxies never forward these end-to-end.
-	respDenylist := connectionNominatedDenylist(resp.Header.Get("Connection"))
+	// RFC 7230 §3.2.2 allows repeated Connection header lines, so merge all
+	// values (Header.Values) rather than reading only the first.
+	respDenylist := connectionNominatedDenylist(resp.Header.Values("Connection"))
 	for k, vs := range resp.Header {
 		if isHopByHopHeader(k) {
 			continue
@@ -210,8 +222,10 @@ func (p *Proxy) buildUpstreamRequest(r *http.Request, svcUpstream, reqPath, esca
 	// Copy headers, excluding hop-by-hop and any headers nominated as
 	// connection-scoped by the client's Connection header (RFC 7230 §6.1).
 	// Without this, a client could smuggle arbitrary headers upstream by
-	// declaring them in Connection.
-	reqDenylist := connectionNominatedDenylist(r.Header.Get("Connection"))
+	// declaring them in Connection. RFC 7230 §3.2.2 allows repeated
+	// Connection header lines, so merge all values (Header.Values) rather
+	// than reading only the first.
+	reqDenylist := connectionNominatedDenylist(r.Header.Values("Connection"))
 	for k, vs := range r.Header {
 		if isHopByHopHeader(k) {
 			continue
@@ -249,33 +263,37 @@ func isHopByHopHeader(h string) bool {
 	return false
 }
 
-// connectionNominatedDenylist parses the value of a Connection header into
-// a set of canonicalized header names that this hop must not forward.
-// RFC 7230 §6.1 defines any token listed in Connection as hop-by-hop for
-// this hop — in addition to the fixed hop-by-hop set returned by
-// isHopByHopHeader. Empty tokens and the literal "close" / "keep-alive"
-// control directives are skipped.
+// connectionNominatedDenylist parses the values of one or more Connection
+// header lines into a set of canonicalized header names that this hop must
+// not forward. RFC 7230 §6.1 defines any token listed in Connection as
+// hop-by-hop for this hop — in addition to the fixed hop-by-hop set
+// returned by isHopByHopHeader. RFC 7230 §3.2.2 allows a field to appear
+// on multiple lines, so callers pass Header.Values("Connection") and this
+// function merges tokens across all lines. Empty tokens and the literal
+// "close" / "keep-alive" control directives are skipped.
 //
-// Returns an empty (non-nil) map when the header is absent so callers can
-// use set lookup without nil-checks.
-func connectionNominatedDenylist(connectionHeader string) map[string]struct{} {
+// Returns an empty (non-nil) map when there are no header lines so callers
+// can use set lookup without nil-checks.
+func connectionNominatedDenylist(connectionHeaders []string) map[string]struct{} {
 	out := make(map[string]struct{})
-	if connectionHeader == "" {
-		return out
-	}
-	for _, tok := range strings.Split(connectionHeader, ",") {
-		tok = strings.TrimSpace(tok)
-		if tok == "" {
+	for _, line := range connectionHeaders {
+		if line == "" {
 			continue
 		}
-		// "close" and "keep-alive" are control directives, not header
-		// names — drop them from the denylist so they don't accidentally
-		// match a legitimate request header.
-		switch strings.ToLower(tok) {
-		case "close", "keep-alive":
-			continue
+		for _, tok := range strings.Split(line, ",") {
+			tok = strings.TrimSpace(tok)
+			if tok == "" {
+				continue
+			}
+			// "close" and "keep-alive" are control directives, not header
+			// names — drop them from the denylist so they don't accidentally
+			// match a legitimate request header.
+			switch strings.ToLower(tok) {
+			case "close", "keep-alive":
+				continue
+			}
+			out[http.CanonicalHeaderKey(tok)] = struct{}{}
 		}
-		out[http.CanonicalHeaderKey(tok)] = struct{}{}
 	}
 	return out
 }

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -290,20 +290,23 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 	// have already drained part of the stream, so leaving r.Body in
 	// place would hand hooks and the upstream a truncated request.
 	//
-	// body is hoisted to function scope so it remains accessible to
-	// logDeclaredServiceRequest below after the hook dispatch block.
-	// When r.Body is nil we pass a nil slice to the logger — HashBody
-	// handles that by returning an empty string.
-	var body []byte
+	// storedBody is hoisted to function scope because it feeds the
+	// on-disk copy written by StoreRequestBody below. It captures the
+	// PRE-hook bytes — i.e. what the agent actually typed — so real
+	// credentials that CredsSubHook substitutes in during PreHook never
+	// land in llm-bodies. The post-hook (forwarded) view is captured
+	// separately after the hook dispatch block, and only feeds the
+	// audit BodySize/BodyHash integrity stamp.
+	var storedBody []byte
 	if r.Body != nil {
 		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, "read request body: "+err.Error(), http.StatusBadRequest)
 			return
 		}
-		body = b
-		r.Body = io.NopCloser(bytes.NewReader(body))
-		r.ContentLength = int64(len(body))
+		storedBody = b
+		r.Body = io.NopCloser(bytes.NewReader(storedBody))
+		r.ContentLength = int64(len(storedBody))
 	}
 
 	// Rewrite r.URL to the upstream-bound form BEFORE running hooks so
@@ -390,26 +393,41 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 	// before hooks ran is still valid (case 1), or the hook explicitly
 	// owns the encoding (cases 3 and 4).
 
-	// Re-read the request body after hooks: declared-service hooks (e.g.
-	// CredsSubHook) may replace r.Body with post-substitution bytes. The
-	// audit record must reflect what is actually forwarded upstream, not
-	// the pre-hook contents.
-	if r.Body != nil {
-		postHookBody, err := io.ReadAll(r.Body)
+	// Compute the two views of the request body:
+	//   - storedBody (captured pre-hook, above): what the agent sent.
+	//     Passed to StoreRequestBody so the on-disk copy in
+	//     <session>/llm-bodies/<request_id>.json reflects the agent's
+	//     original bytes — NOT the post-hook bytes, which for
+	//     CredsSubHook contain real upstream credentials.
+	//   - forwardedBody (captured here, post-hook): what actually
+	//     goes upstream. Feeds BodySize and BodyHash in the audit
+	//     record so the integrity stamp describes the forwarded
+	//     request, not the agent's typed input.
+	//
+	// Special case: a pre-hook may drop the body entirely by setting
+	// r.Body = nil. In that situation neither view is meaningful —
+	// nothing was forwarded, so the audit record should show
+	// BodySize=0/BodyHash="" and nothing should land on disk under
+	// this request ID. Zero both slices to make that explicit.
+	var forwardedBody []byte
+	if r.Body == nil {
+		storedBody = nil
+	} else {
+		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, "re-read request body: "+err.Error(), http.StatusBadGateway)
 			return
 		}
-		body = postHookBody
-		r.Body = io.NopCloser(bytes.NewReader(body))
-		r.ContentLength = int64(len(body))
+		forwardedBody = b
+		r.Body = io.NopCloser(bytes.NewReader(forwardedBody))
+		r.ContentLength = int64(len(forwardedBody))
 	}
 
 	// Audit the request AFTER hooks have run and after the RawPath
 	// reconciliation, so the logged path reflects any hook-driven
 	// rewrites. dec.Rule is the name of the matched rule (empty when
 	// the decision came from the service default).
-	p.logDeclaredServiceRequest(requestID, sessionID, canonicalName, dec.Rule, r, body)
+	p.logDeclaredServiceRequest(requestID, sessionID, canonicalName, dec.Rule, r, forwardedBody, storedBody)
 
 	outReq, err := p.buildUpstreamRequest(r, svc.Upstream)
 	if err != nil {
@@ -656,7 +674,15 @@ func sanitizeHeadersForDeclaredService(h http.Header, injectedNames []string) ma
 // Matches the logRequest signature so future refactors can consolidate the
 // two. ruleName is the name of the rule that matched; if the decision came
 // from the service default (no rule matched), ruleName is the empty string.
-func (p *Proxy) logDeclaredServiceRequest(requestID, sessionID, svcName, ruleName string, r *http.Request, body []byte) {
+//
+// forwardedBody is the post-hook payload that will be sent upstream;
+// BodySize and BodyHash describe THIS slice so the audit record
+// describes what was actually forwarded. storedBody is the pre-hook
+// payload (agent's original input); it is passed to StoreRequestBody
+// so the on-disk copy never captures post-substitution credentials.
+// When a hook drops the request body entirely, both are nil and
+// StoreRequestBody no-ops (it already handles len(body) == 0).
+func (p *Proxy) logDeclaredServiceRequest(requestID, sessionID, svcName, ruleName string, r *http.Request, forwardedBody, storedBody []byte) {
 	if p.storage == nil {
 		return
 	}
@@ -675,14 +701,14 @@ func (p *Proxy) logDeclaredServiceRequest(requestID, sessionID, svcName, ruleNam
 			Method:   r.Method,
 			Path:     r.URL.Path,
 			Headers:  sanitizeHeadersForDeclaredService(r.Header, injected),
-			BodySize: len(body),
-			BodyHash: HashBody(body),
+			BodySize: len(forwardedBody),
+			BodyHash: HashBody(forwardedBody),
 		},
 	}
 	if err := p.storage.LogRequest(entry); err != nil {
 		p.logger.Error("log declared-service request", "error", err, "request_id", requestID)
 	}
-	if err := p.storage.StoreRequestBody(requestID, body); err != nil {
+	if err := p.storage.StoreRequestBody(requestID, storedBody); err != nil {
 		p.logger.Error("store declared-service request body", "error", err, "request_id", requestID)
 	}
 }

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -404,21 +404,31 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 	//     record so the integrity stamp describes the forwarded
 	//     request, not the agent's typed input.
 	//
-	// Special case: a pre-hook may drop the body entirely by setting
-	// r.Body = nil. In that situation neither view is meaningful —
-	// nothing was forwarded, so the audit record should show
-	// BodySize=0/BodyHash="" and nothing should land on disk under
-	// this request ID. Zero both slices to make that explicit.
+	// Empty-body normalization: pre-hooks may drop the body via
+	// r.Body = nil, r.Body = http.NoBody, or by replacing it with a
+	// zero-byte reader. All three mean "nothing forwarded". When we
+	// detect any of them we:
+	//   - Zero storedBody so no on-disk copy is written
+	//   - Leave forwardedBody nil so BodySize/BodyHash describe "empty"
+	//   - Reset r.Body = http.NoBody and r.ContentLength = 0 so
+	//     buildUpstreamRequest does not forward a stale Content-Length
+	//     header to the upstream. Relying on hook authors to zero
+	//     ContentLength themselves is brittle and fails silently.
 	var forwardedBody []byte
-	if r.Body == nil {
-		storedBody = nil
-	} else {
+	if r.Body != nil && r.Body != http.NoBody {
 		b, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, "re-read request body: "+err.Error(), http.StatusBadGateway)
 			return
 		}
 		forwardedBody = b
+	}
+	if len(forwardedBody) == 0 {
+		storedBody = nil
+		forwardedBody = nil
+		r.Body = http.NoBody
+		r.ContentLength = 0
+	} else {
 		r.Body = io.NopCloser(bytes.NewReader(forwardedBody))
 		r.ContentLength = int64(len(forwardedBody))
 	}

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -183,8 +183,29 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 	// credentials in the URL path) are visible to buildUpstreamRequest,
 	// which now reads from r.URL directly rather than captured copies.
 	// The policy decision already ran against the pre-mutation path.
+	//
+	// Path/RawPath contract with hooks:
+	//   - r.URL.Path is set to the decoded tail.
+	//   - r.URL.RawPath is INTENTIONALLY LEFT EMPTY across the hook
+	//     dispatch to avoid the stale-pre-seed footgun: if we pre-seeded
+	//     RawPath with the escaped tail and a hook mutated r.URL.Path,
+	//     the RawPath left behind would no longer match the new Path
+	//     and Go's url.URL.EscapedPath() would silently fall back to
+	//     re-escaping Path — dropping any %2F (or similar) bytes that
+	//     lived in segments the hook didn't touch.
+	//   - After hooks return, if r.URL.Path is byte-identical to the
+	//     snapshot, we know the hook did not touch the path and it is
+	//     safe to re-apply the original escaped tail so encoded bytes
+	//     reach the upstream unchanged.
+	//   - If the hook DID mutate r.URL.Path, the hook owns the
+	//     encoding: Go will re-escape from r.URL.Path and any percent-
+	//     encoded bytes in untouched segments are lost. Hooks that want
+	//     to rewrite Path while preserving encoded bytes elsewhere
+	//     MUST set both r.URL.Path and r.URL.RawPath consistently —
+	//     this is Go's standard contract for url.URL.
 	r.URL.Path = reqPath
-	r.URL.RawPath = escapedPath
+	r.URL.RawPath = ""
+	preHookPath := r.URL.Path
 
 	// Build RequestContext for hook dispatch. The /svc/ path pins
 	// ServiceName to the canonical service name (as written in the
@@ -217,6 +238,17 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 			http.Error(w, "hook error: "+err.Error(), http.StatusBadGateway)
 			return
 		}
+	}
+
+	// Re-apply the original escaped tail only if the hook left r.URL.Path
+	// untouched. If the hook mutated Path, leave r.URL.RawPath empty so
+	// Go's url.URL.EscapedPath() re-escapes r.URL.Path from scratch —
+	// that's the hook's responsibility per the contract documented
+	// above. Skip the re-apply when the escaped and decoded forms are
+	// identical: setting RawPath equal to Path would be a redundant
+	// string write and Go would treat it identically to the empty case.
+	if r.URL.Path == preHookPath && escapedPath != preHookPath {
+		r.URL.RawPath = escapedPath
 	}
 
 	outReq, err := p.buildUpstreamRequest(r, svc.Upstream)

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -390,6 +390,21 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 	// before hooks ran is still valid (case 1), or the hook explicitly
 	// owns the encoding (cases 3 and 4).
 
+	// Re-read the request body after hooks: declared-service hooks (e.g.
+	// CredsSubHook) may replace r.Body with post-substitution bytes. The
+	// audit record must reflect what is actually forwarded upstream, not
+	// the pre-hook contents.
+	if r.Body != nil {
+		postHookBody, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "re-read request body: "+err.Error(), http.StatusBadGateway)
+			return
+		}
+		body = postHookBody
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		r.ContentLength = int64(len(body))
+	}
+
 	// Audit the request AFTER hooks have run and after the RawPath
 	// reconciliation, so the logged path reflects any hook-driven
 	// rewrites. dec.Rule is the name of the matched rule (empty when
@@ -419,7 +434,7 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 		http.Error(w, "read upstream response: "+readErr.Error(), http.StatusBadGateway)
 		return
 	}
-	p.logDeclaredServiceResponse(requestID, sessionID, resp, respBody, startTime)
+	p.logDeclaredServiceResponse(requestID, sessionID, canonicalName, resp, respBody, startTime)
 
 	// Copy response headers and status, then body. Strip hop-by-hop headers
 	// (RFC 7230 §6.1) plus any headers named in the upstream's Connection
@@ -596,6 +611,44 @@ func (p *Proxy) SetHTTPServiceTransportForTest(rt http.RoundTripper) {
 	p.httpSvcTransport = rt
 }
 
+// sanitizeHeadersForDeclaredService redacts headers that may carry
+// credentials on the declared-service path. In addition to the fixed
+// auth denylist shared with the LLM path (Authorization, X-Api-Key,
+// Api-Key), it redacts:
+//
+//   - Cookie / Set-Cookie (session tokens)
+//   - Proxy-Authorization / Proxy-Authenticate (upstream proxy creds)
+//   - Any header name listed in injectedNames, which the caller
+//     populates from Registry.InjectedHeaderNamesForService so
+//     per-service HeaderInjectionHook credentials never hit disk.
+//
+// Comparison is case-insensitive via http.CanonicalHeaderKey. The
+// returned map uses the original header key casing as received, to
+// keep logs readable.
+func sanitizeHeadersForDeclaredService(h http.Header, injectedNames []string) map[string][]string {
+	denylist := map[string]struct{}{
+		"Authorization":       {},
+		"X-Api-Key":           {},
+		"Api-Key":             {},
+		"Cookie":              {},
+		"Set-Cookie":          {},
+		"Proxy-Authorization": {},
+		"Proxy-Authenticate":  {},
+	}
+	for _, n := range injectedNames {
+		denylist[http.CanonicalHeaderKey(n)] = struct{}{}
+	}
+	result := make(map[string][]string, len(h))
+	for k, v := range h {
+		if _, redacted := denylist[http.CanonicalHeaderKey(k)]; redacted {
+			result[k] = []string{"[REDACTED]"}
+			continue
+		}
+		result[k] = v
+	}
+	return result
+}
+
 // logDeclaredServiceRequest writes a RequestLogEntry for a declared-service
 // request to p.storage, mirroring how logRequest works for the LLM path but
 // without a Dialect and with ServiceKind/ServiceName/RuleName set.
@@ -607,6 +660,10 @@ func (p *Proxy) logDeclaredServiceRequest(requestID, sessionID, svcName, ruleNam
 	if p.storage == nil {
 		return
 	}
+	var injected []string
+	if p.hookRegistry != nil {
+		injected = p.hookRegistry.InjectedHeaderNamesForService(svcName)
+	}
 	entry := &RequestLogEntry{
 		ID:          requestID,
 		SessionID:   sessionID,
@@ -617,7 +674,7 @@ func (p *Proxy) logDeclaredServiceRequest(requestID, sessionID, svcName, ruleNam
 		Request: RequestInfo{
 			Method:   r.Method,
 			Path:     r.URL.Path,
-			Headers:  sanitizeHeaders(r.Header),
+			Headers:  sanitizeHeadersForDeclaredService(r.Header, injected),
 			BodySize: len(body),
 			BodyHash: HashBody(body),
 		},
@@ -633,10 +690,16 @@ func (p *Proxy) logDeclaredServiceRequest(requestID, sessionID, svcName, ruleNam
 // logDeclaredServiceResponse mirrors logResponseDirect for the declared-
 // service path. resp.Body must already be drained into respBody; the
 // caller is responsible for restoring resp.Body before writing it back
-// to the client.
-func (p *Proxy) logDeclaredServiceResponse(requestID, sessionID string, resp *http.Response, respBody []byte, startTime time.Time) {
+// to the client. svcName is the canonical service name so the response
+// sanitizer can redact any HeaderInjectionHook-registered header names
+// the upstream echoed back.
+func (p *Proxy) logDeclaredServiceResponse(requestID, sessionID, svcName string, resp *http.Response, respBody []byte, startTime time.Time) {
 	if p.storage == nil {
 		return
+	}
+	var injected []string
+	if p.hookRegistry != nil {
+		injected = p.hookRegistry.InjectedHeaderNamesForService(svcName)
 	}
 	entry := &ResponseLogEntry{
 		RequestID:  requestID,
@@ -645,7 +708,7 @@ func (p *Proxy) logDeclaredServiceResponse(requestID, sessionID string, resp *ht
 		DurationMs: time.Since(startTime).Milliseconds(),
 		Response: ResponseInfo{
 			Status:   resp.StatusCode,
-			Headers:  sanitizeHeaders(resp.Header),
+			Headers:  sanitizeHeadersForDeclaredService(resp.Header, injected),
 			BodySize: len(respBody),
 			BodyHash: HashBody(respBody),
 		},

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -186,26 +186,35 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 	//
 	// Path/RawPath contract with hooks:
 	//   - r.URL.Path is set to the decoded tail.
-	//   - r.URL.RawPath is INTENTIONALLY LEFT EMPTY across the hook
-	//     dispatch to avoid the stale-pre-seed footgun: if we pre-seeded
-	//     RawPath with the escaped tail and a hook mutated r.URL.Path,
-	//     the RawPath left behind would no longer match the new Path
-	//     and Go's url.URL.EscapedPath() would silently fall back to
-	//     re-escaping Path — dropping any %2F (or similar) bytes that
-	//     lived in segments the hook didn't touch.
-	//   - After hooks return, if r.URL.Path is byte-identical to the
-	//     snapshot, we know the hook did not touch the path and it is
-	//     safe to re-apply the original escaped tail so encoded bytes
-	//     reach the upstream unchanged.
-	//   - If the hook DID mutate r.URL.Path, the hook owns the
-	//     encoding: Go will re-escape from r.URL.Path and any percent-
-	//     encoded bytes in untouched segments are lost. Hooks that want
-	//     to rewrite Path while preserving encoded bytes elsewhere
-	//     MUST set both r.URL.Path and r.URL.RawPath consistently —
-	//     this is Go's standard contract for url.URL.
+	//   - r.URL.RawPath is SEEDED with the escaped tail so built-in
+	//     hooks like CredsSubHook — whose RawPath substitution branch
+	//     is gated on RawPath != "" — fire and update both fields in
+	//     lockstep. Because CredsSubHook's substitution is length-
+	//     preserving and leaves non-substituted bytes intact, encoded
+	//     bytes in untouched segments (e.g. %2F) survive the rewrite.
+	//   - After hooks return, four cases are possible:
+	//       1. Neither Path nor RawPath changed: the seeded escapedTail
+	//          is still correct. Nothing to do.
+	//       2. Only Path changed (hook rewrote the decoded Path but
+	//          didn't touch RawPath): the seeded RawPath is now stale
+	//          and no longer a valid encoding of Path. Clear it so
+	//          Go's url.URL.EscapedPath() re-escapes from Path from
+	//          scratch. This loses encoded bytes in segments the hook
+	//          didn't touch — a documented limitation. Hooks that need
+	//          to preserve encoded bytes while rewriting Path must
+	//          update BOTH fields (the CredsSubHook pattern).
+	//          TODO(future): a common-prefix splice could preserve the
+	//          untouched prefix's encoding when only Path changes,
+	//          but that's out of scope for this commit.
+	//       3. Only RawPath changed (hook explicitly rewrote the
+	//          escaping without changing the decoded Path): trust the
+	//          hook and leave its RawPath in place.
+	//       4. Both Path and RawPath changed (CredsSubHook's path):
+	//          trust the hook and leave both in place.
 	r.URL.Path = reqPath
-	r.URL.RawPath = ""
+	r.URL.RawPath = escapedPath
 	preHookPath := r.URL.Path
+	preHookRawPath := r.URL.RawPath
 
 	// Build RequestContext for hook dispatch. The /svc/ path pins
 	// ServiceName to the canonical service name (as written in the
@@ -240,16 +249,21 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 		}
 	}
 
-	// Re-apply the original escaped tail only if the hook left r.URL.Path
-	// untouched. If the hook mutated Path, leave r.URL.RawPath empty so
-	// Go's url.URL.EscapedPath() re-escapes r.URL.Path from scratch —
-	// that's the hook's responsibility per the contract documented
-	// above. Skip the re-apply when the escaped and decoded forms are
-	// identical: setting RawPath equal to Path would be a redundant
-	// string write and Go would treat it identically to the empty case.
-	if r.URL.Path == preHookPath && escapedPath != preHookPath {
-		r.URL.RawPath = escapedPath
+	// Post-hook RawPath reconciliation. See the four-case table in the
+	// pre-hook comment above for the rationale.
+	pathChanged := r.URL.Path != preHookPath
+	rawChanged := r.URL.RawPath != preHookRawPath
+	if pathChanged && !rawChanged {
+		// Case 2: hook rewrote Path without updating RawPath, so the
+		// seeded RawPath is now stale. Clearing it lets Go re-escape
+		// Path from scratch. Encoded bytes in untouched segments are
+		// lost — documented limitation; hooks that care must update
+		// both fields.
+		r.URL.RawPath = ""
 	}
+	// Cases 1, 3, 4: leave r.URL as-is. The seeded escapedPath from
+	// before hooks ran is still valid (case 1), or the hook explicitly
+	// owns the encoding (cases 3 and 4).
 
 	outReq, err := p.buildUpstreamRequest(r, svc.Upstream)
 	if err != nil {

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
@@ -72,7 +74,7 @@ func (p *Proxy) declaredService(reqPath string) (name, rest string, ok bool) {
 
 // serveDeclaredService handles a request routed to a declared http_service.
 // deny returns 403, approve returns 501 (wired in Task 10), allow/audit
-// forward to the configured upstream. Hooks are wired in Task 9.
+// forward to the configured upstream after running per-service pre-hooks.
 func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svcName, reqPath, requestID string, startTime time.Time) {
 	p.mu.Lock()
 	eng := p.policyEngine
@@ -140,6 +142,49 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svc
 	}
 	if escapedPath == "" {
 		escapedPath = "/"
+	}
+
+	// Build RequestContext for hook dispatch. The /svc/ path pins
+	// ServiceName to the declared service name so per-service hooks
+	// (e.g. HeaderInjectionHook keyed on the service) fire.
+	sessionID := r.Header.Get("X-Session-ID")
+	if sessionID == "" {
+		sessionID = p.cfg.SessionID
+	}
+	reqCtx := &RequestContext{
+		RequestID:   requestID,
+		SessionID:   sessionID,
+		ServiceName: svcName,
+		StartTime:   startTime,
+		Attrs:       make(map[string]any),
+	}
+
+	// Buffer the request body before dispatching hooks so they can
+	// inspect it without exhausting the stream. PreHooks may replace
+	// r.Body — buildUpstreamRequest reads whatever body is set after
+	// hooks return.
+	if r.Body != nil {
+		body, err := io.ReadAll(r.Body)
+		if err == nil {
+			r.Body = io.NopCloser(bytes.NewReader(body))
+			r.ContentLength = int64(len(body))
+		}
+	}
+
+	if p.hookRegistry != nil {
+		if err := p.hookRegistry.ApplyPreHooks(svcName, r, reqCtx); err != nil {
+			var abortErr *HookAbortError
+			if errors.As(err, &abortErr) {
+				code := abortErr.StatusCode
+				if code < 400 || code > 599 {
+					code = http.StatusBadGateway
+				}
+				http.Error(w, abortErr.Message, code)
+				return
+			}
+			http.Error(w, "hook error: "+err.Error(), http.StatusBadGateway)
+			return
+		}
 	}
 
 	outReq, err := p.buildUpstreamRequest(r, svc.Upstream, reqPath, escapedPath)

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -9,10 +10,40 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agentsh/agentsh/internal/approvals"
 	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/google/uuid"
 )
 
 const declaredServicePathPrefix = "/svc/"
+
+// HTTPServiceApprovalsManager is the subset of approvals.Manager needed by
+// the declared-service path. Declared here as a local interface to keep
+// the import surface narrow and to simplify testing — tests install a
+// fake implementation via SetApprovalsForTest and don't have to spin up a
+// real approvals.Manager with its TTY/TOTP/WebAuthn machinery.
+type HTTPServiceApprovalsManager interface {
+	RequestApproval(ctx context.Context, req approvals.Request) (approvals.Resolution, error)
+}
+
+// SetHTTPServiceApprovals wires the approvals manager consulted for
+// `approve` decisions on declared services. Called once during startup
+// from app.go alongside SetPolicyEngine and SetHTTPServices.
+func (p *Proxy) SetHTTPServiceApprovals(m HTTPServiceApprovalsManager) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.httpSvcApprovals = m
+}
+
+// SetApprovalsForTest installs an approvals manager for the declared-
+// service path. Test-only; production wiring goes through
+// SetHTTPServiceApprovals.
+func (p *Proxy) SetApprovalsForTest(m HTTPServiceApprovalsManager) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.httpSvcApprovals = m
+}
 
 // SetPolicyEngine wires the policy engine for http_services dispatch.
 // Called once during startup.
@@ -73,8 +104,9 @@ func (p *Proxy) declaredService(reqPath string) (name, rest string, ok bool) {
 }
 
 // serveDeclaredService handles a request routed to a declared http_service.
-// deny returns 403, approve returns 501 (wired in Task 10), allow/audit
-// forward to the configured upstream after running per-service pre-hooks.
+// deny returns 403, approve consults the wired approvals manager (falling
+// through to 501 when none is configured), and allow/audit forward to the
+// configured upstream after running per-service pre-hooks.
 //
 // rawSegment is the service name AS IT APPEARED IN THE REQUEST URL (with
 // its original case preserved). It is used only for the literal
@@ -92,6 +124,14 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 		return
 	}
 
+	// Resolve sessionID up front so it is available to the approvals
+	// request if the decision turns out to be `approve`. The same value
+	// is reused later when constructing RequestContext for hook dispatch.
+	sessionID := r.Header.Get("X-Session-ID")
+	if sessionID == "" {
+		sessionID = p.cfg.SessionID
+	}
+
 	// Strip query string before evaluation — the evaluator does not look at it.
 	pathForEval := reqPath
 	if idx := strings.IndexByte(pathForEval, '?'); idx != -1 {
@@ -104,21 +144,57 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 	// deliberately) sidestep the decision by rewriting the path.
 	dec := eng.CheckHTTPService(rawSegment, r.Method, pathForEval)
 
+	// Gate approve decisions on an interactive approval. This mirrors the
+	// logic in internal/netmonitor/proxy.go maybeApprove; the two call
+	// sites are deliberately duplicated for minimal blast radius. A
+	// follow-up refactor can consolidate them into a shared helper.
+	//
+	// When the manager is nil (operator hasn't wired one yet), the
+	// decision is left untouched and falls through to the 501 branch in
+	// the switch below — so the existing "approval not yet implemented"
+	// contract still holds for un-wired tests and deployments.
+	if dec.PolicyDecision == types.DecisionApprove && dec.EffectiveDecision == types.DecisionApprove {
+		p.mu.Lock()
+		appr := p.httpSvcApprovals
+		p.mu.Unlock()
+		if appr != nil {
+			req := approvals.Request{
+				ID:        "approval-" + uuid.NewString(),
+				SessionID: sessionID,
+				CommandID: requestID,
+				Kind:      "http_service",
+				Target:    rawSegment + " " + r.Method + " " + pathForEval,
+				Rule:      dec.Rule,
+				Message:   dec.Message,
+			}
+			res, err := appr.RequestApproval(r.Context(), req)
+			if dec.Approval != nil {
+				dec.Approval.ID = req.ID
+			}
+			if err != nil || !res.Approved {
+				dec.EffectiveDecision = types.DecisionDeny
+			} else {
+				dec.EffectiveDecision = types.DecisionAllow
+			}
+		}
+	}
+
 	switch dec.EffectiveDecision {
-	case "deny":
+	case types.DecisionDeny:
 		msg := dec.Message
 		if msg == "" {
 			msg = "blocked by http_services rule"
 		}
 		http.Error(w, msg, http.StatusForbidden)
 		return
-	case "approve":
-		// Task 10 wires the real approval manager. Until then, fail closed
-		// with a controlled 501 so callers get a semantically correct error
-		// instead of a 500 "unsupported decision".
+	case types.DecisionApprove:
+		// Only reached when the decision was `approve` but no approvals
+		// manager has been wired. Fail closed with a semantically distinct
+		// 501 so operators can tell the difference between "approvals not
+		// configured" and "policy returned an unsupported decision".
 		http.Error(w, "approval not yet implemented", http.StatusNotImplemented)
 		return
-	case "allow", "audit":
+	case types.DecisionAllow, types.DecisionAudit:
 		// Proceed to forwarding below.
 	default:
 		http.Error(w, "unsupported decision", http.StatusInternalServerError)
@@ -220,11 +296,8 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 	// ServiceName to the canonical service name (as written in the
 	// policy config) so per-service hooks registered under that key —
 	// e.g. HeaderInjectionHook — fire even when the caller used a
-	// different case in the URL.
-	sessionID := r.Header.Get("X-Session-ID")
-	if sessionID == "" {
-		sessionID = p.cfg.SessionID
-	}
+	// different case in the URL. sessionID was resolved near the top of
+	// this function so it was available for the approvals request.
 	reqCtx := &RequestContext{
 		RequestID:   requestID,
 		SessionID:   sessionID,

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -1,0 +1,97 @@
+package proxy
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+const declaredServicePathPrefix = "/svc/"
+
+// SetPolicyEngine wires the policy engine for http_services dispatch.
+// Called once during startup.
+func (p *Proxy) SetPolicyEngine(e *policy.Engine) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.policyEngine = e
+}
+
+// declaredService resolves a request path to a compiled http_service entry
+// if the path starts with /svc/<name>/. Returns the service name, the
+// remaining path (starting with '/'), and ok=true when resolved.
+//
+// A path that starts with /svc/ but names a service that does not exist
+// returns ok=false with name != "". Callers use the name vs "" distinction
+// to decide between "fall through to LLM path" (no /svc/ prefix) and
+// "return 404 for unknown declared service".
+func (p *Proxy) declaredService(reqPath string) (name, rest string, ok bool) {
+	if !strings.HasPrefix(reqPath, declaredServicePathPrefix) {
+		return "", "", false
+	}
+	tail := strings.TrimPrefix(reqPath, declaredServicePathPrefix)
+	slash := strings.IndexByte(tail, '/')
+	if slash == -1 {
+		name = tail
+		rest = "/"
+	} else {
+		name = tail[:slash]
+		rest = tail[slash:]
+	}
+	if name == "" {
+		return "", "", false
+	}
+
+	p.mu.Lock()
+	eng := p.policyEngine
+	p.mu.Unlock()
+	if eng == nil {
+		// Not yet wired — treat as unknown so tests with no engine don't crash.
+		return name, rest, false
+	}
+	for _, svc := range eng.HTTPServices() {
+		if strings.EqualFold(svc.Name, name) {
+			return svc.Name, rest, true
+		}
+	}
+	return name, rest, false
+}
+
+// serveDeclaredService handles a request routed to a declared http_service.
+// For Task 7, only the deny path is fully implemented. allow/audit return 501
+// until Task 8 adds upstream forwarding.
+func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, svcName, reqPath, requestID string, startTime time.Time) {
+	p.mu.Lock()
+	eng := p.policyEngine
+	p.mu.Unlock()
+	if eng == nil {
+		http.Error(w, "http_services not configured", http.StatusInternalServerError)
+		return
+	}
+
+	// Strip query string before evaluation — the evaluator does not look at it.
+	pathForEval := reqPath
+	if idx := strings.IndexByte(pathForEval, '?'); idx != -1 {
+		pathForEval = pathForEval[:idx]
+	}
+
+	dec := eng.CheckHTTPService(svcName, r.Method, pathForEval)
+
+	switch dec.EffectiveDecision {
+	case "deny":
+		msg := dec.Message
+		if msg == "" {
+			msg = "blocked by http_services rule"
+		}
+		http.Error(w, msg, http.StatusForbidden)
+		return
+	case "allow", "audit":
+		// Forwarding implemented in Task 8.
+		http.Error(w, "forwarding not implemented", http.StatusNotImplemented)
+		return
+	default:
+		http.Error(w, "unsupported decision", http.StatusInternalServerError)
+		return
+	}
+}

--- a/internal/proxy/declared_service.go
+++ b/internal/proxy/declared_service.go
@@ -158,10 +158,21 @@ func (p *Proxy) serveDeclaredService(w http.ResponseWriter, r *http.Request, raw
 	prefix := declaredServicePathPrefix + rawSegment
 	escaped := r.URL.EscapedPath()
 	var escapedPath string
-	if strings.HasPrefix(escaped, prefix) {
+	// The literal strip is only safe when the byte immediately after the
+	// prefix is '/' (the unencoded separator) or the prefix is the entire
+	// escaped path. Otherwise the prefix "matches" a name whose trailing
+	// bytes are percent-encoded into the next segment (e.g.
+	// "/svc/github%2Fitems" has prefix "/svc/github" with a '%' next byte),
+	// and stripping the prefix would leave "%2Fitems" — diverging from
+	// the decoded rest ("/items") that policy evaluation and upstream
+	// forwarding use. Fall back to re-escaping the decoded rest in that
+	// case so the approval Target stays aligned with what the rest of
+	// the pipeline sees.
+	if strings.HasPrefix(escaped, prefix) && (len(escaped) == len(prefix) || escaped[len(prefix)] == '/') {
 		escapedPath = strings.TrimPrefix(escaped, prefix)
 	} else {
-		// Name was encoded or case-differs — re-escape the decoded rest.
+		// Name was encoded, case-differs, or bled into the next segment
+		// via an encoded slash — re-escape the decoded rest.
 		escapedPath = (&url.URL{Path: reqPath}).EscapedPath()
 	}
 	if escapedPath == "" {

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -217,6 +217,39 @@ func TestServeDeclaredService_Approve_TargetIncludesQueryString(t *testing.T) {
 	}
 }
 
+// TestServeDeclaredService_Approve_TargetPreservesEncodedPath pins down
+// that the approval Target shows the approver the exact escaped bytes
+// the client sent — not the decoded form. Before the fix, Target was
+// built from r.URL.Path (decoded by net/http), so percent-encoded bytes
+// like %2F collapsed to their literal characters and approvers saw a
+// different or ambiguous path from what the client actually requested.
+// The service rule matches the decoded form (/items/a/b) because
+// CheckHTTPService runs against the decoded path; the Target string is
+// human-facing and must preserve the original encoding.
+func TestServeDeclaredService_Approve_TargetPreservesEncodedPath(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "require-approval", Methods: []string{"POST"}, Paths: []string{"/items/a/b"}, Decision: "approve"},
+	})
+	appr := &fakeApprovalsManager{approve: true}
+	p.SetApprovalsForTest(appr)
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github/items/a%2Fb?force=true", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if got, want := appr.gotReq.Target, "github POST /items/a%2Fb?force=true"; got != want {
+		t.Errorf("approval Target = %q, want %q", got, want)
+	}
+}
+
 // TestServeDeclaredService_Approve_Denied pins down that when an approvals
 // manager is wired and returns Approved=false, the handler must deny with
 // 403 Forbidden and MUST NOT forward the request to the upstream.

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -1,0 +1,68 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+func newTestProxyWithHTTPService(t *testing.T, upstream string, rules []policy.HTTPServiceRule) *Proxy {
+	t.Helper()
+	cfg := Config{SessionID: "test-session"}
+	p, err := New(cfg, "", nil)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	svcs := []policy.HTTPService{{
+		Name: "github", Upstream: upstream, Default: "deny", Rules: rules,
+	}}
+	if err := policy.ValidateHTTPServices(svcs); err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	pol := &policy.Policy{HTTPServices: svcs}
+	eng, err := policy.NewEngine(pol, true, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	p.SetPolicyEngine(eng)
+	p.SetHTTPServices(svcs)
+	return p
+}
+
+func TestServeHTTP_PathPrefixDispatch_NoSuchService(t *testing.T) {
+	p := newTestProxyWithHTTPService(t, "https://api.github.com", nil)
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/nosuch/foo", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", w.Code)
+	}
+	body, _ := io.ReadAll(w.Body)
+	if !strings.Contains(string(body), "no such service") {
+		t.Errorf("body = %q, want 'no such service'", body)
+	}
+}
+
+func TestServeDeclaredService_Deny(t *testing.T) {
+	p := newTestProxyWithHTTPService(t, "https://api.github.com", []policy.HTTPServiceRule{
+		{Name: "block-delete", Methods: []string{"DELETE"}, Paths: []string{"/repos/**"}, Decision: "deny", Message: "no deletes"},
+	})
+
+	req := httptest.NewRequest(http.MethodDelete, "http://127.0.0.1/svc/github/repos/a/b", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	body, _ := io.ReadAll(w.Body)
+	if !strings.Contains(string(body), "no deletes") {
+		t.Errorf("body = %q, want 'no deletes'", body)
+	}
+}

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/agentsh/agentsh/internal/policy"
 )
 
+func init() {
+	policy.SetAllowInsecureHTTPServiceUpstreamForTest(true)
+}
+
 func newTestProxyWithHTTPService(t *testing.T, upstream string, rules []policy.HTTPServiceRule) *Proxy {
 	t.Helper()
 	cfg := Config{SessionID: "test-session"}
@@ -86,5 +90,46 @@ func TestServeDeclaredService_Approve_Returns501(t *testing.T) {
 	body, _ := io.ReadAll(w.Body)
 	if !strings.Contains(string(body), "approval not yet implemented") {
 		t.Errorf("body = %q, want 'approval not yet implemented'", body)
+	}
+}
+
+func TestServeDeclaredService_Allow_Forwards(t *testing.T) {
+	// Fake upstream that records the incoming request.
+	var gotMethod, gotPath string
+	var gotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		io.WriteString(w, `{"ok":true}`)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "post-issues", Methods: []string{"POST"}, Paths: []string{"/repos/*/*/issues"}, Decision: "allow"},
+	})
+
+	body := strings.NewReader(`{"title":"bug"}`)
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github/repos/anthropics/claude-code/issues", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201", w.Code)
+	}
+	if gotMethod != "POST" {
+		t.Errorf("upstream method = %q, want POST", gotMethod)
+	}
+	if gotPath != "/repos/anthropics/claude-code/issues" {
+		t.Errorf("upstream path = %q, want /repos/anthropics/claude-code/issues", gotPath)
+	}
+	if string(gotBody) != `{"title":"bug"}` {
+		t.Errorf("upstream body = %q", gotBody)
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("response Content-Type = %q, want application/json", ct)
 	}
 }

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -455,5 +456,183 @@ func TestServeDeclaredService_StripsMultipleConnectionResponseHeaders(t *testing
 	}
 	if v := w.Header().Get("X-Other-Resp"); v != "" {
 		t.Errorf("response X-Other-Resp = %q, want empty (second Connection line)", v)
+	}
+}
+
+// TestServeDeclaredService_HooksRunForMixedCaseRequest pins down that
+// pre-hooks registered under a declared service's canonical name fire
+// even when the request URL's service segment uses a different case.
+// Hook registration is keyed on the canonical name from the policy
+// config (e.g. "github") — before the fix, serveDeclaredService passed
+// the raw request segment ("GITHUB") to ApplyPreHooks, so the lookup
+// missed the service-scoped hook and the Authorization header was
+// never injected.
+func TestServeDeclaredService_HooksRunForMixedCaseRequest(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	// Canonical name is lowercase "github"; request URL is uppercase.
+	p := newTestProxyWithNamedHTTPService(t, "github", upstream.URL, []policy.HTTPServiceRule{
+		{Name: "get", Methods: []string{"GET"}, Paths: []string{"/**"}, Decision: "allow"},
+	})
+
+	hookCalled := false
+	p.HookRegistry().Register("github", &serviceRecorderHook{
+		name: "fake-injector",
+		preFn: func(r *http.Request, ctx *RequestContext) error {
+			hookCalled = true
+			if ctx.ServiceName != "github" {
+				t.Errorf("ctx.ServiceName = %q, want github (canonical)", ctx.ServiceName)
+			}
+			r.Header.Set("Authorization", "Bearer real-token")
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/GITHUB/user", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if !hookCalled {
+		t.Error("service-scoped hook was not called for mixed-case request")
+	}
+	if gotAuth != "Bearer real-token" {
+		t.Errorf("upstream Authorization = %q, want 'Bearer real-token'", gotAuth)
+	}
+}
+
+// TestServeDeclaredService_HooksRunForMixedCaseRequest_MixedCaseCanonical
+// is the mirror case: canonical name is mixed case "GitHub" and the
+// request uses lowercase "github". The hook is registered under the
+// canonical name "GitHub" and must still fire.
+func TestServeDeclaredService_HooksRunForMixedCaseRequest_MixedCaseCanonical(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithNamedHTTPService(t, "GitHub", upstream.URL, []policy.HTTPServiceRule{
+		{Name: "get", Methods: []string{"GET"}, Paths: []string{"/**"}, Decision: "allow"},
+	})
+
+	hookCalled := false
+	p.HookRegistry().Register("GitHub", &serviceRecorderHook{
+		name: "fake-injector",
+		preFn: func(r *http.Request, ctx *RequestContext) error {
+			hookCalled = true
+			if ctx.ServiceName != "GitHub" {
+				t.Errorf("ctx.ServiceName = %q, want GitHub (canonical)", ctx.ServiceName)
+			}
+			r.Header.Set("Authorization", "Bearer real-token")
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/user", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if !hookCalled {
+		t.Error("service-scoped hook was not called for case-mismatched request")
+	}
+	if gotAuth != "Bearer real-token" {
+		t.Errorf("upstream Authorization = %q, want 'Bearer real-token'", gotAuth)
+	}
+}
+
+// TestServeDeclaredService_PreHookCanRewritePath pins down that pre-hook
+// URL mutations (e.g. CredsSubHook substituting credentials in the URL
+// path) reach the upstream. Before the fix, serveDeclaredService captured
+// reqPath/escapedPath BEFORE running hooks and passed those stale values
+// to buildUpstreamRequest, so any hook rewrites of r.URL.Path/RawPath
+// were silently dropped.
+func TestServeDeclaredService_PreHookCanRewritePath(t *testing.T) {
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		// Policy rule is written against the *original* path, because
+		// CheckHTTPService runs before hooks. The hook then rewrites
+		// the URL to something the upstream serves.
+		{Name: "allow-original", Paths: []string{"/original"}, Decision: "allow"},
+	})
+
+	p.HookRegistry().Register("github", &serviceRecorderHook{
+		name: "path-rewriter",
+		preFn: func(r *http.Request, _ *RequestContext) error {
+			r.URL.Path = "/rewritten"
+			r.URL.RawPath = "/rewritten"
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/original", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if gotPath != "/rewritten" {
+		t.Errorf("upstream path = %q, want /rewritten (hook rewrite dropped?)", gotPath)
+	}
+}
+
+// failingReader is an io.Reader that always returns an error. Used to
+// simulate a client whose request body stream fails mid-read.
+type failingReader struct{}
+
+func (failingReader) Read(_ []byte) (int, error) { return 0, errors.New("boom") }
+
+// TestServeDeclaredService_BodyReadError_Returns400 pins down that a
+// failure to read the request body returns an HTTP 400 and does NOT
+// forward the request upstream. Before the fix, io.ReadAll errors were
+// silently swallowed and the (partially-drained) body was handed to
+// hooks and the upstream, yielding a truncated forwarded request.
+func TestServeDeclaredService_BodyReadError_Returns400(t *testing.T) {
+	upstreamCalled := false
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-all", Methods: []string{"POST"}, Paths: []string{"/**"}, Decision: "allow"},
+	})
+
+	// httptest.NewRequest requires an io.Reader. The failing reader's
+	// Read always errors, simulating a mid-stream failure.
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github/foo", failingReader{})
+	// ContentLength > 0 so net/http doesn't helpfully short-circuit to
+	// http.NoBody before the handler ever calls Read.
+	req.ContentLength = 10
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if upstreamCalled {
+		t.Error("upstream should not be called when request body read fails")
+	}
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body=%q", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !strings.Contains(body, "read request body") {
+		t.Errorf("body = %q, want 'read request body' prefix", body)
 	}
 }

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -16,13 +16,21 @@ func init() {
 
 func newTestProxyWithHTTPService(t *testing.T, upstream string, rules []policy.HTTPServiceRule) *Proxy {
 	t.Helper()
+	return newTestProxyWithNamedHTTPService(t, "github", upstream, rules)
+}
+
+// newTestProxyWithNamedHTTPService is like newTestProxyWithHTTPService but
+// lets the caller pin the declared service name (for tests that deliberately
+// exercise case-mismatched URLs).
+func newTestProxyWithNamedHTTPService(t *testing.T, name, upstream string, rules []policy.HTTPServiceRule) *Proxy {
+	t.Helper()
 	cfg := Config{SessionID: "test-session"}
 	p, err := New(cfg, "", nil)
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
 	svcs := []policy.HTTPService{{
-		Name: "github", Upstream: upstream, Default: "deny", Rules: rules,
+		Name: name, Upstream: upstream, Default: "deny", Rules: rules,
 	}}
 	if err := policy.ValidateHTTPServices(svcs); err != nil {
 		t.Fatalf("validate: %v", err)
@@ -239,5 +247,134 @@ func TestServeDeclaredService_StripsHopByHopResponseHeaders(t *testing.T) {
 	}
 	if v := w.Header().Get("Connection"); v != "" {
 		t.Errorf("response Connection = %q, want empty (hop-by-hop)", v)
+	}
+}
+
+// TestServeDeclaredService_PreservesEscapedPath_MixedCaseServiceName pins
+// down that percent-encoded bytes survive case-mismatched service names.
+// The declared service is "GitHub" (mixed case) but the request uses
+// "/svc/github/..." (lowercase). declaredService must return the request's
+// segment so serveDeclaredService can strip it from EscapedPath() with a
+// case-sensitive HasPrefix — otherwise the fallback decodes %2F to /.
+func TestServeDeclaredService_PreservesEscapedPath_MixedCaseServiceName(t *testing.T) {
+	var gotEscaped string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscaped = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	// Declared name "GitHub" — request uses "github".
+	p := newTestProxyWithNamedHTTPService(t, "GitHub", upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-items", Paths: []string{"/items/**"}, Decision: "allow"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/items/a%2Fb", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if gotEscaped != "/items/a%2Fb" {
+		t.Errorf("upstream EscapedPath = %q, want /items/a%%2Fb", gotEscaped)
+	}
+}
+
+// TestServeDeclaredService_PreservesEscapedPath_UppercaseRequest is the
+// reverse: declared service is lowercase "github", request uses uppercase
+// "/svc/GITHUB/...". Same invariant must hold.
+func TestServeDeclaredService_PreservesEscapedPath_UppercaseRequest(t *testing.T) {
+	var gotEscaped string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscaped = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithNamedHTTPService(t, "github", upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-items", Paths: []string{"/items/**"}, Decision: "allow"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/GITHUB/items/a%2Fb", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if gotEscaped != "/items/a%2Fb" {
+		t.Errorf("upstream EscapedPath = %q, want /items/a%%2Fb", gotEscaped)
+	}
+}
+
+// TestServeDeclaredService_StripsMultipleConnectionRequestHeaders pins down
+// RFC 7230 §3.2.2: a client sending Connection on multiple lines must have
+// ALL nominated headers stripped, not just the first line's tokens.
+// Header.Get returns only the first value — connectionNominatedDenylist
+// must merge via Header.Values.
+func TestServeDeclaredService_StripsMultipleConnectionRequestHeaders(t *testing.T) {
+	var gotHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-foo", Paths: []string{"/foo"}, Decision: "allow"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/foo", nil)
+	// Two separate Connection header lines.
+	req.Header.Add("Connection", "X-Custom-Req")
+	req.Header.Add("Connection", "X-Other-Req")
+	req.Header.Set("X-Custom-Req", "one")
+	req.Header.Set("X-Other-Req", "two")
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if v := gotHeaders.Get("X-Custom-Req"); v != "" {
+		t.Errorf("upstream X-Custom-Req = %q, want empty (first Connection line)", v)
+	}
+	if v := gotHeaders.Get("X-Other-Req"); v != "" {
+		t.Errorf("upstream X-Other-Req = %q, want empty (second Connection line)", v)
+	}
+}
+
+// TestServeDeclaredService_StripsMultipleConnectionResponseHeaders is the
+// response-side equivalent: when the upstream sends Connection on two
+// lines, both lines' nominated headers must be dropped before copying
+// headers back to the client.
+func TestServeDeclaredService_StripsMultipleConnectionResponseHeaders(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Two separate Connection header lines.
+		w.Header().Add("Connection", "X-Custom-Resp")
+		w.Header().Add("Connection", "X-Other-Resp")
+		w.Header().Set("X-Custom-Resp", "one")
+		w.Header().Set("X-Other-Resp", "two")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-foo", Paths: []string{"/foo"}, Decision: "allow"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/foo", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if v := w.Header().Get("X-Custom-Resp"); v != "" {
+		t.Errorf("response X-Custom-Resp = %q, want empty (first Connection line)", v)
+	}
+	if v := w.Header().Get("X-Other-Resp"); v != "" {
+		t.Errorf("response X-Other-Resp = %q, want empty (second Connection line)", v)
 	}
 }

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/proxy/credsub"
 )
 
 func init() {
@@ -679,13 +680,20 @@ func TestServeDeclaredService_PreservesEscapedPath_WhenHookDoesNotTouchPath(t *t
 // TestServeDeclaredService_HookPathRewrite_DropsEncodedBytes documents
 // the intentional limitation of the Path/RawPath contract: when a pre-hook
 // mutates only r.URL.Path (not RawPath), percent-encoded bytes in other
-// segments are LOST because Go's url.URL.EscapedPath() re-escapes from
-// the decoded Path when RawPath is stale or empty.
+// segments are LOST. The handler seeds r.URL.RawPath with the original
+// escaped tail before running hooks (so built-in hooks like CredsSubHook,
+// which update Path and RawPath in lockstep, can preserve encoded bytes),
+// but a hook that only touches Path leaves a stale RawPath behind. The
+// handler detects this post-hook and clears RawPath so Go's
+// url.URL.EscapedPath() re-escapes from the mutated Path — which turns
+// %2F in untouched segments into a literal '/'.
 //
 // Hooks that want to rewrite Path while preserving encoded bytes in
-// untouched segments must set both Path and RawPath together. See
-// TestServeDeclaredService_HookRewritesBothPathAndRawPath below for the
-// opt-in pattern.
+// untouched segments must update BOTH Path and RawPath together (see
+// TestServeDeclaredService_HookRewritesBothPathAndRawPath). This matches
+// what CredsSubHook does — see
+// TestServeDeclaredService_CredsSubHook_PreservesEncodedSlash for the
+// real-hook regression test.
 func TestServeDeclaredService_HookPathRewrite_DropsEncodedBytes(t *testing.T) {
 	var gotEscaped string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -762,5 +770,117 @@ func TestServeDeclaredService_HookRewritesBothPathAndRawPath(t *testing.T) {
 	}
 	if gotEscaped != "/repos/a%2Fb/pulls" {
 		t.Errorf("upstream EscapedPath = %q, want /repos/a%%2Fb/pulls", gotEscaped)
+	}
+}
+
+// TestServeDeclaredService_CredsSubHook_PreservesEncodedSlash is the
+// real-hook regression test for the CredsSubHook path-rewriting branch.
+// CredsSubHook updates r.URL.RawPath ONLY when RawPath is already set
+// (see internal/proxy/credshook.go PreHook). If the declared-service
+// handler clears RawPath before running hooks, CredsSubHook only
+// rewrites Path and any encoded bytes elsewhere in the path (e.g. a
+// %2F in a different segment) are lost when Go re-escapes Path from
+// scratch.
+//
+// The handler must seed r.URL.RawPath with the escaped tail BEFORE
+// running hooks so CredsSubHook's dual-update branch fires. Because
+// the substitution is length-preserving and leaves non-substituted
+// bytes intact, the %2F survives all the way to the upstream.
+func TestServeDeclaredService_CredsSubHook_PreservesEncodedSlash(t *testing.T) {
+	var gotEscaped string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscaped = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		// Policy rule is written against the original decoded path.
+		{Name: "allow-repos", Paths: []string{"/repos/**"}, Decision: "allow"},
+	})
+
+	// Build a credsub table with a fake/real pair of the same length
+	// (24 chars — the table enforces length equality). The fake is
+	// what the agent types; the real is what the upstream receives.
+	tbl := credsub.New()
+	if err := tbl.Add("github",
+		[]byte("FAKE_PLACEHOLDER_12345678"),
+		[]byte("REAL_CREDENTIAL_abcdef012"),
+	); err != nil {
+		t.Fatalf("credsub.Add: %v", err)
+	}
+	// Mirror llmproxy.go: register globally (empty service name) so
+	// the hook fires for every declared service — including "github".
+	p.HookRegistry().Register("", NewCredsSubHook(tbl, nil))
+
+	// The request path contains BOTH:
+	//   - an encoded slash (%2F) in one segment that CredsSubHook must
+	//     not touch, and
+	//   - a placeholder credential in another segment that CredsSubHook
+	//     must substitute.
+	req := httptest.NewRequest(http.MethodGet,
+		"http://127.0.0.1/svc/github/repos/owner%2Fname/tokens/FAKE_PLACEHOLDER_12345678", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	// Upstream must see the substitution applied AND the encoded slash
+	// preserved in the untouched segment.
+	want := "/repos/owner%2Fname/tokens/REAL_CREDENTIAL_abcdef012"
+	if gotEscaped != want {
+		t.Errorf("upstream EscapedPath = %q, want %q", gotEscaped, want)
+	}
+}
+
+// TestServeDeclaredService_HookRewritesOnlyRawPath pins down that a hook
+// which mutates only r.URL.RawPath (leaving r.URL.Path unchanged) has
+// its RawPath propagated to the upstream. Before the fix, the post-hook
+// restore logic checked only Path and silently overwrote any
+// hook-written RawPath with the original escaped tail, so hooks could
+// not adjust escaping without also changing Path.
+//
+// The request URL uses an encoded byte (%62) so that the original
+// escaped tail differs from the decoded Path — that's what triggered
+// the old restore logic's "RawPath := escapedPath" branch. The hook
+// then rewrites RawPath to a third (different) valid encoding, and
+// the upstream must see exactly the hook's encoding.
+func TestServeDeclaredService_HookRewritesOnlyRawPath(t *testing.T) {
+	var gotEscaped string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscaped = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-items", Paths: []string{"/items/**"}, Decision: "allow"},
+	})
+
+	p.HookRegistry().Register("github", &serviceRecorderHook{
+		name: "rawpath-only",
+		preFn: func(r *http.Request, _ *RequestContext) error {
+			// Leave r.URL.Path alone; rewrite only RawPath to a
+			// different valid encoding of the same decoded Path.
+			// The handler must trust the hook's RawPath.
+			r.URL.RawPath = "/items/%61b"
+			return nil
+		},
+	})
+
+	// Encoded %62 ("b") — makes the original escapedPath "/items/a%62"
+	// differ from the decoded Path "/items/ab". The old restore logic
+	// saw Path unchanged and blindly re-applied "/items/a%62",
+	// clobbering the hook's "/items/%61b".
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/items/a%62", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if gotEscaped != "/items/%61b" {
+		t.Errorf("upstream EscapedPath = %q, want /items/%%61b (hook-written RawPath clobbered?)", gotEscaped)
 	}
 }

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -636,3 +636,131 @@ func TestServeDeclaredService_BodyReadError_Returns400(t *testing.T) {
 		t.Errorf("body = %q, want 'read request body' prefix", body)
 	}
 }
+
+// TestServeDeclaredService_PreservesEscapedPath_WhenHookDoesNotTouchPath
+// pins down that percent-encoded bytes in the request path reach the
+// upstream unchanged even when a pre-hook runs — so long as the hook
+// does not mutate r.URL.Path. The hook here injects a header (the common
+// case for per-service hooks) and leaves the URL alone; the %2F must
+// still survive to the upstream.
+func TestServeDeclaredService_PreservesEscapedPath_WhenHookDoesNotTouchPath(t *testing.T) {
+	var gotEscaped string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscaped = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-repos", Paths: []string{"/repos/**"}, Decision: "allow"},
+	})
+
+	p.HookRegistry().Register("github", &serviceRecorderHook{
+		name: "header-only",
+		preFn: func(r *http.Request, _ *RequestContext) error {
+			// Hook leaves r.URL.Path and r.URL.RawPath alone.
+			r.Header.Set("Authorization", "Bearer real-token")
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/repos/a%2Fb/issues", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if gotEscaped != "/repos/a%2Fb/issues" {
+		t.Errorf("upstream EscapedPath = %q, want /repos/a%%2Fb/issues", gotEscaped)
+	}
+}
+
+// TestServeDeclaredService_HookPathRewrite_DropsEncodedBytes documents
+// the intentional limitation of the Path/RawPath contract: when a pre-hook
+// mutates only r.URL.Path (not RawPath), percent-encoded bytes in other
+// segments are LOST because Go's url.URL.EscapedPath() re-escapes from
+// the decoded Path when RawPath is stale or empty.
+//
+// Hooks that want to rewrite Path while preserving encoded bytes in
+// untouched segments must set both Path and RawPath together. See
+// TestServeDeclaredService_HookRewritesBothPathAndRawPath below for the
+// opt-in pattern.
+func TestServeDeclaredService_HookPathRewrite_DropsEncodedBytes(t *testing.T) {
+	var gotEscaped string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscaped = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-repos", Paths: []string{"/repos/**"}, Decision: "allow"},
+	})
+
+	p.HookRegistry().Register("github", &serviceRecorderHook{
+		name: "path-suffix-rewrite",
+		preFn: func(r *http.Request, _ *RequestContext) error {
+			// Hook mutates only Path, leaving RawPath untouched. This
+			// is the "common but wrong" pattern documented in the
+			// fix's follow-up comment.
+			r.URL.Path = strings.Replace(r.URL.Path, "/issues", "/pulls", 1)
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/repos/a%2Fb/issues", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	// The hook owns the re-escaping because it mutated Path without
+	// updating RawPath. %2F is re-encoded from the decoded '/' to a
+	// literal '/' in the upstream path. This is INTENTIONAL — it
+	// documents the hook contract, not a regression.
+	if gotEscaped != "/repos/a/b/pulls" {
+		t.Errorf("upstream EscapedPath = %q, want /repos/a/b/pulls (hook owns encoding when mutating Path)", gotEscaped)
+	}
+}
+
+// TestServeDeclaredService_HookRewritesBothPathAndRawPath pins down the
+// opt-in path for hooks that need to rewrite the URL while preserving
+// encoded bytes: set BOTH r.URL.Path and r.URL.RawPath. When RawPath is
+// a valid encoding of Path, Go's EscapedPath() returns RawPath verbatim
+// and the upstream receives exactly what the hook produced.
+func TestServeDeclaredService_HookRewritesBothPathAndRawPath(t *testing.T) {
+	var gotEscaped string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscaped = r.URL.EscapedPath()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-repos", Paths: []string{"/repos/**"}, Decision: "allow"},
+	})
+
+	p.HookRegistry().Register("github", &serviceRecorderHook{
+		name: "path-suffix-rewrite-encoded",
+		preFn: func(r *http.Request, _ *RequestContext) error {
+			// Hook rewrites the suffix AND keeps the encoded byte in
+			// the untouched prefix by updating both fields.
+			r.URL.Path = "/repos/a/b/pulls"
+			r.URL.RawPath = "/repos/a%2Fb/pulls"
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/repos/a%2Fb/issues", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if gotEscaped != "/repos/a%2Fb/pulls" {
+		t.Errorf("upstream EscapedPath = %q, want /repos/a%%2Fb/pulls", gotEscaped)
+	}
+}

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -1463,6 +1463,149 @@ func TestServeDeclaredService_HookNilsBody_LogsZeroAndStoresNothing(t *testing.T
 	}
 }
 
+// TestServeDeclaredService_HookNilsBodyLeavesStaleContentLength_Normalized
+// pins down that the proxy normalizes empty-body hooks so that a hook
+// which sets r.Body = nil but forgets to zero r.ContentLength does NOT
+// leak a stale positive Content-Length upstream. Relying on hook authors
+// to zero ContentLength themselves is brittle; the proxy must normalize.
+func TestServeDeclaredService_HookNilsBodyLeavesStaleContentLength_Normalized(t *testing.T) {
+	var upstreamGotLen int64
+	var upstreamGotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamGotLen = r.ContentLength
+		b, _ := io.ReadAll(r.Body)
+		upstreamGotBody = b
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	tmpDir := t.TempDir()
+	storage, err := NewStorage(tmpDir, "test-session", true)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-upload", Methods: []string{"POST"}, Paths: []string{"/upload"}, Decision: "allow"},
+	})
+	p.SetStorageForTest(storage)
+
+	// Hook nils the body but deliberately leaves ContentLength stale.
+	// The proxy must still normalize so Content-Length doesn't leak
+	// upstream.
+	p.HookRegistry().Register("github", &serviceRecorderHook{
+		name: "body-nil-stale-clen",
+		preFn: func(r *http.Request, _ *RequestContext) error {
+			r.Body = nil
+			// intentionally do NOT touch r.ContentLength
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github/upload", strings.NewReader("PAYLOAD_WITH_LENGTH"))
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+
+	if upstreamGotLen != 0 {
+		t.Errorf("upstream ContentLength = %d, want 0 (hook dropped body)", upstreamGotLen)
+	}
+	if len(upstreamGotBody) != 0 {
+		t.Errorf("upstream received body %q, want empty (hook dropped body)", upstreamGotBody)
+	}
+
+	entries := readAllRequestLogEntries(t, tmpDir, "test-session")
+	if len(entries) != 1 {
+		t.Fatalf("got %d request log entries, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Request.BodySize != 0 {
+		t.Errorf("BodySize = %d, want 0 (hook dropped body)", e.Request.BodySize)
+	}
+	if e.Request.BodyHash != "" {
+		t.Errorf("BodyHash = %q, want empty (hook dropped body)", e.Request.BodyHash)
+	}
+
+	bodyPath := filepath.Join(tmpDir, "test-session", "llm-bodies", e.ID+".json")
+	if _, statErr := os.Stat(bodyPath); !os.IsNotExist(statErr) {
+		t.Errorf("expected no stored body file at %q, got err=%v", bodyPath, statErr)
+	}
+}
+
+// TestServeDeclaredService_HookSetsHttpNoBody_Normalized pins down that a
+// hook which uses the idiomatic http.NoBody sentinel is treated the same
+// as r.Body = nil: nothing is forwarded upstream, nothing lands on disk,
+// and the audit record shows BodySize=0/BodyHash="". The current code
+// reads empty bytes into forwardedBody but does NOT zero storedBody, so
+// the agent's pre-hook input still lands on disk even though nothing was
+// actually forwarded.
+func TestServeDeclaredService_HookSetsHttpNoBody_Normalized(t *testing.T) {
+	var upstreamGotLen int64
+	var upstreamGotBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamGotLen = r.ContentLength
+		b, _ := io.ReadAll(r.Body)
+		upstreamGotBody = b
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	tmpDir := t.TempDir()
+	storage, err := NewStorage(tmpDir, "test-session", true)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-upload", Methods: []string{"POST"}, Paths: []string{"/upload"}, Decision: "allow"},
+	})
+	p.SetStorageForTest(storage)
+
+	p.HookRegistry().Register("github", &serviceRecorderHook{
+		name: "body-no-body",
+		preFn: func(r *http.Request, _ *RequestContext) error {
+			r.Body = http.NoBody
+			r.ContentLength = 0
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github/upload", strings.NewReader("PAYLOAD_WITH_LENGTH"))
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+
+	if upstreamGotLen != 0 {
+		t.Errorf("upstream ContentLength = %d, want 0 (hook used http.NoBody)", upstreamGotLen)
+	}
+	if len(upstreamGotBody) != 0 {
+		t.Errorf("upstream received body %q, want empty (hook used http.NoBody)", upstreamGotBody)
+	}
+
+	entries := readAllRequestLogEntries(t, tmpDir, "test-session")
+	if len(entries) != 1 {
+		t.Fatalf("got %d request log entries, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Request.BodySize != 0 {
+		t.Errorf("BodySize = %d, want 0 (hook used http.NoBody)", e.Request.BodySize)
+	}
+	if e.Request.BodyHash != "" {
+		t.Errorf("BodyHash = %q, want empty (hook used http.NoBody)", e.Request.BodyHash)
+	}
+
+	bodyPath := filepath.Join(tmpDir, "test-session", "llm-bodies", e.ID+".json")
+	if _, statErr := os.Stat(bodyPath); !os.IsNotExist(statErr) {
+		t.Errorf("expected no stored body file at %q, got err=%v", bodyPath, statErr)
+	}
+}
+
 // readAllRequestLogEntries reads the request JSONL file for a session and
 // returns every RequestLogEntry. Lives next to the test so it can inspect
 // unexported storage internals if needed.

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -8,9 +9,24 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/agentsh/agentsh/internal/approvals"
 	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/internal/proxy/credsub"
 )
+
+// fakeApprovalsManager is a deterministic HTTPServiceApprovalsManager used
+// by the approval-gating tests for the /svc/ path. It short-circuits the
+// full approvals.Manager pipeline (TTY prompt, TOTP, WebAuthn) and returns
+// a fixed Resolution so tests can pin down the approved/denied branches.
+type fakeApprovalsManager struct {
+	approve bool
+	gotReq  approvals.Request
+}
+
+func (f *fakeApprovalsManager) RequestApproval(ctx context.Context, req approvals.Request) (approvals.Resolution, error) {
+	f.gotReq = req
+	return approvals.Resolution{Approved: f.approve}, nil
+}
 
 func init() {
 	policy.SetAllowInsecureHTTPServiceUpstreamForTest(true)
@@ -82,9 +98,11 @@ func TestServeDeclaredService_Deny(t *testing.T) {
 }
 
 // TestServeDeclaredService_Approve_Returns501 pins down the interim behavior
-// for `approve` rules. Task 10 will replace this stub with the real approval
-// flow; until then, an approve match must return 501 (not 500) so callers
-// can distinguish "not yet implemented" from an internal error.
+// for `approve` rules when no approvals manager is wired. Task 10 replaces
+// the always-501 stub with approvals.Manager consultation, but leaves the
+// manager optional: when the manager is nil (e.g. in a test proxy that
+// never calls SetHTTPServiceApprovals), the handler must still return 501
+// so operators can distinguish "no approval wired" from an internal error.
 func TestServeDeclaredService_Approve_Returns501(t *testing.T) {
 	p := newTestProxyWithHTTPService(t, "https://api.github.com", []policy.HTTPServiceRule{
 		{Name: "approve-foo", Paths: []string{"/foo"}, Decision: "approve"},
@@ -100,6 +118,64 @@ func TestServeDeclaredService_Approve_Returns501(t *testing.T) {
 	body, _ := io.ReadAll(w.Body)
 	if !strings.Contains(string(body), "approval not yet implemented") {
 		t.Errorf("body = %q, want 'approval not yet implemented'", body)
+	}
+}
+
+// TestServeDeclaredService_Approve_Approved pins down that when an
+// approvals manager is wired and returns Approved=true, the request
+// proceeds to the forwarding path and the upstream response is
+// returned to the caller.
+func TestServeDeclaredService_Approve_Approved(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "require-approval", Methods: []string{"POST"}, Paths: []string{"/issues"}, Decision: "approve"},
+	})
+	appr := &fakeApprovalsManager{approve: true}
+	p.SetApprovalsForTest(appr)
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github/issues", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if appr.gotReq.Kind != "http_service" {
+		t.Errorf("approval Kind = %q, want http_service", appr.gotReq.Kind)
+	}
+	if !strings.Contains(appr.gotReq.Target, "github") || !strings.Contains(appr.gotReq.Target, "POST") {
+		t.Errorf("approval Target = %q, want to contain service name and method", appr.gotReq.Target)
+	}
+	if appr.gotReq.SessionID != "test-session" {
+		t.Errorf("approval SessionID = %q, want test-session", appr.gotReq.SessionID)
+	}
+}
+
+// TestServeDeclaredService_Approve_Denied pins down that when an approvals
+// manager is wired and returns Approved=false, the handler must deny with
+// 403 Forbidden and MUST NOT forward the request to the upstream.
+func TestServeDeclaredService_Approve_Denied(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("upstream should not be reached when approval denies")
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "require-approval", Methods: []string{"POST"}, Paths: []string{"/issues"}, Decision: "approve"},
+	})
+	p.SetApprovalsForTest(&fakeApprovalsManager{approve: false})
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github/issues", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%q", w.Code, w.Body.String())
 	}
 }
 

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -1099,6 +1099,164 @@ func TestServeDeclaredService_HookRewritesOnlyRawPath(t *testing.T) {
 	}
 }
 
+// TestServeDeclaredService_LogRedactsInjectedAndCookieHeaders pins down
+// that the declared-service audit log redacts session cookies,
+// upstream-proxy credentials, and HeaderInjectionHook-registered
+// headers — not just the three fixed LLM-path auth headers. Upstream
+// Set-Cookie and Authorization values echoed in responses are also
+// redacted so audit records cannot leak live credentials.
+func TestServeDeclaredService_LogRedactsInjectedAndCookieHeaders(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Set-Cookie", "sid=abc123; Path=/")
+		w.Header().Set("Authorization", "Bearer upstream-leak")
+		w.Header().Set("Proxy-Authenticate", "Basic realm=\"upstream\"")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	defer upstream.Close()
+
+	tmpDir := t.TempDir()
+	storage, err := NewStorage(tmpDir, "test-session", false)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-user", Methods: []string{"GET"}, Paths: []string{"/user"}, Decision: "allow"},
+	})
+	p.SetStorageForTest(storage)
+
+	// Build a credsub table and register a HeaderInjectionHook under
+	// "github" that injects an arbitrary header name (X-Hub-Token) —
+	// must be redacted in logs even though it is not in the shared LLM
+	// auth denylist.
+	tbl := credsub.New()
+	if err := tbl.Add("github",
+		[]byte("FAKE_PLACEHOLDER_12345678"),
+		[]byte("REAL_CREDENTIAL_abcdef012"),
+	); err != nil {
+		t.Fatalf("credsub.Add: %v", err)
+	}
+	p.HookRegistry().Register("github", NewHeaderInjectionHook("github", "X-Hub-Token", "Bearer {{secret}}", tbl))
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/user", nil)
+	req.Header.Set("Cookie", "session=secret123")
+	req.Header.Set("X-Hub-Token", "will-be-replaced")
+	req.Header.Set("Authorization", "Bearer real-key")
+	req.Header.Set("Proxy-Authorization", "Basic abc")
+	req.Header.Set("User-Agent", "test-agent")
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+
+	// Validate request entry redactions.
+	reqEntries := readAllRequestLogEntries(t, tmpDir, "test-session")
+	if len(reqEntries) != 1 {
+		t.Fatalf("got %d request log entries, want 1", len(reqEntries))
+	}
+	reqE := reqEntries[0]
+
+	assertRedacted := func(m map[string][]string, key string) {
+		t.Helper()
+		v, ok := m[key]
+		if !ok {
+			// Try canonical form fallback.
+			v, ok = m[http.CanonicalHeaderKey(key)]
+		}
+		if !ok {
+			t.Errorf("expected header %q in log, not present", key)
+			return
+		}
+		if len(v) == 0 || v[0] != "[REDACTED]" {
+			t.Errorf("header %q = %v, want [REDACTED]", key, v)
+		}
+	}
+
+	assertRedacted(reqE.Request.Headers, "Authorization")
+	assertRedacted(reqE.Request.Headers, "Cookie")
+	assertRedacted(reqE.Request.Headers, "X-Hub-Token")
+	assertRedacted(reqE.Request.Headers, "Proxy-Authorization")
+
+	// Non-sensitive header passes through.
+	if ua, ok := reqE.Request.Headers["User-Agent"]; !ok || len(ua) == 0 || ua[0] != "test-agent" {
+		t.Errorf("User-Agent = %v, want [test-agent]", ua)
+	}
+
+	// Validate response entry redactions: upstream-echoed Authorization
+	// and Set-Cookie must be redacted.
+	respEntries := readAllResponseLogEntries(t, tmpDir, "test-session")
+	if len(respEntries) != 1 {
+		t.Fatalf("got %d response log entries, want 1", len(respEntries))
+	}
+	respE := respEntries[0]
+
+	assertRedacted(respE.Response.Headers, "Set-Cookie")
+	assertRedacted(respE.Response.Headers, "Authorization")
+	assertRedacted(respE.Response.Headers, "Proxy-Authenticate")
+}
+
+// TestServeDeclaredService_LogReflectsPostHookBody pins down that the
+// request audit log records the body AFTER pre-hooks have run. Hooks
+// (notably CredsSubHook) may replace r.Body with post-substitution
+// bytes, and the audit entry must reflect what is actually forwarded
+// upstream — not the pre-substitution bytes the agent originally sent.
+// Otherwise BodySize / BodyHash silently diverge from the upstream
+// request, breaking provenance and audit integrity.
+func TestServeDeclaredService_LogReflectsPostHookBody(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	tmpDir := t.TempDir()
+	storage, err := NewStorage(tmpDir, "test-session", false)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-upload", Methods: []string{"POST"}, Paths: []string{"/upload"}, Decision: "allow"},
+	})
+	p.SetStorageForTest(storage)
+
+	// Hook that replaces r.Body with different-length bytes, to prove
+	// the audit log reflects the post-hook value not the pre-hook value.
+	const postHookBody = "POST_HOOK_BODY"
+	p.HookRegistry().Register("github", &serviceRecorderHook{
+		name: "body-rewriter",
+		preFn: func(r *http.Request, _ *RequestContext) error {
+			r.Body = io.NopCloser(bytes.NewReader([]byte(postHookBody)))
+			r.ContentLength = int64(len(postHookBody))
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github/upload", strings.NewReader("PRE_HOOK_BODY"))
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+
+	entries := readAllRequestLogEntries(t, tmpDir, "test-session")
+	if len(entries) != 1 {
+		t.Fatalf("got %d request log entries, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Request.BodySize != len(postHookBody) {
+		t.Errorf("BodySize = %d, want %d (post-hook body length)", e.Request.BodySize, len(postHookBody))
+	}
+	wantHash := HashBody([]byte(postHookBody))
+	if e.Request.BodyHash != wantHash {
+		t.Errorf("BodyHash = %q, want %q (hash of post-hook body)", e.Request.BodyHash, wantHash)
+	}
+}
+
 func TestServeDeclaredService_LogsRequestAndResponseToStorage(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -66,3 +66,25 @@ func TestServeDeclaredService_Deny(t *testing.T) {
 		t.Errorf("body = %q, want 'no deletes'", body)
 	}
 }
+
+// TestServeDeclaredService_Approve_Returns501 pins down the interim behavior
+// for `approve` rules. Task 10 will replace this stub with the real approval
+// flow; until then, an approve match must return 501 (not 500) so callers
+// can distinguish "not yet implemented" from an internal error.
+func TestServeDeclaredService_Approve_Returns501(t *testing.T) {
+	p := newTestProxyWithHTTPService(t, "https://api.github.com", []policy.HTTPServiceRule{
+		{Name: "approve-foo", Paths: []string{"/foo"}, Decision: "approve"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/foo", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want 501", w.Code)
+	}
+	body, _ := io.ReadAll(w.Body)
+	if !strings.Contains(string(body), "approval not yet implemented") {
+		t.Errorf("body = %q, want 'approval not yet implemented'", body)
+	}
+}

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -250,6 +250,46 @@ func TestServeDeclaredService_Approve_TargetPreservesEncodedPath(t *testing.T) {
 	}
 }
 
+// TestServeDeclaredService_Approve_TargetFallsBackWhenNextByteIsEncoded
+// pins down that the escaped-path prefix strip requires a '/' boundary
+// immediately after the /svc/<name> prefix. When a client percent-encodes
+// the slash after the service segment (e.g. /svc/github%2Fitems), the
+// dispatcher decodes it to /svc/github/items and routes the request to
+// service "github" with rest "/items". The approval Target must match
+// the decoded "/items" that policy evaluation used — NOT the literal
+// strip "%2Fitems" that a naive HasPrefix+TrimPrefix would produce,
+// which would diverge from what the upstream actually receives and
+// mislead the approver about what they're authorizing.
+func TestServeDeclaredService_Approve_TargetFallsBackWhenNextByteIsEncoded(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "require-approval", Methods: []string{"POST"}, Paths: []string{"/items"}, Decision: "approve"},
+	})
+	appr := &fakeApprovalsManager{approve: true}
+	p.SetApprovalsForTest(appr)
+
+	// %2F immediately after the service name. Decoded form is
+	// /svc/github/items so the dispatcher routes to service "github"
+	// with rest "/items", and the POST /items rule evaluates as approve.
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github%2Fitems?force=true", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	// The target MUST use the decoded-and-re-escaped fallback form
+	// ("/items") — not the literal-strip result ("%2Fitems") that a
+	// naive HasPrefix+TrimPrefix would produce.
+	if got, want := appr.gotReq.Target, "github POST /items?force=true"; got != want {
+		t.Errorf("approval Target = %q, want %q", got, want)
+	}
+}
+
 // TestServeDeclaredService_Approve_Denied pins down that when an approvals
 // manager is wired and returns Approved=false, the handler must deny with
 // 403 Forbidden and MUST NOT forward the request to the upstream.

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -1121,6 +1121,7 @@ func TestServeDeclaredService_LogRedactsInjectedAndCookieHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStorage: %v", err)
 	}
+	defer storage.Close()
 
 	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
 		{Name: "allow-user", Methods: []string{"GET"}, Paths: []string{"/user"}, Decision: "allow"},
@@ -1217,6 +1218,7 @@ func TestServeDeclaredService_LogReflectsPostHookBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStorage: %v", err)
 	}
+	defer storage.Close()
 
 	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
 		{Name: "allow-upload", Methods: []string{"POST"}, Paths: []string{"/upload"}, Decision: "allow"},
@@ -1271,6 +1273,7 @@ func TestServeDeclaredService_LogsRequestAndResponseToStorage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStorage: %v", err)
 	}
+	defer storage.Close()
 
 	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
 		{Name: "read-user", Methods: []string{"GET"}, Paths: []string{"/user"}, Decision: "allow"},
@@ -1344,6 +1347,7 @@ func TestServeDeclaredService_StoresPreHookBodyDespitePostHookSubstitution(t *te
 	if err != nil {
 		t.Fatalf("NewStorage: %v", err)
 	}
+	defer storage.Close()
 
 	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
 		{Name: "allow-upload", Methods: []string{"POST"}, Paths: []string{"/upload"}, Decision: "allow"},
@@ -1420,6 +1424,7 @@ func TestServeDeclaredService_HookNilsBody_LogsZeroAndStoresNothing(t *testing.T
 	if err != nil {
 		t.Fatalf("NewStorage: %v", err)
 	}
+	defer storage.Close()
 
 	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
 		{Name: "allow-upload", Methods: []string{"POST"}, Paths: []string{"/upload"}, Decision: "allow"},
@@ -1484,6 +1489,7 @@ func TestServeDeclaredService_HookNilsBodyLeavesStaleContentLength_Normalized(t 
 	if err != nil {
 		t.Fatalf("NewStorage: %v", err)
 	}
+	defer storage.Close()
 
 	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
 		{Name: "allow-upload", Methods: []string{"POST"}, Paths: []string{"/upload"}, Decision: "allow"},
@@ -1558,6 +1564,7 @@ func TestServeDeclaredService_HookSetsHttpNoBody_Normalized(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewStorage: %v", err)
 	}
+	defer storage.Close()
 
 	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
 		{Name: "allow-upload", Methods: []string{"POST"}, Paths: []string{"/upload"}, Decision: "allow"},

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -133,3 +133,111 @@ func TestServeDeclaredService_Allow_Forwards(t *testing.T) {
 		t.Errorf("response Content-Type = %q, want application/json", ct)
 	}
 }
+
+// TestServeDeclaredService_PreservesEscapedPath pins down that percent-encoded
+// bytes in the request path reach the upstream unchanged. Before the fix,
+// /svc/github/items/a%2Fb was reconstructed from the decoded URL.Path as
+// /items/a/b — a different resource.
+func TestServeDeclaredService_PreservesEscapedPath(t *testing.T) {
+	var gotEscaped, gotDecoded string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotEscaped = r.URL.EscapedPath()
+		gotDecoded = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-items", Paths: []string{"/items/**"}, Decision: "allow"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/items/a%2Fb", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if gotEscaped != "/items/a%2Fb" {
+		t.Errorf("upstream EscapedPath = %q, want /items/a%%2Fb", gotEscaped)
+	}
+	if gotDecoded != "/items/a/b" {
+		t.Errorf("upstream Path = %q, want /items/a/b", gotDecoded)
+	}
+}
+
+// TestServeDeclaredService_StripsConnectionNominatedRequestHeaders pins down
+// that headers listed in the client's Connection header are dropped before
+// forwarding upstream, in addition to the fixed hop-by-hop set.
+// RFC 7230 §6.1: any token in Connection is hop-by-hop for this hop.
+func TestServeDeclaredService_StripsConnectionNominatedRequestHeaders(t *testing.T) {
+	var gotHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeaders = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-foo", Paths: []string{"/foo"}, Decision: "allow"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/foo", nil)
+	req.Header.Set("Connection", "X-Sensitive, close")
+	req.Header.Set("X-Sensitive", "secret")
+	req.Header.Set("X-Allowed", "ok")
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if v := gotHeaders.Get("X-Sensitive"); v != "" {
+		t.Errorf("upstream X-Sensitive = %q, want empty (stripped by Connection)", v)
+	}
+	if v := gotHeaders.Get("Connection"); v != "" {
+		t.Errorf("upstream Connection = %q, want empty (hop-by-hop)", v)
+	}
+	if v := gotHeaders.Get("X-Allowed"); v != "ok" {
+		t.Errorf("upstream X-Allowed = %q, want ok (end-to-end header dropped)", v)
+	}
+}
+
+// TestServeDeclaredService_StripsHopByHopResponseHeaders pins down that
+// hop-by-hop headers and headers nominated by the upstream's Connection
+// header are stripped from the response copied back to the caller. Real
+// headers like X-Request-Id must pass through.
+func TestServeDeclaredService_StripsHopByHopResponseHeaders(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Connection", "X-Upstream-Secret")
+		w.Header().Set("X-Upstream-Secret", "shh")
+		w.Header().Set("Keep-Alive", "timeout=5")
+		w.Header().Set("X-Request-Id", "abc")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-foo", Paths: []string{"/foo"}, Decision: "allow"},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/foo", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if v := w.Header().Get("X-Request-Id"); v != "abc" {
+		t.Errorf("response X-Request-Id = %q, want abc (end-to-end header dropped)", v)
+	}
+	if v := w.Header().Get("X-Upstream-Secret"); v != "" {
+		t.Errorf("response X-Upstream-Secret = %q, want empty (Connection-nominated)", v)
+	}
+	if v := w.Header().Get("Keep-Alive"); v != "" {
+		t.Errorf("response Keep-Alive = %q, want empty (hop-by-hop)", v)
+	}
+	if v := w.Header().Get("Connection"); v != "" {
+		t.Errorf("response Connection = %q, want empty (hop-by-hop)", v)
+	}
+}

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -1315,6 +1315,154 @@ func TestServeDeclaredService_LogsRequestAndResponseToStorage(t *testing.T) {
 	}
 }
 
+// TestServeDeclaredService_StoresPreHookBodyDespitePostHookSubstitution
+// pins down that on-disk body storage reflects the PRE-hook body (what
+// the agent originally sent) while the audit record's BodySize/BodyHash
+// reflect the POST-hook body (what was actually forwarded upstream).
+//
+// The split matters for CredsSubHook, which replaces fake-credential
+// placeholders in the agent's request with the real upstream secret.
+// If on-disk storage captured the post-hook bytes, every llm-bodies file
+// would leak the real credential to disk — exactly what credsub exists
+// to prevent. Conversely, the audit BodyHash must cover what was
+// forwarded so provenance/integrity stamps describe the actual upstream
+// payload, not the agent's typed input.
+func TestServeDeclaredService_StoresPreHookBodyDespitePostHookSubstitution(t *testing.T) {
+	// Upstream echoes the body it receives so we can sanity-check that
+	// the hook's replacement really did reach the wire.
+	var upstreamGot []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamGot, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(upstreamGot)
+	}))
+	defer upstream.Close()
+
+	// storeBodies: true so StoreRequestBody actually writes to disk.
+	tmpDir := t.TempDir()
+	storage, err := NewStorage(tmpDir, "test-session", true)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-upload", Methods: []string{"POST"}, Paths: []string{"/upload"}, Decision: "allow"},
+	})
+	p.SetStorageForTest(storage)
+
+	const preHookBody = "FAKE_PLACEHOLDER"
+	const postHookBody = "REAL_SECRET_XYZ"
+	p.HookRegistry().Register("github", &serviceRecorderHook{
+		name: "body-replace",
+		preFn: func(r *http.Request, _ *RequestContext) error {
+			r.Body = io.NopCloser(bytes.NewReader([]byte(postHookBody)))
+			r.ContentLength = int64(len(postHookBody))
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github/upload", strings.NewReader(preHookBody))
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	// Sanity: upstream really did see the post-hook body.
+	if string(upstreamGot) != postHookBody {
+		t.Fatalf("upstream received %q, want %q (hook did not take effect)", upstreamGot, postHookBody)
+	}
+
+	// Audit record must describe the FORWARDED body (post-hook).
+	entries := readAllRequestLogEntries(t, tmpDir, "test-session")
+	if len(entries) != 1 {
+		t.Fatalf("got %d request log entries, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Request.BodySize != len(postHookBody) {
+		t.Errorf("BodySize = %d, want %d (post-hook body length)", e.Request.BodySize, len(postHookBody))
+	}
+	wantHash := HashBody([]byte(postHookBody))
+	if e.Request.BodyHash != wantHash {
+		t.Errorf("BodyHash = %q, want %q (hash of post-hook body)", e.Request.BodyHash, wantHash)
+	}
+
+	// On-disk stored body must reflect the PRE-hook bytes. We pull the
+	// request ID out of the audit entry (storage writes the body file
+	// keyed on that ID).
+	bodyPath := filepath.Join(tmpDir, "test-session", "llm-bodies", e.ID+".json")
+	stored, err := os.ReadFile(bodyPath)
+	if err != nil {
+		t.Fatalf("read stored body %q: %v", bodyPath, err)
+	}
+	if string(stored) != preHookBody {
+		t.Errorf("stored body = %q, want %q (pre-hook body)", stored, preHookBody)
+	}
+	if bytes.Contains(stored, []byte(postHookBody)) {
+		t.Errorf("stored body leaked post-hook content %q: got %q", postHookBody, stored)
+	}
+}
+
+// TestServeDeclaredService_HookNilsBody_LogsZeroAndStoresNothing pins
+// down what happens when a pre-hook drops the request body entirely by
+// setting r.Body = nil. In that case nothing is forwarded upstream, so
+// the audit record must show BodySize=0/BodyHash="" and no file must
+// land on disk under this request ID — otherwise the audit record and
+// the on-disk copy describe a body that never actually went anywhere.
+func TestServeDeclaredService_HookNilsBody_LogsZeroAndStoresNothing(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	tmpDir := t.TempDir()
+	storage, err := NewStorage(tmpDir, "test-session", true)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "allow-upload", Methods: []string{"POST"}, Paths: []string{"/upload"}, Decision: "allow"},
+	})
+	p.SetStorageForTest(storage)
+
+	p.HookRegistry().Register("github", &serviceRecorderHook{
+		name: "body-drop",
+		preFn: func(r *http.Request, _ *RequestContext) error {
+			r.Body = nil
+			r.ContentLength = 0
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github/upload", strings.NewReader("PAYLOAD"))
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+
+	entries := readAllRequestLogEntries(t, tmpDir, "test-session")
+	if len(entries) != 1 {
+		t.Fatalf("got %d request log entries, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.Request.BodySize != 0 {
+		t.Errorf("BodySize = %d, want 0 (hook dropped body)", e.Request.BodySize)
+	}
+	if e.Request.BodyHash != "" {
+		t.Errorf("BodyHash = %q, want empty (hook dropped body)", e.Request.BodyHash)
+	}
+
+	// No file should exist in llm-bodies for this request ID — the hook
+	// dropped the body, so there is nothing to persist.
+	bodyPath := filepath.Join(tmpDir, "test-session", "llm-bodies", e.ID+".json")
+	if _, statErr := os.Stat(bodyPath); !os.IsNotExist(statErr) {
+		t.Errorf("expected no stored body file at %q, got err=%v", bodyPath, statErr)
+	}
+}
+
 // readAllRequestLogEntries reads the request JSONL file for a session and
 // returns every RequestLogEntry. Lives next to the test so it can inspect
 // unexported storage internals if needed.

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -1,11 +1,15 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -1093,4 +1097,132 @@ func TestServeDeclaredService_HookRewritesOnlyRawPath(t *testing.T) {
 	if gotEscaped != "/items/%61b" {
 		t.Errorf("upstream EscapedPath = %q, want /items/%%61b (hook-written RawPath clobbered?)", gotEscaped)
 	}
+}
+
+func TestServeDeclaredService_LogsRequestAndResponseToStorage(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		io.WriteString(w, `{"login":"octocat"}`)
+	}))
+	defer upstream.Close()
+
+	// Point storage at a temp dir so we can read back the JSONL.
+	tmpDir := t.TempDir()
+	storage, err := NewStorage(tmpDir, "test-session", false)
+	if err != nil {
+		t.Fatalf("NewStorage: %v", err)
+	}
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "read-user", Methods: []string{"GET"}, Paths: []string{"/user"}, Decision: "allow"},
+	})
+	p.SetStorageForTest(storage)
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/user", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	entries := readAllRequestLogEntries(t, tmpDir, "test-session")
+	if len(entries) != 1 {
+		t.Fatalf("got %d log entries, want 1", len(entries))
+	}
+	e := entries[0]
+	if e.ServiceKind != "http_service" {
+		t.Errorf("ServiceKind = %q, want http_service", e.ServiceKind)
+	}
+	if e.ServiceName != "github" {
+		t.Errorf("ServiceName = %q, want github", e.ServiceName)
+	}
+	if e.RuleName != "read-user" {
+		t.Errorf("RuleName = %q, want read-user", e.RuleName)
+	}
+	if e.Request.Method != "GET" || e.Request.Path != "/user" {
+		t.Errorf("Request = %+v, want GET /user", e.Request)
+	}
+	if e.Dialect != "" {
+		t.Errorf("Dialect = %q, want empty for http_service", e.Dialect)
+	}
+
+	resps := readAllResponseLogEntries(t, tmpDir, "test-session")
+	if len(resps) != 1 {
+		t.Fatalf("got %d response entries, want 1", len(resps))
+	}
+	if resps[0].Response.Status != http.StatusOK {
+		t.Errorf("response status = %d, want 200", resps[0].Response.Status)
+	}
+}
+
+// readAllRequestLogEntries reads the request JSONL file for a session and
+// returns every RequestLogEntry. Lives next to the test so it can inspect
+// unexported storage internals if needed.
+//
+// Note: Storage writes requests AND responses to the same file
+// (llm-requests.jsonl — see internal/proxy/storage.go). We discriminate by
+// looking at which JSON fields are populated: RequestLogEntry has the
+// "request" object, ResponseLogEntry has the "response" object and a
+// "request_id" field.
+func readAllRequestLogEntries(t *testing.T, basePath, sessionID string) []RequestLogEntry {
+	t.Helper()
+	lines := readLogLines(t, basePath, sessionID)
+	var out []RequestLogEntry
+	for _, line := range lines {
+		// Skip response entries by peeking at field names.
+		var probe map[string]json.RawMessage
+		if err := json.Unmarshal(line, &probe); err != nil {
+			t.Fatalf("unmarshal probe: %v", err)
+		}
+		if _, isResponse := probe["request_id"]; isResponse {
+			continue
+		}
+		var e RequestLogEntry
+		if err := json.Unmarshal(line, &e); err != nil {
+			t.Fatalf("decode request log: %v", err)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func readAllResponseLogEntries(t *testing.T, basePath, sessionID string) []ResponseLogEntry {
+	t.Helper()
+	lines := readLogLines(t, basePath, sessionID)
+	var out []ResponseLogEntry
+	for _, line := range lines {
+		var probe map[string]json.RawMessage
+		if err := json.Unmarshal(line, &probe); err != nil {
+			t.Fatalf("unmarshal probe: %v", err)
+		}
+		if _, isResponse := probe["request_id"]; !isResponse {
+			continue
+		}
+		var e ResponseLogEntry
+		if err := json.Unmarshal(line, &e); err != nil {
+			t.Fatalf("decode response log: %v", err)
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// readLogLines reads the shared JSONL log file line-by-line.
+func readLogLines(t *testing.T, basePath, sessionID string) [][]byte {
+	t.Helper()
+	path := filepath.Join(basePath, sessionID, "llm-requests.jsonl")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	var lines [][]byte
+	for _, l := range bytes.Split(data, []byte("\n")) {
+		if len(l) == 0 {
+			continue
+		}
+		lines = append(lines, l)
+	}
+	return lines
 }

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -345,6 +345,85 @@ func TestServeDeclaredService_StripsMultipleConnectionRequestHeaders(t *testing.
 	}
 }
 
+// TestServeDeclaredService_HooksRunPerService pins down that pre-hooks
+// registered under a declared service's name are invoked in the /svc/
+// forwarding path, and that the RequestContext is populated with the
+// correct ServiceName. This is the knob that makes per-service header
+// injection (HeaderInjectionHook) actually take effect at runtime.
+func TestServeDeclaredService_HooksRunPerService(t *testing.T) {
+	var gotAuth string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "get", Methods: []string{"GET"}, Paths: []string{"/**"}, Decision: "allow"},
+	})
+
+	// Register a hook under "github" that sets the Authorization header.
+	p.HookRegistry().Register("github", &serviceRecorderHook{
+		name: "fake-injector",
+		preFn: func(r *http.Request, ctx *RequestContext) error {
+			r.Header.Set("Authorization", "Bearer real-token")
+			if ctx.ServiceName != "github" {
+				t.Errorf("ctx.ServiceName = %q, want github", ctx.ServiceName)
+			}
+			return nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/user", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if gotAuth != "Bearer real-token" {
+		t.Errorf("upstream Authorization = %q, want 'Bearer real-token'", gotAuth)
+	}
+}
+
+// TestServeDeclaredService_HookAbortError_ReturnsStatusCode pins down that
+// returning a *HookAbortError from a pre-hook in the /svc/ path causes the
+// proxy to respond with the error's StatusCode and Message instead of
+// forwarding the request upstream.
+func TestServeDeclaredService_HookAbortError_ReturnsStatusCode(t *testing.T) {
+	var upstreamCalled bool
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "get", Methods: []string{"GET"}, Paths: []string{"/**"}, Decision: "allow"},
+	})
+
+	p.HookRegistry().Register("github", &serviceRecorderHook{
+		name: "abort",
+		preFn: func(r *http.Request, ctx *RequestContext) error {
+			return &HookAbortError{StatusCode: http.StatusForbidden, Message: "blocked by hook"}
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://127.0.0.1/svc/github/user", nil)
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if upstreamCalled {
+		t.Error("upstream should not have been called after hook abort")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%q", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !strings.Contains(body, "blocked by hook") {
+		t.Errorf("body = %q, want 'blocked by hook'", body)
+	}
+}
+
 // TestServeDeclaredService_StripsMultipleConnectionResponseHeaders is the
 // response-side equivalent: when the upstream sends Connection on two
 // lines, both lines' nominated headers must be dropped before copying

--- a/internal/proxy/declared_service_test.go
+++ b/internal/proxy/declared_service_test.go
@@ -156,6 +156,67 @@ func TestServeDeclaredService_Approve_Approved(t *testing.T) {
 	}
 }
 
+// TestServeDeclaredService_Approve_DoesNotSetBogusCommandID pins down that
+// the approval request's CommandID is NOT populated with the proxy's
+// per-request UUID. Declared-service requests do not originate from a
+// single session command — they come from arbitrary HTTP calls the agent
+// makes — so there is no real command to attach, and populating the field
+// with the proxy's internal request ID corrupts downstream command-level
+// correlation. The field must be left empty until a real session command
+// ID can be plumbed through.
+func TestServeDeclaredService_Approve_DoesNotSetBogusCommandID(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "require-approval", Methods: []string{"POST"}, Paths: []string{"/issues"}, Decision: "approve"},
+	})
+	appr := &fakeApprovalsManager{approve: true}
+	p.SetApprovalsForTest(appr)
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github/issues", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if appr.gotReq.CommandID != "" {
+		t.Errorf("approval CommandID = %q, want empty (declared-service requests have no session command)", appr.gotReq.CommandID)
+	}
+}
+
+// TestServeDeclaredService_Approve_TargetIncludesQueryString pins down that
+// the approval Target includes the raw query string when present, so the
+// approver sees the full request the client is making — not just the path
+// segment. Hiding the query string would obscure material details about
+// what's being approved (e.g. a ?force=true override).
+func TestServeDeclaredService_Approve_TargetIncludesQueryString(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	p := newTestProxyWithHTTPService(t, upstream.URL, []policy.HTTPServiceRule{
+		{Name: "require-approval", Methods: []string{"POST"}, Paths: []string{"/issues"}, Decision: "approve"},
+	})
+	appr := &fakeApprovalsManager{approve: true}
+	p.SetApprovalsForTest(appr)
+
+	req := httptest.NewRequest(http.MethodPost, "http://127.0.0.1/svc/github/issues?force=true", strings.NewReader("{}"))
+	w := httptest.NewRecorder()
+	p.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%q", w.Code, w.Body.String())
+	}
+	if !strings.Contains(appr.gotReq.Target, "?force=true") {
+		t.Errorf("approval Target = %q, want to contain '?force=true'", appr.gotReq.Target)
+	}
+}
+
 // TestServeDeclaredService_Approve_Denied pins down that when an approvals
 // manager is wired and returns Approved=false, the handler must deny with
 // 403 Forbidden and MUST NOT forward the request to the upstream.

--- a/internal/proxy/hooks.go
+++ b/internal/proxy/hooks.go
@@ -192,3 +192,28 @@ func (r *Registry) ApplyPostHooks(serviceName string, resp *http.Response, ctx *
 	}
 	return firstErr
 }
+
+// InjectedHeaderNamesForService returns the set of header names that
+// HeaderInjectionHook entries registered for serviceName will write.
+// Declared-service request/response logging consults this list so the
+// audit sanitizer can redact the injected values even when the header
+// name is not in the fixed auth denylist. Includes hooks registered
+// under the empty service name (which run globally).
+func (r *Registry) InjectedHeaderNamesForService(serviceName string) []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []string
+	for _, h := range r.hooks[""] {
+		if hi, ok := h.(*HeaderInjectionHook); ok {
+			out = append(out, hi.HeaderName())
+		}
+	}
+	if serviceName != "" {
+		for _, h := range r.hooks[serviceName] {
+			if hi, ok := h.(*HeaderInjectionHook); ok {
+				out = append(out, hi.HeaderName())
+			}
+		}
+	}
+	return out
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -14,12 +14,14 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/mcpinspect"
 	"github.com/agentsh/agentsh/internal/mcpregistry"
+	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/internal/proxy/services"
 )
 
@@ -77,7 +79,14 @@ type Proxy struct {
 
 	server   *http.Server
 	listener net.Listener
-	mu       sync.Mutex
+	// listenerAddr is the bound address of listener as a string. Captured
+	// once in Start so EnvVars can build base URLs without racing Stop.
+	listenerAddr string
+	// httpServices holds the declared http_services from policy. Used by
+	// EnvVars to emit one <NAME>_API_URL env var per entry. Replaced whole
+	// by SetHTTPServices — never appended in place.
+	httpServices []policy.HTTPService
+	mu           sync.Mutex
 }
 
 // New creates a new LLM proxy.
@@ -249,6 +258,7 @@ func (p *Proxy) Start(ctx context.Context) error {
 		return fmt.Errorf("listen: %w", err)
 	}
 	p.listener = listener
+	p.listenerAddr = listener.Addr().String()
 
 	p.server = &http.Server{
 		Handler:      p,
@@ -668,21 +678,55 @@ func parseURL(s string) (*url.URL, error) {
 	return url.Parse(s)
 }
 
+// SetHTTPServices stores the declared HTTP services for env var injection.
+// Called once during proxy startup in app.go. Thread-safe. The slice is
+// stored as-is — SetHTTPServices replaces it whole on each call and
+// EnvVars snapshots it under lock, so no in-place mutation is safe.
+func (p *Proxy) SetHTTPServices(svcs []policy.HTTPService) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.httpServices = svcs
+}
+
+// setAddrForTest lets tests populate the listener address without
+// actually binding a socket. Unexported to keep it out of the public API.
+func (p *Proxy) setAddrForTest(addr string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.listenerAddr = addr
+}
+
 // EnvVars returns the environment variables to set for the agent process.
+// In addition to the LLM base URLs, this includes one <NAME>_API_URL entry
+// per declared http_services entry, each pointing at /svc/<name> on the
+// proxy listener so cooperating child processes can route through the
+// gateway via a base URL override.
 func (p *Proxy) EnvVars() map[string]string {
-	addr := p.Addr()
-	if addr == nil {
+	p.mu.Lock()
+	addr := p.listenerAddr
+	svcs := p.httpServices
+	p.mu.Unlock()
+
+	if addr == "" {
 		return nil
 	}
 
-	baseURL := fmt.Sprintf("http://%s", addr.String())
-	return map[string]string{
+	baseURL := "http://" + addr
+	env := map[string]string{
 		"ANTHROPIC_BASE_URL": baseURL,
 		"OPENAI_BASE_URL":    baseURL,
 		// Session ID is passed so agent can include it in headers
 		// for correlation when using external proxy
 		"AGENTSH_SESSION_ID": p.cfg.SessionID,
 	}
+	for _, svc := range svcs {
+		name := svc.ExposeAs
+		if name == "" {
+			name = strings.ToUpper(svc.Name) + "_API_URL"
+		}
+		env[name] = baseURL + "/svc/" + svc.Name
+	}
+	return env
 }
 
 // ProxyStatus contains the complete status of the proxy.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -94,6 +94,11 @@ type Proxy struct {
 	// requests to their upstreams. nil means use http.DefaultTransport.
 	// Tests inject a fake via SetHTTPServiceTransportForTest.
 	httpSvcTransport http.RoundTripper
+	// httpSvcApprovals gates the `approve` decision in the declared-service
+	// forwarding path. When nil, approve falls through to a 501 (operator
+	// hasn't wired a real manager yet). Wired in production from app.go via
+	// SetHTTPServiceApprovals. Tests install a fake via SetApprovalsForTest.
+	httpSvcApprovals HTTPServiceApprovalsManager
 	mu               sync.Mutex
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -86,6 +86,10 @@ type Proxy struct {
 	// EnvVars to emit one <NAME>_API_URL env var per entry. Replaced whole
 	// by SetHTTPServices — never appended in place.
 	httpServices []policy.HTTPService
+	// policyEngine is wired by SetPolicyEngine during startup and is the
+	// source of truth for http_services dispatch in ServeHTTP. Reads are
+	// serialized with mu so dispatch cannot race with a late configure.
+	policyEngine *policy.Engine
 	mu           sync.Mutex
 }
 
@@ -310,6 +314,18 @@ func (p *Proxy) Addr() net.Addr {
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	requestID := generateRequestID()
 	startTime := time.Now()
+
+	// Declared HTTP service dispatch — check before LLM dialect detection.
+	if name, rest, ok := p.declaredService(r.URL.Path); ok {
+		p.serveDeclaredService(w, r, name, rest, requestID, startTime)
+		return
+	} else if name != "" {
+		// Path starts with /svc/<name>/ but the service is not declared.
+		// Return a dedicated 404 instead of falling through to dialect
+		// detection, so operators aren't confused by "unknown LLM dialect".
+		http.Error(w, "no such service", http.StatusNotFound)
+		return
+	}
 
 	// Detect dialect
 	dialect := p.detector.Detect(r)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -90,7 +90,11 @@ type Proxy struct {
 	// source of truth for http_services dispatch in ServeHTTP. Reads are
 	// serialized with mu so dispatch cannot race with a late configure.
 	policyEngine *policy.Engine
-	mu           sync.Mutex
+	// httpSvcTransport is the RoundTripper used to forward declared-service
+	// requests to their upstreams. nil means use http.DefaultTransport.
+	// Tests inject a fake via SetHTTPServiceTransportForTest.
+	httpSvcTransport http.RoundTripper
+	mu               sync.Mutex
 }
 
 // New creates a new LLM proxy.

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/mcpinspect"
 	"github.com/agentsh/agentsh/internal/mcpregistry"
+	"github.com/agentsh/agentsh/internal/policy"
 )
 
 // TestProxy_AnthropicPassthrough tests that requests are correctly
@@ -1962,5 +1963,35 @@ func TestProxyRateLimitBlocksToolCall(t *testing.T) {
 	}
 	if ev.SessionID != "test-ratelimit-block" {
 		t.Errorf("session_id: got %q, want %q", ev.SessionID, "test-ratelimit-block")
+	}
+}
+
+// TestEnvVars_IncludesDeclaredServices verifies that EnvVars emits one
+// <NAME>_API_URL entry per declared http_service, pointing at the
+// /svc/<name> path prefix on the proxy listener. The existing LLM base
+// URLs must continue to be set.
+func TestEnvVars_IncludesDeclaredServices(t *testing.T) {
+	cfg := Config{SessionID: "test-session"}
+	p, err := New(cfg, "", nil)
+	if err != nil {
+		t.Fatalf("New() error: %v", err)
+	}
+	// Simulate the proxy having started with a bound listener.
+	p.setAddrForTest("127.0.0.1:12345")
+
+	p.SetHTTPServices([]policy.HTTPService{
+		{Name: "github", Upstream: "https://api.github.com", ExposeAs: "GITHUB_API_URL"},
+		{Name: "stripe", Upstream: "https://api.stripe.com"},
+	})
+
+	env := p.EnvVars()
+	if got := env["GITHUB_API_URL"]; got != "http://127.0.0.1:12345/svc/github" {
+		t.Errorf("GITHUB_API_URL = %q", got)
+	}
+	if got := env["STRIPE_API_URL"]; got != "http://127.0.0.1:12345/svc/stripe" {
+		t.Errorf("STRIPE_API_URL = %q", got)
+	}
+	if _, ok := env["ANTHROPIC_BASE_URL"]; !ok {
+		t.Error("ANTHROPIC_BASE_URL should still be set")
 	}
 }

--- a/internal/proxy/storage.go
+++ b/internal/proxy/storage.go
@@ -14,12 +14,15 @@ import (
 
 // RequestLogEntry represents a logged request.
 type RequestLogEntry struct {
-	ID        string      `json:"id"`
-	SessionID string      `json:"session_id"`
-	Timestamp time.Time   `json:"timestamp"`
-	Dialect   Dialect     `json:"dialect"`
-	Request   RequestInfo `json:"request"`
-	DLP       *DLPInfo    `json:"dlp,omitempty"`
+	ID          string      `json:"id"`
+	SessionID   string      `json:"session_id"`
+	Timestamp   time.Time   `json:"timestamp"`
+	Dialect     Dialect     `json:"dialect,omitempty"`
+	ServiceKind string      `json:"service_kind,omitempty"` // "llm" or "http_service"
+	ServiceName string      `json:"service_name,omitempty"` // e.g. "github"
+	RuleName    string      `json:"rule_name,omitempty"`    // e.g. "read-issues"
+	Request     RequestInfo `json:"request"`
+	DLP         *DLPInfo    `json:"dlp,omitempty"`
 }
 
 // RequestInfo contains request details.

--- a/internal/report/llm_stats.go
+++ b/internal/report/llm_stats.go
@@ -15,16 +15,21 @@ type LLMLogEntry struct {
 	SessionID string `json:"session_id"`
 
 	// Request-specific fields
-	ID      string         `json:"id,omitempty"`
-	Dialect string         `json:"dialect,omitempty"`
-	Request *LLMRequestInfo `json:"request,omitempty"`
-	DLP     *LLMDLPInfo    `json:"dlp,omitempty"`
+	ID      string          `json:"id,omitempty"`
+	Dialect string          `json:"dialect,omitempty"`
+	// ServiceKind discriminates LLM traffic from declared-service
+	// (http_service) traffic sharing the same JSONL file. Entries with
+	// ServiceKind=="http_service" are skipped by this parser so they
+	// don't show up as "Unknown" provider rows in session reports.
+	ServiceKind string          `json:"service_kind,omitempty"`
+	Request     *LLMRequestInfo `json:"request,omitempty"`
+	DLP         *LLMDLPInfo     `json:"dlp,omitempty"`
 
 	// Response-specific fields
-	RequestID  string          `json:"request_id,omitempty"`
-	DurationMs int64           `json:"duration_ms,omitempty"`
+	RequestID  string           `json:"request_id,omitempty"`
+	DurationMs int64            `json:"duration_ms,omitempty"`
 	Response   *LLMResponseInfo `json:"response,omitempty"`
-	Usage      *LLMUsage       `json:"usage,omitempty"`
+	Usage      *LLMUsage        `json:"usage,omitempty"`
 }
 
 // LLMRequestInfo contains request details from the log.
@@ -92,6 +97,10 @@ func ParseLLMRequestsFile(path string) (*LLMUsageStats, *DLPEventStats, error) {
 
 	// Track request dialects for correlating responses
 	requestDialects := make(map[string]string)
+	// Track request IDs whose request-side entry was skipped because
+	// it was declared-service (http_service) traffic, so their
+	// correlated responses can also be skipped.
+	skipIDs := make(map[string]bool)
 
 	scanner := bufio.NewScanner(file)
 	// Set a larger buffer for potentially large log lines
@@ -105,6 +114,13 @@ func ParseLLMRequestsFile(path string) (*LLMUsageStats, *DLPEventStats, error) {
 		}
 
 		if entry.isRequest() {
+			// Declared-service traffic shares this file but is NOT
+			// LLM — skip it so it doesn't show up as an "Unknown"
+			// provider and inflate LLM totals.
+			if entry.ServiceKind == "http_service" {
+				skipIDs[entry.ID] = true
+				continue
+			}
 			// Store dialect for this request
 			requestDialects[entry.ID] = entry.Dialect
 
@@ -115,6 +131,9 @@ func ParseLLMRequestsFile(path string) (*LLMUsageStats, *DLPEventStats, error) {
 				}
 			}
 		} else if entry.isResponse() {
+			if skipIDs[entry.RequestID] {
+				continue
+			}
 			// Look up the dialect from the original request
 			dialect := requestDialects[entry.RequestID]
 			if dialect == "" {

--- a/internal/report/llm_stats_test.go
+++ b/internal/report/llm_stats_test.go
@@ -231,6 +231,51 @@ func TestParseLLMRequestsFile(t *testing.T) {
 	})
 }
 
+// TestParseLLMRequestsFile_SkipsHTTPServiceEntries pins down that
+// entries with service_kind="http_service" are ignored by the session
+// report reader. Declared-service traffic shares the llm-requests.jsonl
+// file with real LLM traffic but must not appear as an "Unknown"
+// provider row or contribute to LLM totals.
+func TestParseLLMRequestsFile_SkipsHTTPServiceEntries(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "llm-requests.jsonl")
+
+	// One LLM pair (anthropic) and one http_service pair (github).
+	testData := `{"id":"req_001","session_id":"sess_123","dialect":"anthropic","request":{"method":"POST","path":"/v1/messages"}}
+{"request_id":"req_001","session_id":"sess_123","duration_ms":1500,"response":{"status":200},"usage":{"input_tokens":150,"output_tokens":892}}
+{"id":"req_http_1","session_id":"sess_123","service_kind":"http_service","service_name":"github","request":{"method":"GET","path":"/user"}}
+{"request_id":"req_http_1","session_id":"sess_123","duration_ms":500,"response":{"status":200}}
+`
+	if err := os.WriteFile(logPath, []byte(testData), 0600); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+
+	llmStats, _, err := ParseLLMRequestsFile(logPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if llmStats == nil {
+		t.Fatal("expected llmStats to be populated")
+	}
+
+	if llmStats.Total.Requests != 1 {
+		t.Errorf("Total.Requests = %d, want 1 (http_service skipped)", llmStats.Total.Requests)
+	}
+	if len(llmStats.Providers) != 1 {
+		t.Fatalf("Providers = %+v, want exactly 1 entry", llmStats.Providers)
+	}
+	if llmStats.Providers[0].Provider != "Anthropic" {
+		t.Errorf("Providers[0] = %q, want Anthropic", llmStats.Providers[0].Provider)
+	}
+	// Explicitly: no "Unknown" bucket from the http_service orphan.
+	for _, p := range llmStats.Providers {
+		if p.Provider == "Unknown" {
+			t.Errorf("found Unknown provider from http_service traffic: %+v", p)
+		}
+	}
+}
+
 func TestFormatProviderName(t *testing.T) {
 	tests := []struct {
 		dialect string

--- a/internal/session/llmproxy.go
+++ b/internal/session/llmproxy.go
@@ -178,22 +178,48 @@ func StartLLMProxy(
 	return proxyURL, closeFn, nil
 }
 
+// proxyEnvVarer is the minimal interface that Session uses to fetch
+// env vars from the proxy instance. The concrete type is *proxy.Proxy;
+// Session holds it as interface{} to avoid an import cycle, so we
+// type-assert against this local interface at read time.
+type proxyEnvVarer interface {
+	EnvVars() map[string]string
+}
+
 // LLMProxyEnvVars returns the environment variables that should be set for
 // the agent process to use the embedded LLM proxy.
 //
-// Returns nil if no LLM proxy is configured for the session.
+// When a proxy instance is attached to the session, this delegates to the
+// proxy's EnvVars() so declared http_services (*_API_URL) are included.
+// Falls back to the three legacy LLM base URLs when no proxy instance is
+// attached (shouldn't happen in production, preserved for test paths that
+// call SetLLMProxy without SetProxyInstance).
+//
+// Returns nil if no LLM proxy URL is configured for the session.
 func (s *Session) LLMProxyEnvVars() map[string]string {
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	proxyURL := s.llmProxyURL
+	proxyInst := s.llmProxy
+	sessID := s.ID
+	s.mu.Unlock()
 
-	if s.llmProxyURL == "" {
+	if proxyURL == "" {
 		return nil
 	}
 
+	// Prefer the proxy's own env var builder — it includes the legacy
+	// LLM URLs plus the declared http_services URLs.
+	if p, ok := proxyInst.(proxyEnvVarer); ok {
+		if env := p.EnvVars(); env != nil {
+			return env
+		}
+	}
+
+	// Fallback for sessions with a URL but no attached proxy instance.
 	return map[string]string{
-		"ANTHROPIC_BASE_URL": s.llmProxyURL,
-		"OPENAI_BASE_URL":    s.llmProxyURL,
-		"AGENTSH_SESSION_ID": s.ID,
+		"ANTHROPIC_BASE_URL": proxyURL,
+		"OPENAI_BASE_URL":    proxyURL,
+		"AGENTSH_SESSION_ID": sessID,
 	}
 }
 

--- a/internal/session/llmproxy_test.go
+++ b/internal/session/llmproxy_test.go
@@ -173,6 +173,83 @@ func TestSession_LLMProxyEnvVars(t *testing.T) {
 	}
 }
 
+// fakeProxyEnvVarer is a test double that satisfies the local proxyEnvVarer
+// interface without pulling in the real proxy package (which would import
+// half the world into this test).
+type fakeProxyEnvVarer struct {
+	env map[string]string
+}
+
+func (f *fakeProxyEnvVarer) EnvVars() map[string]string {
+	return f.env
+}
+
+func TestSession_LLMProxyEnvVars_DelegatesToProxy(t *testing.T) {
+	mgr := NewManager(10)
+	sess, err := mgr.CreateWithID("sess-123", t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+	sess.SetLLMProxy("http://127.0.0.1:9999", nil)
+	sess.SetProxyInstance(&fakeProxyEnvVarer{
+		env: map[string]string{
+			"ANTHROPIC_BASE_URL": "http://127.0.0.1:9999",
+			"OPENAI_BASE_URL":    "http://127.0.0.1:9999",
+			"AGENTSH_SESSION_ID": "sess-123",
+			"GITHUB_API_URL":     "http://127.0.0.1:9999/svc/github",
+			"STRIPE_API_URL":     "http://127.0.0.1:9999/svc/stripe",
+		},
+	})
+
+	envVars := sess.LLMProxyEnvVars()
+	if envVars == nil {
+		t.Fatal("LLMProxyEnvVars returned nil")
+	}
+
+	wantKeys := []string{
+		"ANTHROPIC_BASE_URL",
+		"OPENAI_BASE_URL",
+		"AGENTSH_SESSION_ID",
+		"GITHUB_API_URL",
+		"STRIPE_API_URL",
+	}
+	for _, k := range wantKeys {
+		if _, ok := envVars[k]; !ok {
+			t.Errorf("missing key %q in env: %v", k, envVars)
+		}
+	}
+	if got := envVars["GITHUB_API_URL"]; got != "http://127.0.0.1:9999/svc/github" {
+		t.Errorf("GITHUB_API_URL = %q", got)
+	}
+}
+
+func TestSession_LLMProxyEnvVars_FallbackWhenNoProxyInstance(t *testing.T) {
+	mgr := NewManager(10)
+	sess, err := mgr.CreateWithID("sess-456", t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("failed to create session: %v", err)
+	}
+	sess.SetLLMProxy("http://127.0.0.1:8888", nil)
+	// Do NOT call SetProxyInstance — simulate the legacy test path.
+
+	envVars := sess.LLMProxyEnvVars()
+	if envVars == nil {
+		t.Fatal("LLMProxyEnvVars returned nil")
+	}
+	if got := envVars["ANTHROPIC_BASE_URL"]; got != "http://127.0.0.1:8888" {
+		t.Errorf("ANTHROPIC_BASE_URL = %q", got)
+	}
+	if got := envVars["OPENAI_BASE_URL"]; got != "http://127.0.0.1:8888" {
+		t.Errorf("OPENAI_BASE_URL = %q", got)
+	}
+	if got := envVars["AGENTSH_SESSION_ID"]; got != "sess-456" {
+		t.Errorf("AGENTSH_SESSION_ID = %q", got)
+	}
+	if _, ok := envVars["GITHUB_API_URL"]; ok {
+		t.Errorf("unexpected GITHUB_API_URL in fallback: %v", envVars)
+	}
+}
+
 func TestSession_LLMProxyEnvVars_Integration(t *testing.T) {
 	// Create a mock upstream server
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Introduces `http_services:` — a top-level YAML policy block that lets operators declare named HTTP upstream services a child process can reach through the agentsh proxy gateway, with per-method, per-path rules, approval gating, audit logging, and fail-closed host enforcement.

- **Routing:** child processes get an injected `<NAME>_API_URL` (or custom `expose_as`) env var pointing at the proxy's `/svc/<name>/` endpoint. The proxy strips the prefix, dispatches through service-scoped hooks, and forwards to the upstream on allow.
- **Policy:** `decision: allow | deny | approve | audit`, first-match-wins over `methods` + glob `paths`, per-service `default`. Path traversal guard rejects `//`, `.`, `..` segments before matching; trailing slash is tolerated and stripped.
- **Fail-closed:** declared upstream hostnames (and aliases) are blocked on the netmonitor side for direct HTTP and HTTPS — the only path to the upstream is through the gateway. `allow_direct: true` opts out; denied direct attempts emit `http_service_denied_direct`.
- **Logging:** forwarded requests land in the same `llm-requests.jsonl` file as LLM proxy entries, discriminated by `service_kind: http_service`. Headers, body sizes, and body hashes recorded identically.
- **Validation at NewEngine:** URL-safe service names, https-only upstreams, reserved/duplicate env var name checks (Windows case-insensitive), canonicalized host dedupe (IPv6 literals must be bracketed), and glob path compile.

Built in 15 tasks from the plan at `docs/superpowers/plans/2026-04-10-http-path-verb-filtering.md`, reviewed end-to-end by roborev between tasks. Coverage includes unit tests per package and two fuzz targets for the evaluator (default-deny and default-allow regression) to lock the traversal guard in place against future refactors.

## Docs updated

- `README.md` — feature list, scopes, LLM proxy pointer, references
- `docs/llm-proxy.md` — new Declared HTTP Services section and env var row
- `docs/operations/policies.md` — HTTP Services section with a complete policy example
- `docs/approval-auth.md` — HTTP service approvals subsection
- `docs/cookbook/http-services.md` — four recipes + Gotchas (new file)
- `docs/project-structure.md` — new `internal/policy/http_service*.go` files
- `docs/security-modes.md` — platform-agnostic note in the mode matrix

## Test plan

- [ ] CI green on Linux, macOS, Windows (cross-compile)
- [ ] Existing test suite unaffected (`go test ./...`)
- [ ] Fuzz targets build and run: `go test ./internal/policy -run FuzzCheckHTTPServicePath -fuzz FuzzCheckHTTPServicePath -fuzztime=20s`
- [ ] Smoke: `agentsh policy validate` accepts a policy with an `http_services` block
- [ ] Smoke: `agentsh policy show` renders the declared services section