### PR TITLE
test(wtp): bump TransportLoss deadlines + clamp compression backoff

### DIFF
--- a/internal/store/watchtower/component_inflight_loss_test.go
+++ b/internal/store/watchtower/component_inflight_loss_test.go
@@ -190,7 +190,7 @@ func TestStore_InFlightDrop_EmitsTransportLossOnWire(t *testing.T) {
 			// Emit the drop-triggering event.
 			_ = s.AppendEvent(ctx, tc.makeEvent(1))
 
-			loss, err := srv.WaitForTransportLoss(15 * time.Second)
+			loss, err := srv.WaitForTransportLoss(60 * time.Second)
 			if err != nil {
 				t.Fatalf("WaitForTransportLoss: %v", err)
 			}
@@ -314,7 +314,7 @@ func TestStore_AckRegressionAfterGC_EmitsTransportLoss(t *testing.T) {
 	// If the TODO(Task 22) in Run's stagesLoop is still blocking the
 	// PrefixLoss thread-through, this assertion will time out, which
 	// correctly surfaces the gap.
-	loss, err := srv.WaitForTransportLoss(15 * time.Second)
+	loss, err := srv.WaitForTransportLoss(60 * time.Second)
 	if err != nil {
 		t.Skipf("TestStore_AckRegressionAfterGC_EmitsTransportLoss: "+
 			"TransportLoss not received within deadline; this is expected if "+

--- a/internal/store/watchtower/component_inflight_loss_test.go
+++ b/internal/store/watchtower/component_inflight_loss_test.go
@@ -49,6 +49,8 @@ func newInflightTestStore(t *testing.T, router transport.Dialer, mapper compact.
 		AllowStubMapper:         allowStub,
 		Dialer:                  router,
 		EmitExtendedLossReasons: emitExtended,
+		BackoffInitial:          10 * time.Millisecond,
+		BackoffMax:              50 * time.Millisecond,
 		Logger:                  slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
 	})
 	if err != nil {
@@ -298,6 +300,8 @@ func TestStore_AckRegressionAfterGC_EmitsTransportLoss(t *testing.T) {
 		AllowStubMapper:         true,
 		Dialer:                  router,
 		EmitExtendedLossReasons: true,
+		BackoffInitial:          10 * time.Millisecond,
+		BackoffMax:              50 * time.Millisecond,
 		Logger:                  slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
 	})
 	if err != nil {
@@ -356,6 +360,8 @@ func TestStore_AckRegressionAfterGC_NoTransportLoss_WhenFlagOff(t *testing.T) {
 		AllowStubMapper:         true,
 		Dialer:                  router,
 		EmitExtendedLossReasons: false,
+		BackoffInitial:          10 * time.Millisecond,
+		BackoffMax:              50 * time.Millisecond,
 		Logger:                  slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
 	})
 	if err != nil {

--- a/internal/store/watchtower/component_inflight_slot_test.go
+++ b/internal/store/watchtower/component_inflight_slot_test.go
@@ -65,6 +65,8 @@ func TestStore_TransportLossInflightSlot_RetiredByBatchAck(t *testing.T) {
 		Dialer:                  router,
 		EmitExtendedLossReasons: true,
 		MaxInflight:             1,
+		BackoffInitial:          10 * time.Millisecond,
+		BackoffMax:              50 * time.Millisecond,
 		Logger:                  slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
 	})
 	if err != nil {

--- a/internal/store/watchtower/component_inflight_slot_test.go
+++ b/internal/store/watchtower/component_inflight_slot_test.go
@@ -95,7 +95,7 @@ func TestStore_TransportLossInflightSlot_RetiredByBatchAck(t *testing.T) {
 
 	// Step 1: confirm the loss frame arrived at srvHeld. The ack is
 	// being withheld so the inflight slot is still occupied.
-	loss, err := srvHeld.WaitForTransportLoss(15 * time.Second)
+	loss, err := srvHeld.WaitForTransportLoss(60 * time.Second)
 	if err != nil {
 		t.Fatalf("WaitForTransportLoss (srvHeld): %v", err)
 	}

--- a/internal/store/watchtower/component_loss_carrier_test.go
+++ b/internal/store/watchtower/component_loss_carrier_test.go
@@ -68,6 +68,8 @@ func TestStore_OverflowEmitsTransportLossOnWire(t *testing.T) {
 		BatchMaxAge:     5 * time.Millisecond,
 		AllowStubMapper: true,
 		Dialer:          router,
+		BackoffInitial:  10 * time.Millisecond,
+		BackoffMax:      50 * time.Millisecond,
 		Logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
 	})
 	if err != nil {
@@ -167,6 +169,8 @@ func TestStore_CRCCorruptionEmitsTransportLossOnWire(t *testing.T) {
 		BatchMaxAge:     20 * time.Millisecond,
 		AllowStubMapper: true,
 		Dialer:          router,
+		BackoffInitial:  10 * time.Millisecond,
+		BackoffMax:      50 * time.Millisecond,
 		Logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
 	})
 	if err != nil {
@@ -207,6 +211,8 @@ func TestStore_CRCCorruptionEmitsTransportLossOnWire(t *testing.T) {
 		BatchMaxAge:     20 * time.Millisecond,
 		AllowStubMapper: true,
 		Dialer:          router,
+		BackoffInitial:  10 * time.Millisecond,
+		BackoffMax:      50 * time.Millisecond,
 		Logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
 	})
 	if err != nil {

--- a/internal/store/watchtower/component_loss_carrier_test.go
+++ b/internal/store/watchtower/component_loss_carrier_test.go
@@ -96,7 +96,7 @@ func TestStore_OverflowEmitsTransportLossOnWire(t *testing.T) {
 	}
 
 	// Wait for the testserver to observe at least one TransportLoss.
-	loss, err := srv.WaitForTransportLoss(15 * time.Second)
+	loss, err := srv.WaitForTransportLoss(60 * time.Second)
 	if err != nil {
 		t.Fatalf("WaitForTransportLoss: %v", err)
 	}
@@ -214,7 +214,7 @@ func TestStore_CRCCorruptionEmitsTransportLossOnWire(t *testing.T) {
 	}
 	defer s2.Close()
 
-	loss, err := srv.WaitForTransportLoss(15 * time.Second)
+	loss, err := srv.WaitForTransportLoss(60 * time.Second)
 	if err != nil {
 		t.Fatalf("WaitForTransportLoss: %v", err)
 	}

--- a/internal/store/watchtower/compress_integration_test.go
+++ b/internal/store/watchtower/compress_integration_test.go
@@ -72,6 +72,8 @@ func TestStore_CompressionRoundTrip(t *testing.T) {
 				BatchMaxAge:     50 * time.Millisecond,
 				AllowStubMapper: true,
 				Dialer:          srv.DialerFor(),
+				BackoffInitial:  10 * time.Millisecond,
+				BackoffMax:      50 * time.Millisecond,
 				CompressionAlgo: tc.algo,
 				ZstdLevel:       3,
 				GzipLevel:       6,
@@ -157,6 +159,8 @@ func TestStore_CompressionSizeEnvelope(t *testing.T) {
 		Dialer:          srv.DialerFor(),
 		CompressionAlgo: "zstd",
 		ZstdLevel:       3,
+		BackoffInitial:  10 * time.Millisecond,
+		BackoffMax:      50 * time.Millisecond,
 	})
 	if err != nil {
 		t.Fatalf("watchtower.New: %v", err)
@@ -230,6 +234,8 @@ func TestStore_CompressionWireShapeConformance(t *testing.T) {
 		Dialer:          srv.DialerFor(),
 		CompressionAlgo: "zstd",
 		ZstdLevel:       3,
+		BackoffInitial:  10 * time.Millisecond,
+		BackoffMax:      50 * time.Millisecond,
 	})
 	if err != nil {
 		t.Fatalf("watchtower.New: %v", err)


### PR DESCRIPTION
## Summary
Two related fixes for known CI flakes in `internal/store/watchtower`:

**1. TransportLoss deadline bump (15s → 60s)** — `TestStore_*EmitsTransportLossOnWire` family flakes on Linux + Windows under load with deadline-elapse failures. Bumps the 5 positive `WaitForTransportLoss` call sites to 60s. The two short `gracePeriod=500ms` *absence-of-loss* call sites are intentionally left alone.

**2. Compression-test backoff clamp** — While this PR was in CI, `TestStore_CompressionWireShapeConformance` flaked on test-linux with `missing seq 15`. Root-cause investigation: the three compression integration tests use the production-default reconnect backoff (Initial=200ms, Max=30s, jitter to ~45s per gap). A single spurious reconnect under CI load can eat the test's 60s deadline. Sibling component tests already clamp `BackoffInitial=10ms, BackoffMax=50ms` — mirror that across all three compression tests. Fix at source instead of bumping deadlines again (per `cac83023`'s lessons).

Failing run that motivated each fix:
- TransportLoss: main CI [25199105985](https://github.com/canyonroad/agentsh/actions/runs/25199105985)
- Compression: this PR's first CI [25221245428](https://github.com/canyonroad/agentsh/actions/runs/25221245428)

## Test plan
- [x] `go build ./...`
- [x] `GOOS=windows go build ./...`
- [x] TransportLoss family: `go test -run 'TestStore_TransportLossInflightSlot_RetiredByBatchAck|TestStore_OverflowEmitsTransportLossOnWire|TestStore_CRCCorruptionEmitsTransportLossOnWire|TestStore_InFlightDrop_EmitsTransportLossOnWire|TestStore_AckRegressionAfterGC_EmitsTransportLoss' ./internal/store/watchtower/ -count=1`
- [x] Compression family: `go test -run 'TestStore_Compression' ./internal/store/watchtower/ -count=3`
- [ ] CI green on Linux + Windows + macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)