### PR TITLE
config(landlock): honor allow_connect_tcp / allow_bind_tcp on wrapper path

### DIFF
--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -240,10 +240,16 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 			seccompCfg.AllowWrite = append(seccompCfg.AllowWrite, a.cfg.Landlock.AllowWrite...)
 			seccompCfg.DenyPaths = append(seccompCfg.DenyPaths, a.cfg.Landlock.DenyPaths...)
 
-			// Allow all network by default — agentsh proxy handles network policy.
-			// Without this, Landlock ABI v4+ blocks ALL TCP connections.
-			seccompCfg.AllowNetwork = true
-			seccompCfg.AllowBind = true
+			// Honor landlock.network.* config. validateConfig already rejects
+			// allow_connect_tcp=false while sandbox.network.enabled=true, so reaching
+			// this point with AllowConnectTCP=false implies the operator opted out
+			// of proxy TCP. Defaults (connect=true, bind=false) come from applyDefaults.
+			if a.cfg.Landlock.Network.AllowConnectTCP != nil {
+				seccompCfg.AllowNetwork = *a.cfg.Landlock.Network.AllowConnectTCP
+			}
+			if a.cfg.Landlock.Network.AllowBindTCP != nil {
+				seccompCfg.AllowBind = *a.cfg.Landlock.Network.AllowBindTCP
+			}
 
 			slog.Info("landlock config prepared for wrapper",
 				"abi", llResult.ABI,

--- a/internal/api/core_landlock_network_test.go
+++ b/internal/api/core_landlock_network_test.go
@@ -1,0 +1,92 @@
+//go:build linux
+
+package api
+
+import (
+	"encoding/json"
+	"runtime"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/capabilities"
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// TestSetupSeccompWrapper_LandlockNetwork_HonorsConfig verifies that the
+// seccompWrapperConfig JSON produced by setupSeccompWrapper reflects
+// landlock.network.allow_connect_tcp / allow_bind_tcp values rather than
+// hardcoded true/true.
+func TestSetupSeccompWrapper_LandlockNetwork_HonorsConfig(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("seccomp wrapper only available on Linux")
+	}
+	if !capabilities.DetectLandlock().Available {
+		t.Skip("Landlock not available on this host")
+	}
+
+	cases := []struct {
+		name     string
+		connect  bool
+		bind     bool
+		wantNet  bool
+		wantBind bool
+	}{
+		{"both_true", true, true, true, true},
+		{"connect_true_bind_false", true, false, true, false},
+		{"connect_false_bind_false", false, false, false, false},
+		{"connect_true_bind_true", true, true, true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			connect := tc.connect
+			bind := tc.bind
+
+			enabled := true
+			cfg := &config.Config{}
+			cfg.Sandbox.UnixSockets.Enabled = &enabled
+			cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+			cfg.Landlock.Enabled = true
+			cfg.Landlock.Network.AllowConnectTCP = &connect
+			cfg.Landlock.Network.AllowBindTCP = &bind
+
+			app := newTestAppForSeccomp(t, cfg)
+			req := types.ExecRequest{Command: "/bin/echo", Args: []string{"hi"}}
+			sess := &session.Session{Workspace: "/tmp"}
+
+			result := app.setupSeccompWrapper(req, "test-session", sess)
+			if result == nil || result.extraCfg == nil {
+				t.Fatal("expected non-nil wrapper setup result with extraCfg")
+			}
+			defer func() {
+				if result.extraCfg.notifyParentSock != nil {
+					result.extraCfg.notifyParentSock.Close()
+				}
+				for _, f := range result.extraCfg.extraFiles {
+					if f != nil {
+						f.Close()
+					}
+				}
+			}()
+
+			seccompJSON, ok := result.wrappedReq.Env["AGENTSH_SECCOMP_CONFIG"]
+			if !ok {
+				t.Fatal("AGENTSH_SECCOMP_CONFIG env var not set")
+			}
+
+			var parsed map[string]any
+			if err := json.Unmarshal([]byte(seccompJSON), &parsed); err != nil {
+				t.Fatalf("unmarshal seccomp config: %v\n%s", err, seccompJSON)
+			}
+
+			gotNet, _ := parsed["allow_network"].(bool)
+			gotBind, _ := parsed["allow_bind"].(bool)
+			if gotNet != tc.wantNet {
+				t.Errorf("allow_network = %v; want %v (JSON: %s)", gotNet, tc.wantNet, seccompJSON)
+			}
+			if gotBind != tc.wantBind {
+				t.Errorf("allow_bind = %v; want %v (JSON: %s)", gotBind, tc.wantBind, seccompJSON)
+			}
+		})
+	}
+}

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -173,9 +173,15 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 			seccompCfg.AllowWrite = append(seccompCfg.AllowWrite, a.cfg.Landlock.AllowWrite...)
 			seccompCfg.DenyPaths = append(seccompCfg.DenyPaths, a.cfg.Landlock.DenyPaths...)
 
-			// Allow all network by default — agentsh proxy handles network policy.
-			seccompCfg.AllowNetwork = true
-			seccompCfg.AllowBind = true
+			// Honor landlock.network.* config. Defaults (connect=true, bind=false)
+			// come from applyDefaults; validateConfig already rejects the
+			// allow_connect_tcp=false + sandbox.network.enabled=true combination.
+			if a.cfg.Landlock.Network.AllowConnectTCP != nil {
+				seccompCfg.AllowNetwork = *a.cfg.Landlock.Network.AllowConnectTCP
+			}
+			if a.cfg.Landlock.Network.AllowBindTCP != nil {
+				seccompCfg.AllowBind = *a.cfg.Landlock.Network.AllowBindTCP
+			}
 		}
 	}
 

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/agentsh/agentsh/internal/capabilities"
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/events"
 	"github.com/agentsh/agentsh/internal/policy"
@@ -448,5 +449,69 @@ func TestWrapInit_NoSignalSocketWithoutPolicy(t *testing.T) {
 	}
 	if sigEnabled != false {
 		t.Errorf("expected signal_filter_enabled=false, got %v", sigEnabled)
+	}
+}
+
+func TestWrapInit_LandlockNetwork_HonorsConfig(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+	if !capabilities.DetectLandlock().Available {
+		t.Skip("Landlock not available on this host")
+	}
+
+	cases := []struct {
+		name     string
+		connect  bool
+		bind     bool
+		wantNet  bool
+		wantBind bool
+	}{
+		{"both_true", true, true, true, true},
+		{"connect_true_bind_false", true, false, true, false},
+		{"connect_true_bind_true", true, true, true, true},
+		{"connect_false_bind_false", false, false, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			connect := tc.connect
+			bind := tc.bind
+			enabled := true
+			cfg := &config.Config{}
+			cfg.Sandbox.UnixSockets.Enabled = &enabled
+			cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+			cfg.Sandbox.Seccomp.Execve.Enabled = true
+			cfg.Sandbox.Seccomp.UnixSocket.Enabled = true
+			cfg.Landlock.Enabled = true
+			cfg.Landlock.Network.AllowConnectTCP = &connect
+			cfg.Landlock.Network.AllowBindTCP = &bind
+
+			app, mgr := newTestAppForWrap(t, cfg)
+			s, err := mgr.Create(t.TempDir(), "default")
+			if err != nil {
+				t.Fatalf("create session: %v", err)
+			}
+
+			resp, _, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+				AgentCommand: "/bin/echo",
+			})
+			if err != nil {
+				t.Fatalf("wrapInitCore: %v", err)
+			}
+
+			var parsed map[string]any
+			if err := json.Unmarshal([]byte(resp.SeccompConfig), &parsed); err != nil {
+				t.Fatalf("unmarshal SeccompConfig: %v\n%s", err, resp.SeccompConfig)
+			}
+
+			gotNet, _ := parsed["allow_network"].(bool)
+			gotBind, _ := parsed["allow_bind"].(bool)
+			if gotNet != tc.wantNet {
+				t.Errorf("allow_network = %v; want %v (JSON: %s)", gotNet, tc.wantNet, resp.SeccompConfig)
+			}
+			if gotBind != tc.wantBind {
+				t.Errorf("allow_bind = %v; want %v (JSON: %s)", gotBind, tc.wantBind, resp.SeccompConfig)
+			}
+		})
 	}
 }

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -515,3 +515,73 @@ func TestWrapInit_LandlockNetwork_HonorsConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestWrapInit_LandlockNetwork_BackCompatDefaults(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+	if !capabilities.DetectLandlock().Available {
+		t.Skip("Landlock not available on this host")
+	}
+
+	// Minimal YAML: Landlock enabled, no network block.
+	// Exercises the back-compat promise: omitting landlock.network.* must
+	// yield allow_network=true (proxy-compatible) and allow_bind=false
+	// (new security default, replacing prior accidental permissive behavior).
+	yamlData := []byte(`
+landlock:
+  enabled: true
+sandbox:
+  unix_sockets:
+    enabled: true
+    wrapper_bin: /bin/true
+  seccomp:
+    execve:
+      enabled: true
+    unix_socket:
+      enabled: true
+`)
+	tmpFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(tmpFile, yamlData, 0600); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+	cfg, err := config.Load(tmpFile)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+
+	// Sanity: applyDefaults ran via config.Load.
+	if cfg.Landlock.Network.AllowConnectTCP == nil {
+		t.Fatal("applyDefaults should have filled AllowConnectTCP")
+	}
+	if cfg.Landlock.Network.AllowBindTCP == nil {
+		t.Fatal("applyDefaults should have filled AllowBindTCP")
+	}
+
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, _, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+	})
+	if err != nil {
+		t.Fatalf("wrapInitCore: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(resp.SeccompConfig), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	gotNet, _ := parsed["allow_network"].(bool)
+	gotBind, _ := parsed["allow_bind"].(bool)
+	if !gotNet {
+		t.Error("back-compat: allow_network should default to true (proxy needs it)")
+	}
+	if gotBind {
+		t.Error("back-compat: allow_bind should default to false (security hardening vs prior accidental permissive)")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -1258,6 +1259,23 @@ func applyDefaultsWithSource(cfg *Config, source ConfigSource, configPath string
 	if cfg.Sandbox.MCP.CrossServer.ShadowTool.SimilarityThreshold == nil {
 		d := 0.85
 		cfg.Sandbox.MCP.CrossServer.ShadowTool.SimilarityThreshold = &d
+	}
+
+	// Landlock network defaults — fail-open for connect (proxy needs it),
+	// fail-closed for bind (agents rarely need to listen).
+	// Applied unconditionally so diagnostic dumps show explicit values.
+	if cfg.Landlock.Network.AllowConnectTCP == nil {
+		v := true
+		cfg.Landlock.Network.AllowConnectTCP = &v
+	}
+	if cfg.Landlock.Network.AllowBindTCP == nil {
+		v := false
+		cfg.Landlock.Network.AllowBindTCP = &v
+	}
+	if len(cfg.Landlock.Network.BindPorts) > 0 {
+		slog.Warn("landlock.network.bind_ports is set but not yet enforced",
+			"bind_ports", cfg.Landlock.Network.BindPorts,
+			"note", "port-scoped bind rules are a planned follow-up")
 	}
 
 	// macOS XPC defaults

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -707,9 +707,9 @@ type LandlockConfig struct {
 
 // LandlockNetworkConfig controls Landlock network restrictions (kernel 6.7+).
 type LandlockNetworkConfig struct {
-	AllowConnectTCP bool  `yaml:"allow_connect_tcp"` // Allow outbound TCP
-	AllowBindTCP    bool  `yaml:"allow_bind_tcp"`    // Allow listening
-	BindPorts       []int `yaml:"bind_ports"`        // Specific ports if bind allowed
+	AllowConnectTCP *bool `yaml:"allow_connect_tcp"` // default: true (set by applyDefaults)
+	AllowBindTCP    *bool `yaml:"allow_bind_tcp"`    // default: false (set by applyDefaults)
+	BindPorts       []int `yaml:"bind_ports"`        // reserved; not yet enforced
 }
 
 // CapabilitiesConfig controls Linux capability dropping.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1738,5 +1738,19 @@ func validateConfig(cfg *Config) error {
 			return fmt.Errorf("invalid package_checks.registries[%q].trust %q (must be \"check_full\", \"check_local_only\", or \"trusted\")", name, r.Trust)
 		}
 	}
+	// Landlock network self-lockout check: if the user disables outbound TCP
+	// under Landlock but the sandbox proxy is enabled, agents can never reach
+	// the proxy (which listens on localhost TCP). Fail fast at startup rather
+	// than silently breaking every session with ECONNREFUSED.
+	if cfg.Landlock.Enabled &&
+		cfg.Landlock.Network.AllowConnectTCP != nil &&
+		!*cfg.Landlock.Network.AllowConnectTCP &&
+		cfg.Sandbox.Network.Enabled {
+		return fmt.Errorf(
+			"landlock.network.allow_connect_tcp is false but sandbox.network.enabled " +
+				"is true: agent processes cannot reach the agentsh proxy without " +
+				"outbound TCP. Either set landlock.network.allow_connect_tcp to true, " +
+				"or set sandbox.network.enabled to false")
+	}
 	return nil
 }

--- a/internal/config/landlock_network_test.go
+++ b/internal/config/landlock_network_test.go
@@ -106,3 +106,60 @@ landlock:
 	require.False(t, strings.Contains(buf.String(), "bind_ports"),
 		"no warning should fire when bind_ports is empty")
 }
+
+func TestLandlockValidation_ConnectFalseWithProxyEnabled_Errors(t *testing.T) {
+	f := false
+	cfg := Config{}
+	cfg.Landlock.Enabled = true
+	cfg.Landlock.Network.AllowConnectTCP = &f
+	cfg.Sandbox.Network.Enabled = true
+	// Fill required defaults to avoid unrelated validation errors.
+	cfg.Sandbox.FUSE.Audit.Mode = "monitor"
+	cfg.Sandbox.Network.InterceptMode = "all"
+
+	err := validateConfig(&cfg)
+	require.Error(t, err, "must reject connect_tcp=false while proxy enabled")
+	require.Contains(t, err.Error(), "landlock.network.allow_connect_tcp")
+	require.Contains(t, err.Error(), "sandbox.network.enabled")
+}
+
+func TestLandlockValidation_ConnectFalseWithProxyDisabled_OK(t *testing.T) {
+	f := false
+	cfg := Config{}
+	cfg.Landlock.Enabled = true
+	cfg.Landlock.Network.AllowConnectTCP = &f
+	cfg.Sandbox.Network.Enabled = false
+	cfg.Sandbox.FUSE.Audit.Mode = "monitor"
+	cfg.Sandbox.Network.InterceptMode = "all"
+
+	err := validateConfig(&cfg)
+	require.NoError(t, err, "connect_tcp=false is fine when proxy is off")
+}
+
+func TestLandlockValidation_BindFalseAlwaysOK(t *testing.T) {
+	tr := true
+	f := false
+	cfg := Config{}
+	cfg.Landlock.Enabled = true
+	cfg.Landlock.Network.AllowConnectTCP = &tr
+	cfg.Landlock.Network.AllowBindTCP = &f
+	cfg.Sandbox.Network.Enabled = true
+	cfg.Sandbox.FUSE.Audit.Mode = "monitor"
+	cfg.Sandbox.Network.InterceptMode = "all"
+
+	err := validateConfig(&cfg)
+	require.NoError(t, err, "allow_bind_tcp=false with proxy on is the intended secure case")
+}
+
+func TestLandlockValidation_LandlockDisabled_NoLockoutCheck(t *testing.T) {
+	f := false
+	cfg := Config{}
+	cfg.Landlock.Enabled = false
+	cfg.Landlock.Network.AllowConnectTCP = &f
+	cfg.Sandbox.Network.Enabled = true
+	cfg.Sandbox.FUSE.Audit.Mode = "monitor"
+	cfg.Sandbox.Network.InterceptMode = "all"
+
+	err := validateConfig(&cfg)
+	require.NoError(t, err, "landlock disabled → no lockout check regardless of values")
+}

--- a/internal/config/landlock_network_test.go
+++ b/internal/config/landlock_network_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestLandlockNetworkDefaults_FillsConnectTrueBindFalse(t *testing.T) {
+	yamlData := []byte(`
+landlock:
+  enabled: true
+`)
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(yamlData, &cfg))
+
+	require.Nil(t, cfg.Landlock.Network.AllowConnectTCP, "omitted field must parse as nil")
+	require.Nil(t, cfg.Landlock.Network.AllowBindTCP, "omitted field must parse as nil")
+
+	applyDefaults(&cfg)
+
+	require.NotNil(t, cfg.Landlock.Network.AllowConnectTCP, "default must fill AllowConnectTCP")
+	require.True(t, *cfg.Landlock.Network.AllowConnectTCP, "default AllowConnectTCP must be true")
+	require.NotNil(t, cfg.Landlock.Network.AllowBindTCP, "default must fill AllowBindTCP")
+	require.False(t, *cfg.Landlock.Network.AllowBindTCP, "default AllowBindTCP must be false")
+}
+
+func TestLandlockNetworkDefaults_ExplicitValuesPreserved(t *testing.T) {
+	yamlData := []byte(`
+landlock:
+  enabled: true
+  network:
+    allow_connect_tcp: false
+    allow_bind_tcp: true
+`)
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(yamlData, &cfg))
+
+	applyDefaults(&cfg)
+
+	require.NotNil(t, cfg.Landlock.Network.AllowConnectTCP)
+	require.False(t, *cfg.Landlock.Network.AllowConnectTCP,
+		"explicit false for allow_connect_tcp must survive applyDefaults")
+	require.NotNil(t, cfg.Landlock.Network.AllowBindTCP)
+	require.True(t, *cfg.Landlock.Network.AllowBindTCP,
+		"explicit true for allow_bind_tcp must survive applyDefaults")
+}
+
+func TestLandlockNetworkDefaults_LandlockDisabled_StillFilled(t *testing.T) {
+	yamlData := []byte(`
+landlock:
+  enabled: false
+`)
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(yamlData, &cfg))
+
+	applyDefaults(&cfg)
+
+	require.NotNil(t, cfg.Landlock.Network.AllowConnectTCP,
+		"defaults filled unconditionally for diagnostic-dump stability")
+	require.NotNil(t, cfg.Landlock.Network.AllowBindTCP)
+}
+
+func TestLandlockBindPortsWarning_EmitsWhenSet(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	origLogger := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	defer slog.SetDefault(origLogger)
+
+	yamlData := []byte(`
+landlock:
+  enabled: true
+  network:
+    bind_ports: [8080, 9090]
+`)
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(yamlData, &cfg))
+
+	applyDefaults(&cfg)
+
+	require.Contains(t, buf.String(), "landlock.network.bind_ports",
+		"setting bind_ports must emit a warning about non-enforcement")
+}
+
+func TestLandlockBindPortsWarning_SilentWhenEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	origLogger := slog.Default()
+	slog.SetDefault(slog.New(handler))
+	defer slog.SetDefault(origLogger)
+
+	yamlData := []byte(`
+landlock:
+  enabled: true
+`)
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(yamlData, &cfg))
+
+	applyDefaults(&cfg)
+
+	require.False(t, strings.Contains(buf.String(), "bind_ports"),
+		"no warning should fire when bind_ports is empty")
+}

--- a/internal/landlock/policy.go
+++ b/internal/landlock/policy.go
@@ -287,7 +287,15 @@ func BuildFromConfig(cfg *config.LandlockConfig, pol *policy.Policy, workspace s
 		for _, p := range cfg.DenyPaths {
 			b.AddDenyPath(p)
 		}
-		b.SetNetworkAccess(cfg.Network.AllowConnectTCP, cfg.Network.AllowBindTCP)
+		allowConnect := false
+		if cfg.Network.AllowConnectTCP != nil {
+			allowConnect = *cfg.Network.AllowConnectTCP
+		}
+		allowBind := false
+		if cfg.Network.AllowBindTCP != nil {
+			allowBind = *cfg.Network.AllowBindTCP
+		}
+		b.SetNetworkAccess(allowConnect, allowBind)
 	}
 
 	// Add default deny paths (container escape vectors)


### PR DESCRIPTION
## Summary

- `LandlockNetworkConfig.AllowConnectTCP` and `AllowBindTCP` fields changed to `*bool` to distinguish "unset" from "set to false"
- `applyDefaults` fills `allow_connect_tcp=true` (proxy needs outbound TCP) and `allow_bind_tcp=false` (agents rarely need to listen)
- `validateConfig` rejects `allow_connect_tcp=false` while `sandbox.network.enabled=true` — fail-fast instead of silent mid-session ECONNREFUSED
- Both construction sites (`api/core.go` `setupSeccompWrapper`, `api/wrap.go` `wrapInitCore`) now read config instead of hardcoding `AllowNetwork=true; AllowBind=true`
- `bind_ports` emits a warning if set (reserved for future port-scoped rules)

## Breaking change

`landlock.network.allow_bind_tcp` now takes effect. Previously agent processes could `bind()` to any TCP port regardless of config. New default: `false` (bind blocked). Set `allow_bind_tcp: true` if agents need to listen.

## Test plan

- [x] 5 unit tests for defaults + bind_ports warning (`internal/config/landlock_network_test.go`)
- [x] 4 unit tests for validation truth table (same file)
- [x] 4 integration tests for `setupSeccompWrapper` config wiring (`internal/api/core_landlock_network_test.go`)
- [x] 4 integration tests for `wrapInitCore` config wiring (`internal/api/wrap_test.go`)
- [x] 1 end-to-end back-compat test via `config.Load` → `wrapInitCore` → JSON assertion
- [x] `go test ./...` passes
- [x] `GOOS=windows go build ./...` passes
- [x] `GOOS=darwin go build ./...` passes

Spec: `docs/superpowers/specs/2026-04-15-landlock-network-config-design.md`
Plan: `docs/superpowers/plans/2026-04-15-landlock-network-config.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)