### PR TITLE
pkgcheck: Snyk + Socket pre-install gating with privacy filter, retry+breaker, and policy plumbing

### DIFF
--- a/docs/superpowers/plans/2026-05-01-snyk-socket-pre-install-gate.md
+++ b/docs/superpowers/plans/2026-05-01-snyk-socket-pre-install-gate.md
@@ -1,5 +1,14 @@
 # Snyk and Socket Pre-Install Gating Implementation Plan
 
+> **PIVOT (2026-05-01, mid-execution):** During T5 we discovered that `internal/pkgcheck/provider/socket.go` and `snyk.go` already exist in the codebase from prior PRs (`a703bc06`, `90cf4934`). The original plan assumed both were greenfield. After T1-T4 landed (foundation types + retry/breaker infra), tasks T5-T10 were re-scoped from "create from scratch" to **"enhance existing providers with retry+breaker integration."** Specifically:
+>
+> - T5 was reverted (`buildSocketPURLs` is dead code — existing Socket uses `/v0/scan/batch`, not `/v0/purl`).
+> - T6/T7/T9/T10 dropped in favor of two new tasks: **T6'** (wire `retryClient` + `callWithBreaker` into existing `socketProvider.CheckBatch`) and **T7'** (same for `snykProvider`, plus add bounded concurrency to its sequential fan-out).
+> - **T8'** wires both existing providers into the shared contract suite from T2.
+> - Tasks T11-T20 stand essentially as written. Config defaults (T16) just need to ensure the existing `socket`/`snyk` provider entries exist in the providers map — they currently do not appear in `DefaultPackageChecksConfig()`.
+>
+> The original task descriptions below are kept for historical context but are NOT the source of truth past T4.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Add Snyk and Socket as pluggable `CheckProvider` implementations so intercepted package installs can be gated pre-execution against supply-chain attacks, with degraded-fallback behavior, privacy filtering for private packages, and rule-engine-driven verdict policy.

--- a/docs/superpowers/plans/2026-05-01-snyk-socket-pre-install-gate.md
+++ b/docs/superpowers/plans/2026-05-01-snyk-socket-pre-install-gate.md
@@ -1,0 +1,3232 @@
+# Snyk and Socket Pre-Install Gating Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Snyk and Socket as pluggable `CheckProvider` implementations so intercepted package installs can be gated pre-execution against supply-chain attacks, with degraded-fallback behavior, privacy filtering for private packages, and rule-engine-driven verdict policy.
+
+**Architecture:** Two new providers (`provider/socket.go`, `provider/snyk.go`) implementing the existing `pkgcheck.CheckProvider` interface, plus a small shared `httpclient.go` with retry/rate-limit/circuit-breaker. Privacy filtering happens upstream of the orchestrator. The `fail_mode` config compiles to existing `OnFailure` per-provider semantics. The `block_on` policy config compiles to `policy.PackageRule` entries — no new evaluator engine.
+
+**Tech Stack:** Go 1.22+, standard library `net/http`, `golang.org/x/sync/errgroup`, existing `internal/pkgcheck` infra (orchestrator, evaluator, cache), existing `internal/policy` rule engine.
+
+**Spec:** `docs/superpowers/specs/2026-05-01-snyk-socket-pre-install-gate-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `internal/pkgcheck/provider/httpclient.go` — shared HTTP client with bounded retries, rate-limit handling, and circuit breaker.
+- `internal/pkgcheck/provider/httpclient_test.go`
+- `internal/pkgcheck/provider/socket.go` — Socket provider implementation.
+- `internal/pkgcheck/provider/socket_test.go`
+- `internal/pkgcheck/provider/snyk.go` — Snyk provider implementation.
+- `internal/pkgcheck/provider/snyk_test.go`
+- `internal/pkgcheck/provider/contract_test.go` — shared `CheckProvider` contract suite (run against OSV, Socket, Snyk).
+- `internal/pkgcheck/provider/testdata/socket_purl_response.json`
+- `internal/pkgcheck/provider/testdata/socket_malware_response.json`
+- `internal/pkgcheck/provider/testdata/snyk_test_response.json`
+- `internal/pkgcheck/provider/testdata/snyk_no_issues_response.json`
+- `internal/pkgcheck/privacy.go` — registry/scope filter helper.
+- `internal/pkgcheck/privacy_test.go`
+
+**Modified files:**
+- `internal/pkgcheck/types.go` — add `SkippedPackage` type and `Verdict.Skipped` field.
+- `internal/pkgcheck/orchestrator.go` — pre-filter privacy-skipped packages, surface them on the response, plumb circuit-breaker state per provider.
+- `internal/pkgcheck/cache/cache.go` — distinguish clean / found / not-found TTLs; add `PutNotFound`.
+- `internal/pkgcheck/cache/cache_test.go`
+- `internal/config/pkgcheck.go` — add `BlockOn` policy shorthand, `Privacy` block, `FailMode`; default scope override; emit validation warning.
+- `internal/config/pkgcheck_test.go`
+
+---
+
+## Task Order Rationale
+
+Foundation types (Tasks 1-2) must land first because privacy/orchestrator/test-fixtures all reference them. The shared HTTP helper (Tasks 3-4) lands before either provider so both can consume it. Socket goes before Snyk because it's simpler (single batch call) and exercises the helper. Cache changes (Tasks 11-12) land before orchestrator privacy/fail-mode wiring (Tasks 13-15) because the orchestrator now needs to call new cache methods. Config changes (Tasks 16-18) land last because they wire everything that already works individually.
+
+---
+
+## Task 1: Add SkippedPackage type and Verdict.Skipped field
+
+**Files:**
+- Modify: `internal/pkgcheck/types.go:152-158`
+- Test: `internal/pkgcheck/types_test.go`
+
+- [ ] **Step 1: Write failing test for SkippedPackage**
+
+Add to `internal/pkgcheck/types_test.go`:
+
+```go
+func TestSkippedPackage_ReasonString(t *testing.T) {
+	s := SkippedPackage{
+		Package: PackageRef{Name: "@acme/internal", Version: "1.0.0"},
+		Reason:  SkipReasonPrivateRegistry,
+	}
+	if s.Reason != "private_registry" {
+		t.Fatalf("want private_registry, got %s", s.Reason)
+	}
+}
+
+func TestVerdict_SkippedSurfaced(t *testing.T) {
+	v := Verdict{
+		Action: VerdictAllow,
+		Skipped: []SkippedPackage{{
+			Package: PackageRef{Name: "@acme/internal", Version: "1.0.0"},
+			Reason:  SkipReasonPrivateRegistry,
+		}},
+	}
+	if len(v.Skipped) != 1 {
+		t.Fatalf("want 1 skipped, got %d", len(v.Skipped))
+	}
+}
+```
+
+- [ ] **Step 2: Run test, expect compile failure**
+
+Run: `go test ./internal/pkgcheck/ -run TestSkippedPackage -v`
+Expected: build error referencing `SkipReasonPrivateRegistry` undefined and `Verdict.Skipped` undefined.
+
+- [ ] **Step 3: Add the type and field**
+
+In `internal/pkgcheck/types.go`, after the `PackageVerdict` block:
+
+```go
+// SkipReason describes why a package was excluded from external scanning.
+type SkipReason string
+
+const (
+	// SkipReasonPrivateRegistry indicates the package was resolved from a
+	// registry not on the external-scan allowlist.
+	SkipReasonPrivateRegistry SkipReason = "private_registry"
+
+	// SkipReasonPrivateScopeDenylist indicates the package matched a scope
+	// or prefix on the privacy denylist.
+	SkipReasonPrivateScopeDenylist SkipReason = "private_scope_denylist"
+)
+
+// SkippedPackage records a package that was not externally scanned
+// because of privacy rules.
+type SkippedPackage struct {
+	Package PackageRef `json:"package" yaml:"package"`
+	Reason  SkipReason `json:"reason" yaml:"reason"`
+}
+```
+
+In the `Verdict` struct, add `Skipped`:
+
+```go
+type Verdict struct {
+	Action   VerdictAction             `json:"action" yaml:"action"`
+	Findings []Finding                 `json:"findings,omitempty" yaml:"findings,omitempty"`
+	Summary  string                    `json:"summary" yaml:"summary"`
+	Packages map[string]PackageVerdict `json:"packages,omitempty" yaml:"packages,omitempty"`
+	Skipped  []SkippedPackage          `json:"skipped,omitempty" yaml:"skipped,omitempty"`
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/pkgcheck/ -run "TestSkippedPackage|TestVerdict_SkippedSurfaced" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run full pkgcheck suite to verify no regressions**
+
+Run: `go test ./internal/pkgcheck/...`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/pkgcheck/types.go internal/pkgcheck/types_test.go
+git commit -m "pkgcheck: add Skipped field and SkipReason for privacy filter"
+```
+
+---
+
+## Task 2: Define shared CheckProvider contract test suite
+
+**Files:**
+- Create: `internal/pkgcheck/provider/contract_test.go`
+
+This test runs against any `CheckProvider` and asserts the contract every implementation must satisfy. Each new provider (Socket, Snyk) wires itself into this suite via a sub-test entry point.
+
+- [ ] **Step 1: Write the contract suite scaffold**
+
+Create `internal/pkgcheck/provider/contract_test.go`:
+
+```go
+package provider
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/pkgcheck"
+)
+
+// providerFactory builds a CheckProvider configured to talk to the given baseURL.
+// Each provider's test file defines its own factory.
+type providerFactory func(t *testing.T, baseURL string) pkgcheck.CheckProvider
+
+// runContractSuite runs the shared CheckProvider contract assertions.
+func runContractSuite(t *testing.T, name string, makeProvider providerFactory, fixture contractFixture) {
+	t.Run(name+"/EmptyInput", func(t *testing.T) {
+		p := makeProvider(t, fixture.cleanServerURL)
+		resp, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+			Ecosystem: pkgcheck.EcosystemNPM,
+			Packages:  nil,
+		})
+		if err != nil {
+			t.Fatalf("empty input must not error: %v", err)
+		}
+		if resp == nil {
+			t.Fatal("response must not be nil")
+		}
+		if len(resp.Findings) != 0 {
+			t.Fatalf("empty input should yield 0 findings, got %d", len(resp.Findings))
+		}
+	})
+
+	t.Run(name+"/RespectsContextCancellation", func(t *testing.T) {
+		p := makeProvider(t, fixture.slowServerURL)
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		_, err := p.CheckBatch(ctx, pkgcheck.CheckRequest{
+			Ecosystem: pkgcheck.EcosystemNPM,
+			Packages:  []pkgcheck.PackageRef{{Name: "lodash", Version: "4.17.21"}},
+		})
+		if err == nil {
+			t.Fatal("cancelled context must produce an error")
+		}
+	})
+
+	t.Run(name+"/TransportErrorReturnsError", func(t *testing.T) {
+		p := makeProvider(t, "http://127.0.0.1:1") // unreachable
+		_, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+			Ecosystem: pkgcheck.EcosystemNPM,
+			Packages:  []pkgcheck.PackageRef{{Name: "lodash", Version: "4.17.21"}},
+		})
+		if err == nil {
+			t.Fatal("transport error must return an error")
+		}
+	})
+}
+
+// contractFixture holds the test servers a provider needs to exercise the contract.
+type contractFixture struct {
+	cleanServerURL string // returns a 200 OK with no findings
+	slowServerURL  string // sleeps longer than the test ctx timeout
+}
+```
+
+- [ ] **Step 2: Verify it compiles (no providers wire in yet)**
+
+Run: `go build ./internal/pkgcheck/provider/...`
+Expected: build succeeds. No tests run yet — the suite is invoked by per-provider test files added in Tasks 8 and 10.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/pkgcheck/provider/contract_test.go
+git commit -m "pkgcheck/provider: add shared CheckProvider contract test suite"
+```
+
+---
+
+## Task 3: HTTP helper — bounded retry with backoff and rate-limit handling
+
+**Files:**
+- Create: `internal/pkgcheck/provider/httpclient.go`
+- Create: `internal/pkgcheck/provider/httpclient_test.go`
+
+- [ ] **Step 1: Write failing test for retry on 5xx**
+
+Create `internal/pkgcheck/provider/httpclient_test.go`:
+
+```go
+package provider
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRetryClient_Retries5xxThenSucceeds(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer srv.Close()
+
+	c := newRetryClient(retryConfig{
+		MaxAttempts: 5,
+		BaseBackoff: 1 * time.Millisecond,
+		MaxBackoff:  10 * time.Millisecond,
+	})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("want 3 attempts, got %d", got)
+	}
+}
+
+func TestRetryClient_RespectsRetryAfterHeader(t *testing.T) {
+	start := time.Now()
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newRetryClient(retryConfig{
+		MaxAttempts:    3,
+		BaseBackoff:    1 * time.Millisecond,
+		MaxBackoff:     10 * time.Second,
+		RespectRetryAfter: true,
+	})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+	elapsed := time.Since(start)
+	if elapsed < 900*time.Millisecond {
+		t.Fatalf("expected ~1s wait for Retry-After, got %v", elapsed)
+	}
+}
+
+func TestRetryClient_GivesUpAfterMaxAttempts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newRetryClient(retryConfig{MaxAttempts: 3, BaseBackoff: 1 * time.Millisecond, MaxBackoff: 5 * time.Millisecond})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, strings.NewReader(""))
+	resp, err := c.Do(req)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("expected error after max attempts, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run test, expect compile failure**
+
+Run: `go test ./internal/pkgcheck/provider/ -run TestRetryClient -v`
+Expected: build error — `newRetryClient`, `retryConfig` undefined.
+
+- [ ] **Step 3: Implement retry client**
+
+Create `internal/pkgcheck/provider/httpclient.go`:
+
+```go
+package provider
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// retryConfig configures the bounded-retry HTTP client.
+type retryConfig struct {
+	MaxAttempts       int
+	BaseBackoff       time.Duration
+	MaxBackoff        time.Duration
+	RespectRetryAfter bool
+	Transport         http.RoundTripper // optional, defaults to http.DefaultTransport
+}
+
+// retryClient wraps http.Client with bounded retries on 429/5xx and
+// optional Retry-After header handling.
+type retryClient struct {
+	cfg    retryConfig
+	client *http.Client
+}
+
+// newRetryClient creates a retryClient with sane defaults if zero values are passed.
+func newRetryClient(cfg retryConfig) *retryClient {
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = 3
+	}
+	if cfg.BaseBackoff <= 0 {
+		cfg.BaseBackoff = 200 * time.Millisecond
+	}
+	if cfg.MaxBackoff <= 0 {
+		cfg.MaxBackoff = 5 * time.Second
+	}
+	transport := cfg.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	return &retryClient{
+		cfg:    cfg,
+		client: &http.Client{Transport: transport},
+	}
+}
+
+// Do executes the request with bounded retries on 429/5xx.
+// The request body, if any, must be replayable — callers should pass a
+// *bytes.Reader or similar that can be re-read.
+func (c *retryClient) Do(req *http.Request) (*http.Response, error) {
+	var bodyBytes []byte
+	if req.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(req.Body)
+		_ = req.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read request body: %w", err)
+		}
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= c.cfg.MaxAttempts; attempt++ {
+		if bodyBytes != nil {
+			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			lastErr = err
+			if attempt == c.cfg.MaxAttempts {
+				break
+			}
+			c.sleep(attempt, nil, req)
+			continue
+		}
+
+		if resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
+			return resp, nil
+		}
+
+		// Retryable status — drain body and try again.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		lastErr = fmt.Errorf("http status %d", resp.StatusCode)
+		if attempt == c.cfg.MaxAttempts {
+			break
+		}
+		c.sleep(attempt, resp, req)
+	}
+
+	return nil, fmt.Errorf("retryClient: gave up after %d attempts: %w", c.cfg.MaxAttempts, lastErr)
+}
+
+// sleep applies Retry-After (when configured and present) or exponential
+// backoff with jitter. Honors context cancellation.
+func (c *retryClient) sleep(attempt int, resp *http.Response, req *http.Request) {
+	wait := c.backoff(attempt)
+	if c.cfg.RespectRetryAfter && resp != nil {
+		if h := resp.Header.Get("Retry-After"); h != "" {
+			if secs, err := strconv.Atoi(h); err == nil && secs > 0 {
+				wait = time.Duration(secs) * time.Second
+			}
+		}
+	}
+	if wait > c.cfg.MaxBackoff {
+		wait = c.cfg.MaxBackoff
+	}
+
+	select {
+	case <-time.After(wait):
+	case <-req.Context().Done():
+	}
+}
+
+// backoff returns exponential-with-jitter backoff for the given attempt.
+func (c *retryClient) backoff(attempt int) time.Duration {
+	exp := time.Duration(1<<uint(attempt-1)) * c.cfg.BaseBackoff
+	if exp > c.cfg.MaxBackoff {
+		exp = c.cfg.MaxBackoff
+	}
+	// Full jitter: random in [0, exp].
+	jitter := time.Duration(rand.Int63n(int64(exp) + 1))
+	return jitter
+}
+
+// errMaxAttempts is exposed for tests that want to assert "gave up".
+var errMaxAttempts = errors.New("max retry attempts exceeded")
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/pkgcheck/provider/ -run TestRetryClient -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/pkgcheck/provider/httpclient.go internal/pkgcheck/provider/httpclient_test.go
+git commit -m "pkgcheck/provider: add retry client with backoff and Retry-After support"
+```
+
+---
+
+## Task 4: HTTP helper — circuit breaker
+
+**Files:**
+- Modify: `internal/pkgcheck/provider/httpclient.go`
+- Modify: `internal/pkgcheck/provider/httpclient_test.go`
+
+The breaker tracks consecutive failures per provider; after 3 in 60s it opens for 60s. While open, calls return immediately with a sentinel error so the orchestrator skips the network.
+
+- [ ] **Step 1: Write failing test for circuit breaker**
+
+Append to `internal/pkgcheck/provider/httpclient_test.go`:
+
+```go
+func TestCircuitBreaker_OpensAfterConsecutiveFailures(t *testing.T) {
+	cb := newCircuitBreaker(circuitBreakerConfig{
+		Threshold:  3,
+		Window:     time.Second,
+		OpenPeriod: 100 * time.Millisecond,
+	})
+
+	if !cb.Allow() {
+		t.Fatal("breaker should start closed")
+	}
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if !cb.Allow() {
+		t.Fatal("breaker should still be closed after 2 failures")
+	}
+	cb.RecordFailure()
+	if cb.Allow() {
+		t.Fatal("breaker should be open after 3 failures")
+	}
+}
+
+func TestCircuitBreaker_ClosesAfterOpenPeriod(t *testing.T) {
+	cb := newCircuitBreaker(circuitBreakerConfig{
+		Threshold:  2,
+		Window:     time.Second,
+		OpenPeriod: 50 * time.Millisecond,
+	})
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if cb.Allow() {
+		t.Fatal("breaker should be open")
+	}
+	time.Sleep(80 * time.Millisecond)
+	if !cb.Allow() {
+		t.Fatal("breaker should re-close after open period")
+	}
+}
+
+func TestCircuitBreaker_SuccessResetsFailures(t *testing.T) {
+	cb := newCircuitBreaker(circuitBreakerConfig{
+		Threshold:  3,
+		Window:     time.Second,
+		OpenPeriod: 100 * time.Millisecond,
+	})
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordSuccess()
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if !cb.Allow() {
+		t.Fatal("breaker should still be closed: success reset failure count")
+	}
+}
+```
+
+- [ ] **Step 2: Run, expect compile failure**
+
+Run: `go test ./internal/pkgcheck/provider/ -run TestCircuitBreaker -v`
+Expected: build error — `newCircuitBreaker`, `circuitBreakerConfig` undefined.
+
+- [ ] **Step 3: Implement the breaker**
+
+Append to `internal/pkgcheck/provider/httpclient.go`:
+
+```go
+import "sync"
+
+// circuitBreakerConfig controls breaker behavior.
+type circuitBreakerConfig struct {
+	Threshold  int           // consecutive failures before opening
+	Window     time.Duration // window in which Threshold failures must occur
+	OpenPeriod time.Duration // how long the breaker stays open
+}
+
+// circuitBreaker tracks consecutive provider failures and short-circuits
+// while open. Safe for concurrent use.
+type circuitBreaker struct {
+	cfg circuitBreakerConfig
+
+	mu             sync.Mutex
+	failures       int
+	firstFailureAt time.Time
+	openedAt       time.Time
+}
+
+func newCircuitBreaker(cfg circuitBreakerConfig) *circuitBreaker {
+	if cfg.Threshold <= 0 {
+		cfg.Threshold = 3
+	}
+	if cfg.Window <= 0 {
+		cfg.Window = 60 * time.Second
+	}
+	if cfg.OpenPeriod <= 0 {
+		cfg.OpenPeriod = 60 * time.Second
+	}
+	return &circuitBreaker{cfg: cfg}
+}
+
+// Allow reports whether a call may proceed.
+func (b *circuitBreaker) Allow() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.openedAt.IsZero() {
+		return true
+	}
+	if time.Since(b.openedAt) >= b.cfg.OpenPeriod {
+		// Re-close.
+		b.openedAt = time.Time{}
+		b.failures = 0
+		return true
+	}
+	return false
+}
+
+// RecordSuccess resets the failure counter.
+func (b *circuitBreaker) RecordSuccess() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.failures = 0
+	b.firstFailureAt = time.Time{}
+}
+
+// RecordFailure increments the failure counter and opens the breaker if the
+// threshold is crossed within the window.
+func (b *circuitBreaker) RecordFailure() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := time.Now()
+	if b.failures == 0 || now.Sub(b.firstFailureAt) > b.cfg.Window {
+		b.failures = 1
+		b.firstFailureAt = now
+	} else {
+		b.failures++
+	}
+
+	if b.failures >= b.cfg.Threshold {
+		b.openedAt = now
+	}
+}
+```
+
+(Move the `import "sync"` line into the existing import block at the top of the file.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/pkgcheck/provider/ -run "TestRetryClient|TestCircuitBreaker" -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/pkgcheck/provider/httpclient.go internal/pkgcheck/provider/httpclient_test.go
+git commit -m "pkgcheck/provider: add circuit breaker for provider failure isolation"
+```
+
+---
+
+## Task 5: Socket provider — request building (PURL)
+
+**Files:**
+- Create: `internal/pkgcheck/provider/socket.go`
+- Create: `internal/pkgcheck/provider/socket_test.go`
+
+- [ ] **Step 1: Write failing test for PURL construction**
+
+Create `internal/pkgcheck/provider/socket_test.go`:
+
+```go
+package provider
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/pkgcheck"
+)
+
+func TestSocket_BuildPURLs_NPM(t *testing.T) {
+	pkgs := []pkgcheck.PackageRef{
+		{Name: "lodash", Version: "4.17.21"},
+		{Name: "@types/node", Version: "20.10.0"},
+	}
+	got := buildSocketPURLs(pkgcheck.EcosystemNPM, pkgs)
+	want := []string{
+		"pkg:npm/lodash@4.17.21",
+		"pkg:npm/%40types/node@20.10.0",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: want %d, got %d", len(want), len(got))
+	}
+	for i, p := range got {
+		if p != want[i] {
+			t.Errorf("idx %d: want %q got %q", i, want[i], p)
+		}
+	}
+}
+
+func TestSocket_BuildPURLs_PyPI(t *testing.T) {
+	pkgs := []pkgcheck.PackageRef{{Name: "requests", Version: "2.31.0"}}
+	got := buildSocketPURLs(pkgcheck.EcosystemPyPI, pkgs)
+	want := "pkg:pypi/requests@2.31.0"
+	if got[0] != want {
+		t.Fatalf("want %q got %q", want, got[0])
+	}
+}
+```
+
+- [ ] **Step 2: Run, expect compile failure**
+
+Run: `go test ./internal/pkgcheck/provider/ -run TestSocket_BuildPURLs -v`
+Expected: build error — `buildSocketPURLs` undefined.
+
+- [ ] **Step 3: Implement PURL building**
+
+Create `internal/pkgcheck/provider/socket.go`:
+
+```go
+package provider
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/agentsh/agentsh/internal/pkgcheck"
+)
+
+// buildSocketPURLs converts a list of PackageRef to PURL strings (per spec
+// https://github.com/package-url/purl-spec) for Socket's batch endpoint.
+//
+// The package name is path-escaped (so `@scope/name` becomes `%40scope/name`)
+// to comply with PURL grammar.
+func buildSocketPURLs(eco pkgcheck.Ecosystem, pkgs []pkgcheck.PackageRef) []string {
+	ecoStr := mapEcosystemSocket(eco)
+	out := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		// Split scope from name to escape only the @scope portion.
+		// PURL grammar requires the leading `@` to be percent-encoded.
+		name := p.Name
+		if strings.HasPrefix(name, "@") && strings.Contains(name, "/") {
+			parts := strings.SplitN(name, "/", 2)
+			name = url.PathEscape(parts[0]) + "/" + parts[1]
+		}
+		purl := "pkg:" + ecoStr + "/" + name
+		if p.Version != "" {
+			purl += "@" + p.Version
+		}
+		out = append(out, purl)
+	}
+	return out
+}
+
+// mapEcosystemSocket converts our Ecosystem to Socket's PURL ecosystem token.
+func mapEcosystemSocket(eco pkgcheck.Ecosystem) string {
+	switch eco {
+	case pkgcheck.EcosystemNPM:
+		return "npm"
+	case pkgcheck.EcosystemPyPI:
+		return "pypi"
+	default:
+		return string(eco)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/pkgcheck/provider/ -run TestSocket_BuildPURLs -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/pkgcheck/provider/socket.go internal/pkgcheck/provider/socket_test.go
+git commit -m "pkgcheck/provider: add Socket PURL builder"
+```
+
+---
+
+## Task 6: Socket provider — alert → Finding mapping
+
+**Files:**
+- Modify: `internal/pkgcheck/provider/socket.go`
+- Modify: `internal/pkgcheck/provider/socket_test.go`
+- Create: `internal/pkgcheck/provider/testdata/socket_malware_response.json`
+
+- [ ] **Step 1: Capture a representative Socket response into testdata**
+
+Create `internal/pkgcheck/provider/testdata/socket_malware_response.json`:
+
+```json
+[
+  {
+    "purl": "pkg:npm/evil-package@1.0.0",
+    "name": "evil-package",
+    "version": "1.0.0",
+    "type": "npm",
+    "score": {"supplyChainRisk": {"score": 0.05}},
+    "alerts": [
+      {"type": "malware", "severity": "critical", "title": "Known malicious package"},
+      {"type": "installScripts", "severity": "high", "title": "Runs install scripts"}
+    ]
+  },
+  {
+    "purl": "pkg:npm/lodash@4.17.21",
+    "name": "lodash",
+    "version": "4.17.21",
+    "type": "npm",
+    "score": {"supplyChainRisk": {"score": 0.95}},
+    "alerts": []
+  },
+  {
+    "purl": "pkg:npm/typo-react@1.0.0",
+    "name": "typo-react",
+    "version": "1.0.0",
+    "type": "npm",
+    "score": {"supplyChainRisk": {"score": 0.5}},
+    "alerts": [
+      {"type": "typosquat", "severity": "medium", "title": "Possible typosquat of `react`"}
+    ]
+  }
+]
+```
+
+- [ ] **Step 2: Write failing test for alert mapping**
+
+Append to `internal/pkgcheck/provider/socket_test.go`:
+
+```go
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+func TestSocket_MapAlertsToFindings(t *testing.T) {
+	path := filepath.Join("testdata", "socket_malware_response.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var pkgs []socketPackageResp
+	if err := json.Unmarshal(raw, &pkgs); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	findings := mapSocketAlertsToFindings(pkgs)
+
+	// evil-package: malware (critical) + installScripts (high → malware critical-or-high mapping)
+	// typo-react: typosquat → reputation
+	// lodash: clean
+	wantTypes := map[string]int{
+		"malware":    2,
+		"reputation": 1,
+	}
+	got := map[string]int{}
+	for _, f := range findings {
+		got[string(f.Type)]++
+	}
+	for k, v := range wantTypes {
+		if got[k] != v {
+			t.Errorf("finding type %s: want %d got %d", k, v, got[k])
+		}
+	}
+
+	// Verify malware finding carries critical severity.
+	var sawCriticalMalware bool
+	for _, f := range findings {
+		if f.Type == pkgcheck.FindingMalware && f.Severity == pkgcheck.SeverityCritical {
+			sawCriticalMalware = true
+			break
+		}
+	}
+	if !sawCriticalMalware {
+		t.Error("expected at least one critical malware finding")
+	}
+}
+```
+
+- [ ] **Step 3: Run, expect compile failure**
+
+Run: `go test ./internal/pkgcheck/provider/ -run TestSocket_MapAlerts -v`
+Expected: build error.
+
+- [ ] **Step 4: Implement response types and mapping**
+
+Append to `internal/pkgcheck/provider/socket.go`:
+
+```go
+import (
+	"github.com/agentsh/agentsh/internal/pkgcheck"
+)
+
+// socketPackageResp is one element in the Socket /v0/purl response array.
+type socketPackageResp struct {
+	PURL    string         `json:"purl"`
+	Name    string         `json:"name"`
+	Version string         `json:"version"`
+	Type    string         `json:"type"`
+	Alerts  []socketAlert  `json:"alerts"`
+}
+
+type socketAlert struct {
+	Type     string `json:"type"`
+	Severity string `json:"severity"`
+	Title    string `json:"title"`
+	Detail   string `json:"detail"`
+}
+
+// mapSocketAlertsToFindings converts Socket alert objects into pkgcheck.Finding records.
+//
+// Mapping rules (per spec §"Per-provider implementations / Socket"):
+//   - "malware"                                                                → FindingMalware
+//   - "installScripts" / "shellAccess" / "networkAccess" with severity ≥ high → FindingMalware
+//                                          else                                → FindingReputation
+//   - "typosquat" / "suspiciousStarActivity" / "unmaintained"                  → FindingReputation
+//   - alert types containing "cve"                                             → FindingVulnerability
+//   - "licenseChange" / "nonpermissiveLicense"                                 → FindingLicense
+//   - "provenance*" / "signing*"                                               → FindingProvenance
+//   - unknown alert type                                                        → FindingReputation, severity Medium
+func mapSocketAlertsToFindings(pkgs []socketPackageResp) []pkgcheck.Finding {
+	var out []pkgcheck.Finding
+	for _, pkg := range pkgs {
+		ref := pkgcheck.PackageRef{Name: pkg.Name, Version: pkg.Version}
+		for _, a := range pkg.Alerts {
+			ftype, sev := classifySocketAlert(a)
+			out = append(out, pkgcheck.Finding{
+				Type:     ftype,
+				Provider: "socket",
+				Package:  ref,
+				Severity: sev,
+				Title:    a.Title,
+				Detail:   a.Detail,
+				Reasons:  []pkgcheck.Reason{{Code: a.Type, Message: a.Title}},
+			})
+		}
+	}
+	return out
+}
+
+// classifySocketAlert returns the Finding type and Severity for a Socket alert.
+func classifySocketAlert(a socketAlert) (pkgcheck.FindingType, pkgcheck.Severity) {
+	sev := mapSocketSeverity(a.Severity)
+	switch a.Type {
+	case "malware":
+		return pkgcheck.FindingMalware, sev
+	case "installScripts", "shellAccess", "networkAccess":
+		if sev == pkgcheck.SeverityCritical || sev == pkgcheck.SeverityHigh {
+			return pkgcheck.FindingMalware, sev
+		}
+		return pkgcheck.FindingReputation, sev
+	case "typosquat", "suspiciousStarActivity", "unmaintained":
+		return pkgcheck.FindingReputation, sev
+	case "licenseChange", "nonpermissiveLicense":
+		return pkgcheck.FindingLicense, sev
+	}
+	if strings.Contains(a.Type, "cve") || strings.HasPrefix(a.Type, "CVE-") {
+		return pkgcheck.FindingVulnerability, sev
+	}
+	if strings.HasPrefix(a.Type, "provenance") || strings.HasPrefix(a.Type, "signing") {
+		return pkgcheck.FindingProvenance, sev
+	}
+	// Unknown alert type — surface as reputation/medium per spec.
+	return pkgcheck.FindingReputation, pkgcheck.SeverityMedium
+}
+
+func mapSocketSeverity(s string) pkgcheck.Severity {
+	switch strings.ToLower(s) {
+	case "critical":
+		return pkgcheck.SeverityCritical
+	case "high":
+		return pkgcheck.SeverityHigh
+	case "medium":
+		return pkgcheck.SeverityMedium
+	case "low":
+		return pkgcheck.SeverityLow
+	default:
+		return pkgcheck.SeverityMedium
+	}
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./internal/pkgcheck/provider/ -run TestSocket -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/pkgcheck/provider/socket.go internal/pkgcheck/provider/socket_test.go internal/pkgcheck/provider/testdata/
+git commit -m "pkgcheck/provider: map Socket alerts to pkgcheck Findings"
+```
+
+---
+
+## Task 7: Socket provider — CheckBatch with chunking
+
+**Files:**
+- Modify: `internal/pkgcheck/provider/socket.go`
+- Modify: `internal/pkgcheck/provider/socket_test.go`
+
+- [ ] **Step 1: Write failing test for CheckBatch with httptest server**
+
+Append to `internal/pkgcheck/provider/socket_test.go`:
+
+```go
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"time"
+)
+
+func TestSocket_CheckBatch_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/purl" {
+			t.Errorf("want path /v0/purl, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		raw, _ := os.ReadFile(filepath.Join("testdata", "socket_malware_response.json"))
+		_, _ = w.Write(raw)
+	}))
+	defer srv.Close()
+
+	p := NewSocketProvider(SocketConfig{
+		BaseURL:        srv.URL,
+		APIKey:         "test-key",
+		Timeout:        2 * time.Second,
+		MaxPURLsPerCall: 100,
+	})
+	resp, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages: []pkgcheck.PackageRef{
+			{Name: "evil-package", Version: "1.0.0"},
+			{Name: "lodash", Version: "4.17.21"},
+			{Name: "typo-react", Version: "1.0.0"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Provider != "socket" {
+		t.Errorf("want provider=socket, got %s", resp.Provider)
+	}
+	if len(resp.Findings) == 0 {
+		t.Fatal("expected findings, got none")
+	}
+}
+
+func TestSocket_CheckBatch_Chunks(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+
+	pkgs := make([]pkgcheck.PackageRef, 250)
+	for i := range pkgs {
+		pkgs[i] = pkgcheck.PackageRef{Name: fmt.Sprintf("pkg-%d", i), Version: "1.0.0"}
+	}
+	p := NewSocketProvider(SocketConfig{
+		BaseURL:         srv.URL,
+		APIKey:          "test-key",
+		Timeout:         2 * time.Second,
+		MaxPURLsPerCall: 100,
+	})
+	_, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages:  pkgs,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 250 / 100 = 3 chunks
+	if got := calls.Load(); got != 3 {
+		t.Errorf("want 3 calls (chunks), got %d", got)
+	}
+}
+
+func TestSocket_CheckBatch_AuthHeaderSet(t *testing.T) {
+	var sawAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer srv.Close()
+	p := NewSocketProvider(SocketConfig{BaseURL: srv.URL, APIKey: "abc123", Timeout: time.Second, MaxPURLsPerCall: 100})
+	_, _ = p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages:  []pkgcheck.PackageRef{{Name: "foo", Version: "1"}},
+	})
+	if sawAuth == "" {
+		t.Fatal("Authorization header missing")
+	}
+}
+```
+
+- [ ] **Step 2: Run, expect compile failure**
+
+Run: `go test ./internal/pkgcheck/provider/ -run TestSocket_CheckBatch -v`
+Expected: build error — `NewSocketProvider`, `SocketConfig` undefined.
+
+- [ ] **Step 3: Implement the provider**
+
+Append to `internal/pkgcheck/provider/socket.go`:
+
+```go
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultSocketBaseURL        = "https://api.socket.dev"
+	defaultSocketTimeout        = 5 * time.Second
+	defaultSocketMaxPURLsPerCall = 100
+)
+
+// SocketConfig configures the Socket provider.
+type SocketConfig struct {
+	BaseURL         string
+	APIKey          string
+	Timeout         time.Duration
+	MaxPURLsPerCall int
+}
+
+type socketProvider struct {
+	baseURL         string
+	apiKey          string
+	maxPURLsPerCall int
+	client          *retryClient
+	breaker         *circuitBreaker
+}
+
+// NewSocketProvider returns a CheckProvider that queries Socket's /v0/purl batch endpoint.
+func NewSocketProvider(cfg SocketConfig) pkgcheck.CheckProvider {
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = defaultSocketBaseURL
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultSocketTimeout
+	}
+	if cfg.MaxPURLsPerCall <= 0 {
+		cfg.MaxPURLsPerCall = defaultSocketMaxPURLsPerCall
+	}
+	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
+
+	return &socketProvider{
+		baseURL:         cfg.BaseURL,
+		apiKey:          cfg.APIKey,
+		maxPURLsPerCall: cfg.MaxPURLsPerCall,
+		client: newRetryClient(retryConfig{
+			MaxAttempts:       3,
+			BaseBackoff:       200 * time.Millisecond,
+			MaxBackoff:        2 * time.Second,
+			RespectRetryAfter: true,
+		}),
+		breaker: newCircuitBreaker(circuitBreakerConfig{
+			Threshold:  3,
+			Window:     60 * time.Second,
+			OpenPeriod: 60 * time.Second,
+		}),
+	}
+}
+
+func (p *socketProvider) Name() string { return "socket" }
+
+func (p *socketProvider) Capabilities() []pkgcheck.FindingType {
+	return []pkgcheck.FindingType{
+		pkgcheck.FindingMalware,
+		pkgcheck.FindingVulnerability,
+		pkgcheck.FindingLicense,
+		pkgcheck.FindingReputation,
+		pkgcheck.FindingProvenance,
+	}
+}
+
+func (p *socketProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest) (*pkgcheck.CheckResponse, error) {
+	start := time.Now()
+	if len(req.Packages) == 0 {
+		return &pkgcheck.CheckResponse{
+			Provider: p.Name(),
+			Metadata: pkgcheck.ResponseMetadata{Duration: time.Since(start)},
+		}, nil
+	}
+	if !p.breaker.Allow() {
+		return &pkgcheck.CheckResponse{
+			Provider: p.Name(),
+			Metadata: pkgcheck.ResponseMetadata{
+				Duration: time.Since(start),
+				Partial:  true,
+				Error:    "circuit breaker open",
+			},
+		}, fmt.Errorf("socket: circuit breaker open")
+	}
+
+	purls := buildSocketPURLs(req.Ecosystem, req.Packages)
+
+	var allFindings []pkgcheck.Finding
+	for i := 0; i < len(purls); i += p.maxPURLsPerCall {
+		end := i + p.maxPURLsPerCall
+		if end > len(purls) {
+			end = len(purls)
+		}
+		findings, err := p.queryChunk(ctx, purls[i:end])
+		if err != nil {
+			p.breaker.RecordFailure()
+			return nil, fmt.Errorf("socket: chunk %d: %w", i/p.maxPURLsPerCall, err)
+		}
+		allFindings = append(allFindings, findings...)
+	}
+	p.breaker.RecordSuccess()
+
+	return &pkgcheck.CheckResponse{
+		Provider: p.Name(),
+		Findings: allFindings,
+		Metadata: pkgcheck.ResponseMetadata{Duration: time.Since(start)},
+	}, nil
+}
+
+func (p *socketProvider) queryChunk(ctx context.Context, purls []string) ([]pkgcheck.Finding, error) {
+	body, err := json.Marshal(map[string]any{"components": componentsFromPURLs(purls)})
+	if err != nil {
+		return nil, fmt.Errorf("marshal: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/v0/purl", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if p.apiKey != "" {
+		httpReq.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(p.apiKey+":")))
+	}
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("status %d: %s", resp.StatusCode, string(raw))
+	}
+
+	var pkgs []socketPackageResp
+	if err := json.NewDecoder(resp.Body).Decode(&pkgs); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	return mapSocketAlertsToFindings(pkgs), nil
+}
+
+// componentsFromPURLs wraps PURL strings in the {purl: "..."} object shape that Socket's API expects.
+func componentsFromPURLs(purls []string) []map[string]string {
+	out := make([]map[string]string, len(purls))
+	for i, p := range purls {
+		out[i] = map[string]string{"purl": p}
+	}
+	return out
+}
+```
+
+(Move imports into the existing import block at the top of the file.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/pkgcheck/provider/ -run TestSocket -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/pkgcheck/provider/socket.go internal/pkgcheck/provider/socket_test.go
+git commit -m "pkgcheck/provider: implement Socket CheckBatch with chunking and breaker"
+```
+
+---
+
+## Task 8: Wire Socket into the contract suite
+
+**Files:**
+- Modify: `internal/pkgcheck/provider/socket_test.go`
+
+- [ ] **Step 1: Add a contract-suite entry point for Socket**
+
+Append to `internal/pkgcheck/provider/socket_test.go`:
+
+```go
+func TestSocket_Contract(t *testing.T) {
+	cleanSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer cleanSrv.Close()
+
+	slowSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+	}))
+	defer slowSrv.Close()
+
+	factory := func(t *testing.T, baseURL string) pkgcheck.CheckProvider {
+		return NewSocketProvider(SocketConfig{BaseURL: baseURL, APIKey: "test", Timeout: 2 * time.Second, MaxPURLsPerCall: 100})
+	}
+	runContractSuite(t, "socket", factory, contractFixture{
+		cleanServerURL: cleanSrv.URL,
+		slowServerURL:  slowSrv.URL,
+	})
+}
+```
+
+- [ ] **Step 2: Run the contract suite for Socket**
+
+Run: `go test ./internal/pkgcheck/provider/ -run TestSocket_Contract -v`
+Expected: all sub-tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/pkgcheck/provider/socket_test.go
+git commit -m "pkgcheck/provider: run shared contract suite against Socket"
+```
+
+---
+
+## Task 9: Snyk provider — request/response types and per-package mapping
+
+**Files:**
+- Create: `internal/pkgcheck/provider/snyk.go`
+- Create: `internal/pkgcheck/provider/snyk_test.go`
+- Create: `internal/pkgcheck/provider/testdata/snyk_test_response.json`
+- Create: `internal/pkgcheck/provider/testdata/snyk_no_issues_response.json`
+
+- [ ] **Step 1: Capture Snyk response fixtures**
+
+Create `internal/pkgcheck/provider/testdata/snyk_test_response.json`:
+
+```json
+{
+  "ok": false,
+  "issues": {
+    "vulnerabilities": [
+      {
+        "id": "SNYK-JS-LODASH-1234567",
+        "title": "Prototype Pollution",
+        "severity": "high",
+        "cvssScore": 7.4,
+        "url": "https://snyk.io/vuln/SNYK-JS-LODASH-1234567",
+        "packageName": "lodash",
+        "version": "4.17.20"
+      }
+    ],
+    "licenses": []
+  }
+}
+```
+
+Create `internal/pkgcheck/provider/testdata/snyk_no_issues_response.json`:
+
+```json
+{"ok": true, "issues": {"vulnerabilities": [], "licenses": []}}
+```
+
+- [ ] **Step 2: Write failing test for response → Finding mapping**
+
+Create `internal/pkgcheck/provider/snyk_test.go`:
+
+```go
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/pkgcheck"
+)
+
+func TestSnyk_MapResponseToFindings(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("testdata", "snyk_test_response.json"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	var sr snykTestResp
+	if err := json.Unmarshal(raw, &sr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	ref := pkgcheck.PackageRef{Name: "lodash", Version: "4.17.20"}
+	findings := mapSnykResponseToFindings(ref, sr)
+
+	if len(findings) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(findings))
+	}
+	f := findings[0]
+	if f.Type != pkgcheck.FindingVulnerability {
+		t.Errorf("type: want vulnerability, got %s", f.Type)
+	}
+	if f.Severity != pkgcheck.SeverityHigh {
+		t.Errorf("severity: want high, got %s", f.Severity)
+	}
+	if f.Provider != "snyk" {
+		t.Errorf("provider: want snyk, got %s", f.Provider)
+	}
+}
+
+func TestSnyk_MapResponseToFindings_NoIssues(t *testing.T) {
+	raw, _ := os.ReadFile(filepath.Join("testdata", "snyk_no_issues_response.json"))
+	var sr snykTestResp
+	_ = json.Unmarshal(raw, &sr)
+	findings := mapSnykResponseToFindings(pkgcheck.PackageRef{Name: "lodash", Version: "4.17.21"}, sr)
+	if len(findings) != 0 {
+		t.Fatalf("want 0 findings, got %d", len(findings))
+	}
+}
+```
+
+- [ ] **Step 3: Run, expect compile failure**
+
+Run: `go test ./internal/pkgcheck/provider/ -run TestSnyk_MapResponse -v`
+Expected: build error — `snykTestResp`, `mapSnykResponseToFindings` undefined.
+
+- [ ] **Step 4: Implement types and mapping**
+
+Create `internal/pkgcheck/provider/snyk.go`:
+
+```go
+package provider
+
+import (
+	"github.com/agentsh/agentsh/internal/pkgcheck"
+)
+
+// snykTestResp is the response shape for /test/{ecosystem}/{name}/{version}.
+type snykTestResp struct {
+	OK     bool      `json:"ok"`
+	Issues snykIssues `json:"issues"`
+}
+
+type snykIssues struct {
+	Vulnerabilities []snykVuln    `json:"vulnerabilities"`
+	Licenses        []snykLicense `json:"licenses"`
+}
+
+type snykVuln struct {
+	ID          string  `json:"id"`
+	Title       string  `json:"title"`
+	Severity    string  `json:"severity"`
+	CVSSScore   float64 `json:"cvssScore"`
+	URL         string  `json:"url"`
+	PackageName string  `json:"packageName"`
+	Version     string  `json:"version"`
+}
+
+type snykLicense struct {
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	Severity string `json:"severity"`
+	License  string `json:"license"`
+	URL      string `json:"url"`
+}
+
+// mapSnykResponseToFindings translates a Snyk /test response for a single package
+// into pkgcheck.Finding records.
+func mapSnykResponseToFindings(pkg pkgcheck.PackageRef, r snykTestResp) []pkgcheck.Finding {
+	var out []pkgcheck.Finding
+	for _, v := range r.Issues.Vulnerabilities {
+		out = append(out, pkgcheck.Finding{
+			Type:     pkgcheck.FindingVulnerability,
+			Provider: "snyk",
+			Package:  pkg,
+			Severity: mapSnykSeverity(v.Severity),
+			Title:    v.Title,
+			Reasons:  []pkgcheck.Reason{{Code: "snyk_vuln", Message: v.ID}},
+			Links:    []string{v.URL},
+			Metadata: map[string]string{"snyk_id": v.ID},
+		})
+	}
+	for _, l := range r.Issues.Licenses {
+		out = append(out, pkgcheck.Finding{
+			Type:     pkgcheck.FindingLicense,
+			Provider: "snyk",
+			Package:  pkg,
+			Severity: mapSnykSeverity(l.Severity),
+			Title:    l.Title,
+			Reasons:  []pkgcheck.Reason{{Code: "snyk_license", Message: l.ID}},
+			Links:    []string{l.URL},
+			Metadata: map[string]string{"spdx": l.License},
+		})
+	}
+	return out
+}
+
+func mapSnykSeverity(s string) pkgcheck.Severity {
+	switch s {
+	case "critical":
+		return pkgcheck.SeverityCritical
+	case "high":
+		return pkgcheck.SeverityHigh
+	case "medium":
+		return pkgcheck.SeverityMedium
+	case "low":
+		return pkgcheck.SeverityLow
+	default:
+		return pkgcheck.SeverityMedium
+	}
+}
+
+func mapEcosystemSnyk(eco pkgcheck.Ecosystem) string {
+	switch eco {
+	case pkgcheck.EcosystemNPM:
+		return "npm"
+	case pkgcheck.EcosystemPyPI:
+		return "pip"
+	default:
+		return string(eco)
+	}
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./internal/pkgcheck/provider/ -run TestSnyk_MapResponse -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/pkgcheck/provider/snyk.go internal/pkgcheck/provider/snyk_test.go internal/pkgcheck/provider/testdata/snyk_*.json
+git commit -m "pkgcheck/provider: add Snyk response types and Finding mapper"
+```
+
+---
+
+## Task 10: Snyk provider — concurrency-bounded fan-out CheckBatch
+
+**Files:**
+- Modify: `internal/pkgcheck/provider/snyk.go`
+- Modify: `internal/pkgcheck/provider/snyk_test.go`
+
+- [ ] **Step 1: Write failing tests for fan-out**
+
+Append to `internal/pkgcheck/provider/snyk_test.go`:
+
+```go
+func TestSnyk_CheckBatch_FanOut(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		raw, _ := os.ReadFile(filepath.Join("testdata", "snyk_no_issues_response.json"))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(raw)
+	}))
+	defer srv.Close()
+
+	pkgs := make([]pkgcheck.PackageRef, 50)
+	for i := range pkgs {
+		pkgs[i] = pkgcheck.PackageRef{Name: fmt.Sprintf("pkg-%d", i), Version: "1.0.0"}
+	}
+	p := NewSnykProvider(SnykConfig{BaseURL: srv.URL, APIKey: "tk", Timeout: 2 * time.Second, Concurrency: 8})
+	resp, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages:  pkgs,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if int(calls.Load()) != len(pkgs) {
+		t.Errorf("want %d calls, got %d", len(pkgs), calls.Load())
+	}
+	if resp.Provider != "snyk" {
+		t.Errorf("provider: %s", resp.Provider)
+	}
+}
+
+func TestSnyk_CheckBatch_AggregatesFindings(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		raw, _ := os.ReadFile(filepath.Join("testdata", "snyk_test_response.json"))
+		_, _ = w.Write(raw)
+	}))
+	defer srv.Close()
+	p := NewSnykProvider(SnykConfig{BaseURL: srv.URL, APIKey: "tk", Timeout: time.Second, Concurrency: 4})
+	resp, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages: []pkgcheck.PackageRef{
+			{Name: "lodash", Version: "4.17.20"},
+			{Name: "express", Version: "4.18.0"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Findings) != 2 {
+		t.Fatalf("want 2 findings (1 per package), got %d", len(resp.Findings))
+	}
+}
+
+func TestSnyk_CheckBatch_404IsNotAnError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	p := NewSnykProvider(SnykConfig{BaseURL: srv.URL, APIKey: "tk", Timeout: time.Second, Concurrency: 2})
+	resp, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages:  []pkgcheck.PackageRef{{Name: "@acme/private", Version: "1.0.0"}},
+	})
+	if err != nil {
+		t.Fatalf("404 should not be a hard error, got: %v", err)
+	}
+	if len(resp.Findings) != 0 {
+		t.Fatalf("404 should yield 0 findings, got %d", len(resp.Findings))
+	}
+}
+```
+
+- [ ] **Step 2: Run, expect compile failure**
+
+Run: `go test ./internal/pkgcheck/provider/ -run TestSnyk_CheckBatch -v`
+Expected: build error — `NewSnykProvider`, `SnykConfig` undefined.
+
+- [ ] **Step 3: Implement the provider**
+
+Append to `internal/pkgcheck/provider/snyk.go`:
+
+```go
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultSnykBaseURL     = "https://api.snyk.io"
+	defaultSnykTimeout     = 5 * time.Second
+	defaultSnykConcurrency = 16
+)
+
+// SnykConfig configures the Snyk provider.
+type SnykConfig struct {
+	BaseURL     string
+	APIKey      string
+	Timeout     time.Duration
+	Concurrency int
+}
+
+type snykProvider struct {
+	baseURL     string
+	apiKey      string
+	concurrency int
+	client      *retryClient
+	breaker     *circuitBreaker
+}
+
+// NewSnykProvider returns a CheckProvider that queries Snyk's /test API per package.
+func NewSnykProvider(cfg SnykConfig) pkgcheck.CheckProvider {
+	if cfg.BaseURL == "" {
+		cfg.BaseURL = defaultSnykBaseURL
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultSnykTimeout
+	}
+	if cfg.Concurrency <= 0 {
+		cfg.Concurrency = defaultSnykConcurrency
+	}
+	cfg.BaseURL = strings.TrimRight(cfg.BaseURL, "/")
+
+	return &snykProvider{
+		baseURL:     cfg.BaseURL,
+		apiKey:      cfg.APIKey,
+		concurrency: cfg.Concurrency,
+		client: newRetryClient(retryConfig{
+			MaxAttempts:       3,
+			BaseBackoff:       200 * time.Millisecond,
+			MaxBackoff:        2 * time.Second,
+			RespectRetryAfter: true,
+		}),
+		breaker: newCircuitBreaker(circuitBreakerConfig{
+			Threshold:  3,
+			Window:     60 * time.Second,
+			OpenPeriod: 60 * time.Second,
+		}),
+	}
+}
+
+func (p *snykProvider) Name() string { return "snyk" }
+
+func (p *snykProvider) Capabilities() []pkgcheck.FindingType {
+	return []pkgcheck.FindingType{pkgcheck.FindingVulnerability, pkgcheck.FindingLicense}
+}
+
+func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest) (*pkgcheck.CheckResponse, error) {
+	start := time.Now()
+	if len(req.Packages) == 0 {
+		return &pkgcheck.CheckResponse{Provider: p.Name(), Metadata: pkgcheck.ResponseMetadata{Duration: time.Since(start)}}, nil
+	}
+	if !p.breaker.Allow() {
+		return &pkgcheck.CheckResponse{
+			Provider: p.Name(),
+			Metadata: pkgcheck.ResponseMetadata{Duration: time.Since(start), Partial: true, Error: "circuit breaker open"},
+		}, fmt.Errorf("snyk: circuit breaker open")
+	}
+
+	eco := mapEcosystemSnyk(req.Ecosystem)
+
+	var (
+		mu       sync.Mutex
+		findings []pkgcheck.Finding
+		anyError error
+	)
+	sem := make(chan struct{}, p.concurrency)
+	var wg sync.WaitGroup
+
+	for _, pkg := range req.Packages {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case sem <- struct{}{}:
+		}
+		wg.Add(1)
+		go func(pkg pkgcheck.PackageRef) {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			fs, err := p.queryOne(ctx, eco, pkg)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				if anyError == nil {
+					anyError = err
+				}
+				return
+			}
+			findings = append(findings, fs...)
+		}(pkg)
+	}
+	wg.Wait()
+
+	if anyError != nil {
+		p.breaker.RecordFailure()
+		return nil, anyError
+	}
+	p.breaker.RecordSuccess()
+
+	return &pkgcheck.CheckResponse{
+		Provider: p.Name(),
+		Findings: findings,
+		Metadata: pkgcheck.ResponseMetadata{Duration: time.Since(start)},
+	}, nil
+}
+
+// queryOne fetches /test/{eco}/{name}/{version} for a single package.
+// 404 is not treated as an error — it means Snyk has no data for that package
+// (typically a private package); we return zero findings.
+func (p *snykProvider) queryOne(ctx context.Context, eco string, pkg pkgcheck.PackageRef) ([]pkgcheck.Finding, error) {
+	urlStr := fmt.Sprintf("%s/test/%s/%s/%s", p.baseURL, eco, url.PathEscape(pkg.Name), url.PathEscape(pkg.Version))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, urlStr, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	if p.apiKey != "" {
+		httpReq.Header.Set("Authorization", "token "+p.apiKey)
+	}
+	httpReq.Header.Set("Accept", "application/json")
+
+	resp, err := p.client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("snyk %s@%s: %w", pkg.Name, pkg.Version, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("snyk %s@%s: status %d: %s", pkg.Name, pkg.Version, resp.StatusCode, string(raw))
+	}
+
+	var sr snykTestResp
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		return nil, fmt.Errorf("snyk decode %s@%s: %w", pkg.Name, pkg.Version, err)
+	}
+	return mapSnykResponseToFindings(pkg, sr), nil
+}
+```
+
+(Move imports into the existing import block at the top of the file.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/pkgcheck/provider/ -run TestSnyk -v`
+Expected: PASS.
+
+- [ ] **Step 5: Wire Snyk into the contract suite**
+
+Append to `internal/pkgcheck/provider/snyk_test.go`:
+
+```go
+func TestSnyk_Contract(t *testing.T) {
+	cleanSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok": true, "issues": {"vulnerabilities": [], "licenses": []}}`))
+	}))
+	defer cleanSrv.Close()
+	slowSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok": true, "issues": {"vulnerabilities": [], "licenses": []}}`))
+	}))
+	defer slowSrv.Close()
+
+	factory := func(t *testing.T, baseURL string) pkgcheck.CheckProvider {
+		return NewSnykProvider(SnykConfig{BaseURL: baseURL, APIKey: "tk", Timeout: 2 * time.Second, Concurrency: 4})
+	}
+	runContractSuite(t, "snyk", factory, contractFixture{
+		cleanServerURL: cleanSrv.URL,
+		slowServerURL:  slowSrv.URL,
+	})
+}
+```
+
+Run: `go test ./internal/pkgcheck/provider/ -run TestSnyk_Contract -v`
+Expected: all sub-tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/pkgcheck/provider/snyk.go internal/pkgcheck/provider/snyk_test.go
+git commit -m "pkgcheck/provider: implement Snyk concurrency-bounded fan-out CheckBatch"
+```
+
+---
+
+## Task 11: Cache — distinguish clean vs found vs not-found TTLs
+
+**Files:**
+- Modify: `internal/pkgcheck/cache/cache.go`
+- Modify: `internal/pkgcheck/cache/cache_test.go`
+
+The existing cache uses `TTLByType` keyed by finding type. We need three distinct lifetimes per the spec:
+- **clean** (provider returned no findings) → 24h default
+- **found** (provider returned ≥1 finding) → indefinite (use `0` to mean never expire)
+- **not-found** (provider returned 404 / unknown package) → 1h default
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `internal/pkgcheck/cache/cache_test.go`:
+
+```go
+func TestCache_FoundEntriesNeverExpire(t *testing.T) {
+	dir := t.TempDir()
+	c, err := New(Config{Dir: dir, CleanTTL: 1 * time.Hour, FoundTTL: 0 /* never */, NotFoundTTL: 1 * time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := Key{Provider: "snyk", Ecosystem: "npm", Package: "lodash", Version: "4.17.20"}
+	c.Put(key, []pkgcheck.Finding{{Type: pkgcheck.FindingVulnerability}})
+
+	// Manually rewind the entry's expiry to "the past" — verify it still hits.
+	got, ok := c.Get(key)
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(got))
+	}
+}
+
+func TestCache_CleanEntriesExpire(t *testing.T) {
+	dir := t.TempDir()
+	c, err := New(Config{Dir: dir, CleanTTL: 50 * time.Millisecond, FoundTTL: 0, NotFoundTTL: 1 * time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := Key{Provider: "socket", Ecosystem: "npm", Package: "lodash", Version: "4.17.21"}
+	c.Put(key, nil) // no findings → clean
+
+	if _, ok := c.Get(key); !ok {
+		t.Fatal("expected fresh hit")
+	}
+	time.Sleep(80 * time.Millisecond)
+	if _, ok := c.Get(key); ok {
+		t.Fatal("expected expiry after CleanTTL")
+	}
+}
+
+func TestCache_PutNotFoundUsesNotFoundTTL(t *testing.T) {
+	dir := t.TempDir()
+	c, err := New(Config{Dir: dir, CleanTTL: 24 * time.Hour, FoundTTL: 0, NotFoundTTL: 50 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := Key{Provider: "snyk", Ecosystem: "npm", Package: "@acme/private", Version: "1.0.0"}
+	c.PutNotFound(key)
+	if _, ok := c.Get(key); !ok {
+		t.Fatal("expected fresh hit")
+	}
+	time.Sleep(80 * time.Millisecond)
+	if _, ok := c.Get(key); ok {
+		t.Fatal("expected expiry after NotFoundTTL")
+	}
+}
+```
+
+- [ ] **Step 2: Run, expect compile failure**
+
+Run: `go test ./internal/pkgcheck/cache/ -run TestCache -v`
+Expected: build error — `Config.CleanTTL`, `Config.FoundTTL`, `Config.NotFoundTTL`, `PutNotFound` undefined.
+
+- [ ] **Step 3: Add new Config fields and PutNotFound**
+
+In `internal/pkgcheck/cache/cache.go`, replace the `Config` struct with:
+
+```go
+type Config struct {
+	// Dir is the directory where the cache file is stored.
+	Dir string
+	// MaxSizeMB is the maximum size of the cache file in megabytes (reserved for future use).
+	MaxSizeMB int
+
+	// CleanTTL is the lifetime of an entry where the provider returned no findings.
+	CleanTTL time.Duration
+	// FoundTTL is the lifetime of an entry with one or more findings.
+	// A zero value means "never expire" (findings for a (name, version) are permanent).
+	FoundTTL time.Duration
+	// NotFoundTTL is the lifetime of an entry where the provider had no data
+	// (e.g., 404 from /test/...). Typically used for private packages.
+	NotFoundTTL time.Duration
+
+	// DefaultTTL is retained for backwards compatibility with callers that have
+	// not migrated to the explicit per-result-class TTLs above. It is used
+	// when CleanTTL is zero.
+	DefaultTTL time.Duration
+	// TTLByType is retained for backwards compatibility. It is consulted only
+	// for found entries; if a finding type matches and no explicit FoundTTL is set,
+	// the matched value is used.
+	TTLByType map[string]time.Duration
+}
+```
+
+Add a sentinel for "never expire" handled in `Get`:
+
+```go
+// neverExpires is a far-future expiry used when FoundTTL == 0.
+var neverExpires = time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
+```
+
+Replace `Put` with:
+
+```go
+func (c *Cache) Put(key Key, findings []pkgcheck.Finding) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	stored := deepCopyFindings(findings)
+	expiry := c.computeExpiry(findings)
+	c.entries[key.String()] = entry{Findings: stored, ExpiresAt: expiry}
+}
+
+// PutNotFound stores a "provider has no data on this package" sentinel
+// with the configured NotFoundTTL.
+func (c *Cache) PutNotFound(key Key) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	ttl := c.cfg.NotFoundTTL
+	if ttl <= 0 {
+		ttl = 1 * time.Hour
+	}
+	c.entries[key.String()] = entry{Findings: nil, ExpiresAt: time.Now().Add(ttl)}
+}
+```
+
+Replace `computeTTL` with `computeExpiry`:
+
+```go
+// computeExpiry returns the absolute expiry timestamp for a Put.
+//   - empty findings → CleanTTL (or DefaultTTL fallback)
+//   - non-empty       → FoundTTL (0 = neverExpires); falls back to TTLByType match or DefaultTTL
+func (c *Cache) computeExpiry(findings []pkgcheck.Finding) time.Time {
+	now := time.Now()
+	if len(findings) == 0 {
+		ttl := c.cfg.CleanTTL
+		if ttl <= 0 {
+			ttl = c.cfg.DefaultTTL
+		}
+		if ttl <= 0 {
+			ttl = 24 * time.Hour
+		}
+		return now.Add(ttl)
+	}
+	if c.cfg.FoundTTL == 0 {
+		// Found entries persist indefinitely by default.
+		// Honor TTLByType only if explicitly configured.
+		if len(c.cfg.TTLByType) > 0 {
+			best := time.Duration(0)
+			matched := false
+			for _, f := range findings {
+				if t, ok := c.cfg.TTLByType[string(f.Type)]; ok {
+					if !matched || t > best {
+						best = t
+						matched = true
+					}
+				}
+			}
+			if matched {
+				return now.Add(best)
+			}
+		}
+		return neverExpires
+	}
+	return now.Add(c.cfg.FoundTTL)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/pkgcheck/cache/...`
+Expected: PASS (including pre-existing tests — keep them green by leaving `DefaultTTL` / `TTLByType` honored as fallback).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/pkgcheck/cache/cache.go internal/pkgcheck/cache/cache_test.go
+git commit -m "pkgcheck/cache: distinguish clean/found/not-found TTLs and add PutNotFound"
+```
+
+---
+
+## Task 12: Privacy filter
+
+**Files:**
+- Create: `internal/pkgcheck/privacy.go`
+- Create: `internal/pkgcheck/privacy_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/pkgcheck/privacy_test.go`:
+
+```go
+package pkgcheck
+
+import (
+	"testing"
+)
+
+func TestPrivacyFilter_PrivateRegistryAutoDetect(t *testing.T) {
+	pf := NewPrivacyFilter(PrivacyConfig{
+		ExternalScanRegistries: []string{"registry.npmjs.org", "pypi.org"},
+	})
+	in := []PackageRef{
+		{Name: "lodash", Version: "4.17.21", Registry: "registry.npmjs.org"},
+		{Name: "internal-tool", Version: "0.1.0", Registry: "artifactory.acme.local"},
+	}
+	scan, skip := pf.Partition(in)
+	if len(scan) != 1 || scan[0].Name != "lodash" {
+		t.Fatalf("scan = %+v, want lodash only", scan)
+	}
+	if len(skip) != 1 || skip[0].Reason != SkipReasonPrivateRegistry {
+		t.Fatalf("skip = %+v, want internal-tool with private_registry", skip)
+	}
+}
+
+func TestPrivacyFilter_ScopeDenylist(t *testing.T) {
+	pf := NewPrivacyFilter(PrivacyConfig{
+		ExternalScanRegistries: []string{"registry.npmjs.org"},
+		PrivateScopeDenylist:   []string{"@acme", "@internal-*"},
+	})
+	in := []PackageRef{
+		{Name: "@acme/billing", Version: "1.0.0", Registry: "registry.npmjs.org"},
+		{Name: "@internal-platform/utils", Version: "1.0.0", Registry: "registry.npmjs.org"},
+		{Name: "lodash", Version: "4.17.21", Registry: "registry.npmjs.org"},
+	}
+	scan, skip := pf.Partition(in)
+	if len(scan) != 1 || scan[0].Name != "lodash" {
+		t.Fatalf("scan = %+v, want lodash only", scan)
+	}
+	if len(skip) != 2 {
+		t.Fatalf("skip = %+v, want 2 entries", skip)
+	}
+	for _, s := range skip {
+		if s.Reason != SkipReasonPrivateScopeDenylist {
+			t.Errorf("want denylist reason for %s, got %s", s.Package.Name, s.Reason)
+		}
+	}
+}
+
+func TestPrivacyFilter_EmptyAllowlistTreatsAllAsPublic(t *testing.T) {
+	// An empty allowlist means "no registry filter applied" — defer to denylist only.
+	pf := NewPrivacyFilter(PrivacyConfig{})
+	in := []PackageRef{{Name: "lodash", Version: "4.17.21", Registry: "anything"}}
+	scan, skip := pf.Partition(in)
+	if len(scan) != 1 || len(skip) != 0 {
+		t.Fatalf("scan=%v skip=%v", scan, skip)
+	}
+}
+
+func TestPrivacyFilter_RegistryRuleTakesPriority(t *testing.T) {
+	pf := NewPrivacyFilter(PrivacyConfig{
+		ExternalScanRegistries: []string{"registry.npmjs.org"},
+		PrivateScopeDenylist:   []string{"@acme"},
+	})
+	// On a private registry — should report private_registry, not denylist.
+	in := []PackageRef{{Name: "@acme/x", Version: "1", Registry: "artifactory.acme.local"}}
+	_, skip := pf.Partition(in)
+	if len(skip) != 1 || skip[0].Reason != SkipReasonPrivateRegistry {
+		t.Fatalf("want private_registry, got %+v", skip)
+	}
+}
+```
+
+- [ ] **Step 2: Run, expect compile failure**
+
+Run: `go test ./internal/pkgcheck/ -run TestPrivacyFilter -v`
+Expected: build error — `NewPrivacyFilter`, `PrivacyConfig` undefined.
+
+- [ ] **Step 3: Implement the filter**
+
+Create `internal/pkgcheck/privacy.go`:
+
+```go
+package pkgcheck
+
+import (
+	"path"
+	"strings"
+)
+
+// PrivacyConfig configures the privacy filter.
+type PrivacyConfig struct {
+	// ExternalScanRegistries lists registries whose packages may be sent to
+	// external providers. An empty list means "do not filter by registry."
+	ExternalScanRegistries []string
+
+	// PrivateScopeDenylist lists package name prefixes / glob patterns that
+	// should NOT be sent externally even when on an allowed registry.
+	// Each entry is matched as either an exact prefix (`@acme`) or a
+	// glob (`@internal-*`).
+	PrivateScopeDenylist []string
+}
+
+// PrivacyFilter partitions a list of PackageRef into "to-scan" and "to-skip".
+type PrivacyFilter struct {
+	allowedRegistries map[string]struct{}
+	denylistPatterns  []string
+}
+
+// NewPrivacyFilter builds a filter from configuration.
+func NewPrivacyFilter(cfg PrivacyConfig) *PrivacyFilter {
+	allowed := make(map[string]struct{}, len(cfg.ExternalScanRegistries))
+	for _, r := range cfg.ExternalScanRegistries {
+		allowed[r] = struct{}{}
+	}
+	return &PrivacyFilter{
+		allowedRegistries: allowed,
+		denylistPatterns:  append([]string(nil), cfg.PrivateScopeDenylist...),
+	}
+}
+
+// Partition splits the input into packages eligible for external scanning
+// and packages skipped due to privacy rules. Order within each slice
+// preserves the order of the input.
+//
+// Decision order: registry rule first (if an allowlist is configured),
+// then scope/prefix denylist. A package skipped for "private_registry"
+// is never re-classified to "private_scope_denylist."
+func (f *PrivacyFilter) Partition(pkgs []PackageRef) (scan []PackageRef, skip []SkippedPackage) {
+	for _, p := range pkgs {
+		if len(f.allowedRegistries) > 0 && p.Registry != "" {
+			if _, ok := f.allowedRegistries[p.Registry]; !ok {
+				skip = append(skip, SkippedPackage{Package: p, Reason: SkipReasonPrivateRegistry})
+				continue
+			}
+		}
+		if f.matchesDenylist(p.Name) {
+			skip = append(skip, SkippedPackage{Package: p, Reason: SkipReasonPrivateScopeDenylist})
+			continue
+		}
+		scan = append(scan, p)
+	}
+	return scan, skip
+}
+
+func (f *PrivacyFilter) matchesDenylist(name string) bool {
+	for _, pat := range f.denylistPatterns {
+		if strings.ContainsAny(pat, "*?[") {
+			if ok, _ := path.Match(pat, name); ok {
+				return true
+			}
+			// Also match against the leading scope segment for patterns like @internal-*
+			if strings.HasPrefix(name, "@") && strings.Contains(name, "/") {
+				scope := strings.SplitN(name, "/", 2)[0]
+				if ok, _ := path.Match(pat, scope); ok {
+					return true
+				}
+			}
+		} else {
+			// Plain prefix: matches "@acme" against "@acme/billing" and "@acme".
+			if name == pat || strings.HasPrefix(name, pat+"/") {
+				return true
+			}
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/pkgcheck/ -run TestPrivacyFilter -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/pkgcheck/privacy.go internal/pkgcheck/privacy_test.go
+git commit -m "pkgcheck: add PrivacyFilter for registry and scope-denylist exclusions"
+```
+
+---
+
+## Task 13: Wire privacy filter into orchestrator and surface Skipped
+
+**Files:**
+- Modify: `internal/pkgcheck/orchestrator.go`
+- Create: `internal/pkgcheck/orchestrator_privacy_test.go`
+
+The orchestrator gets a new `PrivacyFilter` field. Before fanning out to providers, it partitions the request and accumulates the skipped list to return alongside findings.
+
+- [ ] **Step 1: Write failing test**
+
+Create `internal/pkgcheck/orchestrator_privacy_test.go`:
+
+```go
+package pkgcheck
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type recordingProvider struct {
+	name string
+	last []PackageRef
+}
+
+func (r *recordingProvider) Name() string                 { return r.name }
+func (r *recordingProvider) Capabilities() []FindingType  { return nil }
+func (r *recordingProvider) CheckBatch(ctx context.Context, req CheckRequest) (*CheckResponse, error) {
+	r.last = append([]PackageRef(nil), req.Packages...)
+	return &CheckResponse{Provider: r.name}, nil
+}
+
+func TestOrchestrator_PrivacyFiltersBeforeProviders(t *testing.T) {
+	rp := &recordingProvider{name: "fake"}
+	o := NewOrchestrator(OrchestratorConfig{
+		Providers: map[string]ProviderEntry{
+			"fake": {Provider: rp, Timeout: time.Second, OnFailure: "warn"},
+		},
+		PrivacyFilter: NewPrivacyFilter(PrivacyConfig{
+			ExternalScanRegistries: []string{"registry.npmjs.org"},
+			PrivateScopeDenylist:   []string{"@acme"},
+		}),
+	})
+	req := CheckRequest{
+		Ecosystem: EcosystemNPM,
+		Packages: []PackageRef{
+			{Name: "lodash", Version: "4.17.21", Registry: "registry.npmjs.org"},
+			{Name: "@acme/x", Version: "1", Registry: "registry.npmjs.org"},
+			{Name: "internal", Version: "0.1", Registry: "artifactory.acme.local"},
+		},
+	}
+	_, _, skipped := o.CheckAllWithPrivacy(context.Background(), req)
+	if len(skipped) != 2 {
+		t.Fatalf("want 2 skipped, got %d", len(skipped))
+	}
+	if len(rp.last) != 1 || rp.last[0].Name != "lodash" {
+		t.Fatalf("provider should have received lodash only, got %+v", rp.last)
+	}
+}
+```
+
+- [ ] **Step 2: Run, expect compile failure**
+
+Run: `go test ./internal/pkgcheck/ -run TestOrchestrator_PrivacyFilters -v`
+Expected: build error — `OrchestratorConfig.PrivacyFilter` and `Orchestrator.CheckAllWithPrivacy` undefined.
+
+- [ ] **Step 3: Add the field and method**
+
+In `internal/pkgcheck/orchestrator.go`, modify `OrchestratorConfig`:
+
+```go
+type OrchestratorConfig struct {
+	Providers     map[string]ProviderEntry
+	PrivacyFilter *PrivacyFilter // optional; nil means no filtering
+}
+```
+
+Update `NewOrchestrator` to keep the filter:
+
+```go
+func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
+	providers := make(map[string]ProviderEntry, len(cfg.Providers))
+	for k, v := range cfg.Providers {
+		providers[k] = v
+	}
+	return &Orchestrator{cfg: OrchestratorConfig{
+		Providers:     providers,
+		PrivacyFilter: cfg.PrivacyFilter,
+	}}
+}
+```
+
+Add the new method that returns the skipped list. Keep the existing `CheckAll` for backward compatibility — it now delegates:
+
+```go
+// CheckAllWithPrivacy applies the configured PrivacyFilter (if any) before
+// dispatching the request to all providers. Returns merged findings, provider
+// errors, and the list of packages that were not externally scanned.
+func (o *Orchestrator) CheckAllWithPrivacy(ctx context.Context, req CheckRequest) ([]Finding, []ProviderError, []SkippedPackage) {
+	var skipped []SkippedPackage
+	if o.cfg.PrivacyFilter != nil {
+		scan, skip := o.cfg.PrivacyFilter.Partition(req.Packages)
+		req.Packages = scan
+		skipped = skip
+	}
+	findings, errs := o.CheckAll(ctx, req)
+	return findings, errs, skipped
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/pkgcheck/ -run TestOrchestrator -v`
+Expected: PASS (existing TestOrchestrator tests + the new privacy test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/pkgcheck/orchestrator.go internal/pkgcheck/orchestrator_privacy_test.go
+git commit -m "pkgcheck: orchestrator filters private packages before provider dispatch"
+```
+
+---
+
+## Task 14: Verdict — surface Skipped and degraded summary annotation
+
+**Files:**
+- Modify: `internal/pkgcheck/evaluator.go`
+- Modify: `internal/pkgcheck/evaluator_test.go`
+
+The evaluator receives findings + skipped + provider errors and emits a complete `Verdict`. Currently `Evaluate(findings, ecosystem)` does not see skipped or errors. Add a wrapper that does.
+
+- [ ] **Step 1: Write failing test**
+
+Add to `internal/pkgcheck/evaluator_test.go`:
+
+```go
+func TestEvaluator_EvaluateWithContext_AnnotatesDegraded(t *testing.T) {
+	ev := NewEvaluator([]policy.PackageRule{
+		{Match: policy.PackageMatch{}, Action: "allow"},
+	})
+	v := ev.EvaluateWithContext(EvalContext{
+		Findings:  nil,
+		Ecosystem: EcosystemNPM,
+		ProviderErrors: []ProviderError{
+			{Provider: "socket", Err: errors.New("timeout"), OnFailure: "warn"},
+		},
+		Skipped: []SkippedPackage{
+			{Package: PackageRef{Name: "@acme/x"}, Reason: SkipReasonPrivateScopeDenylist},
+		},
+	})
+	if !strings.HasPrefix(v.Summary, "degraded:") {
+		t.Errorf("want summary prefixed degraded:, got %q", v.Summary)
+	}
+	if len(v.Skipped) != 1 {
+		t.Errorf("want 1 skipped, got %d", len(v.Skipped))
+	}
+}
+```
+
+(Add the imports `errors`, `strings`, and `policy` if not already present.)
+
+- [ ] **Step 2: Run, expect compile failure**
+
+Run: `go test ./internal/pkgcheck/ -run TestEvaluator_EvaluateWithContext -v`
+Expected: build error — `EvaluateWithContext`, `EvalContext` undefined.
+
+- [ ] **Step 3: Add EvalContext and EvaluateWithContext**
+
+Add to `internal/pkgcheck/evaluator.go`:
+
+```go
+// EvalContext bundles all inputs the evaluator needs to produce a complete Verdict.
+type EvalContext struct {
+	Findings       []Finding
+	Ecosystem      Ecosystem
+	ProviderErrors []ProviderError
+	Skipped        []SkippedPackage
+}
+
+// EvaluateWithContext runs the rule engine and decorates the resulting Verdict
+// with skipped-package info and a "degraded:" summary prefix when one or more
+// providers failed with OnFailure == "warn" (the degraded fail-mode).
+func (e *Evaluator) EvaluateWithContext(c EvalContext) *Verdict {
+	v := e.Evaluate(c.Findings, c.Ecosystem)
+	if v == nil {
+		v = &Verdict{Action: VerdictAllow}
+	}
+	v.Skipped = append([]SkippedPackage(nil), c.Skipped...)
+
+	var degraded []string
+	for _, perr := range c.ProviderErrors {
+		if perr.OnFailure == "warn" {
+			degraded = append(degraded, perr.Provider)
+		}
+	}
+	if len(degraded) > 0 {
+		v.Summary = "degraded: " + strings.Join(degraded, ",") + " unavailable; " + v.Summary
+	}
+	return v
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/pkgcheck/ -run TestEvaluator -v`
+Expected: PASS (new test plus all pre-existing evaluator tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/pkgcheck/evaluator.go internal/pkgcheck/evaluator_test.go
+git commit -m "pkgcheck: evaluator surfaces skipped packages and degraded annotation"
+```
+
+---
+
+## Task 15: Compile block_on policy shorthand into PackageRule list
+
+**Files:**
+- Modify: `internal/config/pkgcheck.go`
+- Create: `internal/config/pkgcheck_policy_test.go`
+
+Per the implementation discovery, the spec's `policy.block_on` config is a shorthand that compiles into `policy.PackageRule` entries that the existing evaluator already understands. This avoids inventing a parallel policy engine.
+
+- [ ] **Step 1: Write failing test**
+
+Create `internal/config/pkgcheck_policy_test.go`:
+
+```go
+package config
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+func TestCompileBlockOn_DefaultsAndOverrides(t *testing.T) {
+	rules := CompileBlockOn(BlockOnConfig{
+		Malware:       "any",
+		Vulnerability: "critical",
+		License:       "never",
+		Reputation:    "never",
+		Provenance:    "never",
+	})
+
+	// Expect: malware-any → deny; vuln-critical → deny; vuln-high → warn;
+	// then a catch-all allow at the end.
+	if len(rules) < 4 {
+		t.Fatalf("want >=4 rules, got %d: %+v", len(rules), rules)
+	}
+
+	denyMalware := containsRule(rules, policy.PackageRule{
+		Match: policy.PackageMatch{FindingType: "malware"}, Action: "deny",
+	})
+	denyCritVuln := containsRule(rules, policy.PackageRule{
+		Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "critical"}, Action: "deny",
+	})
+	warnHighVuln := containsRule(rules, policy.PackageRule{
+		Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "high"}, Action: "warn",
+	})
+	if !denyMalware {
+		t.Error("missing malware deny rule")
+	}
+	if !denyCritVuln {
+		t.Error("missing vulnerability/critical deny rule")
+	}
+	if !warnHighVuln {
+		t.Error("missing vulnerability/high warn rule")
+	}
+
+	last := rules[len(rules)-1]
+	if last.Action != "allow" || last.Match.FindingType != "" {
+		t.Errorf("expected catch-all allow as last rule, got %+v", last)
+	}
+}
+
+// containsRule compares rules ignoring Reason text.
+func containsRule(rules []policy.PackageRule, want policy.PackageRule) bool {
+	for _, r := range rules {
+		if r.Match.FindingType == want.Match.FindingType &&
+			r.Match.Severity == want.Match.Severity &&
+			r.Action == want.Action {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 2: Run, expect compile failure**
+
+Run: `go test ./internal/config/ -run TestCompileBlockOn -v`
+Expected: build error — `BlockOnConfig`, `CompileBlockOn` undefined.
+
+- [ ] **Step 3: Add the type and compiler**
+
+Append to `internal/config/pkgcheck.go`:
+
+```go
+import "github.com/agentsh/agentsh/internal/policy"
+
+// BlockOnConfig is the policy shorthand:
+//   each finding type maps to a severity threshold at which to block.
+//   Allowed values per finding type:
+//     malware:       any | critical | never
+//     vulnerability: critical | high | medium | never
+//     license:       any | never
+//     reputation:    any | never
+//     provenance:    any | never
+type BlockOnConfig struct {
+	Malware       string `yaml:"malware"`
+	Vulnerability string `yaml:"vulnerability"`
+	License       string `yaml:"license"`
+	Reputation    string `yaml:"reputation"`
+	Provenance    string `yaml:"provenance"`
+}
+
+// CompileBlockOn translates the BlockOnConfig shorthand into a list of
+// policy.PackageRule entries (first-match-wins) ending in a catch-all allow.
+//
+// For each finding type we emit deny rules for severities at or above the
+// threshold, warn rules for severities below the threshold but still
+// noteworthy (currently: high vulns become warn even when threshold is
+// critical), and rely on the catch-all allow for everything else.
+func CompileBlockOn(b BlockOnConfig) []policy.PackageRule {
+	var rules []policy.PackageRule
+
+	// Malware: any (deny all severities) or critical (deny only critical).
+	switch b.Malware {
+	case "any":
+		rules = append(rules, policy.PackageRule{
+			Match: policy.PackageMatch{FindingType: "malware"}, Action: "deny",
+			Reason: "block_on.malware=any",
+		})
+	case "critical":
+		rules = append(rules, policy.PackageRule{
+			Match: policy.PackageMatch{FindingType: "malware", Severity: "critical"}, Action: "deny",
+			Reason: "block_on.malware=critical",
+		})
+	}
+
+	// Vulnerability thresholds.
+	switch b.Vulnerability {
+	case "medium":
+		rules = append(rules,
+			policy.PackageRule{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "critical"}, Action: "deny"},
+			policy.PackageRule{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "high"}, Action: "deny"},
+			policy.PackageRule{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "medium"}, Action: "deny"},
+		)
+	case "high":
+		rules = append(rules,
+			policy.PackageRule{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "critical"}, Action: "deny"},
+			policy.PackageRule{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "high"}, Action: "deny"},
+		)
+	case "critical":
+		rules = append(rules,
+			policy.PackageRule{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "critical"}, Action: "deny"},
+			policy.PackageRule{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "high"}, Action: "warn"},
+		)
+	}
+
+	// License / reputation / provenance: any → deny; never → no rule (catch-all allows).
+	for _, kv := range []struct{ ft, mode string }{
+		{"license", b.License}, {"reputation", b.Reputation}, {"provenance", b.Provenance},
+	} {
+		if kv.mode == "any" {
+			rules = append(rules, policy.PackageRule{
+				Match: policy.PackageMatch{FindingType: kv.ft}, Action: "deny",
+				Reason: "block_on." + kv.ft + "=any",
+			})
+		}
+	}
+
+	// Catch-all allow.
+	rules = append(rules, policy.PackageRule{
+		Match: policy.PackageMatch{}, Action: "allow",
+		Reason: "block_on default allow",
+	})
+	return rules
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/config/ -run TestCompileBlockOn -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/pkgcheck.go internal/config/pkgcheck_policy_test.go
+git commit -m "config: compile block_on shorthand into policy.PackageRule list"
+```
+
+---
+
+## Task 16: Add Privacy and FailMode config fields and provider entries
+
+**Files:**
+- Modify: `internal/config/pkgcheck.go`
+- Modify: `internal/config/pkgcheck_test.go`
+
+The existing `ProviderConfig` already has `APIKeyEnv`, `Timeout`, `OnFailure`, `Options` — Snyk and Socket fit as map entries. We add a top-level `Privacy` block, a `FailMode` field, and a `BlockOn` field for the policy shorthand.
+
+- [ ] **Step 1: Write failing test**
+
+Add to `internal/config/pkgcheck_test.go`:
+
+```go
+func TestPackageChecksConfig_FailModeAndPrivacy(t *testing.T) {
+	cfg := PackageChecksConfig{
+		FailMode: "degraded",
+		Privacy: PrivacyConfig{
+			ExternalScanRegistries: []string{"registry.npmjs.org"},
+			PrivateScopeDenylist:   []string{"@acme"},
+		},
+		BlockOn: BlockOnConfig{Malware: "any", Vulnerability: "critical"},
+	}
+	if cfg.FailMode != "degraded" {
+		t.Errorf("FailMode field missing")
+	}
+	if len(cfg.Privacy.ExternalScanRegistries) != 1 {
+		t.Errorf("Privacy field missing")
+	}
+}
+
+func TestDefaultPackageChecksConfig_HasFailModeAndPrivacy(t *testing.T) {
+	d := DefaultPackageChecksConfig()
+	if d.FailMode == "" {
+		t.Error("default FailMode should be set")
+	}
+}
+```
+
+- [ ] **Step 2: Run, expect compile failure**
+
+Run: `go test ./internal/config/ -run "TestPackageChecksConfig_FailMode|TestDefaultPackageChecksConfig_HasFail" -v`
+Expected: build error — `PackageChecksConfig.FailMode`, `PackageChecksConfig.Privacy`, `PackageChecksConfig.BlockOn` undefined.
+
+- [ ] **Step 3: Add fields and update defaults**
+
+In `internal/config/pkgcheck.go`, modify `PackageChecksConfig`:
+
+```go
+type PackageChecksConfig struct {
+	Enabled    bool                           `yaml:"enabled"`
+	Scope      string                         `yaml:"scope"` // "new_packages_only" | "all_installs"
+	Cache      PackageCacheConfig             `yaml:"cache"`
+	Registries map[string]RegistryTrustConfig `yaml:"registries"`
+	Providers  map[string]ProviderConfig      `yaml:"providers"`
+	Resolvers  map[string]ResolverConfig      `yaml:"resolvers"`
+
+	// FailMode controls how the orchestrator reacts to provider failures
+	// for external providers (Snyk / Socket / etc.). One of:
+	//   "open"     — let the install proceed when an external provider fails.
+	//   "closed"   — block the install when an external provider fails.
+	//   "degraded" — fall back to OSV findings, annotate the verdict.
+	// The env var PKGCHECK_FAIL_MODE overrides this at runtime.
+	FailMode string `yaml:"fail_mode"`
+
+	// Privacy filters which packages may be sent to external providers.
+	Privacy PrivacyConfig `yaml:"privacy"`
+
+	// BlockOn is a per-finding-type severity threshold shorthand that compiles
+	// into policy.PackageRule entries via CompileBlockOn.
+	BlockOn BlockOnConfig `yaml:"block_on"`
+}
+
+// PrivacyConfig configures the upstream privacy filter (mirrors pkgcheck.PrivacyConfig).
+type PrivacyConfig struct {
+	ExternalScanRegistries []string `yaml:"external_scan_registries"`
+	PrivateScopeDenylist   []string `yaml:"private_scope_denylist"`
+}
+```
+
+In `DefaultPackageChecksConfig()`, augment the returned struct:
+
+```go
+return PackageChecksConfig{
+	Enabled:  false,
+	Scope:    "new_packages_only",
+	FailMode: "degraded",
+	Privacy: PrivacyConfig{
+		ExternalScanRegistries: []string{"registry.npmjs.org", "pypi.org"},
+	},
+	BlockOn: BlockOnConfig{
+		Malware:       "any",
+		Vulnerability: "critical",
+		License:       "never",
+		Reputation:    "never",
+		Provenance:    "never",
+	},
+	// ... existing Cache/Providers/Resolvers entries unchanged ...
+}
+```
+
+Also add Snyk and Socket as known-but-disabled providers in the default Providers map:
+
+```go
+Providers: map[string]ProviderConfig{
+	"osv": { Enabled: true, Priority: 1, Timeout: 10 * time.Second, OnFailure: "warn" },
+	"depsdev": { Enabled: true, Priority: 2, Timeout: 10 * time.Second, OnFailure: "warn" },
+	"local": { Enabled: true, Priority: 0, OnFailure: "warn" },
+	"socket": { Enabled: false, Priority: 5, Timeout: 5 * time.Second, OnFailure: "warn", APIKeyEnv: "SOCKET_API_KEY" },
+	"snyk": { Enabled: false, Priority: 4, Timeout: 5 * time.Second, OnFailure: "warn", APIKeyEnv: "SNYK_TOKEN",
+		Options: map[string]any{"concurrency": 16}},
+},
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/config/ -run "TestPackageChecksConfig_FailMode|TestDefaultPackageChecksConfig_HasFail" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Verify pre-existing config tests still pass**
+
+Run: `go test ./internal/config/...`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/pkgcheck.go internal/config/pkgcheck_test.go
+git commit -m "config: add fail_mode, privacy, block_on; register snyk and socket providers"
+```
+
+---
+
+## Task 17: Default scope to all_installs when an external provider is enabled
+
+**Files:**
+- Modify: `internal/config/pkgcheck.go`
+- Modify: `internal/config/pkgcheck_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `internal/config/pkgcheck_test.go`:
+
+```go
+func TestApplyExternalProviderDefaults_PromotesScope(t *testing.T) {
+	cfg := PackageChecksConfig{
+		Enabled: true,
+		Scope:   "", // unset — should be promoted
+		Providers: map[string]ProviderConfig{
+			"socket": {Enabled: true, APIKeyEnv: "SOCKET_API_KEY"},
+		},
+	}
+	warnings := ApplyExternalProviderDefaults(&cfg)
+	if cfg.Scope != "all_installs" {
+		t.Errorf("expected scope to be promoted to all_installs, got %q", cfg.Scope)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("no warnings expected when scope was empty; got %v", warnings)
+	}
+}
+
+func TestApplyExternalProviderDefaults_WarnsOnExplicitNarrowScope(t *testing.T) {
+	cfg := PackageChecksConfig{
+		Enabled: true,
+		Scope:   "new_packages_only",
+		Providers: map[string]ProviderConfig{
+			"snyk": {Enabled: true, APIKeyEnv: "SNYK_TOKEN"},
+		},
+	}
+	warnings := ApplyExternalProviderDefaults(&cfg)
+	if cfg.Scope != "new_packages_only" {
+		t.Errorf("user-set scope should not be overwritten")
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected validation warning")
+	}
+	if !strings.Contains(warnings[0], "snyk") || !strings.Contains(warnings[0], "all_installs") {
+		t.Errorf("warning should mention provider and recommend all_installs, got %q", warnings[0])
+	}
+}
+
+func TestApplyExternalProviderDefaults_NoExternalProviderNoOp(t *testing.T) {
+	cfg := PackageChecksConfig{
+		Enabled: true,
+		Scope:   "",
+		Providers: map[string]ProviderConfig{
+			"osv": {Enabled: true},
+		},
+	}
+	warnings := ApplyExternalProviderDefaults(&cfg)
+	if cfg.Scope != "" {
+		t.Errorf("scope should remain empty when no external provider is enabled")
+	}
+	if len(warnings) != 0 {
+		t.Errorf("no warnings expected, got %v", warnings)
+	}
+}
+```
+
+(Add `strings` import if not already present.)
+
+- [ ] **Step 2: Run, expect compile failure**
+
+Run: `go test ./internal/config/ -run TestApplyExternalProviderDefaults -v`
+Expected: build error — `ApplyExternalProviderDefaults` undefined.
+
+- [ ] **Step 3: Implement the helper**
+
+Append to `internal/config/pkgcheck.go`:
+
+```go
+// externalProviderNames lists provider names that send package data to a
+// third-party API (and thus benefit from privacy filtering / scope=all_installs).
+var externalProviderNames = []string{"snyk", "socket"}
+
+// ApplyExternalProviderDefaults adjusts cfg in-place when one or more external
+// providers are enabled:
+//   - if Scope is unset, promote to "all_installs"
+//   - if Scope is "new_packages_only", emit a validation warning naming the
+//     external provider(s) and recommending "all_installs"
+// Returns a list of human-readable warnings the caller should surface.
+func ApplyExternalProviderDefaults(cfg *PackageChecksConfig) []string {
+	var enabledExternal []string
+	for _, name := range externalProviderNames {
+		p, ok := cfg.Providers[name]
+		if ok && p.Enabled {
+			enabledExternal = append(enabledExternal, name)
+		}
+	}
+	if len(enabledExternal) == 0 {
+		return nil
+	}
+	switch cfg.Scope {
+	case "":
+		cfg.Scope = "all_installs"
+		return nil
+	case "new_packages_only":
+		return []string{
+			fmt.Sprintf(
+				"pkgcheck: %s configured but scope=new_packages_only — bare `npm install` and `npm ci` will not be intercepted, "+
+					"so supply-chain attacks via lockfile installs will not be blocked. Set scope: all_installs for full coverage.",
+				strings.Join(enabledExternal, ", "),
+			),
+		}
+	}
+	return nil
+}
+```
+
+(Add imports `fmt` and `strings` if not already present.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/config/ -run TestApplyExternalProviderDefaults -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/pkgcheck.go internal/config/pkgcheck_test.go
+git commit -m "config: promote scope to all_installs when external provider is enabled"
+```
+
+---
+
+## Task 18: Resolve fail_mode to per-provider OnFailure
+
+**Files:**
+- Modify: `internal/config/pkgcheck.go`
+- Modify: `internal/config/pkgcheck_test.go`
+
+`fail_mode` at the top level is a convenience that sets `OnFailure` for external providers, with `PKGCHECK_FAIL_MODE` env var overriding the YAML.
+
+- [ ] **Step 1: Write failing test**
+
+Add to `internal/config/pkgcheck_test.go`:
+
+```go
+func TestResolveFailMode_EnvOverridesYAML(t *testing.T) {
+	cfg := PackageChecksConfig{FailMode: "closed"}
+	t.Setenv("PKGCHECK_FAIL_MODE", "open")
+	got := ResolveFailMode(&cfg)
+	if got != "open" {
+		t.Errorf("env should win, got %q", got)
+	}
+}
+
+func TestResolveFailMode_DefaultsToDegraded(t *testing.T) {
+	cfg := PackageChecksConfig{}
+	t.Setenv("PKGCHECK_FAIL_MODE", "")
+	got := ResolveFailMode(&cfg)
+	if got != "degraded" {
+		t.Errorf("default should be degraded, got %q", got)
+	}
+}
+
+func TestApplyFailMode_SetsOnFailureForExternal(t *testing.T) {
+	cfg := PackageChecksConfig{
+		FailMode: "closed",
+		Providers: map[string]ProviderConfig{
+			"socket": {Enabled: true},
+			"osv":    {Enabled: true, OnFailure: "warn"}, // should be untouched
+		},
+	}
+	ApplyFailMode(&cfg, "closed")
+	if cfg.Providers["socket"].OnFailure != "deny" {
+		t.Errorf("socket OnFailure should be deny, got %q", cfg.Providers["socket"].OnFailure)
+	}
+	if cfg.Providers["osv"].OnFailure != "warn" {
+		t.Errorf("osv OnFailure must remain warn, got %q", cfg.Providers["osv"].OnFailure)
+	}
+}
+```
+
+- [ ] **Step 2: Run, expect compile failure**
+
+Run: `go test ./internal/config/ -run "TestResolveFailMode|TestApplyFailMode" -v`
+Expected: build error — `ResolveFailMode`, `ApplyFailMode` undefined.
+
+- [ ] **Step 3: Implement helpers**
+
+Append to `internal/config/pkgcheck.go`:
+
+```go
+import "os"
+
+// ResolveFailMode returns the effective fail mode, honoring the
+// PKGCHECK_FAIL_MODE env var override. Defaults to "degraded".
+func ResolveFailMode(cfg *PackageChecksConfig) string {
+	if v := os.Getenv("PKGCHECK_FAIL_MODE"); v != "" {
+		return v
+	}
+	if cfg.FailMode != "" {
+		return cfg.FailMode
+	}
+	return "degraded"
+}
+
+// ApplyFailMode sets OnFailure on every enabled external provider to match the
+// resolved fail mode. Mapping:
+//   open     → "allow"
+//   closed   → "deny"
+//   degraded → "warn"
+// External providers are those listed in externalProviderNames. Other
+// providers (osv, depsdev, local) keep whatever OnFailure the user set.
+func ApplyFailMode(cfg *PackageChecksConfig, mode string) {
+	target := ""
+	switch mode {
+	case "open":
+		target = "allow"
+	case "closed":
+		target = "deny"
+	case "degraded":
+		target = "warn"
+	default:
+		target = "warn"
+	}
+	for _, name := range externalProviderNames {
+		p, ok := cfg.Providers[name]
+		if !ok || !p.Enabled {
+			continue
+		}
+		p.OnFailure = target
+		cfg.Providers[name] = p
+	}
+}
+```
+
+(Move `os` into the existing import block.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/config/ -run "TestResolveFailMode|TestApplyFailMode" -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/pkgcheck.go internal/config/pkgcheck_test.go
+git commit -m "config: resolve fail_mode and apply OnFailure to external providers"
+```
+
+---
+
+## Task 19: End-to-end orchestrator integration test (degraded fallback)
+
+**Files:**
+- Create: `internal/pkgcheck/integration_socket_degraded_test.go`
+
+This test wires together: orchestrator + privacy filter + Socket (failing) + OSV (succeeding) + evaluator-with-context. It asserts the verdict carries `"degraded:"` in the summary, OSV findings are present, and skipped packages are surfaced.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `internal/pkgcheck/integration_socket_degraded_test.go`:
+
+```go
+package pkgcheck_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/pkgcheck"
+	"github.com/agentsh/agentsh/internal/pkgcheck/provider"
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+func TestIntegration_SocketDownDegradesToOSV(t *testing.T) {
+	// Socket: returns 500 every call.
+	socketSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer socketSrv.Close()
+
+	// OSV: returns one vuln for lodash.
+	osvSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"results":[{"vulns":[{"id":"GHSA-xxxx","summary":"sample","severity":[{"type":"CVSS_V3","score":"9.8"}]}]}]}`))
+	}))
+	defer osvSrv.Close()
+
+	pf := pkgcheck.NewPrivacyFilter(pkgcheck.PrivacyConfig{
+		ExternalScanRegistries: []string{"registry.npmjs.org"},
+		PrivateScopeDenylist:   []string{"@acme"},
+	})
+
+	o := pkgcheck.NewOrchestrator(pkgcheck.OrchestratorConfig{
+		PrivacyFilter: pf,
+		Providers: map[string]pkgcheck.ProviderEntry{
+			"socket": {
+				Provider:  provider.NewSocketProvider(provider.SocketConfig{BaseURL: socketSrv.URL, APIKey: "tk", Timeout: time.Second, MaxPURLsPerCall: 100}),
+				Timeout:   time.Second,
+				OnFailure: "warn", // fail_mode: degraded
+			},
+			"osv": {
+				Provider:  provider.NewOSVProvider(provider.OSVConfig{BaseURL: osvSrv.URL, Timeout: time.Second}),
+				Timeout:   time.Second,
+				OnFailure: "warn",
+			},
+		},
+	})
+
+	req := pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages: []pkgcheck.PackageRef{
+			{Name: "lodash", Version: "4.17.20", Registry: "registry.npmjs.org"},
+			{Name: "@acme/internal", Version: "1.0.0", Registry: "registry.npmjs.org"},
+		},
+	}
+
+	findings, errs, skipped := o.CheckAllWithPrivacy(context.Background(), req)
+
+	if len(skipped) != 1 {
+		t.Errorf("want 1 skipped (@acme), got %d", len(skipped))
+	}
+
+	ev := pkgcheck.NewEvaluator([]policy.PackageRule{
+		{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "critical"}, Action: "deny"},
+		{Match: policy.PackageMatch{}, Action: "allow"},
+	})
+	verdict := ev.EvaluateWithContext(pkgcheck.EvalContext{
+		Findings:       findings,
+		Ecosystem:      req.Ecosystem,
+		ProviderErrors: errs,
+		Skipped:        skipped,
+	})
+
+	if !strings.Contains(verdict.Summary, "degraded:") || !strings.Contains(verdict.Summary, "socket") {
+		t.Errorf("verdict summary should be annotated degraded for socket, got %q", verdict.Summary)
+	}
+	if verdict.Action != pkgcheck.VerdictBlock {
+		t.Errorf("OSV finding (critical) should drive verdict to block, got %s", verdict.Action)
+	}
+	if len(verdict.Skipped) != 1 {
+		t.Errorf("verdict should carry 1 skipped, got %d", len(verdict.Skipped))
+	}
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `go test ./internal/pkgcheck/ -run TestIntegration_SocketDownDegradesToOSV -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/pkgcheck/integration_socket_degraded_test.go
+git commit -m "pkgcheck: integration test for Socket-down → OSV degraded fallback"
+```
+
+---
+
+## Task 20: Cross-compile verification and full-suite run
+
+**Files:** none modified — verification step only.
+
+- [ ] **Step 1: Cross-compile for Windows**
+
+Run: `GOOS=windows go build ./...`
+Expected: build succeeds (no Linux-only deps in the new providers).
+
+- [ ] **Step 2: Run the full pkgcheck and config test suites**
+
+Run:
+```bash
+go test ./internal/pkgcheck/... ./internal/config/...
+```
+Expected: PASS.
+
+- [ ] **Step 3: Run vet and the full project suite as a sanity pass**
+
+Run:
+```bash
+go vet ./...
+go test ./...
+```
+Expected: PASS for the whole project.
+
+- [ ] **Step 4: If everything is green, push the branch and open a PR**
+
+Run:
+```bash
+git push -u origin <branch>
+gh pr create --title "pkgcheck: add Snyk and Socket pre-install gating" --body "$(cat <<'EOF'
+## Summary
+- Adds Snyk and Socket as `CheckProvider` implementations with shared retry / circuit-breaker helper
+- Privacy filter (registry allowlist + scope denylist) at the orchestrator before any third-party call
+- `fail_mode` (open / closed / degraded) compiles to per-provider `OnFailure`; degraded annotates the verdict and falls back to OSV
+- `block_on` policy shorthand compiles into existing `policy.PackageRule` entries — no new evaluator
+- Cache distinguishes clean / found / not-found TTLs (findings persist indefinitely by default)
+- Scope auto-promotes to `all_installs` when any external provider is enabled
+
+Spec: docs/superpowers/specs/2026-05-01-snyk-socket-pre-install-gate-design.md
+
+## Test plan
+- [ ] go test ./...
+- [ ] GOOS=windows go build ./...
+- [ ] Manually confirm SOCKET_API_KEY / SNYK_TOKEN env vars are read on a real install
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Implementing tasks |
+|---|---|
+| §Architecture (CheckProvider, orchestrator) | Tasks 1, 13 |
+| §Per-provider — Socket (PURL batch, alert mapping, chunking, breaker) | Tasks 5, 6, 7, 8 |
+| §Per-provider — Snyk (per-package fan-out, mapping, breaker) | Tasks 9, 10 |
+| §Verdict policy (`block_on` shorthand) | Task 15 |
+| §Fail mode (per-call timeout, total budget, OnFailure mapping, env override, breaker) | Tasks 4, 7, 10, 18, 19 |
+| §Caching (clean / found / not-found TTLs, negative cache) | Task 11 |
+| §Privacy (registry allowlist + scope denylist + Skipped surfaced) | Tasks 1, 12, 13, 14 |
+| §Configuration shape | Tasks 16, 17, 18 |
+| §Scope implication (`all_installs` default + warning) | Task 17 |
+| §Out of scope (manifest upload, CLI shell-out, post-install, auto-remediate) | Honored — not implemented anywhere |
+| §Testing strategy | Tasks 2, 8, 10, 11, 12, 13, 14, 19, 20 |
+
+**Note on per-`CheckBatch` total budget:** the spec calls for a 30s `total_budget` distinct from the 5s per-call timeout. The orchestrator's existing per-provider `Timeout` already serves this role for the `CheckBatch` call (its context times out the entire fan-out). No new field is needed; the user configures `Providers["snyk"].Timeout = 30s` at the YAML layer. Documented as inline comment on the config in Task 16.
+
+**Placeholder scan:** no TBD / TODO / "implement later" / "similar to task N" instances. Every step has either runnable code, a runnable command with expected output, or a commit. Spot-checked all 20 tasks.
+
+**Type consistency:**
+- `SkipReason`, `SkippedPackage`, `Verdict.Skipped` consistent across Tasks 1, 12, 13, 14, 19.
+- `EvalContext` / `EvaluateWithContext` introduced in Task 14, consumed in Task 19.
+- `ApplyExternalProviderDefaults`, `ResolveFailMode`, `ApplyFailMode`, `CompileBlockOn`, `BlockOnConfig`, `PrivacyConfig` consistent across Tasks 15-18.
+- `NewSocketProvider(SocketConfig{...})` / `NewSnykProvider(SnykConfig{...})` constructor + config-struct names consistent in Tasks 7, 8, 10, 19.
+- `runContractSuite` / `contractFixture` defined in Task 2, consumed in Tasks 8, 10.
+- `retryClient`, `newRetryClient`, `retryConfig`, `circuitBreaker`, `newCircuitBreaker`, `circuitBreakerConfig` consistent in Tasks 3, 4, 7, 10.
+
+**Scope check:** the plan covers exactly the spec — two new providers + privacy + cache + fail-mode + config wiring. Implementation only, no UI / dashboard / SaaS work, matching the spec's non-goals.
+
+No issues found.

--- a/docs/superpowers/specs/2026-05-01-snyk-socket-pre-install-gate-design.md
+++ b/docs/superpowers/specs/2026-05-01-snyk-socket-pre-install-gate-design.md
@@ -1,0 +1,220 @@
+# Snyk and Socket Pre-Install Gating
+
+**Date:** 2026-05-01
+**Author:** Eran Sandler
+**Status:** Design — pending review
+
+## Goal
+
+Add Snyk and Socket as pluggable `CheckProvider` implementations alongside the existing OSV provider, so that intercepted package installs (`npm install`, `pnpm add`, `yarn add`, `pip install`, `uv pip install`, `poetry add`, plus their bulk forms) can be gated **before** the install process runs. Each provider must function as a standalone gate — companies typically license one or the other, not both.
+
+The threat model is the recent wave of supply-chain attacks (Shai-Hulud, `chalk` / `ansi-styles` poisonings, typosquats) that detonate inside `postinstall` scripts. These attacks must be blocked before the install process is allowed to spawn.
+
+## Non-goals
+
+- Snyk manifest-upload path (`POST /test/npm` with package-lock.json). Per-package fan-out only.
+- Snyk CLI shell-out. REST only.
+- Post-install async scanning. Pre-install gate only for v1.
+- Auto-remediation, version-bumping, or rewriting `package.json`.
+- Custom finding-rule DSL. Severity thresholds are the only policy knob.
+- Net-new UI surface. Verdicts flow through the same channel that existing OSV verdicts use.
+
+## Architecture
+
+The existing `internal/pkgcheck` package already has the right shape. No new orchestration is needed.
+
+```
+intercept (interceptor.go)
+   → resolve (resolver/npm.go runs `npm install --package-lock-only --ignore-scripts --json`)
+       → orchestrate (orchestrator.go fans out to all configured CheckProviders in parallel)
+           → providers (provider/osv.go today; provider/socket.go + provider/snyk.go new)
+               → cache (internal/pkgcheck/cache, keyed by provider+ecosystem+name+version)
+                   → evaluate (evaluator.go merges findings → Verdict → allow/warn/approve/block)
+```
+
+Two new files: `internal/pkgcheck/provider/socket.go` and `internal/pkgcheck/provider/snyk.go`. Each implements the existing `pkgcheck.CheckProvider` interface (`Name()`, `Capabilities()`, `CheckBatch(ctx, CheckRequest) (*CheckResponse, error)`).
+
+A small shared helper `internal/pkgcheck/provider/httpclient.go` consolidates retry, rate-limit handling, auth header injection, and circuit-breaker state across the two new providers.
+
+## Per-provider implementations
+
+### Socket (`provider/socket.go`)
+
+- Single `POST /v0/purl` per chunk. Body is a JSON object containing a list of PURLs (`pkg:npm/lodash@4.17.21`, `pkg:pypi/requests@2.31.0`) built from the `[]PackageRef` in the request.
+- Hard cap of 100 PURLs per call (Socket's documented limit). Above 100, chunk and parallelize chunks.
+- Response → `Finding` mapping:
+  - `malware` alert → `FindingMalware`, severity preserved.
+  - `installScripts`, `shellAccess`, `networkAccess` → `FindingMalware` for `critical`, `FindingReputation` otherwise.
+  - `typosquat`, `suspiciousStarActivity`, `unmaintained` → `FindingReputation`.
+  - `cve` alerts → `FindingVulnerability`.
+  - `licenseChange`, `nonpermissiveLicense` → `FindingLicense`.
+  - Provenance / signing alerts → `FindingProvenance`.
+- Auth: `Authorization: Basic <base64(api_key:)>` header, key read from env var.
+- Steady-state latency: one round-trip per chunk; for ≤100 packages, one round-trip.
+
+### Snyk (`provider/snyk.go`)
+
+- Per-package `POST /test/{ecosystem}/{name}/{version}` calls fanned out via a concurrency-bounded `errgroup`. Default concurrency: 16.
+- Each response → 0..N `Finding` entries (`FindingVulnerability`, `FindingLicense`).
+- Auth: `Authorization: token <api_key>` header, key read from env var.
+- Cold-install latency: roughly `ceil(N_uncached / 16) * p50_per_call`. Steady-state cache means subsequent installs only fan out the changed packages (typically a handful).
+
+Both providers share the helper for backoff, rate-limit handling, and circuit-breaker state.
+
+## Verdict policy
+
+```yaml
+pkgcheck:
+  policy:
+    block_on:
+      malware: any           # any | critical | never
+      vulnerability: critical # critical | high | medium | never
+      license: never          # any | never
+      reputation: never       # any | never
+      provenance: never
+```
+
+Defaults rationale:
+
+- **Malware always blocks.** A malware finding means "running this *will* attack you" — that is fundamentally different from a CVE ("a known weakness exists") and warrants a stricter default. This is the entire purpose of the gate.
+- **Vulnerabilities block on `Critical`, warn on `High`.** Blocking on `High` would block half of `npm install` runs in the npm ecosystem (long tail of `High`-severity ReDoS / prototype-pollution findings) without much real-world risk reduction.
+- **License, reputation, provenance default to warn.** Teams with strict policies can flip them to block via config.
+
+The evaluator already merges per-package verdicts using `VerdictAction.weight()`; a single `block` promotes the whole install to `block`. No evaluator changes needed.
+
+## Fail mode
+
+- **Per-HTTP-call timeout:** 5s, configurable. Applies to a single Socket batch call or a single Snyk `/test/...` call. For Snyk, total fan-out wall time is bounded by `ceil(N_uncached / concurrency) * per_call_p50`, not by this timeout.
+- **Per-provider total budget:** 30s, configurable. Caps the worst-case wall time for the entire `CheckBatch` call across all retries and fanned-out requests. If the budget is exceeded, the response carries `ResponseMetadata.Partial: true`, `ResponseMetadata.Error` populated, **no findings emitted**.
+- Any HTTP-call timeout or transport error rolls into the same partial-response shape.
+- **Orchestrator behavior on partial:** if the configured external provider is partial *and* OSV succeeded, emit `Verdict.Action` based on OSV findings only with `Verdict.Summary` prefixed `"degraded: <provider> unavailable"`. Verdict is annotated so callers can render "checked with degraded coverage — N packages not externally verified."
+- **Per-environment override** via env var `PKGCHECK_FAIL_MODE`:
+  - `closed` — block install when external provider is partial. CI default.
+  - `open` — allow install when external provider is partial. Use only with explicit risk acceptance.
+  - `degraded` — fall back to OSV findings only, annotated in the verdict. Interactive default.
+- **Circuit breaker:** after 3 consecutive provider errors within 60s, the provider is short-circuited for the next 60s — subsequent installs go straight to OSV-only with the `degraded` annotation, skipping the 5s timeout. Prevents holding up every install in the org during an outage.
+
+## Caching
+
+The cache layer at `internal/pkgcheck/cache` already keys by `(provider, ecosystem, name, version)`. Three behaviors to add or formalize:
+
+- **TTL: 24h for "clean" results, indefinite for findings.** A clean result can go stale (a maintainer takeover happens *after* we cached "clean"); 24h is the maximum staleness window. Findings, by contrast, are essentially permanent for a given `(name, version)` — a CVE for `lodash@4.17.20` doesn't go away — so they cache indefinitely. A manual purge command (`pkgcheck cache purge`) handles the rare false-positive case.
+- **Negative cache for 404 / "unknown package" responses, TTL 1h.** Private packages return 404 from Socket/Snyk; we don't re-query them every install.
+- **Cache key includes provider name** so Snyk findings and Socket findings live in separate keyspaces — switching providers doesn't surface stale data from the other.
+
+The cache is the single biggest reason per-package Snyk fan-out is viable. After the first install, the steady state for unchanged packages is zero network calls.
+
+## Privacy / private-package handling
+
+Two-layer skip rule:
+
+1. **Auto-detect by registry.** A `PackageRef` whose `Registry` field is not on the configured `external_scan_registries` list is skipped. The resolver already populates `Registry` per package from the lockfile, so this is essentially free and correct in 95% of cases.
+2. **Scope/prefix denylist override.** A configurable `private_scope_denylist` (e.g. `["@mycompany", "@internal-*"]`) catches packages that slip onto a public registry but should still not be sent externally — e.g., accidentally-published-public internal packages.
+
+Skipped packages are surfaced in the verdict as a separate `Skipped` list (not silently dropped). The CLI/UI renders "N packages not externally checked (private)" so users can see the coverage gap explicitly.
+
+This requires a small additive change to `Verdict`:
+
+```go
+type Verdict struct {
+    Action   VerdictAction
+    Findings []Finding
+    Summary  string
+    Packages map[string]PackageVerdict
+    Skipped  []SkippedPackage  // new
+}
+
+type SkippedPackage struct {
+    Package PackageRef
+    Reason  string  // "private_registry" | "private_scope_denylist"
+}
+```
+
+## Configuration shape
+
+```yaml
+pkgcheck:
+  scope: all_installs              # see "Scope implication" below
+
+  providers:
+    osv:
+      enabled: true                 # always-on local fallback
+    socket:
+      enabled: true
+      api_key_env: SOCKET_API_KEY   # env var name; key never lives in the file
+      timeout: 5s                    # per-HTTP-call
+      total_budget: 30s              # per-CheckBatch wall-time cap
+      max_purls_per_call: 100
+    snyk:
+      enabled: false                # mutually-exclusive with socket in typical deployments
+      api_key_env: SNYK_TOKEN
+      timeout: 5s                    # per-HTTP-call
+      total_budget: 30s              # per-CheckBatch wall-time cap across fan-out
+      concurrency: 16
+
+  privacy:
+    external_scan_registries:
+      - registry.npmjs.org
+      - pypi.org
+    private_scope_denylist:
+      - "@mycompany"
+      - "@internal-*"
+
+  policy:
+    block_on:
+      malware: any
+      vulnerability: critical
+      license: never
+      reputation: never
+      provenance: never
+
+  fail_mode: degraded               # open | closed | degraded; PKGCHECK_FAIL_MODE env var overrides
+```
+
+API keys are never read from the config file — only from env vars referenced by `api_key_env`. Keeps secrets out of repos.
+
+## Scope implication (the bare-`npm install` issue)
+
+The current default intercept scope is `new_packages_only`, which **does not intercept bare `npm install`** (the lockfile-driven case). For a pre-install gate against supply-chain attacks, that default is wrong — bare `npm install` and `npm ci` are exactly the entry points through which a poisoned transitive dep gets pulled into a fresh checkout.
+
+**Required change:** when any external provider (Socket or Snyk) is enabled, the scope **defaults to `all_installs`**. Users can override explicitly via config, but the loader emits a validation warning if they configure an external provider with `scope: new_packages_only`:
+
+> "Socket is configured but `scope: new_packages_only` is set — bare `npm install` and `npm ci` will not be intercepted, so supply-chain attacks via lockfile installs will not be blocked. Set `scope: all_installs` to enable full coverage."
+
+No code change to the interceptor itself. Just a default-scope adjustment in the config loader plus the validation warning.
+
+## Testing strategy
+
+- **Unit tests for each provider** using `httptest.Server` fixtures (matches the pattern in `provider/osv_test.go`). Capture real Socket/Snyk responses once into `testdata/`, replay them.
+- **Provider-contract test** — a shared test suite that any `CheckProvider` implementation must pass: handles empty input, deduplicates by `name@version`, respects context cancellation, returns `Partial: true` on transport error. Run against OSV, Socket, Snyk.
+- **Cache test** — fan out with 100 packages, second call issues zero network requests; 404s hit negative cache for 1h.
+- **Fail-mode test** — fake Socket returning 5xx; verify orchestrator emits a degraded verdict with OSV findings only and the "degraded" prefix in summary.
+- **Privacy test** — input includes `@mycompany/foo`; verify no outbound HTTP request was made for that package and verdict marks it `skipped: private_scope_denylist`.
+- **Circuit-breaker test** — 3 consecutive 5xx in 60s flips the breaker; subsequent calls skip the network entirely for 60s.
+- **Cross-compile test** — verify `GOOS=windows go build ./...` still succeeds (no Linux-only deps in the new providers).
+- **Integration test** behind a build tag that hits the real Socket/Snyk APIs with a tiny known package set — runs nightly in CI, not on every PR. Catches API contract drift.
+
+## Files touched
+
+New:
+- `internal/pkgcheck/provider/socket.go`
+- `internal/pkgcheck/provider/socket_test.go`
+- `internal/pkgcheck/provider/snyk.go`
+- `internal/pkgcheck/provider/snyk_test.go`
+- `internal/pkgcheck/provider/httpclient.go` (shared retry / rate-limit / circuit-breaker helper)
+- `internal/pkgcheck/provider/httpclient_test.go`
+- `internal/pkgcheck/provider/contract_test.go` (shared CheckProvider contract suite)
+- `internal/pkgcheck/provider/testdata/socket_*.json`, `snyk_*.json` fixtures
+
+Modified:
+- `internal/pkgcheck/types.go` — add `Skipped []SkippedPackage` to `Verdict`, add `SkippedPackage` type.
+- `internal/pkgcheck/orchestrator.go` — wire privacy filter (registry / scope denylist) before provider calls; surface `Skipped` in `Verdict`; honor `fail_mode` and circuit-breaker state.
+- `internal/pkgcheck/evaluator.go` — apply per-finding-type severity thresholds from `policy.block_on`.
+- `internal/pkgcheck/cache/*.go` — distinguish "clean" (24h TTL) from "found" (indefinite) cache entries; add negative-cache for 404s.
+- `internal/config/pkgcheck*.go` — add `socket`, `snyk`, `privacy`, `policy`, `fail_mode` fields; default scope to `all_installs` when an external provider is enabled; emit validation warning otherwise.
+
+## Open risks
+
+- **Snyk per-package latency on first cold install.** A 500-dep `npm install` against a cold cache, at concurrency 16 and 200ms per-call p50, is roughly 6.5s of fan-out wall time (`ceil(500/16) * 200ms`). That fits within the 30s per-`CheckBatch` budget. The 5s per-call timeout applies to each individual Snyk request and is not the bound on the fan-out. Total cold-install gate latency is dominated by the resolver's `npm install --package-lock-only` step (5–30s), not by Snyk fan-out. Steady-state with cache is sub-second.
+- **Socket alert taxonomy drift.** Socket adds new alert types over time; unrecognized types should map to `FindingReputation` with severity `Medium` rather than be dropped. A test asserts no alert type is silently lost.
+- **API quota exhaustion.** Both Snyk and Socket meter API calls. Snyk in particular charges per call. The cache and circuit breaker mitigate; quota dashboards belong in operations docs, not in this design.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1920,6 +1920,14 @@ func applyDefaultsWithSource(cfg *Config, source ConfigSource, configPath string
 	if cfg.PackageChecks.Providers == nil {
 		cfg.PackageChecks.Providers = pkgDefaults.Providers
 	}
+	// Privacy block defaults: an unset list (nil) inherits the
+	// public-registry allowlist so the privacy gate is on by default.
+	// Use == nil rather than len(...) == 0 so users can explicitly disable
+	// the filter by setting external_scan_registries: [] in YAML.
+	if cfg.PackageChecks.Privacy.ExternalScanRegistries == nil {
+		cfg.PackageChecks.Privacy.ExternalScanRegistries = pkgDefaults.Privacy.ExternalScanRegistries
+	}
+	// PrivateScopeDenylist defaults to nil intentionally (no scope blocked by default).
 
 	// Policy socket defaults (macOS system extension IPC)
 	if cfg.PolicySocket.Path == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2222,6 +2222,11 @@ func validateConfig(cfg *Config) error {
 			return fmt.Errorf("invalid package_checks.registries[%q].trust %q (must be \"check_full\", \"check_local_only\", or \"trusted\")", name, r.Trust)
 		}
 	}
+	// Validate denylist globs in package_checks.privacy so malformed
+	// patterns fail at startup rather than silently fail open at runtime.
+	if err := cfg.PackageChecks.Privacy.Validate(); err != nil {
+		return fmt.Errorf("package_checks.privacy: %w", err)
+	}
 	// Landlock network self-lockout check: if the user disables outbound TCP
 	// under Landlock but the sandbox proxy is enabled, agents can never reach
 	// the proxy (which listens on localhost TCP). Fail fast at startup rather

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1950,13 +1950,24 @@ func applyDefaultsWithSource(cfg *Config, source ConfigSource, configPath string
 		cfg.PackageChecks.Privacy.ExternalScanRegistries = pkgDefaults.Privacy.ExternalScanRegistries
 	}
 	// PrivateScopeDenylist defaults to nil intentionally (no scope blocked by default).
-	// BlockOn defaults: apply when all fields are empty (YAML omitted the block_on section).
-	if cfg.PackageChecks.BlockOn.Malware == "" &&
-		cfg.PackageChecks.BlockOn.Vulnerability == "" &&
-		cfg.PackageChecks.BlockOn.License == "" &&
-		cfg.PackageChecks.BlockOn.Reputation == "" &&
-		cfg.PackageChecks.BlockOn.Provenance == "" {
-		cfg.PackageChecks.BlockOn = pkgDefaults.BlockOn
+	// BlockOn: per-field defaults so partial YAML doesn't silently disable
+	// the malware/vulnerability defaults when the user only set license.
+	// A user who explicitly wants to opt out of a default sets the field to
+	// "never" (a valid BlockOnConfig value that produces no rule).
+	if cfg.PackageChecks.BlockOn.Malware == "" {
+		cfg.PackageChecks.BlockOn.Malware = pkgDefaults.BlockOn.Malware
+	}
+	if cfg.PackageChecks.BlockOn.Vulnerability == "" {
+		cfg.PackageChecks.BlockOn.Vulnerability = pkgDefaults.BlockOn.Vulnerability
+	}
+	if cfg.PackageChecks.BlockOn.License == "" {
+		cfg.PackageChecks.BlockOn.License = pkgDefaults.BlockOn.License
+	}
+	if cfg.PackageChecks.BlockOn.Reputation == "" {
+		cfg.PackageChecks.BlockOn.Reputation = pkgDefaults.BlockOn.Reputation
+	}
+	if cfg.PackageChecks.BlockOn.Provenance == "" {
+		cfg.PackageChecks.BlockOn.Provenance = pkgDefaults.BlockOn.Provenance
 	}
 
 	// Policy socket defaults (macOS system extension IPC)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1920,6 +1920,9 @@ func applyDefaultsWithSource(cfg *Config, source ConfigSource, configPath string
 	if cfg.PackageChecks.Providers == nil {
 		cfg.PackageChecks.Providers = pkgDefaults.Providers
 	}
+	if cfg.PackageChecks.FailMode == "" {
+		cfg.PackageChecks.FailMode = pkgDefaults.FailMode
+	}
 	// Privacy block defaults: an unset list (nil) inherits the
 	// public-registry allowlist so the privacy gate is on by default.
 	// Use == nil rather than len(...) == 0 so users can explicitly disable

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1950,6 +1950,14 @@ func applyDefaultsWithSource(cfg *Config, source ConfigSource, configPath string
 		cfg.PackageChecks.Privacy.ExternalScanRegistries = pkgDefaults.Privacy.ExternalScanRegistries
 	}
 	// PrivateScopeDenylist defaults to nil intentionally (no scope blocked by default).
+	// BlockOn defaults: apply when all fields are empty (YAML omitted the block_on section).
+	if cfg.PackageChecks.BlockOn.Malware == "" &&
+		cfg.PackageChecks.BlockOn.Vulnerability == "" &&
+		cfg.PackageChecks.BlockOn.License == "" &&
+		cfg.PackageChecks.BlockOn.Reputation == "" &&
+		cfg.PackageChecks.BlockOn.Provenance == "" {
+		cfg.PackageChecks.BlockOn = pkgDefaults.BlockOn
+	}
 
 	// Policy socket defaults (macOS system extension IPC)
 	if cfg.PolicySocket.Path == "" {
@@ -2258,6 +2266,11 @@ func validateConfig(cfg *Config) error {
 	// patterns fail at startup rather than silently fail open at runtime.
 	if err := cfg.PackageChecks.Privacy.Validate(); err != nil {
 		return fmt.Errorf("package_checks.privacy: %w", err)
+	}
+	// Validate block_on shorthand enum values so a typo like
+	// vulnerability=critcal doesn't silently compile to a permissive policy.
+	if err := cfg.PackageChecks.BlockOn.Validate(); err != nil {
+		return fmt.Errorf("package_checks.%w", err)
 	}
 	// Landlock network self-lockout check: if the user disables outbound TCP
 	// under Landlock but the sandbox proxy is enabled, agents can never reach

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1899,9 +1899,28 @@ func applyDefaultsWithSource(cfg *Config, source ConfigSource, configPath string
 
 	// Package checks defaults
 	pkgDefaults := DefaultPackageChecksConfig()
+
+	// Capture the user-provided scope BEFORE generic defaulting touches it,
+	// so external-provider promotion can distinguish "user said
+	// new_packages_only" from "YAML omitted scope".
+	userSetScope := cfg.PackageChecks.Scope != ""
+
+	// Run external-provider scope promotion. This may set Scope to
+	// "all_installs" if it was empty and an external provider is enabled,
+	// or emit a warning to stderr if the user explicitly set
+	// new_packages_only with an external provider.
+	if warnings := ApplyExternalProviderDefaults(&cfg.PackageChecks); len(warnings) > 0 {
+		for _, w := range warnings {
+			slog.Warn(w)
+		}
+	}
+
+	// Generic default for scope only kicks in if neither the user nor
+	// ApplyExternalProviderDefaults set it.
 	if cfg.PackageChecks.Scope == "" {
 		cfg.PackageChecks.Scope = pkgDefaults.Scope
 	}
+	_ = userSetScope // currently informational; warning logic uses presence of provider config
 	if cfg.PackageChecks.Cache.TTL.Vulnerability == 0 {
 		cfg.PackageChecks.Cache.TTL.Vulnerability = pkgDefaults.Cache.TTL.Vulnerability
 	}
@@ -2200,6 +2219,16 @@ func validateConfig(cfg *Config) error {
 		case "new_packages_only", "all_installs":
 		default:
 			return fmt.Errorf("invalid package_checks.scope %q (must be \"new_packages_only\" or \"all_installs\")", cfg.PackageChecks.Scope)
+		}
+	}
+	// Validate package_checks.fail_mode (also reachable via PKGCHECK_FAIL_MODE
+	// env var; ResolveFailMode performs the same check at runtime, but we
+	// surface YAML-time misconfig as an explicit startup error).
+	if cfg.PackageChecks.FailMode != "" {
+		switch cfg.PackageChecks.FailMode {
+		case "open", "closed", "degraded":
+		default:
+			return fmt.Errorf("invalid package_checks.fail_mode %q (must be \"open\", \"closed\", or \"degraded\")", cfg.PackageChecks.FailMode)
 		}
 	}
 	for name, p := range cfg.PackageChecks.Providers {

--- a/internal/config/pkgcheck.go
+++ b/internal/config/pkgcheck.go
@@ -72,14 +72,29 @@ type ResolverConfig struct {
 	Timeout       time.Duration `yaml:"timeout"`
 }
 
-// Validate returns an error if the configuration is malformed. In
-// particular, DryRunCommand must be a binary path with no embedded
-// whitespace; multi-token commands should be split into DryRunCommand
-// (binary) plus DryRunArgs (the rest).
+// Validate returns an error if the configuration is malformed.
+//
+// DryRunCommand is the binary path. Paths with spaces (e.g. Windows
+// `C:\Program Files\nodejs\npm.cmd`) are valid — the resolver preserves
+// them verbatim. The validator only rejects values that look like the
+// pre-`dry_run_args` command-string form, where additional whitespace-
+// separated tokens include a flag-shaped argument (`--foo` or `-x`),
+// which the new code can no longer interpret.
 func (r ResolverConfig) Validate() error {
-	if strings.ContainsAny(r.DryRunCommand, " \t") {
-		return fmt.Errorf("dry_run_command must be a binary path without spaces; "+
-			"split arguments into dry_run_args. Got: %q", r.DryRunCommand)
+	if r.DryRunCommand == "" {
+		return nil
+	}
+	if !strings.ContainsAny(r.DryRunCommand, " \t") {
+		return nil
+	}
+	// Heuristic: a multi-token value with a flag-shaped token after the
+	// first whitespace is the legacy command-string form.
+	for _, tok := range strings.Fields(r.DryRunCommand)[1:] {
+		if strings.HasPrefix(tok, "-") {
+			return fmt.Errorf("dry_run_command must be a binary path; "+
+				"multi-token command strings are no longer supported — "+
+				"split arguments into dry_run_args. Got: %q", r.DryRunCommand)
+		}
 	}
 	return nil
 }

--- a/internal/config/pkgcheck.go
+++ b/internal/config/pkgcheck.go
@@ -26,6 +26,9 @@ type PackageChecksConfig struct {
 	//   "degraded" — fall back to OSV findings, annotate the verdict.
 	// The env var PKGCHECK_FAIL_MODE overrides this at runtime.
 	FailMode string `yaml:"fail_mode" json:"fail_mode"`
+	// BlockOn is the per-finding-type severity-threshold shorthand that
+	// compiles to a list of policy rules via CompileBlockOn.
+	BlockOn BlockOnConfig `yaml:"block_on" json:"block_on"`
 }
 
 // PackagePrivacyConfig configures the upstream privacy filter applied
@@ -209,6 +212,13 @@ func DefaultPackageChecksConfig() PackageChecksConfig {
 			},
 			PrivateScopeDenylist: nil,
 		},
+		BlockOn: BlockOnConfig{
+			Malware:       "any",
+			Vulnerability: "critical",
+			License:       "never",
+			Reputation:    "never",
+			Provenance:    "never",
+		},
 	}
 }
 
@@ -225,6 +235,39 @@ type BlockOnConfig struct {
 	License       string `yaml:"license" json:"license"`
 	Reputation    string `yaml:"reputation" json:"reputation"`
 	Provenance    string `yaml:"provenance" json:"provenance"`
+}
+
+// Validate ensures every field in BlockOnConfig holds an enum value from its
+// documented set. Empty strings are permitted (treated as "no rule for this
+// finding type"). Unknown values fail loudly so a typo like "critcal" doesn't
+// compile to permissive policy.
+func (b BlockOnConfig) Validate() error {
+	for _, kv := range []struct {
+		name  string
+		value string
+		valid []string
+	}{
+		{"malware", b.Malware, []string{"", "any", "critical", "never"}},
+		{"vulnerability", b.Vulnerability, []string{"", "critical", "high", "medium", "never"}},
+		{"license", b.License, []string{"", "any", "never"}},
+		{"reputation", b.Reputation, []string{"", "any", "never"}},
+		{"provenance", b.Provenance, []string{"", "any", "never"}},
+	} {
+		if !blockOnContains(kv.valid, kv.value) {
+			return fmt.Errorf("block_on.%s=%q invalid (must be one of %v)", kv.name, kv.value, kv.valid)
+		}
+	}
+	return nil
+}
+
+// blockOnContains reports whether needle is in haystack.
+func blockOnContains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
 }
 
 // CompileBlockOn translates the BlockOnConfig shorthand into a list of

--- a/internal/config/pkgcheck.go
+++ b/internal/config/pkgcheck.go
@@ -398,6 +398,11 @@ func ResolveFailMode(cfg *PackageChecksConfig) string {
 //
 // External providers are those listed in externalProviderNames. Other
 // providers (osv, depsdev, local) keep whatever OnFailure the user set.
+//
+// Per-provider explicit `on_failure` always wins: if a provider already
+// has a non-empty OnFailure, it is preserved. Fail mode only fills in
+// providers that did not configure on_failure themselves, so an operator
+// can override the global mode for a single provider.
 func ApplyFailMode(cfg *PackageChecksConfig, mode string) {
 	target := ""
 	switch mode {
@@ -415,6 +420,10 @@ func ApplyFailMode(cfg *PackageChecksConfig, mode string) {
 	for _, name := range externalProviderNames {
 		p, ok := cfg.Providers[name]
 		if !ok || !p.Enabled {
+			continue
+		}
+		if p.OnFailure != "" {
+			// Operator explicitly set on_failure on this provider — keep it.
 			continue
 		}
 		p.OnFailure = target

--- a/internal/config/pkgcheck.go
+++ b/internal/config/pkgcheck.go
@@ -5,6 +5,8 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/agentsh/agentsh/internal/policy"
 )
 
 // PackageChecksConfig configures package install security checks.
@@ -199,4 +201,87 @@ func DefaultPackageChecksConfig() PackageChecksConfig {
 			PrivateScopeDenylist: nil,
 		},
 	}
+}
+
+// BlockOnConfig is the per-finding-type severity-threshold shorthand:
+//
+//	malware:       any | critical | never
+//	vulnerability: critical | high | medium | never
+//	license:       any | never
+//	reputation:    any | never
+//	provenance:    any | never
+type BlockOnConfig struct {
+	Malware       string `yaml:"malware" json:"malware"`
+	Vulnerability string `yaml:"vulnerability" json:"vulnerability"`
+	License       string `yaml:"license" json:"license"`
+	Reputation    string `yaml:"reputation" json:"reputation"`
+	Provenance    string `yaml:"provenance" json:"provenance"`
+}
+
+// CompileBlockOn translates the BlockOnConfig shorthand into a list of
+// policy.PackageRule entries (first-match-wins) ending in a catch-all allow.
+//
+// For each finding type we emit deny rules for severities at or above the
+// threshold, warn rules for severities below the threshold but still
+// noteworthy (currently: high vulns become warn even when threshold is
+// critical), and rely on the catch-all allow for everything else.
+func CompileBlockOn(b BlockOnConfig) []policy.PackageRule {
+	var rules []policy.PackageRule
+
+	// Malware: any (deny all severities) or critical (deny only critical).
+	switch b.Malware {
+	case "any":
+		rules = append(rules, policy.PackageRule{
+			Match:  policy.PackageMatch{FindingType: "malware"},
+			Action: "deny",
+			Reason: "block_on.malware=any",
+		})
+	case "critical":
+		rules = append(rules, policy.PackageRule{
+			Match:  policy.PackageMatch{FindingType: "malware", Severity: "critical"},
+			Action: "deny",
+			Reason: "block_on.malware=critical",
+		})
+	}
+
+	// Vulnerability thresholds.
+	switch b.Vulnerability {
+	case "medium":
+		rules = append(rules,
+			policy.PackageRule{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "critical"}, Action: "deny"},
+			policy.PackageRule{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "high"}, Action: "deny"},
+			policy.PackageRule{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "medium"}, Action: "deny"},
+		)
+	case "high":
+		rules = append(rules,
+			policy.PackageRule{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "critical"}, Action: "deny"},
+			policy.PackageRule{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "high"}, Action: "deny"},
+		)
+	case "critical":
+		rules = append(rules,
+			policy.PackageRule{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "critical"}, Action: "deny"},
+			policy.PackageRule{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "high"}, Action: "warn"},
+		)
+	}
+
+	// License / reputation / provenance: any → deny; never → no rule (catch-all allows).
+	for _, kv := range []struct{ ft, mode string }{
+		{"license", b.License}, {"reputation", b.Reputation}, {"provenance", b.Provenance},
+	} {
+		if kv.mode == "any" {
+			rules = append(rules, policy.PackageRule{
+				Match:  policy.PackageMatch{FindingType: kv.ft},
+				Action: "deny",
+				Reason: "block_on." + kv.ft + "=any",
+			})
+		}
+	}
+
+	// Catch-all allow.
+	rules = append(rules, policy.PackageRule{
+		Match:  policy.PackageMatch{},
+		Action: "allow",
+		Reason: "block_on default allow",
+	})
+	return rules
 }

--- a/internal/config/pkgcheck.go
+++ b/internal/config/pkgcheck.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -18,6 +19,13 @@ type PackageChecksConfig struct {
 	Providers  map[string]ProviderConfig      `yaml:"providers"`
 	Resolvers  map[string]ResolverConfig      `yaml:"resolvers"`
 	Privacy    PackagePrivacyConfig           `yaml:"privacy" json:"privacy"`
+	// FailMode controls how the orchestrator reacts to provider failures
+	// for external providers (Snyk / Socket / etc.). One of:
+	//   "open"     — let the install proceed when an external provider fails.
+	//   "closed"   — block the install when an external provider fails.
+	//   "degraded" — fall back to OSV findings, annotate the verdict.
+	// The env var PKGCHECK_FAIL_MODE overrides this at runtime.
+	FailMode string `yaml:"fail_mode" json:"fail_mode"`
 }
 
 // PackagePrivacyConfig configures the upstream privacy filter applied
@@ -187,6 +195,7 @@ func DefaultPackageChecksConfig() PackageChecksConfig {
 			},
 		},
 		Resolvers: nil,
+		FailMode:  "degraded",
 		Privacy: PackagePrivacyConfig{
 			ExternalScanRegistries: []string{
 				"registry.npmjs.org",
@@ -323,4 +332,47 @@ func ApplyExternalProviderDefaults(cfg *PackageChecksConfig) []string {
 		}
 	}
 	return nil
+}
+
+// ResolveFailMode returns the effective fail mode, honoring the
+// PKGCHECK_FAIL_MODE env var override. Defaults to "degraded".
+func ResolveFailMode(cfg *PackageChecksConfig) string {
+	if v := os.Getenv("PKGCHECK_FAIL_MODE"); v != "" {
+		return v
+	}
+	if cfg.FailMode != "" {
+		return cfg.FailMode
+	}
+	return "degraded"
+}
+
+// ApplyFailMode sets OnFailure on every enabled external provider to match
+// the resolved fail mode. Mapping:
+//
+//	open     → "allow"
+//	closed   → "deny"
+//	degraded → "warn"
+//
+// External providers are those listed in externalProviderNames. Other
+// providers (osv, depsdev, local) keep whatever OnFailure the user set.
+func ApplyFailMode(cfg *PackageChecksConfig, mode string) {
+	target := ""
+	switch mode {
+	case "open":
+		target = "allow"
+	case "closed":
+		target = "deny"
+	case "degraded":
+		target = "warn"
+	default:
+		target = "warn"
+	}
+	for _, name := range externalProviderNames {
+		p, ok := cfg.Providers[name]
+		if !ok || !p.Enabled {
+			continue
+		}
+		p.OnFailure = target
+		cfg.Providers[name] = p
+	}
 }

--- a/internal/config/pkgcheck.go
+++ b/internal/config/pkgcheck.go
@@ -270,14 +270,19 @@ func blockOnContains(haystack []string, needle string) bool {
 	return false
 }
 
-// CompileBlockOn translates the BlockOnConfig shorthand into a list of
-// policy.PackageRule entries (first-match-wins) ending in a catch-all allow.
+// CompileBlockOnRules translates the BlockOnConfig shorthand into a list of
+// typed policy.PackageRule entries (first-match-wins) WITHOUT a trailing
+// catch-all allow rule.
+//
+// Use this variant when merging block_on rules with an operator policy engine
+// that may deliberately omit a catch-all (fail-closed intent). Adding a
+// catch-all in that context would silently override the operator's default-deny.
 //
 // For each finding type we emit deny rules for severities at or above the
 // threshold, warn rules for severities below the threshold but still
 // noteworthy (currently: high vulns become warn even when threshold is
-// critical), and rely on the catch-all allow for everything else.
-func CompileBlockOn(b BlockOnConfig) []policy.PackageRule {
+// critical).
+func CompileBlockOnRules(b BlockOnConfig) []policy.PackageRule {
 	var rules []policy.PackageRule
 
 	// Malware: any (deny all severities) or critical (deny only critical).
@@ -316,7 +321,7 @@ func CompileBlockOn(b BlockOnConfig) []policy.PackageRule {
 		)
 	}
 
-	// License / reputation / provenance: any → deny; never → no rule (catch-all allows).
+	// License / reputation / provenance: any → deny; never → no rule.
 	for _, kv := range []struct{ ft, mode string }{
 		{"license", b.License}, {"reputation", b.Reputation}, {"provenance", b.Provenance},
 	} {
@@ -329,13 +334,23 @@ func CompileBlockOn(b BlockOnConfig) []policy.PackageRule {
 		}
 	}
 
-	// Catch-all allow.
-	rules = append(rules, policy.PackageRule{
+	return rules
+}
+
+// CompileBlockOn translates the BlockOnConfig shorthand into a list of
+// policy.PackageRule entries (first-match-wins) ending in a catch-all allow.
+//
+// Use this variant when block_on is the sole rule source — the catch-all allow
+// ensures unmatched findings pass through rather than hitting the evaluator's
+// default-deny. When merging with an operator policy engine, use
+// CompileBlockOnRules instead so the engine's catch-all (or deliberate
+// omission of one) is not shadowed.
+func CompileBlockOn(b BlockOnConfig) []policy.PackageRule {
+	return append(CompileBlockOnRules(b), policy.PackageRule{
 		Match:  policy.PackageMatch{},
 		Action: "allow",
 		Reason: "block_on default allow",
 	})
-	return rules
 }
 
 // externalProviderNames lists provider names that send package data to a

--- a/internal/config/pkgcheck.go
+++ b/internal/config/pkgcheck.go
@@ -1,6 +1,10 @@
 package config
 
-import "time"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
 // PackageChecksConfig configures package install security checks.
 type PackageChecksConfig struct {
@@ -66,6 +70,18 @@ type ResolverConfig struct {
 	// Each element is a single token (no shell splitting is performed).
 	DryRunArgs    []string      `yaml:"dry_run_args" json:"dry_run_args"`
 	Timeout       time.Duration `yaml:"timeout"`
+}
+
+// Validate returns an error if the configuration is malformed. In
+// particular, DryRunCommand must be a binary path with no embedded
+// whitespace; multi-token commands should be split into DryRunCommand
+// (binary) plus DryRunArgs (the rest).
+func (r ResolverConfig) Validate() error {
+	if strings.ContainsAny(r.DryRunCommand, " \t") {
+		return fmt.Errorf("dry_run_command must be a binary path without spaces; "+
+			"split arguments into dry_run_args. Got: %q", r.DryRunCommand)
+	}
+	return nil
 }
 
 // SkillcheckConfig configures the skillcheck daemon that scans Claude Code

--- a/internal/config/pkgcheck.go
+++ b/internal/config/pkgcheck.go
@@ -19,6 +19,11 @@ type PackageChecksConfig struct {
 
 // PackagePrivacyConfig configures the upstream privacy filter applied
 // before any external (Snyk / Socket / etc.) provider is invoked.
+//
+// LIMITATION: registry detection is CLI-flag-only. If your installs
+// rely on .npmrc / pip.conf / env-var registry overrides, ALSO list
+// those registries in ExternalScanRegistries — otherwise private
+// packages may be treated as public and sent to external providers.
 type PackagePrivacyConfig struct {
 	// ExternalScanRegistries lists registries whose packages may be sent
 	// to external providers. An empty list means "no registry filter."

--- a/internal/config/pkgcheck.go
+++ b/internal/config/pkgcheck.go
@@ -60,6 +60,21 @@ func (p PackagePrivacyConfig) Validate() error {
 			return fmt.Errorf("invalid denylist pattern %q: %w", pat, err)
 		}
 	}
+	// If the operator provided ExternalScanRegistries entries but every
+	// one is empty/whitespace, that's a config error — the resulting
+	// allowlist is empty (which disables filtering) without the operator
+	// expressing that intent. To explicitly disable, use the empty list `[]`.
+	if len(p.ExternalScanRegistries) > 0 {
+		nonEmpty := 0
+		for _, r := range p.ExternalScanRegistries {
+			if strings.TrimSpace(r) != "" {
+				nonEmpty++
+			}
+		}
+		if nonEmpty == 0 {
+			return fmt.Errorf("external_scan_registries: provided %d entries but all are empty/whitespace; use [] to disable the filter explicitly", len(p.ExternalScanRegistries))
+		}
+	}
 	return nil
 }
 

--- a/internal/config/pkgcheck.go
+++ b/internal/config/pkgcheck.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"path"
 	"strings"
 	"time"
 )
@@ -31,6 +32,22 @@ type PackagePrivacyConfig struct {
 	// PrivateScopeDenylist lists package name prefixes / glob patterns
 	// that should NOT be sent externally even when on an allowed registry.
 	PrivateScopeDenylist []string `yaml:"private_scope_denylist" json:"private_scope_denylist"`
+}
+
+// Validate checks that all PrivateScopeDenylist entries are valid glob
+// patterns.  A malformed pattern would silently match nothing at runtime,
+// producing a fail-open privacy hole.  Call this at config-load time so
+// operators see a startup error instead of silent misbehaviour.
+func (p PackagePrivacyConfig) Validate() error {
+	for _, pat := range p.PrivateScopeDenylist {
+		if pat == "" {
+			continue
+		}
+		if _, err := path.Match(pat, "test"); err != nil {
+			return fmt.Errorf("invalid denylist pattern %q: %w", pat, err)
+		}
+	}
+	return nil
 }
 
 // PackageCacheConfig configures the on-disk check result cache.

--- a/internal/config/pkgcheck.go
+++ b/internal/config/pkgcheck.go
@@ -285,3 +285,42 @@ func CompileBlockOn(b BlockOnConfig) []policy.PackageRule {
 	})
 	return rules
 }
+
+// externalProviderNames lists provider names that send package data to a
+// third-party API and therefore benefit from privacy filtering and
+// scope=all_installs.
+var externalProviderNames = []string{"snyk", "socket"}
+
+// ApplyExternalProviderDefaults adjusts cfg in-place when one or more
+// external providers are enabled:
+//   - if Scope is unset, promote to "all_installs"
+//   - if Scope is "new_packages_only", emit a validation warning naming
+//     the external provider(s) and recommending "all_installs"
+//
+// Returns a list of human-readable warnings the caller should surface.
+func ApplyExternalProviderDefaults(cfg *PackageChecksConfig) []string {
+	var enabledExternal []string
+	for _, name := range externalProviderNames {
+		p, ok := cfg.Providers[name]
+		if ok && p.Enabled {
+			enabledExternal = append(enabledExternal, name)
+		}
+	}
+	if len(enabledExternal) == 0 {
+		return nil
+	}
+	switch cfg.Scope {
+	case "":
+		cfg.Scope = "all_installs"
+		return nil
+	case "new_packages_only":
+		return []string{
+			fmt.Sprintf(
+				"pkgcheck: %s configured but scope=new_packages_only — bare `npm install` and `npm ci` will not be intercepted, "+
+					"so supply-chain attacks via lockfile installs will not be blocked. Set scope: all_installs for full coverage.",
+				strings.Join(enabledExternal, ", "),
+			),
+		}
+	}
+	return nil
+}

--- a/internal/config/pkgcheck.go
+++ b/internal/config/pkgcheck.go
@@ -365,7 +365,9 @@ func ApplyFailMode(cfg *PackageChecksConfig, mode string) {
 	case "degraded":
 		target = "warn"
 	default:
-		target = "warn"
+		// unknown mode — caller should have validated via validateConfig;
+		// leave config untouched rather than silently mapping to warn.
+		return
 	}
 	for _, name := range externalProviderNames {
 		p, ok := cfg.Providers[name]

--- a/internal/config/pkgcheck.go
+++ b/internal/config/pkgcheck.go
@@ -59,7 +59,12 @@ type ProviderConfig struct {
 
 // ResolverConfig configures a single lock-file resolver.
 type ResolverConfig struct {
-	DryRunCommand string        `yaml:"dry_run_command"`
+	// DryRunCommand is the path to the resolver binary.
+	// For additional args to prepend to the resolver-specific args, use DryRunArgs.
+	DryRunCommand string        `yaml:"dry_run_command" json:"dry_run_command"`
+	// DryRunArgs contains args to prepend to the resolver-specific args.
+	// Each element is a single token (no shell splitting is performed).
+	DryRunArgs    []string      `yaml:"dry_run_args" json:"dry_run_args"`
 	Timeout       time.Duration `yaml:"timeout"`
 }
 

--- a/internal/config/pkgcheck.go
+++ b/internal/config/pkgcheck.go
@@ -10,6 +10,18 @@ type PackageChecksConfig struct {
 	Registries map[string]RegistryTrustConfig `yaml:"registries"`
 	Providers  map[string]ProviderConfig      `yaml:"providers"`
 	Resolvers  map[string]ResolverConfig      `yaml:"resolvers"`
+	Privacy    PackagePrivacyConfig           `yaml:"privacy" json:"privacy"`
+}
+
+// PackagePrivacyConfig configures the upstream privacy filter applied
+// before any external (Snyk / Socket / etc.) provider is invoked.
+type PackagePrivacyConfig struct {
+	// ExternalScanRegistries lists registries whose packages may be sent
+	// to external providers. An empty list means "no registry filter."
+	ExternalScanRegistries []string `yaml:"external_scan_registries" json:"external_scan_registries"`
+	// PrivateScopeDenylist lists package name prefixes / glob patterns
+	// that should NOT be sent externally even when on an allowed registry.
+	PrivateScopeDenylist []string `yaml:"private_scope_denylist" json:"private_scope_denylist"`
 }
 
 // PackageCacheConfig configures the on-disk check result cache.
@@ -115,5 +127,9 @@ func DefaultPackageChecksConfig() PackageChecksConfig {
 			},
 		},
 		Resolvers: nil,
+		Privacy: PackagePrivacyConfig{
+			ExternalScanRegistries: []string{"registry.npmjs.org", "pypi.org"},
+			PrivateScopeDenylist:   nil,
+		},
 	}
 }

--- a/internal/config/pkgcheck.go
+++ b/internal/config/pkgcheck.go
@@ -186,8 +186,17 @@ func DefaultPackageChecksConfig() PackageChecksConfig {
 		},
 		Resolvers: nil,
 		Privacy: PackagePrivacyConfig{
-			ExternalScanRegistries: []string{"registry.npmjs.org", "pypi.org"},
-			PrivateScopeDenylist:   nil,
+			ExternalScanRegistries: []string{
+				"registry.npmjs.org",
+				"pypi.org",
+				// pip's default --index-url; users running `pip install
+				// --index-url https://pypi.org/simple` should still hit
+				// the allowlist. We can't simply strip the path during
+				// normalization because that would conflate distinct
+				// paths on a shared private host.
+				"pypi.org/simple",
+			},
+			PrivateScopeDenylist: nil,
 		},
 	}
 }

--- a/internal/config/pkgcheck_policy_test.go
+++ b/internal/config/pkgcheck_policy_test.go
@@ -74,6 +74,35 @@ func containsRule(rules []policy.PackageRule, want policy.PackageRule) bool {
 	return false
 }
 
+func TestCompileBlockOnRules_NoCatchAll(t *testing.T) {
+	// CompileBlockOnRules must NOT append a catch-all allow rule.
+	// CompileBlockOn (the public wrapper) should still end with one.
+	cfg := BlockOnConfig{
+		Malware:       "any",
+		Vulnerability: "critical",
+	}
+
+	rules := CompileBlockOnRules(cfg)
+	if len(rules) == 0 {
+		t.Fatal("expected at least one rule from CompileBlockOnRules")
+	}
+	last := rules[len(rules)-1]
+	if last.Match.FindingType == "" && last.Action == "allow" {
+		t.Errorf("CompileBlockOnRules must NOT end with a catch-all allow rule; got %+v", last)
+	}
+
+	// CompileBlockOn should still end with a catch-all.
+	allRules := CompileBlockOn(cfg)
+	lastAll := allRules[len(allRules)-1]
+	if lastAll.Match.FindingType != "" || lastAll.Action != "allow" {
+		t.Errorf("CompileBlockOn must still end with a catch-all allow rule; got %+v", lastAll)
+	}
+	// CompileBlockOn should have exactly one more rule than CompileBlockOnRules.
+	if len(allRules) != len(rules)+1 {
+		t.Errorf("CompileBlockOn len=%d, CompileBlockOnRules len=%d; expected exactly 1 more", len(allRules), len(rules))
+	}
+}
+
 func TestBlockOnConfig_ValidateRejectsTypos(t *testing.T) {
 	cfg := BlockOnConfig{Vulnerability: "critcal"}
 	if err := cfg.Validate(); err == nil {

--- a/internal/config/pkgcheck_policy_test.go
+++ b/internal/config/pkgcheck_policy_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+func TestCompileBlockOn_DefaultsAndOverrides(t *testing.T) {
+	rules := CompileBlockOn(BlockOnConfig{
+		Malware:       "any",
+		Vulnerability: "critical",
+		License:       "never",
+		Reputation:    "never",
+		Provenance:    "never",
+	})
+
+	// Expect: malware-any → deny; vuln-critical → deny; vuln-high → warn;
+	// then a catch-all allow at the end.
+	if len(rules) < 4 {
+		t.Fatalf("want >=4 rules, got %d: %+v", len(rules), rules)
+	}
+
+	denyMalware := containsRule(rules, policy.PackageRule{
+		Match: policy.PackageMatch{FindingType: "malware"}, Action: "deny",
+	})
+	denyCritVuln := containsRule(rules, policy.PackageRule{
+		Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "critical"}, Action: "deny",
+	})
+	warnHighVuln := containsRule(rules, policy.PackageRule{
+		Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "high"}, Action: "warn",
+	})
+	if !denyMalware {
+		t.Error("missing malware deny rule")
+	}
+	if !denyCritVuln {
+		t.Error("missing vulnerability/critical deny rule")
+	}
+	if !warnHighVuln {
+		t.Error("missing vulnerability/high warn rule")
+	}
+
+	last := rules[len(rules)-1]
+	if last.Action != "allow" || last.Match.FindingType != "" {
+		t.Errorf("expected catch-all allow as last rule, got %+v", last)
+	}
+}
+
+func TestCompileBlockOn_MalwareCriticalOnly(t *testing.T) {
+	rules := CompileBlockOn(BlockOnConfig{Malware: "critical"})
+	denyCritMalware := containsRule(rules, policy.PackageRule{
+		Match: policy.PackageMatch{FindingType: "malware", Severity: "critical"}, Action: "deny",
+	})
+	denyAnyMalware := containsRule(rules, policy.PackageRule{
+		Match: policy.PackageMatch{FindingType: "malware"}, Action: "deny",
+	})
+	if !denyCritMalware {
+		t.Error("missing malware/critical deny rule")
+	}
+	if denyAnyMalware {
+		t.Error("malware/critical mode must NOT also produce an unconditional malware deny rule")
+	}
+}
+
+// containsRule compares rules ignoring Reason text.
+func containsRule(rules []policy.PackageRule, want policy.PackageRule) bool {
+	for _, r := range rules {
+		if r.Match.FindingType == want.Match.FindingType &&
+			r.Match.Severity == want.Match.Severity &&
+			r.Action == want.Action {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/pkgcheck_policy_test.go
+++ b/internal/config/pkgcheck_policy_test.go
@@ -73,3 +73,24 @@ func containsRule(rules []policy.PackageRule, want policy.PackageRule) bool {
 	}
 	return false
 }
+
+func TestBlockOnConfig_ValidateRejectsTypos(t *testing.T) {
+	cfg := BlockOnConfig{Vulnerability: "critcal"}
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("typo must be rejected")
+	}
+}
+
+func TestBlockOnConfig_ValidateAcceptsAllValidCombinations(t *testing.T) {
+	cases := []BlockOnConfig{
+		{Malware: "any", Vulnerability: "critical", License: "never", Reputation: "never", Provenance: "never"},
+		{Malware: "critical", Vulnerability: "high"},
+		{Malware: "never", Vulnerability: "medium", License: "any"},
+		{}, // all empty is fine
+	}
+	for _, c := range cases {
+		if err := c.Validate(); err != nil {
+			t.Errorf("config %+v: unexpected error %v", c, err)
+		}
+	}
+}

--- a/internal/config/pkgcheck_test.go
+++ b/internal/config/pkgcheck_test.go
@@ -150,6 +150,26 @@ func TestApplyDefaults_PackageChecksPrivacy(t *testing.T) {
 	}
 }
 
+func TestApplyDefaults_BlockOn_PerFieldDefaults(t *testing.T) {
+	cfg := &Config{
+		PackageChecks: PackageChecksConfig{
+			BlockOn: BlockOnConfig{
+				License: "any", // user only set this; others should get defaults
+			},
+		},
+	}
+	applyDefaults(cfg)
+	if cfg.PackageChecks.BlockOn.Malware != "any" {
+		t.Errorf("Malware default missing; got %q", cfg.PackageChecks.BlockOn.Malware)
+	}
+	if cfg.PackageChecks.BlockOn.Vulnerability != "critical" {
+		t.Errorf("Vulnerability default missing; got %q", cfg.PackageChecks.BlockOn.Vulnerability)
+	}
+	if cfg.PackageChecks.BlockOn.License != "any" {
+		t.Errorf("License should be preserved; got %q", cfg.PackageChecks.BlockOn.License)
+	}
+}
+
 func TestResolverConfig_Validate_RejectsLegacyCommandString(t *testing.T) {
 	rc := ResolverConfig{
 		DryRunCommand: "npm install --package-lock-only --ignore-scripts",

--- a/internal/config/pkgcheck_test.go
+++ b/internal/config/pkgcheck_test.go
@@ -218,3 +218,17 @@ package_checks:
 	assert.Equal(t, 12*time.Hour, cfg.PackageChecks.Cache.TTL.License)
 	assert.Equal(t, 15*time.Minute, cfg.PackageChecks.Cache.TTL.Malware)
 }
+
+func TestPackagePrivacyConfig_ValidateRejectsBadGlob(t *testing.T) {
+	cfg := PackagePrivacyConfig{PrivateScopeDenylist: []string{"[unclosed"}}
+	if err := cfg.Validate(); err == nil {
+		t.Error("invalid glob must fail validation")
+	}
+}
+
+func TestPackagePrivacyConfig_ValidateAcceptsGoodPatterns(t *testing.T) {
+	cfg := PackagePrivacyConfig{PrivateScopeDenylist: []string{"@acme", "@internal-*"}}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("expected no error; got %v", err)
+	}
+}

--- a/internal/config/pkgcheck_test.go
+++ b/internal/config/pkgcheck_test.go
@@ -477,3 +477,23 @@ func TestApplyFailMode_UnknownModeIsNoOp(t *testing.T) {
 		t.Errorf("unknown mode must leave OnFailure untouched; got %q", cfg.Providers["socket"].OnFailure)
 	}
 }
+
+func TestApplyFailMode_PreservesExplicitProviderOnFailure(t *testing.T) {
+	// User explicitly sets socket.on_failure: deny but no global fail_mode.
+	// applyDefaults sets FailMode to "degraded" → ApplyFailMode runs with "warn".
+	// The explicit "deny" must survive.
+	cfg := PackageChecksConfig{
+		FailMode: "degraded", // came from defaulting
+		Providers: map[string]ProviderConfig{
+			"socket": {Enabled: true, OnFailure: "deny"}, // explicit user choice
+			"snyk":   {Enabled: true},                    // empty → fills with warn
+		},
+	}
+	ApplyFailMode(&cfg, "degraded")
+	if cfg.Providers["socket"].OnFailure != "deny" {
+		t.Errorf("explicit deny must survive default-degraded fail mode; got %q", cfg.Providers["socket"].OnFailure)
+	}
+	if cfg.Providers["snyk"].OnFailure != "warn" {
+		t.Errorf("empty OnFailure should be filled with degraded→warn; got %q", cfg.Providers["snyk"].OnFailure)
+	}
+}

--- a/internal/config/pkgcheck_test.go
+++ b/internal/config/pkgcheck_test.go
@@ -141,6 +141,14 @@ func TestDefaultPackageChecksConfig_HasPrivacyDefaults(t *testing.T) {
 	}
 }
 
+func TestApplyDefaults_PackageChecksPrivacy(t *testing.T) {
+	cfg := &Config{} // empty — no YAML privacy block
+	applyDefaults(cfg)
+	if len(cfg.PackageChecks.Privacy.ExternalScanRegistries) == 0 {
+		t.Error("default Privacy.ExternalScanRegistries should be set after applyDefaults")
+	}
+}
+
 func TestPackageChecksConfig_InConfig(t *testing.T) {
 	yamlInput := `
 package_checks:

--- a/internal/config/pkgcheck_test.go
+++ b/internal/config/pkgcheck_test.go
@@ -134,6 +134,13 @@ func TestPackageChecksConfig_YAMLRoundTrip(t *testing.T) {
 	assert.Equal(t, 20*time.Second, decoded.Resolvers["pip"].Timeout)
 }
 
+func TestDefaultPackageChecksConfig_HasPrivacyDefaults(t *testing.T) {
+	d := DefaultPackageChecksConfig()
+	if len(d.Privacy.ExternalScanRegistries) == 0 {
+		t.Error("default Privacy.ExternalScanRegistries should be set")
+	}
+}
+
 func TestPackageChecksConfig_InConfig(t *testing.T) {
 	yamlInput := `
 package_checks:

--- a/internal/config/pkgcheck_test.go
+++ b/internal/config/pkgcheck_test.go
@@ -242,3 +242,75 @@ func TestValidateConfig_RejectsBadPrivacyDenylistGlob(t *testing.T) {
 		t.Fatal("invalid denylist glob must be rejected by Privacy.Validate")
 	}
 }
+
+func TestApplyExternalProviderDefaults_PromotesScope(t *testing.T) {
+	cfg := PackageChecksConfig{
+		Enabled: true,
+		Scope:   "", // unset — should be promoted
+		Providers: map[string]ProviderConfig{
+			"socket": {Enabled: true, APIKeyEnv: "SOCKET_API_KEY"},
+		},
+	}
+	warnings := ApplyExternalProviderDefaults(&cfg)
+	if cfg.Scope != "all_installs" {
+		t.Errorf("expected scope to be promoted to all_installs, got %q", cfg.Scope)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("no warnings expected when scope was empty; got %v", warnings)
+	}
+}
+
+func TestApplyExternalProviderDefaults_WarnsOnExplicitNarrowScope(t *testing.T) {
+	cfg := PackageChecksConfig{
+		Enabled: true,
+		Scope:   "new_packages_only",
+		Providers: map[string]ProviderConfig{
+			"snyk": {Enabled: true, APIKeyEnv: "SNYK_TOKEN"},
+		},
+	}
+	warnings := ApplyExternalProviderDefaults(&cfg)
+	if cfg.Scope != "new_packages_only" {
+		t.Errorf("user-set scope should not be overwritten")
+	}
+	if len(warnings) == 0 {
+		t.Fatal("expected validation warning")
+	}
+	if !strings.Contains(warnings[0], "snyk") || !strings.Contains(warnings[0], "all_installs") {
+		t.Errorf("warning should mention provider and recommend all_installs, got %q", warnings[0])
+	}
+}
+
+func TestApplyExternalProviderDefaults_NoExternalProviderNoOp(t *testing.T) {
+	cfg := PackageChecksConfig{
+		Enabled: true,
+		Scope:   "",
+		Providers: map[string]ProviderConfig{
+			"osv": {Enabled: true},
+		},
+	}
+	warnings := ApplyExternalProviderDefaults(&cfg)
+	if cfg.Scope != "" {
+		t.Errorf("scope should remain empty when no external provider is enabled")
+	}
+	if len(warnings) != 0 {
+		t.Errorf("no warnings expected, got %v", warnings)
+	}
+}
+
+func TestApplyExternalProviderDefaults_DisabledExternalNoPromote(t *testing.T) {
+	cfg := PackageChecksConfig{
+		Enabled: true,
+		Scope:   "",
+		Providers: map[string]ProviderConfig{
+			"snyk":   {Enabled: false},
+			"socket": {Enabled: false},
+		},
+	}
+	warnings := ApplyExternalProviderDefaults(&cfg)
+	if cfg.Scope != "" {
+		t.Errorf("disabled external providers should not trigger promotion; got scope=%q", cfg.Scope)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("no warnings expected; got %v", warnings)
+	}
+}

--- a/internal/config/pkgcheck_test.go
+++ b/internal/config/pkgcheck_test.go
@@ -314,3 +314,62 @@ func TestApplyExternalProviderDefaults_DisabledExternalNoPromote(t *testing.T) {
 		t.Errorf("no warnings expected; got %v", warnings)
 	}
 }
+
+func TestResolveFailMode_EnvOverridesYAML(t *testing.T) {
+	cfg := PackageChecksConfig{FailMode: "closed"}
+	t.Setenv("PKGCHECK_FAIL_MODE", "open")
+	got := ResolveFailMode(&cfg)
+	if got != "open" {
+		t.Errorf("env should win, got %q", got)
+	}
+}
+
+func TestResolveFailMode_DefaultsToDegraded(t *testing.T) {
+	cfg := PackageChecksConfig{}
+	t.Setenv("PKGCHECK_FAIL_MODE", "")
+	got := ResolveFailMode(&cfg)
+	if got != "degraded" {
+		t.Errorf("default should be degraded, got %q", got)
+	}
+}
+
+func TestApplyFailMode_SetsOnFailureForExternal(t *testing.T) {
+	cfg := PackageChecksConfig{
+		FailMode: "closed",
+		Providers: map[string]ProviderConfig{
+			"socket": {Enabled: true},
+			"osv":    {Enabled: true, OnFailure: "warn"}, // should be untouched
+		},
+	}
+	ApplyFailMode(&cfg, "closed")
+	if cfg.Providers["socket"].OnFailure != "deny" {
+		t.Errorf("socket OnFailure should be deny, got %q", cfg.Providers["socket"].OnFailure)
+	}
+	if cfg.Providers["osv"].OnFailure != "warn" {
+		t.Errorf("osv OnFailure must remain warn, got %q", cfg.Providers["osv"].OnFailure)
+	}
+}
+
+func TestApplyFailMode_OpenMaps(t *testing.T) {
+	cfg := PackageChecksConfig{
+		Providers: map[string]ProviderConfig{
+			"socket": {Enabled: true},
+		},
+	}
+	ApplyFailMode(&cfg, "open")
+	if cfg.Providers["socket"].OnFailure != "allow" {
+		t.Errorf("open should map to allow; got %q", cfg.Providers["socket"].OnFailure)
+	}
+}
+
+func TestApplyFailMode_DegradedMaps(t *testing.T) {
+	cfg := PackageChecksConfig{
+		Providers: map[string]ProviderConfig{
+			"snyk": {Enabled: true},
+		},
+	}
+	ApplyFailMode(&cfg, "degraded")
+	if cfg.Providers["snyk"].OnFailure != "warn" {
+		t.Errorf("degraded should map to warn; got %q", cfg.Providers["snyk"].OnFailure)
+	}
+}

--- a/internal/config/pkgcheck_test.go
+++ b/internal/config/pkgcheck_test.go
@@ -373,3 +373,87 @@ func TestApplyFailMode_DegradedMaps(t *testing.T) {
 		t.Errorf("degraded should map to warn; got %q", cfg.Providers["snyk"].OnFailure)
 	}
 }
+
+func TestApplyDefaults_PromotesScopeWhenExternalProviderEnabled(t *testing.T) {
+	cfg := &Config{
+		PackageChecks: PackageChecksConfig{
+			Enabled: true,
+			// Scope is intentionally omitted — promotion should set it to all_installs
+			Providers: map[string]ProviderConfig{
+				"socket": {Enabled: true, APIKeyEnv: "SOCKET_API_KEY"},
+			},
+		},
+	}
+	applyDefaults(cfg)
+	if cfg.PackageChecks.Scope != "all_installs" {
+		t.Errorf("expected scope to be promoted to all_installs by applyDefaults; got %q", cfg.PackageChecks.Scope)
+	}
+}
+
+func TestServerStartup_AppliesFailMode(t *testing.T) {
+	t.Setenv("PKGCHECK_FAIL_MODE", "closed")
+	cfg := PackageChecksConfig{
+		Providers: map[string]ProviderConfig{
+			"socket": {Enabled: true, APIKeyEnv: "SOCKET_API_KEY"},
+		},
+	}
+	mode := ResolveFailMode(&cfg)
+	if mode != "closed" {
+		t.Fatalf("ResolveFailMode should honor env var; got %q", mode)
+	}
+	ApplyFailMode(&cfg, mode)
+	if cfg.Providers["socket"].OnFailure != "deny" {
+		t.Errorf("ApplyFailMode should map closed→deny on external providers; got %q", cfg.Providers["socket"].OnFailure)
+	}
+}
+
+func TestValidateConfig_RejectsBadFailMode(t *testing.T) {
+	cfg := &Config{
+		PackageChecks: PackageChecksConfig{
+			FailMode: "boom",
+		},
+	}
+	// Pre-apply defaults so other required fields (e.g. sandbox.fuse.audit.mode)
+	// are populated; the test is only concerned with the fail_mode rejection.
+	applyDefaults(cfg)
+	// Override FailMode after defaults (which would set it to "degraded").
+	cfg.PackageChecks.FailMode = "boom"
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("invalid fail_mode must fail validation")
+	}
+	if !strings.Contains(err.Error(), "fail_mode") || !strings.Contains(err.Error(), "boom") {
+		t.Errorf("error should mention fail_mode and the bad value; got: %v", err)
+	}
+}
+
+func TestValidateConfig_AcceptsValidFailModes(t *testing.T) {
+	for _, mode := range []string{"open", "closed", "degraded"} {
+		cfg := &Config{
+			PackageChecks: PackageChecksConfig{
+				FailMode: mode,
+			},
+		}
+		applyDefaults(cfg)
+		cfg.PackageChecks.FailMode = mode
+		if err := validateConfig(cfg); err != nil {
+			// Only fail if the error is about fail_mode — other fields may be invalid.
+			if strings.Contains(err.Error(), "fail_mode") {
+				t.Errorf("valid fail_mode %q should not be rejected; got: %v", mode, err)
+			}
+		}
+	}
+}
+
+func TestApplyFailMode_UnknownModeIsNoOp(t *testing.T) {
+	cfg := PackageChecksConfig{
+		Providers: map[string]ProviderConfig{
+			"socket": {Enabled: true, OnFailure: "allow"},
+		},
+	}
+	ApplyFailMode(&cfg, "unknown-mode")
+	// OnFailure should be unchanged — not silently mapped to warn.
+	if cfg.Providers["socket"].OnFailure != "allow" {
+		t.Errorf("unknown mode must leave OnFailure untouched; got %q", cfg.Providers["socket"].OnFailure)
+	}
+}

--- a/internal/config/pkgcheck_test.go
+++ b/internal/config/pkgcheck_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -146,6 +147,36 @@ func TestApplyDefaults_PackageChecksPrivacy(t *testing.T) {
 	applyDefaults(cfg)
 	if len(cfg.PackageChecks.Privacy.ExternalScanRegistries) == 0 {
 		t.Error("default Privacy.ExternalScanRegistries should be set after applyDefaults")
+	}
+}
+
+func TestResolverConfig_Validate_RejectsSpaciousCommand(t *testing.T) {
+	rc := ResolverConfig{
+		DryRunCommand: "npm install --package-lock-only --ignore-scripts",
+	}
+	err := rc.Validate()
+	if err == nil {
+		t.Fatal("expected validation error for DryRunCommand with spaces, got nil")
+	}
+	if !strings.Contains(err.Error(), "dry_run_args") {
+		t.Errorf("error should mention dry_run_args; got: %v", err)
+	}
+}
+
+func TestResolverConfig_Validate_AcceptsBinaryOnly(t *testing.T) {
+	rc := ResolverConfig{
+		DryRunCommand: "/usr/local/bin/npm",
+		DryRunArgs:    []string{"install", "--package-lock-only", "--ignore-scripts"},
+	}
+	if err := rc.Validate(); err != nil {
+		t.Errorf("expected no error for binary-only DryRunCommand, got: %v", err)
+	}
+}
+
+func TestResolverConfig_Validate_AcceptsEmpty(t *testing.T) {
+	rc := ResolverConfig{}
+	if err := rc.Validate(); err != nil {
+		t.Errorf("expected no error for empty DryRunCommand, got: %v", err)
 	}
 }
 

--- a/internal/config/pkgcheck_test.go
+++ b/internal/config/pkgcheck_test.go
@@ -497,3 +497,32 @@ func TestApplyFailMode_PreservesExplicitProviderOnFailure(t *testing.T) {
 		t.Errorf("empty OnFailure should be filled with degraded→warn; got %q", cfg.Providers["snyk"].OnFailure)
 	}
 }
+
+func TestPackagePrivacyConfig_ValidateRejectsAllEmptyEntries(t *testing.T) {
+	cfg := PackagePrivacyConfig{ExternalScanRegistries: []string{"", "  "}}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("all-empty entries must be rejected")
+	}
+	if !strings.Contains(err.Error(), "external_scan_registries") {
+		t.Errorf("error should mention external_scan_registries; got %v", err)
+	}
+}
+
+func TestPackagePrivacyConfig_ValidateAcceptsExplicitEmptyList(t *testing.T) {
+	cfg := PackagePrivacyConfig{ExternalScanRegistries: nil} // explicit disable
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("nil/empty list is valid (disables filter); got %v", err)
+	}
+	cfg2 := PackagePrivacyConfig{ExternalScanRegistries: []string{}} // explicit []
+	if err := cfg2.Validate(); err != nil {
+		t.Errorf("explicit [] is valid; got %v", err)
+	}
+}
+
+func TestPackagePrivacyConfig_ValidateAcceptsMixedEntries(t *testing.T) {
+	cfg := PackagePrivacyConfig{ExternalScanRegistries: []string{"registry.npmjs.org", ""}}
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("at least one non-empty entry is valid; got %v", err)
+	}
+}

--- a/internal/config/pkgcheck_test.go
+++ b/internal/config/pkgcheck_test.go
@@ -150,16 +150,29 @@ func TestApplyDefaults_PackageChecksPrivacy(t *testing.T) {
 	}
 }
 
-func TestResolverConfig_Validate_RejectsSpaciousCommand(t *testing.T) {
+func TestResolverConfig_Validate_RejectsLegacyCommandString(t *testing.T) {
 	rc := ResolverConfig{
 		DryRunCommand: "npm install --package-lock-only --ignore-scripts",
 	}
 	err := rc.Validate()
 	if err == nil {
-		t.Fatal("expected validation error for DryRunCommand with spaces, got nil")
+		t.Fatal("expected validation error for legacy multi-token command, got nil")
 	}
 	if !strings.Contains(err.Error(), "dry_run_args") {
 		t.Errorf("error should mention dry_run_args; got: %v", err)
+	}
+}
+
+func TestResolverConfig_Validate_AcceptsPathWithSpaces(t *testing.T) {
+	for _, p := range []string{
+		"/Program Files/nodejs/npm.cmd",
+		"C:\\Program Files\\nodejs\\npm.cmd",
+		"/usr/local/my tool/npm",
+	} {
+		rc := ResolverConfig{DryRunCommand: p}
+		if err := rc.Validate(); err != nil {
+			t.Errorf("path %q must validate cleanly (no flag-shaped tokens); got: %v", p, err)
+		}
 	}
 }
 

--- a/internal/config/pkgcheck_test.go
+++ b/internal/config/pkgcheck_test.go
@@ -232,3 +232,13 @@ func TestPackagePrivacyConfig_ValidateAcceptsGoodPatterns(t *testing.T) {
 		t.Errorf("expected no error; got %v", err)
 	}
 }
+
+func TestValidateConfig_RejectsBadPrivacyDenylistGlob(t *testing.T) {
+	// Use the package-level Validate() directly — exercising validateConfig
+	// requires a fully-formed Config that's harder to set up here.
+	cfg := PackagePrivacyConfig{PrivateScopeDenylist: []string{"[unclosed"}}
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("invalid denylist glob must be rejected by Privacy.Validate")
+	}
+}

--- a/internal/pkgcheck/cache/cache.go
+++ b/internal/pkgcheck/cache/cache.go
@@ -30,11 +30,30 @@ type Config struct {
 	Dir string
 	// MaxSizeMB is the maximum size of the cache file in megabytes (reserved for future use).
 	MaxSizeMB int
-	// DefaultTTL is the default time-to-live for cache entries.
+
+	// CleanTTL is the lifetime of an entry where the provider returned no findings.
+	// When zero, falls back to DefaultTTL (and then to 24h if that is also zero).
+	CleanTTL time.Duration
+	// FoundTTL is the lifetime of an entry with one or more findings.
+	// A zero value means "never expire" (findings for a (name, version) are permanent).
+	FoundTTL time.Duration
+	// NotFoundTTL is the lifetime of an entry where the provider has no data
+	// (e.g., 404 from /test/...). Typically used for private packages.
+	// When zero, falls back to 1h.
+	NotFoundTTL time.Duration
+
+	// DefaultTTL is retained for backwards compatibility with callers that have
+	// not migrated to the explicit per-result-class TTLs above. It is used
+	// when CleanTTL is zero.
 	DefaultTTL time.Duration
-	// TTLByType allows overriding the TTL for specific FindingType values.
+	// TTLByType is retained for backwards compatibility. It is consulted only
+	// for found entries; if a finding type matches and FoundTTL is zero,
+	// the matched value is used instead of "never expire."
 	TTLByType map[string]time.Duration
 }
+
+// neverExpires marks a cache entry as effectively permanent.
+var neverExpires = time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
 
 // entry is a single cached result with an expiry timestamp.
 type entry struct {
@@ -94,44 +113,78 @@ func (c *Cache) Get(key Key) ([]pkgcheck.Finding, bool) {
 }
 
 // Put stores findings under the given key with a TTL derived from the findings.
-// The TTL is the maximum TTLByType value among all finding types in the batch,
-// falling back to DefaultTTL when no finding type matches.
+// Empty findings (clean) use CleanTTL; non-empty findings (found) use FoundTTL
+// (0 = never expire). Falls back to DefaultTTL / TTLByType for backwards
+// compatibility with callers that have not migrated to the new fields.
 func (c *Cache) Put(key Key, findings []pkgcheck.Finding) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	stored := deepCopyFindings(findings)
-
-	ttl := c.computeTTL(findings)
-
-	c.entries[key.String()] = entry{
-		Findings:  stored,
-		ExpiresAt: time.Now().Add(ttl),
-	}
+	expiry := c.computeExpiry(findings)
+	c.entries[key.String()] = entry{Findings: stored, ExpiresAt: expiry}
 }
 
-// computeTTL returns the maximum TTLByType value among all finding types,
-// falling back to DefaultTTL when no match is found.
-func (c *Cache) computeTTL(findings []pkgcheck.Finding) time.Duration {
-	if len(c.cfg.TTLByType) == 0 {
-		return c.cfg.DefaultTTL
-	}
+// PutNotFound stores a "provider has no data on this package" sentinel
+// with the configured NotFoundTTL.
+func (c *Cache) PutNotFound(key Key) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-	maxTTL := time.Duration(0)
-	found := false
-	for _, f := range findings {
-		if ttl, ok := c.cfg.TTLByType[string(f.Type)]; ok {
-			if !found || ttl > maxTTL {
-				maxTTL = ttl
-				found = true
+	ttl := c.cfg.NotFoundTTL
+	if ttl <= 0 {
+		ttl = 1 * time.Hour
+	}
+	c.entries[key.String()] = entry{Findings: nil, ExpiresAt: time.Now().Add(ttl)}
+}
+
+// computeExpiry returns the absolute expiry timestamp for a Put.
+//   - empty findings → CleanTTL (or DefaultTTL fallback, 24h ultimate fallback)
+//   - non-empty       → FoundTTL (0 = neverExpires); falls back to TTLByType match,
+//     then DefaultTTL, then neverExpires
+func (c *Cache) computeExpiry(findings []pkgcheck.Finding) time.Time {
+	now := time.Now()
+	if len(findings) == 0 {
+		ttl := c.cfg.CleanTTL
+		if ttl <= 0 {
+			ttl = c.cfg.DefaultTTL
+		}
+		if ttl <= 0 {
+			ttl = 24 * time.Hour
+		}
+		return now.Add(ttl)
+	}
+	if c.cfg.FoundTTL == 0 {
+		// Found entries persist indefinitely by default.
+		// Honor TTLByType only if explicitly configured.
+		if len(c.cfg.TTLByType) > 0 {
+			best := time.Duration(0)
+			matched := false
+			for _, f := range findings {
+				if t, ok := c.cfg.TTLByType[string(f.Type)]; ok {
+					if !matched || t > best {
+						best = t
+						matched = true
+					}
+				}
+			}
+			if matched {
+				return now.Add(best)
+			}
+			// TTLByType was configured but no type matched: fall back to DefaultTTL.
+			if c.cfg.DefaultTTL > 0 {
+				return now.Add(c.cfg.DefaultTTL)
 			}
 		}
+		// If the caller has not opted into the new CleanTTL/FoundTTL API (i.e., they
+		// only set DefaultTTL), honour DefaultTTL for found entries too so that
+		// existing callers are not broken.
+		if c.cfg.CleanTTL == 0 && c.cfg.DefaultTTL > 0 {
+			return now.Add(c.cfg.DefaultTTL)
+		}
+		return neverExpires
 	}
-
-	if !found {
-		return c.cfg.DefaultTTL
-	}
-	return maxTTL
+	return now.Add(c.cfg.FoundTTL)
 }
 
 // Close flushes all entries to disk.

--- a/internal/pkgcheck/cache/cache_test.go
+++ b/internal/pkgcheck/cache/cache_test.go
@@ -457,3 +457,56 @@ func TestFlushToDisk_FiltersExpired(t *testing.T) {
 func writeFile(path string, data []byte) error {
 	return os.WriteFile(path, data, 0600)
 }
+
+func TestCache_FoundEntriesNeverExpire(t *testing.T) {
+	dir := t.TempDir()
+	c, err := New(Config{Dir: dir, CleanTTL: 1 * time.Hour, FoundTTL: 0 /* never */, NotFoundTTL: 1 * time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := Key{Provider: "snyk", Ecosystem: "npm", Package: "lodash", Version: "4.17.20"}
+	c.Put(key, []pkgcheck.Finding{{Type: pkgcheck.FindingVulnerability}})
+
+	got, ok := c.Get(key)
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(got))
+	}
+}
+
+func TestCache_CleanEntriesExpire(t *testing.T) {
+	dir := t.TempDir()
+	c, err := New(Config{Dir: dir, CleanTTL: 50 * time.Millisecond, FoundTTL: 0, NotFoundTTL: 1 * time.Hour})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := Key{Provider: "socket", Ecosystem: "npm", Package: "lodash", Version: "4.17.21"}
+	c.Put(key, nil) // no findings → clean
+
+	if _, ok := c.Get(key); !ok {
+		t.Fatal("expected fresh hit")
+	}
+	time.Sleep(80 * time.Millisecond)
+	if _, ok := c.Get(key); ok {
+		t.Fatal("expected expiry after CleanTTL")
+	}
+}
+
+func TestCache_PutNotFoundUsesNotFoundTTL(t *testing.T) {
+	dir := t.TempDir()
+	c, err := New(Config{Dir: dir, CleanTTL: 24 * time.Hour, FoundTTL: 0, NotFoundTTL: 50 * time.Millisecond})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := Key{Provider: "snyk", Ecosystem: "npm", Package: "@acme/private", Version: "1.0.0"}
+	c.PutNotFound(key)
+	if _, ok := c.Get(key); !ok {
+		t.Fatal("expected fresh hit")
+	}
+	time.Sleep(80 * time.Millisecond)
+	if _, ok := c.Get(key); ok {
+		t.Fatal("expected expiry after NotFoundTTL")
+	}
+}

--- a/internal/pkgcheck/checker.go
+++ b/internal/pkgcheck/checker.go
@@ -77,7 +77,7 @@ func (c *Checker) Check(ctx context.Context, command string, args []string, work
 	// 4. Run all providers in parallel, applying privacy filtering.
 	findings, providerErrs, skipped := c.orch.CheckAllWithPrivacy(ctx, CheckRequest{
 		Ecosystem: plan.Ecosystem,
-		Packages:  plan.AllPackages(),
+		Packages:  plan.AllPackagesWithRegistry(),
 	})
 
 	// 5. Handle provider errors: collect all, then apply strictest action.

--- a/internal/pkgcheck/checker.go
+++ b/internal/pkgcheck/checker.go
@@ -115,9 +115,10 @@ func (c *Checker) Check(ctx context.Context, command string, args []string, work
 	// Apply strictest failure action.
 	if hasFailAction && strictestFailAction == VerdictBlock {
 		return &Verdict{
-			Action:  VerdictBlock,
-			Summary: strictestFailSummary,
-			Skipped: skipped,
+			Action:   VerdictBlock,
+			Findings: findings, // preserve any findings collected before the block decision
+			Skipped:  skipped,
+			Summary:  strictestFailSummary,
 		}, nil
 	}
 

--- a/internal/pkgcheck/checker.go
+++ b/internal/pkgcheck/checker.go
@@ -122,11 +122,12 @@ func (c *Checker) Check(ctx context.Context, command string, args []string, work
 	}
 
 	// 6. Evaluate findings against policy rules.
-	verdict := c.eval.Evaluate(findings, plan.Ecosystem)
-
-	// Copy privacy-skipped packages onto verdict so callers can see which
-	// packages were not externally scanned.
-	verdict.Skipped = skipped
+	verdict := c.eval.EvaluateWithContext(EvalContext{
+		Findings:       findings,
+		Ecosystem:      plan.Ecosystem,
+		ProviderErrors: providerErrs,
+		Skipped:        skipped,
+	})
 
 	// If any provider needs approval and verdict is weaker, upgrade to approve.
 	if hasFailAction && strictestFailAction == VerdictApprove && verdict.Action.weight() < VerdictApprove.weight() {
@@ -142,7 +143,15 @@ func (c *Checker) Check(ctx context.Context, command string, args []string, work
 	}
 
 	// 8. Enrich summary with package list; append provider failure reason if present.
-	verdict.Summary = buildCheckerSummary(intent, plan, verdict)
+	// Capture any "degraded:" prefix EvaluateWithContext added before
+	// buildCheckerSummary regenerates the summary line.
+	degradedPrefix := ""
+	if strings.HasPrefix(verdict.Summary, "degraded:") {
+		if semi := strings.Index(verdict.Summary, "; "); semi >= 0 {
+			degradedPrefix = verdict.Summary[:semi+2]
+		}
+	}
+	verdict.Summary = degradedPrefix + buildCheckerSummary(intent, plan, verdict)
 	if hasFailAction && strictestFailSummary != "" {
 		verdict.Summary = verdict.Summary + "; " + strictestFailSummary
 	}

--- a/internal/pkgcheck/checker.go
+++ b/internal/pkgcheck/checker.go
@@ -15,6 +15,10 @@ type CheckerConfig struct {
 	Providers map[string]ProviderEntry
 	Rules     []policy.PackageRule
 	Allowlist *Allowlist
+	// Privacy configures which packages are sent to external providers.
+	// An empty PrivacyConfig (the zero value) means no filtering — all
+	// packages are sent. T16 will plumb the YAML field through server.go.
+	Privacy PrivacyConfig
 }
 
 // Checker is the single entry point for package install checks.
@@ -28,10 +32,12 @@ type Checker struct {
 
 // NewChecker creates a new Checker wired to the given config.
 func NewChecker(cfg CheckerConfig) *Checker {
+	pf := NewPrivacyFilter(cfg.Privacy)
 	return &Checker{
 		cfg: cfg,
 		orch: NewOrchestrator(OrchestratorConfig{
-			Providers: cfg.Providers,
+			Providers:     cfg.Providers,
+			PrivacyFilter: pf,
 		}),
 		eval: NewEvaluator(cfg.Rules),
 	}
@@ -68,8 +74,8 @@ func (c *Checker) Check(ctx context.Context, command string, args []string, work
 		return nil, fmt.Errorf("resolve install plan: %w", err)
 	}
 
-	// 4. Run all providers in parallel.
-	findings, providerErrs := c.orch.CheckAll(ctx, CheckRequest{
+	// 4. Run all providers in parallel, applying privacy filtering.
+	findings, providerErrs, skipped := c.orch.CheckAllWithPrivacy(ctx, CheckRequest{
 		Ecosystem: plan.Ecosystem,
 		Packages:  plan.AllPackages(),
 	})
@@ -111,11 +117,16 @@ func (c *Checker) Check(ctx context.Context, command string, args []string, work
 		return &Verdict{
 			Action:  VerdictBlock,
 			Summary: strictestFailSummary,
+			Skipped: skipped,
 		}, nil
 	}
 
 	// 6. Evaluate findings against policy rules.
 	verdict := c.eval.Evaluate(findings, plan.Ecosystem)
+
+	// Copy privacy-skipped packages onto verdict so callers can see which
+	// packages were not externally scanned.
+	verdict.Skipped = skipped
 
 	// If any provider needs approval and verdict is weaker, upgrade to approve.
 	if hasFailAction && strictestFailAction == VerdictApprove && verdict.Action.weight() < VerdictApprove.weight() {

--- a/internal/pkgcheck/checker_test.go
+++ b/internal/pkgcheck/checker_test.go
@@ -337,3 +337,62 @@ func TestChecker_PrivacyFilterSurfacesSkipped(t *testing.T) {
 	assert.Equal(t, "@private/utils", verdict.Skipped[0].Package.Name)
 	assert.Equal(t, SkipReasonPrivateScopeDenylist, verdict.Skipped[0].Reason)
 }
+
+// fakeResolver returns a fixed InstallPlan.
+type fakeResolver struct {
+	plan *InstallPlan
+}
+
+func (f *fakeResolver) Name() string                          { return "fake-resolver" }
+func (f *fakeResolver) CanResolve(_ string, _ []string) bool  { return true }
+func (f *fakeResolver) Resolve(_ context.Context, _ string, _ []string) (*InstallPlan, error) {
+	return f.plan, nil
+}
+
+// TestChecker_RegistryPropagationAllowsPublicPackages proves that packages
+// without an explicit Registry on the PackageRef still pass the privacy filter
+// when the plan's Registry matches the allowlist. Without AllPackagesWithRegistry,
+// the fail-closed rule would skip every package and the provider would never fire.
+func TestChecker_RegistryPropagationAllowsPublicPackages(t *testing.T) {
+	rp := &recordingProvider{name: "fake"}
+
+	resolver := &fakeResolver{
+		plan: &InstallPlan{
+			Tool:      "npm",
+			Ecosystem: EcosystemNPM,
+			Registry:  "registry.npmjs.org", // plan-level registry, NOT on the refs
+			Direct: []PackageRef{
+				{Name: "lodash", Version: "4.17.21", Direct: true}, // no Registry field
+			},
+		},
+	}
+
+	rules := []policy.PackageRule{
+		{Match: policy.PackageMatch{}, Action: "allow"},
+	}
+
+	checker := NewChecker(CheckerConfig{
+		Scope:     "new_packages_only",
+		Resolvers: []Resolver{resolver},
+		Providers: map[string]ProviderEntry{
+			"fake": {Provider: rp, Timeout: 5 * time.Second, OnFailure: "warn"},
+		},
+		Rules:     rules,
+		Allowlist: NewAllowlist(30 * time.Second),
+		Privacy: PrivacyConfig{
+			ExternalScanRegistries: []string{"registry.npmjs.org"},
+		},
+	})
+
+	verdict, err := checker.Check(context.Background(), "npm", []string{"install", "lodash"}, t.TempDir())
+	require.NoError(t, err)
+	require.NotNil(t, verdict)
+
+	// The provider must have received lodash — not skipped due to empty Registry.
+	require.Len(t, rp.last, 1, "provider should receive the package (registry propagated from plan)")
+	assert.Equal(t, "lodash", rp.last[0].Name)
+	assert.Equal(t, "registry.npmjs.org", rp.last[0].Registry, "registry should be populated from plan")
+
+	// No packages should be skipped.
+	assert.Empty(t, verdict.Skipped, "no packages should be skipped for a public-registry install")
+}

--- a/internal/pkgcheck/checker_test.go
+++ b/internal/pkgcheck/checker_test.go
@@ -285,3 +285,55 @@ func TestCheckerProviderFailureApproveUpgrades(t *testing.T) {
 	assert.Equal(t, VerdictApprove, verdict.Action)
 	assert.Contains(t, verdict.Summary, "on_failure=approve")
 }
+
+func TestChecker_PrivacyFilterSurfacesSkipped(t *testing.T) {
+	// A PrivacyFilter that excludes @private/* packages.
+	// The fake provider records what it receives.
+	// Only the public package should reach the provider;
+	// the private one should appear in Verdict.Skipped.
+	rp := &recordingProvider{name: "fake"}
+
+	resolver := &mockResolver{
+		name:       "npm-resolver",
+		canResolve: true,
+		plan: &InstallPlan{
+			Tool:      "npm",
+			Ecosystem: EcosystemNPM,
+			Direct: []PackageRef{
+				{Name: "lodash", Version: "4.17.21", Registry: "registry.npmjs.org", Direct: true},
+				{Name: "@private/utils", Version: "1.0.0", Registry: "registry.npmjs.org", Direct: true},
+			},
+		},
+	}
+
+	rules := []policy.PackageRule{
+		{Match: policy.PackageMatch{}, Action: "allow"},
+	}
+
+	checker := NewChecker(CheckerConfig{
+		Scope:     "new_packages_only",
+		Resolvers: []Resolver{resolver},
+		Providers: map[string]ProviderEntry{
+			"fake": {Provider: rp, Timeout: 5 * time.Second, OnFailure: "warn"},
+		},
+		Rules:     rules,
+		Allowlist: NewAllowlist(30 * time.Second),
+		Privacy: PrivacyConfig{
+			ExternalScanRegistries: []string{"registry.npmjs.org"},
+			PrivateScopeDenylist:   []string{"@private"},
+		},
+	})
+
+	verdict, err := checker.Check(context.Background(), "npm", []string{"install", "lodash", "@private/utils"}, t.TempDir())
+	require.NoError(t, err)
+	require.NotNil(t, verdict)
+
+	// The fake provider should have received only lodash (not @private/utils).
+	require.Len(t, rp.last, 1, "provider should receive only non-skipped packages")
+	assert.Equal(t, "lodash", rp.last[0].Name)
+
+	// The verdict should report the skipped package.
+	require.Len(t, verdict.Skipped, 1, "verdict should report skipped packages")
+	assert.Equal(t, "@private/utils", verdict.Skipped[0].Package.Name)
+	assert.Equal(t, SkipReasonPrivateScopeDenylist, verdict.Skipped[0].Reason)
+}

--- a/internal/pkgcheck/checker_test.go
+++ b/internal/pkgcheck/checker_test.go
@@ -349,6 +349,45 @@ func (f *fakeResolver) Resolve(_ context.Context, _ string, _ []string) (*Instal
 	return f.plan, nil
 }
 
+// TestChecker_WarnProviderErrorProducesDegradedSummary proves that a provider
+// failing with on_failure="warn" causes the verdict summary to start with
+// "degraded:" so callers can distinguish a partial scan from a full clean scan.
+func TestChecker_WarnProviderErrorProducesDegradedSummary(t *testing.T) {
+	resolver := &mockResolver{
+		name:       "npm-resolver",
+		canResolve: true,
+		plan: &InstallPlan{
+			Tool:      "npm",
+			Ecosystem: EcosystemNPM,
+			Direct: []PackageRef{
+				{Name: "lodash", Version: "4.17.21", Direct: true},
+			},
+		},
+	}
+	provider := &mockProvider{
+		name: "flaky-provider",
+		err:  assert.AnError,
+	}
+	rules := []policy.PackageRule{
+		{Match: policy.PackageMatch{}, Action: "allow"},
+	}
+
+	checker := newTestChecker(
+		[]Resolver{resolver},
+		map[string]ProviderEntry{
+			"flaky-provider": {Provider: provider, Timeout: 5 * time.Second, OnFailure: "warn"},
+		},
+		rules,
+	)
+
+	verdict, err := checker.Check(context.Background(), "npm", []string{"install", "lodash"}, t.TempDir())
+	require.NoError(t, err)
+	require.NotNil(t, verdict)
+	assert.Equal(t, VerdictAllow, verdict.Action)
+	// The summary must start with "degraded:" to signal partial scan.
+	assert.True(t, len(verdict.Summary) > 0 && verdict.Summary[:9] == "degraded:", "expected summary to start with 'degraded:', got: %q", verdict.Summary)
+}
+
 // TestChecker_RegistryPropagationAllowsPublicPackages proves that packages
 // without an explicit Registry on the PackageRef still pass the privacy filter
 // when the plan's Registry matches the allowlist. Without AllPackagesWithRegistry,

--- a/internal/pkgcheck/checker_test.go
+++ b/internal/pkgcheck/checker_test.go
@@ -435,3 +435,66 @@ func TestChecker_RegistryPropagationAllowsPublicPackages(t *testing.T) {
 	// No packages should be skipped.
 	assert.Empty(t, verdict.Skipped, "no packages should be skipped for a public-registry install")
 }
+
+// TestCheckerDenyOnFailure_PreservesFindings proves that when a provider fails
+// with on_failure="deny" the partial findings collected from other (successful)
+// providers are attached to the block verdict rather than dropped.
+func TestCheckerDenyOnFailure_PreservesFindings(t *testing.T) {
+	resolver := &mockResolver{
+		name:       "npm-resolver",
+		canResolve: true,
+		plan: &InstallPlan{
+			Tool:      "npm",
+			Ecosystem: EcosystemNPM,
+			Direct: []PackageRef{
+				{Name: "lodash", Version: "4.17.21", Direct: true},
+			},
+		},
+	}
+	// Provider A succeeds and returns a finding.
+	goodProvider := &mockProvider{
+		name:         "good-provider",
+		capabilities: []FindingType{FindingVulnerability},
+		findings: []Finding{
+			{
+				Type:     FindingVulnerability,
+				Provider: "good-provider",
+				Package:  PackageRef{Name: "lodash", Version: "4.17.21"},
+				Severity: SeverityHigh,
+				Title:    "Prototype Pollution",
+			},
+		},
+	}
+	// Provider B fails and its on_failure=deny triggers a block verdict.
+	denyProvider := &mockProvider{
+		name: "deny-provider",
+		err:  assert.AnError,
+	}
+	rules := []policy.PackageRule{
+		{Match: policy.PackageMatch{}, Action: "allow"},
+	}
+
+	checker := newTestChecker(
+		[]Resolver{resolver},
+		map[string]ProviderEntry{
+			"good-provider": {Provider: goodProvider, Timeout: 5 * time.Second, OnFailure: "warn"},
+			"deny-provider": {Provider: denyProvider, Timeout: 5 * time.Second, OnFailure: "deny"},
+		},
+		rules,
+	)
+
+	verdict, err := checker.Check(context.Background(), "npm", []string{"install", "lodash"}, t.TempDir())
+	require.NoError(t, err)
+	require.NotNil(t, verdict)
+	assert.Equal(t, VerdictBlock, verdict.Action)
+	// The finding from the successful provider must be preserved on the block verdict.
+	assert.NotEmpty(t, verdict.Findings, "block verdict must carry findings collected before the deny decision")
+	found := false
+	for _, f := range verdict.Findings {
+		if f.Provider == "good-provider" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "good-provider finding should be present in the block verdict")
+}

--- a/internal/pkgcheck/evaluator.go
+++ b/internal/pkgcheck/evaluator.go
@@ -218,19 +218,13 @@ func mapAction(action string) VerdictAction {
 }
 
 // noFindingsVerdict returns a verdict when there are no findings.
-// It applies the last rule as the default.
+// A clean scan with no findings is always Allow regardless of the rule list
+// shape. Rules match facts; when there are no facts there is nothing to
+// evaluate, so the result is unconditionally Allow.
 func (e *Evaluator) noFindingsVerdict() *Verdict {
-	action := VerdictAllow
-	// Use the last rule's action as default, but only if it's a catch-all
-	// (empty match). This prevents filtered-out Options rules from shifting
-	// the default behavior.
-	if len(e.rules) > 0 {
-		last := e.rules[len(e.rules)-1]
-		action = mapAction(last.Action)
-	}
 	return &Verdict{
-		Action:  action,
-		Summary: fmt.Sprintf("no findings, default action: %s", action),
+		Action:  VerdictAllow,
+		Summary: "no findings",
 	}
 }
 

--- a/internal/pkgcheck/evaluator.go
+++ b/internal/pkgcheck/evaluator.go
@@ -248,3 +248,36 @@ func stringInSlice(s string, slice []string) bool {
 func buildSummary(action VerdictAction, findings []Finding) string {
 	return fmt.Sprintf("%d finding(s), overall action: %s", len(findings), action)
 }
+
+// EvalContext bundles all inputs the evaluator needs to produce a complete Verdict.
+type EvalContext struct {
+	Findings       []Finding
+	Ecosystem      Ecosystem
+	ProviderErrors []ProviderError
+	Skipped        []SkippedPackage
+}
+
+// EvaluateWithContext runs the rule engine and decorates the resulting Verdict
+// with skipped-package info and a "degraded:" summary prefix when one or more
+// providers failed with OnFailure == "warn" (the degraded fail-mode).
+//
+// Errors with OnFailure other than "warn" are not annotated here — the
+// upstream Checker logic surfaces them through other channels (block, approve).
+func (e *Evaluator) EvaluateWithContext(c EvalContext) *Verdict {
+	v := e.Evaluate(c.Findings, c.Ecosystem)
+	if v == nil {
+		v = &Verdict{Action: VerdictAllow}
+	}
+	v.Skipped = append([]SkippedPackage(nil), c.Skipped...)
+
+	var degraded []string
+	for _, perr := range c.ProviderErrors {
+		if perr.OnFailure == "warn" {
+			degraded = append(degraded, perr.Provider)
+		}
+	}
+	if len(degraded) > 0 {
+		v.Summary = "degraded: " + strings.Join(degraded, ",") + " unavailable; " + v.Summary
+	}
+	return v
+}

--- a/internal/pkgcheck/evaluator_test.go
+++ b/internal/pkgcheck/evaluator_test.go
@@ -456,6 +456,18 @@ func TestNewEvaluatorAllRulesFilteredFailsClosed(t *testing.T) {
 	assert.Equal(t, VerdictBlock, verdict.Action, "all rules filtered, fail-closed deny injected")
 }
 
+func TestEvaluator_NoFindings_AlwaysAllowEvenWithDenyLastRule(t *testing.T) {
+	// Last rule is deny — but with no findings the verdict must still be allow.
+	rules := []policy.PackageRule{
+		{Match: policy.PackageMatch{FindingType: "malware"}, Action: "deny"},
+	}
+	ev := NewEvaluator(rules)
+	v := ev.Evaluate(nil, EcosystemNPM)
+	if v.Action != VerdictAllow {
+		t.Errorf("no findings should always Allow; got %s", v.Action)
+	}
+}
+
 func TestEvaluator_EvaluateWithContext_AnnotatesDegraded(t *testing.T) {
 	ev := NewEvaluator([]policy.PackageRule{
 		{Match: policy.PackageMatch{}, Action: "allow"},

--- a/internal/pkgcheck/evaluator_test.go
+++ b/internal/pkgcheck/evaluator_test.go
@@ -1,6 +1,8 @@
 package pkgcheck
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/policy"
@@ -452,4 +454,61 @@ func TestNewEvaluatorAllRulesFilteredFailsClosed(t *testing.T) {
 	verdict := ev.Evaluate(findings, EcosystemNPM)
 	require.NotNil(t, verdict)
 	assert.Equal(t, VerdictBlock, verdict.Action, "all rules filtered, fail-closed deny injected")
+}
+
+func TestEvaluator_EvaluateWithContext_AnnotatesDegraded(t *testing.T) {
+	ev := NewEvaluator([]policy.PackageRule{
+		{Match: policy.PackageMatch{}, Action: "allow"},
+	})
+	v := ev.EvaluateWithContext(EvalContext{
+		Findings:  nil,
+		Ecosystem: EcosystemNPM,
+		ProviderErrors: []ProviderError{
+			{Provider: "socket", Err: errors.New("timeout"), OnFailure: "warn"},
+		},
+		Skipped: []SkippedPackage{
+			{Package: PackageRef{Name: "@acme/x"}, Reason: SkipReasonPrivateScopeDenylist},
+		},
+	})
+	if !strings.HasPrefix(v.Summary, "degraded:") {
+		t.Errorf("want summary prefixed degraded:, got %q", v.Summary)
+	}
+	if len(v.Skipped) != 1 {
+		t.Errorf("want 1 skipped, got %d", len(v.Skipped))
+	}
+}
+
+func TestEvaluator_EvaluateWithContext_NoErrorsNoDegradedPrefix(t *testing.T) {
+	ev := NewEvaluator([]policy.PackageRule{
+		{Match: policy.PackageMatch{}, Action: "allow"},
+	})
+	v := ev.EvaluateWithContext(EvalContext{
+		Findings:  nil,
+		Ecosystem: EcosystemNPM,
+		Skipped:   []SkippedPackage{{Package: PackageRef{Name: "x"}, Reason: SkipReasonPrivateRegistry}},
+	})
+	if strings.HasPrefix(v.Summary, "degraded:") {
+		t.Errorf("no errors should not produce degraded prefix; got %q", v.Summary)
+	}
+	if len(v.Skipped) != 1 {
+		t.Errorf("want 1 skipped, got %d", len(v.Skipped))
+	}
+}
+
+func TestEvaluator_EvaluateWithContext_NonWarnErrorsDoNotAnnotate(t *testing.T) {
+	ev := NewEvaluator([]policy.PackageRule{
+		{Match: policy.PackageMatch{}, Action: "allow"},
+	})
+	// OnFailure: "deny" — caller has chosen fail-closed; the verdict is
+	// already going to surface that error elsewhere. Don't double-annotate.
+	v := ev.EvaluateWithContext(EvalContext{
+		Findings:  nil,
+		Ecosystem: EcosystemNPM,
+		ProviderErrors: []ProviderError{
+			{Provider: "socket", Err: errors.New("boom"), OnFailure: "deny"},
+		},
+	})
+	if strings.HasPrefix(v.Summary, "degraded:") {
+		t.Errorf("non-warn error should not prefix degraded:; got %q", v.Summary)
+	}
 }

--- a/internal/pkgcheck/integration_socket_degraded_test.go
+++ b/internal/pkgcheck/integration_socket_degraded_test.go
@@ -1,0 +1,87 @@
+package pkgcheck_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/pkgcheck"
+	"github.com/agentsh/agentsh/internal/pkgcheck/provider"
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+func TestIntegration_SocketDownDegradesToOSV(t *testing.T) {
+	// Socket: returns 500 every call.
+	socketSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer socketSrv.Close()
+
+	// OSV: returns one critical vuln for lodash.
+	osvSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"results":[{"vulns":[{"id":"GHSA-xxxx","summary":"sample","severity":[{"type":"CVSS_V3","score":"9.8"}]}]}]}`))
+	}))
+	defer osvSrv.Close()
+
+	pf := pkgcheck.NewPrivacyFilter(pkgcheck.PrivacyConfig{
+		ExternalScanRegistries: []string{"registry.npmjs.org"},
+		PrivateScopeDenylist:   []string{"@acme"},
+	})
+
+	o := pkgcheck.NewOrchestrator(pkgcheck.OrchestratorConfig{
+		PrivacyFilter: pf,
+		Providers: map[string]pkgcheck.ProviderEntry{
+			"socket": {
+				Provider:  provider.NewSocketProvider(provider.SocketConfig{BaseURL: socketSrv.URL, APIKey: "tk", Timeout: time.Second}),
+				Timeout:   time.Second,
+				OnFailure: "warn", // fail_mode: degraded
+			},
+			"osv": {
+				Provider:  provider.NewOSVProvider(provider.OSVConfig{BaseURL: osvSrv.URL, Timeout: time.Second}),
+				Timeout:   time.Second,
+				OnFailure: "warn",
+			},
+		},
+	})
+
+	req := pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages: []pkgcheck.PackageRef{
+			{Name: "lodash", Version: "4.17.20", Registry: "registry.npmjs.org"},
+			{Name: "@acme/internal", Version: "1.0.0", Registry: "registry.npmjs.org"},
+		},
+	}
+
+	findings, errs, skipped := o.CheckAllWithPrivacy(context.Background(), req)
+
+	if len(skipped) != 1 {
+		t.Errorf("want 1 skipped (@acme), got %d", len(skipped))
+	}
+	if skipped[0].Reason != pkgcheck.SkipReasonPrivateScopeDenylist {
+		t.Errorf("want denylist reason, got %s", skipped[0].Reason)
+	}
+
+	ev := pkgcheck.NewEvaluator([]policy.PackageRule{
+		{Match: policy.PackageMatch{FindingType: "vulnerability", Severity: "critical"}, Action: "deny"},
+		{Match: policy.PackageMatch{}, Action: "allow"},
+	})
+	verdict := ev.EvaluateWithContext(pkgcheck.EvalContext{
+		Findings:       findings,
+		Ecosystem:      req.Ecosystem,
+		ProviderErrors: errs,
+		Skipped:        skipped,
+	})
+
+	if !strings.Contains(verdict.Summary, "degraded:") || !strings.Contains(verdict.Summary, "socket") {
+		t.Errorf("verdict summary should be annotated degraded for socket, got %q", verdict.Summary)
+	}
+	if verdict.Action != pkgcheck.VerdictBlock {
+		t.Errorf("OSV finding (critical) should drive verdict to block, got %s", verdict.Action)
+	}
+	if len(verdict.Skipped) != 1 {
+		t.Errorf("verdict should carry 1 skipped, got %d", len(verdict.Skipped))
+	}
+}

--- a/internal/pkgcheck/integration_socket_degraded_test.go
+++ b/internal/pkgcheck/integration_socket_degraded_test.go
@@ -115,7 +115,7 @@ func TestIntegration_SocketDownDegradesToOSV(t *testing.T) {
 	}
 	for i, body := range osvBodies {
 		s := string(body)
-		if strings.Contains(s, "@acme") || strings.Contains(s, "internal-tool") {
+		if strings.Contains(s, "@acme") || strings.Contains(s, "/internal") {
 			t.Errorf("osv request %d leaked @acme/internal: %s", i, s)
 		}
 	}

--- a/internal/pkgcheck/integration_socket_degraded_test.go
+++ b/internal/pkgcheck/integration_socket_degraded_test.go
@@ -58,7 +58,7 @@ func TestIntegration_SocketDownDegradesToOSV(t *testing.T) {
 	findings, errs, skipped := o.CheckAllWithPrivacy(context.Background(), req)
 
 	if len(skipped) != 1 {
-		t.Errorf("want 1 skipped (@acme), got %d", len(skipped))
+		t.Fatalf("want 1 skipped (@acme), got %d", len(skipped))
 	}
 	if skipped[0].Reason != pkgcheck.SkipReasonPrivateScopeDenylist {
 		t.Errorf("want denylist reason, got %s", skipped[0].Reason)

--- a/internal/pkgcheck/integration_socket_degraded_test.go
+++ b/internal/pkgcheck/integration_socket_degraded_test.go
@@ -2,9 +2,11 @@ package pkgcheck_test
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,14 +16,30 @@ import (
 )
 
 func TestIntegration_SocketDownDegradesToOSV(t *testing.T) {
-	// Socket: returns 500 every call.
+	// Capture request bodies so we can assert the privacy filter actually
+	// stripped @acme/internal before the providers were called.
+	var (
+		socketBodies [][]byte
+		osvBodies    [][]byte
+		bodyMu       sync.Mutex
+	)
+	captureBody := func(target *[][]byte, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		bodyMu.Lock()
+		*target = append(*target, body)
+		bodyMu.Unlock()
+	}
+
+	// Socket: returns 500 every call (after capturing the body).
 	socketSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captureBody(&socketBodies, r)
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer socketSrv.Close()
 
 	// OSV: returns one critical vuln for lodash.
 	osvSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captureBody(&osvBodies, r)
 		_, _ = w.Write([]byte(`{"results":[{"vulns":[{"id":"GHSA-xxxx","summary":"sample","severity":[{"type":"CVSS_V3","score":"9.8"}]}]}]}`))
 	}))
 	defer osvSrv.Close()
@@ -83,5 +101,22 @@ func TestIntegration_SocketDownDegradesToOSV(t *testing.T) {
 	}
 	if len(verdict.Skipped) != 1 {
 		t.Errorf("verdict should carry 1 skipped, got %d", len(verdict.Skipped))
+	}
+
+	// Privacy contract: @acme/internal must NOT appear in any external
+	// provider's request payload. lodash should appear in both.
+	bodyMu.Lock()
+	defer bodyMu.Unlock()
+	for i, body := range socketBodies {
+		s := string(body)
+		if strings.Contains(s, "@acme") || strings.Contains(s, "internal") {
+			t.Errorf("socket request %d leaked @acme/internal: %s", i, s)
+		}
+	}
+	for i, body := range osvBodies {
+		s := string(body)
+		if strings.Contains(s, "@acme") || strings.Contains(s, "internal-tool") {
+			t.Errorf("osv request %d leaked @acme/internal: %s", i, s)
+		}
 	}
 }

--- a/internal/pkgcheck/orchestrator.go
+++ b/internal/pkgcheck/orchestrator.go
@@ -160,6 +160,14 @@ func (o *Orchestrator) CheckAllWithPrivacy(ctx context.Context, req CheckRequest
 	}
 
 	for name, entry := range o.cfg.Providers {
+		// When the privacy filter has skipped every package, external
+		// providers have nothing to do — calling them would fire empty
+		// HTTP requests at remote APIs. Skip them. Local providers still
+		// run on the full original list (license/metadata checks remain
+		// useful for private packages).
+		if len(req.Packages) == 0 && !isLocalProvider(entry.Provider) {
+			continue
+		}
 		wg.Add(1)
 		go func(name string, entry ProviderEntry) {
 			defer wg.Done()

--- a/internal/pkgcheck/orchestrator.go
+++ b/internal/pkgcheck/orchestrator.go
@@ -94,6 +94,13 @@ func (o *Orchestrator) CheckAll(ctx context.Context, req CheckRequest) ([]Findin
 			mu.Lock()
 			defer mu.Unlock()
 
+			// Always merge findings if a response was returned, even on error:
+			// partial-success providers (e.g. Snyk fan-out with some packages
+			// failing) return (resp, err) where resp.Findings holds the
+			// findings for the packages that did succeed.
+			if resp != nil && len(resp.Findings) > 0 {
+				findings = append(findings, resp.Findings...)
+			}
 			if err != nil {
 				errs = append(errs, ProviderError{
 					Provider:  name,
@@ -101,10 +108,6 @@ func (o *Orchestrator) CheckAll(ctx context.Context, req CheckRequest) ([]Findin
 					OnFailure: entry.OnFailure,
 				})
 				return
-			}
-
-			if resp != nil && len(resp.Findings) > 0 {
-				findings = append(findings, resp.Findings...)
 			}
 		}(name, entry)
 	}
@@ -202,6 +205,11 @@ func (o *Orchestrator) CheckAllWithPrivacy(ctx context.Context, req CheckRequest
 			mu.Lock()
 			defer mu.Unlock()
 
+			// Merge findings even on error so partial-success providers
+			// don't lose the packages that did get scanned.
+			if resp != nil && len(resp.Findings) > 0 {
+				findings = append(findings, resp.Findings...)
+			}
 			if err != nil {
 				errs = append(errs, ProviderError{
 					Provider:  name,
@@ -209,10 +217,6 @@ func (o *Orchestrator) CheckAllWithPrivacy(ctx context.Context, req CheckRequest
 					OnFailure: entry.OnFailure,
 				})
 				return
-			}
-
-			if resp != nil && len(resp.Findings) > 0 {
-				findings = append(findings, resp.Findings...)
 			}
 		}(name, entry)
 	}

--- a/internal/pkgcheck/orchestrator.go
+++ b/internal/pkgcheck/orchestrator.go
@@ -113,23 +113,102 @@ func (o *Orchestrator) CheckAll(ctx context.Context, req CheckRequest) ([]Findin
 	return findings, errs
 }
 
+// isLocalProvider reports whether a CheckProvider implements the optional
+// LocalProvider interface and returns true from IsLocal().
+func isLocalProvider(p CheckProvider) bool {
+	lp, ok := p.(LocalProvider)
+	return ok && lp.IsLocal()
+}
+
 // CheckAllWithPrivacy applies the configured PrivacyFilter (if any) before
 // dispatching the request to all providers. Returns merged findings, provider
 // errors, and the list of packages that were not externally scanned.
 //
-// If the filter leaves no packages eligible for external scanning, providers
-// are not invoked at all — this avoids spurious API-key / transport errors
-// from a fan-out over an empty list when every input package was skipped.
+// Local providers (those implementing LocalProvider and returning true from
+// IsLocal) bypass the privacy filter — they run in-process with no network
+// calls, so private packages should still receive license/metadata checks.
+//
+// External providers see only the filtered (scan) list. If the filter leaves
+// no packages eligible for external scanning and there are no local providers,
+// external providers are not invoked at all to avoid spurious API-key /
+// transport errors from a fan-out over an empty list.
 func (o *Orchestrator) CheckAllWithPrivacy(ctx context.Context, req CheckRequest) ([]Finding, []ProviderError, []SkippedPackage) {
+	fullPackages := req.Packages
 	var skipped []SkippedPackage
 	if o.cfg.PrivacyFilter != nil {
 		scan, skip := o.cfg.PrivacyFilter.Partition(req.Packages)
 		req.Packages = scan
 		skipped = skip
 	}
-	if len(req.Packages) == 0 {
+
+	var (
+		mu       sync.Mutex
+		wg       sync.WaitGroup
+		findings []Finding
+		errs     []ProviderError
+	)
+
+	hasWork := len(req.Packages) > 0
+	for _, entry := range o.cfg.Providers {
+		if isLocalProvider(entry.Provider) {
+			hasWork = true
+			break
+		}
+	}
+	if !hasWork {
 		return nil, nil, skipped
 	}
-	findings, errs := o.CheckAll(ctx, req)
+
+	for name, entry := range o.cfg.Providers {
+		wg.Add(1)
+		go func(name string, entry ProviderEntry) {
+			defer wg.Done()
+
+			if entry.Provider == nil {
+				mu.Lock()
+				errs = append(errs, ProviderError{
+					Provider:  name,
+					Err:       fmt.Errorf("provider is nil"),
+					OnFailure: entry.OnFailure,
+				})
+				mu.Unlock()
+				return
+			}
+
+			providerCtx := ctx
+			if entry.Timeout > 0 {
+				var cancel context.CancelFunc
+				providerCtx, cancel = context.WithTimeout(ctx, entry.Timeout)
+				defer cancel()
+			}
+
+			// Local providers see the full (unfiltered) package list so that
+			// private packages still receive license/metadata checks.
+			providerReq := req
+			if isLocalProvider(entry.Provider) {
+				providerReq.Packages = fullPackages
+			}
+
+			resp, err := entry.Provider.CheckBatch(providerCtx, providerReq)
+
+			mu.Lock()
+			defer mu.Unlock()
+
+			if err != nil {
+				errs = append(errs, ProviderError{
+					Provider:  name,
+					Err:       err,
+					OnFailure: entry.OnFailure,
+				})
+				return
+			}
+
+			if resp != nil && len(resp.Findings) > 0 {
+				findings = append(findings, resp.Findings...)
+			}
+		}(name, entry)
+	}
+
+	wg.Wait()
 	return findings, errs, skipped
 }

--- a/internal/pkgcheck/orchestrator.go
+++ b/internal/pkgcheck/orchestrator.go
@@ -28,7 +28,8 @@ func (e ProviderError) Error() string {
 
 // OrchestratorConfig holds configuration for the check orchestrator.
 type OrchestratorConfig struct {
-	Providers map[string]ProviderEntry
+	Providers     map[string]ProviderEntry
+	PrivacyFilter *PrivacyFilter // optional; nil means no filtering
 }
 
 // Orchestrator fans out check requests to all enabled providers in parallel,
@@ -44,7 +45,10 @@ func NewOrchestrator(cfg OrchestratorConfig) *Orchestrator {
 	for k, v := range cfg.Providers {
 		providers[k] = v
 	}
-	return &Orchestrator{cfg: OrchestratorConfig{Providers: providers}}
+	return &Orchestrator{cfg: OrchestratorConfig{
+		Providers:     providers,
+		PrivacyFilter: cfg.PrivacyFilter,
+	}}
 }
 
 // CheckAll dispatches the request to all configured providers in parallel and
@@ -107,4 +111,18 @@ func (o *Orchestrator) CheckAll(ctx context.Context, req CheckRequest) ([]Findin
 
 	wg.Wait()
 	return findings, errs
+}
+
+// CheckAllWithPrivacy applies the configured PrivacyFilter (if any) before
+// dispatching the request to all providers. Returns merged findings, provider
+// errors, and the list of packages that were not externally scanned.
+func (o *Orchestrator) CheckAllWithPrivacy(ctx context.Context, req CheckRequest) ([]Finding, []ProviderError, []SkippedPackage) {
+	var skipped []SkippedPackage
+	if o.cfg.PrivacyFilter != nil {
+		scan, skip := o.cfg.PrivacyFilter.Partition(req.Packages)
+		req.Packages = scan
+		skipped = skip
+	}
+	findings, errs := o.CheckAll(ctx, req)
+	return findings, errs, skipped
 }

--- a/internal/pkgcheck/orchestrator.go
+++ b/internal/pkgcheck/orchestrator.go
@@ -116,12 +116,19 @@ func (o *Orchestrator) CheckAll(ctx context.Context, req CheckRequest) ([]Findin
 // CheckAllWithPrivacy applies the configured PrivacyFilter (if any) before
 // dispatching the request to all providers. Returns merged findings, provider
 // errors, and the list of packages that were not externally scanned.
+//
+// If the filter leaves no packages eligible for external scanning, providers
+// are not invoked at all — this avoids spurious API-key / transport errors
+// from a fan-out over an empty list when every input package was skipped.
 func (o *Orchestrator) CheckAllWithPrivacy(ctx context.Context, req CheckRequest) ([]Finding, []ProviderError, []SkippedPackage) {
 	var skipped []SkippedPackage
 	if o.cfg.PrivacyFilter != nil {
 		scan, skip := o.cfg.PrivacyFilter.Partition(req.Packages)
 		req.Packages = scan
 		skipped = skip
+	}
+	if len(req.Packages) == 0 {
+		return nil, nil, skipped
 	}
 	findings, errs := o.CheckAll(ctx, req)
 	return findings, errs, skipped

--- a/internal/pkgcheck/orchestrator_privacy_test.go
+++ b/internal/pkgcheck/orchestrator_privacy_test.go
@@ -99,3 +99,96 @@ func TestOrchestrator_AllSkippedDoesNotInvokeProviders(t *testing.T) {
 	}
 	_ = calls
 }
+
+// localRecordingProvider is a CheckProvider that also implements LocalProvider.
+type localRecordingProvider struct {
+	recordingProvider
+}
+
+func (p *localRecordingProvider) IsLocal() bool { return true }
+
+// TestOrchestrator_LocalProviderBypassesPrivacyFilter verifies that a local
+// provider receives the full package list even when all packages are filtered
+// by the privacy filter, while external providers only see the filtered list.
+func TestOrchestrator_LocalProviderBypassesPrivacyFilter(t *testing.T) {
+	external := &recordingProvider{name: "external"}
+	local := &localRecordingProvider{recordingProvider: recordingProvider{name: "local"}}
+
+	o := NewOrchestrator(OrchestratorConfig{
+		Providers: map[string]ProviderEntry{
+			"external": {Provider: external, Timeout: time.Second, OnFailure: "warn"},
+			"local":    {Provider: local, Timeout: time.Second, OnFailure: "warn"},
+		},
+		PrivacyFilter: NewPrivacyFilter(PrivacyConfig{
+			ExternalScanRegistries: []string{"registry.npmjs.org"},
+			PrivateScopeDenylist:   []string{"@acme"},
+		}),
+	})
+
+	req := CheckRequest{
+		Ecosystem: EcosystemNPM,
+		Packages: []PackageRef{
+			{Name: "lodash", Version: "4.17.21", Registry: "registry.npmjs.org"},
+			{Name: "@acme/x", Version: "1.0.0", Registry: "registry.npmjs.org"},
+			{Name: "internal", Version: "0.1.0", Registry: "artifactory.acme.local"},
+		},
+	}
+
+	_, _, skipped := o.CheckAllWithPrivacy(context.Background(), req)
+
+	// Privacy filter should have skipped @acme/x (scope) and internal (private registry).
+	if len(skipped) != 2 {
+		t.Fatalf("want 2 skipped, got %d: %+v", len(skipped), skipped)
+	}
+
+	// External provider sees only lodash (public, unscoped).
+	if len(external.last) != 1 || external.last[0].Name != "lodash" {
+		t.Errorf("external provider should see only lodash, got %+v", external.last)
+	}
+
+	// Local provider sees all three packages (bypasses privacy filter).
+	if len(local.last) != 3 {
+		t.Errorf("local provider should see all 3 packages, got %d: %+v", len(local.last), local.last)
+	}
+}
+
+// TestOrchestrator_AllSkippedLocalProviderStillInvoked verifies that when every
+// package is filtered by the privacy filter, a local provider is still invoked
+// with the full list (external providers are not).
+func TestOrchestrator_AllSkippedLocalProviderStillInvoked(t *testing.T) {
+	external := &recordingProvider{name: "external"}
+	local := &localRecordingProvider{recordingProvider: recordingProvider{name: "local"}}
+
+	o := NewOrchestrator(OrchestratorConfig{
+		Providers: map[string]ProviderEntry{
+			"external": {Provider: external, Timeout: time.Second, OnFailure: "warn"},
+			"local":    {Provider: local, Timeout: time.Second, OnFailure: "warn"},
+		},
+		PrivacyFilter: NewPrivacyFilter(PrivacyConfig{
+			ExternalScanRegistries: []string{"registry.npmjs.org"},
+			PrivateScopeDenylist:   []string{"@acme"},
+		}),
+	})
+
+	req := CheckRequest{
+		Ecosystem: EcosystemNPM,
+		Packages: []PackageRef{
+			{Name: "@acme/x", Version: "1.0.0", Registry: "registry.npmjs.org"},
+			{Name: "internal", Version: "0.1.0", Registry: "artifactory.acme.local"},
+		},
+	}
+
+	_, _, skipped := o.CheckAllWithPrivacy(context.Background(), req)
+
+	if len(skipped) != 2 {
+		t.Fatalf("want 2 skipped, got %d", len(skipped))
+	}
+	// External provider must not have been called.
+	if external.last != nil {
+		t.Errorf("external provider must not be invoked when scan list is empty; got %+v", external.last)
+	}
+	// Local provider must still have been called with both packages.
+	if len(local.last) != 2 {
+		t.Errorf("local provider should see both packages, got %d: %+v", len(local.last), local.last)
+	}
+}

--- a/internal/pkgcheck/orchestrator_privacy_test.go
+++ b/internal/pkgcheck/orchestrator_privacy_test.go
@@ -62,3 +62,40 @@ func TestOrchestrator_CheckAllStillWorksWithoutPrivacyFilter(t *testing.T) {
 		t.Fatalf("backward-compat CheckAll should pass packages through unchanged")
 	}
 }
+
+func TestOrchestrator_AllSkippedDoesNotInvokeProviders(t *testing.T) {
+	rp := &recordingProvider{name: "fake"}
+	calls := 0
+	rp2 := &recordingProvider{name: "fake-with-counter"}
+	_ = rp2 // unused but kept for symmetry; recordingProvider records calls already
+	o := NewOrchestrator(OrchestratorConfig{
+		Providers: map[string]ProviderEntry{
+			"fake": {Provider: rp, Timeout: time.Second, OnFailure: "warn"},
+		},
+		PrivacyFilter: NewPrivacyFilter(PrivacyConfig{
+			ExternalScanRegistries: []string{"registry.npmjs.org"},
+			PrivateScopeDenylist:   []string{"@acme"},
+		}),
+	})
+	req := CheckRequest{
+		Ecosystem: EcosystemNPM,
+		Packages: []PackageRef{
+			{Name: "@acme/x", Version: "1", Registry: "registry.npmjs.org"},
+			{Name: "internal", Version: "0.1", Registry: "artifactory.acme.local"},
+		},
+	}
+	findings, errs, skipped := o.CheckAllWithPrivacy(context.Background(), req)
+	if findings != nil {
+		t.Errorf("findings should be nil when all packages skipped, got %+v", findings)
+	}
+	if errs != nil {
+		t.Errorf("errs should be nil when no provider was invoked, got %+v", errs)
+	}
+	if len(skipped) != 2 {
+		t.Errorf("want 2 skipped, got %d", len(skipped))
+	}
+	if rp.last != nil {
+		t.Errorf("provider must not be invoked when all packages skipped; got last=%+v", rp.last)
+	}
+	_ = calls
+}

--- a/internal/pkgcheck/orchestrator_privacy_test.go
+++ b/internal/pkgcheck/orchestrator_privacy_test.go
@@ -1,0 +1,64 @@
+package pkgcheck
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+type recordingProvider struct {
+	name string
+	last []PackageRef
+}
+
+func (r *recordingProvider) Name() string                { return r.name }
+func (r *recordingProvider) Capabilities() []FindingType  { return nil }
+func (r *recordingProvider) CheckBatch(ctx context.Context, req CheckRequest) (*CheckResponse, error) {
+	r.last = append([]PackageRef(nil), req.Packages...)
+	return &CheckResponse{Provider: r.name}, nil
+}
+
+func TestOrchestrator_PrivacyFiltersBeforeProviders(t *testing.T) {
+	rp := &recordingProvider{name: "fake"}
+	o := NewOrchestrator(OrchestratorConfig{
+		Providers: map[string]ProviderEntry{
+			"fake": {Provider: rp, Timeout: time.Second, OnFailure: "warn"},
+		},
+		PrivacyFilter: NewPrivacyFilter(PrivacyConfig{
+			ExternalScanRegistries: []string{"registry.npmjs.org"},
+			PrivateScopeDenylist:   []string{"@acme"},
+		}),
+	})
+	req := CheckRequest{
+		Ecosystem: EcosystemNPM,
+		Packages: []PackageRef{
+			{Name: "lodash", Version: "4.17.21", Registry: "registry.npmjs.org"},
+			{Name: "@acme/x", Version: "1", Registry: "registry.npmjs.org"},
+			{Name: "internal", Version: "0.1", Registry: "artifactory.acme.local"},
+		},
+	}
+	_, _, skipped := o.CheckAllWithPrivacy(context.Background(), req)
+	if len(skipped) != 2 {
+		t.Fatalf("want 2 skipped, got %d", len(skipped))
+	}
+	if len(rp.last) != 1 || rp.last[0].Name != "lodash" {
+		t.Fatalf("provider should have received lodash only, got %+v", rp.last)
+	}
+}
+
+func TestOrchestrator_CheckAllStillWorksWithoutPrivacyFilter(t *testing.T) {
+	rp := &recordingProvider{name: "fake"}
+	o := NewOrchestrator(OrchestratorConfig{
+		Providers: map[string]ProviderEntry{
+			"fake": {Provider: rp, Timeout: time.Second, OnFailure: "warn"},
+		},
+	})
+	req := CheckRequest{
+		Ecosystem: EcosystemNPM,
+		Packages:  []PackageRef{{Name: "lodash", Version: "4.17.21"}},
+	}
+	_, _ = o.CheckAll(context.Background(), req)
+	if len(rp.last) != 1 {
+		t.Fatalf("backward-compat CheckAll should pass packages through unchanged")
+	}
+}

--- a/internal/pkgcheck/orchestrator_privacy_test.go
+++ b/internal/pkgcheck/orchestrator_privacy_test.go
@@ -192,3 +192,33 @@ func TestOrchestrator_AllSkippedLocalProviderStillInvoked(t *testing.T) {
 		t.Errorf("local provider should see both packages, got %d: %+v", len(local.last), local.last)
 	}
 }
+
+func TestOrchestrator_AllSkippedSkipsExternalEvenWithLocalProvider(t *testing.T) {
+	external := &recordingProvider{name: "fake-external"}
+	local := &localRecordingProvider{recordingProvider: recordingProvider{name: "fake-local"}}
+	o := NewOrchestrator(OrchestratorConfig{
+		Providers: map[string]ProviderEntry{
+			"external": {Provider: external, Timeout: time.Second, OnFailure: "warn"},
+			"local":    {Provider: local, Timeout: time.Second, OnFailure: "warn"},
+		},
+		PrivacyFilter: NewPrivacyFilter(PrivacyConfig{
+			ExternalScanRegistries: []string{"registry.npmjs.org"},
+		}),
+	})
+	req := CheckRequest{
+		Ecosystem: EcosystemNPM,
+		Packages: []PackageRef{
+			{Name: "internal", Version: "0.1", Registry: "artifactory.acme.local"},
+		},
+	}
+	_, _, skipped := o.CheckAllWithPrivacy(context.Background(), req)
+	if len(skipped) != 1 {
+		t.Fatalf("want 1 skipped, got %d", len(skipped))
+	}
+	if external.last != nil {
+		t.Errorf("external must not be invoked when scan list is empty, even with local present; got last=%+v", external.last)
+	}
+	if len(local.last) != 1 {
+		t.Errorf("local should still see the full list; got last=%+v", local.last)
+	}
+}

--- a/internal/pkgcheck/orchestrator_privacy_test.go
+++ b/internal/pkgcheck/orchestrator_privacy_test.go
@@ -2,6 +2,7 @@ package pkgcheck
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 )
@@ -220,5 +221,37 @@ func TestOrchestrator_AllSkippedSkipsExternalEvenWithLocalProvider(t *testing.T)
 	}
 	if len(local.last) != 1 {
 		t.Errorf("local should still see the full list; got last=%+v", local.last)
+	}
+}
+
+type respWithErrProvider struct {
+	name     string
+	findings []Finding
+	err      error
+}
+
+func (r *respWithErrProvider) Name() string                { return r.name }
+func (r *respWithErrProvider) Capabilities() []FindingType { return nil }
+func (r *respWithErrProvider) CheckBatch(ctx context.Context, req CheckRequest) (*CheckResponse, error) {
+	return &CheckResponse{Provider: r.name, Findings: r.findings}, r.err
+}
+
+func TestOrchestrator_PreservesFindingsWhenProviderReturnsError(t *testing.T) {
+	finding := Finding{Type: FindingVulnerability, Provider: "x", Title: "partial-found"}
+	rp := &respWithErrProvider{name: "x", findings: []Finding{finding}, err: errors.New("partial: 1 of 2 packages failed")}
+	o := NewOrchestrator(OrchestratorConfig{
+		Providers: map[string]ProviderEntry{
+			"x": {Provider: rp, Timeout: time.Second, OnFailure: "warn"},
+		},
+	})
+	findings, errs := o.CheckAll(context.Background(), CheckRequest{
+		Ecosystem: EcosystemNPM,
+		Packages:  []PackageRef{{Name: "ok", Version: "1"}, {Name: "fail", Version: "1"}},
+	})
+	if len(findings) != 1 {
+		t.Errorf("partial findings must be preserved alongside the error; got %d findings", len(findings))
+	}
+	if len(errs) != 1 {
+		t.Errorf("provider error must still be recorded; got %d errs", len(errs))
 	}
 }

--- a/internal/pkgcheck/privacy.go
+++ b/internal/pkgcheck/privacy.go
@@ -43,9 +43,15 @@ func NewPrivacyFilter(cfg PrivacyConfig) *PrivacyFilter {
 // Decision order: registry rule first (if an allowlist is configured),
 // then scope/prefix denylist. A package skipped for "private_registry"
 // is never re-classified to "private_scope_denylist."
+//
+// Fail-closed semantics: when the allowlist is non-empty, packages with
+// an empty Registry are treated as private (skipped), not waved through.
+// Missing registry metadata can mean an unresolved or internal package
+// whose origin is unknown to us — sending its name to a third-party API
+// would leak information about internal architecture.
 func (f *PrivacyFilter) Partition(pkgs []PackageRef) (scan []PackageRef, skip []SkippedPackage) {
 	for _, p := range pkgs {
-		if len(f.allowedRegistries) > 0 && p.Registry != "" {
+		if len(f.allowedRegistries) > 0 {
 			if _, ok := f.allowedRegistries[p.Registry]; !ok {
 				skip = append(skip, SkippedPackage{Package: p, Reason: SkipReasonPrivateRegistry})
 				continue

--- a/internal/pkgcheck/privacy.go
+++ b/internal/pkgcheck/privacy.go
@@ -1,0 +1,84 @@
+package pkgcheck
+
+import (
+	"path"
+	"strings"
+)
+
+// PrivacyConfig configures the privacy filter.
+type PrivacyConfig struct {
+	// ExternalScanRegistries lists registries whose packages may be sent to
+	// external providers. An empty list means "do not filter by registry."
+	ExternalScanRegistries []string
+
+	// PrivateScopeDenylist lists package name prefixes / glob patterns that
+	// should NOT be sent externally even when on an allowed registry.
+	// Each entry is matched as either an exact prefix (`@acme`) or a
+	// glob (`@internal-*`).
+	PrivateScopeDenylist []string
+}
+
+// PrivacyFilter partitions a list of PackageRef into "to-scan" and "to-skip".
+type PrivacyFilter struct {
+	allowedRegistries map[string]struct{}
+	denylistPatterns  []string
+}
+
+// NewPrivacyFilter builds a filter from configuration.
+func NewPrivacyFilter(cfg PrivacyConfig) *PrivacyFilter {
+	allowed := make(map[string]struct{}, len(cfg.ExternalScanRegistries))
+	for _, r := range cfg.ExternalScanRegistries {
+		allowed[r] = struct{}{}
+	}
+	return &PrivacyFilter{
+		allowedRegistries: allowed,
+		denylistPatterns:  append([]string(nil), cfg.PrivateScopeDenylist...),
+	}
+}
+
+// Partition splits the input into packages eligible for external scanning
+// and packages skipped due to privacy rules. Order within each slice
+// preserves the order of the input.
+//
+// Decision order: registry rule first (if an allowlist is configured),
+// then scope/prefix denylist. A package skipped for "private_registry"
+// is never re-classified to "private_scope_denylist."
+func (f *PrivacyFilter) Partition(pkgs []PackageRef) (scan []PackageRef, skip []SkippedPackage) {
+	for _, p := range pkgs {
+		if len(f.allowedRegistries) > 0 && p.Registry != "" {
+			if _, ok := f.allowedRegistries[p.Registry]; !ok {
+				skip = append(skip, SkippedPackage{Package: p, Reason: SkipReasonPrivateRegistry})
+				continue
+			}
+		}
+		if f.matchesDenylist(p.Name) {
+			skip = append(skip, SkippedPackage{Package: p, Reason: SkipReasonPrivateScopeDenylist})
+			continue
+		}
+		scan = append(scan, p)
+	}
+	return scan, skip
+}
+
+func (f *PrivacyFilter) matchesDenylist(name string) bool {
+	for _, pat := range f.denylistPatterns {
+		if strings.ContainsAny(pat, "*?[") {
+			if ok, _ := path.Match(pat, name); ok {
+				return true
+			}
+			// Also match against the leading scope segment for patterns like @internal-*
+			if strings.HasPrefix(name, "@") && strings.Contains(name, "/") {
+				scope := strings.SplitN(name, "/", 2)[0]
+				if ok, _ := path.Match(pat, scope); ok {
+					return true
+				}
+			}
+		} else {
+			// Plain prefix: matches "@acme" against "@acme/billing" and "@acme".
+			if name == pat || strings.HasPrefix(name, pat+"/") {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/pkgcheck/privacy.go
+++ b/internal/pkgcheck/privacy.go
@@ -110,21 +110,35 @@ func (f *PrivacyFilter) matchesDenylist(name string) bool {
 }
 
 // normalizeRegistry reduces a registry URL or host string to a canonical
-// form for comparison. The privacy allowlist is keyed on hostnames; a
-// caller-configured value of "registry.npmjs.org" matches packages whose
-// resolved registry is "https://registry.npmjs.org/" (or any equivalent
-// scheme/path variant).
+// form for comparison.  Path segments are preserved so that
+// "https://artifact.example/team-a/" and "https://artifact.example/team-b/"
+// are treated as distinct registries.
+//
+// Examples:
+//
+//	"https://registry.npmjs.org/"          → "registry.npmjs.org"
+//	"https://artifact.example/team-a/"     → "artifact.example/team-a"
+//	"registry.npmjs.org"                   → "registry.npmjs.org"
 func normalizeRegistry(s string) string {
 	if s == "" {
 		return ""
 	}
-	// If it parses as a URL with a host, return the host.
+	// If it parses as a URL with a host, return host + path (trailing slash stripped).
 	if strings.Contains(s, "://") {
 		if u, err := url.Parse(s); err == nil && u.Host != "" {
-			return strings.ToLower(u.Host)
+			host := strings.ToLower(u.Host)
+			path := strings.TrimRight(u.Path, "/")
+			if path == "" {
+				return host
+			}
+			return host + path
 		}
 	}
-	// Otherwise treat the whole string as a host; trim trailing slash,
-	// lowercase.
-	return strings.ToLower(strings.TrimRight(s, "/"))
+	// No scheme — treat the whole string as host-or-host+path.
+	// Trim trailing slash, lowercase the host portion only.
+	s = strings.TrimRight(s, "/")
+	if i := strings.IndexByte(s, '/'); i >= 0 {
+		return strings.ToLower(s[:i]) + s[i:]
+	}
+	return strings.ToLower(s)
 }

--- a/internal/pkgcheck/privacy.go
+++ b/internal/pkgcheck/privacy.go
@@ -80,8 +80,13 @@ func (f *PrivacyFilter) matchesDenylist(name string) bool {
 				}
 			}
 		} else {
-			// Plain prefix: matches "@acme" against "@acme/billing" and "@acme".
-			if name == pat || strings.HasPrefix(name, pat+"/") {
+			// Plain prefix match. Examples:
+			//   "@acme" matches "@acme" and "@acme/billing".
+			//   "internal-" matches "internal-tool", "internal-foo".
+			// Privacy semantics are fail-safe: an over-broad prefix produces
+			// over-skip (private), not under-skip (leak), so we err on the
+			// HasPrefix side. Users who need stricter semantics use globs.
+			if strings.HasPrefix(name, pat) {
 				return true
 			}
 		}

--- a/internal/pkgcheck/privacy.go
+++ b/internal/pkgcheck/privacy.go
@@ -40,7 +40,11 @@ type PrivacyFilter struct {
 func NewPrivacyFilter(cfg PrivacyConfig) *PrivacyFilter {
 	allowed := make(map[string]struct{}, len(cfg.ExternalScanRegistries))
 	for _, r := range cfg.ExternalScanRegistries {
-		allowed[normalizeRegistry(r)] = struct{}{}
+		n := normalizeRegistry(r)
+		if n == "" {
+			continue // empty entry is meaningless; ignore rather than match-all-empty-registry
+		}
+		allowed[n] = struct{}{}
 	}
 	return &PrivacyFilter{
 		allowedRegistries: allowed,

--- a/internal/pkgcheck/privacy.go
+++ b/internal/pkgcheck/privacy.go
@@ -68,6 +68,9 @@ func (f *PrivacyFilter) Partition(pkgs []PackageRef) (scan []PackageRef, skip []
 
 func (f *PrivacyFilter) matchesDenylist(name string) bool {
 	for _, pat := range f.denylistPatterns {
+		if pat == "" {
+			continue // empty pattern is a no-op; ignore rather than match-all
+		}
 		if strings.ContainsAny(pat, "*?[") {
 			if ok, _ := path.Match(pat, name); ok {
 				return true

--- a/internal/pkgcheck/privacy.go
+++ b/internal/pkgcheck/privacy.go
@@ -1,11 +1,23 @@
 package pkgcheck
 
 import (
+	"net/url"
 	"path"
 	"strings"
 )
 
 // PrivacyConfig configures the privacy filter.
+//
+// LIMITATION: the privacy filter compares against PackageRef.Registry,
+// which is populated by package-manager resolvers. Resolvers do NOT
+// currently parse `.npmrc`, `~/.config/pip/pip.conf`, or environment
+// variables that override the default registry — they only honor
+// CLI flags (--registry, --index-url, etc.). Operators whose
+// installs use config-file or env-var registry overrides must
+// explicitly include those registries in `external_scan_registries`,
+// or omit the public-registry defaults to keep private packages
+// behind the privacy gate. Scoped npm packages fail closed for this
+// reason (see resolver/npm.go).
 type PrivacyConfig struct {
 	// ExternalScanRegistries lists registries whose packages may be sent to
 	// external providers. An empty list means "do not filter by registry."
@@ -28,7 +40,7 @@ type PrivacyFilter struct {
 func NewPrivacyFilter(cfg PrivacyConfig) *PrivacyFilter {
 	allowed := make(map[string]struct{}, len(cfg.ExternalScanRegistries))
 	for _, r := range cfg.ExternalScanRegistries {
-		allowed[r] = struct{}{}
+		allowed[normalizeRegistry(r)] = struct{}{}
 	}
 	return &PrivacyFilter{
 		allowedRegistries: allowed,
@@ -52,7 +64,7 @@ func NewPrivacyFilter(cfg PrivacyConfig) *PrivacyFilter {
 func (f *PrivacyFilter) Partition(pkgs []PackageRef) (scan []PackageRef, skip []SkippedPackage) {
 	for _, p := range pkgs {
 		if len(f.allowedRegistries) > 0 {
-			if _, ok := f.allowedRegistries[p.Registry]; !ok {
+			if _, ok := f.allowedRegistries[normalizeRegistry(p.Registry)]; !ok {
 				skip = append(skip, SkippedPackage{Package: p, Reason: SkipReasonPrivateRegistry})
 				continue
 			}
@@ -95,4 +107,24 @@ func (f *PrivacyFilter) matchesDenylist(name string) bool {
 		}
 	}
 	return false
+}
+
+// normalizeRegistry reduces a registry URL or host string to a canonical
+// form for comparison. The privacy allowlist is keyed on hostnames; a
+// caller-configured value of "registry.npmjs.org" matches packages whose
+// resolved registry is "https://registry.npmjs.org/" (or any equivalent
+// scheme/path variant).
+func normalizeRegistry(s string) string {
+	if s == "" {
+		return ""
+	}
+	// If it parses as a URL with a host, return the host.
+	if strings.Contains(s, "://") {
+		if u, err := url.Parse(s); err == nil && u.Host != "" {
+			return strings.ToLower(u.Host)
+		}
+	}
+	// Otherwise treat the whole string as a host; trim trailing slash,
+	// lowercase.
+	return strings.ToLower(strings.TrimRight(s, "/"))
 }

--- a/internal/pkgcheck/privacy_test.go
+++ b/internal/pkgcheck/privacy_test.go
@@ -84,6 +84,25 @@ func TestPrivacyFilter_EmptyRegistryFailsClosed(t *testing.T) {
 	}
 }
 
+func TestPrivacyFilter_EmptyAllowlistEntryIsIgnored(t *testing.T) {
+	pf := NewPrivacyFilter(PrivacyConfig{
+		ExternalScanRegistries: []string{"registry.npmjs.org", ""},
+	})
+	// A package with empty Registry must NOT be treated as allowed
+	// just because the allowlist contains an empty entry.
+	in := []PackageRef{
+		{Name: "lodash", Version: "1", Registry: "registry.npmjs.org"},
+		{Name: "private", Version: "1", Registry: ""},
+	}
+	scan, skip := pf.Partition(in)
+	if len(scan) != 1 || scan[0].Name != "lodash" {
+		t.Errorf("scan should be lodash only; got %+v", scan)
+	}
+	if len(skip) != 1 || skip[0].Reason != SkipReasonPrivateRegistry {
+		t.Errorf("private package must be skipped; got %+v", skip)
+	}
+}
+
 func TestPrivacyFilter_EmptyDenylistPatternIsIgnored(t *testing.T) {
 	pf := NewPrivacyFilter(PrivacyConfig{
 		PrivateScopeDenylist: []string{""},

--- a/internal/pkgcheck/privacy_test.go
+++ b/internal/pkgcheck/privacy_test.go
@@ -67,3 +67,19 @@ func TestPrivacyFilter_RegistryRuleTakesPriority(t *testing.T) {
 		t.Fatalf("want private_registry, got %+v", skip)
 	}
 }
+
+func TestPrivacyFilter_EmptyRegistryFailsClosed(t *testing.T) {
+	pf := NewPrivacyFilter(PrivacyConfig{
+		ExternalScanRegistries: []string{"registry.npmjs.org"},
+	})
+	in := []PackageRef{
+		{Name: "lodash", Version: "4.17.21", Registry: ""}, // resolver did not populate Registry
+	}
+	scan, skip := pf.Partition(in)
+	if len(scan) != 0 {
+		t.Errorf("empty Registry must not bypass the allowlist; scan=%+v", scan)
+	}
+	if len(skip) != 1 || skip[0].Reason != SkipReasonPrivateRegistry {
+		t.Errorf("want skip with private_registry reason; got %+v", skip)
+	}
+}

--- a/internal/pkgcheck/privacy_test.go
+++ b/internal/pkgcheck/privacy_test.go
@@ -138,12 +138,30 @@ func TestNormalizeRegistry(t *testing.T) {
 		"registry.npmjs.org":             "registry.npmjs.org",
 		"https://registry.npmjs.org/":    "registry.npmjs.org",
 		"https://registry.npmjs.org":     "registry.npmjs.org",
-		"http://Registry.NPMJS.org/path": "registry.npmjs.org",
+		"http://Registry.NPMJS.org/path": "registry.npmjs.org/path",
+		"https://artifact.example/team-a/": "artifact.example/team-a",
 		"":                               "",
 	}
 	for in, want := range cases {
 		if got := normalizeRegistry(in); got != want {
 			t.Errorf("normalizeRegistry(%q)=%q, want %q", in, got, want)
 		}
+	}
+}
+
+func TestPrivacyFilter_PathDistinguishesRegistries(t *testing.T) {
+	pf := NewPrivacyFilter(PrivacyConfig{
+		ExternalScanRegistries: []string{"https://artifact.example/team-a/"},
+	})
+	in := []PackageRef{
+		{Name: "x", Registry: "https://artifact.example/team-a/"}, // allowed
+		{Name: "y", Registry: "https://artifact.example/team-b/"}, // private — different path
+	}
+	scan, skip := pf.Partition(in)
+	if len(scan) != 1 || scan[0].Name != "x" {
+		t.Errorf("only team-a should be allowed; scan=%v skip=%v", scan, skip)
+	}
+	if len(skip) != 1 || skip[0].Package.Name != "y" || skip[0].Reason != SkipReasonPrivateRegistry {
+		t.Errorf("team-b should be skipped with private_registry; skip=%v", skip)
 	}
 }

--- a/internal/pkgcheck/privacy_test.go
+++ b/internal/pkgcheck/privacy_test.go
@@ -165,3 +165,25 @@ func TestPrivacyFilter_PathDistinguishesRegistries(t *testing.T) {
 		t.Errorf("team-b should be skipped with private_registry; skip=%v", skip)
 	}
 }
+
+func TestPrivacyFilter_DefaultsAllowPyPISimpleIndex(t *testing.T) {
+	// Mirror of the production default allowlist. The pip-default index URL
+	// `https://pypi.org/simple/` must match so explicit --index-url on
+	// public PyPI doesn't get skipped.
+	pf := NewPrivacyFilter(PrivacyConfig{
+		ExternalScanRegistries: []string{"registry.npmjs.org", "pypi.org", "pypi.org/simple"},
+	})
+	in := []PackageRef{
+		{Name: "lodash", Version: "1", Registry: "registry.npmjs.org"},
+		{Name: "requests", Version: "1", Registry: "pypi.org"},
+		{Name: "flask", Version: "1", Registry: "https://pypi.org/simple/"},
+		{Name: "django", Version: "1", Registry: "https://pypi.org/simple"},
+	}
+	scan, skip := pf.Partition(in)
+	if len(skip) != 0 {
+		t.Errorf("all four public-registry forms should match; skip=%+v", skip)
+	}
+	if len(scan) != 4 {
+		t.Errorf("want 4 scanned; got %d", len(scan))
+	}
+}

--- a/internal/pkgcheck/privacy_test.go
+++ b/internal/pkgcheck/privacy_test.go
@@ -84,6 +84,17 @@ func TestPrivacyFilter_EmptyRegistryFailsClosed(t *testing.T) {
 	}
 }
 
+func TestPrivacyFilter_EmptyDenylistPatternIsIgnored(t *testing.T) {
+	pf := NewPrivacyFilter(PrivacyConfig{
+		PrivateScopeDenylist: []string{""},
+	})
+	in := []PackageRef{{Name: "lodash", Version: "1"}}
+	scan, skip := pf.Partition(in)
+	if len(scan) != 1 || len(skip) != 0 {
+		t.Errorf("empty pattern must not match anything; scan=%v skip=%v", scan, skip)
+	}
+}
+
 func TestPrivacyFilter_DenylistMatchesUnscopedPrefix(t *testing.T) {
 	pf := NewPrivacyFilter(PrivacyConfig{
 		PrivateScopeDenylist: []string{"internal-"},

--- a/internal/pkgcheck/privacy_test.go
+++ b/internal/pkgcheck/privacy_test.go
@@ -1,0 +1,69 @@
+package pkgcheck
+
+import (
+	"testing"
+)
+
+func TestPrivacyFilter_PrivateRegistryAutoDetect(t *testing.T) {
+	pf := NewPrivacyFilter(PrivacyConfig{
+		ExternalScanRegistries: []string{"registry.npmjs.org", "pypi.org"},
+	})
+	in := []PackageRef{
+		{Name: "lodash", Version: "4.17.21", Registry: "registry.npmjs.org"},
+		{Name: "internal-tool", Version: "0.1.0", Registry: "artifactory.acme.local"},
+	}
+	scan, skip := pf.Partition(in)
+	if len(scan) != 1 || scan[0].Name != "lodash" {
+		t.Fatalf("scan = %+v, want lodash only", scan)
+	}
+	if len(skip) != 1 || skip[0].Reason != SkipReasonPrivateRegistry {
+		t.Fatalf("skip = %+v, want internal-tool with private_registry", skip)
+	}
+}
+
+func TestPrivacyFilter_ScopeDenylist(t *testing.T) {
+	pf := NewPrivacyFilter(PrivacyConfig{
+		ExternalScanRegistries: []string{"registry.npmjs.org"},
+		PrivateScopeDenylist:   []string{"@acme", "@internal-*"},
+	})
+	in := []PackageRef{
+		{Name: "@acme/billing", Version: "1.0.0", Registry: "registry.npmjs.org"},
+		{Name: "@internal-platform/utils", Version: "1.0.0", Registry: "registry.npmjs.org"},
+		{Name: "lodash", Version: "4.17.21", Registry: "registry.npmjs.org"},
+	}
+	scan, skip := pf.Partition(in)
+	if len(scan) != 1 || scan[0].Name != "lodash" {
+		t.Fatalf("scan = %+v, want lodash only", scan)
+	}
+	if len(skip) != 2 {
+		t.Fatalf("skip = %+v, want 2 entries", skip)
+	}
+	for _, s := range skip {
+		if s.Reason != SkipReasonPrivateScopeDenylist {
+			t.Errorf("want denylist reason for %s, got %s", s.Package.Name, s.Reason)
+		}
+	}
+}
+
+func TestPrivacyFilter_EmptyAllowlistTreatsAllAsPublic(t *testing.T) {
+	// An empty allowlist means "no registry filter applied" — defer to denylist only.
+	pf := NewPrivacyFilter(PrivacyConfig{})
+	in := []PackageRef{{Name: "lodash", Version: "4.17.21", Registry: "anything"}}
+	scan, skip := pf.Partition(in)
+	if len(scan) != 1 || len(skip) != 0 {
+		t.Fatalf("scan=%v skip=%v", scan, skip)
+	}
+}
+
+func TestPrivacyFilter_RegistryRuleTakesPriority(t *testing.T) {
+	pf := NewPrivacyFilter(PrivacyConfig{
+		ExternalScanRegistries: []string{"registry.npmjs.org"},
+		PrivateScopeDenylist:   []string{"@acme"},
+	})
+	// On a private registry — should report private_registry, not denylist.
+	in := []PackageRef{{Name: "@acme/x", Version: "1", Registry: "artifactory.acme.local"}}
+	_, skip := pf.Partition(in)
+	if len(skip) != 1 || skip[0].Reason != SkipReasonPrivateRegistry {
+		t.Fatalf("want private_registry, got %+v", skip)
+	}
+}

--- a/internal/pkgcheck/privacy_test.go
+++ b/internal/pkgcheck/privacy_test.go
@@ -83,3 +83,26 @@ func TestPrivacyFilter_EmptyRegistryFailsClosed(t *testing.T) {
 		t.Errorf("want skip with private_registry reason; got %+v", skip)
 	}
 }
+
+func TestPrivacyFilter_DenylistMatchesUnscopedPrefix(t *testing.T) {
+	pf := NewPrivacyFilter(PrivacyConfig{
+		PrivateScopeDenylist: []string{"internal-"},
+	})
+	in := []PackageRef{
+		{Name: "internal-tool", Version: "1"},
+		{Name: "internal-foo", Version: "1"},
+		{Name: "external-thing", Version: "1"},
+	}
+	scan, skip := pf.Partition(in)
+	if len(scan) != 1 || scan[0].Name != "external-thing" {
+		t.Fatalf("scan = %+v, want external-thing only", scan)
+	}
+	if len(skip) != 2 {
+		t.Fatalf("skip = %+v, want 2 entries", skip)
+	}
+	for _, s := range skip {
+		if s.Reason != SkipReasonPrivateScopeDenylist {
+			t.Errorf("want denylist reason for %s, got %s", s.Package.Name, s.Reason)
+		}
+	}
+}

--- a/internal/pkgcheck/privacy_test.go
+++ b/internal/pkgcheck/privacy_test.go
@@ -117,3 +117,33 @@ func TestPrivacyFilter_DenylistMatchesUnscopedPrefix(t *testing.T) {
 		}
 	}
 }
+
+func TestPrivacyFilter_NormalizesRegistryURLs(t *testing.T) {
+	pf := NewPrivacyFilter(PrivacyConfig{
+		ExternalScanRegistries: []string{"registry.npmjs.org"},
+	})
+	in := []PackageRef{
+		{Name: "lodash", Version: "1", Registry: "https://registry.npmjs.org/"},
+		{Name: "express", Version: "1", Registry: "registry.npmjs.org"},
+		{Name: "react", Version: "1", Registry: "REGISTRY.NPMJS.ORG"},
+	}
+	scan, skip := pf.Partition(in)
+	if len(scan) != 3 {
+		t.Errorf("all three URL forms should match the allowlist; scan=%v skip=%v", scan, skip)
+	}
+}
+
+func TestNormalizeRegistry(t *testing.T) {
+	cases := map[string]string{
+		"registry.npmjs.org":             "registry.npmjs.org",
+		"https://registry.npmjs.org/":    "registry.npmjs.org",
+		"https://registry.npmjs.org":     "registry.npmjs.org",
+		"http://Registry.NPMJS.org/path": "registry.npmjs.org",
+		"":                               "",
+	}
+	for in, want := range cases {
+		if got := normalizeRegistry(in); got != want {
+			t.Errorf("normalizeRegistry(%q)=%q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/pkgcheck/provider.go
+++ b/internal/pkgcheck/provider.go
@@ -17,6 +17,14 @@ type CheckProvider interface {
 	CheckBatch(ctx context.Context, req CheckRequest) (*CheckResponse, error)
 }
 
+// LocalProvider is an optional interface implemented by providers that run
+// entirely in-process, without making any external network calls. The
+// orchestrator skips privacy filtering for local providers so that private
+// packages still receive license/metadata checks.
+type LocalProvider interface {
+	IsLocal() bool
+}
+
 // CheckRequest describes what to check.
 type CheckRequest struct {
 	Ecosystem Ecosystem    `json:"ecosystem" yaml:"ecosystem"`

--- a/internal/pkgcheck/provider/contract_test.go
+++ b/internal/pkgcheck/provider/contract_test.go
@@ -33,7 +33,7 @@ func runContractSuite(t *testing.T, name string, makeProvider providerFactory, f
 
 	t.Run(name+"/RespectsContextCancellation", func(t *testing.T) {
 		p := makeProvider(t, fixture.slowServerURL)
-		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
 		defer cancel()
 		_, err := p.CheckBatch(ctx, pkgcheck.CheckRequest{
 			Ecosystem: pkgcheck.EcosystemNPM,

--- a/internal/pkgcheck/provider/contract_test.go
+++ b/internal/pkgcheck/provider/contract_test.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/pkgcheck"
+)
+
+// providerFactory builds a CheckProvider configured to talk to the given baseURL.
+// Each provider's test file defines its own factory.
+type providerFactory func(t *testing.T, baseURL string) pkgcheck.CheckProvider
+
+// runContractSuite runs the shared CheckProvider contract assertions.
+func runContractSuite(t *testing.T, name string, makeProvider providerFactory, fixture contractFixture) {
+	t.Run(name+"/EmptyInput", func(t *testing.T) {
+		p := makeProvider(t, fixture.cleanServerURL)
+		resp, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+			Ecosystem: pkgcheck.EcosystemNPM,
+			Packages:  nil,
+		})
+		if err != nil {
+			t.Fatalf("empty input must not error: %v", err)
+		}
+		if resp == nil {
+			t.Fatal("response must not be nil")
+		}
+		if len(resp.Findings) != 0 {
+			t.Fatalf("empty input should yield 0 findings, got %d", len(resp.Findings))
+		}
+	})
+
+	t.Run(name+"/RespectsContextCancellation", func(t *testing.T) {
+		p := makeProvider(t, fixture.slowServerURL)
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		_, err := p.CheckBatch(ctx, pkgcheck.CheckRequest{
+			Ecosystem: pkgcheck.EcosystemNPM,
+			Packages:  []pkgcheck.PackageRef{{Name: "lodash", Version: "4.17.21"}},
+		})
+		if err == nil {
+			t.Fatal("cancelled context must produce an error")
+		}
+	})
+
+	t.Run(name+"/TransportErrorReturnsError", func(t *testing.T) {
+		p := makeProvider(t, "http://127.0.0.1:1") // unreachable
+		_, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+			Ecosystem: pkgcheck.EcosystemNPM,
+			Packages:  []pkgcheck.PackageRef{{Name: "lodash", Version: "4.17.21"}},
+		})
+		if err == nil {
+			t.Fatal("transport error must return an error")
+		}
+	})
+}
+
+// contractFixture holds the test servers a provider needs to exercise the contract.
+type contractFixture struct {
+	cleanServerURL string // returns a 200 OK with no findings
+	slowServerURL  string // sleeps longer than the test ctx timeout
+}

--- a/internal/pkgcheck/provider/httpclient.go
+++ b/internal/pkgcheck/provider/httpclient.go
@@ -74,7 +74,10 @@ func (c *retryClient) Do(req *http.Request) (*http.Response, error) {
 			if attempt == c.cfg.MaxAttempts {
 				break
 			}
-			c.sleep(attempt, nil, req)
+			if !c.sleep(attempt, nil, req) {
+				lastErr = req.Context().Err()
+				break
+			}
 			continue
 		}
 
@@ -89,15 +92,18 @@ func (c *retryClient) Do(req *http.Request) (*http.Response, error) {
 		if attempt == c.cfg.MaxAttempts {
 			break
 		}
-		c.sleep(attempt, resp, req)
+		if !c.sleep(attempt, resp, req) {
+			lastErr = req.Context().Err()
+			break
+		}
 	}
 
-	return nil, fmt.Errorf("retryClient: gave up after %d attempts: %w", c.cfg.MaxAttempts, lastErr)
+	return nil, fmt.Errorf("retryClient: gave up after %d attempts: %w", c.cfg.MaxAttempts, errors.Join(errMaxAttempts, lastErr))
 }
 
 // sleep applies Retry-After (when configured and present) or exponential
 // backoff with jitter. Honors context cancellation.
-func (c *retryClient) sleep(attempt int, resp *http.Response, req *http.Request) {
+func (c *retryClient) sleep(attempt int, resp *http.Response, req *http.Request) bool {
 	wait := c.backoff(attempt)
 	if c.cfg.RespectRetryAfter && resp != nil {
 		if h := resp.Header.Get("Retry-After"); h != "" {
@@ -112,14 +118,16 @@ func (c *retryClient) sleep(attempt int, resp *http.Response, req *http.Request)
 
 	select {
 	case <-time.After(wait):
+		return true
 	case <-req.Context().Done():
+		return false
 	}
 }
 
 // backoff returns exponential-with-jitter backoff for the given attempt.
 func (c *retryClient) backoff(attempt int) time.Duration {
 	exp := time.Duration(1<<uint(attempt-1)) * c.cfg.BaseBackoff
-	if exp > c.cfg.MaxBackoff {
+	if exp <= 0 || exp > c.cfg.MaxBackoff {
 		exp = c.cfg.MaxBackoff
 	}
 	// Full jitter: random in [0, exp].

--- a/internal/pkgcheck/provider/httpclient.go
+++ b/internal/pkgcheck/provider/httpclient.go
@@ -157,10 +157,10 @@ type circuitBreakerConfig struct {
 // circuitBreaker tracks consecutive provider failures and short-circuits
 // while open. Safe for concurrent use.
 //
-// As of this commit the breaker is unwired by design — it is consumed by the
-// Socket and Snyk providers introduced in later changes (provider/socket.go
-// and provider/snyk.go). Each provider holds its own breaker instance so that
-// failures of one provider do not isolate the other.
+// Use callWithBreaker as the default invocation site for provider HTTP work;
+// the Socket and Snyk providers introduced later wrap their CheckBatch calls
+// with it. Each provider holds its own breaker instance so that failures of
+// one provider do not isolate the other.
 type circuitBreaker struct {
 	cfg circuitBreakerConfig
 
@@ -225,4 +225,32 @@ func (b *circuitBreaker) RecordFailure() {
 	if b.failures >= b.cfg.Threshold {
 		b.openedAt = now
 	}
+}
+
+// errBreakerOpen is returned by callWithBreaker when the breaker is open.
+// Callers can detect short-circuited calls via errors.Is(err, errBreakerOpen).
+var errBreakerOpen = errors.New("circuit breaker open")
+
+// callWithBreaker runs fn under the protection of a circuit breaker.
+//
+// If the breaker is open, fn is not invoked and errBreakerOpen is returned.
+// Otherwise fn is invoked, and its outcome is recorded on the breaker:
+// errors trip a RecordFailure, success records a RecordSuccess.
+//
+// Provider implementations use this as their single invocation site for
+// CheckBatch's outbound HTTP work, so a sustained-failure provider stops
+// taking the network round-trip cost on every install.
+func callWithBreaker(b *circuitBreaker, fn func() error) error {
+	if b == nil {
+		return fn()
+	}
+	if !b.Allow() {
+		return errBreakerOpen
+	}
+	if err := fn(); err != nil {
+		b.RecordFailure()
+		return err
+	}
+	b.RecordSuccess()
+	return nil
 }

--- a/internal/pkgcheck/provider/httpclient.go
+++ b/internal/pkgcheck/provider/httpclient.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 )
 
@@ -137,3 +138,78 @@ func (c *retryClient) backoff(attempt int) time.Duration {
 
 // errMaxAttempts is exposed for tests that want to assert "gave up".
 var errMaxAttempts = errors.New("max retry attempts exceeded")
+
+// circuitBreakerConfig controls breaker behavior.
+type circuitBreakerConfig struct {
+	Threshold  int           // consecutive failures before opening
+	Window     time.Duration // window in which Threshold failures must occur
+	OpenPeriod time.Duration // how long the breaker stays open
+}
+
+// circuitBreaker tracks consecutive provider failures and short-circuits
+// while open. Safe for concurrent use.
+type circuitBreaker struct {
+	cfg circuitBreakerConfig
+
+	mu             sync.Mutex
+	failures       int
+	firstFailureAt time.Time
+	openedAt       time.Time
+}
+
+func newCircuitBreaker(cfg circuitBreakerConfig) *circuitBreaker {
+	if cfg.Threshold <= 0 {
+		cfg.Threshold = 3
+	}
+	if cfg.Window <= 0 {
+		cfg.Window = 60 * time.Second
+	}
+	if cfg.OpenPeriod <= 0 {
+		cfg.OpenPeriod = 60 * time.Second
+	}
+	return &circuitBreaker{cfg: cfg}
+}
+
+// Allow reports whether a call may proceed.
+func (b *circuitBreaker) Allow() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.openedAt.IsZero() {
+		return true
+	}
+	if time.Since(b.openedAt) >= b.cfg.OpenPeriod {
+		// Re-close.
+		b.openedAt = time.Time{}
+		b.failures = 0
+		return true
+	}
+	return false
+}
+
+// RecordSuccess resets the failure counter.
+func (b *circuitBreaker) RecordSuccess() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.failures = 0
+	b.firstFailureAt = time.Time{}
+}
+
+// RecordFailure increments the failure counter and opens the breaker if the
+// threshold is crossed within the window.
+func (b *circuitBreaker) RecordFailure() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := time.Now()
+	if b.failures == 0 || now.Sub(b.firstFailureAt) > b.cfg.Window {
+		b.failures = 1
+		b.firstFailureAt = now
+	} else {
+		b.failures++
+	}
+
+	if b.failures >= b.cfg.Threshold {
+		b.openedAt = now
+	}
+}

--- a/internal/pkgcheck/provider/httpclient.go
+++ b/internal/pkgcheck/provider/httpclient.go
@@ -72,6 +72,14 @@ func (c *retryClient) Do(req *http.Request) (*http.Response, error) {
 
 		resp, err := c.client.Do(req)
 		if err != nil {
+			// If the failure is due to context cancellation, treat it as
+			// an abort regardless of which attempt we are on — never wrap
+			// it as max-attempts exhaustion.
+			if ctxErr := req.Context().Err(); ctxErr != nil {
+				lastErr = ctxErr
+				cancelled = true
+				break
+			}
 			lastErr = err
 			if attempt == c.cfg.MaxAttempts {
 				break
@@ -106,6 +114,13 @@ func (c *retryClient) Do(req *http.Request) (*http.Response, error) {
 		// Don't classify a cancellation as "max attempts exceeded" — callers
 		// using errors.Is(err, errMaxAttempts) should be able to distinguish.
 		return nil, fmt.Errorf("retryClient: aborted: %w", lastErr)
+	}
+	// Even if the loop exited via the final-attempt break path, the context
+	// may have been cancelled in the meantime (e.g., the final attempt's
+	// request returned a 5xx, then ctx was cancelled before we hit this
+	// return). Surface that as a cancellation rather than max-attempts.
+	if ctxErr := req.Context().Err(); ctxErr != nil {
+		return nil, fmt.Errorf("retryClient: aborted: %w", ctxErr)
 	}
 	return nil, fmt.Errorf("retryClient: gave up after %d attempts: %w", c.cfg.MaxAttempts, errors.Join(errMaxAttempts, lastErr))
 }

--- a/internal/pkgcheck/provider/httpclient.go
+++ b/internal/pkgcheck/provider/httpclient.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -255,6 +256,12 @@ var errBreakerOpen = errors.New("circuit breaker open")
 // Provider implementations use this as their single invocation site for
 // CheckBatch's outbound HTTP work, so a sustained-failure provider stops
 // taking the network round-trip cost on every install.
+//
+// Caller-driven context cancellation and deadline-exceeded errors are treated
+// as neutral outcomes: they do not record a failure (which would let a tight
+// caller timeout open the breaker for unrelated subsequent calls) and do not
+// record a success either. Genuine remote/provider failures (transport errors,
+// 5xx, etc.) still record a failure.
 func callWithBreaker(b *circuitBreaker, fn func() error) error {
 	if b == nil {
 		return fn()
@@ -263,9 +270,18 @@ func callWithBreaker(b *circuitBreaker, fn func() error) error {
 		return errBreakerOpen
 	}
 	if err := fn(); err != nil {
+		if isCallerCancellation(err) {
+			return err
+		}
 		b.RecordFailure()
 		return err
 	}
 	b.RecordSuccess()
 	return nil
+}
+
+// isCallerCancellation reports whether err is a context cancellation or
+// deadline-exceeded that should not count toward breaker health.
+func isCallerCancellation(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }

--- a/internal/pkgcheck/provider/httpclient.go
+++ b/internal/pkgcheck/provider/httpclient.go
@@ -257,12 +257,14 @@ var errBreakerOpen = errors.New("circuit breaker open")
 // CheckBatch's outbound HTTP work, so a sustained-failure provider stops
 // taking the network round-trip cost on every install.
 //
-// Caller-driven context cancellation and deadline-exceeded errors are treated
-// as neutral outcomes: they do not record a failure (which would let a tight
-// caller timeout open the breaker for unrelated subsequent calls) and do not
-// record a success either. Genuine remote/provider failures (transport errors,
-// 5xx, etc.) still record a failure.
-func callWithBreaker(b *circuitBreaker, fn func() error) error {
+// callerCtx must be the original parent context — NOT a derived
+// context with the provider's own per-request timeout. We use it to
+// distinguish caller-driven cancellation/deadline (neutral, no failure
+// recorded) from a provider-own timeout firing (real provider-health
+// signal, recorded as failure). When callerCtx is nil the function falls
+// back to the previous behaviour where any context.Canceled/DeadlineExceeded
+// is treated as neutral.
+func callWithBreaker(b *circuitBreaker, callerCtx context.Context, fn func() error) error {
 	if b == nil {
 		return fn()
 	}
@@ -270,7 +272,7 @@ func callWithBreaker(b *circuitBreaker, fn func() error) error {
 		return errBreakerOpen
 	}
 	if err := fn(); err != nil {
-		if isCallerCancellation(err) {
+		if isNeutralForBreaker(callerCtx, err) {
 			return err
 		}
 		b.RecordFailure()
@@ -280,8 +282,15 @@ func callWithBreaker(b *circuitBreaker, fn func() error) error {
 	return nil
 }
 
-// isCallerCancellation reports whether err is a context cancellation or
-// deadline-exceeded that should not count toward breaker health.
-func isCallerCancellation(err error) bool {
-	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+// isNeutralForBreaker reports whether err should be excluded from breaker
+// health accounting. Caller-driven cancellation/deadline (visible on
+// callerCtx itself) is neutral; provider-own timeouts are not.
+func isNeutralForBreaker(callerCtx context.Context, err error) bool {
+	if callerCtx != nil && callerCtx.Err() != nil {
+		return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+	}
+	if callerCtx == nil {
+		return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+	}
+	return false
 }

--- a/internal/pkgcheck/provider/httpclient.go
+++ b/internal/pkgcheck/provider/httpclient.go
@@ -64,6 +64,7 @@ func (c *retryClient) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	var lastErr error
+	cancelled := false
 	for attempt := 1; attempt <= c.cfg.MaxAttempts; attempt++ {
 		if bodyBytes != nil {
 			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
@@ -77,6 +78,7 @@ func (c *retryClient) Do(req *http.Request) (*http.Response, error) {
 			}
 			if !c.sleep(attempt, nil, req) {
 				lastErr = req.Context().Err()
+				cancelled = true
 				break
 			}
 			continue
@@ -95,10 +97,16 @@ func (c *retryClient) Do(req *http.Request) (*http.Response, error) {
 		}
 		if !c.sleep(attempt, resp, req) {
 			lastErr = req.Context().Err()
+			cancelled = true
 			break
 		}
 	}
 
+	if cancelled {
+		// Don't classify a cancellation as "max attempts exceeded" — callers
+		// using errors.Is(err, errMaxAttempts) should be able to distinguish.
+		return nil, fmt.Errorf("retryClient: aborted: %w", lastErr)
+	}
 	return nil, fmt.Errorf("retryClient: gave up after %d attempts: %w", c.cfg.MaxAttempts, errors.Join(errMaxAttempts, lastErr))
 }
 
@@ -148,6 +156,11 @@ type circuitBreakerConfig struct {
 
 // circuitBreaker tracks consecutive provider failures and short-circuits
 // while open. Safe for concurrent use.
+//
+// As of this commit the breaker is unwired by design — it is consumed by the
+// Socket and Snyk providers introduced in later changes (provider/socket.go
+// and provider/snyk.go). Each provider holds its own breaker instance so that
+// failures of one provider do not isolate the other.
 type circuitBreaker struct {
 	cfg circuitBreakerConfig
 

--- a/internal/pkgcheck/provider/httpclient.go
+++ b/internal/pkgcheck/provider/httpclient.go
@@ -1,0 +1,131 @@
+package provider
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// retryConfig configures the bounded-retry HTTP client.
+type retryConfig struct {
+	MaxAttempts       int
+	BaseBackoff       time.Duration
+	MaxBackoff        time.Duration
+	RespectRetryAfter bool
+	Transport         http.RoundTripper // optional, defaults to http.DefaultTransport
+}
+
+// retryClient wraps http.Client with bounded retries on 429/5xx and
+// optional Retry-After header handling.
+type retryClient struct {
+	cfg    retryConfig
+	client *http.Client
+}
+
+// newRetryClient creates a retryClient with sane defaults if zero values are passed.
+func newRetryClient(cfg retryConfig) *retryClient {
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = 3
+	}
+	if cfg.BaseBackoff <= 0 {
+		cfg.BaseBackoff = 200 * time.Millisecond
+	}
+	if cfg.MaxBackoff <= 0 {
+		cfg.MaxBackoff = 5 * time.Second
+	}
+	transport := cfg.Transport
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+	return &retryClient{
+		cfg:    cfg,
+		client: &http.Client{Transport: transport},
+	}
+}
+
+// Do executes the request with bounded retries on 429/5xx.
+// The request body, if any, must be replayable — callers should pass a
+// *bytes.Reader or similar that can be re-read.
+func (c *retryClient) Do(req *http.Request) (*http.Response, error) {
+	var bodyBytes []byte
+	if req.Body != nil {
+		var err error
+		bodyBytes, err = io.ReadAll(req.Body)
+		_ = req.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("read request body: %w", err)
+		}
+	}
+
+	var lastErr error
+	for attempt := 1; attempt <= c.cfg.MaxAttempts; attempt++ {
+		if bodyBytes != nil {
+			req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		}
+
+		resp, err := c.client.Do(req)
+		if err != nil {
+			lastErr = err
+			if attempt == c.cfg.MaxAttempts {
+				break
+			}
+			c.sleep(attempt, nil, req)
+			continue
+		}
+
+		if resp.StatusCode < 500 && resp.StatusCode != http.StatusTooManyRequests {
+			return resp, nil
+		}
+
+		// Retryable status — drain body and try again.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		lastErr = fmt.Errorf("http status %d", resp.StatusCode)
+		if attempt == c.cfg.MaxAttempts {
+			break
+		}
+		c.sleep(attempt, resp, req)
+	}
+
+	return nil, fmt.Errorf("retryClient: gave up after %d attempts: %w", c.cfg.MaxAttempts, lastErr)
+}
+
+// sleep applies Retry-After (when configured and present) or exponential
+// backoff with jitter. Honors context cancellation.
+func (c *retryClient) sleep(attempt int, resp *http.Response, req *http.Request) {
+	wait := c.backoff(attempt)
+	if c.cfg.RespectRetryAfter && resp != nil {
+		if h := resp.Header.Get("Retry-After"); h != "" {
+			if secs, err := strconv.Atoi(h); err == nil && secs > 0 {
+				wait = time.Duration(secs) * time.Second
+			}
+		}
+	}
+	if wait > c.cfg.MaxBackoff {
+		wait = c.cfg.MaxBackoff
+	}
+
+	select {
+	case <-time.After(wait):
+	case <-req.Context().Done():
+	}
+}
+
+// backoff returns exponential-with-jitter backoff for the given attempt.
+func (c *retryClient) backoff(attempt int) time.Duration {
+	exp := time.Duration(1<<uint(attempt-1)) * c.cfg.BaseBackoff
+	if exp > c.cfg.MaxBackoff {
+		exp = c.cfg.MaxBackoff
+	}
+	// Full jitter: random in [0, exp].
+	jitter := time.Duration(rand.Int63n(int64(exp) + 1))
+	return jitter
+}
+
+// errMaxAttempts is exposed for tests that want to assert "gave up".
+var errMaxAttempts = errors.New("max retry attempts exceeded")

--- a/internal/pkgcheck/provider/httpclient.go
+++ b/internal/pkgcheck/provider/httpclient.go
@@ -264,7 +264,12 @@ var errBreakerOpen = errors.New("circuit breaker open")
 // signal, recorded as failure). When callerCtx is nil the function falls
 // back to the previous behaviour where any context.Canceled/DeadlineExceeded
 // is treated as neutral.
-func callWithBreaker(b *circuitBreaker, callerCtx context.Context, fn func() error) error {
+//
+// neutralIfErr (optional, may be nil) lets callers mark domain-specific
+// errors as neutral for breaker accounting — e.g. authentication errors
+// where N concurrent workers all see a 401 and would otherwise open the
+// breaker before the auth error reaches the caller.
+func callWithBreaker(b *circuitBreaker, callerCtx context.Context, neutralIfErr func(error) bool, fn func() error) error {
 	if b == nil {
 		return fn()
 	}
@@ -273,6 +278,9 @@ func callWithBreaker(b *circuitBreaker, callerCtx context.Context, fn func() err
 	}
 	if err := fn(); err != nil {
 		if isNeutralForBreaker(callerCtx, err) {
+			return err
+		}
+		if neutralIfErr != nil && neutralIfErr(err) {
 			return err
 		}
 		b.RecordFailure()

--- a/internal/pkgcheck/provider/httpclient_test.go
+++ b/internal/pkgcheck/provider/httpclient_test.go
@@ -137,3 +137,57 @@ func TestRetryClient_GivesUp_WrapsErrMaxAttempts(t *testing.T) {
 		t.Fatalf("expected error chain to include errMaxAttempts, got: %v", err)
 	}
 }
+
+func TestCircuitBreaker_OpensAfterConsecutiveFailures(t *testing.T) {
+	cb := newCircuitBreaker(circuitBreakerConfig{
+		Threshold:  3,
+		Window:     time.Second,
+		OpenPeriod: 100 * time.Millisecond,
+	})
+
+	if !cb.Allow() {
+		t.Fatal("breaker should start closed")
+	}
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if !cb.Allow() {
+		t.Fatal("breaker should still be closed after 2 failures")
+	}
+	cb.RecordFailure()
+	if cb.Allow() {
+		t.Fatal("breaker should be open after 3 failures")
+	}
+}
+
+func TestCircuitBreaker_ClosesAfterOpenPeriod(t *testing.T) {
+	cb := newCircuitBreaker(circuitBreakerConfig{
+		Threshold:  2,
+		Window:     time.Second,
+		OpenPeriod: 50 * time.Millisecond,
+	})
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if cb.Allow() {
+		t.Fatal("breaker should be open")
+	}
+	time.Sleep(80 * time.Millisecond)
+	if !cb.Allow() {
+		t.Fatal("breaker should re-close after open period")
+	}
+}
+
+func TestCircuitBreaker_SuccessResetsFailures(t *testing.T) {
+	cb := newCircuitBreaker(circuitBreakerConfig{
+		Threshold:  3,
+		Window:     time.Second,
+		OpenPeriod: 100 * time.Millisecond,
+	})
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordSuccess()
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if !cb.Allow() {
+		t.Fatal("breaker should still be closed: success reset failure count")
+	}
+}

--- a/internal/pkgcheck/provider/httpclient_test.go
+++ b/internal/pkgcheck/provider/httpclient_test.go
@@ -256,13 +256,23 @@ func TestRetryClient_CtxCancelOnFinalAttemptIsNotMaxAttempts(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	// MaxAttempts=2 with backoff long enough to give the cancel goroutine
-	// time to fire between the second attempt's client.Do and the final
-	// return. We pace ourselves with an HTTP handler delay so the second
-	// attempt is in flight when cancel() runs.
+	// We need the cancellation to land BEFORE Do reaches its final return.
+	// A timing-based goroutine is racy; instead, the handler blocks the
+	// second (final) response on a channel that the test closes only after
+	// cancel() has been called. This makes the ordering deterministic:
+	//   1. First request → 500 (no block).
+	//   2. Loop sleeps backoff, second request lands.
+	//   3. Test closes secondReady, handler returns 500.
+	//   4. Loop reaches final-return, ctx.Err() is non-nil → aborted, not max.
 	srvHits := make(chan struct{}, 4)
+	secondReady := make(chan struct{})
+	var hitCount int32
 	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hitCount, 1)
 		srvHits <- struct{}{}
+		if n == 2 {
+			<-secondReady
+		}
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer srv2.Close()
@@ -276,12 +286,10 @@ func TestRetryClient_CtxCancelOnFinalAttemptIsNotMaxAttempts(t *testing.T) {
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv2.URL, nil)
 
 	go func() {
-		// Wait for the second attempt's request to land at the server,
-		// then cancel. By the time the loop reaches the final return,
-		// ctx.Err() is set.
-		<-srvHits
-		<-srvHits
-		cancel()
+		<-srvHits         // first attempt landed at server
+		<-srvHits         // second (final) attempt landed; handler is blocked
+		cancel()          // ensure ctx is cancelled before final return reads ctx.Err()
+		close(secondReady) // unblock handler so client.Do returns 500
 	}()
 
 	_, err := c.Do(req)

--- a/internal/pkgcheck/provider/httpclient_test.go
+++ b/internal/pkgcheck/provider/httpclient_test.go
@@ -303,3 +303,39 @@ func TestRetryClient_CtxCancelOnFinalAttemptIsNotMaxAttempts(t *testing.T) {
 		t.Errorf("ctx cancel on final attempt must not be classified as max-attempts; got %v", err)
 	}
 }
+
+func TestCallWithBreaker_DoesNotRecordCallerCancellation(t *testing.T) {
+	cb := newCircuitBreaker(circuitBreakerConfig{
+		Threshold:  2,
+		Window:     time.Second,
+		OpenPeriod: 100 * time.Millisecond,
+	})
+	// Record one real failure so we're one short of opening.
+	_ = callWithBreaker(cb, func() error { return errors.New("real failure") })
+
+	// Now return a ctx-cancel error N times — the breaker must NOT open.
+	for i := 0; i < 5; i++ {
+		err := callWithBreaker(cb, func() error { return context.Canceled })
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("iteration %d: want context.Canceled, got %v", i, err)
+		}
+	}
+	if !cb.Allow() {
+		t.Fatal("breaker must not have opened from caller-driven cancellations")
+	}
+}
+
+func TestCallWithBreaker_DoesNotRecordDeadlineExceeded(t *testing.T) {
+	cb := newCircuitBreaker(circuitBreakerConfig{
+		Threshold:  2,
+		Window:     time.Second,
+		OpenPeriod: 100 * time.Millisecond,
+	})
+	_ = callWithBreaker(cb, func() error { return errors.New("real failure") })
+	for i := 0; i < 5; i++ {
+		_ = callWithBreaker(cb, func() error { return context.DeadlineExceeded })
+	}
+	if !cb.Allow() {
+		t.Fatal("breaker must not have opened from caller-driven deadline-exceeded")
+	}
+}

--- a/internal/pkgcheck/provider/httpclient_test.go
+++ b/internal/pkgcheck/provider/httpclient_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -87,5 +88,52 @@ func TestRetryClient_GivesUpAfterMaxAttempts(t *testing.T) {
 	if err == nil {
 		resp.Body.Close()
 		t.Fatal("expected error after max attempts, got nil")
+	}
+}
+
+func TestRetryClient_AbortsOnContextCancellation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newRetryClient(retryConfig{
+		MaxAttempts: 5,
+		BaseBackoff: 200 * time.Millisecond,
+		MaxBackoff:  500 * time.Millisecond,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+
+	start := time.Now()
+	_, err := c.Do(req)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected error chain to include context.Canceled, got: %v", err)
+	}
+	// Should abort well before doing 5 attempts × 200ms+ each.
+	if elapsed > 600*time.Millisecond {
+		t.Errorf("retry loop did not abort promptly on ctx cancel; elapsed=%v", elapsed)
+	}
+}
+
+func TestRetryClient_GivesUp_WrapsErrMaxAttempts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	c := newRetryClient(retryConfig{MaxAttempts: 2, BaseBackoff: 1 * time.Millisecond, MaxBackoff: 5 * time.Millisecond})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	_, err := c.Do(req)
+	if !errors.Is(err, errMaxAttempts) {
+		t.Fatalf("expected error chain to include errMaxAttempts, got: %v", err)
 	}
 }

--- a/internal/pkgcheck/provider/httpclient_test.go
+++ b/internal/pkgcheck/provider/httpclient_test.go
@@ -119,6 +119,10 @@ func TestRetryClient_AbortsOnContextCancellation(t *testing.T) {
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("expected error chain to include context.Canceled, got: %v", err)
 	}
+	// Cancellation must NOT be classified as max-attempts exhaustion.
+	if errors.Is(err, errMaxAttempts) {
+		t.Errorf("cancellation should not wrap errMaxAttempts, got: %v", err)
+	}
 	// Should abort well before doing 5 attempts × 200ms+ each.
 	if elapsed > 600*time.Millisecond {
 		t.Errorf("retry loop did not abort promptly on ctx cancel; elapsed=%v", elapsed)

--- a/internal/pkgcheck/provider/httpclient_test.go
+++ b/internal/pkgcheck/provider/httpclient_test.go
@@ -206,14 +206,14 @@ func TestCallWithBreaker_ShortCircuitsWhenOpen(t *testing.T) {
 	// Trip the breaker by recording two failures.
 	calls := 0
 	failing := func() error { calls++; return errors.New("boom") }
-	_ = callWithBreaker(cb, failing)
-	_ = callWithBreaker(cb, failing)
+	_ = callWithBreaker(cb, nil, failing)
+	_ = callWithBreaker(cb, nil, failing)
 	if calls != 2 {
 		t.Fatalf("want 2 fn invocations, got %d", calls)
 	}
 
 	// Now the breaker is open — fn must not be called.
-	err := callWithBreaker(cb, failing)
+	err := callWithBreaker(cb, nil, failing)
 	if !errors.Is(err, errBreakerOpen) {
 		t.Errorf("expected errBreakerOpen, got %v", err)
 	}
@@ -228,11 +228,11 @@ func TestCallWithBreaker_RecordsSuccessAndError(t *testing.T) {
 		Window:     time.Second,
 		OpenPeriod: 100 * time.Millisecond,
 	})
-	if err := callWithBreaker(cb, func() error { return nil }); err != nil {
+	if err := callWithBreaker(cb, nil, func() error { return nil }); err != nil {
 		t.Fatalf("success path returned error: %v", err)
 	}
 	want := errors.New("boom")
-	got := callWithBreaker(cb, func() error { return want })
+	got := callWithBreaker(cb, nil, func() error { return want })
 	if !errors.Is(got, want) {
 		t.Errorf("error path should return fn's error, got %v", got)
 	}
@@ -240,7 +240,7 @@ func TestCallWithBreaker_RecordsSuccessAndError(t *testing.T) {
 
 func TestCallWithBreaker_NilBreakerPassesThrough(t *testing.T) {
 	calls := 0
-	err := callWithBreaker(nil, func() error { calls++; return nil })
+	err := callWithBreaker(nil, nil, func() error { calls++; return nil })
 	if err != nil {
 		t.Errorf("nil breaker should not error, got %v", err)
 	}
@@ -311,11 +311,11 @@ func TestCallWithBreaker_DoesNotRecordCallerCancellation(t *testing.T) {
 		OpenPeriod: 100 * time.Millisecond,
 	})
 	// Record one real failure so we're one short of opening.
-	_ = callWithBreaker(cb, func() error { return errors.New("real failure") })
+	_ = callWithBreaker(cb, nil, func() error { return errors.New("real failure") })
 
 	// Now return a ctx-cancel error N times — the breaker must NOT open.
 	for i := 0; i < 5; i++ {
-		err := callWithBreaker(cb, func() error { return context.Canceled })
+		err := callWithBreaker(cb, nil, func() error { return context.Canceled })
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("iteration %d: want context.Canceled, got %v", i, err)
 		}
@@ -331,11 +331,53 @@ func TestCallWithBreaker_DoesNotRecordDeadlineExceeded(t *testing.T) {
 		Window:     time.Second,
 		OpenPeriod: 100 * time.Millisecond,
 	})
-	_ = callWithBreaker(cb, func() error { return errors.New("real failure") })
+	_ = callWithBreaker(cb, nil, func() error { return errors.New("real failure") })
 	for i := 0; i < 5; i++ {
-		_ = callWithBreaker(cb, func() error { return context.DeadlineExceeded })
+		_ = callWithBreaker(cb, nil, func() error { return context.DeadlineExceeded })
 	}
 	if !cb.Allow() {
 		t.Fatal("breaker must not have opened from caller-driven deadline-exceeded")
+	}
+}
+
+func TestCallWithBreaker_ProviderOwnTimeoutRecordsFailure(t *testing.T) {
+	cb := newCircuitBreaker(circuitBreakerConfig{
+		Threshold:  2,
+		Window:     time.Second,
+		OpenPeriod: 100 * time.Millisecond,
+	})
+	// Caller context never gets cancelled — only a derived "provider-own"
+	// timeout fires. The breaker SHOULD record this as a failure because
+	// the slowness is the provider's, not the caller's.
+	parentCtx := context.Background()
+	deadline := func() error {
+		// Simulate a derived timeout context that fired.
+		return context.DeadlineExceeded
+	}
+	if err := callWithBreaker(cb, parentCtx, deadline); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want DeadlineExceeded, got %v", err)
+	}
+	if err := callWithBreaker(cb, parentCtx, deadline); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("second call: want DeadlineExceeded, got %v", err)
+	}
+	// Two provider-own timeouts at threshold=2 must open the breaker.
+	if cb.Allow() {
+		t.Fatal("breaker should be open after two provider-own timeouts")
+	}
+}
+
+func TestCallWithBreaker_CallerCtxCancelledIsNeutral(t *testing.T) {
+	cb := newCircuitBreaker(circuitBreakerConfig{
+		Threshold:  2,
+		Window:     time.Second,
+		OpenPeriod: 100 * time.Millisecond,
+	})
+	parentCtx, cancel := context.WithCancel(context.Background())
+	cancel() // caller cancelled before fn runs
+	for i := 0; i < 5; i++ {
+		_ = callWithBreaker(cb, parentCtx, func() error { return context.Canceled })
+	}
+	if !cb.Allow() {
+		t.Fatal("breaker must not have opened from caller-driven cancellation")
 	}
 }

--- a/internal/pkgcheck/provider/httpclient_test.go
+++ b/internal/pkgcheck/provider/httpclient_test.go
@@ -248,3 +248,50 @@ func TestCallWithBreaker_NilBreakerPassesThrough(t *testing.T) {
 		t.Errorf("fn should have run; calls=%d", calls)
 	}
 }
+
+func TestRetryClient_CtxCancelOnFinalAttemptIsNotMaxAttempts(t *testing.T) {
+	// Server always returns 500 so every attempt is a retry trigger.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	// MaxAttempts=2 with backoff long enough to give the cancel goroutine
+	// time to fire between the second attempt's client.Do and the final
+	// return. We pace ourselves with an HTTP handler delay so the second
+	// attempt is in flight when cancel() runs.
+	srvHits := make(chan struct{}, 4)
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srvHits <- struct{}{}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv2.Close()
+
+	c := newRetryClient(retryConfig{
+		MaxAttempts: 2,
+		BaseBackoff: 50 * time.Millisecond,
+		MaxBackoff:  100 * time.Millisecond,
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv2.URL, nil)
+
+	go func() {
+		// Wait for the second attempt's request to land at the server,
+		// then cancel. By the time the loop reaches the final return,
+		// ctx.Err() is set.
+		<-srvHits
+		<-srvHits
+		cancel()
+	}()
+
+	_, err := c.Do(req)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled in chain, got %v", err)
+	}
+	if errors.Is(err, errMaxAttempts) {
+		t.Errorf("ctx cancel on final attempt must not be classified as max-attempts; got %v", err)
+	}
+}

--- a/internal/pkgcheck/provider/httpclient_test.go
+++ b/internal/pkgcheck/provider/httpclient_test.go
@@ -1,0 +1,91 @@
+package provider
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRetryClient_Retries5xxThenSucceeds(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	}))
+	defer srv.Close()
+
+	c := newRetryClient(retryConfig{
+		MaxAttempts: 5,
+		BaseBackoff: 1 * time.Millisecond,
+		MaxBackoff:  10 * time.Millisecond,
+	})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("want 3 attempts, got %d", got)
+	}
+}
+
+func TestRetryClient_RespectsRetryAfterHeader(t *testing.T) {
+	start := time.Now()
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := newRetryClient(retryConfig{
+		MaxAttempts:       3,
+		BaseBackoff:       1 * time.Millisecond,
+		MaxBackoff:        10 * time.Second,
+		RespectRetryAfter: true,
+	})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+	resp, err := c.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	resp.Body.Close()
+	elapsed := time.Since(start)
+	if elapsed < 900*time.Millisecond {
+		t.Fatalf("expected ~1s wait for Retry-After, got %v", elapsed)
+	}
+}
+
+func TestRetryClient_GivesUpAfterMaxAttempts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newRetryClient(retryConfig{MaxAttempts: 3, BaseBackoff: 1 * time.Millisecond, MaxBackoff: 5 * time.Millisecond})
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, strings.NewReader(""))
+	resp, err := c.Do(req)
+	if err == nil {
+		resp.Body.Close()
+		t.Fatal("expected error after max attempts, got nil")
+	}
+}

--- a/internal/pkgcheck/provider/httpclient_test.go
+++ b/internal/pkgcheck/provider/httpclient_test.go
@@ -206,14 +206,14 @@ func TestCallWithBreaker_ShortCircuitsWhenOpen(t *testing.T) {
 	// Trip the breaker by recording two failures.
 	calls := 0
 	failing := func() error { calls++; return errors.New("boom") }
-	_ = callWithBreaker(cb, nil, failing)
-	_ = callWithBreaker(cb, nil, failing)
+	_ = callWithBreaker(cb, nil, nil, failing)
+	_ = callWithBreaker(cb, nil, nil, failing)
 	if calls != 2 {
 		t.Fatalf("want 2 fn invocations, got %d", calls)
 	}
 
 	// Now the breaker is open — fn must not be called.
-	err := callWithBreaker(cb, nil, failing)
+	err := callWithBreaker(cb, nil, nil, failing)
 	if !errors.Is(err, errBreakerOpen) {
 		t.Errorf("expected errBreakerOpen, got %v", err)
 	}
@@ -228,11 +228,11 @@ func TestCallWithBreaker_RecordsSuccessAndError(t *testing.T) {
 		Window:     time.Second,
 		OpenPeriod: 100 * time.Millisecond,
 	})
-	if err := callWithBreaker(cb, nil, func() error { return nil }); err != nil {
+	if err := callWithBreaker(cb, nil, nil, func() error { return nil }); err != nil {
 		t.Fatalf("success path returned error: %v", err)
 	}
 	want := errors.New("boom")
-	got := callWithBreaker(cb, nil, func() error { return want })
+	got := callWithBreaker(cb, nil, nil, func() error { return want })
 	if !errors.Is(got, want) {
 		t.Errorf("error path should return fn's error, got %v", got)
 	}
@@ -240,7 +240,7 @@ func TestCallWithBreaker_RecordsSuccessAndError(t *testing.T) {
 
 func TestCallWithBreaker_NilBreakerPassesThrough(t *testing.T) {
 	calls := 0
-	err := callWithBreaker(nil, nil, func() error { calls++; return nil })
+	err := callWithBreaker(nil, nil, nil, func() error { calls++; return nil })
 	if err != nil {
 		t.Errorf("nil breaker should not error, got %v", err)
 	}
@@ -311,11 +311,11 @@ func TestCallWithBreaker_DoesNotRecordCallerCancellation(t *testing.T) {
 		OpenPeriod: 100 * time.Millisecond,
 	})
 	// Record one real failure so we're one short of opening.
-	_ = callWithBreaker(cb, nil, func() error { return errors.New("real failure") })
+	_ = callWithBreaker(cb, nil, nil, func() error { return errors.New("real failure") })
 
 	// Now return a ctx-cancel error N times — the breaker must NOT open.
 	for i := 0; i < 5; i++ {
-		err := callWithBreaker(cb, nil, func() error { return context.Canceled })
+		err := callWithBreaker(cb, nil, nil, func() error { return context.Canceled })
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("iteration %d: want context.Canceled, got %v", i, err)
 		}
@@ -331,9 +331,9 @@ func TestCallWithBreaker_DoesNotRecordDeadlineExceeded(t *testing.T) {
 		Window:     time.Second,
 		OpenPeriod: 100 * time.Millisecond,
 	})
-	_ = callWithBreaker(cb, nil, func() error { return errors.New("real failure") })
+	_ = callWithBreaker(cb, nil, nil, func() error { return errors.New("real failure") })
 	for i := 0; i < 5; i++ {
-		_ = callWithBreaker(cb, nil, func() error { return context.DeadlineExceeded })
+		_ = callWithBreaker(cb, nil, nil, func() error { return context.DeadlineExceeded })
 	}
 	if !cb.Allow() {
 		t.Fatal("breaker must not have opened from caller-driven deadline-exceeded")
@@ -354,10 +354,10 @@ func TestCallWithBreaker_ProviderOwnTimeoutRecordsFailure(t *testing.T) {
 		// Simulate a derived timeout context that fired.
 		return context.DeadlineExceeded
 	}
-	if err := callWithBreaker(cb, parentCtx, deadline); !errors.Is(err, context.DeadlineExceeded) {
+	if err := callWithBreaker(cb, parentCtx, nil, deadline); !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("want DeadlineExceeded, got %v", err)
 	}
-	if err := callWithBreaker(cb, parentCtx, deadline); !errors.Is(err, context.DeadlineExceeded) {
+	if err := callWithBreaker(cb, parentCtx, nil, deadline); !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("second call: want DeadlineExceeded, got %v", err)
 	}
 	// Two provider-own timeouts at threshold=2 must open the breaker.
@@ -375,7 +375,7 @@ func TestCallWithBreaker_CallerCtxCancelledIsNeutral(t *testing.T) {
 	parentCtx, cancel := context.WithCancel(context.Background())
 	cancel() // caller cancelled before fn runs
 	for i := 0; i < 5; i++ {
-		_ = callWithBreaker(cb, parentCtx, func() error { return context.Canceled })
+		_ = callWithBreaker(cb, parentCtx, nil, func() error { return context.Canceled })
 	}
 	if !cb.Allow() {
 		t.Fatal("breaker must not have opened from caller-driven cancellation")

--- a/internal/pkgcheck/provider/httpclient_test.go
+++ b/internal/pkgcheck/provider/httpclient_test.go
@@ -195,3 +195,56 @@ func TestCircuitBreaker_SuccessResetsFailures(t *testing.T) {
 		t.Fatal("breaker should still be closed: success reset failure count")
 	}
 }
+
+func TestCallWithBreaker_ShortCircuitsWhenOpen(t *testing.T) {
+	cb := newCircuitBreaker(circuitBreakerConfig{
+		Threshold:  2,
+		Window:     time.Second,
+		OpenPeriod: 100 * time.Millisecond,
+	})
+
+	// Trip the breaker by recording two failures.
+	calls := 0
+	failing := func() error { calls++; return errors.New("boom") }
+	_ = callWithBreaker(cb, failing)
+	_ = callWithBreaker(cb, failing)
+	if calls != 2 {
+		t.Fatalf("want 2 fn invocations, got %d", calls)
+	}
+
+	// Now the breaker is open — fn must not be called.
+	err := callWithBreaker(cb, failing)
+	if !errors.Is(err, errBreakerOpen) {
+		t.Errorf("expected errBreakerOpen, got %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("fn must not have been invoked while breaker is open; calls=%d", calls)
+	}
+}
+
+func TestCallWithBreaker_RecordsSuccessAndError(t *testing.T) {
+	cb := newCircuitBreaker(circuitBreakerConfig{
+		Threshold:  3,
+		Window:     time.Second,
+		OpenPeriod: 100 * time.Millisecond,
+	})
+	if err := callWithBreaker(cb, func() error { return nil }); err != nil {
+		t.Fatalf("success path returned error: %v", err)
+	}
+	want := errors.New("boom")
+	got := callWithBreaker(cb, func() error { return want })
+	if !errors.Is(got, want) {
+		t.Errorf("error path should return fn's error, got %v", got)
+	}
+}
+
+func TestCallWithBreaker_NilBreakerPassesThrough(t *testing.T) {
+	calls := 0
+	err := callWithBreaker(nil, func() error { calls++; return nil })
+	if err != nil {
+		t.Errorf("nil breaker should not error, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("fn should have run; calls=%d", calls)
+	}
+}

--- a/internal/pkgcheck/provider/local.go
+++ b/internal/pkgcheck/provider/local.go
@@ -20,6 +20,13 @@ func (p *localProvider) Name() string {
 	return "local"
 }
 
+// IsLocal implements pkgcheck.LocalProvider. The local provider runs entirely
+// in-process and never makes network calls, so private packages should still
+// receive license/metadata checks regardless of privacy filter settings.
+func (p *localProvider) IsLocal() bool {
+	return true
+}
+
 func (p *localProvider) Capabilities() []pkgcheck.FindingType {
 	return []pkgcheck.FindingType{pkgcheck.FindingLicense}
 }

--- a/internal/pkgcheck/provider/snyk.go
+++ b/internal/pkgcheck/provider/snyk.go
@@ -3,40 +3,53 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/agentsh/agentsh/internal/pkgcheck"
 )
 
 const (
-	defaultSnykBaseURL = "https://api.snyk.io"
-	defaultSnykTimeout = 30 * time.Second
+	defaultSnykBaseURL    = "https://api.snyk.io"
+	defaultSnykTimeout    = 30 * time.Second
+	defaultSnykConcurrency = 16
 )
 
 // SnykConfig configures the Snyk vulnerability and license provider.
 type SnykConfig struct {
-	BaseURL string
-	Timeout time.Duration
-	APIKey  string
-	OrgID   string
+	BaseURL     string
+	Timeout     time.Duration
+	APIKey      string
+	OrgID       string
+	Concurrency int // max concurrent per-package fetches; default 16
 }
 
 // snykProvider queries the Snyk API for vulnerability and license findings.
 type snykProvider struct {
-	baseURL string
-	client  *http.Client
-	apiKey  string
-	orgID   string
+	baseURL     string
+	client      *retryClient
+	breaker     *circuitBreaker
+	apiKey      string
+	orgID       string
+	timeout     time.Duration
+	concurrency int
 }
 
 // NewSnykProvider returns a CheckProvider that queries Snyk for vulnerabilities
 // and license issues.
 func NewSnykProvider(cfg SnykConfig) pkgcheck.CheckProvider {
+	return newSnykProviderForTest(cfg, circuitBreakerConfig{})
+}
+
+// newSnykProviderForTest constructs a snykProvider with a custom breaker
+// config, allowing tests to inject short thresholds and windows.
+func newSnykProviderForTest(cfg SnykConfig, breakerCfg circuitBreakerConfig) *snykProvider {
 	baseURL := cfg.BaseURL
 	if baseURL == "" {
 		baseURL = defaultSnykBaseURL
@@ -45,11 +58,23 @@ func NewSnykProvider(cfg SnykConfig) pkgcheck.CheckProvider {
 	if timeout == 0 {
 		timeout = defaultSnykTimeout
 	}
+	concurrency := cfg.Concurrency
+	if concurrency <= 0 {
+		concurrency = defaultSnykConcurrency
+	}
 	return &snykProvider{
 		baseURL: strings.TrimRight(baseURL, "/"),
-		client:  &http.Client{Timeout: timeout},
-		apiKey:  cfg.APIKey,
-		orgID:   cfg.OrgID,
+		client: newRetryClient(retryConfig{
+			MaxAttempts:       3,
+			BaseBackoff:       200 * time.Millisecond,
+			MaxBackoff:        2 * time.Second,
+			RespectRetryAfter: true,
+		}),
+		breaker:     newCircuitBreaker(breakerCfg),
+		apiKey:      cfg.APIKey,
+		orgID:       cfg.OrgID,
+		timeout:     timeout,
+		concurrency: concurrency,
 	}
 }
 
@@ -67,18 +92,18 @@ type snykIssuesResponse struct {
 }
 
 type snykIssue struct {
-	ID         string          `json:"id"`
-	Type       string          `json:"type"`
-	Attributes snykAttributes  `json:"attributes"`
+	ID         string         `json:"id"`
+	Type       string         `json:"type"`
+	Attributes snykAttributes `json:"attributes"`
 }
 
 type snykAttributes struct {
-	Title       string       `json:"title"`
-	Description string       `json:"description,omitempty"`
-	Severity    string       `json:"severity"`
-	Type        string       `json:"type"`
-	CVSS        *snykCVSS    `json:"cvss,omitempty"`
-	Slots       *snykSlots   `json:"slots,omitempty"`
+	Title       string     `json:"title"`
+	Description string     `json:"description,omitempty"`
+	Severity    string     `json:"severity"`
+	Type        string     `json:"type"`
+	CVSS        *snykCVSS  `json:"cvss,omitempty"`
+	Slots       *snykSlots `json:"slots,omitempty"`
 }
 
 type snykCVSS struct {
@@ -96,6 +121,12 @@ type snykReference struct {
 	Title string `json:"title,omitempty"`
 }
 
+// pkgResult holds the per-package outcome from the concurrent fan-out.
+type pkgResult struct {
+	findings []pkgcheck.Finding
+	err      error
+}
+
 func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest) (*pkgcheck.CheckResponse, error) {
 	if p.apiKey == "" {
 		return nil, fmt.Errorf("snyk: API key is required")
@@ -107,27 +138,81 @@ func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest
 	start := time.Now()
 	ecosystem := mapEcosystemSnyk(req.Ecosystem)
 
+	n := len(req.Packages)
+	results := make([]pkgResult, n)
+
+	// Semaphore channel for bounded concurrency.
+	sem := make(chan struct{}, p.concurrency)
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	for i, pkg := range req.Packages {
+		i, pkg := i, pkg // capture
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			// Apply per-request timeout only on the HTTP call, NOT on callWithBreaker.
+			reqCtx := ctx
+			var cancel context.CancelFunc
+			if p.timeout > 0 {
+				reqCtx, cancel = context.WithTimeout(ctx, p.timeout)
+				defer cancel()
+			}
+
+			var findings []pkgcheck.Finding
+			err := callWithBreaker(p.breaker, ctx, func() error {
+				var ferr error
+				findings, ferr = p.fetchIssues(reqCtx, ecosystem, pkg)
+				return ferr
+			})
+			results[i] = pkgResult{findings: findings, err: err}
+		}()
+	}
+	wg.Wait()
+
+	// Merge results; detect auth errors and breaker-open conditions.
 	var allFindings []pkgcheck.Finding
 	var partial bool
 	var errCount int
+	var breakerErr error
 
-	for _, pkg := range req.Packages {
-		findings, err := p.fetchIssues(ctx, ecosystem, pkg)
-		if err != nil {
+	for _, r := range results {
+		if r.err != nil {
+			// Auth errors are fail-fast — return immediately.
+			if isSnykAuthError(r.err) {
+				return nil, fmt.Errorf("snyk: authentication failed: %w", r.err)
+			}
 			errCount++
 			partial = true
-			// Check for authentication errors -- return immediately.
-			if isSnykAuthError(err) {
-				return nil, fmt.Errorf("snyk: authentication failed: %w", err)
+			if errors.Is(r.err, errBreakerOpen) {
+				breakerErr = r.err
 			}
 			continue
 		}
-		allFindings = append(allFindings, findings...)
+		allFindings = append(allFindings, r.findings...)
 	}
 
 	// If ALL packages failed, return an error instead of a partial empty response.
-	if errCount > 0 && errCount == len(req.Packages) {
+	if errCount > 0 && errCount == n {
+		if breakerErr != nil {
+			return &pkgcheck.CheckResponse{
+				Provider: p.Name(),
+				Metadata: pkgcheck.ResponseMetadata{
+					Duration: time.Since(start),
+					Partial:  true,
+					Error:    "circuit breaker open",
+				},
+			}, breakerErr
+		}
 		return nil, fmt.Errorf("snyk: all %d packages failed checks", errCount)
+	}
+
+	errMsg := ""
+	if breakerErr != nil {
+		errMsg = "circuit breaker open"
 	}
 
 	return &pkgcheck.CheckResponse{
@@ -136,6 +221,7 @@ func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest
 		Metadata: pkgcheck.ResponseMetadata{
 			Duration: time.Since(start),
 			Partial:  partial,
+			Error:    errMsg,
 		},
 	}, nil
 }
@@ -290,6 +376,6 @@ func (e *snykAuthError) Error() string {
 
 // isSnykAuthError checks if an error is a Snyk authentication error (401/403).
 func isSnykAuthError(err error) bool {
-	_, ok := err.(*snykAuthError)
-	return ok
+	var authErr *snykAuthError
+	return errors.As(err, &authErr)
 }

--- a/internal/pkgcheck/provider/snyk.go
+++ b/internal/pkgcheck/provider/snyk.go
@@ -298,7 +298,15 @@ func (p *snykProvider) fetchIssues(ctx context.Context, ecosystem string, pkg pk
 	}
 
 	var issuesResp snykIssuesResponse
-	if err := json.NewDecoder(resp.Body).Decode(&issuesResp); err != nil {
+	// Use ReadAll + Unmarshal rather than NewDecoder.Decode — Decode accepts
+	// a valid JSON value followed by trailing garbage, so a body like
+	// `{"data":[]} junk` would silently parse as a successful empty response.
+	// Unmarshal is strict and errors on trailing data.
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("snyk: read response: %w", err)
+	}
+	if err := json.Unmarshal(respBody, &issuesResp); err != nil {
 		return nil, fmt.Errorf("snyk: decode response: %w", err)
 	}
 

--- a/internal/pkgcheck/provider/snyk.go
+++ b/internal/pkgcheck/provider/snyk.go
@@ -184,7 +184,7 @@ func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest
 			}
 
 			var findings []pkgcheck.Finding
-			err := callWithBreaker(p.breaker, batchCtx, func() error {
+			err := callWithBreaker(p.breaker, batchCtx, isSnykAuthError, func() error {
 				var ferr error
 				findings, ferr = p.fetchIssues(reqCtx, ecosystem, pkg)
 				return ferr

--- a/internal/pkgcheck/provider/snyk.go
+++ b/internal/pkgcheck/provider/snyk.go
@@ -121,12 +121,6 @@ type snykReference struct {
 	Title string `json:"title,omitempty"`
 }
 
-// pkgResult holds the per-package outcome from the concurrent fan-out.
-type pkgResult struct {
-	findings []pkgcheck.Finding
-	err      error
-}
-
 func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest) (*pkgcheck.CheckResponse, error) {
 	if p.apiKey == "" {
 		return nil, fmt.Errorf("snyk: API key is required")
@@ -139,61 +133,86 @@ func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest
 	ecosystem := mapEcosystemSnyk(req.Ecosystem)
 
 	n := len(req.Packages)
-	results := make([]pkgResult, n)
+
+	// batchCtx allows workers to cancel each other on auth errors.
+	batchCtx, cancelBatch := context.WithCancel(ctx)
+	defer cancelBatch()
+
+	var (
+		mu         sync.Mutex
+		allFindings []pkgcheck.Finding
+		errCount   int
+		breakerErr error
+		authErr    error // first auth error wins; non-nil short-circuits result
+	)
 
 	// Semaphore channel for bounded concurrency.
 	sem := make(chan struct{}, p.concurrency)
 
 	var wg sync.WaitGroup
-	wg.Add(n)
 
-	for i, pkg := range req.Packages {
-		i, pkg := i, pkg // capture
+	for _, pkg := range req.Packages {
+		// Stop scheduling new work once batch is cancelled (e.g., auth failure).
+		if batchCtx.Err() != nil {
+			mu.Lock()
+			errCount++
+			mu.Unlock()
+			continue
+		}
+
+		wg.Add(1)
 		sem <- struct{}{}
+		pkg := pkg // capture
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
 
+			// If an earlier worker already cancelled, exit immediately.
+			if batchCtx.Err() != nil {
+				mu.Lock()
+				errCount++
+				mu.Unlock()
+				return
+			}
+
 			// Apply per-request timeout only on the HTTP call, NOT on callWithBreaker.
-			reqCtx := ctx
+			reqCtx := batchCtx
 			var cancel context.CancelFunc
 			if p.timeout > 0 {
-				reqCtx, cancel = context.WithTimeout(ctx, p.timeout)
+				reqCtx, cancel = context.WithTimeout(batchCtx, p.timeout)
 				defer cancel()
 			}
 
 			var findings []pkgcheck.Finding
-			err := callWithBreaker(p.breaker, ctx, func() error {
+			err := callWithBreaker(p.breaker, batchCtx, func() error {
 				var ferr error
 				findings, ferr = p.fetchIssues(reqCtx, ecosystem, pkg)
 				return ferr
 			})
-			results[i] = pkgResult{findings: findings, err: err}
+
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil {
+				errCount++
+				if isSnykAuthError(err) && authErr == nil {
+					authErr = err
+					cancelBatch() // signal other workers to bail
+				}
+				if errors.Is(err, errBreakerOpen) {
+					breakerErr = err
+				}
+				return
+			}
+			allFindings = append(allFindings, findings...)
 		}()
 	}
 	wg.Wait()
 
-	// Merge results; detect auth errors and breaker-open conditions.
-	var allFindings []pkgcheck.Finding
-	var partial bool
-	var errCount int
-	var breakerErr error
-
-	for _, r := range results {
-		if r.err != nil {
-			// Auth errors are fail-fast — return immediately.
-			if isSnykAuthError(r.err) {
-				return nil, fmt.Errorf("snyk: authentication failed: %w", r.err)
-			}
-			errCount++
-			partial = true
-			if errors.Is(r.err, errBreakerOpen) {
-				breakerErr = r.err
-			}
-			continue
-		}
-		allFindings = append(allFindings, r.findings...)
+	if authErr != nil {
+		return nil, fmt.Errorf("snyk: authentication failed: %w", authErr)
 	}
+
+	partial := errCount > 0
 
 	// If ALL packages failed, return an error instead of a partial empty response.
 	if errCount > 0 && errCount == n {

--- a/internal/pkgcheck/provider/snyk.go
+++ b/internal/pkgcheck/provider/snyk.go
@@ -256,7 +256,7 @@ func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest
 		errMsg = "circuit breaker open"
 	}
 
-	return &pkgcheck.CheckResponse{
+	resp := &pkgcheck.CheckResponse{
 		Provider: p.Name(),
 		Findings: allFindings,
 		Metadata: pkgcheck.ResponseMetadata{
@@ -264,7 +264,18 @@ func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest
 			Partial:  partial,
 			Error:    errMsg,
 		},
-	}, nil
+	}
+	if partial {
+		// Surface the partial outcome as a provider error so the orchestrator
+		// applies the configured on_failure policy. Without this the verdict
+		// looks clean to the caller even though some packages weren't scanned.
+		why := errMsg
+		if why == "" {
+			why = fmt.Sprintf("%d/%d packages failed", errCount, n)
+		}
+		return resp, fmt.Errorf("snyk: partial batch: %s", why)
+	}
+	return resp, nil
 }
 
 func (p *snykProvider) fetchIssues(ctx context.Context, ecosystem string, pkg pkgcheck.PackageRef) ([]pkgcheck.Finding, error) {

--- a/internal/pkgcheck/provider/snyk.go
+++ b/internal/pkgcheck/provider/snyk.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/agentsh/agentsh/internal/pkgcheck"
@@ -138,11 +139,16 @@ func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest
 	batchCtx, cancelBatch := context.WithCancel(ctx)
 	defer cancelBatch()
 
+	// authErr is stored atomically so that a concurrent worker observing the
+	// batchCtx cancellation cannot race with the worker that set the error.
+	// CompareAndSwap ensures exactly one auth error is recorded; the pointer
+	// indirection is required because atomic.Pointer needs a concrete type.
+	var authErr atomic.Pointer[error]
+
 	var (
 		mu         sync.Mutex
 		errCount   int
 		breakerErr error
-		authErr    error // first auth error wins; non-nil short-circuits result
 	)
 
 	// Findings are stored per package index so the final order matches the
@@ -207,9 +213,16 @@ func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest
 			defer mu.Unlock()
 			if err != nil {
 				errCount++
-				if isSnykAuthError(err) && authErr == nil {
-					authErr = err
-					cancelBatch() // signal other workers to bail
+				if isSnykAuthError(err) {
+					// Store atomically BEFORE cancelling so concurrent workers
+					// observing the cancellation cannot beat us to the merged
+					// result. CompareAndSwap ensures only the first auth error
+					// wins; subsequent ones are dropped (any auth error serves
+					// as the fail-fast signal).
+					e := err
+					if authErr.CompareAndSwap(nil, &e) {
+						cancelBatch() // signal other workers to bail
+					}
 				}
 				if errors.Is(err, errBreakerOpen) {
 					breakerErr = err
@@ -230,8 +243,8 @@ func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest
 		}
 	}
 
-	if authErr != nil {
-		return nil, fmt.Errorf("snyk: authentication failed: %w", authErr)
+	if ae := authErr.Load(); ae != nil {
+		return nil, fmt.Errorf("snyk: authentication failed: %w", *ae)
 	}
 
 	partial := errCount > 0

--- a/internal/pkgcheck/provider/snyk.go
+++ b/internal/pkgcheck/provider/snyk.go
@@ -140,18 +140,21 @@ func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest
 
 	var (
 		mu         sync.Mutex
-		allFindings []pkgcheck.Finding
 		errCount   int
 		breakerErr error
 		authErr    error // first auth error wins; non-nil short-circuits result
 	)
+
+	// Findings are stored per package index so the final order matches the
+	// input order regardless of worker completion order.
+	perPkgFindings := make([][]pkgcheck.Finding, n)
 
 	// Semaphore channel for bounded concurrency.
 	sem := make(chan struct{}, p.concurrency)
 
 	var wg sync.WaitGroup
 
-	for _, pkg := range req.Packages {
+	for i, pkg := range req.Packages {
 		// Stop scheduling new work once batch is cancelled (e.g., auth failure).
 		if batchCtx.Err() != nil {
 			mu.Lock()
@@ -162,7 +165,7 @@ func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest
 
 		wg.Add(1)
 		sem <- struct{}{}
-		pkg := pkg // capture
+		i, pkg := i, pkg // capture
 		go func() {
 			defer wg.Done()
 			defer func() { <-sem }()
@@ -203,10 +206,19 @@ func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest
 				}
 				return
 			}
-			allFindings = append(allFindings, findings...)
+			perPkgFindings[i] = findings
 		}()
 	}
 	wg.Wait()
+
+	// Merge per-package findings in input order. perPkgFindings[i] is nil
+	// for packages whose worker errored, which is fine — we skip nil entries.
+	var allFindings []pkgcheck.Finding
+	for _, fs := range perPkgFindings {
+		if len(fs) > 0 {
+			allFindings = append(allFindings, fs...)
+		}
+	}
 
 	if authErr != nil {
 		return nil, fmt.Errorf("snyk: authentication failed: %w", authErr)

--- a/internal/pkgcheck/provider/snyk.go
+++ b/internal/pkgcheck/provider/snyk.go
@@ -163,8 +163,18 @@ func (p *snykProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckRequest
 			continue
 		}
 
+		// Acquire a semaphore slot, but bail out promptly if the batch is
+		// cancelled while we're waiting (e.g., all current workers are hung).
+		select {
+		case sem <- struct{}{}:
+		case <-batchCtx.Done():
+			mu.Lock()
+			errCount++
+			mu.Unlock()
+			continue
+		}
+
 		wg.Add(1)
-		sem <- struct{}{}
 		i, pkg := i, pkg // capture
 		go func() {
 			defer wg.Done()

--- a/internal/pkgcheck/provider/snyk_test.go
+++ b/internal/pkgcheck/provider/snyk_test.go
@@ -333,3 +333,48 @@ func TestSnykProvider_AuthErrorIsFailFast(t *testing.T) {
 		t.Errorf("auth error must short-circuit fan-out; hits=%d (want < 32)", hits.Load())
 	}
 }
+
+func TestSnykProvider_AuthErrorDoesNotPoisonBreaker(t *testing.T) {
+	// All requests return 401. Configure breaker with threshold=2 — without
+	// the neutral-error predicate, two concurrent auth errors would open the
+	// breaker. With the fix, auth errors are neutral and the breaker stays
+	// closed; subsequent calls return the auth error, not "circuit breaker open."
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"errors":[{"detail":"unauthorized"}]}`))
+	}))
+	defer srv.Close()
+
+	p := newSnykProviderForTest(SnykConfig{
+		BaseURL:     srv.URL,
+		APIKey:      "bad",
+		OrgID:       "org",
+		Concurrency: 4,
+	}, circuitBreakerConfig{
+		Threshold:  2,
+		Window:     time.Second,
+		OpenPeriod: 200 * time.Millisecond,
+	})
+
+	// Three back-to-back batches with bad creds. Each must surface an
+	// authentication error, never "circuit breaker open."
+	for i := 0; i < 3; i++ {
+		_, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+			Ecosystem: pkgcheck.EcosystemNPM,
+			Packages: []pkgcheck.PackageRef{
+				{Name: "foo", Version: "1"},
+				{Name: "bar", Version: "1"},
+				{Name: "baz", Version: "1"},
+			},
+		})
+		if err == nil {
+			t.Fatalf("iteration %d: expected error", i)
+		}
+		if !strings.Contains(err.Error(), "authentication failed") {
+			t.Fatalf("iteration %d: want authentication error, got %v", i, err)
+		}
+		if errors.Is(err, errBreakerOpen) {
+			t.Fatalf("iteration %d: auth error must not open breaker; got %v", i, err)
+		}
+	}
+}

--- a/internal/pkgcheck/provider/snyk_test.go
+++ b/internal/pkgcheck/provider/snyk_test.go
@@ -407,3 +407,56 @@ func TestSnykProvider_AuthErrorDoesNotPoisonBreaker(t *testing.T) {
 		}
 	}
 }
+
+func TestSnykProvider_FindingsOrderMatchesInputOrder(t *testing.T) {
+	// Different per-package response delays force concurrent workers to
+	// complete in a different order than they started. The merged findings
+	// must still come out in input order.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The package name is in the URL path: /rest/orgs/{org}/packages/npm%2F{name}/issues
+		var sleepMs time.Duration
+		if strings.Contains(r.URL.Path, "fast") {
+			sleepMs = 5 * time.Millisecond
+		} else {
+			sleepMs = 60 * time.Millisecond
+		}
+		time.Sleep(sleepMs)
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		// One finding per package, with the package name embedded in the title
+		// so we can assert ordering at the finding level.
+		_, _ = w.Write([]byte(`{"data":[{
+			"id":"X",
+			"type":"issue",
+			"attributes":{"title":"` + r.URL.Path + `","severity":"low","type":"package_vulnerability"}
+		}]}`))
+	}))
+	defer srv.Close()
+
+	p := NewSnykProvider(SnykConfig{
+		BaseURL:     srv.URL,
+		APIKey:      "test",
+		OrgID:       "org",
+		Concurrency: 4,
+	})
+	resp, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages: []pkgcheck.PackageRef{
+			{Name: "slow-1", Version: "1"},
+			{Name: "fast-1", Version: "1"},
+			{Name: "slow-2", Version: "1"},
+			{Name: "fast-2", Version: "1"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Findings) != 4 {
+		t.Fatalf("want 4 findings, got %d", len(resp.Findings))
+	}
+	wantOrder := []string{"slow-1", "fast-1", "slow-2", "fast-2"}
+	for i, want := range wantOrder {
+		if resp.Findings[i].Package.Name != want {
+			t.Errorf("findings[%d]: want package %q, got %q", i, want, resp.Findings[i].Package.Name)
+		}
+	}
+}

--- a/internal/pkgcheck/provider/snyk_test.go
+++ b/internal/pkgcheck/provider/snyk_test.go
@@ -2,10 +2,14 @@ package provider
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/agentsh/agentsh/internal/pkgcheck"
 	"github.com/stretchr/testify/assert"
@@ -170,4 +174,116 @@ func TestSnykProvider_MultiplePackages(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 2, requestCount) // One request per package.
+}
+
+func TestSnykProvider_RetriesOn5xx(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("server error"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.Write([]byte(`{"data": []}`))
+	}))
+	defer server.Close()
+
+	p := newSnykProviderForTest(SnykConfig{
+		BaseURL: server.URL,
+		APIKey:  "test-key",
+		OrgID:   "org-123",
+	}, circuitBreakerConfig{Threshold: 5, Window: time.Second, OpenPeriod: 200 * time.Millisecond})
+	resp, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages:  []pkgcheck.PackageRef{{Name: "express", Version: "4.18.0"}},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Findings)
+	assert.Equal(t, 3, attempts, "expected 3 server hits (2 failures + 1 success)")
+}
+
+func TestSnykProvider_BreakerOpensAfterRepeatedFailures(t *testing.T) {
+	serverHits := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverHits++
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("server error"))
+	}))
+	defer server.Close()
+
+	p := newSnykProviderForTest(SnykConfig{
+		BaseURL: server.URL,
+		APIKey:  "test-key",
+		OrgID:   "org-123",
+	}, circuitBreakerConfig{Threshold: 2, Window: time.Second, OpenPeriod: 200 * time.Millisecond})
+
+	req := pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages:  []pkgcheck.PackageRef{{Name: "express", Version: "4.18.0"}},
+	}
+
+	// First call: retryClient exhausts all 3 attempts → server hits → RecordFailure x1 from breaker perspective.
+	// With Threshold=2, after 2 CheckBatch calls the breaker opens.
+	_, err1 := p.CheckBatch(context.Background(), req)
+	require.Error(t, err1)
+
+	_, err2 := p.CheckBatch(context.Background(), req)
+	require.Error(t, err2)
+
+	hitsAfterTwoCalls := serverHits
+
+	// Third call: breaker must be open — no server hit.
+	resp3, err3 := p.CheckBatch(context.Background(), req)
+	require.Error(t, err3)
+	assert.True(t, errors.Is(err3, errBreakerOpen), "expected errBreakerOpen, got: %v", err3)
+	require.NotNil(t, resp3)
+	assert.True(t, resp3.Metadata.Partial, "expected Partial=true when breaker is open")
+	assert.Contains(t, resp3.Metadata.Error, "circuit breaker open")
+	assert.Equal(t, hitsAfterTwoCalls, serverHits, "third call must not hit the server")
+}
+
+func TestSnykProvider_ConcurrentFanOut(t *testing.T) {
+	var mu sync.Mutex
+	inFlight := 0
+	maxConcurrent := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		inFlight++
+		if inFlight > maxConcurrent {
+			maxConcurrent = inFlight
+		}
+		mu.Unlock()
+
+		// Small delay to allow concurrency to build up.
+		time.Sleep(10 * time.Millisecond)
+
+		mu.Lock()
+		inFlight--
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.Write([]byte(`{"data": []}`))
+	}))
+	defer server.Close()
+
+	packages := make([]pkgcheck.PackageRef, 32)
+	for i := range packages {
+		packages[i] = pkgcheck.PackageRef{Name: fmt.Sprintf("pkg-%d", i), Version: "1.0.0"}
+	}
+
+	p := newSnykProviderForTest(SnykConfig{
+		BaseURL:     server.URL,
+		APIKey:      "test-key",
+		OrgID:       "org-123",
+		Concurrency: 8,
+	}, circuitBreakerConfig{})
+	_, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages:  packages,
+	})
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, maxConcurrent, 2, "expected at least 2 simultaneous in-flight requests")
 }

--- a/internal/pkgcheck/provider/snyk_test.go
+++ b/internal/pkgcheck/provider/snyk_test.go
@@ -527,3 +527,45 @@ func TestSnykProvider_RejectsTrailingGarbageOnSuccess(t *testing.T) {
 		t.Fatal("expected decode error from trailing garbage; got nil")
 	}
 }
+
+func TestSnykProvider_PartialBatchReturnsProviderError(t *testing.T) {
+	// Packages whose name starts with "fail" return 400 (non-retryable),
+	// others return 200. errCount > 0 but errCount < n → partial. Provider
+	// must return a non-nil error so the orchestrator can apply on_failure
+	// policy.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "fail") {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	p := newSnykProviderForTest(SnykConfig{
+		BaseURL:     srv.URL,
+		APIKey:      "tk",
+		OrgID:       "org",
+		Concurrency: 4,
+	}, circuitBreakerConfig{Threshold: 100, Window: time.Second, OpenPeriod: 100 * time.Millisecond})
+
+	resp, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages: []pkgcheck.PackageRef{
+			{Name: "ok1", Version: "1"},
+			{Name: "fail1", Version: "1"},
+			{Name: "ok2", Version: "1"},
+			{Name: "fail2", Version: "1"},
+		},
+	})
+	if err == nil {
+		t.Fatal("partial batch must return a provider error so on_failure policy applies")
+	}
+	if resp == nil {
+		t.Fatal("response should still be returned alongside the error")
+	}
+	if !resp.Metadata.Partial {
+		t.Error("response Metadata.Partial should be true")
+	}
+}

--- a/internal/pkgcheck/provider/snyk_test.go
+++ b/internal/pkgcheck/provider/snyk_test.go
@@ -460,3 +460,54 @@ func TestSnykProvider_FindingsOrderMatchesInputOrder(t *testing.T) {
 		}
 	}
 }
+
+func TestSnykProvider_SchedulingBailsOnCancelDuringSemaphoreWait(t *testing.T) {
+	// Server handler is ctx-aware: it responds quickly when the client
+	// cancels its request, but takes 2s otherwise. Concurrency=2 so 30 of
+	// 32 packages are queued waiting on the semaphore. When the caller
+	// cancels at ~50ms, scheduling must bail without waiting for queued
+	// HTTP work — the new select{sem, batchCtx.Done()} is what we're testing.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-time.After(2 * time.Second):
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	p := NewSnykProvider(SnykConfig{
+		BaseURL:     srv.URL,
+		APIKey:      "test",
+		OrgID:       "org",
+		Concurrency: 2,
+		Timeout:     30 * time.Second,
+	})
+
+	pkgs := make([]pkgcheck.PackageRef, 32)
+	for i := range pkgs {
+		pkgs[i] = pkgcheck.PackageRef{Name: fmt.Sprintf("pkg-%d", i), Version: "1"}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, _ = p.CheckBatch(ctx, pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages:  pkgs,
+	})
+	elapsed := time.Since(start)
+	// Without the fix: scheduling was blocked on `sem <- struct{}{}` for the
+	// 30 queued packages, so cancel at 50ms still had to wait for in-flight
+	// 2s server delays.
+	// With the fix: scheduling bails immediately and CheckBatch returns
+	// soon after the in-flight workers' ctx-aware responses.
+	if elapsed > 1*time.Second {
+		t.Errorf("scheduling did not bail promptly on cancel; elapsed=%v", elapsed)
+	}
+}

--- a/internal/pkgcheck/provider/snyk_test.go
+++ b/internal/pkgcheck/provider/snyk_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -286,4 +288,48 @@ func TestSnykProvider_ConcurrentFanOut(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, maxConcurrent, 2, "expected at least 2 simultaneous in-flight requests")
+}
+
+func TestSnykProvider_AuthErrorIsFailFast(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		// Slow on first request so the test can observe early-cancel.
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"errors":[{"detail":"unauthorized"}]}`))
+	}))
+	defer srv.Close()
+
+	p := NewSnykProvider(SnykConfig{
+		BaseURL:     srv.URL,
+		APIKey:      "bad",
+		OrgID:       "org",
+		Concurrency: 8,
+	})
+
+	pkgs := make([]pkgcheck.PackageRef, 64)
+	for i := range pkgs {
+		pkgs[i] = pkgcheck.PackageRef{Name: fmt.Sprintf("pkg-%d", i), Version: "1"}
+	}
+	start := time.Now()
+	_, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages:  pkgs,
+	})
+	elapsed := time.Since(start)
+
+	if err == nil || !strings.Contains(err.Error(), "authentication failed") {
+		t.Fatalf("want authentication failed error, got %v", err)
+	}
+	// Without fail-fast: 64 pkgs × ~3 retries each at concurrency 8 ≫ 1s.
+	// With fail-fast: ~50ms (first hit) + a small drain → well under 1s.
+	if elapsed > 1*time.Second {
+		t.Errorf("auth error must fail fast; elapsed=%v", elapsed)
+	}
+	// Most workers should bail before sending a request — assert we did
+	// not hit the server with all 64 packages.
+	if int(hits.Load()) > 32 {
+		t.Errorf("auth error must short-circuit fan-out; hits=%d (want < 32)", hits.Load())
+	}
 }

--- a/internal/pkgcheck/provider/snyk_test.go
+++ b/internal/pkgcheck/provider/snyk_test.go
@@ -511,3 +511,19 @@ func TestSnykProvider_SchedulingBailsOnCancelDuringSemaphoreWait(t *testing.T) {
 		t.Errorf("scheduling did not bail promptly on cancel; elapsed=%v", elapsed)
 	}
 }
+
+func TestSnykProvider_RejectsTrailingGarbageOnSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{"data":[]} not-json`))
+	}))
+	defer srv.Close()
+	p := NewSnykProvider(SnykConfig{BaseURL: srv.URL, APIKey: "test", OrgID: "org", Concurrency: 1})
+	_, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages:  []pkgcheck.PackageRef{{Name: "foo", Version: "1"}},
+	})
+	if err == nil {
+		t.Fatal("expected decode error from trailing garbage; got nil")
+	}
+}

--- a/internal/pkgcheck/provider/snyk_test.go
+++ b/internal/pkgcheck/provider/snyk_test.go
@@ -206,6 +206,35 @@ func TestSnykProvider_RetriesOn5xx(t *testing.T) {
 	assert.Equal(t, 3, attempts, "expected 3 server hits (2 failures + 1 success)")
 }
 
+func TestSnyk_Contract(t *testing.T) {
+	cleanSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer cleanSrv.Close()
+
+	slowSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer slowSrv.Close()
+
+	factory := func(t *testing.T, baseURL string) pkgcheck.CheckProvider {
+		return NewSnykProvider(SnykConfig{
+			BaseURL:     baseURL,
+			APIKey:      "test",
+			OrgID:       "test",
+			Timeout:     2 * time.Second,
+			Concurrency: 4,
+		})
+	}
+	runContractSuite(t, "snyk", factory, contractFixture{
+		cleanServerURL: cleanSrv.URL,
+		slowServerURL:  slowSrv.URL,
+	})
+}
+
 func TestSnykProvider_BreakerOpensAfterRepeatedFailures(t *testing.T) {
 	serverHits := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/pkgcheck/provider/socket.go
+++ b/internal/pkgcheck/provider/socket.go
@@ -167,7 +167,16 @@ func (p *socketProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckReque
 		// Decode inside the breaker'd block: a malformed 200 is a provider
 		// failure, not a happy path. Otherwise a sustained stream of bad
 		// responses would never trip the breaker.
-		if err := json.NewDecoder(resp.Body).Decode(&socketResp); err != nil {
+		//
+		// Use ReadAll + Unmarshal rather than NewDecoder.Decode — Decode
+		// accepts a valid JSON value followed by trailing garbage, so a
+		// body like `{"packages":[]} junk` would be silently treated as
+		// success. Unmarshal is strict and errors on trailing data.
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("socket: read response: %w", err)
+		}
+		if err := json.Unmarshal(respBody, &socketResp); err != nil {
 			return fmt.Errorf("socket: decode response: %w", err)
 		}
 		return nil

--- a/internal/pkgcheck/provider/socket.go
+++ b/internal/pkgcheck/provider/socket.go
@@ -144,7 +144,7 @@ func (p *socketProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckReque
 		defer cancel()
 	}
 
-	var respBody []byte
+	var socketResp socketResponse
 	err = callWithBreaker(p.breaker, ctx, nil, func() error {
 		httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, p.baseURL+"/v0/scan/batch", bytes.NewReader(body))
 		if err != nil {
@@ -164,9 +164,11 @@ func (p *socketProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckReque
 			return fmt.Errorf("socket: unexpected status %d: %s", resp.StatusCode, string(rb))
 		}
 
-		respBody, err = io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("socket: read response: %w", err)
+		// Decode inside the breaker'd block: a malformed 200 is a provider
+		// failure, not a happy path. Otherwise a sustained stream of bad
+		// responses would never trip the breaker.
+		if err := json.NewDecoder(resp.Body).Decode(&socketResp); err != nil {
+			return fmt.Errorf("socket: decode response: %w", err)
 		}
 		return nil
 	})
@@ -183,11 +185,6 @@ func (p *socketProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckReque
 			}, err
 		}
 		return nil, err
-	}
-
-	var socketResp socketResponse
-	if err := json.Unmarshal(respBody, &socketResp); err != nil {
-		return nil, fmt.Errorf("socket: decode response: %w", err)
 	}
 
 	findings := p.mapFindings(req.Packages, &socketResp)

--- a/internal/pkgcheck/provider/socket.go
+++ b/internal/pkgcheck/provider/socket.go
@@ -220,6 +220,33 @@ func mapSocketAlert(alert socketAlert) (pkgcheck.FindingType, pkgcheck.Severity)
 	return findingType, severity
 }
 
+// buildSocketPURLs converts a list of PackageRef to PURL strings (per spec
+// https://github.com/package-url/purl-spec) for Socket's batch endpoint.
+//
+// The package name is path-escaped so that `@scope/name` becomes
+// `%40scope/name`, complying with PURL grammar which forbids a literal `@`
+// in the name segment (it is reserved as the version separator).
+func buildSocketPURLs(eco pkgcheck.Ecosystem, pkgs []pkgcheck.PackageRef) []string {
+	ecoStr := mapEcosystemSocket(eco)
+	out := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		// Percent-encode only the leading `@` in scoped names like `@scope/pkg`.
+		// url.PathEscape does not encode `@` (it is a valid path char), so we
+		// replace it manually to satisfy the PURL name-segment grammar.
+		name := p.Name
+		if strings.HasPrefix(name, "@") && strings.Contains(name, "/") {
+			parts := strings.SplitN(name, "/", 2)
+			name = "%40" + parts[0][1:] + "/" + parts[1]
+		}
+		purl := "pkg:" + ecoStr + "/" + name
+		if p.Version != "" {
+			purl += "@" + p.Version
+		}
+		out = append(out, purl)
+	}
+	return out
+}
+
 // mapEcosystemSocket converts our Ecosystem type to the Socket ecosystem string.
 func mapEcosystemSocket(eco pkgcheck.Ecosystem) string {
 	switch eco {

--- a/internal/pkgcheck/provider/socket.go
+++ b/internal/pkgcheck/provider/socket.go
@@ -145,7 +145,7 @@ func (p *socketProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckReque
 	}
 
 	var socketResp socketResponse
-	err = callWithBreaker(p.breaker, ctx, nil, func() error {
+	err = callWithBreaker(p.breaker, ctx, isSocketAuthError, func() error {
 		httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, p.baseURL+"/v0/scan/batch", bytes.NewReader(body))
 		if err != nil {
 			return fmt.Errorf("socket: create request: %w", err)
@@ -161,6 +161,9 @@ func (p *socketProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckReque
 
 		if resp.StatusCode != http.StatusOK {
 			rb, _ := io.ReadAll(resp.Body)
+			if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+				return &socketAuthError{status: resp.StatusCode, body: string(rb)}
+			}
 			return fmt.Errorf("socket: unexpected status %d: %s", resp.StatusCode, string(rb))
 		}
 
@@ -283,4 +286,22 @@ func mapEcosystemSocket(eco pkgcheck.Ecosystem) string {
 	default:
 		return string(eco)
 	}
+}
+
+// socketAuthError marks a 401/403 response from Socket.dev. It is treated as
+// neutral by the circuit breaker: a misconfigured API key would otherwise
+// poison the breaker and cause subsequent calls to surface "circuit breaker
+// open" instead of the real authentication failure.
+type socketAuthError struct {
+	status int
+	body   string
+}
+
+func (e *socketAuthError) Error() string {
+	return fmt.Sprintf("socket: authentication failed: status %d: %s", e.status, e.body)
+}
+
+func isSocketAuthError(err error) bool {
+	var sae *socketAuthError
+	return errors.As(err, &sae)
 }

--- a/internal/pkgcheck/provider/socket.go
+++ b/internal/pkgcheck/provider/socket.go
@@ -145,7 +145,7 @@ func (p *socketProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckReque
 	}
 
 	var respBody []byte
-	err = callWithBreaker(p.breaker, ctx, func() error {
+	err = callWithBreaker(p.breaker, ctx, nil, func() error {
 		httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, p.baseURL+"/v0/scan/batch", bytes.NewReader(body))
 		if err != nil {
 			return fmt.Errorf("socket: create request: %w", err)

--- a/internal/pkgcheck/provider/socket.go
+++ b/internal/pkgcheck/provider/socket.go
@@ -145,7 +145,7 @@ func (p *socketProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckReque
 	}
 
 	var respBody []byte
-	err = callWithBreaker(p.breaker, func() error {
+	err = callWithBreaker(p.breaker, ctx, func() error {
 		httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, p.baseURL+"/v0/scan/batch", bytes.NewReader(body))
 		if err != nil {
 			return fmt.Errorf("socket: create request: %w", err)

--- a/internal/pkgcheck/provider/socket.go
+++ b/internal/pkgcheck/provider/socket.go
@@ -220,33 +220,6 @@ func mapSocketAlert(alert socketAlert) (pkgcheck.FindingType, pkgcheck.Severity)
 	return findingType, severity
 }
 
-// buildSocketPURLs converts a list of PackageRef to PURL strings (per spec
-// https://github.com/package-url/purl-spec) for Socket's batch endpoint.
-//
-// The package name is path-escaped so that `@scope/name` becomes
-// `%40scope/name`, complying with PURL grammar which forbids a literal `@`
-// in the name segment (it is reserved as the version separator).
-func buildSocketPURLs(eco pkgcheck.Ecosystem, pkgs []pkgcheck.PackageRef) []string {
-	ecoStr := mapEcosystemSocket(eco)
-	out := make([]string, 0, len(pkgs))
-	for _, p := range pkgs {
-		// Percent-encode only the leading `@` in scoped names like `@scope/pkg`.
-		// url.PathEscape does not encode `@` (it is a valid path char), so we
-		// replace it manually to satisfy the PURL name-segment grammar.
-		name := p.Name
-		if strings.HasPrefix(name, "@") && strings.Contains(name, "/") {
-			parts := strings.SplitN(name, "/", 2)
-			name = "%40" + parts[0][1:] + "/" + parts[1]
-		}
-		purl := "pkg:" + ecoStr + "/" + name
-		if p.Version != "" {
-			purl += "@" + p.Version
-		}
-		out = append(out, purl)
-	}
-	return out
-}
-
 // mapEcosystemSocket converts our Ecosystem type to the Socket ecosystem string.
 func mapEcosystemSocket(eco pkgcheck.Ecosystem) string {
 	switch eco {

--- a/internal/pkgcheck/provider/socket.go
+++ b/internal/pkgcheck/provider/socket.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -28,13 +29,21 @@ type SocketConfig struct {
 // socketProvider queries the Socket.dev API for supply-chain security findings.
 type socketProvider struct {
 	baseURL string
-	client  *http.Client
+	client  *retryClient
+	breaker *circuitBreaker
 	apiKey  string
+	timeout time.Duration
 }
 
 // NewSocketProvider returns a CheckProvider that queries Socket.dev for malware
 // and reputation findings.
 func NewSocketProvider(cfg SocketConfig) pkgcheck.CheckProvider {
+	return newSocketProviderForTest(cfg, circuitBreakerConfig{})
+}
+
+// newSocketProviderForTest constructs a socketProvider with a custom breaker
+// config, allowing tests to inject short thresholds and windows.
+func newSocketProviderForTest(cfg SocketConfig, breakerCfg circuitBreakerConfig) *socketProvider {
 	baseURL := cfg.BaseURL
 	if baseURL == "" {
 		baseURL = defaultSocketBaseURL
@@ -45,8 +54,15 @@ func NewSocketProvider(cfg SocketConfig) pkgcheck.CheckProvider {
 	}
 	return &socketProvider{
 		baseURL: strings.TrimRight(baseURL, "/"),
-		client:  &http.Client{Timeout: timeout},
+		client: newRetryClient(retryConfig{
+			MaxAttempts:       3,
+			BaseBackoff:       200 * time.Millisecond,
+			MaxBackoff:        2 * time.Second,
+			RespectRetryAfter: true,
+		}),
+		breaker: newCircuitBreaker(breakerCfg),
 		apiKey:  cfg.APIKey,
+		timeout: timeout,
 	}
 }
 
@@ -120,26 +136,57 @@ func (p *socketProvider) CheckBatch(ctx context.Context, req pkgcheck.CheckReque
 		return nil, fmt.Errorf("socket: marshal request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, p.baseURL+"/v0/scan/batch", bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("socket: create request: %w", err)
+	// Apply a per-request context deadline to preserve the configured wall-clock cap.
+	reqCtx := ctx
+	if p.timeout > 0 {
+		var cancel context.CancelFunc
+		reqCtx, cancel = context.WithTimeout(ctx, p.timeout)
+		defer cancel()
 	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
 
-	resp, err := p.client.Do(httpReq)
+	var respBody []byte
+	err = callWithBreaker(p.breaker, func() error {
+		httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodPost, p.baseURL+"/v0/scan/batch", bytes.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("socket: create request: %w", err)
+		}
+		httpReq.Header.Set("Content-Type", "application/json")
+		httpReq.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+		resp, err := p.client.Do(httpReq)
+		if err != nil {
+			return fmt.Errorf("socket: request failed: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			rb, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("socket: unexpected status %d: %s", resp.StatusCode, string(rb))
+		}
+
+		respBody, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("socket: read response: %w", err)
+		}
+		return nil
+	})
+
 	if err != nil {
-		return nil, fmt.Errorf("socket: request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("socket: unexpected status %d: %s", resp.StatusCode, string(respBody))
+		if errors.Is(err, errBreakerOpen) {
+			return &pkgcheck.CheckResponse{
+				Provider: p.Name(),
+				Metadata: pkgcheck.ResponseMetadata{
+					Duration: time.Since(start),
+					Partial:  true,
+					Error:    "circuit breaker open",
+				},
+			}, err
+		}
+		return nil, err
 	}
 
 	var socketResp socketResponse
-	if err := json.NewDecoder(resp.Body).Decode(&socketResp); err != nil {
+	if err := json.Unmarshal(respBody, &socketResp); err != nil {
 		return nil, fmt.Errorf("socket: decode response: %w", err)
 	}
 

--- a/internal/pkgcheck/provider/socket_test.go
+++ b/internal/pkgcheck/provider/socket_test.go
@@ -169,6 +169,33 @@ func TestSocketProvider_RetriesOn5xx(t *testing.T) {
 	assert.Equal(t, 3, attempts, "expected 3 server hits (2 failures + 1 success)")
 }
 
+func TestSocket_Contract(t *testing.T) {
+	cleanSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"packages":[]}`))
+	}))
+	defer cleanSrv.Close()
+
+	slowSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"packages":[]}`))
+	}))
+	defer slowSrv.Close()
+
+	factory := func(t *testing.T, baseURL string) pkgcheck.CheckProvider {
+		return NewSocketProvider(SocketConfig{
+			BaseURL: baseURL,
+			APIKey:  "test",
+			Timeout: 2 * time.Second,
+		})
+	}
+	runContractSuite(t, "socket", factory, contractFixture{
+		cleanServerURL: cleanSrv.URL,
+		slowServerURL:  slowSrv.URL,
+	})
+}
+
 func TestSocketProvider_BreakerOpensAfterRepeatedFailures(t *testing.T) {
 	serverHits := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/pkgcheck/provider/socket_test.go
+++ b/internal/pkgcheck/provider/socket_test.go
@@ -121,7 +121,8 @@ func TestSocketProvider_ServerError(t *testing.T) {
 		Packages:  []pkgcheck.PackageRef{{Name: "express", Version: "4.18.0"}},
 	})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "unexpected status 403")
+	assert.Contains(t, err.Error(), "authentication failed")
+	assert.Contains(t, err.Error(), "403")
 }
 
 func TestSocketProvider_NoAlerts(t *testing.T) {
@@ -299,5 +300,39 @@ func TestSocketProvider_RejectsTrailingGarbageOnSuccess(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "decode") {
 		t.Errorf("expected decode error, got: %v", err)
+	}
+}
+
+func TestSocketProvider_AuthErrorDoesNotPoisonBreaker(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	p := newSocketProviderForTest(SocketConfig{
+		BaseURL: srv.URL,
+		APIKey:  "bad",
+		Timeout: 2 * time.Second,
+	}, circuitBreakerConfig{
+		Threshold:  2,
+		Window:     time.Second,
+		OpenPeriod: 200 * time.Millisecond,
+	})
+
+	for i := 0; i < 3; i++ {
+		_, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+			Ecosystem: pkgcheck.EcosystemNPM,
+			Packages:  []pkgcheck.PackageRef{{Name: "foo", Version: "1"}},
+		})
+		if err == nil {
+			t.Fatalf("iteration %d: expected error", i)
+		}
+		if !strings.Contains(err.Error(), "authentication failed") {
+			t.Fatalf("iteration %d: want authentication failure, got %v", i, err)
+		}
+		if errors.Is(err, errBreakerOpen) {
+			t.Fatalf("iteration %d: auth error must not open breaker; got %v", i, err)
+		}
 	}
 }

--- a/internal/pkgcheck/provider/socket_test.go
+++ b/internal/pkgcheck/provider/socket_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -277,5 +278,26 @@ func TestSocketProvider_MalformedResponseTripsBreaker(t *testing.T) {
 	}
 	if resp == nil || !resp.Metadata.Partial || resp.Metadata.Error != "circuit breaker open" {
 		t.Errorf("response should be Partial with circuit breaker open marker; got %+v", resp)
+	}
+}
+
+func TestSocketProvider_RejectsTrailingGarbageOnSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Valid JSON followed by garbage. Strict Unmarshal must reject this.
+		_, _ = w.Write([]byte(`{"packages":[]} not-json`))
+	}))
+	defer srv.Close()
+
+	p := NewSocketProvider(SocketConfig{BaseURL: srv.URL, APIKey: "test", Timeout: 2 * time.Second})
+	_, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages:  []pkgcheck.PackageRef{{Name: "foo", Version: "1"}},
+	})
+	if err == nil {
+		t.Fatal("expected decode error from trailing garbage; got nil")
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Errorf("expected decode error, got: %v", err)
 	}
 }

--- a/internal/pkgcheck/provider/socket_test.go
+++ b/internal/pkgcheck/provider/socket_test.go
@@ -140,31 +140,3 @@ func TestSocketProvider_NoAlerts(t *testing.T) {
 	assert.Empty(t, resp.Findings)
 }
 
-func TestSocket_BuildPURLs_NPM(t *testing.T) {
-	pkgs := []pkgcheck.PackageRef{
-		{Name: "lodash", Version: "4.17.21"},
-		{Name: "@types/node", Version: "20.10.0"},
-	}
-	got := buildSocketPURLs(pkgcheck.EcosystemNPM, pkgs)
-	want := []string{
-		"pkg:npm/lodash@4.17.21",
-		"pkg:npm/%40types/node@20.10.0",
-	}
-	if len(got) != len(want) {
-		t.Fatalf("len mismatch: want %d, got %d", len(want), len(got))
-	}
-	for i, p := range got {
-		if p != want[i] {
-			t.Errorf("idx %d: want %q got %q", i, want[i], p)
-		}
-	}
-}
-
-func TestSocket_BuildPURLs_PyPI(t *testing.T) {
-	pkgs := []pkgcheck.PackageRef{{Name: "requests", Version: "2.31.0"}}
-	got := buildSocketPURLs(pkgcheck.EcosystemPyPI, pkgs)
-	want := "pkg:pypi/requests@2.31.0"
-	if got[0] != want {
-		t.Fatalf("want %q got %q", want, got[0])
-	}
-}

--- a/internal/pkgcheck/provider/socket_test.go
+++ b/internal/pkgcheck/provider/socket_test.go
@@ -3,11 +3,13 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/agentsh/agentsh/internal/pkgcheck"
 	"github.com/stretchr/testify/assert"
@@ -138,5 +140,73 @@ func TestSocketProvider_NoAlerts(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Empty(t, resp.Findings)
+}
+
+func TestSocketProvider_RetriesOn5xx(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte("server error"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"packages": [{"name": "express", "version": "4.18.0", "alerts": []}]}`))
+	}))
+	defer server.Close()
+
+	p := newSocketProviderForTest(SocketConfig{
+		BaseURL: server.URL,
+		APIKey:  "test-key",
+	}, circuitBreakerConfig{Threshold: 5, Window: time.Second, OpenPeriod: 200 * time.Millisecond})
+	resp, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages:  []pkgcheck.PackageRef{{Name: "express", Version: "4.18.0"}},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Findings)
+	assert.Equal(t, 3, attempts, "expected 3 server hits (2 failures + 1 success)")
+}
+
+func TestSocketProvider_BreakerOpensAfterRepeatedFailures(t *testing.T) {
+	serverHits := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverHits++
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("server error"))
+	}))
+	defer server.Close()
+
+	p := newSocketProviderForTest(SocketConfig{
+		BaseURL: server.URL,
+		APIKey:  "test-key",
+	}, circuitBreakerConfig{Threshold: 2, Window: time.Second, OpenPeriod: 200 * time.Millisecond})
+
+	req := pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages:  []pkgcheck.PackageRef{{Name: "express", Version: "4.18.0"}},
+	}
+
+	// First call: retryClient exhausts all 3 attempts → 3 server hits → RecordFailure x1 from breaker perspective.
+	// But since retryClient retries internally and only returns 1 error to callWithBreaker,
+	// the breaker records 1 failure per CheckBatch call.
+	// With Threshold=2, after 2 CheckBatch calls the breaker opens.
+	_, err1 := p.CheckBatch(context.Background(), req)
+	require.Error(t, err1)
+
+	_, err2 := p.CheckBatch(context.Background(), req)
+	require.Error(t, err2)
+
+	hitsAfterTwoCalls := serverHits
+
+	// Third call: breaker must be open — no server hit.
+	resp3, err3 := p.CheckBatch(context.Background(), req)
+	require.Error(t, err3)
+	assert.True(t, errors.Is(err3, errBreakerOpen), "expected errBreakerOpen, got: %v", err3)
+	require.NotNil(t, resp3)
+	assert.True(t, resp3.Metadata.Partial, "expected Partial=true when breaker is open")
+	assert.Equal(t, "circuit breaker open", resp3.Metadata.Error)
+	assert.Equal(t, hitsAfterTwoCalls, serverHits, "third call must not hit the server")
 }
 

--- a/internal/pkgcheck/provider/socket_test.go
+++ b/internal/pkgcheck/provider/socket_test.go
@@ -237,3 +237,45 @@ func TestSocketProvider_BreakerOpensAfterRepeatedFailures(t *testing.T) {
 	assert.Equal(t, hitsAfterTwoCalls, serverHits, "third call must not hit the server")
 }
 
+
+func TestSocketProvider_MalformedResponseTripsBreaker(t *testing.T) {
+	// Server always returns 200 with garbage body — every CheckBatch fails
+	// with a decode error. Decode is now inside callWithBreaker, so two
+	// failures should trip a threshold-2 breaker.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json {{"))
+	}))
+	defer srv.Close()
+
+	p := newSocketProviderForTest(SocketConfig{
+		BaseURL: srv.URL,
+		APIKey:  "test",
+		Timeout: 2 * time.Second,
+	}, circuitBreakerConfig{
+		Threshold:  2,
+		Window:     time.Second,
+		OpenPeriod: 200 * time.Millisecond,
+	})
+
+	for i := 0; i < 2; i++ {
+		_, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+			Ecosystem: pkgcheck.EcosystemNPM,
+			Packages:  []pkgcheck.PackageRef{{Name: "foo", Version: "1"}},
+		})
+		if err == nil {
+			t.Fatalf("iteration %d: expected decode error", i)
+		}
+	}
+	// Third call must short-circuit via the breaker.
+	resp, err := p.CheckBatch(context.Background(), pkgcheck.CheckRequest{
+		Ecosystem: pkgcheck.EcosystemNPM,
+		Packages:  []pkgcheck.PackageRef{{Name: "foo", Version: "1"}},
+	})
+	if err == nil || !errors.Is(err, errBreakerOpen) {
+		t.Fatalf("third call should be short-circuited by breaker; got err=%v", err)
+	}
+	if resp == nil || !resp.Metadata.Partial || resp.Metadata.Error != "circuit breaker open" {
+		t.Errorf("response should be Partial with circuit breaker open marker; got %+v", resp)
+	}
+}

--- a/internal/pkgcheck/provider/socket_test.go
+++ b/internal/pkgcheck/provider/socket_test.go
@@ -139,3 +139,32 @@ func TestSocketProvider_NoAlerts(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, resp.Findings)
 }
+
+func TestSocket_BuildPURLs_NPM(t *testing.T) {
+	pkgs := []pkgcheck.PackageRef{
+		{Name: "lodash", Version: "4.17.21"},
+		{Name: "@types/node", Version: "20.10.0"},
+	}
+	got := buildSocketPURLs(pkgcheck.EcosystemNPM, pkgs)
+	want := []string{
+		"pkg:npm/lodash@4.17.21",
+		"pkg:npm/%40types/node@20.10.0",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: want %d, got %d", len(want), len(got))
+	}
+	for i, p := range got {
+		if p != want[i] {
+			t.Errorf("idx %d: want %q got %q", i, want[i], p)
+		}
+	}
+}
+
+func TestSocket_BuildPURLs_PyPI(t *testing.T) {
+	pkgs := []pkgcheck.PackageRef{{Name: "requests", Version: "2.31.0"}}
+	got := buildSocketPURLs(pkgcheck.EcosystemPyPI, pkgs)
+	want := "pkg:pypi/requests@2.31.0"
+	if got[0] != want {
+		t.Fatalf("want %q got %q", want, got[0])
+	}
+}

--- a/internal/pkgcheck/resolver/npm.go
+++ b/internal/pkgcheck/resolver/npm.go
@@ -19,7 +19,9 @@ type NPMResolverConfig struct {
 }
 
 type npmResolver struct {
-	cfg NPMResolverConfig
+	cfg        NPMResolverConfig
+	binary     string
+	prefixArgs []string
 }
 
 // NewNPMResolver creates a resolver for npm install commands.
@@ -30,7 +32,17 @@ func NewNPMResolver(cfg NPMResolverConfig) pkgcheck.Resolver {
 	if cfg.Timeout == 0 {
 		cfg.Timeout = 30 * time.Second
 	}
-	return &npmResolver{cfg: cfg}
+	// Split the command string into binary + args. Allows users to configure
+	// a full invocation like "npm install --package-lock-only --ignore-scripts"
+	// rather than just the binary path.
+	parts := strings.Fields(cfg.DryRunCommand)
+	binary := cfg.DryRunCommand
+	var prefixArgs []string
+	if len(parts) > 1 {
+		binary = parts[0]
+		prefixArgs = parts[1:]
+	}
+	return &npmResolver{cfg: cfg, binary: binary, prefixArgs: prefixArgs}
 }
 
 func (r *npmResolver) Name() string { return "npm" }
@@ -67,8 +79,9 @@ func (r *npmResolver) Resolve(ctx context.Context, workDir string, command []str
 	// npm install --package-lock-only --ignore-scripts --json <packages>
 	cmdArgs := []string{"install", "--package-lock-only", "--ignore-scripts", "--json"}
 	cmdArgs = append(cmdArgs, packages...)
+	allArgs := append(append([]string(nil), r.prefixArgs...), cmdArgs...)
 
-	cmd := exec.CommandContext(ctx, r.cfg.DryRunCommand, cmdArgs...)
+	cmd := exec.CommandContext(ctx, r.binary, allArgs...)
 	cmd.Dir = workDir
 
 	out, err := cmd.Output()
@@ -106,6 +119,7 @@ func parseNPMDryRunOutput(data []byte, requestedPkgs []string) (*pkgcheck.Instal
 	plan := &pkgcheck.InstallPlan{
 		Tool:       "npm",
 		Ecosystem:  pkgcheck.EcosystemNPM,
+		Registry:   "registry.npmjs.org",
 		ResolvedAt: time.Now(),
 	}
 

--- a/internal/pkgcheck/resolver/npm.go
+++ b/internal/pkgcheck/resolver/npm.go
@@ -75,8 +75,11 @@ func (r *npmResolver) Resolve(ctx context.Context, workDir string, command []str
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.Timeout)
 	defer cancel()
 
-	// npm install --package-lock-only --ignore-scripts --json <packages>
+	// npm install --package-lock-only --ignore-scripts --json [--registry <url>] <packages>
+	// Forward any --registry flag from the original command so the dry-run
+	// resolves against the same registry the actual install will use.
 	cmdArgs := []string{"install", "--package-lock-only", "--ignore-scripts", "--json"}
+	cmdArgs = append(cmdArgs, r.extractRegistryFlags(command)...)
 	cmdArgs = append(cmdArgs, packages...)
 	allArgs := append(append([]string(nil), r.prefixArgs...), cmdArgs...)
 
@@ -283,6 +286,25 @@ func pkgBaseName(spec string) string {
 // leave Registry empty for scoped packages (fail closed).
 func isScopedPackage(name string) bool {
 	return strings.HasPrefix(name, "@") && strings.Contains(name, "/")
+}
+
+// extractRegistryFlags returns the subset of args that influence which
+// registry packages resolve from. Pass these to the dry-run so the
+// resolver hits the same source the actual install will.
+func (r *npmResolver) extractRegistryFlags(args []string) []string {
+	var out []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--registry" && i+1 < len(args) {
+			out = append(out, a, args[i+1])
+			i++
+			continue
+		}
+		if strings.HasPrefix(a, "--registry=") {
+			out = append(out, a)
+		}
+	}
+	return out
 }
 
 // hasRegistryFlag reports whether the args slice contains an explicit

--- a/internal/pkgcheck/resolver/npm.go
+++ b/internal/pkgcheck/resolver/npm.go
@@ -14,8 +14,13 @@ import (
 
 // NPMResolverConfig configures the NPM resolver.
 type NPMResolverConfig struct {
-	DryRunCommand string        // path to npm binary; defaults to "npm"
-	Timeout       time.Duration // timeout for dry-run execution
+	// DryRunCommand is the path to the npm binary; defaults to "npm".
+	// For additional args to prepend to the resolver-specific args, use DryRunArgs.
+	DryRunCommand string
+	// DryRunArgs contains args to prepend to the resolver-specific args.
+	// Each element is a single token (no shell splitting is performed).
+	DryRunArgs []string
+	Timeout    time.Duration // timeout for dry-run execution
 }
 
 type npmResolver struct {
@@ -32,17 +37,9 @@ func NewNPMResolver(cfg NPMResolverConfig) pkgcheck.Resolver {
 	if cfg.Timeout == 0 {
 		cfg.Timeout = 30 * time.Second
 	}
-	// Split the command string into binary + args. Allows users to configure
-	// a full invocation like "npm install --package-lock-only --ignore-scripts"
-	// rather than just the binary path.
-	parts := strings.Fields(cfg.DryRunCommand)
-	binary := cfg.DryRunCommand
-	var prefixArgs []string
-	if len(parts) > 1 {
-		binary = parts[0]
-		prefixArgs = parts[1:]
-	}
-	return &npmResolver{cfg: cfg, binary: binary, prefixArgs: prefixArgs}
+	// DryRunCommand is the binary path only; DryRunArgs carries any prefix args.
+	// No shell splitting is performed so paths with spaces are preserved verbatim.
+	return &npmResolver{cfg: cfg, binary: cfg.DryRunCommand, prefixArgs: cfg.DryRunArgs}
 }
 
 func (r *npmResolver) Name() string { return "npm" }

--- a/internal/pkgcheck/resolver/npm.go
+++ b/internal/pkgcheck/resolver/npm.go
@@ -66,8 +66,10 @@ func (r *npmResolver) CanResolve(command string, args []string) bool {
 func (r *npmResolver) Resolve(ctx context.Context, workDir string, command []string) (*pkgcheck.InstallPlan, error) {
 	// Extract package args (skip the subcommand, filter flags)
 	var packages []string
+	var args []string
 	if len(command) > 1 {
-		packages = extractPkgArgs(command[1:])
+		args = command[1:]
+		packages = extractPkgArgs(args)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.Timeout)
@@ -86,7 +88,27 @@ func (r *npmResolver) Resolve(ctx context.Context, workDir string, command []str
 		return nil, fmt.Errorf("npm dry-run failed: %w", err)
 	}
 
-	return parseNPMDryRunOutput(out, packages)
+	plan, err := parseNPMDryRunOutput(out, packages)
+	if err != nil {
+		return nil, err
+	}
+	plan.Registry = r.detectRegistry(args)
+	return plan, nil
+}
+
+// detectRegistry scans the install command args for an explicit --registry
+// flag and returns its value. Falls back to the public npm registry.
+func (r *npmResolver) detectRegistry(args []string) string {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--registry" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(a, "--registry=") {
+			return strings.TrimPrefix(a, "--registry=")
+		}
+	}
+	return "registry.npmjs.org"
 }
 
 // npmDryRunOutput represents the JSON output from npm install --json.

--- a/internal/pkgcheck/resolver/npm.go
+++ b/internal/pkgcheck/resolver/npm.go
@@ -92,7 +92,27 @@ func (r *npmResolver) Resolve(ctx context.Context, workDir string, command []str
 	if err != nil {
 		return nil, err
 	}
-	plan.Registry = r.detectRegistry(args)
+	planRegistry := r.detectRegistry(args)
+	plan.Registry = planRegistry
+	explicitFlag := r.hasRegistryFlag(args)
+	// Scoped packages may resolve from a private registry per .npmrc scope
+	// directives. Without an explicit --registry CLI flag we cannot prove the
+	// resolved origin, so leave Registry empty and let the privacy filter fail
+	// closed (over-skip rather than risk leaking the package name externally).
+	for i := range plan.Direct {
+		if isScopedPackage(plan.Direct[i].Name) && !explicitFlag {
+			plan.Direct[i].Registry = ""
+		} else {
+			plan.Direct[i].Registry = planRegistry
+		}
+	}
+	for i := range plan.Transitive {
+		if isScopedPackage(plan.Transitive[i].Name) && !explicitFlag {
+			plan.Transitive[i].Registry = ""
+		} else {
+			plan.Transitive[i].Registry = planRegistry
+		}
+	}
 	return plan, nil
 }
 
@@ -254,6 +274,26 @@ func pkgBaseName(spec string) string {
 		}
 	}
 	return spec
+}
+
+// isScopedPackage reports whether name is a scoped npm package (e.g. @acme/foo).
+// Scoped packages can be routed to a private registry via .npmrc
+// "scope:registry" directives that we cannot read. Without an explicit
+// --registry CLI flag we cannot prove the resolved origin, so callers
+// leave Registry empty for scoped packages (fail closed).
+func isScopedPackage(name string) bool {
+	return strings.HasPrefix(name, "@") && strings.Contains(name, "/")
+}
+
+// hasRegistryFlag reports whether the args slice contains an explicit
+// --registry flag (with or without =).
+func (r *npmResolver) hasRegistryFlag(args []string) bool {
+	for _, a := range args {
+		if a == "--registry" || strings.HasPrefix(a, "--registry=") {
+			return true
+		}
+	}
+	return false
 }
 
 // trimWindowsScriptExt strips .cmd and .bat extensions (case-insensitive)

--- a/internal/pkgcheck/resolver/pip.go
+++ b/internal/pkgcheck/resolver/pip.go
@@ -14,8 +14,13 @@ import (
 
 // PipResolverConfig configures the pip resolver.
 type PipResolverConfig struct {
-	DryRunCommand string        // path to pip binary; defaults to "pip"
-	Timeout       time.Duration // timeout for dry-run execution
+	// DryRunCommand is the path to the pip binary; defaults to "pip".
+	// For additional args to prepend to the resolver-specific args, use DryRunArgs.
+	DryRunCommand string
+	// DryRunArgs contains args to prepend to the resolver-specific args.
+	// Each element is a single token (no shell splitting is performed).
+	DryRunArgs []string
+	Timeout    time.Duration // timeout for dry-run execution
 }
 
 type pipResolver struct {
@@ -32,16 +37,9 @@ func NewPipResolver(cfg PipResolverConfig) pkgcheck.Resolver {
 	if cfg.Timeout == 0 {
 		cfg.Timeout = 30 * time.Second
 	}
-	// Split the command string into binary + args. Allows users to configure
-	// a full invocation like "pip install --dry-run" rather than just the binary path.
-	parts := strings.Fields(cfg.DryRunCommand)
-	binary := cfg.DryRunCommand
-	var prefixArgs []string
-	if len(parts) > 1 {
-		binary = parts[0]
-		prefixArgs = parts[1:]
-	}
-	return &pipResolver{cfg: cfg, binary: binary, prefixArgs: prefixArgs}
+	// DryRunCommand is the binary path only; DryRunArgs carries any prefix args.
+	// No shell splitting is performed so paths with spaces are preserved verbatim.
+	return &pipResolver{cfg: cfg, binary: cfg.DryRunCommand, prefixArgs: cfg.DryRunArgs}
 }
 
 func (r *pipResolver) Name() string { return "pip" }

--- a/internal/pkgcheck/resolver/pip.go
+++ b/internal/pkgcheck/resolver/pip.go
@@ -19,7 +19,9 @@ type PipResolverConfig struct {
 }
 
 type pipResolver struct {
-	cfg PipResolverConfig
+	cfg        PipResolverConfig
+	binary     string
+	prefixArgs []string
 }
 
 // NewPipResolver creates a resolver for pip install commands.
@@ -30,7 +32,16 @@ func NewPipResolver(cfg PipResolverConfig) pkgcheck.Resolver {
 	if cfg.Timeout == 0 {
 		cfg.Timeout = 30 * time.Second
 	}
-	return &pipResolver{cfg: cfg}
+	// Split the command string into binary + args. Allows users to configure
+	// a full invocation like "pip install --dry-run" rather than just the binary path.
+	parts := strings.Fields(cfg.DryRunCommand)
+	binary := cfg.DryRunCommand
+	var prefixArgs []string
+	if len(parts) > 1 {
+		binary = parts[0]
+		prefixArgs = parts[1:]
+	}
+	return &pipResolver{cfg: cfg, binary: binary, prefixArgs: prefixArgs}
 }
 
 func (r *pipResolver) Name() string { return "pip" }
@@ -61,8 +72,9 @@ func (r *pipResolver) Resolve(ctx context.Context, workDir string, command []str
 	// pip install --dry-run --report - <packages>
 	cmdArgs := []string{"install", "--dry-run", "--report", "-"}
 	cmdArgs = append(cmdArgs, packages...)
+	allArgs := append(append([]string(nil), r.prefixArgs...), cmdArgs...)
 
-	cmd := exec.CommandContext(ctx, r.cfg.DryRunCommand, cmdArgs...)
+	cmd := exec.CommandContext(ctx, r.binary, allArgs...)
 	cmd.Dir = workDir
 
 	out, err := cmd.Output()
@@ -105,6 +117,7 @@ func parsePipDryRunOutput(data []byte, requestedPkgs []string) (*pkgcheck.Instal
 	plan := &pkgcheck.InstallPlan{
 		Tool:       "pip",
 		Ecosystem:  pkgcheck.EcosystemPyPI,
+		Registry:   "pypi.org",
 		ResolvedAt: time.Now(),
 	}
 

--- a/internal/pkgcheck/resolver/pip.go
+++ b/internal/pkgcheck/resolver/pip.go
@@ -69,8 +69,12 @@ func (r *pipResolver) Resolve(ctx context.Context, workDir string, command []str
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.Timeout)
 	defer cancel()
 
-	// pip install --dry-run --report - <packages>
+	// pip install --dry-run --report - [--index-url <url>] [--extra-index-url <url>] <packages>
+	// Forward any --index-url / -i / --extra-index-url flags from the original
+	// command so the dry-run resolves against the same index the actual install
+	// will use.
 	cmdArgs := []string{"install", "--dry-run", "--report", "-"}
+	cmdArgs = append(cmdArgs, r.extractIndexURLFlags(command)...)
 	cmdArgs = append(cmdArgs, packages...)
 	allArgs := append(append([]string(nil), r.prefixArgs...), cmdArgs...)
 
@@ -88,6 +92,30 @@ func (r *pipResolver) Resolve(ctx context.Context, workDir string, command []str
 	}
 	plan.Registry = r.detectRegistry(args)
 	return plan, nil
+}
+
+// extractIndexURLFlags returns the subset of args that influence which
+// index/registry packages resolve from (--index-url, -i, --extra-index-url).
+// Pass these to the dry-run so the resolver hits the same source the actual
+// install will use.
+func (r *pipResolver) extractIndexURLFlags(args []string) []string {
+	var out []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case (a == "--index-url" || a == "-i") && i+1 < len(args):
+			out = append(out, a, args[i+1])
+			i++
+		case strings.HasPrefix(a, "--index-url="):
+			out = append(out, a)
+		case a == "--extra-index-url" && i+1 < len(args):
+			out = append(out, a, args[i+1])
+			i++
+		case strings.HasPrefix(a, "--extra-index-url="):
+			out = append(out, a)
+		}
+	}
+	return out
 }
 
 // detectRegistry scans the pip install command args for registry override flags.

--- a/internal/pkgcheck/resolver/pip.go
+++ b/internal/pkgcheck/resolver/pip.go
@@ -60,8 +60,10 @@ func (r *pipResolver) CanResolve(command string, args []string) bool {
 
 func (r *pipResolver) Resolve(ctx context.Context, workDir string, command []string) (*pkgcheck.InstallPlan, error) {
 	var packages []string
+	var args []string
 	if len(command) > 1 {
-		packages = extractPkgArgs(command[1:])
+		args = command[1:]
+		packages = extractPkgArgs(args)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.Timeout)
@@ -80,7 +82,49 @@ func (r *pipResolver) Resolve(ctx context.Context, workDir string, command []str
 		return nil, fmt.Errorf("pip dry-run failed: %w", err)
 	}
 
-	return parsePipDryRunOutput(out, packages)
+	plan, err := parsePipDryRunOutput(out, packages)
+	if err != nil {
+		return nil, err
+	}
+	plan.Registry = r.detectRegistry(args)
+	return plan, nil
+}
+
+// detectRegistry scans the pip install command args for registry override flags.
+//
+// --index-url / -i sets the primary registry; return it directly.
+// --extra-index-url means "also use this registry", so the package may have
+// come from EITHER the primary or the extra registry. We can't tell which, so
+// we return "" (unknown) to let the privacy filter fail closed rather than
+// accidentally claiming the package came from a known-public registry.
+func (r *pipResolver) detectRegistry(args []string) string {
+	hasExtra := false
+	primary := "pypi.org"
+
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--index-url" && i+1 < len(args):
+			primary = args[i+1]
+			i++
+		case strings.HasPrefix(a, "--index-url="):
+			primary = strings.TrimPrefix(a, "--index-url=")
+		case a == "-i" && i+1 < len(args):
+			primary = args[i+1]
+			i++
+		case a == "--extra-index-url" && i+1 < len(args):
+			hasExtra = true
+			i++
+		case strings.HasPrefix(a, "--extra-index-url="):
+			hasExtra = true
+		}
+	}
+
+	if hasExtra {
+		// Package origin is ambiguous — return "" so privacy filter fails closed.
+		return ""
+	}
+	return primary
 }
 
 // pipReport represents the JSON output from pip install --report.

--- a/internal/pkgcheck/resolver/pnpm.go
+++ b/internal/pkgcheck/resolver/pnpm.go
@@ -91,8 +91,35 @@ func (r *pnpmResolver) Resolve(ctx context.Context, workDir string, command []st
 	if err != nil {
 		return nil, err
 	}
-	plan.Registry = r.detectRegistry(args)
+	planRegistry := r.detectRegistry(args)
+	plan.Registry = planRegistry
+	explicitFlag := r.hasRegistryFlag(args)
+	for i := range plan.Direct {
+		if isScopedPackage(plan.Direct[i].Name) && !explicitFlag {
+			plan.Direct[i].Registry = ""
+		} else {
+			plan.Direct[i].Registry = planRegistry
+		}
+	}
+	for i := range plan.Transitive {
+		if isScopedPackage(plan.Transitive[i].Name) && !explicitFlag {
+			plan.Transitive[i].Registry = ""
+		} else {
+			plan.Transitive[i].Registry = planRegistry
+		}
+	}
 	return plan, nil
+}
+
+// hasRegistryFlag reports whether the args slice contains an explicit
+// --registry flag (with or without =).
+func (r *pnpmResolver) hasRegistryFlag(args []string) bool {
+	for _, a := range args {
+		if a == "--registry" || strings.HasPrefix(a, "--registry=") {
+			return true
+		}
+	}
+	return false
 }
 
 // detectRegistry scans the install command args for an explicit --registry

--- a/internal/pkgcheck/resolver/pnpm.go
+++ b/internal/pkgcheck/resolver/pnpm.go
@@ -74,8 +74,11 @@ func (r *pnpmResolver) Resolve(ctx context.Context, workDir string, command []st
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.Timeout)
 	defer cancel()
 
-	// pnpm add --lockfile-only --ignore-scripts <packages>
+	// pnpm add --lockfile-only --ignore-scripts [--registry <url>] <packages>
+	// Forward any --registry flag from the original command so the dry-run
+	// resolves against the same registry the actual install will use.
 	cmdArgs := []string{"add", "--lockfile-only", "--ignore-scripts"}
+	cmdArgs = append(cmdArgs, r.extractRegistryFlags(command)...)
 	cmdArgs = append(cmdArgs, packages...)
 	allArgs := append(append([]string(nil), r.prefixArgs...), cmdArgs...)
 
@@ -109,6 +112,25 @@ func (r *pnpmResolver) Resolve(ctx context.Context, workDir string, command []st
 		}
 	}
 	return plan, nil
+}
+
+// extractRegistryFlags returns the subset of args that influence which
+// registry packages resolve from. Pass these to the dry-run so the
+// resolver hits the same source the actual install will.
+func (r *pnpmResolver) extractRegistryFlags(args []string) []string {
+	var out []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--registry" && i+1 < len(args) {
+			out = append(out, a, args[i+1])
+			i++
+			continue
+		}
+		if strings.HasPrefix(a, "--registry=") {
+			out = append(out, a)
+		}
+	}
+	return out
 }
 
 // hasRegistryFlag reports whether the args slice contains an explicit

--- a/internal/pkgcheck/resolver/pnpm.go
+++ b/internal/pkgcheck/resolver/pnpm.go
@@ -65,8 +65,10 @@ func (r *pnpmResolver) CanResolve(command string, args []string) bool {
 
 func (r *pnpmResolver) Resolve(ctx context.Context, workDir string, command []string) (*pkgcheck.InstallPlan, error) {
 	var packages []string
+	var args []string
 	if len(command) > 1 {
-		packages = extractPkgArgs(command[1:])
+		args = command[1:]
+		packages = extractPkgArgs(args)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.Timeout)
@@ -85,7 +87,27 @@ func (r *pnpmResolver) Resolve(ctx context.Context, workDir string, command []st
 		return nil, fmt.Errorf("pnpm dry-run failed: %w", err)
 	}
 
-	return parsePNPMDryRunOutput(out, packages)
+	plan, err := parsePNPMDryRunOutput(out, packages)
+	if err != nil {
+		return nil, err
+	}
+	plan.Registry = r.detectRegistry(args)
+	return plan, nil
+}
+
+// detectRegistry scans the install command args for an explicit --registry
+// flag and returns its value. Falls back to the public npm registry.
+func (r *pnpmResolver) detectRegistry(args []string) string {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--registry" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(a, "--registry=") {
+			return strings.TrimPrefix(a, "--registry=")
+		}
+	}
+	return "registry.npmjs.org"
 }
 
 // pnpmDryRunOutput represents pnpm's JSON output structure.

--- a/internal/pkgcheck/resolver/pnpm.go
+++ b/internal/pkgcheck/resolver/pnpm.go
@@ -19,7 +19,9 @@ type PNPMResolverConfig struct {
 }
 
 type pnpmResolver struct {
-	cfg PNPMResolverConfig
+	cfg        PNPMResolverConfig
+	binary     string
+	prefixArgs []string
 }
 
 // NewPNPMResolver creates a resolver for pnpm add commands.
@@ -30,7 +32,16 @@ func NewPNPMResolver(cfg PNPMResolverConfig) pkgcheck.Resolver {
 	if cfg.Timeout == 0 {
 		cfg.Timeout = 30 * time.Second
 	}
-	return &pnpmResolver{cfg: cfg}
+	// Split the command string into binary + args. Allows users to configure
+	// a full invocation like "pnpm add --lockfile-only" rather than just the binary path.
+	parts := strings.Fields(cfg.DryRunCommand)
+	binary := cfg.DryRunCommand
+	var prefixArgs []string
+	if len(parts) > 1 {
+		binary = parts[0]
+		prefixArgs = parts[1:]
+	}
+	return &pnpmResolver{cfg: cfg, binary: binary, prefixArgs: prefixArgs}
 }
 
 func (r *pnpmResolver) Name() string { return "pnpm" }
@@ -66,8 +77,9 @@ func (r *pnpmResolver) Resolve(ctx context.Context, workDir string, command []st
 	// pnpm add --lockfile-only --ignore-scripts <packages>
 	cmdArgs := []string{"add", "--lockfile-only", "--ignore-scripts"}
 	cmdArgs = append(cmdArgs, packages...)
+	allArgs := append(append([]string(nil), r.prefixArgs...), cmdArgs...)
 
-	cmd := exec.CommandContext(ctx, r.cfg.DryRunCommand, cmdArgs...)
+	cmd := exec.CommandContext(ctx, r.binary, allArgs...)
 	cmd.Dir = workDir
 
 	out, err := cmd.Output()
@@ -106,6 +118,7 @@ func parsePNPMDryRunOutput(data []byte, requestedPkgs []string) (*pkgcheck.Insta
 	plan := &pkgcheck.InstallPlan{
 		Tool:       "pnpm",
 		Ecosystem:  pkgcheck.EcosystemNPM,
+		Registry:   "registry.npmjs.org",
 		ResolvedAt: time.Now(),
 	}
 

--- a/internal/pkgcheck/resolver/pnpm.go
+++ b/internal/pkgcheck/resolver/pnpm.go
@@ -14,8 +14,13 @@ import (
 
 // PNPMResolverConfig configures the pnpm resolver.
 type PNPMResolverConfig struct {
-	DryRunCommand string        // path to pnpm binary; defaults to "pnpm"
-	Timeout       time.Duration // timeout for dry-run execution
+	// DryRunCommand is the path to the pnpm binary; defaults to "pnpm".
+	// For additional args to prepend to the resolver-specific args, use DryRunArgs.
+	DryRunCommand string
+	// DryRunArgs contains args to prepend to the resolver-specific args.
+	// Each element is a single token (no shell splitting is performed).
+	DryRunArgs []string
+	Timeout    time.Duration // timeout for dry-run execution
 }
 
 type pnpmResolver struct {
@@ -32,16 +37,9 @@ func NewPNPMResolver(cfg PNPMResolverConfig) pkgcheck.Resolver {
 	if cfg.Timeout == 0 {
 		cfg.Timeout = 30 * time.Second
 	}
-	// Split the command string into binary + args. Allows users to configure
-	// a full invocation like "pnpm add --lockfile-only" rather than just the binary path.
-	parts := strings.Fields(cfg.DryRunCommand)
-	binary := cfg.DryRunCommand
-	var prefixArgs []string
-	if len(parts) > 1 {
-		binary = parts[0]
-		prefixArgs = parts[1:]
-	}
-	return &pnpmResolver{cfg: cfg, binary: binary, prefixArgs: prefixArgs}
+	// DryRunCommand is the binary path only; DryRunArgs carries any prefix args.
+	// No shell splitting is performed so paths with spaces are preserved verbatim.
+	return &pnpmResolver{cfg: cfg, binary: cfg.DryRunCommand, prefixArgs: cfg.DryRunArgs}
 }
 
 func (r *pnpmResolver) Name() string { return "pnpm" }

--- a/internal/pkgcheck/resolver/poetry.go
+++ b/internal/pkgcheck/resolver/poetry.go
@@ -115,9 +115,14 @@ func parsePoetryDryRunOutput(data []byte, requestedPkgs []string) (*pkgcheck.Ins
 	}
 
 	plan := &pkgcheck.InstallPlan{
-		Tool:       "poetry",
-		Ecosystem:  pkgcheck.EcosystemPyPI,
-		Registry:   "pypi.org",
+		Tool:      "poetry",
+		Ecosystem: pkgcheck.EcosystemPyPI,
+		// Poetry source registries are configured in pyproject.toml's
+		// [[tool.poetry.source]] blocks, which we do not parse. Leaving
+		// Registry empty makes the privacy filter fail closed — operators
+		// using a public PyPI Poetry project must explicitly include
+		// "pypi.org" in external_scan_registries to enable scanning.
+		Registry:   "",
 		ResolvedAt: time.Now(),
 	}
 

--- a/internal/pkgcheck/resolver/poetry.go
+++ b/internal/pkgcheck/resolver/poetry.go
@@ -19,7 +19,9 @@ type PoetryResolverConfig struct {
 }
 
 type poetryResolver struct {
-	cfg PoetryResolverConfig
+	cfg        PoetryResolverConfig
+	binary     string
+	prefixArgs []string
 }
 
 // NewPoetryResolver creates a resolver for poetry add commands.
@@ -30,7 +32,16 @@ func NewPoetryResolver(cfg PoetryResolverConfig) pkgcheck.Resolver {
 	if cfg.Timeout == 0 {
 		cfg.Timeout = 30 * time.Second
 	}
-	return &poetryResolver{cfg: cfg}
+	// Split the command string into binary + args. Allows users to configure
+	// a full invocation like "poetry add --dry-run" rather than just the binary path.
+	parts := strings.Fields(cfg.DryRunCommand)
+	binary := cfg.DryRunCommand
+	var prefixArgs []string
+	if len(parts) > 1 {
+		binary = parts[0]
+		prefixArgs = parts[1:]
+	}
+	return &poetryResolver{cfg: cfg, binary: binary, prefixArgs: prefixArgs}
 }
 
 func (r *poetryResolver) Name() string { return "poetry" }
@@ -62,8 +73,9 @@ func (r *poetryResolver) Resolve(ctx context.Context, workDir string, command []
 	// poetry add --dry-run <packages>
 	cmdArgs := []string{"add", "--dry-run"}
 	cmdArgs = append(cmdArgs, packages...)
+	allArgs := append(append([]string(nil), r.prefixArgs...), cmdArgs...)
 
-	cmd := exec.CommandContext(ctx, r.cfg.DryRunCommand, cmdArgs...)
+	cmd := exec.CommandContext(ctx, r.binary, allArgs...)
 	cmd.Dir = workDir
 
 	out, err := cmd.Output()
@@ -103,6 +115,7 @@ func parsePoetryDryRunOutput(data []byte, requestedPkgs []string) (*pkgcheck.Ins
 	plan := &pkgcheck.InstallPlan{
 		Tool:       "poetry",
 		Ecosystem:  pkgcheck.EcosystemPyPI,
+		Registry:   "pypi.org",
 		ResolvedAt: time.Now(),
 	}
 

--- a/internal/pkgcheck/resolver/poetry.go
+++ b/internal/pkgcheck/resolver/poetry.go
@@ -117,12 +117,16 @@ func parsePoetryDryRunOutput(data []byte, requestedPkgs []string) (*pkgcheck.Ins
 	plan := &pkgcheck.InstallPlan{
 		Tool:      "poetry",
 		Ecosystem: pkgcheck.EcosystemPyPI,
-		// Poetry source registries are configured in pyproject.toml's
-		// [[tool.poetry.source]] blocks, which we do not parse. Leaving
-		// Registry empty makes the privacy filter fail closed — operators
-		// using a public PyPI Poetry project must explicitly include
-		// "pypi.org" in external_scan_registries to enable scanning.
-		Registry:   "",
+		// Default to public PyPI. Poetry's [[tool.poetry.source]] blocks
+		// in pyproject.toml can redirect to a private registry, but we
+		// do not parse pyproject.toml. Operators using a private Poetry
+		// source must:
+		//   1. Add their private registry URL to ExternalScanRegistries
+		//      so private packages reach external providers, OR
+		//   2. Set external_scan_registries: [] to disable the privacy
+		//      filter entirely if all their dependencies are private.
+		// This matches pip/uv defaulting behavior.
+		Registry:   "pypi.org",
 		ResolvedAt: time.Now(),
 	}
 

--- a/internal/pkgcheck/resolver/poetry.go
+++ b/internal/pkgcheck/resolver/poetry.go
@@ -81,6 +81,10 @@ func (r *poetryResolver) Resolve(ctx context.Context, workDir string, command []
 		return nil, fmt.Errorf("poetry dry-run failed: %w", err)
 	}
 
+	// TODO: poetry has no equivalent CLI registry override flag; the registry is
+	// configured via [[tool.poetry.source]] in pyproject.toml. Reading that file
+	// to detect a custom source URL is future work. For now the plan always carries
+	// "pypi.org" regardless of the project's source configuration.
 	return parsePoetryDryRunOutput(out, packages)
 }
 

--- a/internal/pkgcheck/resolver/poetry.go
+++ b/internal/pkgcheck/resolver/poetry.go
@@ -14,8 +14,13 @@ import (
 
 // PoetryResolverConfig configures the poetry resolver.
 type PoetryResolverConfig struct {
-	DryRunCommand string        // path to poetry binary; defaults to "poetry"
-	Timeout       time.Duration // timeout for dry-run execution
+	// DryRunCommand is the path to the poetry binary; defaults to "poetry".
+	// For additional args to prepend to the resolver-specific args, use DryRunArgs.
+	DryRunCommand string
+	// DryRunArgs contains args to prepend to the resolver-specific args.
+	// Each element is a single token (no shell splitting is performed).
+	DryRunArgs []string
+	Timeout    time.Duration // timeout for dry-run execution
 }
 
 type poetryResolver struct {
@@ -32,16 +37,9 @@ func NewPoetryResolver(cfg PoetryResolverConfig) pkgcheck.Resolver {
 	if cfg.Timeout == 0 {
 		cfg.Timeout = 30 * time.Second
 	}
-	// Split the command string into binary + args. Allows users to configure
-	// a full invocation like "poetry add --dry-run" rather than just the binary path.
-	parts := strings.Fields(cfg.DryRunCommand)
-	binary := cfg.DryRunCommand
-	var prefixArgs []string
-	if len(parts) > 1 {
-		binary = parts[0]
-		prefixArgs = parts[1:]
-	}
-	return &poetryResolver{cfg: cfg, binary: binary, prefixArgs: prefixArgs}
+	// DryRunCommand is the binary path only; DryRunArgs carries any prefix args.
+	// No shell splitting is performed so paths with spaces are preserved verbatim.
+	return &poetryResolver{cfg: cfg, binary: cfg.DryRunCommand, prefixArgs: cfg.DryRunArgs}
 }
 
 func (r *poetryResolver) Name() string { return "poetry" }

--- a/internal/pkgcheck/resolver/resolver_test.go
+++ b/internal/pkgcheck/resolver/resolver_test.go
@@ -916,3 +916,121 @@ func TestUVResolver_DetectRegistry(t *testing.T) {
 		})
 	}
 }
+
+// --- Scoped package fail-closed tests (Fix 1) ---
+
+func TestIsScopedPackage(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"@acme/foo", true},
+		{"@types/node", true},
+		{"@babel/core", true},
+		{"lodash", false},
+		{"express", false},
+		{"@missingslash", false}, // @ but no /
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isScopedPackage(tt.name))
+		})
+	}
+}
+
+func TestNPMResolver_HasRegistryFlag(t *testing.T) {
+	r := &npmResolver{}
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"no flag", []string{"install", "@acme/foo"}, false},
+		{"--registry space", []string{"install", "--registry", "https://r/"}, true},
+		{"--registry=", []string{"install", "--registry=https://r/"}, true},
+		{"empty", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, r.hasRegistryFlag(tt.args))
+		})
+	}
+}
+
+func TestPNPMResolver_HasRegistryFlag(t *testing.T) {
+	r := &pnpmResolver{}
+	assert.False(t, r.hasRegistryFlag([]string{"add", "@acme/foo"}))
+	assert.True(t, r.hasRegistryFlag([]string{"add", "--registry", "https://r/"}))
+	assert.True(t, r.hasRegistryFlag([]string{"add", "--registry=https://r/"}))
+}
+
+func TestYarnResolver_HasRegistryFlag(t *testing.T) {
+	r := &yarnResolver{}
+	assert.False(t, r.hasRegistryFlag([]string{"add", "@acme/foo"}))
+	assert.True(t, r.hasRegistryFlag([]string{"add", "--registry", "https://r/"}))
+	assert.True(t, r.hasRegistryFlag([]string{"add", "--registry=https://r/"}))
+}
+
+// TestNPMResolver_ScopedPackageRegistryFailsClosed verifies that scoped packages
+// parsed from npm dry-run output get an empty Registry when no --registry flag is
+// present, while unscoped packages get the default registry.
+func TestNPMResolver_ScopedPackageRegistryFailsClosed(t *testing.T) {
+	json := `{"added":[
+		{"name":"@acme/foo","version":"1.2.3"},
+		{"name":"lodash","version":"4.17.21"}
+	]}`
+	plan, err := parseNPMDryRunOutput([]byte(json), []string{"@acme/foo", "lodash"})
+	require.NoError(t, err)
+
+	r := &npmResolver{}
+	planRegistry := r.detectRegistry([]string{"install", "@acme/foo", "lodash"})
+	explicitFlag := r.hasRegistryFlag([]string{"install", "@acme/foo", "lodash"})
+
+	for i := range plan.Direct {
+		if isScopedPackage(plan.Direct[i].Name) && !explicitFlag {
+			plan.Direct[i].Registry = ""
+		} else {
+			plan.Direct[i].Registry = planRegistry
+		}
+	}
+
+	byName := make(map[string]pkgcheck.PackageRef)
+	for _, p := range plan.Direct {
+		byName[p.Name] = p
+	}
+
+	// @acme/foo should have empty Registry (fail closed — could be private)
+	if byName["@acme/foo"].Registry != "" {
+		t.Errorf("expected empty Registry for @acme/foo, got %q", byName["@acme/foo"].Registry)
+	}
+	// lodash should have default registry
+	if byName["lodash"].Registry != "registry.npmjs.org" {
+		t.Errorf("expected registry.npmjs.org for lodash, got %q", byName["lodash"].Registry)
+	}
+}
+
+// TestNPMResolver_ScopedPackageWithExplicitFlagGetsRegistry verifies that scoped
+// packages DO receive the registry when --registry is explicitly set on the CLI.
+func TestNPMResolver_ScopedPackageWithExplicitFlagGetsRegistry(t *testing.T) {
+	json := `{"added":[{"name":"@acme/foo","version":"1.2.3"}]}`
+	plan, err := parseNPMDryRunOutput([]byte(json), []string{"@acme/foo"})
+	require.NoError(t, err)
+
+	r := &npmResolver{}
+	args := []string{"install", "--registry=https://internal.example/", "@acme/foo"}
+	planRegistry := r.detectRegistry(args)
+	explicitFlag := r.hasRegistryFlag(args)
+
+	for i := range plan.Direct {
+		if isScopedPackage(plan.Direct[i].Name) && !explicitFlag {
+			plan.Direct[i].Registry = ""
+		} else {
+			plan.Direct[i].Registry = planRegistry
+		}
+	}
+
+	if plan.Direct[0].Registry != "https://internal.example/" {
+		t.Errorf("expected https://internal.example/, got %q", plan.Direct[0].Registry)
+	}
+}

--- a/internal/pkgcheck/resolver/resolver_test.go
+++ b/internal/pkgcheck/resolver/resolver_test.go
@@ -763,6 +763,22 @@ func TestUVResolver_BinaryPathWithSpacesPreserved(t *testing.T) {
 	assert.Empty(t, r.prefixArgs)
 }
 
+func TestUVResolver_StripsPipInstallSubcommand(t *testing.T) {
+	// Regression: "uv pip install flask" passes ["pip","install","flask"] as
+	// args inside Resolve.  Both "pip" and "install" must be stripped so that
+	// only "flask" is treated as a package name.
+	r := NewUVResolver(UVResolverConfig{}).(*uvResolver)
+	// Simulate what Resolve does: command[1:] → ["pip","install","flask"]
+	args := []string{"pip", "install", "flask"}
+	pkgArgs := args
+	if len(pkgArgs) >= 2 && pkgArgs[0] == "pip" && pkgArgs[1] == "install" {
+		pkgArgs = pkgArgs[2:]
+	}
+	pkgs := extractPkgArgs(pkgArgs)
+	assert.Equal(t, []string{"flask"}, pkgs, "uv should strip both 'pip' and 'install'")
+	_ = r // ensure we hold the type reference
+}
+
 func TestPNPMResolver_DryRunArgs(t *testing.T) {
 	r := NewPNPMResolver(PNPMResolverConfig{
 		DryRunCommand: "pnpm",

--- a/internal/pkgcheck/resolver/resolver_test.go
+++ b/internal/pkgcheck/resolver/resolver_test.go
@@ -809,3 +809,110 @@ func TestPoetryResolver_BinaryPathWithSpacesPreserved(t *testing.T) {
 	assert.Equal(t, "/Program Files/poetry/poetry.exe", r.binary)
 	assert.Empty(t, r.prefixArgs)
 }
+
+// --- Registry detection tests ---
+
+func TestNPMResolver_DetectRegistry(t *testing.T) {
+	r := &npmResolver{}
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"default (no flag)", []string{"install", "lodash"}, "registry.npmjs.org"},
+		{"--registry space", []string{"install", "--registry", "https://internal.example/"}, "https://internal.example/"},
+		{"--registry=", []string{"install", "--registry=https://x/"}, "https://x/"},
+		{"--registry last", []string{"--registry", "https://r/"}, "https://r/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.detectRegistry(tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPNPMResolver_DetectRegistry(t *testing.T) {
+	r := &pnpmResolver{}
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"default", []string{"add", "react"}, "registry.npmjs.org"},
+		{"--registry space", []string{"add", "--registry", "https://internal.example/"}, "https://internal.example/"},
+		{"--registry=", []string{"add", "--registry=https://x/"}, "https://x/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.detectRegistry(tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestYarnResolver_DetectRegistry(t *testing.T) {
+	r := &yarnResolver{}
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"default", []string{"add", "typescript"}, "registry.npmjs.org"},
+		{"--registry space", []string{"add", "--registry", "https://internal.example/"}, "https://internal.example/"},
+		{"--registry=", []string{"add", "--registry=https://x/"}, "https://x/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.detectRegistry(tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPipResolver_DetectRegistry(t *testing.T) {
+	r := &pipResolver{}
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"default", []string{"install", "requests"}, "pypi.org"},
+		{"--index-url space", []string{"install", "--index-url", "https://internal/simple"}, "https://internal/simple"},
+		{"--index-url=", []string{"install", "--index-url=https://internal/simple"}, "https://internal/simple"},
+		{"-i space", []string{"install", "-i", "https://internal/simple"}, "https://internal/simple"},
+		// --extra-index-url → ambiguous origin, return ""
+		{"--extra-index-url space", []string{"install", "requests", "--extra-index-url", "https://internal/simple"}, ""},
+		{"--extra-index-url=", []string{"install", "requests", "--extra-index-url=https://internal/simple"}, ""},
+		// --index-url plus --extra-index-url → still ambiguous
+		{"index-url + extra", []string{"install", "--index-url", "https://primary/", "--extra-index-url", "https://extra/"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.detectRegistry(tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestUVResolver_DetectRegistry(t *testing.T) {
+	r := &uvResolver{}
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"default", []string{"pip", "install", "flask"}, "pypi.org"},
+		{"--index-url space", []string{"pip", "install", "--index-url", "https://internal/simple"}, "https://internal/simple"},
+		{"--index-url=", []string{"pip", "install", "--index-url=https://internal/simple"}, "https://internal/simple"},
+		// --extra-index-url → ambiguous origin, return ""
+		{"--extra-index-url space", []string{"pip", "install", "flask", "--extra-index-url", "https://internal/simple"}, ""},
+		{"--extra-index-url=", []string{"pip", "install", "flask", "--extra-index-url=https://internal/simple"}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.detectRegistry(tt.args)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/pkgcheck/resolver/resolver_test.go
+++ b/internal/pkgcheck/resolver/resolver_test.go
@@ -665,3 +665,99 @@ func TestNPMResolver_CustomConfig(t *testing.T) {
 	assert.Equal(t, "/custom/npm", r.cfg.DryRunCommand)
 	assert.Equal(t, 60*time.Second, r.cfg.Timeout)
 }
+
+// --- Registry field tests ---
+
+func TestNPMResolver_PlanCarriesRegistry(t *testing.T) {
+	plan, err := parseNPMDryRunOutput([]byte(`{"added":[{"name":"express","version":"4.18.2"}]}`), []string{"express"})
+	require.NoError(t, err)
+	assert.Equal(t, "registry.npmjs.org", plan.Registry)
+}
+
+func TestPipResolver_PlanCarriesRegistry(t *testing.T) {
+	plan, err := parsePipDryRunOutput([]byte(`{"install":[{"metadata":{"name":"flask","version":"3.0.0"},"requested":true}]}`), []string{"flask"})
+	require.NoError(t, err)
+	assert.Equal(t, "pypi.org", plan.Registry)
+}
+
+func TestUVResolver_PlanCarriesRegistry(t *testing.T) {
+	plan, err := parseUVDryRunOutput([]byte("Would install flask-3.0.0\n"), []string{"flask"})
+	require.NoError(t, err)
+	assert.Equal(t, "pypi.org", plan.Registry)
+}
+
+func TestPNPMResolver_PlanCarriesRegistry(t *testing.T) {
+	plan, err := parsePNPMDryRunOutput([]byte(`{"added":[{"name":"react","version":"18.2.0"}]}`), []string{"react"})
+	require.NoError(t, err)
+	assert.Equal(t, "registry.npmjs.org", plan.Registry)
+}
+
+func TestYarnResolver_PlanCarriesRegistry(t *testing.T) {
+	plan, err := parseYarnDryRunOutput([]byte(`{"added":[{"name":"typescript","version":"5.3.3"}]}`), []string{"typescript"})
+	require.NoError(t, err)
+	assert.Equal(t, "registry.npmjs.org", plan.Registry)
+}
+
+func TestPoetryResolver_PlanCarriesRegistry(t *testing.T) {
+	plan, err := parsePoetryDryRunOutput([]byte(`{"added":[{"name":"django","version":"5.0.1"}]}`), []string{"django"})
+	require.NoError(t, err)
+	assert.Equal(t, "pypi.org", plan.Registry)
+}
+
+// --- DryRunCommand multi-token parsing tests ---
+
+func TestNPMResolver_MultiTokenDryRunCommand(t *testing.T) {
+	r := NewNPMResolver(NPMResolverConfig{
+		DryRunCommand: "npx npm --prefix /tmp",
+	}).(*npmResolver)
+	assert.Equal(t, "npx", r.binary)
+	assert.Equal(t, []string{"npm", "--prefix", "/tmp"}, r.prefixArgs)
+}
+
+func TestNPMResolver_SingleTokenDryRunCommand(t *testing.T) {
+	r := NewNPMResolver(NPMResolverConfig{
+		DryRunCommand: "/usr/local/bin/npm",
+	}).(*npmResolver)
+	assert.Equal(t, "/usr/local/bin/npm", r.binary)
+	assert.Empty(t, r.prefixArgs)
+}
+
+func TestPipResolver_MultiTokenDryRunCommand(t *testing.T) {
+	r := NewPipResolver(PipResolverConfig{
+		DryRunCommand: "python -m pip",
+	}).(*pipResolver)
+	assert.Equal(t, "python", r.binary)
+	assert.Equal(t, []string{"-m", "pip"}, r.prefixArgs)
+}
+
+func TestUVResolver_MultiTokenDryRunCommand(t *testing.T) {
+	r := NewUVResolver(UVResolverConfig{
+		DryRunCommand: "/usr/local/bin/uv --quiet",
+	}).(*uvResolver)
+	assert.Equal(t, "/usr/local/bin/uv", r.binary)
+	assert.Equal(t, []string{"--quiet"}, r.prefixArgs)
+}
+
+func TestPNPMResolver_MultiTokenDryRunCommand(t *testing.T) {
+	r := NewPNPMResolver(PNPMResolverConfig{
+		DryRunCommand: "pnpm --store-dir /tmp",
+	}).(*pnpmResolver)
+	assert.Equal(t, "pnpm", r.binary)
+	assert.Equal(t, []string{"--store-dir", "/tmp"}, r.prefixArgs)
+}
+
+func TestYarnResolver_MultiTokenDryRunCommand(t *testing.T) {
+	r := NewYarnResolver(YarnResolverConfig{
+		DryRunCommand: "yarn --cwd /tmp",
+	}).(*yarnResolver)
+	assert.Equal(t, "yarn", r.binary)
+	assert.Equal(t, []string{"--cwd", "/tmp"}, r.prefixArgs)
+}
+
+func TestPoetryResolver_MultiTokenDryRunCommand(t *testing.T) {
+	r := NewPoetryResolver(PoetryResolverConfig{
+		DryRunCommand: "poetry --no-ansi",
+	}).(*poetryResolver)
+	assert.Equal(t, "poetry", r.binary)
+	assert.Equal(t, []string{"--no-ansi"}, r.prefixArgs)
+}

--- a/internal/pkgcheck/resolver/resolver_test.go
+++ b/internal/pkgcheck/resolver/resolver_test.go
@@ -699,13 +699,13 @@ func TestYarnResolver_PlanCarriesRegistry(t *testing.T) {
 	assert.Equal(t, "registry.npmjs.org", plan.Registry)
 }
 
-func TestPoetryResolver_PlanCarriesEmptyRegistryFailClosed(t *testing.T) {
+func TestPoetryResolver_PlanCarriesDefaultRegistry(t *testing.T) {
 	// Poetry source registries live in pyproject.toml; we don't parse it.
-	// The resolver leaves Registry empty so the privacy filter fails closed
-	// — operators using public PyPI must allowlist "pypi.org" explicitly.
+	// The resolver defaults to pypi.org so the privacy filter works like pip/uv.
+	// Operators using a private registry must allowlist it via ExternalScanRegistries.
 	plan, err := parsePoetryDryRunOutput([]byte(`{"added":[{"name":"django","version":"5.0.1"}]}`), []string{"django"})
 	require.NoError(t, err)
-	assert.Equal(t, "", plan.Registry)
+	assert.Equal(t, "pypi.org", plan.Registry)
 }
 
 // --- DryRunArgs explicit-fields tests ---

--- a/internal/pkgcheck/resolver/resolver_test.go
+++ b/internal/pkgcheck/resolver/resolver_test.go
@@ -699,10 +699,13 @@ func TestYarnResolver_PlanCarriesRegistry(t *testing.T) {
 	assert.Equal(t, "registry.npmjs.org", plan.Registry)
 }
 
-func TestPoetryResolver_PlanCarriesRegistry(t *testing.T) {
+func TestPoetryResolver_PlanCarriesEmptyRegistryFailClosed(t *testing.T) {
+	// Poetry source registries live in pyproject.toml; we don't parse it.
+	// The resolver leaves Registry empty so the privacy filter fails closed
+	// — operators using public PyPI must allowlist "pypi.org" explicitly.
 	plan, err := parsePoetryDryRunOutput([]byte(`{"added":[{"name":"django","version":"5.0.1"}]}`), []string{"django"})
 	require.NoError(t, err)
-	assert.Equal(t, "pypi.org", plan.Registry)
+	assert.Equal(t, "", plan.Registry)
 }
 
 // --- DryRunArgs explicit-fields tests ---

--- a/internal/pkgcheck/resolver/resolver_test.go
+++ b/internal/pkgcheck/resolver/resolver_test.go
@@ -704,60 +704,108 @@ func TestPoetryResolver_PlanCarriesRegistry(t *testing.T) {
 	assert.Equal(t, "pypi.org", plan.Registry)
 }
 
-// --- DryRunCommand multi-token parsing tests ---
+// --- DryRunArgs explicit-fields tests ---
 
-func TestNPMResolver_MultiTokenDryRunCommand(t *testing.T) {
+func TestNPMResolver_DryRunArgs(t *testing.T) {
 	r := NewNPMResolver(NPMResolverConfig{
-		DryRunCommand: "npx npm --prefix /tmp",
+		DryRunCommand: "npx",
+		DryRunArgs:    []string{"npm", "--prefix", "/tmp"},
 	}).(*npmResolver)
 	assert.Equal(t, "npx", r.binary)
 	assert.Equal(t, []string{"npm", "--prefix", "/tmp"}, r.prefixArgs)
 }
 
-func TestNPMResolver_SingleTokenDryRunCommand(t *testing.T) {
+func TestNPMResolver_BinaryPathWithSpacesPreserved(t *testing.T) {
 	r := NewNPMResolver(NPMResolverConfig{
-		DryRunCommand: "/usr/local/bin/npm",
+		DryRunCommand: "/Program Files/node/npm.cmd",
+		DryRunArgs:    []string{"install", "--package-lock-only"},
 	}).(*npmResolver)
-	assert.Equal(t, "/usr/local/bin/npm", r.binary)
-	assert.Empty(t, r.prefixArgs)
+	assert.Equal(t, "/Program Files/node/npm.cmd", r.binary)
+	assert.Equal(t, []string{"install", "--package-lock-only"}, r.prefixArgs)
 }
 
-func TestPipResolver_MultiTokenDryRunCommand(t *testing.T) {
+func TestPipResolver_DryRunArgs(t *testing.T) {
 	r := NewPipResolver(PipResolverConfig{
-		DryRunCommand: "python -m pip",
+		DryRunCommand: "python",
+		DryRunArgs:    []string{"-m", "pip"},
 	}).(*pipResolver)
 	assert.Equal(t, "python", r.binary)
 	assert.Equal(t, []string{"-m", "pip"}, r.prefixArgs)
 }
 
-func TestUVResolver_MultiTokenDryRunCommand(t *testing.T) {
+func TestPipResolver_BinaryPathWithSpacesPreserved(t *testing.T) {
+	r := NewPipResolver(PipResolverConfig{
+		DryRunCommand: "/Program Files/Python312/python.exe",
+		DryRunArgs:    []string{"-m", "pip"},
+	}).(*pipResolver)
+	assert.Equal(t, "/Program Files/Python312/python.exe", r.binary)
+	assert.Equal(t, []string{"-m", "pip"}, r.prefixArgs)
+}
+
+func TestUVResolver_DryRunArgs(t *testing.T) {
 	r := NewUVResolver(UVResolverConfig{
-		DryRunCommand: "/usr/local/bin/uv --quiet",
+		DryRunCommand: "/usr/local/bin/uv",
+		DryRunArgs:    []string{"--quiet"},
 	}).(*uvResolver)
 	assert.Equal(t, "/usr/local/bin/uv", r.binary)
 	assert.Equal(t, []string{"--quiet"}, r.prefixArgs)
 }
 
-func TestPNPMResolver_MultiTokenDryRunCommand(t *testing.T) {
+func TestUVResolver_BinaryPathWithSpacesPreserved(t *testing.T) {
+	r := NewUVResolver(UVResolverConfig{
+		DryRunCommand: "/Program Files/uv/uv.exe",
+	}).(*uvResolver)
+	assert.Equal(t, "/Program Files/uv/uv.exe", r.binary)
+	assert.Empty(t, r.prefixArgs)
+}
+
+func TestPNPMResolver_DryRunArgs(t *testing.T) {
 	r := NewPNPMResolver(PNPMResolverConfig{
-		DryRunCommand: "pnpm --store-dir /tmp",
+		DryRunCommand: "pnpm",
+		DryRunArgs:    []string{"--store-dir", "/tmp"},
 	}).(*pnpmResolver)
 	assert.Equal(t, "pnpm", r.binary)
 	assert.Equal(t, []string{"--store-dir", "/tmp"}, r.prefixArgs)
 }
 
-func TestYarnResolver_MultiTokenDryRunCommand(t *testing.T) {
+func TestPNPMResolver_BinaryPathWithSpacesPreserved(t *testing.T) {
+	r := NewPNPMResolver(PNPMResolverConfig{
+		DryRunCommand: "/Program Files/pnpm/pnpm.cmd",
+	}).(*pnpmResolver)
+	assert.Equal(t, "/Program Files/pnpm/pnpm.cmd", r.binary)
+	assert.Empty(t, r.prefixArgs)
+}
+
+func TestYarnResolver_DryRunArgs(t *testing.T) {
 	r := NewYarnResolver(YarnResolverConfig{
-		DryRunCommand: "yarn --cwd /tmp",
+		DryRunCommand: "yarn",
+		DryRunArgs:    []string{"--cwd", "/tmp"},
 	}).(*yarnResolver)
 	assert.Equal(t, "yarn", r.binary)
 	assert.Equal(t, []string{"--cwd", "/tmp"}, r.prefixArgs)
 }
 
-func TestPoetryResolver_MultiTokenDryRunCommand(t *testing.T) {
+func TestYarnResolver_BinaryPathWithSpacesPreserved(t *testing.T) {
+	r := NewYarnResolver(YarnResolverConfig{
+		DryRunCommand: "/Program Files/yarn/bin/yarn.cmd",
+	}).(*yarnResolver)
+	assert.Equal(t, "/Program Files/yarn/bin/yarn.cmd", r.binary)
+	assert.Empty(t, r.prefixArgs)
+}
+
+func TestPoetryResolver_DryRunArgs(t *testing.T) {
 	r := NewPoetryResolver(PoetryResolverConfig{
-		DryRunCommand: "poetry --no-ansi",
+		DryRunCommand: "poetry",
+		DryRunArgs:    []string{"--no-ansi"},
 	}).(*poetryResolver)
 	assert.Equal(t, "poetry", r.binary)
 	assert.Equal(t, []string{"--no-ansi"}, r.prefixArgs)
+}
+
+func TestPoetryResolver_BinaryPathWithSpacesPreserved(t *testing.T) {
+	r := NewPoetryResolver(PoetryResolverConfig{
+		DryRunCommand: "/Program Files/poetry/poetry.exe",
+	}).(*poetryResolver)
+	assert.Equal(t, "/Program Files/poetry/poetry.exe", r.binary)
+	assert.Empty(t, r.prefixArgs)
 }

--- a/internal/pkgcheck/resolver/resolver_test.go
+++ b/internal/pkgcheck/resolver/resolver_test.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"testing"
 	"time"
@@ -1032,5 +1033,110 @@ func TestNPMResolver_ScopedPackageWithExplicitFlagGetsRegistry(t *testing.T) {
 
 	if plan.Direct[0].Registry != "https://internal.example/" {
 		t.Errorf("expected https://internal.example/, got %q", plan.Direct[0].Registry)
+	}
+}
+
+// --- Extract registry/index-url flag tests (Fix A) ---
+
+func TestNPMResolver_ExtractRegistryFlags(t *testing.T) {
+	r := &npmResolver{}
+	cases := []struct {
+		in   []string
+		want []string
+	}{
+		{[]string{"install", "lodash"}, nil},
+		{[]string{"install", "--registry", "https://internal/", "lodash"}, []string{"--registry", "https://internal/"}},
+		{[]string{"install", "--registry=https://x/", "lodash"}, []string{"--registry=https://x/"}},
+		{nil, nil},
+	}
+	for _, c := range cases {
+		got := r.extractRegistryFlags(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("input %v: got %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestPNPMResolver_ExtractRegistryFlags(t *testing.T) {
+	r := &pnpmResolver{}
+	cases := []struct {
+		in   []string
+		want []string
+	}{
+		{[]string{"add", "react"}, nil},
+		{[]string{"add", "--registry", "https://internal/", "react"}, []string{"--registry", "https://internal/"}},
+		{[]string{"add", "--registry=https://x/", "react"}, []string{"--registry=https://x/"}},
+	}
+	for _, c := range cases {
+		got := r.extractRegistryFlags(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("input %v: got %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestYarnResolver_ExtractRegistryFlags(t *testing.T) {
+	r := &yarnResolver{}
+	cases := []struct {
+		in   []string
+		want []string
+	}{
+		{[]string{"add", "typescript"}, nil},
+		{[]string{"add", "--registry", "https://internal/", "typescript"}, []string{"--registry", "https://internal/"}},
+		{[]string{"add", "--registry=https://x/", "typescript"}, []string{"--registry=https://x/"}},
+	}
+	for _, c := range cases {
+		got := r.extractRegistryFlags(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("input %v: got %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestPipResolver_ExtractIndexURLFlags(t *testing.T) {
+	r := &pipResolver{}
+	cases := []struct {
+		in   []string
+		want []string
+	}{
+		{[]string{"install", "requests"}, nil},
+		{[]string{"install", "--index-url", "https://internal/simple", "requests"}, []string{"--index-url", "https://internal/simple"}},
+		{[]string{"install", "--index-url=https://internal/simple", "requests"}, []string{"--index-url=https://internal/simple"}},
+		{[]string{"install", "-i", "https://internal/simple", "requests"}, []string{"-i", "https://internal/simple"}},
+		{[]string{"install", "--extra-index-url", "https://extra/simple", "requests"}, []string{"--extra-index-url", "https://extra/simple"}},
+		{[]string{"install", "--extra-index-url=https://extra/simple", "requests"}, []string{"--extra-index-url=https://extra/simple"}},
+		{
+			[]string{"install", "--index-url", "https://primary/", "--extra-index-url", "https://extra/", "requests"},
+			[]string{"--index-url", "https://primary/", "--extra-index-url", "https://extra/"},
+		},
+	}
+	for _, c := range cases {
+		got := r.extractIndexURLFlags(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("input %v: got %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestUVResolver_ExtractIndexURLFlags(t *testing.T) {
+	r := &uvResolver{}
+	cases := []struct {
+		in   []string
+		want []string
+	}{
+		{[]string{"pip", "install", "flask"}, nil},
+		{[]string{"pip", "install", "--index-url", "https://internal/simple", "flask"}, []string{"--index-url", "https://internal/simple"}},
+		{[]string{"pip", "install", "--index-url=https://internal/simple", "flask"}, []string{"--index-url=https://internal/simple"}},
+		{[]string{"pip", "install", "--extra-index-url", "https://extra/simple", "flask"}, []string{"--extra-index-url", "https://extra/simple"}},
+		{
+			[]string{"pip", "install", "--index-url", "https://primary/", "--extra-index-url", "https://extra/", "flask"},
+			[]string{"--index-url", "https://primary/", "--extra-index-url", "https://extra/"},
+		},
+	}
+	for _, c := range cases {
+		got := r.extractIndexURLFlags(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("input %v: got %v, want %v", c.in, got, c.want)
+		}
 	}
 }

--- a/internal/pkgcheck/resolver/uv.go
+++ b/internal/pkgcheck/resolver/uv.go
@@ -15,8 +15,13 @@ import (
 
 // UVResolverConfig configures the uv resolver.
 type UVResolverConfig struct {
-	DryRunCommand string        // path to uv binary; defaults to "uv"
-	Timeout       time.Duration // timeout for dry-run execution
+	// DryRunCommand is the path to the uv binary; defaults to "uv".
+	// For additional args to prepend to the resolver-specific args, use DryRunArgs.
+	DryRunCommand string
+	// DryRunArgs contains args to prepend to the resolver-specific args.
+	// Each element is a single token (no shell splitting is performed).
+	DryRunArgs []string
+	Timeout    time.Duration // timeout for dry-run execution
 }
 
 type uvResolver struct {
@@ -33,16 +38,9 @@ func NewUVResolver(cfg UVResolverConfig) pkgcheck.Resolver {
 	if cfg.Timeout == 0 {
 		cfg.Timeout = 30 * time.Second
 	}
-	// Split the command string into binary + args. Allows users to configure
-	// a full invocation like "uv pip install --dry-run" rather than just the binary path.
-	parts := strings.Fields(cfg.DryRunCommand)
-	binary := cfg.DryRunCommand
-	var prefixArgs []string
-	if len(parts) > 1 {
-		binary = parts[0]
-		prefixArgs = parts[1:]
-	}
-	return &uvResolver{cfg: cfg, binary: binary, prefixArgs: prefixArgs}
+	// DryRunCommand is the binary path only; DryRunArgs carries any prefix args.
+	// No shell splitting is performed so paths with spaces are preserved verbatim.
+	return &uvResolver{cfg: cfg, binary: cfg.DryRunCommand, prefixArgs: cfg.DryRunArgs}
 }
 
 func (r *uvResolver) Name() string { return "uv" }

--- a/internal/pkgcheck/resolver/uv.go
+++ b/internal/pkgcheck/resolver/uv.go
@@ -68,7 +68,15 @@ func (r *uvResolver) Resolve(ctx context.Context, workDir string, command []stri
 	var args []string
 	if len(command) > 1 {
 		args = command[1:]
-		packages = extractPkgArgs(args)
+		// uv uses a two-token subcommand ("pip install").  Strip both tokens
+		// before extracting package names so "install" is not mistaken for a
+		// package name.  CanResolve already guarantees args[0]=="pip" and
+		// args[1]=="install" when we reach this path.
+		pkgArgs := args
+		if len(pkgArgs) >= 2 && pkgArgs[0] == "pip" && pkgArgs[1] == "install" {
+			pkgArgs = pkgArgs[2:]
+		}
+		packages = extractPkgArgs(pkgArgs)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.Timeout)

--- a/internal/pkgcheck/resolver/uv.go
+++ b/internal/pkgcheck/resolver/uv.go
@@ -74,8 +74,12 @@ func (r *uvResolver) Resolve(ctx context.Context, workDir string, command []stri
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.Timeout)
 	defer cancel()
 
-	// uv pip install --dry-run <packages>
+	// uv pip install --dry-run [--index-url <url>] [--extra-index-url <url>] <packages>
+	// Forward any --index-url / --extra-index-url flags from the original
+	// command so the dry-run resolves against the same index the actual install
+	// will use.
 	cmdArgs := []string{"pip", "install", "--dry-run"}
+	cmdArgs = append(cmdArgs, r.extractIndexURLFlags(command)...)
 	cmdArgs = append(cmdArgs, packages...)
 	allArgs := append(append([]string(nil), r.prefixArgs...), cmdArgs...)
 
@@ -93,6 +97,30 @@ func (r *uvResolver) Resolve(ctx context.Context, workDir string, command []stri
 	}
 	plan.Registry = r.detectRegistry(args)
 	return plan, nil
+}
+
+// extractIndexURLFlags returns the subset of args that influence which
+// index/registry packages resolve from (--index-url, --extra-index-url).
+// Pass these to the dry-run so the resolver hits the same source the actual
+// install will use.
+func (r *uvResolver) extractIndexURLFlags(args []string) []string {
+	var out []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--index-url" && i+1 < len(args):
+			out = append(out, a, args[i+1])
+			i++
+		case strings.HasPrefix(a, "--index-url="):
+			out = append(out, a)
+		case a == "--extra-index-url" && i+1 < len(args):
+			out = append(out, a, args[i+1])
+			i++
+		case strings.HasPrefix(a, "--extra-index-url="):
+			out = append(out, a)
+		}
+	}
+	return out
 }
 
 // detectRegistry scans the uv pip install command args for registry override flags.

--- a/internal/pkgcheck/resolver/uv.go
+++ b/internal/pkgcheck/resolver/uv.go
@@ -65,8 +65,10 @@ func (r *uvResolver) CanResolve(command string, args []string) bool {
 
 func (r *uvResolver) Resolve(ctx context.Context, workDir string, command []string) (*pkgcheck.InstallPlan, error) {
 	var packages []string
+	var args []string
 	if len(command) > 1 {
-		packages = extractPkgArgs(command[1:])
+		args = command[1:]
+		packages = extractPkgArgs(args)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.Timeout)
@@ -85,7 +87,46 @@ func (r *uvResolver) Resolve(ctx context.Context, workDir string, command []stri
 		return nil, fmt.Errorf("uv dry-run failed: %w", err)
 	}
 
-	return parseUVDryRunOutput(out, packages)
+	plan, err := parseUVDryRunOutput(out, packages)
+	if err != nil {
+		return nil, err
+	}
+	plan.Registry = r.detectRegistry(args)
+	return plan, nil
+}
+
+// detectRegistry scans the uv pip install command args for registry override flags.
+//
+// --index-url sets the primary registry; return it directly.
+// --extra-index-url means "also use this registry", so the package may have
+// come from EITHER the primary or the extra registry. We can't tell which, so
+// we return "" (unknown) to let the privacy filter fail closed rather than
+// accidentally claiming the package came from a known-public registry.
+func (r *uvResolver) detectRegistry(args []string) string {
+	hasExtra := false
+	primary := "pypi.org"
+
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--index-url" && i+1 < len(args):
+			primary = args[i+1]
+			i++
+		case strings.HasPrefix(a, "--index-url="):
+			primary = strings.TrimPrefix(a, "--index-url=")
+		case a == "--extra-index-url" && i+1 < len(args):
+			hasExtra = true
+			i++
+		case strings.HasPrefix(a, "--extra-index-url="):
+			hasExtra = true
+		}
+	}
+
+	if hasExtra {
+		// Package origin is ambiguous — return "" so privacy filter fails closed.
+		return ""
+	}
+	return primary
 }
 
 // parseUVDryRunOutput parses uv's --dry-run text output into an InstallPlan.

--- a/internal/pkgcheck/resolver/uv.go
+++ b/internal/pkgcheck/resolver/uv.go
@@ -20,7 +20,9 @@ type UVResolverConfig struct {
 }
 
 type uvResolver struct {
-	cfg UVResolverConfig
+	cfg        UVResolverConfig
+	binary     string
+	prefixArgs []string
 }
 
 // NewUVResolver creates a resolver for uv pip install and uv add commands.
@@ -31,7 +33,16 @@ func NewUVResolver(cfg UVResolverConfig) pkgcheck.Resolver {
 	if cfg.Timeout == 0 {
 		cfg.Timeout = 30 * time.Second
 	}
-	return &uvResolver{cfg: cfg}
+	// Split the command string into binary + args. Allows users to configure
+	// a full invocation like "uv pip install --dry-run" rather than just the binary path.
+	parts := strings.Fields(cfg.DryRunCommand)
+	binary := cfg.DryRunCommand
+	var prefixArgs []string
+	if len(parts) > 1 {
+		binary = parts[0]
+		prefixArgs = parts[1:]
+	}
+	return &uvResolver{cfg: cfg, binary: binary, prefixArgs: prefixArgs}
 }
 
 func (r *uvResolver) Name() string { return "uv" }
@@ -66,8 +77,9 @@ func (r *uvResolver) Resolve(ctx context.Context, workDir string, command []stri
 	// uv pip install --dry-run <packages>
 	cmdArgs := []string{"pip", "install", "--dry-run"}
 	cmdArgs = append(cmdArgs, packages...)
+	allArgs := append(append([]string(nil), r.prefixArgs...), cmdArgs...)
 
-	cmd := exec.CommandContext(ctx, r.cfg.DryRunCommand, cmdArgs...)
+	cmd := exec.CommandContext(ctx, r.binary, allArgs...)
 	cmd.Dir = workDir
 
 	out, err := cmd.Output()
@@ -98,6 +110,7 @@ func parseUVDryRunOutput(data []byte, requestedPkgs []string) (*pkgcheck.Install
 	plan := &pkgcheck.InstallPlan{
 		Tool:       "uv",
 		Ecosystem:  pkgcheck.EcosystemPyPI,
+		Registry:   "pypi.org",
 		ResolvedAt: time.Now(),
 	}
 

--- a/internal/pkgcheck/resolver/yarn.go
+++ b/internal/pkgcheck/resolver/yarn.go
@@ -14,8 +14,13 @@ import (
 
 // YarnResolverConfig configures the yarn resolver.
 type YarnResolverConfig struct {
-	DryRunCommand string        // path to yarn binary; defaults to "yarn"
-	Timeout       time.Duration // timeout for dry-run execution
+	// DryRunCommand is the path to the yarn binary; defaults to "yarn".
+	// For additional args to prepend to the resolver-specific args, use DryRunArgs.
+	DryRunCommand string
+	// DryRunArgs contains args to prepend to the resolver-specific args.
+	// Each element is a single token (no shell splitting is performed).
+	DryRunArgs []string
+	Timeout    time.Duration // timeout for dry-run execution
 }
 
 type yarnResolver struct {
@@ -32,16 +37,9 @@ func NewYarnResolver(cfg YarnResolverConfig) pkgcheck.Resolver {
 	if cfg.Timeout == 0 {
 		cfg.Timeout = 30 * time.Second
 	}
-	// Split the command string into binary + args. Allows users to configure
-	// a full invocation like "yarn add --mode update-lockfile" rather than just the binary path.
-	parts := strings.Fields(cfg.DryRunCommand)
-	binary := cfg.DryRunCommand
-	var prefixArgs []string
-	if len(parts) > 1 {
-		binary = parts[0]
-		prefixArgs = parts[1:]
-	}
-	return &yarnResolver{cfg: cfg, binary: binary, prefixArgs: prefixArgs}
+	// DryRunCommand is the binary path only; DryRunArgs carries any prefix args.
+	// No shell splitting is performed so paths with spaces are preserved verbatim.
+	return &yarnResolver{cfg: cfg, binary: cfg.DryRunCommand, prefixArgs: cfg.DryRunArgs}
 }
 
 func (r *yarnResolver) Name() string { return "yarn" }

--- a/internal/pkgcheck/resolver/yarn.go
+++ b/internal/pkgcheck/resolver/yarn.go
@@ -61,8 +61,10 @@ func (r *yarnResolver) CanResolve(command string, args []string) bool {
 
 func (r *yarnResolver) Resolve(ctx context.Context, workDir string, command []string) (*pkgcheck.InstallPlan, error) {
 	var packages []string
+	var args []string
 	if len(command) > 1 {
-		packages = extractPkgArgs(command[1:])
+		args = command[1:]
+		packages = extractPkgArgs(args)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.Timeout)
@@ -81,7 +83,29 @@ func (r *yarnResolver) Resolve(ctx context.Context, workDir string, command []st
 		return nil, fmt.Errorf("yarn dry-run failed: %w", err)
 	}
 
-	return parseYarnDryRunOutput(out, packages)
+	plan, err := parseYarnDryRunOutput(out, packages)
+	if err != nil {
+		return nil, err
+	}
+	plan.Registry = r.detectRegistry(args)
+	return plan, nil
+}
+
+// detectRegistry scans the install command args for an explicit --registry
+// flag and returns its value. Falls back to the public npm registry.
+// yarn 1.x supports --registry; yarn 2+ uses different config but
+// the CLI flag still works for overrides.
+func (r *yarnResolver) detectRegistry(args []string) string {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--registry" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(a, "--registry=") {
+			return strings.TrimPrefix(a, "--registry=")
+		}
+	}
+	return "registry.npmjs.org"
 }
 
 // yarnDryRunOutput represents yarn's JSON output structure.

--- a/internal/pkgcheck/resolver/yarn.go
+++ b/internal/pkgcheck/resolver/yarn.go
@@ -19,7 +19,9 @@ type YarnResolverConfig struct {
 }
 
 type yarnResolver struct {
-	cfg YarnResolverConfig
+	cfg        YarnResolverConfig
+	binary     string
+	prefixArgs []string
 }
 
 // NewYarnResolver creates a resolver for yarn add commands.
@@ -30,7 +32,16 @@ func NewYarnResolver(cfg YarnResolverConfig) pkgcheck.Resolver {
 	if cfg.Timeout == 0 {
 		cfg.Timeout = 30 * time.Second
 	}
-	return &yarnResolver{cfg: cfg}
+	// Split the command string into binary + args. Allows users to configure
+	// a full invocation like "yarn add --mode update-lockfile" rather than just the binary path.
+	parts := strings.Fields(cfg.DryRunCommand)
+	binary := cfg.DryRunCommand
+	var prefixArgs []string
+	if len(parts) > 1 {
+		binary = parts[0]
+		prefixArgs = parts[1:]
+	}
+	return &yarnResolver{cfg: cfg, binary: binary, prefixArgs: prefixArgs}
 }
 
 func (r *yarnResolver) Name() string { return "yarn" }
@@ -62,8 +73,9 @@ func (r *yarnResolver) Resolve(ctx context.Context, workDir string, command []st
 	// yarn add --mode update-lockfile <packages>
 	cmdArgs := []string{"add", "--mode", "update-lockfile"}
 	cmdArgs = append(cmdArgs, packages...)
+	allArgs := append(append([]string(nil), r.prefixArgs...), cmdArgs...)
 
-	cmd := exec.CommandContext(ctx, r.cfg.DryRunCommand, cmdArgs...)
+	cmd := exec.CommandContext(ctx, r.binary, allArgs...)
 	cmd.Dir = workDir
 
 	out, err := cmd.Output()
@@ -102,6 +114,7 @@ func parseYarnDryRunOutput(data []byte, requestedPkgs []string) (*pkgcheck.Insta
 	plan := &pkgcheck.InstallPlan{
 		Tool:       "yarn",
 		Ecosystem:  pkgcheck.EcosystemNPM,
+		Registry:   "registry.npmjs.org",
 		ResolvedAt: time.Now(),
 	}
 

--- a/internal/pkgcheck/resolver/yarn.go
+++ b/internal/pkgcheck/resolver/yarn.go
@@ -70,8 +70,11 @@ func (r *yarnResolver) Resolve(ctx context.Context, workDir string, command []st
 	ctx, cancel := context.WithTimeout(ctx, r.cfg.Timeout)
 	defer cancel()
 
-	// yarn add --mode update-lockfile <packages>
+	// yarn add --mode update-lockfile [--registry <url>] <packages>
+	// Forward any --registry flag from the original command so the dry-run
+	// resolves against the same registry the actual install will use.
 	cmdArgs := []string{"add", "--mode", "update-lockfile"}
+	cmdArgs = append(cmdArgs, r.extractRegistryFlags(command)...)
 	cmdArgs = append(cmdArgs, packages...)
 	allArgs := append(append([]string(nil), r.prefixArgs...), cmdArgs...)
 
@@ -105,6 +108,25 @@ func (r *yarnResolver) Resolve(ctx context.Context, workDir string, command []st
 		}
 	}
 	return plan, nil
+}
+
+// extractRegistryFlags returns the subset of args that influence which
+// registry packages resolve from. Pass these to the dry-run so the
+// resolver hits the same source the actual install will.
+func (r *yarnResolver) extractRegistryFlags(args []string) []string {
+	var out []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--registry" && i+1 < len(args) {
+			out = append(out, a, args[i+1])
+			i++
+			continue
+		}
+		if strings.HasPrefix(a, "--registry=") {
+			out = append(out, a)
+		}
+	}
+	return out
 }
 
 // hasRegistryFlag reports whether the args slice contains an explicit

--- a/internal/pkgcheck/resolver/yarn.go
+++ b/internal/pkgcheck/resolver/yarn.go
@@ -87,8 +87,35 @@ func (r *yarnResolver) Resolve(ctx context.Context, workDir string, command []st
 	if err != nil {
 		return nil, err
 	}
-	plan.Registry = r.detectRegistry(args)
+	planRegistry := r.detectRegistry(args)
+	plan.Registry = planRegistry
+	explicitFlag := r.hasRegistryFlag(args)
+	for i := range plan.Direct {
+		if isScopedPackage(plan.Direct[i].Name) && !explicitFlag {
+			plan.Direct[i].Registry = ""
+		} else {
+			plan.Direct[i].Registry = planRegistry
+		}
+	}
+	for i := range plan.Transitive {
+		if isScopedPackage(plan.Transitive[i].Name) && !explicitFlag {
+			plan.Transitive[i].Registry = ""
+		} else {
+			plan.Transitive[i].Registry = planRegistry
+		}
+	}
 	return plan, nil
+}
+
+// hasRegistryFlag reports whether the args slice contains an explicit
+// --registry flag (with or without =).
+func (r *yarnResolver) hasRegistryFlag(args []string) bool {
+	for _, a := range args {
+		if a == "--registry" || strings.HasPrefix(a, "--registry=") {
+			return true
+		}
+	}
+	return false
 }
 
 // detectRegistry scans the install command args for an explicit --registry

--- a/internal/pkgcheck/types.go
+++ b/internal/pkgcheck/types.go
@@ -149,12 +149,33 @@ type PackageVerdict struct {
 	Findings []Finding     `json:"findings,omitempty" yaml:"findings,omitempty"`
 }
 
+// SkipReason describes why a package was excluded from external scanning.
+type SkipReason string
+
+const (
+	// SkipReasonPrivateRegistry indicates the package was resolved from a
+	// registry not on the external-scan allowlist.
+	SkipReasonPrivateRegistry SkipReason = "private_registry"
+
+	// SkipReasonPrivateScopeDenylist indicates the package matched a scope
+	// or prefix on the privacy denylist.
+	SkipReasonPrivateScopeDenylist SkipReason = "private_scope_denylist"
+)
+
+// SkippedPackage records a package that was not externally scanned
+// because of privacy rules.
+type SkippedPackage struct {
+	Package PackageRef `json:"package" yaml:"package"`
+	Reason  SkipReason `json:"reason" yaml:"reason"`
+}
+
 // Verdict holds the overall result of checking an install plan.
 type Verdict struct {
 	Action   VerdictAction             `json:"action" yaml:"action"`
 	Findings []Finding                 `json:"findings,omitempty" yaml:"findings,omitempty"`
 	Summary  string                    `json:"summary" yaml:"summary"`
 	Packages map[string]PackageVerdict `json:"packages,omitempty" yaml:"packages,omitempty"`
+	Skipped  []SkippedPackage          `json:"skipped,omitempty" yaml:"skipped,omitempty"`
 }
 
 // HighestAction returns the most restrictive action across all package verdicts.

--- a/internal/pkgcheck/types.go
+++ b/internal/pkgcheck/types.go
@@ -62,12 +62,34 @@ func (p InstallPlan) AllPackagesWithRegistry() []PackageRef {
 	}
 	out := make([]PackageRef, len(all))
 	for i, pkg := range all {
-		if pkg.Registry == "" {
+		// Scoped packages (@scope/name) may resolve from a private registry
+		// per .npmrc-style config that we don't parse. The resolver
+		// deliberately leaves PackageRef.Registry empty for those, so the
+		// privacy filter fails closed. Don't overwrite that intentional
+		// empty with the plan-level default.
+		if pkg.Registry == "" && !isScopedName(pkg.Name) {
 			pkg.Registry = p.Registry
 		}
 		out[i] = pkg
 	}
 	return out
+}
+
+// isScopedName reports whether name looks like a scoped npm package
+// (e.g. "@acme/foo"). Scoped packages may originate from a private
+// registry that we cannot verify without parsing tool-local config,
+// so the resolver leaves their Registry empty by default and we must
+// not paper over that empty.
+func isScopedName(name string) bool {
+	if len(name) < 2 || name[0] != '@' {
+		return false
+	}
+	for i := 1; i < len(name); i++ {
+		if name[i] == '/' {
+			return true
+		}
+	}
+	return false
 }
 
 // FindingType classifies the kind of issue found during a package check.

--- a/internal/pkgcheck/types.go
+++ b/internal/pkgcheck/types.go
@@ -50,6 +50,26 @@ func (p InstallPlan) AllPackages() []PackageRef {
 	return all
 }
 
+// AllPackagesWithRegistry returns every direct and transitive package, with
+// the InstallPlan's Registry value copied onto any PackageRef that has an
+// empty Registry. The PrivacyFilter relies on PackageRef.Registry for the
+// allowlist check; without this propagation a default-public-registry
+// install would be classified as private and skipped.
+func (p InstallPlan) AllPackagesWithRegistry() []PackageRef {
+	all := p.AllPackages()
+	if p.Registry == "" {
+		return all
+	}
+	out := make([]PackageRef, len(all))
+	for i, pkg := range all {
+		if pkg.Registry == "" {
+			pkg.Registry = p.Registry
+		}
+		out[i] = pkg
+	}
+	return out
+}
+
 // FindingType classifies the kind of issue found during a package check.
 type FindingType string
 

--- a/internal/pkgcheck/types_test.go
+++ b/internal/pkgcheck/types_test.go
@@ -190,12 +190,31 @@ func TestInstallPlan_AllPackages_Empty(t *testing.T) {
 }
 
 func TestSkippedPackage_ReasonString(t *testing.T) {
-	s := SkippedPackage{
-		Package: PackageRef{Name: "@acme/internal", Version: "1.0.0"},
-		Reason:  SkipReasonPrivateRegistry,
+	tests := []struct {
+		name   string
+		reason SkipReason
+		want   string
+	}{
+		{
+			name:   "private registry",
+			reason: SkipReasonPrivateRegistry,
+			want:   "private_registry",
+		},
+		{
+			name:   "private scope denylist",
+			reason: SkipReasonPrivateScopeDenylist,
+			want:   "private_scope_denylist",
+		},
 	}
-	if s.Reason != "private_registry" {
-		t.Fatalf("want private_registry, got %s", s.Reason)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := SkippedPackage{
+				Package: PackageRef{Name: "@acme/internal", Version: "1.0.0"},
+				Reason:  tt.reason,
+			}
+			assert.Equal(t, tt.want, string(s.Reason))
+		})
 	}
 }
 
@@ -207,7 +226,6 @@ func TestVerdict_SkippedSurfaced(t *testing.T) {
 			Reason:  SkipReasonPrivateRegistry,
 		}},
 	}
-	if len(v.Skipped) != 1 {
-		t.Fatalf("want 1 skipped, got %d", len(v.Skipped))
-	}
+	assert.Len(t, v.Skipped, 1)
+	assert.Equal(t, SkipReasonPrivateRegistry, v.Skipped[0].Reason)
 }

--- a/internal/pkgcheck/types_test.go
+++ b/internal/pkgcheck/types_test.go
@@ -263,3 +263,40 @@ func TestVerdict_SkippedSurfaced(t *testing.T) {
 	assert.Len(t, v.Skipped, 1)
 	assert.Equal(t, SkipReasonPrivateRegistry, v.Skipped[0].Reason)
 }
+
+func TestInstallPlan_AllPackagesWithRegistry_ScopedPackagePreservesEmpty(t *testing.T) {
+	plan := InstallPlan{
+		Registry: "registry.npmjs.org",
+		Direct: []PackageRef{
+			{Name: "lodash", Version: "1"},                  // unscoped → inherits
+			{Name: "@acme/private", Version: "1"},           // scoped, empty Registry → kept empty
+			{Name: "@acme/public", Version: "1", Registry: "registry.npmjs.org"}, // scoped with explicit → kept
+		},
+	}
+	out := plan.AllPackagesWithRegistry()
+	if out[0].Registry != "registry.npmjs.org" {
+		t.Errorf("unscoped should inherit; got %q", out[0].Registry)
+	}
+	if out[1].Registry != "" {
+		t.Errorf("scoped with empty must NOT inherit (privacy fail-closed); got %q", out[1].Registry)
+	}
+	if out[2].Registry != "registry.npmjs.org" {
+		t.Errorf("scoped with explicit must be preserved; got %q", out[2].Registry)
+	}
+}
+
+func TestIsScopedName(t *testing.T) {
+	cases := map[string]bool{
+		"@acme/foo":      true,
+		"@scope/pkg":     true,
+		"@":              false,
+		"@noslash":       false,
+		"plain":          false,
+		"":               false,
+	}
+	for name, want := range cases {
+		if got := isScopedName(name); got != want {
+			t.Errorf("isScopedName(%q)=%v, want %v", name, got, want)
+		}
+	}
+}

--- a/internal/pkgcheck/types_test.go
+++ b/internal/pkgcheck/types_test.go
@@ -188,3 +188,26 @@ func TestInstallPlan_AllPackages_Empty(t *testing.T) {
 	all := plan.AllPackages()
 	assert.Empty(t, all)
 }
+
+func TestSkippedPackage_ReasonString(t *testing.T) {
+	s := SkippedPackage{
+		Package: PackageRef{Name: "@acme/internal", Version: "1.0.0"},
+		Reason:  SkipReasonPrivateRegistry,
+	}
+	if s.Reason != "private_registry" {
+		t.Fatalf("want private_registry, got %s", s.Reason)
+	}
+}
+
+func TestVerdict_SkippedSurfaced(t *testing.T) {
+	v := Verdict{
+		Action: VerdictAllow,
+		Skipped: []SkippedPackage{{
+			Package: PackageRef{Name: "@acme/internal", Version: "1.0.0"},
+			Reason:  SkipReasonPrivateRegistry,
+		}},
+	}
+	if len(v.Skipped) != 1 {
+		t.Fatalf("want 1 skipped, got %d", len(v.Skipped))
+	}
+}

--- a/internal/pkgcheck/types_test.go
+++ b/internal/pkgcheck/types_test.go
@@ -189,6 +189,40 @@ func TestInstallPlan_AllPackages_Empty(t *testing.T) {
 	assert.Empty(t, all)
 }
 
+func TestInstallPlan_AllPackagesWithRegistry(t *testing.T) {
+	plan := InstallPlan{
+		Registry: "registry.npmjs.org",
+		Direct:   []PackageRef{{Name: "lodash", Version: "1"}, {Name: "weird", Version: "1", Registry: "explicit.example"}},
+		Transitive: []PackageRef{{Name: "underscore", Version: "1"}},
+	}
+	out := plan.AllPackagesWithRegistry()
+	if len(out) != 3 {
+		t.Fatalf("want 3 packages, got %d", len(out))
+	}
+	if out[0].Registry != "registry.npmjs.org" {
+		t.Errorf("direct[0] should inherit plan registry, got %q", out[0].Registry)
+	}
+	if out[1].Registry != "explicit.example" {
+		t.Errorf("explicit registry must be preserved, got %q", out[1].Registry)
+	}
+	if out[2].Registry != "registry.npmjs.org" {
+		t.Errorf("transitive[0] should inherit plan registry, got %q", out[2].Registry)
+	}
+}
+
+func TestInstallPlan_AllPackagesWithRegistry_EmptyPlanRegistry(t *testing.T) {
+	plan := InstallPlan{
+		Direct: []PackageRef{{Name: "lodash", Version: "1"}},
+	}
+	out := plan.AllPackagesWithRegistry()
+	if len(out) != 1 {
+		t.Fatalf("want 1 package, got %d", len(out))
+	}
+	if out[0].Registry != "" {
+		t.Errorf("empty plan.Registry must NOT make up a value; got %q", out[0].Registry)
+	}
+}
+
 func TestSkippedPackage_ReasonString(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/server/pkgcheck_glue.go
+++ b/internal/server/pkgcheck_glue.go
@@ -152,24 +152,26 @@ func optInt(opts map[string]any, key string, defaultVal int) int {
 	return defaultVal
 }
 
-// defaultResolverNames is the ordered list of all built-in resolver names.
-var defaultResolverNames = []string{"npm", "pnpm", "yarn", "pip", "uv", "poetry"}
+// defaultResolverNames is the ordered list of verified built-in resolver names.
+// pnpm, yarn, and poetry are excluded from defaults because their parsers
+// have not been verified against real CLI output (parsers are placeholder JSON
+// formats that do not match actual tool output). Enable them explicitly via
+// package_checks.resolvers.pnpm: {}, .yarn: {}, or .poetry: {}.
+var defaultResolverNames = []string{"npm", "pip", "uv"}
 
 // buildResolvers constructs pkgcheck.Resolver instances from the resolved
-// configuration map. If cfgMap is nil or empty, all six built-in resolvers
-// are returned with their internal defaults (so package_checks.enabled: true
-// with no resolvers: key still works). Unknown resolver names are fatal.
+// configuration map. If cfgMap is nil or empty, only verified resolvers
+// (npm, pip, uv) are returned with their internal defaults. Unknown resolver
+// names are fatal.
 func buildResolvers(cfgMap map[string]config.ResolverConfig) ([]pkgcheck.Resolver, error) {
 	if len(cfgMap) == 0 {
-		// Default: all six resolvers with zero-value config (each uses its own
-		// internal defaults for DryRunCommand and Timeout).
+		// Default: verified resolvers only with zero-value config (each uses its
+		// own internal defaults for DryRunCommand and Timeout). pnpm, yarn, and
+		// poetry are omitted because their output parsers are placeholders.
 		return []pkgcheck.Resolver{
 			resolver.NewNPMResolver(resolver.NPMResolverConfig{}),
-			resolver.NewPNPMResolver(resolver.PNPMResolverConfig{}),
-			resolver.NewYarnResolver(resolver.YarnResolverConfig{}),
 			resolver.NewPipResolver(resolver.PipResolverConfig{}),
 			resolver.NewUVResolver(resolver.UVResolverConfig{}),
-			resolver.NewPoetryResolver(resolver.PoetryResolverConfig{}),
 		}, nil
 	}
 

--- a/internal/server/pkgcheck_glue.go
+++ b/internal/server/pkgcheck_glue.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/pkgcheck"
+	"github.com/agentsh/agentsh/internal/pkgcheck/provider"
+)
+
+// buildProviderEntry constructs a pkgcheck.ProviderEntry from a single
+// ProviderConfig. It returns an error if:
+//   - the name is not a known built-in and provCfg.Type != "exec"
+//   - the provider requires an API key but provCfg.APIKeyEnv is empty
+//   - the provider requires an API key but the env var is unset
+func buildProviderEntry(name string, provCfg config.ProviderConfig) (pkgcheck.ProviderEntry, error) {
+	prov, err := buildProvider(name, provCfg)
+	if err != nil {
+		return pkgcheck.ProviderEntry{}, err
+	}
+	return pkgcheck.ProviderEntry{
+		Provider:  prov,
+		Timeout:   provCfg.Timeout,
+		OnFailure: provCfg.OnFailure,
+	}, nil
+}
+
+// buildProvider constructs the concrete CheckProvider for the given name.
+func buildProvider(name string, provCfg config.ProviderConfig) (pkgcheck.CheckProvider, error) {
+	// exec providers are identified by their Type field rather than name.
+	if provCfg.Type == "exec" {
+		if provCfg.Command == "" {
+			return nil, fmt.Errorf("pkgcheck provider %q: type=exec requires a non-empty command", name)
+		}
+		return provider.NewExecProvider(name, provider.ExecProviderConfig{
+			Command: provCfg.Command,
+			Timeout: provCfg.Timeout,
+		}), nil
+	}
+
+	switch name {
+	case "osv":
+		return provider.NewOSVProvider(provider.OSVConfig{
+			BaseURL: optString(provCfg.Options, "base_url"),
+			Timeout: provCfg.Timeout,
+		}), nil
+
+	case "depsdev":
+		return provider.NewDepsDevProvider(provider.DepsDevConfig{
+			BaseURL: optString(provCfg.Options, "base_url"),
+			Timeout: provCfg.Timeout,
+		}), nil
+
+	case "local":
+		return provider.NewLocalProvider(), nil
+
+	case "snyk":
+		apiKey, err := requireAPIKey(name, provCfg.APIKeyEnv)
+		if err != nil {
+			return nil, err
+		}
+		orgID := optString(provCfg.Options, "org_id")
+		if orgID == "" {
+			return nil, fmt.Errorf("pkgcheck provider %q: options.org_id is required", name)
+		}
+		concurrency := optInt(provCfg.Options, "concurrency", 16)
+		return provider.NewSnykProvider(provider.SnykConfig{
+			BaseURL:     optString(provCfg.Options, "base_url"),
+			APIKey:      apiKey,
+			OrgID:       orgID,
+			Timeout:     provCfg.Timeout,
+			Concurrency: concurrency,
+		}), nil
+
+	case "socket":
+		apiKey, err := requireAPIKey(name, provCfg.APIKeyEnv)
+		if err != nil {
+			return nil, err
+		}
+		return provider.NewSocketProvider(provider.SocketConfig{
+			BaseURL: optString(provCfg.Options, "base_url"),
+			APIKey:  apiKey,
+			Timeout: provCfg.Timeout,
+		}), nil
+
+	default:
+		return nil, fmt.Errorf("pkgcheck provider %q: unknown provider name (known: osv, depsdev, local, snyk, socket, exec)", name)
+	}
+}
+
+// requireAPIKey validates that an API key env var is configured and set.
+func requireAPIKey(providerName, apiKeyEnv string) (string, error) {
+	if apiKeyEnv == "" {
+		return "", fmt.Errorf("pkgcheck provider %q: api_key_env is required", providerName)
+	}
+	val := os.Getenv(apiKeyEnv)
+	if val == "" {
+		return "", fmt.Errorf("pkgcheck provider %q: env var %s is unset or empty", providerName, apiKeyEnv)
+	}
+	return val, nil
+}
+
+// optString retrieves a string value from an options map, returning "" if absent.
+func optString(opts map[string]any, key string) string {
+	if opts == nil {
+		return ""
+	}
+	v, ok := opts[key]
+	if !ok {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+// optInt retrieves an int value from an options map, returning defaultVal if absent or wrong type.
+func optInt(opts map[string]any, key string, defaultVal int) int {
+	if opts == nil {
+		return defaultVal
+	}
+	v, ok := opts[key]
+	if !ok {
+		return defaultVal
+	}
+	switch n := v.(type) {
+	case int:
+		return n
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	}
+	return defaultVal
+}

--- a/internal/server/pkgcheck_glue.go
+++ b/internal/server/pkgcheck_glue.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -8,6 +9,14 @@ import (
 	"github.com/agentsh/agentsh/internal/pkgcheck"
 	"github.com/agentsh/agentsh/internal/pkgcheck/provider"
 )
+
+// errMissingAPIKeyValue is returned by requireAPIKey when the env var name is
+// configured (api_key_env is set) but the variable is currently unset or empty.
+// This is a "soft" error: the operator has wired the key name correctly but the
+// key is absent from the environment, which is acceptable in CI / local dev
+// scenarios where the provider is intentionally left key-less. The caller
+// treats it as a skip-with-warning rather than a fatal startup failure.
+var errMissingAPIKeyValue = errors.New("env var is unset or empty")
 
 // buildProviderEntry constructs a pkgcheck.ProviderEntry from a single
 // ProviderConfig. It returns an error if:
@@ -90,13 +99,16 @@ func buildProvider(name string, provCfg config.ProviderConfig) (pkgcheck.CheckPr
 }
 
 // requireAPIKey validates that an API key env var is configured and set.
+// It returns errMissingAPIKeyValue (a sentinel) when the env var name is
+// configured but the variable is currently empty — callers can test for that
+// specific error to decide whether to skip (soft) or fail hard.
 func requireAPIKey(providerName, apiKeyEnv string) (string, error) {
 	if apiKeyEnv == "" {
 		return "", fmt.Errorf("pkgcheck provider %q: api_key_env is required", providerName)
 	}
 	val := os.Getenv(apiKeyEnv)
 	if val == "" {
-		return "", fmt.Errorf("pkgcheck provider %q: env var %s is unset or empty", providerName, apiKeyEnv)
+		return "", fmt.Errorf("pkgcheck provider %q: %w: %s", providerName, errMissingAPIKeyValue, apiKeyEnv)
 	}
 	return val, nil
 }

--- a/internal/server/pkgcheck_glue.go
+++ b/internal/server/pkgcheck_glue.go
@@ -192,31 +192,37 @@ func buildResolver(name string, rc config.ResolverConfig) (pkgcheck.Resolver, er
 	case "npm":
 		return resolver.NewNPMResolver(resolver.NPMResolverConfig{
 			DryRunCommand: rc.DryRunCommand,
+			DryRunArgs:    rc.DryRunArgs,
 			Timeout:       rc.Timeout,
 		}), nil
 	case "pnpm":
 		return resolver.NewPNPMResolver(resolver.PNPMResolverConfig{
 			DryRunCommand: rc.DryRunCommand,
+			DryRunArgs:    rc.DryRunArgs,
 			Timeout:       rc.Timeout,
 		}), nil
 	case "yarn":
 		return resolver.NewYarnResolver(resolver.YarnResolverConfig{
 			DryRunCommand: rc.DryRunCommand,
+			DryRunArgs:    rc.DryRunArgs,
 			Timeout:       rc.Timeout,
 		}), nil
 	case "pip":
 		return resolver.NewPipResolver(resolver.PipResolverConfig{
 			DryRunCommand: rc.DryRunCommand,
+			DryRunArgs:    rc.DryRunArgs,
 			Timeout:       rc.Timeout,
 		}), nil
 	case "uv":
 		return resolver.NewUVResolver(resolver.UVResolverConfig{
 			DryRunCommand: rc.DryRunCommand,
+			DryRunArgs:    rc.DryRunArgs,
 			Timeout:       rc.Timeout,
 		}), nil
 	case "poetry":
 		return resolver.NewPoetryResolver(resolver.PoetryResolverConfig{
 			DryRunCommand: rc.DryRunCommand,
+			DryRunArgs:    rc.DryRunArgs,
 			Timeout:       rc.Timeout,
 		}), nil
 	default:

--- a/internal/server/pkgcheck_glue.go
+++ b/internal/server/pkgcheck_glue.go
@@ -8,6 +8,7 @@ import (
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/pkgcheck"
 	"github.com/agentsh/agentsh/internal/pkgcheck/provider"
+	"github.com/agentsh/agentsh/internal/pkgcheck/resolver"
 )
 
 // errMissingAPIKeyValue is returned by requireAPIKey when the env var name is
@@ -28,10 +29,14 @@ func buildProviderEntry(name string, provCfg config.ProviderConfig) (pkgcheck.Pr
 	if err != nil {
 		return pkgcheck.ProviderEntry{}, err
 	}
+	onFailure := provCfg.OnFailure
+	if onFailure == "" {
+		onFailure = "warn"
+	}
 	return pkgcheck.ProviderEntry{
 		Provider:  prov,
 		Timeout:   provCfg.Timeout,
-		OnFailure: provCfg.OnFailure,
+		OnFailure: onFailure,
 	}, nil
 }
 
@@ -45,6 +50,7 @@ func buildProvider(name string, provCfg config.ProviderConfig) (pkgcheck.CheckPr
 		return provider.NewExecProvider(name, provider.ExecProviderConfig{
 			Command: provCfg.Command,
 			Timeout: provCfg.Timeout,
+			Config:  provCfg.Options,
 		}), nil
 	}
 
@@ -144,4 +150,74 @@ func optInt(opts map[string]any, key string, defaultVal int) int {
 		return int(n)
 	}
 	return defaultVal
+}
+
+// defaultResolverNames is the ordered list of all built-in resolver names.
+var defaultResolverNames = []string{"npm", "pnpm", "yarn", "pip", "uv", "poetry"}
+
+// buildResolvers constructs pkgcheck.Resolver instances from the resolved
+// configuration map. If cfgMap is nil or empty, all six built-in resolvers
+// are returned with their internal defaults (so package_checks.enabled: true
+// with no resolvers: key still works). Unknown resolver names are fatal.
+func buildResolvers(cfgMap map[string]config.ResolverConfig) ([]pkgcheck.Resolver, error) {
+	if len(cfgMap) == 0 {
+		// Default: all six resolvers with zero-value config (each uses its own
+		// internal defaults for DryRunCommand and Timeout).
+		return []pkgcheck.Resolver{
+			resolver.NewNPMResolver(resolver.NPMResolverConfig{}),
+			resolver.NewPNPMResolver(resolver.PNPMResolverConfig{}),
+			resolver.NewYarnResolver(resolver.YarnResolverConfig{}),
+			resolver.NewPipResolver(resolver.PipResolverConfig{}),
+			resolver.NewUVResolver(resolver.UVResolverConfig{}),
+			resolver.NewPoetryResolver(resolver.PoetryResolverConfig{}),
+		}, nil
+	}
+
+	out := make([]pkgcheck.Resolver, 0, len(cfgMap))
+	for name, rc := range cfgMap {
+		r, err := buildResolver(name, rc)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// buildResolver constructs a single resolver by name.
+func buildResolver(name string, rc config.ResolverConfig) (pkgcheck.Resolver, error) {
+	switch name {
+	case "npm":
+		return resolver.NewNPMResolver(resolver.NPMResolverConfig{
+			DryRunCommand: rc.DryRunCommand,
+			Timeout:       rc.Timeout,
+		}), nil
+	case "pnpm":
+		return resolver.NewPNPMResolver(resolver.PNPMResolverConfig{
+			DryRunCommand: rc.DryRunCommand,
+			Timeout:       rc.Timeout,
+		}), nil
+	case "yarn":
+		return resolver.NewYarnResolver(resolver.YarnResolverConfig{
+			DryRunCommand: rc.DryRunCommand,
+			Timeout:       rc.Timeout,
+		}), nil
+	case "pip":
+		return resolver.NewPipResolver(resolver.PipResolverConfig{
+			DryRunCommand: rc.DryRunCommand,
+			Timeout:       rc.Timeout,
+		}), nil
+	case "uv":
+		return resolver.NewUVResolver(resolver.UVResolverConfig{
+			DryRunCommand: rc.DryRunCommand,
+			Timeout:       rc.Timeout,
+		}), nil
+	case "poetry":
+		return resolver.NewPoetryResolver(resolver.PoetryResolverConfig{
+			DryRunCommand: rc.DryRunCommand,
+			Timeout:       rc.Timeout,
+		}), nil
+	default:
+		return nil, fmt.Errorf("pkgcheck resolver %q: unknown resolver name (known: npm, pnpm, yarn, pip, uv, poetry)", name)
+	}
 }

--- a/internal/server/pkgcheck_glue.go
+++ b/internal/server/pkgcheck_glue.go
@@ -177,6 +177,9 @@ func buildResolvers(cfgMap map[string]config.ResolverConfig) ([]pkgcheck.Resolve
 
 	out := make([]pkgcheck.Resolver, 0, len(cfgMap))
 	for name, rc := range cfgMap {
+		if err := rc.Validate(); err != nil {
+			return nil, fmt.Errorf("pkgcheck resolver %q: %w", name, err)
+		}
 		r, err := buildResolver(name, rc)
 		if err != nil {
 			return nil, err

--- a/internal/server/pkgcheck_glue_test.go
+++ b/internal/server/pkgcheck_glue_test.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+// TestBuildResolvers_DefaultsToSix verifies that calling buildResolvers with a
+// nil map returns all six built-in resolvers so that package_checks.enabled:
+// true with no explicit resolvers: block still works.
+func TestBuildResolvers_DefaultsToSix(t *testing.T) {
+	resolvers, err := buildResolvers(nil)
+	if err != nil {
+		t.Fatalf("buildResolvers(nil) unexpected error: %v", err)
+	}
+	if len(resolvers) != 6 {
+		t.Fatalf("expected 6 default resolvers, got %d", len(resolvers))
+	}
+
+	want := map[string]bool{
+		"npm":    false,
+		"pnpm":   false,
+		"yarn":   false,
+		"pip":    false,
+		"uv":     false,
+		"poetry": false,
+	}
+	for _, r := range resolvers {
+		name := r.Name()
+		if _, ok := want[name]; !ok {
+			t.Errorf("unexpected resolver name %q", name)
+			continue
+		}
+		want[name] = true
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("missing resolver %q in default set", name)
+		}
+	}
+}
+
+// TestBuildResolvers_EmptyMapDefaultsToSix verifies that an empty (non-nil) map
+// also falls through to the default six resolvers.
+func TestBuildResolvers_EmptyMapDefaultsToSix(t *testing.T) {
+	resolvers, err := buildResolvers(map[string]config.ResolverConfig{})
+	if err != nil {
+		t.Fatalf("buildResolvers({}) unexpected error: %v", err)
+	}
+	if len(resolvers) != 6 {
+		t.Fatalf("expected 6 default resolvers, got %d", len(resolvers))
+	}
+}
+
+// TestBuildResolvers_ExplicitSubset verifies that an explicit subset is
+// honored without adding defaults.
+func TestBuildResolvers_ExplicitSubset(t *testing.T) {
+	resolvers, err := buildResolvers(map[string]config.ResolverConfig{
+		"npm": {DryRunCommand: "/usr/local/bin/npm"},
+		"pip": {},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resolvers) != 2 {
+		t.Fatalf("expected 2 resolvers, got %d", len(resolvers))
+	}
+}
+
+// TestBuildResolvers_UnknownNameRejected verifies that an unknown resolver name
+// returns a fatal error describing the bad name.
+func TestBuildResolvers_UnknownNameRejected(t *testing.T) {
+	_, err := buildResolvers(map[string]config.ResolverConfig{
+		"bundler": {},
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown resolver name")
+	}
+	if !strings.Contains(err.Error(), "bundler") || !strings.Contains(err.Error(), "unknown") {
+		t.Errorf("error should mention the bad name and 'unknown'; got: %v", err)
+	}
+}
+
+// TestBuildProviderEntry_DefaultOnFailureIsWarn verifies that an empty
+// OnFailure in the config is normalized to "warn".
+func TestBuildProviderEntry_DefaultOnFailureIsWarn(t *testing.T) {
+	entry, err := buildProviderEntry("osv", config.ProviderConfig{
+		Enabled:   true,
+		OnFailure: "", // deliberately empty
+	})
+	if err != nil {
+		t.Fatalf("buildProviderEntry: %v", err)
+	}
+	if entry.OnFailure != "warn" {
+		t.Errorf("expected OnFailure=%q, got %q", "warn", entry.OnFailure)
+	}
+}
+
+// TestBuildProviderEntry_ExplicitOnFailurePreserved verifies that a non-empty
+// OnFailure value is not overwritten.
+func TestBuildProviderEntry_ExplicitOnFailurePreserved(t *testing.T) {
+	entry, err := buildProviderEntry("osv", config.ProviderConfig{
+		Enabled:   true,
+		OnFailure: "deny",
+	})
+	if err != nil {
+		t.Fatalf("buildProviderEntry: %v", err)
+	}
+	if entry.OnFailure != "deny" {
+		t.Errorf("expected OnFailure=%q, got %q", "deny", entry.OnFailure)
+	}
+}

--- a/internal/server/pkgcheck_glue_test.go
+++ b/internal/server/pkgcheck_glue_test.go
@@ -7,30 +7,28 @@ import (
 	"github.com/agentsh/agentsh/internal/config"
 )
 
-// TestBuildResolvers_DefaultsToSix verifies that calling buildResolvers with a
-// nil map returns all six built-in resolvers so that package_checks.enabled:
-// true with no explicit resolvers: block still works.
-func TestBuildResolvers_DefaultsToSix(t *testing.T) {
+// TestBuildResolvers_DefaultsToVerified verifies that calling buildResolvers with a
+// nil map returns only the three verified built-in resolvers (npm, pip, uv).
+// pnpm, yarn, and poetry are excluded from defaults because their parsers are
+// placeholders. They remain available via explicit config.
+func TestBuildResolvers_DefaultsToVerified(t *testing.T) {
 	resolvers, err := buildResolvers(nil)
 	if err != nil {
 		t.Fatalf("buildResolvers(nil) unexpected error: %v", err)
 	}
-	if len(resolvers) != 6 {
-		t.Fatalf("expected 6 default resolvers, got %d", len(resolvers))
+	if len(resolvers) != 3 {
+		t.Fatalf("expected 3 default resolvers, got %d", len(resolvers))
 	}
 
 	want := map[string]bool{
-		"npm":    false,
-		"pnpm":   false,
-		"yarn":   false,
-		"pip":    false,
-		"uv":     false,
-		"poetry": false,
+		"npm": false,
+		"pip": false,
+		"uv":  false,
 	}
 	for _, r := range resolvers {
 		name := r.Name()
 		if _, ok := want[name]; !ok {
-			t.Errorf("unexpected resolver name %q", name)
+			t.Errorf("unexpected resolver name %q in defaults", name)
 			continue
 		}
 		want[name] = true
@@ -42,15 +40,32 @@ func TestBuildResolvers_DefaultsToSix(t *testing.T) {
 	}
 }
 
-// TestBuildResolvers_EmptyMapDefaultsToSix verifies that an empty (non-nil) map
-// also falls through to the default six resolvers.
-func TestBuildResolvers_EmptyMapDefaultsToSix(t *testing.T) {
+// TestBuildResolvers_EmptyMapDefaultsToVerified verifies that an empty (non-nil) map
+// also falls through to the default three verified resolvers.
+func TestBuildResolvers_EmptyMapDefaultsToVerified(t *testing.T) {
 	resolvers, err := buildResolvers(map[string]config.ResolverConfig{})
 	if err != nil {
 		t.Fatalf("buildResolvers({}) unexpected error: %v", err)
 	}
-	if len(resolvers) != 6 {
-		t.Fatalf("expected 6 default resolvers, got %d", len(resolvers))
+	if len(resolvers) != 3 {
+		t.Fatalf("expected 3 default resolvers, got %d", len(resolvers))
+	}
+}
+
+// TestBuildResolvers_PnpmYarnPoetryAvailableExplicitly verifies that pnpm, yarn,
+// and poetry are still constructable via explicit config even though they are
+// not in the default set.
+func TestBuildResolvers_PnpmYarnPoetryAvailableExplicitly(t *testing.T) {
+	resolvers, err := buildResolvers(map[string]config.ResolverConfig{
+		"pnpm":   {},
+		"yarn":   {},
+		"poetry": {},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resolvers) != 3 {
+		t.Fatalf("expected 3 resolvers, got %d", len(resolvers))
 	}
 }
 

--- a/internal/server/pkgcheck_glue_test.go
+++ b/internal/server/pkgcheck_glue_test.go
@@ -1,10 +1,12 @@
 package server
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/pkgcheck"
 )
 
 // TestBuildResolvers_DefaultsToVerified verifies that calling buildResolvers with a
@@ -141,5 +143,66 @@ func TestBuildProviderEntry_ExplicitOnFailurePreserved(t *testing.T) {
 	}
 	if entry.OnFailure != "deny" {
 		t.Errorf("expected OnFailure=%q, got %q", "deny", entry.OnFailure)
+	}
+}
+
+// TestBuildProviderEntries_MissingAPIKeySkipsProvider verifies that a provider
+// configured with api_key_env pointing to an unset variable is skipped
+// (returns errMissingAPIKeyValue) rather than causing a fatal error.
+// This underpins Fix 3: if ALL providers are skipped this way, the caller
+// must detect the empty map and fail loudly.
+func TestBuildProviderEntries_MissingAPIKeySkipsProvider(t *testing.T) {
+	// Use an env var that is guaranteed not to be set.
+	const missingEnvVar = "AGENTSH_TEST_SNYK_KEY_DEFINITELY_NOT_SET_XYZ"
+	t.Setenv(missingEnvVar, "") // ensure it's empty
+
+	_, err := buildProviderEntry("snyk", config.ProviderConfig{
+		Enabled:    true,
+		APIKeyEnv:  missingEnvVar,
+		OnFailure:  "warn",
+		Options:    map[string]any{"org_id": "test-org"},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing API key, got nil")
+	}
+	if !errors.Is(err, errMissingAPIKeyValue) {
+		t.Errorf("expected errMissingAPIKeyValue, got: %v", err)
+	}
+}
+
+// TestBuildProviderEntries_ZeroProvidersDetectableByLoop verifies that when all
+// configured providers are skipped due to missing API keys, the resulting map
+// is empty. This is what the server.go zero-providers check guards against.
+func TestBuildProviderEntries_ZeroProvidersDetectableByLoop(t *testing.T) {
+	const missingEnvVar = "AGENTSH_TEST_SNYK_KEY_DEFINITELY_NOT_SET_XYZ"
+	t.Setenv(missingEnvVar, "") // ensure empty
+
+	cfgProviders := map[string]config.ProviderConfig{
+		"snyk": {
+			Enabled:   true,
+			APIKeyEnv: missingEnvVar,
+			Options:   map[string]any{"org_id": "test-org"},
+		},
+	}
+
+	providerEntries := make(map[string]pkgcheck.ProviderEntry)
+	for name, provCfg := range cfgProviders {
+		if !provCfg.Enabled {
+			continue
+		}
+		entry, err := buildProviderEntry(name, provCfg)
+		if err != nil {
+			if errors.Is(err, errMissingAPIKeyValue) {
+				continue // soft skip — this is the expected path
+			}
+			t.Fatalf("unexpected hard error: %v", err)
+		}
+		providerEntries[name] = entry
+	}
+
+	// All providers were skipped → empty map.
+	// This is the condition server.go's zero-providers check catches.
+	if len(providerEntries) != 0 {
+		t.Errorf("expected 0 provider entries, got %d", len(providerEntries))
 	}
 }

--- a/internal/server/pkgcheck_glue_test.go
+++ b/internal/server/pkgcheck_glue_test.go
@@ -98,6 +98,22 @@ func TestBuildResolvers_UnknownNameRejected(t *testing.T) {
 	}
 }
 
+// TestBuildResolvers_SpacedDryRunCommandRejected verifies that a DryRunCommand
+// containing spaces fails at resolver-build time with a message pointing to
+// dry_run_args, so users with the old "npm install --package-lock-only" config
+// shape get a clear migration hint.
+func TestBuildResolvers_SpacedDryRunCommandRejected(t *testing.T) {
+	_, err := buildResolvers(map[string]config.ResolverConfig{
+		"npm": {DryRunCommand: "npm install --package-lock-only --ignore-scripts"},
+	})
+	if err == nil {
+		t.Fatal("expected error for DryRunCommand with spaces")
+	}
+	if !strings.Contains(err.Error(), "dry_run_args") {
+		t.Errorf("error should mention dry_run_args; got: %v", err)
+	}
+}
+
 // TestBuildProviderEntry_DefaultOnFailureIsWarn verifies that an empty
 // OnFailure in the config is normalized to "warn".
 func TestBuildProviderEntry_DefaultOnFailureIsWarn(t *testing.T) {

--- a/internal/server/pkgcheck_glue_test.go
+++ b/internal/server/pkgcheck_glue_test.go
@@ -2,11 +2,13 @@ package server
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/pkgcheck"
+	"github.com/agentsh/agentsh/internal/policy"
 )
 
 // TestBuildResolvers_DefaultsToVerified verifies that calling buildResolvers with a
@@ -170,7 +172,110 @@ func TestBuildProviderEntries_MissingAPIKeySkipsProvider(t *testing.T) {
 	}
 }
 
-// TestBuildProviderEntries_ZeroProvidersDetectableByLoop verifies that when all
+// TestComposedRules_NoCatchAllLeakFromBlockOn verifies that when CompileBlockOnRules
+// (no-catch-all variant) is appended after engine-style rules, the merged set does
+// NOT end with a Match{} / Action:"allow" catch-all. This is the wiring that
+// server.go uses so an operator policy with no catch-all retains fail-closed intent.
+func TestComposedRules_NoCatchAllLeakFromBlockOn(t *testing.T) {
+	blockOnCfg := config.BlockOnConfig{
+		Malware:       "any",
+		Vulnerability: "critical",
+		License:       "never",
+		Reputation:    "never",
+		Provenance:    "never",
+	}
+
+	// Simulate an operator policy that has no catch-all (deliberately fail-closed).
+	engineRules := []policy.PackageRule{
+		{Match: policy.PackageMatch{FindingType: "malware"}, Action: "deny", Reason: "operator deny malware"},
+	}
+
+	// This is exactly what server.go does now (uses CompileBlockOnRules, not CompileBlockOn).
+	rules := append([]policy.PackageRule(nil), engineRules...)
+	rules = append(rules, config.CompileBlockOnRules(blockOnCfg)...)
+
+	if len(rules) == 0 {
+		t.Fatal("expected at least one composed rule")
+	}
+	last := rules[len(rules)-1]
+	if last.Match.FindingType == "" && last.Action == "allow" {
+		t.Errorf("merged rules must NOT end with a catch-all allow when using CompileBlockOnRules; "+
+			"engine fail-closed intent would be shadowed. Last rule: %+v", last)
+	}
+}
+
+// TestMissingAPIKey_ClosedModeIsFatal verifies that when fail_mode=closed and
+// an external provider is configured with an unset API key env var, the error
+// is errMissingAPIKeyValue and callers should treat it as fatal (not skip).
+func TestMissingAPIKey_ClosedModeIsFatal(t *testing.T) {
+	const missingEnvVar = "AGENTSH_TEST_SNYK_KEY_CLOSED_MODE_XYZ"
+	t.Setenv(missingEnvVar, "") // ensure empty
+
+	_, err := buildProviderEntry("snyk", config.ProviderConfig{
+		Enabled:   true,
+		APIKeyEnv: missingEnvVar,
+		OnFailure: "deny",
+		Options:   map[string]any{"org_id": "test-org"},
+	})
+	if err == nil {
+		t.Fatal("expected an error for missing API key, got nil")
+	}
+	if !errors.Is(err, errMissingAPIKeyValue) {
+		t.Fatalf("expected errMissingAPIKeyValue sentinel, got: %v", err)
+	}
+
+	// Now simulate the closed-mode check from server.go's loop:
+	// when mode == "closed" and err is errMissingAPIKeyValue, return a fatal error.
+	mode := "closed"
+	var fatalErr error
+	if errors.Is(err, errMissingAPIKeyValue) {
+		if mode == "closed" {
+			fatalErr = fmt.Errorf("pkgcheck: provider %q enabled with missing API key under fail_mode=closed: configured to fail closed, but provider cannot operate", "snyk")
+		}
+	}
+	if fatalErr == nil {
+		t.Error("expected a fatal error under fail_mode=closed with missing API key, got nil")
+	}
+	if !strings.Contains(fatalErr.Error(), "fail_mode=closed") {
+		t.Errorf("fatal error should mention fail_mode=closed; got: %v", fatalErr)
+	}
+}
+
+// TestMissingAPIKey_DegradedModeContinues verifies that when fail_mode=degraded
+// (the default) and an external provider is configured with an unset API key,
+// the code path continues (skip with warning) rather than failing fatally.
+// This is the previously-correct degraded behavior — the fix only adds the
+// closed-mode branch without changing degraded/open.
+func TestMissingAPIKey_DegradedModeContinues(t *testing.T) {
+	const missingEnvVar = "AGENTSH_TEST_SNYK_KEY_DEGRADED_MODE_XYZ"
+	t.Setenv(missingEnvVar, "") // ensure empty
+
+	_, err := buildProviderEntry("snyk", config.ProviderConfig{
+		Enabled:   true,
+		APIKeyEnv: missingEnvVar,
+		OnFailure: "warn",
+		Options:   map[string]any{"org_id": "test-org"},
+	})
+	if err == nil {
+		t.Fatal("expected errMissingAPIKeyValue, got nil")
+	}
+	if !errors.Is(err, errMissingAPIKeyValue) {
+		t.Fatalf("expected errMissingAPIKeyValue, got: %v", err)
+	}
+
+	// Simulate the degraded-mode branch: skip, do NOT return a fatal error.
+	mode := "degraded"
+	skipped := false
+	if errors.Is(err, errMissingAPIKeyValue) {
+		if mode != "closed" {
+			skipped = true // warn and continue — no fatal error
+		}
+	}
+	if !skipped {
+		t.Error("expected degraded mode to skip (not fail) on missing API key")
+	}
+}
+
 // configured providers are skipped due to missing API keys, the resulting map
 // is empty. This is what the server.go zero-providers check guards against.
 func TestBuildProviderEntries_ZeroProvidersDetectableByLoop(t *testing.T) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -560,11 +560,19 @@ func New(cfg *config.Config) (*Server, error) {
 			return nil, fmt.Errorf("package_checks.enabled=true but no providers were initialized — at least one provider must be configured and have its API key (if required) set")
 		}
 
+		// Compose evaluator rules: engine.PackageRules() runs first
+		// (operator's policy file overrides), then block_on shorthand
+		// rules. Engine catch-all (if any) sits between the two; the
+		// final catch-all allow at the end of CompileBlockOn covers
+		// findings neither rule set named explicitly.
+		rules := append([]policy.PackageRule(nil), engine.PackageRules()...)
+		rules = append(rules, config.CompileBlockOn(cfg.PackageChecks.BlockOn)...)
+
 		pkgChecker := pkgcheck.NewChecker(pkgcheck.CheckerConfig{
 			Scope:     cfg.PackageChecks.Scope,
 			Resolvers: resolvers,
 			Providers: providerEntries,
-			Rules:     engine.PackageRules(),
+			Rules:     rules,
 			Allowlist: pkgcheck.NewAllowlist(30 * time.Second),
 			Privacy: pkgcheck.PrivacyConfig{
 				ExternalScanRegistries: cfg.PackageChecks.Privacy.ExternalScanRegistries,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -541,6 +541,10 @@ func New(cfg *config.Config) (*Server, error) {
 			return nil, fmt.Errorf("pkgcheck: resolvers misconfigured: %w", err)
 		}
 
+		if len(providerEntries) == 0 {
+			return nil, fmt.Errorf("package_checks.enabled=true but no providers were initialized — at least one provider must be configured and have its API key (if required) set")
+		}
+
 		pkgChecker := pkgcheck.NewChecker(pkgcheck.CheckerConfig{
 			Scope:     cfg.PackageChecks.Scope,
 			Resolvers: resolvers,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -514,6 +514,11 @@ func New(cfg *config.Config) (*Server, error) {
 
 	// Initialize package checker (optional).
 	if cfg.PackageChecks.Enabled {
+		// Resolve and apply fail mode so Snyk/Socket OnFailure reflects
+		// the operator's policy before provider entries are constructed.
+		mode := config.ResolveFailMode(&cfg.PackageChecks)
+		config.ApplyFailMode(&cfg.PackageChecks, mode)
+
 		providerEntries := make(map[string]pkgcheck.ProviderEntry)
 		for name, provCfg := range cfg.PackageChecks.Providers {
 			if !provCfg.Enabled {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -536,8 +536,14 @@ func New(cfg *config.Config) (*Server, error) {
 			providerEntries[name] = entry
 		}
 
+		resolvers, err := buildResolvers(cfg.PackageChecks.Resolvers)
+		if err != nil {
+			return nil, fmt.Errorf("pkgcheck: resolvers misconfigured: %w", err)
+		}
+
 		pkgChecker := pkgcheck.NewChecker(pkgcheck.CheckerConfig{
 			Scope:     cfg.PackageChecks.Scope,
+			Resolvers: resolvers,
 			Providers: providerEntries,
 			Rules:     engine.PackageRules(),
 			Allowlist: pkgcheck.NewAllowlist(30 * time.Second),

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -538,11 +538,13 @@ func New(cfg *config.Config) (*Server, error) {
 			if err != nil {
 				// A missing env-var value is a soft misconfiguration: the operator
 				// has named the key correctly but the value is absent (CI / dev).
-				// Skip with a warning so the server still starts.
-				// Any other error (unknown provider name, missing api_key_env field,
-				// missing org_id, etc.) is a YAML-level misconfiguration the operator
-				// must fix — fail hard so it is not silently ignored.
+				// Under fail_mode=closed, however, an operator's intent is to fail
+				// closed on any provider failure — silently disabling a configured
+				// provider would undermine that intent, so we treat it as fatal.
 				if errors.Is(err, errMissingAPIKeyValue) {
+					if mode == "closed" {
+						return nil, fmt.Errorf("pkgcheck: provider %q enabled with missing API key under fail_mode=closed: configured to fail closed, but provider cannot operate", name)
+					}
 					slog.Warn("pkgcheck: skipping provider (API key env var unset)", "name", name, "error", err)
 					continue
 				}
@@ -560,13 +562,12 @@ func New(cfg *config.Config) (*Server, error) {
 			return nil, fmt.Errorf("package_checks.enabled=true but no providers were initialized — at least one provider must be configured and have its API key (if required) set")
 		}
 
-		// Compose evaluator rules: engine.PackageRules() runs first
-		// (operator's policy file overrides), then block_on shorthand
-		// rules. Engine catch-all (if any) sits between the two; the
-		// final catch-all allow at the end of CompileBlockOn covers
-		// findings neither rule set named explicitly.
+		// Compose rules: engine.PackageRules() takes precedence, then block_on
+		// shorthand fills in the remaining finding types. We use the no-catch-all
+		// variant here so that an operator's policy file can deliberately omit
+		// a catch-all rule and rely on the evaluator's default-deny.
 		rules := append([]policy.PackageRule(nil), engine.PackageRules()...)
-		rules = append(rules, config.CompileBlockOn(cfg.PackageChecks.BlockOn)...)
+		rules = append(rules, config.CompileBlockOnRules(cfg.PackageChecks.BlockOn)...)
 
 		pkgChecker := pkgcheck.NewChecker(pkgcheck.CheckerConfig{
 			Scope:     cfg.PackageChecks.Scope,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -521,8 +521,17 @@ func New(cfg *config.Config) (*Server, error) {
 			}
 			entry, err := buildProviderEntry(name, provCfg)
 			if err != nil {
-				slog.Warn("pkgcheck: skipping provider", "name", name, "error", err)
-				continue
+				// A missing env-var value is a soft misconfiguration: the operator
+				// has named the key correctly but the value is absent (CI / dev).
+				// Skip with a warning so the server still starts.
+				// Any other error (unknown provider name, missing api_key_env field,
+				// missing org_id, etc.) is a YAML-level misconfiguration the operator
+				// must fix — fail hard so it is not silently ignored.
+				if errors.Is(err, errMissingAPIKeyValue) {
+					slog.Warn("pkgcheck: skipping provider (API key env var unset)", "name", name, "error", err)
+					continue
+				}
+				return nil, fmt.Errorf("pkgcheck: provider %q misconfigured: %w", name, err)
 			}
 			providerEntries[name] = entry
 		}
@@ -532,9 +541,10 @@ func New(cfg *config.Config) (*Server, error) {
 			Providers: providerEntries,
 			Rules:     engine.PackageRules(),
 			Allowlist: pkgcheck.NewAllowlist(30 * time.Second),
-			// TODO(T16): populate Privacy from cfg.PackageChecks.Privacy
-			// once the YAML field is plumbed through in T16.
-			Privacy: pkgcheck.PrivacyConfig{},
+			Privacy: pkgcheck.PrivacyConfig{
+				ExternalScanRegistries: cfg.PackageChecks.Privacy.ExternalScanRegistries,
+				PrivateScopeDenylist:   cfg.PackageChecks.Privacy.PrivateScopeDenylist,
+			},
 		})
 		app.SetPackageChecker(pkgChecker)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -519,10 +519,12 @@ func New(cfg *config.Config) (*Server, error) {
 			if !provCfg.Enabled {
 				continue
 			}
-			// Concrete provider wiring will be added in a follow-up;
-			// for now only the skeleton is set up.
-			_ = name
-			_ = provCfg
+			entry, err := buildProviderEntry(name, provCfg)
+			if err != nil {
+				slog.Warn("pkgcheck: skipping provider", "name", name, "error", err)
+				continue
+			}
+			providerEntries[name] = entry
 		}
 
 		pkgChecker := pkgcheck.NewChecker(pkgcheck.CheckerConfig{
@@ -530,6 +532,9 @@ func New(cfg *config.Config) (*Server, error) {
 			Providers: providerEntries,
 			Rules:     engine.PackageRules(),
 			Allowlist: pkgcheck.NewAllowlist(30 * time.Second),
+			// TODO(T16): populate Privacy from cfg.PackageChecks.Privacy
+			// once the YAML field is plumbed through in T16.
+			Privacy: pkgcheck.PrivacyConfig{},
 		})
 		app.SetPackageChecker(pkgChecker)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -517,6 +517,16 @@ func New(cfg *config.Config) (*Server, error) {
 		// Resolve and apply fail mode so Snyk/Socket OnFailure reflects
 		// the operator's policy before provider entries are constructed.
 		mode := config.ResolveFailMode(&cfg.PackageChecks)
+		// Validate the resolved mode (which may have come from
+		// PKGCHECK_FAIL_MODE env var, bypassing YAML validation).
+		// A typo like "clsoed" would otherwise silently no-op via
+		// ApplyFailMode and leave the default OnFailure in place,
+		// undermining the operator's intent.
+		switch mode {
+		case "open", "closed", "degraded":
+		default:
+			return nil, fmt.Errorf("pkgcheck: invalid fail_mode %q (env PKGCHECK_FAIL_MODE or package_checks.fail_mode); must be one of open, closed, degraded", mode)
+		}
 		config.ApplyFailMode(&cfg.PackageChecks, mode)
 
 		providerEntries := make(map[string]pkgcheck.ProviderEntry)


### PR DESCRIPTION
## Summary
- Wires Snyk and Socket as pluggable pre-install gates against supply-chain attacks
- Adds privacy filter (registry allowlist + scope denylist) so private packages don't leak to third-party providers
- Adds retry + circuit breaker + bounded-concurrency fan-out infrastructure shared by all external providers
- Plumbs `block_on` policy shorthand, `fail_mode` (open/closed/degraded), scope auto-promotion, and config validation through to production startup

## Background

Original plan (`docs/superpowers/specs/2026-05-01-snyk-socket-pre-install-gate-design.md`) assumed Socket/Snyk were greenfield. **They already existed** from prior PRs (`a703bc06`, `90cf4934`). Mid-execution we pivoted to enhance the existing providers rather than replace them. The plan document at `docs/superpowers/plans/2026-05-01-snyk-socket-pre-install-gate.md` includes a top-level "PIVOT" note explaining the re-scope.

## What's in this branch

**Foundation (T1–T4):**
- `Verdict.Skipped` + `SkipReason` types
- Shared `CheckProvider` contract test suite
- Retry HTTP client with bounded retries, Retry-After header, ctx-cancel-aware abort
- Circuit breaker + `callWithBreaker` helper that distinguishes caller cancellation from provider-own timeouts and supports per-domain neutral-error predicates

**Provider enhancements (T6'/T7'/T8'):**
- Existing Socket/Snyk providers wrapped in `retryClient` + `callWithBreaker`
- Snyk gains bounded-concurrency fan-out, fail-fast on auth errors (with cancellable batch ctx), deterministic input-order findings
- Strict JSON decoding (rejects trailing garbage); malformed 200 trips breaker; auth errors are neutral for breaker accounting
- Both wired into shared contract suite

**Privacy + cache + evaluator (T11–T15):**
- Cache distinguishes clean (24h default) / found (indefinite default) / not-found (1h default) entries
- `PrivacyFilter` partitions packages with URL normalization, glob+prefix denylist, fail-closed on empty Registry
- Orchestrator routes filtered packages around external providers but keeps local providers on the full list
- `EvaluateWithContext` surfaces skipped packages and prefixes verdict summary with `degraded:` when warn-mode providers fail
- `block_on` shorthand compiles to `policy.PackageRule` list (split into with-catch-all and rules-only variants for merging)

**Config + production wiring (T16–T20):**
- Top-level YAML fields: `package_checks.privacy`, `package_checks.fail_mode`, `package_checks.block_on`
- `ApplyExternalProviderDefaults` auto-promotes scope to `all_installs` when an external provider is enabled (warns on explicit `new_packages_only`)
- `ResolveFailMode` honors `PKGCHECK_FAIL_MODE` env override; `ApplyFailMode` translates to per-provider `OnFailure`, preserving explicit values
- server.go now constructs concrete providers + resolvers, wires privacy filter into checker, refuses startup on misconfig (missing API keys under `fail_mode=closed`, zero active providers, invalid `fail_mode`/denylist globs/`dry_run_command`/all-empty registries)
- `dry_run_command` accepts paths-with-spaces; legacy multi-token command strings rejected with migration guidance pointing at `dry_run_args`
- Resolvers detect `--registry` / `--index-url` / `--extra-index-url` flags and propagate them to dry-run subprocesses; scoped npm packages without `--registry` fail closed
- End-to-end integration test (Socket-down → OSV degraded fallback) with body-leak assertions

## Known limitation

Resolvers do not parse `.npmrc` / `pip.conf` / `pyproject.toml` / env-var registry overrides — only CLI flags. Operators using config-file or env-var overrides must add those registries to `external_scan_registries`. Documented in code comments on `PackagePrivacyConfig`.

## Test plan
- [x] `go test ./...` — 104 packages pass, 0 failures
- [x] `GOOS=windows go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] End-to-end integration test exercises Socket-down → OSV degraded fallback path
- [x] roborev iterative refine loop — passed clean once mid-loop and resolved 30+ findings before reaching the documented limitation boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)