### PR TITLE
fix(limits): cgroup writability probe before claiming nested mode (closes #272)

### DIFF
--- a/internal/limits/cgroup_fs_fake_test.go
+++ b/internal/limits/cgroup_fs_fake_test.go
@@ -31,6 +31,11 @@ type fakeCgroupFS struct {
 	// tests where the first enableControllers write fails with EBUSY and
 	// the retry after leaf-move succeeds.
 	openWriteErrsOnce map[string]error
+	// mkdirErrUnder injects an error returned by Mkdir for any direct
+	// child of the given parent directory. Used to simulate hosts where
+	// cgroup.subtree_control reports delegated controllers but the kernel
+	// denies mkdir within the subtree (read-only delegation, MAC policies).
+	mkdirErrUnder map[string]error
 }
 
 type fakeEntry struct {
@@ -44,6 +49,7 @@ func newFakeCgroupFS() *fakeCgroupFS {
 		writeErrs:    map[string]error{},
 		openErrs:     map[string]error{},
 		openWriteErrsOnce: map[string]error{},
+		mkdirErrUnder:     map[string]error{},
 	}
 }
 
@@ -96,6 +102,9 @@ func (f *fakeCgroupFS) Mkdir(p string, perm os.FileMode) error {
 	p = path.Clean(p)
 	if _, ok := f.files[p]; ok {
 		return &fs.PathError{Op: "mkdir", Path: p, Err: syscall.EEXIST}
+	}
+	if err, ok := f.mkdirErrUnder[path.Dir(p)]; ok {
+		return &fs.PathError{Op: "mkdir", Path: p, Err: err}
 	}
 	if _, ok := f.files[path.Dir(p)]; !ok {
 		return &fs.PathError{Op: "mkdir", Path: p, Err: syscall.ENOENT}

--- a/internal/limits/cgroupv2_probe.go
+++ b/internal/limits/cgroupv2_probe.go
@@ -128,6 +128,19 @@ func ProbeCgroupsV2(ctx context.Context, fs cgroupFS, ownHint string) (*CgroupPr
 	// Step 3: already delegated?
 	ownDelegated, err := readControllerSet(fs, filepath.Join(own, "cgroup.subtree_control"))
 	if err == nil && containsAll(ownDelegated, requiredControllers) {
+		// cgroup.subtree_control says we have delegation, but on some hosts
+		// (read-only-delegated subtrees, MAC policies) mkdir within the
+		// subtree is still denied — silently producing per-command
+		// cgroup_apply_failed events at runtime while detect over-reports
+		// availability. Verify writability before claiming success.
+		if probeErr := probeNestedWritability(fs, own); probeErr != nil {
+			reason := fmt.Sprintf("subtree delegated but child cgroup mkdir denied: %v", probeErr)
+			res, err := tryTopLevel(ctx, fs, own, reason)
+			if err == nil && res != nil {
+				res.LeafMoved = res.LeafMoved || leafResident
+			}
+			return res, err
+		}
 		return &CgroupProbeResult{
 			Mode:        ModeNested,
 			Reason:      "already delegated",
@@ -140,6 +153,17 @@ func ProbeCgroupsV2(ctx context.Context, fs cgroupFS, ownHint string) (*CgroupPr
 	// Step 4: try to enable the required set.
 	enableErr := enableControllersFS(fs, own, requiredControllers)
 	if enableErr == nil {
+		// Same writability check as the already-delegated branch: enabling
+		// controllers in subtree_control proves the file is writable but
+		// does not prove that mkdir of child cgroups will be permitted.
+		if probeErr := probeNestedWritability(fs, own); probeErr != nil {
+			reason := fmt.Sprintf("controllers enabled but child cgroup mkdir denied: %v", probeErr)
+			res, err := tryTopLevel(ctx, fs, own, reason)
+			if err == nil && res != nil {
+				res.LeafMoved = res.LeafMoved || leafResident
+			}
+			return res, err
+		}
 		// Re-read to confirm and to pick up the io flag.
 		delegatedNow, _ := readControllerSet(fs, filepath.Join(own, "cgroup.subtree_control"))
 		return &CgroupProbeResult{
@@ -156,6 +180,14 @@ func ProbeCgroupsV2(ctx context.Context, fs cgroupFS, ownHint string) (*CgroupPr
 	if errors.Is(enableErr, syscall.EBUSY) {
 		moved, enabled, retryErr := tryLeafMove(fs, own)
 		if enabled {
+			if probeErr := probeNestedWritability(fs, own); probeErr != nil {
+				reason := fmt.Sprintf("leaf-moved and controllers enabled but child cgroup mkdir denied: %v", probeErr)
+				res, err := tryTopLevel(ctx, fs, own, reason)
+				if err == nil && res != nil {
+					res.LeafMoved = true
+				}
+				return res, err
+			}
 			delegatedNow, _ := readControllerSet(fs, filepath.Join(own, "cgroup.subtree_control"))
 			return &CgroupProbeResult{
 				Mode:        ModeNested,
@@ -200,6 +232,27 @@ func ProbeCgroupsV2(ctx context.Context, fs cgroupFS, ownHint string) (*CgroupPr
 // the limits package (e.g. the capabilities probe).
 func ProbeCgroupsV2Default(ctx context.Context) (*CgroupProbeResult, error) {
 	return ProbeCgroupsV2(ctx, osCgroupFS{}, "")
+}
+
+// probeNestedWritability creates and removes a temporary child cgroup under
+// own to verify the kernel actually permits creating new cgroups there.
+// Some hosts present a delegated cgroup.subtree_control while still denying
+// mkdir within the subtree (read-only delegation, MAC policies). Without
+// this probe, the capability check over-reports cgroups_v2 availability and
+// per-command resource limits silently fail at runtime via per-command
+// cgroup_apply_failed events.
+//
+// EEXIST is treated as success: a stale probe directory from a crashed prior
+// run is itself evidence that mkdir succeeded at some point. The function
+// makes a best-effort cleanup attempt either way.
+func probeNestedWritability(fs cgroupFS, own string) error {
+	probeDir := filepath.Join(own, fmt.Sprintf("agentsh.write-probe-%d", os.Getpid()))
+	err := fs.Mkdir(probeDir, 0o755)
+	if err != nil && !errors.Is(err, syscall.EEXIST) {
+		return err
+	}
+	_ = fs.Remove(probeDir)
+	return nil
 }
 
 // tryLeafMove handles the EBUSY case: the own cgroup has internal processes

--- a/internal/limits/cgroupv2_probe_test.go
+++ b/internal/limits/cgroupv2_probe_test.go
@@ -406,3 +406,145 @@ func TestProbe_ExplicitLeafHintNotStripped(t *testing.T) {
 		t.Fatalf("explicit leaf hint should NOT be stripped: got %q, want %q", res.OwnCgroup, leafPath)
 	}
 }
+
+// TestProbe_AlreadyDelegated_MkdirDeniedFallsBack covers the OpenComputer
+// case: cgroup.subtree_control reports cpu/memory/pids delegated, but
+// mkdir within the subtree is denied. Without the writability probe, this
+// silently produces per-command cgroup_apply_failed at runtime while
+// detect over-reports cgroups_v2 ✓ (canyonroad/agentsh#272).
+func TestProbe_AlreadyDelegated_MkdirDeniedFallsBack(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu io memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "cpu io memory pids")
+	f.mkdirErrUnder[own] = syscall.EACCES
+	// Top-level slice mkdir should also fail (mirrors OC posture).
+	f.mkdirErrUnder["/sys/fs/cgroup"] = syscall.EACCES
+
+	res, err := ProbeCgroupsV2(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeUnavailable {
+		t.Fatalf("mode: got %q, want unavailable (subtree mkdir denied + top-level mkdir denied)", res.Mode)
+	}
+	if !strings.Contains(res.Reason, "subtree delegated but child cgroup mkdir denied") {
+		t.Fatalf("reason should explain delegated-but-not-writable: %q", res.Reason)
+	}
+}
+
+// TestProbe_AlreadyDelegated_MkdirDeniedFallsToTopLevel is the case where
+// the nested subtree is read-only-delegated but the top-level slice mkdir
+// works — we should land in top-level mode, not unavailable.
+func TestProbe_AlreadyDelegated_MkdirDeniedFallsToTopLevel(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "cpu memory pids")
+	f.mkdirErrUnder[own] = syscall.EACCES
+	// Top-level slice mkdir works; pre-seed memory.max so the slice probe passes.
+	f.seedFile("/sys/fs/cgroup/agentsh.slice/memory.max", "max")
+
+	res, err := ProbeCgroupsV2(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeTopLevel {
+		t.Fatalf("mode: got %q, want top-level", res.Mode)
+	}
+	if !strings.Contains(res.Reason, "subtree delegated but child cgroup mkdir denied") {
+		t.Fatalf("reason should explain why nested was rejected: %q", res.Reason)
+	}
+}
+
+// TestProbe_AlreadyDelegated_MkdirSucceeds_ProbeCleanedUp verifies the
+// writability probe leaves no stray directories on the happy path.
+func TestProbe_AlreadyDelegated_MkdirSucceeds_ProbeCleanedUp(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu io memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "cpu io memory pids")
+
+	res, err := ProbeCgroupsV2(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeNested || res.Reason != "already delegated" {
+		t.Fatalf("mode/reason: got %q/%q, want nested/already delegated", res.Mode, res.Reason)
+	}
+	// No agentsh.write-probe-* directories should remain under own.
+	entries, err := f.ReadDir(own)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "agentsh.write-probe-") {
+			t.Fatalf("probe directory leaked: %s", e.Name())
+		}
+	}
+}
+
+// TestProbe_EnabledByProbe_MkdirDeniedFallsBack covers the case where
+// enableControllersFS succeeds (subtree_control is writable) but mkdir
+// within the subtree is still denied — same OC failure mode reached
+// through a different path.
+func TestProbe_EnabledByProbe_MkdirDeniedFallsBack(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+	f.mkdirErrUnder[own] = syscall.EACCES
+	f.seedFile("/sys/fs/cgroup/agentsh.slice/memory.max", "max")
+
+	res, err := ProbeCgroupsV2(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeTopLevel {
+		t.Fatalf("mode: got %q, want top-level", res.Mode)
+	}
+	if !strings.Contains(res.Reason, "controllers enabled but child cgroup mkdir denied") {
+		t.Fatalf("reason should explain enable-but-not-writable: %q", res.Reason)
+	}
+}
+
+// TestProbe_LeafMove_MkdirDeniedFallsBack covers the leaf-move path: parent
+// hits EBUSY, leaf-move + retry-enable succeeds, but child cgroup mkdir is
+// still denied. The probe should also catch this case so the leaf-move
+// branch can't over-report nested availability either.
+func TestProbe_LeafMove_MkdirDeniedFallsBack(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+	// First write to subtree_control fails with EBUSY; retry after leaf-move succeeds.
+	f.openWriteErrsOnce[own+"/cgroup.subtree_control:write"] = syscall.EBUSY
+	// Block child cgroup mkdir specifically (but allow the leaf cgroup itself,
+	// since agentsh.leaf creation happens before the writability probe).
+	// We can't easily distinguish the two with mkdirErrUnder, so we accept
+	// that the leaf is created first and then block subsequent probes by
+	// switching the predicate after leaf creation. The fake doesn't support
+	// that natively; instead, verify behavior via top-level fallback path.
+	f.mkdirErrUnder[own] = syscall.EACCES
+	f.seedFile("/sys/fs/cgroup/agentsh.slice/memory.max", "max")
+
+	// Pre-create the leaf so the EBUSY+leaf-move retry doesn't need to mkdir
+	// it (which would also be blocked by mkdirErrUnder[own]).
+	f.seedDir(own + "/agentsh.leaf")
+
+	res, err := ProbeCgroupsV2(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeTopLevel {
+		t.Fatalf("mode: got %q, want top-level (probe should reject nested when child mkdir denied)", res.Mode)
+	}
+	if !strings.Contains(res.Reason, "child cgroup mkdir denied") {
+		t.Fatalf("reason should mention the writability failure: %q", res.Reason)
+	}
+}


### PR DESCRIPTION
## Summary

- `ProbeCgroupsV2` returned `ModeNested` whenever `cgroup.subtree_control` listed the required controllers, without verifying that `mkdir` of child cgroups would actually succeed. On hosts with read-only-delegated subtrees (e.g. OpenComputer), this over-reported `cgroups_v2 ✓` in `agentsh detect` while every per-command cgroup `mkdir` failed at runtime via silent `cgroup_apply_failed` events.
- Add `probeNestedWritability(fs, own)`: `mkdir`+`rmdir` of an `agentsh.write-probe-<pid>` directory under the own cgroup. EEXIST treated as success (stale probe dir = evidence mkdir worked previously).
- Wired into all three nested-return sites: `already delegated`, `enabled by probe`, and `leaf-moved; enabled by probe`. On probe failure, falls through to `tryTopLevel` with a structured reason.

## Behavior matrix

| Host posture | Before | After |
|---|---|---|
| Subtree delegated, mkdir works | `ModeNested` ✓ | `ModeNested` ✓ (probe cleans itself up) |
| Subtree delegated read-only, top-level writable | `ModeNested` (silent runtime failures) | `ModeTopLevel` (works) |
| Subtree delegated read-only, top-level also denied (OC) | `ModeNested` (silent runtime failures, score 15/15) | `ModeUnavailable` (clean refusal, accurate score) |

`internal/capabilities/check_cgroups_linux.go:48-51` keys availability on `Mode != ModeUnavailable`, so the detect score now matches actual enforcement state. `CgroupManager.Apply` returns `CgroupUnavailableError` cleanly on the OC posture instead of leaking per-command `cgroup_apply_failed`.

## Tests

- 5 new tests in `cgroupv2_probe_test.go` covering the OC posture, partial-deny → top-level fallback, probe-cleanup-on-success, and the enabled-by-probe + leaf-move paths.
- `mkdirErrUnder` injection added to `fakeCgroupFS`; `Mkdir` reordered so EEXIST takes precedence over the permission injection (matches real fs).

## Test plan

- [x] `go test ./internal/limits/... -count=1`
- [x] `go test ./internal/capabilities/... -count=1`
- [x] `go test ./internal/api/... -count=1 -short`
- [x] `GOOS=windows go build ./...`
- [x] `go vet ./internal/limits/ ./internal/capabilities/ ./internal/api/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)