### PR TITLE
fix(skillcheck): integration test waits for trash manifest write

### DIFF
--- a/internal/skillcheck/integration_test.go
+++ b/internal/skillcheck/integration_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/agentsh/agentsh/internal/trash"
 )
 
 // TestEndToEnd_QuarantineRoundTrip drops the malicious fixture into a temp
@@ -85,15 +87,25 @@ func TestEndToEnd_QuarantineRoundTrip(t *testing.T) {
 	// Wait for quarantine. Use a 10s deadline: on Windows CI runners under
 	// load, the Daemon's fsnotify → LoadSkill → Scan → Evaluate → Apply
 	// pipeline adds significant latency on top of fsnotify event delivery.
+	//
+	// Both conditions must hold before we proceed: the source skill dir is
+	// gone AND the trash has at least one entry. On Windows, trash.Divert
+	// moves the source before persisting the manifest, so a check on source-
+	// removal alone races against the manifest write.
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
-		if _, err := os.Stat(skillDir); os.IsNotExist(err) {
+		_, statErr := os.Stat(skillDir)
+		entries, _ := trash.List(trashDir)
+		if os.IsNotExist(statErr) && len(entries) > 0 {
 			break
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
 	if _, err := os.Stat(skillDir); !os.IsNotExist(err) {
 		t.Fatalf("skill was not quarantined within 10s")
+	}
+	if entries, _ := trash.List(trashDir); len(entries) == 0 {
+		t.Fatalf("trash list is empty after quarantine completed (race between source removal and manifest write?)")
 	}
 
 	// Use CLI to confirm we can list the quarantined entry.


### PR DESCRIPTION
## Summary

Post-merge CI on `main` (run [25125265155](https://github.com/canyonroad/agentsh/actions/runs/25125265155)) showed `TestEndToEnd_QuarantineRoundTrip` failing on Windows in 0.63s. Root cause: \`trash.Divert\` on Windows moves the source skill dir before persisting the manifest. The polling loop in the integration test exited as soon as source-removal was observed, then immediately read \`trash.List()\` — racing the manifest write. Symptoms:

- list output empty (\"no quarantined skills\")
- \`strings.Fields\` parsed that as \`[\"no\",\"quarantined\",\"skills\"]\`, so token = \"no\"
- restore failed with \`open …\\manifest\\no.json: file not found\`

Fix: require BOTH \`os.Stat(skillDir) == IsNotExist\` AND \`len(trash.List(trashDir)) > 0\` before proceeding. Adds an explicit assertion on the trash-list precondition so a future regression on the trash atomicity guarantee fails loudly rather than masquerading as a parse error downstream.

## Test plan

- [ ] CI passes on Linux + Windows
- [ ] Local run \`go test ./internal/skillcheck/ -run TestEndToEnd -v\` passes (verified)

## Note on \`internal/store/watchtower\` flakes

The same CI run also showed pre-existing flakes in \`internal/store/watchtower\` (\`TestStore_*EmitsTransportLossOnWire\`-family, all 15s deadline timeouts). Those are unrelated to skillcheck and were already a known flake-class on \`main\`. This PR doesn't address them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)