### PR TITLE
wtp/transport: RunDone signal — eliminate Stop-after-Run-exit deadlock (Task 27c)

### DIFF
--- a/internal/store/watchtower/store.go
+++ b/internal/store/watchtower/store.go
@@ -450,11 +450,12 @@ func New(ctx context.Context, opts Options) (*Store, error) {
 // watchtower.Store on the same WAL Dir in the same process is a
 // contract violation.
 //
-// CAVEAT: under racy shutdown (Run exits between the peek and the
-// Stop goroutine launch) the Stop goroutine MAY leak. Until
-// Transport.Stop gains a non-blocking-on-late-call mode, this is the
-// least-bad shutdown shape that satisfies EventStore.Close()'s
-// no-ctx contract while still attempting graceful drain.
+// Per Task 27c, Transport.Stop now selects on transport.runDone, so a
+// Stop arriving AFTER Run has exited returns promptly instead of
+// deadlocking. The pre-Stop peek below is therefore a fast-path /
+// defense-in-depth check rather than a load-bearing dedup; the
+// previously documented "Stop goroutine MAY leak under racy
+// shutdown" caveat no longer applies.
 func (s *Store) Close() error {
 	s.closeOnce.Do(func() {
 		// Gate new AppendEvent transactions from entering the

--- a/internal/store/watchtower/transport/shutdown_test.go
+++ b/internal/store/watchtower/transport/shutdown_test.go
@@ -702,3 +702,86 @@ func TestShutdown_StopBeforeLiveExits(t *testing.T) {
 		t.Fatal("Run did not return within 2s of Stop")
 	}
 }
+
+// TestStop_AfterRunAlreadyExited is the Task 27c acceptance test: once
+// the Run loop has terminated (e.g. via SessionAck rejection), a
+// subsequent Transport.Stop call MUST return without blocking on a
+// never-closed stopReq.done channel. Without the RunDone signal,
+// Stop's send to t.stopCh succeeds (cap-1 buffer) but its <-r.done
+// wait deadlocks because no consumer ever services the request.
+//
+// The test drives Run to terminal exit via SessionAck rejection,
+// waits for Run to actually return, THEN calls Stop and asserts it
+// returns within a tight bound.
+func TestStop_AfterRunAlreadyExited(t *testing.T) {
+	conn := newFakeConn()
+	dialer := transport.DialerFunc(func(_ context.Context) (transport.Conn, error) {
+		return conn, nil
+	})
+
+	tr, err := transport.New(transport.Options{
+		Dialer:    dialer,
+		AgentID:   "a",
+		SessionID: "s",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runDone := make(chan error, 1)
+	rdrFactory := func(uint32, uint64) (*wal.Reader, error) {
+		t.Fatal("rdrFactory called; rejection should fire before Replaying/Live")
+		return nil, nil
+	}
+	go func() {
+		runDone <- tr.Run(ctx, rdrFactory, transport.LiveOptions{
+			Batcher: transport.BatcherOptions{
+				MaxRecords: 100,
+				MaxBytes:   1 << 16,
+				MaxAge:     50 * time.Millisecond,
+			},
+			MaxInflight:    8,
+			HeartbeatEvery: time.Second,
+		})
+	}()
+
+	// Drain the SessionInit; respond with a rejection.
+	select {
+	case <-conn.sendCh:
+	case <-time.After(1 * time.Second):
+		t.Fatal("no SessionInit sent")
+	}
+	conn.recvCh <- &wtpv1.ServerMessage{
+		Msg: &wtpv1.ServerMessage_SessionAck{
+			SessionAck: &wtpv1.SessionAck{
+				Accepted:     false,
+				RejectReason: "go away",
+			},
+		},
+	}
+
+	// Wait for Run to return — the precondition for the test is "Run
+	// has already exited when Stop is called". Without this wait we
+	// would race against the run loop and might hit the
+	// stopCh-still-being-consumed path instead.
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within 2s of rejection")
+	}
+
+	// Now Stop. Per Task 27c, this MUST return promptly because the
+	// RunDone signal lets Stop observe that no consumer is left.
+	stopReturned := make(chan struct{})
+	go func() {
+		tr.Stop(0)
+		close(stopReturned)
+	}()
+	select {
+	case <-stopReturned:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Stop did not return within 500ms after Run exit; RunDone signal missing")
+	}
+}

--- a/internal/store/watchtower/transport/shutdown_test.go
+++ b/internal/store/watchtower/transport/shutdown_test.go
@@ -785,3 +785,153 @@ func TestStop_AfterRunAlreadyExited(t *testing.T) {
 		t.Fatal("Stop did not return within 500ms after Run exit; RunDone signal missing")
 	}
 }
+
+// TestRun_RejectsSecondInvocation pins the roborev finding that Task
+// 27c's `defer close(t.runDone)` would panic on a second Run call
+// (close-of-closed-channel). Transport is single-use per run-loop
+// lifetime — the contract is now explicit. A second Run MUST return
+// an error rather than panic.
+func TestRun_RejectsSecondInvocation(t *testing.T) {
+	conn := newFakeConn()
+	dialer := transport.DialerFunc(func(_ context.Context) (transport.Conn, error) {
+		return conn, nil
+	})
+	tr, err := transport.New(transport.Options{
+		Dialer:    dialer,
+		AgentID:   "a",
+		SessionID: "s",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rdrFactory := func(uint32, uint64) (*wal.Reader, error) {
+		t.Fatal("rdrFactory called; rejection should fire before Replaying/Live")
+		return nil, nil
+	}
+	liveOpts := transport.LiveOptions{
+		Batcher: transport.BatcherOptions{
+			MaxRecords: 100,
+			MaxBytes:   1 << 16,
+			MaxAge:     50 * time.Millisecond,
+		},
+		MaxInflight:    8,
+		HeartbeatEvery: time.Second,
+	}
+
+	// Drive the first Run to terminal exit.
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- tr.Run(ctx, rdrFactory, liveOpts) }()
+	select {
+	case <-conn.sendCh:
+	case <-time.After(1 * time.Second):
+		t.Fatal("no SessionInit sent")
+	}
+	conn.recvCh <- &wtpv1.ServerMessage{
+		Msg: &wtpv1.ServerMessage_SessionAck{
+			SessionAck: &wtpv1.SessionAck{Accepted: false, RejectReason: "go away"},
+		},
+	}
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first Run did not return within 2s of rejection")
+	}
+
+	// Second Run MUST return an error, not panic on close-of-closed.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("second Run panicked: %v", r)
+		}
+	}()
+	err = tr.Run(ctx, rdrFactory, liveOpts)
+	if err == nil {
+		t.Fatal("second Run returned nil; want sentinel rejecting reuse")
+	}
+	if !errors.Is(err, transport.ErrTransportSingleUse) {
+		t.Fatalf("second Run returned %v; want errors.Is(...) == ErrTransportSingleUse", err)
+	}
+}
+
+// TestStop_PostEnqueueNotCalledOnRunDoneFastPath pins the roborev
+// finding that the documented seam contract (postEnqueue runs after
+// the stopCh send completes) was being violated on the runDone
+// bail-out path: the bail-out skips the send entirely, so postEnqueue
+// must NOT fire. Tests/seams that rely on "postEnqueue ran => stopCh
+// has the request" would otherwise be misled.
+func TestStop_PostEnqueueNotCalledOnRunDoneFastPath(t *testing.T) {
+	conn := newFakeConn()
+	dialer := transport.DialerFunc(func(_ context.Context) (transport.Conn, error) {
+		return conn, nil
+	})
+	tr, err := transport.New(transport.Options{
+		Dialer:    dialer,
+		AgentID:   "a",
+		SessionID: "s",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runDone := make(chan error, 1)
+	rdrFactory := func(uint32, uint64) (*wal.Reader, error) {
+		t.Fatal("rdrFactory called; rejection should fire before Replaying/Live")
+		return nil, nil
+	}
+	go func() {
+		runDone <- tr.Run(ctx, rdrFactory, transport.LiveOptions{
+			Batcher: transport.BatcherOptions{
+				MaxRecords: 100,
+				MaxBytes:   1 << 16,
+				MaxAge:     50 * time.Millisecond,
+			},
+			MaxInflight:    8,
+			HeartbeatEvery: time.Second,
+		})
+	}()
+	select {
+	case <-conn.sendCh:
+	case <-time.After(1 * time.Second):
+		t.Fatal("no SessionInit sent")
+	}
+	conn.recvCh <- &wtpv1.ServerMessage{
+		Msg: &wtpv1.ServerMessage_SessionAck{
+			SessionAck: &wtpv1.SessionAck{Accepted: false, RejectReason: "go away"},
+		},
+	}
+	select {
+	case <-runDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within 2s of rejection")
+	}
+
+	var preCalls, postCalls atomic.Int32
+	pre := func() { preCalls.Add(1) }
+	post := func() { postCalls.Add(1) }
+
+	stopReturned := make(chan struct{})
+	go func() {
+		transport.EnqueueStopAndWaitForTest(tr, 0, pre, post)
+		close(stopReturned)
+	}()
+	select {
+	case <-stopReturned:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Stop did not return within 500ms after Run exit")
+	}
+
+	// preEnqueue is documented to fire BEFORE the send attempt, so it
+	// runs even on the bail-out path — that's correct. postEnqueue is
+	// documented to fire AFTER a successful send, so on the runDone
+	// bail-out (no send) it must NOT fire.
+	if got := preCalls.Load(); got != 1 {
+		t.Errorf("preEnqueue calls = %d; want 1", got)
+	}
+	if got := postCalls.Load(); got != 0 {
+		t.Errorf("postEnqueue calls = %d; want 0 (bail-out path skipped the send)", got)
+	}
+}

--- a/internal/store/watchtower/transport/transport.go
+++ b/internal/store/watchtower/transport/transport.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"github.com/agentsh/agentsh/internal/metrics"
@@ -204,6 +205,14 @@ func validate(opts Options) error {
 	return nil
 }
 
+// ErrTransportSingleUse is returned by Run when invoked a second
+// time on the same Transport. Transport is single-use per run-loop
+// lifetime — callers MUST construct a fresh Transport via New() to
+// reconnect. Per Task 27c: making Transport explicitly single-use
+// avoids the close-of-closed-channel panic that would otherwise
+// fire at `defer close(t.runDone)`.
+var ErrTransportSingleUse = errors.New("transport: Run already invoked; Transport is single-use")
+
 // Transport runs the four-state WTP client state machine. It is owned by
 // a single goroutine — callers interact via channels.
 type Transport struct {
@@ -268,6 +277,12 @@ type Transport struct {
 	// without it, Stop's <-r.done wait would deadlock because no
 	// consumer is left to service stopReq. Per Task 27c.
 	runDone chan struct{}
+
+	// runStarted guards Run's single-use contract. Set true on the
+	// first Run invocation; subsequent calls return
+	// ErrTransportSingleUse rather than panicking on
+	// `close(t.runDone)`. Per Task 27c.
+	runStarted atomic.Bool
 
 	// recv holds the per-connection recv-multiplexer state per round-22
 	// plan §"Per-connection recv state". A new recvSession is created on
@@ -482,15 +497,26 @@ func (t *Transport) stopWithHooks(drainDeadline time.Duration, preEnqueue, postE
 		preEnqueue()
 	}
 	r := stopReq{drainDeadline: drainDeadline, done: make(chan struct{})}
-	// Enqueue, but bail if Run has already exited — a send into stopCh
-	// would still succeed (cap-1 buffer) and then <-r.done would
-	// deadlock because no consumer is left. Per Task 27c.
+	// Fast-path: if Run has already exited, bail BEFORE the enqueue
+	// select. A plain `select { case stopCh <- r: case <-runDone: }`
+	// is racy when stopCh has buffer slack and runDone is closed —
+	// Go picks randomly among ready arms, so the send sometimes
+	// wins and postEnqueue fires for a request nobody will service.
+	// Per Task 27c.
+	select {
+	case <-t.runDone:
+		return
+	default:
+	}
+	// Enqueue, still racing runDone in case Run exits between the
+	// fast-path check and now.
+	//
+	// postEnqueue is documented to fire AFTER a successful send to
+	// stopCh; on the runDone bail-out below the send did NOT happen,
+	// so postEnqueue is intentionally NOT invoked.
 	select {
 	case t.stopCh <- r:
 	case <-t.runDone:
-		if postEnqueue != nil {
-			postEnqueue()
-		}
 		return
 	}
 	if postEnqueue != nil {
@@ -973,6 +999,12 @@ func (t *Transport) handleOuterStop(sr stopReq) {
 // nil) at the top of StateLive so a subsequent Live entry after a
 // reconnect picks up the fresh value (or nil if no replay ran).
 func (t *Transport) Run(ctx context.Context, rdrFactory func(gen uint32, start uint64) (*wal.Reader, error), liveOpts LiveOptions) error {
+	// Single-use guard: Run owns the close of t.runDone, so a second
+	// invocation would panic on close-of-closed-channel. Reject the
+	// second call cleanly. Per Task 27c.
+	if !t.runStarted.CompareAndSwap(false, true) {
+		return ErrTransportSingleUse
+	}
 	// Signal Stop callers that the run loop has exited regardless of
 	// which return path is taken (ctx cancel, Stop request, terminal
 	// error). Stop selects on t.runDone so a Stop arriving AFTER the

--- a/internal/store/watchtower/transport/transport.go
+++ b/internal/store/watchtower/transport/transport.go
@@ -261,6 +261,14 @@ type Transport struct {
 	// drains it on the next pass. See Stop / runShutdown.
 	stopCh chan stopReq
 
+	// runDone is closed by Run's defer when the run loop returns
+	// (any path: ctx cancel, Stop, or terminal error such as
+	// SessionAck rejection). Stop selects on this channel so it
+	// returns promptly when called AFTER Run has already exited —
+	// without it, Stop's <-r.done wait would deadlock because no
+	// consumer is left to service stopReq. Per Task 27c.
+	runDone chan struct{}
+
 	// recv holds the per-connection recv-multiplexer state per round-22
 	// plan §"Per-connection recv state". A new recvSession is created on
 	// each successful dial and discarded on every tear-down; the field
@@ -307,6 +315,7 @@ func New(opts Options) (*Transport, error) {
 		metrics:           opts.Metrics,
 		ackAnomalyLimiter: rate.NewLimiter(rate.Every(time.Minute), 1),
 		stopCh:            make(chan stopReq, 1),
+		runDone:           make(chan struct{}),
 	}
 	if opts.InitialAckTuple != nil && opts.InitialAckTuple.Present {
 		seed := AckCursor{
@@ -473,11 +482,26 @@ func (t *Transport) stopWithHooks(drainDeadline time.Duration, preEnqueue, postE
 		preEnqueue()
 	}
 	r := stopReq{drainDeadline: drainDeadline, done: make(chan struct{})}
-	t.stopCh <- r
+	// Enqueue, but bail if Run has already exited — a send into stopCh
+	// would still succeed (cap-1 buffer) and then <-r.done would
+	// deadlock because no consumer is left. Per Task 27c.
+	select {
+	case t.stopCh <- r:
+	case <-t.runDone:
+		if postEnqueue != nil {
+			postEnqueue()
+		}
+		return
+	}
 	if postEnqueue != nil {
 		postEnqueue()
 	}
-	<-r.done
+	// Wait for the run loop to service the request OR for it to have
+	// exited via another path between enqueue and now.
+	select {
+	case <-r.done:
+	case <-t.runDone:
+	}
 }
 
 // sessionInit returns the SessionInit message for the current connection.
@@ -949,6 +973,12 @@ func (t *Transport) handleOuterStop(sr stopReq) {
 // nil) at the top of StateLive so a subsequent Live entry after a
 // reconnect picks up the fresh value (or nil if no replay ran).
 func (t *Transport) Run(ctx context.Context, rdrFactory func(gen uint32, start uint64) (*wal.Reader, error), liveOpts LiveOptions) error {
+	// Signal Stop callers that the run loop has exited regardless of
+	// which return path is taken (ctx cancel, Stop request, terminal
+	// error). Stop selects on t.runDone so a Stop arriving AFTER the
+	// loop has already returned does not deadlock on stopReq.done.
+	// Per Task 27c.
+	defer close(t.runDone)
 	bo := NewBackoff(BackoffOptions{
 		Initial: 200 * time.Millisecond,
 		Max:     30 * time.Second,


### PR DESCRIPTION
## Summary

Closes Task 27c per the WTP plan (`docs/superpowers/plans/2026-04-18-wtp-client.md`). Adds a `RunDone chan struct{}` on `*Transport`, closed in `Run`'s defer, so a `Transport.Stop` arriving AFTER `Run` has already exited returns promptly instead of deadlocking on a never-serviced `stopReq.done`.

Eliminates the narrow race `watchtower.Store.Close()`'s pre-Stop `runDone` peek was working around: if `Run` exited between the peek and the `Stop` goroutine launch, the goroutine would leak on `<-r.done`. The peek is left in place as a fast-path / defense-in-depth check; the load-bearing dedup is now in transport.

Also makes `Transport.Run` explicitly single-use (atomic.Bool guard) so a second invocation returns `ErrTransportSingleUse` instead of panicking on `close(t.runDone)`. Tightens the seam contract: `postEnqueue` is no longer invoked on the `runDone` bail-out path.

## Scope

- `internal/store/watchtower/transport/transport.go` — RunDone field, Run-loop defer, single-use guard, `stopWithHooks` selects on RunDone
- `internal/store/watchtower/transport/shutdown_test.go` — `TestStop_AfterRunAlreadyExited`, `TestRun_RejectsSecondInvocation`, `TestStop_PostEnqueueNotCalledOnRunDoneFastPath`
- `internal/store/watchtower/store.go` — replaces obsolete CAVEAT in `Close` docstring (the leak it described is what 27c fixes)

## Out of scope

Per Task 27c spec: the wedged-goroutine path (a goroutine parked in a ctx-ignoring `Send/Recv/Dial`) stays guarded by `ErrCloseSafetyNet`. `TestStore_CloseSafetyNetReturnsSentinel` still passes.

## Roborev

Two rounds: first found 1 Medium + 1 Low, both addressed. Second pass: clean.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `GOOS=windows go build ./...` — clean
- [x] `GOOS=darwin go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] Stress-tested at -count=50 across the transport tests — deterministic

🤖 Generated with [Claude Code](https://claude.com/claude-code)