### PR TITLE
wtp/ocsf: address roborev #6346 findings — Phase 1 emitter shape fixes

### DIFF
--- a/internal/ocsf/exhaustiveness_test.go
+++ b/internal/ocsf/exhaustiveness_test.go
@@ -17,6 +17,25 @@ import (
 // .gomodcache/, build/, bin/, dist/, etc.) and collects every string
 // literal passed as the Type field of a types.Event composite literal
 // or assigned to ev.Type.
+//
+// LIMITATION: the AST walker matches only literal `Type: "..."` or
+// `ev.Type = "..."` assignments. Emitters that call a helper function
+// and then assign its return value — for example:
+//
+//	n.emitFileEvent(ctx, "dir_list", ...)
+//
+// are NOT auto-detected because the string literal is an argument to a
+// function call rather than a direct assignment to a Type field. Such
+// types must be registered manually in the appropriate project_*.go
+// file. Known helper-based emit sites (as of roborev #6346):
+//
+//	internal/netmonitor/proxy.go:252          — "net_close"
+//	internal/netmonitor/transparent_tcp.go:141 — "net_close"
+//	internal/fsmonitor/fuse.go:236-325        — "dir_list", "file_stat",
+//	                                            "dir_create", "dir_delete",
+//	                                            "symlink_create", "symlink_read"
+//
+// TODO: extend the walker to follow helper-based emitters using go/types.
 func scanTypeLiterals(t *testing.T, rootDir string) map[string]string {
 	t.Helper()
 	out := map[string]string{}

--- a/internal/ocsf/mapper_test.go
+++ b/internal/ocsf/mapper_test.go
@@ -204,25 +204,35 @@ func goldenSampleEvents() []types.Event {
 		{ID: "ev-file-chmod-1", Type: "file_chmod", Timestamp: t0, PID: 207, Path: "/tmp/perm"},
 		{ID: "ev-file-mkdir-1", Type: "file_mkdir", Timestamp: t0, PID: 208, Path: "/tmp/dir"},
 		{ID: "ev-file-rmdir-1", Type: "file_rmdir", Timestamp: t0, PID: 209, Path: "/tmp/dir"},
-		{ID: "ev-file-rename-1", Type: "file_rename", Timestamp: t0, PID: 210, Path: "/tmp/new", Fields: map[string]any{"from_path": "/tmp/old"}},
-		{ID: "ev-file-renamed-1", Type: "file_renamed", Timestamp: t0, PID: 211, Path: "/tmp/dest", Fields: map[string]any{"from_path": "/tmp/src"}},
+		{ID: "ev-file-rename-1", Type: "file_rename", Timestamp: t0, PID: 210, Path: "/tmp/old", Fields: map[string]any{"to_path": "/tmp/new"}},
+		{ID: "ev-file-renamed-1", Type: "file_renamed", Timestamp: t0, PID: 211, Path: "/tmp/src", Fields: map[string]any{"to_path": "/tmp/dest"}},
 		{ID: "ev-file-modified-1", Type: "file_modified", Timestamp: t0, PID: 212, Path: "/tmp/changed"},
 		{ID: "ev-file-soft-deleted-1", Type: "file_soft_deleted", Timestamp: t0, PID: 213, Path: "/tmp/soft"},
 		{ID: "ev-file-unknown-1", Type: "file_unknown", Timestamp: t0, PID: 214, Path: "/tmp/unknown"},
 		{ID: "ev-ptrace-file-1", Type: "ptrace_file", Timestamp: t0, PID: 215, Path: "/etc/shadow"},
 		{ID: "ev-registry-write-1", Type: "registry_write", Timestamp: t0, PID: 216, Path: "HKLM\\Software\\Foo"},
 		{ID: "ev-registry-error-1", Type: "registry_error", Timestamp: t0, PID: 217, Path: "HKLM\\Software\\Bar"},
+		// Dynamically-emitted via emitFileEvent helper (not caught by AST walker).
+		{ID: "ev-dir-list-1", Type: "dir_list", Timestamp: t0, PID: 220, Path: "/home/agent"},
+		{ID: "ev-dir-create-1", Type: "dir_create", Timestamp: t0, PID: 221, Path: "/home/agent/newdir"},
+		{ID: "ev-dir-delete-1", Type: "dir_delete", Timestamp: t0, PID: 222, Path: "/home/agent/olddir"},
+		{ID: "ev-file-stat-1", Type: "file_stat", Timestamp: t0, PID: 223, Path: "/etc/hosts"},
+		{ID: "ev-symlink-create-1", Type: "symlink_create", Timestamp: t0, PID: 224, Path: "/home/agent/link"},
+		{ID: "ev-symlink-read-1", Type: "symlink_read", Timestamp: t0, PID: 225, Path: "/home/agent/link"},
 
 		// Network Activity (4001) — Task 18
-		{ID: "ev-net-connect-1", Type: "net_connect", Timestamp: t0, PID: 300, Domain: "example.com", Remote: "93.184.216.34"},
+		{ID: "ev-net-connect-1", Type: "net_connect", Timestamp: t0, PID: 300, Domain: "example.com", Remote: "93.184.216.34:443"},
 		{ID: "ev-conn-allowed-1", Type: "connection_allowed", Timestamp: t0, PID: 301, Domain: "ok.example", Remote: "10.0.0.1"},
-		{ID: "ev-connect-redirect-1", Type: "connect_redirect", Timestamp: t0, PID: 302, Domain: "in.example", Fields: map[string]any{"redirect_target": "out.example:443"}},
+		{ID: "ev-connect-redirect-1", Type: "connect_redirect", Timestamp: t0, PID: 302, Domain: "in.example", Remote: "10.1.2.3:443", Fields: map[string]any{"redirect_to": "out.example:443"}},
 		{ID: "ev-ptrace-network-1", Type: "ptrace_network", Timestamp: t0, PID: 303, Domain: "trace.example"},
 		{ID: "ev-unix-sock-1", Type: "unix_socket_op", Timestamp: t0, PID: 304, Path: "/run/agentsh.sock", Abstract: false},
 		{ID: "ev-tnet-failed-1", Type: "transparent_net_failed", Timestamp: t0},
 		{ID: "ev-tnet-ready-1", Type: "transparent_net_ready", Timestamp: t0},
 		{ID: "ev-tnet-setup-1", Type: "transparent_net_setup", Timestamp: t0},
 		{ID: "ev-mcp-net-1", Type: "mcp_network_connection", Timestamp: t0, PID: 305, Domain: "mcp.example", Remote: "10.0.0.5"},
+		// net_close is dynamically emitted via emitNetEvent helper.
+		{ID: "ev-net-close-1", Type: "net_close", Timestamp: t0, PID: 306, Domain: "example.com", Remote: "93.184.216.34:443",
+			Fields: map[string]any{"bytes_sent": uint64(1024), "bytes_received": uint64(4096)}},
 
 		// HTTP Activity (4002) — Task 19
 		{ID: "ev-http-1", Type: "http", Timestamp: t0, PID: 400, Domain: "api.example", Fields: map[string]any{
@@ -230,8 +240,8 @@ func goldenSampleEvents() []types.Event {
 			"user_agent": "agentsh/1.0", "http_version": "1.1",
 			"status_code": 200, "response_bytes": 1024,
 		}},
-		{ID: "ev-net-http-req-1", Type: "net_http_request", Timestamp: t0, PID: 401, Domain: "raw.example",
-			Fields: map[string]any{"method": "GET", "url": "https://raw.example/file"}},
+		{ID: "ev-net-http-req-1", Type: "net_http_request", Timestamp: t0, PID: 401, Domain: "raw.example", Remote: "1.2.3.4:80",
+			Fields: map[string]any{"method": "GET", "path": "/file"}},
 		{ID: "ev-http-svc-denied-1", Type: "http_service_denied_direct", Timestamp: t0, PID: 402, Domain: "blocked.example",
 			Fields: map[string]any{"method": "POST", "url": "https://blocked.example/api"},
 			Policy: &types.PolicyInfo{Decision: "deny", EffectiveDecision: "deny", Rule: "no-direct"}},
@@ -240,7 +250,7 @@ func goldenSampleEvents() []types.Event {
 		{ID: "ev-dns-query-1", Type: "dns_query", Timestamp: t0, PID: 500, Domain: "lookup.example",
 			Fields: map[string]any{"rrtype": 1, "rrtype_name": "A"}},
 		{ID: "ev-dns-redirect-1", Type: "dns_redirect", Timestamp: t0, PID: 501, Domain: "in.example",
-			Fields: map[string]any{"rrtype_name": "A", "redirect_target": "127.0.0.1"}},
+			Fields: map[string]any{"rrtype_name": "A", "resolved_to": "127.0.0.1"}},
 
 		// Detection Finding (2004) — Task 21
 		{ID: "ev-cmd-policy-1", Type: "command_policy", Timestamp: t0, PID: 600,

--- a/internal/ocsf/project_dns.go
+++ b/internal/ocsf/project_dns.go
@@ -32,7 +32,7 @@ func dnsProjector(activity uint32) Projector {
 			q.Type = u32p(v)
 		}
 		msg.Query = q
-		if rt, ok := allowed["redirect_target"].(string); ok && rt != "" {
+		if rt, ok := allowed["resolved_to"].(string); ok && rt != "" {
 			msg.RedirectTarget = strp(rt)
 		}
 		if ev.Policy != nil {
@@ -52,7 +52,8 @@ func init() {
 		{Key: "hostname", Transform: AsString, DestPath: "query.hostname"},
 		{Key: "rrtype", Transform: AsUint32, DestPath: "query.type"},
 		{Key: "rrtype_name", Transform: AsString, DestPath: "query.type_name"},
-		{Key: "redirect_target", Transform: AsString, DestPath: "redirect_target"},
+		// dns_redirect emitter uses "resolved_to" (not "redirect_target"); allowlist the real key.
+		{Key: "resolved_to", Transform: AsString, DestPath: "redirect_target"},
 	}
 	register("dns_query", Mapping{
 		ClassUID: ClassDNSActivity, ActivityID: DNSActivityQuery,

--- a/internal/ocsf/project_file.go
+++ b/internal/ocsf/project_file.go
@@ -22,10 +22,27 @@ func fileProjector(activity uint32) Projector {
 			Operation:   strpOrNil(ev.Operation),
 		}
 		if ev.Type == "file_rename" || ev.Type == "file_renamed" {
-			if old, ok := allowed["from_path"].(string); ok && old != "" {
-				msg.FileDiff = &ocsfpb.File{
-					Path: strp(old),
-					Name: strp(basename(old)),
+			// OCSF rename semantics: file = destination, file_diff = source.
+			// ev.Path holds the source (from) path as emitted by fuse.go.
+			// Fields["to_path"] (or "path2" on darwin ESF) holds the destination.
+			dest := ""
+			if v, ok := allowed["to_path"].(string); ok && v != "" {
+				dest = v
+			} else if v, ok := allowed["path2"].(string); ok && v != "" {
+				dest = v
+			}
+			if dest != "" {
+				// Destination goes into file (overrides the default ev.Path-based File).
+				msg.File = &ocsfpb.File{
+					Path: strp(dest),
+					Name: strp(basename(dest)),
+				}
+				// Source goes into file_diff.
+				if ev.Path != "" {
+					msg.FileDiff = &ocsfpb.File{
+						Path: strp(ev.Path),
+						Name: strp(basename(ev.Path)),
+					}
 				}
 			}
 		}
@@ -104,10 +121,23 @@ func init() {
 		"ptrace_file":       FileActivityRead,
 		"registry_write":    FileActivityUpdate,
 		"registry_error":    FileActivityUpdate,
+		// Dynamically-emitted types (helper-based; not caught by AST walker).
+		// See exhaustiveness_test.go comment for context.
+		"dir_list":      FileActivityRead,
+		"dir_create":    FileActivityCreate,
+		"dir_delete":    FileActivityDelete,
+		"file_stat":     FileActivityRead,
+		"symlink_create": FileActivityCreate,
+		"symlink_read":  FileActivityRead,
 	}
-	renameAllowlist := []FieldRule{{
-		Key: "from_path", Required: false, Transform: AsString, DestPath: "file_diff.path",
-	}}
+	// renameAllowlist carries the destination path and the optional
+	// cross_mount flag from fuse rename events. to_path is the move
+	// destination; ev.Path is the source (from, used for file_diff).
+	// Darwin ESF emitters use path2 for the same destination field.
+	renameAllowlist := []FieldRule{
+		{Key: "to_path", Required: false, Transform: AsString, DestPath: "file.path"},
+		{Key: "path2", Required: false, Transform: AsString, DestPath: "file.path"},
+	}
 	for t, activity := range fileMappings {
 		var allow []FieldRule
 		if t == "file_rename" || t == "file_renamed" {

--- a/internal/ocsf/project_http.go
+++ b/internal/ocsf/project_http.go
@@ -28,6 +28,10 @@ func httpProjector(activity uint32) Projector {
 		if v, ok := allowed["url"].(string); ok && v != "" {
 			req.Url = strp(v)
 			anyReq = true
+		} else if v, ok := allowed["path"].(string); ok && v != "" {
+			// net_http_request emitter stores the URL path as "path" (not "url").
+			req.Url = strp(v)
+			anyReq = true
 		}
 		if v, ok := allowed["user_agent"].(string); ok && v != "" {
 			req.UserAgent = strp(v)
@@ -76,6 +80,9 @@ func init() {
 	httpAllow := []FieldRule{
 		{Key: "method", Transform: AsString, DestPath: "http_request.http_method"},
 		{Key: "url", Transform: AsString, DestPath: "http_request.url"},
+		// net_http_request emitter stores the URL as "path" (proxy plain-HTTP path),
+		// not "url". Allowlist both; projector above prefers "url" then falls back to "path".
+		{Key: "path", Transform: AsString, DestPath: "http_request.url"},
 		{Key: "host", Transform: AsString, DestPath: "http_request.host"},
 		{Key: "user_agent", Transform: AsString, DestPath: "http_request.user_agent"},
 		{Key: "http_version", Transform: AsString, DestPath: "http_request.version"},

--- a/internal/ocsf/project_network.go
+++ b/internal/ocsf/project_network.go
@@ -1,6 +1,9 @@
 package ocsf
 
 import (
+	"net"
+	"strconv"
+
 	"google.golang.org/protobuf/proto"
 
 	"github.com/agentsh/agentsh/pkg/types"
@@ -21,7 +24,7 @@ func networkProjector(activity uint32) Projector {
 			DstEndpoint:    buildDstEndpoint(ev),
 			ConnectionInfo: buildConnInfo(ev),
 		}
-		if rt, ok := allowed["redirect_target"].(string); ok && rt != "" {
+		if rt, ok := allowed["redirect_to"].(string); ok && rt != "" {
 			msg.RedirectTarget = strp(rt)
 		}
 		if ev.Policy != nil {
@@ -46,7 +49,24 @@ func buildDstEndpoint(ev types.Event) *ocsfpb.Endpoint {
 		e.Hostname = strp(ev.Domain)
 	}
 	if ev.Remote != "" {
-		e.Ip = strp(ev.Remote)
+		// ev.Remote may be "host:port" or a bare IP/hostname.
+		// net.SplitHostPort handles IPv6 brackets correctly.
+		if host, portStr, err := net.SplitHostPort(ev.Remote); err == nil {
+			if p, err := strconv.ParseUint(portStr, 10, 32); err == nil {
+				e.Port = u32p(uint32(p))
+			}
+			// If domain is already set, keep it; only override hostname
+			// if the host part is non-empty and domain was not set.
+			if host != "" {
+				if e.Hostname == nil {
+					e.Hostname = strp(host)
+				}
+				e.Ip = strp(host)
+			}
+		} else {
+			// Bare IP or hostname without port.
+			e.Ip = strp(ev.Remote)
+		}
 	}
 	return e
 }
@@ -83,9 +103,13 @@ func init() {
 		"transparent_net_ready":  NetworkActivityOpen,
 		"transparent_net_setup":  NetworkActivityOpen,
 		"mcp_network_connection": NetworkActivityOpen,
+		// Dynamically-emitted; not caught by AST walker — see exhaustiveness_test.go.
+		"net_close": NetworkActivityClose,
 	}
+	// redirect_to is the real field key used by proxy.go and transparent_tcp.go
+	// emitters (was incorrectly allowlisted as redirect_target in the original code).
 	allow := []FieldRule{{
-		Key: "redirect_target", Required: false, Transform: AsString, DestPath: "redirect_target",
+		Key: "redirect_to", Required: false, Transform: AsString, DestPath: "redirect_target",
 	}}
 	for t, activity := range netMappings {
 		register(t, Mapping{

--- a/internal/ocsf/testdata/golden/connect_redirect.json
+++ b/internal/ocsf/testdata/golden/connect_redirect.json
@@ -21,6 +21,8 @@
     }
   },
   "dst_endpoint": {
+    "ip": "10.1.2.3",
+    "port": 443,
     "hostname": "in.example",
     "domain": "in.example"
   },

--- a/internal/ocsf/testdata/golden/dir_create.json
+++ b/internal/ocsf/testdata/golden/dir_create.json
@@ -1,0 +1,27 @@
+{
+  "class_uid": 1001,
+  "activity_id": 1,
+  "category_uid": 1,
+  "type_uid": 100101,
+  "time": "1777118400000000000",
+  "severity": "Informational",
+  "metadata": {
+    "version": "1.8.0",
+    "product": {
+      "name": "agentsh",
+      "vendor_name": "agentsh"
+    },
+    "logged_time": "1777118400000000000",
+    "event_code": "dir_create",
+    "uid": "ev-dir-create-1"
+  },
+  "actor": {
+    "process": {
+      "pid": "221"
+    }
+  },
+  "file": {
+    "path": "/home/agent/newdir",
+    "name": "newdir"
+  }
+}

--- a/internal/ocsf/testdata/golden/dir_delete.json
+++ b/internal/ocsf/testdata/golden/dir_delete.json
@@ -1,0 +1,27 @@
+{
+  "class_uid": 1001,
+  "activity_id": 4,
+  "category_uid": 1,
+  "type_uid": 100104,
+  "time": "1777118400000000000",
+  "severity": "Informational",
+  "metadata": {
+    "version": "1.8.0",
+    "product": {
+      "name": "agentsh",
+      "vendor_name": "agentsh"
+    },
+    "logged_time": "1777118400000000000",
+    "event_code": "dir_delete",
+    "uid": "ev-dir-delete-1"
+  },
+  "actor": {
+    "process": {
+      "pid": "222"
+    }
+  },
+  "file": {
+    "path": "/home/agent/olddir",
+    "name": "olddir"
+  }
+}

--- a/internal/ocsf/testdata/golden/dir_list.json
+++ b/internal/ocsf/testdata/golden/dir_list.json
@@ -1,0 +1,27 @@
+{
+  "class_uid": 1001,
+  "activity_id": 2,
+  "category_uid": 1,
+  "type_uid": 100102,
+  "time": "1777118400000000000",
+  "severity": "Informational",
+  "metadata": {
+    "version": "1.8.0",
+    "product": {
+      "name": "agentsh",
+      "vendor_name": "agentsh"
+    },
+    "logged_time": "1777118400000000000",
+    "event_code": "dir_list",
+    "uid": "ev-dir-list-1"
+  },
+  "actor": {
+    "process": {
+      "pid": "220"
+    }
+  },
+  "file": {
+    "path": "/home/agent",
+    "name": "agent"
+  }
+}

--- a/internal/ocsf/testdata/golden/file_stat.json
+++ b/internal/ocsf/testdata/golden/file_stat.json
@@ -1,0 +1,27 @@
+{
+  "class_uid": 1001,
+  "activity_id": 2,
+  "category_uid": 1,
+  "type_uid": 100102,
+  "time": "1777118400000000000",
+  "severity": "Informational",
+  "metadata": {
+    "version": "1.8.0",
+    "product": {
+      "name": "agentsh",
+      "vendor_name": "agentsh"
+    },
+    "logged_time": "1777118400000000000",
+    "event_code": "file_stat",
+    "uid": "ev-file-stat-1"
+  },
+  "actor": {
+    "process": {
+      "pid": "223"
+    }
+  },
+  "file": {
+    "path": "/etc/hosts",
+    "name": "hosts"
+  }
+}

--- a/internal/ocsf/testdata/golden/net_close.json
+++ b/internal/ocsf/testdata/golden/net_close.json
@@ -1,8 +1,8 @@
 {
-  "class_uid": 4002,
-  "activity_id": 1,
+  "class_uid": 4001,
+  "activity_id": 2,
   "category_uid": 4,
-  "type_uid": 400201,
+  "type_uid": 400102,
   "time": "1777118400000000000",
   "severity": "Informational",
   "metadata": {
@@ -12,22 +12,18 @@
       "vendor_name": "agentsh"
     },
     "logged_time": "1777118400000000000",
-    "event_code": "net_http_request",
-    "uid": "ev-net-http-req-1"
+    "event_code": "net_close",
+    "uid": "ev-net-close-1"
   },
   "actor": {
     "process": {
-      "pid": "401"
+      "pid": "306"
     }
   },
   "dst_endpoint": {
-    "ip": "1.2.3.4",
-    "port": 80,
-    "hostname": "raw.example",
-    "domain": "raw.example"
-  },
-  "http_request": {
-    "http_method": "GET",
-    "url": "/file"
+    "ip": "93.184.216.34",
+    "port": 443,
+    "hostname": "example.com",
+    "domain": "example.com"
   }
 }

--- a/internal/ocsf/testdata/golden/net_connect.json
+++ b/internal/ocsf/testdata/golden/net_connect.json
@@ -22,6 +22,7 @@
   },
   "dst_endpoint": {
     "ip": "93.184.216.34",
+    "port": 443,
     "hostname": "example.com",
     "domain": "example.com"
   },

--- a/internal/ocsf/testdata/golden/symlink_create.json
+++ b/internal/ocsf/testdata/golden/symlink_create.json
@@ -1,0 +1,27 @@
+{
+  "class_uid": 1001,
+  "activity_id": 1,
+  "category_uid": 1,
+  "type_uid": 100101,
+  "time": "1777118400000000000",
+  "severity": "Informational",
+  "metadata": {
+    "version": "1.8.0",
+    "product": {
+      "name": "agentsh",
+      "vendor_name": "agentsh"
+    },
+    "logged_time": "1777118400000000000",
+    "event_code": "symlink_create",
+    "uid": "ev-symlink-create-1"
+  },
+  "actor": {
+    "process": {
+      "pid": "224"
+    }
+  },
+  "file": {
+    "path": "/home/agent/link",
+    "name": "link"
+  }
+}

--- a/internal/ocsf/testdata/golden/symlink_read.json
+++ b/internal/ocsf/testdata/golden/symlink_read.json
@@ -1,0 +1,27 @@
+{
+  "class_uid": 1001,
+  "activity_id": 2,
+  "category_uid": 1,
+  "type_uid": 100102,
+  "time": "1777118400000000000",
+  "severity": "Informational",
+  "metadata": {
+    "version": "1.8.0",
+    "product": {
+      "name": "agentsh",
+      "vendor_name": "agentsh"
+    },
+    "logged_time": "1777118400000000000",
+    "event_code": "symlink_read",
+    "uid": "ev-symlink-read-1"
+  },
+  "actor": {
+    "process": {
+      "pid": "225"
+    }
+  },
+  "file": {
+    "path": "/home/agent/link",
+    "name": "link"
+  }
+}


### PR DESCRIPTION
## Summary

Fixes all findings from roborev job #6346 on the WTP Phase 1 OCSF mapper.

- **H1 (high):** Registered 7 event Types that the AST-walker exhaustiveness test missed because they are emitted via helper functions rather than direct literal assignments (`dir_list`, `dir_create`, `dir_delete`, `file_stat`, `symlink_create`, `symlink_read` from `fuse.go`; `net_close` from `proxy.go` and `transparent_tcp.go`). Added a TODO comment in `exhaustiveness_test.go` documenting the walker limitation.

- **H2 (high):** Fixed `file_rename`/`file_renamed` projector. The real fuse emitter stores the destination in `Fields["to_path"]` and the source in `ev.Path`; the darwin ESF emitter uses `Fields["path2"]` for the destination. The old code allowlisted `from_path` (which never exists) and accidentally left OCSF `file` populated from `ev.Path` (source). New code: `file` = destination (`to_path`/`path2`), `file_diff` = source (`ev.Path`), matching OCSF rename semantics.

- **M1 (medium):** Three allowlist key mismatches corrected: `redirect_target` → `redirect_to` for `connect_redirect` (proxy.go emits `redirect_to`); `redirect_target` → `resolved_to` for `dns_redirect` (dns.go emits `resolved_to`); added `path` key for `net_http_request` (proxy.go emits `path`, not `url`). Also fixed `buildDstEndpoint` to call `net.SplitHostPort` on `ev.Remote` and populate `Endpoint.port` (uint32) alongside `Endpoint.ip`.

## Test plan

- [ ] `go test ./internal/ocsf/...` — all tests pass; exhaustiveness confirms `pendingTypes is empty — Phase 1 catalog complete`
- [ ] `go test ./internal/store/watchtower/...` — passes
- [ ] `go test ./...` — full repo green
- [ ] `GOOS=windows go build ./...` clean
- [ ] `GOOS=darwin go build ./...` clean
- [ ] 7 new golden files created (dir_create, dir_delete, dir_list, file_stat, net_close, symlink_create, symlink_read)
- [ ] 3 existing goldens updated (connect_redirect, net_connect, net_http_request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)