### PR TITLE
[codex] Fix seccomp notify socket ownership

### DIFF
--- a/internal/integration/seccomp_onblock_test.go
+++ b/internal/integration/seccomp_onblock_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"sync"
 	"syscall"
 	"testing"
@@ -343,6 +344,43 @@ func startWrappedChild(t *testing.T, cfgJSON string, cmdArg string) (syscall.Wai
 }
 
 // ---------- Tests ----------
+
+const seccompOnBlockGCPressureEnv = "AGENTSH_TEST_SECCOMP_ONBLOCK_GC_PRESSURE"
+
+func TestSeccompOnBlock_LogAndKill_GCPressure(t *testing.T) {
+	cfgJSON := `{
+		"unix_socket_enabled": false,
+		"blocked_syscalls": ["ptrace"],
+		"on_block": "log_and_kill"
+	}`
+
+	if os.Getenv(seccompOnBlockGCPressureEnv) == "1" {
+		oldGCPercent := debug.SetGCPercent(1)
+		oldMemLimit := debug.SetMemoryLimit(64 << 20)
+		defer debug.SetGCPercent(oldGCPercent)
+		defer debug.SetMemoryLimit(oldMemLimit)
+
+		for i := 0; i < 25; i++ {
+			runtime.GC()
+
+			st, events, err := startWrappedChild(t, cfgJSON, "ptrace-traceme")
+			require.NoErrorf(t, err, "iteration %d", i)
+			require.Truef(t, st.Signaled(), "iteration %d", i)
+			require.Equalf(t, syscall.SIGKILL, st.Signal(), "iteration %d", i)
+			require.Lenf(t, events, 1, "iteration %d", i)
+
+			runtime.GC()
+		}
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestSeccompOnBlock_LogAndKill_GCPressure$")
+	cmd.Env = append(os.Environ(), seccompOnBlockGCPressureEnv+"=1")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	require.NoError(t, cmd.Run())
+}
 
 func TestSeccompOnBlock_Errno(t *testing.T) {
 	cfgJSON := `{

--- a/internal/integration/seccomp_onblock_test.go
+++ b/internal/integration/seccomp_onblock_test.go
@@ -345,20 +345,65 @@ func startWrappedChild(t *testing.T, cfgJSON string, cmdArg string) (syscall.Wai
 
 // ---------- Tests ----------
 
-func TestSeccompOnBlock_LogAndKill_GCPressure(t *testing.T) {
-	oldGCPercent := debug.SetGCPercent(1)
-	oldMemLimit := debug.SetMemoryLimit(64 << 20)
-	defer debug.SetGCPercent(oldGCPercent)
-	defer debug.SetMemoryLimit(oldMemLimit)
+const seccompOnBlockGCPressureEnv = "AGENTSH_TEST_SECCOMP_ONBLOCK_GC_PRESSURE"
 
-	runtime.GC()
+func TestSeccompOnBlock_LogAndKill_GCPressure(t *testing.T) {
+	if os.Getenv(seccompOnBlockGCPressureEnv) == "1" {
+		oldGCPercent := debug.SetGCPercent(1)
+		oldMemLimit := debug.SetMemoryLimit(64 << 20)
+		defer debug.SetGCPercent(oldGCPercent)
+		defer debug.SetMemoryLimit(oldMemLimit)
+
+		cfgJSON := `{
+			"unix_socket_enabled": false,
+			"blocked_syscalls": ["ptrace"],
+			"on_block": "log_and_kill"
+		}`
+
+		stop := make(chan struct{})
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			buf := make([][]byte, 0, 8)
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				buf = append(buf, make([]byte, 256<<10))
+				if len(buf) > 32 {
+					buf = buf[:0]
+					runtime.GC()
+					debug.FreeOSMemory()
+				}
+			}
+		}()
+		defer func() {
+			close(stop)
+			<-done
+		}()
+
+		for i := 0; i < 100; i++ {
+			runtime.GC()
+
+			st, events, err := startWrappedChild(t, cfgJSON, "ptrace-traceme")
+			require.NoErrorf(t, err, "iteration %d", i)
+			require.Truef(t, st.Signaled(), "iteration %d", i)
+			require.Equalf(t, syscall.SIGKILL, st.Signal(), "iteration %d", i)
+			require.Lenf(t, events, 1, "iteration %d", i)
+
+			runtime.GC()
+		}
+		return
+	}
 
 	cmd := exec.Command(
 		os.Args[0],
-		"-test.run=^TestSeccompOnBlock_LogAndKill$",
-		"-test.count=20",
+		"-test.run=^TestSeccompOnBlock_LogAndKill_GCPressure$",
 	)
 	cmd.Env = append(os.Environ(),
+		seccompOnBlockGCPressureEnv+"=1",
 		"GOGC=1",
 		"GOMEMLIMIT=64MiB",
 	)

--- a/internal/integration/seccomp_onblock_test.go
+++ b/internal/integration/seccomp_onblock_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -364,19 +365,15 @@ func TestSeccompOnBlock_LogAndKill_GCPressure(t *testing.T) {
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
-			buf := make([][]byte, 0, 8)
 			for {
 				select {
 				case <-stop:
 					return
 				default:
 				}
-				buf = append(buf, make([]byte, 256<<10))
-				if len(buf) > 32 {
-					buf = buf[:0]
-					runtime.GC()
-					debug.FreeOSMemory()
-				}
+				_ = make([]byte, 64<<10)
+				runtime.GC()
+				debug.FreeOSMemory()
 			}
 		}()
 		defer func() {
@@ -384,7 +381,7 @@ func TestSeccompOnBlock_LogAndKill_GCPressure(t *testing.T) {
 			<-done
 		}()
 
-		for i := 0; i < 100; i++ {
+		for i := 0; i < 25; i++ {
 			runtime.GC()
 
 			st, events, err := startWrappedChild(t, cfgJSON, "ptrace-traceme")
@@ -409,6 +406,12 @@ func TestSeccompOnBlock_LogAndKill_GCPressure(t *testing.T) {
 	)
 	out, err := cmd.CombinedOutput()
 
+	if err != nil {
+		sawTarget := strings.Contains(string(out), "ACK: invalid argument") ||
+			strings.Contains(string(out), "RecvFD: bad file descriptor") ||
+			strings.Contains(string(out), "ACK handshake failed: expected 1 ACK byte, got 0")
+		require.Truef(t, sawTarget, "child output did not include a target handshake failure:\n%s", out)
+	}
 	require.NoErrorf(t, err, "child output:\n%s", out)
 }
 

--- a/internal/integration/seccomp_onblock_test.go
+++ b/internal/integration/seccomp_onblock_test.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"runtime/debug"
 	"sync"
 	"syscall"
 	"testing"
@@ -345,37 +344,28 @@ func startWrappedChild(t *testing.T, cfgJSON string, cmdArg string) (syscall.Wai
 
 // ---------- Tests ----------
 
-const seccompOnBlockGCPressureEnv = "AGENTSH_TEST_SECCOMP_ONBLOCK_GC_PRESSURE"
-
 func TestSeccompOnBlock_LogAndKill_GCPressure(t *testing.T) {
-	cfgJSON := `{
-		"unix_socket_enabled": false,
-		"blocked_syscalls": ["ptrace"],
-		"on_block": "log_and_kill"
-	}`
-
-	if os.Getenv(seccompOnBlockGCPressureEnv) == "1" {
-		oldGCPercent := debug.SetGCPercent(1)
-		oldMemLimit := debug.SetMemoryLimit(64 << 20)
-		defer debug.SetGCPercent(oldGCPercent)
-		defer debug.SetMemoryLimit(oldMemLimit)
-
-		for i := 0; i < 25; i++ {
-			runtime.GC()
-
-			st, events, err := startWrappedChild(t, cfgJSON, "ptrace-traceme")
-			require.NoErrorf(t, err, "iteration %d", i)
-			require.Truef(t, st.Signaled(), "iteration %d", i)
-			require.Equalf(t, syscall.SIGKILL, st.Signal(), "iteration %d", i)
-			require.Lenf(t, events, 1, "iteration %d", i)
-
-			runtime.GC()
+	repoRoot := "."
+	if wd, err := os.Getwd(); err == nil {
+		for {
+			if _, statErr := os.Stat(filepath.Join(wd, "go.mod")); statErr == nil {
+				repoRoot = wd
+				break
+			}
+			parent := filepath.Dir(wd)
+			if parent == wd {
+				break
+			}
+			wd = parent
 		}
-		return
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run=^TestSeccompOnBlock_LogAndKill_GCPressure$")
-	cmd.Env = append(os.Environ(), seccompOnBlockGCPressureEnv+"=1")
+	cmd := exec.Command("go", "test", "-tags=integration", "./internal/integration", "-run", "^TestSeccompOnBlock_LogAndKill$", "-count=20")
+	cmd.Dir = repoRoot
+	cmd.Env = append(os.Environ(),
+		"GOGC=1",
+		"GOMEMLIMIT=64MiB",
+	)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/internal/integration/seccomp_onblock_test.go
+++ b/internal/integration/seccomp_onblock_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"sync"
 	"syscall"
 	"testing"
@@ -345,31 +346,25 @@ func startWrappedChild(t *testing.T, cfgJSON string, cmdArg string) (syscall.Wai
 // ---------- Tests ----------
 
 func TestSeccompOnBlock_LogAndKill_GCPressure(t *testing.T) {
-	repoRoot := "."
-	if wd, err := os.Getwd(); err == nil {
-		for {
-			if _, statErr := os.Stat(filepath.Join(wd, "go.mod")); statErr == nil {
-				repoRoot = wd
-				break
-			}
-			parent := filepath.Dir(wd)
-			if parent == wd {
-				break
-			}
-			wd = parent
-		}
-	}
+	oldGCPercent := debug.SetGCPercent(1)
+	oldMemLimit := debug.SetMemoryLimit(64 << 20)
+	defer debug.SetGCPercent(oldGCPercent)
+	defer debug.SetMemoryLimit(oldMemLimit)
 
-	cmd := exec.Command("go", "test", "-tags=integration", "./internal/integration", "-run", "^TestSeccompOnBlock_LogAndKill$", "-count=20")
-	cmd.Dir = repoRoot
+	runtime.GC()
+
+	cmd := exec.Command(
+		os.Args[0],
+		"-test.run=^TestSeccompOnBlock_LogAndKill$",
+		"-test.count=20",
+	)
 	cmd.Env = append(os.Environ(),
 		"GOGC=1",
 		"GOMEMLIMIT=64MiB",
 	)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	out, err := cmd.CombinedOutput()
 
-	require.NoError(t, cmd.Run())
+	require.NoErrorf(t, err, "child output:\n%s", out)
 }
 
 func TestSeccompOnBlock_Errno(t *testing.T) {

--- a/internal/integration/seccomp_onblock_test.go
+++ b/internal/integration/seccomp_onblock_test.go
@@ -239,12 +239,9 @@ func startWrappedChild(t *testing.T, cfgJSON string, cmdArg string) (syscall.Wai
 	if err != nil {
 		return 0, nil, fmt.Errorf("socketpair: %w", err)
 	}
-	parentFD := sp[0]
-	childFD := sp[1]
-	// childEnd will be dup'd into the wrapper via ExtraFiles (fd 3); we close
-	// our copy immediately after start. parentEnd stays open for the duration.
-	defer unix.Close(parentFD)
-	childEnd := os.NewFile(uintptr(childFD), "child-end")
+	parentEnd := os.NewFile(uintptr(sp[0]), "parent-end")
+	childEnd := os.NewFile(uintptr(sp[1]), "child-end")
+	defer parentEnd.Close()
 	// Note: passing via ExtraFiles causes Go to dup-and-clexec. We keep
 	// childEnd alive until after cmd.Start so the fd survives the fork.
 	defer childEnd.Close()
@@ -284,8 +281,6 @@ func startWrappedChild(t *testing.T, cfgJSON string, cmdArg string) (syscall.Wai
 	var notifyFile *os.File
 	if hasNotify {
 		// Receive the notify fd from the wrapper.
-		parentEnd := os.NewFile(uintptr(parentFD), "parent-end")
-		// parentEnd shares the fd with parentFD; do NOT double-close.
 		recvd, rerr := unixmon.RecvFD(parentEnd)
 		if rerr != nil {
 			_ = cmd.Process.Kill()
@@ -295,7 +290,7 @@ func startWrappedChild(t *testing.T, cfgJSON string, cmdArg string) (syscall.Wai
 		notifyFile = recvd
 
 		// ACK so the wrapper proceeds to exec.
-		if _, werr := unix.Write(parentFD, []byte{1}); werr != nil {
+		if _, werr := parentEnd.Write([]byte{1}); werr != nil {
 			_ = notifyFile.Close()
 			_ = cmd.Process.Kill()
 			_, _ = cmd.Process.Wait()


### PR DESCRIPTION
## Summary
- add a GC-pressure integration harness that reliably reproduces the seccomp notify handshake failure before the fix
- refactor `startWrappedChild` to use single-owner `*os.File` socket handles for both fd receive and ACK writes
- keep the change local to `internal/integration/seccomp_onblock_test.go`

## Root Cause
The flaky integration failure came from mixed ownership of the same socket fd in the test helper. `startWrappedChild` kept a raw socket integer while also wrapping that same fd in `*os.File`, then used the wrapper for `RecvFD` and the raw fd for the ACK write. Under GC pressure, the short-lived `*os.File` could finalize and close or recycle the descriptor before the raw ACK write ran, producing `ACK: invalid argument`, `RecvFD: bad file descriptor`, and wrapper-side ACK EOF failures.

## Impact
This hardens the seccomp `on_block=log_and_kill` integration coverage and removes a post-merge CI flake without changing product behavior.

## Validation
- `go test -tags=integration ./internal/integration -run 'TestSeccompOnBlock_(Errno|Kill|Log|LogAndKill|LogAndKill_GCPressure|LogAndKill_ConcurrentCalls)$' -count=1`
- `go test ./... -count=1`
- `GOOS=windows go build ./...`