### PR TITLE
fix(seccomp): surface raw kernel errno + gate WaitKill retry on EINVAL (#282)

### DIFF
--- a/internal/netmonitor/unix/seccomp_linux.go
+++ b/internal/netmonitor/unix/seccomp_linux.go
@@ -260,6 +260,19 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 		return nil, err
 	}
 
+	// Surface raw kernel errnos from filt.Load() instead of letting
+	// libseccomp mask every failure as ECANCELED. Without this, a kernel
+	// rejection (EINVAL for unknown flags, EBUSY for listener conflicts,
+	// EPERM/EACCES for missing privileges, ...) is indistinguishable from
+	// any other "system failure beyond the control of the library" — which
+	// is exactly the diagnostic dead-end hit on Runloop devboxes in #282.
+	// Best-effort: if libseccomp is too old (<2.5) we continue without
+	// raw errnos and rely on the masked ECANCELED.
+	if rcErr := filt.SetRawRC(true); rcErr != nil {
+		slog.Debug("seccomp: SetRawRC unsupported; kernel errnos will be masked as ECANCELED",
+			"error", rcErr)
+	}
+
 	// Enable SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV (kernel 6.0+).
 	// When active, non-fatal signals (including Go's ~10ms SIGURG preemption)
 	// cannot interrupt seccomp_do_user_notification, preventing ERESTARTSYS loops.
@@ -480,9 +493,19 @@ func familyToScmpAction(a seccompkg.OnBlockAction) (seccomp.ScmpAction, error) {
 }
 
 // loadWithRetryOnWaitKillFailure loads a seccomp filter and, if the load
-// fails with WaitKill set, clears WaitKill and retries once. This handles
-// custom or vendor kernels that report 6.0+ but reject
-// SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV at filter load time.
+// fails with WaitKill set AND the underlying errno is EINVAL, clears
+// WaitKill and retries once. This handles custom or vendor kernels that
+// report 6.0+ but reject SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV at filter
+// load time — the kernel returns EINVAL from the flag-mask check in
+// seccomp_set_mode_filter when an unknown flag is set.
+//
+// For any other errno (EBUSY, EPERM, EACCES, ENOMEM, ...) the failure is
+// unrelated to WaitKill, so we surface the original error verbatim
+// instead of emitting a misleading "WaitKillable rejected" warning and
+// wasting a retry that will fail with the same kernel reason. This
+// requires SetRawRC(true) on the filter so libseccomp does not mask the
+// underlying errno as ECANCELED — InstallFilterWithConfig sets that
+// flag.
 //
 // loadFn is injected so tests can simulate Load() failures deterministically.
 // Production call sites pass `filt.Load`.
@@ -492,6 +515,9 @@ func loadWithRetryOnWaitKillFailure(filt *seccomp.ScmpFilter, waitKillSet bool, 
 		return nil
 	}
 	if !waitKillSet {
+		return err
+	}
+	if !errors.Is(err, unix.EINVAL) {
 		return err
 	}
 	slog.Warn("seccomp: WaitKillable rejected at filter load time; falling back to SIGURG signal mask only",

--- a/internal/netmonitor/unix/seccomp_retry_test.go
+++ b/internal/netmonitor/unix/seccomp_retry_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 
 	seccomp "github.com/seccomp/libseccomp-golang"
+	"golang.org/x/sys/unix"
 )
 
 // TestLoadWithRetryOnWaitKillFailure_RetriesOnWaitKillFailure verifies that
-// when the first Load() call fails with WaitKill set, the helper calls
+// when the first Load() call fails with EINVAL (the kernel's response to
+// an unknown filter flag) and WaitKill set, the helper calls
 // SetWaitKill(false) and retries — reproducing the fallback path used for
 // custom kernels that report >=6.0 but reject WAIT_KILLABLE_RECV.
 func TestLoadWithRetryOnWaitKillFailure_RetriesOnWaitKillFailure(t *testing.T) {
@@ -28,7 +30,7 @@ func TestLoadWithRetryOnWaitKillFailure_RetriesOnWaitKillFailure(t *testing.T) {
 	loadFn := func() error {
 		calls++
 		if calls == 1 {
-			return errors.New("simulated: kernel rejected WAIT_KILLABLE_RECV")
+			return unix.EINVAL
 		}
 		return nil
 	}
@@ -72,6 +74,52 @@ func TestLoadWithRetryOnWaitKillFailure_NoRetryWhenWaitKillNotSet(t *testing.T) 
 	}
 	if calls != 1 {
 		t.Fatalf("expected 1 load call, got %d", calls)
+	}
+}
+
+// TestLoadWithRetryOnWaitKillFailure_NoRetryOnNonEINVAL verifies that when
+// the first load fails with an errno other than EINVAL — i.e., the failure
+// is unrelated to WAIT_KILLABLE_RECV being unsupported — the helper does
+// not retry and does not clear WaitKill. The original error is propagated
+// verbatim so callers can see the real kernel reason. EINVAL is the only
+// errno the kernel returns when it rejects the WAIT_KILLABLE_RECV flag at
+// load time (the flag-mask validation in seccomp_set_mode_filter), so any
+// other errno indicates a different problem (e.g., EBUSY from listener
+// conflicts, EPERM from missing NO_NEW_PRIVS, ENOMEM, EACCES, ...).
+// Without this gate the helper silently misattributes those failures to
+// WaitKill in its slog.Warn line and wastes a retry that will fail with
+// the same errno — exactly the symptom of issue #282 on Runloop devboxes.
+func TestLoadWithRetryOnWaitKillFailure_NoRetryOnNonEINVAL(t *testing.T) {
+	filt, err := seccomp.NewFilter(seccomp.ActAllow)
+	if err != nil {
+		t.Fatalf("NewFilter: %v", err)
+	}
+	defer filt.Release()
+
+	if err := filt.SetWaitKill(true); err != nil {
+		t.Skipf("SetWaitKill unsupported on this libseccomp build: %v", err)
+	}
+
+	calls := 0
+	loadFn := func() error {
+		calls++
+		return unix.EBUSY
+	}
+
+	err = loadWithRetryOnWaitKillFailure(filt, true, loadFn)
+	if !errors.Is(err, unix.EBUSY) {
+		t.Fatalf("expected EBUSY to propagate, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 load call (no retry on non-EINVAL), got %d", calls)
+	}
+
+	got, err := filt.GetWaitKill()
+	if err != nil {
+		t.Fatalf("GetWaitKill: %v", err)
+	}
+	if !got {
+		t.Fatalf("expected WaitKill to remain true on non-EINVAL failure, got false")
 	}
 }
 


### PR DESCRIPTION
## Summary

Diagnostic-first patch for #282 — seccomp filter install fails with `operation canceled` on Runloop devboxes in v0.19.1, with a misleading `WaitKillable rejected at filter load time` warning preceding it.

- `InstallFilterWithConfig` now calls `filt.SetRawRC(true)` so libseccomp surfaces the actual kernel errno from `seccomp(2)` instead of masking every failure as `ECANCELED`. Best-effort: on libseccomp <2.5 we log debug and keep the masked behaviour.
- `loadWithRetryOnWaitKillFailure` now only logs the WaitKill warning and retries when the underlying errno is `EINVAL` (the kernel's response to an unknown filter flag — the only errno that can come from the `WAIT_KILLABLE_RECV` flag-mask rejection). Other errnos propagate verbatim, so we stop misattributing unrelated failures to WaitKill and stop wasting a retry that fails with the same errno.

## Why this is "diagnostic-first" rather than a structural fix

The current code masks the real kernel reason twice: once by libseccomp (default `ECANCELED`) and once by the WaitKill-specific warning + retry path. From the user report we know both load attempts return `ECANCELED`, so the failure cannot actually be `WAIT_KILLABLE_RECV` — but the underlying errno is hidden. With this change the next Runloop run will print something like `install seccomp filter: device or resource busy` (or whatever the real cause is) and we can write the actual fix in a follow-up PR.

## Test plan

- [x] `go test ./internal/netmonitor/... ./internal/seccomp/... ./cmd/agentsh-unixwrap/...`
- [x] `go build ./...`, `GOOS=windows go build ./...`, `GOOS=darwin go build ./...`
- [x] New unit test `TestLoadWithRetryOnWaitKillFailure_NoRetryOnNonEINVAL` confirms an EBUSY first-load is propagated without retry and without clearing WaitKill
- [x] Updated `TestLoadWithRetryOnWaitKillFailure_RetriesOnWaitKillFailure` to inject the realistic `unix.EINVAL` errno
- [ ] Cut RC build, run on a Runloop devbox, capture the new error message in #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)