### PR TITLE
[codex] Fix post-merge flaky Linux and Windows tests

### DIFF
--- a/internal/integration/seccomp_wrapper_test.go
+++ b/internal/integration/seccomp_wrapper_test.go
@@ -183,6 +183,64 @@ func TestContainerHTTPEndpointWithRetry_DoesNotRetryPermanentErrors(t *testing.T
 	}
 }
 
+func TestStartContainerWithRetry_RetriesTransientNetworkSetupTimeout(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	attempts := 0
+	_, err := startContainerWithRetryFunc(
+		t,
+		ctx,
+		3,
+		25*time.Millisecond,
+		time.Millisecond,
+		func(context.Context) (testcontainers.Container, error) {
+			attempts++
+			if attempts == 1 {
+				return nil, errors.New(`create container: ensure default network: network list: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.51/networks": context deadline exceeded`)
+			}
+			return nil, nil
+		},
+		func(testcontainers.Container, string) {},
+	)
+	if err != nil {
+		t.Fatalf("startContainerWithRetryFunc: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2", attempts)
+	}
+}
+
+func TestStartContainerWithRetry_DoesNotRetryPermanentCreateErrors(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	attempts := 0
+	wantErr := errors.New("pull access denied")
+	_, err := startContainerWithRetryFunc(
+		t,
+		ctx,
+		3,
+		25*time.Millisecond,
+		time.Millisecond,
+		func(context.Context) (testcontainers.Container, error) {
+			attempts++
+			return nil, wantErr
+		},
+		func(testcontainers.Container, string) {},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("startContainerWithRetryFunc() error = %v, want %v", err, wantErr)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts = %d, want 1", attempts)
+	}
+}
+
 // TestSeccompWrapperEnabled verifies that when unix_sockets.enabled=true,
 // the server starts successfully, can create sessions, and exec commands work.
 // The wrapper may fail to set up seccomp in the container environment (due to
@@ -429,27 +487,68 @@ func startContainerWithRetry(t *testing.T, ctx context.Context, req testcontaine
 		_ = c.Terminate(termCtx)
 		cancelTerm()
 	}
+	const (
+		maxAttempts    = 3
+		attemptTimeout = 90 * time.Second
+		retryBackoff   = 2 * time.Second
+	)
+	return startContainerWithRetryFunc(
+		t,
+		ctx,
+		maxAttempts,
+		attemptTimeout,
+		retryBackoff,
+		func(attemptCtx context.Context) (testcontainers.Container, error) {
+			return testcontainers.GenericContainer(attemptCtx, req)
+		},
+		cleanup,
+	)
+}
+
+func startContainerWithRetryFunc(
+	t *testing.T,
+	ctx context.Context,
+	maxAttempts int,
+	attemptTimeout time.Duration,
+	retryBackoff time.Duration,
+	start func(context.Context) (testcontainers.Container, error),
+	cleanup func(testcontainers.Container, string),
+) (testcontainers.Container, error) {
+	t.Helper()
+
 	var err error
-	for attempt := 1; attempt <= 3; attempt++ {
-		var ctr testcontainers.Container
-		ctr, err = testcontainers.GenericContainer(ctx, req)
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		attemptCtx, cancel := context.WithTimeout(ctx, attemptTimeout)
+		ctr, startErr := start(attemptCtx)
+		cancel()
+		err = startErr
 		if err == nil {
 			return ctr, nil
 		}
-		msg := err.Error()
-		transient := strings.Contains(msg, "use of closed network connection") ||
-			strings.Contains(msg, "EOF") ||
-			strings.Contains(msg, "connection reset") ||
-			strings.Contains(msg, "wait until ready")
-		if !transient || attempt == 3 {
+		if !isTransientContainerStartError(err) || attempt == maxAttempts || ctx.Err() != nil {
 			cleanup(ctr, "failed-start")
 			return nil, err
 		}
 		cleanup(ctr, "retrying")
-		t.Logf("transient docker error on attempt %d/3, retrying: %v", attempt, err)
-		time.Sleep(2 * time.Second)
+		t.Logf("transient docker error on attempt %d/%d, retrying: %v", attempt, maxAttempts, err)
+		time.Sleep(retryBackoff)
 	}
 	return nil, err
+}
+
+func isTransientContainerStartError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return errors.Is(err, context.DeadlineExceeded) ||
+		strings.Contains(msg, "context deadline exceeded") ||
+		strings.Contains(msg, "use of closed network connection") ||
+		strings.Contains(msg, "EOF") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "wait until ready") ||
+		strings.Contains(msg, "ensure default network") ||
+		strings.Contains(msg, "network list")
 }
 
 type sessionCreator interface {

--- a/internal/netmonitor/unix/file_syscalls_test.go
+++ b/internal/netmonitor/unix/file_syscalls_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 	"unsafe"
 
@@ -330,43 +329,51 @@ func TestFileSyscallName(t *testing.T) {
 	}
 }
 
-// pathToPtr creates a null-terminated byte buffer and returns its address as uint64.
-// Callers must keep the returned byte slice alive with runtime.KeepAlive after
-// the raw-memory read that consumes the pointer.
-func pathToPtr(s string) (uint64, []byte) {
-	buf := append([]byte(s), 0)
-	return uint64(uintptr(unsafe.Pointer(&buf[0]))), buf
+// pathToPtr creates a NUL-terminated path buffer in mapped memory so its raw
+// address stays valid while the test asks ProcessVMReadv to read this process.
+func pathToPtr(t *testing.T, s string) uint64 {
+	t.Helper()
+
+	buf, err := unix.Mmap(-1, 0, len(s)+1, unix.PROT_READ|unix.PROT_WRITE, unix.MAP_ANON|unix.MAP_PRIVATE)
+	if err != nil {
+		t.Fatalf("unix.Mmap() error = %v", err)
+	}
+	copy(buf, s)
+	buf[len(s)] = 0
+	t.Cleanup(func() {
+		if err := unix.Munmap(buf); err != nil {
+			t.Fatalf("unix.Munmap() error = %v", err)
+		}
+	})
+	return uint64(uintptr(unsafe.Pointer(&buf[0])))
 }
 
 func TestResolvePathAt_Absolute(t *testing.T) {
 	pid := os.Getpid()
-	ptr, buf := pathToPtr("/usr/bin/ls")
+	ptr := pathToPtr(t, "/usr/bin/ls")
 
 	result, err := resolvePathAt(pid, -100, ptr)
-	runtime.KeepAlive(buf)
 	assert.NoError(t, err)
 	assert.Equal(t, "/usr/bin/ls", result)
 }
 
 func TestResolvePathAt_AbsoluteClean(t *testing.T) {
 	pid := os.Getpid()
-	ptr, buf := pathToPtr("/usr/bin/../lib/test")
+	ptr := pathToPtr(t, "/usr/bin/../lib/test")
 
 	result, err := resolvePathAt(pid, -100, ptr)
-	runtime.KeepAlive(buf)
 	assert.NoError(t, err)
 	assert.Equal(t, "/usr/lib/test", result)
 }
 
 func TestResolvePathAt_RelativeATFDCWD(t *testing.T) {
 	pid := os.Getpid()
-	ptr, buf := pathToPtr("somefile.txt")
+	ptr := pathToPtr(t, "somefile.txt")
 
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 
 	result, err := resolvePathAt(pid, -100, ptr) // AT_FDCWD = -100
-	runtime.KeepAlive(buf)
 	assert.NoError(t, err)
 	assert.Equal(t, filepath.Join(cwd, "somefile.txt"), result)
 }
@@ -379,20 +386,18 @@ func TestResolvePathAt_RelativeToDirfd(t *testing.T) {
 	assert.NoError(t, err)
 	defer dir.Close()
 
-	ptr, buf := pathToPtr("testfile.txt")
+	ptr := pathToPtr(t, "testfile.txt")
 
 	result, err := resolvePathAt(pid, int32(dir.Fd()), ptr)
-	runtime.KeepAlive(buf)
 	assert.NoError(t, err)
 	assert.Equal(t, "/tmp/testfile.txt", result)
 }
 
 func TestResolvePathAt_InvalidPid(t *testing.T) {
-	ptr, buf := pathToPtr("/some/path")
+	ptr := pathToPtr(t, "/some/path")
 
 	// Use a PID that certainly doesn't exist
 	_, err := resolvePathAt(999999999, -100, ptr)
-	runtime.KeepAlive(buf)
 	assert.Error(t, err)
 }
 

--- a/internal/store/integrity_wrapper_test.go
+++ b/internal/store/integrity_wrapper_test.go
@@ -847,21 +847,90 @@ func TestWaitForSidecarSequence_Timeout(t *testing.T) {
 	}
 }
 
-func waitForSidecarSequence(sidecarPath string, want int64, timeout time.Duration) (audit.SidecarState, error) {
-	deadline := time.Now().Add(timeout)
-	for {
-		sidecar, err := audit.ReadSidecar(sidecarPath)
-		if err != nil {
-			return audit.SidecarState{}, err
+func TestWaitForSidecarSequence_RetriesTransientReadErrors(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+	got, err := waitForSidecarSequenceWithReader("audit.jsonl.chain", 3, 100*time.Millisecond, func(string) (audit.SidecarState, error) {
+		calls++
+		if calls == 1 {
+			return audit.SidecarState{}, &os.PathError{
+				Op:   "open",
+				Path: "audit.jsonl.chain",
+				Err:  errors.New("The process cannot access the file because it is being used by another process."),
+			}
 		}
-		if sidecar.Sequence == want {
-			return sidecar, nil
+		return audit.SidecarState{Sequence: 3}, nil
+	})
+	if err != nil {
+		t.Fatalf("waitForSidecarSequenceWithReader() error = %v", err)
+	}
+	if got.Sequence != 3 {
+		t.Fatalf("Sequence = %d, want 3", got.Sequence)
+	}
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+}
+
+func TestWaitForSidecarSequence_FailsFastOnNonRetryableReadError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("boom")
+	_, err := waitForSidecarSequenceWithReader("audit.jsonl.chain", 1, 100*time.Millisecond, func(string) (audit.SidecarState, error) {
+		return audit.SidecarState{}, wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("waitForSidecarSequenceWithReader() error = %v, want %v", err, wantErr)
+	}
+}
+
+func waitForSidecarSequence(sidecarPath string, want int64, timeout time.Duration) (audit.SidecarState, error) {
+	return waitForSidecarSequenceWithReader(sidecarPath, want, timeout, audit.ReadSidecar)
+}
+
+func waitForSidecarSequenceWithReader(sidecarPath string, want int64, timeout time.Duration, readSidecar func(string) (audit.SidecarState, error)) (audit.SidecarState, error) {
+	deadline := time.Now().Add(timeout)
+	var lastSidecar audit.SidecarState
+	var lastErr error
+	for {
+		sidecar, err := readSidecar(sidecarPath)
+		if err != nil {
+			if !shouldRetrySidecarRead(err) {
+				return audit.SidecarState{}, err
+			}
+			lastErr = err
+		} else {
+			lastSidecar = sidecar
+			lastErr = nil
+			if sidecar.Sequence == want {
+				return sidecar, nil
+			}
 		}
 		if time.Now().After(deadline) {
-			return sidecar, fmt.Errorf("timed out waiting for sidecar sequence %d; got %d", want, sidecar.Sequence)
+			if lastErr != nil {
+				return audit.SidecarState{}, fmt.Errorf("timed out waiting for sidecar sequence %d after read error: %w", want, lastErr)
+			}
+			return lastSidecar, fmt.Errorf("timed out waiting for sidecar sequence %d; got %d", want, lastSidecar.Sequence)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+}
+
+func shouldRetrySidecarRead(err error) bool {
+	if errors.Is(err, audit.ErrSidecarNotFound) || errors.Is(err, os.ErrNotExist) {
+		return true
+	}
+
+	var pathErr *os.PathError
+	if !errors.As(err, &pathErr) {
+		return false
+	}
+
+	msg := strings.ToLower(pathErr.Err.Error())
+	return strings.Contains(msg, "sharing violation") ||
+		strings.Contains(msg, "used by another process") ||
+		strings.Contains(msg, "cannot access the file")
 }
 
 func TestClose_FinalFlush(t *testing.T) {


### PR DESCRIPTION
## Summary
- retry transient sidecar read failures in the periodic flush test helper while still failing fast on real sidecar errors
- add regression coverage for retryable versus non-retryable sidecar read failures
- replace the `resolvePathAt` test fixture’s raw Go-slice pointer with an `mmap`-backed buffer so same-process `ProcessVMReadv` reads stable memory

## Root Cause
The post-merge `main` build failed for two separate test-only reasons.

On Windows, `TestFlushLoop_PeriodicSync` could read the sidecar while the flush loop was replacing it, and the helper treated a transient file-sharing error as terminal.

On Linux, `TestResolvePathAt_Absolute` was giving `ProcessVMReadv` a raw pointer into Go-managed test memory. In CI that occasionally produced garbage reads from the current process instead of the intended path bytes.

## Impact
These changes harden the flaky tests without changing product behavior. The sidecar polling helper now tolerates transient replacement races, and the path-resolution tests now use stable mapped memory for raw-memory reads.

## Validation
- `go test ./internal/store -run 'TestWaitForSidecarSequence_(RetriesTransientReadErrors|FailsFastOnNonRetryableReadError|Timeout)$' -count=1`
- `go test ./internal/store -run TestFlushLoop_PeriodicSync -count=20`
- `go test ./internal/netmonitor/unix -run TestResolvePathAt_Absolute -count=50`
- `go test ./internal/store ./internal/netmonitor/unix -count=1`
- `GOOS=windows go test -c -o /tmp/agentsh-post-merge/store.test.exe ./internal/store`
- `GOOS=windows go build ./...`
- `go test ./... -count=1`