### PR TITLE
wtp/ocsf: clean up Phase 1 deferred minor issues

### DIFF
--- a/internal/ocsf/mapping.go
+++ b/internal/ocsf/mapping.go
@@ -19,12 +19,9 @@ import (
 //     is no global denylist.
 //   - Project builds the class-specific proto.Message. Map() handles
 //     the deterministic marshal at the boundary.
-//
-// AgentInternal is informational (also set inside the projected proto).
 type Mapping struct {
 	ClassUID        uint32
 	ActivityID      uint32
-	AgentInternal   bool
 	FieldsAllowlist []FieldRule
 	Project         Projector
 }

--- a/internal/ocsf/mapping_test.go
+++ b/internal/ocsf/mapping_test.go
@@ -1,0 +1,195 @@
+package ocsf
+
+import (
+	"math"
+	"testing"
+)
+
+// TestAsString exercises AsString across all supported types and edge cases.
+func TestAsString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   any
+		want    any // nil means we expect the result to be nil
+		wantErr bool
+	}{
+		// nil passthrough
+		{name: "nil", input: nil, want: nil, wantErr: false},
+
+		// string passthrough
+		{name: "string", input: "hello", want: "hello", wantErr: false},
+		{name: "empty string", input: "", want: "", wantErr: false},
+
+		// []byte → string
+		{name: "bytes", input: []byte("world"), want: "world", wantErr: false},
+		{name: "empty bytes", input: []byte{}, want: "", wantErr: false},
+
+		// numeric stringification
+		{name: "int", input: int(42), want: "42", wantErr: false},
+		{name: "int negative", input: int(-7), want: "-7", wantErr: false},
+		{name: "int32", input: int32(100), want: "100", wantErr: false},
+		{name: "int64", input: int64(1<<40), want: "1099511627776", wantErr: false},
+		{name: "uint", input: uint(9), want: "9", wantErr: false},
+		{name: "uint32", input: uint32(math.MaxUint32), want: "4294967295", wantErr: false},
+		{name: "uint64", input: uint64(math.MaxUint64), want: "18446744073709551615", wantErr: false},
+		{name: "float32", input: float32(3.14), want: "3.14", wantErr: false},
+		{name: "float64", input: float64(2.718), want: "2.718", wantErr: false},
+		{name: "bool true", input: bool(true), want: "true", wantErr: false},
+		{name: "bool false", input: bool(false), want: "false", wantErr: false},
+
+		// unsupported type
+		{name: "struct", input: struct{}{}, want: nil, wantErr: true},
+		{name: "slice int", input: []int{1, 2}, want: nil, wantErr: true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := AsString(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("AsString(%T) = (%v, nil), want error", tc.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("AsString(%T) unexpected error: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Errorf("AsString(%T) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAsUint32 exercises AsUint32 across all supported types and edge cases.
+func TestAsUint32(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   any
+		want    any
+		wantErr bool
+	}{
+		// nil passthrough
+		{name: "nil", input: nil, want: nil, wantErr: false},
+
+		// int in range
+		{name: "int zero", input: int(0), want: uint32(0), wantErr: false},
+		{name: "int positive", input: int(1000), want: uint32(1000), wantErr: false},
+		{name: "int max uint32", input: int(math.MaxUint32), want: uint32(math.MaxUint32), wantErr: false},
+
+		// int negative → error
+		{name: "int negative", input: int(-1), want: nil, wantErr: true},
+
+		// int64 in range
+		{name: "int64 zero", input: int64(0), want: uint32(0), wantErr: false},
+		{name: "int64 max uint32", input: int64(math.MaxUint32), want: uint32(math.MaxUint32), wantErr: false},
+
+		// int64 out of range
+		{name: "int64 negative", input: int64(-1), want: nil, wantErr: true},
+		{name: "int64 overflow", input: int64(1<<32), want: nil, wantErr: true},
+
+		// int32
+		{name: "int32 positive", input: int32(255), want: uint32(255), wantErr: false},
+		{name: "int32 negative", input: int32(-1), want: nil, wantErr: true},
+
+		// uint32 passthrough
+		{name: "uint32 passthrough", input: uint32(42), want: uint32(42), wantErr: false},
+		{name: "uint32 max", input: uint32(math.MaxUint32), want: uint32(math.MaxUint32), wantErr: false},
+
+		// uint64 in range and overflow
+		{name: "uint64 in range", input: uint64(100), want: uint32(100), wantErr: false},
+		{name: "uint64 overflow", input: uint64(1<<32), want: nil, wantErr: true},
+		{name: "uint64 max", input: uint64(math.MaxUint64), want: nil, wantErr: true},
+
+		// float64
+		{name: "float64 zero", input: float64(0), want: uint32(0), wantErr: false},
+		{name: "float64 positive in range", input: float64(65535), want: uint32(65535), wantErr: false},
+		{name: "float64 negative", input: float64(-1.0), want: nil, wantErr: true},
+		{name: "float64 overflow", input: float64(1 << 33), want: nil, wantErr: true},
+
+		// unsupported type
+		{name: "string", input: "123", want: nil, wantErr: true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := AsUint32(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("AsUint32(%T=%v) = (%v, nil), want error", tc.input, tc.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("AsUint32(%T=%v) unexpected error: %v", tc.input, tc.input, err)
+			}
+			if got != tc.want {
+				t.Errorf("AsUint32(%T=%v) = %v, want %v", tc.input, tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAsUint64 exercises AsUint64 across all supported types and edge cases.
+func TestAsUint64(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   any
+		want    any
+		wantErr bool
+	}{
+		// nil passthrough
+		{name: "nil", input: nil, want: nil, wantErr: false},
+
+		// int
+		{name: "int zero", input: int(0), want: uint64(0), wantErr: false},
+		{name: "int positive", input: int(1<<30), want: uint64(1 << 30), wantErr: false},
+		{name: "int negative", input: int(-1), want: nil, wantErr: true},
+
+		// int64
+		{name: "int64 zero", input: int64(0), want: uint64(0), wantErr: false},
+		{name: "int64 large", input: int64(math.MaxInt64), want: uint64(math.MaxInt64), wantErr: false},
+		{name: "int64 negative", input: int64(-1), want: nil, wantErr: true},
+
+		// uint64 passthrough
+		{name: "uint64 passthrough", input: uint64(42), want: uint64(42), wantErr: false},
+		{name: "uint64 max", input: uint64(math.MaxUint64), want: uint64(math.MaxUint64), wantErr: false},
+
+		// uint32 widening
+		{name: "uint32 widening", input: uint32(math.MaxUint32), want: uint64(math.MaxUint32), wantErr: false},
+		{name: "uint32 zero", input: uint32(0), want: uint64(0), wantErr: false},
+
+		// float64
+		{name: "float64 zero", input: float64(0), want: uint64(0), wantErr: false},
+		{name: "float64 positive", input: float64(1000), want: uint64(1000), wantErr: false},
+		{name: "float64 negative", input: float64(-0.1), want: nil, wantErr: true},
+
+		// unsupported type
+		{name: "string", input: "99", want: nil, wantErr: true},
+		{name: "bool", input: true, want: nil, wantErr: true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := AsUint64(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("AsUint64(%T=%v) = (%v, nil), want error", tc.input, tc.input, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("AsUint64(%T=%v) unexpected error: %v", tc.input, tc.input, err)
+			}
+			if got != tc.want {
+				t.Errorf("AsUint64(%T=%v) = %v, want %v", tc.input, tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/ocsf/project_app.go
+++ b/internal/ocsf/project_app.go
@@ -81,7 +81,6 @@ func init() {
 		register(t, Mapping{
 			ClassUID:        ClassApplicationActivity,
 			ActivityID:      activity,
-			AgentInternal:   false,
 			FieldsAllowlist: standardAllow,
 			Project:         appProjector(activity, false),
 		})
@@ -121,7 +120,6 @@ func init() {
 		register(t, Mapping{
 			ClassUID:        ClassApplicationActivity,
 			ActivityID:      activity,
-			AgentInternal:   true,
 			FieldsAllowlist: infraAllow,
 			Project:         appProjector(activity, true),
 		})

--- a/internal/ocsf/project_file.go
+++ b/internal/ocsf/project_file.go
@@ -120,7 +120,13 @@ func init() {
 		"file_unknown":      FileActivityUnknown,
 		"ptrace_file":       FileActivityRead,
 		"registry_write":    FileActivityUpdate,
-		"registry_error":    FileActivityUpdate,
+		// registry_error is emitted by the registry monitor's generic error
+		// handler (sendErrorEvent) when the monitoring infrastructure itself
+		// fails — e.g. a WaitForMultipleObjects or key-open error. It is NOT
+		// a failed registry write attempt; it carries no operation context.
+		// FileActivityUnknown (0) is the correct classification for this
+		// catch-all monitoring-layer error event.
+		"registry_error":    FileActivityUnknown,
 		// Dynamically-emitted types (helper-based; not caught by AST walker).
 		// See exhaustiveness_test.go comment for context.
 		"dir_list":      FileActivityRead,

--- a/internal/ocsf/project_network.go
+++ b/internal/ocsf/project_network.go
@@ -85,6 +85,11 @@ func buildConnInfo(ev types.Event) *ocsfpb.ConnectionInfo {
 		ci.ProtocolName = strp("tcp")
 		ci.Direction = strp("Outbound")
 		populated = true
+	// transparent_net_setup, transparent_net_ready, and transparent_net_failed
+	// are lifecycle events about the transparent-networking subsystem itself
+	// (e.g. tproxy/redirect table setup or teardown), not events for an
+	// individual network connection. They carry no protocol, direction, or
+	// endpoint information, so ConnectionInfo is intentionally omitted (nil).
 	}
 	if !populated {
 		return nil
@@ -100,6 +105,10 @@ func init() {
 		"ptrace_network":         NetworkActivityOpen,
 		"unix_socket_op":         NetworkActivityOpen,
 		"transparent_net_failed": NetworkActivityClose,
+		// transparent_net_ready and transparent_net_setup are lifecycle events
+		// about the transparent-networking subsystem, not individual connections.
+		// They are mapped to NetworkActivityOpen for event-class consistency
+		// but carry no ConnectionInfo (no protocol/direction — see buildConnInfo).
 		"transparent_net_ready":  NetworkActivityOpen,
 		"transparent_net_setup":  NetworkActivityOpen,
 		"mcp_network_connection": NetworkActivityOpen,

--- a/internal/ocsf/testdata/golden/registry_error.json
+++ b/internal/ocsf/testdata/golden/registry_error.json
@@ -1,8 +1,8 @@
 {
   "class_uid": 1001,
-  "activity_id": 3,
+  "activity_id": 0,
   "category_uid": 1,
-  "type_uid": 100103,
+  "type_uid": 100100,
   "time": "1777118400000000000",
   "severity": "Informational",
   "metadata": {


### PR DESCRIPTION
## Summary

Addresses four \"Minor\" findings deferred from the Phase 1 OCSF mapper review:

- **M1 — registry_error reclassified to FileActivityUnknown (0):** `registry_error` is emitted by `sendErrorEvent` in `internal/platform/windows/registry.go` — a generic registry-monitor infrastructure error handler (e.g. WaitForMultipleObjects failure), not a failed registry write. It carries no operation context, so `FileActivityUnknown` (0) is the correct OCSF classification. Updated the golden accordingly (`activity_id` 3→0, `type_uid` 100103→100100).

- **M2 — Direct unit tests for AsString/AsUint32/AsUint64:** Added `internal/ocsf/mapping_test.go` with table-driven tests covering nil passthrough, all supported concrete types, overflow/underflow boundaries, and unsupported-type error paths. Previously these transforms were only exercised indirectly via golden tests.

- **M3 — Removed dead Mapping.AgentInternal field:** The field was set in `project_app.go` struct literals but never read by `Map()` or any other code. The load-bearing flag is `AgentInternal` on the `ApplicationActivity` proto message, set directly in the `appProjector` closure (which captures the value via its parameter). Removed the struct field and both initialization sites; no behavior change.

- **M4 — Documented nil ConnectionInfo for transparent_net_* events:** Added code comments in `buildConnInfo` and the `init()` registry in `project_network.go` explaining that `transparent_net_setup`, `transparent_net_ready`, and `transparent_net_failed` are lifecycle events about the transparent-networking subsystem itself (not individual connections), so nil ConnectionInfo is correct and intentional.

## Test plan

- [ ] `go test ./internal/ocsf/...` — all pass including new `TestAsString`, `TestAsUint32`, `TestAsUint64` tests and updated `TestGoldens/registry_error`
- [ ] `go test ./internal/store/watchtower/...` — all pass
- [ ] `go test ./...` — full repo green (no failures)
- [ ] `GOOS=windows go build ./...` — clean
- [ ] `GOOS=darwin go build ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)