### PR TITLE
wtp: tech-debt cleanup — vet copylocks fix + Metrics/CompressMetrics split

### DIFF
--- a/internal/store/watchtower/store.go
+++ b/internal/store/watchtower/store.go
@@ -381,6 +381,7 @@ func New(ctx context.Context, opts Options) (*Store, error) {
 		Logger:           opts.Logger,
 		WAL:              w,
 		Metrics:          mw,
+		CompressMetrics:  mw,
 		BackoffInitial:   opts.BackoffInitial,
 		BackoffMax:       opts.BackoffMax,
 		LogGoawayMessage: opts.LogGoawayMessage,

--- a/internal/store/watchtower/testserver/server.go
+++ b/internal/store/watchtower/testserver/server.go
@@ -317,10 +317,6 @@ func (noopClassifierMetrics) IncResendNeeded()          {}
 func (noopClassifierMetrics) IncAckRegressionLoss()     {}
 func (noopClassifierMetrics) IncDroppedInvalidFrame(metrics.WTPInvalidFrameReason) {
 }
-func (noopClassifierMetrics) IncCompressError(string)                      {}
-func (noopClassifierMetrics) ObserveBatchCompressionRatio(string, float64) {}
-func (noopClassifierMetrics) AddBatchUncompressedBytes(string, int)        {}
-func (noopClassifierMetrics) AddBatchCompressedBytes(string, int)          {}
 
 // Stream implements the WatchtowerServer bidi streaming RPC. Every
 // ClientMessage variant the Transport can emit is handled:

--- a/internal/store/watchtower/testserver/server.go
+++ b/internal/store/watchtower/testserver/server.go
@@ -218,9 +218,11 @@ func (s *Server) TransportLosses() []*wtpv1.TransportLoss {
 	defer s.mu.Unlock()
 	out := make([]*wtpv1.TransportLoss, len(s.transportLosses))
 	for i, tl := range s.transportLosses {
-		// Deep copy so callers can't mutate server state.
-		cp := *tl
-		out[i] = &cp
+		// Deep copy so callers can't mutate server state. proto.Clone
+		// is the proto-aware copy that does NOT trip go vet's
+		// copylocks check (the `*tl` shorthand copies the embedded
+		// protoimpl.MessageState which contains a sync.Mutex).
+		out[i] = proto.Clone(tl).(*wtpv1.TransportLoss)
 	}
 	return out
 }
@@ -267,9 +269,11 @@ func (s *Server) WaitForTransportLoss(deadline time.Duration) (*wtpv1.TransportL
 	for {
 		s.mu.Lock()
 		if len(s.transportLosses) > 0 {
-			cp := *s.transportLosses[0]
+			// proto.Clone avoids the sync.Mutex-copy that go vet
+			// flags on a plain struct dereference of *wtpv1.TransportLoss.
+			cp := proto.Clone(s.transportLosses[0]).(*wtpv1.TransportLoss)
 			s.mu.Unlock()
-			return &cp, nil
+			return cp, nil
 		}
 		s.mu.Unlock()
 		select {

--- a/internal/store/watchtower/transport/state_connecting_clamp_internal_test.go
+++ b/internal/store/watchtower/transport/state_connecting_clamp_internal_test.go
@@ -38,10 +38,6 @@ func (f *fakeMetrics) IncAckRegressionLoss() { f.ackRegressionLoss++ }
 func (f *fakeMetrics) IncDroppedInvalidFrame(reason metrics.WTPInvalidFrameReason) {
 	f.droppedInvalidFrameReasons = append(f.droppedInvalidFrameReasons, reason)
 }
-func (f *fakeMetrics) IncCompressError(string)                      {}
-func (f *fakeMetrics) ObserveBatchCompressionRatio(string, float64) {}
-func (f *fakeMetrics) AddBatchUncompressedBytes(string, int)        {}
-func (f *fakeMetrics) AddBatchCompressedBytes(string, int)          {}
 
 // logEntry decodes a single JSON-formatted slog record.
 type logEntry struct {

--- a/internal/store/watchtower/transport/state_live.go
+++ b/internal/store/watchtower/transport/state_live.go
@@ -17,19 +17,6 @@ import (
 // Test seam — production wiring sets this from transport.New.
 var encoderMetrics *metrics.WTPMetrics
 
-// compressMetrics is the metrics surface encodeBatchMessage uses for
-// compression bookkeeping. Production wiring is *internal/metrics.WTPMetrics
-// (which implements all four methods after the metrics-side Task 4
-// landed). A nil value is allowed and disables metric recording.
-// Tests substitute a fake recorder to assert call patterns without
-// standing up a full Collector.
-type compressMetrics interface {
-	IncCompressError(algo string)
-	ObserveBatchCompressionRatio(algo string, ratio float64)
-	AddBatchUncompressedBytes(algo string, n int)
-	AddBatchCompressedBytes(algo string, n int)
-}
-
 // noneCompressorSingleton is the package-level fallback encoder used by
 // encodeBatchMessage's no-args wrapper (the test-only path that does not
 // thread a compressor through) and by transport.New when Options leaves
@@ -234,7 +221,7 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 					break
 				}
 				if outBatch := b.Add(rec); outBatch != nil {
-					msgs, err := encodeBatchMessageFn(outBatch.Records, t.emitExtendedLossReasons, t.compressor, t.opts.Metrics)
+					msgs, err := encodeBatchMessageFn(outBatch.Records, t.emitExtendedLossReasons, t.compressor, t.compressMetrics)
 					if err != nil {
 						_ = t.conn.Close()
 						t.teardownRecv()
@@ -274,7 +261,7 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 			// returns the buffered batch.
 			if inflight.Len() < opts.MaxInflight {
 				if outBatch := b.Tick(now); outBatch != nil {
-					msgs, err := encodeBatchMessageFn(outBatch.Records, t.emitExtendedLossReasons, t.compressor, t.opts.Metrics)
+					msgs, err := encodeBatchMessageFn(outBatch.Records, t.emitExtendedLossReasons, t.compressor, t.compressMetrics)
 					if err != nil {
 						_ = t.conn.Close()
 						t.teardownRecv()
@@ -308,7 +295,7 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 // TransportLoss frames are emitted or silently dropped; callers pass
 // their per-Transport flag captured at run-state entry so a global flag
 // mutation in another test goroutine cannot affect an in-progress encode.
-var encodeBatchMessageFn = func(records []wal.Record, emitExtended bool, compressor compress.Encoder, m compressMetrics) ([]*wtpv1.ClientMessage, error) {
+var encodeBatchMessageFn = func(records []wal.Record, emitExtended bool, compressor compress.Encoder, m CompressMetrics) ([]*wtpv1.ClientMessage, error) {
 	return encodeBatchMessageWithCompressor(records, emitExtended, compressor, m)
 }
 
@@ -361,7 +348,7 @@ func extractWireHighWatermark(msg *wtpv1.ClientMessage) (uint32, uint64) {
 // exists for defense in depth.
 //
 // m is the metrics recorder; nil is allowed and disables recording.
-func encodeBatchMessageWithCompressor(records []wal.Record, emitExtended bool, compressor compress.Encoder, m compressMetrics) ([]*wtpv1.ClientMessage, error) {
+func encodeBatchMessageWithCompressor(records []wal.Record, emitExtended bool, compressor compress.Encoder, m CompressMetrics) ([]*wtpv1.ClientMessage, error) {
 	var msgs []*wtpv1.ClientMessage
 
 	var (

--- a/internal/store/watchtower/transport/state_replaying.go
+++ b/internal/store/watchtower/transport/state_replaying.go
@@ -108,7 +108,7 @@ func (t *Transport) runReplaying(ctx context.Context, r *Replayer) (State, error
 			return StateConnecting, fmt.Errorf("replay batch: %w", err)
 		}
 		if len(batch.Records) > 0 {
-			msgs, err := buildEventBatchFn(batch.Records, t.emitExtendedLossReasons, t.compressor, t.opts.Metrics)
+			msgs, err := buildEventBatchFn(batch.Records, t.emitExtendedLossReasons, t.compressor, t.compressMetrics)
 			if err != nil {
 				_ = t.conn.Close()
 				t.teardownRecv()
@@ -145,6 +145,6 @@ func (t *Transport) runReplaying(ctx context.Context, r *Replayer) (State, error
 // Tests that need to assert against a custom wire shape can override
 // via setBuildEventBatchFnForTest (see state_replaying_internal_test.go).
 // Production code MUST NOT mutate this variable.
-var buildEventBatchFn = func(records []wal.Record, emitExtended bool, compressor compress.Encoder, m compressMetrics) ([]*wtpv1.ClientMessage, error) {
+var buildEventBatchFn = func(records []wal.Record, emitExtended bool, compressor compress.Encoder, m CompressMetrics) ([]*wtpv1.ClientMessage, error) {
 	return encodeBatchMessageWithCompressor(records, emitExtended, compressor, m)
 }

--- a/internal/store/watchtower/transport/state_replaying_internal_test.go
+++ b/internal/store/watchtower/transport/state_replaying_internal_test.go
@@ -52,7 +52,7 @@ func (t *Transport) RunReplayingForTest(ctx context.Context, r *Replayer) (State
 // outside the transport package cannot mutate it without going through
 // this guarded helper.
 func setBuildEventBatchFnForTest(fn func([]wal.Record) ([]*wtpv1.ClientMessage, error)) func() {
-	wrapped := func(records []wal.Record, _ bool, _ compress.Encoder, _ compressMetrics) ([]*wtpv1.ClientMessage, error) {
+	wrapped := func(records []wal.Record, _ bool, _ compress.Encoder, _ CompressMetrics) ([]*wtpv1.ClientMessage, error) {
 		return fn(records)
 	}
 	prev := buildEventBatchFn
@@ -87,7 +87,7 @@ func SetBuildEventBatchFnForTest(fn func([]wal.Record) ([]*wtpv1.ClientMessage, 
 // encoder plumbing and keeping two knobs is less invasive than
 // unifying them in a test-driven refactor.
 func SetEncodeBatchMessageFnForTest(fn func([]wal.Record) ([]*wtpv1.ClientMessage, error)) func() {
-	wrapped := func(records []wal.Record, _ bool, _ compress.Encoder, _ compressMetrics) ([]*wtpv1.ClientMessage, error) {
+	wrapped := func(records []wal.Record, _ bool, _ compress.Encoder, _ CompressMetrics) ([]*wtpv1.ClientMessage, error) {
 		return fn(records)
 	}
 	prev := encodeBatchMessageFn

--- a/internal/store/watchtower/transport/state_shutdown.go
+++ b/internal/store/watchtower/transport/state_shutdown.go
@@ -55,7 +55,7 @@ func (t *Transport) runShutdown(parent context.Context, b *Batcher, rdr *wal.Rea
 				break
 			}
 			if outBatch := b.Add(rec); outBatch != nil {
-				msgs, err := encodeBatchMessageFn(outBatch.Records, t.emitExtendedLossReasons, t.compressor, t.opts.Metrics)
+				msgs, err := encodeBatchMessageFn(outBatch.Records, t.emitExtendedLossReasons, t.compressor, t.compressMetrics)
 				if err != nil {
 					break drainLoop
 				}
@@ -69,7 +69,7 @@ func (t *Transport) runShutdown(parent context.Context, b *Batcher, rdr *wal.Rea
 		}
 	}
 	if final := b.Drain(); final != nil {
-		msgs, err := encodeBatchMessageFn(final.Records, t.emitExtendedLossReasons, t.compressor, t.opts.Metrics)
+		msgs, err := encodeBatchMessageFn(final.Records, t.emitExtendedLossReasons, t.compressor, t.compressMetrics)
 		if err == nil {
 			for _, msg := range msgs {
 				_ = t.conn.Send(msg)

--- a/internal/store/watchtower/transport/transport.go
+++ b/internal/store/watchtower/transport/transport.go
@@ -16,21 +16,30 @@ import (
 )
 
 // Metrics is the production-side counter/gauge surface the Transport calls
-// into. The real implementation is *internal/metrics.WTPMetrics; tests
-// substitute fakes. New() defaults to a no-op when Options.Metrics is nil
-// so callers can construct a Transport without wiring metrics.
+// into for ack/anomaly/recv-classifier bookkeeping. The real implementation
+// is *internal/metrics.WTPMetrics; tests substitute fakes. New() defaults
+// to a no-op when Options.Metrics is nil so callers can construct a
+// Transport without wiring metrics.
+//
+// Compression-specific metrics live on a separate CompressMetrics
+// interface so test fakes that don't care about compression don't have to
+// stub out the four compress methods.
 type Metrics interface {
 	SetAckHighWatermark(seq int64)
 	IncAnomalousAck(reason string)
 	IncResendNeeded()
 	IncAckRegressionLoss()
 	IncDroppedInvalidFrame(reason metrics.WTPInvalidFrameReason)
+}
 
-	// Compression metrics (Task 8 of 2026-04-27 batch-compression plan).
-	// Production implementer is *internal/metrics.WTPMetrics, which
-	// gained these methods in Task 4. The encoder's compressMetrics
-	// interface (state_live.go) is satisfied by anything with these
-	// four methods, so production wires *WTPMetrics directly.
+// CompressMetrics is the metrics surface encodeBatchMessage calls into for
+// per-batch compression bookkeeping. Production wiring is
+// *internal/metrics.WTPMetrics, which structurally satisfies both Metrics
+// and CompressMetrics — the same Collector instance is threaded into both
+// Options fields. New() defaults to a no-op when Options.CompressMetrics is
+// nil so tests that don't care about compression don't need to wire a
+// fake.
+type CompressMetrics interface {
 	IncCompressError(algo string)
 	ObserveBatchCompressionRatio(algo string, ratio float64)
 	AddBatchUncompressedBytes(algo string, n int)
@@ -44,10 +53,13 @@ func (noopMetrics) IncAnomalousAck(string)                               {}
 func (noopMetrics) IncResendNeeded()                                     {}
 func (noopMetrics) IncAckRegressionLoss()                                {}
 func (noopMetrics) IncDroppedInvalidFrame(metrics.WTPInvalidFrameReason) {}
-func (noopMetrics) IncCompressError(string)                              {}
-func (noopMetrics) ObserveBatchCompressionRatio(string, float64)         {}
-func (noopMetrics) AddBatchUncompressedBytes(string, int)                {}
-func (noopMetrics) AddBatchCompressedBytes(string, int)                  {}
+
+type noopCompressMetrics struct{}
+
+func (noopCompressMetrics) IncCompressError(string)                      {}
+func (noopCompressMetrics) ObserveBatchCompressionRatio(string, float64) {}
+func (noopCompressMetrics) AddBatchUncompressedBytes(string, int)        {}
+func (noopCompressMetrics) AddBatchCompressedBytes(string, int)          {}
 
 // AckTuple is the persisted (gen, seq) ack pair seeded from wal.Meta on
 // cold start. Present=false means the WAL has never recorded an ack
@@ -238,6 +250,15 @@ type Options struct {
 	// goroutine-safe across Transports but reused serially within one
 	// Transport.
 	Compressor compress.Encoder
+
+	// CompressMetrics is the per-Transport sink for compression
+	// bookkeeping (ratio histogram, byte counters, fail-open counter).
+	// nil disables compress metric recording — the encoder still runs,
+	// but observations are dropped. Production wires the same
+	// *WTPMetrics instance that satisfies Metrics; the two interfaces
+	// are deliberately separate so test fakes don't have to stub out
+	// methods they have no semantic relationship to.
+	CompressMetrics CompressMetrics
 }
 
 // validate enforces the construction-time invariants documented on
@@ -364,9 +385,14 @@ type Transport struct {
 	// compressor is the per-Transport batch encoder captured from
 	// Options.Compressor at New() time. Defaulted to a noneEncoder
 	// when Options.Compressor is nil so callers downstream can
-	// always invoke it without nil-checks. Not consumed yet; Task 8
-	// wires encodeBatchMessage to call it.
+	// always invoke it without nil-checks.
 	compressor compress.Encoder
+
+	// compressMetrics is the per-Transport compress-metrics sink
+	// captured from Options.CompressMetrics at New() time. Defaulted
+	// to a noopCompressMetrics when nil so encodeBatchMessage can
+	// always invoke it without nil-checks.
+	compressMetrics CompressMetrics
 }
 
 // New constructs a Transport. It does not dial; call Run to start.
@@ -398,9 +424,13 @@ func New(opts Options) (*Transport, error) {
 		runDone:                 make(chan struct{}),
 		emitExtendedLossReasons: opts.EmitExtendedLossReasons,
 		compressor:              opts.Compressor,
+		compressMetrics:         opts.CompressMetrics,
 	}
 	if t.compressor == nil {
 		t.compressor = noneCompressorSingleton
+	}
+	if t.compressMetrics == nil {
+		t.compressMetrics = noopCompressMetrics{}
 	}
 	if opts.InitialAckTuple != nil && opts.InitialAckTuple.Present {
 		seed := AckCursor{


### PR DESCRIPTION
## Summary

Two follow-ups deferred from PR #256 (WTP batch compression):

1. **\`wtp/testserver\` proto.Clone fix.** \`go vet -copylocks\` flagged two struct-copy assignments of \`*wtpv1.TransportLoss\` in \`server.go:222\` (TransportLosses) and \`server.go:270\` (WaitForTransportLoss). The embedded \`protoimpl.MessageState\` contains a \`sync.Mutex\`. Switched to \`proto.Clone\` — proto-aware deep copy that doesn't trip the lint. Pre-existing warnings from PR #255 (commit \`bae6d21d\`); cleaned up here.

2. **Split \`CompressMetrics\` out of \`transport.Metrics\`.** PR #256 widened \`transport.Metrics\` with four compress methods, forcing two unrelated test fakes to grow no-op stubs (\`noopClassifierMetrics\` in testserver, \`fakeMetrics\` in state_connecting_clamp_internal_test.go) — flagged as a design smell in the final code review. Introduce an exported \`transport.CompressMetrics\` interface + matching \`Options.CompressMetrics\` field. Production \`*WTPMetrics\` structurally satisfies both; store.go threads the same instance into both Options fields. Test fakes that don't care about compression no longer have to stub four no-op methods. The unexported \`compressMetrics\` interface in state_live.go is removed.

No behavior change. Both commits are independent.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`GOOS=windows go build ./...\` clean
- [x] \`go vet ./...\` clean (warnings from PR #255 are gone)
- [x] \`go test ./internal/store/watchtower/transport/... ./internal/store/watchtower/transport/compress/... ./internal/store/watchtower/testserver/... ./internal/metrics/... ./internal/config/...\` clean
- [x] Full suite \`go test ./...\` — pre-existing flakes (\`TestStore_TransportLossInflightSlot_RetiredByBatchAck\`, \`TestServer_GRPC_EventsTail\`) reproduced under parallel-test load only and pass in isolation; not regressions