### PR TITLE
wtp/store: wire drop-class counters + structured WARN

### DIFF
--- a/docs/superpowers/plans/2026-04-25-wtp-drop-class-counters.md
+++ b/docs/superpowers/plans/2026-04-25-wtp-drop-class-counters.md
@@ -1,0 +1,985 @@
+# WTP Drop-Class Counters Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the five `wtp_dropped_invalid_*_total` counters at the existing reject sites in `internal/store/watchtower/AppendEvent`, plus structured WARN logs on every drop.
+
+**Architecture:** Three private methods on `*Store` — `recordSequenceOverflow`, `recordCompactEncodeFailure`, `recordCanonicalFailure` — each owning one reject class. Helpers increment the right counter on `*WTPMetrics` (nil-safe) and emit a structured WARN with reason/event_seq/event_gen/session_id/agent_id. Each `AppendEvent` reject site calls one helper before its existing `return fmt.Errorf(...)`, so error semantics are preserved exactly.
+
+**Tech Stack:** Go, `log/slog`, `errors.Is`, existing `internal/metrics.WTPMetrics`.
+
+**Spec:** `docs/superpowers/specs/2026-04-25-wtp-drop-class-counters-design.md`
+
+---
+
+## File Structure
+
+| File | Purpose |
+|---|---|
+| `internal/store/watchtower/append.go` (modify) | Houses `AppendEvent` and the three new private helpers. Existing reject-site code calls the helpers; existing error returns stay byte-identical. |
+| `internal/store/watchtower/append_drop_internal_test.go` (NEW, package `watchtower`) | Direct helper invocations for all 5 drop classes. Internal because it touches unexported helpers AND because two classes (`ErrInvalidMapper`, `ErrInvalidUTF8`) are unreachable through `watchtower.New` due to construction-time validation. |
+| `internal/store/watchtower/append_drop_test.go` (NEW, package `watchtower_test`) | End-to-end `watchtower.New` + `AppendEvent` integration for the three reachable drop classes (timestamp, mapper-failure, sequence-overflow) plus a happy-path negative test. |
+| `internal/metrics/wtp.go` (modify) | Update the "NOT YET WIRED — emits zero" doc comments at lines 463-467 to point at `AppendEvent` as the live producer. No code changes. |
+
+The helpers stay in `append.go` (alongside the call sites) rather than a separate file because there are only three of them, they are tightly coupled to `AppendEvent`'s error handling, and splitting them would force a reader to context-switch when reasoning about each reject site.
+
+---
+
+## Task 1: Add `recordSequenceOverflow` helper (TDD)
+
+**Files:**
+- Modify: `internal/store/watchtower/append.go`
+- Test: `internal/store/watchtower/append_drop_internal_test.go` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/store/watchtower/append_drop_internal_test.go`:
+
+```go
+package watchtower
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/metrics"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// newDropTestStore builds a minimal Store wired with a counter-asserting
+// *WTPMetrics and a buffered JSON slog handler so the recordX helpers
+// can be unit-tested without standing up a WAL / transport / chain.
+// Returns the Store, the metrics handle, and the log buffer.
+func newDropTestStore(t *testing.T) (*Store, *metrics.WTPMetrics, *bytes.Buffer) {
+	t.Helper()
+	col := metrics.New()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	s := &Store{
+		opts: Options{
+			Logger:    logger,
+			SessionID: "s-test",
+			AgentID:   "a-test",
+		},
+		metrics: col.WTP(),
+	}
+	return s, col.WTP(), &buf
+}
+
+// findWarnEntry returns the single decoded WARN log entry from buf, or
+// fails the test if zero or more than one entry is present.
+func findWarnEntry(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 1 || lines[0] == "" {
+		t.Fatalf("expected exactly 1 WARN log entry, got %d: %q", len(lines), buf.String())
+	}
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &entry); err != nil {
+		t.Fatalf("parse log entry: %v", err)
+	}
+	return entry
+}
+
+func TestRecordSequenceOverflow_IncrementsCounterAndEmitsWarn(t *testing.T) {
+	s, m, buf := newDropTestStore(t)
+
+	ev := types.Event{
+		Timestamp: time.Unix(1700000000, 0),
+		Chain:     &types.ChainState{Sequence: 99, Generation: 7},
+	}
+	s.recordSequenceOverflow(ev)
+
+	if got := m.DroppedSequenceOverflow(); got != 1 {
+		t.Fatalf("DroppedSequenceOverflow() = %d, want 1", got)
+	}
+
+	entry := findWarnEntry(t, buf)
+	if got := entry["reason"]; got != "sequence_overflow" {
+		t.Fatalf("reason = %v, want sequence_overflow", got)
+	}
+	if got := entry["event_seq"]; got != float64(99) {
+		t.Fatalf("event_seq = %v, want 99", got)
+	}
+	if got := entry["event_gen"]; got != float64(7) {
+		t.Fatalf("event_gen = %v, want 7", got)
+	}
+	if got := entry["session_id"]; got != "s-test" {
+		t.Fatalf("session_id = %v, want s-test", got)
+	}
+	if got := entry["agent_id"]; got != "a-test" {
+		t.Fatalf("agent_id = %v, want a-test", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+go test -run TestRecordSequenceOverflow_IncrementsCounterAndEmitsWarn ./internal/store/watchtower/
+```
+
+Expected: FAIL with `s.recordSequenceOverflow undefined` (compile error).
+
+- [ ] **Step 3: Implement `recordSequenceOverflow`**
+
+Add to `internal/store/watchtower/append.go` (just below the `AppendEvent` function, after `latchFatal`):
+
+```go
+// recordSequenceOverflow increments wtp_dropped_sequence_overflow_total
+// and emits a structured WARN. Called from AppendEvent's
+// ev.Chain.Sequence > math.MaxInt64 branch BEFORE the existing error
+// return so the counter increments exactly once per drop and the WARN
+// gives operators triage context (which (gen, seq) was rejected).
+//
+// No underlying err is logged because this is our own range check, not
+// a wrapped sentinel — the message is deterministic from event_seq.
+func (s *Store) recordSequenceOverflow(ev types.Event) {
+	s.metrics.IncDroppedSequenceOverflow(1)
+	s.opts.Logger.LogAttrs(context.Background(), slog.LevelWarn,
+		"wtp: dropping event before WAL append",
+		slog.String("reason", "sequence_overflow"),
+		slog.Uint64("event_seq", ev.Chain.Sequence),
+		slog.Uint64("event_gen", uint64(ev.Chain.Generation)),
+		slog.String("session_id", s.opts.SessionID),
+		slog.String("agent_id", s.opts.AgentID))
+}
+```
+
+Add `"log/slog"` to the import block at the top of `append.go` if not already present.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+go test -run TestRecordSequenceOverflow_IncrementsCounterAndEmitsWarn ./internal/store/watchtower/
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/store/watchtower/append.go internal/store/watchtower/append_drop_internal_test.go
+git commit -m "feat(wtp/store): add recordSequenceOverflow helper
+
+Increments wtp_dropped_sequence_overflow_total and emits a structured
+WARN with reason/event_seq/event_gen/session_id/agent_id. Helper called
+from AppendEvent's Chain.Sequence range check (wired in a later task)."
+```
+
+---
+
+## Task 2: Add `recordCompactEncodeFailure` helper with 3-way classification (TDD)
+
+**Files:**
+- Modify: `internal/store/watchtower/append.go`
+- Test: `internal/store/watchtower/append_drop_internal_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/store/watchtower/append_drop_internal_test.go`:
+
+```go
+import (
+	// ... existing imports ...
+	"errors"
+	"fmt"
+
+	"github.com/agentsh/agentsh/internal/store/watchtower/compact"
+)
+
+func TestRecordCompactEncodeFailure_ClassifiesInvalidMapper(t *testing.T) {
+	s, m, buf := newDropTestStore(t)
+
+	ev := types.Event{
+		Timestamp: time.Unix(1700000000, 0),
+		Chain:     &types.ChainState{Sequence: 1, Generation: 1},
+	}
+	s.recordCompactEncodeFailure(compact.ErrInvalidMapper, ev)
+
+	if got := m.DroppedInvalidMapper(); got != 1 {
+		t.Fatalf("DroppedInvalidMapper() = %d, want 1", got)
+	}
+	if got := m.DroppedInvalidTimestamp(); got != 0 {
+		t.Fatalf("DroppedInvalidTimestamp() = %d, want 0 (wrong branch fired)", got)
+	}
+	if got := m.DroppedMapperFailure(); got != 0 {
+		t.Fatalf("DroppedMapperFailure() = %d, want 0 (wrong branch fired)", got)
+	}
+
+	entry := findWarnEntry(t, buf)
+	if got := entry["reason"]; got != "invalid_mapper" {
+		t.Fatalf("reason = %v, want invalid_mapper", got)
+	}
+	if got := entry["err"]; got == nil || !strings.Contains(got.(string), "mapper is required") {
+		t.Fatalf("err attr = %v, want non-empty containing %q", got, "mapper is required")
+	}
+}
+
+func TestRecordCompactEncodeFailure_ClassifiesInvalidTimestamp(t *testing.T) {
+	s, m, buf := newDropTestStore(t)
+
+	ev := types.Event{
+		Timestamp: time.Unix(1700000000, 0),
+		Chain:     &types.ChainState{Sequence: 2, Generation: 1},
+	}
+	wrapped := fmt.Errorf("compact.Encode: %w", compact.ErrInvalidTimestamp)
+	s.recordCompactEncodeFailure(wrapped, ev)
+
+	if got := m.DroppedInvalidTimestamp(); got != 1 {
+		t.Fatalf("DroppedInvalidTimestamp() = %d, want 1", got)
+	}
+	if got := m.DroppedInvalidMapper(); got != 0 {
+		t.Fatalf("DroppedInvalidMapper() = %d, want 0 (wrong branch fired)", got)
+	}
+	if got := m.DroppedMapperFailure(); got != 0 {
+		t.Fatalf("DroppedMapperFailure() = %d, want 0 (wrong branch fired)", got)
+	}
+
+	entry := findWarnEntry(t, buf)
+	if got := entry["reason"]; got != "invalid_timestamp" {
+		t.Fatalf("reason = %v, want invalid_timestamp", got)
+	}
+}
+
+func TestRecordCompactEncodeFailure_ClassifiesMapperFailureCatchAll(t *testing.T) {
+	s, m, buf := newDropTestStore(t)
+
+	ev := types.Event{
+		Timestamp: time.Unix(1700000000, 0),
+		Chain:     &types.ChainState{Sequence: 3, Generation: 1},
+	}
+	// A mapper-side error wrapped exactly like compact/encoder.go:71 does.
+	wrapped := fmt.Errorf("compact mapper: %w", errors.New("synthetic mapper failure"))
+	s.recordCompactEncodeFailure(wrapped, ev)
+
+	if got := m.DroppedMapperFailure(); got != 1 {
+		t.Fatalf("DroppedMapperFailure() = %d, want 1", got)
+	}
+	if got := m.DroppedInvalidMapper(); got != 0 {
+		t.Fatalf("DroppedInvalidMapper() = %d, want 0 (wrong branch fired)", got)
+	}
+	if got := m.DroppedInvalidTimestamp(); got != 0 {
+		t.Fatalf("DroppedInvalidTimestamp() = %d, want 0 (wrong branch fired)", got)
+	}
+
+	entry := findWarnEntry(t, buf)
+	if got := entry["reason"]; got != "mapper_failure" {
+		t.Fatalf("reason = %v, want mapper_failure", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+go test -run TestRecordCompactEncodeFailure ./internal/store/watchtower/
+```
+
+Expected: FAIL with `s.recordCompactEncodeFailure undefined` (compile error).
+
+- [ ] **Step 3: Implement `recordCompactEncodeFailure`**
+
+Add to `internal/store/watchtower/append.go` immediately below `recordSequenceOverflow`:
+
+```go
+// recordCompactEncodeFailure inspects err for the compact.Encode
+// sentinels and routes the drop to the matching counter + WARN.
+// Called from AppendEvent's compact.Encode error branch BEFORE the
+// existing error return.
+//
+// Classification priority (errors.Is order):
+//   - compact.ErrInvalidMapper    → IncDroppedInvalidMapper / "invalid_mapper"
+//   - compact.ErrInvalidTimestamp → IncDroppedInvalidTimestamp / "invalid_timestamp"
+//   - (fallthrough)               → IncDroppedMapperFailure / "mapper_failure"
+//
+// The fallthrough catches the mapper-wrapped error returned by
+// compact/encoder.go:71 (`fmt.Errorf("compact mapper: %w", err)`),
+// which intentionally does not preserve a typed sentinel. The
+// compact.ErrMissingChain sentinel is unreachable from AppendEvent
+// because the ev.Chain == nil check earlier in the function bails
+// before compact.Encode runs; if a future change makes it reachable,
+// it falls into the mapper_failure catch-all and surfaces in logs.
+func (s *Store) recordCompactEncodeFailure(err error, ev types.Event) {
+	var reason string
+	switch {
+	case errors.Is(err, compact.ErrInvalidMapper):
+		s.metrics.IncDroppedInvalidMapper(1)
+		reason = "invalid_mapper"
+	case errors.Is(err, compact.ErrInvalidTimestamp):
+		s.metrics.IncDroppedInvalidTimestamp(1)
+		reason = "invalid_timestamp"
+	default:
+		s.metrics.IncDroppedMapperFailure(1)
+		reason = "mapper_failure"
+	}
+	s.opts.Logger.LogAttrs(context.Background(), slog.LevelWarn,
+		"wtp: dropping event before WAL append",
+		slog.String("reason", reason),
+		slog.String("err", err.Error()),
+		slog.Uint64("event_seq", ev.Chain.Sequence),
+		slog.Uint64("event_gen", uint64(ev.Chain.Generation)),
+		slog.String("session_id", s.opts.SessionID),
+		slog.String("agent_id", s.opts.AgentID))
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+go test -run TestRecordCompactEncodeFailure ./internal/store/watchtower/
+```
+
+Expected: PASS (3 sub-tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/store/watchtower/append.go internal/store/watchtower/append_drop_internal_test.go
+git commit -m "feat(wtp/store): add recordCompactEncodeFailure with 3-way classification
+
+errors.Is checks against compact.ErrInvalidMapper / ErrInvalidTimestamp
+route to their respective counters; everything else is the mapper-side
+catch-all (mirrors the wrapping at compact/encoder.go:71). All three
+branches emit the same WARN shape with a class-specific reason label."
+```
+
+---
+
+## Task 3: Add `recordCanonicalFailure` helper (TDD)
+
+**Files:**
+- Modify: `internal/store/watchtower/append.go`
+- Test: `internal/store/watchtower/append_drop_internal_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `internal/store/watchtower/append_drop_internal_test.go`:
+
+```go
+import (
+	// ... existing imports ...
+	"github.com/agentsh/agentsh/internal/store/watchtower/chain"
+)
+
+func TestRecordCanonicalFailure_ClassifiesInvalidUTF8(t *testing.T) {
+	s, m, buf := newDropTestStore(t)
+
+	ev := types.Event{
+		Timestamp: time.Unix(1700000000, 0),
+		Chain:     &types.ChainState{Sequence: 4, Generation: 2},
+	}
+	wrapped := fmt.Errorf("chain.EncodeCanonical: %w", chain.ErrInvalidUTF8)
+	s.recordCanonicalFailure(wrapped, ev)
+
+	if got := m.DroppedInvalidUTF8(); got != 1 {
+		t.Fatalf("DroppedInvalidUTF8() = %d, want 1", got)
+	}
+
+	entry := findWarnEntry(t, buf)
+	if got := entry["reason"]; got != "invalid_utf8" {
+		t.Fatalf("reason = %v, want invalid_utf8", got)
+	}
+	if got := entry["event_seq"]; got != float64(4) {
+		t.Fatalf("event_seq = %v, want 4", got)
+	}
+	if got := entry["event_gen"]; got != float64(2) {
+		t.Fatalf("event_gen = %v, want 2", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+go test -run TestRecordCanonicalFailure_ClassifiesInvalidUTF8 ./internal/store/watchtower/
+```
+
+Expected: FAIL with `s.recordCanonicalFailure undefined`.
+
+- [ ] **Step 3: Implement `recordCanonicalFailure`**
+
+Add to `internal/store/watchtower/append.go` immediately below `recordCompactEncodeFailure`:
+
+```go
+// recordCanonicalFailure increments wtp_dropped_invalid_utf8_total
+// and emits a structured WARN. Called from AppendEvent's
+// chain.EncodeCanonical error branch BEFORE the existing error
+// return.
+//
+// chain.EncodeCanonical's only error sentinel today is
+// chain.ErrInvalidUTF8 — the function returns that or nil. This
+// helper unconditionally classifies as invalid_utf8 rather than
+// errors.Is-checking, so a future expansion of EncodeCanonical's
+// error surface will fall through here and surface as invalid_utf8
+// until the helper is updated. That posture is deliberate: it keeps
+// the call site one line and matches the today-only contract; if a
+// new sentinel is added, the helper grows a switch like
+// recordCompactEncodeFailure.
+func (s *Store) recordCanonicalFailure(err error, ev types.Event) {
+	s.metrics.IncDroppedInvalidUTF8(1)
+	s.opts.Logger.LogAttrs(context.Background(), slog.LevelWarn,
+		"wtp: dropping event before WAL append",
+		slog.String("reason", "invalid_utf8"),
+		slog.String("err", err.Error()),
+		slog.Uint64("event_seq", ev.Chain.Sequence),
+		slog.Uint64("event_gen", uint64(ev.Chain.Generation)),
+		slog.String("session_id", s.opts.SessionID),
+		slog.String("agent_id", s.opts.AgentID))
+}
+```
+
+Add `"github.com/agentsh/agentsh/internal/store/watchtower/chain"` to the imports if not already present (it likely already is).
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+go test -run TestRecordCanonicalFailure_ClassifiesInvalidUTF8 ./internal/store/watchtower/
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/store/watchtower/append.go internal/store/watchtower/append_drop_internal_test.go
+git commit -m "feat(wtp/store): add recordCanonicalFailure helper
+
+Increments wtp_dropped_invalid_utf8_total and emits a structured WARN.
+chain.EncodeCanonical's only sentinel today is ErrInvalidUTF8; the
+helper unconditionally classifies as invalid_utf8 to match that
+contract. Future sentinels would extend the helper into a switch."
+```
+
+---
+
+## Task 4: Wire helpers into `AppendEvent` reject sites
+
+**Files:**
+- Modify: `internal/store/watchtower/append.go` (3 reject sites)
+
+This task adds NO new tests — the helpers are already covered by Task 1-3 internal tests; the wiring is verified end-to-end by Task 5's external tests.
+
+- [ ] **Step 1: Wire `recordSequenceOverflow` at the sequence range check**
+
+In `internal/store/watchtower/append.go`, find the existing block:
+
+```go
+	if ev.Chain.Sequence > math.MaxInt64 {
+		return fmt.Errorf("watchtower: ev.Chain.Sequence %d overflows int64", ev.Chain.Sequence)
+	}
+```
+
+Replace with:
+
+```go
+	if ev.Chain.Sequence > math.MaxInt64 {
+		s.recordSequenceOverflow(ev)
+		return fmt.Errorf("watchtower: ev.Chain.Sequence %d overflows int64", ev.Chain.Sequence)
+	}
+```
+
+- [ ] **Step 2: Wire `recordCompactEncodeFailure` at the compact.Encode call**
+
+Find:
+
+```go
+	ce, err := compact.Encode(s.opts.Mapper, ev)
+	if err != nil {
+		return fmt.Errorf("compact.Encode: %w", err)
+	}
+```
+
+Replace with:
+
+```go
+	ce, err := compact.Encode(s.opts.Mapper, ev)
+	if err != nil {
+		s.recordCompactEncodeFailure(err, ev)
+		return fmt.Errorf("compact.Encode: %w", err)
+	}
+```
+
+- [ ] **Step 3: Wire `recordCanonicalFailure` at the chain.EncodeCanonical call**
+
+Find:
+
+```go
+	canonicalIntegrity, err := chain.EncodeCanonical(integrityRec)
+	if err != nil {
+		// chain.ErrInvalidUTF8 propagates here for any peer-derived
+		// field that slipped through upstream validation. Task 23
+		// follow-up wires this into wtp_dropped_invalid_utf8_total;
+		// today it surfaces to the caller.
+		return fmt.Errorf("chain.EncodeCanonical: %w", err)
+	}
+```
+
+Replace with:
+
+```go
+	canonicalIntegrity, err := chain.EncodeCanonical(integrityRec)
+	if err != nil {
+		s.recordCanonicalFailure(err, ev)
+		return fmt.Errorf("chain.EncodeCanonical: %w", err)
+	}
+```
+
+(The stale "Task 23 follow-up" comment is removed because this commit IS that follow-up.)
+
+- [ ] **Step 4: Update the `AppendEvent` SCOPE NOTE**
+
+Find the comment block at the top of `AppendEvent` ending with:
+
+```go
+// SCOPE NOTE: this is Task 23's core transactional path. The full
+// spec additionally routes compact.ErrInvalidMapper /
+// ErrInvalidTimestamp / mapper-wrapped / sequence-overflow /
+// chain.ErrInvalidUTF8 through per-class drop counters
+// (wtp_dropped_invalid_*_total) with structured WARN logs. That
+// counter-wiring layer is follow-up work alongside the Task 22a
+// sink-failure counter surface; today those errors propagate to the
+// caller as wrapped errors.
+```
+
+Replace the SCOPE NOTE block with:
+
+```go
+// Per-class drop counters: every reject path (sequence overflow,
+// compact.Encode classification, chain.EncodeCanonical) increments
+// the matching wtp_dropped_invalid_*_total counter and emits a
+// structured WARN with reason/event_seq/event_gen/session_id/agent_id
+// before the wrapped error is returned. See recordSequenceOverflow,
+// recordCompactEncodeFailure, recordCanonicalFailure below.
+```
+
+- [ ] **Step 5: Run the existing AppendEvent tests to verify no regression**
+
+```bash
+go test ./internal/store/watchtower/...
+```
+
+Expected: PASS — all existing AppendEvent tests should still pass because the helpers are pure side-effects (counter + WARN); the returned error is unchanged byte-for-byte.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/store/watchtower/append.go
+git commit -m "feat(wtp/store): wire drop-class helpers at AppendEvent reject sites
+
+Three call sites: sequence-overflow check, compact.Encode error,
+chain.EncodeCanonical error. Each calls the matching record* helper
+before returning the existing wrapped error — error semantics are
+preserved exactly. Updates the AppendEvent SCOPE NOTE to reflect that
+the per-class counter wiring is now live (this commit closes the
+Task 23 follow-up gap)."
+```
+
+---
+
+## Task 5: Add external integration tests (3 reachable drop classes + happy path)
+
+**Files:**
+- Test: `internal/store/watchtower/append_drop_test.go` (NEW, package `watchtower_test`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/store/watchtower/append_drop_test.go`:
+
+```go
+package watchtower_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/audit"
+	"github.com/agentsh/agentsh/internal/metrics"
+	"github.com/agentsh/agentsh/internal/store/watchtower"
+	"github.com/agentsh/agentsh/internal/store/watchtower/compact"
+	"github.com/agentsh/agentsh/internal/store/watchtower/testserver"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// failingMapper is a Mapper that always returns the configured error.
+// Used to drive AppendEvent into the mapper_failure catch-all branch
+// without depending on a particular OCSF mapper's failure modes.
+type failingMapper struct{ err error }
+
+func (f failingMapper) Map(_ types.Event) (compact.MappedEvent, error) {
+	return compact.MappedEvent{}, f.err
+}
+
+// dropTestFixture wires a Store with a counter-asserting collector and
+// a captured logger so each test can assert the precise observability
+// emitted on a drop. The Store is constructed via watchtower.New so
+// the test exercises the real reject-site wiring, not the helpers
+// directly. A testserver is started so Options.Dialer is satisfied;
+// the transport never actually delivers anything in these tests
+// because every test path errors before WAL append.
+type dropTestFixture struct {
+	store     *watchtower.Store
+	collector *metrics.Collector
+	logBuf    *bytes.Buffer
+}
+
+func newDropFixture(t *testing.T, optsMutator func(*watchtower.Options)) *dropTestFixture {
+	t.Helper()
+	col := metrics.New()
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	srv := testserver.New(testserver.Options{})
+	t.Cleanup(srv.Close)
+
+	opts := watchtower.Options{
+		WALDir:          t.TempDir(),
+		Mapper:          compact.StubMapper{},
+		Allocator:       audit.NewSequenceAllocator(),
+		AgentID:         "a-test",
+		SessionID:       "s-test",
+		KeyFingerprint:  "sha256:drop-test",
+		HMACKeyID:       "k1",
+		HMACSecret:      bytes.Repeat([]byte("a"), 32),
+		HMACAlgorithm:   "hmac-sha256",
+		BatchMaxRecords: 8,
+		BatchMaxBytes:   8 * 1024,
+		BatchMaxAge:     50 * time.Millisecond,
+		AllowStubMapper: true,
+		Dialer:          srv.DialerFor(),
+		Metrics:         col,
+		Logger:          logger,
+	}
+	if optsMutator != nil {
+		optsMutator(&opts)
+	}
+
+	s, err := watchtower.New(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("watchtower.New: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	return &dropTestFixture{store: s, collector: col, logBuf: &logBuf}
+}
+
+// findWarnEntry parses the captured log buffer and returns the single
+// drop WARN entry. Fails the test if zero or multiple entries match.
+func (f *dropTestFixture) findDropWarn(t *testing.T) map[string]any {
+	t.Helper()
+	var matches []map[string]any
+	for _, line := range strings.Split(strings.TrimRight(f.logBuf.String(), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("parse log line %q: %v", line, err)
+		}
+		if entry["msg"] == "wtp: dropping event before WAL append" {
+			matches = append(matches, entry)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 drop WARN, got %d (full buf: %q)", len(matches), f.logBuf.String())
+	}
+	return matches[0]
+}
+
+func TestAppendEvent_DropsOnInvalidTimestamp(t *testing.T) {
+	f := newDropFixture(t, nil)
+
+	ev := types.Event{
+		Type:      "exec",
+		SessionID: "s-test",
+		Timestamp: time.Time{}, // zero value trips compact.ErrInvalidTimestamp
+		Chain:     &types.ChainState{Sequence: 1, Generation: 1},
+	}
+	err := f.store.AppendEvent(context.Background(), ev)
+	if err == nil {
+		t.Fatal("AppendEvent: expected error, got nil")
+	}
+	if !errors.Is(err, compact.ErrInvalidTimestamp) {
+		t.Fatalf("error = %v, want errors.Is(_, ErrInvalidTimestamp)", err)
+	}
+
+	if got := f.collector.WTP().DroppedInvalidTimestamp(); got != 1 {
+		t.Fatalf("DroppedInvalidTimestamp() = %d, want 1", got)
+	}
+
+	entry := f.findDropWarn(t)
+	if got := entry["reason"]; got != "invalid_timestamp" {
+		t.Fatalf("reason = %v, want invalid_timestamp", got)
+	}
+	if got := entry["event_seq"]; got != float64(1) {
+		t.Fatalf("event_seq = %v, want 1", got)
+	}
+	if got := entry["event_gen"]; got != float64(1) {
+		t.Fatalf("event_gen = %v, want 1", got)
+	}
+	if got := entry["session_id"]; got != "s-test" {
+		t.Fatalf("session_id = %v, want s-test", got)
+	}
+	if got := entry["agent_id"]; got != "a-test" {
+		t.Fatalf("agent_id = %v, want a-test", got)
+	}
+}
+
+func TestAppendEvent_DropsOnMapperFailure(t *testing.T) {
+	mapperErr := errors.New("synthetic mapper failure")
+	f := newDropFixture(t, func(opts *watchtower.Options) {
+		opts.Mapper = failingMapper{err: mapperErr}
+		opts.AllowStubMapper = false
+	})
+
+	ev := types.Event{
+		Type:      "exec",
+		SessionID: "s-test",
+		Timestamp: time.Now(),
+		Chain:     &types.ChainState{Sequence: 1, Generation: 1},
+	}
+	err := f.store.AppendEvent(context.Background(), ev)
+	if err == nil {
+		t.Fatal("AppendEvent: expected error, got nil")
+	}
+	if !errors.Is(err, mapperErr) {
+		t.Fatalf("error = %v, want errors.Is(_, mapperErr)", err)
+	}
+
+	if got := f.collector.WTP().DroppedMapperFailure(); got != 1 {
+		t.Fatalf("DroppedMapperFailure() = %d, want 1", got)
+	}
+
+	entry := f.findDropWarn(t)
+	if got := entry["reason"]; got != "mapper_failure" {
+		t.Fatalf("reason = %v, want mapper_failure", got)
+	}
+	if got := entry["err"]; got == nil || !strings.Contains(got.(string), "synthetic mapper failure") {
+		t.Fatalf("err attr = %v, want non-empty containing %q", got, "synthetic mapper failure")
+	}
+}
+
+func TestAppendEvent_DropsOnSequenceOverflow(t *testing.T) {
+	f := newDropFixture(t, nil)
+
+	ev := types.Event{
+		Type:      "exec",
+		SessionID: "s-test",
+		Timestamp: time.Now(),
+		Chain:     &types.ChainState{Sequence: math.MaxInt64 + 1, Generation: 1},
+	}
+	err := f.store.AppendEvent(context.Background(), ev)
+	if err == nil {
+		t.Fatal("AppendEvent: expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "overflows int64") {
+		t.Fatalf("error = %v, want message containing %q", err, "overflows int64")
+	}
+
+	if got := f.collector.WTP().DroppedSequenceOverflow(); got != 1 {
+		t.Fatalf("DroppedSequenceOverflow() = %d, want 1", got)
+	}
+
+	entry := f.findDropWarn(t)
+	if got := entry["reason"]; got != "sequence_overflow" {
+		t.Fatalf("reason = %v, want sequence_overflow", got)
+	}
+	// No "err" attr expected — sequence_overflow is our own range check, not a wrapped sentinel.
+	if _, present := entry["err"]; present {
+		t.Fatalf("err attr present in sequence_overflow WARN; want absent")
+	}
+}
+
+func TestAppendEvent_HappyPath_NoDrops(t *testing.T) {
+	// Explicit no-op mutator so we go through the same fixture path as
+	// the failing tests; the contract under test is "valid input bumps
+	// no drop counter and emits no drop WARN."
+	f := newDropFixture(t, nil)
+
+	ev := types.Event{
+		Type:      "exec",
+		SessionID: "s-test",
+		Timestamp: time.Now(),
+		Chain:     &types.ChainState{Sequence: 1, Generation: 1},
+	}
+	if err := f.store.AppendEvent(context.Background(), ev); err != nil {
+		t.Fatalf("AppendEvent (happy path): %v", err)
+	}
+
+	wtp := f.collector.WTP()
+	if got := wtp.DroppedSequenceOverflow(); got != 0 {
+		t.Errorf("DroppedSequenceOverflow() = %d, want 0", got)
+	}
+	if got := wtp.DroppedInvalidMapper(); got != 0 {
+		t.Errorf("DroppedInvalidMapper() = %d, want 0", got)
+	}
+	if got := wtp.DroppedInvalidTimestamp(); got != 0 {
+		t.Errorf("DroppedInvalidTimestamp() = %d, want 0", got)
+	}
+	if got := wtp.DroppedMapperFailure(); got != 0 {
+		t.Errorf("DroppedMapperFailure() = %d, want 0", got)
+	}
+	if got := wtp.DroppedInvalidUTF8(); got != 0 {
+		t.Errorf("DroppedInvalidUTF8() = %d, want 0", got)
+	}
+
+	// No drop WARN should have fired.
+	for _, line := range strings.Split(strings.TrimRight(f.logBuf.String(), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		if entry["msg"] == "wtp: dropping event before WAL append" {
+			t.Fatalf("happy-path append emitted a drop WARN: %v", entry)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run the new tests to verify they pass**
+
+```bash
+go test -run "TestAppendEvent_DropsOn|TestAppendEvent_HappyPath_NoDrops" -v ./internal/store/watchtower/
+```
+
+Expected: PASS for all four tests (`TestAppendEvent_DropsOnInvalidTimestamp`, `TestAppendEvent_DropsOnMapperFailure`, `TestAppendEvent_DropsOnSequenceOverflow`, `TestAppendEvent_HappyPath_NoDrops`).
+
+- [ ] **Step 3: Run the full watchtower suite to confirm no regression**
+
+```bash
+go test ./internal/store/watchtower/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/store/watchtower/append_drop_test.go
+git commit -m "test(wtp/store): add end-to-end drop-class tests via AppendEvent
+
+Three reachable drop classes (invalid_timestamp, mapper_failure,
+sequence_overflow) plus a happy-path negative test. Each failing case
+asserts the wrapped error is preserved (errors.Is for sentinels,
+substring match for the home-grown sequence-overflow message), the
+matching counter increments exactly once, and the drop WARN carries
+reason/event_seq/event_gen/session_id/agent_id.
+
+The happy-path test catches a regression where every successful append
+accidentally bumps a drop counter."
+```
+
+---
+
+## Task 6: Update metrics doc comments
+
+**Files:**
+- Modify: `internal/metrics/wtp.go` (lines 463-467)
+
+- [ ] **Step 1: Update the "NOT YET WIRED" status comments**
+
+In `internal/metrics/wtp.go`, find this block (around line 463):
+
+```go
+//	wtp_dropped_invalid_utf8_total              AppendEvent (Task 23)                    NOT YET WIRED — emits zero
+//	wtp_dropped_sequence_overflow_total         AppendEvent (Task 23)                    NOT YET WIRED — emits zero
+//	wtp_dropped_invalid_mapper_total            AppendEvent (Task 23)                    NOT YET WIRED — emits zero
+//	wtp_dropped_invalid_timestamp_total         AppendEvent (Task 23)                    NOT YET WIRED — emits zero
+//	wtp_dropped_mapper_failure_total            AppendEvent (Task 23)                    NOT YET WIRED — emits zero
+```
+
+Replace with:
+
+```go
+//	wtp_dropped_invalid_utf8_total              AppendEvent (Task 23 follow-up)          WIRED — recordCanonicalFailure
+//	wtp_dropped_sequence_overflow_total         AppendEvent (Task 23 follow-up)          WIRED — recordSequenceOverflow
+//	wtp_dropped_invalid_mapper_total            AppendEvent (Task 23 follow-up)          WIRED — recordCompactEncodeFailure (defense-in-depth)
+//	wtp_dropped_invalid_timestamp_total         AppendEvent (Task 23 follow-up)          WIRED — recordCompactEncodeFailure
+//	wtp_dropped_mapper_failure_total            AppendEvent (Task 23 follow-up)          WIRED — recordCompactEncodeFailure (catch-all)
+```
+
+(`(defense-in-depth)` notes which counters can only increment if construction-time validation is bypassed.)
+
+- [ ] **Step 2: Confirm the file still compiles and the metrics tests still pass**
+
+```bash
+go build ./internal/metrics/...
+go test ./internal/metrics/...
+```
+
+Expected: PASS for both.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/metrics/wtp.go
+git commit -m "docs(metrics): mark wtp_dropped_invalid_*_total as WIRED
+
+Updates the producer-status table at internal/metrics/wtp.go:463-467
+now that AppendEvent emits all five counters via recordSequenceOverflow,
+recordCompactEncodeFailure, and recordCanonicalFailure. Notes which
+counters are defense-in-depth (unreachable through normal construction
+because Options.validate / chain.ComputeContextDigest catch them at
+watchtower.New time)."
+```
+
+---
+
+## Task 7: Verification
+
+**Files:** none
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+go test ./...
+```
+
+Expected: PASS, no FAIL anywhere.
+
+- [ ] **Step 2: Cross-compile to Windows**
+
+```bash
+GOOS=windows go build ./...
+```
+
+Expected: exit 0, no output.
+
+- [ ] **Step 3: Roborev**
+
+```bash
+roborev review --wait
+```
+
+Expected: clean, or findings at Low severity only. Findings above Low must be fixed (per the project's between-tasks rule) before this task is considered complete.
+
+- [ ] **Step 4: Final commit (only if roborev requested fixes; otherwise skip)**
+
+If roborev surfaces fixable findings, address them in additional commits following the same `fix(wtp/store): roborev #NNNN — <summary>` pattern used in PR #243.
+
+---
+
+## Acceptance Recap
+
+When all tasks are complete:
+
+- All five `wtp_dropped_invalid_*_total` counters increment exactly once at their reject sites in `AppendEvent`.
+- Each drop emits one structured WARN with `reason` (matching the metric suffix), `err` (where applicable), `event_seq`, `event_gen`, `session_id`, `agent_id`.
+- Existing `AppendEvent` error returns are preserved verbatim — no caller-visible change to error semantics.
+- 3 internal helper unit tests (one per helper, covering all 5 classification branches) + 4 external integration tests (3 reachable drops + happy path).
+- `go test ./...` and `GOOS=windows go build ./...` both clean.
+- `roborev review` clean (no findings above Low).

--- a/docs/superpowers/specs/2026-04-25-wtp-drop-class-counters-design.md
+++ b/docs/superpowers/specs/2026-04-25-wtp-drop-class-counters-design.md
@@ -89,7 +89,12 @@ The existing `compact.Encode` and `chain.EncodeCanonical` returns already use `%
 
 ## Testing
 
-Two test files. The split exists because `Options.validate` rejects nil and typed-nil `Mapper` at construction (`internal/store/watchtower/options.go:181-185`), so `compact.ErrInvalidMapper` is unreachable from `AppendEvent` through a real `watchtower.New` flow. The wiring is still defense-in-depth — operators want the counter to fire if the validation surface ever changes — but the test for that branch must call the helper directly.
+Two test files. The split exists because two of the five drop classes are pure defense-in-depth — the construction surface validates them before `AppendEvent` is reachable:
+
+- **`compact.ErrInvalidMapper`** — `Options.validate` rejects nil and typed-nil `Mapper` at construction (`internal/store/watchtower/options.go:181-185`).
+- **`chain.ErrInvalidUTF8`** — `chain.ComputeContextDigest` (called by `watchtower.New` at `store.go:279-287`) UTF-8-validates every `SessionContext` string including `KeyFingerprint`. The other strings that reach `chain.EncodeCanonical` at append time (`ContextDigest`, `EventHash`, `PrevHash`) are computed internally from validated inputs.
+
+The wiring is still right — operators want the counter to fire if the validation surface ever changes — but the tests for these two branches must call the helper directly.
 
 ### `internal/store/watchtower/append_drop_test.go` (external `watchtower_test` package)
 
@@ -98,16 +103,18 @@ Real `watchtower.New` + `AppendEvent` integration tests, one per reachable drop 
 | Test | Trigger | Counter asserted | Reason label asserted |
 |---|---|---|---|
 | `TestAppendEvent_DropsOnInvalidTimestamp` | `ev.Timestamp = time.Time{}` | `DroppedInvalidTimestamp() == 1` | `invalid_timestamp` |
-| `TestAppendEvent_DropsOnMapperFailure` | Test-fixture mapper whose `MapEvent` returns an error | `DroppedMapperFailure() == 1` | `mapper_failure` |
+| `TestAppendEvent_DropsOnMapperFailure` | Test-fixture mapper whose `Map` returns an error | `DroppedMapperFailure() == 1` | `mapper_failure` |
 | `TestAppendEvent_DropsOnSequenceOverflow` | `ev.Chain.Sequence = math.MaxInt64 + 1` | `DroppedSequenceOverflow() == 1` | `sequence_overflow` |
-| `TestAppendEvent_DropsOnInvalidUTF8` | `Options.KeyFingerprint` containing a non-UTF-8 byte (flows into `IntegrityRecord.KeyFingerprint` → `chain.EncodeCanonical` → `chain.ErrInvalidUTF8`) | `DroppedInvalidUTF8() == 1` | `invalid_utf8` |
 | `TestAppendEvent_HappyPath_NoDrops` | Valid mapper, timestamp, sequence, key fingerprint | ALL five counters stay at 0; no WARN | — |
 
 ### `internal/store/watchtower/append_drop_internal_test.go` (internal `watchtower` package)
 
+Direct helper invocations for the two defense-in-depth branches:
+
 | Test | Approach | Counter asserted | Reason label asserted |
 |---|---|---|---|
 | `TestRecordCompactEncodeFailure_ClassifiesInvalidMapper` | Construct a Store, call `s.recordCompactEncodeFailure(compact.ErrInvalidMapper, ev)` directly | `DroppedInvalidMapper() == 1` | `invalid_mapper` |
+| `TestRecordCanonicalFailure_ClassifiesInvalidUTF8` | Construct a Store, call `s.recordCanonicalFailure(chain.ErrInvalidUTF8, ev)` directly | `DroppedInvalidUTF8() == 1` | `invalid_utf8` |
 
 Each failing-path test (both files) also asserts:
 - `errors.Is(err, <expected sentinel>)` on the returned error where applicable (preserves existing semantics; sequence overflow has no sentinel and asserts on the message instead).
@@ -120,8 +127,8 @@ The happy-path test catches a regression where every successful append accidenta
 | File | Change |
 |---|---|
 | `internal/store/watchtower/append.go` | Add 3 private helpers; insert 3 helper calls at the existing reject sites; remove the SCOPE NOTE referencing this work as future. |
-| `internal/store/watchtower/append_drop_test.go` | NEW: 5 tests via real `AppendEvent` (4 reachable drop classes + 1 happy path). |
-| `internal/store/watchtower/append_drop_internal_test.go` | NEW: 1 test calling `recordCompactEncodeFailure` directly to cover the defense-in-depth `ErrInvalidMapper` branch (unreachable through Options validation). |
+| `internal/store/watchtower/append_drop_test.go` | NEW: 4 tests via real `AppendEvent` (3 reachable drop classes + 1 happy path). |
+| `internal/store/watchtower/append_drop_internal_test.go` | NEW: 2 tests calling helpers directly to cover defense-in-depth `ErrInvalidMapper` and `ErrInvalidUTF8` (both unreachable through normal construction). |
 | `internal/metrics/wtp.go` | Update the "NOT YET WIRED — emits zero" comments at lines 463-467 to point at `AppendEvent` as the live producer. |
 
 ## Acceptance

--- a/docs/superpowers/specs/2026-04-25-wtp-drop-class-counters-design.md
+++ b/docs/superpowers/specs/2026-04-25-wtp-drop-class-counters-design.md
@@ -1,0 +1,132 @@
+# WTP Drop-Class Counters — Design
+
+**Date:** 2026-04-25
+**Status:** Approved (brainstorming complete; ready for implementation plan)
+**Scope:** Wire the five existing `wtp_dropped_invalid_*_total` counters at the existing reject sites in `internal/store/watchtower/AppendEvent`, plus structured WARN logs.
+
+## Background
+
+Task 22a registered five drop-class counters on `metrics.WTPMetrics`:
+
+| Counter | Trip condition |
+|---|---|
+| `wtp_dropped_invalid_utf8_total` | `chain.EncodeCanonical` returns `chain.ErrInvalidUTF8` |
+| `wtp_dropped_sequence_overflow_total` | `ev.Chain.Sequence > math.MaxInt64` |
+| `wtp_dropped_invalid_mapper_total` | `compact.Encode` returns `compact.ErrInvalidMapper` |
+| `wtp_dropped_invalid_timestamp_total` | `compact.Encode` returns `compact.ErrInvalidTimestamp` |
+| `wtp_dropped_mapper_failure_total` | `compact.Encode` returns a mapper-wrapped error (catch-all) |
+
+`internal/metrics/wtp.go` lines 463-467 explicitly mark these as **NOT YET WIRED — emits zero**. The `AppendEvent` docstring at `internal/store/watchtower/append.go:67-75` documents the gap as Task 23 follow-up:
+
+> SCOPE NOTE: this is Task 23's core transactional path. The full spec additionally routes compact.ErrInvalidMapper / ErrInvalidTimestamp / mapper-wrapped / sequence-overflow / chain.ErrInvalidUTF8 through per-class drop counters (wtp_dropped_invalid_*_total) with structured WARN logs. That counter-wiring layer is follow-up work alongside the Task 22a sink-failure counter surface; today those errors propagate to the caller as wrapped errors.
+
+This design closes that gap.
+
+## Architecture
+
+Three private methods on `*Store`, each owning the classify-and-emit logic for one reject class:
+
+```
+AppendEvent reject sites (in source order):
+  ├─ ev.Chain.Sequence > math.MaxInt64   ─→ s.recordSequenceOverflow(ev)
+  ├─ compact.Encode(...) error            ─→ s.recordCompactEncodeFailure(err, ev)
+  └─ chain.EncodeCanonical(...) error     ─→ s.recordCanonicalFailure(err, ev)
+```
+
+Each helper:
+1. Increments the appropriate `WTPMetrics.IncDroppedX(1)` counter (nil-safe via `*WTPMetrics` receiver).
+2. Emits one structured WARN via `s.opts.Logger`.
+3. Returns `void` — the caller still does its existing `return fmt.Errorf("…: %w", err)`, so error-return semantics are preserved exactly.
+
+`recordCompactEncodeFailure` does the multi-way classification:
+
+| `errors.Is(err, …)` | Counter | Reason label |
+|---|---|---|
+| `compact.ErrInvalidMapper` | `IncDroppedInvalidMapper(1)` | `invalid_mapper` |
+| `compact.ErrInvalidTimestamp` | `IncDroppedInvalidTimestamp(1)` | `invalid_timestamp` |
+| (catch-all) | `IncDroppedMapperFailure(1)` | `mapper_failure` |
+
+The catch-all branch fires for the mapper-wrapped error returned by `compact/encoder.go:71` (`fmt.Errorf("compact mapper: %w", err)`), since that path does not preserve a typed sentinel by design.
+
+Note: `compact.ErrMissingChain` is unreachable from `AppendEvent` because line 100 (`if ev.Chain == nil { return … }`) bails before `compact.Encode` runs. No counter is added for that path; if a future code change makes it reachable it falls into the `mapper_failure` catch-all and surfaces in logs.
+
+## WARN log shape
+
+Mirrors the existing `recv_multiplexer.go` pattern:
+
+```go
+s.opts.Logger.LogAttrs(context.Background(), slog.LevelWarn,
+    "wtp: dropping event before WAL append",
+    slog.String("reason", "<class>"),
+    slog.String("err", err.Error()),         // omitted for sequence_overflow (no underlying err)
+    slog.Uint64("event_seq", ev.Chain.Sequence),
+    slog.Uint64("event_gen", uint64(ev.Chain.Generation)),
+    slog.String("session_id", s.opts.SessionID),
+    slog.String("agent_id", s.opts.AgentID))
+```
+
+The `reason` label values (`invalid_mapper`, `invalid_timestamp`, `mapper_failure`, `sequence_overflow`, `invalid_utf8`) match the metric suffix exactly so log readers can grep by reason and find the matching counter without translation.
+
+`event_seq` / `event_gen` give triage context (what record was rejected); `session_id` / `agent_id` cross-correlate with WAL identity warnings already in `store.go`.
+
+## Error-return semantics
+
+Existing returns are preserved verbatim:
+
+| Site | Existing return |
+|---|---|
+| Sequence overflow | `fmt.Errorf("watchtower: ev.Chain.Sequence %d overflows int64", ev.Chain.Sequence)` |
+| compact.Encode failure | `fmt.Errorf("compact.Encode: %w", err)` |
+| chain.EncodeCanonical failure | `fmt.Errorf("chain.EncodeCanonical: %w", err)` |
+
+The existing `compact.Encode` and `chain.EncodeCanonical` returns already use `%w` to preserve the underlying sentinel for `errors.Is` callers. This design adds the counter+WARN side effect; it does not introduce a new sentinel for sequence overflow (the existing error is a one-off `fmt.Errorf` that callers do not match against today, and there is no demonstrated need to add one).
+
+## Out of scope
+
+- WAL `Append` and `Commit` errors. These are transactional infrastructure failures (clean / ambiguous classification, fatal-latch territory) — not "drop class." They have their own paths in `append.go` and stay as-is.
+- The `ev.Chain == nil` early bail at line 100. It returns a one-off error and is not a peer-derived drop class; no counter is added.
+- New metric counters. The five counters in scope are already registered on `WTPMetrics`; this work only wires producers.
+
+## Testing
+
+Two test files. The split exists because `Options.validate` rejects nil and typed-nil `Mapper` at construction (`internal/store/watchtower/options.go:181-185`), so `compact.ErrInvalidMapper` is unreachable from `AppendEvent` through a real `watchtower.New` flow. The wiring is still defense-in-depth — operators want the counter to fire if the validation surface ever changes — but the test for that branch must call the helper directly.
+
+### `internal/store/watchtower/append_drop_test.go` (external `watchtower_test` package)
+
+Real `watchtower.New` + `AppendEvent` integration tests, one per reachable drop class plus happy path:
+
+| Test | Trigger | Counter asserted | Reason label asserted |
+|---|---|---|---|
+| `TestAppendEvent_DropsOnInvalidTimestamp` | `ev.Timestamp = time.Time{}` | `DroppedInvalidTimestamp() == 1` | `invalid_timestamp` |
+| `TestAppendEvent_DropsOnMapperFailure` | Test-fixture mapper whose `MapEvent` returns an error | `DroppedMapperFailure() == 1` | `mapper_failure` |
+| `TestAppendEvent_DropsOnSequenceOverflow` | `ev.Chain.Sequence = math.MaxInt64 + 1` | `DroppedSequenceOverflow() == 1` | `sequence_overflow` |
+| `TestAppendEvent_DropsOnInvalidUTF8` | `Options.KeyFingerprint` containing a non-UTF-8 byte (flows into `IntegrityRecord.KeyFingerprint` → `chain.EncodeCanonical` → `chain.ErrInvalidUTF8`) | `DroppedInvalidUTF8() == 1` | `invalid_utf8` |
+| `TestAppendEvent_HappyPath_NoDrops` | Valid mapper, timestamp, sequence, key fingerprint | ALL five counters stay at 0; no WARN | — |
+
+### `internal/store/watchtower/append_drop_internal_test.go` (internal `watchtower` package)
+
+| Test | Approach | Counter asserted | Reason label asserted |
+|---|---|---|---|
+| `TestRecordCompactEncodeFailure_ClassifiesInvalidMapper` | Construct a Store, call `s.recordCompactEncodeFailure(compact.ErrInvalidMapper, ev)` directly | `DroppedInvalidMapper() == 1` | `invalid_mapper` |
+
+Each failing-path test (both files) also asserts:
+- `errors.Is(err, <expected sentinel>)` on the returned error where applicable (preserves existing semantics; sequence overflow has no sentinel and asserts on the message instead).
+- The captured WARN log carries the triage attrs (`event_seq`, `event_gen`, `session_id`, `agent_id`).
+
+The happy-path test catches a regression where every successful append accidentally bumps a drop counter.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `internal/store/watchtower/append.go` | Add 3 private helpers; insert 3 helper calls at the existing reject sites; remove the SCOPE NOTE referencing this work as future. |
+| `internal/store/watchtower/append_drop_test.go` | NEW: 5 tests via real `AppendEvent` (4 reachable drop classes + 1 happy path). |
+| `internal/store/watchtower/append_drop_internal_test.go` | NEW: 1 test calling `recordCompactEncodeFailure` directly to cover the defense-in-depth `ErrInvalidMapper` branch (unreachable through Options validation). |
+| `internal/metrics/wtp.go` | Update the "NOT YET WIRED — emits zero" comments at lines 463-467 to point at `AppendEvent` as the live producer. |
+
+## Acceptance
+
+- `go test ./...` passes (existing tests stay green; 6 new tests added — 5 external + 1 internal).
+- `GOOS=windows go build ./...` passes.
+- All 5 counters increment exactly once per trip, with no double-counting under the happy path.
+- `roborev review` clean (no findings above Low).

--- a/internal/metrics/wtp.go
+++ b/internal/metrics/wtp.go
@@ -460,11 +460,11 @@ func (c *Collector) emitWTPMetrics(w io.Writer) {
 // Wiring status SPLITS into two groups per the table below:
 //
 //	Counter family                              Wired by                                 Status (as of Task 22a R2)
-//	wtp_dropped_invalid_utf8_total              AppendEvent (Task 23)                    NOT YET WIRED — emits zero
-//	wtp_dropped_sequence_overflow_total         AppendEvent (Task 23)                    NOT YET WIRED — emits zero
-//	wtp_dropped_invalid_mapper_total            AppendEvent (Task 23)                    NOT YET WIRED — emits zero
-//	wtp_dropped_invalid_timestamp_total         AppendEvent (Task 23)                    NOT YET WIRED — emits zero
-//	wtp_dropped_mapper_failure_total            AppendEvent (Task 23)                    NOT YET WIRED — emits zero
+//	wtp_dropped_invalid_utf8_total              AppendEvent (Task 23 follow-up)          WIRED — recordCanonicalFailure
+//	wtp_dropped_sequence_overflow_total         AppendEvent (Task 23 follow-up)          WIRED — recordSequenceOverflow
+//	wtp_dropped_invalid_mapper_total            AppendEvent (Task 23 follow-up)          WIRED — recordCompactEncodeFailure (defense-in-depth)
+//	wtp_dropped_invalid_timestamp_total         AppendEvent (Task 23 follow-up)          WIRED — recordCompactEncodeFailure
+//	wtp_dropped_mapper_failure_total            AppendEvent (Task 23 follow-up)          WIRED — recordCompactEncodeFailure (catch-all)
 //	wtp_dropped_invalid_frame_total{reason}     transport receivers (Task 17 Step 4a)    NOT YET WIRED — emits zero
 //	wtp_session_init_failures_total{reason}     transport (Phase 8)                      NOT YET WIRED — emits zero
 //	wtp_session_rotation_failures_total{reason} transport (Phase 8)                      NOT YET WIRED — emits zero

--- a/internal/store/watchtower/append.go
+++ b/internal/store/watchtower/append.go
@@ -66,14 +66,12 @@ var deterministicMarshal = proto.MarshalOptions{Deterministic: true}
 //   - On terminal Commit failure (stale result, cross-chain,
 //     backwards-generation, latched fatal), the store latches fatal.
 //
-// SCOPE NOTE: this is Task 23's core transactional path. The full
-// spec additionally routes compact.ErrInvalidMapper /
-// ErrInvalidTimestamp / mapper-wrapped / sequence-overflow /
-// chain.ErrInvalidUTF8 through per-class drop counters
-// (wtp_dropped_invalid_*_total) with structured WARN logs. That
-// counter-wiring layer is follow-up work alongside the Task 22a
-// sink-failure counter surface; today those errors propagate to the
-// caller as wrapped errors.
+// Per-class drop counters: every reject path (sequence overflow,
+// compact.Encode classification, chain.EncodeCanonical) increments
+// the matching wtp_dropped_invalid_*_total counter and emits a
+// structured WARN with reason/event_seq/event_gen/session_id/agent_id
+// before the wrapped error is returned. See recordSequenceOverflow,
+// recordCompactEncodeFailure, recordCanonicalFailure below.
 func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
 	// Serialise the full Compute → Append → Commit transaction. The
 	// composite store fans events out to sinks under RLock, so two
@@ -102,11 +100,13 @@ func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
 		return fmt.Errorf("watchtower: ev.Chain is required")
 	}
 	if ev.Chain.Sequence > math.MaxInt64 {
+		s.recordSequenceOverflow(ev)
 		return fmt.Errorf("watchtower: ev.Chain.Sequence %d overflows int64", ev.Chain.Sequence)
 	}
 
 	ce, err := compact.Encode(s.opts.Mapper, ev)
 	if err != nil {
+		s.recordCompactEncodeFailure(err, ev)
 		return fmt.Errorf("compact.Encode: %w", err)
 	}
 
@@ -150,10 +150,7 @@ func (s *Store) AppendEvent(ctx context.Context, ev types.Event) error {
 	}
 	canonicalIntegrity, err := chain.EncodeCanonical(integrityRec)
 	if err != nil {
-		// chain.ErrInvalidUTF8 propagates here for any peer-derived
-		// field that slipped through upstream validation. Task 23
-		// follow-up wires this into wtp_dropped_invalid_utf8_total;
-		// today it surfaces to the caller.
+		s.recordCanonicalFailure(err, ev)
 		return fmt.Errorf("chain.EncodeCanonical: %w", err)
 	}
 

--- a/internal/store/watchtower/append.go
+++ b/internal/store/watchtower/append.go
@@ -282,3 +282,29 @@ func (s *Store) recordCompactEncodeFailure(err error, ev types.Event) {
 		slog.String("session_id", s.opts.SessionID),
 		slog.String("agent_id", s.opts.AgentID))
 }
+
+// recordCanonicalFailure increments wtp_dropped_invalid_utf8_total
+// and emits a structured WARN. Called from AppendEvent's
+// chain.EncodeCanonical error branch BEFORE the existing error
+// return.
+//
+// chain.EncodeCanonical's only error sentinel today is
+// chain.ErrInvalidUTF8 — the function returns that or nil. This
+// helper unconditionally classifies as invalid_utf8 rather than
+// errors.Is-checking, so a future expansion of EncodeCanonical's
+// error surface will fall through here and surface as invalid_utf8
+// until the helper is updated. That posture is deliberate: it keeps
+// the call site one line and matches the today-only contract; if a
+// new sentinel is added, the helper grows a switch like
+// recordCompactEncodeFailure.
+func (s *Store) recordCanonicalFailure(err error, ev types.Event) {
+	s.metrics.IncDroppedInvalidUTF8(1)
+	s.opts.Logger.LogAttrs(context.Background(), slog.LevelWarn,
+		"wtp: dropping event before WAL append",
+		slog.String("reason", "invalid_utf8"),
+		slog.String("err", err.Error()),
+		slog.Uint64("event_seq", ev.Chain.Sequence),
+		slog.Uint64("event_gen", uint64(ev.Chain.Generation)),
+		slog.String("session_id", s.opts.SessionID),
+		slog.String("agent_id", s.opts.AgentID))
+}

--- a/internal/store/watchtower/append.go
+++ b/internal/store/watchtower/append.go
@@ -242,3 +242,43 @@ func (s *Store) recordSequenceOverflow(ev types.Event) {
 		slog.String("session_id", s.opts.SessionID),
 		slog.String("agent_id", s.opts.AgentID))
 }
+
+// recordCompactEncodeFailure inspects err for the compact.Encode
+// sentinels and routes the drop to the matching counter + WARN.
+// Called from AppendEvent's compact.Encode error branch BEFORE the
+// existing error return.
+//
+// Classification priority (errors.Is order):
+//   - compact.ErrInvalidMapper    → IncDroppedInvalidMapper / "invalid_mapper"
+//   - compact.ErrInvalidTimestamp → IncDroppedInvalidTimestamp / "invalid_timestamp"
+//   - (fallthrough)               → IncDroppedMapperFailure / "mapper_failure"
+//
+// The fallthrough catches the mapper-wrapped error returned by
+// compact/encoder.go:71 (`fmt.Errorf("compact mapper: %w", err)`),
+// which intentionally does not preserve a typed sentinel. The
+// compact.ErrMissingChain sentinel is unreachable from AppendEvent
+// because the ev.Chain == nil check earlier in the function bails
+// before compact.Encode runs; if a future change makes it reachable,
+// it falls into the mapper_failure catch-all and surfaces in logs.
+func (s *Store) recordCompactEncodeFailure(err error, ev types.Event) {
+	var reason string
+	switch {
+	case errors.Is(err, compact.ErrInvalidMapper):
+		s.metrics.IncDroppedInvalidMapper(1)
+		reason = "invalid_mapper"
+	case errors.Is(err, compact.ErrInvalidTimestamp):
+		s.metrics.IncDroppedInvalidTimestamp(1)
+		reason = "invalid_timestamp"
+	default:
+		s.metrics.IncDroppedMapperFailure(1)
+		reason = "mapper_failure"
+	}
+	s.opts.Logger.LogAttrs(context.Background(), slog.LevelWarn,
+		"wtp: dropping event before WAL append",
+		slog.String("reason", reason),
+		slog.String("err", err.Error()),
+		slog.Uint64("event_seq", ev.Chain.Sequence),
+		slog.Uint64("event_gen", uint64(ev.Chain.Generation)),
+		slog.String("session_id", s.opts.SessionID),
+		slog.String("agent_id", s.opts.AgentID))
+}

--- a/internal/store/watchtower/append.go
+++ b/internal/store/watchtower/append.go
@@ -245,21 +245,30 @@ func (s *Store) recordSequenceOverflow(ev types.Event) {
 // Called from AppendEvent's compact.Encode error branch BEFORE the
 // existing error return.
 //
-// Classification priority (errors.Is order):
+// Classification priority (errors.Is order — MUST stay in this order):
+//   - compact.ErrMapperFailure    → IncDroppedMapperFailure / "mapper_failure"
 //   - compact.ErrInvalidMapper    → IncDroppedInvalidMapper / "invalid_mapper"
 //   - compact.ErrInvalidTimestamp → IncDroppedInvalidTimestamp / "invalid_timestamp"
 //   - (fallthrough)               → IncDroppedMapperFailure / "mapper_failure"
 //
-// The fallthrough catches the mapper-wrapped error returned by
-// compact/encoder.go:71 (`fmt.Errorf("compact mapper: %w", err)`),
-// which intentionally does not preserve a typed sentinel. The
-// compact.ErrMissingChain sentinel is unreachable from AppendEvent
-// because the ev.Chain == nil check earlier in the function bails
-// before compact.Encode runs; if a future change makes it reachable,
-// it falls into the mapper_failure catch-all and surfaces in logs.
+// ErrMapperFailure is checked FIRST because compact.Encode wraps every
+// mapper-side error with it via `fmt.Errorf("%w: %w", ErrMapperFailure,
+// err)`; without that priority, a Mapper that happened to return
+// ErrInvalidMapper or ErrInvalidTimestamp from inside Map would have
+// its drop misclassified as a validation-gate hit (roborev #6177
+// Medium). The fallthrough remains for any future encoder error path
+// that does not wrap with ErrMapperFailure or one of the other
+// sentinels. The compact.ErrMissingChain sentinel is unreachable from
+// AppendEvent because the ev.Chain == nil check earlier in the
+// function bails before compact.Encode runs; if a future change makes
+// it reachable, it falls into the mapper_failure catch-all and
+// surfaces in logs.
 func (s *Store) recordCompactEncodeFailure(err error, ev types.Event) {
 	var reason string
 	switch {
+	case errors.Is(err, compact.ErrMapperFailure):
+		s.metrics.IncDroppedMapperFailure(1)
+		reason = "mapper_failure"
 	case errors.Is(err, compact.ErrInvalidMapper):
 		s.metrics.IncDroppedInvalidMapper(1)
 		reason = "invalid_mapper"

--- a/internal/store/watchtower/append.go
+++ b/internal/store/watchtower/append.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 
 	"github.com/agentsh/agentsh/internal/audit"
@@ -221,4 +222,23 @@ func (s *Store) latchFatal(err error) {
 			s.fatalErr.Store(err)
 		}
 	}
+}
+
+// recordSequenceOverflow increments wtp_dropped_sequence_overflow_total
+// and emits a structured WARN. Called from AppendEvent's
+// ev.Chain.Sequence > math.MaxInt64 branch BEFORE the existing error
+// return so the counter increments exactly once per drop and the WARN
+// gives operators triage context (which (gen, seq) was rejected).
+//
+// No underlying err is logged because this is our own range check, not
+// a wrapped sentinel — the message is deterministic from event_seq.
+func (s *Store) recordSequenceOverflow(ev types.Event) {
+	s.metrics.IncDroppedSequenceOverflow(1)
+	s.opts.Logger.LogAttrs(context.Background(), slog.LevelWarn,
+		"wtp: dropping event before WAL append",
+		slog.String("reason", "sequence_overflow"),
+		slog.Uint64("event_seq", ev.Chain.Sequence),
+		slog.Uint64("event_gen", uint64(ev.Chain.Generation)),
+		slog.String("session_id", s.opts.SessionID),
+		slog.String("agent_id", s.opts.AgentID))
 }

--- a/internal/store/watchtower/append_drop_internal_test.go
+++ b/internal/store/watchtower/append_drop_internal_test.go
@@ -1,0 +1,79 @@
+package watchtower
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/metrics"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// newDropTestStore builds a minimal Store wired with a counter-asserting
+// *WTPMetrics and a buffered JSON slog handler so the recordX helpers
+// can be unit-tested without standing up a WAL / transport / chain.
+// Returns the Store, the metrics handle, and the log buffer.
+func newDropTestStore(t *testing.T) (*Store, *metrics.WTPMetrics, *bytes.Buffer) {
+	t.Helper()
+	col := metrics.New()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	s := &Store{
+		opts: Options{
+			Logger:    logger,
+			SessionID: "s-test",
+			AgentID:   "a-test",
+		},
+		metrics: col.WTP(),
+	}
+	return s, col.WTP(), &buf
+}
+
+// findWarnEntry returns the single decoded WARN log entry from buf, or
+// fails the test if zero or more than one entry is present.
+func findWarnEntry(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if len(lines) != 1 || lines[0] == "" {
+		t.Fatalf("expected exactly 1 WARN log entry, got %d: %q", len(lines), buf.String())
+	}
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &entry); err != nil {
+		t.Fatalf("parse log entry: %v", err)
+	}
+	return entry
+}
+
+func TestRecordSequenceOverflow_IncrementsCounterAndEmitsWarn(t *testing.T) {
+	s, m, buf := newDropTestStore(t)
+
+	ev := types.Event{
+		Timestamp: time.Unix(1700000000, 0),
+		Chain:     &types.ChainState{Sequence: 99, Generation: 7},
+	}
+	s.recordSequenceOverflow(ev)
+
+	if got := m.DroppedSequenceOverflow(); got != 1 {
+		t.Fatalf("DroppedSequenceOverflow() = %d, want 1", got)
+	}
+
+	entry := findWarnEntry(t, buf)
+	if got := entry["reason"]; got != "sequence_overflow" {
+		t.Fatalf("reason = %v, want sequence_overflow", got)
+	}
+	if got := entry["event_seq"]; got != float64(99) {
+		t.Fatalf("event_seq = %v, want 99", got)
+	}
+	if got := entry["event_gen"]; got != float64(7) {
+		t.Fatalf("event_gen = %v, want 7", got)
+	}
+	if got := entry["session_id"]; got != "s-test" {
+		t.Fatalf("session_id = %v, want s-test", got)
+	}
+	if got := entry["agent_id"]; got != "a-test" {
+		t.Fatalf("agent_id = %v, want a-test", got)
+	}
+}

--- a/internal/store/watchtower/append_drop_internal_test.go
+++ b/internal/store/watchtower/append_drop_internal_test.go
@@ -143,8 +143,10 @@ func TestRecordCompactEncodeFailure_ClassifiesMapperFailureCatchAll(t *testing.T
 		Timestamp: time.Unix(1700000000, 0),
 		Chain:     &types.ChainState{Sequence: 3, Generation: 1},
 	}
-	// A mapper-side error wrapped exactly like compact/encoder.go:71 does.
-	wrapped := fmt.Errorf("compact mapper: %w", errors.New("synthetic mapper failure"))
+	// A mapper-side error wrapped exactly the way compact.Encode wraps
+	// every Mapper.Map error post-#6177 fix — via the ErrMapperFailure
+	// sentinel.
+	wrapped := fmt.Errorf("%w: %w", compact.ErrMapperFailure, errors.New("synthetic mapper failure"))
 	s.recordCompactEncodeFailure(wrapped, ev)
 
 	if got := m.DroppedMapperFailure(); got != 1 {
@@ -160,6 +162,53 @@ func TestRecordCompactEncodeFailure_ClassifiesMapperFailureCatchAll(t *testing.T
 	entry := findWarnEntry(t, buf)
 	if got := entry["reason"]; got != "mapper_failure" {
 		t.Fatalf("reason = %v, want mapper_failure", got)
+	}
+}
+
+// TestRecordCompactEncodeFailure_MapperReturningSentinelStaysMapperFailure
+// pins roborev #6177 (Medium): a Mapper that happens to return
+// compact.ErrInvalidMapper or compact.ErrInvalidTimestamp from inside
+// its Map method MUST be classified as `mapper_failure`, not as the
+// validation-gate counter the inner sentinel would otherwise match.
+// compact.Encode wraps every mapper-side error with ErrMapperFailure,
+// so the classifier's priority order (ErrMapperFailure first) keeps
+// the inner sentinel from leaking into the wrong counter.
+func TestRecordCompactEncodeFailure_MapperReturningSentinelStaysMapperFailure(t *testing.T) {
+	cases := []struct {
+		name  string
+		inner error
+	}{
+		{"inner=ErrInvalidMapper", compact.ErrInvalidMapper},
+		{"inner=ErrInvalidTimestamp", compact.ErrInvalidTimestamp},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s, m, buf := newDropTestStore(t)
+
+			ev := types.Event{
+				Timestamp: time.Unix(1700000000, 0),
+				Chain:     &types.ChainState{Sequence: 5, Generation: 3},
+			}
+			// Mirror the exact wrap compact.Encode applies in its
+			// `m.Map(ev)` error branch.
+			wrapped := fmt.Errorf("%w: %w", compact.ErrMapperFailure, tc.inner)
+			s.recordCompactEncodeFailure(wrapped, ev)
+
+			if got := m.DroppedMapperFailure(); got != 1 {
+				t.Fatalf("DroppedMapperFailure() = %d, want 1", got)
+			}
+			if got := m.DroppedInvalidMapper(); got != 0 {
+				t.Fatalf("DroppedInvalidMapper() = %d, want 0 (mapper-originated sentinel must NOT leak)", got)
+			}
+			if got := m.DroppedInvalidTimestamp(); got != 0 {
+				t.Fatalf("DroppedInvalidTimestamp() = %d, want 0 (mapper-originated sentinel must NOT leak)", got)
+			}
+
+			entry := findWarnEntry(t, buf)
+			if got := entry["reason"]; got != "mapper_failure" {
+				t.Fatalf("reason = %v, want mapper_failure", got)
+			}
+		})
 	}
 }
 

--- a/internal/store/watchtower/append_drop_internal_test.go
+++ b/internal/store/watchtower/append_drop_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/agentsh/agentsh/internal/metrics"
+	"github.com/agentsh/agentsh/internal/store/watchtower/chain"
 	"github.com/agentsh/agentsh/internal/store/watchtower/compact"
 	"github.com/agentsh/agentsh/pkg/types"
 )
@@ -159,6 +160,41 @@ func TestRecordCompactEncodeFailure_ClassifiesMapperFailureCatchAll(t *testing.T
 	entry := findWarnEntry(t, buf)
 	if got := entry["reason"]; got != "mapper_failure" {
 		t.Fatalf("reason = %v, want mapper_failure", got)
+	}
+}
+
+func TestRecordCanonicalFailure_ClassifiesInvalidUTF8(t *testing.T) {
+	s, m, buf := newDropTestStore(t)
+
+	ev := types.Event{
+		Timestamp: time.Unix(1700000000, 0),
+		Chain:     &types.ChainState{Sequence: 4, Generation: 2},
+	}
+	wrapped := fmt.Errorf("chain.EncodeCanonical: %w", chain.ErrInvalidUTF8)
+	s.recordCanonicalFailure(wrapped, ev)
+
+	if got := m.DroppedInvalidUTF8(); got != 1 {
+		t.Fatalf("DroppedInvalidUTF8() = %d, want 1", got)
+	}
+
+	entry := findWarnEntry(t, buf)
+	if got := entry["reason"]; got != "invalid_utf8" {
+		t.Fatalf("reason = %v, want invalid_utf8", got)
+	}
+	if got := entry["event_seq"]; got != float64(4) {
+		t.Fatalf("event_seq = %v, want 4", got)
+	}
+	if got := entry["event_gen"]; got != float64(2) {
+		t.Fatalf("event_gen = %v, want 2", got)
+	}
+	if got := entry["session_id"]; got != "s-test" {
+		t.Fatalf("session_id = %v, want s-test", got)
+	}
+	if got := entry["agent_id"]; got != "a-test" {
+		t.Fatalf("agent_id = %v, want a-test", got)
+	}
+	if got := entry["err"]; got == nil {
+		t.Fatalf("err attr missing, want non-empty string")
 	}
 }
 

--- a/internal/store/watchtower/append_drop_internal_test.go
+++ b/internal/store/watchtower/append_drop_internal_test.go
@@ -3,12 +3,15 @@ package watchtower
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/agentsh/agentsh/internal/metrics"
+	"github.com/agentsh/agentsh/internal/store/watchtower/compact"
 	"github.com/agentsh/agentsh/pkg/types"
 )
 
@@ -77,3 +80,85 @@ func TestRecordSequenceOverflow_IncrementsCounterAndEmitsWarn(t *testing.T) {
 		t.Fatalf("agent_id = %v, want a-test", got)
 	}
 }
+
+func TestRecordCompactEncodeFailure_ClassifiesInvalidMapper(t *testing.T) {
+	s, m, buf := newDropTestStore(t)
+
+	ev := types.Event{
+		Timestamp: time.Unix(1700000000, 0),
+		Chain:     &types.ChainState{Sequence: 1, Generation: 1},
+	}
+	s.recordCompactEncodeFailure(compact.ErrInvalidMapper, ev)
+
+	if got := m.DroppedInvalidMapper(); got != 1 {
+		t.Fatalf("DroppedInvalidMapper() = %d, want 1", got)
+	}
+	if got := m.DroppedInvalidTimestamp(); got != 0 {
+		t.Fatalf("DroppedInvalidTimestamp() = %d, want 0 (wrong branch fired)", got)
+	}
+	if got := m.DroppedMapperFailure(); got != 0 {
+		t.Fatalf("DroppedMapperFailure() = %d, want 0 (wrong branch fired)", got)
+	}
+
+	entry := findWarnEntry(t, buf)
+	if got := entry["reason"]; got != "invalid_mapper" {
+		t.Fatalf("reason = %v, want invalid_mapper", got)
+	}
+	if got := entry["err"]; got == nil || !strings.Contains(got.(string), "mapper is required") {
+		t.Fatalf("err attr = %v, want non-empty containing %q", got, "mapper is required")
+	}
+}
+
+func TestRecordCompactEncodeFailure_ClassifiesInvalidTimestamp(t *testing.T) {
+	s, m, buf := newDropTestStore(t)
+
+	ev := types.Event{
+		Timestamp: time.Unix(1700000000, 0),
+		Chain:     &types.ChainState{Sequence: 2, Generation: 1},
+	}
+	wrapped := fmt.Errorf("compact.Encode: %w", compact.ErrInvalidTimestamp)
+	s.recordCompactEncodeFailure(wrapped, ev)
+
+	if got := m.DroppedInvalidTimestamp(); got != 1 {
+		t.Fatalf("DroppedInvalidTimestamp() = %d, want 1", got)
+	}
+	if got := m.DroppedInvalidMapper(); got != 0 {
+		t.Fatalf("DroppedInvalidMapper() = %d, want 0 (wrong branch fired)", got)
+	}
+	if got := m.DroppedMapperFailure(); got != 0 {
+		t.Fatalf("DroppedMapperFailure() = %d, want 0 (wrong branch fired)", got)
+	}
+
+	entry := findWarnEntry(t, buf)
+	if got := entry["reason"]; got != "invalid_timestamp" {
+		t.Fatalf("reason = %v, want invalid_timestamp", got)
+	}
+}
+
+func TestRecordCompactEncodeFailure_ClassifiesMapperFailureCatchAll(t *testing.T) {
+	s, m, buf := newDropTestStore(t)
+
+	ev := types.Event{
+		Timestamp: time.Unix(1700000000, 0),
+		Chain:     &types.ChainState{Sequence: 3, Generation: 1},
+	}
+	// A mapper-side error wrapped exactly like compact/encoder.go:71 does.
+	wrapped := fmt.Errorf("compact mapper: %w", errors.New("synthetic mapper failure"))
+	s.recordCompactEncodeFailure(wrapped, ev)
+
+	if got := m.DroppedMapperFailure(); got != 1 {
+		t.Fatalf("DroppedMapperFailure() = %d, want 1", got)
+	}
+	if got := m.DroppedInvalidMapper(); got != 0 {
+		t.Fatalf("DroppedInvalidMapper() = %d, want 0 (wrong branch fired)", got)
+	}
+	if got := m.DroppedInvalidTimestamp(); got != 0 {
+		t.Fatalf("DroppedInvalidTimestamp() = %d, want 0 (wrong branch fired)", got)
+	}
+
+	entry := findWarnEntry(t, buf)
+	if got := entry["reason"]; got != "mapper_failure" {
+		t.Fatalf("reason = %v, want mapper_failure", got)
+	}
+}
+

--- a/internal/store/watchtower/append_drop_test.go
+++ b/internal/store/watchtower/append_drop_test.go
@@ -1,0 +1,259 @@
+package watchtower_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/audit"
+	"github.com/agentsh/agentsh/internal/metrics"
+	"github.com/agentsh/agentsh/internal/store/watchtower"
+	"github.com/agentsh/agentsh/internal/store/watchtower/compact"
+	"github.com/agentsh/agentsh/internal/store/watchtower/testserver"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// failingMapper is a Mapper that always returns the configured error.
+// Used to drive AppendEvent into the mapper_failure catch-all branch
+// without depending on a particular OCSF mapper's failure modes.
+type failingMapper struct{ err error }
+
+func (f failingMapper) Map(_ types.Event) (compact.MappedEvent, error) {
+	return compact.MappedEvent{}, f.err
+}
+
+// dropTestFixture wires a Store with a counter-asserting collector and
+// a captured logger so each test can assert the precise observability
+// emitted on a drop. The Store is constructed via watchtower.New so
+// the test exercises the real reject-site wiring, not the helpers
+// directly. A testserver is started so Options.Dialer is satisfied;
+// the transport never actually delivers anything in these tests
+// because every test path errors before WAL append.
+type dropTestFixture struct {
+	store     *watchtower.Store
+	collector *metrics.Collector
+	logBuf    *bytes.Buffer
+}
+
+func newDropFixture(t *testing.T, optsMutator func(*watchtower.Options)) *dropTestFixture {
+	t.Helper()
+	col := metrics.New()
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	srv := testserver.New(testserver.Options{})
+	t.Cleanup(srv.Close)
+
+	opts := watchtower.Options{
+		WALDir:          t.TempDir(),
+		Mapper:          compact.StubMapper{},
+		Allocator:       audit.NewSequenceAllocator(),
+		AgentID:         "a-test",
+		SessionID:       "s-test",
+		KeyFingerprint:  "sha256:drop-test",
+		HMACKeyID:       "k1",
+		HMACSecret:      bytes.Repeat([]byte("a"), 32),
+		HMACAlgorithm:   "hmac-sha256",
+		BatchMaxRecords: 8,
+		BatchMaxBytes:   8 * 1024,
+		BatchMaxAge:     50 * time.Millisecond,
+		AllowStubMapper: true,
+		Dialer:          srv.DialerFor(),
+		Metrics:         col,
+		Logger:          logger,
+	}
+	if optsMutator != nil {
+		optsMutator(&opts)
+	}
+
+	s, err := watchtower.New(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("watchtower.New: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+
+	return &dropTestFixture{store: s, collector: col, logBuf: &logBuf}
+}
+
+// dropWarnEntries returns every parsed log entry whose msg matches the
+// drop WARN string. Helper used by both findDropWarn (asserts exactly
+// one) and the happy-path test (asserts zero) so the message string
+// lives in one place.
+func dropWarnEntries(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var matches []map[string]any
+	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("parse log line %q: %v", line, err)
+		}
+		if entry["msg"] == "wtp: dropping event before WAL append" {
+			matches = append(matches, entry)
+		}
+	}
+	return matches
+}
+
+// findDropWarn parses the captured log buffer and returns the single
+// drop WARN entry. Fails the test if zero or multiple entries match.
+func (f *dropTestFixture) findDropWarn(t *testing.T) map[string]any {
+	t.Helper()
+	matches := dropWarnEntries(t, f.logBuf)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 drop WARN, got %d (full buf: %q)", len(matches), f.logBuf.String())
+	}
+	return matches[0]
+}
+
+func TestAppendEvent_DropsOnInvalidTimestamp(t *testing.T) {
+	f := newDropFixture(t, nil)
+
+	ev := types.Event{
+		Type:      "exec",
+		SessionID: "s-test",
+		Timestamp: time.Time{}, // zero value trips compact.ErrInvalidTimestamp
+		Chain:     &types.ChainState{Sequence: 1, Generation: 1},
+	}
+	err := f.store.AppendEvent(context.Background(), ev)
+	if err == nil {
+		t.Fatal("AppendEvent: expected error, got nil")
+	}
+	if !errors.Is(err, compact.ErrInvalidTimestamp) {
+		t.Fatalf("error = %v, want errors.Is(_, ErrInvalidTimestamp)", err)
+	}
+
+	if got := f.collector.WTP().DroppedInvalidTimestamp(); got != 1 {
+		t.Fatalf("DroppedInvalidTimestamp() = %d, want 1", got)
+	}
+
+	entry := f.findDropWarn(t)
+	if got := entry["reason"]; got != "invalid_timestamp" {
+		t.Fatalf("reason = %v, want invalid_timestamp", got)
+	}
+	if got := entry["event_seq"]; got != float64(1) {
+		t.Fatalf("event_seq = %v, want 1", got)
+	}
+	if got := entry["event_gen"]; got != float64(1) {
+		t.Fatalf("event_gen = %v, want 1", got)
+	}
+	if got := entry["session_id"]; got != "s-test" {
+		t.Fatalf("session_id = %v, want s-test", got)
+	}
+	if got := entry["agent_id"]; got != "a-test" {
+		t.Fatalf("agent_id = %v, want a-test", got)
+	}
+}
+
+func TestAppendEvent_DropsOnMapperFailure(t *testing.T) {
+	mapperErr := errors.New("synthetic mapper failure")
+	f := newDropFixture(t, func(opts *watchtower.Options) {
+		// failingMapper is not a StubMapper, so AllowStubMapper does not need to flip.
+		opts.Mapper = failingMapper{err: mapperErr}
+	})
+
+	ev := types.Event{
+		Type:      "exec",
+		SessionID: "s-test",
+		Timestamp: time.Now(),
+		Chain:     &types.ChainState{Sequence: 1, Generation: 1},
+	}
+	err := f.store.AppendEvent(context.Background(), ev)
+	if err == nil {
+		t.Fatal("AppendEvent: expected error, got nil")
+	}
+	if !errors.Is(err, mapperErr) {
+		t.Fatalf("error = %v, want errors.Is(_, mapperErr)", err)
+	}
+
+	if got := f.collector.WTP().DroppedMapperFailure(); got != 1 {
+		t.Fatalf("DroppedMapperFailure() = %d, want 1", got)
+	}
+
+	entry := f.findDropWarn(t)
+	if got := entry["reason"]; got != "mapper_failure" {
+		t.Fatalf("reason = %v, want mapper_failure", got)
+	}
+	if got := entry["err"]; got == nil || !strings.Contains(got.(string), "synthetic mapper failure") {
+		t.Fatalf("err attr = %v, want non-empty containing %q", got, "synthetic mapper failure")
+	}
+}
+
+func TestAppendEvent_DropsOnSequenceOverflow(t *testing.T) {
+	f := newDropFixture(t, nil)
+
+	ev := types.Event{
+		Type:      "exec",
+		SessionID: "s-test",
+		Timestamp: time.Now(),
+		Chain:     &types.ChainState{Sequence: math.MaxInt64 + 1, Generation: 1},
+	}
+	err := f.store.AppendEvent(context.Background(), ev)
+	if err == nil {
+		t.Fatal("AppendEvent: expected error, got nil")
+	}
+	// sequence_overflow has no sentinel — assert on the message substring.
+	if !strings.Contains(err.Error(), "overflows int64") {
+		t.Fatalf("error = %v, want message containing %q", err, "overflows int64")
+	}
+
+	if got := f.collector.WTP().DroppedSequenceOverflow(); got != 1 {
+		t.Fatalf("DroppedSequenceOverflow() = %d, want 1", got)
+	}
+
+	entry := f.findDropWarn(t)
+	if got := entry["reason"]; got != "sequence_overflow" {
+		t.Fatalf("reason = %v, want sequence_overflow", got)
+	}
+	// No "err" attr expected — sequence_overflow is our own range check, not a wrapped sentinel.
+	if _, present := entry["err"]; present {
+		t.Fatalf("err attr present in sequence_overflow WARN; want absent")
+	}
+}
+
+func TestAppendEvent_HappyPath_NoDrops(t *testing.T) {
+	// Explicit no-op mutator so we go through the same fixture path as
+	// the failing tests; the contract under test is "valid input bumps
+	// no drop counter and emits no drop WARN."
+	f := newDropFixture(t, nil)
+
+	ev := types.Event{
+		Type:      "exec",
+		SessionID: "s-test",
+		Timestamp: time.Now(),
+		Chain:     &types.ChainState{Sequence: 1, Generation: 1},
+	}
+	if err := f.store.AppendEvent(context.Background(), ev); err != nil {
+		t.Fatalf("AppendEvent (happy path): %v", err)
+	}
+
+	wtp := f.collector.WTP()
+	if got := wtp.DroppedSequenceOverflow(); got != 0 {
+		t.Errorf("DroppedSequenceOverflow() = %d, want 0", got)
+	}
+	if got := wtp.DroppedInvalidMapper(); got != 0 {
+		t.Errorf("DroppedInvalidMapper() = %d, want 0", got)
+	}
+	if got := wtp.DroppedInvalidTimestamp(); got != 0 {
+		t.Errorf("DroppedInvalidTimestamp() = %d, want 0", got)
+	}
+	if got := wtp.DroppedMapperFailure(); got != 0 {
+		t.Errorf("DroppedMapperFailure() = %d, want 0", got)
+	}
+	if got := wtp.DroppedInvalidUTF8(); got != 0 {
+		t.Errorf("DroppedInvalidUTF8() = %d, want 0", got)
+	}
+
+	// No drop WARN should have fired.
+	if drops := dropWarnEntries(t, f.logBuf); len(drops) > 0 {
+		t.Fatalf("happy-path append emitted %d drop WARN(s); want 0: %v", len(drops), drops)
+	}
+}

--- a/internal/store/watchtower/append_drop_test.go
+++ b/internal/store/watchtower/append_drop_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"math"
 	"strings"
@@ -184,6 +185,72 @@ func TestAppendEvent_DropsOnMapperFailure(t *testing.T) {
 	}
 	if got := entry["err"]; got == nil || !strings.Contains(got.(string), "synthetic mapper failure") {
 		t.Fatalf("err attr = %v, want non-empty containing %q", got, "synthetic mapper failure")
+	}
+}
+
+// TestAppendEvent_MapperReturningWrappedSentinelStaysMapperFailure pins
+// the end-to-end roborev #6177/#6180 contract: a Mapper whose Map
+// method returns a wrapped variant of compact.ErrInvalidMapper or
+// compact.ErrInvalidTimestamp MUST be classified as `mapper_failure`,
+// not as the validation-gate counter the inner sentinel would
+// otherwise match. The internal helper test pins this for the
+// classifier in isolation; this test exercises the same invariant
+// through real AppendEvent → compact.Encode → recordCompactEncodeFailure.
+func TestAppendEvent_MapperReturningWrappedSentinelStaysMapperFailure(t *testing.T) {
+	cases := []struct {
+		name  string
+		inner error
+	}{
+		{"inner=ErrInvalidMapper", compact.ErrInvalidMapper},
+		{"inner=ErrInvalidTimestamp", compact.ErrInvalidTimestamp},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mapper returns a wrapped sentinel — exactly the case where
+			// the classifier could leak into the wrong counter without
+			// the ErrMapperFailure priority guard.
+			mapperErr := fmt.Errorf("mapper logic returned: %w", tc.inner)
+			f := newDropFixture(t, func(opts *watchtower.Options) {
+				// failingMapper is not a StubMapper, so AllowStubMapper does not need to flip.
+				opts.Mapper = failingMapper{err: mapperErr}
+			})
+
+			ev := types.Event{
+				Type:      "exec",
+				SessionID: "s-test",
+				Timestamp: time.Now(),
+				Chain:     &types.ChainState{Sequence: 1, Generation: 1},
+			}
+			err := f.store.AppendEvent(context.Background(), ev)
+			if err == nil {
+				t.Fatal("AppendEvent: expected error, got nil")
+			}
+			// The inner sentinel is reachable via errors.Is (chain
+			// preservation), AND so is the mapper-failure outer
+			// sentinel — both contracts hold simultaneously.
+			if !errors.Is(err, tc.inner) {
+				t.Fatalf("error = %v, want errors.Is(_, %v)", err, tc.inner)
+			}
+			if !errors.Is(err, compact.ErrMapperFailure) {
+				t.Fatalf("error = %v, want errors.Is(_, ErrMapperFailure)", err)
+			}
+
+			wtp := f.collector.WTP()
+			if got := wtp.DroppedMapperFailure(); got != 1 {
+				t.Fatalf("DroppedMapperFailure() = %d, want 1", got)
+			}
+			if got := wtp.DroppedInvalidMapper(); got != 0 {
+				t.Fatalf("DroppedInvalidMapper() = %d, want 0 (inner sentinel must NOT leak past classifier)", got)
+			}
+			if got := wtp.DroppedInvalidTimestamp(); got != 0 {
+				t.Fatalf("DroppedInvalidTimestamp() = %d, want 0 (inner sentinel must NOT leak past classifier)", got)
+			}
+
+			entry := f.findDropWarn(t)
+			if got := entry["reason"]; got != "mapper_failure" {
+				t.Fatalf("reason = %v, want mapper_failure", got)
+			}
+		})
 	}
 }
 

--- a/internal/store/watchtower/compact/encoder.go
+++ b/internal/store/watchtower/compact/encoder.go
@@ -2,7 +2,6 @@ package compact
 
 import (
 	"errors"
-	"fmt"
 	"reflect"
 
 	"github.com/agentsh/agentsh/pkg/types"
@@ -37,6 +36,35 @@ var ErrInvalidTimestamp = errors.New("compact.Encode: ev.Timestamp must be non-z
 // originated sentinel does not leak into the validation-gate
 // counters; see watchtower.recordCompactEncodeFailure.
 var ErrMapperFailure = errors.New("compact mapper")
+
+// mapperFailureErr is the wrapper Encode returns when m.Map errors.
+// It implements:
+//
+//   - Error() — same wire string as the previous fmt.Errorf form
+//     (`"compact mapper: <inner>"`) so log/diagnostic output is
+//     unchanged.
+//   - Unwrap() error — preserves the LINEAR unwrap contract: callers
+//     using `errors.Unwrap(encodeErr)` get the original mapper error
+//     directly, matching the behavior the encoder shipped before
+//     ErrMapperFailure was introduced (roborev #6180 Low).
+//   - Is(target error) — matches ErrMapperFailure so
+//     errors.Is(err, ErrMapperFailure) returns true. The inner sentinel
+//     (if any) is reachable via Unwrap chain, so errors.Is against
+//     ErrInvalidMapper / ErrInvalidTimestamp also still works.
+//
+// The previous `fmt.Errorf("%w: %w", ErrMapperFailure, err)` form
+// produced an Unwrap() []error multi-wrap whose linear errors.Unwrap
+// returned nil — a silent contract change for any caller that used
+// linear unwrapping. This explicit type pins the contract.
+type mapperFailureErr struct{ inner error }
+
+func (e *mapperFailureErr) Error() string {
+	return ErrMapperFailure.Error() + ": " + e.inner.Error()
+}
+
+func (e *mapperFailureErr) Unwrap() error { return e.inner }
+
+func (e *mapperFailureErr) Is(target error) bool { return target == ErrMapperFailure }
 
 // Encode projects an agentsh event into a wtpv1.CompactEvent, populating
 // everything EXCEPT the IntegrityRecord. The IntegrityRecord is filled in by
@@ -81,7 +109,7 @@ func Encode(m Mapper, ev types.Event) (*wtpv1.CompactEvent, error) {
 	}
 	mapped, err := m.Map(ev)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %w", ErrMapperFailure, err)
+		return nil, &mapperFailureErr{inner: err}
 	}
 	return &wtpv1.CompactEvent{
 		Sequence:           ev.Chain.Sequence,

--- a/internal/store/watchtower/compact/encoder.go
+++ b/internal/store/watchtower/compact/encoder.go
@@ -25,6 +25,19 @@ var ErrMissingChain = errors.New("compact.Encode: ev.Chain is nil; composite did
 // when cast to uint64 nanoseconds, masking caller bugs in the hot path.
 var ErrInvalidTimestamp = errors.New("compact.Encode: ev.Timestamp must be non-zero and ≥ Unix epoch")
 
+// ErrMapperFailure is the OUTER sentinel that wraps every error
+// returned from a Mapper's Map method. It distinguishes "Encode's own
+// validation gates fired" (bare ErrInvalidMapper / ErrInvalidTimestamp
+// returned from Encode's pre-call checks) from "the Mapper rejected
+// the event" (the call into m.Map returned an error). Without this
+// outer sentinel, a Mapper that happens to return ErrInvalidMapper or
+// ErrInvalidTimestamp would be misclassified by downstream consumers
+// using errors.Is to route drop-class metrics. Callers that classify
+// the encoder's error MUST check ErrMapperFailure FIRST so a mapper-
+// originated sentinel does not leak into the validation-gate
+// counters; see watchtower.recordCompactEncodeFailure.
+var ErrMapperFailure = errors.New("compact mapper")
+
 // Encode projects an agentsh event into a wtpv1.CompactEvent, populating
 // everything EXCEPT the IntegrityRecord. The IntegrityRecord is filled in by
 // the WTP Store in the AppendEvent transactional pattern, AFTER chain.Compute
@@ -68,7 +81,7 @@ func Encode(m Mapper, ev types.Event) (*wtpv1.CompactEvent, error) {
 	}
 	mapped, err := m.Map(ev)
 	if err != nil {
-		return nil, fmt.Errorf("compact mapper: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrMapperFailure, err)
 	}
 	return &wtpv1.CompactEvent{
 		Sequence:           ev.Chain.Sequence,

--- a/internal/store/watchtower/compact/encoder_test.go
+++ b/internal/store/watchtower/compact/encoder_test.go
@@ -92,6 +92,19 @@ func TestEncode_PropagatesMapperError(t *testing.T) {
 	if !errors.Is(err, errBoom) {
 		t.Errorf("err = %v, want wrapped errBoom", err)
 	}
+	// Pin the linear-unwrap contract preserved by mapperFailureErr
+	// (roborev #6192 Low). errors.Unwrap must return the inner error
+	// directly — a regression to multi-%w wrapping would have
+	// errors.Unwrap return nil and silently break callers using linear
+	// unwrapping.
+	if got := errors.Unwrap(err); got != errBoom {
+		t.Errorf("errors.Unwrap(err) = %v, want %v (linear unwrap broken)", got, errBoom)
+	}
+	// And errors.Is(_, ErrMapperFailure) must hold so drop-class
+	// classifiers can route to the right counter.
+	if !errors.Is(err, ErrMapperFailure) {
+		t.Errorf("err = %v, want errors.Is(_, ErrMapperFailure)", err)
+	}
 }
 
 func TestEncode_RejectsZeroTimestamp(t *testing.T) {


### PR DESCRIPTION
## Summary
- Wires the five `wtp_dropped_invalid_*_total` counters that Task 22a registered but left as zero-emit (per the SCOPE NOTE on `AppendEvent` and the producer-status table at `internal/metrics/wtp.go:463-467`).
- Three private helpers on `*Store` — `recordSequenceOverflow`, `recordCompactEncodeFailure`, `recordCanonicalFailure` — increment the matching counter and emit a structured WARN with `reason` / `event_seq` / `event_gen` / `session_id` / `agent_id` before each existing `return fmt.Errorf(...)`.
- Adds `compact.ErrMapperFailure` as the OUTER sentinel wrapping every `Mapper.Map` error, with a private `mapperFailureErr` type that preserves linear `errors.Unwrap()` AND `errors.Is(_, ErrMapperFailure)` simultaneously. The classifier checks `ErrMapperFailure` first so a Mapper that returns a wrapped validation sentinel can't leak into the wrong counter.

## Spec & plan

- Design: `docs/superpowers/specs/2026-04-25-wtp-drop-class-counters-design.md`
- Plan: `docs/superpowers/plans/2026-04-25-wtp-drop-class-counters.md`

## Roborev cycle

- #6177 (Medium): classifier could route a Mapper-returned `ErrInvalidMapper`/`ErrInvalidTimestamp` to the validation-gate counter — fixed by `ErrMapperFailure` priority.
- #6180 (Low): preserved linear `errors.Unwrap()` via dedicated wrapper type; added end-to-end wrapped-sentinel coverage.
- #6192 (Low): pinned the encoder-layer linear-unwrap contract in unit tests.
- #6194: clean.

## Test plan
- [x] `go test ./...` — all packages green
- [x] `GOOS=windows go build ./...` — clean cross-compile
- [x] New unit tests for the 5 classification branches (3 reachable + 2 defense-in-depth) plus a happy-path negative test
- [x] New end-to-end test via `watchtower.New` + `AppendEvent` for the 3 reachable drop classes + wrapped-sentinel scenarios
- [x] CI: pending (will trigger on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)