### PR TITLE
diag(seccomp): log caller's /proc/self/status seccomp state + parent comm (#282)

### DIFF
--- a/internal/netmonitor/unix/seccomp_linux.go
+++ b/internal/netmonitor/unix/seccomp_linux.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"time"
 	"unsafe"
 
@@ -661,10 +662,34 @@ func logFilterSnapshot(filt *seccomp.ScmpFilter, cfg FilterConfig, waitKillSet b
 		total += n
 	}
 
+	// Pre-install caller seccomp state — the key signal for the #282
+	// stacked-install hypothesis. If this snapshot fires from a process
+	// that already has Seccomp:2 + FilterCount>=1 inherited via execve,
+	// the kernel may reject the about-to-happen Load() with EFAULT (or
+	// the documented EBUSY) because we're stacking another USER_NOTIF
+	// filter on top. Distinguishing the FIRST install (clean state) from
+	// a NESTED install (state already set) is exactly what tells us
+	// whether the failing rc1 reproduction is a stacking issue or a
+	// kernel quirk in the filter content itself.
+	procState := readSelfSeccompState()
+	procStateStr := "unreadable"
+	if procState.Present {
+		procStateStr = fmt.Sprintf("mode=%d filter_count=%d", procState.Mode, procState.FilterCount)
+	}
+	pid := os.Getpid()
+	ppid := os.Getppid()
+	parentComm := readProcComm(ppid)
+	selfComm := readProcComm(pid)
+
 	slog.Info("seccomp: filter snapshot before Load",
 		"libseccomp_version", libVer,
 		"libseccomp_api", apiStr,
 		"kernel_release", kernel,
+		"self_pid", pid,
+		"self_comm", selfComm,
+		"parent_pid", ppid,
+		"parent_comm", parentComm,
+		"caller_seccomp_state", procStateStr,
 		"attr_tsync", tsync,
 		"attr_no_new_privs", nnp,
 		"attr_raw_rc", rawRC,

--- a/internal/netmonitor/unix/seccomp_proc_state_linux.go
+++ b/internal/netmonitor/unix/seccomp_proc_state_linux.go
@@ -1,0 +1,92 @@
+//go:build linux && cgo
+
+package unix
+
+import (
+	"bytes"
+	"os"
+	"strconv"
+)
+
+// procSelfSeccompState is what readSelfSeccompState surfaces about the
+// calling process's seccomp state, parsed from /proc/self/status.
+// Used by the filter-install snapshot to distinguish a clean install
+// from one running on top of an inherited filter (issue #282 stacked-
+// install hypothesis on Runloop / Freestyle: parent unixwrap installs
+// F1, then a nested unixwrap inherits it via execve and the kernel
+// rejects F2 with EFAULT).
+type procSelfSeccompState struct {
+	// Mode is the SECCOMP_MODE_* value from `Seccomp:` (0 = disabled,
+	// 1 = strict, 2 = filter). Zero when Present is false.
+	Mode int
+	// FilterCount is the chain length from `Seccomp_filters:` (added in
+	// kernel 4.10). Zero when the field is absent or Present is false.
+	FilterCount int
+	// Present is true when the Seccomp line was found in input. Lets
+	// callers distinguish "kernel reported mode 0" from "kernel did not
+	// report" (older kernels, /proc disabled, etc.).
+	Present bool
+}
+
+// parseProcSelfSeccompState parses /proc/self/status content, extracting
+// the Seccomp: and Seccomp_filters: fields. Tab-separated, one field per
+// line. Tolerant of missing fields and unrelated lines.
+func parseProcSelfSeccompState(status []byte) procSelfSeccompState {
+	var out procSelfSeccompState
+	for _, line := range bytes.Split(status, []byte{'\n'}) {
+		switch {
+		case bytes.HasPrefix(line, []byte("Seccomp:")):
+			if v, ok := parseProcStatusInt(line); ok {
+				out.Mode = v
+				out.Present = true
+			}
+		case bytes.HasPrefix(line, []byte("Seccomp_filters:")):
+			if v, ok := parseProcStatusInt(line); ok {
+				out.FilterCount = v
+			}
+		}
+	}
+	return out
+}
+
+// parseProcStatusInt extracts the integer value from a `Key:\t<value>`
+// /proc/[pid]/status line. Returns (0, false) on any parse failure.
+func parseProcStatusInt(line []byte) (int, bool) {
+	colon := bytes.IndexByte(line, ':')
+	if colon < 0 {
+		return 0, false
+	}
+	rest := bytes.TrimSpace(line[colon+1:])
+	if len(rest) == 0 {
+		return 0, false
+	}
+	v, err := strconv.Atoi(string(rest))
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// readSelfSeccompState reads /proc/self/status and returns the parsed
+// seccomp state. Returns the zero value (Present=false) if the file
+// cannot be read — never errors, since this is a best-effort
+// diagnostic and the caller logs whatever it gets.
+func readSelfSeccompState() procSelfSeccompState {
+	data, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return procSelfSeccompState{}
+	}
+	return parseProcSelfSeccompState(data)
+}
+
+// readProcComm returns the command name from /proc/<pid>/comm, trimmed
+// of trailing newline. Returns "" on any error so callers can log
+// "comm=" for unreadable parents (kernel-thread, exited, restricted
+// proc, etc.) without special-casing.
+func readProcComm(pid int) string {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/comm")
+	if err != nil {
+		return ""
+	}
+	return string(bytes.TrimSpace(data))
+}

--- a/internal/netmonitor/unix/seccomp_proc_state_test.go
+++ b/internal/netmonitor/unix/seccomp_proc_state_test.go
@@ -1,0 +1,98 @@
+//go:build linux && cgo
+
+package unix
+
+import "testing"
+
+// TestParseProcSelfSeccompState_FilterModeWithCount covers the case the
+// rc1 #282 diagnostic is meant to confirm: a process running unixwrap
+// that has *already* inherited a seccomp filter from its parent. Mode 2
+// = SECCOMP_MODE_FILTER, Seccomp_filters > 0 means at least one filter
+// chain entry is in place. If the next failing snapshot on Runloop
+// shows this state before Load() runs, the EFAULT is confirmed to be
+// stacked-install rejection rather than a kernel quirk in F2's content.
+func TestParseProcSelfSeccompState_FilterModeWithCount(t *testing.T) {
+	const status = `Name:	agentsh-unixwra
+Tgid:	123
+Pid:	123
+PPid:	100
+Seccomp:	2
+Seccomp_filters:	3
+Speculation_Store_Bypass:	thread vulnerable
+`
+	got := parseProcSelfSeccompState([]byte(status))
+	if got.Mode != 2 {
+		t.Errorf("Mode: got %d, want 2 (SECCOMP_MODE_FILTER)", got.Mode)
+	}
+	if got.FilterCount != 3 {
+		t.Errorf("FilterCount: got %d, want 3", got.FilterCount)
+	}
+}
+
+// TestParseProcSelfSeccompState_NoFilters covers a clean parent process
+// (no inherited filter) — the contrast case that should appear in the
+// FIRST snapshot of any successful run, and would appear in BOTH if the
+// double-wrap stacking hypothesis is wrong.
+func TestParseProcSelfSeccompState_NoFilters(t *testing.T) {
+	const status = `Name:	test
+Seccomp:	0
+Seccomp_filters:	0
+`
+	got := parseProcSelfSeccompState([]byte(status))
+	if got.Mode != 0 {
+		t.Errorf("Mode: got %d, want 0 (SECCOMP_MODE_DISABLED)", got.Mode)
+	}
+	if got.FilterCount != 0 {
+		t.Errorf("FilterCount: got %d, want 0", got.FilterCount)
+	}
+}
+
+// TestParseProcSelfSeccompState_MissingFilterCount handles older kernels
+// (<4.10) that emit Seccomp without Seccomp_filters. The parser must
+// not error out — it should report Mode and leave FilterCount at zero
+// so the diagnostic snapshot still surfaces useful state.
+func TestParseProcSelfSeccompState_MissingFilterCount(t *testing.T) {
+	const status = `Name:	test
+Seccomp:	2
+`
+	got := parseProcSelfSeccompState([]byte(status))
+	if got.Mode != 2 {
+		t.Errorf("Mode: got %d, want 2", got.Mode)
+	}
+	if got.FilterCount != 0 {
+		t.Errorf("FilterCount: got %d, want 0 (field absent)", got.FilterCount)
+	}
+}
+
+// TestParseProcSelfSeccompState_NeitherField documents the parser's
+// behavior when /proc/self/status contains neither Seccomp nor
+// Seccomp_filters lines: zero values, Present=false. Used by the
+// snapshot helper to distinguish "kernel did not report" from "mode is
+// disabled (0)".
+func TestParseProcSelfSeccompState_NeitherField(t *testing.T) {
+	const status = `Name:	test
+Pid:	123
+`
+	got := parseProcSelfSeccompState([]byte(status))
+	if got.Present {
+		t.Errorf("Present: got true, want false (no Seccomp line in input)")
+	}
+	if got.Mode != 0 || got.FilterCount != 0 {
+		t.Errorf("got Mode=%d FilterCount=%d, want zero values", got.Mode, got.FilterCount)
+	}
+}
+
+// TestParseProcSelfSeccompState_PresentTrueWhenSeccompFound documents
+// the inverse of TestParseProcSelfSeccompState_NeitherField: if the
+// Seccomp: line is parsed at all, Present=true even if the value is 0
+// (clean process). Lets the snapshot helper distinguish "kernel
+// reported mode 0" from "kernel didn't report".
+func TestParseProcSelfSeccompState_PresentTrueWhenSeccompFound(t *testing.T) {
+	const status = `Seccomp:	0
+Seccomp_filters:	0
+`
+	got := parseProcSelfSeccompState([]byte(status))
+	if !got.Present {
+		t.Errorf("Present: got false, want true (Seccomp line present even if 0)")
+	}
+}


### PR DESCRIPTION
Follow-up diagnostic for #282. The previous rc1 cut surfaced the real errno (EFAULT) and showed two byte-identical filter snapshots in one execve chain producing different results — first Load succeeds, second fails. Same code path (only `cmd/agentsh-unixwrap/main.go:85` calls `InstallFilterWithConfig` in production), same filter content (rules_total=69 in both), same kernel (6.18.5), same libseccomp (2.6.0). The only thing that can differ between two `unixwrap` processes in the same chain is **the caller's prior seccomp state**, inherited via execve from a parent that already installed F1. Stacked install.

This PR adds the fields needed to confirm or refute that hypothesis on the next reproduction:

- `self_pid`, `self_comm`
- `parent_pid`, `parent_comm` — tells us whether the parent that's about to be on top of the new filter is another `agentsh-unixwra`, `agentsh-shell-shi`, `agentsh`, or the user's SDK supervisor. That's the smoking gun for "where did the chain double up?"
- `caller_seccomp_state="mode=N filter_count=M"` parsed from `/proc/self/status`. `mode=2 filter_count>=1` BEFORE `Load()` confirms the calling process already has at least one inherited seccomp filter chain entry, and the about-to-happen install is genuinely stacking on top.

The next reproduction reads off:
- **stacked-install confirmed** → `parent_comm` shows another agentsh binary AND `caller_seccomp_state=mode=2 filter_count>0` in the failing snapshot but not the succeeding one. Fix path: deduplicate the wrap chain (e.g., shim + `agentsh exec` both wrapping), or detect inherited filter and degrade rather than EFAULT.
- **stacked-install ruled out** → both snapshots have `caller_seccomp_state=mode=0` (or identical state) and EFAULT is genuinely about the F2 filter content interacting with kernel 6.18.5. Different fix path.

5 unit tests cover the parser (`parseProcSelfSeccompState`):
- filter mode + count
- no filters
- missing `Seccomp_filters` field (kernel <4.10)
- neither field present (older kernel / restricted /proc)
- `Present` flag semantics (distinguishes "kernel reported 0" from "kernel didn't report")

## Test plan

- [x] `go test ./...` (all packages green)
- [x] `go build ./...`, `GOOS=windows go build ./...`, `GOOS=darwin go build ./...`
- [ ] After merge: delete + recut `v0.19.2-rc1` on the new main commit, ask user to rerun `secured.exec('echo hello')` on Runloop / Freestyle, capture the new snapshot fields, decide fix direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)