### PR TITLE
fix(shim/unixwrap): preserve argv[0] across kernel-install on busybox systems

### DIFF
--- a/cmd/agentsh-shell-shim/main.go
+++ b/cmd/agentsh-shell-shim/main.go
@@ -130,6 +130,10 @@ func main() {
 				ShellArgs:     os.Args[1:],
 				Env:           os.Environ(),
 				CallerUID:     os.Getuid(),
+				// Forward the user's original invocation name so the wrapper
+				// can preserve argv[0] semantics (busybox applet routing on
+				// Alpine, login-shell detection on others).
+				Argv0: argv0,
 			})
 			if installErr != nil {
 				fatalWithHint(126, "agentsh-shell-shim: kernel install: "+installErr.Error(),

--- a/cmd/agentsh-unixwrap/argv0_override_test.go
+++ b/cmd/agentsh-unixwrap/argv0_override_test.go
@@ -56,6 +56,18 @@ func TestApplyArgv0Override(t *testing.T) {
 			override: "/bin/sh",
 			want:     []string{"/bin/sh", "-c", "echo 'hello world' | tr a-z A-Z"},
 		},
+		{
+			name:     "empty rawArgs with override does not panic and returns empty",
+			args:     []string{},
+			override: "/bin/sh",
+			want:     []string{},
+		},
+		{
+			name:     "nil rawArgs with override returns empty",
+			args:     nil,
+			override: "/bin/sh",
+			want:     nil,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/agentsh-unixwrap/argv0_override_test.go
+++ b/cmd/agentsh-unixwrap/argv0_override_test.go
@@ -1,0 +1,85 @@
+//go:build linux && cgo
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestApplyArgv0Override covers the Alpine busybox regression
+// (canyonroad/agentsh#270 follow-up): the shim sets
+// AGENTSH_UNIXWRAP_ARGV0 so busybox-multicall binaries see the original
+// invocation name (e.g. "/bin/sh") instead of the renamed
+// "/bin/sh.real" — busybox uses argv[0] basename to pick its applet,
+// and "sh.real" is not a known applet.
+func TestApplyArgv0Override(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		override string
+		want     []string
+	}{
+		{
+			name:     "override substitutes argv[0] only",
+			args:     []string{"/bin/sh.real", "-c", "echo hi"},
+			override: "/bin/sh",
+			want:     []string{"/bin/sh", "-c", "echo hi"},
+		},
+		{
+			name:     "empty override leaves args unchanged",
+			args:     []string{"/bin/sh.real", "-c", "echo hi"},
+			override: "",
+			want:     []string{"/bin/sh.real", "-c", "echo hi"},
+		},
+		{
+			name:     "whitespace-only override is treated as empty",
+			args:     []string{"/bin/sh.real", "-c", "echo hi"},
+			override: "   \t\n  ",
+			want:     []string{"/bin/sh.real", "-c", "echo hi"},
+		},
+		{
+			name:     "override with surrounding whitespace is trimmed",
+			args:     []string{"/bin/sh.real", "-c", "echo hi"},
+			override: "  /bin/sh  ",
+			want:     []string{"/bin/sh", "-c", "echo hi"},
+		},
+		{
+			name:     "single-arg invocation still works",
+			args:     []string{"/bin/sh.real"},
+			override: "/bin/sh",
+			want:     []string{"/bin/sh"},
+		},
+		{
+			name:     "args with embedded whitespace and metachars preserved",
+			args:     []string{"/bin/sh.real", "-c", "echo 'hello world' | tr a-z A-Z"},
+			override: "/bin/sh",
+			want:     []string{"/bin/sh", "-c", "echo 'hello world' | tr a-z A-Z"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := applyArgv0Override(tc.args, tc.override)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("applyArgv0Override(%v, %q) = %v, want %v", tc.args, tc.override, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestApplyArgv0Override_DoesNotMutateInput guards against an aliasing
+// bug where the override path could share backing storage with the
+// caller's slice and corrupt it on later mutation.
+func TestApplyArgv0Override_DoesNotMutateInput(t *testing.T) {
+	in := []string{"/bin/sh.real", "-c", "echo hi"}
+	orig := append([]string(nil), in...)
+	out := applyArgv0Override(in, "/bin/sh")
+
+	// Mutating the output must not affect the input.
+	out[0] = "/bin/zsh"
+	out[1] = "-l"
+
+	if !reflect.DeepEqual(in, orig) {
+		t.Errorf("applyArgv0Override mutated input: in=%v orig=%v", in, orig)
+	}
+}

--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"syscall"
 	"unsafe"
 
@@ -219,10 +220,30 @@ func main() {
 	if err != nil {
 		log.Fatalf("resolve command %q: %v", cmd, err)
 	}
-	args := os.Args[2:]
+	args := applyArgv0Override(os.Args[2:], os.Getenv("AGENTSH_UNIXWRAP_ARGV0"))
 	if err := syscall.Exec(cmdPath, args, os.Environ()); err != nil {
 		log.Fatalf("exec %s failed: %v", cmd, err)
 	}
+}
+
+// applyArgv0Override returns the argv slice to pass to syscall.Exec,
+// substituting argv[0] with override when override is non-empty (after
+// trimming whitespace). The shim sets AGENTSH_UNIXWRAP_ARGV0 so
+// busybox-multicall binaries (Alpine /bin/sh, BusyBox /bin/bash on some
+// systems) see the original invocation name (e.g. "/bin/sh") instead of
+// the renamed "/bin/sh.real" — busybox uses argv[0] basename to pick
+// its applet, and "sh.real" is not a known applet, so without the
+// override the exec exits 127 with "applet not found". An empty or
+// whitespace-only value preserves the previous behaviour (argv[0]
+// = the resolved real path).
+func applyArgv0Override(rawArgs []string, override string) []string {
+	if override = strings.TrimSpace(override); override == "" {
+		return rawArgs
+	}
+	out := make([]string, len(rawArgs))
+	out[0] = override
+	copy(out[1:], rawArgs[1:])
+	return out
 }
 
 func notifySockFD() (int, error) {

--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -236,7 +236,14 @@ func main() {
 // override the exec exits 127 with "applet not found". An empty or
 // whitespace-only value preserves the previous behaviour (argv[0]
 // = the resolved real path).
+//
+// Returns rawArgs unchanged when len(rawArgs) == 0; the call site
+// guards via the `len(os.Args) < 3` check, but the explicit zero-arg
+// guard makes the helper safe against future re-use.
 func applyArgv0Override(rawArgs []string, override string) []string {
+	if len(rawArgs) == 0 {
+		return rawArgs
+	}
 	if override = strings.TrimSpace(override); override == "" {
 		return rawArgs
 	}

--- a/internal/shim/kernelinstall/install_linux.go
+++ b/internal/shim/kernelinstall/install_linux.go
@@ -127,6 +127,15 @@ func runRelay(p InstallParams, resp types.WrapInitResponse) (Result, error) {
 	env := make([]string, len(filteredBase))
 	copy(env, filteredBase)
 	env = append(env, "AGENTSH_NOTIFY_SOCK_FD=3")
+	// Plumb the original invocation name (e.g. "/bin/sh") through to the
+	// wrapper so it can override argv[0] when execve'ing the real shell.
+	// On Alpine, /bin/sh.real is a busybox binary; without this override,
+	// busybox derives applet name "sh.real" → "applet not found" → exit
+	// 127. The wrapper falls back to its os.Args[2] (the real shell path)
+	// when this is empty, which is correct on non-busybox systems.
+	if p.Argv0 != "" {
+		env = append(env, fmt.Sprintf("AGENTSH_UNIXWRAP_ARGV0=%s", p.Argv0))
+	}
 	for k, v := range resp.WrapperEnv {
 		if k == signalSockFDKey {
 			slog.Debug("kernelinstall: stripping signal sock fd from wrapper env (shim mode limitation)")

--- a/internal/shim/kernelinstall/install_linux.go
+++ b/internal/shim/kernelinstall/install_linux.go
@@ -27,6 +27,14 @@ const wrapInitTimeout = 10 * time.Second
 // wrapper binary.
 const signalSockFDKey = "AGENTSH_SIGNAL_SOCK_FD"
 
+// argv0EnvKey is the env var the shim injects so unixwrap preserves the
+// caller's original invocation name as argv[0] when execve'ing the real
+// shell. Stripped from inherited env so a stale value from a re-entrant
+// invocation (or operator-set value) cannot leak through and contradict
+// the InstallParams.Argv0=="" "no override" contract — only the value we
+// append in runRelay is honored.
+const argv0EnvKey = "AGENTSH_UNIXWRAP_ARGV0"
+
 // Install is the all-in-one entry point that the shim calls before launching
 // the user's command.  It:
 //
@@ -123,7 +131,7 @@ func runRelay(p InstallParams, resp types.WrapInitResponse) (Result, error) {
 	//    shim runs inside an already-wrapped process) must not reach the wrapper.
 	//  - from WrapperEnv: shim mode does not replicate the signal-filter
 	//    socketpair, so the wrapper must not try to open that fd.
-	filteredBase := filterSignalSockFD(p.Env)
+	filteredBase := filterShimInternalEnv(p.Env)
 	env := make([]string, len(filteredBase))
 	copy(env, filteredBase)
 	env = append(env, "AGENTSH_NOTIFY_SOCK_FD=3")
@@ -134,7 +142,7 @@ func runRelay(p InstallParams, resp types.WrapInitResponse) (Result, error) {
 	// 127. The wrapper falls back to its os.Args[2] (the real shell path)
 	// when this is empty, which is correct on non-busybox systems.
 	if p.Argv0 != "" {
-		env = append(env, fmt.Sprintf("AGENTSH_UNIXWRAP_ARGV0=%s", p.Argv0))
+		env = append(env, fmt.Sprintf("%s=%s", argv0EnvKey, p.Argv0))
 	}
 	for k, v := range resp.WrapperEnv {
 		if k == signalSockFDKey {
@@ -303,6 +311,28 @@ func filterSignalSockFD(env []string) []string {
 	prefix := signalSockFDKey + "="
 	for _, e := range env {
 		if strings.HasPrefix(e, prefix) {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+// filterShimInternalEnv returns a copy of env with all internal env vars
+// (AGENTSH_SIGNAL_SOCK_FD, AGENTSH_UNIXWRAP_ARGV0) removed. The signal
+// fd is stripped because shim mode does not replicate the signal-filter
+// socketpair, so a stale value would point the wrapper at a non-existent
+// fd. The argv0 override is stripped because we always append the
+// authoritative value (or omit it entirely when InstallParams.Argv0 is
+// empty); a stale inherited value from a re-entrant invocation would
+// otherwise silently win on Argv0=="" and contradict the documented
+// "empty falls back to the resolved real path" contract.
+func filterShimInternalEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	signalPrefix := signalSockFDKey + "="
+	argv0Prefix := argv0EnvKey + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, signalPrefix) || strings.HasPrefix(e, argv0Prefix) {
 			continue
 		}
 		out = append(out, e)

--- a/internal/shim/kernelinstall/install_linux_test.go
+++ b/internal/shim/kernelinstall/install_linux_test.go
@@ -258,6 +258,133 @@ func TestInstall_StripsSignalSockFdFromPEnv(t *testing.T) {
 	t.Logf("wrapper env output (excerpt):\n%s", string(envOutput))
 }
 
+// TestInstall_PassesArgv0ToWrapper covers the v0.19.1 alpine docker-test
+// regression: on busybox-multicall systems (Alpine) the renamed shell at
+// /bin/sh.real is the busybox binary, and busybox derives the applet from
+// argv[0]'s basename. Without forwarding the original invocation name
+// ("/bin/sh") to the wrapper, the wrapper's syscall.Exec sets argv[0] to
+// "/bin/sh.real", busybox looks up applet "sh.real", fails, and exits 127.
+// This test verifies the fix: when InstallParams.Argv0 is set, the
+// AGENTSH_UNIXWRAP_ARGV0 env var is propagated to the wrapper. The
+// wrapper itself then substitutes argv[0]; that substitution is covered
+// by tests in cmd/agentsh-unixwrap.
+func TestInstall_PassesArgv0ToWrapper(t *testing.T) {
+	wrapperBin := buildFakeWrapperPrintEnv(t)
+
+	sockDir := t.TempDir()
+	notifySockPath := sockDir + "/notify.sock"
+	ln, err := net.Listen("unix", notifySockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, _ := ln.Accept()
+		if conn != nil {
+			buf := make([]byte, 1)
+			oob := make([]byte, 64)
+			conn.(*net.UnixConn).ReadMsgUnix(buf, oob) //nolint:errcheck
+			conn.Close()
+		}
+	}()
+
+	handler, _ := makeWrapInitHandler(200, types.WrapInitResponse{
+		WrapperBinary: wrapperBin,
+		NotifySocket:  notifySockPath,
+		WrapperEnv:    map[string]string{},
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	outFile, err := os.CreateTemp(t.TempDir(), "wrapper-env-*.txt")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	outPath := outFile.Name()
+	outFile.Close()
+
+	p := baseParams(srv)
+	p.Mode = ModeOn
+	p.Argv0 = "/bin/sh"
+	p.Env = []string{"FAKE_ENV_OUT=" + outPath}
+
+	res, err := Install(p)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if res.Action != ResultExec {
+		t.Fatalf("expected ResultExec, got %v (reason: %s)", res.Action, res.Reason)
+	}
+
+	envOutput, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read wrapper env output: %v", err)
+	}
+	if !strings.Contains(string(envOutput), "AGENTSH_UNIXWRAP_ARGV0=/bin/sh\n") {
+		t.Errorf("AGENTSH_UNIXWRAP_ARGV0 was not propagated to wrapper env. Got:\n%s", string(envOutput))
+	}
+}
+
+// TestInstall_OmitsArgv0WhenEmpty covers the symmetric case: when
+// InstallParams.Argv0 is empty (older shim, agent-mode caller), the
+// AGENTSH_UNIXWRAP_ARGV0 env var must NOT be set. unixwrap's empty-string
+// path falls back to argv[0]=resolved-cmd-path, preserving prior behavior.
+func TestInstall_OmitsArgv0WhenEmpty(t *testing.T) {
+	wrapperBin := buildFakeWrapperPrintEnv(t)
+
+	sockDir := t.TempDir()
+	notifySockPath := sockDir + "/notify.sock"
+	ln, err := net.Listen("unix", notifySockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, _ := ln.Accept()
+		if conn != nil {
+			buf := make([]byte, 1)
+			oob := make([]byte, 64)
+			conn.(*net.UnixConn).ReadMsgUnix(buf, oob) //nolint:errcheck
+			conn.Close()
+		}
+	}()
+
+	handler, _ := makeWrapInitHandler(200, types.WrapInitResponse{
+		WrapperBinary: wrapperBin,
+		NotifySocket:  notifySockPath,
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	outFile, err := os.CreateTemp(t.TempDir(), "wrapper-env-*.txt")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	outPath := outFile.Name()
+	outFile.Close()
+
+	p := baseParams(srv)
+	p.Mode = ModeOn
+	p.Argv0 = "" // explicitly empty
+	p.Env = []string{"FAKE_ENV_OUT=" + outPath}
+
+	res, err := Install(p)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if res.Action != ResultExec {
+		t.Fatalf("expected ResultExec, got %v (reason: %s)", res.Action, res.Reason)
+	}
+
+	envOutput, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read wrapper env output: %v", err)
+	}
+	if strings.Contains(string(envOutput), "AGENTSH_UNIXWRAP_ARGV0=") {
+		t.Errorf("AGENTSH_UNIXWRAP_ARGV0 must NOT be set when Argv0 is empty. Got:\n%s", string(envOutput))
+	}
+}
+
 // fakeWrapperPrintEnvSrc is a fake wrapper that writes its environment to the
 // file named by FAKE_ENV_OUT, sends the notify fd, reads the ACK, and exits 0.
 const fakeWrapperPrintEnvSrc = `package main

--- a/internal/shim/kernelinstall/install_linux_test.go
+++ b/internal/shim/kernelinstall/install_linux_test.go
@@ -385,6 +385,109 @@ func TestInstall_OmitsArgv0WhenEmpty(t *testing.T) {
 	}
 }
 
+// TestInstall_StripsStaleArgv0FromInheritedEnv guards roborev #7950
+// finding (Low #2): a stale AGENTSH_UNIXWRAP_ARGV0 in p.Env (e.g.
+// re-entrant shim invocation, or operator-set value) must NOT silently
+// reach the wrapper. With InstallParams.Argv0 == "", the contract is
+// "no override, fall back to resolved real path"; a leaked stale value
+// would contradict that. We strip both internal env vars before
+// appending the authoritative value (or none) in runRelay.
+func TestInstall_StripsStaleArgv0FromInheritedEnv(t *testing.T) {
+	wrapperBin := buildFakeWrapperPrintEnv(t)
+
+	sockDir := t.TempDir()
+	notifySockPath := sockDir + "/notify.sock"
+	ln, err := net.Listen("unix", notifySockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, _ := ln.Accept()
+		if conn != nil {
+			buf := make([]byte, 1)
+			oob := make([]byte, 64)
+			conn.(*net.UnixConn).ReadMsgUnix(buf, oob) //nolint:errcheck
+			conn.Close()
+		}
+	}()
+
+	handler, _ := makeWrapInitHandler(200, types.WrapInitResponse{
+		WrapperBinary: wrapperBin,
+		NotifySocket:  notifySockPath,
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	outFile, err := os.CreateTemp(t.TempDir(), "wrapper-env-*.txt")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	outPath := outFile.Name()
+	outFile.Close()
+
+	p := baseParams(srv)
+	p.Mode = ModeOn
+	p.Argv0 = "" // explicitly empty — must not be overridden by inherited stale
+	p.Env = []string{
+		"AGENTSH_UNIXWRAP_ARGV0=/bin/stale-shell", // stale inherited value
+		"FAKE_ENV_OUT=" + outPath,
+	}
+
+	res, err := Install(p)
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	if res.Action != ResultExec {
+		t.Fatalf("expected ResultExec, got %v (reason: %s)", res.Action, res.Reason)
+	}
+
+	envOutput, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read wrapper env output: %v", err)
+	}
+	for _, line := range strings.Split(string(envOutput), "\n") {
+		if strings.HasPrefix(line, "AGENTSH_UNIXWRAP_ARGV0=") {
+			t.Errorf("stale AGENTSH_UNIXWRAP_ARGV0 leaked into wrapper env: %q", line)
+		}
+	}
+}
+
+// TestFilterShimInternalEnv covers the helper directly: it must drop
+// both internal env vars and preserve everything else.
+func TestFilterShimInternalEnv(t *testing.T) {
+	in := []string{
+		"AGENTSH_SIGNAL_SOCK_FD=4",
+		"AGENTSH_UNIXWRAP_ARGV0=/bin/stale",
+		"OTHER=x",
+		"HOME=/tmp",
+		"AGENTSH_UNIXWRAP_ARGV0_NOT_OURS=keep", // prefix-not-equal must be preserved
+	}
+	out := filterShimInternalEnv(in)
+	for _, e := range out {
+		if strings.HasPrefix(e, "AGENTSH_SIGNAL_SOCK_FD=") {
+			t.Errorf("AGENTSH_SIGNAL_SOCK_FD not stripped: %q", e)
+		}
+		if strings.HasPrefix(e, "AGENTSH_UNIXWRAP_ARGV0=") {
+			t.Errorf("AGENTSH_UNIXWRAP_ARGV0 not stripped: %q", e)
+		}
+	}
+	want := map[string]bool{
+		"OTHER=x":                            true,
+		"HOME=/tmp":                          true,
+		"AGENTSH_UNIXWRAP_ARGV0_NOT_OURS=keep": true,
+	}
+	got := map[string]bool{}
+	for _, e := range out {
+		got[e] = true
+	}
+	for w := range want {
+		if !got[w] {
+			t.Errorf("expected entry %q in filtered env", w)
+		}
+	}
+}
+
 // fakeWrapperPrintEnvSrc is a fake wrapper that writes its environment to the
 // file named by FAKE_ENV_OUT, sends the notify fd, reads the ACK, and exits 0.
 const fakeWrapperPrintEnvSrc = `package main

--- a/internal/shim/kernelinstall/types.go
+++ b/internal/shim/kernelinstall/types.go
@@ -13,6 +13,16 @@ type InstallParams struct {
 	ShellArgs     []string
 	Env           []string
 	CallerUID     int
+	// Argv0 is the path the user originally invoked the shim as (e.g.
+	// "/bin/sh"). The wrapper uses this as argv[0] when execve'ing the
+	// real shell so busybox-multicall binaries (Alpine /bin/sh) and
+	// shells that key off argv[0] for login/applet semantics see the
+	// expected name. Without this, /bin/sh.real on Alpine — which is a
+	// busybox binary — exits with "sh.real: applet not found" because
+	// busybox derives the applet from the invocation name. Empty falls
+	// back to RealShell, preserving prior behaviour for non-busybox
+	// systems where the basename happens to match.
+	Argv0 string
 }
 
 // Result is returned by Install to tell the caller what to do next.


### PR DESCRIPTION
## Summary

The shim's kernel-install path (added in #274) execs the wrapper with argv[0] set to the resolved real-shell path (e.g. `/bin/sh.real`). On Alpine and other busybox-multicall systems, `/bin/sh.real` IS the busybox binary, and busybox derives the applet from argv[0]'s basename. `sh.real` is not a known applet, so busybox exits 127 with `sh.real: applet not found` — every shim-routed shell invocation fails on Alpine even before policy enforcement runs.

This was caught by the v0.19.1 release docker-test on alpine. v0.19.0 worked because the pre-#274 path used `agentsh exec --argv0 /bin/sh ...` which preserved the original invocation name. The kernel-install path re-introduced the argv[0] mismatch.

The other v0.19.1 release-block fixes (already merged to main):
- #275/#276 — cgroup writability probe (#272 + EEXIST follow-up)
- #277 — unixwrap PATH fallback + diagnostics (#271)
- #278 — `.real` suffix in basename match (#270)
- #279 — wrap-init shim policy pre-check (closes the v0.19.1 docker-test deny-not-firing regression on debian/arch/fedora)

This PR closes the last remaining v0.19.1 docker-test regression (alpine).

## Fix

Thread the original invocation name through the kernel-install path:

- **`InstallParams.Argv0`** (new field) carries the user's invocation path.
- **shim** populates it from `os.Args[0]`.
- **`install_linux.go`** propagates it as `AGENTSH_UNIXWRAP_ARGV0` in the wrapper environment, AND strips any stale value from inherited env via the new `filterShimInternalEnv` helper (extends the prior `filterSignalSockFD` semantics).
- **`agentsh-unixwrap`** reads the env var and substitutes argv[0] before `syscall.Exec`. Empty/whitespace-only values fall back to the prior behaviour (argv[0] = resolved path). The substitution lives in `applyArgv0Override` for unit-testability.

## Roborev pre-merge

- #7949 (codex, max reasoning) — agent hit usage quota; switched to claude-code.
- #7950 (claude-code, max reasoning) on initial commit `f024cf4` → 2 Low findings: zero-arg panic in helper + stale env var leakage in p.Env.
- #7953 (claude-code, max reasoning) on review-fix commit `adebcfc` → clean pass.

## Tests

- `TestApplyArgv0Override` — 8 sub-cases: override, empty, whitespace, trim, single-arg, metachars, plus zero-arg and nil-arg guards (no panic).
- `TestApplyArgv0Override_DoesNotMutateInput` — aliasing guard.
- `TestInstall_PassesArgv0ToWrapper` — env var is propagated when `Argv0` is set.
- `TestInstall_OmitsArgv0WhenEmpty` — env var is NOT set when `Argv0` is empty.
- `TestInstall_StripsStaleArgv0FromInheritedEnv` — stale value in `p.Env` does NOT leak through to the wrapper.
- `TestFilterShimInternalEnv` — helper drops both internal vars; preserves prefix-not-equal entries.

## Test plan

- [x] `go test ./... -count=1 -short`
- [x] `go vet ./...`
- [x] `GOOS=windows go build ./...`
- [x] Local docker repro: `sh.real: applet not found exit=127` on Alpine before fix; with the fix the override propagates and busybox finds the `sh` applet.

Once merged, retag v0.19.1 to validate end-to-end on the docker-test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)