### PR TITLE
[codex] Harden multi-user wrap socket permissions

### DIFF
--- a/docs/superpowers/plans/2026-04-16-multi-user-wrap-socket-permissions.md
+++ b/docs/superpowers/plans/2026-04-16-multi-user-wrap-socket-permissions.md
@@ -1,0 +1,970 @@
+# Multi-User Wrap Socket Permissions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix notify socket permissions so `agentsh wrap` works when the server runs as root and the CLI runs as an unprivileged user, with per-caller isolation via chown and SO_PEERCRED verification.
+
+**Architecture:** Add `CallerUID` to the wrap-init protocol. Server chowns the temp directory + sockets to the caller's UID (falls back to relaxed `0711`/`0666` if not root). On accept, the server verifies the connecting process's UID via kernel-provided SO_PEERCRED credentials.
+
+**Tech Stack:** Go, Unix domain sockets, `os.Chown`/`os.Chmod`, `unix.GetsockoptUcred` (SO_PEERCRED)
+
+---
+
+## File Map
+
+- **Modify:** `pkg/types/sessions.go:126-129` — add `CallerUID` field to `WrapInitRequest`
+- **Modify:** `internal/cli/wrap.go:296-299` — set `CallerUID` in wrap-init call
+- **Modify:** `internal/api/wrap.go:55-263` — add `secureNotifyDir`/`secureSocket` helpers, wire into `wrapInitCore` ptrace + seccomp paths, thread `expectedUID` into accept goroutines
+- **Modify:** `internal/api/wrap.go:410-504` — add `expectedUID` param to `acceptNotifyFD`/`acceptSignalFD`, add UID verification
+- **Modify:** `internal/api/wrap_linux.go:211-228` — rename `getConnPeerPID` → `getConnPeerCreds`, return `peerCreds` struct
+- **Modify:** `internal/api/wrap_linux.go:233-306` — add `expectedUID` param to `acceptPtracePID`, add UID verification
+- **Modify:** `internal/api/wrap_windows.go:42-48` — update `getConnPeerPID` → `getConnPeerCreds` stub, update `acceptPtracePID` signature
+- **Modify:** `internal/api/wrap_other.go:39-45` — same stub updates
+- **Modify:** `internal/api/wrap_test.go` — existing tests pass CallerUID, add new permission tests
+
+---
+
+### Task 1: Add CallerUID to WrapInitRequest
+
+**Files:**
+- Modify: `pkg/types/sessions.go:126-129`
+- Modify: `internal/cli/wrap.go:296-299`
+- Test: `internal/api/wrap_test.go`
+
+- [ ] **Step 1: Write failing test — CallerUID round-trips through wrapInitCore**
+
+Add to `internal/api/wrap_test.go`:
+
+```go
+func TestWrapInit_CallerUIDPassedThrough(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    1000,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Errorf("expected 200, got %d", code)
+	}
+	if resp.NotifySocket == "" {
+		t.Error("expected notify socket path")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -run TestWrapInit_CallerUIDPassedThrough -v`
+Expected: compilation error — `CallerUID` field does not exist on `WrapInitRequest`.
+
+- [ ] **Step 3: Add CallerUID field to WrapInitRequest**
+
+In `pkg/types/sessions.go`, change:
+
+```go
+type WrapInitRequest struct {
+	AgentCommand string   `json:"agent_command"`
+	AgentArgs    []string `json:"agent_args,omitempty"`
+}
+```
+
+to:
+
+```go
+type WrapInitRequest struct {
+	AgentCommand string   `json:"agent_command"`
+	AgentArgs    []string `json:"agent_args,omitempty"`
+	CallerUID    int      `json:"caller_uid,omitempty"`
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -run TestWrapInit_CallerUIDPassedThrough -v`
+Expected: PASS
+
+- [ ] **Step 5: Set CallerUID in CLI wrap**
+
+In `internal/cli/wrap.go`, change the wrap-init call at line ~296:
+
+```go
+	wrapResp, err := c.WrapInit(ctx, sessID, types.WrapInitRequest{
+		AgentCommand: agentPath,
+		AgentArgs:    agentArgs,
+	})
+```
+
+to:
+
+```go
+	wrapResp, err := c.WrapInit(ctx, sessID, types.WrapInitRequest{
+		AgentCommand: agentPath,
+		AgentArgs:    agentArgs,
+		CallerUID:    os.Getuid(),
+	})
+```
+
+Add `"os"` to imports if not already present.
+
+- [ ] **Step 6: Verify build**
+
+Run: `cd /home/eran/work/agentsh && go build ./...`
+Expected: clean build
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `cd /home/eran/work/agentsh && go test ./...`
+Expected: all tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pkg/types/sessions.go internal/cli/wrap.go internal/api/wrap_test.go
+git commit -m "feat(wrap): add CallerUID to WrapInitRequest for multi-user socket permissions"
+```
+
+---
+
+### Task 2: Add secureNotifyDir and secureSocket helpers
+
+**Files:**
+- Modify: `internal/api/wrap.go` (add helpers near the top, before `wrapInitCore`)
+- Test: `internal/api/wrap_test.go`
+
+- [ ] **Step 1: Write failing tests for the helpers**
+
+Add to `internal/api/wrap_test.go`:
+
+```go
+func TestSecureNotifyDir_ChownSuccess(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Unix permissions")
+	}
+
+	dir := t.TempDir()
+	uid := os.Getuid()
+
+	// When callerUID matches current user, chown succeeds (we own it)
+	chownOK := secureNotifyDir(dir, uid)
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0700 {
+		t.Errorf("expected 0700, got %04o", info.Mode().Perm())
+	}
+	// chown to ourselves should succeed (even without root)
+	if !chownOK {
+		t.Error("expected chownOK=true when chowning to self")
+	}
+}
+
+func TestSecureNotifyDir_CallerUIDZero_Fallback(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Unix permissions")
+	}
+
+	dir := t.TempDir()
+	chownOK := secureNotifyDir(dir, 0)
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0711 {
+		t.Errorf("expected 0711, got %04o", info.Mode().Perm())
+	}
+	if chownOK {
+		t.Error("expected chownOK=false for callerUID=0")
+	}
+}
+
+func TestSecureSocket_ChownOK(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Unix permissions")
+	}
+
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	secureSocket(sockPath, os.Getuid(), true)
+
+	// Socket should NOT be world-connectable (no 0666)
+	info, err := os.Stat(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// When chownOK, we don't chmod to 0666
+	if info.Mode().Perm()&0066 == 0066 {
+		t.Error("socket should not be world-connectable when chown succeeded")
+	}
+}
+
+func TestSecureSocket_Fallback(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Unix permissions")
+	}
+
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	secureSocket(sockPath, 0, false)
+
+	info, err := os.Stat(sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0666 {
+		t.Errorf("expected 0666, got %04o", info.Mode().Perm())
+	}
+}
+```
+
+Add `"net"` to the test file imports.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -run "TestSecureNotifyDir|TestSecureSocket" -v`
+Expected: compilation error — `secureNotifyDir` and `secureSocket` are undefined.
+
+- [ ] **Step 3: Implement the helpers**
+
+Add to `internal/api/wrap.go`, after the imports and before `wrapInit`:
+
+```go
+// secureNotifyDir sets ownership and permissions on the notify socket directory
+// for multi-user wrap. If callerUID > 0, it attempts to chown the directory to
+// the caller so only they can traverse it (0700). If chown fails (server is not
+// root) or callerUID is 0 (old client), it falls back to 0711 (traverse-only).
+// Returns true if chown succeeded, false if fallback permissions were applied.
+func secureNotifyDir(dir string, callerUID int) bool {
+	if callerUID > 0 {
+		if err := os.Chown(dir, callerUID, -1); err != nil {
+			slog.Debug("wrap: chown notify dir failed, using permissive fallback",
+				"dir", dir, "uid", callerUID, "error", err)
+			os.Chmod(dir, 0711)
+			return false
+		}
+		os.Chmod(dir, 0700)
+		return true
+	}
+	os.Chmod(dir, 0711)
+	return false
+}
+
+// secureSocket sets ownership and permissions on a notify socket after creation.
+// If chownOK (directory chown succeeded), it chowns the socket to the caller.
+// Otherwise, it chmods the socket to 0666 so any local user can connect.
+func secureSocket(socketPath string, callerUID int, chownOK bool) {
+	if chownOK && callerUID > 0 {
+		if err := os.Chown(socketPath, callerUID, -1); err != nil {
+			slog.Debug("wrap: chown socket failed, using permissive fallback",
+				"path", socketPath, "uid", callerUID, "error", err)
+			os.Chmod(socketPath, 0666)
+		}
+		return
+	}
+	os.Chmod(socketPath, 0666)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -run "TestSecureNotifyDir|TestSecureSocket" -v`
+Expected: all 4 tests PASS
+
+- [ ] **Step 5: Verify full build + existing tests**
+
+Run: `cd /home/eran/work/agentsh && go build ./... && go test ./internal/api/ -v`
+Expected: clean build, all tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/api/wrap.go internal/api/wrap_test.go
+git commit -m "feat(wrap): add secureNotifyDir/secureSocket helpers for multi-user permissions"
+```
+
+---
+
+### Task 3: Wire helpers into wrapInitCore
+
+**Files:**
+- Modify: `internal/api/wrap.go:76-111` (ptrace path)
+- Modify: `internal/api/wrap.go:194-257` (seccomp path)
+- Test: `internal/api/wrap_test.go`
+
+- [ ] **Step 1: Write failing test — notify socket directory uses 0711 fallback for CallerUID=0**
+
+Add to `internal/api/wrap_test.go`:
+
+```go
+func TestWrapInit_NotifyDirPermissions_Fallback(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	// CallerUID=0 simulates an old client — should get permissive fallback
+	resp, _, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Check the notify socket's parent directory has 0711
+	notifyDir := filepath.Dir(resp.NotifySocket)
+	info, err := os.Stat(notifyDir)
+	if err != nil {
+		t.Fatalf("stat notify dir: %v", err)
+	}
+	if info.Mode().Perm() != 0711 {
+		t.Errorf("expected dir perm 0711 for CallerUID=0, got %04o", info.Mode().Perm())
+	}
+
+	// Check the notify socket has 0666
+	sockInfo, err := os.Stat(resp.NotifySocket)
+	if err != nil {
+		t.Fatalf("stat socket: %v", err)
+	}
+	if sockInfo.Mode().Perm() != 0666 {
+		t.Errorf("expected socket perm 0666 for CallerUID=0, got %04o", sockInfo.Mode().Perm())
+	}
+}
+
+func TestWrapInit_NotifyDirPermissions_CallerUID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	// Use our own UID so chown succeeds without root
+	resp, _, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    os.Getuid(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	notifyDir := filepath.Dir(resp.NotifySocket)
+	info, err := os.Stat(notifyDir)
+	if err != nil {
+		t.Fatalf("stat notify dir: %v", err)
+	}
+	if info.Mode().Perm() != 0700 {
+		t.Errorf("expected dir perm 0700 for CallerUID=%d, got %04o", os.Getuid(), info.Mode().Perm())
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -run "TestWrapInit_NotifyDirPermissions" -v`
+Expected: FAIL — directory is still 0700 (hardcoded), not 0711.
+
+- [ ] **Step 3: Wire secureNotifyDir + secureSocket into the ptrace path**
+
+In `internal/api/wrap.go`, in the ptrace path (starting at line ~76), replace:
+
+```go
+		notifyDir, err := os.MkdirTemp("", "agentsh-wrap-*")
+		if err != nil {
+			return types.WrapInitResponse{}, http.StatusInternalServerError, err
+		}
+		if err := os.Chmod(notifyDir, 0700); err != nil {
+			os.RemoveAll(notifyDir)
+			return types.WrapInitResponse{}, http.StatusInternalServerError, err
+		}
+```
+
+with:
+
+```go
+		notifyDir, err := os.MkdirTemp("", "agentsh-wrap-*")
+		if err != nil {
+			return types.WrapInitResponse{}, http.StatusInternalServerError, err
+		}
+		chownOK := secureNotifyDir(notifyDir, req.CallerUID)
+```
+
+Then after `net.Listen("unix", notifySocketPath)` (line ~105), before the `go a.acceptPtracePID` call, add:
+
+```go
+		secureSocket(notifySocketPath, req.CallerUID, chownOK)
+```
+
+- [ ] **Step 4: Wire secureNotifyDir + secureSocket into the seccomp path**
+
+In the seccomp path (starting at line ~198), replace:
+
+```go
+	notifyDir, err := os.MkdirTemp("", "agentsh-wrap-*")
+	if err != nil {
+		return types.WrapInitResponse{}, http.StatusInternalServerError, err
+	}
+	if err := os.Chmod(notifyDir, 0700); err != nil {
+		os.RemoveAll(notifyDir)
+		return types.WrapInitResponse{}, http.StatusInternalServerError, err
+	}
+```
+
+with:
+
+```go
+	notifyDir, err := os.MkdirTemp("", "agentsh-wrap-*")
+	if err != nil {
+		return types.WrapInitResponse{}, http.StatusInternalServerError, err
+	}
+	chownOK := secureNotifyDir(notifyDir, req.CallerUID)
+```
+
+Then after `net.Listen("unix", notifySocketPath)` (line ~226), before `go a.acceptNotifyFD`, add:
+
+```go
+	secureSocket(notifySocketPath, req.CallerUID, chownOK)
+```
+
+And after `signalListener, err := net.Listen("unix", signalSocketPath)` (line ~248), inside the `if signalFilterEnabled` block, after the `net.Listen` success path and before `go a.acceptSignalFD`, add:
+
+```go
+			secureSocket(signalSocketPath, req.CallerUID, chownOK)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -run "TestWrapInit_NotifyDirPermissions" -v`
+Expected: both tests PASS
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -v`
+Expected: all tests pass (existing tests use CallerUID=0, so they get fallback behavior — still functional)
+
+- [ ] **Step 7: Cross-compile check**
+
+Run: `cd /home/eran/work/agentsh && GOOS=windows go build ./...`
+Expected: clean build
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/api/wrap.go internal/api/wrap_test.go
+git commit -m "feat(wrap): wire secureNotifyDir/secureSocket into wrapInitCore paths"
+```
+
+---
+
+### Task 4: Extend getConnPeerPID to getConnPeerCreds
+
+**Files:**
+- Modify: `internal/api/wrap_linux.go:211-228`
+- Modify: `internal/api/wrap_windows.go:42-44`
+- Modify: `internal/api/wrap_other.go:39-41`
+- Modify: `internal/api/wrap.go:434-439` (call site in `acceptNotifyFD`)
+- Test: `internal/api/wrap_test.go`
+
+- [ ] **Step 1: Write failing test for getConnPeerCreds**
+
+Add to `internal/api/wrap_test.go`:
+
+```go
+func TestGetConnPeerCreds(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("SO_PEERCRED is Linux-only")
+	}
+
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	// Connect from this process
+	connCh := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		connCh <- c
+	}()
+
+	clientConn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientConn.Close()
+
+	serverConn := <-connCh
+	defer serverConn.Close()
+
+	unixConn, ok := serverConn.(*net.UnixConn)
+	if !ok {
+		t.Fatal("not a unix conn")
+	}
+
+	creds := getConnPeerCreds(unixConn)
+	if creds.PID <= 0 {
+		t.Errorf("expected PID > 0, got %d", creds.PID)
+	}
+	if creds.UID != uint32(os.Getuid()) {
+		t.Errorf("expected UID %d, got %d", os.Getuid(), creds.UID)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -run TestGetConnPeerCreds -v`
+Expected: compilation error — `getConnPeerCreds` undefined, returns wrong type.
+
+- [ ] **Step 3: Implement getConnPeerCreds on Linux**
+
+In `internal/api/wrap_linux.go`, replace `getConnPeerPID` (lines 211-228):
+
+```go
+// peerCreds holds the peer process credentials from SO_PEERCRED.
+type peerCreds struct {
+	PID int
+	UID uint32
+}
+
+// getConnPeerCreds extracts the peer process PID and UID from a Unix connection.
+func getConnPeerCreds(conn *net.UnixConn) peerCreds {
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		slog.Debug("getConnPeerCreds: failed to get syscall conn", "error", err)
+		return peerCreds{}
+	}
+	var creds peerCreds
+	rawConn.Control(func(fd uintptr) {
+		ucred, err := unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+		if err != nil {
+			slog.Debug("getConnPeerCreds: GetsockoptUcred failed", "error", err)
+		} else {
+			creds.PID = int(ucred.Pid)
+			creds.UID = ucred.Uid
+		}
+	})
+	return creds
+}
+```
+
+- [ ] **Step 4: Update Windows stub**
+
+In `internal/api/wrap_windows.go`, replace:
+
+```go
+func getConnPeerPID(conn *net.UnixConn) int {
+	return 0
+}
+```
+
+with:
+
+```go
+type peerCreds struct {
+	PID int
+	UID uint32
+}
+
+func getConnPeerCreds(conn *net.UnixConn) peerCreds {
+	return peerCreds{}
+}
+```
+
+- [ ] **Step 5: Update Other stub**
+
+In `internal/api/wrap_other.go`, replace:
+
+```go
+func getConnPeerPID(conn *net.UnixConn) int {
+	return 0
+}
+```
+
+with:
+
+```go
+type peerCreds struct {
+	PID int
+	UID uint32
+}
+
+func getConnPeerCreds(conn *net.UnixConn) peerCreds {
+	return peerCreds{}
+}
+```
+
+- [ ] **Step 6: Update call site in acceptNotifyFD**
+
+In `internal/api/wrap.go`, in `acceptNotifyFD` (~line 434-439), replace:
+
+```go
+	// Get wrapper PID from socket credentials for depth tracking
+	wrapperPID := getConnPeerPID(unixConn)
+	if wrapperPID > 0 {
+		slog.Debug("wrap: got wrapper PID from socket credentials",
+			"wrapper_pid", wrapperPID, "session_id", sessionID)
+	}
+```
+
+with:
+
+```go
+	// Get wrapper credentials from socket for depth tracking and UID verification
+	creds := getConnPeerCreds(unixConn)
+	wrapperPID := creds.PID
+	if wrapperPID > 0 {
+		slog.Debug("wrap: got wrapper credentials from socket",
+			"wrapper_pid", wrapperPID, "wrapper_uid", creds.UID, "session_id", sessionID)
+	}
+```
+
+- [ ] **Step 7: Run test and verify it passes**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -run TestGetConnPeerCreds -v`
+Expected: PASS
+
+- [ ] **Step 8: Cross-compile check**
+
+Run: `cd /home/eran/work/agentsh && GOOS=windows go build ./... && GOOS=darwin go build ./...`
+Expected: clean build on all platforms
+
+- [ ] **Step 9: Run full test suite**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -v`
+Expected: all tests pass
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/api/wrap.go internal/api/wrap_linux.go internal/api/wrap_windows.go internal/api/wrap_other.go internal/api/wrap_test.go
+git commit -m "refactor(wrap): rename getConnPeerPID to getConnPeerCreds, return PID+UID"
+```
+
+---
+
+### Task 5: Add SO_PEERCRED UID verification to accept functions
+
+**Files:**
+- Modify: `internal/api/wrap.go:410` (`acceptNotifyFD` signature + verification)
+- Modify: `internal/api/wrap.go:467` (`acceptSignalFD` signature + verification)
+- Modify: `internal/api/wrap_linux.go:233` (`acceptPtracePID` signature + verification)
+- Modify: `internal/api/wrap_windows.go:46` (`acceptPtracePID` stub signature)
+- Modify: `internal/api/wrap_other.go:43` (`acceptPtracePID` stub signature)
+- Modify: `internal/api/wrap.go` (goroutine call sites to pass `expectedUID`)
+- Test: `internal/api/wrap_test.go`
+
+- [ ] **Step 1: Write failing test — UID verification rejects mismatched UID**
+
+Add to `internal/api/wrap_test.go`:
+
+```go
+func TestAcceptNotifyFD_RejectsWrongUID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("SO_PEERCRED is Linux-only")
+	}
+
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// expectedUID=99999 won't match our real UID
+	app, mgr := newTestAppForWrap(t, &config.Config{})
+	_ = mgr
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptNotifyFD(context.Background(), ln, sockPath, "test-session", nil, false, 99999)
+	}()
+
+	// Connect — should be rejected
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	// The server should close the connection without reading
+	buf := make([]byte, 1)
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	_, err = conn.Read(buf)
+	if err == nil {
+		t.Error("expected connection to be closed by server")
+	}
+	conn.Close()
+	<-done
+}
+
+func TestAcceptNotifyFD_AcceptsCorrectUID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("SO_PEERCRED is Linux-only")
+	}
+
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "test.sock")
+	ln, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// expectedUID=0 means no check (old client)
+	app, _ := newTestAppForWrap(t, &config.Config{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptNotifyFD(context.Background(), ln, sockPath, "test-session", nil, false, 0)
+	}()
+
+	// Connect — should be accepted (UID check skipped)
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	// Send a byte to unblock recvmsg (it will fail to parse fd, but that's fine —
+	// we're testing that the connection was accepted, not fd forwarding)
+	conn.Write([]byte{0})
+	conn.Close()
+	<-done
+}
+```
+
+Add `"context"` and `"time"` to the test file imports if not already present.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -run "TestAcceptNotifyFD" -v`
+Expected: compilation error — `acceptNotifyFD` doesn't accept `expectedUID` parameter.
+
+- [ ] **Step 3: Add expectedUID to acceptNotifyFD**
+
+In `internal/api/wrap.go`, change the `acceptNotifyFD` signature:
+
+```go
+func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketPath string, sessionID string, s *session.Session, execveEnabled bool) {
+```
+
+to:
+
+```go
+func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketPath string, sessionID string, s *session.Session, execveEnabled bool, expectedUID int) {
+```
+
+After the `getConnPeerCreds` call and before `file, err := unixConn.File()`, add the UID verification:
+
+```go
+	// Verify connecting process UID matches expected caller
+	if expectedUID > 0 && creds.UID != uint32(expectedUID) {
+		slog.Warn("wrap: rejected notify connection from unexpected UID",
+			"expected_uid", expectedUID, "actual_uid", creds.UID,
+			"pid", creds.PID, "session_id", sessionID)
+		return
+	}
+```
+
+Update the goroutine call site in `wrapInitCore` (seccomp path, ~line 233):
+
+```go
+	go a.acceptNotifyFD(ctx, listener, notifySocketPath, sessionID, s, execveEnabled, req.CallerUID)
+```
+
+- [ ] **Step 4: Add expectedUID to acceptSignalFD**
+
+Change the `acceptSignalFD` signature:
+
+```go
+func (a *App) acceptSignalFD(ctx context.Context, listener net.Listener, socketPath string, sessionID string, s *session.Session) {
+```
+
+to:
+
+```go
+func (a *App) acceptSignalFD(ctx context.Context, listener net.Listener, socketPath string, sessionID string, s *session.Session, expectedUID int) {
+```
+
+After `listener.Accept()` succeeds and the `*net.UnixConn` type assertion, add UID verification. Insert after `unixConn, ok := conn.(*net.UnixConn)` and before `file, err := unixConn.File()`:
+
+```go
+	// Verify connecting process UID matches expected caller
+	if expectedUID > 0 {
+		creds := getConnPeerCreds(unixConn)
+		if creds.UID != uint32(expectedUID) {
+			slog.Warn("wrap: rejected signal connection from unexpected UID",
+				"expected_uid", expectedUID, "actual_uid", creds.UID,
+				"pid", creds.PID, "session_id", sessionID)
+			return
+		}
+	}
+```
+
+Update the goroutine call site (~line 255):
+
+```go
+			go a.acceptSignalFD(ctx, signalListener, signalSocketPath, sessionID, s, req.CallerUID)
+```
+
+- [ ] **Step 5: Add expectedUID to acceptPtracePID on Linux**
+
+In `internal/api/wrap_linux.go`, change the `acceptPtracePID` signature:
+
+```go
+func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string) {
+```
+
+to:
+
+```go
+func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string, expectedUID int) {
+```
+
+After `conn, err := listener.Accept()` succeeds (~line 242), before the read deadline, add:
+
+```go
+	// Verify connecting process UID matches expected caller
+	if expectedUID > 0 {
+		if unixConn, ok := conn.(*net.UnixConn); ok {
+			creds := getConnPeerCreds(unixConn)
+			if creds.UID != uint32(expectedUID) {
+				slog.Warn("ptrace wrap: rejected connection from unexpected UID",
+					"expected_uid", expectedUID, "actual_uid", creds.UID,
+					"pid", creds.PID, "session_id", sessionID)
+				conn.Close()
+				return
+			}
+		}
+	}
+```
+
+- [ ] **Step 6: Update acceptPtracePID stubs**
+
+In `internal/api/wrap_windows.go`, change:
+
+```go
+func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string) {
+```
+
+to:
+
+```go
+func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string, expectedUID int) {
+```
+
+In `internal/api/wrap_other.go`, make the same signature change.
+
+- [ ] **Step 7: Update ptrace goroutine call site**
+
+In `internal/api/wrap.go`, in the ptrace path (~line 111), change:
+
+```go
+		go a.acceptPtracePID(ctx, listener, notifySocketPath, sessionID)
+```
+
+to:
+
+```go
+		go a.acceptPtracePID(ctx, listener, notifySocketPath, sessionID, req.CallerUID)
+```
+
+- [ ] **Step 8: Run the UID verification tests**
+
+Run: `cd /home/eran/work/agentsh && go test ./internal/api/ -run "TestAcceptNotifyFD" -v`
+Expected: both tests PASS
+
+- [ ] **Step 9: Cross-compile check**
+
+Run: `cd /home/eran/work/agentsh && GOOS=windows go build ./... && GOOS=darwin go build ./...`
+Expected: clean build
+
+- [ ] **Step 10: Run full test suite**
+
+Run: `cd /home/eran/work/agentsh && go test ./... -count=1`
+Expected: all tests pass
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add internal/api/wrap.go internal/api/wrap_linux.go internal/api/wrap_windows.go internal/api/wrap_other.go internal/api/wrap_test.go
+git commit -m "feat(wrap): add SO_PEERCRED UID verification on notify socket accept"
+```
+
+---
+
+### Task 6: Final validation
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full build and test**
+
+Run: `cd /home/eran/work/agentsh && go build ./... && go test ./... -count=1`
+Expected: all pass
+
+- [ ] **Step 2: Cross-compile**
+
+Run: `cd /home/eran/work/agentsh && GOOS=windows go build ./... && GOOS=darwin go build ./...`
+Expected: clean build on all platforms
+
+- [ ] **Step 3: Verify the complete permission flow manually**
+
+Run the new tests specifically to confirm the full chain works:
+
+```bash
+cd /home/eran/work/agentsh
+go test ./internal/api/ -run "TestWrapInit_CallerUID|TestWrapInit_NotifyDirPermissions|TestSecureNotifyDir|TestSecureSocket|TestGetConnPeerCreds|TestAcceptNotifyFD" -v
+```
+
+Expected: all tests PASS

--- a/docs/superpowers/specs/2026-04-16-multi-user-wrap-socket-permissions-design.md
+++ b/docs/superpowers/specs/2026-04-16-multi-user-wrap-socket-permissions-design.md
@@ -1,0 +1,141 @@
+# Multi-User Wrap Socket Permissions
+
+**Date:** 2026-04-16
+**Status:** Draft
+**Scope:** `internal/api/wrap.go`, `internal/api/wrap_linux.go`, `internal/cli/wrap.go`, `internal/cli/wrap_linux.go`, `pkg/types/sessions.go`
+
+## Problem
+
+When `agentsh server` runs as root (e.g. a systemd service) and `agentsh wrap` runs as an unprivileged user (e.g. uid=1000), the wrap process cannot connect to the notify sockets. The server creates the temp directory at `/tmp/agentsh-wrap-*/` as `root:root 0700`. The unprivileged CLI cannot traverse the directory to reach the sockets, failing with `EACCES` at `forwardNotifyFD` → `net.Dial("unix", socketPath)`.
+
+All three socket types are affected: seccomp notify, ptrace notify, and signal filter.
+
+## Approach: Chown + SO_PEERCRED (defense in depth)
+
+Two independent barriers:
+
+1. **Filesystem isolation (chown):** The server chowns the notify directory and sockets to the wrap caller's UID. Directory stays `0700` — only the specific user can traverse. Falls back to relaxed permissions (`0711`/`0666`) when the server lacks `CAP_CHOWN` (non-root mode).
+
+2. **Runtime verification (SO_PEERCRED):** On every notify socket accept, the server extracts the connecting process's UID from kernel-provided `SO_PEERCRED` credentials and rejects mismatches. This is the always-on layer — even if chown succeeded, the server still verifies.
+
+The combination means: a spoofed `CallerUID` in the HTTP request is self-defeating (chown grants access to the wrong user, but SO_PEERCRED then rejects the attacker's real UID), and relaxed filesystem permissions in fallback mode are backstopped by kernel credential checks.
+
+## Protocol Change
+
+`WrapInitRequest` gains one field:
+
+```go
+type WrapInitRequest struct {
+    AgentCommand string   `json:"agent_command"`
+    AgentArgs    []string `json:"agent_args,omitempty"`
+    CallerUID    int      `json:"caller_uid,omitempty"` // 0 = not provided (old client)
+}
+```
+
+The CLI sets `CallerUID = os.Getuid()` before the wrap-init HTTP call. `omitempty` ensures old clients that don't send it produce `caller_uid: 0`, which the server treats as "unknown caller."
+
+No changes to `WrapInitResponse`.
+
+## Server-Side: Directory and Socket Ownership
+
+After `MkdirTemp` and before creating sockets, the server secures the directory and each socket. Two helpers, since the directory is created once but may contain multiple sockets (seccomp path shares a directory between notify and signal sockets):
+
+```
+// secureNotifyDir chowns the directory to callerUID. Returns true if chown
+// succeeded, false if fallback permissions were applied instead.
+secureNotifyDir(dir, callerUID) bool:
+  if callerUID > 0:
+    err := os.Chown(dir, callerUID, -1)
+    if err is EPERM:
+      log.Debug("chown failed, falling back to permissive mode")
+      chmod(dir, 0711)       // traverse-only for others
+      return false
+    chmod(dir, 0700)         // only caller can traverse
+    return true
+  else:
+    chmod(dir, 0711)         // old client, permissive fallback
+    return false
+
+// secureSocket chowns or chmods the socket after net.Listen.
+secureSocket(socketPath, callerUID, chownOK):
+  if chownOK:
+    os.Chown(socketPath, callerUID, -1)  // caller owns socket
+  else:
+    chmod(socketPath, 0666)              // world-connectable fallback
+```
+
+Call pattern in `wrapInitCore`:
+- **Ptrace path** (~line 76): `secureNotifyDir` once, `net.Listen`, `secureSocket` once.
+- **Seccomp path** (~line 198): `secureNotifyDir` once, then for each of notify socket (~line 226) and signal socket (~line 248): `net.Listen`, `secureSocket`.
+
+## Server-Side: SO_PEERCRED Verification
+
+### Extend `getConnPeerPID` → `getConnPeerCreds`
+
+```go
+type peerCreds struct {
+    PID int
+    UID uint32
+}
+
+func getConnPeerCreds(conn *net.UnixConn) peerCreds {
+    // Existing GetsockoptUcred logic, return both .Pid and .Uid
+}
+```
+
+### Verify in each accept function
+
+In `acceptNotifyFD`, `acceptSignalFD`, and `acceptPtracePID`, after `listener.Accept()`:
+
+```
+creds := getConnPeerCreds(unixConn)
+if expectedUID > 0 && creds.UID != uint32(expectedUID):
+    log.Warn("wrap: rejected connection from unexpected UID",
+        "expected", expectedUID, "got", creds.UID, "pid", creds.PID)
+    conn.Close()
+    return
+```
+
+The `expectedUID` is threaded from `wrapInitCore` into the accept goroutines (passed as a parameter). When `CallerUID == 0` (old client), skip the check.
+
+## Client-Side Change
+
+In `internal/cli/wrap.go`, before the wrap-init call:
+
+```go
+req.CallerUID = os.Getuid()
+```
+
+One line.
+
+## Backward Compatibility
+
+| Server | Client | Behavior |
+|--------|--------|----------|
+| New | New | Full: chown + SO_PEERCRED |
+| New | Old | `CallerUID=0` → fallback `0711`/`0666`, no UID check. Equivalent to user's proposed fix. |
+| Old | New | Server ignores unknown field (Go JSON unmarshal lenient). Old `0700` behavior — still broken for multi-user, but was already broken. |
+| Old | Old | Status quo |
+
+No configuration required. Chown-vs-fallback is automatic based on server capabilities and client version.
+
+## Testing
+
+### Unit tests
+
+1. **`getConnPeerCreds`** — verify both PID and UID are returned from a local socketpair.
+
+2. **`secureNotifyDir` + `secureSocket` helpers** — three cases:
+   - `callerUID > 0`, chown succeeds → directory owned by callerUID, mode `0700`; socket owned by callerUID.
+   - `callerUID > 0`, chown returns `EPERM` → directory mode `0711`, socket mode `0666`.
+   - `callerUID == 0` → same fallback as EPERM case.
+
+3. **SO_PEERCRED rejection** — create a listener, connect from current process. Accept succeeds when `expectedUID == os.Getuid()`. Accept rejects (closes connection) when `expectedUID` is a different value.
+
+### Integration test
+
+4. **Multi-user wrap round-trip (root only)** — if running as root: create wrap-init with `CallerUID=1000`, verify ownership, connect from a forked uid=1000 process, confirm fd forwarding succeeds. Skip if not root.
+
+### Not tested
+
+Actually running as two different non-root users simultaneously — requires `setuid`, fragile in CI. The unit tests for permission logic and SO_PEERCRED cover the critical paths.

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -55,6 +55,10 @@ func secureNotifyDir(dir string, callerUID int) bool {
 		if err := os.Chown(dir, callerUID, -1); err == nil {
 			if err := os.Chmod(dir, 0700); err != nil {
 				slog.Debug("wrap: failed to chmod notify dir", "dir", dir, "mode", "0700", "error", err)
+				if err := os.Chmod(dir, 0711); err != nil {
+					slog.Debug("wrap: failed to chmod notify dir", "dir", dir, "mode", "0711", "error", err)
+				}
+				return false
 			}
 			return true
 		} else {

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -185,7 +185,7 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 			return types.WrapInitResponse{}, http.StatusInternalServerError, err
 		}
 
-		go a.acceptPtracePID(ctx, listener, notifySocketPath, sessionID)
+		go a.acceptPtracePID(ctx, listener, notifySocketPath, sessionID, req.CallerUID)
 
 		ev := types.Event{
 			ID:        uuid.NewString(),
@@ -324,7 +324,7 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 	}
 
 	// Start background goroutine to accept the notify fd connection
-	go a.acceptNotifyFD(ctx, listener, notifySocketPath, sessionID, s, execveEnabled)
+	go a.acceptNotifyFD(ctx, listener, notifySocketPath, sessionID, s, execveEnabled, req.CallerUID)
 
 	// Create signal filter socket if signal filtering is enabled.
 	// This must happen before marshaling the seccomp config so that
@@ -358,7 +358,7 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 				os.RemoveAll(notifyDir)
 				return types.WrapInitResponse{}, http.StatusInternalServerError, err
 			}
-			go a.acceptSignalFD(ctx, signalListener, signalSocketPath, sessionID, s)
+			go a.acceptSignalFD(ctx, signalListener, signalSocketPath, sessionID, s, req.CallerUID)
 		}
 	}
 	seccompCfg.SignalFilterEnabled = signalFilterEnabled
@@ -513,7 +513,7 @@ func blockListUsesNotify(block []string, onBlock string) bool {
 
 // acceptNotifyFD listens on the Unix socket for a single connection from the CLI,
 // receives the seccomp notify fd, and starts the notify handler.
-func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketPath string, sessionID string, s *session.Session, execveEnabled bool) {
+func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketPath string, sessionID string, s *session.Session, execveEnabled bool, expectedUID int) {
 	defer listener.Close()
 	// Clean up the entire private temp directory containing the socket
 	defer os.RemoveAll(filepath.Dir(socketPath))
@@ -537,12 +537,17 @@ func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketP
 		return
 	}
 
-	// Read the notify-socket peer credentials for depth tracking.
+	// Read the notify-socket peer credentials and enforce the expected UID.
 	creds := getConnPeerCreds(unixConn)
 	notifyPeerPID := creds.PID
 	if notifyPeerPID > 0 {
 		slog.Debug("wrap: got notify-socket peer credentials",
 			"peer_pid", notifyPeerPID, "peer_uid", creds.UID, "session_id", sessionID)
+	}
+	if expectedUID > 0 && creds.UID != uint32(expectedUID) {
+		slog.Warn("wrap: rejecting notify connection from unexpected UID",
+			"peer_uid", creds.UID, "expected_uid", expectedUID, "session_id", sessionID)
+		return
 	}
 
 	file, err := unixConn.File()
@@ -571,7 +576,7 @@ func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketP
 
 // acceptSignalFD listens on the Unix socket for a single connection from the CLI,
 // receives the signal filter notify fd, and starts the signal handler.
-func (a *App) acceptSignalFD(ctx context.Context, listener net.Listener, socketPath string, sessionID string, s *session.Session) {
+func (a *App) acceptSignalFD(ctx context.Context, listener net.Listener, socketPath string, sessionID string, s *session.Session, expectedUID int) {
 	defer listener.Close()
 	// Note: do NOT remove the parent directory here — acceptNotifyFD owns that cleanup.
 
@@ -588,6 +593,13 @@ func (a *App) acceptSignalFD(ctx context.Context, listener net.Listener, socketP
 
 	unixConn, ok := conn.(*net.UnixConn)
 	if !ok {
+		return
+	}
+
+	creds := getConnPeerCreds(unixConn)
+	if expectedUID > 0 && creds.UID != uint32(expectedUID) {
+		slog.Warn("wrap: rejecting signal connection from unexpected UID",
+			"peer_uid", creds.UID, "expected_uid", expectedUID, "session_id", sessionID)
 		return
 	}
 

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -116,10 +116,7 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 		if err != nil {
 			return types.WrapInitResponse{}, http.StatusInternalServerError, err
 		}
-		if err := os.Chmod(notifyDir, 0700); err != nil {
-			os.RemoveAll(notifyDir)
-			return types.WrapInitResponse{}, http.StatusInternalServerError, err
-		}
+		chownOK := secureNotifyDir(notifyDir, req.CallerUID)
 		// Apply same path-budget + hash truncation as seccomp wrap path
 		safeID := filepath.Base(sessionID)
 		const socketPathLimit = 104
@@ -146,6 +143,7 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 			os.RemoveAll(notifyDir)
 			return types.WrapInitResponse{}, http.StatusInternalServerError, err
 		}
+		secureSocket(notifySocketPath, req.CallerUID, chownOK)
 
 		go a.acceptPtracePID(ctx, listener, notifySocketPath, sessionID)
 
@@ -238,10 +236,7 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 	if err != nil {
 		return types.WrapInitResponse{}, http.StatusInternalServerError, err
 	}
-	if err := os.Chmod(notifyDir, 0700); err != nil {
-		os.RemoveAll(notifyDir)
-		return types.WrapInitResponse{}, http.StatusInternalServerError, err
-	}
+	chownOK := secureNotifyDir(notifyDir, req.CallerUID)
 	// Unix socket paths are limited to 104 bytes (macOS) or 108 (Linux).
 	// Compute remaining budget for the session ID portion and hash if needed.
 	const socketPathLimit = 104 // use the most restrictive (macOS)
@@ -267,6 +262,7 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 		os.RemoveAll(notifyDir)
 		return types.WrapInitResponse{}, http.StatusInternalServerError, err
 	}
+	secureSocket(notifySocketPath, req.CallerUID, chownOK)
 
 	// Start background goroutine to accept the notify fd connection
 	go a.acceptNotifyFD(ctx, listener, notifySocketPath, sessionID, s, execveEnabled)
@@ -291,6 +287,7 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 			signalSocketPath = ""
 			signalFilterEnabled = false
 		} else {
+			secureSocket(signalSocketPath, req.CallerUID, chownOK)
 			go a.acceptSignalFD(ctx, signalListener, signalSocketPath, sessionID, s)
 		}
 	}

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -49,6 +49,32 @@ func (a *App) wrapInit(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, code, resp)
 }
 
+func secureNotifyDir(dir string, callerUID int) bool {
+	if callerUID > 0 {
+		if err := os.Chown(dir, callerUID, -1); err == nil {
+			_ = os.Chmod(dir, 0700)
+			return true
+		} else {
+			slog.Debug("wrap: failed to chown notify dir", "dir", dir, "caller_uid", callerUID, "error", err)
+			_ = os.Chmod(dir, 0711)
+			return false
+		}
+	}
+	_ = os.Chmod(dir, 0711)
+	return false
+}
+
+func secureSocket(socketPath string, callerUID int, chownOK bool) {
+	if chownOK && callerUID > 0 {
+		if err := os.Chown(socketPath, callerUID, -1); err == nil {
+			return
+		} else {
+			slog.Debug("wrap: failed to chown socket", "socket_path", socketPath, "caller_uid", callerUID, "error", err)
+		}
+	}
+	_ = os.Chmod(socketPath, 0666)
+}
+
 // wrapInitCore contains the core logic for wrap initialization.
 // Uses context.Background() (not the HTTP request context) so that
 // the notify handler stays active after the HTTP response is sent.

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -26,8 +26,9 @@ import (
 )
 
 var (
-	wrapChown = os.Chown
-	wrapChmod = os.Chmod
+	wrapChown                     = os.Chown
+	wrapChmod                     = os.Chmod
+	startNotifyHandlerForWrapHook = startNotifyHandlerForWrap
 )
 
 // wrapInit handles POST /api/v1/sessions/{id}/wrap-init.
@@ -115,6 +116,10 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 	// Use a background context so the notify handler outlives the HTTP request.
 	// The handler will be cleaned up when the session ends or the connection closes.
 	ctx := context.Background()
+
+	if req.CallerUID < 0 {
+		return types.WrapInitResponse{}, http.StatusBadRequest, fmt.Errorf("invalid caller uid: %d", req.CallerUID)
+	}
 
 	// Windows uses driver-based interception, not seccomp
 	if runtime.GOOS == "windows" {
@@ -576,7 +581,7 @@ func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketP
 	slog.Info("wrap: received notify fd", "session_id", sessionID, "fd", notifyFD.Fd())
 
 	// Start the notify handler using existing infrastructure
-	startNotifyHandlerForWrap(ctx, notifyFD, sessionID, a, execveEnabled, notifyPeerPID, s)
+	startNotifyHandlerForWrapHook(ctx, notifyFD, sessionID, a, execveEnabled, notifyPeerPID, s)
 }
 
 // acceptSignalFD listens on the Unix socket for a single connection from the CLI,

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -544,6 +544,11 @@ func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketP
 		slog.Debug("wrap: got notify-socket peer credentials",
 			"peer_pid", notifyPeerPID, "peer_uid", creds.UID, "session_id", sessionID)
 	}
+	if expectedUID < 0 {
+		slog.Warn("wrap: rejecting notify connection with invalid caller UID",
+			"expected_uid", expectedUID, "session_id", sessionID)
+		return
+	}
 	if expectedUID > 0 && creds.UID != uint32(expectedUID) {
 		slog.Warn("wrap: rejecting notify connection from unexpected UID",
 			"peer_uid", creds.UID, "expected_uid", expectedUID, "session_id", sessionID)
@@ -597,6 +602,11 @@ func (a *App) acceptSignalFD(ctx context.Context, listener net.Listener, socketP
 	}
 
 	creds := getConnPeerCreds(unixConn)
+	if expectedUID < 0 {
+		slog.Warn("wrap: rejecting signal connection with invalid caller UID",
+			"expected_uid", expectedUID, "session_id", sessionID)
+		return
+	}
 	if expectedUID > 0 && creds.UID != uint32(expectedUID) {
 		slog.Warn("wrap: rejecting signal connection from unexpected UID",
 			"peer_uid", creds.UID, "expected_uid", expectedUID, "session_id", sessionID)

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -537,11 +537,12 @@ func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketP
 		return
 	}
 
-	// Get wrapper PID from socket credentials for depth tracking
-	wrapperPID := getConnPeerPID(unixConn)
+	// Get wrapper credentials from socket credentials for depth tracking
+	creds := getConnPeerCreds(unixConn)
+	wrapperPID := creds.PID
 	if wrapperPID > 0 {
-		slog.Debug("wrap: got wrapper PID from socket credentials",
-			"wrapper_pid", wrapperPID, "session_id", sessionID)
+		slog.Debug("wrap: got wrapper credentials from socket",
+			"wrapper_pid", wrapperPID, "wrapper_uid", creds.UID, "session_id", sessionID)
 	}
 
 	file, err := unixConn.File()

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -50,17 +50,24 @@ func (a *App) wrapInit(w http.ResponseWriter, r *http.Request) {
 }
 
 func secureNotifyDir(dir string, callerUID int) bool {
+	// callerUID == 0 is the sentinel fallback path.
 	if callerUID > 0 {
 		if err := os.Chown(dir, callerUID, -1); err == nil {
-			_ = os.Chmod(dir, 0700)
+			if err := os.Chmod(dir, 0700); err != nil {
+				slog.Debug("wrap: failed to chmod notify dir", "dir", dir, "mode", "0700", "error", err)
+			}
 			return true
 		} else {
 			slog.Debug("wrap: failed to chown notify dir", "dir", dir, "caller_uid", callerUID, "error", err)
-			_ = os.Chmod(dir, 0711)
+			if err := os.Chmod(dir, 0711); err != nil {
+				slog.Debug("wrap: failed to chmod notify dir", "dir", dir, "mode", "0711", "error", err)
+			}
 			return false
 		}
 	}
-	_ = os.Chmod(dir, 0711)
+	if err := os.Chmod(dir, 0711); err != nil {
+		slog.Debug("wrap: failed to chmod notify dir", "dir", dir, "mode", "0711", "error", err)
+	}
 	return false
 }
 
@@ -72,7 +79,9 @@ func secureSocket(socketPath string, callerUID int, chownOK bool) {
 			slog.Debug("wrap: failed to chown socket", "socket_path", socketPath, "caller_uid", callerUID, "error", err)
 		}
 	}
-	_ = os.Chmod(socketPath, 0666)
+	if err := os.Chmod(socketPath, 0666); err != nil {
+		slog.Debug("wrap: failed to chmod socket", "socket_path", socketPath, "mode", "0666", "error", err)
+	}
 }
 
 // wrapInitCore contains the core logic for wrap initialization.

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -25,6 +25,11 @@ import (
 	"github.com/google/uuid"
 )
 
+var (
+	wrapChown = os.Chown
+	wrapChmod = os.Chmod
+)
+
 // wrapInit handles POST /api/v1/sessions/{id}/wrap-init.
 // It returns the seccomp wrapper configuration for the CLI to launch the agent
 // through the wrapper, and starts listening for the notify fd on a Unix socket.
@@ -52,10 +57,10 @@ func (a *App) wrapInit(w http.ResponseWriter, r *http.Request) {
 func secureNotifyDir(dir string, callerUID int) bool {
 	// callerUID == 0 is the sentinel fallback path.
 	if callerUID > 0 {
-		if err := os.Chown(dir, callerUID, -1); err == nil {
-			if err := os.Chmod(dir, 0700); err != nil {
+		if err := wrapChown(dir, callerUID, -1); err == nil {
+			if err := wrapChmod(dir, 0700); err != nil {
 				slog.Debug("wrap: failed to chmod notify dir", "dir", dir, "mode", "0700", "error", err)
-				if err := os.Chmod(dir, 0711); err != nil {
+				if err := wrapChmod(dir, 0711); err != nil {
 					slog.Debug("wrap: failed to chmod notify dir", "dir", dir, "mode", "0711", "error", err)
 				}
 				return false
@@ -63,13 +68,13 @@ func secureNotifyDir(dir string, callerUID int) bool {
 			return true
 		} else {
 			slog.Debug("wrap: failed to chown notify dir", "dir", dir, "caller_uid", callerUID, "error", err)
-			if err := os.Chmod(dir, 0711); err != nil {
+			if err := wrapChmod(dir, 0711); err != nil {
 				slog.Debug("wrap: failed to chmod notify dir", "dir", dir, "mode", "0711", "error", err)
 			}
 			return false
 		}
 	}
-	if err := os.Chmod(dir, 0711); err != nil {
+	if err := wrapChmod(dir, 0711); err != nil {
 		slog.Debug("wrap: failed to chmod notify dir", "dir", dir, "mode", "0711", "error", err)
 	}
 	return false
@@ -77,15 +82,30 @@ func secureNotifyDir(dir string, callerUID int) bool {
 
 func secureSocket(socketPath string, callerUID int, chownOK bool) {
 	if chownOK && callerUID > 0 {
-		if err := os.Chown(socketPath, callerUID, -1); err == nil {
+		if err := wrapChown(socketPath, callerUID, -1); err == nil {
+			if err := wrapChmod(socketPath, 0600); err != nil {
+				slog.Debug("wrap: failed to chmod socket", "socket_path", socketPath, "mode", "0600", "error", err)
+			}
 			return
 		} else {
 			slog.Debug("wrap: failed to chown socket", "socket_path", socketPath, "caller_uid", callerUID, "error", err)
 		}
 	}
-	if err := os.Chmod(socketPath, 0666); err != nil {
+	if err := wrapChmod(socketPath, 0666); err != nil {
 		slog.Debug("wrap: failed to chmod socket", "socket_path", socketPath, "mode", "0666", "error", err)
 	}
+}
+
+func validatePermissionMode(path string, want os.FileMode, kind string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	got := info.Mode().Perm()
+	if got != want {
+		return fmt.Errorf("wrap: %s permissions not established for %s: got %04o want %04o", kind, path, got, want)
+	}
+	return nil
 }
 
 // wrapInitCore contains the core logic for wrap initialization.
@@ -144,6 +164,26 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 			return types.WrapInitResponse{}, http.StatusInternalServerError, err
 		}
 		secureSocket(notifySocketPath, req.CallerUID, chownOK)
+		if err := validatePermissionMode(notifyDir, func() os.FileMode {
+			if chownOK {
+				return 0700
+			}
+			return 0711
+		}(), "notify directory"); err != nil {
+			_ = listener.Close()
+			os.RemoveAll(notifyDir)
+			return types.WrapInitResponse{}, http.StatusInternalServerError, err
+		}
+		if err := validatePermissionMode(notifySocketPath, func() os.FileMode {
+			if chownOK {
+				return 0600
+			}
+			return 0666
+		}(), "notify socket"); err != nil {
+			_ = listener.Close()
+			os.RemoveAll(notifyDir)
+			return types.WrapInitResponse{}, http.StatusInternalServerError, err
+		}
 
 		go a.acceptPtracePID(ctx, listener, notifySocketPath, sessionID)
 
@@ -237,6 +277,15 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 		return types.WrapInitResponse{}, http.StatusInternalServerError, err
 	}
 	chownOK := secureNotifyDir(notifyDir, req.CallerUID)
+	if err := validatePermissionMode(notifyDir, func() os.FileMode {
+		if chownOK {
+			return 0700
+		}
+		return 0711
+	}(), "notify directory"); err != nil {
+		os.RemoveAll(notifyDir)
+		return types.WrapInitResponse{}, http.StatusInternalServerError, err
+	}
 	// Unix socket paths are limited to 104 bytes (macOS) or 108 (Linux).
 	// Compute remaining budget for the session ID portion and hash if needed.
 	const socketPathLimit = 104 // use the most restrictive (macOS)
@@ -263,6 +312,16 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 		return types.WrapInitResponse{}, http.StatusInternalServerError, err
 	}
 	secureSocket(notifySocketPath, req.CallerUID, chownOK)
+	if err := validatePermissionMode(notifySocketPath, func() os.FileMode {
+		if chownOK {
+			return 0600
+		}
+		return 0666
+	}(), "notify socket"); err != nil {
+		_ = listener.Close()
+		os.RemoveAll(notifyDir)
+		return types.WrapInitResponse{}, http.StatusInternalServerError, err
+	}
 
 	// Start background goroutine to accept the notify fd connection
 	go a.acceptNotifyFD(ctx, listener, notifySocketPath, sessionID, s, execveEnabled)
@@ -288,6 +347,17 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 			signalFilterEnabled = false
 		} else {
 			secureSocket(signalSocketPath, req.CallerUID, chownOK)
+			if err := validatePermissionMode(signalSocketPath, func() os.FileMode {
+				if chownOK {
+					return 0600
+				}
+				return 0666
+			}(), "signal socket"); err != nil {
+				_ = signalListener.Close()
+				_ = listener.Close()
+				os.RemoveAll(notifyDir)
+				return types.WrapInitResponse{}, http.StatusInternalServerError, err
+			}
 			go a.acceptSignalFD(ctx, signalListener, signalSocketPath, sessionID, s)
 		}
 	}

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -530,19 +530,19 @@ func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketP
 	}
 	defer conn.Close()
 
-	// Receive the notify fd from the CLI via SCM_RIGHTS
+	// Receive the notify fd from the CLI peer via SCM_RIGHTS.
 	unixConn, ok := conn.(*net.UnixConn)
 	if !ok {
 		slog.Debug("wrap: connection is not a Unix connection", "session_id", sessionID)
 		return
 	}
 
-	// Get wrapper credentials from socket credentials for depth tracking
+	// Read the notify-socket peer credentials for depth tracking.
 	creds := getConnPeerCreds(unixConn)
-	wrapperPID := creds.PID
-	if wrapperPID > 0 {
-		slog.Debug("wrap: got wrapper credentials from socket",
-			"wrapper_pid", wrapperPID, "wrapper_uid", creds.UID, "session_id", sessionID)
+	notifyPeerPID := creds.PID
+	if notifyPeerPID > 0 {
+		slog.Debug("wrap: got notify-socket peer credentials",
+			"peer_pid", notifyPeerPID, "peer_uid", creds.UID, "session_id", sessionID)
 	}
 
 	file, err := unixConn.File()
@@ -566,7 +566,7 @@ func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketP
 	slog.Info("wrap: received notify fd", "session_id", sessionID, "fd", notifyFD.Fd())
 
 	// Start the notify handler using existing infrastructure
-	startNotifyHandlerForWrap(ctx, notifyFD, sessionID, a, execveEnabled, wrapperPID, s)
+	startNotifyHandlerForWrap(ctx, notifyFD, sessionID, a, execveEnabled, notifyPeerPID, s)
 }
 
 // acceptSignalFD listens on the Unix socket for a single connection from the CLI,

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -117,10 +117,6 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 	// The handler will be cleaned up when the session ends or the connection closes.
 	ctx := context.Background()
 
-	if req.CallerUID < 0 {
-		return types.WrapInitResponse{}, http.StatusBadRequest, fmt.Errorf("invalid caller uid: %d", req.CallerUID)
-	}
-
 	// Windows uses driver-based interception, not seccomp
 	if runtime.GOOS == "windows" {
 		return a.wrapInitWindows(ctx, s, sessionID, req)
@@ -129,6 +125,10 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 	// Only supported on Linux (seccomp) otherwise
 	if runtime.GOOS != "linux" {
 		return types.WrapInitResponse{}, http.StatusBadRequest, errWrapNotSupported
+	}
+
+	if req.CallerUID < 0 {
+		return types.WrapInitResponse{}, http.StatusBadRequest, fmt.Errorf("invalid caller uid: %d", req.CallerUID)
 	}
 
 	// Ptrace mode: skip seccomp wrapper entirely. Create a socket for PID handshake.
@@ -528,37 +528,48 @@ func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketP
 		dl.SetDeadline(time.Now().Add(30 * time.Second))
 	}
 
-	conn, err := listener.Accept()
-	if err != nil {
-		slog.Debug("wrap: failed to accept notify connection", "session_id", sessionID, "error", err)
-		return
+	var conn net.Conn
+	var notifyPeerPID int
+	for {
+		nextConn, err := listener.Accept()
+		if err != nil {
+			slog.Debug("wrap: failed to accept notify connection", "session_id", sessionID, "error", err)
+			return
+		}
+
+		unixConn, ok := nextConn.(*net.UnixConn)
+		if !ok {
+			_ = nextConn.Close()
+			slog.Debug("wrap: connection is not a Unix connection", "session_id", sessionID)
+			continue
+		}
+
+		// Read the notify-socket peer credentials and enforce the expected UID.
+		creds := getConnPeerCreds(unixConn)
+		notifyPeerPID = creds.PID
+		if notifyPeerPID > 0 {
+			slog.Debug("wrap: got notify-socket peer credentials",
+				"peer_pid", notifyPeerPID, "peer_uid", creds.UID, "session_id", sessionID)
+		}
+		if expectedUID < 0 {
+			_ = nextConn.Close()
+			slog.Warn("wrap: rejecting notify connection with invalid caller UID",
+				"expected_uid", expectedUID, "session_id", sessionID)
+			return
+		}
+		if expectedUID > 0 && creds.UID != uint32(expectedUID) {
+			_ = nextConn.Close()
+			slog.Warn("wrap: rejecting notify connection from unexpected UID",
+				"peer_uid", creds.UID, "expected_uid", expectedUID, "session_id", sessionID)
+			continue
+		}
+
+		conn = nextConn
+		break
 	}
 	defer conn.Close()
 
-	// Receive the notify fd from the CLI peer via SCM_RIGHTS.
-	unixConn, ok := conn.(*net.UnixConn)
-	if !ok {
-		slog.Debug("wrap: connection is not a Unix connection", "session_id", sessionID)
-		return
-	}
-
-	// Read the notify-socket peer credentials and enforce the expected UID.
-	creds := getConnPeerCreds(unixConn)
-	notifyPeerPID := creds.PID
-	if notifyPeerPID > 0 {
-		slog.Debug("wrap: got notify-socket peer credentials",
-			"peer_pid", notifyPeerPID, "peer_uid", creds.UID, "session_id", sessionID)
-	}
-	if expectedUID < 0 {
-		slog.Warn("wrap: rejecting notify connection with invalid caller UID",
-			"expected_uid", expectedUID, "session_id", sessionID)
-		return
-	}
-	if expectedUID > 0 && creds.UID != uint32(expectedUID) {
-		slog.Warn("wrap: rejecting notify connection from unexpected UID",
-			"peer_uid", creds.UID, "expected_uid", expectedUID, "session_id", sessionID)
-		return
-	}
+	unixConn := conn.(*net.UnixConn)
 
 	file, err := unixConn.File()
 	if err != nil {
@@ -594,29 +605,40 @@ func (a *App) acceptSignalFD(ctx context.Context, listener net.Listener, socketP
 		dl.SetDeadline(time.Now().Add(30 * time.Second))
 	}
 
-	conn, err := listener.Accept()
-	if err != nil {
-		slog.Debug("wrap: failed to accept signal connection", "session_id", sessionID, "error", err)
-		return
+	var conn net.Conn
+	for {
+		nextConn, err := listener.Accept()
+		if err != nil {
+			slog.Debug("wrap: failed to accept signal connection", "session_id", sessionID, "error", err)
+			return
+		}
+
+		unixConn, ok := nextConn.(*net.UnixConn)
+		if !ok {
+			_ = nextConn.Close()
+			continue
+		}
+
+		creds := getConnPeerCreds(unixConn)
+		if expectedUID < 0 {
+			_ = nextConn.Close()
+			slog.Warn("wrap: rejecting signal connection with invalid caller UID",
+				"expected_uid", expectedUID, "session_id", sessionID)
+			return
+		}
+		if expectedUID > 0 && creds.UID != uint32(expectedUID) {
+			_ = nextConn.Close()
+			slog.Warn("wrap: rejecting signal connection from unexpected UID",
+				"peer_uid", creds.UID, "expected_uid", expectedUID, "session_id", sessionID)
+			continue
+		}
+
+		conn = nextConn
+		break
 	}
 	defer conn.Close()
 
-	unixConn, ok := conn.(*net.UnixConn)
-	if !ok {
-		return
-	}
-
-	creds := getConnPeerCreds(unixConn)
-	if expectedUID < 0 {
-		slog.Warn("wrap: rejecting signal connection with invalid caller UID",
-			"expected_uid", expectedUID, "session_id", sessionID)
-		return
-	}
-	if expectedUID > 0 && creds.UID != uint32(expectedUID) {
-		slog.Warn("wrap: rejecting signal connection from unexpected UID",
-			"peer_uid", creds.UID, "expected_uid", expectedUID, "session_id", sessionID)
-		return
-	}
+	unixConn := conn.(*net.UnixConn)
 
 	file, err := unixConn.File()
 	if err != nil {

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -262,6 +262,12 @@ func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socket
 	}
 
 	creds := getConnPeerCreds(unixConn)
+	if expectedUID < 0 {
+		conn.Close()
+		slog.Warn("ptrace wrap: rejecting connection with invalid caller UID",
+			"expected_uid", expectedUID, "session_id", sessionID)
+		return
+	}
 	if expectedUID > 0 && creds.UID != uint32(expectedUID) {
 		conn.Close()
 		slog.Warn("ptrace wrap: rejecting connection from unexpected UID",

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -239,7 +239,7 @@ func getConnPeerCreds(conn *net.UnixConn) peerCreds {
 // acceptPtracePID accepts a connection on the notify socket, extracts the peer
 // PID via SO_PEERCRED, and attaches the ptrace tracer. The connection is kept
 // open as a keepalive — when the shell exits, the connection closes.
-func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string) {
+func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string, expectedUID int) {
 	defer listener.Close()
 	defer os.RemoveAll(filepath.Dir(socketPath))
 
@@ -251,6 +251,21 @@ func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socket
 	conn, err := listener.Accept()
 	if err != nil {
 		slog.Error("ptrace wrap: accept failed", "error", err, "session_id", sessionID)
+		return
+	}
+
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		conn.Close()
+		slog.Error("ptrace wrap: connection is not a Unix connection", "session_id", sessionID)
+		return
+	}
+
+	creds := getConnPeerCreds(unixConn)
+	if expectedUID > 0 && creds.UID != uint32(expectedUID) {
+		conn.Close()
+		slog.Warn("ptrace wrap: rejecting connection from unexpected UID",
+			"peer_uid", creds.UID, "expected_uid", expectedUID, "session_id", sessionID)
 		return
 	}
 

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -248,31 +248,37 @@ func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socket
 		ul.SetDeadline(time.Now().Add(30 * time.Second))
 	}
 
-	conn, err := listener.Accept()
-	if err != nil {
-		slog.Error("ptrace wrap: accept failed", "error", err, "session_id", sessionID)
-		return
-	}
+	var conn net.Conn
+	for {
+		nextConn, err := listener.Accept()
+		if err != nil {
+			slog.Error("ptrace wrap: accept failed", "error", err, "session_id", sessionID)
+			return
+		}
 
-	unixConn, ok := conn.(*net.UnixConn)
-	if !ok {
-		conn.Close()
-		slog.Error("ptrace wrap: connection is not a Unix connection", "session_id", sessionID)
-		return
-	}
+		unixConn, ok := nextConn.(*net.UnixConn)
+		if !ok {
+			_ = nextConn.Close()
+			slog.Error("ptrace wrap: connection is not a Unix connection", "session_id", sessionID)
+			continue
+		}
 
-	creds := getConnPeerCreds(unixConn)
-	if expectedUID < 0 {
-		conn.Close()
-		slog.Warn("ptrace wrap: rejecting connection with invalid caller UID",
-			"expected_uid", expectedUID, "session_id", sessionID)
-		return
-	}
-	if expectedUID > 0 && creds.UID != uint32(expectedUID) {
-		conn.Close()
-		slog.Warn("ptrace wrap: rejecting connection from unexpected UID",
-			"peer_uid", creds.UID, "expected_uid", expectedUID, "session_id", sessionID)
-		return
+		creds := getConnPeerCreds(unixConn)
+		if expectedUID < 0 {
+			_ = nextConn.Close()
+			slog.Warn("ptrace wrap: rejecting connection with invalid caller UID",
+				"expected_uid", expectedUID, "session_id", sessionID)
+			return
+		}
+		if expectedUID > 0 && creds.UID != uint32(expectedUID) {
+			_ = nextConn.Close()
+			slog.Warn("ptrace wrap: rejecting connection from unexpected UID",
+				"peer_uid", creds.UID, "expected_uid", expectedUID, "session_id", sessionID)
+			continue
+		}
+
+		conn = nextConn
+		break
 	}
 
 	// Set read deadline for the handshake

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -221,7 +221,7 @@ func getConnPeerCreds(conn *net.UnixConn) peerCreds {
 		return peerCreds{}
 	}
 	var creds peerCreds
-	rawConn.Control(func(fd uintptr) {
+	if err := rawConn.Control(func(fd uintptr) {
 		ucred, err := unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
 		if err != nil {
 			slog.Debug("getConnPeerCreds: GetsockoptUcred failed", "error", err)
@@ -229,7 +229,10 @@ func getConnPeerCreds(conn *net.UnixConn) peerCreds {
 			creds.PID = int(ucred.Pid)
 			creds.UID = ucred.Uid
 		}
-	})
+	}); err != nil {
+		slog.Debug("getConnPeerCreds: RawConn.Control failed", "error", err)
+		return peerCreds{}
+	}
 	return creds
 }
 

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -208,23 +208,29 @@ func (a *App) wrapInitWindows(_ context.Context, _ *session.Session, _ string, _
 	return types.WrapInitResponse{}, http.StatusBadRequest, errWrapNotSupported
 }
 
-// getConnPeerPID extracts the peer process PID from a Unix connection.
-func getConnPeerPID(conn *net.UnixConn) int {
+type peerCreds struct {
+	PID int
+	UID uint32
+}
+
+// getConnPeerCreds extracts the peer process credentials from a Unix connection.
+func getConnPeerCreds(conn *net.UnixConn) peerCreds {
 	rawConn, err := conn.SyscallConn()
 	if err != nil {
-		slog.Debug("getConnPeerPID: failed to get syscall conn", "error", err)
-		return 0
+		slog.Debug("getConnPeerCreds: failed to get syscall conn", "error", err)
+		return peerCreds{}
 	}
-	var pid int
+	var creds peerCreds
 	rawConn.Control(func(fd uintptr) {
 		ucred, err := unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
 		if err != nil {
-			slog.Debug("getConnPeerPID: GetsockoptUcred failed", "error", err)
+			slog.Debug("getConnPeerCreds: GetsockoptUcred failed", "error", err)
 		} else {
-			pid = int(ucred.Pid)
+			creds.PID = int(ucred.Pid)
+			creds.UID = ucred.Uid
 		}
 	})
-	return pid
+	return creds
 }
 
 // acceptPtracePID accepts a connection on the notify socket, extracts the peer

--- a/internal/api/wrap_linux_cgo_test.go
+++ b/internal/api/wrap_linux_cgo_test.go
@@ -1,0 +1,58 @@
+//go:build linux && cgo
+
+package api
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetConnPeerCreds(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "peercreds.sock")
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	serverConnCh := make(chan *net.UnixConn, 1)
+	serverErrCh := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		unixConn, ok := conn.(*net.UnixConn)
+		if !ok {
+			serverErrCh <- err
+			return
+		}
+		serverConnCh <- unixConn
+	}()
+
+	clientConn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial unix socket: %v", err)
+	}
+	defer clientConn.Close()
+
+	var serverConn *net.UnixConn
+	select {
+	case err := <-serverErrCh:
+		t.Fatalf("accept unix socket: %v", err)
+	case serverConn = <-serverConnCh:
+	}
+	defer serverConn.Close()
+
+	creds := getConnPeerCreds(serverConn)
+	if creds.PID != os.Getpid() {
+		t.Fatalf("expected peer PID %d, got %d", os.Getpid(), creds.PID)
+	}
+	if creds.UID != uint32(os.Getuid()) {
+		t.Fatalf("expected peer UID %d, got %d", os.Getuid(), creds.UID)
+	}
+}

--- a/internal/api/wrap_linux_cgo_test.go
+++ b/internal/api/wrap_linux_cgo_test.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -28,7 +29,8 @@ func TestGetConnPeerCreds(t *testing.T) {
 		}
 		unixConn, ok := conn.(*net.UnixConn)
 		if !ok {
-			serverErrCh <- err
+			_ = conn.Close()
+			serverErrCh <- fmt.Errorf("expected *net.UnixConn, got %T", conn)
 			return
 		}
 		serverConnCh <- unixConn

--- a/internal/api/wrap_linux_test.go
+++ b/internal/api/wrap_linux_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -23,6 +24,40 @@ func waitForTestDone(t *testing.T, done <-chan struct{}) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for accept goroutine")
+	}
+}
+
+func dialUnixConn(t *testing.T, socketPath string) *net.UnixConn {
+	t.Helper()
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial unix socket: %v", err)
+	}
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		t.Fatalf("expected UnixConn, got %T", conn)
+	}
+	t.Cleanup(func() { _ = unixConn.Close() })
+	return unixConn
+}
+
+func waitForConnClosed(t *testing.T, conn net.Conn) {
+	t.Helper()
+
+	if err := conn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	buf := make([]byte, 1)
+	n, err := conn.Read(buf)
+	if n != 0 {
+		t.Fatalf("expected closed connection, read %d bytes", n)
+	}
+	if err == nil {
+		t.Fatal("expected connection to be closed")
+	}
+	if !errors.Is(err, net.ErrClosed) && !errors.Is(err, io.EOF) && !errors.Is(err, syscall.ECONNRESET) {
+		t.Fatalf("expected closed connection, got %v", err)
 	}
 }
 
@@ -88,27 +123,16 @@ func TestAcceptNotifyFD_RejectsWrongUID(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = conn.Close() })
 
-	waitForTestDone(t, done)
 	select {
 	case <-called:
 		t.Fatal("expected notify handoff to be rejected")
 	default:
 	}
 
-	if err := conn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
-		t.Fatalf("set read deadline: %v", err)
-	}
-	buf := make([]byte, 1)
-	n, err := conn.Read(buf)
-	if n != 0 {
-		t.Fatalf("expected closed connection, read %d bytes", n)
-	}
-	if err == nil {
-		t.Fatal("expected connection to be closed")
-	}
-	if !errors.Is(err, net.ErrClosed) && !errors.Is(err, io.EOF) {
-		t.Fatalf("expected closed connection, got %v", err)
-	}
+	waitForConnClosed(t, conn)
+
+	_ = listener.Close()
+	waitForTestDone(t, done)
 }
 
 func TestAcceptNotifyFD_RejectsNegativeUID(t *testing.T) {
@@ -275,4 +299,100 @@ func TestAcceptNotifyFD_AcceptsLegacyZeroUID(t *testing.T) {
 	default:
 		t.Fatal("expected notify handoff to be called")
 	}
+}
+
+func TestAcceptNotifyFD_ContinuesAfterWrongUID(t *testing.T) {
+	cfg := &config.Config{}
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "notify.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptNotifyFD(context.Background(), listener, socketPath, s.ID, s, false, os.Getuid()+1)
+	}()
+
+	firstConn := dialUnixConn(t, socketPath)
+	waitForConnClosed(t, firstConn)
+
+	secondConn := dialUnixConn(t, socketPath)
+	waitForConnClosed(t, secondConn)
+
+	_ = listener.Close()
+	waitForTestDone(t, done)
+}
+
+func TestAcceptSignalFD_ContinuesAfterWrongUID(t *testing.T) {
+	cfg := &config.Config{}
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "signal.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptSignalFD(context.Background(), listener, socketPath, s.ID, s, os.Getuid()+1)
+	}()
+
+	firstConn := dialUnixConn(t, socketPath)
+	waitForConnClosed(t, firstConn)
+
+	secondConn := dialUnixConn(t, socketPath)
+	waitForConnClosed(t, secondConn)
+
+	_ = listener.Close()
+	waitForTestDone(t, done)
+}
+
+func TestAcceptPtracePID_ContinuesAfterWrongUID(t *testing.T) {
+	cfg := &config.Config{}
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "ptrace.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptPtracePID(context.Background(), listener, socketPath, s.ID, os.Getuid()+1)
+	}()
+
+	firstConn := dialUnixConn(t, socketPath)
+	waitForConnClosed(t, firstConn)
+
+	secondConn := dialUnixConn(t, socketPath)
+	waitForConnClosed(t, secondConn)
+
+	_ = listener.Close()
+	waitForTestDone(t, done)
 }

--- a/internal/api/wrap_linux_test.go
+++ b/internal/api/wrap_linux_test.go
@@ -141,27 +141,26 @@ func TestAcceptNotifyFD_RejectsNegativeUID(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = conn.Close() })
 
-	unixConn, ok := conn.(*net.UnixConn)
-	if !ok {
-		t.Fatal("expected UnixConn")
-	}
-
-	pipeR, pipeW, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = pipeR.Close()
-		_ = pipeW.Close()
-	})
-
-	sendFDOverUnixConn(t, unixConn, int(pipeR.Fd()))
-
 	waitForTestDone(t, done)
 	select {
 	case <-called:
 		t.Fatal("expected notify handoff to be rejected")
 	default:
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	buf := make([]byte, 1)
+	n, err := conn.Read(buf)
+	if n != 0 {
+		t.Fatalf("expected closed connection, read %d bytes", n)
+	}
+	if err == nil {
+		t.Fatal("expected connection to be closed")
+	}
+	if !errors.Is(err, net.ErrClosed) && !errors.Is(err, io.EOF) {
+		t.Fatalf("expected closed connection, got %v", err)
 	}
 }
 

--- a/internal/api/wrap_linux_test.go
+++ b/internal/api/wrap_linux_test.go
@@ -86,7 +86,106 @@ func TestAcceptNotifyFD_RejectsWrongUID(t *testing.T) {
 	}
 }
 
-func TestAcceptNotifyFD_AcceptsCorrectUID(t *testing.T) {
+func TestAcceptNotifyFD_RejectsNegativeUID(t *testing.T) {
+	cfg := &config.Config{}
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "notify.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptNotifyFD(context.Background(), listener, socketPath, s.ID, s, false, -1)
+	}()
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		t.Fatal("expected UnixConn")
+	}
+
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = pipeR.Close()
+		_ = pipeW.Close()
+	})
+
+	sendFDOverUnixConn(t, unixConn, int(pipeR.Fd()))
+
+	waitForTestDone(t, done)
+}
+
+func TestAcceptNotifyFD_AcceptsMatchingUID(t *testing.T) {
+	currentUID := os.Getuid()
+	if currentUID == 0 {
+		t.Skip("legacy root sentinel keeps UID 0 permissive")
+	}
+
+	cfg := &config.Config{}
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "notify.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptNotifyFD(context.Background(), listener, socketPath, s.ID, s, false, currentUID)
+	}()
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		t.Fatal("expected UnixConn")
+	}
+
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = pipeR.Close()
+		_ = pipeW.Close()
+	})
+
+	sendFDOverUnixConn(t, unixConn, int(pipeR.Fd()))
+
+	waitForTestDone(t, done)
+}
+
+func TestAcceptNotifyFD_AcceptsLegacyZeroUID(t *testing.T) {
 	cfg := &config.Config{}
 	app, mgr := newTestAppForWrap(t, cfg)
 	s, err := mgr.Create(t.TempDir(), "default")

--- a/internal/api/wrap_linux_test.go
+++ b/internal/api/wrap_linux_test.go
@@ -1,0 +1,134 @@
+//go:build linux
+
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"golang.org/x/sys/unix"
+)
+
+func waitForTestDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for accept goroutine")
+	}
+}
+
+func sendFDOverUnixConn(t *testing.T, conn *net.UnixConn, fd int) {
+	t.Helper()
+
+	file, err := conn.File()
+	if err != nil {
+		t.Fatalf("get file from connection: %v", err)
+	}
+	defer file.Close()
+
+	rights := unix.UnixRights(fd)
+	if err := unix.Sendmsg(int(file.Fd()), []byte{0}, rights, nil, 0); err != nil {
+		t.Fatalf("sendmsg: %v", err)
+	}
+}
+
+func TestAcceptNotifyFD_RejectsWrongUID(t *testing.T) {
+	cfg := &config.Config{}
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "notify.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptNotifyFD(context.Background(), listener, socketPath, s.ID, s, false, 99999)
+	}()
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	waitForTestDone(t, done)
+
+	if err := conn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	buf := make([]byte, 1)
+	n, err := conn.Read(buf)
+	if n != 0 {
+		t.Fatalf("expected closed connection, read %d bytes", n)
+	}
+	if err == nil {
+		t.Fatal("expected connection to be closed")
+	}
+	if !errors.Is(err, net.ErrClosed) && !errors.Is(err, io.EOF) {
+		t.Fatalf("expected closed connection, got %v", err)
+	}
+}
+
+func TestAcceptNotifyFD_AcceptsCorrectUID(t *testing.T) {
+	cfg := &config.Config{}
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "notify.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptNotifyFD(context.Background(), listener, socketPath, s.ID, s, false, 0)
+	}()
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		t.Fatal("expected UnixConn")
+	}
+
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = pipeR.Close()
+		_ = pipeW.Close()
+	})
+
+	sendFDOverUnixConn(t, unixConn, int(pipeR.Fd()))
+
+	waitForTestDone(t, done)
+}

--- a/internal/api/wrap_linux_test.go
+++ b/internal/api/wrap_linux_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/session"
 	"golang.org/x/sys/unix"
 )
 
@@ -40,7 +41,26 @@ func sendFDOverUnixConn(t *testing.T, conn *net.UnixConn, fd int) {
 	}
 }
 
+func withNotifyHandoffHook(t *testing.T) chan struct{} {
+	t.Helper()
+
+	called := make(chan struct{})
+	prev := startNotifyHandlerForWrapHook
+	startNotifyHandlerForWrapHook = func(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session) {
+		if notifyFD != nil {
+			_ = notifyFD.Close()
+		}
+		close(called)
+	}
+	t.Cleanup(func() {
+		startNotifyHandlerForWrapHook = prev
+	})
+	return called
+}
+
 func TestAcceptNotifyFD_RejectsWrongUID(t *testing.T) {
+	called := withNotifyHandoffHook(t)
+
 	cfg := &config.Config{}
 	app, mgr := newTestAppForWrap(t, cfg)
 	s, err := mgr.Create(t.TempDir(), "default")
@@ -69,6 +89,11 @@ func TestAcceptNotifyFD_RejectsWrongUID(t *testing.T) {
 	t.Cleanup(func() { _ = conn.Close() })
 
 	waitForTestDone(t, done)
+	select {
+	case <-called:
+		t.Fatal("expected notify handoff to be rejected")
+	default:
+	}
 
 	if err := conn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
 		t.Fatalf("set read deadline: %v", err)
@@ -87,6 +112,8 @@ func TestAcceptNotifyFD_RejectsWrongUID(t *testing.T) {
 }
 
 func TestAcceptNotifyFD_RejectsNegativeUID(t *testing.T) {
+	called := withNotifyHandoffHook(t)
+
 	cfg := &config.Config{}
 	app, mgr := newTestAppForWrap(t, cfg)
 	s, err := mgr.Create(t.TempDir(), "default")
@@ -131,6 +158,11 @@ func TestAcceptNotifyFD_RejectsNegativeUID(t *testing.T) {
 	sendFDOverUnixConn(t, unixConn, int(pipeR.Fd()))
 
 	waitForTestDone(t, done)
+	select {
+	case <-called:
+		t.Fatal("expected notify handoff to be rejected")
+	default:
+	}
 }
 
 func TestAcceptNotifyFD_AcceptsMatchingUID(t *testing.T) {
@@ -138,6 +170,8 @@ func TestAcceptNotifyFD_AcceptsMatchingUID(t *testing.T) {
 	if currentUID == 0 {
 		t.Skip("legacy root sentinel keeps UID 0 permissive")
 	}
+
+	called := withNotifyHandoffHook(t)
 
 	cfg := &config.Config{}
 	app, mgr := newTestAppForWrap(t, cfg)
@@ -183,9 +217,16 @@ func TestAcceptNotifyFD_AcceptsMatchingUID(t *testing.T) {
 	sendFDOverUnixConn(t, unixConn, int(pipeR.Fd()))
 
 	waitForTestDone(t, done)
+	select {
+	case <-called:
+	default:
+		t.Fatal("expected notify handoff to be called")
+	}
 }
 
 func TestAcceptNotifyFD_AcceptsLegacyZeroUID(t *testing.T) {
+	called := withNotifyHandoffHook(t)
+
 	cfg := &config.Config{}
 	app, mgr := newTestAppForWrap(t, cfg)
 	s, err := mgr.Create(t.TempDir(), "default")
@@ -230,4 +271,9 @@ func TestAcceptNotifyFD_AcceptsLegacyZeroUID(t *testing.T) {
 	sendFDOverUnixConn(t, unixConn, int(pipeR.Fd()))
 
 	waitForTestDone(t, done)
+	select {
+	case <-called:
+	default:
+		t.Fatal("expected notify handoff to be called")
+	}
 }

--- a/internal/api/wrap_other.go
+++ b/internal/api/wrap_other.go
@@ -18,6 +18,11 @@ var (
 	errWrapperNotFound  = errors.New("seccomp wrapper binary not found")
 )
 
+type peerCreds struct {
+	PID int
+	UID uint32
+}
+
 func recvFDFromConn(sock *os.File) (*os.File, error) {
 	return nil, errWrapNotSupported
 }
@@ -36,8 +41,8 @@ func (a *App) wrapInitWindows(ctx context.Context, s *session.Session, sessionID
 	return types.WrapInitResponse{}, http.StatusBadRequest, errWrapNotSupported
 }
 
-func getConnPeerPID(conn *net.UnixConn) int {
-	return 0
+func getConnPeerCreds(conn *net.UnixConn) peerCreds {
+	return peerCreds{}
 }
 
 func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string) {

--- a/internal/api/wrap_other.go
+++ b/internal/api/wrap_other.go
@@ -45,6 +45,6 @@ func getConnPeerCreds(conn *net.UnixConn) peerCreds {
 	return peerCreds{}
 }
 
-func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string) {
+func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string, expectedUID int) {
 	listener.Close()
 }

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -131,58 +131,6 @@ func TestSecureSocket_Fallback(t *testing.T) {
 	}
 }
 
-func TestGetConnPeerCreds(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("getConnPeerCreds is Linux-only")
-	}
-
-	dir := t.TempDir()
-	sockPath := filepath.Join(dir, "peercreds.sock")
-	listener, err := net.Listen("unix", sockPath)
-	if err != nil {
-		t.Fatalf("listen unix socket: %v", err)
-	}
-	t.Cleanup(func() { _ = listener.Close() })
-
-	serverConnCh := make(chan *net.UnixConn, 1)
-	serverErrCh := make(chan error, 1)
-	go func() {
-		conn, err := listener.Accept()
-		if err != nil {
-			serverErrCh <- err
-			return
-		}
-		unixConn, ok := conn.(*net.UnixConn)
-		if !ok {
-			serverErrCh <- err
-			return
-		}
-		serverConnCh <- unixConn
-	}()
-
-	clientConn, err := net.Dial("unix", sockPath)
-	if err != nil {
-		t.Fatalf("dial unix socket: %v", err)
-	}
-	defer clientConn.Close()
-
-	var serverConn *net.UnixConn
-	select {
-	case err := <-serverErrCh:
-		t.Fatalf("accept unix socket: %v", err)
-	case serverConn = <-serverConnCh:
-	}
-	defer serverConn.Close()
-
-	creds := getConnPeerCreds(serverConn)
-	if creds.PID <= 0 {
-		t.Fatalf("expected peer PID > 0, got %d", creds.PID)
-	}
-	if creds.UID != uint32(os.Getuid()) {
-		t.Fatalf("expected peer UID %d, got %d", os.Getuid(), creds.UID)
-	}
-}
-
 func TestWrapInit_NotifyDirPermissions_Fallback(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("wrap is Linux-only")

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -319,6 +319,10 @@ func TestWrapInit_WrapperNotFound(t *testing.T) {
 }
 
 func TestWrapInit_RejectsNegativeCallerUID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("negative caller uid validation is Linux-only")
+	}
+
 	cfg := &config.Config{}
 	app, mgr := newTestAppForWrap(t, cfg)
 

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -27,13 +27,22 @@ func newTestAppForWrap(t *testing.T, cfg *config.Config) (*App, *session.Manager
 	return app, mgr
 }
 
+func nonzeroTestUID() int {
+	// UID 0 is the helper's fallback sentinel, so pick any nonzero UID for coverage.
+	uid := os.Getuid()
+	if uid == 0 {
+		return 1
+	}
+	return uid
+}
+
 func TestSecureNotifyDir_ChownSuccess(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("secureNotifyDir is Linux-only")
 	}
 
 	dir := t.TempDir()
-	if got := secureNotifyDir(dir, os.Getuid()); !got {
+	if got := secureNotifyDir(dir, nonzeroTestUID()); !got {
 		t.Fatal("expected chown success path")
 	}
 
@@ -82,7 +91,7 @@ func TestSecureSocket_ChownOK(t *testing.T) {
 		t.Fatalf("chmod socket before helper: %v", err)
 	}
 
-	secureSocket(sockPath, os.Getuid(), true)
+	secureSocket(sockPath, nonzeroTestUID(), true)
 
 	info, err := os.Stat(sockPath)
 	if err != nil {

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -24,6 +25,100 @@ func newTestAppForWrap(t *testing.T, cfg *config.Config) (*App, *session.Manager
 	broker := events.NewBroker()
 	app := NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil)
 	return app, mgr
+}
+
+func TestSecureNotifyDir_ChownSuccess(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("secureNotifyDir is Linux-only")
+	}
+
+	dir := t.TempDir()
+	if got := secureNotifyDir(dir, os.Getuid()); !got {
+		t.Fatal("expected chown success path")
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat notify dir: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0700 {
+		t.Fatalf("expected 0700 permissions, got %04o", got)
+	}
+}
+
+func TestSecureNotifyDir_CallerUIDZero_Fallback(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("secureNotifyDir is Linux-only")
+	}
+
+	dir := t.TempDir()
+	if got := secureNotifyDir(dir, 0); got {
+		t.Fatal("expected fallback path")
+	}
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("stat notify dir: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0711 {
+		t.Fatalf("expected 0711 permissions, got %04o", got)
+	}
+}
+
+func TestSecureSocket_ChownOK(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("secureSocket is Linux-only")
+	}
+
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "socket.sock")
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	if err := os.Chmod(sockPath, 0600); err != nil {
+		t.Fatalf("chmod socket before helper: %v", err)
+	}
+
+	secureSocket(sockPath, os.Getuid(), true)
+
+	info, err := os.Stat(sockPath)
+	if err != nil {
+		t.Fatalf("stat socket: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0600 {
+		t.Fatalf("expected socket mode to stay 0600, got %04o", got)
+	}
+}
+
+func TestSecureSocket_Fallback(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("secureSocket is Linux-only")
+	}
+
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "socket.sock")
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	if err := os.Chmod(sockPath, 0600); err != nil {
+		t.Fatalf("chmod socket before helper: %v", err)
+	}
+
+	secureSocket(sockPath, os.Getuid(), false)
+
+	info, err := os.Stat(sockPath)
+	if err != nil {
+		t.Fatalf("stat socket: %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0666 {
+		t.Fatalf("expected fallback socket mode 0666, got %04o", got)
+	}
 }
 
 func TestWrapInit_SessionNotFound(t *testing.T) {

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -130,6 +130,93 @@ func TestSecureSocket_Fallback(t *testing.T) {
 	}
 }
 
+func TestWrapInit_NotifyDirPermissions_Fallback(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	app, mgr := newTestAppForWrap(t, cfg)
+	app.ptraceTracer = struct{}{}
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected status 200, got %d", code)
+	}
+
+	notifyDir := filepath.Dir(resp.NotifySocket)
+	t.Cleanup(func() { _ = os.RemoveAll(notifyDir) })
+
+	dirInfo, err := os.Stat(notifyDir)
+	if err != nil {
+		t.Fatalf("stat notify dir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0711 {
+		t.Fatalf("expected fallback notify dir mode 0711, got %04o", got)
+	}
+
+	socketInfo, err := os.Stat(resp.NotifySocket)
+	if err != nil {
+		t.Fatalf("stat notify socket: %v", err)
+	}
+	if got := socketInfo.Mode().Perm(); got != 0666 {
+		t.Fatalf("expected fallback notify socket mode 0666, got %04o", got)
+	}
+}
+
+func TestWrapInit_NotifyDirPermissions_CallerUID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    nonzeroTestUID(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected status 200, got %d", code)
+	}
+
+	notifyDir := filepath.Dir(resp.NotifySocket)
+	t.Cleanup(func() { _ = os.RemoveAll(notifyDir) })
+
+	dirInfo, err := os.Stat(notifyDir)
+	if err != nil {
+		t.Fatalf("stat notify dir: %v", err)
+	}
+	if got := dirInfo.Mode().Perm(); got != 0700 {
+		t.Fatalf("expected caller-owned notify dir mode 0700, got %04o", got)
+	}
+}
+
 func TestWrapInit_SessionNotFound(t *testing.T) {
 	cfg := &config.Config{}
 	app, _ := newTestAppForWrap(t, cfg)

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -131,6 +131,58 @@ func TestSecureSocket_Fallback(t *testing.T) {
 	}
 }
 
+func TestGetConnPeerCreds(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("getConnPeerCreds is Linux-only")
+	}
+
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "peercreds.sock")
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	serverConnCh := make(chan *net.UnixConn, 1)
+	serverErrCh := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		unixConn, ok := conn.(*net.UnixConn)
+		if !ok {
+			serverErrCh <- err
+			return
+		}
+		serverConnCh <- unixConn
+	}()
+
+	clientConn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("dial unix socket: %v", err)
+	}
+	defer clientConn.Close()
+
+	var serverConn *net.UnixConn
+	select {
+	case err := <-serverErrCh:
+		t.Fatalf("accept unix socket: %v", err)
+	case serverConn = <-serverConnCh:
+	}
+	defer serverConn.Close()
+
+	creds := getConnPeerCreds(serverConn)
+	if creds.PID <= 0 {
+		t.Fatalf("expected peer PID > 0, got %d", creds.PID)
+	}
+	if creds.UID != uint32(os.Getuid()) {
+		t.Fatalf("expected peer UID %d, got %d", os.Getuid(), creds.UID)
+	}
+}
+
 func TestWrapInit_NotifyDirPermissions_Fallback(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("wrap is Linux-only")

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -1,10 +1,7 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
-	"errors"
-	"io"
 	"net"
 	"net/http"
 	"os"
@@ -12,7 +9,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/agentsh/agentsh/internal/capabilities"
 	"github.com/agentsh/agentsh/internal/config"
@@ -21,7 +17,6 @@ import (
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/internal/store/composite"
 	"github.com/agentsh/agentsh/pkg/types"
-	"golang.org/x/sys/unix"
 )
 
 func newTestAppForWrap(t *testing.T, cfg *config.Config) (*App, *session.Manager) {
@@ -40,131 +35,6 @@ func nonzeroTestUID() int {
 		return 1
 	}
 	return uid
-}
-
-func waitForTestDone(t *testing.T, done <-chan struct{}) {
-	t.Helper()
-	select {
-	case <-done:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for accept goroutine")
-	}
-}
-
-func sendFDOverUnixConn(t *testing.T, conn *net.UnixConn, fd int) {
-	t.Helper()
-
-	file, err := conn.File()
-	if err != nil {
-		t.Fatalf("get file from connection: %v", err)
-	}
-	defer file.Close()
-
-	rights := unix.UnixRights(fd)
-	if err := unix.Sendmsg(int(file.Fd()), []byte{0}, rights, nil, 0); err != nil {
-		t.Fatalf("sendmsg: %v", err)
-	}
-}
-
-func TestAcceptNotifyFD_RejectsWrongUID(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("acceptNotifyFD is Linux-only")
-	}
-
-	cfg := &config.Config{}
-	app, mgr := newTestAppForWrap(t, cfg)
-	s, err := mgr.Create(t.TempDir(), "default")
-	if err != nil {
-		t.Fatalf("create session: %v", err)
-	}
-
-	socketDir := t.TempDir()
-	socketPath := filepath.Join(socketDir, "notify.sock")
-	listener, err := net.Listen("unix", socketPath)
-	if err != nil {
-		t.Fatalf("listen unix socket: %v", err)
-	}
-	t.Cleanup(func() { _ = listener.Close() })
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		app.acceptNotifyFD(context.Background(), listener, socketPath, s.ID, s, false, 99999)
-	}()
-
-	conn, err := net.Dial("unix", socketPath)
-	if err != nil {
-		t.Fatalf("dial unix socket: %v", err)
-	}
-	t.Cleanup(func() { _ = conn.Close() })
-
-	waitForTestDone(t, done)
-
-	if err := conn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
-		t.Fatalf("set read deadline: %v", err)
-	}
-	buf := make([]byte, 1)
-	n, err := conn.Read(buf)
-	if n != 0 {
-		t.Fatalf("expected closed connection, read %d bytes", n)
-	}
-	if err == nil {
-		t.Fatal("expected connection to be closed")
-	}
-	if !errors.Is(err, net.ErrClosed) && !errors.Is(err, io.EOF) {
-		t.Fatalf("expected closed connection, got %v", err)
-	}
-}
-
-func TestAcceptNotifyFD_AcceptsCorrectUID(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("acceptNotifyFD is Linux-only")
-	}
-
-	cfg := &config.Config{}
-	app, mgr := newTestAppForWrap(t, cfg)
-	s, err := mgr.Create(t.TempDir(), "default")
-	if err != nil {
-		t.Fatalf("create session: %v", err)
-	}
-
-	socketDir := t.TempDir()
-	socketPath := filepath.Join(socketDir, "notify.sock")
-	listener, err := net.Listen("unix", socketPath)
-	if err != nil {
-		t.Fatalf("listen unix socket: %v", err)
-	}
-	t.Cleanup(func() { _ = listener.Close() })
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		app.acceptNotifyFD(context.Background(), listener, socketPath, s.ID, s, false, 0)
-	}()
-
-	conn, err := net.Dial("unix", socketPath)
-	if err != nil {
-		t.Fatalf("dial unix socket: %v", err)
-	}
-	t.Cleanup(func() { _ = conn.Close() })
-
-	unixConn, ok := conn.(*net.UnixConn)
-	if !ok {
-		t.Fatal("expected UnixConn")
-	}
-
-	pipeR, pipeW, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = pipeR.Close()
-		_ = pipeW.Close()
-	})
-
-	sendFDOverUnixConn(t, unixConn, int(pipeR.Fd()))
-
-	waitForTestDone(t, done)
 }
 
 func TestSecureNotifyDir_ChownSuccess(t *testing.T) {

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -9,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/agentsh/agentsh/internal/capabilities"
 	"github.com/agentsh/agentsh/internal/config"
@@ -17,6 +21,7 @@ import (
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/internal/store/composite"
 	"github.com/agentsh/agentsh/pkg/types"
+	"golang.org/x/sys/unix"
 )
 
 func newTestAppForWrap(t *testing.T, cfg *config.Config) (*App, *session.Manager) {
@@ -35,6 +40,131 @@ func nonzeroTestUID() int {
 		return 1
 	}
 	return uid
+}
+
+func waitForTestDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for accept goroutine")
+	}
+}
+
+func sendFDOverUnixConn(t *testing.T, conn *net.UnixConn, fd int) {
+	t.Helper()
+
+	file, err := conn.File()
+	if err != nil {
+		t.Fatalf("get file from connection: %v", err)
+	}
+	defer file.Close()
+
+	rights := unix.UnixRights(fd)
+	if err := unix.Sendmsg(int(file.Fd()), []byte{0}, rights, nil, 0); err != nil {
+		t.Fatalf("sendmsg: %v", err)
+	}
+}
+
+func TestAcceptNotifyFD_RejectsWrongUID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("acceptNotifyFD is Linux-only")
+	}
+
+	cfg := &config.Config{}
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "notify.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptNotifyFD(context.Background(), listener, socketPath, s.ID, s, false, 99999)
+	}()
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	waitForTestDone(t, done)
+
+	if err := conn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	buf := make([]byte, 1)
+	n, err := conn.Read(buf)
+	if n != 0 {
+		t.Fatalf("expected closed connection, read %d bytes", n)
+	}
+	if err == nil {
+		t.Fatal("expected connection to be closed")
+	}
+	if !errors.Is(err, net.ErrClosed) && !errors.Is(err, io.EOF) {
+		t.Fatalf("expected closed connection, got %v", err)
+	}
+}
+
+func TestAcceptNotifyFD_AcceptsCorrectUID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("acceptNotifyFD is Linux-only")
+	}
+
+	cfg := &config.Config{}
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "notify.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptNotifyFD(context.Background(), listener, socketPath, s.ID, s, false, 0)
+	}()
+
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		t.Fatalf("dial unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		t.Fatal("expected UnixConn")
+	}
+
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = pipeR.Close()
+		_ = pipeW.Close()
+	})
+
+	sendFDOverUnixConn(t, unixConn, int(pipeR.Fd()))
+
+	waitForTestDone(t, done)
 }
 
 func TestSecureNotifyDir_ChownSuccess(t *testing.T) {

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -214,6 +215,38 @@ func TestWrapInit_NotifyDirPermissions_CallerUID(t *testing.T) {
 	}
 	if got := dirInfo.Mode().Perm(); got != 0700 {
 		t.Fatalf("expected caller-owned notify dir mode 0700, got %04o", got)
+	}
+}
+
+func TestWrapInit_NotifyDirPermissions_ValidationFailure(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	prevChmod := wrapChmod
+	wrapChmod = func(string, os.FileMode) error { return nil }
+	t.Cleanup(func() { wrapChmod = prevChmod })
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	_, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    0,
+	})
+	if err == nil {
+		t.Fatal("expected error when notify permissions are not established")
+	}
+	if code != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %d", code)
 	}
 }
 
@@ -620,6 +653,59 @@ func TestWrapInit_SignalSocketSet(t *testing.T) {
 		t.Error("expected AGENTSH_SIGNAL_SOCK_FD in wrapper env")
 	} else if fd != "4" {
 		t.Errorf("expected AGENTSH_SIGNAL_SOCK_FD=4, got %q", fd)
+	}
+}
+
+func TestWrapInit_SignalSocketPermissions_CallerUID(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	app, mgr := newTestAppForWrapWithSignalPolicy(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    nonzeroTestUID(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", code)
+	}
+	if resp.SignalSocket == "" {
+		t.Fatal("expected signal socket to be created")
+	}
+
+	notifyDir := filepath.Dir(resp.NotifySocket)
+	t.Cleanup(func() { _ = os.RemoveAll(notifyDir) })
+
+	notifyInfo, err := os.Stat(resp.NotifySocket)
+	if err != nil {
+		t.Fatalf("stat notify socket: %v", err)
+	}
+	if got := notifyInfo.Mode().Perm(); got != 0600 {
+		t.Fatalf("expected caller-owned notify socket mode 0600, got %04o", got)
+	}
+
+	signalInfo, err := os.Stat(resp.SignalSocket)
+	if err != nil {
+		t.Fatalf("stat signal socket: %v", err)
+	}
+	if got := signalInfo.Mode().Perm(); got != 0600 {
+		t.Fatalf("expected caller-owned signal socket mode 0600, got %04o", got)
+	}
+	if filepath.Dir(resp.SignalSocket) != notifyDir {
+		t.Fatalf("expected signal socket to share notify dir, got %s vs %s", filepath.Dir(resp.SignalSocket), notifyDir)
 	}
 }
 

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -141,6 +141,38 @@ func TestWrapInit_Success(t *testing.T) {
 	}
 }
 
+func TestWrapInit_CallerUIDPassedThrough(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    1000,
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected status 200, got %d", code)
+	}
+	if resp.NotifySocket == "" {
+		t.Fatal("expected notify socket path to be set")
+	}
+}
+
 func TestWrapInit_SeccompConfigContent(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("wrap is Linux-only")

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -318,6 +318,34 @@ func TestWrapInit_WrapperNotFound(t *testing.T) {
 	}
 }
 
+func TestWrapInit_RejectsNegativeCallerUID(t *testing.T) {
+	cfg := &config.Config{}
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    -1,
+	})
+
+	if err == nil {
+		t.Fatal("expected error for negative caller uid")
+	}
+	if code != http.StatusBadRequest {
+		t.Fatalf("expected status 400, got %d", code)
+	}
+	if resp.NotifySocket != "" || resp.WrapperBinary != "" || resp.StubBinary != "" {
+		t.Fatalf("expected empty wrap response on invalid caller uid, got %#v", resp)
+	}
+	if !strings.Contains(err.Error(), "invalid caller uid") {
+		t.Fatalf("expected invalid caller uid error, got %v", err)
+	}
+}
+
 func TestWrapInit_Success(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("wrap is Linux-only")

--- a/internal/api/wrap_windows.go
+++ b/internal/api/wrap_windows.go
@@ -48,7 +48,7 @@ func getConnPeerCreds(conn *net.UnixConn) peerCreds {
 	return peerCreds{}
 }
 
-func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string) {
+func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string, expectedUID int) {
 	listener.Close()
 }
 

--- a/internal/api/wrap_windows.go
+++ b/internal/api/wrap_windows.go
@@ -31,6 +31,11 @@ var (
 	errWrapperNotFound  = errors.New("agentsh-stub binary not found (agentsh-stub not in PATH)")
 )
 
+type peerCreds struct {
+	PID int
+	UID uint32
+}
+
 func recvFDFromConn(sock *os.File) (*os.File, error) {
 	return nil, fmt.Errorf("SCM_RIGHTS not available on Windows")
 }
@@ -39,8 +44,8 @@ func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID
 	// Not used on Windows — the driver handles exec interception directly.
 }
 
-func getConnPeerPID(conn *net.UnixConn) int {
-	return 0
+func getConnPeerCreds(conn *net.UnixConn) peerCreds {
+	return peerCreds{}
 }
 
 func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string) {

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -296,6 +296,7 @@ func setupWrapInterception(ctx context.Context, c client.CLIClient, sessID strin
 	wrapResp, err := c.WrapInit(ctx, sessID, types.WrapInitRequest{
 		AgentCommand: agentPath,
 		AgentArgs:    agentArgs,
+		CallerUID:    os.Getuid(),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("wrap-init: %w", err)

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os"
 	"net/url"
 	"runtime"
 	"syscall"
@@ -252,6 +253,7 @@ func TestSetupWrapInterception_CallsWrapInit(t *testing.T) {
 	assert.True(t, mc.wrapInitCalled, "WrapInit should have been called")
 	assert.Equal(t, "/bin/echo", mc.wrapInitReq.AgentCommand)
 	assert.Equal(t, []string{"hello"}, mc.wrapInitReq.AgentArgs)
+	assert.Equal(t, os.Getuid(), mc.wrapInitReq.CallerUID)
 
 	// Verify the launch config (OS-specific assertions)
 	if runtime.GOOS == "linux" {

--- a/pkg/types/sessions.go
+++ b/pkg/types/sessions.go
@@ -126,6 +126,7 @@ type SessionPatchRequest struct {
 type WrapInitRequest struct {
 	AgentCommand string   `json:"agent_command"`
 	AgentArgs    []string `json:"agent_args,omitempty"`
+	CallerUID    int      `json:"caller_uid,omitempty"`
 }
 
 // WrapInitResponse returns the seccomp wrapper configuration to the CLI.


### PR DESCRIPTION
## Summary
- thread `CallerUID` from the CLI into `wrap-init` and use it to establish per-caller socket ownership and permissions for notify/signal/ptrace sockets
- validate socket permission setup synchronously and enforce peer UID checks on notify, signal, and ptrace accept paths using `SO_PEERCRED`
- add Linux/Linux+cgo coverage for peer credentials, permission modes, UID rejection, matching-UID success, and accept-loop continuation after wrong-UID peers

## Why
`agentsh wrap` could fail or become unsafe in multi-user/root-server scenarios because socket setup relied on permissive filesystem access and a single wrong local connection could consume the only accept attempt. This change hardens the handoff by propagating caller identity, validating socket setup up front, and rejecting unexpected peers without losing the listener.

## Impact
Linux multi-user wrap flows are stricter and more resilient. Legacy clients that omit `caller_uid` still use the compatibility fallback path.

## Test Plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `GOOS=windows go build ./...`
- [x] `GOOS=darwin go build ./...`
- [x] `go test ./internal/api/ -run 'TestWrapInit_CallerUID|TestWrapInit_NotifyDirPermissions|TestSecureNotifyDir|TestSecureSocket|TestGetConnPeerCreds|TestAcceptNotifyFD|TestAcceptSignalFD_ContinuesAfterWrongUID|TestAcceptPtracePID_ContinuesAfterWrongUID' -v`

## Notes
A residual limitation remains on the explicit permissive fallback path (`CallerUID == 0` or any environment where ownership cannot be tightened): a hostile local peer can still consume the fixed 30s accept window by repeatedly reconnecting. That is an availability limitation on the fallback path, not an authorization bypass.