### PR TITLE
fix(unixwrap): pre-resolve cmd path before seccomp filter install (#283 bug B)

### DIFF
--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -68,6 +68,32 @@ func main() {
 		log.Printf("warning: skipped unknown syscalls: %v", skipped)
 	}
 
+	// Pre-resolve the command path BEFORE installing the seccomp filter.
+	// resolveCommandPath calls exec.LookPath which stats the candidate
+	// (newfstatat) and may probe with faccessat2(X_OK). When
+	// InterceptMetadata is enabled the to-be-installed seccomp filter
+	// traps both syscalls via SECCOMP_RET_USER_NOTIF; the file-monitor
+	// handler then asks the policy engine and DENIES paths the policy
+	// has no rule for — including /bin/bash.real (the shim's renamed
+	// real shell), surfacing as
+	//   resolve command "/bin/bash.real": exec: ... permission denied
+	// (#283 bug B). Resolving here, before the filter is installed,
+	// keeps the path-resolution syscalls outside the notify scope.
+	// syscall.Exec at the end is a single execve — that's governed
+	// by the kernel's execve check independently and is filter-gated
+	// only when cfg.ExecveEnabled is true.
+	//
+	// applyArgv0Override is also moved up so the argv slice is fully
+	// computed before any filter setup happens; it only reads an env
+	// var and reshuffles strings, no filesystem I/O, but co-locating
+	// keeps the "all the exec arguments are ready" boundary clear.
+	cmd := os.Args[2]
+	cmdPath, err := resolveCommandPath(cmd)
+	if err != nil {
+		log.Fatalf("resolve command %q: %v", cmd, err)
+	}
+	args := applyArgv0Override(os.Args[2:], os.Getenv("AGENTSH_UNIXWRAP_ARGV0"))
+
 	// Build filter config.
 	onBlock, _ := seccompkg.ParseOnBlock(cfg.OnBlock)
 	filterCfg := unixmon.FilterConfig{
@@ -218,13 +244,11 @@ func main() {
 		blockSIGURG()
 	}
 
-	// Exec the real command.
-	cmd := os.Args[2]
-	cmdPath, err := resolveCommandPath(cmd)
-	if err != nil {
-		log.Fatalf("resolve command %q: %v", cmd, err)
-	}
-	args := applyArgv0Override(os.Args[2:], os.Getenv("AGENTSH_UNIXWRAP_ARGV0"))
+	// Exec the real command. cmdPath and args were pre-resolved at the
+	// top of main(), before the seccomp filter was installed, so
+	// resolveCommandPath's exec.LookPath probes (newfstatat /
+	// faccessat2 — see #283 bug B) do not get intercepted by the
+	// file-monitor notify handler.
 	if err := syscall.Exec(cmdPath, args, os.Environ()); err != nil {
 		log.Fatalf("exec %s failed: %v", cmd, err)
 	}


### PR DESCRIPTION
Targeted fix for #283's "first call works, rest EACCES" symptom that the user (Eran) root-caused via shim debug log: wrap-init returns 404 on the first call (server-side session not yet known), shim falls through to `agentsh exec` which lazy-creates the session and succeeds. From the second call on, wrap-init succeeds, the shim installs the seccomp filter, and `unixwrap` EACCESes on `/bin/bash.real` from `unix.Access(X_OK)` — which is `faccessat2`.

## Root cause

When `InterceptMetadata=true` (the default for FUSE-backed file monitoring), the wrap path's seccomp filter intercepts `newfstatat` AND `faccessat2` via `SECCOMP_RET_USER_NOTIF` (see `internal/netmonitor/unix/seccomp_linux.go` `metadataRules` block). The file-monitor handler queries `policy.Engine.CheckFile`, and policies typically have no file rule covering `/bin/bash.real` (the shim's renamed real shell isn't in any ordinary allow list), so the handler returns `EACCES`. `exec.LookPath` inside `resolveCommandPath` stats the candidate, that stat is intercepted, the handler denies, and `LookPath` surfaces the denial as `fs.ErrPermission` — surfaced as:

```
resolve command "/bin/bash.real": exec: "/bin/bash.real": permission denied
```

The user explicitly noted this in their #283 comment after running with `AGENTSH_SHIM_DEBUG=1`.

## Fix

In `cmd/agentsh-unixwrap/main.go`, move the `resolveCommandPath` call (and the cosmetic `applyArgv0Override` that pairs with it) to **before** `InstallFilterWithConfig`. Path resolution is pure file lookup and reads no policy state — doing it before the filter exists is safe, and it keeps the `newfstatat`/`faccessat2` probes out of the notify scope.

The eventual `syscall.Exec` at the end is a single `execve`, which is governed by the kernel's execve check independently (and only gated by the filter when `cfg.ExecveEnabled` is true; in the user's repro that flag is `false`).

## What this does NOT fix

- **#283 bug A** (wrap-init returns 404 on first call because the session isn't lazy-created server-side). `shim_install=auto` masks it via the agentsh-exec fall-through, but `shim_install=on` fails closed. That's a server-side change to wrap-init session handling — separate PR.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go build ./...`, `GOOS=windows go build ./...`, `GOOS=darwin go build ./...`
- [ ] After merge: recut `v0.19.2-rc1` and ask user to retest the `for i in 1..5; do bash -c id; done` repro on Tensorlake. All five iterations should now succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)