### PR TITLE
fix(landlock): derive execute paths from file rules

### DIFF
--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -225,9 +225,11 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 
 			// Derive paths from policy
 			if sessionPolicy != nil {
-				seccompCfg.AllowExecute = landlock.DeriveExecutePathsFromPolicy(sessionPolicy.Policy())
-				seccompCfg.AllowRead = landlock.DeriveReadPathsFromPolicy(sessionPolicy.Policy())
-				seccompCfg.AllowWrite = landlock.DeriveWritePathsFromPolicy(sessionPolicy.Policy())
+				pol := sessionPolicy.Policy()
+				seccompCfg.AllowExecute = landlock.DeriveExecutePathsFromPolicy(pol)
+				seccompCfg.AllowExecute = append(seccompCfg.AllowExecute, landlock.DeriveExecutePathsFromFileRules(pol)...)
+				seccompCfg.AllowRead = landlock.DeriveReadPathsFromPolicy(pol)
+				seccompCfg.AllowWrite = landlock.DeriveWritePathsFromPolicy(pol)
 			}
 
 			// Add explicit config paths

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -309,9 +309,11 @@ func (a *App) deriveLandlockAllowPaths(s *session.Session) (execute, read, write
 		return nil, nil, nil
 	}
 	pol := engine.Policy()
-	return landlock.DeriveExecutePathsFromPolicy(pol),
-		landlock.DeriveReadPathsFromPolicy(pol),
-		landlock.DeriveWritePathsFromPolicy(pol)
+	execute = landlock.DeriveExecutePathsFromPolicy(pol)
+	execute = append(execute, landlock.DeriveExecutePathsFromFileRules(pol)...)
+	read = landlock.DeriveReadPathsFromPolicy(pol)
+	write = landlock.DeriveWritePathsFromPolicy(pol)
+	return execute, read, write
 }
 
 // signalFilterEnabled reports whether wrap-init should create a signal

--- a/internal/landlock/policy.go
+++ b/internal/landlock/policy.go
@@ -262,6 +262,9 @@ func BuildFromConfig(cfg *config.LandlockConfig, pol *policy.Policy, workspace s
 		for _, p := range DeriveExecutePathsFromPolicy(pol) {
 			_ = b.AddExecutePath(p)
 		}
+		for _, p := range DeriveExecutePathsFromFileRules(pol) {
+			_ = b.AddExecutePath(p)
+		}
 		for _, p := range DeriveReadPathsFromPolicy(pol) {
 			_ = b.AddReadPath(p)
 		}

--- a/internal/landlock/policy.go
+++ b/internal/landlock/policy.go
@@ -172,6 +172,82 @@ func extractBaseDir(pathPattern string) string {
 	return filepath.Dir(pathPattern)
 }
 
+// knownBinaryDirs lists standard FHS directories that contain executable binaries.
+var knownBinaryDirs = []string{
+	"/bin", "/sbin",
+	"/usr/bin", "/usr/sbin",
+	"/usr/local/bin", "/usr/local/sbin",
+}
+
+// couldContainBinaries returns true if dir is, or is a parent of, a known
+// FHS binary directory (e.g. /bin, /usr/bin, /usr/local/sbin).
+func couldContainBinaries(dir string) bool {
+	for _, binDir := range knownBinaryDirs {
+		if dir == binDir || strings.HasPrefix(binDir, dir+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// DeriveExecutePathsFromFileRules extracts Landlock execute paths from file
+// rules that grant read access to FHS binary directories. This bridges the gap
+// when policies use bare command names (e.g. "git") with glob file rules
+// (e.g. "/usr/**", "/bin/**") -- without explicit execute paths, Landlock
+// blocks exec with EACCES.
+func DeriveExecutePathsFromFileRules(p *policy.Policy) []string {
+	if p == nil {
+		return nil
+	}
+
+	pathSet := make(map[string]struct{})
+
+	for _, rule := range p.FileRules {
+		// Only process allow rules
+		if strings.ToLower(rule.Decision) != "allow" {
+			continue
+		}
+
+		// Only include rules that allow read or open operations
+		hasReadOrOpen := false
+		for _, op := range rule.Operations {
+			op = strings.ToLower(op)
+			if op == "read" || op == "open" || op == "*" {
+				hasReadOrOpen = true
+				break
+			}
+		}
+		if !hasReadOrOpen && len(rule.Operations) > 0 {
+			continue
+		}
+
+		for _, path := range rule.Paths {
+			path = strings.TrimSpace(path)
+			if path == "" {
+				continue
+			}
+
+			// Extract base directory (strips globs)
+			dir := extractBaseDir(path)
+			if dir == "" || dir == "." || dir == "/" {
+				continue
+			}
+
+			// Only include directories that are or contain FHS binary dirs
+			if couldContainBinaries(dir) {
+				pathSet[dir] = struct{}{}
+			}
+		}
+	}
+
+	// Convert to slice
+	paths := make([]string, 0, len(pathSet))
+	for p := range pathSet {
+		paths = append(paths, p)
+	}
+	return paths
+}
+
 // BuildFromConfig creates a RulesetBuilder from config and policy.
 func BuildFromConfig(cfg *config.LandlockConfig, pol *policy.Policy, workspace string, abi int) (*RulesetBuilder, error) {
 	b := NewRulesetBuilder(abi)

--- a/internal/landlock/policy_test.go
+++ b/internal/landlock/policy_test.go
@@ -167,6 +167,113 @@ func TestDeriveWritePaths_WildcardOps(t *testing.T) {
 	}
 }
 
+func TestCouldContainBinaries(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("landlock tests use Unix paths")
+	}
+	tests := []struct {
+		dir  string
+		want bool
+	}{
+		{"/bin", true},
+		{"/sbin", true},
+		{"/usr", true},          // parent of /usr/bin
+		{"/usr/bin", true},
+		{"/usr/sbin", true},
+		{"/usr/local", true},    // parent of /usr/local/bin
+		{"/usr/local/bin", true},
+		{"/usr/local/sbin", true},
+		{"/lib", false},
+		{"/lib64", false},
+		{"/dev", false},
+		{"/etc", false},
+		{"/opt", false},
+		{"/tmp", false},
+		{"/home/user", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.dir, func(t *testing.T) {
+			if got := couldContainBinaries(tt.dir); got != tt.want {
+				t.Errorf("couldContainBinaries(%q) = %v, want %v", tt.dir, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeriveExecutePathsFromFileRules(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("landlock tests use Unix paths")
+	}
+	p := &policy.Policy{
+		FileRules: []policy.FileRule{
+			{
+				Name:       "allow-system-read",
+				Paths:      []string{"/usr/**", "/lib/**", "/lib64/**", "/bin/**", "/sbin/**", "/opt/**", "/dev/**"},
+				Operations: []string{"read", "open", "stat", "list", "readlink"},
+				Decision:   "allow",
+			},
+			{
+				Name:       "allow-tmp",
+				Paths:      []string{"/tmp/**", "/var/tmp/**"},
+				Operations: []string{"*"},
+				Decision:   "allow",
+			},
+			{
+				Name:       "deny-sensitive",
+				Paths:      []string{"/usr/bin/secret"},
+				Operations: []string{"read"},
+				Decision:   "deny",
+			},
+		},
+	}
+
+	paths := DeriveExecutePathsFromFileRules(p)
+	found := make(map[string]bool)
+	for _, p := range paths {
+		found[p] = true
+	}
+
+	for _, want := range []string{"/usr", "/bin", "/sbin"} {
+		if !found[want] {
+			t.Errorf("expected %q in result, got %v", want, paths)
+		}
+	}
+
+	for _, reject := range []string{"/lib", "/lib64", "/opt", "/dev", "/tmp", "/var/tmp"} {
+		if found[reject] {
+			t.Errorf("unexpected %q in result", reject)
+		}
+	}
+}
+
+func TestDeriveExecutePathsFromFileRules_NilPolicy(t *testing.T) {
+	paths := DeriveExecutePathsFromFileRules(nil)
+	if paths != nil {
+		t.Errorf("expected nil for nil policy, got %v", paths)
+	}
+}
+
+func TestDeriveExecutePathsFromFileRules_NoReadOps(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("landlock tests use Unix paths")
+	}
+	p := &policy.Policy{
+		FileRules: []policy.FileRule{
+			{
+				Name:       "write-only",
+				Paths:      []string{"/usr/bin/**"},
+				Operations: []string{"write"},
+				Decision:   "allow",
+			},
+		},
+	}
+
+	paths := DeriveExecutePathsFromFileRules(p)
+	if len(paths) != 0 {
+		t.Errorf("expected empty for write-only rule, got %v", paths)
+	}
+}
+
 func TestDeriveReadPaths(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("landlock tests use Unix paths")

--- a/internal/landlock/policy_test.go
+++ b/internal/landlock/policy_test.go
@@ -190,6 +190,7 @@ func TestCouldContainBinaries(t *testing.T) {
 		{"/opt", false},
 		{"/tmp", false},
 		{"/home/user", false},
+		{"/", false},           // root — filtered out by caller, but function itself returns false
 	}
 	for _, tt := range tests {
 		t.Run(tt.dir, func(t *testing.T) {
@@ -271,6 +272,131 @@ func TestDeriveExecutePathsFromFileRules_NoReadOps(t *testing.T) {
 	paths := DeriveExecutePathsFromFileRules(p)
 	if len(paths) != 0 {
 		t.Errorf("expected empty for write-only rule, got %v", paths)
+	}
+}
+
+func TestDeriveExecutePathsFromFileRules_EmptyFileRules(t *testing.T) {
+	// Non-nil policy with empty FileRules slice should return empty.
+	p := &policy.Policy{
+		FileRules: []policy.FileRule{},
+	}
+	paths := DeriveExecutePathsFromFileRules(p)
+	if len(paths) != 0 {
+		t.Errorf("expected empty for empty FileRules, got %v", paths)
+	}
+}
+
+func TestDeriveExecutePathsFromFileRules_EmptyOperations(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("landlock tests use Unix paths")
+	}
+	// A rule with empty Operations is treated as "all operations" (consistent
+	// with DeriveReadPathsFromPolicy behavior). This test documents that.
+	p := &policy.Policy{
+		FileRules: []policy.FileRule{
+			{
+				Name:       "no-ops-specified",
+				Paths:      []string{"/usr/bin/**"},
+				Operations: []string{},
+				Decision:   "allow",
+			},
+		},
+	}
+
+	paths := DeriveExecutePathsFromFileRules(p)
+	found := make(map[string]bool)
+	for _, p := range paths {
+		found[p] = true
+	}
+	if !found["/usr/bin"] {
+		t.Errorf("expected /usr/bin from rule with empty operations, got %v", paths)
+	}
+}
+
+func TestDeriveExecutePathsFromFileRules_Deduplication(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("landlock tests use Unix paths")
+	}
+	// Multiple rules pointing to the same base directory should be deduplicated.
+	p := &policy.Policy{
+		FileRules: []policy.FileRule{
+			{
+				Name:       "rule-a",
+				Paths:      []string{"/usr/bin/**"},
+				Operations: []string{"read"},
+				Decision:   "allow",
+			},
+			{
+				Name:       "rule-b",
+				Paths:      []string{"/usr/bin/**", "/usr/sbin/**"},
+				Operations: []string{"open"},
+				Decision:   "allow",
+			},
+		},
+	}
+
+	paths := DeriveExecutePathsFromFileRules(p)
+	counts := make(map[string]int)
+	for _, p := range paths {
+		counts[p]++
+	}
+	for dir, count := range counts {
+		if count > 1 {
+			t.Errorf("directory %q appears %d times, expected 1", dir, count)
+		}
+	}
+	if counts["/usr/bin"] != 1 {
+		t.Errorf("expected /usr/bin exactly once, got %d", counts["/usr/bin"])
+	}
+}
+
+// TestDeriveExecutePaths_BareCommandGap verifies that the original issue is
+// fixed: policies using bare command names (git, bash) produce no results from
+// DeriveExecutePathsFromPolicy, but DeriveExecutePathsFromFileRules fills the
+// gap when file rules grant read access to FHS binary directories.
+func TestDeriveExecutePaths_BareCommandGap(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("landlock tests use Unix paths")
+	}
+	// This mimics a real-world policy: bare command names + glob file rules.
+	p := &policy.Policy{
+		CommandRules: []policy.CommandRule{
+			{Name: "allow git", Commands: []string{"git"}, Decision: "allow"},
+			{Name: "allow bash", Commands: []string{"bash"}, Decision: "allow"},
+			{Name: "allow node", Commands: []string{"node"}, Decision: "allow"},
+		},
+		FileRules: []policy.FileRule{
+			{
+				Name:       "allow-system-read",
+				Paths:      []string{"/usr/**", "/bin/**", "/sbin/**", "/lib/**"},
+				Operations: []string{"read", "open"},
+				Decision:   "allow",
+			},
+		},
+	}
+
+	// DeriveExecutePathsFromPolicy should return empty — bare names have no "/".
+	fromCommands := DeriveExecutePathsFromPolicy(p)
+	if len(fromCommands) != 0 {
+		t.Errorf("DeriveExecutePathsFromPolicy should return empty for bare names, got %v", fromCommands)
+	}
+
+	// DeriveExecutePathsFromFileRules should bridge the gap.
+	fromFileRules := DeriveExecutePathsFromFileRules(p)
+	found := make(map[string]bool)
+	for _, p := range fromFileRules {
+		found[p] = true
+	}
+
+	// Must include FHS binary directory ancestors.
+	for _, want := range []string{"/usr", "/bin", "/sbin"} {
+		if !found[want] {
+			t.Errorf("DeriveExecutePathsFromFileRules missing %q — original issue NOT fixed", want)
+		}
+	}
+	// Must exclude non-binary dirs.
+	if found["/lib"] {
+		t.Errorf("/lib should not be included as execute path")
 	}
 }
 

--- a/internal/landlock/ruleset.go
+++ b/internal/landlock/ruleset.go
@@ -4,6 +4,7 @@ package landlock
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -73,6 +74,25 @@ type landlockNetPortAttr struct {
 	Port          uint64
 }
 
+// stripGlobPrefix returns the non-glob prefix of a path. If the path contains
+// glob characters (*, ?, [), returns everything before the first one with the
+// trailing slash trimmed. If no glob characters are present, returns the path
+// unchanged. Defense-in-depth: glob patterns should be stripped on the server
+// side, but if they leak through, this prevents unix.Open from receiving a
+// literal "/bin/**".
+func stripGlobPrefix(path string) string {
+	for i, c := range path {
+		if c == '*' || c == '?' || c == '[' {
+			prefix := strings.TrimSuffix(path[:i], "/")
+			if prefix == "" {
+				return "/"
+			}
+			return prefix
+		}
+	}
+	return path
+}
+
 // RulesetBuilder constructs a Landlock ruleset from paths.
 type RulesetBuilder struct {
 	abi          int
@@ -103,7 +123,12 @@ func (b *RulesetBuilder) SetWorkspace(path string) {
 
 // AddExecutePath adds a path where execution is allowed.
 func (b *RulesetBuilder) AddExecutePath(path string) error {
-	absPath, err := filepath.Abs(path)
+	cleaned := stripGlobPrefix(path)
+	if cleaned != path {
+		slog.Warn("landlock: glob pattern in execute path, stripped to base dir",
+			"original", path, "cleaned", cleaned)
+	}
+	absPath, err := filepath.Abs(cleaned)
 	if err != nil {
 		return fmt.Errorf("invalid path %s: %w", path, err)
 	}
@@ -113,7 +138,12 @@ func (b *RulesetBuilder) AddExecutePath(path string) error {
 
 // AddReadPath adds a path where reading is allowed.
 func (b *RulesetBuilder) AddReadPath(path string) error {
-	absPath, err := filepath.Abs(path)
+	cleaned := stripGlobPrefix(path)
+	if cleaned != path {
+		slog.Warn("landlock: glob pattern in read path, stripped to base dir",
+			"original", path, "cleaned", cleaned)
+	}
+	absPath, err := filepath.Abs(cleaned)
 	if err != nil {
 		return fmt.Errorf("invalid path %s: %w", path, err)
 	}
@@ -123,7 +153,12 @@ func (b *RulesetBuilder) AddReadPath(path string) error {
 
 // AddWritePath adds a path where writing is allowed.
 func (b *RulesetBuilder) AddWritePath(path string) error {
-	absPath, err := filepath.Abs(path)
+	cleaned := stripGlobPrefix(path)
+	if cleaned != path {
+		slog.Warn("landlock: glob pattern in write path, stripped to base dir",
+			"original", path, "cleaned", cleaned)
+	}
+	absPath, err := filepath.Abs(cleaned)
 	if err != nil {
 		return fmt.Errorf("invalid path %s: %w", path, err)
 	}
@@ -300,6 +335,8 @@ const accessFile = LANDLOCK_ACCESS_FS_EXECUTE |
 func (b *RulesetBuilder) addPathRule(rulesetFd int, path string, access uint64) error {
 	fd, err := unix.Open(path, unix.O_PATH|unix.O_CLOEXEC, 0)
 	if err != nil {
+		slog.Debug("landlock: addPathRule open failed",
+			"path", path, "error", err)
 		return fmt.Errorf("open %s: %w", path, err)
 	}
 	defer unix.Close(fd)

--- a/internal/landlock/ruleset_test.go
+++ b/internal/landlock/ruleset_test.go
@@ -83,6 +83,71 @@ func TestRulesetBuilder_WriteAccessMask_IncludesMakeSock(t *testing.T) {
 	}
 }
 
+func TestStripGlobPrefix(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"/bin/**", "/bin"},
+		{"/usr/bin/*", "/usr/bin"},
+		{"/opt/*/bin/*", "/opt"},
+		{"/usr/bin", "/usr/bin"},             // no glob — unchanged
+		{"/etc/ssl/certs", "/etc/ssl/certs"}, // no glob — unchanged
+		{"/**", "/"},
+		{"/tmp/test[0-9]", "/tmp/test"},
+		{"/a?b", "/a"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := stripGlobPrefix(tt.input); got != tt.want {
+				t.Errorf("stripGlobPrefix(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddExecutePath_GlobStripped(t *testing.T) {
+	b := NewRulesetBuilder(3)
+	err := b.AddExecutePath("/bin/**")
+	if err != nil {
+		t.Fatalf("AddExecutePath failed: %v", err)
+	}
+	if len(b.executePaths) != 1 {
+		t.Fatalf("expected 1 execute path, got %d", len(b.executePaths))
+	}
+	if b.executePaths[0] != "/bin" {
+		t.Errorf("expected /bin, got %s", b.executePaths[0])
+	}
+}
+
+func TestAddReadPath_GlobStripped(t *testing.T) {
+	b := NewRulesetBuilder(3)
+	err := b.AddReadPath("/usr/lib/**")
+	if err != nil {
+		t.Fatalf("AddReadPath failed: %v", err)
+	}
+	if len(b.readPaths) != 1 {
+		t.Fatalf("expected 1 read path, got %d", len(b.readPaths))
+	}
+	if b.readPaths[0] != "/usr/lib" {
+		t.Errorf("expected /usr/lib, got %s", b.readPaths[0])
+	}
+}
+
+func TestAddWritePath_GlobStripped(t *testing.T) {
+	b := NewRulesetBuilder(3)
+	err := b.AddWritePath("/tmp/**")
+	if err != nil {
+		t.Fatalf("AddWritePath failed: %v", err)
+	}
+	if len(b.writePaths) != 1 {
+		t.Fatalf("expected 1 write path, got %d", len(b.writePaths))
+	}
+	if b.writePaths[0] != "/tmp" {
+		t.Errorf("expected /tmp, got %s", b.writePaths[0])
+	}
+}
+
 func TestRulesetBuilder_IsDenied(t *testing.T) {
 	b := NewRulesetBuilder(3)
 	b.AddDenyPath("/var/run/docker.sock")


### PR DESCRIPTION
## Summary

- Adds `DeriveExecutePathsFromFileRules` to extract Landlock execute paths from policy file rules that grant read access to FHS binary directories (`/bin`, `/usr`, `/sbin`). This fixes EACCES on every exec when policies use bare command names (`git`, `bash`) with glob file rules (`/usr/**`, `/bin/**`).
- Adds `stripGlobPrefix` defense-in-depth in the wrapper's ruleset builder — if a glob pattern like `/bin/**` reaches `unix.Open`, it is stripped to `/bin` before the syscall, preventing silent ENOENT.
- Wires the new derivation into all three API integration points: `core.go`, `wrap.go`, and `BuildFromConfig`.

## Test plan

- [x] `TestDeriveExecutePaths_BareCommandGap` — proves the original issue is fixed (bare commands + file rules now produce execute paths)
- [x] `TestCouldContainBinaries` — 16 subtests covering FHS dirs, parents, and negatives
- [x] `TestDeriveExecutePathsFromFileRules` — Accomplish-style policy with inclusion/exclusion assertions
- [x] `TestStripGlobPrefix` — 8 subtests covering all glob characters and no-glob passthrough
- [x] `TestAdd{Execute,Read,Write}Path_GlobStripped` — end-to-end builder integration
- [x] `go test ./...` — full suite passes
- [x] `go build ./...` — clean build
- [x] `GOOS=windows go build ./...` — cross-compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)