### PR TITLE
[codex] Harden flaky Windows and seccomp CI checks

### DIFF
--- a/internal/integration/container_endpoint_test.go
+++ b/internal/integration/container_endpoint_test.go
@@ -1,0 +1,62 @@
+//go:build integration && linux
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/docker/go-connections/nat"
+)
+
+type containerEndpointSource interface {
+	Host(context.Context) (string, error)
+	MappedPort(context.Context, nat.Port) (nat.Port, error)
+}
+
+func containerHTTPEndpointWithRetry(ctx context.Context, ctr containerEndpointSource, port string) (string, error) {
+	const (
+		maxAttempts    = 3
+		attemptTimeout = 5 * time.Second
+		retryBackoff   = 250 * time.Millisecond
+	)
+
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
+		host, err := ctr.Host(attemptCtx)
+		if err == nil {
+			mappedPort, mapErr := ctr.MappedPort(attemptCtx, nat.Port(port))
+			if mapErr == nil {
+				cancel()
+				return "http://" + net.JoinHostPort(host, mappedPort.Port()), nil
+			}
+			err = mapErr
+		}
+		cancel()
+
+		lastErr = err
+		if !isTransientContainerEndpointError(err) || attempt == maxAttempts || ctx.Err() != nil {
+			return "", err
+		}
+		time.Sleep(retryBackoff)
+	}
+
+	return "", lastErr
+}
+
+func isTransientContainerEndpointError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return errors.Is(err, context.DeadlineExceeded) ||
+		strings.Contains(msg, "context deadline exceeded") ||
+		strings.Contains(msg, "use of closed network connection") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "EOF") ||
+		strings.Contains(msg, "inspect:")
+}

--- a/internal/integration/seccomp_wrapper_test.go
+++ b/internal/integration/seccomp_wrapper_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/agentsh/agentsh/internal/client"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 )
@@ -101,6 +102,84 @@ func TestCreateSessionWithRetry_UsesExistingSessionAfterConflict(t *testing.T) {
 	}
 	if getAttempts != 1 {
 		t.Fatalf("get attempts = %d, want 1", getAttempts)
+	}
+}
+
+type fakeEndpointContainer struct {
+	hostCalls int
+	portCalls int
+
+	hostFunc func(context.Context) (string, error)
+	portFunc func(context.Context, nat.Port) (nat.Port, error)
+}
+
+func (f *fakeEndpointContainer) Host(ctx context.Context) (string, error) {
+	f.hostCalls++
+	return f.hostFunc(ctx)
+}
+
+func (f *fakeEndpointContainer) MappedPort(ctx context.Context, port nat.Port) (nat.Port, error) {
+	f.portCalls++
+	return f.portFunc(ctx, port)
+}
+
+func TestContainerHTTPEndpointWithRetry_RetriesTransientMappedPortErrors(t *testing.T) {
+	t.Parallel()
+
+	wantPort, err := nat.NewPort("tcp", "49152")
+	if err != nil {
+		t.Fatalf("nat.NewPort: %v", err)
+	}
+
+	attempts := 0
+	ctr := &fakeEndpointContainer{
+		hostFunc: func(context.Context) (string, error) {
+			return "127.0.0.1", nil
+		},
+		portFunc: func(context.Context, nat.Port) (nat.Port, error) {
+			attempts++
+			if attempts == 1 {
+				return "", errors.New(`inspect: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.48/containers/abc/json": context deadline exceeded`)
+			}
+			return wantPort, nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	endpoint, err := containerHTTPEndpointWithRetry(ctx, ctr, "18080/tcp")
+	if err != nil {
+		t.Fatalf("containerHTTPEndpointWithRetry: %v", err)
+	}
+	if endpoint != "http://127.0.0.1:49152" {
+		t.Fatalf("endpoint = %q, want %q", endpoint, "http://127.0.0.1:49152")
+	}
+	if ctr.portCalls != 2 {
+		t.Fatalf("MappedPort calls = %d, want 2", ctr.portCalls)
+	}
+}
+
+func TestContainerHTTPEndpointWithRetry_DoesNotRetryPermanentErrors(t *testing.T) {
+	t.Parallel()
+
+	ctr := &fakeEndpointContainer{
+		hostFunc: func(context.Context) (string, error) {
+			return "127.0.0.1", nil
+		},
+		portFunc: func(context.Context, nat.Port) (nat.Port, error) {
+			return "", errors.New("port not exposed")
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if _, err := containerHTTPEndpointWithRetry(ctx, ctr, "18080/tcp"); err == nil {
+		t.Fatal("containerHTTPEndpointWithRetry() error = nil, want permanent failure")
+	}
+	if ctr.portCalls != 1 {
+		t.Fatalf("MappedPort calls = %d, want 1", ctr.portCalls)
 	}
 }
 
@@ -297,15 +376,10 @@ func startSeccompServerContainer(t *testing.T, ctx context.Context, agentshBin, 
 		t.Fatalf("start container: %v", err)
 	}
 
-	host, err := ctr.Host(ctx)
+	endpoint, err := containerHTTPEndpointWithRetry(ctx, ctr, "18080/tcp")
 	if err != nil {
-		t.Fatalf("container host: %v", err)
+		t.Fatalf("resolve endpoint: %v", err)
 	}
-	mappedPort, err := ctr.MappedPort(ctx, "18080/tcp")
-	if err != nil {
-		t.Fatalf("map port: %v", err)
-	}
-	endpoint := fmt.Sprintf("http://%s:%s", host, mappedPort.Port())
 
 	cleanup := func() {
 		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/internal/store/integrity_wrapper_test.go
+++ b/internal/store/integrity_wrapper_test.go
@@ -823,15 +823,44 @@ func TestFlushLoop_PeriodicSync(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	time.Sleep(250 * time.Millisecond)
+	chainState := chain.State()
 
-	sidecar, err := audit.ReadSidecar(audit.SidecarPath(logPath))
+	sidecar, err := waitForSidecarSequence(audit.SidecarPath(logPath), chainState.Sequence, 2*time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
-	chainState := chain.State()
 	if sidecar.Sequence != chainState.Sequence {
 		t.Fatalf("sidecar.Sequence = %d, want %d (timer should have flushed)", sidecar.Sequence, chainState.Sequence)
+	}
+}
+
+func TestWaitForSidecarSequence_Timeout(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "audit.jsonl")
+	writeSidecarForState(t, logPath, audit.ChainState{
+		Sequence: 0,
+		PrevHash: "prev-hash",
+	})
+
+	if _, err := waitForSidecarSequence(audit.SidecarPath(logPath), 1, 50*time.Millisecond); err == nil {
+		t.Fatal("waitForSidecarSequence() error = nil, want timeout")
+	}
+}
+
+func waitForSidecarSequence(sidecarPath string, want int64, timeout time.Duration) (audit.SidecarState, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		sidecar, err := audit.ReadSidecar(sidecarPath)
+		if err != nil {
+			return audit.SidecarState{}, err
+		}
+		if sidecar.Sequence == want {
+			return sidecar, nil
+		}
+		if time.Now().After(deadline) {
+			return sidecar, fmt.Errorf("timed out waiting for sidecar sequence %d; got %d", want, sidecar.Sequence)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace the fixed-sleep sidecar assertion in the periodic integrity flush test with a timeout-bounded poll helper and add a helper timeout regression test
- add a retrying container endpoint helper for seccomp integration tests so transient Docker inspect/mapped-port failures do not burn the full test timeout
- switch the seccomp wrapper integration startup path to use the retrying endpoint resolver and cover its transient/permanent error behavior directly

## Why
The post-merge `main` CI run for `#239` exposed two separate test fragility issues.

On Windows, `internal/store` depended on a fixed `250ms` sleep in `TestFlushLoop_PeriodicSync` even though the sidecar flush is driven by a background ticker and real disk writes. That timing assumption held locally on Linux but failed on the Windows 2025 runner.

In Linux integration, `TestSeccompWrapperEnabled` could hang for the full five-minute test context when `ctr.MappedPort` stalled inside Docker inspect after the container had already become healthy. The test was using the outer test context for host/port resolution, so a transient Docker socket issue turned into a full test timeout.

## Impact
The Windows store test now waits for the observable sidecar state with an explicit timeout instead of guessing scheduler timing.

The seccomp integration path now resolves the test container HTTP endpoint through a short-timeout retry helper, which preserves the existing test semantics while preventing transient Docker inspect failures from consuming the whole test budget.

## Validation
- `go test ./internal/store -count=1`
- `GOOS=windows go test -c -o /tmp/agentsh-ci-fix/store.test.exe ./internal/store`
- `go test -tags=integration ./internal/integration -run 'TestContainerHTTPEndpointWithRetry_|TestCreateSessionWithRetry_|TestSeccompWrapper(Enabled|Disabled)$' -count=1`
