### PR TITLE
fix(policy): server-side shell-c derive closes deny bypass via sh -c

### DIFF
--- a/internal/api/pty_grpc_exec_test.go
+++ b/internal/api/pty_grpc_exec_test.go
@@ -69,7 +69,7 @@ func TestGRPC_PTY_ExecBasic(t *testing.T) {
 			Start: &ptygrpc.ExecPTYStart{
 				SessionId: sess.ID,
 				Command:   "sh",
-				Args:      []string{"-lc", "printf hi"},
+				Args:      []string{"-c", "printf hi"},
 				Rows:      24,
 				Cols:      80,
 			},

--- a/internal/api/pty_ws_test.go
+++ b/internal/api/pty_ws_test.go
@@ -73,7 +73,7 @@ func TestPTYWebSocket_StartAndExit(t *testing.T) {
 		"type": "start",
 		// Non-interactive command executed under a PTY.
 		"command": "sh",
-		"args":    []string{"-lc", "printf hi"},
+		"args":    []string{"-c", "printf hi"},
 		"rows":    24,
 		"cols":    80,
 	}

--- a/internal/policy/command_shellc_test.go
+++ b/internal/policy/command_shellc_test.go
@@ -1,0 +1,728 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// TestEngine_CheckCommand_ShellCDerive verifies that a policy rule targeting
+// an inner binary fires when the binary is invoked via `<shell> -c "<cmd>"`.
+// Before the shellparse integration, `sh -c "shutdown now"` only matched
+// rules targeting `sh`, so `deny bin=shutdown` was trivially bypassable.
+func TestEngine_CheckCommand_ShellCDerive(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "deny-shutdown", Commands: []string{"shutdown"}, Decision: "deny"},
+			{Name: "allow-shells", Commands: []string{"sh", "bash", "dash", "zsh"}, Decision: "allow"},
+			{Name: "allow-reboot-absolute", Commands: []string{"/sbin/reboot"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		command  string
+		args     []string
+		decision types.Decision
+		rule     string
+	}{
+		// --- the bug fix ---
+		{"sh -c 'shutdown now' → derived deny", "/bin/sh", []string{"-c", "shutdown now"}, types.DecisionDeny, "deny-shutdown"},
+		{"bash -c 'shutdown' → derived deny", "/bin/bash", []string{"-c", "shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"bash -euxc 'shutdown' → clustered safe options, derived deny", "/bin/bash", []string{"-euxc", "shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -e -c 'shutdown' → split safe option + c, derived deny", "/bin/sh", []string{"-e", "-c", "shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"bash -e -u -c 'shutdown' → multi-split, derived deny", "/bin/bash", []string{"-e", "-u", "-c", "shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -l -c 'shutdown' → login option hides -c, bypass-deny", "/bin/sh", []string{"-l", "-c", "shutdown"}, types.DecisionDeny, "shellc-wrapper-bypass"},
+		{"bash -o errexit -c 'shutdown' → operand option hides -c, bypass-deny", "/bin/bash", []string{"-o", "errexit", "-c", "shutdown"}, types.DecisionDeny, "shellc-wrapper-bypass"},
+		{"sh -c 'shutdown now' argv0 → POSIX positional params ignored, derived deny", "/bin/sh", []string{"-c", "shutdown now", "argv0_name"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -c 'shutdown' argv0 p1 p2 → positional params ignored, derived deny", "/bin/sh", []string{"-c", "shutdown", "argv0_name", "p1", "p2"}, types.DecisionDeny, "deny-shutdown"},
+		{"uppercase shell path (case-insensitive FS) → derived deny", "/BIN/SH", []string{"-c", "shutdown now"}, types.DecisionDeny, "deny-shutdown"},
+		{"dash -c 'exec shutdown' → wrapper stripped, derived deny", "/bin/dash", []string{"-c", "exec shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -c 'nohup shutdown' → wrapper stripped, derived deny", "/bin/sh", []string{"-c", "nohup shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -c 'nice shutdown' → wrapper stripped, derived deny", "/bin/sh", []string{"-c", "nice shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"bash -c 'nohup exec shutdown' → chained wrappers, derived deny", "/bin/bash", []string{"-c", "nohup exec shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -c 'nice -n 19 shutdown' → nice -n N parsed, derived deny", "/bin/sh", []string{"-c", "nice -n 19 shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -c 'nice -n -5 shutdown' → nice -n negative parsed, derived deny", "/bin/sh", []string{"-c", "nice -n -5 shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"absolute path shutdown via sh", "sh", []string{"-c", "/sbin/shutdown now"}, types.DecisionDeny, "deny-shutdown"},
+		// --- time/env transparent wrappers (R15) ---
+		{"sh -c 'time shutdown' → time stripped, derived deny", "/bin/sh", []string{"-c", "time shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -c 'env shutdown' → env stripped, derived deny", "/bin/sh", []string{"-c", "env shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -c 'time nohup shutdown' → time+nohup chained, derived deny", "/bin/sh", []string{"-c", "time nohup shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -c 'env nohup shutdown' → env+nohup chained, derived deny", "/bin/sh", []string{"-c", "env nohup shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -c 'exec env shutdown' → exec+env chained, derived deny", "/bin/sh", []string{"-c", "exec env shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -c 'time -p shutdown' → time flag bypass", "/bin/sh", []string{"-c", "time -p shutdown"}, types.DecisionDeny, "shellc-wrapper-bypass"},
+		{"sh -c 'env -i shutdown' → env flag bypass", "/bin/sh", []string{"-c", "env -i shutdown"}, types.DecisionDeny, "shellc-wrapper-bypass"},
+		{"sh -c 'env -u PATH shutdown' → env -u bypass", "/bin/sh", []string{"-c", "env -u PATH shutdown"}, types.DecisionDeny, "shellc-wrapper-bypass"},
+		{"sh -c 'env VAR=val shutdown' → env with assign is byte-allowlist evasion bypass", "/bin/sh", []string{"-c", "env VAR=val shutdown"}, types.DecisionDeny, "shellc-wrapper-bypass"},
+		// --- zsh treated as known shell: outer allow bin=zsh doesn't mask inner deny.
+		{"zsh -c 'shutdown' → derived deny", "zsh", []string{"-c", "shutdown now"}, types.DecisionDeny, "deny-shutdown"},
+		{"zsh -c 'nohup shutdown' → wrapper stripped, derived deny", "/usr/bin/zsh", []string{"-c", "nohup shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"zsh -c 'exec -a foo shutdown' → bypass deny", "zsh", []string{"-c", "exec -a foo shutdown"}, types.DecisionDeny, "shellc-wrapper-bypass"},
+		// --- env-assignment parse-through: strip leading NAME=VALUE and
+		// derive past them so `deny-shutdown` fires instead of falling
+		// back to the outer shell allow.
+		{"sh -c 'PATH=/tmp shutdown' → assign parse-through, derived deny", "/bin/sh", []string{"-c", "PATH=/tmp shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -c 'FOO=bar shutdown now' → assign parse-through with arg, derived deny", "/bin/sh", []string{"-c", "FOO=bar shutdown now"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -c 'PATH=/tmp nohup shutdown' → assign + wrapper parse-through, derived deny", "/bin/sh", []string{"-c", "PATH=/tmp nohup shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -c 'FOO=1 BAR=2 nice -n 19 shutdown' → multi-assign + nice -n parse-through, derived deny", "/bin/sh", []string{"-c", "FOO=1 BAR=2 nice -n 19 shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"sh -c 'FOO= exec shutdown' → empty-value assign + exec parse-through, derived deny", "/bin/sh", []string{"-c", "FOO= exec shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		// --- nested derivation ---
+		{"sh -c 'bash -c shutdown' → recursive derive", "/bin/sh", []string{"-c", "bash -c shutdown"}, types.DecisionDeny, "deny-shutdown"},
+
+		// --- original allow path still works when derived command has no explicit rule ---
+		{"sh -c 'ls' → no ls rule, fall back to shell allow", "/bin/sh", []string{"-c", "ls"}, types.DecisionAllow, "allow-shells"},
+		{"sh -c 'echo hi' → builtin rejects derive, shell allow", "/bin/sh", []string{"-c", "echo hi"}, types.DecisionAllow, "allow-shells"},
+
+		// --- opaque scripts (metachars, pipes, subshells, globs, …) fail
+		// closed because policy contains a restrictive command rule
+		// (`deny-shutdown`). Without this, `sh -c "shutdown; true"` would
+		// silently fall through to `allow-shells`.
+		{"sh -c 'ls | wc' → pipe is opaque", "/bin/sh", []string{"-c", "ls | wc"}, types.DecisionDeny, "shellc-opaque-script"},
+		{"sh -c 'shutdown; true' → semicolon is opaque", "/bin/sh", []string{"-c", "shutdown; true"}, types.DecisionDeny, "shellc-opaque-script"},
+		{"sh -c 'foo && shutdown' → && is opaque", "/bin/sh", []string{"-c", "foo && shutdown"}, types.DecisionDeny, "shellc-opaque-script"},
+		{"sh -c 'shutdown || true' → || is opaque", "/bin/sh", []string{"-c", "shutdown || true"}, types.DecisionDeny, "shellc-opaque-script"},
+		{"sh -c 'foo > out' → redirect is opaque", "/bin/sh", []string{"-c", "foo > out"}, types.DecisionDeny, "shellc-opaque-script"},
+		{"sh -c 'foo < in' → redirect-in is opaque", "/bin/sh", []string{"-c", "foo < in"}, types.DecisionDeny, "shellc-opaque-script"},
+		{"sh -c '(shutdown)' → subshell is opaque", "/bin/sh", []string{"-c", "(shutdown)"}, types.DecisionDeny, "shellc-opaque-script"},
+		{"sh -c 'ls *.go' → glob is opaque", "/bin/sh", []string{"-c", "ls *.go"}, types.DecisionDeny, "shellc-opaque-script"},
+		{"sh -c 'echo \"hi there\"' → quoted string is opaque", "/bin/sh", []string{"-c", "echo \"hi there\""}, types.DecisionDeny, "shellc-opaque-script"},
+		{"sh -c 'echo $FOO' → variable expansion is opaque", "/bin/sh", []string{"-c", "echo $FOO"}, types.DecisionDeny, "shellc-opaque-script"},
+		{"sh -c 'echo `date`' → command substitution is opaque", "/bin/sh", []string{"-c", "echo `date`"}, types.DecisionDeny, "shellc-opaque-script"},
+
+		// --- bare invocations unchanged ---
+		{"bare sh", "/bin/sh", nil, types.DecisionAllow, "allow-shells"},
+		{"bare bash", "bash", nil, types.DecisionAllow, "allow-shells"},
+		{"bare shutdown", "shutdown", nil, types.DecisionDeny, "deny-shutdown"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dec := e.CheckCommand(tc.command, tc.args)
+			if dec.PolicyDecision != tc.decision {
+				t.Errorf("decision: got %s, want %s (rule=%q)", dec.PolicyDecision, tc.decision, dec.Rule)
+			}
+			if dec.Rule != tc.rule {
+				t.Errorf("rule: got %q, want %q", dec.Rule, tc.rule)
+			}
+		})
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_OriginalDenyWins verifies that if the
+// shell itself is denied, we return that deny without evaluating the inner
+// command. This protects operators who use "deny all shells" as a baseline.
+func TestEngine_CheckCommand_ShellCDerive_OriginalDenyWins(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "deny-shells", Commands: []string{"sh", "bash"}, Decision: "deny"},
+			{Name: "allow-ls", Commands: []string{"ls"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "ls"})
+	if dec.PolicyDecision != types.DecisionDeny {
+		t.Fatalf("expected deny, got %s (rule=%q)", dec.PolicyDecision, dec.Rule)
+	}
+	if dec.Rule != "deny-shells" {
+		t.Errorf("expected rule deny-shells, got %q", dec.Rule)
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_DefaultDenyNotEscalated verifies that
+// a derived command that hits default-deny (no matching rule) does NOT
+// override an original allow. Otherwise `allow-shells` would require an
+// explicit allow rule for every binary a shell can launch.
+func TestEngine_CheckCommand_ShellCDerive_DefaultDenyNotEscalated(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "allow-shells", Commands: []string{"sh", "bash"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No rule targets shutdown, so the default-deny applies at the derived
+	// level — but because it's a default-deny (matched=false), we return
+	// the original (allow-shells).
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "shutdown now"})
+	if dec.PolicyDecision != types.DecisionAllow {
+		t.Fatalf("expected allow-shells, got %s (rule=%q)", dec.PolicyDecision, dec.Rule)
+	}
+	if dec.Rule != "allow-shells" {
+		t.Errorf("expected rule allow-shells, got %q", dec.Rule)
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_NotAShell verifies we don't try to
+// peek past non-shell binaries, even if their args include `-c`.
+func TestEngine_CheckCommand_ShellCDerive_NotAShell(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "deny-shutdown", Commands: []string{"shutdown"}, Decision: "deny"},
+			{Name: "allow-python", Commands: []string{"python3"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// python -c "shutdown" is a python string, not a shell script. Don't
+	// derive.
+	dec := e.CheckCommand("python3", []string{"-c", "shutdown"})
+	if dec.PolicyDecision != types.DecisionAllow {
+		t.Fatalf("expected allow-python, got %s (rule=%q)", dec.PolicyDecision, dec.Rule)
+	}
+	if dec.Rule != "allow-python" {
+		t.Errorf("expected rule allow-python, got %q", dec.Rule)
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_ApproveEscalates verifies that an
+// explicit `approve` rule on the inner binary is honored when invoked via
+// `<shell> -c`. Before the strictness comparison, only deny escalated, so an
+// operator using approval gating could be bypassed via `sh -c "cmd"`.
+func TestEngine_CheckCommand_ShellCDerive_ApproveEscalates(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "approve-shutdown", Commands: []string{"shutdown"}, Decision: "approve", Message: "needs approval"},
+			{Name: "allow-shells", Commands: []string{"sh", "bash"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, true /*enforceApprovals*/, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "shutdown now"})
+	if dec.PolicyDecision != types.DecisionApprove {
+		t.Fatalf("PolicyDecision: got %s, want approve (rule=%q)", dec.PolicyDecision, dec.Rule)
+	}
+	if dec.Rule != "approve-shutdown" {
+		t.Errorf("Rule: got %q, want approve-shutdown", dec.Rule)
+	}
+	if dec.Approval == nil || !dec.Approval.Required {
+		t.Errorf("expected Approval.Required=true, got %+v", dec.Approval)
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_RedirectEscalates verifies that an
+// explicit `redirect` rule on the inner binary is honored when invoked via
+// `<shell> -c`. Without this, operators relying on command rewriting (e.g.
+// `rm → trash`) could be silently bypassed by wrapping in `sh -c`.
+func TestEngine_CheckCommand_ShellCDerive_RedirectEscalates(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{
+				Name:       "redirect-rm",
+				Commands:   []string{"rm"},
+				Decision:   "redirect",
+				RedirectTo: &CommandRedirect{Command: "trash"},
+			},
+			{Name: "allow-shells", Commands: []string{"sh", "bash"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true /*enforceRedirects*/)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "rm foo"})
+	if dec.PolicyDecision != types.DecisionRedirect {
+		t.Fatalf("PolicyDecision: got %s, want redirect (rule=%q)", dec.PolicyDecision, dec.Rule)
+	}
+	if dec.Rule != "redirect-rm" {
+		t.Errorf("Rule: got %q, want redirect-rm", dec.Rule)
+	}
+	if dec.Redirect == nil || dec.Redirect.Command != "trash" {
+		t.Errorf("expected Redirect.Command=trash, got %+v", dec.Redirect)
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_AuditEscalates verifies that an
+// explicit `audit` rule on the inner binary is honored when invoked via
+// `<shell> -c`. The effective decision stays allow, but PolicyDecision is
+// audit so downstream logging fires — without this, `sh -c "sudo …"` would
+// escape audit capture that operators configured for direct `sudo` calls.
+func TestEngine_CheckCommand_ShellCDerive_AuditEscalates(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "audit-sudo", Commands: []string{"sudo"}, Decision: "audit"},
+			{Name: "allow-shells", Commands: []string{"sh", "bash"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "sudo id"})
+	if dec.PolicyDecision != types.DecisionAudit {
+		t.Fatalf("PolicyDecision: got %s, want audit (rule=%q)", dec.PolicyDecision, dec.Rule)
+	}
+	if dec.EffectiveDecision != types.DecisionAllow {
+		t.Errorf("EffectiveDecision: got %s, want allow (audit is allow+log)", dec.EffectiveDecision)
+	}
+	if dec.Rule != "audit-sudo" {
+		t.Errorf("Rule: got %q, want audit-sudo", dec.Rule)
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_NoDowngrade verifies that a derived
+// rule with a STRICTLY LESS restrictive decision does not weaken the
+// original. Example: `sh -c "ls"` where the shell itself is gated by an
+// approve rule — the inner `allow-ls` must not drop us below approve.
+func TestEngine_CheckCommand_ShellCDerive_NoDowngrade(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "approve-shells", Commands: []string{"sh", "bash"}, Decision: "approve"},
+			{Name: "allow-ls", Commands: []string{"ls"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "ls"})
+	if dec.PolicyDecision != types.DecisionApprove {
+		t.Fatalf("PolicyDecision: got %s, want approve (rule=%q)", dec.PolicyDecision, dec.Rule)
+	}
+	if dec.Rule != "approve-shells" {
+		t.Errorf("Rule: got %q, want approve-shells", dec.Rule)
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_StrictnessOrdering walks through a
+// nested shell-c chain where each depth matches a different strictness,
+// confirming that the strictest wins regardless of position in the chain.
+// `sh -c "bash -c shutdown"` with allow-sh + audit-bash + deny-shutdown
+// should end up deny.
+func TestEngine_CheckCommand_ShellCDerive_StrictnessOrdering(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "deny-shutdown", Commands: []string{"shutdown"}, Decision: "deny"},
+			{Name: "audit-bash", Commands: []string{"bash"}, Decision: "audit"},
+			{Name: "allow-sh", Commands: []string{"sh"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "bash -c shutdown"})
+	if dec.PolicyDecision != types.DecisionDeny {
+		t.Fatalf("PolicyDecision: got %s, want deny (rule=%q)", dec.PolicyDecision, dec.Rule)
+	}
+	if dec.Rule != "deny-shutdown" {
+		t.Errorf("Rule: got %q, want deny-shutdown", dec.Rule)
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_AuditPreservesShellEnvPolicy is a
+// regression test for round-10 roborev: audit/approve don't rewrite the
+// executing command (the outer shell still runs), so the shell rule's
+// EnvPolicy must survive when an inner audit/approve rule promotes the
+// decision. Without this, env_allow configured on allow-shells would
+// silently vanish whenever a stricter audit/approve rule matched the
+// derived inner binary, weakening the operator's env-filtering posture.
+func TestEngine_CheckCommand_ShellCDerive_AuditPreservesShellEnvPolicy(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{
+				Name:        "audit-sudo",
+				Commands:    []string{"sudo"},
+				Decision:    "audit",
+				EnvAllow:    []string{"SUDO_SPECIFIC"},
+				EnvMaxBytes: 64,
+			},
+			{
+				Name:        "allow-shells",
+				Commands:    []string{"sh", "bash"},
+				Decision:    "allow",
+				EnvAllow:    []string{"PATH", "HOME", "SHELL_SPECIFIC"},
+				EnvMaxBytes: 16384,
+			},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "sudo id"})
+	if dec.PolicyDecision != types.DecisionAudit {
+		t.Fatalf("PolicyDecision: got %s, want audit", dec.PolicyDecision)
+	}
+	// EnvPolicy must be the OUTER shell's, because the outer shell is
+	// what actually executes under an audit decision.
+	if !containsString(dec.EnvPolicy.Allow, "SHELL_SPECIFIC") {
+		t.Errorf("expected shell rule's Allow to survive, got %v", dec.EnvPolicy.Allow)
+	}
+	if containsString(dec.EnvPolicy.Allow, "SUDO_SPECIFIC") {
+		t.Errorf("inner audit-sudo env allow leaked into result: %v", dec.EnvPolicy.Allow)
+	}
+	if dec.EnvPolicy.MaxBytes != 16384 {
+		t.Errorf("expected shell MaxBytes=16384, got %d", dec.EnvPolicy.MaxBytes)
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_ApprovePreservesShellEnvPolicy
+// mirrors the audit test for approve: after the human approves, the
+// ORIGINAL shell command still runs, so the shell rule's env restrictions
+// must continue to apply.
+func TestEngine_CheckCommand_ShellCDerive_ApprovePreservesShellEnvPolicy(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{
+				Name:     "approve-shutdown",
+				Commands: []string{"shutdown"},
+				Decision: "approve",
+				EnvAllow: []string{"INNER_ONLY"},
+			},
+			{
+				Name:     "allow-shells",
+				Commands: []string{"sh"},
+				Decision: "allow",
+				EnvAllow: []string{"PATH", "HOME"},
+			},
+		},
+	}
+	e, err := NewEngine(p, true /*enforceApprovals*/, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "shutdown now"})
+	if dec.PolicyDecision != types.DecisionApprove {
+		t.Fatalf("PolicyDecision: got %s, want approve", dec.PolicyDecision)
+	}
+	if !containsString(dec.EnvPolicy.Allow, "PATH") || !containsString(dec.EnvPolicy.Allow, "HOME") {
+		t.Errorf("expected shell env Allow to survive, got %v", dec.EnvPolicy.Allow)
+	}
+	if containsString(dec.EnvPolicy.Allow, "INNER_ONLY") {
+		t.Errorf("inner rule env Allow leaked: %v", dec.EnvPolicy.Allow)
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_RedirectUsesInnerEnvPolicy
+// documents the deliberate non-preservation for redirect: a redirect
+// REPLACES the command, so the outer shell no longer runs and the new
+// target's EnvPolicy is what governs execution.
+func TestEngine_CheckCommand_ShellCDerive_RedirectUsesInnerEnvPolicy(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{
+				Name:       "redirect-rm",
+				Commands:   []string{"rm"},
+				Decision:   "redirect",
+				RedirectTo: &CommandRedirect{Command: "trash"},
+				EnvAllow:   []string{"TRASH_SPECIFIC"},
+			},
+			{
+				Name:     "allow-shells",
+				Commands: []string{"sh"},
+				Decision: "allow",
+				EnvAllow: []string{"SHELL_ONLY"},
+			},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "rm foo"})
+	if dec.PolicyDecision != types.DecisionRedirect {
+		t.Fatalf("PolicyDecision: got %s, want redirect", dec.PolicyDecision)
+	}
+	if !containsString(dec.EnvPolicy.Allow, "TRASH_SPECIFIC") {
+		t.Errorf("expected inner redirect env Allow, got %v", dec.EnvPolicy.Allow)
+	}
+	if containsString(dec.EnvPolicy.Allow, "SHELL_ONLY") {
+		t.Errorf("outer shell env Allow leaked into redirect: %v", dec.EnvPolicy.Allow)
+	}
+}
+
+func containsString(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+// TestEngine_CheckCommand_ShellCDerive_BypassFailsClosed verifies that a
+// shell-c invocation containing a known command-exec wrapper in a flag form
+// we can't safely collapse results in a DENY — not a silent fall-through
+// to the outer shell's allow rule. Without this check, an operator relying
+// on `allow bin=sh` would be blind to `sh -c "exec -a name shutdown"`,
+// `sh -c "nohup --help shutdown"`, `sh -c "nice --adjustment=N shutdown"`,
+// etc. The outer allow rule wasn't written to cover wrappers.
+func TestEngine_CheckCommand_ShellCDerive_BypassFailsClosed(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "deny-shutdown", Commands: []string{"shutdown"}, Decision: "deny"},
+			{Name: "allow-shells", Commands: []string{"sh", "bash"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		command string
+		args    []string
+	}{
+		{"exec -a custom argv0", "/bin/sh", []string{"-c", "exec -a foo shutdown"}},
+		{"command -v (probe form)", "/bin/sh", []string{"-c", "command -v shutdown"}},
+		{"nohup --help", "/bin/sh", []string{"-c", "nohup --help shutdown"}},
+		{"nohup -x", "/bin/sh", []string{"-c", "nohup -x shutdown"}},
+		{"nice -n bogus (non-numeric)", "/bin/sh", []string{"-c", "nice -n bogus shutdown"}},
+		{"nice -19 (unsupported form)", "/bin/sh", []string{"-c", "nice -19 shutdown"}},
+		{"nice --adjustment=N (byte-allowlist evasion)", "/bin/sh", []string{"-c", "nice --adjustment=19 shutdown"}},
+		{"nohup --preserve-status=1 (byte-allowlist evasion)", "/bin/sh", []string{"-c", "nohup --preserve-status=1 shutdown"}},
+		// Unsafe shell options hiding -c.
+		{"bash -lc shutdown (login + c cluster)", "/bin/bash", []string{"-lc", "shutdown"}},
+		{"bash -l -c shutdown (login split)", "/bin/bash", []string{"-l", "-c", "shutdown"}},
+		{"bash -o errexit -c shutdown (operand option)", "/bin/bash", []string{"-o", "errexit", "-c", "shutdown"}},
+		{"bash --rcfile=X -c shutdown (long option)", "/bin/bash", []string{"--rcfile=/tmp/rc", "-c", "shutdown"}},
+		{"bash --norc -c shutdown (long option)", "/bin/bash", []string{"--norc", "-c", "shutdown"}},
+		{"bash -ic shutdown (interactive + c)", "/bin/bash", []string{"-ic", "shutdown"}},
+		// Env-assignment prefix with inner bypass (parse-through strips
+		// the assignment but the inner form is still unparsable).
+		{"assign + exec -a", "/bin/sh", []string{"-c", "VAR=x exec -a foo shutdown"}},
+		{"assign + nohup --preserve-status", "/bin/sh", []string{"-c", "PATH=/tmp nohup --preserve-status=1 shutdown"}},
+		{"assign + command -v", "/bin/sh", []string{"-c", "FOO=1 command -v shutdown"}},
+		// Env-assignment with a dirty VALUE (byte outside the narrow
+		// allowlist). The shell accepts these, but we can't safely
+		// parse-through, so fail closed.
+		{"dirty VALUE with colon", "/bin/sh", []string{"-c", "PATH=/tmp:/bin shutdown"}},
+		{"dirty VALUE with glob", "/bin/sh", []string{"-c", "PATH=*/bad nohup shutdown"}},
+		{"dirty VALUE with dollar", "/bin/sh", []string{"-c", "FOO=$VAR shutdown"}},
+		{"dirty VALUE with embedded equals", "/bin/sh", []string{"-c", "FOO=a=b shutdown"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dec := e.CheckCommand(tc.command, tc.args)
+			if dec.PolicyDecision != types.DecisionDeny {
+				t.Errorf("PolicyDecision: got %s, want deny (rule=%q)", dec.PolicyDecision, dec.Rule)
+			}
+			if dec.Rule != "shellc-wrapper-bypass" {
+				t.Errorf("Rule: got %q, want shellc-wrapper-bypass", dec.Rule)
+			}
+		})
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_OuterDenyBeatsBypass verifies that
+// when the outer shell rule is itself deny, we don't promote to
+// shellc-wrapper-bypass — the baseline deny already applies. (Strictness
+// comparison: outer deny has the same strictness as bypass deny, so no
+// upgrade happens.)
+func TestEngine_CheckCommand_ShellCDerive_OuterDenyBeatsBypass(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "deny-shells", Commands: []string{"sh"}, Decision: "deny"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "exec -a foo shutdown"})
+	if dec.PolicyDecision != types.DecisionDeny {
+		t.Fatalf("expected deny, got %s", dec.PolicyDecision)
+	}
+	if dec.Rule != "deny-shells" {
+		t.Errorf("expected outer deny-shells, got %q", dec.Rule)
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_BypassNotAShell verifies we don't
+// fail closed on non-shell binaries that happen to use a `-c` flag with
+// wrapper-looking syntax (e.g. python -c "nohup -x something" is a python
+// string, not a shell script).
+func TestEngine_CheckCommand_ShellCDerive_BypassNotAShell(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "allow-python", Commands: []string{"python3"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec := e.CheckCommand("python3", []string{"-c", "exec -a foo shutdown"})
+	if dec.PolicyDecision != types.DecisionAllow {
+		t.Fatalf("expected allow, got %s (rule=%q)", dec.PolicyDecision, dec.Rule)
+	}
+	if dec.Rule != "allow-python" {
+		t.Errorf("expected allow-python, got %q", dec.Rule)
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_OpaqueAllowOnlyPolicy verifies that
+// an allow-only policy (no deny/approve/redirect/audit/soft_delete rules)
+// does NOT trigger opaque-script fail-closed. Operators who've decided a
+// broad `allow sh` is acceptable shouldn't suddenly have every pipeline
+// denied; the opaque promotion is strictly a defense against silent
+// fall-through past a restrictive rule.
+func TestEngine_CheckCommand_ShellCDerive_OpaqueAllowOnlyPolicy(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "allow-shells", Commands: []string{"sh", "bash"}, Decision: "allow"},
+			{Name: "allow-ls", Commands: []string{"ls"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "ls | wc"})
+	if dec.PolicyDecision != types.DecisionAllow {
+		t.Fatalf("expected allow (no restrictive rule), got %s (rule=%q)", dec.PolicyDecision, dec.Rule)
+	}
+	if dec.Rule != "allow-shells" {
+		t.Errorf("expected allow-shells, got %q", dec.Rule)
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_DepthCapFailsClosed verifies that a
+// shell-c chain deeper than maxShellCDeriveDepth fails closed instead of
+// silently returning the outer allow. Without this, an attacker could
+// smuggle a denied command past inspection by wrapping it in enough nested
+// `sh -c "sh -c …"` layers.
+func TestEngine_CheckCommand_ShellCDerive_DepthCapFailsClosed(t *testing.T) {
+	// Temporarily lower the cap to 1 so a single nesting level exceeds it.
+	// Restoring via defer keeps the package-level var honest across tests.
+	orig := maxShellCDeriveDepth
+	maxShellCDeriveDepth = 1
+	defer func() { maxShellCDeriveDepth = orig }()
+
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "deny-shutdown", Commands: []string{"shutdown"}, Decision: "deny"},
+			{Name: "allow-shells", Commands: []string{"sh", "bash"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Depth 2 chain: outer sh-c wraps a bash-c that wraps shutdown.
+	// With cap=1, the loop peels the outermost sh-c once, then exits
+	// still holding `bash -c shutdown` — which is still derivable. The
+	// post-loop check must deny.
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "bash -c shutdown"})
+	if dec.PolicyDecision != types.DecisionDeny {
+		t.Fatalf("expected deny (cap exceeded), got %s (rule=%q)", dec.PolicyDecision, dec.Rule)
+	}
+	if dec.Rule != "shellc-depth-exceeded" {
+		t.Errorf("expected rule shellc-depth-exceeded, got %q", dec.Rule)
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_DepthCapAllowOnlyPolicy verifies
+// that when NO restrictive rule exists, depth-cap exhaustion does NOT
+// fire — the allow-only policy admits the chain via the outer allow,
+// same as the non-nested cases.
+//
+// Wait — actually the depth-cap check currently fires regardless of
+// hasRestrictiveCommandRule (it just promotes by strictness). If the
+// outer is `allow` (strictness 0), deny (strictness 4) > 0, so the
+// cap-exceeded deny always wins when the loop terminates with a
+// still-derivable tail. That's actually the desired behavior: even
+// under a broad allow, a runaway nesting chain is suspicious enough
+// to fail closed. This test pins that behavior so we don't accidentally
+// regress.
+func TestEngine_CheckCommand_ShellCDerive_DepthCapAllowOnlyFailsClosed(t *testing.T) {
+	orig := maxShellCDeriveDepth
+	maxShellCDeriveDepth = 1
+	defer func() { maxShellCDeriveDepth = orig }()
+
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "allow-shells", Commands: []string{"sh", "bash"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "bash -c shutdown"})
+	if dec.PolicyDecision != types.DecisionDeny {
+		t.Fatalf("expected deny (cap exceeded fails closed), got %s (rule=%q)", dec.PolicyDecision, dec.Rule)
+	}
+	if dec.Rule != "shellc-depth-exceeded" {
+		t.Errorf("expected rule shellc-depth-exceeded, got %q", dec.Rule)
+	}
+}
+
+// TestEngine_CheckCommand_ShellCDerive_DepthCapLoopCompletes verifies the
+// cap-exceeded path does NOT fire when the loop exits naturally (the tail
+// isn't derivable). This is the no-false-positive case — a chain that
+// bottoms out in a plain binary within the cap must not be flagged.
+func TestEngine_CheckCommand_ShellCDerive_DepthCapLoopCompletes(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "deny-shutdown", Commands: []string{"shutdown"}, Decision: "deny"},
+			{Name: "allow-shells", Commands: []string{"sh", "bash"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// `sh -c "ls"` — loop peels once, inner tail is `ls`, not derivable
+	// (not a shell), so the post-loop check sees ok=false and doesn't fire.
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "ls"})
+	if dec.PolicyDecision != types.DecisionAllow {
+		t.Fatalf("expected allow (loop completes cleanly), got %s (rule=%q)", dec.PolicyDecision, dec.Rule)
+	}
+	if dec.Rule != "allow-shells" {
+		t.Errorf("expected allow-shells, got %q", dec.Rule)
+	}
+}

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -10,9 +10,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agentsh/agentsh/internal/shellparse"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/gobwas/glob"
 )
+
+// maxShellCDeriveDepth bounds how many nested `sh -c "…"` forms CheckCommand
+// will peel off while looking for an explicit deny. Each level has to pass
+// the strict shellparse byte-allowlist, so real-world chains terminate in
+// one or two levels; the cap guards against a pathological input. var (not
+// const) so tests can lower it to exercise the cap-exceeded fail-closed path.
+var maxShellCDeriveDepth = 4
 
 // ThreatCheckResult holds the outcome of a threat feed lookup.
 type ThreatCheckResult struct {
@@ -36,6 +44,13 @@ type Engine struct {
 	compiledCommandRules  []compiledCommandRule
 	compiledUnixRules     []compiledUnixRule
 	compiledRegistryRules []compiledRegistryRule
+
+	// hasRestrictiveCommandRule is true iff any compiled command rule has
+	// a decision that restricts or instruments execution (deny, redirect,
+	// soft_delete, approve, audit). Gates the opaque-shell-c deny so that
+	// allow-only policies aren't unexpectedly tightened. See
+	// CheckCommand for the consumer.
+	hasRestrictiveCommandRule bool
 
 	// HTTP service compiled lookup maps
 	httpServices     map[string]*compiledHTTPService // keyed by lowercased name
@@ -238,6 +253,27 @@ func NewEngine(p *Policy, enforceApprovals bool, enforceRedirects bool) (*Engine
 			cr.argsRegexes = append(cr.argsRegexes, re)
 		}
 		e.compiledCommandRules = append(e.compiledCommandRules, cr)
+	}
+
+	// Precompute whether any command rule restricts or instruments execution.
+	// Consumed by CheckCommand's opaque-shell-c defense: a shell script we
+	// can't parse (metachars, subshells, …) is a bypass risk only when the
+	// operator has expressed intent to restrict commands. If every command
+	// rule is a plain allow, the operator accepted broad shell use and
+	// denying opaque scripts would be a behavior change without a security
+	// gain.
+	for _, r := range e.compiledCommandRules {
+		switch types.Decision(strings.ToLower(r.rule.Decision)) {
+		case types.DecisionDeny,
+			types.DecisionRedirect,
+			types.DecisionSoftDelete,
+			types.DecisionApprove,
+			types.DecisionAudit:
+			e.hasRestrictiveCommandRule = true
+		}
+		if e.hasRestrictiveCommandRule {
+			break
+		}
 	}
 
 	for _, r := range p.UnixRules {
@@ -545,6 +581,119 @@ func (e *Engine) CheckNetworkIP(domain string, ip net.IP, port int) Decision {
 }
 
 func (e *Engine) CheckCommand(command string, args []string) Decision {
+	result, _ := e.matchCommandRules(command, args)
+	// For `<shell> -c "<simple-cmd>"` invocations, also evaluate the
+	// underlying binary so a rule like `deny bin=shutdown` fires for
+	// `sh -c "shutdown now"`. An EXPLICITLY matched rule at any derivation
+	// depth whose policy decision is strictly more restrictive than the
+	// current result takes effect (deny > redirect/soft_delete > approve >
+	// audit > allow). A default-deny on an intermediate derivation (e.g.
+	// the shell allows `ls` but no rule targets `ls`) is ignored; otherwise
+	// every indirect invocation would be blocked by default-deny.
+	resultStrictness := decisionStrictness(result.PolicyDecision)
+	cur, curArgs := command, args
+	for depth := 0; depth < maxShellCDeriveDepth; depth++ {
+		derivedCmd, derivedArgs, ok := shellparse.DerivePolicyTarget(cur, curArgs)
+		if !ok {
+			// If the original (or a previously-derived) invocation is a
+			// shell-c form that we recognize as a wrapper-bypass attempt
+			// (`exec -a name target`, `nohup --help target`,
+			// `nice --adjustment=N target`, etc.), fail closed: the
+			// operator's allow-shell rule wasn't written to cover
+			// wrappers we can't collapse, and falling through to that
+			// rule would leak the deny.
+			if shellparse.IsShellCBypassAttempt(cur, curArgs) {
+				denyDec := e.wrapDecision(string(types.DecisionDeny), "shellc-wrapper-bypass", "bypass attempt via unparsable shell-c wrapper", nil)
+				if dec := denyDec; decisionStrictness(dec.PolicyDecision) > resultStrictness {
+					if dec.PolicyDecision == types.DecisionAudit || dec.PolicyDecision == types.DecisionApprove {
+						dec.EnvPolicy = result.EnvPolicy
+					}
+					result = dec
+					resultStrictness = decisionStrictness(dec.PolicyDecision)
+				}
+			} else if e.hasRestrictiveCommandRule && shellparse.IsOpaqueShellC(cur, curArgs) {
+				// Opaque scripts (metachars, pipes, subshells, globs, …) can
+				// execute binaries we can't predict. With any restrictive
+				// command rule in the policy, silently falling through to
+				// the outer `allow sh` admits a bypass (`sh -c "shutdown; :"`).
+				// Policies without restrictive command rules are unaffected.
+				denyDec := e.wrapDecision(string(types.DecisionDeny), "shellc-opaque-script", "opaque shell script cannot be safely parsed for policy pre-check", nil)
+				if dec := denyDec; decisionStrictness(dec.PolicyDecision) > resultStrictness {
+					result = dec
+					resultStrictness = decisionStrictness(dec.PolicyDecision)
+				}
+			}
+			break
+		}
+		cur, curArgs = derivedCmd, derivedArgs
+		dec, matched := e.matchCommandRules(cur, curArgs)
+		if !matched {
+			continue
+		}
+		if s := decisionStrictness(dec.PolicyDecision); s > resultStrictness {
+			// Audit and approve don't rewrite the command — the ORIGINAL
+			// shell invocation is what actually executes (audit just
+			// emits a log event, approve gates on a human who then runs
+			// the unchanged shell command). So the shell rule's
+			// EnvPolicy must follow along; otherwise env_allow /
+			// env_deny / env_max_bytes / BASH_ENV-style injection
+			// attached to the allow-shells rule would silently vanish
+			// as soon as a stricter inner-command rule matched. For
+			// deny (no execution) and redirect (command replaced with
+			// a different target) the derived rule's EnvPolicy is
+			// appropriate as-is.
+			if dec.PolicyDecision == types.DecisionAudit || dec.PolicyDecision == types.DecisionApprove {
+				dec.EnvPolicy = result.EnvPolicy
+			}
+			result = dec
+			resultStrictness = s
+		}
+	}
+	// Depth-cap defense: if the loop terminated with a still-derivable
+	// target, a malicious chain deeper than maxShellCDeriveDepth could
+	// have smuggled a denied command past our inspection. Fail closed
+	// with shellc-depth-exceeded. Checking DerivePolicyTarget on the
+	// current (cur, curArgs) is safe: if we broke via !ok above, this
+	// call also returns !ok (no false positive); if the loop ran to
+	// completion with each level ok, this call tests the (N+1)th level.
+	if _, _, ok := shellparse.DerivePolicyTarget(cur, curArgs); ok {
+		denyDec := e.wrapDecision(string(types.DecisionDeny), "shellc-depth-exceeded", "nested shell-c chain exceeded max derivation depth", nil)
+		if s := decisionStrictness(denyDec.PolicyDecision); s > resultStrictness {
+			result = denyDec
+			resultStrictness = s
+		}
+	}
+	return result
+}
+
+// decisionStrictness ranks PolicyDecision values by how much they restrict or
+// instrument execution. Used by CheckCommand to decide whether an explicit
+// rule matched on a shell-c-derived inner command should override a more
+// permissive rule matched on the outer shell. Ordering is intentionally:
+// deny > redirect/soft_delete > approve > audit > allow — deny blocks
+// execution outright, redirect rewrites what runs, approve gates on a
+// human, audit only adds logging, and allow is the baseline.
+func decisionStrictness(d types.Decision) int {
+	switch d {
+	case types.DecisionDeny:
+		return 4
+	case types.DecisionRedirect, types.DecisionSoftDelete:
+		return 3
+	case types.DecisionApprove:
+		return 2
+	case types.DecisionAudit:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// matchCommandRules runs the rule-matching loop against command/args and
+// returns the resulting decision plus whether an explicit rule matched.
+// When no rule matched, matched=false and the returned Decision is the
+// default-deny fall-through (kept here so callers that don't care about
+// match status continue to see deny-by-default).
+func (e *Engine) matchCommandRules(command string, args []string) (Decision, bool) {
 	cmdLower := strings.ToLower(command)
 	cmdBase := strings.ToLower(filepath.Base(command))
 
@@ -616,12 +765,12 @@ func (e *Engine) CheckCommand(command string, args []string) Decision {
 
 		dec := e.wrapDecision(r.rule.Decision, r.rule.Name, r.rule.Message, r.rule.RedirectTo)
 		dec.EnvPolicy = MergeEnvPolicy(e.policy.EnvPolicy, r.rule)
-		return dec
+		return dec, true
 	}
 	// Default deny (consistent with file_rules, network_rules, and unix_socket_rules).
 	dec := e.wrapDecision(string(types.DecisionDeny), "default-deny-commands", "", nil)
 	dec.EnvPolicy = MergeEnvPolicy(e.policy.EnvPolicy, CommandRule{})
-	return dec
+	return dec, false
 }
 
 // isReadOperation returns true for non-mutating file operations.

--- a/internal/shellparse/shellparse.go
+++ b/internal/shellparse/shellparse.go
@@ -1,0 +1,638 @@
+// Package shellparse extracts the policy-relevant binary from a shell-wrapped
+// invocation like `sh -c "shutdown now"`.
+//
+// Why: the server's policy pre-check runs CheckCommand(cmd, args). When the
+// client invokes a shell with `-c`, the command is the shell binary and the
+// script is opaque to the policy engine. A rule like `deny bin=shutdown`
+// never fires for `sh -c "shutdown now"` unless we peek inside the script.
+//
+// This package implements that peek for the narrow case where the script is
+// a single external command with no shell features (pipes, globs, redirects,
+// builtins, quoting, compound operators, …). For anything more complex we
+// return ok=false and the caller falls back to checking the shell itself —
+// a safe default because the shell's own rule (or per-builtin rule via
+// env_inject) still applies.
+//
+// This is a best-effort pre-check aid, NOT a sandbox. The actual exec still
+// runs via the shell; seccomp/landlock/env_inject remain the primary
+// enforcement layers. This package only widens what the policy pre-check
+// can see.
+package shellparse
+
+import (
+	"strings"
+)
+
+// DerivePolicyTarget reports the underlying binary and args that should be
+// used for a policy pre-check when command+args represents a simple shell
+// invocation of the form `<shell> -c "<simple-cmd>"`.
+//
+// Returns (derivedCmd, derivedArgs, true) for invocations the caller can
+// safely substitute for policy evaluation, or ("", nil, false) otherwise —
+// in which case the caller MUST use the original command/args UNLESS
+// IsShellCBypassAttempt reports true, which indicates a known command-exec
+// wrapper in a form we can't safely parse; the caller should fail closed.
+//
+// The input command may be an absolute path ("/bin/sh"), a relative path
+// ("./sh"), or a bare name ("bash"); the basename is lowercased before
+// matching the known-shell set so that case-insensitive filesystems
+// (e.g. stock macOS) don't produce a bypass where `/BIN/SH` is recognized
+// by the policy engine but not by this derivation. Both `/` and `\` are
+// treated as path separators regardless of GOOS so cross-compiled Windows
+// builds parse Unix-style exec paths the same way a Linux server would.
+func DerivePolicyTarget(command string, args []string) (string, []string, bool) {
+	if command == "" {
+		return "", nil, false
+	}
+	if !isKnownShell(basenameLower(command)) {
+		return "", nil, false
+	}
+	cmd, argv, status := parseSimpleShellC(args)
+	if status == statusOK {
+		return cmd, argv, true
+	}
+	return "", nil, false
+}
+
+// IsShellCBypassAttempt reports whether command+args is a shell-c invocation
+// that exposes a known command-exec wrapper (nohup, nice, exec, command) in
+// a form we can't safely collapse to a single binary — for example
+// `sh -c "exec -a foo shutdown"` or `sh -c "nohup --preserve-status rm /"`.
+// The caller (policy engine) should treat a true return as grounds to fail
+// closed: the operator's allow-shell rule would otherwise cover a bypass
+// attempt that DerivePolicyTarget declined to rewrite.
+//
+// Returns false for invocations that DerivePolicyTarget would succeed on,
+// so a typical caller checks this only after DerivePolicyTarget reports
+// ok=false.
+func IsShellCBypassAttempt(command string, args []string) bool {
+	if command == "" {
+		return false
+	}
+	if !isKnownShell(basenameLower(command)) {
+		return false
+	}
+	_, _, status := parseSimpleShellC(args)
+	return status == statusBypass
+}
+
+// IsOpaqueShellC reports whether command+args is a shell-c invocation whose
+// script is a multi-command program our parser can't safely reduce to a
+// single binary. Opaque scripts contain shell features like metacharacters
+// (`;`, `&`, `|`), redirects, subshells, globs, quoting, or parameter
+// substitution — any of which can cause the shell to execute a different
+// binary than the first token suggests.
+//
+// The caller (policy engine) should fail closed on true ONLY when the
+// policy contains at least one restrictive command rule (deny, redirect,
+// soft_delete, approve, audit). Policies that only allow are, by the
+// operator's own expression, not relying on command-level restrictions —
+// denying opaque scripts there would break legitimate shell use without
+// closing any bypass. See Engine.hasRestrictiveCommandRule for the gate.
+//
+// Returns false for invocations DerivePolicyTarget can rewrite and for
+// bypass forms (IsShellCBypassAttempt is the correct API for those).
+func IsOpaqueShellC(command string, args []string) bool {
+	if command == "" {
+		return false
+	}
+	if !isKnownShell(basenameLower(command)) {
+		return false
+	}
+	_, _, status := parseSimpleShellC(args)
+	return status == statusOpaque
+}
+
+// basenameLower returns the last path segment of s, lowercased, treating
+// both '/' and '\' as separators. Using stdlib filepath.Base would pick up
+// host-OS separator rules at build time, which would cause the same input
+// to parse differently on a Linux vs. Windows build of this binary. The
+// policy engine normalizes command basenames the same way, so mirroring
+// that behavior here closes the mismatch that would otherwise let a
+// Windows-separator path slip past shell detection while still matching
+// shell-targeted allow rules.
+func basenameLower(s string) string {
+	if i := strings.LastIndexAny(s, `/\`); i >= 0 {
+		s = s[i+1:]
+	}
+	return strings.ToLower(s)
+}
+
+// isKnownShell reports whether base names a POSIX-compatible shell whose
+// `-c` semantics are well-defined enough to justify looking past it.
+// `busybox` and multi-call binaries are intentionally excluded: inferring
+// which applet will run would require replicating busybox's argv dispatch,
+// and a false-positive there could bypass policy.
+//
+// zsh is included even though its -c handling has some idiosyncrasies
+// (globbing, word-splitting) because operators commonly set zsh as $SHELL;
+// excluding it creates a bypass where `allow bin=zsh` admits denied inner
+// commands. Our script byte allowlist already excludes glob metachars, so
+// the practical derive path stays safe.
+func isKnownShell(base string) bool {
+	switch base {
+	case "sh", "bash", "dash", "ash", "mksh", "ksh", "zsh":
+		return true
+	}
+	return false
+}
+
+// parseStatus reports the outcome of shell-c derivation, distinguishing
+// four cases the caller needs to act on differently:
+//
+//   - statusOK: the returned (cmd, args) is a safe policy substitute.
+//   - statusFallback: shape isn't something we can rewrite (unknown shell
+//     option, builtin first token, empty script, unknown assign-prefix
+//     shape, etc.) AND we don't see a bypass risk. The caller should
+//     evaluate the original shell invocation — this is the
+//     default-safe fallback.
+//   - statusBypass: we recognized a known command-exec wrapper in a form
+//     we can't safely collapse (e.g. `exec -a foo bin`, `nohup --help bin`,
+//     `nice --adjustment=N bin`). Falling back to the outer shell rule
+//     would allow a deny bypass, because the operator named the shell
+//     rule expecting only simple shell use. The caller should fail closed.
+//   - statusOpaque: the script is a multi-command shell program we can't
+//     parse — metachars like `;`, `&`, `|`, globs, quotes, redirects, etc.
+//     The shell will execute arbitrary binaries, so an operator with a
+//     restrictive command rule (deny, redirect, audit, approve, soft_delete)
+//     anywhere in their policy cannot rely on the outer `allow sh` rule to
+//     cover the script. The caller should promote to deny iff any
+//     restrictive command rule exists; otherwise fall back to the outer
+//     rule (operator chose broad shell use, no bypass risk).
+type parseStatus int
+
+const (
+	statusFallback parseStatus = iota
+	statusOK
+	statusBypass
+	statusOpaque
+)
+
+// parseSimpleShellC detects the safe subset of `-c "<script>"` invocations
+// that can be rewritten to a direct argv for policy purposes.
+//
+// Returns (cmd, args, statusOK) only when:
+//   - shellArgs begins with zero or more SAFE short-option clusters
+//     followed by the cluster containing 'c'. Safe clusters contain only
+//     {c, e, u, f, x}: e (errexit) and u (nounset) are no-ops for a
+//     single external command, f (noglob) is redundant with our script
+//     byte-allowlist, and x (xtrace) only prints. So `sh -c "…"`,
+//     `sh -ec "…"`, `sh -euxc "…"`, AND split forms like `sh -e -c "…"`
+//     or `bash -e -u -c "…"` are all accepted. Long options (`--login`,
+//     `--rcfile=…`), operand options (`-o name`, `+o name`), and unknown
+//     short options are REJECTED — they either source profile scripts,
+//     change the inherited environment, or we can't prove they don't.
+//   - The argv entry immediately after the -c cluster is the script. Any
+//     arguments AFTER the script are POSIX-positional parameters: the
+//     first becomes `$0` inside the script and subsequent ones become
+//     `$1`, `$2`, … (sh(1) "COMMAND_STRING" form). Because our script
+//     byte-allowlist forbids `$`, the script's executed argv cannot
+//     reference them, so it is safe to ignore the extras — the actual
+//     command that will run is still `tokens[0] tokens[1:]` from the
+//     script string.
+//   - script uses only bytes from [A-Za-z0-9_./-] plus space/tab
+//   - after stripping transparent wrappers, the first token is NOT a shell
+//     builtin or reserved word
+//
+// Known transparent wrappers (exec/command/nohup/nice) in flag forms we
+// can't safely parse return statusBypass — see stripWrappers. Anything
+// else returns statusFallback.
+func parseSimpleShellC(shellArgs []string) (string, []string, parseStatus) {
+	cFlagIdx, ok := findShellCFlag(shellArgs)
+	if !ok {
+		// findShellCFlag rejects the whole args sequence on the first
+		// unsafe option, which conflates "no -c anywhere" with "-c is
+		// present but preceded or combined with options we can't parse"
+		// (e.g., `bash -lc "shutdown"`, `bash -o errexit -c "shutdown"`,
+		// `bash --rcfile=X -c "shutdown"`). Returning statusFallback in
+		// the latter case lets the outer shell rule admit a deny bypass:
+		// operator writes `allow bash` + `deny shutdown`, user runs
+		// `bash -lc "shutdown"`, the inner deny never fires. Distinguish
+		// the two by scanning for a -c flag anywhere in any short cluster
+		// and failing closed when it's present.
+		if hasShellCWithUnsafeOptions(shellArgs) {
+			return "", nil, statusBypass
+		}
+		return "", nil, statusFallback
+	}
+	if cFlagIdx+1 >= len(shellArgs) {
+		return "", nil, statusFallback
+	}
+	script := strings.TrimSpace(shellArgs[cFlagIdx+1])
+	if script == "" {
+		return "", nil, statusFallback
+	}
+	// POSIX allows env-assignment prefixes: `PATH=/tmp cmd` runs `cmd` with
+	// PATH overridden for that exec only. The `=` byte fails the downstream
+	// scriptBytesAllowed check, which without this parse-through would push
+	// assign-prefixed scripts to statusFallback and silently admit a deny
+	// bypass (operator writes `allow sh` + `deny shutdown`, user runs
+	// `sh -c "PATH=/tmp shutdown"`, inner deny never fires). Strip leading
+	// NAME=VALUE tokens and continue deriving with the remainder, so the
+	// inner binary's rule fires normally. A VALUE containing bytes outside
+	// the allowlist (`:` in $PATH, `*` in globs, `$` in substitutions, …)
+	// signals a bypass: the user is smuggling shell-disallowed content
+	// through a pattern our pure-string check can't safely reason about.
+	script, dirty := stripLeadingAssignments(script)
+	if dirty {
+		return "", nil, statusBypass
+	}
+	script = strings.TrimSpace(script)
+	if script == "" {
+		// The entire script was env assignments — the shell sets vars and
+		// exits with no exec. No command to derive; hand back to outer
+		// shell rule.
+		return "", nil, statusFallback
+	}
+	// Detect bypass attempts that evade the byte allowlist: a known wrapper
+	// followed by a long option like `--adjustment=19` uses `=` which the
+	// allowlist rejects. Without this pre-check, such inputs would silently
+	// fall back to the outer shell rule even though they are clear bypass
+	// attempts. We peek at the first whitespace-delimited word and, if it
+	// is a known wrapper, any non-allowlisted bytes in the rest of the
+	// script count as an unparsable wrapper form — fail closed.
+	if headWord := firstWord(script); isTransparentWrapper(headWord) {
+		if !scriptBytesAllowed(script) {
+			return "", nil, statusBypass
+		}
+	}
+	if !scriptBytesAllowed(script) {
+		// Script has bytes outside the narrow allowlist but the head word
+		// isn't a known wrapper — so this is a multi-command shell program
+		// (pipes, subshells, redirects, compound commands, …) whose real
+		// argv we can't predict without running a shell. Tag statusOpaque
+		// so CheckCommand can promote to deny when any restrictive command
+		// rule exists in the policy — `allow sh` + `deny shutdown` mustn't
+		// silently admit `sh -c "shutdown; true"`.
+		return "", nil, statusOpaque
+	}
+	tokens := strings.Fields(script)
+	if len(tokens) == 0 {
+		return "", nil, statusFallback
+	}
+	tokens, bypass := stripWrappers(tokens)
+	if bypass {
+		return "", nil, statusBypass
+	}
+	if len(tokens) == 0 {
+		return "", nil, statusFallback
+	}
+	if isShellBuiltin(tokens[0]) {
+		return "", nil, statusFallback
+	}
+	return tokens[0], tokens[1:], statusOK
+}
+
+// firstWord returns the first whitespace-delimited token in s, or "" if
+// none. It is cheaper than strings.Fields for the common case where we
+// only need the head word.
+func firstWord(s string) string {
+	s = strings.TrimLeft(s, " \t")
+	if i := strings.IndexAny(s, " \t"); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// stripLeadingAssignments consumes leading whitespace-separated POSIX
+// env-assignment tokens (NAME=VALUE) from script and returns the
+// unconsumed remainder. The caller uses this to parse-through prefixes
+// like `PATH=/tmp nohup shutdown`: after stripping `PATH=/tmp`, the
+// remainder is `nohup shutdown`, which derives to `shutdown` via the
+// usual wrapper strip. Without parse-through, the `=` byte would fail
+// scriptBytesAllowed and the inner deny rule would be masked by the
+// outer shell's allow.
+//
+// A token is treated as an assignment iff:
+//   - It contains an `=`.
+//   - The bytes before `=` form a portable shell variable name:
+//     leading letter or underscore, then letters/digits/underscores.
+//     Names starting with a digit (`0FOO=bar`) are not assignments —
+//     the shell would try to exec them — so they end stripping.
+//
+// The VALUE (bytes after `=`, up to the next whitespace) must be within
+// the narrow byte allowlist [A-Za-z0-9_./-]. Any other byte (`:`, `*`,
+// `$`, `=`, …) signals a bypass: the user is embedding content the
+// shell would process specially that our downstream allowlist check
+// can't safely reason about. dirty=true instructs the caller to fail
+// closed.
+//
+// Returns (remainder, false) when zero or more clean assignments were
+// consumed. The remainder may still have leading whitespace; callers
+// that care should TrimSpace.
+// Returns ("", true) when a leading assignment has a dirty VALUE.
+func stripLeadingAssignments(script string) (string, bool) {
+	remainder := script
+	for {
+		i := 0
+		for i < len(remainder) && (remainder[i] == ' ' || remainder[i] == '\t') {
+			i++
+		}
+		if i >= len(remainder) {
+			break
+		}
+		start := i
+		for i < len(remainder) && remainder[i] != ' ' && remainder[i] != '\t' {
+			i++
+		}
+		tok := remainder[start:i]
+		eq := strings.IndexByte(tok, '=')
+		if eq < 1 {
+			return remainder, false
+		}
+		if !isValidAssignName(tok[:eq]) {
+			return remainder, false
+		}
+		if !valueBytesAllowed(tok[eq+1:]) {
+			return "", true
+		}
+		remainder = remainder[i:]
+	}
+	return remainder, false
+}
+
+// isValidAssignName reports whether name has the shape of a portable
+// POSIX shell variable name: leading letter or underscore, then
+// letters/digits/underscores. Names that don't match this shape are
+// not treated as assignments because the shell itself would not —
+// it'd try to execute them as commands — so there's no bypass to
+// defend against in that shape.
+func isValidAssignName(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	c := name[0]
+	if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_') {
+		return false
+	}
+	for i := 1; i < len(name); i++ {
+		c = name[i]
+		if !((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+			(c >= '0' && c <= '9') || c == '_') {
+			return false
+		}
+	}
+	return true
+}
+
+// valueBytesAllowed reports whether every byte of value is in the
+// narrow allowlist [A-Za-z0-9_./-]. This is scriptBytesAllowed minus
+// whitespace — VALUEs produced by whitespace-based token splitting
+// cannot themselves contain whitespace, so a stricter set is both safe
+// and correct. Characters outside the set (`:`, `*`, `$`, `=`, …) are
+// either shell metachars, glob metachars, or embedded separators that
+// a downstream scan of the full script would have rejected anyway;
+// returning false here surfaces the bypass attempt at the point where
+// we can still distinguish it from a benign mismatch.
+func valueBytesAllowed(value string) bool {
+	for i := 0; i < len(value); i++ {
+		b := value[i]
+		switch {
+		case b >= 'A' && b <= 'Z':
+		case b >= 'a' && b <= 'z':
+		case b >= '0' && b <= '9':
+		case b == '_' || b == '.' || b == '/' || b == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// scriptBytesAllowed returns true when every byte of script is in the
+// narrow allowlist [A-Za-z0-9_./-] plus space/tab. This is the core
+// safety invariant: disallowing `$`, quotes, metachars, and assignment
+// operators ensures a token-split of the script yields the actual argv
+// the shell would execute (no parameter substitution, no field-splitting
+// surprises from quoting).
+func scriptBytesAllowed(script string) bool {
+	for i := 0; i < len(script); i++ {
+		b := script[i]
+		switch {
+		case b >= 'A' && b <= 'Z':
+		case b >= 'a' && b <= 'z':
+		case b >= '0' && b <= '9':
+		case b == '_' || b == '.' || b == '/' || b == '-':
+		case b == ' ' || b == '\t':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// stripWrappers removes transparent-wrapper prefixes from tokens. Known
+// wrappers are consumed one at a time until the head token is either a
+// non-wrapper or unstrippable.
+//
+// Returns (rest, false) when either all wrappers were stripped cleanly
+// or the head isn't a wrapper at all. Returns (nil, true) — bypass — when
+// a wrapper is followed by a flag form we can't safely parse:
+//
+//   - exec -a NAME CMD … : `-a` sets a custom argv0. We don't parse it
+//     (one could, but we'd need to validate NAME and the subsequent CMD
+//     shape), so any `-` after `exec` fails closed.
+//   - command -v / -V / -p : these print info or change the PATH; none
+//     are transparent forwarding.
+//   - nohup -FLAG … : POSIX nohup has no options; GNU nohup only has
+//     --help / --version, neither of which runs a command. Any `-` is
+//     either a deliberate bypass or a no-op.
+//   - nice -n INCREMENT CMD … : the ONE nice flag form we recognize.
+//     Consumed as three tokens (`nice`, `-n`, INCREMENT) when INCREMENT
+//     parses as an optionally-signed integer. Other nice flags
+//     (--adjustment=N, +N, --help, etc.) fall into bypass.
+//
+// Design note: we fail closed rather than fall back to the outer shell
+// rule because the caller (policy engine) applies the outer rule when
+// DerivePolicyTarget returns ok=false. If the head token is a known
+// wrapper, the operator's `allow sh` rule was not written anticipating
+// a `exec -a CMD shutdown` bypass — that's NOT simple shell use. The
+// conservative answer is deny.
+func stripWrappers(tokens []string) ([]string, bool) {
+	for len(tokens) >= 2 && isTransparentWrapper(tokens[0]) {
+		wrapper := tokens[0]
+		next := tokens[1]
+		if !strings.HasPrefix(next, "-") {
+			tokens = tokens[1:]
+			continue
+		}
+		// nice -n INCREMENT CMD … : the one flag form we parse.
+		if wrapper == "nice" && next == "-n" && len(tokens) >= 3 && isNumericIncrement(tokens[2]) {
+			tokens = tokens[3:]
+			continue
+		}
+		return nil, true
+	}
+	return tokens, false
+}
+
+// isNumericIncrement reports whether s parses as an optionally-signed
+// decimal integer. Used to validate the `nice -n <increment>` operand.
+func isNumericIncrement(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	i := 0
+	if s[0] == '+' || s[0] == '-' {
+		i = 1
+		if i >= len(s) {
+			return false
+		}
+	}
+	for ; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// findShellCFlag locates the short-option cluster that introduces `-c`
+// inside shellArgs, walking past any leading safe-option clusters. It
+// returns (idx, true) with idx = position of the cluster containing 'c';
+// the script lives at shellArgs[idx+1]. On any unexpected option shape
+// (long option, operand option like `-o errexit`, unknown short char)
+// it returns (0, false).
+//
+// Safe leading option chars are {e, u, f, x} — see parseSimpleShellC for
+// why each is harmless for our single-external-command scope. The 'c'
+// option may appear anywhere in a cluster; it terminates scanning as
+// soon as it is seen because -c's required argument is the script.
+func findShellCFlag(shellArgs []string) (int, bool) {
+	for i, arg := range shellArgs {
+		if len(arg) < 2 || arg[0] != '-' {
+			return 0, false
+		}
+		if arg[1] == '-' {
+			// Rejects long options (`--login`, `--rcfile=…`, `--norc`)
+			// AND the bare `--` end-of-options marker — we don't need
+			// it since our option set is well-defined, and allowing
+			// it would complicate reasoning about positional params.
+			return 0, false
+		}
+		cluster := arg[1:]
+		hasC := false
+		for j := 0; j < len(cluster); j++ {
+			switch cluster[j] {
+			case 'c':
+				hasC = true
+			case 'e', 'u', 'f', 'x':
+				// safe; no impact on a single-command script
+			default:
+				return 0, false
+			}
+		}
+		if hasC {
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// hasShellCWithUnsafeOptions reports whether shellArgs contains a `-c`
+// short option anywhere in any cluster, even when paired with options
+// outside our safe subset. Called after findShellCFlag fails, it lets
+// the caller distinguish "no -c at all" (fall back to the outer shell
+// rule) from "-c present but option shape unparsable" (fail closed,
+// because the outer allow-rule was not written with bypass-via-option
+// shapes in mind).
+//
+// The scan stops at `--` since everything after it is positional. Long
+// options (those starting with `--`) are skipped — they never contain
+// a short `-c`. Non-option arguments are skipped too; they may appear
+// after an `-o NAME` pairing or simply be operand junk, and none of
+// them introduce a short-c flag.
+func hasShellCWithUnsafeOptions(shellArgs []string) bool {
+	for _, arg := range shellArgs {
+		if arg == "--" {
+			return false
+		}
+		if len(arg) < 2 || arg[0] != '-' {
+			continue
+		}
+		if arg[1] == '-' {
+			continue
+		}
+		for j := 1; j < len(arg); j++ {
+			if arg[j] == 'c' {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isTransparentWrapper reports whether tok is a wrapper whose
+// policy-relevant binary is the NEXT token. The wrapper itself is not what
+// the caller ultimately wants to run — it merely forwards execution:
+//
+//   - exec: shell builtin that replaces the shell with the command.
+//   - command: shell builtin that bypasses function lookup.
+//   - nohup: spawns the next command with SIGHUP ignored.
+//   - nice: spawns the next command with an adjusted niceness.
+//   - time: shell reserved word / binary that runs the next command and
+//     prints timing stats. Without this, `sh -c "time shutdown"` falls
+//     through to the outer shell allow because `time` classifies as a
+//     reserved word → statusFallback.
+//   - env: exec wrapper that optionally modifies the environment before
+//     running the next command. Without this, `sh -c "env shutdown"`
+//     derives to `env` (a bare name with no rule), which default-denies
+//     at the derived level but doesn't override the outer shell allow.
+//
+// Stripping these for policy derivation does NOT alter runtime semantics:
+// policy derivation only picks which rule to evaluate. The command that
+// actually executes is still the outer `sh -c "<script>"`, so the shell
+// will run `nohup shutdown` with SIGHUP ignored exactly as written when
+// the decision is allow/audit/approve. For deny the shell never runs, and
+// for redirect the command is replaced entirely, so the lost wrapper is
+// intentional. Treating these as transparent closes the bypass where
+// `sh -c "nohup shutdown"` evaded a `deny bin=shutdown` rule by surfacing
+// `nohup` (a bare name with no rule) as the policy target and falling
+// through to the outer shell allow.
+//
+// Wrappers followed by any flag token (e.g. `exec -a`, `command -v`,
+// `nice -n 19`, `env -i`, `time -p`) are rejected by the caller — flag
+// parsing is wrapper-specific and out of scope; failing to derive at all
+// is the safe default.
+func isTransparentWrapper(tok string) bool {
+	switch tok {
+	case "exec", "command", "nohup", "nice", "time", "env":
+		return true
+	}
+	return false
+}
+
+// isShellBuiltin reports whether tok is a POSIX or bash shell builtin,
+// reserved word, or syntactic keyword that cannot be safely replaced by a
+// same-named external binary for policy purposes. Reasons:
+//   - No external equivalent (cd, eval, hash, builtin, let, shopt, …).
+//   - Dual builtins with divergent semantics (echo, printf, pwd, test, …).
+//   - Reserved words (if, while, …) aren't valid first tokens anyway, but
+//     blocking them costs nothing.
+func isShellBuiltin(tok string) bool {
+	switch tok {
+	// POSIX special builtins
+	case ":", ".", "break", "continue", "eval", "exec", "exit",
+		"export", "readonly", "return", "set", "shift", "trap", "unset":
+		return true
+	// POSIX regular builtins and dual builtins (echo/printf/pwd/test/[
+	// blocked to avoid semantic divergence)
+	case "alias", "bg", "cd", "command", "fc", "fg", "getopts", "jobs",
+		"kill", "newgrp", "read", "umask", "unalias", "wait",
+		"echo", "printf", "pwd", "test", "[", "true", "false":
+		return true
+	// Bash-specific builtins
+	case "bind", "builtin", "caller", "compgen", "compopt", "complete",
+		"coproc", "declare", "dirs", "disown", "enable", "hash", "help",
+		"history", "let", "local", "logout", "mapfile", "popd", "pushd",
+		"readarray", "shopt", "source", "suspend", "times", "type",
+		"typeset", "ulimit":
+		return true
+	// Reserved words / syntactic keywords
+	case "if", "then", "else", "elif", "fi", "case", "esac", "while",
+		"do", "done", "for", "in", "function", "select", "time", "until",
+		"{", "}", "!", "[[", "]]":
+		return true
+	}
+	return false
+}

--- a/internal/shellparse/shellparse_test.go
+++ b/internal/shellparse/shellparse_test.go
@@ -1,0 +1,438 @@
+package shellparse
+
+import (
+	"testing"
+)
+
+// TestDerivePolicyTarget covers the public API: given a (command, args)
+// pair as it would arrive at the server exec API, return the binary the
+// policy pre-check should evaluate.
+func TestDerivePolicyTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		args    []string
+		wantCmd string
+		wantArg []string
+		wantOK  bool
+	}{
+		// --- happy path: basic shell-c forms ---
+		{"bare sh, simple cmd", "sh", []string{"-c", "shutdown now"}, "shutdown", []string{"now"}, true},
+		{"absolute sh, simple cmd", "/bin/sh", []string{"-c", "shutdown now"}, "shutdown", []string{"now"}, true},
+		{"relative sh", "./sh", []string{"-c", "ls"}, "ls", []string{}, true},
+		{"backslash-separator windows-style sh path", `C:\bin\sh`, []string{"-c", "shutdown"}, "shutdown", []string{}, true},
+		{"mixed-separator bash path", `/usr/local\bash`, []string{"-c", "ls"}, "ls", []string{}, true},
+		{"uppercase shell basename (case-insensitive FS)", "/BIN/SH", []string{"-c", "ls"}, "ls", []string{}, true},
+		{"bash, simple cmd", "bash", []string{"-c", "rm foo"}, "rm", []string{"foo"}, true},
+		{"dash", "/bin/dash", []string{"-c", "whoami"}, "whoami", []string{}, true},
+		{"ash (busybox shell on alpine)", "/bin/ash", []string{"-c", "id"}, "id", []string{}, true},
+		{"ksh", "ksh", []string{"-c", "ps"}, "ps", []string{}, true},
+		{"mksh", "mksh", []string{"-c", "date"}, "date", []string{}, true},
+
+		// --- flag forms ---
+		{"-ec (errexit + command)", "sh", []string{"-ec", "ls"}, "ls", []string{}, true},
+		{"-ce (reversed cluster)", "sh", []string{"-ce", "ls"}, "ls", []string{}, true},
+		{"-euxc (all safe shorts clustered)", "bash", []string{"-euxc", "shutdown"}, "shutdown", []string{}, true},
+		{"-e -c (split safe + c)", "sh", []string{"-e", "-c", "shutdown"}, "shutdown", []string{}, true},
+		{"-e -u -c (three split)", "bash", []string{"-e", "-u", "-c", "rm foo"}, "rm", []string{"foo"}, true},
+		{"-ux -c (split with cluster)", "sh", []string{"-ux", "-c", "ls"}, "ls", []string{}, true},
+		{"-f -c (noglob + c)", "sh", []string{"-f", "-c", "shutdown"}, "shutdown", []string{}, true},
+		{"-x -c (xtrace + c)", "sh", []string{"-x", "-c", "shutdown"}, "shutdown", []string{}, true},
+		{"-e -c script argv0 (positional after script)", "sh", []string{"-e", "-c", "shutdown", "argv0"}, "shutdown", []string{}, true},
+
+		// --- transparent wrappers ---
+		{"exec wrapper", "sh", []string{"-c", "exec shutdown now"}, "shutdown", []string{"now"}, true},
+		{"command wrapper", "sh", []string{"-c", "command ls"}, "ls", []string{}, true},
+		{"double exec", "sh", []string{"-c", "exec exec shutdown"}, "shutdown", []string{}, true},
+		{"exec then command", "sh", []string{"-c", "exec command ls"}, "ls", []string{}, true},
+		{"nohup wrapper stripped", "sh", []string{"-c", "nohup shutdown"}, "shutdown", []string{}, true},
+		{"nice wrapper stripped", "sh", []string{"-c", "nice ls"}, "ls", []string{}, true},
+		{"nohup exec chained", "sh", []string{"-c", "nohup exec shutdown"}, "shutdown", []string{}, true},
+		{"exec nohup chained", "sh", []string{"-c", "exec nohup shutdown"}, "shutdown", []string{}, true},
+		{"nice shutdown with arg", "sh", []string{"-c", "nice shutdown now"}, "shutdown", []string{"now"}, true},
+		// --- time wrapper: shell reserved word / binary that times the
+		// next command. Without this, `time shutdown` would classify as a
+		// shell builtin (reserved word) and fall through to outer allow.
+		{"time wrapper stripped", "sh", []string{"-c", "time shutdown"}, "shutdown", []string{}, true},
+		{"time with arg passes through", "sh", []string{"-c", "time shutdown now"}, "shutdown", []string{"now"}, true},
+		{"time then nohup chained", "sh", []string{"-c", "time nohup shutdown"}, "shutdown", []string{}, true},
+		{"nice then time chained", "sh", []string{"-c", "nice time shutdown"}, "shutdown", []string{}, true},
+		// --- env wrapper: runs the next command with (optionally modified)
+		// environment. Without this, `env shutdown` would surface `env`
+		// (bare name with no rule) and default-deny fails closed to outer
+		// allow.
+		{"env wrapper stripped", "sh", []string{"-c", "env shutdown"}, "shutdown", []string{}, true},
+		{"env with arg", "sh", []string{"-c", "env shutdown now"}, "shutdown", []string{"now"}, true},
+		{"env then nohup chained", "sh", []string{"-c", "env nohup shutdown"}, "shutdown", []string{}, true},
+		{"exec env shutdown chained", "sh", []string{"-c", "exec env shutdown"}, "shutdown", []string{}, true},
+
+		// --- rejected wrapper flag forms (deny rewrite via StatusBypass, NOT silent fallback) ---
+		{"command -v (flag form)", "sh", []string{"-c", "command -v ls"}, "", nil, false},
+		{"exec -a (flag form)", "sh", []string{"-c", "exec -a foo ls"}, "", nil, false},
+		{"nohup with flag rejects", "sh", []string{"-c", "nohup -h shutdown"}, "", nil, false},
+		{"nice -n N parsed (succeeds)", "sh", []string{"-c", "nice -n 19 shutdown"}, "shutdown", []string{}, true},
+		{"nice -n -5 parsed (succeeds)", "sh", []string{"-c", "nice -n -5 shutdown"}, "shutdown", []string{}, true},
+		{"nice -n +5 rejected (+ not in byte allowlist)", "sh", []string{"-c", "nice -n +5 shutdown"}, "", nil, false},
+		{"nice -n bogus (non-numeric increment)", "sh", []string{"-c", "nice -n bogus shutdown"}, "", nil, false},
+		{"nice --adjustment= rejects (= blocked by allowlist)", "sh", []string{"-c", "nice --adjustment=19 shutdown"}, "", nil, false},
+		{"time -p CMD rejected (unknown time flag)", "sh", []string{"-c", "time -p shutdown"}, "", nil, false},
+		{"time --help rejected", "sh", []string{"-c", "time --help shutdown"}, "", nil, false},
+		{"env -i CMD rejected (unknown env flag)", "sh", []string{"-c", "env -i shutdown"}, "", nil, false},
+		{"env -u VAR CMD rejected", "sh", []string{"-c", "env -u PATH shutdown"}, "", nil, false},
+		{"env --chdir= rejected (= blocked by allowlist)", "sh", []string{"-c", "env --chdir=/tmp shutdown"}, "", nil, false},
+		{"env VAR=val CMD rejected (= blocked in env wrapper form)", "sh", []string{"-c", "env VAR=val shutdown"}, "", nil, false},
+
+		// --- zsh: treated as a known shell so allow bin=zsh + deny
+		// bin=shutdown can't be bypassed via `zsh -c "shutdown"`.
+		{"zsh simple cmd", "zsh", []string{"-c", "ls"}, "ls", []string{}, true},
+		{"zsh absolute path", "/usr/bin/zsh", []string{"-c", "shutdown now"}, "shutdown", []string{"now"}, true},
+		// --- unknown shells ---
+		{"fish not supported", "/usr/bin/fish", []string{"-c", "ls"}, "", nil, false},
+		{"busybox multicall not supported", "busybox", []string{"sh", "-c", "ls"}, "", nil, false},
+		{"random binary with -c", "/usr/bin/python3", []string{"-c", "print('hi')"}, "", nil, false},
+		{"empty command", "", []string{"-c", "ls"}, "", nil, false},
+
+		// --- wrong flag forms ---
+		{"no flag", "sh", []string{"ls"}, "", nil, false},
+		{"-l (login)", "sh", []string{"-l", "-c", "ls"}, "", nil, false},
+		{"--login", "bash", []string{"--login", "-c", "ls"}, "", nil, false},
+		{"-lc cluster", "bash", []string{"-lc", "ls"}, "", nil, false},
+		{"-i (interactive)", "bash", []string{"-i", "-c", "ls"}, "", nil, false},
+		{"-p (privileged)", "bash", []string{"-p", "-c", "ls"}, "", nil, false},
+		{"-a (allexport)", "sh", []string{"-a", "-c", "ls"}, "", nil, false},
+		{"-s (read-stdin)", "sh", []string{"-s", "-c", "ls"}, "", nil, false},
+		{"-o errexit (operand option rejected)", "bash", []string{"-o", "errexit", "-c", "ls"}, "", nil, false},
+		{"+o (plus-form rejected)", "bash", []string{"+o", "noclobber", "-c", "ls"}, "", nil, false},
+		{"--rcfile=file (profile source)", "bash", []string{"--rcfile=/tmp/rc", "-c", "ls"}, "", nil, false},
+		{"--norc (long option)", "bash", []string{"--norc", "-c", "ls"}, "", nil, false},
+		{"-- (end-of-options marker)", "sh", []string{"--", "-c", "ls"}, "", nil, false},
+		{"empty args", "sh", nil, "", nil, false},
+		{"single arg no script", "sh", []string{"-c"}, "", nil, false},
+		// --- unsafe-option shapes with -c (treated as bypass, not fallback) ---
+		{"-lc with script (bypass, not fallback)", "bash", []string{"-lc", "shutdown"}, "", nil, false},
+		{"-rc cluster with script", "bash", []string{"-rc", "shutdown"}, "", nil, false},
+		{"-l -c split (bypass)", "bash", []string{"-l", "-c", "shutdown"}, "", nil, false},
+		{"-o errexit -c (bypass)", "bash", []string{"-o", "errexit", "-c", "shutdown"}, "", nil, false},
+		{"--rcfile -c (bypass)", "bash", []string{"--rcfile=/tmp/rc", "-c", "shutdown"}, "", nil, false},
+		{"--norc -c (bypass)", "bash", []string{"--norc", "-c", "shutdown"}, "", nil, false},
+		// --- env-assignment-prefix parse-through: strip leading NAME=VALUE
+		// tokens, derive the rest. Under `allow sh` + `deny shutdown` this
+		// lets the inner deny fire instead of masking it behind the shell.
+		{"assign + nohup (parse-through)", "sh", []string{"-c", "PATH=/tmp nohup shutdown"}, "shutdown", []string{}, true},
+		{"assign + exec (parse-through)", "sh", []string{"-c", "VAR=x exec shutdown"}, "shutdown", []string{}, true},
+		{"multiple assigns + nice -n N (parse-through)", "sh", []string{"-c", "FOO=1 BAR=2 nice -n 19 shutdown"}, "shutdown", []string{}, true},
+		{"empty-value assign + nohup (parse-through)", "sh", []string{"-c", "FOO= nohup shutdown"}, "shutdown", []string{}, true},
+		{"assign + plain binary (parse-through)", "sh", []string{"-c", "PATH=/tmp shutdown"}, "shutdown", []string{}, true},
+		{"assign + plain binary with arg (parse-through)", "sh", []string{"-c", "FOO=bar shutdown now"}, "shutdown", []string{"now"}, true},
+		// assign + inner bypass form (exec -a …) — strip leaves inner
+		// still unparsable → bypass.
+		{"assign + exec -a (inner bypass)", "sh", []string{"-c", "VAR=x exec -a foo shutdown"}, "", nil, false},
+		// dirty VALUE (byte outside the narrow allowlist) is a bypass.
+		{"assign with colon in VALUE", "sh", []string{"-c", "PATH=/tmp:/bin shutdown"}, "", nil, false},
+		{"assign with glob in VALUE", "sh", []string{"-c", "PATH=*/bad nohup shutdown"}, "", nil, false},
+		{"assign with dollar in VALUE", "sh", []string{"-c", "FOO=$VAR shutdown"}, "", nil, false},
+		{"assign with equals in VALUE", "sh", []string{"-c", "FOO=a=b shutdown"}, "", nil, false},
+		// digit-leading tokens are NOT valid assignments — shell would
+		// try to exec them. Falls through to the byte-allowlist check
+		// which rejects the `=` → statusFallback (not bypass).
+		{"digit-leading token is not assign (fallback)", "sh", []string{"-c", "0FOO=bar nohup ls"}, "", nil, false},
+		// All-assignment script: shell sets vars and exits, no command
+		// to derive. Falls back to outer shell rule.
+		{"only assignments (fallback)", "sh", []string{"-c", "FOO=1 BAR=2"}, "", nil, false},
+		// --- three args ---
+		{"three args", "sh", []string{"-c", "ls", "extra"}, "ls", []string{}, true},
+		{"four args (argv0 + positional)", "sh", []string{"-c", "shutdown now", "argv0_name", "param1"}, "shutdown", []string{"now"}, true},
+		{"many positional params", "bash", []string{"-c", "rm foo", "bash", "a", "b", "c"}, "rm", []string{"foo"}, true},
+		{"-ec with argv0", "sh", []string{"-ec", "whoami", "myscript"}, "whoami", []string{}, true},
+
+		// --- empty or whitespace scripts ---
+		{"empty script", "sh", []string{"-c", ""}, "", nil, false},
+		{"whitespace-only script", "sh", []string{"-c", "   \t  "}, "", nil, false},
+
+		// --- rejected chars (shell metachars) ---
+		{"pipe", "sh", []string{"-c", "ls | wc"}, "", nil, false},
+		{"redirect >", "sh", []string{"-c", "echo hi > out"}, "", nil, false},
+		{"redirect <", "sh", []string{"-c", "cat < in"}, "", nil, false},
+		{"semicolon", "sh", []string{"-c", "ls; pwd"}, "", nil, false},
+		{"ampersand", "sh", []string{"-c", "ls &"}, "", nil, false},
+		{"backtick", "sh", []string{"-c", "echo `date`"}, "", nil, false},
+		{"dollar expansion", "sh", []string{"-c", "echo $PWD"}, "", nil, false},
+		{"parens (subshell)", "sh", []string{"-c", "(ls)"}, "", nil, false},
+		{"double quotes", "sh", []string{"-c", "echo \"hi\""}, "", nil, false},
+		{"single quotes", "sh", []string{"-c", "echo 'hi'"}, "", nil, false},
+		{"backslash", "sh", []string{"-c", "echo \\n"}, "", nil, false},
+		{"asterisk (glob)", "sh", []string{"-c", "ls *.go"}, "", nil, false},
+		{"question glob", "sh", []string{"-c", "ls foo?"}, "", nil, false},
+		{"bracket glob", "sh", []string{"-c", "ls foo[0-9]"}, "", nil, false},
+		{"brace expansion", "sh", []string{"-c", "echo {a,b}"}, "", nil, false},
+		{"tilde expansion", "sh", []string{"-c", "ls ~/foo"}, "", nil, false},
+		{"hash (comment)", "sh", []string{"-c", "ls # comment"}, "", nil, false},
+		{"percent (job ctrl)", "sh", []string{"-c", "fg %1"}, "", nil, false},
+		{"newline", "sh", []string{"-c", "ls\npwd"}, "", nil, false},
+		{"non-ascii", "sh", []string{"-c", "éls"}, "", nil, false},
+
+		// --- builtins (first token blocked) ---
+		{"echo (dual builtin)", "sh", []string{"-c", "echo hi"}, "", nil, false},
+		{"printf (dual builtin)", "sh", []string{"-c", "printf hi"}, "", nil, false},
+		{"pwd", "sh", []string{"-c", "pwd"}, "", nil, false},
+		{"test", "sh", []string{"-c", "test -f foo"}, "", nil, false},
+		{"[ builtin", "sh", []string{"-c", "[ -f foo ]"}, "", nil, false},
+		{"true builtin", "sh", []string{"-c", "true"}, "", nil, false},
+		{"false builtin", "sh", []string{"-c", "false"}, "", nil, false},
+		{"cd", "sh", []string{"-c", "cd /tmp"}, "", nil, false},
+		{"kill (builtin on bash)", "sh", []string{"-c", "kill 1"}, "", nil, false},
+		{"ulimit (bash builtin)", "sh", []string{"-c", "ulimit -n 1024"}, "", nil, false},
+		{"enable (bash builtin, used to re-enable kill)", "sh", []string{"-c", "enable kill"}, "", nil, false},
+		{"hash", "sh", []string{"-c", "hash -r"}, "", nil, false},
+		{"type", "sh", []string{"-c", "type ls"}, "", nil, false},
+		{"let", "sh", []string{"-c", "let x=1"}, "", nil, false},
+
+		// --- reserved words (first token blocked) ---
+		{"if", "sh", []string{"-c", "if true"}, "", nil, false},
+		{"while", "sh", []string{"-c", "while true"}, "", nil, false},
+		{"for", "sh", []string{"-c", "for x in a"}, "", nil, false},
+		{"function", "sh", []string{"-c", "function foo"}, "", nil, false},
+		{"double-bracket", "sh", []string{"-c", "[[ -f foo ]]"}, "", nil, false},
+
+		// --- builtin after stripping wrapper is also blocked ---
+		{"exec echo (blocked via builtin)", "sh", []string{"-c", "exec echo hi"}, "", nil, false},
+		{"command cd (blocked via builtin)", "sh", []string{"-c", "command cd /tmp"}, "", nil, false},
+
+		// --- absolute path binaries ---
+		{"absolute path binary", "sh", []string{"-c", "/usr/sbin/shutdown now"}, "/usr/sbin/shutdown", []string{"now"}, true},
+		{"relative dot-slash", "sh", []string{"-c", "./script"}, "./script", []string{}, true},
+		{"relative dotdot", "sh", []string{"-c", "../tool arg"}, "../tool", []string{"arg"}, true},
+
+		// --- bare transparent wrapper ---
+		{"exec alone", "sh", []string{"-c", "exec"}, "", nil, false},
+		{"command alone", "sh", []string{"-c", "command"}, "", nil, false},
+		// nohup/nice as bare tokens are valid external binaries in their own
+		// right (they just wouldn't have anything to wrap); the policy layer
+		// is free to have a rule named `nohup` or `nice`, so we return them
+		// as-is rather than treating the missing operand as a parse error.
+		{"nohup alone, bare binary", "sh", []string{"-c", "nohup"}, "nohup", []string{}, true},
+		{"nice alone, bare binary", "sh", []string{"-c", "nice"}, "nice", []string{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCmd, gotArgs, gotOK := DerivePolicyTarget(tt.command, tt.args)
+			if gotOK != tt.wantOK {
+				t.Fatalf("ok: got %v, want %v (cmd=%q args=%v)", gotOK, tt.wantOK, gotCmd, gotArgs)
+			}
+			if !gotOK {
+				if gotCmd != "" || gotArgs != nil {
+					t.Errorf("expected zero returns on !ok, got cmd=%q args=%v", gotCmd, gotArgs)
+				}
+				return
+			}
+			if gotCmd != tt.wantCmd {
+				t.Errorf("cmd: got %q, want %q", gotCmd, tt.wantCmd)
+			}
+			if !slicesEqual(gotArgs, tt.wantArg) {
+				t.Errorf("args: got %v, want %v", gotArgs, tt.wantArg)
+			}
+		})
+	}
+}
+
+// TestIsShellCBypassAttempt verifies the escape hatch for wrapper forms
+// that DerivePolicyTarget won't rewrite but that we DO recognize as deny
+// bypasses. The caller (policy engine) uses this to fail closed instead of
+// falling through to the outer shell's allow rule.
+func TestIsShellCBypassAttempt(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		args    []string
+		want    bool
+	}{
+		// Bypass — flag forms we refuse to parse.
+		{"exec -a NAME CMD", "sh", []string{"-c", "exec -a foo shutdown"}, true},
+		{"command -v CMD", "sh", []string{"-c", "command -v shutdown"}, true},
+		{"command -p CMD", "sh", []string{"-c", "command -p shutdown"}, true},
+		{"nohup --help CMD", "sh", []string{"-c", "nohup --help shutdown"}, true},
+		{"nohup -x CMD", "sh", []string{"-c", "nohup -x shutdown"}, true},
+		{"nice -n bogus CMD (non-numeric)", "sh", []string{"-c", "nice -n bogus shutdown"}, true},
+		{"nice -19 CMD (unsupported form)", "sh", []string{"-c", "nice -19 shutdown"}, true},
+		// Byte allowlist evasion via wrapper long-option `=`.
+		{"nice --adjustment=19 CMD", "sh", []string{"-c", "nice --adjustment=19 shutdown"}, true},
+		{"nohup --preserve-status=1 CMD", "sh", []string{"-c", "nohup --preserve-status=1 shutdown"}, true},
+		// time / env wrapper bypass (R15).
+		{"time -p CMD", "sh", []string{"-c", "time -p shutdown"}, true},
+		{"time --help CMD", "sh", []string{"-c", "time --help shutdown"}, true},
+		{"env -i CMD", "sh", []string{"-c", "env -i shutdown"}, true},
+		{"env -u VAR CMD", "sh", []string{"-c", "env -u PATH shutdown"}, true},
+		{"env VAR=val CMD (byte-allowlist evasion)", "sh", []string{"-c", "env VAR=val shutdown"}, true},
+		{"env --chdir=/tmp CMD (byte-allowlist evasion)", "sh", []string{"-c", "env --chdir=/tmp shutdown"}, true},
+
+		// Bypass — unsafe shell options hiding -c.
+		{"bash -lc shutdown", "bash", []string{"-lc", "shutdown"}, true},
+		{"bash -l -c shutdown", "bash", []string{"-l", "-c", "shutdown"}, true},
+		{"bash -o errexit -c shutdown", "bash", []string{"-o", "errexit", "-c", "shutdown"}, true},
+		{"bash --rcfile=X -c shutdown", "bash", []string{"--rcfile=/tmp/rc", "-c", "shutdown"}, true},
+		{"bash --norc -c shutdown", "bash", []string{"--norc", "-c", "shutdown"}, true},
+		{"bash -ic shutdown (interactive+c)", "bash", []string{"-ic", "shutdown"}, true},
+		{"sh -pc shutdown (privileged+c)", "sh", []string{"-pc", "shutdown"}, true},
+
+		// Bypass — env-assignment prefix followed by a wrapper in an
+		// UNPARSABLE flag form (inner bypass survives the parse-through).
+		{"assign + exec -a", "sh", []string{"-c", "VAR=x exec -a foo shutdown"}, true},
+		{"assign + command -v", "sh", []string{"-c", "FOO=1 command -v shutdown"}, true},
+		{"assign + nohup --preserve-status", "sh", []string{"-c", "PATH=/tmp nohup --preserve-status=1 shutdown"}, true},
+
+		// Bypass — env-assignment with a VALUE byte outside the narrow
+		// allowlist. The shell would accept these, but our pure-string
+		// check cannot safely reason about them, so fail closed.
+		{"assign with colon in VALUE", "sh", []string{"-c", "PATH=/tmp:/bin shutdown"}, true},
+		{"assign with glob in VALUE", "sh", []string{"-c", "PATH=*/bad nohup shutdown"}, true},
+		{"assign with dollar in VALUE", "sh", []string{"-c", "FOO=$VAR shutdown"}, true},
+		{"assign with equals in VALUE", "sh", []string{"-c", "FOO=a=b shutdown"}, true},
+
+		// Not a bypass — assignment parse-through to a parseable inner.
+		// DerivePolicyTarget succeeds (returns the inner binary) under
+		// these, so the caller uses the derived target directly.
+		{"assign + nohup (parses through)", "sh", []string{"-c", "PATH=/tmp nohup shutdown"}, false},
+		{"assign + exec (parses through)", "sh", []string{"-c", "VAR=x exec shutdown"}, false},
+		{"assign + nice (parses through)", "sh", []string{"-c", "FOO=1 nice shutdown"}, false},
+		{"two assigns + nice -n N (parses through)", "sh", []string{"-c", "FOO=1 BAR=2 nice -n 19 shutdown"}, false},
+		{"empty-value assign + nohup (parses through)", "sh", []string{"-c", "FOO= nohup shutdown"}, false},
+		{"assign + plain binary (parses through)", "sh", []string{"-c", "PATH=/tmp shutdown"}, false},
+		{"assign + plain binary with arg (parses through)", "sh", []string{"-c", "FOO=bar shutdown now"}, false},
+
+		// Not a bypass — DerivePolicyTarget would succeed.
+		{"nohup CMD", "sh", []string{"-c", "nohup shutdown"}, false},
+		{"nice CMD", "sh", []string{"-c", "nice shutdown"}, false},
+		{"nice -n 19 CMD", "sh", []string{"-c", "nice -n 19 shutdown"}, false},
+		{"exec CMD", "sh", []string{"-c", "exec shutdown"}, false},
+		{"time CMD", "sh", []string{"-c", "time shutdown"}, false},
+		{"env CMD", "sh", []string{"-c", "env shutdown"}, false},
+		{"time nohup CMD chained", "sh", []string{"-c", "time nohup shutdown"}, false},
+		{"env nohup CMD chained", "sh", []string{"-c", "env nohup shutdown"}, false},
+
+		// Not a bypass — plain shell-c that doesn't involve a wrapper.
+		{"plain command", "sh", []string{"-c", "shutdown"}, false},
+		{"builtin (fallback, not bypass)", "sh", []string{"-c", "echo hi"}, false},
+		{"metachar (fallback)", "sh", []string{"-c", "ls | wc"}, false},
+
+		// Not a bypass — assignment without wrapper (separate issue, out of scope).
+		{"assign + plain binary (out of scope, fallback)", "sh", []string{"-c", "PATH=/tmp shutdown"}, false},
+		{"digit-leading token (not a valid assign)", "sh", []string{"-c", "0FOO=bar nohup shutdown"}, false},
+
+		// Not a bypass — unsafe option without -c.
+		{"bash -l script.sh (no -c)", "bash", []string{"-l", "script.sh"}, false},
+		{"bash --norc script.sh (no -c)", "bash", []string{"--norc", "script.sh"}, false},
+		{"bash -- -c script (after --)", "bash", []string{"--", "-c", "script"}, false},
+
+		// Not a known shell — never a bypass.
+		{"python -c", "python3", []string{"-c", "exec -a foo shutdown"}, false},
+		// zsh IS a known shell — the nice bypass form fails closed.
+		{"zsh with nice -n bogus (bypass)", "zsh", []string{"-c", "nice -n bogus shutdown"}, true},
+
+		// Malformed — no -c flag at all.
+		{"no -c", "sh", []string{"shutdown"}, false},
+		{"empty args", "sh", nil, false},
+		{"empty command", "", []string{"-c", "exec -a foo shutdown"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsShellCBypassAttempt(tt.command, tt.args); got != tt.want {
+				t.Errorf("IsShellCBypassAttempt(%q, %v) = %v, want %v", tt.command, tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsOpaqueShellC(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		args    []string
+		want    bool
+	}{
+		// --- opaque cases: metachars, pipes, subshells, globs, quotes, expansions ---
+		{"pipe", "sh", []string{"-c", "ls | wc"}, true},
+		{"semicolon", "sh", []string{"-c", "foo; bar"}, true},
+		{"and", "bash", []string{"-c", "foo && bar"}, true},
+		{"or", "bash", []string{"-c", "foo || bar"}, true},
+		{"redirect out", "sh", []string{"-c", "foo > out"}, true},
+		{"redirect in", "sh", []string{"-c", "foo < in"}, true},
+		{"subshell", "sh", []string{"-c", "(foo)"}, true},
+		{"glob", "sh", []string{"-c", "ls *.go"}, true},
+		{"double quote", "sh", []string{"-c", "echo \"hi\""}, true},
+		{"single quote", "sh", []string{"-c", "echo 'hi'"}, true},
+		{"dollar var", "sh", []string{"-c", "echo $X"}, true},
+		{"backtick substitution", "sh", []string{"-c", "echo `date`"}, true},
+		{"absolute shell path opaque", "/usr/bin/bash", []string{"-c", "foo | bar"}, true},
+		{"zsh opaque", "zsh", []string{"-c", "foo; bar"}, true},
+
+		// --- NOT opaque: bypass cases return statusBypass, not opaque ---
+		{"exec -a bypass (not opaque)", "sh", []string{"-c", "exec -a foo shutdown"}, false},
+		{"nohup --help bypass (not opaque)", "sh", []string{"-c", "nohup --help shutdown"}, false},
+		{"bash -lc bypass (not opaque)", "bash", []string{"-lc", "shutdown"}, false},
+
+		// --- NOT opaque: normal derivable scripts ---
+		{"plain command", "sh", []string{"-c", "ls"}, false},
+		{"command with safe args", "sh", []string{"-c", "shutdown now"}, false},
+		{"wrapper + cmd", "bash", []string{"-c", "nohup shutdown"}, false},
+		{"env assignment", "sh", []string{"-c", "PATH=/tmp shutdown"}, false},
+
+		// --- NOT opaque: not a shell ---
+		{"python -c pipe (not a shell)", "python3", []string{"-c", "ls | wc"}, false},
+		{"python -c metachar", "python", []string{"-c", "a; b"}, false},
+
+		// --- NOT opaque: no -c ---
+		{"sh bare", "sh", []string{}, false},
+		{"sh login", "sh", []string{"-l"}, false},
+
+		// --- NOT opaque: empty command ---
+		{"empty", "", []string{"-c", "foo | bar"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsOpaqueShellC(tt.command, tt.args); got != tt.want {
+				t.Errorf("IsOpaqueShellC(%q, %v) = %v, want %v", tt.command, tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsKnownShell(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"sh", true},
+		{"bash", true},
+		{"dash", true},
+		{"ash", true},
+		{"mksh", true},
+		{"ksh", true},
+		{"zsh", true},
+		{"fish", false},
+		{"busybox", false},
+		{"python", false},
+		{"", false},
+		{"sh.exe", false}, // Windows shells not in scope
+		{"-sh", false},    // login-shell argv0 convention
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := isKnownShell(tt.in); got != tt.want {
+				t.Errorf("isKnownShell(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -180,7 +180,7 @@ exec_rc=0
 max_exec_attempts=3
 for attempt in $(seq 1 $max_exec_attempts); do
   {
-    exec_out="$(./bin/agentsh exec "$sid" -- sh -lc 'echo hi' 2>&1 | tr -d '\r')"
+    exec_out="$(./bin/agentsh exec "$sid" -- sh -c 'echo hi' 2>&1 | tr -d '\r')"
     exec_rc=$?
   } || exec_rc=$?
 
@@ -218,7 +218,7 @@ if ! pty_ok; then
 else
   pty_out="$(
     set +e
-    ./bin/agentsh exec --pty "$sid" -- sh -lc 'printf pty_hi' 2>&1 | tr -d '\r'
+    ./bin/agentsh exec --pty "$sid" -- sh -c 'printf pty_hi' 2>&1 | tr -d '\r'
     exit ${PIPESTATUS[0]}
   )" || {
     echo "smoke: NOTE (agentsh PTY failed; skipping PTY checks): $pty_out" >&2
@@ -242,7 +242,7 @@ ln -sf "$(command -v sh)" "$shim_dir/sh.real"
 # Shim test with retry for transient failures.
 shim_out=""
 for attempt in $(seq 1 $max_exec_attempts); do
-  shim_out="$(AGENTSH_BIN="$repo_root/bin/agentsh" AGENTSH_SESSION_ID="$sid" AGENTSH_SERVER="$base_url" "$shim_dir/sh" -lc 'echo shim_hi' | tr -d '\r' | tail -n 1)" || true
+  shim_out="$(AGENTSH_BIN="$repo_root/bin/agentsh" AGENTSH_SESSION_ID="$sid" AGENTSH_SERVER="$base_url" "$shim_dir/sh" -c 'echo shim_hi' | tr -d '\r' | tail -n 1)" || true
   if [[ "$shim_out" == "shim_hi" ]]; then
     break
   fi
@@ -283,7 +283,7 @@ fi
 # Rootfs shim test with retry.
 rootfs_out=""
 for attempt in $(seq 1 $max_exec_attempts); do
-  rootfs_out="$(AGENTSH_BIN="$repo_root/bin/agentsh" AGENTSH_SESSION_ID="$sid" AGENTSH_SERVER="$base_url" "$rootfs/bin/sh" -lc 'echo rootfs_hi' | tr -d '\r' | tail -n 1)" || true
+  rootfs_out="$(AGENTSH_BIN="$repo_root/bin/agentsh" AGENTSH_SESSION_ID="$sid" AGENTSH_SERVER="$base_url" "$rootfs/bin/sh" -c 'echo rootfs_hi' | tr -d '\r' | tail -n 1)" || true
   if [[ "$rootfs_out" == "rootfs_hi" ]]; then
     break
   fi
@@ -307,7 +307,7 @@ fi
 # Shim delegation via PATH (no AGENTSH_BIN) with retry.
 shim_out_path=""
 for attempt in $(seq 1 $max_exec_attempts); do
-  shim_out_path="$(PATH="$repo_root/bin:$PATH" AGENTSH_SESSION_ID="$sid" AGENTSH_SERVER="$base_url" "$shim_dir/sh" -lc 'echo shim_path_hi' | tr -d '\r' | tail -n 1)" || true
+  shim_out_path="$(PATH="$repo_root/bin:$PATH" AGENTSH_SESSION_ID="$sid" AGENTSH_SERVER="$base_url" "$shim_dir/sh" -c 'echo shim_path_hi' | tr -d '\r' | tail -n 1)" || true
   if [[ "$shim_out_path" == "shim_path_hi" ]]; then
     break
   fi
@@ -322,7 +322,7 @@ if [[ "$shim_out_path" != "shim_path_hi" ]]; then
 fi
 
 # Shim recursion guard: should not need agentsh when already in-session.
-rec_out="$(AGENTSH_BIN="/nonexistent/agentsh" AGENTSH_IN_SESSION=1 "$shim_dir/sh" -lc 'echo recursion_hi' | tr -d '\r' | tail -n 1)"
+rec_out="$(AGENTSH_BIN="/nonexistent/agentsh" AGENTSH_IN_SESSION=1 "$shim_dir/sh" -c 'echo recursion_hi' | tr -d '\r' | tail -n 1)"
 if [[ "$rec_out" != "recursion_hi" ]]; then
   echo "smoke: shim recursion output mismatch: got=$rec_out" >&2
   exit 1
@@ -346,7 +346,7 @@ env["AGENTSH_SERVER"] = os.environ["SMOKE_SERVER"]
 
 m, s = pty.openpty()
 try:
-    p = subprocess.Popen([shim, "-lc", "printf pty_shim_hi"], stdin=s, stdout=s, stderr=s, env=env)
+    p = subprocess.Popen([shim, "-c", "printf pty_shim_hi"], stdin=s, stdout=s, stderr=s, env=env)
     os.close(s)
     buf = bytearray()
     deadline = time.time() + 5.0
@@ -388,14 +388,14 @@ if command -v bash >/dev/null 2>&1; then
   chmod +x "$shim_dir/bash"
   ln -sf "$(command -v bash)" "$shim_dir/bash.real"
 
-  bash_out="$(AGENTSH_BIN="$repo_root/bin/agentsh" AGENTSH_SESSION_ID="$sid" AGENTSH_SERVER="$base_url" "$shim_dir/bash" -lc 'echo bash_hi' | tr -d '\r' | tail -n 1)"
+  bash_out="$(AGENTSH_BIN="$repo_root/bin/agentsh" AGENTSH_SESSION_ID="$sid" AGENTSH_SERVER="$base_url" "$shim_dir/bash" -c 'echo bash_hi' | tr -d '\r' | tail -n 1)"
   if [[ "$bash_out" != "bash_hi" ]]; then
     echo "smoke: bash shim output mismatch: got=$bash_out" >&2
     exit 1
   fi
 
   # Login-style argv0 ("-bash") should still select bash semantics.
-  login_out="$(AGENTSH_BIN="$repo_root/bin/agentsh" AGENTSH_SESSION_ID="$sid" AGENTSH_SERVER="$base_url" SMOKE_BASH_SHIM="$shim_dir/bash" bash -lc 'exec -a -bash "$SMOKE_BASH_SHIM" -lc "echo login_hi"' | tr -d '\r' | tail -n 1)"
+  login_out="$(AGENTSH_BIN="$repo_root/bin/agentsh" AGENTSH_SESSION_ID="$sid" AGENTSH_SERVER="$base_url" SMOKE_BASH_SHIM="$shim_dir/bash" bash -lc 'exec -a -bash "$SMOKE_BASH_SHIM" -c "echo login_hi"' | tr -d '\r' | tail -n 1)"
   if [[ "$login_out" != "login_hi" ]]; then
     echo "smoke: bash login shim output mismatch: got=$login_out" >&2
     exit 1


### PR DESCRIPTION
## Summary

- Closes a deny bypass where `<shell> -c "<cmd>"` silently evaded rules targeting the inner binary. A policy with `allow bin=sh` + `deny bin=shutdown` used to admit `sh -c "shutdown now"`; this fixes that, with 16 rounds of security review driving the hardening.
- Adds `internal/shellparse` — a conservative, byte-allowlisted parser for the narrow subset of shell-c forms we can reason about without spawning a shell. Everything outside that subset (pipes, subshells, redirects, globs, quotes, expansions, unsafe shell options, unknown wrapper flags) fails closed.
- Integrates into `Engine.CheckCommand`: recursive derivation (max depth 4), strictness comparison so the strictest of {outer, derived} wins, escalation for all decisions (deny/approve/redirect/audit), transparent-wrapper stripping (`exec`, `command`, `nohup`, `nice`, `time`, `env`), env-assignment parse-through, opaque-script fail-closed, and depth-cap fail-closed.
- EnvPolicy handling: outer shell's EnvPolicy is preserved for audit/approve (the shell is what executes); inner command's EnvPolicy applies for redirect.

## Design notes

- **Shim stays minimal.** All parsing is server-side, so no client-side argv rewriting or normalization is needed.
- **Fail closed by default.** Anything not explicitly recognized as safe either derives to an explicit policy target or denies with a named rule (`shellc-wrapper-bypass`, `shellc-opaque-script`, `shellc-depth-exceeded`).
- **Allow-only policies unaffected.** The opaque-script promotion only fires when the policy contains a restrictive rule (deny/approve/redirect/audit/soft_delete). Operators who've decided broad `allow sh` is acceptable don't get every pipeline suddenly denied.
- **Strictness lattice:** deny(4) > redirect/soft_delete(3) > approve(2) > audit(1) > allow(0). The strictest decision across the outer + derived chain wins.

## Test plan

- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [x] `GOOS=windows go build ./...` — clean
- [x] `GOOS=darwin go build ./...` — clean
- [x] 16 rounds of `roborev review --type security` — final round returns no findings at any severity
- [ ] CI: 6 docker-test distros pass
- [ ] Manual: `AGENTSH_SHIM_FORCE=1 /bin/sh -c 'shutdown now'` returns "blocked by policy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)