### PR TITLE
fix(kernelinstall): skip when caller already has a filter inherited (closes #282)

### DIFF
--- a/internal/api/seccomp_wrapper_shim_install_test.go
+++ b/internal/api/seccomp_wrapper_shim_install_test.go
@@ -240,25 +240,37 @@ func TestShimInstall_NestedInstallsCompose(t *testing.T) {
 	// once by the inner shim.  This proves the test is exercising filter
 	// stacking, not just exec-deny on the inner shim binary.
 	//
-	// KNOWN LIMITATION: when Landlock ABI v4+ is used, the outer wrapper
-	// applies a network policy that restricts TCP connections in the inner
-	// process.  The inner shim's wrap-init call to the httptest server is
-	// blocked by Landlock TCP restrictions — the inner shim fails closed
-	// (which is the correct security behaviour!) but it means this test can
+	// EXPECTED OUTCOME (after #282 fix landed 2026-05-04): the INNER
+	// shim's `kernelinstall.Install` detects via /proc/self/status that
+	// the calling process already has a filter inherited from the outer
+	// shim and returns ResultSkip *before* calling wrap-init. Stacking
+	// two `SECCOMP_RET_USER_NOTIF` filters returns EFAULT on real-world
+	// kernels (Runloop 6.18.5 + libseccomp 2.6.0 reported in #282) and
+	// is functionally redundant — the inherited outer filter already
+	// enforces for the inner process and its descendants. So `wrapCalls
+	// == 1` is the *correct* count, not a regression.
+	//
+	// KNOWN LIMITATION (pre-#282-fix and orthogonal to it): when
+	// Landlock ABI v4+ is used, the outer wrapper applies a network
+	// policy that restricts TCP connections in the inner process. The
+	// inner shim's wrap-init call to the httptest server is blocked by
+	// Landlock TCP restrictions — the inner shim fails closed (which is
+	// also correct security behaviour) but it means this test can
 	// currently only verify the security guarantee (no leak), not the
 	// install-twice path.
 	//
-	// To fully verify nested install, the test server would need to either:
+	// To force stacking and verify it on kernels that DO support it,
+	// the test server would need to either:
 	//   a) listen on a unix socket (exempted from Landlock TCP restrictions), or
 	//   b) use Landlock network rules that explicitly allowlist the test port.
 	// Neither is trivially achievable with the current httptest infrastructure.
 	wrapCalls := spec.wrapInitCalls.Load()
 	t.Logf("wrap-init call count: %d", wrapCalls)
-	if wrapCalls < 2 {
-		t.Logf("WARNING: expected >= 2 wrap-init calls (outer + inner shim), got %d", wrapCalls)
-		t.Logf("The inner shim's TCP connection to the test server is blocked by the outer")
-		t.Logf("Landlock policy — inner shim fails closed (correct behaviour) but means")
-		t.Logf("this test verifies the security guarantee (no leak) not the install-twice path.")
+	if wrapCalls < 1 {
+		t.Errorf("expected >= 1 wrap-init call (outer shim must always run), got %d", wrapCalls)
+	}
+	if wrapCalls > 1 {
+		t.Logf("note: inner shim also called wrap-init — current run did not exercise the #282 inherited-filter skip (probably no Landlock TCP block AND no inherited filter detected)")
 	}
 
 	t.Logf("PASS: nested shim exited non-zero, sentinel did not appear, wrap-init called %d time(s)", wrapCalls)

--- a/internal/shim/kernelinstall/install_linux.go
+++ b/internal/shim/kernelinstall/install_linux.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -35,22 +36,83 @@ const signalSockFDKey = "AGENTSH_SIGNAL_SOCK_FD"
 // append in runRelay is honored.
 const argv0EnvKey = "AGENTSH_UNIXWRAP_ARGV0"
 
+// seccompFilterCount returns the number of seccomp filters already
+// installed on the calling process, parsed from /proc/self/status's
+// `Seccomp_filters:` line. Returns 0 on any read/parse error.
+//
+// Indirection via package var lets tests simulate the
+// inherited-filter state without forking a real child with a live
+// filter (which would also pollute the Go test runner's seccomp state
+// and break unrelated tests). Production calls
+// readKernelSeccompFilterCount, which is the only path that reads
+// /proc.
+var seccompFilterCount = readKernelSeccompFilterCount
+
+// readKernelSeccompFilterCount reads /proc/self/status and returns the
+// integer value of the Seccomp_filters: line (added in kernel 4.10).
+// The kernel reports this field unconditionally when seccomp is
+// compiled in — non-zero means at least one filter is already attached
+// to this task or inherited via execve. We treat any read or parse
+// failure as zero (best-effort): the gate is a defense-in-depth check,
+// not a security boundary.
+func readKernelSeccompFilterCount() int {
+	const key = "Seccomp_filters:"
+	data, err := os.ReadFile("/proc/self/status")
+	if err != nil {
+		return 0
+	}
+	for _, raw := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(raw, key) {
+			continue
+		}
+		v := strings.TrimSpace(raw[len(key):])
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return 0
+		}
+		return n
+	}
+	return 0
+}
+
 // Install is the all-in-one entry point that the shim calls before launching
 // the user's command.  It:
 //
 //  1. Returns ResultSkip immediately when Mode == ModeOff.
-//  2. Calls wrap-init via the agentsh server to get a wrapper binary + socket.
-//  3. On failure, fails closed (ModeOn) or skips (ModeAuto).
-//  4. Runs the socketpair relay: mirrors internal/cli/wrap_linux.go
+//  2. Returns ResultSkip when the calling process already has a seccomp
+//     filter inherited (any Mode), because trying to install another
+//     filter on top of an inherited one fails on some kernels/runtimes
+//     (issue #282 EFAULT on Runloop kernel 6.18.5: nested
+//     `agentsh-shell-shim` invocation inside a process tree where
+//     `agentsh-unixwrap` already installed F1). The inherited filter is
+//     unforgeable evidence that policy enforcement is already active —
+//     re-installing would be redundant at best, and on hostile kernels
+//     the second `seccomp(SECCOMP_SET_MODE_FILTER, ...)` call rejects
+//     the program with EFAULT and breaks every wrapped exec. ModeOn
+//     "fail-closed" is satisfied here because we ARE filtered, just not
+//     by us.
+//  3. Calls wrap-init via the agentsh server to get a wrapper binary + socket.
+//  4. On failure, fails closed (ModeOn) or skips (ModeAuto).
+//  5. Runs the socketpair relay: mirrors internal/cli/wrap_linux.go
 //     platformSetupWrap, minus the signal-filter second socketpair.
-//  5. Returns ResultExec carrying the exit code from the wrapper process.
+//  6. Returns ResultExec carrying the exit code from the wrapper process.
 func Install(p InstallParams) (Result, error) {
 	// Step 1: mode gate
 	if p.Mode == ModeOff {
 		return Result{Action: ResultSkip, Reason: "mode=off"}, nil
 	}
 
-	// Step 2: call wrap-init
+	// Step 2: inherited-filter gate (#282). Unforgeable: the kernel
+	// itself reports the live filter chain count via /proc/self/status,
+	// regardless of any caller-controlled env var.
+	if n := seccompFilterCount(); n > 0 {
+		return Result{
+			Action: ResultSkip,
+			Reason: fmt.Sprintf("already filtered (Seccomp_filters=%d, inherited from parent)", n),
+		}, nil
+	}
+
+	// Step 3: call wrap-init
 	resp, err := callWrapInit(p)
 	if err != nil {
 		reason := fmt.Sprintf("wrap-init failed: %v", err)
@@ -62,7 +124,7 @@ func Install(p InstallParams) (Result, error) {
 		return Result{Action: ResultSkip, Reason: reason}, nil
 	}
 
-	// Step 3: check response completeness
+	// Step 4: check response completeness
 	if resp.WrapperBinary == "" || resp.NotifySocket == "" {
 		reason := "wrap-init returned empty WrapperBinary or NotifySocket"
 		if p.Mode == ModeOn {
@@ -71,7 +133,7 @@ func Install(p InstallParams) (Result, error) {
 		return Result{Action: ResultSkip, Reason: reason}, nil
 	}
 
-	// Step 4–7: socketpair relay
+	// Step 5–6: socketpair relay
 	return runRelay(p, resp)
 }
 

--- a/internal/shim/kernelinstall/install_linux_test.go
+++ b/internal/shim/kernelinstall/install_linux_test.go
@@ -70,6 +70,122 @@ func TestInstall_ModeOff_ReturnsSkip(t *testing.T) {
 	}
 }
 
+// ─── Test InheritedFilter: caller already has seccomp filter → ResultSkip ────
+
+// TestInstall_AlreadyFiltered_ReturnsSkip covers the #282 root cause
+// confirmed by the rc1 (commit a4de5e1) diagnostic on Runloop:
+// agentsh CLI spawns unixwrap_1 (installs F1, success); unixwrap_1 execs
+// the user's command which goes through the shell-shim again, and the
+// shim's kernelinstall.Install is called *inside* a process tree that
+// already has F1 inherited via execve. Trying to install F2 on top
+// returns EFAULT on this kernel/runtime. The fix: kernelinstall must
+// detect the unforgeable Seccomp:2 + Seccomp_filters>=1 signal from
+// /proc/self/status and skip wrap-init entirely — the inherited filter
+// is already enforcing for this process and all its descendants, so a
+// second install is both redundant and harmful.
+//
+// We inject seccompFilterCount via a package-level var so the test can
+// simulate the inherited-filter state without forking a real child
+// process with a live filter installed (which would also pollute the
+// Go test runner's seccomp state and break unrelated tests).
+//
+// The httptest handler is registered but should NOT be hit. Reaching
+// it indicates the skip gate fired AFTER wrap-init was contacted, which
+// would still leak server load and side-effects (notify socket creation,
+// event emission) on every nested shim invocation.
+func TestInstall_AlreadyFiltered_ReturnsSkip(t *testing.T) {
+	handler, calls := makeWrapInitHandler(200, types.WrapInitResponse{
+		WrapperBinary: "/usr/bin/agentsh-unixwrap",
+		NotifySocket:  "/tmp/notify.sock",
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	orig := seccompFilterCount
+	seccompFilterCount = func() int { return 1 }
+	t.Cleanup(func() { seccompFilterCount = orig })
+
+	p := baseParams(srv)
+	p.Mode = ModeAuto
+
+	res, err := Install(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Action != ResultSkip {
+		t.Errorf("expected ResultSkip, got %v (reason=%q)", res.Action, res.Reason)
+	}
+	if !strings.Contains(res.Reason, "already") {
+		t.Errorf("expected reason to mention already-filtered state, got %q", res.Reason)
+	}
+	if *calls != 0 {
+		t.Errorf("expected 0 HTTP calls (skip must happen before wrap-init), got %d", *calls)
+	}
+}
+
+// TestInstall_AlreadyFiltered_ModeOnAlsoSkips documents that inherited-
+// filter detection bypasses ModeOn's fail-closed semantics. ModeOn means
+// "must install or fail" — but if a filter is *already* installed via
+// inheritance, the policy intent is satisfied (the filter is
+// enforcing). Treating this as fail-closed would break the entire
+// nested-shim case for users who set shim_install=on, so we still skip.
+func TestInstall_AlreadyFiltered_ModeOnAlsoSkips(t *testing.T) {
+	handler, calls := makeWrapInitHandler(200, types.WrapInitResponse{
+		WrapperBinary: "/usr/bin/agentsh-unixwrap",
+		NotifySocket:  "/tmp/notify.sock",
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	orig := seccompFilterCount
+	seccompFilterCount = func() int { return 1 }
+	t.Cleanup(func() { seccompFilterCount = orig })
+
+	p := baseParams(srv)
+	p.Mode = ModeOn
+
+	res, err := Install(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Action != ResultSkip {
+		t.Errorf("ModeOn must still skip when a filter is inherited; got %v", res.Action)
+	}
+	if *calls != 0 {
+		t.Errorf("expected 0 HTTP calls, got %d", *calls)
+	}
+}
+
+// TestInstall_NotFiltered_ProceedsAsBefore guards against a regression
+// where the new gate accidentally fires on a clean process: when
+// seccompFilterCount returns 0 (no inherited filter), the existing
+// wrap-init/relay path must run — exactly the rc1 first-Load case
+// (parent_comm=agentsh, caller_seccomp_state="mode=0 filter_count=0")
+// that the rc1 diagnostic showed succeeding.
+func TestInstall_NotFiltered_ProceedsAsBefore(t *testing.T) {
+	handler, calls := makeWrapInitHandler(200, types.WrapInitResponse{}) // empty resp → ResultSkip via existing path
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	orig := seccompFilterCount
+	seccompFilterCount = func() int { return 0 }
+	t.Cleanup(func() { seccompFilterCount = orig })
+
+	p := baseParams(srv)
+	p.Mode = ModeAuto
+
+	res, err := Install(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Action != ResultSkip {
+		t.Errorf("expected ResultSkip from empty wrap-init response, got %v", res.Action)
+	}
+	if *calls != 1 {
+		t.Errorf("expected wrap-init to be called when no filter inherited, got %d calls", *calls)
+	}
+}
+
 // ─── Test 2: ModeAuto + server 500 → ResultSkip ─────────────────────────────
 
 func TestInstall_ModeAuto_WrapInitError_Skips(t *testing.T) {


### PR DESCRIPTION
Real fix for #282, not a diagnostic. Stacking confirmed by the rc1 (`a4de5e1`) snapshot from the user on Runloop kernel 6.18.5:

| Field | First Load ✅ | Second Load ❌ |
|---|---|---|
| `parent_pid` / `parent_comm` | 411 / `agentsh` | 476 / **`bash`** |
| `caller_seccomp_state` | `mode=0 filter_count=0` | **`mode=2 filter_count=1`** |
| `errno` | (success) | `EFAULT` |

The 69-rule filter and attr flags were byte-identical between attempts — the only material difference is that the second `agentsh-unixwra` was running inside an already-filtered process tree (parent is `bash`, which is the shell-shim, which is itself a child of the first `unixwra` that already installed F1). Stacking a second `SECCOMP_RET_USER_NOTIF` filter on top of an inherited one returns `EFAULT` on this kernel — and is functionally redundant because the inherited filter already enforces for descendants.

## The fix

In `kernelinstall.Install`, before contacting wrap-init or spawning the wrapper, read `/proc/self/status`'s `Seccomp_filters:` line. When the count is non-zero we return `ResultSkip` with reason `"already filtered (Seccomp_filters=N, inherited from parent)"` — this applies to `ModeAuto` AND `ModeOn`, because ModeOn's "must install or fail" semantics are satisfied when a filter is already enforcing (just not by us). The kernel's `Seccomp_filters` line is unforgeable, unlike the `AGENTSH_SHIM_INSTALL_DONE` env var that #274's commit message intended to switch away from but never did.

Reader is injected via a `seccompFilterCount` package var so unit tests can simulate the inherited state without forking a child with a live filter (which would also pollute the Go test runner's seccomp state and break unrelated tests).

## Tests

- `TestInstall_AlreadyFiltered_ReturnsSkip` — `Mode=auto` + `filter_count=1` → `ResultSkip`, 0 wrap-init calls.
- `TestInstall_AlreadyFiltered_ModeOnAlsoSkips` — `Mode=on` + `filter_count=1` → `ResultSkip`, 0 wrap-init calls. Documents that `ModeOn` does NOT fail-closed when the inherited filter already enforces.
- `TestInstall_NotFiltered_ProceedsAsBefore` — `filter_count=0` keeps the existing wrap-init/relay path; guards against the gate firing on clean processes.
- `TestShimInstall_NestedInstallsCompose` (existing integration test): comment updated. `wrapCalls=1` is now the *expected* outcome (inner shim correctly skips). The security guarantee (sentinel doesn't leak) still holds because the inherited outer filter is what enforces.

## Test plan

- [x] `go test ./...` — all packages green (Linux + cgo, including the existing 13s shell-shim integration tests and 6s api shim-install integration tests)
- [x] `go build ./...`, `GOOS=windows go build ./...`, `GOOS=darwin go build ./...`
- [x] Existing kernelinstall + shim integration tests still pass
- [ ] After merge: delete + recut `v0.19.2-rc1` on the new main commit; user retests `secured.exec('echo hello')` on Runloop and Freestyle. Expected outcome: the SECOND snapshot now shows `caller_seccomp_state="mode=2 filter_count=1"` and Install returns `ResultSkip` instead of EFAULT-ing on Load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)