### PR TITLE
fix(detect): reason-sensitive tips for ebpf (#217)

### DIFF
--- a/internal/capabilities/detect_linux.go
+++ b/internal/capabilities/detect_linux.go
@@ -308,11 +308,10 @@ func Detect() (*DetectResult, error) {
 	if !wrapperFound {
 		suppressFeatures := make(map[string]bool)
 		for name := range wrapperDependentBackends {
-			if tip, ok := tipsByBackend[name]; ok {
+			if tip := lookupTip(name, ""); tip != nil {
 				suppressFeatures[tip.Feature] = true
 			}
 		}
-
 		filtered := tips[:0]
 		for _, tip := range tips {
 			if !suppressFeatures[tip.Feature] {

--- a/internal/capabilities/tips.go
+++ b/internal/capabilities/tips.go
@@ -2,7 +2,10 @@
 
 package capabilities
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // tipDefinition defines a tip for a missing capability.
 type tipDefinition struct {
@@ -10,6 +13,14 @@ type tipDefinition struct {
 	Impact   string
 	Action   string
 	CheckKey string // capability key to check
+}
+
+// reasonTip pairs a substring filter with a tip. When looking up a tip for
+// a backend, the first entry whose Contains is a non-empty substring of
+// DetectedBackend.Detail wins. An entry with Contains == "" is the fallback.
+type reasonTip struct {
+	Contains string
+	Tip      Tip
 }
 
 var linuxTips = []tipDefinition{
@@ -131,31 +142,54 @@ func GenerateTips(platform string, caps map[string]any) []Tip {
 	return tips
 }
 
-// tipsByBackend maps backend names to tip definitions.
-var tipsByBackend = map[string]Tip{
+// tipsByBackend maps backend names to an ordered slice of reason-sensitive
+// tips. Entries are scanned in order; the first whose Contains is a
+// non-empty substring of DetectedBackend.Detail wins. An entry with
+// Contains == "" acts as the fallback. Place more-specific substrings
+// before less-specific ones (e.g. "kernel version unknown" before "kernel").
+var tipsByBackend = map[string][]reasonTip{
 	// Linux
-	"fuse":             {Feature: "fuse", Impact: "Fine-grained filesystem control disabled", Action: "Install FUSE3: apt install fuse3 (Debian/Ubuntu), dnf install fuse3 (Fedora)"},
-	"seccomp-execve":   {Feature: "seccomp", Impact: "Syscall filtering disabled (likely nested container)", Action: "Run in privileged container or on host for full seccomp support"},
-	"seccomp-notify":   {Feature: "seccomp-notify", Impact: "Seccomp-based file enforcement disabled", Action: "Run in privileged container or on host for seccomp support"},
-	"landlock-network": {Feature: "landlock-network", Impact: "Kernel-level network restrictions disabled", Action: "Requires kernel 6.7+ (Landlock ABI v4)"},
-	"ebpf":             {Feature: "ebpf", Impact: "Network monitoring disabled", Action: "Requires CAP_BPF and cgroups v2. Run as root or with elevated privileges."},
-	"cgroups-v2":       {Feature: "cgroups-v2", Impact: "Resource limits unavailable", Action: "Enable cgroups v2 in kernel or container runtime"},
-	"ptrace":           {Feature: "ptrace", Impact: "Syscall-level enforcement via ptrace unavailable", Action: "Add SYS_PTRACE capability"},
-	"pid-namespace":    {Feature: "pid-namespace", Impact: "Process isolation unavailable", Action: "Run in a PID namespace (docker run --pid=host or unshare -p)"},
-	"capability-drop":  {Feature: "capability-drop", Impact: "Process retains full Linux capabilities (privilege reduction inactive)", Action: "Start the process with a reduced capability set using systemd CapabilityBoundingSet= + User=, docker run --cap-drop=ALL, or an unprivileged user. Note: capabilities.DropCapabilities() only narrows the bounding set for exec'd children via PR_CAPBSET_DROP and does not lower the running process's permitted/effective sets, so calling it from inside the server is not a substitute for the startup-time mechanisms above."},
+	"fuse":           {{Tip: Tip{Feature: "fuse", Impact: "Fine-grained filesystem control disabled", Action: "Install FUSE3: apt install fuse3 (Debian/Ubuntu), dnf install fuse3 (Fedora)"}}},
+	"seccomp-execve": {{Tip: Tip{Feature: "seccomp", Impact: "Syscall filtering disabled (likely nested container)", Action: "Run in privileged container or on host for full seccomp support"}}},
+	"seccomp-notify": {{Tip: Tip{Feature: "seccomp-notify", Impact: "Seccomp-based file enforcement disabled", Action: "Run in privileged container or on host for seccomp support"}}},
+	"landlock-network": {{Tip: Tip{Feature: "landlock-network", Impact: "Kernel-level network restrictions disabled", Action: "Requires kernel 6.7+ (Landlock ABI v4)"}}},
+	"ebpf": {
+		{Contains: "btf not present", Tip: Tip{Feature: "ebpf", Impact: "Network monitoring disabled", Action: "Kernel was built without CONFIG_DEBUG_INFO_BTF=y; cilium/ebpf CO-RE programs cannot relocate types without BTF. Rebuild the kernel with CONFIG_DEBUG_INFO_BTF=y (and ideally CONFIG_DEBUG_INFO_BTF_MODULES=y)."}},
+		{Contains: "cgroup v2 not available", Tip: Tip{Feature: "ebpf", Impact: "Network monitoring disabled", Action: "eBPF socket association requires cgroups v2. Mount a unified cgroup hierarchy or switch to a systemd-based init."}},
+		{Contains: "kernel version unknown", Tip: Tip{Feature: "ebpf", Impact: "Network monitoring disabled", Action: "Could not determine kernel version. eBPF network monitoring requires kernel 5.8+."}},
+		{Contains: "kernel", Tip: Tip{Feature: "ebpf", Impact: "Network monitoring disabled", Action: "eBPF network monitoring requires kernel 5.8+ for BPF ring buffer and CO-RE support. Upgrade your kernel."}},
+		{Tip: Tip{Feature: "ebpf", Impact: "Network monitoring disabled", Action: "Requires CAP_BPF (or CAP_SYS_ADMIN) and cgroups v2. Run as root or with elevated privileges."}},
+	},
+	"cgroups-v2":      {{Tip: Tip{Feature: "cgroups-v2", Impact: "Resource limits unavailable", Action: "Enable cgroups v2 in kernel or container runtime"}}},
+	"ptrace":          {{Tip: Tip{Feature: "ptrace", Impact: "Syscall-level enforcement via ptrace unavailable", Action: "Add SYS_PTRACE capability"}}},
+	"pid-namespace":   {{Tip: Tip{Feature: "pid-namespace", Impact: "Process isolation unavailable", Action: "Run in a PID namespace (docker run --pid=host or unshare -p)"}}},
+	"capability-drop": {{Tip: Tip{Feature: "capability-drop", Impact: "Process retains full Linux capabilities (privilege reduction inactive)", Action: "Start the process with a reduced capability set using systemd CapabilityBoundingSet= + User=, docker run --cap-drop=ALL, or an unprivileged user. Note: capabilities.DropCapabilities() only narrows the bounding set for exec'd children via PR_CAPBSET_DROP and does not lower the running process's permitted/effective sets, so calling it from inside the server is not a substitute for the startup-time mechanisms above."}}},
 	// Darwin
-	"esf":               {Feature: "esf", Impact: "Endpoint Security Framework unavailable", Action: "Install the agentsh macOS app bundle with system extension"},
-	"network-extension": {Feature: "network-extension", Impact: "Network filtering unavailable", Action: "Requires network extension entitlement from Apple"},
+	"esf":               {{Tip: Tip{Feature: "esf", Impact: "Endpoint Security Framework unavailable", Action: "Install the agentsh macOS app bundle with system extension"}}},
+	"network-extension": {{Tip: Tip{Feature: "network-extension", Impact: "Network filtering unavailable", Action: "Requires network extension entitlement from Apple"}}},
 	// Windows
-	"winfsp":     {Feature: "winfsp", Impact: "Filesystem interception unavailable", Action: "Install WinFsp: https://winfsp.dev/"},
-	"minifilter": {Feature: "minifilter", Impact: "Kernel-level file filtering unavailable", Action: "Install agentsh minifilter driver"},
-	"windivert":  {Feature: "windivert", Impact: "Network interception unavailable", Action: "Install WinDivert: https://reqrypt.org/windivert.html"},
+	"winfsp":     {{Tip: Tip{Feature: "winfsp", Impact: "Filesystem interception unavailable", Action: "Install WinFsp: https://winfsp.dev/"}}},
+	"minifilter": {{Tip: Tip{Feature: "minifilter", Impact: "Kernel-level file filtering unavailable", Action: "Install agentsh minifilter driver"}}},
+	"windivert":  {{Tip: Tip{Feature: "windivert", Impact: "Network interception unavailable", Action: "Install WinDivert: https://reqrypt.org/windivert.html"}}},
 }
 
-func lookupTip(backendName string) *Tip {
-	if tip, ok := tipsByBackend[backendName]; ok {
-		copy := tip // don't modify the map entry
-		return &copy
+func lookupTip(backendName, detail string) *Tip {
+	reasons, ok := tipsByBackend[backendName]
+	if !ok {
+		return nil
+	}
+	for _, r := range reasons {
+		if r.Contains != "" && strings.Contains(detail, r.Contains) {
+			copy := r.Tip
+			return &copy
+		}
+	}
+	// Fallback: first entry with empty Contains.
+	for _, r := range reasons {
+		if r.Contains == "" {
+			copy := r.Tip
+			return &copy
+		}
 	}
 	return nil
 }
@@ -173,7 +207,7 @@ func GenerateTipsFromDomains(domains []ProtectionDomain) []Tip {
 			if b.Available {
 				continue
 			}
-			tip := lookupTip(b.Name)
+			tip := lookupTip(b.Name, b.Detail)
 			if tip != nil {
 				tip.Impact = fmt.Sprintf("%s (+%d pts)", tip.Impact, d.Weight)
 				tips = append(tips, *tip)

--- a/internal/capabilities/tips.go
+++ b/internal/capabilities/tips.go
@@ -5,6 +5,8 @@ package capabilities
 import (
 	"fmt"
 	"strings"
+
+	"github.com/agentsh/agentsh/internal/netmonitor/ebpf"
 )
 
 // tipDefinition defines a tip for a missing capability.
@@ -154,10 +156,10 @@ var tipsByBackend = map[string][]reasonTip{
 	"seccomp-notify": {{Tip: Tip{Feature: "seccomp-notify", Impact: "Seccomp-based file enforcement disabled", Action: "Run in privileged container or on host for seccomp support"}}},
 	"landlock-network": {{Tip: Tip{Feature: "landlock-network", Impact: "Kernel-level network restrictions disabled", Action: "Requires kernel 6.7+ (Landlock ABI v4)"}}},
 	"ebpf": {
-		{Contains: "btf not present", Tip: Tip{Feature: "ebpf", Impact: "Network monitoring disabled", Action: "Kernel was built without CONFIG_DEBUG_INFO_BTF=y; cilium/ebpf CO-RE programs cannot relocate types without BTF. Rebuild the kernel with CONFIG_DEBUG_INFO_BTF=y (and ideally CONFIG_DEBUG_INFO_BTF_MODULES=y)."}},
-		{Contains: "cgroup v2 not available", Tip: Tip{Feature: "ebpf", Impact: "Network monitoring disabled", Action: "eBPF socket association requires cgroups v2. Mount a unified cgroup hierarchy or switch to a systemd-based init."}},
-		{Contains: "kernel version unknown", Tip: Tip{Feature: "ebpf", Impact: "Network monitoring disabled", Action: "Could not determine kernel version. eBPF network monitoring requires kernel 5.8+."}},
-		{Contains: "kernel", Tip: Tip{Feature: "ebpf", Impact: "Network monitoring disabled", Action: "eBPF network monitoring requires kernel 5.8+ for BPF ring buffer and CO-RE support. Upgrade your kernel."}},
+		{Contains: ebpf.ReasonBTFNotPresent, Tip: Tip{Feature: "ebpf", Impact: "Network monitoring disabled", Action: "Kernel was built without CONFIG_DEBUG_INFO_BTF=y; cilium/ebpf CO-RE programs cannot relocate types without BTF. Rebuild the kernel with CONFIG_DEBUG_INFO_BTF=y (and ideally CONFIG_DEBUG_INFO_BTF_MODULES=y)."}},
+		{Contains: ebpf.ReasonCgroupV2NotAvail, Tip: Tip{Feature: "ebpf", Impact: "Network monitoring disabled", Action: "eBPF socket association requires cgroups v2. Mount a unified cgroup hierarchy or switch to a systemd-based init."}},
+		{Contains: ebpf.ReasonKernelVersionUnknown, Tip: Tip{Feature: "ebpf", Impact: "Network monitoring disabled", Action: "Could not determine kernel version. eBPF network monitoring requires kernel 5.8+."}},
+		{Contains: ebpf.ReasonKernelTooOld, Tip: Tip{Feature: "ebpf", Impact: "Network monitoring disabled", Action: "eBPF network monitoring requires kernel 5.8+ for BPF ring buffer and CO-RE support. Upgrade your kernel."}},
 		{Tip: Tip{Feature: "ebpf", Impact: "Network monitoring disabled", Action: "Requires CAP_BPF (or CAP_SYS_ADMIN) and cgroups v2. Run as root or with elevated privileges."}},
 	},
 	"cgroups-v2":      {{Tip: Tip{Feature: "cgroups-v2", Impact: "Resource limits unavailable", Action: "Enable cgroups v2 in kernel or container runtime"}}},

--- a/internal/capabilities/tips_test.go
+++ b/internal/capabilities/tips_test.go
@@ -102,7 +102,7 @@ func TestGenerateTipsFromDomains_ZeroScoreOnly(t *testing.T) {
 			{Name: "fuse", Available: true},
 		}},
 		{Name: "Network", Weight: 20, Score: 0, Backends: []DetectedBackend{
-			{Name: "ebpf", Available: false},
+			{Name: "ebpf", Available: false, Detail: "btf not present (missing /sys/kernel/btf/vmlinux)"},
 		}},
 	}
 	tips := GenerateTipsFromDomains(domains)
@@ -110,6 +110,7 @@ func TestGenerateTipsFromDomains_ZeroScoreOnly(t *testing.T) {
 	assert.Len(t, tips, 1)
 	assert.Equal(t, "ebpf", tips[0].Feature)
 	assert.Contains(t, tips[0].Impact, "+20 pts")
+	assert.Contains(t, tips[0].Action, "CONFIG_DEBUG_INFO_BTF")
 }
 
 func TestGenerateTipsFromDomains_NoTipsWhenAllScored(t *testing.T) {
@@ -122,11 +123,11 @@ func TestGenerateTipsFromDomains_NoTipsWhenAllScored(t *testing.T) {
 }
 
 func TestLookupTip(t *testing.T) {
-	tip := lookupTip("ebpf")
+	tip := lookupTip("ebpf", "")
 	assert.NotNil(t, tip)
 	assert.Equal(t, "ebpf", tip.Feature)
 
-	tip2 := lookupTip("nonexistent")
+	tip2 := lookupTip("nonexistent", "")
 	assert.Nil(t, tip2)
 }
 
@@ -151,7 +152,7 @@ func TestLookupTip(t *testing.T) {
 // asserts all three: the marker exists, the cautionary section is
 // non-empty, and it mentions DropCapabilities.
 func TestLookupTip_CapabilityDropSemanticsChanged(t *testing.T) {
-	tip := lookupTip("capability-drop")
+	tip := lookupTip("capability-drop", "")
 	if tip == nil {
 		t.Fatal("capability-drop tip missing")
 	}
@@ -215,4 +216,66 @@ func TestLookupTip_CapabilityDropSemanticsChanged(t *testing.T) {
 	if !strings.Contains(cautionBody, "DropCapabilities") {
 		t.Errorf("capability-drop cautionary body must explain why DropCapabilities is not a substitute, got %q", cautionBody)
 	}
+}
+
+func TestLookupTip_EBPFReasonSensitive(t *testing.T) {
+	tests := []struct {
+		name       string
+		detail     string
+		wantAction string
+	}{
+		{
+			name:       "btf not present",
+			detail:     "btf not present (missing /sys/kernel/btf/vmlinux)",
+			wantAction: "CONFIG_DEBUG_INFO_BTF=y",
+		},
+		{
+			name:       "cgroup v2 not available",
+			detail:     "cgroup v2 not available",
+			wantAction: "cgroups v2",
+		},
+		{
+			name:       "kernel version unknown",
+			detail:     "kernel version unknown",
+			wantAction: "Could not determine kernel version",
+		},
+		{
+			name:       "kernel too old",
+			detail:     "kernel 5.4 < 5.8",
+			wantAction: "kernel 5.8+",
+		},
+		{
+			name:       "missing caps falls to fallback",
+			detail:     "missing CAP_BPF or CAP_SYS_ADMIN",
+			wantAction: "CAP_BPF",
+		},
+		{
+			name:       "empty detail falls to fallback",
+			detail:     "",
+			wantAction: "CAP_BPF",
+		},
+		{
+			name:       "unknown detail falls to fallback",
+			detail:     "something completely new",
+			wantAction: "CAP_BPF",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tip := lookupTip("ebpf", tt.detail)
+			if tip == nil {
+				t.Fatal("expected tip, got nil")
+			}
+			assert.Contains(t, tip.Action, tt.wantAction)
+		})
+	}
+}
+
+func TestLookupTip_NonEBPFUnchanged(t *testing.T) {
+	// Backends with only a fallback entry should return their tip
+	// regardless of detail content.
+	tip := lookupTip("fuse", "any detail string")
+	assert.NotNil(t, tip)
+	assert.Equal(t, "fuse", tip.Feature)
+	assert.Contains(t, tip.Action, "FUSE3")
 }

--- a/internal/capabilities/tips_test.go
+++ b/internal/capabilities/tips_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/agentsh/agentsh/internal/netmonitor/ebpf"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -102,7 +103,7 @@ func TestGenerateTipsFromDomains_ZeroScoreOnly(t *testing.T) {
 			{Name: "fuse", Available: true},
 		}},
 		{Name: "Network", Weight: 20, Score: 0, Backends: []DetectedBackend{
-			{Name: "ebpf", Available: false, Detail: "btf not present (missing /sys/kernel/btf/vmlinux)"},
+			{Name: "ebpf", Available: false, Detail: ebpf.ReasonBTFNotPresent + " (missing /sys/kernel/btf/vmlinux)"},
 		}},
 	}
 	tips := GenerateTipsFromDomains(domains)
@@ -226,27 +227,27 @@ func TestLookupTip_EBPFReasonSensitive(t *testing.T) {
 	}{
 		{
 			name:       "btf not present",
-			detail:     "btf not present (missing /sys/kernel/btf/vmlinux)",
+			detail:     ebpf.ReasonBTFNotPresent + " (missing /sys/kernel/btf/vmlinux)",
 			wantAction: "CONFIG_DEBUG_INFO_BTF=y",
 		},
 		{
 			name:       "cgroup v2 not available",
-			detail:     "cgroup v2 not available",
+			detail:     ebpf.ReasonCgroupV2NotAvail,
 			wantAction: "cgroups v2",
 		},
 		{
 			name:       "kernel version unknown",
-			detail:     "kernel version unknown",
+			detail:     ebpf.ReasonKernelVersionUnknown,
 			wantAction: "Could not determine kernel version",
 		},
 		{
 			name:       "kernel too old",
-			detail:     "kernel 5.4 < 5.8",
+			detail:     ebpf.ReasonKernelTooOld + " 5.4 < 5.8",
 			wantAction: "kernel 5.8+",
 		},
 		{
 			name:       "missing caps falls to fallback",
-			detail:     "missing CAP_BPF or CAP_SYS_ADMIN",
+			detail:     ebpf.ReasonMissingCap,
 			wantAction: "CAP_BPF",
 		},
 		{

--- a/internal/netmonitor/ebpf/capability_linux.go
+++ b/internal/netmonitor/ebpf/capability_linux.go
@@ -42,25 +42,25 @@ func CheckSupport() SupportStatus {
 	// "cgroup bpf controller not available" universally and silently
 	// skipped the integration tests that would have caught #196.
 	if _, err := os.Stat("/sys/fs/cgroup/cgroup.controllers"); err != nil {
-		return SupportStatus{Supported: false, Reason: "cgroup v2 not available"}
+		return SupportStatus{Supported: false, Reason: ReasonCgroupV2NotAvail}
 	}
 
 	if _, err := os.Stat("/sys/kernel/btf/vmlinux"); err != nil {
 		if _, dirErr := os.Stat("/sys/kernel/btf"); dirErr != nil {
-			return SupportStatus{Supported: false, Reason: "btf not present (missing /sys/kernel/btf/vmlinux)"}
+			return SupportStatus{Supported: false, Reason: ReasonBTFNotPresent + " (missing /sys/kernel/btf/vmlinux)"}
 		}
 	}
 
 	if !hasCap(unix.CAP_BPF) && !hasCap(unix.CAP_SYS_ADMIN) {
-		return SupportStatus{Supported: false, Reason: "missing CAP_BPF or CAP_SYS_ADMIN"}
+		return SupportStatus{Supported: false, Reason: ReasonMissingCap}
 	}
 
 	major, minor, err := kernelVersion()
 	if err != nil {
-		return SupportStatus{Supported: false, Reason: "kernel version unknown"}
+		return SupportStatus{Supported: false, Reason: ReasonKernelVersionUnknown}
 	}
 	if major < 5 || (major == 5 && minor < 8) {
-		return SupportStatus{Supported: false, Reason: fmt.Sprintf("kernel %d.%d < 5.8", major, minor)}
+		return SupportStatus{Supported: false, Reason: fmt.Sprintf("%s %d.%d < 5.8", ReasonKernelTooOld, major, minor)}
 	}
 
 	// Warn (but do not fail) on potential lockdown/LSM restrictions; attach may still fail.

--- a/internal/netmonitor/ebpf/reasons.go
+++ b/internal/netmonitor/ebpf/reasons.go
@@ -1,0 +1,13 @@
+package ebpf
+
+// Reason substrings returned by CheckSupport. These are matched by the
+// tip system in internal/capabilities to produce reason-specific
+// remediation advice. Changing these values requires updating the
+// corresponding entries in tipsByBackend.
+const (
+	ReasonBTFNotPresent       = "btf not present"
+	ReasonCgroupV2NotAvail    = "cgroup v2 not available"
+	ReasonKernelVersionUnknown = "kernel version unknown"
+	ReasonKernelTooOld        = "kernel"
+	ReasonMissingCap          = "missing CAP_BPF or CAP_SYS_ADMIN"
+)


### PR DESCRIPTION
## Summary

- Makes `agentsh detect` tips context-sensitive: each eBPF failure reason now produces a specific remediation tip instead of the generic "Requires CAP_BPF and cgroups v2" message
- Introduces `reasonTip` type with ordered substring matching on `DetectedBackend.Detail`, falling back to a generic tip when no specific reason matches
- Extracts shared reason constants (`ebpf.ReasonBTFNotPresent`, etc.) so producer (probe) and consumer (tips) stay in sync

Closes #217

## Test plan
- [x] `TestLookupTip_EBPFReasonSensitive` — 7 subtests covering BTF, cgroup v2, kernel-too-old, kernel-unknown, missing caps, empty detail, unknown detail
- [x] `TestLookupTip_NonEBPFUnchanged` — non-eBPF backends still return their tip regardless of detail
- [x] `TestGenerateTipsFromDomains_ZeroScoreOnly` — verifies reason-sensitive tip propagates through domain generation
- [x] Existing tests updated for new `lookupTip(name, detail)` signature
- [x] Cross-compile: linux, windows, darwin

🤖 Generated with [Claude Code](https://claude.com/claude-code)