### PR TITLE
fix(seccomp): Yama-aware PR_SET_PTRACER with ProcessVMReadv self-test

### DIFF
--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -46,10 +46,15 @@ func main() {
 	// Under Yama ptrace_scope=1 (Ubuntu/Debian default), only ancestor
 	// processes can use ProcessVMReadv. In the wrap path the server is NOT
 	// our ancestor, so this prctl authorizes it specifically.
-	// Must run before any seccomp notifications can be processed.
+	// On kernels without Yama, PR_SET_PTRACER returns EINVAL — but it's
+	// also unnecessary because standard Unix DAC governs ptrace.
 	if cfg.ServerPID > 0 {
-		if err := unix.Prctl(unix.PR_SET_PTRACER, uintptr(cfg.ServerPID), 0, 0, 0); err != nil {
-			log.Printf("PR_SET_PTRACER(%d): %v (ProcessVMReadv may fail under Yama)", cfg.ServerPID, err)
+		if isYamaActive() {
+			if err := unix.Prctl(unix.PR_SET_PTRACER, uintptr(cfg.ServerPID), 0, 0, 0); err != nil {
+				log.Printf("PR_SET_PTRACER(%d): %v (Yama active, ProcessVMReadv may fail)", cfg.ServerPID, err)
+			}
+		} else {
+			log.Printf("yama: not active, skipping PR_SET_PTRACER (standard DAC governs ptrace)")
 		}
 	}
 

--- a/cmd/agentsh-unixwrap/yama_linux.go
+++ b/cmd/agentsh-unixwrap/yama_linux.go
@@ -1,0 +1,17 @@
+//go:build linux && cgo
+
+package main
+
+import "os"
+
+// yamaPtraceScopePath is the sysctl that exists when Yama LSM is loaded.
+// Package-level var for testability.
+var yamaPtraceScopePath = "/proc/sys/kernel/yama/ptrace_scope"
+
+// isYamaActive returns true if the Yama LSM is loaded and active.
+// When Yama is not loaded, PR_SET_PTRACER is meaningless (returns EINVAL)
+// and ProcessVMReadv permissions fall back to standard Unix DAC.
+func isYamaActive() bool {
+	_, err := os.Stat(yamaPtraceScopePath)
+	return err == nil
+}

--- a/cmd/agentsh-unixwrap/yama_linux_test.go
+++ b/cmd/agentsh-unixwrap/yama_linux_test.go
@@ -1,0 +1,32 @@
+//go:build linux && cgo
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsYamaActive_WhenPresent(t *testing.T) {
+	dir := t.TempDir()
+	fakePath := filepath.Join(dir, "ptrace_scope")
+	require.NoError(t, os.WriteFile(fakePath, []byte("1\n"), 0644))
+
+	orig := yamaPtraceScopePath
+	yamaPtraceScopePath = fakePath
+	defer func() { yamaPtraceScopePath = orig }()
+
+	assert.True(t, isYamaActive(), "should report Yama active when ptrace_scope file exists")
+}
+
+func TestIsYamaActive_WhenAbsent(t *testing.T) {
+	orig := yamaPtraceScopePath
+	yamaPtraceScopePath = "/nonexistent/path/ptrace_scope"
+	defer func() { yamaPtraceScopePath = orig }()
+
+	assert.False(t, isYamaActive(), "should report Yama inactive when ptrace_scope file is missing")
+}

--- a/docs/superpowers/plans/2026-04-12-yama-aware-ptracer.md
+++ b/docs/superpowers/plans/2026-04-12-yama-aware-ptracer.md
@@ -1,0 +1,576 @@
+# Yama-Aware PR_SET_PTRACER with ProcessVMReadv Self-Test — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix #218 — make the PR_SET_PTRACER call Yama-aware and add a ProcessVMReadv self-test so file_monitor works on kernels without Yama LSM.
+
+**Architecture:** Two new files (`yama_linux.go` for Yama detection, `pvr_probe_linux.go` for the memory-access self-test) plus edits to three existing files (`main.go`, `notify_linux.go`, `wrap_linux.go`). The wrapper skips PR_SET_PTRACER when Yama isn't loaded. The server probes ProcessVMReadv against the wrapper PID during the notify handshake, failing fast if both memory-access methods are broken and file_monitor or execve interception is enabled.
+
+**Tech Stack:** Go, `golang.org/x/sys/unix`, Linux seccomp-notify
+
+**Spec:** `docs/superpowers/specs/2026-04-12-yama-aware-ptracer-design.md`
+
+---
+
+### Task 1: Yama Detection — Test + Implementation
+
+**Files:**
+- Create: `cmd/agentsh-unixwrap/yama_linux.go`
+- Create: `cmd/agentsh-unixwrap/yama_linux_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `cmd/agentsh-unixwrap/yama_linux_test.go`:
+
+```go
+//go:build linux && cgo
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsYamaActive_WhenPresent(t *testing.T) {
+	// Create a temp file that simulates /proc/sys/kernel/yama/ptrace_scope
+	dir := t.TempDir()
+	fakePath := filepath.Join(dir, "ptrace_scope")
+	require.NoError(t, os.WriteFile(fakePath, []byte("1\n"), 0644))
+
+	orig := yamaPtraceScopePath
+	yamaPtraceScopePath = fakePath
+	defer func() { yamaPtraceScopePath = orig }()
+
+	assert.True(t, isYamaActive(), "should report Yama active when ptrace_scope file exists")
+}
+
+func TestIsYamaActive_WhenAbsent(t *testing.T) {
+	orig := yamaPtraceScopePath
+	yamaPtraceScopePath = "/nonexistent/path/ptrace_scope"
+	defer func() { yamaPtraceScopePath = orig }()
+
+	assert.False(t, isYamaActive(), "should report Yama inactive when ptrace_scope file is missing")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/eran/work/agentsh && go test ./cmd/agentsh-unixwrap/ -run TestIsYamaActive -v`
+
+Expected: compilation error — `yamaPtraceScopePath` and `isYamaActive` are not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `cmd/agentsh-unixwrap/yama_linux.go`:
+
+```go
+//go:build linux && cgo
+
+package main
+
+import "os"
+
+// yamaPtraceScopePath is the sysctl that exists when Yama LSM is loaded.
+// Package-level var for testability.
+var yamaPtraceScopePath = "/proc/sys/kernel/yama/ptrace_scope"
+
+// isYamaActive returns true if the Yama LSM is loaded and active.
+// When Yama is not loaded, PR_SET_PTRACER is meaningless (returns EINVAL)
+// and ProcessVMReadv permissions fall back to standard Unix DAC.
+func isYamaActive() bool {
+	_, err := os.Stat(yamaPtraceScopePath)
+	return err == nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/eran/work/agentsh && go test ./cmd/agentsh-unixwrap/ -run TestIsYamaActive -v`
+
+Expected: both tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/agentsh-unixwrap/yama_linux.go cmd/agentsh-unixwrap/yama_linux_test.go
+git commit -m "feat(seccomp): add Yama LSM detection for PR_SET_PTRACER (#218)"
+```
+
+---
+
+### Task 2: Yama-Aware PR_SET_PTRACER in Wrapper
+
+**Files:**
+- Modify: `cmd/agentsh-unixwrap/main.go:45-54`
+
+- [ ] **Step 1: Replace the unconditional PR_SET_PTRACER call**
+
+In `cmd/agentsh-unixwrap/main.go`, replace lines 45-54 (the comment block and the `if cfg.ServerPID > 0` block):
+
+Old code:
+```go
+	// Authorize the server process to read our memory via ProcessVMReadv.
+	// Under Yama ptrace_scope=1 (Ubuntu/Debian default), only ancestor
+	// processes can use ProcessVMReadv. In the wrap path the server is NOT
+	// our ancestor, so this prctl authorizes it specifically.
+	// Must run before any seccomp notifications can be processed.
+	if cfg.ServerPID > 0 {
+		if err := unix.Prctl(unix.PR_SET_PTRACER, uintptr(cfg.ServerPID), 0, 0, 0); err != nil {
+			log.Printf("PR_SET_PTRACER(%d): %v (ProcessVMReadv may fail under Yama)", cfg.ServerPID, err)
+		}
+	}
+```
+
+New code:
+```go
+	// Authorize the server process to read our memory via ProcessVMReadv.
+	// Under Yama ptrace_scope=1 (Ubuntu/Debian default), only ancestor
+	// processes can use ProcessVMReadv. In the wrap path the server is NOT
+	// our ancestor, so this prctl authorizes it specifically.
+	// On kernels without Yama, PR_SET_PTRACER returns EINVAL — but it's
+	// also unnecessary because standard Unix DAC governs ptrace.
+	if cfg.ServerPID > 0 {
+		if isYamaActive() {
+			if err := unix.Prctl(unix.PR_SET_PTRACER, uintptr(cfg.ServerPID), 0, 0, 0); err != nil {
+				log.Printf("PR_SET_PTRACER(%d): %v (Yama active, ProcessVMReadv may fail)", cfg.ServerPID, err)
+			}
+		} else {
+			log.Printf("yama: not active, skipping PR_SET_PTRACER (standard DAC governs ptrace)")
+		}
+	}
+```
+
+- [ ] **Step 2: Verify build and existing tests pass**
+
+Run: `cd /home/eran/work/agentsh && go build ./cmd/agentsh-unixwrap/ && go test ./cmd/agentsh-unixwrap/ -v`
+
+Expected: build succeeds, all existing tests pass.
+
+- [ ] **Step 3: Verify cross-compilation**
+
+Run: `cd /home/eran/work/agentsh && GOOS=windows go build ./...`
+
+Expected: build succeeds (the new file has `_linux.go` suffix, excluded from Windows builds).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/agentsh-unixwrap/main.go
+git commit -m "fix(seccomp): skip PR_SET_PTRACER when Yama LSM not loaded (#218)"
+```
+
+---
+
+### Task 3: ProcessVMReadv Probe Functions — Test + Implementation
+
+**Files:**
+- Create: `internal/api/pvr_probe_linux.go`
+- Create: `internal/api/pvr_probe_linux_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/api/pvr_probe_linux_test.go`:
+
+```go
+//go:build linux && cgo
+
+package api
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindReadableAddr_Self(t *testing.T) {
+	addr, err := findReadableAddr(os.Getpid())
+	require.NoError(t, err, "should find a readable mapping in own process")
+	assert.NotZero(t, addr, "address should be non-zero")
+}
+
+func TestProbeProcessVMReadvAt_Self(t *testing.T) {
+	addr, err := findReadableAddr(os.Getpid())
+	require.NoError(t, err)
+
+	err = probeProcessVMReadvAt(os.Getpid(), addr)
+	assert.NoError(t, err, "ProcessVMReadv against own PID should succeed")
+}
+
+func TestProbeProcMemAt_Self(t *testing.T) {
+	addr, err := findReadableAddr(os.Getpid())
+	require.NoError(t, err)
+
+	err = probeProcMemAt(os.Getpid(), addr)
+	assert.NoError(t, err, "/proc/self/mem read should succeed")
+}
+
+func TestProbeMemoryAccess_Self(t *testing.T) {
+	pvrErr, memErr := probeMemoryAccess(os.Getpid())
+	assert.NoError(t, pvrErr, "ProcessVMReadv should succeed against self")
+	assert.NoError(t, memErr, "memErr should be nil when ProcessVMReadv succeeds")
+}
+
+func TestProbeMemoryAccess_InvalidPID(t *testing.T) {
+	// PID that almost certainly doesn't exist
+	pvrErr, memErr := probeMemoryAccess(999999999)
+	assert.Error(t, pvrErr, "should fail for nonexistent PID")
+	assert.Error(t, memErr, "fallback should also fail for nonexistent PID")
+}
+
+func TestFindReadableAddr_InvalidPID(t *testing.T) {
+	_, err := findReadableAddr(999999999)
+	assert.Error(t, err, "should fail for nonexistent PID")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -run "TestFindReadableAddr|TestProbeProcessVMReadvAt|TestProbeProcMemAt|TestProbeMemoryAccess" -v`
+
+Expected: compilation error — functions not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `internal/api/pvr_probe_linux.go`:
+
+```go
+//go:build linux && cgo
+
+package api
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// probeMemoryAccess tests that the server can read from the given PID's address
+// space using ProcessVMReadv and the /proc/<pid>/mem fallback. Returns
+// (nil, nil) if ProcessVMReadv works, (pvrErr, nil) if only /proc/mem works,
+// or (pvrErr, memErr) if both fail.
+func probeMemoryAccess(pid int) (pvrErr, memErr error) {
+	addr, err := findReadableAddr(pid)
+	if err != nil {
+		return fmt.Errorf("find readable addr: %w", err), fmt.Errorf("find readable addr: %w", err)
+	}
+	pvrErr = probeProcessVMReadvAt(pid, addr)
+	if pvrErr != nil {
+		memErr = probeProcMemAt(pid, addr)
+	}
+	return pvrErr, memErr
+}
+
+// probeProcessVMReadvAt reads 8 bytes from the given address in the target
+// process via ProcessVMReadv. Returns nil on success.
+func probeProcessVMReadvAt(pid int, addr uint64) error {
+	buf := make([]byte, 8)
+	liov := unix.Iovec{Base: &buf[0], Len: 8}
+	riov := unix.RemoteIovec{Base: uintptr(addr), Len: 8}
+	_, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
+	return err
+}
+
+// probeProcMemAt reads 8 bytes from the given address via /proc/<pid>/mem.
+// Returns nil on success.
+func probeProcMemAt(pid int, addr uint64) error {
+	f, err := os.Open(fmt.Sprintf("/proc/%d/mem", pid))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	buf := make([]byte, 8)
+	_, err = f.ReadAt(buf, int64(addr))
+	return err
+}
+
+// findReadableAddr parses /proc/<pid>/maps to find the start address of the
+// first readable mapping. Scans at most 20 lines.
+func findReadableAddr(pid int) (uint64, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/maps", pid))
+	if err != nil {
+		return 0, fmt.Errorf("read /proc/%d/maps: %w", pid, err)
+	}
+	lines := strings.Split(string(data), "\n")
+	limit := 20
+	if len(lines) < limit {
+		limit = len(lines)
+	}
+	for _, line := range lines[:limit] {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		// permissions field: rwxp — check first char is 'r'
+		if len(fields[1]) < 1 || fields[1][0] != 'r' {
+			continue
+		}
+		addrs := strings.SplitN(fields[0], "-", 2)
+		if len(addrs) < 2 {
+			continue
+		}
+		addr, err := strconv.ParseUint(addrs[0], 16, 64)
+		if err != nil {
+			continue
+		}
+		return addr, nil
+	}
+	return 0, fmt.Errorf("no readable mapping found in /proc/%d/maps (scanned %d lines)", pid, limit)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -run "TestFindReadableAddr|TestProbeProcessVMReadvAt|TestProbeProcMemAt|TestProbeMemoryAccess" -v`
+
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/api/pvr_probe_linux.go internal/api/pvr_probe_linux_test.go
+git commit -m "feat(seccomp): add ProcessVMReadv/proc-mem memory access probe (#218)"
+```
+
+---
+
+### Task 4: Self-Test Integration in Exec Path
+
+**Files:**
+- Modify: `internal/api/notify_linux.go:297-299`
+
+- [ ] **Step 1: Add the self-test between handler setup and ACK**
+
+In `internal/api/notify_linux.go`, find the code between the execve handler setup closing brace (line 297) and the ACK comment (line 299). Insert the probe block between them.
+
+Old code (lines 297-302):
+```go
+		}
+		// Send ACK to wrapper so it knows the notify handler is ready before exec.
+		if _, err := parentSock.Write([]byte{1}); err != nil {
+			slog.Debug("notify: ACK write to wrapper failed", "error", err, "session_id", sessID)
+		}
+```
+
+New code:
+```go
+		}
+
+		// Probe: verify ProcessVMReadv (or /proc/mem fallback) works against
+		// the wrapper before starting. Catches Yama, missing CAP_SYS_PTRACE,
+		// or other LSM restrictions at startup instead of on first notification.
+		if wrapperPID > 0 {
+			pvrErr, memErr := probeMemoryAccess(wrapperPID)
+			if pvrErr != nil && memErr != nil {
+				if fileHandler != nil || h != nil {
+					slog.Error("seccomp notify: ProcessVMReadv and /proc/mem both failed — "+
+						"handler cannot read tracee memory for path resolution",
+						"wrapper_pid", wrapperPID,
+						"pvr_error", pvrErr, "mem_error", memErr,
+						"session_id", sessID,
+						"hint", "check kernel.yama.ptrace_scope, ensure CAP_SYS_PTRACE, "+
+							"or set sandbox.seccomp.file_monitor.enabled: false")
+					return // Don't send ACK — wrapper fails with clear handshake error
+				}
+				slog.Warn("ProcessVMReadv probe failed, socket monitoring may be degraded",
+					"wrapper_pid", wrapperPID, "pvr_error", pvrErr, "mem_error", memErr)
+			} else if pvrErr != nil {
+				slog.Debug("ProcessVMReadv failed but /proc/mem fallback works",
+					"wrapper_pid", wrapperPID, "pvr_error", pvrErr)
+			}
+		}
+
+		// Send ACK to wrapper so it knows the notify handler is ready before exec.
+		if _, err := parentSock.Write([]byte{1}); err != nil {
+			slog.Debug("notify: ACK write to wrapper failed", "error", err, "session_id", sessID)
+		}
+```
+
+- [ ] **Step 2: Verify build succeeds**
+
+Run: `cd /home/eran/work/agentsh && go build ./internal/api/`
+
+Expected: build succeeds with no errors.
+
+- [ ] **Step 3: Run existing tests to check for regressions**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -v -count=1 2>&1 | tail -20`
+
+Expected: all existing tests pass. The probe runs against self PID in test contexts and should succeed.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/api/notify_linux.go
+git commit -m "fix(seccomp): add ProcessVMReadv self-test in exec notify handshake (#218)"
+```
+
+---
+
+### Task 5: Self-Test Integration in Wrap Path
+
+**Files:**
+- Modify: `internal/api/wrap_linux.go:113-115`
+
+- [ ] **Step 1: Add the self-test between fileHandler creation and the handler goroutine**
+
+In `internal/api/wrap_linux.go`, find lines 113-115 (fileHandler creation through goroutine start). Insert the probe between them.
+
+Old code (lines 112-115):
+```go
+	// Create file handler if configured
+	fileHandler := createFileHandler(a.cfg.Sandbox.Seccomp.FileMonitor, sessionPolicy, emitter, a.cfg.Landlock.Enabled)
+
+	go func() {
+```
+
+New code:
+```go
+	// Create file handler if configured
+	fileHandler := createFileHandler(a.cfg.Sandbox.Seccomp.FileMonitor, sessionPolicy, emitter, a.cfg.Landlock.Enabled)
+
+	// Probe: verify ProcessVMReadv (or /proc/mem fallback) works against
+	// the wrapper before starting. Same logic as the exec path probe in
+	// notify_linux.go — catches broken memory access at startup.
+	if wrapperPID > 0 {
+		pvrErr, memErr := probeMemoryAccess(wrapperPID)
+		if pvrErr != nil && memErr != nil {
+			if fileHandler != nil || execveHandler != nil {
+				slog.Error("wrap: ProcessVMReadv and /proc/mem both failed — "+
+					"handler cannot read tracee memory for path resolution",
+					"wrapper_pid", wrapperPID,
+					"pvr_error", pvrErr, "mem_error", memErr,
+					"session_id", sessionID,
+					"hint", "check kernel.yama.ptrace_scope, ensure CAP_SYS_PTRACE, "+
+						"or set sandbox.seccomp.file_monitor.enabled: false")
+				// Clean up resources that would normally be handled by the goroutine.
+				notifyFD.Close()
+				if cleanupSymlink != nil {
+					cleanupSymlink()
+				}
+				return
+			}
+			slog.Warn("wrap: ProcessVMReadv probe failed, socket monitoring may be degraded",
+				"wrapper_pid", wrapperPID, "pvr_error", pvrErr, "mem_error", memErr)
+		} else if pvrErr != nil {
+			slog.Debug("wrap: ProcessVMReadv failed but /proc/mem fallback works",
+				"wrapper_pid", wrapperPID, "pvr_error", pvrErr)
+		}
+	}
+
+	go func() {
+```
+
+- [ ] **Step 2: Verify build succeeds**
+
+Run: `cd /home/eran/work/agentsh && go build ./internal/api/`
+
+Expected: build succeeds with no errors.
+
+- [ ] **Step 3: Run existing tests**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -v -count=1 2>&1 | tail -20`
+
+Expected: all existing tests pass.
+
+- [ ] **Step 4: Verify cross-compilation**
+
+Run: `cd /home/eran/work/agentsh && GOOS=windows go build ./...`
+
+Expected: build succeeds. `pvr_probe_linux.go` and the modified `wrap_linux.go` are excluded from Windows builds by filename suffix.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/api/wrap_linux.go
+git commit -m "fix(seccomp): add ProcessVMReadv self-test in wrap notify handler (#218)"
+```
+
+---
+
+### Task 6: Cross-Process Integration Test
+
+**Files:**
+- Modify: `internal/api/pvr_probe_linux_test.go`
+
+- [ ] **Step 1: Add a cross-process probe test**
+
+Append to `internal/api/pvr_probe_linux_test.go`:
+
+```go
+func TestProbeMemoryAccess_CrossProcess(t *testing.T) {
+	// Fork a child process (sleep), probe it from parent, then kill it.
+	// This validates the actual access pattern: server reading from wrapper.
+	cmd := exec.Command("sleep", "10")
+	require.NoError(t, cmd.Start(), "failed to start child process")
+	defer func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	}()
+
+	// Give the child a moment to be fully mapped.
+	time.Sleep(50 * time.Millisecond)
+
+	pvrErr, memErr := probeMemoryAccess(cmd.Process.Pid)
+	assert.NoError(t, pvrErr, "ProcessVMReadv should succeed against child process")
+	assert.NoError(t, memErr, "memErr should be nil when ProcessVMReadv succeeds")
+}
+```
+
+Also add the needed imports at the top of the file. The full import block becomes:
+
+```go
+import (
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -run TestProbeMemoryAccess_CrossProcess -v`
+
+Expected: PASS. Parent can read from child process (same UID, standard ptrace access).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/api/pvr_probe_linux_test.go
+git commit -m "test(seccomp): add cross-process ProcessVMReadv integration test (#218)"
+```
+
+---
+
+### Task 7: Final Verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd /home/eran/work/agentsh && go test ./... 2>&1 | tail -30`
+
+Expected: all tests pass.
+
+- [ ] **Step 2: Verify Windows cross-compilation**
+
+Run: `cd /home/eran/work/agentsh && GOOS=windows go build ./...`
+
+Expected: build succeeds. All new files have `_linux` suffix.
+
+- [ ] **Step 3: Verify Linux build**
+
+Run: `cd /home/eran/work/agentsh && go build ./...`
+
+Expected: build succeeds.

--- a/docs/superpowers/specs/2026-04-12-yama-aware-ptracer-design.md
+++ b/docs/superpowers/specs/2026-04-12-yama-aware-ptracer-design.md
@@ -1,0 +1,183 @@
+# Yama-Aware PR_SET_PTRACER with ProcessVMReadv Self-Test
+
+**Issue**: #218 — `file_monitor: PR_SET_PTRACER EINVAL treated as fatal on kernels without Yama LSM`
+**Date**: 2026-04-12
+
+## Problem
+
+On kernels where Yama LSM is not loaded (e.g., Firecracker/Hopx microVMs with kernel 5.10), `prctl(PR_SET_PTRACER, ...)` returns `EINVAL` because the kernel doesn't recognize the Yama-specific option `0x59616d61`. The current wrapper logs a warning and continues, but downstream effects cause seccomp-notify handlers to fail when they can't read tracee memory — resulting in `permission denied` for all intercepted execs when `file_monitor.enabled: true`.
+
+The root cause: `PR_SET_PTRACER` is only meaningful when Yama is loaded. Without Yama, standard Unix DAC governs ptrace and `ProcessVMReadv` works without any grant. The warning is misleading and the potential for downstream failures is unnecessary.
+
+## Approach
+
+Two changes:
+
+1. **Yama-aware `PR_SET_PTRACER` in the wrapper** — skip the prctl entirely when Yama is not loaded.
+2. **Server-side `ProcessVMReadv` self-test** — during the notify handler handshake, probe that the server can actually read from the wrapper's address space before processing any notifications.
+
+## Design
+
+### 1. Yama Detection
+
+**File**: `cmd/agentsh-unixwrap/yama_linux.go` (new)
+
+```go
+const yamaPtraceScope = "/proc/sys/kernel/yama/ptrace_scope"
+
+// isYamaActive returns true if the Yama LSM is loaded and active.
+// When Yama is not loaded, PR_SET_PTRACER is meaningless (returns EINVAL)
+// and ProcessVMReadv permissions fall back to standard Unix DAC.
+func isYamaActive() bool {
+    _, err := os.Stat(yamaPtraceScope)
+    return err == nil
+}
+```
+
+For testability, the sysctl path is a package-level variable that tests can override:
+
+```go
+var yamaPtraceScopePath = "/proc/sys/kernel/yama/ptrace_scope"
+
+func isYamaActive() bool {
+    _, err := os.Stat(yamaPtraceScopePath)
+    return err == nil
+}
+```
+
+### 2. Wrapper Changes
+
+**File**: `cmd/agentsh-unixwrap/main.go` (lines 45-54)
+
+Replace the unconditional `PR_SET_PTRACER` call with Yama-aware logic:
+
+```go
+if cfg.ServerPID > 0 {
+    if isYamaActive() {
+        if err := unix.Prctl(unix.PR_SET_PTRACER, uintptr(cfg.ServerPID), 0, 0, 0); err != nil {
+            log.Printf("PR_SET_PTRACER(%d): %v (Yama active, ProcessVMReadv may fail)",
+                cfg.ServerPID, err)
+        }
+    } else {
+        log.Printf("yama: not active, skipping PR_SET_PTRACER (standard DAC governs ptrace)")
+    }
+}
+```
+
+**No change to the C ptracer library** (`cmd/agentsh-unixwrap/ptracer/ptracer.c`). It already ignores the prctl return value. The overhead of a failed prctl per child is negligible vs fork/exec cost.
+
+### 3. ProcessVMReadv Self-Test
+
+**File**: `internal/api/pvr_probe_linux.go` (new)
+
+Three functions:
+
+- `probeProcessVMReadv(pid int) error` — reads 8 bytes from a readable mapping in `/proc/<pid>/maps` via `ProcessVMReadv`. Returns nil on success.
+- `probeProcMem(pid int) error` — reads 8 bytes from the same address via `/proc/<pid>/mem` (the fallback mechanism). Returns nil on success.
+- `findReadableAddr(pid int) (uint64, error)` — parses `/proc/<pid>/maps` to find the start address of the first readable mapping (`r--` or `r-x` permissions). Scans at most 20 lines; returns error if no readable mapping found.
+
+The caller resolves the address once via `findReadableAddr` and passes it to both probe functions to avoid parsing `/proc/maps` twice:
+
+```go
+func probeMemoryAccess(pid int) (pvrErr, memErr error) {
+    addr, err := findReadableAddr(pid)
+    if err != nil {
+        return err, err
+    }
+    pvrErr = probeProcessVMReadvAt(pid, addr)
+    if pvrErr != nil {
+        memErr = probeProcMemAt(pid, addr)
+    }
+    return pvrErr, memErr
+}
+```
+
+### 4. Self-Test Integration (Exec Path)
+
+**File**: `internal/api/notify_linux.go`, in `startNotifyHandler()`
+
+Insertion point: after notify fd is received (line 236) and before ACK is sent (line 300). The wrapper PID is already available from `SO_PEERCRED` (line 206).
+
+```go
+if wrapperPID > 0 {
+    pvrErr, memErr := probeMemoryAccess(wrapperPID)
+
+    if pvrErr != nil && memErr != nil {
+        fileMonEnabled := config.FileMonitorBoolWithDefault(fileMonitorCfg.Enabled, false)
+        if fileMonEnabled || execveHandler != nil {
+            slog.Error("seccomp notify: ProcessVMReadv and /proc/mem both failed — "+
+                "handler cannot read tracee memory for path resolution",
+                "wrapper_pid", wrapperPID,
+                "pvr_error", pvrErr, "mem_error", memErr,
+                "session_id", sessID)
+            return // Don't send ACK — wrapper fails with clear handshake error
+        }
+        slog.Warn("ProcessVMReadv probe failed, socket monitoring may be degraded",
+            "wrapper_pid", wrapperPID, "pvr_error", pvrErr, "mem_error", memErr)
+    } else if pvrErr != nil {
+        slog.Debug("ProcessVMReadv failed, /proc/mem fallback works",
+            "wrapper_pid", wrapperPID, "pvr_error", pvrErr)
+    }
+}
+```
+
+### 5. Self-Test Integration (Wrap Path)
+
+**File**: `internal/api/wrap_linux.go`, in `startNotifyHandlerForWrap()`
+
+Insertion point: before starting the handler goroutine (line 115). The `wrapperPID` is already a function parameter.
+
+Same probe logic as the exec path. On fatal failure (both mechanisms broken + file_monitor/execve enabled), log the error and return without starting the handler.
+
+### 6. Failure Behavior
+
+| ProcessVMReadv | /proc/mem | file_monitor/execve | Action |
+|---|---|---|---|
+| OK | (not tested) | any | Continue normally |
+| Fail | OK | any | Continue (debug log — degraded performance) |
+| Fail | Fail | enabled | **Fatal** — don't send ACK, log clear error with diagnostics |
+| Fail | Fail | disabled | Warn, continue (only socket monitoring is active) |
+
+The fatal case produces an error like:
+```
+seccomp notify: ProcessVMReadv and /proc/mem both failed — handler cannot read tracee memory for path resolution
+    wrapper_pid=1234, pvr_error=EPERM, mem_error=EACCES
+Fix: check kernel.yama.ptrace_scope sysctl, ensure CAP_SYS_PTRACE capability,
+or set 'sandbox.seccomp.file_monitor.enabled: false' in your config.
+```
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `cmd/agentsh-unixwrap/yama_linux.go` | New — `isYamaActive()` Yama LSM detection |
+| `cmd/agentsh-unixwrap/main.go` | Yama-aware PR_SET_PTRACER logic (lines 45-54) |
+| `internal/api/pvr_probe_linux.go` | New — `probeProcessVMReadv()`, `probeProcMem()`, `findReadableAddr()` |
+| `internal/api/pvr_probe_linux_test.go` | New — unit tests for probe functions |
+| `internal/api/notify_linux.go` | Self-test insertion in `startNotifyHandler()` |
+| `internal/api/wrap_linux.go` | Self-test insertion in `startNotifyHandlerForWrap()` |
+| `cmd/agentsh-unixwrap/yama_linux_test.go` | New — unit tests for `isYamaActive()` |
+
+## Testing
+
+### Unit Tests
+
+- **`TestIsYamaActive_WhenPresent`** / **`TestIsYamaActive_WhenAbsent`**: Use a package-level path variable overridden in tests to simulate Yama presence/absence.
+- **`TestProbeProcessVMReadv_Self`**: Probe against `os.Getpid()` — succeeds on any Linux kernel.
+- **`TestProbeProcMem_Self`**: Probe `/proc/self/mem` — succeeds on any Linux kernel.
+- **`TestFindReadableAddr`**: Parses `/proc/self/maps` and returns a valid address.
+
+### Integration Test
+
+- **`TestProbeProcessVMReadv_CrossProcess`** (build-tagged `integration`): Fork a child, probe it from the parent. Validates the actual cross-process access pattern.
+
+### Existing Coverage
+
+- `ptracer_linux_test.go` — covers `setupPtracerPreload` (no changes to that code).
+- `file_handler_test.go` — covers ProcessVMReadv-failure handler paths.
+
+## Out of Scope
+
+- **C ptracer library changes**: `libagentsh-ptracer.so` already ignores prctl errors. Making it Yama-aware would save a failed syscall per child but adds complexity for negligible benefit.
+- **`agentsh detect` Yama tips**: The detect command's capability tips (#217) already cover Yama; this fix is orthogonal.
+- **Handler-level fallback improvements**: The existing `/proc/mem` fallbacks in `readStringWithFallback` and `resolvePathAtWithFallback` are already correct. The self-test catches the case where both mechanisms are broken.

--- a/internal/api/notify_linux.go
+++ b/internal/api/notify_linux.go
@@ -303,7 +303,7 @@ func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string,
 		if wrapperPID > 0 {
 			pvrErr, memErr := probeMemoryAccess(wrapperPID)
 			if pvrErr != nil && memErr != nil {
-				if fileHandler != nil || h != nil {
+				if fileHandler != nil || h != nil || pol != nil {
 					slog.Error("seccomp notify: ProcessVMReadv and /proc/mem both failed — "+
 						"handler cannot read tracee memory for path resolution",
 						"wrapper_pid", wrapperPID,
@@ -313,11 +313,19 @@ func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string,
 							"or set sandbox.seccomp.file_monitor.enabled: false")
 					return // Don't send ACK — wrapper fails with clear handshake error
 				}
-				slog.Warn("ProcessVMReadv probe failed, socket monitoring may be degraded",
+				slog.Warn("ProcessVMReadv probe failed, monitoring may be degraded",
 					"wrapper_pid", wrapperPID, "pvr_error", pvrErr, "mem_error", memErr)
 			} else if pvrErr != nil {
-				slog.Debug("ProcessVMReadv failed but /proc/mem fallback works",
-					"wrapper_pid", wrapperPID, "pvr_error", pvrErr)
+				// /proc/mem fallback works for file monitoring, but socket monitoring
+				// uses ProcessVMReadv directly (ReadSockaddr has no /proc/mem fallback).
+				if pol != nil {
+					slog.Warn("ProcessVMReadv failed — socket monitoring will be degraded "+
+						"(ReadSockaddr requires ProcessVMReadv), /proc/mem fallback works for file monitoring",
+						"wrapper_pid", wrapperPID, "pvr_error", pvrErr)
+				} else {
+					slog.Debug("ProcessVMReadv failed but /proc/mem fallback works",
+						"wrapper_pid", wrapperPID, "pvr_error", pvrErr)
+				}
 			}
 		}
 

--- a/internal/api/notify_linux.go
+++ b/internal/api/notify_linux.go
@@ -296,6 +296,31 @@ func startNotifyHandler(ctx context.Context, parentSock *os.File, sessID string,
 				}
 			}
 		}
+
+		// Probe: verify ProcessVMReadv (or /proc/mem fallback) works against
+		// the wrapper before starting. Catches Yama, missing CAP_SYS_PTRACE,
+		// or other LSM restrictions at startup instead of on first notification.
+		if wrapperPID > 0 {
+			pvrErr, memErr := probeMemoryAccess(wrapperPID)
+			if pvrErr != nil && memErr != nil {
+				if fileHandler != nil || h != nil {
+					slog.Error("seccomp notify: ProcessVMReadv and /proc/mem both failed — "+
+						"handler cannot read tracee memory for path resolution",
+						"wrapper_pid", wrapperPID,
+						"pvr_error", pvrErr, "mem_error", memErr,
+						"session_id", sessID,
+						"hint", "check kernel.yama.ptrace_scope, ensure CAP_SYS_PTRACE, "+
+							"or set sandbox.seccomp.file_monitor.enabled: false")
+					return // Don't send ACK — wrapper fails with clear handshake error
+				}
+				slog.Warn("ProcessVMReadv probe failed, socket monitoring may be degraded",
+					"wrapper_pid", wrapperPID, "pvr_error", pvrErr, "mem_error", memErr)
+			} else if pvrErr != nil {
+				slog.Debug("ProcessVMReadv failed but /proc/mem fallback works",
+					"wrapper_pid", wrapperPID, "pvr_error", pvrErr)
+			}
+		}
+
 		// Send ACK to wrapper so it knows the notify handler is ready before exec.
 		if _, err := parentSock.Write([]byte{1}); err != nil {
 			slog.Debug("notify: ACK write to wrapper failed", "error", err, "session_id", sessID)

--- a/internal/api/pvr_probe_linux.go
+++ b/internal/api/pvr_probe_linux.go
@@ -1,0 +1,85 @@
+//go:build linux && cgo
+
+package api
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+// probeMemoryAccess tests that the server can read from the given PID's address
+// space using ProcessVMReadv and the /proc/<pid>/mem fallback. Returns
+// (nil, nil) if ProcessVMReadv works, (pvrErr, nil) if only /proc/mem works,
+// or (pvrErr, memErr) if both fail.
+func probeMemoryAccess(pid int) (pvrErr, memErr error) {
+	addr, err := findReadableAddr(pid)
+	if err != nil {
+		return fmt.Errorf("find readable addr: %w", err), fmt.Errorf("find readable addr: %w", err)
+	}
+	pvrErr = probeProcessVMReadvAt(pid, addr)
+	if pvrErr != nil {
+		memErr = probeProcMemAt(pid, addr)
+	}
+	return pvrErr, memErr
+}
+
+// probeProcessVMReadvAt reads 8 bytes from the given address in the target
+// process via ProcessVMReadv. Returns nil on success.
+func probeProcessVMReadvAt(pid int, addr uint64) error {
+	buf := make([]byte, 8)
+	liov := unix.Iovec{Base: &buf[0], Len: 8}
+	riov := unix.RemoteIovec{Base: uintptr(addr), Len: 8}
+	_, err := unix.ProcessVMReadv(pid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
+	return err
+}
+
+// probeProcMemAt reads 8 bytes from the given address via /proc/<pid>/mem.
+// Returns nil on success.
+func probeProcMemAt(pid int, addr uint64) error {
+	f, err := os.Open(fmt.Sprintf("/proc/%d/mem", pid))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	buf := make([]byte, 8)
+	_, err = f.ReadAt(buf, int64(addr))
+	return err
+}
+
+// findReadableAddr parses /proc/<pid>/maps to find the start address of the
+// first readable mapping. Scans at most 20 lines.
+func findReadableAddr(pid int) (uint64, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/maps", pid))
+	if err != nil {
+		return 0, fmt.Errorf("read /proc/%d/maps: %w", pid, err)
+	}
+	lines := strings.Split(string(data), "\n")
+	limit := 20
+	if len(lines) < limit {
+		limit = len(lines)
+	}
+	for _, line := range lines[:limit] {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		// permissions field: rwxp — check first char is 'r'
+		if len(fields[1]) < 1 || fields[1][0] != 'r' {
+			continue
+		}
+		addrs := strings.SplitN(fields[0], "-", 2)
+		if len(addrs) < 2 {
+			continue
+		}
+		addr, err := strconv.ParseUint(addrs[0], 16, 64)
+		if err != nil {
+			continue
+		}
+		return addr, nil
+	}
+	return 0, fmt.Errorf("no readable mapping found in /proc/%d/maps (scanned %d lines)", pid, limit)
+}

--- a/internal/api/pvr_probe_linux.go
+++ b/internal/api/pvr_probe_linux.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strconv"
@@ -51,18 +52,18 @@ func probeProcMemAt(pid int, addr uint64) error {
 }
 
 // findReadableAddr parses /proc/<pid>/maps to find the start address of the
-// first readable mapping. Scans at most 20 lines.
+// first readable mapping. Scans all lines (no artificial cap) using a
+// streaming reader to avoid loading the entire maps file into memory.
 func findReadableAddr(pid int) (uint64, error) {
-	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/maps", pid))
+	f, err := os.Open(fmt.Sprintf("/proc/%d/maps", pid))
 	if err != nil {
-		return 0, fmt.Errorf("read /proc/%d/maps: %w", pid, err)
+		return 0, fmt.Errorf("open /proc/%d/maps: %w", pid, err)
 	}
-	lines := strings.Split(string(data), "\n")
-	limit := 20
-	if len(lines) < limit {
-		limit = len(lines)
-	}
-	for _, line := range lines[:limit] {
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
 		fields := strings.Fields(line)
 		if len(fields) < 2 {
 			continue
@@ -81,5 +82,8 @@ func findReadableAddr(pid int) (uint64, error) {
 		}
 		return addr, nil
 	}
-	return 0, fmt.Errorf("no readable mapping found in /proc/%d/maps (scanned %d lines)", pid, limit)
+	if err := scanner.Err(); err != nil {
+		return 0, fmt.Errorf("scan /proc/%d/maps: %w", pid, err)
+	}
+	return 0, fmt.Errorf("no readable mapping found in /proc/%d/maps", pid)
 }

--- a/internal/api/pvr_probe_linux_test.go
+++ b/internal/api/pvr_probe_linux_test.go
@@ -4,7 +4,9 @@ package api
 
 import (
 	"os"
+	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,4 +49,22 @@ func TestProbeMemoryAccess_InvalidPID(t *testing.T) {
 func TestFindReadableAddr_InvalidPID(t *testing.T) {
 	_, err := findReadableAddr(999999999)
 	assert.Error(t, err, "should fail for nonexistent PID")
+}
+
+func TestProbeMemoryAccess_CrossProcess(t *testing.T) {
+	// Fork a child process (sleep), probe it from parent, then kill it.
+	// This validates the actual access pattern: server reading from wrapper.
+	cmd := exec.Command("sleep", "10")
+	require.NoError(t, cmd.Start(), "failed to start child process")
+	defer func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	}()
+
+	// Give the child a moment to be fully mapped.
+	time.Sleep(50 * time.Millisecond)
+
+	pvrErr, memErr := probeMemoryAccess(cmd.Process.Pid)
+	assert.NoError(t, pvrErr, "ProcessVMReadv should succeed against child process")
+	assert.NoError(t, memErr, "memErr should be nil when ProcessVMReadv succeeds")
 }

--- a/internal/api/pvr_probe_linux_test.go
+++ b/internal/api/pvr_probe_linux_test.go
@@ -1,0 +1,50 @@
+//go:build linux && cgo
+
+package api
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindReadableAddr_Self(t *testing.T) {
+	addr, err := findReadableAddr(os.Getpid())
+	require.NoError(t, err, "should find a readable mapping in own process")
+	assert.NotZero(t, addr, "address should be non-zero")
+}
+
+func TestProbeProcessVMReadvAt_Self(t *testing.T) {
+	addr, err := findReadableAddr(os.Getpid())
+	require.NoError(t, err)
+
+	err = probeProcessVMReadvAt(os.Getpid(), addr)
+	assert.NoError(t, err, "ProcessVMReadv against own PID should succeed")
+}
+
+func TestProbeProcMemAt_Self(t *testing.T) {
+	addr, err := findReadableAddr(os.Getpid())
+	require.NoError(t, err)
+
+	err = probeProcMemAt(os.Getpid(), addr)
+	assert.NoError(t, err, "/proc/self/mem read should succeed")
+}
+
+func TestProbeMemoryAccess_Self(t *testing.T) {
+	pvrErr, memErr := probeMemoryAccess(os.Getpid())
+	assert.NoError(t, pvrErr, "ProcessVMReadv should succeed against self")
+	assert.NoError(t, memErr, "memErr should be nil when ProcessVMReadv succeeds")
+}
+
+func TestProbeMemoryAccess_InvalidPID(t *testing.T) {
+	pvrErr, memErr := probeMemoryAccess(999999999)
+	assert.Error(t, pvrErr, "should fail for nonexistent PID")
+	assert.Error(t, memErr, "fallback should also fail for nonexistent PID")
+}
+
+func TestFindReadableAddr_InvalidPID(t *testing.T) {
+	_, err := findReadableAddr(999999999)
+	assert.Error(t, err, "should fail for nonexistent PID")
+}

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -118,7 +118,7 @@ func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID
 	if wrapperPID > 0 {
 		pvrErr, memErr := probeMemoryAccess(wrapperPID)
 		if pvrErr != nil && memErr != nil {
-			if fileHandler != nil || execveHandler != nil {
+			if fileHandler != nil || execveHandler != nil || sessionPolicy != nil {
 				slog.Error("wrap: ProcessVMReadv and /proc/mem both failed — "+
 					"handler cannot read tracee memory for path resolution",
 					"wrapper_pid", wrapperPID,
@@ -133,11 +133,19 @@ func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID
 				}
 				return
 			}
-			slog.Warn("wrap: ProcessVMReadv probe failed, socket monitoring may be degraded",
+			slog.Warn("wrap: ProcessVMReadv probe failed, monitoring may be degraded",
 				"wrapper_pid", wrapperPID, "pvr_error", pvrErr, "mem_error", memErr)
 		} else if pvrErr != nil {
-			slog.Debug("wrap: ProcessVMReadv failed but /proc/mem fallback works",
-				"wrapper_pid", wrapperPID, "pvr_error", pvrErr)
+			// /proc/mem fallback works for file monitoring, but socket monitoring
+			// uses ProcessVMReadv directly (ReadSockaddr has no /proc/mem fallback).
+			if sessionPolicy != nil {
+				slog.Warn("wrap: ProcessVMReadv failed — socket monitoring will be degraded "+
+					"(ReadSockaddr requires ProcessVMReadv), /proc/mem fallback works for file monitoring",
+					"wrapper_pid", wrapperPID, "pvr_error", pvrErr)
+			} else {
+				slog.Debug("wrap: ProcessVMReadv failed but /proc/mem fallback works",
+					"wrapper_pid", wrapperPID, "pvr_error", pvrErr)
+			}
 		}
 	}
 

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -112,6 +112,35 @@ func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID
 	// Create file handler if configured
 	fileHandler := createFileHandler(a.cfg.Sandbox.Seccomp.FileMonitor, sessionPolicy, emitter, a.cfg.Landlock.Enabled)
 
+	// Probe: verify ProcessVMReadv (or /proc/mem fallback) works against
+	// the wrapper before starting. Same logic as the exec path probe in
+	// notify_linux.go — catches broken memory access at startup.
+	if wrapperPID > 0 {
+		pvrErr, memErr := probeMemoryAccess(wrapperPID)
+		if pvrErr != nil && memErr != nil {
+			if fileHandler != nil || execveHandler != nil {
+				slog.Error("wrap: ProcessVMReadv and /proc/mem both failed — "+
+					"handler cannot read tracee memory for path resolution",
+					"wrapper_pid", wrapperPID,
+					"pvr_error", pvrErr, "mem_error", memErr,
+					"session_id", sessionID,
+					"hint", "check kernel.yama.ptrace_scope, ensure CAP_SYS_PTRACE, "+
+						"or set sandbox.seccomp.file_monitor.enabled: false")
+				// Clean up resources that would normally be handled by the goroutine.
+				notifyFD.Close()
+				if cleanupSymlink != nil {
+					cleanupSymlink()
+				}
+				return
+			}
+			slog.Warn("wrap: ProcessVMReadv probe failed, socket monitoring may be degraded",
+				"wrapper_pid", wrapperPID, "pvr_error", pvrErr, "mem_error", memErr)
+		} else if pvrErr != nil {
+			slog.Debug("wrap: ProcessVMReadv failed but /proc/mem fallback works",
+				"wrapper_pid", wrapperPID, "pvr_error", pvrErr)
+		}
+	}
+
 	go func() {
 		defer notifyFD.Close()
 		if cleanupSymlink != nil {


### PR DESCRIPTION
## Summary

Fixes #218 — `file_monitor: PR_SET_PTRACER EINVAL treated as fatal on kernels without Yama LSM`

- **Yama detection**: Skip `PR_SET_PTRACER` when Yama LSM isn't loaded — the prctl is meaningless without Yama and standard Unix DAC governs ptrace
- **ProcessVMReadv self-test**: Probe memory access against the wrapper PID during the seccomp-notify handshake (both exec and wrap paths), failing fast with actionable diagnostics when both ProcessVMReadv and `/proc/mem` fallback are broken
- **Socket monitoring awareness**: Probe failure is fatal when socket monitoring is active (`pol != nil`), since `ReadSockaddr` uses ProcessVMReadv directly with no `/proc/mem` fallback
- **Streaming maps scan**: `findReadableAddr` uses `bufio.Scanner` instead of reading the entire `/proc/<pid>/maps` into memory with an arbitrary 20-line cap

### Failure behavior

| ProcessVMReadv | /proc/mem | Features active | Action |
|---|---|---|---|
| OK | (not tested) | any | Continue normally |
| Fail | OK | file/execve only | Continue (debug log) |
| Fail | OK | socket monitoring | Warn (degraded) |
| Fail | Fail | any feature active | **Fatal** — abort with diagnostics |
| Fail | Fail | none | Warn, continue |

### Known limitations

- **Wrap path ACK timing**: CLI ACKs the wrapper before the server confirms probe passed (pre-existing protocol design, not introduced by this PR)
- **`pol != nil` as socket monitoring proxy**: Policy engine presence is used as a proxy for socket monitoring activity — imprecise but acceptable approximation

## Test plan

- [x] `TestIsYamaActive_WhenPresent` / `_WhenAbsent` — Yama detection with temp file simulation
- [x] `TestProbeProcessVMReadvAt_Self` / `TestProbeProcMemAt_Self` — self-process memory probes
- [x] `TestProbeMemoryAccess_Self` / `_InvalidPID` — orchestrated probe success and failure
- [x] `TestFindReadableAddr_Self` / `_InvalidPID` — maps parsing
- [x] `TestProbeMemoryAccess_CrossProcess` — fork child, probe from parent (validates production access pattern)
- [x] `go test ./internal/api/ ./cmd/agentsh-unixwrap/` — all 9 new tests pass
- [x] `GOOS=windows go build ./...` — cross-compilation clean (all new files have `_linux.go` suffix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)