### PR TITLE
[codex] Fix wrap seccomp config parity for file monitoring

### DIFF
--- a/docs/superpowers/plans/2026-04-20-wrap-seccomp-config-parity.md
+++ b/docs/superpowers/plans/2026-04-20-wrap-seccomp-config-parity.md
@@ -1,0 +1,395 @@
+# Wrap Seccomp Config Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `agentsh wrap` derive the same seccomp wrapper config as the `exec` path for file-monitor fields, restoring fine-grained `file_rules` enforcement and eliminating config-construction drift.
+
+**Architecture:** Add a shared `buildSeccompWrapperConfig` helper in `internal/api` that owns config-derived fields (`FileMonitorEnabled`, `InterceptMetadata`, `BlockIOUring`, block-list transport, and Landlock wiring). Keep runtime-only decisions (`UnixSocketEnabled`, `ExecveEnabled`, `SignalFilterEnabled`) in the two callers and pass them into the helper via a small params struct. Prove the fix with JSON-based regression tests on both the wrap-init and exec surfaces.
+
+**Tech Stack:** Go 1.22+, stdlib `encoding/json`, `internal/api`, `internal/config`, Linux seccomp wrapper plumbing, existing `go test` package tests, Windows cross-compile via `GOOS=windows go build ./...`.
+
+**Spec:** `docs/superpowers/specs/2026-04-20-wrap-seccomp-config-parity-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `internal/api/seccomp_wrapper_config.go` — shared `seccompWrapperConfig` home, runtime params struct, and `buildSeccompWrapperConfig` helper.
+
+**Modify:**
+- `internal/api/core.go` — remove inline `seccompWrapperConfig` definition and duplicated assembly; call the shared helper.
+- `internal/api/wrap.go` — replace duplicated config assembly with the shared helper after runtime-only signal/unix decisions are known.
+- `internal/api/wrap_test.go` — convert wrap config smoke test into JSON assertions for file-monitor fields.
+- `internal/api/seccomp_wrapper_test.go` — add exec-path JSON regression coverage for the same file-monitor fields.
+
+---
+
+### Task 1: Add regression tests for both JSON surfaces
+
+**Files:**
+- Modify: `internal/api/wrap_test.go`
+- Modify: `internal/api/seccomp_wrapper_test.go`
+
+- [ ] **Step 1: Replace the wrap smoke test with a JSON regression test**
+
+In `internal/api/wrap_test.go`, replace `TestWrapInit_SeccompConfigContent` with:
+
+```go
+func TestWrapInit_SeccompConfigContent(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.Seccomp.Execve.Enabled = true
+	cfg.Sandbox.Seccomp.UnixSocket.Enabled = true
+	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &enabled
+	cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE = &enabled
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, _, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(resp.SeccompConfig), &parsed); err != nil {
+		t.Fatalf("unmarshal SeccompConfig: %v\n%s", err, resp.SeccompConfig)
+	}
+
+	if got, _ := parsed["unix_socket_enabled"].(bool); !got {
+		t.Fatalf("unix_socket_enabled = %v, want true (JSON: %s)", got, resp.SeccompConfig)
+	}
+	if got, _ := parsed["execve_enabled"].(bool); !got {
+		t.Fatalf("execve_enabled = %v, want true (JSON: %s)", got, resp.SeccompConfig)
+	}
+	if got, _ := parsed["file_monitor_enabled"].(bool); !got {
+		t.Fatalf("file_monitor_enabled = %v, want true (JSON: %s)", got, resp.SeccompConfig)
+	}
+	if got, _ := parsed["intercept_metadata"].(bool); !got {
+		t.Fatalf("intercept_metadata = %v, want true (JSON: %s)", got, resp.SeccompConfig)
+	}
+	if got, _ := parsed["block_io_uring"].(bool); !got {
+		t.Fatalf("block_io_uring = %v, want true (JSON: %s)", got, resp.SeccompConfig)
+	}
+}
+```
+
+- [ ] **Step 2: Add the exec-path regression test**
+
+In `internal/api/seccomp_wrapper_test.go`, add `encoding/json` to the import block, then append:
+
+```go
+func TestSetupSeccompWrapper_FileMonitorDefaults(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("seccomp wrapper only available on Linux")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &enabled
+	cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE = &enabled
+
+	app := newTestAppForSeccomp(t, cfg)
+
+	req := types.ExecRequest{
+		Command: "/bin/echo",
+		Args:    []string{"hello"},
+	}
+
+	result := app.setupSeccompWrapper(req, "test-session", nil)
+	if result == nil || result.extraCfg == nil {
+		t.Fatal("expected non-nil wrapper setup result with extraCfg")
+	}
+	defer func() {
+		if result.extraCfg.notifyParentSock != nil {
+			result.extraCfg.notifyParentSock.Close()
+		}
+		for _, f := range result.extraCfg.extraFiles {
+			if f != nil {
+				f.Close()
+			}
+		}
+	}()
+
+	seccompJSON, ok := result.wrappedReq.Env["AGENTSH_SECCOMP_CONFIG"]
+	if !ok {
+		t.Fatal("AGENTSH_SECCOMP_CONFIG env var not set")
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(seccompJSON), &parsed); err != nil {
+		t.Fatalf("unmarshal seccomp config: %v\n%s", err, seccompJSON)
+	}
+
+	if got, _ := parsed["file_monitor_enabled"].(bool); !got {
+		t.Fatalf("file_monitor_enabled = %v, want true (JSON: %s)", got, seccompJSON)
+	}
+	if got, _ := parsed["intercept_metadata"].(bool); !got {
+		t.Fatalf("intercept_metadata = %v, want true (JSON: %s)", got, seccompJSON)
+	}
+	if got, _ := parsed["block_io_uring"].(bool); !got {
+		t.Fatalf("block_io_uring = %v, want true (JSON: %s)", got, seccompJSON)
+	}
+}
+```
+
+- [ ] **Step 3: Run the two regression tests and confirm the current bug**
+
+Run:
+
+```bash
+go test ./internal/api -run 'TestWrapInit_SeccompConfigContent|TestSetupSeccompWrapper_FileMonitorDefaults' -count=1
+```
+
+Expected:
+
+- overall command exits non-zero
+- `TestWrapInit_SeccompConfigContent` fails because `file_monitor_enabled` is absent/false in `resp.SeccompConfig`
+- `TestSetupSeccompWrapper_FileMonitorDefaults` passes, proving the drift is only on the wrap path
+
+---
+
+### Task 2: Extract the shared config builder and wire both callers to it
+
+**Files:**
+- Create: `internal/api/seccomp_wrapper_config.go`
+- Modify: `internal/api/core.go`
+- Modify: `internal/api/wrap.go`
+
+- [ ] **Step 1: Create the shared helper file**
+
+Create `internal/api/seccomp_wrapper_config.go` with:
+
+```go
+package api
+
+import (
+	"os"
+
+	"github.com/agentsh/agentsh/internal/capabilities"
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/session"
+)
+
+// seccompWrapperConfig is passed to the agentsh-unixwrap wrapper via
+// AGENTSH_SECCOMP_CONFIG environment variable to configure seccomp-bpf filtering.
+type seccompWrapperConfig struct {
+	UnixSocketEnabled   bool     `json:"unix_socket_enabled"`
+	SignalFilterEnabled bool     `json:"signal_filter_enabled"`
+	ExecveEnabled       bool     `json:"execve_enabled"`
+	FileMonitorEnabled  bool     `json:"file_monitor_enabled"`
+	BlockedSyscalls     []string `json:"blocked_syscalls"`
+	OnBlock             string   `json:"on_block,omitempty"`
+
+	// File monitor sub-options
+	InterceptMetadata bool `json:"intercept_metadata,omitempty"`
+	BlockIOUring      bool `json:"block_io_uring,omitempty"`
+
+	// Landlock filesystem restrictions
+	LandlockEnabled bool     `json:"landlock_enabled,omitempty"`
+	LandlockABI     int      `json:"landlock_abi,omitempty"`
+	Workspace       string   `json:"workspace,omitempty"`
+	AllowExecute    []string `json:"allow_execute,omitempty"`
+	AllowRead       []string `json:"allow_read,omitempty"`
+	AllowWrite      []string `json:"allow_write,omitempty"`
+	DenyPaths       []string `json:"deny_paths,omitempty"`
+	AllowNetwork    bool     `json:"allow_network,omitempty"`
+	AllowBind       bool     `json:"allow_bind,omitempty"`
+
+	// Server PID for PR_SET_PTRACER (Yama ptrace_scope=1 workaround)
+	ServerPID int `json:"server_pid,omitempty"`
+}
+
+type seccompWrapperParams struct {
+	UnixSocketEnabled   bool
+	SignalFilterEnabled bool
+	ExecveEnabled       bool
+}
+
+func (a *App) buildSeccompWrapperConfig(s *session.Session, p seccompWrapperParams) seccompWrapperConfig {
+	seccompCfg := seccompWrapperConfig{
+		UnixSocketEnabled:   p.UnixSocketEnabled,
+		SignalFilterEnabled: p.SignalFilterEnabled,
+		ExecveEnabled:       p.ExecveEnabled,
+		FileMonitorEnabled:  config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.Enabled, false),
+		BlockedSyscalls:     a.cfg.Sandbox.Seccomp.Syscalls.Block,
+		OnBlock:             a.cfg.Sandbox.Seccomp.Syscalls.OnBlock,
+		ServerPID:           os.Getpid(),
+	}
+
+	fmDefault := config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE, false)
+	seccompCfg.InterceptMetadata = config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata, fmDefault)
+	seccompCfg.BlockIOUring = config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.BlockIOUring, fmDefault)
+
+	if a.cfg.Landlock.Enabled {
+		llResult := capabilities.DetectLandlock()
+		if llResult.Available {
+			workspace := s.WorkspaceMountPath()
+			seccompCfg.LandlockEnabled = true
+			seccompCfg.LandlockABI = llResult.ABI
+			seccompCfg.Workspace = workspace
+
+			seccompCfg.AllowExecute, seccompCfg.AllowRead, seccompCfg.AllowWrite = a.deriveLandlockAllowPaths(s)
+			seccompCfg.AllowExecute = append(seccompCfg.AllowExecute, a.cfg.Landlock.AllowExecute...)
+			seccompCfg.AllowRead = append(seccompCfg.AllowRead, a.cfg.Landlock.AllowRead...)
+			seccompCfg.AllowWrite = append(seccompCfg.AllowWrite, a.cfg.Landlock.AllowWrite...)
+			seccompCfg.DenyPaths = append(seccompCfg.DenyPaths, a.cfg.Landlock.DenyPaths...)
+
+			if a.cfg.Landlock.Network.AllowConnectTCP != nil {
+				seccompCfg.AllowNetwork = *a.cfg.Landlock.Network.AllowConnectTCP
+			}
+			if a.cfg.Landlock.Network.AllowBindTCP != nil {
+				seccompCfg.AllowBind = *a.cfg.Landlock.Network.AllowBindTCP
+			}
+		}
+	}
+
+	return seccompCfg
+}
+```
+
+- [ ] **Step 2: Replace the exec-path inline construction with the helper**
+
+In `internal/api/core.go`, delete the old `seccompWrapperConfig` type definition and replace the inline construction block with:
+
+```go
+	seccompCfg := a.buildSeccompWrapperConfig(s, seccompWrapperParams{
+		UnixSocketEnabled:   a.cfg.Sandbox.Seccomp.UnixSocket.Enabled,
+		SignalFilterEnabled: signalFilterActive,
+		ExecveEnabled:       execveEnabled,
+	})
+```
+
+Keep the rest of `setupSeccompWrapper` unchanged, including `sessionPolicy`,
+`hasNotifyFeatures`, `extraEnv`, and `extraCfg`.
+
+- [ ] **Step 3: Replace the wrap-path inline construction with the helper**
+
+In `internal/api/wrap.go`, delete the old early `seccompCfg := seccompWrapperConfig{...}` block and the later `seccompCfg.SignalFilterEnabled = signalFilterEnabled` assignment. After the signal-socket setup and just before `json.Marshal`, insert:
+
+```go
+	unixSocketEnabled := a.cfg.Sandbox.Seccomp.UnixSocket.Enabled
+	if a.cfg.Sandbox.UnixSockets.Enabled != nil && *a.cfg.Sandbox.UnixSockets.Enabled {
+		unixSocketEnabled = true
+	}
+
+	seccompCfg := a.buildSeccompWrapperConfig(s, seccompWrapperParams{
+		UnixSocketEnabled:   unixSocketEnabled,
+		SignalFilterEnabled: signalFilterEnabled,
+		ExecveEnabled:       execveEnabled,
+	})
+```
+
+Do not change the surrounding notify/socket flow. The only behavior change in this task should be that `wrap-init` now gets the same config-derived file-monitor fields as the exec path.
+
+- [ ] **Step 4: Run the focused regression tests plus existing Landlock coverage**
+
+Run:
+
+```bash
+go test ./internal/api -run 'TestWrapInit_SeccompConfigContent|TestSetupSeccompWrapper_FileMonitorDefaults|TestSetupSeccompWrapper_LandlockNetwork_HonorsConfig|TestWrapInit_LandlockNetwork_HonorsConfig|TestWrapInit_LandlockNetwork_BackCompatDefaults' -count=1
+```
+
+Expected:
+
+- all listed tests PASS
+- the two new file-monitor assertions are green
+- the pre-existing Landlock JSON tests stay green, proving the refactor did not break network/allow-path propagation
+
+- [ ] **Step 5: Commit the shared-builder refactor**
+
+Run:
+
+```bash
+git add internal/api/seccomp_wrapper_config.go internal/api/core.go internal/api/wrap.go internal/api/wrap_test.go internal/api/seccomp_wrapper_test.go
+git commit -m "refactor: share seccomp wrapper config builder"
+```
+
+Expected:
+
+- commit succeeds with the helper extraction and both regression tests included
+
+---
+
+### Task 3: Run broad verification for Linux tests and Windows compilation
+
+**Files:**
+- Verify: `internal/api/*`
+- Verify: repository build graph
+
+- [ ] **Step 1: Run the full `internal/api` package tests**
+
+Run:
+
+```bash
+go test ./internal/api -count=1
+```
+
+Expected:
+
+- PASS
+- Linux-only tests may skip when host capabilities are unavailable; skips are acceptable
+
+- [ ] **Step 2: Run the repository-wide Windows compile check**
+
+Run:
+
+```bash
+GOOS=windows go build ./...
+```
+
+Expected:
+
+- command exits 0
+- no Windows compile regressions from the new shared helper
+
+- [ ] **Step 3: Run the full repository test suite**
+
+Run:
+
+```bash
+go test ./... -count=1
+```
+
+Expected:
+
+- PASS
+- platform/capability-based skips are acceptable where already expected by the suite
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+- Shared builder for config-derived fields: covered in Task 2, Steps 1-3.
+- Preserve runtime-only toggles in the callers: covered in Task 2, Steps 2-3.
+- Wrap JSON regression for file-monitor fields: covered in Task 1, Step 1.
+- Exec JSON regression for file-monitor fields: covered in Task 1, Step 2.
+- Broader verification, including Windows compile: covered in Task 3.
+
+### Placeholder scan
+
+- No `TBD`, `TODO`, or deferred implementation markers remain.
+- Every code-changing step includes concrete code blocks.
+- Every verification step includes an exact command and expected outcome.
+
+### Type consistency
+
+- `seccompWrapperConfig` remains the transport type used by both callers.
+- `seccompWrapperParams` only carries runtime booleans, matching the design spec.
+- `buildSeccompWrapperConfig` returns the same config object shape currently marshaled into `AGENTSH_SECCOMP_CONFIG`.

--- a/docs/superpowers/specs/2026-04-20-wrap-seccomp-config-parity-design.md
+++ b/docs/superpowers/specs/2026-04-20-wrap-seccomp-config-parity-design.md
@@ -1,0 +1,285 @@
+# Wrap Seccomp Config Parity — Design Spec
+
+**Date:** 2026-04-20
+**Status:** Approved
+**Author:** design session between Eran Sandler and Codex
+
+## Problem
+
+`seccompWrapperConfig` is assembled in two places:
+
+- `internal/api/core.go` for the `exec` path
+- `internal/api/wrap.go` for the `wrap-init` path
+
+The two construction sites have drifted.
+
+The `exec` path sets these file-monitor-related fields:
+
+- `FileMonitorEnabled`
+- `InterceptMetadata`
+- `BlockIOUring`
+
+The `wrap-init` path omits them.
+
+That omission is not cosmetic. `cmd/agentsh-unixwrap` copies those JSON fields
+directly into `unixmon.FilterConfig`, and the seccomp filter only traps file and
+metadata syscalls when the corresponding booleans are set. As a result,
+`agentsh wrap` can create a server-side file handler from config, but the
+wrapper never installs the notify rules needed to send those syscalls to the
+handler.
+
+Effect:
+
+- Landlock still enforces coarse directory boundaries.
+- Fine-grained `file_rules` decisions do not run on the `wrap` path.
+- `intercept_metadata` is silently ignored on the `wrap` path.
+- `block_io_uring` is silently ignored on the `wrap` path.
+
+## Goal
+
+Make `wrap-init` and `exec` derive `seccompWrapperConfig` from the same shared
+logic for all config-driven fields, so file-monitor behavior is consistent and
+future fields cannot drift the same way.
+
+## Non-Goals
+
+- Do not change the existing runtime semantics of `UnixSocketEnabled`,
+  `ExecveEnabled`, or `SignalFilterEnabled` beyond what is required to remove
+  the current file-monitor bug.
+- Do not change the wrapper JSON schema.
+- Do not change Landlock policy derivation logic.
+- Do not change file-monitor enforcement semantics themselves.
+
+## Root Cause
+
+The bug is structural, not a one-off typo.
+
+`seccompWrapperConfig` has become a shared transport object, but the logic that
+fills it is duplicated. The duplication spans:
+
+- file-monitor option defaulting
+- Landlock config wiring
+- block-list transport
+- runtime-only flags
+
+The current bug happened because a field was added to one constructor but not
+the other. If this remains duplicated, the same class of bug is likely to recur
+for future fields.
+
+## Recommended Design
+
+### 1. Introduce a shared builder for `seccompWrapperConfig`
+
+Add a private helper in `internal/api` that builds the config object from:
+
+- `App`
+- `session.Session`
+- a small params struct containing runtime-specific booleans
+
+Proposed shape:
+
+```go
+type seccompWrapperParams struct {
+    UnixSocketEnabled   bool
+    ExecveEnabled       bool
+    SignalFilterEnabled bool
+}
+
+func (a *App) buildSeccompWrapperConfig(
+    s *session.Session,
+    p seccompWrapperParams,
+) seccompWrapperConfig
+```
+
+The helper owns all config-derived fields and policy/session-derived Landlock
+fields.
+
+### 2. Keep path-specific runtime decisions in the callers
+
+The callers continue to decide values that are genuinely path-dependent:
+
+- `UnixSocketEnabled`
+- `ExecveEnabled`
+- `SignalFilterEnabled`
+
+This is intentional.
+
+The current `wrap-init` path and `exec` path do not compute all of those fields
+the same way, and this design does not try to "clean up" those semantics as part
+of the bugfix. The helper removes duplication only for the parts that should be
+identical.
+
+### 3. Move all config/defaulting logic into the shared helper
+
+The helper should populate:
+
+- `BlockedSyscalls`
+- `OnBlock`
+- `FileMonitorEnabled`
+- `InterceptMetadata`
+- `BlockIOUring`
+- `ServerPID`
+- all Landlock fields:
+  - `LandlockEnabled`
+  - `LandlockABI`
+  - `Workspace`
+  - `AllowExecute`
+  - `AllowRead`
+  - `AllowWrite`
+  - `DenyPaths`
+  - `AllowNetwork`
+  - `AllowBind`
+
+File-monitor sub-option defaulting must remain exactly as it is on the `exec`
+path today:
+
+- `fmDefault := FileMonitorBoolWithDefault(EnforceWithoutFUSE, false)`
+- `InterceptMetadata := FileMonitorBoolWithDefault(InterceptMetadata, fmDefault)`
+- `BlockIOUring := FileMonitorBoolWithDefault(BlockIOUring, fmDefault)`
+
+That logic should exist in one place only after the change.
+
+### 4. Make both call sites use the helper
+
+`internal/api/core.go`
+
+- compute the runtime booleans as it does today
+- pass them into the helper
+- stop doing file-monitor and Landlock field assembly inline
+
+`internal/api/wrap.go`
+
+- compute the runtime booleans as it does today
+- pass them into the helper
+- stop doing file-monitor and Landlock field assembly inline
+
+This should leave each call site responsible only for:
+
+- local gating
+- socket creation
+- runtime capability decisions
+- marshaling / env plumbing
+
+## Why this is better than the alternatives
+
+### Alternative A: patch `wrapInitCore` only
+
+Rejected because it fixes this specific bug but leaves the duplication intact.
+The next added field can drift again.
+
+### Alternative B: add parity tests only
+
+Rejected because tests would detect future drift, but only after the code has
+already diverged. The production defect still comes from duplicated derivation
+logic.
+
+### Alternative C: move all runtime toggles into the helper too
+
+Rejected for this change because it risks altering unrelated wrap-vs-exec
+behavior. The bugfix should eliminate config drift without broadening scope.
+
+## Data Flow After The Change
+
+### Exec path
+
+```
+config + session + runtime booleans
+  → buildSeccompWrapperConfig(...)
+  → json.Marshal
+  → AGENTSH_SECCOMP_CONFIG
+  → agentsh-unixwrap
+  → unixmon.FilterConfig
+```
+
+### Wrap path
+
+```
+config + session + runtime booleans
+  → buildSeccompWrapperConfig(...)
+  → json.Marshal
+  → WrapInitResponse.SeccompConfig / WrapperEnv
+  → agentsh-unixwrap
+  → unixmon.FilterConfig
+```
+
+The important property is that both paths now share the same config derivation
+for file-monitor and Landlock fields.
+
+## Testing Plan
+
+### Wrap-path regression test
+
+Strengthen `TestWrapInit_SeccompConfigContent` in `internal/api/wrap_test.go`
+from a string-contains smoke test into JSON assertions.
+
+It should assert at least:
+
+- `file_monitor_enabled`
+- `intercept_metadata`
+- `block_io_uring`
+
+Use a config that exercises the existing defaulting behavior:
+
+- `Enabled = true`
+- `EnforceWithoutFUSE = true`
+- leave `InterceptMetadata` unset
+- leave `BlockIOUring` unset
+
+Expected result:
+
+- `file_monitor_enabled == true`
+- `intercept_metadata == true`
+- `block_io_uring == true`
+
+That proves the wrap path is using the same defaulting logic as the exec path.
+
+### Exec-path regression test
+
+Add a corresponding `setupSeccompWrapper` JSON test in `internal/api` that
+asserts the same three fields for the `exec` path.
+
+This is partly redundant once the helper is shared, but it keeps both public
+integration surfaces covered.
+
+### Optional focused helper test
+
+If the extraction makes the helper clean to test directly without excessive
+fixture setup, a narrow unit test is acceptable. It is not required.
+
+The integration tests above are the required boundary.
+
+## Files Expected To Change
+
+**Modify:**
+
+- `internal/api/core.go`
+- `internal/api/wrap.go`
+- `internal/api/wrap_test.go`
+- one `internal/api/*test.go` file covering `setupSeccompWrapper`
+
+**Create only if needed:**
+
+- a small shared helper file in `internal/api` if extracting the builder there
+  is cleaner than placing it beside one caller
+
+## Risks
+
+- **Accidentally changing runtime flag semantics.**
+  Mitigation: keep `UnixSocketEnabled`, `ExecveEnabled`, and
+  `SignalFilterEnabled` as caller-provided params.
+
+- **Over-refactoring unrelated wrap logic.**
+  Mitigation: extract only config assembly, not socket setup or caller flow.
+
+- **Tests only checking field presence, not values.**
+  Mitigation: parse JSON and assert concrete booleans, especially the
+  `EnforceWithoutFUSE`-driven defaults.
+
+## Success Criteria
+
+- `agentsh wrap` sets `file_monitor_enabled` the same way as the `exec` path.
+- `agentsh wrap` sets `intercept_metadata` and `block_io_uring` the same way as
+  the `exec` path.
+- Fine-grained `file_rules` enforcement is restored on the `wrap` path.
+- Future `seccompWrapperConfig` fields have one shared derivation path instead
+  of two independent constructors.

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -16,10 +16,8 @@ import (
 	"time"
 
 	"github.com/agentsh/agentsh/internal/approvals"
-	"github.com/agentsh/agentsh/internal/capabilities"
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/events"
-	"github.com/agentsh/agentsh/internal/landlock"
 	"github.com/agentsh/agentsh/internal/pkgcheck"
 	"github.com/agentsh/agentsh/internal/platform"
 	"github.com/agentsh/agentsh/internal/policy"
@@ -44,35 +42,6 @@ func traceparentFromContext(ctx context.Context) string {
 		return v
 	}
 	return ""
-}
-
-// seccompWrapperConfig is passed to the agentsh-unixwrap wrapper via
-// AGENTSH_SECCOMP_CONFIG environment variable to configure seccomp-bpf filtering.
-type seccompWrapperConfig struct {
-	UnixSocketEnabled   bool     `json:"unix_socket_enabled"`
-	SignalFilterEnabled bool     `json:"signal_filter_enabled"`
-	ExecveEnabled       bool     `json:"execve_enabled"`
-	FileMonitorEnabled  bool     `json:"file_monitor_enabled"`
-	BlockedSyscalls     []string `json:"blocked_syscalls"`
-	OnBlock             string   `json:"on_block,omitempty"`
-
-	// File monitor sub-options
-	InterceptMetadata bool `json:"intercept_metadata,omitempty"`
-	BlockIOUring      bool `json:"block_io_uring,omitempty"`
-
-	// Landlock filesystem restrictions
-	LandlockEnabled bool     `json:"landlock_enabled,omitempty"`
-	LandlockABI     int      `json:"landlock_abi,omitempty"`
-	Workspace       string   `json:"workspace,omitempty"`
-	AllowExecute    []string `json:"allow_execute,omitempty"`
-	AllowRead       []string `json:"allow_read,omitempty"`
-	AllowWrite      []string `json:"allow_write,omitempty"`
-	DenyPaths       []string `json:"deny_paths,omitempty"`
-	AllowNetwork    bool     `json:"allow_network,omitempty"`
-	AllowBind       bool     `json:"allow_bind,omitempty"`
-
-	// Server PID for PR_SET_PTRACER (Yama ptrace_scope=1 workaround)
-	ServerPID int `json:"server_pid,omitempty"`
 }
 
 // macSandboxWrapperConfig is passed to agentsh-macwrap via
@@ -201,66 +170,11 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 	}
 
 	// Pass seccomp configuration to the wrapper
-	seccompCfg := seccompWrapperConfig{
+	seccompCfg := a.buildSeccompWrapperConfig(s, seccompWrapperParams{
 		UnixSocketEnabled:   a.cfg.Sandbox.Seccomp.UnixSocket.Enabled,
-		BlockedSyscalls:     a.cfg.Sandbox.Seccomp.Syscalls.Block,
-		OnBlock:             a.cfg.Sandbox.Seccomp.Syscalls.OnBlock,
-		SignalFilterEnabled: signalFilterActive, // Only true if signal socket succeeded
+		SignalFilterEnabled: signalFilterActive,
 		ExecveEnabled:       execveEnabled,
-		FileMonitorEnabled:  config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.Enabled, false),
-		ServerPID:           os.Getpid(),
-	}
-
-	// Bridge file monitor sub-options using EnforceWithoutFUSE as the default
-	fmDefault := config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE, false)
-	seccompCfg.InterceptMetadata = config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata, fmDefault)
-	seccompCfg.BlockIOUring = config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.BlockIOUring, fmDefault)
-
-	// Add Landlock config if enabled
-	if a.cfg.Landlock.Enabled {
-		llResult := capabilities.DetectLandlock()
-		if llResult.Available {
-			workspace := s.WorkspaceMountPath()
-			seccompCfg.LandlockEnabled = true
-			seccompCfg.LandlockABI = llResult.ABI
-			seccompCfg.Workspace = workspace
-
-			// Derive paths from policy
-			if sessionPolicy != nil {
-				pol := sessionPolicy.Policy()
-				seccompCfg.AllowExecute = landlock.DeriveExecutePathsFromPolicy(pol)
-				seccompCfg.AllowExecute = append(seccompCfg.AllowExecute, landlock.DeriveExecutePathsFromFileRules(pol)...)
-				seccompCfg.AllowRead = landlock.DeriveReadPathsFromPolicy(pol)
-				seccompCfg.AllowWrite = landlock.DeriveWritePathsFromPolicy(pol)
-			}
-
-			// Add explicit config paths
-			seccompCfg.AllowExecute = append(seccompCfg.AllowExecute, a.cfg.Landlock.AllowExecute...)
-			seccompCfg.AllowRead = append(seccompCfg.AllowRead, a.cfg.Landlock.AllowRead...)
-			seccompCfg.AllowWrite = append(seccompCfg.AllowWrite, a.cfg.Landlock.AllowWrite...)
-			seccompCfg.DenyPaths = append(seccompCfg.DenyPaths, a.cfg.Landlock.DenyPaths...)
-
-			// Honor landlock.network.* config. validateConfig already rejects
-			// allow_connect_tcp=false while sandbox.network.enabled=true, so reaching
-			// this point with AllowConnectTCP=false implies the operator opted out
-			// of proxy TCP. Defaults (connect=true, bind=false) come from applyDefaults.
-			if a.cfg.Landlock.Network.AllowConnectTCP != nil {
-				seccompCfg.AllowNetwork = *a.cfg.Landlock.Network.AllowConnectTCP
-			}
-			if a.cfg.Landlock.Network.AllowBindTCP != nil {
-				seccompCfg.AllowBind = *a.cfg.Landlock.Network.AllowBindTCP
-			}
-
-			slog.Info("landlock config prepared for wrapper",
-				"abi", llResult.ABI,
-				"workspace", workspace,
-				"session_id", sessionID)
-		} else {
-			slog.Warn("landlock enabled but not available",
-				"error", llResult.Error,
-				"session_id", sessionID)
-		}
-	}
+	})
 	if cfgJSON, err := json.Marshal(seccompCfg); err == nil {
 		wrappedReq.Env["AGENTSH_SECCOMP_CONFIG"] = string(cfgJSON)
 	}

--- a/internal/api/seccomp_wrapper_config.go
+++ b/internal/api/seccomp_wrapper_config.go
@@ -1,0 +1,85 @@
+package api
+
+import (
+	"os"
+
+	"github.com/agentsh/agentsh/internal/capabilities"
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/session"
+)
+
+// seccompWrapperConfig is passed to the agentsh-unixwrap wrapper via
+// AGENTSH_SECCOMP_CONFIG environment variable to configure seccomp-bpf filtering.
+type seccompWrapperConfig struct {
+	UnixSocketEnabled   bool     `json:"unix_socket_enabled"`
+	SignalFilterEnabled bool     `json:"signal_filter_enabled"`
+	ExecveEnabled       bool     `json:"execve_enabled"`
+	FileMonitorEnabled  bool     `json:"file_monitor_enabled"`
+	BlockedSyscalls     []string `json:"blocked_syscalls"`
+	OnBlock             string   `json:"on_block,omitempty"`
+
+	// File monitor sub-options
+	InterceptMetadata bool `json:"intercept_metadata,omitempty"`
+	BlockIOUring      bool `json:"block_io_uring,omitempty"`
+
+	// Landlock filesystem restrictions
+	LandlockEnabled bool     `json:"landlock_enabled,omitempty"`
+	LandlockABI     int      `json:"landlock_abi,omitempty"`
+	Workspace       string   `json:"workspace,omitempty"`
+	AllowExecute    []string `json:"allow_execute,omitempty"`
+	AllowRead       []string `json:"allow_read,omitempty"`
+	AllowWrite      []string `json:"allow_write,omitempty"`
+	DenyPaths       []string `json:"deny_paths,omitempty"`
+	AllowNetwork    bool     `json:"allow_network,omitempty"`
+	AllowBind       bool     `json:"allow_bind,omitempty"`
+
+	// Server PID for PR_SET_PTRACER (Yama ptrace_scope=1 workaround)
+	ServerPID int `json:"server_pid,omitempty"`
+}
+
+type seccompWrapperParams struct {
+	UnixSocketEnabled   bool
+	SignalFilterEnabled bool
+	ExecveEnabled       bool
+}
+
+func (a *App) buildSeccompWrapperConfig(s *session.Session, p seccompWrapperParams) seccompWrapperConfig {
+	seccompCfg := seccompWrapperConfig{
+		UnixSocketEnabled:   p.UnixSocketEnabled,
+		SignalFilterEnabled: p.SignalFilterEnabled,
+		ExecveEnabled:       p.ExecveEnabled,
+		FileMonitorEnabled:  config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.Enabled, false),
+		BlockedSyscalls:     a.cfg.Sandbox.Seccomp.Syscalls.Block,
+		OnBlock:             a.cfg.Sandbox.Seccomp.Syscalls.OnBlock,
+		ServerPID:           os.Getpid(),
+	}
+
+	fmDefault := config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE, false)
+	seccompCfg.InterceptMetadata = config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata, fmDefault)
+	seccompCfg.BlockIOUring = config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.BlockIOUring, fmDefault)
+
+	if a.cfg.Landlock.Enabled {
+		llResult := capabilities.DetectLandlock()
+		if llResult.Available {
+			workspace := s.WorkspaceMountPath()
+			seccompCfg.LandlockEnabled = true
+			seccompCfg.LandlockABI = llResult.ABI
+			seccompCfg.Workspace = workspace
+
+			seccompCfg.AllowExecute, seccompCfg.AllowRead, seccompCfg.AllowWrite = a.deriveLandlockAllowPaths(s)
+			seccompCfg.AllowExecute = append(seccompCfg.AllowExecute, a.cfg.Landlock.AllowExecute...)
+			seccompCfg.AllowRead = append(seccompCfg.AllowRead, a.cfg.Landlock.AllowRead...)
+			seccompCfg.AllowWrite = append(seccompCfg.AllowWrite, a.cfg.Landlock.AllowWrite...)
+			seccompCfg.DenyPaths = append(seccompCfg.DenyPaths, a.cfg.Landlock.DenyPaths...)
+
+			if a.cfg.Landlock.Network.AllowConnectTCP != nil {
+				seccompCfg.AllowNetwork = *a.cfg.Landlock.Network.AllowConnectTCP
+			}
+			if a.cfg.Landlock.Network.AllowBindTCP != nil {
+				seccompCfg.AllowBind = *a.cfg.Landlock.Network.AllowBindTCP
+			}
+		}
+	}
+
+	return seccompCfg
+}

--- a/internal/api/seccomp_wrapper_test.go
+++ b/internal/api/seccomp_wrapper_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"runtime"
 	"testing"
 
@@ -227,5 +228,60 @@ func TestSetupSeccompWrapper_PreservesEnv(t *testing.T) {
 				f.Close()
 			}
 		}
+	}
+}
+
+func TestSetupSeccompWrapper_FileMonitorDefaults(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("seccomp wrapper only available on Linux")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &enabled
+	cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE = &enabled
+
+	app := newTestAppForSeccomp(t, cfg)
+
+	req := types.ExecRequest{
+		Command: "/bin/echo",
+		Args:    []string{"hello"},
+	}
+
+	result := app.setupSeccompWrapper(req, "test-session", nil)
+	if result == nil || result.extraCfg == nil {
+		t.Fatal("expected non-nil wrapper setup result with extraCfg")
+	}
+	defer func() {
+		if result.extraCfg.notifyParentSock != nil {
+			result.extraCfg.notifyParentSock.Close()
+		}
+		for _, f := range result.extraCfg.extraFiles {
+			if f != nil {
+				f.Close()
+			}
+		}
+	}()
+
+	seccompJSON, ok := result.wrappedReq.Env["AGENTSH_SECCOMP_CONFIG"]
+	if !ok {
+		t.Fatal("AGENTSH_SECCOMP_CONFIG env var not set")
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(seccompJSON), &parsed); err != nil {
+		t.Fatalf("unmarshal seccomp config: %v\n%s", err, seccompJSON)
+	}
+
+	if got, _ := parsed["file_monitor_enabled"].(bool); !got {
+		t.Fatalf("file_monitor_enabled = %v, want true (JSON: %s)", got, seccompJSON)
+	}
+	if got, _ := parsed["intercept_metadata"].(bool); !got {
+		t.Fatalf("intercept_metadata = %v, want true (JSON: %s)", got, seccompJSON)
+	}
+	if got, _ := parsed["block_io_uring"].(bool); !got {
+		t.Fatalf("block_io_uring = %v, want true (JSON: %s)", got, seccompJSON)
 	}
 }

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/agentsh/agentsh/internal/capabilities"
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/landlock"
 	"github.com/agentsh/agentsh/internal/session"
@@ -230,49 +229,7 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 	stubBin := "agentsh-stub"
 	stubPath, _ := exec.LookPath(stubBin)
 
-	// Build seccomp config
 	execveEnabled := a.cfg.Sandbox.Seccomp.Execve.Enabled
-	seccompCfg := seccompWrapperConfig{
-		UnixSocketEnabled: a.cfg.Sandbox.Seccomp.UnixSocket.Enabled,
-		BlockedSyscalls:   a.cfg.Sandbox.Seccomp.Syscalls.Block,
-		OnBlock:           a.cfg.Sandbox.Seccomp.Syscalls.OnBlock,
-		ExecveEnabled:     execveEnabled,
-		ServerPID:         os.Getpid(),
-	}
-
-	// Add Landlock config if enabled
-	if a.cfg.Landlock.Enabled {
-		llResult := capabilities.DetectLandlock()
-		if llResult.Available {
-			workspace := s.WorkspaceMountPath()
-			seccompCfg.LandlockEnabled = true
-			seccompCfg.LandlockABI = llResult.ABI
-			seccompCfg.Workspace = workspace
-
-			seccompCfg.AllowExecute, seccompCfg.AllowRead, seccompCfg.AllowWrite = a.deriveLandlockAllowPaths(s)
-
-			seccompCfg.AllowExecute = append(seccompCfg.AllowExecute, a.cfg.Landlock.AllowExecute...)
-			seccompCfg.AllowRead = append(seccompCfg.AllowRead, a.cfg.Landlock.AllowRead...)
-			seccompCfg.AllowWrite = append(seccompCfg.AllowWrite, a.cfg.Landlock.AllowWrite...)
-			seccompCfg.DenyPaths = append(seccompCfg.DenyPaths, a.cfg.Landlock.DenyPaths...)
-
-			// Honor landlock.network.* config. Defaults (connect=true, bind=false)
-			// come from applyDefaults; validateConfig already rejects the
-			// allow_connect_tcp=false + sandbox.network.enabled=true combination.
-			if a.cfg.Landlock.Network.AllowConnectTCP != nil {
-				seccompCfg.AllowNetwork = *a.cfg.Landlock.Network.AllowConnectTCP
-			}
-			if a.cfg.Landlock.Network.AllowBindTCP != nil {
-				seccompCfg.AllowBind = *a.cfg.Landlock.Network.AllowBindTCP
-			}
-		}
-	}
-
-	// Check if unix socket monitoring is enabled at all
-	unixEnabled := a.cfg.Sandbox.UnixSockets.Enabled != nil && *a.cfg.Sandbox.UnixSockets.Enabled
-	if unixEnabled {
-		seccompCfg.UnixSocketEnabled = true
-	}
 
 	// Create a private temp directory for the notify socket to prevent
 	// other local users from connecting first (security: socket path injection).
@@ -367,7 +324,17 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 			go a.acceptSignalFD(ctx, signalListener, signalSocketPath, sessionID, s, req.CallerUID)
 		}
 	}
-	seccompCfg.SignalFilterEnabled = signalFilterEnabled
+
+	unixSocketEnabled := a.cfg.Sandbox.Seccomp.UnixSocket.Enabled
+	if a.cfg.Sandbox.UnixSockets.Enabled != nil && *a.cfg.Sandbox.UnixSockets.Enabled {
+		unixSocketEnabled = true
+	}
+
+	seccompCfg := a.buildSeccompWrapperConfig(s, seccompWrapperParams{
+		UnixSocketEnabled:   unixSocketEnabled,
+		SignalFilterEnabled: signalFilterEnabled,
+		ExecveEnabled:       execveEnabled,
+	})
 
 	cfgJSON, err := json.Marshal(seccompCfg)
 	if err != nil {

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -569,6 +569,8 @@ func TestWrapInit_SeccompConfigContent(t *testing.T) {
 	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
 	cfg.Sandbox.Seccomp.Execve.Enabled = true
 	cfg.Sandbox.Seccomp.UnixSocket.Enabled = true
+	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &enabled
+	cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE = &enabled
 	app, mgr := newTestAppForWrap(t, cfg)
 
 	s, err := mgr.Create(t.TempDir(), "default")
@@ -584,31 +586,26 @@ func TestWrapInit_SeccompConfigContent(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// The seccomp config should contain the expected fields
-	cfg_str := resp.SeccompConfig
-	if cfg_str == "" {
-		t.Fatal("expected non-empty seccomp config")
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(resp.SeccompConfig), &parsed); err != nil {
+		t.Fatalf("unmarshal SeccompConfig: %v\n%s", err, resp.SeccompConfig)
 	}
-	// Verify it contains expected JSON fields
-	if !contains(cfg_str, "unix_socket_enabled") {
-		t.Error("seccomp config should contain unix_socket_enabled")
-	}
-	if !contains(cfg_str, "execve_enabled") {
-		t.Error("seccomp config should contain execve_enabled")
-	}
-}
 
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && searchString(s, substr)
-}
-
-func searchString(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
+	if got, _ := parsed["unix_socket_enabled"].(bool); !got {
+		t.Fatalf("unix_socket_enabled = %v, want true (JSON: %s)", got, resp.SeccompConfig)
 	}
-	return false
+	if got, _ := parsed["execve_enabled"].(bool); !got {
+		t.Fatalf("execve_enabled = %v, want true (JSON: %s)", got, resp.SeccompConfig)
+	}
+	if got, _ := parsed["file_monitor_enabled"].(bool); !got {
+		t.Fatalf("file_monitor_enabled = %v, want true (JSON: %s)", got, resp.SeccompConfig)
+	}
+	if got, _ := parsed["intercept_metadata"].(bool); !got {
+		t.Fatalf("intercept_metadata = %v, want true (JSON: %s)", got, resp.SeccompConfig)
+	}
+	if got, _ := parsed["block_io_uring"].(bool); !got {
+		t.Fatalf("block_io_uring = %v, want true (JSON: %s)", got, resp.SeccompConfig)
+	}
 }
 
 func TestWrapInit_LongTMPDIR_LongSessionID(t *testing.T) {

--- a/internal/integration/seccomp_wrapper_test.go
+++ b/internal/integration/seccomp_wrapper_test.go
@@ -22,6 +22,88 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
+func TestCreateSessionWithRetry_RetriesTransientTransportErrors(t *testing.T) {
+	t.Parallel()
+
+	want := types.Session{ID: "session-retried"}
+	attempts := 0
+	cli := &fakeSessionClient{
+		createWithID: func(context.Context, string, string, string) (types.Session, error) {
+			attempts++
+			if attempts == 1 {
+				return types.Session{}, errors.New(`Post "http://localhost:1234/api/v1/sessions": read tcp [::1]:123->[::1]:456: read: bad file descriptor`)
+			}
+			return want, nil
+		},
+	}
+
+	got, err := createSessionWithRetry(context.Background(), cli, "/workspace", "default")
+	if err != nil {
+		t.Fatalf("createSessionWithRetry: %v", err)
+	}
+	if got.ID != want.ID {
+		t.Fatalf("session ID = %q, want %q", got.ID, want.ID)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
+func TestCreateSessionWithRetry_DoesNotRetryPermanentErrors(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	cli := &fakeSessionClient{
+		createWithID: func(context.Context, string, string, string) (types.Session, error) {
+			attempts++
+			return types.Session{}, errors.New("policy not found")
+		},
+	}
+
+	_, err := createSessionWithRetry(context.Background(), cli, "/workspace", "default")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
+func TestCreateSessionWithRetry_UsesExistingSessionAfterConflict(t *testing.T) {
+	t.Parallel()
+
+	want := types.Session{ID: "session-existing"}
+	createAttempts := 0
+	getAttempts := 0
+	cli := &fakeSessionClient{
+		createWithID: func(context.Context, string, string, string) (types.Session, error) {
+			createAttempts++
+			if createAttempts == 1 {
+				return types.Session{}, errors.New(`Post "http://localhost:1234/api/v1/sessions": context deadline exceeded (Client.Timeout exceeded while awaiting headers)`)
+			}
+			return types.Session{}, &client.HTTPError{Method: http.MethodPost, Path: "/api/v1/sessions", Status: "409 Conflict", StatusCode: http.StatusConflict}
+		},
+		getSession: func(context.Context, string) (types.Session, error) {
+			getAttempts++
+			return want, nil
+		},
+	}
+
+	got, err := createSessionWithRetry(context.Background(), cli, "/workspace", "default")
+	if err != nil {
+		t.Fatalf("createSessionWithRetry: %v", err)
+	}
+	if got.ID != want.ID {
+		t.Fatalf("session ID = %q, want %q", got.ID, want.ID)
+	}
+	if createAttempts != 2 {
+		t.Fatalf("create attempts = %d, want 2", createAttempts)
+	}
+	if getAttempts != 1 {
+		t.Fatalf("get attempts = %d, want 1", getAttempts)
+	}
+}
+
 // TestSeccompWrapperEnabled verifies that when unix_sockets.enabled=true,
 // the server starts successfully, can create sessions, and exec commands work.
 // The wrapper may fail to set up seccomp in the container environment (due to
@@ -55,7 +137,7 @@ func TestSeccompWrapperEnabled(t *testing.T) {
 	cli := client.New(endpoint, "test-key")
 
 	// Verify session creation works with wrapper config enabled
-	sess, err := cli.CreateSession(ctx, "/workspace", "default")
+	sess, err := createSessionWithRetry(ctx, cli, "/workspace", "default")
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -120,7 +202,7 @@ func TestSeccompWrapperDisabled(t *testing.T) {
 	cli := client.New(endpoint, "test-key")
 
 	// Verify session creation works with wrapper disabled
-	sess, err := cli.CreateSession(ctx, "/workspace", "default")
+	sess, err := createSessionWithRetry(ctx, cli, "/workspace", "default")
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}
@@ -249,6 +331,7 @@ func startSeccompServerContainer(t *testing.T, ctx context.Context, agentshBin, 
 //   - wait.ForHTTP startup timeouts where the container starts but the
 //     mapped port briefly isn't reachable in time; the next attempt on the
 //     same image typically succeeds in a few seconds.
+//
 // Any non-nil container returned alongside an error is terminated (after a
 // best-effort log capture) before we return or retry, so privileged
 // containers never leak across attempts or out to the caller (which
@@ -293,6 +376,58 @@ func startContainerWithRetry(t *testing.T, ctx context.Context, req testcontaine
 		time.Sleep(2 * time.Second)
 	}
 	return nil, err
+}
+
+type sessionCreator interface {
+	CreateSessionWithID(ctx context.Context, id, workspace, policy string) (types.Session, error)
+	GetSession(ctx context.Context, id string) (types.Session, error)
+}
+
+type fakeSessionClient struct {
+	createWithID func(ctx context.Context, id, workspace, policy string) (types.Session, error)
+	getSession   func(ctx context.Context, id string) (types.Session, error)
+}
+
+func (f *fakeSessionClient) CreateSessionWithID(ctx context.Context, id, workspace, policy string) (types.Session, error) {
+	return f.createWithID(ctx, id, workspace, policy)
+}
+
+func (f *fakeSessionClient) GetSession(ctx context.Context, id string) (types.Session, error) {
+	return f.getSession(ctx, id)
+}
+
+func createSessionWithRetry(ctx context.Context, cli sessionCreator, workspace, policy string) (types.Session, error) {
+	sessionID := fmt.Sprintf("session-%d", time.Now().UnixNano())
+	var err error
+	for attempt := 1; attempt <= 3; attempt++ {
+		var sess types.Session
+		sess, err = cli.CreateSessionWithID(ctx, sessionID, workspace, policy)
+		if err == nil {
+			return sess, nil
+		}
+		var httpErr *client.HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusConflict {
+			return cli.GetSession(ctx, sessionID)
+		}
+		if !isTransientCreateSessionError(err) || attempt == 3 || ctx.Err() != nil {
+			return types.Session{}, err
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	return types.Session{}, err
+}
+
+func isTransientCreateSessionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return errors.Is(err, context.DeadlineExceeded) ||
+		strings.Contains(msg, "Client.Timeout exceeded while awaiting headers") ||
+		strings.Contains(msg, "bad file descriptor") ||
+		strings.Contains(msg, "use of closed network connection") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "EOF")
 }
 
 const seccompTestPolicyYAML = `
@@ -389,7 +524,7 @@ func TestExecveInterception_DepthEnforcement(t *testing.T) {
 
 	cli := client.New(endpoint, "test-key")
 
-	sess, err := cli.CreateSession(ctx, "/workspace", "depth-test")
+	sess, err := createSessionWithRetry(ctx, cli, "/workspace", "depth-test")
 	if err != nil {
 		t.Fatalf("CreateSession: %v", err)
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -57,9 +56,9 @@ type Proxy struct {
 	logger          *slog.Logger
 	isCustomOpenAI  bool
 	chatGPTUpstream *url.URL
-	registry         *mcpregistry.Registry
+	registry        *mcpregistry.Registry
 	// policy is immutable after construction — set once in New(), never changed.
-	policy           *mcpinspect.PolicyEvaluator
+	policy *mcpinspect.PolicyEvaluator
 	// onInterceptEvent is called for each MCP tool call intercept event.
 	// Set via SetEventCallback; the API layer uses it to persist events.
 	onInterceptEvent func(mcpinspect.MCPToolCallInterceptedEvent)
@@ -105,17 +104,16 @@ func New(cfg Config, storagePath string, logger *slog.Logger) (*Proxy, error) {
 		logger = slog.Default()
 	}
 
-	// Run retention cleanup asynchronously if configured
-	// storagePath is like ~/.agentsh/sessions/<session-id>/llm-logs
-	// sessionsDir is ~/.agentsh/sessions
+	// Run retention cleanup asynchronously if configured.
+	// storagePath is the base sessions directory used by NewStorage, for example
+	// ~/.agentsh/sessions.
 	if storagePath != "" && (cfg.Storage.Retention.MaxAgeDays > 0 || cfg.Storage.Retention.MaxSizeMB > 0) {
-		sessionsDir := filepath.Dir(filepath.Dir(storagePath))
 		retentionCfg := RetentionConfig{
 			MaxAgeDays: cfg.Storage.Retention.MaxAgeDays,
 			MaxSizeMB:  cfg.Storage.Retention.MaxSizeMB,
 			Eviction:   cfg.Storage.Retention.Eviction,
 		}
-		go RunRetention(sessionsDir, retentionCfg, cfg.SessionID, logger)
+		go RunRetention(storagePath, retentionCfg, cfg.SessionID, logger)
 	}
 
 	// Build dialect configs with any overrides from ProxyConfig.Providers

--- a/internal/proxy/proxy_retention_path_test.go
+++ b/internal/proxy/proxy_retention_path_test.go
@@ -1,0 +1,72 @@
+package proxy
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+type lockedBuffer struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.String()
+}
+
+func TestNew_RetentionUsesStorageBaseDir(t *testing.T) {
+	storagePath := filepath.Join(t.TempDir(), "sessions")
+	if err := os.MkdirAll(storagePath, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	logs := &lockedBuffer{}
+	logger := slog.New(slog.NewTextHandler(io.Writer(logs), nil))
+
+	cfg := Config{
+		SessionID: "session-current",
+		Proxy:     config.DefaultProxyConfig(),
+		DLP:       config.DefaultDLPConfig(),
+		Storage:   config.DefaultLLMStorageConfig(),
+	}
+	cfg.Storage.Retention.MaxAgeDays = 1
+	cfg.Storage.Retention.MaxSizeMB = 0
+
+	p, err := New(cfg, storagePath, logger)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if p.storage != nil {
+		defer p.storage.Close()
+	}
+
+	want := "sessions_dir=" + storagePath
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if out := logs.String(); strings.Contains(out, "retention cleanup started") {
+			if !strings.Contains(out, want) {
+				t.Fatalf("retention log = %q, want %q", out, want)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("did not observe retention startup log; logs=%q", logs.String())
+}


### PR DESCRIPTION
## Summary
- add regression tests for wrap-init and exec seccomp config JSON so file-monitor fields are asserted directly
- extract a shared `buildSeccompWrapperConfig` helper and use it from both `setupSeccompWrapper` and `wrapInitCore`
- restore wrap-path propagation of `file_monitor_enabled`, `intercept_metadata`, and `block_io_uring`
- fix embedded proxy retention to clean up from `sessions.base_dir` instead of deriving an ancestor directory from the storage path
- make seccomp integration session creation idempotent and retry transient post-startup transport failures observed in CI

## Why
The exec path and wrap-init path built `seccompWrapperConfig` separately. The exec path propagated file-monitor fields, but the wrap path omitted them. That left coarse Landlock boundaries in place while skipping fine-grained `file_rules` enforcement on `agentsh wrap` because the wrapper never installed the corresponding seccomp notify rules.

While validating the PR in GitHub Actions, the `integration` job exposed a separate retention bug in the embedded LLM proxy: retention treated the storage base dir as if it were a session-specific path, derived the wrong cleanup root, and scanned top-level directories during session creation. That made `TestSeccompWrapperEnabled` flaky in CI.

After fixing retention, the same CI lane still showed occasional `CreateSession` failures immediately after `/health` passed or after the server had already created the session. The seccomp integration tests now use a fixed session ID and recover from transient transport errors by retrying and resolving `409 Conflict` back to the already-created session.

## Impact
`agentsh wrap` now emits the same config-derived file-monitor fields as the exec path, so wrap sessions regain the intended file-monitor behavior without changing the caller-owned runtime toggles.

The embedded proxy now runs retention cleanup against the configured sessions directory, avoiding accidental scans outside session storage and stabilizing the seccomp integration path exercised in CI.

The seccomp integration tests are now resilient to response-loss and Docker forwarding hiccups without masking real policy or execution failures.

## Validation
- `go test ./internal/api -count=1`
- `GOOS=windows go build ./...`
- `go test ./... -count=1`
- `go test -tags=integration ./internal/integration -count=1`
- `go test -tags=integration ./internal/integration -run TestSeccompWrapperEnabled -count=20`
- `go test -tags=integration ./internal/integration -run TestSeccompWrapperDisabled -count=20`
