### PR TITLE
fix(wrap): include AgentCommand parent dir in Landlock AllowExecute (closes #283 problem 1)

### DIFF
--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -408,6 +408,27 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 		ExecveEnabled:       execveEnabled,
 	})
 
+	// Ensure the parent directory of the about-to-be-execed command is
+	// in AllowExecute. Without this, any Landlock-enabled session
+	// blocks the wrap path from invoking shells whose path is not
+	// already covered by a policy command rule with a slash. The
+	// shim's renamed real shells (/bin/bash.real, /bin/sh.real) are
+	// the canonical case (#283 on Tensorlake): typical policies use
+	// bare names (`commands: [bash, sh]`), so
+	// DeriveExecutePathsFromPolicy adds nothing for them, and Landlock
+	// denies execve of /bin/bash.real with EACCES.
+	//
+	// Bare-name AgentCommand values (no slash) are skipped — there is
+	// no parent directory to add, and resolving via PATH at exec time
+	// is the wrapper's responsibility. We also guard against the "/"
+	// and "." dirs that would broaden the allow list to root or cwd.
+	if seccompCfg.LandlockEnabled && strings.ContainsRune(req.AgentCommand, '/') {
+		dir := filepath.Dir(req.AgentCommand)
+		if dir != "" && dir != "." && dir != "/" && !containsString(seccompCfg.AllowExecute, dir) {
+			seccompCfg.AllowExecute = append(seccompCfg.AllowExecute, dir)
+		}
+	}
+
 	cfgJSON, err := json.Marshal(seccompCfg)
 	if err != nil {
 		return types.WrapInitResponse{}, http.StatusInternalServerError, err
@@ -558,6 +579,19 @@ func blockListUsesNotify(block []string, onBlock string) bool {
 		return false
 	}
 	return resolvableBlockListCount(block) > 0
+}
+
+// containsString returns true when s appears in xs. Used by wrapInitCore
+// to dedupe entries appended to AllowExecute (the AgentCommand parent
+// dir might already be present from policy or global config — adding it
+// twice is harmless but noisier in logs and serialized config).
+func containsString(xs []string, s string) bool {
+	for _, x := range xs {
+		if x == s {
+			return true
+		}
+	}
+	return false
 }
 
 // blockedFamiliesUsesNotify reports whether any BlockedSocketFamilies entry

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -1464,3 +1464,122 @@ func TestMainFilterUsesUserNotify_FamilyErrnoAndKill_NoNotify(t *testing.T) {
 		t.Error("mainFilterUsesUserNotify should return false when all families use errno/kill (kernel-side)")
 	}
 }
+
+// TestWrapInit_AllowExecuteIncludesAgentCommandDir covers the #283
+// regression on Tensorlake (and any environment where the shell-shim is
+// installed): wrap-init must include the parent directory of the
+// AgentCommand in the seccomp wrapper's AllowExecute list, otherwise
+// Landlock denies execve of the renamed real shell (e.g.,
+// /bin/bash.real) because typical policies use bare command names
+// (`commands: [bash, sh]`) and DeriveExecutePathsFromPolicy adds
+// nothing for those.
+//
+// Without this fix, every wrapped command on Tensorlake exits 1 with
+// `resolve command "/bin/bash.real": exec: ... permission denied` —
+// the EACCES surfaces from Go's exec.LookPath after Landlock has been
+// applied to unixwrap's process.
+func TestWrapInit_AllowExecuteIncludesAgentCommandDir(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+	if !capabilities.DetectLandlock().Available {
+		t.Skip("Landlock not available on this host")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Landlock.Enabled = true
+
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, _, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/bash.real",
+	})
+	if err != nil {
+		t.Fatalf("wrapInitCore: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(resp.SeccompConfig), &parsed); err != nil {
+		t.Fatalf("unmarshal SeccompConfig: %v\n%s", err, resp.SeccompConfig)
+	}
+
+	rawAllow, _ := parsed["allow_execute"].([]any)
+	allow := make([]string, 0, len(rawAllow))
+	for _, p := range rawAllow {
+		if s, ok := p.(string); ok {
+			allow = append(allow, s)
+		}
+	}
+
+	found := false
+	for _, p := range allow {
+		if p == "/bin" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected /bin in allow_execute, got %v\nfull config: %s", allow, resp.SeccompConfig)
+	}
+}
+
+// TestWrapInit_AllowExecuteSkipsBareCommandName verifies the inverse:
+// when AgentCommand is a bare name (no slash, e.g., "echo"), wrap-init
+// does NOT add anything based on it — there is no parent directory to
+// derive, and resolving via PATH at exec time is the unixwrap caller's
+// responsibility. The list still contains whatever the policy and
+// global config supplied.
+func TestWrapInit_AllowExecuteSkipsBareCommandName(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+	if !capabilities.DetectLandlock().Available {
+		t.Skip("Landlock not available on this host")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Landlock.Enabled = true
+
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, _, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "echo",
+	})
+	if err != nil {
+		t.Fatalf("wrapInitCore: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(resp.SeccompConfig), &parsed); err != nil {
+		t.Fatalf("unmarshal SeccompConfig: %v\n%s", err, resp.SeccompConfig)
+	}
+
+	// We don't assert the exact list (it depends on default policy +
+	// landlock config); we just confirm no spurious entry derived from
+	// the bare name was injected. "" or "." would be the most likely
+	// bug shapes if filepath.Dir was applied unguarded.
+	rawAllow, _ := parsed["allow_execute"].([]any)
+	for _, p := range rawAllow {
+		s, ok := p.(string)
+		if !ok {
+			continue
+		}
+		if s == "" || s == "." {
+			t.Errorf("allow_execute should not contain bare-name-derived %q; got list %v", s, rawAllow)
+		}
+	}
+}


### PR DESCRIPTION
Addresses the original #283 — Landlock denies execve of `/bin/bash.real` on Tensorlake (and any shim-installed environment). Reproduces 100% on v0.19.1 and v0.19.2-rc1 with `shim_install=auto/on`.

## Root cause

When `shell-shim` is installed it renames `/bin/{sh,bash}` → `/bin/{sh,bash}.real`. The wrap path's `RealShell` is `/bin/bash.real`. But typical policies use bare command names (`commands: [bash, sh]`), and `DeriveExecutePathsFromPolicy` in `internal/landlock/policy.go:32` only adds directories from commands that contain a `/` — so `/bin` is never added to `AllowExecute`.

Landlock then denies `execve` of `/bin/bash.real`, surfacing as:

```
resolve command "/bin/bash.real": exec: "/bin/bash.real": permission denied
```

from Go's `exec.LookPath` inside `unixwrap` (Landlock has been applied just before `resolveCommandPath` runs).

## Fix

In `wrapInitCore` (`internal/api/wrap.go`), after `buildSeccompWrapperConfig`, append `filepath.Dir(req.AgentCommand)` to `seccompCfg.AllowExecute` when the command path contains a slash and Landlock is enabled. The shim sends `AgentCommand=/bin/{sh,bash}.real` (its resolved `RealShell`), and the agentsh CLI wrap path sends an absolute `agentPath` — both flows benefit.

Bare-name `AgentCommand` values (no slash) are skipped — there's no parent directory to derive, and PATH resolution at exec time is the wrapper's responsibility. Guarded against `"/"` and `"."` which would broaden the allow list to root or the cwd. A small `containsString` helper dedupes against entries already present from the policy or global Landlock config.

## Tests

- `TestWrapInit_AllowExecuteIncludesAgentCommandDir`: `AgentCommand=/bin/bash.real` + Landlock enabled → `/bin` is in `allow_execute`. Was **RED** before the fix (allow_execute was `[]`), **GREEN** after.
- `TestWrapInit_AllowExecuteSkipsBareCommandName`: `AgentCommand=echo` → no spurious `""` or `"."` entry. Guards against an unguarded `filepath.Dir` call.

## What this does NOT fix

The user's #283 thread also reports two **new** rc1 observations:
- SIGKILL of every command with `AGENTSH_SHIM_FORCE=1` + ptrace-pid (worked in v0.19.1).
- Silent bypass without env (was enforced in v0.19.1).

Neither is visible in our `v0.19.1..main` diff: only PRs #284 and #288 touched the shim/wrap/ptrace surface, and #288's gate only fires when `Mode != ModeOff` (the user's config has `shim_install=off`). Those need failing-run logs from the user (`AGENTSH_SHIM_DEBUG=1` + `server.log`) before we can localize.

## Test plan

- [x] `go test ./...` (all packages green)
- [x] `go build ./...`, `GOOS=windows go build ./...`, `GOOS=darwin go build ./...`
- [ ] After merge: recut `v0.19.2-rc1` and ask user to retest the `shim_install=auto/on` case on Tensorlake. The EACCES on `/bin/bash.real` should be gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)