### PR TITLE
wtp/transport: close SCAFFOLDING ONLY blockers (Task 27 prereq)

### DIFF
--- a/internal/store/watchtower/component_drop_test.go
+++ b/internal/store/watchtower/component_drop_test.go
@@ -29,30 +29,13 @@ import (
 // test is verifying is only that no sequence is PERMANENTLY missing,
 // not that exactly one copy of each was observed.
 func TestStore_DropsMidBatchTriggersReplay(t *testing.T) {
-	// SKIPPED until the recv-goroutine startup gap documented in
-	// transport.Run (internal/store/watchtower/transport/transport.go,
-	// "SCAFFOLDING ONLY" header at the Run() docstring) is closed.
-	//
-	// The contract this test exercises is "server drops Stream#1 mid-
-	// transmission → client must reconnect and re-send every record
-	// past the remote ack cursor." Today that loop deterministically
-	// stalls because Run never calls newRecvSession / runRecv after a
-	// successful dial:
-	//   - runLive's recvErrCh / recvEventCh arms are dormant (nil-
-	//     channel semantics), so a server-side stream close is invisible
-	//     to the state machine.
-	//   - The replay-side drains the WAL faster than gRPC propagates the
-	//     server close, so all post-drop conn.Send calls succeed locally,
-	//     runReplaying returns StateLive, and runLive then blocks
-	//     forever on a half-dead conn.
-	// The test passes only when the producer/replayer timing happens to
-	// surface a Send EOF before the WAL drain finishes — racy by
-	// construction, deterministically failing under -cpu=1.
-	//
-	// Re-enable as part of Task 17/18 (recv multiplexer wiring) +
-	// Task 22/27 (Run-loop recv-goroutine startup hook) per the plan
-	// at docs/superpowers/plans/2026-04-18-wtp-client.md.
-	t.Skip("blocked on Task 17/18 + 22/27 recv-goroutine startup; see transport.Run scaffolding header")
+	// Unskipped: the recv-goroutine startup gap, the inflight
+	// increment-only bug, and the wire-encoding stub — the three
+	// blockers documented in the original transport.Run "SCAFFOLDING
+	// ONLY" header — are all closed (see Run's updated docstring).
+	// runLive's recvErrCh / recvEventCh arms are now alive, server-
+	// side stream closes are visible, and BatchAck releases inflight
+	// slots so the send path no longer stalls at MaxInflight.
 
 	srv := testserver.New(testserver.Options{
 		DropAfterBatchN:     2,

--- a/internal/store/watchtower/transport/inflight.go
+++ b/internal/store/watchtower/transport/inflight.go
@@ -1,0 +1,53 @@
+package transport
+
+// inflightTracker tracks the (generation, sequence) high-watermarks of
+// EventBatches that have been Sent but not yet covered by an
+// AckOutcomeAdopted BatchAck. The WTP protocol allows a single
+// BatchAck to coalesce acknowledgements for multiple batches via its
+// AckHighWatermarkSeq + Generation tuple, so a counter that
+// decrements by one per ack would under-release the inflight window
+// against any conforming server that batches acknowledgements
+// (roborev Medium round-3). Release pops every pending entry whose
+// high-watermark is at or below the adopted ack's (gen, seq) tuple.
+//
+// Pending entries are appended in send order; the protocol guarantees
+// (gen, seq) is monotonically non-decreasing across successive Sends
+// on the same connection, so a prefix-pop is correct.
+type inflightTracker struct {
+	pending []AckCursor
+}
+
+// Push records an EventBatch boundary. (gen, seq) is the high-
+// watermark of the batch's records — the same tuple the server will
+// echo back via BatchAck.AckHighWatermarkSeq + Generation.
+func (it *inflightTracker) Push(gen uint32, seq uint64) {
+	it.pending = append(it.pending, AckCursor{Sequence: seq, Generation: gen})
+}
+
+// Release pops the longest prefix of pending whose high-watermark is
+// at or below (ackGen, ackSeq). Returns the number of batches
+// released so callers can observe coalesced-ack progress.
+//
+// Lexicographic ordering: a pending entry is "at or below" the ack if
+// its generation is strictly lower, or its generation matches AND its
+// sequence is at or below the ack sequence. A higher-generation
+// entry is always above the ack regardless of sequence (the ack
+// belongs to a prior generation that has rolled over).
+func (it *inflightTracker) Release(ackGen uint32, ackSeq uint64) int {
+	n := 0
+	for n < len(it.pending) {
+		p := it.pending[n]
+		if p.Generation > ackGen || (p.Generation == ackGen && p.Sequence > ackSeq) {
+			break
+		}
+		n++
+	}
+	if n > 0 {
+		it.pending = it.pending[n:]
+	}
+	return n
+}
+
+// Len returns the number of pending (un-acked) batches. Used by
+// runLive to gate further sends against MaxInflight.
+func (it *inflightTracker) Len() int { return len(it.pending) }

--- a/internal/store/watchtower/transport/inflight_test.go
+++ b/internal/store/watchtower/transport/inflight_test.go
@@ -1,0 +1,109 @@
+package transport
+
+import "testing"
+
+// TestInflightTracker_PushReleasePerBatchAck pins the per-batch ack
+// case (server sends one BatchAck per Send): four pushes with
+// strictly increasing seqs in the same generation, then a single
+// Release with the high-water of the last → all four released.
+func TestInflightTracker_PushReleasePerBatchAck(t *testing.T) {
+	var it inflightTracker
+	for _, seq := range []uint64{10, 20, 30, 40} {
+		it.Push(1, seq)
+	}
+	if got := it.Len(); got != 4 {
+		t.Fatalf("Len after 4 pushes: got %d, want 4", got)
+	}
+
+	released := it.Release(1, 40)
+	if released != 4 {
+		t.Errorf("Release(1,40): got %d, want 4 (cumulative ack covers all)", released)
+	}
+	if got := it.Len(); got != 0 {
+		t.Errorf("Len after full release: got %d, want 0", got)
+	}
+}
+
+// TestInflightTracker_CumulativeAckReleasesAllCovered pins the
+// roborev Medium round-3 finding: a single Adopted BatchAck whose
+// high-watermark covers multiple unacked batches MUST release every
+// covered batch, not just one. Counter-decrement-by-one would stall
+// the send path against a coalescing server.
+func TestInflightTracker_CumulativeAckReleasesAllCovered(t *testing.T) {
+	var it inflightTracker
+	for _, seq := range []uint64{10, 20, 30, 40} {
+		it.Push(1, seq)
+	}
+
+	// Cumulative ack covers the first two batches only.
+	released := it.Release(1, 25)
+	if released != 2 {
+		t.Errorf("Release(1,25) covering [10,20] only: got %d, want 2", released)
+	}
+	if got := it.Len(); got != 2 {
+		t.Errorf("Len after partial release: got %d, want 2", got)
+	}
+
+	// Subsequent ack covers the remaining two.
+	released = it.Release(1, 40)
+	if released != 2 {
+		t.Errorf("Release(1,40) covering [30,40]: got %d, want 2", released)
+	}
+	if got := it.Len(); got != 0 {
+		t.Errorf("Len after final release: got %d, want 0", got)
+	}
+}
+
+// TestInflightTracker_StaleAckBelowFrontReleasesNothing — an ack at
+// or below the oldest pending batch's high-watermark must not pop
+// anything. The reviewer's concern path: a duplicate or stale
+// BatchAck must not over-release the window.
+func TestInflightTracker_StaleAckBelowFrontReleasesNothing(t *testing.T) {
+	var it inflightTracker
+	it.Push(1, 100)
+
+	if released := it.Release(1, 50); released != 0 {
+		t.Errorf("Release(1,50) below front=(1,100): got %d, want 0", released)
+	}
+	if got := it.Len(); got != 1 {
+		t.Errorf("Len after stale ack: got %d, want 1", got)
+	}
+}
+
+// TestInflightTracker_GenerationBoundary verifies the lexicographic
+// ordering across generation rolls: an ack at (gen=2, seq=5)
+// releases ALL gen=1 entries (regardless of seq) AND any gen=2
+// entries with seq ≤ 5.
+func TestInflightTracker_GenerationBoundary(t *testing.T) {
+	var it inflightTracker
+	it.Push(1, 10)
+	it.Push(1, 20)
+	it.Push(2, 5)
+	it.Push(2, 15)
+
+	released := it.Release(2, 5)
+	if released != 3 {
+		t.Errorf("Release(2,5) covering [(1,10),(1,20),(2,5)]: got %d, want 3", released)
+	}
+	if got := it.Len(); got != 1 {
+		t.Errorf("Len after cross-generation release: got %d, want 1", got)
+	}
+}
+
+// TestInflightTracker_HigherGenerationAckReleasesAllPriorGenerations —
+// a generation roll is a hard boundary: any ack in a later
+// generation covers ALL prior-generation pending entries even if
+// the ack's sequence is small.
+func TestInflightTracker_HigherGenerationAckReleasesAllPriorGenerations(t *testing.T) {
+	var it inflightTracker
+	it.Push(1, 1000)
+	it.Push(1, 2000)
+
+	released := it.Release(2, 0)
+	if released != 2 {
+		t.Errorf("Release(2,0) above prior generation [1,*]: got %d, want 2", released)
+	}
+	if got := it.Len(); got != 0 {
+		t.Errorf("Len after generation-skip release: got %d, want 0", got)
+	}
+}

--- a/internal/store/watchtower/transport/recv_multiplexer.go
+++ b/internal/store/watchtower/transport/recv_multiplexer.go
@@ -136,6 +136,24 @@ func (t *Transport) teardownRecv() {
 	<-rs.done
 }
 
+// startRecv constructs a recvSession bound to the given parent context
+// and starts the runRecv goroutine. Called by runConnecting on a
+// successful (accepted) SessionAck so that runReplaying / runLive can
+// consume BatchAck, ServerHeartbeat, Goaway, and stream-error events
+// via the recvSession channels. Paired one-to-one with teardownRecv on
+// every conn-close exit path.
+//
+// Preconditions: t.conn is set; t.recv is nil. The latter is enforced
+// by the run-loop lifecycle — every state-handler exit path that
+// closes the conn calls teardownRecv (which sets t.recv = nil) before
+// the loop re-enters runConnecting, so a clean entry to runConnecting
+// always sees t.recv == nil.
+func (t *Transport) startRecv(parent context.Context) {
+	rs := newRecvSession(parent)
+	t.recv = rs
+	go t.runRecv(rs)
+}
+
 // runRecv is the recv-goroutine loop. It calls t.conn.Recv() repeatedly,
 // demuxes the inbound *wtpv1.ServerMessage frame into a tagged-union
 // recvAckEvent, and pushes the event onto rs.eventCh in strict wire

--- a/internal/store/watchtower/transport/recv_multiplexer.go
+++ b/internal/store/watchtower/transport/recv_multiplexer.go
@@ -417,7 +417,13 @@ func (t *Transport) applyAckFromRecv(frame string, serverGen uint32, serverSeq u
 			t.persistedAckPresent = priorPresent
 			// Server will re-deliver this watermark on the next BatchAck
 			// or ServerHeartbeat. No metric emission on the failure path.
-			return outcome.Kind
+			//
+			// Return NoOp (NOT outcome.Kind == Adopted) so runLive does
+			// NOT decrement inflight on the rolled-back attempt — a
+			// later successful re-delivery of the same watermark would
+			// otherwise decrement again, allowing the client to exceed
+			// MaxInflight (roborev Medium follow-up).
+			return AckOutcomeNoOp
 		}
 		t.metrics.SetAckHighWatermark(int64(t.persistedAck.Sequence))
 	case AckOutcomeResendNeeded:

--- a/internal/store/watchtower/transport/recv_multiplexer.go
+++ b/internal/store/watchtower/transport/recv_multiplexer.go
@@ -348,7 +348,14 @@ func (t *Transport) runRecv(rs *recvSession) {
 // the gauge; ResendNeeded logs INFO and regresses remoteReplayCursor
 // only; Anomaly logs WARN and leaves both cursors unchanged; NoOp
 // is silent.
-func (t *Transport) applyAckFromRecv(frame string, serverGen uint32, serverSeq uint64) {
+//
+// Returns the AckOutcomeKind so callers (runLive) can release a slot
+// in the inflight window only when the ack actually advanced the
+// acknowledged watermark (AckOutcomeAdopted). Decrementing on
+// Anomaly / ResendNeeded / NoOp would let duplicate or stale acks
+// reopen send capacity without a newly acknowledged batch and so
+// allow the client to exceed MaxInflight (roborev Medium).
+func (t *Transport) applyAckFromRecv(frame string, serverGen uint32, serverSeq uint64) AckOutcomeKind {
 	// Snapshot BOTH cursors before the helper mutates — required for
 	// rollback on Adopted-then-MarkAcked-failure per Task 15.1 Step 1b.5.
 	priorPersisted := t.persistedAck
@@ -410,7 +417,7 @@ func (t *Transport) applyAckFromRecv(frame string, serverGen uint32, serverSeq u
 			t.persistedAckPresent = priorPresent
 			// Server will re-deliver this watermark on the next BatchAck
 			// or ServerHeartbeat. No metric emission on the failure path.
-			return
+			return outcome.Kind
 		}
 		t.metrics.SetAckHighWatermark(int64(t.persistedAck.Sequence))
 	case AckOutcomeResendNeeded:
@@ -436,6 +443,7 @@ func (t *Transport) applyAckFromRecv(frame string, serverGen uint32, serverSeq u
 	case AckOutcomeNoOp:
 		// No cursor moved; nothing to do.
 	}
+	return outcome.Kind
 }
 
 const (

--- a/internal/store/watchtower/transport/recv_multiplexer_test.go
+++ b/internal/store/watchtower/transport/recv_multiplexer_test.go
@@ -700,6 +700,22 @@ func TestRecvMultiplexer_BatchAckReturnsOutcomeKind(t *testing.T) {
 			t.Fatalf("rolled-back ack: got outcome %v, want non-Adopted (rollback path must not gate inflight--)", got)
 		}
 	})
+
+	t.Run("Heartbeat_advancing_returns_Adopted", func(t *testing.T) {
+		// Pins the roborev Medium round-4 finding: ServerHeartbeat
+		// uses the same ack clamp as BatchAck and may carry an ack
+		// advance when a BatchAck was missed. runLive MUST be able
+		// to release inflight slots from a heartbeat-driven advance
+		// or the sender wedges at MaxInflight until reconnect.
+		env := newClampTestEnv(t, Options{})
+		SetAckAnomalyLimiterForTest(env.tr, permissiveLimiter())
+		appendDataInGen(t, env.w, 1, 1, 100)
+
+		got := env.tr.applyAckFromRecv("server_heartbeat", 1, 50)
+		if got != AckOutcomeAdopted {
+			t.Fatalf("Adopted heartbeat ack: got outcome %v, want AckOutcomeAdopted", got)
+		}
+	})
 }
 
 // silence unused import warnings for wal package; the wal package is needed

--- a/internal/store/watchtower/transport/recv_multiplexer_test.go
+++ b/internal/store/watchtower/transport/recv_multiplexer_test.go
@@ -676,6 +676,30 @@ func TestRecvMultiplexer_BatchAckReturnsOutcomeKind(t *testing.T) {
 			t.Fatalf("Duplicate ack: got outcome %v, want AckOutcomeNoOp", got)
 		}
 	})
+
+	t.Run("MarkAcked_failure_does_not_report_Adopted", func(t *testing.T) {
+		// Pins the roborev Medium follow-up: when walMarkAckedFn fails,
+		// applyAckFromRecv rolls the cursors back and MUST NOT report
+		// AckOutcomeAdopted to the caller — runLive uses Adopted as
+		// the gate for decrementing inflight. Reporting Adopted here
+		// would let a server re-delivery of the same watermark
+		// decrement inflight twice (once on the rolled-back attempt,
+		// again on the eventual successful retry), reopening send
+		// capacity past MaxInflight without a newly persisted batch.
+		env := newClampTestEnv(t, Options{
+			InitialAckTuple: &AckTuple{Sequence: 50, Generation: 7, Present: true},
+		})
+		SetAckAnomalyLimiterForTest(env.tr, permissiveLimiter())
+		appendDataInGen(t, env.w, 1, 7, 200)
+		SetWALMarkAckedFnForTest(env.tr, func(_ uint32, _ uint64) error {
+			return errors.New("disk full")
+		})
+
+		got := env.tr.applyAckFromRecv("batch_ack", 7, 100)
+		if got == AckOutcomeAdopted {
+			t.Fatalf("rolled-back ack: got outcome %v, want non-Adopted (rollback path must not gate inflight--)", got)
+		}
+	})
 }
 
 // silence unused import warnings for wal package; the wal package is needed

--- a/internal/store/watchtower/transport/recv_multiplexer_test.go
+++ b/internal/store/watchtower/transport/recv_multiplexer_test.go
@@ -610,6 +610,74 @@ func TestRecvMultiplexer_BatchAckAdoptedDoesNotAdvanceOnMarkAckedFailure(t *test
 	}
 }
 
+// TestRecvMultiplexer_BatchAckReturnsOutcomeKind pins the contract that
+// applyAckFromRecv reports the outcome to its caller so runLive can
+// release a slot in the inflight window ONLY when the ack actually
+// advanced the live acknowledged watermark (AckOutcomeAdopted).
+// Decrementing on Anomaly / ResendNeeded / NoOp would let duplicate or
+// stale BatchAcks reopen send capacity without a newly acknowledged
+// batch and so allow the client to exceed MaxInflight (roborev Medium).
+func TestRecvMultiplexer_BatchAckReturnsOutcomeKind(t *testing.T) {
+	t.Run("Adopted_advancing_ack", func(t *testing.T) {
+		env := newClampTestEnv(t, Options{})
+		SetAckAnomalyLimiterForTest(env.tr, permissiveLimiter())
+		appendDataInGen(t, env.w, 1, 1, 100)
+
+		got := env.tr.applyAckFromRecv("batch_ack", 1, 50)
+		if got != AckOutcomeAdopted {
+			t.Fatalf("Adopted ack: got outcome %v, want AckOutcomeAdopted", got)
+		}
+	})
+
+	t.Run("ResendNeeded_lower_seq_same_gen", func(t *testing.T) {
+		env := newClampTestEnv(t, Options{
+			InitialAckTuple: &AckTuple{Sequence: 100, Generation: 7, Present: true},
+		})
+		SetAckAnomalyLimiterForTest(env.tr, permissiveLimiter())
+		appendDataInGen(t, env.w, 1, 7, 200)
+		if err := env.w.MarkAcked(7, 100); err != nil {
+			t.Fatalf("MarkAcked seed: %v", err)
+		}
+
+		got := env.tr.applyAckFromRecv("batch_ack", 7, 50)
+		if got != AckOutcomeResendNeeded {
+			t.Fatalf("ResendNeeded ack: got outcome %v, want AckOutcomeResendNeeded", got)
+		}
+	})
+
+	t.Run("Anomaly_lower_generation", func(t *testing.T) {
+		env := newClampTestEnv(t, Options{
+			InitialAckTuple: &AckTuple{Sequence: 100, Generation: 7, Present: true},
+		})
+		SetAckAnomalyLimiterForTest(env.tr, permissiveLimiter())
+		appendDataInGen(t, env.w, 1, 7, 200)
+		if err := env.w.MarkAcked(7, 100); err != nil {
+			t.Fatalf("MarkAcked seed: %v", err)
+		}
+
+		got := env.tr.applyAckFromRecv("batch_ack", 5, 50)
+		if got != AckOutcomeAnomaly {
+			t.Fatalf("Anomaly ack: got outcome %v, want AckOutcomeAnomaly", got)
+		}
+	})
+
+	t.Run("NoOp_duplicate_same_tuple", func(t *testing.T) {
+		env := newClampTestEnv(t, Options{
+			InitialAckTuple: &AckTuple{Sequence: 100, Generation: 7, Present: true},
+		})
+		SetAckAnomalyLimiterForTest(env.tr, permissiveLimiter())
+		appendDataInGen(t, env.w, 1, 7, 200)
+		if err := env.w.MarkAcked(7, 100); err != nil {
+			t.Fatalf("MarkAcked seed: %v", err)
+		}
+
+		got := env.tr.applyAckFromRecv("batch_ack", 7, 100)
+		if got != AckOutcomeNoOp {
+			t.Fatalf("Duplicate ack: got outcome %v, want AckOutcomeNoOp", got)
+		}
+	})
+}
+
 // silence unused import warnings for wal package; the wal package is needed
 // for clampTestEnv types pulled in transitively in some test rows.
 var _ = wal.LossRecord{}

--- a/internal/store/watchtower/transport/recv_multiplexer_test.go
+++ b/internal/store/watchtower/transport/recv_multiplexer_test.go
@@ -696,8 +696,8 @@ func TestRecvMultiplexer_BatchAckReturnsOutcomeKind(t *testing.T) {
 		})
 
 		got := env.tr.applyAckFromRecv("batch_ack", 7, 100)
-		if got == AckOutcomeAdopted {
-			t.Fatalf("rolled-back ack: got outcome %v, want non-Adopted (rollback path must not gate inflight--)", got)
+		if got != AckOutcomeNoOp {
+			t.Fatalf("rolled-back ack: got outcome %v, want AckOutcomeNoOp (rollback path must report NoOp so runLive's inflight-- gate stays closed AND log/metric semantics match the no-cursor-moved contract)", got)
 		}
 	})
 

--- a/internal/store/watchtower/transport/state_connecting.go
+++ b/internal/store/watchtower/transport/state_connecting.go
@@ -67,6 +67,13 @@ func (t *Transport) runConnecting(ctx context.Context) (State, error) {
 	}
 
 	t.ackSessionAck(ack)
+	// Start the per-connection recv goroutine. runReplaying and
+	// runLive consume from t.recv.eventCh / t.recv.errCh; without
+	// this call those select arms remain dormant via Go's nil-
+	// channel semantics. The goroutine is torn down on every conn-
+	// close exit path in runReplaying / runLive (paired with
+	// t.teardownRecv()).
+	t.startRecv(ctx)
 	return StateReplaying, nil
 }
 

--- a/internal/store/watchtower/transport/state_connecting.go
+++ b/internal/store/watchtower/transport/state_connecting.go
@@ -154,10 +154,22 @@ func (t *Transport) ackSessionAck(ack *wtpv1.SessionAck) {
 // RunOnce runs a single state transition for testing. Production code
 // should use Run, which loops until Shutdown. The error mirrors whatever
 // the per-state handler surfaced so tests can assert on failure modes.
+//
+// Self-contained teardown: a successful runConnecting transition leaves
+// t.conn set for the next state handler to consume; the production Run
+// loop hands off ownership to runReplaying / runLive which own
+// teardown. As a single-transition seam, RunOnce closes the conn (and
+// tears down any in-flight recv session, though startRecv now runs in
+// Run, not in runConnecting) before returning so callers do not
+// inherit live resources with no owner. Per roborev Medium round-5.
 func (t *Transport) RunOnce(ctx context.Context, st State) (State, error) {
 	switch st {
 	case StateConnecting:
-		return t.runConnecting(ctx)
+		next, err := t.runConnecting(ctx)
+		if next == StateReplaying {
+			t.regressToConnecting()
+		}
+		return next, err
 	default:
 		return StateShutdown, nil
 	}

--- a/internal/store/watchtower/transport/state_connecting.go
+++ b/internal/store/watchtower/transport/state_connecting.go
@@ -67,13 +67,13 @@ func (t *Transport) runConnecting(ctx context.Context) (State, error) {
 	}
 
 	t.ackSessionAck(ack)
-	// Start the per-connection recv goroutine. runReplaying and
-	// runLive consume from t.recv.eventCh / t.recv.errCh; without
-	// this call those select arms remain dormant via Go's nil-
-	// channel semantics. The goroutine is torn down on every conn-
-	// close exit path in runReplaying / runLive (paired with
-	// t.teardownRecv()).
-	t.startRecv(ctx)
+	// NOTE: starting the recv goroutine has been moved to the Run
+	// loop so RunOnce(StateConnecting) — used by transport-level
+	// tests that drive a single state transition — does NOT leave a
+	// live recvSession with no owner to call teardownRecv. Run owns
+	// the lifecycle: it calls startRecv after runConnecting returns
+	// successfully, and runReplaying / runLive own the matching
+	// teardown. Per roborev Medium round-3.
 	return StateReplaying, nil
 }
 

--- a/internal/store/watchtower/transport/state_live.go
+++ b/internal/store/watchtower/transport/state_live.go
@@ -144,15 +144,17 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 			// this select arm dormant in that case.
 			switch ev.kind {
 			case recvAckEventBatchAck:
-				t.applyAckFromRecv("batch_ack", ev.gen, ev.seq)
-				// One batch has been fully acknowledged; release a
-				// slot in the inflight window so the next NextBatch
-				// loop iteration is not gated by stale capacity.
-				// Closes SCAFFOLDING ONLY item #3 (inflight was
-				// previously increment-only, stalling the send path
-				// at MaxInflight). Floor at zero to defend against
-				// duplicate or out-of-order BatchAcks.
-				if inflight > 0 {
+				outcome := t.applyAckFromRecv("batch_ack", ev.gen, ev.seq)
+				// Release a slot in the inflight window ONLY when the
+				// ack actually advanced the acknowledged watermark.
+				// Decrementing on Anomaly / ResendNeeded / NoOp would
+				// let duplicate or stale BatchAcks reopen send
+				// capacity without a newly acknowledged batch — the
+				// client could then exceed MaxInflight (roborev
+				// Medium). Closes SCAFFOLDING ONLY item #3 cleanly.
+				// Floor at zero so we cannot underflow even if the
+				// caller's bookkeeping has drifted.
+				if outcome == AckOutcomeAdopted && inflight > 0 {
 					inflight--
 				}
 			case recvAckEventHeartbeat:

--- a/internal/store/watchtower/transport/state_live.go
+++ b/internal/store/watchtower/transport/state_live.go
@@ -145,6 +145,16 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 			switch ev.kind {
 			case recvAckEventBatchAck:
 				t.applyAckFromRecv("batch_ack", ev.gen, ev.seq)
+				// One batch has been fully acknowledged; release a
+				// slot in the inflight window so the next NextBatch
+				// loop iteration is not gated by stale capacity.
+				// Closes SCAFFOLDING ONLY item #3 (inflight was
+				// previously increment-only, stalling the send path
+				// at MaxInflight). Floor at zero to defend against
+				// duplicate or out-of-order BatchAcks.
+				if inflight > 0 {
+					inflight--
+				}
 			case recvAckEventHeartbeat:
 				// Heartbeat carries no gen on the wire; FIFO order on
 				// eventCh guarantees any earlier BatchAck has already

--- a/internal/store/watchtower/transport/state_live.go
+++ b/internal/store/watchtower/transport/state_live.go
@@ -223,7 +223,25 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 				}
 			}
 		case now := <-tick.C:
-			if outBatch := b.Tick(now); outBatch != nil {
+			// Gate the tick-driven flush on available inflight
+			// capacity. Without this gate the tick path would send
+			// an aged batch even when inflight.Len() ==
+			// opts.MaxInflight, allowing one extra unacked batch
+			// onto the wire. The Notify path's overshoot scenario:
+			// b.Add(rec) flushes a full batch (inflight.Push), but
+			// the same Add buffers `rec` as the start of a new
+			// batch in b.pending; if the window now equals
+			// MaxInflight, the next tick.C arm would still flush
+			// that fresh batch (roborev Medium round-6).
+			//
+			// Records stay in b.pending across ticks until the
+			// window opens (a BatchAck releases capacity); the
+			// next tick after release flushes them. b.Tick is
+			// idempotent on full pending — calling it later with
+			// the same MaxAge boundary already crossed still
+			// returns the buffered batch.
+			if inflight.Len() < opts.MaxInflight {
+				if outBatch := b.Tick(now); outBatch != nil {
 				msg, err := encodeBatchMessageFn(outBatch.Records)
 				if err != nil {
 					_ = t.conn.Close()
@@ -242,6 +260,7 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 				}
 				last := outBatch.Records[len(outBatch.Records)-1]
 				inflight.Push(last.Generation, last.Sequence)
+				}
 			}
 		}
 		_ = flush // explicit lint reference; called from Drain path

--- a/internal/store/watchtower/transport/state_live.go
+++ b/internal/store/watchtower/transport/state_live.go
@@ -167,7 +167,17 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 				// eventCh guarantees any earlier BatchAck has already
 				// advanced t.persistedAck.Generation, so substituting
 				// here is safe (round-22 Finding 1 invariant).
-				t.applyAckFromRecv("server_heartbeat", t.persistedAck.Generation, ev.seq)
+				//
+				// Heartbeats use the SAME ack clamp as BatchAck and
+				// may carry an ack advance when a BatchAck was
+				// missed (per spec). Release every covered batch on
+				// an Adopted heartbeat — otherwise the sender would
+				// wedge at MaxInflight until reconnect (roborev
+				// Medium round-4).
+				outcome := t.applyAckFromRecv("server_heartbeat", t.persistedAck.Generation, ev.seq)
+				if outcome == AckOutcomeAdopted {
+					inflight.Release(t.persistedAck.Generation, ev.seq)
+				}
 			}
 		case err := <-recvErrCh:
 			// Recv goroutine surfaced a fatal stream error OR a fail-

--- a/internal/store/watchtower/transport/state_live.go
+++ b/internal/store/watchtower/transport/state_live.go
@@ -66,7 +66,12 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 	tick := time.NewTicker(opts.Batcher.MaxAge / 2)
 	defer tick.Stop()
 
-	inflight := 0
+	// Track outstanding batch boundaries by (gen, seq) so a single
+	// coalesced BatchAck releases every covered batch — a counter
+	// that decrements by one per ack would stall the send path
+	// against any conforming server that batches acknowledgements
+	// (roborev Medium round-3).
+	var inflight inflightTracker
 
 	flush := func() error {
 		batch := b.Drain()
@@ -80,7 +85,8 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 		if err := t.conn.Send(msg); err != nil {
 			return fmt.Errorf("send EventBatch: %w", err)
 		}
-		inflight++
+		last := batch.Records[len(batch.Records)-1]
+		inflight.Push(last.Generation, last.Sequence)
 		return nil
 	}
 
@@ -145,17 +151,16 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 			switch ev.kind {
 			case recvAckEventBatchAck:
 				outcome := t.applyAckFromRecv("batch_ack", ev.gen, ev.seq)
-				// Release a slot in the inflight window ONLY when the
-				// ack actually advanced the acknowledged watermark.
-				// Decrementing on Anomaly / ResendNeeded / NoOp would
-				// let duplicate or stale BatchAcks reopen send
-				// capacity without a newly acknowledged batch — the
-				// client could then exceed MaxInflight (roborev
-				// Medium). Closes SCAFFOLDING ONLY item #3 cleanly.
-				// Floor at zero so we cannot underflow even if the
-				// caller's bookkeeping has drifted.
-				if outcome == AckOutcomeAdopted && inflight > 0 {
-					inflight--
+				// Release every pending batch whose high-watermark is
+				// at or below the adopted ack — a coalesced BatchAck
+				// can cover several Sends, and decrementing by one
+				// would stall the send path. Anomaly / ResendNeeded /
+				// NoOp acks are NOT a release event (cursor did not
+				// advance); the rolled-back-Adopted path also returns
+				// NoOp from applyAckFromRecv so it is correctly
+				// excluded here.
+				if outcome == AckOutcomeAdopted {
+					inflight.Release(ev.gen, ev.seq)
 				}
 			case recvAckEventHeartbeat:
 				// Heartbeat carries no gen on the wire; FIFO order on
@@ -175,7 +180,7 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 			return StateConnecting, fmt.Errorf("recv: %w", err)
 		case <-rdr.Notify():
 			// Pull as many records as the window and batcher allow.
-			for inflight < opts.MaxInflight {
+			for inflight.Len() < opts.MaxInflight {
 				rec, ok, err := rdr.TryNext()
 				if err != nil {
 					_ = t.conn.Close()
@@ -203,7 +208,8 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 						t.conn = nil
 						return StateConnecting, fmt.Errorf("send EventBatch: %w", err)
 					}
-					inflight++
+					last := outBatch.Records[len(outBatch.Records)-1]
+					inflight.Push(last.Generation, last.Sequence)
 				}
 			}
 		case now := <-tick.C:
@@ -224,7 +230,8 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 					t.conn = nil
 					return StateConnecting, fmt.Errorf("send EventBatch: %w", err)
 				}
-				inflight++
+				last := outBatch.Records[len(outBatch.Records)-1]
+				inflight.Push(last.Generation, last.Sequence)
 			}
 		}
 		_ = flush // explicit lint reference; called from Drain path

--- a/internal/store/watchtower/transport/state_replaying.go
+++ b/internal/store/watchtower/transport/state_replaying.go
@@ -23,38 +23,20 @@ import (
 // the same as any other replay failure: conn is torn down, state regresses
 // to Connecting, and the run loop owns whether to retry or shut down.
 //
-// PRODUCTION-BLOCKED — recv multiplexer not yet wired. The spec at
-// docs/superpowers/specs/2026-04-18-wtp-client-design.md:565 requires
-// stateReplaying to process inbound BatchAck, ServerHeartbeat,
-// SessionUpdate, and Goaway concurrently with replay completion. This
-// implementation only loops over NextBatch and Send — it has NO recv
-// branch, so any inbound control frame that arrives during a long replay
-// would be dropped (or, depending on the gRPC stream's buffer, would
-// stall the receive side). Task 17 (Live state Batcher) and Task 18
-// (heartbeat) introduce the shared recv goroutine + multiplexer that
-// runReplaying will plug into. Until then, runReplaying MUST NOT be
-// wired into the production run loop.
-//
-// The unexport of runReplaying is an EXTERNAL-CALL-SITE GUARD, not a
-// compile-time guarantee:
-//   - Callers OUTSIDE the internal/store/watchtower/transport package
-//     CANNOT reach runReplaying without going through a future RunOnce
-//     dispatch table that Task 22 will add (and which will gate
-//     Replaying behind the recv loop landing in Task 17/18).
-//   - Callers INSIDE the transport package CAN still call runReplaying
-//     directly — Go's package-level visibility does not prevent this.
-//     Production wiring inside the transport package (Task 22's Run
-//     loop) MUST gate the call behind the recv-multiplexer plumbing
-//     that Tasks 17/18 introduce. See the updated Task 22 Run-loop
-//     snippet in docs/superpowers/plans/2026-04-18-wtp-client.md
-//     "Task 16 — Deferred to Task 17/18", which makes that dependency
-//     structural (the snippet visibly cannot work without Task 17/18
-//     landing first).
+// PRODUCTION-CONSUMABLE — the recv-multiplexer plumbing is wired.
+// runConnecting (state_connecting.go) calls startRecv on accepted
+// SessionAck so runReplaying's recvEventCh / recvErrCh select arms
+// observe inbound BatchAck, ServerHeartbeat, Goaway, and stream-error
+// events concurrently with NextBatch + Send. Per the spec at
+// docs/superpowers/specs/2026-04-18-wtp-client-design.md:565 this
+// satisfies the "process inbound frames concurrently with replay"
+// contract.
 //
 // The exported test seam RunReplayingForTest lives in
 // state_replaying_internal_test.go (compiled out of the production
 // binary) so external transport_test callers can still drive the
-// per-state handler in isolation.
+// per-state handler in isolation; tests that pre-date the production
+// recv wiring use StartRecvForTest to inject a recvSession manually.
 func (t *Transport) runReplaying(ctx context.Context, r *Replayer) (State, error) {
 	// Per-connection recv channel handles, captured once per loop entry.
 	// Nil-channel semantics make the drain arms dormant when t.recv is

--- a/internal/store/watchtower/transport/transport.go
+++ b/internal/store/watchtower/transport/transport.go
@@ -1036,6 +1036,15 @@ func (t *Transport) Run(ctx context.Context, rdrFactory func(gen uint32, start u
 	for {
 		select {
 		case <-ctx.Done():
+			// If cancellation lands between state transitions
+			// (after runConnecting → StateReplaying or after
+			// runReplaying → StateLive) the prior state handler
+			// has not yet had a chance to teardown — without this
+			// cleanup the transport would exit holding an open
+			// conn and a live recvSession (roborev Medium follow-
+			// up). regressToConnecting is idempotent so it is
+			// also safe when the prior handler already tore down.
+			t.regressToConnecting()
 			return ctx.Err()
 		case sr := <-t.stopCh:
 			// Stop arrived between states (or during a Connecting

--- a/internal/store/watchtower/transport/transport.go
+++ b/internal/store/watchtower/transport/transport.go
@@ -1083,6 +1083,19 @@ func (t *Transport) Run(ctx context.Context, rdrFactory func(gen uint32, start u
 			bo.Reset()
 			rep = nil
 			st = next
+			// Start the per-connection recv goroutine now that the
+			// dial succeeded and the SessionAck was accepted;
+			// runReplaying / runLive consume from t.recv.eventCh /
+			// t.recv.errCh and teardown is owned by their exit
+			// paths (with regressToConnecting as the safety-net for
+			// run-loop bail-outs that bypass them). Doing this
+			// here — not inside runConnecting — keeps RunOnce a
+			// pure single-transition seam that does not leak a
+			// recvSession when callers stop after Connecting.
+			// Per roborev Medium round-3.
+			if next == StateReplaying {
+				t.startRecv(ctx)
+			}
 		case StateReplaying:
 			stages, lerr := t.computeReplayPlan(t.remoteReplayCursor, t.persistedAck)
 			if lerr != nil {

--- a/internal/store/watchtower/transport/transport.go
+++ b/internal/store/watchtower/transport/transport.go
@@ -947,39 +947,32 @@ func (t *Transport) handleOuterStop(sr stopReq) {
 // exponential backoff with jitter between StateConnecting attempts
 // (200ms → 30s, factor 2).
 //
-// SCAFFOLDING ONLY — NOT PRODUCTION-CONSUMABLE YET. This step lands
-// the loop skeleton so subsequent tasks (Task 19 Stop/drain, Task 22
-// Store integration) can layer on top. Three production prerequisites
-// remain unmet and any caller that adopts Run end-to-end today will
-// observe broken behavior:
+// PRODUCTION-CONSUMABLE — the three SCAFFOLDING ONLY blockers are
+// closed (this commit, Task 27 prereq):
 //
-//  1. NO recv-goroutine startup. Run never calls newRecvSession /
-//     runRecv after a successful dial, so runLive's recv arms remain
-//     dormant via Go nil-channel semantics. Inbound BatchAck and
-//     ServerHeartbeat frames are not consumed; cursors will not
-//     advance once Live is reached. Recv startup belongs to a
-//     post-dial hook the plan does not yet specify.
-//  2. STUB wire encoding. encodeBatchMessage (state_live.go) and the
-//     replay-side buildEventBatchFn return empty *wtpv1.ClientMessage
-//     envelopes. Any send is a placeholder frame, not a real EventBatch.
-//  3. inflight is increment-only in runLive. Live cannot decrement
-//     it on BatchAck, so once MaxInflight batches have shipped the
-//     send path stalls until the next reconnect. This is independent
-//     of whether recv startup is wired and predates Task 18 Step 4.
+//  1. Recv-goroutine startup is wired. runConnecting calls startRecv
+//     (recv_multiplexer.go) on accepted SessionAck so runReplaying /
+//     runLive can consume BatchAck, ServerHeartbeat, Goaway, and
+//     stream-error events. teardownRecv is paired with conn.Close on
+//     every exit path.
+//  2. Wire encoding is real. encodeBatchMessage (state_live.go) and
+//     the replay-side buildEventBatchFn (state_replaying.go, aliased
+//     to encodeBatchMessage) build full EventBatch frames from WAL
+//     RecordData via proto.Unmarshal of the per-record CompactEvent
+//     payloads.
+//  3. inflight decrements on BatchAck. The runLive recv arm releases
+//     one slot per acknowledged batch (floor at zero to absorb stale
+//     or duplicate acks), so the send path no longer stalls at
+//     MaxInflight.
 //
-// Until those land (Task 22 / Task 27 wiring per the plan), Run is
-// useful only as the integration surface for the Stop/drain plumbing
-// of Task 19 and as a structural target for end-to-end tests that
-// stop short of Live's recv path.
-//
-// rdrFactory takes the WAL generation AND the start sequence so the
-// caller can position the Reader explicitly per state entry. `gen` is
-// the WAL generation the Reader will be scoped to (segments with a
-// different SegmentHeader.Generation are skipped at segment iteration
-// before record decoding — see wal/reader.go ReaderOptions.Generation
-// and Task 14b); `start` is the inclusive lowest seq the returned
-// Reader will surface for RecordData (RecordLoss markers always
-// surface — see wal/reader.go NewReader).
+// Caller wiring: rdrFactory takes the WAL generation AND the start
+// sequence so the caller can position the Reader explicitly per state
+// entry. `gen` is the WAL generation the Reader will be scoped to
+// (segments with a different SegmentHeader.Generation are skipped at
+// segment iteration before record decoding — see wal/reader.go
+// ReaderOptions.Generation and Task 14b); `start` is the inclusive
+// lowest seq the returned Reader will surface for RecordData
+// (RecordLoss markers always surface — see wal/reader.go NewReader).
 //
 // Replaying opens one Reader per stage returned by computeReplayPlan;
 // only the first stage carries a non-nil PrefixLoss. Subsequent stages

--- a/internal/store/watchtower/transport/transport.go
+++ b/internal/store/watchtower/transport/transport.go
@@ -941,6 +941,28 @@ func (t *Transport) handleOuterStop(sr stopReq) {
 	close(sr.done)
 }
 
+// regressToConnecting tears down the live conn + recv goroutine
+// established by a prior runConnecting (startRecv on accepted
+// SessionAck), used by run-loop branches that bail BEFORE
+// runReplaying or runLive owns teardown — i.e. computeReplayPlan
+// failure, rdrFactory failure inside the StateReplaying stagesLoop,
+// NewReplayer failure, and the StateLive rdrFactory failure. Without
+// this teardown, the next dial's startRecv would orphan the prior
+// recvSession and let it race the new connection through the shared
+// t.conn pointer.
+//
+// Idempotent: a nil t.conn (already torn down) makes both sub-calls
+// no-ops. The conn-then-recv order is load-bearing — runRecv blocks
+// on t.conn.Recv() and only unblocks when the conn is closed, so
+// closing recv first would deadlock on teardownRecv's <-rs.done wait.
+func (t *Transport) regressToConnecting() {
+	if t.conn != nil {
+		_ = t.conn.Close()
+		t.teardownRecv()
+		t.conn = nil
+	}
+}
+
 // Run loops the four-state state machine until ctx is cancelled, the
 // state machine reaches StateShutdown, or runConnecting returns a
 // terminal error (StateShutdown + non-nil error). It applies
@@ -1055,6 +1077,11 @@ func (t *Transport) Run(ctx context.Context, rdrFactory func(gen uint32, start u
 		case StateReplaying:
 			stages, lerr := t.computeReplayPlan(t.remoteReplayCursor, t.persistedAck)
 			if lerr != nil {
+				// runConnecting started the recv goroutine after
+				// SessionAck; without teardown here the next dial's
+				// startRecv would orphan it and let it race the
+				// new conn through t.conn (roborev High).
+				t.regressToConnecting()
 				rep = nil
 				st = StateConnecting
 				continue
@@ -1112,6 +1139,13 @@ func (t *Transport) Run(ctx context.Context, rdrFactory func(gen uint32, start u
 				}
 			}
 			if stageErr != nil {
+				// rdrFactory and NewReplayer failures inside the
+				// stagesLoop above leak conn + recv if not torn down
+				// here — runReplaying returns its own teardown only
+				// when it actually executed. A break before
+				// runReplaying lands here without teardown (roborev
+				// High).
+				t.regressToConnecting()
 				rep = nil
 				st = StateConnecting
 				select {
@@ -1141,6 +1175,10 @@ func (t *Transport) Run(ctx context.Context, rdrFactory func(gen uint32, start u
 			}
 			rdr, err := rdrFactory(liveGen, start)
 			if err != nil {
+				// Same leak path as the StateReplaying rdrFactory
+				// failure above — runLive never executes, so its
+				// internal teardown never runs (roborev High).
+				t.regressToConnecting()
 				st = StateConnecting
 				continue
 			}

--- a/internal/store/watchtower/transport/transport_run_test.go
+++ b/internal/store/watchtower/transport/transport_run_test.go
@@ -559,6 +559,16 @@ func TestRun_NoRecvLeakOnOuterCtxCancel(t *testing.T) {
 	if rsh := transport.RecvSessionForTest(tr); rsh != nil {
 		t.Fatal("recv goroutine still attached after Run returned; outer ctx.Done branch leaked")
 	}
+
+	// AND the conn must have been closed. regressToConnecting closes
+	// t.conn; without that call the accepted stream would survive.
+	// fakeConn.Close closes the `closed` channel, so observing the
+	// closed channel proves Close was called (roborev Low round-6).
+	select {
+	case <-conn.closed:
+	default:
+		t.Fatal("conn still open after Run returned; outer ctx.Done branch leaked the accepted stream")
+	}
 }
 
 // TestRunOnce_DoesNotStartRecvGoroutine pins the roborev Medium

--- a/internal/store/watchtower/transport/transport_run_test.go
+++ b/internal/store/watchtower/transport/transport_run_test.go
@@ -459,3 +459,95 @@ func TestRun_NoRecvLeakOnReaderFactoryFailure(t *testing.T) {
 		t.Fatal("Run did not return within 3s of cancel")
 	}
 }
+
+// TestRun_NoRecvLeakOnOuterCtxCancel pins the roborev Medium follow-up:
+// the outer Run-loop's ctx.Done branch returned ctx.Err() without
+// tearing down conn or recv, so a cancellation landing between state
+// transitions (after runConnecting -> StateReplaying, or after
+// runReplaying -> StateLive) would leave both leaked. With the fix,
+// the ctx.Done branch routes through regressToConnecting first.
+func TestRun_NoRecvLeakOnOuterCtxCancel(t *testing.T) {
+	conn := newFakeConn()
+	dialer := transport.DialerFunc(func(_ context.Context) (transport.Conn, error) {
+		return conn, nil
+	})
+	tr, err := transport.New(transport.Options{
+		Dialer:    dialer,
+		AgentID:   "a",
+		SessionID: "s",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rdrFactoryEntered := make(chan struct{}, 1)
+	rdrFactoryRelease := make(chan struct{})
+	rdrFactory := func(uint32, uint64) (*wal.Reader, error) {
+		select {
+		case rdrFactoryEntered <- struct{}{}:
+		default:
+		}
+		<-rdrFactoryRelease
+		return nil, errors.New("test: rdrFactory release")
+	}
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- tr.Run(ctx, rdrFactory, transport.LiveOptions{
+			Batcher: transport.BatcherOptions{
+				MaxRecords: 100,
+				MaxBytes:   1 << 16,
+				MaxAge:     50 * time.Millisecond,
+			},
+			MaxInflight:    8,
+			HeartbeatEvery: time.Second,
+		})
+	}()
+
+	// SessionInit + accept.
+	select {
+	case <-conn.sendCh:
+	case <-time.After(1 * time.Second):
+		t.Fatal("no SessionInit sent")
+	}
+	conn.recvCh <- &wtpv1.ServerMessage{
+		Msg: &wtpv1.ServerMessage_SessionAck{
+			SessionAck: &wtpv1.SessionAck{Accepted: true},
+		},
+	}
+
+	// Wait until rdrFactory blocks — a state where conn is held and
+	// recv goroutine is alive.
+	select {
+	case <-rdrFactoryEntered:
+	case <-time.After(1 * time.Second):
+		t.Fatal("rdrFactory was not entered within 1s of SessionAck")
+	}
+
+	rsh := transport.RecvSessionForTest(tr)
+	if rsh == nil {
+		t.Fatal("recv goroutine not running at rdrFactory entry")
+	}
+
+	// Cancel ctx WHILE rdrFactory is blocked. The rdrFactory return
+	// path eventually triggers regressToConnecting, but we want to
+	// also exercise the OUTER ctx.Done branch — release rdrFactory
+	// AFTER ctx is cancelled so the run-loop's top-of-loop select
+	// sees ctx.Done first on a subsequent iteration. Either way, the
+	// recv goroutine must be torn down before Run returns; rsh.Done()
+	// closes once teardown completes.
+	cancel()
+	close(rdrFactoryRelease)
+
+	select {
+	case <-rsh.Done():
+	case <-time.After(1 * time.Second):
+		t.Fatal("recv goroutine still running after ctx cancel; outer ctx.Done branch leaked")
+	}
+
+	select {
+	case <-runDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return within 3s of cancel")
+	}
+}

--- a/internal/store/watchtower/transport/transport_run_test.go
+++ b/internal/store/watchtower/transport/transport_run_test.go
@@ -462,12 +462,20 @@ func TestRun_NoRecvLeakOnReaderFactoryFailure(t *testing.T) {
 	}
 }
 
-// TestRun_NoRecvLeakOnOuterCtxCancel pins the roborev Medium follow-up:
-// the outer Run-loop's ctx.Done branch returned ctx.Err() without
-// tearing down conn or recv, so a cancellation landing between state
-// transitions (after runConnecting -> StateReplaying, or after
-// runReplaying -> StateLive) would leave both leaked. With the fix,
-// the ctx.Done branch routes through regressToConnecting first.
+// TestRun_NoRecvLeakOnOuterCtxCancel pins the roborev Medium round-3
+// finding by exercising specifically the outer Run-loop top-of-iteration
+// ctx.Done() branch — NOT the rdrFactory regress path.
+//
+// Determinism trick (round-4 follow-up): cancel ctx BEFORE sending
+// SessionAck. fakeConn.Recv does not honor ctx, so the run loop is
+// blocked in conn.Recv() inside runConnecting and does not observe
+// the cancel. When SessionAck arrives, runConnecting completes,
+// startRecv runs, and the StateConnecting case sets st = StateReplaying
+// and falls through. The NEXT iteration's top-of-loop select then
+// sees ctx.Done() — and ONLY the outer ctx.Done branch teardown can
+// fire here (rdrFactory was never called). Removing the outer
+// regressToConnecting() call from that branch would leave the recv
+// goroutine alive, failing this test.
 func TestRun_NoRecvLeakOnOuterCtxCancel(t *testing.T) {
 	conn := newFakeConn()
 	dialer := transport.DialerFunc(func(_ context.Context) (transport.Conn, error) {
@@ -483,15 +491,13 @@ func TestRun_NoRecvLeakOnOuterCtxCancel(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	rdrFactoryEntered := make(chan struct{}, 1)
-	rdrFactoryRelease := make(chan struct{})
+	rdrFactoryCalled := make(chan struct{}, 1)
 	rdrFactory := func(uint32, uint64) (*wal.Reader, error) {
 		select {
-		case rdrFactoryEntered <- struct{}{}:
+		case rdrFactoryCalled <- struct{}{}:
 		default:
 		}
-		<-rdrFactoryRelease
-		return nil, errors.New("test: rdrFactory release")
+		return nil, errors.New("rdrFactory should not be reached")
 	}
 	runDone := make(chan error, 1)
 	go func() {
@@ -506,51 +512,52 @@ func TestRun_NoRecvLeakOnOuterCtxCancel(t *testing.T) {
 		})
 	}()
 
-	// SessionInit + accept.
+	// Drain SessionInit (run loop is now in conn.Recv waiting for ack).
 	select {
 	case <-conn.sendCh:
 	case <-time.After(1 * time.Second):
 		t.Fatal("no SessionInit sent")
 	}
+
+	// Cancel ctx BEFORE the ack arrives. fakeConn.Recv ignores ctx so
+	// the run loop continues to wait on conn.recvCh.
+	cancel()
+
+	// Now deliver the ack. Run loop unblocks, ackSessionAck runs,
+	// startRecv runs, st = StateReplaying, continue → next iteration's
+	// select sees ctx.Done() and the OUTER teardown fires.
 	conn.recvCh <- &wtpv1.ServerMessage{
 		Msg: &wtpv1.ServerMessage_SessionAck{
 			SessionAck: &wtpv1.SessionAck{Accepted: true},
 		},
 	}
 
-	// Wait until rdrFactory blocks — a state where conn is held and
-	// recv goroutine is alive.
+	// Run must return ctx.Canceled with no leaked goroutine. If the
+	// outer ctx.Done branch were missing the regressToConnecting call,
+	// runRecv would still be alive after Run returns — we detect this
+	// by asserting Run returns AND no rdrFactory call ever happened
+	// (proving we did not pass through StateLive's regress path).
 	select {
-	case <-rdrFactoryEntered:
-	case <-time.After(1 * time.Second):
-		t.Fatal("rdrFactory was not entered within 1s of SessionAck")
-	}
-
-	rsh := transport.RecvSessionForTest(tr)
-	if rsh == nil {
-		t.Fatal("recv goroutine not running at rdrFactory entry")
-	}
-
-	// Cancel ctx WHILE rdrFactory is blocked. The rdrFactory return
-	// path eventually triggers regressToConnecting, but we want to
-	// also exercise the OUTER ctx.Done branch — release rdrFactory
-	// AFTER ctx is cancelled so the run-loop's top-of-loop select
-	// sees ctx.Done first on a subsequent iteration. Either way, the
-	// recv goroutine must be torn down before Run returns; rsh.Done()
-	// closes once teardown completes.
-	cancel()
-	close(rdrFactoryRelease)
-
-	select {
-	case <-rsh.Done():
-	case <-time.After(1 * time.Second):
-		t.Fatal("recv goroutine still running after ctx cancel; outer ctx.Done branch leaked")
+	case got := <-runDone:
+		if !errors.Is(got, context.Canceled) {
+			t.Fatalf("Run returned %v, want context.Canceled", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return within 2s of cancel")
 	}
 
 	select {
-	case <-runDone:
-	case <-time.After(3 * time.Second):
-		t.Fatal("Run did not return within 3s of cancel")
+	case <-rdrFactoryCalled:
+		t.Fatal("rdrFactory was reached; test no longer isolates the outer ctx.Done teardown path")
+	default:
+	}
+
+	// After Run returns, t.recv MUST be nil. This is the load-bearing
+	// assertion: the outer ctx.Done branch is the ONLY teardown path
+	// reachable in this test, so a nil t.recv proves the branch fired
+	// regressToConnecting (which sets t.recv = nil via teardownRecv).
+	if rsh := transport.RecvSessionForTest(tr); rsh != nil {
+		t.Fatal("recv goroutine still attached after Run returned; outer ctx.Done branch leaked")
 	}
 }
 

--- a/internal/store/watchtower/transport/transport_run_test.go
+++ b/internal/store/watchtower/transport/transport_run_test.go
@@ -293,9 +293,17 @@ func TestRun_StartsRecvGoroutineAfterAcceptedSessionAck(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	// Block rdrFactory so the recv goroutine state is observable
+	// BEFORE the test could regress through StateLive's failure path
+	// and tear it down.
+	rdrFactoryEntered := make(chan struct{}, 1)
+	rdrFactoryRelease := make(chan struct{})
 	rdrFactory := func(uint32, uint64) (*wal.Reader, error) {
-		// Returning an error sends runReplaying back to Connecting,
-		// which exits the test cleanly via ctx cancel below.
+		select {
+		case rdrFactoryEntered <- struct{}{}:
+		default:
+		}
+		<-rdrFactoryRelease
 		return nil, errors.New("test: no replay reader")
 	}
 	runDone := make(chan error, 1)
@@ -323,22 +331,127 @@ func TestRun_StartsRecvGoroutineAfterAcceptedSessionAck(t *testing.T) {
 		},
 	}
 
-	// Poll briefly for the recv goroutine to be wired up. The exact
-	// moment runConnecting transitions to Replaying is not directly
-	// observable, so we tolerate scheduling latency.
-	deadline := time.Now().Add(500 * time.Millisecond)
-	var rsh *transport.RecvSessionHandle
-	for time.Now().Before(deadline) {
-		rsh = transport.RecvSessionForTest(tr)
-		if rsh != nil {
-			break
-		}
-		time.Sleep(2 * time.Millisecond)
+	// Wait for rdrFactory to be entered. At this point the run loop
+	// has crossed runConnecting → StateReplaying → StateLive and is
+	// blocked inside our gated rdrFactory; the recv goroutine started
+	// in runConnecting MUST be alive.
+	select {
+	case <-rdrFactoryEntered:
+	case <-time.After(1 * time.Second):
+		t.Fatal("rdrFactory was not entered within 1s of SessionAck")
 	}
-	if rsh == nil {
+
+	if rsh := transport.RecvSessionForTest(tr); rsh == nil {
 		t.Fatal("recv goroutine never started after accepted SessionAck (SCAFFOLDING ONLY item #1 still open)")
 	}
 
+	close(rdrFactoryRelease)
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return within 3s of cancel")
+	}
+}
+
+// TestRun_NoRecvLeakOnReaderFactoryFailure pins the roborev High
+// finding: if a post-SessionAck path regresses to StateConnecting
+// without runReplaying / runLive taking ownership, the recv goroutine
+// started in runConnecting must be torn down — otherwise the next
+// dial's startRecv overwrites t.recv and the orphaned goroutine
+// races the new connection through the shared t.conn pointer.
+//
+// We block rdrFactory until the test has observed the recv goroutine,
+// then unblock with an error to drive StateLive → StateConnecting.
+// rsh.Done() must close before the next dial, proving teardown ran.
+func TestRun_NoRecvLeakOnReaderFactoryFailure(t *testing.T) {
+	conn := newFakeConn()
+	dialAttempts := 0
+	gateSecondDial := make(chan struct{})
+	dialer := transport.DialerFunc(func(_ context.Context) (transport.Conn, error) {
+		dialAttempts++
+		if dialAttempts == 1 {
+			return conn, nil
+		}
+		// Block the second dial so the first recv-session lifecycle
+		// is observable before the next iteration races us.
+		<-gateSecondDial
+		return nil, errors.New("dial gate released")
+	})
+
+	tr, err := transport.New(transport.Options{
+		Dialer:    dialer,
+		AgentID:   "a",
+		SessionID: "s",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rdrFactoryEntered := make(chan struct{}, 1)
+	rdrFactoryRelease := make(chan struct{})
+	rdrFactory := func(uint32, uint64) (*wal.Reader, error) {
+		// Signal entry; test inspects recv state, then releases.
+		select {
+		case rdrFactoryEntered <- struct{}{}:
+		default:
+		}
+		<-rdrFactoryRelease
+		return nil, errors.New("test: rdrFactory always fails")
+	}
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- tr.Run(ctx, rdrFactory, transport.LiveOptions{
+			Batcher: transport.BatcherOptions{
+				MaxRecords: 100,
+				MaxBytes:   1 << 16,
+				MaxAge:     50 * time.Millisecond,
+			},
+			MaxInflight:    8,
+			HeartbeatEvery: time.Second,
+		})
+	}()
+
+	// SessionInit + accept.
+	select {
+	case <-conn.sendCh:
+	case <-time.After(1 * time.Second):
+		t.Fatal("no SessionInit sent")
+	}
+	conn.recvCh <- &wtpv1.ServerMessage{
+		Msg: &wtpv1.ServerMessage_SessionAck{
+			SessionAck: &wtpv1.SessionAck{Accepted: true},
+		},
+	}
+
+	// Wait for rdrFactory to be entered — at this point startRecv has
+	// run AND we are still inside the StateLive setup before regress.
+	select {
+	case <-rdrFactoryEntered:
+	case <-time.After(1 * time.Second):
+		t.Fatal("rdrFactory was not entered within 1s of SessionAck")
+	}
+
+	rsh := transport.RecvSessionForTest(tr)
+	if rsh == nil {
+		t.Fatal("recv goroutine not running at rdrFactory entry; startRecv did not fire")
+	}
+
+	// Release rdrFactory (which returns an error → regressToConnecting).
+	close(rdrFactoryRelease)
+
+	// rsh.Done() closes when runRecv exits via teardown's
+	// cancel + close(rs.done) sequence. Without the fix, teardown
+	// is skipped on this leak path and the goroutine is orphaned.
+	select {
+	case <-rsh.Done():
+	case <-time.After(1 * time.Second):
+		t.Fatal("recv goroutine still running after rdrFactory failure; teardown leaked the recvSession")
+	}
+
+	close(gateSecondDial)
 	cancel()
 	select {
 	case <-runDone:

--- a/internal/store/watchtower/transport/transport_run_test.go
+++ b/internal/store/watchtower/transport/transport_run_test.go
@@ -567,6 +567,11 @@ func TestRun_NoRecvLeakOnOuterCtxCancel(t *testing.T) {
 // recvSession with no owner. Run owns the recv lifecycle (calling
 // startRecv after a successful runConnecting), so RunOnce by design
 // does NOT start one.
+//
+// Round-5 follow-up: the seam must also not leave the accepted
+// stream open for callers to inherit — RunOnce is now self-
+// contained and closes t.conn on a successful transition. The test
+// asserts both contracts.
 func TestRunOnce_DoesNotStartRecvGoroutine(t *testing.T) {
 	conn := newFakeConn()
 	dialer := transport.DialerFunc(func(_ context.Context) (transport.Conn, error) {
@@ -617,10 +622,19 @@ func TestRunOnce_DoesNotStartRecvGoroutine(t *testing.T) {
 		t.Fatal("RunOnce did not return within 2s of SessionAck")
 	}
 
-	// CRITICAL: RunOnce must not have started the recv goroutine.
+	// CRITICAL #1: RunOnce must not have started the recv goroutine.
 	// Run owns that lifecycle so a single-transition seam does not
 	// leak a recvSession with no teardown owner.
 	if rsh := transport.RecvSessionForTest(tr); rsh != nil {
 		t.Fatal("RunOnce(StateConnecting) leaked a recvSession; Run should own startRecv, not runConnecting")
+	}
+
+	// CRITICAL #2: RunOnce must close the accepted conn before
+	// returning — otherwise callers inherit a live stream with no
+	// teardown owner. fakeConn.Close closes the `closed` channel.
+	select {
+	case <-conn.closed:
+	default:
+		t.Fatal("RunOnce(StateConnecting) did not close the accepted conn; caller would inherit a live stream")
 	}
 }

--- a/internal/store/watchtower/transport/transport_run_test.go
+++ b/internal/store/watchtower/transport/transport_run_test.go
@@ -167,19 +167,21 @@ func TestRun_ReturnsTerminalErrorOnSessionRejection(t *testing.T) {
 // pass a "dials >= 2" assertion.
 func TestRun_RetriesTransientDialFailureUntilSuccess(t *testing.T) {
 	var attempts atomic.Int32
-	conn := newFakeConn()
+	conn2 := newFakeConn()
+	conn3 := newFakeConn()
 	dialer := transport.DialerFunc(func(_ context.Context) (transport.Conn, error) {
 		n := attempts.Add(1)
 		if n == 1 {
 			return nil, errors.New("transient dial fail")
 		}
-		// Hand back the same fakeConn for attempts 2 and 3. The conn
-		// stays open across the replay-failure regress because runReplaying
-		// is not reached (rdrFactory errors before NewReplayer); the
-		// state regress goes through the Run loop's stage-error branch
-		// without runReplaying tearing the conn down. The next dial
-		// reuses this conn (it has not been Close'd).
-		return conn, nil
+		if n == 2 {
+			return conn2, nil
+		}
+		// Run-loop now closes the held conn on rdrFactory failure
+		// (regressToConnecting helper) to avoid leaking conn + recv;
+		// the third dial therefore needs a fresh conn rather than
+		// reusing conn2 (which would have been Close'd).
+		return conn3, nil
 	})
 
 	tr, err := transport.New(transport.Options{
@@ -217,11 +219,11 @@ func TestRun_RetriesTransientDialFailureUntilSuccess(t *testing.T) {
 
 	// === attempt 2: drain SessionInit, ack accepted, drive into Replaying.
 	select {
-	case <-conn.sendCh:
+	case <-conn2.sendCh:
 	case <-time.After(2 * time.Second):
 		t.Fatal("no SessionInit on second attempt within 2s")
 	}
-	conn.recvCh <- &wtpv1.ServerMessage{
+	conn2.recvCh <- &wtpv1.ServerMessage{
 		Msg: &wtpv1.ServerMessage_SessionAck{
 			SessionAck: &wtpv1.SessionAck{
 				Accepted:            true,
@@ -237,10 +239,10 @@ func TestRun_RetriesTransientDialFailureUntilSuccess(t *testing.T) {
 	}
 
 	// === attempt 3: replay failure should regress to Connecting and
-	// re-dial. Observe a third SessionInit on the conn — proves the
-	// replay-failure → reconnect cycle, not just "loop ran twice."
+	// re-dial. Observe a third SessionInit on the FRESH conn — proves
+	// the replay-failure → reconnect cycle, not just "loop ran twice."
 	select {
-	case <-conn.sendCh:
+	case <-conn3.sendCh:
 	case <-time.After(3 * time.Second):
 		t.Fatalf("no SessionInit on third attempt; replay-failure did not regress to Connecting (dial attempts=%d)", attempts.Load())
 	}
@@ -249,10 +251,10 @@ func TestRun_RetriesTransientDialFailureUntilSuccess(t *testing.T) {
 	}
 
 	cancel()
-	// fakeConn.Recv does not honor ctx; close the conn so the third
-	// attempt's Recv unblocks and the Run loop sees ctx.Done() on the
-	// next iteration.
-	_ = conn.Close()
+	// fakeConn.Recv does not honor ctx; close the third conn so the
+	// runConnecting Recv unblocks and the Run loop sees ctx.Done() on
+	// the next iteration.
+	_ = conn3.Close()
 	select {
 	case err := <-done:
 		if !errors.Is(err, context.Canceled) {
@@ -549,5 +551,69 @@ func TestRun_NoRecvLeakOnOuterCtxCancel(t *testing.T) {
 	case <-runDone:
 	case <-time.After(3 * time.Second):
 		t.Fatal("Run did not return within 3s of cancel")
+	}
+}
+
+// TestRunOnce_DoesNotStartRecvGoroutine pins the roborev Medium
+// round-3 finding: RunOnce(StateConnecting) is a single-transition
+// seam used by transport-level tests; it MUST NOT leave a live
+// recvSession with no owner. Run owns the recv lifecycle (calling
+// startRecv after a successful runConnecting), so RunOnce by design
+// does NOT start one.
+func TestRunOnce_DoesNotStartRecvGoroutine(t *testing.T) {
+	conn := newFakeConn()
+	dialer := transport.DialerFunc(func(_ context.Context) (transport.Conn, error) {
+		return conn, nil
+	})
+	tr, err := transport.New(transport.Options{
+		Dialer:    dialer,
+		AgentID:   "a",
+		SessionID: "s",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type res struct {
+		st  transport.State
+		err error
+	}
+	done := make(chan res, 1)
+	go func() {
+		st, e := tr.RunOnce(ctx, transport.StateConnecting)
+		done <- res{st, e}
+	}()
+
+	select {
+	case <-conn.sendCh:
+	case <-time.After(1 * time.Second):
+		t.Fatal("no SessionInit sent")
+	}
+	conn.recvCh <- &wtpv1.ServerMessage{
+		Msg: &wtpv1.ServerMessage_SessionAck{
+			SessionAck: &wtpv1.SessionAck{Accepted: true},
+		},
+	}
+
+	select {
+	case r := <-done:
+		if r.err != nil {
+			t.Fatalf("RunOnce returned err: %v", r.err)
+		}
+		if r.st != transport.StateReplaying {
+			t.Fatalf("RunOnce next state: got %v, want StateReplaying", r.st)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunOnce did not return within 2s of SessionAck")
+	}
+
+	// CRITICAL: RunOnce must not have started the recv goroutine.
+	// Run owns that lifecycle so a single-transition seam does not
+	// leak a recvSession with no teardown owner.
+	if rsh := transport.RecvSessionForTest(tr); rsh != nil {
+		t.Fatal("RunOnce(StateConnecting) leaked a recvSession; Run should own startRecv, not runConnecting")
 	}
 }

--- a/internal/store/watchtower/transport/transport_run_test.go
+++ b/internal/store/watchtower/transport/transport_run_test.go
@@ -262,3 +262,87 @@ func TestRun_RetriesTransientDialFailureUntilSuccess(t *testing.T) {
 		t.Fatal("Run did not return within 3s of cancel")
 	}
 }
+
+// TestRun_StartsRecvGoroutineAfterAcceptedSessionAck closes SCAFFOLDING
+// item #1: "Run never calls newRecvSession / runRecv after a successful
+// dial, so runLive's recv arms remain dormant via Go nil-channel
+// semantics." After the SessionAck-accepted handshake completes, the
+// recv goroutine MUST be running so that runReplaying / runLive can
+// observe BatchAck, ServerHeartbeat, Goaway, and stream errors.
+//
+// This is the load-bearing prerequisite for every component test that
+// exercises server-initiated stream behaviour (Tasks 25, 26).
+func TestRun_StartsRecvGoroutineAfterAcceptedSessionAck(t *testing.T) {
+	conn := newFakeConn()
+	dialer := transport.DialerFunc(func(_ context.Context) (transport.Conn, error) {
+		return conn, nil
+	})
+	tr, err := transport.New(transport.Options{
+		Dialer:    dialer,
+		AgentID:   "a",
+		SessionID: "s",
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	// Pre-condition: no recv goroutine before Run starts.
+	if rsh := transport.RecvSessionForTest(tr); rsh != nil {
+		t.Fatalf("RecvSessionForTest pre-Run = %v, want nil", rsh)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	rdrFactory := func(uint32, uint64) (*wal.Reader, error) {
+		// Returning an error sends runReplaying back to Connecting,
+		// which exits the test cleanly via ctx cancel below.
+		return nil, errors.New("test: no replay reader")
+	}
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- tr.Run(ctx, rdrFactory, transport.LiveOptions{
+			Batcher: transport.BatcherOptions{
+				MaxRecords: 100,
+				MaxBytes:   1 << 16,
+				MaxAge:     50 * time.Millisecond,
+			},
+			MaxInflight:    8,
+			HeartbeatEvery: time.Second,
+		})
+	}()
+
+	// Drain SessionInit, accept the session.
+	select {
+	case <-conn.sendCh:
+	case <-time.After(1 * time.Second):
+		t.Fatal("no SessionInit sent")
+	}
+	conn.recvCh <- &wtpv1.ServerMessage{
+		Msg: &wtpv1.ServerMessage_SessionAck{
+			SessionAck: &wtpv1.SessionAck{Accepted: true},
+		},
+	}
+
+	// Poll briefly for the recv goroutine to be wired up. The exact
+	// moment runConnecting transitions to Replaying is not directly
+	// observable, so we tolerate scheduling latency.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	var rsh *transport.RecvSessionHandle
+	for time.Now().Before(deadline) {
+		rsh = transport.RecvSessionForTest(tr)
+		if rsh != nil {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if rsh == nil {
+		t.Fatal("recv goroutine never started after accepted SessionAck (SCAFFOLDING ONLY item #1 still open)")
+	}
+
+	cancel()
+	select {
+	case <-runDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return within 3s of cancel")
+	}
+}


### PR DESCRIPTION
## Summary

**Stacks on #246.** Closes the three production prerequisites that the prior `transport.Run` "SCAFFOLDING ONLY" header listed as "remaining unmet" — the load-bearing prerequisite for daemon wiring (Task 27 proper) and the unblocker for the Phase 11 component tests.

What landed:
1. **Recv-goroutine startup is wired.** `runConnecting` returns successfully and the Run loop calls `startRecv` after an accepted SessionAck, so `runReplaying` / `runLive` observe `BatchAck`, `ServerHeartbeat`, `Goaway`, and stream-error events live (previously dormant via Go nil-channel semantics on `t.recv`).
2. **Inflight tracking is cumulative-ack aware.** `inflightTracker` records each Send's high-watermark `(gen, seq)`. On every adopted ack — `BatchAck` AND `ServerHeartbeat` — every pending batch whose high-watermark is at or below the ack tuple is released. Replaces the increment-only counter that stalled the send path at MaxInflight. The `tick.C` flush is gated on available capacity so an aged pending batch can't race a full window onto the wire.
3. **The wire-encoding stub claim was already stale** when the prior SCAFFOLDING comment was written — `encodeBatchMessage` and the replay-side `buildEventBatchFn` build real EventBatch frames. Updated the docstring to match reality.

Plus all the leak-cleanup work that followed: `regressToConnecting` helper now closes `t.conn` + tears down recv on every post-`startRecv` failure path that bails before `runReplaying`/`runLive` owns teardown (`computeReplayPlan` failure, `rdrFactory` failure, `NewReplayer` failure, StateLive `rdrFactory` failure). The outer `ctx.Done` branch routes through the same helper. `RunOnce(StateConnecting)` is self-contained — closes the accepted conn before returning.

## Bonus: Task 25 unskipped

`TestStore_DropsMidBatchTriggersReplay` (the Phase 11 drop-replay component test) was previously `t.Skip`-ed with the comment "blocked on Task 17/18 + 22/27 recv-goroutine startup." With those gaps closed it now passes deterministically. Stress-tested at -count=20.

## Out of scope

- **Daemon wiring (Task 27 proper)** is deferred until Phase 1 supplies a production `compact.Mapper` (the OCSF class/activity mapping). `Store.validate()` rejects `StubMapper`, so the wiring would be a feature flag that can't be turned on. This branch makes the wiring straightforward to land once Phase 1 is ready.
- **Task 26 (component restart test)** is now exercisable but ships separately as a small follow-up branch (~50 lines including the `RoutingDialer` helper).
- **Task 27a/b** (operator monitoring docs, LogGoaway config) — not affected.

## Roborev

Seven rounds. Found 9 Mediums + 4 Lows total, all addressed. Final round: 1 Low (request for a runLive-level test of the tick.C gate); deferred per the standing rule "fix all issues above low" and because the same path is exercised end-to-end by the unskipped Task 25 component test.

Round-by-round detail in the commit messages — each `fix(wtp/transport): roborev — ...` commit names the specific findings it addresses.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `GOOS=windows go build ./...` — clean
- [x] `GOOS=darwin go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] Transport package stress at -count=50 — deterministic
- [x] `TestStore_DropsMidBatchTriggersReplay` (the previously-skipped Task 25 component test) at -count=20 — deterministic
- [ ] One outstanding Low: runLive-level integration test for the `tick.C` capacity gate. Deferrable per memory rule; the gate is exercised indirectly by the component drop test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)