### PR TITLE
docs: request JSON for session ID examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ See [macOS Build Guide](docs/macos-build.md) for detailed macOS build instructio
 ./bin/agentsh server --config configs/server-config.yaml
 
 # Create a session and run a command (shell output)
-SID=$(./bin/agentsh session create --workspace . | jq -r .id)
+SID=$(./bin/agentsh session create --workspace . --json | jq -r .id)
 ./bin/agentsh exec "$SID" -- ls -la
 
 # Structured output for agents
@@ -148,7 +148,7 @@ SID=$(./bin/agentsh session create --workspace . | jq -r .id)
 - Run commands via agentsh, not directly in bash/zsh.
 - Use: `agentsh exec $SID -- <your-command-here>`
 - For structured output: `agentsh exec --output json --events summary $SID -- <your-command-here>`
-- Get session ID first: `SID=$(agentsh session create --workspace . | jq -r .id)`
+- Get session ID first: `SID=$(agentsh session create --workspace . --json | jq -r .id)`
 ```
 
 ---
@@ -295,7 +295,7 @@ command_rules:
 ./bin/agentsh server --config configs/server-config.yaml
 
 # Create a session pinned to a policy
-SID=$(./bin/agentsh session create --workspace /workspace --policy default | jq -r .id)
+SID=$(./bin/agentsh session create --workspace /workspace --policy default --json | jq -r .id)
 
 # Exec commands; responses include decision + guidance when blocked/approved
 ./bin/agentsh exec "$SID" -- rm -rf /workspace/tmp
@@ -336,7 +336,7 @@ The fastest way to "get it" is to run something that spawns subprocesses and tou
 
 ```bash
 # 1) Create a session in your repo/workspace
-SID=$(agentsh session create --workspace . | jq -r .id)
+SID=$(agentsh session create --workspace . --json | jq -r .id)
 
 # 2) Run something simple (human-friendly output)
 agentsh exec "$SID" -- uname -a

--- a/docs/cicd-integration.md
+++ b/docs/cicd-integration.md
@@ -39,7 +39,7 @@ jobs:
         run: |
           agentsh server &
           sleep 2
-          SESSION=$(agentsh session create --workspace . --policy ci-agent | jq -r '.id')
+          SESSION=$(agentsh session create --workspace . --policy ci-agent --json | jq -r '.id')
           echo "id=$SESSION" >> $GITHUB_OUTPUT
 
       - name: Run AI agent
@@ -87,7 +87,7 @@ ai-agent-task:
     - export PATH="$HOME/.local/bin:$PATH"
     - agentsh server &
     - sleep 2
-    - export AGENTSH_SESSION=$(agentsh session create --workspace . --policy ci-agent | jq -r '.id')
+    - export AGENTSH_SESSION=$(agentsh session create --workspace . --policy ci-agent --json | jq -r '.id')
   script:
     - agentsh exec $AGENTSH_SESSION -- your-agent-cli "do the task"
   after_script:
@@ -160,7 +160,7 @@ done
 echo "agentsh server ready"
 
 # Create a session for the workspace
-export AGENTSH_SESSION=$(agentsh session create --workspace /workspace --policy default | jq -r '.id')
+export AGENTSH_SESSION=$(agentsh session create --workspace /workspace --policy default --json | jq -r '.id')
 
 # Execute the main command through the shell shim
 exec agentsh-shell-shim "$@"
@@ -365,7 +365,7 @@ jobs:
           else
             POLICY="ci-generated"
           fi
-          SESSION=$(agentsh session create --workspace . --policy $POLICY | jq -r '.id')
+          SESSION=$(agentsh session create --workspace . --policy $POLICY --json | jq -r '.id')
           echo "id=$SESSION" >> $GITHUB_OUTPUT
 
       - name: Run build and tests


### PR DESCRIPTION
Summary

This updates documentation examples that pipe `agentsh session create` into `jq` so they request machine-readable output first:

`agentsh session create ... --json | jq -r .id`

Without `--json`, the current CLI emits human-friendly text by default. That makes the documented examples fail with a `jq` parse error instead of producing a session ID.

What changed

- Updated README local-run, AGENTS.md snippet, policy, and 60-second demo examples
- Updated CI/CD examples that export a session ID from `session create | jq`

Validation

- Searched current user-facing docs for `session create ... | jq` examples and confirmed each now includes `--json`
- Left existing examples that already used `--json` unchanged
- Ran `git diff --check`

Notes

I checked existing issues and PRs in `canyonroad/agentsh` for matching `session create --json` / `jq` documentation reports before preparing this change and did not find an existing duplicate.
