### PR TITLE
[codex] Gate AGENTSH_IN_SESSION on wrap interception strength

### DIFF
--- a/docs/cookbook/command-policies.md
+++ b/docs/cookbook/command-policies.md
@@ -159,8 +159,8 @@ Nested shell behavior depends on the active wrap mode. In strong interception
 paths such as ptrace or execve-intercepting wrap, descendant `sh`/`bash`
 processes bypass the shell shim because wrap is already enforcing exec policy
 for the whole tree. In fallback or no-`execve` modes, nested shells still
-depend on the shim for command steering, so `AGENTSH_IN_SESSION` is not
-injected.
+depend on the shim for command steering, so `AGENTSH_IN_SESSION` is
+intentionally not injected.
 
 ### Electron sharp edges
 

--- a/docs/cookbook/command-policies.md
+++ b/docs/cookbook/command-policies.md
@@ -155,6 +155,13 @@ No `command_rules` entry for `emdash` is needed — the binary is launched
 directly. The policy applies to everything emdash then spawns: subprocesses,
 shell commands, network, file writes.
 
+Nested shell behavior depends on the active wrap mode. In strong interception
+paths such as ptrace or execve-intercepting wrap, descendant `sh`/`bash`
+processes bypass the shell shim because wrap is already enforcing exec policy
+for the whole tree. In fallback or no-`execve` modes, nested shells still
+depend on the shim for command steering, so `AGENTSH_IN_SESSION` is not
+injected.
+
 ### Electron sharp edges
 
 Electron apps (and anything using a Chromium renderer subprocess) exercise

--- a/docs/cookbook/command-policies.md
+++ b/docs/cookbook/command-policies.md
@@ -158,9 +158,9 @@ shell commands, network, file writes.
 Nested shell behavior depends on the active wrap mode. In strong interception
 paths such as ptrace or execve-intercepting wrap, descendant `sh`/`bash`
 processes bypass the shell shim because wrap is already enforcing exec policy
-for the whole tree. In fallback or no-`execve` modes, nested shells still
-depend on the shim for command steering, so `AGENTSH_IN_SESSION` is
-intentionally not injected.
+for the whole tree. In fallback or no-`execve` modes, the wrap-launched
+agent process does not receive `AGENTSH_IN_SESSION`, because nested shells
+still need the shim for command steering.
 
 ### Electron sharp edges
 

--- a/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
@@ -1,0 +1,1721 @@
+# Phase 0 — Shared Sequence Allocator + Sink-Local Chain Contract — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor the integrity layer so the composite store allocates one shared `(sequence, generation)` tuple per event, and each chained sink computes its own sink-local HMAC via a transactional Compute → durable-write → Commit/Fatal protocol. Single-sink installations (today's bare JSONL primary) keep working with byte-identical output.
+
+**Architecture:** Two new types in `internal/audit` — `SequenceAllocator` (composite-owned, no hash state) and `SinkChain` (per-sink, owns prev_hash). The legacy `IntegrityChain.Wrap()` is preserved verbatim by composing the two new types internally. A typed `Chain *ChainState` field on `pkg/types.Event` (with `json:"-"`) carries the allocated tuple from composite to sinks; the JSON tag prevents leakage into any user-visible serializer at the type level. The composite store gains an allocator and stamps `ev.Chain` before fanout. Three verification tests assert cross-sink convergence, generation roll consistency, and transactional rollback.
+
+**Tech Stack:** Go 1.x stdlib only. Uses `sync.Mutex`, `crypto/hmac`, `crypto/sha256`, `crypto/sha512`, `errors`, `math`. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md`
+
+**Naming note:** Spec calls the SinkChain state struct `ChainState`, but `audit.ChainState` already exists for `IntegrityChain.State()` and is referenced from `internal/store/integrity_startup_test.go`, `internal/store/integrity_wrapper_test.go`. To avoid breaking those callers, this plan uses `audit.SinkChainState` for the new type. The `pkg/types.ChainState` carried on `Event.Chain` keeps the spec's name (no collision in that package).
+
+**Format version note:** The HMAC input format remains `format_version=2` — `(formatVersion | sequence | prevHash | canonicalPayload)`, no generation byte. Generation only controls when prev_hash resets to `""`. Bumping to `format_version=3` to fold generation into the HMAC is out of scope (would need verify-CLI dual-version support); cross-generation framing protection lives in the WTP wire layer per its spec.
+
+---
+
+## Files
+
+**Create:**
+- `internal/audit/sequence_allocator.go` — `SequenceAllocator` type, `AllocatorState`, `ErrSequenceOverflow` (re-exposed via this file)
+- `internal/audit/sequence_allocator_test.go` — unit tests
+- `internal/audit/sink_chain.go` — `SinkChain` type, `SinkChainState`, `ErrFatalIntegrity`, `ErrMissingChainState`
+- `internal/audit/sink_chain_test.go` — unit tests
+- `internal/store/composite/sequence_contract_test.go` — three Phase 0 verification tests
+
+**Modify:**
+- `pkg/types/events.go` — add `ChainState` type and `Event.Chain *ChainState` field with `json:"-"`
+- `internal/audit/integrity.go` — refactor `IntegrityChain` internals to compose `SequenceAllocator` + `SinkChain`; preserve all public method signatures (`NewIntegrityChain`, `NewIntegrityChainWithAlgorithm`, `Wrap`, `State`, `Restore`, `KeyFingerprint`, `VerifyHash`, `VerifyWrapped`)
+- `internal/store/composite/composite.go` — add `allocator *audit.SequenceAllocator` field, stamp `ev.Chain` in `AppendEvent` before fanout, add `NextGeneration()` method
+
+---
+
+## Task 1: Add typed `Chain` field on `pkg/types.Event`
+
+**Files:**
+- Modify: `pkg/types/events.go`
+- Test: `pkg/types/events_test.go` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+If `pkg/types/events_test.go` does not exist, create it. Otherwise append:
+
+```go
+package types
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestEvent_ChainFieldNotMarshaled is a load-bearing safety test for the
+// Phase 0 contract: the typed Chain field MUST NEVER appear in JSON output,
+// because it carries internal sink coordination state, not user-visible data.
+func TestEvent_ChainFieldNotMarshaled(t *testing.T) {
+	ev := Event{
+		ID:        "abc",
+		Timestamp: time.Unix(1700000000, 0).UTC(),
+		Type:      "file_open",
+		SessionID: "sess-1",
+		Chain: &ChainState{
+			Sequence:   42,
+			Generation: 7,
+		},
+	}
+
+	out, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(out)
+
+	for _, banned := range []string{`"chain"`, `"Chain"`, `"sequence":42`, `"generation":7`} {
+		if strings.Contains(got, banned) {
+			t.Errorf("Event JSON must not contain %q; got %s", banned, got)
+		}
+	}
+}
+
+// TestEvent_ChainFieldIgnoredOnUnmarshal verifies that decoding JSON which
+// happens to contain a "chain" key does not populate Event.Chain.
+func TestEvent_ChainFieldIgnoredOnUnmarshal(t *testing.T) {
+	raw := []byte(`{"id":"x","type":"file_open","session_id":"s","timestamp":"2024-01-02T03:04:05Z","chain":{"sequence":99,"generation":3}}`)
+	var ev Event
+	if err := json.Unmarshal(raw, &ev); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if ev.Chain != nil {
+		t.Fatalf("Chain should remain nil after unmarshal, got %+v", ev.Chain)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /home/eran/work/agentsh
+go test ./pkg/types/ -run TestEvent_ChainField -v
+```
+
+Expected: build failure ("undefined: ChainState", "Event has no field Chain") — both compile errors prove the field/type don't exist yet.
+
+- [ ] **Step 3: Add the type and field**
+
+Edit `pkg/types/events.go`. Inside the file, find the `Event` struct (currently lines 23-59) and add the `Chain` field as the LAST field of the struct, right after `Fields map[string]any \`json:"fields,omitempty"\``:
+
+```go
+	Fields map[string]any `json:"fields,omitempty"`
+
+	// Chain is the shared (sequence, generation) allocated by the composite
+	// store before fanout. Used by chained sinks to produce sink-local
+	// integrity hashes.
+	//
+	// json:"-" is load-bearing: this field must never appear in any
+	// user-visible serialization. Tested by TestEvent_ChainFieldNotMarshaled.
+	Chain *ChainState `json:"-"`
+}
+```
+
+Then add the `ChainState` type at the end of the file (after the `EventQuery` struct):
+
+```go
+// ChainState is the shared (sequence, generation) tuple stamped on each event
+// by the composite store before fanout to chained sinks. See
+// docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
+type ChainState struct {
+	Sequence   uint64
+	Generation uint32
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./pkg/types/ -run TestEvent_ChainField -v
+```
+
+Expected: PASS for both `TestEvent_ChainFieldNotMarshaled` and `TestEvent_ChainFieldIgnoredOnUnmarshal`.
+
+- [ ] **Step 5: Verify the rest of the build still compiles**
+
+```bash
+go build ./...
+```
+
+Expected: clean build, no errors. Adding a field is source-compatible with all existing code.
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: all tests pass. Adding a `nil`-by-default field changes no behavior.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pkg/types/events.go pkg/types/events_test.go
+git commit -m "$(cat <<'EOF'
+feat(types): add typed Event.Chain field for sink coordination
+
+Adds pkg/types.ChainState{Sequence, Generation} and an Event.Chain pointer
+field with json:"-" so the composite store can stamp the shared sequence
+tuple onto events without ever leaking it into JSONL, OTEL, gRPC, webhook
+or any future serializer. Tested by TestEvent_ChainFieldNotMarshaled.
+
+Phase 0 of the shared sequence allocator contract — see
+docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Implement `SequenceAllocator`
+
+**Files:**
+- Create: `internal/audit/sequence_allocator.go`
+- Create: `internal/audit/sequence_allocator_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/audit/sequence_allocator_test.go`:
+
+```go
+package audit
+
+import (
+	"errors"
+	"math"
+	"sync"
+	"testing"
+)
+
+func TestSequenceAllocator_Next_ReturnsZeroFirst(t *testing.T) {
+	a := NewSequenceAllocator()
+	seq, gen, err := a.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if seq != 0 || gen != 0 {
+		t.Fatalf("first Next() = (%d, %d), want (0, 0)", seq, gen)
+	}
+}
+
+func TestSequenceAllocator_Next_Monotonic(t *testing.T) {
+	a := NewSequenceAllocator()
+	for i := int64(0); i < 100; i++ {
+		seq, gen, err := a.Next()
+		if err != nil {
+			t.Fatalf("Next #%d: %v", i, err)
+		}
+		if seq != i {
+			t.Fatalf("Next #%d returned seq=%d, want %d", i, seq, i)
+		}
+		if gen != 0 {
+			t.Fatalf("Next #%d returned gen=%d, want 0", i, gen)
+		}
+	}
+}
+
+func TestSequenceAllocator_NextGeneration_ResetsSequence(t *testing.T) {
+	a := NewSequenceAllocator()
+	if _, _, err := a.Next(); err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if _, _, err := a.Next(); err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	// State now: sequence=1, gen=0; next Next() would return (2, 0).
+
+	newGen := a.NextGeneration()
+	if newGen != 1 {
+		t.Fatalf("NextGeneration() = %d, want 1", newGen)
+	}
+
+	seq, gen, err := a.Next()
+	if err != nil {
+		t.Fatalf("Next after NextGeneration: %v", err)
+	}
+	if seq != 0 || gen != 1 {
+		t.Fatalf("after rollover: Next() = (%d, %d), want (0, 1)", seq, gen)
+	}
+}
+
+func TestSequenceAllocator_State_Restore_RoundTrip(t *testing.T) {
+	a := NewSequenceAllocator()
+	for i := 0; i < 5; i++ {
+		if _, _, err := a.Next(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	a.NextGeneration()
+	if _, _, err := a.Next(); err != nil {
+		t.Fatal(err)
+	}
+	// State: sequence=0, gen=1.
+
+	state := a.State()
+	if state.Sequence != 0 || state.Generation != 1 {
+		t.Fatalf("State() = %+v, want {Sequence:0 Generation:1}", state)
+	}
+
+	b := NewSequenceAllocator()
+	b.Restore(state)
+	seq, gen, err := b.Next()
+	if err != nil {
+		t.Fatalf("Next after Restore: %v", err)
+	}
+	if seq != 1 || gen != 1 {
+		t.Fatalf("after restore: Next() = (%d, %d), want (1, 1)", seq, gen)
+	}
+}
+
+func TestSequenceAllocator_Overflow(t *testing.T) {
+	a := NewSequenceAllocator()
+	a.Restore(AllocatorState{Sequence: math.MaxInt64, Generation: 0})
+
+	_, _, err := a.Next()
+	if !errors.Is(err, ErrSequenceOverflow) {
+		t.Fatalf("Next at MaxInt64: err = %v, want ErrSequenceOverflow", err)
+	}
+}
+
+func TestSequenceAllocator_ConcurrentNext_NoDuplicates(t *testing.T) {
+	a := NewSequenceAllocator()
+	const workers = 8
+	const perWorker = 1000
+
+	var wg sync.WaitGroup
+	results := make(chan int64, workers*perWorker)
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				seq, _, err := a.Next()
+				if err != nil {
+					t.Errorf("Next: %v", err)
+					return
+				}
+				results <- seq
+			}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	seen := make(map[int64]bool, workers*perWorker)
+	for s := range results {
+		if seen[s] {
+			t.Fatalf("duplicate sequence: %d", s)
+		}
+		seen[s] = true
+	}
+	if len(seen) != workers*perWorker {
+		t.Fatalf("got %d unique sequences, want %d", len(seen), workers*perWorker)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/audit/ -run TestSequenceAllocator -v
+```
+
+Expected: build failure ("undefined: NewSequenceAllocator", "undefined: AllocatorState"). The type does not exist yet.
+
+- [ ] **Step 3: Implement the type**
+
+Create `internal/audit/sequence_allocator.go`:
+
+```go
+package audit
+
+import (
+	"math"
+	"sync"
+)
+
+// SequenceAllocator owns the shared (sequence, generation) tuple. It has no
+// hash state. Composite holds exactly one allocator and stamps every event
+// with the next allocated tuple before fanning out to chained sinks.
+//
+// Sequence is monotonically increasing within a generation, starting at 0.
+// Generation is incremented by NextGeneration() and resets sequence so the
+// next Next() returns (0, new_generation).
+//
+// Concurrency-safe.
+type SequenceAllocator struct {
+	mu         sync.Mutex
+	sequence   int64  // last returned sequence; -1 means "none yet"
+	generation uint32 // current generation
+}
+
+// AllocatorState captures the allocator's persistent state. Snapshot via
+// State() and rehydrate with Restore() across restarts.
+type AllocatorState struct {
+	Sequence   int64
+	Generation uint32
+}
+
+// NewSequenceAllocator creates an allocator whose first Next() returns (0, 0).
+func NewSequenceAllocator() *SequenceAllocator {
+	return &SequenceAllocator{sequence: -1}
+}
+
+// Next returns the next (sequence, generation) and advances the counter.
+// Returns ErrSequenceOverflow when sequence == math.MaxInt64; the caller
+// should treat this as fatal (it implies > 9.2e18 events in a single
+// generation, so a generation rotation is the recovery path).
+func (a *SequenceAllocator) Next() (sequence int64, generation uint32, err error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.sequence == math.MaxInt64 {
+		return 0, 0, ErrSequenceOverflow
+	}
+	a.sequence++
+	return a.sequence, a.generation, nil
+}
+
+// NextGeneration increments generation and resets sequence so the next Next()
+// returns (0, new_generation). Returns the new generation. Used by the
+// composite owner when the chain key rotates.
+func (a *SequenceAllocator) NextGeneration() uint32 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.generation++
+	a.sequence = -1
+	return a.generation
+}
+
+// State returns the current (sequence, generation) for persistence. After
+// Restore(state), the next Next() returns (state.Sequence + 1, state.Generation).
+func (a *SequenceAllocator) State() AllocatorState {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return AllocatorState{Sequence: a.sequence, Generation: a.generation}
+}
+
+// Restore rehydrates allocator state after restart.
+func (a *SequenceAllocator) Restore(state AllocatorState) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.sequence = state.Sequence
+	a.generation = state.Generation
+}
+```
+
+Note: `ErrSequenceOverflow` already exists in `internal/audit/integrity.go:51` (`var ErrSequenceOverflow = errors.New("integrity sequence overflow")`). Reusing it — do not redeclare.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/audit/ -run TestSequenceAllocator -v
+```
+
+Expected: all 6 tests PASS.
+
+- [ ] **Step 5: Run the full audit test suite**
+
+```bash
+go test ./internal/audit/ -v
+```
+
+Expected: all existing audit tests still PASS — we added a new file with no edits to existing code.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/audit/sequence_allocator.go internal/audit/sequence_allocator_test.go
+git commit -m "$(cat <<'EOF'
+feat(audit): add SequenceAllocator for shared (seq, gen) allocation
+
+Composite-owned allocator that produces a single (sequence, generation)
+tuple per event before fanout. No hash state — that lives in SinkChain
+(next commit). Concurrency-safe; reuses the existing ErrSequenceOverflow.
+
+Phase 0 — see docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Implement `SinkChain`
+
+**Files:**
+- Create: `internal/audit/sink_chain.go`
+- Create: `internal/audit/sink_chain_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/audit/sink_chain_test.go`:
+
+```go
+package audit
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// computeExpectedHash mirrors the production HMAC formula from
+// internal/audit/integrity.go: format_version | sequence | prev_hash | payload.
+// Generation is intentionally NOT in the HMAC input — see the format-version
+// note in the implementation plan.
+func computeExpectedHash(t *testing.T, key []byte, formatVersion int, sequence int64, prevHash string, payload []byte) string {
+	t.Helper()
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(strconv.Itoa(formatVersion)))
+	h.Write([]byte("|"))
+	h.Write([]byte(strconv.FormatInt(sequence, 10)))
+	h.Write([]byte("|"))
+	h.Write([]byte(prevHash))
+	h.Write([]byte("|"))
+	h.Write(payload)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func newTestSinkChain(t *testing.T) (*SinkChain, []byte) {
+	t.Helper()
+	key := make([]byte, MinKeyLength)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	c, err := NewSinkChain(key, "hmac-sha256")
+	if err != nil {
+		t.Fatalf("NewSinkChain: %v", err)
+	}
+	return c, key
+}
+
+func TestSinkChain_Compute_FirstEntryUsesEmptyPrev(t *testing.T) {
+	c, key := newTestSinkChain(t)
+	payload := []byte(`{"k":"v"}`)
+
+	entryHash, prevHash, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if prevHash != "" {
+		t.Errorf("first Compute: prevHash = %q, want empty", prevHash)
+	}
+	want := computeExpectedHash(t, key, IntegrityFormatVersion, 0, "", payload)
+	if entryHash != want {
+		t.Errorf("entryHash = %q, want %q", entryHash, want)
+	}
+}
+
+func TestSinkChain_Compute_IsPure_NoMutationWithoutCommit(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+	payload := []byte(`{"k":"v"}`)
+
+	first, _, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compute again without Commit — must produce the SAME entryHash, since
+	// prev_hash hasn't moved.
+	second, _, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Errorf("Compute mutated chain state: first=%q second=%q", first, second)
+	}
+}
+
+func TestSinkChain_Commit_AdvancesPrevHash(t *testing.T) {
+	c, key := newTestSinkChain(t)
+
+	first, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Commit(0, first)
+
+	second, prev, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prev != first {
+		t.Errorf("after Commit: prev_hash = %q, want %q", prev, first)
+	}
+	want := computeExpectedHash(t, key, IntegrityFormatVersion, 1, first, []byte(`{"b":2}`))
+	if second != want {
+		t.Errorf("second entryHash = %q, want %q", second, want)
+	}
+}
+
+func TestSinkChain_Compute_GenerationRollover_ResetsPrevToEmpty(t *testing.T) {
+	c, key := newTestSinkChain(t)
+
+	// Establish gen=0 chain with one committed entry.
+	h0, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Commit(0, h0)
+
+	// Compute at gen=1 — prev_hash should be "" automatically.
+	h1, prev, err := c.Compute(IntegrityFormatVersion, 0, 1, []byte(`{"y":2}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prev != "" {
+		t.Errorf("after gen rollover: prev_hash = %q, want empty", prev)
+	}
+	want := computeExpectedHash(t, key, IntegrityFormatVersion, 0, "", []byte(`{"y":2}`))
+	if h1 != want {
+		t.Errorf("rolled entryHash = %q, want %q", h1, want)
+	}
+
+	// Until Commit(1, h1), the chain's recorded generation is still 0.
+	state := c.State()
+	if state.Generation != 0 {
+		t.Errorf("State.Generation before Commit = %d, want 0", state.Generation)
+	}
+
+	c.Commit(1, h1)
+	state = c.State()
+	if state.Generation != 1 {
+		t.Errorf("State.Generation after Commit = %d, want 1", state.Generation)
+	}
+	if state.PrevHash != h1 {
+		t.Errorf("State.PrevHash = %q, want %q", state.PrevHash, h1)
+	}
+}
+
+func TestSinkChain_Fatal_LatchesAndBlocksFurtherCompute(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+
+	if _, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	c.Fatal(errors.New("ambiguous WAL write"))
+
+	_, _, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
+	if !errors.Is(err, ErrFatalIntegrity) {
+		t.Fatalf("Compute after Fatal: err = %v, want ErrFatalIntegrity", err)
+	}
+}
+
+func TestSinkChain_State_Restore_RoundTrip(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+
+	h0, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Commit(0, h0)
+	h1, _, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Commit(0, h1)
+
+	state := c.State()
+	if state.Generation != 0 || state.PrevHash != h1 {
+		t.Fatalf("State() = %+v, want {Generation:0 PrevHash:%q}", state, h1)
+	}
+
+	d, _ := newTestSinkChain(t)
+	d.Restore(state.Generation, state.PrevHash)
+
+	// Continue the chain from d — same key, so same entry hash as if c
+	// had continued.
+	cNext, _, err := c.Compute(IntegrityFormatVersion, 2, 0, []byte(`{"c":3}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dNext, _, err := d.Compute(IntegrityFormatVersion, 2, 0, []byte(`{"c":3}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cNext != dNext {
+		t.Errorf("after Restore: entryHash mismatch %q vs %q", cNext, dNext)
+	}
+}
+
+func TestNewSinkChain_RejectsShortKey(t *testing.T) {
+	_, err := NewSinkChain(make([]byte, MinKeyLength-1), "hmac-sha256")
+	if err == nil {
+		t.Fatal("NewSinkChain accepted a too-short key")
+	}
+	if !strings.Contains(err.Error(), "key too short") {
+		t.Errorf("error = %q, want 'key too short'", err)
+	}
+}
+
+func TestNewSinkChain_RejectsUnsupportedAlgorithm(t *testing.T) {
+	key := make([]byte, MinKeyLength)
+	_, err := NewSinkChain(key, "md5")
+	if err == nil {
+		t.Fatal("NewSinkChain accepted unsupported algorithm")
+	}
+	if !strings.Contains(err.Error(), "unsupported algorithm") {
+		t.Errorf("error = %q, want 'unsupported algorithm'", err)
+	}
+}
+
+func TestSinkChain_Concurrent_ComputeCommit_NoChainBreakage(t *testing.T) {
+	c, key := newTestSinkChain(t)
+
+	// Single owner serializes Compute+Commit pairs; this test asserts that
+	// repeated Compute under contention with Commit does not produce a
+	// chain that fails verification when replayed in committed order.
+	const N = 200
+	type record struct {
+		seq       int64
+		payload   []byte
+		entryHash string
+		prevHash  string
+	}
+	records := make([]record, 0, N)
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := int64(0); i < N; i++ {
+			payload := []byte(`{"i":` + strconv.FormatInt(i, 10) + `}`)
+			entry, prev, err := c.Compute(IntegrityFormatVersion, i, 0, payload)
+			if err != nil {
+				t.Errorf("Compute %d: %v", i, err)
+				return
+			}
+			c.Commit(0, entry)
+			mu.Lock()
+			records = append(records, record{seq: i, payload: payload, entryHash: entry, prevHash: prev})
+			mu.Unlock()
+		}
+	}()
+	wg.Wait()
+
+	// Walk records and verify chain continuity.
+	if len(records) != N {
+		t.Fatalf("got %d records, want %d", len(records), N)
+	}
+	expectedPrev := ""
+	for _, r := range records {
+		if r.prevHash != expectedPrev {
+			t.Fatalf("seq %d: prev=%q want %q", r.seq, r.prevHash, expectedPrev)
+		}
+		want := computeExpectedHash(t, key, IntegrityFormatVersion, r.seq, expectedPrev, r.payload)
+		if r.entryHash != want {
+			t.Fatalf("seq %d: entry=%q want %q", r.seq, r.entryHash, want)
+		}
+		expectedPrev = r.entryHash
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/audit/ -run TestSinkChain -v
+go test ./internal/audit/ -run TestNewSinkChain -v
+```
+
+Expected: build failure ("undefined: NewSinkChain", "undefined: ErrFatalIntegrity"). Type doesn't exist yet.
+
+- [ ] **Step 3: Implement the type**
+
+Create `internal/audit/sink_chain.go`:
+
+```go
+package audit
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// SinkChain owns prev_hash for one sink. Each chained sink holds one.
+// Compute is pure (no mutation); Commit advances prev_hash; Fatal latches
+// the chain after an ambiguous durable-write failure.
+//
+// The same (formatVersion, sequence, prevHash, payload) under different
+// keys produces different entryHash values — that is the entire point of
+// per-sink chaining.
+//
+// Concurrency-safe. Compute+Commit pairs must be issued by a single
+// goroutine in order; concurrent Compute calls with interleaved Commits
+// is supported but each Commit applies to the most recent Compute that
+// observed the same prev_hash.
+type SinkChain struct {
+	mu         sync.Mutex
+	key        []byte
+	algorithm  string
+	generation uint32
+	prevHash   string
+	fatal      bool
+}
+
+// SinkChainState is the persistent state of a SinkChain. The spec calls
+// this ChainState; renamed here to avoid colliding with the existing
+// audit.ChainState used by IntegrityChain.State().
+type SinkChainState struct {
+	Generation uint32
+	PrevHash   string
+}
+
+// ErrFatalIntegrity is returned by Compute after Fatal has been called.
+// The chain cannot be reused; the sink must be reinitialized (e.g., via
+// generation rotation).
+var ErrFatalIntegrity = errors.New("integrity chain latched fatal; sink must be reinitialized")
+
+// ErrMissingChainState is returned by chained sinks when an event arrives
+// without ev.Chain set (i.e., composite did not stamp it). Production
+// configurations with chained sinks must always run inside a composite
+// with a SequenceAllocator.
+var ErrMissingChainState = errors.New("event missing Chain field; composite did not stamp it")
+
+// NewSinkChain creates a new chain keyed by `key` (must be >= MinKeyLength).
+// Supported algorithms: "hmac-sha256" (default), "hmac-sha512".
+func NewSinkChain(key []byte, algorithm string) (*SinkChain, error) {
+	if len(key) < MinKeyLength {
+		return nil, fmt.Errorf("key too short: got %d bytes, need at least %d", len(key), MinKeyLength)
+	}
+	if algorithm == "" {
+		algorithm = "hmac-sha256"
+	}
+	switch algorithm {
+	case "hmac-sha256", "hmac-sha512":
+		// supported
+	default:
+		return nil, fmt.Errorf("unsupported algorithm %q: use hmac-sha256 or hmac-sha512", algorithm)
+	}
+	return &SinkChain{key: key, algorithm: algorithm}, nil
+}
+
+// Compute computes the HMAC of (formatVersion, sequence, prev_hash, payload)
+// using the chain's key. Compute is PURE: it does not mutate prev_hash. The
+// caller must follow with Commit on durable-write success or discard the
+// result on durable-write failure.
+//
+// If `generation` differs from the chain's current generation, prev_hash
+// is treated as "" for this Compute (chain rolls automatically). The
+// transition is committed only when Commit is called with the new generation.
+//
+// Returns ErrFatalIntegrity if Fatal was previously called.
+func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32, payload []byte) (entryHash string, prevHash string, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.fatal {
+		return "", "", ErrFatalIntegrity
+	}
+	prev := c.prevHash
+	if generation != c.generation {
+		prev = ""
+	}
+	hash, err := computeIntegrityHash(c.key, c.algorithm, formatVersion, sequence, prev, payload)
+	if err != nil {
+		return "", "", err
+	}
+	return hash, prev, nil
+}
+
+// Commit advances prev_hash to entryHash and records the generation. Must be
+// called exactly once per successful Compute, after the durable write
+// succeeds. On ambiguous failure (write may or may not have landed), the
+// caller MUST call Fatal instead; Commit and Fatal are mutually exclusive
+// per Compute.
+func (c *SinkChain) Commit(generation uint32, entryHash string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.fatal {
+		return
+	}
+	c.generation = generation
+	c.prevHash = entryHash
+}
+
+// Fatal latches the chain in an unrecoverable state. All subsequent Compute
+// calls return ErrFatalIntegrity. Used when a durable write returned an
+// ambiguous error (timeout, partial write detection) — we cannot know whether
+// the entry was persisted, so we cannot safely continue chaining.
+func (c *SinkChain) Fatal(reason error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.fatal = true
+	_ = reason // reserved for future telemetry; intentionally unused
+}
+
+// State returns the (generation, prev_hash) for persistence.
+func (c *SinkChain) State() SinkChainState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return SinkChainState{Generation: c.generation, PrevHash: c.prevHash}
+}
+
+// Restore rehydrates chain state after restart.
+func (c *SinkChain) Restore(generation uint32, prevHash string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.generation = generation
+	c.prevHash = prevHash
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/audit/ -run "TestSinkChain|TestNewSinkChain" -v
+```
+
+Expected: all 9 tests PASS.
+
+- [ ] **Step 5: Run the full audit test suite**
+
+```bash
+go test ./internal/audit/ -v
+```
+
+Expected: all existing audit tests still PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/audit/sink_chain.go internal/audit/sink_chain_test.go
+git commit -m "$(cat <<'EOF'
+feat(audit): add SinkChain with transactional Compute/Commit/Fatal
+
+Per-sink chain that owns prev_hash and exposes:
+- Compute (pure HMAC, no mutation)
+- Commit (advances prev_hash on durable-write success)
+- Fatal (latches on ambiguous durable-write failure)
+
+Generation rollover is automatic: a Compute call with a new generation uses
+prev_hash="" without mutating chain state. The transition is recorded only
+when Commit is called with the new generation.
+
+SinkChainState renamed from spec's ChainState to avoid collision with
+existing audit.ChainState used by IntegrityChain.State().
+
+Phase 0 — see docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Refactor `IntegrityChain` to compose `SequenceAllocator` + `SinkChain`
+
+The spec says `Wrap()` is preserved verbatim at the source level. This task swaps the internals of `IntegrityChain` so the existing single-sink callers (and the existing test suite) keep working.
+
+**Files:**
+- Modify: `internal/audit/integrity.go`
+
+- [ ] **Step 1: Read the current implementation**
+
+```bash
+sed -n '34,42p;199,272p' internal/audit/integrity.go
+```
+
+Confirm the existing struct fields are `mu`, `key`, `algorithm`, `sequence`, `prevHash` and the methods touched are `NewIntegrityChainWithAlgorithm`, `Wrap`, `State`, `Restore`. The existing public API is what we must preserve.
+
+- [ ] **Step 2: Replace the struct and constructors**
+
+In `internal/audit/integrity.go`, replace the existing `IntegrityChain` struct (currently lines 34-42) with the composed version:
+
+```go
+// IntegrityChain is the legacy single-sink composer of SequenceAllocator +
+// SinkChain. New code should use those two types directly via the composite
+// store's allocator and per-sink chains. Wrap/State/Restore are preserved
+// at the source level for existing callers.
+type IntegrityChain struct {
+	alloc *SequenceAllocator
+	chain *SinkChain
+}
+```
+
+Replace the body of `NewIntegrityChainWithAlgorithm` (currently lines 72-91) with:
+
+```go
+func NewIntegrityChainWithAlgorithm(key []byte, algorithm string) (*IntegrityChain, error) {
+	chain, err := NewSinkChain(key, algorithm)
+	if err != nil {
+		return nil, err
+	}
+	return &IntegrityChain{
+		alloc: NewSequenceAllocator(),
+		chain: chain,
+	}, nil
+}
+```
+
+Note: `NewSinkChain` already does the key length and algorithm validation, so we keep the same error semantics for the `IntegrityChain` constructor.
+
+- [ ] **Step 3: Replace `Wrap()` to use the composed types**
+
+Replace the body of `Wrap()` (currently lines 201-252) with:
+
+```go
+// Wrap adds integrity metadata to an event payload.
+// The payload must be valid JSON. Returns a new JSON payload with an "integrity" field.
+func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error) {
+	data, err := parseIntegrityPayloadUseNumber(payload)
+	if err != nil {
+		return nil, err
+	}
+	canonicalPayload, err := marshalCanonicalPayload(data)
+	if err != nil {
+		return nil, err
+	}
+
+	seq, gen, err := c.alloc.Next()
+	if err != nil {
+		return nil, err
+	}
+
+	entryHash, prevHash, err := c.chain.Compute(IntegrityFormatVersion, seq, gen, canonicalPayload)
+	if err != nil {
+		return nil, err
+	}
+
+	data["integrity"] = IntegrityMetadata{
+		FormatVersion: IntegrityFormatVersion,
+		Sequence:      seq,
+		PrevHash:      prevHash,
+		EntryHash:     entryHash,
+	}
+
+	result, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("marshal wrapped payload: %w", err)
+	}
+
+	c.chain.Commit(gen, entryHash)
+	return result, nil
+}
+```
+
+Single-sink callers don't expose Compute/Commit because there's no fanout; the legacy contract is "Wrap returns the bytes; if the caller's write fails, the caller never calls Wrap again on the same record." That contract is preserved — Commit happens inside Wrap.
+
+- [ ] **Step 4: Replace `State()` to delegate**
+
+Replace the body of `State()` (currently lines 254-262) with:
+
+```go
+// State returns the last written chain state for persistence.
+func (c *IntegrityChain) State() ChainState {
+	allocState := c.alloc.State()
+	chainState := c.chain.State()
+	return ChainState{
+		Sequence: allocState.Sequence,
+		PrevHash: chainState.PrevHash,
+	}
+}
+```
+
+- [ ] **Step 5: Replace `Restore()` to delegate**
+
+Replace the body of `Restore()` (currently lines 264-271) with:
+
+```go
+// Restore restores the chain state after a restart.
+// The sequence must be the last written entry so the next Wrap continues at sequence+1.
+func (c *IntegrityChain) Restore(sequence int64, prevHash string) {
+	c.alloc.Restore(AllocatorState{Sequence: sequence, Generation: 0})
+	c.chain.Restore(0, prevHash)
+}
+```
+
+Note: legacy `IntegrityChain` does not expose generation (its callers were single-sink with no rotation concept beyond key change, which today is handled via key-fingerprint mismatch detection in `internal/store/integrity_wrapper.go`). We pin generation=0 to keep behavior identical.
+
+- [ ] **Step 6: Update `KeyFingerprint()`, `VerifyHash()`, `VerifyWrapped()`, `computeHash()`**
+
+These methods used `c.key` and `c.algorithm` directly. Now they need to access the SinkChain's key. Add accessors on `SinkChain` first — edit `internal/audit/sink_chain.go` to add:
+
+```go
+// keyAndAlgorithm exposes the chain's key and algorithm for legacy
+// IntegrityChain delegation. NOT part of the public Phase 0 contract;
+// future code should use Compute and never reach for raw key material.
+func (c *SinkChain) keyAndAlgorithm() ([]byte, string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.key, c.algorithm
+}
+```
+
+Then in `internal/audit/integrity.go`, replace the four affected methods (currently lines 274-339):
+
+```go
+// KeyFingerprint returns a stable SHA-256 fingerprint prefix for the chain key.
+func (c *IntegrityChain) KeyFingerprint() string {
+	key, _ := c.chain.keyAndAlgorithm()
+	return KeyFingerprint(key)
+}
+
+// VerifyHash recomputes the canonical payload hash using the chain key and format version.
+func (c *IntegrityChain) VerifyHash(formatVersion int, sequence int64, prevHash string, payload []byte, expectedHash string) (bool, error) {
+	key, alg := c.chain.keyAndAlgorithm()
+	return VerifyHash(key, alg, formatVersion, sequence, prevHash, payload, expectedHash)
+}
+
+// VerifyWrapped verifies a wrapped payload, including integrity metadata.
+func (c *IntegrityChain) VerifyWrapped(wrapped []byte) (bool, error) {
+	key, alg := c.chain.keyAndAlgorithm()
+	return VerifyWrapped(key, alg, wrapped)
+}
+
+// computeHash computes the HMAC of: format_version || sequence || prev_hash || payload
+func (c *IntegrityChain) computeHash(formatVersion int, sequence int64, prevHash string, payload []byte) (string, error) {
+	key, alg := c.chain.keyAndAlgorithm()
+	return computeIntegrityHash(key, alg, formatVersion, sequence, prevHash, payload)
+}
+```
+
+Note: `c.computeHash()` may be unused after the Wrap refactor (Wrap now calls SinkChain.Compute, which calls computeIntegrityHash internally). Check usages and delete the method if no callers remain:
+
+```bash
+grep -rn "\.computeHash(" internal/audit/
+```
+
+If no production callers remain, delete the method.
+
+- [ ] **Step 7: Build and run the existing audit test suite**
+
+```bash
+go build ./...
+go test ./internal/audit/ -v
+```
+
+Expected: clean build; all existing audit tests PASS without modification. Tests that exercise `chain.Restore(...)`, `chain.State()`, `chain.Wrap(...)` round-trips, sequence overflow at MaxInt64 — all of these continue to behave identically.
+
+If any test fails, the most likely culprits are:
+- `Restore` not pinning generation correctly (chain.Restore(0, prevHash) is required)
+- `State()` returning wrong sequence after Wrap (allocator's `State()` is the last-returned sequence, which matches what the old code stored in `c.sequence`)
+- Overflow test expecting `c.sequence == math.MaxInt64` — the new code triggers overflow inside `c.alloc.Next()` and returns `ErrSequenceOverflow` from there, identical to the old behavior
+
+- [ ] **Step 8: Run the full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: all tests PASS, including `internal/store/` integrity wrapper tests and any callers of `audit.IntegrityChain`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/audit/integrity.go internal/audit/sink_chain.go
+git commit -m "$(cat <<'EOF'
+refactor(audit): IntegrityChain now composes SequenceAllocator + SinkChain
+
+Legacy IntegrityChain.Wrap/State/Restore preserved at the source level.
+Internals delegate to the new Phase 0 types so single-sink callers and the
+existing test suite continue to work unchanged.
+
+generation is pinned to 0 inside the legacy wrapper — IntegrityChain has
+no generation concept; key rotation today is handled by key-fingerprint
+mismatch detection in internal/store/integrity_wrapper.go.
+
+Phase 0 — see docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Refactor `composite.Store` to allocate and stamp `ev.Chain`
+
+**Files:**
+- Modify: `internal/store/composite/composite.go`
+- Test: `internal/store/composite/composite_test.go` (extend)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/store/composite/composite_test.go`. No new imports needed — the test uses only `context`, `testing`, and `types` (all already imported).
+
+```go
+type chainCapturingStore struct {
+	captured []*types.ChainState
+}
+
+func (s *chainCapturingStore) AppendEvent(ctx context.Context, ev types.Event) error {
+	if ev.Chain != nil {
+		copy := *ev.Chain
+		s.captured = append(s.captured, &copy)
+	} else {
+		s.captured = append(s.captured, nil)
+	}
+	return nil
+}
+func (s *chainCapturingStore) QueryEvents(ctx context.Context, q types.EventQuery) ([]types.Event, error) {
+	return nil, nil
+}
+func (s *chainCapturingStore) Close() error { return nil }
+
+func TestComposite_StampsChainBeforeFanout(t *testing.T) {
+	primary := &chainCapturingStore{}
+	other := &chainCapturingStore{}
+	s := New(primary, nil, other)
+
+	for i := 0; i < 5; i++ {
+		if err := s.AppendEvent(context.Background(), types.Event{ID: "e"}); err != nil {
+			t.Fatalf("AppendEvent #%d: %v", i, err)
+		}
+	}
+
+	if len(primary.captured) != 5 || len(other.captured) != 5 {
+		t.Fatalf("captured counts: primary=%d other=%d", len(primary.captured), len(other.captured))
+	}
+	for i, p := range primary.captured {
+		o := other.captured[i]
+		if p == nil || o == nil {
+			t.Fatalf("event %d: nil Chain — primary=%v other=%v", i, p, o)
+		}
+		if p.Sequence != uint64(i) || p.Generation != 0 {
+			t.Errorf("primary event %d: Chain=%+v want {Sequence:%d Generation:0}", i, p, i)
+		}
+		if *p != *o {
+			t.Errorf("event %d: sinks saw different Chain: primary=%+v other=%+v", i, p, o)
+		}
+	}
+}
+
+func TestComposite_NextGeneration_ResetsSequence(t *testing.T) {
+	primary := &chainCapturingStore{}
+	s := New(primary, nil)
+
+	for i := 0; i < 3; i++ {
+		if err := s.AppendEvent(context.Background(), types.Event{}); err != nil {
+			t.Fatalf("AppendEvent #%d: %v", i, err)
+		}
+	}
+
+	newGen := s.NextGeneration()
+	if newGen != 1 {
+		t.Fatalf("NextGeneration() = %d, want 1", newGen)
+	}
+
+	if err := s.AppendEvent(context.Background(), types.Event{}); err != nil {
+		t.Fatal(err)
+	}
+
+	last := primary.captured[len(primary.captured)-1]
+	if last == nil || last.Sequence != 0 || last.Generation != 1 {
+		t.Errorf("after rollover: Chain=%+v want {Sequence:0 Generation:1}", last)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+go test ./internal/store/composite/ -run "TestComposite_StampsChainBeforeFanout|TestComposite_NextGeneration_ResetsSequence" -v
+```
+
+Expected: build failure (`s.NextGeneration` undefined) OR test failure (`Chain` is nil because composite doesn't stamp).
+
+- [ ] **Step 3: Add allocator field and stamp logic**
+
+Edit `internal/store/composite/composite.go`. Add the audit import:
+
+```go
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/audit"
+	"github.com/agentsh/agentsh/internal/store"
+	"github.com/agentsh/agentsh/internal/store/sqlite"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+```
+
+Replace the `Store` struct and `New` constructor (currently lines 14-23):
+
+```go
+type Store struct {
+	primary       store.EventStore
+	output        store.OutputStore
+	others        []store.EventStore
+	allocator     *audit.SequenceAllocator
+	onAppendError func(error)
+}
+
+func New(primary store.EventStore, output store.OutputStore, others ...store.EventStore) *Store {
+	return &Store{
+		primary:   primary,
+		output:    output,
+		others:    others,
+		allocator: audit.NewSequenceAllocator(),
+	}
+}
+```
+
+Replace `AppendEvent` (currently lines 29-64) — keep all existing error-collection logic, add the allocate+stamp prologue:
+
+```go
+func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
+	seq, gen, err := s.allocator.Next()
+	if err != nil {
+		return err
+	}
+	ev.Chain = &types.ChainState{
+		Sequence:   uint64(seq),
+		Generation: gen,
+	}
+
+	var firstErr error
+	var hookErr error
+	if s.primary != nil {
+		if err := s.primary.AppendEvent(ctx, ev); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			if hookErr == nil {
+				hookErr = err
+			}
+			var fatal *store.FatalIntegrityError
+			if errors.As(err, &fatal) {
+				hookErr = fatal
+			}
+		}
+	}
+	for _, o := range s.others {
+		if err := o.AppendEvent(ctx, ev); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			if hookErr == nil {
+				hookErr = err
+			}
+			var fatal *store.FatalIntegrityError
+			if errors.As(err, &fatal) {
+				hookErr = fatal
+			}
+		}
+	}
+	if hookErr != nil && s.onAppendError != nil {
+		s.onAppendError(hookErr)
+	}
+	return firstErr
+}
+```
+
+Add `NextGeneration` method (place it directly below `AppendEvent`):
+
+```go
+// NextGeneration advances the shared sequence generation. The next
+// AppendEvent stamps ev.Chain with (Sequence:0, Generation:newGen).
+// Used by the composite owner when the chain key rotates.
+func (s *Store) NextGeneration() uint32 {
+	return s.allocator.NextGeneration()
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+go test ./internal/store/composite/ -v
+```
+
+Expected: all composite tests PASS, including the two new ones.
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: all tests PASS. The existing composite tests (`TestAppendEventCollectsFirstError`, `TestAppendEventErrorHookReceivesFirstError`, etc.) work because they use `fakeEventStore` which ignores `ev.Chain`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/store/composite/composite.go internal/store/composite/composite_test.go
+git commit -m "$(cat <<'EOF'
+feat(composite): allocate shared (seq, gen) and stamp ev.Chain before fanout
+
+Composite now owns a SequenceAllocator and stamps every event with the
+allocated tuple before invoking sinks. Sinks that chain consume ev.Chain;
+sinks that don't ignore it.
+
+Adds NextGeneration() so the composite owner (the daemon) can trigger a
+generation rollover; the next AppendEvent stamps (Sequence:0, Generation:N+1).
+
+Phase 0 — see docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Phase 0 verification tests in `sequence_contract_test.go`
+
+These are the three tests called out in the spec's `## Verification` section. They live in their own file because they exercise the contract end-to-end (allocator + chain + composite + a fake "second sink").
+
+**Files:**
+- Create: `internal/store/composite/sequence_contract_test.go`
+
+- [ ] **Step 1: Write all three contract tests**
+
+Create `internal/store/composite/sequence_contract_test.go`:
+
+```go
+package composite
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/audit"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// chainingFakeSink simulates a second chained sink. It serializes events
+// using a stable canonical encoding (id + seq + gen + payload) and runs
+// each event through its own SinkChain. Every accepted event also produces
+// a record so tests can compare what each sink saw.
+type chainingFakeSink struct {
+	chain      *audit.SinkChain
+	mu         sync.Mutex
+	records    []chainRecord
+	failNext   error // if set, the next AppendEvent fails clean (no chain advance)
+	failFatal  bool  // if set, the next AppendEvent fails ambiguously (Fatal)
+	failedSeq  int64 // sequence at which failure was injected
+}
+
+type chainRecord struct {
+	Sequence   uint64
+	Generation uint32
+	EntryHash  string
+	PrevHash   string
+}
+
+func newChainingFakeSink(t *testing.T, key []byte) *chainingFakeSink {
+	t.Helper()
+	c, err := audit.NewSinkChain(key, "hmac-sha256")
+	if err != nil {
+		t.Fatalf("NewSinkChain: %v", err)
+	}
+	return &chainingFakeSink{chain: c}
+}
+
+func (s *chainingFakeSink) AppendEvent(ctx context.Context, ev types.Event) error {
+	if ev.Chain == nil {
+		return audit.ErrMissingChainState
+	}
+	canonical := []byte(`{"id":"` + ev.ID + `","seq":` + strconv.FormatUint(ev.Chain.Sequence, 10) + `,"gen":` + strconv.FormatUint(uint64(ev.Chain.Generation), 10) + `}`)
+
+	entryHash, prevHash, err := s.chain.Compute(audit.IntegrityFormatVersion, int64(ev.Chain.Sequence), ev.Chain.Generation, canonical)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	failClean := s.failNext
+	failAmbiguous := s.failFatal
+	if failClean != nil {
+		s.failedSeq = int64(ev.Chain.Sequence)
+		s.failNext = nil
+	}
+	if failAmbiguous {
+		s.failedSeq = int64(ev.Chain.Sequence)
+		s.failFatal = false
+	}
+	s.mu.Unlock()
+
+	switch {
+	case failClean != nil:
+		// Clean failure → do NOT commit, chain unchanged.
+		return failClean
+	case failAmbiguous:
+		// Ambiguous failure → latch fatal.
+		s.chain.Fatal(errors.New("ambiguous write"))
+		return errors.New("ambiguous write")
+	default:
+		s.chain.Commit(ev.Chain.Generation, entryHash)
+		s.mu.Lock()
+		s.records = append(s.records, chainRecord{
+			Sequence:   ev.Chain.Sequence,
+			Generation: ev.Chain.Generation,
+			EntryHash:  entryHash,
+			PrevHash:   prevHash,
+		})
+		s.mu.Unlock()
+		return nil
+	}
+}
+
+func (s *chainingFakeSink) QueryEvents(ctx context.Context, q types.EventQuery) ([]types.Event, error) {
+	return nil, nil
+}
+func (s *chainingFakeSink) Close() error { return nil }
+
+func newSharedKey(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, audit.MinKeyLength)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	return key
+}
+
+// TestPhase0_CrossSinkSequenceConvergence (Spec verification #1):
+// With two chained sinks, every event's (seq, gen) matches between sinks.
+// entry_hash matches when both sinks hash identical canonical bytes with
+// the same key — but the contract only guarantees (seq, gen) convergence,
+// not entry_hash equality in general.
+func TestPhase0_CrossSinkSequenceConvergence(t *testing.T) {
+	key := newSharedKey(t)
+	a := newChainingFakeSink(t, key)
+	b := newChainingFakeSink(t, key)
+
+	s := New(a, nil, b)
+
+	const N = 10000
+	for i := 0; i < N; i++ {
+		if err := s.AppendEvent(context.Background(), types.Event{ID: strconv.Itoa(i)}); err != nil {
+			t.Fatalf("AppendEvent #%d: %v", i, err)
+		}
+	}
+
+	if len(a.records) != N || len(b.records) != N {
+		t.Fatalf("record counts: a=%d b=%d want %d", len(a.records), len(b.records), N)
+	}
+	for i := 0; i < N; i++ {
+		ar := a.records[i]
+		br := b.records[i]
+		if ar.Sequence != br.Sequence || ar.Generation != br.Generation {
+			t.Fatalf("record %d: a=(seq=%d,gen=%d) b=(seq=%d,gen=%d)", i, ar.Sequence, ar.Generation, br.Sequence, br.Generation)
+		}
+		if ar.Sequence != uint64(i) {
+			t.Fatalf("record %d: seq=%d want %d", i, ar.Sequence, i)
+		}
+		// Both sinks hashed identical canonical bytes with the same key, so
+		// entry_hash must also match. This is the narrow case where the
+		// stronger assertion holds.
+		if ar.EntryHash != br.EntryHash {
+			t.Fatalf("record %d: entry_hash mismatch a=%q b=%q", i, ar.EntryHash, br.EntryHash)
+		}
+	}
+}
+
+// TestPhase0_GenerationRollConsistency (Spec verification #2):
+// After NextGeneration(), both sinks observe the rollover at the same
+// event boundary; sequence resets to 0 in both; each sink's prev_hash
+// resets to "" independently.
+func TestPhase0_GenerationRollConsistency(t *testing.T) {
+	key := newSharedKey(t)
+	a := newChainingFakeSink(t, key)
+	b := newChainingFakeSink(t, key)
+	s := New(a, nil, b)
+
+	for i := 0; i < 3; i++ {
+		if err := s.AppendEvent(context.Background(), types.Event{ID: strconv.Itoa(i)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	gen := s.NextGeneration()
+	if gen != 1 {
+		t.Fatalf("NextGeneration() = %d, want 1", gen)
+	}
+
+	for i := 0; i < 3; i++ {
+		if err := s.AppendEvent(context.Background(), types.Event{ID: strconv.Itoa(i + 100)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if len(a.records) != 6 || len(b.records) != 6 {
+		t.Fatalf("counts: a=%d b=%d", len(a.records), len(b.records))
+	}
+
+	// Records 0..2 are gen=0 with monotonic seq; records 3..5 are gen=1
+	// with seq starting from 0.
+	expected := []struct {
+		seq uint64
+		gen uint32
+	}{
+		{0, 0}, {1, 0}, {2, 0},
+		{0, 1}, {1, 1}, {2, 1},
+	}
+	for i, want := range expected {
+		got := a.records[i]
+		if got.Sequence != want.seq || got.Generation != want.gen {
+			t.Errorf("a.records[%d] = (seq=%d, gen=%d), want (seq=%d, gen=%d)", i, got.Sequence, got.Generation, want.seq, want.gen)
+		}
+		if a.records[i] != b.records[i] {
+			t.Errorf("a.records[%d] != b.records[%d]: %+v vs %+v", i, i, a.records[i], b.records[i])
+		}
+	}
+
+	// First record after rollover MUST have prev_hash == "" — independent
+	// per-sink chain reset.
+	if a.records[3].PrevHash != "" {
+		t.Errorf("a.records[3].PrevHash = %q, want empty", a.records[3].PrevHash)
+	}
+	if b.records[3].PrevHash != "" {
+		t.Errorf("b.records[3].PrevHash = %q, want empty", b.records[3].PrevHash)
+	}
+}
+
+// TestPhase0_TransactionalRollback_CleanFailure (Spec verification #3a):
+// A clean durable-write failure does NOT advance prev_hash. After the
+// failure, a successful write of a new event uses the previous (pre-failure)
+// prev_hash — proving rollback is correct.
+func TestPhase0_TransactionalRollback_CleanFailure(t *testing.T) {
+	key := newSharedKey(t)
+	a := newChainingFakeSink(t, key)
+	s := New(a, nil)
+
+	// Three successful events first.
+	for i := 0; i < 3; i++ {
+		if err := s.AppendEvent(context.Background(), types.Event{ID: strconv.Itoa(i)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	preFailPrev := a.records[2].EntryHash
+
+	// Inject clean failure for next event.
+	cleanErr := errors.New("transient disk full")
+	a.mu.Lock()
+	a.failNext = cleanErr
+	a.mu.Unlock()
+
+	err := s.AppendEvent(context.Background(), types.Event{ID: "fail"})
+	if !errors.Is(err, cleanErr) {
+		t.Fatalf("expected clean error, got %v", err)
+	}
+
+	// Sink recorded no new entry on failure.
+	if len(a.records) != 3 {
+		t.Fatalf("record count after clean failure: %d, want 3 (no advance)", len(a.records))
+	}
+
+	// Next successful event continues from the PRE-FAILURE prev_hash, not
+	// from a phantom advanced state.
+	if err := s.AppendEvent(context.Background(), types.Event{ID: "after-fail"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := a.records[3].PrevHash; got != preFailPrev {
+		t.Errorf("after clean failure: prev_hash advanced unexpectedly. got=%q want=%q", got, preFailPrev)
+	}
+}
+
+// TestPhase0_TransactionalRollback_AmbiguousFailure (Spec verification #3b):
+// An ambiguous durable-write failure latches Fatal. Subsequent SinkChain.Compute
+// (driven by a subsequent AppendEvent) returns ErrFatalIntegrity.
+func TestPhase0_TransactionalRollback_AmbiguousFailure(t *testing.T) {
+	key := newSharedKey(t)
+	a := newChainingFakeSink(t, key)
+	s := New(a, nil)
+
+	if err := s.AppendEvent(context.Background(), types.Event{ID: "0"}); err != nil {
+		t.Fatal(err)
+	}
+
+	a.mu.Lock()
+	a.failFatal = true
+	a.mu.Unlock()
+	if err := s.AppendEvent(context.Background(), types.Event{ID: "ambig"}); err == nil {
+		t.Fatal("expected ambiguous error, got nil")
+	}
+
+	// Subsequent AppendEvent now drives Compute, which must return
+	// ErrFatalIntegrity from the latched chain.
+	err := s.AppendEvent(context.Background(), types.Event{ID: "after-ambig"})
+	if !errors.Is(err, audit.ErrFatalIntegrity) {
+		t.Fatalf("after ambiguous failure: err = %v, want ErrFatalIntegrity", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run the contract tests**
+
+```bash
+go test ./internal/store/composite/ -run TestPhase0 -v
+```
+
+Expected: all 4 tests PASS (the spec calls #3 a single test but it's cleaner to split clean and ambiguous into two; both are listed under verification #3).
+
+- [ ] **Step 3: Run the full test suite one more time**
+
+```bash
+go test ./...
+```
+
+Expected: all tests PASS across the repo.
+
+- [ ] **Step 4: Verify Windows cross-compile per CLAUDE.md**
+
+```bash
+GOOS=windows go build ./...
+```
+
+Expected: clean build. Phase 0 changes are pure Go stdlib, no OS-specific code.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/store/composite/sequence_contract_test.go
+git commit -m "$(cat <<'EOF'
+test(composite): Phase 0 sequence-contract verification tests
+
+Three (split into four) tests covering the spec's verification matrix:
+1. Cross-sink (seq, gen) convergence over 10k events
+2. Generation roll consistency: both sinks observe rollover at the same
+   boundary; each sink's prev_hash independently resets to "".
+3a. Clean durable failure does NOT advance prev_hash.
+3b. Ambiguous failure latches Fatal; next Compute returns ErrFatalIntegrity.
+
+Phase 0 — see docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Wrap-up
+
+After all six tasks land, Phase 0 is complete. Verify by running:
+
+```bash
+go test ./pkg/types/ ./internal/audit/ ./internal/store/ ./internal/store/composite/ -v
+GOOS=windows go build ./...
+```
+
+All tests should pass; cross-compile should be clean.
+
+The next plan in this series will implement the WTP client itself — the new `internal/store/wtp/` sink that consumes `ev.Chain` via the contract this plan establishes. That plan has 12 implementation phases per the WTP spec; it will be written separately after Phase 0 lands.

--- a/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
@@ -1949,13 +1949,14 @@ Expected: build failure (`s.NextGeneration` undefined) OR test failure (`Chain` 
 
 - [ ] **Step 3: Add allocator field and stamp logic**
 
-Edit `internal/store/composite/composite.go`. Add the audit import:
+Edit `internal/store/composite/composite.go`. Add the audit + sync imports:
 
 ```go
 import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/agentsh/agentsh/internal/audit"
@@ -1965,10 +1966,11 @@ import (
 )
 ```
 
-Replace the `Store` struct and `New` constructor (currently lines 14-23):
+Replace the `Store` struct and `New` constructor. The struct gains a `sync.RWMutex` (the wrapper-level rotation lock — see `## Composite Concurrency Model` in the spec for the discipline points):
 
 ```go
 type Store struct {
+	mu            sync.RWMutex
 	primary       store.EventStore
 	output        store.OutputStore
 	others        []store.EventStore
@@ -1986,14 +1988,27 @@ func New(primary store.EventStore, output store.OutputStore, others ...store.Eve
 }
 ```
 
-Replace `AppendEvent` (currently lines 29-64) — keep all existing error-collection logic, add the allocate+stamp prologue. Note the per-sink-copy pattern: the allocator is called ONCE per AppendEvent so all sinks see the same `(seq, gen)`, but each sink receives its own freshly-allocated `*ChainState` so no two sinks alias the same pointer. This is the runtime guarantee that backs the "Chain MUST be treated as read-only" contract on `pkg/types.ChainState`.
+Replace `AppendEvent` (currently lines 29-64) — keep all existing error-collection logic, add the allocate+stamp prologue and wrap the body in `mu.RLock()`. Note the per-sink-copy pattern: the allocator is called ONCE per AppendEvent so all sinks see the same `(seq, gen)`, but each sink receives its own freshly-allocated `*ChainState` so no two sinks alias the same pointer. This is the runtime guarantee that backs the "Chain MUST be treated as read-only" contract on `pkg/types.ChainState`.
+
+The RLock is the outer half of the wrapper-level rotation lock: `NextGeneration` (and `State`/`Restore`) take `mu.Lock()` so they block until every concurrent AppendEvent has completed its fanout. Without this lock, a stamped (seq, oldGen) event could race against sink rekeying and a sink that had already rotated would observe a backwards-generation event — exactly the failure mode `SinkChain.Commit` is designed to reject.
+
+Allocator failures (overflow) are wrapped as `*store.FatalIntegrityError{Op: "audit sequence allocate"}` and routed through the existing `onAppendError` hook so the daemon's fatal-audit watcher observes them, matching the convention in `internal/store/integrity_wrapper.go` (`Op: "write audit log"`, `Op: "sync audit log"`, `Op: "write audit integrity sidecar"`).
 
 ```go
 func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	// Phase 0: composite allocates the shared (seq, gen) once before fanout.
 	seq, gen, err := s.allocator.Next()
 	if err != nil {
-		return err
+		// Allocator failures bypass fanout. Wrap + route through hook so the
+		// daemon's fatal-audit watcher observes the overflow.
+		fatalErr := &store.FatalIntegrityError{Op: "audit sequence allocate", Err: err}
+		if s.onAppendError != nil {
+			s.onAppendError(fatalErr)
+		}
+		return fatalErr
 	}
 
 	// stampForSink returns ev with a FRESH *ChainState pointer so no two
@@ -2042,29 +2057,69 @@ func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
 }
 ```
 
-Add `NextGeneration` method (place it directly below `AppendEvent`):
+Add `NextGeneration` method (place it directly below `AppendEvent`). It takes `mu.Lock()` so it cannot return until every in-flight AppendEvent (each holding `mu.RLock()`) has completed its fanout, AND no new AppendEvent may begin until rotation finishes:
 
 ```go
 // NextGeneration advances the shared sequence generation. The next
 // AppendEvent stamps ev.Chain with (Sequence:0, Generation:newGen).
 // Used by the composite owner when the chain key rotates.
 //
+// Acquires mu.Lock() so the rotation cannot interleave with any in-flight
+// AppendEvent fanout. After return, every subsequent AppendEvent stamps
+// the new generation; there is no window where a stamped (seq, oldGen)
+// event can race against sink rekeying.
+//
 // Returns ErrGenerationOverflow on uint32 wrap; the allocator is not
 // modified in that case (see audit.SequenceAllocator.NextGeneration).
 func (s *Store) NextGeneration() (uint32, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.allocator.NextGeneration()
 }
 ```
 
-- [ ] **Step 4: Run tests to verify they pass**
+Add `State` and `Restore` methods so the daemon can persist + rehydrate the shared allocator across restarts. Phase 0 only adds the API; daemon wiring is out of scope.
 
-```bash
-go test ./internal/store/composite/ -v
+```go
+// State returns the allocator's (sequence, generation) for persistence.
+// Acquires mu.Lock() so the snapshot is taken while no AppendEvent is
+// mid-fanout and no NextGeneration is in progress.
+func (s *Store) State() audit.AllocatorState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.allocator.State()
+}
+
+// Restore rehydrates the allocator state after restart. Returns
+// audit.ErrInvalidAllocatorState on rejected input; the wrapper is not
+// modified in that case (delegated guarantee from
+// SequenceAllocator.Restore).
+func (s *Store) Restore(state audit.AllocatorState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.allocator.Restore(state)
+}
 ```
 
-Expected: all composite tests PASS, including the two new ones.
+- [ ] **Step 4: Add the rollover-atomicity + alloc-error + State/Restore regression tests**
 
-- [ ] **Step 5: Run the full test suite**
+These five tests guard the wrapper-level RWMutex contract, the allocator-error → hook routing, and the State/Restore roundtrip. Append them to `internal/store/composite/composite_test.go` and add `math`, `sync`, `sync/atomic`, `time`, and `audit` to the test imports.
+
+- `TestComposite_NextGeneration_BlocksUntilInflightFanoutCompletes` — uses a `blockingEventStore` (a small helper with a `chan struct{}` release signal) to pin a goroutine inside the composite's per-event fanout, then verifies that a concurrent `NextGeneration` does NOT return while the AppendEvent is still in fanout. Without `mu.RWMutex` this test fails: NextGeneration would advance the allocator and a subsequent AppendEvent on the SAME composite would stamp the new generation while the original AppendEvent's fanout is still mid-flight.
+- `TestComposite_NextGeneration_NoStaleStamping` — spawns 100 AppendEvent goroutines and concurrently calls NextGeneration five times. Asserts no captured (seq, gen) tuple is duplicated, no captured tuple has gen < the maximum generation seen earlier in the captured stream, and the per-generation sequence range is contiguous from 0. Run with `-race`.
+- `TestComposite_AppendEvent_AllocatorErrorRoutedToHook` — drives the allocator to `MaxInt64` via `s.Restore(audit.AllocatorState{Sequence: math.MaxInt64})`, sets the error hook, calls AppendEvent. Asserts the returned error wraps `audit.ErrSequenceOverflow` AND is a `*store.FatalIntegrityError` with `Op == "audit sequence allocate"`, the hook received the SAME error instance, and no sink was called.
+- `TestComposite_State_Restore_Roundtrip` — appends a few events, snapshots `State()`, constructs a new composite, calls `Restore(snapshot)`, and verifies the next AppendEvent stamps `Sequence: snapshot.Sequence + 1`.
+- `TestComposite_Restore_RejectsInvalidInput_LeavesStateIntact` — appends a few events, snapshots `State()` as `S0`, calls `Restore(audit.AllocatorState{Sequence: -2})`, asserts the returned error wraps `audit.ErrInvalidAllocatorState`, asserts `State()` still equals `S0`, and asserts the next AppendEvent stamps `Sequence: S0.Sequence + 1`.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+go test ./internal/store/composite/ -v -count=1 -race
+```
+
+Expected: all composite tests PASS, including the seven new ones (two from Step 1, five from Step 4).
+
+- [ ] **Step 6: Run the full test suite**
 
 ```bash
 go test ./...
@@ -2072,7 +2127,7 @@ go test ./...
 
 Expected: all tests PASS. The existing composite tests (`TestAppendEventCollectsFirstError`, `TestAppendEventErrorHookReceivesFirstError`, etc.) work because they use `fakeEventStore` which ignores `ev.Chain`.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add internal/store/composite/composite.go internal/store/composite/composite_test.go
@@ -2085,6 +2140,13 @@ sinks that don't ignore it.
 
 Adds NextGeneration() so the composite owner (the daemon) can trigger a
 generation rollover; the next AppendEvent stamps (Sequence:0, Generation:N+1).
+
+Holds a wrapper-level sync.RWMutex so AppendEvent fanout is atomic with
+respect to NextGeneration: the rotation cannot interleave with any
+in-flight fanout. Allocator-overflow errors are wrapped as
+*store.FatalIntegrityError and routed through the existing onAppendError
+hook so the daemon's fatal-audit watcher observes them. State()/Restore()
+expose the allocator at the composite level for future restart wiring.
 
 Phase 0 — see docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
 

--- a/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
@@ -61,7 +61,10 @@ func TestEvent_ChainFieldNotMarshaled(t *testing.T) {
 		Timestamp: time.Unix(1700000000, 0).UTC(),
 		Type:      "file_open",
 		SessionID: "sess-1",
-		Chain:     NewChainState(42, 7),
+		Chain: &ChainState{
+			Sequence:   42,
+			Generation: 7,
+		},
 	}
 
 	out, err := json.Marshal(ev)
@@ -90,26 +93,18 @@ func TestEvent_ChainFieldIgnoredOnUnmarshal(t *testing.T) {
 	}
 }
 
-// TestChainState_Immutable verifies that the ChainState pointer aliased
-// across sinks during composite fanout cannot be mutated by any sink.
-// This is the structural guarantee that justifies sharing the pointer
-// rather than deep-copying per sink.
-func TestChainState_Immutable(t *testing.T) {
-	c := NewChainState(100, 5)
-	if c.Sequence() != 100 {
-		t.Fatalf("Sequence(): got %d, want 100", c.Sequence())
-	}
-	if c.Generation() != 5 {
-		t.Fatalf("Generation(): got %d, want 5", c.Generation())
-	}
+// TestChainState_PerSinkCopy_Independence documents the contract that the
+// composite store stamps a fresh *ChainState per sink during fanout. Two
+// separately-allocated ChainState values must be independent: mutating one
+// must not affect the other. This is the runtime guarantee underlying the
+// "Chain MUST be treated as read-only" contract documented on the type.
+func TestChainState_PerSinkCopy_Independence(t *testing.T) {
+	a := &ChainState{Sequence: 100, Generation: 5}
+	b := &ChainState{Sequence: 100, Generation: 5}
 
-	// The struct fields are unexported; outside the types package this
-	// test wouldn't even compile if a caller tried to write c.sequence = 0.
-	// Inside the package we can demonstrate the read-only intent by
-	// confirming that two readers see the same values regardless of order.
-	c2 := c
-	if c2.Sequence() != c.Sequence() || c2.Generation() != c.Generation() {
-		t.Fatalf("aliased pointer reads diverged: c=%v c2=%v", c, c2)
+	a.Sequence = 999
+	if b.Sequence != 100 {
+		t.Fatalf("per-sink copy not independent: b.Sequence got %d, want 100", b.Sequence)
 	}
 }
 ```
@@ -132,12 +127,9 @@ Edit `pkg/types/events.go`. Inside the file, find the `Event` struct (currently 
 
 	// Chain is the shared (sequence, generation) allocated by the composite
 	// store before fanout. Used by chained sinks to produce sink-local
-	// integrity hashes.
-	//
-	// The pointed-to ChainState is immutable from the outside (unexported
-	// fields, read-only Sequence/Generation accessors), so the pointer can
-	// be safely aliased across sinks during fanout without any sink being
-	// able to corrupt the values seen by other sinks.
+	// integrity hashes. See ChainState's contract: composite stamps a
+	// fresh *ChainState per sink during fanout, so the pointer is never
+	// aliased across sinks.
 	//
 	// json:"-" is load-bearing: this field must never appear in any
 	// user-visible serialization. Tested by TestEvent_ChainFieldNotMarshaled.
@@ -152,25 +144,16 @@ Then add the `ChainState` type at the end of the file (after the `EventQuery` st
 // by the composite store before fanout to chained sinks. See
 // docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
 //
-// Fields are unexported and exposed via read-only methods so sinks cannot
-// mutate the state through the aliased pointer that fanout produces. The
-// composite store constructs values via NewChainState and never reuses
-// instances across events.
+// Although the fields are exported for ergonomic field access in chained
+// sinks, ChainState MUST be treated as read-only by every consumer. The
+// composite store stamps a fresh *ChainState per fanned-out sink in
+// AppendEvent (see internal/store/composite/composite.go), so no two sinks
+// alias the same ChainState. This contract is the per-sink-copy guarantee
+// that prevents one sink's mutation from corrupting another's view.
 type ChainState struct {
-	sequence   uint64
-	generation uint32
+	Sequence   uint64
+	Generation uint32
 }
-
-// NewChainState returns a stamped ChainState. Used by the composite store.
-func NewChainState(sequence uint64, generation uint32) *ChainState {
-	return &ChainState{sequence: sequence, generation: generation}
-}
-
-// Sequence returns the shared monotonic sequence allocated for the event.
-func (c *ChainState) Sequence() uint64 { return c.sequence }
-
-// Generation returns the chain generation at the time of allocation.
-func (c *ChainState) Generation() uint32 { return c.generation }
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
@@ -204,8 +187,9 @@ git add pkg/types/events.go pkg/types/events_test.go
 git commit -m "$(cat <<'EOF'
 feat(types): add typed Event.Chain field for sink coordination
 
-Adds pkg/types.ChainState (immutable, accessed via NewChainState +
-Sequence()/Generation()) and an Event.Chain pointer field with json:"-"
+Adds pkg/types.ChainState (exported Sequence/Generation fields; treated
+as read-only — composite stamps a fresh *ChainState per sink during
+fanout) and an Event.Chain pointer field with json:"-"
 so the composite store can stamp the shared sequence tuple onto events
 without ever leaking it into JSONL, OTEL, gRPC, webhook or any future
 serializer. Tested by TestEvent_ChainFieldNotMarshaled.
@@ -1195,7 +1179,7 @@ EOF
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `internal/store/composite/composite_test.go`. No new imports needed — the test uses only `context`, `testing`, and `types` (all already imported).
+Append to `internal/store/composite/composite_test.go`. The test imports `context`, `reflect`, `testing`, and `types` — add `reflect` if not already imported by the file.
 
 ```go
 type chainCapturingStore struct {
@@ -1203,8 +1187,8 @@ type chainCapturingStore struct {
 }
 
 func (s *chainCapturingStore) AppendEvent(ctx context.Context, ev types.Event) error {
-	// ChainState is immutable from outside the types package, so the
-	// pointer aliased across sinks is safe to retain directly.
+	// Composite stamps a fresh *ChainState per sink, so the captured
+	// pointer is the sink-local copy — distinct from every other sink's.
 	s.captured = append(s.captured, ev.Chain)
 	return nil
 }
@@ -1232,12 +1216,24 @@ func TestComposite_StampsChainBeforeFanout(t *testing.T) {
 		if p == nil || o == nil {
 			t.Fatalf("event %d: nil Chain — primary=%v other=%v", i, p, o)
 		}
-		if p.Sequence() != uint64(i) || p.Generation() != 0 {
-			t.Errorf("primary event %d: Chain=(seq=%d,gen=%d) want (seq=%d,gen=0)", i, p.Sequence(), p.Generation(), i)
+		if p.Sequence != uint64(i) || p.Generation != 0 {
+			t.Errorf("primary event %d: Chain=(seq=%d,gen=%d) want (seq=%d,gen=0)", i, p.Sequence, p.Generation, i)
 		}
-		if p.Sequence() != o.Sequence() || p.Generation() != o.Generation() {
-			t.Errorf("event %d: sinks saw different Chain: primary=(seq=%d,gen=%d) other=(seq=%d,gen=%d)", i, p.Sequence(), p.Generation(), o.Sequence(), o.Generation())
+		// Per-sink-copy contract: pointer-distinct across sinks but
+		// value-equal. Use == on pointers (must differ) and DeepEqual
+		// on dereferenced values (must match).
+		if p == o {
+			t.Errorf("event %d: sinks alias the same *ChainState pointer (%p); composite must stamp fresh per sink", i, p)
 		}
+		if !reflect.DeepEqual(*p, *o) {
+			t.Errorf("event %d: sinks saw different Chain values: primary=%+v other=%+v", i, *p, *o)
+		}
+	}
+
+	// Mutating one sink's captured ChainState must not affect the other's.
+	primary.captured[0].Sequence = 0xDEADBEEF
+	if other.captured[0].Sequence == 0xDEADBEEF {
+		t.Errorf("per-sink-copy invariant violated: mutating primary leaked into other")
 	}
 }
 
@@ -1261,11 +1257,13 @@ func TestComposite_NextGeneration_ResetsSequence(t *testing.T) {
 	}
 
 	last := primary.captured[len(primary.captured)-1]
-	if last == nil || last.Sequence() != 0 || last.Generation() != 1 {
-		t.Errorf("after rollover: Chain=(seq=%d,gen=%d) want (seq=0,gen=1)", last.Sequence(), last.Generation())
+	if last == nil || last.Sequence != 0 || last.Generation != 1 {
+		t.Errorf("after rollover: Chain=(seq=%d,gen=%d) want (seq=0,gen=1)", last.Sequence, last.Generation)
 	}
 }
 ```
+
+Note: this test imports `reflect` for `reflect.DeepEqual`.
 
 - [ ] **Step 2: Run tests to verify they fail**
 
@@ -1314,20 +1312,29 @@ func New(primary store.EventStore, output store.OutputStore, others ...store.Eve
 }
 ```
 
-Replace `AppendEvent` (currently lines 29-64) — keep all existing error-collection logic, add the allocate+stamp prologue:
+Replace `AppendEvent` (currently lines 29-64) — keep all existing error-collection logic, add the allocate+stamp prologue. Note the per-sink-copy pattern: the allocator is called ONCE per AppendEvent so all sinks see the same `(seq, gen)`, but each sink receives its own freshly-allocated `*ChainState` so no two sinks alias the same pointer. This is the runtime guarantee that backs the "Chain MUST be treated as read-only" contract on `pkg/types.ChainState`.
 
 ```go
 func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
+	// Phase 0: composite allocates the shared (seq, gen) once before fanout.
 	seq, gen, err := s.allocator.Next()
 	if err != nil {
 		return err
 	}
-	ev.Chain = types.NewChainState(uint64(seq), gen)
+
+	// stampForSink returns ev with a FRESH *ChainState pointer so no two
+	// sinks ever alias the same ChainState. This is the per-sink-copy
+	// guarantee that prevents one sink's mutation from corrupting another.
+	stampForSink := func() types.Event {
+		stamped := ev
+		stamped.Chain = &types.ChainState{Sequence: uint64(seq), Generation: gen}
+		return stamped
+	}
 
 	var firstErr error
 	var hookErr error
 	if s.primary != nil {
-		if err := s.primary.AppendEvent(ctx, ev); err != nil {
+		if err := s.primary.AppendEvent(ctx, stampForSink()); err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
@@ -1341,7 +1348,7 @@ func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
 		}
 	}
 	for _, o := range s.others {
-		if err := o.AppendEvent(ctx, ev); err != nil {
+		if err := o.AppendEvent(ctx, stampForSink()); err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
@@ -1469,8 +1476,8 @@ func (s *chainingFakeSink) AppendEvent(ctx context.Context, ev types.Event) erro
 	if ev.Chain == nil {
 		return audit.ErrMissingChainState
 	}
-	seq := ev.Chain.Sequence()
-	gen := ev.Chain.Generation()
+	seq := ev.Chain.Sequence
+	gen := ev.Chain.Generation
 	canonical := []byte(`{"id":"` + ev.ID + `","seq":` + strconv.FormatUint(seq, 10) + `,"gen":` + strconv.FormatUint(uint64(gen), 10) + `}`)
 
 	entryHash, prevHash, err := s.chain.Compute(audit.IntegrityFormatVersion, int64(seq), gen, canonical)

--- a/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
@@ -61,10 +61,7 @@ func TestEvent_ChainFieldNotMarshaled(t *testing.T) {
 		Timestamp: time.Unix(1700000000, 0).UTC(),
 		Type:      "file_open",
 		SessionID: "sess-1",
-		Chain: &ChainState{
-			Sequence:   42,
-			Generation: 7,
-		},
+		Chain:     NewChainState(42, 7),
 	}
 
 	out, err := json.Marshal(ev)
@@ -92,6 +89,29 @@ func TestEvent_ChainFieldIgnoredOnUnmarshal(t *testing.T) {
 		t.Fatalf("Chain should remain nil after unmarshal, got %+v", ev.Chain)
 	}
 }
+
+// TestChainState_Immutable verifies that the ChainState pointer aliased
+// across sinks during composite fanout cannot be mutated by any sink.
+// This is the structural guarantee that justifies sharing the pointer
+// rather than deep-copying per sink.
+func TestChainState_Immutable(t *testing.T) {
+	c := NewChainState(100, 5)
+	if c.Sequence() != 100 {
+		t.Fatalf("Sequence(): got %d, want 100", c.Sequence())
+	}
+	if c.Generation() != 5 {
+		t.Fatalf("Generation(): got %d, want 5", c.Generation())
+	}
+
+	// The struct fields are unexported; outside the types package this
+	// test wouldn't even compile if a caller tried to write c.sequence = 0.
+	// Inside the package we can demonstrate the read-only intent by
+	// confirming that two readers see the same values regardless of order.
+	c2 := c
+	if c2.Sequence() != c.Sequence() || c2.Generation() != c.Generation() {
+		t.Fatalf("aliased pointer reads diverged: c=%v c2=%v", c, c2)
+	}
+}
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -114,6 +134,11 @@ Edit `pkg/types/events.go`. Inside the file, find the `Event` struct (currently 
 	// store before fanout. Used by chained sinks to produce sink-local
 	// integrity hashes.
 	//
+	// The pointed-to ChainState is immutable from the outside (unexported
+	// fields, read-only Sequence/Generation accessors), so the pointer can
+	// be safely aliased across sinks during fanout without any sink being
+	// able to corrupt the values seen by other sinks.
+	//
 	// json:"-" is load-bearing: this field must never appear in any
 	// user-visible serialization. Tested by TestEvent_ChainFieldNotMarshaled.
 	Chain *ChainState `json:"-"`
@@ -126,10 +151,26 @@ Then add the `ChainState` type at the end of the file (after the `EventQuery` st
 // ChainState is the shared (sequence, generation) tuple stamped on each event
 // by the composite store before fanout to chained sinks. See
 // docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
+//
+// Fields are unexported and exposed via read-only methods so sinks cannot
+// mutate the state through the aliased pointer that fanout produces. The
+// composite store constructs values via NewChainState and never reuses
+// instances across events.
 type ChainState struct {
-	Sequence   uint64
-	Generation uint32
+	sequence   uint64
+	generation uint32
 }
+
+// NewChainState returns a stamped ChainState. Used by the composite store.
+func NewChainState(sequence uint64, generation uint32) *ChainState {
+	return &ChainState{sequence: sequence, generation: generation}
+}
+
+// Sequence returns the shared monotonic sequence allocated for the event.
+func (c *ChainState) Sequence() uint64 { return c.sequence }
+
+// Generation returns the chain generation at the time of allocation.
+func (c *ChainState) Generation() uint32 { return c.generation }
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
@@ -163,10 +204,11 @@ git add pkg/types/events.go pkg/types/events_test.go
 git commit -m "$(cat <<'EOF'
 feat(types): add typed Event.Chain field for sink coordination
 
-Adds pkg/types.ChainState{Sequence, Generation} and an Event.Chain pointer
-field with json:"-" so the composite store can stamp the shared sequence
-tuple onto events without ever leaking it into JSONL, OTEL, gRPC, webhook
-or any future serializer. Tested by TestEvent_ChainFieldNotMarshaled.
+Adds pkg/types.ChainState (immutable, accessed via NewChainState +
+Sequence()/Generation()) and an Event.Chain pointer field with json:"-"
+so the composite store can stamp the shared sequence tuple onto events
+without ever leaking it into JSONL, OTEL, gRPC, webhook or any future
+serializer. Tested by TestEvent_ChainFieldNotMarshaled.
 
 Phase 0 of the shared sequence allocator contract — see
 docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
@@ -1161,12 +1203,9 @@ type chainCapturingStore struct {
 }
 
 func (s *chainCapturingStore) AppendEvent(ctx context.Context, ev types.Event) error {
-	if ev.Chain != nil {
-		copy := *ev.Chain
-		s.captured = append(s.captured, &copy)
-	} else {
-		s.captured = append(s.captured, nil)
-	}
+	// ChainState is immutable from outside the types package, so the
+	// pointer aliased across sinks is safe to retain directly.
+	s.captured = append(s.captured, ev.Chain)
 	return nil
 }
 func (s *chainCapturingStore) QueryEvents(ctx context.Context, q types.EventQuery) ([]types.Event, error) {
@@ -1193,11 +1232,11 @@ func TestComposite_StampsChainBeforeFanout(t *testing.T) {
 		if p == nil || o == nil {
 			t.Fatalf("event %d: nil Chain — primary=%v other=%v", i, p, o)
 		}
-		if p.Sequence != uint64(i) || p.Generation != 0 {
-			t.Errorf("primary event %d: Chain=%+v want {Sequence:%d Generation:0}", i, p, i)
+		if p.Sequence() != uint64(i) || p.Generation() != 0 {
+			t.Errorf("primary event %d: Chain=(seq=%d,gen=%d) want (seq=%d,gen=0)", i, p.Sequence(), p.Generation(), i)
 		}
-		if *p != *o {
-			t.Errorf("event %d: sinks saw different Chain: primary=%+v other=%+v", i, p, o)
+		if p.Sequence() != o.Sequence() || p.Generation() != o.Generation() {
+			t.Errorf("event %d: sinks saw different Chain: primary=(seq=%d,gen=%d) other=(seq=%d,gen=%d)", i, p.Sequence(), p.Generation(), o.Sequence(), o.Generation())
 		}
 	}
 }
@@ -1222,8 +1261,8 @@ func TestComposite_NextGeneration_ResetsSequence(t *testing.T) {
 	}
 
 	last := primary.captured[len(primary.captured)-1]
-	if last == nil || last.Sequence != 0 || last.Generation != 1 {
-		t.Errorf("after rollover: Chain=%+v want {Sequence:0 Generation:1}", last)
+	if last == nil || last.Sequence() != 0 || last.Generation() != 1 {
+		t.Errorf("after rollover: Chain=(seq=%d,gen=%d) want (seq=0,gen=1)", last.Sequence(), last.Generation())
 	}
 }
 ```
@@ -1283,10 +1322,7 @@ func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
 	if err != nil {
 		return err
 	}
-	ev.Chain = &types.ChainState{
-		Sequence:   uint64(seq),
-		Generation: gen,
-	}
+	ev.Chain = types.NewChainState(uint64(seq), gen)
 
 	var firstErr error
 	var hookErr error
@@ -1433,9 +1469,11 @@ func (s *chainingFakeSink) AppendEvent(ctx context.Context, ev types.Event) erro
 	if ev.Chain == nil {
 		return audit.ErrMissingChainState
 	}
-	canonical := []byte(`{"id":"` + ev.ID + `","seq":` + strconv.FormatUint(ev.Chain.Sequence, 10) + `,"gen":` + strconv.FormatUint(uint64(ev.Chain.Generation), 10) + `}`)
+	seq := ev.Chain.Sequence()
+	gen := ev.Chain.Generation()
+	canonical := []byte(`{"id":"` + ev.ID + `","seq":` + strconv.FormatUint(seq, 10) + `,"gen":` + strconv.FormatUint(uint64(gen), 10) + `}`)
 
-	entryHash, prevHash, err := s.chain.Compute(audit.IntegrityFormatVersion, int64(ev.Chain.Sequence), ev.Chain.Generation, canonical)
+	entryHash, prevHash, err := s.chain.Compute(audit.IntegrityFormatVersion, int64(seq), gen, canonical)
 	if err != nil {
 		return err
 	}
@@ -1444,11 +1482,11 @@ func (s *chainingFakeSink) AppendEvent(ctx context.Context, ev types.Event) erro
 	failClean := s.failNext
 	failAmbiguous := s.failFatal
 	if failClean != nil {
-		s.failedSeq = int64(ev.Chain.Sequence)
+		s.failedSeq = int64(seq)
 		s.failNext = nil
 	}
 	if failAmbiguous {
-		s.failedSeq = int64(ev.Chain.Sequence)
+		s.failedSeq = int64(seq)
 		s.failFatal = false
 	}
 	s.mu.Unlock()
@@ -1462,11 +1500,11 @@ func (s *chainingFakeSink) AppendEvent(ctx context.Context, ev types.Event) erro
 		s.chain.Fatal(errors.New("ambiguous write"))
 		return errors.New("ambiguous write")
 	default:
-		s.chain.Commit(ev.Chain.Generation, entryHash)
+		s.chain.Commit(gen, entryHash)
 		s.mu.Lock()
 		s.records = append(s.records, chainRecord{
-			Sequence:   ev.Chain.Sequence,
-			Generation: ev.Chain.Generation,
+			Sequence:   seq,
+			Generation: gen,
 			EntryHash:  entryHash,
 			PrevHash:   prevHash,
 		})

--- a/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
@@ -92,22 +92,13 @@ func TestEvent_ChainFieldIgnoredOnUnmarshal(t *testing.T) {
 		t.Fatalf("Chain should remain nil after unmarshal, got %+v", ev.Chain)
 	}
 }
-
-// TestChainState_PerSinkCopy_Independence documents the contract that the
-// composite store stamps a fresh *ChainState per sink during fanout. Two
-// separately-allocated ChainState values must be independent: mutating one
-// must not affect the other. This is the runtime guarantee underlying the
-// "Chain MUST be treated as read-only" contract documented on the type.
-func TestChainState_PerSinkCopy_Independence(t *testing.T) {
-	a := &ChainState{Sequence: 100, Generation: 5}
-	b := &ChainState{Sequence: 100, Generation: 5}
-
-	a.Sequence = 999
-	if b.Sequence != 100 {
-		t.Fatalf("per-sink copy not independent: b.Sequence got %d, want 100", b.Sequence)
-	}
-}
 ```
+
+The per-sink-copy contract (composite stamps a fresh `*ChainState` per
+sink during fanout) is a composite-fanout property that this Task cannot
+verify in isolation — the composite stamping logic does not exist yet.
+Task 6's `TestComposite_StampsChainBeforeFanout` exercises that contract
+end-to-end (pointer-distinct, value-equal, mutation-isolated).
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -127,12 +118,13 @@ Edit `pkg/types/events.go`. Inside the file, find the `Event` struct (currently 
 
 	// Chain is the shared (sequence, generation) allocated by the composite
 	// store before fanout. Used by chained sinks to produce sink-local
-	// integrity hashes. See ChainState's contract: composite stamps a
-	// fresh *ChainState per sink during fanout, so the pointer is never
-	// aliased across sinks.
+	// integrity hashes. Nil until composite stamps it.
 	//
 	// json:"-" is load-bearing: this field must never appear in any
 	// user-visible serialization. Tested by TestEvent_ChainFieldNotMarshaled.
+	//
+	// Sinks MUST treat the pointed-to ChainState as read-only — see the
+	// ChainState type comment for the per-sink-copy contract.
 	Chain *ChainState `json:"-"`
 }
 ```
@@ -144,12 +136,17 @@ Then add the `ChainState` type at the end of the file (after the `EventQuery` st
 // by the composite store before fanout to chained sinks. See
 // docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
 //
-// Although the fields are exported for ergonomic field access in chained
-// sinks, ChainState MUST be treated as read-only by every consumer. The
-// composite store stamps a fresh *ChainState per fanned-out sink in
-// AppendEvent (see internal/store/composite/composite.go), so no two sinks
-// alias the same ChainState. This contract is the per-sink-copy guarantee
-// that prevents one sink's mutation from corrupting another's view.
+// Contract for consumers: ChainState MUST be treated as read-only. Sinks
+// must never mutate the fields of a *ChainState they receive on
+// types.Event.Chain. The composite store is the sole writer; it allocates
+// the (sequence, generation) tuple via audit.SequenceAllocator and stamps
+// the resulting ChainState onto the event in AppendEvent.
+//
+// To make accidental aliasing across sinks impossible, the composite is
+// expected to stamp a separate *ChainState per fanned-out sink (see Task 5
+// of the Phase 0 plan). Until Task 5 lands the typed Chain field is unused
+// at runtime; this type and the field exist now so downstream tasks can
+// build against a stable type.
 type ChainState struct {
 	Sequence   uint64
 	Generation uint32
@@ -188,11 +185,12 @@ git commit -m "$(cat <<'EOF'
 feat(types): add typed Event.Chain field for sink coordination
 
 Adds pkg/types.ChainState (exported Sequence/Generation fields; treated
-as read-only — composite stamps a fresh *ChainState per sink during
-fanout) and an Event.Chain pointer field with json:"-"
-so the composite store can stamp the shared sequence tuple onto events
-without ever leaking it into JSONL, OTEL, gRPC, webhook or any future
-serializer. Tested by TestEvent_ChainFieldNotMarshaled.
+as read-only — Task 5 will land the composite stamping that allocates a
+fresh *ChainState per sink during fanout) and an Event.Chain pointer
+field with json:"-" so the composite store can stamp the shared
+sequence tuple onto events without ever leaking it into JSONL, OTEL,
+gRPC, webhook or any future serializer. Tested by
+TestEvent_ChainFieldNotMarshaled.
 
 Phase 0 of the shared sequence allocator contract — see
 docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.

--- a/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
@@ -1135,7 +1135,9 @@ import (
 // (unexported fields, accessor methods) and chain-bound — only the
 // SinkChain instance that produced the result can commit it. The
 // unexported fields make literal construction or post-Compute mutation
-// impossible from outside the audit package.
+// impossible from outside the audit package. Callers that need to persist
+// the integrity metadata alongside the payload use EntryHash() and
+// PrevHash(); see the lifecycle note below.
 //
 // Enforced invariants on Commit:
 //   - nil ComputeResult → error (no latch).
@@ -1146,12 +1148,6 @@ import (
 //   - Stale prev_hash within the current generation, or non-empty prev_hash
 //     on a rollover commit → ErrStaleResult, latches fatal.
 //   - Otherwise, generation and prev_hash advance.
-//
-// ComputeResult is opaque (unexported fields, accessor methods) and
-// chain-bound (cannot be committed on a different SinkChain). Callers that
-// need to serialize a result use EntryHash() and PrevHash(). The
-// unexported (sequence, generation, chain) fields make it impossible to
-// fabricate or cross-mix tokens outside the audit package.
 //
 // Contract — what remains the caller's responsibility:
 //
@@ -1169,6 +1165,23 @@ import (
 //     succeeded. SinkChain has no knowledge of durable state; Commit on a
 //     result whose write failed silently advances the in-memory chain
 //     past an entry that does not exist in storage.
+//
+// Lifecycle / serialization boundary:
+//
+// A ComputeResult is bound to the in-memory SinkChain instance that
+// produced it (chain-bound by pointer identity). It cannot be durably
+// stored and committed later: a SinkChain reconstructed via NewSinkChain
+// + Restore is a new instance and will reject prior tokens with
+// ErrCrossChainResult. This is intentional — Compute and Commit are
+// designed to be co-located in a single process, with the durable write
+// of the integrity metadata happening between them.
+//
+// EntryHash() and PrevHash() exist so that callers can persist the
+// integrity metadata alongside the payload for later VerifyHash. They are
+// NOT the input shape for reconstructing a Commit token across process
+// boundaries — there is no such API and no such need; the chain itself
+// remembers what it has committed via prev_hash, and VerifyHash
+// re-derives entry hashes from the persisted metadata.
 //
 // Recovery — a fatal latch makes the SinkChain instance unusable:
 //
@@ -1210,6 +1223,23 @@ type SinkChainState struct {
 // or fabricate one outside the audit package.
 //
 // Use EntryHash() and PrevHash() to inspect the values for serialization.
+//
+// Lifecycle / serialization boundary:
+//
+// A ComputeResult is bound to the in-memory SinkChain instance that
+// produced it (chain-bound by pointer identity). It cannot be durably
+// stored and committed later: a SinkChain reconstructed via NewSinkChain
+// + Restore is a new instance and will reject prior tokens with
+// ErrCrossChainResult. This is intentional — Compute and Commit are
+// designed to be co-located in a single process, with the durable write
+// of the integrity metadata happening between them.
+//
+// EntryHash() and PrevHash() exist so that callers can persist the
+// integrity metadata alongside the payload for later VerifyHash. They are
+// NOT the input shape for reconstructing a Commit token across process
+// boundaries — there is no such API and no such need; the chain itself
+// remembers what it has committed via prev_hash, and VerifyHash
+// re-derives entry hashes from the persisted metadata.
 type ComputeResult struct {
 	entryHash  string
 	prevHash   string

--- a/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
@@ -634,16 +634,16 @@ func TestSinkChain_Compute_FirstEntryUsesEmptyPrev(t *testing.T) {
 	c, key := newTestSinkChain(t)
 	payload := []byte(`{"k":"v"}`)
 
-	entryHash, prevHash, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+	result, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
 	if err != nil {
 		t.Fatalf("Compute: %v", err)
 	}
-	if prevHash != "" {
-		t.Errorf("first Compute: prevHash = %q, want empty", prevHash)
+	if result.PrevHash != "" {
+		t.Errorf("first Compute: prevHash = %q, want empty", result.PrevHash)
 	}
 	want := computeExpectedHash(t, key, IntegrityFormatVersion, 0, "", payload)
-	if entryHash != want {
-		t.Errorf("entryHash = %q, want %q", entryHash, want)
+	if result.EntryHash != want {
+		t.Errorf("entryHash = %q, want %q", result.EntryHash, want)
 	}
 }
 
@@ -651,41 +651,43 @@ func TestSinkChain_Compute_IsPure_NoMutationWithoutCommit(t *testing.T) {
 	c, _ := newTestSinkChain(t)
 	payload := []byte(`{"k":"v"}`)
 
-	first, _, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+	first, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Compute again without Commit — must produce the SAME entryHash, since
 	// prev_hash hasn't moved.
-	second, _, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+	second, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if first != second {
-		t.Errorf("Compute mutated chain state: first=%q second=%q", first, second)
+	if first.EntryHash != second.EntryHash {
+		t.Errorf("Compute mutated chain state: first=%q second=%q", first.EntryHash, second.EntryHash)
 	}
 }
 
 func TestSinkChain_Commit_AdvancesPrevHash(t *testing.T) {
 	c, key := newTestSinkChain(t)
 
-	first, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`))
+	first, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Commit(0, first)
+	if err := c.Commit(first); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
 
-	second, prev, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
+	second, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if prev != first {
-		t.Errorf("after Commit: prev_hash = %q, want %q", prev, first)
+	if second.PrevHash != first.EntryHash {
+		t.Errorf("after Commit: prev_hash = %q, want %q", second.PrevHash, first.EntryHash)
 	}
-	want := computeExpectedHash(t, key, IntegrityFormatVersion, 1, first, []byte(`{"b":2}`))
-	if second != want {
-		t.Errorf("second entryHash = %q, want %q", second, want)
+	want := computeExpectedHash(t, key, IntegrityFormatVersion, 1, first.EntryHash, []byte(`{"b":2}`))
+	if second.EntryHash != want {
+		t.Errorf("second entryHash = %q, want %q", second.EntryHash, want)
 	}
 }
 
@@ -693,51 +695,55 @@ func TestSinkChain_Compute_GenerationRollover_ResetsPrevToEmpty(t *testing.T) {
 	c, key := newTestSinkChain(t)
 
 	// Establish gen=0 chain with one committed entry.
-	h0, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"x":1}`))
+	r0, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"x":1}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Commit(0, h0)
+	if err := c.Commit(r0); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
 
 	// Compute at gen=1 — prev_hash should be "" automatically.
-	h1, prev, err := c.Compute(IntegrityFormatVersion, 0, 1, []byte(`{"y":2}`))
+	r1, err := c.Compute(IntegrityFormatVersion, 0, 1, []byte(`{"y":2}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if prev != "" {
-		t.Errorf("after gen rollover: prev_hash = %q, want empty", prev)
+	if r1.PrevHash != "" {
+		t.Errorf("after gen rollover: prev_hash = %q, want empty", r1.PrevHash)
 	}
 	want := computeExpectedHash(t, key, IntegrityFormatVersion, 0, "", []byte(`{"y":2}`))
-	if h1 != want {
-		t.Errorf("rolled entryHash = %q, want %q", h1, want)
+	if r1.EntryHash != want {
+		t.Errorf("rolled entryHash = %q, want %q", r1.EntryHash, want)
 	}
 
-	// Until Commit(1, h1), the chain's recorded generation is still 0.
+	// Until Commit(r1), the chain's recorded generation is still 0.
 	state := c.State()
 	if state.Generation != 0 {
 		t.Errorf("State.Generation before Commit = %d, want 0", state.Generation)
 	}
 
-	c.Commit(1, h1)
+	if err := c.Commit(r1); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
 	state = c.State()
 	if state.Generation != 1 {
 		t.Errorf("State.Generation after Commit = %d, want 1", state.Generation)
 	}
-	if state.PrevHash != h1 {
-		t.Errorf("State.PrevHash = %q, want %q", state.PrevHash, h1)
+	if state.PrevHash != r1.EntryHash {
+		t.Errorf("State.PrevHash = %q, want %q", state.PrevHash, r1.EntryHash)
 	}
 }
 
 func TestSinkChain_Fatal_LatchesAndBlocksFurtherCompute(t *testing.T) {
 	c, _ := newTestSinkChain(t)
 
-	if _, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`)); err != nil {
+	if _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`)); err != nil {
 		t.Fatal(err)
 	}
 
 	c.Fatal(errors.New("ambiguous WAL write"))
 
-	_, _, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
+	_, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
 	if !errors.Is(err, ErrFatalIntegrity) {
 		t.Fatalf("Compute after Fatal: err = %v, want ErrFatalIntegrity", err)
 	}
@@ -746,20 +752,24 @@ func TestSinkChain_Fatal_LatchesAndBlocksFurtherCompute(t *testing.T) {
 func TestSinkChain_State_Restore_RoundTrip(t *testing.T) {
 	c, _ := newTestSinkChain(t)
 
-	h0, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`))
+	r0, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Commit(0, h0)
-	h1, _, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
+	if err := c.Commit(r0); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	r1, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Commit(0, h1)
+	if err := c.Commit(r1); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
 
 	state := c.State()
-	if state.Generation != 0 || state.PrevHash != h1 {
-		t.Fatalf("State() = %+v, want {Generation:0 PrevHash:%q}", state, h1)
+	if state.Generation != 0 || state.PrevHash != r1.EntryHash {
+		t.Fatalf("State() = %+v, want {Generation:0 PrevHash:%q}", state, r1.EntryHash)
 	}
 
 	d, _ := newTestSinkChain(t)
@@ -769,16 +779,16 @@ func TestSinkChain_State_Restore_RoundTrip(t *testing.T) {
 
 	// Continue the chain from d — same key, so same entry hash as if c
 	// had continued.
-	cNext, _, err := c.Compute(IntegrityFormatVersion, 2, 0, []byte(`{"c":3}`))
+	cNext, err := c.Compute(IntegrityFormatVersion, 2, 0, []byte(`{"c":3}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	dNext, _, err := d.Compute(IntegrityFormatVersion, 2, 0, []byte(`{"c":3}`))
+	dNext, err := d.Compute(IntegrityFormatVersion, 2, 0, []byte(`{"c":3}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cNext != dNext {
-		t.Errorf("after Restore: entryHash mismatch %q vs %q", cNext, dNext)
+	if cNext.EntryHash != dNext.EntryHash {
+		t.Errorf("after Restore: entryHash mismatch %q vs %q", cNext.EntryHash, dNext.EntryHash)
 	}
 }
 
@@ -827,14 +837,17 @@ func TestSinkChain_SerialComputeCommit_NoChainBreakage(t *testing.T) {
 		defer wg.Done()
 		for i := int64(0); i < N; i++ {
 			payload := []byte(`{"i":` + strconv.FormatInt(i, 10) + `}`)
-			entry, prev, err := c.Compute(IntegrityFormatVersion, i, 0, payload)
+			result, err := c.Compute(IntegrityFormatVersion, i, 0, payload)
 			if err != nil {
 				t.Errorf("Compute %d: %v", i, err)
 				return
 			}
-			c.Commit(0, entry)
+			if err := c.Commit(result); err != nil {
+				t.Errorf("Commit %d: %v", i, err)
+				return
+			}
 			mu.Lock()
-			records = append(records, record{seq: i, payload: payload, entryHash: entry, prevHash: prev})
+			records = append(records, record{seq: i, payload: payload, entryHash: result.EntryHash, prevHash: result.PrevHash})
 			mu.Unlock()
 		}
 	}()
@@ -862,24 +875,20 @@ func TestSinkChain_Compute_IsPureUnderConcurrentCallers(t *testing.T) {
 	payload := []byte(`{"k":"v"}`)
 
 	const N = 32
-	type result struct {
-		entry string
-		prev  string
-	}
-	results := make([]result, 0, N)
+	results := make([]*ComputeResult, 0, N)
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 	wg.Add(N)
 	for i := 0; i < N; i++ {
 		go func() {
 			defer wg.Done()
-			entry, prev, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+			result, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
 			if err != nil {
 				t.Errorf("Compute: %v", err)
 				return
 			}
 			mu.Lock()
-			results = append(results, result{entry: entry, prev: prev})
+			results = append(results, result)
 			mu.Unlock()
 		}()
 	}
@@ -888,14 +897,14 @@ func TestSinkChain_Compute_IsPureUnderConcurrentCallers(t *testing.T) {
 	if len(results) != N {
 		t.Fatalf("got %d results, want %d", len(results), N)
 	}
-	wantEntry := results[0].entry
-	wantPrev := results[0].prev
+	wantEntry := results[0].EntryHash
+	wantPrev := results[0].PrevHash
 	for i, r := range results {
-		if r.entry != wantEntry {
-			t.Errorf("result %d: entry=%q, want %q (Compute is not pure under contention)", i, r.entry, wantEntry)
+		if r.EntryHash != wantEntry {
+			t.Errorf("result %d: entry=%q, want %q (Compute is not pure under contention)", i, r.EntryHash, wantEntry)
 		}
-		if r.prev != wantPrev {
-			t.Errorf("result %d: prev=%q, want %q (Compute is not pure under contention)", i, r.prev, wantPrev)
+		if r.PrevHash != wantPrev {
+			t.Errorf("result %d: prev=%q, want %q (Compute is not pure under contention)", i, r.PrevHash, wantPrev)
 		}
 	}
 }
@@ -903,7 +912,7 @@ func TestSinkChain_Compute_IsPureUnderConcurrentCallers(t *testing.T) {
 func TestSinkChain_State_PersistsFatal(t *testing.T) {
 	c, _ := newTestSinkChain(t)
 
-	if _, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`)); err != nil {
+	if _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`)); err != nil {
 		t.Fatal(err)
 	}
 	c.Fatal(errors.New("ambiguous WAL write"))
@@ -918,7 +927,7 @@ func TestSinkChain_State_PersistsFatal(t *testing.T) {
 	if err := d.Restore(state.Generation, state.PrevHash, state.Fatal); err != nil {
 		t.Fatalf("Restore: %v", err)
 	}
-	if _, _, err := d.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`)); !errors.Is(err, ErrFatalIntegrity) {
+	if _, err := d.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`)); !errors.Is(err, ErrFatalIntegrity) {
 		t.Fatalf("Compute after Restore-with-Fatal: err = %v, want ErrFatalIntegrity", err)
 	}
 }
@@ -980,30 +989,102 @@ func TestSinkChain_Restore_ValidatesPrevHash(t *testing.T) {
 	}
 }
 
-func TestSinkChain_Commit_BackwardsGenerationIsIgnored(t *testing.T) {
+// TestSinkChain_Commit_BackwardsGenerationLatchesFatal verifies that a Commit
+// whose ComputeResult was produced before a generation rollover (i.e. its
+// generation is older than the chain's current generation) latches the chain
+// fatal and returns an error. Silently no-op'ing this would hide an integrity
+// divergence: the durable write would have succeeded but the in-memory
+// prev_hash would lag, breaking subsequent Compute calls without signal.
+func TestSinkChain_Commit_BackwardsGenerationLatchesFatal(t *testing.T) {
 	c, _ := newTestSinkChain(t)
 
-	// Establish gen=2 with one committed entry.
-	if _, _, err := c.Compute(IntegrityFormatVersion, 0, 2, []byte(`{"a":1}`)); err != nil {
-		t.Fatal(err)
-	}
-	h2, _, err := c.Compute(IntegrityFormatVersion, 0, 2, []byte(`{"a":1}`))
+	// Establish chain at gen=2 by Compute+Commit.
+	r2, err := c.Compute(IntegrityFormatVersion, 0, 2, []byte(`{"a":1}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Commit(2, h2)
-
-	before := c.State()
-	if before.Generation != 2 || before.PrevHash != h2 {
-		t.Fatalf("setup: state = %+v, want {Generation:2 PrevHash:%q}", before, h2)
+	if err := c.Commit(r2); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	state := c.State()
+	if state.Generation != 2 {
+		t.Fatalf("setup: chain generation = %d, want 2", state.Generation)
 	}
 
-	// Commit with an older generation must be a no-op.
-	c.Commit(1, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	// Construct a backwards-generation result. Restore the chain to gen=1
+	// briefly, Compute under gen=1, then restore back to gen=2 — the result
+	// carries result.generation=1 even though the chain is now at gen=2.
+	if err := c.Restore(1, "", false); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	older, err := c.Compute(IntegrityFormatVersion, 0, 1, []byte(`{"old":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if older.generation != 1 {
+		t.Fatalf("older.generation = %d, want 1", older.generation)
+	}
+	if err := c.Restore(2, r2.EntryHash, false); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
 
-	after := c.State()
-	if after.Generation != before.Generation || after.PrevHash != before.PrevHash {
-		t.Errorf("backwards-generation Commit mutated state: before=%+v after=%+v", before, after)
+	// Commit the backwards result must return an error mentioning
+	// "backwards generation" and latch the chain fatal.
+	err = c.Commit(older)
+	if err == nil {
+		t.Fatal("Commit(backwards result): err = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "backwards generation") {
+		t.Errorf("Commit error = %q, want substring 'backwards generation'", err)
+	}
+
+	if !c.State().Fatal {
+		t.Errorf("State.Fatal = false after backwards-gen Commit; want true")
+	}
+
+	// Subsequent Compute must surface the fatal latch.
+	if _, err := c.Compute(IntegrityFormatVersion, 1, 2, []byte(`{"x":1}`)); !errors.Is(err, ErrFatalIntegrity) {
+		t.Errorf("Compute after backwards-gen Commit: err = %v, want ErrFatalIntegrity", err)
+	}
+}
+
+// TestSinkChain_Commit_NilResultErrors verifies that Commit rejects a nil
+// ComputeResult with an error rather than panicking.
+func TestSinkChain_Commit_NilResultErrors(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+
+	err := c.Commit(nil)
+	if err == nil {
+		t.Fatal("Commit(nil): err = nil, want error")
+	}
+
+	// nil-result error is a caller bug, not a fatal integrity event — the
+	// chain should NOT latch fatal in this case.
+	if c.State().Fatal {
+		t.Errorf("Commit(nil) latched fatal; want chain unchanged")
+	}
+}
+
+// TestSinkChain_Commit_AfterFatalReturnsError verifies that Commit on a chain
+// that was previously latched Fatal returns ErrFatalIntegrity (replacing the
+// earlier silent-no-op behavior). The chain stays latched.
+func TestSinkChain_Commit_AfterFatalReturnsError(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+
+	result, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.Fatal(errors.New("ambiguous WAL write"))
+
+	err = c.Commit(result)
+	if !errors.Is(err, ErrFatalIntegrity) {
+		t.Errorf("Commit after Fatal: err = %v, want ErrFatalIntegrity", err)
+	}
+
+	if !c.State().Fatal {
+		t.Errorf("State.Fatal = false after Commit-on-fatal-chain; want true (latch must persist)")
 	}
 }
 ```
@@ -1043,11 +1124,19 @@ import (
 // and concurrent Compute calls (with no intervening Commit) are pure and
 // return identical results — they do not corrupt state. However, callers
 // MUST NOT interleave Compute/Commit pairs across goroutines: Commit
-// carries no token identifying which Compute it finalizes, so a stale or
-// reordered Commit can overwrite prev_hash with a hash that does not
-// correspond to the most recent Compute. The expected pattern is a single
-// owner that issues Compute → durable write → Commit (or Fatal) in
-// sequence per event.
+// consumes a typed *ComputeResult and validates the result's generation
+// against the chain's current generation, but the (sequence, generation)
+// tuple alone does not identify which Compute call produced it within the
+// same generation. The expected pattern is a single owner that issues
+// Compute → durable write → Commit (or Fatal) in sequence per event.
+//
+// Compute/Commit token contract: Compute returns a *ComputeResult that
+// callers MUST pass to Commit unchanged. The unexported fields on
+// ComputeResult let Commit verify the result really came from Compute on
+// this chain. Callers cannot construct a ComputeResult literal because
+// the unexported fields make that impossible from outside the audit
+// package; this prevents Commit from accepting a fabricated EntryHash
+// that Compute would never have produced.
 type SinkChain struct {
 	mu         sync.Mutex
 	key        []byte
@@ -1070,9 +1159,39 @@ type SinkChainState struct {
 	Fatal      bool
 }
 
-// ErrFatalIntegrity is returned by Compute after Fatal has been called.
-// The chain cannot be reused; the sink must be reinitialized (e.g., via
-// generation rotation).
+// ComputeResult is the typed output of SinkChain.Compute. It is the only
+// value Commit will accept. The exported fields are inspectable; the
+// unexported fields let Commit verify it really came out of Compute and
+// that no impossible state transition is being requested.
+//
+// Callers MUST NOT construct ComputeResult literals — only Compute returns
+// valid ones. The unexported fields make literal construction impossible
+// outside the audit package; that is load-bearing for the chain-state
+// invariants Commit enforces.
+type ComputeResult struct {
+	// EntryHash is the HMAC of (formatVersion | sequence | prevHash |
+	// payload) under the chain's key. Inspectable — callers serialize this
+	// into the entry's integrity metadata.
+	EntryHash string
+
+	// PrevHash is the prev_hash that was hashed into EntryHash. For the
+	// first entry of a chain (or the first entry after a generation
+	// rollover) this is the empty string. Inspectable — callers serialize
+	// this into the entry's integrity metadata.
+	PrevHash string
+
+	// sequence and generation are unexported so external packages cannot
+	// fabricate a ComputeResult with arbitrary state. Commit reads these
+	// to enforce chain-state invariants (e.g., backwards-generation Commit
+	// is a caller bug and latches fatal).
+	sequence   int64
+	generation uint32
+}
+
+// ErrFatalIntegrity is returned by Compute after Fatal has been called,
+// and by Commit when called on a chain that was latched Fatal (either by
+// Fatal itself or by a backwards-generation Commit). The chain cannot be
+// reused; the sink must be reinitialized (e.g., via generation rotation).
 var ErrFatalIntegrity = errors.New("integrity chain latched fatal; sink must be reinitialized")
 
 // ErrMissingChainState is returned by chained sinks when an event arrives
@@ -1106,20 +1225,22 @@ func NewSinkChain(key []byte, algorithm string) (*SinkChain, error) {
 }
 
 // Compute computes the HMAC of (formatVersion, sequence, prev_hash, payload)
-// using the chain's key. Compute is PURE: it does not mutate prev_hash. The
-// caller must follow with Commit on durable-write success or discard the
-// result on durable-write failure.
+// using the chain's key and returns it as a *ComputeResult. Compute is
+// PURE: it does not mutate prev_hash. The caller must follow with Commit
+// (passing the returned *ComputeResult) on durable-write success or
+// discard the result on durable-write failure.
 //
 // If `generation` differs from the chain's current generation, prev_hash
 // is treated as "" for this Compute (chain rolls automatically). The
-// transition is committed only when Commit is called with the new generation.
+// transition is committed only when Commit is called with a result whose
+// generation is the new generation.
 //
 // Returns ErrFatalIntegrity if Fatal was previously called.
-func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32, payload []byte) (entryHash string, prevHash string, err error) {
+func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32, payload []byte) (*ComputeResult, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.fatal {
-		return "", "", ErrFatalIntegrity
+		return nil, ErrFatalIntegrity
 	}
 	prev := c.prevHash
 	if generation != c.generation {
@@ -1127,33 +1248,52 @@ func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32
 	}
 	hash, err := computeIntegrityHash(c.key, c.algorithm, formatVersion, sequence, prev, payload)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
-	return hash, prev, nil
+	return &ComputeResult{
+		EntryHash:  hash,
+		PrevHash:   prev,
+		sequence:   sequence,
+		generation: generation,
+	}, nil
 }
 
-// Commit advances prev_hash to entryHash and records the generation. Must be
-// called exactly once per successful Compute, after the durable write
-// succeeds. On ambiguous failure (write may or may not have landed), the
-// caller MUST call Fatal instead; Commit and Fatal are mutually exclusive
-// per Compute.
+// Commit advances prev_hash using the result of a previous Compute on this
+// chain. Must be called exactly once per successful Compute, after the
+// durable write succeeds. On ambiguous failure (write may or may not have
+// landed), the caller MUST call Fatal instead; Commit and Fatal are
+// mutually exclusive per Compute.
 //
-// Commit silently no-ops in two cases: (1) the chain has been latched Fatal,
-// and (2) `generation` is older than the chain's current generation —
-// rolling backwards across a generation boundary would re-use prior
-// (sequence, generation) tuples and corrupt the chain. The latter is a
-// caller programming error and is treated as ignorable rather than fatal.
-func (c *SinkChain) Commit(generation uint32, entryHash string) {
+// Returns an error if `result` is nil (caller bug; chain is not modified).
+//
+// Returns ErrFatalIntegrity if the chain was previously latched Fatal —
+// either by an explicit Fatal call or by a prior backwards-generation
+// Commit. The chain stays latched.
+//
+// Returns a non-nil error AND latches the chain Fatal if the result's
+// generation is older than the chain's current generation. This indicates
+// a caller bug: the durable write succeeded for an entry whose generation
+// is no longer current, so accepting the Commit would leave in-memory
+// prev_hash lagging the durable state and silently corrupt subsequent
+// Compute results. Latching fatal makes the divergence visible
+// immediately rather than later as a chain-break.
+func (c *SinkChain) Commit(result *ComputeResult) error {
+	if result == nil {
+		return errors.New("nil ComputeResult")
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.fatal {
-		return
+		return ErrFatalIntegrity
 	}
-	if generation < c.generation {
-		return
+	if result.generation < c.generation {
+		c.fatal = true
+		return fmt.Errorf("backwards generation Commit: result.generation=%d < c.generation=%d (caller bug, chain latched fatal)",
+			result.generation, c.generation)
 	}
-	c.generation = generation
-	c.prevHash = entryHash
+	c.generation = result.generation
+	c.prevHash = result.EntryHash
+	return nil
 }
 
 // Fatal latches the chain in an unrecoverable state. All subsequent Compute
@@ -1225,7 +1365,7 @@ func validatePrevHash(algorithm, prevHash string) error {
 go test ./internal/audit/ -run "TestSinkChain|TestNewSinkChain" -v
 ```
 
-Expected: all 12 tests PASS.
+Expected: all 15 tests PASS.
 
 - [ ] **Step 5: Run the full audit test suite**
 
@@ -1332,7 +1472,7 @@ func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	entryHash, prevHash, err := c.chain.Compute(IntegrityFormatVersion, seq, gen, canonicalPayload)
+	result, err := c.chain.Compute(IntegrityFormatVersion, seq, gen, canonicalPayload)
 	if err != nil {
 		return nil, err
 	}
@@ -1340,17 +1480,19 @@ func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error) {
 	data["integrity"] = IntegrityMetadata{
 		FormatVersion: IntegrityFormatVersion,
 		Sequence:      seq,
-		PrevHash:      prevHash,
-		EntryHash:     entryHash,
+		PrevHash:      result.PrevHash,
+		EntryHash:     result.EntryHash,
 	}
 
-	result, err := json.Marshal(data)
+	wrapped, err := json.Marshal(data)
 	if err != nil {
 		return nil, fmt.Errorf("marshal wrapped payload: %w", err)
 	}
 
-	c.chain.Commit(gen, entryHash)
-	return result, nil
+	if err := c.chain.Commit(result); err != nil {
+		return nil, err
+	}
+	return wrapped, nil
 }
 ```
 
@@ -1810,7 +1952,7 @@ func (s *chainingFakeSink) AppendEvent(ctx context.Context, ev types.Event) erro
 	gen := ev.Chain.Generation
 	canonical := []byte(`{"id":"` + ev.ID + `","seq":` + strconv.FormatUint(seq, 10) + `,"gen":` + strconv.FormatUint(uint64(gen), 10) + `}`)
 
-	entryHash, prevHash, err := s.chain.Compute(audit.IntegrityFormatVersion, int64(seq), gen, canonical)
+	result, err := s.chain.Compute(audit.IntegrityFormatVersion, int64(seq), gen, canonical)
 	if err != nil {
 		return err
 	}
@@ -1837,13 +1979,18 @@ func (s *chainingFakeSink) AppendEvent(ctx context.Context, ev types.Event) erro
 		s.chain.Fatal(errors.New("ambiguous write"))
 		return errors.New("ambiguous write")
 	default:
-		s.chain.Commit(gen, entryHash)
+		// Successful durable write — commit. A non-nil error here means the
+		// chain has latched fatal (e.g., backwards-generation Commit), which
+		// is itself a write divergence and must be surfaced to the caller.
+		if err := s.chain.Commit(result); err != nil {
+			return err
+		}
 		s.mu.Lock()
 		s.records = append(s.records, chainRecord{
 			Sequence:   seq,
 			Generation: gen,
-			EntryHash:  entryHash,
-			PrevHash:   prevHash,
+			EntryHash:  result.EntryHash,
+			PrevHash:   result.PrevHash,
 		})
 		s.mu.Unlock()
 		return nil

--- a/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
@@ -1574,11 +1574,24 @@ In `internal/audit/integrity.go`, replace the existing `IntegrityChain` struct (
 // SinkChain. New code should use those two types directly via the composite
 // store's allocator and per-sink chains. Wrap/State/Restore are preserved
 // at the source level for existing callers.
+//
+// Concurrency: Wrap, State, and Restore are serialized by an internal
+// mutex so the wrapper preserves the legacy single-mutex atomicity contract:
+// concurrent Wrap calls do not race against each other, State returns a
+// consistent (sequence, prev_hash) snapshot, and Restore is all-or-nothing
+// (a failed Restore leaves the wrapper in its pre-call state).
+//
+// KeyFingerprint, VerifyHash, and VerifyWrapped do NOT take the wrapper
+// mutex — they read immutable key/algorithm via the underlying SinkChain's
+// own mutex and have no need for wrapper-level serialization.
 type IntegrityChain struct {
+	mu    sync.Mutex
 	alloc *SequenceAllocator
 	chain *SinkChain
 }
 ```
+
+Add `"sync"` to the import block alongside the existing standard-library imports.
 
 Replace the body of `NewIntegrityChainWithAlgorithm` (currently lines 72-91) with:
 
@@ -1605,6 +1618,9 @@ Replace the body of `Wrap()` (currently lines 201-252) with:
 // Wrap adds integrity metadata to an event payload.
 // The payload must be valid JSON. Returns a new JSON payload with an "integrity" field.
 func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	data, err := parseIntegrityPayloadUseNumber(payload)
 	if err != nil {
 		return nil, err
@@ -1645,6 +1661,8 @@ func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error) {
 
 Single-sink callers don't expose Compute/Commit because there's no fanout; the legacy contract is "Wrap returns the bytes; if the caller's write fails, the caller never calls Wrap again on the same record." That contract is preserved — Commit happens inside Wrap.
 
+The `c.mu.Lock()`/`defer c.mu.Unlock()` preserves the legacy single-mutex atomicity contract: concurrent Wrap calls cannot interleave `alloc.Next()` from one goroutine with `chain.Compute()`/`chain.Commit()` from another, which would produce ErrStaleResult and latch the chain fatal. The wrapper mutex always wraps calls into `c.alloc` / `c.chain`; there is no path where component code calls back into the wrapper, so no lock-ordering hazard exists.
+
 - [ ] **Step 4: Replace `State()` to delegate**
 
 Replace the body of `State()` (currently lines 254-262) with:
@@ -1652,6 +1670,8 @@ Replace the body of `State()` (currently lines 254-262) with:
 ```go
 // State returns the last written chain state for persistence.
 func (c *IntegrityChain) State() ChainState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	allocState := c.alloc.State()
 	chainState := c.chain.State()
 	return ChainState{
@@ -1660,6 +1680,8 @@ func (c *IntegrityChain) State() ChainState {
 	}
 }
 ```
+
+The wrapper mutex makes the `(sequence, prev_hash)` snapshot consistent: callers cannot observe a torn read where the allocator has advanced past N but the chain still reports `prev_hash` for N-1 (or vice versa). Without the wrapper mutex, the two component `State()` calls would interleave with concurrent `Wrap()` calls.
 
 - [ ] **Step 5: Replace `Restore()` to delegate**
 
@@ -1672,11 +1694,31 @@ Replace the body of `Restore()` (currently lines 264-271) with:
 // Aggregates errors from the underlying allocator and sink chain restores —
 // SequenceAllocator.Restore rejects sequence < -1, and SinkChain.Restore
 // rejects malformed prev_hash (non-hex or wrong length for the algorithm).
+//
+// Restore is all-or-nothing: if either component rejects its input, the
+// IntegrityChain is left in its pre-call state. The implementation
+// snapshots the allocator before mutating and rolls it back if the chain
+// restore is rejected. The wrapper mutex serializes Restore against
+// concurrent Wrap and State calls.
 func (c *IntegrityChain) Restore(sequence int64, prevHash string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Snapshot allocator state for rollback so Restore is all-or-nothing:
+	// if chain restoration fails, the allocator must not be observed as
+	// partially restored. SequenceAllocator.Restore validates Sequence >= -1
+	// before mutating; SinkChain.Restore validates prevHash format before
+	// mutating. We attempt allocator first; if chain restore rejects the
+	// prevHash, we restore the allocator to the pre-call snapshot.
+	prevAlloc := c.alloc.State()
+
 	if err := c.alloc.Restore(AllocatorState{Sequence: sequence, Generation: 0}); err != nil {
 		return fmt.Errorf("restore allocator: %w", err)
 	}
 	if err := c.chain.Restore(0, prevHash, false); err != nil {
+		// Roll back allocator. prevAlloc came from State() so it satisfies
+		// the Sequence >= -1 invariant; this rollback cannot fail.
+		_ = c.alloc.Restore(prevAlloc)
 		return fmt.Errorf("restore chain: %w", err)
 	}
 	return nil
@@ -1684,6 +1726,8 @@ func (c *IntegrityChain) Restore(sequence int64, prevHash string) error {
 ```
 
 Note: legacy `IntegrityChain` does not expose generation (its callers were single-sink with no rotation concept beyond key change, which today is handled via key-fingerprint mismatch detection in `internal/store/integrity_wrapper.go`). We pin generation=0 to keep behavior identical. Fatal is also pinned to false — the legacy single-sink Wrap path has no Fatal latch concept; ambiguous-write recovery is the new `SinkChain.Fatal`/`Compute`/`Commit` API.
+
+The all-or-nothing semantics matter because callers (`internal/store/integrity_wrapper.go`) use Restore both during startup recovery and after a clean-failure write to roll the chain back to its pre-write state. A half-restored wrapper (allocator advanced, chain unchanged) would silently corrupt subsequent Wrap output. Both component `Restore`s validate their input before mutating, so the rollback `c.alloc.Restore(prevAlloc)` cannot itself fail (we are restoring a value we just read from `State()`).
 
 The new error return is a behavior change for existing callers (`internal/store/integrity_wrapper.go` etc.) — those callers must be updated to check the error. The change mirrors what we already did for `SequenceAllocator.Restore` in Task 2.
 
@@ -1751,6 +1795,20 @@ If any test fails, the most likely culprits are:
 - `Restore` not pinning generation correctly (chain.Restore(0, prevHash, false) is required)
 - `State()` returning wrong sequence after Wrap (allocator's `State()` is the last-returned sequence, which matches what the old code stored in `c.sequence`)
 - Overflow test expecting `c.sequence == math.MaxInt64` — the new code triggers overflow inside `c.alloc.Next()` and returns `ErrSequenceOverflow` from there, identical to the old behavior
+
+- [ ] **Step 7b: Add regression tests for the wrapper-mutex contract**
+
+Add three regression tests in `internal/audit/integrity_test.go` covering the new failure modes the composition boundary would otherwise introduce:
+
+1. **`TestIntegrityChain_Wrap_ConcurrentSafety`** — fire 50 goroutines × 20 `Wrap()` calls (1000 entries total) with distinct payloads. After all complete, parse each wrapped entry, build `map[seq]entry_hash` and `map[seq]prev_hash`, assert sequences are exactly `{0..999}`, assert `prev_hash[seq] == entry_hash[seq-1]` for `seq > 0` and `prev_hash[0] == ""`, and verify each entry with `chain.VerifyWrapped`. Without the wrapper mutex, concurrent `Wrap` produces ErrStaleResult or breaks chain integrity.
+2. **`TestIntegrityChain_State_SnapshotConsistency`** — start a goroutine that calls `Wrap` in a loop (200 iterations) and records `(sequence, entry_hash)` in a `sync.Map`. In parallel, sample `chain.State()` repeatedly (200 times). For each sampled state, assert `entry_hash(state.Sequence) == state.PrevHash` (with `state.Sequence == -1` and empty `PrevHash` as the legitimate pre-Wrap genesis snapshot). Without the wrapper mutex, `State()` returns torn `(sequence, prev_hash)` reads.
+3. **`TestIntegrityChain_Restore_PartialFailure_LeavesStateIntact`** — Wrap a few entries, snapshot `S0 = chain.State()`. Call `chain.Restore(99, "not-valid-hex")`; assert the call returns an error wrapping `ErrInvalidChainState`. Then assert `chain.State()` equals `S0` byte-for-byte and that a subsequent `chain.Wrap(...)` produces an entry whose `Sequence == S0.Sequence + 1` and `PrevHash == S0.PrevHash` (proving allocator was not advanced by the rejected Restore).
+
+```bash
+go test ./internal/audit/... -count=1 -race -run 'IntegrityChain_Wrap_ConcurrentSafety|IntegrityChain_State_SnapshotConsistency|IntegrityChain_Restore_PartialFailure_LeavesStateIntact'
+```
+
+Expected: PASS under `-race`. The `-race` flag is essential because the concurrency tests assert behavior that the data-race detector alone won't surface (the races here are logical, not memory-level).
 
 - [ ] **Step 8: Run the full test suite**
 

--- a/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
@@ -638,12 +638,12 @@ func TestSinkChain_Compute_FirstEntryUsesEmptyPrev(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Compute: %v", err)
 	}
-	if result.PrevHash != "" {
-		t.Errorf("first Compute: prevHash = %q, want empty", result.PrevHash)
+	if result.PrevHash() != "" {
+		t.Errorf("first Compute: prevHash = %q, want empty", result.PrevHash())
 	}
 	want := computeExpectedHash(t, key, IntegrityFormatVersion, 0, "", payload)
-	if result.EntryHash != want {
-		t.Errorf("entryHash = %q, want %q", result.EntryHash, want)
+	if result.EntryHash() != want {
+		t.Errorf("entryHash = %q, want %q", result.EntryHash(), want)
 	}
 }
 
@@ -662,8 +662,8 @@ func TestSinkChain_Compute_IsPure_NoMutationWithoutCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if first.EntryHash != second.EntryHash {
-		t.Errorf("Compute mutated chain state: first=%q second=%q", first.EntryHash, second.EntryHash)
+	if first.EntryHash() != second.EntryHash() {
+		t.Errorf("Compute mutated chain state: first=%q second=%q", first.EntryHash(), second.EntryHash())
 	}
 }
 
@@ -682,12 +682,12 @@ func TestSinkChain_Commit_AdvancesPrevHash(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if second.PrevHash != first.EntryHash {
-		t.Errorf("after Commit: prev_hash = %q, want %q", second.PrevHash, first.EntryHash)
+	if second.PrevHash() != first.EntryHash() {
+		t.Errorf("after Commit: prev_hash = %q, want %q", second.PrevHash(), first.EntryHash())
 	}
-	want := computeExpectedHash(t, key, IntegrityFormatVersion, 1, first.EntryHash, []byte(`{"b":2}`))
-	if second.EntryHash != want {
-		t.Errorf("second entryHash = %q, want %q", second.EntryHash, want)
+	want := computeExpectedHash(t, key, IntegrityFormatVersion, 1, first.EntryHash(), []byte(`{"b":2}`))
+	if second.EntryHash() != want {
+		t.Errorf("second entryHash = %q, want %q", second.EntryHash(), want)
 	}
 }
 
@@ -708,12 +708,12 @@ func TestSinkChain_Compute_GenerationRollover_ResetsPrevToEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r1.PrevHash != "" {
-		t.Errorf("after gen rollover: prev_hash = %q, want empty", r1.PrevHash)
+	if r1.PrevHash() != "" {
+		t.Errorf("after gen rollover: prev_hash = %q, want empty", r1.PrevHash())
 	}
 	want := computeExpectedHash(t, key, IntegrityFormatVersion, 0, "", []byte(`{"y":2}`))
-	if r1.EntryHash != want {
-		t.Errorf("rolled entryHash = %q, want %q", r1.EntryHash, want)
+	if r1.EntryHash() != want {
+		t.Errorf("rolled entryHash = %q, want %q", r1.EntryHash(), want)
 	}
 
 	// Until Commit(r1), the chain's recorded generation is still 0.
@@ -729,8 +729,8 @@ func TestSinkChain_Compute_GenerationRollover_ResetsPrevToEmpty(t *testing.T) {
 	if state.Generation != 1 {
 		t.Errorf("State.Generation after Commit = %d, want 1", state.Generation)
 	}
-	if state.PrevHash != r1.EntryHash {
-		t.Errorf("State.PrevHash = %q, want %q", state.PrevHash, r1.EntryHash)
+	if state.PrevHash != r1.EntryHash() {
+		t.Errorf("State.PrevHash = %q, want %q", state.PrevHash, r1.EntryHash())
 	}
 }
 
@@ -768,8 +768,8 @@ func TestSinkChain_State_Restore_RoundTrip(t *testing.T) {
 	}
 
 	state := c.State()
-	if state.Generation != 0 || state.PrevHash != r1.EntryHash {
-		t.Fatalf("State() = %+v, want {Generation:0 PrevHash:%q}", state, r1.EntryHash)
+	if state.Generation != 0 || state.PrevHash != r1.EntryHash() {
+		t.Fatalf("State() = %+v, want {Generation:0 PrevHash:%q}", state, r1.EntryHash())
 	}
 
 	d, _ := newTestSinkChain(t)
@@ -787,8 +787,8 @@ func TestSinkChain_State_Restore_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cNext.EntryHash != dNext.EntryHash {
-		t.Errorf("after Restore: entryHash mismatch %q vs %q", cNext.EntryHash, dNext.EntryHash)
+	if cNext.EntryHash() != dNext.EntryHash() {
+		t.Errorf("after Restore: entryHash mismatch %q vs %q", cNext.EntryHash(), dNext.EntryHash())
 	}
 }
 
@@ -847,7 +847,7 @@ func TestSinkChain_SerialComputeCommit_NoChainBreakage(t *testing.T) {
 				return
 			}
 			mu.Lock()
-			records = append(records, record{seq: i, payload: payload, entryHash: result.EntryHash, prevHash: result.PrevHash})
+			records = append(records, record{seq: i, payload: payload, entryHash: result.EntryHash(), prevHash: result.PrevHash()})
 			mu.Unlock()
 		}
 	}()
@@ -897,14 +897,14 @@ func TestSinkChain_Compute_IsPureUnderConcurrentCallers(t *testing.T) {
 	if len(results) != N {
 		t.Fatalf("got %d results, want %d", len(results), N)
 	}
-	wantEntry := results[0].EntryHash
-	wantPrev := results[0].PrevHash
+	wantEntry := results[0].EntryHash()
+	wantPrev := results[0].PrevHash()
 	for i, r := range results {
-		if r.EntryHash != wantEntry {
-			t.Errorf("result %d: entry=%q, want %q (Compute is not pure under contention)", i, r.EntryHash, wantEntry)
+		if r.EntryHash() != wantEntry {
+			t.Errorf("result %d: entry=%q, want %q (Compute is not pure under contention)", i, r.EntryHash(), wantEntry)
 		}
-		if r.PrevHash != wantPrev {
-			t.Errorf("result %d: prev=%q, want %q (Compute is not pure under contention)", i, r.PrevHash, wantPrev)
+		if r.PrevHash() != wantPrev {
+			t.Errorf("result %d: prev=%q, want %q (Compute is not pure under contention)", i, r.PrevHash(), wantPrev)
 		}
 	}
 }
@@ -1024,7 +1024,7 @@ func TestSinkChain_Commit_BackwardsGenerationLatchesFatal(t *testing.T) {
 	if older.generation != 1 {
 		t.Fatalf("older.generation = %d, want 1", older.generation)
 	}
-	if err := c.Restore(2, r2.EntryHash, false); err != nil {
+	if err := c.Restore(2, r2.EntryHash(), false); err != nil {
 		t.Fatalf("Restore: %v", err)
 	}
 
@@ -1131,12 +1131,57 @@ import (
 // Compute → durable write → Commit (or Fatal) in sequence per event.
 //
 // Compute/Commit token contract: Compute returns a *ComputeResult that
-// callers MUST pass to Commit unchanged. The unexported fields on
-// ComputeResult let Commit verify the result really came from Compute on
-// this chain. Callers cannot construct a ComputeResult literal because
-// the unexported fields make that impossible from outside the audit
-// package; this prevents Commit from accepting a fabricated EntryHash
-// that Compute would never have produced.
+// callers MUST pass to Commit unchanged. ComputeResult is opaque
+// (unexported fields, accessor methods) and chain-bound — only the
+// SinkChain instance that produced the result can commit it. The
+// unexported fields make literal construction or post-Compute mutation
+// impossible from outside the audit package.
+//
+// Enforced invariants on Commit:
+//   - nil ComputeResult → error (no latch).
+//   - Post-Fatal Commit → ErrFatalIntegrity (no further latch).
+//   - Cross-chain ComputeResult (one produced by a different SinkChain
+//     instance) → ErrCrossChainResult, latches fatal on this chain.
+//   - Backwards generation → ErrBackwardsGeneration, latches fatal.
+//   - Stale prev_hash within the current generation, or non-empty prev_hash
+//     on a rollover commit → ErrStaleResult, latches fatal.
+//   - Otherwise, generation and prev_hash advance.
+//
+// ComputeResult is opaque (unexported fields, accessor methods) and
+// chain-bound (cannot be committed on a different SinkChain). Callers that
+// need to serialize a result use EntryHash() and PrevHash(). The
+// unexported (sequence, generation, chain) fields make it impossible to
+// fabricate or cross-mix tokens outside the audit package.
+//
+// Contract — what remains the caller's responsibility:
+//
+//   - Serialize Compute → durable write → Commit per record. SinkChain
+//     does NOT detect concurrent overlapping Compute/Commit pairs from
+//     multiple goroutines; the (sequence, generation) tuple is not a
+//     unique identifier within a generation.
+//   - Do not concurrently Compute+Commit across goroutines. Commit only
+//     validates the result against the chain's CURRENT prev_hash; if two
+//     goroutines race a Compute → Commit pair, the second Commit will
+//     either appear stale (good — caught) or appear fresh (bad — silently
+//     accepted) depending on interleaving. The single-owner pattern is
+//     the only safe one.
+//   - Only call Commit with a result whose durable write actually
+//     succeeded. SinkChain has no knowledge of durable state; Commit on a
+//     result whose write failed silently advances the in-memory chain
+//     past an entry that does not exist in storage.
+//
+// Recovery — a fatal latch makes the SinkChain instance unusable:
+//
+//   - All subsequent Compute calls return ErrFatalIntegrity.
+//   - All subsequent Commit calls return ErrFatalIntegrity.
+//   - The latch survives State()/Restore() round-trips (Fatal is part of
+//     SinkChainState).
+//   - The instance must be recreated via NewSinkChain (and a fresh
+//     generation established externally — typically by rotating the
+//     chain key and bumping the SequenceAllocator's generation, then
+//     wiring a fresh SinkChain into the sink). There is no in-place
+//     reset method by design: a fatal latch indicates an integrity
+//     event the operator must observe.
 type SinkChain struct {
 	mu         sync.Mutex
 	key        []byte
@@ -1159,34 +1204,27 @@ type SinkChainState struct {
 	Fatal      bool
 }
 
-// ComputeResult is the typed output of SinkChain.Compute. It is the only
-// value Commit will accept. The exported fields are inspectable; the
-// unexported fields let Commit verify it really came out of Compute and
-// that no impossible state transition is being requested.
+// ComputeResult is the opaque, chain-bound output of SinkChain.Compute. It is
+// the only value Commit will accept, and only the SinkChain instance that
+// produced it can commit it. Fields are unexported so callers cannot mutate
+// or fabricate one outside the audit package.
 //
-// Callers MUST NOT construct ComputeResult literals — only Compute returns
-// valid ones. The unexported fields make literal construction impossible
-// outside the audit package; that is load-bearing for the chain-state
-// invariants Commit enforces.
+// Use EntryHash() and PrevHash() to inspect the values for serialization.
 type ComputeResult struct {
-	// EntryHash is the HMAC of (formatVersion | sequence | prevHash |
-	// payload) under the chain's key. Inspectable — callers serialize this
-	// into the entry's integrity metadata.
-	EntryHash string
-
-	// PrevHash is the prev_hash that was hashed into EntryHash. For the
-	// first entry of a chain (or the first entry after a generation
-	// rollover) this is the empty string. Inspectable — callers serialize
-	// this into the entry's integrity metadata.
-	PrevHash string
-
-	// sequence and generation are unexported so external packages cannot
-	// fabricate a ComputeResult with arbitrary state. Commit reads these
-	// to enforce chain-state invariants (e.g., backwards-generation Commit
-	// is a caller bug and latches fatal).
+	entryHash  string
+	prevHash   string
 	sequence   int64
 	generation uint32
+	chain      *SinkChain // identity-bound; Commit verifies result.chain == c
 }
+
+// EntryHash returns the HMAC entry hash that should be persisted alongside
+// the payload for later integrity verification.
+func (r *ComputeResult) EntryHash() string { return r.entryHash }
+
+// PrevHash returns the prev_hash the entry was chained against. For the
+// genesis entry of a chain or generation, this is "".
+func (r *ComputeResult) PrevHash() string { return r.prevHash }
 
 // ErrFatalIntegrity is returned by Compute after Fatal has been called,
 // and by Commit when called on a chain that was latched Fatal (either by
@@ -1205,6 +1243,33 @@ var ErrMissingChainState = errors.New("event missing Chain field; composite did 
 // hex string of the algorithm's expected length). The chain is not
 // modified on rejected restore.
 var ErrInvalidChainState = errors.New("invalid sink chain state")
+
+// ErrBackwardsGeneration is wrapped by Commit when the result's generation
+// is older than the chain's current generation. Latches the chain fatal:
+// the durable write succeeded for an entry whose generation is no longer
+// current, so silently accepting it would leave in-memory prev_hash
+// lagging the durable state and corrupt subsequent Compute results.
+var ErrBackwardsGeneration = errors.New("backwards-generation Commit: chain latched fatal")
+
+// ErrStaleResult is wrapped by Commit when the result was computed against
+// an obsolete chain head. Two cases:
+//
+//   - same-generation: result.PrevHash != c.prevHash (a prior Commit
+//     advanced prev_hash between this result's Compute and Commit).
+//   - rollover: result.generation > c.generation but result.PrevHash != ""
+//     (rollover results MUST have empty PrevHash; this branch is
+//     defense-in-depth).
+//
+// In either case the chain latches fatal: silently accepting the stale
+// result would fork the chain.
+var ErrStaleResult = errors.New("stale ComputeResult: caller committed against an obsolete chain head; chain latched fatal")
+
+// ErrCrossChainResult is wrapped by Commit when the supplied ComputeResult
+// was produced by a different SinkChain instance. The misuse latches fatal
+// on the receiving chain so the programming error becomes loud rather than
+// silently corrupting state. The chain that produced the result is
+// unaffected.
+var ErrCrossChainResult = errors.New("ComputeResult bound to a different SinkChain")
 
 // NewSinkChain creates a new chain keyed by `key` (must be >= MinKeyLength).
 // Supported algorithms: "hmac-sha256" (default), "hmac-sha512".
@@ -1230,6 +1295,10 @@ func NewSinkChain(key []byte, algorithm string) (*SinkChain, error) {
 // (passing the returned *ComputeResult) on durable-write success or
 // discard the result on durable-write failure.
 //
+// The returned *ComputeResult is bound to this SinkChain instance — only
+// Commit on this same chain will accept it. Cross-chain commits fail with
+// ErrCrossChainResult and latch the receiving chain fatal.
+//
 // If `generation` differs from the chain's current generation, prev_hash
 // is treated as "" for this Compute (chain rolls automatically). The
 // transition is committed only when Commit is called with a result whose
@@ -1251,10 +1320,11 @@ func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32
 		return nil, err
 	}
 	return &ComputeResult{
-		EntryHash:  hash,
-		PrevHash:   prev,
+		entryHash:  hash,
+		prevHash:   prev,
 		sequence:   sequence,
 		generation: generation,
+		chain:      c,
 	}, nil
 }
 
@@ -1267,16 +1337,34 @@ func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32
 // Returns an error if `result` is nil (caller bug; chain is not modified).
 //
 // Returns ErrFatalIntegrity if the chain was previously latched Fatal —
-// either by an explicit Fatal call or by a prior backwards-generation
+// either by an explicit Fatal call, by a prior backwards-generation
+// Commit, by a prior stale-result Commit, or by a prior cross-chain
 // Commit. The chain stays latched.
 //
-// Returns a non-nil error AND latches the chain Fatal if the result's
-// generation is older than the chain's current generation. This indicates
-// a caller bug: the durable write succeeded for an entry whose generation
-// is no longer current, so accepting the Commit would leave in-memory
-// prev_hash lagging the durable state and silently corrupt subsequent
-// Compute results. Latching fatal makes the divergence visible
-// immediately rather than later as a chain-break.
+// Returns an error wrapping ErrCrossChainResult AND latches the chain
+// Fatal if the supplied ComputeResult was produced by a different
+// SinkChain instance. The cross-chain check runs BEFORE
+// generation/prev_hash validation so that mixing tokens between chains is
+// always reported as a cross-chain error rather than as a downstream
+// invariant violation.
+//
+// Returns an error wrapping ErrBackwardsGeneration AND latches the chain
+// Fatal if the result's generation is older than the chain's current
+// generation. Accepting it would leave in-memory prev_hash lagging the
+// durable state and silently corrupt subsequent Compute results.
+//
+// Returns an error wrapping ErrStaleResult AND latches the chain Fatal in
+// two cases that both indicate the result was computed against an
+// obsolete chain head:
+//
+//   - result.generation == c.generation and result.PrevHash != c.prevHash:
+//     a prior Commit advanced prev_hash between this result's Compute and
+//     Commit. Silently accepting would fork the chain.
+//   - result.generation > c.generation and result.PrevHash != "": rollover
+//     results MUST have empty PrevHash (Compute always sets prev="" on
+//     rollover). A non-empty PrevHash here means the result was forged or
+//     computed against mismatched state. Defense-in-depth: normal callers
+//     cannot construct this via the public API.
 func (c *SinkChain) Commit(result *ComputeResult) error {
 	if result == nil {
 		return errors.New("nil ComputeResult")
@@ -1286,13 +1374,42 @@ func (c *SinkChain) Commit(result *ComputeResult) error {
 	if c.fatal {
 		return ErrFatalIntegrity
 	}
+	// Cross-chain check runs first so that mixing tokens between chains
+	// always surfaces as ErrCrossChainResult, not as a downstream
+	// generation/prev_hash invariant violation.
+	if result.chain != c {
+		c.fatal = true
+		return fmt.Errorf("%w", ErrCrossChainResult)
+	}
 	if result.generation < c.generation {
 		c.fatal = true
-		return fmt.Errorf("backwards generation Commit: result.generation=%d < c.generation=%d (caller bug, chain latched fatal)",
-			result.generation, c.generation)
+		return fmt.Errorf("%w: result.generation=%d < c.generation=%d",
+			ErrBackwardsGeneration, result.generation, c.generation)
+	}
+	// Stale-token detection — fatal latch.
+	// Two cases:
+	//   * result.generation == c.generation: result.prevHash MUST equal
+	//     c.prevHash. Mismatch means the caller computed against an older
+	//     chain head and is replaying a stale token.
+	//   * result.generation > c.generation: this is a rollover commit. The
+	//     result MUST have prevHash == "" because Compute used "" for the
+	//     rolled gen. Anything else means the result was forged or computed
+	//     against mismatched state.
+	if result.generation == c.generation {
+		if result.prevHash != c.prevHash {
+			c.fatal = true
+			return fmt.Errorf("%w: result.prev_hash=%q, current prev_hash=%q",
+				ErrStaleResult, result.prevHash, c.prevHash)
+		}
+	} else { // result.generation > c.generation (rollover)
+		if result.prevHash != "" {
+			c.fatal = true
+			return fmt.Errorf("%w: rollover commit must have empty prev_hash; got %q",
+				ErrStaleResult, result.prevHash)
+		}
 	}
 	c.generation = result.generation
-	c.prevHash = result.EntryHash
+	c.prevHash = result.entryHash
 	return nil
 }
 
@@ -1365,7 +1482,7 @@ func validatePrevHash(algorithm, prevHash string) error {
 go test ./internal/audit/ -run "TestSinkChain|TestNewSinkChain" -v
 ```
 
-Expected: all 15 tests PASS.
+Expected: all 19 tests PASS.
 
 - [ ] **Step 5: Run the full audit test suite**
 
@@ -1480,8 +1597,8 @@ func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error) {
 	data["integrity"] = IntegrityMetadata{
 		FormatVersion: IntegrityFormatVersion,
 		Sequence:      seq,
-		PrevHash:      result.PrevHash,
-		EntryHash:     result.EntryHash,
+		PrevHash:      result.PrevHash(),
+		EntryHash:     result.EntryHash(),
 	}
 
 	wrapped, err := json.Marshal(data)
@@ -1989,8 +2106,8 @@ func (s *chainingFakeSink) AppendEvent(ctx context.Context, ev types.Event) erro
 		s.records = append(s.records, chainRecord{
 			Sequence:   seq,
 			Generation: gen,
-			EntryHash:  result.EntryHash,
-			PrevHash:   result.PrevHash,
+			EntryHash:  result.EntryHash(),
+			PrevHash:   result.PrevHash(),
 		})
 		s.mu.Unlock()
 		return nil

--- a/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
@@ -259,7 +259,10 @@ func TestSequenceAllocator_NextGeneration_ResetsSequence(t *testing.T) {
 	}
 	// State now: sequence=1, gen=0; next Next() would return (2, 0).
 
-	newGen := a.NextGeneration()
+	newGen, err := a.NextGeneration()
+	if err != nil {
+		t.Fatalf("NextGeneration: %v", err)
+	}
 	if newGen != 1 {
 		t.Fatalf("NextGeneration() = %d, want 1", newGen)
 	}
@@ -280,7 +283,9 @@ func TestSequenceAllocator_State_Restore_RoundTrip(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	a.NextGeneration()
+	if _, err := a.NextGeneration(); err != nil {
+		t.Fatal(err)
+	}
 	if _, _, err := a.Next(); err != nil {
 		t.Fatal(err)
 	}
@@ -292,7 +297,9 @@ func TestSequenceAllocator_State_Restore_RoundTrip(t *testing.T) {
 	}
 
 	b := NewSequenceAllocator()
-	b.Restore(state)
+	if err := b.Restore(state); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
 	seq, gen, err := b.Next()
 	if err != nil {
 		t.Fatalf("Next after Restore: %v", err)
@@ -304,7 +311,9 @@ func TestSequenceAllocator_State_Restore_RoundTrip(t *testing.T) {
 
 func TestSequenceAllocator_Overflow(t *testing.T) {
 	a := NewSequenceAllocator()
-	a.Restore(AllocatorState{Sequence: math.MaxInt64, Generation: 0})
+	if err := a.Restore(AllocatorState{Sequence: math.MaxInt64, Generation: 0}); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
 
 	_, _, err := a.Next()
 	if !errors.Is(err, ErrSequenceOverflow) {
@@ -348,6 +357,70 @@ func TestSequenceAllocator_ConcurrentNext_NoDuplicates(t *testing.T) {
 		t.Fatalf("got %d unique sequences, want %d", len(seen), workers*perWorker)
 	}
 }
+
+func TestSequenceAllocator_NextGeneration_Overflow(t *testing.T) {
+	a := NewSequenceAllocator()
+	if err := a.Restore(AllocatorState{Sequence: -1, Generation: math.MaxUint32}); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	_, err := a.NextGeneration()
+	if !errors.Is(err, ErrGenerationOverflow) {
+		t.Fatalf("NextGeneration at MaxUint32: err = %v, want ErrGenerationOverflow", err)
+	}
+
+	// Allocator must not be mutated by a rejected NextGeneration.
+	state := a.State()
+	if state.Generation != math.MaxUint32 {
+		t.Fatalf("Generation mutated after rejected NextGeneration: got %d, want MaxUint32", state.Generation)
+	}
+	if state.Sequence != -1 {
+		t.Fatalf("Sequence mutated after rejected NextGeneration: got %d, want -1", state.Sequence)
+	}
+
+	// Sequences in the current (max) generation must still allocate cleanly.
+	seq, gen, err := a.Next()
+	if err != nil {
+		t.Fatalf("Next after rejected NextGeneration: %v", err)
+	}
+	if seq != 0 || gen != math.MaxUint32 {
+		t.Fatalf("Next at max generation: got (%d, %d), want (0, MaxUint32)", seq, gen)
+	}
+}
+
+func TestSequenceAllocator_Restore_RejectsInvalidSequence(t *testing.T) {
+	a := NewSequenceAllocator()
+	// Allocate one tuple so we have non-default state to verify we don't perturb on reject.
+	if _, _, err := a.Next(); err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	pre := a.State()
+
+	for _, bad := range []int64{-2, -100, math.MinInt64} {
+		err := a.Restore(AllocatorState{Sequence: bad, Generation: 5})
+		if !errors.Is(err, ErrInvalidAllocatorState) {
+			t.Fatalf("Restore(Sequence=%d): err = %v, want ErrInvalidAllocatorState", bad, err)
+		}
+	}
+
+	// Allocator must be unchanged after rejected restores.
+	post := a.State()
+	if post != pre {
+		t.Fatalf("allocator mutated by rejected Restore: pre=%+v, post=%+v", pre, post)
+	}
+
+	// Boundary: Sequence == -1 is the valid minimum (means "no Next() yet").
+	if err := a.Restore(AllocatorState{Sequence: -1, Generation: 9}); err != nil {
+		t.Fatalf("Restore(Sequence=-1): %v", err)
+	}
+	seq, gen, err := a.Next()
+	if err != nil {
+		t.Fatalf("Next after Restore(-1, 9): %v", err)
+	}
+	if seq != 0 || gen != 9 {
+		t.Fatalf("after Restore(-1, 9): Next() = (%d, %d), want (0, 9)", seq, gen)
+	}
+}
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -366,9 +439,21 @@ Create `internal/audit/sequence_allocator.go`:
 package audit
 
 import (
+	"errors"
 	"math"
 	"sync"
 )
+
+// ErrGenerationOverflow is returned by NextGeneration when the generation
+// counter would wrap past math.MaxUint32. Reaching this is a fatal
+// integrity event — wrapping would re-use prior (sequence, generation)
+// tuples, defeating the new-generation boundary guarantee.
+var ErrGenerationOverflow = errors.New("integrity generation overflow")
+
+// ErrInvalidAllocatorState is returned by Restore when the supplied state
+// violates allocator invariants (e.g., Sequence < -1). The allocator is
+// not modified on rejected restore.
+var ErrInvalidAllocatorState = errors.New("invalid allocator state")
 
 // SequenceAllocator owns the shared (sequence, generation) tuple. It has no
 // hash state. Composite holds exactly one allocator and stamps every event
@@ -414,12 +499,20 @@ func (a *SequenceAllocator) Next() (sequence int64, generation uint32, err error
 // NextGeneration increments generation and resets sequence so the next Next()
 // returns (0, new_generation). Returns the new generation. Used by the
 // composite owner when the chain key rotates.
-func (a *SequenceAllocator) NextGeneration() uint32 {
+//
+// Returns ErrGenerationOverflow if generation == math.MaxUint32; the
+// allocator is not modified in that case. Reaching this is fatal — there
+// is no clean recovery short of provisioning a new allocator with a fresh
+// chain key namespace.
+func (a *SequenceAllocator) NextGeneration() (uint32, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	if a.generation == math.MaxUint32 {
+		return 0, ErrGenerationOverflow
+	}
 	a.generation++
 	a.sequence = -1
-	return a.generation
+	return a.generation, nil
 }
 
 // State returns the current (sequence, generation) for persistence. After
@@ -430,12 +523,18 @@ func (a *SequenceAllocator) State() AllocatorState {
 	return AllocatorState{Sequence: a.sequence, Generation: a.generation}
 }
 
-// Restore rehydrates allocator state after restart.
-func (a *SequenceAllocator) Restore(state AllocatorState) {
+// Restore rehydrates allocator state after restart. Returns
+// ErrInvalidAllocatorState if state.Sequence < -1 (which would violate the
+// monotonic-from-zero contract); the allocator is not modified in that case.
+func (a *SequenceAllocator) Restore(state AllocatorState) error {
+	if state.Sequence < -1 {
+		return ErrInvalidAllocatorState
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.sequence = state.Sequence
 	a.generation = state.Generation
+	return nil
 }
 ```
 
@@ -1245,7 +1344,10 @@ func TestComposite_NextGeneration_ResetsSequence(t *testing.T) {
 		}
 	}
 
-	newGen := s.NextGeneration()
+	newGen, err := s.NextGeneration()
+	if err != nil {
+		t.Fatalf("NextGeneration: %v", err)
+	}
 	if newGen != 1 {
 		t.Fatalf("NextGeneration() = %d, want 1", newGen)
 	}
@@ -1372,7 +1474,10 @@ Add `NextGeneration` method (place it directly below `AppendEvent`):
 // NextGeneration advances the shared sequence generation. The next
 // AppendEvent stamps ev.Chain with (Sequence:0, Generation:newGen).
 // Used by the composite owner when the chain key rotates.
-func (s *Store) NextGeneration() uint32 {
+//
+// Returns ErrGenerationOverflow on uint32 wrap; the allocator is not
+// modified in that case (see audit.SequenceAllocator.NextGeneration).
+func (s *Store) NextGeneration() (uint32, error) {
 	return s.allocator.NextGeneration()
 }
 ```
@@ -1588,7 +1693,10 @@ func TestPhase0_GenerationRollConsistency(t *testing.T) {
 		}
 	}
 
-	gen := s.NextGeneration()
+	gen, err := s.NextGeneration()
+	if err != nil {
+		t.Fatalf("NextGeneration: %v", err)
+	}
 	if gen != 1 {
 		t.Fatalf("NextGeneration() = %d, want 1", gen)
 	}

--- a/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/plans/2026-04-18-phase-0-shared-sequence-contract.md
@@ -27,7 +27,7 @@
 
 **Modify:**
 - `pkg/types/events.go` — add `ChainState` type and `Event.Chain *ChainState` field with `json:"-"`
-- `internal/audit/integrity.go` — refactor `IntegrityChain` internals to compose `SequenceAllocator` + `SinkChain`; preserve all public method signatures (`NewIntegrityChain`, `NewIntegrityChainWithAlgorithm`, `Wrap`, `State`, `Restore`, `KeyFingerprint`, `VerifyHash`, `VerifyWrapped`)
+- `internal/audit/integrity.go` — refactor `IntegrityChain` internals to compose `SequenceAllocator` + `SinkChain`; preserve `NewIntegrityChain`, `NewIntegrityChainWithAlgorithm`, `Wrap`, `State`, `KeyFingerprint`, `VerifyHash`, `VerifyWrapped` verbatim. `Restore` gains an `error` return (mirrors the SequenceAllocator.Restore and SinkChain.Restore validation; existing callers in `internal/store/` must check the error)
 - `internal/store/composite/composite.go` — add `allocator *audit.SequenceAllocator` field, stamp `ev.Chain` in `AppendEvent` before fanout, add `NextGeneration()` method
 
 ---
@@ -763,7 +763,9 @@ func TestSinkChain_State_Restore_RoundTrip(t *testing.T) {
 	}
 
 	d, _ := newTestSinkChain(t)
-	d.Restore(state.Generation, state.PrevHash)
+	if err := d.Restore(state.Generation, state.PrevHash, state.Fatal); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
 
 	// Continue the chain from d — same key, so same entry hash as if c
 	// had continued.
@@ -801,12 +803,14 @@ func TestNewSinkChain_RejectsUnsupportedAlgorithm(t *testing.T) {
 	}
 }
 
-func TestSinkChain_Concurrent_ComputeCommit_NoChainBreakage(t *testing.T) {
+func TestSinkChain_SerialComputeCommit_NoChainBreakage(t *testing.T) {
 	c, key := newTestSinkChain(t)
 
-	// Single owner serializes Compute+Commit pairs; this test asserts that
-	// repeated Compute under contention with Commit does not produce a
-	// chain that fails verification when replayed in committed order.
+	// Single-goroutine serialization verifies chain continuity; concurrent
+	// ComputeCommit pairs across goroutines is NOT a supported pattern (Commit
+	// cannot identify which Compute it finalizes). This test asserts that
+	// repeated Compute+Commit in serial order produces a chain that verifies
+	// when replayed in committed order.
 	const N = 200
 	type record struct {
 		seq       int64
@@ -852,6 +856,156 @@ func TestSinkChain_Concurrent_ComputeCommit_NoChainBreakage(t *testing.T) {
 		expectedPrev = r.entryHash
 	}
 }
+
+func TestSinkChain_Compute_IsPureUnderConcurrentCallers(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+	payload := []byte(`{"k":"v"}`)
+
+	const N = 32
+	type result struct {
+		entry string
+		prev  string
+	}
+	results := make([]result, 0, N)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			entry, prev, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+			if err != nil {
+				t.Errorf("Compute: %v", err)
+				return
+			}
+			mu.Lock()
+			results = append(results, result{entry: entry, prev: prev})
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	if len(results) != N {
+		t.Fatalf("got %d results, want %d", len(results), N)
+	}
+	wantEntry := results[0].entry
+	wantPrev := results[0].prev
+	for i, r := range results {
+		if r.entry != wantEntry {
+			t.Errorf("result %d: entry=%q, want %q (Compute is not pure under contention)", i, r.entry, wantEntry)
+		}
+		if r.prev != wantPrev {
+			t.Errorf("result %d: prev=%q, want %q (Compute is not pure under contention)", i, r.prev, wantPrev)
+		}
+	}
+}
+
+func TestSinkChain_State_PersistsFatal(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+
+	if _, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	c.Fatal(errors.New("ambiguous WAL write"))
+
+	state := c.State()
+	if !state.Fatal {
+		t.Fatalf("State.Fatal = false after Fatal(); want true")
+	}
+
+	// Round-trip into a fresh chain via Restore. The latch must survive.
+	d, _ := newTestSinkChain(t)
+	if err := d.Restore(state.Generation, state.PrevHash, state.Fatal); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if _, _, err := d.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`)); !errors.Is(err, ErrFatalIntegrity) {
+		t.Fatalf("Compute after Restore-with-Fatal: err = %v, want ErrFatalIntegrity", err)
+	}
+}
+
+func TestSinkChain_Restore_ValidatesPrevHash(t *testing.T) {
+	validSha256 := strings.Repeat("a", 64)  // 32 bytes hex-encoded
+	validSha512 := strings.Repeat("b", 128) // 64 bytes hex-encoded
+
+	cases := []struct {
+		name      string
+		algorithm string
+		prevHash  string
+		wantErr   bool
+	}{
+		{name: "empty is genesis", algorithm: "hmac-sha256", prevHash: "", wantErr: false},
+		{name: "valid sha256 hex", algorithm: "hmac-sha256", prevHash: validSha256, wantErr: false},
+		{name: "wrong length hex (sha512 under sha256)", algorithm: "hmac-sha256", prevHash: validSha512, wantErr: true},
+		{name: "non-hex characters", algorithm: "hmac-sha256", prevHash: strings.Repeat("z", 64), wantErr: true},
+		{name: "odd-length hex", algorithm: "hmac-sha256", prevHash: strings.Repeat("a", 63), wantErr: true},
+		{name: "valid sha512 hex under sha512", algorithm: "hmac-sha512", prevHash: validSha512, wantErr: false},
+		{name: "sha256 length under sha512", algorithm: "hmac-sha512", prevHash: validSha256, wantErr: true},
+		{name: "empty under sha512 is genesis", algorithm: "hmac-sha512", prevHash: "", wantErr: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			key := make([]byte, MinKeyLength)
+			c, err := NewSinkChain(key, tc.algorithm)
+			if err != nil {
+				t.Fatalf("NewSinkChain: %v", err)
+			}
+
+			// Capture pre-state to assert non-mutation on rejected restore.
+			before := c.State()
+
+			err = c.Restore(7, tc.prevHash, false)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Restore(%q): err = nil, want error", tc.prevHash)
+				}
+				if !errors.Is(err, ErrInvalidChainState) {
+					t.Errorf("Restore(%q): err = %v, want errors.Is ErrInvalidChainState", tc.prevHash, err)
+				}
+				after := c.State()
+				if after != before {
+					t.Errorf("rejected Restore mutated state: before=%+v after=%+v", before, after)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Restore(%q): unexpected err = %v", tc.prevHash, err)
+			}
+			after := c.State()
+			if after.Generation != 7 || after.PrevHash != tc.prevHash || after.Fatal {
+				t.Errorf("after Restore: state = %+v, want {Generation:7 PrevHash:%q Fatal:false}", after, tc.prevHash)
+			}
+		})
+	}
+}
+
+func TestSinkChain_Commit_BackwardsGenerationIsIgnored(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+
+	// Establish gen=2 with one committed entry.
+	if _, _, err := c.Compute(IntegrityFormatVersion, 0, 2, []byte(`{"a":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	h2, _, err := c.Compute(IntegrityFormatVersion, 0, 2, []byte(`{"a":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Commit(2, h2)
+
+	before := c.State()
+	if before.Generation != 2 || before.PrevHash != h2 {
+		t.Fatalf("setup: state = %+v, want {Generation:2 PrevHash:%q}", before, h2)
+	}
+
+	// Commit with an older generation must be a no-op.
+	c.Commit(1, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+
+	after := c.State()
+	if after.Generation != before.Generation || after.PrevHash != before.PrevHash {
+		t.Errorf("backwards-generation Commit mutated state: before=%+v after=%+v", before, after)
+	}
+}
 ```
 
 - [ ] **Step 2: Run tests to verify they fail**
@@ -871,6 +1025,7 @@ Create `internal/audit/sink_chain.go`:
 package audit
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
@@ -884,10 +1039,15 @@ import (
 // keys produces different entryHash values — that is the entire point of
 // per-sink chaining.
 //
-// Concurrency-safe. Compute+Commit pairs must be issued by a single
-// goroutine in order; concurrent Compute calls with interleaved Commits
-// is supported but each Commit applies to the most recent Compute that
-// observed the same prev_hash.
+// Concurrency model: single-owner serialized use. SinkChain is mutex-safe,
+// and concurrent Compute calls (with no intervening Commit) are pure and
+// return identical results — they do not corrupt state. However, callers
+// MUST NOT interleave Compute/Commit pairs across goroutines: Commit
+// carries no token identifying which Compute it finalizes, so a stale or
+// reordered Commit can overwrite prev_hash with a hash that does not
+// correspond to the most recent Compute. The expected pattern is a single
+// owner that issues Compute → durable write → Commit (or Fatal) in
+// sequence per event.
 type SinkChain struct {
 	mu         sync.Mutex
 	key        []byte
@@ -900,9 +1060,14 @@ type SinkChain struct {
 // SinkChainState is the persistent state of a SinkChain. The spec calls
 // this ChainState; renamed here to avoid colliding with the existing
 // audit.ChainState used by IntegrityChain.State().
+//
+// Fatal is included so persistence round-trips preserve the latch — a
+// chain that latched Fatal before a restart must come back latched after
+// Restore, otherwise the safety model is defeated.
 type SinkChainState struct {
 	Generation uint32
 	PrevHash   string
+	Fatal      bool
 }
 
 // ErrFatalIntegrity is returned by Compute after Fatal has been called.
@@ -915,6 +1080,12 @@ var ErrFatalIntegrity = errors.New("integrity chain latched fatal; sink must be 
 // configurations with chained sinks must always run inside a composite
 // with a SequenceAllocator.
 var ErrMissingChainState = errors.New("event missing Chain field; composite did not stamp it")
+
+// ErrInvalidChainState is returned by Restore when the supplied state
+// violates SinkChain invariants (e.g., prevHash is neither empty nor a
+// hex string of the algorithm's expected length). The chain is not
+// modified on rejected restore.
+var ErrInvalidChainState = errors.New("invalid sink chain state")
 
 // NewSinkChain creates a new chain keyed by `key` (must be >= MinKeyLength).
 // Supported algorithms: "hmac-sha256" (default), "hmac-sha512".
@@ -966,10 +1137,19 @@ func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32
 // succeeds. On ambiguous failure (write may or may not have landed), the
 // caller MUST call Fatal instead; Commit and Fatal are mutually exclusive
 // per Compute.
+//
+// Commit silently no-ops in two cases: (1) the chain has been latched Fatal,
+// and (2) `generation` is older than the chain's current generation —
+// rolling backwards across a generation boundary would re-use prior
+// (sequence, generation) tuples and corrupt the chain. The latter is a
+// caller programming error and is treated as ignorable rather than fatal.
 func (c *SinkChain) Commit(generation uint32, entryHash string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.fatal {
+		return
+	}
+	if generation < c.generation {
 		return
 	}
 	c.generation = generation
@@ -987,19 +1167,55 @@ func (c *SinkChain) Fatal(reason error) {
 	_ = reason // reserved for future telemetry; intentionally unused
 }
 
-// State returns the (generation, prev_hash) for persistence.
+// State returns the (generation, prev_hash, fatal) for persistence.
 func (c *SinkChain) State() SinkChainState {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return SinkChainState{Generation: c.generation, PrevHash: c.prevHash}
+	return SinkChainState{Generation: c.generation, PrevHash: c.prevHash, Fatal: c.fatal}
 }
 
-// Restore rehydrates chain state after restart.
-func (c *SinkChain) Restore(generation uint32, prevHash string) {
+// Restore rehydrates chain state after restart. Returns ErrInvalidChainState
+// if `prevHash` is neither empty (genesis) nor a hex string whose decoded
+// length matches the chain's algorithm output (32 bytes for hmac-sha256,
+// 64 bytes for hmac-sha512). The chain is not modified on rejected restore.
+//
+// If `fatal` is true, the chain comes back latched: subsequent Compute calls
+// return ErrFatalIntegrity. This is required so persistence round-trips
+// preserve the safety latch across restarts.
+func (c *SinkChain) Restore(generation uint32, prevHash string, fatal bool) error {
+	if err := validatePrevHash(c.algorithm, prevHash); err != nil {
+		return err
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.generation = generation
 	c.prevHash = prevHash
+	c.fatal = fatal
+	return nil
+}
+
+// validatePrevHash returns nil if prevHash is empty (genesis) or a valid
+// hex string of the algorithm's expected output length. Otherwise it
+// returns an error wrapping ErrInvalidChainState.
+func validatePrevHash(algorithm, prevHash string) error {
+	if prevHash == "" {
+		return nil
+	}
+	var wantBytes int
+	switch algorithm {
+	case "hmac-sha512":
+		wantBytes = 64
+	default: // hmac-sha256 (also default when algorithm == "")
+		wantBytes = 32
+	}
+	wantHex := wantBytes * 2
+	if len(prevHash) != wantHex {
+		return fmt.Errorf("%w: prevHash length %d, want %d hex chars for %s", ErrInvalidChainState, len(prevHash), wantHex, algorithm)
+	}
+	if _, err := hex.DecodeString(prevHash); err != nil {
+		return fmt.Errorf("%w: prevHash is not valid hex: %v", ErrInvalidChainState, err)
+	}
+	return nil
 }
 ```
 
@@ -1009,7 +1225,7 @@ func (c *SinkChain) Restore(generation uint32, prevHash string) {
 go test ./internal/audit/ -run "TestSinkChain|TestNewSinkChain" -v
 ```
 
-Expected: all 9 tests PASS.
+Expected: all 12 tests PASS.
 
 - [ ] **Step 5: Run the full audit test suite**
 
@@ -1163,13 +1379,24 @@ Replace the body of `Restore()` (currently lines 264-271) with:
 ```go
 // Restore restores the chain state after a restart.
 // The sequence must be the last written entry so the next Wrap continues at sequence+1.
-func (c *IntegrityChain) Restore(sequence int64, prevHash string) {
-	c.alloc.Restore(AllocatorState{Sequence: sequence, Generation: 0})
-	c.chain.Restore(0, prevHash)
+//
+// Aggregates errors from the underlying allocator and sink chain restores —
+// SequenceAllocator.Restore rejects sequence < -1, and SinkChain.Restore
+// rejects malformed prev_hash (non-hex or wrong length for the algorithm).
+func (c *IntegrityChain) Restore(sequence int64, prevHash string) error {
+	if err := c.alloc.Restore(AllocatorState{Sequence: sequence, Generation: 0}); err != nil {
+		return fmt.Errorf("restore allocator: %w", err)
+	}
+	if err := c.chain.Restore(0, prevHash, false); err != nil {
+		return fmt.Errorf("restore chain: %w", err)
+	}
+	return nil
 }
 ```
 
-Note: legacy `IntegrityChain` does not expose generation (its callers were single-sink with no rotation concept beyond key change, which today is handled via key-fingerprint mismatch detection in `internal/store/integrity_wrapper.go`). We pin generation=0 to keep behavior identical.
+Note: legacy `IntegrityChain` does not expose generation (its callers were single-sink with no rotation concept beyond key change, which today is handled via key-fingerprint mismatch detection in `internal/store/integrity_wrapper.go`). We pin generation=0 to keep behavior identical. Fatal is also pinned to false — the legacy single-sink Wrap path has no Fatal latch concept; ambiguous-write recovery is the new `SinkChain.Fatal`/`Compute`/`Commit` API.
+
+The new error return is a behavior change for existing callers (`internal/store/integrity_wrapper.go` etc.) — those callers must be updated to check the error. The change mirrors what we already did for `SequenceAllocator.Restore` in Task 2.
 
 - [ ] **Step 6: Update `KeyFingerprint()`, `VerifyHash()`, `VerifyWrapped()`, `computeHash()`**
 
@@ -1229,10 +1456,10 @@ go build ./...
 go test ./internal/audit/ -v
 ```
 
-Expected: clean build; all existing audit tests PASS without modification. Tests that exercise `chain.Restore(...)`, `chain.State()`, `chain.Wrap(...)` round-trips, sequence overflow at MaxInt64 — all of these continue to behave identically.
+Expected: clean build; existing audit tests for `chain.State()`, `chain.Wrap(...)` round-trips and sequence overflow at MaxInt64 continue to behave identically. Tests that call `chain.Restore(...)` will need a small update to handle the new `error` return — wrap each call with a nil-error check (`if err := chain.Restore(...); err != nil { t.Fatal(err) }`).
 
 If any test fails, the most likely culprits are:
-- `Restore` not pinning generation correctly (chain.Restore(0, prevHash) is required)
+- `Restore` not pinning generation correctly (chain.Restore(0, prevHash, false) is required)
 - `State()` returning wrong sequence after Wrap (allocator's `State()` is the last-returned sequence, which matches what the old code stored in `c.sequence`)
 - Overflow test expecting `c.sequence == math.MaxInt64` — the new code triggers overflow inside `c.alloc.Next()` and returns `ErrSequenceOverflow` from there, identical to the old behavior
 

--- a/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
@@ -122,24 +122,37 @@ type SinkChain struct { /* mu, key, algorithm, generation, prevHash, fatal */ }
 
 func NewSinkChain(key []byte, algorithm string) (*SinkChain, error)
 
-// ComputeResult is the typed token returned by SinkChain.Compute and
-// consumed by SinkChain.Commit. Only Compute can produce a valid one
-// (unexported fields make literal construction outside the package
-// impossible). Commit reads the unexported (sequence, generation) and
-// the exported PrevHash to enforce chain-state invariants — backwards-
-// generation, stale-token, and rollover-with-nonempty-prev all latch
-// fatal rather than silently corrupt the chain.
+// ComputeResult is the opaque, chain-bound token returned by
+// SinkChain.Compute and consumed by SinkChain.Commit. All fields are
+// unexported so callers cannot mutate or fabricate one outside the audit
+// package; EntryHash() and PrevHash() expose the values for serialization.
+// The result is identity-bound to the SinkChain instance that produced it
+// (chain pointer pinned at Compute time); only that same chain's Commit
+// will accept it. Commit enforces five invariants — nil result, post-fatal
+// commit, cross-chain misuse, backwards-generation, and stale-token (same-
+// generation prev_hash mismatch OR rollover-with-nonempty-prev) — with all
+// integrity-affecting violations latching fatal rather than silently
+// corrupting the chain.
 type ComputeResult struct {
-    EntryHash string // HMAC of (formatVersion | sequence | prevHash | payload)
-    PrevHash  string // prev_hash that was hashed into EntryHash
-    // unexported sequence, generation
+    // unexported: entryHash, prevHash, sequence, generation, chain
 }
 
+// EntryHash returns the HMAC entry hash that should be persisted alongside
+// the payload for later integrity verification.
+func (r *ComputeResult) EntryHash() string
+
+// PrevHash returns the prev_hash the entry was chained against. For the
+// genesis entry of a chain or generation, this is "".
+func (r *ComputeResult) PrevHash() string
+
 // Compute computes the HMAC over (formatVersion, sequence, prev_hash,
-// canonical_payload) using the chain's key and returns it as a typed
-// *ComputeResult. PURE: it does not mutate prev_hash. The caller must
-// follow with Commit on durable success or discard the result on durable
-// failure.
+// canonical_payload) using the chain's key and returns it as an opaque,
+// chain-bound *ComputeResult. PURE: it does not mutate prev_hash. The
+// returned result is bound to this SinkChain instance — only Commit on
+// this same chain will accept it; cross-chain commits fail with
+// ErrCrossChainResult and latch the receiving chain fatal. The caller
+// must follow with Commit on durable success or discard the result on
+// durable failure.
 //
 // If generation differs from the chain's current generation, Compute
 // treats prev_hash as "" (chain rolls automatically). The transition is
@@ -151,12 +164,17 @@ func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32
 // the durable write succeeds. On ambiguous failure, the caller MUST call
 // Fatal instead; Commit and Fatal are mutually exclusive per Compute.
 //
-// Three failure modes latch the chain Fatal and return a typed error
+// Four failure modes latch the chain Fatal and return a typed error
 // (callers use errors.Is to detect):
+//   - result.chain != c (ComputeResult was produced by a different
+//     SinkChain instance) → wraps ErrCrossChainResult. Checked FIRST so
+//     mixing tokens between chains always surfaces as cross-chain misuse,
+//     not as a downstream invariant violation. Latches the receiving
+//     chain only; the producing chain is unaffected.
 //   - result.generation < c.generation → wraps ErrBackwardsGeneration.
-//   - result.generation == c.generation but result.PrevHash != c.prevHash
+//   - result.generation == c.generation but result.PrevHash() != c.prevHash
 //     (stale token: a prior Commit advanced prev_hash) → wraps ErrStaleResult.
-//   - result.generation > c.generation but result.PrevHash != "" (rollover
+//   - result.generation > c.generation but result.PrevHash() != "" (rollover
 //     results MUST have empty prev_hash) → wraps ErrStaleResult.
 //
 // nil result returns an error WITHOUT latching fatal (caller bug, not an
@@ -191,6 +209,7 @@ var (
     ErrInvalidChainState   = errors.New("invalid sink chain state")
     ErrBackwardsGeneration = errors.New("backwards-generation Commit: chain latched fatal")
     ErrStaleResult         = errors.New("stale ComputeResult: caller committed against an obsolete chain head; chain latched fatal")
+    ErrCrossChainResult    = errors.New("ComputeResult bound to a different SinkChain")
 )
 ```
 
@@ -217,8 +236,8 @@ func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error) {
     wrapped := buildJSON(payload, IntegrityMetadata{
         FormatVersion: IntegrityFormatVersion,
         Sequence:      seq,
-        PrevHash:      result.PrevHash,
-        EntryHash:     result.EntryHash,
+        PrevHash:      result.PrevHash(),
+        EntryHash:     result.EntryHash(),
     })
     if err := c.chain.Commit(result); err != nil {
         return nil, err
@@ -300,7 +319,7 @@ func (s *MySink) AppendEvent(ctx context.Context, ev types.Event) error {
     }
 
     // Step 2: durable write. Failure modes split three ways.
-    werr := s.writeDurable(canonical, result.EntryHash, result.PrevHash)
+    werr := s.writeDurable(canonical, result.EntryHash(), result.PrevHash())
     switch {
     case werr == nil:
         // Step 3a: clean success → commit. A non-nil error from Commit means
@@ -338,7 +357,7 @@ When the composite owner rotates the chain key:
 
 1. Owner calls `composite.NextGeneration()` → returns new generation.
 2. Next `AppendEvent` call allocates `(seq=0, gen=new)`.
-3. Each chained sink observes `ev.Chain.Generation` differs from its `SinkChain.State().Generation`. `SinkChain.Compute` automatically uses `prev_hash = ""` for the new generation and returns a `*ComputeResult` with `PrevHash == ""` — the rollover signal. `Commit(result)` records the new generation.
+3. Each chained sink observes `ev.Chain.Generation` differs from its `SinkChain.State().Generation`. `SinkChain.Compute` automatically uses `prev_hash = ""` for the new generation and returns a `*ComputeResult` whose `PrevHash()` is `""` — the rollover signal. `Commit(result)` records the new generation.
 4. Per-sink work (e.g., WTP forces a batch flush + WAL segment roll + `SessionUpdate`) is triggered by the sink observing the generation change in `ev.Chain.Generation`.
 
 Generation is a property of the *shared allocator*, not of any individual sink. All sinks roll on the same logical event boundary — the first event with the new generation.

--- a/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
@@ -118,25 +118,51 @@ package audit
 // SinkChain owns prev_hash for one sink. Each chained sink holds one.
 // It is keyed: the same (seq, gen, prev_hash, payload) under different keys
 // produces different entry_hash values, which is the entire point.
-type SinkChain struct { /* mu, key, algorithm, generation, prevHash */ }
+type SinkChain struct { /* mu, key, algorithm, generation, prevHash, fatal */ }
 
 func NewSinkChain(key []byte, algorithm string) (*SinkChain, error)
 
-// Compute computes the HMAC over (formatVersion, sequence, generation,
-// prev_hash, canonical_payload) using the chain's key. It is PURE: it does
-// not mutate prev_hash. The caller must follow with Commit on durable success
-// or discard the result on durable failure.
-//
-// If generation differs from the chain's current generation, Compute treats
-// prev_hash as "" (chain rolls automatically). The transition is committed
-// only when Commit is called.
-func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32, payload []byte) (entryHash string, prevHash string, err error)
+// ComputeResult is the typed token returned by SinkChain.Compute and
+// consumed by SinkChain.Commit. Only Compute can produce a valid one
+// (unexported fields make literal construction outside the package
+// impossible). Commit reads the unexported (sequence, generation) and
+// the exported PrevHash to enforce chain-state invariants — backwards-
+// generation, stale-token, and rollover-with-nonempty-prev all latch
+// fatal rather than silently corrupt the chain.
+type ComputeResult struct {
+    EntryHash string // HMAC of (formatVersion | sequence | prevHash | payload)
+    PrevHash  string // prev_hash that was hashed into EntryHash
+    // unexported sequence, generation
+}
 
-// Commit advances prev_hash to entryHash. Must be called exactly once per
-// successful Compute, after the durable write succeeds. On ambiguous failure
-// (write may or may not have landed), the caller MUST call Fatal instead;
-// Commit and Fatal are mutually exclusive per Compute.
-func (c *SinkChain) Commit(generation uint32, entryHash string)
+// Compute computes the HMAC over (formatVersion, sequence, prev_hash,
+// canonical_payload) using the chain's key and returns it as a typed
+// *ComputeResult. PURE: it does not mutate prev_hash. The caller must
+// follow with Commit on durable success or discard the result on durable
+// failure.
+//
+// If generation differs from the chain's current generation, Compute
+// treats prev_hash as "" (chain rolls automatically). The transition is
+// committed only when Commit is called with the rollover result.
+func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32, payload []byte) (*ComputeResult, error)
+
+// Commit advances prev_hash using the result of a previous Compute on
+// this chain. Must be called exactly once per successful Compute, after
+// the durable write succeeds. On ambiguous failure, the caller MUST call
+// Fatal instead; Commit and Fatal are mutually exclusive per Compute.
+//
+// Three failure modes latch the chain Fatal and return a typed error
+// (callers use errors.Is to detect):
+//   - result.generation < c.generation → wraps ErrBackwardsGeneration.
+//   - result.generation == c.generation but result.PrevHash != c.prevHash
+//     (stale token: a prior Commit advanced prev_hash) → wraps ErrStaleResult.
+//   - result.generation > c.generation but result.PrevHash != "" (rollover
+//     results MUST have empty prev_hash) → wraps ErrStaleResult.
+//
+// nil result returns an error WITHOUT latching fatal (caller bug, not an
+// integrity event). Calling Commit on an already-fatal chain returns
+// ErrFatalIntegrity.
+func (c *SinkChain) Commit(result *ComputeResult) error
 
 // Fatal latches the chain in an unrecoverable state. All subsequent Compute
 // calls return ErrFatalIntegrity. Used when a durable write returned an
@@ -144,20 +170,27 @@ func (c *SinkChain) Commit(generation uint32, entryHash string)
 // whether the entry was persisted, so we cannot safely continue chaining.
 func (c *SinkChain) Fatal(reason error)
 
-// State returns (generation, prev_hash) for persistence.
-func (c *SinkChain) State() ChainState
+// State returns (generation, prev_hash, fatal) for persistence. Fatal is
+// included so a chain that latched before a restart comes back latched.
+func (c *SinkChain) State() SinkChainState
 
-// Restore restores chain state after restart.
-func (c *SinkChain) Restore(generation uint32, prevHash string)
+// Restore restores chain state after restart. Validates prev_hash against
+// the algorithm's expected hex length; rejects malformed input without
+// mutating the chain.
+func (c *SinkChain) Restore(generation uint32, prevHash string, fatal bool) error
 
-type ChainState struct {
+type SinkChainState struct {
     Generation uint32
     PrevHash   string
+    Fatal      bool
 }
 
 var (
-    ErrFatalIntegrity   = errors.New("integrity chain latched fatal; sink must be reinitialized")
-    ErrMissingChainState = errors.New("event missing Chain field; composite did not stamp it")
+    ErrFatalIntegrity      = errors.New("integrity chain latched fatal; sink must be reinitialized")
+    ErrMissingChainState   = errors.New("event missing Chain field; composite did not stamp it")
+    ErrInvalidChainState   = errors.New("invalid sink chain state")
+    ErrBackwardsGeneration = errors.New("backwards-generation Commit: chain latched fatal")
+    ErrStaleResult         = errors.New("stale ComputeResult: caller committed against an obsolete chain head; chain latched fatal")
 )
 ```
 
@@ -179,15 +212,17 @@ func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error) {
     seq, gen, err := c.alloc.Next()
     if err != nil { return nil, err }
     canonical := canonicalize(payload)
-    entry, prev, err := c.chain.Compute(IntegrityFormatVersion, seq, gen, canonical)
+    result, err := c.chain.Compute(IntegrityFormatVersion, seq, gen, canonical)
     if err != nil { return nil, err }
     wrapped := buildJSON(payload, IntegrityMetadata{
         FormatVersion: IntegrityFormatVersion,
         Sequence:      seq,
-        PrevHash:      prev,
-        EntryHash:     entry,
+        PrevHash:      result.PrevHash,
+        EntryHash:     result.EntryHash,
     })
-    c.chain.Commit(gen, entry)
+    if err := c.chain.Commit(result); err != nil {
+        return nil, err
+    }
     return wrapped, nil
 }
 ```
@@ -255,8 +290,9 @@ func (s *MySink) AppendEvent(ctx context.Context, ev types.Event) error {
     }
     canonical := s.encode(ev)
 
-    // Step 1: pure compute — no chain mutation yet.
-    entryHash, prevHash, err := s.chain.Compute(
+    // Step 1: pure compute — no chain mutation yet. Returns a typed
+    // *ComputeResult that Commit will validate.
+    result, err := s.chain.Compute(
         formatVersion, int64(ev.Chain.Sequence), ev.Chain.Generation, canonical,
     )
     if err != nil {
@@ -264,11 +300,15 @@ func (s *MySink) AppendEvent(ctx context.Context, ev types.Event) error {
     }
 
     // Step 2: durable write. Failure modes split three ways.
-    werr := s.writeDurable(canonical, entryHash, prevHash)
+    werr := s.writeDurable(canonical, result.EntryHash, result.PrevHash)
     switch {
     case werr == nil:
-        // Step 3a: clean success → commit.
-        s.chain.Commit(ev.Chain.Generation, entryHash)
+        // Step 3a: clean success → commit. A non-nil error from Commit means
+        // the chain just latched fatal (backwards generation, stale token, or
+        // rollover-with-nonempty-prev) and must be surfaced to the caller.
+        if err := s.chain.Commit(result); err != nil {
+            return err
+        }
         return nil
 
     case errors.Is(werr, errCleanFailure):
@@ -298,7 +338,7 @@ When the composite owner rotates the chain key:
 
 1. Owner calls `composite.NextGeneration()` → returns new generation.
 2. Next `AppendEvent` call allocates `(seq=0, gen=new)`.
-3. Each chained sink observes `ev.Chain.Generation` differs from its `SinkChain.State().Generation`. `SinkChain.Compute` automatically uses `prev_hash = ""` for the new generation and returns the rollover indicator via `prevHash == ""`. `Commit` records the new generation.
+3. Each chained sink observes `ev.Chain.Generation` differs from its `SinkChain.State().Generation`. `SinkChain.Compute` automatically uses `prev_hash = ""` for the new generation and returns a `*ComputeResult` with `PrevHash == ""` — the rollover signal. `Commit(result)` records the new generation.
 4. Per-sink work (e.g., WTP forces a batch flush + WAL segment roll + `SessionUpdate`) is triggered by the sink observing the generation change in `ev.Chain.Generation`.
 
 Generation is a property of the *shared allocator*, not of any individual sink. All sinks roll on the same logical event boundary — the first event with the new generation.

--- a/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
@@ -38,6 +38,9 @@ This contract solves both by introducing two distinct types and a transactional 
 | **Refactor of `audit.IntegrityChain`** | Preserved as a convenience wrapper that internally composes a `SequenceAllocator` + `SinkChain`. The existing `Wrap()` method is unchanged at the source level. | Single-sink callers (today's JSONL primary when not in composite) keep working without code changes. |
 | **Generation semantics** | Allocator owns generation; sequence resets to 0 on `NextGeneration()`. Each `SinkChain` resets its `prev_hash` to `""` when it first sees a new generation (signalled via the typed `Chain` field). | Matches WTP spec §6.4. Generation is a property of the shared allocator, not of any sink. |
 | **Per-sink `TransportLoss` doesn't perturb the shared sequence** | Sinks that drop locally emit their own marker. The allocator does not roll back. | The shared sequence reflects what the system *produced*, not what each sink *delivered*. |
+| **Allocator-error reporting** | A failure from `allocator.Next()` (in practice only `ErrSequenceOverflow`) is wrapped as `*store.FatalIntegrityError` with `Op == "audit sequence allocate"` and routed through `composite.SetAppendErrorHook`. The event is rejected before any sink runs. | Matches the convention used elsewhere in `internal/store/integrity_wrapper.go` (`Op: "write audit log"`, `Op: "sync audit log"`, `Op: "write audit integrity sidecar"`). The daemon's fatal-audit watcher (`internal/server/server.go`) only listens to hook-delivered `FatalIntegrityError`s; using the same routing means allocator overflow surfaces through the same operator path as every other fatal integrity event. |
+| **Composite rollover atomicity** | `composite.Store` holds a `sync.RWMutex`. `AppendEvent` takes the read lock for the duration of `allocator.Next()` AND the entire fanout. `NextGeneration` takes the write lock so it cannot return until every in-flight `AppendEvent` has completed AND no new `AppendEvent` may begin until the rotation finishes. `State`/`Restore` also take the write lock so the snapshot is consistent. | Without this, an in-flight `AppendEvent` could stamp `ev.Chain` with the OLD generation while a sink that has already rekeyed observes the NEW generation — exactly the backwards-generation race `SinkChain.Commit` is designed to reject. With the wrapper RWMutex, "all chained sinks roll on the same logical event boundary" is enforceable rather than aspirational. |
+| **Pre-write sequence semantics** | The shared sequence advances eagerly on every successful `allocator.Next()` call, regardless of whether any sink accepts the event. Allocator failures (overflow) consume no sequence and surface via the hook. | Matches `TransportLoss` semantics: the shared sequence reflects what the system PRODUCED, not what each sink DELIVERED. Per-sink drops do not perturb the allocator; pre-write allocator failures bypass fanout entirely so no per-sink loss marker is needed. |
 
 ## Typed `Chain` Field
 
@@ -306,33 +309,46 @@ For single-sink callers, durable success is implicit (Wrap returns the bytes; th
 
 ```go
 type Store struct {
+    mu            sync.RWMutex                 // wrapper-level rotation lock
     primary       store.EventStore
     output        store.OutputStore
     others        []store.EventStore
-    allocator     *audit.SequenceAllocator   // NEW: shared allocator
+    allocator     *audit.SequenceAllocator     // shared allocator
     onAppendError func(error)
 }
 
 func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
+    s.mu.RLock()
+    defer s.mu.RUnlock()
+
     // Phase 0: composite allocates the shared (seq, gen) before fanout.
     seq, gen, err := s.allocator.Next()
     if err != nil {
-        return err  // typically ErrSequenceOverflow; caller treats as fatal
+        // Allocator failures (overflow) bypass fanout entirely. Wrap as
+        // FatalIntegrityError + route through the hook so the daemon's
+        // fatal-audit watcher observes them, matching the convention in
+        // internal/store/integrity_wrapper.go.
+        fatalErr := &store.FatalIntegrityError{Op: "audit sequence allocate", Err: err}
+        if s.onAppendError != nil {
+            s.onAppendError(fatalErr)
+        }
+        return fatalErr
     }
-    ev.Chain = &types.ChainState{
-        Sequence:   uint64(seq),
-        Generation: gen,
+    stampForSink := func() types.Event {
+        stamped := ev
+        stamped.Chain = &types.ChainState{Sequence: uint64(seq), Generation: gen}
+        return stamped
     }
 
     // Fan out — each sink that chains computes its own hash; the others ignore.
     var firstErr, hookErr error
     if s.primary != nil {
-        if err := s.primary.AppendEvent(ctx, ev); err != nil {
+        if err := s.primary.AppendEvent(ctx, stampForSink()); err != nil {
             firstErr, hookErr = collectErr(firstErr, hookErr, err)
         }
     }
     for _, o := range s.others {
-        if err := o.AppendEvent(ctx, ev); err != nil {
+        if err := o.AppendEvent(ctx, stampForSink()); err != nil {
             firstErr, hookErr = collectErr(firstErr, hookErr, err)
         }
     }
@@ -344,13 +360,47 @@ func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
 
 // NextGeneration is called by the composite owner (the daemon) when the
 // chain key rotates. All chained sinks observe the new generation on the
-// next event.
-func (s *Store) NextGeneration() uint32 {
+// next event. Acquires the wrapper write lock so the rotation cannot
+// interleave with any in-flight AppendEvent fanout.
+func (s *Store) NextGeneration() (uint32, error) {
+    s.mu.Lock()
+    defer s.mu.Unlock()
     return s.allocator.NextGeneration()
+}
+
+// State returns the allocator's (sequence, generation) for persistence.
+// Acquires the wrapper write lock so the snapshot reflects a state that
+// no AppendEvent fanout is partway through and no NextGeneration is
+// partway through.
+func (s *Store) State() audit.AllocatorState {
+    s.mu.Lock()
+    defer s.mu.Unlock()
+    return s.allocator.State()
+}
+
+// Restore rehydrates the allocator state after restart. Returns
+// audit.ErrInvalidAllocatorState on rejected input; the wrapper is not
+// modified in that case (delegated guarantee from
+// SequenceAllocator.Restore).
+func (s *Store) Restore(state audit.AllocatorState) error {
+    s.mu.Lock()
+    defer s.mu.Unlock()
+    return s.allocator.Restore(state)
 }
 ```
 
-The error-hook semantics (`onAppendError`, `FatalIntegrityError` detection) of the current composite are preserved verbatim; only the sequence-allocation step is added.
+The error-hook semantics (`onAppendError`, `FatalIntegrityError` detection) of the current composite are preserved verbatim; the only additions are the allocator integration, the wrapper RWMutex, and the State/Restore handles for future restart wiring.
+
+### Composite Concurrency Model
+
+`composite.Store` holds a single `sync.RWMutex` that is the outermost lock in the package. The lock has four discipline points:
+
+- **`AppendEvent` takes `mu.RLock()` for the entire stamp + fanout duration.** Concurrent `AppendEvent` calls do NOT serialize against each other — the read lock is shared — so the high-throughput hot path retains its concurrency. They DO serialize against `NextGeneration`, `State`, and `Restore`.
+- **`NextGeneration` takes `mu.Lock()`.** It cannot return until every in-flight `AppendEvent` (each holding `mu.RLock()`) has completed its fanout, AND no new `AppendEvent` may begin until the rotation finishes. After return, every subsequent `AppendEvent` stamps the new generation; there is no window where a stamped `(seq, oldGen)` event can race against sink rekeying.
+- **`State` and `Restore` take `mu.Lock()`** so a snapshot is consistent (no partial fanout, no partial rotation) and a restore lands cleanly.
+- **The shared sequence advances eagerly: a successful `allocator.Next()` consumes a sequence even if every sink rejects the event.** This matches `TransportLoss` semantics — the shared sequence reflects what the system PRODUCED, not what each sink DELIVERED. A pre-write allocator overflow is the one exception: it consumes no sequence, surfaces as `*store.FatalIntegrityError{Op: "audit sequence allocate"}`, and is routed through `onAppendError` so the daemon's fatal-audit watcher observes it (matching the convention in `internal/store/integrity_wrapper.go`).
+
+Lock order is always `composite.mu` (outer) → `allocator.mu` (inner). The allocator never calls back into the composite, so there is no deadlock potential. This matches the wrapper-level mutex discipline established for `audit.IntegrityChain` in commit 915251c7.
 
 ### Sink integration — the transactional pattern
 
@@ -415,6 +465,8 @@ When the composite owner rotates the chain key:
 4. Per-sink work (e.g., WTP forces a batch flush + WAL segment roll + `SessionUpdate`) is triggered by the sink observing the generation change in `ev.Chain.Generation`.
 
 Generation is a property of the *shared allocator*, not of any individual sink. All sinks roll on the same logical event boundary — the first event with the new generation.
+
+**Enforcement.** The "same logical event boundary" guarantee is enforceable, not aspirational, because of the wrapper RWMutex on `composite.Store` (see *Composite Concurrency Model* above): `NextGeneration` takes the write lock and waits for every in-flight `AppendEvent` (each holding the read lock) to complete its fanout before advancing the allocator. After `NextGeneration` returns, every subsequent `AppendEvent` stamps the new generation. Without this lock, a stamped `(seq, oldGen)` event could race against sink rekeying and a sink that had already rotated would observe a backwards-generation event — exactly the failure mode `SinkChain.Commit` is designed to reject.
 
 ## TransportLoss Semantics
 

--- a/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
@@ -231,14 +231,22 @@ The existing `Wrap()` is preserved verbatim as a convenience for single-sink cal
 ```go
 // IntegrityChain is the legacy single-sink composer of SequenceAllocator +
 // SinkChain. New code should use the two types directly via the composite
-// store's allocator and per-sink chains. Wrap() is preserved unchanged at the
-// source level for existing callers.
+// store's allocator and per-sink chains. Wrap/State/Restore are preserved
+// at the source level for existing callers.
+//
+// Concurrency: Wrap, State, and Restore are serialized by an internal
+// mutex so the wrapper preserves the legacy single-mutex atomicity
+// contract. KeyFingerprint, VerifyHash, and VerifyWrapped do NOT take the
+// wrapper mutex (they read immutable fields via the chain's own mutex).
 type IntegrityChain struct {
+    mu    sync.Mutex
     alloc *SequenceAllocator
     chain *SinkChain
 }
 
 func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error) {
+    c.mu.Lock()
+    defer c.mu.Unlock()
     seq, gen, err := c.alloc.Next()
     if err != nil { return nil, err }
     canonical := canonicalize(payload)
@@ -255,9 +263,44 @@ func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error) {
     }
     return wrapped, nil
 }
+
+func (c *IntegrityChain) State() ChainState {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    a := c.alloc.State()
+    s := c.chain.State()
+    return ChainState{Sequence: a.Sequence, PrevHash: s.PrevHash}
+}
+
+func (c *IntegrityChain) Restore(sequence int64, prevHash string) error {
+    c.mu.Lock()
+    defer c.mu.Unlock()
+    // All-or-nothing: snapshot allocator, advance it, then attempt chain
+    // restore. If chain restore rejects the prevHash, roll the allocator
+    // back to its pre-call snapshot. Both component Restores validate
+    // their input before mutating, so rolling back to a State() snapshot
+    // cannot itself fail.
+    prevAlloc := c.alloc.State()
+    if err := c.alloc.Restore(AllocatorState{Sequence: sequence, Generation: 0}); err != nil {
+        return fmt.Errorf("restore allocator: %w", err)
+    }
+    if err := c.chain.Restore(0, prevHash, false); err != nil {
+        _ = c.alloc.Restore(prevAlloc) // rollback; cannot fail
+        return fmt.Errorf("restore chain: %w", err)
+    }
+    return nil
+}
 ```
 
 For single-sink callers, durable success is implicit (Wrap returns the bytes; the caller writes them; if the write fails the caller never calls Wrap again on the same record). The single-sink case does not need the Compute/Commit split exposed because there is no fanout — but composite-mode callers absolutely do.
+
+**Wrapper-level atomicity contract.** `IntegrityChain` holds a single `sync.Mutex` around `Wrap`, `State`, and `Restore`. This preserves the legacy single-mutex contract verbatim, even though the internals now compose two independently-locked components:
+
+- **Concurrent `Wrap` calls serialize.** Two callers cannot interleave `alloc.Next()` from one with `chain.Compute()` / `chain.Commit()` from another, so chained sequences cannot end up linked to the wrong predecessor and the wrapper cannot latch fatal via `ErrStaleResult` from a benign concurrent caller.
+- **`State` returns a consistent snapshot.** `(sequence, prev_hash)` is always observed at the same point in the chain — never a torn read where one value is from a Wrap that has not finished committing.
+- **`Restore` is all-or-nothing.** If either the allocator or the chain rejects its input, the wrapper is left in its pre-call state. Implementation snapshots the allocator before mutating and rolls it back on chain-restore failure; the rollback restores a value that came from `State()` and therefore satisfies the allocator's `Sequence >= -1` invariant by construction.
+
+`KeyFingerprint`, `VerifyHash`, and `VerifyWrapped` do NOT take the wrapper mutex. They read immutable key/algorithm material via the underlying `SinkChain`'s own mutex (`keyAndAlgorithm()`) and have no need for wrapper-level serialization. Adding the wrapper mutex there would be a lock-ordering risk and serves no purpose.
 
 ### `internal/store/composite/composite.go` — allocate + stamp + fanout
 

--- a/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
@@ -1,0 +1,340 @@
+# Phase 0: Shared Sequence Allocator + Sink-Local Chain Contract
+
+**Date:** 2026-04-18
+**Status:** Draft (contract specification; implementation tracked separately)
+**Scope:** Defines the contract that the composite store and per-sink integrity chains must implement so multiple sinks can attest to the *same* logical event using a *shared* `(sequence, generation)` allocated once, with each sink computing its own *sink-local* hash.
+**Related:**
+- `docs/superpowers/specs/2026-04-18-wtp-client-design.md` (consumer of this contract)
+- `docs/superpowers/specs/2026-03-30-wire-hmac-integrity-chain-design.md` (existing single-sink chain)
+- `docs/superpowers/specs/2026-04-11-hmac-chain-tamper-evidence-design.md` (sidecar, recovery)
+- `internal/audit/integrity.go` (current implementation; refactor target)
+- `internal/store/composite/composite.go` (current fanout; refactor target)
+- `pkg/types/events.go` (target of typed `Chain` field)
+
+## Why
+
+Today, `internal/audit/integrity.IntegrityChain.Wrap()` does three things atomically under one mutex:
+
+1. **Allocate** the next sequence (`c.sequence + 1`).
+2. **Compute** the HMAC over `(format_version, sequence, prev_hash, canonical_payload)`.
+3. **Commit** the result by updating `c.prevHash` to the new entry hash.
+
+This is correct for a single sink, but two structural problems block multi-sink chaining:
+
+1. **Allocation and hashing are conflated.** Multiple sinks need to attest to the same logical event. They must all see the same `(sequence, generation)` but compute *different* `entry_hash` values (different keys → different outputs). Today's API can't separate "who owns the counter" from "who owns the hash."
+2. **Computation and commit are conflated.** If a sink writes the hashed payload to durable storage and the write fails *after* `prev_hash` was already updated, the chain is corrupted: the next event will hash against an entry that was never persisted. The existing `internal/store/integrity_wrapper.go` already handles this for the single-sink case via snapshot/restore + a fatal-latch on ambiguous failures; we need to inherit that discipline for every chained sink.
+
+This contract solves both by introducing two distinct types and a transactional compute/commit protocol.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| **Where sequence advances** | A new `audit.SequenceAllocator` owned by composite. Allocates `(seq, gen)` exactly once per event, before fanout. | Single source of truth. Sinks never disagree on `(seq, gen)`. Allocator has no hash state; it only counts. |
+| **Where prev_hash lives** | A new `audit.SinkChain` owned by each chained sink. Computes per-sink `entry_hash` from externally-supplied `(seq, gen, prev_hash, payload)`. | Lets each sink hash its own canonical payload with its own key. No shared mutable state across sinks. |
+| **How sinks learn `(seq, gen)`** | A typed `Chain *ChainState` field on `pkg/types.Event` (not via `ev.Fields`). | Typed → can't accidentally leak into user-visible payloads. Untyped `_integrity_*` map keys would need a strip helper at every serializer; a typed field that's `json:"-"` cannot leak. |
+| **Compute/commit split** | `SinkChain` exposes `Compute` (pure: returns `entryHash`, no mutation) and `Commit` (mutator: advances `prev_hash`). Caller does Compute → durable write → only-on-success Commit. | Clean failure of the durable write rolls back trivially (no commit, retry safe). Ambiguous failure latches `FatalIntegrityError` and locks the chain. |
+| **Where the chain key lives** | Each sink resolves its own key (via existing `internal/audit/kms`). Composite knows nothing about sink keys. | Different sinks may use different keys. The Phase 0 contract is purely about `(seq, gen)` allocation, not key management. |
+| **Refactor of `audit.IntegrityChain`** | Preserved as a convenience wrapper that internally composes a `SequenceAllocator` + `SinkChain`. The existing `Wrap()` method is unchanged at the source level. | Single-sink callers (today's JSONL primary when not in composite) keep working without code changes. |
+| **Generation semantics** | Allocator owns generation; sequence resets to 0 on `NextGeneration()`. Each `SinkChain` resets its `prev_hash` to `""` when it first sees a new generation (signalled via the typed `Chain` field). | Matches WTP spec §6.4. Generation is a property of the shared allocator, not of any sink. |
+| **Per-sink `TransportLoss` doesn't perturb the shared sequence** | Sinks that drop locally emit their own marker. The allocator does not roll back. | The shared sequence reflects what the system *produced*, not what each sink *delivered*. |
+
+## Typed `Chain` Field
+
+A typed field on `pkg/types.Event` carries the per-event chain state stamped by the composite store:
+
+```go
+// pkg/types/events.go (additive change)
+
+type Event struct {
+    // … existing fields unchanged …
+
+    // Chain is the shared (sequence, generation) allocated by the composite
+    // store before fanout. It is used by chained sinks to produce sink-local
+    // integrity hashes.
+    //
+    // The field is intentionally json:"-" — it must never appear in any
+    // user-visible serialization (audit log, query result, OTEL export).
+    // Sinks that need it consume it directly; sinks that don't ignore it.
+    //
+    // Nil if composite did not stamp the event (e.g., test fixtures, single-
+    // sink installations where chaining is disabled).
+    Chain *ChainState `json:"-"`
+}
+
+type ChainState struct {
+    Sequence   uint64
+    Generation uint32
+}
+```
+
+The `json:"-"` tag means the field is invisible to every JSON-based serializer in the codebase: JSONL store, OTEL export, webhook, gRPC stream (which uses protobuf, not JSON, but cannot accidentally include a Go field that's marked unexported-from-JSON for the JSONL fallback). The leak risk that motivates many of these protocols disappears at the type level.
+
+### Backwards compatibility
+
+- Adding a field to `types.Event` is source-compatible with all existing code.
+- The field is `nil` when not set; chained sinks check for nil and either ignore (single-sink mode) or return `ErrMissingChainState` (multi-sink mode).
+- No JSONL or OTEL output changes byte-for-byte for existing installations.
+
+## API Refactor
+
+### `internal/audit` — new types
+
+```go
+package audit
+
+// SequenceAllocator owns the shared (sequence, generation) tuple. It has no
+// hash state. Composite holds exactly one allocator.
+type SequenceAllocator struct { /* mu, sequence int64, generation uint32 */ }
+
+func NewSequenceAllocator() *SequenceAllocator
+
+// Next returns the next (sequence, generation) and advances. Sequence is
+// monotonic within a generation; generation does not change here.
+// ErrSequenceOverflow if sequence == math.MaxInt64.
+func (a *SequenceAllocator) Next() (sequence int64, generation uint32, err error)
+
+// NextGeneration increments generation and resets sequence to -1, so the
+// next Next() returns (0, new_generation). Used by the composite when the
+// chain key rotates.
+func (a *SequenceAllocator) NextGeneration() (generation uint32)
+
+// State returns the current (sequence, generation) for persistence.
+func (a *SequenceAllocator) State() AllocatorState
+
+// Restore restores allocator state after restart. The next Next() returns
+// (sequence + 1, generation).
+func (a *SequenceAllocator) Restore(state AllocatorState)
+
+type AllocatorState struct {
+    Sequence   int64
+    Generation uint32
+}
+```
+
+```go
+package audit
+
+// SinkChain owns prev_hash for one sink. Each chained sink holds one.
+// It is keyed: the same (seq, gen, prev_hash, payload) under different keys
+// produces different entry_hash values, which is the entire point.
+type SinkChain struct { /* mu, key, algorithm, generation, prevHash */ }
+
+func NewSinkChain(key []byte, algorithm string) (*SinkChain, error)
+
+// Compute computes the HMAC over (formatVersion, sequence, generation,
+// prev_hash, canonical_payload) using the chain's key. It is PURE: it does
+// not mutate prev_hash. The caller must follow with Commit on durable success
+// or discard the result on durable failure.
+//
+// If generation differs from the chain's current generation, Compute treats
+// prev_hash as "" (chain rolls automatically). The transition is committed
+// only when Commit is called.
+func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32, payload []byte) (entryHash string, prevHash string, err error)
+
+// Commit advances prev_hash to entryHash. Must be called exactly once per
+// successful Compute, after the durable write succeeds. On ambiguous failure
+// (write may or may not have landed), the caller MUST call Fatal instead;
+// Commit and Fatal are mutually exclusive per Compute.
+func (c *SinkChain) Commit(generation uint32, entryHash string)
+
+// Fatal latches the chain in an unrecoverable state. All subsequent Compute
+// calls return ErrFatalIntegrity. Used when a durable write returned an
+// ambiguous error (timeout, partial write detection) — we cannot know
+// whether the entry was persisted, so we cannot safely continue chaining.
+func (c *SinkChain) Fatal(reason error)
+
+// State returns (generation, prev_hash) for persistence.
+func (c *SinkChain) State() ChainState
+
+// Restore restores chain state after restart.
+func (c *SinkChain) Restore(generation uint32, prevHash string)
+
+type ChainState struct {
+    Generation uint32
+    PrevHash   string
+}
+
+var (
+    ErrFatalIntegrity   = errors.New("integrity chain latched fatal; sink must be reinitialized")
+    ErrMissingChainState = errors.New("event missing Chain field; composite did not stamp it")
+)
+```
+
+### `audit.IntegrityChain.Wrap()` — preserved
+
+The existing `Wrap()` is preserved verbatim as a convenience for single-sink callers:
+
+```go
+// IntegrityChain is the legacy single-sink composer of SequenceAllocator +
+// SinkChain. New code should use the two types directly via the composite
+// store's allocator and per-sink chains. Wrap() is preserved unchanged at the
+// source level for existing callers.
+type IntegrityChain struct {
+    alloc *SequenceAllocator
+    chain *SinkChain
+}
+
+func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error) {
+    seq, gen, err := c.alloc.Next()
+    if err != nil { return nil, err }
+    canonical := canonicalize(payload)
+    entry, prev, err := c.chain.Compute(IntegrityFormatVersion, seq, gen, canonical)
+    if err != nil { return nil, err }
+    wrapped := buildJSON(payload, IntegrityMetadata{
+        FormatVersion: IntegrityFormatVersion,
+        Sequence:      seq,
+        PrevHash:      prev,
+        EntryHash:     entry,
+    })
+    c.chain.Commit(gen, entry)
+    return wrapped, nil
+}
+```
+
+For single-sink callers, durable success is implicit (Wrap returns the bytes; the caller writes them; if the write fails the caller never calls Wrap again on the same record). The single-sink case does not need the Compute/Commit split exposed because there is no fanout — but composite-mode callers absolutely do.
+
+### `internal/store/composite/composite.go` — allocate + stamp + fanout
+
+```go
+type Store struct {
+    primary       store.EventStore
+    output        store.OutputStore
+    others        []store.EventStore
+    allocator     *audit.SequenceAllocator   // NEW: shared allocator
+    onAppendError func(error)
+}
+
+func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
+    // Phase 0: composite allocates the shared (seq, gen) before fanout.
+    seq, gen, err := s.allocator.Next()
+    if err != nil {
+        return err  // typically ErrSequenceOverflow; caller treats as fatal
+    }
+    ev.Chain = &types.ChainState{
+        Sequence:   uint64(seq),
+        Generation: gen,
+    }
+
+    // Fan out — each sink that chains computes its own hash; the others ignore.
+    var firstErr, hookErr error
+    if s.primary != nil {
+        if err := s.primary.AppendEvent(ctx, ev); err != nil {
+            firstErr, hookErr = collectErr(firstErr, hookErr, err)
+        }
+    }
+    for _, o := range s.others {
+        if err := o.AppendEvent(ctx, ev); err != nil {
+            firstErr, hookErr = collectErr(firstErr, hookErr, err)
+        }
+    }
+    if hookErr != nil && s.onAppendError != nil {
+        s.onAppendError(hookErr)
+    }
+    return firstErr
+}
+
+// NextGeneration is called by the composite owner (the daemon) when the
+// chain key rotates. All chained sinks observe the new generation on the
+// next event.
+func (s *Store) NextGeneration() uint32 {
+    return s.allocator.NextGeneration()
+}
+```
+
+The error-hook semantics (`onAppendError`, `FatalIntegrityError` detection) of the current composite are preserved verbatim; only the sequence-allocation step is added.
+
+### Sink integration — the transactional pattern
+
+Sinks that chain (JSONL primary in composite mode, WTP, any future chained sink) follow this exact pattern:
+
+```go
+func (s *MySink) AppendEvent(ctx context.Context, ev types.Event) error {
+    if ev.Chain == nil {
+        return audit.ErrMissingChainState
+    }
+    canonical := s.encode(ev)
+
+    // Step 1: pure compute — no chain mutation yet.
+    entryHash, prevHash, err := s.chain.Compute(
+        formatVersion, int64(ev.Chain.Sequence), ev.Chain.Generation, canonical,
+    )
+    if err != nil {
+        return err  // includes ErrFatalIntegrity if a previous append latched fatal
+    }
+
+    // Step 2: durable write. Failure modes split three ways.
+    werr := s.writeDurable(canonical, entryHash, prevHash)
+    switch {
+    case werr == nil:
+        // Step 3a: clean success → commit.
+        s.chain.Commit(ev.Chain.Generation, entryHash)
+        return nil
+
+    case errors.Is(werr, errCleanFailure):
+        // Step 3b: clean failure → no commit, chain unchanged. Caller may retry.
+        return werr
+
+    default:
+        // Step 3c: ambiguous failure → latch fatal. We cannot know whether
+        // the write landed, so any future chaining would be unsound.
+        s.chain.Fatal(werr)
+        return werr
+    }
+}
+```
+
+The classification of `errCleanFailure` vs ambiguous is sink-specific and must be documented per sink. For example:
+
+- **WAL.Append**: a returned error from `os.Write` *before* the system call has been issued (parameter validation, closed file) is clean. An error from `os.Write` itself, or from `f.Sync()`, is ambiguous — the bytes may have hit the platter. Default: ambiguous.
+- **Network sends** (no chained sink does this synchronously; WTP buffers via WAL first): always ambiguous.
+- **In-memory checks before any I/O**: clean.
+
+Sinks that do not chain (OTel, webhook in non-chained configurations) ignore `ev.Chain` entirely.
+
+## Generation Roll
+
+When the composite owner rotates the chain key:
+
+1. Owner calls `composite.NextGeneration()` → returns new generation.
+2. Next `AppendEvent` call allocates `(seq=0, gen=new)`.
+3. Each chained sink observes `ev.Chain.Generation` differs from its `SinkChain.State().Generation`. `SinkChain.Compute` automatically uses `prev_hash = ""` for the new generation and returns the rollover indicator via `prevHash == ""`. `Commit` records the new generation.
+4. Per-sink work (e.g., WTP forces a batch flush + WAL segment roll + `SessionUpdate`) is triggered by the sink observing the generation change in `ev.Chain.Generation`.
+
+Generation is a property of the *shared allocator*, not of any individual sink. All sinks roll on the same logical event boundary — the first event with the new generation.
+
+## TransportLoss Semantics
+
+Per-sink loss does not perturb the shared sequence. Example:
+
+- Composite allocates seq=100 (gen=7).
+- JSONL writes seq=100 successfully.
+- WTP cannot write seq=100 (WAL full): drops it locally, emits a `TransportLoss{from_seq:100, to_seq:100, generation:7}` marker into its own WAL.
+- Composite allocates seq=101 (gen=7).
+- Both sinks write seq=101.
+
+An auditor reconstructing the WTP stream sees `..., 99, TransportLoss(100), 101, ...` — the gap is explicit. An auditor reconstructing the JSONL stream sees `..., 99, 100, 101, ...` — no gap, because that sink delivered. Cross-correlating reveals which sink lost what.
+
+The shared sequence is therefore a property of *what the system produced*, not of *what each sink delivered*. This is the only consistent interpretation that lets sinks have different durability profiles.
+
+## Migration
+
+This refactor is **invisible** to single-sink installations:
+
+- The legacy `audit.IntegrityChain.Wrap()` API is unchanged at the source level. Existing callers compile and run without modification.
+- The new `Chain` field on `types.Event` is `json:"-"` and additive; existing JSON output is byte-identical.
+- Only when composite is configured with a chained sink besides the primary, *or* when WTP is enabled, does the composite begin allocating and stamping `ev.Chain`. Until that moment, `ev.Chain` is `nil` and chained sinks fall back to either erroring (strict mode) or behaving as ungrounded (lenient mode, dev only).
+
+## Verification
+
+Three new tests in `internal/store/composite/sequence_contract_test.go`:
+
+1. **Cross-sink `(seq, gen)` convergence:** With two chained sinks (JSONL + a fake WTP using identical canonical encoding and the same key), every record's `(seq, gen)` matches between the two. Run for 10,000 events. `entry_hash` is *not* asserted equal in the general case — sinks that hash different canonical bytes will produce different entry hashes by design; the assertion narrows to "if both sinks hash the same canonical bytes with the same key, then `entry_hash` matches."
+2. **Generation roll consistency:** After a `composite.NextGeneration()` call, both sinks observe the rollover at the same event boundary; sequence resets to 0 in both; each sink's `prev_hash` resets to `""` independently.
+3. **Transactional rollback:** A fake sink that fails its durable write with `errCleanFailure` does NOT advance its `SinkChain.prev_hash`. After the failure, a successful write of a NEW event uses the previous (pre-failure) `prev_hash` — proving rollback is correct. A second test injects an ambiguous failure and asserts `SinkChain.Compute` returns `ErrFatalIntegrity` on every subsequent call.
+
+## Out-of-Scope
+
+- The actual WTP client implementation (separate doc).
+- KMS-backed key rotation automation (existing `internal/audit/kms` is unchanged; the *trigger* for `composite.NextGeneration()` is operator-driven for now).
+- Surfacing `Chain` in any user-visible API. The field is `json:"-"` and used only by chained sinks internally.

--- a/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
@@ -1,0 +1,219 @@
+# Phase 0: Shared Sequence + Generation Contract
+
+**Date:** 2026-04-18
+**Status:** Draft (contract specification; implementation tracked separately)
+**Scope:** Defines the contract that the composite store and per-sink integrity chains must implement so that multiple sinks can chain over a *shared* sequence/generation while computing *sink-local* hashes.
+**Related:**
+- `docs/superpowers/specs/2026-04-18-wtp-client-design.md` (consumer of this contract)
+- `docs/superpowers/specs/2026-03-30-wire-hmac-integrity-chain-design.md` (existing single-sink chain)
+- `docs/superpowers/specs/2026-04-11-hmac-chain-tamper-evidence-design.md` (sidecar, recovery)
+- `internal/audit/integrity.go` (current implementation; refactor target)
+- `internal/store/composite/composite.go` (current fanout; refactor target)
+
+## Why
+
+Today, `internal/audit/integrity.IntegrityChain.Wrap()` does two things atomically under one mutex:
+
+1. **Advance** the chain's sequence (`c.sequence + 1`) and update `c.prevHash`.
+2. **Compute** the HMAC over `(format_version, sequence, prev_hash, canonical_payload)`.
+
+This works for a single sink. It does not work when multiple sinks need to attest to the *same* logical event with their *own* HMAC keys, because:
+
+- Each sink computes its own `entry_hash` (different key → different output).
+- All sinks must agree on `(sequence, generation)` so an auditor can correlate records across sinks.
+- The composite store must therefore advance `(sequence, generation)` *once*, then hand them to every sink for its own hashing.
+
+WTP (the new Watchtower sink) is the immediate consumer of this refactor, but the contract is general: any future sink that chains will use it the same way.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| **Where sequence advances** | In `composite.Store.AppendEvent`, *once*, before fanout. | Single source of truth. Sinks can never disagree on what `(seq, gen)` an event has. |
+| **How sinks learn `(seq, gen)`** | Via well-known `ev.Fields` keys (`_integrity_seq`, `_integrity_generation`). | Doesn't require changing `store.EventStore` interface. Sinks that don't care can ignore the fields. |
+| **Field name prefix** | `_integrity_` | Underscore prefix marks "internal/transport metadata", consistent with how OTel SDKs mark non-user attrs. We document that fields starting with `_` are reserved. |
+| **Field types** | `uint64` for sequence, `uint32` for generation. | Matches WTP wire format. JSON encoders that round-trip via `float64` will lose precision near the top of uint64 — sinks must use the typed accessor (a small helper in `internal/store`) to read these. |
+| **Where the chain key lives** | Composite holds a single shared key resolver; injects per-sink `chain.Key` at sink construction. | Different sinks may use different keys (or the same key); composite is the only place that knows about all of them. |
+| **Refactor of `audit.IntegrityChain`** | Split `Wrap` into `AdvanceSequence` + `ComputeHash`. Existing `Wrap` becomes a convenience wrapper that calls both atomically (preserves all current call sites). | Lets composite call `AdvanceSequence` once and pass `(seq, gen)` to each sink for `ComputeHash`. Existing single-sink callers (the JSONL primary) continue to use `Wrap` unchanged. |
+| **Generation semantics** | Generation increments on key rotation. Sequence resets to 0 on a new generation. `prev_hash = ""` on the first record of a new generation. | Matches WTP spec §6.4 (`generation` field) and the existing rotation expectation in the integrity-tamper-evidence doc. |
+| **TransportLoss on shared sequence** | Each sink that drops records (e.g., WTP WAL overflow) emits its *own* TransportLoss marker locally. The shared sequence is **not** affected by per-sink loss. | Loss is per-sink. The shared sequence reflects what the system *produced*, not what each sink *delivered*. An auditor reconstructing the chain across sinks correlates by `(seq, gen)`; gaps in one sink reveal gaps in delivery, not in production. |
+
+## Field Contract
+
+The composite store stamps two fields on every `types.Event` *before* fanning out to sinks:
+
+```go
+ev.Fields["_integrity_seq"]        = uint64(seq)   // monotonic, gap-free per generation
+ev.Fields["_integrity_generation"] = uint32(gen)   // increments on key rotation; seq resets to 0
+```
+
+### Reserved field-name prefix
+
+Field names starting with `_integrity_` are reserved for the composite store and must not be set by event producers. Sinks must treat them as transport metadata and not surface them as user-visible event fields. (For example, the WTP `compact.Encoder` strips `_integrity_*` before projecting into the OCSF payload.)
+
+### Reading the fields
+
+Sinks use a typed helper in `internal/store/chainstate` (new package, ~40 lines):
+
+```go
+package chainstate
+
+import "github.com/agentsh/agentsh/pkg/types"
+
+type State struct {
+    Sequence   uint64
+    Generation uint32
+}
+
+// FromEvent extracts the shared chain state stamped by the composite store.
+// Returns (State, true) if both fields are present and well-typed; (State, false)
+// otherwise. Sinks should treat (State, false) as a programming error and emit
+// a counter rather than guessing.
+func FromEvent(ev types.Event) (State, bool)
+
+// MustFromEvent panics if either field is missing. For tests only.
+func MustFromEvent(ev types.Event) State
+```
+
+The helper handles JSON-decoded variants (`float64`, `json.Number`) the same way `internal/audit/integrity.go`'s `jsonInt64` does, so a sink that receives an event from JSONL replay (where the field came back as `float64`) and a sink that receives it directly from the in-memory composite both see the same `State`.
+
+## API Refactor
+
+### `internal/audit/integrity.go` — split Wrap
+
+Today:
+
+```go
+// Wrap adds integrity metadata to an event payload. Advances sequence and
+// computes hash atomically.
+func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error)
+```
+
+After Phase 0:
+
+```go
+// AdvanceSequence allocates the next (sequence, generation) under the chain's
+// mutex and returns it. Does not compute or update prev_hash. The caller is
+// responsible for calling ComputeHash with the returned sequence.
+func (c *IntegrityChain) AdvanceSequence() (sequence int64, generation uint32, err error)
+
+// ComputeHash computes the HMAC over (format_version, sequence, prev_hash,
+// canonical_payload) and updates the chain's prev_hash. Must be called
+// exactly once per AdvanceSequence call, with the same sequence value.
+// If a caller fails to call ComputeHash after AdvanceSequence, the chain
+// becomes inconsistent — callers should treat this as a fatal condition.
+func (c *IntegrityChain) ComputeHash(formatVersion int, sequence int64, payload []byte) (prevHash, entryHash string, err error)
+
+// Wrap is preserved for backwards compatibility. It internally calls
+// AdvanceSequence + ComputeHash + builds the JSON payload.
+func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error)
+```
+
+The mutex is still held across the *pair* of operations when called via `Wrap` (composite path will not use Wrap; it will hold its own mutex around the pair). This is necessary because `prev_hash` depends on the previous `entry_hash`.
+
+### `internal/store/composite/composite.go` — advance + fanout
+
+```go
+func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
+    // Phase 0: composite owns sequence advancement.
+    seq, gen, err := s.chain.AdvanceSequence()
+    if err != nil {
+        return err
+    }
+    ev.Fields = ensureFields(ev.Fields)
+    ev.Fields["_integrity_seq"]        = uint64(seq)
+    ev.Fields["_integrity_generation"] = gen
+
+    // Fan out — each sink computes its own hash from (seq, gen).
+    var firstErr error
+    if s.primary != nil {
+        if err := s.primary.AppendEvent(ctx, ev); err != nil && firstErr == nil {
+            firstErr = err
+        }
+    }
+    for _, o := range s.others {
+        if err := o.AppendEvent(ctx, ev); err != nil && firstErr == nil {
+            firstErr = err
+        }
+    }
+    return firstErr
+}
+```
+
+The error-hook semantics (`onAppendError`, `FatalIntegrityError` detection) of the current composite are preserved verbatim; only the sequence-advance position changes.
+
+### Sink integration
+
+Sinks that chain (JSONL primary, WTP, any future chained sink) read `(seq, gen)` from `ev.Fields` and compute their own hash:
+
+```go
+func (s *MySink) AppendEvent(ctx context.Context, ev types.Event) error {
+    state, ok := chainstate.FromEvent(ev)
+    if !ok {
+        return ErrMissingChainState  // composite did not stamp the event
+    }
+    canonicalPayload := s.encode(ev)
+    prevHash, entryHash, err := s.chain.ComputeHash(formatVersion, int64(state.Sequence), canonicalPayload)
+    if err != nil {
+        return err
+    }
+    return s.write(state, prevHash, entryHash, canonicalPayload)
+}
+```
+
+Sinks that don't chain (OTel, webhook) ignore the fields entirely.
+
+## Generation Roll
+
+When the composite's chain key rotates:
+
+1. Composite calls `chain.NextGeneration()` (new helper) which:
+   - Acquires the chain mutex.
+   - Increments `c.generation`.
+   - Resets `c.sequence = -1` (so the next `AdvanceSequence` returns 0).
+   - Sets `c.prevHash = ""`.
+   - Releases the mutex.
+2. The next `AdvanceSequence` returns `(0, new_gen)`.
+3. Sinks observe the new generation in `ev.Fields["_integrity_generation"]`. Each sink takes its own action:
+   - JSONL: writes a marker line.
+   - WTP: forces a batch flush, segment roll, and `SessionUpdate`.
+
+Generation is a property of the *shared* chain, not of any sink. All sinks see the same rollover at the same logical event boundary.
+
+## TransportLoss Semantics
+
+Per-sink loss does not perturb the shared sequence. Example:
+
+- Composite advances seq=100 (gen=7).
+- JSONL writes seq=100 successfully.
+- WTP cannot write seq=100 (WAL full): it drops it locally and emits a `TransportLoss{from_seq:100, to_seq:100, generation:7}` marker into its own WAL.
+- Composite advances seq=101 (gen=7).
+- Both sinks write seq=101.
+
+An auditor reconstructing the WTP stream sees: `..., 99, TransportLoss(100), 101, ...` — the gap is explicit. An auditor reconstructing the JSONL stream sees: `..., 99, 100, 101, ...` — no gap, because that sink delivered. Cross-correlating the two streams reveals which sink lost what.
+
+The shared sequence is therefore a property of *what the system produced*, not of *what each sink delivered*. This is the only consistent interpretation that lets sinks have different durability profiles.
+
+## Migration
+
+This refactor is **invisible** to single-sink installations:
+
+- `Wrap()` is preserved unchanged. Callers using `Wrap` (today: the integrity wrapper around JSONL when there's only one sink) continue to work.
+- Only when the composite store is configured with `>1` chained sink, or when WTP is enabled, does the new `AdvanceSequence + ComputeHash` path activate.
+- The reserved `_integrity_*` field prefix is new — we add a startup check that rejects user-supplied event fields starting with `_integrity_` (today no such fields exist; this is purely defensive).
+
+## Verification
+
+The refactor is self-verifying via existing tests if we add three new ones:
+
+1. **Cross-sink convergence:** With two chained sinks (JSONL + a fake WTP using the same key), every record's `(seq, gen, entry_hash)` matches between the two. Run for 10,000 events.
+2. **Per-sink divergence with different keys:** With two chained sinks using *different* keys, `(seq, gen)` matches but `entry_hash` differs.
+3. **Generation roll consistency:** After a `NextGeneration()` call, both sinks observe the rollover at the same event boundary; sequence resets to 0 in both.
+
+These live in `internal/store/composite/sequence_contract_test.go` (new file) and use a fake `EventStore` that records the `(seq, gen)` it sees per event.
+
+## Out-of-Scope
+
+- The actual WTP client implementation (separate doc).
+- KMS-backed key rotation automation (existing `internal/audit/kms` is unchanged).
+- Surfacing `_integrity_*` fields in any user-visible API (they are strictly internal transport metadata).

--- a/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
@@ -1,196 +1,319 @@
-# Phase 0: Shared Sequence + Generation Contract
+# Phase 0: Shared Sequence Allocator + Sink-Local Chain Contract
 
 **Date:** 2026-04-18
 **Status:** Draft (contract specification; implementation tracked separately)
-**Scope:** Defines the contract that the composite store and per-sink integrity chains must implement so that multiple sinks can chain over a *shared* sequence/generation while computing *sink-local* hashes.
+**Scope:** Defines the contract that the composite store and per-sink integrity chains must implement so multiple sinks can attest to the *same* logical event using a *shared* `(sequence, generation)` allocated once, with each sink computing its own *sink-local* hash.
 **Related:**
 - `docs/superpowers/specs/2026-04-18-wtp-client-design.md` (consumer of this contract)
 - `docs/superpowers/specs/2026-03-30-wire-hmac-integrity-chain-design.md` (existing single-sink chain)
 - `docs/superpowers/specs/2026-04-11-hmac-chain-tamper-evidence-design.md` (sidecar, recovery)
 - `internal/audit/integrity.go` (current implementation; refactor target)
 - `internal/store/composite/composite.go` (current fanout; refactor target)
+- `pkg/types/events.go` (target of typed `Chain` field)
 
 ## Why
 
-Today, `internal/audit/integrity.IntegrityChain.Wrap()` does two things atomically under one mutex:
+Today, `internal/audit/integrity.IntegrityChain.Wrap()` does three things atomically under one mutex:
 
-1. **Advance** the chain's sequence (`c.sequence + 1`) and update `c.prevHash`.
+1. **Allocate** the next sequence (`c.sequence + 1`).
 2. **Compute** the HMAC over `(format_version, sequence, prev_hash, canonical_payload)`.
+3. **Commit** the result by updating `c.prevHash` to the new entry hash.
 
-This works for a single sink. It does not work when multiple sinks need to attest to the *same* logical event with their *own* HMAC keys, because:
+This is correct for a single sink, but two structural problems block multi-sink chaining:
 
-- Each sink computes its own `entry_hash` (different key → different output).
-- All sinks must agree on `(sequence, generation)` so an auditor can correlate records across sinks.
-- The composite store must therefore advance `(sequence, generation)` *once*, then hand them to every sink for its own hashing.
+1. **Allocation and hashing are conflated.** Multiple sinks need to attest to the same logical event. They must all see the same `(sequence, generation)` but compute *different* `entry_hash` values (different keys → different outputs). Today's API can't separate "who owns the counter" from "who owns the hash."
+2. **Computation and commit are conflated.** If a sink writes the hashed payload to durable storage and the write fails *after* `prev_hash` was already updated, the chain is corrupted: the next event will hash against an entry that was never persisted. The existing `internal/store/integrity_wrapper.go` already handles this for the single-sink case via snapshot/restore + a fatal-latch on ambiguous failures; we need to inherit that discipline for every chained sink.
 
-WTP (the new Watchtower sink) is the immediate consumer of this refactor, but the contract is general: any future sink that chains will use it the same way.
+This contract solves both by introducing two distinct types and a transactional compute/commit protocol.
 
 ## Decisions
 
 | Decision | Choice | Rationale |
 |---|---|---|
-| **Where sequence advances** | In `composite.Store.AppendEvent`, *once*, before fanout. | Single source of truth. Sinks can never disagree on what `(seq, gen)` an event has. |
-| **How sinks learn `(seq, gen)`** | Via well-known `ev.Fields` keys (`_integrity_seq`, `_integrity_generation`). | Doesn't require changing `store.EventStore` interface. Sinks that don't care can ignore the fields. |
-| **Field name prefix** | `_integrity_` | Underscore prefix marks "internal/transport metadata", consistent with how OTel SDKs mark non-user attrs. We document that fields starting with `_` are reserved. |
-| **Field types** | `uint64` for sequence, `uint32` for generation. | Matches WTP wire format. JSON encoders that round-trip via `float64` will lose precision near the top of uint64 — sinks must use the typed accessor (a small helper in `internal/store`) to read these. |
-| **Where the chain key lives** | Composite holds a single shared key resolver; injects per-sink `chain.Key` at sink construction. | Different sinks may use different keys (or the same key); composite is the only place that knows about all of them. |
-| **Refactor of `audit.IntegrityChain`** | Split `Wrap` into `AdvanceSequence` + `ComputeHash`. Existing `Wrap` becomes a convenience wrapper that calls both atomically (preserves all current call sites). | Lets composite call `AdvanceSequence` once and pass `(seq, gen)` to each sink for `ComputeHash`. Existing single-sink callers (the JSONL primary) continue to use `Wrap` unchanged. |
-| **Generation semantics** | Generation increments on key rotation. Sequence resets to 0 on a new generation. `prev_hash = ""` on the first record of a new generation. | Matches WTP spec §6.4 (`generation` field) and the existing rotation expectation in the integrity-tamper-evidence doc. |
-| **TransportLoss on shared sequence** | Each sink that drops records (e.g., WTP WAL overflow) emits its *own* TransportLoss marker locally. The shared sequence is **not** affected by per-sink loss. | Loss is per-sink. The shared sequence reflects what the system *produced*, not what each sink *delivered*. An auditor reconstructing the chain across sinks correlates by `(seq, gen)`; gaps in one sink reveal gaps in delivery, not in production. |
+| **Where sequence advances** | A new `audit.SequenceAllocator` owned by composite. Allocates `(seq, gen)` exactly once per event, before fanout. | Single source of truth. Sinks never disagree on `(seq, gen)`. Allocator has no hash state; it only counts. |
+| **Where prev_hash lives** | A new `audit.SinkChain` owned by each chained sink. Computes per-sink `entry_hash` from externally-supplied `(seq, gen, prev_hash, payload)`. | Lets each sink hash its own canonical payload with its own key. No shared mutable state across sinks. |
+| **How sinks learn `(seq, gen)`** | A typed `Chain *ChainState` field on `pkg/types.Event` (not via `ev.Fields`). | Typed → can't accidentally leak into user-visible payloads. Untyped `_integrity_*` map keys would need a strip helper at every serializer; a typed field that's `json:"-"` cannot leak. |
+| **Compute/commit split** | `SinkChain` exposes `Compute` (pure: returns `entryHash`, no mutation) and `Commit` (mutator: advances `prev_hash`). Caller does Compute → durable write → only-on-success Commit. | Clean failure of the durable write rolls back trivially (no commit, retry safe). Ambiguous failure latches `FatalIntegrityError` and locks the chain. |
+| **Where the chain key lives** | Each sink resolves its own key (via existing `internal/audit/kms`). Composite knows nothing about sink keys. | Different sinks may use different keys. The Phase 0 contract is purely about `(seq, gen)` allocation, not key management. |
+| **Refactor of `audit.IntegrityChain`** | Preserved as a convenience wrapper that internally composes a `SequenceAllocator` + `SinkChain`. The existing `Wrap()` method is unchanged at the source level. | Single-sink callers (today's JSONL primary when not in composite) keep working without code changes. |
+| **Generation semantics** | Allocator owns generation; sequence resets to 0 on `NextGeneration()`. Each `SinkChain` resets its `prev_hash` to `""` when it first sees a new generation (signalled via the typed `Chain` field). | Matches WTP spec §6.4. Generation is a property of the shared allocator, not of any sink. |
+| **Per-sink `TransportLoss` doesn't perturb the shared sequence** | Sinks that drop locally emit their own marker. The allocator does not roll back. | The shared sequence reflects what the system *produced*, not what each sink *delivered*. |
 
-## Field Contract
+## Typed `Chain` Field
 
-The composite store stamps two fields on every `types.Event` *before* fanning out to sinks:
-
-```go
-ev.Fields["_integrity_seq"]        = uint64(seq)   // monotonic, gap-free per generation
-ev.Fields["_integrity_generation"] = uint32(gen)   // increments on key rotation; seq resets to 0
-```
-
-### Reserved field-name prefix
-
-Field names starting with `_integrity_` are reserved for the composite store and must not be set by event producers. Sinks must treat them as transport metadata and not surface them as user-visible event fields. (For example, the WTP `compact.Encoder` strips `_integrity_*` before projecting into the OCSF payload.)
-
-### Reading the fields
-
-Sinks use a typed helper in `internal/store/chainstate` (new package, ~40 lines):
+A typed field on `pkg/types.Event` carries the per-event chain state stamped by the composite store:
 
 ```go
-package chainstate
+// pkg/types/events.go (additive change)
 
-import "github.com/agentsh/agentsh/pkg/types"
+type Event struct {
+    // … existing fields unchanged …
 
-type State struct {
+    // Chain is the shared (sequence, generation) allocated by the composite
+    // store before fanout. It is used by chained sinks to produce sink-local
+    // integrity hashes.
+    //
+    // The field is intentionally json:"-" — it must never appear in any
+    // user-visible serialization (audit log, query result, OTEL export).
+    // Sinks that need it consume it directly; sinks that don't ignore it.
+    //
+    // Nil if composite did not stamp the event (e.g., test fixtures, single-
+    // sink installations where chaining is disabled).
+    Chain *ChainState `json:"-"`
+}
+
+type ChainState struct {
     Sequence   uint64
     Generation uint32
 }
-
-// FromEvent extracts the shared chain state stamped by the composite store.
-// Returns (State, true) if both fields are present and well-typed; (State, false)
-// otherwise. Sinks should treat (State, false) as a programming error and emit
-// a counter rather than guessing.
-func FromEvent(ev types.Event) (State, bool)
-
-// MustFromEvent panics if either field is missing. For tests only.
-func MustFromEvent(ev types.Event) State
 ```
 
-The helper handles JSON-decoded variants (`float64`, `json.Number`) the same way `internal/audit/integrity.go`'s `jsonInt64` does, so a sink that receives an event from JSONL replay (where the field came back as `float64`) and a sink that receives it directly from the in-memory composite both see the same `State`.
+The `json:"-"` tag means the field is invisible to every JSON-based serializer in the codebase: JSONL store, OTEL export, webhook, gRPC stream (which uses protobuf, not JSON, but cannot accidentally include a Go field that's marked unexported-from-JSON for the JSONL fallback). The leak risk that motivates many of these protocols disappears at the type level.
+
+### Backwards compatibility
+
+- Adding a field to `types.Event` is source-compatible with all existing code.
+- The field is `nil` when not set; chained sinks check for nil and either ignore (single-sink mode) or return `ErrMissingChainState` (multi-sink mode).
+- No JSONL or OTEL output changes byte-for-byte for existing installations.
 
 ## API Refactor
 
-### `internal/audit/integrity.go` — split Wrap
-
-Today:
+### `internal/audit` — new types
 
 ```go
-// Wrap adds integrity metadata to an event payload. Advances sequence and
-// computes hash atomically.
-func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error)
+package audit
+
+// SequenceAllocator owns the shared (sequence, generation) tuple. It has no
+// hash state. Composite holds exactly one allocator.
+type SequenceAllocator struct { /* mu, sequence int64, generation uint32 */ }
+
+func NewSequenceAllocator() *SequenceAllocator
+
+// Next returns the next (sequence, generation) and advances. Sequence is
+// monotonic within a generation; generation does not change here.
+// ErrSequenceOverflow if sequence == math.MaxInt64.
+func (a *SequenceAllocator) Next() (sequence int64, generation uint32, err error)
+
+// NextGeneration increments generation and resets sequence to -1, so the
+// next Next() returns (0, new_generation). Used by the composite when the
+// chain key rotates.
+func (a *SequenceAllocator) NextGeneration() (generation uint32)
+
+// State returns the current (sequence, generation) for persistence.
+func (a *SequenceAllocator) State() AllocatorState
+
+// Restore restores allocator state after restart. The next Next() returns
+// (sequence + 1, generation).
+func (a *SequenceAllocator) Restore(state AllocatorState)
+
+type AllocatorState struct {
+    Sequence   int64
+    Generation uint32
+}
 ```
 
-After Phase 0:
-
 ```go
-// AdvanceSequence allocates the next (sequence, generation) under the chain's
-// mutex and returns it. Does not compute or update prev_hash. The caller is
-// responsible for calling ComputeHash with the returned sequence.
-func (c *IntegrityChain) AdvanceSequence() (sequence int64, generation uint32, err error)
+package audit
 
-// ComputeHash computes the HMAC over (format_version, sequence, prev_hash,
-// canonical_payload) and updates the chain's prev_hash. Must be called
-// exactly once per AdvanceSequence call, with the same sequence value.
-// If a caller fails to call ComputeHash after AdvanceSequence, the chain
-// becomes inconsistent — callers should treat this as a fatal condition.
-func (c *IntegrityChain) ComputeHash(formatVersion int, sequence int64, payload []byte) (prevHash, entryHash string, err error)
+// SinkChain owns prev_hash for one sink. Each chained sink holds one.
+// It is keyed: the same (seq, gen, prev_hash, payload) under different keys
+// produces different entry_hash values, which is the entire point.
+type SinkChain struct { /* mu, key, algorithm, generation, prevHash */ }
 
-// Wrap is preserved for backwards compatibility. It internally calls
-// AdvanceSequence + ComputeHash + builds the JSON payload.
-func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error)
+func NewSinkChain(key []byte, algorithm string) (*SinkChain, error)
+
+// Compute computes the HMAC over (formatVersion, sequence, generation,
+// prev_hash, canonical_payload) using the chain's key. It is PURE: it does
+// not mutate prev_hash. The caller must follow with Commit on durable success
+// or discard the result on durable failure.
+//
+// If generation differs from the chain's current generation, Compute treats
+// prev_hash as "" (chain rolls automatically). The transition is committed
+// only when Commit is called.
+func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32, payload []byte) (entryHash string, prevHash string, err error)
+
+// Commit advances prev_hash to entryHash. Must be called exactly once per
+// successful Compute, after the durable write succeeds. On ambiguous failure
+// (write may or may not have landed), the caller MUST call Fatal instead;
+// Commit and Fatal are mutually exclusive per Compute.
+func (c *SinkChain) Commit(generation uint32, entryHash string)
+
+// Fatal latches the chain in an unrecoverable state. All subsequent Compute
+// calls return ErrFatalIntegrity. Used when a durable write returned an
+// ambiguous error (timeout, partial write detection) — we cannot know
+// whether the entry was persisted, so we cannot safely continue chaining.
+func (c *SinkChain) Fatal(reason error)
+
+// State returns (generation, prev_hash) for persistence.
+func (c *SinkChain) State() ChainState
+
+// Restore restores chain state after restart.
+func (c *SinkChain) Restore(generation uint32, prevHash string)
+
+type ChainState struct {
+    Generation uint32
+    PrevHash   string
+}
+
+var (
+    ErrFatalIntegrity   = errors.New("integrity chain latched fatal; sink must be reinitialized")
+    ErrMissingChainState = errors.New("event missing Chain field; composite did not stamp it")
+)
 ```
 
-The mutex is still held across the *pair* of operations when called via `Wrap` (composite path will not use Wrap; it will hold its own mutex around the pair). This is necessary because `prev_hash` depends on the previous `entry_hash`.
+### `audit.IntegrityChain.Wrap()` — preserved
 
-### `internal/store/composite/composite.go` — advance + fanout
+The existing `Wrap()` is preserved verbatim as a convenience for single-sink callers:
 
 ```go
+// IntegrityChain is the legacy single-sink composer of SequenceAllocator +
+// SinkChain. New code should use the two types directly via the composite
+// store's allocator and per-sink chains. Wrap() is preserved unchanged at the
+// source level for existing callers.
+type IntegrityChain struct {
+    alloc *SequenceAllocator
+    chain *SinkChain
+}
+
+func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error) {
+    seq, gen, err := c.alloc.Next()
+    if err != nil { return nil, err }
+    canonical := canonicalize(payload)
+    entry, prev, err := c.chain.Compute(IntegrityFormatVersion, seq, gen, canonical)
+    if err != nil { return nil, err }
+    wrapped := buildJSON(payload, IntegrityMetadata{
+        FormatVersion: IntegrityFormatVersion,
+        Sequence:      seq,
+        PrevHash:      prev,
+        EntryHash:     entry,
+    })
+    c.chain.Commit(gen, entry)
+    return wrapped, nil
+}
+```
+
+For single-sink callers, durable success is implicit (Wrap returns the bytes; the caller writes them; if the write fails the caller never calls Wrap again on the same record). The single-sink case does not need the Compute/Commit split exposed because there is no fanout — but composite-mode callers absolutely do.
+
+### `internal/store/composite/composite.go` — allocate + stamp + fanout
+
+```go
+type Store struct {
+    primary       store.EventStore
+    output        store.OutputStore
+    others        []store.EventStore
+    allocator     *audit.SequenceAllocator   // NEW: shared allocator
+    onAppendError func(error)
+}
+
 func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
-    // Phase 0: composite owns sequence advancement.
-    seq, gen, err := s.chain.AdvanceSequence()
+    // Phase 0: composite allocates the shared (seq, gen) before fanout.
+    seq, gen, err := s.allocator.Next()
     if err != nil {
-        return err
+        return err  // typically ErrSequenceOverflow; caller treats as fatal
     }
-    ev.Fields = ensureFields(ev.Fields)
-    ev.Fields["_integrity_seq"]        = uint64(seq)
-    ev.Fields["_integrity_generation"] = gen
+    ev.Chain = &types.ChainState{
+        Sequence:   uint64(seq),
+        Generation: gen,
+    }
 
-    // Fan out — each sink computes its own hash from (seq, gen).
-    var firstErr error
+    // Fan out — each sink that chains computes its own hash; the others ignore.
+    var firstErr, hookErr error
     if s.primary != nil {
-        if err := s.primary.AppendEvent(ctx, ev); err != nil && firstErr == nil {
-            firstErr = err
+        if err := s.primary.AppendEvent(ctx, ev); err != nil {
+            firstErr, hookErr = collectErr(firstErr, hookErr, err)
         }
     }
     for _, o := range s.others {
-        if err := o.AppendEvent(ctx, ev); err != nil && firstErr == nil {
-            firstErr = err
+        if err := o.AppendEvent(ctx, ev); err != nil {
+            firstErr, hookErr = collectErr(firstErr, hookErr, err)
         }
+    }
+    if hookErr != nil && s.onAppendError != nil {
+        s.onAppendError(hookErr)
     }
     return firstErr
 }
-```
 
-The error-hook semantics (`onAppendError`, `FatalIntegrityError` detection) of the current composite are preserved verbatim; only the sequence-advance position changes.
-
-### Sink integration
-
-Sinks that chain (JSONL primary, WTP, any future chained sink) read `(seq, gen)` from `ev.Fields` and compute their own hash:
-
-```go
-func (s *MySink) AppendEvent(ctx context.Context, ev types.Event) error {
-    state, ok := chainstate.FromEvent(ev)
-    if !ok {
-        return ErrMissingChainState  // composite did not stamp the event
-    }
-    canonicalPayload := s.encode(ev)
-    prevHash, entryHash, err := s.chain.ComputeHash(formatVersion, int64(state.Sequence), canonicalPayload)
-    if err != nil {
-        return err
-    }
-    return s.write(state, prevHash, entryHash, canonicalPayload)
+// NextGeneration is called by the composite owner (the daemon) when the
+// chain key rotates. All chained sinks observe the new generation on the
+// next event.
+func (s *Store) NextGeneration() uint32 {
+    return s.allocator.NextGeneration()
 }
 ```
 
-Sinks that don't chain (OTel, webhook) ignore the fields entirely.
+The error-hook semantics (`onAppendError`, `FatalIntegrityError` detection) of the current composite are preserved verbatim; only the sequence-allocation step is added.
+
+### Sink integration — the transactional pattern
+
+Sinks that chain (JSONL primary in composite mode, WTP, any future chained sink) follow this exact pattern:
+
+```go
+func (s *MySink) AppendEvent(ctx context.Context, ev types.Event) error {
+    if ev.Chain == nil {
+        return audit.ErrMissingChainState
+    }
+    canonical := s.encode(ev)
+
+    // Step 1: pure compute — no chain mutation yet.
+    entryHash, prevHash, err := s.chain.Compute(
+        formatVersion, int64(ev.Chain.Sequence), ev.Chain.Generation, canonical,
+    )
+    if err != nil {
+        return err  // includes ErrFatalIntegrity if a previous append latched fatal
+    }
+
+    // Step 2: durable write. Failure modes split three ways.
+    werr := s.writeDurable(canonical, entryHash, prevHash)
+    switch {
+    case werr == nil:
+        // Step 3a: clean success → commit.
+        s.chain.Commit(ev.Chain.Generation, entryHash)
+        return nil
+
+    case errors.Is(werr, errCleanFailure):
+        // Step 3b: clean failure → no commit, chain unchanged. Caller may retry.
+        return werr
+
+    default:
+        // Step 3c: ambiguous failure → latch fatal. We cannot know whether
+        // the write landed, so any future chaining would be unsound.
+        s.chain.Fatal(werr)
+        return werr
+    }
+}
+```
+
+The classification of `errCleanFailure` vs ambiguous is sink-specific and must be documented per sink. For example:
+
+- **WAL.Append**: a returned error from `os.Write` *before* the system call has been issued (parameter validation, closed file) is clean. An error from `os.Write` itself, or from `f.Sync()`, is ambiguous — the bytes may have hit the platter. Default: ambiguous.
+- **Network sends** (no chained sink does this synchronously; WTP buffers via WAL first): always ambiguous.
+- **In-memory checks before any I/O**: clean.
+
+Sinks that do not chain (OTel, webhook in non-chained configurations) ignore `ev.Chain` entirely.
 
 ## Generation Roll
 
-When the composite's chain key rotates:
+When the composite owner rotates the chain key:
 
-1. Composite calls `chain.NextGeneration()` (new helper) which:
-   - Acquires the chain mutex.
-   - Increments `c.generation`.
-   - Resets `c.sequence = -1` (so the next `AdvanceSequence` returns 0).
-   - Sets `c.prevHash = ""`.
-   - Releases the mutex.
-2. The next `AdvanceSequence` returns `(0, new_gen)`.
-3. Sinks observe the new generation in `ev.Fields["_integrity_generation"]`. Each sink takes its own action:
-   - JSONL: writes a marker line.
-   - WTP: forces a batch flush, segment roll, and `SessionUpdate`.
+1. Owner calls `composite.NextGeneration()` → returns new generation.
+2. Next `AppendEvent` call allocates `(seq=0, gen=new)`.
+3. Each chained sink observes `ev.Chain.Generation` differs from its `SinkChain.State().Generation`. `SinkChain.Compute` automatically uses `prev_hash = ""` for the new generation and returns the rollover indicator via `prevHash == ""`. `Commit` records the new generation.
+4. Per-sink work (e.g., WTP forces a batch flush + WAL segment roll + `SessionUpdate`) is triggered by the sink observing the generation change in `ev.Chain.Generation`.
 
-Generation is a property of the *shared* chain, not of any sink. All sinks see the same rollover at the same logical event boundary.
+Generation is a property of the *shared allocator*, not of any individual sink. All sinks roll on the same logical event boundary — the first event with the new generation.
 
 ## TransportLoss Semantics
 
 Per-sink loss does not perturb the shared sequence. Example:
 
-- Composite advances seq=100 (gen=7).
+- Composite allocates seq=100 (gen=7).
 - JSONL writes seq=100 successfully.
-- WTP cannot write seq=100 (WAL full): it drops it locally and emits a `TransportLoss{from_seq:100, to_seq:100, generation:7}` marker into its own WAL.
-- Composite advances seq=101 (gen=7).
+- WTP cannot write seq=100 (WAL full): drops it locally, emits a `TransportLoss{from_seq:100, to_seq:100, generation:7}` marker into its own WAL.
+- Composite allocates seq=101 (gen=7).
 - Both sinks write seq=101.
 
-An auditor reconstructing the WTP stream sees: `..., 99, TransportLoss(100), 101, ...` — the gap is explicit. An auditor reconstructing the JSONL stream sees: `..., 99, 100, 101, ...` — no gap, because that sink delivered. Cross-correlating the two streams reveals which sink lost what.
+An auditor reconstructing the WTP stream sees `..., 99, TransportLoss(100), 101, ...` — the gap is explicit. An auditor reconstructing the JSONL stream sees `..., 99, 100, 101, ...` — no gap, because that sink delivered. Cross-correlating reveals which sink lost what.
 
 The shared sequence is therefore a property of *what the system produced*, not of *what each sink delivered*. This is the only consistent interpretation that lets sinks have different durability profiles.
 
@@ -198,22 +321,20 @@ The shared sequence is therefore a property of *what the system produced*, not o
 
 This refactor is **invisible** to single-sink installations:
 
-- `Wrap()` is preserved unchanged. Callers using `Wrap` (today: the integrity wrapper around JSONL when there's only one sink) continue to work.
-- Only when the composite store is configured with `>1` chained sink, or when WTP is enabled, does the new `AdvanceSequence + ComputeHash` path activate.
-- The reserved `_integrity_*` field prefix is new — we add a startup check that rejects user-supplied event fields starting with `_integrity_` (today no such fields exist; this is purely defensive).
+- The legacy `audit.IntegrityChain.Wrap()` API is unchanged at the source level. Existing callers compile and run without modification.
+- The new `Chain` field on `types.Event` is `json:"-"` and additive; existing JSON output is byte-identical.
+- Only when composite is configured with a chained sink besides the primary, *or* when WTP is enabled, does the composite begin allocating and stamping `ev.Chain`. Until that moment, `ev.Chain` is `nil` and chained sinks fall back to either erroring (strict mode) or behaving as ungrounded (lenient mode, dev only).
 
 ## Verification
 
-The refactor is self-verifying via existing tests if we add three new ones:
+Three new tests in `internal/store/composite/sequence_contract_test.go`:
 
-1. **Cross-sink convergence:** With two chained sinks (JSONL + a fake WTP using the same key), every record's `(seq, gen, entry_hash)` matches between the two. Run for 10,000 events.
-2. **Per-sink divergence with different keys:** With two chained sinks using *different* keys, `(seq, gen)` matches but `entry_hash` differs.
-3. **Generation roll consistency:** After a `NextGeneration()` call, both sinks observe the rollover at the same event boundary; sequence resets to 0 in both.
-
-These live in `internal/store/composite/sequence_contract_test.go` (new file) and use a fake `EventStore` that records the `(seq, gen)` it sees per event.
+1. **Cross-sink `(seq, gen)` convergence:** With two chained sinks (JSONL + a fake WTP using identical canonical encoding and the same key), every record's `(seq, gen)` matches between the two. Run for 10,000 events. `entry_hash` is *not* asserted equal in the general case — sinks that hash different canonical bytes will produce different entry hashes by design; the assertion narrows to "if both sinks hash the same canonical bytes with the same key, then `entry_hash` matches."
+2. **Generation roll consistency:** After a `composite.NextGeneration()` call, both sinks observe the rollover at the same event boundary; sequence resets to 0 in both; each sink's `prev_hash` resets to `""` independently.
+3. **Transactional rollback:** A fake sink that fails its durable write with `errCleanFailure` does NOT advance its `SinkChain.prev_hash`. After the failure, a successful write of a NEW event uses the previous (pre-failure) `prev_hash` — proving rollback is correct. A second test injects an ambiguous failure and asserts `SinkChain.Compute` returns `ErrFatalIntegrity` on every subsequent call.
 
 ## Out-of-Scope
 
 - The actual WTP client implementation (separate doc).
-- KMS-backed key rotation automation (existing `internal/audit/kms` is unchanged).
-- Surfacing `_integrity_*` fields in any user-visible API (they are strictly internal transport metadata).
+- KMS-backed key rotation automation (existing `internal/audit/kms` is unchanged; the *trigger* for `composite.NextGeneration()` is operator-driven for now).
+- Surfacing `Chain` in any user-visible API. The field is `json:"-"` and used only by chained sinks internally.

--- a/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
+++ b/docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md
@@ -133,6 +133,17 @@ func NewSinkChain(key []byte, algorithm string) (*SinkChain, error)
 // generation prev_hash mismatch OR rollover-with-nonempty-prev) — with all
 // integrity-affecting violations latching fatal rather than silently
 // corrupting the chain.
+//
+// Lifecycle / serialization boundary: a ComputeResult is bound to the
+// in-memory SinkChain instance that produced it. It is NOT a durable
+// token — a SinkChain reconstructed via NewSinkChain + Restore is a new
+// instance and will reject prior tokens with ErrCrossChainResult. Compute
+// and Commit are designed to be co-located in a single process, with the
+// durable write of the integrity metadata happening between them.
+// EntryHash() and PrevHash() exist so that callers can persist the
+// integrity metadata alongside the payload for later VerifyHash; they are
+// NOT the input shape for reconstructing a Commit token across process
+// boundaries.
 type ComputeResult struct {
     // unexported: entryHash, prevHash, sequence, generation, chain
 }

--- a/docs/superpowers/specs/2026-04-18-wtp-client-design.md
+++ b/docs/superpowers/specs/2026-04-18-wtp-client-design.md
@@ -113,24 +113,45 @@ The root `store.go` is small (~150 lines): it constructs a `Config`, builds the 
 
 ## Data Flow
 
-### Steady state — `AppendEvent`
+### Steady state — `AppendEvent` (transactional pattern)
 
 ```
 caller (composite store)
-  │
-  │ ev = types.Event{Type, Timestamp, Fields{..., _integrity_seq=N, _integrity_generation=G}}
+  │  composite has already allocated (seq, gen) and stamped ev.Chain
+  │  via the typed pkg/types.Event.Chain *ChainState field (Phase 0).
   ▼
 watchtower.Store.AppendEvent(ctx, ev)
   │
-  ├─ compact.Encode(ev)            → wtpv1.CompactEvent  (OCSF class, activity, payload)
-  ├─ chain.Advance(seq=N, gen=G,
-  │   prev_hash, canonical_record) → entry_hash, prev_hash := entry_hash
-  ├─ wal.Append(record_bytes)      → fsync (or deferred per §6 of this doc)
-  └─ transport.Notify()            → wake transport goroutine
-  return nil
+  │ 1. validate: ev.Chain != nil, else ErrMissingChainState
+  │
+  │ 2. compact.Encode(ev) → wtpv1.CompactEvent
+  │
+  │ 3. canonicalize → bytes for hashing
+  │
+  │ 4. SinkChain.Compute(formatVersion, seq, gen, payload)
+  │      → (entryHash, prevHash) — PURE, no chain mutation
+  │
+  │ 5. wal.Append(seq, gen, record_bytes)
+  │      → (a) clean failure: return err, no Commit, chain unchanged
+  │      → (b) ambiguous failure: SinkChain.Fatal(err); return ErrFatalIntegrity
+  │      → (c) success: continue
+  │
+  │ 6. SinkChain.Commit(gen, entryHash) — chain advances
+  │
+  │ 7. transport.Notify() → wake transport goroutine (non-blocking)
+  │
+  └─ return nil
 ```
 
-The caller — typically the composite store — has already advanced the shared `(sequence, generation)` and stamped them on `ev.Fields` (Phase 0 contract). This client never advances them itself; doing so would break sink-local hash convergence.
+The WTP `AppendEvent` follows the transactional Compute → durable-write → Commit pattern from §"Sink integration" of the Phase 0 contract. Failure modes:
+
+| WAL failure | Action | Chain state | Caller-visible error |
+|---|---|---|---|
+| Clean (e.g., overflow detected before any I/O, validation error) | No Commit. Caller may retry. | Unchanged. | The clean error. |
+| Ambiguous (write returned, fsync returned, partial write possible) | `SinkChain.Fatal(err)`. Subsequent appends return `ErrFatalIntegrity`. | Latched fatal. | The ambiguous error wrapped in `FatalIntegrityError`. |
+| Success | `Commit`. | `prev_hash := entry_hash`, `generation := ev.Chain.Generation`. | nil. |
+
+The `wal.Append` function is the only place that classifies WAL failures into clean vs ambiguous. The classification is documented in §4 below.
 
 ### Transport loop (single goroutine)
 
@@ -162,15 +183,24 @@ The caller — typically the composite store — has already advanced the shared
                          (back to connecting)
 ```
 
-### Generation roll
+### Generation roll (WAL-driven, not transport-driven)
 
-When a new event arrives with `_integrity_generation > current_generation`, the transport must:
-1. Flush the current batch (a batch is single-generation per spec §7).
-2. Seal the current WAL segment and start a new one (segment is single-generation by file header).
-3. Send a `SessionUpdate` carrying the new context digest and generation.
-4. Append the new record under the new generation.
+Generation boundaries are detected and enforced inside `wal.Append`, *before* the record is written. This is the only place that can guarantee "single generation per segment" because the WAL writes records to the segment file before the transport ever sees them.
 
-The chain itself resets: `prev_hash = ""` and the per-sink HMAC continues with the new `(gen, seq=0)` tuple.
+```
+wal.Append(seq, gen, payload):
+  if gen != currentSegment.generation:
+    seal currentSegment (rename .INPROGRESS → .seg, fsync parent)
+    open new segment with header.generation = gen
+    fsync new segment header
+    enqueue an internal "GENERATION_ROLL" notification record so the
+      transport knows to flush the current batch and emit SessionUpdate
+      before sending the first record of the new generation.
+  write framed record into currentSegment
+  fsync per policy
+```
+
+The transport, on observing the GENERATION_ROLL notification in the WAL stream, performs the protocol-level work (flush current batch, send `SessionUpdate` with new context digest, then begin batching new-generation records). The chain itself resets per-sink: `SinkChain.Compute` automatically uses `prev_hash = ""` when it sees a new generation, and `Commit` records the new generation.
 
 ### WAL overflow → TransportLoss
 
@@ -180,52 +210,73 @@ When `wal.Append` would push total disk usage past `max_total_bytes`:
 3. Increment `wtp_transport_loss_total`.
 4. The marker is sent like any other batch when the transport reaches it; the server learns about the gap via the marker, not via a missing sequence number alone.
 
+CRC-corruption recovery emits `TransportLoss` with a *coarse* range: when a record fails CRC verification on read, we report `TransportLoss{from_seq: last_good_seq + 1, to_seq: segment_max_seq_estimate, generation: segment.generation}`. The estimate is computed as `last_good_seq + (segment_remaining_bytes / typical_record_size)`. This is best-effort but bounded: corruption in practice almost always means a truncated tail, where the gap extends to the segment end. A v2 enhancement (per-record sequence in the frame header, +8 bytes/record) would enable exact gap reporting; deferred until operators report imprecise ranges in practice.
+
 ## Phase 0 Contract (consumed, not implemented)
 
-The composite store advances a shared `(sequence, generation)` *before* fanning the event out to sinks. Each sink stamps these onto its own per-sink hash. The WTP client reads them via:
+The composite store allocates a shared `(sequence, generation)` *once* via a `audit.SequenceAllocator` and stamps it onto the typed `ev.Chain *types.ChainState` field *before* fanning the event out to sinks. The WTP client reads it via:
 
 ```go
-ev.Fields["_integrity_seq"]        // uint64
-ev.Fields["_integrity_generation"] // uint32
+if ev.Chain == nil {
+    return audit.ErrMissingChainState  // composite did not stamp
+}
+seq := ev.Chain.Sequence    // uint64
+gen := ev.Chain.Generation  // uint32
 ```
 
-If either field is missing or the wrong type, `AppendEvent` returns `ErrMissingChainState` and increments `wtp_dropped_missing_chain_state_total`. This is a programming error (composite not refactored or sink wired incorrectly), not a runtime condition we try to recover from.
+The field is `json:"-"` on `pkg/types.Event` — it cannot leak into JSONL, OTEL, or any other JSON-based serializer. Per-sink hashing is the responsibility of each sink's own `audit.SinkChain` instance, using the shared `(seq, gen)` from `ev.Chain`.
 
-The full contract — including the existing `audit/integrity.go` refactor split (chain.AdvanceSequence vs chain.ComputeHash), the exact field names, value types, and the `TransportLoss` semantics on the shared sequence — is documented in `docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md`. That doc is the source of truth for the contract; this design depends on it but does not change it.
+The full contract — `SequenceAllocator` + `SinkChain` types, the transactional Compute/Commit protocol, generation semantics, `TransportLoss` semantics on the shared sequence, and the `types.Event.Chain` field — is documented in `docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md`. That doc is the source of truth; this design depends on it but does not change it.
 
 ## Chain Package (`internal/store/watchtower/chain`)
 
-### API
+The WTP sink uses `audit.SinkChain` from the Phase 0 contract directly — there is no WTP-specific chain wrapper. This package contains only the helpers `audit.SinkChain` does not provide: canonical-record encoding (the byte-exact format that gets hashed) and the WTP-specific context digest.
+
+### Helpers (not a new chain type)
 
 ```go
 package chain
 
-type SinkChain struct { /* key, algorithm, prev_hash */ }
-
-func New(key []byte, algorithm string) (*SinkChain, error)        // hmac-sha256 | hmac-sha512
-func (c *SinkChain) Advance(rec IntegrityRecord) (entryHash string, err error)
-func (c *SinkChain) Reset(generation uint32, prevHash string)     // for SessionUpdate
-func (c *SinkChain) State() (prevHash string)                      // for crash-recovery rebuild
-
+// IntegrityRecord is the WTP-specific structure that gets canonical-encoded
+// and passed as the payload to audit.SinkChain.Compute. The on-the-wire
+// integrity_record JSON object in WTP CompactEvent has these fields.
 type IntegrityRecord struct {
-    FormatVersion uint32      // = 2 (spec §6.4)
-    Sequence      uint64      // shared, from composite
-    Generation    uint32      // shared, from composite
-    PrevHash      string      // sink-local
-    EventHash     string      // sha256(canonical_event_bytes)
-    ContextDigest string      // bound at SessionInit/Update/rotation
+    FormatVersion  uint32   // = 2 (spec §6.4)
+    Sequence       uint64   // shared, from ev.Chain.Sequence
+    Generation     uint32   // shared, from ev.Chain.Generation
+    PrevHash       string   // sink-local; provided by audit.SinkChain
+    EventHash      string   // sha256(canonical_compact_event_bytes)
+    ContextDigest  string   // bound at SessionInit/Update/rotation
     KeyFingerprint string
 }
+
+// EncodeCanonical produces the byte-exact JSON encoding mandated by spec §6.4
+// (sorted keys, no insignificant whitespace, ASCII-escaped non-ASCII, decimal
+// numbers). This output is the payload passed to audit.SinkChain.Compute and
+// is the contract surface for cross-implementation parity.
+func EncodeCanonical(rec IntegrityRecord) ([]byte, error)
+
+// ComputeContextDigest returns the SHA-256 of the canonical encoding of the
+// SessionContext fields the spec lists. Bound into every event hash in the
+// session/segment.
+func ComputeContextDigest(ctx SessionContext) string
+
+// ComputeEventHash returns sha256(canonical_compact_event_bytes). Used to
+// populate IntegrityRecord.EventHash before passing the canonical-encoded
+// IntegrityRecord to audit.SinkChain.Compute.
+func ComputeEventHash(canonicalEvent []byte) string
 ```
+
+The actual chain mutations (Compute/Commit/Fatal/State/Restore) all live on `audit.SinkChain`; we do not re-implement them. The transactional pattern from §"Steady state" calls into `audit.SinkChain` directly.
 
 ### Canonical encoding — non-negotiable byte parity
 
 Spec §6.4 mandates a canonical JSON encoding with sorted keys, no insignificant whitespace, ASCII-escaped non-ASCII, and decimal numbers (no scientific notation). `encoding/json` does *not* guarantee any of these invariants across versions, and a single byte difference breaks every other implementation's verification.
 
-We hand-roll a canonical encoder in `chain/canonical.go`:
+We hand-roll the encoder in `chain/canonical.go`:
 
 ```go
-func encodeCanonical(rec IntegrityRecord) ([]byte, error)
+func EncodeCanonical(rec IntegrityRecord) ([]byte, error)
 ```
 
 The encoder is exhaustively tested against `chain/testdata/vectors.json`, which is also published as the cross-implementation conformance suite for the spec. Vectors include UTF-8 edge cases (escaped non-ASCII, surrogate pairs), large numbers near uint64 max, and empty strings.
@@ -240,9 +291,10 @@ Computed once on `SessionInit`, again on `SessionUpdate`, and again on chain rot
 
 ### What this package does NOT do
 
-- Advance the shared sequence (composite owns it).
-- Persist any state (root `store.go` reconstructs `prev_hash` from WAL on startup).
-- Talk to the network or to a KMS (the key is passed in already-resolved).
+- Advance the shared sequence (composite owns the `audit.SequenceAllocator`).
+- Mutate `prev_hash` (lives on `audit.SinkChain`).
+- Persist any state (root `store.go` reconstructs `audit.SinkChain` from WAL on startup via `Restore`).
+- Talk to the network or to a KMS (the key is passed in already-resolved at construction).
 
 ## WAL Package (`internal/store/watchtower/wal`)
 
@@ -277,23 +329,88 @@ Header is fsync'd at segment creation. A reader rejects segments with unknown ma
 offset  size      field
 0       4         length     (uint32 BE; bytes after this field, excluding the CRC and including payload)
 4       4         crc32c     (Castagnoli, computed over payload)
-8       length-4  payload    (protobuf-encoded WAL record)
+8       length-4  payload    (protobuf-encoded WAL record; carries seq + gen)
 ```
 
-The CRC is the last line of defense against truncated tails (crash mid-fsync). Reader behaviour on bad CRC: log + emit `TransportLoss` marker for the affected sequence(s) + skip to next valid record.
+Sequence and generation are encoded inside the protobuf payload (not in the frame header), so a per-record scan after CRC failure can recover them when the record itself parses cleanly. When CRC fails, the record bytes are unsafe to parse — the recovery path below uses the segment header's generation and the last-good record's sequence to bound the lost range.
+
+The CRC is the last line of defense against truncated tails (crash mid-fsync). Reader behaviour on bad CRC: log + emit `TransportLoss` marker with a coarse range (see "CRC corruption recovery" below) + skip to next valid record.
+
+### `Append` — clean vs ambiguous failure classification
+
+`wal.Append` is the only place that decides whether a write failure is recoverable. The classification feeds directly into the WTP `AppendEvent` transactional pattern (clean → no Commit, ambiguous → Fatal).
+
+```go
+func (w *WAL) Append(seq int64, gen uint32, payload []byte) (AppendResult, error)
+
+type AppendResult struct {
+    GenerationRolled bool   // true iff this Append rolled the segment for a new generation
+}
+```
+
+Failure classification:
+
+| Failure source | Classification | Why |
+|---|---|---|
+| `payload` exceeds segment-size budget | Clean | Validated before any I/O. |
+| WAL is in `closed` state | Clean | Validated before any I/O. |
+| `MaxTotalBytes` exceeded after attempting overflow GC | Clean (loss marker emitted instead of returning error) | We drop oldest segments and emit `TransportLoss`. The Append itself succeeds. |
+| `os.Write` returns short write or io error | Ambiguous | Bytes may have hit the filesystem buffer or the platter. |
+| `f.Sync()` returns error | Ambiguous | Sync may have partially flushed. |
+| Segment-roll rename fails after seal | Ambiguous | Old segment may or may not have been removed; new segment may or may not exist. |
+| `meta.json` atomic-rename fails on watermark update (on Ack path, not Append) | Ambiguous | meta.json may be in either old or new state. |
+
+A clean failure leaves the WAL in a consistent state: the partial frame (if any) is truncated back to the last good byte, the segment file's logical size is restored, and `Append` returns the error. The caller (WTP `AppendEvent`) does NOT call `SinkChain.Commit`, so the chain stays at the previous `prev_hash` and the next event hashes against the same prev_hash. If the caller retries with a new event allocation, the `(seq, gen)` differs but `prev_hash` is unchanged — which is correct, because the failed event was never durably persisted.
+
+An ambiguous failure latches the WAL in `degraded` state. Any subsequent `Append` returns `ErrFatalIntegrity` immediately. The WTP `AppendEvent` calls `SinkChain.Fatal(err)` and returns. The composite store's `onAppendError` hook is invoked and the daemon decides whether to halt the agent (default) or continue with the WTP sink disabled (operator opt-in).
+
+### Generation roll happens INSIDE Append
+
+`Append` detects generation transitions and seals/rolls segments before writing the new record. This is the only place that can guarantee "single generation per segment" because the WAL writes records before the transport ever sees them.
+
+```
+Append(seq, gen, payload):
+  if gen != currentSegment.generation:
+    seal currentSegment:
+      truncate to actual length
+      fsync segment file
+      rename .INPROGRESS → .seg
+      fsync(segments/)
+    open new segment with header.generation = gen
+    fsync new segment header
+    fsync(segments/)
+    set AppendResult.GenerationRolled = true
+  write framed record into currentSegment
+  fsync per policy
+  return AppendResult, nil
+```
+
+When `AppendResult.GenerationRolled == true`, the WTP `AppendEvent` notifies the transport to flush its current batch and emit a `SessionUpdate` with the new context digest before the new-generation batch begins. The chain itself rolls inside `audit.SinkChain.Compute` (it sees the new generation and uses `prev_hash = ""`).
 
 ### Lifecycle
 
 | Event | Action |
 |---|---|
-| Open | Scan `segments/`. Last `*.INPROGRESS` is the live segment; reopen for append. Replay all records to recover `prev_hash` and verify CRCs. |
-| Append | Write framed record. Fsync per policy (immediate, or deferred per `2026-04-13-deferred-sync`). |
+| Open | Scan `segments/`. Last `*.INPROGRESS` is the live segment; reopen for append. Replay all records, verifying CRCs and rebuilding `audit.SinkChain.prev_hash`. |
+| Append | Detect generation change → seal/roll if needed. Write framed record. Fsync per policy (immediate, or deferred per `2026-04-13-deferred-sync`). |
 | Segment full | Truncate to actual length, fsync, rename `.INPROGRESS` → `.seg`, open new `.INPROGRESS`. |
-| Generation change | Force segment roll (header carries generation). |
-| `SessionUpdate` | Force fsync of live segment + meta.json. |
+| Generation change | Detected inside Append (see above). |
+| `SessionUpdate` write | Force fsync of live segment + meta.json. |
 | `TransportLoss` write | Force fsync (operator visibility into loss must be durable). |
 | Ack received | Update `meta.json` with new `ack_high_watermark`. GC fully-acked segments via `os.Remove` after fsync(parent). |
 | Close | Fsync live segment, leave `.INPROGRESS` suffix in place (will be reopened on restart). |
+
+### CRC corruption recovery
+
+When a record fails CRC verification on read:
+
+1. Log the corruption with segment file, offset, expected/actual CRC.
+2. Compute coarse range: `from_seq = last_good_seq + 1`, `to_seq = last_good_seq + max(1, segment_remaining_bytes / typical_record_size)`. The estimate uses the segment's average record size from records read so far.
+3. Emit `TransportLoss{from_seq, to_seq, generation: segment.generation, reason: "crc_corruption"}` into the WAL stream.
+4. Increment `wtp_wal_corruption_total`.
+5. Skip to the next segment (we do not attempt to scan-and-resync within a corrupted segment; the most common cause is a truncated tail, which extends to the segment end by definition).
+
+This is best-effort. A v2 enhancement (per-record sequence in the frame header, +8 bytes/record overhead) would enable exact gap reporting and is deferred until operators report imprecise ranges in practice. Documented in §8.
 
 ### meta.json schema
 
@@ -322,7 +439,7 @@ func (r *Reader) Close() error
 func (w *WAL) MarkAcked(seq uint64) error    // GC fully-acked segments
 ```
 
-The transport goroutine consumes via the reader; it does not poll. Notifications coalesce naturally — one wakeup may correspond to many appended records.
+The transport goroutine consumes via the reader; it does not poll. Notifications coalesce naturally — one wakeup may correspond to many appended records. The reader surfaces `TransportLoss` and generation-roll markers as ordinary records (with a typed kind field) so the transport state machine handles them in the same select branch as data records.
 
 ## Transport Package (`internal/store/watchtower/transport`)
 
@@ -423,7 +540,7 @@ All exposed via slog at debug + as structured counters consumable by the existin
 - `wtp_wal_segments` (gauge)
 - `wtp_wal_bytes` (gauge)
 - `wtp_ack_high_watermark` (gauge)
-- `wtp_dropped_missing_chain_state_total` (counter)
+- `wtp_dropped_missing_chain_total` (counter; increments when `ev.Chain == nil`)
 - `wtp_send_latency_seconds` (histogram, per batch)
 
 ## Configuration & Wiring
@@ -490,7 +607,10 @@ type Config struct {
         Max  time.Duration // default 30s
     }
 
-    Filter wtpfilter.Filter   // reuse the existing OTEL/webhook filter type
+    Filter wtpfilter.Filter   // see "Filter generalization" below — currently
+                              // OTEL has its own private filter type; we
+                              // generalize it into a shared package as part
+                              // of this work.
 }
 ```
 
@@ -514,7 +634,7 @@ type Option func(*options)
 
 func WithMapper(m compact.Mapper) Option        // injected from Phase 1
 func WithDialer(d transport.Dialer) Option      // injected by tests
-func WithMetrics(reg metrics.Registry) Option   // injected by host
+func WithMetrics(c *metrics.Collector) Option   // injected by host (internal/metrics.Collector)
 func WithLogger(l *slog.Logger) Option          // injected by host
 func WithChainKey(key []byte, fp string) Option // injected by composite (Phase 0)
 ```
@@ -523,7 +643,17 @@ The host (the agentsh daemon) is responsible for building the `Store` with the r
 
 ### Wiring into existing composite
 
-`internal/store/composite/composite.go` already has a `New(primary, output, others...)` constructor. The WTP store is added as another `EventStore` in `others`. No composite-side change is needed *as part of this work* beyond the Phase 0 refactor (which is its own design doc). When Phase 0 lands, composite advances `(seq, gen)` and stamps them on `ev.Fields` before calling `o.AppendEvent`; this client picks them up.
+`internal/store/composite/composite.go` already has a `New(primary, output, others...)` constructor. The WTP store is added as another `EventStore` in `others`. The Phase 0 refactor adds a `audit.SequenceAllocator` to composite and stamps `ev.Chain` before fanout (separate doc); this client consumes `ev.Chain` directly.
+
+### Prerequisite plumbing (in-scope for this work)
+
+These three pieces of plumbing don't exist in the codebase today and must land alongside the WTP sink. Each is small but explicit so reviewers know it's not assumed:
+
+1. **Filter generalization.** `internal/store/otel/otel.go` has a private `Filter` type. We move it into a shared package `internal/store/eventfilter/` (or similar; final name in the implementation plan), update OTEL to consume the shared type, and use it from WTP. Backwards-compatible YAML; no behavior change for OTEL.
+2. **YAML config schema.** Add `WatchtowerConfig` under `internal/config/config.go` mirroring §6 above. Wire into the existing `AuditConfig` (or its peer) so the daemon constructs a WTP `Store` when `enabled: true`. Add `config_test.go` cases for default expansion (ephemeral overrides, mutual-exclusion validation).
+3. **Metrics wiring.** `internal/metrics.Collector` exposes a counter/gauge registry. Add the `wtp_*` series listed under "Metrics" above as fields on a `metrics.Collector` extension or a sibling collector. The host (the daemon `cmd/agentsh`) registers them at startup and passes the collector via `WithMetrics`.
+
+None of these three blocks the WTP package's own unit tests — they only matter at host-wiring time. Each shows up as a discrete milestone in §"Implementation Phases" below.
 
 ## Testing Strategy
 
@@ -536,6 +666,35 @@ The host (the agentsh daemon) is responsible for building the `Store` with the r
 | Unit (state machine) | `transport.state` transitions | Mock `Conn` + table tests | `TestState_GoawayTriggersReconnect` |
 | Component | Whole `Store` against `testserver` | bufconn | `TestStore_DropsMidBatchTriggersReplay` |
 | Integration | Long-running flow: append, kill server, restart, expect ack catch-up | bufconn with restartable scenario | `TestStore_ServerRestart_AcksCatchUp` |
+
+### High-risk integrity tests (first-class, gated before component layer)
+
+These four cases are explicit milestones — they cover the failure modes most likely to corrupt the audit chain or leak metadata, and they must pass before the component-layer tests run.
+
+| Test | Asserts | Where it lives |
+|---|---|---|
+| `TestStore_WALCleanFailure_NoChainAdvance` | A clean `wal.Append` failure (e.g., overflow detected pre-I/O) returns the error to the caller AND `audit.SinkChain.State().PrevHash` is unchanged. The next successful append uses the same `prev_hash` as before the failure. | `internal/store/watchtower/store_failure_test.go` |
+| `TestStore_WALAmbiguousFailure_LatchesFatal` | An ambiguous `wal.Append` failure (injected via a fake file with a flaky `Write`) calls `audit.SinkChain.Fatal`. Subsequent `AppendEvent` calls return `audit.ErrFatalIntegrity` without writing to the WAL. The composite `onAppendError` hook receives a `FatalIntegrityError`. | `internal/store/watchtower/store_failure_test.go` |
+| `TestEvent_ChainFieldNotMarshaled` | After composite stamps `ev.Chain`, marshaling `ev` to JSON via the JSONL store, the OTEL converter, and `encoding/json.Marshal` directly, the output contains no `chain`, `Chain`, `_integrity_*`, or `sequence` keys at the top level. Catches accidental tag changes on `pkg/types.Event`. | `pkg/types/events_chain_test.go` (Phase 0) + `internal/store/jsonl/jsonl_chain_test.go` |
+| `TestWAL_GenerationBoundaryOrdering` | Appending events `(seq=0..N, gen=7)` then `(seq=0..M, gen=8)` produces exactly two segments: one with header.generation=7 containing only gen-7 records, one with header.generation=8 containing only gen-8 records. The `AppendResult.GenerationRolled` flag is set on the boundary record. | `internal/store/watchtower/wal/wal_generation_test.go` |
+
+These four tests are required before any of the five-layer pyramid component/integration tests are accepted. They directly verify the contract changes from roborev findings #2, #3, and #4.
+
+### `AppendEvent` context semantics
+
+`AppendEvent` does NOT honor `ctx.Done()` for the WAL write step. The audit-durability invariant is that any event the caller passed to `AppendEvent` either lands in the WAL or returns an error — a partially-cancelled write would corrupt this invariant. Specifically:
+
+- `compact.Encode`, `chain.EncodeCanonical`, `audit.SinkChain.Compute`: pure CPU, no ctx check.
+- `wal.Append`: ignores ctx cancellation. The WAL write completes (or fails cleanly/ambiguously) before `AppendEvent` returns.
+- `transport.Notify()`: non-blocking channel send; no ctx involvement.
+
+The transport goroutine's outbound gRPC sends DO honor ctx cancellation — they're invisible to the `AppendEvent` caller and respect the connection's context for clean shutdown.
+
+This is documented in the package doc-comment on `Store.AppendEvent` so callers don't expect cancellation semantics.
+
+### `QueryEvents`
+
+WTP is a fire-and-forget transport sink. `QueryEvents` returns `(nil, ErrNotSupported)` matching the pattern in `internal/store/otel/otel.go:138` (`"otel store does not support queries"`). The composite store routes queries to its `primary` (SQLite) and never to `others`, so this never fires in practice.
 
 ### `testserver` capabilities
 
@@ -582,8 +741,8 @@ A test failure on a golden is a load-bearing alarm: the canonical encoding has c
 
 | Item | Status | Where it shows up in the code |
 |---|---|---|
-| Phase 0: composite shared sequence | Prerequisite | `docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md` is the contract doc; `watchtower.Store.AppendEvent` reads `ev.Fields["_integrity_seq"]` and `["_integrity_generation"]`. |
-| Phase 1: OCSF mapper | Prerequisite | `compact.Mapper` interface; implementation lives in a different package. The WTP client's `compact/encoder.go` has a stub `defaultMapper` that handles the most common event types so the package can compile and unit-test stand-alone, but production wiring requires `WithMapper(...)` from Phase 1. |
+| Phase 0: composite shared sequence | Prerequisite | `docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md` is the contract doc; `watchtower.Store.AppendEvent` reads the typed `ev.Chain *types.ChainState` field. |
+| Phase 1: OCSF mapper | Prerequisite (hard) | `compact.Mapper` interface; production implementation lives in a different package. The WTP client's `compact/encoder.go` ships a stub `defaultMapper` for unit tests only — production deployment requires `WithMapper(...)` from Phase 1, enforced by `validate()`. |
 | Open Q: live key rotation pause/resume | Deferred | Comment in `transport/state.go` at the spot where a `KeyRotation` server message would be handled. The WTP client tolerates session-level `SessionUpdate` (the rotation envelope), so the rotation can be performed by issuing a `SessionUpdate` with a new key fingerprint — the only piece deferred is the *automation* of pausing the chain across the swap. |
 | Open Q: OCSF version negotiation | Deferred | Comment in `transport/transport.go` `SessionInit` builder. Today we hard-code `ocsf_version = "1.8.0"` matching the spec. |
 | Open Q: sub-second timestamp granularity | Deferred | Comment in `compact/encoder.go` next to the timestamp field. We use uint64 nanoseconds today (already sufficient for nanosecond precision); if the spec lands on a coarser truncation, we'll honour it there. |
@@ -594,11 +753,32 @@ These deferrals do not block this design. Each is a localized future PR.
 
 ## Migration & Rollout
 
-- The sink is **opt-in** via `[stores.watchtower].enabled = true` in the existing config TOML. It defaults to disabled.
+- The sink is **opt-in** via the existing YAML config under `internal/config` (e.g., `audit.watchtower.enabled: true`). It defaults to disabled. The exact YAML schema is added to `internal/config/config.go` as part of this work; see "Prerequisite plumbing" above.
 - When disabled, no goroutines start, no disk space is used, and `composite.others` does not include it.
 - When enabled but Phase 0 has not landed, `validate()` fails fast with a clear message: `"watchtower sink requires composite shared-sequence support (Phase 0); enable when available"`.
-- When enabled but the OCSF mapper is not injected, the sink runs with the stub mapper and logs a single warning at startup.
+- When enabled but the OCSF mapper is not injected, `validate()` ALSO fails fast: `"watchtower sink requires OCSF mapper (Phase 1); enable when available"`. The stub mapper exists strictly for compile-time and unit-test purposes — production deployment requires Phase 1. (This tightens an earlier inconsistency: the stub is no longer a fallback, it's a test fixture.)
 - Operators can verify the sink end-to-end without a live Watchtower by pointing `Endpoint` at the testserver binary that ships in `cmd/wtp-testserver/` (a thin wrapper around `internal/store/watchtower/testserver`). This is also how we recommend running it in development.
+
+## Implementation Phases
+
+This section enumerates ordered milestones with one-line entry/exit criteria, scaffolding the `writing-plans` follow-up. Each phase is independently reviewable and produces a green CI build.
+
+| # | Phase | Entry | Exit |
+|---|---|---|---|
+| 1 | **Phase 0 contract land** | Phase 0 contract doc approved. | `audit.SequenceAllocator` and `audit.SinkChain` exist with full unit tests. `audit.IntegrityChain.Wrap` preserved (existing tests green). `pkg/types.Event.Chain *ChainState` added with `json:"-"` tag. `TestEvent_ChainFieldNotMarshaled` passes. |
+| 2 | **Composite refactor** | Phase 1 done. | `composite.Store` constructs a `SequenceAllocator`, stamps `ev.Chain` before fanout, exposes `NextGeneration()`. Cross-sink `(seq, gen)` convergence test passes. Single-sink installations behave identically (no observable change). |
+| 3 | **Filter + config + metrics plumbing** | Phase 2 done. | `internal/store/eventfilter/` package generalized from OTEL's private filter (OTEL still passes its own tests). `WatchtowerConfig` schema added to `internal/config/config.go` with default-expansion and validation tests. `wtp_*` metrics registered with `internal/metrics.Collector`. |
+| 4 | **Proto + wire goldens** | Phase 3 done. | `proto/canyonroad/wtp/v1/wtp.proto` defined matching spec §7. Generated code committed. `proto/canyonroad/wtp/v1/testdata/*.bin` goldens generated by in-tree `cmd/gen-wire-goldens` and verified to round-trip in CI. |
+| 5 | **Chain helpers** | Phase 4 done. | `internal/store/watchtower/chain/` package: `EncodeCanonical`, `ComputeContextDigest`, `ComputeEventHash`. `chain/testdata/vectors.json` goldens published (cross-implementation conformance suite). All pure unit tests green. |
+| 6 | **Compact encoder + mapper interface** | Phase 5 done. | `compact.Mapper` interface defined. Stub mapper for unit tests only. Per-OCSF-class projection helpers tested against `compact/payload/testdata/*.json`. |
+| 7 | **WAL package** | Phase 6 done. | `internal/store/watchtower/wal/`: segment header, framing, CRC32C, atomic seal, INPROGRESS lifecycle, meta.json, Reader API. **Required tests**: `TestWAL_RolloverAndReplay`, `TestWAL_GenerationBoundaryOrdering`, `TestWAL_CRCFailureEmitsCoarseLossRange`, `TestWAL_OverflowEmitsLossMarker`. |
+| 8 | **Transport state machine** | Phase 7 done. | `internal/store/watchtower/transport/`: Conn interface, Dialer pattern, four-state machine, Batcher with all six invariants, Replayer, Heartbeat. Mock-Conn-driven table tests cover every (state × event) cell. |
+| 9 | **In-tree testserver** | Phase 8 done. | `internal/store/watchtower/testserver/`: bufconn server, scenario hooks (Drop, Goaway, AckDelay, StaleWatermark), `WaitForBatch` / `AssertSequenceRange` / `AssertReplayObserved` helpers. Self-tested. |
+| 10 | **Store integration + transactional Append** | Phase 9 done. | `internal/store/watchtower/store.go` glues compact + chain + wal + transport. Implements `store.EventStore`. **Required tests**: `TestStore_WALCleanFailure_NoChainAdvance`, `TestStore_WALAmbiguousFailure_LatchesFatal`. |
+| 11 | **Component + integration tests** | Phase 10 done. | The five-layer pyramid's component and integration rows pass: `TestStore_DropsMidBatchTriggersReplay`, `TestStore_ServerRestart_AcksCatchUp`, plus the testserver-driven scenario suite. |
+| 12 | **Daemon wiring** | Phase 11 done. | `cmd/agentsh` constructs a WTP `Store` when `audit.watchtower.enabled: true`, passes `WithMapper`, `WithMetrics`, `WithLogger`, `WithChainKey`. Manual end-to-end smoke test against `cmd/wtp-testserver` documented. |
+
+Phases 5/6/7/8 can be parallelized across contributors after Phase 4 (the proto definitions are the only shared dependency). Phases 1/2/3 are strict sequential prerequisites.
 
 ## Risks
 

--- a/docs/superpowers/specs/2026-04-18-wtp-client-design.md
+++ b/docs/superpowers/specs/2026-04-18-wtp-client-design.md
@@ -1,0 +1,804 @@
+# Watchtower Transport Protocol (WTP) Client Design
+
+**Date:** 2026-04-18
+**Status:** Draft
+**Spec:** AgentSH → Watchtower Transport Protocol v0.4.9-draft
+**Scope:** Phase 2 only — client library (no server, no OCSF mapper, no composite refactor)
+**Related:**
+- `docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md` (sequence/generation contract)
+- `docs/superpowers/specs/2026-03-30-wire-hmac-integrity-chain-design.md` (existing chain wiring)
+- `docs/superpowers/specs/2026-04-11-hmac-chain-tamper-evidence-design.md` (sidecar, recovery)
+- `docs/superpowers/specs/2026-04-13-deferred-sync-audit-write-design.md` (deferred-sync model reused for WAL)
+
+## Problem
+
+AgentSH today persists audit events to local sinks: SQLite (queryable, optional), JSONL (durable, append-only), OTEL (export to collector), and webhook (HTTP push). For Watchtower — the agentic-fleet console — we need a fifth sink that ships events over a long-lived gRPC connection with the WTP wire protocol: TLS 1.3, OCSF-aligned `CompactEvent`, HMAC chain with sink-local hashes over a shared sequence, WAL-backed at-least-once delivery, batching, compression, reconnect with replay, and `TransportLoss` markers when the WAL must drop records.
+
+This design covers the **client library only**. The server side, the OCSF schema mapper (Phase 1), and the composite-store sequence refactor (Phase 0) are prerequisites whose contracts are documented but whose implementation is not part of this work.
+
+## Goals
+
+- New sink `internal/store/watchtower/` implementing `store.EventStore`.
+- Faithful implementation of WTP v0.4.9 §6 (integrity), §7 (wire format), §8 (transport), §10 (config).
+- Survives network failures, server restarts, segment loss, and process crashes without corrupting the integrity chain or losing events that were durably accepted.
+- Cross-platform Go build (Linux/macOS/Windows). No CGo dependencies.
+- Testable end-to-end with an in-tree `bufconn`-based test server that simulates drops, GOAWAYs, ack delays, and stale watermarks — no external Watchtower instance required to run the test suite.
+
+## Non-Goals
+
+- Server implementation (Watchtower).
+- OCSF schema mapper (Phase 1) — assumed available via a `Mapper` interface that this client consumes.
+- Composite-store refactor to advance a shared sequence/generation before fanout (Phase 0) — assumed; this client reads the contract via well-known `ev.Fields` keys.
+- Live key rotation while connected (deferred Open Question).
+- mTLS automation / SPIFFE / cert rotation hooks beyond reading static cert/key files (deferred).
+- HTTP/2 fallback transport (deferred).
+- Multi-tenant routing.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| **Scope** | Phase 2 only (client library) | Server is owned by another team; Phase 0 (composite refactor) and Phase 1 (OCSF mapper) are prerequisites. Client can be built and tested in isolation given a contract for both. |
+| **Architecture** | Layered sub-packages under `internal/store/watchtower/` | Each layer has one responsibility (chain, compact, wal, transport) and can be unit-tested without the others. Wire types live in a separate `proto/canyonroad/wtp/v1/` tree to be regeneratable. |
+| **WAL framing** | 4-byte length + 4-byte CRC32C-Castagnoli + protobuf record bytes; 16-byte segment header (WTP1 magic, version, flags, generation) | CRC32C catches segment corruption (truncated tail, bit-flips). Castagnoli has hardware acceleration on x86 and arm64. Length prefix allows streaming reads without protobuf parse. |
+| **Concurrency model** | WAL is the queue; one transport goroutine drives a `select{}` state machine; small recv-goroutine reads ACKs from the gRPC stream | `AppendEvent` never blocks on network — it returns as soon as the WAL fsync completes (or fast path: page cache + background sync, matching `2026-04-13-deferred-sync`). The transport goroutine owns all session/connection state, eliminating lock contention. |
+| **Backpressure** | WAL bounded by `max_total_bytes`; overflow → drop oldest unacked + emit `TransportLoss` marker | Matches spec §8.5. AppendEvent never fails due to a slow server. Loss is observable to the operator and to the server (gap in sequences). |
+| **Testing** | In-tree `testserver` package using `bufconn`; scenario hooks for Drop/Goaway/AckDelay/stale watermark | Hermetic, fast, deterministic. Integration tests against real Watchtower instances are out of scope for this work. |
+| **Open questions** | Defer all three (key rotation pause/resume, OCSF version negotiation, sub-second timestamp granularity) | Spec is explicit they are unresolved. Each gets a code comment marking the integration point so a follow-up PR can wire them in without restructuring. |
+
+## Architecture
+
+### Package layout
+
+```
+internal/store/watchtower/
+  store.go                  // implements store.EventStore; orchestrates the others
+  config.go                 // Config struct, applyDefaults, validate
+  errors.go                 // typed errors (ErrShuttingDown, ErrWALOverflow, …)
+
+  chain/
+    chain.go                // SinkChain (advance hash given shared seq+gen)
+    canonical.go            // IntegrityRecord canonical-JSON encoder (custom, not encoding/json)
+    context.go              // ContextDigest computation per spec §6.4.6
+    testdata/
+      vectors.json          // golden vectors: input record → expected canonical bytes → expected hash
+
+  compact/
+    encoder.go              // events.EventType → wtpv1.EventClass + Activity + payload
+    encoder_test.go         // golden vectors per event type
+    payload/
+      file.go process.go network.go …  // per-class field projection
+      testdata/             // golden JSON projections per OCSF class
+
+  wal/
+    wal.go                  // WAL writer + reader; segment lifecycle
+    segment.go              // header layout, INPROGRESS suffix, atomic seal
+    meta.go                 // meta.json (atomic temp+rename + dir fsync)
+    framing.go              // length+CRC32C+payload; readers verify CRC
+    testdata/               // golden segment bytes for cross-version compat
+
+  transport/
+    transport.go            // Conn interface, gRPC implementation
+    state.go                // state machine: connecting/replaying/live/shutdown
+    batcher.go              // assembles EventBatch under invariants
+    replayer.go             // post-reconnect replay from WAL up to ack watermark
+    heartbeat.go            // periodic Heartbeat send + miss-detection
+    metrics.go              // wtp_* counters/gauges/histograms (slog or expvar)
+
+  testserver/
+    server.go               // bufconn-based in-process WTP server stub
+    scenarios.go            // hooks: Drop, Goaway, AckDelay, StaleWatermark
+    dialer.go               // returns a transport.Dialer wired to bufconn
+    matcher.go              // helpers: WaitForBatch(...), AssertSequenceRange(...)
+
+proto/canyonroad/wtp/v1/
+  wtp.proto                 // service + messages from spec §7
+  wtp.pb.go wtp_grpc.pb.go  // generated
+  testdata/
+    *.bin                   // canonical wire-format goldens for parity with other implementations
+```
+
+### Layer responsibilities
+
+| Package | Responsibility | Touches network? | Touches disk? |
+|---|---|---|---|
+| `watchtower` (root) | Implements `store.EventStore`, owns lifecycle (Start/Close), wires the others together. | No directly | No directly |
+| `chain` | Pure: advance a sink-local entry hash from `(seq, gen, prev_hash, canonical_record)`. Computes context digest. | No | No |
+| `compact` | Pure: project an `events.Event` into a `CompactEvent` (OCSF class + activity + payload). | No | No |
+| `wal` | Append+fsync records, seal+roll segments, replay records on startup, GC after ack. | No | Yes |
+| `transport` | One goroutine state machine: dial, SessionInit, send batches, replay on reconnect, heartbeat. | Yes | No |
+| `testserver` | bufconn stub of the WTP server; scriptable scenarios. | In-process only | No |
+
+The root `store.go` is small (~150 lines): it constructs a `Config`, builds the `chain`, opens the `wal`, starts the `transport`, and forwards `AppendEvent` calls. Everything else is delegated.
+
+## Data Flow
+
+### Steady state — `AppendEvent` (transactional pattern)
+
+```
+caller (composite store)
+  │  composite has already allocated (seq, gen) and stamped ev.Chain
+  │  via the typed pkg/types.Event.Chain *ChainState field (Phase 0).
+  ▼
+watchtower.Store.AppendEvent(ctx, ev)
+  │
+  │ 1. validate: ev.Chain != nil, else ErrMissingChainState
+  │
+  │ 2. compact.Encode(ev) → wtpv1.CompactEvent
+  │
+  │ 3. canonicalize → bytes for hashing
+  │
+  │ 4. SinkChain.Compute(formatVersion, seq, gen, payload)
+  │      → (entryHash, prevHash) — PURE, no chain mutation
+  │
+  │ 5. wal.Append(seq, gen, record_bytes)
+  │      → (a) clean failure: return err, no Commit, chain unchanged
+  │      → (b) ambiguous failure: SinkChain.Fatal(err); return ErrFatalIntegrity
+  │      → (c) success: continue
+  │
+  │ 6. SinkChain.Commit(gen, entryHash) — chain advances
+  │
+  │ 7. transport.Notify() → wake transport goroutine (non-blocking)
+  │
+  └─ return nil
+```
+
+The WTP `AppendEvent` follows the transactional Compute → durable-write → Commit pattern from §"Sink integration" of the Phase 0 contract. Failure modes:
+
+| WAL failure | Action | Chain state | Caller-visible error |
+|---|---|---|---|
+| Clean (e.g., overflow detected before any I/O, validation error) | No Commit. Caller may retry. | Unchanged. | The clean error. |
+| Ambiguous (write returned, fsync returned, partial write possible) | `SinkChain.Fatal(err)`. Subsequent appends return `ErrFatalIntegrity`. | Latched fatal. | The ambiguous error wrapped in `FatalIntegrityError`. |
+| Success | `Commit`. | `prev_hash := entry_hash`, `generation := ev.Chain.Generation`. | nil. |
+
+The `wal.Append` function is the only place that classifies WAL failures into clean vs ambiguous. The classification is documented in §4 below.
+
+### Transport loop (single goroutine)
+
+```
+                ┌─────────────────────────────┐
+                │  state = stateConnecting    │
+                └──────────────┬──────────────┘
+                               │ Dial + SessionInit (wal_high_watermark_seq from disk)
+                               │ server returns ack_high_watermark_seq
+                               ▼
+                ┌─────────────────────────────┐
+   ┌───────────►│  state = stateReplaying     │
+   │            └──────────────┬──────────────┘
+   │                           │ replayer reads wal records (ack_hw, wal_hw], sends them
+   │                           │ in batches; each batch obeys all invariants
+   │                           ▼
+   │            ┌─────────────────────────────┐
+   │   notify   │  state = stateLive          │
+   │   (append) │  - select { wakeup, hb,     │
+   │            │    recv ack, recv goaway,   │
+   │            │    flush timer, ctx done }  │
+   │            └──────┬──────────┬──────┬────┘
+   │      goaway/loss  │          │      │ shutdown
+   │      /timeout     │          │      │ (Close)
+   └───────────────────┘          │      ▼
+                                  │   stateShutdown: drain in-flight, close stream
+                                  │   gracefully, close wal, close conn
+                                  ▼
+                         (back to connecting)
+```
+
+### Generation roll (WAL-driven, not transport-driven)
+
+Generation boundaries are detected and enforced inside `wal.Append`, *before* the record is written. This is the only place that can guarantee "single generation per segment" because the WAL writes records to the segment file before the transport ever sees them.
+
+```
+wal.Append(seq, gen, payload):
+  if gen != currentSegment.generation:
+    seal currentSegment (rename .INPROGRESS → .seg, fsync parent)
+    open new segment with header.generation = gen
+    fsync new segment header
+    enqueue an internal "GENERATION_ROLL" notification record so the
+      transport knows to flush the current batch and emit SessionUpdate
+      before sending the first record of the new generation.
+  write framed record into currentSegment
+  fsync per policy
+```
+
+The transport, on observing the GENERATION_ROLL notification in the WAL stream, performs the protocol-level work (flush current batch, send `SessionUpdate` with new context digest, then begin batching new-generation records). The chain itself resets per-sink: `SinkChain.Compute` automatically uses `prev_hash = ""` when it sees a new generation, and `Commit` records the new generation.
+
+### WAL overflow → TransportLoss
+
+When `wal.Append` would push total disk usage past `max_total_bytes`:
+1. Drop the oldest *unacked* segment(s) until under budget.
+2. Emit a synthetic `TransportLoss{from_seq, to_seq, dropped_count, generation}` record into the WAL.
+3. Increment `wtp_transport_loss_total`.
+4. The marker is sent like any other batch when the transport reaches it; the server learns about the gap via the marker, not via a missing sequence number alone.
+
+CRC-corruption recovery emits `TransportLoss` with a *coarse* range: when a record fails CRC verification on read, we report `TransportLoss{from_seq: last_good_seq + 1, to_seq: segment_max_seq_estimate, generation: segment.generation}`. The estimate is computed as `last_good_seq + (segment_remaining_bytes / typical_record_size)`. This is best-effort but bounded: corruption in practice almost always means a truncated tail, where the gap extends to the segment end. A v2 enhancement (per-record sequence in the frame header, +8 bytes/record) would enable exact gap reporting; deferred until operators report imprecise ranges in practice.
+
+## Phase 0 Contract (consumed, not implemented)
+
+The composite store allocates a shared `(sequence, generation)` *once* via a `audit.SequenceAllocator` and stamps it onto the typed `ev.Chain *types.ChainState` field *before* fanning the event out to sinks. The WTP client reads it via:
+
+```go
+if ev.Chain == nil {
+    return audit.ErrMissingChainState  // composite did not stamp
+}
+seq := ev.Chain.Sequence    // uint64
+gen := ev.Chain.Generation  // uint32
+```
+
+The field is `json:"-"` on `pkg/types.Event` — it cannot leak into JSONL, OTEL, or any other JSON-based serializer. Per-sink hashing is the responsibility of each sink's own `audit.SinkChain` instance, using the shared `(seq, gen)` from `ev.Chain`.
+
+The full contract — `SequenceAllocator` + `SinkChain` types, the transactional Compute/Commit protocol, generation semantics, `TransportLoss` semantics on the shared sequence, and the `types.Event.Chain` field — is documented in `docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md`. That doc is the source of truth; this design depends on it but does not change it.
+
+## Chain Package (`internal/store/watchtower/chain`)
+
+The WTP sink uses `audit.SinkChain` from the Phase 0 contract directly — there is no WTP-specific chain wrapper. This package contains only the helpers `audit.SinkChain` does not provide: canonical-record encoding (the byte-exact format that gets hashed) and the WTP-specific context digest.
+
+### Helpers (not a new chain type)
+
+```go
+package chain
+
+// IntegrityRecord is the WTP-specific structure that gets canonical-encoded
+// and passed as the payload to audit.SinkChain.Compute. The on-the-wire
+// integrity_record JSON object in WTP CompactEvent has these fields.
+type IntegrityRecord struct {
+    FormatVersion  uint32   // = 2 (spec §6.4)
+    Sequence       uint64   // shared, from ev.Chain.Sequence
+    Generation     uint32   // shared, from ev.Chain.Generation
+    PrevHash       string   // sink-local; provided by audit.SinkChain
+    EventHash      string   // sha256(canonical_compact_event_bytes)
+    ContextDigest  string   // bound at SessionInit/Update/rotation
+    KeyFingerprint string
+}
+
+// EncodeCanonical produces the byte-exact JSON encoding mandated by spec §6.4
+// (sorted keys, no insignificant whitespace, ASCII-escaped non-ASCII, decimal
+// numbers). This output is the payload passed to audit.SinkChain.Compute and
+// is the contract surface for cross-implementation parity.
+func EncodeCanonical(rec IntegrityRecord) ([]byte, error)
+
+// ComputeContextDigest returns the SHA-256 of the canonical encoding of the
+// SessionContext fields the spec lists. Bound into every event hash in the
+// session/segment.
+func ComputeContextDigest(ctx SessionContext) string
+
+// ComputeEventHash returns sha256(canonical_compact_event_bytes). Used to
+// populate IntegrityRecord.EventHash before passing the canonical-encoded
+// IntegrityRecord to audit.SinkChain.Compute.
+func ComputeEventHash(canonicalEvent []byte) string
+```
+
+The actual chain mutations (Compute/Commit/Fatal/State/Restore) all live on `audit.SinkChain`; we do not re-implement them. The transactional pattern from §"Steady state" calls into `audit.SinkChain` directly.
+
+### Canonical encoding — non-negotiable byte parity
+
+Spec §6.4 mandates a canonical JSON encoding with sorted keys, no insignificant whitespace, ASCII-escaped non-ASCII, and decimal numbers (no scientific notation). `encoding/json` does *not* guarantee any of these invariants across versions, and a single byte difference breaks every other implementation's verification.
+
+We hand-roll the encoder in `chain/canonical.go`:
+
+```go
+func EncodeCanonical(rec IntegrityRecord) ([]byte, error)
+```
+
+The encoder is exhaustively tested against `chain/testdata/vectors.json`, which is also published as the cross-implementation conformance suite for the spec. Vectors include UTF-8 edge cases (escaped non-ASCII, surrogate pairs), large numbers near uint64 max, and empty strings.
+
+### Context digest (§6.4.6)
+
+```go
+func ComputeContextDigest(ctx SessionContext) string
+```
+
+Computed once on `SessionInit`, again on `SessionUpdate`, and again on chain rotation. Bound into every event hash in that segment. Implemented as SHA-256 of the canonical encoding of the SessionContext fields the spec lists.
+
+### What this package does NOT do
+
+- Advance the shared sequence (composite owns the `audit.SequenceAllocator`).
+- Mutate `prev_hash` (lives on `audit.SinkChain`).
+- Persist any state (root `store.go` reconstructs `audit.SinkChain` from WAL on startup via `Restore`).
+- Talk to the network or to a KMS (the key is passed in already-resolved at construction).
+
+## WAL Package (`internal/store/watchtower/wal`)
+
+### Directory layout
+
+```
+$state_dir/wtp/
+  meta.json                      // atomic temp+rename, fsync(parent)
+  segments/
+    0000000000.seg.INPROGRESS    // currently being written
+    0000000001.seg                // sealed
+    0000000002.seg                // sealed
+    …
+```
+
+### Segment header (16 bytes)
+
+```
+offset  size  field
+0       4     magic     = "WTP1"
+4       2     version   = 1
+6       2     flags     (bit 0: gen_init, others reserved 0)
+8       4     generation
+12      4     reserved
+```
+
+Header is fsync'd at segment creation. A reader rejects segments with unknown magic, unknown version, or non-zero reserved bits.
+
+### Record framing (per record)
+
+```
+offset  size      field
+0       4         length     (uint32 BE; bytes after this field, excluding the CRC and including payload)
+4       4         crc32c     (Castagnoli, computed over payload)
+8       length-4  payload    (protobuf-encoded WAL record; carries seq + gen)
+```
+
+Sequence and generation are encoded inside the protobuf payload (not in the frame header), so a per-record scan after CRC failure can recover them when the record itself parses cleanly. When CRC fails, the record bytes are unsafe to parse — the recovery path below uses the segment header's generation and the last-good record's sequence to bound the lost range.
+
+The CRC is the last line of defense against truncated tails (crash mid-fsync). Reader behaviour on bad CRC: log + emit `TransportLoss` marker with a coarse range (see "CRC corruption recovery" below) + skip to next valid record.
+
+### `Append` — clean vs ambiguous failure classification
+
+`wal.Append` is the only place that decides whether a write failure is recoverable. The classification feeds directly into the WTP `AppendEvent` transactional pattern (clean → no Commit, ambiguous → Fatal).
+
+```go
+func (w *WAL) Append(seq int64, gen uint32, payload []byte) (AppendResult, error)
+
+type AppendResult struct {
+    GenerationRolled bool   // true iff this Append rolled the segment for a new generation
+}
+```
+
+Failure classification:
+
+| Failure source | Classification | Why |
+|---|---|---|
+| `payload` exceeds segment-size budget | Clean | Validated before any I/O. |
+| WAL is in `closed` state | Clean | Validated before any I/O. |
+| `MaxTotalBytes` exceeded after attempting overflow GC | Clean (loss marker emitted instead of returning error) | We drop oldest segments and emit `TransportLoss`. The Append itself succeeds. |
+| `os.Write` returns short write or io error | Ambiguous | Bytes may have hit the filesystem buffer or the platter. |
+| `f.Sync()` returns error | Ambiguous | Sync may have partially flushed. |
+| Segment-roll rename fails after seal | Ambiguous | Old segment may or may not have been removed; new segment may or may not exist. |
+| `meta.json` atomic-rename fails on watermark update (on Ack path, not Append) | Ambiguous | meta.json may be in either old or new state. |
+
+A clean failure leaves the WAL in a consistent state: the partial frame (if any) is truncated back to the last good byte, the segment file's logical size is restored, and `Append` returns the error. The caller (WTP `AppendEvent`) does NOT call `SinkChain.Commit`, so the chain stays at the previous `prev_hash` and the next event hashes against the same prev_hash. If the caller retries with a new event allocation, the `(seq, gen)` differs but `prev_hash` is unchanged — which is correct, because the failed event was never durably persisted.
+
+An ambiguous failure latches the WAL in `degraded` state. Any subsequent `Append` returns `ErrFatalIntegrity` immediately. The WTP `AppendEvent` calls `SinkChain.Fatal(err)` and returns. The composite store's `onAppendError` hook is invoked and the daemon decides whether to halt the agent (default) or continue with the WTP sink disabled (operator opt-in).
+
+### Generation roll happens INSIDE Append
+
+`Append` detects generation transitions and seals/rolls segments before writing the new record. This is the only place that can guarantee "single generation per segment" because the WAL writes records before the transport ever sees them.
+
+```
+Append(seq, gen, payload):
+  if gen != currentSegment.generation:
+    seal currentSegment:
+      truncate to actual length
+      fsync segment file
+      rename .INPROGRESS → .seg
+      fsync(segments/)
+    open new segment with header.generation = gen
+    fsync new segment header
+    fsync(segments/)
+    set AppendResult.GenerationRolled = true
+  write framed record into currentSegment
+  fsync per policy
+  return AppendResult, nil
+```
+
+When `AppendResult.GenerationRolled == true`, the WTP `AppendEvent` notifies the transport to flush its current batch and emit a `SessionUpdate` with the new context digest before the new-generation batch begins. The chain itself rolls inside `audit.SinkChain.Compute` (it sees the new generation and uses `prev_hash = ""`).
+
+### Lifecycle
+
+| Event | Action |
+|---|---|
+| Open | Scan `segments/`. Last `*.INPROGRESS` is the live segment; reopen for append. Replay all records, verifying CRCs and rebuilding `audit.SinkChain.prev_hash`. |
+| Append | Detect generation change → seal/roll if needed. Write framed record. Fsync per policy (immediate, or deferred per `2026-04-13-deferred-sync`). |
+| Segment full | Truncate to actual length, fsync, rename `.INPROGRESS` → `.seg`, open new `.INPROGRESS`. |
+| Generation change | Detected inside Append (see above). |
+| `SessionUpdate` write | Force fsync of live segment + meta.json. |
+| `TransportLoss` write | Force fsync (operator visibility into loss must be durable). |
+| Ack received | Update `meta.json` with new `ack_high_watermark`. GC fully-acked segments via `os.Remove` after fsync(parent). |
+| Close | Fsync live segment, leave `.INPROGRESS` suffix in place (will be reopened on restart). |
+
+### CRC corruption recovery
+
+When a record fails CRC verification on read:
+
+1. Log the corruption with segment file, offset, expected/actual CRC.
+2. Compute coarse range: `from_seq = last_good_seq + 1`, `to_seq = last_good_seq + max(1, segment_remaining_bytes / typical_record_size)`. The estimate uses the segment's average record size from records read so far.
+3. Emit `TransportLoss{from_seq, to_seq, generation: segment.generation, reason: "crc_corruption"}` into the WAL stream.
+4. Increment `wtp_wal_corruption_total`.
+5. Skip to the next segment (we do not attempt to scan-and-resync within a corrupted segment; the most common cause is a truncated tail, which extends to the segment end by definition).
+
+This is best-effort. A v2 enhancement (per-record sequence in the frame header, +8 bytes/record overhead) would enable exact gap reporting and is deferred until operators report imprecise ranges in practice. Documented in §8.
+
+### meta.json schema
+
+```json
+{
+  "format_version": 1,
+  "ack_high_watermark_seq": 12345,
+  "ack_high_watermark_gen": 7,
+  "session_id": "01J...ulid",
+  "key_fingerprint": "sha256:abcd…"
+}
+```
+
+Atomically written via `os.WriteFile` on a temp + `os.Rename` + `fsync(parent)` using the existing `internal/audit/fsync_dir_unix.go` and `fsync_dir_windows.go` helpers. The session ID is included so a stale meta.json from a previous installation cannot be silently consumed.
+
+### Reader API
+
+```go
+type Reader struct { /* private */ }
+
+func (w *WAL) NewReader(start uint64) (*Reader, error)
+func (r *Reader) Notify() <-chan struct{}    // signaled when new records appended
+func (r *Reader) Next() (Record, error)      // io.EOF when caught up
+func (r *Reader) Close() error
+
+func (w *WAL) MarkAcked(seq uint64) error    // GC fully-acked segments
+```
+
+The transport goroutine consumes via the reader; it does not poll. Notifications coalesce naturally — one wakeup may correspond to many appended records. The reader surfaces `TransportLoss` and generation-roll markers as ordinary records (with a typed kind field) so the transport state machine handles them in the same select branch as data records.
+
+## Transport Package (`internal/store/watchtower/transport`)
+
+### Conn interface and Dialer pattern
+
+```go
+type Conn interface {
+    Send(ctx context.Context, msg *wtpv1.ClientMessage) error
+    Recv(ctx context.Context) (*wtpv1.ServerMessage, error)
+    CloseSend() error
+    Close() error
+}
+
+type Dialer interface {
+    Dial(ctx context.Context) (Conn, error)
+}
+```
+
+Production: `GRPCDialer` wraps `grpc.NewClient` with TLS 1.3 credentials, ALPN `wtp/1`, configured timeouts, and the bidi stream `Watchtower/Stream`. Tests: `testserver.NewDialer()` returns a `Dialer` backed by `bufconn` and a scenario script.
+
+The transport package never references `grpc-go` types in its own API surface, so tests don't need a real network listener.
+
+### State machine (single goroutine)
+
+```go
+type state int
+
+const (
+    stateConnecting state = iota
+    stateReplaying
+    stateLive
+    stateShutdown
+)
+```
+
+The goroutine runs `for { select { … } }`. The set of events depends on state:
+
+| State | select branches |
+|---|---|
+| `stateConnecting` | `dialResult`, `ctx.Done()` |
+| `stateReplaying`  | `replayDone`, `replayBatchSent`, `recv`, `ctx.Done()` |
+| `stateLive`       | `walReader.Notify()`, `flushTimer.C`, `heartbeatTimer.C`, `recv`, `ctx.Done()` |
+| `stateShutdown`   | `drainDone`, `gracefulCloseTimeout`, `ctx.Done()` |
+
+`recv` is fed by a small companion goroutine that calls `Conn.Recv` in a loop; this is the only other goroutine in the package. It exits when the stream closes.
+
+### Batcher invariants (per spec §7)
+
+A `Batcher` accumulates `CompactEvent`s and flushes when **any** of the following triggers:
+
+- Generation change: next event's generation differs from current batch.
+- Time span: oldest event in batch is older than `max_event_timespan` (default 5s).
+- Event count: `>= max_events_per_batch` (default 256).
+- Byte budget (post-compression): estimated `>= max_batch_bytes` (default 256 KiB).
+- Flush timer: `flush_interval` elapsed (default 1s; 200ms in ephemeral mode).
+- Generation rollover (sequence wrap): forces a fresh batch.
+
+Each invariant is enforced by a single function (`Batcher.Add` returns `(addedToBatch, shouldFlush)`); making the Batcher entirely table-test-driven.
+
+### Replayer
+
+On `stateReplaying`:
+
+```go
+for seq := ackHighWatermark + 1; seq <= walHighWatermark; seq++ {
+    rec := walReader.Next()
+    batcher.Add(rec)
+    if batcher.ShouldFlush() {
+        send(batcher.Drain())
+        if err { goto reconnect }
+    }
+}
+sendFinalBatchIfAny()
+state = stateLive
+```
+
+Replay batches obey the same invariants as live batches; the only difference is the source of records. The server may legitimately return a stale (lower) ack watermark during gradual rollout or partition recovery; the replayer trusts the lower of `(server_returned_hw, local_ack_hw)` so we re-send unacked records rather than dropping the gap. A higher-than-local server watermark is anomalous and is logged + ignored — we replay from `local_ack_hw + 1`.
+
+### Heartbeat
+
+A `heartbeatTimer` ticks at `heartbeat_interval` (default 30s; 10s in ephemeral mode). On tick: send `Heartbeat`. If two consecutive heartbeats elapse with no inbound message (ack or ServerHeartbeat), set `state = stateConnecting` (reconnect with backoff).
+
+### Backoff
+
+Exponential with jitter: `min(base * 2^n, max) ± 30%`. Defaults: base=500ms, max=30s. Reset on successful SessionInit + first ack received.
+
+### Metrics
+
+All exposed via slog at debug + as structured counters consumable by the existing `internal/metrics` registry:
+
+- `wtp_events_appended_total` (counter)
+- `wtp_events_acked_total` (counter)
+- `wtp_batches_sent_total` (counter)
+- `wtp_bytes_sent_total` (counter, post-compression)
+- `wtp_transport_loss_total` (counter)
+- `wtp_reconnects_total` (counter, labeled by reason)
+- `wtp_session_state` (gauge: 0=connecting, 1=replaying, 2=live, 3=shutdown)
+- `wtp_wal_segments` (gauge)
+- `wtp_wal_bytes` (gauge)
+- `wtp_ack_high_watermark` (gauge)
+- `wtp_dropped_missing_chain_total` (counter; increments when `ev.Chain == nil`)
+- `wtp_send_latency_seconds` (histogram, per batch)
+
+## Configuration & Wiring
+
+### Config struct
+
+Mirrors spec §10.2 verbatim. Loaded by the existing `internal/config` package alongside other sink configs.
+
+```go
+type Config struct {
+    Enabled bool
+
+    Endpoint   string            // host:port
+    SessionID  string            // optional; auto-generated ULID if empty
+    StateDir   string            // default: $XDG_STATE_HOME/agentsh/wtp
+    EphemeralMode bool
+
+    TLS struct {
+        InsecureSkipVerify bool   // tests/dev only
+        CACertFile         string
+        ClientCertFile     string
+        ClientKeyFile      string
+    }
+
+    Auth struct {
+        TokenFile      string    // mutually exclusive with the others
+        TokenEnv       string
+        ClientCertAuth bool      // use mTLS cert as identity; no bearer
+    }
+
+    Chain struct {
+        Algorithm string  // hmac-sha256 | hmac-sha512 (default sha256)
+        KeyFile   string  // resolved via existing internal/audit/kms LoadKey
+        KeyEnv    string
+        // KMS sources (AWS, Azure, Vault, GCP) reuse internal/audit/kms
+        // config blocks; we share that struct rather than re-declare it.
+        // Each sink may use a different key (per Phase 0 contract); only the
+        // shared (sequence, generation) is required to match across sinks.
+    }
+
+    Batch struct {
+        MaxEvents       int           // default 256; ephemeral 64
+        MaxBytes        int           // default 256 KiB; ephemeral 64 KiB
+        MaxTimespan     time.Duration // default 5s; ephemeral 1s
+        FlushInterval   time.Duration // default 1s; ephemeral 200ms
+        Compression     string        // "zstd" (default) | "gzip" | "none"
+        ZstdLevel       int           // default 3
+    }
+
+    WAL struct {
+        SegmentSize    int64         // default 16 MiB; ephemeral 4 MiB
+        MaxTotalBytes  int64         // default 1 GiB; ephemeral 64 MiB
+        SyncMode       string        // "immediate" (default) | "deferred"
+        SyncInterval   time.Duration // for deferred; default 100ms
+    }
+
+    Heartbeat struct {
+        Interval        time.Duration // default 30s; ephemeral 10s
+        ReconnectAfterMisses int      // default 2
+    }
+
+    Backoff struct {
+        Base time.Duration // default 500ms
+        Max  time.Duration // default 30s
+    }
+
+    Filter wtpfilter.Filter   // see "Filter generalization" below — currently
+                              // OTEL has its own private filter type; we
+                              // generalize it into a shared package as part
+                              // of this work.
+}
+```
+
+### applyDefaults() and validate()
+
+`applyDefaults()` checks `EphemeralMode` and overrides any zero-valued fields with the ephemeral profile *before* falling back to the standard defaults. `validate()` enforces:
+
+- Exactly one of `Auth.TokenFile`, `Auth.TokenEnv`, `Auth.ClientCertAuth` is set (strict mutual exclusion; configuration ambiguity is a fail-closed error).
+- `Endpoint` parses as `host:port`.
+- TLS files exist and are readable (early failure beats first-batch failure).
+- `StateDir` is writeable.
+- `Batch.MaxBytes >= 4 KiB` (avoid pathological tiny batches).
+- `WAL.SegmentSize <= WAL.MaxTotalBytes / 2` (need room for at least 2 segments).
+
+### Constructor
+
+```go
+func New(ctx context.Context, cfg Config, opts ...Option) (*Store, error)
+
+type Option func(*options)
+
+func WithMapper(m compact.Mapper) Option        // injected from Phase 1
+func WithDialer(d transport.Dialer) Option      // injected by tests
+func WithMetrics(c *metrics.Collector) Option   // injected by host (internal/metrics.Collector)
+func WithLogger(l *slog.Logger) Option          // injected by host
+func WithChainKey(key []byte, fp string) Option // injected by composite (Phase 0)
+```
+
+The host (the agentsh daemon) is responsible for building the `Store` with the right options. In tests we pass `WithDialer(testserver.NewDialer(...))` and skip TLS entirely.
+
+### Wiring into existing composite
+
+`internal/store/composite/composite.go` already has a `New(primary, output, others...)` constructor. The WTP store is added as another `EventStore` in `others`. The Phase 0 refactor adds a `audit.SequenceAllocator` to composite and stamps `ev.Chain` before fanout (separate doc); this client consumes `ev.Chain` directly.
+
+### Prerequisite plumbing (in-scope for this work)
+
+These three pieces of plumbing don't exist in the codebase today and must land alongside the WTP sink. Each is small but explicit so reviewers know it's not assumed:
+
+1. **Filter generalization.** `internal/store/otel/otel.go` has a private `Filter` type. We move it into a shared package `internal/store/eventfilter/` (or similar; final name in the implementation plan), update OTEL to consume the shared type, and use it from WTP. Backwards-compatible YAML; no behavior change for OTEL.
+2. **YAML config schema.** Add `WatchtowerConfig` under `internal/config/config.go` mirroring §6 above. Wire into the existing `AuditConfig` (or its peer) so the daemon constructs a WTP `Store` when `enabled: true`. Add `config_test.go` cases for default expansion (ephemeral overrides, mutual-exclusion validation).
+3. **Metrics wiring.** `internal/metrics.Collector` exposes a counter/gauge registry. Add the `wtp_*` series listed under "Metrics" above as fields on a `metrics.Collector` extension or a sibling collector. The host (the daemon `cmd/agentsh`) registers them at startup and passes the collector via `WithMetrics`.
+
+None of these three blocks the WTP package's own unit tests — they only matter at host-wiring time. Each shows up as a discrete milestone in §"Implementation Phases" below.
+
+## Testing Strategy
+
+### Five-layer pyramid
+
+| Layer | What | Tooling | Example |
+|---|---|---|---|
+| Unit (pure) | `chain/canonical.go`, `chain/context.go`, `compact/encoder.go`, `transport/batcher.go`, `wal/framing.go` CRC paths | Go test + golden files | `TestCanonicalEncoder_Goldens` |
+| Unit (I/O) | `wal.WAL` lifecycle on a real FS (tempdir) | Go test + `t.TempDir()` | `TestWAL_RolloverAndReplay` |
+| Unit (state machine) | `transport.state` transitions | Mock `Conn` + table tests | `TestState_GoawayTriggersReconnect` |
+| Component | Whole `Store` against `testserver` | bufconn | `TestStore_DropsMidBatchTriggersReplay` |
+| Integration | Long-running flow: append, kill server, restart, expect ack catch-up | bufconn with restartable scenario | `TestStore_ServerRestart_AcksCatchUp` |
+
+### High-risk integrity tests (first-class, gated before component layer)
+
+These four cases are explicit milestones — they cover the failure modes most likely to corrupt the audit chain or leak metadata, and they must pass before the component-layer tests run.
+
+| Test | Asserts | Where it lives |
+|---|---|---|
+| `TestStore_WALCleanFailure_NoChainAdvance` | A clean `wal.Append` failure (e.g., overflow detected pre-I/O) returns the error to the caller AND `audit.SinkChain.State().PrevHash` is unchanged. The next successful append uses the same `prev_hash` as before the failure. | `internal/store/watchtower/store_failure_test.go` |
+| `TestStore_WALAmbiguousFailure_LatchesFatal` | An ambiguous `wal.Append` failure (injected via a fake file with a flaky `Write`) calls `audit.SinkChain.Fatal`. Subsequent `AppendEvent` calls return `audit.ErrFatalIntegrity` without writing to the WAL. The composite `onAppendError` hook receives a `FatalIntegrityError`. | `internal/store/watchtower/store_failure_test.go` |
+| `TestEvent_ChainFieldNotMarshaled` | After composite stamps `ev.Chain`, marshaling `ev` to JSON via the JSONL store, the OTEL converter, and `encoding/json.Marshal` directly, the output contains no `chain`, `Chain`, `_integrity_*`, or `sequence` keys at the top level. Catches accidental tag changes on `pkg/types.Event`. | `pkg/types/events_chain_test.go` (Phase 0) + `internal/store/jsonl/jsonl_chain_test.go` |
+| `TestWAL_GenerationBoundaryOrdering` | Appending events `(seq=0..N, gen=7)` then `(seq=0..M, gen=8)` produces exactly two segments: one with header.generation=7 containing only gen-7 records, one with header.generation=8 containing only gen-8 records. The `AppendResult.GenerationRolled` flag is set on the boundary record. | `internal/store/watchtower/wal/wal_generation_test.go` |
+
+These four tests are required before any of the five-layer pyramid component/integration tests are accepted. They directly verify the contract changes from roborev findings #2, #3, and #4.
+
+### `AppendEvent` context semantics
+
+`AppendEvent` does NOT honor `ctx.Done()` for the WAL write step. The audit-durability invariant is that any event the caller passed to `AppendEvent` either lands in the WAL or returns an error — a partially-cancelled write would corrupt this invariant. Specifically:
+
+- `compact.Encode`, `chain.EncodeCanonical`, `audit.SinkChain.Compute`: pure CPU, no ctx check.
+- `wal.Append`: ignores ctx cancellation. The WAL write completes (or fails cleanly/ambiguously) before `AppendEvent` returns.
+- `transport.Notify()`: non-blocking channel send; no ctx involvement.
+
+The transport goroutine's outbound gRPC sends DO honor ctx cancellation — they're invisible to the `AppendEvent` caller and respect the connection's context for clean shutdown.
+
+This is documented in the package doc-comment on `Store.AppendEvent` so callers don't expect cancellation semantics.
+
+### `QueryEvents`
+
+WTP is a fire-and-forget transport sink. `QueryEvents` returns `(nil, ErrNotSupported)` matching the pattern in `internal/store/otel/otel.go:138` (`"otel store does not support queries"`). The composite store routes queries to its `primary` (SQLite) and never to `others`, so this never fires in practice.
+
+### `testserver` capabilities
+
+```go
+ts := testserver.New(t,
+    testserver.AckImmediately(),
+    testserver.Drop(after: 3, then: testserver.Resume()),
+    testserver.Goaway(after: 5*time.Second, code: "DRAINING"),
+    testserver.AckDelay(500 * time.Millisecond),
+    testserver.StaleWatermark(returnSeq: 100),
+)
+defer ts.Close()
+
+dialer := ts.NewDialer()
+store, _ := watchtower.New(ctx, cfg, watchtower.WithDialer(dialer))
+
+// drive the store
+for i := 0; i < 10; i++ { store.AppendEvent(ctx, ev) }
+
+// assertions
+ts.WaitForBatch(t, 5 * time.Second)
+ts.AssertSequenceRange(t, 1, 10)
+ts.AssertReplayObserved(t)
+```
+
+The testserver also exposes a `Recorded()` accessor returning all batches it has received in order, so tests can assert against the full conversation, not just final state.
+
+### Golden vectors — published in two locations
+
+1. `internal/store/watchtower/chain/testdata/vectors.json` — IntegrityRecord canonical-encoding vectors. These are also published in `docs/spec/wtp/conformance/` for cross-implementation use.
+2. `proto/canyonroad/wtp/v1/testdata/*.bin` — wire-format goldens (CompactEvent, EventBatch, SessionInit). Generated by a small `go run ./internal/store/watchtower/cmd/gen-wire-goldens` tool that we ship in-tree but do not run in CI; CI only verifies that the existing goldens parse + round-trip cleanly.
+
+A test failure on a golden is a load-bearing alarm: the canonical encoding has changed and is now incompatible with every other implementation. The golden test message says exactly this.
+
+### Cross-platform considerations (per AGENTS.md)
+
+- Use `filepath.Join` everywhere. No string concatenation of paths.
+- WAL `*.INPROGRESS` rename uses `os.Rename`, which on Windows requires the target not to exist (handled by always renaming a new file into a fresh sealed name).
+- `fsync(parent)` calls go through the existing `internal/audit/fsync_dir_{unix,windows}.go` helpers (Windows is a no-op there, which the existing audit chain already accepts).
+- bufconn-based tests are cross-platform with no extra effort.
+- We do *not* exec anything. No /tmp paths anywhere.
+
+## Deferrals and Open Questions
+
+| Item | Status | Where it shows up in the code |
+|---|---|---|
+| Phase 0: composite shared sequence | Prerequisite | `docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md` is the contract doc; `watchtower.Store.AppendEvent` reads the typed `ev.Chain *types.ChainState` field. |
+| Phase 1: OCSF mapper | Prerequisite (hard) | `compact.Mapper` interface; production implementation lives in a different package. The WTP client's `compact/encoder.go` ships a stub `defaultMapper` for unit tests only — production deployment requires `WithMapper(...)` from Phase 1, enforced by `validate()`. |
+| Open Q: live key rotation pause/resume | Deferred | Comment in `transport/state.go` at the spot where a `KeyRotation` server message would be handled. The WTP client tolerates session-level `SessionUpdate` (the rotation envelope), so the rotation can be performed by issuing a `SessionUpdate` with a new key fingerprint — the only piece deferred is the *automation* of pausing the chain across the swap. |
+| Open Q: OCSF version negotiation | Deferred | Comment in `transport/transport.go` `SessionInit` builder. Today we hard-code `ocsf_version = "1.8.0"` matching the spec. |
+| Open Q: sub-second timestamp granularity | Deferred | Comment in `compact/encoder.go` next to the timestamp field. We use uint64 nanoseconds today (already sufficient for nanosecond precision); if the spec lands on a coarser truncation, we'll honour it there. |
+| Spec ambiguity #1: loss-only batch sequence range | Flagged for v0.4.10 | Code TODO in `transport/batcher.go` near the `TransportLoss` flush path. We currently emit `from_seq..to_seq` as the missing range and leave the batch's own `sequence_range` covering only the marker record. |
+| Spec ambiguity #2: definition of `total_chained` | Flagged for v0.4.10 | Code TODO in `chain/chain.go` next to the SessionInit-building helper. We currently treat it as the count of records the *sink* has chained since installation. |
+
+These deferrals do not block this design. Each is a localized future PR.
+
+## Migration & Rollout
+
+- The sink is **opt-in** via the existing YAML config under `internal/config` (e.g., `audit.watchtower.enabled: true`). It defaults to disabled. The exact YAML schema is added to `internal/config/config.go` as part of this work; see "Prerequisite plumbing" above.
+- When disabled, no goroutines start, no disk space is used, and `composite.others` does not include it.
+- When enabled but Phase 0 has not landed, `validate()` fails fast with a clear message: `"watchtower sink requires composite shared-sequence support (Phase 0); enable when available"`.
+- When enabled but the OCSF mapper is not injected, `validate()` ALSO fails fast: `"watchtower sink requires OCSF mapper (Phase 1); enable when available"`. The stub mapper exists strictly for compile-time and unit-test purposes — production deployment requires Phase 1. (This tightens an earlier inconsistency: the stub is no longer a fallback, it's a test fixture.)
+- Operators can verify the sink end-to-end without a live Watchtower by pointing `Endpoint` at the testserver binary that ships in `cmd/wtp-testserver/` (a thin wrapper around `internal/store/watchtower/testserver`). This is also how we recommend running it in development.
+
+## Implementation Phases
+
+This section enumerates ordered milestones with one-line entry/exit criteria, scaffolding the `writing-plans` follow-up. Each phase is independently reviewable and produces a green CI build.
+
+| # | Phase | Entry | Exit |
+|---|---|---|---|
+| 1 | **Phase 0 contract land** | Phase 0 contract doc approved. | `audit.SequenceAllocator` and `audit.SinkChain` exist with full unit tests. `audit.IntegrityChain.Wrap` preserved (existing tests green). `pkg/types.Event.Chain *ChainState` added with `json:"-"` tag. `TestEvent_ChainFieldNotMarshaled` passes. |
+| 2 | **Composite refactor** | Phase 1 done. | `composite.Store` constructs a `SequenceAllocator`, stamps `ev.Chain` before fanout, exposes `NextGeneration()`. Cross-sink `(seq, gen)` convergence test passes. Single-sink installations behave identically (no observable change). |
+| 3 | **Filter + config + metrics plumbing** | Phase 2 done. | `internal/store/eventfilter/` package generalized from OTEL's private filter (OTEL still passes its own tests). `WatchtowerConfig` schema added to `internal/config/config.go` with default-expansion and validation tests. `wtp_*` metrics registered with `internal/metrics.Collector`. |
+| 4 | **Proto + wire goldens** | Phase 3 done. | `proto/canyonroad/wtp/v1/wtp.proto` defined matching spec §7. Generated code committed. `proto/canyonroad/wtp/v1/testdata/*.bin` goldens generated by in-tree `cmd/gen-wire-goldens` and verified to round-trip in CI. |
+| 5 | **Chain helpers** | Phase 4 done. | `internal/store/watchtower/chain/` package: `EncodeCanonical`, `ComputeContextDigest`, `ComputeEventHash`. `chain/testdata/vectors.json` goldens published (cross-implementation conformance suite). All pure unit tests green. |
+| 6 | **Compact encoder + mapper interface** | Phase 5 done. | `compact.Mapper` interface defined. Stub mapper for unit tests only. Per-OCSF-class projection helpers tested against `compact/payload/testdata/*.json`. |
+| 7 | **WAL package** | Phase 6 done. | `internal/store/watchtower/wal/`: segment header, framing, CRC32C, atomic seal, INPROGRESS lifecycle, meta.json, Reader API. **Required tests**: `TestWAL_RolloverAndReplay`, `TestWAL_GenerationBoundaryOrdering`, `TestWAL_CRCFailureEmitsCoarseLossRange`, `TestWAL_OverflowEmitsLossMarker`. |
+| 8 | **Transport state machine** | Phase 7 done. | `internal/store/watchtower/transport/`: Conn interface, Dialer pattern, four-state machine, Batcher with all six invariants, Replayer, Heartbeat. Mock-Conn-driven table tests cover every (state × event) cell. |
+| 9 | **In-tree testserver** | Phase 8 done. | `internal/store/watchtower/testserver/`: bufconn server, scenario hooks (Drop, Goaway, AckDelay, StaleWatermark), `WaitForBatch` / `AssertSequenceRange` / `AssertReplayObserved` helpers. Self-tested. |
+| 10 | **Store integration + transactional Append** | Phase 9 done. | `internal/store/watchtower/store.go` glues compact + chain + wal + transport. Implements `store.EventStore`. **Required tests**: `TestStore_WALCleanFailure_NoChainAdvance`, `TestStore_WALAmbiguousFailure_LatchesFatal`. |
+| 11 | **Component + integration tests** | Phase 10 done. | The five-layer pyramid's component and integration rows pass: `TestStore_DropsMidBatchTriggersReplay`, `TestStore_ServerRestart_AcksCatchUp`, plus the testserver-driven scenario suite. |
+| 12 | **Daemon wiring** | Phase 11 done. | `cmd/agentsh` constructs a WTP `Store` when `audit.watchtower.enabled: true`, passes `WithMapper`, `WithMetrics`, `WithLogger`, `WithChainKey`. Manual end-to-end smoke test against `cmd/wtp-testserver` documented. |
+
+Phases 5/6/7/8 can be parallelized across contributors after Phase 4 (the proto definitions are the only shared dependency). Phases 1/2/3 are strict sequential prerequisites.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Canonical encoding drift breaks every other implementation. | Golden vectors are mandatory for every change to `chain/canonical.go`. Vectors are also published as the conformance suite. |
+| WAL grows unbounded if server is offline forever. | `max_total_bytes` is hard-capped; oldest unacked drops with `TransportLoss`. Marker is fsynced before the drop is reported as complete. |
+| State-machine bugs deadlock the transport goroutine. | All select branches have a `ctx.Done()` arm. Heartbeat miss timer is independent of inbound traffic. State machine has full table-test coverage of every (state × event) cell. |
+| Fsync cost on the hot path regresses end-to-end latency (cf. `2026-04-13-deferred-sync`). | Default WAL sync mode is `immediate`, but we expose `deferred` with the same 100ms tick used for the existing JSONL/sidecar path. Operators with the same constraints can opt in. |
+| gRPC connection establishment blocks startup. | Dial happens in a background goroutine; `New` returns immediately. The first `AppendEvent` does not wait for connection — the WAL absorbs records until the transport catches up. |
+| Cross-platform regressions in WAL atomic-rename or dir-fsync. | The same helpers as the existing JSONL/integrity sidecar; they are already in production on all three OSes. |
+
+## Out-of-Scope (Explicit)
+
+- Server implementation (Watchtower).
+- Phase 0 composite refactor (separate doc).
+- Phase 1 OCSF mapper (separate work).
+- Live key rotation automation.
+- mTLS automation, SPIFFE, cert rotation.
+- HTTP/2 fallback.
+- Multi-tenant routing.
+- Querying acked events back from the server (one-way only).
+- Backfill from existing JSONL/SQLite stores into WTP.

--- a/docs/superpowers/specs/2026-04-18-wtp-client-design.md
+++ b/docs/superpowers/specs/2026-04-18-wtp-client-design.md
@@ -1,0 +1,624 @@
+# Watchtower Transport Protocol (WTP) Client Design
+
+**Date:** 2026-04-18
+**Status:** Draft
+**Spec:** AgentSH → Watchtower Transport Protocol v0.4.9-draft
+**Scope:** Phase 2 only — client library (no server, no OCSF mapper, no composite refactor)
+**Related:**
+- `docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md` (sequence/generation contract)
+- `docs/superpowers/specs/2026-03-30-wire-hmac-integrity-chain-design.md` (existing chain wiring)
+- `docs/superpowers/specs/2026-04-11-hmac-chain-tamper-evidence-design.md` (sidecar, recovery)
+- `docs/superpowers/specs/2026-04-13-deferred-sync-audit-write-design.md` (deferred-sync model reused for WAL)
+
+## Problem
+
+AgentSH today persists audit events to local sinks: SQLite (queryable, optional), JSONL (durable, append-only), OTEL (export to collector), and webhook (HTTP push). For Watchtower — the agentic-fleet console — we need a fifth sink that ships events over a long-lived gRPC connection with the WTP wire protocol: TLS 1.3, OCSF-aligned `CompactEvent`, HMAC chain with sink-local hashes over a shared sequence, WAL-backed at-least-once delivery, batching, compression, reconnect with replay, and `TransportLoss` markers when the WAL must drop records.
+
+This design covers the **client library only**. The server side, the OCSF schema mapper (Phase 1), and the composite-store sequence refactor (Phase 0) are prerequisites whose contracts are documented but whose implementation is not part of this work.
+
+## Goals
+
+- New sink `internal/store/watchtower/` implementing `store.EventStore`.
+- Faithful implementation of WTP v0.4.9 §6 (integrity), §7 (wire format), §8 (transport), §10 (config).
+- Survives network failures, server restarts, segment loss, and process crashes without corrupting the integrity chain or losing events that were durably accepted.
+- Cross-platform Go build (Linux/macOS/Windows). No CGo dependencies.
+- Testable end-to-end with an in-tree `bufconn`-based test server that simulates drops, GOAWAYs, ack delays, and stale watermarks — no external Watchtower instance required to run the test suite.
+
+## Non-Goals
+
+- Server implementation (Watchtower).
+- OCSF schema mapper (Phase 1) — assumed available via a `Mapper` interface that this client consumes.
+- Composite-store refactor to advance a shared sequence/generation before fanout (Phase 0) — assumed; this client reads the contract via well-known `ev.Fields` keys.
+- Live key rotation while connected (deferred Open Question).
+- mTLS automation / SPIFFE / cert rotation hooks beyond reading static cert/key files (deferred).
+- HTTP/2 fallback transport (deferred).
+- Multi-tenant routing.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| **Scope** | Phase 2 only (client library) | Server is owned by another team; Phase 0 (composite refactor) and Phase 1 (OCSF mapper) are prerequisites. Client can be built and tested in isolation given a contract for both. |
+| **Architecture** | Layered sub-packages under `internal/store/watchtower/` | Each layer has one responsibility (chain, compact, wal, transport) and can be unit-tested without the others. Wire types live in a separate `proto/canyonroad/wtp/v1/` tree to be regeneratable. |
+| **WAL framing** | 4-byte length + 4-byte CRC32C-Castagnoli + protobuf record bytes; 16-byte segment header (WTP1 magic, version, flags, generation) | CRC32C catches segment corruption (truncated tail, bit-flips). Castagnoli has hardware acceleration on x86 and arm64. Length prefix allows streaming reads without protobuf parse. |
+| **Concurrency model** | WAL is the queue; one transport goroutine drives a `select{}` state machine; small recv-goroutine reads ACKs from the gRPC stream | `AppendEvent` never blocks on network — it returns as soon as the WAL fsync completes (or fast path: page cache + background sync, matching `2026-04-13-deferred-sync`). The transport goroutine owns all session/connection state, eliminating lock contention. |
+| **Backpressure** | WAL bounded by `max_total_bytes`; overflow → drop oldest unacked + emit `TransportLoss` marker | Matches spec §8.5. AppendEvent never fails due to a slow server. Loss is observable to the operator and to the server (gap in sequences). |
+| **Testing** | In-tree `testserver` package using `bufconn`; scenario hooks for Drop/Goaway/AckDelay/stale watermark | Hermetic, fast, deterministic. Integration tests against real Watchtower instances are out of scope for this work. |
+| **Open questions** | Defer all three (key rotation pause/resume, OCSF version negotiation, sub-second timestamp granularity) | Spec is explicit they are unresolved. Each gets a code comment marking the integration point so a follow-up PR can wire them in without restructuring. |
+
+## Architecture
+
+### Package layout
+
+```
+internal/store/watchtower/
+  store.go                  // implements store.EventStore; orchestrates the others
+  config.go                 // Config struct, applyDefaults, validate
+  errors.go                 // typed errors (ErrShuttingDown, ErrWALOverflow, …)
+
+  chain/
+    chain.go                // SinkChain (advance hash given shared seq+gen)
+    canonical.go            // IntegrityRecord canonical-JSON encoder (custom, not encoding/json)
+    context.go              // ContextDigest computation per spec §6.4.6
+    testdata/
+      vectors.json          // golden vectors: input record → expected canonical bytes → expected hash
+
+  compact/
+    encoder.go              // events.EventType → wtpv1.EventClass + Activity + payload
+    encoder_test.go         // golden vectors per event type
+    payload/
+      file.go process.go network.go …  // per-class field projection
+      testdata/             // golden JSON projections per OCSF class
+
+  wal/
+    wal.go                  // WAL writer + reader; segment lifecycle
+    segment.go              // header layout, INPROGRESS suffix, atomic seal
+    meta.go                 // meta.json (atomic temp+rename + dir fsync)
+    framing.go              // length+CRC32C+payload; readers verify CRC
+    testdata/               // golden segment bytes for cross-version compat
+
+  transport/
+    transport.go            // Conn interface, gRPC implementation
+    state.go                // state machine: connecting/replaying/live/shutdown
+    batcher.go              // assembles EventBatch under invariants
+    replayer.go             // post-reconnect replay from WAL up to ack watermark
+    heartbeat.go            // periodic Heartbeat send + miss-detection
+    metrics.go              // wtp_* counters/gauges/histograms (slog or expvar)
+
+  testserver/
+    server.go               // bufconn-based in-process WTP server stub
+    scenarios.go            // hooks: Drop, Goaway, AckDelay, StaleWatermark
+    dialer.go               // returns a transport.Dialer wired to bufconn
+    matcher.go              // helpers: WaitForBatch(...), AssertSequenceRange(...)
+
+proto/canyonroad/wtp/v1/
+  wtp.proto                 // service + messages from spec §7
+  wtp.pb.go wtp_grpc.pb.go  // generated
+  testdata/
+    *.bin                   // canonical wire-format goldens for parity with other implementations
+```
+
+### Layer responsibilities
+
+| Package | Responsibility | Touches network? | Touches disk? |
+|---|---|---|---|
+| `watchtower` (root) | Implements `store.EventStore`, owns lifecycle (Start/Close), wires the others together. | No directly | No directly |
+| `chain` | Pure: advance a sink-local entry hash from `(seq, gen, prev_hash, canonical_record)`. Computes context digest. | No | No |
+| `compact` | Pure: project an `events.Event` into a `CompactEvent` (OCSF class + activity + payload). | No | No |
+| `wal` | Append+fsync records, seal+roll segments, replay records on startup, GC after ack. | No | Yes |
+| `transport` | One goroutine state machine: dial, SessionInit, send batches, replay on reconnect, heartbeat. | Yes | No |
+| `testserver` | bufconn stub of the WTP server; scriptable scenarios. | In-process only | No |
+
+The root `store.go` is small (~150 lines): it constructs a `Config`, builds the `chain`, opens the `wal`, starts the `transport`, and forwards `AppendEvent` calls. Everything else is delegated.
+
+## Data Flow
+
+### Steady state — `AppendEvent`
+
+```
+caller (composite store)
+  │
+  │ ev = types.Event{Type, Timestamp, Fields{..., _integrity_seq=N, _integrity_generation=G}}
+  ▼
+watchtower.Store.AppendEvent(ctx, ev)
+  │
+  ├─ compact.Encode(ev)            → wtpv1.CompactEvent  (OCSF class, activity, payload)
+  ├─ chain.Advance(seq=N, gen=G,
+  │   prev_hash, canonical_record) → entry_hash, prev_hash := entry_hash
+  ├─ wal.Append(record_bytes)      → fsync (or deferred per §6 of this doc)
+  └─ transport.Notify()            → wake transport goroutine
+  return nil
+```
+
+The caller — typically the composite store — has already advanced the shared `(sequence, generation)` and stamped them on `ev.Fields` (Phase 0 contract). This client never advances them itself; doing so would break sink-local hash convergence.
+
+### Transport loop (single goroutine)
+
+```
+                ┌─────────────────────────────┐
+                │  state = stateConnecting    │
+                └──────────────┬──────────────┘
+                               │ Dial + SessionInit (wal_high_watermark_seq from disk)
+                               │ server returns ack_high_watermark_seq
+                               ▼
+                ┌─────────────────────────────┐
+   ┌───────────►│  state = stateReplaying     │
+   │            └──────────────┬──────────────┘
+   │                           │ replayer reads wal records (ack_hw, wal_hw], sends them
+   │                           │ in batches; each batch obeys all invariants
+   │                           ▼
+   │            ┌─────────────────────────────┐
+   │   notify   │  state = stateLive          │
+   │   (append) │  - select { wakeup, hb,     │
+   │            │    recv ack, recv goaway,   │
+   │            │    flush timer, ctx done }  │
+   │            └──────┬──────────┬──────┬────┘
+   │      goaway/loss  │          │      │ shutdown
+   │      /timeout     │          │      │ (Close)
+   └───────────────────┘          │      ▼
+                                  │   stateShutdown: drain in-flight, close stream
+                                  │   gracefully, close wal, close conn
+                                  ▼
+                         (back to connecting)
+```
+
+### Generation roll
+
+When a new event arrives with `_integrity_generation > current_generation`, the transport must:
+1. Flush the current batch (a batch is single-generation per spec §7).
+2. Seal the current WAL segment and start a new one (segment is single-generation by file header).
+3. Send a `SessionUpdate` carrying the new context digest and generation.
+4. Append the new record under the new generation.
+
+The chain itself resets: `prev_hash = ""` and the per-sink HMAC continues with the new `(gen, seq=0)` tuple.
+
+### WAL overflow → TransportLoss
+
+When `wal.Append` would push total disk usage past `max_total_bytes`:
+1. Drop the oldest *unacked* segment(s) until under budget.
+2. Emit a synthetic `TransportLoss{from_seq, to_seq, dropped_count, generation}` record into the WAL.
+3. Increment `wtp_transport_loss_total`.
+4. The marker is sent like any other batch when the transport reaches it; the server learns about the gap via the marker, not via a missing sequence number alone.
+
+## Phase 0 Contract (consumed, not implemented)
+
+The composite store advances a shared `(sequence, generation)` *before* fanning the event out to sinks. Each sink stamps these onto its own per-sink hash. The WTP client reads them via:
+
+```go
+ev.Fields["_integrity_seq"]        // uint64
+ev.Fields["_integrity_generation"] // uint32
+```
+
+If either field is missing or the wrong type, `AppendEvent` returns `ErrMissingChainState` and increments `wtp_dropped_missing_chain_state_total`. This is a programming error (composite not refactored or sink wired incorrectly), not a runtime condition we try to recover from.
+
+The full contract — including the existing `audit/integrity.go` refactor split (chain.AdvanceSequence vs chain.ComputeHash), the exact field names, value types, and the `TransportLoss` semantics on the shared sequence — is documented in `docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md`. That doc is the source of truth for the contract; this design depends on it but does not change it.
+
+## Chain Package (`internal/store/watchtower/chain`)
+
+### API
+
+```go
+package chain
+
+type SinkChain struct { /* key, algorithm, prev_hash */ }
+
+func New(key []byte, algorithm string) (*SinkChain, error)        // hmac-sha256 | hmac-sha512
+func (c *SinkChain) Advance(rec IntegrityRecord) (entryHash string, err error)
+func (c *SinkChain) Reset(generation uint32, prevHash string)     // for SessionUpdate
+func (c *SinkChain) State() (prevHash string)                      // for crash-recovery rebuild
+
+type IntegrityRecord struct {
+    FormatVersion uint32      // = 2 (spec §6.4)
+    Sequence      uint64      // shared, from composite
+    Generation    uint32      // shared, from composite
+    PrevHash      string      // sink-local
+    EventHash     string      // sha256(canonical_event_bytes)
+    ContextDigest string      // bound at SessionInit/Update/rotation
+    KeyFingerprint string
+}
+```
+
+### Canonical encoding — non-negotiable byte parity
+
+Spec §6.4 mandates a canonical JSON encoding with sorted keys, no insignificant whitespace, ASCII-escaped non-ASCII, and decimal numbers (no scientific notation). `encoding/json` does *not* guarantee any of these invariants across versions, and a single byte difference breaks every other implementation's verification.
+
+We hand-roll a canonical encoder in `chain/canonical.go`:
+
+```go
+func encodeCanonical(rec IntegrityRecord) ([]byte, error)
+```
+
+The encoder is exhaustively tested against `chain/testdata/vectors.json`, which is also published as the cross-implementation conformance suite for the spec. Vectors include UTF-8 edge cases (escaped non-ASCII, surrogate pairs), large numbers near uint64 max, and empty strings.
+
+### Context digest (§6.4.6)
+
+```go
+func ComputeContextDigest(ctx SessionContext) string
+```
+
+Computed once on `SessionInit`, again on `SessionUpdate`, and again on chain rotation. Bound into every event hash in that segment. Implemented as SHA-256 of the canonical encoding of the SessionContext fields the spec lists.
+
+### What this package does NOT do
+
+- Advance the shared sequence (composite owns it).
+- Persist any state (root `store.go` reconstructs `prev_hash` from WAL on startup).
+- Talk to the network or to a KMS (the key is passed in already-resolved).
+
+## WAL Package (`internal/store/watchtower/wal`)
+
+### Directory layout
+
+```
+$state_dir/wtp/
+  meta.json                      // atomic temp+rename, fsync(parent)
+  segments/
+    0000000000.seg.INPROGRESS    // currently being written
+    0000000001.seg                // sealed
+    0000000002.seg                // sealed
+    …
+```
+
+### Segment header (16 bytes)
+
+```
+offset  size  field
+0       4     magic     = "WTP1"
+4       2     version   = 1
+6       2     flags     (bit 0: gen_init, others reserved 0)
+8       4     generation
+12      4     reserved
+```
+
+Header is fsync'd at segment creation. A reader rejects segments with unknown magic, unknown version, or non-zero reserved bits.
+
+### Record framing (per record)
+
+```
+offset  size      field
+0       4         length     (uint32 BE; bytes after this field, excluding the CRC and including payload)
+4       4         crc32c     (Castagnoli, computed over payload)
+8       length-4  payload    (protobuf-encoded WAL record)
+```
+
+The CRC is the last line of defense against truncated tails (crash mid-fsync). Reader behaviour on bad CRC: log + emit `TransportLoss` marker for the affected sequence(s) + skip to next valid record.
+
+### Lifecycle
+
+| Event | Action |
+|---|---|
+| Open | Scan `segments/`. Last `*.INPROGRESS` is the live segment; reopen for append. Replay all records to recover `prev_hash` and verify CRCs. |
+| Append | Write framed record. Fsync per policy (immediate, or deferred per `2026-04-13-deferred-sync`). |
+| Segment full | Truncate to actual length, fsync, rename `.INPROGRESS` → `.seg`, open new `.INPROGRESS`. |
+| Generation change | Force segment roll (header carries generation). |
+| `SessionUpdate` | Force fsync of live segment + meta.json. |
+| `TransportLoss` write | Force fsync (operator visibility into loss must be durable). |
+| Ack received | Update `meta.json` with new `ack_high_watermark`. GC fully-acked segments via `os.Remove` after fsync(parent). |
+| Close | Fsync live segment, leave `.INPROGRESS` suffix in place (will be reopened on restart). |
+
+### meta.json schema
+
+```json
+{
+  "format_version": 1,
+  "ack_high_watermark_seq": 12345,
+  "ack_high_watermark_gen": 7,
+  "session_id": "01J...ulid",
+  "key_fingerprint": "sha256:abcd…"
+}
+```
+
+Atomically written via `os.WriteFile` on a temp + `os.Rename` + `fsync(parent)` using the existing `internal/audit/fsync_dir_unix.go` and `fsync_dir_windows.go` helpers. The session ID is included so a stale meta.json from a previous installation cannot be silently consumed.
+
+### Reader API
+
+```go
+type Reader struct { /* private */ }
+
+func (w *WAL) NewReader(start uint64) (*Reader, error)
+func (r *Reader) Notify() <-chan struct{}    // signaled when new records appended
+func (r *Reader) Next() (Record, error)      // io.EOF when caught up
+func (r *Reader) Close() error
+
+func (w *WAL) MarkAcked(seq uint64) error    // GC fully-acked segments
+```
+
+The transport goroutine consumes via the reader; it does not poll. Notifications coalesce naturally — one wakeup may correspond to many appended records.
+
+## Transport Package (`internal/store/watchtower/transport`)
+
+### Conn interface and Dialer pattern
+
+```go
+type Conn interface {
+    Send(ctx context.Context, msg *wtpv1.ClientMessage) error
+    Recv(ctx context.Context) (*wtpv1.ServerMessage, error)
+    CloseSend() error
+    Close() error
+}
+
+type Dialer interface {
+    Dial(ctx context.Context) (Conn, error)
+}
+```
+
+Production: `GRPCDialer` wraps `grpc.NewClient` with TLS 1.3 credentials, ALPN `wtp/1`, configured timeouts, and the bidi stream `Watchtower/Stream`. Tests: `testserver.NewDialer()` returns a `Dialer` backed by `bufconn` and a scenario script.
+
+The transport package never references `grpc-go` types in its own API surface, so tests don't need a real network listener.
+
+### State machine (single goroutine)
+
+```go
+type state int
+
+const (
+    stateConnecting state = iota
+    stateReplaying
+    stateLive
+    stateShutdown
+)
+```
+
+The goroutine runs `for { select { … } }`. The set of events depends on state:
+
+| State | select branches |
+|---|---|
+| `stateConnecting` | `dialResult`, `ctx.Done()` |
+| `stateReplaying`  | `replayDone`, `replayBatchSent`, `recv`, `ctx.Done()` |
+| `stateLive`       | `walReader.Notify()`, `flushTimer.C`, `heartbeatTimer.C`, `recv`, `ctx.Done()` |
+| `stateShutdown`   | `drainDone`, `gracefulCloseTimeout`, `ctx.Done()` |
+
+`recv` is fed by a small companion goroutine that calls `Conn.Recv` in a loop; this is the only other goroutine in the package. It exits when the stream closes.
+
+### Batcher invariants (per spec §7)
+
+A `Batcher` accumulates `CompactEvent`s and flushes when **any** of the following triggers:
+
+- Generation change: next event's generation differs from current batch.
+- Time span: oldest event in batch is older than `max_event_timespan` (default 5s).
+- Event count: `>= max_events_per_batch` (default 256).
+- Byte budget (post-compression): estimated `>= max_batch_bytes` (default 256 KiB).
+- Flush timer: `flush_interval` elapsed (default 1s; 200ms in ephemeral mode).
+- Generation rollover (sequence wrap): forces a fresh batch.
+
+Each invariant is enforced by a single function (`Batcher.Add` returns `(addedToBatch, shouldFlush)`); making the Batcher entirely table-test-driven.
+
+### Replayer
+
+On `stateReplaying`:
+
+```go
+for seq := ackHighWatermark + 1; seq <= walHighWatermark; seq++ {
+    rec := walReader.Next()
+    batcher.Add(rec)
+    if batcher.ShouldFlush() {
+        send(batcher.Drain())
+        if err { goto reconnect }
+    }
+}
+sendFinalBatchIfAny()
+state = stateLive
+```
+
+Replay batches obey the same invariants as live batches; the only difference is the source of records. The server may legitimately return a stale (lower) ack watermark during gradual rollout or partition recovery; the replayer trusts the lower of `(server_returned_hw, local_ack_hw)` so we re-send unacked records rather than dropping the gap. A higher-than-local server watermark is anomalous and is logged + ignored — we replay from `local_ack_hw + 1`.
+
+### Heartbeat
+
+A `heartbeatTimer` ticks at `heartbeat_interval` (default 30s; 10s in ephemeral mode). On tick: send `Heartbeat`. If two consecutive heartbeats elapse with no inbound message (ack or ServerHeartbeat), set `state = stateConnecting` (reconnect with backoff).
+
+### Backoff
+
+Exponential with jitter: `min(base * 2^n, max) ± 30%`. Defaults: base=500ms, max=30s. Reset on successful SessionInit + first ack received.
+
+### Metrics
+
+All exposed via slog at debug + as structured counters consumable by the existing `internal/metrics` registry:
+
+- `wtp_events_appended_total` (counter)
+- `wtp_events_acked_total` (counter)
+- `wtp_batches_sent_total` (counter)
+- `wtp_bytes_sent_total` (counter, post-compression)
+- `wtp_transport_loss_total` (counter)
+- `wtp_reconnects_total` (counter, labeled by reason)
+- `wtp_session_state` (gauge: 0=connecting, 1=replaying, 2=live, 3=shutdown)
+- `wtp_wal_segments` (gauge)
+- `wtp_wal_bytes` (gauge)
+- `wtp_ack_high_watermark` (gauge)
+- `wtp_dropped_missing_chain_state_total` (counter)
+- `wtp_send_latency_seconds` (histogram, per batch)
+
+## Configuration & Wiring
+
+### Config struct
+
+Mirrors spec §10.2 verbatim. Loaded by the existing `internal/config` package alongside other sink configs.
+
+```go
+type Config struct {
+    Enabled bool
+
+    Endpoint   string            // host:port
+    SessionID  string            // optional; auto-generated ULID if empty
+    StateDir   string            // default: $XDG_STATE_HOME/agentsh/wtp
+    EphemeralMode bool
+
+    TLS struct {
+        InsecureSkipVerify bool   // tests/dev only
+        CACertFile         string
+        ClientCertFile     string
+        ClientKeyFile      string
+    }
+
+    Auth struct {
+        TokenFile      string    // mutually exclusive with the others
+        TokenEnv       string
+        ClientCertAuth bool      // use mTLS cert as identity; no bearer
+    }
+
+    Chain struct {
+        Algorithm string  // hmac-sha256 | hmac-sha512 (default sha256)
+        KeyFile   string  // resolved via existing internal/audit/kms LoadKey
+        KeyEnv    string
+        // KMS sources (AWS, Azure, Vault, GCP) reuse internal/audit/kms
+        // config blocks; we share that struct rather than re-declare it.
+        // Each sink may use a different key (per Phase 0 contract); only the
+        // shared (sequence, generation) is required to match across sinks.
+    }
+
+    Batch struct {
+        MaxEvents       int           // default 256; ephemeral 64
+        MaxBytes        int           // default 256 KiB; ephemeral 64 KiB
+        MaxTimespan     time.Duration // default 5s; ephemeral 1s
+        FlushInterval   time.Duration // default 1s; ephemeral 200ms
+        Compression     string        // "zstd" (default) | "gzip" | "none"
+        ZstdLevel       int           // default 3
+    }
+
+    WAL struct {
+        SegmentSize    int64         // default 16 MiB; ephemeral 4 MiB
+        MaxTotalBytes  int64         // default 1 GiB; ephemeral 64 MiB
+        SyncMode       string        // "immediate" (default) | "deferred"
+        SyncInterval   time.Duration // for deferred; default 100ms
+    }
+
+    Heartbeat struct {
+        Interval        time.Duration // default 30s; ephemeral 10s
+        ReconnectAfterMisses int      // default 2
+    }
+
+    Backoff struct {
+        Base time.Duration // default 500ms
+        Max  time.Duration // default 30s
+    }
+
+    Filter wtpfilter.Filter   // reuse the existing OTEL/webhook filter type
+}
+```
+
+### applyDefaults() and validate()
+
+`applyDefaults()` checks `EphemeralMode` and overrides any zero-valued fields with the ephemeral profile *before* falling back to the standard defaults. `validate()` enforces:
+
+- Exactly one of `Auth.TokenFile`, `Auth.TokenEnv`, `Auth.ClientCertAuth` is set (strict mutual exclusion; configuration ambiguity is a fail-closed error).
+- `Endpoint` parses as `host:port`.
+- TLS files exist and are readable (early failure beats first-batch failure).
+- `StateDir` is writeable.
+- `Batch.MaxBytes >= 4 KiB` (avoid pathological tiny batches).
+- `WAL.SegmentSize <= WAL.MaxTotalBytes / 2` (need room for at least 2 segments).
+
+### Constructor
+
+```go
+func New(ctx context.Context, cfg Config, opts ...Option) (*Store, error)
+
+type Option func(*options)
+
+func WithMapper(m compact.Mapper) Option        // injected from Phase 1
+func WithDialer(d transport.Dialer) Option      // injected by tests
+func WithMetrics(reg metrics.Registry) Option   // injected by host
+func WithLogger(l *slog.Logger) Option          // injected by host
+func WithChainKey(key []byte, fp string) Option // injected by composite (Phase 0)
+```
+
+The host (the agentsh daemon) is responsible for building the `Store` with the right options. In tests we pass `WithDialer(testserver.NewDialer(...))` and skip TLS entirely.
+
+### Wiring into existing composite
+
+`internal/store/composite/composite.go` already has a `New(primary, output, others...)` constructor. The WTP store is added as another `EventStore` in `others`. No composite-side change is needed *as part of this work* beyond the Phase 0 refactor (which is its own design doc). When Phase 0 lands, composite advances `(seq, gen)` and stamps them on `ev.Fields` before calling `o.AppendEvent`; this client picks them up.
+
+## Testing Strategy
+
+### Five-layer pyramid
+
+| Layer | What | Tooling | Example |
+|---|---|---|---|
+| Unit (pure) | `chain/canonical.go`, `chain/context.go`, `compact/encoder.go`, `transport/batcher.go`, `wal/framing.go` CRC paths | Go test + golden files | `TestCanonicalEncoder_Goldens` |
+| Unit (I/O) | `wal.WAL` lifecycle on a real FS (tempdir) | Go test + `t.TempDir()` | `TestWAL_RolloverAndReplay` |
+| Unit (state machine) | `transport.state` transitions | Mock `Conn` + table tests | `TestState_GoawayTriggersReconnect` |
+| Component | Whole `Store` against `testserver` | bufconn | `TestStore_DropsMidBatchTriggersReplay` |
+| Integration | Long-running flow: append, kill server, restart, expect ack catch-up | bufconn with restartable scenario | `TestStore_ServerRestart_AcksCatchUp` |
+
+### `testserver` capabilities
+
+```go
+ts := testserver.New(t,
+    testserver.AckImmediately(),
+    testserver.Drop(after: 3, then: testserver.Resume()),
+    testserver.Goaway(after: 5*time.Second, code: "DRAINING"),
+    testserver.AckDelay(500 * time.Millisecond),
+    testserver.StaleWatermark(returnSeq: 100),
+)
+defer ts.Close()
+
+dialer := ts.NewDialer()
+store, _ := watchtower.New(ctx, cfg, watchtower.WithDialer(dialer))
+
+// drive the store
+for i := 0; i < 10; i++ { store.AppendEvent(ctx, ev) }
+
+// assertions
+ts.WaitForBatch(t, 5 * time.Second)
+ts.AssertSequenceRange(t, 1, 10)
+ts.AssertReplayObserved(t)
+```
+
+The testserver also exposes a `Recorded()` accessor returning all batches it has received in order, so tests can assert against the full conversation, not just final state.
+
+### Golden vectors — published in two locations
+
+1. `internal/store/watchtower/chain/testdata/vectors.json` — IntegrityRecord canonical-encoding vectors. These are also published in `docs/spec/wtp/conformance/` for cross-implementation use.
+2. `proto/canyonroad/wtp/v1/testdata/*.bin` — wire-format goldens (CompactEvent, EventBatch, SessionInit). Generated by a small `go run ./internal/store/watchtower/cmd/gen-wire-goldens` tool that we ship in-tree but do not run in CI; CI only verifies that the existing goldens parse + round-trip cleanly.
+
+A test failure on a golden is a load-bearing alarm: the canonical encoding has changed and is now incompatible with every other implementation. The golden test message says exactly this.
+
+### Cross-platform considerations (per AGENTS.md)
+
+- Use `filepath.Join` everywhere. No string concatenation of paths.
+- WAL `*.INPROGRESS` rename uses `os.Rename`, which on Windows requires the target not to exist (handled by always renaming a new file into a fresh sealed name).
+- `fsync(parent)` calls go through the existing `internal/audit/fsync_dir_{unix,windows}.go` helpers (Windows is a no-op there, which the existing audit chain already accepts).
+- bufconn-based tests are cross-platform with no extra effort.
+- We do *not* exec anything. No /tmp paths anywhere.
+
+## Deferrals and Open Questions
+
+| Item | Status | Where it shows up in the code |
+|---|---|---|
+| Phase 0: composite shared sequence | Prerequisite | `docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md` is the contract doc; `watchtower.Store.AppendEvent` reads `ev.Fields["_integrity_seq"]` and `["_integrity_generation"]`. |
+| Phase 1: OCSF mapper | Prerequisite | `compact.Mapper` interface; implementation lives in a different package. The WTP client's `compact/encoder.go` has a stub `defaultMapper` that handles the most common event types so the package can compile and unit-test stand-alone, but production wiring requires `WithMapper(...)` from Phase 1. |
+| Open Q: live key rotation pause/resume | Deferred | Comment in `transport/state.go` at the spot where a `KeyRotation` server message would be handled. The WTP client tolerates session-level `SessionUpdate` (the rotation envelope), so the rotation can be performed by issuing a `SessionUpdate` with a new key fingerprint — the only piece deferred is the *automation* of pausing the chain across the swap. |
+| Open Q: OCSF version negotiation | Deferred | Comment in `transport/transport.go` `SessionInit` builder. Today we hard-code `ocsf_version = "1.8.0"` matching the spec. |
+| Open Q: sub-second timestamp granularity | Deferred | Comment in `compact/encoder.go` next to the timestamp field. We use uint64 nanoseconds today (already sufficient for nanosecond precision); if the spec lands on a coarser truncation, we'll honour it there. |
+| Spec ambiguity #1: loss-only batch sequence range | Flagged for v0.4.10 | Code TODO in `transport/batcher.go` near the `TransportLoss` flush path. We currently emit `from_seq..to_seq` as the missing range and leave the batch's own `sequence_range` covering only the marker record. |
+| Spec ambiguity #2: definition of `total_chained` | Flagged for v0.4.10 | Code TODO in `chain/chain.go` next to the SessionInit-building helper. We currently treat it as the count of records the *sink* has chained since installation. |
+
+These deferrals do not block this design. Each is a localized future PR.
+
+## Migration & Rollout
+
+- The sink is **opt-in** via `[stores.watchtower].enabled = true` in the existing config TOML. It defaults to disabled.
+- When disabled, no goroutines start, no disk space is used, and `composite.others` does not include it.
+- When enabled but Phase 0 has not landed, `validate()` fails fast with a clear message: `"watchtower sink requires composite shared-sequence support (Phase 0); enable when available"`.
+- When enabled but the OCSF mapper is not injected, the sink runs with the stub mapper and logs a single warning at startup.
+- Operators can verify the sink end-to-end without a live Watchtower by pointing `Endpoint` at the testserver binary that ships in `cmd/wtp-testserver/` (a thin wrapper around `internal/store/watchtower/testserver`). This is also how we recommend running it in development.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Canonical encoding drift breaks every other implementation. | Golden vectors are mandatory for every change to `chain/canonical.go`. Vectors are also published as the conformance suite. |
+| WAL grows unbounded if server is offline forever. | `max_total_bytes` is hard-capped; oldest unacked drops with `TransportLoss`. Marker is fsynced before the drop is reported as complete. |
+| State-machine bugs deadlock the transport goroutine. | All select branches have a `ctx.Done()` arm. Heartbeat miss timer is independent of inbound traffic. State machine has full table-test coverage of every (state × event) cell. |
+| Fsync cost on the hot path regresses end-to-end latency (cf. `2026-04-13-deferred-sync`). | Default WAL sync mode is `immediate`, but we expose `deferred` with the same 100ms tick used for the existing JSONL/sidecar path. Operators with the same constraints can opt in. |
+| gRPC connection establishment blocks startup. | Dial happens in a background goroutine; `New` returns immediately. The first `AppendEvent` does not wait for connection — the WAL absorbs records until the transport catches up. |
+| Cross-platform regressions in WAL atomic-rename or dir-fsync. | The same helpers as the existing JSONL/integrity sidecar; they are already in production on all three OSes. |
+
+## Out-of-Scope (Explicit)
+
+- Server implementation (Watchtower).
+- Phase 0 composite refactor (separate doc).
+- Phase 1 OCSF mapper (separate work).
+- Live key rotation automation.
+- mTLS automation, SPIFFE, cert rotation.
+- HTTP/2 fallback.
+- Multi-tenant routing.
+- Querying acked events back from the server (one-way only).
+- Backfill from existing JSONL/SQLite stores into WTP.

--- a/docs/superpowers/specs/2026-04-18-wtp-client-design.md
+++ b/docs/superpowers/specs/2026-04-18-wtp-client-design.md
@@ -129,14 +129,18 @@ watchtower.Store.AppendEvent(ctx, ev)
   │ 3. canonicalize → bytes for hashing
   │
   │ 4. SinkChain.Compute(formatVersion, seq, gen, payload)
-  │      → (entryHash, prevHash) — PURE, no chain mutation
+  │      → *ComputeResult (EntryHash, PrevHash exposed; sequence,
+  │        generation tracked internally for Commit-time validation)
+  │        PURE, no chain mutation
   │
   │ 5. wal.Append(seq, gen, record_bytes)
   │      → (a) clean failure: return err, no Commit, chain unchanged
   │      → (b) ambiguous failure: SinkChain.Fatal(err); return ErrFatalIntegrity
   │      → (c) success: continue
   │
-  │ 6. SinkChain.Commit(gen, entryHash) — chain advances
+  │ 6. SinkChain.Commit(result) — chain advances; non-nil error means the
+  │      chain just latched fatal (backwards generation, stale token, or
+  │      rollover-with-nonempty-prev) and must be surfaced
   │
   │ 7. transport.Notify() → wake transport goroutine (non-blocking)
   │

--- a/docs/superpowers/specs/2026-04-18-wtp-client-design.md
+++ b/docs/superpowers/specs/2026-04-18-wtp-client-design.md
@@ -129,8 +129,10 @@ watchtower.Store.AppendEvent(ctx, ev)
   │ 3. canonicalize → bytes for hashing
   │
   │ 4. SinkChain.Compute(formatVersion, seq, gen, payload)
-  │      → *ComputeResult (EntryHash, PrevHash exposed; sequence,
-  │        generation tracked internally for Commit-time validation)
+  │      → *ComputeResult (opaque, chain-bound; EntryHash() and
+  │        PrevHash() accessors expose values for serialization;
+  │        sequence, generation, chain pointer tracked internally for
+  │        Commit-time validation)
   │        PURE, no chain mutation
   │
   │ 5. wal.Append(seq, gen, record_bytes)

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -208,8 +208,9 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 		a.broker.Publish(ev)
 
 		return types.WrapInitResponse{
-			PtraceMode:   true,
-			NotifySocket: notifySocketPath,
+			PtraceMode:            true,
+			SafeToBypassShellShim: true,
+			NotifySocket:          notifySocketPath,
 		}, http.StatusOK, nil
 	}
 
@@ -398,12 +399,13 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 	a.broker.Publish(ev)
 
 	return types.WrapInitResponse{
-		WrapperBinary: wrapperPath,
-		StubBinary:    stubPath,
-		SeccompConfig: string(cfgJSON),
-		NotifySocket:  notifySocketPath,
-		SignalSocket:  signalSocketPath,
-		WrapperEnv:    wrapperEnv,
+		SafeToBypassShellShim: execveEnabled,
+		WrapperBinary:         wrapperPath,
+		StubBinary:            stubPath,
+		SeccompConfig:         string(cfgJSON),
+		NotifySocket:          notifySocketPath,
+		SignalSocket:          signalSocketPath,
+		WrapperEnv:            wrapperEnv,
 	}, http.StatusOK, nil
 }
 

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -440,6 +442,40 @@ func TestWrapInit_SafeToBypassShellShim_SeccompExecveDisabled(t *testing.T) {
 	}
 	if resp.SafeToBypassShellShim {
 		t.Fatal("expected execve-disabled seccomp mode to require the shell shim")
+	}
+}
+
+func TestWrapInit_HTTPResponseIncludesSafeToBypassShellShimFalse(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap response serialization is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Development.DisableAuth = true
+	cfg.Health.Path = "/health"
+	cfg.Health.ReadinessPath = "/ready"
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.Seccomp.Execve.Enabled = false
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	body := []byte(`{"agent_command":"/bin/echo","caller_uid":0}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+s.ID+"/wrap-init", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	app.Router().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"safe_to_bypass_shell_shim":false`) {
+		t.Fatalf("expected serialized response to include safe_to_bypass_shell_shim=false, got %s", rr.Body.String())
 	}
 }
 

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -350,6 +350,99 @@ func TestWrapInit_RejectsNegativeCallerUID(t *testing.T) {
 	}
 }
 
+func TestWrapInit_SafeToBypassShellShim_Ptrace(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap ptrace mode is Linux-only")
+	}
+
+	cfg := &config.Config{}
+	app, mgr := newTestAppForWrap(t, cfg)
+	app.ptraceTracer = struct{}{}
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", code)
+	}
+	if !resp.SafeToBypassShellShim {
+		t.Fatal("expected ptrace mode to be safe to bypass the shell shim")
+	}
+}
+
+func TestWrapInit_SafeToBypassShellShim_SeccompExecveEnabled(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap seccomp mode is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.Seccomp.Execve.Enabled = true
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", code)
+	}
+	if !resp.SafeToBypassShellShim {
+		t.Fatal("expected execve-enabled seccomp mode to be safe to bypass the shell shim")
+	}
+}
+
+func TestWrapInit_SafeToBypassShellShim_SeccompExecveDisabled(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap seccomp mode is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.Seccomp.Execve.Enabled = false
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", code)
+	}
+	if resp.SafeToBypassShellShim {
+		t.Fatal("expected execve-disabled seccomp mode to require the shell shim")
+	}
+}
+
 func TestWrapInit_Success(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("wrap is Linux-only")

--- a/internal/api/wrap_windows.go
+++ b/internal/api/wrap_windows.go
@@ -128,7 +128,8 @@ func (a *App) wrapInitWindows(ctx context.Context, s *session.Session, sessionID
 
 	// On Windows, no wrapper binary is needed — the driver intercepts system-wide.
 	return types.WrapInitResponse{
-		StubBinary: stubPath,
+		SafeToBypassShellShim: true,
+		StubBinary:            stubPath,
 	}, http.StatusOK, nil
 }
 

--- a/internal/audit/integrity.go
+++ b/internal/audit/integrity.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/agentsh/agentsh/internal/audit/kms"
 	"github.com/agentsh/agentsh/internal/config"
@@ -31,14 +30,13 @@ type IntegrityMetadata struct {
 	EntryHash     string `json:"entry_hash"`
 }
 
-// IntegrityChain maintains HMAC chain state for tamper-proof audit logging.
-// Each entry's hash depends on the previous entry, forming a verifiable chain.
+// IntegrityChain is the legacy single-sink composer of SequenceAllocator +
+// SinkChain. New code should use those two types directly via the composite
+// store's allocator and per-sink chains. Wrap/State/Restore are preserved
+// at the source level for existing callers.
 type IntegrityChain struct {
-	mu        sync.Mutex
-	key       []byte
-	algorithm string
-	sequence  int64
-	prevHash  string
+	alloc *SequenceAllocator
+	chain *SinkChain
 }
 
 // MinKeyLength is the minimum recommended key length for HMAC-SHA256.
@@ -70,23 +68,13 @@ func NewIntegrityChain(key []byte) (*IntegrityChain, error) {
 // Supported algorithms: "hmac-sha256", "hmac-sha512".
 // Returns an error if the key is shorter than MinKeyLength bytes or algorithm is unsupported.
 func NewIntegrityChainWithAlgorithm(key []byte, algorithm string) (*IntegrityChain, error) {
-	if len(key) < MinKeyLength {
-		return nil, fmt.Errorf("key too short: got %d bytes, need at least %d", len(key), MinKeyLength)
-	}
-	if algorithm == "" {
-		algorithm = "hmac-sha256"
-	}
-	switch algorithm {
-	case "hmac-sha256", "hmac-sha512":
-		// valid
-	default:
-		return nil, fmt.Errorf("unsupported algorithm %q: use hmac-sha256 or hmac-sha512", algorithm)
+	chain, err := NewSinkChain(key, algorithm)
+	if err != nil {
+		return nil, err
 	}
 	return &IntegrityChain{
-		key:       key,
-		algorithm: algorithm,
-		sequence:  -1,
-		prevHash:  "",
+		alloc: NewSequenceAllocator(),
+		chain: chain,
 	}, nil
 }
 
@@ -199,75 +187,67 @@ func NewIntegrityChainFromConfig(ctx context.Context, cfg config.AuditIntegrityC
 // Wrap adds integrity metadata to an event payload.
 // The payload must be valid JSON. Returns a new JSON payload with an "integrity" field.
 func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	// Parse existing payload
 	data, err := parseIntegrityPayloadUseNumber(payload)
 	if err != nil {
 		return nil, err
 	}
-
-	// Use canonical JSON (re-marshaled) for HMAC to ensure verifiability.
-	// Go's json.Marshal produces deterministic output with sorted keys.
 	canonicalPayload, err := marshalCanonicalPayload(data)
 	if err != nil {
 		return nil, err
 	}
 
-	if c.sequence == math.MaxInt64 {
-		return nil, ErrSequenceOverflow
-	}
-	nextSequence := c.sequence + 1
-
-	// Compute HMAC of: format_version || sequence || prev_hash || canonical_payload
-	entryHash, err := c.computeHash(IntegrityFormatVersion, nextSequence, c.prevHash, canonicalPayload)
+	seq, gen, err := c.alloc.Next()
 	if err != nil {
 		return nil, err
 	}
 
-	// Create integrity metadata
-	meta := IntegrityMetadata{
-		FormatVersion: IntegrityFormatVersion,
-		Sequence:      nextSequence,
-		PrevHash:      c.prevHash,
-		EntryHash:     entryHash,
+	result, err := c.chain.Compute(IntegrityFormatVersion, seq, gen, canonicalPayload)
+	if err != nil {
+		return nil, err
 	}
 
-	// Add integrity field to payload
-	data["integrity"] = meta
+	data["integrity"] = IntegrityMetadata{
+		FormatVersion: IntegrityFormatVersion,
+		Sequence:      seq,
+		PrevHash:      result.PrevHash(),
+		EntryHash:     result.EntryHash(),
+	}
 
-	// Marshal the result
-	result, err := json.Marshal(data)
+	wrapped, err := json.Marshal(data)
 	if err != nil {
 		return nil, fmt.Errorf("marshal wrapped payload: %w", err)
 	}
 
-	// Record the most recent wrapped entry. State() reflects the last durable
-	// entry once callers persist or explicitly Restore after a failed write.
-	c.sequence = nextSequence
-	c.prevHash = entryHash
-
-	return result, nil
+	if err := c.chain.Commit(result); err != nil {
+		return nil, err
+	}
+	return wrapped, nil
 }
 
 // State returns the last written chain state for persistence.
 func (c *IntegrityChain) State() ChainState {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	allocState := c.alloc.State()
+	chainState := c.chain.State()
 	return ChainState{
-		Sequence: c.sequence,
-		PrevHash: c.prevHash,
+		Sequence: allocState.Sequence,
+		PrevHash: chainState.PrevHash,
 	}
 }
 
 // Restore restores the chain state after a restart.
 // The sequence must be the last written entry so the next Wrap continues at sequence+1.
-func (c *IntegrityChain) Restore(sequence int64, prevHash string) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.sequence = sequence
-	c.prevHash = prevHash
+//
+// Aggregates errors from the underlying allocator and sink chain restores —
+// SequenceAllocator.Restore rejects sequence < -1, and SinkChain.Restore
+// rejects malformed prev_hash (non-hex or wrong length for the algorithm).
+func (c *IntegrityChain) Restore(sequence int64, prevHash string) error {
+	if err := c.alloc.Restore(AllocatorState{Sequence: sequence, Generation: 0}); err != nil {
+		return fmt.Errorf("restore allocator: %w", err)
+	}
+	if err := c.chain.Restore(0, prevHash, false); err != nil {
+		return fmt.Errorf("restore chain: %w", err)
+	}
+	return nil
 }
 
 // KeyFingerprint returns a stable SHA-256 fingerprint prefix for an HMAC key.
@@ -278,17 +258,20 @@ func KeyFingerprint(key []byte) string {
 
 // KeyFingerprint returns a stable SHA-256 fingerprint prefix for the chain key.
 func (c *IntegrityChain) KeyFingerprint() string {
-	return KeyFingerprint(c.key)
+	key, _ := c.chain.keyAndAlgorithm()
+	return KeyFingerprint(key)
 }
 
 // VerifyHash recomputes the canonical payload hash using the chain key and format version.
 func (c *IntegrityChain) VerifyHash(formatVersion int, sequence int64, prevHash string, payload []byte, expectedHash string) (bool, error) {
-	return VerifyHash(c.key, c.algorithm, formatVersion, sequence, prevHash, payload, expectedHash)
+	key, alg := c.chain.keyAndAlgorithm()
+	return VerifyHash(key, alg, formatVersion, sequence, prevHash, payload, expectedHash)
 }
 
 // VerifyWrapped verifies a wrapped payload, including integrity metadata.
 func (c *IntegrityChain) VerifyWrapped(wrapped []byte) (bool, error) {
-	return VerifyWrapped(c.key, c.algorithm, wrapped)
+	key, alg := c.chain.keyAndAlgorithm()
+	return VerifyWrapped(key, alg, wrapped)
 }
 
 // VerifyHash recomputes an entry hash using canonical JSON payload encoding.
@@ -331,11 +314,6 @@ func VerifyWrapped(key []byte, algorithm string, wrapped []byte) (bool, error) {
 		return false, err
 	}
 	return hmac.Equal([]byte(actualHash), []byte(meta.EntryHash)), nil
-}
-
-// computeHash computes the HMAC of: format_version || sequence || prev_hash || payload
-func (c *IntegrityChain) computeHash(formatVersion int, sequence int64, prevHash string, payload []byte) (string, error) {
-	return computeIntegrityHash(c.key, c.algorithm, formatVersion, sequence, prevHash, payload)
 }
 
 func parseIntegrityPayloadUseNumber(payload []byte) (map[string]any, error) {

--- a/internal/audit/integrity.go
+++ b/internal/audit/integrity.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/agentsh/agentsh/internal/audit/kms"
 	"github.com/agentsh/agentsh/internal/config"
@@ -34,7 +35,18 @@ type IntegrityMetadata struct {
 // SinkChain. New code should use those two types directly via the composite
 // store's allocator and per-sink chains. Wrap/State/Restore are preserved
 // at the source level for existing callers.
+//
+// Concurrency: Wrap, State, and Restore are serialized by an internal
+// mutex so the wrapper preserves the legacy single-mutex atomicity contract:
+// concurrent Wrap calls do not race against each other, State returns a
+// consistent (sequence, prev_hash) snapshot, and Restore is all-or-nothing
+// (a failed Restore leaves the wrapper in its pre-call state).
+//
+// KeyFingerprint, VerifyHash, and VerifyWrapped do NOT take the wrapper
+// mutex — they read immutable key/algorithm via the underlying SinkChain's
+// own mutex and have no need for wrapper-level serialization.
 type IntegrityChain struct {
+	mu    sync.Mutex
 	alloc *SequenceAllocator
 	chain *SinkChain
 }
@@ -187,6 +199,9 @@ func NewIntegrityChainFromConfig(ctx context.Context, cfg config.AuditIntegrityC
 // Wrap adds integrity metadata to an event payload.
 // The payload must be valid JSON. Returns a new JSON payload with an "integrity" field.
 func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	data, err := parseIntegrityPayloadUseNumber(payload)
 	if err != nil {
 		return nil, err
@@ -226,6 +241,8 @@ func (c *IntegrityChain) Wrap(payload []byte) ([]byte, error) {
 
 // State returns the last written chain state for persistence.
 func (c *IntegrityChain) State() ChainState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	allocState := c.alloc.State()
 	chainState := c.chain.State()
 	return ChainState{
@@ -240,11 +257,31 @@ func (c *IntegrityChain) State() ChainState {
 // Aggregates errors from the underlying allocator and sink chain restores —
 // SequenceAllocator.Restore rejects sequence < -1, and SinkChain.Restore
 // rejects malformed prev_hash (non-hex or wrong length for the algorithm).
+//
+// Restore is all-or-nothing: if either component rejects its input, the
+// IntegrityChain is left in its pre-call state. The implementation
+// snapshots the allocator before mutating and rolls it back if the chain
+// restore is rejected. The wrapper mutex serializes Restore against
+// concurrent Wrap and State calls.
 func (c *IntegrityChain) Restore(sequence int64, prevHash string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Snapshot allocator state for rollback so Restore is all-or-nothing:
+	// if chain restoration fails, the allocator must not be observed as
+	// partially restored. SequenceAllocator.Restore validates Sequence >= -1
+	// before mutating; SinkChain.Restore validates prevHash format before
+	// mutating. We attempt allocator first; if chain restore rejects the
+	// prevHash, we restore the allocator to the pre-call snapshot.
+	prevAlloc := c.alloc.State()
+
 	if err := c.alloc.Restore(AllocatorState{Sequence: sequence, Generation: 0}); err != nil {
 		return fmt.Errorf("restore allocator: %w", err)
 	}
 	if err := c.chain.Restore(0, prevHash, false); err != nil {
+		// Roll back allocator. prevAlloc came from State() so it satisfies
+		// the Sequence >= -1 invariant; this rollback cannot fail.
+		_ = c.alloc.Restore(prevAlloc)
 		return fmt.Errorf("restore chain: %w", err)
 	}
 	return nil

--- a/internal/audit/integrity_test.go
+++ b/internal/audit/integrity_test.go
@@ -104,7 +104,9 @@ func TestIntegrityChain_Restore_ContinuesFromLastWrittenSequence(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewIntegrityChain() error = %v", err)
 	}
-	chain.Restore(41, "prev-hash")
+	if err := chain.Restore(41, "0000000000000000000000000000000000000000000000000000000000000000"); err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
 
 	wrapped, err := chain.Wrap([]byte(`{"event":"after_restore"}`))
 	if err != nil {
@@ -120,8 +122,8 @@ func TestIntegrityChain_Restore_ContinuesFromLastWrittenSequence(t *testing.T) {
 	if got := int64(integrity["sequence"].(float64)); got != 42 {
 		t.Fatalf("sequence = %d, want 42", got)
 	}
-	if got := integrity["prev_hash"].(string); got != "prev-hash" {
-		t.Fatalf("prev_hash = %q, want prev-hash", got)
+	if got := integrity["prev_hash"].(string); got != "0000000000000000000000000000000000000000000000000000000000000000" {
+		t.Fatalf("prev_hash = %q, want zero hex", got)
 	}
 }
 
@@ -160,7 +162,10 @@ func TestIntegrityChain_Wrap_ReturnsSequenceOverflowAtMaxInt64(t *testing.T) {
 		t.Fatalf("NewIntegrityChain() error = %v", err)
 	}
 
-	chain.Restore(math.MaxInt64, "prev-hash")
+	const zeroHash = "0000000000000000000000000000000000000000000000000000000000000000"
+	if err := chain.Restore(math.MaxInt64, zeroHash); err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
 
 	_, err = chain.Wrap([]byte(`{"event":"overflow"}`))
 	if !errors.Is(err, ErrSequenceOverflow) {
@@ -171,8 +176,8 @@ func TestIntegrityChain_Wrap_ReturnsSequenceOverflowAtMaxInt64(t *testing.T) {
 	if state.Sequence != math.MaxInt64 {
 		t.Fatalf("State().Sequence = %d, want %d", state.Sequence, int64(math.MaxInt64))
 	}
-	if state.PrevHash != "prev-hash" {
-		t.Fatalf("State().PrevHash = %q, want %q", state.PrevHash, "prev-hash")
+	if state.PrevHash != zeroHash {
+		t.Fatalf("State().PrevHash = %q, want %q", state.PrevHash, zeroHash)
 	}
 }
 
@@ -426,7 +431,9 @@ func TestIntegrityChain_VerifyWrapped_PreservesLargeSequencePrecision(t *testing
 	}
 
 	const lastWrittenSequence int64 = 9007199254740992
-	chain.Restore(lastWrittenSequence, "prev-hash")
+	if err := chain.Restore(lastWrittenSequence, ""); err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
 
 	wrapped, err := chain.Wrap([]byte(`{"event":"high_sequence"}`))
 	if err != nil {
@@ -551,7 +558,9 @@ func TestIntegrityChain_Restore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewIntegrityChain() error = %v", err)
 	}
-	newChain.Restore(state.Sequence, state.PrevHash)
+	if err := newChain.Restore(state.Sequence, state.PrevHash); err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
 
 	// Wrap a new entry
 	wrapped, err := newChain.Wrap([]byte(`{"event":"after_restore"}`))

--- a/internal/audit/integrity_test.go
+++ b/internal/audit/integrity_test.go
@@ -5,10 +5,12 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -859,5 +861,260 @@ func TestNewIntegrityChainWithAlgorithm_EmptyAlgorithmDefaultsToSHA256(t *testin
 	// SHA-256 produces 64 hex characters (32 bytes)
 	if len(entryHash) != 64 {
 		t.Errorf("entry_hash length = %d, want 64 for SHA-256 (default)", len(entryHash))
+	}
+}
+
+// TestIntegrityChain_Wrap_ConcurrentSafety verifies that the legacy
+// IntegrityChain.Wrap() preserves the single-mutex atomicity contract
+// when called concurrently. Without wrapper-level locking, alloc.Next()
+// from one goroutine can interleave with chain.Compute() from another,
+// producing chains where prev_hash[seq] != entry_hash[seq-1] (or
+// latching the chain fatal with ErrStaleResult).
+func TestIntegrityChain_Wrap_ConcurrentSafety(t *testing.T) {
+	chain, err := NewIntegrityChain(testKey)
+	if err != nil {
+		t.Fatalf("NewIntegrityChain() error = %v", err)
+	}
+
+	const goroutines = 50
+	const perGoroutine = 20
+	const total = goroutines * perGoroutine
+
+	var (
+		mu      sync.Mutex
+		entries = make([][]byte, 0, total)
+		wrapErr error
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		g := g
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				payload := []byte(fmt.Sprintf(`{"goroutine":%d,"iteration":%d}`, g, i))
+				wrapped, err := chain.Wrap(payload)
+				mu.Lock()
+				if err != nil && wrapErr == nil {
+					wrapErr = fmt.Errorf("g=%d i=%d: Wrap: %w", g, i, err)
+				}
+				if err == nil {
+					entries = append(entries, wrapped)
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if wrapErr != nil {
+		t.Fatalf("concurrent Wrap returned error: %v", wrapErr)
+	}
+	if len(entries) != total {
+		t.Fatalf("got %d wrapped entries, want %d", len(entries), total)
+	}
+
+	entryHash := make(map[int64]string, total)
+	prevHash := make(map[int64]string, total)
+	for i, wrapped := range entries {
+		var result map[string]any
+		if err := json.Unmarshal(wrapped, &result); err != nil {
+			t.Fatalf("entry %d unmarshal: %v", i, err)
+		}
+		integrity, ok := result["integrity"].(map[string]any)
+		if !ok {
+			t.Fatalf("entry %d: integrity field missing or not an object", i)
+		}
+		seq := int64(integrity["sequence"].(float64))
+		eh := integrity["entry_hash"].(string)
+		ph := integrity["prev_hash"].(string)
+		if existing, dup := entryHash[seq]; dup {
+			t.Fatalf("duplicate sequence %d: entry_hash=%q vs %q", seq, existing, eh)
+		}
+		entryHash[seq] = eh
+		prevHash[seq] = ph
+	}
+
+	for seq := int64(0); seq < int64(total); seq++ {
+		if _, ok := entryHash[seq]; !ok {
+			t.Fatalf("missing sequence %d (sequences must be exactly 0..%d)", seq, total-1)
+		}
+	}
+
+	for seq := int64(1); seq < int64(total); seq++ {
+		want := entryHash[seq-1]
+		if got := prevHash[seq]; got != want {
+			t.Fatalf("chain integrity break at seq=%d: prev_hash=%q, want entry_hash[%d]=%q",
+				seq, got, seq-1, want)
+		}
+	}
+	if got := prevHash[0]; got != "" {
+		t.Fatalf("genesis seq=0: prev_hash=%q, want empty", got)
+	}
+
+	for i, wrapped := range entries {
+		ok, err := chain.VerifyWrapped(wrapped)
+		if err != nil {
+			t.Fatalf("entry %d VerifyWrapped: %v", i, err)
+		}
+		if !ok {
+			t.Fatalf("entry %d VerifyWrapped: false (chain integrity broken)", i)
+		}
+	}
+}
+
+// TestIntegrityChain_State_SnapshotConsistency verifies that State()
+// returns a consistent (sequence, prev_hash) snapshot — never a torn
+// read where Sequence is from a newer wrap than PrevHash, or vice versa.
+//
+// Without wrapper-level locking, State() reads alloc.State() then
+// chain.State() with no atomicity, so a concurrent Wrap can advance the
+// allocator between the two reads (producing state.Sequence=N but
+// state.PrevHash=hash[N-1]) or advance both (producing state.Sequence=N
+// but state.PrevHash=hash[N+1] if the chain commit lands between reads).
+func TestIntegrityChain_State_SnapshotConsistency(t *testing.T) {
+	chain, err := NewIntegrityChain(testKey)
+	if err != nil {
+		t.Fatalf("NewIntegrityChain() error = %v", err)
+	}
+
+	const wraps = 200
+	const samples = 200
+
+	// entryHashBySeq[seq] = entry_hash for the entry at that sequence.
+	var entryHashBySeq sync.Map
+
+	done := make(chan struct{})
+	var wrapErr error
+	go func() {
+		defer close(done)
+		for i := 0; i < wraps; i++ {
+			payload := []byte(fmt.Sprintf(`{"i":%d}`, i))
+			wrapped, err := chain.Wrap(payload)
+			if err != nil {
+				wrapErr = fmt.Errorf("Wrap %d: %w", i, err)
+				return
+			}
+			var result map[string]any
+			if err := json.Unmarshal(wrapped, &result); err != nil {
+				wrapErr = fmt.Errorf("unmarshal %d: %w", i, err)
+				return
+			}
+			integrity := result["integrity"].(map[string]any)
+			seq := int64(integrity["sequence"].(float64))
+			eh := integrity["entry_hash"].(string)
+			entryHashBySeq.Store(seq, eh)
+		}
+	}()
+
+	// Sample State() in parallel.
+	type torn struct {
+		seq      int64
+		prevHash string
+		want     string
+	}
+	var tornReads []torn
+	for s := 0; s < samples; s++ {
+		st := chain.State()
+		// Genesis: sequence == -1 means no Wrap has completed; prev_hash must be empty.
+		if st.Sequence == -1 {
+			if st.PrevHash != "" {
+				tornReads = append(tornReads, torn{seq: -1, prevHash: st.PrevHash, want: ""})
+			}
+			continue
+		}
+		// For any committed sequence s, the legacy contract is:
+		// state.PrevHash == entry_hash[s] (the chain head equals the
+		// most-recently-committed entry's hash).
+		v, ok := entryHashBySeq.Load(st.Sequence)
+		if !ok {
+			// Allocator advanced past s but Wrap hasn't recorded entry_hash[s] yet.
+			// This is itself a torn snapshot: alloc reports seq=s but the
+			// committing goroutine hasn't yet stored its entry_hash, meaning
+			// the wrapper exposed an alloc-state that is ahead of the
+			// chain-state caller would observe. Defer the check by retrying
+			// once after the writer goroutine completes.
+			<-done
+			if wrapErr != nil {
+				t.Fatalf("background Wrap failed: %v", wrapErr)
+			}
+			v, ok = entryHashBySeq.Load(st.Sequence)
+			if !ok {
+				t.Fatalf("no entry_hash recorded for sampled seq=%d", st.Sequence)
+			}
+		}
+		want := v.(string)
+		if st.PrevHash != want {
+			tornReads = append(tornReads, torn{seq: st.Sequence, prevHash: st.PrevHash, want: want})
+		}
+	}
+	<-done
+	if wrapErr != nil {
+		t.Fatalf("background Wrap failed: %v", wrapErr)
+	}
+	if len(tornReads) > 0 {
+		t.Fatalf("State() returned %d torn snapshots; first: seq=%d prev_hash=%q want=%q",
+			len(tornReads), tornReads[0].seq, tornReads[0].prevHash, tornReads[0].want)
+	}
+}
+
+// TestIntegrityChain_Restore_PartialFailure_LeavesStateIntact verifies
+// that a Restore call rejected by the chain (invalid prev_hash) leaves
+// the allocator unchanged. Without rollback, the allocator would be
+// advanced before the chain validation runs, leaving the wrapper in a
+// half-restored state where State().Sequence and State().PrevHash are
+// inconsistent.
+func TestIntegrityChain_Restore_PartialFailure_LeavesStateIntact(t *testing.T) {
+	chain, err := NewIntegrityChain(testKey)
+	if err != nil {
+		t.Fatalf("NewIntegrityChain() error = %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := chain.Wrap([]byte(`{"event":"warmup"}`)); err != nil {
+			t.Fatalf("Wrap %d: %v", i, err)
+		}
+	}
+
+	s0 := chain.State()
+	if s0.Sequence != 2 {
+		t.Fatalf("pre-Restore State().Sequence = %d, want 2", s0.Sequence)
+	}
+
+	err = chain.Restore(99, "not-valid-hex")
+	if err == nil {
+		t.Fatal("Restore(99, \"not-valid-hex\") returned nil error, want rejection")
+	}
+	if !errors.Is(err, ErrInvalidChainState) {
+		t.Fatalf("Restore error = %v, want errors.Is(err, ErrInvalidChainState)", err)
+	}
+
+	s1 := chain.State()
+	if s1.Sequence != s0.Sequence {
+		t.Fatalf("post-failed-Restore State().Sequence = %d, want %d (pre-call S0)",
+			s1.Sequence, s0.Sequence)
+	}
+	if s1.PrevHash != s0.PrevHash {
+		t.Fatalf("post-failed-Restore State().PrevHash = %q, want %q (pre-call S0)",
+			s1.PrevHash, s0.PrevHash)
+	}
+
+	wrapped, err := chain.Wrap([]byte(`{"event":"after_failed_restore"}`))
+	if err != nil {
+		t.Fatalf("Wrap after failed Restore: %v", err)
+	}
+	var result map[string]any
+	if err := json.Unmarshal(wrapped, &result); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	integrity := result["integrity"].(map[string]any)
+	if got := int64(integrity["sequence"].(float64)); got != s0.Sequence+1 {
+		t.Fatalf("post-Restore Wrap sequence = %d, want %d (S0.Sequence+1; allocator advanced by failed Restore)",
+			got, s0.Sequence+1)
+	}
+	if got := integrity["prev_hash"].(string); got != s0.PrevHash {
+		t.Fatalf("post-Restore Wrap prev_hash = %q, want %q (chain advanced by failed Restore)",
+			got, s0.PrevHash)
 	}
 }

--- a/internal/audit/sequence_allocator.go
+++ b/internal/audit/sequence_allocator.go
@@ -1,9 +1,21 @@
 package audit
 
 import (
+	"errors"
 	"math"
 	"sync"
 )
+
+// ErrGenerationOverflow is returned by NextGeneration when the generation
+// counter would wrap past math.MaxUint32. Reaching this is a fatal
+// integrity event — wrapping would re-use prior (sequence, generation)
+// tuples, defeating the new-generation boundary guarantee.
+var ErrGenerationOverflow = errors.New("integrity generation overflow")
+
+// ErrInvalidAllocatorState is returned by Restore when the supplied state
+// violates allocator invariants (e.g., Sequence < -1). The allocator is
+// not modified on rejected restore.
+var ErrInvalidAllocatorState = errors.New("invalid allocator state")
 
 // SequenceAllocator owns the shared (sequence, generation) tuple. It has no
 // hash state. Composite holds exactly one allocator and stamps every event
@@ -49,12 +61,20 @@ func (a *SequenceAllocator) Next() (sequence int64, generation uint32, err error
 // NextGeneration increments generation and resets sequence so the next Next()
 // returns (0, new_generation). Returns the new generation. Used by the
 // composite owner when the chain key rotates.
-func (a *SequenceAllocator) NextGeneration() uint32 {
+//
+// Returns ErrGenerationOverflow if generation == math.MaxUint32; the
+// allocator is not modified in that case. Reaching this is fatal — there
+// is no clean recovery short of provisioning a new allocator with a fresh
+// chain key namespace.
+func (a *SequenceAllocator) NextGeneration() (uint32, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+	if a.generation == math.MaxUint32 {
+		return 0, ErrGenerationOverflow
+	}
 	a.generation++
 	a.sequence = -1
-	return a.generation
+	return a.generation, nil
 }
 
 // State returns the current (sequence, generation) for persistence. After
@@ -65,10 +85,16 @@ func (a *SequenceAllocator) State() AllocatorState {
 	return AllocatorState{Sequence: a.sequence, Generation: a.generation}
 }
 
-// Restore rehydrates allocator state after restart.
-func (a *SequenceAllocator) Restore(state AllocatorState) {
+// Restore rehydrates allocator state after restart. Returns
+// ErrInvalidAllocatorState if state.Sequence < -1 (which would violate the
+// monotonic-from-zero contract); the allocator is not modified in that case.
+func (a *SequenceAllocator) Restore(state AllocatorState) error {
+	if state.Sequence < -1 {
+		return ErrInvalidAllocatorState
+	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.sequence = state.Sequence
 	a.generation = state.Generation
+	return nil
 }

--- a/internal/audit/sequence_allocator.go
+++ b/internal/audit/sequence_allocator.go
@@ -1,0 +1,74 @@
+package audit
+
+import (
+	"math"
+	"sync"
+)
+
+// SequenceAllocator owns the shared (sequence, generation) tuple. It has no
+// hash state. Composite holds exactly one allocator and stamps every event
+// with the next allocated tuple before fanning out to chained sinks.
+//
+// Sequence is monotonically increasing within a generation, starting at 0.
+// Generation is incremented by NextGeneration() and resets sequence so the
+// next Next() returns (0, new_generation).
+//
+// Concurrency-safe.
+type SequenceAllocator struct {
+	mu         sync.Mutex
+	sequence   int64  // last returned sequence; -1 means "none yet"
+	generation uint32 // current generation
+}
+
+// AllocatorState captures the allocator's persistent state. Snapshot via
+// State() and rehydrate with Restore() across restarts.
+type AllocatorState struct {
+	Sequence   int64
+	Generation uint32
+}
+
+// NewSequenceAllocator creates an allocator whose first Next() returns (0, 0).
+func NewSequenceAllocator() *SequenceAllocator {
+	return &SequenceAllocator{sequence: -1}
+}
+
+// Next returns the next (sequence, generation) and advances the counter.
+// Returns ErrSequenceOverflow when sequence == math.MaxInt64; the caller
+// should treat this as fatal (it implies > 9.2e18 events in a single
+// generation, so a generation rotation is the recovery path).
+func (a *SequenceAllocator) Next() (sequence int64, generation uint32, err error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.sequence == math.MaxInt64 {
+		return 0, 0, ErrSequenceOverflow
+	}
+	a.sequence++
+	return a.sequence, a.generation, nil
+}
+
+// NextGeneration increments generation and resets sequence so the next Next()
+// returns (0, new_generation). Returns the new generation. Used by the
+// composite owner when the chain key rotates.
+func (a *SequenceAllocator) NextGeneration() uint32 {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.generation++
+	a.sequence = -1
+	return a.generation
+}
+
+// State returns the current (sequence, generation) for persistence. After
+// Restore(state), the next Next() returns (state.Sequence + 1, state.Generation).
+func (a *SequenceAllocator) State() AllocatorState {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return AllocatorState{Sequence: a.sequence, Generation: a.generation}
+}
+
+// Restore rehydrates allocator state after restart.
+func (a *SequenceAllocator) Restore(state AllocatorState) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.sequence = state.Sequence
+	a.generation = state.Generation
+}

--- a/internal/audit/sequence_allocator_test.go
+++ b/internal/audit/sequence_allocator_test.go
@@ -1,0 +1,135 @@
+package audit
+
+import (
+	"errors"
+	"math"
+	"sync"
+	"testing"
+)
+
+func TestSequenceAllocator_Next_ReturnsZeroFirst(t *testing.T) {
+	a := NewSequenceAllocator()
+	seq, gen, err := a.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if seq != 0 || gen != 0 {
+		t.Fatalf("first Next() = (%d, %d), want (0, 0)", seq, gen)
+	}
+}
+
+func TestSequenceAllocator_Next_Monotonic(t *testing.T) {
+	a := NewSequenceAllocator()
+	for i := int64(0); i < 100; i++ {
+		seq, gen, err := a.Next()
+		if err != nil {
+			t.Fatalf("Next #%d: %v", i, err)
+		}
+		if seq != i {
+			t.Fatalf("Next #%d returned seq=%d, want %d", i, seq, i)
+		}
+		if gen != 0 {
+			t.Fatalf("Next #%d returned gen=%d, want 0", i, gen)
+		}
+	}
+}
+
+func TestSequenceAllocator_NextGeneration_ResetsSequence(t *testing.T) {
+	a := NewSequenceAllocator()
+	if _, _, err := a.Next(); err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if _, _, err := a.Next(); err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	// State now: sequence=1, gen=0; next Next() would return (2, 0).
+
+	newGen := a.NextGeneration()
+	if newGen != 1 {
+		t.Fatalf("NextGeneration() = %d, want 1", newGen)
+	}
+
+	seq, gen, err := a.Next()
+	if err != nil {
+		t.Fatalf("Next after NextGeneration: %v", err)
+	}
+	if seq != 0 || gen != 1 {
+		t.Fatalf("after rollover: Next() = (%d, %d), want (0, 1)", seq, gen)
+	}
+}
+
+func TestSequenceAllocator_State_Restore_RoundTrip(t *testing.T) {
+	a := NewSequenceAllocator()
+	for i := 0; i < 5; i++ {
+		if _, _, err := a.Next(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	a.NextGeneration()
+	if _, _, err := a.Next(); err != nil {
+		t.Fatal(err)
+	}
+	// State: sequence=0, gen=1.
+
+	state := a.State()
+	if state.Sequence != 0 || state.Generation != 1 {
+		t.Fatalf("State() = %+v, want {Sequence:0 Generation:1}", state)
+	}
+
+	b := NewSequenceAllocator()
+	b.Restore(state)
+	seq, gen, err := b.Next()
+	if err != nil {
+		t.Fatalf("Next after Restore: %v", err)
+	}
+	if seq != 1 || gen != 1 {
+		t.Fatalf("after restore: Next() = (%d, %d), want (1, 1)", seq, gen)
+	}
+}
+
+func TestSequenceAllocator_Overflow(t *testing.T) {
+	a := NewSequenceAllocator()
+	a.Restore(AllocatorState{Sequence: math.MaxInt64, Generation: 0})
+
+	_, _, err := a.Next()
+	if !errors.Is(err, ErrSequenceOverflow) {
+		t.Fatalf("Next at MaxInt64: err = %v, want ErrSequenceOverflow", err)
+	}
+}
+
+func TestSequenceAllocator_ConcurrentNext_NoDuplicates(t *testing.T) {
+	a := NewSequenceAllocator()
+	const workers = 8
+	const perWorker = 1000
+
+	var wg sync.WaitGroup
+	results := make(chan int64, workers*perWorker)
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				seq, _, err := a.Next()
+				if err != nil {
+					t.Errorf("Next: %v", err)
+					return
+				}
+				results <- seq
+			}
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	seen := make(map[int64]bool, workers*perWorker)
+	for s := range results {
+		if seen[s] {
+			t.Fatalf("duplicate sequence: %d", s)
+		}
+		seen[s] = true
+	}
+	if len(seen) != workers*perWorker {
+		t.Fatalf("got %d unique sequences, want %d", len(seen), workers*perWorker)
+	}
+}

--- a/internal/audit/sequence_allocator_test.go
+++ b/internal/audit/sequence_allocator_test.go
@@ -44,7 +44,10 @@ func TestSequenceAllocator_NextGeneration_ResetsSequence(t *testing.T) {
 	}
 	// State now: sequence=1, gen=0; next Next() would return (2, 0).
 
-	newGen := a.NextGeneration()
+	newGen, err := a.NextGeneration()
+	if err != nil {
+		t.Fatalf("NextGeneration: %v", err)
+	}
 	if newGen != 1 {
 		t.Fatalf("NextGeneration() = %d, want 1", newGen)
 	}
@@ -65,7 +68,9 @@ func TestSequenceAllocator_State_Restore_RoundTrip(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	a.NextGeneration()
+	if _, err := a.NextGeneration(); err != nil {
+		t.Fatal(err)
+	}
 	if _, _, err := a.Next(); err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +82,9 @@ func TestSequenceAllocator_State_Restore_RoundTrip(t *testing.T) {
 	}
 
 	b := NewSequenceAllocator()
-	b.Restore(state)
+	if err := b.Restore(state); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
 	seq, gen, err := b.Next()
 	if err != nil {
 		t.Fatalf("Next after Restore: %v", err)
@@ -89,7 +96,9 @@ func TestSequenceAllocator_State_Restore_RoundTrip(t *testing.T) {
 
 func TestSequenceAllocator_Overflow(t *testing.T) {
 	a := NewSequenceAllocator()
-	a.Restore(AllocatorState{Sequence: math.MaxInt64, Generation: 0})
+	if err := a.Restore(AllocatorState{Sequence: math.MaxInt64, Generation: 0}); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
 
 	_, _, err := a.Next()
 	if !errors.Is(err, ErrSequenceOverflow) {
@@ -131,5 +140,69 @@ func TestSequenceAllocator_ConcurrentNext_NoDuplicates(t *testing.T) {
 	}
 	if len(seen) != workers*perWorker {
 		t.Fatalf("got %d unique sequences, want %d", len(seen), workers*perWorker)
+	}
+}
+
+func TestSequenceAllocator_NextGeneration_Overflow(t *testing.T) {
+	a := NewSequenceAllocator()
+	if err := a.Restore(AllocatorState{Sequence: -1, Generation: math.MaxUint32}); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	_, err := a.NextGeneration()
+	if !errors.Is(err, ErrGenerationOverflow) {
+		t.Fatalf("NextGeneration at MaxUint32: err = %v, want ErrGenerationOverflow", err)
+	}
+
+	// Allocator must not be mutated by a rejected NextGeneration.
+	state := a.State()
+	if state.Generation != math.MaxUint32 {
+		t.Fatalf("Generation mutated after rejected NextGeneration: got %d, want MaxUint32", state.Generation)
+	}
+	if state.Sequence != -1 {
+		t.Fatalf("Sequence mutated after rejected NextGeneration: got %d, want -1", state.Sequence)
+	}
+
+	// Sequences in the current (max) generation must still allocate cleanly.
+	seq, gen, err := a.Next()
+	if err != nil {
+		t.Fatalf("Next after rejected NextGeneration: %v", err)
+	}
+	if seq != 0 || gen != math.MaxUint32 {
+		t.Fatalf("Next at max generation: got (%d, %d), want (0, MaxUint32)", seq, gen)
+	}
+}
+
+func TestSequenceAllocator_Restore_RejectsInvalidSequence(t *testing.T) {
+	a := NewSequenceAllocator()
+	// Allocate one tuple so we have non-default state to verify we don't perturb on reject.
+	if _, _, err := a.Next(); err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	pre := a.State()
+
+	for _, bad := range []int64{-2, -100, math.MinInt64} {
+		err := a.Restore(AllocatorState{Sequence: bad, Generation: 5})
+		if !errors.Is(err, ErrInvalidAllocatorState) {
+			t.Fatalf("Restore(Sequence=%d): err = %v, want ErrInvalidAllocatorState", bad, err)
+		}
+	}
+
+	// Allocator must be unchanged after rejected restores.
+	post := a.State()
+	if post != pre {
+		t.Fatalf("allocator mutated by rejected Restore: pre=%+v, post=%+v", pre, post)
+	}
+
+	// Boundary: Sequence == -1 is the valid minimum (means "no Next() yet").
+	if err := a.Restore(AllocatorState{Sequence: -1, Generation: 9}); err != nil {
+		t.Fatalf("Restore(Sequence=-1): %v", err)
+	}
+	seq, gen, err := a.Next()
+	if err != nil {
+		t.Fatalf("Next after Restore(-1, 9): %v", err)
+	}
+	if seq != 0 || gen != 9 {
+		t.Fatalf("after Restore(-1, 9): Next() = (%d, %d), want (0, 9)", seq, gen)
 	}
 }

--- a/internal/audit/sink_chain.go
+++ b/internal/audit/sink_chain.go
@@ -376,6 +376,15 @@ func (c *SinkChain) Restore(generation uint32, prevHash string, fatal bool) erro
 	return nil
 }
 
+// keyAndAlgorithm exposes the chain's key and algorithm for legacy
+// IntegrityChain delegation. NOT part of the public Phase 0 contract;
+// future code should use Compute and never reach for raw key material.
+func (c *SinkChain) keyAndAlgorithm() ([]byte, string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.key, c.algorithm
+}
+
 // validatePrevHash returns nil if prevHash is empty (genesis) or a valid
 // hex string of the algorithm's expected output length. Otherwise it
 // returns an error wrapping ErrInvalidChainState.

--- a/internal/audit/sink_chain.go
+++ b/internal/audit/sink_chain.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"sync"
@@ -14,10 +15,15 @@ import (
 // keys produces different entryHash values — that is the entire point of
 // per-sink chaining.
 //
-// Concurrency-safe. Compute+Commit pairs must be issued by a single
-// goroutine in order; concurrent Compute calls with interleaved Commits
-// is supported but each Commit applies to the most recent Compute that
-// observed the same prev_hash.
+// Concurrency model: single-owner serialized use. SinkChain is mutex-safe,
+// and concurrent Compute calls (with no intervening Commit) are pure and
+// return identical results — they do not corrupt state. However, callers
+// MUST NOT interleave Compute/Commit pairs across goroutines: Commit
+// carries no token identifying which Compute it finalizes, so a stale or
+// reordered Commit can overwrite prev_hash with a hash that does not
+// correspond to the most recent Compute. The expected pattern is a single
+// owner that issues Compute → durable write → Commit (or Fatal) in
+// sequence per event.
 type SinkChain struct {
 	mu         sync.Mutex
 	key        []byte
@@ -30,9 +36,14 @@ type SinkChain struct {
 // SinkChainState is the persistent state of a SinkChain. The spec calls
 // this ChainState; renamed here to avoid colliding with the existing
 // audit.ChainState used by IntegrityChain.State().
+//
+// Fatal is included so persistence round-trips preserve the latch — a
+// chain that latched Fatal before a restart must come back latched after
+// Restore, otherwise the safety model is defeated.
 type SinkChainState struct {
 	Generation uint32
 	PrevHash   string
+	Fatal      bool
 }
 
 // ErrFatalIntegrity is returned by Compute after Fatal has been called.
@@ -45,6 +56,12 @@ var ErrFatalIntegrity = errors.New("integrity chain latched fatal; sink must be 
 // configurations with chained sinks must always run inside a composite
 // with a SequenceAllocator.
 var ErrMissingChainState = errors.New("event missing Chain field; composite did not stamp it")
+
+// ErrInvalidChainState is returned by Restore when the supplied state
+// violates SinkChain invariants (e.g., prevHash is neither empty nor a
+// hex string of the algorithm's expected length). The chain is not
+// modified on rejected restore.
+var ErrInvalidChainState = errors.New("invalid sink chain state")
 
 // NewSinkChain creates a new chain keyed by `key` (must be >= MinKeyLength).
 // Supported algorithms: "hmac-sha256" (default), "hmac-sha512".
@@ -96,10 +113,19 @@ func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32
 // succeeds. On ambiguous failure (write may or may not have landed), the
 // caller MUST call Fatal instead; Commit and Fatal are mutually exclusive
 // per Compute.
+//
+// Commit silently no-ops in two cases: (1) the chain has been latched Fatal,
+// and (2) `generation` is older than the chain's current generation —
+// rolling backwards across a generation boundary would re-use prior
+// (sequence, generation) tuples and corrupt the chain. The latter is a
+// caller programming error and is treated as ignorable rather than fatal.
 func (c *SinkChain) Commit(generation uint32, entryHash string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.fatal {
+		return
+	}
+	if generation < c.generation {
 		return
 	}
 	c.generation = generation
@@ -117,17 +143,53 @@ func (c *SinkChain) Fatal(reason error) {
 	_ = reason // reserved for future telemetry; intentionally unused
 }
 
-// State returns the (generation, prev_hash) for persistence.
+// State returns the (generation, prev_hash, fatal) for persistence.
 func (c *SinkChain) State() SinkChainState {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return SinkChainState{Generation: c.generation, PrevHash: c.prevHash}
+	return SinkChainState{Generation: c.generation, PrevHash: c.prevHash, Fatal: c.fatal}
 }
 
-// Restore rehydrates chain state after restart.
-func (c *SinkChain) Restore(generation uint32, prevHash string) {
+// Restore rehydrates chain state after restart. Returns ErrInvalidChainState
+// if `prevHash` is neither empty (genesis) nor a hex string whose decoded
+// length matches the chain's algorithm output (32 bytes for hmac-sha256,
+// 64 bytes for hmac-sha512). The chain is not modified on rejected restore.
+//
+// If `fatal` is true, the chain comes back latched: subsequent Compute calls
+// return ErrFatalIntegrity. This is required so persistence round-trips
+// preserve the safety latch across restarts.
+func (c *SinkChain) Restore(generation uint32, prevHash string, fatal bool) error {
+	if err := validatePrevHash(c.algorithm, prevHash); err != nil {
+		return err
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.generation = generation
 	c.prevHash = prevHash
+	c.fatal = fatal
+	return nil
+}
+
+// validatePrevHash returns nil if prevHash is empty (genesis) or a valid
+// hex string of the algorithm's expected output length. Otherwise it
+// returns an error wrapping ErrInvalidChainState.
+func validatePrevHash(algorithm, prevHash string) error {
+	if prevHash == "" {
+		return nil
+	}
+	var wantBytes int
+	switch algorithm {
+	case "hmac-sha512":
+		wantBytes = 64
+	default: // hmac-sha256 (also default when algorithm == "")
+		wantBytes = 32
+	}
+	wantHex := wantBytes * 2
+	if len(prevHash) != wantHex {
+		return fmt.Errorf("%w: prevHash length %d, want %d hex chars for %s", ErrInvalidChainState, len(prevHash), wantHex, algorithm)
+	}
+	if _, err := hex.DecodeString(prevHash); err != nil {
+		return fmt.Errorf("%w: prevHash is not valid hex: %v", ErrInvalidChainState, err)
+	}
+	return nil
 }

--- a/internal/audit/sink_chain.go
+++ b/internal/audit/sink_chain.go
@@ -26,36 +26,27 @@ import (
 // Compute → durable write → Commit (or Fatal) in sequence per event.
 //
 // Compute/Commit token contract: Compute returns a *ComputeResult that
-// callers MUST pass to Commit unchanged. The unexported fields on
-// ComputeResult let Commit verify the result really came from Compute on
-// this chain. Callers cannot construct a ComputeResult literal because
-// the unexported fields make that impossible from outside the audit
-// package; this prevents Commit from accepting a fabricated EntryHash
-// that Compute would never have produced.
+// callers MUST pass to Commit unchanged. ComputeResult is opaque
+// (unexported fields, accessor methods) and chain-bound — only the
+// SinkChain instance that produced the result can commit it. The
+// unexported fields make literal construction or post-Compute mutation
+// impossible from outside the audit package.
 //
-// Contract — what SinkChain enforces:
+// Enforced invariants on Commit:
+//   - nil ComputeResult → error (no latch).
+//   - Post-Fatal Commit → ErrFatalIntegrity (no further latch).
+//   - Cross-chain ComputeResult (one produced by a different SinkChain
+//     instance) → ErrCrossChainResult, latches fatal on this chain.
+//   - Backwards generation → ErrBackwardsGeneration, latches fatal.
+//   - Stale prev_hash within the current generation, or non-empty prev_hash
+//     on a rollover commit → ErrStaleResult, latches fatal.
+//   - Otherwise, generation and prev_hash advance.
 //
-//   - Commit(nil) returns an error and does NOT latch fatal (the chain is
-//     unmodified; this is a caller bug, not an integrity divergence).
-//   - Commit on a chain that was previously latched Fatal (via Fatal or via
-//     a prior backwards/stale Commit) returns ErrFatalIntegrity. The chain
-//     stays latched.
-//   - Commit with a result whose generation < c.generation latches fatal
-//     and returns an error wrapping ErrBackwardsGeneration. This indicates
-//     the durable write succeeded for an entry whose generation is no
-//     longer current; accepting it would silently corrupt subsequent
-//     Compute results.
-//   - Commit with a result whose generation == c.generation but whose
-//     PrevHash != c.prevHash latches fatal and returns an error wrapping
-//     ErrStaleResult. The result was computed against a chain head that has
-//     since been advanced by a successful prior Commit; accepting it would
-//     silently fork the chain.
-//   - Commit with a result whose generation > c.generation (rollover)
-//     requires PrevHash == "" (because Compute always uses prev="" when
-//     rolling). A non-empty PrevHash on a rollover result latches fatal
-//     and returns an error wrapping ErrStaleResult. This branch is
-//     defense-in-depth: normal callers cannot construct such a result via
-//     the public Compute API.
+// ComputeResult is opaque (unexported fields, accessor methods) and
+// chain-bound (cannot be committed on a different SinkChain). Callers that
+// need to serialize a result use EntryHash() and PrevHash(). The
+// unexported (sequence, generation, chain) fields make it impossible to
+// fabricate or cross-mix tokens outside the audit package.
 //
 // Contract — what remains the caller's responsibility:
 //
@@ -108,34 +99,27 @@ type SinkChainState struct {
 	Fatal      bool
 }
 
-// ComputeResult is the typed output of SinkChain.Compute. It is the only
-// value Commit will accept. The exported fields are inspectable; the
-// unexported fields let Commit verify it really came out of Compute and
-// that no impossible state transition is being requested.
+// ComputeResult is the opaque, chain-bound output of SinkChain.Compute. It is
+// the only value Commit will accept, and only the SinkChain instance that
+// produced it can commit it. Fields are unexported so callers cannot mutate
+// or fabricate one outside the audit package.
 //
-// Callers MUST NOT construct ComputeResult literals — only Compute returns
-// valid ones. The unexported fields make literal construction impossible
-// outside the audit package; that is load-bearing for the chain-state
-// invariants Commit enforces.
+// Use EntryHash() and PrevHash() to inspect the values for serialization.
 type ComputeResult struct {
-	// EntryHash is the HMAC of (formatVersion | sequence | prevHash |
-	// payload) under the chain's key. Inspectable — callers serialize this
-	// into the entry's integrity metadata.
-	EntryHash string
-
-	// PrevHash is the prev_hash that was hashed into EntryHash. For the
-	// first entry of a chain (or the first entry after a generation
-	// rollover) this is the empty string. Inspectable — callers serialize
-	// this into the entry's integrity metadata.
-	PrevHash string
-
-	// sequence and generation are unexported so external packages cannot
-	// fabricate a ComputeResult with arbitrary state. Commit reads these
-	// to enforce chain-state invariants (e.g., backwards-generation Commit
-	// is a caller bug and latches fatal).
+	entryHash  string
+	prevHash   string
 	sequence   int64
 	generation uint32
+	chain      *SinkChain // identity-bound; Commit verifies result.chain == c
 }
+
+// EntryHash returns the HMAC entry hash that should be persisted alongside
+// the payload for later integrity verification.
+func (r *ComputeResult) EntryHash() string { return r.entryHash }
+
+// PrevHash returns the prev_hash the entry was chained against. For the
+// genesis entry of a chain or generation, this is "".
+func (r *ComputeResult) PrevHash() string { return r.prevHash }
 
 // ErrFatalIntegrity is returned by Compute after Fatal has been called,
 // and by Commit when called on a chain that was latched Fatal (either by
@@ -175,6 +159,13 @@ var ErrBackwardsGeneration = errors.New("backwards-generation Commit: chain latc
 // result would fork the chain.
 var ErrStaleResult = errors.New("stale ComputeResult: caller committed against an obsolete chain head; chain latched fatal")
 
+// ErrCrossChainResult is wrapped by Commit when the supplied ComputeResult
+// was produced by a different SinkChain instance. The misuse latches fatal
+// on the receiving chain so the programming error becomes loud rather than
+// silently corrupting state. The chain that produced the result is
+// unaffected.
+var ErrCrossChainResult = errors.New("ComputeResult bound to a different SinkChain")
+
 // NewSinkChain creates a new chain keyed by `key` (must be >= MinKeyLength).
 // Supported algorithms: "hmac-sha256" (default), "hmac-sha512".
 func NewSinkChain(key []byte, algorithm string) (*SinkChain, error) {
@@ -199,6 +190,10 @@ func NewSinkChain(key []byte, algorithm string) (*SinkChain, error) {
 // (passing the returned *ComputeResult) on durable-write success or
 // discard the result on durable-write failure.
 //
+// The returned *ComputeResult is bound to this SinkChain instance — only
+// Commit on this same chain will accept it. Cross-chain commits fail with
+// ErrCrossChainResult and latch the receiving chain fatal.
+//
 // If `generation` differs from the chain's current generation, prev_hash
 // is treated as "" for this Compute (chain rolls automatically). The
 // transition is committed only when Commit is called with a result whose
@@ -220,10 +215,11 @@ func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32
 		return nil, err
 	}
 	return &ComputeResult{
-		EntryHash:  hash,
-		PrevHash:   prev,
+		entryHash:  hash,
+		prevHash:   prev,
 		sequence:   sequence,
 		generation: generation,
+		chain:      c,
 	}, nil
 }
 
@@ -237,7 +233,15 @@ func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32
 //
 // Returns ErrFatalIntegrity if the chain was previously latched Fatal —
 // either by an explicit Fatal call, by a prior backwards-generation
-// Commit, or by a prior stale-result Commit. The chain stays latched.
+// Commit, by a prior stale-result Commit, or by a prior cross-chain
+// Commit. The chain stays latched.
+//
+// Returns an error wrapping ErrCrossChainResult AND latches the chain
+// Fatal if the supplied ComputeResult was produced by a different
+// SinkChain instance. The cross-chain check runs BEFORE
+// generation/prev_hash validation so that mixing tokens between chains is
+// always reported as a cross-chain error rather than as a downstream
+// invariant violation.
 //
 // Returns an error wrapping ErrBackwardsGeneration AND latches the chain
 // Fatal if the result's generation is older than the chain's current
@@ -265,6 +269,13 @@ func (c *SinkChain) Commit(result *ComputeResult) error {
 	if c.fatal {
 		return ErrFatalIntegrity
 	}
+	// Cross-chain check runs first so that mixing tokens between chains
+	// always surfaces as ErrCrossChainResult, not as a downstream
+	// generation/prev_hash invariant violation.
+	if result.chain != c {
+		c.fatal = true
+		return fmt.Errorf("%w", ErrCrossChainResult)
+	}
 	if result.generation < c.generation {
 		c.fatal = true
 		return fmt.Errorf("%w: result.generation=%d < c.generation=%d",
@@ -272,28 +283,28 @@ func (c *SinkChain) Commit(result *ComputeResult) error {
 	}
 	// Stale-token detection — fatal latch.
 	// Two cases:
-	//   * result.generation == c.generation: result.PrevHash MUST equal
+	//   * result.generation == c.generation: result.prevHash MUST equal
 	//     c.prevHash. Mismatch means the caller computed against an older
 	//     chain head and is replaying a stale token.
 	//   * result.generation > c.generation: this is a rollover commit. The
-	//     result MUST have PrevHash == "" because Compute used "" for the
+	//     result MUST have prevHash == "" because Compute used "" for the
 	//     rolled gen. Anything else means the result was forged or computed
 	//     against mismatched state.
 	if result.generation == c.generation {
-		if result.PrevHash != c.prevHash {
+		if result.prevHash != c.prevHash {
 			c.fatal = true
 			return fmt.Errorf("%w: result.prev_hash=%q, current prev_hash=%q",
-				ErrStaleResult, result.PrevHash, c.prevHash)
+				ErrStaleResult, result.prevHash, c.prevHash)
 		}
 	} else { // result.generation > c.generation (rollover)
-		if result.PrevHash != "" {
+		if result.prevHash != "" {
 			c.fatal = true
 			return fmt.Errorf("%w: rollover commit must have empty prev_hash; got %q",
-				ErrStaleResult, result.PrevHash)
+				ErrStaleResult, result.prevHash)
 		}
 	}
 	c.generation = result.generation
-	c.prevHash = result.EntryHash
+	c.prevHash = result.entryHash
 	return nil
 }
 

--- a/internal/audit/sink_chain.go
+++ b/internal/audit/sink_chain.go
@@ -32,6 +32,60 @@ import (
 // the unexported fields make that impossible from outside the audit
 // package; this prevents Commit from accepting a fabricated EntryHash
 // that Compute would never have produced.
+//
+// Contract — what SinkChain enforces:
+//
+//   - Commit(nil) returns an error and does NOT latch fatal (the chain is
+//     unmodified; this is a caller bug, not an integrity divergence).
+//   - Commit on a chain that was previously latched Fatal (via Fatal or via
+//     a prior backwards/stale Commit) returns ErrFatalIntegrity. The chain
+//     stays latched.
+//   - Commit with a result whose generation < c.generation latches fatal
+//     and returns an error wrapping ErrBackwardsGeneration. This indicates
+//     the durable write succeeded for an entry whose generation is no
+//     longer current; accepting it would silently corrupt subsequent
+//     Compute results.
+//   - Commit with a result whose generation == c.generation but whose
+//     PrevHash != c.prevHash latches fatal and returns an error wrapping
+//     ErrStaleResult. The result was computed against a chain head that has
+//     since been advanced by a successful prior Commit; accepting it would
+//     silently fork the chain.
+//   - Commit with a result whose generation > c.generation (rollover)
+//     requires PrevHash == "" (because Compute always uses prev="" when
+//     rolling). A non-empty PrevHash on a rollover result latches fatal
+//     and returns an error wrapping ErrStaleResult. This branch is
+//     defense-in-depth: normal callers cannot construct such a result via
+//     the public Compute API.
+//
+// Contract — what remains the caller's responsibility:
+//
+//   - Serialize Compute → durable write → Commit per record. SinkChain
+//     does NOT detect concurrent overlapping Compute/Commit pairs from
+//     multiple goroutines; the (sequence, generation) tuple is not a
+//     unique identifier within a generation.
+//   - Do not concurrently Compute+Commit across goroutines. Commit only
+//     validates the result against the chain's CURRENT prev_hash; if two
+//     goroutines race a Compute → Commit pair, the second Commit will
+//     either appear stale (good — caught) or appear fresh (bad — silently
+//     accepted) depending on interleaving. The single-owner pattern is
+//     the only safe one.
+//   - Only call Commit with a result whose durable write actually
+//     succeeded. SinkChain has no knowledge of durable state; Commit on a
+//     result whose write failed silently advances the in-memory chain
+//     past an entry that does not exist in storage.
+//
+// Recovery — a fatal latch makes the SinkChain instance unusable:
+//
+//   - All subsequent Compute calls return ErrFatalIntegrity.
+//   - All subsequent Commit calls return ErrFatalIntegrity.
+//   - The latch survives State()/Restore() round-trips (Fatal is part of
+//     SinkChainState).
+//   - The instance must be recreated via NewSinkChain (and a fresh
+//     generation established externally — typically by rotating the
+//     chain key and bumping the SequenceAllocator's generation, then
+//     wiring a fresh SinkChain into the sink). There is no in-place
+//     reset method by design: a fatal latch indicates an integrity
+//     event the operator must observe.
 type SinkChain struct {
 	mu         sync.Mutex
 	key        []byte
@@ -101,6 +155,26 @@ var ErrMissingChainState = errors.New("event missing Chain field; composite did 
 // modified on rejected restore.
 var ErrInvalidChainState = errors.New("invalid sink chain state")
 
+// ErrBackwardsGeneration is wrapped by Commit when the result's generation
+// is older than the chain's current generation. Latches the chain fatal:
+// the durable write succeeded for an entry whose generation is no longer
+// current, so silently accepting it would leave in-memory prev_hash
+// lagging the durable state and corrupt subsequent Compute results.
+var ErrBackwardsGeneration = errors.New("backwards-generation Commit: chain latched fatal")
+
+// ErrStaleResult is wrapped by Commit when the result was computed against
+// an obsolete chain head. Two cases:
+//
+//   - same-generation: result.PrevHash != c.prevHash (a prior Commit
+//     advanced prev_hash between this result's Compute and Commit).
+//   - rollover: result.generation > c.generation but result.PrevHash != ""
+//     (rollover results MUST have empty PrevHash; this branch is
+//     defense-in-depth).
+//
+// In either case the chain latches fatal: silently accepting the stale
+// result would fork the chain.
+var ErrStaleResult = errors.New("stale ComputeResult: caller committed against an obsolete chain head; chain latched fatal")
+
 // NewSinkChain creates a new chain keyed by `key` (must be >= MinKeyLength).
 // Supported algorithms: "hmac-sha256" (default), "hmac-sha512".
 func NewSinkChain(key []byte, algorithm string) (*SinkChain, error) {
@@ -162,16 +236,26 @@ func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32
 // Returns an error if `result` is nil (caller bug; chain is not modified).
 //
 // Returns ErrFatalIntegrity if the chain was previously latched Fatal —
-// either by an explicit Fatal call or by a prior backwards-generation
-// Commit. The chain stays latched.
+// either by an explicit Fatal call, by a prior backwards-generation
+// Commit, or by a prior stale-result Commit. The chain stays latched.
 //
-// Returns a non-nil error AND latches the chain Fatal if the result's
-// generation is older than the chain's current generation. This indicates
-// a caller bug: the durable write succeeded for an entry whose generation
-// is no longer current, so accepting the Commit would leave in-memory
-// prev_hash lagging the durable state and silently corrupt subsequent
-// Compute results. Latching fatal makes the divergence visible
-// immediately rather than later as a chain-break.
+// Returns an error wrapping ErrBackwardsGeneration AND latches the chain
+// Fatal if the result's generation is older than the chain's current
+// generation. Accepting it would leave in-memory prev_hash lagging the
+// durable state and silently corrupt subsequent Compute results.
+//
+// Returns an error wrapping ErrStaleResult AND latches the chain Fatal in
+// two cases that both indicate the result was computed against an
+// obsolete chain head:
+//
+//   - result.generation == c.generation and result.PrevHash != c.prevHash:
+//     a prior Commit advanced prev_hash between this result's Compute and
+//     Commit. Silently accepting would fork the chain.
+//   - result.generation > c.generation and result.PrevHash != "": rollover
+//     results MUST have empty PrevHash (Compute always sets prev="" on
+//     rollover). A non-empty PrevHash here means the result was forged or
+//     computed against mismatched state. Defense-in-depth: normal callers
+//     cannot construct this via the public API.
 func (c *SinkChain) Commit(result *ComputeResult) error {
 	if result == nil {
 		return errors.New("nil ComputeResult")
@@ -183,8 +267,30 @@ func (c *SinkChain) Commit(result *ComputeResult) error {
 	}
 	if result.generation < c.generation {
 		c.fatal = true
-		return fmt.Errorf("backwards generation Commit: result.generation=%d < c.generation=%d (caller bug, chain latched fatal)",
-			result.generation, c.generation)
+		return fmt.Errorf("%w: result.generation=%d < c.generation=%d",
+			ErrBackwardsGeneration, result.generation, c.generation)
+	}
+	// Stale-token detection — fatal latch.
+	// Two cases:
+	//   * result.generation == c.generation: result.PrevHash MUST equal
+	//     c.prevHash. Mismatch means the caller computed against an older
+	//     chain head and is replaying a stale token.
+	//   * result.generation > c.generation: this is a rollover commit. The
+	//     result MUST have PrevHash == "" because Compute used "" for the
+	//     rolled gen. Anything else means the result was forged or computed
+	//     against mismatched state.
+	if result.generation == c.generation {
+		if result.PrevHash != c.prevHash {
+			c.fatal = true
+			return fmt.Errorf("%w: result.prev_hash=%q, current prev_hash=%q",
+				ErrStaleResult, result.PrevHash, c.prevHash)
+		}
+	} else { // result.generation > c.generation (rollover)
+		if result.PrevHash != "" {
+			c.fatal = true
+			return fmt.Errorf("%w: rollover commit must have empty prev_hash; got %q",
+				ErrStaleResult, result.PrevHash)
+		}
 	}
 	c.generation = result.generation
 	c.prevHash = result.EntryHash

--- a/internal/audit/sink_chain.go
+++ b/internal/audit/sink_chain.go
@@ -30,7 +30,9 @@ import (
 // (unexported fields, accessor methods) and chain-bound — only the
 // SinkChain instance that produced the result can commit it. The
 // unexported fields make literal construction or post-Compute mutation
-// impossible from outside the audit package.
+// impossible from outside the audit package. Callers that need to persist
+// the integrity metadata alongside the payload use EntryHash() and
+// PrevHash(); see the lifecycle note below.
 //
 // Enforced invariants on Commit:
 //   - nil ComputeResult → error (no latch).
@@ -41,12 +43,6 @@ import (
 //   - Stale prev_hash within the current generation, or non-empty prev_hash
 //     on a rollover commit → ErrStaleResult, latches fatal.
 //   - Otherwise, generation and prev_hash advance.
-//
-// ComputeResult is opaque (unexported fields, accessor methods) and
-// chain-bound (cannot be committed on a different SinkChain). Callers that
-// need to serialize a result use EntryHash() and PrevHash(). The
-// unexported (sequence, generation, chain) fields make it impossible to
-// fabricate or cross-mix tokens outside the audit package.
 //
 // Contract — what remains the caller's responsibility:
 //
@@ -64,6 +60,23 @@ import (
 //     succeeded. SinkChain has no knowledge of durable state; Commit on a
 //     result whose write failed silently advances the in-memory chain
 //     past an entry that does not exist in storage.
+//
+// Lifecycle / serialization boundary:
+//
+// A ComputeResult is bound to the in-memory SinkChain instance that
+// produced it (chain-bound by pointer identity). It cannot be durably
+// stored and committed later: a SinkChain reconstructed via NewSinkChain
+// + Restore is a new instance and will reject prior tokens with
+// ErrCrossChainResult. This is intentional — Compute and Commit are
+// designed to be co-located in a single process, with the durable write
+// of the integrity metadata happening between them.
+//
+// EntryHash() and PrevHash() exist so that callers can persist the
+// integrity metadata alongside the payload for later VerifyHash. They are
+// NOT the input shape for reconstructing a Commit token across process
+// boundaries — there is no such API and no such need; the chain itself
+// remembers what it has committed via prev_hash, and VerifyHash
+// re-derives entry hashes from the persisted metadata.
 //
 // Recovery — a fatal latch makes the SinkChain instance unusable:
 //
@@ -105,6 +118,23 @@ type SinkChainState struct {
 // or fabricate one outside the audit package.
 //
 // Use EntryHash() and PrevHash() to inspect the values for serialization.
+//
+// Lifecycle / serialization boundary:
+//
+// A ComputeResult is bound to the in-memory SinkChain instance that
+// produced it (chain-bound by pointer identity). It cannot be durably
+// stored and committed later: a SinkChain reconstructed via NewSinkChain
+// + Restore is a new instance and will reject prior tokens with
+// ErrCrossChainResult. This is intentional — Compute and Commit are
+// designed to be co-located in a single process, with the durable write
+// of the integrity metadata happening between them.
+//
+// EntryHash() and PrevHash() exist so that callers can persist the
+// integrity metadata alongside the payload for later VerifyHash. They are
+// NOT the input shape for reconstructing a Commit token across process
+// boundaries — there is no such API and no such need; the chain itself
+// remembers what it has committed via prev_hash, and VerifyHash
+// re-derives entry hashes from the persisted metadata.
 type ComputeResult struct {
 	entryHash  string
 	prevHash   string

--- a/internal/audit/sink_chain.go
+++ b/internal/audit/sink_chain.go
@@ -19,11 +19,19 @@ import (
 // and concurrent Compute calls (with no intervening Commit) are pure and
 // return identical results — they do not corrupt state. However, callers
 // MUST NOT interleave Compute/Commit pairs across goroutines: Commit
-// carries no token identifying which Compute it finalizes, so a stale or
-// reordered Commit can overwrite prev_hash with a hash that does not
-// correspond to the most recent Compute. The expected pattern is a single
-// owner that issues Compute → durable write → Commit (or Fatal) in
-// sequence per event.
+// consumes a typed *ComputeResult and validates the result's generation
+// against the chain's current generation, but the (sequence, generation)
+// tuple alone does not identify which Compute call produced it within the
+// same generation. The expected pattern is a single owner that issues
+// Compute → durable write → Commit (or Fatal) in sequence per event.
+//
+// Compute/Commit token contract: Compute returns a *ComputeResult that
+// callers MUST pass to Commit unchanged. The unexported fields on
+// ComputeResult let Commit verify the result really came from Compute on
+// this chain. Callers cannot construct a ComputeResult literal because
+// the unexported fields make that impossible from outside the audit
+// package; this prevents Commit from accepting a fabricated EntryHash
+// that Compute would never have produced.
 type SinkChain struct {
 	mu         sync.Mutex
 	key        []byte
@@ -46,9 +54,39 @@ type SinkChainState struct {
 	Fatal      bool
 }
 
-// ErrFatalIntegrity is returned by Compute after Fatal has been called.
-// The chain cannot be reused; the sink must be reinitialized (e.g., via
-// generation rotation).
+// ComputeResult is the typed output of SinkChain.Compute. It is the only
+// value Commit will accept. The exported fields are inspectable; the
+// unexported fields let Commit verify it really came out of Compute and
+// that no impossible state transition is being requested.
+//
+// Callers MUST NOT construct ComputeResult literals — only Compute returns
+// valid ones. The unexported fields make literal construction impossible
+// outside the audit package; that is load-bearing for the chain-state
+// invariants Commit enforces.
+type ComputeResult struct {
+	// EntryHash is the HMAC of (formatVersion | sequence | prevHash |
+	// payload) under the chain's key. Inspectable — callers serialize this
+	// into the entry's integrity metadata.
+	EntryHash string
+
+	// PrevHash is the prev_hash that was hashed into EntryHash. For the
+	// first entry of a chain (or the first entry after a generation
+	// rollover) this is the empty string. Inspectable — callers serialize
+	// this into the entry's integrity metadata.
+	PrevHash string
+
+	// sequence and generation are unexported so external packages cannot
+	// fabricate a ComputeResult with arbitrary state. Commit reads these
+	// to enforce chain-state invariants (e.g., backwards-generation Commit
+	// is a caller bug and latches fatal).
+	sequence   int64
+	generation uint32
+}
+
+// ErrFatalIntegrity is returned by Compute after Fatal has been called,
+// and by Commit when called on a chain that was latched Fatal (either by
+// Fatal itself or by a backwards-generation Commit). The chain cannot be
+// reused; the sink must be reinitialized (e.g., via generation rotation).
 var ErrFatalIntegrity = errors.New("integrity chain latched fatal; sink must be reinitialized")
 
 // ErrMissingChainState is returned by chained sinks when an event arrives
@@ -82,20 +120,22 @@ func NewSinkChain(key []byte, algorithm string) (*SinkChain, error) {
 }
 
 // Compute computes the HMAC of (formatVersion, sequence, prev_hash, payload)
-// using the chain's key. Compute is PURE: it does not mutate prev_hash. The
-// caller must follow with Commit on durable-write success or discard the
-// result on durable-write failure.
+// using the chain's key and returns it as a *ComputeResult. Compute is
+// PURE: it does not mutate prev_hash. The caller must follow with Commit
+// (passing the returned *ComputeResult) on durable-write success or
+// discard the result on durable-write failure.
 //
 // If `generation` differs from the chain's current generation, prev_hash
 // is treated as "" for this Compute (chain rolls automatically). The
-// transition is committed only when Commit is called with the new generation.
+// transition is committed only when Commit is called with a result whose
+// generation is the new generation.
 //
 // Returns ErrFatalIntegrity if Fatal was previously called.
-func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32, payload []byte) (entryHash string, prevHash string, err error) {
+func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32, payload []byte) (*ComputeResult, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.fatal {
-		return "", "", ErrFatalIntegrity
+		return nil, ErrFatalIntegrity
 	}
 	prev := c.prevHash
 	if generation != c.generation {
@@ -103,33 +143,52 @@ func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32
 	}
 	hash, err := computeIntegrityHash(c.key, c.algorithm, formatVersion, sequence, prev, payload)
 	if err != nil {
-		return "", "", err
+		return nil, err
 	}
-	return hash, prev, nil
+	return &ComputeResult{
+		EntryHash:  hash,
+		PrevHash:   prev,
+		sequence:   sequence,
+		generation: generation,
+	}, nil
 }
 
-// Commit advances prev_hash to entryHash and records the generation. Must be
-// called exactly once per successful Compute, after the durable write
-// succeeds. On ambiguous failure (write may or may not have landed), the
-// caller MUST call Fatal instead; Commit and Fatal are mutually exclusive
-// per Compute.
+// Commit advances prev_hash using the result of a previous Compute on this
+// chain. Must be called exactly once per successful Compute, after the
+// durable write succeeds. On ambiguous failure (write may or may not have
+// landed), the caller MUST call Fatal instead; Commit and Fatal are
+// mutually exclusive per Compute.
 //
-// Commit silently no-ops in two cases: (1) the chain has been latched Fatal,
-// and (2) `generation` is older than the chain's current generation —
-// rolling backwards across a generation boundary would re-use prior
-// (sequence, generation) tuples and corrupt the chain. The latter is a
-// caller programming error and is treated as ignorable rather than fatal.
-func (c *SinkChain) Commit(generation uint32, entryHash string) {
+// Returns an error if `result` is nil (caller bug; chain is not modified).
+//
+// Returns ErrFatalIntegrity if the chain was previously latched Fatal —
+// either by an explicit Fatal call or by a prior backwards-generation
+// Commit. The chain stays latched.
+//
+// Returns a non-nil error AND latches the chain Fatal if the result's
+// generation is older than the chain's current generation. This indicates
+// a caller bug: the durable write succeeded for an entry whose generation
+// is no longer current, so accepting the Commit would leave in-memory
+// prev_hash lagging the durable state and silently corrupt subsequent
+// Compute results. Latching fatal makes the divergence visible
+// immediately rather than later as a chain-break.
+func (c *SinkChain) Commit(result *ComputeResult) error {
+	if result == nil {
+		return errors.New("nil ComputeResult")
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.fatal {
-		return
+		return ErrFatalIntegrity
 	}
-	if generation < c.generation {
-		return
+	if result.generation < c.generation {
+		c.fatal = true
+		return fmt.Errorf("backwards generation Commit: result.generation=%d < c.generation=%d (caller bug, chain latched fatal)",
+			result.generation, c.generation)
 	}
-	c.generation = generation
-	c.prevHash = entryHash
+	c.generation = result.generation
+	c.prevHash = result.EntryHash
+	return nil
 }
 
 // Fatal latches the chain in an unrecoverable state. All subsequent Compute

--- a/internal/audit/sink_chain.go
+++ b/internal/audit/sink_chain.go
@@ -1,0 +1,133 @@
+package audit
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// SinkChain owns prev_hash for one sink. Each chained sink holds one.
+// Compute is pure (no mutation); Commit advances prev_hash; Fatal latches
+// the chain after an ambiguous durable-write failure.
+//
+// The same (formatVersion, sequence, prevHash, payload) under different
+// keys produces different entryHash values — that is the entire point of
+// per-sink chaining.
+//
+// Concurrency-safe. Compute+Commit pairs must be issued by a single
+// goroutine in order; concurrent Compute calls with interleaved Commits
+// is supported but each Commit applies to the most recent Compute that
+// observed the same prev_hash.
+type SinkChain struct {
+	mu         sync.Mutex
+	key        []byte
+	algorithm  string
+	generation uint32
+	prevHash   string
+	fatal      bool
+}
+
+// SinkChainState is the persistent state of a SinkChain. The spec calls
+// this ChainState; renamed here to avoid colliding with the existing
+// audit.ChainState used by IntegrityChain.State().
+type SinkChainState struct {
+	Generation uint32
+	PrevHash   string
+}
+
+// ErrFatalIntegrity is returned by Compute after Fatal has been called.
+// The chain cannot be reused; the sink must be reinitialized (e.g., via
+// generation rotation).
+var ErrFatalIntegrity = errors.New("integrity chain latched fatal; sink must be reinitialized")
+
+// ErrMissingChainState is returned by chained sinks when an event arrives
+// without ev.Chain set (i.e., composite did not stamp it). Production
+// configurations with chained sinks must always run inside a composite
+// with a SequenceAllocator.
+var ErrMissingChainState = errors.New("event missing Chain field; composite did not stamp it")
+
+// NewSinkChain creates a new chain keyed by `key` (must be >= MinKeyLength).
+// Supported algorithms: "hmac-sha256" (default), "hmac-sha512".
+func NewSinkChain(key []byte, algorithm string) (*SinkChain, error) {
+	if len(key) < MinKeyLength {
+		return nil, fmt.Errorf("key too short: got %d bytes, need at least %d", len(key), MinKeyLength)
+	}
+	if algorithm == "" {
+		algorithm = "hmac-sha256"
+	}
+	switch algorithm {
+	case "hmac-sha256", "hmac-sha512":
+		// supported
+	default:
+		return nil, fmt.Errorf("unsupported algorithm %q: use hmac-sha256 or hmac-sha512", algorithm)
+	}
+	return &SinkChain{key: key, algorithm: algorithm}, nil
+}
+
+// Compute computes the HMAC of (formatVersion, sequence, prev_hash, payload)
+// using the chain's key. Compute is PURE: it does not mutate prev_hash. The
+// caller must follow with Commit on durable-write success or discard the
+// result on durable-write failure.
+//
+// If `generation` differs from the chain's current generation, prev_hash
+// is treated as "" for this Compute (chain rolls automatically). The
+// transition is committed only when Commit is called with the new generation.
+//
+// Returns ErrFatalIntegrity if Fatal was previously called.
+func (c *SinkChain) Compute(formatVersion int, sequence int64, generation uint32, payload []byte) (entryHash string, prevHash string, err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.fatal {
+		return "", "", ErrFatalIntegrity
+	}
+	prev := c.prevHash
+	if generation != c.generation {
+		prev = ""
+	}
+	hash, err := computeIntegrityHash(c.key, c.algorithm, formatVersion, sequence, prev, payload)
+	if err != nil {
+		return "", "", err
+	}
+	return hash, prev, nil
+}
+
+// Commit advances prev_hash to entryHash and records the generation. Must be
+// called exactly once per successful Compute, after the durable write
+// succeeds. On ambiguous failure (write may or may not have landed), the
+// caller MUST call Fatal instead; Commit and Fatal are mutually exclusive
+// per Compute.
+func (c *SinkChain) Commit(generation uint32, entryHash string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.fatal {
+		return
+	}
+	c.generation = generation
+	c.prevHash = entryHash
+}
+
+// Fatal latches the chain in an unrecoverable state. All subsequent Compute
+// calls return ErrFatalIntegrity. Used when a durable write returned an
+// ambiguous error (timeout, partial write detection) — we cannot know whether
+// the entry was persisted, so we cannot safely continue chaining.
+func (c *SinkChain) Fatal(reason error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.fatal = true
+	_ = reason // reserved for future telemetry; intentionally unused
+}
+
+// State returns the (generation, prev_hash) for persistence.
+func (c *SinkChain) State() SinkChainState {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return SinkChainState{Generation: c.generation, PrevHash: c.prevHash}
+}
+
+// Restore rehydrates chain state after restart.
+func (c *SinkChain) Restore(generation uint32, prevHash string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.generation = generation
+	c.prevHash = prevHash
+}

--- a/internal/audit/sink_chain_test.go
+++ b/internal/audit/sink_chain_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -595,22 +596,19 @@ func TestSinkChain_Commit_CrossChainResultLatchesFatal(t *testing.T) {
 	}
 }
 
-// TestComputeResult_FieldsAreUnexported documents the compile-time guarantee
-// that ComputeResult has no exported data fields — only accessor methods.
-// External packages cannot mutate or fabricate a ComputeResult; the build
-// itself rejects such attempts. This test exists to catch accidental
-// re-exports of the fields and to exercise the EntryHash()/PrevHash()
-// accessors at runtime.
-func TestComputeResult_FieldsAreUnexported(t *testing.T) {
-	c, _ := newTestSinkChain(t)
-	r, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"k":"v"}`))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if r.EntryHash() == "" {
-		t.Fatal("EntryHash() returned empty")
-	}
-	if r.PrevHash() != "" {
-		t.Fatal("PrevHash() should be empty for genesis entry")
+// TestComputeResult_HasNoExportedDataFields enforces the structural invariant
+// that ComputeResult has zero exported data fields via reflection. Accessor
+// methods (EntryHash, PrevHash) are intentionally the only public surface; if
+// anyone re-introduces an exported data field (e.g., renames `entryHash` to
+// `EntryHash`), this test fails. The opacity of the token — the property that
+// callers cannot mutate or fabricate one outside the audit package — depends
+// directly on this invariant.
+func TestComputeResult_HasNoExportedDataFields(t *testing.T) {
+	typ := reflect.TypeOf(ComputeResult{})
+	for i := 0; i < typ.NumField(); i++ {
+		f := typ.Field(i)
+		if f.IsExported() {
+			t.Errorf("ComputeResult has exported data field %q (type %s) — must remain unexported to preserve token opacity", f.Name, f.Type)
+		}
 	}
 }

--- a/internal/audit/sink_chain_test.go
+++ b/internal/audit/sink_chain_test.go
@@ -49,12 +49,12 @@ func TestSinkChain_Compute_FirstEntryUsesEmptyPrev(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Compute: %v", err)
 	}
-	if result.PrevHash != "" {
-		t.Errorf("first Compute: prevHash = %q, want empty", result.PrevHash)
+	if result.PrevHash() != "" {
+		t.Errorf("first Compute: prevHash = %q, want empty", result.PrevHash())
 	}
 	want := computeExpectedHash(t, key, IntegrityFormatVersion, 0, "", payload)
-	if result.EntryHash != want {
-		t.Errorf("entryHash = %q, want %q", result.EntryHash, want)
+	if result.EntryHash() != want {
+		t.Errorf("entryHash = %q, want %q", result.EntryHash(), want)
 	}
 }
 
@@ -73,8 +73,8 @@ func TestSinkChain_Compute_IsPure_NoMutationWithoutCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if first.EntryHash != second.EntryHash {
-		t.Errorf("Compute mutated chain state: first=%q second=%q", first.EntryHash, second.EntryHash)
+	if first.EntryHash() != second.EntryHash() {
+		t.Errorf("Compute mutated chain state: first=%q second=%q", first.EntryHash(), second.EntryHash())
 	}
 }
 
@@ -93,12 +93,12 @@ func TestSinkChain_Commit_AdvancesPrevHash(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if second.PrevHash != first.EntryHash {
-		t.Errorf("after Commit: prev_hash = %q, want %q", second.PrevHash, first.EntryHash)
+	if second.PrevHash() != first.EntryHash() {
+		t.Errorf("after Commit: prev_hash = %q, want %q", second.PrevHash(), first.EntryHash())
 	}
-	want := computeExpectedHash(t, key, IntegrityFormatVersion, 1, first.EntryHash, []byte(`{"b":2}`))
-	if second.EntryHash != want {
-		t.Errorf("second entryHash = %q, want %q", second.EntryHash, want)
+	want := computeExpectedHash(t, key, IntegrityFormatVersion, 1, first.EntryHash(), []byte(`{"b":2}`))
+	if second.EntryHash() != want {
+		t.Errorf("second entryHash = %q, want %q", second.EntryHash(), want)
 	}
 }
 
@@ -119,12 +119,12 @@ func TestSinkChain_Compute_GenerationRollover_ResetsPrevToEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if r1.PrevHash != "" {
-		t.Errorf("after gen rollover: prev_hash = %q, want empty", r1.PrevHash)
+	if r1.PrevHash() != "" {
+		t.Errorf("after gen rollover: prev_hash = %q, want empty", r1.PrevHash())
 	}
 	want := computeExpectedHash(t, key, IntegrityFormatVersion, 0, "", []byte(`{"y":2}`))
-	if r1.EntryHash != want {
-		t.Errorf("rolled entryHash = %q, want %q", r1.EntryHash, want)
+	if r1.EntryHash() != want {
+		t.Errorf("rolled entryHash = %q, want %q", r1.EntryHash(), want)
 	}
 
 	// Until Commit(r1), the chain's recorded generation is still 0.
@@ -140,8 +140,8 @@ func TestSinkChain_Compute_GenerationRollover_ResetsPrevToEmpty(t *testing.T) {
 	if state.Generation != 1 {
 		t.Errorf("State.Generation after Commit = %d, want 1", state.Generation)
 	}
-	if state.PrevHash != r1.EntryHash {
-		t.Errorf("State.PrevHash = %q, want %q", state.PrevHash, r1.EntryHash)
+	if state.PrevHash != r1.EntryHash() {
+		t.Errorf("State.PrevHash = %q, want %q", state.PrevHash, r1.EntryHash())
 	}
 }
 
@@ -179,8 +179,8 @@ func TestSinkChain_State_Restore_RoundTrip(t *testing.T) {
 	}
 
 	state := c.State()
-	if state.Generation != 0 || state.PrevHash != r1.EntryHash {
-		t.Fatalf("State() = %+v, want {Generation:0 PrevHash:%q}", state, r1.EntryHash)
+	if state.Generation != 0 || state.PrevHash != r1.EntryHash() {
+		t.Fatalf("State() = %+v, want {Generation:0 PrevHash:%q}", state, r1.EntryHash())
 	}
 
 	d, _ := newTestSinkChain(t)
@@ -198,8 +198,8 @@ func TestSinkChain_State_Restore_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cNext.EntryHash != dNext.EntryHash {
-		t.Errorf("after Restore: entryHash mismatch %q vs %q", cNext.EntryHash, dNext.EntryHash)
+	if cNext.EntryHash() != dNext.EntryHash() {
+		t.Errorf("after Restore: entryHash mismatch %q vs %q", cNext.EntryHash(), dNext.EntryHash())
 	}
 }
 
@@ -258,7 +258,7 @@ func TestSinkChain_SerialComputeCommit_NoChainBreakage(t *testing.T) {
 				return
 			}
 			mu.Lock()
-			records = append(records, record{seq: i, payload: payload, entryHash: result.EntryHash, prevHash: result.PrevHash})
+			records = append(records, record{seq: i, payload: payload, entryHash: result.EntryHash(), prevHash: result.PrevHash()})
 			mu.Unlock()
 		}
 	}()
@@ -308,14 +308,14 @@ func TestSinkChain_Compute_IsPureUnderConcurrentCallers(t *testing.T) {
 	if len(results) != N {
 		t.Fatalf("got %d results, want %d", len(results), N)
 	}
-	wantEntry := results[0].EntryHash
-	wantPrev := results[0].PrevHash
+	wantEntry := results[0].EntryHash()
+	wantPrev := results[0].PrevHash()
 	for i, r := range results {
-		if r.EntryHash != wantEntry {
-			t.Errorf("result %d: entry=%q, want %q (Compute is not pure under contention)", i, r.EntryHash, wantEntry)
+		if r.EntryHash() != wantEntry {
+			t.Errorf("result %d: entry=%q, want %q (Compute is not pure under contention)", i, r.EntryHash(), wantEntry)
 		}
-		if r.PrevHash != wantPrev {
-			t.Errorf("result %d: prev=%q, want %q (Compute is not pure under contention)", i, r.PrevHash, wantPrev)
+		if r.PrevHash() != wantPrev {
+			t.Errorf("result %d: prev=%q, want %q (Compute is not pure under contention)", i, r.PrevHash(), wantPrev)
 		}
 	}
 }
@@ -435,7 +435,7 @@ func TestSinkChain_Commit_BackwardsGenerationLatchesFatal(t *testing.T) {
 	if older.generation != 1 {
 		t.Fatalf("older.generation = %d, want 1", older.generation)
 	}
-	if err := c.Restore(2, r2.EntryHash, false); err != nil {
+	if err := c.Restore(2, r2.EntryHash(), false); err != nil {
 		t.Fatalf("Restore: %v", err)
 	}
 
@@ -509,11 +509,14 @@ func TestSinkChain_Commit_RolloverWithNonEmptyPrev_LatchesFatal(t *testing.T) {
 	// Forge a result whose generation > c.generation (rollover) but with a
 	// non-empty PrevHash. Normal callers cannot construct this via Compute;
 	// this is defense-in-depth against future API changes or in-package bugs.
+	// chain: c is required so the cross-chain check passes and we exercise
+	// the rollover branch specifically.
 	forged := &ComputeResult{
-		EntryHash:  "deadbeef",
-		PrevHash:   "shouldbeempty",
+		entryHash:  "deadbeef",
+		prevHash:   "shouldbeempty",
 		sequence:   0,
 		generation: 1,
+		chain:      c,
 	}
 	err := c.Commit(forged)
 	if !errors.Is(err, ErrStaleResult) {
@@ -561,5 +564,53 @@ func TestSinkChain_Commit_AfterFatalReturnsError(t *testing.T) {
 
 	if !c.State().Fatal {
 		t.Errorf("State.Fatal = false after Commit-on-fatal-chain; want true (latch must persist)")
+	}
+}
+
+// TestSinkChain_Commit_CrossChainResultLatchesFatal verifies that committing a
+// ComputeResult produced by SinkChain A on SinkChain B is rejected with
+// ErrCrossChainResult AND latches B fatal. A is unaffected — only the chain
+// that received the cross-chain commit latches. The check runs BEFORE
+// generation/prev_hash validation so cross-chain wins over backwards-gen, etc.
+func TestSinkChain_Commit_CrossChainResultLatchesFatal(t *testing.T) {
+	a, _ := newTestSinkChain(t)
+	b, _ := newTestSinkChain(t)
+
+	// Compute on a, attempt to Commit on b.
+	r, err := a.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = b.Commit(r)
+	if !errors.Is(err, ErrCrossChainResult) {
+		t.Fatalf("Commit(cross-chain): err = %v, want ErrCrossChainResult", err)
+	}
+	if !b.State().Fatal {
+		t.Fatalf("cross-chain Commit did not latch fatal on b")
+	}
+	// a is unaffected — only b should have latched.
+	if a.State().Fatal {
+		t.Fatalf("cross-chain Commit incorrectly latched a")
+	}
+}
+
+// TestComputeResult_FieldsAreUnexported documents the compile-time guarantee
+// that ComputeResult has no exported data fields — only accessor methods.
+// External packages cannot mutate or fabricate a ComputeResult; the build
+// itself rejects such attempts. This test exists to catch accidental
+// re-exports of the fields and to exercise the EntryHash()/PrevHash()
+// accessors at runtime.
+func TestComputeResult_FieldsAreUnexported(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+	r, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"k":"v"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.EntryHash() == "" {
+		t.Fatal("EntryHash() returned empty")
+	}
+	if r.PrevHash() != "" {
+		t.Fatal("PrevHash() should be empty for genesis entry")
 	}
 }

--- a/internal/audit/sink_chain_test.go
+++ b/internal/audit/sink_chain_test.go
@@ -1,0 +1,265 @@
+package audit
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// computeExpectedHash mirrors the production HMAC formula from
+// internal/audit/integrity.go: format_version | sequence | prev_hash | payload.
+// Generation is intentionally NOT in the HMAC input — see the format-version
+// note in the implementation plan.
+func computeExpectedHash(t *testing.T, key []byte, formatVersion int, sequence int64, prevHash string, payload []byte) string {
+	t.Helper()
+	h := hmac.New(sha256.New, key)
+	h.Write([]byte(strconv.Itoa(formatVersion)))
+	h.Write([]byte("|"))
+	h.Write([]byte(strconv.FormatInt(sequence, 10)))
+	h.Write([]byte("|"))
+	h.Write([]byte(prevHash))
+	h.Write([]byte("|"))
+	h.Write(payload)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func newTestSinkChain(t *testing.T) (*SinkChain, []byte) {
+	t.Helper()
+	key := make([]byte, MinKeyLength)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	c, err := NewSinkChain(key, "hmac-sha256")
+	if err != nil {
+		t.Fatalf("NewSinkChain: %v", err)
+	}
+	return c, key
+}
+
+func TestSinkChain_Compute_FirstEntryUsesEmptyPrev(t *testing.T) {
+	c, key := newTestSinkChain(t)
+	payload := []byte(`{"k":"v"}`)
+
+	entryHash, prevHash, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+	if err != nil {
+		t.Fatalf("Compute: %v", err)
+	}
+	if prevHash != "" {
+		t.Errorf("first Compute: prevHash = %q, want empty", prevHash)
+	}
+	want := computeExpectedHash(t, key, IntegrityFormatVersion, 0, "", payload)
+	if entryHash != want {
+		t.Errorf("entryHash = %q, want %q", entryHash, want)
+	}
+}
+
+func TestSinkChain_Compute_IsPure_NoMutationWithoutCommit(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+	payload := []byte(`{"k":"v"}`)
+
+	first, _, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Compute again without Commit — must produce the SAME entryHash, since
+	// prev_hash hasn't moved.
+	second, _, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Errorf("Compute mutated chain state: first=%q second=%q", first, second)
+	}
+}
+
+func TestSinkChain_Commit_AdvancesPrevHash(t *testing.T) {
+	c, key := newTestSinkChain(t)
+
+	first, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Commit(0, first)
+
+	second, prev, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prev != first {
+		t.Errorf("after Commit: prev_hash = %q, want %q", prev, first)
+	}
+	want := computeExpectedHash(t, key, IntegrityFormatVersion, 1, first, []byte(`{"b":2}`))
+	if second != want {
+		t.Errorf("second entryHash = %q, want %q", second, want)
+	}
+}
+
+func TestSinkChain_Compute_GenerationRollover_ResetsPrevToEmpty(t *testing.T) {
+	c, key := newTestSinkChain(t)
+
+	// Establish gen=0 chain with one committed entry.
+	h0, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"x":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Commit(0, h0)
+
+	// Compute at gen=1 — prev_hash should be "" automatically.
+	h1, prev, err := c.Compute(IntegrityFormatVersion, 0, 1, []byte(`{"y":2}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prev != "" {
+		t.Errorf("after gen rollover: prev_hash = %q, want empty", prev)
+	}
+	want := computeExpectedHash(t, key, IntegrityFormatVersion, 0, "", []byte(`{"y":2}`))
+	if h1 != want {
+		t.Errorf("rolled entryHash = %q, want %q", h1, want)
+	}
+
+	// Until Commit(1, h1), the chain's recorded generation is still 0.
+	state := c.State()
+	if state.Generation != 0 {
+		t.Errorf("State.Generation before Commit = %d, want 0", state.Generation)
+	}
+
+	c.Commit(1, h1)
+	state = c.State()
+	if state.Generation != 1 {
+		t.Errorf("State.Generation after Commit = %d, want 1", state.Generation)
+	}
+	if state.PrevHash != h1 {
+		t.Errorf("State.PrevHash = %q, want %q", state.PrevHash, h1)
+	}
+}
+
+func TestSinkChain_Fatal_LatchesAndBlocksFurtherCompute(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+
+	if _, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	c.Fatal(errors.New("ambiguous WAL write"))
+
+	_, _, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
+	if !errors.Is(err, ErrFatalIntegrity) {
+		t.Fatalf("Compute after Fatal: err = %v, want ErrFatalIntegrity", err)
+	}
+}
+
+func TestSinkChain_State_Restore_RoundTrip(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+
+	h0, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Commit(0, h0)
+	h1, _, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Commit(0, h1)
+
+	state := c.State()
+	if state.Generation != 0 || state.PrevHash != h1 {
+		t.Fatalf("State() = %+v, want {Generation:0 PrevHash:%q}", state, h1)
+	}
+
+	d, _ := newTestSinkChain(t)
+	d.Restore(state.Generation, state.PrevHash)
+
+	// Continue the chain from d — same key, so same entry hash as if c
+	// had continued.
+	cNext, _, err := c.Compute(IntegrityFormatVersion, 2, 0, []byte(`{"c":3}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dNext, _, err := d.Compute(IntegrityFormatVersion, 2, 0, []byte(`{"c":3}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cNext != dNext {
+		t.Errorf("after Restore: entryHash mismatch %q vs %q", cNext, dNext)
+	}
+}
+
+func TestNewSinkChain_RejectsShortKey(t *testing.T) {
+	_, err := NewSinkChain(make([]byte, MinKeyLength-1), "hmac-sha256")
+	if err == nil {
+		t.Fatal("NewSinkChain accepted a too-short key")
+	}
+	if !strings.Contains(err.Error(), "key too short") {
+		t.Errorf("error = %q, want 'key too short'", err)
+	}
+}
+
+func TestNewSinkChain_RejectsUnsupportedAlgorithm(t *testing.T) {
+	key := make([]byte, MinKeyLength)
+	_, err := NewSinkChain(key, "md5")
+	if err == nil {
+		t.Fatal("NewSinkChain accepted unsupported algorithm")
+	}
+	if !strings.Contains(err.Error(), "unsupported algorithm") {
+		t.Errorf("error = %q, want 'unsupported algorithm'", err)
+	}
+}
+
+func TestSinkChain_Concurrent_ComputeCommit_NoChainBreakage(t *testing.T) {
+	c, key := newTestSinkChain(t)
+
+	// Single owner serializes Compute+Commit pairs; this test asserts that
+	// repeated Compute under contention with Commit does not produce a
+	// chain that fails verification when replayed in committed order.
+	const N = 200
+	type record struct {
+		seq       int64
+		payload   []byte
+		entryHash string
+		prevHash  string
+	}
+	records := make([]record, 0, N)
+
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := int64(0); i < N; i++ {
+			payload := []byte(`{"i":` + strconv.FormatInt(i, 10) + `}`)
+			entry, prev, err := c.Compute(IntegrityFormatVersion, i, 0, payload)
+			if err != nil {
+				t.Errorf("Compute %d: %v", i, err)
+				return
+			}
+			c.Commit(0, entry)
+			mu.Lock()
+			records = append(records, record{seq: i, payload: payload, entryHash: entry, prevHash: prev})
+			mu.Unlock()
+		}
+	}()
+	wg.Wait()
+
+	// Walk records and verify chain continuity.
+	if len(records) != N {
+		t.Fatalf("got %d records, want %d", len(records), N)
+	}
+	expectedPrev := ""
+	for _, r := range records {
+		if r.prevHash != expectedPrev {
+			t.Fatalf("seq %d: prev=%q want %q", r.seq, r.prevHash, expectedPrev)
+		}
+		want := computeExpectedHash(t, key, IntegrityFormatVersion, r.seq, expectedPrev, r.payload)
+		if r.entryHash != want {
+			t.Fatalf("seq %d: entry=%q want %q", r.seq, r.entryHash, want)
+		}
+		expectedPrev = r.entryHash
+	}
+}

--- a/internal/audit/sink_chain_test.go
+++ b/internal/audit/sink_chain_test.go
@@ -45,16 +45,16 @@ func TestSinkChain_Compute_FirstEntryUsesEmptyPrev(t *testing.T) {
 	c, key := newTestSinkChain(t)
 	payload := []byte(`{"k":"v"}`)
 
-	entryHash, prevHash, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+	result, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
 	if err != nil {
 		t.Fatalf("Compute: %v", err)
 	}
-	if prevHash != "" {
-		t.Errorf("first Compute: prevHash = %q, want empty", prevHash)
+	if result.PrevHash != "" {
+		t.Errorf("first Compute: prevHash = %q, want empty", result.PrevHash)
 	}
 	want := computeExpectedHash(t, key, IntegrityFormatVersion, 0, "", payload)
-	if entryHash != want {
-		t.Errorf("entryHash = %q, want %q", entryHash, want)
+	if result.EntryHash != want {
+		t.Errorf("entryHash = %q, want %q", result.EntryHash, want)
 	}
 }
 
@@ -62,41 +62,43 @@ func TestSinkChain_Compute_IsPure_NoMutationWithoutCommit(t *testing.T) {
 	c, _ := newTestSinkChain(t)
 	payload := []byte(`{"k":"v"}`)
 
-	first, _, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+	first, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Compute again without Commit — must produce the SAME entryHash, since
 	// prev_hash hasn't moved.
-	second, _, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+	second, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if first != second {
-		t.Errorf("Compute mutated chain state: first=%q second=%q", first, second)
+	if first.EntryHash != second.EntryHash {
+		t.Errorf("Compute mutated chain state: first=%q second=%q", first.EntryHash, second.EntryHash)
 	}
 }
 
 func TestSinkChain_Commit_AdvancesPrevHash(t *testing.T) {
 	c, key := newTestSinkChain(t)
 
-	first, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`))
+	first, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Commit(0, first)
+	if err := c.Commit(first); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
 
-	second, prev, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
+	second, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if prev != first {
-		t.Errorf("after Commit: prev_hash = %q, want %q", prev, first)
+	if second.PrevHash != first.EntryHash {
+		t.Errorf("after Commit: prev_hash = %q, want %q", second.PrevHash, first.EntryHash)
 	}
-	want := computeExpectedHash(t, key, IntegrityFormatVersion, 1, first, []byte(`{"b":2}`))
-	if second != want {
-		t.Errorf("second entryHash = %q, want %q", second, want)
+	want := computeExpectedHash(t, key, IntegrityFormatVersion, 1, first.EntryHash, []byte(`{"b":2}`))
+	if second.EntryHash != want {
+		t.Errorf("second entryHash = %q, want %q", second.EntryHash, want)
 	}
 }
 
@@ -104,51 +106,55 @@ func TestSinkChain_Compute_GenerationRollover_ResetsPrevToEmpty(t *testing.T) {
 	c, key := newTestSinkChain(t)
 
 	// Establish gen=0 chain with one committed entry.
-	h0, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"x":1}`))
+	r0, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"x":1}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Commit(0, h0)
+	if err := c.Commit(r0); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
 
 	// Compute at gen=1 — prev_hash should be "" automatically.
-	h1, prev, err := c.Compute(IntegrityFormatVersion, 0, 1, []byte(`{"y":2}`))
+	r1, err := c.Compute(IntegrityFormatVersion, 0, 1, []byte(`{"y":2}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if prev != "" {
-		t.Errorf("after gen rollover: prev_hash = %q, want empty", prev)
+	if r1.PrevHash != "" {
+		t.Errorf("after gen rollover: prev_hash = %q, want empty", r1.PrevHash)
 	}
 	want := computeExpectedHash(t, key, IntegrityFormatVersion, 0, "", []byte(`{"y":2}`))
-	if h1 != want {
-		t.Errorf("rolled entryHash = %q, want %q", h1, want)
+	if r1.EntryHash != want {
+		t.Errorf("rolled entryHash = %q, want %q", r1.EntryHash, want)
 	}
 
-	// Until Commit(1, h1), the chain's recorded generation is still 0.
+	// Until Commit(r1), the chain's recorded generation is still 0.
 	state := c.State()
 	if state.Generation != 0 {
 		t.Errorf("State.Generation before Commit = %d, want 0", state.Generation)
 	}
 
-	c.Commit(1, h1)
+	if err := c.Commit(r1); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
 	state = c.State()
 	if state.Generation != 1 {
 		t.Errorf("State.Generation after Commit = %d, want 1", state.Generation)
 	}
-	if state.PrevHash != h1 {
-		t.Errorf("State.PrevHash = %q, want %q", state.PrevHash, h1)
+	if state.PrevHash != r1.EntryHash {
+		t.Errorf("State.PrevHash = %q, want %q", state.PrevHash, r1.EntryHash)
 	}
 }
 
 func TestSinkChain_Fatal_LatchesAndBlocksFurtherCompute(t *testing.T) {
 	c, _ := newTestSinkChain(t)
 
-	if _, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`)); err != nil {
+	if _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`)); err != nil {
 		t.Fatal(err)
 	}
 
 	c.Fatal(errors.New("ambiguous WAL write"))
 
-	_, _, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
+	_, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
 	if !errors.Is(err, ErrFatalIntegrity) {
 		t.Fatalf("Compute after Fatal: err = %v, want ErrFatalIntegrity", err)
 	}
@@ -157,20 +163,24 @@ func TestSinkChain_Fatal_LatchesAndBlocksFurtherCompute(t *testing.T) {
 func TestSinkChain_State_Restore_RoundTrip(t *testing.T) {
 	c, _ := newTestSinkChain(t)
 
-	h0, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`))
+	r0, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Commit(0, h0)
-	h1, _, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
+	if err := c.Commit(r0); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	r1, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Commit(0, h1)
+	if err := c.Commit(r1); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
 
 	state := c.State()
-	if state.Generation != 0 || state.PrevHash != h1 {
-		t.Fatalf("State() = %+v, want {Generation:0 PrevHash:%q}", state, h1)
+	if state.Generation != 0 || state.PrevHash != r1.EntryHash {
+		t.Fatalf("State() = %+v, want {Generation:0 PrevHash:%q}", state, r1.EntryHash)
 	}
 
 	d, _ := newTestSinkChain(t)
@@ -180,16 +190,16 @@ func TestSinkChain_State_Restore_RoundTrip(t *testing.T) {
 
 	// Continue the chain from d — same key, so same entry hash as if c
 	// had continued.
-	cNext, _, err := c.Compute(IntegrityFormatVersion, 2, 0, []byte(`{"c":3}`))
+	cNext, err := c.Compute(IntegrityFormatVersion, 2, 0, []byte(`{"c":3}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	dNext, _, err := d.Compute(IntegrityFormatVersion, 2, 0, []byte(`{"c":3}`))
+	dNext, err := d.Compute(IntegrityFormatVersion, 2, 0, []byte(`{"c":3}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cNext != dNext {
-		t.Errorf("after Restore: entryHash mismatch %q vs %q", cNext, dNext)
+	if cNext.EntryHash != dNext.EntryHash {
+		t.Errorf("after Restore: entryHash mismatch %q vs %q", cNext.EntryHash, dNext.EntryHash)
 	}
 }
 
@@ -238,14 +248,17 @@ func TestSinkChain_SerialComputeCommit_NoChainBreakage(t *testing.T) {
 		defer wg.Done()
 		for i := int64(0); i < N; i++ {
 			payload := []byte(`{"i":` + strconv.FormatInt(i, 10) + `}`)
-			entry, prev, err := c.Compute(IntegrityFormatVersion, i, 0, payload)
+			result, err := c.Compute(IntegrityFormatVersion, i, 0, payload)
 			if err != nil {
 				t.Errorf("Compute %d: %v", i, err)
 				return
 			}
-			c.Commit(0, entry)
+			if err := c.Commit(result); err != nil {
+				t.Errorf("Commit %d: %v", i, err)
+				return
+			}
 			mu.Lock()
-			records = append(records, record{seq: i, payload: payload, entryHash: entry, prevHash: prev})
+			records = append(records, record{seq: i, payload: payload, entryHash: result.EntryHash, prevHash: result.PrevHash})
 			mu.Unlock()
 		}
 	}()
@@ -273,24 +286,20 @@ func TestSinkChain_Compute_IsPureUnderConcurrentCallers(t *testing.T) {
 	payload := []byte(`{"k":"v"}`)
 
 	const N = 32
-	type result struct {
-		entry string
-		prev  string
-	}
-	results := make([]result, 0, N)
+	results := make([]*ComputeResult, 0, N)
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 	wg.Add(N)
 	for i := 0; i < N; i++ {
 		go func() {
 			defer wg.Done()
-			entry, prev, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+			result, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
 			if err != nil {
 				t.Errorf("Compute: %v", err)
 				return
 			}
 			mu.Lock()
-			results = append(results, result{entry: entry, prev: prev})
+			results = append(results, result)
 			mu.Unlock()
 		}()
 	}
@@ -299,14 +308,14 @@ func TestSinkChain_Compute_IsPureUnderConcurrentCallers(t *testing.T) {
 	if len(results) != N {
 		t.Fatalf("got %d results, want %d", len(results), N)
 	}
-	wantEntry := results[0].entry
-	wantPrev := results[0].prev
+	wantEntry := results[0].EntryHash
+	wantPrev := results[0].PrevHash
 	for i, r := range results {
-		if r.entry != wantEntry {
-			t.Errorf("result %d: entry=%q, want %q (Compute is not pure under contention)", i, r.entry, wantEntry)
+		if r.EntryHash != wantEntry {
+			t.Errorf("result %d: entry=%q, want %q (Compute is not pure under contention)", i, r.EntryHash, wantEntry)
 		}
-		if r.prev != wantPrev {
-			t.Errorf("result %d: prev=%q, want %q (Compute is not pure under contention)", i, r.prev, wantPrev)
+		if r.PrevHash != wantPrev {
+			t.Errorf("result %d: prev=%q, want %q (Compute is not pure under contention)", i, r.PrevHash, wantPrev)
 		}
 	}
 }
@@ -314,7 +323,7 @@ func TestSinkChain_Compute_IsPureUnderConcurrentCallers(t *testing.T) {
 func TestSinkChain_State_PersistsFatal(t *testing.T) {
 	c, _ := newTestSinkChain(t)
 
-	if _, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`)); err != nil {
+	if _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`)); err != nil {
 		t.Fatal(err)
 	}
 	c.Fatal(errors.New("ambiguous WAL write"))
@@ -329,7 +338,7 @@ func TestSinkChain_State_PersistsFatal(t *testing.T) {
 	if err := d.Restore(state.Generation, state.PrevHash, state.Fatal); err != nil {
 		t.Fatalf("Restore: %v", err)
 	}
-	if _, _, err := d.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`)); !errors.Is(err, ErrFatalIntegrity) {
+	if _, err := d.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`)); !errors.Is(err, ErrFatalIntegrity) {
 		t.Fatalf("Compute after Restore-with-Fatal: err = %v, want ErrFatalIntegrity", err)
 	}
 }
@@ -391,29 +400,101 @@ func TestSinkChain_Restore_ValidatesPrevHash(t *testing.T) {
 	}
 }
 
-func TestSinkChain_Commit_BackwardsGenerationIsIgnored(t *testing.T) {
+// TestSinkChain_Commit_BackwardsGenerationLatchesFatal verifies that a Commit
+// whose ComputeResult was produced before a generation rollover (i.e. its
+// generation is older than the chain's current generation) latches the chain
+// fatal and returns an error. Silently no-op'ing this would hide an integrity
+// divergence: the durable write would have succeeded but the in-memory
+// prev_hash would lag, breaking subsequent Compute calls without signal.
+func TestSinkChain_Commit_BackwardsGenerationLatchesFatal(t *testing.T) {
 	c, _ := newTestSinkChain(t)
 
-	// Establish gen=2 with one committed entry.
-	if _, _, err := c.Compute(IntegrityFormatVersion, 0, 2, []byte(`{"a":1}`)); err != nil {
-		t.Fatal(err)
-	}
-	h2, _, err := c.Compute(IntegrityFormatVersion, 0, 2, []byte(`{"a":1}`))
+	// Establish chain at gen=2 by Compute+Commit.
+	r2, err := c.Compute(IntegrityFormatVersion, 0, 2, []byte(`{"a":1}`))
 	if err != nil {
 		t.Fatal(err)
 	}
-	c.Commit(2, h2)
-
-	before := c.State()
-	if before.Generation != 2 || before.PrevHash != h2 {
-		t.Fatalf("setup: state = %+v, want {Generation:2 PrevHash:%q}", before, h2)
+	if err := c.Commit(r2); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	state := c.State()
+	if state.Generation != 2 {
+		t.Fatalf("setup: chain generation = %d, want 2", state.Generation)
 	}
 
-	// Commit with an older generation must be a no-op.
-	c.Commit(1, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	// Construct a backwards-generation result. Restore the chain to gen=1
+	// briefly, Compute under gen=1, then restore back to gen=2 — the result
+	// carries result.generation=1 even though the chain is now at gen=2.
+	if err := c.Restore(1, "", false); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	older, err := c.Compute(IntegrityFormatVersion, 0, 1, []byte(`{"old":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if older.generation != 1 {
+		t.Fatalf("older.generation = %d, want 1", older.generation)
+	}
+	if err := c.Restore(2, r2.EntryHash, false); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
 
-	after := c.State()
-	if after.Generation != before.Generation || after.PrevHash != before.PrevHash {
-		t.Errorf("backwards-generation Commit mutated state: before=%+v after=%+v", before, after)
+	// Commit the backwards result must return an error mentioning
+	// "backwards generation" and latch the chain fatal.
+	err = c.Commit(older)
+	if err == nil {
+		t.Fatal("Commit(backwards result): err = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "backwards generation") {
+		t.Errorf("Commit error = %q, want substring 'backwards generation'", err)
+	}
+
+	if !c.State().Fatal {
+		t.Errorf("State.Fatal = false after backwards-gen Commit; want true")
+	}
+
+	// Subsequent Compute must surface the fatal latch.
+	if _, err := c.Compute(IntegrityFormatVersion, 1, 2, []byte(`{"x":1}`)); !errors.Is(err, ErrFatalIntegrity) {
+		t.Errorf("Compute after backwards-gen Commit: err = %v, want ErrFatalIntegrity", err)
+	}
+}
+
+// TestSinkChain_Commit_NilResultErrors verifies that Commit rejects a nil
+// ComputeResult with an error rather than panicking.
+func TestSinkChain_Commit_NilResultErrors(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+
+	err := c.Commit(nil)
+	if err == nil {
+		t.Fatal("Commit(nil): err = nil, want error")
+	}
+
+	// nil-result error is a caller bug, not a fatal integrity event — the
+	// chain should NOT latch fatal in this case.
+	if c.State().Fatal {
+		t.Errorf("Commit(nil) latched fatal; want chain unchanged")
+	}
+}
+
+// TestSinkChain_Commit_AfterFatalReturnsError verifies that Commit on a chain
+// that was previously latched Fatal returns ErrFatalIntegrity (replacing the
+// earlier silent-no-op behavior). The chain stays latched.
+func TestSinkChain_Commit_AfterFatalReturnsError(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+
+	result, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.Fatal(errors.New("ambiguous WAL write"))
+
+	err = c.Commit(result)
+	if !errors.Is(err, ErrFatalIntegrity) {
+		t.Errorf("Commit after Fatal: err = %v, want ErrFatalIntegrity", err)
+	}
+
+	if !c.State().Fatal {
+		t.Errorf("State.Fatal = false after Commit-on-fatal-chain; want true (latch must persist)")
 	}
 }

--- a/internal/audit/sink_chain_test.go
+++ b/internal/audit/sink_chain_test.go
@@ -174,7 +174,9 @@ func TestSinkChain_State_Restore_RoundTrip(t *testing.T) {
 	}
 
 	d, _ := newTestSinkChain(t)
-	d.Restore(state.Generation, state.PrevHash)
+	if err := d.Restore(state.Generation, state.PrevHash, state.Fatal); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
 
 	// Continue the chain from d — same key, so same entry hash as if c
 	// had continued.
@@ -212,12 +214,14 @@ func TestNewSinkChain_RejectsUnsupportedAlgorithm(t *testing.T) {
 	}
 }
 
-func TestSinkChain_Concurrent_ComputeCommit_NoChainBreakage(t *testing.T) {
+func TestSinkChain_SerialComputeCommit_NoChainBreakage(t *testing.T) {
 	c, key := newTestSinkChain(t)
 
-	// Single owner serializes Compute+Commit pairs; this test asserts that
-	// repeated Compute under contention with Commit does not produce a
-	// chain that fails verification when replayed in committed order.
+	// Single-goroutine serialization verifies chain continuity; concurrent
+	// ComputeCommit pairs across goroutines is NOT a supported pattern (Commit
+	// cannot identify which Compute it finalizes). This test asserts that
+	// repeated Compute+Commit in serial order produces a chain that verifies
+	// when replayed in committed order.
 	const N = 200
 	type record struct {
 		seq       int64
@@ -261,5 +265,155 @@ func TestSinkChain_Concurrent_ComputeCommit_NoChainBreakage(t *testing.T) {
 			t.Fatalf("seq %d: entry=%q want %q", r.seq, r.entryHash, want)
 		}
 		expectedPrev = r.entryHash
+	}
+}
+
+func TestSinkChain_Compute_IsPureUnderConcurrentCallers(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+	payload := []byte(`{"k":"v"}`)
+
+	const N = 32
+	type result struct {
+		entry string
+		prev  string
+	}
+	results := make([]result, 0, N)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			entry, prev, err := c.Compute(IntegrityFormatVersion, 0, 0, payload)
+			if err != nil {
+				t.Errorf("Compute: %v", err)
+				return
+			}
+			mu.Lock()
+			results = append(results, result{entry: entry, prev: prev})
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	if len(results) != N {
+		t.Fatalf("got %d results, want %d", len(results), N)
+	}
+	wantEntry := results[0].entry
+	wantPrev := results[0].prev
+	for i, r := range results {
+		if r.entry != wantEntry {
+			t.Errorf("result %d: entry=%q, want %q (Compute is not pure under contention)", i, r.entry, wantEntry)
+		}
+		if r.prev != wantPrev {
+			t.Errorf("result %d: prev=%q, want %q (Compute is not pure under contention)", i, r.prev, wantPrev)
+		}
+	}
+}
+
+func TestSinkChain_State_PersistsFatal(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+
+	if _, _, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	c.Fatal(errors.New("ambiguous WAL write"))
+
+	state := c.State()
+	if !state.Fatal {
+		t.Fatalf("State.Fatal = false after Fatal(); want true")
+	}
+
+	// Round-trip into a fresh chain via Restore. The latch must survive.
+	d, _ := newTestSinkChain(t)
+	if err := d.Restore(state.Generation, state.PrevHash, state.Fatal); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if _, _, err := d.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`)); !errors.Is(err, ErrFatalIntegrity) {
+		t.Fatalf("Compute after Restore-with-Fatal: err = %v, want ErrFatalIntegrity", err)
+	}
+}
+
+func TestSinkChain_Restore_ValidatesPrevHash(t *testing.T) {
+	validSha256 := strings.Repeat("a", 64)  // 32 bytes hex-encoded
+	validSha512 := strings.Repeat("b", 128) // 64 bytes hex-encoded
+
+	cases := []struct {
+		name      string
+		algorithm string
+		prevHash  string
+		wantErr   bool
+	}{
+		{name: "empty is genesis", algorithm: "hmac-sha256", prevHash: "", wantErr: false},
+		{name: "valid sha256 hex", algorithm: "hmac-sha256", prevHash: validSha256, wantErr: false},
+		{name: "wrong length hex (sha512 under sha256)", algorithm: "hmac-sha256", prevHash: validSha512, wantErr: true},
+		{name: "non-hex characters", algorithm: "hmac-sha256", prevHash: strings.Repeat("z", 64), wantErr: true},
+		{name: "odd-length hex", algorithm: "hmac-sha256", prevHash: strings.Repeat("a", 63), wantErr: true},
+		{name: "valid sha512 hex under sha512", algorithm: "hmac-sha512", prevHash: validSha512, wantErr: false},
+		{name: "sha256 length under sha512", algorithm: "hmac-sha512", prevHash: validSha256, wantErr: true},
+		{name: "empty under sha512 is genesis", algorithm: "hmac-sha512", prevHash: "", wantErr: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			key := make([]byte, MinKeyLength)
+			c, err := NewSinkChain(key, tc.algorithm)
+			if err != nil {
+				t.Fatalf("NewSinkChain: %v", err)
+			}
+
+			// Capture pre-state to assert non-mutation on rejected restore.
+			before := c.State()
+
+			err = c.Restore(7, tc.prevHash, false)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("Restore(%q): err = nil, want error", tc.prevHash)
+				}
+				if !errors.Is(err, ErrInvalidChainState) {
+					t.Errorf("Restore(%q): err = %v, want errors.Is ErrInvalidChainState", tc.prevHash, err)
+				}
+				after := c.State()
+				if after != before {
+					t.Errorf("rejected Restore mutated state: before=%+v after=%+v", before, after)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("Restore(%q): unexpected err = %v", tc.prevHash, err)
+			}
+			after := c.State()
+			if after.Generation != 7 || after.PrevHash != tc.prevHash || after.Fatal {
+				t.Errorf("after Restore: state = %+v, want {Generation:7 PrevHash:%q Fatal:false}", after, tc.prevHash)
+			}
+		})
+	}
+}
+
+func TestSinkChain_Commit_BackwardsGenerationIsIgnored(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+
+	// Establish gen=2 with one committed entry.
+	if _, _, err := c.Compute(IntegrityFormatVersion, 0, 2, []byte(`{"a":1}`)); err != nil {
+		t.Fatal(err)
+	}
+	h2, _, err := c.Compute(IntegrityFormatVersion, 0, 2, []byte(`{"a":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Commit(2, h2)
+
+	before := c.State()
+	if before.Generation != 2 || before.PrevHash != h2 {
+		t.Fatalf("setup: state = %+v, want {Generation:2 PrevHash:%q}", before, h2)
+	}
+
+	// Commit with an older generation must be a no-op.
+	c.Commit(1, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+
+	after := c.State()
+	if after.Generation != before.Generation || after.PrevHash != before.PrevHash {
+		t.Errorf("backwards-generation Commit mutated state: before=%+v after=%+v", before, after)
 	}
 }

--- a/internal/audit/sink_chain_test.go
+++ b/internal/audit/sink_chain_test.go
@@ -439,14 +439,11 @@ func TestSinkChain_Commit_BackwardsGenerationLatchesFatal(t *testing.T) {
 		t.Fatalf("Restore: %v", err)
 	}
 
-	// Commit the backwards result must return an error mentioning
-	// "backwards generation" and latch the chain fatal.
+	// Commit the backwards result must return an error wrapping
+	// ErrBackwardsGeneration and latch the chain fatal.
 	err = c.Commit(older)
-	if err == nil {
-		t.Fatal("Commit(backwards result): err = nil, want error")
-	}
-	if !strings.Contains(err.Error(), "backwards generation") {
-		t.Errorf("Commit error = %q, want substring 'backwards generation'", err)
+	if !errors.Is(err, ErrBackwardsGeneration) {
+		t.Fatalf("Commit(backwards result): err = %v, want errors.Is ErrBackwardsGeneration", err)
 	}
 
 	if !c.State().Fatal {
@@ -456,6 +453,74 @@ func TestSinkChain_Commit_BackwardsGenerationLatchesFatal(t *testing.T) {
 	// Subsequent Compute must surface the fatal latch.
 	if _, err := c.Compute(IntegrityFormatVersion, 1, 2, []byte(`{"x":1}`)); !errors.Is(err, ErrFatalIntegrity) {
 		t.Errorf("Compute after backwards-gen Commit: err = %v, want ErrFatalIntegrity", err)
+	}
+}
+
+// TestSinkChain_Commit_StaleResultLatchesFatal verifies that a Commit whose
+// ComputeResult was produced before an earlier Commit advanced prev_hash
+// (i.e., a stale token whose result.PrevHash no longer matches the chain's
+// current prev_hash within the same generation) latches the chain fatal and
+// returns an error wrapping ErrStaleResult. Silently committing the stale
+// result would silently fork the chain.
+func TestSinkChain_Commit_StaleResultLatchesFatal(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+
+	// Two Computes in a row at gen=0 with NO Commit between them.
+	// Both observe the empty prev_hash and produce results with PrevHash="".
+	r1, err := c.Compute(IntegrityFormatVersion, 0, 0, []byte(`{"a":1}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2, err := c.Compute(IntegrityFormatVersion, 1, 0, []byte(`{"b":2}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Commit r1 — advances prev_hash to r1.EntryHash.
+	if err := c.Commit(r1); err != nil {
+		t.Fatalf("Commit(r1): %v", err)
+	}
+
+	// Now commit r2. r2.PrevHash is "" (from when c.prevHash was empty), but
+	// c.prevHash is now r1.EntryHash. The mismatch must be detected and
+	// latched fatal.
+	err = c.Commit(r2)
+	if !errors.Is(err, ErrStaleResult) {
+		t.Fatalf("Commit(stale r2): err = %v, want ErrStaleResult", err)
+	}
+	if !c.State().Fatal {
+		t.Fatalf("Commit(stale r2) did not latch fatal")
+	}
+
+	// Subsequent Compute must fail.
+	if _, err := c.Compute(IntegrityFormatVersion, 2, 0, []byte(`{"c":3}`)); !errors.Is(err, ErrFatalIntegrity) {
+		t.Fatalf("Compute after stale-result fatal: err = %v, want ErrFatalIntegrity", err)
+	}
+}
+
+// TestSinkChain_Commit_RolloverWithNonEmptyPrev_LatchesFatal exercises the
+// defense-in-depth branch of the stale-token validation: a result whose
+// generation > c.generation (rollover) but with PrevHash != "". Normal
+// callers cannot construct this via Compute (Compute always sets prev=""
+// on rollover); this test forges the result directly via the unexported
+// fields, which is only possible from within the audit package.
+func TestSinkChain_Commit_RolloverWithNonEmptyPrev_LatchesFatal(t *testing.T) {
+	c, _ := newTestSinkChain(t)
+	// Forge a result whose generation > c.generation (rollover) but with a
+	// non-empty PrevHash. Normal callers cannot construct this via Compute;
+	// this is defense-in-depth against future API changes or in-package bugs.
+	forged := &ComputeResult{
+		EntryHash:  "deadbeef",
+		PrevHash:   "shouldbeempty",
+		sequence:   0,
+		generation: 1,
+	}
+	err := c.Commit(forged)
+	if !errors.Is(err, ErrStaleResult) {
+		t.Fatalf("Commit(forged rollover): err = %v, want ErrStaleResult", err)
+	}
+	if !c.State().Fatal {
+		t.Fatalf("forged rollover did not latch fatal")
 	}
 }
 

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"runtime"
+	"strings"
 	"syscall"
 
 	"github.com/agentsh/agentsh/internal/client"
@@ -312,7 +313,19 @@ func setupWrapInterception(ctx context.Context, c client.CLIClient, sessID strin
 }
 
 func buildWrapEnv(base []string, sessionID string, serverAddr string, bypassShellShim bool) []string {
-	env := append([]string{}, base...)
+	env := make([]string, 0, len(base)+3)
+	for _, e := range base {
+		switch {
+		case strings.HasPrefix(e, "AGENTSH_SESSION_ID="):
+			continue
+		case strings.HasPrefix(e, "AGENTSH_SERVER="):
+			continue
+		case strings.HasPrefix(e, "AGENTSH_IN_SESSION="):
+			continue
+		default:
+			env = append(env, e)
+		}
+	}
 	env = append(env,
 		fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessionID),
 		fmt.Sprintf("AGENTSH_SERVER=%s", serverAddr),

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -146,10 +146,7 @@ func runWrap(ctx context.Context, cfg *clientConfig, opts wrapOptions) error {
 		agentProc.Stdin = os.Stdin
 		agentProc.Stdout = os.Stdout
 		agentProc.Stderr = os.Stderr
-		agentProc.Env = append(os.Environ(),
-			fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessID),
-			fmt.Sprintf("AGENTSH_SERVER=%s", cfg.serverAddr),
-		)
+		agentProc.Env = buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, false)
 	}
 
 	// If FUSE mount is active, add it to the environment and set the working
@@ -280,8 +277,8 @@ type wrapLaunchConfig struct {
 	env         []string
 	extraFiles  []*os.File
 	sysProcAttr *syscall.SysProcAttr
-	postStart   func() // Called after the process starts (e.g., to forward notify fd)
-	postWait    func() // Called after the process exits (e.g., to reclaim terminal)
+	postStart   func()    // Called after the process starts (e.g., to forward notify fd)
+	postWait    func()    // Called after the process exits (e.g., to reclaim terminal)
 	keepAlive   io.Closer // Held open during shell lifetime (e.g., ptrace handshake conn)
 	// ptracePostStart is called after the child is started with the child PID.
 	// It performs the ptrace handshake (send PID, wait for ACK).
@@ -312,6 +309,18 @@ func setupWrapInterception(ctx context.Context, c client.CLIClient, sessID strin
 
 	// Delegate to platform-specific code for socket pair creation and fd management
 	return platformSetupWrap(ctx, wrapResp, sessID, agentPath, agentArgs, cfg)
+}
+
+func buildWrapEnv(base []string, sessionID string, serverAddr string, bypassShellShim bool) []string {
+	env := append([]string{}, base...)
+	env = append(env,
+		fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessionID),
+		fmt.Sprintf("AGENTSH_SERVER=%s", serverAddr),
+	)
+	if bypassShellShim {
+		env = append(env, "AGENTSH_IN_SESSION=1")
+	}
+	return env
 }
 
 // fetchSessionForWrap resolves the session for runWrap, either by reusing

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -315,12 +315,17 @@ func setupWrapInterception(ctx context.Context, c client.CLIClient, sessID strin
 func buildWrapEnv(base []string, sessionID string, serverAddr string, bypassShellShim bool) []string {
 	env := make([]string, 0, len(base)+3)
 	for _, e := range base {
+		key, _, found := strings.Cut(e, "=")
+		if !found {
+			env = append(env, e)
+			continue
+		}
 		switch {
-		case strings.HasPrefix(e, "AGENTSH_SESSION_ID="):
+		case strings.EqualFold(key, "AGENTSH_SESSION_ID"):
 			continue
-		case strings.HasPrefix(e, "AGENTSH_SERVER="):
+		case strings.EqualFold(key, "AGENTSH_SERVER"):
 			continue
-		case strings.HasPrefix(e, "AGENTSH_IN_SESSION="):
+		case strings.EqualFold(key, "AGENTSH_IN_SESSION"):
 			continue
 		default:
 			env = append(env, e)

--- a/internal/cli/wrap_darwin.go
+++ b/internal/cli/wrap_darwin.go
@@ -19,11 +19,7 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 	if wrapResp.WrapperBinary == "" {
 		// No wrapper needed on macOS — ES interception is handled by System Extension.
 		// The agent runs directly, and the ESF client intercepts its execs.
-		env := os.Environ()
-		env = append(env,
-			fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessID),
-			fmt.Sprintf("AGENTSH_SERVER=%s", cfg.serverAddr),
-		)
+		env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
 
 		return &wrapLaunchConfig{
 			command: agentPath,
@@ -37,11 +33,7 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 
 	// If the server returns a wrapper binary (e.g., agentsh-macwrap for sandboxing),
 	// use it as the launch command.
-	env := os.Environ()
-	env = append(env,
-		fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessID),
-		fmt.Sprintf("AGENTSH_SERVER=%s", cfg.serverAddr),
-	)
+	env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
 	for k, v := range wrapResp.WrapperEnv {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}

--- a/internal/cli/wrap_linux.go
+++ b/internal/cli/wrap_linux.go
@@ -25,11 +25,7 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 	if wrapResp.PtraceMode {
 		notifySocket := wrapResp.NotifySocket
 
-		env := os.Environ()
-		env = append(env,
-			fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessID),
-			fmt.Sprintf("AGENTSH_SERVER=%s", cfg.serverAddr),
-		)
+		env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
 
 		// connHolder stores the keepalive connection set by ptracePostStart.
 		var connHolder net.Conn
@@ -130,12 +126,8 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 	}
 
 	// Build env for the wrapped process
-	env := os.Environ()
-	env = append(env,
-		fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessID),
-		fmt.Sprintf("AGENTSH_SERVER=%s", cfg.serverAddr),
-		"AGENTSH_NOTIFY_SOCK_FD=3", // fd 3 = ExtraFiles[0]
-	)
+	env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
+	env = append(env, "AGENTSH_NOTIFY_SOCK_FD=3") // fd 3 = ExtraFiles[0]
 	if hasSignalSocket {
 		env = append(env, "AGENTSH_SIGNAL_SOCK_FD=4") // fd 4 = ExtraFiles[1]
 	}

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"os"
 	"net/url"
+	"os"
 	"runtime"
 	"syscall"
 	"testing"
@@ -129,10 +129,10 @@ func TestWrapCmd_RequiresCommandWithFlags(t *testing.T) {
 
 // mockWrapClient implements CLIClient for testing wrap interception setup.
 type mockWrapClient struct {
-	wrapInitCalled  bool
-	wrapInitReq     types.WrapInitRequest
-	wrapInitResp    types.WrapInitResponse
-	wrapInitErr     error
+	wrapInitCalled   bool
+	wrapInitReq      types.WrapInitRequest
+	wrapInitResp     types.WrapInitResponse
+	wrapInitErr      error
 	createSessCalled bool
 	getSessionCalled bool
 	getSessionFn     func(ctx context.Context, id string) (types.Session, error)
@@ -173,7 +173,7 @@ func (m *mockWrapClient) GetSession(ctx context.Context, id string) (types.Sessi
 	}
 	return types.Session{ID: id}, nil
 }
-func (m *mockWrapClient) DestroySession(ctx context.Context, id string) error    { return nil }
+func (m *mockWrapClient) DestroySession(ctx context.Context, id string) error { return nil }
 func (m *mockWrapClient) PatchSession(ctx context.Context, id string, req types.SessionPatchRequest) (types.Session, error) {
 	return types.Session{}, nil
 }
@@ -198,7 +198,9 @@ func (m *mockWrapClient) StreamSessionEvents(ctx context.Context, sessionID stri
 func (m *mockWrapClient) OutputChunk(ctx context.Context, sessionID, commandID string, stream string, offset, limit int64) (map[string]any, error) {
 	return nil, nil
 }
-func (m *mockWrapClient) ListApprovals(ctx context.Context) ([]map[string]any, error) { return nil, nil }
+func (m *mockWrapClient) ListApprovals(ctx context.Context) ([]map[string]any, error) {
+	return nil, nil
+}
 func (m *mockWrapClient) ResolveApproval(ctx context.Context, id string, decision string, reason string) error {
 	return nil
 }
@@ -309,6 +311,27 @@ func TestSetupWrapInterception_WrapInitError(t *testing.T) {
 	assert.Contains(t, err.Error(), "wrap-init")
 }
 
+func TestBuildWrapEnv_IncludesInSessionWhenBypassEnabled(t *testing.T) {
+	env := buildWrapEnv([]string{"PATH=/usr/bin"}, "sess-123", "http://127.0.0.1:18080", true)
+	envMap := make(map[string]bool)
+	for _, e := range env {
+		envMap[e] = true
+	}
+
+	assert.True(t, envMap["AGENTSH_SESSION_ID=sess-123"])
+	assert.True(t, envMap["AGENTSH_SERVER=http://127.0.0.1:18080"])
+	assert.True(t, envMap["AGENTSH_IN_SESSION=1"])
+}
+
+func TestBuildWrapEnv_OmitsInSessionWhenBypassDisabled(t *testing.T) {
+	env := buildWrapEnv([]string{"PATH=/usr/bin"}, "sess-123", "http://127.0.0.1:18080", false)
+	for _, e := range env {
+		if e == "AGENTSH_IN_SESSION=1" {
+			t.Fatal("did not expect AGENTSH_IN_SESSION when bypass is disabled")
+		}
+	}
+}
+
 func TestWrapLaunchConfig_EnvContainsSessionAndWrapper(t *testing.T) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("wrap interception requires Linux or macOS")
@@ -345,6 +368,72 @@ func TestWrapLaunchConfig_EnvContainsSessionAndWrapper(t *testing.T) {
 	}
 
 	// Clean up
+	for _, f := range lcfg.extraFiles {
+		if f != nil {
+			f.Close()
+		}
+	}
+}
+
+func TestWrapLaunchConfig_EnvIncludesInSessionWhenSafe(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("wrap interception requires Linux or macOS")
+	}
+
+	mc := &mockWrapClient{
+		wrapInitResp: types.WrapInitResponse{
+			WrapperBinary:         "/bin/true",
+			NotifySocket:          "/tmp/agentsh-notify-test.sock",
+			SafeToBypassShellShim: true,
+			WrapperEnv: map[string]string{
+				"AGENTSH_SECCOMP_CONFIG": `{"unix_socket_enabled":true}`,
+			},
+		},
+	}
+
+	cfg := &clientConfig{serverAddr: "http://127.0.0.1:18080"}
+	lcfg, err := setupWrapInterception(context.Background(), mc, "test-session", "/bin/echo", nil, cfg)
+	require.NoError(t, err)
+
+	envMap := make(map[string]bool)
+	for _, e := range lcfg.env {
+		envMap[e] = true
+	}
+	assert.True(t, envMap["AGENTSH_IN_SESSION=1"])
+
+	for _, f := range lcfg.extraFiles {
+		if f != nil {
+			f.Close()
+		}
+	}
+}
+
+func TestWrapLaunchConfig_EnvOmitsInSessionWhenUnsafe(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("wrap interception requires Linux or macOS")
+	}
+
+	mc := &mockWrapClient{
+		wrapInitResp: types.WrapInitResponse{
+			WrapperBinary:         "/bin/true",
+			NotifySocket:          "/tmp/agentsh-notify-test.sock",
+			SafeToBypassShellShim: false,
+			WrapperEnv: map[string]string{
+				"AGENTSH_SECCOMP_CONFIG": `{"unix_socket_enabled":true}`,
+			},
+		},
+	}
+
+	cfg := &clientConfig{serverAddr: "http://127.0.0.1:18080"}
+	lcfg, err := setupWrapInterception(context.Background(), mc, "test-session", "/bin/echo", nil, cfg)
+	require.NoError(t, err)
+
+	for _, e := range lcfg.env {
+		if e == "AGENTSH_IN_SESSION=1" {
+			t.Fatal("did not expect AGENTSH_IN_SESSION when wrap response marks bypass unsafe")
+		}
+	}
+
 	for _, f := range lcfg.extraFiles {
 		if f != nil {
 			f.Close()

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -380,6 +380,56 @@ func TestBuildWrapEnv_ReplacesInheritedAgentshVarsWhenBypassEnabled(t *testing.T
 	assert.Equal(t, 0, envMap["AGENTSH_SERVER=http://stale"])
 }
 
+func TestBuildWrapEnv_StripsInheritedMixedCaseAgentshVarsWhenBypassDisabled(t *testing.T) {
+	env := buildWrapEnv([]string{
+		"PATH=/usr/bin",
+		"agentsh_session_id=stale-session",
+		"Agentsh_Server=http://stale",
+		"agentsh_in_session=1",
+	}, "sess-123", "http://127.0.0.1:18080", false)
+
+	for _, e := range env {
+		if e == "agentsh_in_session=1" {
+			t.Fatal("did not expect mixed-case inherited AGENTSH_IN_SESSION when bypass is disabled")
+		}
+		if e == "agentsh_session_id=stale-session" {
+			t.Fatal("did not expect mixed-case stale AGENTSH_SESSION_ID to remain in env")
+		}
+		if e == "Agentsh_Server=http://stale" {
+			t.Fatal("did not expect mixed-case stale AGENTSH_SERVER to remain in env")
+		}
+	}
+
+	envMap := make(map[string]int)
+	for _, e := range env {
+		envMap[e]++
+	}
+	assert.Equal(t, 1, envMap["AGENTSH_SESSION_ID=sess-123"])
+	assert.Equal(t, 1, envMap["AGENTSH_SERVER=http://127.0.0.1:18080"])
+	assert.Equal(t, 0, envMap["AGENTSH_IN_SESSION=1"])
+}
+
+func TestBuildWrapEnv_ReplacesInheritedMixedCaseAgentshVarsWhenBypassEnabled(t *testing.T) {
+	env := buildWrapEnv([]string{
+		"PATH=/usr/bin",
+		"agentsh_session_id=stale-session",
+		"Agentsh_Server=http://stale",
+		"agentsh_in_session=1",
+	}, "sess-123", "http://127.0.0.1:18080", true)
+
+	envMap := make(map[string]int)
+	for _, e := range env {
+		envMap[e]++
+	}
+
+	assert.Equal(t, 1, envMap["AGENTSH_SESSION_ID=sess-123"])
+	assert.Equal(t, 1, envMap["AGENTSH_SERVER=http://127.0.0.1:18080"])
+	assert.Equal(t, 1, envMap["AGENTSH_IN_SESSION=1"])
+	assert.Equal(t, 0, envMap["agentsh_session_id=stale-session"])
+	assert.Equal(t, 0, envMap["Agentsh_Server=http://stale"])
+	assert.Equal(t, 0, envMap["agentsh_in_session=1"])
+}
+
 func TestWrapLaunchConfig_EnvContainsSessionAndWrapper(t *testing.T) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("wrap interception requires Linux or macOS")

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -332,6 +332,54 @@ func TestBuildWrapEnv_OmitsInSessionWhenBypassDisabled(t *testing.T) {
 	}
 }
 
+func TestBuildWrapEnv_StripsInheritedAgentshVarsWhenBypassDisabled(t *testing.T) {
+	env := buildWrapEnv([]string{
+		"PATH=/usr/bin",
+		"AGENTSH_SESSION_ID=stale-session",
+		"AGENTSH_SERVER=http://stale",
+		"AGENTSH_IN_SESSION=1",
+	}, "sess-123", "http://127.0.0.1:18080", false)
+
+	for _, e := range env {
+		if e == "AGENTSH_IN_SESSION=1" {
+			t.Fatal("did not expect inherited AGENTSH_IN_SESSION when bypass is disabled")
+		}
+		if e == "AGENTSH_SESSION_ID=stale-session" {
+			t.Fatal("did not expect stale AGENTSH_SESSION_ID to remain in env")
+		}
+		if e == "AGENTSH_SERVER=http://stale" {
+			t.Fatal("did not expect stale AGENTSH_SERVER to remain in env")
+		}
+	}
+
+	envMap := make(map[string]int)
+	for _, e := range env {
+		envMap[e]++
+	}
+	assert.Equal(t, 1, envMap["AGENTSH_SESSION_ID=sess-123"])
+	assert.Equal(t, 1, envMap["AGENTSH_SERVER=http://127.0.0.1:18080"])
+}
+
+func TestBuildWrapEnv_ReplacesInheritedAgentshVarsWhenBypassEnabled(t *testing.T) {
+	env := buildWrapEnv([]string{
+		"PATH=/usr/bin",
+		"AGENTSH_SESSION_ID=stale-session",
+		"AGENTSH_SERVER=http://stale",
+		"AGENTSH_IN_SESSION=1",
+	}, "sess-123", "http://127.0.0.1:18080", true)
+
+	envMap := make(map[string]int)
+	for _, e := range env {
+		envMap[e]++
+	}
+
+	assert.Equal(t, 1, envMap["AGENTSH_SESSION_ID=sess-123"])
+	assert.Equal(t, 1, envMap["AGENTSH_SERVER=http://127.0.0.1:18080"])
+	assert.Equal(t, 1, envMap["AGENTSH_IN_SESSION=1"])
+	assert.Equal(t, 0, envMap["AGENTSH_SESSION_ID=stale-session"])
+	assert.Equal(t, 0, envMap["AGENTSH_SERVER=http://stale"])
+}
+
 func TestWrapLaunchConfig_EnvContainsSessionAndWrapper(t *testing.T) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("wrap interception requires Linux or macOS")

--- a/internal/cli/wrap_windows.go
+++ b/internal/cli/wrap_windows.go
@@ -15,11 +15,7 @@ import (
 // Like macOS, Windows uses a system-wide driver (agentsh.sys) for exec
 // interception, so the agent runs directly without a wrapper binary.
 func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, sessID string, agentPath string, agentArgs []string, cfg *clientConfig) (*wrapLaunchConfig, error) {
-	env := os.Environ()
-	env = append(env,
-		fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessID),
-		fmt.Sprintf("AGENTSH_SERVER=%s", cfg.serverAddr),
-	)
+	env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
 	for k, v := range wrapResp.WrapperEnv {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}

--- a/internal/integration/agentsh_wrap_linux_test.go
+++ b/internal/integration/agentsh_wrap_linux_test.go
@@ -1,0 +1,213 @@
+//go:build integration && linux
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/client"
+	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const wrapStrongTestConfigYAML = `
+server:
+  http:
+    addr: "0.0.0.0:18080"
+auth:
+  type: "api_key"
+  api_key:
+    keys_file: "/keys.yaml"
+    header_name: "X-API-Key"
+logging:
+  level: "info"
+  format: "text"
+  output: "stdout"
+audit:
+  enabled: false
+  storage:
+    sqlite_path: "/tmp/events.db"
+sessions:
+  base_dir: "/sessions"
+sandbox:
+  fuse:
+    enabled: false
+  network:
+    enabled: false
+  unix_sockets:
+    enabled: true
+    wrapper_bin: "/usr/local/bin/agentsh-unixwrap"
+  seccomp:
+    unix_socket:
+      enabled: true
+    execve:
+      enabled: true
+policies:
+  dir: "/policies"
+  default: "agent-default"
+approvals:
+  enabled: false
+metrics:
+  enabled: false
+health:
+  path: "/health"
+`
+
+func TestWrapStrongMode_SetsInSessionMarker(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	agentshBin, unixwrapBin := buildSeccompBinaries(t)
+	temp := t.TempDir()
+
+	configPath := filepath.Join(temp, "config.yaml")
+	writeFile(t, configPath, wrapStrongTestConfigYAML)
+	keysPath := filepath.Join(temp, "keys.yaml")
+	writeFile(t, keysPath, testAPIKeysYAML)
+
+	policiesDir := filepath.Join(temp, "policies")
+	mustMkdir(t, policiesDir)
+	writeFile(t, filepath.Join(policiesDir, "agent-default.yaml"), wrapTestPolicyYAML)
+
+	workspace := filepath.Join(temp, "workspace")
+	mustMkdir(t, workspace)
+
+	ctr, endpoint, cleanup := startWrapSeccompServerContainer(t, ctx, agentshBin, unixwrapBin, configPath, keysPath, policiesDir, workspace)
+	t.Cleanup(cleanup)
+
+	cli := client.New(endpoint, "test-key")
+
+	probeSess, err := cli.CreateSession(ctx, "/workspace", "agent-default")
+	if err != nil {
+		t.Fatalf("CreateSession probe: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cli.DestroySession(context.Background(), probeSess.ID); err != nil {
+			t.Logf("DestroySession probe: %v", err)
+		}
+	})
+
+	probeCtx, probeCancel := context.WithTimeout(ctx, 10*time.Second)
+	probeResult, probeErr := cli.Exec(probeCtx, probeSess.ID, types.ExecRequest{
+		Command: "/bin/echo",
+		Args:    []string{"probe"},
+	})
+	probeCancel()
+
+	if probeErr != nil {
+		if errors.Is(probeErr, context.DeadlineExceeded) || strings.Contains(probeErr.Error(), "deadline exceeded") {
+			t.Skip("seccomp-user-notify appears unreliable in this environment (probe timeout)")
+		}
+		t.Fatalf("Exec probe: %v", probeErr)
+	}
+	if probeResult.Result.ExitCode != 0 {
+		t.Skip("seccomp-user-notify may not be active in this environment (probe exit non-zero)")
+	}
+
+	exitCode, outputReader, err := ctr.Exec(ctx, []string{
+		"/bin/sh", "-lc",
+		`timeout 20s env AGENTSH_NO_AUTO=1 AGENTSH_API_KEY=test-key /usr/local/bin/agentsh --server http://127.0.0.1:18080 wrap -- /bin/sh -c 'if [ -n "$AGENTSH_IN_SESSION" ]; then echo MARKER_SET; else echo MARKER_UNSET; fi' 2>&1`,
+	})
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "deadline exceeded") {
+			t.Skip("seccomp wrap execution appears unreliable in this environment (wrap timeout)")
+		}
+		t.Fatalf("wrap exec: %v", err)
+	}
+	logBytes, err := io.ReadAll(outputReader)
+	if err != nil {
+		t.Fatalf("read wrap exec output: %v", err)
+	}
+	logOutput := string(logBytes)
+
+	if exitCode == 124 {
+		t.Skipf("seccomp wrap execution appears unreliable in this environment (wrap timed out)\n%s", logOutput)
+	}
+	if exitCode != 0 {
+		t.Fatalf("wrap exec exit=%d output:\n%s", exitCode, logOutput)
+	}
+	if !strings.Contains(logOutput, "MARKER_SET") {
+		t.Fatalf("expected MARKER_SET in strong wrap output, got:\n%s", logOutput)
+	}
+	if strings.Contains(logOutput, "MARKER_UNSET") {
+		t.Fatalf("did not expect MARKER_UNSET in strong wrap output, got:\n%s", logOutput)
+	}
+}
+
+func startWrapSeccompServerContainer(
+	t *testing.T,
+	ctx context.Context,
+	agentshBin string,
+	unixwrapBin string,
+	configPath string,
+	keysPath string,
+	policiesDir string,
+	workspace string,
+) (testcontainers.Container, string, func()) {
+	t.Helper()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "debian:bookworm-slim",
+		ExposedPorts: []string{"18080/tcp"},
+		Cmd:          []string{"/usr/local/bin/agentsh", "server", "--config", "/config.yaml"},
+		Mounts: []testcontainers.ContainerMount{
+			testcontainers.BindMount(agentshBin, "/usr/local/bin/agentsh"),
+			testcontainers.BindMount(unixwrapBin, "/usr/local/bin/agentsh-unixwrap"),
+			testcontainers.BindMount(configPath, "/config.yaml"),
+			testcontainers.BindMount(keysPath, "/keys.yaml"),
+			testcontainers.BindMount(policiesDir, "/policies"),
+			testcontainers.BindMount(workspace, "/workspace"),
+		},
+		Privileged: true,
+		CapAdd:     []string{"SYS_ADMIN"},
+		HostConfigModifier: func(hc *container.HostConfig) {
+			hc.SecurityOpt = []string{"apparmor:unconfined", "seccomp:unconfined"}
+		},
+		WaitingFor: wait.ForHTTP("/health").
+			WithPort("18080/tcp").
+			WithStartupTimeout(60 * time.Second).
+			WithStatusCodeMatcher(func(code int) bool { return code >= 200 && code < 500 }),
+	}
+
+	ctr, err := startContainerWithRetry(t, ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatalf("start seccomp server container: %v", err)
+	}
+
+	host, err := ctr.Host(ctx)
+	if err != nil {
+		t.Fatalf("container host: %v", err)
+	}
+	mappedPort, err := ctr.MappedPort(ctx, "18080/tcp")
+	if err != nil {
+		t.Fatalf("map port: %v", err)
+	}
+	endpoint := fmt.Sprintf("http://%s:%s", host, mappedPort.Port())
+
+	cleanup := func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cleanupCancel()
+		if logs, err := ctr.Logs(cleanupCtx); err == nil {
+			defer logs.Close()
+			b, _ := io.ReadAll(logs)
+			if len(b) > 0 {
+				t.Logf("container logs:\n%s", string(b))
+			}
+		}
+		_ = ctr.Terminate(cleanupCtx)
+	}
+
+	return ctr, endpoint, cleanup
+}

--- a/internal/integration/agentsh_wrap_test.go
+++ b/internal/integration/agentsh_wrap_test.go
@@ -4,12 +4,16 @@ package integration
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/agentsh/agentsh/internal/client"
+	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -69,9 +73,12 @@ resource_limits:
 const wrapStrongTestConfigYAML = `
 server:
   http:
-    addr: "127.0.0.1:18080"
+    addr: "0.0.0.0:18080"
 auth:
-  type: "none"
+  type: "api_key"
+  api_key:
+    keys_file: "/keys.yaml"
+    header_name: "X-API-Key"
 logging:
   level: "info"
   format: "text"
@@ -87,15 +94,14 @@ sandbox:
     enabled: false
   network:
     enabled: false
-  ptrace:
-    enabled: true
-    trace:
-      execve: true
   unix_sockets:
-    enabled: false
+    enabled: true
+    wrapper_bin: "/usr/local/bin/agentsh-unixwrap"
   seccomp:
+    unix_socket:
+      enabled: true
     execve:
-      enabled: false
+      enabled: true
 policies:
   dir: "/policies"
   default: "agent-default"
@@ -264,13 +270,16 @@ func TestWrapFallback_OmitsInSessionMarker(t *testing.T) {
 }
 
 func TestWrapStrongMode_SetsInSessionMarker(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 
 	agentshBin, unixwrapBin := buildSeccompBinaries(t)
 	temp := t.TempDir()
 
 	configPath := filepath.Join(temp, "config.yaml")
 	writeFile(t, configPath, wrapStrongTestConfigYAML)
+	keysPath := filepath.Join(temp, "keys.yaml")
+	writeFile(t, keysPath, testAPIKeysYAML)
 
 	policiesDir := filepath.Join(temp, "policies")
 	mustMkdir(t, policiesDir)
@@ -279,23 +288,98 @@ func TestWrapStrongMode_SetsInSessionMarker(t *testing.T) {
 	workspace := filepath.Join(temp, "workspace")
 	mustMkdir(t, workspace)
 
+	ctr, endpoint, cleanup := startWrapSeccompServerContainer(t, ctx, agentshBin, unixwrapBin, configPath, keysPath, policiesDir, workspace)
+	t.Cleanup(cleanup)
+
+	cli := client.New(endpoint, "test-key")
+
+	probeSess, err := cli.CreateSession(ctx, "/workspace", "agent-default")
+	if err != nil {
+		t.Fatalf("CreateSession probe: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cli.DestroySession(context.Background(), probeSess.ID); err != nil {
+			t.Logf("DestroySession probe: %v", err)
+		}
+	})
+
+	probeCtx, probeCancel := context.WithTimeout(ctx, 10*time.Second)
+	probeResult, probeErr := cli.Exec(probeCtx, probeSess.ID, types.ExecRequest{
+		Command: "/bin/echo",
+		Args:    []string{"probe"},
+	})
+	probeCancel()
+
+	if probeErr != nil {
+		if errors.Is(probeErr, context.DeadlineExceeded) || strings.Contains(probeErr.Error(), "deadline exceeded") {
+			t.Skip("seccomp-user-notify appears unreliable in this environment (probe timeout)")
+		}
+		t.Fatalf("Exec probe: %v", probeErr)
+	}
+	if probeResult.Result.ExitCode != 0 {
+		t.Skip("seccomp-user-notify may not be active in this environment (probe exit non-zero)")
+	}
+
+	exitCode, outputReader, err := ctr.Exec(ctx, []string{
+		"/bin/sh", "-lc",
+		`timeout 20s env AGENTSH_NO_AUTO=1 AGENTSH_API_KEY=test-key /usr/local/bin/agentsh --server http://127.0.0.1:18080 wrap -- /usr/bin/env 2>&1`,
+	})
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "deadline exceeded") {
+			t.Skip("seccomp wrap execution appears unreliable in this environment (wrap timeout)")
+		}
+		t.Fatalf("wrap exec: %v", err)
+	}
+	logBytes, err := io.ReadAll(outputReader)
+	if err != nil {
+		t.Fatalf("read wrap exec output: %v", err)
+	}
+	logOutput := string(logBytes)
+
+	if exitCode == 124 {
+		t.Skipf("seccomp wrap execution appears unreliable in this environment (wrap timed out)\n%s", logOutput)
+	}
+	if exitCode != 0 {
+		t.Fatalf("wrap exec exit=%d output:\n%s", exitCode, logOutput)
+	}
+	if !strings.Contains(logOutput, "AGENTSH_IN_SESSION=1") {
+		t.Fatalf("expected AGENTSH_IN_SESSION=1 in strong wrap output, got:\n%s", logOutput)
+	}
+}
+
+func startWrapSeccompServerContainer(
+	t *testing.T,
+	ctx context.Context,
+	agentshBin string,
+	unixwrapBin string,
+	configPath string,
+	keysPath string,
+	policiesDir string,
+	workspace string,
+) (testcontainers.Container, string, func()) {
+	t.Helper()
+
 	req := testcontainers.ContainerRequest{
-		Image: "debian:bookworm-slim",
-		Cmd:   []string{"/usr/local/bin/agentsh", "wrap", "--", "/usr/bin/env"},
+		Image:        "debian:bookworm-slim",
+		ExposedPorts: []string{"18080/tcp"},
+		Cmd:          []string{"/usr/local/bin/agentsh", "server", "--config", "/config.yaml"},
 		Mounts: []testcontainers.ContainerMount{
 			testcontainers.BindMount(agentshBin, "/usr/local/bin/agentsh"),
 			testcontainers.BindMount(unixwrapBin, "/usr/local/bin/agentsh-unixwrap"),
 			testcontainers.BindMount(configPath, "/config.yaml"),
+			testcontainers.BindMount(keysPath, "/keys.yaml"),
 			testcontainers.BindMount(policiesDir, "/policies"),
 			testcontainers.BindMount(workspace, "/workspace"),
 		},
-		Env:        map[string]string{"AGENTSH_CONFIG": "/config.yaml"},
 		Privileged: true,
+		CapAdd:     []string{"SYS_ADMIN"},
 		HostConfigModifier: func(hc *container.HostConfig) {
 			hc.SecurityOpt = []string{"apparmor:unconfined", "seccomp:unconfined"}
-			hc.CapAdd = []string{"SYS_PTRACE"}
 		},
-		WaitingFor: wait.ForExit().WithExitTimeout(30 * time.Second),
+		WaitingFor: wait.ForHTTP("/health").
+			WithPort("18080/tcp").
+			WithStartupTimeout(60 * time.Second).
+			WithStatusCodeMatcher(func(code int) bool { return code >= 200 && code < 500 }),
 	}
 
 	ctr, err := startContainerWithRetry(t, ctx, testcontainers.GenericContainerRequest{
@@ -303,23 +387,31 @@ func TestWrapStrongMode_SetsInSessionMarker(t *testing.T) {
 		Started:          true,
 	})
 	if err != nil {
-		t.Fatalf("start container: %v", err)
+		t.Fatalf("start seccomp server container: %v", err)
 	}
-	defer func() { _ = ctr.Terminate(context.Background()) }()
 
-	logs, err := ctr.Logs(ctx)
+	host, err := ctr.Host(ctx)
 	if err != nil {
-		t.Fatalf("get logs: %v", err)
+		t.Fatalf("container host: %v", err)
 	}
-	defer logs.Close()
-
-	logBytes, err := io.ReadAll(logs)
+	mappedPort, err := ctr.MappedPort(ctx, "18080/tcp")
 	if err != nil {
-		t.Fatalf("read logs: %v", err)
+		t.Fatalf("map port: %v", err)
 	}
-	logOutput := string(logBytes)
+	endpoint := fmt.Sprintf("http://%s:%s", host, mappedPort.Port())
 
-	if !strings.Contains(logOutput, "AGENTSH_IN_SESSION=1") {
-		t.Fatalf("expected AGENTSH_IN_SESSION=1 in strong wrap output, got:\n%s", logOutput)
+	cleanup := func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cleanupCancel()
+		if logs, err := ctr.Logs(cleanupCtx); err == nil {
+			defer logs.Close()
+			b, _ := io.ReadAll(logs)
+			if len(b) > 0 {
+				t.Logf("container logs:\n%s", string(b))
+			}
+		}
+		_ = ctr.Terminate(cleanupCtx)
 	}
+
+	return ctr, endpoint, cleanup
 }

--- a/internal/integration/agentsh_wrap_test.go
+++ b/internal/integration/agentsh_wrap_test.go
@@ -4,16 +4,12 @@ package integration
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/agentsh/agentsh/internal/client"
-	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -68,49 +64,6 @@ resource_limits:
   command_timeout: 30s
   session_timeout: 1h
   idle_timeout: 30m
-`
-
-const wrapStrongTestConfigYAML = `
-server:
-  http:
-    addr: "0.0.0.0:18080"
-auth:
-  type: "api_key"
-  api_key:
-    keys_file: "/keys.yaml"
-    header_name: "X-API-Key"
-logging:
-  level: "info"
-  format: "text"
-  output: "stdout"
-audit:
-  enabled: false
-  storage:
-    sqlite_path: "/tmp/events.db"
-sessions:
-  base_dir: "/sessions"
-sandbox:
-  fuse:
-    enabled: false
-  network:
-    enabled: false
-  unix_sockets:
-    enabled: true
-    wrapper_bin: "/usr/local/bin/agentsh-unixwrap"
-  seccomp:
-    unix_socket:
-      enabled: true
-    execve:
-      enabled: true
-policies:
-  dir: "/policies"
-  default: "agent-default"
-approvals:
-  enabled: false
-metrics:
-  enabled: false
-health:
-  path: "/health"
 `
 
 func TestWrapAutoStart(t *testing.T) {
@@ -228,7 +181,8 @@ func TestWrapFallback_OmitsInSessionMarker(t *testing.T) {
 	req := testcontainers.ContainerRequest{
 		Image: "debian:bookworm-slim",
 		Cmd: []string{
-			"/usr/local/bin/agentsh", "wrap", "--", "/usr/bin/env",
+			"/usr/local/bin/agentsh", "wrap", "--",
+			"/bin/sh", "-c", `if [ -n "$AGENTSH_IN_SESSION" ]; then echo MARKER_SET; else echo MARKER_UNSET; fi`,
 		},
 		Mounts: []testcontainers.ContainerMount{
 			testcontainers.BindMount(bin, "/usr/local/bin/agentsh"),
@@ -243,7 +197,7 @@ func TestWrapFallback_OmitsInSessionMarker(t *testing.T) {
 		WaitingFor: wait.ForExit().WithExitTimeout(30 * time.Second),
 	}
 
-	ctr, err := startContainerWithRetry(t, ctx, testcontainers.GenericContainerRequest{
+	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
@@ -264,154 +218,17 @@ func TestWrapFallback_OmitsInSessionMarker(t *testing.T) {
 	}
 	logOutput := string(logBytes)
 
-	if strings.Contains(logOutput, "AGENTSH_IN_SESSION=1") {
-		t.Fatalf("did not expect AGENTSH_IN_SESSION=1 in fallback wrap output, got:\n%s", logOutput)
-	}
-}
-
-func TestWrapStrongMode_SetsInSessionMarker(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	agentshBin, unixwrapBin := buildSeccompBinaries(t)
-	temp := t.TempDir()
-
-	configPath := filepath.Join(temp, "config.yaml")
-	writeFile(t, configPath, wrapStrongTestConfigYAML)
-	keysPath := filepath.Join(temp, "keys.yaml")
-	writeFile(t, keysPath, testAPIKeysYAML)
-
-	policiesDir := filepath.Join(temp, "policies")
-	mustMkdir(t, policiesDir)
-	writeFile(t, filepath.Join(policiesDir, "agent-default.yaml"), wrapTestPolicyYAML)
-
-	workspace := filepath.Join(temp, "workspace")
-	mustMkdir(t, workspace)
-
-	ctr, endpoint, cleanup := startWrapSeccompServerContainer(t, ctx, agentshBin, unixwrapBin, configPath, keysPath, policiesDir, workspace)
-	t.Cleanup(cleanup)
-
-	cli := client.New(endpoint, "test-key")
-
-	probeSess, err := cli.CreateSession(ctx, "/workspace", "agent-default")
+	state, err := ctr.State(ctx)
 	if err != nil {
-		t.Fatalf("CreateSession probe: %v", err)
+		t.Fatalf("get container state: %v", err)
 	}
-	t.Cleanup(func() {
-		if err := cli.DestroySession(context.Background(), probeSess.ID); err != nil {
-			t.Logf("DestroySession probe: %v", err)
-		}
-	})
-
-	probeCtx, probeCancel := context.WithTimeout(ctx, 10*time.Second)
-	probeResult, probeErr := cli.Exec(probeCtx, probeSess.ID, types.ExecRequest{
-		Command: "/bin/echo",
-		Args:    []string{"probe"},
-	})
-	probeCancel()
-
-	if probeErr != nil {
-		if errors.Is(probeErr, context.DeadlineExceeded) || strings.Contains(probeErr.Error(), "deadline exceeded") {
-			t.Skip("seccomp-user-notify appears unreliable in this environment (probe timeout)")
-		}
-		t.Fatalf("Exec probe: %v", probeErr)
+	if state.ExitCode != 0 {
+		t.Fatalf("container exited with code %d, expected 0; logs:\n%s", state.ExitCode, logOutput)
 	}
-	if probeResult.Result.ExitCode != 0 {
-		t.Skip("seccomp-user-notify may not be active in this environment (probe exit non-zero)")
+	if !strings.Contains(logOutput, "MARKER_UNSET") {
+		t.Fatalf("expected MARKER_UNSET in fallback wrap output, got:\n%s", logOutput)
 	}
-
-	exitCode, outputReader, err := ctr.Exec(ctx, []string{
-		"/bin/sh", "-lc",
-		`timeout 20s env AGENTSH_NO_AUTO=1 AGENTSH_API_KEY=test-key /usr/local/bin/agentsh --server http://127.0.0.1:18080 wrap -- /usr/bin/env 2>&1`,
-	})
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "deadline exceeded") {
-			t.Skip("seccomp wrap execution appears unreliable in this environment (wrap timeout)")
-		}
-		t.Fatalf("wrap exec: %v", err)
+	if strings.Contains(logOutput, "MARKER_SET") {
+		t.Fatalf("did not expect MARKER_SET in fallback wrap output, got:\n%s", logOutput)
 	}
-	logBytes, err := io.ReadAll(outputReader)
-	if err != nil {
-		t.Fatalf("read wrap exec output: %v", err)
-	}
-	logOutput := string(logBytes)
-
-	if exitCode == 124 {
-		t.Skipf("seccomp wrap execution appears unreliable in this environment (wrap timed out)\n%s", logOutput)
-	}
-	if exitCode != 0 {
-		t.Fatalf("wrap exec exit=%d output:\n%s", exitCode, logOutput)
-	}
-	if !strings.Contains(logOutput, "AGENTSH_IN_SESSION=1") {
-		t.Fatalf("expected AGENTSH_IN_SESSION=1 in strong wrap output, got:\n%s", logOutput)
-	}
-}
-
-func startWrapSeccompServerContainer(
-	t *testing.T,
-	ctx context.Context,
-	agentshBin string,
-	unixwrapBin string,
-	configPath string,
-	keysPath string,
-	policiesDir string,
-	workspace string,
-) (testcontainers.Container, string, func()) {
-	t.Helper()
-
-	req := testcontainers.ContainerRequest{
-		Image:        "debian:bookworm-slim",
-		ExposedPorts: []string{"18080/tcp"},
-		Cmd:          []string{"/usr/local/bin/agentsh", "server", "--config", "/config.yaml"},
-		Mounts: []testcontainers.ContainerMount{
-			testcontainers.BindMount(agentshBin, "/usr/local/bin/agentsh"),
-			testcontainers.BindMount(unixwrapBin, "/usr/local/bin/agentsh-unixwrap"),
-			testcontainers.BindMount(configPath, "/config.yaml"),
-			testcontainers.BindMount(keysPath, "/keys.yaml"),
-			testcontainers.BindMount(policiesDir, "/policies"),
-			testcontainers.BindMount(workspace, "/workspace"),
-		},
-		Privileged: true,
-		CapAdd:     []string{"SYS_ADMIN"},
-		HostConfigModifier: func(hc *container.HostConfig) {
-			hc.SecurityOpt = []string{"apparmor:unconfined", "seccomp:unconfined"}
-		},
-		WaitingFor: wait.ForHTTP("/health").
-			WithPort("18080/tcp").
-			WithStartupTimeout(60 * time.Second).
-			WithStatusCodeMatcher(func(code int) bool { return code >= 200 && code < 500 }),
-	}
-
-	ctr, err := startContainerWithRetry(t, ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
-	if err != nil {
-		t.Fatalf("start seccomp server container: %v", err)
-	}
-
-	host, err := ctr.Host(ctx)
-	if err != nil {
-		t.Fatalf("container host: %v", err)
-	}
-	mappedPort, err := ctr.MappedPort(ctx, "18080/tcp")
-	if err != nil {
-		t.Fatalf("map port: %v", err)
-	}
-	endpoint := fmt.Sprintf("http://%s:%s", host, mappedPort.Port())
-
-	cleanup := func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 60*time.Second)
-		defer cleanupCancel()
-		if logs, err := ctr.Logs(cleanupCtx); err == nil {
-			defer logs.Close()
-			b, _ := io.ReadAll(logs)
-			if len(b) > 0 {
-				t.Logf("container logs:\n%s", string(b))
-			}
-		}
-		_ = ctr.Terminate(cleanupCtx)
-	}
-
-	return ctr, endpoint, cleanup
 }

--- a/internal/integration/agentsh_wrap_test.go
+++ b/internal/integration/agentsh_wrap_test.go
@@ -190,7 +190,10 @@ func TestWrapFallback_OmitsInSessionMarker(t *testing.T) {
 			testcontainers.BindMount(policiesDir, "/policies"),
 			testcontainers.BindMount(workspace, "/workspace"),
 		},
-		Env: map[string]string{"AGENTSH_CONFIG": "/config.yaml"},
+		Env: map[string]string{
+			"AGENTSH_CONFIG":     "/config.yaml",
+			"AGENTSH_IN_SESSION": "1",
+		},
 		HostConfigModifier: func(hc *container.HostConfig) {
 			hc.SecurityOpt = []string{"apparmor:unconfined", "seccomp:unconfined"}
 		},

--- a/internal/integration/agentsh_wrap_test.go
+++ b/internal/integration/agentsh_wrap_test.go
@@ -66,6 +66,47 @@ resource_limits:
   idle_timeout: 30m
 `
 
+const wrapStrongTestConfigYAML = `
+server:
+  http:
+    addr: "127.0.0.1:18080"
+auth:
+  type: "none"
+logging:
+  level: "info"
+  format: "text"
+  output: "stdout"
+audit:
+  enabled: false
+  storage:
+    sqlite_path: "/tmp/events.db"
+sessions:
+  base_dir: "/sessions"
+sandbox:
+  fuse:
+    enabled: false
+  network:
+    enabled: false
+  ptrace:
+    enabled: true
+    trace:
+      execve: true
+  unix_sockets:
+    enabled: false
+  seccomp:
+    execve:
+      enabled: false
+policies:
+  dir: "/policies"
+  default: "agent-default"
+approvals:
+  enabled: false
+metrics:
+  enabled: false
+health:
+  path: "/health"
+`
+
 func TestWrapAutoStart(t *testing.T) {
 	ctx := context.Background()
 
@@ -159,5 +200,126 @@ func TestWrapAutoStart(t *testing.T) {
 	// Verify the child command produced output
 	if !strings.Contains(logOutput, "hello") {
 		t.Error("expected 'hello' in output (echo command should have run)")
+	}
+}
+
+func TestWrapFallback_OmitsInSessionMarker(t *testing.T) {
+	ctx := context.Background()
+
+	bin := buildAgentshBinary(t)
+	temp := t.TempDir()
+
+	configPath := filepath.Join(temp, "config.yaml")
+	writeFile(t, configPath, wrapTestConfigYAML)
+
+	policiesDir := filepath.Join(temp, "policies")
+	mustMkdir(t, policiesDir)
+	writeFile(t, filepath.Join(policiesDir, "agent-default.yaml"), wrapTestPolicyYAML)
+
+	workspace := filepath.Join(temp, "workspace")
+	mustMkdir(t, workspace)
+
+	req := testcontainers.ContainerRequest{
+		Image: "debian:bookworm-slim",
+		Cmd: []string{
+			"/usr/local/bin/agentsh", "wrap", "--", "/usr/bin/env",
+		},
+		Mounts: []testcontainers.ContainerMount{
+			testcontainers.BindMount(bin, "/usr/local/bin/agentsh"),
+			testcontainers.BindMount(configPath, "/config.yaml"),
+			testcontainers.BindMount(policiesDir, "/policies"),
+			testcontainers.BindMount(workspace, "/workspace"),
+		},
+		Env: map[string]string{"AGENTSH_CONFIG": "/config.yaml"},
+		HostConfigModifier: func(hc *container.HostConfig) {
+			hc.SecurityOpt = []string{"apparmor:unconfined", "seccomp:unconfined"}
+		},
+		WaitingFor: wait.ForExit().WithExitTimeout(30 * time.Second),
+	}
+
+	ctr, err := startContainerWithRetry(t, ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatalf("start container: %v", err)
+	}
+	defer func() { _ = ctr.Terminate(context.Background()) }()
+
+	logs, err := ctr.Logs(ctx)
+	if err != nil {
+		t.Fatalf("get logs: %v", err)
+	}
+	defer logs.Close()
+
+	logBytes, err := io.ReadAll(logs)
+	if err != nil {
+		t.Fatalf("read logs: %v", err)
+	}
+	logOutput := string(logBytes)
+
+	if strings.Contains(logOutput, "AGENTSH_IN_SESSION=1") {
+		t.Fatalf("did not expect AGENTSH_IN_SESSION=1 in fallback wrap output, got:\n%s", logOutput)
+	}
+}
+
+func TestWrapStrongMode_SetsInSessionMarker(t *testing.T) {
+	ctx := context.Background()
+
+	agentshBin, unixwrapBin := buildSeccompBinaries(t)
+	temp := t.TempDir()
+
+	configPath := filepath.Join(temp, "config.yaml")
+	writeFile(t, configPath, wrapStrongTestConfigYAML)
+
+	policiesDir := filepath.Join(temp, "policies")
+	mustMkdir(t, policiesDir)
+	writeFile(t, filepath.Join(policiesDir, "agent-default.yaml"), wrapTestPolicyYAML)
+
+	workspace := filepath.Join(temp, "workspace")
+	mustMkdir(t, workspace)
+
+	req := testcontainers.ContainerRequest{
+		Image: "debian:bookworm-slim",
+		Cmd:   []string{"/usr/local/bin/agentsh", "wrap", "--", "/usr/bin/env"},
+		Mounts: []testcontainers.ContainerMount{
+			testcontainers.BindMount(agentshBin, "/usr/local/bin/agentsh"),
+			testcontainers.BindMount(unixwrapBin, "/usr/local/bin/agentsh-unixwrap"),
+			testcontainers.BindMount(configPath, "/config.yaml"),
+			testcontainers.BindMount(policiesDir, "/policies"),
+			testcontainers.BindMount(workspace, "/workspace"),
+		},
+		Env:        map[string]string{"AGENTSH_CONFIG": "/config.yaml"},
+		Privileged: true,
+		HostConfigModifier: func(hc *container.HostConfig) {
+			hc.SecurityOpt = []string{"apparmor:unconfined", "seccomp:unconfined"}
+			hc.CapAdd = []string{"SYS_PTRACE"}
+		},
+		WaitingFor: wait.ForExit().WithExitTimeout(30 * time.Second),
+	}
+
+	ctr, err := startContainerWithRetry(t, ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatalf("start container: %v", err)
+	}
+	defer func() { _ = ctr.Terminate(context.Background()) }()
+
+	logs, err := ctr.Logs(ctx)
+	if err != nil {
+		t.Fatalf("get logs: %v", err)
+	}
+	defer logs.Close()
+
+	logBytes, err := io.ReadAll(logs)
+	if err != nil {
+		t.Fatalf("read logs: %v", err)
+	}
+	logOutput := string(logBytes)
+
+	if !strings.Contains(logOutput, "AGENTSH_IN_SESSION=1") {
+		t.Fatalf("expected AGENTSH_IN_SESSION=1 in strong wrap output, got:\n%s", logOutput)
 	}
 }

--- a/internal/store/composite/composite.go
+++ b/internal/store/composite/composite.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/agentsh/agentsh/internal/audit"
@@ -12,7 +13,35 @@ import (
 	"github.com/agentsh/agentsh/pkg/types"
 )
 
+// Store fans an event out to a primary EventStore plus zero-or-more chained
+// sinks while owning the shared sequence allocator that stamps ev.Chain.
+//
+// Concurrency model:
+//
+//   - mu is a sync.RWMutex held outermost in this package. AppendEvent takes
+//     mu.RLock() for the duration of allocator.Next() AND the entire fanout
+//     so concurrent appends do not serialize against each other but DO
+//     serialize against the rotation paths.
+//   - NextGeneration takes mu.Lock(): it cannot return until every in-flight
+//     AppendEvent has completed its fanout, AND no new AppendEvent may begin
+//     until the rotation finishes. This is what makes the spec's "all chained
+//     sinks roll on the same logical event boundary" guarantee enforceable
+//     rather than aspirational — without it, an in-flight AppendEvent could
+//     stamp ev.Chain with the OLD generation while a sink that has already
+//     rekeyed observes the NEW generation, exactly the backwards-generation
+//     race SinkChain.Commit is designed to reject.
+//   - State and Restore take mu.Lock() so the snapshot reflects a state that
+//     no AppendEvent fanout is partway through and no NextGeneration is
+//     partway through.
+//
+// The allocator carries its own internal mutex — that is fine because the
+// allocator never calls back into the wrapper; lock order is always
+// composite.mu (outer) → allocator.mu (inner).
+//
+// This matches the wrapper-level mutex discipline established for
+// audit.IntegrityChain in commit 915251c7.
 type Store struct {
+	mu            sync.RWMutex
 	primary       store.EventStore
 	output        store.OutputStore
 	others        []store.EventStore
@@ -33,11 +62,40 @@ func (s *Store) SetAppendErrorHook(fn func(error)) {
 	s.onAppendError = fn
 }
 
+// AppendEvent allocates the shared (sequence, generation), stamps a
+// per-sink-fresh ev.Chain, and fans out to every configured sink.
+//
+// Pre-fanout sequence semantics: the shared sequence advances eagerly on
+// every successful allocator.Next() call, regardless of whether any sink
+// accepts the event. This matches the spec's TransportLoss semantics —
+// the shared sequence reflects what the system PRODUCED, not what each
+// sink DELIVERED. A sink that drops an event still observes a gap and
+// must emit its own loss marker.
+//
+// If allocator.Next() itself fails (overflow), no sequence is consumed
+// and the event is rejected before any sink sees it. The error is wrapped
+// as *store.FatalIntegrityError with Op == "audit sequence allocate" and
+// delivered through the onAppendError hook so the daemon's fatal-audit
+// watcher observes it (matching the convention used elsewhere in this
+// package; see internal/store/integrity_wrapper.go).
+//
+// Holds mu.RLock() for the entire stamp+fanout duration so NextGeneration
+// (which takes mu.Lock()) cannot interleave: any rotation that begins
+// after this AppendEvent started will block until this fanout completes,
+// guaranteeing the stamped ev.Chain.Generation is the generation in
+// effect at allocation time and that the same generation is observed by
+// every sink in this fanout.
 func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
-	// Phase 0: composite allocates the shared (seq, gen) once before fanout.
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	seq, gen, err := s.allocator.Next()
 	if err != nil {
-		return err
+		fatalErr := &store.FatalIntegrityError{Op: "audit sequence allocate", Err: err}
+		if s.onAppendError != nil {
+			s.onAppendError(fatalErr)
+		}
+		return fatalErr
 	}
 
 	// stampForSink returns ev with a FRESH *ChainState pointer so no two
@@ -89,10 +147,43 @@ func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
 // AppendEvent stamps ev.Chain with (Sequence:0, Generation:newGen).
 // Used by the composite owner when the chain key rotates.
 //
+// Acquires mu.Lock() so the rotation cannot interleave with any in-flight
+// AppendEvent fanout: this method blocks until every concurrent
+// AppendEvent (which holds mu.RLock()) has completed, AND no new
+// AppendEvent may begin until this method returns. After return, every
+// subsequent AppendEvent stamps the new generation; there is no window
+// where a stamped (seq, oldGen) event can race against sink rekeying.
+//
 // Returns ErrGenerationOverflow on uint32 wrap; the allocator is not
 // modified in that case (see audit.SequenceAllocator.NextGeneration).
 func (s *Store) NextGeneration() (uint32, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.allocator.NextGeneration()
+}
+
+// State returns the allocator's current (sequence, generation) for
+// persistence. Acquires mu.Lock() so the snapshot is taken while no
+// AppendEvent is mid-fanout and no NextGeneration is in progress —
+// the returned state is a consistent view of where the chain is.
+func (s *Store) State() audit.AllocatorState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.allocator.State()
+}
+
+// Restore rehydrates the allocator state after restart. Returns an error
+// wrapping audit.ErrInvalidAllocatorState on rejected input; the wrapper
+// is not modified in that case (delegated guarantee from
+// SequenceAllocator.Restore).
+//
+// Acquires mu.Lock() so Restore is serialized with both AppendEvent
+// fanout and NextGeneration. Phase 0 only adds the API; daemon wiring
+// for persist+restore across process restarts is out of scope.
+func (s *Store) Restore(state audit.AllocatorState) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.allocator.Restore(state)
 }
 
 func (s *Store) QueryEvents(ctx context.Context, q types.EventQuery) ([]types.Event, error) {

--- a/internal/store/composite/composite.go
+++ b/internal/store/composite/composite.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/agentsh/agentsh/internal/audit"
 	"github.com/agentsh/agentsh/internal/store"
 	"github.com/agentsh/agentsh/internal/store/sqlite"
 	"github.com/agentsh/agentsh/pkg/types"
@@ -15,11 +16,17 @@ type Store struct {
 	primary       store.EventStore
 	output        store.OutputStore
 	others        []store.EventStore
+	allocator     *audit.SequenceAllocator
 	onAppendError func(error)
 }
 
 func New(primary store.EventStore, output store.OutputStore, others ...store.EventStore) *Store {
-	return &Store{primary: primary, output: output, others: others}
+	return &Store{
+		primary:   primary,
+		output:    output,
+		others:    others,
+		allocator: audit.NewSequenceAllocator(),
+	}
 }
 
 func (s *Store) SetAppendErrorHook(fn func(error)) {
@@ -27,10 +34,25 @@ func (s *Store) SetAppendErrorHook(fn func(error)) {
 }
 
 func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
+	// Phase 0: composite allocates the shared (seq, gen) once before fanout.
+	seq, gen, err := s.allocator.Next()
+	if err != nil {
+		return err
+	}
+
+	// stampForSink returns ev with a FRESH *ChainState pointer so no two
+	// sinks ever alias the same ChainState. This is the per-sink-copy
+	// guarantee that prevents one sink's mutation from corrupting another.
+	stampForSink := func() types.Event {
+		stamped := ev
+		stamped.Chain = &types.ChainState{Sequence: uint64(seq), Generation: gen}
+		return stamped
+	}
+
 	var firstErr error
 	var hookErr error
 	if s.primary != nil {
-		if err := s.primary.AppendEvent(ctx, ev); err != nil {
+		if err := s.primary.AppendEvent(ctx, stampForSink()); err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
@@ -44,7 +66,7 @@ func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
 		}
 	}
 	for _, o := range s.others {
-		if err := o.AppendEvent(ctx, ev); err != nil {
+		if err := o.AppendEvent(ctx, stampForSink()); err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
@@ -61,6 +83,16 @@ func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
 		s.onAppendError(hookErr)
 	}
 	return firstErr
+}
+
+// NextGeneration advances the shared sequence generation. The next
+// AppendEvent stamps ev.Chain with (Sequence:0, Generation:newGen).
+// Used by the composite owner when the chain key rotates.
+//
+// Returns ErrGenerationOverflow on uint32 wrap; the allocator is not
+// modified in that case (see audit.SequenceAllocator.NextGeneration).
+func (s *Store) NextGeneration() (uint32, error) {
+	return s.allocator.NextGeneration()
 }
 
 func (s *Store) QueryEvents(ctx context.Context, q types.EventQuery) ([]types.Event, error) {

--- a/internal/store/composite/composite_test.go
+++ b/internal/store/composite/composite_test.go
@@ -3,9 +3,14 @@ package composite
 import (
 	"context"
 	"errors"
+	"math"
 	"reflect"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/agentsh/agentsh/internal/audit"
 	storepkg "github.com/agentsh/agentsh/internal/store"
 	"github.com/agentsh/agentsh/pkg/types"
 )
@@ -300,5 +305,440 @@ func TestComposite_NextGeneration_ResetsSequence(t *testing.T) {
 	last := primary.captured[len(primary.captured)-1]
 	if last == nil || last.Sequence != 0 || last.Generation != 1 {
 		t.Errorf("after rollover: Chain=(seq=%d,gen=%d) want (seq=0,gen=1)", last.Sequence, last.Generation)
+	}
+}
+
+// blockingEventStore blocks AppendEvent on a release channel so the test can
+// pin a goroutine inside the composite's per-event fanout. Used to verify
+// rollover atomicity: NextGeneration must NOT advance while an AppendEvent
+// is mid-fanout (and conversely, an AppendEvent that started before
+// NextGeneration must observe the OLD generation, not the new one).
+type blockingEventStore struct {
+	mu       sync.Mutex
+	captured []*types.ChainState
+	release  chan struct{} // close to release blocked AppendEvent
+	entered  chan struct{} // closed by AppendEvent when it has begun
+	once     sync.Once
+}
+
+func newBlockingEventStore() *blockingEventStore {
+	return &blockingEventStore{
+		release: make(chan struct{}),
+		entered: make(chan struct{}),
+	}
+}
+
+func (b *blockingEventStore) AppendEvent(ctx context.Context, ev types.Event) error {
+	b.once.Do(func() { close(b.entered) })
+	<-b.release
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.captured = append(b.captured, ev.Chain)
+	return nil
+}
+
+func (b *blockingEventStore) QueryEvents(ctx context.Context, q types.EventQuery) ([]types.Event, error) {
+	return nil, nil
+}
+func (b *blockingEventStore) Close() error { return nil }
+
+// TestComposite_NextGeneration_BlocksUntilInflightFanoutCompletes is the
+// regression test for the rollover-atomicity bug roborev caught: without a
+// wrapper-level RWMutex, NextGeneration can advance while an in-flight
+// AppendEvent is still mid-fanout. The first AppendEvent stamps with the
+// OLD generation, NextGeneration concurrently flips the allocator, and any
+// sink that has already rekeyed sees a backwards-generation event.
+//
+// With the fix in place, NextGeneration takes a write lock and waits for
+// every in-flight AppendEvent (which holds an RLock) to complete before
+// advancing the generation.
+func TestComposite_NextGeneration_BlocksUntilInflightFanoutCompletes(t *testing.T) {
+	blocker := newBlockingEventStore()
+	tail := &chainCapturingStore{}
+	s := New(blocker, nil, tail)
+
+	// Goroutine 1: AppendEvent that blocks in fanout (inside blocker).
+	appendDone := make(chan error, 1)
+	go func() {
+		appendDone <- s.AppendEvent(context.Background(), types.Event{ID: "blocked"})
+	}()
+
+	// Wait until the blocked AppendEvent has actually begun fanning out.
+	select {
+	case <-blocker.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("blocked AppendEvent never entered the sink")
+	}
+
+	// Goroutine 2: NextGeneration. Must NOT return while the first
+	// AppendEvent is still mid-fanout.
+	nextGenDone := make(chan struct {
+		gen uint32
+		err error
+	}, 1)
+	go func() {
+		gen, err := s.NextGeneration()
+		nextGenDone <- struct {
+			gen uint32
+			err error
+		}{gen, err}
+	}()
+
+	// Verify NextGeneration is blocked: it should not return within a short
+	// window while the AppendEvent is still in fanout.
+	select {
+	case got := <-nextGenDone:
+		t.Fatalf("NextGeneration returned (gen=%d, err=%v) while AppendEvent was mid-fanout; expected to block", got.gen, got.err)
+	case <-time.After(150 * time.Millisecond):
+		// Good: NextGeneration is properly blocked.
+	}
+
+	// Release the AppendEvent.
+	close(blocker.release)
+
+	// First AppendEvent should now complete.
+	select {
+	case err := <-appendDone:
+		if err != nil {
+			t.Fatalf("blocked AppendEvent returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("AppendEvent never completed after release")
+	}
+
+	// NextGeneration should return shortly after.
+	select {
+	case got := <-nextGenDone:
+		if got.err != nil {
+			t.Fatalf("NextGeneration error: %v", got.err)
+		}
+		if got.gen != 1 {
+			t.Errorf("NextGeneration returned gen=%d, want 1", got.gen)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("NextGeneration never returned after AppendEvent completed")
+	}
+
+	// Verify the blocked AppendEvent stamped the OLD generation (0), not 1.
+	if len(blocker.captured) != 1 {
+		t.Fatalf("blocker captured %d events, want 1", len(blocker.captured))
+	}
+	if blocker.captured[0].Generation != 0 {
+		t.Errorf("blocked AppendEvent stamped Generation=%d, want 0 (OLD generation)", blocker.captured[0].Generation)
+	}
+	if len(tail.captured) != 1 || tail.captured[0].Generation != 0 {
+		t.Errorf("tail sink Generation=%v, want 0", tail.captured)
+	}
+
+	// A subsequent AppendEvent should now stamp the new generation.
+	if err := s.AppendEvent(context.Background(), types.Event{ID: "after"}); err != nil {
+		t.Fatalf("post-rollover AppendEvent: %v", err)
+	}
+	if len(tail.captured) != 2 {
+		t.Fatalf("tail captured %d events, want 2", len(tail.captured))
+	}
+	if tail.captured[1].Generation != 1 || tail.captured[1].Sequence != 0 {
+		t.Errorf("post-rollover tuple = (seq=%d, gen=%d), want (seq=0, gen=1)", tail.captured[1].Sequence, tail.captured[1].Generation)
+	}
+}
+
+// concurrentChainCapturingStore is a thread-safe variant of
+// chainCapturingStore. The tests in this file that exercise concurrent
+// AppendEvent calls use this; the original chainCapturingStore is used by
+// single-goroutine tests where the lock would be noise.
+type concurrentChainCapturingStore struct {
+	mu       sync.Mutex
+	captured []types.ChainState
+}
+
+func (s *concurrentChainCapturingStore) AppendEvent(ctx context.Context, ev types.Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if ev.Chain == nil {
+		// Record a sentinel so the assertion phase can flag "no Chain stamped".
+		s.captured = append(s.captured, types.ChainState{})
+		return nil
+	}
+	// Snapshot the value so subsequent stamping by a later AppendEvent on
+	// the same goroutine cannot mutate what we recorded.
+	s.captured = append(s.captured, *ev.Chain)
+	return nil
+}
+
+func (s *concurrentChainCapturingStore) QueryEvents(ctx context.Context, q types.EventQuery) ([]types.Event, error) {
+	return nil, nil
+}
+func (s *concurrentChainCapturingStore) Close() error { return nil }
+
+// TestComposite_NextGeneration_NoStaleStamping verifies the per-generation
+// monotonic invariant: across concurrent AppendEvents and concurrent
+// NextGeneration calls, the captured stream must be strictly monotonic on
+// (generation, then sequence). In particular, no gen=N event may appear in
+// the captured stream after any gen=N+1 event from the same goroutine — and
+// (gen, seq) pairs must be unique.
+//
+// This catches the bug where an AppendEvent reads gen=N from the allocator,
+// gets preempted, NextGeneration advances to N+1, a different AppendEvent
+// reads gen=N+1, completes fanout, and THEN the preempted AppendEvent
+// completes fanout with its older gen=N stamp. With the wrapper RWMutex in
+// place this race cannot happen because NextGeneration cannot advance while
+// any AppendEvent holds an RLock.
+func TestComposite_NextGeneration_NoStaleStamping(t *testing.T) {
+	tail := &concurrentChainCapturingStore{}
+	s := New(tail, nil)
+
+	const numAppendGoroutines = 100
+	const appendsPerGoroutine = 20
+	const numRollovers = 5
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Append goroutines: each one calls AppendEvent in a tight loop until
+	// it has done its quota, observed a stop signal, OR returns an error.
+	var totalAppended atomic.Int64
+	for i := 0; i < numAppendGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < appendsPerGoroutine; j++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if err := s.AppendEvent(context.Background(), types.Event{ID: "x"}); err != nil {
+					t.Errorf("AppendEvent: %v", err)
+					return
+				}
+				totalAppended.Add(1)
+			}
+		}()
+	}
+
+	// Rollover goroutine: spaces out NextGeneration calls so they
+	// interleave with the AppendEvents above.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < numRollovers; i++ {
+			time.Sleep(2 * time.Millisecond)
+			if _, err := s.NextGeneration(); err != nil {
+				t.Errorf("NextGeneration #%d: %v", i, err)
+				close(stop)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	tail.mu.Lock()
+	captured := append([]types.ChainState(nil), tail.captured...)
+	tail.mu.Unlock()
+
+	if int64(len(captured)) != totalAppended.Load() {
+		t.Fatalf("captured %d events, want %d", len(captured), totalAppended.Load())
+	}
+
+	// Build a map from generation → max sequence seen, and assert
+	// uniqueness of every (gen, seq) tuple.
+	seen := make(map[uint64]map[uint64]bool) // gen -> seq -> bool
+	maxSeqPerGen := make(map[uint64]uint64)
+	for i, c := range captured {
+		gen := uint64(c.Generation)
+		if seen[gen] == nil {
+			seen[gen] = make(map[uint64]bool)
+		}
+		if seen[gen][c.Sequence] {
+			t.Fatalf("captured[%d]: duplicate (seq=%d, gen=%d) in stream", i, c.Sequence, c.Generation)
+		}
+		seen[gen][c.Sequence] = true
+		if c.Sequence > maxSeqPerGen[gen] {
+			maxSeqPerGen[gen] = c.Sequence
+		}
+	}
+
+	// Each generation's sequence range must be contiguous from 0 to
+	// maxSeqPerGen[gen] — no holes (every allocation stamps an event).
+	for gen, max := range maxSeqPerGen {
+		for seq := uint64(0); seq <= max; seq++ {
+			if !seen[gen][seq] {
+				t.Errorf("gen=%d: missing sequence %d in [0, %d]", gen, seq, max)
+			}
+		}
+	}
+
+	// Strict monotonicity per goroutine is hard to assert without per-call
+	// instrumentation (we don't know which append went to which goroutine).
+	// Instead, assert: in the captured stream, the maximum generation seen
+	// up to any index is non-decreasing. Once the stream has observed gen=N,
+	// no later append may stamp gen<N (because under the wrapper RWMutex,
+	// once NextGeneration has advanced the allocator, every AppendEvent
+	// that started AFTER the rollover sees the new generation, and every
+	// AppendEvent that started BEFORE has already completed fanout — so its
+	// captured entry is positioned earlier in the stream).
+	//
+	// Specifically: once we've seen any gen=g in the captured stream, no
+	// future entry may have generation < g - (numAppendGoroutines+1), where
+	// the slack accounts for the fact that captured-stream order is the
+	// order in which fanouts ENDED, which can interleave with the order
+	// they STARTED. The wrapper-lock guarantee is that all stamping with
+	// gen=g happens-before any stamping with gen=g+1; the captured stream
+	// preserves this ordering because both stampings happen inside the
+	// fanout, which happens inside the RLock, which is fully serialized
+	// against the NextGeneration write lock.
+	maxGenSeen := uint64(0)
+	for i, c := range captured {
+		gen := uint64(c.Generation)
+		if gen > maxGenSeen {
+			maxGenSeen = gen
+		}
+		// Strict: gen must equal maxGenSeen at this point. If gen <
+		// maxGenSeen, an older-generation event slipped in after a
+		// newer-generation event, which is exactly the rollover-atomicity
+		// violation we are testing for.
+		if gen < maxGenSeen {
+			t.Fatalf("captured[%d]: stale stamping — got gen=%d after observing gen=%d earlier in stream", i, gen, maxGenSeen)
+		}
+	}
+}
+
+// TestComposite_AppendEvent_AllocatorErrorRoutedToHook verifies that when the
+// allocator rejects the next allocation (overflow), the resulting error is:
+//   - wrapped as *store.FatalIntegrityError with Op == "audit sequence allocate"
+//   - delivered to the onAppendError hook
+//   - returned to the caller
+//   - and that NO sink saw the event (allocator failure short-circuits fanout).
+//
+// This routes allocator overflow through the same fatal-audit watcher path
+// the daemon already uses for other FatalIntegrityErrors raised by
+// internal/store/integrity_wrapper.go.
+func TestComposite_AppendEvent_AllocatorErrorRoutedToHook(t *testing.T) {
+	primary := &chainCapturingStore{}
+	other := &chainCapturingStore{}
+	s := New(primary, nil, other)
+
+	// Drive the allocator to MaxInt64 so the next Next() returns
+	// ErrSequenceOverflow.
+	if err := s.Restore(audit.AllocatorState{Sequence: math.MaxInt64}); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	var hookErr error
+	s.SetAppendErrorHook(func(err error) {
+		hookErr = err
+	})
+
+	err := s.AppendEvent(context.Background(), types.Event{ID: "overflow"})
+	if err == nil {
+		t.Fatal("AppendEvent returned nil; want fatal allocator error")
+	}
+	if !errors.Is(err, audit.ErrSequenceOverflow) {
+		t.Fatalf("AppendEvent err = %v, want errors.Is(ErrSequenceOverflow)", err)
+	}
+	var fatal *storepkg.FatalIntegrityError
+	if !errors.As(err, &fatal) {
+		t.Fatalf("AppendEvent err = %T(%v), want *FatalIntegrityError", err, err)
+	}
+	if fatal.Op != "audit sequence allocate" {
+		t.Errorf("fatal.Op = %q, want %q", fatal.Op, "audit sequence allocate")
+	}
+
+	if hookErr == nil {
+		t.Fatal("onAppendError hook not called")
+	}
+	var hookFatal *storepkg.FatalIntegrityError
+	if !errors.As(hookErr, &hookFatal) {
+		t.Fatalf("hook err = %T(%v), want *FatalIntegrityError", hookErr, hookErr)
+	}
+	if hookFatal != fatal {
+		t.Errorf("hook delivered a different *FatalIntegrityError instance: hook=%p returned=%p", hookFatal, fatal)
+	}
+
+	// No sink should have seen the event — allocator failure short-circuits
+	// fanout entirely.
+	if len(primary.captured) != 0 {
+		t.Errorf("primary captured %d events, want 0", len(primary.captured))
+	}
+	if len(other.captured) != 0 {
+		t.Errorf("other captured %d events, want 0", len(other.captured))
+	}
+}
+
+// TestComposite_State_Restore_Roundtrip verifies that the composite's State
+// snapshot can be persisted and rehydrated into a fresh composite, with the
+// next AppendEvent stamping at exactly snapshot.Sequence + 1.
+func TestComposite_State_Restore_Roundtrip(t *testing.T) {
+	first := &chainCapturingStore{}
+	src := New(first, nil)
+
+	for i := 0; i < 4; i++ {
+		if err := src.AppendEvent(context.Background(), types.Event{}); err != nil {
+			t.Fatalf("AppendEvent #%d: %v", i, err)
+		}
+	}
+	snap := src.State()
+	if snap.Sequence != 3 {
+		t.Fatalf("State.Sequence = %d, want 3", snap.Sequence)
+	}
+
+	dst := New(&chainCapturingStore{}, nil)
+	if err := dst.Restore(snap); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+
+	tail := &chainCapturingStore{}
+	dst2 := New(tail, nil)
+	if err := dst2.Restore(snap); err != nil {
+		t.Fatalf("Restore: %v", err)
+	}
+	if err := dst2.AppendEvent(context.Background(), types.Event{}); err != nil {
+		t.Fatalf("post-Restore AppendEvent: %v", err)
+	}
+	if len(tail.captured) != 1 {
+		t.Fatalf("tail captured %d events, want 1", len(tail.captured))
+	}
+	if tail.captured[0].Sequence != uint64(snap.Sequence+1) {
+		t.Errorf("post-Restore stamp Sequence = %d, want %d", tail.captured[0].Sequence, snap.Sequence+1)
+	}
+	if tail.captured[0].Generation != snap.Generation {
+		t.Errorf("post-Restore stamp Generation = %d, want %d", tail.captured[0].Generation, snap.Generation)
+	}
+}
+
+// TestComposite_Restore_RejectsInvalidInput_LeavesStateIntact verifies the
+// delegated all-or-nothing guarantee from SequenceAllocator.Restore. A
+// rejected Restore must not perturb composite state, and a subsequent
+// AppendEvent must continue from the prior State() snapshot.
+func TestComposite_Restore_RejectsInvalidInput_LeavesStateIntact(t *testing.T) {
+	tail := &chainCapturingStore{}
+	s := New(tail, nil)
+
+	for i := 0; i < 3; i++ {
+		if err := s.AppendEvent(context.Background(), types.Event{}); err != nil {
+			t.Fatalf("AppendEvent #%d: %v", i, err)
+		}
+	}
+	s0 := s.State()
+
+	err := s.Restore(audit.AllocatorState{Sequence: -2})
+	if err == nil {
+		t.Fatal("Restore(-2) returned nil; want ErrInvalidAllocatorState")
+	}
+	if !errors.Is(err, audit.ErrInvalidAllocatorState) {
+		t.Fatalf("Restore err = %v, want errors.Is(ErrInvalidAllocatorState)", err)
+	}
+
+	if got := s.State(); got != s0 {
+		t.Fatalf("after rejected Restore: State = %+v, want %+v", got, s0)
+	}
+
+	if err := s.AppendEvent(context.Background(), types.Event{}); err != nil {
+		t.Fatalf("post-rejected-Restore AppendEvent: %v", err)
+	}
+	last := tail.captured[len(tail.captured)-1]
+	if last == nil || last.Sequence != uint64(s0.Sequence+1) {
+		t.Fatalf("post-rejected-Restore stamp Sequence = %d, want %d", last.Sequence, s0.Sequence+1)
 	}
 }

--- a/internal/store/composite/composite_test.go
+++ b/internal/store/composite/composite_test.go
@@ -3,6 +3,7 @@ package composite
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	storepkg "github.com/agentsh/agentsh/internal/store"
@@ -216,5 +217,88 @@ func TestComposite_NilPrimary_Close(t *testing.T) {
 	}
 	if !other.closed {
 		t.Fatal("expected other store to be closed")
+	}
+}
+
+type chainCapturingStore struct {
+	captured []*types.ChainState
+}
+
+func (s *chainCapturingStore) AppendEvent(ctx context.Context, ev types.Event) error {
+	// Composite stamps a fresh *ChainState per sink, so the captured
+	// pointer is the sink-local copy — distinct from every other sink's.
+	s.captured = append(s.captured, ev.Chain)
+	return nil
+}
+func (s *chainCapturingStore) QueryEvents(ctx context.Context, q types.EventQuery) ([]types.Event, error) {
+	return nil, nil
+}
+func (s *chainCapturingStore) Close() error { return nil }
+
+func TestComposite_StampsChainBeforeFanout(t *testing.T) {
+	primary := &chainCapturingStore{}
+	other := &chainCapturingStore{}
+	s := New(primary, nil, other)
+
+	for i := 0; i < 5; i++ {
+		if err := s.AppendEvent(context.Background(), types.Event{ID: "e"}); err != nil {
+			t.Fatalf("AppendEvent #%d: %v", i, err)
+		}
+	}
+
+	if len(primary.captured) != 5 || len(other.captured) != 5 {
+		t.Fatalf("captured counts: primary=%d other=%d", len(primary.captured), len(other.captured))
+	}
+	for i, p := range primary.captured {
+		o := other.captured[i]
+		if p == nil || o == nil {
+			t.Fatalf("event %d: nil Chain — primary=%v other=%v", i, p, o)
+		}
+		if p.Sequence != uint64(i) || p.Generation != 0 {
+			t.Errorf("primary event %d: Chain=(seq=%d,gen=%d) want (seq=%d,gen=0)", i, p.Sequence, p.Generation, i)
+		}
+		// Per-sink-copy contract: pointer-distinct across sinks but
+		// value-equal. Use == on pointers (must differ) and DeepEqual
+		// on dereferenced values (must match).
+		if p == o {
+			t.Errorf("event %d: sinks alias the same *ChainState pointer (%p); composite must stamp fresh per sink", i, p)
+		}
+		if !reflect.DeepEqual(*p, *o) {
+			t.Errorf("event %d: sinks saw different Chain values: primary=%+v other=%+v", i, *p, *o)
+		}
+	}
+
+	// Mutating one sink's captured ChainState must not affect the other's.
+	primary.captured[0].Sequence = 0xDEADBEEF
+	if other.captured[0].Sequence == 0xDEADBEEF {
+		t.Errorf("per-sink-copy invariant violated: mutating primary leaked into other")
+	}
+}
+
+func TestComposite_NextGeneration_ResetsSequence(t *testing.T) {
+	primary := &chainCapturingStore{}
+	s := New(primary, nil)
+
+	for i := 0; i < 3; i++ {
+		if err := s.AppendEvent(context.Background(), types.Event{}); err != nil {
+			t.Fatalf("AppendEvent #%d: %v", i, err)
+		}
+	}
+
+	newGen, err := s.NextGeneration()
+	if err != nil {
+		t.Fatalf("NextGeneration: %v", err)
+	}
+	if newGen != 1 {
+		t.Fatalf("NextGeneration() = %d, want 1", newGen)
+	}
+
+	if err := s.AppendEvent(context.Background(), types.Event{}); err != nil {
+		t.Fatal(err)
+	}
+
+	last := primary.captured[len(primary.captured)-1]
+	if last == nil || last.Sequence != 0 || last.Generation != 1 {
+		t.Errorf("after rollover: Chain=(seq=%d,gen=%d) want (seq=0,gen=1)", last.Sequence, last.Generation)
 	}
 }

--- a/internal/store/composite/sequence_contract_test.go
+++ b/internal/store/composite/sequence_contract_test.go
@@ -1,0 +1,281 @@
+package composite
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/audit"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// chainingFakeSink simulates a second chained sink. It serializes events
+// using a stable canonical encoding (id + seq + gen + payload) and runs
+// each event through its own SinkChain. Every accepted event also produces
+// a record so tests can compare what each sink saw.
+type chainingFakeSink struct {
+	chain     *audit.SinkChain
+	mu        sync.Mutex
+	records   []chainRecord
+	failNext  error // if set, the next AppendEvent fails clean (no chain advance)
+	failFatal bool  // if set, the next AppendEvent fails ambiguously (Fatal)
+	failedSeq int64 // sequence at which failure was injected
+}
+
+type chainRecord struct {
+	Sequence   uint64
+	Generation uint32
+	EntryHash  string
+	PrevHash   string
+}
+
+func newChainingFakeSink(t *testing.T, key []byte) *chainingFakeSink {
+	t.Helper()
+	c, err := audit.NewSinkChain(key, "hmac-sha256")
+	if err != nil {
+		t.Fatalf("NewSinkChain: %v", err)
+	}
+	return &chainingFakeSink{chain: c}
+}
+
+func (s *chainingFakeSink) AppendEvent(ctx context.Context, ev types.Event) error {
+	if ev.Chain == nil {
+		return audit.ErrMissingChainState
+	}
+	seq := ev.Chain.Sequence
+	gen := ev.Chain.Generation
+	canonical := []byte(`{"id":"` + ev.ID + `","seq":` + strconv.FormatUint(seq, 10) + `,"gen":` + strconv.FormatUint(uint64(gen), 10) + `}`)
+
+	result, err := s.chain.Compute(audit.IntegrityFormatVersion, int64(seq), gen, canonical)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	failClean := s.failNext
+	failAmbiguous := s.failFatal
+	if failClean != nil {
+		s.failedSeq = int64(seq)
+		s.failNext = nil
+	}
+	if failAmbiguous {
+		s.failedSeq = int64(seq)
+		s.failFatal = false
+	}
+	s.mu.Unlock()
+
+	switch {
+	case failClean != nil:
+		// Clean failure → do NOT commit, chain unchanged.
+		return failClean
+	case failAmbiguous:
+		// Ambiguous failure → latch fatal.
+		s.chain.Fatal(errors.New("ambiguous write"))
+		return errors.New("ambiguous write")
+	default:
+		// Successful durable write — commit. A non-nil error here means the
+		// chain has latched fatal (e.g., backwards-generation Commit), which
+		// is itself a write divergence and must be surfaced to the caller.
+		if err := s.chain.Commit(result); err != nil {
+			return err
+		}
+		s.mu.Lock()
+		s.records = append(s.records, chainRecord{
+			Sequence:   seq,
+			Generation: gen,
+			EntryHash:  result.EntryHash(),
+			PrevHash:   result.PrevHash(),
+		})
+		s.mu.Unlock()
+		return nil
+	}
+}
+
+func (s *chainingFakeSink) QueryEvents(ctx context.Context, q types.EventQuery) ([]types.Event, error) {
+	return nil, nil
+}
+func (s *chainingFakeSink) Close() error { return nil }
+
+func newSharedKey(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, audit.MinKeyLength)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+	return key
+}
+
+// TestPhase0_CrossSinkSequenceConvergence (Spec verification #1):
+// With two chained sinks, every event's (seq, gen) matches between sinks.
+// entry_hash matches when both sinks hash identical canonical bytes with
+// the same key — but the contract only guarantees (seq, gen) convergence,
+// not entry_hash equality in general.
+func TestPhase0_CrossSinkSequenceConvergence(t *testing.T) {
+	key := newSharedKey(t)
+	a := newChainingFakeSink(t, key)
+	b := newChainingFakeSink(t, key)
+
+	s := New(a, nil, b)
+
+	const N = 10000
+	for i := 0; i < N; i++ {
+		if err := s.AppendEvent(context.Background(), types.Event{ID: strconv.Itoa(i)}); err != nil {
+			t.Fatalf("AppendEvent #%d: %v", i, err)
+		}
+	}
+
+	if len(a.records) != N || len(b.records) != N {
+		t.Fatalf("record counts: a=%d b=%d want %d", len(a.records), len(b.records), N)
+	}
+	for i := 0; i < N; i++ {
+		ar := a.records[i]
+		br := b.records[i]
+		if ar.Sequence != br.Sequence || ar.Generation != br.Generation {
+			t.Fatalf("record %d: a=(seq=%d,gen=%d) b=(seq=%d,gen=%d)", i, ar.Sequence, ar.Generation, br.Sequence, br.Generation)
+		}
+		if ar.Sequence != uint64(i) {
+			t.Fatalf("record %d: seq=%d want %d", i, ar.Sequence, i)
+		}
+		// Both sinks hashed identical canonical bytes with the same key, so
+		// entry_hash must also match. This is the narrow case where the
+		// stronger assertion holds.
+		if ar.EntryHash != br.EntryHash {
+			t.Fatalf("record %d: entry_hash mismatch a=%q b=%q", i, ar.EntryHash, br.EntryHash)
+		}
+	}
+}
+
+// TestPhase0_GenerationRollConsistency (Spec verification #2):
+// After NextGeneration(), both sinks observe the rollover at the same
+// event boundary; sequence resets to 0 in both; each sink's prev_hash
+// resets to "" independently.
+func TestPhase0_GenerationRollConsistency(t *testing.T) {
+	key := newSharedKey(t)
+	a := newChainingFakeSink(t, key)
+	b := newChainingFakeSink(t, key)
+	s := New(a, nil, b)
+
+	for i := 0; i < 3; i++ {
+		if err := s.AppendEvent(context.Background(), types.Event{ID: strconv.Itoa(i)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	gen, err := s.NextGeneration()
+	if err != nil {
+		t.Fatalf("NextGeneration: %v", err)
+	}
+	if gen != 1 {
+		t.Fatalf("NextGeneration() = %d, want 1", gen)
+	}
+
+	for i := 0; i < 3; i++ {
+		if err := s.AppendEvent(context.Background(), types.Event{ID: strconv.Itoa(i + 100)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if len(a.records) != 6 || len(b.records) != 6 {
+		t.Fatalf("counts: a=%d b=%d", len(a.records), len(b.records))
+	}
+
+	// Records 0..2 are gen=0 with monotonic seq; records 3..5 are gen=1
+	// with seq starting from 0.
+	expected := []struct {
+		seq uint64
+		gen uint32
+	}{
+		{0, 0}, {1, 0}, {2, 0},
+		{0, 1}, {1, 1}, {2, 1},
+	}
+	for i, want := range expected {
+		got := a.records[i]
+		if got.Sequence != want.seq || got.Generation != want.gen {
+			t.Errorf("a.records[%d] = (seq=%d, gen=%d), want (seq=%d, gen=%d)", i, got.Sequence, got.Generation, want.seq, want.gen)
+		}
+		if a.records[i] != b.records[i] {
+			t.Errorf("a.records[%d] != b.records[%d]: %+v vs %+v", i, i, a.records[i], b.records[i])
+		}
+	}
+
+	// First record after rollover MUST have prev_hash == "" — independent
+	// per-sink chain reset.
+	if a.records[3].PrevHash != "" {
+		t.Errorf("a.records[3].PrevHash = %q, want empty", a.records[3].PrevHash)
+	}
+	if b.records[3].PrevHash != "" {
+		t.Errorf("b.records[3].PrevHash = %q, want empty", b.records[3].PrevHash)
+	}
+}
+
+// TestPhase0_TransactionalRollback_CleanFailure (Spec verification #3a):
+// A clean durable-write failure does NOT advance prev_hash. After the
+// failure, a successful write of a new event uses the previous (pre-failure)
+// prev_hash — proving rollback is correct.
+func TestPhase0_TransactionalRollback_CleanFailure(t *testing.T) {
+	key := newSharedKey(t)
+	a := newChainingFakeSink(t, key)
+	s := New(a, nil)
+
+	// Three successful events first.
+	for i := 0; i < 3; i++ {
+		if err := s.AppendEvent(context.Background(), types.Event{ID: strconv.Itoa(i)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	preFailPrev := a.records[2].EntryHash
+
+	// Inject clean failure for next event.
+	cleanErr := errors.New("transient disk full")
+	a.mu.Lock()
+	a.failNext = cleanErr
+	a.mu.Unlock()
+
+	err := s.AppendEvent(context.Background(), types.Event{ID: "fail"})
+	if !errors.Is(err, cleanErr) {
+		t.Fatalf("expected clean error, got %v", err)
+	}
+
+	// Sink recorded no new entry on failure.
+	if len(a.records) != 3 {
+		t.Fatalf("record count after clean failure: %d, want 3 (no advance)", len(a.records))
+	}
+
+	// Next successful event continues from the PRE-FAILURE prev_hash, not
+	// from a phantom advanced state.
+	if err := s.AppendEvent(context.Background(), types.Event{ID: "after-fail"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := a.records[3].PrevHash; got != preFailPrev {
+		t.Errorf("after clean failure: prev_hash advanced unexpectedly. got=%q want=%q", got, preFailPrev)
+	}
+}
+
+// TestPhase0_TransactionalRollback_AmbiguousFailure (Spec verification #3b):
+// An ambiguous durable-write failure latches Fatal. Subsequent SinkChain.Compute
+// (driven by a subsequent AppendEvent) returns ErrFatalIntegrity.
+func TestPhase0_TransactionalRollback_AmbiguousFailure(t *testing.T) {
+	key := newSharedKey(t)
+	a := newChainingFakeSink(t, key)
+	s := New(a, nil)
+
+	if err := s.AppendEvent(context.Background(), types.Event{ID: "0"}); err != nil {
+		t.Fatal(err)
+	}
+
+	a.mu.Lock()
+	a.failFatal = true
+	a.mu.Unlock()
+	if err := s.AppendEvent(context.Background(), types.Event{ID: "ambig"}); err == nil {
+		t.Fatal("expected ambiguous error, got nil")
+	}
+
+	// Subsequent AppendEvent now drives Compute, which must return
+	// ErrFatalIntegrity from the latched chain.
+	err := s.AppendEvent(context.Background(), types.Event{ID: "after-ambig"})
+	if !errors.Is(err, audit.ErrFatalIntegrity) {
+		t.Fatalf("after ambiguous failure: err = %v, want ErrFatalIntegrity", err)
+	}
+}

--- a/internal/store/composite/sequence_contract_test.go
+++ b/internal/store/composite/sequence_contract_test.go
@@ -12,9 +12,14 @@ import (
 )
 
 // chainingFakeSink simulates a second chained sink. It serializes events
-// using a stable canonical encoding (id + seq + gen + payload) and runs
-// each event through its own SinkChain. Every accepted event also produces
-// a record so tests can compare what each sink saw.
+// using an intentionally minimal canonical encoding of (id, seq, gen) and
+// runs each event through its own SinkChain. The canonical form is just
+// enough to produce distinct entry hashes per event without coupling the
+// test to types.Event fields whose serialization is not stable across
+// changes (Fields, Timestamp, etc.); the test's purpose is to verify the
+// (seq, gen) sharing contract, not to mirror a real sink's exhaustive
+// canonicalization. Every accepted event also produces a record so tests
+// can compare what each sink saw.
 type chainingFakeSink struct {
 	chain     *audit.SinkChain
 	mu        sync.Mutex
@@ -107,6 +112,18 @@ func newSharedKey(t *testing.T) []byte {
 	return key
 }
 
+// newDistinctKey returns a key that is byte-different from newSharedKey,
+// used to construct heterogeneous chained sinks that must produce
+// different entry hashes despite sharing (seq, gen).
+func newDistinctKey(t *testing.T) []byte {
+	t.Helper()
+	key := make([]byte, audit.MinKeyLength)
+	for i := range key {
+		key[i] = byte(0xFF - i)
+	}
+	return key
+}
+
 // TestPhase0_CrossSinkSequenceConvergence (Spec verification #1):
 // With two chained sinks, every event's (seq, gen) matches between sinks.
 // entry_hash matches when both sinks hash identical canonical bytes with
@@ -143,6 +160,72 @@ func TestPhase0_CrossSinkSequenceConvergence(t *testing.T) {
 		// stronger assertion holds.
 		if ar.EntryHash != br.EntryHash {
 			t.Fatalf("record %d: entry_hash mismatch a=%q b=%q", i, ar.EntryHash, br.EntryHash)
+		}
+	}
+}
+
+// TestPhase0_HeterogeneousSinks_SequenceConvergence_HashesDiverge
+// (Spec verification #1, heterogeneous case):
+//
+// This is the heterogeneous case. Different HMAC keys MUST produce
+// different entry hashes per event, but the shared sequence allocator
+// MUST still produce identical (seq, gen) for both sinks. This directly
+// verifies the Phase 0 contract claim of "shared sequence, sink-local
+// hash chains."
+//
+// The narrow same-key case in TestPhase0_CrossSinkSequenceConvergence
+// is itself a useful invariant (it documents that identical canonical
+// inputs to identical chains are reproducible), but it does not exercise
+// the design claim that the contract holds across heterogeneous sinks.
+// This test does.
+func TestPhase0_HeterogeneousSinks_SequenceConvergence_HashesDiverge(t *testing.T) {
+	a := newChainingFakeSink(t, newSharedKey(t))
+	b := newChainingFakeSink(t, newDistinctKey(t))
+
+	s := New(a, nil, b)
+
+	const N = 1000
+	for i := 0; i < N; i++ {
+		if err := s.AppendEvent(context.Background(), types.Event{ID: strconv.Itoa(i)}); err != nil {
+			t.Fatalf("AppendEvent #%d: %v", i, err)
+		}
+	}
+
+	if len(a.records) != N || len(b.records) != N {
+		t.Fatalf("record counts: a=%d b=%d want %d", len(a.records), len(b.records), N)
+	}
+
+	for i := 0; i < N; i++ {
+		ar := a.records[i]
+		br := b.records[i]
+
+		// SHARED invariant: identical (seq, gen) for both sinks.
+		if ar.Sequence != br.Sequence {
+			t.Fatalf("record %d: sequence mismatch a=%d b=%d", i, ar.Sequence, br.Sequence)
+		}
+		if ar.Generation != br.Generation {
+			t.Fatalf("record %d: generation mismatch a=%d b=%d", i, ar.Generation, br.Generation)
+		}
+		if ar.Sequence != uint64(i) {
+			t.Fatalf("record %d: seq=%d want %d", i, ar.Sequence, i)
+		}
+		if ar.Generation != 0 {
+			t.Fatalf("record %d: gen=%d want 0", i, ar.Generation)
+		}
+
+		// Non-vacuous: entry hashes are populated on both sides.
+		if ar.EntryHash == "" {
+			t.Fatalf("record %d: a.EntryHash is empty", i)
+		}
+		if br.EntryHash == "" {
+			t.Fatalf("record %d: b.EntryHash is empty", i)
+		}
+
+		// SINK-LOCAL invariant: different keys MUST produce different
+		// entry hashes for every event.
+		if ar.EntryHash == br.EntryHash {
+			t.Fatalf("record %d: entry_hash unexpectedly equal under distinct keys: a=%q b=%q",
+				i, ar.EntryHash, br.EntryHash)
 		}
 	}
 }
@@ -277,5 +360,177 @@ func TestPhase0_TransactionalRollback_AmbiguousFailure(t *testing.T) {
 	err := s.AppendEvent(context.Background(), types.Event{ID: "after-ambig"})
 	if !errors.Is(err, audit.ErrFatalIntegrity) {
 		t.Fatalf("after ambiguous failure: err = %v, want ErrFatalIntegrity", err)
+	}
+}
+
+// TestPhase0_MixedSinkOutcome_PrimaryCommitsSecondaryFailsClean
+// (Spec verification #4a — composite-level mixed outcome):
+//
+// Exercises the meeting point of eager sequence consumption, sink-local
+// rollback, and append-error surfacing. Primary commits while secondary
+// returns a CLEAN failure (no Fatal latch). The composite must:
+//
+//   - return the secondary's error to the caller (firstErr);
+//   - leave the primary's chain advanced (it succeeded);
+//   - leave the secondary's chain UN-advanced (clean failure rolled back);
+//   - have eagerly consumed the shared sequence anyway (TransportLoss
+//     semantics: shared sequence reflects what the system PRODUCED, not
+//     what each sink DELIVERED).
+//
+// The follow-up event then proves that secondary's chain continued from
+// its PRE-FAILURE prev_hash (true rollback), while both sinks observe
+// the same post-failure sequence (eager-advance is symmetric).
+func TestPhase0_MixedSinkOutcome_PrimaryCommitsSecondaryFailsClean(t *testing.T) {
+	key := newSharedKey(t)
+	a := newChainingFakeSink(t, key)
+	b := newChainingFakeSink(t, key)
+	s := New(a, nil, b)
+
+	// Two successful events through both sinks.
+	for i := 0; i < 2; i++ {
+		if err := s.AppendEvent(context.Background(), types.Event{ID: strconv.Itoa(i)}); err != nil {
+			t.Fatalf("AppendEvent #%d: %v", i, err)
+		}
+	}
+	if len(a.records) != 2 {
+		t.Fatalf("len(a.records) = %d, want 2", len(a.records))
+	}
+	if len(b.records) != 2 {
+		t.Fatalf("len(b.records) = %d, want 2", len(b.records))
+	}
+	bPreFailEntryHash := b.records[1].EntryHash
+	if bPreFailEntryHash == "" {
+		t.Fatalf("bPreFailEntryHash is empty; cannot verify rollback against it")
+	}
+
+	seqBeforeFailure := s.State().Sequence
+
+	// Inject a clean failure on the secondary's next append.
+	cleanErr := errors.New("secondary disk full")
+	b.mu.Lock()
+	b.failNext = cleanErr
+	b.mu.Unlock()
+
+	err := s.AppendEvent(context.Background(), types.Event{ID: "mixed-fail"})
+	if !errors.Is(err, cleanErr) {
+		t.Fatalf("AppendEvent: err = %v, want errors.Is(err, cleanErr)", err)
+	}
+
+	// Primary committed; secondary did NOT.
+	if len(a.records) != 3 {
+		t.Fatalf("len(a.records) after mixed failure = %d, want 3 (primary committed)", len(a.records))
+	}
+	if len(b.records) != 2 {
+		t.Fatalf("len(b.records) after mixed failure = %d, want 2 (secondary rolled back)", len(b.records))
+	}
+
+	// Allocator advanced eagerly even though secondary failed.
+	if got := s.State().Sequence; got != seqBeforeFailure+1 {
+		t.Fatalf("State().Sequence after mixed failure = %d, want %d (eager advance)",
+			got, seqBeforeFailure+1)
+	}
+
+	// Recovery event must succeed.
+	if err := s.AppendEvent(context.Background(), types.Event{ID: "after-mixed-fail"}); err != nil {
+		t.Fatalf("recovery AppendEvent: %v", err)
+	}
+	if len(a.records) != 4 {
+		t.Fatalf("len(a.records) after recovery = %d, want 4", len(a.records))
+	}
+	if len(b.records) != 3 {
+		t.Fatalf("len(b.records) after recovery = %d, want 3", len(b.records))
+	}
+
+	// Both sinks observe the SAME post-failure sequence on the recovery event.
+	if a.records[3].Sequence != 3 {
+		t.Fatalf("a.records[3].Sequence = %d, want 3", a.records[3].Sequence)
+	}
+	if b.records[2].Sequence != 3 {
+		t.Fatalf("b.records[2].Sequence = %d, want 3 (eager-advance leaves both observing the same fresh seq)",
+			b.records[2].Sequence)
+	}
+
+	// Secondary's chain continued from PRE-FAILURE prev_hash — rollback proof.
+	if got := b.records[2].PrevHash; got != bPreFailEntryHash {
+		t.Fatalf("b.records[2].PrevHash = %q, want %q (secondary chain must continue from pre-failure prev_hash)",
+			got, bPreFailEntryHash)
+	}
+
+	// Primary's chain continued normally; never failed.
+	if got, want := a.records[3].PrevHash, a.records[2].EntryHash; got != want {
+		t.Fatalf("a.records[3].PrevHash = %q, want %q (primary chain unaffected)", got, want)
+	}
+}
+
+// TestPhase0_MixedSinkOutcome_PrimaryCommitsSecondaryLatchesFatal
+// (Spec verification #4b — composite-level mixed outcome with Fatal):
+//
+// Same composite shape as Test A, but secondary fails AMBIGUOUSLY and
+// latches Fatal. The composite must:
+//
+//   - return the secondary's ambiguous error on the failing call (Fatal
+//     is being SET, not yet observed via Compute);
+//   - on the NEXT append, surface ErrFatalIntegrity (Compute observes
+//     the latched Fatal) while the primary continues to commit normally.
+//
+// Verifies that a latched secondary does not block the primary's chain
+// from making progress — only the secondary's error stream surfaces.
+func TestPhase0_MixedSinkOutcome_PrimaryCommitsSecondaryLatchesFatal(t *testing.T) {
+	key := newSharedKey(t)
+	a := newChainingFakeSink(t, key)
+	b := newChainingFakeSink(t, key)
+	s := New(a, nil, b)
+
+	// One successful event through both sinks.
+	if err := s.AppendEvent(context.Background(), types.Event{ID: "0"}); err != nil {
+		t.Fatalf("AppendEvent #0: %v", err)
+	}
+	if len(a.records) != 1 || len(b.records) != 1 {
+		t.Fatalf("initial counts: a=%d b=%d, want 1/1", len(a.records), len(b.records))
+	}
+	seqBeforeAmbig := s.State().Sequence
+
+	// Inject ambiguous failure on the secondary.
+	b.mu.Lock()
+	b.failFatal = true
+	b.mu.Unlock()
+
+	err := s.AppendEvent(context.Background(), types.Event{ID: "mixed-ambig"})
+	if err == nil {
+		t.Fatal("expected ambiguous error from mixed append, got nil")
+	}
+
+	// Primary committed; secondary did NOT.
+	if len(a.records) != 2 {
+		t.Fatalf("len(a.records) after mixed-ambig = %d, want 2 (primary committed)", len(a.records))
+	}
+	if len(b.records) != 1 {
+		t.Fatalf("len(b.records) after mixed-ambig = %d, want 1 (secondary latched, no commit)", len(b.records))
+	}
+	// Allocator advanced.
+	if got := s.State().Sequence; got != seqBeforeAmbig+1 {
+		t.Fatalf("State().Sequence after mixed-ambig = %d, want %d (eager advance)",
+			got, seqBeforeAmbig+1)
+	}
+
+	// Next append: secondary's Compute returns ErrFatalIntegrity, which
+	// surfaces as the firstErr (primary succeeds, secondary returns
+	// ErrFatalIntegrity from Compute).
+	err = s.AppendEvent(context.Background(), types.Event{ID: "after-mixed-ambig"})
+	if !errors.Is(err, audit.ErrFatalIntegrity) {
+		t.Fatalf("AppendEvent after mixed-ambig: err = %v, want ErrFatalIntegrity", err)
+	}
+	if len(a.records) != 3 {
+		t.Fatalf("len(a.records) after follow-up = %d, want 3 (primary continues despite latched secondary)",
+			len(a.records))
+	}
+	if len(b.records) != 1 {
+		t.Fatalf("len(b.records) after follow-up = %d, want 1 (secondary remains latched)", len(b.records))
+	}
+
+	// Primary's chain unaffected by secondary's Fatal.
+	if got, want := a.records[2].PrevHash, a.records[1].EntryHash; got != want {
+		t.Fatalf("a.records[2].PrevHash = %q, want %q (primary chain unaffected by secondary Fatal)",
+			got, want)
 	}
 }

--- a/internal/store/composite/sequence_contract_test.go
+++ b/internal/store/composite/sequence_contract_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 
@@ -386,6 +387,19 @@ func TestPhase0_MixedSinkOutcome_PrimaryCommitsSecondaryFailsClean(t *testing.T)
 	b := newChainingFakeSink(t, key)
 	s := New(a, nil, b)
 
+	// Capture onAppendError invocations so we can verify both the
+	// caller-visible error path AND the daemon-visible audit hook path
+	// (composite.Store calls the hook at most once per AppendEvent, with
+	// the first encountered error — or the first FatalIntegrityError if
+	// any was extracted via errors.As).
+	var hookMu sync.Mutex
+	var hookCalls []error
+	s.SetAppendErrorHook(func(err error) {
+		hookMu.Lock()
+		defer hookMu.Unlock()
+		hookCalls = append(hookCalls, err)
+	})
+
 	// Two successful events through both sinks.
 	for i := 0; i < 2; i++ {
 		if err := s.AppendEvent(context.Background(), types.Event{ID: strconv.Itoa(i)}); err != nil {
@@ -403,6 +417,13 @@ func TestPhase0_MixedSinkOutcome_PrimaryCommitsSecondaryFailsClean(t *testing.T)
 		t.Fatalf("bPreFailEntryHash is empty; cannot verify rollback against it")
 	}
 
+	// No failures yet → hook must not have been called.
+	hookMu.Lock()
+	if got := len(hookCalls); got != 0 {
+		t.Fatalf("hook calls before failure injection = %d, want 0", got)
+	}
+	hookMu.Unlock()
+
 	seqBeforeFailure := s.State().Sequence
 
 	// Inject a clean failure on the secondary's next append.
@@ -415,6 +436,19 @@ func TestPhase0_MixedSinkOutcome_PrimaryCommitsSecondaryFailsClean(t *testing.T)
 	if !errors.Is(err, cleanErr) {
 		t.Fatalf("AppendEvent: err = %v, want errors.Is(err, cleanErr)", err)
 	}
+
+	// Hook fired exactly once with the secondary's clean error — verifies
+	// daemon-visible surfacing, not just caller-visible return.
+	hookMu.Lock()
+	if got := len(hookCalls); got != 1 {
+		hookMu.Unlock()
+		t.Fatalf("hook calls after mixed-fail = %d, want 1", got)
+	}
+	if !errors.Is(hookCalls[0], cleanErr) {
+		hookMu.Unlock()
+		t.Fatalf("hookCalls[0] = %v, want errors.Is(_, cleanErr)", hookCalls[0])
+	}
+	hookMu.Unlock()
 
 	// Primary committed; secondary did NOT.
 	if len(a.records) != 3 {
@@ -440,6 +474,14 @@ func TestPhase0_MixedSinkOutcome_PrimaryCommitsSecondaryFailsClean(t *testing.T)
 	if len(b.records) != 3 {
 		t.Fatalf("len(b.records) after recovery = %d, want 3", len(b.records))
 	}
+
+	// Successful recovery append must NOT fire the hook again.
+	hookMu.Lock()
+	if got := len(hookCalls); got != 1 {
+		hookMu.Unlock()
+		t.Fatalf("hook calls after recovery = %d, want 1 (no new call on success)", got)
+	}
+	hookMu.Unlock()
 
 	// Both sinks observe the SAME post-failure sequence on the recovery event.
 	if a.records[3].Sequence != 3 {
@@ -481,6 +523,16 @@ func TestPhase0_MixedSinkOutcome_PrimaryCommitsSecondaryLatchesFatal(t *testing.
 	b := newChainingFakeSink(t, key)
 	s := New(a, nil, b)
 
+	// Capture onAppendError invocations to verify daemon-visible
+	// audit hook surfacing in addition to caller-visible errors.
+	var hookMu sync.Mutex
+	var hookCalls []error
+	s.SetAppendErrorHook(func(err error) {
+		hookMu.Lock()
+		defer hookMu.Unlock()
+		hookCalls = append(hookCalls, err)
+	})
+
 	// One successful event through both sinks.
 	if err := s.AppendEvent(context.Background(), types.Event{ID: "0"}); err != nil {
 		t.Fatalf("AppendEvent #0: %v", err)
@@ -488,6 +540,14 @@ func TestPhase0_MixedSinkOutcome_PrimaryCommitsSecondaryLatchesFatal(t *testing.
 	if len(a.records) != 1 || len(b.records) != 1 {
 		t.Fatalf("initial counts: a=%d b=%d, want 1/1", len(a.records), len(b.records))
 	}
+
+	// Warm-up succeeded → hook must not have been called yet.
+	hookMu.Lock()
+	if got := len(hookCalls); got != 0 {
+		t.Fatalf("hook calls before failure injection = %d, want 0", got)
+	}
+	hookMu.Unlock()
+
 	seqBeforeAmbig := s.State().Sequence
 
 	// Inject ambiguous failure on the secondary.
@@ -499,6 +559,24 @@ func TestPhase0_MixedSinkOutcome_PrimaryCommitsSecondaryLatchesFatal(t *testing.
 	if err == nil {
 		t.Fatal("expected ambiguous error from mixed append, got nil")
 	}
+
+	// Hook fires once with the ambiguous error string from chainingFakeSink.
+	// The fake sink emits an ad-hoc errors.New("ambiguous write") that is
+	// not exposed for errors.Is comparison, so match by message.
+	hookMu.Lock()
+	if got := len(hookCalls); got != 1 {
+		hookMu.Unlock()
+		t.Fatalf("hook calls after mixed-ambig = %d, want 1", got)
+	}
+	if hookCalls[0] == nil {
+		hookMu.Unlock()
+		t.Fatal("hookCalls[0] is nil; want ambiguous error")
+	}
+	if !strings.Contains(hookCalls[0].Error(), "ambiguous") {
+		hookMu.Unlock()
+		t.Fatalf("hookCalls[0].Error() = %q, want to contain \"ambiguous\"", hookCalls[0].Error())
+	}
+	hookMu.Unlock()
 
 	// Primary committed; secondary did NOT.
 	if len(a.records) != 2 {
@@ -527,6 +605,21 @@ func TestPhase0_MixedSinkOutcome_PrimaryCommitsSecondaryLatchesFatal(t *testing.
 	if len(b.records) != 1 {
 		t.Fatalf("len(b.records) after follow-up = %d, want 1 (secondary remains latched)", len(b.records))
 	}
+
+	// KEY ASSERTION (roborev finding): the audit hook MUST also surface
+	// ErrFatalIntegrity on the follow-up append, not just the caller. This
+	// is the daemon-visible path the prior review specifically flagged as
+	// untested.
+	hookMu.Lock()
+	if got := len(hookCalls); got != 2 {
+		hookMu.Unlock()
+		t.Fatalf("hook calls after follow-up = %d, want 2", got)
+	}
+	if !errors.Is(hookCalls[1], audit.ErrFatalIntegrity) {
+		hookMu.Unlock()
+		t.Fatalf("hookCalls[1] = %v, want errors.Is(_, ErrFatalIntegrity)", hookCalls[1])
+	}
+	hookMu.Unlock()
 
 	// Primary's chain unaffected by secondary's Fatal.
 	if got, want := a.records[2].PrevHash, a.records[1].EntryHash; got != want {

--- a/internal/store/integrity_wrapper.go
+++ b/internal/store/integrity_wrapper.go
@@ -324,7 +324,9 @@ func (s *IntegrityStore) resumeFromSidecar(sidecar audit.SidecarState, lastFile 
 		if !ok {
 			return fmt.Errorf("audit integrity chain mismatch: invalid last entry in %s", lastFile.Path)
 		}
-		s.chain.Restore(sidecar.Sequence, sidecar.PrevHash)
+		if err := s.chain.Restore(sidecar.Sequence, sidecar.PrevHash); err != nil {
+			return fmt.Errorf("restore integrity chain: %w", err)
+		}
 		return nil
 	}
 
@@ -434,7 +436,9 @@ func (s *IntegrityStore) recoverFromSidecarGap(sidecar audit.SidecarState, lastF
 		return false, nil
 	}
 
-	s.chain.Restore(lastVerified.Integrity.Sequence, lastVerified.Integrity.EntryHash)
+	if err := s.chain.Restore(lastVerified.Integrity.Sequence, lastVerified.Integrity.EntryHash); err != nil {
+		return false, fmt.Errorf("restore integrity chain: %w", err)
+	}
 	slog.Warn("audit integrity: sidecar behind, advancing after crash recovery",
 		"sidecar_seq", sidecar.Sequence,
 		"log_seq", lastVerified.Integrity.Sequence,
@@ -493,7 +497,9 @@ func (s *IntegrityStore) bootstrapWithoutSidecar(files []audit.LogFile, lastFile
 			if err := s.validateVisibleChain(files); err != nil {
 				return err
 			}
-			s.chain.Restore(entry.Integrity.Sequence, entry.Integrity.EntryHash)
+			if err := s.chain.Restore(entry.Integrity.Sequence, entry.Integrity.EntryHash); err != nil {
+				return fmt.Errorf("restore integrity chain: %w", err)
+			}
 			return audit.WriteSidecar(s.sidecarPath, audit.SidecarState{
 				Sequence:       entry.Integrity.Sequence,
 				PrevHash:       entry.Integrity.EntryHash,
@@ -602,7 +608,9 @@ func (s *IntegrityStore) AppendEvent(ctx context.Context, ev types.Event) error 
 			return &FatalIntegrityError{Op: "write audit log", Err: err}
 		}
 		// Clean failure: no bytes hit disk, safe to roll back chain state.
-		s.chain.Restore(prevState.Sequence, prevState.PrevHash)
+		if restoreErr := s.chain.Restore(prevState.Sequence, prevState.PrevHash); restoreErr != nil {
+			return fmt.Errorf("restore integrity chain after write failure: %w", restoreErr)
+		}
 		return err
 	}
 

--- a/pkg/types/events.go
+++ b/pkg/types/events.go
@@ -59,12 +59,9 @@ type Event struct {
 
 	// Chain is the shared (sequence, generation) allocated by the composite
 	// store before fanout. Used by chained sinks to produce sink-local
-	// integrity hashes.
-	//
-	// The pointed-to ChainState is immutable from the outside (unexported
-	// fields, read-only Sequence/Generation accessors), so the pointer can
-	// be safely aliased across sinks during fanout without any sink being
-	// able to corrupt the values seen by other sinks.
+	// integrity hashes. See ChainState's contract: composite stamps a
+	// fresh *ChainState per sink during fanout, so the pointer is never
+	// aliased across sinks.
 	//
 	// json:"-" is load-bearing: this field must never appear in any
 	// user-visible serialization. Tested by TestEvent_ChainFieldNotMarshaled.
@@ -93,22 +90,13 @@ type EventQuery struct {
 // by the composite store before fanout to chained sinks. See
 // docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
 //
-// Fields are unexported and exposed via read-only methods so sinks cannot
-// mutate the state through the aliased pointer that fanout produces. The
-// composite store constructs values via NewChainState and never reuses
-// instances across events.
+// Although the fields are exported for ergonomic field access in chained
+// sinks, ChainState MUST be treated as read-only by every consumer. The
+// composite store stamps a fresh *ChainState per fanned-out sink in
+// AppendEvent (see internal/store/composite/composite.go), so no two sinks
+// alias the same ChainState. This contract is the per-sink-copy guarantee
+// that prevents one sink's mutation from corrupting another's view.
 type ChainState struct {
-	sequence   uint64
-	generation uint32
+	Sequence   uint64
+	Generation uint32
 }
-
-// NewChainState returns a stamped ChainState. Used by the composite store.
-func NewChainState(sequence uint64, generation uint32) *ChainState {
-	return &ChainState{sequence: sequence, generation: generation}
-}
-
-// Sequence returns the shared monotonic sequence allocated for the event.
-func (c *ChainState) Sequence() uint64 { return c.sequence }
-
-// Generation returns the chain generation at the time of allocation.
-func (c *ChainState) Generation() uint32 { return c.generation }

--- a/pkg/types/events.go
+++ b/pkg/types/events.go
@@ -56,6 +56,14 @@ type Event struct {
 	EffectiveAction string `json:"effective_action,omitempty"`
 
 	Fields map[string]any `json:"fields,omitempty"`
+
+	// Chain is the shared (sequence, generation) allocated by the composite
+	// store before fanout. Used by chained sinks to produce sink-local
+	// integrity hashes.
+	//
+	// json:"-" is load-bearing: this field must never appear in any
+	// user-visible serialization. Tested by TestEvent_ChainFieldNotMarshaled.
+	Chain *ChainState `json:"-"`
 }
 
 type EventQuery struct {
@@ -74,4 +82,12 @@ type EventQuery struct {
 	Limit  int
 	Offset int
 	Asc    bool
+}
+
+// ChainState is the shared (sequence, generation) tuple stamped on each event
+// by the composite store before fanout to chained sinks. See
+// docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
+type ChainState struct {
+	Sequence   uint64
+	Generation uint32
 }

--- a/pkg/types/events.go
+++ b/pkg/types/events.go
@@ -59,12 +59,13 @@ type Event struct {
 
 	// Chain is the shared (sequence, generation) allocated by the composite
 	// store before fanout. Used by chained sinks to produce sink-local
-	// integrity hashes. See ChainState's contract: composite stamps a
-	// fresh *ChainState per sink during fanout, so the pointer is never
-	// aliased across sinks.
+	// integrity hashes. Nil until composite stamps it.
 	//
 	// json:"-" is load-bearing: this field must never appear in any
 	// user-visible serialization. Tested by TestEvent_ChainFieldNotMarshaled.
+	//
+	// Sinks MUST treat the pointed-to ChainState as read-only — see the
+	// ChainState type comment for the per-sink-copy contract.
 	Chain *ChainState `json:"-"`
 }
 
@@ -90,12 +91,17 @@ type EventQuery struct {
 // by the composite store before fanout to chained sinks. See
 // docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
 //
-// Although the fields are exported for ergonomic field access in chained
-// sinks, ChainState MUST be treated as read-only by every consumer. The
-// composite store stamps a fresh *ChainState per fanned-out sink in
-// AppendEvent (see internal/store/composite/composite.go), so no two sinks
-// alias the same ChainState. This contract is the per-sink-copy guarantee
-// that prevents one sink's mutation from corrupting another's view.
+// Contract for consumers: ChainState MUST be treated as read-only. Sinks
+// must never mutate the fields of a *ChainState they receive on
+// types.Event.Chain. The composite store is the sole writer; it allocates
+// the (sequence, generation) tuple via audit.SequenceAllocator and stamps
+// the resulting ChainState onto the event in AppendEvent.
+//
+// To make accidental aliasing across sinks impossible, the composite is
+// expected to stamp a separate *ChainState per fanned-out sink (see Task 5
+// of the Phase 0 plan). Until Task 5 lands the typed Chain field is unused
+// at runtime; this type and the field exist now so downstream tasks can
+// build against a stable type.
 type ChainState struct {
 	Sequence   uint64
 	Generation uint32

--- a/pkg/types/events.go
+++ b/pkg/types/events.go
@@ -61,6 +61,11 @@ type Event struct {
 	// store before fanout. Used by chained sinks to produce sink-local
 	// integrity hashes.
 	//
+	// The pointed-to ChainState is immutable from the outside (unexported
+	// fields, read-only Sequence/Generation accessors), so the pointer can
+	// be safely aliased across sinks during fanout without any sink being
+	// able to corrupt the values seen by other sinks.
+	//
 	// json:"-" is load-bearing: this field must never appear in any
 	// user-visible serialization. Tested by TestEvent_ChainFieldNotMarshaled.
 	Chain *ChainState `json:"-"`
@@ -87,7 +92,23 @@ type EventQuery struct {
 // ChainState is the shared (sequence, generation) tuple stamped on each event
 // by the composite store before fanout to chained sinks. See
 // docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
+//
+// Fields are unexported and exposed via read-only methods so sinks cannot
+// mutate the state through the aliased pointer that fanout produces. The
+// composite store constructs values via NewChainState and never reuses
+// instances across events.
 type ChainState struct {
-	Sequence   uint64
-	Generation uint32
+	sequence   uint64
+	generation uint32
 }
+
+// NewChainState returns a stamped ChainState. Used by the composite store.
+func NewChainState(sequence uint64, generation uint32) *ChainState {
+	return &ChainState{sequence: sequence, generation: generation}
+}
+
+// Sequence returns the shared monotonic sequence allocated for the event.
+func (c *ChainState) Sequence() uint64 { return c.sequence }
+
+// Generation returns the chain generation at the time of allocation.
+func (c *ChainState) Generation() uint32 { return c.generation }

--- a/pkg/types/events.go
+++ b/pkg/types/events.go
@@ -87,21 +87,20 @@ type EventQuery struct {
 	Asc    bool
 }
 
-// ChainState is the shared (sequence, generation) tuple stamped on each event
-// by the composite store before fanout to chained sinks. See
+// ChainState is the shared (sequence, generation) tuple that the composite
+// store will stamp on each event before fanout to chained sinks. See
 // docs/superpowers/specs/2026-04-18-phase-0-shared-sequence-contract.md.
 //
 // Contract for consumers: ChainState MUST be treated as read-only. Sinks
 // must never mutate the fields of a *ChainState they receive on
-// types.Event.Chain. The composite store is the sole writer; it allocates
-// the (sequence, generation) tuple via audit.SequenceAllocator and stamps
-// the resulting ChainState onto the event in AppendEvent.
+// types.Event.Chain.
 //
-// To make accidental aliasing across sinks impossible, the composite is
-// expected to stamp a separate *ChainState per fanned-out sink (see Task 5
-// of the Phase 0 plan). Until Task 5 lands the typed Chain field is unused
-// at runtime; this type and the field exist now so downstream tasks can
-// build against a stable type.
+// Lifecycle: this type and the Event.Chain field exist now so downstream
+// tasks can build against a stable type, but no caller writes to Chain
+// yet. Task 5 of the Phase 0 plan will land the composite-store wiring
+// that allocates a (sequence, generation) tuple via
+// audit.SequenceAllocator and stamps a separate *ChainState per
+// fanned-out sink (so the pointer is never aliased across sinks).
 type ChainState struct {
 	Sequence   uint64
 	Generation uint32

--- a/pkg/types/events_test.go
+++ b/pkg/types/events_test.go
@@ -55,10 +55,7 @@ func TestEvent_ChainFieldNotMarshaled(t *testing.T) {
 		Timestamp: time.Unix(1700000000, 0).UTC(),
 		Type:      "file_open",
 		SessionID: "sess-1",
-		Chain: &ChainState{
-			Sequence:   42,
-			Generation: 7,
-		},
+		Chain:     NewChainState(42, 7),
 	}
 
 	out, err := json.Marshal(ev)
@@ -84,5 +81,28 @@ func TestEvent_ChainFieldIgnoredOnUnmarshal(t *testing.T) {
 	}
 	if ev.Chain != nil {
 		t.Fatalf("Chain should remain nil after unmarshal, got %+v", ev.Chain)
+	}
+}
+
+// TestChainState_Immutable verifies that the ChainState pointer aliased
+// across sinks during composite fanout cannot be mutated by any sink.
+// This is the structural guarantee that justifies sharing the pointer
+// rather than deep-copying per sink.
+func TestChainState_Immutable(t *testing.T) {
+	c := NewChainState(100, 5)
+	if c.Sequence() != 100 {
+		t.Fatalf("Sequence(): got %d, want 100", c.Sequence())
+	}
+	if c.Generation() != 5 {
+		t.Fatalf("Generation(): got %d, want 5", c.Generation())
+	}
+
+	// The struct fields are unexported; outside the types package this
+	// test wouldn't even compile if a caller tried to write c.sequence = 0.
+	// Inside the package we can demonstrate the read-only intent by
+	// confirming that two readers see the same values regardless of order.
+	c2 := c
+	if c2.Sequence() != c.Sequence() || c2.Generation() != c.Generation() {
+		t.Fatalf("aliased pointer reads diverged: c=%v c2=%v", c, c2)
 	}
 }

--- a/pkg/types/events_test.go
+++ b/pkg/types/events_test.go
@@ -55,7 +55,10 @@ func TestEvent_ChainFieldNotMarshaled(t *testing.T) {
 		Timestamp: time.Unix(1700000000, 0).UTC(),
 		Type:      "file_open",
 		SessionID: "sess-1",
-		Chain:     NewChainState(42, 7),
+		Chain: &ChainState{
+			Sequence:   42,
+			Generation: 7,
+		},
 	}
 
 	out, err := json.Marshal(ev)
@@ -84,25 +87,17 @@ func TestEvent_ChainFieldIgnoredOnUnmarshal(t *testing.T) {
 	}
 }
 
-// TestChainState_Immutable verifies that the ChainState pointer aliased
-// across sinks during composite fanout cannot be mutated by any sink.
-// This is the structural guarantee that justifies sharing the pointer
-// rather than deep-copying per sink.
-func TestChainState_Immutable(t *testing.T) {
-	c := NewChainState(100, 5)
-	if c.Sequence() != 100 {
-		t.Fatalf("Sequence(): got %d, want 100", c.Sequence())
-	}
-	if c.Generation() != 5 {
-		t.Fatalf("Generation(): got %d, want 5", c.Generation())
-	}
+// TestChainState_PerSinkCopy_Independence documents the contract that the
+// composite store stamps a fresh *ChainState per sink during fanout. Two
+// separately-allocated ChainState values must be independent: mutating one
+// must not affect the other. This is the runtime guarantee underlying the
+// "Chain MUST be treated as read-only" contract documented on the type.
+func TestChainState_PerSinkCopy_Independence(t *testing.T) {
+	a := &ChainState{Sequence: 100, Generation: 5}
+	b := &ChainState{Sequence: 100, Generation: 5}
 
-	// The struct fields are unexported; outside the types package this
-	// test wouldn't even compile if a caller tried to write c.sequence = 0.
-	// Inside the package we can demonstrate the read-only intent by
-	// confirming that two readers see the same values regardless of order.
-	c2 := c
-	if c2.Sequence() != c.Sequence() || c2.Generation() != c.Generation() {
-		t.Fatalf("aliased pointer reads diverged: c=%v c2=%v", c, c2)
+	a.Sequence = 999
+	if b.Sequence != 100 {
+		t.Fatalf("per-sink copy not independent: b.Sequence got %d, want 100", b.Sequence)
 	}
 }

--- a/pkg/types/events_test.go
+++ b/pkg/types/events_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,4 +44,45 @@ func TestExecveEvent_JSON(t *testing.T) {
 	assert.Equal(t, 1234, decoded.PID)
 	assert.Equal(t, 1000, decoded.ParentPID)
 	assert.False(t, decoded.Truncated)
+}
+
+// TestEvent_ChainFieldNotMarshaled is a load-bearing safety test for the
+// Phase 0 contract: the typed Chain field MUST NEVER appear in JSON output,
+// because it carries internal sink coordination state, not user-visible data.
+func TestEvent_ChainFieldNotMarshaled(t *testing.T) {
+	ev := Event{
+		ID:        "abc",
+		Timestamp: time.Unix(1700000000, 0).UTC(),
+		Type:      "file_open",
+		SessionID: "sess-1",
+		Chain: &ChainState{
+			Sequence:   42,
+			Generation: 7,
+		},
+	}
+
+	out, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	got := string(out)
+
+	for _, banned := range []string{`"chain"`, `"Chain"`, `"sequence":42`, `"generation":7`} {
+		if strings.Contains(got, banned) {
+			t.Errorf("Event JSON must not contain %q; got %s", banned, got)
+		}
+	}
+}
+
+// TestEvent_ChainFieldIgnoredOnUnmarshal verifies that decoding JSON which
+// happens to contain a "chain" key does not populate Event.Chain.
+func TestEvent_ChainFieldIgnoredOnUnmarshal(t *testing.T) {
+	raw := []byte(`{"id":"x","type":"file_open","session_id":"s","timestamp":"2024-01-02T03:04:05Z","chain":{"sequence":99,"generation":3}}`)
+	var ev Event
+	if err := json.Unmarshal(raw, &ev); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if ev.Chain != nil {
+		t.Fatalf("Chain should remain nil after unmarshal, got %+v", ev.Chain)
+	}
 }

--- a/pkg/types/events_test.go
+++ b/pkg/types/events_test.go
@@ -86,18 +86,3 @@ func TestEvent_ChainFieldIgnoredOnUnmarshal(t *testing.T) {
 		t.Fatalf("Chain should remain nil after unmarshal, got %+v", ev.Chain)
 	}
 }
-
-// TestChainState_PerSinkCopy_Independence documents the contract that the
-// composite store stamps a fresh *ChainState per sink during fanout. Two
-// separately-allocated ChainState values must be independent: mutating one
-// must not affect the other. This is the runtime guarantee underlying the
-// "Chain MUST be treated as read-only" contract documented on the type.
-func TestChainState_PerSinkCopy_Independence(t *testing.T) {
-	a := &ChainState{Sequence: 100, Generation: 5}
-	b := &ChainState{Sequence: 100, Generation: 5}
-
-	a.Sequence = 999
-	if b.Sequence != 100 {
-		t.Fatalf("per-sink copy not independent: b.Sequence got %d, want 100", b.Sequence)
-	}
-}

--- a/pkg/types/sessions.go
+++ b/pkg/types/sessions.go
@@ -132,7 +132,7 @@ type WrapInitRequest struct {
 // WrapInitResponse returns the seccomp wrapper configuration to the CLI.
 type WrapInitResponse struct {
 	PtraceMode            bool              `json:"ptrace_mode,omitempty"`
-	SafeToBypassShellShim bool              `json:"safe_to_bypass_shell_shim,omitempty"`
+	SafeToBypassShellShim bool              `json:"safe_to_bypass_shell_shim"`
 	WrapperBinary         string            `json:"wrapper_binary"`
 	StubBinary            string            `json:"stub_binary,omitempty"`
 	SeccompConfig         string            `json:"seccomp_config"`          // JSON-encoded seccomp config

--- a/pkg/types/sessions.go
+++ b/pkg/types/sessions.go
@@ -110,7 +110,7 @@ type CreateSessionRequest struct {
 	Workspace         string `json:"workspace,omitempty"`
 	Policy            string `json:"policy,omitempty"`
 	Profile           string `json:"profile,omitempty"`
-	Home              string `json:"home,omitempty"`                 // User's home directory for ${HOME} policy expansion
+	Home              string `json:"home,omitempty"`                // User's home directory for ${HOME} policy expansion
 	DetectProjectRoot *bool  `json:"detect_project_root,omitempty"` // Override server default
 	ProjectRoot       string `json:"project_root,omitempty"`        // Explicit override
 	RealPaths         *bool  `json:"real_paths,omitempty"`          // Use actual host paths instead of /workspace
@@ -131,11 +131,12 @@ type WrapInitRequest struct {
 
 // WrapInitResponse returns the seccomp wrapper configuration to the CLI.
 type WrapInitResponse struct {
-	PtraceMode    bool              `json:"ptrace_mode,omitempty"`
-	WrapperBinary string            `json:"wrapper_binary"`
-	StubBinary    string            `json:"stub_binary,omitempty"`
-	SeccompConfig string            `json:"seccomp_config"`          // JSON-encoded seccomp config
-	NotifySocket  string            `json:"notify_socket"`           // Unix socket path for forwarding notify fd
-	SignalSocket  string            `json:"signal_socket,omitempty"` // Unix socket path for forwarding signal filter fd
-	WrapperEnv    map[string]string `json:"wrapper_env"`             // Extra env vars for the wrapper
+	PtraceMode            bool              `json:"ptrace_mode,omitempty"`
+	SafeToBypassShellShim bool              `json:"safe_to_bypass_shell_shim,omitempty"`
+	WrapperBinary         string            `json:"wrapper_binary"`
+	StubBinary            string            `json:"stub_binary,omitempty"`
+	SeccompConfig         string            `json:"seccomp_config"`          // JSON-encoded seccomp config
+	NotifySocket          string            `json:"notify_socket"`           // Unix socket path for forwarding notify fd
+	SignalSocket          string            `json:"signal_socket,omitempty"` // Unix socket path for forwarding signal filter fd
+	WrapperEnv            map[string]string `json:"wrapper_env"`             // Extra env vars for the wrapper
 }


### PR DESCRIPTION
Superseded by #238. This draft was opened from a branch with unrelated history and is intentionally closed in favor of the clean replacement PR.