### PR TITLE
fix(shellparse): recognize .real shim suffix as known shell

### DIFF
--- a/internal/policy/command_shellc_test.go
+++ b/internal/policy/command_shellc_test.go
@@ -726,3 +726,63 @@ func TestEngine_CheckCommand_ShellCDerive_DepthCapLoopCompletes(t *testing.T) {
 		t.Errorf("expected allow-shells, got %q", dec.Rule)
 	}
 }
+
+// TestEngine_CheckCommand_ShellCDerive_ShimRealSuffix verifies that the shim
+// install layout — where `/bin/sh` is the shim binary and `/bin/sh.real` is
+// the renamed original shell — is treated as a known shell for derive
+// purposes. Without this, `allow sh.real` (present in default.yaml for shim
+// integration) + `deny shutdown` would fall through to allow, silently
+// re-opening the exact bypass CheckCommand is meant to close when the shim
+// forwards via `agentsh exec -- /bin/sh.real -c "shutdown now"`.
+//
+// This test is the end-to-end assertion that caught the v0.19.0-rc1/rc2
+// release-CI regression: smoke.sh ran `AGENTSH_SHIM_FORCE=1 /bin/sh -c
+// 'shutdown now'`, the shim forwarded to `/bin/sh.real`, and the engine
+// returned DecisionAllow (rule=allow-shim-shells) instead of DecisionDeny.
+func TestEngine_CheckCommand_ShellCDerive_ShimRealSuffix(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []CommandRule{
+			{Name: "deny-shutdown", Commands: []string{"shutdown"}, Decision: "deny"},
+			{Name: "allow-shim-shells", Commands: []string{"sh", "bash", "sh.real", "bash.real"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		command  string
+		args     []string
+		decision types.Decision
+		rule     string
+	}{
+		// --- primary regression cases ---
+		{"/bin/sh.real -c 'shutdown now' → derived deny (shim flow)", "/bin/sh.real", []string{"-c", "shutdown now"}, types.DecisionDeny, "deny-shutdown"},
+		{"/bin/bash.real -c 'shutdown' → derived deny (shim flow)", "/bin/bash.real", []string{"-c", "shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"/usr/bin/sh.real -c 'shutdown' → derived deny (alt install path)", "/usr/bin/sh.real", []string{"-c", "shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		// --- ensure wrapper/opaque handling still applies through .real ---
+		{"/bin/sh.real -c 'nohup shutdown' → wrapper stripped, derived deny", "/bin/sh.real", []string{"-c", "nohup shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		{"/bin/sh.real -c 'shutdown; true' → opaque is deny-on-restrictive-policy", "/bin/sh.real", []string{"-c", "shutdown; true"}, types.DecisionDeny, "shellc-opaque-script"},
+		{"/bin/sh.real -l -c 'shutdown' → login option bypass-deny", "/bin/sh.real", []string{"-l", "-c", "shutdown"}, types.DecisionDeny, "shellc-wrapper-bypass"},
+		// --- allow path when inner has no explicit rule ---
+		{"/bin/sh.real -c 'ls' → no ls rule, fall back to shim-shells allow", "/bin/sh.real", []string{"-c", "ls"}, types.DecisionAllow, "allow-shim-shells"},
+		// --- bare invocation of .real still allowed ---
+		{"bare /bin/sh.real → allow", "/bin/sh.real", nil, types.DecisionAllow, "allow-shim-shells"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dec := e.CheckCommand(tc.command, tc.args)
+			if dec.PolicyDecision != tc.decision {
+				t.Errorf("decision: got %s, want %s (rule=%q)", dec.PolicyDecision, tc.decision, dec.Rule)
+			}
+			if dec.Rule != tc.rule {
+				t.Errorf("rule: got %q, want %q", dec.Rule, tc.rule)
+			}
+		})
+	}
+}

--- a/internal/shellparse/shellparse.go
+++ b/internal/shellparse/shellparse.go
@@ -111,11 +111,25 @@ func IsOpaqueShellC(command string, args []string) bool {
 // that behavior here closes the mismatch that would otherwise let a
 // Windows-separator path slip past shell detection while still matching
 // shell-targeted allow rules.
+//
+// A trailing ".real" suffix is stripped so shell detection also covers
+// the agentsh shell shim's install layout. `agentsh shim install-shell`
+// renames the original shell to `<name>.real` and places the shim at
+// the original path (`/bin/sh` → shim, `/bin/sh.real` → real shell).
+// When the shim forwards to `agentsh exec`, the server sees the real
+// shell's `.real` path as the outer command. Without this normalization,
+// `sh.real`/`bash.real` would miss isKnownShell, shell-c derivation
+// would be skipped, and the policy would fall through to the outer
+// allow-rule that must exist for the shim's real-shell invocations to
+// run — silently admitting inner commands the policy would otherwise
+// deny.
 func basenameLower(s string) string {
 	if i := strings.LastIndexAny(s, `/\`); i >= 0 {
 		s = s[i+1:]
 	}
-	return strings.ToLower(s)
+	s = strings.ToLower(s)
+	s = strings.TrimSuffix(s, ".real")
+	return s
 }
 
 // isKnownShell reports whether base names a POSIX-compatible shell whose

--- a/internal/shellparse/shellparse_test.go
+++ b/internal/shellparse/shellparse_test.go
@@ -23,6 +23,18 @@ func TestDerivePolicyTarget(t *testing.T) {
 		{"backslash-separator windows-style sh path", `C:\bin\sh`, []string{"-c", "shutdown"}, "shutdown", []string{}, true},
 		{"mixed-separator bash path", `/usr/local\bash`, []string{"-c", "ls"}, "ls", []string{}, true},
 		{"uppercase shell basename (case-insensitive FS)", "/BIN/SH", []string{"-c", "ls"}, "ls", []string{}, true},
+		// --- shell-shim install layout: the agentsh shell shim installs
+		// the original shell under a `.real` suffix (/bin/sh.real) and
+		// takes over the original name. When the shim forwards to
+		// `agentsh exec`, the server sees the `.real` path as the outer
+		// command. Without normalization, `sh.real` / `bash.real` miss
+		// the known-shell set and the policy falls through to the
+		// outer allow-rule (which must exist for the shim to function).
+		{"shim .real sh suffix", "/bin/sh.real", []string{"-c", "shutdown now"}, "shutdown", []string{"now"}, true},
+		{"shim .real bash suffix", "/bin/bash.real", []string{"-c", "shutdown now"}, "shutdown", []string{"now"}, true},
+		{"shim .real usr/bin path", "/usr/bin/sh.real", []string{"-c", "rm foo"}, "rm", []string{"foo"}, true},
+		{"shim .real uppercase (case-insensitive FS)", "/BIN/SH.REAL", []string{"-c", "ls"}, "ls", []string{}, true},
+		{"shim .real bare name", "sh.real", []string{"-c", "shutdown"}, "shutdown", []string{}, true},
 		{"bash, simple cmd", "bash", []string{"-c", "rm foo"}, "rm", []string{"foo"}, true},
 		{"dash", "/bin/dash", []string{"-c", "whoami"}, "whoami", []string{}, true},
 		{"ash (busybox shell on alpine)", "/bin/ash", []string{"-c", "id"}, "id", []string{}, true},


### PR DESCRIPTION
## Summary

- Strip `.real` suffix in `basenameLower` so `sh.real`/`bash.real` (the shim install layout, where `/bin/sh` is the shim binary and `/bin/sh.real` is the renamed original) are recognized as known shells for derive purposes.
- Add 5 shellparse-level unit tests + 8 engine-level integration tests covering the full shim flow.

## Why

On v0.19.0-rc1 and v0.19.0-rc2 release CI, the smoke test `AGENTSH_SHIM_FORCE=1 /bin/sh -c 'shutdown now'` failed across every docker-test distro:

```
FAIL: blocked command through shim fails — rc=127, no 'blocked by policy'
on stderr; got: /bin/sh: 1: shutdown: not found
```

Root cause: when the shim forwards through `agentsh exec`, the server sees the outer command as `/bin/sh.real`. `basenameLower("/bin/sh.real")` returned `"sh.real"`, `isKnownShell` rejected it, `DerivePolicyTarget` returned `!ok`, and the default policy's `allow sh.real` / `allow bash.real` rules (required for shim integration) admitted the whole command — silently re-opening the exact bypass that #228 was meant to close.

Fix is one line: strip the lowercase `.real` suffix in `basenameLower`. Safe — `.real` is not a shell name on any platform — and aligns the shim install convention with the rest of the derive pipeline (wrappers, byte allowlist, opaque-script detection, depth cap).

## Test Plan

- [x] `go test ./internal/shellparse/` — 5 new cases pass (pre-fix: all fail)
- [x] `go test ./internal/policy/` — 8 new engine cases pass (plain derive, wrapper-strip, opaque-deny, login-option bypass, inner-has-no-rule allow, bare invocation)
- [x] `go test ./...` — full suite green
- [x] `GOOS=windows go build ./...` — cross-compile clean
- [x] roborev security review — no issues found
- [ ] Docker-test CI green across all distros (the actual regression test from rc1/rc2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)