### PR TITLE
fix(unixwrap): silence informational logs on non-Yama kernels (closes #281)

### DIFF
--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -50,13 +50,15 @@ func main() {
 	// our ancestor, so this prctl authorizes it specifically.
 	// On kernels without Yama, PR_SET_PTRACER returns EINVAL — but it's
 	// also unnecessary because standard Unix DAC governs ptrace.
-	if cfg.ServerPID > 0 {
-		if isYamaActive() {
-			if err := unix.Prctl(unix.PR_SET_PTRACER, uintptr(cfg.ServerPID), 0, 0, 0); err != nil {
-				log.Printf("PR_SET_PTRACER(%d): %v (Yama active, ProcessVMReadv may fail)", cfg.ServerPID, err)
-			}
-		} else {
-			log.Printf("yama: not active, skipping PR_SET_PTRACER (standard DAC governs ptrace)")
+	//
+	// yamaActive is computed once and reused for setupPtracerPreload below
+	// so we don't double-stat the sysctl path. The non-Yama path returns
+	// silently — emitting a "skipping PR_SET_PTRACER" log here would add
+	// noise on every wrapper invocation on most distros (issue #281).
+	yamaActive := isYamaActive()
+	if cfg.ServerPID > 0 && yamaActive {
+		if err := unix.Prctl(unix.PR_SET_PTRACER, uintptr(cfg.ServerPID), 0, 0, 0); err != nil {
+			log.Printf("PR_SET_PTRACER(%d): %v (Yama active, ProcessVMReadv may fail)", cfg.ServerPID, err)
 		}
 	}
 
@@ -193,9 +195,11 @@ func main() {
 	// Set up LD_PRELOAD for the ptracer library so that child processes
 	// call PR_SET_PTRACER(server_pid). Without this, ProcessVMReadv fails
 	// for children under Yama ptrace_scope=1, breaking seccomp path resolution.
-	// Only needed when seccomp notify is active (notifFD >= 0).
+	// Only needed when seccomp notify is active (notifFD >= 0) AND Yama is
+	// active — on non-Yama kernels the LD_PRELOAD is irrelevant and would
+	// only emit confusing "ptracer: lib not found" noise (issue #281).
 	if notifFD >= 0 {
-		setupPtracerPreload(cfg.ServerPID)
+		setupPtracerPreload(cfg.ServerPID, yamaActive)
 	}
 
 	// Block SIGURG on this OS thread to prevent Go's ~10ms async preemption

--- a/cmd/agentsh-unixwrap/ptracer_linux.go
+++ b/cmd/agentsh-unixwrap/ptracer_linux.go
@@ -17,11 +17,20 @@ const ptracerLibName = "libagentsh-ptracer.so"
 // This allows the server to use ProcessVMReadv on child processes under Yama
 // ptrace_scope=1, restoring seccomp path resolution for file monitoring.
 //
+// yamaActive gates the work: when Yama is not loaded, PR_SET_PTRACER is a
+// no-op and ProcessVMReadv falls back to standard Unix DAC, so the LD_PRELOAD
+// library is not needed and the function returns silently. This keeps the
+// happy path on non-Yama kernels noise-free (issue #281) while preserving
+// the actionable warning when Yama IS active and the library is missing.
+//
 // The library is searched for in:
 //  1. Same directory as the wrapper binary
 //  2. /usr/lib/agentsh/ (deb/rpm install path)
-func setupPtracerPreload(serverPID int) {
+func setupPtracerPreload(serverPID int, yamaActive bool) {
 	if serverPID <= 0 {
+		return
+	}
+	if !yamaActive {
 		return
 	}
 

--- a/cmd/agentsh-unixwrap/ptracer_linux_test.go
+++ b/cmd/agentsh-unixwrap/ptracer_linux_test.go
@@ -3,6 +3,8 @@
 package main
 
 import (
+	"bytes"
+	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +16,7 @@ import (
 func TestSetupPtracerPreload_ZeroPID(t *testing.T) {
 	os.Unsetenv("LD_PRELOAD")
 	os.Unsetenv("AGENTSH_SERVER_PID")
-	setupPtracerPreload(0)
+	setupPtracerPreload(0, true)
 	assert.Empty(t, os.Getenv("LD_PRELOAD"), "should not set LD_PRELOAD for pid 0")
 	assert.Empty(t, os.Getenv("AGENTSH_SERVER_PID"), "should not set AGENTSH_SERVER_PID for pid 0")
 }
@@ -22,7 +24,7 @@ func TestSetupPtracerPreload_ZeroPID(t *testing.T) {
 func TestSetupPtracerPreload_NegativePID(t *testing.T) {
 	os.Unsetenv("LD_PRELOAD")
 	os.Unsetenv("AGENTSH_SERVER_PID")
-	setupPtracerPreload(-1)
+	setupPtracerPreload(-1, true)
 	assert.Empty(t, os.Getenv("LD_PRELOAD"), "should not set LD_PRELOAD for negative pid")
 }
 
@@ -40,7 +42,7 @@ func TestSetupPtracerPreload_SetsEnvWhenLibExists(t *testing.T) {
 	defer os.Unsetenv("LD_PRELOAD")
 	defer os.Unsetenv("AGENTSH_SERVER_PID")
 
-	setupPtracerPreload(12345)
+	setupPtracerPreload(12345, true)
 
 	assert.Equal(t, soPath, os.Getenv("LD_PRELOAD"), "should set LD_PRELOAD to ptracer lib path")
 	assert.Equal(t, "12345", os.Getenv("AGENTSH_SERVER_PID"), "should set AGENTSH_SERVER_PID")
@@ -59,12 +61,72 @@ func TestSetupPtracerPreload_PreservesExistingLDPreload(t *testing.T) {
 	defer os.Unsetenv("LD_PRELOAD")
 	defer os.Unsetenv("AGENTSH_SERVER_PID")
 
-	setupPtracerPreload(42)
+	setupPtracerPreload(42, true)
 
 	ldPreload := os.Getenv("LD_PRELOAD")
 	assert.Contains(t, ldPreload, soPath, "should include ptracer lib")
 	assert.Contains(t, ldPreload, "/existing/lib.so", "should preserve existing LD_PRELOAD")
 	assert.Equal(t, "42", os.Getenv("AGENTSH_SERVER_PID"))
+}
+
+// TestSetupPtracerPreload_YamaInactive_NoLog asserts that when Yama is not
+// active, setupPtracerPreload returns silently — even if the .so is missing.
+// This is the regression behind issue #281: the unconditional "ptracer: ...
+// not found" log emitted noise during routine wrapper invocations on
+// non-Yama kernels (where the library is irrelevant), which the v0.19.1
+// shim kernel-install path surfaced in many more contexts than v0.19.0.
+func TestSetupPtracerPreload_YamaInactive_NoLog(t *testing.T) {
+	// Ensure no .so is discoverable next to the test binary.
+	self, err := os.Executable()
+	require.NoError(t, err)
+	soPath := filepath.Join(filepath.Dir(self), ptracerLibName)
+	_ = os.Remove(soPath)
+
+	os.Unsetenv("LD_PRELOAD")
+	os.Unsetenv("AGENTSH_SERVER_PID")
+	defer os.Unsetenv("LD_PRELOAD")
+	defer os.Unsetenv("AGENTSH_SERVER_PID")
+
+	var buf bytes.Buffer
+	origOut := log.Default().Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(origOut)
+
+	setupPtracerPreload(123, false)
+
+	assert.NotContains(t, buf.String(), "ptracer:", "must not log ptracer warning when Yama is inactive")
+	assert.Empty(t, os.Getenv("LD_PRELOAD"), "must not modify LD_PRELOAD when Yama is inactive")
+}
+
+// TestSetupPtracerPreload_YamaActive_LogsWhenLibMissing asserts that when
+// Yama IS active and the .so is not discoverable, the warning still fires —
+// in that case the message is actionable (children may fail under Yama).
+func TestSetupPtracerPreload_YamaActive_LogsWhenLibMissing(t *testing.T) {
+	self, err := os.Executable()
+	require.NoError(t, err)
+	soPath := filepath.Join(filepath.Dir(self), ptracerLibName)
+	_ = os.Remove(soPath)
+
+	// Force findPtracerLib to return "" by also stubbing the system path lookup
+	// via a test that runs in environments where /usr/lib/agentsh/ does not
+	// contain the .so. If it does, skip — we can't reliably assert "not found".
+	if _, statErr := os.Stat(filepath.Join("/usr/lib/agentsh", ptracerLibName)); statErr == nil {
+		t.Skip("/usr/lib/agentsh ptracer lib present; cannot assert not-found path")
+	}
+
+	os.Unsetenv("LD_PRELOAD")
+	os.Unsetenv("AGENTSH_SERVER_PID")
+	defer os.Unsetenv("LD_PRELOAD")
+	defer os.Unsetenv("AGENTSH_SERVER_PID")
+
+	var buf bytes.Buffer
+	origOut := log.Default().Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(origOut)
+
+	setupPtracerPreload(123, true)
+
+	assert.Contains(t, buf.String(), "ptracer:", "must log ptracer warning when Yama is active and lib is missing")
 }
 
 func TestFindPtracerLib_NextToBinary(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #281.

`agentsh-unixwrap` emitted two informational logs on every wrapper invocation that downstream JSON consumers (e.g. `agentsh detect --output json` via `@agentsh/secure-sandbox`) saw mixed into their captured streams:

- `"yama: not active, skipping PR_SET_PTRACER (standard DAC governs ptrace)"` — pure success-path noise; absence of an error is sufficient signal.
- `"ptracer: libagentsh-ptracer.so not found, child ProcessVMReadv may fail under Yama"` — fired even on non-Yama kernels where the library is irrelevant (PR_SET_PTRACER is a no-op without Yama and ProcessVMReadv falls back to standard Unix DAC).

v0.19.0 → v0.19.1 surfaced this far more often: PR #274 added the shim's kernel-install path, which now invokes `agentsh-unixwrap` for many shell invocations that previously didn't trigger it.

### Fix

- Compute `yamaActive` once at the top of `main` (no double-stat of the sysctl path).
- Drop the success-path "yama: not active" log entirely.
- Pass `yamaActive` to `setupPtracerPreload`; it returns silently when Yama is inactive, so the "ptracer: not found" warning only fires when actionable (Yama active **and** lib missing).

## Test plan

- [x] `go test ./cmd/agentsh-unixwrap/` — all unixwrap tests pass, including new `TestSetupPtracerPreload_YamaInactive_NoLog` and `TestSetupPtracerPreload_YamaActive_LogsWhenLibMissing`.
- [x] `go test ./cmd/... ./internal/api/ ./internal/capabilities/ ./internal/shim/...` — adjacent suites pass.
- [x] `go build ./...` and `GOOS=windows go build ./...` clean.
- [x] Roborev review passed clean (job 7959).

🤖 Generated with [Claude Code](https://claude.com/claude-code)