### PR TITLE
fix(api): wire attach_mode "pid" config to actual AttachPID call

### DIFF
--- a/internal/api/app_ptrace_init_linux_test.go
+++ b/internal/api/app_ptrace_init_linux_test.go
@@ -1,0 +1,172 @@
+//go:build linux
+
+package api
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/events"
+	"github.com/agentsh/agentsh/internal/ptrace"
+	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/store/composite"
+	"golang.org/x/sys/unix"
+)
+
+// requirePtrace skips the test if the runner cannot PTRACE_SEIZE a child
+// (no CAP_SYS_PTRACE, restrictive Yama, container without privilege).
+func requirePtrace(t *testing.T) {
+	t.Helper()
+	cmd := exec.Command("/bin/sleep", "0.01")
+	if err := cmd.Start(); err != nil {
+		t.Skip("cannot start child process")
+	}
+	pid := cmd.Process.Pid
+	err := unix.PtraceSeize(pid)
+	cmd.Process.Kill()
+	cmd.Wait()
+	if err != nil {
+		t.Skipf("PTRACE_SEIZE unavailable on this runner: %v", err)
+	}
+}
+
+// waitForTraceeCount polls the App's ptrace tracer until TraceeCount > 0 or
+// the deadline passes. Returns true when the tracee was registered.
+func waitForTraceeCount(t *testing.T, app *App, timeout time.Duration) bool {
+	t.Helper()
+	tr, ok := app.ptraceTracer.(*ptrace.Tracer)
+	if !ok || tr == nil {
+		t.Fatalf("app.ptraceTracer is nil or wrong type: %T", app.ptraceTracer)
+	}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if tr.TraceeCount() > 0 {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return false
+}
+
+// newPtraceTestApp constructs a minimal App with ptrace.enabled and the given
+// attach_mode/target. It spins up the App's ptrace tracer goroutine; caller
+// must call closePtraceTracer when done.
+func newPtraceTestApp(t *testing.T, mutate func(*config.Config)) *App {
+	t.Helper()
+	cfg := &config.Config{}
+	cfg.Development.DisableAuth = true
+	cfg.Metrics.Enabled = false
+	cfg.Sandbox.Ptrace.Enabled = true
+	cfg.Sandbox.Ptrace.Trace.Execve = true
+	cfg.Sandbox.Ptrace.Trace.File = false
+	cfg.Sandbox.Ptrace.Trace.Network = false
+	cfg.Sandbox.Ptrace.Trace.Signal = false
+	cfg.Sandbox.Ptrace.Performance.MaxTracees = 100
+	cfg.Sandbox.Ptrace.Performance.MaxHoldMs = 5000
+	cfg.Sandbox.Ptrace.OnAttachFailure = "fail_open"
+	mutate(cfg)
+
+	mgr := session.NewManager(5)
+	store := composite.New(mockEventStore{}, nil)
+	broker := events.NewBroker()
+	app := NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil)
+	t.Cleanup(func() { app.closePtraceTracer() })
+	return app
+}
+
+// TestInitPtraceTracer_AttachModePidFromTargetPID verifies the runtime path
+// for `sandbox.ptrace.attach_mode: "pid"` with `target_pid: N` actually
+// attaches to the configured pid.
+//
+// Regression test for the bug where TargetPID was parsed/validated but never
+// reached the tracer (initPtraceTracer started Run() and returned without
+// calling AttachPID), causing all enforcement to silently no-op on hosts
+// where commands aren't children of the agentsh server.
+func TestInitPtraceTracer_AttachModePidFromTargetPID(t *testing.T) {
+	requirePtrace(t)
+
+	// Spawn a sleep child as the attach target.
+	cmd := exec.Command("/bin/sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	})
+	pid := cmd.Process.Pid
+
+	// Release Go's child-tracking so it doesn't compete with the tracer's
+	// Wait4(-1) for events. (Same pattern used in ptrace integration tests.)
+	cmd.Process.Release()
+
+	app := newPtraceTestApp(t, func(c *config.Config) {
+		c.Sandbox.Ptrace.AttachMode = "pid"
+		c.Sandbox.Ptrace.TargetPID = pid
+	})
+
+	if !waitForTraceeCount(t, app, 3*time.Second) {
+		t.Fatalf("tracer did not register a tracee within 3s — initPtraceTracer is not wiring TargetPID")
+	}
+}
+
+// TestInitPtraceTracer_AttachModePidFromTargetPIDFile verifies the runtime
+// path for `target_pid_file` (alternative to inline target_pid).
+func TestInitPtraceTracer_AttachModePidFromTargetPIDFile(t *testing.T) {
+	requirePtrace(t)
+
+	cmd := exec.Command("/bin/sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		cmd.Process.Kill()
+		cmd.Wait()
+	})
+	pid := cmd.Process.Pid
+	cmd.Process.Release()
+
+	pidFile := filepath.Join(t.TempDir(), "target.pid")
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(pid)+"\n"), 0644); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+
+	app := newPtraceTestApp(t, func(c *config.Config) {
+		c.Sandbox.Ptrace.AttachMode = "pid"
+		c.Sandbox.Ptrace.TargetPIDFile = pidFile
+	})
+
+	if !waitForTraceeCount(t, app, 3*time.Second) {
+		t.Fatalf("tracer did not register a tracee within 3s — TargetPIDFile path not wired")
+	}
+}
+
+// TestInitPtraceTracer_AttachModePidFailsClosedOnBadPID verifies fail_closed
+// semantics: when AttachPID fails (e.g. the target doesn't exist), the App's
+// ptraceFailed flag is set so subsequent commands are rejected.
+func TestInitPtraceTracer_AttachModePidFailsClosedOnBadPID(t *testing.T) {
+	requirePtrace(t)
+
+	app := newPtraceTestApp(t, func(c *config.Config) {
+		c.Sandbox.Ptrace.AttachMode = "pid"
+		c.Sandbox.Ptrace.TargetPID = 0x7fffffff // unlikely to exist
+		c.Sandbox.Ptrace.OnAttachFailure = "fail_closed"
+	})
+
+	// Give the goroutine time to fail.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		// Defensive: ptraceFailed is sync/atomic.Bool in the App struct.
+		if v, ok := any(&app.ptraceFailed).(*atomic.Bool); ok && v.Load() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("expected ptraceFailed to be set after AttachPID(non-existent pid) under fail_closed")
+}

--- a/internal/api/app_ptrace_linux.go
+++ b/internal/api/app_ptrace_linux.go
@@ -5,6 +5,9 @@ package api
 import (
 	"context"
 	"log/slog"
+	"os"
+	"strconv"
+	"strings"
 
 	"github.com/agentsh/agentsh/internal/capabilities"
 	"github.com/agentsh/agentsh/internal/config"
@@ -108,6 +111,58 @@ func (a *App) initPtraceTracer() {
 		}
 	}()
 	slog.Info("ptrace tracer started", "attach_mode", cfg.AttachMode)
+
+	// attach_mode: "pid" — attach to the configured target so PTRACE_O_TRACEFORK
+	// catches all its descendants. Without this wiring, the AttachMode field is
+	// parsed and validated but the runtime never calls AttachPID — the tracer
+	// runs with zero tracees and policy enforcement silently no-ops.
+	//
+	// Useful for hosts where the agentsh server is not the ancestor of the
+	// process tree being governed (OpenComputer's osb-agent, generic Docker
+	// exec setups, sidecar deployments, etc.).
+	if cfg.AttachMode == "pid" {
+		targetPID := cfg.TargetPID
+		if targetPID == 0 && cfg.TargetPIDFile != "" {
+			b, err := os.ReadFile(cfg.TargetPIDFile)
+			if err != nil {
+				slog.Error("ptrace: failed to read target_pid_file",
+					"path", cfg.TargetPIDFile, "error", err)
+				if cfg.OnAttachFailure == "fail_closed" {
+					a.ptraceFailed.Store(true)
+				}
+			} else {
+				n, parseErr := strconv.Atoi(strings.TrimSpace(string(b)))
+				if parseErr != nil || n <= 0 {
+					slog.Error("ptrace: target_pid_file does not contain a valid pid",
+						"path", cfg.TargetPIDFile, "error", parseErr, "raw", string(b))
+					if cfg.OnAttachFailure == "fail_closed" {
+						a.ptraceFailed.Store(true)
+					}
+				} else {
+					targetPID = n
+				}
+			}
+		}
+		if targetPID > 0 {
+			go func(pid int) {
+				if err := tr.AttachPID(pid); err != nil {
+					slog.Error("ptrace: AttachPID failed", "pid", pid, "error", err)
+					if cfg.OnAttachFailure == "fail_closed" {
+						a.ptraceFailed.Store(true)
+					}
+					return
+				}
+				if err := tr.WaitAttached(pid); err != nil {
+					slog.Error("ptrace: WaitAttached failed", "pid", pid, "error", err)
+					if cfg.OnAttachFailure == "fail_closed" {
+						a.ptraceFailed.Store(true)
+					}
+					return
+				}
+				slog.Info("ptrace: attached to target PID", "pid", pid)
+			}(targetPID)
+		}
+	}
 }
 
 // resolveFamilyCheckerForPtrace resolves the FamilyChecker to install on the


### PR DESCRIPTION
## Summary

`sandbox.ptrace.attach_mode: \"pid\"` with `target_pid` (or `target_pid_file`) is parsed, validated, and logged at startup — but the runtime never calls `tr.AttachPID(targetPID)`. The tracer runs with zero tracees and command/network policy enforcement silently no-ops.

This is the path needed for hosts where commands are spawned by a non-agentsh ancestor — OpenComputer (`osb-agent` is PID 1, agentsh server is its child), generic Docker `exec` setups, sidecar deployments, etc. On those hosts `attach_mode: \"children\"` misses everything because `sbx.exec.run` commands aren't children of agentsh.

## Reproduction

OpenComputer was the discovery vector. Full repro repo: https://github.com/canyonroad/agentsh-opencomputer (build pipeline, config, image, end-to-end probe with output traces).

Minimal config that exhibits the bug on any Linux host where agentsh isn't the ancestor of the workload:

\`\`\`yaml
sandbox:
  ptrace:
    enabled: true
    attach_mode: \"pid\"
    target_pid: 1                # or any pid not descended from agentsh
    trace: { execve: true, file: false, network: true, signal: false }
    on_attach_failure: \"fail_closed\"
\`\`\`

Run agentsh server (with CAP_SYS_PTRACE if Yama is active), then exec a denied command externally — it returns successfully because the tracer never attached. Server log shows `INFO ptrace tracer started attach_mode=pid` but no `attached to PID` line and no `AttachPID failed` line — the call simply doesn't happen.

## Root cause

`internal/api/app_ptrace_linux.go:initPtraceTracer()` builds a `TracerConfig` from `cfg.AttachMode` etc. and starts `tr.Run(ctx)` in a goroutine, then returns. `cfg.TargetPID` and `cfg.TargetPIDFile` are read into `SandboxPtraceConfig` from YAML (`internal/config/ptrace.go`) but never reach the tracer. `Validate()` only checks `AttachMode == \"pid\" && TargetPID <= 0 && TargetPIDFile == \"\"`, so a config like the one above passes validation cleanly.

`tr.AttachPID(...)` is currently called only from:
- `internal/api/exec_ptrace_linux.go:48` (the wrap-on-API-exec path)
- `internal/api/wrap_linux.go:316` (the wrap-on-shim path)

Neither triggers from the `attach_mode: \"pid\"` config. The integration tests under `internal/ptrace/integration_test.go` that exercise pid mode call `tr.AttachPID(pid)` manually from test code — they bypass `initPtraceTracer` entirely so wouldn't catch this regression.

## What this PR does

1. **`internal/api/app_ptrace_linux.go`** — after the `tr.Run` goroutine launches, if `cfg.AttachMode == \"pid\"`:
   - Resolve target from `cfg.TargetPID`, falling back to parsing `cfg.TargetPIDFile`
   - In a goroutine: `tr.AttachPID(pid)` → `tr.WaitAttached(pid)` → log success or failure
   - Honor `cfg.OnAttachFailure: \"fail_closed\"` by setting `a.ptraceFailed`

2. **`internal/api/app_ptrace_init_linux_test.go`** (new) — three regression tests:
   - `TestInitPtraceTracer_AttachModePidFromTargetPID` — inline `target_pid` → `TraceeCount() > 0`
   - `TestInitPtraceTracer_AttachModePidFromTargetPIDFile` — pid file is read, parsed, attached
   - `TestInitPtraceTracer_AttachModePidFailsClosedOnBadPID` — fail_closed semantics on `AttachPID` failure

Each test guards with a `requirePtrace(t)` helper that skips on runners without `PTRACE_SEIZE` permission (matches the pattern in `internal/ptrace/integration_test.go`).

## Verification

\`\`\`
$ go build ./...
clean

$ go test ./internal/api/ ./internal/config/ ./internal/ptrace/
ok  	github.com/agentsh/agentsh/internal/api      9.9s
ok  	github.com/agentsh/agentsh/internal/config   <1s
ok  	github.com/agentsh/agentsh/internal/ptrace   <1s

$ go test -v -run TestInitPtraceTracer_AttachMode ./internal/api/
--- PASS: TestInitPtraceTracer_AttachModePidFromTargetPID (0.02s)
--- PASS: TestInitPtraceTracer_AttachModePidFromTargetPIDFile (0.02s)
--- PASS: TestInitPtraceTracer_AttachModePidFailsClosedOnBadPID (0.02s)

# Without the fix (test file alone, against unmodified main):
--- FAIL: TestInitPtraceTracer_AttachModePidFromTargetPID (3.01s)
    app_ptrace_init_linux_test.go:115: tracer did not register a tracee within 3s — initPtraceTracer is not wiring TargetPID
--- FAIL: TestInitPtraceTracer_AttachModePidFromTargetPIDFile (3.03s)
--- FAIL: TestInitPtraceTracer_AttachModePidFailsClosedOnBadPID (2.02s)
\`\`\`

The without-patch failure messages are exactly the diagnostic strings each test asserts — they're real regression catchers, not just compile checks.

## Side findings (not addressed in this PR — flagging for separate issues)

These came up during the OpenComputer investigation and are worth tracking, but are out of scope for this fix:

1. **`shellc-opaque-script` blanket-denies `bash -c \"echo hello\"`** when `AGENTSH_SHIM_FORCE=1` is set. The shim already has a parser (`internal/shellparse`) that could analyze the `-c` content; deny-on-restrictive should fire only when the parser actually flags an opaque construct, not all `-c` invocations.
2. **`agentsh-unixwrap`'s `exec.LookPath` fails on OC** with the same image that works on E2B. `cmd/agentsh-unixwrap/main.go:220` uses `os.Getenv(\"PATH\")` which appears empty in the wrapper's runtime context on OC, or `/usr/bin` traversal is restricted by landlock.
3. **`cgroups-v2 ✓` is misleading on OC** — `agentsh detect` reports cgroups available, but `mkdir /sys/fs/cgroup/agentsh-session-...` fails with `permission denied` even though the cgroup subtree is delegated. Per-session resource isolation reports as available but doesn't actually work.

Happy to file these as separate issues if useful.

## Test plan

- [ ] Reviewer runs `go test ./...` and confirms green
- [ ] Reviewer runs `go test -v -run TestInitPtraceTracer_AttachMode ./internal/api/` to see the three new tests pass
- [ ] (Optional) Reviewer reverts `internal/api/app_ptrace_linux.go` only and re-runs the new tests — should fail with the documented diagnostic strings, confirming they catch the bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)