### PR TITLE
feat(seccomp,ptrace): per-AF_* socket family blocking

### DIFF
--- a/cmd/agentsh-unixwrap/config.go
+++ b/cmd/agentsh-unixwrap/config.go
@@ -6,22 +6,25 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+
+	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
 )
 
 // WrapperConfig is the configuration passed via AGENTSH_SECCOMP_CONFIG env var.
 type WrapperConfig struct {
-	UnixSocketEnabled   bool     `json:"unix_socket_enabled"`
-	ExecveEnabled       bool     `json:"execve_enabled"`
-	SignalFilterEnabled bool     `json:"signal_filter_enabled"`
-	FileMonitorEnabled  bool     `json:"file_monitor_enabled"`
-	BlockedSyscalls     []string `json:"blocked_syscalls"`
-	OnBlock             string   `json:"on_block,omitempty"`
+	UnixSocketEnabled   bool                      `json:"unix_socket_enabled"`
+	ExecveEnabled       bool                      `json:"execve_enabled"`
+	SignalFilterEnabled bool                      `json:"signal_filter_enabled"`
+	FileMonitorEnabled  bool                      `json:"file_monitor_enabled"`
+	BlockedSyscalls     []string                  `json:"blocked_syscalls"`
+	BlockedFamilies     []seccompkg.BlockedFamily `json:"blocked_families,omitempty"`
+	OnBlock             string                    `json:"on_block,omitempty"`
 
 	InterceptMetadata bool `json:"intercept_metadata,omitempty"`
 	BlockIOUring      bool `json:"block_io_uring,omitempty"`
 
 	// Landlock filesystem restrictions
-	LandlockEnabled bool `json:"landlock_enabled,omitempty"`
+	LandlockEnabled bool     `json:"landlock_enabled,omitempty"`
 	LandlockABI     int      `json:"landlock_abi,omitempty"`
 	Workspace       string   `json:"workspace,omitempty"`
 	AllowExecute    []string `json:"allow_execute,omitempty"`

--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -75,6 +75,7 @@ func main() {
 		InterceptMetadata:  cfg.InterceptMetadata,
 		BlockIOUring:       cfg.BlockIOUring,
 		BlockedSyscalls:    blockedNrs,
+		BlockedFamilies:    cfg.BlockedFamilies,
 		OnBlockAction:      onBlock,
 	}
 

--- a/docs/seccomp.md
+++ b/docs/seccomp.md
@@ -36,6 +36,16 @@ sandbox:
         - umount2
         # ... see defaults below
       on_block: errno  # errno | kill | log | log_and_kill (default: errno)
+
+    # Per-AF_* socket family blocking on socket(2) and socketpair(2).
+    # Unset → recommended-default list applied (12 families at errno).
+    # Set to [] → opt out of all family blocking entirely.
+    # Non-empty list → overrides defaults.
+    blocked_socket_families:
+      - family: AF_ALG       # by name (preferred) or numeric ("38")
+        action: errno        # errno | kill | log | log_and_kill (default: errno)
+      - family: AF_VSOCK
+        action: log_and_kill
 ```
 
 ## Signal Interception
@@ -210,6 +220,91 @@ When seccomp is enabled, these syscalls are blocked by default:
 **Why four modes:** `errno` is the lowest-cost default — well-behaved agents get a predictable `EPERM` and carry on; misbehaving ones are stopped at the kernel. `kill` is the irrevocable stance. `log` / `log_and_kill` take a user-notify round-trip per blocked call, so they are observable but more expensive; reach for them when you want an audit trail of every attempted violation.
 
 **Startup warning:** when `on_block` is `log` or `log_and_kill` but no audit sink is registered, agentsh logs a warning at startup so operators don't wonder where events went.
+
+## Socket Family Blocking
+
+`sandbox.seccomp.blocked_socket_families` blocks creation of specified `AF_*` socket families on `socket(2)` and `socketpair(2)`. Mitigates the recurring CVE class where `socket(AF_<niche-family>, ...)` is the kernel attack entry point — see [copy.fail](https://copy.fail/#mitigation) for the AF_ALG case that motivated this feature.
+
+### Default list (when field unset)
+
+When `blocked_socket_families` is omitted from config, agentsh applies a recommended-default list of 12 families at `action: errno`. Set the field to `[]` to opt out entirely; set it to a non-empty list to override the defaults.
+
+| Family | Number | Why default |
+|---|---|---|
+| `AF_ALG` | 38 | copy.fail mitigation; near-zero legitimate userspace use |
+| `AF_VSOCK` | 40 | Niche (VM-host); multiple historical CVEs |
+| `AF_RDS` | 21 | Reliable Datagram Sockets; multiple CVEs; effectively dead |
+| `AF_TIPC` | 30 | Niche cluster protocol; multiple CVEs |
+| `AF_KCM` | 41 | Kernel Connection Multiplexor; niche; CVEs |
+| `AF_X25`, `AF_AX25`, `AF_NETROM`, `AF_ROSE`, `AF_DECnet`, `AF_APPLETALK`, `AF_IPX` | various | Legacy/dead protocols, pure attack surface |
+
+**Not** in defaults (too widely used; opt-in only): `AF_NETLINK`, `AF_PACKET`, `AF_BLUETOOTH`, `AF_CAN`.
+
+### Family resolution
+
+Each entry's `family` field accepts either a name (`AF_ALG`) or a numeric string (`38`). Names resolve via a built-in table; numbers in `[0, 64)` are accepted as a fallback for families the table doesn't yet know. Unknown names and out-of-range numbers are rejected at config-load time.
+
+### Action mapping
+
+| Action | Effect on `socket(AF_X, ...)` | Audit event |
+|---|---|---|
+| `errno` | Returns `EAFNOSUPPORT` (97) — the standard "this family isn't supported" code | none (kernel-side) |
+| `kill` | Process killed by `SCMP_ACT_KILL_PROCESS` | none (kernel-side) |
+| `log` | Returns `EAFNOSUPPORT` + emits audit event | `seccomp_socket_family_blocked`, outcome `denied` |
+| `log_and_kill` | Process killed by `SIGKILL` + emits audit event | `seccomp_socket_family_blocked`, outcome `killed` |
+
+`errno` is the right default for security tooling — well-behaved userspace falls back gracefully when a family isn't supported.
+
+### Two enforcement engines
+
+Family blocking has two engines that share the same config and emit identical audit-event shapes:
+
+1. **seccomp-bpf (primary)** — adds an `AddRuleConditional` rule on `socket(2)` arg0 to the existing seccomp filter. Cheap, kernel-side. Used when seccomp is available AND the agentsh-unixwrap binary will run.
+2. **ptrace (fallback + defensive)** — when `sandbox.ptrace.enabled: true`, the family checker is also wired into the ptrace tracer regardless of which engine the selector reports. Runtime dispatch is mutually exclusive between engines, so this is safe and ensures coverage in hybrid configurations where the seccomp wrapper is skipped.
+
+If neither engine is available on the host, agentsh logs a startup warning and continues — families are not blocked.
+
+### Audit event
+
+```json
+{
+  "type": "seccomp_socket_family_blocked",
+  "timestamp": "2026-04-29T18:00:00Z",
+  "session_id": "sess_abc123",
+  "source": "seccomp",
+  "pid": 12345,
+  "fields": {
+    "family_name": "AF_ALG",
+    "family_number": 38,
+    "syscall": "socket",
+    "action": "log_and_kill",
+    "outcome": "killed",
+    "engine": "seccomp"
+  }
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `family_name` | Original config name (e.g. `AF_ALG`); empty if the entry was numeric-only |
+| `family_number` | Resolved AF_* number |
+| `syscall` | `socket` or `socketpair` |
+| `action` | Value of `action` that matched (`log` or `log_and_kill`) |
+| `outcome` | `denied` (errno path) / `killed` (kill landed) / `vanished` (tracee gone before enforcement) / `deny_failed` / `deny_fallback_failed` |
+| `engine` | `seccomp` or `ptrace` — same audit shape regardless |
+
+### Coexistence
+
+When a family is in `blocked_socket_families` AND `socket` is in `blocked_syscalls`, the family rule wins (more specific). When `unix_socket.enabled: true` is also set, libseccomp's action-precedence ensures family `errno`/`kill` rules outrank the unconditional `ActNotify` on `socket(2)` — AF_UNIX traffic still flows through unix-socket monitoring; AF_ALG (etc.) is denied.
+
+### Validation
+
+Config typos fail fast at startup with a clear error:
+
+```
+sandbox.seccomp.blocked_socket_families[0].family: "AF_ALGOG" is not a valid AF_* name or number
+sandbox.seccomp.blocked_socket_families[1].action: "deny" is not valid (allowed: errno, kill, log, log_and_kill)
+```
 
 ## Audit Events
 

--- a/docs/security-modes.md
+++ b/docs/security-modes.md
@@ -185,6 +185,7 @@ Ptrace mode exposes Prometheus metrics at the `/metrics` endpoint:
 | Filesystem (fine-grained) | FUSE | ptrace | FUSE | Landlock | No |
 | Unix sockets (path-based) | seccomp | ptrace | Landlock | Landlock | No |
 | Unix sockets (abstract) | seccomp | No | No | No | No |
+| Socket family blocking (AF_ALG, AF_VSOCK, …) | seccomp | ptrace | No | No | No |
 | Signal interception | seccomp | ptrace | No* | No* | No* |
 | Network (kernel) | eBPF | ptrace | Landlock** | Landlock** | No |
 | Resource limits | cgroups | cgroups | cgroups | cgroups | cgroups |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2025,7 +2025,14 @@ sandbox:
         - umount2
         # ... see docs/seccomp.md for full default list
       on_block: kill  # kill | log_and_kill
+    blocked_socket_families:        # see docs/seccomp.md § Socket Family Blocking
+      - family: AF_ALG              # blocks socket(AF_ALG, ...) → EAFNOSUPPORT
+        action: errno
 ```
+
+**Default blocked socket families** (when `blocked_socket_families` is unset):
+
+agentsh ships a default list of 12 families blocked at `errno` (returns `EAFNOSUPPORT`): `AF_ALG`, `AF_VSOCK`, `AF_RDS`, `AF_TIPC`, `AF_KCM`, plus the dead protocols `AF_X25`, `AF_AX25`, `AF_NETROM`, `AF_ROSE`, `AF_DECnet`, `AF_APPLETALK`, `AF_IPX`. Set the field to `[]` to opt out.
 
 **Default blocked syscalls** (when seccomp is enabled):
 

--- a/docs/superpowers/plans/2026-04-29-socket-family-block.md
+++ b/docs/superpowers/plans/2026-04-29-socket-family-block.md
@@ -1,0 +1,1511 @@
+# Socket Family Blocking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add per-socket-family blocking to agentsh's sandbox: a YAML-configurable list of `AF_*` families whose `socket(2)`/`socketpair(2)` calls return `EAFNOSUPPORT` (or kill, log, log_and_kill). Two enforcement engines share the same config and types: seccomp-bpf primary, ptrace fallback when seccomp is unavailable.
+
+**Architecture:** New `internal/seccomp/families.go` defines `BlockedFamily` + name↔number table + `DefaultBlockedFamilies()`. The seccomp engine (`internal/netmonitor/unix/seccomp_linux.go`) gets `AddRuleConditional` calls keyed on arg0. The ptrace engine (`internal/ptrace/family_checker.go`) gets a small checker invoked from the existing tracer dispatch. Config field on `SandboxSeccompConfig`. Spec: `docs/superpowers/specs/2026-04-29-socket-family-block-design.md`.
+
+**Tech Stack:** Go 1.x, `github.com/seccomp/libseccomp-golang` (already a dep, used at `internal/seccomp/syscalls.go:8`), `golang.org/x/sys/unix`, internal `audit`/`config`/`server` packages.
+
+---
+
+## Conventions for every task
+
+- Run all commands from `/home/eran/work/agentsh`. The brainstorming skill should have placed you in a worktree under `.claude/worktrees/<branch>/`; if so, run from there.
+- Read the existing analogous code first when adding new code: `internal/netmonitor/unix/seccomp_linux.go::InstallFilterWithConfig` for seccomp rules, `internal/ptrace/static_policy.go` for ptrace patterns.
+- Module path: `github.com/agentsh/agentsh` (verify with `head -1 go.mod`).
+- Tab indentation; `gofmt -w` on touched files; `go vet ./...` clean before commit.
+- Cross-compile gate per `CLAUDE.md`: `GOOS=windows go build ./...` after every Linux-only file change.
+- Run `go test -race ./internal/seccomp/... ./internal/ptrace/... ./internal/netmonitor/unix/...` after engine changes.
+- Don't `git add -A`. Add files explicitly per the commit step.
+- Don't push.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `internal/seccomp/families.go` (new) | `BlockedFamily` type, `nameTable`, `ParseFamily`, `DefaultBlockedFamilies` |
+| `internal/seccomp/families_test.go` (new) | Table-driven tests for the above |
+| `internal/seccomp/filter.go` (modify) | Add `BlockedFamilies` to `FilterConfig` + helper |
+| `internal/seccomp/filter_test.go` (modify) | Tests for the helper |
+| `internal/config/config.go` (modify) | Add `SandboxSeccompSocketFamilyConfig` + field on `SandboxSeccompConfig` + `applyDefaults` for it |
+| `internal/config/seccomp_test.go` or similar (modify) | Default-merge + round-trip tests |
+| `internal/netmonitor/unix/seccomp_linux.go` (modify) | Add per-family `AddRuleConditional` block + `blockedFamilyMap` |
+| `internal/netmonitor/unix/seccomp_family_test.go` (new) | Real-process integration tests for seccomp engine |
+| `internal/ptrace/family_checker.go` (new) | `FamilyChecker` type + `Check` + `Apply` |
+| `internal/ptrace/family_checker_test.go` (new) | Unit tests with synthetic regs |
+| `internal/ptrace/family_checker_integration_test.go` (new) | Real-tracee integration test |
+| `internal/server/security.go` or `server.go` (modify) | Engine selection: seccomp vs ptrace vs warn |
+| `cmd/agentsh-unixwrap/config.go` + `main.go` (modify) | Forward `BlockedFamilies` from JSON config to FilterConfig |
+
+---
+
+## Task 1: Define `BlockedFamily` type and family name table
+
+**Files:**
+- Create: `internal/seccomp/families.go`
+- Create: `internal/seccomp/families_test.go`
+
+- [ ] **Step 1: Read existing files for reference**
+
+```bash
+cat internal/seccomp/filter.go internal/seccomp/syscalls.go
+```
+
+- [ ] **Step 2: Write failing tests**
+
+`internal/seccomp/families.go` will live in `package seccomp` (same as filter.go) with `//go:build linux && cgo`. The test file uses the same constraints.
+
+`internal/seccomp/families_test.go`:
+
+```go
+//go:build linux && cgo
+
+package seccomp
+
+import (
+	"testing"
+)
+
+func TestParseFamily_Names(t *testing.T) {
+	cases := []struct {
+		in     string
+		wantNr int
+	}{
+		{"AF_ALG", 38},
+		{"AF_VSOCK", 40},
+		{"AF_RDS", 21},
+		{"AF_TIPC", 30},
+		{"AF_KCM", 41},
+		{"AF_X25", 9},
+		{"AF_AX25", 3},
+		{"AF_NETROM", 6},
+		{"AF_ROSE", 11},
+		{"AF_DECnet", 12},
+		{"AF_APPLETALK", 5},
+		{"AF_IPX", 4},
+		{"AF_INET", 2},
+		{"AF_INET6", 10},
+		{"AF_UNIX", 1},
+		{"AF_NETLINK", 16},
+		{"AF_PACKET", 17},
+		{"AF_BLUETOOTH", 31},
+		{"AF_CAN", 29},
+	}
+	for _, c := range cases {
+		nr, name, ok := ParseFamily(c.in)
+		if !ok {
+			t.Errorf("ParseFamily(%q): ok=false, want true", c.in)
+			continue
+		}
+		if nr != c.wantNr {
+			t.Errorf("ParseFamily(%q): nr=%d, want %d", c.in, nr, c.wantNr)
+		}
+		if name != c.in {
+			t.Errorf("ParseFamily(%q): name=%q, want %q", c.in, name, c.in)
+		}
+	}
+}
+
+func TestParseFamily_NumericFallback(t *testing.T) {
+	nr, name, ok := ParseFamily("38")
+	if !ok || nr != 38 || name != "" {
+		t.Errorf("ParseFamily(\"38\"): got (%d, %q, %v), want (38, \"\", true)", nr, name, ok)
+	}
+	nr, _, ok = ParseFamily("63") // upper edge of valid range
+	if !ok || nr != 63 {
+		t.Errorf("ParseFamily(\"63\"): got (%d, _, %v), want (63, _, true)", nr, ok)
+	}
+}
+
+func TestParseFamily_Invalid(t *testing.T) {
+	cases := []string{"", "AF_ALGOG", "AF_NOT_A_THING", "-1", "64", "1000", "abc"}
+	for _, in := range cases {
+		if _, _, ok := ParseFamily(in); ok {
+			t.Errorf("ParseFamily(%q): ok=true, want false", in)
+		}
+	}
+}
+
+func TestDefaultBlockedFamilies(t *testing.T) {
+	defaults := DefaultBlockedFamilies()
+	if len(defaults) == 0 {
+		t.Fatal("DefaultBlockedFamilies returned empty list")
+	}
+	// AF_ALG must be in defaults — copy.fail mitigation.
+	found := false
+	for _, bf := range defaults {
+		if bf.Name == "AF_ALG" && bf.Family == 38 {
+			found = true
+			if bf.Action != OnBlockErrno {
+				t.Errorf("AF_ALG default action = %s, want errno", bf.Action)
+			}
+		}
+	}
+	if !found {
+		t.Error("AF_ALG missing from DefaultBlockedFamilies")
+	}
+	// All defaults must use errno.
+	for _, bf := range defaults {
+		if bf.Action != OnBlockErrno {
+			t.Errorf("default %s action = %s, want errno", bf.Name, bf.Action)
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Run tests; expect compile failure**
+
+```bash
+go test ./internal/seccomp/ -run "TestParseFamily|TestDefaultBlockedFamilies" -v
+```
+
+Expected: build failure (`undefined: ParseFamily`, etc.).
+
+- [ ] **Step 4: Implement `families.go`**
+
+`internal/seccomp/families.go`:
+
+```go
+//go:build linux && cgo
+
+package seccomp
+
+import "strconv"
+
+// BlockedFamily is one entry on the blocked_socket_families list.
+type BlockedFamily struct {
+	Family int           // resolved AF_* number
+	Action OnBlockAction // errno|kill|log|log_and_kill
+	Name   string        // original config name; "" if numeric
+}
+
+// nameTable maps human-readable AF_* names to their kernel numbers.
+// New families need a code update — kernel adds them rarely.
+var nameTable = map[string]int{
+	"AF_UNIX":      1,
+	"AF_INET":      2,
+	"AF_AX25":      3,
+	"AF_IPX":       4,
+	"AF_APPLETALK": 5,
+	"AF_NETROM":    6,
+	"AF_X25":       9,
+	"AF_INET6":     10,
+	"AF_ROSE":      11,
+	"AF_DECnet":    12,
+	"AF_NETLINK":   16,
+	"AF_PACKET":    17,
+	"AF_RDS":       21,
+	"AF_CAN":       29,
+	"AF_TIPC":      30,
+	"AF_BLUETOOTH": 31,
+	"AF_ALG":       38,
+	"AF_VSOCK":     40,
+	"AF_KCM":       41,
+}
+
+// ParseFamily resolves a config value (name string or numeric string) to
+// its AF_* int. Returns ok=false if the value is neither a known name
+// nor a parseable integer in [0, 64).
+//
+// On numeric input, name is returned as "" so callers can preserve the
+// fact that the operator chose a number.
+func ParseFamily(value string) (nr int, name string, ok bool) {
+	if value == "" {
+		return 0, "", false
+	}
+	if n, found := nameTable[value]; found {
+		return n, value, true
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, "", false
+	}
+	if parsed < 0 || parsed >= 64 {
+		// AF_MAX is currently 47 in mainline; 64 leaves headroom but
+		// rejects clearly-bogus values like 1000.
+		return 0, "", false
+	}
+	return parsed, "", true
+}
+
+// DefaultBlockedFamilies returns the recommended-default list applied
+// when blocked_socket_families is unset in config. Each entry uses
+// OnBlockErrno (returns EAFNOSUPPORT to userspace).
+//
+// Rationale per docs/superpowers/specs/2026-04-29-socket-family-block-design.md.
+func DefaultBlockedFamilies() []BlockedFamily {
+	names := []string{
+		"AF_ALG", "AF_VSOCK", "AF_RDS", "AF_TIPC", "AF_KCM",
+		"AF_X25", "AF_AX25", "AF_NETROM", "AF_ROSE", "AF_DECnet",
+		"AF_APPLETALK", "AF_IPX",
+	}
+	out := make([]BlockedFamily, 0, len(names))
+	for _, n := range names {
+		out = append(out, BlockedFamily{
+			Family: nameTable[n],
+			Action: OnBlockErrno,
+			Name:   n,
+		})
+	}
+	return out
+}
+```
+
+- [ ] **Step 5: Run tests; expect pass**
+
+```bash
+go test ./internal/seccomp/ -run "TestParseFamily|TestDefaultBlockedFamilies" -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Cross-compile check**
+
+```bash
+GOOS=windows go build ./...
+```
+
+Expected: clean (no output).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/seccomp/families.go internal/seccomp/families_test.go
+git commit -m "feat(seccomp): BlockedFamily type and AF_* name table
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Wire `BlockedFamilies` into `FilterConfig`
+
+**Files:**
+- Modify: `internal/seccomp/filter.go`
+- Modify: `internal/seccomp/filter_test.go`
+
+- [ ] **Step 1: Read current filter.go**
+
+```bash
+cat internal/seccomp/filter.go
+```
+
+Confirms shape: `FilterConfig { UnixSocketEnabled bool; BlockedSyscalls []string; OnBlock OnBlockAction }` and `FilterConfigFromYAML(unixEnabled, blockedSyscalls, onBlock)`.
+
+- [ ] **Step 2: Write failing test**
+
+Append to `internal/seccomp/filter_test.go`:
+
+```go
+func TestFilterConfig_IncludesBlockedFamilies(t *testing.T) {
+	cfg := FilterConfig{
+		UnixSocketEnabled: false,
+		BlockedSyscalls:   nil,
+		BlockedFamilies: []BlockedFamily{
+			{Family: 38, Action: OnBlockErrno, Name: "AF_ALG"},
+		},
+		OnBlock: OnBlockErrno,
+	}
+	if len(cfg.BlockedFamilies) != 1 {
+		t.Fatalf("expected 1 family, got %d", len(cfg.BlockedFamilies))
+	}
+	if cfg.BlockedFamilies[0].Name != "AF_ALG" {
+		t.Errorf("name=%q want AF_ALG", cfg.BlockedFamilies[0].Name)
+	}
+}
+
+func TestFilterConfigFromYAML_PassesFamilies(t *testing.T) {
+	families := []BlockedFamily{
+		{Family: 38, Action: OnBlockErrno, Name: "AF_ALG"},
+	}
+	cfg := FilterConfigFromYAML(true, []string{"ptrace"}, "errno", families)
+	if len(cfg.BlockedFamilies) != 1 || cfg.BlockedFamilies[0].Family != 38 {
+		t.Errorf("FilterConfigFromYAML did not pass families through: %+v", cfg.BlockedFamilies)
+	}
+}
+```
+
+- [ ] **Step 3: Run; expect compile failure**
+
+```bash
+go test ./internal/seccomp/ -run "TestFilterConfig_IncludesBlockedFamilies|TestFilterConfigFromYAML_PassesFamilies" -v
+```
+
+Expected: build error (`unknown field BlockedFamilies` and arity mismatch on `FilterConfigFromYAML`).
+
+- [ ] **Step 4: Modify `internal/seccomp/filter.go`**
+
+Replace the `FilterConfig` struct and `FilterConfigFromYAML` signature:
+
+```go
+// FilterConfig holds settings for building a seccomp filter.
+type FilterConfig struct {
+	UnixSocketEnabled bool
+	BlockedSyscalls   []string
+	BlockedFamilies   []BlockedFamily
+	OnBlock           OnBlockAction
+}
+
+// FilterConfigFromYAML creates a FilterConfig from config package types.
+// This is a separate function to avoid import cycles.
+func FilterConfigFromYAML(unixEnabled bool, blockedSyscalls []string, onBlock string, blockedFamilies []BlockedFamily) FilterConfig {
+	action, _ := ParseOnBlock(onBlock)
+	return FilterConfig{
+		UnixSocketEnabled: unixEnabled,
+		BlockedSyscalls:   blockedSyscalls,
+		BlockedFamilies:   blockedFamilies,
+		OnBlock:           action,
+	}
+}
+```
+
+- [ ] **Step 5: Update existing callers of `FilterConfigFromYAML`**
+
+Find callers:
+
+```bash
+grep -rn "FilterConfigFromYAML(" --include="*.go"
+```
+
+For each caller, add a `nil` argument as the new `blockedFamilies` parameter. Likely callers are in `internal/api/seccomp_wrapper_config.go` and `cmd/agentsh-unixwrap/main.go` and possibly tests. Pass `nil` for now — Tasks 6–7 will wire real values.
+
+- [ ] **Step 6: Run filter package tests**
+
+```bash
+go test ./internal/seccomp/ -v
+```
+
+Expected: all pass (existing tests + 2 new).
+
+- [ ] **Step 7: Run full build**
+
+```bash
+go build ./...
+GOOS=windows go build ./...
+```
+
+Both clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/seccomp/filter.go internal/seccomp/filter_test.go internal/api/seccomp_wrapper_config.go cmd/agentsh-unixwrap/main.go
+git commit -m "feat(seccomp): wire BlockedFamilies through FilterConfig
+
+Callers pass nil; later tasks populate real values.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+If you didn't have to touch some of those files (because they don't actually call `FilterConfigFromYAML`), drop them from the `git add` line.
+
+---
+
+## Task 3: Config schema — `SandboxSeccompSocketFamilyConfig`
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Modify: a config test file (find with `grep -l "SandboxSeccompConfig\|SandboxSeccompSyscallConfig" internal/config/*_test.go`)
+
+- [ ] **Step 1: Read the existing seccomp config block**
+
+```bash
+sed -n '482,520p' internal/config/config.go
+```
+
+Confirms `SandboxSeccompConfig` struct shape.
+
+- [ ] **Step 2: Write failing tests**
+
+Append to whichever test file owns seccomp config (likely `internal/config/config_test.go` or a dedicated `seccomp_test.go`):
+
+```go
+func TestSandboxSeccompSocketFamilyConfig_DefaultMerge(t *testing.T) {
+	// When BlockedSocketFamilies is nil → defaults applied.
+	cfg := &Config{}
+	cfg.Sandbox.Seccomp.Enabled = true
+	if err := cfg.applyDefaults(); err != nil {
+		t.Fatalf("applyDefaults: %v", err)
+	}
+	if len(cfg.Sandbox.Seccomp.BlockedSocketFamilies) == 0 {
+		t.Errorf("expected default-merge to populate BlockedSocketFamilies; got empty")
+	}
+	// AF_ALG must appear.
+	found := false
+	for _, e := range cfg.Sandbox.Seccomp.BlockedSocketFamilies {
+		if e.Family == "AF_ALG" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("AF_ALG missing from default BlockedSocketFamilies")
+	}
+}
+
+func TestSandboxSeccompSocketFamilyConfig_ExplicitEmptyOptOut(t *testing.T) {
+	// When the operator sets blocked_socket_families: [] → opt-out.
+	// Distinguish nil (unset, apply defaults) from empty (explicit opt-out).
+	cfg := &Config{}
+	cfg.Sandbox.Seccomp.Enabled = true
+	cfg.Sandbox.Seccomp.BlockedSocketFamilies = []SandboxSeccompSocketFamilyConfig{} // explicit empty
+	cfg.Sandbox.Seccomp.BlockedSocketFamiliesSet = true                              // sentinel
+	if err := cfg.applyDefaults(); err != nil {
+		t.Fatalf("applyDefaults: %v", err)
+	}
+	if len(cfg.Sandbox.Seccomp.BlockedSocketFamilies) != 0 {
+		t.Errorf("explicit empty should not be replaced by defaults; got %v",
+			cfg.Sandbox.Seccomp.BlockedSocketFamilies)
+	}
+}
+
+func TestSandboxSeccompSocketFamilyConfig_NonEmptyOverridesDefaults(t *testing.T) {
+	cfg := &Config{}
+	cfg.Sandbox.Seccomp.Enabled = true
+	cfg.Sandbox.Seccomp.BlockedSocketFamiliesSet = true
+	cfg.Sandbox.Seccomp.BlockedSocketFamilies = []SandboxSeccompSocketFamilyConfig{
+		{Family: "AF_VSOCK", Action: "errno"},
+	}
+	if err := cfg.applyDefaults(); err != nil {
+		t.Fatalf("applyDefaults: %v", err)
+	}
+	if len(cfg.Sandbox.Seccomp.BlockedSocketFamilies) != 1 {
+		t.Errorf("non-empty should override defaults entirely; got %d entries",
+			len(cfg.Sandbox.Seccomp.BlockedSocketFamilies))
+	}
+}
+```
+
+If the existing config tests use a different `Config` constructor / different `applyDefaults` entry point, adapt to whatever is real. The shape of the assertions is the right scope.
+
+- [ ] **Step 3: Run; expect failure**
+
+```bash
+go test ./internal/config/ -run "TestSandboxSeccompSocketFamily" -v
+```
+
+Expected: build failure (`undefined: SandboxSeccompSocketFamilyConfig`).
+
+- [ ] **Step 4: Add the config struct and field**
+
+In `internal/config/config.go`, after `SandboxSeccompFileMonitorConfig` (around line 512), add:
+
+```go
+// SandboxSeccompSocketFamilyConfig describes one blocked socket family.
+type SandboxSeccompSocketFamilyConfig struct {
+	Family string `yaml:"family"` // AF_* name or numeric string
+	Action string `yaml:"action"` // errno|kill|log|log_and_kill (defaults to errno)
+}
+```
+
+In `SandboxSeccompConfig` struct (lines 482–489), add two fields:
+
+```go
+type SandboxSeccompConfig struct {
+	Enabled     bool                            `yaml:"enabled"`
+	Mode        string                          `yaml:"mode"`
+	UnixSocket  SandboxSeccompUnixConfig        `yaml:"unix_socket"`
+	Syscalls    SandboxSeccompSyscallConfig     `yaml:"syscalls"`
+	Execve      ExecveConfig                    `yaml:"execve"`
+	FileMonitor SandboxSeccompFileMonitorConfig `yaml:"file_monitor"`
+
+	BlockedSocketFamilies    []SandboxSeccompSocketFamilyConfig `yaml:"blocked_socket_families"`
+	// BlockedSocketFamiliesSet is internal — set by the YAML unmarshaler when
+	// the field is present (even as []), so applyDefaults can distinguish
+	// "unset → apply defaults" from "explicit empty → opt-out".
+	BlockedSocketFamiliesSet bool `yaml:"-"`
+}
+```
+
+For YAML unmarshal to correctly set `BlockedSocketFamiliesSet`, you need a custom `UnmarshalYAML` on `SandboxSeccompConfig`. The simplest approach: a sentinel through a parallel type. Look at how the codebase handles other "unset vs empty" distinctions; if there's an existing pattern (e.g., `*[]Foo` pointer), use it instead of the bool sentinel.
+
+If `*[]SandboxSeccompSocketFamilyConfig` (pointer to slice) is the project's convention, adapt the design accordingly:
+
+```go
+BlockedSocketFamilies *[]SandboxSeccompSocketFamilyConfig `yaml:"blocked_socket_families,omitempty"`
+```
+
+…and the test/applyDefaults code uses `nil` vs `&[]{}` to distinguish. Pick whichever pattern matches existing code.
+
+- [ ] **Step 5: Add default-merge in `applyDefaults`**
+
+Find the relevant block (around line 1574–1605 — search for existing `Sandbox.Seccomp` defaults):
+
+```bash
+grep -n "Sandbox.Seccomp.Syscalls" internal/config/config.go | head
+```
+
+After the existing `Syscalls.Block` default-merge block, add:
+
+```go
+// Apply default blocked socket families when seccomp is enabled and the
+// operator hasn't explicitly set the field. Unset → apply defaults.
+// Explicit [] → opt-out (no defaults applied).
+if seccompActive && !cfg.Sandbox.Seccomp.BlockedSocketFamiliesSet {
+	for _, bf := range seccomp.DefaultBlockedFamilies() {
+		cfg.Sandbox.Seccomp.BlockedSocketFamilies = append(
+			cfg.Sandbox.Seccomp.BlockedSocketFamilies,
+			SandboxSeccompSocketFamilyConfig{
+				Family: bf.Name,
+				Action: string(bf.Action),
+			},
+		)
+	}
+}
+```
+
+(`seccomp` import is `github.com/agentsh/agentsh/internal/seccomp`. Add the import if not already present in config.go.)
+
+If the project uses the pointer-slice convention instead of a bool sentinel, replace `!cfg.Sandbox.Seccomp.BlockedSocketFamiliesSet` with `cfg.Sandbox.Seccomp.BlockedSocketFamilies == nil`, and update tests accordingly.
+
+- [ ] **Step 6: Run tests; expect pass**
+
+```bash
+go test ./internal/config/ -run "TestSandboxSeccompSocketFamily" -v
+```
+
+- [ ] **Step 7: Run full config tests**
+
+```bash
+go test ./internal/config/ -v
+```
+
+Make sure no existing tests broke from the schema addition.
+
+- [ ] **Step 8: Cross-compile**
+
+```bash
+GOOS=windows go build ./...
+GOOS=darwin go build ./...
+```
+
+Both clean. (Config field is platform-neutral.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/config/config.go internal/config/<test-file>.go
+git commit -m "feat(config): blocked_socket_families with default-merge
+
+Distinguishes unset (apply defaults) from explicit empty (opt-out).
+Defaults from internal/seccomp.DefaultBlockedFamilies.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Config validation — reject unknown family names
+
+**Files:**
+- Modify: `internal/config/config.go` (or wherever validation lives — find with `grep -n "func.*Validate\|return.*fmt.Errorf.*sandbox.seccomp" internal/config/*.go`)
+- Modify: same test file as Task 3
+
+- [ ] **Step 1: Write failing test**
+
+```go
+func TestSandboxSeccompSocketFamily_RejectsUnknownName(t *testing.T) {
+	cfg := &Config{}
+	cfg.Sandbox.Seccomp.Enabled = true
+	cfg.Sandbox.Seccomp.BlockedSocketFamiliesSet = true
+	cfg.Sandbox.Seccomp.BlockedSocketFamilies = []SandboxSeccompSocketFamilyConfig{
+		{Family: "AF_NOT_REAL", Action: "errno"},
+	}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatalf("expected error for unknown family name")
+	}
+	if !strings.Contains(err.Error(), "AF_NOT_REAL") {
+		t.Errorf("error should mention bad name; got %v", err)
+	}
+}
+
+func TestSandboxSeccompSocketFamily_RejectsBadAction(t *testing.T) {
+	cfg := &Config{}
+	cfg.Sandbox.Seccomp.Enabled = true
+	cfg.Sandbox.Seccomp.BlockedSocketFamiliesSet = true
+	cfg.Sandbox.Seccomp.BlockedSocketFamilies = []SandboxSeccompSocketFamilyConfig{
+		{Family: "AF_ALG", Action: "deny"}, // "deny" is not in the OnBlockAction enum
+	}
+	if err := cfg.Validate(); err == nil {
+		t.Errorf("expected error for invalid action")
+	}
+}
+
+func TestSandboxSeccompSocketFamily_AcceptsNumericFamily(t *testing.T) {
+	cfg := &Config{}
+	cfg.Sandbox.Seccomp.Enabled = true
+	cfg.Sandbox.Seccomp.BlockedSocketFamiliesSet = true
+	cfg.Sandbox.Seccomp.BlockedSocketFamilies = []SandboxSeccompSocketFamilyConfig{
+		{Family: "38", Action: "errno"},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("numeric family should be accepted; got %v", err)
+	}
+}
+```
+
+Adapt to whatever the project's `Validate()` entry point is named.
+
+- [ ] **Step 2: Run; expect failure**
+
+```bash
+go test ./internal/config/ -run "TestSandboxSeccompSocketFamily_Reject|TestSandboxSeccompSocketFamily_Accepts" -v
+```
+
+- [ ] **Step 3: Add validation**
+
+In `Config.Validate()` (find with `grep -n "func.*Validate" internal/config/config.go | head`), add a block:
+
+```go
+// Validate blocked_socket_families entries.
+for i, e := range cfg.Sandbox.Seccomp.BlockedSocketFamilies {
+	if _, _, ok := seccomp.ParseFamily(e.Family); !ok {
+		return fmt.Errorf("sandbox.seccomp.blocked_socket_families[%d].family: %q is not a valid AF_* name or number", i, e.Family)
+	}
+	if e.Action != "" {
+		if _, ok := seccomp.ParseOnBlock(e.Action); !ok {
+			return fmt.Errorf("sandbox.seccomp.blocked_socket_families[%d].action: %q is not valid (allowed: errno, kill, log, log_and_kill)", i, e.Action)
+		}
+	}
+}
+```
+
+If the project's validation is split into multiple methods (e.g., `validateSandbox()`), put the block in the seccomp-relevant one.
+
+- [ ] **Step 4: Run; expect pass**
+
+```bash
+go test ./internal/config/ -run "TestSandboxSeccompSocketFamily" -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/config.go internal/config/<test-file>.go
+git commit -m "feat(config): validate blocked_socket_families entries
+
+Reject unknown AF_* names and unknown actions at config-load time.
+Numeric family values pass validation if in [0, 64).
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Convert config to `[]seccomp.BlockedFamily`
+
+**Files:**
+- Create: `internal/config/seccomp_families.go`
+- Create: `internal/config/seccomp_families_test.go`
+
+A small adapter function that converts the YAML-typed `[]SandboxSeccompSocketFamilyConfig` to the engine-typed `[]seccomp.BlockedFamily`. Lives in `internal/config` to avoid making `internal/seccomp` import config.
+
+- [ ] **Step 1: Write failing test**
+
+`internal/config/seccomp_families_test.go`:
+
+```go
+package config
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/seccomp"
+)
+
+func TestResolveBlockedFamilies(t *testing.T) {
+	in := []SandboxSeccompSocketFamilyConfig{
+		{Family: "AF_ALG", Action: "errno"},
+		{Family: "40", Action: "kill"},
+		{Family: "AF_VSOCK", Action: ""}, // empty action → defaults to errno
+	}
+	out, err := ResolveBlockedFamilies(in)
+	if err != nil {
+		t.Fatalf("ResolveBlockedFamilies: %v", err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("got %d entries, want 3", len(out))
+	}
+	if out[0].Family != 38 || out[0].Name != "AF_ALG" || out[0].Action != seccomp.OnBlockErrno {
+		t.Errorf("entry 0 wrong: %+v", out[0])
+	}
+	if out[1].Family != 40 || out[1].Name != "" || out[1].Action != seccomp.OnBlockKill {
+		t.Errorf("entry 1 wrong: %+v", out[1])
+	}
+	if out[2].Action != seccomp.OnBlockErrno {
+		t.Errorf("entry 2 default action wrong: %s", out[2].Action)
+	}
+}
+
+func TestResolveBlockedFamilies_RejectsBadEntry(t *testing.T) {
+	in := []SandboxSeccompSocketFamilyConfig{
+		{Family: "BOGUS", Action: "errno"},
+	}
+	_, err := ResolveBlockedFamilies(in)
+	if err == nil {
+		t.Errorf("expected error for bogus family name")
+	}
+}
+```
+
+- [ ] **Step 2: Run; expect failure**
+
+```bash
+go test ./internal/config/ -run "TestResolveBlockedFamilies" -v
+```
+
+- [ ] **Step 3: Implement the adapter**
+
+`internal/config/seccomp_families.go`:
+
+```go
+package config
+
+import (
+	"fmt"
+
+	"github.com/agentsh/agentsh/internal/seccomp"
+)
+
+// ResolveBlockedFamilies converts YAML-typed entries into the engine-typed
+// slice consumed by FilterConfigFromYAML / FamilyChecker. Empty Action
+// defaults to errno. Caller should have run config validation first;
+// this function returns an error if any entry fails to resolve, but it
+// does not catch unknown-action strings (those degrade to errno via
+// seccomp.ParseOnBlock).
+func ResolveBlockedFamilies(in []SandboxSeccompSocketFamilyConfig) ([]seccomp.BlockedFamily, error) {
+	out := make([]seccomp.BlockedFamily, 0, len(in))
+	for i, e := range in {
+		nr, name, ok := seccomp.ParseFamily(e.Family)
+		if !ok {
+			return nil, fmt.Errorf("blocked_socket_families[%d]: invalid family %q", i, e.Family)
+		}
+		actionStr := e.Action
+		if actionStr == "" {
+			actionStr = string(seccomp.OnBlockErrno)
+		}
+		action, _ := seccomp.ParseOnBlock(actionStr)
+		out = append(out, seccomp.BlockedFamily{
+			Family: nr,
+			Action: action,
+			Name:   name,
+		})
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run; expect pass**
+
+```bash
+go test ./internal/config/ -run "TestResolveBlockedFamilies" -v
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/seccomp_families.go internal/config/seccomp_families_test.go
+git commit -m "feat(config): ResolveBlockedFamilies adapter
+
+Converts YAML-typed entries to seccomp.BlockedFamily. Empty Action
+defaults to errno.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Seccomp engine — add per-family rules
+
+**Files:**
+- Modify: `internal/netmonitor/unix/seccomp_linux.go`
+- Create: `internal/netmonitor/unix/seccomp_family_test.go`
+
+- [ ] **Step 1: Read the existing filter builder around lines 350–400**
+
+```bash
+sed -n '340,410p' internal/netmonitor/unix/seccomp_linux.go
+```
+
+Note: the file has `BlockedSyscalls`, `OnBlockAction`, and a `blockListMap` for notify-routing. Our family rules go AFTER the existing `BlockedSyscalls` block.
+
+- [ ] **Step 2: Add `BlockedFamilies` to the local `FilterConfig`**
+
+Around line 217 in `seccomp_linux.go`:
+
+```go
+type FilterConfig struct {
+	UnixSocketEnabled  bool
+	ExecveEnabled      bool
+	FileMonitorEnabled bool
+	InterceptMetadata  bool
+	BlockIOUring       bool
+	BlockedSyscalls    []int
+	BlockedFamilies    []seccompkg.BlockedFamily  // NEW
+	OnBlockAction      seccompkg.OnBlockAction
+}
+```
+
+- [ ] **Step 3: Add a per-family map for notify routing**
+
+Find the existing `blockListMap` declaration (line 357 from grep earlier) and add a sibling:
+
+```go
+blockListMap := map[uint32]seccompkg.OnBlockAction{}
+blockedFamilyMap := map[uint64]seccompkg.BlockedFamily{}  // key = (syscall<<32) | family
+```
+
+If `blockListMap` is exposed via a getter for the userspace handler, add the equivalent getter for `blockedFamilyMap`. Inspect the file to see how `blockListMap` is exposed (likely returned as part of the `*Filter` struct).
+
+- [ ] **Step 4: Add the family-rule installation block**
+
+After the existing `BlockedSyscalls` switch block (line ~379), add:
+
+```go
+// Per-socket-family blocking on socket(2) and socketpair(2).
+// libseccomp action-precedence (KILL > TRAP > ERRNO > … > NOTIFY) ensures
+// these conditional rules take priority over the unconditional ActNotify
+// rule on socket(2) added by UnixSocketEnabled.
+for _, bf := range cfg.BlockedFamilies {
+	cond := seccomp.ScmpCondition{
+		Argument: 0,
+		Op:       seccomp.CompareEqual,
+		Operand1: uint64(bf.Family),
+	}
+	famAction, err := familyToScmpAction(bf.Action)
+	if err != nil {
+		slog.Warn("seccomp: skipping family rule with unknown action",
+			"family", bf.Name, "action", bf.Action, "error", err)
+		continue
+	}
+	for _, sc := range []uint{unix.SYS_SOCKET, unix.SYS_SOCKETPAIR} {
+		if err := filt.AddRuleConditional(
+			seccomp.ScmpSyscall(sc), famAction, []seccomp.ScmpCondition{cond},
+		); err != nil {
+			slog.Warn("seccomp: failed to add family rule; family skipped",
+				"family", bf.Name, "syscall", sc, "error", err)
+			continue
+		}
+	}
+	if bf.Action == seccompkg.OnBlockLog || bf.Action == seccompkg.OnBlockLogAndKill {
+		blockedFamilyMap[uint64(unix.SYS_SOCKET)<<32|uint64(bf.Family)] = bf
+		blockedFamilyMap[uint64(unix.SYS_SOCKETPAIR)<<32|uint64(bf.Family)] = bf
+	}
+}
+```
+
+Add the helper near the bottom of the file:
+
+```go
+// familyToScmpAction maps an OnBlockAction to the libseccomp action used
+// for per-family rules.
+func familyToScmpAction(a seccompkg.OnBlockAction) (seccomp.ScmpAction, error) {
+	switch a {
+	case seccompkg.OnBlockErrno:
+		return seccomp.ActErrno.SetReturnCode(int16(unix.EAFNOSUPPORT)), nil
+	case seccompkg.OnBlockKill:
+		return seccomp.ActKillProcess, nil
+	case seccompkg.OnBlockLog, seccompkg.OnBlockLogAndKill:
+		return seccomp.ActNotify, nil
+	default:
+		return seccomp.ActAllow, fmt.Errorf("unknown action %q", a)
+	}
+}
+```
+
+- [ ] **Step 5: Write integration test**
+
+`internal/netmonitor/unix/seccomp_family_test.go`:
+
+```go
+//go:build linux && cgo
+
+package unix
+
+import (
+	"errors"
+	"os/exec"
+	"runtime"
+	"syscall"
+	"testing"
+
+	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
+	"golang.org/x/sys/unix"
+)
+
+// TestSeccomp_FamilyBlock_Errno spawns a child process under a filter
+// that errnos AF_ALG, then asserts a socket(AF_ALG) call returns
+// EAFNOSUPPORT.
+func TestSeccomp_FamilyBlock_Errno(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux only")
+	}
+	// Use exec.Command + a small Go helper that calls socket(AF_ALG).
+	// Build the helper at test time. Skip if uname doesn't allow filter
+	// installation.
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp filter not supported: %v", err)
+	}
+
+	// Inline the test in the current process by installing the filter
+	// before forking. Use unix.RawSyscall directly so we don't go
+	// through libc.
+	cmd := exec.Command("/bin/sh", "-c", `
+		exec /proc/self/exe -test.run=helperFamilyAFALG
+	`)
+	cmd.Env = append(cmd.Env, "FAMILY_TEST_HELPER=1")
+	out, _ := cmd.CombinedOutput()
+	t.Logf("child output: %s", out)
+	// We expect the child to print "EAFNOSUPPORT" if our filter worked.
+	// (Implementation detail: this depends on a TestMain helper —
+	// alternative is to use syscall.ForkExec with a custom child entry.)
+}
+
+// helperFamilyAFALG is invoked inside the child process when
+// FAMILY_TEST_HELPER is set. It installs the filter, calls socket(AF_ALG),
+// prints the result, and exits.
+//
+// (For implementation: the cleaner pattern in this codebase is to put
+// the helper in a separate test main — see internal/seccomp/integration_test.go
+// for an existing example to model on. Adapt the helper structure to whatever
+// the existing tests use.)
+```
+
+The actual test mechanics depend on how the existing seccomp integration tests are structured. Look at `internal/seccomp/integration_test.go` (already exists) for the helper pattern and **mirror it**. The key assertions:
+
+1. With `BlockedFamilies: [{AF_ALG, errno}]` and the filter installed, `socket(AF_ALG, SOCK_SEQPACKET, 0)` returns errno `EAFNOSUPPORT` (97).
+2. With `BlockedFamilies: [{AF_ALG, kill}]`, the child process gets killed (waitpid reports SIGSYS or kill signal).
+3. With **both** `UnixSocketEnabled: true` AND `BlockedFamilies: [{AF_ALG, errno}]`, `socket(AF_UNIX, …)` succeeds (notify path) and `socket(AF_ALG, …)` returns EAFNOSUPPORT (errno path takes precedence over notify).
+
+Use the existing test framework's helpers; don't reinvent forking infrastructure.
+
+- [ ] **Step 6: Run integration test**
+
+```bash
+sudo go test ./internal/netmonitor/unix/ -run "TestSeccomp_FamilyBlock" -v
+```
+
+(Many seccomp tests need privileges. If they don't, drop `sudo`.)
+
+Expected: tests pass.
+
+- [ ] **Step 7: Update `cmd/agentsh-unixwrap` to forward families**
+
+Find where `FilterConfig` is constructed in `cmd/agentsh-unixwrap/main.go` (around line 64):
+
+```bash
+sed -n '60,90p' cmd/agentsh-unixwrap/main.go
+```
+
+Add the family forwarding:
+
+```go
+// In the config struct (cmd/agentsh-unixwrap/config.go):
+type WrapperConfig struct {
+	UnixSocketEnabled bool                      `json:"unix_socket_enabled"`
+	BlockedSyscalls   []string                  `json:"blocked_syscalls"`
+	BlockedFamilies   []seccompkg.BlockedFamily `json:"blocked_families"`
+	OnBlock           string                    `json:"on_block"`
+	// ... existing fields
+}
+
+// In main.go, when populating the netmonitor FilterConfig:
+filterCfg := unixfm.FilterConfig{
+	UnixSocketEnabled: cfg.UnixSocketEnabled,
+	BlockedSyscalls:   blockedNrs,
+	BlockedFamilies:   cfg.BlockedFamilies, // forward as-is
+	OnBlockAction:     /* existing */,
+}
+```
+
+Then update `internal/api/seccomp_wrapper_config.go` (which composes the JSON sent to unixwrap from the YAML config) to add `BlockedFamilies` from `ResolveBlockedFamilies(cfg.Sandbox.Seccomp.BlockedSocketFamilies)`.
+
+- [ ] **Step 8: Cross-compile + tests**
+
+```bash
+go build ./...
+GOOS=windows go build ./...
+go test ./internal/seccomp/... ./internal/netmonitor/unix/... ./internal/config/... ./cmd/agentsh-unixwrap/...
+```
+
+All pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/netmonitor/unix/seccomp_linux.go internal/netmonitor/unix/seccomp_family_test.go cmd/agentsh-unixwrap/config.go cmd/agentsh-unixwrap/main.go internal/api/seccomp_wrapper_config.go
+git commit -m "feat(seccomp): per-family rules on socket(2)/socketpair(2)
+
+AddRuleConditional with arg0 == family. EAFNOSUPPORT for errno action;
+ActKillProcess for kill; ActNotify+blockedFamilyMap for log variants.
+Coexists with UnixSocketEnabled via libseccomp action-precedence.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Audit event for log/log_and_kill family attempts
+
+**Files:**
+- Modify: `internal/netmonitor/unix/<wherever the notify handler dispatches blocklist events>` — find with `grep -n "blockListMap\|BlockListMap\|seccomp.syscall_blocked" --include='*.go' -r internal/`
+- Create or modify a test in the same package
+
+The existing notify handler reads `blockListMap` to emit `seccomp.syscall_blocked` audit events for log-action syscall blocks. Adding family events follows the same path.
+
+- [ ] **Step 1: Find the notify handler**
+
+```bash
+grep -rn "blockListMap\|seccomp.syscall_blocked" --include="*.go" internal/
+```
+
+Locate the function that processes a notify message and dispatches the audit event.
+
+- [ ] **Step 2: Write failing test**
+
+Adapt to the existing test pattern. Roughly:
+
+```go
+func TestNotifyHandler_FamilyAuditEvent(t *testing.T) {
+	// Construct a FilterConfig with BlockedFamilies=[{AF_ALG, log}].
+	// Spawn a tracee that calls socket(AF_ALG).
+	// Assert exactly one audit event of kind seccomp.socket_family_blocked
+	// with family_name=AF_ALG, family_number=38, syscall=socket, engine=seccomp.
+}
+```
+
+- [ ] **Step 3: Implement event emission**
+
+In the notify handler, after the existing `blockListMap` check, add a parallel lookup:
+
+```go
+key := uint64(req.Data.Nr)<<32 | uint64(req.Data.Args[0])
+if bf, ok := filt.BlockedFamilyMap[key]; ok {
+	auditSink.Emit(ctx, audit.Event{
+		Kind: "seccomp.socket_family_blocked",
+		Fields: map[string]any{
+			"family_name":   bf.Name,
+			"family_number": bf.Family,
+			"syscall":       syscallName(req.Data.Nr),
+			"action":        string(bf.Action),
+			"engine":        "seccomp",
+			"pid":           int(req.Pid),
+		},
+	})
+	if bf.Action == seccompkg.OnBlockLogAndKill {
+		// Send SIGKILL to the tracee.
+	} else {
+		// Allow the syscall.
+	}
+	return
+}
+```
+
+Adapt the exact field names and audit-event API to whatever the codebase already uses for `seccomp.syscall_blocked`.
+
+- [ ] **Step 4: Run test; expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add <files>
+git commit -m "feat(seccomp): emit seccomp.socket_family_blocked audit event
+
+Dispatched from the notify handler when a log/log_and_kill family
+attempt fires. Mirrors the existing syscall_blocked event shape.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: ptrace `FamilyChecker` (unit-level)
+
+**Files:**
+- Create: `internal/ptrace/family_checker.go`
+- Create: `internal/ptrace/family_checker_test.go`
+
+- [ ] **Step 1: Read existing ptrace patterns**
+
+```bash
+cat internal/ptrace/static_policy.go | head -80
+ls internal/ptrace/ | head
+```
+
+Note the `arg0` extraction differs by arch — `internal/ptrace/args_amd64.go` and `args_arm64.go` exist for this.
+
+- [ ] **Step 2: Write failing tests**
+
+`internal/ptrace/family_checker_test.go`:
+
+```go
+//go:build linux
+
+package ptrace
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/seccomp"
+	"golang.org/x/sys/unix"
+)
+
+func TestFamilyChecker_Check_MatchAndMiss(t *testing.T) {
+	c := NewFamilyChecker([]seccomp.BlockedFamily{
+		{Family: 38, Action: seccomp.OnBlockErrno, Name: "AF_ALG"},
+	})
+
+	// AF_ALG on socket(2) → match.
+	bf, ok := c.Check(uint64(unix.SYS_SOCKET), 38)
+	if !ok || bf.Name != "AF_ALG" {
+		t.Errorf("expected match for AF_ALG on SYS_SOCKET; got bf=%+v ok=%v", bf, ok)
+	}
+
+	// AF_INET on socket(2) → miss.
+	if _, ok := c.Check(uint64(unix.SYS_SOCKET), 2); ok {
+		t.Errorf("expected miss for AF_INET")
+	}
+
+	// AF_ALG on read(2) → miss (only socket/socketpair are checked).
+	if _, ok := c.Check(uint64(unix.SYS_READ), 38); ok {
+		t.Errorf("expected miss for AF_ALG on SYS_READ")
+	}
+}
+
+func TestFamilyChecker_Check_Socketpair(t *testing.T) {
+	c := NewFamilyChecker([]seccomp.BlockedFamily{
+		{Family: 38, Action: seccomp.OnBlockErrno, Name: "AF_ALG"},
+	})
+	_, ok := c.Check(uint64(unix.SYS_SOCKETPAIR), 38)
+	if !ok {
+		t.Errorf("expected match for AF_ALG on SYS_SOCKETPAIR")
+	}
+}
+
+func TestFamilyChecker_Empty(t *testing.T) {
+	c := NewFamilyChecker(nil)
+	if _, ok := c.Check(uint64(unix.SYS_SOCKET), 38); ok {
+		t.Errorf("empty checker should never match")
+	}
+}
+```
+
+- [ ] **Step 3: Run; expect compile failure**
+
+- [ ] **Step 4: Implement `family_checker.go`**
+
+```go
+//go:build linux
+
+package ptrace
+
+import (
+	"github.com/agentsh/agentsh/internal/seccomp"
+	"golang.org/x/sys/unix"
+)
+
+// FamilyChecker matches socket(2)/socketpair(2) calls against a list of
+// blocked AF_* families. Reuses the same []seccomp.BlockedFamily slice
+// that the seccomp engine consumes — single source of truth.
+type FamilyChecker struct {
+	// bySyscall: SYS_SOCKET / SYS_SOCKETPAIR → family number → entry.
+	bySyscall map[uint64]map[uint64]seccomp.BlockedFamily
+}
+
+// NewFamilyChecker indexes the entries for fast lookup. nil/empty input
+// produces a checker that never matches.
+func NewFamilyChecker(entries []seccomp.BlockedFamily) *FamilyChecker {
+	c := &FamilyChecker{bySyscall: map[uint64]map[uint64]seccomp.BlockedFamily{}}
+	for _, sc := range []uint64{uint64(unix.SYS_SOCKET), uint64(unix.SYS_SOCKETPAIR)} {
+		c.bySyscall[sc] = map[uint64]seccomp.BlockedFamily{}
+	}
+	for _, e := range entries {
+		for sc := range c.bySyscall {
+			c.bySyscall[sc][uint64(e.Family)] = e
+		}
+	}
+	return c
+}
+
+// Check reports the BlockedFamily entry for a given syscall+arg0 pair.
+// ok=false means no rule applies (the syscall should be allowed).
+func (c *FamilyChecker) Check(syscall, arg0 uint64) (seccomp.BlockedFamily, bool) {
+	if c == nil || c.bySyscall == nil {
+		return seccomp.BlockedFamily{}, false
+	}
+	families, ok := c.bySyscall[syscall]
+	if !ok {
+		return seccomp.BlockedFamily{}, false
+	}
+	bf, ok := families[arg0]
+	return bf, ok
+}
+```
+
+- [ ] **Step 5: Run; expect pass**
+
+```bash
+go test ./internal/ptrace/ -run TestFamilyChecker -v
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/ptrace/family_checker.go internal/ptrace/family_checker_test.go
+git commit -m "feat(ptrace): FamilyChecker for socket-family blocking
+
+Indexes []seccomp.BlockedFamily by syscall+family for fast lookup at
+syscall-entry stops. Pure logic; no ptrace integration yet.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: ptrace integration — wire `FamilyChecker` into the tracer
+
+**Files:**
+- Modify: `internal/ptrace/tracer.go` (or wherever the syscall-entry callback dispatches handlers — verify with `grep -n "syscall.*entry\|HandleSyscall\|^func.*Tracer" internal/ptrace/tracer.go`)
+- Modify: `internal/ptrace/family_checker.go` — add `Apply` method
+- Create: `internal/ptrace/family_checker_integration_test.go`
+
+- [ ] **Step 1: Find the syscall dispatch site**
+
+```bash
+grep -n "syscall\|Handler\|callback" internal/ptrace/tracer.go | head -20
+```
+
+Identify where the tracer reads `regs` at SYSCALL_ENTRY and decides what to do.
+
+- [ ] **Step 2: Write failing integration test**
+
+The existing `internal/ptrace/syscalls_test.go` and `static_policy_test.go` show how the project tests ptrace flows. Mirror that pattern. Test asserts: under a Tracer configured with `FamilyChecker(AF_ALG, errno)`, a tracee calling `socket(AF_ALG, ...)` gets `errno=EAFNOSUPPORT`.
+
+The exact code depends heavily on existing test helpers; don't try to author it without reading them first.
+
+- [ ] **Step 3: Add `Apply` to `FamilyChecker`**
+
+`internal/ptrace/family_checker.go` — append:
+
+```go
+// Apply executes the action against a stopped tracee. Caller has already
+// matched via Check. Returns nil on success, or an error if the
+// underlying ptrace operations fail.
+//
+// errno: SetRegs RAX = -EAFNOSUPPORT, ORIG_RAX = -1 (skip syscall).
+//        Caller continues with PTRACE_SYSEMU or equivalent.
+// kill:  return PtraceKillRequested so the caller drives PTRACE_KILL.
+// log:   emit audit event; allow syscall to proceed.
+// log_and_kill: emit audit + return PtraceKillRequested.
+//
+// PtraceKillRequested is a sentinel error so callers can distinguish
+// "killed intentionally" from "ptrace operation failed".
+func (c *FamilyChecker) Apply(pid int, regs *unix.PtraceRegs, action seccomp.OnBlockAction, audit AuditSink, syscall uint64, family seccomp.BlockedFamily) error {
+	switch action {
+	case seccomp.OnBlockErrno:
+		// Skip the syscall and set the return value.
+		// Implementation detail: ORIG_RAX = -1 cancels the syscall on
+		// modern kernels. RAX gets the negated errno.
+		setReturnRegister(regs, -int64(unix.EAFNOSUPPORT))
+		setSyscallNumber(regs, ^uint64(0)) // -1
+		return unix.PtraceSetRegs(pid, regs)
+	case seccomp.OnBlockKill:
+		return PtraceKillRequested
+	case seccomp.OnBlockLog:
+		audit.Emit(audit.Event{
+			Kind: "seccomp.socket_family_blocked",
+			Fields: map[string]any{
+				"family_name":   family.Name,
+				"family_number": family.Family,
+				"syscall":       syscallName(syscall),
+				"action":        string(action),
+				"engine":        "ptrace",
+				"pid":           pid,
+			},
+		})
+		return nil
+	case seccomp.OnBlockLogAndKill:
+		audit.Emit(audit.Event{
+			Kind: "seccomp.socket_family_blocked",
+			Fields: map[string]any{
+				"family_name":   family.Name,
+				"family_number": family.Family,
+				"syscall":       syscallName(syscall),
+				"action":        string(action),
+				"engine":        "ptrace",
+				"pid":           pid,
+			},
+		})
+		return PtraceKillRequested
+	default:
+		return nil
+	}
+}
+
+// PtraceKillRequested signals that the caller should kill the tracee.
+var PtraceKillRequested = errors.New("ptrace: kill requested by family check")
+
+// setReturnRegister and setSyscallNumber are arch-specific helpers
+// already defined in args_amd64.go / args_arm64.go (or should be added
+// there if not). The checker delegates rather than open-coding.
+```
+
+The arch-specific register helpers may already exist under different names in `internal/ptrace/args_*.go`. **Do not duplicate** — reuse what's there. If the names differ, adjust the call sites.
+
+`AuditSink` type alias for the existing audit interface used elsewhere in `internal/ptrace`.
+
+- [ ] **Step 4: Hook the checker into the tracer dispatch**
+
+In `tracer.go`'s syscall-entry handler, after the static-allow checks and before the per-handler dispatch:
+
+```go
+if t.familyChecker != nil {
+	syscallNr := getSyscallNumber(regs)
+	arg0 := getArg(regs, 0)
+	if bf, ok := t.familyChecker.Check(syscallNr, arg0); ok {
+		if err := t.familyChecker.Apply(pid, regs, bf.Action, t.auditSink, syscallNr, bf); err != nil {
+			if errors.Is(err, PtraceKillRequested) {
+				_ = unix.Kill(pid, unix.SIGKILL)
+				return
+			}
+			slog.Warn("ptrace family check apply failed", "pid", pid, "error", err)
+		}
+		// Skip the rest of the dispatch — the syscall has been handled.
+		return
+	}
+}
+```
+
+Add a `familyChecker *FamilyChecker` field to the `Tracer` struct and a `WithFamilyChecker` option (or constructor argument).
+
+- [ ] **Step 5: Run integration test; expect pass**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/ptrace/family_checker.go internal/ptrace/family_checker_integration_test.go internal/ptrace/tracer.go
+git commit -m "feat(ptrace): wire FamilyChecker into tracer syscall-entry dispatch
+
+errno path skips the syscall and sets RAX to -EAFNOSUPPORT.
+kill path returns PtraceKillRequested for the caller to dispatch SIGKILL.
+log/log_and_kill emit seccomp.socket_family_blocked audit events with
+engine=ptrace.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Engine selection in server startup
+
+**Files:**
+- Modify: `internal/server/security.go` (or wherever sandbox initialization happens — find with `grep -n "Sandbox.Seccomp\|InstallFilter\|tracer.New" internal/server/*.go`)
+
+- [ ] **Step 1: Find where the engines are wired today**
+
+```bash
+grep -n "InstallFilter\|tracer\." internal/server/*.go
+```
+
+Find the spots where seccomp filter is installed AND where the ptrace tracer is constructed.
+
+- [ ] **Step 2: Write failing test**
+
+Server-startup tests usually use a config fixture and assert behavior. The minimum new test:
+
+```go
+func TestSkillcheck_FamilyEngineSelection_Seccomp(t *testing.T) {
+	// Capabilities mock: seccomp present.
+	// Config: blocked_socket_families set.
+	// Assert: filter receives BlockedFamilies; tracer family-checker is nil.
+}
+
+func TestSkillcheck_FamilyEngineSelection_PtraceFallback(t *testing.T) {
+	// Capabilities mock: seccomp absent, ptrace present.
+	// Assert: tracer family-checker is populated; seccomp filter is not built.
+}
+
+func TestSkillcheck_FamilyEngineSelection_NeitherWarn(t *testing.T) {
+	// Capabilities mock: both absent.
+	// Assert: server starts; warning logged; nothing installed.
+}
+```
+
+The test interfaces depend on what's mockable in the project. If capabilities aren't easily mockable for unit tests, write a smaller test that just checks the resolved `BlockedFamilies` slice is correctly forwarded into whichever engine path the resolver picks.
+
+- [ ] **Step 3: Implement engine selection**
+
+In the server bootstrap, around the existing seccomp-vs-ptrace decision (or add it if absent):
+
+```go
+families, err := config.ResolveBlockedFamilies(cfg.Sandbox.Seccomp.BlockedSocketFamilies)
+if err != nil {
+	return nil, fmt.Errorf("resolve blocked_socket_families: %w", err)
+}
+
+useSeccomp := cfg.Sandbox.Seccomp.Enabled && capabilities.HasSeccompFilter()
+usePtrace := !useSeccomp && cfg.Sandbox.Ptrace.Enabled && capabilities.HasPtrace()
+
+switch {
+case useSeccomp:
+	filterCfg.BlockedFamilies = families
+case usePtrace:
+	tracerCfg.FamilyChecker = ptrace.NewFamilyChecker(families)
+case len(families) > 0:
+	slog.Warn("socket family blocking is configured but no enforcement engine is available on this host (seccomp and ptrace both unavailable); families will not be blocked",
+		"families", len(families))
+}
+```
+
+The exact field names depend on the codebase. Don't invent new ones if the equivalents already exist.
+
+- [ ] **Step 4: Run test; expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/security.go internal/server/<test-file>.go
+git commit -m "feat(server): engine selection for socket family blocking
+
+Seccomp primary; ptrace fallback when seccomp unavailable; warn-and-
+continue when both are absent.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+- [ ] **Spec coverage check**
+
+Re-read `docs/superpowers/specs/2026-04-29-socket-family-block-design.md`. For each section, confirm a task implements it:
+
+  - Config schema (Section: Configuration) → Task 3
+  - Default list (Section: Recommended default list) → Task 1 + Task 3 default-merge
+  - Both names + numeric (Section: Configuration) → Task 1 `ParseFamily`
+  - Per-family action (Section: Configuration) → Tasks 6, 9 (both engines respect it)
+  - Engine selection (Section: Engine selection) → Task 10
+  - Audit events (Section: Audit events) → Tasks 7 (seccomp), 9 (ptrace)
+  - libseccomp action-precedence coexistence (Section: Coexistence) → Task 6 integration test
+  - Cross-platform build (Section: Cross-platform) → Tasks 1–10 all add cross-compile gate
+
+- [ ] **Verification before completion**
+
+After Task 10, run the full gate:
+
+```bash
+go build ./...
+GOOS=windows go build ./...
+GOOS=darwin go build ./...
+go vet ./...
+go test -race ./internal/seccomp/... ./internal/config/... ./internal/netmonitor/unix/... ./internal/ptrace/... ./internal/server/...
+go test ./...
+```
+
+All clean.

--- a/docs/superpowers/specs/2026-04-29-socket-family-block-design.md
+++ b/docs/superpowers/specs/2026-04-29-socket-family-block-design.md
@@ -1,0 +1,421 @@
+# Socket Family Blocking — Design
+
+**Date:** 2026-04-29
+**Status:** Draft, awaiting user review
+**Related:** `internal/seccomp/`, `internal/netmonitor/unix/seccomp_linux.go`,
+`internal/ptrace/`, `internal/capabilities/`. Mitigation context: [copy.fail](https://copy.fail/#mitigation).
+
+## Summary
+
+Add per-socket-family blocking to agentsh's sandbox. A new config field
+`sandbox.seccomp.blocked_socket_families` lets operators block creation
+of specified `AF_*` socket families on `socket(2)` and `socketpair(2)`,
+with per-family action override (`errno|kill|log|log_and_kill`).
+
+When `socket(AF_ALG, ...)` (or any blocked family) fires, the kernel
+returns `EAFNOSUPPORT` (or kills the process, or routes through the
+notify-handler for audit), depending on per-family action. Userspace
+sees the same observable behavior as on a kernel that doesn't ship
+that family — graceful fallback in well-written code.
+
+Two enforcement engines, sharing config and types:
+
+1. **seccomp-bpf (primary)** — `AddRuleConditional` on `socket(2)` arg0.
+   Kernel-side filter, ~free runtime cost. Code lives in
+   `internal/netmonitor/unix/seccomp_linux.go`.
+2. **ptrace (fallback)** — checker invoked from the existing tracer
+   when seccomp filter is unavailable. Skips the syscall and writes
+   `-EAFNOSUPPORT` into `RAX`. Code lives in `internal/ptrace/`.
+
+Recommended-default list ships blocked at `errno`: `AF_ALG`,
+`AF_VSOCK`, `AF_RDS`, `AF_TIPC`, `AF_KCM`, plus the dead protocols
+(`AF_X25`, `AF_AX25`, `AF_NETROM`, `AF_ROSE`, `AF_DECnet`,
+`AF_APPLETALK`, `AF_IPX`). Operators override or extend.
+
+## Motivation
+
+[copy.fail (CVE-2025-…)] is the latest in a recurring class:
+exploitation chains that begin with `socket(AF_<family>, ...)` against
+a kernel subsystem that has thinner attack-surface review than the
+mainline networking stack. AF_ALG is the kernel crypto API; AF_VSOCK
+the VM-host transport; AF_RDS, AF_TIPC, AF_KCM are niche/legacy
+networking subsystems. None see meaningful userspace use outside
+narrow tooling, but every one is a kernel attack vector reachable from
+unprivileged userspace.
+
+The copy.fail mitigation says explicitly:
+
+> For untrusted workloads, block `AF_ALG` socket creation via seccomp
+> regardless of patch state.
+
+agentsh today exposes `BlockedSyscalls []string` for whole-syscall
+blocking by name. Adding `socket` to that list blocks every
+`socket(2)` call (including AF_INET, AF_UNIX) — far too broad.
+`libseccomp-golang` (already a project dep, used at
+`internal/seccomp/syscalls.go:8`) supports argument-conditional
+rules; the existing 46-line `internal/seccomp/filter.go` simply
+doesn't expose that path.
+
+This design exposes it as a typed surface — names not numbers,
+per-family actions matching the existing `OnBlockAction` enum — and
+adds a ptrace fallback for hosts where seccomp is unavailable.
+
+[copy.fail (CVE-2025-…)]: https://copy.fail/#mitigation
+
+## Non-Goals
+
+- **`AF_NETLINK` blanket blocking.** Too widely used (iproute2, audit,
+  libnl, systemd). If a specific netlink protocol family becomes a
+  vector, that's a separate spec.
+- **`AF_PACKET`, `AF_BLUETOOTH`, `AF_CAN` defaults.** Real userspace
+  uses these; opt-in only.
+- **eBPF LSM tier.** Cleanest long-term option for Linux 5.7+ but
+  introduces a substantial new dependency stack (libbpf, CO-RE, BTF,
+  CAP_BPF). Separate spec when/if pursued.
+- **Landlock network rules for arbitrary families.** Kernel only
+  exposes TCP bind/connect via Landlock. Kernel-side change required;
+  out of agentsh's control.
+- **`socketcall(2)` (i386 multiplexed entry).** Agentsh's existing
+  seccomp setup doesn't filter it; libseccomp 2.6+ auto-emulates the
+  modern entries on architectures without a dedicated `socket` syscall.
+  Documented as a known limitation.
+- **Auto-detection of which families a binary already uses.** Useful
+  observability feature but requires a separate pass; out of v1.
+- **macOS/Windows.** No AF_ALG, no equivalent attack surface. The
+  config field parses (cross-compile builds clean) but is documented
+  as Linux-only.
+
+## Configuration
+
+New top-level field on the sandbox seccomp config:
+
+```yaml
+sandbox:
+  seccomp:
+    # When unset → recommended-default list (below) applies at action: errno.
+    # Set to []   → opt-out of all family blocking.
+    # Non-empty   → overrides defaults entirely.
+    blocked_socket_families:
+      - family: AF_ALG       # by name (preferred)
+        action: errno
+      - family: 40           # numeric fallback (AF_VSOCK)
+        action: log_and_kill
+```
+
+Per-family `action` field accepts the existing `OnBlockAction` values:
+`errno` (default; returns `EAFNOSUPPORT = 97`), `kill`,
+`log` (notify→audit, allow), `log_and_kill` (notify→audit, kill).
+
+### Recommended default list (when field unset)
+
+| Family | Number | Why default |
+|---|---|---|
+| `AF_ALG` | 38 | copy.fail mitigation; near-zero legitimate userspace use |
+| `AF_VSOCK` | 40 | Niche (VM-host); multiple historical CVEs |
+| `AF_RDS` | 21 | Reliable Datagram Sockets; multiple CVEs; effectively dead |
+| `AF_TIPC` | 30 | Niche cluster protocol; multiple CVEs |
+| `AF_KCM` | 41 | Kernel Connection Multiplexor; niche; CVEs |
+| `AF_X25` | 9 | Legacy/dead protocol, pure attack surface |
+| `AF_AX25` | 3 | Amateur radio; legacy |
+| `AF_NETROM` | 6 | Amateur radio; legacy |
+| `AF_ROSE` | 11 | Amateur radio; legacy |
+| `AF_DECnet` | 12 | Dead protocol |
+| `AF_APPLETALK` | 5 | Dead protocol |
+| `AF_IPX` | 4 | Dead protocol |
+
+All defaults use `action: errno` — `EAFNOSUPPORT` matches the standard
+"this family isn't supported" semantics, so well-behaved userspace
+falls back gracefully.
+
+**Not** in defaults (too widely used; opt-in only):
+`AF_NETLINK`, `AF_PACKET`, `AF_BLUETOOTH`, `AF_CAN`.
+
+## Architecture
+
+```
+┌─────────────────── internal/seccomp ────────────────────┐
+│ filter.go           types: BlockedFamily, FilterConfig   │
+│ families.go (NEW)   name↔number table; ParseFamily;       │
+│                     DefaultBlockedFamilies()              │
+│ syscalls.go         (unchanged) libseccomp number lookup  │
+└──────────────────────────────────────────────────────────┘
+                       │
+        ┌──────────────┴──────────────┐
+        ▼                             ▼
+┌─── seccomp engine ────┐    ┌─── ptrace fallback ────────┐
+│ internal/netmonitor/  │    │ internal/ptrace/             │
+│ unix/seccomp_linux.go │    │   family_checker.go (NEW)    │
+│ (extended)            │    │   trace.go (modified)        │
+└───────────────────────┘    └──────────────────────────────┘
+        │                             │
+        └─────────────┬───────────────┘
+                      ▼
+              ┌─── audit sink ────┐
+              │ kind = seccomp.   │
+              │ socket_family_    │
+              │ blocked           │
+              └───────────────────┘
+```
+
+## Components
+
+### `internal/seccomp/filter.go` (extended)
+
+Add to `FilterConfig`:
+
+```go
+type FilterConfig struct {
+    UnixSocketEnabled  bool
+    BlockedSyscalls    []string
+    BlockedFamilies    []BlockedFamily   // NEW
+    OnBlock            OnBlockAction
+}
+```
+
+`FilterConfigFromYAML` extended to take and pass through.
+
+### `internal/seccomp/families.go` (new)
+
+```go
+//go:build linux
+
+package seccomp
+
+// BlockedFamily is one entry on the blocked_socket_families list.
+type BlockedFamily struct {
+    Family int           // resolved AF_* number
+    Action OnBlockAction // errno|kill|log|log_and_kill
+    Name   string        // original config name; "" if numeric
+}
+
+// ParseFamily resolves a config value (name string or number) to its
+// AF_* int. Returns ok=false if value is neither a known name nor a
+// parseable number in [0, 64).
+func ParseFamily(value string) (nr int, name string, ok bool)
+
+// DefaultBlockedFamilies returns the recommended-default list.
+// Each entry uses OnBlockErrno.
+func DefaultBlockedFamilies() []BlockedFamily
+
+// nameTable: AF_ALG → 38, AF_VSOCK → 40, … (compiled-in)
+```
+
+The table covers the families in the recommended-default list plus
+common ones operators might want to add explicitly (AF_INET, AF_INET6,
+AF_UNIX, AF_NETLINK, AF_PACKET, AF_BLUETOOTH, AF_CAN). New families
+require a code update — kernel adds them rarely.
+
+### `internal/netmonitor/unix/seccomp_linux.go` (modified)
+
+After the existing `BlockedSyscalls` block in `InstallFilterWithConfig`:
+
+```go
+// Per-family socket(2) and socketpair(2) filtering.
+for _, bf := range cfg.BlockedFamilies {
+    cond := seccomp.ScmpCondition{
+        Argument: 0,
+        Op:       seccomp.CompareEqual,
+        Operand1: uint64(bf.Family),
+    }
+    action := familyToScmpAction(bf.Action)
+    for _, sc := range []uint{unix.SYS_SOCKET, unix.SYS_SOCKETPAIR} {
+        if err := filt.AddRuleConditional(
+            seccomp.ScmpSyscall(sc), action, []seccomp.ScmpCondition{cond},
+        ); err != nil {
+            slog.Warn("seccomp: failed to add family rule; family skipped",
+                "family", bf.Name, "syscall", sc, "error", err)
+            continue
+        }
+    }
+    if bf.Action == seccompkg.OnBlockLog || bf.Action == seccompkg.OnBlockLogAndKill {
+        // Register for the userspace notify-handler to route to audit.
+        // Composite key: (syscall<<32) | family.
+        blockedFamilyMap[uint64(unix.SYS_SOCKET)<<32|uint64(bf.Family)] = bf
+        blockedFamilyMap[uint64(unix.SYS_SOCKETPAIR)<<32|uint64(bf.Family)] = bf
+    }
+}
+```
+
+`familyToScmpAction(errno) = ActErrno(EAFNOSUPPORT)`,
+`familyToScmpAction(kill) = ActKillProcess`,
+`familyToScmpAction(log|log_and_kill) = ActNotify`.
+
+### `internal/ptrace/family_checker.go` (new)
+
+```go
+//go:build linux
+
+package ptrace
+
+// FamilyChecker decides whether a socket(2)/socketpair(2) call should
+// be blocked based on its family argument. Reuses the same
+// []seccomp.BlockedFamily list as the seccomp engine.
+type FamilyChecker struct {
+    bySyscall map[uint64]map[uint64]seccomp.BlockedFamily // syscall → family → entry
+}
+
+// Check reports the action for a given syscall+arg0. ok=false means
+// allow (no rule).
+func (c *FamilyChecker) Check(syscall, arg0 uint64) (
+    seccomp.BlockedFamily, bool,
+)
+
+// Apply executes the action against a stopped tracee:
+//   errno         → set RAX = -EAFNOSUPPORT, skip syscall
+//   kill          → PTRACE_KILL
+//   log           → emit audit, allow syscall
+//   log_and_kill  → emit audit + PTRACE_KILL
+func (c *FamilyChecker) Apply(
+    pid int, regs *unix.PtraceRegs, action seccompkg.OnBlockAction,
+    audit AuditSink,
+) error
+```
+
+Hooks into the existing tracer dispatch in `internal/ptrace/trace.go`
+(or wherever the syscall-entry callback lives — verify before
+implementing). Invocation is at the existing syscall-entry stop, after
+the static-allow fast path and before any expensive checks.
+
+`arg0` extraction is arch-specific (`regs.Rdi` on x86_64,
+`regs.Regs[0]` on arm64). The checker abstracts this through a small
+helper.
+
+### Engine selection (`internal/server/server.go`)
+
+At server startup:
+
+```
+if cfg.Sandbox.Seccomp.Enabled && capabilities.HasSeccompFilter():
+    → seccomp path: family rules added to the filter alongside
+      BlockedSyscalls etc.
+elif cfg.Sandbox.Ptrace.Enabled && capabilities.HasPtrace():
+    → ptrace path: FamilyChecker registered with the tracer
+else:
+    → log warning: "socket family blocking is configured but no
+      enforcement engine is available on this host (seccomp and
+      ptrace both unavailable); families will not be blocked"
+    → continue startup
+```
+
+Both engines are mutually exclusive at runtime — never both for the
+same tracee.
+
+## Data flow
+
+### Seccomp path (primary)
+
+```
+config YAML
+    ↓ parse (internal/config)
+[]BlockedFamily (resolved)
+    ↓ FilterConfigFromYAML
+seccomp.FilterConfig
+    ↓ InstallFilterWithConfig
+libseccomp filter (kernel BPF)
+    ↓ socket(AF_ALG, …)
+ActErrno(EAFNOSUPPORT) returned to tracee
+    OR ActNotify → notify FD → userspace handler → audit event → action
+```
+
+### Ptrace path (fallback)
+
+```
+config YAML
+    ↓ parse
+[]BlockedFamily (resolved)
+    ↓ NewFamilyChecker
+FamilyChecker (in-memory map)
+    ↓ tracee calls socket(AF_ALG, …) → SYSCALL_ENTRY stop
+ptrace tracer reads RAX (syscall #) and RDI (arg0)
+    ↓ FamilyChecker.Check
+match found → Apply:
+    errno → SETREGS RAX=-97, ORIG_RAX=-1, PTRACE_SYSEMU continue
+    kill  → PTRACE_KILL
+    log   → emit audit, PTRACE_CONT
+    log_and_kill → emit audit + PTRACE_KILL
+```
+
+### Coexistence with existing `UnixSocketEnabled`
+
+When both flags are active, libseccomp's action-precedence
+(`KILL > TRAP > ERRNO > TRACE > LOG > ALLOW > NOTIFY`) ensures the
+conditional `ActErrno` rule on AF_ALG outranks the unconditional
+`ActNotify` rule on `socket(2)`. Validated by an integration test
+(see Testing).
+
+## Audit events
+
+New event family `seccomp.socket_family_blocked` emitted when action
+is `log` or `log_and_kill`:
+
+| Field | Value |
+|---|---|
+| `kind` | `seccomp.socket_family_blocked` |
+| `family_name` | e.g. `AF_ALG` (empty if numeric-only config) |
+| `family_number` | e.g. `38` |
+| `syscall` | `socket` or `socketpair` |
+| `action` | `log` or `log_and_kill` |
+| `engine` | `seccomp` or `ptrace` |
+| `pid` | tracee PID |
+
+Routed through the existing audit sink alongside other seccomp events.
+Operators see the same SIEM signal regardless of which engine fired.
+
+## Error handling
+
+| Failure | Behavior |
+|---|---|
+| Unknown family name in config (typo) | Fail-fast at startup with valid-set listing |
+| Numeric family out of range | Fail-fast |
+| Invalid action string | Existing `ParseOnBlock` path: degrade to errno + warn |
+| `AddRuleConditional` returns error for one family | Log family + syscall + error; skip that rule; continue |
+| Tracer can't read regs (zombied tracee, etc.) | Skip family check, fall through to existing allow logic. Never block on inability to inspect — false positives mask real bugs |
+| Both seccomp and ptrace unavailable | Startup warning; continue; families are not blocked |
+
+## Testing strategy
+
+| Surface | Tests |
+|---|---|
+| `internal/seccomp/families.go` | Table-driven name→number for every entry; numeric fallback; unknown names rejected; `DefaultBlockedFamilies()` returns documented set; YAML round-trip |
+| `internal/seccomp` config integration | Default-merge: empty config → defaults; `[]` → opt-out; mix of named + numeric; per-family action variants; duplicate-family warning |
+| `internal/netmonitor/unix/seccomp_linux.go` | Real-process: spawn child under filter, attempt `socket(AF_ALG, SOCK_SEQPACKET, 0)`, assert `errno == EAFNOSUPPORT`. Repeat with `kill` action; child receives SIGSYS or is killed. Coverage matrix: each action × at least two families |
+| Coexistence with `UnixSocketEnabled` | Spawn under both flags; `socket(AF_UNIX,…)` → notify path succeeds; `socket(AF_ALG,…)` → blocked. Validates libseccomp action-precedence |
+| `internal/ptrace/family_checker.go` | Unit: arg0 extraction across x86_64 + arm64; checker matrix per action |
+| `internal/ptrace` integration | Real-tracee: spawn under tracer, attempt `socket(AF_ALG,…)`, assert errno; repeat with `kill` |
+| Engine selection (`internal/server`) | Capabilities matrix: seccomp present → seccomp; only ptrace → ptrace; neither → startup warning + continue |
+| Negative — backward compat | Existing tests for `BlockedSyscalls`, `UnixSocketEnabled`, `BlockIOUring` unchanged, still pass |
+
+The seccomp coexistence test is the most important — it pins that
+adding family rules doesn't break the existing AF_UNIX monitoring
+users depend on today.
+
+Cross-compile: `GOOS=windows go build ./...` and
+`GOOS=darwin go build ./...` must succeed. The `BlockedFamily` type
+is platform-neutral; the engine code is `//go:build linux`.
+
+## Cross-platform
+
+`go:build linux` on all enforcement code. Config parsing is
+platform-neutral so cross-compile builds clean. On non-Linux,
+agentsh logs `socket family blocking is configured but only enforced
+on Linux; ignored on this platform` once at startup if the field is
+non-empty.
+
+## Open questions / future work
+
+- **eBPF LSM tier.** When agentsh adopts libbpf for other purposes
+  (network filtering, file integrity), revisit the `security_socket_create`
+  hook as a third enforcement engine. Cleaner than ptrace, lower
+  overhead. Out of scope for v1.
+- **Per-binary policy.** Currently the family list applies to every
+  tracee under the filter. A future extension might let policy match
+  the executed binary so e.g. `iproute2` can use `AF_NETLINK` while
+  arbitrary user binaries can't. Out of scope.
+- **Reverse — allowlist mode.** If operators want "block everything
+  except AF_INET/AF_INET6/AF_UNIX", today they'd have to enumerate
+  ~30 families. A future `mode: allowlist` switch could invert. Not
+  needed for v1.
+- **Userspace observability.** Telling operators "this binary tried to
+  use AF_ALG and got blocked" via audit is half the story. A future
+  observability pass might surface this in a dashboard with workload
+  attribution. Separate project.

--- a/internal/api/app_ptrace_linux.go
+++ b/internal/api/app_ptrace_linux.go
@@ -13,8 +13,9 @@ import (
 
 // initPtraceTracer initializes the ptrace tracer if configured.
 // Called from NewApp on Linux when sandbox.ptrace.enabled is true.
-// Also wires FamilyChecker when ptrace is the selected enforcement engine
-// for socket-family blocking (seccomp unavailable/disabled, ptrace available).
+// Always wires FamilyChecker when families are configured, regardless of which
+// engine the selector reports as primary. Runtime dispatch is mutually exclusive
+// (a syscall reaches at most one engine), so dual installation is safe.
 func (a *App) initPtraceTracer() {
 	cfg := a.cfg.Sandbox.Ptrace
 	if !cfg.Enabled {
@@ -33,29 +34,30 @@ func (a *App) initPtraceTracer() {
 		trashPath:          a.cfg.Sandbox.FUSE.Audit.TrashPath,
 	}
 
-	// Engine selection for socket-family blocking.
-	// Resolve the family list once; selectFamilyBlockingEngine decides
-	// which enforcement path to use based on config + host capabilities.
-	var familyChecker *ptrace.FamilyChecker
-	families, err := config.ResolveBlockedFamilies(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies)
+	// Socket-family blocking: resolve families once, then wire defensively.
+	//
+	// Always install the FamilyChecker when families are configured and the
+	// ptrace tracer is being initialized.  selectFamilyBlockingEngine is used
+	// only for the warn-and-continue path (familyEngineNone) and is no longer
+	// load-bearing for deciding which engine enforces.  The seccomp engine has
+	// its own independent wiring path (buildSeccompWrapperConfig); runtime
+	// dispatch is mutually exclusive, so dual installation is safe — no
+	// double-audit risk.
+	familyChecker, err := resolveFamilyCheckerForPtrace(a.cfg)
 	if err != nil {
 		slog.Warn("initPtraceTracer: failed to resolve blocked_socket_families; socket-family blocking will not be enforced via ptrace",
 			"error", err)
 	} else {
-		caps := capabilities.DetectSecurityCapabilities()
-		switch selectFamilyBlockingEngine(families, &a.cfg.Sandbox, caps) {
-		case familyEnginePtrace:
-			familyChecker = ptrace.NewFamilyChecker(families)
-			slog.Info("socket-family blocking: using ptrace engine",
+		families, _ := config.ResolveBlockedFamilies(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies)
+		if familyChecker != nil {
+			slog.Info("socket-family blocking: wired FamilyChecker on ptrace tracer",
 				"families", len(families))
-		case familyEngineSeccomp:
-			// seccomp handles it via buildSeccompWrapperConfig; nothing to do here.
-		case familyEngineNone:
-			if len(families) > 0 {
-				slog.Warn("socket-family blocking is configured but no enforcement engine is available on this host "+
-					"(seccomp and ptrace both unavailable or disabled); families will not be blocked",
-					"families", len(families))
-			}
+		}
+		caps := capabilities.DetectSecurityCapabilities()
+		engine := selectFamilyBlockingEngine(families, &a.cfg.Sandbox, caps)
+		if engine == familyEngineNone && len(families) > 0 {
+			slog.Warn("socket-family blocking is configured but no enforcement engine is available; families will not be blocked",
+				"families_count", len(families))
 		}
 	}
 
@@ -88,6 +90,24 @@ func (a *App) initPtraceTracer() {
 		}
 	}()
 	slog.Info("ptrace tracer started", "attach_mode", cfg.AttachMode)
+}
+
+// resolveFamilyCheckerForPtrace resolves the FamilyChecker to install on the
+// ptrace tracer for the given app config.  Returns a non-nil checker
+// whenever families are configured, regardless of which engine
+// selectFamilyBlockingEngine reports as primary.  The caller is responsible
+// for the warn-and-continue log when the selector returns familyEngineNone.
+//
+// Extracted as a standalone function for testability.
+func resolveFamilyCheckerForPtrace(cfg *config.Config) (*ptrace.FamilyChecker, error) {
+	families, err := config.ResolveBlockedFamilies(cfg.Sandbox.Seccomp.BlockedSocketFamilies)
+	if err != nil {
+		return nil, err
+	}
+	if len(families) == 0 {
+		return nil, nil
+	}
+	return ptrace.NewFamilyChecker(families), nil
 }
 
 // closePtraceTracer stops the ptrace tracer if running.

--- a/internal/api/app_ptrace_linux.go
+++ b/internal/api/app_ptrace_linux.go
@@ -9,7 +9,24 @@ import (
 	"github.com/agentsh/agentsh/internal/capabilities"
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/ptrace"
+	"github.com/agentsh/agentsh/pkg/types"
 )
+
+// ptraceFamilyEmitter adapts the API's event store/broker to the
+// ptrace.FamilyEmitter interface so family-block audit events reach the
+// same sink as the seccomp engine's events.
+type ptraceFamilyEmitter struct {
+	store  eventStore
+	broker eventBroker
+}
+
+func (e *ptraceFamilyEmitter) AppendEvent(ctx context.Context, ev types.Event) error {
+	return e.store.AppendEvent(ctx, ev)
+}
+
+func (e *ptraceFamilyEmitter) Publish(ev types.Event) {
+	e.broker.Publish(ev)
+}
 
 // initPtraceTracer initializes the ptrace tracer if configured.
 // Called from NewApp on Linux when sandbox.ptrace.enabled is true.
@@ -43,7 +60,8 @@ func (a *App) initPtraceTracer() {
 	// its own independent wiring path (buildSeccompWrapperConfig); runtime
 	// dispatch is mutually exclusive, so dual installation is safe — no
 	// double-audit risk.
-	familyChecker, err := resolveFamilyCheckerForPtrace(a.cfg)
+	emit := &ptraceFamilyEmitter{store: a.store, broker: a.broker}
+	familyChecker, err := resolveFamilyCheckerForPtrace(a.cfg, emit)
 	if err != nil {
 		slog.Warn("initPtraceTracer: failed to resolve blocked_socket_families; socket-family blocking will not be enforced via ptrace",
 			"error", err)
@@ -98,8 +116,12 @@ func (a *App) initPtraceTracer() {
 // selectFamilyBlockingEngine reports as primary.  The caller is responsible
 // for the warn-and-continue log when the selector returns familyEngineNone.
 //
+// emit is wired into the checker so every family-block fires an audit event
+// through the same sink as the seccomp engine.  Pass nil to skip audit
+// emission (tests / cases where the emitter is not yet available).
+//
 // Extracted as a standalone function for testability.
-func resolveFamilyCheckerForPtrace(cfg *config.Config) (*ptrace.FamilyChecker, error) {
+func resolveFamilyCheckerForPtrace(cfg *config.Config, emit ptrace.FamilyEmitter) (*ptrace.FamilyChecker, error) {
 	families, err := config.ResolveBlockedFamilies(cfg.Sandbox.Seccomp.BlockedSocketFamilies)
 	if err != nil {
 		return nil, err
@@ -107,7 +129,7 @@ func resolveFamilyCheckerForPtrace(cfg *config.Config) (*ptrace.FamilyChecker, e
 	if len(families) == 0 {
 		return nil, nil
 	}
-	return ptrace.NewFamilyChecker(families), nil
+	return ptrace.NewFamilyCheckerWithEmitter(families, emit), nil
 }
 
 // closePtraceTracer stops the ptrace tracer if running.

--- a/internal/api/app_ptrace_linux.go
+++ b/internal/api/app_ptrace_linux.go
@@ -6,14 +6,21 @@ import (
 	"context"
 	"log/slog"
 
+	"github.com/agentsh/agentsh/internal/capabilities"
+	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/ptrace"
 )
 
 // initPtraceTracer initializes the ptrace tracer if configured.
 // Called from NewApp on Linux when sandbox.ptrace.enabled is true.
+// Also wires FamilyChecker when ptrace is the selected enforcement engine
+// for socket-family blocking (seccomp unavailable/disabled, ptrace available).
 func (a *App) initPtraceTracer() {
 	cfg := a.cfg.Sandbox.Ptrace
 	if !cfg.Enabled {
+		// Even when ptrace is disabled, check if socket-family blocking is
+		// configured but has no enforcement engine available, and warn.
+		a.warnIfFamiliesOrphan()
 		return
 	}
 
@@ -25,6 +32,33 @@ func (a *App) initPtraceTracer() {
 		staticAllowNetwork: cfg.Performance.StaticAllowNetwork,
 		trashPath:          a.cfg.Sandbox.FUSE.Audit.TrashPath,
 	}
+
+	// Engine selection for socket-family blocking.
+	// Resolve the family list once; selectFamilyBlockingEngine decides
+	// which enforcement path to use based on config + host capabilities.
+	var familyChecker *ptrace.FamilyChecker
+	families, err := config.ResolveBlockedFamilies(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies)
+	if err != nil {
+		slog.Warn("initPtraceTracer: failed to resolve blocked_socket_families; socket-family blocking will not be enforced via ptrace",
+			"error", err)
+	} else {
+		caps := capabilities.DetectSecurityCapabilities()
+		switch selectFamilyBlockingEngine(families, &a.cfg.Sandbox, caps) {
+		case familyEnginePtrace:
+			familyChecker = ptrace.NewFamilyChecker(families)
+			slog.Info("socket-family blocking: using ptrace engine",
+				"families", len(families))
+		case familyEngineSeccomp:
+			// seccomp handles it via buildSeccompWrapperConfig; nothing to do here.
+		case familyEngineNone:
+			if len(families) > 0 {
+				slog.Warn("socket-family blocking is configured but no enforcement engine is available on this host "+
+					"(seccomp and ptrace both unavailable or disabled); families will not be blocked",
+					"families", len(families))
+			}
+		}
+	}
+
 	tr := ptrace.NewTracer(ptrace.TracerConfig{
 		AttachMode:       cfg.AttachMode,
 		TraceExecve:      cfg.Trace.Execve,
@@ -41,6 +75,7 @@ func (a *App) initPtraceTracer() {
 		FileHandler:      router,
 		NetworkHandler:   router,
 		SignalHandler:    router,
+		FamilyChecker:    familyChecker,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -60,5 +95,25 @@ func (a *App) closePtraceTracer() {
 	if a.ptraceCancel != nil {
 		a.ptraceCancel()
 		a.ptraceCancel = nil
+	}
+}
+
+// warnIfFamiliesOrphan emits a warning when socket-family blocking is
+// configured but neither seccomp nor ptrace is available/enabled.
+// Called from initPtraceTracer when ptrace is disabled, to cover the
+// case where seccomp is also absent.
+func (a *App) warnIfFamiliesOrphan() {
+	if len(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies) == 0 {
+		return
+	}
+	families, err := config.ResolveBlockedFamilies(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies)
+	if err != nil || len(families) == 0 {
+		return
+	}
+	caps := capabilities.DetectSecurityCapabilities()
+	if selectFamilyBlockingEngine(families, &a.cfg.Sandbox, caps) == familyEngineNone {
+		slog.Warn("socket-family blocking is configured but no enforcement engine is available on this host "+
+			"(seccomp and ptrace both unavailable or disabled); families will not be blocked",
+			"families", len(families))
 	}
 }

--- a/internal/api/blocklist_config_linux.go
+++ b/internal/api/blocklist_config_linux.go
@@ -6,35 +6,60 @@ import (
 	"log/slog"
 	"runtime"
 
+	"github.com/agentsh/agentsh/internal/config"
 	unixmon "github.com/agentsh/agentsh/internal/netmonitor/unix"
 	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
+	"golang.org/x/sys/unix"
 )
 
 // buildBlockListConfigFor returns the per-session *BlockListConfig derived
-// from Sandbox.Seccomp.Syscalls. When on_block is errno or kill the seccomp
-// filter handles the action kernel-side and no notify traps fire — an empty
-// config is returned in that case (nil-safe; IsBlockListed returns (_, false)).
+// from Sandbox.Seccomp.Syscalls and Sandbox.Seccomp.BlockedSocketFamilies.
+// When on_block is errno or kill the seccomp filter handles the action
+// kernel-side and no notify traps fire — an empty config is returned in that
+// case (nil-safe; IsBlockListed returns (_, false)).
+// Socket-family entries with log/log_and_kill actions are always included in
+// FamilyByKey regardless of the syscall on_block setting.
 //
 // Returns a non-nil *BlockListConfig (wrapped as any so the signature matches
 // the non-Linux stub) so callers can always probe len(ActionByNr) without a
 // separate nil check.
 func (a *App) buildBlockListConfigFor(sessionID string) any {
 	cfg := &unixmon.BlockListConfig{}
+
+	// Syscall block-list: only log/log_and_kill route through notify.
 	action, ok := seccompkg.ParseOnBlock(a.cfg.Sandbox.Seccomp.Syscalls.OnBlock)
-	if !ok {
-		return cfg
+	if ok && (action == seccompkg.OnBlockLog || action == seccompkg.OnBlockLogAndKill) {
+		nrs, skipped := seccompkg.ResolveSyscalls(a.cfg.Sandbox.Seccomp.Syscalls.Block)
+		if len(skipped) > 0 {
+			slog.Warn("blocklist: some syscalls could not be resolved on this arch",
+				"session_id", sessionID, "skipped", skipped, "arch", runtime.GOARCH)
+		}
+		cfg.ActionByNr = make(map[uint32]seccompkg.OnBlockAction, len(nrs))
+		for _, nr := range nrs {
+			cfg.ActionByNr[uint32(nr)] = action
+		}
 	}
-	if action != seccompkg.OnBlockLog && action != seccompkg.OnBlockLogAndKill {
-		return cfg
+
+	// Socket-family block-list: log/log_and_kill families route through notify.
+	// Build (syscallNr<<32)|af_family → BlockedFamily for dispatch in the handler.
+	if len(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies) > 0 {
+		families, err := config.ResolveBlockedFamilies(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies)
+		if err != nil {
+			slog.Warn("blocklist: failed to resolve blocked_socket_families for notify dispatch",
+				"session_id", sessionID, "error", err)
+		} else {
+			for _, bf := range families {
+				if bf.Action != seccompkg.OnBlockLog && bf.Action != seccompkg.OnBlockLogAndKill {
+					continue
+				}
+				if cfg.FamilyByKey == nil {
+					cfg.FamilyByKey = make(map[uint64]seccompkg.BlockedFamily)
+				}
+				cfg.FamilyByKey[uint64(unix.SYS_SOCKET)<<32|uint64(bf.Family)] = bf
+				cfg.FamilyByKey[uint64(unix.SYS_SOCKETPAIR)<<32|uint64(bf.Family)] = bf
+			}
+		}
 	}
-	nrs, skipped := seccompkg.ResolveSyscalls(a.cfg.Sandbox.Seccomp.Syscalls.Block)
-	if len(skipped) > 0 {
-		slog.Warn("blocklist: some syscalls could not be resolved on this arch",
-			"session_id", sessionID, "skipped", skipped, "arch", runtime.GOARCH)
-	}
-	cfg.ActionByNr = make(map[uint32]seccompkg.OnBlockAction, len(nrs))
-	for _, nr := range nrs {
-		cfg.ActionByNr[uint32(nr)] = action
-	}
+
 	return cfg
 }

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -186,7 +186,7 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 	// Only enable ptrace sync handshake when the wrapper will produce a notify FD.
 	// If no seccomp features need USER_NOTIF, the wrapper skips the FD send and
 	// the READY/GO handshake has nothing to synchronize on.
-	hasNotifyFeatures := seccompCfg.UnixSocketEnabled || seccompCfg.ExecveEnabled || seccompCfg.FileMonitorEnabled || seccompCfg.InterceptMetadata || blockListUsesNotify(seccompCfg.BlockedSyscalls, seccompCfg.OnBlock)
+	hasNotifyFeatures := seccompCfg.UnixSocketEnabled || seccompCfg.ExecveEnabled || seccompCfg.FileMonitorEnabled || seccompCfg.InterceptMetadata || blockListUsesNotify(seccompCfg.BlockedSyscalls, seccompCfg.OnBlock) || blockedFamiliesUsesNotify(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies)
 	// AGENTSH_PTRACE_SYNC goes into envInject (not env) so it overrides any
 	// user-supplied value. envInject deduplicates keys before appending.
 	ptraceSyncValue := "0"

--- a/internal/api/family_engine_linux.go
+++ b/internal/api/family_engine_linux.go
@@ -1,0 +1,55 @@
+//go:build linux
+
+package api
+
+import (
+	"github.com/agentsh/agentsh/internal/capabilities"
+	"github.com/agentsh/agentsh/internal/config"
+	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
+)
+
+// familyEngine describes which enforcement engine should handle socket-family
+// blocking for a given configuration + capability snapshot.
+type familyEngine int
+
+const (
+	familyEngineNone    familyEngine = iota // no engine available; warn if families configured
+	familyEngineSeccomp                     // seccomp-bpf (primary)
+	familyEnginePtrace                      // ptrace (fallback)
+)
+
+// selectFamilyBlockingEngine picks the appropriate enforcement engine for
+// socket-family blocking given the resolved family list, the sandbox config,
+// and the detected host capabilities.
+//
+// Decision order (per spec §"Engine selection"):
+//  1. seccomp available + enabled in config → seccomp engine
+//  2. seccomp unavailable/disabled AND ptrace available + enabled → ptrace engine
+//  3. neither → familyEngineNone (caller logs a warning if families > 0)
+//
+// The function does NOT install anything; it only reports which engine should
+// be used.  The seccomp path is wired by buildSeccompWrapperConfig; the ptrace
+// path is wired by initPtraceTracer after calling this function.
+func selectFamilyBlockingEngine(
+	families []seccompkg.BlockedFamily,
+	cfg *config.SandboxConfig,
+	caps *capabilities.SecurityCapabilities,
+) familyEngine {
+	if len(families) == 0 {
+		return familyEngineNone
+	}
+
+	seccompAvailable := caps != nil && caps.Seccomp
+	seccompEnabled := cfg != nil && cfg.Seccomp.Enabled
+	if seccompAvailable && seccompEnabled {
+		return familyEngineSeccomp
+	}
+
+	ptraceAvailable := caps != nil && caps.Ptrace
+	ptraceEnabled := cfg != nil && cfg.Ptrace.Enabled
+	if ptraceAvailable && ptraceEnabled {
+		return familyEnginePtrace
+	}
+
+	return familyEngineNone
+}

--- a/internal/api/family_engine_linux.go
+++ b/internal/api/family_engine_linux.go
@@ -3,6 +3,9 @@
 package api
 
 import (
+	"os/exec"
+	"strings"
+
 	"github.com/agentsh/agentsh/internal/capabilities"
 	"github.com/agentsh/agentsh/internal/config"
 	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
@@ -18,13 +21,48 @@ const (
 	familyEnginePtrace                      // ptrace (fallback)
 )
 
+// familyEngineLookPath is the exec.LookPath function used to check wrapper binary
+// availability. Package-level variable for testability (matches wrapperLookPath
+// pattern in the capabilities package).
+var familyEngineLookPath = exec.LookPath
+
+// wrapperWillRun returns true when the seccomp wrapper (agentsh-unixwrap) is
+// expected to actually run for the given config.  Two conditions must hold:
+//
+//  1. unix_sockets is enabled in config (nil defaults to true, per applyDefaults).
+//  2. The wrapper binary is present on PATH (or at the configured override path).
+//
+// Kernel seccomp support (caps.Seccomp) is a necessary but not sufficient
+// condition: the wrapper binary must also be reachable, otherwise the seccomp
+// engine commits to enforcement but installs nothing — silent fail-open.
+func wrapperWillRun(cfg *config.SandboxConfig) bool {
+	if cfg == nil {
+		return false
+	}
+
+	// unix_sockets.enabled: nil means "defaulted to true" by applyDefaults,
+	// but selectFamilyBlockingEngine may be called before defaults are applied
+	// (e.g. in tests).  Treat nil as enabled, matching the runtime behaviour.
+	if cfg.UnixSockets.Enabled != nil && !*cfg.UnixSockets.Enabled {
+		return false
+	}
+
+	wrapperBin := strings.TrimSpace(cfg.UnixSockets.WrapperBin)
+	if wrapperBin == "" {
+		wrapperBin = "agentsh-unixwrap"
+	}
+
+	_, err := familyEngineLookPath(wrapperBin)
+	return err == nil
+}
+
 // selectFamilyBlockingEngine picks the appropriate enforcement engine for
 // socket-family blocking given the resolved family list, the sandbox config,
 // and the detected host capabilities.
 //
 // Decision order (per spec §"Engine selection"):
-//  1. seccomp available + enabled in config → seccomp engine
-//  2. seccomp unavailable/disabled AND ptrace available + enabled → ptrace engine
+//  1. seccomp available + enabled in config + wrapper will run → seccomp engine
+//  2. seccomp unavailable/disabled OR wrapper absent AND ptrace available + enabled → ptrace engine
 //  3. neither → familyEngineNone (caller logs a warning if families > 0)
 //
 // The function does NOT install anything; it only reports which engine should
@@ -41,7 +79,7 @@ func selectFamilyBlockingEngine(
 
 	seccompAvailable := caps != nil && caps.Seccomp
 	seccompEnabled := cfg != nil && cfg.Seccomp.Enabled
-	if seccompAvailable && seccompEnabled {
+	if seccompAvailable && seccompEnabled && wrapperWillRun(cfg) {
 		return familyEngineSeccomp
 	}
 

--- a/internal/api/family_engine_linux.go
+++ b/internal/api/family_engine_linux.go
@@ -56,9 +56,13 @@ func wrapperWillRun(cfg *config.SandboxConfig) bool {
 	return err == nil
 }
 
-// selectFamilyBlockingEngine picks the appropriate enforcement engine for
+// selectFamilyBlockingEngine reports which engine WILL primarily enforce
 // socket-family blocking given the resolved family list, the sandbox config,
-// and the detected host capabilities.
+// and the detected host capabilities.  Used for diagnostics and the
+// warn-and-continue path only — it is NOT load-bearing for which engine
+// actually enforces.  Both the seccomp and ptrace engines may hold the
+// FamilyChecker; runtime dispatch is mutually exclusive (a syscall reaches at
+// most one engine), so dual installation is safe.
 //
 // Decision order (per spec §"Engine selection"):
 //  1. seccomp available + enabled in config + wrapper will run → seccomp engine

--- a/internal/api/family_engine_linux_test.go
+++ b/internal/api/family_engine_linux_test.go
@@ -1,0 +1,118 @@
+//go:build linux
+
+package api
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/capabilities"
+	"github.com/agentsh/agentsh/internal/config"
+	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
+)
+
+func oneFamilySlice() []seccompkg.BlockedFamily {
+	return []seccompkg.BlockedFamily{
+		{Family: 38, Action: seccompkg.OnBlockErrno, Name: "AF_ALG"},
+	}
+}
+
+func TestSelectFamilyBlockingEngine_Seccomp(t *testing.T) {
+	// seccomp available + enabled → seccomp engine
+	families := oneFamilySlice()
+	caps := &capabilities.SecurityCapabilities{Seccomp: true, Ptrace: true}
+	cfg := &config.SandboxConfig{
+		Seccomp: config.SandboxSeccompConfig{Enabled: true},
+		Ptrace:  config.SandboxPtraceConfig{Enabled: true},
+	}
+	got := selectFamilyBlockingEngine(families, cfg, caps)
+	if got != familyEngineSeccomp {
+		t.Errorf("expected familyEngineSeccomp; got %v", got)
+	}
+}
+
+func TestSelectFamilyBlockingEngine_SeccompDisabled_PtraceAvailable(t *testing.T) {
+	// seccomp disabled → ptrace fallback even if seccomp capable
+	families := oneFamilySlice()
+	caps := &capabilities.SecurityCapabilities{Seccomp: true, Ptrace: true}
+	cfg := &config.SandboxConfig{
+		Seccomp: config.SandboxSeccompConfig{Enabled: false},
+		Ptrace:  config.SandboxPtraceConfig{Enabled: true},
+	}
+	got := selectFamilyBlockingEngine(families, cfg, caps)
+	if got != familyEnginePtrace {
+		t.Errorf("expected familyEnginePtrace; got %v", got)
+	}
+}
+
+func TestSelectFamilyBlockingEngine_SeccompUnavailable_PtraceEnabled(t *testing.T) {
+	// seccomp not available on host, ptrace enabled → ptrace engine
+	families := oneFamilySlice()
+	caps := &capabilities.SecurityCapabilities{Seccomp: false, Ptrace: true}
+	cfg := &config.SandboxConfig{
+		Seccomp: config.SandboxSeccompConfig{Enabled: true},
+		Ptrace:  config.SandboxPtraceConfig{Enabled: true},
+	}
+	got := selectFamilyBlockingEngine(families, cfg, caps)
+	if got != familyEnginePtrace {
+		t.Errorf("expected familyEnginePtrace; got %v", got)
+	}
+}
+
+func TestSelectFamilyBlockingEngine_NeitherAvailable(t *testing.T) {
+	// neither engine available → none
+	families := oneFamilySlice()
+	caps := &capabilities.SecurityCapabilities{Seccomp: false, Ptrace: false}
+	cfg := &config.SandboxConfig{
+		Seccomp: config.SandboxSeccompConfig{Enabled: true},
+		Ptrace:  config.SandboxPtraceConfig{Enabled: true},
+	}
+	got := selectFamilyBlockingEngine(families, cfg, caps)
+	if got != familyEngineNone {
+		t.Errorf("expected familyEngineNone; got %v", got)
+	}
+}
+
+func TestSelectFamilyBlockingEngine_NeitherEnabled(t *testing.T) {
+	// both disabled in config → none
+	families := oneFamilySlice()
+	caps := &capabilities.SecurityCapabilities{Seccomp: true, Ptrace: true}
+	cfg := &config.SandboxConfig{
+		Seccomp: config.SandboxSeccompConfig{Enabled: false},
+		Ptrace:  config.SandboxPtraceConfig{Enabled: false},
+	}
+	got := selectFamilyBlockingEngine(families, cfg, caps)
+	if got != familyEngineNone {
+		t.Errorf("expected familyEngineNone; got %v", got)
+	}
+}
+
+func TestSelectFamilyBlockingEngine_EmptyFamilies(t *testing.T) {
+	// no families configured → none regardless of caps
+	caps := &capabilities.SecurityCapabilities{Seccomp: true, Ptrace: true}
+	cfg := &config.SandboxConfig{
+		Seccomp: config.SandboxSeccompConfig{Enabled: true},
+		Ptrace:  config.SandboxPtraceConfig{Enabled: true},
+	}
+	got := selectFamilyBlockingEngine(nil, cfg, caps)
+	if got != familyEngineNone {
+		t.Errorf("expected familyEngineNone for nil families; got %v", got)
+	}
+	got = selectFamilyBlockingEngine([]seccompkg.BlockedFamily{}, cfg, caps)
+	if got != familyEngineNone {
+		t.Errorf("expected familyEngineNone for empty families; got %v", got)
+	}
+}
+
+func TestSelectFamilyBlockingEngine_SeccompPreferredOverPtrace(t *testing.T) {
+	// when both are available + enabled, seccomp wins (cheaper)
+	families := oneFamilySlice()
+	caps := &capabilities.SecurityCapabilities{Seccomp: true, Ptrace: true}
+	cfg := &config.SandboxConfig{
+		Seccomp: config.SandboxSeccompConfig{Enabled: true},
+		Ptrace:  config.SandboxPtraceConfig{Enabled: true},
+	}
+	got := selectFamilyBlockingEngine(families, cfg, caps)
+	if got != familyEngineSeccomp {
+		t.Errorf("expected seccomp over ptrace when both available; got %v", got)
+	}
+}

--- a/internal/api/family_engine_linux_test.go
+++ b/internal/api/family_engine_linux_test.go
@@ -3,6 +3,7 @@
 package api
 
 import (
+	"os/exec"
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/capabilities"
@@ -17,7 +18,8 @@ func oneFamilySlice() []seccompkg.BlockedFamily {
 }
 
 func TestSelectFamilyBlockingEngine_Seccomp(t *testing.T) {
-	// seccomp available + enabled → seccomp engine
+	// seccomp available + enabled + wrapper present → seccomp engine
+	withPresentWrapper(t)
 	families := oneFamilySlice()
 	caps := &capabilities.SecurityCapabilities{Seccomp: true, Ptrace: true}
 	cfg := &config.SandboxConfig{
@@ -104,7 +106,8 @@ func TestSelectFamilyBlockingEngine_EmptyFamilies(t *testing.T) {
 }
 
 func TestSelectFamilyBlockingEngine_SeccompPreferredOverPtrace(t *testing.T) {
-	// when both are available + enabled, seccomp wins (cheaper)
+	// when both are available + enabled + wrapper present, seccomp wins (cheaper)
+	withPresentWrapper(t)
 	families := oneFamilySlice()
 	caps := &capabilities.SecurityCapabilities{Seccomp: true, Ptrace: true}
 	cfg := &config.SandboxConfig{
@@ -114,5 +117,68 @@ func TestSelectFamilyBlockingEngine_SeccompPreferredOverPtrace(t *testing.T) {
 	got := selectFamilyBlockingEngine(families, cfg, caps)
 	if got != familyEngineSeccomp {
 		t.Errorf("expected seccomp over ptrace when both available; got %v", got)
+	}
+}
+
+// withMissingWrapper temporarily replaces familyEngineLookPath so that any
+// lookup of "agentsh-unixwrap" returns an error (binary not found).
+func withMissingWrapper(t *testing.T) {
+	t.Helper()
+	orig := familyEngineLookPath
+	familyEngineLookPath = func(file string) (string, error) {
+		return "", &exec.Error{Name: file, Err: exec.ErrNotFound}
+	}
+	t.Cleanup(func() { familyEngineLookPath = orig })
+}
+
+// withPresentWrapper temporarily replaces familyEngineLookPath so that any
+// lookup returns a fixed path (wrapper present).
+func withPresentWrapper(t *testing.T) {
+	t.Helper()
+	orig := familyEngineLookPath
+	familyEngineLookPath = func(file string) (string, error) {
+		return "/usr/local/bin/" + file, nil
+	}
+	t.Cleanup(func() { familyEngineLookPath = orig })
+}
+
+func TestSelectFamilyEngine_WrapperMissing_FallsBackToPtrace(t *testing.T) {
+	// Capabilities: seccomp + ptrace both available.
+	// Config: seccomp enabled, unix_sockets enabled (nil → default true).
+	// Wrapper binary: NOT on PATH.
+	// Ptrace: enabled.
+	// Expected: familyEnginePtrace (NOT familyEngineSeccomp).
+	withMissingWrapper(t)
+
+	families := oneFamilySlice()
+	caps := &capabilities.SecurityCapabilities{Seccomp: true, Ptrace: true}
+	cfg := &config.SandboxConfig{
+		Seccomp: config.SandboxSeccompConfig{Enabled: true},
+		Ptrace:  config.SandboxPtraceConfig{Enabled: true},
+		// UnixSockets.Enabled is nil → treated as true (default), so the
+		// only reason wrapperWillRun returns false is the missing binary.
+	}
+
+	got := selectFamilyBlockingEngine(families, cfg, caps)
+	if got != familyEnginePtrace {
+		t.Errorf("expected familyEnginePtrace when wrapper binary missing; got %v", got)
+	}
+}
+
+func TestSelectFamilyEngine_WrapperMissing_NeitherFallback(t *testing.T) {
+	// Same as above but ptrace also unavailable/disabled.
+	// Expected: familyEngineNone (silent fail — caller logs the warning).
+	withMissingWrapper(t)
+
+	families := oneFamilySlice()
+	caps := &capabilities.SecurityCapabilities{Seccomp: true, Ptrace: false}
+	cfg := &config.SandboxConfig{
+		Seccomp: config.SandboxSeccompConfig{Enabled: true},
+		Ptrace:  config.SandboxPtraceConfig{Enabled: false},
+	}
+
+	got := selectFamilyBlockingEngine(families, cfg, caps)
+	if got != familyEngineNone {
+		t.Errorf("expected familyEngineNone when wrapper missing and ptrace unavailable; got %v", got)
 	}
 }

--- a/internal/api/family_engine_linux_test.go
+++ b/internal/api/family_engine_linux_test.go
@@ -182,3 +182,92 @@ func TestSelectFamilyEngine_WrapperMissing_NeitherFallback(t *testing.T) {
 		t.Errorf("expected familyEngineNone when wrapper missing and ptrace unavailable; got %v", got)
 	}
 }
+
+// TestResolveFamilyCheckerForPtrace_AlwaysWiresWhenFamiliesConfigured verifies
+// the defensive wiring fix: resolveFamilyCheckerForPtrace must return a
+// non-nil FamilyChecker whenever BlockedSocketFamilies is non-empty,
+// regardless of which engine selectFamilyBlockingEngine would choose.
+// This is the direct regression test for the hybrid-ptrace fail-open bug
+// (see commit message for context).
+func TestResolveFamilyCheckerForPtrace_AlwaysWiresWhenFamiliesConfigured(t *testing.T) {
+	cfg := &config.Config{
+		Sandbox: config.SandboxConfig{
+			Seccomp: config.SandboxSeccompConfig{
+				Enabled: true,
+				BlockedSocketFamilies: []config.SandboxSeccompSocketFamilyConfig{
+					{Family: "AF_ALG", Action: "errno"},
+				},
+			},
+			Ptrace: config.SandboxPtraceConfig{Enabled: true},
+		},
+	}
+
+	checker, err := resolveFamilyCheckerForPtrace(cfg)
+	if err != nil {
+		t.Fatalf("resolveFamilyCheckerForPtrace returned unexpected error: %v", err)
+	}
+	if checker == nil {
+		t.Error("expected non-nil FamilyChecker when BlockedSocketFamilies is configured; got nil (families would fail open)")
+	}
+}
+
+// TestResolveFamilyCheckerForPtrace_NilWhenNoFamilies verifies that no
+// FamilyChecker is created when the blocked families list is empty.
+func TestResolveFamilyCheckerForPtrace_NilWhenNoFamilies(t *testing.T) {
+	cfg := &config.Config{
+		Sandbox: config.SandboxConfig{
+			Seccomp: config.SandboxSeccompConfig{
+				Enabled:               true,
+				BlockedSocketFamilies: nil,
+			},
+			Ptrace: config.SandboxPtraceConfig{Enabled: true},
+		},
+	}
+
+	checker, err := resolveFamilyCheckerForPtrace(cfg)
+	if err != nil {
+		t.Fatalf("resolveFamilyCheckerForPtrace returned unexpected error: %v", err)
+	}
+	if checker != nil {
+		t.Error("expected nil FamilyChecker when BlockedSocketFamilies is empty; got non-nil")
+	}
+}
+
+// TestResolveFamilyCheckerForPtrace_SeccompSelectedEngine verifies the key
+// scenario from the bug report: even when selectFamilyBlockingEngine would
+// choose familyEngineSeccomp (wrapper present, seccomp enabled), the helper
+// still returns a non-nil checker so the ptrace tracer is wired defensively.
+func TestResolveFamilyCheckerForPtrace_SeccompSelectedEngine(t *testing.T) {
+	// Simulate "seccomp would win" from the selector's perspective.
+	withPresentWrapper(t)
+
+	cfg := &config.Config{
+		Sandbox: config.SandboxConfig{
+			Seccomp: config.SandboxSeccompConfig{
+				Enabled: true,
+				BlockedSocketFamilies: []config.SandboxSeccompSocketFamilyConfig{
+					{Family: "AF_ALG", Action: "errno"},
+				},
+			},
+			Ptrace: config.SandboxPtraceConfig{Enabled: true},
+		},
+	}
+
+	// Confirm selector would pick seccomp.
+	families := oneFamilySlice()
+	caps := &capabilities.SecurityCapabilities{Seccomp: true, Ptrace: true}
+	engine := selectFamilyBlockingEngine(families, &cfg.Sandbox, caps)
+	if engine != familyEngineSeccomp {
+		t.Skipf("precondition failed: expected seccomp engine, got %v", engine)
+	}
+
+	// The defensive helper must still wire the checker.
+	checker, err := resolveFamilyCheckerForPtrace(cfg)
+	if err != nil {
+		t.Fatalf("resolveFamilyCheckerForPtrace returned unexpected error: %v", err)
+	}
+	if checker == nil {
+		t.Error("expected non-nil FamilyChecker even when seccomp engine is selected; " +
+			"ptrace tracer must be defensively wired (families would fail open otherwise)")
+	}
+}

--- a/internal/api/family_engine_linux_test.go
+++ b/internal/api/family_engine_linux_test.go
@@ -202,7 +202,7 @@ func TestResolveFamilyCheckerForPtrace_AlwaysWiresWhenFamiliesConfigured(t *test
 		},
 	}
 
-	checker, err := resolveFamilyCheckerForPtrace(cfg)
+	checker, err := resolveFamilyCheckerForPtrace(cfg, nil)
 	if err != nil {
 		t.Fatalf("resolveFamilyCheckerForPtrace returned unexpected error: %v", err)
 	}
@@ -224,7 +224,7 @@ func TestResolveFamilyCheckerForPtrace_NilWhenNoFamilies(t *testing.T) {
 		},
 	}
 
-	checker, err := resolveFamilyCheckerForPtrace(cfg)
+	checker, err := resolveFamilyCheckerForPtrace(cfg, nil)
 	if err != nil {
 		t.Fatalf("resolveFamilyCheckerForPtrace returned unexpected error: %v", err)
 	}
@@ -262,7 +262,7 @@ func TestResolveFamilyCheckerForPtrace_SeccompSelectedEngine(t *testing.T) {
 	}
 
 	// The defensive helper must still wire the checker.
-	checker, err := resolveFamilyCheckerForPtrace(cfg)
+	checker, err := resolveFamilyCheckerForPtrace(cfg, nil)
 	if err != nil {
 		t.Fatalf("resolveFamilyCheckerForPtrace returned unexpected error: %v", err)
 	}

--- a/internal/api/seccomp_wrapper_config.go
+++ b/internal/api/seccomp_wrapper_config.go
@@ -1,22 +1,25 @@
 package api
 
 import (
+	"log/slog"
 	"os"
 
 	"github.com/agentsh/agentsh/internal/capabilities"
 	"github.com/agentsh/agentsh/internal/config"
+	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
 	"github.com/agentsh/agentsh/internal/session"
 )
 
 // seccompWrapperConfig is passed to the agentsh-unixwrap wrapper via
 // AGENTSH_SECCOMP_CONFIG environment variable to configure seccomp-bpf filtering.
 type seccompWrapperConfig struct {
-	UnixSocketEnabled   bool     `json:"unix_socket_enabled"`
-	SignalFilterEnabled bool     `json:"signal_filter_enabled"`
-	ExecveEnabled       bool     `json:"execve_enabled"`
-	FileMonitorEnabled  bool     `json:"file_monitor_enabled"`
-	BlockedSyscalls     []string `json:"blocked_syscalls"`
-	OnBlock             string   `json:"on_block,omitempty"`
+	UnixSocketEnabled   bool                      `json:"unix_socket_enabled"`
+	SignalFilterEnabled bool                      `json:"signal_filter_enabled"`
+	ExecveEnabled       bool                      `json:"execve_enabled"`
+	FileMonitorEnabled  bool                      `json:"file_monitor_enabled"`
+	BlockedSyscalls     []string                  `json:"blocked_syscalls"`
+	BlockedFamilies     []seccompkg.BlockedFamily `json:"blocked_families,omitempty"`
+	OnBlock             string                    `json:"on_block,omitempty"`
 
 	// File monitor sub-options
 	InterceptMetadata bool `json:"intercept_metadata,omitempty"`
@@ -52,6 +55,17 @@ func (a *App) buildSeccompWrapperConfig(s *session.Session, p seccompWrapperPara
 		BlockedSyscalls:     a.cfg.Sandbox.Seccomp.Syscalls.Block,
 		OnBlock:             a.cfg.Sandbox.Seccomp.Syscalls.OnBlock,
 		ServerPID:           os.Getpid(),
+	}
+
+	// Resolve and forward blocked socket families.
+	if len(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies) > 0 {
+		families, err := config.ResolveBlockedFamilies(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies)
+		if err != nil {
+			slog.Warn("seccomp: failed to resolve blocked_socket_families; families will not be blocked",
+				"error", err)
+		} else {
+			seccompCfg.BlockedFamilies = families
+		}
 	}
 
 	fmDefault := config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE, false)

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -467,6 +467,9 @@ func (a *App) mainFilterUsesUserNotify(execveEnabled bool) bool {
 	if blockListUsesNotify(a.cfg.Sandbox.Seccomp.Syscalls.Block, a.cfg.Sandbox.Seccomp.Syscalls.OnBlock) {
 		return true
 	}
+	if blockedFamiliesUsesNotify(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies) {
+		return true
+	}
 	return false
 }
 
@@ -483,6 +486,18 @@ func blockListUsesNotify(block []string, onBlock string) bool {
 		return false
 	}
 	return resolvableBlockListCount(block) > 0
+}
+
+// blockedFamiliesUsesNotify reports whether any BlockedSocketFamilies entry
+// uses an action that requires the userspace notify handler (log or log_and_kill).
+// errno and kill are handled kernel-side and do not require a notify fd.
+func blockedFamiliesUsesNotify(families []config.SandboxSeccompSocketFamilyConfig) bool {
+	for _, f := range families {
+		if f.Action == "log" || f.Action == "log_and_kill" {
+			return true
+		}
+	}
+	return false
 }
 
 // acceptNotifyFD listens on the Unix socket for a single connection from the CLI,

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -1052,3 +1052,126 @@ sandbox:
 		t.Error("back-compat: allow_bind should default to false (security hardening vs prior accidental permissive)")
 	}
 }
+
+// TestBlockedFamiliesUsesNotify verifies that the helper function correctly
+// identifies families that require the userspace notify handler.
+func TestBlockedFamiliesUsesNotify(t *testing.T) {
+	cases := []struct {
+		name     string
+		families []config.SandboxSeccompSocketFamilyConfig
+		want     bool
+	}{
+		{
+			name:     "empty",
+			families: nil,
+			want:     false,
+		},
+		{
+			name:     "errno only",
+			families: []config.SandboxSeccompSocketFamilyConfig{{Family: "AF_ALG", Action: "errno"}},
+			want:     false,
+		},
+		{
+			name:     "kill only",
+			families: []config.SandboxSeccompSocketFamilyConfig{{Family: "AF_ALG", Action: "kill"}},
+			want:     false,
+		},
+		{
+			name:     "log",
+			families: []config.SandboxSeccompSocketFamilyConfig{{Family: "AF_ALG", Action: "log"}},
+			want:     true,
+		},
+		{
+			name:     "log_and_kill",
+			families: []config.SandboxSeccompSocketFamilyConfig{{Family: "AF_ALG", Action: "log_and_kill"}},
+			want:     true,
+		},
+		{
+			name: "mixed: log and errno — log wins",
+			families: []config.SandboxSeccompSocketFamilyConfig{
+				{Family: "AF_ALG", Action: "errno"},
+				{Family: "AF_INET", Action: "log"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := blockedFamiliesUsesNotify(tc.families)
+			if got != tc.want {
+				t.Errorf("blockedFamiliesUsesNotify(%v) = %v, want %v", tc.families, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestMainFilterUsesUserNotify_FamilyLog verifies that mainFilterUsesUserNotify
+// returns true when the config contains a family with a log action, even when
+// all other notify-triggering options are disabled. This guards against the
+// signal-filter stacking bug (#191): if the predicate misses family-log entries,
+// a second USER_NOTIF filter (signal) could be stacked on top of the main one.
+func TestMainFilterUsesUserNotify_FamilyLog(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("mainFilterUsesUserNotify is Linux-only")
+	}
+	cfg := &config.Config{}
+	// All notify features explicitly off.
+	disabled := false
+	cfg.Sandbox.Seccomp.UnixSocket.Enabled = false
+	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &disabled
+	cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata = &disabled
+	// Only a single family with log action.
+	cfg.Sandbox.Seccomp.BlockedSocketFamilies = []config.SandboxSeccompSocketFamilyConfig{
+		{Family: "AF_ALG", Action: "log"},
+	}
+	app := &App{cfg: cfg}
+
+	if !app.mainFilterUsesUserNotify(false) {
+		t.Error("mainFilterUsesUserNotify should return true when a family has log action")
+	}
+}
+
+// TestMainFilterUsesUserNotify_FamilyLogAndKill mirrors TestMainFilterUsesUserNotify_FamilyLog
+// for log_and_kill.
+func TestMainFilterUsesUserNotify_FamilyLogAndKill(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("mainFilterUsesUserNotify is Linux-only")
+	}
+	cfg := &config.Config{}
+	disabled := false
+	cfg.Sandbox.Seccomp.UnixSocket.Enabled = false
+	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &disabled
+	cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata = &disabled
+	cfg.Sandbox.Seccomp.BlockedSocketFamilies = []config.SandboxSeccompSocketFamilyConfig{
+		{Family: "AF_ALG", Action: "log_and_kill"},
+	}
+	app := &App{cfg: cfg}
+
+	if !app.mainFilterUsesUserNotify(false) {
+		t.Error("mainFilterUsesUserNotify should return true when a family has log_and_kill action")
+	}
+}
+
+// TestMainFilterUsesUserNotify_FamilyErrnoAndKill_NoNotify verifies that
+// mainFilterUsesUserNotify returns false when all families use kernel-side
+// actions (errno or kill).
+func TestMainFilterUsesUserNotify_FamilyErrnoAndKill_NoNotify(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("mainFilterUsesUserNotify is Linux-only")
+	}
+	cfg := &config.Config{}
+	disabled := false
+	cfg.Sandbox.Seccomp.UnixSocket.Enabled = false
+	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &disabled
+	cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata = &disabled
+	cfg.Sandbox.Seccomp.BlockedSocketFamilies = []config.SandboxSeccompSocketFamilyConfig{
+		{Family: "AF_ALG", Action: "errno"},
+		{Family: "AF_INET", Action: "kill"},
+	}
+	app := &App{cfg: cfg}
+
+	if app.mainFilterUsesUserNotify(false) {
+		t.Error("mainFilterUsesUserNotify should return false when all families use errno/kill (kernel-side)")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	seccompPkg "github.com/agentsh/agentsh/internal/seccomp"
 	"gopkg.in/yaml.v3"
 )
 
@@ -486,6 +487,13 @@ type SandboxSeccompConfig struct {
 	Syscalls    SandboxSeccompSyscallConfig     `yaml:"syscalls"`
 	Execve      ExecveConfig                    `yaml:"execve"`
 	FileMonitor SandboxSeccompFileMonitorConfig `yaml:"file_monitor"`
+
+	// BlockedSocketFamilies lists AF_* families whose socket/socketpair calls
+	// are intercepted. A nil value (field omitted in YAML) means "apply
+	// defaults"; a non-nil empty slice means "explicitly block nothing"
+	// (opt-out). Populated via applyDefaults from
+	// seccomp.DefaultBlockedFamilies when nil.
+	BlockedSocketFamilies []SandboxSeccompSocketFamilyConfig `yaml:"blocked_socket_families"`
 }
 
 // SandboxSeccompUnixConfig configures unix socket monitoring via seccomp.
@@ -509,6 +517,19 @@ type SandboxSeccompFileMonitorConfig struct {
 	InterceptMetadata  *bool `yaml:"intercept_metadata"`
 	OpenatEmulation    *bool `yaml:"openat_emulation"`
 	BlockIOUring       *bool `yaml:"block_io_uring"`
+}
+
+// SandboxSeccompSocketFamilyConfig describes one blocked socket family entry.
+// Family is an AF_* name (e.g. "AF_ALG") or a numeric string (e.g. "38").
+// Action is one of: errno (default), kill, log, log_and_kill.
+//
+// When blocked_socket_families is omitted from YAML the field is nil and
+// applyDefaults fills it from seccomp.DefaultBlockedFamilies. When the
+// operator sets blocked_socket_families: [] the field is a non-nil empty
+// slice and applyDefaults leaves it untouched (opt-out of all defaults).
+type SandboxSeccompSocketFamilyConfig struct {
+	Family string `yaml:"family"` // AF_* name or numeric string
+	Action string `yaml:"action"` // errno|kill|log|log_and_kill (defaults to errno)
 }
 
 // FileMonitorBoolWithDefault returns the value of a *bool field, or defaultVal if nil.
@@ -1615,6 +1636,21 @@ func applyDefaultsWithSource(cfg *Config, source ConfigSource, configPath string
 			"sethostname",
 			"setdomainname",
 		}
+	}
+
+	// Apply default blocked socket families when seccomp is active and the
+	// operator has not set the field. nil means "unset → apply defaults";
+	// a non-nil empty slice means "explicit opt-out → leave empty".
+	if seccompActive && cfg.Sandbox.Seccomp.BlockedSocketFamilies == nil {
+		defaults := seccompPkg.DefaultBlockedFamilies()
+		families := make([]SandboxSeccompSocketFamilyConfig, 0, len(defaults))
+		for _, bf := range defaults {
+			families = append(families, SandboxSeccompSocketFamilyConfig{
+				Family: bf.Name,
+				Action: string(bf.Action),
+			})
+		}
+		cfg.Sandbox.Seccomp.BlockedSocketFamilies = families
 	}
 
 	// Enable file_monitor by default when seccomp is explicitly enabled,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2232,5 +2232,16 @@ func validateConfig(cfg *Config) error {
 	if err := cfg.Audit.Watchtower.validate(); err != nil {
 		return err
 	}
+	// Validate blocked_socket_families entries.
+	for i, e := range cfg.Sandbox.Seccomp.BlockedSocketFamilies {
+		if _, _, ok := seccompPkg.ParseFamily(e.Family); !ok {
+			return fmt.Errorf("sandbox.seccomp.blocked_socket_families[%d].family: %q is not a valid AF_* name or number", i, e.Family)
+		}
+		if e.Action != "" {
+			if _, ok := seccompPkg.ParseOnBlock(e.Action); !ok {
+				return fmt.Errorf("sandbox.seccomp.blocked_socket_families[%d].action: %q is not valid (allowed: errno, kill, log, log_and_kill)", i, e.Action)
+			}
+		}
+	}
 	return nil
 }

--- a/internal/config/seccomp_families.go
+++ b/internal/config/seccomp_families.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/agentsh/agentsh/internal/seccomp"
+)
+
+// ResolveBlockedFamilies converts YAML-typed entries into the engine-typed
+// slice consumed by FilterConfigFromYAML / FamilyChecker. Empty Action
+// defaults to errno. Caller should have run config validation first;
+// this function returns an error if any entry fails to resolve, but it
+// does not catch unknown-action strings (those degrade to errno via
+// seccomp.ParseOnBlock).
+func ResolveBlockedFamilies(in []SandboxSeccompSocketFamilyConfig) ([]seccomp.BlockedFamily, error) {
+	out := make([]seccomp.BlockedFamily, 0, len(in))
+	for i, e := range in {
+		nr, name, ok := seccomp.ParseFamily(e.Family)
+		if !ok {
+			return nil, fmt.Errorf("blocked_socket_families[%d]: invalid family %q", i, e.Family)
+		}
+		actionStr := e.Action
+		if actionStr == "" {
+			actionStr = string(seccomp.OnBlockErrno)
+		}
+		action, _ := seccomp.ParseOnBlock(actionStr)
+		out = append(out, seccomp.BlockedFamily{
+			Family: nr,
+			Action: action,
+			Name:   name,
+		})
+	}
+	return out, nil
+}

--- a/internal/config/seccomp_families.go
+++ b/internal/config/seccomp_families.go
@@ -8,10 +8,8 @@ import (
 
 // ResolveBlockedFamilies converts YAML-typed entries into the engine-typed
 // slice consumed by FilterConfigFromYAML / FamilyChecker. Empty Action
-// defaults to errno. Caller should have run config validation first;
-// this function returns an error if any entry fails to resolve, but it
-// does not catch unknown-action strings (those degrade to errno via
-// seccomp.ParseOnBlock).
+// defaults to errno. Returns an error if any entry has an unknown family or
+// an invalid action string.
 func ResolveBlockedFamilies(in []SandboxSeccompSocketFamilyConfig) ([]seccomp.BlockedFamily, error) {
 	out := make([]seccomp.BlockedFamily, 0, len(in))
 	for i, e := range in {
@@ -23,7 +21,10 @@ func ResolveBlockedFamilies(in []SandboxSeccompSocketFamilyConfig) ([]seccomp.Bl
 		if actionStr == "" {
 			actionStr = string(seccomp.OnBlockErrno)
 		}
-		action, _ := seccomp.ParseOnBlock(actionStr)
+		action, ok := seccomp.ParseOnBlock(actionStr)
+		if !ok {
+			return nil, fmt.Errorf("blocked_socket_families[%d]: invalid action %q", i, e.Action)
+		}
 		out = append(out, seccomp.BlockedFamily{
 			Family: nr,
 			Action: action,

--- a/internal/config/seccomp_families_test.go
+++ b/internal/config/seccomp_families_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/seccomp"
@@ -37,5 +38,17 @@ func TestResolveBlockedFamilies_RejectsBadEntry(t *testing.T) {
 	_, err := ResolveBlockedFamilies(in)
 	if err == nil {
 		t.Errorf("expected error for bogus family name")
+	}
+}
+
+func TestResolveBlockedFamilies_RejectsBadAction(t *testing.T) {
+	_, err := ResolveBlockedFamilies([]SandboxSeccompSocketFamilyConfig{
+		{Family: "AF_ALG", Action: "deny"}, // not in {errno, kill, log, log_and_kill}
+	})
+	if err == nil {
+		t.Errorf("expected error for invalid action")
+	}
+	if err != nil && !strings.Contains(err.Error(), "deny") {
+		t.Errorf("error should mention bad action; got %v", err)
 	}
 }

--- a/internal/config/seccomp_families_test.go
+++ b/internal/config/seccomp_families_test.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/seccomp"
+)
+
+func TestResolveBlockedFamilies(t *testing.T) {
+	in := []SandboxSeccompSocketFamilyConfig{
+		{Family: "AF_ALG", Action: "errno"},
+		{Family: "40", Action: "kill"},
+		{Family: "AF_VSOCK", Action: ""}, // empty action → defaults to errno
+	}
+	out, err := ResolveBlockedFamilies(in)
+	if err != nil {
+		t.Fatalf("ResolveBlockedFamilies: %v", err)
+	}
+	if len(out) != 3 {
+		t.Fatalf("got %d entries, want 3", len(out))
+	}
+	if out[0].Family != 38 || out[0].Name != "AF_ALG" || out[0].Action != seccomp.OnBlockErrno {
+		t.Errorf("entry 0 wrong: %+v", out[0])
+	}
+	if out[1].Family != 40 || out[1].Name != "" || out[1].Action != seccomp.OnBlockKill {
+		t.Errorf("entry 1 wrong: %+v", out[1])
+	}
+	if out[2].Action != seccomp.OnBlockErrno {
+		t.Errorf("entry 2 default action wrong: %s", out[2].Action)
+	}
+}
+
+func TestResolveBlockedFamilies_RejectsBadEntry(t *testing.T) {
+	in := []SandboxSeccompSocketFamilyConfig{
+		{Family: "BOGUS", Action: "errno"},
+	}
+	_, err := ResolveBlockedFamilies(in)
+	if err == nil {
+		t.Errorf("expected error for bogus family name")
+	}
+}

--- a/internal/config/seccomp_test.go
+++ b/internal/config/seccomp_test.go
@@ -157,3 +157,108 @@ func TestOnBlockValidatorAcceptsLegalValues(t *testing.T) {
 		})
 	}
 }
+
+// TestSandboxSeccompSocketFamilyConfig_DefaultMerge verifies that when
+// blocked_socket_families is omitted (nil slice), applyDefaults populates
+// the list from DefaultBlockedFamilies (including AF_ALG).
+func TestSandboxSeccompSocketFamilyConfig_DefaultMerge(t *testing.T) {
+	cfg := &Config{}
+	cfg.Sandbox.Seccomp.Enabled = true
+	applyDefaults(cfg)
+
+	require.NotEmpty(t, cfg.Sandbox.Seccomp.BlockedSocketFamilies,
+		"expected default-merge to populate BlockedSocketFamilies; got empty")
+
+	found := false
+	for _, e := range cfg.Sandbox.Seccomp.BlockedSocketFamilies {
+		if e.Family == "AF_ALG" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "AF_ALG missing from default BlockedSocketFamilies")
+}
+
+// TestSandboxSeccompSocketFamilyConfig_ExplicitEmptyOptOut verifies that when
+// blocked_socket_families is set to an explicit empty slice (opt-out),
+// applyDefaults does NOT replace it with defaults.
+func TestSandboxSeccompSocketFamilyConfig_ExplicitEmptyOptOut(t *testing.T) {
+	yamlData := []byte(`
+sandbox:
+  seccomp:
+    enabled: true
+    blocked_socket_families: []
+`)
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(yamlData, &cfg))
+	require.NotNil(t, cfg.Sandbox.Seccomp.BlockedSocketFamilies,
+		"explicit [] must parse as non-nil empty slice")
+
+	applyDefaults(&cfg)
+
+	require.Empty(t, cfg.Sandbox.Seccomp.BlockedSocketFamilies,
+		"explicit empty should not be replaced by defaults")
+}
+
+// TestSandboxSeccompSocketFamilyConfig_NonEmptyOverridesDefaults verifies that
+// when the operator provides explicit entries, applyDefaults leaves them alone.
+func TestSandboxSeccompSocketFamilyConfig_NonEmptyOverridesDefaults(t *testing.T) {
+	yamlData := []byte(`
+sandbox:
+  seccomp:
+    enabled: true
+    blocked_socket_families:
+      - family: AF_VSOCK
+        action: errno
+`)
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(yamlData, &cfg))
+
+	applyDefaults(&cfg)
+
+	require.Len(t, cfg.Sandbox.Seccomp.BlockedSocketFamilies, 1,
+		"non-empty should override defaults entirely")
+	require.Equal(t, "AF_VSOCK", cfg.Sandbox.Seccomp.BlockedSocketFamilies[0].Family)
+}
+
+// TestSandboxSeccompSocketFamilyConfig_OmittedWhenSeccompDisabled verifies that
+// defaults are not applied when both seccomp and the unix_sockets wrapper are
+// explicitly disabled (seccompActive is false in that case).
+func TestSandboxSeccompSocketFamilyConfig_OmittedWhenSeccompDisabled(t *testing.T) {
+	yamlData := []byte(`
+sandbox:
+  seccomp:
+    enabled: false
+  unix_sockets:
+    enabled: false
+`)
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(yamlData, &cfg))
+	applyDefaults(&cfg)
+
+	require.Nil(t, cfg.Sandbox.Seccomp.BlockedSocketFamilies,
+		"defaults must not be applied when seccomp is disabled")
+}
+
+// TestSandboxSeccompSocketFamilyConfig_ParseYAML verifies full YAML round-trip
+// for a non-trivial blocked_socket_families list.
+func TestSandboxSeccompSocketFamilyConfig_ParseYAML(t *testing.T) {
+	yamlData := []byte(`
+sandbox:
+  seccomp:
+    enabled: true
+    blocked_socket_families:
+      - family: AF_ALG
+        action: errno
+      - family: AF_VSOCK
+        action: kill
+`)
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(yamlData, &cfg))
+
+	require.Len(t, cfg.Sandbox.Seccomp.BlockedSocketFamilies, 2)
+	require.Equal(t, "AF_ALG", cfg.Sandbox.Seccomp.BlockedSocketFamilies[0].Family)
+	require.Equal(t, "errno", cfg.Sandbox.Seccomp.BlockedSocketFamilies[0].Action)
+	require.Equal(t, "AF_VSOCK", cfg.Sandbox.Seccomp.BlockedSocketFamilies[1].Family)
+	require.Equal(t, "kill", cfg.Sandbox.Seccomp.BlockedSocketFamilies[1].Action)
+}

--- a/internal/config/seccomp_test.go
+++ b/internal/config/seccomp_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -261,4 +262,45 @@ sandbox:
 	require.Equal(t, "errno", cfg.Sandbox.Seccomp.BlockedSocketFamilies[0].Action)
 	require.Equal(t, "AF_VSOCK", cfg.Sandbox.Seccomp.BlockedSocketFamilies[1].Family)
 	require.Equal(t, "kill", cfg.Sandbox.Seccomp.BlockedSocketFamilies[1].Action)
+}
+
+func TestSandboxSeccompSocketFamily_RejectsUnknownName(t *testing.T) {
+	cfg := &Config{}
+	cfg.Sandbox.FUSE.Audit.Mode = "monitor" // satisfy existing FUSE validator
+	cfg.Sandbox.Seccomp.Enabled = true
+	cfg.Sandbox.Seccomp.BlockedSocketFamilies = []SandboxSeccompSocketFamilyConfig{
+		{Family: "AF_NOT_REAL", Action: "errno"},
+	}
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatalf("expected error for unknown family name")
+	}
+	if !strings.Contains(err.Error(), "AF_NOT_REAL") {
+		t.Errorf("error should mention bad name; got %v", err)
+	}
+}
+
+func TestSandboxSeccompSocketFamily_RejectsBadAction(t *testing.T) {
+	cfg := &Config{}
+	cfg.Sandbox.FUSE.Audit.Mode = "monitor"
+	cfg.Sandbox.Seccomp.Enabled = true
+	cfg.Sandbox.Seccomp.BlockedSocketFamilies = []SandboxSeccompSocketFamilyConfig{
+		{Family: "AF_ALG", Action: "deny"}, // "deny" is not in the OnBlockAction enum
+	}
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Errorf("expected error for invalid action")
+	}
+}
+
+func TestSandboxSeccompSocketFamily_AcceptsNumericFamily(t *testing.T) {
+	cfg := &Config{}
+	cfg.Sandbox.FUSE.Audit.Mode = "monitor"
+	cfg.Sandbox.Seccomp.Enabled = true
+	cfg.Sandbox.Seccomp.BlockedSocketFamilies = []SandboxSeccompSocketFamilyConfig{
+		{Family: "38", Action: "errno"},
+	}
+	if err := validateConfig(cfg); err != nil {
+		t.Errorf("numeric family should be accepted; got %v", err)
+	}
 }

--- a/internal/netmonitor/unix/blocklist_linux.go
+++ b/internal/netmonitor/unix/blocklist_linux.go
@@ -393,6 +393,7 @@ func handleFamilyBlockNotify(
 				"action":        string(bf.Action),
 				"outcome":       outcome,
 				"arch":          runtime.GOARCH,
+				"engine":        "seccomp",
 			},
 		}
 		if err := emit.AppendEvent(context.Background(), ev); err != nil {

--- a/internal/netmonitor/unix/blocklist_linux.go
+++ b/internal/netmonitor/unix/blocklist_linux.go
@@ -22,9 +22,23 @@ import (
 
 // BlockListConfig maps seccomp syscall numbers to the on-block action that
 // should be taken when a block-listed syscall traps via USER_NOTIF.
+// FamilyByKey maps (syscall_nr<<32)|af_family → BlockedFamily for log/log_and_kill
+// socket-family rules that also route through the notify handler.
 // A nil receiver is treated as an empty configuration.
 type BlockListConfig struct {
-	ActionByNr map[uint32]seccompkg.OnBlockAction
+	ActionByNr  map[uint32]seccompkg.OnBlockAction
+	FamilyByKey map[uint64]seccompkg.BlockedFamily
+}
+
+// FamilyBlockListed returns the BlockedFamily for the (syscallNr, af_family) pair
+// if it is registered for notify-mode dispatch. Nil receiver returns (_, false).
+func (c *BlockListConfig) FamilyBlockListed(syscallNr uint32, afFamily uint64) (seccompkg.BlockedFamily, bool) {
+	if c == nil || len(c.FamilyByKey) == 0 {
+		return seccompkg.BlockedFamily{}, false
+	}
+	key := uint64(syscallNr)<<32 | afFamily
+	bf, ok := c.FamilyByKey[key]
+	return bf, ok
 }
 
 // notifIDValidFn is a test seam wrapping seccomp.NotifIDValid so unit tests
@@ -304,5 +318,99 @@ func buildSeccompBlockedEvent(
 			"outcome":    outcome,
 			"arch":       runtime.GOARCH,
 		},
+	}
+}
+
+// handleFamilyBlockNotify processes a seccomp notification for a socket/socketpair
+// call whose address-family is in the blocked-family map (log or log_and_kill
+// actions). It mirrors handleBlockListNotify but emits a
+// "seccomp.socket_family_blocked" event type with family-specific fields, and
+// responds with EAFNOSUPPORT (the canonical errno for unsupported address families).
+// For log_and_kill it also SIGKILLs the tracee via pidfd.
+func handleFamilyBlockNotify(
+	ctx context.Context,
+	fd int,
+	req *seccomp.ScmpNotifReq,
+	bf seccompkg.BlockedFamily,
+	sessID string,
+	emit Emitter,
+) {
+	if req == nil {
+		return
+	}
+
+	// TOCTOU check — same convention as handleBlockListNotify.
+	if err := notifIDValidFn(fd, req.ID); err != nil {
+		slog.Debug("seccomp family-block: notif id no longer valid",
+			"session_id", sessID, "pid", req.Pid, "error", err)
+		if derr := NotifRespondDeny(fd, req.ID, int32(unix.EAFNOSUPPORT)); derr != nil && !isENOENT(derr) {
+			slog.Warn("seccomp family-block: deny response failed after invalid id",
+				"session_id", sessID, "pid", req.Pid, "error", derr)
+		}
+		return
+	}
+
+	syscallNr := uint32(req.Data.Syscall)
+	scName := resolveSyscallName(syscallNr)
+	tid := int(req.Pid)
+
+	// For log_and_kill: resolve TGID and SIGKILL before responding.
+	outcome := "denied"
+	if bf.Action == seccompkg.OnBlockLogAndKill {
+		targetPID := tid
+		if tgid, err := resolveTGIDFn(tid); err == nil {
+			targetPID = tgid
+		} else if errors.Is(err, unix.ESRCH) {
+			slog.Debug("seccomp family-block: TGID resolution ESRCH (target already exited)",
+				"session_id", sessID, "tid", tid, "family", bf.Name)
+			targetPID = -1
+		} else {
+			slog.Warn("seccomp family-block: TGID resolution failed; falling back to TID",
+				"session_id", sessID, "tid", tid, "family", bf.Name, "error", err)
+		}
+
+		if targetPID == -1 {
+			outcome = "killed"
+		} else {
+			outcome = attemptKill(fd, req.ID, targetPID, sessID, scName)
+		}
+	}
+
+	// Emit audit event (guarded; nil emitter skips).
+	if emit != nil {
+		ev := types.Event{
+			ID:        fmt.Sprintf("seccomp-%d-%d", tid, time.Now().UnixNano()),
+			Timestamp: time.Now().UTC(),
+			Type:      "seccomp_socket_family_blocked",
+			SessionID: sessID,
+			Source:    "seccomp",
+			PID:       tid,
+			Fields: map[string]any{
+				"family_name":   bf.Name,
+				"family_number": bf.Family,
+				"syscall":       scName,
+				"syscall_nr":    syscallNr,
+				"action":        string(bf.Action),
+				"outcome":       outcome,
+				"arch":          runtime.GOARCH,
+			},
+		}
+		if err := emit.AppendEvent(context.Background(), ev); err != nil {
+			slog.Warn("seccomp family-block: AppendEvent failed",
+				"session_id", sessID, "tid", tid, "family", bf.Name, "error", err)
+		}
+		emit.Publish(ev)
+	}
+
+	// Respond deny with EAFNOSUPPORT. ENOENT after a successful kill is expected.
+	_ = ctx
+	if err := NotifRespondDeny(fd, req.ID, int32(unix.EAFNOSUPPORT)); err != nil {
+		if isENOENT(err) {
+			slog.Debug("seccomp family-block: deny response hit ENOENT (target already gone)",
+				"session_id", sessID, "tid", tid, "family", bf.Name)
+			return
+		}
+		slog.Warn("seccomp family-block: deny response failed",
+			"session_id", sessID, "tid", tid, "family", bf.Name, "error", err)
 	}
 }

--- a/internal/netmonitor/unix/blocklist_linux_test.go
+++ b/internal/netmonitor/unix/blocklist_linux_test.go
@@ -3,6 +3,7 @@
 package unix
 
 import (
+	"context"
 	"os"
 	"runtime"
 	"sync"
@@ -10,6 +11,8 @@ import (
 	"testing"
 
 	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
+	"github.com/agentsh/agentsh/pkg/types"
+	libseccomp "github.com/seccomp/libseccomp-golang"
 	"github.com/stretchr/testify/require"
 	gounix "golang.org/x/sys/unix"
 )
@@ -309,4 +312,78 @@ func TestResolveTGIDFromProc_Nonexistent(t *testing.T) {
 	_, err := resolveTGIDFromProc(0x7FFFFFFF)
 	require.ErrorIs(t, err, gounix.ESRCH,
 		"non-existent TID must surface as ESRCH (not a generic os.ErrNotExist)")
+}
+
+// blocklistTestEmitter is a thread-safe in-memory audit sink for blocklist unit tests.
+type blocklistTestEmitter struct {
+	mu     sync.Mutex
+	events []types.Event
+}
+
+func (e *blocklistTestEmitter) AppendEvent(_ context.Context, ev types.Event) error {
+	e.mu.Lock()
+	e.events = append(e.events, ev)
+	e.mu.Unlock()
+	return nil
+}
+
+func (e *blocklistTestEmitter) Publish(ev types.Event) {
+	e.mu.Lock()
+	e.events = append(e.events, ev)
+	e.mu.Unlock()
+}
+
+func (e *blocklistTestEmitter) Events() []types.Event {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]types.Event, len(e.events))
+	copy(out, e.events)
+	return out
+}
+
+// TestHandleFamilyBlockNotify_EmitsEngineField verifies that handleFamilyBlockNotify
+// emits Fields["engine"]="seccomp" so SIEM consumers can differentiate the
+// seccomp engine from the ptrace engine (which emits engine="ptrace").
+//
+// We use notifIDValidFn (already a test seam) to skip the kernel TOCTOU check.
+// NotifRespondDeny with fd=-1 returns EBADF but the code handles that gracefully
+// (slog.Warn only), so the event is still emitted before the deny call.
+func TestHandleFamilyBlockNotify_EmitsEngineField(t *testing.T) {
+	// Stub notifIDValidFn so the TOCTOU check passes without a real fd.
+	restoreValid := swapNotifIDValidFn(t, func(int, uint64) error { return nil })
+	defer restoreValid()
+
+	bf := seccompkg.BlockedFamily{
+		Family: gounix.AF_ALG,
+		Name:   "AF_ALG",
+		Action: seccompkg.OnBlockLog,
+	}
+	req := &libseccomp.ScmpNotifReq{
+		ID:  42,
+		Pid: 1234,
+		Data: libseccomp.ScmpNotifData{
+			Syscall: libseccomp.ScmpSyscall(gounix.SYS_SOCKET),
+		},
+	}
+
+	sink := &blocklistTestEmitter{}
+	// fd=-1: NotifRespondDeny will fail with EBADF, but that's handled gracefully.
+	handleFamilyBlockNotify(context.Background(), -1, req, bf, "sess-test", sink)
+
+	evts := sink.Events()
+	// AppendEvent and Publish both called — deduplicate by taking first.
+	require.NotEmpty(t, evts, "expected at least one event from handleFamilyBlockNotify")
+
+	ev := evts[0]
+	require.Equal(t, "seccomp_socket_family_blocked", ev.Type)
+	require.Equal(t, "seccomp", ev.Source)
+
+	engine, ok := ev.Fields["engine"]
+	require.True(t, ok, "Fields[\"engine\"] must be present in seccomp family-block event")
+	require.Equal(t, "seccomp", engine, "Fields[\"engine\"] must be \"seccomp\"")
+
+	// Verify the full shape matches the ptrace engine (modulo engine value).
+	require.Equal(t, "AF_ALG", ev.Fields["family_name"])
+	require.Equal(t, "denied", ev.Fields["outcome"])
+	require.Equal(t, string(seccompkg.OnBlockLog), ev.Fields["action"])
 }

--- a/internal/netmonitor/unix/handler.go
+++ b/internal/netmonitor/unix/handler.go
@@ -226,6 +226,22 @@ func ServeNotifyWithExecve(ctx context.Context, fd *os.File, sessID string, pol 
 		syscallNr := int32(req.Data.Syscall)
 		slog.Debug("ServeNotifyWithExecve: received notification", "session_id", sessID, "syscall_nr", syscallNr, "pid", req.Pid, "count", notifCount)
 
+		// Family dispatch FIRST for socket(2)/socketpair(2) — more specific than
+		// the generic syscall blocklist. If the operator configured both a generic
+		// on_block action for "socket" AND a per-family action for e.g. AF_ALG,
+		// the more-specific family rule must win. We check family before the
+		// generic blocklist only for these two syscalls; all others fall through
+		// to the generic check below unchanged.
+		// nil-safe: FamilyBlockListed returns (_, false) on a nil receiver or empty map.
+		if uint32(syscallNr) == uint32(unix.SYS_SOCKET) || uint32(syscallNr) == uint32(unix.SYS_SOCKETPAIR) {
+			if bf, ok := blockList.FamilyBlockListed(uint32(req.Data.Syscall), req.Data.Args[0]); ok {
+				slog.Debug("ServeNotifyWithExecve: routing to family-block handler (pre-blocklist)",
+					"session_id", sessID, "pid", req.Pid, "syscall_nr", syscallNr, "family", bf.Family)
+				handleFamilyBlockNotify(ctx, int(scmpFD), req, bf, sessID, emit)
+				continue
+			}
+		}
+
 		// Block-list dispatch (log / log_and_kill modes). Silent modes (errno, kill)
 		// never reach here — the kernel executes them without a notify trap.
 		// nil-safe: IsBlockListed returns (_, false) on a nil receiver.
@@ -260,16 +276,6 @@ func ServeNotifyWithExecve(ctx context.Context, fd *os.File, sessID string, pol 
 
 		// Existing unix socket handling
 		ctxReq := ExtractContext(req)
-
-		// Family-blocked dispatch: check if this (syscall, arg0/AF) pair is in the
-		// blocked-family map. This runs BEFORE unix-socket dispatch so that
-		// socket/socketpair calls for a blocked family are caught even when
-		// UnixSocketEnabled is also true. The map is only populated for log and
-		// log_and_kill actions; errno/kill are handled kernel-side.
-		if bf, ok := blockList.FamilyBlockListed(uint32(req.Data.Syscall), req.Data.Args[0]); ok {
-			handleFamilyBlockNotify(ctx, int(scmpFD), req, bf, sessID, emit)
-			continue
-		}
 
 		if !isUnixSocketSyscall(ctxReq.Syscall) {
 			slog.Debug("ServeNotifyWithExecve: non-unix syscall, allowing", "session_id", sessID, "syscall", ctxReq.Syscall)

--- a/internal/netmonitor/unix/handler.go
+++ b/internal/netmonitor/unix/handler.go
@@ -260,6 +260,17 @@ func ServeNotifyWithExecve(ctx context.Context, fd *os.File, sessID string, pol 
 
 		// Existing unix socket handling
 		ctxReq := ExtractContext(req)
+
+		// Family-blocked dispatch: check if this (syscall, arg0/AF) pair is in the
+		// blocked-family map. This runs BEFORE unix-socket dispatch so that
+		// socket/socketpair calls for a blocked family are caught even when
+		// UnixSocketEnabled is also true. The map is only populated for log and
+		// log_and_kill actions; errno/kill are handled kernel-side.
+		if bf, ok := blockList.FamilyBlockListed(uint32(req.Data.Syscall), req.Data.Args[0]); ok {
+			handleFamilyBlockNotify(ctx, int(scmpFD), req, bf, sessID, emit)
+			continue
+		}
+
 		if !isUnixSocketSyscall(ctxReq.Syscall) {
 			slog.Debug("ServeNotifyWithExecve: non-unix syscall, allowing", "session_id", sessID, "syscall", ctxReq.Syscall)
 			if err := NotifRespondContinue(int(scmpFD), req.ID); err != nil {

--- a/internal/netmonitor/unix/seccomp_family_test.go
+++ b/internal/netmonitor/unix/seccomp_family_test.go
@@ -352,6 +352,13 @@ func TestSeccompFamilyBlock_Notify_LogDispatched(t *testing.T) {
 	runErr := cmd.Run()
 	combined := out.String()
 
+	// Check for an explicit skip sentinel first — t.Skipf in the child exits
+	// status 0, so runErr is nil even when the child skipped. Without this
+	// check the parent would continue to assertions on empty output and fail.
+	if strings.Contains(combined, "SKIP:") {
+		t.Skipf("child skipped: %s", combined)
+	}
+
 	if runErr != nil {
 		lower := strings.ToLower(combined)
 		if strings.Contains(lower, "permission denied") ||
@@ -507,6 +514,13 @@ func TestFamilyDispatchBeforeGenericBlocklist(t *testing.T) {
 	cmd.Stderr = &out
 	runErr := cmd.Run()
 	combined := out.String()
+
+	// Check for an explicit skip sentinel first — t.Skipf in the child exits
+	// status 0, so runErr is nil even when the child skipped. Without this
+	// check the parent would continue to assertions on empty output and fail.
+	if strings.Contains(combined, "SKIP:") {
+		t.Skipf("child skipped: %s", combined)
+	}
 
 	if runErr != nil {
 		lower := strings.ToLower(combined)

--- a/internal/netmonitor/unix/seccomp_family_test.go
+++ b/internal/netmonitor/unix/seccomp_family_test.go
@@ -1,0 +1,263 @@
+//go:build linux && cgo
+
+package unix
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
+	"golang.org/x/sys/unix"
+)
+
+// familyHelperEnv gates the re-exec body inside the family block tests.
+// Setting it outside of those tests' parent→child dispatch is unsupported.
+const familyHelperEnv = "AGENTSH_TEST_FAMILY_HELPER"
+
+// TestSeccompFamilyBlock_Errno verifies that installing a filter with
+// BlockedFamilies = [{AF_ALG, errno}] causes socket(AF_ALG, ...) to return
+// EAFNOSUPPORT in the process running with that filter.
+//
+// The test re-execs itself as a helper subprocess (keyed by familyHelperEnv)
+// that installs the filter and calls socket(AF_ALG) via a raw syscall,
+// printing the result. This isolates filter installation to the subprocess
+// so the test runner's own filter is not affected.
+func TestSeccompFamilyBlock_Errno(t *testing.T) {
+	if os.Getenv(familyHelperEnv) == familyHelperErrno {
+		runFamilyHelperErrno(t)
+		return
+	}
+
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	cmd := exec.Command(exe, "-test.run=^TestSeccompFamilyBlock_Errno$", "-test.v")
+	cmd.Env = append(os.Environ(), familyHelperEnv+"="+familyHelperErrno)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	runErr := cmd.Run()
+	combined := out.String()
+
+	if runErr != nil {
+		lower := strings.ToLower(combined)
+		if strings.Contains(lower, "permission denied") ||
+			strings.Contains(lower, "operation not permitted") ||
+			strings.Contains(lower, "lacks user notify") {
+			t.Skipf("host cannot install seccomp filter; skipping.\nhelper output:\n%s", combined)
+		}
+		t.Fatalf("helper subprocess failed: %v\noutput:\n%s", runErr, combined)
+	}
+
+	if !strings.Contains(combined, "socket_result=EAFNOSUPPORT") &&
+		!strings.Contains(combined, "socket_result=address family not supported") &&
+		!strings.Contains(combined, "errno=97") {
+		t.Errorf("expected socket(AF_ALG) to return EAFNOSUPPORT (errno 97); helper output:\n%s", combined)
+	}
+}
+
+// runFamilyHelperErrno is the subprocess body for TestSeccompFamilyBlock_Errno.
+// It installs the filter and performs a raw socket(AF_ALG) syscall,
+// printing the errno so the parent can assert the correct result.
+func runFamilyHelperErrno(t *testing.T) {
+	t.Helper()
+	cfg := FilterConfig{
+		BlockedFamilies: []seccompkg.BlockedFamily{
+			{Family: unix.AF_ALG, Action: seccompkg.OnBlockErrno, Name: "AF_ALG"},
+		},
+	}
+	filt, err := InstallFilterWithConfig(cfg)
+	if err != nil {
+		t.Fatalf("InstallFilterWithConfig: %v", err)
+	}
+	defer filt.Close()
+
+	// Raw syscall so the filter interception is visible at the syscall level.
+	fd, _, errno := unix.RawSyscall(unix.SYS_SOCKET, unix.AF_ALG, unix.SOCK_SEQPACKET, 0)
+	if fd != ^uintptr(0) {
+		// Unexpectedly got a valid fd — close it.
+		_ = unix.Close(int(fd))
+		fmt.Printf("socket_result=OK (expected EAFNOSUPPORT)\n")
+		return
+	}
+	// Print both the numeric errno and the stringer form so the parent
+	// can match either. EAFNOSUPPORT=97 on Linux/amd64.
+	fmt.Printf("socket_result=%v (errno=%d)\n", errno, int(errno))
+}
+
+// TestSeccompFamilyBlock_Map_Errno verifies that BlockedFamilyMap is empty
+// for errno-action families (they use ActErrno, not notify — no dispatch needed).
+func TestSeccompFamilyBlock_Map_Errno(t *testing.T) {
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+	cfg := FilterConfig{
+		UnixSocketEnabled: true,
+		BlockedFamilies: []seccompkg.BlockedFamily{
+			{Family: unix.AF_ALG, Action: seccompkg.OnBlockErrno, Name: "AF_ALG"},
+		},
+	}
+	filt, err := InstallFilterWithConfig(cfg)
+	if err != nil {
+		t.Fatalf("InstallFilterWithConfig: %v", err)
+	}
+	defer filt.Close()
+
+	m := filt.BlockedFamilyMap()
+	if len(m) != 0 {
+		t.Errorf("errno-action families must not populate BlockedFamilyMap; got %v", m)
+	}
+}
+
+// TestSeccompFamilyBlock_Map_Log verifies that log-action families populate
+// BlockedFamilyMap with keys for both SYS_SOCKET and SYS_SOCKETPAIR.
+func TestSeccompFamilyBlock_Map_Log(t *testing.T) {
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+	cfg := FilterConfig{
+		UnixSocketEnabled: true,
+		BlockedFamilies: []seccompkg.BlockedFamily{
+			{Family: unix.AF_ALG, Action: seccompkg.OnBlockLog, Name: "AF_ALG"},
+		},
+	}
+	filt, err := InstallFilterWithConfig(cfg)
+	if err != nil {
+		t.Fatalf("InstallFilterWithConfig: %v", err)
+	}
+	defer filt.Close()
+
+	m := filt.BlockedFamilyMap()
+	socketKey := uint64(unix.SYS_SOCKET)<<32 | uint64(unix.AF_ALG)
+	socketpairKey := uint64(unix.SYS_SOCKETPAIR)<<32 | uint64(unix.AF_ALG)
+
+	if _, ok := m[socketKey]; !ok {
+		t.Errorf("BlockedFamilyMap missing SYS_SOCKET|AF_ALG key; map: %v", m)
+	}
+	if _, ok := m[socketpairKey]; !ok {
+		t.Errorf("BlockedFamilyMap missing SYS_SOCKETPAIR|AF_ALG key; map: %v", m)
+	}
+	if len(m) != 2 {
+		t.Errorf("expected exactly 2 map entries (socket+socketpair for AF_ALG); got %d: %v", len(m), m)
+	}
+	if m[socketKey].Name != "AF_ALG" {
+		t.Errorf("map entry name=%q, want AF_ALG", m[socketKey].Name)
+	}
+}
+
+// TestSeccompFamilyBlock_Map_LogAndKill verifies that log_and_kill-action families
+// also populate BlockedFamilyMap (same dispatch path as log).
+func TestSeccompFamilyBlock_Map_LogAndKill(t *testing.T) {
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+	cfg := FilterConfig{
+		UnixSocketEnabled: true,
+		BlockedFamilies: []seccompkg.BlockedFamily{
+			{Family: unix.AF_ALG, Action: seccompkg.OnBlockLogAndKill, Name: "AF_ALG"},
+		},
+	}
+	filt, err := InstallFilterWithConfig(cfg)
+	if err != nil {
+		t.Fatalf("InstallFilterWithConfig: %v", err)
+	}
+	defer filt.Close()
+
+	m := filt.BlockedFamilyMap()
+	if len(m) != 2 {
+		t.Errorf("log_and_kill must populate BlockedFamilyMap; got %d entries: %v", len(m), m)
+	}
+}
+
+// TestSeccompFamilyBlock_Map_Kill verifies that kill-action families do NOT
+// populate BlockedFamilyMap (ActKillProcess, no notify path needed).
+func TestSeccompFamilyBlock_Map_Kill(t *testing.T) {
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+	cfg := FilterConfig{
+		UnixSocketEnabled: true,
+		BlockedFamilies: []seccompkg.BlockedFamily{
+			{Family: unix.AF_ALG, Action: seccompkg.OnBlockKill, Name: "AF_ALG"},
+		},
+	}
+	filt, err := InstallFilterWithConfig(cfg)
+	if err != nil {
+		t.Fatalf("InstallFilterWithConfig: %v", err)
+	}
+	defer filt.Close()
+
+	m := filt.BlockedFamilyMap()
+	if len(m) != 0 {
+		t.Errorf("kill-action families must not populate BlockedFamilyMap; got %v", m)
+	}
+}
+
+// TestSeccompFamilyBlock_Coexistence verifies Section B of the plan:
+// with UnixSocketEnabled=true AND BlockedFamilies=[{AF_ALG, errno}],
+// an AF_ALG socket returns EAFNOSUPPORT (errno path takes precedence
+// over the unconditional ActNotify for socket(2) via libseccomp's
+// action-precedence: ERRNO > NOTIFY).
+//
+// This test installs the filter in-process since it only checks the
+// map state, not actual socket calls (which would trap the test runner).
+func TestSeccompFamilyBlock_Coexistence_MapState(t *testing.T) {
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+	cfg := FilterConfig{
+		UnixSocketEnabled: true,
+		BlockedFamilies: []seccompkg.BlockedFamily{
+			{Family: unix.AF_ALG, Action: seccompkg.OnBlockErrno, Name: "AF_ALG"},
+		},
+	}
+	filt, err := InstallFilterWithConfig(cfg)
+	if err != nil {
+		t.Fatalf("InstallFilterWithConfig: %v", err)
+	}
+	defer filt.Close()
+
+	// The filter should have installed successfully. The important
+	// invariant is that BlockedFamilyMap is empty (errno uses ActErrno,
+	// not notify) and the notify fd is valid (UnixSocketEnabled).
+	m := filt.BlockedFamilyMap()
+	if len(m) != 0 {
+		t.Errorf("errno-action family must not populate notify dispatch map; got %v", m)
+	}
+	if filt.NotifFD() < 0 {
+		t.Errorf("UnixSocketEnabled=true should produce valid notify fd; got %d", filt.NotifFD())
+	}
+}
+
+// TestFamilyToScmpAction verifies the helper maps actions to the
+// correct libseccomp actions without requiring filter installation.
+func TestFamilyToScmpAction(t *testing.T) {
+	cases := []struct {
+		action  seccompkg.OnBlockAction
+		wantErr bool
+	}{
+		{seccompkg.OnBlockErrno, false},
+		{seccompkg.OnBlockKill, false},
+		{seccompkg.OnBlockLog, false},
+		{seccompkg.OnBlockLogAndKill, false},
+		{seccompkg.OnBlockAction("bogus"), true},
+	}
+	for _, c := range cases {
+		_, err := familyToScmpAction(c.action)
+		if (err != nil) != c.wantErr {
+			t.Errorf("familyToScmpAction(%q): err=%v wantErr=%v", c.action, err, c.wantErr)
+		}
+	}
+}
+
+const familyHelperErrno = "errno"

--- a/internal/netmonitor/unix/seccomp_family_test.go
+++ b/internal/netmonitor/unix/seccomp_family_test.go
@@ -264,8 +264,62 @@ func TestFamilyToScmpAction(t *testing.T) {
 	}
 }
 
+// TestFamilyDispatchBeforeGenericBlocklist_Unit is a unit-level guard for the
+// dispatch ordering fix: when both a generic blocklist entry for socket(2) AND
+// a more-specific family entry for AF_ALG are configured, FamilyBlockListed
+// must return true (and thus win) before IsBlockListed is consulted.
+//
+// This does NOT need real seccomp — it exercises only the BlockListConfig
+// lookup methods to prove the dispatch branching in ServeNotifyWithExecve is
+// correct by construction.
+func TestFamilyDispatchBeforeGenericBlocklist_Unit(t *testing.T) {
+	genericAction := seccompkg.OnBlockLog       // generic socket action
+	familyAction := seccompkg.OnBlockLogAndKill // more-specific AF_ALG action
+
+	bl := &BlockListConfig{
+		// Generic blocklist: socket(2) → log
+		ActionByNr: map[uint32]seccompkg.OnBlockAction{
+			uint32(gounix.SYS_SOCKET): genericAction,
+		},
+		// Family blocklist: (socket, AF_ALG) → log_and_kill
+		FamilyByKey: map[uint64]seccompkg.BlockedFamily{
+			uint64(gounix.SYS_SOCKET)<<32 | uint64(gounix.AF_ALG): {
+				Family: gounix.AF_ALG,
+				Action: familyAction,
+				Name:   "AF_ALG",
+			},
+		},
+	}
+
+	// For SYS_SOCKET + AF_ALG: family check should match (and would win).
+	bf, familyMatched := bl.FamilyBlockListed(uint32(gounix.SYS_SOCKET), uint64(gounix.AF_ALG))
+	if !familyMatched {
+		t.Fatal("FamilyBlockListed should match for (SYS_SOCKET, AF_ALG)")
+	}
+	if bf.Action != familyAction {
+		t.Errorf("family action = %q; want %q", bf.Action, familyAction)
+	}
+
+	// Generic check also matches — but dispatch order means family checked first.
+	_, genericMatched := bl.IsBlockListed(uint32(gounix.SYS_SOCKET))
+	if !genericMatched {
+		t.Fatal("IsBlockListed should also match for SYS_SOCKET (sanity check)")
+	}
+
+	// For SYS_SOCKET + AF_INET: family check should NOT match; generic should.
+	_, familyMatchedInet := bl.FamilyBlockListed(uint32(gounix.SYS_SOCKET), uint64(gounix.AF_INET))
+	if familyMatchedInet {
+		t.Error("FamilyBlockListed should NOT match for (SYS_SOCKET, AF_INET)")
+	}
+	_, genericMatchedInet := bl.IsBlockListed(uint32(gounix.SYS_SOCKET))
+	if !genericMatchedInet {
+		t.Error("IsBlockListed should match for SYS_SOCKET even for non-blocked family")
+	}
+}
+
 const familyHelperErrno = "errno"
 const familyHelperNotifyLog = "notify_log"
+const familyHelperFamilyWinsOverBlocklist = "family_wins_over_blocklist"
 
 // TestSeccompFamilyBlock_Notify_LogDispatched verifies that when a filter is
 // installed with BlockedFamilies=[{AF_ALG, log}] and UnixSocketEnabled=false,
@@ -418,5 +472,159 @@ func (e *captureEmitter) AppendEvent(_ context.Context, ev types.Event) error {
 func (e *captureEmitter) Publish(ev types.Event) {
 	if e.fn != nil {
 		e.fn(ev.Type)
+	}
+}
+
+// TestFamilyDispatchBeforeGenericBlocklist verifies the dispatch ordering fix:
+// when a filter has socket(2) in the generic syscall blocklist (on_block=log) AND
+// AF_ALG in blocked_socket_families (action=log — so the process is NOT killed and
+// can print the audit event), the family-specific event type must win.
+//
+// The key assertion: audit event type is seccomp_socket_family_blocked, NOT
+// seccomp_blocked.
+//
+// The test re-execs itself as a helper subprocess. Skip if the host cannot
+// install a seccomp notify filter.
+func TestFamilyDispatchBeforeGenericBlocklist(t *testing.T) {
+	if os.Getenv(familyHelperEnv) == familyHelperFamilyWinsOverBlocklist {
+		runFamilyHelperFamilyWinsOverBlocklist(t)
+		return
+	}
+
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	cmd := exec.Command(exe, "-test.run=^TestFamilyDispatchBeforeGenericBlocklist$", "-test.v")
+	cmd.Env = append(os.Environ(), familyHelperEnv+"="+familyHelperFamilyWinsOverBlocklist)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	runErr := cmd.Run()
+	combined := out.String()
+
+	if runErr != nil {
+		lower := strings.ToLower(combined)
+		if strings.Contains(lower, "permission denied") ||
+			strings.Contains(lower, "operation not permitted") ||
+			strings.Contains(lower, "lacks user notify") ||
+			strings.Contains(lower, "skip") {
+			t.Skipf("host cannot install seccomp filter; skipping.\nhelper output:\n%s", combined)
+		}
+		t.Fatalf("helper subprocess failed: %v\noutput:\n%s", runErr, combined)
+	}
+
+	// Family action must win: audit event is socket_family_blocked, not syscall_blocked.
+	if !strings.Contains(combined, "audit_event=seccomp_socket_family_blocked") {
+		t.Errorf("expected seccomp_socket_family_blocked audit event (family action must win);\nhelper output:\n%s", combined)
+	}
+	if strings.Contains(combined, "audit_event=seccomp_blocked") {
+		t.Errorf("seccomp_blocked event emitted — generic blocklist shadowed family action;\nhelper output:\n%s", combined)
+	}
+}
+
+// runFamilyHelperFamilyWinsOverBlocklist is the subprocess body for
+// TestFamilyDispatchBeforeGenericBlocklist. It installs a filter that has:
+//   - socket(2) in the generic syscall blocklist (on_block=log → notify path)
+//   - AF_ALG in the blocked-family map with action=log (notify path, no kill)
+//
+// Using log (not log_and_kill) for the family action so the process is not
+// killed and can emit the audit event before printing. The test parent verifies
+// that the emitted audit event is seccomp_socket_family_blocked, not
+// seccomp_blocked.
+func runFamilyHelperFamilyWinsOverBlocklist(t *testing.T) {
+	t.Helper()
+
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+
+	// Install a filter with both a generic socket blocklist entry (log) AND a
+	// family-specific entry for AF_ALG (also log, so the process is not killed
+	// and can print results). The family action must win (event type check).
+	cfg := FilterConfig{
+		UnixSocketEnabled: false,
+		BlockedSyscalls:   []int{int(gounix.SYS_SOCKET)},
+		OnBlockAction:     seccompkg.OnBlockLog,
+		BlockedFamilies: []seccompkg.BlockedFamily{
+			{Family: gounix.AF_ALG, Action: seccompkg.OnBlockLog, Name: "AF_ALG"},
+		},
+	}
+	filt, err := InstallFilterWithConfig(cfg)
+	if err != nil {
+		lower := strings.ToLower(err.Error())
+		if strings.Contains(lower, "permission") || strings.Contains(lower, "operation not permitted") {
+			t.Skipf("cannot install seccomp filter (privilege): %v", err)
+		}
+		t.Fatalf("InstallFilterWithConfig: %v", err)
+	}
+	defer filt.Close()
+
+	notifFD := filt.NotifFD()
+	if notifFD < 0 {
+		t.Fatalf("expected valid notify fd; got %d", notifFD)
+	}
+
+	// Build BlockListConfig with both the generic socket action AND the family map.
+	familyByKey := filt.BlockedFamilyMap()
+	if len(familyByKey) == 0 {
+		t.Fatalf("BlockedFamilyMap is empty; log family should populate it")
+	}
+	bl := &BlockListConfig{
+		ActionByNr:  filt.BlockListMap(),
+		FamilyByKey: familyByKey,
+	}
+	if len(bl.ActionByNr) == 0 {
+		t.Fatalf("BlockListMap is empty; log action on socket should populate it")
+	}
+
+	// Collect emitted events.
+	var (
+		mu     sync.Mutex
+		events []string
+	)
+	emitter := &captureEmitter{fn: func(typ string) {
+		mu.Lock()
+		events = append(events, typ)
+		mu.Unlock()
+	}}
+
+	// Run the notify handler in background.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	notifyFile := os.NewFile(uintptr(notifFD), "seccomp-notify")
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		ServeNotifyWithExecve(ctx, notifyFile, "test-family-dispatch-order", nil, emitter, nil, nil, bl)
+	}()
+
+	// Perform the blocked socket call.
+	fd, _, errno := gounix.RawSyscall(gounix.SYS_SOCKET, gounix.AF_ALG, gounix.SOCK_SEQPACKET, 0)
+	if fd != ^uintptr(0) {
+		_ = gounix.Close(int(fd))
+		fmt.Printf("socket_result=OK\n")
+	} else {
+		fmt.Printf("socket_result=%v (errno=%d)\n", errno, int(errno))
+	}
+
+	// Cancel and wait for handler to exit.
+	cancel()
+	select {
+	case <-handlerDone:
+	case <-time.After(2 * time.Second):
+		fmt.Printf("handler did not exit in time\n")
+	}
+
+	// Report emitted events so the parent can assert dispatch routing.
+	mu.Lock()
+	defer mu.Unlock()
+	for _, ev := range events {
+		fmt.Printf("audit_event=%s\n", ev)
 	}
 }

--- a/internal/netmonitor/unix/seccomp_family_test.go
+++ b/internal/netmonitor/unix/seccomp_family_test.go
@@ -4,14 +4,18 @@ package unix
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
-	"golang.org/x/sys/unix"
+	"github.com/agentsh/agentsh/pkg/types"
+	gounix "golang.org/x/sys/unix"
 )
 
 // familyHelperEnv gates the re-exec body inside the family block tests.
@@ -73,7 +77,7 @@ func runFamilyHelperErrno(t *testing.T) {
 	t.Helper()
 	cfg := FilterConfig{
 		BlockedFamilies: []seccompkg.BlockedFamily{
-			{Family: unix.AF_ALG, Action: seccompkg.OnBlockErrno, Name: "AF_ALG"},
+			{Family: gounix.AF_ALG, Action: seccompkg.OnBlockErrno, Name: "AF_ALG"},
 		},
 	}
 	filt, err := InstallFilterWithConfig(cfg)
@@ -83,10 +87,10 @@ func runFamilyHelperErrno(t *testing.T) {
 	defer filt.Close()
 
 	// Raw syscall so the filter interception is visible at the syscall level.
-	fd, _, errno := unix.RawSyscall(unix.SYS_SOCKET, unix.AF_ALG, unix.SOCK_SEQPACKET, 0)
+	fd, _, errno := gounix.RawSyscall(gounix.SYS_SOCKET, gounix.AF_ALG, gounix.SOCK_SEQPACKET, 0)
 	if fd != ^uintptr(0) {
 		// Unexpectedly got a valid fd — close it.
-		_ = unix.Close(int(fd))
+		_ = gounix.Close(int(fd))
 		fmt.Printf("socket_result=OK (expected EAFNOSUPPORT)\n")
 		return
 	}
@@ -104,7 +108,7 @@ func TestSeccompFamilyBlock_Map_Errno(t *testing.T) {
 	cfg := FilterConfig{
 		UnixSocketEnabled: true,
 		BlockedFamilies: []seccompkg.BlockedFamily{
-			{Family: unix.AF_ALG, Action: seccompkg.OnBlockErrno, Name: "AF_ALG"},
+			{Family: gounix.AF_ALG, Action: seccompkg.OnBlockErrno, Name: "AF_ALG"},
 		},
 	}
 	filt, err := InstallFilterWithConfig(cfg)
@@ -128,7 +132,7 @@ func TestSeccompFamilyBlock_Map_Log(t *testing.T) {
 	cfg := FilterConfig{
 		UnixSocketEnabled: true,
 		BlockedFamilies: []seccompkg.BlockedFamily{
-			{Family: unix.AF_ALG, Action: seccompkg.OnBlockLog, Name: "AF_ALG"},
+			{Family: gounix.AF_ALG, Action: seccompkg.OnBlockLog, Name: "AF_ALG"},
 		},
 	}
 	filt, err := InstallFilterWithConfig(cfg)
@@ -138,8 +142,8 @@ func TestSeccompFamilyBlock_Map_Log(t *testing.T) {
 	defer filt.Close()
 
 	m := filt.BlockedFamilyMap()
-	socketKey := uint64(unix.SYS_SOCKET)<<32 | uint64(unix.AF_ALG)
-	socketpairKey := uint64(unix.SYS_SOCKETPAIR)<<32 | uint64(unix.AF_ALG)
+	socketKey := uint64(gounix.SYS_SOCKET)<<32 | uint64(gounix.AF_ALG)
+	socketpairKey := uint64(gounix.SYS_SOCKETPAIR)<<32 | uint64(gounix.AF_ALG)
 
 	if _, ok := m[socketKey]; !ok {
 		t.Errorf("BlockedFamilyMap missing SYS_SOCKET|AF_ALG key; map: %v", m)
@@ -164,7 +168,7 @@ func TestSeccompFamilyBlock_Map_LogAndKill(t *testing.T) {
 	cfg := FilterConfig{
 		UnixSocketEnabled: true,
 		BlockedFamilies: []seccompkg.BlockedFamily{
-			{Family: unix.AF_ALG, Action: seccompkg.OnBlockLogAndKill, Name: "AF_ALG"},
+			{Family: gounix.AF_ALG, Action: seccompkg.OnBlockLogAndKill, Name: "AF_ALG"},
 		},
 	}
 	filt, err := InstallFilterWithConfig(cfg)
@@ -188,7 +192,7 @@ func TestSeccompFamilyBlock_Map_Kill(t *testing.T) {
 	cfg := FilterConfig{
 		UnixSocketEnabled: true,
 		BlockedFamilies: []seccompkg.BlockedFamily{
-			{Family: unix.AF_ALG, Action: seccompkg.OnBlockKill, Name: "AF_ALG"},
+			{Family: gounix.AF_ALG, Action: seccompkg.OnBlockKill, Name: "AF_ALG"},
 		},
 	}
 	filt, err := InstallFilterWithConfig(cfg)
@@ -218,7 +222,7 @@ func TestSeccompFamilyBlock_Coexistence_MapState(t *testing.T) {
 	cfg := FilterConfig{
 		UnixSocketEnabled: true,
 		BlockedFamilies: []seccompkg.BlockedFamily{
-			{Family: unix.AF_ALG, Action: seccompkg.OnBlockErrno, Name: "AF_ALG"},
+			{Family: gounix.AF_ALG, Action: seccompkg.OnBlockErrno, Name: "AF_ALG"},
 		},
 	}
 	filt, err := InstallFilterWithConfig(cfg)
@@ -261,3 +265,158 @@ func TestFamilyToScmpAction(t *testing.T) {
 }
 
 const familyHelperErrno = "errno"
+const familyHelperNotifyLog = "notify_log"
+
+// TestSeccompFamilyBlock_Notify_LogDispatched verifies that when a filter is
+// installed with BlockedFamilies=[{AF_ALG, log}] and UnixSocketEnabled=false,
+// socket(AF_ALG) dispatches through the notify handler and returns EAFNOSUPPORT,
+// and that a seccomp_socket_family_blocked audit event is emitted.
+//
+// The test re-execs itself as a helper subprocess that installs the filter,
+// starts the notify handler, and performs a raw socket(AF_ALG) syscall.
+// Skip if insufficient privileges.
+func TestSeccompFamilyBlock_Notify_LogDispatched(t *testing.T) {
+	if os.Getenv(familyHelperEnv) == familyHelperNotifyLog {
+		runFamilyHelperNotifyLog(t)
+		return
+	}
+
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	cmd := exec.Command(exe, "-test.run=^TestSeccompFamilyBlock_Notify_LogDispatched$", "-test.v")
+	cmd.Env = append(os.Environ(), familyHelperEnv+"="+familyHelperNotifyLog)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	runErr := cmd.Run()
+	combined := out.String()
+
+	if runErr != nil {
+		lower := strings.ToLower(combined)
+		if strings.Contains(lower, "permission denied") ||
+			strings.Contains(lower, "operation not permitted") ||
+			strings.Contains(lower, "lacks user notify") ||
+			strings.Contains(lower, "skip") {
+			t.Skipf("host cannot install seccomp filter; skipping.\nhelper output:\n%s", combined)
+		}
+		t.Fatalf("helper subprocess failed: %v\noutput:\n%s", runErr, combined)
+	}
+
+	if !strings.Contains(combined, "socket_result=EAFNOSUPPORT") &&
+		!strings.Contains(combined, "socket_result=address family not supported") &&
+		!strings.Contains(combined, "errno=97") {
+		t.Errorf("expected socket(AF_ALG) to return EAFNOSUPPORT via notify handler; helper output:\n%s", combined)
+	}
+	if !strings.Contains(combined, "audit_event=seccomp_socket_family_blocked") {
+		t.Errorf("expected seccomp_socket_family_blocked audit event; helper output:\n%s", combined)
+	}
+}
+
+// runFamilyHelperNotifyLog is the subprocess body for TestSeccompFamilyBlock_Notify_LogDispatched.
+// It installs the filter with log action, runs the notify handler, performs a
+// raw socket(AF_ALG) call, and prints the result and audit event type.
+func runFamilyHelperNotifyLog(t *testing.T) {
+	t.Helper()
+
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+
+	cfg := FilterConfig{
+		UnixSocketEnabled: false,
+		BlockedFamilies: []seccompkg.BlockedFamily{
+			{Family: gounix.AF_ALG, Action: seccompkg.OnBlockLog, Name: "AF_ALG"},
+		},
+	}
+	filt, err := InstallFilterWithConfig(cfg)
+	if err != nil {
+		lower := strings.ToLower(err.Error())
+		if strings.Contains(lower, "permission") || strings.Contains(lower, "operation not permitted") {
+			t.Skipf("cannot install seccomp filter (privilege): %v", err)
+		}
+		t.Fatalf("InstallFilterWithConfig: %v", err)
+	}
+	defer filt.Close()
+
+	notifFD := filt.NotifFD()
+	if notifFD < 0 {
+		t.Fatalf("expected valid notify fd; got %d", notifFD)
+	}
+
+	// Build a BlockListConfig carrying the family map.
+	familyByKey := filt.BlockedFamilyMap()
+	if len(familyByKey) == 0 {
+		t.Fatalf("BlockedFamilyMap is empty; log action should populate it")
+	}
+	bl := &BlockListConfig{FamilyByKey: familyByKey}
+
+	// Collect emitted events.
+	type capturedEvent struct{ typ string }
+	var (
+		mu     sync.Mutex
+		events []capturedEvent
+	)
+	emitter := &captureEmitter{fn: func(typ string) {
+		mu.Lock()
+		events = append(events, capturedEvent{typ: typ})
+		mu.Unlock()
+	}}
+
+	// Run the notify handler in background.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	notifyFile := os.NewFile(uintptr(notifFD), "seccomp-notify")
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		ServeNotifyWithExecve(ctx, notifyFile, "test-family-notify", nil, emitter, nil, nil, bl)
+	}()
+
+	// Perform the blocked socket call.
+	fd, _, errno := gounix.RawSyscall(gounix.SYS_SOCKET, gounix.AF_ALG, gounix.SOCK_SEQPACKET, 0)
+	if fd != ^uintptr(0) {
+		_ = gounix.Close(int(fd))
+		fmt.Printf("socket_result=OK (expected EAFNOSUPPORT)\n")
+	} else {
+		fmt.Printf("socket_result=%v (errno=%d)\n", errno, int(errno))
+	}
+
+	// Cancel and wait for handler to exit.
+	cancel()
+	select {
+	case <-handlerDone:
+	case <-time.After(2 * time.Second):
+		fmt.Printf("handler did not exit in time\n")
+	}
+
+	// Report emitted events.
+	mu.Lock()
+	defer mu.Unlock()
+	for _, ev := range events {
+		fmt.Printf("audit_event=%s\n", ev.typ)
+	}
+}
+
+// captureEmitter records the Type field of every emitted event.
+type captureEmitter struct {
+	fn func(typ string)
+}
+
+func (e *captureEmitter) AppendEvent(_ context.Context, ev types.Event) error {
+	if e.fn != nil {
+		e.fn(ev.Type)
+	}
+	return nil
+}
+func (e *captureEmitter) Publish(ev types.Event) {
+	if e.fn != nil {
+		e.fn(ev.Type)
+	}
+}

--- a/internal/netmonitor/unix/seccomp_linux.go
+++ b/internal/netmonitor/unix/seccomp_linux.go
@@ -27,8 +27,9 @@ func DetectSupport() error {
 
 // Filter encapsulates a loaded seccomp user-notify filter and its notify fd.
 type Filter struct {
-	fd        seccomp.ScmpFd
-	blockList map[uint32]seccompkg.OnBlockAction
+	fd               seccomp.ScmpFd
+	blockList        map[uint32]seccompkg.OnBlockAction
+	blockedFamilyMap map[uint64]seccompkg.BlockedFamily
 }
 
 func (f *Filter) Close() error {
@@ -47,6 +48,20 @@ func (f *Filter) BlockListMap() map[uint32]seccompkg.OnBlockAction {
 	}
 	out := make(map[uint32]seccompkg.OnBlockAction, len(f.blockList))
 	for k, v := range f.blockList {
+		out[k] = v
+	}
+	return out
+}
+
+// BlockedFamilyMap returns a copy of the per-family dispatch map
+// (key = (syscall<<32)|family → BlockedFamily) for consumers that need to
+// route log/log_and_kill family notifications. Used by the notify handler.
+func (f *Filter) BlockedFamilyMap() map[uint64]seccompkg.BlockedFamily {
+	if f == nil || len(f.blockedFamilyMap) == 0 {
+		return nil
+	}
+	out := make(map[uint64]seccompkg.BlockedFamily, len(f.blockedFamilyMap))
+	for k, v := range f.blockedFamilyMap {
 		out[k] = v
 	}
 	return out
@@ -221,6 +236,7 @@ type FilterConfig struct {
 	InterceptMetadata  bool  // statx, newfstatat, faccessat2, readlinkat
 	BlockIOUring       bool  // io_uring_setup/enter/register → EPERM
 	BlockedSyscalls    []int // syscall numbers to block; action controlled by OnBlockAction
+	BlockedFamilies    []seccompkg.BlockedFamily
 	OnBlockAction      seccompkg.OnBlockAction
 }
 
@@ -355,6 +371,7 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 			"value", cfg.OnBlockAction)
 	}
 	blockListMap := map[uint32]seccompkg.OnBlockAction{}
+	blockedFamilyMap := map[uint64]seccompkg.BlockedFamily{}
 	switch action {
 	case seccompkg.OnBlockErrno:
 		errnoAction := seccomp.ActErrno.SetReturnCode(int16(unix.EPERM))
@@ -375,6 +392,38 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 				return nil, fmt.Errorf("add blocked notify rule %v: %w", nr, err)
 			}
 			blockListMap[uint32(nr)] = action
+		}
+	}
+
+	// Per-socket-family blocking on socket(2) and socketpair(2).
+	// libseccomp action-precedence (KILL > TRAP > ERRNO > … > NOTIFY) ensures
+	// these conditional rules take priority over the unconditional ActNotify
+	// rule on socket(2) added by UnixSocketEnabled.
+	for _, bf := range cfg.BlockedFamilies {
+		cond := seccomp.ScmpCondition{
+			Argument: 0,
+			Op:       seccomp.CompareEqual,
+			Operand1: uint64(bf.Family),
+		}
+		famAction, err := familyToScmpAction(bf.Action)
+		if err != nil {
+			slog.Warn("seccomp: skipping family rule with unknown action",
+				"family", bf.Name, "action", bf.Action, "error", err)
+			continue
+		}
+		installed := true
+		for _, sc := range []int{unix.SYS_SOCKET, unix.SYS_SOCKETPAIR} {
+			if addErr := filt.AddRuleConditional(
+				seccomp.ScmpSyscall(sc), famAction, []seccomp.ScmpCondition{cond},
+			); addErr != nil {
+				slog.Warn("seccomp: failed to add family rule; family skipped",
+					"family", bf.Name, "syscall", sc, "error", addErr)
+				installed = false
+			}
+		}
+		if installed && (bf.Action == seccompkg.OnBlockLog || bf.Action == seccompkg.OnBlockLogAndKill) {
+			blockedFamilyMap[uint64(unix.SYS_SOCKET)<<32|uint64(bf.Family)] = bf
+			blockedFamilyMap[uint64(unix.SYS_SOCKETPAIR)<<32|uint64(bf.Family)] = bf
 		}
 	}
 
@@ -408,11 +457,26 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 	if err != nil {
 		// If no notify rules, fd will be -1, which is fine
 		if !cfg.UnixSocketEnabled && !cfg.ExecveEnabled && !cfg.FileMonitorEnabled {
-			return &Filter{fd: -1, blockList: blockListMap}, nil
+			return &Filter{fd: -1, blockList: blockListMap, blockedFamilyMap: blockedFamilyMap}, nil
 		}
 		return nil, err
 	}
-	return &Filter{fd: fd, blockList: blockListMap}, nil
+	return &Filter{fd: fd, blockList: blockListMap, blockedFamilyMap: blockedFamilyMap}, nil
+}
+
+// familyToScmpAction maps an OnBlockAction to the libseccomp action used
+// for per-family conditional rules on socket(2)/socketpair(2).
+func familyToScmpAction(a seccompkg.OnBlockAction) (seccomp.ScmpAction, error) {
+	switch a {
+	case seccompkg.OnBlockErrno:
+		return seccomp.ActErrno.SetReturnCode(int16(unix.EAFNOSUPPORT)), nil
+	case seccompkg.OnBlockKill:
+		return seccomp.ActKillProcess, nil
+	case seccompkg.OnBlockLog, seccompkg.OnBlockLogAndKill:
+		return seccomp.ActNotify, nil
+	default:
+		return seccomp.ActAllow, fmt.Errorf("unknown family block action %q", a)
+	}
 }
 
 // loadWithRetryOnWaitKillFailure loads a seccomp filter and, if the load

--- a/internal/ocsf/project_finding.go
+++ b/internal/ocsf/project_finding.go
@@ -50,14 +50,15 @@ func findingProjector(activity uint32, findingType string) Projector {
 
 func init() {
 	findingTypes := map[string]string{
-		"command_policy":            "policy_decision",
-		"seccomp_blocked":           "policy_decision",
-		"agent_detected":            "agent_self_detected",
-		"taint_created":             "taint",
-		"taint_propagated":          "taint",
-		"taint_removed":             "taint",
-		"mcp_cross_server_blocked":  "policy_decision",
-		"mcp_tool_call_intercepted": "policy_decision",
+		"command_policy":                   "policy_decision",
+		"seccomp_blocked":                  "policy_decision",
+		"seccomp_socket_family_blocked":    "policy_decision",
+		"agent_detected":                   "agent_self_detected",
+		"taint_created":                    "taint",
+		"taint_propagated":                 "taint",
+		"taint_removed":                    "taint",
+		"mcp_cross_server_blocked":         "policy_decision",
+		"mcp_tool_call_intercepted":        "policy_decision",
 	}
 	for t, ft := range findingTypes {
 		register(t, Mapping{

--- a/internal/ocsf/registry.go
+++ b/internal/ocsf/registry.go
@@ -75,9 +75,10 @@ var pendingTypes = map[string]struct{}{
 	"dns_query":    {},
 	"dns_redirect": {},
 	// Detection Finding (2004) — Task 21
-	"command_policy":            {},
-	"seccomp_blocked":           {},
-	"agent_detected":            {},
+	"command_policy":                {},
+	"seccomp_blocked":               {},
+	"seccomp_socket_family_blocked": {},
+	"agent_detected":                {},
 	"taint_created":             {},
 	"taint_propagated":          {},
 	"taint_removed":             {},

--- a/internal/ptrace/family_checker.go
+++ b/internal/ptrace/family_checker.go
@@ -67,15 +67,21 @@ var ptraceAlreadyResumed = errors.New("ptrace: tracee already resumed by Apply")
 //	Returns ptraceAlreadyResumed (internal) to signal the tracee
 //	was already continued; the caller must not call allowSyscall.
 //
-// kill:         returns PtraceKillRequested so the caller delivers SIGKILL via
+// kill:         calls unix.Tgkill(tgid, tid, SIGKILL). On success returns
 //
-//	unix.Tgkill; Apply does not kill the process itself.
+//	PtraceKillRequested so the caller calls allowSyscall to let the
+//	killed tracee run until it receives the signal. On ESRCH (process
+//	already vanished) returns nil. On other Tgkill errors, fails closed
+//	by calling denySyscall and returning ptraceAlreadyResumed (or the
+//	deny error if deny also fails).
 //
 // log:          emits a slog event with audit_event=seccomp_socket_family_blocked
 //
-//	(cross-engine audit consistency) and returns nil (allow proceeds).
+//	(cross-engine audit consistency) and then denies the syscall by
+//	calling denySyscall(tid, EAFNOSUPPORT). Log means log-and-deny in
+//	ptrace mode, mirroring the seccomp engine. Returns ptraceAlreadyResumed.
 //
-// log_and_kill: emits the audit event and returns PtraceKillRequested.
+// log_and_kill: emits the audit event and behaves like kill above.
 //
 // On ESRCH from denySyscall (tracee vanished), Apply returns ptraceAlreadyResumed
 // so the caller does not attempt another ptrace call on a dead TID.
@@ -102,16 +108,42 @@ func (c *FamilyChecker) Apply(
 		}
 		return ptraceAlreadyResumed
 
-	case seccomp.OnBlockKill:
+	case seccomp.OnBlockKill, seccomp.OnBlockLogAndKill:
+		if action == seccomp.OnBlockLogAndKill {
+			emitFamilyBlockedLog(tid, syscallNr, bf, action)
+		}
+		if err := unix.Tgkill(tgid, tid, unix.SIGKILL); err != nil {
+			if errors.Is(err, unix.ESRCH) {
+				// Process already vanished; nothing to do.
+				return nil
+			}
+			// Real failure: fail closed — deny the syscall and surface the error.
+			if denyErr := tracer.denySyscall(tid, int(unix.EAFNOSUPPORT)); denyErr != nil {
+				// denySyscall itself failed; log and let caller know tracee state
+				// is uncertain — return ptraceAlreadyResumed to prevent a second
+				// allowSyscall on an indeterminate tracee.
+				slog.Warn("ptrace: tgkill failed and deny fallback also failed",
+					"tid", tid, "tgkill_err", err, "deny_err", denyErr)
+				return ptraceAlreadyResumed
+			}
+			// denySyscall succeeded (tracee already resumed via deny path).
+			slog.Warn("ptrace: tgkill failed; denied syscall instead",
+				"tid", tid, "tgkill_err", err)
+			return ptraceAlreadyResumed
+		}
 		return PtraceKillRequested
 
 	case seccomp.OnBlockLog:
 		emitFamilyBlockedLog(tid, syscallNr, bf, action)
-		return nil
-
-	case seccomp.OnBlockLogAndKill:
-		emitFamilyBlockedLog(tid, syscallNr, bf, action)
-		return PtraceKillRequested
+		// Deny the syscall — log == log_and_deny in ptrace mode, mirroring the
+		// seccomp engine (OnBlockLog denies AND logs there too).
+		if err := tracer.denySyscall(tid, int(unix.EAFNOSUPPORT)); err != nil {
+			if errors.Is(err, unix.ESRCH) {
+				return ptraceAlreadyResumed
+			}
+			return err
+		}
+		return ptraceAlreadyResumed
 
 	default:
 		// Unknown action — fail open: allow the syscall to proceed.

--- a/internal/ptrace/family_checker.go
+++ b/internal/ptrace/family_checker.go
@@ -1,0 +1,45 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"github.com/agentsh/agentsh/internal/seccomp"
+	"golang.org/x/sys/unix"
+)
+
+// FamilyChecker matches socket(2)/socketpair(2) calls against a list of
+// blocked AF_* families. Reuses the same []seccomp.BlockedFamily slice
+// that the seccomp engine consumes — single source of truth.
+type FamilyChecker struct {
+	// bySyscall: SYS_SOCKET / SYS_SOCKETPAIR → family number → entry.
+	bySyscall map[uint64]map[uint64]seccomp.BlockedFamily
+}
+
+// NewFamilyChecker indexes the entries for fast lookup. nil/empty input
+// produces a checker that never matches.
+func NewFamilyChecker(entries []seccomp.BlockedFamily) *FamilyChecker {
+	c := &FamilyChecker{bySyscall: map[uint64]map[uint64]seccomp.BlockedFamily{}}
+	for _, sc := range []uint64{uint64(unix.SYS_SOCKET), uint64(unix.SYS_SOCKETPAIR)} {
+		c.bySyscall[sc] = map[uint64]seccomp.BlockedFamily{}
+	}
+	for _, e := range entries {
+		for sc := range c.bySyscall {
+			c.bySyscall[sc][uint64(e.Family)] = e
+		}
+	}
+	return c
+}
+
+// Check reports the BlockedFamily entry for a given syscall+arg0 pair.
+// ok=false means no rule applies (the syscall should be allowed).
+func (c *FamilyChecker) Check(syscall, arg0 uint64) (seccomp.BlockedFamily, bool) {
+	if c == nil || c.bySyscall == nil {
+		return seccomp.BlockedFamily{}, false
+	}
+	families, ok := c.bySyscall[syscall]
+	if !ok {
+		return seccomp.BlockedFamily{}, false
+	}
+	bf, ok := families[arg0]
+	return bf, ok
+}

--- a/internal/ptrace/family_checker.go
+++ b/internal/ptrace/family_checker.go
@@ -3,6 +3,10 @@
 package ptrace
 
 import (
+	"errors"
+	"log/slog"
+	"runtime"
+
 	"github.com/agentsh/agentsh/internal/seccomp"
 	"golang.org/x/sys/unix"
 )
@@ -42,4 +46,107 @@ func (c *FamilyChecker) Check(syscall, arg0 uint64) (seccomp.BlockedFamily, bool
 	}
 	bf, ok := families[arg0]
 	return bf, ok
+}
+
+// PtraceKillRequested is the sentinel error returned by Apply when the
+// action requires sending SIGKILL to the tracee. The caller is responsible
+// for delivering the signal; Apply does not kill the process itself.
+var PtraceKillRequested = errors.New("ptrace: kill requested by family check")
+
+// ptraceAlreadyResumed is an internal sentinel returned by Apply when
+// the action has already resumed the tracee (e.g., via denySyscall).
+// The caller must not call allowSyscall in this case.
+var ptraceAlreadyResumed = errors.New("ptrace: tracee already resumed by Apply")
+
+// Apply executes the blocking action for a matched family rule against a
+// stopped tracee. The caller has already matched via Check.
+//
+// errno:        calls denySyscall(tid, EAFNOSUPPORT) so the tracer's exit-stop
+//
+//	machinery delivers the correct return value on syscall exit.
+//	Returns ptraceAlreadyResumed (internal) to signal the tracee
+//	was already continued; the caller must not call allowSyscall.
+//
+// kill:         returns PtraceKillRequested so the caller delivers SIGKILL via
+//
+//	unix.Tgkill; Apply does not kill the process itself.
+//
+// log:          emits a slog event with audit_event=seccomp_socket_family_blocked
+//
+//	(cross-engine audit consistency) and returns nil (allow proceeds).
+//
+// log_and_kill: emits the audit event and returns PtraceKillRequested.
+//
+// On ESRCH from denySyscall (tracee vanished), Apply returns ptraceAlreadyResumed
+// so the caller does not attempt another ptrace call on a dead TID.
+func (c *FamilyChecker) Apply(
+	tid int,
+	tgid int,
+	tracer *Tracer,
+	action seccomp.OnBlockAction,
+	syscallNr int,
+	bf seccomp.BlockedFamily,
+) error {
+	switch action {
+	case seccomp.OnBlockErrno:
+		// denySyscall sets ORIG_RAX=-1 and records PendingDenyErrno so the
+		// tracer's exit-stop handler overwrites RAX with -EAFNOSUPPORT.
+		// It also calls unix.PtraceSyscall internally, so the tracee is
+		// already continued — return ptraceAlreadyResumed.
+		if err := tracer.denySyscall(tid, int(unix.EAFNOSUPPORT)); err != nil {
+			// ESRCH means the tracee is already gone — same outcome.
+			if errors.Is(err, unix.ESRCH) {
+				return ptraceAlreadyResumed
+			}
+			return err
+		}
+		return ptraceAlreadyResumed
+
+	case seccomp.OnBlockKill:
+		return PtraceKillRequested
+
+	case seccomp.OnBlockLog:
+		emitFamilyBlockedLog(tid, syscallNr, bf, action)
+		return nil
+
+	case seccomp.OnBlockLogAndKill:
+		emitFamilyBlockedLog(tid, syscallNr, bf, action)
+		return PtraceKillRequested
+
+	default:
+		// Unknown action — fail open: allow the syscall to proceed.
+		return nil
+	}
+}
+
+// emitFamilyBlockedLog emits a structured slog event for a family block.
+// The event type "seccomp_socket_family_blocked" matches the seccomp engine
+// (internal/netmonitor/unix/blocklist_linux.go) for cross-engine SIEM
+// consistency.
+func emitFamilyBlockedLog(tid int, syscallNr int, bf seccomp.BlockedFamily, action seccomp.OnBlockAction) {
+	syscallName := familySyscallName(syscallNr)
+	slog.Info("ptrace: socket family blocked",
+		"audit_event", "seccomp_socket_family_blocked",
+		"family_name", bf.Name,
+		"family_number", bf.Family,
+		"syscall", syscallName,
+		"syscall_nr", syscallNr,
+		"action", string(action),
+		"engine", "ptrace",
+		"pid", tid,
+		"arch", runtime.GOARCH,
+	)
+}
+
+// familySyscallName returns a human-readable name for socket/socketpair.
+// For any other syscall number a numeric sentinel is returned.
+func familySyscallName(nr int) string {
+	switch nr {
+	case unix.SYS_SOCKET:
+		return "socket"
+	case unix.SYS_SOCKETPAIR:
+		return "socketpair"
+	default:
+		return "unknown"
+	}
 }

--- a/internal/ptrace/family_checker.go
+++ b/internal/ptrace/family_checker.go
@@ -3,13 +3,25 @@
 package ptrace
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"runtime"
+	"time"
 
 	"github.com/agentsh/agentsh/internal/seccomp"
+	"github.com/agentsh/agentsh/pkg/types"
 	"golang.org/x/sys/unix"
 )
+
+// FamilyEmitter is the audit-sink interface required by FamilyChecker.
+// It matches the shape used by the seccomp engine
+// (internal/netmonitor/unix.Emitter) so callers can pass the same adapter.
+type FamilyEmitter interface {
+	AppendEvent(ctx context.Context, ev types.Event) error
+	Publish(ev types.Event)
+}
 
 // FamilyChecker matches socket(2)/socketpair(2) calls against a list of
 // blocked AF_* families. Reuses the same []seccomp.BlockedFamily slice
@@ -17,12 +29,25 @@ import (
 type FamilyChecker struct {
 	// bySyscall: SYS_SOCKET / SYS_SOCKETPAIR → family number → entry.
 	bySyscall map[uint64]map[uint64]seccomp.BlockedFamily
+	// emit is the audit sink; nil means skip audit emission (local dev / tests).
+	emit FamilyEmitter
 }
 
 // NewFamilyChecker indexes the entries for fast lookup. nil/empty input
 // produces a checker that never matches.
 func NewFamilyChecker(entries []seccomp.BlockedFamily) *FamilyChecker {
-	c := &FamilyChecker{bySyscall: map[uint64]map[uint64]seccomp.BlockedFamily{}}
+	return NewFamilyCheckerWithEmitter(entries, nil)
+}
+
+// NewFamilyCheckerWithEmitter is like NewFamilyChecker but also wires an
+// audit-sink emitter so that every family-block event reaches the same
+// audit pipeline as the seccomp engine.  Pass nil to skip audit emission
+// (equivalent to NewFamilyChecker).
+func NewFamilyCheckerWithEmitter(entries []seccomp.BlockedFamily, emit FamilyEmitter) *FamilyChecker {
+	c := &FamilyChecker{
+		bySyscall: map[uint64]map[uint64]seccomp.BlockedFamily{},
+		emit:      emit,
+	}
 	for _, sc := range []uint64{uint64(unix.SYS_SOCKET), uint64(unix.SYS_SOCKETPAIR)} {
 		c.bySyscall[sc] = map[uint64]seccomp.BlockedFamily{}
 	}
@@ -75,8 +100,9 @@ var ptraceAlreadyResumed = errors.New("ptrace: tracee already resumed by Apply")
 //	by calling denySyscall and returning ptraceAlreadyResumed (or the
 //	deny error if deny also fails).
 //
-// log:          emits a slog event with audit_event=seccomp_socket_family_blocked
+// log:          emits a types.Event to the audit sink (and slog.Debug for
 //
+//	local diagnostics) with type "seccomp_socket_family_blocked"
 //	(cross-engine audit consistency) and then denies the syscall by
 //	calling denySyscall(tid, EAFNOSUPPORT). Log means log-and-deny in
 //	ptrace mode, mirroring the seccomp engine. Returns ptraceAlreadyResumed.
@@ -92,6 +118,7 @@ func (c *FamilyChecker) Apply(
 	action seccomp.OnBlockAction,
 	syscallNr int,
 	bf seccomp.BlockedFamily,
+	sessionID string,
 ) error {
 	switch action {
 	case seccomp.OnBlockErrno:
@@ -110,7 +137,7 @@ func (c *FamilyChecker) Apply(
 
 	case seccomp.OnBlockKill, seccomp.OnBlockLogAndKill:
 		if action == seccomp.OnBlockLogAndKill {
-			emitFamilyBlockedLog(tid, syscallNr, bf, action)
+			c.emitFamilyBlocked(tid, syscallNr, bf, action, sessionID, "killed")
 		}
 		if err := unix.Tgkill(tgid, tid, unix.SIGKILL); err != nil {
 			if errors.Is(err, unix.ESRCH) {
@@ -134,7 +161,7 @@ func (c *FamilyChecker) Apply(
 		return PtraceKillRequested
 
 	case seccomp.OnBlockLog:
-		emitFamilyBlockedLog(tid, syscallNr, bf, action)
+		c.emitFamilyBlocked(tid, syscallNr, bf, action, sessionID, "denied")
 		// Deny the syscall — log == log_and_deny in ptrace mode, mirroring the
 		// seccomp engine (OnBlockLog denies AND logs there too).
 		if err := tracer.denySyscall(tid, int(unix.EAFNOSUPPORT)); err != nil {
@@ -151,23 +178,61 @@ func (c *FamilyChecker) Apply(
 	}
 }
 
-// emitFamilyBlockedLog emits a structured slog event for a family block.
-// The event type "seccomp_socket_family_blocked" matches the seccomp engine
-// (internal/netmonitor/unix/blocklist_linux.go) for cross-engine SIEM
-// consistency.
-func emitFamilyBlockedLog(tid int, syscallNr int, bf seccomp.BlockedFamily, action seccomp.OnBlockAction) {
+// emitFamilyBlocked emits a types.Event to the audit sink and a slog.Debug
+// line for local diagnostics.  It matches the seccomp engine's event shape
+// exactly (internal/netmonitor/unix/blocklist_linux.go handleFamilyBlockNotify)
+// so SIEM consumers see identical records regardless of which engine fired.
+// The only differentiator is Fields["engine"] = "ptrace".
+//
+// If c.emit is nil the audit-sink emission is skipped; the slog.Debug line
+// is always emitted.
+func (c *FamilyChecker) emitFamilyBlocked(
+	tid int,
+	syscallNr int,
+	bf seccomp.BlockedFamily,
+	action seccomp.OnBlockAction,
+	sessionID string,
+	outcome string,
+) {
 	syscallName := familySyscallName(syscallNr)
-	slog.Info("ptrace: socket family blocked",
-		"audit_event", "seccomp_socket_family_blocked",
+	slog.Debug("ptrace: socket family blocked",
+		"session_id", sessionID,
 		"family_name", bf.Name,
 		"family_number", bf.Family,
 		"syscall", syscallName,
 		"syscall_nr", syscallNr,
 		"action", string(action),
+		"outcome", outcome,
 		"engine", "ptrace",
 		"pid", tid,
 		"arch", runtime.GOARCH,
 	)
+	if c == nil || c.emit == nil {
+		return
+	}
+	ev := types.Event{
+		ID:        fmt.Sprintf("ptrace-%d-%d", tid, time.Now().UnixNano()),
+		Timestamp: time.Now().UTC(),
+		Type:      "seccomp_socket_family_blocked",
+		SessionID: sessionID,
+		Source:    "ptrace",
+		PID:       tid,
+		Fields: map[string]any{
+			"family_name":   bf.Name,
+			"family_number": bf.Family,
+			"syscall":       syscallName,
+			"syscall_nr":    syscallNr,
+			"action":        string(action),
+			"outcome":       outcome,
+			"arch":          runtime.GOARCH,
+			"engine":        "ptrace",
+		},
+	}
+	if err := c.emit.AppendEvent(context.Background(), ev); err != nil {
+		slog.Warn("ptrace family-block: AppendEvent failed",
+			"session_id", sessionID, "tid", tid, "family", bf.Name, "error", err)
+	}
+	c.emit.Publish(ev)
 }
 
 // familySyscallName returns a human-readable name for socket/socketpair.

--- a/internal/ptrace/family_checker.go
+++ b/internal/ptrace/family_checker.go
@@ -202,9 +202,10 @@ func (c *FamilyChecker) Apply(
 		actualOutcome := "denied"
 		if err := denySC(tid, int(unix.EAFNOSUPPORT)); err != nil {
 			if errors.Is(err, unix.ESRCH) {
-				// Tracee vanished: emit with "denied" (the intended outcome) and
-				// return the already-resumed sentinel so the caller does not
-				// attempt another ptrace call.
+				// Tracee vanished: report the actual outcome, not the
+				// intended one. Return the already-resumed sentinel so the
+				// caller does not attempt another ptrace call.
+				actualOutcome = "vanished"
 				c.emitFamilyBlocked(tid, syscallNr, bf, action, sessionID, actualOutcome)
 				return ptraceAlreadyResumed
 			}

--- a/internal/ptrace/family_checker.go
+++ b/internal/ptrace/family_checker.go
@@ -31,6 +31,10 @@ type FamilyChecker struct {
 	bySyscall map[uint64]map[uint64]seccomp.BlockedFamily
 	// emit is the audit sink; nil means skip audit emission (local dev / tests).
 	emit FamilyEmitter
+	// tgkillFn is the test seam for unix.Tgkill. Tests can inject failure paths.
+	tgkillFn func(tgid, tid int, sig unix.Signal) error
+	// denySyscallFn is the test seam for tracer.denySyscall. Tests can inject failure paths.
+	denySyscallFn func(tid int, errno int) error
 }
 
 // NewFamilyChecker indexes the entries for fast lookup. nil/empty input
@@ -47,6 +51,9 @@ func NewFamilyCheckerWithEmitter(entries []seccomp.BlockedFamily, emit FamilyEmi
 	c := &FamilyChecker{
 		bySyscall: map[uint64]map[uint64]seccomp.BlockedFamily{},
 		emit:      emit,
+		tgkillFn: func(tgid, tid int, sig unix.Signal) error {
+			return unix.Tgkill(tgid, tid, sig)
+		},
 	}
 	for _, sc := range []uint64{uint64(unix.SYS_SOCKET), uint64(unix.SYS_SOCKETPAIR)} {
 		c.bySyscall[sc] = map[uint64]seccomp.BlockedFamily{}
@@ -111,6 +118,9 @@ var ptraceAlreadyResumed = errors.New("ptrace: tracee already resumed by Apply")
 //
 // On ESRCH from denySyscall (tracee vanished), Apply returns ptraceAlreadyResumed
 // so the caller does not attempt another ptrace call on a dead TID.
+//
+// The audit event is always emitted AFTER enforcement runs, so outcome reflects
+// what actually happened — not just what was intended.
 func (c *FamilyChecker) Apply(
 	tid int,
 	tgid int,
@@ -120,13 +130,22 @@ func (c *FamilyChecker) Apply(
 	bf seccomp.BlockedFamily,
 	sessionID string,
 ) error {
+	// denySC is the effective deny function: prefer the injected seam (tests),
+	// fall back to the real tracer method (production).
+	denySC := c.denySyscallFn
+	if denySC == nil {
+		denySC = func(t int, errno int) error {
+			return tracer.denySyscall(t, errno)
+		}
+	}
+
 	switch action {
 	case seccomp.OnBlockErrno:
 		// denySyscall sets ORIG_RAX=-1 and records PendingDenyErrno so the
 		// tracer's exit-stop handler overwrites RAX with -EAFNOSUPPORT.
 		// It also calls unix.PtraceSyscall internally, so the tracee is
 		// already continued — return ptraceAlreadyResumed.
-		if err := tracer.denySyscall(tid, int(unix.EAFNOSUPPORT)); err != nil {
+		if err := denySC(tid, int(unix.EAFNOSUPPORT)); err != nil {
 			// ESRCH means the tracee is already gone — same outcome.
 			if errors.Is(err, unix.ESRCH) {
 				return ptraceAlreadyResumed
@@ -136,40 +155,64 @@ func (c *FamilyChecker) Apply(
 		return ptraceAlreadyResumed
 
 	case seccomp.OnBlockKill, seccomp.OnBlockLogAndKill:
-		if action == seccomp.OnBlockLogAndKill {
-			c.emitFamilyBlocked(tid, syscallNr, bf, action, sessionID, "killed")
-		}
-		if err := unix.Tgkill(tgid, tid, unix.SIGKILL); err != nil {
-			if errors.Is(err, unix.ESRCH) {
-				// Process already vanished; nothing to do.
-				return nil
+		// Run enforcement first, then emit event with the actual outcome.
+		tgkill := c.tgkillFn
+		if tgkill == nil {
+			tgkill = func(tg, t int, sig unix.Signal) error {
+				return unix.Tgkill(tg, t, sig)
 			}
-			// Real failure: fail closed — deny the syscall and surface the error.
-			if denyErr := tracer.denySyscall(tid, int(unix.EAFNOSUPPORT)); denyErr != nil {
+		}
+
+		err := tgkill(tgid, tid, unix.SIGKILL)
+		var actualOutcome string
+		var retErr error
+
+		if err == nil {
+			actualOutcome = "killed"
+			retErr = PtraceKillRequested
+		} else if errors.Is(err, unix.ESRCH) {
+			// Process already vanished; nothing to do.
+			actualOutcome = "vanished"
+			retErr = nil
+		} else {
+			// Real Tgkill failure: fail closed — deny the syscall.
+			if denyErr := denySC(tid, int(unix.EAFNOSUPPORT)); denyErr != nil {
 				// denySyscall itself failed; log and let caller know tracee state
 				// is uncertain — return ptraceAlreadyResumed to prevent a second
 				// allowSyscall on an indeterminate tracee.
 				slog.Warn("ptrace: tgkill failed and deny fallback also failed",
 					"tid", tid, "tgkill_err", err, "deny_err", denyErr)
-				return ptraceAlreadyResumed
+				actualOutcome = "deny_fallback_failed"
+			} else {
+				// denySyscall succeeded (tracee already resumed via deny path).
+				slog.Warn("ptrace: tgkill failed; denied syscall instead",
+					"tid", tid, "tgkill_err", err)
+				actualOutcome = "denied"
 			}
-			// denySyscall succeeded (tracee already resumed via deny path).
-			slog.Warn("ptrace: tgkill failed; denied syscall instead",
-				"tid", tid, "tgkill_err", err)
-			return ptraceAlreadyResumed
+			retErr = ptraceAlreadyResumed
 		}
-		return PtraceKillRequested
+
+		if action == seccomp.OnBlockLogAndKill {
+			c.emitFamilyBlocked(tid, syscallNr, bf, action, sessionID, actualOutcome)
+		}
+		return retErr
 
 	case seccomp.OnBlockLog:
-		c.emitFamilyBlocked(tid, syscallNr, bf, action, sessionID, "denied")
-		// Deny the syscall — log == log_and_deny in ptrace mode, mirroring the
-		// seccomp engine (OnBlockLog denies AND logs there too).
-		if err := tracer.denySyscall(tid, int(unix.EAFNOSUPPORT)); err != nil {
+		// Run enforcement first, then emit with the actual outcome.
+		actualOutcome := "denied"
+		if err := denySC(tid, int(unix.EAFNOSUPPORT)); err != nil {
 			if errors.Is(err, unix.ESRCH) {
+				// Tracee vanished: emit with "denied" (the intended outcome) and
+				// return the already-resumed sentinel so the caller does not
+				// attempt another ptrace call.
+				c.emitFamilyBlocked(tid, syscallNr, bf, action, sessionID, actualOutcome)
 				return ptraceAlreadyResumed
 			}
+			actualOutcome = "deny_failed"
+			c.emitFamilyBlocked(tid, syscallNr, bf, action, sessionID, actualOutcome)
 			return err
 		}
+		c.emitFamilyBlocked(tid, syscallNr, bf, action, sessionID, actualOutcome)
 		return ptraceAlreadyResumed
 
 	default:

--- a/internal/ptrace/family_checker_integration_test.go
+++ b/internal/ptrace/family_checker_integration_test.go
@@ -57,6 +57,64 @@ func main() {
 }
 `
 
+// socketInetHelperSrc is a minimal Go program that calls socket(AF_INET,
+// SOCK_STREAM, 0) and reports whether it returned a valid fd.
+// Used by TestIntegration_FamilyChecker_AllowNonBlocked.
+const socketInetHelperSrc = `//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+	"syscall"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: socket-inet-helper <ready-file>")
+		os.Exit(1)
+	}
+	readyFile := os.Args[1]
+
+	// Wait for the ready file (max 10s).
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(readyFile); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// AF_INET = 2; SOCK_STREAM = 1
+	fd, _, errno := syscall.RawSyscall(syscall.SYS_SOCKET, 2, 1, 0)
+	if errno != 0 {
+		fmt.Printf("socket_result=ERRNO errno=%d\n", int(errno))
+		return
+	}
+	syscall.Close(int(fd))
+	fmt.Printf("socket_result=OK fd=%d\n", int(fd))
+}
+`
+
+// buildSocketInetHelper compiles socketInetHelperSrc in a temp dir and
+// returns the binary path.
+func buildSocketInetHelper(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	src := tmpDir + "/main.go"
+	bin := tmpDir + "/socket-inet-helper"
+	if err := os.WriteFile(src, []byte(socketInetHelperSrc), 0644); err != nil {
+		t.Fatalf("write socket inet helper src: %v", err)
+	}
+	out, err := exec.Command("go", "build", "-o", bin, src).CombinedOutput()
+	if err != nil {
+		t.Fatalf("build socket inet helper: %v\n%s", err, out)
+	}
+	return bin
+}
+
 // buildSocketHelper compiles socketHelperSrc in a temp dir and returns the binary path.
 func buildSocketHelper(t *testing.T) string {
 	t.Helper()
@@ -163,55 +221,31 @@ func TestIntegration_FamilyChecker_Errno(t *testing.T) {
 func TestIntegration_FamilyChecker_AllowNonBlocked(t *testing.T) {
 	requirePtrace(t)
 
+	helperBin := buildSocketInetHelper(t)
+	tmpDir := t.TempDir()
+
 	checker := NewFamilyChecker([]seccomp.BlockedFamily{
 		{Family: unix.AF_ALG, Action: seccomp.OnBlockErrno, Name: "AF_ALG"},
 	})
-	netHandler := &mockNetworkHandler{defaultAllow: true}
+	result := runWithFamilyChecker(t, TracerConfig{
+		TraceExecve:   true,
+		FamilyChecker: checker,
+		ExecHandler:   &mockExecHandler{defaultAllow: true},
+	}, helperBin, tmpDir+"/ready1", tmpDir+"/ready2", tmpDir+"/result.txt")
+	t.Logf("ptrace allow-non-blocked result: %s", result)
 
-	tmpDir := t.TempDir()
-	readyFile := tmpDir + "/ready"
-
-	tr := NewTracer(TracerConfig{
-		TraceExecve:    true,
-		TraceNetwork:   true,
-		FamilyChecker:  checker,
-		ExecHandler:    &mockExecHandler{defaultAllow: true},
-		NetworkHandler: netHandler,
-	})
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	errCh := make(chan error, 1)
-	go func() { errCh <- tr.Run(ctx) }()
-
-	shellCmd := fmt.Sprintf(
-		`while [ ! -f %s ]; do sleep 0.01; done; (echo | nc -n -w1 127.0.0.1 1 2>/dev/null); true`,
-		readyFile,
-	)
-	cmd := exec.Command("/bin/sh", "-c", shellCmd)
-	if err := cmd.Start(); err != nil {
-		t.Fatal(err)
+	// AF_INET must pass through unblocked: the helper should return a valid fd.
+	if !strings.Contains(result, "socket_result=OK") {
+		t.Errorf("expected socket(AF_INET) to succeed (non-blocked family); got: %q", result)
 	}
-	pid := cmd.Process.Pid
-	cmd.Process.Release()
-
-	tr.AttachPID(pid)
-	if !waitForAttach(t, tr, 2*time.Second) {
-		t.Skip("could not attach in time")
+	if strings.Contains(result, "ERRNO") || strings.Contains(result, "errno=97") {
+		t.Errorf("socket(AF_INET) was erroneously blocked by FamilyChecker; got: %q", result)
 	}
-	os.WriteFile(readyFile, []byte("go"), 0644)
-
-	waitForTraceesDrained(t, tr, 8*time.Second)
-	cancel()
-	<-errCh
-
-	calls := netHandler.CallCount()
-	t.Logf("network handler calls (AF_INET connect): %d", calls)
 }
 
-// TestIntegration_FamilyChecker_Log verifies that action=log does NOT inject
-// EAFNOSUPPORT — the syscall is allowed to proceed to the kernel.
+// TestIntegration_FamilyChecker_Log verifies that action=log denies the
+// syscall (returns EAFNOSUPPORT) AND emits the audit event — mirroring the
+// seccomp engine, where OnBlockLog means log-and-deny.
 func TestIntegration_FamilyChecker_Log(t *testing.T) {
 	requirePtrace(t)
 
@@ -228,9 +262,13 @@ func TestIntegration_FamilyChecker_Log(t *testing.T) {
 	}, helperBin, tmpDir+"/ready1", tmpDir+"/ready2", tmpDir+"/result.txt")
 	t.Logf("ptrace log-action result: %s", result)
 
-	// With log action the tracer must NOT inject EAFNOSUPPORT.
-	if strings.Contains(result, "errno=97") {
-		t.Errorf("log action must not inject EAFNOSUPPORT (errno 97); got: %q", result)
+	// With log action the tracer must inject EAFNOSUPPORT (log == log_and_deny).
+	if !strings.Contains(result, "EAFNOSUPPORT") &&
+		!strings.Contains(result, "address family not supported") &&
+		!strings.Contains(result, "errno=97") {
+		t.Errorf("log action must deny socket(AF_ALG) with EAFNOSUPPORT; got: %q", result)
 	}
-	t.Log("log action: tracer allowed the syscall (audit event logged to slog)")
+	if result == "socket_result=OK" {
+		t.Errorf("socket(AF_ALG) was NOT blocked by FamilyChecker (log action must deny); got: %q", result)
+	}
 }

--- a/internal/ptrace/family_checker_integration_test.go
+++ b/internal/ptrace/family_checker_integration_test.go
@@ -1,0 +1,236 @@
+//go:build integration && linux
+
+package ptrace
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/seccomp"
+	"golang.org/x/sys/unix"
+)
+
+// socketHelperSrc is a minimal Go program that waits for a ready file then calls
+// socket(AF_ALG) via a raw syscall, printing the errno result. The ready file
+// is a SECOND gate written by the test AFTER the exec event is confirmed — see
+// the two-stage sync pattern in runWithFamilyChecker.
+const socketHelperSrc = `//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+	"syscall"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: socket-helper <ready-file>")
+		os.Exit(1)
+	}
+	readyFile := os.Args[1]
+
+	// Wait for the ready file (max 10s).
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(readyFile); err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// AF_ALG = 38; SOCK_SEQPACKET = 5
+	fd, _, errno := syscall.RawSyscall(syscall.SYS_SOCKET, 38, 5, 0)
+	if fd != ^uintptr(0) {
+		syscall.Close(int(fd))
+		fmt.Printf("socket_result=OK\n")
+		return
+	}
+	fmt.Printf("socket_result=%v (errno=%d)\n", errno, int(errno))
+}
+`
+
+// buildSocketHelper compiles socketHelperSrc in a temp dir and returns the binary path.
+func buildSocketHelper(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	src := tmpDir + "/main.go"
+	bin := tmpDir + "/socket-helper"
+	if err := os.WriteFile(src, []byte(socketHelperSrc), 0644); err != nil {
+		t.Fatalf("write socket helper src: %v", err)
+	}
+	out, err := exec.Command("go", "build", "-o", bin, src).CombinedOutput()
+	if err != nil {
+		t.Fatalf("build socket helper: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// runWithFamilyChecker sets up a tracer with the given config, starts the helper
+// via a two-stage ready-file sync, and returns the contents of outFile.
+//
+// Two-stage sync:
+//  1. Shell waits for readyFile1 → after the tracer is attached.
+//  2. Shell execs helperBin, which waits for readyFile2 → written by the
+//     test after a 200ms pause to let the exec event propagate through the
+//     tracer. This ensures the helper's socket() call is seen under ptrace.
+func runWithFamilyChecker(t *testing.T, cfg TracerConfig, helperBin, readyFile1, readyFile2, outFile string) string {
+	t.Helper()
+	tr := NewTracer(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- tr.Run(ctx) }()
+
+	// Stage 1: shell waits for readyFile1, then execs helperBin with readyFile2.
+	// helperBin writes to outFile.
+	cmd := exec.Command("/bin/sh", "-c",
+		fmt.Sprintf("while [ ! -f %s ]; do sleep 0.01; done; exec %s %s > %s 2>&1",
+			readyFile1, helperBin, readyFile2, outFile))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
+
+	tr.AttachPID(pid)
+	if !waitForAttach(t, tr, 3*time.Second) {
+		cancel()
+		<-errCh
+		t.Skip("could not attach to shell in time")
+	}
+
+	// Stage 2: write readyFile1 to let the shell exec the helper.
+	os.WriteFile(readyFile1, []byte("go"), 0644)
+
+	// Pause 200ms so the exec event (PTRACE_EVENT_EXEC) propagates through
+	// the tracer's event loop before we signal the helper to proceed.
+	time.Sleep(200 * time.Millisecond)
+
+	// Now write readyFile2 so the helper binary calls socket().
+	os.WriteFile(readyFile2, []byte("go"), 0644)
+
+	waitForTraceesDrained(t, tr, 15*time.Second)
+	cancel()
+	<-errCh
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("result file not found: %v", err)
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// TestIntegration_FamilyChecker_Errno verifies that a tracer configured with
+// FamilyChecker([{AF_ALG, errno}]) causes a tracee's socket(AF_ALG, ...)
+// call to return EAFNOSUPPORT.
+func TestIntegration_FamilyChecker_Errno(t *testing.T) {
+	requirePtrace(t)
+
+	helperBin := buildSocketHelper(t)
+	tmpDir := t.TempDir()
+
+	checker := NewFamilyChecker([]seccomp.BlockedFamily{
+		{Family: unix.AF_ALG, Action: seccomp.OnBlockErrno, Name: "AF_ALG"},
+	})
+	result := runWithFamilyChecker(t, TracerConfig{
+		TraceExecve:   true,
+		FamilyChecker: checker,
+		ExecHandler:   &mockExecHandler{defaultAllow: true},
+	}, helperBin, tmpDir+"/ready1", tmpDir+"/ready2", tmpDir+"/result.txt")
+	t.Logf("ptrace errno-action result: %s", result)
+
+	// The tracer must inject EAFNOSUPPORT.
+	if !strings.Contains(result, "EAFNOSUPPORT") &&
+		!strings.Contains(result, "address family not supported") &&
+		!strings.Contains(result, "errno=97") {
+		t.Errorf("expected socket(AF_ALG) to return EAFNOSUPPORT from FamilyChecker; got: %q", result)
+	}
+	if result == "socket_result=OK" {
+		t.Errorf("socket(AF_ALG) was NOT blocked by FamilyChecker (errno action returned OK)")
+	}
+}
+
+// TestIntegration_FamilyChecker_AllowNonBlocked verifies that AF_INET socket
+// calls are NOT blocked when FamilyChecker only blocks AF_ALG.
+func TestIntegration_FamilyChecker_AllowNonBlocked(t *testing.T) {
+	requirePtrace(t)
+
+	checker := NewFamilyChecker([]seccomp.BlockedFamily{
+		{Family: unix.AF_ALG, Action: seccomp.OnBlockErrno, Name: "AF_ALG"},
+	})
+	netHandler := &mockNetworkHandler{defaultAllow: true}
+
+	tmpDir := t.TempDir()
+	readyFile := tmpDir + "/ready"
+
+	tr := NewTracer(TracerConfig{
+		TraceExecve:    true,
+		TraceNetwork:   true,
+		FamilyChecker:  checker,
+		ExecHandler:    &mockExecHandler{defaultAllow: true},
+		NetworkHandler: netHandler,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- tr.Run(ctx) }()
+
+	shellCmd := fmt.Sprintf(
+		`while [ ! -f %s ]; do sleep 0.01; done; (echo | nc -n -w1 127.0.0.1 1 2>/dev/null); true`,
+		readyFile,
+	)
+	cmd := exec.Command("/bin/sh", "-c", shellCmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
+
+	tr.AttachPID(pid)
+	if !waitForAttach(t, tr, 2*time.Second) {
+		t.Skip("could not attach in time")
+	}
+	os.WriteFile(readyFile, []byte("go"), 0644)
+
+	waitForTraceesDrained(t, tr, 8*time.Second)
+	cancel()
+	<-errCh
+
+	calls := netHandler.CallCount()
+	t.Logf("network handler calls (AF_INET connect): %d", calls)
+}
+
+// TestIntegration_FamilyChecker_Log verifies that action=log does NOT inject
+// EAFNOSUPPORT — the syscall is allowed to proceed to the kernel.
+func TestIntegration_FamilyChecker_Log(t *testing.T) {
+	requirePtrace(t)
+
+	helperBin := buildSocketHelper(t)
+	tmpDir := t.TempDir()
+
+	checker := NewFamilyChecker([]seccomp.BlockedFamily{
+		{Family: unix.AF_ALG, Action: seccomp.OnBlockLog, Name: "AF_ALG"},
+	})
+	result := runWithFamilyChecker(t, TracerConfig{
+		TraceExecve:   true,
+		FamilyChecker: checker,
+		ExecHandler:   &mockExecHandler{defaultAllow: true},
+	}, helperBin, tmpDir+"/ready1", tmpDir+"/ready2", tmpDir+"/result.txt")
+	t.Logf("ptrace log-action result: %s", result)
+
+	// With log action the tracer must NOT inject EAFNOSUPPORT.
+	if strings.Contains(result, "errno=97") {
+		t.Errorf("log action must not inject EAFNOSUPPORT (errno 97); got: %q", result)
+	}
+	t.Log("log action: tracer allowed the syscall (audit event logged to slog)")
+}

--- a/internal/ptrace/family_checker_integration_test.go
+++ b/internal/ptrace/family_checker_integration_test.go
@@ -8,12 +8,49 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/agentsh/agentsh/internal/seccomp"
+	"github.com/agentsh/agentsh/pkg/types"
 	"golang.org/x/sys/unix"
 )
+
+// fakeEmitter is a thread-safe in-memory audit sink for tests.
+type fakeEmitter struct {
+	mu     sync.Mutex
+	events []types.Event
+}
+
+func (f *fakeEmitter) AppendEvent(_ context.Context, ev types.Event) error {
+	f.mu.Lock()
+	f.events = append(f.events, ev)
+	f.mu.Unlock()
+	return nil
+}
+
+func (f *fakeEmitter) Publish(ev types.Event) {
+	f.mu.Lock()
+	// Publish is also captured so tests can assert it was called.
+	// We deduplicate by ID to avoid double-counting.
+	for _, existing := range f.events {
+		if existing.ID == ev.ID {
+			f.mu.Unlock()
+			return
+		}
+	}
+	f.events = append(f.events, ev)
+	f.mu.Unlock()
+}
+
+func (f *fakeEmitter) Events() []types.Event {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]types.Event, len(f.events))
+	copy(out, f.events)
+	return out
+}
 
 // socketHelperSrc is a minimal Go program that waits for a ready file then calls
 // socket(AF_ALG) via a raw syscall, printing the errno result. The ready file
@@ -244,17 +281,19 @@ func TestIntegration_FamilyChecker_AllowNonBlocked(t *testing.T) {
 }
 
 // TestIntegration_FamilyChecker_Log verifies that action=log denies the
-// syscall (returns EAFNOSUPPORT) AND emits the audit event — mirroring the
-// seccomp engine, where OnBlockLog means log-and-deny.
+// syscall (returns EAFNOSUPPORT) AND emits a types.Event to the audit sink
+// with the same shape as the seccomp engine — mirroring the spec guarantee
+// that operators see the same SIEM signal regardless of which engine fired.
 func TestIntegration_FamilyChecker_Log(t *testing.T) {
 	requirePtrace(t)
 
 	helperBin := buildSocketHelper(t)
 	tmpDir := t.TempDir()
 
-	checker := NewFamilyChecker([]seccomp.BlockedFamily{
+	sink := &fakeEmitter{}
+	checker := NewFamilyCheckerWithEmitter([]seccomp.BlockedFamily{
 		{Family: unix.AF_ALG, Action: seccomp.OnBlockLog, Name: "AF_ALG"},
-	})
+	}, sink)
 	result := runWithFamilyChecker(t, TracerConfig{
 		TraceExecve:   true,
 		FamilyChecker: checker,
@@ -270,5 +309,42 @@ func TestIntegration_FamilyChecker_Log(t *testing.T) {
 	}
 	if result == "socket_result=OK" {
 		t.Errorf("socket(AF_ALG) was NOT blocked by FamilyChecker (log action must deny); got: %q", result)
+	}
+
+	// Audit-sink assertion: the event must reach the same pipeline as the
+	// seccomp engine.  Assert exactly one event was published with the
+	// correct shape (Type, Outcome, engine field).
+	events := sink.Events()
+	if len(events) == 0 {
+		t.Fatal("audit sink received no events; expected exactly one seccomp_socket_family_blocked event from ptrace engine")
+	}
+	if len(events) > 1 {
+		t.Errorf("audit sink received %d events; expected exactly 1", len(events))
+	}
+	ev := events[0]
+	if ev.Type != "seccomp_socket_family_blocked" {
+		t.Errorf("event Type=%q; want %q", ev.Type, "seccomp_socket_family_blocked")
+	}
+	if ev.PID == 0 {
+		t.Error("event PID is 0; expected the tracee's TID")
+	}
+	wantFields := map[string]any{
+		"family_name":   "AF_ALG",
+		"family_number": uint64(unix.AF_ALG),
+		"syscall":       "socket",
+		"action":        string(seccomp.OnBlockLog),
+		"outcome":       "denied",
+		"engine":        "ptrace",
+	}
+	for k, want := range wantFields {
+		got, ok := ev.Fields[k]
+		if !ok {
+			t.Errorf("event missing field %q", k)
+			continue
+		}
+		// Compare as strings to avoid uint64 vs int mismatches in map[string]any.
+		if fmt.Sprintf("%v", got) != fmt.Sprintf("%v", want) {
+			t.Errorf("event Fields[%q]=%v (%T); want %v (%T)", k, got, got, want, want)
+		}
 	}
 }

--- a/internal/ptrace/family_checker_test.go
+++ b/internal/ptrace/family_checker_test.go
@@ -3,9 +3,12 @@
 package ptrace
 
 import (
+	"context"
+	"sync"
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/seccomp"
+	"github.com/agentsh/agentsh/pkg/types"
 	"golang.org/x/sys/unix"
 )
 
@@ -90,5 +93,202 @@ func TestFamilyChecker_NilReceiver(t *testing.T) {
 	var c *FamilyChecker
 	if _, ok := c.Check(uint64(unix.SYS_SOCKET), 38); ok {
 		t.Errorf("nil receiver should never match")
+	}
+}
+
+// applyTestEmitter is a thread-safe in-memory sink for Apply unit tests.
+type applyTestEmitter struct {
+	mu     sync.Mutex
+	events []types.Event
+}
+
+func (e *applyTestEmitter) AppendEvent(_ context.Context, ev types.Event) error {
+	e.mu.Lock()
+	e.events = append(e.events, ev)
+	e.mu.Unlock()
+	return nil
+}
+
+func (e *applyTestEmitter) Publish(ev types.Event) {
+	e.mu.Lock()
+	e.events = append(e.events, ev)
+	e.mu.Unlock()
+}
+
+func (e *applyTestEmitter) Events() []types.Event {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]types.Event, len(e.events))
+	copy(out, e.events)
+	return out
+}
+
+// makeApplyChecker builds a FamilyChecker with the given emitter and injects
+// the provided tgkill and denySyscall seams. A nil seam means the field is
+// not overridden (production behaviour would apply, but tests always set both).
+func makeApplyChecker(
+	emit FamilyEmitter,
+	tgkill func(tgid, tid int, sig unix.Signal) error,
+	denySyscall func(tid int, errno int) error,
+) *FamilyChecker {
+	c := NewFamilyCheckerWithEmitter([]seccomp.BlockedFamily{
+		{Family: unix.AF_ALG, Action: seccomp.OnBlockLogAndKill, Name: "AF_ALG"},
+	}, emit)
+	if tgkill != nil {
+		c.tgkillFn = tgkill
+	}
+	if denySyscall != nil {
+		c.denySyscallFn = denySyscall
+	}
+	return c
+}
+
+// bf is a helper BlockedFamily value for the Apply unit tests.
+var applyBF = seccomp.BlockedFamily{
+	Family: unix.AF_ALG,
+	Name:   "AF_ALG",
+	Action: seccomp.OnBlockLogAndKill,
+}
+
+// TestApply_LogAndKill_TgkillFailure_NonESRCH verifies that when Tgkill
+// returns a non-ESRCH error and denySyscall succeeds, the emitted outcome is
+// "denied" — NOT "killed". This is the core correctness fix for Bug 1.
+func TestApply_LogAndKill_TgkillFailure_NonESRCH(t *testing.T) {
+	sink := &applyTestEmitter{}
+	c := makeApplyChecker(
+		sink,
+		func(tgid, tid int, sig unix.Signal) error { return unix.EPERM },
+		func(tid int, errno int) error { return nil }, // deny succeeds
+	)
+
+	err := c.Apply(100, 200, nil, seccomp.OnBlockLogAndKill, unix.SYS_SOCKET, applyBF, "sess-1")
+	if err != ptraceAlreadyResumed {
+		t.Errorf("Apply return = %v; want ptraceAlreadyResumed", err)
+	}
+
+	evts := sink.Events()
+	if len(evts) == 0 {
+		t.Fatal("expected at least one audit event; got none")
+	}
+	outcome, _ := evts[0].Fields["outcome"].(string)
+	if outcome == "killed" {
+		t.Errorf("outcome=%q; must NOT be \"killed\" when Tgkill failed — want \"denied\"", outcome)
+	}
+	if outcome != "denied" {
+		t.Errorf("outcome=%q; want \"denied\" (deny-fallback succeeded)", outcome)
+	}
+}
+
+// TestApply_LogAndKill_TgkillFailure_DenyAlsoFails verifies that when both
+// Tgkill and denySyscall fail, the emitted outcome is "deny_fallback_failed".
+func TestApply_LogAndKill_TgkillFailure_DenyAlsoFails(t *testing.T) {
+	sink := &applyTestEmitter{}
+	c := makeApplyChecker(
+		sink,
+		func(tgid, tid int, sig unix.Signal) error { return unix.EPERM },
+		func(tid int, errno int) error { return unix.EIO },
+	)
+
+	err := c.Apply(100, 200, nil, seccomp.OnBlockLogAndKill, unix.SYS_SOCKET, applyBF, "sess-2")
+	if err != ptraceAlreadyResumed {
+		t.Errorf("Apply return = %v; want ptraceAlreadyResumed", err)
+	}
+
+	evts := sink.Events()
+	if len(evts) == 0 {
+		t.Fatal("expected at least one audit event; got none")
+	}
+	outcome, _ := evts[0].Fields["outcome"].(string)
+	if outcome == "killed" {
+		t.Errorf("outcome=%q; must NOT be \"killed\" when Tgkill failed", outcome)
+	}
+	if outcome != "deny_fallback_failed" {
+		t.Errorf("outcome=%q; want \"deny_fallback_failed\"", outcome)
+	}
+}
+
+// TestApply_LogAndKill_TgkillSuccess verifies that when Tgkill succeeds, the
+// emitted outcome is "killed" and Apply returns PtraceKillRequested.
+func TestApply_LogAndKill_TgkillSuccess(t *testing.T) {
+	sink := &applyTestEmitter{}
+	c := makeApplyChecker(
+		sink,
+		func(tgid, tid int, sig unix.Signal) error { return nil },
+		func(tid int, errno int) error {
+			t.Fatal("denySyscall must not be called on Tgkill success")
+			return nil
+		},
+	)
+
+	err := c.Apply(100, 200, nil, seccomp.OnBlockLogAndKill, unix.SYS_SOCKET, applyBF, "sess-3")
+	if err != PtraceKillRequested {
+		t.Errorf("Apply return = %v; want PtraceKillRequested", err)
+	}
+
+	evts := sink.Events()
+	if len(evts) == 0 {
+		t.Fatal("expected at least one audit event; got none")
+	}
+	outcome, _ := evts[0].Fields["outcome"].(string)
+	if outcome != "killed" {
+		t.Errorf("outcome=%q; want \"killed\"", outcome)
+	}
+}
+
+// TestApply_LogAndKill_TgkillESRCH verifies that when Tgkill returns ESRCH
+// (target already gone), the emitted outcome is "vanished" and Apply returns nil.
+func TestApply_LogAndKill_TgkillESRCH(t *testing.T) {
+	sink := &applyTestEmitter{}
+	c := makeApplyChecker(
+		sink,
+		func(tgid, tid int, sig unix.Signal) error { return unix.ESRCH },
+		func(tid int, errno int) error { t.Fatal("denySyscall must not be called on ESRCH"); return nil },
+	)
+
+	err := c.Apply(100, 200, nil, seccomp.OnBlockLogAndKill, unix.SYS_SOCKET, applyBF, "sess-4")
+	if err != nil {
+		t.Errorf("Apply return = %v; want nil (target already gone)", err)
+	}
+
+	// ESRCH (vanished): no event should be emitted as the target is gone.
+	// The outcome field would be "vanished" but the event is emitted.
+	evts := sink.Events()
+	if len(evts) == 0 {
+		t.Fatal("expected at least one audit event for vanished target; got none")
+	}
+	outcome, _ := evts[0].Fields["outcome"].(string)
+	if outcome != "vanished" {
+		t.Errorf("outcome=%q; want \"vanished\"", outcome)
+	}
+}
+
+// TestApply_Log_DenySyscallFailure verifies that when denySyscall fails with a
+// non-ESRCH error in OnBlockLog mode, the emitted outcome is "deny_failed".
+func TestApply_Log_DenySyscallFailure(t *testing.T) {
+	logBF := seccomp.BlockedFamily{
+		Family: unix.AF_ALG,
+		Name:   "AF_ALG",
+		Action: seccomp.OnBlockLog,
+	}
+	sink := &applyTestEmitter{}
+	c := NewFamilyCheckerWithEmitter([]seccomp.BlockedFamily{logBF}, sink)
+	c.denySyscallFn = func(tid int, errno int) error { return unix.EIO }
+
+	err := c.Apply(100, 200, nil, seccomp.OnBlockLog, unix.SYS_SOCKET, logBF, "sess-5")
+	// EIO from denySyscall is returned directly.
+	if err != unix.EIO {
+		t.Errorf("Apply return = %v; want EIO", err)
+	}
+
+	evts := sink.Events()
+	if len(evts) == 0 {
+		t.Fatal("expected at least one audit event; got none")
+	}
+	outcome, _ := evts[0].Fields["outcome"].(string)
+	if outcome == "denied" {
+		t.Errorf("outcome=%q; must NOT be \"denied\" when denySyscall failed — want \"deny_failed\"", outcome)
+	}
+	if outcome != "deny_failed" {
+		t.Errorf("outcome=%q; want \"deny_failed\"", outcome)
 	}
 }

--- a/internal/ptrace/family_checker_test.go
+++ b/internal/ptrace/family_checker_test.go
@@ -292,3 +292,34 @@ func TestApply_Log_DenySyscallFailure(t *testing.T) {
 		t.Errorf("outcome=%q; want \"deny_failed\"", outcome)
 	}
 }
+
+// TestApply_Log_DenySyscallESRCH verifies that when denySyscall returns ESRCH
+// in OnBlockLog mode (tracee vanished mid-syscall), the emitted outcome is
+// "vanished" rather than the intended "denied".
+func TestApply_Log_DenySyscallESRCH(t *testing.T) {
+	logBF := seccomp.BlockedFamily{
+		Family: unix.AF_ALG,
+		Name:   "AF_ALG",
+		Action: seccomp.OnBlockLog,
+	}
+	sink := &applyTestEmitter{}
+	c := NewFamilyCheckerWithEmitter([]seccomp.BlockedFamily{logBF}, sink)
+	c.denySyscallFn = func(tid int, errno int) error { return unix.ESRCH }
+
+	err := c.Apply(100, 200, nil, seccomp.OnBlockLog, unix.SYS_SOCKET, logBF, "sess-6")
+	if err != ptraceAlreadyResumed {
+		t.Errorf("Apply return = %v; want ptraceAlreadyResumed", err)
+	}
+
+	evts := sink.Events()
+	if len(evts) == 0 {
+		t.Fatal("expected at least one audit event; got none")
+	}
+	outcome, _ := evts[0].Fields["outcome"].(string)
+	if outcome == "denied" {
+		t.Errorf("outcome=%q; must NOT be \"denied\" when tracee vanished — want \"vanished\"", outcome)
+	}
+	if outcome != "vanished" {
+		t.Errorf("outcome=%q; want \"vanished\"", outcome)
+	}
+}

--- a/internal/ptrace/family_checker_test.go
+++ b/internal/ptrace/family_checker_test.go
@@ -1,0 +1,94 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/seccomp"
+	"golang.org/x/sys/unix"
+)
+
+func TestFamilyChecker_Check_MatchAndMiss(t *testing.T) {
+	c := NewFamilyChecker([]seccomp.BlockedFamily{
+		{Family: 38, Action: seccomp.OnBlockErrno, Name: "AF_ALG"},
+	})
+
+	// AF_ALG on socket(2) → match.
+	bf, ok := c.Check(uint64(unix.SYS_SOCKET), 38)
+	if !ok || bf.Name != "AF_ALG" {
+		t.Errorf("expected match for AF_ALG on SYS_SOCKET; got bf=%+v ok=%v", bf, ok)
+	}
+
+	// AF_INET on socket(2) → miss.
+	if _, ok := c.Check(uint64(unix.SYS_SOCKET), 2); ok {
+		t.Errorf("expected miss for AF_INET")
+	}
+
+	// AF_ALG on read(2) → miss (only socket/socketpair are checked).
+	if _, ok := c.Check(uint64(unix.SYS_READ), 38); ok {
+		t.Errorf("expected miss for AF_ALG on SYS_READ")
+	}
+}
+
+func TestFamilyChecker_Check_Socketpair(t *testing.T) {
+	c := NewFamilyChecker([]seccomp.BlockedFamily{
+		{Family: 38, Action: seccomp.OnBlockErrno, Name: "AF_ALG"},
+	})
+	_, ok := c.Check(uint64(unix.SYS_SOCKETPAIR), 38)
+	if !ok {
+		t.Errorf("expected match for AF_ALG on SYS_SOCKETPAIR")
+	}
+}
+
+func TestFamilyChecker_Empty(t *testing.T) {
+	c := NewFamilyChecker(nil)
+	if _, ok := c.Check(uint64(unix.SYS_SOCKET), 38); ok {
+		t.Errorf("empty checker should never match")
+	}
+}
+
+func TestFamilyChecker_MultipleEntries(t *testing.T) {
+	c := NewFamilyChecker([]seccomp.BlockedFamily{
+		{Family: 38, Action: seccomp.OnBlockErrno, Name: "AF_ALG"},
+		{Family: 40, Action: seccomp.OnBlockKill, Name: "AF_VSOCK"},
+		{Family: 21, Action: seccomp.OnBlockLog, Name: "AF_RDS"},
+	})
+
+	cases := []struct {
+		syscall uint64
+		family  uint64
+		want    bool
+		name    string
+		action  seccomp.OnBlockAction
+	}{
+		{uint64(unix.SYS_SOCKET), 38, true, "AF_ALG", seccomp.OnBlockErrno},
+		{uint64(unix.SYS_SOCKET), 40, true, "AF_VSOCK", seccomp.OnBlockKill},
+		{uint64(unix.SYS_SOCKETPAIR), 21, true, "AF_RDS", seccomp.OnBlockLog},
+		{uint64(unix.SYS_SOCKET), 2, false, "", ""},
+		{uint64(unix.SYS_SOCKET), 10, false, "", ""},
+	}
+
+	for _, tc := range cases {
+		bf, ok := c.Check(tc.syscall, tc.family)
+		if ok != tc.want {
+			t.Errorf("Check(%d, %d): ok=%v want=%v", tc.syscall, tc.family, ok, tc.want)
+			continue
+		}
+		if ok {
+			if bf.Name != tc.name {
+				t.Errorf("Check(%d, %d): name=%q want=%q", tc.syscall, tc.family, bf.Name, tc.name)
+			}
+			if bf.Action != tc.action {
+				t.Errorf("Check(%d, %d): action=%v want=%v", tc.syscall, tc.family, bf.Action, tc.action)
+			}
+		}
+	}
+}
+
+func TestFamilyChecker_NilReceiver(t *testing.T) {
+	var c *FamilyChecker
+	if _, ok := c.Check(uint64(unix.SYS_SOCKET), 38); ok {
+		t.Errorf("nil receiver should never match")
+	}
+}

--- a/internal/ptrace/syscalls.go
+++ b/internal/ptrace/syscalls.go
@@ -88,6 +88,9 @@ func narrowTracedSyscallNumbers(cfg *TracerConfig) []int {
 	if cfg.MaskTracerPid || (cfg.TraceNetwork && cfg.NetworkHandler != nil) {
 		nums = append(nums, unix.SYS_CLOSE)
 	}
+	if cfg.FamilyChecker != nil {
+		nums = append(nums, unix.SYS_SOCKET, unix.SYS_SOCKETPAIR)
+	}
 
 	return nums
 }

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -1006,13 +1006,15 @@ func (t *Tracer) dispatchSyscall(ctx context.Context, tid int, nr int, sc *Sysca
 		family := sc.Info.Args[0]
 		if bf, ok := t.cfg.FamilyChecker.Check(uint64(nr), family); ok {
 			tgid := tid
+			var sessionID string
 			t.mu.Lock()
 			if state := t.tracees[tid]; state != nil {
 				tgid = state.TGID
+				sessionID = state.SessionID
 			}
 			t.mu.Unlock()
 
-			err := t.cfg.FamilyChecker.Apply(tid, tgid, t, bf.Action, nr, bf)
+			err := t.cfg.FamilyChecker.Apply(tid, tgid, t, bf.Action, nr, bf, sessionID)
 			switch {
 			case errors.Is(err, PtraceKillRequested):
 				// Apply already delivered SIGKILL via Tgkill; allow the tracee

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -1015,7 +1015,8 @@ func (t *Tracer) dispatchSyscall(ctx context.Context, tid int, nr int, sc *Sysca
 			err := t.cfg.FamilyChecker.Apply(tid, tgid, t, bf.Action, nr, bf)
 			switch {
 			case errors.Is(err, PtraceKillRequested):
-				unix.Tgkill(tgid, tid, unix.SIGKILL)
+				// Apply already delivered SIGKILL via Tgkill; allow the tracee
+				// to run so it receives the signal.
 				t.allowSyscall(tid)
 			case errors.Is(err, ptraceAlreadyResumed):
 				// denySyscall already resumed the tracee — nothing more to do.
@@ -1024,7 +1025,7 @@ func (t *Tracer) dispatchSyscall(ctx context.Context, tid int, nr int, sc *Sysca
 					"tid", tid, "family", bf.Name, "error", err)
 				t.allowSyscall(tid)
 			default:
-				// log/log_and_kill(non-kill) or unknown action: allow proceeds.
+				// Unknown action: allow proceeds.
 				t.allowSyscall(tid)
 			}
 			return

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -89,9 +89,9 @@ type NetworkResult struct {
 	Allow            bool
 	Action           string // "" (legacy), "allow", "deny", "redirect"
 	Errno            int32
-	RedirectAddr     string // for redirect
-	RedirectPort     int    // for redirect
-	RedirectUpstream string // Forward DNS query to this resolver (ip:port)
+	RedirectAddr     string      // for redirect
+	RedirectPort     int         // for redirect
+	RedirectUpstream string      // Forward DNS query to this resolver (ip:port)
 	Records          []DNSRecord // Synthetic DNS response records
 }
 
@@ -142,28 +142,29 @@ type TracerConfig struct {
 	FileHandler      FileHandler
 	NetworkHandler   NetworkHandler
 	SignalHandler    SignalHandler
+	FamilyChecker    *FamilyChecker // nil disables socket-family blocking
 	Metrics          Metrics
 }
 
 // TraceeState tracks the state of a single traced thread.
 type TraceeState struct {
-	TID              int
-	TGID             int
-	ParentPID        int
-	SessionID        string
-	CommandID        string
-	InSyscall        bool
-	LastNr           int
-	Attached         time.Time
-	ParkedAt         time.Time
+	TID                   int
+	TGID                  int
+	ParentPID             int
+	SessionID             string
+	CommandID             string
+	InSyscall             bool
+	LastNr                int
+	Attached              time.Time
+	ParkedAt              time.Time
 	PendingDenyErrno      int
 	PendingFakeZero       bool  // force return value to 0 on syscall exit
 	PendingReturnOverride int64 // force return value to this on syscall exit
 	HasPendingReturn      bool  // whether PendingReturnOverride is active
 	PendingInterrupt      bool
-	HasPrefilter     bool // true if seccomp prefilter is installed for this tracee
-	PendingPrefilter bool // inject seccomp filter on next syscall stop
-	NeedExitStop     bool // resume with PtraceSyscall to catch exit
+	HasPrefilter          bool // true if seccomp prefilter is installed for this tracee
+	PendingPrefilter      bool // inject seccomp filter on next syscall stop
+	NeedExitStop          bool // resume with PtraceSyscall to catch exit
 	// TGID-level: any thread in this TGID triggered escalation
 	NeedsReadEscalation  bool
 	NeedsWriteEscalation bool
@@ -173,14 +174,14 @@ type TraceeState struct {
 	// Deferred: inject escalation at next exit stop
 	PendingReadEscalation  bool
 	PendingWriteEscalation bool
-	IsVforkChild     bool
-	SuppressInitialStop bool // suppress initial SIGSTOP from auto-trace
-	LastOpenFlags    int    // flags from last openat/openat2 entry (event-loop-only)
-	LastOpenOp       string // operation from last openat/openat2 entry (event-loop-only)
-	LastFileAction   string // action from last file entry-time policy check (event-loop-only)
-	PendingExecStubFD  int // fd injected for exec redirect; cleaned up on exec failure (-1 = none)
-	PendingExecSavedFD int // fd that was displaced by stub fd; restored on exec failure (-1 = none)
-	MemFD              int
+	IsVforkChild           bool
+	SuppressInitialStop    bool   // suppress initial SIGSTOP from auto-trace
+	LastOpenFlags          int    // flags from last openat/openat2 entry (event-loop-only)
+	LastOpenOp             string // operation from last openat/openat2 entry (event-loop-only)
+	LastFileAction         string // action from last file entry-time policy check (event-loop-only)
+	PendingExecStubFD      int    // fd injected for exec redirect; cleaned up on exec failure (-1 = none)
+	PendingExecSavedFD     int    // fd that was displaced by stub fd; restored on exec failure (-1 = none)
+	MemFD                  int
 }
 
 type resumeRequest struct {
@@ -193,9 +194,9 @@ type resumeRequest struct {
 type ExitReason int
 
 const (
-	ExitNormal    ExitReason = iota // process exited or was signaled (Code/Signal valid)
-	ExitVanished                    // ESRCH — process disappeared (ptrace call failed)
-	ExitTracerDown                  // tracer shut down while process was running
+	ExitNormal     ExitReason = iota // process exited or was signaled (Code/Signal valid)
+	ExitVanished                     // ESRCH — process disappeared (ptrace call failed)
+	ExitTracerDown                   // tracer shut down while process was running
 )
 
 // ExitStatus carries process exit information for tracer-managed wait.
@@ -239,9 +240,9 @@ func WithKeepStopped() AttachOption {
 
 // Tracer implements a ptrace-based syscall tracer.
 type Tracer struct {
-	cfg             TracerConfig
-	metrics         Metrics
-	processTree     *ProcessTree
+	cfg         TracerConfig
+	metrics     Metrics
+	processTree *ProcessTree
 
 	attachQueue chan attachRequest
 	resumeQueue chan resumeRequest
@@ -997,6 +998,39 @@ func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
 
 // dispatchSyscall routes a syscall to the appropriate handler.
 func (t *Tracer) dispatchSyscall(ctx context.Context, tid int, nr int, sc *SyscallContext) {
+	// Socket-family blocking: check before all other handlers so that
+	// FamilyChecker rules take precedence over the generic network handler.
+	// SYS_SOCKET and SYS_SOCKETPAIR pass the AF_* family as arg0.
+	if t.cfg.FamilyChecker != nil &&
+		(nr == unix.SYS_SOCKET || nr == unix.SYS_SOCKETPAIR) {
+		family := sc.Info.Args[0]
+		if bf, ok := t.cfg.FamilyChecker.Check(uint64(nr), family); ok {
+			tgid := tid
+			t.mu.Lock()
+			if state := t.tracees[tid]; state != nil {
+				tgid = state.TGID
+			}
+			t.mu.Unlock()
+
+			err := t.cfg.FamilyChecker.Apply(tid, tgid, t, bf.Action, nr, bf)
+			switch {
+			case errors.Is(err, PtraceKillRequested):
+				unix.Tgkill(tgid, tid, unix.SIGKILL)
+				t.allowSyscall(tid)
+			case errors.Is(err, ptraceAlreadyResumed):
+				// denySyscall already resumed the tracee — nothing more to do.
+			case err != nil:
+				slog.Warn("ptrace: family check apply failed",
+					"tid", tid, "family", bf.Name, "error", err)
+				t.allowSyscall(tid)
+			default:
+				// log/log_and_kill(non-kill) or unknown action: allow proceeds.
+				t.allowSyscall(tid)
+			}
+			return
+		}
+	}
+
 	switch {
 	case isExecveSyscall(nr):
 		t.handleExecve(ctx, tid, sc)

--- a/internal/seccomp/actions.go
+++ b/internal/seccomp/actions.go
@@ -1,0 +1,28 @@
+package seccomp
+
+// OnBlockAction determines what seccomp does when a block-listed syscall
+// or socket family fires. Pure config type; importable from any package
+// regardless of platform.
+type OnBlockAction string
+
+const (
+	OnBlockErrno      OnBlockAction = "errno"
+	OnBlockKill       OnBlockAction = "kill"
+	OnBlockLog        OnBlockAction = "log"
+	OnBlockLogAndKill OnBlockAction = "log_and_kill"
+)
+
+// ParseOnBlock converts a config string to a typed action.
+// Empty string maps to OnBlockErrno (the default). Unknown strings
+// return OnBlockErrno and false — callers should treat this as a
+// defense-in-depth degradation and log a warning.
+func ParseOnBlock(s string) (OnBlockAction, bool) {
+	switch OnBlockAction(s) {
+	case "", OnBlockErrno:
+		return OnBlockErrno, true
+	case OnBlockKill, OnBlockLog, OnBlockLogAndKill:
+		return OnBlockAction(s), true
+	default:
+		return OnBlockErrno, false
+	}
+}

--- a/internal/seccomp/families.go
+++ b/internal/seccomp/families.go
@@ -1,5 +1,3 @@
-//go:build linux && cgo
-
 package seccomp
 
 import "strconv"

--- a/internal/seccomp/families.go
+++ b/internal/seccomp/families.go
@@ -1,0 +1,83 @@
+//go:build linux && cgo
+
+package seccomp
+
+import "strconv"
+
+// BlockedFamily is one entry on the blocked_socket_families list.
+type BlockedFamily struct {
+	Family int           // resolved AF_* number
+	Action OnBlockAction // errno|kill|log|log_and_kill
+	Name   string        // original config name; "" if numeric
+}
+
+// nameTable maps human-readable AF_* names to their kernel numbers.
+// New families need a code update — kernel adds them rarely.
+var nameTable = map[string]int{
+	"AF_UNIX":      1,
+	"AF_INET":      2,
+	"AF_AX25":      3,
+	"AF_IPX":       4,
+	"AF_APPLETALK": 5,
+	"AF_NETROM":    6,
+	"AF_X25":       9,
+	"AF_INET6":     10,
+	"AF_ROSE":      11,
+	"AF_DECnet":    12,
+	"AF_NETLINK":   16,
+	"AF_PACKET":    17,
+	"AF_RDS":       21,
+	"AF_CAN":       29,
+	"AF_TIPC":      30,
+	"AF_BLUETOOTH": 31,
+	"AF_ALG":       38,
+	"AF_VSOCK":     40,
+	"AF_KCM":       41,
+}
+
+// ParseFamily resolves a config value (name string or numeric string) to
+// its AF_* int. Returns ok=false if the value is neither a known name
+// nor a parseable integer in [0, 64).
+//
+// On numeric input, name is returned as "" so callers can preserve the
+// fact that the operator chose a number.
+func ParseFamily(value string) (nr int, name string, ok bool) {
+	if value == "" {
+		return 0, "", false
+	}
+	if n, found := nameTable[value]; found {
+		return n, value, true
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, "", false
+	}
+	if parsed < 0 || parsed >= 64 {
+		// AF_MAX is currently 47 in mainline; 64 leaves headroom but
+		// rejects clearly-bogus values like 1000.
+		return 0, "", false
+	}
+	return parsed, "", true
+}
+
+// DefaultBlockedFamilies returns the recommended-default list applied
+// when blocked_socket_families is unset in config. Each entry uses
+// OnBlockErrno (returns EAFNOSUPPORT to userspace).
+//
+// Rationale per docs/superpowers/specs/2026-04-29-socket-family-block-design.md.
+func DefaultBlockedFamilies() []BlockedFamily {
+	names := []string{
+		"AF_ALG", "AF_VSOCK", "AF_RDS", "AF_TIPC", "AF_KCM",
+		"AF_X25", "AF_AX25", "AF_NETROM", "AF_ROSE", "AF_DECnet",
+		"AF_APPLETALK", "AF_IPX",
+	}
+	out := make([]BlockedFamily, 0, len(names))
+	for _, n := range names {
+		out = append(out, BlockedFamily{
+			Family: nameTable[n],
+			Action: OnBlockErrno,
+			Name:   n,
+		})
+	}
+	return out
+}

--- a/internal/seccomp/families_test.go
+++ b/internal/seccomp/families_test.go
@@ -1,5 +1,3 @@
-//go:build linux && cgo
-
 package seccomp
 
 import (

--- a/internal/seccomp/families_test.go
+++ b/internal/seccomp/families_test.go
@@ -1,0 +1,93 @@
+//go:build linux && cgo
+
+package seccomp
+
+import (
+	"testing"
+)
+
+func TestParseFamily_Names(t *testing.T) {
+	cases := []struct {
+		in     string
+		wantNr int
+	}{
+		{"AF_ALG", 38},
+		{"AF_VSOCK", 40},
+		{"AF_RDS", 21},
+		{"AF_TIPC", 30},
+		{"AF_KCM", 41},
+		{"AF_X25", 9},
+		{"AF_AX25", 3},
+		{"AF_NETROM", 6},
+		{"AF_ROSE", 11},
+		{"AF_DECnet", 12},
+		{"AF_APPLETALK", 5},
+		{"AF_IPX", 4},
+		{"AF_INET", 2},
+		{"AF_INET6", 10},
+		{"AF_UNIX", 1},
+		{"AF_NETLINK", 16},
+		{"AF_PACKET", 17},
+		{"AF_BLUETOOTH", 31},
+		{"AF_CAN", 29},
+	}
+	for _, c := range cases {
+		nr, name, ok := ParseFamily(c.in)
+		if !ok {
+			t.Errorf("ParseFamily(%q): ok=false, want true", c.in)
+			continue
+		}
+		if nr != c.wantNr {
+			t.Errorf("ParseFamily(%q): nr=%d, want %d", c.in, nr, c.wantNr)
+		}
+		if name != c.in {
+			t.Errorf("ParseFamily(%q): name=%q, want %q", c.in, name, c.in)
+		}
+	}
+}
+
+func TestParseFamily_NumericFallback(t *testing.T) {
+	nr, name, ok := ParseFamily("38")
+	if !ok || nr != 38 || name != "" {
+		t.Errorf("ParseFamily(\"38\"): got (%d, %q, %v), want (38, \"\", true)", nr, name, ok)
+	}
+	nr, _, ok = ParseFamily("63") // upper edge of valid range
+	if !ok || nr != 63 {
+		t.Errorf("ParseFamily(\"63\"): got (%d, _, %v), want (63, _, true)", nr, ok)
+	}
+}
+
+func TestParseFamily_Invalid(t *testing.T) {
+	cases := []string{"", "AF_ALGOG", "AF_NOT_A_THING", "-1", "64", "1000", "abc"}
+	for _, in := range cases {
+		if _, _, ok := ParseFamily(in); ok {
+			t.Errorf("ParseFamily(%q): ok=true, want false", in)
+		}
+	}
+}
+
+func TestDefaultBlockedFamilies(t *testing.T) {
+	defaults := DefaultBlockedFamilies()
+	if len(defaults) == 0 {
+		t.Fatal("DefaultBlockedFamilies returned empty list")
+	}
+	// AF_ALG must be in defaults — copy.fail mitigation.
+	found := false
+	for _, bf := range defaults {
+		if bf.Name == "AF_ALG" && bf.Family == 38 {
+			found = true
+			if bf.Action != OnBlockErrno {
+				t.Errorf("AF_ALG default action = %s, want errno", bf.Action)
+			}
+		}
+	}
+	if !found {
+		t.Error("AF_ALG missing from DefaultBlockedFamilies")
+	}
+	// All defaults must use errno.
+	for _, bf := range defaults {
+		if bf.Action != OnBlockErrno {
+			t.Errorf("default %s action = %s, want errno", bf.Name, bf.Action)
+		}
+	}
+}

--- a/internal/seccomp/filter.go
+++ b/internal/seccomp/filter.go
@@ -6,16 +6,18 @@ package seccomp
 type FilterConfig struct {
 	UnixSocketEnabled bool
 	BlockedSyscalls   []string
+	BlockedFamilies   []BlockedFamily
 	OnBlock           OnBlockAction
 }
 
 // FilterConfigFromYAML creates a FilterConfig from config package types.
 // This is a separate function to avoid import cycles.
-func FilterConfigFromYAML(unixEnabled bool, blockedSyscalls []string, onBlock string) FilterConfig {
+func FilterConfigFromYAML(unixEnabled bool, blockedSyscalls []string, onBlock string, blockedFamilies []BlockedFamily) FilterConfig {
 	action, _ := ParseOnBlock(onBlock)
 	return FilterConfig{
 		UnixSocketEnabled: unixEnabled,
 		BlockedSyscalls:   blockedSyscalls,
+		BlockedFamilies:   blockedFamilies,
 		OnBlock:           action,
 	}
 }

--- a/internal/seccomp/filter.go
+++ b/internal/seccomp/filter.go
@@ -2,31 +2,6 @@
 
 package seccomp
 
-// OnBlockAction determines what seccomp does when a block-listed syscall fires.
-type OnBlockAction string
-
-const (
-	OnBlockErrno      OnBlockAction = "errno"
-	OnBlockKill       OnBlockAction = "kill"
-	OnBlockLog        OnBlockAction = "log"
-	OnBlockLogAndKill OnBlockAction = "log_and_kill"
-)
-
-// ParseOnBlock converts a config string to a typed action.
-// Empty string maps to OnBlockErrno (the default after applyDefaults runs).
-// Unknown strings return OnBlockErrno and false — callers should treat this
-// as a defense-in-depth degradation and log a warning.
-func ParseOnBlock(s string) (OnBlockAction, bool) {
-	switch OnBlockAction(s) {
-	case "", OnBlockErrno:
-		return OnBlockErrno, true
-	case OnBlockKill, OnBlockLog, OnBlockLogAndKill:
-		return OnBlockAction(s), true
-	default:
-		return OnBlockErrno, false
-	}
-}
-
 // FilterConfig holds settings for building a seccomp filter.
 type FilterConfig struct {
 	UnixSocketEnabled bool

--- a/internal/seccomp/filter_test.go
+++ b/internal/seccomp/filter_test.go
@@ -107,12 +107,39 @@ func TestParseOnBlock(t *testing.T) {
 }
 
 func TestFilterConfigFromYAML(t *testing.T) {
-	cfg := FilterConfigFromYAML(true, []string{"ptrace"}, "log_and_kill")
+	cfg := FilterConfigFromYAML(true, []string{"ptrace"}, "log_and_kill", nil)
 	require.True(t, cfg.UnixSocketEnabled)
 	require.Equal(t, []string{"ptrace"}, cfg.BlockedSyscalls)
 	require.Equal(t, OnBlockLogAndKill, cfg.OnBlock)
 
 	// Unknown string degrades to errno
-	cfgBad := FilterConfigFromYAML(false, nil, "nope")
+	cfgBad := FilterConfigFromYAML(false, nil, "nope", nil)
 	require.Equal(t, OnBlockErrno, cfgBad.OnBlock)
+}
+
+func TestFilterConfig_IncludesBlockedFamilies(t *testing.T) {
+	cfg := FilterConfig{
+		UnixSocketEnabled: false,
+		BlockedSyscalls:   nil,
+		BlockedFamilies: []BlockedFamily{
+			{Family: 38, Action: OnBlockErrno, Name: "AF_ALG"},
+		},
+		OnBlock: OnBlockErrno,
+	}
+	if len(cfg.BlockedFamilies) != 1 {
+		t.Fatalf("expected 1 family, got %d", len(cfg.BlockedFamilies))
+	}
+	if cfg.BlockedFamilies[0].Name != "AF_ALG" {
+		t.Errorf("name=%q want AF_ALG", cfg.BlockedFamilies[0].Name)
+	}
+}
+
+func TestFilterConfigFromYAML_PassesFamilies(t *testing.T) {
+	families := []BlockedFamily{
+		{Family: 38, Action: OnBlockErrno, Name: "AF_ALG"},
+	}
+	cfg := FilterConfigFromYAML(true, []string{"ptrace"}, "errno", families)
+	if len(cfg.BlockedFamilies) != 1 || cfg.BlockedFamilies[0].Family != 38 {
+		t.Errorf("FilterConfigFromYAML did not pass families through: %+v", cfg.BlockedFamilies)
+	}
 }


### PR DESCRIPTION
## Summary

Per-\`AF_*\`-socket-family blocking on \`socket(2)\` and \`socketpair(2)\` via two engines that share config and types. Mitigation context: [copy.fail](https://copy.fail/#mitigation) and the recurring CVE class where \`socket(AF_<niche-family>, ...)\` is the kernel attack entry point. Spec: \`docs/superpowers/specs/2026-04-29-socket-family-block-design.md\`. Plan: \`docs/superpowers/plans/2026-04-29-socket-family-block.md\`.

- **Config**: \`sandbox.seccomp.blocked_socket_families: [{family, action}, ...]\`. Family by name (\`AF_ALG\`) or number (\`38\`); per-family action (\`errno|kill|log|log_and_kill\`). Recommended-default list ships **12 families at \`errno\`** (AF_ALG, AF_VSOCK, AF_RDS, AF_TIPC, AF_KCM + 7 dead protocols). Unset → defaults applied; \`[]\` → opt-out; non-empty → overrides defaults entirely.
- **seccomp engine (primary)**: \`AddRuleConditional\` on arg0 in \`internal/netmonitor/unix/seccomp_linux.go\`. Notify handler dispatches \`log\`/\`log_and_kill\` and emits \`seccomp_socket_family_blocked\` audit events through the existing audit sink. libseccomp action-precedence ensures family rules outrank the unconditional \`UnixSocketEnabled\` notify on \`socket(2)\`.
- **ptrace engine (fallback + defensive)**: \`internal/ptrace/family_checker.go\` indexes families by syscall+arg0; \`Apply\` runs enforcement first, then emits an identical \`types.Event\` with engine=\"ptrace\" and the *actual* outcome (denied / killed / vanished / deny_failed / deny_fallback_failed) — not the intended one.
- **Engine selection**: defensively wires the \`FamilyChecker\` whenever ptrace is enabled and families are configured (runtime dispatch is mutually exclusive). Selector retained for the warn-and-continue path when no engine can enforce. Both engines emit the same audit-event shape (\`Type\`, \`Outcome\`, \`Pid\`, \`Fields[engine]\`) so SIEM consumers see one signal regardless of which engine fired.
- **Validation** (fail-closed at two layers): \`Config.Validate()\` rejects unknown family names and invalid actions at config-load; \`ResolveBlockedFamilies\` adapter rejects them again defensively.

21 commits across 10 plan tasks, each task subagent-implemented with TDD and individually reviewed by \`roborev\` (max reasoning) before proceeding. Holistic post-implementation review caught a remaining audit-sink asymmetry between engines (ptrace was using \`slog\`); fixed.

**Branch name** is auto-generated by the worktree workflow (\`worktree-socket-family-block\`) — feel free to rename to \`feat/socket-family-block\` before merging.

## Known follow-ups (not blockers)

- Per-binary policy (e.g., let \`iproute2\` use \`AF_NETLINK\` while user binaries can't)
- Reverse allowlist mode (\`mode: allowlist\` to invert)
- \`scan --all\` style operator audit / dashboard surfacing
- eBPF LSM tier (Linux 5.7+ \`security_socket_create\` hook); cleaner than ptrace, lower overhead
- Spec-listed but deferred: \`socketcall(2)\` (i386 multiplexed entry); on-startup non-Linux warning when field non-empty; duplicate-family detection in validator

## Pre-existing test issues (NOT introduced by this branch)

\`go test -race ./internal/api/...\` reports a race in \`notify_linux_test.go\` (3 tests). Files untouched by this branch (\`git diff main..HEAD -- internal/api/notify_linux*.go\` is empty). Same tests pass without \`-race\`.

## Test Plan

- [ ] CI passes on Linux + Windows + macOS + cross-builds
- [ ] Local: \`go test ./internal/seccomp/... ./internal/config/... ./internal/netmonitor/unix/... ./internal/ptrace/...\` clean
- [ ] Manual: \`socket(AF_ALG, ...)\` from a sandboxed process under default config returns \`EAFNOSUPPORT\`
- [ ] Manual: \`socket(AF_INET, ...)\` still works (non-blocked families pass through)
- [ ] Manual: config typo (\`AF_ALGOG\` or \`action: deny\`) errors at config-load with helpful message
- [ ] Manual: \`blocked_socket_families: []\` opts out of the default list entirely
- [ ] Manual: family event appears in audit sink with \`engine=\"seccomp\"\` (or \`engine=\"ptrace\"\` on a no-wrapper host) and \`outcome=\"denied\"\`/\"killed\"/\"vanished\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)