### PR TITLE
fix(unixwrap): PATH fallback + diagnostic context on lookup failure (closes #271)

### DIFF
--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"runtime"
 	"strconv"
 	"syscall"
@@ -216,10 +215,9 @@ func main() {
 
 	// Exec the real command.
 	cmd := os.Args[2]
-	// syscall.Exec requires an absolute path — resolve via PATH lookup.
-	cmdPath, err := exec.LookPath(cmd)
+	cmdPath, err := resolveCommandPath(cmd)
 	if err != nil {
-		log.Fatalf("exec %s failed: %v", cmd, err)
+		log.Fatalf("resolve command %q: %v", cmd, err)
 	}
 	args := os.Args[2:]
 	if err := syscall.Exec(cmdPath, args, os.Environ()); err != nil {

--- a/cmd/agentsh-unixwrap/resolve.go
+++ b/cmd/agentsh-unixwrap/resolve.go
@@ -1,0 +1,68 @@
+//go:build linux && cgo
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// fallbackPATH lists standard system directories searched when exec.LookPath
+// fails to resolve a bare command name. The OC posture (canyonroad/agentsh#271)
+// can strip PATH from the wrapper's inherited environment, causing LookPath
+// to return "executable file not found in $PATH" even for ubiquitous commands
+// like echo that exist at /usr/bin/echo. The wrapper retries through this
+// list before failing.
+var fallbackPATH = []string{
+	"/usr/local/sbin",
+	"/usr/local/bin",
+	"/usr/sbin",
+	"/usr/bin",
+	"/sbin",
+	"/bin",
+}
+
+// resolveCommandPath returns the absolute path to cmd, suitable for
+// syscall.Exec. It first delegates to exec.LookPath (which honors PATH and
+// handles absolute paths). If that fails for a bare command name, it falls
+// back to scanning standard system directories. On total failure, the
+// returned error includes diagnostic context (PATH value, env count) to
+// help localize OC-style failures (#271).
+//
+// Slash-containing arguments (absolute or relative) intentionally do NOT
+// fall back to system dirs — the caller asked for that specific path, so
+// the error should reflect what they asked for, not silently substitute.
+func resolveCommandPath(cmd string) (string, error) {
+	if cmd == "" {
+		return "", fmt.Errorf("empty command")
+	}
+	if path, err := exec.LookPath(cmd); err == nil {
+		return path, nil
+	} else if strings.ContainsRune(cmd, os.PathSeparator) {
+		return "", fmt.Errorf("%w (PATH=%q, env_count=%d)", err, os.Getenv("PATH"), len(os.Environ()))
+	} else {
+		// Bare name: scan fallback dirs. Save the original LookPath error
+		// for the diagnostic if no fallback hits.
+		for _, dir := range fallbackPATH {
+			candidate := filepath.Join(dir, cmd)
+			info, statErr := os.Stat(candidate)
+			if statErr != nil {
+				continue
+			}
+			if info.IsDir() {
+				continue
+			}
+			if info.Mode()&0o111 == 0 {
+				continue
+			}
+			return candidate, nil
+		}
+		return "", fmt.Errorf(
+			"%w (PATH=%q, env_count=%d, fallback_dirs=%v)",
+			err, os.Getenv("PATH"), len(os.Environ()), fallbackPATH,
+		)
+	}
+}

--- a/cmd/agentsh-unixwrap/resolve.go
+++ b/cmd/agentsh-unixwrap/resolve.go
@@ -3,11 +3,14 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/sys/unix"
 )
 
 // fallbackPATH lists standard system directories searched when exec.LookPath
@@ -25,12 +28,22 @@ var fallbackPATH = []string{
 	"/bin",
 }
 
+// lookPathFn is overridable in tests to inject specific LookPath errors
+// (notably exec.ErrDot, which is otherwise hard to trigger deterministically
+// because it depends on the process CWD and PATH semantics).
+var lookPathFn = exec.LookPath
+
 // resolveCommandPath returns the absolute path to cmd, suitable for
 // syscall.Exec. It first delegates to exec.LookPath (which honors PATH and
-// handles absolute paths). If that fails for a bare command name, it falls
-// back to scanning standard system directories. On total failure, the
-// returned error includes diagnostic context (PATH value, env count) to
-// help localize OC-style failures (#271).
+// handles absolute paths). If that fails for a bare command name with
+// exec.ErrNotFound, it falls back to scanning standard system directories.
+// On total failure, the returned error includes diagnostic context (PATH
+// value, env count) to help localize OC-style failures (#271).
+//
+// The fallback ONLY fires for not-found errors. Permission errors,
+// exec.ErrDot, and other LookPath errors propagate unchanged — silently
+// substituting a different binary from /usr/bin when LookPath rejected
+// the original for permission reasons would mask a policy violation.
 //
 // Slash-containing arguments (absolute or relative) intentionally do NOT
 // fall back to system dirs — the caller asked for that specific path, so
@@ -39,30 +52,36 @@ func resolveCommandPath(cmd string) (string, error) {
 	if cmd == "" {
 		return "", fmt.Errorf("empty command")
 	}
-	if path, err := exec.LookPath(cmd); err == nil {
+	path, err := lookPathFn(cmd)
+	if err == nil {
 		return path, nil
-	} else if strings.ContainsRune(cmd, os.PathSeparator) {
-		return "", fmt.Errorf("%w (PATH=%q, env_count=%d)", err, os.Getenv("PATH"), len(os.Environ()))
-	} else {
-		// Bare name: scan fallback dirs. Save the original LookPath error
-		// for the diagnostic if no fallback hits.
-		for _, dir := range fallbackPATH {
-			candidate := filepath.Join(dir, cmd)
-			info, statErr := os.Stat(candidate)
-			if statErr != nil {
-				continue
-			}
-			if info.IsDir() {
-				continue
-			}
-			if info.Mode()&0o111 == 0 {
-				continue
-			}
-			return candidate, nil
-		}
-		return "", fmt.Errorf(
-			"%w (PATH=%q, env_count=%d, fallback_dirs=%v)",
-			err, os.Getenv("PATH"), len(os.Environ()), fallbackPATH,
-		)
 	}
+	if strings.ContainsRune(cmd, os.PathSeparator) {
+		return "", fmt.Errorf("%w (PATH=%q, env_count=%d)", err, os.Getenv("PATH"), len(os.Environ()))
+	}
+	// Non-not-found errors (ErrDot, fs.ErrPermission, etc.) must not be
+	// papered over by the fallback. They tell us something specific about
+	// the user's invocation — surface them with diagnostics.
+	if !errors.Is(err, exec.ErrNotFound) {
+		return "", fmt.Errorf("%w (PATH=%q, env_count=%d)", err, os.Getenv("PATH"), len(os.Environ()))
+	}
+	for _, dir := range fallbackPATH {
+		candidate := filepath.Join(dir, cmd)
+		info, statErr := os.Stat(candidate)
+		if statErr != nil || info.IsDir() {
+			continue
+		}
+		// unix.Access honors the effective uid/gid, ACLs, and MAC; the
+		// raw mode bits would let us return a binary the current process
+		// cannot actually execute, blocking later fallback dirs from
+		// being considered.
+		if accessErr := unix.Access(candidate, unix.X_OK); accessErr != nil {
+			continue
+		}
+		return candidate, nil
+	}
+	return "", fmt.Errorf(
+		"%w (PATH=%q, env_count=%d, fallback_dirs=%v)",
+		err, os.Getenv("PATH"), len(os.Environ()), fallbackPATH,
+	)
 }

--- a/cmd/agentsh-unixwrap/resolve_test.go
+++ b/cmd/agentsh-unixwrap/resolve_test.go
@@ -3,7 +3,9 @@
 package main
 
 import (
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -97,4 +99,50 @@ func TestResolveCommandPath_DirectoryNotResolved(t *testing.T) {
 	t.Setenv("PATH", "")
 	_, err := resolveCommandPath("sh")
 	require.Error(t, err, "a directory named sh must not be returned as the resolved command path")
+}
+
+// TestResolveCommandPath_ErrDotDoesNotFallback guards against roborev
+// #7712 finding (Medium): if LookPath returns a non-not-found error
+// (e.g. exec.ErrDot when the resolved entry is in CWD via "." in PATH),
+// the resolver must NOT silently substitute /usr/bin/<cmd>. Falling
+// back would route around the operator's intended binary in CWD.
+func TestResolveCommandPath_ErrDotDoesNotFallback(t *testing.T) {
+	orig := lookPathFn
+	lookPathFn = func(name string) (string, error) {
+		return "./sh", &exec.Error{Name: name, Err: exec.ErrDot}
+	}
+	t.Cleanup(func() { lookPathFn = orig })
+
+	t.Setenv("PATH", ".")
+	_, err := resolveCommandPath("sh")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, exec.ErrDot), "ErrDot must propagate unchanged, got: %v", err)
+	// fallback_dirs is only emitted when we actually entered the fallback loop.
+	require.NotContains(t, err.Error(), "fallback_dirs=", "non-not-found error must skip the fallback loop")
+}
+
+// TestResolveCommandPath_FallbackSkipsNonExecutableCandidate guards
+// against roborev #7712 finding (Low): if a fallback dir contains a
+// regular file matching the command name but the current process
+// cannot execute it (e.g. mode 0o644, or owned by another user with
+// no group/world execute bit), the resolver must skip it and continue
+// to the next fallback dir rather than returning a path the caller
+// cannot actually exec.
+func TestResolveCommandPath_FallbackSkipsNonExecutableCandidate(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	// dir1 has a non-executable file matching the command.
+	require.NoError(t, os.WriteFile(filepath.Join(dir1, "agentsh-271-probe"), []byte("notexec"), 0o644))
+	// dir2 has the executable.
+	exe := filepath.Join(dir2, "agentsh-271-probe")
+	require.NoError(t, os.WriteFile(exe, []byte("#!/bin/sh\nexit 0\n"), 0o755))
+
+	orig := fallbackPATH
+	fallbackPATH = []string{dir1, dir2}
+	t.Cleanup(func() { fallbackPATH = orig })
+
+	t.Setenv("PATH", "")
+	resolved, err := resolveCommandPath("agentsh-271-probe")
+	require.NoError(t, err)
+	require.Equal(t, exe, resolved, "resolver must skip non-executable candidate in dir1 and find dir2's executable")
 }

--- a/cmd/agentsh-unixwrap/resolve_test.go
+++ b/cmd/agentsh-unixwrap/resolve_test.go
@@ -1,0 +1,100 @@
+//go:build linux && cgo
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveCommandPath_FoundInPATH verifies the standard happy path:
+// a bare command name found via exec.LookPath using the caller's PATH.
+func TestResolveCommandPath_FoundInPATH(t *testing.T) {
+	t.Setenv("PATH", "/usr/bin:/bin")
+	path, err := resolveCommandPath("sh")
+	require.NoError(t, err)
+	require.True(t, filepath.IsAbs(path), "expected absolute path, got %q", path)
+}
+
+// TestResolveCommandPath_FallbackWhenPATHEmpty covers the OC posture
+// (canyonroad/agentsh#271): the inherited PATH is empty, exec.LookPath
+// fails, and the resolver must find the command via the hardcoded fallback
+// dirs. Without this, every bare command name fails on hosts where the
+// server filters PATH out of the wrapper's environment.
+func TestResolveCommandPath_FallbackWhenPATHEmpty(t *testing.T) {
+	// /bin/sh is universal on Linux. Verify presence as a precondition.
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skipf("/bin/sh not present, cannot exercise fallback: %v", err)
+	}
+
+	t.Setenv("PATH", "")
+	path, err := resolveCommandPath("sh")
+	require.NoError(t, err, "fallback should resolve sh even with empty PATH")
+	require.True(t, filepath.IsAbs(path), "expected absolute path, got %q", path)
+	// Resolved path must come from a fallback dir, not from PATH.
+	matched := false
+	for _, dir := range fallbackPATH {
+		if filepath.Dir(path) == dir {
+			matched = true
+			break
+		}
+	}
+	require.True(t, matched, "resolved path %q not under fallbackPATH", path)
+}
+
+// TestResolveCommandPath_NotFoundIncludesDiagnostics verifies that a
+// total-miss error includes the PATH value, env count, and fallback dirs
+// so OC-style failures can be diagnosed from the agentsh-server logs
+// without needing to reproduce the bug.
+func TestResolveCommandPath_NotFoundIncludesDiagnostics(t *testing.T) {
+	t.Setenv("PATH", "/nonexistent:/also-nonexistent")
+	_, err := resolveCommandPath("definitely-not-a-real-command-xyzzy-271")
+	require.Error(t, err)
+	msg := err.Error()
+	require.Contains(t, msg, `PATH="/nonexistent:/also-nonexistent"`, "error must surface PATH for diagnostics")
+	require.Contains(t, msg, "env_count=", "error must surface env count")
+	require.Contains(t, msg, "fallback_dirs=", "error must surface fallback list")
+}
+
+// TestResolveCommandPath_AbsolutePathBypassesFallback ensures that if the
+// caller asked for /opt/some/bin/x and that does not exist, we do NOT
+// silently substitute /usr/bin/x — the failure must be reported against
+// the requested path. Otherwise a misconfigured policy could land at the
+// wrong binary.
+func TestResolveCommandPath_AbsolutePathBypassesFallback(t *testing.T) {
+	t.Setenv("PATH", "")
+	// Non-existent absolute path that shares a basename with a real fallback.
+	_, err := resolveCommandPath("/nonexistent/dir/sh")
+	require.Error(t, err, "absolute path must not silently fall back to /bin/sh")
+	require.NotContains(t, err.Error(), "fallback_dirs=", "absolute paths skip fallback search")
+	require.Contains(t, err.Error(), `PATH=""`, "absolute path errors still include diagnostics")
+}
+
+// TestResolveCommandPath_EmptyCommand covers the trivial guard.
+func TestResolveCommandPath_EmptyCommand(t *testing.T) {
+	_, err := resolveCommandPath("")
+	require.Error(t, err)
+	require.Contains(t, strings.ToLower(err.Error()), "empty")
+}
+
+// TestResolveCommandPath_DirectoryNotResolved guards against the case
+// where a fallback dir contains a subdirectory with the same name as the
+// requested command. os.Stat would succeed on the directory, but it's
+// not executable in the exec-syscall sense.
+func TestResolveCommandPath_DirectoryNotResolved(t *testing.T) {
+	tmp := t.TempDir()
+	// Create a fake "sh" subdirectory inside a fallback path candidate.
+	require.NoError(t, os.MkdirAll(filepath.Join(tmp, "sh"), 0o755))
+	// Override fallbackPATH to point at our temp dir for the scope of this test.
+	orig := fallbackPATH
+	fallbackPATH = []string{tmp}
+	t.Cleanup(func() { fallbackPATH = orig })
+
+	t.Setenv("PATH", "")
+	_, err := resolveCommandPath("sh")
+	require.Error(t, err, "a directory named sh must not be returned as the resolved command path")
+}


### PR DESCRIPTION
## Summary

`agentsh-unixwrap` resolves bare command names (e.g. `echo`) to absolute paths via `exec.LookPath` before `syscall.Exec`. On hosts where the server strips `PATH` from the wrapper's inherited environment (OpenComputer being the documented case), every bare command name fails with the unhelpful `executable file not found in \$PATH` — even for ubiquitous commands that exist at `/usr/bin/echo`. The original `log.Fatalf` swallowed all diagnostic context, so operators could not localize the failure to PATH filtering vs. landlock denial vs. seccomp file_monitor interference without re-running with custom instrumentation.

Two changes:

1. **PATH fallback for bare names.** `resolveCommandPath()` first tries `exec.LookPath`. On `errors.Is(err, exec.ErrNotFound)` for a bare name, it scans `/usr/local/sbin`, `/usr/local/bin`, `/usr/sbin`, `/usr/bin`, `/sbin`, `/bin` for an executable file. Slash-containing arguments do NOT fall back — the caller asked for that specific path, so the failure is reported against what they asked for. Other LookPath errors (notably `exec.ErrDot`) propagate unchanged so policy-relevant signals are not masked.
2. **Diagnostic context on failure.** Errors include `PATH` value, env count, and the fallback dir list, so future OC-style failures are localizable from the first agentsh-server log without needing to reproduce.

`exec.LookPath` is wrapped in an overridable `lookPathFn` so the `ErrDot` gate can be tested deterministically without manipulating CWD.

## Roborev pre-merge

- #7712 on initial commit (`677c9ef`) → 1 Medium (fallback masked non-not-found errors), 1 Low (mode-bit check vs effective access). Both addressed.
- #7717 on `634bc6e` → clean pass, no findings.

## Tests (8 total)

- happy-path: bare name resolves via PATH
- fallback fires when PATH is empty (the OC bug)
- absolute path bypasses fallback (no silent substitution)
- diagnostic content (PATH, env_count, fallback_dirs)
- empty command rejected
- directory matching the cmd name is skipped
- ErrDot propagates unchanged, skips fallback
- non-executable candidate in fallbackPATH[0] is skipped, executable in fallbackPATH[1] is found (uses `unix.Access`)

## Test plan

- [x] `go test ./cmd/agentsh-unixwrap/... -count=1`
- [x] `go vet ./cmd/agentsh-unixwrap/`
- [x] `GOOS=windows go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)