### PR TITLE
feat(wtp): Task 27b — LogGoawayMessage config surface

### DIFF
--- a/docs/superpowers/operator/wtp-monitoring-migration.md
+++ b/docs/superpowers/operator/wtp-monitoring-migration.md
@@ -4,7 +4,13 @@
 
 **Default:** unset (resolves to `false`).
 
-**What it does.** When `true`, the WARN log emitted on GOAWAY receipt includes the server-supplied `goaway_message` text after client-side sanitization (control-char stripping, truncation to 512 bytes at a UTF-8 rune boundary, invalid-UTF-8 → U+FFFD). When `false` or unset, only `goaway_message_present: bool` is emitted.
+**What it does.** When `true`, the WARN log emitted on GOAWAY receipt includes the server-supplied `goaway_message` text after client-side sanitization via `sanitizeForLog` (transport implementation). The sanitizer applies these rules **in order**:
+
+1. Replace any invalid UTF-8 sequence with U+FFFD.
+2. Replace any control or non-printable rune (including `\t`, `\n`, all C0 controls) with U+FFFD. Only the literal space character and printable Unicode pass through.
+3. Truncate the **sanitized** output to at most 512 bytes at a UTF-8 rune boundary, appending `...[truncated]` **within** that 512-byte budget. When truncation fires, operators see the prefix of the message followed by the `...[truncated]` marker; the total length including the marker is at most 512 bytes.
+
+When `false` or unset, only `goaway_message_present: bool` is emitted.
 
 **Three-state semantics.** YAML omitted, explicit `false`, and explicit `true` are distinct on the wire so a future major-version-bump default flip is auditable in startup logs.
 

--- a/docs/superpowers/operator/wtp-monitoring-migration.md
+++ b/docs/superpowers/operator/wtp-monitoring-migration.md
@@ -1,0 +1,19 @@
+# WTP Monitoring Migration
+
+## `audit.watchtower.log_goaway_message`
+
+**Default:** unset (resolves to `false`).
+
+**What it does.** When `true`, the WARN log emitted on GOAWAY receipt includes the server-supplied `goaway_message` text after client-side sanitization (control-char stripping, truncation to 512 bytes at a UTF-8 rune boundary, invalid-UTF-8 → U+FFFD). When `false` or unset, only `goaway_message_present: bool` is emitted.
+
+**Three-state semantics.** YAML omitted, explicit `false`, and explicit `true` are distinct on the wire so a future major-version-bump default flip is auditable in startup logs.
+
+**Server-side contract.** The Watchtower server contract at `proto/canyonroad/wtp/v1/wtp.proto` (`Goaway.message`) REQUIRES that the message field MUST NOT contain credentials, secrets, or PII. Setting `log_goaway_message: true` opts your operator log aggregator into receiving that text under the trust assumption that the server contract is enforced.
+
+**Threat model.** Server is trusted not to leak secrets in `Goaway.message`. If the server side ever violates the contract, those values land in your log aggregator. The conservative default (`false`/unset) is recommended for any deployment where the server side is not under unified operational control.
+
+**Reload model.** Read at transport-construction time. Changes take effect ONLY after a daemon restart.
+
+**Verification after a flip.** Restart the daemon. Look for the startup INFO line `watchtower: log_goaway_message omitted; using default` (when unset) or the WARN line `watchtower: log_goaway_message=true; …` (when explicitly true). The transport will then honor the value.
+
+**Default-flip migration policy.** Changing the in-code default from `false` to `true` is forbidden without a major schema version bump in the daemon config — silent flips would expose the goaway_message field to log aggregators on upgrade for any fleet that omitted the field. See spec §"`goaway_message` redaction policy" for the binding policy.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -848,6 +848,30 @@ type AuditWatchtowerConfig struct {
 	StateDir      string `yaml:"state_dir"`       // default GetUserStateDir() + "/wtp"; per-OS path differs (XDG_STATE_HOME on Linux, LOCALAPPDATA on Windows). See defaultWatchtowerStateDir.
 	EphemeralMode bool   `yaml:"ephemeral_mode"`
 
+	// LogGoawayMessage controls whether the WARN log emitted on GOAWAY
+	// receipt includes the server-supplied message text (after client-
+	// side sanitization). Three-state:
+	//   nil   — field omitted from YAML; resolved to PRD default at
+	//           store-construction time. The store-construction path
+	//           emits a single INFO at startup announcing the resolved
+	//           default so operators can audit a future default-flip.
+	//   false — explicit operator-set; same runtime behavior as nil today.
+	//   true  — opt in to verbatim sanitized goaway_message logging.
+	//           Store-construction emits a single WARN at startup
+	//           reminding the operator that this depends on the server-
+	//           side no-secrets contract documented at
+	//           proto/canyonroad/wtp/v1/wtp.proto Goaway.message.
+	//
+	// This pointer-form is mandatory: a plain bool would collapse "unset"
+	// into "explicit false" before the daemon could distinguish them,
+	// preventing a future schema-major-bump default-flip from being
+	// detectable in audit logs.
+	//
+	// IMPORTANT: Defaulting MUST NOT happen in applyDefaults/applyDefaultsWithSource.
+	// The nil state must survive the config-load pipeline. Defaulting occurs
+	// ONLY at store-construction time (buildWatchtowerStore in internal/server/wtp.go).
+	LogGoawayMessage *bool `yaml:"log_goaway_message,omitempty"`
+
 	TLS       WatchtowerTLSConfig       `yaml:"tls"`
 	Auth      WatchtowerAuthConfig      `yaml:"auth"`
 	Chain     WatchtowerChainConfig     `yaml:"chain"`

--- a/internal/server/wtp.go
+++ b/internal/server/wtp.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"strings"
@@ -16,6 +17,33 @@ import (
 	"github.com/agentsh/agentsh/internal/store/watchtower"
 	"github.com/agentsh/agentsh/internal/store/watchtower/compact"
 )
+
+// resolveLogGoawayMessage applies the three-state (nil / false / true)
+// semantics to the AuditWatchtowerConfig.LogGoawayMessage field and
+// emits the appropriate startup log. It is the single source of truth
+// for the resolution logic used by both the production
+// buildWatchtowerStore path and the test helper
+// ResolveLogGoawayMessageForTest — keeping them in sync so a drift in
+// production cannot leave tests green while operators see different
+// behavior.
+//
+// PRD-defined default at this major version (v1) is false.
+func resolveLogGoawayMessage(cfgVal *bool, logger *slog.Logger) bool {
+	const defaultV = false
+	switch {
+	case cfgVal == nil:
+		logger.Info("watchtower: log_goaway_message omitted; using default",
+			"value", defaultV)
+		return defaultV
+	case *cfgVal:
+		logger.Warn("watchtower: log_goaway_message=true; goaway_message text will be logged after client-side sanitization, depends on server-side no-secrets contract",
+			"see", "proto/canyonroad/wtp/v1/wtp.proto Goaway.message")
+		return true
+	default:
+		// explicit false — no log
+		return false
+	}
+}
 
 // buildWatchtowerStore constructs a watchtower.Store from the daemon
 // AuditWatchtowerConfig. Returns (nil, nil) when disabled.
@@ -84,21 +112,7 @@ func buildWatchtowerStore(
 	// Defaulting MUST happen here (NOT in config.go's Validate/applyDefaults)
 	// so that non-daemon CLI subcommands like `agentsh config show` don't
 	// emit operational startup logs.
-	const logGoawayDefault = false // PRD-defined default at this major version (v1)
-	var logGoaway bool
-	switch {
-	case cfg.LogGoawayMessage == nil:
-		logGoaway = logGoawayDefault
-		slog.Default().Info("watchtower: log_goaway_message omitted; using default",
-			"value", logGoawayDefault)
-	case *cfg.LogGoawayMessage:
-		logGoaway = true
-		slog.Default().Warn("watchtower: log_goaway_message=true; goaway_message text will be logged after client-side sanitization, depends on server-side no-secrets contract",
-			"see", "proto/canyonroad/wtp/v1/wtp.proto Goaway.message")
-	default:
-		logGoaway = false
-		// explicit false — no log
-	}
+	logGoaway := resolveLogGoawayMessage(cfg.LogGoawayMessage, slog.Default())
 
 	// Build the eventfilter.Filter from config.
 	var filter *eventfilter.Filter
@@ -234,17 +248,25 @@ func BuildWatchtowerStoreForTest(ctx context.Context, cfg config.AuditWatchtower
 // ResolveLogGoawayMessageForTest exports the three-state resolution logic
 // for unit tests. Returns the resolved bool and a string describing which
 // case fired ("nil", "explicit_true", "explicit_false").
-// Production code uses this same logic inline in buildWatchtowerStore.
+// Production code uses resolveLogGoawayMessage (the shared helper) inline in
+// buildWatchtowerStore — this export is a thin pass-through so tests exercise
+// the same code path production uses. The caseLabel return is test-only
+// bookkeeping; production does not need it.
 func ResolveLogGoawayMessageForTest(cfg config.AuditWatchtowerConfig) (resolved bool, caseLabel string) {
-	const logGoawayDefault = false
+	// Derive the label WITHOUT duplicating the resolution logic: call the
+	// shared helper first (with a discard logger so tests stay silent),
+	// then classify the pointer state to produce the stable test label.
+	discardLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	resolved = resolveLogGoawayMessage(cfg.LogGoawayMessage, discardLogger)
 	switch {
 	case cfg.LogGoawayMessage == nil:
-		return logGoawayDefault, "nil"
+		caseLabel = "nil"
 	case *cfg.LogGoawayMessage:
-		return true, "explicit_true"
+		caseLabel = "explicit_true"
 	default:
-		return false, "explicit_false"
+		caseLabel = "explicit_false"
 	}
+	return resolved, caseLabel
 }
 
 // ResolveAuthBearerForTest is a thin export of resolveAuthBearer for

--- a/internal/server/wtp.go
+++ b/internal/server/wtp.go
@@ -80,6 +80,26 @@ func buildWatchtowerStore(
 		slog.Warn("watchtower: TLS disabled via tls.insecure=true; traffic is plaintext — do not use in production")
 	}
 
+	// Resolve LogGoawayMessage three-state to the transport.Options bool.
+	// Defaulting MUST happen here (NOT in config.go's Validate/applyDefaults)
+	// so that non-daemon CLI subcommands like `agentsh config show` don't
+	// emit operational startup logs.
+	const logGoawayDefault = false // PRD-defined default at this major version (v1)
+	var logGoaway bool
+	switch {
+	case cfg.LogGoawayMessage == nil:
+		logGoaway = logGoawayDefault
+		slog.Default().Info("watchtower: log_goaway_message omitted; using default",
+			"value", logGoawayDefault)
+	case *cfg.LogGoawayMessage:
+		logGoaway = true
+		slog.Default().Warn("watchtower: log_goaway_message=true; goaway_message text will be logged after client-side sanitization, depends on server-side no-secrets contract",
+			"see", "proto/canyonroad/wtp/v1/wtp.proto Goaway.message")
+	default:
+		logGoaway = false
+		// explicit false — no log
+	}
+
 	// Build the eventfilter.Filter from config.
 	var filter *eventfilter.Filter
 	if cfg.Filter.IncludeTypes != nil || cfg.Filter.ExcludeTypes != nil ||
@@ -111,6 +131,7 @@ func buildWatchtowerStore(
 		HeartbeatEvery:  cfg.Heartbeat.Interval,
 		BackoffInitial:  cfg.Backoff.Base,
 		BackoffMax:      cfg.Backoff.Max,
+		LogGoawayMessage: logGoaway,
 		Endpoint:        cfg.Endpoint,
 		TLSEnabled:      tlsEnabled,
 		TLSCACertFile:   cfg.TLS.CACertFile,
@@ -208,6 +229,22 @@ func resolveAuthBearer(auth config.WatchtowerAuthConfig) (string, error) {
 // for white-box tests. Production callers use buildWatchtowerStore.
 func BuildWatchtowerStoreForTest(ctx context.Context, cfg config.AuditWatchtowerConfig, m compact.Mapper) (store.EventStore, error) {
 	return buildWatchtowerStore(ctx, cfg, m)
+}
+
+// ResolveLogGoawayMessageForTest exports the three-state resolution logic
+// for unit tests. Returns the resolved bool and a string describing which
+// case fired ("nil", "explicit_true", "explicit_false").
+// Production code uses this same logic inline in buildWatchtowerStore.
+func ResolveLogGoawayMessageForTest(cfg config.AuditWatchtowerConfig) (resolved bool, caseLabel string) {
+	const logGoawayDefault = false
+	switch {
+	case cfg.LogGoawayMessage == nil:
+		return logGoawayDefault, "nil"
+	case *cfg.LogGoawayMessage:
+		return true, "explicit_true"
+	default:
+		return false, "explicit_false"
+	}
 }
 
 // ResolveAuthBearerForTest is a thin export of resolveAuthBearer for

--- a/internal/server/wtp_log_goaway_test.go
+++ b/internal/server/wtp_log_goaway_test.go
@@ -1,0 +1,126 @@
+package server_test
+
+// Three-case integration test for AuditWatchtowerConfig.LogGoawayMessage
+// (Task 27b). The test drives the full config.Load → Validate →
+// applyDefaultsWithSource pipeline from real YAML fixtures written to a
+// TempDir, then calls ResolveLogGoawayMessageForTest to assert the
+// three-state resolution.
+//
+// Assertions:
+//
+//  1. unset: YAML omits log_goaway_message. After Load+Validate the field
+//     MUST still be nil (applyDefaults must NOT have materialised it). The
+//     resolved value must be false (the v1 default).
+//
+//  2. explicit false: YAML sets log_goaway_message: false. Field must be
+//     non-nil pointing to false. Resolved value must be false.
+//
+//  3. explicit true: YAML sets log_goaway_message: true. Field must be
+//     non-nil pointing to true. Resolved value must be true.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/server"
+)
+
+// minimalWatchtowerYAML produces a complete config YAML with
+// audit.watchtower disabled (so validate() skips the endpoint/auth/chain
+// checks). logGoawayLine is inserted verbatim into the watchtower block,
+// e.g. "  log_goaway_message: true" or "" (omitted).
+func minimalWatchtowerYAML(logGoawayLine string) string {
+	return `
+audit:
+  watchtower:
+    enabled: false
+` + logGoawayLine + `
+`
+}
+
+// loadCfgFromYAML writes the YAML to a temp file and loads it through the
+// real config.Load pipeline (applyDefaults + validate).
+func loadCfgFromYAML(t *testing.T, yaml string) *config.Config {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(cfgPath, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write config fixture: %v", err)
+	}
+	cfg, err := config.Load(cfgPath)
+	if err != nil {
+		t.Fatalf("config.Load: %v", err)
+	}
+	return cfg
+}
+
+// TestLogGoawayMessage_NilSurvivesLoad verifies that when the YAML omits
+// log_goaway_message, the field is still nil after the full Load+Validate
+// pipeline (applyDefaults MUST NOT eagerly materialise it).
+//
+// It also verifies that ResolveLogGoawayMessageForTest returns false (the
+// v1 PRD default) for the nil case, and labels it "nil".
+func TestLogGoawayMessage_NilSurvivesLoad(t *testing.T) {
+	cfg := loadCfgFromYAML(t, minimalWatchtowerYAML(""))
+
+	// LOAD-BEARING: the nil state must survive through applyDefaults.
+	if cfg.Audit.Watchtower.LogGoawayMessage != nil {
+		t.Fatalf("expected LogGoawayMessage to be nil after Load (applyDefaults must not materialise it), got *%v",
+			*cfg.Audit.Watchtower.LogGoawayMessage)
+	}
+
+	// Resolver must return the default (false) and label "nil".
+	resolved, label := server.ResolveLogGoawayMessageForTest(cfg.Audit.Watchtower)
+	if resolved != false {
+		t.Errorf("unset case: expected resolved=false, got %v", resolved)
+	}
+	if label != "nil" {
+		t.Errorf("unset case: expected label=%q, got %q", "nil", label)
+	}
+}
+
+// TestLogGoawayMessage_ExplicitFalse verifies that log_goaway_message: false
+// in YAML produces a non-nil *bool pointing to false, and that the resolver
+// returns false with label "explicit_false".
+func TestLogGoawayMessage_ExplicitFalse(t *testing.T) {
+	cfg := loadCfgFromYAML(t, minimalWatchtowerYAML("    log_goaway_message: false"))
+
+	if cfg.Audit.Watchtower.LogGoawayMessage == nil {
+		t.Fatal("expected LogGoawayMessage to be non-nil for explicit false")
+	}
+	if *cfg.Audit.Watchtower.LogGoawayMessage != false {
+		t.Fatalf("expected *LogGoawayMessage=false, got %v", *cfg.Audit.Watchtower.LogGoawayMessage)
+	}
+
+	resolved, label := server.ResolveLogGoawayMessageForTest(cfg.Audit.Watchtower)
+	if resolved != false {
+		t.Errorf("explicit_false case: expected resolved=false, got %v", resolved)
+	}
+	if label != "explicit_false" {
+		t.Errorf("explicit_false case: expected label=%q, got %q", "explicit_false", label)
+	}
+}
+
+// TestLogGoawayMessage_ExplicitTrue verifies that log_goaway_message: true
+// in YAML produces a non-nil *bool pointing to true, and that the resolver
+// returns true with label "explicit_true".
+func TestLogGoawayMessage_ExplicitTrue(t *testing.T) {
+	cfg := loadCfgFromYAML(t, minimalWatchtowerYAML("    log_goaway_message: true"))
+
+	if cfg.Audit.Watchtower.LogGoawayMessage == nil {
+		t.Fatal("expected LogGoawayMessage to be non-nil for explicit true")
+	}
+	if *cfg.Audit.Watchtower.LogGoawayMessage != true {
+		t.Fatalf("expected *LogGoawayMessage=true, got %v", *cfg.Audit.Watchtower.LogGoawayMessage)
+	}
+
+	resolved, label := server.ResolveLogGoawayMessageForTest(cfg.Audit.Watchtower)
+	if resolved != true {
+		t.Errorf("explicit_true case: expected resolved=true, got %v", resolved)
+	}
+	if label != "explicit_true" {
+		t.Errorf("explicit_true case: expected label=%q, got %q", "explicit_true", label)
+	}
+}

--- a/internal/store/watchtower/log_goaway_test.go
+++ b/internal/store/watchtower/log_goaway_test.go
@@ -2,9 +2,17 @@ package watchtower_test
 
 // TestOptions_LogGoawayMessage_WireThrough verifies that
 // watchtower.Options.LogGoawayMessage is threaded into the Store and
-// accessible via the test-only OptsLogGoawayMessageForTest accessor.
-// This guards the watchtower.Options → transport.Options wiring path
-// added in Task 27b.
+// flows all the way to the Transport via transport.New.
+//
+// Two assertions are made:
+//  1. OptsLogGoawayMessageForTest: the watchtower.Options copy is set
+//     correctly (guards buildWatchtowerStore → watchtower.Options).
+//  2. TransportLogGoawayMessageForTest: the Transport's resolved value
+//     matches (guards the store.go hop: watchtower.Options →
+//     transport.New call). If store.go ever stops threading
+//     opts.LogGoawayMessage into transport.New, the Transport's field
+//     stays at its zero value (false), causing the second assertion to
+//     fail even when the first passes.
 //
 // The test uses a nopDialer so the bg goroutine runs but never
 // connects; closeStore handles the bounded-deadline shutdown.
@@ -34,10 +42,21 @@ func TestOptions_LogGoawayMessage_WireThrough(t *testing.T) {
 			}
 			defer closeStore(t, s)
 
+			// Assertion 1: the watchtower.Options copy was set.
 			got := s.OptsLogGoawayMessageForTest()
 			if got != tc.value {
 				t.Errorf("OptsLogGoawayMessageForTest() = %v, want %v", got, tc.value)
 			}
+
+			// Assertion 2: the value was wired through to the Transport.
+			// This assertion fails if store.go stops passing
+			// opts.LogGoawayMessage to transport.New — even if
+			// Assertion 1 still passes.
+			gotTr := s.TransportLogGoawayMessageForTest()
+			if gotTr != tc.value {
+				t.Errorf("TransportLogGoawayMessageForTest() = %v, want %v (wire-through to transport.New regressed)", gotTr, tc.value)
+			}
 		})
 	}
 }
+

--- a/internal/store/watchtower/log_goaway_test.go
+++ b/internal/store/watchtower/log_goaway_test.go
@@ -1,0 +1,43 @@
+package watchtower_test
+
+// TestOptions_LogGoawayMessage_WireThrough verifies that
+// watchtower.Options.LogGoawayMessage is threaded into the Store and
+// accessible via the test-only OptsLogGoawayMessageForTest accessor.
+// This guards the watchtower.Options → transport.Options wiring path
+// added in Task 27b.
+//
+// The test uses a nopDialer so the bg goroutine runs but never
+// connects; closeStore handles the bounded-deadline shutdown.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/store/watchtower"
+)
+
+func TestOptions_LogGoawayMessage_WireThrough(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		value bool
+	}{
+		{"false", false},
+		{"true", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := validOpts(t.TempDir())
+			opts.LogGoawayMessage = tc.value
+
+			s, err := watchtower.New(context.Background(), opts)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			defer closeStore(t, s)
+
+			got := s.OptsLogGoawayMessageForTest()
+			if got != tc.value {
+				t.Errorf("OptsLogGoawayMessageForTest() = %v, want %v", got, tc.value)
+			}
+		})
+	}
+}

--- a/internal/store/watchtower/options.go
+++ b/internal/store/watchtower/options.go
@@ -93,6 +93,14 @@ type Options struct {
 	BackoffInitial time.Duration
 	BackoffMax     time.Duration
 
+	// LogGoawayMessage controls whether the WARN log emitted on GOAWAY
+	// receipt includes the server-supplied message text verbatim (after
+	// client-side sanitization). Threaded from AuditWatchtowerConfig
+	// (config layer) through buildWatchtowerStore (store-construction)
+	// into transport.Options.LogGoawayMessage. See transport.Options for
+	// the full semantics and the server-side no-secrets contract reference.
+	LogGoawayMessage bool
+
 	// Filter is the optional eventfilter.Filter applied before
 	// AppendEvent reaches the chain/WAL pipeline.
 	Filter *eventfilter.Filter

--- a/internal/store/watchtower/store.go
+++ b/internal/store/watchtower/store.go
@@ -364,6 +364,7 @@ func New(ctx context.Context, opts Options) (*Store, error) {
 		Metrics:         mw,
 		BackoffInitial:  opts.BackoffInitial,
 		BackoffMax:      opts.BackoffMax,
+		LogGoawayMessage: opts.LogGoawayMessage,
 		// Handshake metadata: the SessionInit frame MUST advertise the
 		// SAME algorithm / key fingerprint / context digest that the
 		// WAL records are chained with; otherwise the receiver sees a

--- a/internal/store/watchtower/store_export_test.go
+++ b/internal/store/watchtower/store_export_test.go
@@ -18,3 +18,12 @@ package watchtower
 func (s *Store) PeekPrevHash() string {
 	return s.sink.PeekPrevHash()
 }
+
+// OptsLogGoawayMessageForTest returns the Options.LogGoawayMessage value
+// the Store was constructed with. Used by integration tests to assert
+// that the config-layer three-state resolution is correctly threaded
+// through watchtower.Options → transport.Options.
+func (s *Store) OptsLogGoawayMessageForTest() bool {
+	return s.opts.LogGoawayMessage
+}
+

--- a/internal/store/watchtower/store_export_test.go
+++ b/internal/store/watchtower/store_export_test.go
@@ -27,3 +27,13 @@ func (s *Store) OptsLogGoawayMessageForTest() bool {
 	return s.opts.LogGoawayMessage
 }
 
+// TransportLogGoawayMessageForTest returns the LogGoawayMessage value
+// as resolved by the Transport the Store constructed. This is the
+// load-bearing seam for the wire-through regression test: if store.go
+// ever stops passing opts.LogGoawayMessage into transport.New, the
+// Transport's value will be false (the zero value) regardless of what
+// Options.LogGoawayMessage was set to, causing the assertion to fail.
+func (s *Store) TransportLogGoawayMessageForTest() bool {
+	return s.tr.LogGoawayMessage()
+}
+

--- a/internal/store/watchtower/transport/seams_export_test.go
+++ b/internal/store/watchtower/transport/seams_export_test.go
@@ -254,12 +254,17 @@ func StartRecvForTest(t *Transport, parent context.Context) *RecvSessionHandle {
 	}
 }
 
+// LogGoawayMessageForTest returns the transport's LogGoawayMessage option
+// value so integration tests can assert the wiring path from
+// watchtower.Options → transport.Options.
+func LogGoawayMessageForTest(t *Transport) bool {
+	return t.opts.LogGoawayMessage
+}
+
 // TeardownRecvForTest invokes the production teardownRecv helper so
 // integration tests can assert the round-22 lifecycle (cancel + nil
 // out the field) without touching unexported state.
 func TeardownRecvForTest(t *Transport) { t.teardownRecv() }
-
-// RunShutdownForTest invokes the unexported runShutdown helper directly
 // so external tests can exercise the drain path without driving the
 // full Run loop. Used by the roborev #6143 regression test that
 // verifies post-sentinel buffered records are NOT flushed during

--- a/internal/store/watchtower/transport/transport.go
+++ b/internal/store/watchtower/transport/transport.go
@@ -376,6 +376,14 @@ func (t *Transport) RejectReason() string {
 	return t.rejectReason
 }
 
+// LogGoawayMessage returns the LogGoawayMessage option the Transport was
+// constructed with. Used by watchtower.Store's test seam
+// (TransportLogGoawayMessageForTest in store_export_test.go) to assert that
+// store.go correctly wires opts.LogGoawayMessage through to transport.New.
+func (t *Transport) LogGoawayMessage() bool {
+	return t.opts.LogGoawayMessage
+}
+
 // stopReq carries a Stop request through the run loop. The done channel
 // is closed by whichever loop branch services the request, which
 // unblocks the Stop caller. drainDeadline bounds how long runShutdown

--- a/proto/canyonroad/wtp/v1/wtp.proto
+++ b/proto/canyonroad/wtp/v1/wtp.proto
@@ -160,7 +160,19 @@ enum TransportLossReason {
 
 message Goaway {
   GoawayCode code             = 1;
+
+  // Human-readable diagnostic message describing the reason for the
+  // GOAWAY. The Watchtower server-side contract REQUIRES that this
+  // string MUST NOT contain credentials, secrets, or PII — clients
+  // may log it (per the client's LogGoawayMessage config flag) after
+  // applying client-side sanitization (control-char stripping +
+  // truncation to 512 bytes at a UTF-8 rune boundary + invalid-UTF-8
+  // replacement with U+FFFD). Server operators MUST produce only
+  // operator-facing diagnostic text here; the server is the
+  // authoritative owner of the no-secrets contract. Client-side
+  // redaction beyond the sanitization described above is out of scope.
   string     message          = 2;
+
   bool       retry_immediately = 3;
 }
 


### PR DESCRIPTION
## Summary

- **Precursor commit** (`604351d4`): Adds the no-secrets contract doc comment to `Goaway.message` in `proto/canyonroad/wtp/v1/wtp.proto`. This satisfies Task 27b's prereq #3 ("Watchtower-server-side Goaway.message no-secrets contract published") — the contract is now in the proto: the message field MUST NOT contain credentials, secrets, or PII; server operators own the enforcement; clients may log after sanitization under the `LogGoawayMessage` opt-in.

- **Main commit** (`27f3456b`): Adds `AuditWatchtowerConfig.LogGoawayMessage *bool` with three-state semantics and wires it through to `transport.Options.LogGoawayMessage` (which already existed from Task 22d).

**Three-state semantics:**
- `nil` (YAML omitted) → resolves to `false` at store-construction; emits startup INFO so a future default-flip is auditable
- `false` (explicit) → silent; operator has documented intent
- `true` (explicit) → resolves to `true`; emits startup WARN linking the proto no-secrets contract

**Wire-through path:**
`AuditWatchtowerConfig.LogGoawayMessage (*bool)` → `buildWatchtowerStore` three-state resolver → `watchtower.Options.LogGoawayMessage` (new field, Task 27b) → `transport.Options.LogGoawayMessage` (pre-existing Task 22d field)

**Key design decision:** Defaulting does NOT happen in `config.go`'s `applyDefaults`/`applyDefaultsWithSource`. The `nil` state survives the full `Load` → `Validate` pipeline. This preserves the ability to audit default-flip migrations in startup logs and keeps non-daemon CLI commands (e.g. `agentsh config show`) quiet.

## Test plan

- [x] `TestLogGoawayMessage_NilSurvivesLoad` — nil state preserved through real `config.Load` pipeline
- [x] `TestLogGoawayMessage_ExplicitFalse` — explicit false round-trips correctly
- [x] `TestLogGoawayMessage_ExplicitTrue` — explicit true round-trips correctly
- [x] `TestOptions_LogGoawayMessage_WireThrough` — `watchtower.Options.LogGoawayMessage` → `Store` accessor
- [x] `go test ./...` — all packages pass
- [x] `GOOS=windows go build ./...` — cross-compile clean
- [x] `GOOS=darwin go build ./...` — cross-compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)