### PR TITLE
fix(policy): strip .real suffix in basename match (closes #270)

### DIFF
--- a/internal/policy/command_shellc_test.go
+++ b/internal/policy/command_shellc_test.go
@@ -803,3 +803,59 @@ func TestEngine_CheckCommand_ShellCDerive_ShimRealSuffix(t *testing.T) {
 		})
 	}
 }
+
+// TestEngine_CheckCommand_RealSuffix_PolicyOmitsRealVariant covers
+// canyonroad/agentsh#270: under shim install, the server sees the renamed
+// real shell (e.g. /bin/bash.real) as the outer command, but operator
+// policies typically list shells without the .real suffix
+// (`commands: [bash]`). Before the fix, basename matching was strict and
+// every shim-routed bash invocation hit default-deny — making
+// AGENTSH_SHIM_FORCE=1 unusable on hosts where the shim is the only
+// enforcement path. The fix: matchCommandRules normalizes the trailing
+// `.real` suffix when checking basenames, mirroring shellparse's
+// known-shell normalization.
+func TestEngine_CheckCommand_RealSuffix_PolicyOmitsRealVariant(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "shim-policy-without-real-variants",
+		CommandRules: []CommandRule{
+			{Name: "deny-shutdown", Commands: []string{"shutdown"}, Decision: "deny"},
+			{Name: "allow-safe-commands", Commands: []string{"echo", "ls", "cat"}, Decision: "allow"},
+			// Operator wrote the canonical name only — no `.real` variants.
+			{Name: "allow-shells", Commands: []string{"sh", "bash", "dash", "zsh"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		command  string
+		args     []string
+		decision types.Decision
+		rule     string
+	}{
+		// The exact scenario from #270 — the trivial case must allow.
+		{"/bin/bash.real -c 'echo hello' (#270 trivial case)", "/bin/bash.real", []string{"-c", "echo hello"}, types.DecisionAllow, "allow-shells"},
+		{"/bin/sh.real -c 'echo hi'", "/bin/sh.real", []string{"-c", "echo hi"}, types.DecisionAllow, "allow-shells"},
+		// Bare shim-routed shell still allows.
+		{"/bin/bash.real (bare)", "/bin/bash.real", nil, types.DecisionAllow, "allow-shells"},
+		// Inner-deny still fires through .real (does not regress shim-real bypass coverage).
+		{"/bin/bash.real -c 'shutdown' → derived deny", "/bin/bash.real", []string{"-c", "shutdown"}, types.DecisionDeny, "deny-shutdown"},
+		// Case insensitivity preserved through .real strip.
+		{"/bin/BASH.REAL -c 'echo ok'", "/bin/BASH.REAL", []string{"-c", "echo ok"}, types.DecisionAllow, "allow-shells"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dec := e.CheckCommand(tc.command, tc.args)
+			if dec.PolicyDecision != tc.decision {
+				t.Errorf("decision: got %s, want %s (rule=%q)", dec.PolicyDecision, tc.decision, dec.Rule)
+			}
+			if dec.Rule != tc.rule {
+				t.Errorf("rule: got %q, want %q", dec.Rule, tc.rule)
+			}
+		})
+	}
+}

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -696,6 +696,16 @@ func decisionStrictness(d types.Decision) int {
 func (e *Engine) matchCommandRules(command string, args []string) (Decision, bool) {
 	cmdLower := strings.ToLower(command)
 	cmdBase := strings.ToLower(filepath.Base(command))
+	// The shim install renames the original shell to <name>.real and places
+	// the shim at the original path. Server-side, the shim forwards the
+	// real shell as the outer command — so an operator policy listing
+	// `commands: [bash]` would otherwise miss `bash.real` and fall through
+	// to default-deny on every shim-routed shell invocation. shellparse
+	// already strips this suffix for known-shell detection (see
+	// shellparse.basenameLower); apply the same normalization to the
+	// basename match here so policy entries written without `.real`
+	// continue to match after a shim install.
+	cmdBaseNorm := strings.TrimSuffix(cmdBase, ".real")
 
 	for _, r := range e.compiledCommandRules {
 		// Pre-check is always depth 0 (direct command from user)
@@ -730,6 +740,10 @@ func (e *Engine) matchCommandRules(command string, args []string) (Decision, boo
 			if !commandMatched {
 				if _, ok := r.basenames[cmdBase]; ok {
 					commandMatched = true
+				} else if cmdBaseNorm != cmdBase {
+					if _, ok := r.basenames[cmdBaseNorm]; ok {
+						commandMatched = true
+					}
 				}
 			}
 
@@ -737,6 +751,10 @@ func (e *Engine) matchCommandRules(command string, args []string) (Decision, boo
 			if !commandMatched {
 				for _, g := range r.basenameGlobs {
 					if g.Match(cmdBase) || g.Match(filepath.Base(command)) {
+						commandMatched = true
+						break
+					}
+					if cmdBaseNorm != cmdBase && g.Match(cmdBaseNorm) {
 						commandMatched = true
 						break
 					}


### PR DESCRIPTION
## Summary

Under shim install, the server sees the renamed real shell as the outer command (`/bin/bash.real`, `/bin/sh.real`). `shellparse` already strips the `.real` suffix for known-shell detection so derive-and-promote logic works, but `matchCommandRules` was strict — comparing the basename literally against the rule's command list. So an operator writing `commands: [bash]` (the natural form, matching what users type) had every shim-routed bash invocation fall through to default-deny because `bash.real` never matched `bash` in the basename map.

Practical impact: `AGENTSH_SHIM_FORCE=1` was unusable on hosts where the shim is the only enforcement path — every command, including trivial `bash -c "echo hello"`, was denied even when the policy clearly intended to allow it. The user's report (#270) labeled this as `shellc-opaque-script`; my repro shows the exact rule is `default-deny-commands` (the engine's loop semantics only PROMOTE strictness — they cannot weaken the outer deny that fires when nothing matches the literal `bash.real` basename). Same symptom, same root cause: asymmetric `.real` handling between `shellparse` and `matchCommandRules`.

## Fix

Normalize the trailing `.real` suffix when matching basenames and basename globs in `matchCommandRules`, mirroring `shellparse.basenameLower` (internal/shellparse/shellparse.go:131). Full-path matches (`commands: [/bin/bash]`) stay exact — operators who use full paths have explicitly opted into specificity.

```go
cmdBaseNorm := strings.TrimSuffix(cmdBase, ".real")
```

Used as a second-chance lookup against `r.basenames` and `r.basenameGlobs` only when the literal `cmdBase` did not match.

## Roborev pre-merge

- #7747 with `--reasoning maximum` on `2da53e2` → clean pass, no findings.

## Tests

`TestEngine_CheckCommand_RealSuffix_PolicyOmitsRealVariant` — five cases:

- `/bin/bash.real -c "echo hello"` (the #270 trivial case) → allow
- `/bin/sh.real -c "echo hi"` → allow
- bare `/bin/bash.real` → allow
- `/bin/bash.real -c "shutdown"` → derived deny (no regression of shim-real bypass coverage from #759 / `TestEngine_CheckCommand_ShellCDerive_ShimRealSuffix`)
- `/bin/BASH.REAL -c "echo ok"` (case-insensitive .REAL) → allow

## Test plan

- [x] `go test ./internal/policy/... -count=1`
- [x] `go test ./internal/api/... -count=1 -short`
- [x] `go vet ./internal/policy/`
- [x] `GOOS=windows go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)