### PR TITLE
Deferred sync audit write: move fsync off seccomp notify hot path

### DIFF
--- a/internal/api/file_monitor_linux_test.go
+++ b/internal/api/file_monitor_linux_test.go
@@ -45,7 +45,7 @@ func TestCreateFileHandler_NilPolicy(t *testing.T) {
 	require.NotNil(t, h)
 
 	// With nil policy, Handle should return ActionContinue
-	result := h.Handle(unixmon.FileRequest{
+	result, _ := h.Handle(unixmon.FileRequest{
 		PID:       1,
 		Path:      "/any/path",
 		Operation: "open",
@@ -79,7 +79,7 @@ func TestCreateFileHandler_EnforceWithoutFUSE(t *testing.T) {
 		h := createFileHandler(cfg, engine, nil, false)
 		require.NotNil(t, h)
 
-		result := h.Handle(unixmon.FileRequest{
+		result, _ := h.Handle(unixmon.FileRequest{
 			PID:       1,
 			Path:      "/etc/shadow",
 			Operation: "open",
@@ -96,7 +96,7 @@ func TestCreateFileHandler_EnforceWithoutFUSE(t *testing.T) {
 		h := createFileHandler(cfg, engine, nil, false)
 		require.NotNil(t, h)
 
-		result := h.Handle(unixmon.FileRequest{
+		result, _ := h.Handle(unixmon.FileRequest{
 			PID:       1,
 			Path:      "/etc/shadow",
 			Operation: "open",

--- a/internal/integration/execve_interception_test.go
+++ b/internal/integration/execve_interception_test.go
@@ -70,7 +70,7 @@ func TestExecveInterception_HandlerLogic(t *testing.T) {
 			Argv:      []string{"curl", "http://example.com"},
 			Truncated: false,
 		}
-		result := h.Handle(context.Background(), ctx)
+		result, _ := h.Handle(context.Background(), ctx)
 		assert.True(t, result.Allow, "direct curl (depth 0) should be allowed")
 	})
 
@@ -84,7 +84,7 @@ func TestExecveInterception_HandlerLogic(t *testing.T) {
 			Argv:      []string{"sh", "-c", "curl http://example.com"},
 			Truncated: false,
 		}
-		shellResult := h.Handle(context.Background(), shellCtx)
+		shellResult, _ := h.Handle(context.Background(), shellCtx)
 		assert.True(t, shellResult.Allow, "shell should be allowed")
 
 		// Now curl from the shell is nested (depth 1)
@@ -95,7 +95,7 @@ func TestExecveInterception_HandlerLogic(t *testing.T) {
 			Argv:      []string{"curl", "http://example.com"},
 			Truncated: false,
 		}
-		curlResult := h.Handle(context.Background(), curlCtx)
+		curlResult, _ := h.Handle(context.Background(), curlCtx)
 		assert.False(t, curlResult.Allow, "nested curl (depth 1) should be blocked")
 	})
 
@@ -108,7 +108,7 @@ func TestExecveInterception_HandlerLogic(t *testing.T) {
 			Argv:      []string{"agentsh", "exec"},
 			Truncated: false,
 		}
-		result := h.Handle(context.Background(), ctx)
+		result, _ := h.Handle(context.Background(), ctx)
 		assert.True(t, result.Allow, "agentsh should bypass")
 		assert.Equal(t, "internal_bypass", result.Rule)
 	})
@@ -122,7 +122,7 @@ func TestExecveInterception_HandlerLogic(t *testing.T) {
 			Argv:      []string{"echo", "hello"},
 			Truncated: true,
 		}
-		result := h.Handle(context.Background(), ctx)
+		result, _ := h.Handle(context.Background(), ctx)
 		assert.False(t, result.Allow, "truncated should be denied")
 		assert.Equal(t, "truncated", result.Reason)
 	})
@@ -176,7 +176,7 @@ func TestExecveInterception_DepthTracking(t *testing.T) {
 			Argv:      []string{"bash"},
 			Truncated: false,
 		}
-		result := h.Handle(context.Background(), ctx)
+		result, _ := h.Handle(context.Background(), ctx)
 		assert.True(t, result.Allow, "depth 0 should be allowed")
 	})
 
@@ -189,7 +189,7 @@ func TestExecveInterception_DepthTracking(t *testing.T) {
 			Argv:      []string{"script.sh"},
 			Truncated: false,
 		}
-		result := h.Handle(context.Background(), ctx)
+		result, _ := h.Handle(context.Background(), ctx)
 		assert.True(t, result.Allow, "depth 1 should be allowed")
 	})
 
@@ -202,7 +202,7 @@ func TestExecveInterception_DepthTracking(t *testing.T) {
 			Argv:      []string{"ls", "-la"},
 			Truncated: false,
 		}
-		result := h.Handle(context.Background(), ctx)
+		result, _ := h.Handle(context.Background(), ctx)
 		assert.True(t, result.Allow, "depth 2 should be allowed")
 	})
 
@@ -215,7 +215,7 @@ func TestExecveInterception_DepthTracking(t *testing.T) {
 			Argv:      []string{"cat", "file.txt"},
 			Truncated: false,
 		}
-		result := h.Handle(context.Background(), ctx)
+		result, _ := h.Handle(context.Background(), ctx)
 		assert.False(t, result.Allow, "depth 3 should be denied")
 	})
 }
@@ -261,7 +261,7 @@ func TestExecveInterception_SessionIsolation(t *testing.T) {
 			Argv:      []string{"echo", "hello"},
 			Truncated: false,
 		}
-		result := h.Handle(context.Background(), ctx)
+		result, _ := h.Handle(context.Background(), ctx)
 		assert.True(t, result.Allow)
 
 		// Verify session ID was set (after allow, PID is recorded)
@@ -280,7 +280,7 @@ func TestExecveInterception_SessionIsolation(t *testing.T) {
 			Argv:      []string{"date"},
 			Truncated: false,
 		}
-		result := h.Handle(context.Background(), ctx)
+		result, _ := h.Handle(context.Background(), ctx)
 		assert.True(t, result.Allow)
 
 		// Verify session ID is different
@@ -332,7 +332,7 @@ func TestExecveInterception_NoPolicy(t *testing.T) {
 		Truncated: false,
 	}
 
-	result := h.Handle(context.Background(), ctx)
+	result, _ := h.Handle(context.Background(), ctx)
 	assert.True(t, result.Allow, "should allow when no policy")
 	assert.Equal(t, "no_policy", result.Rule)
 }
@@ -388,7 +388,7 @@ func TestExecveInterception_TruncationPolicies(t *testing.T) {
 				Truncated: true,
 			}
 
-			result := h.Handle(context.Background(), ctx)
+			result, _ := h.Handle(context.Background(), ctx)
 			assert.Equal(t, tt.expectAllow, result.Allow, "truncation policy %s failed", tt.onTruncated)
 			if tt.expectRule != "" {
 				assert.Equal(t, tt.expectRule, result.Rule)

--- a/internal/netmonitor/unix/emit_order_test.go
+++ b/internal/netmonitor/unix/emit_order_test.go
@@ -1,0 +1,133 @@
+//go:build linux && cgo
+
+package unix
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// recordingEmitter records calls to AppendEvent and Publish so tests can
+// assert that builder functions do NOT call the emitter.
+type recordingEmitter struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (r *recordingEmitter) AppendEvent(_ context.Context, _ types.Event) error {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+	return nil
+}
+
+func (r *recordingEmitter) Publish(_ types.Event) {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+}
+
+// TestBuildEvent_ExecveHandler_NoSideEffects verifies that
+// ExecveHandler.buildEvent returns a well-formed event and does NOT call
+// the emitter.
+func TestBuildEvent_ExecveHandler_NoSideEffects(t *testing.T) {
+	rec := &recordingEmitter{}
+	h := &ExecveHandler{emitter: rec}
+
+	ctx := ExecveContext{
+		PID:       1234,
+		Filename:  "/bin/ls",
+		Argv:      []string{"ls"},
+		SessionID: "test-sess",
+	}
+	result := ExecveResult{
+		Allow:    true,
+		Action:   ActionContinue,
+		Rule:     "test",
+		Decision: "allow",
+	}
+
+	ev := h.buildEvent(ctx, result, "test")
+
+	if ev == nil {
+		t.Fatal("buildEvent returned nil event")
+	}
+	if ev.Type != "execve" {
+		t.Errorf("expected event Type %q, got %q", "execve", ev.Type)
+	}
+
+	rec.mu.Lock()
+	calls := rec.calls
+	rec.mu.Unlock()
+	if calls != 0 {
+		t.Errorf("buildEvent called the emitter %d time(s); expected 0", calls)
+	}
+}
+
+// TestBuildEvent_FileHandler_NoSideEffects verifies that
+// FileHandler.buildFileEvent returns a well-formed event and does NOT call
+// the emitter.
+func TestBuildEvent_FileHandler_NoSideEffects(t *testing.T) {
+	rec := &recordingEmitter{}
+	h := &FileHandler{emitter: rec}
+
+	req := FileRequest{
+		PID:       1234,
+		Path:      "/tmp/test",
+		Operation: "write",
+		SessionID: "test-sess",
+	}
+	dec := FilePolicyDecision{
+		Decision:          "allow",
+		EffectiveDecision: "allow",
+		Rule:              "test",
+	}
+
+	ev := h.buildFileEvent(req, dec, false, false)
+
+	if ev == nil {
+		t.Fatal("buildFileEvent returned nil event")
+	}
+	if len(ev.Type) < 5 || ev.Type[:5] != "file_" {
+		t.Errorf("expected event Type to start with %q, got %q", "file_", ev.Type)
+	}
+
+	rec.mu.Lock()
+	calls := rec.calls
+	rec.mu.Unlock()
+	if calls != 0 {
+		t.Errorf("buildFileEvent called the emitter %d time(s); expected 0", calls)
+	}
+}
+
+// TestBuildEvent_UnixSocket_NoSideEffects verifies that buildUnixSocketEvent
+// returns a well-formed event and does NOT call the emitter.
+func TestBuildEvent_UnixSocket_NoSideEffects(t *testing.T) {
+	rec := &recordingEmitter{}
+
+	dec := policy.Decision{
+		PolicyDecision:    types.DecisionDeny,
+		EffectiveDecision: types.DecisionDeny,
+		Rule:              "test_rule",
+	}
+
+	ev := buildUnixSocketEvent(rec, "test-sess", dec, "/tmp/test.sock", false, "connect")
+
+	if ev == nil {
+		t.Fatal("buildUnixSocketEvent returned nil event")
+	}
+	if ev.Type != "unix_socket_op" {
+		t.Errorf("expected event Type %q, got %q", "unix_socket_op", ev.Type)
+	}
+
+	rec.mu.Lock()
+	calls := rec.calls
+	rec.mu.Unlock()
+	if calls != 0 {
+		t.Errorf("buildUnixSocketEvent called the emitter %d time(s); expected 0", calls)
+	}
+}

--- a/internal/netmonitor/unix/execve_handler.go
+++ b/internal/netmonitor/unix/execve_handler.go
@@ -139,8 +139,9 @@ func (h *ExecveHandler) RegisterSession(pid int, sessionID string) {
 	}
 }
 
-// Handle processes an execve notification and returns the decision.
-func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveResult {
+// Handle processes an execve notification and returns the decision plus an
+// optional audit event. The caller is responsible for emitting the event.
+func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) (ExecveResult, *types.Event) {
 	if goCtx == nil {
 		goCtx = context.Background()
 	}
@@ -179,8 +180,7 @@ func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveR
 		}
 		result := ExecveResult{Allow: true, Action: ActionContinue, Rule: "internal_bypass", Decision: "allow"}
 		// Log every execve per design doc, including internal bypass
-		h.emitEvent(ctx, result, "internal_bypass")
-		return result
+		return result, h.buildEvent(ctx, result, "internal_bypass")
 	}
 
 	// Check truncation policy
@@ -194,8 +194,7 @@ func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveR
 				Errno:    int32(unix.EACCES),
 				Decision: "deny",
 			}
-			h.emitEvent(ctx, result, "truncated")
-			return result
+			return result, h.buildEvent(ctx, result, "truncated")
 		case "approval":
 			if h.approver == nil {
 				result := ExecveResult{
@@ -205,8 +204,7 @@ func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveR
 					Errno:    int32(unix.EACCES),
 					Decision: "deny",
 				}
-				h.emitEvent(ctx, result, "truncated_no_approver")
-				return result
+				return result, h.buildEvent(ctx, result, "truncated_no_approver")
 			}
 			timeout := h.cfg.ApprovalTimeout
 			if timeout <= 0 {
@@ -239,8 +237,7 @@ func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveR
 					Errno:    int32(unix.EACCES),
 					Decision: "deny",
 				}
-				h.emitEvent(ctx, result, reason)
-				return result
+				return result, h.buildEvent(ctx, result, reason)
 			}
 			if !approved {
 				result := ExecveResult{
@@ -250,8 +247,7 @@ func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveR
 					Errno:    int32(unix.EACCES),
 					Decision: "deny",
 				}
-				h.emitEvent(ctx, result, "truncated_approval_denied")
-				return result
+				return result, h.buildEvent(ctx, result, "truncated_approval_denied")
 			}
 			// Approved — fall through to policy check
 		// "allow" falls through to policy check
@@ -291,8 +287,7 @@ func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveR
 				Errno:    int32(unix.EACCES),
 				Decision: payloadDecision.Decision,
 			}
-			h.emitEvent(ctx, result, payloadDecision.Rule)
-			return result
+			return result, h.buildEvent(ctx, result, payloadDecision.Rule)
 		}
 		if wrapperEffective == "deny" {
 			result := ExecveResult{
@@ -303,8 +298,7 @@ func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveR
 				Errno:    int32(unix.EACCES),
 				Decision: wrapperDecision.Decision,
 			}
-			h.emitEvent(ctx, result, wrapperDecision.Rule)
-			return result
+			return result, h.buildEvent(ctx, result, wrapperDecision.Rule)
 		}
 
 		// Both allowed — use the more restrictive decision
@@ -325,8 +319,7 @@ func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveR
 		switch effectiveDecision {
 		case "allow":
 			result := ExecveResult{Allow: true, Action: ActionContinue, Rule: chosenDecision.Rule, Decision: chosenDecision.Decision}
-			h.emitEvent(ctx, result, chosenDecision.Rule)
-			return result
+			return result, h.buildEvent(ctx, result, chosenDecision.Rule)
 		case "approve", "redirect":
 			result := ExecveResult{
 				Allow:    false,
@@ -336,8 +329,7 @@ func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveR
 				Decision: chosenDecision.Decision,
 				Redirect: chosenDecision.Redirect,
 			}
-			h.emitEvent(ctx, result, chosenDecision.Rule)
-			return result
+			return result, h.buildEvent(ctx, result, chosenDecision.Rule)
 		default:
 			// Unknown — fall through to normal evaluation
 		}
@@ -351,8 +343,7 @@ func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveR
 			h.depthTracker.RecordExecve(ctx.PID, ctx.ParentPID)
 		}
 		// Log every execve per design doc, including when no policy
-		h.emitEvent(ctx, result, "no_policy")
-		return result
+		return result, h.buildEvent(ctx, result, "no_policy")
 	}
 
 	// Check policy
@@ -374,8 +365,7 @@ func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveR
 			h.depthTracker.RecordExecve(ctx.PID, ctx.ParentPID)
 		}
 		result := ExecveResult{Allow: true, Action: ActionContinue, Rule: decision.Rule, Decision: decision.Decision}
-		h.emitEvent(ctx, result, decision.Rule)
-		return result
+		return result, h.buildEvent(ctx, result, decision.Rule)
 
 	case "deny":
 		result := ExecveResult{
@@ -386,8 +376,7 @@ func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveR
 			Errno:    int32(unix.EACCES),
 			Decision: decision.Decision,
 		}
-		h.emitEvent(ctx, result, decision.Rule)
-		return result
+		return result, h.buildEvent(ctx, result, decision.Rule)
 
 	case "approve":
 		// Redirect to agentsh-stub for approval workflow
@@ -399,8 +388,7 @@ func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveR
 			Decision: decision.Decision,
 			Redirect: decision.Redirect,
 		}
-		h.emitEvent(ctx, result, decision.Rule)
-		return result
+		return result, h.buildEvent(ctx, result, decision.Rule)
 
 	case "redirect":
 		// Redirect execve to agentsh-stub
@@ -412,8 +400,7 @@ func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveR
 			Decision: decision.Decision,
 			Redirect: decision.Redirect,
 		}
-		h.emitEvent(ctx, result, decision.Rule)
-		return result
+		return result, h.buildEvent(ctx, result, decision.Rule)
 
 	default:
 		// Unknown effective decision - deny (fail-secure)
@@ -424,15 +411,14 @@ func (h *ExecveHandler) Handle(goCtx context.Context, ctx ExecveContext) ExecveR
 			Errno:    int32(unix.EACCES),
 			Decision: decision.Decision,
 		}
-		h.emitEvent(ctx, result, "unknown")
-		return result
+		return result, h.buildEvent(ctx, result, "unknown")
 	}
 }
 
-// emitEvent emits an execve event to the emitter if configured.
-func (h *ExecveHandler) emitEvent(ctx ExecveContext, result ExecveResult, rule string) {
+// buildEvent builds an execve audit event without emitting it.
+func (h *ExecveHandler) buildEvent(ctx ExecveContext, result ExecveResult, rule string) *types.Event {
 	if h.emitter == nil {
-		return
+		return nil
 	}
 
 	action := "allowed"
@@ -456,7 +442,7 @@ func (h *ExecveHandler) emitEvent(ctx ExecveContext, result ExecveResult, rule s
 		effectiveDecision = types.DecisionDeny
 	}
 
-	ev := types.Event{
+	return &types.Event{
 		ID:        fmt.Sprintf("execve-%d-%d", ctx.PID, time.Now().UnixNano()),
 		Timestamp: time.Now().UTC(),
 		Type:      "execve",
@@ -478,9 +464,6 @@ func (h *ExecveHandler) emitEvent(ctx ExecveContext, result ExecveResult, rule s
 		},
 		EffectiveAction: action,
 	}
-
-	_ = h.emitter.AppendEvent(context.Background(), ev)
-	h.emitter.Publish(ev)
 }
 
 // isInternalBypass checks if filename matches internal bypass patterns.

--- a/internal/netmonitor/unix/execve_handler_test.go
+++ b/internal/netmonitor/unix/execve_handler_test.go
@@ -44,7 +44,7 @@ func TestExecveHandler_Handle_Allow(t *testing.T) {
 		Truncated: false,
 	}
 
-	result := h.Handle(context.Background(), ctx)
+	result, _ := h.Handle(context.Background(), ctx)
 	assert.True(t, result.Allow)
 	assert.Equal(t, "allow-git", result.Rule)
 }
@@ -68,7 +68,7 @@ func TestExecveHandler_Handle_Deny(t *testing.T) {
 		Truncated: false,
 	}
 
-	result := h.Handle(context.Background(), ctx)
+	result, _ := h.Handle(context.Background(), ctx)
 	assert.False(t, result.Allow)
 }
 
@@ -91,7 +91,7 @@ func TestExecveHandler_Handle_TruncatedDeny(t *testing.T) {
 		Truncated: true,
 	}
 
-	result := h.Handle(context.Background(), ctx)
+	result, _ := h.Handle(context.Background(), ctx)
 	assert.False(t, result.Allow)
 	assert.Equal(t, "truncated", result.Reason)
 }
@@ -113,7 +113,7 @@ func TestExecveHandler_Handle_InternalBypass(t *testing.T) {
 		Truncated: false,
 	}
 
-	result := h.Handle(context.Background(), ctx)
+	result, _ := h.Handle(context.Background(), ctx)
 	assert.True(t, result.Allow)
 	assert.Equal(t, "internal_bypass", result.Rule)
 }
@@ -161,7 +161,7 @@ func TestExecveHandler_Action(t *testing.T) {
 		dt.RegisterSession(1000, "sess-1")
 		h := NewExecveHandler(cfg, pol, dt, nil)
 
-		result := h.Handle(context.Background(), ExecveContext{
+		result, _ := h.Handle(context.Background(), ExecveContext{
 			PID:       1001,
 			ParentPID: 1000,
 			Filename:  "/usr/bin/git",
@@ -185,7 +185,7 @@ func TestExecveHandler_Action(t *testing.T) {
 		dt.RegisterSession(1000, "sess-1")
 		h := NewExecveHandler(cfg, pol, dt, nil)
 
-		result := h.Handle(context.Background(), ExecveContext{
+		result, _ := h.Handle(context.Background(), ExecveContext{
 			PID:       1001,
 			ParentPID: 1000,
 			Filename:  "/usr/bin/curl",
@@ -210,7 +210,7 @@ func TestExecveHandler_Action(t *testing.T) {
 		dt.RegisterSession(1000, "sess-1")
 		h := NewExecveHandler(cfg, pol, dt, nil)
 
-		result := h.Handle(context.Background(), ExecveContext{
+		result, _ := h.Handle(context.Background(), ExecveContext{
 			PID:       1001,
 			ParentPID: 1000,
 			Filename:  "/usr/bin/rm",
@@ -234,7 +234,7 @@ func TestExecveHandler_Action(t *testing.T) {
 		dt.RegisterSession(1000, "sess-1")
 		h := NewExecveHandler(cfg, pol, dt, nil)
 
-		result := h.Handle(context.Background(), ExecveContext{
+		result, _ := h.Handle(context.Background(), ExecveContext{
 			PID:       1001,
 			ParentPID: 1000,
 			Filename:  "/usr/bin/rm",
@@ -258,7 +258,7 @@ func TestExecveHandler_Action(t *testing.T) {
 		dt.RegisterSession(1000, "sess-1")
 		h := NewExecveHandler(cfg, pol, dt, nil)
 
-		result := h.Handle(context.Background(), ExecveContext{
+		result, _ := h.Handle(context.Background(), ExecveContext{
 			PID:       1001,
 			ParentPID: 1000,
 			Filename:  "/usr/bin/npm",
@@ -277,7 +277,7 @@ func TestExecveHandler_Action(t *testing.T) {
 		dt := NewDepthTracker()
 		h := NewExecveHandler(cfg, nil, dt, nil)
 
-		result := h.Handle(context.Background(), ExecveContext{
+		result, _ := h.Handle(context.Background(), ExecveContext{
 			PID:       1001,
 			ParentPID: 1000,
 			Filename:  "/usr/local/bin/agentsh",
@@ -295,7 +295,7 @@ func TestExecveHandler_Action(t *testing.T) {
 		dt.RegisterSession(1000, "sess-1")
 		h := NewExecveHandler(cfg, nil, dt, nil)
 
-		result := h.Handle(context.Background(), ExecveContext{
+		result, _ := h.Handle(context.Background(), ExecveContext{
 			PID:       1001,
 			ParentPID: 1000,
 			Filename:  "/usr/bin/ls",
@@ -312,7 +312,7 @@ func TestExecveHandler_Action(t *testing.T) {
 		dt := NewDepthTracker()
 		h := NewExecveHandler(cfg, nil, dt, nil)
 
-		result := h.Handle(context.Background(), ExecveContext{
+		result, _ := h.Handle(context.Background(), ExecveContext{
 			PID:       1001,
 			ParentPID: 1000,
 			Filename:  "/usr/bin/something",
@@ -330,7 +330,7 @@ func TestExecveHandler_Action(t *testing.T) {
 		dt := NewDepthTracker()
 		h := NewExecveHandler(cfg, nil, dt, nil)
 
-		result := h.Handle(context.Background(), ExecveContext{
+		result, _ := h.Handle(context.Background(), ExecveContext{
 			PID:       1001,
 			ParentPID: 1000,
 			Filename:  "/usr/bin/something",
@@ -354,7 +354,7 @@ func TestExecveHandler_Action(t *testing.T) {
 		dt.RegisterSession(1000, "sess-1")
 		h := NewExecveHandler(cfg, pol, dt, nil)
 
-		result := h.Handle(context.Background(), ExecveContext{
+		result, _ := h.Handle(context.Background(), ExecveContext{
 			PID:       1001,
 			ParentPID: 1000,
 			Filename:  "/usr/bin/mystery",
@@ -397,7 +397,7 @@ func TestExecveHandler_TruncatedApproval_Approved(t *testing.T) {
 	h := NewExecveHandler(cfg, pol, dt, nil)
 	h.SetApprover(approver)
 
-	result := h.Handle(context.Background(), ExecveContext{
+	result, _ := h.Handle(context.Background(), ExecveContext{
 		PID:       1001,
 		ParentPID: 1000,
 		Filename:  "/usr/bin/something",
@@ -423,7 +423,7 @@ func TestExecveHandler_TruncatedApproval_Denied(t *testing.T) {
 	h := NewExecveHandler(cfg, nil, dt, nil)
 	h.SetApprover(approver)
 
-	result := h.Handle(context.Background(), ExecveContext{
+	result, _ := h.Handle(context.Background(), ExecveContext{
 		PID:       1001,
 		ParentPID: 1000,
 		Filename:  "/usr/bin/something",
@@ -449,7 +449,7 @@ func TestExecveHandler_TruncatedApproval_Timeout(t *testing.T) {
 		h := NewExecveHandler(cfg, nil, dt, nil)
 		h.SetApprover(approver)
 
-		result := h.Handle(context.Background(), ExecveContext{
+		result, _ := h.Handle(context.Background(), ExecveContext{
 			PID:       1001,
 			ParentPID: 1000,
 			Filename:  "/usr/bin/something",
@@ -480,7 +480,7 @@ func TestExecveHandler_TruncatedApproval_Timeout(t *testing.T) {
 		h := NewExecveHandler(cfg, pol, dt, nil)
 		h.SetApprover(approver)
 
-		result := h.Handle(context.Background(), ExecveContext{
+		result, _ := h.Handle(context.Background(), ExecveContext{
 			PID:       1001,
 			ParentPID: 1000,
 			Filename:  "/usr/bin/something",
@@ -505,7 +505,7 @@ func TestExecveHandler_TruncatedApproval_Timeout(t *testing.T) {
 		h := NewExecveHandler(cfg, nil, dt, nil)
 		h.SetApprover(approver)
 
-		result := h.Handle(context.Background(), ExecveContext{
+		result, _ := h.Handle(context.Background(), ExecveContext{
 			PID:       1001,
 			ParentPID: 1000,
 			Filename:  "/usr/bin/something",
@@ -537,7 +537,7 @@ func TestExecveContext_RawFilename(t *testing.T) {
 		Argv:        []string{"git", "status"},
 	}
 
-	result := h.Handle(context.Background(), ctx)
+	result, _ := h.Handle(context.Background(), ctx)
 	assert.True(t, result.Allow)
 	// RawFilename should be accessible on the context
 	assert.Equal(t, "/proc/self/root/usr/bin/git", ctx.RawFilename)
@@ -549,7 +549,7 @@ func TestExecveHandler_TruncatedApproval_NoApprover(t *testing.T) {
 	h := NewExecveHandler(cfg, nil, dt, nil)
 	// No approver set — fail-secure
 
-	result := h.Handle(context.Background(), ExecveContext{
+	result, _ := h.Handle(context.Background(), ExecveContext{
 		PID:       1001,
 		ParentPID: 1000,
 		Filename:  "/usr/bin/something",
@@ -599,7 +599,7 @@ func TestExecveHandler_TransparentUnwrap_DenyPayload(t *testing.T) {
 	dt.RegisterSession(1000, "sess-1")
 	h := NewExecveHandler(ExecveHandlerConfig{}, pol, dt, nil)
 
-	result := h.Handle(context.Background(), ExecveContext{
+	result, _ := h.Handle(context.Background(), ExecveContext{
 		PID:       1001,
 		ParentPID: 1000,
 		Filename:  "/usr/bin/env",
@@ -621,7 +621,7 @@ func TestExecveHandler_TransparentUnwrap_AllowPayload(t *testing.T) {
 	dt.RegisterSession(1000, "sess-1")
 	h := NewExecveHandler(ExecveHandlerConfig{}, pol, dt, nil)
 
-	result := h.Handle(context.Background(), ExecveContext{
+	result, _ := h.Handle(context.Background(), ExecveContext{
 		PID:       1001,
 		ParentPID: 1000,
 		Filename:  "/usr/bin/env",
@@ -641,7 +641,7 @@ func TestExecveHandler_TransparentUnwrap_DenyWrapper(t *testing.T) {
 	dt.RegisterSession(1000, "sess-1")
 	h := NewExecveHandler(ExecveHandlerConfig{}, pol, dt, nil)
 
-	result := h.Handle(context.Background(), ExecveContext{
+	result, _ := h.Handle(context.Background(), ExecveContext{
 		PID:       1001,
 		ParentPID: 1000,
 		Filename:  "/usr/bin/sudo",
@@ -661,7 +661,7 @@ func TestExecveHandler_TransparentUnwrap_NonTransparent(t *testing.T) {
 	dt.RegisterSession(1000, "sess-1")
 	h := NewExecveHandler(ExecveHandlerConfig{}, pol, dt, nil)
 
-	result := h.Handle(context.Background(), ExecveContext{
+	result, _ := h.Handle(context.Background(), ExecveContext{
 		PID:       1001,
 		ParentPID: 1000,
 		Filename:  "/usr/bin/git",
@@ -683,15 +683,16 @@ func TestExecveHandler_TransparentUnwrap_AuditFields(t *testing.T) {
 	emitter := &mockEmitter{}
 	h := NewExecveHandler(ExecveHandlerConfig{}, pol, dt, emitter)
 
-	h.Handle(context.Background(), ExecveContext{
+	_, ev := h.Handle(context.Background(), ExecveContext{
 		PID:       1001,
 		ParentPID: 1000,
 		Filename:  "/usr/bin/env",
 		Argv:      []string{"env", "git", "status"},
 	})
 
-	require.Len(t, emitter.events, 1)
-	ev := emitter.events[0]
+	// Handle() no longer emits directly — the caller is responsible.
+	// Verify the returned event carries the unwrap audit fields.
+	require.NotNil(t, ev)
 	assert.Equal(t, "/usr/bin/env", ev.UnwrappedFrom)
 	assert.Equal(t, "git", ev.PayloadCommand)
 }

--- a/internal/netmonitor/unix/file_handler.go
+++ b/internal/netmonitor/unix/file_handler.go
@@ -3,7 +3,6 @@
 package unix
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -72,19 +71,20 @@ func (h *FileHandler) EmulateOpen() bool {
 	return h.emulateOpen
 }
 
-// Handle evaluates a file request against policy and returns the enforcement result.
+// Handle evaluates a file request against policy and returns the enforcement result
+// and an optional audit event. The caller is responsible for emitting the event.
 //
 // Routing logic:
 //  1. No policy -> allow with "no_policy" event.
 //  2. Path under FUSE mount -> audit-only (FUSE handles enforcement).
 //  3. Otherwise -> full enforcement based on policy decision and enforce flag.
-func (h *FileHandler) Handle(req FileRequest) FileResult {
+func (h *FileHandler) Handle(req FileRequest) (FileResult, *types.Event) {
 	// 0. Pseudo-paths (pipe:[...], socket:[...], anon_inode:[...]) resolve
 	//    from /proc/<pid>/fd/<N> for non-filesystem fds. They are not
 	//    filesystem objects and cannot match path-based policy rules —
 	//    allow unconditionally to avoid spurious denials.
 	if req.Path != "" && !strings.HasPrefix(req.Path, "/") {
-		return FileResult{Action: ActionContinue}
+		return FileResult{Action: ActionContinue}, nil
 	}
 
 	// 1. No policy configured — allow everything.
@@ -94,8 +94,7 @@ func (h *FileHandler) Handle(req FileRequest) FileResult {
 			EffectiveDecision: "allow",
 			Rule:              "no_policy",
 		}
-		h.emitFileEvent(req, dec, false, false)
-		return FileResult{Action: ActionContinue}
+		return FileResult{Action: ActionContinue}, h.buildFileEvent(req, dec, false, false)
 	}
 
 	// Resolve /proc/self/fd/N, /proc/<pid>/fd/N, /dev/fd/N to actual target.
@@ -116,8 +115,7 @@ func (h *FileHandler) Handle(req FileRequest) FileResult {
 	if h.registry != nil && h.registry.IsUnderFUSEMount(req.SessionID, req.Path) {
 		dec := h.policy.CheckFile(req.Path, req.Operation)
 		shadowDeny := dec.EffectiveDecision == "deny"
-		h.emitFileEvent(req, dec, false, shadowDeny)
-		return FileResult{Action: ActionContinue}
+		return FileResult{Action: ActionContinue}, h.buildFileEvent(req, dec, false, shadowDeny)
 	}
 
 	// 3. Full enforcement path.
@@ -135,23 +133,20 @@ func (h *FileHandler) Handle(req FileRequest) FileResult {
 	if dec.EffectiveDecision == "deny" {
 		if !h.enforce {
 			// Audit-only mode: log but allow.
-			h.emitFileEvent(req, dec, false, false)
-			return FileResult{Action: ActionContinue}
+			return FileResult{Action: ActionContinue}, h.buildFileEvent(req, dec, false, false)
 		}
 		// Enforced deny.
-		h.emitFileEvent(req, dec, true, false)
-		return FileResult{Action: ActionDeny, Errno: int32(sysunix.EACCES)}
+		return FileResult{Action: ActionDeny, Errno: int32(sysunix.EACCES)}, h.buildFileEvent(req, dec, true, false)
 	}
 
 	// Allowed.
-	h.emitFileEvent(req, dec, false, false)
-	return FileResult{Action: ActionContinue}
+	return FileResult{Action: ActionContinue}, h.buildFileEvent(req, dec, false, false)
 }
 
-// emitFileEvent emits a structured event for a file operation.
-func (h *FileHandler) emitFileEvent(req FileRequest, dec FilePolicyDecision, blocked, shadowDeny bool) {
+// buildFileEvent builds a structured event for a file operation without emitting it.
+func (h *FileHandler) buildFileEvent(req FileRequest, dec FilePolicyDecision, blocked, shadowDeny bool) *types.Event {
 	if h.emitter == nil {
-		return
+		return nil
 	}
 
 	action := "allowed"
@@ -169,7 +164,7 @@ func (h *FileHandler) emitFileEvent(req FileRequest, dec FilePolicyDecision, blo
 		fields["path2"] = req.Path2
 	}
 
-	ev := types.Event{
+	ev := &types.Event{
 		ID:        fmt.Sprintf("file-%d-%d", req.PID, time.Now().UnixNano()),
 		Timestamp: time.Now().UTC(),
 		Type:      "file_" + req.Operation,
@@ -188,6 +183,5 @@ func (h *FileHandler) emitFileEvent(req FileRequest, dec FilePolicyDecision, blo
 		Fields:          fields,
 	}
 
-	_ = h.emitter.AppendEvent(context.Background(), ev)
-	h.emitter.Publish(ev)
+	return ev
 }

--- a/internal/netmonitor/unix/file_handler_test.go
+++ b/internal/netmonitor/unix/file_handler_test.go
@@ -64,7 +64,10 @@ func TestFileHandler_AllowWithoutFUSE(t *testing.T) {
 		SessionID: "sess-1",
 	}
 
-	result := handler.Handle(req)
+	result, ev := handler.Handle(req)
+	if ev != nil {
+		_ = emitter.AppendEvent(context.Background(), *ev)
+	}
 
 	if result.Action != ActionContinue {
 		t.Errorf("expected ActionContinue, got %s", result.Action)
@@ -75,24 +78,24 @@ func TestFileHandler_AllowWithoutFUSE(t *testing.T) {
 	if len(emitter.events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(emitter.events))
 	}
-	ev := emitter.events[0]
-	if ev.Source != "seccomp" {
-		t.Errorf("expected Source 'seccomp', got %q", ev.Source)
+	ev0 := emitter.events[0]
+	if ev0.Source != "seccomp" {
+		t.Errorf("expected Source 'seccomp', got %q", ev0.Source)
 	}
-	if ev.Type != "file_open" {
-		t.Errorf("expected Type 'file_open', got %q", ev.Type)
+	if ev0.Type != "file_open" {
+		t.Errorf("expected Type 'file_open', got %q", ev0.Type)
 	}
-	if ev.Path != "/home/user/file.txt" {
-		t.Errorf("expected Path '/home/user/file.txt', got %q", ev.Path)
+	if ev0.Path != "/home/user/file.txt" {
+		t.Errorf("expected Path '/home/user/file.txt', got %q", ev0.Path)
 	}
-	if ev.SessionID != "sess-1" {
-		t.Errorf("expected SessionID 'sess-1', got %q", ev.SessionID)
+	if ev0.SessionID != "sess-1" {
+		t.Errorf("expected SessionID 'sess-1', got %q", ev0.SessionID)
 	}
-	if ev.Policy == nil {
+	if ev0.Policy == nil {
 		t.Fatal("expected non-nil Policy")
 	}
-	if ev.Policy.Decision != "allow" {
-		t.Errorf("expected policy decision 'allow', got %q", ev.Policy.Decision)
+	if ev0.Policy.Decision != "allow" {
+		t.Errorf("expected policy decision 'allow', got %q", ev0.Policy.Decision)
 	}
 }
 
@@ -119,7 +122,10 @@ func TestFileHandler_DenyWithoutFUSE(t *testing.T) {
 		SessionID: "sess-1",
 	}
 
-	result := handler.Handle(req)
+	result, ev := handler.Handle(req)
+	if ev != nil {
+		_ = emitter.AppendEvent(context.Background(), *ev)
+	}
 
 	if result.Action != ActionDeny {
 		t.Errorf("expected ActionDeny, got %s", result.Action)
@@ -130,9 +136,9 @@ func TestFileHandler_DenyWithoutFUSE(t *testing.T) {
 	if len(emitter.events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(emitter.events))
 	}
-	ev := emitter.events[0]
-	if ev.EffectiveAction != "blocked" {
-		t.Errorf("expected EffectiveAction 'blocked', got %q", ev.EffectiveAction)
+	ev0 := emitter.events[0]
+	if ev0.EffectiveAction != "blocked" {
+		t.Errorf("expected EffectiveAction 'blocked', got %q", ev0.EffectiveAction)
 	}
 }
 
@@ -160,7 +166,10 @@ func TestFileHandler_AuditOnlyUnderFUSE(t *testing.T) {
 		SessionID: "sess-1",
 	}
 
-	result := handler.Handle(req)
+	result, ev := handler.Handle(req)
+	if ev != nil {
+		_ = emitter.AppendEvent(context.Background(), *ev)
+	}
 
 	// Under FUSE: always continue, let FUSE handle enforcement
 	if result.Action != ActionContinue {
@@ -172,12 +181,12 @@ func TestFileHandler_AuditOnlyUnderFUSE(t *testing.T) {
 	if len(emitter.events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(emitter.events))
 	}
-	ev := emitter.events[0]
+	ev0 := emitter.events[0]
 	// Should have shadow_deny=true in Fields
-	if ev.Fields == nil {
+	if ev0.Fields == nil {
 		t.Fatal("expected non-nil Fields")
 	}
-	shadowDeny, ok := ev.Fields["shadow_deny"]
+	shadowDeny, ok := ev0.Fields["shadow_deny"]
 	if !ok {
 		t.Fatal("expected shadow_deny in Fields")
 	}
@@ -209,7 +218,10 @@ func TestFileHandler_EnforceDisabled(t *testing.T) {
 		SessionID: "sess-1",
 	}
 
-	result := handler.Handle(req)
+	result, ev := handler.Handle(req)
+	if ev != nil {
+		_ = emitter.AppendEvent(context.Background(), *ev)
+	}
 
 	// Audit-only: allow even though policy says deny
 	if result.Action != ActionContinue {
@@ -221,10 +233,10 @@ func TestFileHandler_EnforceDisabled(t *testing.T) {
 	if len(emitter.events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(emitter.events))
 	}
-	ev := emitter.events[0]
+	ev0 := emitter.events[0]
 	// Event should still reflect the deny decision
-	if ev.Policy == nil || ev.Policy.Decision != "deny" {
-		t.Errorf("expected policy decision 'deny' in audit-only event, got %v", ev.Policy)
+	if ev0.Policy == nil || ev0.Policy.Decision != "deny" {
+		t.Errorf("expected policy decision 'deny' in audit-only event, got %v", ev0.Policy)
 	}
 }
 
@@ -256,7 +268,10 @@ func TestFileHandler_Rename(t *testing.T) {
 		SessionID: "sess-1",
 	}
 
-	result := handler.Handle(req)
+	result, ev := handler.Handle(req)
+	if ev != nil {
+		_ = emitter.AppendEvent(context.Background(), *ev)
+	}
 
 	if result.Action != ActionContinue {
 		t.Errorf("expected ActionContinue, got %s", result.Action)
@@ -264,16 +279,16 @@ func TestFileHandler_Rename(t *testing.T) {
 	if len(emitter.events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(emitter.events))
 	}
-	ev := emitter.events[0]
-	if ev.Type != "file_rename" {
-		t.Errorf("expected Type 'file_rename', got %q", ev.Type)
+	ev0 := emitter.events[0]
+	if ev0.Type != "file_rename" {
+		t.Errorf("expected Type 'file_rename', got %q", ev0.Type)
 	}
 	// Check path2 is in Fields
-	if ev.Fields == nil {
+	if ev0.Fields == nil {
 		t.Fatal("expected non-nil Fields for rename")
 	}
-	if p2, ok := ev.Fields["path2"]; !ok || p2 != "/home/user/new.txt" {
-		t.Errorf("expected Fields[path2]='/home/user/new.txt', got %v", ev.Fields["path2"])
+	if p2, ok := ev0.Fields["path2"]; !ok || p2 != "/home/user/new.txt" {
+		t.Errorf("expected Fields[path2]='/home/user/new.txt', got %v", ev0.Fields["path2"])
 	}
 }
 
@@ -306,7 +321,7 @@ func TestFileHandler_RenameDenyOnSecondPath(t *testing.T) {
 		SessionID: "sess-1",
 	}
 
-	result := handler.Handle(req)
+	result, _ := handler.Handle(req)
 
 	if result.Action != ActionDeny {
 		t.Errorf("expected ActionDeny (second path denied), got %s", result.Action)
@@ -329,7 +344,10 @@ func TestFileHandler_NilPolicy(t *testing.T) {
 		SessionID: "sess-1",
 	}
 
-	result := handler.Handle(req)
+	result, ev := handler.Handle(req)
+	if ev != nil {
+		_ = emitter.AppendEvent(context.Background(), *ev)
+	}
 
 	if result.Action != ActionContinue {
 		t.Errorf("expected ActionContinue (nil policy), got %s", result.Action)
@@ -337,12 +355,12 @@ func TestFileHandler_NilPolicy(t *testing.T) {
 	if len(emitter.events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(emitter.events))
 	}
-	ev := emitter.events[0]
-	if ev.Policy == nil {
+	ev0 := emitter.events[0]
+	if ev0.Policy == nil {
 		t.Fatal("expected non-nil Policy in event")
 	}
-	if ev.Policy.Rule != "no_policy" {
-		t.Errorf("expected rule 'no_policy', got %q", ev.Policy.Rule)
+	if ev0.Policy.Rule != "no_policy" {
+		t.Errorf("expected rule 'no_policy', got %q", ev0.Policy.Rule)
 	}
 }
 
@@ -369,7 +387,7 @@ func TestFileHandler_NilEmitter(t *testing.T) {
 	}
 
 	// Should not panic
-	result := handler.Handle(req)
+	result, _ := handler.Handle(req)
 	assert.Equal(t, ActionContinue, result.Action)
 }
 
@@ -395,7 +413,7 @@ func TestFileHandler_NilEmitterDeny(t *testing.T) {
 		SessionID: "sess-1",
 	}
 
-	result := handler.Handle(req)
+	result, _ := handler.Handle(req)
 	assert.Equal(t, ActionDeny, result.Action)
 	assert.Equal(t, int32(unix.EACCES), result.Errno)
 }
@@ -422,7 +440,7 @@ func TestFileHandler_NilRegistry(t *testing.T) {
 		SessionID: "sess-1",
 	}
 
-	result := handler.Handle(req)
+	result, _ := handler.Handle(req)
 	// Should deny (not treated as FUSE path)
 	assert.Equal(t, ActionDeny, result.Action)
 	assert.Equal(t, int32(unix.EACCES), result.Errno)
@@ -440,7 +458,7 @@ func TestFileHandler_NilPolicyAndEmitter(t *testing.T) {
 	}
 
 	// Should not panic, should allow
-	result := handler.Handle(req)
+	result, _ := handler.Handle(req)
 	assert.Equal(t, ActionContinue, result.Action)
 }
 
@@ -476,7 +494,7 @@ func TestFileHandler_ProcSelfFD_ResolvesToTarget(t *testing.T) {
 		SessionID: "sess-1",
 	}
 
-	result := handler.Handle(req)
+	result, _ := handler.Handle(req)
 	// Resolved to temp file path (not in deny list) → allowed
 	assert.Equal(t, ActionContinue, result.Action)
 }
@@ -518,7 +536,7 @@ func TestFileHandler_PseudoPath_AllowedUnconditionally(t *testing.T) {
 			Operation: "stat",
 			SessionID: "sess-1",
 		}
-		result := handler.Handle(req)
+		result, _ := handler.Handle(req)
 		assert.Equal(t, ActionContinue, result.Action, "pseudo-path %q should be allowed", pp)
 	}
 }
@@ -550,7 +568,7 @@ func TestFileHandler_ReadOnlyOpen_SkipsEmulation(t *testing.T) {
 		Flags:     uint32(unix.O_RDONLY | unix.O_CLOEXEC),
 		SessionID: "sess-test",
 	}
-	result := handler.Handle(req)
+	result, _ := handler.Handle(req)
 	assert.Equal(t, ActionContinue, result.Action,
 		"read-only open must get ActionContinue even with emulation enabled")
 }

--- a/internal/netmonitor/unix/file_integration_test.go
+++ b/internal/netmonitor/unix/file_integration_test.go
@@ -3,6 +3,7 @@
 package unix
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -36,24 +37,27 @@ func TestFileHandler_FullPipeline(t *testing.T) {
 			SessionID: "sess-1",
 		}
 
-		result := handler.Handle(req)
+		result, ev := handler.Handle(req)
+		if ev != nil {
+			_ = emit.AppendEvent(context.Background(), *ev)
+		}
 
 		assert.Equal(t, ActionContinue, result.Action)
 		assert.Equal(t, int32(0), result.Errno)
 
 		require.Len(t, emit.events, 1)
-		ev := emit.events[0]
-		assert.Equal(t, "seccomp", ev.Source, "Source must always be seccomp")
-		assert.Equal(t, "file_open", ev.Type)
-		assert.Equal(t, "/workspace/src/main.go", ev.Path)
-		assert.Equal(t, "sess-1", ev.SessionID)
-		assert.Equal(t, 100, ev.PID)
-		assert.Equal(t, "allowed", ev.EffectiveAction)
+		ev0 := emit.events[0]
+		assert.Equal(t, "seccomp", ev0.Source, "Source must always be seccomp")
+		assert.Equal(t, "file_open", ev0.Type)
+		assert.Equal(t, "/workspace/src/main.go", ev0.Path)
+		assert.Equal(t, "sess-1", ev0.SessionID)
+		assert.Equal(t, 100, ev0.PID)
+		assert.Equal(t, "allowed", ev0.EffectiveAction)
 
-		require.NotNil(t, ev.Policy)
-		assert.Equal(t, "allow", string(ev.Policy.Decision))
-		assert.Equal(t, "allow", string(ev.Policy.EffectiveDecision))
-		assert.Equal(t, "workspace-allow", ev.Policy.Rule)
+		require.NotNil(t, ev0.Policy)
+		assert.Equal(t, "allow", string(ev0.Policy.Decision))
+		assert.Equal(t, "allow", string(ev0.Policy.EffectiveDecision))
+		assert.Equal(t, "workspace-allow", ev0.Policy.Rule)
 	})
 
 	// ── Test 2: Denied open ───────────────────────────────────────────
@@ -68,21 +72,24 @@ func TestFileHandler_FullPipeline(t *testing.T) {
 			SessionID: "sess-1",
 		}
 
-		result := handler.Handle(req)
+		result, ev := handler.Handle(req)
+		if ev != nil {
+			_ = emit.AppendEvent(context.Background(), *ev)
+		}
 
 		assert.Equal(t, ActionDeny, result.Action)
 		assert.Equal(t, int32(unix.EACCES), result.Errno)
 
 		require.Len(t, emit.events, 1)
-		ev := emit.events[0]
-		assert.Equal(t, "seccomp", ev.Source)
-		assert.Equal(t, "file_open", ev.Type)
-		assert.Equal(t, "blocked", ev.EffectiveAction)
+		ev0 := emit.events[0]
+		assert.Equal(t, "seccomp", ev0.Source)
+		assert.Equal(t, "file_open", ev0.Type)
+		assert.Equal(t, "blocked", ev0.EffectiveAction)
 
-		require.NotNil(t, ev.Policy)
-		assert.Equal(t, "deny", string(ev.Policy.Decision))
-		assert.Equal(t, "deny", string(ev.Policy.EffectiveDecision))
-		assert.Equal(t, "system-deny", ev.Policy.Rule)
+		require.NotNil(t, ev0.Policy)
+		assert.Equal(t, "deny", string(ev0.Policy.Decision))
+		assert.Equal(t, "deny", string(ev0.Policy.EffectiveDecision))
+		assert.Equal(t, "system-deny", ev0.Policy.Rule)
 	})
 
 	// ── Test 3: FUSE overlap — audit-only ─────────────────────────────
@@ -103,16 +110,19 @@ func TestFileHandler_FullPipeline(t *testing.T) {
 			SessionID: "sess-1",
 		}
 
-		result := handler.Handle(req)
+		result, ev := handler.Handle(req)
+		if ev != nil {
+			_ = emit.AppendEvent(context.Background(), *ev)
+		}
 
 		assert.Equal(t, ActionContinue, result.Action,
 			"FUSE overlap must always allow — FUSE handles enforcement")
 		assert.Equal(t, int32(0), result.Errno)
 
 		require.Len(t, emit.events, 1)
-		ev := emit.events[0]
-		assert.Equal(t, "seccomp", ev.Source)
-		assert.Equal(t, "file_open", ev.Type)
+		ev0 := emit.events[0]
+		assert.Equal(t, "seccomp", ev0.Source)
+		assert.Equal(t, "file_open", ev0.Type)
 	})
 
 	// ── Test 4: Non-FUSE path still enforces after FUSE registration ──
@@ -132,16 +142,19 @@ func TestFileHandler_FullPipeline(t *testing.T) {
 			SessionID: "sess-1",
 		}
 
-		result := handler.Handle(req)
+		result, ev := handler.Handle(req)
+		if ev != nil {
+			_ = emit.AppendEvent(context.Background(), *ev)
+		}
 
 		assert.Equal(t, ActionDeny, result.Action,
 			"/etc/shadow is not under FUSE mount — must enforce deny")
 		assert.Equal(t, int32(unix.EACCES), result.Errno)
 
 		require.Len(t, emit.events, 1)
-		ev := emit.events[0]
-		assert.Equal(t, "seccomp", ev.Source)
-		assert.Equal(t, "blocked", ev.EffectiveAction)
+		ev0 := emit.events[0]
+		assert.Equal(t, "seccomp", ev0.Source)
+		assert.Equal(t, "blocked", ev0.EffectiveAction)
 	})
 
 	// ── Test 5: FUSE overlap with would-deny path — shadow deny ───────
@@ -161,19 +174,22 @@ func TestFileHandler_FullPipeline(t *testing.T) {
 			SessionID: "sess-1",
 		}
 
-		result := handler.Handle(req)
+		result, ev := handler.Handle(req)
+		if ev != nil {
+			_ = emit.AppendEvent(context.Background(), *ev)
+		}
 
 		assert.Equal(t, ActionContinue, result.Action,
 			"under FUSE mount — must allow even when policy says deny")
 		assert.Equal(t, int32(0), result.Errno)
 
 		require.Len(t, emit.events, 1)
-		ev := emit.events[0]
-		assert.Equal(t, "seccomp", ev.Source)
+		ev0 := emit.events[0]
+		assert.Equal(t, "seccomp", ev0.Source)
 
 		// shadow_deny should be set because policy would deny but FUSE overrides.
-		require.NotNil(t, ev.Fields)
-		shadowDeny, ok := ev.Fields["shadow_deny"]
+		require.NotNil(t, ev0.Fields)
+		shadowDeny, ok := ev0.Fields["shadow_deny"]
 		require.True(t, ok, "expected shadow_deny field")
 		assert.Equal(t, true, shadowDeny)
 	})
@@ -205,7 +221,10 @@ func TestEmulatedOpen_AllowRoutesToAddFD(t *testing.T) {
 		SessionID: "sess-emu",
 	}
 
-	result := handler.Handle(req)
+	result, ev := handler.Handle(req)
+	if ev != nil {
+		_ = emit.AppendEvent(context.Background(), *ev)
+	}
 
 	assert.Equal(t, ActionContinue, result.Action,
 		"allowed open must produce ActionContinue (triggers AddFD in emulated path)")
@@ -213,17 +232,17 @@ func TestEmulatedOpen_AllowRoutesToAddFD(t *testing.T) {
 
 	// Verify the event was emitted with correct metadata.
 	require.Len(t, emit.events, 1)
-	ev := emit.events[0]
-	assert.Equal(t, "seccomp", ev.Source)
-	assert.Equal(t, "file_open", ev.Type)
-	assert.Equal(t, "allowed", ev.EffectiveAction)
-	assert.Equal(t, "/workspace/data.txt", ev.Path)
-	assert.Equal(t, 300, ev.PID)
-	assert.Equal(t, "sess-emu", ev.SessionID)
+	ev0 := emit.events[0]
+	assert.Equal(t, "seccomp", ev0.Source)
+	assert.Equal(t, "file_open", ev0.Type)
+	assert.Equal(t, "allowed", ev0.EffectiveAction)
+	assert.Equal(t, "/workspace/data.txt", ev0.Path)
+	assert.Equal(t, 300, ev0.PID)
+	assert.Equal(t, "sess-emu", ev0.SessionID)
 
-	require.NotNil(t, ev.Policy)
-	assert.Equal(t, "allow", string(ev.Policy.Decision))
-	assert.Equal(t, "workspace-rw", ev.Policy.Rule)
+	require.NotNil(t, ev0.Policy)
+	assert.Equal(t, "allow", string(ev0.Policy.Decision))
+	assert.Equal(t, "workspace-rw", ev0.Policy.Rule)
 
 	// Verify that isOpenSyscall agrees this is an emulatable open.
 	assert.True(t, isOpenSyscall(unix.SYS_OPENAT), "SYS_OPENAT must be an open syscall")
@@ -253,7 +272,10 @@ func TestEmulatedOpen_DenyReturnsEACCES(t *testing.T) {
 		SessionID: "sess-emu",
 	}
 
-	result := handler.Handle(req)
+	result, ev := handler.Handle(req)
+	if ev != nil {
+		_ = emit.AppendEvent(context.Background(), *ev)
+	}
 
 	assert.Equal(t, ActionDeny, result.Action,
 		"denied open must produce ActionDeny even with emulateOpen")
@@ -261,14 +283,14 @@ func TestEmulatedOpen_DenyReturnsEACCES(t *testing.T) {
 		"denied open must return EACCES")
 
 	require.Len(t, emit.events, 1)
-	ev := emit.events[0]
-	assert.Equal(t, "seccomp", ev.Source)
-	assert.Equal(t, "blocked", ev.EffectiveAction)
-	assert.Equal(t, "/etc/shadow", ev.Path)
+	ev0 := emit.events[0]
+	assert.Equal(t, "seccomp", ev0.Source)
+	assert.Equal(t, "blocked", ev0.EffectiveAction)
+	assert.Equal(t, "/etc/shadow", ev0.Path)
 
-	require.NotNil(t, ev.Policy)
-	assert.Equal(t, "deny", string(ev.Policy.EffectiveDecision))
-	assert.Equal(t, "system-deny", ev.Policy.Rule)
+	require.NotNil(t, ev0.Policy)
+	assert.Equal(t, "deny", string(ev0.Policy.EffectiveDecision))
+	assert.Equal(t, "system-deny", ev0.Policy.Rule)
 }
 
 // TestEmulatedOpen_FallbackToContinue verifies that open syscalls with
@@ -383,7 +405,10 @@ func TestEmulatedOpen_WriteOperation(t *testing.T) {
 		SessionID: "sess-emu",
 	}
 
-	result := handler.Handle(req)
+	result, ev := handler.Handle(req)
+	if ev != nil {
+		_ = emit.AppendEvent(context.Background(), *ev)
+	}
 	assert.Equal(t, ActionContinue, result.Action)
 
 	require.Len(t, emit.events, 1)
@@ -462,7 +487,10 @@ func TestEmulatedOpen_CreateOperation(t *testing.T) {
 		SessionID: "sess-emu",
 	}
 
-	result := handler.Handle(req)
+	result, ev := handler.Handle(req)
+	if ev != nil {
+		_ = emit.AppendEvent(context.Background(), *ev)
+	}
 	assert.Equal(t, ActionContinue, result.Action)
 
 	require.Len(t, emit.events, 1)
@@ -563,7 +591,7 @@ func TestEmulatedOpen_FullDecisionMatrix(t *testing.T) {
 				SessionID: "sess-matrix",
 			}
 
-			result := handler.Handle(req)
+			result, _ := handler.Handle(req)
 			assert.Equal(t, tt.wantAction, result.Action, "action mismatch")
 			assert.Equal(t, tt.wantErrno, result.Errno, "errno mismatch")
 		})
@@ -712,21 +740,24 @@ func TestFileHandler_OperationMapping(t *testing.T) {
 				SessionID: "sess-op",
 			}
 
-			result := handler.Handle(req)
+			result, ev := handler.Handle(req)
+			if ev != nil {
+				_ = emit.AppendEvent(context.Background(), *ev)
+			}
 			assert.Equal(t, ActionContinue, result.Action)
 
 			require.Len(t, emit.events, 1)
-			ev := emit.events[0]
-			assert.Equal(t, tt.wantType, ev.Type,
+			ev0 := emit.events[0]
+			assert.Equal(t, tt.wantType, ev0.Type,
 				"event Type must be file_<operation>")
-			assert.Equal(t, "seccomp", ev.Source,
+			assert.Equal(t, "seccomp", ev0.Source,
 				"Source must always be seccomp")
-			assert.Equal(t, gotOp, ev.Operation,
+			assert.Equal(t, gotOp, ev0.Operation,
 				"event Operation must match mapped operation")
 
 			// Verify syscall name is in Fields
-			require.NotNil(t, ev.Fields)
-			assert.Equal(t, tt.wantSysc, ev.Fields["syscall"],
+			require.NotNil(t, ev0.Fields)
+			assert.Equal(t, tt.wantSysc, ev0.Fields["syscall"],
 				"Fields[syscall] must be the syscall name")
 		})
 	}

--- a/internal/netmonitor/unix/handler.go
+++ b/internal/netmonitor/unix/handler.go
@@ -481,7 +481,7 @@ func handleFileNotification(goCtx context.Context, fd seccomp.ScmpFd, req *secco
 		SessionID: sessID,
 	}
 
-	result := h.Handle(frequest)
+	result, ev := h.Handle(frequest)
 
 	if result.Action == ActionDeny {
 		if err := NotifRespondDeny(int(fd), req.ID, result.Errno); err != nil {
@@ -491,6 +491,14 @@ func handleFileNotification(goCtx context.Context, fd seccomp.ScmpFd, req *secco
 		if err := NotifRespondContinue(int(fd), req.ID); err != nil {
 			slog.Debug("file handler: continue response failed", "pid", pid, "error", err)
 		}
+	}
+
+	// Emit the audit event after the notify response to avoid blocking the
+	// traced process on audit I/O. Uses context.Background() because the
+	// event should be emitted even if the request context was cancelled.
+	if ev != nil && h.emitter != nil {
+		_ = h.emitter.AppendEvent(context.Background(), *ev)
+		h.emitter.Publish(*ev)
 	}
 }
 
@@ -631,7 +639,16 @@ func handleFileNotificationEmulated(goCtx context.Context, fd seccomp.ScmpFd, re
 		}
 	}
 
-	result := h.Handle(frequest)
+	result, ev := h.Handle(frequest)
+
+	// Defer event emission so it runs after the notify response, avoiding
+	// blocking the traced process on audit I/O.
+	defer func() {
+		if ev != nil && h.emitter != nil {
+			_ = h.emitter.AppendEvent(context.Background(), *ev)
+			h.emitter.Publish(*ev)
+		}
+	}()
 
 	// Branch: is this an open syscall that we should emulate via AddFD?
 	if !forceContinue {

--- a/internal/netmonitor/unix/handler.go
+++ b/internal/netmonitor/unix/handler.go
@@ -353,7 +353,18 @@ func handleExecveNotification(goCtx context.Context, fd seccomp.ScmpFd, req *sec
 		Truncated:   truncated,
 	}
 
-	result := h.Handle(goCtx, ectx)
+	result, ev := h.Handle(goCtx, ectx)
+
+	// Defer event emission so it runs after the seccomp notify response.
+	// This ensures the tracee is unblocked before any fsync I/O from the
+	// audit store. Use context.Background() because the event should be
+	// emitted even if the request context was cancelled.
+	defer func() {
+		if ev != nil && h.emitter != nil {
+			_ = h.emitter.AppendEvent(context.Background(), *ev)
+			h.emitter.Publish(*ev)
+		}
+	}()
 
 	switch result.Action {
 	case ActionRedirect:

--- a/internal/netmonitor/unix/handler.go
+++ b/internal/netmonitor/unix/handler.go
@@ -70,6 +70,7 @@ func ServeNotify(ctx context.Context, fd *os.File, sessID string, pol *policy.En
 		errno := int32(unix.EACCES)
 		path := ""
 		abstract := false
+		var ev *types.Event
 		if raw, err := ReadSockaddr(ctxReq.PID, ctxReq.AddrPtr, ctxReq.AddrLen); err == nil {
 			if p, abs, perr := ParseSockaddr(raw); perr == nil {
 				path, abstract = p, abs
@@ -78,7 +79,7 @@ func ServeNotify(ctx context.Context, fd *os.File, sessID string, pol *policy.En
 				allow = dec.EffectiveDecision == types.DecisionAllow
 				if !allow {
 					errno = int32(unix.EACCES)
-					emitEvent(emit, sessID, dec, path, abstract, op)
+					ev = buildUnixSocketEvent(emit, sessID, dec, path, abstract, op)
 				}
 			}
 		}
@@ -90,6 +91,12 @@ func ServeNotify(ctx context.Context, fd *os.File, sessID string, pol *policy.En
 			if err := NotifRespondDeny(int(scmpFD), req.ID, errno); err != nil {
 				slog.Error("unix socket: deny response failed", "path", path, "error", err)
 			}
+		}
+		// Emit the audit event after the notify response to avoid blocking
+		// the traced process on audit I/O.
+		if ev != nil {
+			_ = emit.AppendEvent(context.Background(), *ev)
+			emit.Publish(*ev)
 		}
 	}
 }
@@ -137,8 +144,11 @@ func isENOENT(err error) bool {
 	return false
 }
 
-func emitEvent(emit Emitter, session string, dec policy.Decision, path string, abstract bool, op string) {
-	ev := types.Event{
+func buildUnixSocketEvent(emit Emitter, session string, dec policy.Decision, path string, abstract bool, op string) *types.Event {
+	if emit == nil {
+		return nil
+	}
+	return &types.Event{
 		ID:        fmt.Sprintf("evt-%d", time.Now().UnixNano()),
 		Timestamp: time.Now().UTC(),
 		Type:      "unix_socket_op",
@@ -153,8 +163,6 @@ func emitEvent(emit Emitter, session string, dec policy.Decision, path string, a
 		Abstract:  abstract,
 		Operation: op,
 	}
-	_ = emit.AppendEvent(context.Background(), ev)
-	emit.Publish(ev)
 }
 
 // ServeNotifyWithExecve runs the seccomp notify loop with execve interception support.
@@ -244,6 +252,7 @@ func ServeNotifyWithExecve(ctx context.Context, fd *os.File, sessID string, pol 
 		errno := int32(unix.EACCES)
 		path := ""
 		abstract := false
+		var ev *types.Event
 		if raw, err := ReadSockaddr(ctxReq.PID, ctxReq.AddrPtr, ctxReq.AddrLen); err == nil {
 			if p, abs, perr := ParseSockaddr(raw); perr == nil {
 				path, abstract = p, abs
@@ -252,7 +261,7 @@ func ServeNotifyWithExecve(ctx context.Context, fd *os.File, sessID string, pol 
 				allow = dec.EffectiveDecision == types.DecisionAllow
 				if !allow {
 					errno = int32(unix.EACCES)
-					emitEvent(emit, sessID, dec, path, abstract, op)
+					ev = buildUnixSocketEvent(emit, sessID, dec, path, abstract, op)
 				}
 			}
 		}
@@ -264,6 +273,12 @@ func ServeNotifyWithExecve(ctx context.Context, fd *os.File, sessID string, pol 
 			if err := NotifRespondDeny(int(scmpFD), req.ID, errno); err != nil {
 				slog.Error("unix socket: deny response failed", "path", path, "error", err)
 			}
+		}
+		// Emit the audit event after the notify response to avoid blocking
+		// the traced process on audit I/O.
+		if ev != nil {
+			_ = emit.AppendEvent(context.Background(), *ev)
+			emit.Publish(*ev)
 		}
 	}
 }

--- a/internal/store/integrity_startup_test.go
+++ b/internal/store/integrity_startup_test.go
@@ -862,6 +862,11 @@ func TestIntegrityStore_AppendEvent_WritesSidecarAfterRawWrite(t *testing.T) {
 		t.Fatalf("AppendEvent() error = %v", err)
 	}
 
+	// Sidecar is written by FlushSync, not AppendEvent — flush explicitly.
+	if err := store.FlushSync(); err != nil {
+		t.Fatalf("FlushSync() error = %v", err)
+	}
+
 	sidecar, err := audit.ReadSidecar(audit.SidecarPath(logPath))
 	if err != nil {
 		t.Fatalf("audit.ReadSidecar() error = %v", err)

--- a/internal/store/integrity_wrapper.go
+++ b/internal/store/integrity_wrapper.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"sync"
 	"time"
@@ -51,6 +52,11 @@ type IntegrityStore struct {
 	keyFingerprint string
 	now            func() time.Time
 	fatal          bool // sticky; set on first FatalIntegrityError
+	pendingFlush   bool
+	flushTick      *time.Ticker
+	stopFlush      chan struct{}
+	flushDone      chan struct{}
+	closeOnce      sync.Once
 }
 
 type visibleChainState struct {
@@ -94,6 +100,18 @@ func NewIntegrityStore(inner EventStore, chain *audit.IntegrityChain, opts Integ
 	if err := store.bootstrap(); err != nil {
 		return nil, err
 	}
+
+	// Disable per-write sync on inner store — FlushSync handles it.
+	type syncController interface{ SetSyncOnWrite(bool) }
+	if sc, ok := inner.(syncController); ok {
+		sc.SetSyncOnWrite(false)
+	}
+
+	store.stopFlush = make(chan struct{})
+	store.flushDone = make(chan struct{})
+	store.flushTick = time.NewTicker(100 * time.Millisecond)
+	go store.runFlushLoop()
+
 	return store, nil
 }
 
@@ -468,17 +486,59 @@ func (s *IntegrityStore) AppendEvent(ctx context.Context, ev types.Event) error 
 		return err
 	}
 
+	s.pendingFlush = true
+	return nil
+}
+
+// FlushSync flushes buffered writes to durable storage and updates the sidecar.
+// Safe to call concurrently with AppendEvent — the chain mutex is held only
+// briefly to snapshot state, then released before slow I/O.
+func (s *IntegrityStore) FlushSync() error {
+	s.mu.Lock()
+	if !s.pendingFlush || s.fatal {
+		s.mu.Unlock()
+		return nil
+	}
 	state := s.chain.State()
+	s.pendingFlush = false
+	s.mu.Unlock()
+
+	if syncer, ok := s.inner.(Syncer); ok {
+		if err := syncer.Sync(); err != nil {
+			s.mu.Lock()
+			s.fatal = true
+			s.mu.Unlock()
+			return &FatalIntegrityError{Op: "sync audit log", Err: err}
+		}
+	}
+
 	if err := audit.WriteSidecar(s.sidecarPath, audit.SidecarState{
 		Sequence:       state.Sequence,
 		PrevHash:       state.PrevHash,
 		KeyFingerprint: s.keyFingerprint,
 		UpdatedAt:      s.now().UTC(),
 	}); err != nil {
+		s.mu.Lock()
 		s.fatal = true
+		s.mu.Unlock()
 		return &FatalIntegrityError{Op: "write audit integrity sidecar", Err: err}
 	}
 	return nil
+}
+
+func (s *IntegrityStore) runFlushLoop() {
+	defer close(s.flushDone)
+	for {
+		select {
+		case <-s.flushTick.C:
+			if err := s.FlushSync(); err != nil {
+				slog.Error("audit flush failed", "error", err)
+			}
+		case <-s.stopFlush:
+			s.flushTick.Stop()
+			return
+		}
+	}
 }
 
 // QueryEvents delegates to the inner store.
@@ -486,9 +546,21 @@ func (s *IntegrityStore) QueryEvents(ctx context.Context, q types.EventQuery) ([
 	return s.inner.QueryEvents(ctx, q)
 }
 
-// Close closes the inner store.
+// Close stops the flush loop, performs a final flush, and closes the inner store.
+// Safe to call multiple times.
 func (s *IntegrityStore) Close() error {
-	return s.inner.Close()
+	var closeErr error
+	s.closeOnce.Do(func() {
+		if s.stopFlush != nil {
+			close(s.stopFlush)
+			<-s.flushDone
+		}
+		if err := s.FlushSync(); err != nil {
+			slog.Error("final audit flush failed", "error", err)
+		}
+		closeErr = s.inner.Close()
+	})
+	return closeErr
 }
 
 // Chain returns the integrity chain for state management.

--- a/internal/store/integrity_wrapper.go
+++ b/internal/store/integrity_wrapper.go
@@ -179,11 +179,17 @@ func (s *IntegrityStore) validateVisibleChain(files []audit.LogFile) error {
 			}
 
 			entry, err := audit.ParseIntegrityEntry(line)
-			if err != nil {
-				_ = f.Close()
-				return fmt.Errorf("audit log corrupted at %s:%d: %w", file.Path, lineNo, err)
-			}
-			if entry.Integrity == nil {
+			if err != nil || entry.Integrity == nil {
+				// A parse error on the last line of the active file (readErr == io.EOF,
+				// meaning no trailing newline) indicates a truncated write from a prior
+				// crash. Skip it here; recoverFromSidecarGap will truncate the file.
+				if errors.Is(readErr, io.EOF) && !file.IsBackup {
+					break
+				}
+				if err != nil {
+					_ = f.Close()
+					return fmt.Errorf("audit log corrupted at %s:%d: %w", file.Path, lineNo, err)
+				}
 				_ = f.Close()
 				return fmt.Errorf("unsigned line at %s:%d", file.Path, lineNo)
 			}
@@ -291,9 +297,19 @@ func (s *IntegrityStore) resumeFromSidecar(sidecar audit.SidecarState, lastFile 
 
 	entry, err := audit.ParseIntegrityEntry(lastLine)
 	if err != nil || entry.Integrity == nil {
+		// Malformed last entry: could be a truncated partial write from a crash.
+		// Attempt gap recovery, which will truncate the file and recover valid entries.
+		advanced, recoverErr := s.recoverFromSidecarGap(sidecar, lastFile)
+		if recoverErr != nil {
+			return recoverErr
+		}
+		if advanced {
+			return nil
+		}
 		return fmt.Errorf("audit integrity chain mismatch: malformed last entry in %s", lastFile.Path)
 	}
 
+	// Case 1: sidecar exactly matches last entry — normal resume.
 	if sidecar.Sequence == entry.Integrity.Sequence && sidecar.PrevHash == entry.Integrity.EntryHash {
 		ok, err := s.chain.VerifyHash(
 			entry.Integrity.FormatVersion,
@@ -312,8 +328,84 @@ func (s *IntegrityStore) resumeFromSidecar(sidecar audit.SidecarState, lastFile 
 		return nil
 	}
 
-	if sidecar.Sequence+1 == entry.Integrity.Sequence &&
-		entry.Integrity.PrevHash == sidecar.PrevHash {
+	// Case 2: sidecar is behind — crash recovery (seq+N from deferred sync).
+	if sidecar.Sequence < entry.Integrity.Sequence {
+		advanced, err := s.recoverFromSidecarGap(sidecar, lastFile)
+		if err != nil {
+			return err
+		}
+		if advanced {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("audit integrity chain mismatch: sidecar does not match %s", lastFile.Path)
+}
+
+// recoverFromSidecarGap walks the audit log from the sidecar position forward,
+// verifying each entry forms a valid chain continuation. On success, advances
+// the sidecar to the last verified entry. Also handles truncated last lines
+// from crash-during-Write by truncating the file back to the last complete line.
+func (s *IntegrityStore) recoverFromSidecarGap(sidecar audit.SidecarState, lastFile audit.LogFile) (bool, error) {
+	f, err := os.Open(lastFile.Path)
+	if err != nil {
+		return false, fmt.Errorf("open %s for recovery: %w", lastFile.Path, err)
+	}
+	defer f.Close()
+
+	reader := bufio.NewReader(f)
+	var lastVerified *audit.ParsedEntry
+	var lastGoodOffset int64
+	var currentOffset int64
+	expectedSeq := sidecar.Sequence + 1
+	expectedPrev := sidecar.PrevHash
+
+	for {
+		rawLine, readErr := reader.ReadBytes('\n')
+		lineLen := int64(len(rawLine))
+
+		if errors.Is(readErr, io.EOF) && len(rawLine) == 0 {
+			break
+		}
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			return false, fmt.Errorf("read %s for recovery: %w", lastFile.Path, readErr)
+		}
+
+		line := bytes.TrimSpace(rawLine)
+		if len(line) == 0 {
+			currentOffset += lineLen
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+			continue
+		}
+
+		entry, parseErr := audit.ParseIntegrityEntry(line)
+		if parseErr != nil || entry.Integrity == nil {
+			// Truncated last line from crash-during-Write. This is safe to
+			// truncate because validateVisibleChain (which runs before this)
+			// already verified all complete lines; only a trailing partial
+			// line without a newline can reach here.
+			if err := truncateFile(lastFile.Path, lastGoodOffset); err != nil {
+				slog.Warn("failed to truncate partial line during recovery",
+					"path", lastFile.Path, "error", err)
+			}
+			break
+		}
+
+		currentOffset += lineLen
+
+		// Skip entries at or before the sidecar position
+		if entry.Integrity.Sequence <= sidecar.Sequence {
+			lastGoodOffset = currentOffset
+			continue
+		}
+
+		// Verify chain link
+		if entry.Integrity.Sequence != expectedSeq || entry.Integrity.PrevHash != expectedPrev {
+			return false, fmt.Errorf("audit integrity chain mismatch: chain broken during recovery at seq %d", entry.Integrity.Sequence)
+		}
+
 		ok, err := s.chain.VerifyHash(
 			entry.Integrity.FormatVersion,
 			entry.Integrity.Sequence,
@@ -322,20 +414,48 @@ func (s *IntegrityStore) resumeFromSidecar(sidecar audit.SidecarState, lastFile 
 			entry.Integrity.EntryHash,
 		)
 		if err != nil {
-			return fmt.Errorf("audit integrity chain mismatch: verify last entry: %w", err)
+			return false, fmt.Errorf("audit integrity chain mismatch: verify entry seq %d: %w", entry.Integrity.Sequence, err)
 		}
-		if ok {
-			s.chain.Restore(entry.Integrity.Sequence, entry.Integrity.EntryHash)
-			return audit.WriteSidecar(s.sidecarPath, audit.SidecarState{
-				Sequence:       entry.Integrity.Sequence,
-				PrevHash:       entry.Integrity.EntryHash,
-				KeyFingerprint: s.keyFingerprint,
-				UpdatedAt:      s.now().UTC(),
-			})
+		if !ok {
+			return false, fmt.Errorf("audit integrity chain mismatch: invalid HMAC at seq %d", entry.Integrity.Sequence)
+		}
+
+		expectedSeq = entry.Integrity.Sequence + 1
+		expectedPrev = entry.Integrity.EntryHash
+		lastVerified = &entry
+		lastGoodOffset = currentOffset
+
+		if errors.Is(readErr, io.EOF) {
+			break
 		}
 	}
 
-	return fmt.Errorf("audit integrity chain mismatch: sidecar does not match %s", lastFile.Path)
+	if lastVerified == nil {
+		return false, nil
+	}
+
+	s.chain.Restore(lastVerified.Integrity.Sequence, lastVerified.Integrity.EntryHash)
+	slog.Warn("audit integrity: sidecar behind, advancing after crash recovery",
+		"sidecar_seq", sidecar.Sequence,
+		"log_seq", lastVerified.Integrity.Sequence,
+		"events_recovered", lastVerified.Integrity.Sequence-sidecar.Sequence,
+	)
+	return true, audit.WriteSidecar(s.sidecarPath, audit.SidecarState{
+		Sequence:       lastVerified.Integrity.Sequence,
+		PrevHash:       lastVerified.Integrity.EntryHash,
+		KeyFingerprint: s.keyFingerprint,
+		UpdatedAt:      s.now().UTC(),
+	})
+}
+
+// truncateFile truncates a file to the given size (removing a partial trailing line).
+func truncateFile(path string, size int64) error {
+	f, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return f.Truncate(size)
 }
 
 func (s *IntegrityStore) bootstrapWithoutSidecar(files []audit.LogFile, lastFile audit.LogFile, lastLine []byte, lastErr error, reasonCode, reason string) error {

--- a/internal/store/integrity_wrapper_test.go
+++ b/internal/store/integrity_wrapper_test.go
@@ -1,12 +1,14 @@
 package store
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -125,6 +127,7 @@ func newBootstrappedRawIntegrityStore(t *testing.T, inner EventStore) (*Integrit
 func TestIntegrityStore_AppendEvent_WrapsPayload(t *testing.T) {
 	mock := &mockRawWriter{}
 	store, _, _, initialState := newBootstrappedRawIntegrityStore(t, mock)
+	t.Cleanup(func() { _ = store.Close() })
 
 	ev := types.Event{
 		ID:        "ev-1",
@@ -198,6 +201,7 @@ func TestIntegrityStore_AppendEvent_FallbackWithoutRawWriter(t *testing.T) {
 func TestIntegrityStore_ChainContinuity(t *testing.T) {
 	mock := &mockRawWriter{}
 	store, _, _, prevState := newBootstrappedRawIntegrityStore(t, mock)
+	t.Cleanup(func() { _ = store.Close() })
 
 	for i := 0; i < 3; i++ {
 		if err := store.AppendEvent(context.Background(), types.Event{
@@ -232,6 +236,7 @@ func TestIntegrityStore_ChainContinuity(t *testing.T) {
 
 func TestIntegrityStore_AppendEvent_WriteFailureRollsBackChain(t *testing.T) {
 	store, chain, _, initialState := newBootstrappedRawIntegrityStore(t, &mockFailingRawWriter{})
+	t.Cleanup(func() { _ = store.Close() })
 
 	err := store.AppendEvent(context.Background(), types.Event{ID: "ev-1", Type: "test"})
 	if err == nil {
@@ -265,6 +270,9 @@ func TestIntegrityStore_FatalSidecarFailureRecoversOnRestart(t *testing.T) {
 	if err := store.AppendEvent(context.Background(), types.Event{ID: "1", Type: "ok"}); err != nil {
 		t.Fatalf("AppendEvent(first) error = %v", err)
 	}
+	if err := store.FlushSync(); err != nil {
+		t.Fatalf("FlushSync(first) error = %v", err)
+	}
 
 	sidecarPath := audit.SidecarPath(logPath)
 	beforeFailure, err := audit.ReadSidecar(sidecarPath)
@@ -272,10 +280,14 @@ func TestIntegrityStore_FatalSidecarFailureRecoversOnRestart(t *testing.T) {
 		t.Fatalf("audit.ReadSidecar() before failure error = %v", err)
 	}
 
+	if err := store.AppendEvent(context.Background(), types.Event{ID: "2", Type: "fatal_sidecar"}); err != nil {
+		t.Fatalf("AppendEvent(second) error = %v", err)
+	}
+
 	if err := os.Chmod(dir, 0o500); err != nil {
 		t.Fatalf("os.Chmod(%q, 0500) error = %v", dir, err)
 	}
-	fatalErr := store.AppendEvent(context.Background(), types.Event{ID: "2", Type: "fatal_sidecar"})
+	fatalErr := store.FlushSync()
 	if err := os.Chmod(dir, 0o700); err != nil {
 		t.Fatalf("os.Chmod(%q, 0700) error = %v", dir, err)
 	}
@@ -286,7 +298,7 @@ func TestIntegrityStore_FatalSidecarFailureRecoversOnRestart(t *testing.T) {
 
 	var fatal *FatalIntegrityError
 	if !errors.As(fatalErr, &fatal) {
-		t.Fatalf("AppendEvent(second) error = %v, want FatalIntegrityError", fatalErr)
+		t.Fatalf("FlushSync(second) error = %v, want FatalIntegrityError", fatalErr)
 	}
 
 	afterFailure, err := audit.ReadSidecar(sidecarPath)
@@ -330,6 +342,7 @@ func TestIntegrityStore_FatalSidecarFailureRecoversOnRestart(t *testing.T) {
 
 func TestIntegrityStore_PartialWriteReturnsFatalErrorAndDoesNotRollBack(t *testing.T) {
 	store, chain, _, initialState := newBootstrappedRawIntegrityStore(t, &mockPartialFailRawWriter{})
+	t.Cleanup(func() { _ = store.Close() })
 
 	err := store.AppendEvent(context.Background(), types.Event{ID: "ev-1", Type: "test"})
 	if err == nil {
@@ -351,6 +364,7 @@ func TestIntegrityStore_PartialWriteReturnsFatalErrorAndDoesNotRollBack(t *testi
 
 func TestIntegrityStore_StickyFatalRejectsSubsequentAppends(t *testing.T) {
 	store, _, _, _ := newBootstrappedRawIntegrityStore(t, &mockPartialFailRawWriter{})
+	t.Cleanup(func() { _ = store.Close() })
 
 	// First append triggers a partial write → FatalIntegrityError.
 	err := store.AppendEvent(context.Background(), types.Event{ID: "ev-1", Type: "test"})
@@ -444,4 +458,440 @@ func computeHMAC(key []byte, formatVersion int, sequence int64, prevHash string,
 	h.Write([]byte("|"))
 	h.Write(payload)
 	return hex.EncodeToString(h.Sum(nil))
+}
+
+func TestFlushSync_WritesSidecar(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	expectedState := writeResumableIntegrityState(t, logPath)
+	chain := mustNewIntegrityChain(t)
+
+	inner := &mockRawWriter{}
+	store, err := NewIntegrityStore(inner, chain, testIntegrityOptions(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ev := types.Event{ID: "ev-flush-1", Timestamp: time.Now().UTC(), Type: "test", SessionID: "s1"}
+	if err := store.AppendEvent(context.Background(), ev); err != nil {
+		t.Fatal(err)
+	}
+
+	sidecar, err := audit.ReadSidecar(audit.SidecarPath(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sidecar.Sequence != expectedState.Sequence {
+		t.Fatalf("pre-flush sidecar.Sequence = %d, want %d", sidecar.Sequence, expectedState.Sequence)
+	}
+
+	if err := store.FlushSync(); err != nil {
+		t.Fatal(err)
+	}
+
+	sidecar, err = audit.ReadSidecar(audit.SidecarPath(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sidecar.Sequence != expectedState.Sequence+1 {
+		t.Fatalf("post-flush sidecar.Sequence = %d, want %d", sidecar.Sequence, expectedState.Sequence+1)
+	}
+}
+
+func TestFlushSync_Noop_WhenNoPending(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	writeResumableIntegrityState(t, logPath)
+	chain := mustNewIntegrityChain(t)
+
+	inner := &mockRawWriter{}
+	store, err := NewIntegrityStore(inner, chain, testIntegrityOptions(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	sidecarBefore, err := audit.ReadSidecar(audit.SidecarPath(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.FlushSync(); err != nil {
+		t.Fatal(err)
+	}
+
+	sidecarAfter, err := audit.ReadSidecar(audit.SidecarPath(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sidecarAfter.Sequence != sidecarBefore.Sequence {
+		t.Fatalf("sidecar changed without pending events: %d -> %d", sidecarBefore.Sequence, sidecarAfter.Sequence)
+	}
+}
+
+func TestAppendEvent_NoSidecarWrite(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	initialState := writeResumableIntegrityState(t, logPath)
+	chain := mustNewIntegrityChain(t)
+
+	inner := &mockRawWriter{}
+	store, err := NewIntegrityStore(inner, chain, testIntegrityOptions(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	// Stop the background timer so only AppendEvent's behavior is tested.
+	close(store.stopFlush)
+	<-store.flushDone
+	store.stopFlush = nil // prevent double-close in Close()
+
+	sidecarPath := audit.SidecarPath(logPath)
+
+	ev := types.Event{ID: "ev-no-sidecar", Timestamp: time.Now().UTC(), Type: "test", SessionID: "s1"}
+	if err := store.AppendEvent(context.Background(), ev); err != nil {
+		t.Fatal(err)
+	}
+
+	sidecar, _ := audit.ReadSidecar(sidecarPath)
+	if sidecar.Sequence != initialState.Sequence {
+		t.Fatalf("sidecar.Sequence = %d, want %d (AppendEvent should not write sidecar)", sidecar.Sequence, initialState.Sequence)
+	}
+}
+
+type mockSyncerWriter struct {
+	mockRawWriter
+	syncErr error
+}
+
+func (m *mockSyncerWriter) Sync() error {
+	return m.syncErr
+}
+
+func TestFlushSync_SetsFatal_OnSyncError(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	writeResumableIntegrityState(t, logPath)
+	chain := mustNewIntegrityChain(t)
+
+	inner := &mockSyncerWriter{syncErr: errors.New("disk failure")}
+	store, err := NewIntegrityStore(inner, chain, testIntegrityOptions(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ev := types.Event{ID: "ev-fatal", Timestamp: time.Now().UTC(), Type: "test", SessionID: "s1"}
+	if err := store.AppendEvent(context.Background(), ev); err != nil {
+		t.Fatal(err)
+	}
+
+	err = store.FlushSync()
+	if err == nil {
+		t.Fatal("FlushSync() should have returned error")
+	}
+	var fatal *FatalIntegrityError
+	if !errors.As(err, &fatal) {
+		t.Fatalf("expected FatalIntegrityError, got %T: %v", err, err)
+	}
+
+	ev2 := types.Event{ID: "ev-after-fatal", Timestamp: time.Now().UTC(), Type: "test", SessionID: "s1"}
+	if err := store.AppendEvent(context.Background(), ev2); !errors.Is(err, ErrIntegrityFatal) {
+		t.Fatalf("AppendEvent after fatal = %v, want ErrIntegrityFatal", err)
+	}
+}
+
+func TestFlushSync_SetsFatal_OnSidecarError(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	writeResumableIntegrityState(t, logPath)
+	chain := mustNewIntegrityChain(t)
+
+	inner := &mockRawWriter{}
+	store, err := NewIntegrityStore(inner, chain, testIntegrityOptions(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	store.sidecarPath = "/proc/nonexistent/sidecar.json"
+
+	ev := types.Event{ID: "ev-sidecar-fail", Timestamp: time.Now().UTC(), Type: "test", SessionID: "s1"}
+	if err := store.AppendEvent(context.Background(), ev); err != nil {
+		t.Fatal(err)
+	}
+
+	err = store.FlushSync()
+	if err == nil {
+		t.Fatal("FlushSync() should have returned error for unwritable sidecar")
+	}
+	var fatal *FatalIntegrityError
+	if !errors.As(err, &fatal) {
+		t.Fatalf("expected FatalIntegrityError, got %T: %v", err, err)
+	}
+
+	ev2 := types.Event{ID: "ev-after-sidecar-fatal", Timestamp: time.Now().UTC(), Type: "test", SessionID: "s1"}
+	if err := store.AppendEvent(context.Background(), ev2); !errors.Is(err, ErrIntegrityFatal) {
+		t.Fatalf("AppendEvent after sidecar fatal = %v, want ErrIntegrityFatal", err)
+	}
+}
+
+func TestAppendEvent_Then_FlushSync_ChainContinuity(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "audit.jsonl")
+	writeResumableIntegrityState(t, logPath)
+
+	chain := mustNewIntegrityChain(t)
+	jstore, err := jsonl.New(logPath, 10*1024*1024, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jstore.SetSyncOnWrite(false)
+	defer jstore.Close()
+
+	store, err := NewIntegrityStore(jstore, chain, testIntegrityOptions(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for batch := 0; batch < 2; batch++ {
+		for i := 0; i < 10; i++ {
+			ev := types.Event{
+				ID:        fmt.Sprintf("ev-%d-%d", batch, i),
+				Timestamp: time.Now().UTC(),
+				Type:      "test",
+				SessionID: "s1",
+			}
+			if err := store.AppendEvent(context.Background(), ev); err != nil {
+				t.Fatalf("batch %d event %d: %v", batch, i, err)
+			}
+		}
+		if err := store.FlushSync(); err != nil {
+			t.Fatalf("FlushSync batch %d: %v", batch, err)
+		}
+	}
+
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := bytes.Split(bytes.TrimSpace(content), []byte("\n"))
+
+	var prevHash string
+	for i, line := range lines {
+		entry, err := audit.ParseIntegrityEntry(line)
+		if err != nil {
+			t.Fatalf("line %d: parse error: %v", i, err)
+		}
+		if entry.Integrity == nil {
+			t.Fatalf("line %d: no integrity metadata", i)
+		}
+		if entry.Type == "integrity_chain_rotated" {
+			prevHash = entry.Integrity.EntryHash
+			continue
+		}
+		if entry.Integrity.PrevHash != prevHash {
+			t.Fatalf("line %d: chain broken: prev_hash=%q, want %q", i, entry.Integrity.PrevHash, prevHash)
+		}
+		ok, err := chain.VerifyHash(
+			entry.Integrity.FormatVersion, entry.Integrity.Sequence,
+			entry.Integrity.PrevHash, entry.CanonicalPayload, entry.Integrity.EntryHash,
+		)
+		if err != nil {
+			t.Fatalf("line %d: verify error: %v", i, err)
+		}
+		if !ok {
+			t.Fatalf("line %d: HMAC verification failed", i)
+		}
+		prevHash = entry.Integrity.EntryHash
+	}
+}
+
+func TestConcurrent_AppendEvent_And_FlushSync(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "audit.jsonl")
+	writeResumableIntegrityState(t, logPath)
+
+	chain := mustNewIntegrityChain(t)
+	jstore, err := jsonl.New(logPath, 10*1024*1024, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jstore.SetSyncOnWrite(false)
+	defer jstore.Close()
+
+	store, err := NewIntegrityStore(jstore, chain, testIntegrityOptions(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const numEvents = 100
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numEvents; i++ {
+			ev := types.Event{
+				ID:        "ev-concurrent-" + strconv.Itoa(i),
+				Timestamp: time.Now().UTC(),
+				Type:      "test",
+				SessionID: "s1",
+			}
+			if err := store.AppendEvent(context.Background(), ev); err != nil {
+				t.Errorf("AppendEvent %d: %v", i, err)
+				return
+			}
+		}
+	}()
+
+	stop := make(chan struct{})
+	var flushWg sync.WaitGroup
+	flushWg.Add(1)
+	go func() {
+		defer flushWg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = store.FlushSync()
+				time.Sleep(10 * time.Millisecond)
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(stop)
+	flushWg.Wait()
+
+	if err := store.FlushSync(); err != nil {
+		t.Fatal(err)
+	}
+
+	verifyChain := mustNewIntegrityChain(t)
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := bytes.Split(bytes.TrimSpace(content), []byte("\n"))
+
+	var prevHash string
+	for i, line := range lines {
+		entry, err := audit.ParseIntegrityEntry(line)
+		if err != nil {
+			t.Fatalf("line %d: parse: %v", i, err)
+		}
+		if entry.Integrity == nil {
+			t.Fatalf("line %d: no integrity", i)
+		}
+		if entry.Type == "integrity_chain_rotated" {
+			prevHash = entry.Integrity.EntryHash
+			continue
+		}
+		if entry.Integrity.PrevHash != prevHash {
+			t.Fatalf("line %d: chain broken", i)
+		}
+		ok, err := verifyChain.VerifyHash(
+			entry.Integrity.FormatVersion, entry.Integrity.Sequence,
+			entry.Integrity.PrevHash, entry.CanonicalPayload, entry.Integrity.EntryHash,
+		)
+		if err != nil || !ok {
+			t.Fatalf("line %d: HMAC verify failed", i)
+		}
+		prevHash = entry.Integrity.EntryHash
+	}
+}
+
+func TestFlushLoop_PeriodicSync(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "audit.jsonl")
+	writeResumableIntegrityState(t, logPath)
+
+	chain := mustNewIntegrityChain(t)
+	jstore, err := jsonl.New(logPath, 10*1024*1024, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jstore.Close()
+
+	store, err := NewIntegrityStore(jstore, chain, testIntegrityOptions(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	ev := types.Event{ID: "ev-timer", Timestamp: time.Now().UTC(), Type: "test", SessionID: "s1"}
+	if err := store.AppendEvent(context.Background(), ev); err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(250 * time.Millisecond)
+
+	sidecar, err := audit.ReadSidecar(audit.SidecarPath(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	chainState := chain.State()
+	if sidecar.Sequence != chainState.Sequence {
+		t.Fatalf("sidecar.Sequence = %d, want %d (timer should have flushed)", sidecar.Sequence, chainState.Sequence)
+	}
+}
+
+func TestClose_FinalFlush(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "audit.jsonl")
+	initialState := writeResumableIntegrityState(t, logPath)
+
+	chain := mustNewIntegrityChain(t)
+	jstore, err := jsonl.New(logPath, 10*1024*1024, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := NewIntegrityStore(jstore, chain, testIntegrityOptions(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ev := types.Event{ID: "ev-close", Timestamp: time.Now().UTC(), Type: "test", SessionID: "s1"}
+	if err := store.AppendEvent(context.Background(), ev); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	sidecar, err := audit.ReadSidecar(audit.SidecarPath(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sidecar.Sequence != initialState.Sequence+1 {
+		t.Fatalf("sidecar.Sequence = %d, want %d (Close should have flushed)", sidecar.Sequence, initialState.Sequence+1)
+	}
+}
+
+func TestFlushLoop_StopsOnClose(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "audit.jsonl")
+	writeResumableIntegrityState(t, logPath)
+
+	chain := mustNewIntegrityChain(t)
+	jstore, err := jsonl.New(logPath, 10*1024*1024, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := NewIntegrityStore(jstore, chain, testIntegrityOptions(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-store.flushDone:
+	default:
+		t.Fatal("flushDone channel not closed after Close()")
+	}
 }

--- a/internal/store/integrity_wrapper_test.go
+++ b/internal/store/integrity_wrapper_test.go
@@ -895,3 +895,145 @@ func TestFlushLoop_StopsOnClose(t *testing.T) {
 		t.Fatal("flushDone channel not closed after Close()")
 	}
 }
+
+// writeIntegrityStateWithGap writes a JSONL file with totalEvents events
+// (seq 0..totalEvents-1) and a sidecar pointing to sidecarSeq.
+// Simulates a crash where the sidecar is behind by N unflushed events.
+func writeIntegrityStateWithGap(t testing.TB, logPath string, totalEvents, sidecarSeq int) {
+	t.Helper()
+
+	chain, err := audit.NewIntegrityChain(testKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.Create(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var sidecarState audit.ChainState
+	for i := 0; i < totalEvents; i++ {
+		ev := types.Event{
+			ID:        "gap-ev-" + strconv.Itoa(i),
+			Timestamp: time.Now().UTC(),
+			Type:      "test",
+			SessionID: "s1",
+		}
+		payload, _ := json.Marshal(ev)
+		wrapped, _ := chain.Wrap(payload)
+		f.Write(append(wrapped, '\n'))
+
+		if chain.State().Sequence == int64(sidecarSeq) {
+			sidecarState = chain.State()
+		}
+	}
+	f.Close()
+
+	if err := audit.WriteSidecar(audit.SidecarPath(logPath), audit.SidecarState{
+		Sequence:       sidecarState.Sequence,
+		PrevHash:       sidecarState.PrevHash,
+		KeyFingerprint: chain.KeyFingerprint(),
+		UpdatedAt:      time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStartup_SidecarBehindByN(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	// 11 events (seq 0..10), sidecar at seq 7 — behind by 3
+	writeIntegrityStateWithGap(t, logPath, 11, 7)
+
+	chain := mustNewIntegrityChain(t)
+	jstore, err := jsonl.New(logPath, 10*1024*1024, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jstore.Close()
+
+	store, err := NewIntegrityStore(jstore, chain, testIntegrityOptions(logPath))
+	if err != nil {
+		t.Fatalf("NewIntegrityStore should recover from seq+N gap, got: %v", err)
+	}
+	defer store.Close()
+
+	sidecar, err := audit.ReadSidecar(audit.SidecarPath(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sidecar.Sequence != 10 {
+		t.Fatalf("sidecar.Sequence = %d, want 10 (should have recovered)", sidecar.Sequence)
+	}
+
+	state := chain.State()
+	if state.Sequence != 10 {
+		t.Fatalf("chain.State().Sequence = %d, want 10", state.Sequence)
+	}
+}
+
+func TestStartup_SidecarBehindByN_InvalidChain(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	writeIntegrityStateWithGap(t, logPath, 11, 7)
+
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := bytes.Split(bytes.TrimSpace(content), []byte("\n"))
+	// Corrupt line 9 (an event after sidecar seq 7)
+	if len(lines) > 9 {
+		lines[9] = bytes.Replace(lines[9], []byte(`"test"`), []byte(`"tampered"`), 1)
+	}
+	os.WriteFile(logPath, append(bytes.Join(lines, []byte("\n")), '\n'), 0o644)
+
+	chain := mustNewIntegrityChain(t)
+	jstore, err := jsonl.New(logPath, 10*1024*1024, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jstore.Close()
+
+	_, err = NewIntegrityStore(jstore, chain, testIntegrityOptions(logPath))
+	if err == nil {
+		t.Fatal("expected error for tampered chain, got nil")
+	}
+	if !strings.Contains(err.Error(), "chain mismatch") && !strings.Contains(err.Error(), "invalid") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestStartup_TruncatedLastLine(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	// Write 6 events, sidecar at seq 3 (behind by 2)
+	writeIntegrityStateWithGap(t, logPath, 6, 3)
+
+	// Append a truncated line (incomplete JSON)
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString(`{"integrity":{"sequence":6,"prev_hash":"abc","entry_hash":`)
+	f.Close()
+
+	chain := mustNewIntegrityChain(t)
+	jstore, err := jsonl.New(logPath, 10*1024*1024, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer jstore.Close()
+
+	store, err := NewIntegrityStore(jstore, chain, testIntegrityOptions(logPath))
+	if err != nil {
+		t.Fatalf("should recover from truncated last line, got: %v", err)
+	}
+	defer store.Close()
+
+	sidecar, err := audit.ReadSidecar(audit.SidecarPath(logPath))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sidecar.Sequence != 5 {
+		t.Fatalf("sidecar.Sequence = %d, want 5 (should recover up to last valid)", sidecar.Sequence)
+	}
+}

--- a/internal/store/integrity_wrapper_test.go
+++ b/internal/store/integrity_wrapper_test.go
@@ -1037,3 +1037,90 @@ func TestStartup_TruncatedLastLine(t *testing.T) {
 		t.Fatalf("sidecar.Sequence = %d, want 5 (should recover up to last valid)", sidecar.Sequence)
 	}
 }
+
+// benchmarkIntegritySetup creates a bootstrapped IntegrityStore with deferred sync
+// suitable for both tests and benchmarks.
+func benchmarkIntegritySetup(tb testing.TB) (*IntegrityStore, func()) {
+	tb.Helper()
+	dir := tb.TempDir()
+	logPath := filepath.Join(dir, "audit.jsonl")
+
+	chain, err := audit.NewIntegrityChain(testKey)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	f, err := os.Create(logPath)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	rotEv := types.Event{ID: "init", Timestamp: time.Now().UTC(), Type: "integrity_chain_rotated", SessionID: "bench"}
+	payload, _ := json.Marshal(rotEv)
+	wrapped, _ := chain.Wrap(payload)
+	f.Write(append(wrapped, '\n'))
+	f.Close()
+
+	state := chain.State()
+	if err := audit.WriteSidecar(audit.SidecarPath(logPath), audit.SidecarState{
+		Sequence:       state.Sequence,
+		PrevHash:       state.PrevHash,
+		KeyFingerprint: chain.KeyFingerprint(),
+		UpdatedAt:      time.Now().UTC(),
+	}); err != nil {
+		tb.Fatal(err)
+	}
+
+	chain2, err := audit.NewIntegrityChain(testKey)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	jstore, err := jsonl.New(logPath, 100, 3)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	store, err := NewIntegrityStore(jstore, chain2, IntegrityOptions{
+		LogPath: logPath, Now: time.Now,
+	})
+	if err != nil {
+		jstore.Close()
+		tb.Fatal(err)
+	}
+
+	cleanup := func() {
+		store.Close()
+	}
+	return store, cleanup
+}
+
+func BenchmarkAppendEvent_DeferredSync(b *testing.B) {
+	store, cleanup := benchmarkIntegritySetup(b)
+	defer cleanup()
+
+	ev := types.Event{
+		ID: "bench-ev", Timestamp: time.Now().UTC(), Type: "execve",
+		SessionID: "bench", Filename: "/usr/bin/ls",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ev.ID = "bench-" + strconv.Itoa(i)
+		_ = store.AppendEvent(context.Background(), ev)
+	}
+}
+
+func BenchmarkFlushSync(b *testing.B) {
+	store, cleanup := benchmarkIntegritySetup(b)
+	defer cleanup()
+
+	ev := types.Event{
+		ID: "bench-ev", Timestamp: time.Now().UTC(), Type: "execve",
+		SessionID: "bench",
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ev.ID = "bench-" + strconv.Itoa(i)
+		_ = store.AppendEvent(context.Background(), ev)
+		_ = store.FlushSync()
+	}
+}

--- a/internal/store/jsonl/jsonl.go
+++ b/internal/store/jsonl/jsonl.go
@@ -43,9 +43,10 @@ type Store struct {
 	maxBytes   int64
 	maxBackups int
 
-	mu       sync.Mutex
-	file     *os.File
-	lockFile *os.File
+	mu          sync.Mutex
+	file        *os.File
+	lockFile    *os.File
+	syncOnWrite bool
 }
 
 func New(path string, maxSizeMB int, maxBackups int) (*Store, error) {
@@ -85,11 +86,12 @@ func NewWithLock(path string, maxSizeMB int, maxBackups int, lockFile *os.File) 
 	}
 
 	return &Store{
-		path:       path,
-		maxBytes:   int64(maxSizeMB) * 1024 * 1024,
-		maxBackups: maxBackups,
-		file:       f,
-		lockFile:   lockFile,
+		path:        path,
+		maxBytes:    int64(maxSizeMB) * 1024 * 1024,
+		maxBackups:  maxBackups,
+		file:        f,
+		lockFile:    lockFile,
+		syncOnWrite: true,
 	}, nil
 }
 
@@ -147,10 +149,30 @@ func (s *Store) WriteRaw(_ context.Context, data []byte) error {
 		}
 		return fmt.Errorf("write jsonl raw: %w", writeErr)
 	}
-	if err := s.file.Sync(); err != nil {
-		return &DurabilityError{Err: fmt.Errorf("sync jsonl raw: %w", err)}
+	if s.syncOnWrite {
+		if err := s.file.Sync(); err != nil {
+			return &DurabilityError{Err: fmt.Errorf("sync jsonl raw: %w", err)}
+		}
 	}
 	return nil
+}
+
+// SetSyncOnWrite controls whether WriteRaw calls file.Sync() after each write.
+// When false, callers are responsible for calling Sync() periodically.
+func (s *Store) SetSyncOnWrite(v bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.syncOnWrite = v
+}
+
+// Sync flushes buffered writes to durable storage.
+func (s *Store) Sync() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.file == nil {
+		return nil
+	}
+	return s.file.Sync()
 }
 
 func (s *Store) QueryEvents(_ context.Context, _ types.EventQuery) ([]types.Event, error) {

--- a/internal/store/jsonl/jsonl_test.go
+++ b/internal/store/jsonl/jsonl_test.go
@@ -1,12 +1,17 @@
 package jsonl
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/agentsh/agentsh/pkg/types"
 )
@@ -129,5 +134,136 @@ func TestJSONLStore_RotationKeepsAuditLockHeld(t *testing.T) {
 	}
 	if !errors.Is(err, ErrLocked) {
 		t.Fatalf("AcquireLock() error = %v, want ErrLocked", err)
+	}
+}
+
+func TestSync_FlushesToDisk(t *testing.T) {
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "audit.jsonl"), 10*1024*1024, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	data := []byte(`{"type":"test","id":"1"}`)
+	if err := s.WriteRaw(context.Background(), data); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Sync(); err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "audit.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(content, data) {
+		t.Fatalf("file does not contain written data")
+	}
+}
+
+func TestSync_NilFile(t *testing.T) {
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "audit.jsonl"), 10*1024*1024, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s.Close()
+
+	if err := s.Sync(); err != nil {
+		t.Fatalf("Sync() on closed store should return nil, got %v", err)
+	}
+}
+
+func TestWriteRaw_NoSyncWhenDisabled(t *testing.T) {
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "audit.jsonl"), 10*1024*1024, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	s.SetSyncOnWrite(false)
+
+	data := []byte(`{"type":"test","id":"nosync"}`)
+	if err := s.WriteRaw(context.Background(), data); err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "audit.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(content, data) {
+		t.Fatalf("file does not contain written data")
+	}
+}
+
+func TestWriteRaw_And_Sync_Concurrent(t *testing.T) {
+	dir := t.TempDir()
+	s, err := New(filepath.Join(dir, "audit.jsonl"), 10*1024*1024, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.Close()
+
+	s.SetSyncOnWrite(false)
+
+	const numWriters = 4
+	const eventsPerWriter = 50
+
+	var wg sync.WaitGroup
+
+	for w := 0; w < numWriters; w++ {
+		wg.Add(1)
+		go func(writerID int) {
+			defer wg.Done()
+			for i := 0; i < eventsPerWriter; i++ {
+				data := []byte(fmt.Sprintf(`{"writer":%d,"seq":%d}`, writerID, i))
+				if err := s.WriteRaw(context.Background(), data); err != nil {
+					t.Errorf("WriteRaw error: %v", err)
+				}
+			}
+		}(w)
+	}
+
+	stopSync := make(chan struct{})
+	var syncerWg sync.WaitGroup
+	syncerWg.Add(1)
+	go func() {
+		defer syncerWg.Done()
+		for {
+			select {
+			case <-stopSync:
+				return
+			default:
+				_ = s.Sync()
+				time.Sleep(10 * time.Millisecond)
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(stopSync)
+	syncerWg.Wait()
+
+	if err := s.Sync(); err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(dir, "audit.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := bytes.Split(bytes.TrimSpace(content), []byte("\n"))
+	if len(lines) != numWriters*eventsPerWriter {
+		t.Fatalf("got %d lines, want %d", len(lines), numWriters*eventsPerWriter)
+	}
+	for i, line := range lines {
+		var obj map[string]any
+		if err := json.Unmarshal(line, &obj); err != nil {
+			t.Fatalf("line %d: invalid JSON: %v", i, err)
+		}
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,6 +17,11 @@ type RawWriter interface {
 	WriteRaw(ctx context.Context, data []byte) error
 }
 
+// Syncer can flush buffered writes to durable storage.
+type Syncer interface {
+	Sync() error
+}
+
 type OutputStore interface {
 	SaveOutput(ctx context.Context, sessionID, commandID string, stdout, stderr []byte, stdoutTotal, stderrTotal int64, stdoutTrunc, stderrTrunc bool) error
 	ReadOutputChunk(ctx context.Context, commandID string, stream string, offset, limit int64) (chunk []byte, total int64, truncated bool, err error)


### PR DESCRIPTION
## Summary

- **Deferred fsync**: `AppendEvent` now writes to the page cache only (~11µs); a background 100ms timer calls `FlushSync()` to fsync + update the chain sidecar
- **Respond-before-emit**: All three handler paths (execve, file, unix socket) send the seccomp notify response before emitting the audit event, so the traced process is never blocked on audit I/O
- **Crash recovery extended**: Sidecar can lag behind by N events; startup walks forward from sidecar state, verifies the HMAC chain, and truncates any partial trailing lines

## Changes

| Area | What |
|------|------|
| `internal/store/jsonl` | `Syncer` interface, `SetSyncOnWrite(bool)`, `Sync()` |
| `internal/store` | `FlushSync()`, background flush timer (100ms), `sync.Once` idempotent `Close()`, seq+N crash recovery |
| `internal/netmonitor/unix` | `buildEvent`, `buildFileEvent`, `buildUnixSocketEvent` — pure builders; handlers restructured to respond then emit |
| `internal/api` | Fix `Handle()` callers for new two-return-value signature |

## Benchmarks

```
BenchmarkAppendEvent_DeferredSync-16      105214    11245 ns/op   (hot path)
BenchmarkFlushSync-16                      76681    40795 ns/op   (durability)
```

## Test plan

- [x] `go test ./...` — 90 packages, all passing
- [x] `GOOS=windows go build ./...` — cross-compile OK
- [x] `GOOS=darwin go build ./...` — cross-compile OK
- [x] New tests: FlushSync, timer, Close, concurrent, crash recovery (seq+N gap, invalid chain, truncated line)
- [x] New tests: event builders have no side effects (`emit_order_test.go`)
- [x] Benchmarks: AppendEvent ~11µs, FlushSync ~41µs


🤖 Generated with [Claude Code](https://claude.com/claude-code)