### PR TITLE
test: accept PTY deny phrasing in Dockerfile.test shim assertion

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -522,15 +522,16 @@ fi
 # `shutdown` can exit non-zero for unrelated reasons (binary not
 # installed, non-root in a restricted container), so a vacuous pass
 # would not prove the policy layer actually denied anything.
-# internal/cli/exec.go emits `agentsh: blocked by policy (rule=...)`
-# via fmt.Sprintf when the server refuses the command; assert on
-# that exact substring.
+# The shim routes through the PTY code path (internal/cli/exec_pty.go),
+# which emits `agentsh: command denied by policy (rule=...)`. The
+# non-PTY path in internal/cli/exec.go emits `blocked by policy`
+# instead. Accept either phrasing so the test is robust to both paths.
 set +e
 shim_block_stderr="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'shutdown now' 2>&1 >/dev/null)"
 shim_block_rc=$?
 set -e
 case "$shim_block_stderr" in
-  *"blocked by policy"*)
+  *"denied by policy"*|*"blocked by policy"*)
     # Denial substring alone is insufficient — a regression where the
     # shim prints the policy message but then exits 0 would still pass
     # a substring-only check even though the command effectively
@@ -538,11 +539,11 @@ case "$shim_block_stderr" in
     if [ "$shim_block_rc" -ne 0 ]; then
       pass "blocked command through shim fails (rc=$shim_block_rc; policy denial observed)"
     else
-      fail "blocked command through shim fails" "rc=0 with 'blocked by policy' on stderr — denial printed but command returned success. stderr: ${shim_block_stderr}"
+      fail "blocked command through shim fails" "rc=0 with policy denial on stderr — denial printed but command returned success. stderr: ${shim_block_stderr}"
     fi
     ;;
   *)
-    fail "blocked command through shim fails" "rc=$shim_block_rc, no 'blocked by policy' on stderr; got: ${shim_block_stderr}"
+    fail "blocked command through shim fails" "rc=$shim_block_rc, no policy denial on stderr; got: ${shim_block_stderr}"
     ;;
 esac
 

--- a/Dockerfile.test.alpine
+++ b/Dockerfile.test.alpine
@@ -513,15 +513,16 @@ fi
 # `shutdown` can exit non-zero for unrelated reasons (binary not
 # installed, non-root in a restricted container), so a vacuous pass
 # would not prove the policy layer actually denied anything.
-# internal/cli/exec.go emits `agentsh: blocked by policy (rule=...)`
-# via fmt.Sprintf when the server refuses the command; assert on
-# that exact substring.
+# The shim routes through the PTY code path (internal/cli/exec_pty.go),
+# which emits `agentsh: command denied by policy (rule=...)`. The
+# non-PTY path in internal/cli/exec.go emits `blocked by policy`
+# instead. Accept either phrasing so the test is robust to both paths.
 set +e
 shim_block_stderr="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'shutdown now' 2>&1 >/dev/null)"
 shim_block_rc=$?
 set -e
 case "$shim_block_stderr" in
-  *"blocked by policy"*)
+  *"denied by policy"*|*"blocked by policy"*)
     # Denial substring alone is insufficient — a regression where the
     # shim prints the policy message but then exits 0 would still pass
     # a substring-only check even though the command effectively
@@ -529,11 +530,11 @@ case "$shim_block_stderr" in
     if [ "$shim_block_rc" -ne 0 ]; then
       pass "blocked command through shim fails (rc=$shim_block_rc; policy denial observed)"
     else
-      fail "blocked command through shim fails" "rc=0 with 'blocked by policy' on stderr — denial printed but command returned success. stderr: ${shim_block_stderr}"
+      fail "blocked command through shim fails" "rc=0 with policy denial on stderr — denial printed but command returned success. stderr: ${shim_block_stderr}"
     fi
     ;;
   *)
-    fail "blocked command through shim fails" "rc=$shim_block_rc, no 'blocked by policy' on stderr; got: ${shim_block_stderr}"
+    fail "blocked command through shim fails" "rc=$shim_block_rc, no policy denial on stderr; got: ${shim_block_stderr}"
     ;;
 esac
 

--- a/Dockerfile.test.arch
+++ b/Dockerfile.test.arch
@@ -519,15 +519,16 @@ fi
 # `shutdown` can exit non-zero for unrelated reasons (binary not
 # installed, non-root in a restricted container), so a vacuous pass
 # would not prove the policy layer actually denied anything.
-# internal/cli/exec.go emits `agentsh: blocked by policy (rule=...)`
-# via fmt.Sprintf when the server refuses the command; assert on
-# that exact substring.
+# The shim routes through the PTY code path (internal/cli/exec_pty.go),
+# which emits `agentsh: command denied by policy (rule=...)`. The
+# non-PTY path in internal/cli/exec.go emits `blocked by policy`
+# instead. Accept either phrasing so the test is robust to both paths.
 set +e
 shim_block_stderr="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'shutdown now' 2>&1 >/dev/null)"
 shim_block_rc=$?
 set -e
 case "$shim_block_stderr" in
-  *"blocked by policy"*)
+  *"denied by policy"*|*"blocked by policy"*)
     # Denial substring alone is insufficient — a regression where the
     # shim prints the policy message but then exits 0 would still pass
     # a substring-only check even though the command effectively
@@ -535,11 +536,11 @@ case "$shim_block_stderr" in
     if [ "$shim_block_rc" -ne 0 ]; then
       pass "blocked command through shim fails (rc=$shim_block_rc; policy denial observed)"
     else
-      fail "blocked command through shim fails" "rc=0 with 'blocked by policy' on stderr — denial printed but command returned success. stderr: ${shim_block_stderr}"
+      fail "blocked command through shim fails" "rc=0 with policy denial on stderr — denial printed but command returned success. stderr: ${shim_block_stderr}"
     fi
     ;;
   *)
-    fail "blocked command through shim fails" "rc=$shim_block_rc, no 'blocked by policy' on stderr; got: ${shim_block_stderr}"
+    fail "blocked command through shim fails" "rc=$shim_block_rc, no policy denial on stderr; got: ${shim_block_stderr}"
     ;;
 esac
 

--- a/Dockerfile.test.rpm
+++ b/Dockerfile.test.rpm
@@ -505,15 +505,16 @@ fi
 # `shutdown` can exit non-zero for unrelated reasons (binary not
 # installed, non-root in a restricted container), so a vacuous pass
 # would not prove the policy layer actually denied anything.
-# internal/cli/exec.go emits `agentsh: blocked by policy (rule=...)`
-# via fmt.Sprintf when the server refuses the command; assert on
-# that exact substring.
+# The shim routes through the PTY code path (internal/cli/exec_pty.go),
+# which emits `agentsh: command denied by policy (rule=...)`. The
+# non-PTY path in internal/cli/exec.go emits `blocked by policy`
+# instead. Accept either phrasing so the test is robust to both paths.
 set +e
 shim_block_stderr="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'shutdown now' 2>&1 >/dev/null)"
 shim_block_rc=$?
 set -e
 case "$shim_block_stderr" in
-  *"blocked by policy"*)
+  *"denied by policy"*|*"blocked by policy"*)
     # Denial substring alone is insufficient — a regression where the
     # shim prints the policy message but then exits 0 would still pass
     # a substring-only check even though the command effectively
@@ -521,11 +522,11 @@ case "$shim_block_stderr" in
     if [ "$shim_block_rc" -ne 0 ]; then
       pass "blocked command through shim fails (rc=$shim_block_rc; policy denial observed)"
     else
-      fail "blocked command through shim fails" "rc=0 with 'blocked by policy' on stderr — denial printed but command returned success. stderr: ${shim_block_stderr}"
+      fail "blocked command through shim fails" "rc=0 with policy denial on stderr — denial printed but command returned success. stderr: ${shim_block_stderr}"
     fi
     ;;
   *)
-    fail "blocked command through shim fails" "rc=$shim_block_rc, no 'blocked by policy' on stderr; got: ${shim_block_stderr}"
+    fail "blocked command through shim fails" "rc=$shim_block_rc, no policy denial on stderr; got: ${shim_block_stderr}"
     ;;
 esac
 

--- a/Dockerfile.test.ubuntu
+++ b/Dockerfile.test.ubuntu
@@ -574,15 +574,16 @@ fi
 # `shutdown` can exit non-zero for unrelated reasons (binary not
 # installed, non-root in a restricted container), so a vacuous pass
 # would not prove the policy layer actually denied anything.
-# internal/cli/exec.go emits `agentsh: blocked by policy (rule=...)`
-# via fmt.Sprintf when the server refuses the command; assert on
-# that exact substring.
+# The shim routes through the PTY code path (internal/cli/exec_pty.go),
+# which emits `agentsh: command denied by policy (rule=...)`. The
+# non-PTY path in internal/cli/exec.go emits `blocked by policy`
+# instead. Accept either phrasing so the test is robust to both paths.
 set +e
 shim_block_stderr="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'shutdown now' 2>&1 >/dev/null)"
 shim_block_rc=$?
 set -e
 case "$shim_block_stderr" in
-  *"blocked by policy"*)
+  *"denied by policy"*|*"blocked by policy"*)
     # Denial substring alone is insufficient — a regression where the
     # shim prints the policy message but then exits 0 would still pass
     # a substring-only check even though the command effectively
@@ -590,11 +591,11 @@ case "$shim_block_stderr" in
     if [ "$shim_block_rc" -ne 0 ]; then
       pass "blocked command through shim fails (rc=$shim_block_rc; policy denial observed)"
     else
-      fail "blocked command through shim fails" "rc=0 with 'blocked by policy' on stderr — denial printed but command returned success. stderr: ${shim_block_stderr}"
+      fail "blocked command through shim fails" "rc=0 with policy denial on stderr — denial printed but command returned success. stderr: ${shim_block_stderr}"
     fi
     ;;
   *)
-    fail "blocked command through shim fails" "rc=$shim_block_rc, no 'blocked by policy' on stderr; got: ${shim_block_stderr}"
+    fail "blocked command through shim fails" "rc=$shim_block_rc, no policy denial on stderr; got: ${shim_block_stderr}"
     ;;
 esac
 

--- a/Dockerfile.test.ubuntu2204
+++ b/Dockerfile.test.ubuntu2204
@@ -725,15 +725,16 @@ fi
 # `shutdown` can exit non-zero for unrelated reasons (binary not
 # installed, non-root in a restricted container), so a vacuous pass
 # would not prove the policy layer actually denied anything.
-# internal/cli/exec.go emits `agentsh: blocked by policy (rule=...)`
-# via fmt.Sprintf when the server refuses the command; assert on
-# that exact substring.
+# The shim routes through the PTY code path (internal/cli/exec_pty.go),
+# which emits `agentsh: command denied by policy (rule=...)`. The
+# non-PTY path in internal/cli/exec.go emits `blocked by policy`
+# instead. Accept either phrasing so the test is robust to both paths.
 set +e
 shim_block_stderr="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'shutdown now' 2>&1 >/dev/null)"
 shim_block_rc=$?
 set -e
 case "$shim_block_stderr" in
-  *"blocked by policy"*)
+  *"denied by policy"*|*"blocked by policy"*)
     # Denial substring alone is insufficient — a regression where the
     # shim prints the policy message but then exits 0 would still pass
     # a substring-only check even though the command effectively
@@ -741,11 +742,11 @@ case "$shim_block_stderr" in
     if [ "$shim_block_rc" -ne 0 ]; then
       pass "blocked command through shim fails (rc=$shim_block_rc; policy denial observed)"
     else
-      fail "blocked command through shim fails" "rc=0 with 'blocked by policy' on stderr — denial printed but command returned success. stderr: ${shim_block_stderr}"
+      fail "blocked command through shim fails" "rc=0 with policy denial on stderr — denial printed but command returned success. stderr: ${shim_block_stderr}"
     fi
     ;;
   *)
-    fail "blocked command through shim fails" "rc=$shim_block_rc, no 'blocked by policy' on stderr; got: ${shim_block_stderr}"
+    fail "blocked command through shim fails" "rc=$shim_block_rc, no policy denial on stderr; got: ${shim_block_stderr}"
     ;;
 esac
 


### PR DESCRIPTION
## Summary

- Widen the `shim + policy integration` case pattern in all six `Dockerfile.test*` variants to accept both `denied by policy` (PTY path, `internal/cli/exec_pty.go`) and `blocked by policy` (non-PTY path, `internal/cli/exec.go`).
- Keeps the `rc != 0` guard so a regression that prints the denial but returns success still fails the test.
- Rewords the accompanying comment and fail messages to reflect both code paths.

This unblocks the rc4 release test — the alpine job failed with the shim printing `command denied by policy` while the test looked for `blocked by policy`.

## Test plan

- [x] All six variants updated identically (`grep` confirms the new case pattern)
- [ ] rc5 tag: release workflow passes Dockerfile.test integration across all six variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)