### PR TITLE
test(wtp/store): bump encoder e2e deadline 3s→15s for Windows tolerance

### DIFF
--- a/internal/store/watchtower/encoder_e2e_test.go
+++ b/internal/store/watchtower/encoder_e2e_test.go
@@ -63,7 +63,14 @@ func TestStore_AppendEvent_DeliversRealEventBatch(t *testing.T) {
 		}
 	}
 
-	deadline := time.Now().Add(3 * time.Second)
+	// Deadline is generous so Windows GitHub-runner scheduling jitter
+	// (which has flaked the 3s deadline this test originally shipped
+	// with — see post-merge CI on commits c03cc2df and 905db273)
+	// cannot trip the assertion when the underlying transport is
+	// healthy. The test polls every 20ms and breaks on first success,
+	// so a healthy run still completes in tens of milliseconds; the
+	// deadline only fires when the transport is genuinely wedged.
+	deadline := time.Now().Add(15 * time.Second)
 	var lastErr error
 	for time.Now().Before(deadline) {
 		if err := srv.AssertSequenceRange(1, 4); err == nil {
@@ -75,7 +82,7 @@ func TestStore_AppendEvent_DeliversRealEventBatch(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	if lastErr != nil {
-		t.Fatalf("did not observe seq=[1..4] within 3s: %v", lastErr)
+		t.Fatalf("did not observe seq=[1..4] within 15s: %v", lastErr)
 	}
 
 	// Drill into the recorded batches: at least one must carry a real


### PR DESCRIPTION
## Summary
- The 3s polling deadline in `TestStore_AppendEvent_DeliversRealEventBatch` (added in PR #243) has flaked on the Windows GitHub runner for two post-merge CI runs in a row: `c03cc2df` (PR #243) and `905db273` (PR #244).
- Under runner-scheduling jitter, the bidi-stream + WAL fsync + batcher tick path can slip past 3s even when the transport is healthy. Both prior post-merge runs failed with `AssertSequenceRange[1..4]: missing seq 4`.

## Fix
- Bump the deadline to 15s. The test polls every 20ms and breaks on first success, so a healthy run still completes in tens of milliseconds — the deadline only fires when the transport is genuinely wedged. Pattern matches other Windows-tolerant deadlines in the WTP test suite.

## Test plan
- [x] `go test -count=3 -run TestStore_AppendEvent_DeliversRealEventBatch ./internal/store/watchtower/` — clean
- [x] Full local `go test ./...` — clean
- [x] CI: pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)