### PR TITLE
fix(cli): route detect output to stdout; diag: structured seccomp install logs (#281, #282)

### DIFF
--- a/internal/cli/detect.go
+++ b/internal/cli/detect.go
@@ -43,7 +43,12 @@ Use 'agentsh detect config' to generate an optimized configuration.`,
 				return fmt.Errorf("format output: %w", err)
 			}
 
-			cmd.Println(string(output))
+			// Route the formatted document to stdout, not stderr — callers
+			// pipe `agentsh detect --output json | jq` and expect the
+			// document on stdout. cobra's cmd.Println uses OutOrStderr
+			// (defaults to os.Stderr), which broke that contract for #281
+			// on v0.19.2-rc1 (stdout empty, JSON on stderr).
+			fmt.Fprintln(cmd.OutOrStdout(), string(output))
 			return nil
 		},
 	}
@@ -84,11 +89,15 @@ Example:
 				if err := os.WriteFile(outputPath, config, 0644); err != nil {
 					return fmt.Errorf("write config to %s: %w", outputPath, err)
 				}
-				cmd.Printf("Configuration written to %s\n", outputPath)
+				fmt.Fprintf(cmd.OutOrStdout(), "Configuration written to %s\n", outputPath)
 				return nil
 			}
 
-			cmd.Print(string(config))
+			// Same routing fix as the parent detect command — when the
+			// generated config goes to stdout (no --output file), it must
+			// land on os.Stdout so `agentsh detect config > security.yaml`
+			// works as documented.
+			fmt.Fprint(cmd.OutOrStdout(), string(config))
 			return nil
 		},
 	}

--- a/internal/cli/detect_test.go
+++ b/internal/cli/detect_test.go
@@ -2,7 +2,10 @@ package cli
 
 import (
 	"bytes"
+	"io"
+	"os"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -84,5 +87,113 @@ func TestDetectConfigCmd(t *testing.T) {
 	}
 	if !strings.Contains(output, "security:") {
 		t.Error("config output missing security section")
+	}
+}
+
+// captureStdStreams runs fn with os.Stdout and os.Stderr redirected to
+// pipes, returning whatever was written to each stream. Use this when a
+// test must verify which actual standard stream a command wrote to —
+// cobra's SetOut/SetErr both feed cmd.Print*/Println via the same
+// outWriter, so they cannot distinguish the two streams (existing tests
+// in this file merge them deliberately).
+func captureStdStreams(t *testing.T, fn func()) (stdout, stderr string) {
+	t.Helper()
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe stdout: %v", err)
+	}
+	rErr, wErr, err := os.Pipe()
+	if err != nil {
+		_ = rOut.Close()
+		_ = wOut.Close()
+		t.Fatalf("os.Pipe stderr: %v", err)
+	}
+	origStdout, origStderr := os.Stdout, os.Stderr
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	var outBuf, errBuf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); _, _ = io.Copy(&outBuf, rOut) }()
+	go func() { defer wg.Done(); _, _ = io.Copy(&errBuf, rErr) }()
+
+	defer func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+	fn()
+	_ = wOut.Close()
+	_ = wErr.Close()
+	wg.Wait()
+	return outBuf.String(), errBuf.String()
+}
+
+// TestDetectCmd_JSON_GoesToStdout verifies that with --output json, the
+// JSON document is written to the actual os.Stdout, NOT os.Stderr —
+// machine-parseable output must be on stdout so callers can pipe it into
+// JSON.parse / jq without merging streams. cobra's cmd.Print*/Println
+// route to OutOrStderr by default; without an explicit cmd.SetOut to
+// os.Stdout (or use of OutOrStdout) the JSON ends up on stderr — exactly
+// the symptom reported in #281 against v0.19.2-rc1 (stdout empty,
+// JSON on stderr).
+func TestDetectCmd_JSON_GoesToStdout(t *testing.T) {
+	stdout, stderr := captureStdStreams(t, func() {
+		cmd := newDetectCmd()
+		cmd.SetArgs([]string{"--output", "json"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute(): %v", err)
+		}
+	})
+
+	if !strings.HasPrefix(stdout, "{") {
+		t.Errorf("expected JSON on stdout, got\nstdout=%q\nstderr=%q", stdout, stderr)
+	}
+	if !strings.Contains(stdout, `"platform"`) {
+		t.Errorf("stdout missing platform field; stdout=%q", stdout)
+	}
+	if strings.Contains(stderr, `"platform"`) {
+		t.Errorf("JSON document must NOT be on stderr; stderr=%q", stderr)
+	}
+}
+
+// TestDetectCmd_YAML_GoesToStdout is the YAML counterpart of
+// TestDetectCmd_JSON_GoesToStdout — same routing requirement: the YAML
+// document goes to stdout, never stderr.
+func TestDetectCmd_YAML_GoesToStdout(t *testing.T) {
+	stdout, stderr := captureStdStreams(t, func() {
+		cmd := newDetectCmd()
+		cmd.SetArgs([]string{"--output", "yaml"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute(): %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, "platform:") {
+		t.Errorf("expected YAML on stdout, got\nstdout=%q\nstderr=%q", stdout, stderr)
+	}
+	if strings.Contains(stderr, "platform:") {
+		t.Errorf("YAML document must NOT be on stderr; stderr=%q", stderr)
+	}
+}
+
+// TestDetectConfigCmd_StdoutDefault verifies that `agentsh detect config`
+// without an --output file path writes the generated config to stdout
+// (so `agentsh detect config > security.yaml` works as documented in the
+// command's Long help). Same #281 routing: data on stdout, never stderr.
+func TestDetectConfigCmd_StdoutDefault(t *testing.T) {
+	stdout, stderr := captureStdStreams(t, func() {
+		cmd := newDetectCmd()
+		cmd.SetArgs([]string{"config"})
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute(): %v", err)
+		}
+	})
+
+	if !strings.Contains(stdout, "security:") {
+		t.Errorf("expected config on stdout, got\nstdout=%q\nstderr=%q", stdout, stderr)
+	}
+	if strings.Contains(stderr, "security:") {
+		t.Errorf("config document must NOT be on stderr; stderr=%q", stderr)
 	}
 }

--- a/internal/netmonitor/unix/seccomp_linux.go
+++ b/internal/netmonitor/unix/seccomp_linux.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 	"unsafe"
 
 	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
@@ -273,6 +274,14 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 			"error", rcErr)
 	}
 
+	// Per-category rule counts surfaced in the pre-load diagnostic
+	// snapshot below. Useful when narrowing down which feature triggers a
+	// kernel rejection on hostile devbox kernels (issue #282 EFAULT) — a
+	// single "install seccomp filter: bad address" line is far less
+	// actionable than "filter had N rules across these categories with
+	// these flags."
+	ruleCounts := map[string]int{}
+
 	// Enable SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV (kernel 6.0+).
 	// When active, non-fatal signals (including Go's ~10ms SIGURG preemption)
 	// cannot interrupt seccomp_do_user_notification, preventing ERESTARTSYS loops.
@@ -308,6 +317,7 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 				return nil, fmt.Errorf("add notify rule %v: %w", sc, err)
 			}
 		}
+		ruleCounts["unix_socket"] = len(rules)
 	}
 
 	// Execve interception via user-notify
@@ -322,6 +332,7 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 				return nil, fmt.Errorf("add execve rule %v: %w", sc, err)
 			}
 		}
+		ruleCounts["execve"] = len(execRules)
 	}
 
 	// File I/O monitoring via user-notify
@@ -343,11 +354,13 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 				return nil, fmt.Errorf("add file monitor rule %v: %w", sc, err)
 			}
 		}
-		for _, sc := range legacyFileSyscallList() {
+		legacy := legacyFileSyscallList()
+		for _, sc := range legacy {
 			if err := filt.AddRule(seccomp.ScmpSyscall(sc), trap); err != nil {
 				return nil, fmt.Errorf("add legacy file rule %v: %w", sc, err)
 			}
 		}
+		ruleCounts["file_monitor"] = len(fileRules) + len(legacy)
 	}
 
 	// Metadata syscalls via user-notify (when intercept_metadata is enabled)
@@ -364,6 +377,7 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 				return nil, fmt.Errorf("add metadata rule %v: %w", sc, err)
 			}
 		}
+		ruleCounts["metadata"] = len(metadataRules)
 	}
 
 	// mknodat is always included with file monitoring (create-category)
@@ -407,11 +421,13 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 			blockListMap[uint32(nr)] = action
 		}
 	}
+	ruleCounts["blocked_syscalls"] = len(cfg.BlockedSyscalls)
 
 	// Per-socket-family blocking on socket(2) and socketpair(2).
 	// libseccomp action-precedence (KILL > TRAP > ERRNO > … > NOTIFY) ensures
 	// these conditional rules take priority over the unconditional ActNotify
 	// rule on socket(2) added by UnixSocketEnabled.
+	familyRulesAdded := 0
 	for _, bf := range cfg.BlockedFamilies {
 		cond := seccomp.ScmpCondition{
 			Argument: 0,
@@ -432,6 +448,8 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 				slog.Warn("seccomp: failed to add family rule; family skipped",
 					"family", bf.Name, "syscall", sc, "error", addErr)
 				installed = false
+			} else {
+				familyRulesAdded++
 			}
 		}
 		if installed && (bf.Action == seccompkg.OnBlockLog || bf.Action == seccompkg.OnBlockLogAndKill) {
@@ -439,6 +457,7 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 			blockedFamilyMap[uint64(unix.SYS_SOCKETPAIR)<<32|uint64(bf.Family)] = bf
 		}
 	}
+	ruleCounts["blocked_families"] = familyRulesAdded
 
 	// Block io_uring to prevent seccomp bypass.
 	// Skip syscalls already in BlockedSyscalls to avoid duplicate rule errors.
@@ -453,6 +472,7 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 			unix.SYS_IO_URING_ENTER,
 			unix.SYS_IO_URING_REGISTER,
 		}
+		ioUringRulesAdded := 0
 		for _, nr := range ioUringSyscalls {
 			if blockedSet[nr] {
 				continue // already blocked via BlockedSyscalls
@@ -460,8 +480,19 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 			if err := filt.AddRule(seccomp.ScmpSyscall(nr), ioUringBlock); err != nil {
 				return nil, fmt.Errorf("add io_uring block rule %v: %w", nr, err)
 			}
+			ioUringRulesAdded++
 		}
+		ruleCounts["io_uring_block"] = ioUringRulesAdded
 	}
+
+	// Pre-load diagnostic snapshot. Logged at INFO so it lands in the
+	// wrapper's stderr/log capture even when slog level is Info-default.
+	// On hostile devbox kernels (#282 EFAULT on Runloop+Freestyle) a bare
+	// "install seccomp filter: bad address" tells us nothing about which
+	// rules or flags the kernel rejected — this snapshot lets the next
+	// reproduction pinpoint the exact filter shape that triggered the
+	// rejection without requiring strace/sysdig on the affected VM.
+	logFilterSnapshot(filt, cfg, waitKillSet, ruleCounts)
 
 	if err := loadWithRetryOnWaitKillFailure(filt, waitKillSet, filt.Load); err != nil {
 		return nil, err
@@ -507,13 +538,25 @@ func familyToScmpAction(a seccompkg.OnBlockAction) (seccomp.ScmpAction, error) {
 // underlying errno as ECANCELED — InstallFilterWithConfig sets that
 // flag.
 //
+// Each Load() attempt is logged with timing and the resulting errno so a
+// hostile-kernel rejection (issue #282 EFAULT on Runloop+Freestyle) lands
+// in the wrapper's stderr capture with enough detail to point at the
+// failing flag combination.
+//
 // loadFn is injected so tests can simulate Load() failures deterministically.
 // Production call sites pass `filt.Load`.
 func loadWithRetryOnWaitKillFailure(filt *seccomp.ScmpFilter, waitKillSet bool, loadFn func() error) error {
+	start := time.Now()
 	err := loadFn()
+	dur := time.Since(start)
 	if err == nil {
+		slog.Info("seccomp: filter Load succeeded",
+			"attempt", 1, "wait_kill", waitKillSet, "duration_ms", dur.Milliseconds())
 		return nil
 	}
+	slog.Warn("seccomp: filter Load failed",
+		"attempt", 1, "wait_kill", waitKillSet, "duration_ms", dur.Milliseconds(),
+		"errno", errnoString(err), "error", err)
 	if !waitKillSet {
 		return err
 	}
@@ -523,7 +566,121 @@ func loadWithRetryOnWaitKillFailure(filt *seccomp.ScmpFilter, waitKillSet bool, 
 	slog.Warn("seccomp: WaitKillable rejected at filter load time; falling back to SIGURG signal mask only",
 		"error", err)
 	if clearErr := filt.SetWaitKill(false); clearErr != nil {
+		slog.Warn("seccomp: SetWaitKill(false) failed; cannot retry without WaitKill",
+			"error", clearErr)
 		return err
 	}
-	return loadFn()
+	start = time.Now()
+	err = loadFn()
+	dur = time.Since(start)
+	if err == nil {
+		slog.Info("seccomp: filter Load succeeded on retry without WaitKill",
+			"attempt", 2, "duration_ms", dur.Milliseconds())
+		return nil
+	}
+	slog.Warn("seccomp: filter Load failed on retry without WaitKill",
+		"attempt", 2, "duration_ms", dur.Milliseconds(),
+		"errno", errnoString(err), "error", err)
+	return err
+}
+
+// errnoString returns a short stable string identifying the errno class
+// of err (e.g., "EFAULT", "EINVAL"), or "non-errno" if err is not a
+// syscall.Errno. Used in structured log fields so log scrapers and
+// engineers can search on the symbolic name rather than the localized
+// "bad address" message.
+func errnoString(err error) string {
+	var en unix.Errno
+	if !errors.As(err, &en) {
+		return "non-errno"
+	}
+	switch en {
+	case unix.EINVAL:
+		return "EINVAL"
+	case unix.EFAULT:
+		return "EFAULT"
+	case unix.EBUSY:
+		return "EBUSY"
+	case unix.EPERM:
+		return "EPERM"
+	case unix.EACCES:
+		return "EACCES"
+	case unix.ENOMEM:
+		return "ENOMEM"
+	case unix.ENOSYS:
+		return "ENOSYS"
+	case unix.ECANCELED:
+		return "ECANCELED"
+	case unix.ESRCH:
+		return "ESRCH"
+	}
+	return fmt.Sprintf("errno=%d", int(en))
+}
+
+// logFilterSnapshot emits an INFO-level structured snapshot of the
+// filter context just before Load() is invoked. Captures libseccomp
+// version + API level, kernel release, the rule-count breakdown by
+// category, and the set of flags about to be applied to the seccomp(2)
+// syscall. On the next devbox reproduction (issue #282 EFAULT) this
+// makes it possible to identify whether the rejection correlates with a
+// specific feature category, the WaitKill flag, libseccomp version, or
+// kernel release — without rebuilding with strace or asking the user
+// for further data collection.
+func logFilterSnapshot(filt *seccomp.ScmpFilter, cfg FilterConfig, waitKillSet bool, ruleCounts map[string]int) {
+	libMaj, libMin, libMicro := seccomp.GetLibraryVersion()
+	libVer := fmt.Sprintf("%d.%d.%d", libMaj, libMin, libMicro)
+
+	apiLevel, apiErr := seccomp.GetAPI()
+	apiStr := fmt.Sprintf("%d", apiLevel)
+	if apiErr != nil {
+		apiStr = "unavailable"
+	}
+
+	var kernel string
+	var utsname unix.Utsname
+	if err := unix.Uname(&utsname); err == nil {
+		kernel = unix.ByteSliceToString(utsname.Release[:])
+	}
+
+	// libseccomp-golang sets SCMP_FLTATR_CTL_TSYNC = 1 in NewFilter() with
+	// no exported getter; it is enabled when the kernel supports it. We
+	// surface "default(NewFilter)" to make it explicit in the snapshot
+	// rather than implying it was independently chosen.
+	tsync := "default(NewFilter)"
+	nnp := "unknown"
+	if v, err := filt.GetNoNewPrivsBit(); err == nil {
+		nnp = fmt.Sprintf("%t", v)
+	}
+	rawRC := "unknown"
+	if v, err := filt.GetRawRC(); err == nil {
+		rawRC = fmt.Sprintf("%t", v)
+	}
+
+	total := 0
+	for _, n := range ruleCounts {
+		total += n
+	}
+
+	slog.Info("seccomp: filter snapshot before Load",
+		"libseccomp_version", libVer,
+		"libseccomp_api", apiStr,
+		"kernel_release", kernel,
+		"attr_tsync", tsync,
+		"attr_no_new_privs", nnp,
+		"attr_raw_rc", rawRC,
+		"attr_wait_killable_recv", waitKillSet,
+		"rules_total", total,
+		"rules_unix_socket", ruleCounts["unix_socket"],
+		"rules_execve", ruleCounts["execve"],
+		"rules_file_monitor", ruleCounts["file_monitor"],
+		"rules_metadata", ruleCounts["metadata"],
+		"rules_blocked_syscalls", ruleCounts["blocked_syscalls"],
+		"rules_blocked_families", ruleCounts["blocked_families"],
+		"rules_io_uring_block", ruleCounts["io_uring_block"],
+		"cfg_unix_socket_enabled", cfg.UnixSocketEnabled,
+		"cfg_execve_enabled", cfg.ExecveEnabled,
+		"cfg_file_monitor_enabled", cfg.FileMonitorEnabled,
+		"cfg_intercept_metadata", cfg.InterceptMetadata,
+		"cfg_block_io_uring", cfg.BlockIOUring,
+	)
 }


### PR DESCRIPTION
Two fixes confirmed against v0.19.2-rc1 user reports.

## #281 — `agentsh detect` JSON/YAML output goes to stderr

User confirmed on Freestyle (binary `agentsh 0.19.2-rc1+9360228`):

```
$ agentsh detect --output json
exit=0
stdout=""
stderr="{ "platform": "linux", ... }"
```

Cause: `internal/cli/detect.go` used `cmd.Println(string(output))`. cobra's `cmd.Println` routes through `OutOrStderr` which defaults to `os.Stderr`, and `NewRoot` never calls `cmd.SetOut(os.Stdout)`. So the parseable document landed on stderr with empty stdout — `JSON.parse(stdout)` fails on empty input. The same bug also affects YAML and the `detect config` stdout path (documented `agentsh detect config > security.yaml`).

Fix: switch to `fmt.Fprintln(cmd.OutOrStdout(), ...)` (and `fmt.Fprint` for the no-newline `detect config` path). Falls back to `os.Stdout` when no SetOut is configured, while still respecting `cmd.SetOut(buf)` for tests.

Three new tests use `os.Pipe()` to redirect the real `os.Stdout`/`os.Stderr` (the existing tests merged both streams into one buffer via `SetOut`/`SetErr`, so they couldn't distinguish them and missed the regression). All three were RED before the fix and GREEN after. Verified end-to-end with `agentsh detect --output json`: 4225-byte JSON on stdout, empty stderr, exit 0.

## #282 — diagnostic logging around seccomp filter install

User confirmed on Runloop and Freestyle (same rc1 binary): `install seccomp filter: bad address` (= `EFAULT`). The rc1 SetRawRC change is doing its job (we now see the actual kernel errno instead of masked `ECANCELED`), but a single line doesn't tell us which feature triggered the kernel rejection.

Add structured logging:
- INFO snapshot right before `filt.Load()` recording libseccomp version + API level, kernel release, attribute states (NNP, raw_rc, wait_killable_recv, and a note that TSYNC is libseccomp's NewFilter default — no exported getter), and per-category rule counts (`unix_socket`, `execve`, `file_monitor`, `metadata`, `blocked_syscalls`, `blocked_families`, `io_uring_block`) plus the originating cfg flags.
- Per-`Load()`-attempt INFO/WARN with timing and an `errno` class field (`EFAULT`, `EINVAL`, `EBUSY`, `EPERM`, `EACCES`, `ENOMEM`, `ENOSYS`, `ECANCELED`, `ESRCH`, or `errno=N`).

When the next user reruns the failing wrapped exec on Runloop/Freestyle, the wrapper's stderr will tell us:
- libseccomp version + kernel version where the rejection happens
- exact rule-count breakdown of the filter that got rejected
- whether NNP was already set
- which Load attempt failed (first / WaitKill-fallback retry) and how long it took

That's enough to localize whether EFAULT is correlated with a specific feature category, the WaitKill flag, or the kernel/libseccomp combo on those VMs — without rebuilding with strace or asking the user for more data collection.

## Test plan

- [x] `go test ./internal/netmonitor/... ./internal/seccomp/... ./internal/cli/... ./cmd/...` (all green, including ~42s of cmd/agentsh-shell-shim integration tests)
- [x] `go build ./...`, `GOOS=windows go build ./...`, `GOOS=darwin go build ./...`
- [x] Three new TDD tests for the detect stream routing — were RED before the fix and GREEN after.
- [x] Hand-verified `/tmp/agentsh-bin detect --output json`: stdout 4225 bytes JSON, stderr empty, exit 0.
- [ ] Cut RC, capture the new diagnostic log on Runloop/Freestyle to identify the EFAULT trigger.

Plan after merge: delete the existing v0.19.2-rc1 GitHub release and tag, then retag v0.19.2-rc1 on the new main commit so the user can rerun on the same RC name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)