### PR TITLE
[codex] Gate AGENTSH_IN_SESSION on wrap interception strength

### DIFF
--- a/docs/cookbook/command-policies.md
+++ b/docs/cookbook/command-policies.md
@@ -159,8 +159,8 @@ Nested shell behavior depends on the active wrap mode. In strong interception
 paths such as ptrace or execve-intercepting wrap, descendant `sh`/`bash`
 processes bypass the shell shim because wrap is already enforcing exec policy
 for the whole tree. In fallback or no-`execve` modes, nested shells still
-depend on the shim for command steering, so `AGENTSH_IN_SESSION` is not
-injected.
+depend on the shim for command steering, so `AGENTSH_IN_SESSION` is
+intentionally not injected.
 
 ### Electron sharp edges
 

--- a/docs/cookbook/command-policies.md
+++ b/docs/cookbook/command-policies.md
@@ -155,6 +155,13 @@ No `command_rules` entry for `emdash` is needed — the binary is launched
 directly. The policy applies to everything emdash then spawns: subprocesses,
 shell commands, network, file writes.
 
+Nested shell behavior depends on the active wrap mode. In strong interception
+paths such as ptrace or execve-intercepting wrap, descendant `sh`/`bash`
+processes bypass the shell shim because wrap is already enforcing exec policy
+for the whole tree. In fallback or no-`execve` modes, nested shells still
+depend on the shim for command steering, so `AGENTSH_IN_SESSION` is not
+injected.
+
 ### Electron sharp edges
 
 Electron apps (and anything using a Chromium renderer subprocess) exercise

--- a/docs/cookbook/command-policies.md
+++ b/docs/cookbook/command-policies.md
@@ -158,9 +158,9 @@ shell commands, network, file writes.
 Nested shell behavior depends on the active wrap mode. In strong interception
 paths such as ptrace or execve-intercepting wrap, descendant `sh`/`bash`
 processes bypass the shell shim because wrap is already enforcing exec policy
-for the whole tree. In fallback or no-`execve` modes, nested shells still
-depend on the shim for command steering, so `AGENTSH_IN_SESSION` is
-intentionally not injected.
+for the whole tree. In fallback or no-`execve` modes, the wrap-launched
+agent process does not receive `AGENTSH_IN_SESSION`, because nested shells
+still need the shim for command steering.
 
 ### Electron sharp edges
 

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -208,8 +208,9 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 		a.broker.Publish(ev)
 
 		return types.WrapInitResponse{
-			PtraceMode:   true,
-			NotifySocket: notifySocketPath,
+			PtraceMode:            true,
+			SafeToBypassShellShim: true,
+			NotifySocket:          notifySocketPath,
 		}, http.StatusOK, nil
 	}
 
@@ -398,12 +399,13 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 	a.broker.Publish(ev)
 
 	return types.WrapInitResponse{
-		WrapperBinary: wrapperPath,
-		StubBinary:    stubPath,
-		SeccompConfig: string(cfgJSON),
-		NotifySocket:  notifySocketPath,
-		SignalSocket:  signalSocketPath,
-		WrapperEnv:    wrapperEnv,
+		SafeToBypassShellShim: execveEnabled,
+		WrapperBinary:         wrapperPath,
+		StubBinary:            stubPath,
+		SeccompConfig:         string(cfgJSON),
+		NotifySocket:          notifySocketPath,
+		SignalSocket:          signalSocketPath,
+		WrapperEnv:            wrapperEnv,
 	}, http.StatusOK, nil
 }
 

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -1,9 +1,11 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -440,6 +442,40 @@ func TestWrapInit_SafeToBypassShellShim_SeccompExecveDisabled(t *testing.T) {
 	}
 	if resp.SafeToBypassShellShim {
 		t.Fatal("expected execve-disabled seccomp mode to require the shell shim")
+	}
+}
+
+func TestWrapInit_HTTPResponseIncludesSafeToBypassShellShimFalse(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap response serialization is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Development.DisableAuth = true
+	cfg.Health.Path = "/health"
+	cfg.Health.ReadinessPath = "/ready"
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.Seccomp.Execve.Enabled = false
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	body := []byte(`{"agent_command":"/bin/echo","caller_uid":0}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/"+s.ID+"/wrap-init", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	app.Router().ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), `"safe_to_bypass_shell_shim":false`) {
+		t.Fatalf("expected serialized response to include safe_to_bypass_shell_shim=false, got %s", rr.Body.String())
 	}
 }
 

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -350,6 +350,99 @@ func TestWrapInit_RejectsNegativeCallerUID(t *testing.T) {
 	}
 }
 
+func TestWrapInit_SafeToBypassShellShim_Ptrace(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap ptrace mode is Linux-only")
+	}
+
+	cfg := &config.Config{}
+	app, mgr := newTestAppForWrap(t, cfg)
+	app.ptraceTracer = struct{}{}
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", code)
+	}
+	if !resp.SafeToBypassShellShim {
+		t.Fatal("expected ptrace mode to be safe to bypass the shell shim")
+	}
+}
+
+func TestWrapInit_SafeToBypassShellShim_SeccompExecveEnabled(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap seccomp mode is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.Seccomp.Execve.Enabled = true
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", code)
+	}
+	if !resp.SafeToBypassShellShim {
+		t.Fatal("expected execve-enabled seccomp mode to be safe to bypass the shell shim")
+	}
+}
+
+func TestWrapInit_SafeToBypassShellShim_SeccompExecveDisabled(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap seccomp mode is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.Seccomp.Execve.Enabled = false
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    0,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", code)
+	}
+	if resp.SafeToBypassShellShim {
+		t.Fatal("expected execve-disabled seccomp mode to require the shell shim")
+	}
+}
+
 func TestWrapInit_Success(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("wrap is Linux-only")

--- a/internal/api/wrap_windows.go
+++ b/internal/api/wrap_windows.go
@@ -128,7 +128,8 @@ func (a *App) wrapInitWindows(ctx context.Context, s *session.Session, sessionID
 
 	// On Windows, no wrapper binary is needed — the driver intercepts system-wide.
 	return types.WrapInitResponse{
-		StubBinary: stubPath,
+		SafeToBypassShellShim: true,
+		StubBinary:            stubPath,
 	}, http.StatusOK, nil
 }
 

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"runtime"
+	"strings"
 	"syscall"
 
 	"github.com/agentsh/agentsh/internal/client"
@@ -312,7 +313,19 @@ func setupWrapInterception(ctx context.Context, c client.CLIClient, sessID strin
 }
 
 func buildWrapEnv(base []string, sessionID string, serverAddr string, bypassShellShim bool) []string {
-	env := append([]string{}, base...)
+	env := make([]string, 0, len(base)+3)
+	for _, e := range base {
+		switch {
+		case strings.HasPrefix(e, "AGENTSH_SESSION_ID="):
+			continue
+		case strings.HasPrefix(e, "AGENTSH_SERVER="):
+			continue
+		case strings.HasPrefix(e, "AGENTSH_IN_SESSION="):
+			continue
+		default:
+			env = append(env, e)
+		}
+	}
 	env = append(env,
 		fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessionID),
 		fmt.Sprintf("AGENTSH_SERVER=%s", serverAddr),

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -146,10 +146,7 @@ func runWrap(ctx context.Context, cfg *clientConfig, opts wrapOptions) error {
 		agentProc.Stdin = os.Stdin
 		agentProc.Stdout = os.Stdout
 		agentProc.Stderr = os.Stderr
-		agentProc.Env = append(os.Environ(),
-			fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessID),
-			fmt.Sprintf("AGENTSH_SERVER=%s", cfg.serverAddr),
-		)
+		agentProc.Env = buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, false)
 	}
 
 	// If FUSE mount is active, add it to the environment and set the working
@@ -280,8 +277,8 @@ type wrapLaunchConfig struct {
 	env         []string
 	extraFiles  []*os.File
 	sysProcAttr *syscall.SysProcAttr
-	postStart   func() // Called after the process starts (e.g., to forward notify fd)
-	postWait    func() // Called after the process exits (e.g., to reclaim terminal)
+	postStart   func()    // Called after the process starts (e.g., to forward notify fd)
+	postWait    func()    // Called after the process exits (e.g., to reclaim terminal)
 	keepAlive   io.Closer // Held open during shell lifetime (e.g., ptrace handshake conn)
 	// ptracePostStart is called after the child is started with the child PID.
 	// It performs the ptrace handshake (send PID, wait for ACK).
@@ -312,6 +309,18 @@ func setupWrapInterception(ctx context.Context, c client.CLIClient, sessID strin
 
 	// Delegate to platform-specific code for socket pair creation and fd management
 	return platformSetupWrap(ctx, wrapResp, sessID, agentPath, agentArgs, cfg)
+}
+
+func buildWrapEnv(base []string, sessionID string, serverAddr string, bypassShellShim bool) []string {
+	env := append([]string{}, base...)
+	env = append(env,
+		fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessionID),
+		fmt.Sprintf("AGENTSH_SERVER=%s", serverAddr),
+	)
+	if bypassShellShim {
+		env = append(env, "AGENTSH_IN_SESSION=1")
+	}
+	return env
 }
 
 // fetchSessionForWrap resolves the session for runWrap, either by reusing

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -315,12 +315,17 @@ func setupWrapInterception(ctx context.Context, c client.CLIClient, sessID strin
 func buildWrapEnv(base []string, sessionID string, serverAddr string, bypassShellShim bool) []string {
 	env := make([]string, 0, len(base)+3)
 	for _, e := range base {
+		key, _, found := strings.Cut(e, "=")
+		if !found {
+			env = append(env, e)
+			continue
+		}
 		switch {
-		case strings.HasPrefix(e, "AGENTSH_SESSION_ID="):
+		case strings.EqualFold(key, "AGENTSH_SESSION_ID"):
 			continue
-		case strings.HasPrefix(e, "AGENTSH_SERVER="):
+		case strings.EqualFold(key, "AGENTSH_SERVER"):
 			continue
-		case strings.HasPrefix(e, "AGENTSH_IN_SESSION="):
+		case strings.EqualFold(key, "AGENTSH_IN_SESSION"):
 			continue
 		default:
 			env = append(env, e)

--- a/internal/cli/wrap_darwin.go
+++ b/internal/cli/wrap_darwin.go
@@ -19,11 +19,7 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 	if wrapResp.WrapperBinary == "" {
 		// No wrapper needed on macOS — ES interception is handled by System Extension.
 		// The agent runs directly, and the ESF client intercepts its execs.
-		env := os.Environ()
-		env = append(env,
-			fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessID),
-			fmt.Sprintf("AGENTSH_SERVER=%s", cfg.serverAddr),
-		)
+		env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
 
 		return &wrapLaunchConfig{
 			command: agentPath,
@@ -37,11 +33,7 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 
 	// If the server returns a wrapper binary (e.g., agentsh-macwrap for sandboxing),
 	// use it as the launch command.
-	env := os.Environ()
-	env = append(env,
-		fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessID),
-		fmt.Sprintf("AGENTSH_SERVER=%s", cfg.serverAddr),
-	)
+	env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
 	for k, v := range wrapResp.WrapperEnv {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}

--- a/internal/cli/wrap_linux.go
+++ b/internal/cli/wrap_linux.go
@@ -25,11 +25,7 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 	if wrapResp.PtraceMode {
 		notifySocket := wrapResp.NotifySocket
 
-		env := os.Environ()
-		env = append(env,
-			fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessID),
-			fmt.Sprintf("AGENTSH_SERVER=%s", cfg.serverAddr),
-		)
+		env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
 
 		// connHolder stores the keepalive connection set by ptracePostStart.
 		var connHolder net.Conn
@@ -130,12 +126,8 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 	}
 
 	// Build env for the wrapped process
-	env := os.Environ()
-	env = append(env,
-		fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessID),
-		fmt.Sprintf("AGENTSH_SERVER=%s", cfg.serverAddr),
-		"AGENTSH_NOTIFY_SOCK_FD=3", // fd 3 = ExtraFiles[0]
-	)
+	env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
+	env = append(env, "AGENTSH_NOTIFY_SOCK_FD=3") // fd 3 = ExtraFiles[0]
 	if hasSignalSocket {
 		env = append(env, "AGENTSH_SIGNAL_SOCK_FD=4") // fd 4 = ExtraFiles[1]
 	}

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"os"
 	"net/url"
+	"os"
 	"runtime"
 	"syscall"
 	"testing"
@@ -129,10 +129,10 @@ func TestWrapCmd_RequiresCommandWithFlags(t *testing.T) {
 
 // mockWrapClient implements CLIClient for testing wrap interception setup.
 type mockWrapClient struct {
-	wrapInitCalled  bool
-	wrapInitReq     types.WrapInitRequest
-	wrapInitResp    types.WrapInitResponse
-	wrapInitErr     error
+	wrapInitCalled   bool
+	wrapInitReq      types.WrapInitRequest
+	wrapInitResp     types.WrapInitResponse
+	wrapInitErr      error
 	createSessCalled bool
 	getSessionCalled bool
 	getSessionFn     func(ctx context.Context, id string) (types.Session, error)
@@ -173,7 +173,7 @@ func (m *mockWrapClient) GetSession(ctx context.Context, id string) (types.Sessi
 	}
 	return types.Session{ID: id}, nil
 }
-func (m *mockWrapClient) DestroySession(ctx context.Context, id string) error    { return nil }
+func (m *mockWrapClient) DestroySession(ctx context.Context, id string) error { return nil }
 func (m *mockWrapClient) PatchSession(ctx context.Context, id string, req types.SessionPatchRequest) (types.Session, error) {
 	return types.Session{}, nil
 }
@@ -198,7 +198,9 @@ func (m *mockWrapClient) StreamSessionEvents(ctx context.Context, sessionID stri
 func (m *mockWrapClient) OutputChunk(ctx context.Context, sessionID, commandID string, stream string, offset, limit int64) (map[string]any, error) {
 	return nil, nil
 }
-func (m *mockWrapClient) ListApprovals(ctx context.Context) ([]map[string]any, error) { return nil, nil }
+func (m *mockWrapClient) ListApprovals(ctx context.Context) ([]map[string]any, error) {
+	return nil, nil
+}
 func (m *mockWrapClient) ResolveApproval(ctx context.Context, id string, decision string, reason string) error {
 	return nil
 }
@@ -309,6 +311,27 @@ func TestSetupWrapInterception_WrapInitError(t *testing.T) {
 	assert.Contains(t, err.Error(), "wrap-init")
 }
 
+func TestBuildWrapEnv_IncludesInSessionWhenBypassEnabled(t *testing.T) {
+	env := buildWrapEnv([]string{"PATH=/usr/bin"}, "sess-123", "http://127.0.0.1:18080", true)
+	envMap := make(map[string]bool)
+	for _, e := range env {
+		envMap[e] = true
+	}
+
+	assert.True(t, envMap["AGENTSH_SESSION_ID=sess-123"])
+	assert.True(t, envMap["AGENTSH_SERVER=http://127.0.0.1:18080"])
+	assert.True(t, envMap["AGENTSH_IN_SESSION=1"])
+}
+
+func TestBuildWrapEnv_OmitsInSessionWhenBypassDisabled(t *testing.T) {
+	env := buildWrapEnv([]string{"PATH=/usr/bin"}, "sess-123", "http://127.0.0.1:18080", false)
+	for _, e := range env {
+		if e == "AGENTSH_IN_SESSION=1" {
+			t.Fatal("did not expect AGENTSH_IN_SESSION when bypass is disabled")
+		}
+	}
+}
+
 func TestWrapLaunchConfig_EnvContainsSessionAndWrapper(t *testing.T) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("wrap interception requires Linux or macOS")
@@ -345,6 +368,72 @@ func TestWrapLaunchConfig_EnvContainsSessionAndWrapper(t *testing.T) {
 	}
 
 	// Clean up
+	for _, f := range lcfg.extraFiles {
+		if f != nil {
+			f.Close()
+		}
+	}
+}
+
+func TestWrapLaunchConfig_EnvIncludesInSessionWhenSafe(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("wrap interception requires Linux or macOS")
+	}
+
+	mc := &mockWrapClient{
+		wrapInitResp: types.WrapInitResponse{
+			WrapperBinary:         "/bin/true",
+			NotifySocket:          "/tmp/agentsh-notify-test.sock",
+			SafeToBypassShellShim: true,
+			WrapperEnv: map[string]string{
+				"AGENTSH_SECCOMP_CONFIG": `{"unix_socket_enabled":true}`,
+			},
+		},
+	}
+
+	cfg := &clientConfig{serverAddr: "http://127.0.0.1:18080"}
+	lcfg, err := setupWrapInterception(context.Background(), mc, "test-session", "/bin/echo", nil, cfg)
+	require.NoError(t, err)
+
+	envMap := make(map[string]bool)
+	for _, e := range lcfg.env {
+		envMap[e] = true
+	}
+	assert.True(t, envMap["AGENTSH_IN_SESSION=1"])
+
+	for _, f := range lcfg.extraFiles {
+		if f != nil {
+			f.Close()
+		}
+	}
+}
+
+func TestWrapLaunchConfig_EnvOmitsInSessionWhenUnsafe(t *testing.T) {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		t.Skip("wrap interception requires Linux or macOS")
+	}
+
+	mc := &mockWrapClient{
+		wrapInitResp: types.WrapInitResponse{
+			WrapperBinary:         "/bin/true",
+			NotifySocket:          "/tmp/agentsh-notify-test.sock",
+			SafeToBypassShellShim: false,
+			WrapperEnv: map[string]string{
+				"AGENTSH_SECCOMP_CONFIG": `{"unix_socket_enabled":true}`,
+			},
+		},
+	}
+
+	cfg := &clientConfig{serverAddr: "http://127.0.0.1:18080"}
+	lcfg, err := setupWrapInterception(context.Background(), mc, "test-session", "/bin/echo", nil, cfg)
+	require.NoError(t, err)
+
+	for _, e := range lcfg.env {
+		if e == "AGENTSH_IN_SESSION=1" {
+			t.Fatal("did not expect AGENTSH_IN_SESSION when wrap response marks bypass unsafe")
+		}
+	}
+
 	for _, f := range lcfg.extraFiles {
 		if f != nil {
 			f.Close()

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -380,6 +380,56 @@ func TestBuildWrapEnv_ReplacesInheritedAgentshVarsWhenBypassEnabled(t *testing.T
 	assert.Equal(t, 0, envMap["AGENTSH_SERVER=http://stale"])
 }
 
+func TestBuildWrapEnv_StripsInheritedMixedCaseAgentshVarsWhenBypassDisabled(t *testing.T) {
+	env := buildWrapEnv([]string{
+		"PATH=/usr/bin",
+		"agentsh_session_id=stale-session",
+		"Agentsh_Server=http://stale",
+		"agentsh_in_session=1",
+	}, "sess-123", "http://127.0.0.1:18080", false)
+
+	for _, e := range env {
+		if e == "agentsh_in_session=1" {
+			t.Fatal("did not expect mixed-case inherited AGENTSH_IN_SESSION when bypass is disabled")
+		}
+		if e == "agentsh_session_id=stale-session" {
+			t.Fatal("did not expect mixed-case stale AGENTSH_SESSION_ID to remain in env")
+		}
+		if e == "Agentsh_Server=http://stale" {
+			t.Fatal("did not expect mixed-case stale AGENTSH_SERVER to remain in env")
+		}
+	}
+
+	envMap := make(map[string]int)
+	for _, e := range env {
+		envMap[e]++
+	}
+	assert.Equal(t, 1, envMap["AGENTSH_SESSION_ID=sess-123"])
+	assert.Equal(t, 1, envMap["AGENTSH_SERVER=http://127.0.0.1:18080"])
+	assert.Equal(t, 0, envMap["AGENTSH_IN_SESSION=1"])
+}
+
+func TestBuildWrapEnv_ReplacesInheritedMixedCaseAgentshVarsWhenBypassEnabled(t *testing.T) {
+	env := buildWrapEnv([]string{
+		"PATH=/usr/bin",
+		"agentsh_session_id=stale-session",
+		"Agentsh_Server=http://stale",
+		"agentsh_in_session=1",
+	}, "sess-123", "http://127.0.0.1:18080", true)
+
+	envMap := make(map[string]int)
+	for _, e := range env {
+		envMap[e]++
+	}
+
+	assert.Equal(t, 1, envMap["AGENTSH_SESSION_ID=sess-123"])
+	assert.Equal(t, 1, envMap["AGENTSH_SERVER=http://127.0.0.1:18080"])
+	assert.Equal(t, 1, envMap["AGENTSH_IN_SESSION=1"])
+	assert.Equal(t, 0, envMap["agentsh_session_id=stale-session"])
+	assert.Equal(t, 0, envMap["Agentsh_Server=http://stale"])
+	assert.Equal(t, 0, envMap["agentsh_in_session=1"])
+}
+
 func TestWrapLaunchConfig_EnvContainsSessionAndWrapper(t *testing.T) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("wrap interception requires Linux or macOS")

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -332,6 +332,54 @@ func TestBuildWrapEnv_OmitsInSessionWhenBypassDisabled(t *testing.T) {
 	}
 }
 
+func TestBuildWrapEnv_StripsInheritedAgentshVarsWhenBypassDisabled(t *testing.T) {
+	env := buildWrapEnv([]string{
+		"PATH=/usr/bin",
+		"AGENTSH_SESSION_ID=stale-session",
+		"AGENTSH_SERVER=http://stale",
+		"AGENTSH_IN_SESSION=1",
+	}, "sess-123", "http://127.0.0.1:18080", false)
+
+	for _, e := range env {
+		if e == "AGENTSH_IN_SESSION=1" {
+			t.Fatal("did not expect inherited AGENTSH_IN_SESSION when bypass is disabled")
+		}
+		if e == "AGENTSH_SESSION_ID=stale-session" {
+			t.Fatal("did not expect stale AGENTSH_SESSION_ID to remain in env")
+		}
+		if e == "AGENTSH_SERVER=http://stale" {
+			t.Fatal("did not expect stale AGENTSH_SERVER to remain in env")
+		}
+	}
+
+	envMap := make(map[string]int)
+	for _, e := range env {
+		envMap[e]++
+	}
+	assert.Equal(t, 1, envMap["AGENTSH_SESSION_ID=sess-123"])
+	assert.Equal(t, 1, envMap["AGENTSH_SERVER=http://127.0.0.1:18080"])
+}
+
+func TestBuildWrapEnv_ReplacesInheritedAgentshVarsWhenBypassEnabled(t *testing.T) {
+	env := buildWrapEnv([]string{
+		"PATH=/usr/bin",
+		"AGENTSH_SESSION_ID=stale-session",
+		"AGENTSH_SERVER=http://stale",
+		"AGENTSH_IN_SESSION=1",
+	}, "sess-123", "http://127.0.0.1:18080", true)
+
+	envMap := make(map[string]int)
+	for _, e := range env {
+		envMap[e]++
+	}
+
+	assert.Equal(t, 1, envMap["AGENTSH_SESSION_ID=sess-123"])
+	assert.Equal(t, 1, envMap["AGENTSH_SERVER=http://127.0.0.1:18080"])
+	assert.Equal(t, 1, envMap["AGENTSH_IN_SESSION=1"])
+	assert.Equal(t, 0, envMap["AGENTSH_SESSION_ID=stale-session"])
+	assert.Equal(t, 0, envMap["AGENTSH_SERVER=http://stale"])
+}
+
 func TestWrapLaunchConfig_EnvContainsSessionAndWrapper(t *testing.T) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("wrap interception requires Linux or macOS")

--- a/internal/cli/wrap_windows.go
+++ b/internal/cli/wrap_windows.go
@@ -15,11 +15,7 @@ import (
 // Like macOS, Windows uses a system-wide driver (agentsh.sys) for exec
 // interception, so the agent runs directly without a wrapper binary.
 func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, sessID string, agentPath string, agentArgs []string, cfg *clientConfig) (*wrapLaunchConfig, error) {
-	env := os.Environ()
-	env = append(env,
-		fmt.Sprintf("AGENTSH_SESSION_ID=%s", sessID),
-		fmt.Sprintf("AGENTSH_SERVER=%s", cfg.serverAddr),
-	)
+	env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
 	for k, v := range wrapResp.WrapperEnv {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}

--- a/internal/integration/agentsh_wrap_linux_test.go
+++ b/internal/integration/agentsh_wrap_linux_test.go
@@ -1,0 +1,213 @@
+//go:build integration && linux
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/client"
+	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+const wrapStrongTestConfigYAML = `
+server:
+  http:
+    addr: "0.0.0.0:18080"
+auth:
+  type: "api_key"
+  api_key:
+    keys_file: "/keys.yaml"
+    header_name: "X-API-Key"
+logging:
+  level: "info"
+  format: "text"
+  output: "stdout"
+audit:
+  enabled: false
+  storage:
+    sqlite_path: "/tmp/events.db"
+sessions:
+  base_dir: "/sessions"
+sandbox:
+  fuse:
+    enabled: false
+  network:
+    enabled: false
+  unix_sockets:
+    enabled: true
+    wrapper_bin: "/usr/local/bin/agentsh-unixwrap"
+  seccomp:
+    unix_socket:
+      enabled: true
+    execve:
+      enabled: true
+policies:
+  dir: "/policies"
+  default: "agent-default"
+approvals:
+  enabled: false
+metrics:
+  enabled: false
+health:
+  path: "/health"
+`
+
+func TestWrapStrongMode_SetsInSessionMarker(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	agentshBin, unixwrapBin := buildSeccompBinaries(t)
+	temp := t.TempDir()
+
+	configPath := filepath.Join(temp, "config.yaml")
+	writeFile(t, configPath, wrapStrongTestConfigYAML)
+	keysPath := filepath.Join(temp, "keys.yaml")
+	writeFile(t, keysPath, testAPIKeysYAML)
+
+	policiesDir := filepath.Join(temp, "policies")
+	mustMkdir(t, policiesDir)
+	writeFile(t, filepath.Join(policiesDir, "agent-default.yaml"), wrapTestPolicyYAML)
+
+	workspace := filepath.Join(temp, "workspace")
+	mustMkdir(t, workspace)
+
+	ctr, endpoint, cleanup := startWrapSeccompServerContainer(t, ctx, agentshBin, unixwrapBin, configPath, keysPath, policiesDir, workspace)
+	t.Cleanup(cleanup)
+
+	cli := client.New(endpoint, "test-key")
+
+	probeSess, err := cli.CreateSession(ctx, "/workspace", "agent-default")
+	if err != nil {
+		t.Fatalf("CreateSession probe: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cli.DestroySession(context.Background(), probeSess.ID); err != nil {
+			t.Logf("DestroySession probe: %v", err)
+		}
+	})
+
+	probeCtx, probeCancel := context.WithTimeout(ctx, 10*time.Second)
+	probeResult, probeErr := cli.Exec(probeCtx, probeSess.ID, types.ExecRequest{
+		Command: "/bin/echo",
+		Args:    []string{"probe"},
+	})
+	probeCancel()
+
+	if probeErr != nil {
+		if errors.Is(probeErr, context.DeadlineExceeded) || strings.Contains(probeErr.Error(), "deadline exceeded") {
+			t.Skip("seccomp-user-notify appears unreliable in this environment (probe timeout)")
+		}
+		t.Fatalf("Exec probe: %v", probeErr)
+	}
+	if probeResult.Result.ExitCode != 0 {
+		t.Skip("seccomp-user-notify may not be active in this environment (probe exit non-zero)")
+	}
+
+	exitCode, outputReader, err := ctr.Exec(ctx, []string{
+		"/bin/sh", "-lc",
+		`timeout 20s env AGENTSH_NO_AUTO=1 AGENTSH_API_KEY=test-key /usr/local/bin/agentsh --server http://127.0.0.1:18080 wrap -- /bin/sh -c 'if [ -n "$AGENTSH_IN_SESSION" ]; then echo MARKER_SET; else echo MARKER_UNSET; fi' 2>&1`,
+	})
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "deadline exceeded") {
+			t.Skip("seccomp wrap execution appears unreliable in this environment (wrap timeout)")
+		}
+		t.Fatalf("wrap exec: %v", err)
+	}
+	logBytes, err := io.ReadAll(outputReader)
+	if err != nil {
+		t.Fatalf("read wrap exec output: %v", err)
+	}
+	logOutput := string(logBytes)
+
+	if exitCode == 124 {
+		t.Skipf("seccomp wrap execution appears unreliable in this environment (wrap timed out)\n%s", logOutput)
+	}
+	if exitCode != 0 {
+		t.Fatalf("wrap exec exit=%d output:\n%s", exitCode, logOutput)
+	}
+	if !strings.Contains(logOutput, "MARKER_SET") {
+		t.Fatalf("expected MARKER_SET in strong wrap output, got:\n%s", logOutput)
+	}
+	if strings.Contains(logOutput, "MARKER_UNSET") {
+		t.Fatalf("did not expect MARKER_UNSET in strong wrap output, got:\n%s", logOutput)
+	}
+}
+
+func startWrapSeccompServerContainer(
+	t *testing.T,
+	ctx context.Context,
+	agentshBin string,
+	unixwrapBin string,
+	configPath string,
+	keysPath string,
+	policiesDir string,
+	workspace string,
+) (testcontainers.Container, string, func()) {
+	t.Helper()
+
+	req := testcontainers.ContainerRequest{
+		Image:        "debian:bookworm-slim",
+		ExposedPorts: []string{"18080/tcp"},
+		Cmd:          []string{"/usr/local/bin/agentsh", "server", "--config", "/config.yaml"},
+		Mounts: []testcontainers.ContainerMount{
+			testcontainers.BindMount(agentshBin, "/usr/local/bin/agentsh"),
+			testcontainers.BindMount(unixwrapBin, "/usr/local/bin/agentsh-unixwrap"),
+			testcontainers.BindMount(configPath, "/config.yaml"),
+			testcontainers.BindMount(keysPath, "/keys.yaml"),
+			testcontainers.BindMount(policiesDir, "/policies"),
+			testcontainers.BindMount(workspace, "/workspace"),
+		},
+		Privileged: true,
+		CapAdd:     []string{"SYS_ADMIN"},
+		HostConfigModifier: func(hc *container.HostConfig) {
+			hc.SecurityOpt = []string{"apparmor:unconfined", "seccomp:unconfined"}
+		},
+		WaitingFor: wait.ForHTTP("/health").
+			WithPort("18080/tcp").
+			WithStartupTimeout(60 * time.Second).
+			WithStatusCodeMatcher(func(code int) bool { return code >= 200 && code < 500 }),
+	}
+
+	ctr, err := startContainerWithRetry(t, ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatalf("start seccomp server container: %v", err)
+	}
+
+	host, err := ctr.Host(ctx)
+	if err != nil {
+		t.Fatalf("container host: %v", err)
+	}
+	mappedPort, err := ctr.MappedPort(ctx, "18080/tcp")
+	if err != nil {
+		t.Fatalf("map port: %v", err)
+	}
+	endpoint := fmt.Sprintf("http://%s:%s", host, mappedPort.Port())
+
+	cleanup := func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cleanupCancel()
+		if logs, err := ctr.Logs(cleanupCtx); err == nil {
+			defer logs.Close()
+			b, _ := io.ReadAll(logs)
+			if len(b) > 0 {
+				t.Logf("container logs:\n%s", string(b))
+			}
+		}
+		_ = ctr.Terminate(cleanupCtx)
+	}
+
+	return ctr, endpoint, cleanup
+}

--- a/internal/integration/agentsh_wrap_test.go
+++ b/internal/integration/agentsh_wrap_test.go
@@ -4,12 +4,16 @@ package integration
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/agentsh/agentsh/internal/client"
+	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -69,9 +73,12 @@ resource_limits:
 const wrapStrongTestConfigYAML = `
 server:
   http:
-    addr: "127.0.0.1:18080"
+    addr: "0.0.0.0:18080"
 auth:
-  type: "none"
+  type: "api_key"
+  api_key:
+    keys_file: "/keys.yaml"
+    header_name: "X-API-Key"
 logging:
   level: "info"
   format: "text"
@@ -87,15 +94,14 @@ sandbox:
     enabled: false
   network:
     enabled: false
-  ptrace:
-    enabled: true
-    trace:
-      execve: true
   unix_sockets:
-    enabled: false
+    enabled: true
+    wrapper_bin: "/usr/local/bin/agentsh-unixwrap"
   seccomp:
+    unix_socket:
+      enabled: true
     execve:
-      enabled: false
+      enabled: true
 policies:
   dir: "/policies"
   default: "agent-default"
@@ -264,13 +270,16 @@ func TestWrapFallback_OmitsInSessionMarker(t *testing.T) {
 }
 
 func TestWrapStrongMode_SetsInSessionMarker(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 
 	agentshBin, unixwrapBin := buildSeccompBinaries(t)
 	temp := t.TempDir()
 
 	configPath := filepath.Join(temp, "config.yaml")
 	writeFile(t, configPath, wrapStrongTestConfigYAML)
+	keysPath := filepath.Join(temp, "keys.yaml")
+	writeFile(t, keysPath, testAPIKeysYAML)
 
 	policiesDir := filepath.Join(temp, "policies")
 	mustMkdir(t, policiesDir)
@@ -279,23 +288,98 @@ func TestWrapStrongMode_SetsInSessionMarker(t *testing.T) {
 	workspace := filepath.Join(temp, "workspace")
 	mustMkdir(t, workspace)
 
+	ctr, endpoint, cleanup := startWrapSeccompServerContainer(t, ctx, agentshBin, unixwrapBin, configPath, keysPath, policiesDir, workspace)
+	t.Cleanup(cleanup)
+
+	cli := client.New(endpoint, "test-key")
+
+	probeSess, err := cli.CreateSession(ctx, "/workspace", "agent-default")
+	if err != nil {
+		t.Fatalf("CreateSession probe: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cli.DestroySession(context.Background(), probeSess.ID); err != nil {
+			t.Logf("DestroySession probe: %v", err)
+		}
+	})
+
+	probeCtx, probeCancel := context.WithTimeout(ctx, 10*time.Second)
+	probeResult, probeErr := cli.Exec(probeCtx, probeSess.ID, types.ExecRequest{
+		Command: "/bin/echo",
+		Args:    []string{"probe"},
+	})
+	probeCancel()
+
+	if probeErr != nil {
+		if errors.Is(probeErr, context.DeadlineExceeded) || strings.Contains(probeErr.Error(), "deadline exceeded") {
+			t.Skip("seccomp-user-notify appears unreliable in this environment (probe timeout)")
+		}
+		t.Fatalf("Exec probe: %v", probeErr)
+	}
+	if probeResult.Result.ExitCode != 0 {
+		t.Skip("seccomp-user-notify may not be active in this environment (probe exit non-zero)")
+	}
+
+	exitCode, outputReader, err := ctr.Exec(ctx, []string{
+		"/bin/sh", "-lc",
+		`timeout 20s env AGENTSH_NO_AUTO=1 AGENTSH_API_KEY=test-key /usr/local/bin/agentsh --server http://127.0.0.1:18080 wrap -- /usr/bin/env 2>&1`,
+	})
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "deadline exceeded") {
+			t.Skip("seccomp wrap execution appears unreliable in this environment (wrap timeout)")
+		}
+		t.Fatalf("wrap exec: %v", err)
+	}
+	logBytes, err := io.ReadAll(outputReader)
+	if err != nil {
+		t.Fatalf("read wrap exec output: %v", err)
+	}
+	logOutput := string(logBytes)
+
+	if exitCode == 124 {
+		t.Skipf("seccomp wrap execution appears unreliable in this environment (wrap timed out)\n%s", logOutput)
+	}
+	if exitCode != 0 {
+		t.Fatalf("wrap exec exit=%d output:\n%s", exitCode, logOutput)
+	}
+	if !strings.Contains(logOutput, "AGENTSH_IN_SESSION=1") {
+		t.Fatalf("expected AGENTSH_IN_SESSION=1 in strong wrap output, got:\n%s", logOutput)
+	}
+}
+
+func startWrapSeccompServerContainer(
+	t *testing.T,
+	ctx context.Context,
+	agentshBin string,
+	unixwrapBin string,
+	configPath string,
+	keysPath string,
+	policiesDir string,
+	workspace string,
+) (testcontainers.Container, string, func()) {
+	t.Helper()
+
 	req := testcontainers.ContainerRequest{
-		Image: "debian:bookworm-slim",
-		Cmd:   []string{"/usr/local/bin/agentsh", "wrap", "--", "/usr/bin/env"},
+		Image:        "debian:bookworm-slim",
+		ExposedPorts: []string{"18080/tcp"},
+		Cmd:          []string{"/usr/local/bin/agentsh", "server", "--config", "/config.yaml"},
 		Mounts: []testcontainers.ContainerMount{
 			testcontainers.BindMount(agentshBin, "/usr/local/bin/agentsh"),
 			testcontainers.BindMount(unixwrapBin, "/usr/local/bin/agentsh-unixwrap"),
 			testcontainers.BindMount(configPath, "/config.yaml"),
+			testcontainers.BindMount(keysPath, "/keys.yaml"),
 			testcontainers.BindMount(policiesDir, "/policies"),
 			testcontainers.BindMount(workspace, "/workspace"),
 		},
-		Env:        map[string]string{"AGENTSH_CONFIG": "/config.yaml"},
 		Privileged: true,
+		CapAdd:     []string{"SYS_ADMIN"},
 		HostConfigModifier: func(hc *container.HostConfig) {
 			hc.SecurityOpt = []string{"apparmor:unconfined", "seccomp:unconfined"}
-			hc.CapAdd = []string{"SYS_PTRACE"}
 		},
-		WaitingFor: wait.ForExit().WithExitTimeout(30 * time.Second),
+		WaitingFor: wait.ForHTTP("/health").
+			WithPort("18080/tcp").
+			WithStartupTimeout(60 * time.Second).
+			WithStatusCodeMatcher(func(code int) bool { return code >= 200 && code < 500 }),
 	}
 
 	ctr, err := startContainerWithRetry(t, ctx, testcontainers.GenericContainerRequest{
@@ -303,23 +387,31 @@ func TestWrapStrongMode_SetsInSessionMarker(t *testing.T) {
 		Started:          true,
 	})
 	if err != nil {
-		t.Fatalf("start container: %v", err)
+		t.Fatalf("start seccomp server container: %v", err)
 	}
-	defer func() { _ = ctr.Terminate(context.Background()) }()
 
-	logs, err := ctr.Logs(ctx)
+	host, err := ctr.Host(ctx)
 	if err != nil {
-		t.Fatalf("get logs: %v", err)
+		t.Fatalf("container host: %v", err)
 	}
-	defer logs.Close()
-
-	logBytes, err := io.ReadAll(logs)
+	mappedPort, err := ctr.MappedPort(ctx, "18080/tcp")
 	if err != nil {
-		t.Fatalf("read logs: %v", err)
+		t.Fatalf("map port: %v", err)
 	}
-	logOutput := string(logBytes)
+	endpoint := fmt.Sprintf("http://%s:%s", host, mappedPort.Port())
 
-	if !strings.Contains(logOutput, "AGENTSH_IN_SESSION=1") {
-		t.Fatalf("expected AGENTSH_IN_SESSION=1 in strong wrap output, got:\n%s", logOutput)
+	cleanup := func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cleanupCancel()
+		if logs, err := ctr.Logs(cleanupCtx); err == nil {
+			defer logs.Close()
+			b, _ := io.ReadAll(logs)
+			if len(b) > 0 {
+				t.Logf("container logs:\n%s", string(b))
+			}
+		}
+		_ = ctr.Terminate(cleanupCtx)
 	}
+
+	return ctr, endpoint, cleanup
 }

--- a/internal/integration/agentsh_wrap_test.go
+++ b/internal/integration/agentsh_wrap_test.go
@@ -4,16 +4,12 @@ package integration
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/agentsh/agentsh/internal/client"
-	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
@@ -68,49 +64,6 @@ resource_limits:
   command_timeout: 30s
   session_timeout: 1h
   idle_timeout: 30m
-`
-
-const wrapStrongTestConfigYAML = `
-server:
-  http:
-    addr: "0.0.0.0:18080"
-auth:
-  type: "api_key"
-  api_key:
-    keys_file: "/keys.yaml"
-    header_name: "X-API-Key"
-logging:
-  level: "info"
-  format: "text"
-  output: "stdout"
-audit:
-  enabled: false
-  storage:
-    sqlite_path: "/tmp/events.db"
-sessions:
-  base_dir: "/sessions"
-sandbox:
-  fuse:
-    enabled: false
-  network:
-    enabled: false
-  unix_sockets:
-    enabled: true
-    wrapper_bin: "/usr/local/bin/agentsh-unixwrap"
-  seccomp:
-    unix_socket:
-      enabled: true
-    execve:
-      enabled: true
-policies:
-  dir: "/policies"
-  default: "agent-default"
-approvals:
-  enabled: false
-metrics:
-  enabled: false
-health:
-  path: "/health"
 `
 
 func TestWrapAutoStart(t *testing.T) {
@@ -228,7 +181,8 @@ func TestWrapFallback_OmitsInSessionMarker(t *testing.T) {
 	req := testcontainers.ContainerRequest{
 		Image: "debian:bookworm-slim",
 		Cmd: []string{
-			"/usr/local/bin/agentsh", "wrap", "--", "/usr/bin/env",
+			"/usr/local/bin/agentsh", "wrap", "--",
+			"/bin/sh", "-c", `if [ -n "$AGENTSH_IN_SESSION" ]; then echo MARKER_SET; else echo MARKER_UNSET; fi`,
 		},
 		Mounts: []testcontainers.ContainerMount{
 			testcontainers.BindMount(bin, "/usr/local/bin/agentsh"),
@@ -243,7 +197,7 @@ func TestWrapFallback_OmitsInSessionMarker(t *testing.T) {
 		WaitingFor: wait.ForExit().WithExitTimeout(30 * time.Second),
 	}
 
-	ctr, err := startContainerWithRetry(t, ctx, testcontainers.GenericContainerRequest{
+	ctr, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})
@@ -264,154 +218,17 @@ func TestWrapFallback_OmitsInSessionMarker(t *testing.T) {
 	}
 	logOutput := string(logBytes)
 
-	if strings.Contains(logOutput, "AGENTSH_IN_SESSION=1") {
-		t.Fatalf("did not expect AGENTSH_IN_SESSION=1 in fallback wrap output, got:\n%s", logOutput)
-	}
-}
-
-func TestWrapStrongMode_SetsInSessionMarker(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
-
-	agentshBin, unixwrapBin := buildSeccompBinaries(t)
-	temp := t.TempDir()
-
-	configPath := filepath.Join(temp, "config.yaml")
-	writeFile(t, configPath, wrapStrongTestConfigYAML)
-	keysPath := filepath.Join(temp, "keys.yaml")
-	writeFile(t, keysPath, testAPIKeysYAML)
-
-	policiesDir := filepath.Join(temp, "policies")
-	mustMkdir(t, policiesDir)
-	writeFile(t, filepath.Join(policiesDir, "agent-default.yaml"), wrapTestPolicyYAML)
-
-	workspace := filepath.Join(temp, "workspace")
-	mustMkdir(t, workspace)
-
-	ctr, endpoint, cleanup := startWrapSeccompServerContainer(t, ctx, agentshBin, unixwrapBin, configPath, keysPath, policiesDir, workspace)
-	t.Cleanup(cleanup)
-
-	cli := client.New(endpoint, "test-key")
-
-	probeSess, err := cli.CreateSession(ctx, "/workspace", "agent-default")
+	state, err := ctr.State(ctx)
 	if err != nil {
-		t.Fatalf("CreateSession probe: %v", err)
+		t.Fatalf("get container state: %v", err)
 	}
-	t.Cleanup(func() {
-		if err := cli.DestroySession(context.Background(), probeSess.ID); err != nil {
-			t.Logf("DestroySession probe: %v", err)
-		}
-	})
-
-	probeCtx, probeCancel := context.WithTimeout(ctx, 10*time.Second)
-	probeResult, probeErr := cli.Exec(probeCtx, probeSess.ID, types.ExecRequest{
-		Command: "/bin/echo",
-		Args:    []string{"probe"},
-	})
-	probeCancel()
-
-	if probeErr != nil {
-		if errors.Is(probeErr, context.DeadlineExceeded) || strings.Contains(probeErr.Error(), "deadline exceeded") {
-			t.Skip("seccomp-user-notify appears unreliable in this environment (probe timeout)")
-		}
-		t.Fatalf("Exec probe: %v", probeErr)
+	if state.ExitCode != 0 {
+		t.Fatalf("container exited with code %d, expected 0; logs:\n%s", state.ExitCode, logOutput)
 	}
-	if probeResult.Result.ExitCode != 0 {
-		t.Skip("seccomp-user-notify may not be active in this environment (probe exit non-zero)")
+	if !strings.Contains(logOutput, "MARKER_UNSET") {
+		t.Fatalf("expected MARKER_UNSET in fallback wrap output, got:\n%s", logOutput)
 	}
-
-	exitCode, outputReader, err := ctr.Exec(ctx, []string{
-		"/bin/sh", "-lc",
-		`timeout 20s env AGENTSH_NO_AUTO=1 AGENTSH_API_KEY=test-key /usr/local/bin/agentsh --server http://127.0.0.1:18080 wrap -- /usr/bin/env 2>&1`,
-	})
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) || strings.Contains(err.Error(), "deadline exceeded") {
-			t.Skip("seccomp wrap execution appears unreliable in this environment (wrap timeout)")
-		}
-		t.Fatalf("wrap exec: %v", err)
+	if strings.Contains(logOutput, "MARKER_SET") {
+		t.Fatalf("did not expect MARKER_SET in fallback wrap output, got:\n%s", logOutput)
 	}
-	logBytes, err := io.ReadAll(outputReader)
-	if err != nil {
-		t.Fatalf("read wrap exec output: %v", err)
-	}
-	logOutput := string(logBytes)
-
-	if exitCode == 124 {
-		t.Skipf("seccomp wrap execution appears unreliable in this environment (wrap timed out)\n%s", logOutput)
-	}
-	if exitCode != 0 {
-		t.Fatalf("wrap exec exit=%d output:\n%s", exitCode, logOutput)
-	}
-	if !strings.Contains(logOutput, "AGENTSH_IN_SESSION=1") {
-		t.Fatalf("expected AGENTSH_IN_SESSION=1 in strong wrap output, got:\n%s", logOutput)
-	}
-}
-
-func startWrapSeccompServerContainer(
-	t *testing.T,
-	ctx context.Context,
-	agentshBin string,
-	unixwrapBin string,
-	configPath string,
-	keysPath string,
-	policiesDir string,
-	workspace string,
-) (testcontainers.Container, string, func()) {
-	t.Helper()
-
-	req := testcontainers.ContainerRequest{
-		Image:        "debian:bookworm-slim",
-		ExposedPorts: []string{"18080/tcp"},
-		Cmd:          []string{"/usr/local/bin/agentsh", "server", "--config", "/config.yaml"},
-		Mounts: []testcontainers.ContainerMount{
-			testcontainers.BindMount(agentshBin, "/usr/local/bin/agentsh"),
-			testcontainers.BindMount(unixwrapBin, "/usr/local/bin/agentsh-unixwrap"),
-			testcontainers.BindMount(configPath, "/config.yaml"),
-			testcontainers.BindMount(keysPath, "/keys.yaml"),
-			testcontainers.BindMount(policiesDir, "/policies"),
-			testcontainers.BindMount(workspace, "/workspace"),
-		},
-		Privileged: true,
-		CapAdd:     []string{"SYS_ADMIN"},
-		HostConfigModifier: func(hc *container.HostConfig) {
-			hc.SecurityOpt = []string{"apparmor:unconfined", "seccomp:unconfined"}
-		},
-		WaitingFor: wait.ForHTTP("/health").
-			WithPort("18080/tcp").
-			WithStartupTimeout(60 * time.Second).
-			WithStatusCodeMatcher(func(code int) bool { return code >= 200 && code < 500 }),
-	}
-
-	ctr, err := startContainerWithRetry(t, ctx, testcontainers.GenericContainerRequest{
-		ContainerRequest: req,
-		Started:          true,
-	})
-	if err != nil {
-		t.Fatalf("start seccomp server container: %v", err)
-	}
-
-	host, err := ctr.Host(ctx)
-	if err != nil {
-		t.Fatalf("container host: %v", err)
-	}
-	mappedPort, err := ctr.MappedPort(ctx, "18080/tcp")
-	if err != nil {
-		t.Fatalf("map port: %v", err)
-	}
-	endpoint := fmt.Sprintf("http://%s:%s", host, mappedPort.Port())
-
-	cleanup := func() {
-		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 60*time.Second)
-		defer cleanupCancel()
-		if logs, err := ctr.Logs(cleanupCtx); err == nil {
-			defer logs.Close()
-			b, _ := io.ReadAll(logs)
-			if len(b) > 0 {
-				t.Logf("container logs:\n%s", string(b))
-			}
-		}
-		_ = ctr.Terminate(cleanupCtx)
-	}
-
-	return ctr, endpoint, cleanup
 }

--- a/internal/integration/agentsh_wrap_test.go
+++ b/internal/integration/agentsh_wrap_test.go
@@ -190,7 +190,10 @@ func TestWrapFallback_OmitsInSessionMarker(t *testing.T) {
 			testcontainers.BindMount(policiesDir, "/policies"),
 			testcontainers.BindMount(workspace, "/workspace"),
 		},
-		Env: map[string]string{"AGENTSH_CONFIG": "/config.yaml"},
+		Env: map[string]string{
+			"AGENTSH_CONFIG":     "/config.yaml",
+			"AGENTSH_IN_SESSION": "1",
+		},
 		HostConfigModifier: func(hc *container.HostConfig) {
 			hc.SecurityOpt = []string{"apparmor:unconfined", "seccomp:unconfined"}
 		},

--- a/internal/integration/agentsh_wrap_test.go
+++ b/internal/integration/agentsh_wrap_test.go
@@ -66,6 +66,47 @@ resource_limits:
   idle_timeout: 30m
 `
 
+const wrapStrongTestConfigYAML = `
+server:
+  http:
+    addr: "127.0.0.1:18080"
+auth:
+  type: "none"
+logging:
+  level: "info"
+  format: "text"
+  output: "stdout"
+audit:
+  enabled: false
+  storage:
+    sqlite_path: "/tmp/events.db"
+sessions:
+  base_dir: "/sessions"
+sandbox:
+  fuse:
+    enabled: false
+  network:
+    enabled: false
+  ptrace:
+    enabled: true
+    trace:
+      execve: true
+  unix_sockets:
+    enabled: false
+  seccomp:
+    execve:
+      enabled: false
+policies:
+  dir: "/policies"
+  default: "agent-default"
+approvals:
+  enabled: false
+metrics:
+  enabled: false
+health:
+  path: "/health"
+`
+
 func TestWrapAutoStart(t *testing.T) {
 	ctx := context.Background()
 
@@ -159,5 +200,126 @@ func TestWrapAutoStart(t *testing.T) {
 	// Verify the child command produced output
 	if !strings.Contains(logOutput, "hello") {
 		t.Error("expected 'hello' in output (echo command should have run)")
+	}
+}
+
+func TestWrapFallback_OmitsInSessionMarker(t *testing.T) {
+	ctx := context.Background()
+
+	bin := buildAgentshBinary(t)
+	temp := t.TempDir()
+
+	configPath := filepath.Join(temp, "config.yaml")
+	writeFile(t, configPath, wrapTestConfigYAML)
+
+	policiesDir := filepath.Join(temp, "policies")
+	mustMkdir(t, policiesDir)
+	writeFile(t, filepath.Join(policiesDir, "agent-default.yaml"), wrapTestPolicyYAML)
+
+	workspace := filepath.Join(temp, "workspace")
+	mustMkdir(t, workspace)
+
+	req := testcontainers.ContainerRequest{
+		Image: "debian:bookworm-slim",
+		Cmd: []string{
+			"/usr/local/bin/agentsh", "wrap", "--", "/usr/bin/env",
+		},
+		Mounts: []testcontainers.ContainerMount{
+			testcontainers.BindMount(bin, "/usr/local/bin/agentsh"),
+			testcontainers.BindMount(configPath, "/config.yaml"),
+			testcontainers.BindMount(policiesDir, "/policies"),
+			testcontainers.BindMount(workspace, "/workspace"),
+		},
+		Env: map[string]string{"AGENTSH_CONFIG": "/config.yaml"},
+		HostConfigModifier: func(hc *container.HostConfig) {
+			hc.SecurityOpt = []string{"apparmor:unconfined", "seccomp:unconfined"}
+		},
+		WaitingFor: wait.ForExit().WithExitTimeout(30 * time.Second),
+	}
+
+	ctr, err := startContainerWithRetry(t, ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatalf("start container: %v", err)
+	}
+	defer func() { _ = ctr.Terminate(context.Background()) }()
+
+	logs, err := ctr.Logs(ctx)
+	if err != nil {
+		t.Fatalf("get logs: %v", err)
+	}
+	defer logs.Close()
+
+	logBytes, err := io.ReadAll(logs)
+	if err != nil {
+		t.Fatalf("read logs: %v", err)
+	}
+	logOutput := string(logBytes)
+
+	if strings.Contains(logOutput, "AGENTSH_IN_SESSION=1") {
+		t.Fatalf("did not expect AGENTSH_IN_SESSION=1 in fallback wrap output, got:\n%s", logOutput)
+	}
+}
+
+func TestWrapStrongMode_SetsInSessionMarker(t *testing.T) {
+	ctx := context.Background()
+
+	agentshBin, unixwrapBin := buildSeccompBinaries(t)
+	temp := t.TempDir()
+
+	configPath := filepath.Join(temp, "config.yaml")
+	writeFile(t, configPath, wrapStrongTestConfigYAML)
+
+	policiesDir := filepath.Join(temp, "policies")
+	mustMkdir(t, policiesDir)
+	writeFile(t, filepath.Join(policiesDir, "agent-default.yaml"), wrapTestPolicyYAML)
+
+	workspace := filepath.Join(temp, "workspace")
+	mustMkdir(t, workspace)
+
+	req := testcontainers.ContainerRequest{
+		Image: "debian:bookworm-slim",
+		Cmd:   []string{"/usr/local/bin/agentsh", "wrap", "--", "/usr/bin/env"},
+		Mounts: []testcontainers.ContainerMount{
+			testcontainers.BindMount(agentshBin, "/usr/local/bin/agentsh"),
+			testcontainers.BindMount(unixwrapBin, "/usr/local/bin/agentsh-unixwrap"),
+			testcontainers.BindMount(configPath, "/config.yaml"),
+			testcontainers.BindMount(policiesDir, "/policies"),
+			testcontainers.BindMount(workspace, "/workspace"),
+		},
+		Env:        map[string]string{"AGENTSH_CONFIG": "/config.yaml"},
+		Privileged: true,
+		HostConfigModifier: func(hc *container.HostConfig) {
+			hc.SecurityOpt = []string{"apparmor:unconfined", "seccomp:unconfined"}
+			hc.CapAdd = []string{"SYS_PTRACE"}
+		},
+		WaitingFor: wait.ForExit().WithExitTimeout(30 * time.Second),
+	}
+
+	ctr, err := startContainerWithRetry(t, ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		t.Fatalf("start container: %v", err)
+	}
+	defer func() { _ = ctr.Terminate(context.Background()) }()
+
+	logs, err := ctr.Logs(ctx)
+	if err != nil {
+		t.Fatalf("get logs: %v", err)
+	}
+	defer logs.Close()
+
+	logBytes, err := io.ReadAll(logs)
+	if err != nil {
+		t.Fatalf("read logs: %v", err)
+	}
+	logOutput := string(logBytes)
+
+	if !strings.Contains(logOutput, "AGENTSH_IN_SESSION=1") {
+		t.Fatalf("expected AGENTSH_IN_SESSION=1 in strong wrap output, got:\n%s", logOutput)
 	}
 }

--- a/pkg/types/sessions.go
+++ b/pkg/types/sessions.go
@@ -132,7 +132,7 @@ type WrapInitRequest struct {
 // WrapInitResponse returns the seccomp wrapper configuration to the CLI.
 type WrapInitResponse struct {
 	PtraceMode            bool              `json:"ptrace_mode,omitempty"`
-	SafeToBypassShellShim bool              `json:"safe_to_bypass_shell_shim,omitempty"`
+	SafeToBypassShellShim bool              `json:"safe_to_bypass_shell_shim"`
 	WrapperBinary         string            `json:"wrapper_binary"`
 	StubBinary            string            `json:"stub_binary,omitempty"`
 	SeccompConfig         string            `json:"seccomp_config"`          // JSON-encoded seccomp config

--- a/pkg/types/sessions.go
+++ b/pkg/types/sessions.go
@@ -110,7 +110,7 @@ type CreateSessionRequest struct {
 	Workspace         string `json:"workspace,omitempty"`
 	Policy            string `json:"policy,omitempty"`
 	Profile           string `json:"profile,omitempty"`
-	Home              string `json:"home,omitempty"`                 // User's home directory for ${HOME} policy expansion
+	Home              string `json:"home,omitempty"`                // User's home directory for ${HOME} policy expansion
 	DetectProjectRoot *bool  `json:"detect_project_root,omitempty"` // Override server default
 	ProjectRoot       string `json:"project_root,omitempty"`        // Explicit override
 	RealPaths         *bool  `json:"real_paths,omitempty"`          // Use actual host paths instead of /workspace
@@ -131,11 +131,12 @@ type WrapInitRequest struct {
 
 // WrapInitResponse returns the seccomp wrapper configuration to the CLI.
 type WrapInitResponse struct {
-	PtraceMode    bool              `json:"ptrace_mode,omitempty"`
-	WrapperBinary string            `json:"wrapper_binary"`
-	StubBinary    string            `json:"stub_binary,omitempty"`
-	SeccompConfig string            `json:"seccomp_config"`          // JSON-encoded seccomp config
-	NotifySocket  string            `json:"notify_socket"`           // Unix socket path for forwarding notify fd
-	SignalSocket  string            `json:"signal_socket,omitempty"` // Unix socket path for forwarding signal filter fd
-	WrapperEnv    map[string]string `json:"wrapper_env"`             // Extra env vars for the wrapper
+	PtraceMode            bool              `json:"ptrace_mode,omitempty"`
+	SafeToBypassShellShim bool              `json:"safe_to_bypass_shell_shim,omitempty"`
+	WrapperBinary         string            `json:"wrapper_binary"`
+	StubBinary            string            `json:"stub_binary,omitempty"`
+	SeccompConfig         string            `json:"seccomp_config"`          // JSON-encoded seccomp config
+	NotifySocket          string            `json:"notify_socket"`           // Unix socket path for forwarding notify fd
+	SignalSocket          string            `json:"signal_socket,omitempty"` // Unix socket path for forwarding signal filter fd
+	WrapperEnv            map[string]string `json:"wrapper_env"`             // Extra env vars for the wrapper
 }


### PR DESCRIPTION
## Summary
- add an explicit `SafeToBypassShellShim` wrap-init capability bit and return it from strong wrap modes
- gate `AGENTSH_IN_SESSION` injection in `agentsh wrap` on that capability, including inherited-env scrubbing and cross-platform CLI coverage
- add fallback and strong-mode integration coverage plus cookbook docs for conditional shell-shim bypass

## Why
`agentsh wrap` was not distinguishing between strong interception modes and fallback/no-`execve` modes when deciding whether nested shells should bypass the shell shim. That left `wrap` inconsistent with the existing shim contract and allowed inherited `AGENTSH_IN_SESSION` to leak into unsafe paths.

## User impact
- strong wrap modes now mark the wrap-launched agent process as already in-session
- fallback and no-`execve` wrap modes keep nested shells on the shim path
- inherited stale `AGENTSH_*` env is normalized before launching wrapped children

## Test Plan
- `go test ./internal/api -run 'TestWrapInit_SafeToBypassShellShim_|TestWrapInit_SeccompConfigContent'`
- `go test ./internal/cli -run 'TestBuildWrapEnv_|TestWrapLaunchConfig_Env|TestSetupWrapInterception_CallsWrapInit'`
- `go test -tags integration ./internal/integration -run 'TestWrapAutoStart|TestWrapFallback_OmitsInSessionMarker|TestWrapStrongMode_SetsInSessionMarker'`
- `GOOS=windows go build ./...`