### PR TITLE
fix(limits): cgroup writability probe fails closed on EEXIST (#272 followup)

### DIFF
--- a/internal/limits/cgroupv2_probe.go
+++ b/internal/limits/cgroupv2_probe.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 )
 
 // CgroupMode names an operating mode for cgroup v2 enforcement.
@@ -242,13 +243,16 @@ func ProbeCgroupsV2Default(ctx context.Context) (*CgroupProbeResult, error) {
 // per-command resource limits silently fail at runtime via per-command
 // cgroup_apply_failed events.
 //
-// EEXIST is treated as success: a stale probe directory from a crashed prior
-// run is itself evidence that mkdir succeeded at some point. The function
-// makes a best-effort cleanup attempt either way.
+// The probe name combines PID and a nanosecond timestamp to make collisions
+// against any stale leftover directory vanishingly unlikely. EEXIST is NOT
+// treated as success — an existing directory is stale evidence (perms may
+// have changed since it was created, cleanup may have failed for unrelated
+// reasons), so we fail closed in that case rather than falsely claim
+// writability.
 func probeNestedWritability(fs cgroupFS, own string) error {
-	probeDir := filepath.Join(own, fmt.Sprintf("agentsh.write-probe-%d", os.Getpid()))
-	err := fs.Mkdir(probeDir, 0o755)
-	if err != nil && !errors.Is(err, syscall.EEXIST) {
+	name := fmt.Sprintf("agentsh.write-probe-%d-%d", os.Getpid(), time.Now().UnixNano())
+	probeDir := filepath.Join(own, name)
+	if err := fs.Mkdir(probeDir, 0o755); err != nil {
 		return err
 	}
 	_ = fs.Remove(probeDir)

--- a/internal/limits/cgroupv2_probe_test.go
+++ b/internal/limits/cgroupv2_probe_test.go
@@ -389,6 +389,36 @@ func TestProbe_LeafMove_IdempotentSecondProbe(t *testing.T) {
 	}
 }
 
+// TestProbe_AlreadyDelegated_EEXISTTreatedAsFailure ensures the writability
+// probe does NOT treat EEXIST as success. A stale probe directory is no
+// proof of current writability — the kernel's permission state may have
+// changed since the prior run. Failing closed here is what prevents the
+// false-positive availability the probe is designed to catch (roborev #7691
+// finding on the original PR).
+func TestProbe_AlreadyDelegated_EEXISTTreatedAsFailure(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "cpu memory pids")
+	// Every mkdir under own returns EEXIST (simulates a host where probe
+	// dirs collide with leftovers — or, more realistically, where the
+	// kernel returns EEXIST as a misleading proxy for some other state).
+	f.mkdirErrUnder[own] = syscall.EEXIST
+	f.seedFile("/sys/fs/cgroup/agentsh.slice/memory.max", "max")
+
+	res, err := ProbeCgroupsV2(context.Background(), f, own)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode == ModeNested {
+		t.Fatalf("EEXIST under own must NOT be treated as proof of writability; got mode=%q", res.Mode)
+	}
+	if res.Mode != ModeTopLevel {
+		t.Fatalf("expected fallback to top-level, got mode=%q reason=%q", res.Mode, res.Reason)
+	}
+}
+
 func TestProbe_ExplicitLeafHintNotStripped(t *testing.T) {
 	// Verify that an explicit absolute ownHint ending in "leaf" is NOT
 	// rewritten — normalization only applies to auto-discovered paths.


### PR DESCRIPTION
## Summary

Follow-up to #275 addressing roborev #7691 (Medium):

> `probeNestedWritability` treats `EEXIST` as success, so a stale `agentsh.write-probe-<pid>` directory can make the probe report nested mode even when the current process cannot create new child cgroups.

Valid concern — my reasoning was "stale dir = evidence mkdir worked once," but that's stale evidence. Permissions can have changed since the directory was created, or the leftover could come from a different process state. The probe must fail closed in that case.

## Changes

- Probe directory name now combines PID + nanosecond timestamp (`agentsh.write-probe-<pid>-<unixnano>`), making collisions with any stale leftover effectively impossible in practice.
- Removed the `errors.Is(err, syscall.EEXIST)` carve-out. If mkdir returns EEXIST, the probe returns the error and the caller falls through to top-level mode — matching every other failure path.

## Test

`TestProbe_AlreadyDelegated_EEXISTTreatedAsFailure`: with `mkdirErrUnder[own] = EEXIST` and a healthy top-level slice, the probe must land in `ModeTopLevel` (not `ModeNested`).

## Test plan

- [x] `go test ./internal/limits/... -count=1` (21 tests, including the new one)
- [x] `go vet ./internal/limits/`
- [x] `GOOS=windows go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)