### PR TITLE
fix(api): pre-check shim wrap-init against policy (v0.19.1 release-block fix)

### DIFF
--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -152,16 +152,27 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 				fmt.Errorf("shim wrap-init: no policy engine available for session")
 		}
 		dec := engine.CheckCommand(req.AgentCommand, req.AgentArgs)
-		// EffectiveDecision honors enforce_approvals/enforce_redirects so
-		// monitor-only deployments still get the wrapper; PolicyDecision
-		// reflects the underlying rule. Use Effective to gate.
-		eff := dec.EffectiveDecision
-		if eff == "" {
-			eff = dec.PolicyDecision
-		}
-		if eff != types.DecisionAllow && eff != types.DecisionAudit {
+		// We must check BOTH the underlying PolicyDecision and the
+		// EffectiveDecision. Some decisions resolve to effective-allow
+		// even though they carry semantics the shim path does not
+		// implement:
+		//
+		//   - soft_delete: PolicyDecision=soft_delete, Effective=allow.
+		//     The wrapper would not redirect rm to trash; we must defer
+		//     to agentsh-exec which performs the rewrite.
+		//   - approve with enforce_approvals=false (monitor mode):
+		//     PolicyDecision=approve, Effective=allow. Same reasoning.
+		//   - redirect with enforce_redirects=false: PolicyDecision=
+		//     redirect, Effective=allow. Same.
+		//
+		// So gate on PolicyDecision being one of {allow, audit}. Audit
+		// is "allow + enhanced logging" with no rewrite, so it's safe
+		// to issue a wrapper — the wrapped session's audit pipeline
+		// still emits events.
+		pol := dec.PolicyDecision
+		if pol != types.DecisionAllow && pol != types.DecisionAudit {
 			return types.WrapInitResponse{}, http.StatusForbidden,
-				fmt.Errorf("command requires non-shim handling by policy (rule=%s, decision=%s)", dec.Rule, eff)
+				fmt.Errorf("command requires non-shim handling by policy (rule=%s, decision=%s)", dec.Rule, pol)
 		}
 	}
 

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -126,10 +126,16 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 	// in-kernel enforcement may or may not catch it depending on whether
 	// it has the necessary privileges in the runtime environment.
 	//
-	// On deny, we return 403 so the shim's ModeAuto branch falls through
-	// to the existing `agentsh exec` path, which has its own CheckCommand
-	// pre-check and emits the user-visible policy denial. ModeOn still
-	// fail-closes via the same path.
+	// We accept only effective decisions that the wrapper path can faithfully
+	// execute end-to-end: allow (proceed) and audit (allow + logging, which
+	// the wrapped session's audit pipeline still emits). Any restrictive
+	// non-allow decision (deny, approve, redirect, soft_delete) requires
+	// semantics the shim wrap path does NOT implement — approval gating,
+	// command rewriting, redirect target validation. For those we return
+	// 403 so the shim's ModeAuto branch falls through to the existing
+	// `agentsh exec` path, which has full pre-exec policy semantics
+	// (approval prompt, redirect rewrite, deny + user-visible message).
+	// ModeOn still fail-closes via the same path.
 	//
 	// Agent mode (`agentsh wrap`) intentionally retains pre-existing
 	// behavior — it is invoked by an operator with explicit intent and
@@ -146,9 +152,16 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 				fmt.Errorf("shim wrap-init: no policy engine available for session")
 		}
 		dec := engine.CheckCommand(req.AgentCommand, req.AgentArgs)
-		if dec.PolicyDecision == types.DecisionDeny {
+		// EffectiveDecision honors enforce_approvals/enforce_redirects so
+		// monitor-only deployments still get the wrapper; PolicyDecision
+		// reflects the underlying rule. Use Effective to gate.
+		eff := dec.EffectiveDecision
+		if eff == "" {
+			eff = dec.PolicyDecision
+		}
+		if eff != types.DecisionAllow && eff != types.DecisionAudit {
 			return types.WrapInitResponse{}, http.StatusForbidden,
-				fmt.Errorf("command denied by policy (rule=%s)", dec.Rule)
+				fmt.Errorf("command requires non-shim handling by policy (rule=%s, decision=%s)", dec.Rule, eff)
 		}
 	}
 

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -116,6 +116,42 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 	// The handler will be cleaned up when the session ends or the connection closes.
 	ctx := context.Background()
 
+	// Shim mode: pre-check the agent command against policy before issuing
+	// the wrapper. The shim's kernel-install path replaces the existing
+	// `agentsh exec` flow with `wrap-init` + direct wrapper exec, which
+	// bypasses the Exec endpoint's CheckCommand pre-check that surfaces
+	// `command denied by policy` to the user. Without this guard, a denied
+	// command (e.g. `sh -c "shutdown now"`) routes around policy entirely:
+	// the shim invokes the wrapper, the wrapped shell spawns shutdown, and
+	// in-kernel enforcement may or may not catch it depending on whether
+	// it has the necessary privileges in the runtime environment.
+	//
+	// On deny, we return 403 so the shim's ModeAuto branch falls through
+	// to the existing `agentsh exec` path, which has its own CheckCommand
+	// pre-check and emits the user-visible policy denial. ModeOn still
+	// fail-closes via the same path.
+	//
+	// Agent mode (`agentsh wrap`) intentionally retains pre-existing
+	// behavior — it is invoked by an operator with explicit intent and
+	// has its own integration with policy elsewhere.
+	if req.Mode == "shim" {
+		engine := a.policyEngineFor(s)
+		if engine == nil {
+			// No policy engine configured for this session AND no global
+			// engine on the App — fail closed rather than letting the
+			// kernel-install path run without any policy gate. In
+			// production the App is always constructed with a global
+			// engine; reaching this branch means a misconfiguration.
+			return types.WrapInitResponse{}, http.StatusServiceUnavailable,
+				fmt.Errorf("shim wrap-init: no policy engine available for session")
+		}
+		dec := engine.CheckCommand(req.AgentCommand, req.AgentArgs)
+		if dec.PolicyDecision == types.DecisionDeny {
+			return types.WrapInitResponse{}, http.StatusForbidden,
+				fmt.Errorf("command denied by policy (rule=%s)", dec.Rule)
+		}
+	}
+
 	// Windows uses driver-based interception, not seccomp
 	if runtime.GOOS == "windows" {
 		return a.wrapInitWindows(ctx, s, sessionID, req)

--- a/internal/api/wrap_shim_mode_test.go
+++ b/internal/api/wrap_shim_mode_test.go
@@ -6,8 +6,43 @@ import (
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/events"
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/store/composite"
 	"github.com/agentsh/agentsh/pkg/types"
 )
+
+// permissiveTestEngine returns a policy.Engine that allows the bash/sh
+// invocations these wrap-shim tests use, satisfying the shim-mode
+// pre-check added to wrapInitCore so the tests continue to exercise the
+// wrap-init response shape rather than the policy gate.
+func permissiveTestEngine(t *testing.T) *policy.Engine {
+	t.Helper()
+	e, err := policy.NewEngine(&policy.Policy{
+		Version: 1,
+		Name:    "permissive-test",
+		CommandRules: []policy.CommandRule{
+			{Name: "allow-test-commands", Commands: []string{"sh", "bash", "sh.real", "bash.real", "echo", "true"}, Decision: "allow"},
+		},
+	}, false, true)
+	if err != nil {
+		t.Fatalf("build permissive policy engine: %v", err)
+	}
+	return e
+}
+
+// newTestAppForWrapWithPermissivePolicy mirrors newTestAppForWrap but
+// installs a permissive policy engine so shim-mode wrap-init's pre-check
+// admits bash/sh test invocations.
+func newTestAppForWrapWithPermissivePolicy(t *testing.T, cfg *config.Config) (*App, *session.Manager) {
+	t.Helper()
+	mgr := session.NewManager(5)
+	store := composite.New(mockEventStore{}, nil)
+	broker := events.NewBroker()
+	app := NewApp(cfg, mgr, store, permissiveTestEngine(t), broker, nil, nil, nil, nil, nil, nil)
+	return app, mgr
+}
 
 // TestWrapInit_ShimMode_PopulatesWrapperBinary verifies that wrap-init with
 // Mode=="shim" returns the same shape of response as agent mode: a populated
@@ -21,7 +56,7 @@ func TestWrapInit_ShimMode_PopulatesWrapperBinary(t *testing.T) {
 	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
 	cfg.Sandbox.UnixSockets.Enabled = func(b bool) *bool { return &b }(true)
 
-	app, mgr := newTestAppForWrap(t, cfg)
+	app, mgr := newTestAppForWrapWithPermissivePolicy(t, cfg)
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
 		t.Fatalf("create session: %v", err)
@@ -60,7 +95,7 @@ func TestWrapInit_ShimMode_NoFeaturesConfigured(t *testing.T) {
 	// anything" config — the server still hands back a populated wrapper
 	// response, leaving the install decision to the shim.
 
-	app, mgr := newTestAppForWrap(t, cfg)
+	app, mgr := newTestAppForWrapWithPermissivePolicy(t, cfg)
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
 		t.Fatalf("create session: %v", err)

--- a/internal/api/wrap_shim_teardown_test.go
+++ b/internal/api/wrap_shim_teardown_test.go
@@ -30,7 +30,7 @@ func TestWrapInit_ShimMode_ListenerExitsAfterOneConnection(t *testing.T) {
 	// without requiring agentsh-unixwrap to be preinstalled on PATH.
 	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
 
-	app, mgr := newTestAppForWrap(t, cfg)
+	app, mgr := newTestAppForWrapWithPermissivePolicy(t, cfg)
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
 		t.Fatalf("create session: %v", err)

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -438,6 +438,46 @@ func TestWrapInit_ShimMode_PolicyRedirect(t *testing.T) {
 	}
 }
 
+// TestWrapInit_ShimMode_PolicySoftDelete guards roborev #7872 (High):
+// soft_delete resolves to EffectiveDecision=allow even though the
+// underlying rule requires the rm-to-trash redirect that only the
+// agentsh-exec path implements. Gating on EffectiveDecision alone let
+// soft_delete commands through unrewritten — the wrapper would have
+// faithfully run rm against the requested path. Test asserts both that
+// the pre-check rejects soft_delete and that PolicyDecision is the gate
+// (a future change reverting to EffectiveDecision-only would re-fail).
+func TestWrapInit_ShimMode_PolicySoftDelete(t *testing.T) {
+	cfg := &config.Config{}
+	mgr := session.NewManager(5)
+	store := composite.New(mockEventStore{}, nil)
+	broker := events.NewBroker()
+	engine, err := policy.NewEngine(&policy.Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []policy.CommandRule{
+			{Name: "soft-delete-rm", Commands: []string{"rm"}, Decision: "soft_delete"},
+			{Name: "allow-shells", Commands: []string{"sh", "bash", "sh.real", "bash.real"}, Decision: "allow"},
+		},
+	}, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	_, code, _ := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/sh.real",
+		AgentArgs:    []string{"-c", "rm /tmp/x"},
+		Mode:         "shim",
+	})
+	if code != http.StatusForbidden {
+		t.Fatalf("soft_delete must not silently issue a wrapper; got code %d", code)
+	}
+}
+
 // TestWrapInit_ShimMode_PolicyAuditAllowed covers the inverse: audit is
 // "allow + enhanced logging" — the wrapper SHOULD be issued so the
 // session's audit pipeline can record events. This is the only non-allow

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -362,8 +362,122 @@ func TestWrapInit_ShimMode_PolicyDeny(t *testing.T) {
 	if code != http.StatusForbidden {
 		t.Errorf("expected 403, got %d", code)
 	}
-	if !strings.Contains(err.Error(), "denied by policy") {
-		t.Errorf("error must surface policy denial; got %q", err.Error())
+	if !strings.Contains(err.Error(), "policy") {
+		t.Errorf("error must surface policy gate; got %q", err.Error())
+	}
+}
+
+// TestWrapInit_ShimMode_PolicyApprove guards roborev #7867 (High): if a
+// rule that requires human approval is enforced, the shim wrap path
+// must not silently issue a wrapper. Falling back to the agentsh-exec
+// path is what surfaces the approval prompt.
+func TestWrapInit_ShimMode_PolicyApprove(t *testing.T) {
+	cfg := &config.Config{}
+	mgr := session.NewManager(5)
+	store := composite.New(mockEventStore{}, nil)
+	broker := events.NewBroker()
+	engine, err := policy.NewEngine(&policy.Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []policy.CommandRule{
+			{Name: "approve-pip", Commands: []string{"pip"}, Decision: "approve"},
+			{Name: "allow-shells", Commands: []string{"sh", "bash", "sh.real", "bash.real"}, Decision: "allow"},
+		},
+	}, true /* enforceApprovals */, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	_, code, _ := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/sh.real",
+		AgentArgs:    []string{"-c", "pip install requests"},
+		Mode:         "shim",
+	})
+	if code != http.StatusForbidden {
+		t.Fatalf("approve must not silently issue a wrapper; got code %d", code)
+	}
+}
+
+// TestWrapInit_ShimMode_PolicyRedirect covers the redirect decision.
+// Same reasoning as approve — redirect rewrites the command, which the
+// shim wrap path does not implement, so we must defer to agentsh-exec.
+func TestWrapInit_ShimMode_PolicyRedirect(t *testing.T) {
+	cfg := &config.Config{}
+	mgr := session.NewManager(5)
+	store := composite.New(mockEventStore{}, nil)
+	broker := events.NewBroker()
+	engine, err := policy.NewEngine(&policy.Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []policy.CommandRule{
+			{Name: "redirect-rm", Commands: []string{"rm"}, Decision: "redirect", RedirectTo: &policy.CommandRedirect{Command: "trash"}},
+			{Name: "allow-shells", Commands: []string{"sh", "bash", "sh.real", "bash.real"}, Decision: "allow"},
+		},
+	}, true, true /* enforceRedirects */)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	_, code, _ := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/sh.real",
+		AgentArgs:    []string{"-c", "rm /tmp/x"},
+		Mode:         "shim",
+	})
+	if code != http.StatusForbidden {
+		t.Fatalf("redirect must not silently issue a wrapper; got code %d", code)
+	}
+}
+
+// TestWrapInit_ShimMode_PolicyAuditAllowed covers the inverse: audit is
+// "allow + enhanced logging" — the wrapper SHOULD be issued so the
+// session's audit pipeline can record events. This is the only non-allow
+// effective decision the shim path admits.
+func TestWrapInit_ShimMode_PolicyAuditAllowed(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only beyond the policy pre-check")
+	}
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.WrapperBin = "nonexistent-wrapper-binary-xyz-12345"
+	mgr := session.NewManager(5)
+	store := composite.New(mockEventStore{}, nil)
+	broker := events.NewBroker()
+	engine, err := policy.NewEngine(&policy.Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []policy.CommandRule{
+			{Name: "audit-curl", Commands: []string{"curl"}, Decision: "audit"},
+			{Name: "allow-shells", Commands: []string{"sh", "bash", "sh.real", "bash.real"}, Decision: "allow"},
+		},
+	}, true, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	_, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/sh.real",
+		AgentArgs:    []string{"-c", "curl example"},
+		Mode:         "shim",
+	})
+	// Pre-check must let audit through; downstream wrapper resolution
+	// then fails (503) since we configured a non-existent binary. 403
+	// would mean the policy gate incorrectly blocked an audit decision.
+	if code == http.StatusForbidden {
+		t.Fatalf("audit must pass the policy gate; got 403 with err: %v", err)
 	}
 }
 

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -320,6 +320,141 @@ func TestWrapInit_WrapperNotFound(t *testing.T) {
 	}
 }
 
+// TestWrapInit_ShimMode_PolicyDeny covers the v0.19.1 docker-test
+// regression: when the shim's kernel-install path calls wrap-init for a
+// command the policy denies, the server must return 403 so the shim's
+// ModeAuto branch falls through to the existing `agentsh exec` path
+// (which surfaces "command denied by policy" to the user). Without this
+// pre-check, wrap-init succeeded for denied commands and the wrapper
+// ran without the policy gate firing — regression introduced in #274.
+func TestWrapInit_ShimMode_PolicyDeny(t *testing.T) {
+	cfg := &config.Config{}
+	mgr := session.NewManager(5)
+	store := composite.New(mockEventStore{}, nil)
+	broker := events.NewBroker()
+	engine, err := policy.NewEngine(&policy.Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []policy.CommandRule{
+			{Name: "block-system-commands", Commands: []string{"shutdown", "reboot"}, Decision: "deny"},
+			{Name: "allow-shells", Commands: []string{"sh", "bash", "sh.real", "bash.real"}, Decision: "allow"},
+		},
+	}, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	// shim mode + denied inner command via shell-c derivation must return 403.
+	_, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/sh.real",
+		AgentArgs:    []string{"-c", "shutdown now"},
+		Mode:         "shim",
+	})
+	if err == nil {
+		t.Fatal("expected wrap-init to return policy denial for shutdown via shell-c")
+	}
+	if code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", code)
+	}
+	if !strings.Contains(err.Error(), "denied by policy") {
+		t.Errorf("error must surface policy denial; got %q", err.Error())
+	}
+}
+
+// TestWrapInit_ShimMode_PolicyAllow confirms the pre-check does not
+// reject allowed shim invocations. /bin/sh -c "echo hi" must pass the
+// policy gate so wrap-init proceeds normally.
+func TestWrapInit_ShimMode_PolicyAllow(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only beyond the policy pre-check; this test runs the post-check path")
+	}
+	cfg := &config.Config{}
+	// Force wrap-init to fail AFTER the policy pre-check (e.g. wrapper not
+	// found) so we observe the policy gate let us through without inheriting
+	// the platform's full wrapper-launch path.
+	cfg.Sandbox.UnixSockets.WrapperBin = "nonexistent-wrapper-binary-xyz-12345"
+	mgr := session.NewManager(5)
+	store := composite.New(mockEventStore{}, nil)
+	broker := events.NewBroker()
+	engine, err := policy.NewEngine(&policy.Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []policy.CommandRule{
+			{Name: "allow-safe-commands", Commands: []string{"echo", "sh", "bash", "sh.real", "bash.real"}, Decision: "allow"},
+			{Name: "block-system-commands", Commands: []string{"shutdown"}, Decision: "deny"},
+		},
+	}, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	_, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/sh.real",
+		AgentArgs:    []string{"-c", "echo hi"},
+		Mode:         "shim",
+	})
+	// wrap-init goes past the policy pre-check, then fails at wrapper
+	// resolution with 503. Policy denial would have produced 403 — ensure
+	// we did NOT short-circuit there.
+	if code == http.StatusForbidden {
+		t.Fatalf("policy pre-check incorrectly denied an allowed command: %v", err)
+	}
+}
+
+// TestWrapInit_AgentMode_PolicyNotChecked verifies the pre-check is
+// scoped to Mode=="shim" only. The agentsh wrap path (Mode=="agent" or
+// empty) retains pre-existing behavior — pre-check would change the
+// semantics of `agentsh wrap` for any operator policy that does not
+// list the agent's outer binary.
+func TestWrapInit_AgentMode_PolicyNotChecked(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only beyond the policy pre-check")
+	}
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.WrapperBin = "nonexistent-wrapper-binary-xyz-12345"
+	mgr := session.NewManager(5)
+	store := composite.New(mockEventStore{}, nil)
+	broker := events.NewBroker()
+	engine, err := policy.NewEngine(&policy.Policy{
+		Version: 1,
+		Name:    "test",
+		CommandRules: []policy.CommandRule{
+			{Name: "block-system-commands", Commands: []string{"shutdown"}, Decision: "deny"},
+		},
+	}, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	// Same denied command but Mode="" (agent default). Pre-check must NOT fire.
+	_, code, _ := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/sh.real",
+		AgentArgs:    []string{"-c", "shutdown now"},
+	})
+	if code == http.StatusForbidden {
+		t.Fatal("agent-mode wrap-init must not invoke shim-mode policy pre-check")
+	}
+}
+
+
 func TestWrapInit_RejectsNegativeCallerUID(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("negative caller uid validation is Linux-only")


### PR DESCRIPTION
## Summary

The shim's kernel-install path (added in #274) bypassed the existing policy pre-check that surfaces \"command denied by policy\" to the user. Flow: shim → POST `/sessions/{id}/wrap-init` with `AgentCommand`+`AgentArgs` → server returns wrapper binary + notify socket → shim execs wrapper directly, skipping the `agentsh-exec` → `CheckCommand` path.

Result: a denied command like `bash -c \"shutdown now\"` invoked through the shim was no longer policy-denied at pre-exec time. The v0.19.1 release-build docker-test on debian/archlinux/fedora caught this — the test asserts shutdown-via-shim emits a policy denial; instead the command actually executed (or returned distro-specific not-found). v0.19.1 was tagged and immediately rolled back; this PR fixes the underlying issue.

## Fix

`wrapInitCore` now pre-checks `Engine.CheckCommand(AgentCommand, AgentArgs)` when `req.Mode == \"shim\"`. The gate admits ONLY `PolicyDecision` in `{allow, audit}` — anything else (deny, approve, redirect, soft_delete) returns 403 so the shim's `ModeAuto` falls through to `agentsh exec` which has the full pre-exec semantics (approval prompt, redirect rewrite, deny + user-visible message). `ModeOn` fail-closes via the same path.

Why `PolicyDecision` not `EffectiveDecision`: `soft_delete` resolves to `EffectiveDecision=allow` because the operation is allowed (just rewritten to trash). Gating on Effective alone would let `soft_delete` issue a wrapper that runs `rm` unrewritten — caught by roborev #7872. The `PolicyDecision` gate also covers monitor-mode (`enforce_approvals=false` / `enforce_redirects=false`) where approve/redirect resolve to Effective=allow but the operator still expects no wrapper bypass.

`Mode == \"agent\"` (`agentsh wrap`) intentionally retains pre-existing behavior — it is invoked by an operator with explicit intent.

## Roborev pre-merge

- #7867 max-reasoning on initial commit → 1 High (gate only blocked `Deny`, missed approve/redirect/soft_delete).
- #7872 max-reasoning on follow-up → 1 High (`Effective`-only gate missed `soft_delete` because it's effective-allow).
- #7877 max-reasoning on third commit → clean pass.

## Tests (all in internal/api/wrap_test.go)

- `TestWrapInit_ShimMode_PolicyDeny` — denied shell-c invocation → 403.
- `TestWrapInit_ShimMode_PolicyApprove` — enforced approve → 403.
- `TestWrapInit_ShimMode_PolicyRedirect` — enforced redirect → 403.
- `TestWrapInit_ShimMode_PolicySoftDelete` — soft_delete (effective=allow) → 403, locks in the gate-on-PolicyDecision contract.
- `TestWrapInit_ShimMode_PolicyAuditAllowed` — audit passes pre-check (only non-allow PolicyDecision the path admits).
- `TestWrapInit_ShimMode_PolicyAllow` — allowed invocation passes pre-check.
- `TestWrapInit_AgentMode_PolicyNotChecked` — `Mode==\"agent\"` does NOT invoke the shim pre-check.

Existing shim-mode tests updated to use `newTestAppForWrapWithPermissivePolicy` so they continue to test wrap-init shape rather than the policy gate.

## Test plan

- [x] `go test ./internal/api/... -count=1 -short`
- [x] `go test ./... -count=1 -short`
- [x] `go vet ./...`
- [x] `GOOS=windows go build ./...`

Once merged, retag v0.19.1 to validate against the docker-test suite that originally surfaced the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)