### PR TITLE
[codex] Add YAML mitigation sets for Dirty Frag socket rules

### DIFF
--- a/cmd/agentsh-unixwrap/config.go
+++ b/cmd/agentsh-unixwrap/config.go
@@ -18,6 +18,7 @@ type WrapperConfig struct {
 	FileMonitorEnabled  bool                      `json:"file_monitor_enabled"`
 	BlockedSyscalls     []string                  `json:"blocked_syscalls"`
 	BlockedFamilies     []seccompkg.BlockedFamily `json:"blocked_families,omitempty"`
+	SocketRules         []seccompkg.SocketRule    `json:"socket_rules,omitempty"`
 	OnBlock             string                    `json:"on_block,omitempty"`
 
 	InterceptMetadata bool `json:"intercept_metadata,omitempty"`

--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -104,6 +104,7 @@ func main() {
 		BlockIOUring:       cfg.BlockIOUring,
 		BlockedSyscalls:    blockedNrs,
 		BlockedFamilies:    cfg.BlockedFamilies,
+		SocketRules:        cfg.SocketRules,
 		OnBlockAction:      onBlock,
 	}
 

--- a/config.yml
+++ b/config.yml
@@ -243,21 +243,12 @@ sandbox:
   seccomp:
     # Linux seccomp-bpf enforcement for syscall, file, and socket filters.
     enabled: false
-    # Enable this profile to apply the conservative Dirty Frag mitigation.
-    # It blocks AF_RXRPC and AF_NETLINK with protocol NETLINK_XFRM only;
-    # it does not block all AF_NETLINK traffic.
-    # hardening_profiles:
+    # Advisory mitigation sets. Built-ins are embedded in agentsh; external
+    # directories are optional and only requested IDs are loaded.
+    # mitigation_sets:
     #   - dirtyfrag-conservative
-    #
-    # Manual equivalent if you do not want to use the profile:
-    # socket_rules:
-    #   - name: dirtyfrag-conservative-rxrpc
-    #     family: AF_RXRPC
-    #     action: log_and_kill
-    #   - name: dirtyfrag-conservative-xfrm
-    #     family: AF_NETLINK
-    #     protocol: NETLINK_XFRM
-    #     action: log_and_kill
+    # mitigation_dirs:
+    #   - /etc/agentsh/mitigations
     # File I/O interception via seccomp-notify.
     # When enabled, seccomp intercepts file syscalls (openat, unlinkat, etc.)
     # and evaluates them against the active policy's file_rules.

--- a/config.yml
+++ b/config.yml
@@ -241,9 +241,23 @@ sandbox:
 
   # seccomp settings
   seccomp:
-    # Reserved for future hardening (not implemented yet).
+    # Linux seccomp-bpf enforcement for syscall, file, and socket filters.
     enabled: false
-    profile: "default"             # or path to custom profile
+    # Enable this profile to apply the conservative Dirty Frag mitigation.
+    # It blocks AF_RXRPC and AF_NETLINK with protocol NETLINK_XFRM only;
+    # it does not block all AF_NETLINK traffic.
+    # hardening_profiles:
+    #   - dirtyfrag-conservative
+    #
+    # Manual equivalent if you do not want to use the profile:
+    # socket_rules:
+    #   - name: dirtyfrag-conservative-rxrpc
+    #     family: AF_RXRPC
+    #     action: log_and_kill
+    #   - name: dirtyfrag-conservative-xfrm
+    #     family: AF_NETLINK
+    #     protocol: NETLINK_XFRM
+    #     action: log_and_kill
     # File I/O interception via seccomp-notify.
     # When enabled, seccomp intercepts file syscalls (openat, unlinkat, etc.)
     # and evaluates them against the active policy's file_rules.

--- a/docs/seccomp.md
+++ b/docs/seccomp.md
@@ -46,6 +46,20 @@ sandbox:
         action: errno        # errno | kill | log | log_and_kill (default: errno)
       - family: AF_VSOCK
         action: log_and_kill
+
+    # Optional hardening profile for the May 7, 2026 Openwall Dirty Frag advisory.
+    # hardening_profiles:
+    #   - dirtyfrag-conservative
+
+    # Lower-level socket tuple rules are also available as an alternative.
+    # socket_rules:
+    #   - name: dirtyfrag-conservative-rxrpc
+    #     family: AF_RXRPC
+    #     action: log_and_kill
+    #   - name: dirtyfrag-conservative-xfrm
+    #     family: AF_NETLINK
+    #     protocol: NETLINK_XFRM
+    #     action: log_and_kill
 ```
 
 ## Signal Interception
@@ -305,6 +319,81 @@ Config typos fail fast at startup with a clear error:
 sandbox.seccomp.blocked_socket_families[0].family: "AF_ALGOG" is not a valid AF_* name or number
 sandbox.seccomp.blocked_socket_families[1].action: "deny" is not valid (allowed: errno, kill, log, log_and_kill)
 ```
+
+## Socket Tuple Rules
+
+`sandbox.seccomp.socket_rules` blocks specific `socket(2)` and `socketpair(2)` tuples. Both syscalls match the same fields: `family`, optional `type`, and optional `protocol`.
+
+Use this when a mitigation should be narrower than an entire `AF_*` family. The manual syntax is:
+
+```yaml
+sandbox:
+  seccomp:
+    socket_rules:
+      - name: dirtyfrag-conservative-rxrpc
+        family: AF_RXRPC
+        action: log_and_kill
+      - name: dirtyfrag-conservative-xfrm
+        family: AF_NETLINK
+        protocol: NETLINK_XFRM
+        action: log_and_kill
+```
+
+Fields:
+
+| Field | Required | Meaning |
+|---|---|---|
+| `name` | yes | Stable rule name used in audit events; names must be unique after profile expansion |
+| `family` | yes | `AF_*` name or numeric string |
+| `type` | no | `SOCK_*` name or numeric socket type; flags such as `SOCK_CLOEXEC` are masked out before matching |
+| `protocol` | no | Numeric protocol string, or a named `NETLINK_*` protocol when `family: AF_NETLINK` |
+| `action` | yes | `errno`, `kill`, `log`, or `log_and_kill` |
+
+Named `NETLINK_*` protocol values are valid only with `family: AF_NETLINK`. A protocol-scoped netlink rule does not block other netlink protocols.
+
+### Dirty Frag Conservative Profile
+
+`sandbox.seccomp.hardening_profiles` currently supports `dirtyfrag-conservative`, a conservative mitigation for the Openwall Dirty Frag advisory dated May 7, 2026.
+
+The profile expands to these two `socket_rules` entries:
+
+| Rule | Match | Action |
+|---|---|---|
+| `dirtyfrag-conservative-rxrpc` | `family: AF_RXRPC` only; `type` and `protocol` are intentionally omitted | `log_and_kill` |
+| `dirtyfrag-conservative-xfrm` | `family: AF_NETLINK`, `protocol: NETLINK_XFRM` | `log_and_kill` |
+
+This does **not** block all `AF_NETLINK`. `NETLINK_ROUTE`, `NETLINK_GENERIC`, `NETLINK_AUDIT`, and other netlink protocols remain available unless separately blocked.
+
+Because the profile uses `log_and_kill`, a matching call emits `seccomp_socket_rule_blocked` and kills the offending process.
+
+### Socket Rule Audit Event
+
+`log` and `log_and_kill` socket rules emit `seccomp_socket_rule_blocked`; `errno` and `kill` are enforced kernel-side and do not emit an event.
+
+```json
+{
+  "type": "seccomp_socket_rule_blocked",
+  "timestamp": "2026-05-07T18:00:00Z",
+  "session_id": "sess_abc123",
+  "source": "seccomp",
+  "pid": 12345,
+  "fields": {
+    "rule_name": "dirtyfrag-conservative-xfrm",
+    "family_name": "AF_NETLINK",
+    "family_number": 16,
+    "protocol_name": "NETLINK_XFRM",
+    "protocol_number": 6,
+    "syscall": "socket",
+    "syscall_nr": 41,
+    "action": "log_and_kill",
+    "outcome": "killed",
+    "arch": "amd64",
+    "engine": "seccomp"
+  }
+}
+```
+
+`type_name` / `type_number` appear only when the matching rule includes `type`; `protocol_name` / `protocol_number` appear only when it includes `protocol`. Current socket-rule events are emitted by the seccomp engine, so `engine` is `seccomp`.
 
 ## Audit Events
 

--- a/docs/seccomp.md
+++ b/docs/seccomp.md
@@ -346,7 +346,7 @@ Fields:
 
 | Field | Required | Meaning |
 |---|---|---|
-| `name` | yes | Stable rule name used in audit events; names must be unique after profile expansion |
+| `name` | yes | Stable rule name used in audit events; names must be unique after mitigation sets are expanded |
 | `family` | yes | `AF_*` name or numeric string |
 | `type` | no | `SOCK_*` name or numeric socket type; flags such as `SOCK_CLOEXEC` are masked out before matching |
 | `protocol` | no | Numeric protocol string, or a named `NETLINK_*` protocol when `family: AF_NETLINK` |
@@ -358,6 +358,8 @@ Named `NETLINK_*` protocol values are valid only with `family: AF_NETLINK`. A pr
 
 `sandbox.seccomp.mitigation_sets` loads named mitigation YAML files and expands them into ordinary seccomp rules. agentsh ships built-in mitigations and can also load external mitigation files from opt-in `mitigation_dirs`.
 
+External mitigation IDs are loaded from `<id>.yaml` or `<id>.yml` files in `mitigation_dirs`. Duplicate mitigation IDs across built-in and external sources are rejected.
+
 ```yaml
 sandbox:
   seccomp:
@@ -367,7 +369,7 @@ sandbox:
       - /etc/agentsh/mitigations
 ```
 
-The built-in `dirtyfrag-conservative` set is a conservative mitigation for the Openwall Dirty Frag advisory dated May 7, 2026. It expands to two `socket_rules`: one for `AF_RXRPC`, and one for `AF_NETLINK` with protocol `NETLINK_XFRM`. It does not block all `AF_NETLINK`.
+The built-in `dirtyfrag-conservative` set is a conservative mitigation for the Openwall Dirty Frag advisory dated May 7, 2026. It expands to two `socket_rules`: one for `AF_RXRPC`, and one for `AF_NETLINK` with protocol `NETLINK_XFRM`. Both rules use `action: log_and_kill`, so matching processes are killed and audit events are emitted. It does not block all `AF_NETLINK`.
 
 ### Socket Rule Audit Event
 

--- a/docs/seccomp.md
+++ b/docs/seccomp.md
@@ -347,7 +347,7 @@ Fields:
 | `family` | yes | `AF_*` name or numeric string |
 | `type` | no | `SOCK_*` name or numeric socket type; flags such as `SOCK_CLOEXEC` are masked out before matching |
 | `protocol` | no | Numeric protocol string, or a named `NETLINK_*` protocol when `family: AF_NETLINK` |
-| `action` | yes | `errno`, `kill`, `log`, or `log_and_kill` |
+| `action` | no | `errno`, `kill`, `log`, or `log_and_kill`; defaults to `errno` when omitted |
 
 Named `NETLINK_*` protocol values are valid only with `family: AF_NETLINK`. A protocol-scoped netlink rule does not block other netlink protocols.
 

--- a/docs/seccomp.md
+++ b/docs/seccomp.md
@@ -47,9 +47,12 @@ sandbox:
       - family: AF_VSOCK
         action: log_and_kill
 
-    # Optional hardening profile for the May 7, 2026 Openwall Dirty Frag advisory.
-    # hardening_profiles:
+    # Advisory mitigation sets. Built-ins are embedded in agentsh; external
+    # directories are optional and only requested IDs are loaded.
+    # mitigation_sets:
     #   - dirtyfrag-conservative
+    # mitigation_dirs:
+    #   - /etc/agentsh/mitigations
 
     # Lower-level socket tuple rules are also available as an alternative.
     # socket_rules:
@@ -351,20 +354,20 @@ Fields:
 
 Named `NETLINK_*` protocol values are valid only with `family: AF_NETLINK`. A protocol-scoped netlink rule does not block other netlink protocols.
 
-### Dirty Frag Conservative Profile
+### Mitigation Sets
 
-`sandbox.seccomp.hardening_profiles` currently supports `dirtyfrag-conservative`, a conservative mitigation for the Openwall Dirty Frag advisory dated May 7, 2026.
+`sandbox.seccomp.mitigation_sets` loads named mitigation YAML files and expands them into ordinary seccomp rules. agentsh ships built-in mitigations and can also load external mitigation files from opt-in `mitigation_dirs`.
 
-The profile expands to these two `socket_rules` entries:
+```yaml
+sandbox:
+  seccomp:
+    mitigation_sets:
+      - dirtyfrag-conservative
+    mitigation_dirs:
+      - /etc/agentsh/mitigations
+```
 
-| Rule | Match | Action |
-|---|---|---|
-| `dirtyfrag-conservative-rxrpc` | `family: AF_RXRPC` only; `type` and `protocol` are intentionally omitted | `log_and_kill` |
-| `dirtyfrag-conservative-xfrm` | `family: AF_NETLINK`, `protocol: NETLINK_XFRM` | `log_and_kill` |
-
-This does **not** block all `AF_NETLINK`. `NETLINK_ROUTE`, `NETLINK_GENERIC`, `NETLINK_AUDIT`, and other netlink protocols remain available unless separately blocked.
-
-Because the profile uses `log_and_kill`, a matching call emits `seccomp_socket_rule_blocked` and kills the offending process.
+The built-in `dirtyfrag-conservative` set is a conservative mitigation for the Openwall Dirty Frag advisory dated May 7, 2026. It expands to two `socket_rules`: one for `AF_RXRPC`, and one for `AF_NETLINK` with protocol `NETLINK_XFRM`. It does not block all `AF_NETLINK`.
 
 ### Socket Rule Audit Event
 

--- a/docs/superpowers/plans/2026-05-08-yaml-mitigation-sets.md
+++ b/docs/superpowers/plans/2026-05-08-yaml-mitigation-sets.md
@@ -1,0 +1,1389 @@
+# YAML Mitigation Sets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace hardcoded advisory profiles with YAML-backed mitigation sets that load only when selected and expand into existing seccomp primitives.
+
+**Architecture:** Add a config-layer mitigation resolver that loads embedded built-in YAML files and optional external YAML files by requested ID. The resolver produces effective seccomp config slices, and existing seccomp, ptrace, wrapper, and notify code consume those effective slices instead of hardcoded `hardening_profiles`.
+
+**Tech Stack:** Go, `gopkg.in/yaml.v3`, `go:embed`, seccomp/libseccomp, ptrace fallback, platform-specific build tags.
+
+---
+
+## File Structure
+
+- Create `internal/config/mitigations/dirtyfrag-conservative.yaml`
+  - Built-in Dirty Frag mitigation data embedded into the binary.
+- Create `internal/config/seccomp_mitigations.go`
+  - Mitigation YAML schema, embedded-file lookup, external-file lookup, strict YAML decode, effective-rule merge helpers, load metadata.
+- Create `internal/config/seccomp_mitigations_unix.go`
+  - Unix permission checks for external mitigation directories and files.
+- Create `internal/config/seccomp_mitigations_other.go`
+  - Non-Unix permission-check stub.
+- Create `internal/config/seccomp_mitigations_test.go`
+  - Resolver, schema, duplicate, external-dir, and syscall merge tests.
+- Modify `internal/config/config.go`
+  - Add `mitigation_sets` and `mitigation_dirs`, keep `hardening_profiles` as deprecated alias, validate effective mitigation-expanded config.
+- Modify `internal/config/seccomp_socket_rules.go`
+  - Remove hardcoded `dirtyfrag-conservative` switch; resolve through mitigation loader.
+- Modify `internal/config/seccomp_socket_rules_test.go`
+  - Rename profile tests to mitigation-set tests and keep one alias coverage test.
+- Modify `internal/api/seccomp_wrapper_config.go`
+  - Forward mitigation-expanded syscall blocks, socket families, and socket rules to the wrapper.
+- Modify `internal/api/blocklist_config_linux.go`
+  - Build notify dispatch maps from mitigation-expanded rules.
+- Modify `internal/api/wrap.go`
+  - Gate user-notify startup from mitigation-expanded syscall/family/socket tuple rules.
+- Modify `internal/api/app_ptrace_linux.go`
+  - Build ptrace family and socket tuple checkers from mitigation-expanded rules.
+- Modify focused API tests in `internal/api/*test.go`
+  - Update `hardening_profiles` expectations to `mitigation_sets`; add effective-rule wiring coverage.
+- Modify `docs/seccomp.md` and `config.yml`
+  - Present `mitigation_sets` and `mitigation_dirs`; stop presenting `hardening_profiles` as the preferred interface.
+
+## Task 1: Config Surface
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Modify: `internal/config/seccomp_socket_rules_test.go`
+
+- [ ] **Step 1: Write failing YAML parse tests**
+
+Add these tests to `internal/config/seccomp_socket_rules_test.go`:
+
+```go
+func TestSandboxSeccompMitigationSets_ParseYAML(t *testing.T) {
+	data := []byte(`
+sandbox:
+  seccomp:
+    mitigation_sets:
+      - dirtyfrag-conservative
+    mitigation_dirs:
+      - /etc/agentsh/mitigations
+`)
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	require.Equal(t, []string{"dirtyfrag-conservative"}, cfg.Sandbox.Seccomp.MitigationSets)
+	require.Equal(t, []string{"/etc/agentsh/mitigations"}, cfg.Sandbox.Seccomp.MitigationDirs)
+}
+
+func TestSandboxSeccompHardeningProfiles_DeprecatedAliasParseYAML(t *testing.T) {
+	data := []byte(`
+sandbox:
+  seccomp:
+    hardening_profiles:
+      - dirtyfrag-conservative
+`)
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	require.Equal(t, []string{"dirtyfrag-conservative"}, cfg.Sandbox.Seccomp.HardeningProfiles)
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+go test ./internal/config -run 'MitigationSets|HardeningProfiles' -count=1
+```
+
+Expected: FAIL because `MitigationSets` and `MitigationDirs` do not exist on `SandboxSeccompConfig`.
+
+- [ ] **Step 3: Add config fields**
+
+In `internal/config/config.go`, update `SandboxSeccompConfig`:
+
+```go
+	BlockedSocketFamilies []SandboxSeccompSocketFamilyConfig `yaml:"blocked_socket_families"`
+	SocketRules           []SandboxSeccompSocketRuleConfig   `yaml:"socket_rules"`
+	MitigationSets        []string                           `yaml:"mitigation_sets"`
+	MitigationDirs        []string                           `yaml:"mitigation_dirs"`
+	// HardeningProfiles is a deprecated alias for MitigationSets. It exists
+	// only so config files written against the Dirty Frag feature branch fail
+	// less abruptly while the public name changes.
+	HardeningProfiles []string `yaml:"hardening_profiles"`
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run:
+
+```bash
+go test ./internal/config -run 'MitigationSets|HardeningProfiles' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/config.go internal/config/seccomp_socket_rules_test.go
+git commit -m "config: add mitigation set fields"
+```
+
+## Task 2: Built-In Mitigation YAML Loader
+
+**Files:**
+- Create: `internal/config/mitigations/dirtyfrag-conservative.yaml`
+- Create: `internal/config/seccomp_mitigations.go`
+- Create: `internal/config/seccomp_mitigations_test.go`
+- Modify: `internal/config/seccomp_socket_rules.go`
+
+- [ ] **Step 1: Add built-in Dirty Frag YAML**
+
+Create `internal/config/mitigations/dirtyfrag-conservative.yaml`:
+
+```yaml
+version: 1
+id: dirtyfrag-conservative
+title: Dirty Frag conservative mitigation
+references:
+  - https://www.openwall.com/lists/oss-security/2026/05/07/8
+
+seccomp:
+  socket_rules:
+    - name: dirtyfrag-conservative-rxrpc
+      family: AF_RXRPC
+      action: log_and_kill
+    - name: dirtyfrag-conservative-xfrm
+      family: AF_NETLINK
+      protocol: NETLINK_XFRM
+      action: log_and_kill
+```
+
+- [ ] **Step 2: Write failing built-in resolver tests**
+
+Create `internal/config/seccomp_mitigations_test.go` with:
+
+```go
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/seccomp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEffectiveSeccompRules_BuiltInDirtyFrag(t *testing.T) {
+	eff, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"dirtyfrag-conservative"},
+	})
+	require.NoError(t, err)
+	require.Len(t, eff.LoadedMitigations, 1)
+	require.Equal(t, "dirtyfrag-conservative", eff.LoadedMitigations[0].ID)
+	require.Equal(t, "builtin", eff.LoadedMitigations[0].Source)
+	require.NotEmpty(t, eff.LoadedMitigations[0].Checksum)
+	require.Len(t, eff.SocketRules, 2)
+	require.Equal(t, "dirtyfrag-conservative-rxrpc", eff.SocketRules[0].Name)
+	require.Equal(t, "AF_RXRPC", eff.SocketRules[0].Family)
+	require.Equal(t, "log_and_kill", eff.SocketRules[0].Action)
+	require.Equal(t, "dirtyfrag-conservative-xfrm", eff.SocketRules[1].Name)
+	require.Equal(t, "AF_NETLINK", eff.SocketRules[1].Family)
+	require.Equal(t, "NETLINK_XFRM", eff.SocketRules[1].Protocol)
+	require.Equal(t, "log_and_kill", eff.SocketRules[1].Action)
+}
+
+func TestResolveSocketRules_BuiltInDirtyFrag(t *testing.T) {
+	rules, err := ResolveSocketRules(SandboxSeccompConfig{
+		MitigationSets: []string{"dirtyfrag-conservative"},
+	})
+	require.NoError(t, err)
+	require.Len(t, rules, 2)
+
+	rxrpcFamily, _, ok := seccomp.ParseFamily("AF_RXRPC")
+	require.True(t, ok)
+	netlinkFamily, _, ok := seccomp.ParseFamily("AF_NETLINK")
+	require.True(t, ok)
+	xfrmProtocol, _, ok := seccomp.ParseSocketProtocol("NETLINK_XFRM")
+	require.True(t, ok)
+
+	require.Equal(t, rxrpcFamily, rules[0].Family)
+	require.Equal(t, seccomp.OnBlockLogAndKill, rules[0].Action)
+	require.Equal(t, netlinkFamily, rules[1].Family)
+	require.NotNil(t, rules[1].Protocol)
+	require.Equal(t, xfrmProtocol, *rules[1].Protocol)
+	require.Equal(t, seccomp.OnBlockLogAndKill, rules[1].Action)
+}
+
+func TestEffectiveSeccompRules_RejectsUnknownMitigationSet(t *testing.T) {
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"dirtyfrag"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `mitigation_sets[0]`)
+	require.Contains(t, err.Error(), "dirtyfrag")
+}
+
+func TestEffectiveSeccompRules_RejectsDuplicateRequestedMitigationSet(t *testing.T) {
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets:    []string{"dirtyfrag-conservative"},
+		HardeningProfiles: []string{"dirtyfrag-conservative"},
+	})
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "duplicate mitigation set"), err.Error())
+}
+```
+
+- [ ] **Step 3: Run tests to verify failure**
+
+Run:
+
+```bash
+go test ./internal/config -run 'EffectiveSeccompRules|ResolveSocketRules_BuiltInDirtyFrag' -count=1
+```
+
+Expected: FAIL because the mitigation resolver does not exist.
+
+- [ ] **Step 4: Implement embedded mitigation loader**
+
+Create `internal/config/seccomp_mitigations.go`:
+
+```go
+package config
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed mitigations/*.yaml
+var builtinMitigationFS embed.FS
+
+var mitigationIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+
+type EffectiveSeccompRules struct {
+	SocketRules           []SandboxSeccompSocketRuleConfig
+	BlockedSocketFamilies []SandboxSeccompSocketFamilyConfig
+	SyscallBlock          []string
+	SyscallOnBlock        string
+	LoadedMitigations    []MitigationLoadInfo
+}
+
+type MitigationLoadInfo struct {
+	ID                    string
+	Source                string
+	Path                  string
+	Checksum              string
+	SocketRules           int
+	BlockedSocketFamilies int
+	Syscalls              int
+}
+
+type mitigationDocument struct {
+	Version    int                `yaml:"version"`
+	ID         string             `yaml:"id"`
+	Title      string             `yaml:"title,omitempty"`
+	References []string           `yaml:"references,omitempty"`
+	Seccomp    mitigationSeccomp  `yaml:"seccomp"`
+}
+
+type mitigationSeccomp struct {
+	SocketRules           []SandboxSeccompSocketRuleConfig   `yaml:"socket_rules"`
+	BlockedSocketFamilies []SandboxSeccompSocketFamilyConfig `yaml:"blocked_socket_families"`
+	Syscalls              mitigationSyscalls                 `yaml:"syscalls"`
+}
+
+type mitigationSyscalls struct {
+	Block   []string `yaml:"block"`
+	OnBlock string   `yaml:"on_block"`
+}
+
+func EffectiveSeccompRulesForConfig(in SandboxSeccompConfig) (EffectiveSeccompRules, error) {
+	out := EffectiveSeccompRules{
+		SocketRules:           append([]SandboxSeccompSocketRuleConfig(nil), in.SocketRules...),
+		BlockedSocketFamilies: append([]SandboxSeccompSocketFamilyConfig(nil), in.BlockedSocketFamilies...),
+		SyscallBlock:          append([]string(nil), in.Syscalls.Block...),
+		SyscallOnBlock:        in.Syscalls.OnBlock,
+	}
+	if out.SyscallOnBlock == "" {
+		out.SyscallOnBlock = "errno"
+	}
+
+	ids, err := requestedMitigationSetIDs(in)
+	if err != nil {
+		return EffectiveSeccompRules{}, err
+	}
+	for i, id := range ids {
+		doc, info, err := loadMitigationSet(id, in.MitigationDirs)
+		if err != nil {
+			return EffectiveSeccompRules{}, fmt.Errorf("mitigation_sets[%d]: %w", i, err)
+		}
+		if doc.Seccomp.Syscalls.OnBlock != "" && doc.Seccomp.Syscalls.OnBlock != out.SyscallOnBlock {
+			return EffectiveSeccompRules{}, fmt.Errorf("mitigation_sets[%d] %q: seccomp.syscalls.on_block %q conflicts with effective sandbox.seccomp.syscalls.on_block %q",
+				i, id, doc.Seccomp.Syscalls.OnBlock, out.SyscallOnBlock)
+		}
+		out.SocketRules = append(out.SocketRules, doc.Seccomp.SocketRules...)
+		out.BlockedSocketFamilies = append(out.BlockedSocketFamilies, doc.Seccomp.BlockedSocketFamilies...)
+		out.SyscallBlock = append(out.SyscallBlock, doc.Seccomp.Syscalls.Block...)
+		out.LoadedMitigations = append(out.LoadedMitigations, info)
+	}
+	return out, nil
+}
+
+func requestedMitigationSetIDs(in SandboxSeccompConfig) ([]string, error) {
+	ids := make([]string, 0, len(in.MitigationSets)+len(in.HardeningProfiles))
+	seen := map[string]struct{}{}
+	for _, source := range []struct {
+		field string
+		vals  []string
+	}{
+		{field: "mitigation_sets", vals: in.MitigationSets},
+		{field: "hardening_profiles", vals: in.HardeningProfiles},
+	} {
+		for i, id := range source.vals {
+			if !mitigationIDPattern.MatchString(id) {
+				return nil, fmt.Errorf("%s[%d]: invalid mitigation set id %q", source.field, i, id)
+			}
+			if _, ok := seen[id]; ok {
+				return nil, fmt.Errorf("duplicate mitigation set %q", id)
+			}
+			seen[id] = struct{}{}
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
+}
+
+func loadMitigationSet(id string, dirs []string) (mitigationDocument, MitigationLoadInfo, error) {
+	builtinData, builtinFound, err := readBuiltinMitigation(id)
+	if err != nil {
+		return mitigationDocument{}, MitigationLoadInfo{}, err
+	}
+	externalData, externalPath, externalFound, err := readExternalMitigation(id, dirs)
+	if err != nil {
+		return mitigationDocument{}, MitigationLoadInfo{}, err
+	}
+	if builtinFound && externalFound {
+		return mitigationDocument{}, MitigationLoadInfo{}, fmt.Errorf("%q exists as both built-in and external mitigation %q", id, externalPath)
+	}
+	if !builtinFound && !externalFound {
+		return mitigationDocument{}, MitigationLoadInfo{}, fmt.Errorf("unknown mitigation set %q", id)
+	}
+
+	source := "builtin"
+	path := mitigationFSPath(id)
+	data := builtinData
+	if externalFound {
+		source = "external"
+		path = externalPath
+		data = externalData
+	}
+	doc, err := decodeMitigation(id, data, path)
+	if err != nil {
+		return mitigationDocument{}, MitigationLoadInfo{}, err
+	}
+	sum := sha256.Sum256(data)
+	info := MitigationLoadInfo{
+		ID:                    id,
+		Source:                source,
+		Path:                  path,
+		Checksum:              "sha256:" + hex.EncodeToString(sum[:]),
+		SocketRules:           len(doc.Seccomp.SocketRules),
+		BlockedSocketFamilies: len(doc.Seccomp.BlockedSocketFamilies),
+		Syscalls:              len(doc.Seccomp.Syscalls.Block),
+	}
+	return doc, info, nil
+}
+
+func readBuiltinMitigation(id string) ([]byte, bool, error) {
+	data, err := builtinMitigationFS.ReadFile(mitigationFSPath(id))
+	if err == nil {
+		return data, true, nil
+	}
+	if errorsIsNotExist(err) {
+		return nil, false, nil
+	}
+	return nil, false, fmt.Errorf("read built-in mitigation %q: %w", id, err)
+}
+
+func readExternalMitigation(id string, dirs []string) ([]byte, string, bool, error) {
+	var foundPath string
+	for _, dir := range dirs {
+		for _, name := range []string{id + ".yaml", id + ".yml"} {
+			candidate := filepath.Join(dir, name)
+			if _, err := os.Stat(candidate); err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				return nil, "", false, fmt.Errorf("stat external mitigation %q: %w", candidate, err)
+			}
+			if foundPath != "" {
+				return nil, "", false, fmt.Errorf("mitigation set %q found in multiple external files: %q and %q", id, foundPath, candidate)
+			}
+			foundPath = candidate
+		}
+	}
+	if foundPath == "" {
+		return nil, "", false, nil
+	}
+	if err := validateMitigationPathPermissions(foundPath); err != nil {
+		return nil, "", false, err
+	}
+	data, err := os.ReadFile(foundPath)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("read external mitigation %q: %w", foundPath, err)
+	}
+	return data, foundPath, true, nil
+}
+
+func decodeMitigation(requestedID string, data []byte, source string) (mitigationDocument, error) {
+	var doc mitigationDocument
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&doc); err != nil {
+		return mitigationDocument{}, fmt.Errorf("parse mitigation %q: %w", source, err)
+	}
+	if doc.Version != 1 {
+		return mitigationDocument{}, fmt.Errorf("mitigation %q: version must be 1", source)
+	}
+	if doc.ID != requestedID {
+		return mitigationDocument{}, fmt.Errorf("mitigation %q: id %q does not match requested id %q", source, doc.ID, requestedID)
+	}
+	if len(doc.Seccomp.SocketRules) == 0 &&
+		len(doc.Seccomp.BlockedSocketFamilies) == 0 &&
+		len(doc.Seccomp.Syscalls.Block) == 0 {
+		return mitigationDocument{}, fmt.Errorf("mitigation %q: empty mitigations are not allowed", source)
+	}
+	return doc, nil
+}
+
+func mitigationFSPath(id string) string {
+	return filepath.ToSlash(filepath.Join("mitigations", id+".yaml"))
+}
+
+func errorsIsNotExist(err error) bool {
+	return os.IsNotExist(err) || errors.Is(err, fs.ErrNotExist)
+}
+```
+
+- [ ] **Step 5: Replace hardcoded socket profile expansion**
+
+In `internal/config/seccomp_socket_rules.go`, change `ResolveSocketRules` and remove `effectiveSocketRuleConfigs`:
+
+```go
+func ResolveSocketRules(in SandboxSeccompConfig) ([]seccomp.SocketRule, error) {
+	effective, err := EffectiveSeccompRulesForConfig(in)
+	if err != nil {
+		return nil, err
+	}
+	return resolveSocketRuleConfigs(effective.SocketRules)
+}
+
+func resolveSocketRuleConfigs(configs []SandboxSeccompSocketRuleConfig) ([]seccomp.SocketRule, error) {
+	out := make([]seccomp.SocketRule, 0, len(configs))
+	seen := map[string]struct{}{}
+	for i, e := range configs {
+		name := strings.TrimSpace(e.Name)
+		if name == "" {
+			return nil, fmt.Errorf("socket_rules[%d].name: required", i)
+		}
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("duplicate socket rule name %q", name)
+		}
+		seen[name] = struct{}{}
+
+		family, familyName, ok := seccomp.ParseFamily(e.Family)
+		if !ok {
+			return nil, fmt.Errorf("socket_rules[%d].family: %q is not valid", i, e.Family)
+		}
+		actionStr := e.Action
+		if actionStr == "" {
+			actionStr = string(seccomp.OnBlockErrno)
+		}
+		action, ok := seccomp.ParseOnBlock(actionStr)
+		if !ok {
+			return nil, fmt.Errorf("socket_rules[%d].action: %q is not valid (allowed: errno, kill, log, log_and_kill)", i, e.Action)
+		}
+		rule := seccomp.SocketRule{Name: name, Family: family, FamilyName: familyName, Action: action}
+		if e.Type != "" {
+			typ, typName, ok := seccomp.ParseSocketType(e.Type)
+			if !ok {
+				return nil, fmt.Errorf("socket_rules[%d].type: %q is not valid", i, e.Type)
+			}
+			rule.Type = &typ
+			rule.TypeName = typName
+		}
+		if e.Protocol != "" {
+			proto, protoName, ok := seccomp.ParseSocketProtocol(e.Protocol)
+			if !ok {
+				return nil, fmt.Errorf("socket_rules[%d].protocol: %q is not valid", i, e.Protocol)
+			}
+			if strings.HasPrefix(protoName, "NETLINK_") && family != afNetlinkFamily {
+				return nil, fmt.Errorf("socket_rules[%d].protocol: %q requires family AF_NETLINK", i, e.Protocol)
+			}
+			rule.Protocol = &proto
+			rule.ProtocolName = protoName
+		}
+		out = append(out, rule)
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 6: Run tests to verify pass**
+
+Run:
+
+```bash
+go test ./internal/config -run 'EffectiveSeccompRules|ResolveSocketRules_BuiltInDirtyFrag' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/config/mitigations/dirtyfrag-conservative.yaml internal/config/seccomp_mitigations.go internal/config/seccomp_mitigations_test.go internal/config/seccomp_socket_rules.go
+git commit -m "config: load built-in YAML mitigation sets"
+```
+
+## Task 3: External Mitigation Directories and Guardrails
+
+**Files:**
+- Create: `internal/config/seccomp_mitigations_unix.go`
+- Create: `internal/config/seccomp_mitigations_other.go`
+- Modify: `internal/config/seccomp_mitigations_test.go`
+
+- [ ] **Step 1: Add failing external mitigation tests**
+
+Append to `internal/config/seccomp_mitigations_test.go`:
+
+```go
+func TestEffectiveSeccompRules_ExternalMitigation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "local-xfrm.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+version: 1
+id: local-xfrm
+seccomp:
+  socket_rules:
+    - name: local-xfrm
+      family: AF_NETLINK
+      protocol: NETLINK_XFRM
+      action: log
+`), 0o600))
+
+	eff, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"local-xfrm"},
+		MitigationDirs: []string{dir},
+	})
+	require.NoError(t, err)
+	require.Len(t, eff.SocketRules, 1)
+	require.Equal(t, "local-xfrm", eff.SocketRules[0].Name)
+	require.Len(t, eff.LoadedMitigations, 1)
+	require.Equal(t, "external", eff.LoadedMitigations[0].Source)
+	require.Equal(t, path, eff.LoadedMitigations[0].Path)
+}
+
+func TestEffectiveSeccompRules_RejectsInvalidMitigationID(t *testing.T) {
+	for _, id := range []string{"../dirtyfrag", "/dirtyfrag", "DirtyFrag", ""} {
+		t.Run(id, func(t *testing.T) {
+			_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+				MitigationSets: []string{id},
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid mitigation set id")
+		})
+	}
+}
+
+func TestEffectiveSeccompRules_RejectsUnknownYAMLFields(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte(`
+version: 1
+id: bad
+unexpected: true
+seccomp:
+  socket_rules:
+    - name: bad
+      family: AF_RXRPC
+`), 0o600))
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"bad"},
+		MitigationDirs: []string{dir},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "field unexpected not found")
+}
+
+func TestEffectiveSeccompRules_RejectsMismatchedYAMLID(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "wanted.yaml"), []byte(`
+version: 1
+id: other
+seccomp:
+  socket_rules:
+    - name: other
+      family: AF_RXRPC
+`), 0o600))
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"wanted"},
+		MitigationDirs: []string{dir},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `id "other" does not match requested id "wanted"`)
+}
+
+func TestEffectiveSeccompRules_RejectsEmptyMitigation(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty.yaml"), []byte(`
+version: 1
+id: empty
+seccomp: {}
+`), 0o600))
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"empty"},
+		MitigationDirs: []string{dir},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty mitigations are not allowed")
+}
+
+func TestEffectiveSeccompRules_RejectsBuiltInExternalDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dirtyfrag-conservative.yaml"), []byte(`
+version: 1
+id: dirtyfrag-conservative
+seccomp:
+  socket_rules:
+    - name: replacement
+      family: AF_RXRPC
+`), 0o600))
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"dirtyfrag-conservative"},
+		MitigationDirs: []string{dir},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exists as both built-in and external")
+}
+```
+
+Update the test imports:
+
+```go
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+```
+
+- [ ] **Step 2: Add failing Unix permission test**
+
+Append to `internal/config/seccomp_mitigations_test.go`:
+
+```go
+func TestEffectiveSeccompRules_RejectsWorldWritableExternalFileOnUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix mode bits are not portable to Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "unsafe.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+version: 1
+id: unsafe
+seccomp:
+  socket_rules:
+    - name: unsafe
+      family: AF_RXRPC
+`), 0o666))
+	require.NoError(t, os.Chmod(path, 0o666))
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"unsafe"},
+		MitigationDirs: []string{dir},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "world-writable")
+}
+```
+
+- [ ] **Step 3: Run tests to verify failure**
+
+Run:
+
+```bash
+go test ./internal/config -run 'EffectiveSeccompRules_External|EffectiveSeccompRules_Rejects' -count=1
+```
+
+Expected: FAIL until permission helpers and all guardrails are wired correctly.
+
+- [ ] **Step 4: Add Unix permission helper**
+
+Create `internal/config/seccomp_mitigations_unix.go`:
+
+```go
+//go:build linux || darwin
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func validateMitigationPathPermissions(filePath string) error {
+	dir := filepath.Dir(filePath)
+	for _, path := range []string{dir, filePath} {
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("stat mitigation path %q: %w", path, err)
+		}
+		if info.Mode().Perm()&0o002 != 0 {
+			return fmt.Errorf("mitigation path %q is world-writable", path)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Add non-Unix permission helper**
+
+Create `internal/config/seccomp_mitigations_other.go`:
+
+```go
+//go:build !linux && !darwin
+
+package config
+
+func validateMitigationPathPermissions(filePath string) error {
+	return nil
+}
+```
+
+- [ ] **Step 6: Fix loader imports and behavior**
+
+Ensure `internal/config/seccomp_mitigations.go` imports `errors` and uses only `filepath.Join` for filesystem paths:
+
+```go
+import (
+	"bytes"
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"gopkg.in/yaml.v3"
+)
+```
+
+Verify `readExternalMitigation` checks both `.yaml` and `.yml`, rejects duplicate external files, validates permissions before reading, and never lists the directory.
+
+- [ ] **Step 7: Run tests to verify pass**
+
+Run:
+
+```bash
+go test ./internal/config -run 'EffectiveSeccompRules_External|EffectiveSeccompRules_Rejects' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/config/seccomp_mitigations.go internal/config/seccomp_mitigations_unix.go internal/config/seccomp_mitigations_other.go internal/config/seccomp_mitigations_test.go
+git commit -m "config: support external mitigation directories"
+```
+
+## Task 4: Effective Seccomp Merge Helpers
+
+**Files:**
+- Modify: `internal/config/seccomp_mitigations.go`
+- Modify: `internal/config/seccomp_mitigations_test.go`
+- Modify: `internal/config/seccomp_socket_rules_test.go`
+- Modify: `internal/config/config.go`
+
+- [ ] **Step 1: Add failing merge tests**
+
+Append to `internal/config/seccomp_mitigations_test.go`:
+
+```go
+func TestEffectiveSeccompRules_MergesExternalFamiliesAndSyscalls(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "mixed.yaml"), []byte(`
+version: 1
+id: mixed
+seccomp:
+  blocked_socket_families:
+    - family: AF_ALG
+      action: log
+  syscalls:
+    block:
+      - ptrace
+    on_block: log
+`), 0o600))
+
+	eff, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"mixed"},
+		MitigationDirs: []string{dir},
+		Syscalls: SandboxSeccompSyscallConfig{
+			Block:   []string{"mount"},
+			OnBlock: "log",
+		},
+		BlockedSocketFamilies: []SandboxSeccompSocketFamilyConfig{{
+			Family: "AF_VSOCK",
+			Action: "errno",
+		}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"mount", "ptrace"}, eff.SyscallBlock)
+	require.Equal(t, "log", eff.SyscallOnBlock)
+	require.Len(t, eff.BlockedSocketFamilies, 2)
+	require.Equal(t, "AF_VSOCK", eff.BlockedSocketFamilies[0].Family)
+	require.Equal(t, "AF_ALG", eff.BlockedSocketFamilies[1].Family)
+}
+
+func TestEffectiveSeccompRules_RejectsSyscallOnBlockConflict(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "conflict.yaml"), []byte(`
+version: 1
+id: conflict
+seccomp:
+  syscalls:
+    block:
+      - ptrace
+    on_block: log_and_kill
+`), 0o600))
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"conflict"},
+		MitigationDirs: []string{dir},
+		Syscalls: SandboxSeccompSyscallConfig{
+			OnBlock: "errno",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "conflicts with effective sandbox.seccomp.syscalls.on_block")
+}
+
+func TestResolveEffectiveBlockedFamilies_MitigationSet(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "family.yaml"), []byte(`
+version: 1
+id: family
+seccomp:
+  blocked_socket_families:
+    - family: AF_ALG
+      action: log
+`), 0o600))
+
+	families, err := ResolveEffectiveBlockedFamilies(SandboxSeccompConfig{
+		MitigationSets: []string{"family"},
+		MitigationDirs: []string{dir},
+	})
+	require.NoError(t, err)
+	require.Len(t, families, 1)
+	require.Equal(t, "AF_ALG", families[0].Name)
+	require.Equal(t, seccomp.OnBlockLog, families[0].Action)
+}
+
+func TestEffectiveSyscallBlock_MitigationSet(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "syscalls.yaml"), []byte(`
+version: 1
+id: syscalls
+seccomp:
+  syscalls:
+    block:
+      - ptrace
+`), 0o600))
+
+	block, action, err := EffectiveSyscallBlock(SandboxSeccompConfig{
+		MitigationSets: []string{"syscalls"},
+		MitigationDirs: []string{dir},
+		Syscalls: SandboxSeccompSyscallConfig{
+			Block:   []string{"mount"},
+			OnBlock: "errno",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"mount", "ptrace"}, block)
+	require.Equal(t, "errno", action)
+}
+```
+
+- [ ] **Step 2: Update stale hardening profile tests**
+
+In `internal/config/seccomp_socket_rules_test.go`, replace the old `TestResolveSocketRules_DirtyFragProfile` with a `MitigationSets` version. Keep the alias test explicit:
+
+```go
+func TestResolveSocketRules_DirtyFragMitigationSet(t *testing.T) {
+	cfg := SandboxSeccompConfig{
+		MitigationSets: []string{"dirtyfrag-conservative"},
+	}
+	rules, err := ResolveSocketRules(cfg)
+	require.NoError(t, err)
+	require.Len(t, rules, 2)
+	require.Equal(t, "dirtyfrag-conservative-rxrpc", rules[0].Name)
+	require.Equal(t, "dirtyfrag-conservative-xfrm", rules[1].Name)
+}
+
+func TestResolveSocketRules_HardeningProfilesDeprecatedAlias(t *testing.T) {
+	cfg := SandboxSeccompConfig{
+		HardeningProfiles: []string{"dirtyfrag-conservative"},
+	}
+	rules, err := ResolveSocketRules(cfg)
+	require.NoError(t, err)
+	require.Len(t, rules, 2)
+	require.Equal(t, "dirtyfrag-conservative-rxrpc", rules[0].Name)
+	require.Equal(t, "dirtyfrag-conservative-xfrm", rules[1].Name)
+}
+```
+
+Update unknown-profile and duplicate-name tests to use `MitigationSets` and expect `mitigation_sets[0]` in errors.
+
+- [ ] **Step 3: Run tests to verify failure**
+
+Run:
+
+```bash
+go test ./internal/config -run 'EffectiveSeccompRules_Merges|EffectiveSyscallBlock|ResolveEffectiveBlockedFamilies|DirtyFragMitigationSet|HardeningProfilesDeprecatedAlias' -count=1
+```
+
+Expected: FAIL because effective helper functions are missing.
+
+- [ ] **Step 4: Add effective helper functions**
+
+In `internal/config/seccomp_mitigations.go`, add:
+
+```go
+func ResolveEffectiveBlockedFamilies(in SandboxSeccompConfig) ([]seccomp.BlockedFamily, error) {
+	effective, err := EffectiveSeccompRulesForConfig(in)
+	if err != nil {
+		return nil, err
+	}
+	return ResolveBlockedFamilies(effective.BlockedSocketFamilies)
+}
+
+func EffectiveSyscallBlock(in SandboxSeccompConfig) ([]string, string, error) {
+	effective, err := EffectiveSeccompRulesForConfig(in)
+	if err != nil {
+		return nil, "", err
+	}
+	return effective.SyscallBlock, effective.SyscallOnBlock, nil
+}
+```
+
+Add the seccomp import:
+
+```go
+	"github.com/agentsh/agentsh/internal/seccomp"
+```
+
+- [ ] **Step 5: Validate effective config in config validation**
+
+In `internal/config/config.go`, replace the direct socket-rule validation block at the end of `validateConfig` with effective validation:
+
+```go
+	effective, err := EffectiveSeccompRulesForConfig(cfg.Sandbox.Seccomp)
+	if err != nil {
+		return fmt.Errorf("sandbox.seccomp.%w", err)
+	}
+	if _, err := ResolveBlockedFamilies(effective.BlockedSocketFamilies); err != nil {
+		return fmt.Errorf("sandbox.seccomp.%w", err)
+	}
+	if _, err := resolveSocketRuleConfigs(effective.SocketRules); err != nil {
+		return fmt.Errorf("sandbox.seccomp.%w", err)
+	}
+	for _, loaded := range effective.LoadedMitigations {
+		slog.Info("seccomp mitigation loaded",
+			"id", loaded.ID,
+			"source", loaded.Source,
+			"path", loaded.Path,
+			"checksum", loaded.Checksum,
+			"socket_rules", loaded.SocketRules,
+			"blocked_socket_families", loaded.BlockedSocketFamilies,
+			"syscalls", loaded.Syscalls)
+	}
+```
+
+Leave the existing raw `blocked_socket_families` validation in place before this block. The effective `ResolveBlockedFamilies` call is the additional validation that covers mitigation-derived families.
+
+- [ ] **Step 6: Run tests to verify pass**
+
+Run:
+
+```bash
+go test ./internal/config -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/config/config.go internal/config/seccomp_mitigations.go internal/config/seccomp_mitigations_test.go internal/config/seccomp_socket_rules.go internal/config/seccomp_socket_rules_test.go
+git commit -m "config: merge mitigation sets into effective seccomp rules"
+```
+
+## Task 5: Runtime Wiring
+
+**Files:**
+- Modify: `internal/api/seccomp_wrapper_config.go`
+- Modify: `internal/api/blocklist_config_linux.go`
+- Modify: `internal/api/wrap.go`
+- Modify: `internal/api/app_ptrace_linux.go`
+- Modify: `internal/api/blocklist_config_linux_test.go`
+- Modify: `internal/api/socket_rule_checker_ptrace_linux_test.go`
+- Modify: `internal/api/wrap_test.go`
+
+- [ ] **Step 1: Add failing API tests for mitigation-set wiring**
+
+Update existing Dirty Frag API tests that set `HardeningProfiles` to use:
+
+```go
+cfg.Sandbox.Seccomp.MitigationSets = []string{"dirtyfrag-conservative"}
+```
+
+Add this wrapper config test to `internal/api/wrap_test.go` near the socket-rule wrapper tests:
+
+```go
+func TestWrapInit_SeccompConfigContent_MitigationSetsForwardSocketRules(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.Seccomp.MitigationSets = []string{"dirtyfrag-conservative"}
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, _, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.SeccompConfig == "" {
+		t.Fatal("expected seccomp config")
+	}
+
+	var parsed seccompWrapperConfig
+	require.NoError(t, json.Unmarshal([]byte(resp.SeccompConfig), &parsed))
+	require.Len(t, parsed.SocketRules, 2)
+	require.Equal(t, "dirtyfrag-conservative-rxrpc", parsed.SocketRules[0].Name)
+	require.Equal(t, "dirtyfrag-conservative-xfrm", parsed.SocketRules[1].Name)
+}
+```
+
+- [ ] **Step 2: Run API tests to verify failure**
+
+Run:
+
+```bash
+go test ./internal/api -run 'MitigationSets|DirtyFrag|SocketRuleChecker|SeccompConfigContent' -count=1
+```
+
+Expected: FAIL where runtime code still reads raw `BlockedSocketFamilies` or `Syscalls.Block`.
+
+- [ ] **Step 3: Update wrapper config construction**
+
+In `internal/api/seccomp_wrapper_config.go`, change the initial syscall fields:
+
+```go
+	blockedSyscalls, onBlock, err := config.EffectiveSyscallBlock(a.cfg.Sandbox.Seccomp)
+	if err != nil {
+		slog.Warn("seccomp: failed to resolve effective syscall block list; syscall rules will not be blocked", "error", err)
+	}
+	seccompCfg := seccompWrapperConfig{
+		UnixSocketEnabled:   p.UnixSocketEnabled,
+		SignalFilterEnabled: p.SignalFilterEnabled,
+		ExecveEnabled:       p.ExecveEnabled,
+		FileMonitorEnabled:  config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.Enabled, false),
+		BlockedSyscalls:     blockedSyscalls,
+		OnBlock:             onBlock,
+		ServerPID:           os.Getpid(),
+	}
+```
+
+Replace family resolution:
+
+```go
+	families, err := config.ResolveEffectiveBlockedFamilies(a.cfg.Sandbox.Seccomp)
+	if err != nil {
+		slog.Warn("seccomp: failed to resolve blocked_socket_families; families will not be blocked", "error", err)
+	} else {
+		seccompCfg.BlockedFamilies = families
+	}
+```
+
+Keep `ResolveSocketRules(a.cfg.Sandbox.Seccomp)` for socket tuple rules because it now resolves mitigation sets.
+
+- [ ] **Step 4: Update notify blocklist config**
+
+In `internal/api/blocklist_config_linux.go`, replace raw syscall and family reads:
+
+```go
+	block, onBlock, err := config.EffectiveSyscallBlock(a.cfg.Sandbox.Seccomp)
+	if err != nil {
+		slog.Warn("blocklist: failed to resolve effective syscall block list",
+			"session_id", sessionID, "error", err)
+	} else if action, ok := seccompkg.ParseOnBlock(onBlock); ok && (action == seccompkg.OnBlockLog || action == seccompkg.OnBlockLogAndKill) {
+		nrs, skipped := seccompkg.ResolveSyscalls(block)
+		if len(skipped) > 0 {
+			slog.Warn("blocklist: some syscalls could not be resolved on this arch",
+				"session_id", sessionID, "skipped", skipped, "arch", runtime.GOARCH)
+		}
+		cfg.ActionByNr = make(map[uint32]seccompkg.OnBlockAction, len(nrs))
+		for _, nr := range nrs {
+			cfg.ActionByNr[uint32(nr)] = action
+		}
+	}
+
+	families, err := config.ResolveEffectiveBlockedFamilies(a.cfg.Sandbox.Seccomp)
+	if err != nil {
+		slog.Warn("blocklist: failed to resolve blocked_socket_families for notify dispatch",
+			"session_id", sessionID, "error", err)
+	} else {
+		for _, bf := range families {
+			if bf.Action != seccompkg.OnBlockLog && bf.Action != seccompkg.OnBlockLogAndKill {
+				continue
+			}
+			if cfg.FamilyByKey == nil {
+				cfg.FamilyByKey = make(map[uint64]seccompkg.BlockedFamily)
+			}
+			cfg.FamilyByKey[uint64(unix.SYS_SOCKET)<<32|uint64(bf.Family)] = bf
+			cfg.FamilyByKey[uint64(unix.SYS_SOCKETPAIR)<<32|uint64(bf.Family)] = bf
+		}
+	}
+```
+
+- [ ] **Step 5: Update user-notify gating**
+
+In `internal/api/wrap.go`, change `mainFilterUsesUserNotify`:
+
+```go
+	block, onBlock, err := config.EffectiveSyscallBlock(a.cfg.Sandbox.Seccomp)
+	if err == nil && blockListUsesNotify(block, onBlock) {
+		return true
+	}
+	if blockedFamiliesUseNotifyForSeccomp(a.cfg.Sandbox.Seccomp) {
+		return true
+	}
+	if seccompSocketRulesUseNotify(a.cfg.Sandbox.Seccomp) {
+		return true
+	}
+```
+
+Add a helper near `blockedFamiliesUsesNotify`:
+
+```go
+func blockedFamiliesUseNotifyForSeccomp(seccompCfg config.SandboxSeccompConfig) bool {
+	families, err := config.ResolveEffectiveBlockedFamilies(seccompCfg)
+	if err != nil {
+		slog.Warn("seccomp: failed to resolve blocked_socket_families; socket family rules will not use user notify", "error", err)
+		return false
+	}
+	for _, f := range families {
+		if f.Action == seccomppkg.OnBlockLog || f.Action == seccomppkg.OnBlockLogAndKill {
+			return true
+		}
+	}
+	return false
+}
+```
+
+Keep `blockedFamiliesUsesNotify` only if existing tests still use it directly; otherwise remove it after updating tests.
+
+- [ ] **Step 6: Update ptrace family resolution**
+
+In `internal/api/app_ptrace_linux.go`, replace direct family calls:
+
+```go
+func resolveFamilyCheckerForPtrace(cfg *config.Config, emit ptrace.FamilyEmitter) (*ptrace.FamilyChecker, error) {
+	families, err := config.ResolveEffectiveBlockedFamilies(cfg.Sandbox.Seccomp)
+	if err != nil {
+		return nil, err
+	}
+	if len(families) == 0 {
+		return nil, nil
+	}
+	return ptrace.NewFamilyCheckerWithEmitter(families, emit), nil
+}
+```
+
+Update log-count and orphan-warning paths to use `ResolveEffectiveBlockedFamilies`. Keep `ResolveSocketRules` for tuple rules because it now resolves mitigation sets.
+
+- [ ] **Step 7: Run API tests to verify pass**
+
+Run:
+
+```bash
+go test ./internal/api -run 'MitigationSets|DirtyFrag|SocketRuleChecker|SeccompConfigContent|mainFilterUsesUserNotify|BlockListConfig' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/api/seccomp_wrapper_config.go internal/api/blocklist_config_linux.go internal/api/wrap.go internal/api/app_ptrace_linux.go internal/api/*test.go
+git commit -m "api: apply mitigation sets to runtime seccomp wiring"
+```
+
+## Task 6: Docs and Example Config
+
+**Files:**
+- Modify: `docs/seccomp.md`
+- Modify: `config.yml`
+- Modify: any tests or comments found by `rg "hardening_profiles|dirtyfrag-conservative"`
+
+- [ ] **Step 1: Update docs and config examples**
+
+In `docs/seccomp.md`, replace the Dirty Frag section with:
+
+````markdown
+### Mitigation Sets
+
+`sandbox.seccomp.mitigation_sets` loads named mitigation YAML files and expands them into ordinary seccomp rules. agentsh ships built-in mitigations and can also load external mitigation files from opt-in `mitigation_dirs`.
+
+```yaml
+sandbox:
+  seccomp:
+    mitigation_sets:
+      - dirtyfrag-conservative
+    mitigation_dirs:
+      - /etc/agentsh/mitigations
+```
+
+The built-in `dirtyfrag-conservative` set is a conservative mitigation for the Openwall Dirty Frag advisory dated May 7, 2026. It expands to two `socket_rules`: one for `AF_RXRPC`, and one for `AF_NETLINK` with protocol `NETLINK_XFRM`. It does not block all `AF_NETLINK`.
+````
+
+In `config.yml`, replace the commented `hardening_profiles` example:
+
+```yaml
+    # Advisory mitigation sets. Built-ins are embedded in agentsh; external
+    # directories are optional and only requested IDs are loaded.
+    # mitigation_sets:
+    #   - dirtyfrag-conservative
+    # mitigation_dirs:
+    #   - /etc/agentsh/mitigations
+```
+
+- [ ] **Step 2: Search for stale public wording**
+
+Run:
+
+```bash
+rg -n "hardening_profiles|hardening profile|Dirty Frag" docs config.yml internal
+```
+
+Expected: no public docs prefer `hardening_profiles`. Remaining `hardening_profiles` hits should be code comments or alias tests that explicitly call it deprecated.
+
+- [ ] **Step 3: Run focused docs/config tests**
+
+Run:
+
+```bash
+go test ./internal/config ./internal/api -run 'MitigationSets|HardeningProfiles|DirtyFrag|SeccompConfigContent' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/seccomp.md config.yml internal
+git commit -m "docs: document YAML mitigation sets"
+```
+
+## Task 7: Final Verification
+
+**Files:**
+- No planned edits.
+
+- [ ] **Step 1: Run focused config and enforcement tests**
+
+Run:
+
+```bash
+go test ./internal/config ./internal/api ./internal/netmonitor/unix ./internal/ptrace -run 'MitigationSets|HardeningProfiles|DirtyFrag|SocketRule|SocketRules|BlockListConfig|mainFilterUsesUserNotify|FamilyChecker' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run Dirty Frag subprocess regression tests**
+
+Run:
+
+```bash
+GOMAXPROCS=1 go test ./internal/netmonitor/unix -run 'TestDirtyFrag|TestSeccompSocketRuleBlock_Notify_LogDispatched|TestSeccompSocketRuleBlock_ErrnoTuple' -count=1 -timeout=60s -v
+```
+
+Expected: PASS. The `NETLINK_ROUTE` test must still avoid `seccomp_socket_rule_blocked`.
+
+- [ ] **Step 3: Run full repository tests**
+
+Run:
+
+```bash
+go test ./... -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run required Windows compilation check**
+
+Run:
+
+```bash
+GOOS=windows go build ./...
+```
+
+Expected: exit 0.
+
+- [ ] **Step 5: Check formatting and diff hygiene**
+
+Run:
+
+```bash
+gofmt -w internal/config internal/api
+git diff --check
+git status --short
+```
+
+Expected: `git diff --check` exits 0. `git status --short` shows only intentional tracked changes plus any pre-existing untracked `.agentsh/` directory.
+
+- [ ] **Step 6: Commit verification fixes if needed**
+
+If verification required fixes, commit only those fixes:
+
+```bash
+git add <fixed-files>
+git commit -m "fix: stabilize YAML mitigation set wiring"
+```
+
+Expected: no commit is made when verification does not require file changes.

--- a/docs/superpowers/specs/2026-05-08-yaml-mitigation-sets-design.md
+++ b/docs/superpowers/specs/2026-05-08-yaml-mitigation-sets-design.md
@@ -77,6 +77,8 @@ The first version supports:
 
 Unknown YAML fields are errors. Empty mitigation files are errors because they create a false sense of protection.
 
+The existing syscall block primitive has one `on_block` action for the whole effective syscall block list. A mitigation that adds `seccomp.syscalls.block` can omit `on_block` to use the effective `sandbox.seccomp.syscalls.on_block`, or can set `on_block` only when it matches that effective action. A mismatch is a config error. Per-syscall actions are out of scope for v1.
+
 ## File Resolution
 
 Mitigation IDs must match:
@@ -120,7 +122,7 @@ User-authored rules and selected mitigations are merged into one effective secco
 3. Final duplicate rule names are rejected.
 4. For seccomp install ordering, narrow `socket_rules` continue to install before broad socket family rules.
 
-There is no implicit action override in v1. Mitigation files choose their own actions. Users who need a different action can copy the YAML into an external directory under a new ID and select that ID.
+There is no implicit action override in v1. Mitigation files choose their own actions for primitives that already carry per-rule actions, such as `socket_rules` and `blocked_socket_families`. Syscall blocks use the single existing effective `syscalls.on_block` action. Users who need a different mitigation action can copy the YAML into an external directory under a new ID and select that ID.
 
 ## Observability
 

--- a/docs/superpowers/specs/2026-05-08-yaml-mitigation-sets-design.md
+++ b/docs/superpowers/specs/2026-05-08-yaml-mitigation-sets-design.md
@@ -1,0 +1,196 @@
+# YAML Mitigation Sets Design
+
+## Problem
+
+The Dirty Frag work adds the right low-level primitive for advisory response: protocol-aware `socket_rules` that can block narrow `socket(2)` and `socketpair(2)` tuples. The current `hardening_profiles` implementation does not scale because each advisory becomes another hardcoded Go `switch` case.
+
+agentsh needs a generic way to ship and load advisory mitigations while still letting users write explicit low-level rules. The mitigation mechanism should avoid parsing every shipped advisory on startup and should not force users to overblock broad resources such as all `AF_NETLINK` when a narrow protocol rule is enough.
+
+## Goals
+
+- Represent advisory mitigations as YAML files that expand into existing generic seccomp config primitives.
+- Load only the requested mitigation YAML files.
+- Keep low-level `socket_rules` as the enforcement primitive for Dirty Frag and similar socket-family/protocol mitigations.
+- Support built-in mitigations shipped with agentsh as embedded YAML files and optional external mitigation directories for emergency or private rules.
+- Treat external mitigation files as trusted local admin config with guardrails.
+- Fail closed when a requested mitigation cannot be loaded or validated.
+- Preserve the conservative Dirty Frag behavior: block `AF_RXRPC` and `AF_NETLINK` protocol `NETLINK_XFRM`, not all `AF_NETLINK`.
+
+## Non-Goals
+
+- No remote mitigation feed or automatic network update mechanism.
+- No signature enforcement in the first version.
+- No new seccomp enforcement behavior beyond expanding YAML into the same typed rules users can already configure.
+- No bulk loading or scanning of every mitigation file to discover available advisories at runtime.
+
+## User Configuration
+
+Replace the advisory-specific `hardening_profiles` field with generic mitigation sets:
+
+```yaml
+sandbox:
+  seccomp:
+    mitigation_sets:
+      - dirtyfrag-conservative
+
+    mitigation_dirs:
+      - /etc/agentsh/mitigations
+```
+
+`mitigation_sets` contains requested mitigation IDs. agentsh resolves each ID to one YAML file and loads only those files.
+
+`mitigation_dirs` is optional. When omitted, only built-in mitigations are available. External files are trusted local admin config, but they must pass permission checks, schema validation, and semantic rule validation.
+
+For compatibility inside the current branch, `hardening_profiles` can remain as a deprecated alias for `mitigation_sets`. Because this branch has not shipped, the preferred implementation is to rename the public docs and examples to `mitigation_sets` before merge.
+
+## Mitigation YAML Format
+
+Each mitigation file describes one mitigation set:
+
+```yaml
+version: 1
+id: dirtyfrag-conservative
+title: Dirty Frag conservative mitigation
+references:
+  - https://www.openwall.com/lists/oss-security/2026/05/07/8
+
+seccomp:
+  socket_rules:
+    - name: dirtyfrag-conservative-rxrpc
+      family: AF_RXRPC
+      action: log_and_kill
+    - name: dirtyfrag-conservative-xfrm
+      family: AF_NETLINK
+      protocol: NETLINK_XFRM
+      action: log_and_kill
+```
+
+The first version supports:
+
+- `version`: required, currently `1`.
+- `id`: required, must match the requested mitigation ID and the filename stem.
+- `title`: optional human-readable description.
+- `references`: optional list of advisory or vendor URLs.
+- `seccomp.socket_rules`: optional list using the same schema as `sandbox.seccomp.socket_rules`.
+- `seccomp.blocked_socket_families`: optional list using the same schema as `sandbox.seccomp.blocked_socket_families`.
+- `seccomp.syscalls.block` and `seccomp.syscalls.on_block`: optional syscall blocking rules using the existing syscall block schema.
+
+Unknown YAML fields are errors. Empty mitigation files are errors because they create a false sense of protection.
+
+## File Resolution
+
+Mitigation IDs must match:
+
+```text
+^[a-z0-9][a-z0-9._-]*$
+```
+
+This keeps lookup path-safe and avoids directory traversal. A requested ID maps to `<id>.yaml`, with `<id>.yml` accepted only as a fallback for external directories.
+
+Lookup order:
+
+1. Built-in mitigation file embedded in the agentsh binary with `go:embed`.
+2. External `mitigation_dirs`, in configured order, only when no built-in with that ID exists.
+
+External files do not override built-ins by default. If a requested ID exists as both a built-in file and an external file, v1 rejects the config as an ambiguous duplicate. A later explicit override option can be added if operators need to replace a built-in mitigation.
+
+The built-in YAML files live in the repo, for example under `internal/config/mitigations/*.yaml`, and are embedded into the binary. The loader does not parse every embedded YAML file during normal config load. It constructs candidate filenames from each requested ID and reads only those requested files from the embedded filesystem and configured external directories. External lookup uses `stat`/read only for the requested candidate filenames; it does not enumerate the full directory.
+
+## Validation
+
+The resolver validates in layers:
+
+1. Validate the requested mitigation ID before constructing paths.
+2. Locate exactly one mitigation file.
+3. For external files, reject world-writable directories and world-writable files.
+4. Decode YAML with strict field checking.
+5. Require `version: 1` and matching `id`.
+6. Expand the mitigation into existing config structs.
+7. Run the same semantic validators used for user-authored `socket_rules`, `blocked_socket_families`, and syscall blocks.
+8. Reject duplicate final rule names across user config and all selected mitigations.
+
+If any selected mitigation fails validation, config load fails. agentsh should not silently continue without a requested security mitigation.
+
+## Merge Semantics
+
+User-authored rules and selected mitigations are merged into one effective seccomp configuration:
+
+1. User-authored `socket_rules`, `blocked_socket_families`, and syscall block entries remain supported.
+2. Selected mitigation rules are appended in the order listed in `mitigation_sets`.
+3. Final duplicate rule names are rejected.
+4. For seccomp install ordering, narrow `socket_rules` continue to install before broad socket family rules.
+
+There is no implicit action override in v1. Mitigation files choose their own actions. Users who need a different action can copy the YAML into an external directory under a new ID and select that ID.
+
+## Observability
+
+When agentsh loads a mitigation file, it logs:
+
+- mitigation ID
+- source: built-in or external path
+- SHA-256 checksum of the YAML bytes
+- expanded rule counts by rule type
+
+Audit events emitted by enforcement keep the existing rule-level fields such as `rule_name`, `family`, `protocol`, and `action`. For mitigation-derived rules, the rule name should be stable and advisory-specific, such as `dirtyfrag-conservative-xfrm`.
+
+## Security Model
+
+External mitigation YAMLs are trusted local admin config. The first version does not require signatures because operators who can write these files can already change agentsh's local policy. The guardrails are strict schema validation, existing semantic validation, permission checks, explicit opt-in directories, and fail-closed loading.
+
+Signature enforcement can be added later as a separate trust policy:
+
+```yaml
+sandbox:
+  seccomp:
+    mitigation_trust:
+      require_signatures: true
+      trusted_keys:
+        - /etc/agentsh/mitigation-pubkey.pem
+```
+
+The v1 schema leaves room for that extension without baking signature logic into mitigation expansion.
+
+## Dirty Frag Built-In
+
+The current hardcoded `dirtyfrag-conservative` profile becomes a built-in YAML mitigation file:
+
+```yaml
+version: 1
+id: dirtyfrag-conservative
+title: Dirty Frag conservative mitigation
+references:
+  - https://www.openwall.com/lists/oss-security/2026/05/07/8
+
+seccomp:
+  socket_rules:
+    - name: dirtyfrag-conservative-rxrpc
+      family: AF_RXRPC
+      action: log_and_kill
+    - name: dirtyfrag-conservative-xfrm
+      family: AF_NETLINK
+      protocol: NETLINK_XFRM
+      action: log_and_kill
+```
+
+This preserves the existing conservative behavior and avoids blocking all `AF_NETLINK`.
+
+## Testing
+
+Tests should cover:
+
+- Resolving a built-in mitigation by ID without loading unrelated mitigation files.
+- Resolving an external mitigation by ID from `mitigation_dirs`.
+- Rejecting invalid IDs and traversal attempts.
+- Rejecting unknown YAML fields.
+- Rejecting mismatched file stem and YAML `id`.
+- Rejecting duplicate final rule names.
+- Rejecting world-writable external directories and files on Unix.
+- Expanding Dirty Frag YAML to the exact two socket rules used by the current implementation.
+- Preserving existing seccomp and ptrace Dirty Frag enforcement tests after the resolver changes.
+- Windows compilation, with Unix permission checks behind platform-specific files or no-op behavior where not applicable.
+
+## Migration
+
+Because `hardening_profiles` was introduced on the current feature branch and has not shipped, the cleanest path is to rename it to `mitigation_sets` before merge. If compatibility is desired anyway, `hardening_profiles` can remain as a deprecated alias that feeds the same resolver and emits a warning.
+
+Docs and `config.yml` should stop presenting `hardening_profiles` as the preferred interface.

--- a/docs/superpowers/specs/2026-05-08-yaml-mitigation-sets-design.md
+++ b/docs/superpowers/specs/2026-05-08-yaml-mitigation-sets-design.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-The Dirty Frag work adds the right low-level primitive for advisory response: protocol-aware `socket_rules` that can block narrow `socket(2)` and `socketpair(2)` tuples. The current `hardening_profiles` implementation does not scale because each advisory becomes another hardcoded Go `switch` case.
+The Dirty Frag work adds the right low-level primitive for advisory response: protocol-aware `socket_rules` that can block narrow `socket(2)` and `socketpair(2)` tuples. Advisory mitigations should be data files, not dedicated Go code paths for each issue.
 
 agentsh needs a generic way to ship and load advisory mitigations while still letting users write explicit low-level rules. The mitigation mechanism should avoid parsing every shipped advisory on startup and should not force users to overblock broad resources such as all `AF_NETLINK` when a narrow protocol rule is enough.
 
@@ -25,7 +25,7 @@ agentsh needs a generic way to ship and load advisory mitigations while still le
 
 ## User Configuration
 
-Replace the advisory-specific `hardening_profiles` field with generic mitigation sets:
+Configure advisory mitigations with generic mitigation sets:
 
 ```yaml
 sandbox:
@@ -41,7 +41,7 @@ sandbox:
 
 `mitigation_dirs` is optional. When omitted, only built-in mitigations are available. External files are trusted local admin config, but they must pass permission checks, schema validation, and semantic rule validation.
 
-For compatibility inside the current branch, `hardening_profiles` can remain as a deprecated alias for `mitigation_sets`. Because this branch has not shipped, the preferred implementation is to rename the public docs and examples to `mitigation_sets` before merge.
+Because this branch has not shipped, no compatibility alias is needed. Stale configs that use the earlier `sandbox.seccomp.hardening_profiles` name should fail fast with an error that points to `sandbox.seccomp.mitigation_sets`.
 
 ## Mitigation YAML Format
 
@@ -154,7 +154,7 @@ The v1 schema leaves room for that extension without baking signature logic into
 
 ## Dirty Frag Built-In
 
-The current hardcoded `dirtyfrag-conservative` profile becomes a built-in YAML mitigation file:
+The Dirty Frag conservative rules ship as a built-in YAML mitigation file:
 
 ```yaml
 version: 1
@@ -193,6 +193,4 @@ Tests should cover:
 
 ## Migration
 
-Because `hardening_profiles` was introduced on the current feature branch and has not shipped, the cleanest path is to rename it to `mitigation_sets` before merge. If compatibility is desired anyway, `hardening_profiles` can remain as a deprecated alias that feeds the same resolver and emits a warning.
-
-Docs and `config.yml` should stop presenting `hardening_profiles` as the preferred interface.
+Because the earlier profile field was introduced only on the current feature branch and has not shipped, there is no public migration burden. Any local branch config that used the old name must be changed to `mitigation_sets`; agentsh should reject the old key instead of silently ignoring it.

--- a/internal/api/app_ptrace_linux.go
+++ b/internal/api/app_ptrace_linux.go
@@ -42,6 +42,7 @@ func (a *App) initPtraceTracer() {
 		// Even when ptrace is disabled, check if socket-family blocking is
 		// configured but has no enforcement engine available, and warn.
 		a.warnIfFamiliesOrphan()
+		a.warnIfSocketRulesOrphan()
 		return
 	}
 
@@ -238,4 +239,29 @@ func (a *App) warnIfFamiliesOrphan() {
 			"(seccomp and ptrace both unavailable or disabled); families will not be blocked",
 			"families", len(families))
 	}
+}
+
+// warnIfSocketRulesOrphan emits a warning when socket tuple rules are
+// configured but neither seccomp nor ptrace is available/enabled.
+// Called from initPtraceTracer when ptrace is disabled, to cover the
+// case where seccomp is also absent or the wrapper will not run.
+func (a *App) warnIfSocketRulesOrphan() {
+	_ = a.warnIfSocketRulesOrphanWithCaps(capabilities.DetectSecurityCapabilities())
+}
+
+func (a *App) warnIfSocketRulesOrphanWithCaps(caps *capabilities.SecurityCapabilities) bool {
+	if a == nil || a.cfg == nil {
+		return false
+	}
+	rules, err := config.ResolveSocketRules(a.cfg.Sandbox.Seccomp)
+	if err != nil || len(rules) == 0 {
+		return false
+	}
+	if selectSocketRuleBlockingEngine(rules, &a.cfg.Sandbox, caps) != familyEngineNone {
+		return false
+	}
+	slog.Warn("socket tuple blocking is configured but no enforcement engine is available on this host "+
+		"(seccomp and ptrace both unavailable or disabled); socket rules will not be blocked",
+		"rules", len(rules))
+	return true
 }

--- a/internal/api/app_ptrace_linux.go
+++ b/internal/api/app_ptrace_linux.go
@@ -200,7 +200,7 @@ func resolveFamilyCheckerForPtrace(cfg *config.Config, emit ptrace.FamilyEmitter
 }
 
 // resolveSocketRuleCheckerForPtrace resolves socket tuple rules to install on
-// the ptrace tracer. Returns nil when no raw rules or hardening profile rules
+// the ptrace tracer. Returns nil when no raw rules or mitigation set rules
 // are configured/effective.
 func resolveSocketRuleCheckerForPtrace(cfg *config.Config, emit ptrace.FamilyEmitter) (*ptrace.SocketRuleChecker, error) {
 	rules, err := config.ResolveSocketRules(cfg.Sandbox.Seccomp)

--- a/internal/api/app_ptrace_linux.go
+++ b/internal/api/app_ptrace_linux.go
@@ -16,7 +16,7 @@ import (
 )
 
 // ptraceFamilyEmitter adapts the API's event store/broker to the
-// ptrace.FamilyEmitter interface so family-block audit events reach the
+// ptrace.FamilyEmitter interface so ptrace socket audit events reach the
 // same sink as the seccomp engine's events.
 type ptraceFamilyEmitter struct {
 	store  eventStore
@@ -82,23 +82,34 @@ func (a *App) initPtraceTracer() {
 		}
 	}
 
+	socketRuleChecker, err := resolveSocketRuleCheckerForPtrace(a.cfg, emit)
+	if err != nil {
+		slog.Warn("initPtraceTracer: failed to resolve socket_rules; socket tuple rules will not be enforced via ptrace",
+			"error", err)
+	} else if socketRuleChecker != nil {
+		rules, _ := config.ResolveSocketRules(a.cfg.Sandbox.Seccomp)
+		slog.Info("socket tuple blocking: wired SocketRuleChecker on ptrace tracer",
+			"rules", len(rules))
+	}
+
 	tr := ptrace.NewTracer(ptrace.TracerConfig{
-		AttachMode:       cfg.AttachMode,
-		TraceExecve:      cfg.Trace.Execve,
-		TraceFile:        cfg.Trace.File,
-		TraceNetwork:     cfg.Trace.Network,
-		TraceSignal:      cfg.Trace.Signal,
-		MaskTracerPid:    false, // validation rejects non-"off" values for now
-		SeccompPrefilter: cfg.Performance.SeccompPrefilter,
-		ArgLevelFilter:   cfg.Performance.ArgLevelFilter,
-		MaxTracees:       cfg.Performance.MaxTracees,
-		MaxHoldMs:        cfg.Performance.MaxHoldMs,
-		OnAttachFailure:  cfg.OnAttachFailure,
-		ExecHandler:      router,
-		FileHandler:      router,
-		NetworkHandler:   router,
-		SignalHandler:    router,
-		FamilyChecker:    familyChecker,
+		AttachMode:        cfg.AttachMode,
+		TraceExecve:       cfg.Trace.Execve,
+		TraceFile:         cfg.Trace.File,
+		TraceNetwork:      cfg.Trace.Network,
+		TraceSignal:       cfg.Trace.Signal,
+		MaskTracerPid:     false, // validation rejects non-"off" values for now
+		SeccompPrefilter:  cfg.Performance.SeccompPrefilter,
+		ArgLevelFilter:    cfg.Performance.ArgLevelFilter,
+		MaxTracees:        cfg.Performance.MaxTracees,
+		MaxHoldMs:         cfg.Performance.MaxHoldMs,
+		OnAttachFailure:   cfg.OnAttachFailure,
+		ExecHandler:       router,
+		FileHandler:       router,
+		NetworkHandler:    router,
+		SignalHandler:     router,
+		SocketRuleChecker: socketRuleChecker,
+		FamilyChecker:     familyChecker,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -185,6 +196,20 @@ func resolveFamilyCheckerForPtrace(cfg *config.Config, emit ptrace.FamilyEmitter
 		return nil, nil
 	}
 	return ptrace.NewFamilyCheckerWithEmitter(families, emit), nil
+}
+
+// resolveSocketRuleCheckerForPtrace resolves socket tuple rules to install on
+// the ptrace tracer. Returns nil when no raw rules or hardening profile rules
+// are configured/effective.
+func resolveSocketRuleCheckerForPtrace(cfg *config.Config, emit ptrace.FamilyEmitter) (*ptrace.SocketRuleChecker, error) {
+	rules, err := config.ResolveSocketRules(cfg.Sandbox.Seccomp)
+	if err != nil {
+		return nil, err
+	}
+	if len(rules) == 0 {
+		return nil, nil
+	}
+	return ptrace.NewSocketRuleCheckerWithEmitter(rules, emit), nil
 }
 
 // closePtraceTracer stops the ptrace tracer if running.

--- a/internal/api/app_ptrace_linux.go
+++ b/internal/api/app_ptrace_linux.go
@@ -70,7 +70,7 @@ func (a *App) initPtraceTracer() {
 		slog.Warn("initPtraceTracer: failed to resolve blocked_socket_families; socket-family blocking will not be enforced via ptrace",
 			"error", err)
 	} else {
-		families, _ := config.ResolveBlockedFamilies(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies)
+		families, _ := config.ResolveEffectiveBlockedFamilies(a.cfg.Sandbox.Seccomp)
 		if familyChecker != nil {
 			slog.Info("socket-family blocking: wired FamilyChecker on ptrace tracer",
 				"families", len(families))
@@ -189,7 +189,7 @@ func (a *App) initPtraceTracer() {
 //
 // Extracted as a standalone function for testability.
 func resolveFamilyCheckerForPtrace(cfg *config.Config, emit ptrace.FamilyEmitter) (*ptrace.FamilyChecker, error) {
-	families, err := config.ResolveBlockedFamilies(cfg.Sandbox.Seccomp.BlockedSocketFamilies)
+	families, err := config.ResolveEffectiveBlockedFamilies(cfg.Sandbox.Seccomp)
 	if err != nil {
 		return nil, err
 	}
@@ -226,10 +226,7 @@ func (a *App) closePtraceTracer() {
 // Called from initPtraceTracer when ptrace is disabled, to cover the
 // case where seccomp is also absent.
 func (a *App) warnIfFamiliesOrphan() {
-	if len(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies) == 0 {
-		return
-	}
-	families, err := config.ResolveBlockedFamilies(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies)
+	families, err := config.ResolveEffectiveBlockedFamilies(a.cfg.Sandbox.Seccomp)
 	if err != nil || len(families) == 0 {
 		return
 	}

--- a/internal/api/blocklist_config_linux.go
+++ b/internal/api/blocklist_config_linux.go
@@ -14,7 +14,7 @@ import (
 
 // buildBlockListConfigFor returns the per-session *BlockListConfig derived
 // from Sandbox.Seccomp.Syscalls, Sandbox.Seccomp.BlockedSocketFamilies, and
-// Sandbox.Seccomp.SocketRules/hardening_profiles.
+// Sandbox.Seccomp.SocketRules/mitigation_sets.
 // When on_block is errno or kill the seccomp filter handles the action
 // kernel-side and no notify traps fire — an empty config is returned in that
 // case (nil-safe; IsBlockListed returns (_, false)).
@@ -30,9 +30,12 @@ func (a *App) buildBlockListConfigFor(sessionID string) any {
 	cfg := &unixmon.BlockListConfig{}
 
 	// Syscall block-list: only log/log_and_kill route through notify.
-	action, ok := seccompkg.ParseOnBlock(a.cfg.Sandbox.Seccomp.Syscalls.OnBlock)
-	if ok && (action == seccompkg.OnBlockLog || action == seccompkg.OnBlockLogAndKill) {
-		nrs, skipped := seccompkg.ResolveSyscalls(a.cfg.Sandbox.Seccomp.Syscalls.Block)
+	block, onBlock, err := config.EffectiveSyscallBlock(a.cfg.Sandbox.Seccomp)
+	if err != nil {
+		slog.Warn("blocklist: failed to resolve effective syscall block list",
+			"session_id", sessionID, "error", err)
+	} else if action, ok := seccompkg.ParseOnBlock(onBlock); ok && (action == seccompkg.OnBlockLog || action == seccompkg.OnBlockLogAndKill) {
+		nrs, skipped := seccompkg.ResolveSyscalls(block)
 		if len(skipped) > 0 {
 			slog.Warn("blocklist: some syscalls could not be resolved on this arch",
 				"session_id", sessionID, "skipped", skipped, "arch", runtime.GOARCH)
@@ -45,22 +48,20 @@ func (a *App) buildBlockListConfigFor(sessionID string) any {
 
 	// Socket-family block-list: log/log_and_kill families route through notify.
 	// Build (syscallNr<<32)|af_family → BlockedFamily for dispatch in the handler.
-	if len(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies) > 0 {
-		families, err := config.ResolveBlockedFamilies(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies)
-		if err != nil {
-			slog.Warn("blocklist: failed to resolve blocked_socket_families for notify dispatch",
-				"session_id", sessionID, "error", err)
-		} else {
-			for _, bf := range families {
-				if bf.Action != seccompkg.OnBlockLog && bf.Action != seccompkg.OnBlockLogAndKill {
-					continue
-				}
-				if cfg.FamilyByKey == nil {
-					cfg.FamilyByKey = make(map[uint64]seccompkg.BlockedFamily)
-				}
-				cfg.FamilyByKey[uint64(unix.SYS_SOCKET)<<32|uint64(bf.Family)] = bf
-				cfg.FamilyByKey[uint64(unix.SYS_SOCKETPAIR)<<32|uint64(bf.Family)] = bf
+	families, err := config.ResolveEffectiveBlockedFamilies(a.cfg.Sandbox.Seccomp)
+	if err != nil {
+		slog.Warn("blocklist: failed to resolve blocked_socket_families for notify dispatch",
+			"session_id", sessionID, "error", err)
+	} else {
+		for _, bf := range families {
+			if bf.Action != seccompkg.OnBlockLog && bf.Action != seccompkg.OnBlockLogAndKill {
+				continue
 			}
+			if cfg.FamilyByKey == nil {
+				cfg.FamilyByKey = make(map[uint64]seccompkg.BlockedFamily)
+			}
+			cfg.FamilyByKey[uint64(unix.SYS_SOCKET)<<32|uint64(bf.Family)] = bf
+			cfg.FamilyByKey[uint64(unix.SYS_SOCKETPAIR)<<32|uint64(bf.Family)] = bf
 		}
 	}
 

--- a/internal/api/blocklist_config_linux.go
+++ b/internal/api/blocklist_config_linux.go
@@ -13,12 +13,15 @@ import (
 )
 
 // buildBlockListConfigFor returns the per-session *BlockListConfig derived
-// from Sandbox.Seccomp.Syscalls and Sandbox.Seccomp.BlockedSocketFamilies.
+// from Sandbox.Seccomp.Syscalls, Sandbox.Seccomp.BlockedSocketFamilies, and
+// Sandbox.Seccomp.SocketRules/hardening_profiles.
 // When on_block is errno or kill the seccomp filter handles the action
 // kernel-side and no notify traps fire — an empty config is returned in that
 // case (nil-safe; IsBlockListed returns (_, false)).
 // Socket-family entries with log/log_and_kill actions are always included in
 // FamilyByKey regardless of the syscall on_block setting.
+// Socket tuple rules with log/log_and_kill actions are included in SocketRules
+// for userspace notify dispatch; errno/kill rules are kernel-side.
 //
 // Returns a non-nil *BlockListConfig (wrapped as any so the signature matches
 // the non-Linux stub) so callers can always probe len(ActionByNr) without a
@@ -58,6 +61,20 @@ func (a *App) buildBlockListConfigFor(sessionID string) any {
 				cfg.FamilyByKey[uint64(unix.SYS_SOCKET)<<32|uint64(bf.Family)] = bf
 				cfg.FamilyByKey[uint64(unix.SYS_SOCKETPAIR)<<32|uint64(bf.Family)] = bf
 			}
+		}
+	}
+
+	// Socket tuple block-list: log/log_and_kill rules route through notify.
+	socketRules, err := config.ResolveSocketRules(a.cfg.Sandbox.Seccomp)
+	if err != nil {
+		slog.Warn("blocklist: failed to resolve socket_rules for notify dispatch",
+			"session_id", sessionID, "error", err)
+	} else {
+		for _, rule := range socketRules {
+			if rule.Action != seccompkg.OnBlockLog && rule.Action != seccompkg.OnBlockLogAndKill {
+				continue
+			}
+			cfg.SocketRules = append(cfg.SocketRules, rule)
 		}
 	}
 

--- a/internal/api/blocklist_config_linux_test.go
+++ b/internal/api/blocklist_config_linux_test.go
@@ -1,0 +1,55 @@
+//go:build linux && cgo
+
+package api
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	unixmon "github.com/agentsh/agentsh/internal/netmonitor/unix"
+	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
+	"github.com/stretchr/testify/require"
+	gounix "golang.org/x/sys/unix"
+)
+
+func TestBuildBlockListConfigFor_SocketRulesNotifyOnly(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Sandbox.Seccomp.SocketRules = []config.SandboxSeccompSocketRuleConfig{
+		{Name: "errno-rule", Family: "AF_NETLINK", Protocol: "NETLINK_AUDIT", Action: "errno"},
+		{Name: "kill-rule", Family: "AF_NETLINK", Protocol: "NETLINK_GENERIC", Action: "kill"},
+		{Name: "log-rule", Family: "AF_NETLINK", Protocol: "NETLINK_XFRM", Action: "log"},
+		{Name: "log-and-kill-rule", Family: "AF_RXRPC", Action: "log_and_kill"},
+	}
+
+	app := &App{cfg: cfg}
+	bl, ok := app.buildBlockListConfigFor("sess-socket-rules").(*unixmon.BlockListConfig)
+	require.True(t, ok)
+	require.NotNil(t, bl)
+
+	require.Len(t, bl.SocketRules, 2)
+	require.Equal(t, "log-rule", bl.SocketRules[0].Name)
+	require.Equal(t, seccompkg.OnBlockLog, bl.SocketRules[0].Action)
+	require.Equal(t, gounix.AF_NETLINK, bl.SocketRules[0].Family)
+	require.NotNil(t, bl.SocketRules[0].Protocol)
+	require.Equal(t, int(gounix.NETLINK_XFRM), *bl.SocketRules[0].Protocol)
+	require.Equal(t, "log-and-kill-rule", bl.SocketRules[1].Name)
+	require.Equal(t, seccompkg.OnBlockLogAndKill, bl.SocketRules[1].Action)
+}
+
+func TestBuildBlockListConfigFor_SocketRulesFromHardeningProfile(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Sandbox.Seccomp.HardeningProfiles = []string{"dirtyfrag-conservative"}
+
+	app := &App{cfg: cfg}
+	bl, ok := app.buildBlockListConfigFor("sess-dirtyfrag-profile").(*unixmon.BlockListConfig)
+	require.True(t, ok)
+	require.NotNil(t, bl)
+
+	require.Len(t, bl.SocketRules, 2)
+	require.Equal(t, "dirtyfrag-conservative-rxrpc", bl.SocketRules[0].Name)
+	require.Equal(t, seccompkg.OnBlockLogAndKill, bl.SocketRules[0].Action)
+	require.Equal(t, "dirtyfrag-conservative-xfrm", bl.SocketRules[1].Name)
+	require.Equal(t, seccompkg.OnBlockLogAndKill, bl.SocketRules[1].Action)
+	require.NotNil(t, bl.SocketRules[1].Protocol)
+	require.Equal(t, int(gounix.NETLINK_XFRM), *bl.SocketRules[1].Protocol)
+}

--- a/internal/api/blocklist_config_linux_test.go
+++ b/internal/api/blocklist_config_linux_test.go
@@ -36,12 +36,12 @@ func TestBuildBlockListConfigFor_SocketRulesNotifyOnly(t *testing.T) {
 	require.Equal(t, seccompkg.OnBlockLogAndKill, bl.SocketRules[1].Action)
 }
 
-func TestBuildBlockListConfigFor_SocketRulesFromHardeningProfile(t *testing.T) {
+func TestBuildBlockListConfigFor_SocketRulesFromMitigationSet(t *testing.T) {
 	cfg := &config.Config{}
-	cfg.Sandbox.Seccomp.HardeningProfiles = []string{"dirtyfrag-conservative"}
+	cfg.Sandbox.Seccomp.MitigationSets = []string{"dirtyfrag-conservative"}
 
 	app := &App{cfg: cfg}
-	bl, ok := app.buildBlockListConfigFor("sess-dirtyfrag-profile").(*unixmon.BlockListConfig)
+	bl, ok := app.buildBlockListConfigFor("sess-dirtyfrag-mitigation").(*unixmon.BlockListConfig)
 	require.True(t, ok)
 	require.NotNil(t, bl)
 
@@ -52,4 +52,39 @@ func TestBuildBlockListConfigFor_SocketRulesFromHardeningProfile(t *testing.T) {
 	require.Equal(t, seccompkg.OnBlockLogAndKill, bl.SocketRules[1].Action)
 	require.NotNil(t, bl.SocketRules[1].Protocol)
 	require.Equal(t, int(gounix.NETLINK_XFRM), *bl.SocketRules[1].Protocol)
+}
+
+func TestBuildBlockListConfigFor_MitigationSetSyscallsAndFamilies(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Sandbox.Seccomp.Syscalls.OnBlock = "log"
+	addTestMitigationSet(t, cfg, "api-blocklist", `
+version: 1
+id: api-blocklist
+seccomp:
+  syscalls:
+    block:
+      - ptrace
+  blocked_socket_families:
+    - family: AF_ALG
+      action: log
+`)
+
+	app := &App{cfg: cfg}
+	bl, ok := app.buildBlockListConfigFor("sess-mitigation-blocklist").(*unixmon.BlockListConfig)
+	require.True(t, ok)
+	require.NotNil(t, bl)
+
+	action, ok := bl.IsBlockListed(uint32(gounix.SYS_PTRACE))
+	require.True(t, ok)
+	require.Equal(t, seccompkg.OnBlockLog, action)
+
+	family, ok := bl.FamilyBlockListed(uint32(gounix.SYS_SOCKET), uint64(gounix.AF_ALG))
+	require.True(t, ok)
+	require.Equal(t, "AF_ALG", family.Name)
+	require.Equal(t, seccompkg.OnBlockLog, family.Action)
+
+	family, ok = bl.FamilyBlockListed(uint32(gounix.SYS_SOCKETPAIR), uint64(gounix.AF_ALG))
+	require.True(t, ok)
+	require.Equal(t, "AF_ALG", family.Name)
+	require.Equal(t, seccompkg.OnBlockLog, family.Action)
 }

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -192,7 +192,7 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 		seccompCfg.InterceptMetadata ||
 		blockListUsesNotify(seccompCfg.BlockedSyscalls, seccompCfg.OnBlock) ||
 		blockedFamiliesUsesNotify(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies) ||
-		socketRulesUsesNotify(a.cfg.Sandbox.Seccomp.SocketRules)
+		seccompSocketRulesUseNotify(a.cfg.Sandbox.Seccomp)
 	// AGENTSH_PTRACE_SYNC goes into envInject (not env) so it overrides any
 	// user-supplied value. envInject deduplicates keys before appending.
 	ptraceSyncValue := "0"

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -186,7 +186,13 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 	// Only enable ptrace sync handshake when the wrapper will produce a notify FD.
 	// If no seccomp features need USER_NOTIF, the wrapper skips the FD send and
 	// the READY/GO handshake has nothing to synchronize on.
-	hasNotifyFeatures := seccompCfg.UnixSocketEnabled || seccompCfg.ExecveEnabled || seccompCfg.FileMonitorEnabled || seccompCfg.InterceptMetadata || blockListUsesNotify(seccompCfg.BlockedSyscalls, seccompCfg.OnBlock) || blockedFamiliesUsesNotify(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies)
+	hasNotifyFeatures := seccompCfg.UnixSocketEnabled ||
+		seccompCfg.ExecveEnabled ||
+		seccompCfg.FileMonitorEnabled ||
+		seccompCfg.InterceptMetadata ||
+		blockListUsesNotify(seccompCfg.BlockedSyscalls, seccompCfg.OnBlock) ||
+		blockedFamiliesUsesNotify(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies) ||
+		socketRulesUsesNotify(a.cfg.Sandbox.Seccomp.SocketRules)
 	// AGENTSH_PTRACE_SYNC goes into envInject (not env) so it overrides any
 	// user-supplied value. envInject deduplicates keys before appending.
 	ptraceSyncValue := "0"

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -191,7 +191,7 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 		seccompCfg.FileMonitorEnabled ||
 		seccompCfg.InterceptMetadata ||
 		blockListUsesNotify(seccompCfg.BlockedSyscalls, seccompCfg.OnBlock) ||
-		blockedFamiliesUsesNotify(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies) ||
+		blockedFamiliesUseNotifyForSeccomp(a.cfg.Sandbox.Seccomp) ||
 		seccompSocketRulesUseNotify(a.cfg.Sandbox.Seccomp)
 	// AGENTSH_PTRACE_SYNC goes into envInject (not env) so it overrides any
 	// user-supplied value. envInject deduplicates keys before appending.

--- a/internal/api/family_engine_linux.go
+++ b/internal/api/family_engine_linux.go
@@ -77,7 +77,23 @@ func selectFamilyBlockingEngine(
 	cfg *config.SandboxConfig,
 	caps *capabilities.SecurityCapabilities,
 ) familyEngine {
-	if len(families) == 0 {
+	return selectSocketBlockingEngine(len(families) > 0, cfg, caps)
+}
+
+func selectSocketRuleBlockingEngine(
+	rules []seccompkg.SocketRule,
+	cfg *config.SandboxConfig,
+	caps *capabilities.SecurityCapabilities,
+) familyEngine {
+	return selectSocketBlockingEngine(len(rules) > 0, cfg, caps)
+}
+
+func selectSocketBlockingEngine(
+	configured bool,
+	cfg *config.SandboxConfig,
+	caps *capabilities.SecurityCapabilities,
+) familyEngine {
+	if !configured {
 		return familyEngineNone
 	}
 

--- a/internal/api/family_engine_linux.go
+++ b/internal/api/family_engine_linux.go
@@ -77,7 +77,23 @@ func selectFamilyBlockingEngine(
 	cfg *config.SandboxConfig,
 	caps *capabilities.SecurityCapabilities,
 ) familyEngine {
-	return selectSocketBlockingEngine(len(families) > 0, cfg, caps)
+	if len(families) == 0 {
+		return familyEngineNone
+	}
+
+	seccompAvailable := caps != nil && caps.Seccomp
+	seccompEnabled := cfg != nil && cfg.Seccomp.Enabled
+	if seccompAvailable && seccompEnabled && wrapperWillRun(cfg) {
+		return familyEngineSeccomp
+	}
+
+	ptraceAvailable := caps != nil && caps.Ptrace
+	ptraceEnabled := cfg != nil && cfg.Ptrace.Enabled
+	if ptraceAvailable && ptraceEnabled {
+		return familyEnginePtrace
+	}
+
+	return familyEngineNone
 }
 
 func selectSocketRuleBlockingEngine(
@@ -85,21 +101,12 @@ func selectSocketRuleBlockingEngine(
 	cfg *config.SandboxConfig,
 	caps *capabilities.SecurityCapabilities,
 ) familyEngine {
-	return selectSocketBlockingEngine(len(rules) > 0, cfg, caps)
-}
-
-func selectSocketBlockingEngine(
-	configured bool,
-	cfg *config.SandboxConfig,
-	caps *capabilities.SecurityCapabilities,
-) familyEngine {
-	if !configured {
+	if len(rules) == 0 {
 		return familyEngineNone
 	}
 
 	seccompAvailable := caps != nil && caps.Seccomp
-	seccompEnabled := cfg != nil && cfg.Seccomp.Enabled
-	if seccompAvailable && seccompEnabled && wrapperWillRun(cfg) {
+	if seccompAvailable && wrapperWillRun(cfg) {
 		return familyEngineSeccomp
 	}
 

--- a/internal/api/seccomp_wrapper_config.go
+++ b/internal/api/seccomp_wrapper_config.go
@@ -48,25 +48,26 @@ type seccompWrapperParams struct {
 }
 
 func (a *App) buildSeccompWrapperConfig(s *session.Session, p seccompWrapperParams) seccompWrapperConfig {
+	blockedSyscalls, onBlock, err := config.EffectiveSyscallBlock(a.cfg.Sandbox.Seccomp)
+	if err != nil {
+		slog.Warn("seccomp: failed to resolve effective syscall block list; syscall rules will not be blocked", "error", err)
+	}
 	seccompCfg := seccompWrapperConfig{
 		UnixSocketEnabled:   p.UnixSocketEnabled,
 		SignalFilterEnabled: p.SignalFilterEnabled,
 		ExecveEnabled:       p.ExecveEnabled,
 		FileMonitorEnabled:  config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.Enabled, false),
-		BlockedSyscalls:     a.cfg.Sandbox.Seccomp.Syscalls.Block,
-		OnBlock:             a.cfg.Sandbox.Seccomp.Syscalls.OnBlock,
+		BlockedSyscalls:     blockedSyscalls,
+		OnBlock:             onBlock,
 		ServerPID:           os.Getpid(),
 	}
 
 	// Resolve and forward blocked socket families.
-	if len(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies) > 0 {
-		families, err := config.ResolveBlockedFamilies(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies)
-		if err != nil {
-			slog.Warn("seccomp: failed to resolve blocked_socket_families; families will not be blocked",
-				"error", err)
-		} else {
-			seccompCfg.BlockedFamilies = families
-		}
+	families, err := config.ResolveEffectiveBlockedFamilies(a.cfg.Sandbox.Seccomp)
+	if err != nil {
+		slog.Warn("seccomp: failed to resolve blocked_socket_families; families will not be blocked", "error", err)
+	} else {
+		seccompCfg.BlockedFamilies = families
 	}
 
 	if rules, err := config.ResolveSocketRules(a.cfg.Sandbox.Seccomp); err != nil {

--- a/internal/api/seccomp_wrapper_config.go
+++ b/internal/api/seccomp_wrapper_config.go
@@ -19,6 +19,7 @@ type seccompWrapperConfig struct {
 	FileMonitorEnabled  bool                      `json:"file_monitor_enabled"`
 	BlockedSyscalls     []string                  `json:"blocked_syscalls"`
 	BlockedFamilies     []seccompkg.BlockedFamily `json:"blocked_families,omitempty"`
+	SocketRules         []seccompkg.SocketRule    `json:"socket_rules,omitempty"`
 	OnBlock             string                    `json:"on_block,omitempty"`
 
 	// File monitor sub-options
@@ -66,6 +67,12 @@ func (a *App) buildSeccompWrapperConfig(s *session.Session, p seccompWrapperPara
 		} else {
 			seccompCfg.BlockedFamilies = families
 		}
+	}
+
+	if rules, err := config.ResolveSocketRules(a.cfg.Sandbox.Seccomp); err != nil {
+		slog.Warn("seccomp: failed to resolve socket_rules; socket rules will not be blocked", "error", err)
+	} else {
+		seccompCfg.SocketRules = rules
 	}
 
 	fmDefault := config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE, false)

--- a/internal/api/seccomp_wrapper_test.go
+++ b/internal/api/seccomp_wrapper_test.go
@@ -285,3 +285,57 @@ func TestSetupSeccompWrapper_FileMonitorDefaults(t *testing.T) {
 		t.Fatalf("block_io_uring = %v, want true (JSON: %s)", got, seccompJSON)
 	}
 }
+
+func TestSetupSeccompWrapper_PtraceSync_MitigationSetFamilyLog(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("seccomp wrapper only available on Linux")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+
+	app := newTestAppForSeccomp(t, cfg)
+	addTestMitigationSet(t, cfg, "ptrace-sync-family", `
+version: 1
+id: ptrace-sync-family
+seccomp:
+  blocked_socket_families:
+    - family: AF_ALG
+      action: log
+`)
+	cfg.Sandbox.Ptrace.Enabled = true
+	cfg.Sandbox.Ptrace.Trace.Execve = true
+	cfg.Sandbox.Ptrace.Trace.File = false
+	cfg.Sandbox.Ptrace.Trace.Network = false
+	cfg.Sandbox.Ptrace.Trace.Signal = false
+	app.ptraceTracer = struct{}{}
+
+	req := types.ExecRequest{
+		Command: "/bin/echo",
+		Args:    []string{"hello"},
+	}
+
+	result := app.setupSeccompWrapper(req, "test-session", nil)
+	if result == nil || result.extraCfg == nil {
+		t.Fatal("expected non-nil wrapper setup result with extraCfg")
+	}
+	defer func() {
+		if result.extraCfg.notifyParentSock != nil {
+			result.extraCfg.notifyParentSock.Close()
+		}
+		for _, f := range result.extraCfg.extraFiles {
+			if f != nil {
+				f.Close()
+			}
+		}
+	}()
+
+	if !result.extraCfg.ptraceSync {
+		t.Fatal("expected ptrace sync when a mitigation-set socket family uses log")
+	}
+	if got := result.extraCfg.envInject["AGENTSH_PTRACE_SYNC"]; got != "1" {
+		t.Fatalf("AGENTSH_PTRACE_SYNC = %q, want 1", got)
+	}
+}

--- a/internal/api/socket_rule_checker_ptrace_linux_test.go
+++ b/internal/api/socket_rule_checker_ptrace_linux_test.go
@@ -141,6 +141,25 @@ func TestResolveSocketRuleCheckerForPtrace_WarnIfSocketRulesOrphan_NoWarnWhenWra
 	}
 }
 
+func TestResolveSocketRuleCheckerForPtrace_WarnIfSocketRulesOrphan_NoWarnWhenWrapperRunsWithSeccompDisabled(t *testing.T) {
+	withPresentWrapper(t)
+	cfg := &config.Config{}
+	cfg.Sandbox.Seccomp.Enabled = false
+	cfg.Sandbox.Ptrace.Enabled = false
+	cfg.Sandbox.Seccomp.HardeningProfiles = []string{"dirtyfrag-conservative"}
+	enabled := true
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	app := &App{cfg: cfg}
+
+	warned := app.warnIfSocketRulesOrphanWithCaps(&capabilities.SecurityCapabilities{
+		Seccomp: true,
+		Ptrace:  false,
+	})
+	if warned {
+		t.Fatal("must not warn when unix_sockets wrapper can enforce socket rules even with sandbox.seccomp.enabled=false")
+	}
+}
+
 func TestResolveSocketRuleCheckerForPtrace_WarnIfSocketRulesOrphan_NoWarnWhenPtraceEnabled(t *testing.T) {
 	withMissingWrapper(t)
 	cfg := &config.Config{}

--- a/internal/api/socket_rule_checker_ptrace_linux_test.go
+++ b/internal/api/socket_rule_checker_ptrace_linux_test.go
@@ -5,6 +5,7 @@ package api
 import (
 	"testing"
 
+	"github.com/agentsh/agentsh/internal/capabilities"
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/seccomp"
 	"golang.org/x/sys/unix"
@@ -81,5 +82,78 @@ func TestResolveSocketRuleCheckerForPtrace_ErrorOnInvalidConfig(t *testing.T) {
 	}
 	if checker != nil {
 		t.Fatalf("expected nil checker on error, got %+v", checker)
+	}
+}
+
+func TestResolveSocketRuleCheckerForPtrace_WarnIfSocketRulesOrphan_RawRules(t *testing.T) {
+	withMissingWrapper(t)
+	cfg := &config.Config{}
+	cfg.Sandbox.Seccomp.Enabled = true
+	cfg.Sandbox.Ptrace.Enabled = false
+	cfg.Sandbox.Seccomp.SocketRules = []config.SandboxSeccompSocketRuleConfig{{
+		Name:     "dirtyfrag-xfrm",
+		Family:   "AF_NETLINK",
+		Protocol: "NETLINK_XFRM",
+		Action:   "log_and_kill",
+	}}
+	app := &App{cfg: cfg}
+
+	warned := app.warnIfSocketRulesOrphanWithCaps(&capabilities.SecurityCapabilities{
+		Seccomp: true,
+		Ptrace:  false,
+	})
+	if !warned {
+		t.Fatal("expected orphan warning for socket_rules when ptrace is disabled and wrapper is missing")
+	}
+}
+
+func TestResolveSocketRuleCheckerForPtrace_WarnIfSocketRulesOrphan_HardeningProfile(t *testing.T) {
+	withMissingWrapper(t)
+	cfg := &config.Config{}
+	cfg.Sandbox.Seccomp.Enabled = true
+	cfg.Sandbox.Ptrace.Enabled = false
+	cfg.Sandbox.Seccomp.HardeningProfiles = []string{"dirtyfrag-conservative"}
+	app := &App{cfg: cfg}
+
+	warned := app.warnIfSocketRulesOrphanWithCaps(&capabilities.SecurityCapabilities{
+		Seccomp: true,
+		Ptrace:  false,
+	})
+	if !warned {
+		t.Fatal("expected orphan warning for dirtyfrag-conservative socket rules when ptrace is disabled and wrapper is missing")
+	}
+}
+
+func TestResolveSocketRuleCheckerForPtrace_WarnIfSocketRulesOrphan_NoWarnWhenWrapperWillRun(t *testing.T) {
+	withPresentWrapper(t)
+	cfg := &config.Config{}
+	cfg.Sandbox.Seccomp.Enabled = true
+	cfg.Sandbox.Ptrace.Enabled = false
+	cfg.Sandbox.Seccomp.HardeningProfiles = []string{"dirtyfrag-conservative"}
+	app := &App{cfg: cfg}
+
+	warned := app.warnIfSocketRulesOrphanWithCaps(&capabilities.SecurityCapabilities{
+		Seccomp: true,
+		Ptrace:  false,
+	})
+	if warned {
+		t.Fatal("must not warn when seccomp wrapper will enforce socket rules")
+	}
+}
+
+func TestResolveSocketRuleCheckerForPtrace_WarnIfSocketRulesOrphan_NoWarnWhenPtraceEnabled(t *testing.T) {
+	withMissingWrapper(t)
+	cfg := &config.Config{}
+	cfg.Sandbox.Seccomp.Enabled = true
+	cfg.Sandbox.Ptrace.Enabled = true
+	cfg.Sandbox.Seccomp.HardeningProfiles = []string{"dirtyfrag-conservative"}
+	app := &App{cfg: cfg}
+
+	warned := app.warnIfSocketRulesOrphanWithCaps(&capabilities.SecurityCapabilities{
+		Seccomp: true,
+		Ptrace:  true,
+	})
+	if warned {
+		t.Fatal("must not warn when ptrace is enabled and available to enforce socket rules")
 	}
 }

--- a/internal/api/socket_rule_checker_ptrace_linux_test.go
+++ b/internal/api/socket_rule_checker_ptrace_linux_test.go
@@ -1,0 +1,85 @@
+//go:build linux
+
+package api
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/seccomp"
+	"golang.org/x/sys/unix"
+)
+
+func TestResolveSocketRuleCheckerForPtrace_RawSocketRules(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Sandbox.Seccomp.SocketRules = []config.SandboxSeccompSocketRuleConfig{{
+		Name:     "dirtyfrag-xfrm",
+		Family:   "AF_NETLINK",
+		Protocol: "NETLINK_XFRM",
+		Action:   "log_and_kill",
+	}}
+
+	checker, err := resolveSocketRuleCheckerForPtrace(cfg, nil)
+	if err != nil {
+		t.Fatalf("resolveSocketRuleCheckerForPtrace returned error: %v", err)
+	}
+	if checker == nil {
+		t.Fatal("expected non-nil SocketRuleChecker")
+	}
+	rule, ok := checker.Check(uint64(unix.SYS_SOCKET), uint64(unix.AF_NETLINK), uint64(unix.SOCK_RAW), uint64(unix.NETLINK_XFRM))
+	if !ok {
+		t.Fatal("expected checker to match configured NETLINK_XFRM socket rule")
+	}
+	if rule.Name != "dirtyfrag-xfrm" || rule.Action != seccomp.OnBlockLogAndKill {
+		t.Fatalf("unexpected rule: %+v", rule)
+	}
+}
+
+func TestResolveSocketRuleCheckerForPtrace_HardeningProfile(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Sandbox.Seccomp.HardeningProfiles = []string{"dirtyfrag-conservative"}
+
+	checker, err := resolveSocketRuleCheckerForPtrace(cfg, nil)
+	if err != nil {
+		t.Fatalf("resolveSocketRuleCheckerForPtrace returned error: %v", err)
+	}
+	if checker == nil {
+		t.Fatal("expected non-nil SocketRuleChecker")
+	}
+	if rule, ok := checker.Check(uint64(unix.SYS_SOCKET), uint64(unix.AF_RXRPC), uint64(unix.SOCK_DGRAM), 0); !ok || rule.Name != "dirtyfrag-conservative-rxrpc" {
+		t.Fatalf("expected RXRPC hardening profile rule, got rule=%+v ok=%v", rule, ok)
+	}
+	if rule, ok := checker.Check(uint64(unix.SYS_SOCKETPAIR), uint64(unix.AF_NETLINK), uint64(unix.SOCK_DGRAM), uint64(unix.NETLINK_XFRM)); !ok || rule.Name != "dirtyfrag-conservative-xfrm" {
+		t.Fatalf("expected XFRM hardening profile rule, got rule=%+v ok=%v", rule, ok)
+	}
+}
+
+func TestResolveSocketRuleCheckerForPtrace_NilWhenNoRules(t *testing.T) {
+	cfg := &config.Config{}
+
+	checker, err := resolveSocketRuleCheckerForPtrace(cfg, nil)
+	if err != nil {
+		t.Fatalf("resolveSocketRuleCheckerForPtrace returned error: %v", err)
+	}
+	if checker != nil {
+		t.Fatal("expected nil checker when no socket rules are configured")
+	}
+}
+
+func TestResolveSocketRuleCheckerForPtrace_ErrorOnInvalidConfig(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Sandbox.Seccomp.SocketRules = []config.SandboxSeccompSocketRuleConfig{{
+		Name:     "bad-xfrm",
+		Family:   "AF_INET",
+		Protocol: "NETLINK_XFRM",
+		Action:   "log",
+	}}
+
+	checker, err := resolveSocketRuleCheckerForPtrace(cfg, nil)
+	if err == nil {
+		t.Fatal("expected invalid socket rule config to return an error")
+	}
+	if checker != nil {
+		t.Fatalf("expected nil checker on error, got %+v", checker)
+	}
+}

--- a/internal/api/socket_rule_checker_ptrace_linux_test.go
+++ b/internal/api/socket_rule_checker_ptrace_linux_test.go
@@ -36,9 +36,9 @@ func TestResolveSocketRuleCheckerForPtrace_RawSocketRules(t *testing.T) {
 	}
 }
 
-func TestResolveSocketRuleCheckerForPtrace_HardeningProfile(t *testing.T) {
+func TestResolveSocketRuleCheckerForPtrace_MitigationSet(t *testing.T) {
 	cfg := &config.Config{}
-	cfg.Sandbox.Seccomp.HardeningProfiles = []string{"dirtyfrag-conservative"}
+	cfg.Sandbox.Seccomp.MitigationSets = []string{"dirtyfrag-conservative"}
 
 	checker, err := resolveSocketRuleCheckerForPtrace(cfg, nil)
 	if err != nil {
@@ -48,10 +48,37 @@ func TestResolveSocketRuleCheckerForPtrace_HardeningProfile(t *testing.T) {
 		t.Fatal("expected non-nil SocketRuleChecker")
 	}
 	if rule, ok := checker.Check(uint64(unix.SYS_SOCKET), uint64(unix.AF_RXRPC), uint64(unix.SOCK_DGRAM), 0); !ok || rule.Name != "dirtyfrag-conservative-rxrpc" {
-		t.Fatalf("expected RXRPC hardening profile rule, got rule=%+v ok=%v", rule, ok)
+		t.Fatalf("expected RXRPC mitigation-set rule, got rule=%+v ok=%v", rule, ok)
 	}
 	if rule, ok := checker.Check(uint64(unix.SYS_SOCKETPAIR), uint64(unix.AF_NETLINK), uint64(unix.SOCK_DGRAM), uint64(unix.NETLINK_XFRM)); !ok || rule.Name != "dirtyfrag-conservative-xfrm" {
-		t.Fatalf("expected XFRM hardening profile rule, got rule=%+v ok=%v", rule, ok)
+		t.Fatalf("expected XFRM mitigation-set rule, got rule=%+v ok=%v", rule, ok)
+	}
+}
+
+func TestResolveFamilyCheckerForPtrace_MitigationSet(t *testing.T) {
+	cfg := &config.Config{}
+	addTestMitigationSet(t, cfg, "ptrace-family", `
+version: 1
+id: ptrace-family
+seccomp:
+  blocked_socket_families:
+    - family: AF_ALG
+      action: log
+`)
+
+	checker, err := resolveFamilyCheckerForPtrace(cfg, nil)
+	if err != nil {
+		t.Fatalf("resolveFamilyCheckerForPtrace returned error: %v", err)
+	}
+	if checker == nil {
+		t.Fatal("expected non-nil FamilyChecker")
+	}
+	family, ok := checker.Check(uint64(unix.SYS_SOCKET), uint64(unix.AF_ALG))
+	if !ok {
+		t.Fatal("expected checker to match mitigation-set AF_ALG socket family")
+	}
+	if family.Name != "AF_ALG" || family.Action != seccomp.OnBlockLog {
+		t.Fatalf("unexpected family: %+v", family)
 	}
 }
 
@@ -107,12 +134,12 @@ func TestResolveSocketRuleCheckerForPtrace_WarnIfSocketRulesOrphan_RawRules(t *t
 	}
 }
 
-func TestResolveSocketRuleCheckerForPtrace_WarnIfSocketRulesOrphan_HardeningProfile(t *testing.T) {
+func TestResolveSocketRuleCheckerForPtrace_WarnIfSocketRulesOrphan_MitigationSet(t *testing.T) {
 	withMissingWrapper(t)
 	cfg := &config.Config{}
 	cfg.Sandbox.Seccomp.Enabled = true
 	cfg.Sandbox.Ptrace.Enabled = false
-	cfg.Sandbox.Seccomp.HardeningProfiles = []string{"dirtyfrag-conservative"}
+	cfg.Sandbox.Seccomp.MitigationSets = []string{"dirtyfrag-conservative"}
 	app := &App{cfg: cfg}
 
 	warned := app.warnIfSocketRulesOrphanWithCaps(&capabilities.SecurityCapabilities{
@@ -129,7 +156,7 @@ func TestResolveSocketRuleCheckerForPtrace_WarnIfSocketRulesOrphan_NoWarnWhenWra
 	cfg := &config.Config{}
 	cfg.Sandbox.Seccomp.Enabled = true
 	cfg.Sandbox.Ptrace.Enabled = false
-	cfg.Sandbox.Seccomp.HardeningProfiles = []string{"dirtyfrag-conservative"}
+	cfg.Sandbox.Seccomp.MitigationSets = []string{"dirtyfrag-conservative"}
 	app := &App{cfg: cfg}
 
 	warned := app.warnIfSocketRulesOrphanWithCaps(&capabilities.SecurityCapabilities{
@@ -146,7 +173,7 @@ func TestResolveSocketRuleCheckerForPtrace_WarnIfSocketRulesOrphan_NoWarnWhenWra
 	cfg := &config.Config{}
 	cfg.Sandbox.Seccomp.Enabled = false
 	cfg.Sandbox.Ptrace.Enabled = false
-	cfg.Sandbox.Seccomp.HardeningProfiles = []string{"dirtyfrag-conservative"}
+	cfg.Sandbox.Seccomp.MitigationSets = []string{"dirtyfrag-conservative"}
 	enabled := true
 	cfg.Sandbox.UnixSockets.Enabled = &enabled
 	app := &App{cfg: cfg}
@@ -165,7 +192,7 @@ func TestResolveSocketRuleCheckerForPtrace_WarnIfSocketRulesOrphan_NoWarnWhenPtr
 	cfg := &config.Config{}
 	cfg.Sandbox.Seccomp.Enabled = true
 	cfg.Sandbox.Ptrace.Enabled = true
-	cfg.Sandbox.Seccomp.HardeningProfiles = []string{"dirtyfrag-conservative"}
+	cfg.Sandbox.Seccomp.MitigationSets = []string{"dirtyfrag-conservative"}
 	app := &App{cfg: cfg}
 
 	warned := app.warnIfSocketRulesOrphanWithCaps(&capabilities.SecurityCapabilities{

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/landlock"
+	seccomppkg "github.com/agentsh/agentsh/internal/seccomp"
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/go-chi/chi/v5"
@@ -563,7 +564,7 @@ func (a *App) mainFilterUsesUserNotify(execveEnabled bool) bool {
 	if blockedFamiliesUsesNotify(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies) {
 		return true
 	}
-	if socketRulesUsesNotify(a.cfg.Sandbox.Seccomp.SocketRules) {
+	if seccompSocketRulesUseNotify(a.cfg.Sandbox.Seccomp) {
 		return true
 	}
 	return false
@@ -610,8 +611,21 @@ func blockedFamiliesUsesNotify(families []config.SandboxSeccompSocketFamilyConfi
 }
 
 func socketRulesUsesNotify(rules []config.SandboxSeccompSocketRuleConfig) bool {
+	return seccompSocketRulesUseNotify(config.SandboxSeccompConfig{SocketRules: rules})
+}
+
+func seccompSocketRulesUseNotify(seccompCfg config.SandboxSeccompConfig) bool {
+	rules, err := config.ResolveSocketRules(seccompCfg)
+	if err != nil {
+		slog.Warn("seccomp: failed to resolve socket_rules; socket rules will not use user notify", "error", err)
+		return false
+	}
+	return resolvedSocketRulesUseNotify(rules)
+}
+
+func resolvedSocketRulesUseNotify(rules []seccomppkg.SocketRule) bool {
 	for _, r := range rules {
-		if r.Action == "log" || r.Action == "log_and_kill" {
+		if r.Action == seccomppkg.OnBlockLog || r.Action == seccomppkg.OnBlockLogAndKill {
 			return true
 		}
 	}

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -558,10 +558,11 @@ func (a *App) mainFilterUsesUserNotify(execveEnabled bool) bool {
 	if config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata, false) {
 		return true
 	}
-	if blockListUsesNotify(a.cfg.Sandbox.Seccomp.Syscalls.Block, a.cfg.Sandbox.Seccomp.Syscalls.OnBlock) {
+	block, onBlock, err := config.EffectiveSyscallBlock(a.cfg.Sandbox.Seccomp)
+	if err == nil && blockListUsesNotify(block, onBlock) {
 		return true
 	}
-	if blockedFamiliesUsesNotify(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies) {
+	if blockedFamiliesUseNotifyForSeccomp(a.cfg.Sandbox.Seccomp) {
 		return true
 	}
 	if seccompSocketRulesUseNotify(a.cfg.Sandbox.Seccomp) {
@@ -604,6 +605,20 @@ func containsString(xs []string, s string) bool {
 func blockedFamiliesUsesNotify(families []config.SandboxSeccompSocketFamilyConfig) bool {
 	for _, f := range families {
 		if f.Action == "log" || f.Action == "log_and_kill" {
+			return true
+		}
+	}
+	return false
+}
+
+func blockedFamiliesUseNotifyForSeccomp(seccompCfg config.SandboxSeccompConfig) bool {
+	families, err := config.ResolveEffectiveBlockedFamilies(seccompCfg)
+	if err != nil {
+		slog.Warn("seccomp: failed to resolve blocked_socket_families; socket family rules will not use user notify", "error", err)
+		return false
+	}
+	for _, f := range families {
+		if f.Action == seccomppkg.OnBlockLog || f.Action == seccomppkg.OnBlockLogAndKill {
 			return true
 		}
 	}

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -563,6 +563,9 @@ func (a *App) mainFilterUsesUserNotify(execveEnabled bool) bool {
 	if blockedFamiliesUsesNotify(a.cfg.Sandbox.Seccomp.BlockedSocketFamilies) {
 		return true
 	}
+	if socketRulesUsesNotify(a.cfg.Sandbox.Seccomp.SocketRules) {
+		return true
+	}
 	return false
 }
 
@@ -600,6 +603,15 @@ func containsString(xs []string, s string) bool {
 func blockedFamiliesUsesNotify(families []config.SandboxSeccompSocketFamilyConfig) bool {
 	for _, f := range families {
 		if f.Action == "log" || f.Action == "log_and_kill" {
+			return true
+		}
+	}
+	return false
+}
+
+func socketRulesUsesNotify(rules []config.SandboxSeccompSocketRuleConfig) bool {
+	for _, r := range rules {
+		if r.Action == "log" || r.Action == "log_and_kill" {
 			return true
 		}
 	}
@@ -754,4 +766,3 @@ func (a *App) acceptSignalFD(ctx context.Context, listener net.Listener, socketP
 	slog.Info("wrap: received signal fd", "session_id", sessionID, "fd", signalFD.Fd())
 	startSignalHandlerForWrap(ctx, signalFD, sessionID, a, s)
 }
-

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -608,7 +608,6 @@ func TestWrapInit_AgentMode_PolicyNotChecked(t *testing.T) {
 	}
 }
 
-
 func TestWrapInit_RejectsNegativeCallerUID(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("negative caller uid validation is Linux-only")
@@ -1392,6 +1391,49 @@ func TestBlockedFamiliesUsesNotify(t *testing.T) {
 				t.Errorf("blockedFamiliesUsesNotify(%v) = %v, want %v", tc.families, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestSocketRulesUsesNotify(t *testing.T) {
+	cases := []struct {
+		name  string
+		rules []config.SandboxSeccompSocketRuleConfig
+		want  bool
+	}{
+		{name: "empty", rules: nil, want: false},
+		{name: "errno", rules: []config.SandboxSeccompSocketRuleConfig{{Name: "x", Family: "AF_RXRPC", Action: "errno"}}, want: false},
+		{name: "kill", rules: []config.SandboxSeccompSocketRuleConfig{{Name: "x", Family: "AF_RXRPC", Action: "kill"}}, want: false},
+		{name: "log", rules: []config.SandboxSeccompSocketRuleConfig{{Name: "x", Family: "AF_RXRPC", Action: "log"}}, want: true},
+		{name: "log_and_kill", rules: []config.SandboxSeccompSocketRuleConfig{{Name: "x", Family: "AF_RXRPC", Action: "log_and_kill"}}, want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := socketRulesUsesNotify(tc.rules)
+			if got != tc.want {
+				t.Fatalf("socketRulesUsesNotify() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMainFilterUsesUserNotify_SocketRuleLog(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("mainFilterUsesUserNotify is Linux-only")
+	}
+	cfg := &config.Config{}
+	disabled := false
+	cfg.Sandbox.Seccomp.UnixSocket.Enabled = false
+	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &disabled
+	cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata = &disabled
+	cfg.Sandbox.Seccomp.SocketRules = []config.SandboxSeccompSocketRuleConfig{{
+		Name:     "dirtyfrag-xfrm",
+		Family:   "AF_NETLINK",
+		Protocol: "NETLINK_XFRM",
+		Action:   "log",
+	}}
+	app := &App{cfg: cfg}
+	if !app.mainFilterUsesUserNotify(false) {
+		t.Fatal("mainFilterUsesUserNotify should return true when a socket rule uses log")
 	}
 }
 

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/internal/store/composite"
 	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/stretchr/testify/require"
 )
 
 func newTestAppForWrap(t *testing.T, cfg *config.Config) (*App, *session.Manager) {
@@ -28,6 +29,14 @@ func newTestAppForWrap(t *testing.T, cfg *config.Config) (*App, *session.Manager
 	broker := events.NewBroker()
 	app := NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil)
 	return app, mgr
+}
+
+func addTestMitigationSet(t *testing.T, cfg *config.Config, id string, data string) {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, id+".yaml"), []byte(data), 0o600))
+	cfg.Sandbox.Seccomp.MitigationSets = append(cfg.Sandbox.Seccomp.MitigationSets, id)
+	cfg.Sandbox.Seccomp.MitigationDirs = append(cfg.Sandbox.Seccomp.MitigationDirs, dir)
 }
 
 func nonzeroTestUID() int {
@@ -896,6 +905,87 @@ func TestWrapInit_SeccompConfigContent(t *testing.T) {
 	}
 }
 
+func TestWrapInit_SeccompConfigContent_MitigationSetsForwardSocketRules(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.Seccomp.MitigationSets = []string{"dirtyfrag-conservative"}
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, _, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.SeccompConfig == "" {
+		t.Fatal("expected seccomp config")
+	}
+
+	var parsed seccompWrapperConfig
+	require.NoError(t, json.Unmarshal([]byte(resp.SeccompConfig), &parsed))
+	require.Len(t, parsed.SocketRules, 2)
+	require.Equal(t, "dirtyfrag-conservative-rxrpc", parsed.SocketRules[0].Name)
+	require.Equal(t, "dirtyfrag-conservative-xfrm", parsed.SocketRules[1].Name)
+}
+
+func TestWrapInit_SeccompConfigContent_MitigationSetsForwardSyscallsAndFamilies(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.Seccomp.Syscalls.OnBlock = "log"
+	addTestMitigationSet(t, cfg, "api-runtime", `
+version: 1
+id: api-runtime
+seccomp:
+  syscalls:
+    block:
+      - ptrace
+  blocked_socket_families:
+    - family: AF_ALG
+      action: log
+`)
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, _, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.SeccompConfig == "" {
+		t.Fatal("expected seccomp config")
+	}
+
+	var parsed seccompWrapperConfig
+	require.NoError(t, json.Unmarshal([]byte(resp.SeccompConfig), &parsed))
+	require.Equal(t, []string{"ptrace"}, parsed.BlockedSyscalls)
+	require.Equal(t, "log", parsed.OnBlock)
+	require.Len(t, parsed.BlockedFamilies, 1)
+	require.Equal(t, "AF_ALG", parsed.BlockedFamilies[0].Name)
+	require.Equal(t, "log", string(parsed.BlockedFamilies[0].Action))
+}
+
 func TestWrapInit_LongTMPDIR_LongSessionID(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("wrap is Linux-only")
@@ -1437,7 +1527,7 @@ func TestMainFilterUsesUserNotify_SocketRuleLog(t *testing.T) {
 	}
 }
 
-func TestMainFilterUsesUserNotify_SocketRuleHardeningProfile(t *testing.T) {
+func TestMainFilterUsesUserNotify_SocketRuleMitigationSet(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("mainFilterUsesUserNotify is Linux-only")
 	}
@@ -1446,10 +1536,57 @@ func TestMainFilterUsesUserNotify_SocketRuleHardeningProfile(t *testing.T) {
 	cfg.Sandbox.Seccomp.UnixSocket.Enabled = false
 	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &disabled
 	cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata = &disabled
-	cfg.Sandbox.Seccomp.HardeningProfiles = []string{"dirtyfrag-conservative"}
+	cfg.Sandbox.Seccomp.MitigationSets = []string{"dirtyfrag-conservative"}
 	app := &App{cfg: cfg}
 	if !app.mainFilterUsesUserNotify(false) {
-		t.Fatal("mainFilterUsesUserNotify should return true when a hardening profile expands to log socket rules")
+		t.Fatal("mainFilterUsesUserNotify should return true when a mitigation set expands to log socket rules")
+	}
+}
+
+func TestMainFilterUsesUserNotify_MitigationSetSyscallLog(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("mainFilterUsesUserNotify is Linux-only")
+	}
+	cfg := &config.Config{}
+	disabled := false
+	cfg.Sandbox.Seccomp.UnixSocket.Enabled = false
+	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &disabled
+	cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata = &disabled
+	cfg.Sandbox.Seccomp.Syscalls.OnBlock = "log"
+	addTestMitigationSet(t, cfg, "notify-syscall", `
+version: 1
+id: notify-syscall
+seccomp:
+  syscalls:
+    block:
+      - ptrace
+`)
+	app := &App{cfg: cfg}
+	if !app.mainFilterUsesUserNotify(false) {
+		t.Fatal("mainFilterUsesUserNotify should return true when a mitigation set adds a log syscall block")
+	}
+}
+
+func TestMainFilterUsesUserNotify_MitigationSetFamilyLog(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("mainFilterUsesUserNotify is Linux-only")
+	}
+	cfg := &config.Config{}
+	disabled := false
+	cfg.Sandbox.Seccomp.UnixSocket.Enabled = false
+	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &disabled
+	cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata = &disabled
+	addTestMitigationSet(t, cfg, "notify-family", `
+version: 1
+id: notify-family
+seccomp:
+  blocked_socket_families:
+    - family: AF_ALG
+      action: log
+`)
+	app := &App{cfg: cfg}
+	if !app.mainFilterUsesUserNotify(false) {
+		t.Fatal("mainFilterUsesUserNotify should return true when a mitigation set adds a log socket family")
 	}
 }
 

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -1437,6 +1437,22 @@ func TestMainFilterUsesUserNotify_SocketRuleLog(t *testing.T) {
 	}
 }
 
+func TestMainFilterUsesUserNotify_SocketRuleHardeningProfile(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("mainFilterUsesUserNotify is Linux-only")
+	}
+	cfg := &config.Config{}
+	disabled := false
+	cfg.Sandbox.Seccomp.UnixSocket.Enabled = false
+	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &disabled
+	cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata = &disabled
+	cfg.Sandbox.Seccomp.HardeningProfiles = []string{"dirtyfrag-conservative"}
+	app := &App{cfg: cfg}
+	if !app.mainFilterUsesUserNotify(false) {
+		t.Fatal("mainFilterUsesUserNotify should return true when a hardening profile expands to log socket rules")
+	}
+}
+
 // TestMainFilterUsesUserNotify_FamilyLog verifies that mainFilterUsesUserNotify
 // returns true when the config contains a family with a log action, even when
 // all other notify-triggering options are disabled. This guards against the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -495,7 +495,12 @@ type SandboxSeccompConfig struct {
 	// seccomp.DefaultBlockedFamilies when nil.
 	BlockedSocketFamilies []SandboxSeccompSocketFamilyConfig `yaml:"blocked_socket_families"`
 	SocketRules           []SandboxSeccompSocketRuleConfig   `yaml:"socket_rules"`
-	HardeningProfiles     []string                           `yaml:"hardening_profiles"`
+	MitigationSets        []string                           `yaml:"mitigation_sets"`
+	MitigationDirs        []string                           `yaml:"mitigation_dirs"`
+	// HardeningProfiles is a deprecated alias for MitigationSets. It exists
+	// only so config files written against the Dirty Frag feature branch fail
+	// less abruptly while the public name changes.
+	HardeningProfiles []string `yaml:"hardening_profiles"`
 }
 
 // SandboxSeccompUnixConfig configures unix socket monitoring via seccomp.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -494,6 +494,8 @@ type SandboxSeccompConfig struct {
 	// (opt-out). Populated via applyDefaults from
 	// seccomp.DefaultBlockedFamilies when nil.
 	BlockedSocketFamilies []SandboxSeccompSocketFamilyConfig `yaml:"blocked_socket_families"`
+	SocketRules           []SandboxSeccompSocketRuleConfig   `yaml:"socket_rules"`
+	HardeningProfiles     []string                           `yaml:"hardening_profiles"`
 }
 
 // SandboxSeccompUnixConfig configures unix socket monitoring via seccomp.
@@ -530,6 +532,14 @@ type SandboxSeccompFileMonitorConfig struct {
 type SandboxSeccompSocketFamilyConfig struct {
 	Family string `yaml:"family"` // AF_* name or numeric string
 	Action string `yaml:"action"` // errno|kill|log|log_and_kill (defaults to errno)
+}
+
+type SandboxSeccompSocketRuleConfig struct {
+	Name     string `yaml:"name"`
+	Family   string `yaml:"family"`
+	Type     string `yaml:"type,omitempty"`
+	Protocol string `yaml:"protocol,omitempty"`
+	Action   string `yaml:"action"`
 }
 
 // FileMonitorBoolWithDefault returns the value of a *bool field, or defaultVal if nil.
@@ -2311,6 +2321,9 @@ func validateConfig(cfg *Config) error {
 				return fmt.Errorf("sandbox.seccomp.blocked_socket_families[%d].action: %q is not valid (allowed: errno, kill, log, log_and_kill)", i, e.Action)
 			}
 		}
+	}
+	if _, err := ResolveSocketRules(cfg.Sandbox.Seccomp); err != nil {
+		return fmt.Errorf("sandbox.seccomp.%w", err)
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -497,10 +497,6 @@ type SandboxSeccompConfig struct {
 	SocketRules           []SandboxSeccompSocketRuleConfig   `yaml:"socket_rules"`
 	MitigationSets        []string                           `yaml:"mitigation_sets"`
 	MitigationDirs        []string                           `yaml:"mitigation_dirs"`
-	// HardeningProfiles is a deprecated alias for MitigationSets. It exists
-	// only so config files written against the Dirty Frag feature branch fail
-	// less abruptly while the public name changes.
-	HardeningProfiles []string `yaml:"hardening_profiles"`
 }
 
 // SandboxSeccompUnixConfig configures unix socket monitoring via seccomp.
@@ -1316,6 +1312,9 @@ func Load(path string) (*Config, error) {
 
 	// Expand environment variables in config content (e.g., $HOME, ${HOME})
 	expanded := os.ExpandEnv(string(b))
+	if err := rejectRemovedConfigKeys([]byte(expanded)); err != nil {
+		return nil, err
+	}
 
 	var cfg Config
 	// Pre-seed ptrace performance defaults before YAML unmarshal.
@@ -1335,6 +1334,46 @@ func Load(path string) (*Config, error) {
 	return &cfg, nil
 }
 
+func rejectRemovedConfigKeys(data []byte) error {
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return fmt.Errorf("parse config: %w", err)
+	}
+	if yamlMappingPathExists(&root, "sandbox", "seccomp", "hardening_profiles") {
+		return fmt.Errorf("sandbox.seccomp.hardening_profiles has been removed; use sandbox.seccomp.mitigation_sets")
+	}
+	return nil
+}
+
+func yamlMappingPathExists(node *yaml.Node, path ...string) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == yaml.DocumentNode {
+		if len(node.Content) == 0 {
+			return false
+		}
+		node = node.Content[0]
+	}
+	for _, want := range path {
+		if node == nil || node.Kind != yaml.MappingNode {
+			return false
+		}
+		var next *yaml.Node
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			if node.Content[i].Value == want {
+				next = node.Content[i+1]
+				break
+			}
+		}
+		if next == nil {
+			return false
+		}
+		node = next
+	}
+	return true
+}
+
 // LoadWithSource loads config from path and returns the config along with its source.
 // The source parameter indicates where this config path came from.
 func LoadWithSource(path string, source ConfigSource) (*Config, ConfigSource, error) {
@@ -1345,6 +1384,9 @@ func LoadWithSource(path string, source ConfigSource) (*Config, ConfigSource, er
 
 	// Expand environment variables in config content (e.g., $HOME, ${HOME})
 	expanded := os.ExpandEnv(string(b))
+	if err := rejectRemovedConfigKeys([]byte(expanded)); err != nil {
+		return nil, source, err
+	}
 
 	var cfg Config
 	// Pre-seed ptrace performance defaults before YAML unmarshal (same as Load).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2327,8 +2327,25 @@ func validateConfig(cfg *Config) error {
 			}
 		}
 	}
-	if _, err := ResolveSocketRules(cfg.Sandbox.Seccomp); err != nil {
+	effective, err := EffectiveSeccompRulesForConfig(cfg.Sandbox.Seccomp)
+	if err != nil {
 		return fmt.Errorf("sandbox.seccomp.%w", err)
+	}
+	if _, err := ResolveBlockedFamilies(effective.BlockedSocketFamilies); err != nil {
+		return fmt.Errorf("sandbox.seccomp.%w", err)
+	}
+	if _, err := resolveSocketRuleConfigs(effective.SocketRules); err != nil {
+		return fmt.Errorf("sandbox.seccomp.%w", err)
+	}
+	for _, loaded := range effective.LoadedMitigations {
+		slog.Info("seccomp mitigation loaded",
+			"id", loaded.ID,
+			"source", loaded.Source,
+			"path", loaded.Path,
+			"checksum", loaded.Checksum,
+			"socket_rules", loaded.SocketRules,
+			"blocked_socket_families", loaded.BlockedSocketFamilies,
+			"syscalls", loaded.Syscalls)
 	}
 	return nil
 }

--- a/internal/config/mitigations/dirtyfrag-conservative.yaml
+++ b/internal/config/mitigations/dirtyfrag-conservative.yaml
@@ -1,0 +1,15 @@
+version: 1
+id: dirtyfrag-conservative
+title: Dirty Frag conservative mitigation
+references:
+  - https://www.openwall.com/lists/oss-security/2026/05/07/8
+
+seccomp:
+  socket_rules:
+    - name: dirtyfrag-conservative-rxrpc
+      family: AF_RXRPC
+      action: log_and_kill
+    - name: dirtyfrag-conservative-xfrm
+      family: AF_NETLINK
+      protocol: NETLINK_XFRM
+      action: log_and_kill

--- a/internal/config/seccomp_mitigations.go
+++ b/internal/config/seccomp_mitigations.go
@@ -1,0 +1,239 @@
+package config
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed mitigations/*.yaml
+var builtinMitigationFS embed.FS
+
+var mitigationIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+
+type EffectiveSeccompRules struct {
+	SocketRules           []SandboxSeccompSocketRuleConfig
+	BlockedSocketFamilies []SandboxSeccompSocketFamilyConfig
+	SyscallBlock          []string
+	SyscallOnBlock        string
+	LoadedMitigations     []MitigationLoadInfo
+}
+
+type MitigationLoadInfo struct {
+	ID                    string
+	Source                string
+	Path                  string
+	Checksum              string
+	SocketRules           int
+	BlockedSocketFamilies int
+	Syscalls              int
+}
+
+type mitigationDocument struct {
+	Version    int               `yaml:"version"`
+	ID         string            `yaml:"id"`
+	Title      string            `yaml:"title,omitempty"`
+	References []string          `yaml:"references,omitempty"`
+	Seccomp    mitigationSeccomp `yaml:"seccomp"`
+}
+
+type mitigationSeccomp struct {
+	SocketRules           []SandboxSeccompSocketRuleConfig   `yaml:"socket_rules"`
+	BlockedSocketFamilies []SandboxSeccompSocketFamilyConfig `yaml:"blocked_socket_families"`
+	Syscalls              mitigationSyscalls                 `yaml:"syscalls"`
+}
+
+type mitigationSyscalls struct {
+	Block   []string `yaml:"block"`
+	OnBlock string   `yaml:"on_block"`
+}
+
+func EffectiveSeccompRulesForConfig(in SandboxSeccompConfig) (EffectiveSeccompRules, error) {
+	out := EffectiveSeccompRules{
+		SocketRules:           append([]SandboxSeccompSocketRuleConfig(nil), in.SocketRules...),
+		BlockedSocketFamilies: append([]SandboxSeccompSocketFamilyConfig(nil), in.BlockedSocketFamilies...),
+		SyscallBlock:          append([]string(nil), in.Syscalls.Block...),
+		SyscallOnBlock:        in.Syscalls.OnBlock,
+	}
+	if out.SyscallOnBlock == "" {
+		out.SyscallOnBlock = "errno"
+	}
+
+	requests, err := requestedMitigationSetIDs(in)
+	if err != nil {
+		return EffectiveSeccompRules{}, err
+	}
+	for _, request := range requests {
+		doc, info, err := loadMitigationSet(request.id, in.MitigationDirs)
+		if err != nil {
+			return EffectiveSeccompRules{}, fmt.Errorf("%s[%d]: %w", request.field, request.index, err)
+		}
+		if doc.Seccomp.Syscalls.OnBlock != "" && doc.Seccomp.Syscalls.OnBlock != out.SyscallOnBlock {
+			return EffectiveSeccompRules{}, fmt.Errorf("%s[%d] %q: seccomp.syscalls.on_block %q conflicts with effective sandbox.seccomp.syscalls.on_block %q",
+				request.field, request.index, request.id, doc.Seccomp.Syscalls.OnBlock, out.SyscallOnBlock)
+		}
+		out.SocketRules = append(out.SocketRules, doc.Seccomp.SocketRules...)
+		out.BlockedSocketFamilies = append(out.BlockedSocketFamilies, doc.Seccomp.BlockedSocketFamilies...)
+		out.SyscallBlock = append(out.SyscallBlock, doc.Seccomp.Syscalls.Block...)
+		out.LoadedMitigations = append(out.LoadedMitigations, info)
+	}
+	return out, nil
+}
+
+type requestedMitigationSet struct {
+	field string
+	index int
+	id    string
+}
+
+func requestedMitigationSetIDs(in SandboxSeccompConfig) ([]requestedMitigationSet, error) {
+	requests := make([]requestedMitigationSet, 0, len(in.MitigationSets)+len(in.HardeningProfiles))
+	seen := map[string]struct{}{}
+	for _, source := range []struct {
+		field string
+		vals  []string
+	}{
+		{field: "mitigation_sets", vals: in.MitigationSets},
+		{field: "hardening_profiles", vals: in.HardeningProfiles},
+	} {
+		for i, id := range source.vals {
+			if !mitigationIDPattern.MatchString(id) {
+				return nil, fmt.Errorf("%s[%d]: invalid mitigation set id %q", source.field, i, id)
+			}
+			if _, ok := seen[id]; ok {
+				return nil, fmt.Errorf("duplicate mitigation set %q", id)
+			}
+			seen[id] = struct{}{}
+			requests = append(requests, requestedMitigationSet{
+				field: source.field,
+				index: i,
+				id:    id,
+			})
+		}
+	}
+	return requests, nil
+}
+
+func loadMitigationSet(id string, dirs []string) (mitigationDocument, MitigationLoadInfo, error) {
+	builtinData, builtinFound, err := readBuiltinMitigation(id)
+	if err != nil {
+		return mitigationDocument{}, MitigationLoadInfo{}, err
+	}
+	externalData, externalPath, externalFound, err := readExternalMitigation(id, dirs)
+	if err != nil {
+		return mitigationDocument{}, MitigationLoadInfo{}, err
+	}
+	if builtinFound && externalFound {
+		return mitigationDocument{}, MitigationLoadInfo{}, fmt.Errorf("%q exists as both built-in and external mitigation %q", id, externalPath)
+	}
+	if !builtinFound && !externalFound {
+		return mitigationDocument{}, MitigationLoadInfo{}, fmt.Errorf("unknown mitigation set %q", id)
+	}
+
+	source := "builtin"
+	path := mitigationFSPath(id)
+	data := builtinData
+	if externalFound {
+		source = "external"
+		path = externalPath
+		data = externalData
+	}
+	doc, err := decodeMitigation(id, data, path)
+	if err != nil {
+		return mitigationDocument{}, MitigationLoadInfo{}, err
+	}
+	sum := sha256.Sum256(data)
+	info := MitigationLoadInfo{
+		ID:                    id,
+		Source:                source,
+		Path:                  path,
+		Checksum:              "sha256:" + hex.EncodeToString(sum[:]),
+		SocketRules:           len(doc.Seccomp.SocketRules),
+		BlockedSocketFamilies: len(doc.Seccomp.BlockedSocketFamilies),
+		Syscalls:              len(doc.Seccomp.Syscalls.Block),
+	}
+	return doc, info, nil
+}
+
+func readBuiltinMitigation(id string) ([]byte, bool, error) {
+	data, err := builtinMitigationFS.ReadFile(mitigationFSPath(id))
+	if err == nil {
+		return data, true, nil
+	}
+	if errorsIsNotExist(err) {
+		return nil, false, nil
+	}
+	return nil, false, fmt.Errorf("read built-in mitigation %q: %w", id, err)
+}
+
+func readExternalMitigation(id string, dirs []string) ([]byte, string, bool, error) {
+	var foundPath string
+	for _, dir := range dirs {
+		for _, name := range []string{id + ".yaml", id + ".yml"} {
+			candidate := filepath.Join(dir, name)
+			if _, err := os.Stat(candidate); err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				return nil, "", false, fmt.Errorf("stat external mitigation %q: %w", candidate, err)
+			}
+			if foundPath != "" {
+				return nil, "", false, fmt.Errorf("mitigation set %q found in multiple external files: %q and %q", id, foundPath, candidate)
+			}
+			foundPath = candidate
+		}
+	}
+	if foundPath == "" {
+		return nil, "", false, nil
+	}
+	if err := validateMitigationPathPermissions(foundPath); err != nil {
+		return nil, "", false, err
+	}
+	data, err := os.ReadFile(foundPath)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("read external mitigation %q: %w", foundPath, err)
+	}
+	return data, foundPath, true, nil
+}
+
+func decodeMitigation(requestedID string, data []byte, source string) (mitigationDocument, error) {
+	var doc mitigationDocument
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&doc); err != nil {
+		return mitigationDocument{}, fmt.Errorf("parse mitigation %q: %w", source, err)
+	}
+	if doc.Version != 1 {
+		return mitigationDocument{}, fmt.Errorf("mitigation %q: version must be 1", source)
+	}
+	if doc.ID != requestedID {
+		return mitigationDocument{}, fmt.Errorf("mitigation %q: id %q does not match requested id %q", source, doc.ID, requestedID)
+	}
+	if len(doc.Seccomp.SocketRules) == 0 &&
+		len(doc.Seccomp.BlockedSocketFamilies) == 0 &&
+		len(doc.Seccomp.Syscalls.Block) == 0 {
+		return mitigationDocument{}, fmt.Errorf("mitigation %q: empty mitigations are not allowed", source)
+	}
+	return doc, nil
+}
+
+func mitigationFSPath(id string) string {
+	return filepath.ToSlash(filepath.Join("mitigations", id+".yaml"))
+}
+
+func errorsIsNotExist(err error) bool {
+	return os.IsNotExist(err) || errors.Is(err, fs.ErrNotExist)
+}
+
+func validateMitigationPathPermissions(string) error {
+	return nil
+}

--- a/internal/config/seccomp_mitigations.go
+++ b/internal/config/seccomp_mitigations.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/agentsh/agentsh/internal/seccomp"
 	"gopkg.in/yaml.v3"
 )
 
@@ -88,6 +89,22 @@ func EffectiveSeccompRulesForConfig(in SandboxSeccompConfig) (EffectiveSeccompRu
 		out.LoadedMitigations = append(out.LoadedMitigations, info)
 	}
 	return out, nil
+}
+
+func ResolveEffectiveBlockedFamilies(in SandboxSeccompConfig) ([]seccomp.BlockedFamily, error) {
+	effective, err := EffectiveSeccompRulesForConfig(in)
+	if err != nil {
+		return nil, err
+	}
+	return ResolveBlockedFamilies(effective.BlockedSocketFamilies)
+}
+
+func EffectiveSyscallBlock(in SandboxSeccompConfig) ([]string, string, error) {
+	effective, err := EffectiveSeccompRulesForConfig(in)
+	if err != nil {
+		return nil, "", err
+	}
+	return effective.SyscallBlock, effective.SyscallOnBlock, nil
 }
 
 type requestedMitigationSet struct {

--- a/internal/config/seccomp_mitigations.go
+++ b/internal/config/seccomp_mitigations.go
@@ -176,33 +176,7 @@ func readBuiltinMitigation(id string) ([]byte, bool, error) {
 }
 
 func readExternalMitigation(id string, dirs []string) ([]byte, string, bool, error) {
-	var foundPath string
-	for _, dir := range dirs {
-		for _, name := range []string{id + ".yaml", id + ".yml"} {
-			candidate := filepath.Join(dir, name)
-			if _, err := os.Stat(candidate); err != nil {
-				if os.IsNotExist(err) {
-					continue
-				}
-				return nil, "", false, fmt.Errorf("stat external mitigation %q: %w", candidate, err)
-			}
-			if foundPath != "" {
-				return nil, "", false, fmt.Errorf("mitigation set %q found in multiple external files: %q and %q", id, foundPath, candidate)
-			}
-			foundPath = candidate
-		}
-	}
-	if foundPath == "" {
-		return nil, "", false, nil
-	}
-	if err := validateMitigationPathPermissions(foundPath); err != nil {
-		return nil, "", false, err
-	}
-	data, err := os.ReadFile(foundPath)
-	if err != nil {
-		return nil, "", false, fmt.Errorf("read external mitigation %q: %w", foundPath, err)
-	}
-	return data, foundPath, true, nil
+	return nil, "", false, nil
 }
 
 func decodeMitigation(requestedID string, data []byte, source string) (mitigationDocument, error) {
@@ -232,8 +206,4 @@ func mitigationFSPath(id string) string {
 
 func errorsIsNotExist(err error) bool {
 	return os.IsNotExist(err) || errors.Is(err, fs.ErrNotExist)
-}
-
-func validateMitigationPathPermissions(string) error {
-	return nil
 }

--- a/internal/config/seccomp_mitigations.go
+++ b/internal/config/seccomp_mitigations.go
@@ -114,29 +114,21 @@ type requestedMitigationSet struct {
 }
 
 func requestedMitigationSetIDs(in SandboxSeccompConfig) ([]requestedMitigationSet, error) {
-	requests := make([]requestedMitigationSet, 0, len(in.MitigationSets)+len(in.HardeningProfiles))
+	requests := make([]requestedMitigationSet, 0, len(in.MitigationSets))
 	seen := map[string]struct{}{}
-	for _, source := range []struct {
-		field string
-		vals  []string
-	}{
-		{field: "mitigation_sets", vals: in.MitigationSets},
-		{field: "hardening_profiles", vals: in.HardeningProfiles},
-	} {
-		for i, id := range source.vals {
-			if !mitigationIDPattern.MatchString(id) {
-				return nil, fmt.Errorf("%s[%d]: invalid mitigation set id %q", source.field, i, id)
-			}
-			if _, ok := seen[id]; ok {
-				return nil, fmt.Errorf("duplicate mitigation set %q", id)
-			}
-			seen[id] = struct{}{}
-			requests = append(requests, requestedMitigationSet{
-				field: source.field,
-				index: i,
-				id:    id,
-			})
+	for i, id := range in.MitigationSets {
+		if !mitigationIDPattern.MatchString(id) {
+			return nil, fmt.Errorf("mitigation_sets[%d]: invalid mitigation set id %q", i, id)
 		}
+		if _, ok := seen[id]; ok {
+			return nil, fmt.Errorf("duplicate mitigation set %q", id)
+		}
+		seen[id] = struct{}{}
+		requests = append(requests, requestedMitigationSet{
+			field: "mitigation_sets",
+			index: i,
+			id:    id,
+		})
 	}
 	return requests, nil
 }

--- a/internal/config/seccomp_mitigations.go
+++ b/internal/config/seccomp_mitigations.go
@@ -181,11 +181,15 @@ func readExternalMitigation(id string, dirs []string) ([]byte, string, bool, err
 	for _, dir := range dirs {
 		for _, name := range []string{id + ".yaml", id + ".yml"} {
 			candidate := filepath.Join(dir, name)
-			if _, err := os.Stat(candidate); err != nil {
+			info, err := os.Stat(candidate)
+			if err != nil {
 				if os.IsNotExist(err) {
 					continue
 				}
 				return nil, "", false, fmt.Errorf("stat external mitigation %q: %w", candidate, err)
+			}
+			if !info.Mode().IsRegular() {
+				return nil, "", false, fmt.Errorf("external mitigation path %q is not a regular file", candidate)
 			}
 			if foundPath != "" {
 				return nil, "", false, fmt.Errorf("mitigation set %q found in multiple external files: %q and %q", id, foundPath, candidate)

--- a/internal/config/seccomp_mitigations.go
+++ b/internal/config/seccomp_mitigations.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -176,7 +177,33 @@ func readBuiltinMitigation(id string) ([]byte, bool, error) {
 }
 
 func readExternalMitigation(id string, dirs []string) ([]byte, string, bool, error) {
-	return nil, "", false, nil
+	var foundPath string
+	for _, dir := range dirs {
+		for _, name := range []string{id + ".yaml", id + ".yml"} {
+			candidate := filepath.Join(dir, name)
+			if _, err := os.Stat(candidate); err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				return nil, "", false, fmt.Errorf("stat external mitigation %q: %w", candidate, err)
+			}
+			if foundPath != "" {
+				return nil, "", false, fmt.Errorf("mitigation set %q found in multiple external files: %q and %q", id, foundPath, candidate)
+			}
+			foundPath = candidate
+		}
+	}
+	if foundPath == "" {
+		return nil, "", false, nil
+	}
+	if err := validateMitigationPathPermissions(foundPath); err != nil {
+		return nil, "", false, err
+	}
+	data, err := os.ReadFile(foundPath)
+	if err != nil {
+		return nil, "", false, fmt.Errorf("read external mitigation %q: %w", foundPath, err)
+	}
+	return data, foundPath, true, nil
 }
 
 func decodeMitigation(requestedID string, data []byte, source string) (mitigationDocument, error) {
@@ -185,6 +212,14 @@ func decodeMitigation(requestedID string, data []byte, source string) (mitigatio
 	dec.KnownFields(true)
 	if err := dec.Decode(&doc); err != nil {
 		return mitigationDocument{}, fmt.Errorf("parse mitigation %q: %w", source, err)
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != nil {
+		if !errors.Is(err, io.EOF) {
+			return mitigationDocument{}, fmt.Errorf("parse mitigation %q: %w", source, err)
+		}
+	} else {
+		return mitigationDocument{}, fmt.Errorf("mitigation %q: multiple YAML documents are not allowed", source)
 	}
 	if doc.Version != 1 {
 		return mitigationDocument{}, fmt.Errorf("mitigation %q: version must be 1", source)

--- a/internal/config/seccomp_mitigations_fifo_other_test.go
+++ b/internal/config/seccomp_mitigations_fifo_other_test.go
@@ -1,0 +1,15 @@
+//go:build !linux && !darwin
+
+package config
+
+import "testing"
+
+func createExternalMitigationFIFO(t *testing.T, path string) {
+	t.Helper()
+	t.Skip("Unix special files are not portable to this platform")
+}
+
+func startExternalMitigationFIFOWriter(t *testing.T, path string, data []byte) func() {
+	t.Helper()
+	return func() {}
+}

--- a/internal/config/seccomp_mitigations_fifo_unix_test.go
+++ b/internal/config/seccomp_mitigations_fifo_unix_test.go
@@ -1,0 +1,57 @@
+//go:build linux || darwin
+
+package config
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func createExternalMitigationFIFO(t *testing.T, path string) {
+	t.Helper()
+	require.NoError(t, unix.Mkfifo(path, 0o600))
+}
+
+func startExternalMitigationFIFOWriter(t *testing.T, path string, data []byte) func() {
+	t.Helper()
+
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+
+		ticker := time.NewTicker(time.Millisecond)
+		defer ticker.Stop()
+		timeout := time.NewTimer(2 * time.Second)
+		defer timeout.Stop()
+
+		for {
+			fd, err := unix.Open(path, unix.O_WRONLY|unix.O_NONBLOCK, 0)
+			if err == nil {
+				_, _ = unix.Write(fd, data)
+				_ = unix.Close(fd)
+				return
+			}
+			if !errors.Is(err, unix.ENXIO) {
+				return
+			}
+
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+			case <-timeout.C:
+				return
+			}
+		}
+	}()
+
+	return func() {
+		close(done)
+		<-finished
+	}
+}

--- a/internal/config/seccomp_mitigations_other.go
+++ b/internal/config/seccomp_mitigations_other.go
@@ -1,0 +1,7 @@
+//go:build !linux && !darwin
+
+package config
+
+func validateMitigationPathPermissions(filePath string) error {
+	return nil
+}

--- a/internal/config/seccomp_mitigations_test.go
+++ b/internal/config/seccomp_mitigations_test.go
@@ -108,6 +108,31 @@ seccomp:
 	require.Equal(t, path, eff.LoadedMitigations[0].Path)
 }
 
+func TestEffectiveSeccompRules_ExternalMitigationYMLFallback(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "local-yml.yml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+version: 1
+id: local-yml
+seccomp:
+  socket_rules:
+    - name: local-yml
+      family: AF_RXRPC
+      action: log
+`), 0o600))
+
+	eff, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"local-yml"},
+		MitigationDirs: []string{dir},
+	})
+	require.NoError(t, err)
+	require.Len(t, eff.SocketRules, 1)
+	require.Equal(t, "local-yml", eff.SocketRules[0].Name)
+	require.Len(t, eff.LoadedMitigations, 1)
+	require.Equal(t, "external", eff.LoadedMitigations[0].Source)
+	require.Equal(t, path, eff.LoadedMitigations[0].Path)
+}
+
 func TestEffectiveSeccompRules_RejectsInvalidMitigationID(t *testing.T) {
 	for _, id := range []string{"../dirtyfrag", "/dirtyfrag", "DirtyFrag", ""} {
 		t.Run(id, func(t *testing.T) {
@@ -194,6 +219,52 @@ seccomp:
 	require.Contains(t, err.Error(), "exists as both built-in and external")
 }
 
+func TestEffectiveSeccompRules_RejectsDuplicateExternalFiles(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte(`
+version: 1
+id: dupe
+seccomp:
+  socket_rules:
+    - name: dupe
+      family: AF_RXRPC
+`)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dupe.yaml"), data, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dupe.yml"), data, 0o600))
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"dupe"},
+		MitigationDirs: []string{dir},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "multiple external files")
+}
+
+func TestEffectiveSeccompRules_RejectsNonRegularExternalMitigationPathOnUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix special files are not portable to Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pipe.yaml")
+	createExternalMitigationFIFO(t, path)
+	stopWriter := startExternalMitigationFIFOWriter(t, path, []byte(`
+version: 1
+id: pipe
+seccomp:
+  socket_rules:
+    - name: pipe
+      family: AF_RXRPC
+`))
+	defer stopWriter()
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"pipe"},
+		MitigationDirs: []string{dir},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not a regular file")
+}
+
 func TestEffectiveSeccompRules_RejectsWorldWritableExternalFileOnUnix(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix mode bits are not portable to Windows")
@@ -212,6 +283,32 @@ seccomp:
 
 	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
 		MitigationSets: []string{"unsafe"},
+		MitigationDirs: []string{dir},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "world-writable")
+}
+
+func TestEffectiveSeccompRules_RejectsWorldWritableExternalDirectoryOnUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix mode bits are not portable to Windows")
+	}
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "unsafe-dir.yaml"), []byte(`
+version: 1
+id: unsafe-dir
+seccomp:
+  socket_rules:
+    - name: unsafe-dir
+      family: AF_RXRPC
+`), 0o600))
+	require.NoError(t, os.Chmod(dir, 0o777))
+	defer func() {
+		require.NoError(t, os.Chmod(dir, 0o700))
+	}()
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"unsafe-dir"},
 		MitigationDirs: []string{dir},
 	})
 	require.Error(t, err)

--- a/internal/config/seccomp_mitigations_test.go
+++ b/internal/config/seccomp_mitigations_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/seccomp"
@@ -71,15 +70,6 @@ func TestEffectiveSeccompRules_RejectsUnknownMitigationSet(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `mitigation_sets[0]`)
 	require.Contains(t, err.Error(), "dirtyfrag")
-}
-
-func TestEffectiveSeccompRules_RejectsDuplicateRequestedDeprecatedAliasMitigationSet(t *testing.T) {
-	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
-		MitigationSets:    []string{"dirtyfrag-conservative"},
-		HardeningProfiles: []string{"dirtyfrag-conservative"},
-	})
-	require.Error(t, err)
-	require.True(t, strings.Contains(err.Error(), "duplicate mitigation set"), err.Error())
 }
 
 func TestEffectiveSeccompRules_ExternalMitigation(t *testing.T) {

--- a/internal/config/seccomp_mitigations_test.go
+++ b/internal/config/seccomp_mitigations_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -25,6 +27,19 @@ func TestEffectiveSeccompRules_BuiltInDirtyFrag(t *testing.T) {
 	require.Equal(t, "AF_NETLINK", eff.SocketRules[1].Family)
 	require.Equal(t, "NETLINK_XFRM", eff.SocketRules[1].Protocol)
 	require.Equal(t, "log_and_kill", eff.SocketRules[1].Action)
+}
+
+func TestEffectiveSeccompRules_IgnoresMitigationDirsForTask2(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dirtyfrag-conservative.yaml"), []byte("not: active\n"), 0o600))
+
+	eff, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"dirtyfrag-conservative"},
+		MitigationDirs: []string{dir},
+	})
+	require.NoError(t, err)
+	require.Len(t, eff.LoadedMitigations, 1)
+	require.Equal(t, "builtin", eff.LoadedMitigations[0].Source)
 }
 
 func TestResolveSocketRules_BuiltInDirtyFrag(t *testing.T) {

--- a/internal/config/seccomp_mitigations_test.go
+++ b/internal/config/seccomp_mitigations_test.go
@@ -1,0 +1,68 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/seccomp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEffectiveSeccompRules_BuiltInDirtyFrag(t *testing.T) {
+	eff, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"dirtyfrag-conservative"},
+	})
+	require.NoError(t, err)
+	require.Len(t, eff.LoadedMitigations, 1)
+	require.Equal(t, "dirtyfrag-conservative", eff.LoadedMitigations[0].ID)
+	require.Equal(t, "builtin", eff.LoadedMitigations[0].Source)
+	require.NotEmpty(t, eff.LoadedMitigations[0].Checksum)
+	require.Len(t, eff.SocketRules, 2)
+	require.Equal(t, "dirtyfrag-conservative-rxrpc", eff.SocketRules[0].Name)
+	require.Equal(t, "AF_RXRPC", eff.SocketRules[0].Family)
+	require.Equal(t, "log_and_kill", eff.SocketRules[0].Action)
+	require.Equal(t, "dirtyfrag-conservative-xfrm", eff.SocketRules[1].Name)
+	require.Equal(t, "AF_NETLINK", eff.SocketRules[1].Family)
+	require.Equal(t, "NETLINK_XFRM", eff.SocketRules[1].Protocol)
+	require.Equal(t, "log_and_kill", eff.SocketRules[1].Action)
+}
+
+func TestResolveSocketRules_BuiltInDirtyFrag(t *testing.T) {
+	rules, err := ResolveSocketRules(SandboxSeccompConfig{
+		MitigationSets: []string{"dirtyfrag-conservative"},
+	})
+	require.NoError(t, err)
+	require.Len(t, rules, 2)
+
+	rxrpcFamily, _, ok := seccomp.ParseFamily("AF_RXRPC")
+	require.True(t, ok)
+	netlinkFamily, _, ok := seccomp.ParseFamily("AF_NETLINK")
+	require.True(t, ok)
+	xfrmProtocol, _, ok := seccomp.ParseSocketProtocol("NETLINK_XFRM")
+	require.True(t, ok)
+
+	require.Equal(t, rxrpcFamily, rules[0].Family)
+	require.Equal(t, seccomp.OnBlockLogAndKill, rules[0].Action)
+	require.Equal(t, netlinkFamily, rules[1].Family)
+	require.NotNil(t, rules[1].Protocol)
+	require.Equal(t, xfrmProtocol, *rules[1].Protocol)
+	require.Equal(t, seccomp.OnBlockLogAndKill, rules[1].Action)
+}
+
+func TestEffectiveSeccompRules_RejectsUnknownMitigationSet(t *testing.T) {
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"dirtyfrag"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `mitigation_sets[0]`)
+	require.Contains(t, err.Error(), "dirtyfrag")
+}
+
+func TestEffectiveSeccompRules_RejectsDuplicateRequestedMitigationSet(t *testing.T) {
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets:    []string{"dirtyfrag-conservative"},
+		HardeningProfiles: []string{"dirtyfrag-conservative"},
+	})
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "duplicate mitigation set"), err.Error())
+}

--- a/internal/config/seccomp_mitigations_test.go
+++ b/internal/config/seccomp_mitigations_test.go
@@ -73,7 +73,7 @@ func TestEffectiveSeccompRules_RejectsUnknownMitigationSet(t *testing.T) {
 	require.Contains(t, err.Error(), "dirtyfrag")
 }
 
-func TestEffectiveSeccompRules_RejectsDuplicateRequestedMitigationSet(t *testing.T) {
+func TestEffectiveSeccompRules_RejectsDuplicateRequestedDeprecatedAliasMitigationSet(t *testing.T) {
 	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
 		MitigationSets:    []string{"dirtyfrag-conservative"},
 		HardeningProfiles: []string{"dirtyfrag-conservative"},

--- a/internal/config/seccomp_mitigations_test.go
+++ b/internal/config/seccomp_mitigations_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -29,17 +30,16 @@ func TestEffectiveSeccompRules_BuiltInDirtyFrag(t *testing.T) {
 	require.Equal(t, "log_and_kill", eff.SocketRules[1].Action)
 }
 
-func TestEffectiveSeccompRules_IgnoresMitigationDirsForTask2(t *testing.T) {
+func TestEffectiveSeccompRules_RejectsBuiltInExternalDuplicateBeforeParsing(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "dirtyfrag-conservative.yaml"), []byte("not: active\n"), 0o600))
 
-	eff, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
 		MitigationSets: []string{"dirtyfrag-conservative"},
 		MitigationDirs: []string{dir},
 	})
-	require.NoError(t, err)
-	require.Len(t, eff.LoadedMitigations, 1)
-	require.Equal(t, "builtin", eff.LoadedMitigations[0].Source)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exists as both built-in and external")
 }
 
 func TestResolveSocketRules_BuiltInDirtyFrag(t *testing.T) {
@@ -80,4 +80,185 @@ func TestEffectiveSeccompRules_RejectsDuplicateRequestedMitigationSet(t *testing
 	})
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "duplicate mitigation set"), err.Error())
+}
+
+func TestEffectiveSeccompRules_ExternalMitigation(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "local-xfrm.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+version: 1
+id: local-xfrm
+seccomp:
+  socket_rules:
+    - name: local-xfrm
+      family: AF_NETLINK
+      protocol: NETLINK_XFRM
+      action: log
+`), 0o600))
+
+	eff, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"local-xfrm"},
+		MitigationDirs: []string{dir},
+	})
+	require.NoError(t, err)
+	require.Len(t, eff.SocketRules, 1)
+	require.Equal(t, "local-xfrm", eff.SocketRules[0].Name)
+	require.Len(t, eff.LoadedMitigations, 1)
+	require.Equal(t, "external", eff.LoadedMitigations[0].Source)
+	require.Equal(t, path, eff.LoadedMitigations[0].Path)
+}
+
+func TestEffectiveSeccompRules_RejectsInvalidMitigationID(t *testing.T) {
+	for _, id := range []string{"../dirtyfrag", "/dirtyfrag", "DirtyFrag", ""} {
+		t.Run(id, func(t *testing.T) {
+			_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+				MitigationSets: []string{id},
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid mitigation set id")
+		})
+	}
+}
+
+func TestEffectiveSeccompRules_RejectsUnknownYAMLFields(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.yaml"), []byte(`
+version: 1
+id: bad
+unexpected: true
+seccomp:
+  socket_rules:
+    - name: bad
+      family: AF_RXRPC
+`), 0o600))
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"bad"},
+		MitigationDirs: []string{dir},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "field unexpected not found")
+}
+
+func TestEffectiveSeccompRules_RejectsMismatchedYAMLID(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "wanted.yaml"), []byte(`
+version: 1
+id: other
+seccomp:
+  socket_rules:
+    - name: other
+      family: AF_RXRPC
+`), 0o600))
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"wanted"},
+		MitigationDirs: []string{dir},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `id "other" does not match requested id "wanted"`)
+}
+
+func TestEffectiveSeccompRules_RejectsEmptyMitigation(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "empty.yaml"), []byte(`
+version: 1
+id: empty
+seccomp: {}
+`), 0o600))
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"empty"},
+		MitigationDirs: []string{dir},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty mitigations are not allowed")
+}
+
+func TestEffectiveSeccompRules_RejectsBuiltInExternalDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dirtyfrag-conservative.yaml"), []byte(`
+version: 1
+id: dirtyfrag-conservative
+seccomp:
+  socket_rules:
+    - name: replacement
+      family: AF_RXRPC
+`), 0o600))
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"dirtyfrag-conservative"},
+		MitigationDirs: []string{dir},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exists as both built-in and external")
+}
+
+func TestEffectiveSeccompRules_RejectsWorldWritableExternalFileOnUnix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix mode bits are not portable to Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "unsafe.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+version: 1
+id: unsafe
+seccomp:
+  socket_rules:
+    - name: unsafe
+      family: AF_RXRPC
+`), 0o666))
+	require.NoError(t, os.Chmod(path, 0o666))
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"unsafe"},
+		MitigationDirs: []string{dir},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "world-writable")
+}
+
+func TestEffectiveSeccompRules_RejectsTrailingYAMLDocument(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "multi.yaml"), []byte(`
+version: 1
+id: multi
+seccomp:
+  socket_rules:
+    - name: multi
+      family: AF_RXRPC
+---
+version: 1
+id: ignored
+seccomp:
+  socket_rules:
+    - name: ignored
+      family: AF_NETLINK
+`), 0o600))
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"multi"},
+		MitigationDirs: []string{dir},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "multiple YAML documents")
+}
+
+func TestEffectiveSeccompRules_RejectsBadMitigationVersion(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad-version.yaml"), []byte(`
+version: 2
+id: bad-version
+seccomp:
+  socket_rules:
+    - name: bad-version
+      family: AF_RXRPC
+`), 0o600))
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"bad-version"},
+		MitigationDirs: []string{dir},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "version must be 1")
 }

--- a/internal/config/seccomp_mitigations_test.go
+++ b/internal/config/seccomp_mitigations_test.go
@@ -359,3 +359,106 @@ seccomp:
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "version must be 1")
 }
+
+func TestEffectiveSeccompRules_MergesExternalFamiliesAndSyscalls(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "mixed.yaml"), []byte(`
+version: 1
+id: mixed
+seccomp:
+  blocked_socket_families:
+    - family: AF_ALG
+      action: log
+  syscalls:
+    block:
+      - ptrace
+    on_block: log
+`), 0o600))
+
+	eff, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"mixed"},
+		MitigationDirs: []string{dir},
+		Syscalls: SandboxSeccompSyscallConfig{
+			Block:   []string{"mount"},
+			OnBlock: "log",
+		},
+		BlockedSocketFamilies: []SandboxSeccompSocketFamilyConfig{{
+			Family: "AF_VSOCK",
+			Action: "errno",
+		}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"mount", "ptrace"}, eff.SyscallBlock)
+	require.Equal(t, "log", eff.SyscallOnBlock)
+	require.Len(t, eff.BlockedSocketFamilies, 2)
+	require.Equal(t, "AF_VSOCK", eff.BlockedSocketFamilies[0].Family)
+	require.Equal(t, "AF_ALG", eff.BlockedSocketFamilies[1].Family)
+}
+
+func TestEffectiveSeccompRules_RejectsSyscallOnBlockConflict(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "conflict.yaml"), []byte(`
+version: 1
+id: conflict
+seccomp:
+  syscalls:
+    block:
+      - ptrace
+    on_block: log_and_kill
+`), 0o600))
+
+	_, err := EffectiveSeccompRulesForConfig(SandboxSeccompConfig{
+		MitigationSets: []string{"conflict"},
+		MitigationDirs: []string{dir},
+		Syscalls: SandboxSeccompSyscallConfig{
+			OnBlock: "errno",
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "conflicts with effective sandbox.seccomp.syscalls.on_block")
+}
+
+func TestResolveEffectiveBlockedFamilies_MitigationSet(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "family.yaml"), []byte(`
+version: 1
+id: family
+seccomp:
+  blocked_socket_families:
+    - family: AF_ALG
+      action: log
+`), 0o600))
+
+	families, err := ResolveEffectiveBlockedFamilies(SandboxSeccompConfig{
+		MitigationSets: []string{"family"},
+		MitigationDirs: []string{dir},
+	})
+	require.NoError(t, err)
+	require.Len(t, families, 1)
+	require.Equal(t, "AF_ALG", families[0].Name)
+	require.Equal(t, seccomp.OnBlockLog, families[0].Action)
+}
+
+func TestEffectiveSyscallBlock_MitigationSet(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "syscalls.yaml"), []byte(`
+version: 1
+id: syscalls
+seccomp:
+  syscalls:
+    block:
+      - ptrace
+`), 0o600))
+
+	block, action, err := EffectiveSyscallBlock(SandboxSeccompConfig{
+		MitigationSets: []string{"syscalls"},
+		MitigationDirs: []string{dir},
+		Syscalls: SandboxSeccompSyscallConfig{
+			Block:   []string{"mount"},
+			OnBlock: "errno",
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"mount", "ptrace"}, block)
+	require.Equal(t, "errno", action)
+}

--- a/internal/config/seccomp_mitigations_unix.go
+++ b/internal/config/seccomp_mitigations_unix.go
@@ -1,0 +1,23 @@
+//go:build linux || darwin
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func validateMitigationPathPermissions(filePath string) error {
+	dir := filepath.Dir(filePath)
+	for _, path := range []string{dir, filePath} {
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("stat mitigation path %q: %w", path, err)
+		}
+		if info.Mode().Perm()&0o002 != 0 {
+			return fmt.Errorf("mitigation path %q is world-writable", path)
+		}
+	}
+	return nil
+}

--- a/internal/config/seccomp_socket_rules.go
+++ b/internal/config/seccomp_socket_rules.go
@@ -7,6 +7,8 @@ import (
 	"github.com/agentsh/agentsh/internal/seccomp"
 )
 
+const afNetlinkFamily = 16
+
 func ResolveSocketRules(in SandboxSeccompConfig) ([]seccomp.SocketRule, error) {
 	configs, err := effectiveSocketRuleConfigs(in)
 	if err != nil {
@@ -49,6 +51,9 @@ func ResolveSocketRules(in SandboxSeccompConfig) ([]seccomp.SocketRule, error) {
 			proto, protoName, ok := seccomp.ParseSocketProtocol(e.Protocol)
 			if !ok {
 				return nil, fmt.Errorf("socket_rules[%d].protocol: %q is not valid", i, e.Protocol)
+			}
+			if strings.HasPrefix(protoName, "NETLINK_") && family != afNetlinkFamily {
+				return nil, fmt.Errorf("socket_rules[%d].protocol: %q requires family AF_NETLINK", i, e.Protocol)
 			}
 			rule.Protocol = &proto
 			rule.ProtocolName = protoName

--- a/internal/config/seccomp_socket_rules.go
+++ b/internal/config/seccomp_socket_rules.go
@@ -10,10 +10,14 @@ import (
 const afNetlinkFamily = 16
 
 func ResolveSocketRules(in SandboxSeccompConfig) ([]seccomp.SocketRule, error) {
-	configs, err := effectiveSocketRuleConfigs(in)
+	effective, err := EffectiveSeccompRulesForConfig(in)
 	if err != nil {
 		return nil, err
 	}
+	return resolveSocketRuleConfigs(effective.SocketRules)
+}
+
+func resolveSocketRuleConfigs(configs []SandboxSeccompSocketRuleConfig) ([]seccomp.SocketRule, error) {
 	out := make([]seccomp.SocketRule, 0, len(configs))
 	seen := map[string]struct{}{}
 	for i, e := range configs {
@@ -59,32 +63,6 @@ func ResolveSocketRules(in SandboxSeccompConfig) ([]seccomp.SocketRule, error) {
 			rule.ProtocolName = protoName
 		}
 		out = append(out, rule)
-	}
-	return out, nil
-}
-
-func effectiveSocketRuleConfigs(in SandboxSeccompConfig) ([]SandboxSeccompSocketRuleConfig, error) {
-	out := make([]SandboxSeccompSocketRuleConfig, 0, len(in.SocketRules)+2*len(in.HardeningProfiles))
-	out = append(out, in.SocketRules...)
-	for i, profile := range in.HardeningProfiles {
-		switch profile {
-		case "dirtyfrag-conservative":
-			out = append(out,
-				SandboxSeccompSocketRuleConfig{
-					Name:   "dirtyfrag-conservative-rxrpc",
-					Family: "AF_RXRPC",
-					Action: "log_and_kill",
-				},
-				SandboxSeccompSocketRuleConfig{
-					Name:     "dirtyfrag-conservative-xfrm",
-					Family:   "AF_NETLINK",
-					Protocol: "NETLINK_XFRM",
-					Action:   "log_and_kill",
-				},
-			)
-		default:
-			return nil, fmt.Errorf("hardening_profiles[%d]: unknown profile %q", i, profile)
-		}
 	}
 	return out, nil
 }

--- a/internal/config/seccomp_socket_rules.go
+++ b/internal/config/seccomp_socket_rules.go
@@ -1,0 +1,85 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/agentsh/agentsh/internal/seccomp"
+)
+
+func ResolveSocketRules(in SandboxSeccompConfig) ([]seccomp.SocketRule, error) {
+	configs, err := effectiveSocketRuleConfigs(in)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]seccomp.SocketRule, 0, len(configs))
+	seen := map[string]struct{}{}
+	for i, e := range configs {
+		name := strings.TrimSpace(e.Name)
+		if name == "" {
+			return nil, fmt.Errorf("socket_rules[%d].name: required", i)
+		}
+		if _, ok := seen[name]; ok {
+			return nil, fmt.Errorf("duplicate socket rule name %q", name)
+		}
+		seen[name] = struct{}{}
+
+		family, familyName, ok := seccomp.ParseFamily(e.Family)
+		if !ok {
+			return nil, fmt.Errorf("socket_rules[%d].family: %q is not valid", i, e.Family)
+		}
+		actionStr := e.Action
+		if actionStr == "" {
+			actionStr = string(seccomp.OnBlockErrno)
+		}
+		action, ok := seccomp.ParseOnBlock(actionStr)
+		if !ok {
+			return nil, fmt.Errorf("socket_rules[%d].action: %q is not valid (allowed: errno, kill, log, log_and_kill)", i, e.Action)
+		}
+		rule := seccomp.SocketRule{Name: name, Family: family, FamilyName: familyName, Action: action}
+		if e.Type != "" {
+			typ, typName, ok := seccomp.ParseSocketType(e.Type)
+			if !ok {
+				return nil, fmt.Errorf("socket_rules[%d].type: %q is not valid", i, e.Type)
+			}
+			rule.Type = &typ
+			rule.TypeName = typName
+		}
+		if e.Protocol != "" {
+			proto, protoName, ok := seccomp.ParseSocketProtocol(e.Protocol)
+			if !ok {
+				return nil, fmt.Errorf("socket_rules[%d].protocol: %q is not valid", i, e.Protocol)
+			}
+			rule.Protocol = &proto
+			rule.ProtocolName = protoName
+		}
+		out = append(out, rule)
+	}
+	return out, nil
+}
+
+func effectiveSocketRuleConfigs(in SandboxSeccompConfig) ([]SandboxSeccompSocketRuleConfig, error) {
+	out := make([]SandboxSeccompSocketRuleConfig, 0, len(in.SocketRules)+2*len(in.HardeningProfiles))
+	out = append(out, in.SocketRules...)
+	for i, profile := range in.HardeningProfiles {
+		switch profile {
+		case "dirtyfrag-conservative":
+			out = append(out,
+				SandboxSeccompSocketRuleConfig{
+					Name:   "dirtyfrag-conservative-rxrpc",
+					Family: "AF_RXRPC",
+					Action: "log_and_kill",
+				},
+				SandboxSeccompSocketRuleConfig{
+					Name:     "dirtyfrag-conservative-xfrm",
+					Family:   "AF_NETLINK",
+					Protocol: "NETLINK_XFRM",
+					Action:   "log_and_kill",
+				},
+			)
+		default:
+			return nil, fmt.Errorf("hardening_profiles[%d]: unknown profile %q", i, profile)
+		}
+	}
+	return out, nil
+}

--- a/internal/config/seccomp_socket_rules_test.go
+++ b/internal/config/seccomp_socket_rules_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/agentsh/agentsh/internal/seccomp"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -55,26 +54,26 @@ sandbox:
 	require.Equal(t, []string{"dirtyfrag-conservative"}, cfg.Sandbox.Seccomp.HardeningProfiles)
 }
 
-func TestResolveSocketRules_DirtyFragProfile(t *testing.T) {
+func TestResolveSocketRules_DirtyFragMitigationSet(t *testing.T) {
+	cfg := SandboxSeccompConfig{
+		MitigationSets: []string{"dirtyfrag-conservative"},
+	}
+	rules, err := ResolveSocketRules(cfg)
+	require.NoError(t, err)
+	require.Len(t, rules, 2)
+	require.Equal(t, "dirtyfrag-conservative-rxrpc", rules[0].Name)
+	require.Equal(t, "dirtyfrag-conservative-xfrm", rules[1].Name)
+}
+
+func TestResolveSocketRules_HardeningProfilesDeprecatedAlias(t *testing.T) {
 	cfg := SandboxSeccompConfig{
 		HardeningProfiles: []string{"dirtyfrag-conservative"},
 	}
 	rules, err := ResolveSocketRules(cfg)
 	require.NoError(t, err)
 	require.Len(t, rules, 2)
-	rxrpcFamily, _, ok := seccomp.ParseFamily("AF_RXRPC")
-	require.True(t, ok)
-	netlinkFamily, _, ok := seccomp.ParseFamily("AF_NETLINK")
-	require.True(t, ok)
-	xfrmProtocol, _, ok := seccomp.ParseSocketProtocol("NETLINK_XFRM")
-	require.True(t, ok)
 	require.Equal(t, "dirtyfrag-conservative-rxrpc", rules[0].Name)
-	require.Equal(t, rxrpcFamily, rules[0].Family)
-	require.Equal(t, seccomp.OnBlockLogAndKill, rules[0].Action)
 	require.Equal(t, "dirtyfrag-conservative-xfrm", rules[1].Name)
-	require.Equal(t, netlinkFamily, rules[1].Family)
-	require.NotNil(t, rules[1].Protocol)
-	require.Equal(t, xfrmProtocol, *rules[1].Protocol)
 }
 
 func TestResolveSocketRules_RejectsBadProtocol(t *testing.T) {
@@ -121,15 +120,15 @@ func TestResolveSocketRules_AllowsNumericProtocolForNonNetlinkFamily(t *testing.
 	require.Equal(t, 6, *rules[0].Protocol)
 }
 
-func TestResolveSocketRules_RejectsUnknownProfile(t *testing.T) {
+func TestResolveSocketRules_RejectsUnknownMitigationSet(t *testing.T) {
 	_, err := ResolveSocketRules(SandboxSeccompConfig{
-		HardeningProfiles: []string{"dirtyfrag"},
+		MitigationSets: []string{"dirtyfrag"},
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), `hardening_profiles[0]`)
+	require.Contains(t, err.Error(), `mitigation_sets[0]`)
 }
 
-func TestResolveSocketRules_RejectsDuplicateNamesAfterProfileExpansion(t *testing.T) {
+func TestResolveSocketRules_RejectsDuplicateNamesAfterMitigationSetExpansion(t *testing.T) {
 	_, err := ResolveSocketRules(SandboxSeccompConfig{
 		SocketRules: []SandboxSeccompSocketRuleConfig{{
 			Name:     "dirtyfrag-conservative-xfrm",
@@ -137,7 +136,7 @@ func TestResolveSocketRules_RejectsDuplicateNamesAfterProfileExpansion(t *testin
 			Protocol: "NETLINK_XFRM",
 			Action:   "errno",
 		}},
-		HardeningProfiles: []string{"dirtyfrag-conservative"},
+		MitigationSets: []string{"dirtyfrag-conservative"},
 	})
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "duplicate socket rule name"), err.Error())

--- a/internal/config/seccomp_socket_rules_test.go
+++ b/internal/config/seccomp_socket_rules_test.go
@@ -42,32 +42,21 @@ sandbox:
 	require.Equal(t, []string{"admin-mitigations"}, cfg.Sandbox.Seccomp.MitigationDirs)
 }
 
-func TestSandboxSeccompHardeningProfiles_DeprecatedAliasParseYAML(t *testing.T) {
-	data := []byte(`
+func TestLoad_RejectsHardeningProfiles(t *testing.T) {
+	_, err := loadFromString(t, `
 sandbox:
   seccomp:
     hardening_profiles:
       - dirtyfrag-conservative
 `)
-	var cfg Config
-	require.NoError(t, yaml.Unmarshal(data, &cfg))
-	require.Equal(t, []string{"dirtyfrag-conservative"}, cfg.Sandbox.Seccomp.HardeningProfiles)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "sandbox.seccomp.hardening_profiles has been removed")
+	require.Contains(t, err.Error(), "sandbox.seccomp.mitigation_sets")
 }
 
 func TestResolveSocketRules_DirtyFragMitigationSet(t *testing.T) {
 	cfg := SandboxSeccompConfig{
 		MitigationSets: []string{"dirtyfrag-conservative"},
-	}
-	rules, err := ResolveSocketRules(cfg)
-	require.NoError(t, err)
-	require.Len(t, rules, 2)
-	require.Equal(t, "dirtyfrag-conservative-rxrpc", rules[0].Name)
-	require.Equal(t, "dirtyfrag-conservative-xfrm", rules[1].Name)
-}
-
-func TestResolveSocketRules_HardeningProfilesDeprecatedAlias(t *testing.T) {
-	cfg := SandboxSeccompConfig{
-		HardeningProfiles: []string{"dirtyfrag-conservative"},
 	}
 	rules, err := ResolveSocketRules(cfg)
 	require.NoError(t, err)

--- a/internal/config/seccomp_socket_rules_test.go
+++ b/internal/config/seccomp_socket_rules_test.go
@@ -35,12 +35,12 @@ sandbox:
     mitigation_sets:
       - dirtyfrag-conservative
     mitigation_dirs:
-      - /etc/agentsh/mitigations
+      - admin-mitigations
 `)
 	var cfg Config
 	require.NoError(t, yaml.Unmarshal(data, &cfg))
 	require.Equal(t, []string{"dirtyfrag-conservative"}, cfg.Sandbox.Seccomp.MitigationSets)
-	require.Equal(t, []string{"/etc/agentsh/mitigations"}, cfg.Sandbox.Seccomp.MitigationDirs)
+	require.Equal(t, []string{"admin-mitigations"}, cfg.Sandbox.Seccomp.MitigationDirs)
 }
 
 func TestSandboxSeccompHardeningProfiles_DeprecatedAliasParseYAML(t *testing.T) {

--- a/internal/config/seccomp_socket_rules_test.go
+++ b/internal/config/seccomp_socket_rules_test.go
@@ -28,6 +28,33 @@ sandbox:
 	require.Equal(t, "log_and_kill", cfg.Sandbox.Seccomp.SocketRules[0].Action)
 }
 
+func TestSandboxSeccompMitigationSets_ParseYAML(t *testing.T) {
+	data := []byte(`
+sandbox:
+  seccomp:
+    mitigation_sets:
+      - dirtyfrag-conservative
+    mitigation_dirs:
+      - /etc/agentsh/mitigations
+`)
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	require.Equal(t, []string{"dirtyfrag-conservative"}, cfg.Sandbox.Seccomp.MitigationSets)
+	require.Equal(t, []string{"/etc/agentsh/mitigations"}, cfg.Sandbox.Seccomp.MitigationDirs)
+}
+
+func TestSandboxSeccompHardeningProfiles_DeprecatedAliasParseYAML(t *testing.T) {
+	data := []byte(`
+sandbox:
+  seccomp:
+    hardening_profiles:
+      - dirtyfrag-conservative
+`)
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	require.Equal(t, []string{"dirtyfrag-conservative"}, cfg.Sandbox.Seccomp.HardeningProfiles)
+}
+
 func TestResolveSocketRules_DirtyFragProfile(t *testing.T) {
 	cfg := SandboxSeccompConfig{
 		HardeningProfiles: []string{"dirtyfrag-conservative"},

--- a/internal/config/seccomp_socket_rules_test.go
+++ b/internal/config/seccomp_socket_rules_test.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/seccomp"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSandboxSeccompSocketRules_ParseYAML(t *testing.T) {
+	data := []byte(`
+sandbox:
+  seccomp:
+    socket_rules:
+      - name: dirtyfrag-xfrm
+        family: AF_NETLINK
+        protocol: NETLINK_XFRM
+        action: log_and_kill
+`)
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	require.Len(t, cfg.Sandbox.Seccomp.SocketRules, 1)
+	require.Equal(t, "dirtyfrag-xfrm", cfg.Sandbox.Seccomp.SocketRules[0].Name)
+	require.Equal(t, "AF_NETLINK", cfg.Sandbox.Seccomp.SocketRules[0].Family)
+	require.Equal(t, "NETLINK_XFRM", cfg.Sandbox.Seccomp.SocketRules[0].Protocol)
+	require.Equal(t, "log_and_kill", cfg.Sandbox.Seccomp.SocketRules[0].Action)
+}
+
+func TestResolveSocketRules_DirtyFragProfile(t *testing.T) {
+	cfg := SandboxSeccompConfig{
+		HardeningProfiles: []string{"dirtyfrag-conservative"},
+	}
+	rules, err := ResolveSocketRules(cfg)
+	require.NoError(t, err)
+	require.Len(t, rules, 2)
+	require.Equal(t, "dirtyfrag-conservative-rxrpc", rules[0].Name)
+	require.Equal(t, 33, rules[0].Family)
+	require.Equal(t, seccomp.OnBlockLogAndKill, rules[0].Action)
+	require.Equal(t, "dirtyfrag-conservative-xfrm", rules[1].Name)
+	require.Equal(t, 16, rules[1].Family)
+	require.NotNil(t, rules[1].Protocol)
+	require.Equal(t, 6, *rules[1].Protocol)
+}
+
+func TestResolveSocketRules_RejectsBadProtocol(t *testing.T) {
+	_, err := ResolveSocketRules(SandboxSeccompConfig{
+		SocketRules: []SandboxSeccompSocketRuleConfig{{
+			Name:     "bad",
+			Family:   "AF_NETLINK",
+			Protocol: "NETLINK_XFRMM",
+			Action:   "errno",
+		}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `socket_rules[0].protocol`)
+	require.Contains(t, err.Error(), "NETLINK_XFRMM")
+}
+
+func TestResolveSocketRules_RejectsUnknownProfile(t *testing.T) {
+	_, err := ResolveSocketRules(SandboxSeccompConfig{
+		HardeningProfiles: []string{"dirtyfrag"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `hardening_profiles[0]`)
+}
+
+func TestResolveSocketRules_RejectsDuplicateNamesAfterProfileExpansion(t *testing.T) {
+	_, err := ResolveSocketRules(SandboxSeccompConfig{
+		SocketRules: []SandboxSeccompSocketRuleConfig{{
+			Name:     "dirtyfrag-conservative-xfrm",
+			Family:   "AF_NETLINK",
+			Protocol: "NETLINK_XFRM",
+			Action:   "errno",
+		}},
+		HardeningProfiles: []string{"dirtyfrag-conservative"},
+	})
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "duplicate socket rule name"), err.Error())
+}
+
+func TestValidateConfig_ValidatesSocketRules(t *testing.T) {
+	cfg := &Config{}
+	cfg.Sandbox.FUSE.Audit.Mode = "monitor"
+	cfg.Sandbox.Seccomp.SocketRules = []SandboxSeccompSocketRuleConfig{{
+		Name:   "bad-family",
+		Family: "AF_NOT_REAL",
+		Action: "errno",
+	}}
+	err := validateConfig(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "AF_NOT_REAL")
+}

--- a/internal/config/seccomp_socket_rules_test.go
+++ b/internal/config/seccomp_socket_rules_test.go
@@ -35,13 +35,19 @@ func TestResolveSocketRules_DirtyFragProfile(t *testing.T) {
 	rules, err := ResolveSocketRules(cfg)
 	require.NoError(t, err)
 	require.Len(t, rules, 2)
+	rxrpcFamily, _, ok := seccomp.ParseFamily("AF_RXRPC")
+	require.True(t, ok)
+	netlinkFamily, _, ok := seccomp.ParseFamily("AF_NETLINK")
+	require.True(t, ok)
+	xfrmProtocol, _, ok := seccomp.ParseSocketProtocol("NETLINK_XFRM")
+	require.True(t, ok)
 	require.Equal(t, "dirtyfrag-conservative-rxrpc", rules[0].Name)
-	require.Equal(t, 33, rules[0].Family)
+	require.Equal(t, rxrpcFamily, rules[0].Family)
 	require.Equal(t, seccomp.OnBlockLogAndKill, rules[0].Action)
 	require.Equal(t, "dirtyfrag-conservative-xfrm", rules[1].Name)
-	require.Equal(t, 16, rules[1].Family)
+	require.Equal(t, netlinkFamily, rules[1].Family)
 	require.NotNil(t, rules[1].Protocol)
-	require.Equal(t, 6, *rules[1].Protocol)
+	require.Equal(t, xfrmProtocol, *rules[1].Protocol)
 }
 
 func TestResolveSocketRules_RejectsBadProtocol(t *testing.T) {
@@ -56,6 +62,36 @@ func TestResolveSocketRules_RejectsBadProtocol(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), `socket_rules[0].protocol`)
 	require.Contains(t, err.Error(), "NETLINK_XFRMM")
+}
+
+func TestResolveSocketRules_RejectsNetlinkProtocolForNonNetlinkFamily(t *testing.T) {
+	_, err := ResolveSocketRules(SandboxSeccompConfig{
+		SocketRules: []SandboxSeccompSocketRuleConfig{{
+			Name:     "bad-family-protocol",
+			Family:   "AF_INET",
+			Protocol: "NETLINK_XFRM",
+			Action:   "errno",
+		}},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `socket_rules[0].protocol`)
+	require.Contains(t, err.Error(), "NETLINK_XFRM")
+	require.Contains(t, err.Error(), "AF_NETLINK")
+}
+
+func TestResolveSocketRules_AllowsNumericProtocolForNonNetlinkFamily(t *testing.T) {
+	rules, err := ResolveSocketRules(SandboxSeccompConfig{
+		SocketRules: []SandboxSeccompSocketRuleConfig{{
+			Name:     "tcp",
+			Family:   "AF_INET",
+			Protocol: "6",
+			Action:   "errno",
+		}},
+	})
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	require.NotNil(t, rules[0].Protocol)
+	require.Equal(t, 6, *rules[0].Protocol)
 }
 
 func TestResolveSocketRules_RejectsUnknownProfile(t *testing.T) {

--- a/internal/netmonitor/unix/blocklist_linux.go
+++ b/internal/netmonitor/unix/blocklist_linux.go
@@ -24,10 +24,13 @@ import (
 // should be taken when a block-listed syscall traps via USER_NOTIF.
 // FamilyByKey maps (syscall_nr<<32)|af_family → BlockedFamily for log/log_and_kill
 // socket-family rules that also route through the notify handler.
+// SocketRules carries notify-mode socket tuple rules that need userspace
+// dispatch after the kernel returns SECCOMP_RET_USER_NOTIF.
 // A nil receiver is treated as an empty configuration.
 type BlockListConfig struct {
 	ActionByNr  map[uint32]seccompkg.OnBlockAction
 	FamilyByKey map[uint64]seccompkg.BlockedFamily
+	SocketRules []seccompkg.SocketRule
 }
 
 // FamilyBlockListed returns the BlockedFamily for the (syscallNr, af_family) pair
@@ -39,6 +42,29 @@ func (c *BlockListConfig) FamilyBlockListed(syscallNr uint32, afFamily uint64) (
 	key := uint64(syscallNr)<<32 | afFamily
 	bf, ok := c.FamilyByKey[key]
 	return bf, ok
+}
+
+// SocketRuleBlockListed returns the first notify-mode socket tuple rule that
+// matches socket(2) or socketpair(2). Nil receiver returns (_, false).
+func (c *BlockListConfig) SocketRuleBlockListed(syscallNr uint32, family, typ, protocol uint64) (seccompkg.SocketRule, bool) {
+	if c == nil || len(c.SocketRules) == 0 {
+		return seccompkg.SocketRule{}, false
+	}
+	switch syscallNr {
+	case uint32(unix.SYS_SOCKET):
+		for _, rule := range c.SocketRules {
+			if rule.MatchesSocket(family, typ, protocol) {
+				return rule, true
+			}
+		}
+	case uint32(unix.SYS_SOCKETPAIR):
+		for _, rule := range c.SocketRules {
+			if rule.MatchesSocketpair(family, typ, protocol) {
+				return rule, true
+			}
+		}
+	}
+	return seccompkg.SocketRule{}, false
 }
 
 // notifIDValidFn is a test seam wrapping seccomp.NotifIDValid so unit tests
@@ -413,5 +439,108 @@ func handleFamilyBlockNotify(
 		}
 		slog.Warn("seccomp family-block: deny response failed",
 			"session_id", sessID, "tid", tid, "family", bf.Name, "error", err)
+	}
+}
+
+// handleSocketRuleBlockNotify processes a seccomp notification for a
+// socket/socketpair call that matched a configured socket tuple rule. It mirrors
+// handleFamilyBlockNotify, emits seccomp_socket_rule_blocked, and denies with
+// EAFNOSUPPORT so callers see the same errno as family-level blocks.
+func handleSocketRuleBlockNotify(
+	ctx context.Context,
+	fd int,
+	req *seccomp.ScmpNotifReq,
+	rule seccompkg.SocketRule,
+	sessID string,
+	emit Emitter,
+) {
+	if req == nil {
+		return
+	}
+
+	if err := notifIDValidFn(fd, req.ID); err != nil {
+		slog.Debug("seccomp socket-rule: notif id no longer valid",
+			"session_id", sessID, "pid", req.Pid, "rule", rule.Name, "error", err)
+		if derr := NotifRespondDeny(fd, req.ID, int32(unix.EAFNOSUPPORT)); derr != nil && !isENOENT(derr) {
+			slog.Warn("seccomp socket-rule: deny response failed after invalid id",
+				"session_id", sessID, "pid", req.Pid, "rule", rule.Name, "error", derr)
+		}
+		return
+	}
+
+	syscallNr := uint32(req.Data.Syscall)
+	scName := resolveSyscallName(syscallNr)
+	tid := int(req.Pid)
+
+	outcome := "denied"
+	if rule.Action == seccompkg.OnBlockLogAndKill {
+		targetPID := tid
+		if tgid, err := resolveTGIDFn(tid); err == nil {
+			targetPID = tgid
+		} else if errors.Is(err, unix.ESRCH) {
+			slog.Debug("seccomp socket-rule: TGID resolution ESRCH (target already exited)",
+				"session_id", sessID, "tid", tid, "rule", rule.Name)
+			targetPID = -1
+		} else {
+			slog.Warn("seccomp socket-rule: TGID resolution failed; falling back to TID",
+				"session_id", sessID, "tid", tid, "rule", rule.Name, "error", err)
+		}
+
+		if targetPID == -1 {
+			outcome = "killed"
+		} else {
+			outcome = attemptKill(fd, req.ID, targetPID, sessID, scName)
+		}
+	}
+
+	if emit != nil {
+		fields := map[string]any{
+			"rule_name":     rule.Name,
+			"family_name":   rule.FamilyName,
+			"family_number": rule.Family,
+			"syscall":       scName,
+			"syscall_nr":    syscallNr,
+			"action":        string(rule.Action),
+			"outcome":       outcome,
+			"arch":          runtime.GOARCH,
+			"engine":        "seccomp",
+		}
+		if rule.Type != nil {
+			fields["type_number"] = *rule.Type
+			if rule.TypeName != "" {
+				fields["type_name"] = rule.TypeName
+			}
+		}
+		if rule.Protocol != nil {
+			fields["protocol_number"] = *rule.Protocol
+			if rule.ProtocolName != "" {
+				fields["protocol_name"] = rule.ProtocolName
+			}
+		}
+		ev := types.Event{
+			ID:        fmt.Sprintf("seccomp-%d-%d", tid, time.Now().UnixNano()),
+			Timestamp: time.Now().UTC(),
+			Type:      "seccomp_socket_rule_blocked",
+			SessionID: sessID,
+			Source:    "seccomp",
+			PID:       tid,
+			Fields:    fields,
+		}
+		if err := emit.AppendEvent(context.Background(), ev); err != nil {
+			slog.Warn("seccomp socket-rule: AppendEvent failed",
+				"session_id", sessID, "tid", tid, "rule", rule.Name, "error", err)
+		}
+		emit.Publish(ev)
+	}
+
+	_ = ctx
+	if err := NotifRespondDeny(fd, req.ID, int32(unix.EAFNOSUPPORT)); err != nil {
+		if isENOENT(err) {
+			slog.Debug("seccomp socket-rule: deny response hit ENOENT (target already gone)",
+				"session_id", sessID, "tid", tid, "rule", rule.Name)
+			return
+		}
+		slog.Warn("seccomp socket-rule: deny response failed",
+			"session_id", sessID, "tid", tid, "rule", rule.Name, "error", err)
 	}
 }

--- a/internal/netmonitor/unix/blocklist_linux_test.go
+++ b/internal/netmonitor/unix/blocklist_linux_test.go
@@ -257,6 +257,65 @@ func TestBlockListConfig_IsBlockListed(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestBlockListConfig_SocketRuleBlockListed(t *testing.T) {
+	typ := int(gounix.SOCK_RAW)
+	protocol := int(gounix.NETLINK_XFRM)
+	rule := seccompkg.SocketRule{
+		Name:         "dirtyfrag-xfrm",
+		Family:       gounix.AF_NETLINK,
+		FamilyName:   "AF_NETLINK",
+		Type:         &typ,
+		TypeName:     "SOCK_RAW",
+		Protocol:     &protocol,
+		ProtocolName: "NETLINK_XFRM",
+		Action:       seccompkg.OnBlockLog,
+	}
+
+	var nilCfg *BlockListConfig
+	_, ok := nilCfg.SocketRuleBlockListed(uint32(gounix.SYS_SOCKET), uint64(gounix.AF_NETLINK), uint64(gounix.SOCK_RAW), uint64(gounix.NETLINK_XFRM))
+	require.False(t, ok)
+
+	empty := &BlockListConfig{}
+	_, ok = empty.SocketRuleBlockListed(uint32(gounix.SYS_SOCKET), uint64(gounix.AF_NETLINK), uint64(gounix.SOCK_RAW), uint64(gounix.NETLINK_XFRM))
+	require.False(t, ok)
+
+	cfg := &BlockListConfig{SocketRules: []seccompkg.SocketRule{rule}}
+
+	got, ok := cfg.SocketRuleBlockListed(
+		uint32(gounix.SYS_SOCKET),
+		uint64(gounix.AF_NETLINK),
+		uint64(gounix.SOCK_RAW|gounix.SOCK_CLOEXEC),
+		uint64(gounix.NETLINK_XFRM),
+	)
+	require.True(t, ok, "socket(2) should match by family, masked type, and protocol")
+	require.Equal(t, "dirtyfrag-xfrm", got.Name)
+
+	got, ok = cfg.SocketRuleBlockListed(
+		uint32(gounix.SYS_SOCKETPAIR),
+		uint64(gounix.AF_NETLINK),
+		uint64(gounix.SOCK_RAW|gounix.SOCK_NONBLOCK),
+		uint64(gounix.NETLINK_XFRM),
+	)
+	require.True(t, ok, "socketpair(2) should preserve and match arg2 protocol")
+	require.Equal(t, "dirtyfrag-xfrm", got.Name)
+
+	_, ok = cfg.SocketRuleBlockListed(
+		uint32(gounix.SYS_SOCKETPAIR),
+		uint64(gounix.AF_NETLINK),
+		uint64(gounix.SOCK_RAW),
+		uint64(gounix.NETLINK_AUDIT),
+	)
+	require.False(t, ok, "socketpair(2) must not drop protocol when matching")
+
+	_, ok = cfg.SocketRuleBlockListed(
+		uint32(gounix.SYS_CONNECT),
+		uint64(gounix.AF_NETLINK),
+		uint64(gounix.SOCK_RAW),
+		uint64(gounix.NETLINK_XFRM),
+	)
+	require.False(t, ok, "non socket/socketpair syscalls must not match socket rules")
+}
+
 // TestResolveTGIDFromProc_MainThread verifies that reading /proc/<tid>/status
 // for the test process's own main-thread TID returns its own TGID.
 func TestResolveTGIDFromProc_MainThread(t *testing.T) {
@@ -386,4 +445,64 @@ func TestHandleFamilyBlockNotify_EmitsEngineField(t *testing.T) {
 	require.Equal(t, "AF_ALG", ev.Fields["family_name"])
 	require.Equal(t, "denied", ev.Fields["outcome"])
 	require.Equal(t, string(seccompkg.OnBlockLog), ev.Fields["action"])
+}
+
+func TestHandleSocketRuleBlockNotify_EmitsEventShapeAndEngine(t *testing.T) {
+	restoreValid := swapNotifIDValidFn(t, func(int, uint64) error { return nil })
+	defer restoreValid()
+
+	typ := int(gounix.SOCK_RAW)
+	protocol := int(gounix.NETLINK_XFRM)
+	rule := seccompkg.SocketRule{
+		Name:         "dirtyfrag-xfrm",
+		Family:       gounix.AF_NETLINK,
+		FamilyName:   "AF_NETLINK",
+		Type:         &typ,
+		TypeName:     "SOCK_RAW",
+		Protocol:     &protocol,
+		ProtocolName: "NETLINK_XFRM",
+		Action:       seccompkg.OnBlockLog,
+	}
+	req := &libseccomp.ScmpNotifReq{
+		ID:  84,
+		Pid: 4321,
+		Data: libseccomp.ScmpNotifData{
+			Syscall: libseccomp.ScmpSyscall(gounix.SYS_SOCKETPAIR),
+			Args: []uint64{
+				uint64(gounix.AF_NETLINK),
+				uint64(gounix.SOCK_RAW | gounix.SOCK_CLOEXEC),
+				uint64(gounix.NETLINK_XFRM),
+			},
+		},
+	}
+
+	sink := &blocklistTestEmitter{}
+	handleSocketRuleBlockNotify(context.Background(), -1, req, rule, "sess-socket-rule", sink)
+
+	evts := sink.Events()
+	require.NotEmpty(t, evts, "expected at least one event from handleSocketRuleBlockNotify")
+
+	ev := evts[0]
+	require.Equal(t, "seccomp_socket_rule_blocked", ev.Type)
+	require.Equal(t, "sess-socket-rule", ev.SessionID)
+	require.Equal(t, 4321, ev.PID)
+	require.Equal(t, "seccomp", ev.Source)
+	require.NotEmpty(t, ev.ID)
+	require.False(t, ev.Timestamp.IsZero())
+
+	require.Equal(t, "dirtyfrag-xfrm", ev.Fields["rule_name"])
+	require.Equal(t, "AF_NETLINK", ev.Fields["family_name"])
+	require.Equal(t, gounix.AF_NETLINK, ev.Fields["family_number"])
+	require.Equal(t, "SOCK_RAW", ev.Fields["type_name"])
+	require.Equal(t, gounix.SOCK_RAW, ev.Fields["type_number"])
+	require.Equal(t, "NETLINK_XFRM", ev.Fields["protocol_name"])
+	require.Equal(t, gounix.NETLINK_XFRM, ev.Fields["protocol_number"])
+	require.Equal(t, "socketpair", ev.Fields["syscall"])
+	require.Equal(t, uint32(gounix.SYS_SOCKETPAIR), ev.Fields["syscall_nr"])
+	require.Equal(t, string(seccompkg.OnBlockLog), ev.Fields["action"])
+	require.Equal(t, "denied", ev.Fields["outcome"])
+	require.Equal(t, "seccomp", ev.Fields["engine"])
+	arch, ok := ev.Fields["arch"].(string)
+	require.True(t, ok, "arch should be a string")
+	require.NotEmpty(t, arch)
 }

--- a/internal/netmonitor/unix/handler.go
+++ b/internal/netmonitor/unix/handler.go
@@ -226,14 +226,23 @@ func ServeNotifyWithExecve(ctx context.Context, fd *os.File, sessID string, pol 
 		syscallNr := int32(req.Data.Syscall)
 		slog.Debug("ServeNotifyWithExecve: received notification", "session_id", sessID, "syscall_nr", syscallNr, "pid", req.Pid, "count", notifCount)
 
-		// Family dispatch FIRST for socket(2)/socketpair(2) — more specific than
-		// the generic syscall blocklist. If the operator configured both a generic
-		// on_block action for "socket" AND a per-family action for e.g. AF_ALG,
-		// the more-specific family rule must win. We check family before the
-		// generic blocklist only for these two syscalls; all others fall through
-		// to the generic check below unchanged.
-		// nil-safe: FamilyBlockListed returns (_, false) on a nil receiver or empty map.
+		// Socket dispatch order for socket(2)/socketpair(2): tuple rules first,
+		// family rules second, generic syscall block-list third. This preserves
+		// the most-specific configured decision and avoids duplicate events for a
+		// tuple hit when broad AF_NETLINK or generic socket rules are also present.
+		// nil-safe: both lookup methods return (_, false) on nil receivers.
 		if uint32(syscallNr) == uint32(unix.SYS_SOCKET) || uint32(syscallNr) == uint32(unix.SYS_SOCKETPAIR) {
+			if rule, ok := blockList.SocketRuleBlockListed(
+				uint32(req.Data.Syscall),
+				req.Data.Args[0],
+				req.Data.Args[1],
+				req.Data.Args[2],
+			); ok {
+				slog.Debug("ServeNotifyWithExecve: routing to socket-rule handler (pre-family)",
+					"session_id", sessID, "pid", req.Pid, "syscall_nr", syscallNr, "rule", rule.Name)
+				handleSocketRuleBlockNotify(ctx, int(scmpFD), req, rule, sessID, emit)
+				continue
+			}
 			if bf, ok := blockList.FamilyBlockListed(uint32(req.Data.Syscall), req.Data.Args[0]); ok {
 				slog.Debug("ServeNotifyWithExecve: routing to family-block handler (pre-blocklist)",
 					"session_id", sessID, "pid", req.Pid, "syscall_nr", syscallNr, "family", bf.Family)

--- a/internal/netmonitor/unix/seccomp_linux.go
+++ b/internal/netmonitor/unix/seccomp_linux.go
@@ -441,24 +441,9 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 	// family-only rules so later dispatch can evaluate the most specific
 	// configured tuples first. Kernel action precedence still determines the
 	// result when actions differ, preserving existing blocked-family behavior.
-	socketRulesAdded := 0
-	for _, sr := range cfg.SocketRules {
-		socketAction, err := familyToScmpAction(sr.Action)
-		if err != nil {
-			slog.Warn("seccomp: skipping socket rule with unknown action",
-				"rule", sr.Name, "family", sr.FamilyName, "action", sr.Action, "error", err)
-			continue
-		}
-		added, addErr := installSocketRuleConditional(filt, sr, socketAction)
-		socketRulesAdded += added
-		if addErr != nil {
-			slog.Warn("seccomp: failed to add socket rule; rule skipped",
-				"rule", sr.Name, "family", sr.FamilyName, "action", sr.Action, "error", addErr)
-			continue
-		}
-		if socketRuleUsesNotify(sr) {
-			socketRules = append(socketRules, cloneSocketRule(sr))
-		}
+	socketRules, socketRulesAdded, err := installSocketRulesConditional(filt, cfg.SocketRules)
+	if err != nil {
+		return nil, err
 	}
 	ruleCounts["socket_rules"] = socketRulesAdded
 
@@ -568,20 +553,44 @@ type conditionalRuleAdder interface {
 	AddRuleConditional(seccomp.ScmpSyscall, seccomp.ScmpAction, []seccomp.ScmpCondition) error
 }
 
+func installSocketRulesConditional(adder conditionalRuleAdder, rules []seccompkg.SocketRule) ([]seccompkg.SocketRule, int, error) {
+	retained := []seccompkg.SocketRule{}
+	rulesAdded := 0
+	for _, rule := range rules {
+		action, err := familyToScmpAction(rule.Action)
+		if err != nil {
+			slog.Warn("seccomp: skipping socket rule with unknown action",
+				"rule", rule.Name, "family", rule.FamilyName, "action", rule.Action, "error", err)
+			continue
+		}
+		added, addErr := installSocketRuleConditional(adder, rule, action)
+		rulesAdded += added
+		if addErr != nil {
+			if added > 0 {
+				return nil, rulesAdded, fmt.Errorf("partial socket rule install for %q: %w", rule.Name, addErr)
+			}
+			return nil, rulesAdded, fmt.Errorf("add socket rule %q: %w", rule.Name, addErr)
+		}
+		if socketRuleUsesNotify(rule) {
+			retained = append(retained, cloneSocketRule(rule))
+		}
+	}
+	if len(retained) == 0 {
+		return nil, rulesAdded, nil
+	}
+	return retained, rulesAdded, nil
+}
+
 func installSocketRuleConditional(adder conditionalRuleAdder, rule seccompkg.SocketRule, action seccomp.ScmpAction) (int, error) {
 	conditions := socketRuleConditions(rule)
 	added := 0
-	var firstErr error
 	for _, sc := range []int{unix.SYS_SOCKET, unix.SYS_SOCKETPAIR} {
 		if err := adder.AddRuleConditional(seccomp.ScmpSyscall(sc), action, conditions); err != nil {
-			if firstErr == nil {
-				firstErr = fmt.Errorf("add conditional rule for syscall %d: %w", sc, err)
-			}
-			continue
+			return added, fmt.Errorf("add conditional rule for syscall %d: %w", sc, err)
 		}
 		added++
 	}
-	return added, firstErr
+	return added, nil
 }
 
 func socketRuleConditions(rule seccompkg.SocketRule) []seccomp.ScmpCondition {

--- a/internal/netmonitor/unix/seccomp_linux.go
+++ b/internal/netmonitor/unix/seccomp_linux.go
@@ -32,6 +32,7 @@ type Filter struct {
 	fd               seccomp.ScmpFd
 	blockList        map[uint32]seccompkg.OnBlockAction
 	blockedFamilyMap map[uint64]seccompkg.BlockedFamily
+	socketRules      []seccompkg.SocketRule
 }
 
 func (f *Filter) Close() error {
@@ -67,6 +68,15 @@ func (f *Filter) BlockedFamilyMap() map[uint64]seccompkg.BlockedFamily {
 		out[k] = v
 	}
 	return out
+}
+
+// SocketRules returns a copy of notify-mode socket tuple rules retained for
+// later notification dispatch. Kernel-only errno/kill rules are not included.
+func (f *Filter) SocketRules() []seccompkg.SocketRule {
+	if f == nil || len(f.socketRules) == 0 {
+		return nil
+	}
+	return cloneSocketRules(f.socketRules)
 }
 
 // InstallFilter installs a user-notify seccomp filter on the current process
@@ -401,6 +411,7 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 	}
 	blockListMap := map[uint32]seccompkg.OnBlockAction{}
 	blockedFamilyMap := map[uint64]seccompkg.BlockedFamily{}
+	socketRules := []seccompkg.SocketRule{}
 	switch action {
 	case seccompkg.OnBlockErrno:
 		errnoAction := seccomp.ActErrno.SetReturnCode(int16(unix.EPERM))
@@ -424,6 +435,32 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 		}
 	}
 	ruleCounts["blocked_syscalls"] = len(cfg.BlockedSyscalls)
+
+	// Per-socket tuple blocking on socket(2) and socketpair(2).
+	// These narrow family/type/protocol rules are installed before broad
+	// family-only rules so later dispatch can evaluate the most specific
+	// configured tuples first. Kernel action precedence still determines the
+	// result when actions differ, preserving existing blocked-family behavior.
+	socketRulesAdded := 0
+	for _, sr := range cfg.SocketRules {
+		socketAction, err := familyToScmpAction(sr.Action)
+		if err != nil {
+			slog.Warn("seccomp: skipping socket rule with unknown action",
+				"rule", sr.Name, "family", sr.FamilyName, "action", sr.Action, "error", err)
+			continue
+		}
+		added, addErr := installSocketRuleConditional(filt, sr, socketAction)
+		socketRulesAdded += added
+		if addErr != nil {
+			slog.Warn("seccomp: failed to add socket rule; rule skipped",
+				"rule", sr.Name, "family", sr.FamilyName, "action", sr.Action, "error", addErr)
+			continue
+		}
+		if socketRuleUsesNotify(sr) {
+			socketRules = append(socketRules, cloneSocketRule(sr))
+		}
+	}
+	ruleCounts["socket_rules"] = socketRulesAdded
 
 	// Per-socket-family blocking on socket(2) and socketpair(2).
 	// libseccomp action-precedence (KILL > TRAP > ERRNO > … > NOTIFY) ensures
@@ -504,12 +541,12 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 	fd, err := filt.GetNotifFd()
 	if err != nil {
 		// If no notify rules, fd will be -1, which is fine
-		if !cfg.UnixSocketEnabled && !cfg.ExecveEnabled && !cfg.FileMonitorEnabled {
-			return &Filter{fd: -1, blockList: blockListMap, blockedFamilyMap: blockedFamilyMap}, nil
+		if !filterConfigNeedsNotifyFD(cfg, blockListMap, blockedFamilyMap, socketRules) {
+			return &Filter{fd: -1, blockList: blockListMap, blockedFamilyMap: blockedFamilyMap, socketRules: socketRules}, nil
 		}
 		return nil, err
 	}
-	return &Filter{fd: fd, blockList: blockListMap, blockedFamilyMap: blockedFamilyMap}, nil
+	return &Filter{fd: fd, blockList: blockListMap, blockedFamilyMap: blockedFamilyMap, socketRules: socketRules}, nil
 }
 
 // familyToScmpAction maps an OnBlockAction to the libseccomp action used
@@ -525,6 +562,105 @@ func familyToScmpAction(a seccompkg.OnBlockAction) (seccomp.ScmpAction, error) {
 	default:
 		return seccomp.ActAllow, fmt.Errorf("unknown family block action %q", a)
 	}
+}
+
+type conditionalRuleAdder interface {
+	AddRuleConditional(seccomp.ScmpSyscall, seccomp.ScmpAction, []seccomp.ScmpCondition) error
+}
+
+func installSocketRuleConditional(adder conditionalRuleAdder, rule seccompkg.SocketRule, action seccomp.ScmpAction) (int, error) {
+	conditions := socketRuleConditions(rule)
+	added := 0
+	var firstErr error
+	for _, sc := range []int{unix.SYS_SOCKET, unix.SYS_SOCKETPAIR} {
+		if err := adder.AddRuleConditional(seccomp.ScmpSyscall(sc), action, conditions); err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("add conditional rule for syscall %d: %w", sc, err)
+			}
+			continue
+		}
+		added++
+	}
+	return added, firstErr
+}
+
+func socketRuleConditions(rule seccompkg.SocketRule) []seccomp.ScmpCondition {
+	conditions := []seccomp.ScmpCondition{
+		{
+			Argument: 0,
+			Op:       seccomp.CompareEqual,
+			Operand1: uint64(rule.Family),
+		},
+	}
+	if rule.Type != nil {
+		conditions = append(conditions, seccomp.ScmpCondition{
+			Argument: 1,
+			Op:       seccomp.CompareMaskedEqual,
+			Operand1: uint64(seccompkg.SocketTypeMask),
+			Operand2: uint64(*rule.Type),
+		})
+	}
+	if rule.Protocol != nil {
+		conditions = append(conditions, seccomp.ScmpCondition{
+			Argument: 2,
+			Op:       seccomp.CompareEqual,
+			Operand1: uint64(*rule.Protocol),
+		})
+	}
+	return conditions
+}
+
+func notifySocketRules(rules []seccompkg.SocketRule) []seccompkg.SocketRule {
+	if len(rules) == 0 {
+		return nil
+	}
+	out := make([]seccompkg.SocketRule, 0, len(rules))
+	for _, rule := range rules {
+		if socketRuleUsesNotify(rule) {
+			out = append(out, cloneSocketRule(rule))
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func socketRuleUsesNotify(rule seccompkg.SocketRule) bool {
+	return rule.Action == seccompkg.OnBlockLog || rule.Action == seccompkg.OnBlockLogAndKill
+}
+
+func cloneSocketRules(rules []seccompkg.SocketRule) []seccompkg.SocketRule {
+	if len(rules) == 0 {
+		return nil
+	}
+	out := make([]seccompkg.SocketRule, len(rules))
+	for i, rule := range rules {
+		out[i] = cloneSocketRule(rule)
+	}
+	return out
+}
+
+func cloneSocketRule(rule seccompkg.SocketRule) seccompkg.SocketRule {
+	if rule.Type != nil {
+		typ := *rule.Type
+		rule.Type = &typ
+	}
+	if rule.Protocol != nil {
+		protocol := *rule.Protocol
+		rule.Protocol = &protocol
+	}
+	return rule
+}
+
+func filterConfigNeedsNotifyFD(cfg FilterConfig, blockListMap map[uint32]seccompkg.OnBlockAction, blockedFamilyMap map[uint64]seccompkg.BlockedFamily, socketRules []seccompkg.SocketRule) bool {
+	return cfg.UnixSocketEnabled ||
+		cfg.ExecveEnabled ||
+		cfg.FileMonitorEnabled ||
+		cfg.InterceptMetadata ||
+		len(blockListMap) > 0 ||
+		len(blockedFamilyMap) > 0 ||
+		len(socketRules) > 0
 }
 
 // loadWithRetryOnWaitKillFailure loads a seccomp filter and, if the load
@@ -723,6 +859,7 @@ func filterDiagnosticFields(filt *seccomp.ScmpFilter, cfg FilterConfig, waitKill
 		"rules_metadata", ruleCounts["metadata"],
 		"rules_blocked_syscalls", ruleCounts["blocked_syscalls"],
 		"rules_blocked_families", ruleCounts["blocked_families"],
+		"rules_socket_rules", ruleCounts["socket_rules"],
 		"rules_io_uring_block", ruleCounts["io_uring_block"],
 		"cfg_unix_socket_enabled", cfg.UnixSocketEnabled,
 		"cfg_execve_enabled", cfg.ExecveEnabled,

--- a/internal/netmonitor/unix/seccomp_linux.go
+++ b/internal/netmonitor/unix/seccomp_linux.go
@@ -239,6 +239,7 @@ type FilterConfig struct {
 	BlockIOUring       bool  // io_uring_setup/enter/register → EPERM
 	BlockedSyscalls    []int // syscall numbers to block; action controlled by OnBlockAction
 	BlockedFamilies    []seccompkg.BlockedFamily
+	SocketRules        []seccompkg.SocketRule
 	OnBlockAction      seccompkg.OnBlockAction
 }
 

--- a/internal/netmonitor/unix/seccomp_socket_rules_test.go
+++ b/internal/netmonitor/unix/seccomp_socket_rules_test.go
@@ -13,8 +13,11 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unsafe"
 
+	"github.com/agentsh/agentsh/internal/config"
 	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
+	"github.com/agentsh/agentsh/pkg/types"
 	seccomp "github.com/seccomp/libseccomp-golang"
 	"github.com/stretchr/testify/require"
 	gounix "golang.org/x/sys/unix"
@@ -22,6 +25,10 @@ import (
 
 const socketRuleHelperEnv = "AGENTSH_TEST_SOCKET_RULE_HELPER"
 const socketRuleHelperNotifyLog = "notify_log"
+const socketRuleHelperDirtyFragNetlinkXFRM = "dirtyfrag_netlink_xfrm"
+const socketRuleHelperDirtyFragNetlinkRoute = "dirtyfrag_netlink_route"
+const socketRuleHelperDirtyFragRXRPC = "dirtyfrag_rxrpc"
+const socketRuleHelperDirtyFragSocketpairXFRM = "dirtyfrag_socketpair_xfrm"
 
 func TestNotifySocketRules_FiltersNotifyActions(t *testing.T) {
 	rules := []seccompkg.SocketRule{
@@ -240,6 +247,369 @@ func TestSeccompSocketRuleBlock_Notify_LogDispatched(t *testing.T) {
 	}
 	if strings.Contains(combined, "audit_event=seccomp_blocked") {
 		t.Errorf("generic blocklist event emitted — generic dispatch shadowed socket tuple rule;\nhelper output:\n%s", combined)
+	}
+}
+
+func TestDirtyFragNetlinkXFRM_ProfileLogAndKillSeccompSocketRule(t *testing.T) {
+	if os.Getenv(socketRuleHelperEnv) == socketRuleHelperDirtyFragNetlinkXFRM {
+		runDirtyFragSocketRuleHelper(t, socketRuleHelperDirtyFragNetlinkXFRM)
+		return
+	}
+
+	combined := runSocketRuleHelperSubprocess(t, socketRuleHelperDirtyFragNetlinkXFRM)
+	requireResultEAFNOSUPPORT(t, combined, "socket_result")
+	require.Contains(t, combined, "audit_event=seccomp_socket_rule_blocked")
+	require.Contains(t, combined, "audit_rule=dirtyfrag-conservative-xfrm")
+	require.Contains(t, combined, "audit_action=log_and_kill")
+	require.Contains(t, combined, "audit_protocol=NETLINK_XFRM")
+	require.NotContains(t, combined, "audit_event=seccomp_socket_family_blocked")
+	require.NotContains(t, combined, "audit_event=seccomp_blocked")
+}
+
+func TestDirtyFragNetlinkRoute_DoesNotDispatchSocketRule(t *testing.T) {
+	if os.Getenv(socketRuleHelperEnv) == socketRuleHelperDirtyFragNetlinkRoute {
+		runDirtyFragSocketRuleHelper(t, socketRuleHelperDirtyFragNetlinkRoute)
+		return
+	}
+
+	combined := runSocketRuleHelperSubprocess(t, socketRuleHelperDirtyFragNetlinkRoute)
+	require.Contains(t, combined, "socket_result=")
+	require.NotContains(t, combined, "audit_event=seccomp_socket_rule_blocked")
+	require.NotContains(t, combined, "audit_rule=dirtyfrag-conservative-xfrm")
+}
+
+func TestDirtyFragRXRPC_ProfileFamilyOnlyRuleDispatchesAsSocketRule(t *testing.T) {
+	if os.Getenv(socketRuleHelperEnv) == socketRuleHelperDirtyFragRXRPC {
+		runDirtyFragSocketRuleHelper(t, socketRuleHelperDirtyFragRXRPC)
+		return
+	}
+
+	combined := runSocketRuleHelperSubprocess(t, socketRuleHelperDirtyFragRXRPC)
+	requireResultEAFNOSUPPORT(t, combined, "socket_result")
+	require.Contains(t, combined, "audit_event=seccomp_socket_rule_blocked")
+	require.Contains(t, combined, "audit_rule=dirtyfrag-conservative-rxrpc")
+	require.Contains(t, combined, "audit_action=log_and_kill")
+	require.Contains(t, combined, "audit_family=AF_RXRPC")
+	require.NotContains(t, combined, "audit_event=seccomp_socket_family_blocked")
+	require.NotContains(t, combined, "audit_event=seccomp_blocked")
+}
+
+func TestDirtyFragSocketpairNetlinkXFRM_ProfileProtocolRule(t *testing.T) {
+	if os.Getenv(socketRuleHelperEnv) == socketRuleHelperDirtyFragSocketpairXFRM {
+		runDirtyFragSocketRuleHelper(t, socketRuleHelperDirtyFragSocketpairXFRM)
+		return
+	}
+
+	combined := runSocketRuleHelperSubprocess(t, socketRuleHelperDirtyFragSocketpairXFRM)
+	requireResultEAFNOSUPPORT(t, combined, "socketpair_result")
+	require.Contains(t, combined, "audit_event=seccomp_socket_rule_blocked")
+	require.Contains(t, combined, "audit_rule=dirtyfrag-conservative-xfrm")
+	require.Contains(t, combined, "audit_protocol=NETLINK_XFRM")
+	require.Contains(t, combined, "audit_syscall=socketpair")
+	require.NotContains(t, combined, "audit_event=seccomp_socket_family_blocked")
+	require.NotContains(t, combined, "audit_event=seccomp_blocked")
+}
+
+func runSocketRuleHelperSubprocess(t *testing.T, mode string) string {
+	t.Helper()
+
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, exe, "-test.run=^"+t.Name()+"$", "-test.v")
+	cmd.Env = append(os.Environ(), socketRuleHelperEnv+"="+mode)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	runErr := cmd.Run()
+	combined := out.String()
+
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("helper subprocess timed out\noutput:\n%s", combined)
+	}
+	if strings.Contains(combined, "SKIP:") {
+		t.Skipf("child skipped: %s", combined)
+	}
+	if runErr != nil {
+		lower := strings.ToLower(combined)
+		if strings.Contains(lower, "permission denied") ||
+			strings.Contains(lower, "operation not permitted") ||
+			strings.Contains(lower, "lacks user notify") ||
+			strings.Contains(lower, "notification ioctl blocked") ||
+			strings.Contains(lower, "skip") {
+			t.Skipf("host cannot run seccomp notify helper; skipping.\nhelper output:\n%s", combined)
+		}
+		t.Fatalf("helper subprocess failed: %v\noutput:\n%s", runErr, combined)
+	}
+
+	return combined
+}
+
+func runDirtyFragSocketRuleHelper(t *testing.T, mode string) {
+	t.Helper()
+
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+
+	rules := dirtyFragProfileSocketRules(t)
+	cfg := FilterConfig{
+		UnixSocketEnabled: false,
+		BlockedSyscalls:   []int{int(gounix.SYS_SOCKET), int(gounix.SYS_SOCKETPAIR)},
+		OnBlockAction:     seccompkg.OnBlockLog,
+		BlockedFamilies: []seccompkg.BlockedFamily{
+			{Family: gounix.AF_NETLINK, Action: seccompkg.OnBlockLog, Name: "AF_NETLINK"},
+			{Family: gounix.AF_RXRPC, Action: seccompkg.OnBlockLog, Name: "AF_RXRPC"},
+		},
+		SocketRules: rules,
+	}
+	filt, err := InstallFilterWithConfig(cfg)
+	if err != nil {
+		lower := strings.ToLower(err.Error())
+		if strings.Contains(lower, "permission") || strings.Contains(lower, "operation not permitted") {
+			t.Skipf("cannot install seccomp filter (privilege): %v", err)
+		}
+		t.Fatalf("InstallFilterWithConfig: %v", err)
+	}
+
+	if got := filt.SocketRules(); len(got) != 2 {
+		_ = filt.Close()
+		t.Fatalf("dirtyfrag profile socket rules not retained for notify; got %d", len(got))
+	}
+
+	restore := swapPidfdSeams(t,
+		func(pid int) (int, error) { return openDevNullFD(t), nil },
+		func(pidfd int, sig gounix.Signal) error { return nil },
+	)
+	defer restore()
+
+	emitter := &captureEventsEmitter{}
+	bl := &BlockListConfig{
+		ActionByNr:  filt.BlockListMap(),
+		FamilyByKey: filt.BlockedFamilyMap(),
+		SocketRules: filt.SocketRules(),
+	}
+	stopNotify := startSocketRuleNotifyHelper(t, filt, bl, emitter)
+	defer stopNotify()
+
+	switch mode {
+	case socketRuleHelperDirtyFragNetlinkXFRM:
+		fd, _, errno := gounix.RawSyscall(
+			gounix.SYS_SOCKET,
+			uintptr(gounix.AF_NETLINK),
+			uintptr(gounix.SOCK_RAW|gounix.SOCK_CLOEXEC),
+			uintptr(gounix.NETLINK_XFRM),
+		)
+		printRawSyscallResult("socket_result", fd, errno)
+	case socketRuleHelperDirtyFragNetlinkRoute:
+		fd, _, errno := gounix.RawSyscall(
+			gounix.SYS_SOCKET,
+			uintptr(gounix.AF_NETLINK),
+			uintptr(gounix.SOCK_RAW|gounix.SOCK_CLOEXEC),
+			uintptr(gounix.NETLINK_ROUTE),
+		)
+		printRawSyscallResult("socket_result", fd, errno)
+	case socketRuleHelperDirtyFragRXRPC:
+		fd, _, errno := gounix.RawSyscall(
+			gounix.SYS_SOCKET,
+			uintptr(gounix.AF_RXRPC),
+			uintptr(gounix.SOCK_DGRAM|gounix.SOCK_CLOEXEC),
+			0,
+		)
+		printRawSyscallResult("socket_result", fd, errno)
+	case socketRuleHelperDirtyFragSocketpairXFRM:
+		// Linux does not create AF_NETLINK socketpairs, but seccomp evaluates
+		// the syscall arguments before the kernel rejects the family. This keeps
+		// the end-to-end assertion about protocol arg2 without depending on a
+		// successful host socketpair implementation.
+		var pair [2]int
+		fd, _, errno := gounix.RawSyscall6(
+			gounix.SYS_SOCKETPAIR,
+			uintptr(gounix.AF_NETLINK),
+			uintptr(gounix.SOCK_RAW|gounix.SOCK_CLOEXEC),
+			uintptr(gounix.NETLINK_XFRM),
+			uintptr(unsafe.Pointer(&pair[0])),
+			0,
+			0,
+		)
+		if fd != ^uintptr(0) {
+			_ = gounix.Close(pair[0])
+			_ = gounix.Close(pair[1])
+		}
+		printRawSyscallResult("socketpair_result", fd, errno)
+	default:
+		t.Fatalf("unknown dirtyfrag helper mode %q", mode)
+	}
+
+	stopNotify()
+	printCapturedAuditEvents(emitter.Events())
+}
+
+func dirtyFragProfileSocketRules(t *testing.T) []seccompkg.SocketRule {
+	t.Helper()
+
+	rules, err := config.ResolveSocketRules(config.SandboxSeccompConfig{
+		HardeningProfiles: []string{"dirtyfrag-conservative"},
+	})
+	require.NoError(t, err)
+	require.Len(t, rules, 2)
+	return rules
+}
+
+func startSocketRuleNotifyHelper(t *testing.T, filt *Filter, bl *BlockListConfig, emitter Emitter) func() {
+	t.Helper()
+
+	notifFD := filt.NotifFD()
+	if notifFD < 0 {
+		t.Fatalf("expected valid notify fd; got %d", notifFD)
+	}
+	if err := ProbeNotifReceive(notifFD); err != nil {
+		_ = filt.Close()
+		if errors.Is(err, ErrNotifyBlocked) {
+			t.Skipf("seccomp notification ioctl blocked: %v", err)
+		}
+		t.Fatalf("probe seccomp notification fd: %v", err)
+	}
+
+	notifyFile := os.NewFile(uintptr(notifFD), "seccomp-notify")
+	if notifyFile == nil {
+		_ = filt.Close()
+		t.Fatalf("os.NewFile returned nil for notify fd %d", notifFD)
+	}
+	filt.fd = -1
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if capture, ok := emitter.(*captureEventsEmitter); ok {
+		var cancelOnce sync.Once
+		capture.SetOnEvent(func() {
+			cancelOnce.Do(cancel)
+		})
+	}
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		ServeNotifyWithExecve(ctx, notifyFile, "test-dirtyfrag-socket-rules", nil, emitter, nil, nil, bl)
+	}()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			cancel()
+			_ = notifyFile.Close()
+			select {
+			case <-handlerDone:
+			case <-time.After(2 * time.Second):
+				t.Fatalf("seccomp notify handler did not exit in time")
+			}
+		})
+	}
+}
+
+func printRawSyscallResult(label string, fd uintptr, errno gounix.Errno) {
+	if fd != ^uintptr(0) {
+		_ = gounix.Close(int(fd))
+		fmt.Printf("%s=OK\n", label)
+		return
+	}
+	fmt.Printf("%s=%v (errno=%d)\n", label, errno, int(errno))
+}
+
+func requireResultEAFNOSUPPORT(t *testing.T, combined, label string) {
+	t.Helper()
+
+	if !strings.Contains(combined, label+"=EAFNOSUPPORT") &&
+		!strings.Contains(combined, label+"=address family not supported") &&
+		!strings.Contains(combined, "errno=97") {
+		t.Fatalf("expected %s to return EAFNOSUPPORT; helper output:\n%s", label, combined)
+	}
+}
+
+type captureEventsEmitter struct {
+	mu      sync.Mutex
+	events  []types.Event
+	onEvent func()
+}
+
+func (e *captureEventsEmitter) AppendEvent(_ context.Context, ev types.Event) error {
+	e.add(ev)
+	return nil
+}
+
+func (e *captureEventsEmitter) Publish(ev types.Event) {
+	e.add(ev)
+}
+
+func (e *captureEventsEmitter) add(ev types.Event) {
+	e.mu.Lock()
+	e.events = append(e.events, ev)
+	onEvent := e.onEvent
+	e.mu.Unlock()
+
+	if onEvent != nil {
+		onEvent()
+	}
+}
+
+func (e *captureEventsEmitter) Events() []types.Event {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]types.Event, len(e.events))
+	copy(out, e.events)
+	return out
+}
+
+func (e *captureEventsEmitter) SetOnEvent(fn func()) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.onEvent = fn
+}
+
+func printCapturedAuditEvents(events []types.Event) {
+	seen := map[string]struct{}{}
+	for _, ev := range events {
+		key := fmt.Sprintf(
+			"%s|%v|%v|%v|%v|%v|%v",
+			ev.Type,
+			ev.Fields["rule_name"],
+			ev.Fields["action"],
+			ev.Fields["family_name"],
+			ev.Fields["protocol_name"],
+			ev.Fields["syscall"],
+			ev.Fields["outcome"],
+		)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+
+		fmt.Printf("audit_event=%s\n", ev.Type)
+		if v, ok := ev.Fields["rule_name"]; ok {
+			fmt.Printf("audit_rule=%v\n", v)
+		}
+		if v, ok := ev.Fields["action"]; ok {
+			fmt.Printf("audit_action=%v\n", v)
+		}
+		if v, ok := ev.Fields["family_name"]; ok {
+			fmt.Printf("audit_family=%v\n", v)
+		}
+		if v, ok := ev.Fields["protocol_name"]; ok {
+			fmt.Printf("audit_protocol=%v\n", v)
+		}
+		if v, ok := ev.Fields["syscall"]; ok {
+			fmt.Printf("audit_syscall=%v\n", v)
+		}
+		if v, ok := ev.Fields["outcome"]; ok {
+			fmt.Printf("audit_outcome=%v\n", v)
+		}
 	}
 }
 

--- a/internal/netmonitor/unix/seccomp_socket_rules_test.go
+++ b/internal/netmonitor/unix/seccomp_socket_rules_test.go
@@ -4,12 +4,15 @@ package unix
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
 	seccomp "github.com/seccomp/libseccomp-golang"
@@ -18,6 +21,7 @@ import (
 )
 
 const socketRuleHelperEnv = "AGENTSH_TEST_SOCKET_RULE_HELPER"
+const socketRuleHelperNotifyLog = "notify_log"
 
 func TestNotifySocketRules_FiltersNotifyActions(t *testing.T) {
 	rules := []seccompkg.SocketRule{
@@ -183,6 +187,158 @@ func TestInstallSocketRulesConditional_RejectsPartialInstall(t *testing.T) {
 	require.Equal(t, 1, added)
 	require.Empty(t, retained)
 	require.Len(t, recorder.calls, 2)
+}
+
+func TestSeccompSocketRuleBlock_Notify_LogDispatched(t *testing.T) {
+	if os.Getenv(socketRuleHelperEnv) == socketRuleHelperNotifyLog {
+		runSocketRuleHelperNotifyLog(t)
+		return
+	}
+
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	cmd := exec.Command(exe, "-test.run=^TestSeccompSocketRuleBlock_Notify_LogDispatched$", "-test.v")
+	cmd.Env = append(os.Environ(), socketRuleHelperEnv+"="+socketRuleHelperNotifyLog)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	runErr := cmd.Run()
+	combined := out.String()
+
+	if strings.Contains(combined, "SKIP:") {
+		t.Skipf("child skipped: %s", combined)
+	}
+
+	if runErr != nil {
+		lower := strings.ToLower(combined)
+		if strings.Contains(lower, "permission denied") ||
+			strings.Contains(lower, "operation not permitted") ||
+			strings.Contains(lower, "lacks user notify") ||
+			strings.Contains(lower, "skip") {
+			t.Skipf("host cannot install seccomp filter; skipping.\nhelper output:\n%s", combined)
+		}
+		t.Fatalf("helper subprocess failed: %v\noutput:\n%s", runErr, combined)
+	}
+
+	if !strings.Contains(combined, "socket_result=EAFNOSUPPORT") &&
+		!strings.Contains(combined, "socket_result=address family not supported") &&
+		!strings.Contains(combined, "errno=97") {
+		t.Errorf("expected matching socket tuple to return EAFNOSUPPORT; helper output:\n%s", combined)
+	}
+	if !strings.Contains(combined, "audit_event=seccomp_socket_rule_blocked") {
+		t.Errorf("expected seccomp_socket_rule_blocked audit event; helper output:\n%s", combined)
+	}
+	if strings.Contains(combined, "audit_event=seccomp_socket_family_blocked") {
+		t.Errorf("socket family event emitted — family dispatch shadowed socket tuple rule;\nhelper output:\n%s", combined)
+	}
+	if strings.Contains(combined, "audit_event=seccomp_blocked") {
+		t.Errorf("generic blocklist event emitted — generic dispatch shadowed socket tuple rule;\nhelper output:\n%s", combined)
+	}
+}
+
+func runSocketRuleHelperNotifyLog(t *testing.T) {
+	t.Helper()
+
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+
+	typ := int(gounix.SOCK_RAW)
+	protocol := int(gounix.NETLINK_XFRM)
+	rule := seccompkg.SocketRule{
+		Name:         "dirtyfrag-xfrm",
+		Family:       gounix.AF_NETLINK,
+		FamilyName:   "AF_NETLINK",
+		Type:         &typ,
+		TypeName:     "SOCK_RAW",
+		Protocol:     &protocol,
+		ProtocolName: "NETLINK_XFRM",
+		Action:       seccompkg.OnBlockLog,
+	}
+	cfg := FilterConfig{
+		UnixSocketEnabled: false,
+		BlockedSyscalls:   []int{int(gounix.SYS_SOCKET)},
+		OnBlockAction:     seccompkg.OnBlockLog,
+		BlockedFamilies: []seccompkg.BlockedFamily{
+			{Family: gounix.AF_NETLINK, Action: seccompkg.OnBlockLog, Name: "AF_NETLINK"},
+		},
+		SocketRules: []seccompkg.SocketRule{rule},
+	}
+	filt, err := InstallFilterWithConfig(cfg)
+	if err != nil {
+		lower := strings.ToLower(err.Error())
+		if strings.Contains(lower, "permission") || strings.Contains(lower, "operation not permitted") {
+			t.Skipf("cannot install seccomp filter (privilege): %v", err)
+		}
+		t.Fatalf("InstallFilterWithConfig: %v", err)
+	}
+	defer filt.Close()
+
+	notifFD := filt.NotifFD()
+	if notifFD < 0 {
+		t.Fatalf("expected valid notify fd; got %d", notifFD)
+	}
+
+	bl := &BlockListConfig{
+		ActionByNr:  filt.BlockListMap(),
+		FamilyByKey: filt.BlockedFamilyMap(),
+		SocketRules: filt.SocketRules(),
+	}
+	if len(bl.SocketRules) == 0 {
+		t.Fatalf("SocketRules is empty; log socket rule should populate it")
+	}
+
+	var (
+		mu     sync.Mutex
+		events []string
+	)
+	emitter := &captureEmitter{fn: func(typ string) {
+		mu.Lock()
+		events = append(events, typ)
+		mu.Unlock()
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	notifyFile := os.NewFile(uintptr(notifFD), "seccomp-notify")
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		ServeNotifyWithExecve(ctx, notifyFile, "test-socket-rule-notify", nil, emitter, nil, nil, bl)
+	}()
+
+	fd, _, errno := gounix.RawSyscall(
+		gounix.SYS_SOCKET,
+		uintptr(gounix.AF_NETLINK),
+		uintptr(gounix.SOCK_RAW|gounix.SOCK_CLOEXEC),
+		uintptr(gounix.NETLINK_XFRM),
+	)
+	if fd != ^uintptr(0) {
+		_ = gounix.Close(int(fd))
+		fmt.Printf("socket_result=OK (expected EAFNOSUPPORT)\n")
+	} else {
+		fmt.Printf("socket_result=%v (errno=%d)\n", errno, int(errno))
+	}
+
+	cancel()
+	select {
+	case <-handlerDone:
+	case <-time.After(2 * time.Second):
+		fmt.Printf("handler did not exit in time\n")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, ev := range events {
+		fmt.Printf("audit_event=%s\n", ev)
+	}
 }
 
 func TestSeccompSocketRuleBlock_ErrnoTuple(t *testing.T) {

--- a/internal/netmonitor/unix/seccomp_socket_rules_test.go
+++ b/internal/netmonitor/unix/seccomp_socket_rules_test.go
@@ -1,0 +1,215 @@
+//go:build linux && cgo
+
+package unix
+
+import (
+	"errors"
+	"testing"
+
+	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
+	seccomp "github.com/seccomp/libseccomp-golang"
+	"github.com/stretchr/testify/require"
+	gounix "golang.org/x/sys/unix"
+)
+
+func TestNotifySocketRules_FiltersNotifyActions(t *testing.T) {
+	rules := []seccompkg.SocketRule{
+		{Name: "errno", Family: 60, Action: seccompkg.OnBlockErrno},
+		{Name: "kill", Family: 61, Action: seccompkg.OnBlockKill},
+		{Name: "log", Family: 62, Action: seccompkg.OnBlockLog},
+		{Name: "log_and_kill", Family: 63, Action: seccompkg.OnBlockLogAndKill},
+	}
+
+	got := notifySocketRules(rules)
+
+	require.Len(t, got, 2)
+	require.Equal(t, "log", got[0].Name)
+	require.Equal(t, "log_and_kill", got[1].Name)
+}
+
+func TestInstallFilterWithConfig_SocketRulesRetainedOnlyForNotifyActions(t *testing.T) {
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+
+	rules := []seccompkg.SocketRule{
+		{Name: "errno", Family: 60, Action: seccompkg.OnBlockErrno},
+		{Name: "kill", Family: 61, Action: seccompkg.OnBlockKill},
+		{Name: "log", Family: 62, Action: seccompkg.OnBlockLog},
+		{Name: "log_and_kill", Family: 63, Action: seccompkg.OnBlockLogAndKill},
+	}
+
+	filt, err := InstallFilterWithConfig(FilterConfig{SocketRules: rules})
+	require.NoError(t, err)
+	defer filt.Close()
+
+	got := filt.SocketRules()
+	require.Len(t, got, 2)
+	require.Equal(t, "log", got[0].Name)
+	require.Equal(t, "log_and_kill", got[1].Name)
+}
+
+func TestFilterSocketRules_ReturnsDeepCopy(t *testing.T) {
+	typ := int(gounix.SOCK_DGRAM)
+	protocol := int(gounix.NETLINK_XFRM)
+	filt := &Filter{
+		socketRules: []seccompkg.SocketRule{
+			{
+				Name:     "netlink_xfrm",
+				Family:   gounix.AF_NETLINK,
+				Type:     &typ,
+				Protocol: &protocol,
+				Action:   seccompkg.OnBlockLog,
+			},
+		},
+	}
+
+	got := filt.SocketRules()
+	require.Len(t, got, 1)
+	got[0].Name = "mutated"
+	*got[0].Type = int(gounix.SOCK_RAW)
+	*got[0].Protocol = int(gounix.NETLINK_AUDIT)
+
+	again := filt.SocketRules()
+	require.Equal(t, "netlink_xfrm", again[0].Name)
+	require.Equal(t, int(gounix.SOCK_DGRAM), *again[0].Type)
+	require.Equal(t, int(gounix.NETLINK_XFRM), *again[0].Protocol)
+}
+
+func TestSocketRules_RetainProtocolSpecificNetlinkXFRM(t *testing.T) {
+	typ := int(gounix.SOCK_RAW)
+	protocol := int(gounix.NETLINK_XFRM)
+	got := notifySocketRules([]seccompkg.SocketRule{
+		{
+			Name:         "netlink_xfrm",
+			Family:       gounix.AF_NETLINK,
+			FamilyName:   "AF_NETLINK",
+			Type:         &typ,
+			TypeName:     "SOCK_RAW",
+			Protocol:     &protocol,
+			ProtocolName: "NETLINK_XFRM",
+			Action:       seccompkg.OnBlockLog,
+		},
+	})
+
+	require.Len(t, got, 1)
+	require.Equal(t, gounix.AF_NETLINK, got[0].Family)
+	require.NotNil(t, got[0].Protocol)
+	require.Equal(t, int(gounix.NETLINK_XFRM), *got[0].Protocol)
+}
+
+func TestSocketRuleConditions_UseMaskedTypeAndProtocol(t *testing.T) {
+	typ := int(gounix.SOCK_DGRAM)
+	protocol := int(gounix.NETLINK_XFRM)
+	rule := seccompkg.SocketRule{
+		Family:   gounix.AF_NETLINK,
+		Type:     &typ,
+		Protocol: &protocol,
+		Action:   seccompkg.OnBlockLog,
+	}
+
+	conds := socketRuleConditions(rule)
+
+	require.Len(t, conds, 3)
+	require.Equal(t, seccomp.ScmpCondition{
+		Argument: 0,
+		Op:       seccomp.CompareEqual,
+		Operand1: uint64(gounix.AF_NETLINK),
+	}, conds[0])
+	require.Equal(t, seccomp.ScmpCondition{
+		Argument: 1,
+		Op:       seccomp.CompareMaskedEqual,
+		Operand1: uint64(seccompkg.SocketTypeMask),
+		Operand2: uint64(gounix.SOCK_DGRAM),
+	}, conds[1])
+	require.Equal(t, seccomp.ScmpCondition{
+		Argument: 2,
+		Op:       seccomp.CompareEqual,
+		Operand1: uint64(gounix.NETLINK_XFRM),
+	}, conds[2])
+}
+
+func TestInstallSocketRuleConditional_InstallsSocketpairProtocolRule(t *testing.T) {
+	protocol := int(gounix.NETLINK_XFRM)
+	rule := seccompkg.SocketRule{
+		Family:   gounix.AF_NETLINK,
+		Protocol: &protocol,
+		Action:   seccompkg.OnBlockLog,
+	}
+	recorder := &recordingConditionalAdder{}
+
+	added, err := installSocketRuleConditional(recorder, rule, seccomp.ActNotify)
+
+	require.NoError(t, err)
+	require.Equal(t, 2, added)
+	require.Len(t, recorder.calls, 2)
+	require.Equal(t, seccomp.ScmpSyscall(gounix.SYS_SOCKET), recorder.calls[0].syscall)
+	require.Equal(t, seccomp.ScmpSyscall(gounix.SYS_SOCKETPAIR), recorder.calls[1].syscall)
+	for _, call := range recorder.calls {
+		require.Contains(t, call.conditions, seccomp.ScmpCondition{
+			Argument: 2,
+			Op:       seccomp.CompareEqual,
+			Operand1: uint64(gounix.NETLINK_XFRM),
+		})
+	}
+}
+
+func TestInstallSocketRuleConditional_ReportsPartialFailure(t *testing.T) {
+	rule := seccompkg.SocketRule{Family: 62, Action: seccompkg.OnBlockLog}
+	recorder := &recordingConditionalAdder{failOnCall: 2}
+
+	added, err := installSocketRuleConditional(recorder, rule, seccomp.ActNotify)
+
+	require.Error(t, err)
+	require.Equal(t, 1, added)
+	require.Len(t, recorder.calls, 2)
+}
+
+func TestFilterDiagnosticFields_RulesSocketRules(t *testing.T) {
+	filt, err := seccomp.NewFilter(seccomp.ActAllow)
+	require.NoError(t, err)
+
+	fields := filterDiagnosticFields(filt, FilterConfig{}, false, map[string]int{
+		"blocked_syscalls": 2,
+		"socket_rules":     4,
+	})
+
+	got := diagnosticFieldsMap(fields)
+	require.Equal(t, 6, got["rules_total"])
+	require.Equal(t, 4, got["rules_socket_rules"])
+}
+
+type recordingConditionalAdder struct {
+	failOnCall int
+	calls      []recordedConditionalCall
+}
+
+type recordedConditionalCall struct {
+	syscall    seccomp.ScmpSyscall
+	action     seccomp.ScmpAction
+	conditions []seccomp.ScmpCondition
+}
+
+func (r *recordingConditionalAdder) AddRuleConditional(call seccomp.ScmpSyscall, action seccomp.ScmpAction, conds []seccomp.ScmpCondition) error {
+	copied := append([]seccomp.ScmpCondition(nil), conds...)
+	r.calls = append(r.calls, recordedConditionalCall{
+		syscall:    call,
+		action:     action,
+		conditions: copied,
+	})
+	if r.failOnCall != 0 && len(r.calls) == r.failOnCall {
+		return errors.New("synthetic add failure")
+	}
+	return nil
+}
+
+func diagnosticFieldsMap(fields []any) map[string]any {
+	out := make(map[string]any, len(fields)/2)
+	for i := 0; i+1 < len(fields); i += 2 {
+		key, ok := fields[i].(string)
+		if ok {
+			out[key] = fields[i+1]
+		}
+	}
+	return out
+}

--- a/internal/netmonitor/unix/seccomp_socket_rules_test.go
+++ b/internal/netmonitor/unix/seccomp_socket_rules_test.go
@@ -3,7 +3,12 @@
 package unix
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
 	"testing"
 
 	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
@@ -11,6 +16,8 @@ import (
 	"github.com/stretchr/testify/require"
 	gounix "golang.org/x/sys/unix"
 )
+
+const socketRuleHelperEnv = "AGENTSH_TEST_SOCKET_RULE_HELPER"
 
 func TestNotifySocketRules_FiltersNotifyActions(t *testing.T) {
 	rules := []seccompkg.SocketRule{
@@ -163,6 +170,110 @@ func TestInstallSocketRuleConditional_ReportsPartialFailure(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, 1, added)
 	require.Len(t, recorder.calls, 2)
+}
+
+func TestInstallSocketRulesConditional_RejectsPartialInstall(t *testing.T) {
+	rule := seccompkg.SocketRule{Name: "partial", Family: 62, Action: seccompkg.OnBlockLog}
+	recorder := &recordingConditionalAdder{failOnCall: 2}
+
+	retained, added, err := installSocketRulesConditional(recorder, []seccompkg.SocketRule{rule})
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "partial")
+	require.Equal(t, 1, added)
+	require.Empty(t, retained)
+	require.Len(t, recorder.calls, 2)
+}
+
+func TestSeccompSocketRuleBlock_ErrnoTuple(t *testing.T) {
+	if os.Getenv(socketRuleHelperEnv) == "errno_tuple" {
+		runSocketRuleHelperErrnoTuple(t)
+		return
+	}
+
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	cmd := exec.Command(exe, "-test.run=^TestSeccompSocketRuleBlock_ErrnoTuple$", "-test.v")
+	cmd.Env = append(os.Environ(), socketRuleHelperEnv+"=errno_tuple")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	runErr := cmd.Run()
+	combined := out.String()
+
+	if strings.Contains(combined, "SKIP:") {
+		t.Skipf("child skipped: %s", combined)
+	}
+	if runErr != nil {
+		lower := strings.ToLower(combined)
+		if strings.Contains(lower, "permission denied") ||
+			strings.Contains(lower, "operation not permitted") ||
+			strings.Contains(lower, "lacks user notify") ||
+			strings.Contains(lower, "skip") {
+			t.Skipf("host cannot install seccomp filter; skipping.\nhelper output:\n%s", combined)
+		}
+		t.Fatalf("helper subprocess failed: %v\noutput:\n%s", runErr, combined)
+	}
+
+	if !strings.Contains(combined, "socket_result=EAFNOSUPPORT") &&
+		!strings.Contains(combined, "socket_result=address family not supported") &&
+		!strings.Contains(combined, "errno=97") {
+		t.Errorf("expected matching socket tuple to return EAFNOSUPPORT; helper output:\n%s", combined)
+	}
+}
+
+func runSocketRuleHelperErrnoTuple(t *testing.T) {
+	t.Helper()
+
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+
+	typ := int(gounix.SOCK_RAW)
+	protocol := int(gounix.NETLINK_XFRM)
+	cfg := FilterConfig{
+		SocketRules: []seccompkg.SocketRule{
+			{
+				Name:         "netlink_xfrm",
+				Family:       gounix.AF_NETLINK,
+				FamilyName:   "AF_NETLINK",
+				Type:         &typ,
+				TypeName:     "SOCK_RAW",
+				Protocol:     &protocol,
+				ProtocolName: "NETLINK_XFRM",
+				Action:       seccompkg.OnBlockErrno,
+			},
+		},
+	}
+	filt, err := InstallFilterWithConfig(cfg)
+	if err != nil {
+		lower := strings.ToLower(err.Error())
+		if strings.Contains(lower, "permission") || strings.Contains(lower, "operation not permitted") {
+			t.Skipf("cannot install seccomp filter (privilege): %v", err)
+		}
+		t.Fatalf("InstallFilterWithConfig: %v", err)
+	}
+	defer filt.Close()
+
+	fd, _, errno := gounix.RawSyscall(
+		gounix.SYS_SOCKET,
+		uintptr(gounix.AF_NETLINK),
+		uintptr(gounix.SOCK_RAW|gounix.SOCK_CLOEXEC),
+		uintptr(gounix.NETLINK_XFRM),
+	)
+	if fd != ^uintptr(0) {
+		_ = gounix.Close(int(fd))
+		fmt.Printf("socket_result=OK (expected EAFNOSUPPORT)\n")
+		return
+	}
+	fmt.Printf("socket_result=%v (errno=%d)\n", errno, int(errno))
 }
 
 func TestFilterDiagnosticFields_RulesSocketRules(t *testing.T) {

--- a/internal/netmonitor/unix/seccomp_socket_rules_test.go
+++ b/internal/netmonitor/unix/seccomp_socket_rules_test.go
@@ -403,7 +403,7 @@ func runDirtyFragSocketRuleHelper(t *testing.T, mode string) {
 
 	switch mode {
 	case socketRuleHelperDirtyFragNetlinkXFRM:
-		fd, _, errno := gounix.RawSyscall(
+		fd, _, errno := gounix.Syscall(
 			gounix.SYS_SOCKET,
 			uintptr(gounix.AF_NETLINK),
 			uintptr(gounix.SOCK_RAW|gounix.SOCK_CLOEXEC),
@@ -411,7 +411,7 @@ func runDirtyFragSocketRuleHelper(t *testing.T, mode string) {
 		)
 		printRawSyscallResult("socket_result", fd, errno)
 	case socketRuleHelperDirtyFragNetlinkRoute:
-		fd, _, errno := gounix.RawSyscall(
+		fd, _, errno := gounix.Syscall(
 			gounix.SYS_SOCKET,
 			uintptr(gounix.AF_NETLINK),
 			uintptr(gounix.SOCK_RAW|gounix.SOCK_CLOEXEC),
@@ -419,7 +419,7 @@ func runDirtyFragSocketRuleHelper(t *testing.T, mode string) {
 		)
 		printRawSyscallResult("socket_result", fd, errno)
 	case socketRuleHelperDirtyFragRXRPC:
-		fd, _, errno := gounix.RawSyscall(
+		fd, _, errno := gounix.Syscall(
 			gounix.SYS_SOCKET,
 			uintptr(gounix.AF_RXRPC),
 			uintptr(gounix.SOCK_DGRAM|gounix.SOCK_CLOEXEC),
@@ -432,7 +432,7 @@ func runDirtyFragSocketRuleHelper(t *testing.T, mode string) {
 		// the end-to-end assertion about protocol arg2 without depending on a
 		// successful host socketpair implementation.
 		var pair [2]int
-		fd, _, errno := gounix.RawSyscall6(
+		fd, _, errno := gounix.Syscall6(
 			gounix.SYS_SOCKETPAIR,
 			uintptr(gounix.AF_NETLINK),
 			uintptr(gounix.SOCK_RAW|gounix.SOCK_CLOEXEC),

--- a/internal/netmonitor/unix/seccomp_socket_rules_test.go
+++ b/internal/netmonitor/unix/seccomp_socket_rules_test.go
@@ -352,7 +352,7 @@ func runDirtyFragSocketRuleHelper(t *testing.T, mode string) {
 
 	if got := filt.SocketRules(); len(got) != 2 {
 		_ = filt.Close()
-		t.Fatalf("dirtyfrag profile socket rules not retained for notify; got %d", len(got))
+		t.Fatalf("dirtyfrag mitigation set socket rules not retained for notify; got %d", len(got))
 	}
 
 	restore := swapPidfdSeams(t,

--- a/internal/netmonitor/unix/seccomp_socket_rules_test.go
+++ b/internal/netmonitor/unix/seccomp_socket_rules_test.go
@@ -330,7 +330,7 @@ func runDirtyFragSocketRuleHelper(t *testing.T, mode string) {
 		t.Skipf("seccomp user-notify not supported: %v", err)
 	}
 
-	rules := dirtyFragProfileSocketRules(t)
+	rules := dirtyFragMitigationSetSocketRules(t)
 	cfg := FilterConfig{
 		UnixSocketEnabled: false,
 		BlockedSyscalls:   []int{int(gounix.SYS_SOCKET), int(gounix.SYS_SOCKETPAIR)},
@@ -423,11 +423,11 @@ func runDirtyFragSocketRuleHelper(t *testing.T, mode string) {
 	printCapturedAuditEvents(emitter.Events())
 }
 
-func dirtyFragProfileSocketRules(t *testing.T) []seccompkg.SocketRule {
+func dirtyFragMitigationSetSocketRules(t *testing.T) []seccompkg.SocketRule {
 	t.Helper()
 
 	rules, err := config.ResolveSocketRules(config.SandboxSeccompConfig{
-		HardeningProfiles: []string{"dirtyfrag-conservative"},
+		MitigationSets: []string{"dirtyfrag-conservative"},
 	})
 	require.NoError(t, err)
 	require.Len(t, rules, 2)

--- a/internal/netmonitor/unix/seccomp_socket_rules_test.go
+++ b/internal/netmonitor/unix/seccomp_socket_rules_test.go
@@ -219,7 +219,7 @@ func TestSeccompSocketRuleBlock_Notify_LogDispatched(t *testing.T) {
 	}
 }
 
-func TestDirtyFragNetlinkXFRM_ProfileLogAndKillSeccompSocketRule(t *testing.T) {
+func TestDirtyFragNetlinkXFRM_MitigationSetLogAndKillSeccompSocketRule(t *testing.T) {
 	if os.Getenv(socketRuleHelperEnv) == socketRuleHelperDirtyFragNetlinkXFRM {
 		runDirtyFragSocketRuleHelper(t, socketRuleHelperDirtyFragNetlinkXFRM)
 		return
@@ -247,7 +247,7 @@ func TestDirtyFragNetlinkRoute_DoesNotDispatchSocketRule(t *testing.T) {
 	require.NotContains(t, combined, "audit_rule=dirtyfrag-conservative-xfrm")
 }
 
-func TestDirtyFragRXRPC_ProfileFamilyOnlyRuleDispatchesAsSocketRule(t *testing.T) {
+func TestDirtyFragRXRPC_MitigationSetFamilyOnlyRuleDispatchesAsSocketRule(t *testing.T) {
 	if os.Getenv(socketRuleHelperEnv) == socketRuleHelperDirtyFragRXRPC {
 		runDirtyFragSocketRuleHelper(t, socketRuleHelperDirtyFragRXRPC)
 		return
@@ -263,7 +263,7 @@ func TestDirtyFragRXRPC_ProfileFamilyOnlyRuleDispatchesAsSocketRule(t *testing.T
 	require.NotContains(t, combined, "audit_event=seccomp_blocked")
 }
 
-func TestDirtyFragSocketpairNetlinkXFRM_ProfileProtocolRule(t *testing.T) {
+func TestDirtyFragSocketpairNetlinkXFRM_MitigationSetProtocolRule(t *testing.T) {
 	if os.Getenv(socketRuleHelperEnv) == socketRuleHelperDirtyFragSocketpairXFRM {
 		runDirtyFragSocketRuleHelper(t, socketRuleHelperDirtyFragSocketpairXFRM)
 		return

--- a/internal/netmonitor/unix/seccomp_socket_rules_test.go
+++ b/internal/netmonitor/unix/seccomp_socket_rules_test.go
@@ -206,39 +206,8 @@ func TestSeccompSocketRuleBlock_Notify_LogDispatched(t *testing.T) {
 		t.Skipf("seccomp user-notify not supported: %v", err)
 	}
 
-	exe, err := os.Executable()
-	if err != nil {
-		t.Fatalf("os.Executable: %v", err)
-	}
-
-	cmd := exec.Command(exe, "-test.run=^TestSeccompSocketRuleBlock_Notify_LogDispatched$", "-test.v")
-	cmd.Env = append(os.Environ(), socketRuleHelperEnv+"="+socketRuleHelperNotifyLog)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	runErr := cmd.Run()
-	combined := out.String()
-
-	if strings.Contains(combined, "SKIP:") {
-		t.Skipf("child skipped: %s", combined)
-	}
-
-	if runErr != nil {
-		lower := strings.ToLower(combined)
-		if strings.Contains(lower, "permission denied") ||
-			strings.Contains(lower, "operation not permitted") ||
-			strings.Contains(lower, "lacks user notify") ||
-			strings.Contains(lower, "skip") {
-			t.Skipf("host cannot install seccomp filter; skipping.\nhelper output:\n%s", combined)
-		}
-		t.Fatalf("helper subprocess failed: %v\noutput:\n%s", runErr, combined)
-	}
-
-	if !strings.Contains(combined, "socket_result=EAFNOSUPPORT") &&
-		!strings.Contains(combined, "socket_result=address family not supported") &&
-		!strings.Contains(combined, "errno=97") {
-		t.Errorf("expected matching socket tuple to return EAFNOSUPPORT; helper output:\n%s", combined)
-	}
+	combined := runSocketRuleHelperSubprocess(t, socketRuleHelperNotifyLog)
+	requireResultEAFNOSUPPORT(t, combined, "socket_result")
 	if !strings.Contains(combined, "audit_event=seccomp_socket_rule_blocked") {
 		t.Errorf("expected seccomp_socket_rule_blocked audit event; helper output:\n%s", combined)
 	}
@@ -684,7 +653,7 @@ func runSocketRuleHelperNotifyLog(t *testing.T) {
 		ServeNotifyWithExecve(ctx, notifyFile, "test-socket-rule-notify", nil, emitter, nil, nil, bl)
 	}()
 
-	fd, _, errno := gounix.RawSyscall(
+	fd, _, errno := gounix.Syscall(
 		gounix.SYS_SOCKET,
 		uintptr(gounix.AF_NETLINK),
 		uintptr(gounix.SOCK_RAW|gounix.SOCK_CLOEXEC),

--- a/internal/ocsf/mapper_test.go
+++ b/internal/ocsf/mapper_test.go
@@ -35,6 +35,52 @@ func TestMap_UnmappedTypeReturnsErrUnmappedType(t *testing.T) {
 	}
 }
 
+func TestMap_seccomp_socket_rule_blockedFinding(t *testing.T) {
+	m := New()
+	ev := types.Event{
+		ID:        "ev-seccomp-socket-rule-1",
+		Type:      "seccomp_socket_rule_blocked",
+		Timestamp: time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC),
+		PID:       601,
+		Fields: map[string]any{
+			"rule_name":       "dirtyfrag-xfrm",
+			"family_name":     "AF_NETLINK",
+			"family_number":   16,
+			"protocol_name":   "NETLINK_XFRM",
+			"protocol_number": 6,
+			"syscall":         "socket",
+			"syscall_nr":      41,
+			"action":          "log",
+			"outcome":         "denied",
+			"arch":            "amd64",
+			"engine":          "seccomp",
+		},
+	}
+
+	mapped, err := m.Map(ev)
+	if err != nil {
+		t.Fatalf("Map(%q): %v", ev.Type, err)
+	}
+	if mapped.OCSFClassUID != ClassDetectionFinding {
+		t.Fatalf("class uid = %d, want %d", mapped.OCSFClassUID, ClassDetectionFinding)
+	}
+	if mapped.OCSFActivityID != FindingActivityCreate {
+		t.Fatalf("activity id = %d, want %d", mapped.OCSFActivityID, FindingActivityCreate)
+	}
+
+	msg, err := decodePayloadForGolden(mapped.OCSFClassUID, mapped.Payload)
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	finding, ok := msg.(*ocsfpb.DetectionFinding)
+	if !ok {
+		t.Fatalf("mapped payload type = %T, want *DetectionFinding", msg)
+	}
+	if got := finding.GetFindingInfo().GetTypes(); got != "policy_decision" {
+		t.Fatalf("finding type = %q, want policy_decision", got)
+	}
+}
+
 // TestMapDeterministic asserts that for any registered event, mapping
 // 1000 times produces byte-identical Payload. Run on a sample of
 // events covering every class. New event Types added in per-class
@@ -257,6 +303,10 @@ func goldenSampleEvents() []types.Event {
 			Policy: &types.PolicyInfo{Decision: "deny", Rule: "no-curl", Message: "curl is blocked"}},
 		{ID: "ev-seccomp-1", Type: "seccomp_blocked", Timestamp: t0, PID: 601,
 			Policy: &types.PolicyInfo{Decision: "deny", Rule: "syscall-block"}},
+		{ID: "ev-seccomp-socket-rule-1", Type: "seccomp_socket_rule_blocked", Timestamp: t0, PID: 601,
+			Fields: map[string]any{"rule_name": "dirtyfrag-xfrm", "family_name": "AF_NETLINK", "family_number": 16,
+				"protocol_name": "NETLINK_XFRM", "protocol_number": 6, "syscall": "socket",
+				"syscall_nr": 41, "action": "log", "outcome": "denied", "arch": "amd64", "engine": "seccomp"}},
 		{ID: "ev-agent-detect-1", Type: "agent_detected", Timestamp: t0, PID: 602,
 			Policy: &types.PolicyInfo{Decision: "warn", Message: "self-detection succeeded"}},
 		{ID: "ev-taint-created-1", Type: "taint_created", Timestamp: t0, PID: 603},

--- a/internal/ocsf/project_finding.go
+++ b/internal/ocsf/project_finding.go
@@ -50,15 +50,16 @@ func findingProjector(activity uint32, findingType string) Projector {
 
 func init() {
 	findingTypes := map[string]string{
-		"command_policy":                   "policy_decision",
-		"seccomp_blocked":                  "policy_decision",
-		"seccomp_socket_family_blocked":    "policy_decision",
-		"agent_detected":                   "agent_self_detected",
-		"taint_created":                    "taint",
-		"taint_propagated":                 "taint",
-		"taint_removed":                    "taint",
-		"mcp_cross_server_blocked":         "policy_decision",
-		"mcp_tool_call_intercepted":        "policy_decision",
+		"command_policy":                "policy_decision",
+		"seccomp_blocked":               "policy_decision",
+		"seccomp_socket_family_blocked": "policy_decision",
+		"seccomp_socket_rule_blocked":   "policy_decision",
+		"agent_detected":                "agent_self_detected",
+		"taint_created":                 "taint",
+		"taint_propagated":              "taint",
+		"taint_removed":                 "taint",
+		"mcp_cross_server_blocked":      "policy_decision",
+		"mcp_tool_call_intercepted":     "policy_decision",
 	}
 	for t, ft := range findingTypes {
 		register(t, Mapping{

--- a/internal/ocsf/registry.go
+++ b/internal/ocsf/registry.go
@@ -78,12 +78,13 @@ var pendingTypes = map[string]struct{}{
 	"command_policy":                {},
 	"seccomp_blocked":               {},
 	"seccomp_socket_family_blocked": {},
+	"seccomp_socket_rule_blocked":   {},
 	"agent_detected":                {},
-	"taint_created":             {},
-	"taint_propagated":          {},
-	"taint_removed":             {},
-	"mcp_cross_server_blocked":  {},
-	"mcp_tool_call_intercepted": {},
+	"taint_created":                 {},
+	"taint_propagated":              {},
+	"taint_removed":                 {},
+	"mcp_cross_server_blocked":      {},
+	"mcp_tool_call_intercepted":     {},
 	// Application Activity (6005) — Task 22
 	"mcp_tool_called":             {},
 	"mcp_tool_seen":               {},
@@ -134,4 +135,3 @@ func register(t string, m Mapping) {
 	registry[t] = m
 	delete(pendingTypes, t)
 }
-

--- a/internal/ocsf/testdata/golden/seccomp_socket_rule_blocked.json
+++ b/internal/ocsf/testdata/golden/seccomp_socket_rule_blocked.json
@@ -1,0 +1,28 @@
+{
+  "class_uid":  2004,
+  "activity_id":  1,
+  "category_uid":  2,
+  "type_uid":  200401,
+  "time":  "1777118400000000000",
+  "severity":  "Medium",
+  "metadata":  {
+    "version":  "1.8.0",
+    "product":  {
+      "name":  "agentsh",
+      "vendor_name":  "agentsh"
+    },
+    "logged_time":  "1777118400000000000",
+    "event_code":  "seccomp_socket_rule_blocked",
+    "uid":  "ev-seccomp-socket-rule-1"
+  },
+  "actor":  {
+    "process":  {
+      "pid":  "601"
+    }
+  },
+  "finding_info":  {
+    "title":  "seccomp_socket_rule_blocked",
+    "finding_uid":  "ev-seccomp-socket-rule-1",
+    "types":  "policy_decision"
+  }
+}

--- a/internal/ptrace/socket_rule_checker.go
+++ b/internal/ptrace/socket_rule_checker.go
@@ -1,0 +1,223 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"runtime"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/seccomp"
+	"github.com/agentsh/agentsh/pkg/types"
+	"golang.org/x/sys/unix"
+)
+
+// SocketRuleChecker matches socket(2)/socketpair(2) calls against resolved
+// socket tuple rules. Rules are evaluated in configuration order so the first
+// specific match wins.
+type SocketRuleChecker struct {
+	rules []seccomp.SocketRule
+	emit  FamilyEmitter
+
+	// tgkillFn and denySyscallFn mirror FamilyChecker's test seams.
+	tgkillFn      func(tgid, tid int, sig unix.Signal) error
+	denySyscallFn func(tid int, errno int) error
+}
+
+// NewSocketRuleChecker indexes socket tuple rules for ptrace enforcement.
+// nil/empty input produces a checker that never matches.
+func NewSocketRuleChecker(rules []seccomp.SocketRule) *SocketRuleChecker {
+	return NewSocketRuleCheckerWithEmitter(rules, nil)
+}
+
+// NewSocketRuleCheckerWithEmitter wires socket tuple rules to the shared
+// audit sink. Pass nil emit to skip event-store emission in tests/local use.
+func NewSocketRuleCheckerWithEmitter(rules []seccomp.SocketRule, emit FamilyEmitter) *SocketRuleChecker {
+	c := &SocketRuleChecker{
+		emit: emit,
+		tgkillFn: func(tgid, tid int, sig unix.Signal) error {
+			return unix.Tgkill(tgid, tid, sig)
+		},
+	}
+	if len(rules) > 0 {
+		c.rules = append([]seccomp.SocketRule(nil), rules...)
+	}
+	return c
+}
+
+// Check reports the first socket tuple rule matching syscall+args.
+// Only SYS_SOCKET and SYS_SOCKETPAIR are eligible.
+func (c *SocketRuleChecker) Check(syscall, family, typ, protocol uint64) (seccomp.SocketRule, bool) {
+	if c == nil || len(c.rules) == 0 {
+		return seccomp.SocketRule{}, false
+	}
+	switch syscall {
+	case uint64(unix.SYS_SOCKET):
+		for _, rule := range c.rules {
+			if rule.MatchesSocket(family, typ, protocol) {
+				return rule, true
+			}
+		}
+	case uint64(unix.SYS_SOCKETPAIR):
+		for _, rule := range c.rules {
+			if rule.MatchesSocketpair(family, typ, protocol) {
+				return rule, true
+			}
+		}
+	}
+	return seccomp.SocketRule{}, false
+}
+
+// Apply executes the blocking action for a matched socket tuple rule.
+// Behavior intentionally mirrors FamilyChecker.Apply so ptrace fallback
+// enforces the same errno/kill/log semantics as socket-family blocking.
+func (c *SocketRuleChecker) Apply(
+	tid int,
+	tgid int,
+	tracer *Tracer,
+	action seccomp.OnBlockAction,
+	syscallNr int,
+	rule seccomp.SocketRule,
+	sessionID string,
+) error {
+	denySC := c.denySyscallFn
+	if denySC == nil {
+		denySC = func(t int, errno int) error {
+			return tracer.denySyscall(t, errno)
+		}
+	}
+
+	switch action {
+	case seccomp.OnBlockErrno:
+		if err := denySC(tid, int(unix.EAFNOSUPPORT)); err != nil {
+			if errors.Is(err, unix.ESRCH) {
+				return ptraceAlreadyResumed
+			}
+			return err
+		}
+		return ptraceAlreadyResumed
+
+	case seccomp.OnBlockKill, seccomp.OnBlockLogAndKill:
+		tgkill := c.tgkillFn
+		if tgkill == nil {
+			tgkill = func(tg, t int, sig unix.Signal) error {
+				return unix.Tgkill(tg, t, sig)
+			}
+		}
+
+		err := tgkill(tgid, tid, unix.SIGKILL)
+		var actualOutcome string
+		var retErr error
+
+		if err == nil {
+			actualOutcome = "killed"
+			retErr = PtraceKillRequested
+		} else if errors.Is(err, unix.ESRCH) {
+			actualOutcome = "vanished"
+			retErr = nil
+		} else {
+			if denyErr := denySC(tid, int(unix.EAFNOSUPPORT)); denyErr != nil {
+				slog.Warn("ptrace: socket-rule tgkill failed and deny fallback also failed",
+					"tid", tid, "rule", rule.Name, "tgkill_err", err, "deny_err", denyErr)
+				actualOutcome = "deny_fallback_failed"
+			} else {
+				slog.Warn("ptrace: socket-rule tgkill failed; denied syscall instead",
+					"tid", tid, "rule", rule.Name, "tgkill_err", err)
+				actualOutcome = "denied"
+			}
+			retErr = ptraceAlreadyResumed
+		}
+
+		if action == seccomp.OnBlockLogAndKill {
+			c.emitSocketRuleBlocked(tid, syscallNr, rule, action, sessionID, actualOutcome)
+		}
+		return retErr
+
+	case seccomp.OnBlockLog:
+		actualOutcome := "denied"
+		if err := denySC(tid, int(unix.EAFNOSUPPORT)); err != nil {
+			if errors.Is(err, unix.ESRCH) {
+				actualOutcome = "vanished"
+				c.emitSocketRuleBlocked(tid, syscallNr, rule, action, sessionID, actualOutcome)
+				return ptraceAlreadyResumed
+			}
+			actualOutcome = "deny_failed"
+			c.emitSocketRuleBlocked(tid, syscallNr, rule, action, sessionID, actualOutcome)
+			return err
+		}
+		c.emitSocketRuleBlocked(tid, syscallNr, rule, action, sessionID, actualOutcome)
+		return ptraceAlreadyResumed
+
+	default:
+		return nil
+	}
+}
+
+func (c *SocketRuleChecker) emitSocketRuleBlocked(
+	tid int,
+	syscallNr int,
+	rule seccomp.SocketRule,
+	action seccomp.OnBlockAction,
+	sessionID string,
+	outcome string,
+) {
+	syscallName := familySyscallName(syscallNr)
+	slog.Debug("ptrace: socket rule blocked",
+		"session_id", sessionID,
+		"rule_name", rule.Name,
+		"family_name", rule.FamilyName,
+		"family_number", rule.Family,
+		"syscall", syscallName,
+		"syscall_nr", syscallNr,
+		"action", string(action),
+		"outcome", outcome,
+		"engine", "ptrace",
+		"pid", tid,
+		"arch", runtime.GOARCH,
+	)
+	if c == nil || c.emit == nil {
+		return
+	}
+
+	fields := map[string]any{
+		"rule_name":     rule.Name,
+		"family_name":   rule.FamilyName,
+		"family_number": rule.Family,
+		"syscall":       syscallName,
+		"syscall_nr":    uint32(syscallNr),
+		"action":        string(action),
+		"outcome":       outcome,
+		"arch":          runtime.GOARCH,
+		"engine":        "ptrace",
+	}
+	if rule.Type != nil {
+		fields["type_number"] = *rule.Type
+		if rule.TypeName != "" {
+			fields["type_name"] = rule.TypeName
+		}
+	}
+	if rule.Protocol != nil {
+		fields["protocol_number"] = *rule.Protocol
+		if rule.ProtocolName != "" {
+			fields["protocol_name"] = rule.ProtocolName
+		}
+	}
+
+	ev := types.Event{
+		ID:        fmt.Sprintf("ptrace-%d-%d", tid, time.Now().UnixNano()),
+		Timestamp: time.Now().UTC(),
+		Type:      "seccomp_socket_rule_blocked",
+		SessionID: sessionID,
+		Source:    "ptrace",
+		PID:       tid,
+		Fields:    fields,
+	}
+	if err := c.emit.AppendEvent(context.Background(), ev); err != nil {
+		slog.Warn("ptrace socket-rule: AppendEvent failed",
+			"session_id", sessionID, "tid", tid, "rule", rule.Name, "error", err)
+	}
+	c.emit.Publish(ev)
+}

--- a/internal/ptrace/socket_rule_checker.go
+++ b/internal/ptrace/socket_rule_checker.go
@@ -43,7 +43,7 @@ func NewSocketRuleCheckerWithEmitter(rules []seccomp.SocketRule, emit FamilyEmit
 		},
 	}
 	if len(rules) > 0 {
-		c.rules = append([]seccomp.SocketRule(nil), rules...)
+		c.rules = cloneSocketRules(rules)
 	}
 	return c
 }
@@ -58,17 +58,40 @@ func (c *SocketRuleChecker) Check(syscall, family, typ, protocol uint64) (seccom
 	case uint64(unix.SYS_SOCKET):
 		for _, rule := range c.rules {
 			if rule.MatchesSocket(family, typ, protocol) {
-				return rule, true
+				return cloneSocketRule(rule), true
 			}
 		}
 	case uint64(unix.SYS_SOCKETPAIR):
 		for _, rule := range c.rules {
 			if rule.MatchesSocketpair(family, typ, protocol) {
-				return rule, true
+				return cloneSocketRule(rule), true
 			}
 		}
 	}
 	return seccomp.SocketRule{}, false
+}
+
+func cloneSocketRules(rules []seccomp.SocketRule) []seccomp.SocketRule {
+	if len(rules) == 0 {
+		return nil
+	}
+	out := make([]seccomp.SocketRule, len(rules))
+	for i, rule := range rules {
+		out[i] = cloneSocketRule(rule)
+	}
+	return out
+}
+
+func cloneSocketRule(rule seccomp.SocketRule) seccomp.SocketRule {
+	if rule.Type != nil {
+		typ := *rule.Type
+		rule.Type = &typ
+	}
+	if rule.Protocol != nil {
+		protocol := *rule.Protocol
+		rule.Protocol = &protocol
+	}
+	return rule
 }
 
 // Apply executes the blocking action for a matched socket tuple rule.

--- a/internal/ptrace/socket_rule_checker_test.go
+++ b/internal/ptrace/socket_rule_checker_test.go
@@ -1,0 +1,262 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"context"
+	"runtime"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/seccomp"
+	"golang.org/x/sys/unix"
+)
+
+func intPtr(v int) *int {
+	return &v
+}
+
+func TestSocketRuleChecker_Check_MatchMissTypeMaskAndNilReceiver(t *testing.T) {
+	rule := seccomp.SocketRule{
+		Name:         "dirtyfrag-xfrm",
+		Family:       unix.AF_NETLINK,
+		FamilyName:   "AF_NETLINK",
+		Type:         intPtr(unix.SOCK_RAW),
+		TypeName:     "SOCK_RAW",
+		Protocol:     intPtr(unix.NETLINK_XFRM),
+		ProtocolName: "NETLINK_XFRM",
+		Action:       seccomp.OnBlockLogAndKill,
+	}
+	c := NewSocketRuleChecker([]seccomp.SocketRule{rule})
+
+	got, ok := c.Check(
+		uint64(unix.SYS_SOCKET),
+		uint64(unix.AF_NETLINK),
+		uint64(unix.SOCK_RAW|unix.SOCK_CLOEXEC|unix.SOCK_NONBLOCK),
+		uint64(unix.NETLINK_XFRM),
+	)
+	if !ok || got.Name != "dirtyfrag-xfrm" {
+		t.Fatalf("expected NETLINK_XFRM socket match with masked type; got rule=%+v ok=%v", got, ok)
+	}
+
+	if _, ok := c.Check(uint64(unix.SYS_SOCKET), uint64(unix.AF_NETLINK), uint64(unix.SOCK_RAW), uint64(unix.NETLINK_ROUTE)); ok {
+		t.Fatal("NETLINK_ROUTE must not match a NETLINK_XFRM socket rule")
+	}
+	if _, ok := c.Check(uint64(unix.SYS_BIND), uint64(unix.AF_NETLINK), uint64(unix.SOCK_RAW), uint64(unix.NETLINK_XFRM)); ok {
+		t.Fatal("non-socket syscalls must not match socket tuple rules")
+	}
+	if _, ok := NewSocketRuleChecker(nil).Check(uint64(unix.SYS_SOCKET), uint64(unix.AF_NETLINK), uint64(unix.SOCK_RAW), uint64(unix.NETLINK_XFRM)); ok {
+		t.Fatal("empty checker should never match")
+	}
+	var nilChecker *SocketRuleChecker
+	if _, ok := nilChecker.Check(uint64(unix.SYS_SOCKET), uint64(unix.AF_NETLINK), uint64(unix.SOCK_RAW), uint64(unix.NETLINK_XFRM)); ok {
+		t.Fatal("nil checker should never match")
+	}
+}
+
+func TestSocketRuleChecker_Check_SocketpairUsesProtocolArg2(t *testing.T) {
+	rule := seccomp.SocketRule{
+		Name:         "dirtyfrag-xfrm",
+		Family:       unix.AF_NETLINK,
+		FamilyName:   "AF_NETLINK",
+		Type:         intPtr(unix.SOCK_DGRAM),
+		TypeName:     "SOCK_DGRAM",
+		Protocol:     intPtr(unix.NETLINK_XFRM),
+		ProtocolName: "NETLINK_XFRM",
+		Action:       seccomp.OnBlockLogAndKill,
+	}
+	c := NewSocketRuleChecker([]seccomp.SocketRule{rule})
+
+	if _, ok := c.Check(uint64(unix.SYS_SOCKETPAIR), uint64(unix.AF_NETLINK), uint64(unix.SOCK_DGRAM), uint64(unix.NETLINK_XFRM)); !ok {
+		t.Fatal("socketpair(AF_NETLINK, SOCK_DGRAM, NETLINK_XFRM) should match")
+	}
+	if _, ok := c.Check(uint64(unix.SYS_SOCKETPAIR), uint64(unix.AF_NETLINK), uint64(unix.SOCK_DGRAM), uint64(unix.NETLINK_ROUTE)); ok {
+		t.Fatal("socketpair protocol arg2 must be honored")
+	}
+}
+
+func TestSocketRuleChecker_ApplyLogEmitsPtraceEventAndDenies(t *testing.T) {
+	rule := seccomp.SocketRule{
+		Name:         "dirtyfrag-xfrm",
+		Family:       unix.AF_NETLINK,
+		FamilyName:   "AF_NETLINK",
+		Type:         intPtr(unix.SOCK_RAW),
+		TypeName:     "SOCK_RAW",
+		Protocol:     intPtr(unix.NETLINK_XFRM),
+		ProtocolName: "NETLINK_XFRM",
+		Action:       seccomp.OnBlockLog,
+	}
+	sink := &applyTestEmitter{}
+	c := NewSocketRuleCheckerWithEmitter([]seccomp.SocketRule{rule}, sink)
+	var denied bool
+	c.denySyscallFn = func(tid int, errno int) error {
+		if tid != 100 {
+			t.Fatalf("deny tid=%d, want 100", tid)
+		}
+		if errno != int(unix.EAFNOSUPPORT) {
+			t.Fatalf("deny errno=%d, want EAFNOSUPPORT", errno)
+		}
+		denied = true
+		return nil
+	}
+
+	err := c.Apply(100, 200, nil, rule.Action, unix.SYS_SOCKETPAIR, rule, "sess-socket-rule")
+	if err != ptraceAlreadyResumed {
+		t.Fatalf("Apply return=%v, want ptraceAlreadyResumed", err)
+	}
+	if !denied {
+		t.Fatal("expected log action to deny the syscall")
+	}
+
+	evts := sink.Events()
+	if len(evts) == 0 {
+		t.Fatal("expected audit event")
+	}
+	ev := evts[0]
+	if ev.Type != "seccomp_socket_rule_blocked" {
+		t.Fatalf("event type=%q, want seccomp_socket_rule_blocked", ev.Type)
+	}
+	if ev.SessionID != "sess-socket-rule" || ev.Source != "ptrace" || ev.PID != 100 {
+		t.Fatalf("unexpected event identity: session=%q source=%q pid=%d", ev.SessionID, ev.Source, ev.PID)
+	}
+	assertField(t, ev.Fields, "rule_name", "dirtyfrag-xfrm")
+	assertField(t, ev.Fields, "family_name", "AF_NETLINK")
+	assertField(t, ev.Fields, "family_number", unix.AF_NETLINK)
+	assertField(t, ev.Fields, "type_name", "SOCK_RAW")
+	assertField(t, ev.Fields, "type_number", unix.SOCK_RAW)
+	assertField(t, ev.Fields, "protocol_name", "NETLINK_XFRM")
+	assertField(t, ev.Fields, "protocol_number", unix.NETLINK_XFRM)
+	assertField(t, ev.Fields, "syscall", "socketpair")
+	assertField(t, ev.Fields, "syscall_nr", uint32(unix.SYS_SOCKETPAIR))
+	assertField(t, ev.Fields, "action", string(seccomp.OnBlockLog))
+	assertField(t, ev.Fields, "outcome", "denied")
+	assertField(t, ev.Fields, "engine", "ptrace")
+	assertField(t, ev.Fields, "arch", runtime.GOARCH)
+}
+
+func TestSocketRuleChecker_ApplyLogAndKillEmitsKilledOutcome(t *testing.T) {
+	rule := seccomp.SocketRule{
+		Name:       "dirtyfrag-rxrpc",
+		Family:     unix.AF_RXRPC,
+		FamilyName: "AF_RXRPC",
+		Action:     seccomp.OnBlockLogAndKill,
+	}
+	sink := &applyTestEmitter{}
+	c := NewSocketRuleCheckerWithEmitter([]seccomp.SocketRule{rule}, sink)
+	c.tgkillFn = func(tgid, tid int, sig unix.Signal) error {
+		if tgid != 200 || tid != 100 || sig != unix.SIGKILL {
+			t.Fatalf("tgkill(%d,%d,%v), want (200,100,SIGKILL)", tgid, tid, sig)
+		}
+		return nil
+	}
+	c.denySyscallFn = func(tid int, errno int) error {
+		t.Fatal("denySyscall must not be called when tgkill succeeds")
+		return nil
+	}
+
+	err := c.Apply(100, 200, nil, rule.Action, unix.SYS_SOCKET, rule, "sess-kill")
+	if err != PtraceKillRequested {
+		t.Fatalf("Apply return=%v, want PtraceKillRequested", err)
+	}
+
+	evts := sink.Events()
+	if len(evts) == 0 {
+		t.Fatal("expected audit event")
+	}
+	assertField(t, evts[0].Fields, "outcome", "killed")
+	assertField(t, evts[0].Fields, "engine", "ptrace")
+}
+
+func TestSocketRuleChecker_ApplyErrnoDeniesWithoutEvent(t *testing.T) {
+	rule := seccomp.SocketRule{
+		Name:       "dirtyfrag-rxrpc",
+		Family:     unix.AF_RXRPC,
+		FamilyName: "AF_RXRPC",
+		Action:     seccomp.OnBlockErrno,
+	}
+	sink := &applyTestEmitter{}
+	c := NewSocketRuleCheckerWithEmitter([]seccomp.SocketRule{rule}, sink)
+	var denied bool
+	c.denySyscallFn = func(tid int, errno int) error {
+		denied = true
+		return nil
+	}
+
+	err := c.Apply(100, 200, nil, rule.Action, unix.SYS_SOCKET, rule, "sess-errno")
+	if err != ptraceAlreadyResumed {
+		t.Fatalf("Apply return=%v, want ptraceAlreadyResumed", err)
+	}
+	if !denied {
+		t.Fatal("expected errno action to deny the syscall")
+	}
+	if got := sink.Events(); len(got) != 0 {
+		t.Fatalf("errno action should not emit events, got %d", len(got))
+	}
+}
+
+func TestDispatchSyscall_SocketRuleWinsOverFamilyAndNetwork(t *testing.T) {
+	rule := seccomp.SocketRule{
+		Name:         "dirtyfrag-xfrm",
+		Family:       unix.AF_NETLINK,
+		FamilyName:   "AF_NETLINK",
+		Protocol:     intPtr(unix.NETLINK_XFRM),
+		ProtocolName: "NETLINK_XFRM",
+		Action:       seccomp.OnBlockLog,
+	}
+	socketChecker := NewSocketRuleChecker([]seccomp.SocketRule{rule})
+	var socketDenied int
+	socketChecker.denySyscallFn = func(tid int, errno int) error {
+		socketDenied++
+		return nil
+	}
+
+	familyChecker := NewFamilyChecker([]seccomp.BlockedFamily{
+		{Family: unix.AF_NETLINK, Name: "AF_NETLINK", Action: seccomp.OnBlockLog},
+	})
+	familyChecker.denySyscallFn = func(tid int, errno int) error {
+		t.Fatal("family checker must not run after a socket tuple match")
+		return nil
+	}
+
+	networkHandler := &countingNetworkHandler{}
+	tr := NewTracer(TracerConfig{
+		TraceNetwork:      true,
+		NetworkHandler:    networkHandler,
+		SocketRuleChecker: socketChecker,
+		FamilyChecker:     familyChecker,
+	})
+	tr.tracees[123] = &TraceeState{TID: 123, TGID: 456, SessionID: "sess-dispatch"}
+
+	tr.dispatchSyscall(context.Background(), 123, unix.SYS_SOCKET, &SyscallContext{
+		Info: SyscallEntryInfo{
+			Nr: unix.SYS_SOCKET,
+			Args: [6]uint64{
+				uint64(unix.AF_NETLINK),
+				uint64(unix.SOCK_RAW),
+				uint64(unix.NETLINK_XFRM),
+			},
+		},
+	})
+
+	if socketDenied != 1 {
+		t.Fatalf("socket checker deny calls=%d, want 1", socketDenied)
+	}
+	if networkHandler.calls != 0 {
+		t.Fatalf("network handler calls=%d, want 0", networkHandler.calls)
+	}
+}
+
+type countingNetworkHandler struct {
+	calls int
+}
+
+func (h *countingNetworkHandler) HandleNetwork(_ context.Context, _ NetworkContext) NetworkResult {
+	h.calls++
+	return NetworkResult{Allow: true}
+}
+
+func assertField(t *testing.T, fields map[string]any, key string, want any) {
+	t.Helper()
+	if got := fields[key]; got != want {
+		t.Fatalf("field %q=%#v, want %#v", key, got, want)
+	}
+}

--- a/internal/ptrace/socket_rule_checker_test.go
+++ b/internal/ptrace/socket_rule_checker_test.go
@@ -74,6 +74,60 @@ func TestSocketRuleChecker_Check_SocketpairUsesProtocolArg2(t *testing.T) {
 	}
 }
 
+func TestSocketRuleChecker_ConstructionCopiesRulePointers(t *testing.T) {
+	typ := unix.SOCK_RAW
+	proto := unix.NETLINK_XFRM
+	rules := []seccomp.SocketRule{{
+		Name:         "dirtyfrag-xfrm",
+		Family:       unix.AF_NETLINK,
+		FamilyName:   "AF_NETLINK",
+		Type:         &typ,
+		TypeName:     "SOCK_RAW",
+		Protocol:     &proto,
+		ProtocolName: "NETLINK_XFRM",
+		Action:       seccomp.OnBlockLogAndKill,
+	}}
+
+	c := NewSocketRuleChecker(rules)
+	typ = unix.SOCK_DGRAM
+	proto = unix.NETLINK_ROUTE
+
+	if _, ok := c.Check(uint64(unix.SYS_SOCKET), uint64(unix.AF_NETLINK), uint64(unix.SOCK_RAW), uint64(unix.NETLINK_XFRM)); !ok {
+		t.Fatal("checker should retain original Type/Protocol values after caller mutates input pointers")
+	}
+	if _, ok := c.Check(uint64(unix.SYS_SOCKET), uint64(unix.AF_NETLINK), uint64(unix.SOCK_DGRAM), uint64(unix.NETLINK_ROUTE)); ok {
+		t.Fatal("checker should not observe caller mutations to input Type/Protocol pointers")
+	}
+}
+
+func TestSocketRuleChecker_CheckReturnsRuleCopy(t *testing.T) {
+	rule := seccomp.SocketRule{
+		Name:         "dirtyfrag-xfrm",
+		Family:       unix.AF_NETLINK,
+		FamilyName:   "AF_NETLINK",
+		Type:         intPtr(unix.SOCK_RAW),
+		TypeName:     "SOCK_RAW",
+		Protocol:     intPtr(unix.NETLINK_XFRM),
+		ProtocolName: "NETLINK_XFRM",
+		Action:       seccomp.OnBlockLogAndKill,
+	}
+	c := NewSocketRuleChecker([]seccomp.SocketRule{rule})
+
+	got, ok := c.Check(uint64(unix.SYS_SOCKET), uint64(unix.AF_NETLINK), uint64(unix.SOCK_RAW), uint64(unix.NETLINK_XFRM))
+	if !ok {
+		t.Fatal("expected initial socket rule match")
+	}
+	*got.Type = unix.SOCK_DGRAM
+	*got.Protocol = unix.NETLINK_ROUTE
+
+	if _, ok := c.Check(uint64(unix.SYS_SOCKET), uint64(unix.AF_NETLINK), uint64(unix.SOCK_RAW), uint64(unix.NETLINK_XFRM)); !ok {
+		t.Fatal("mutating returned rule pointers should not mutate checker-owned rule")
+	}
+	if _, ok := c.Check(uint64(unix.SYS_SOCKET), uint64(unix.AF_NETLINK), uint64(unix.SOCK_DGRAM), uint64(unix.NETLINK_ROUTE)); ok {
+		t.Fatal("checker should not observe mutations to a rule returned by Check")
+	}
+}
+
 func TestSocketRuleChecker_ApplyLogEmitsPtraceEventAndDenies(t *testing.T) {
 	rule := seccomp.SocketRule{
 		Name:         "dirtyfrag-xfrm",

--- a/internal/ptrace/syscalls.go
+++ b/internal/ptrace/syscalls.go
@@ -88,7 +88,7 @@ func narrowTracedSyscallNumbers(cfg *TracerConfig) []int {
 	if cfg.MaskTracerPid || (cfg.TraceNetwork && cfg.NetworkHandler != nil) {
 		nums = append(nums, unix.SYS_CLOSE)
 	}
-	if cfg.FamilyChecker != nil {
+	if cfg.FamilyChecker != nil || cfg.SocketRuleChecker != nil {
 		nums = append(nums, unix.SYS_SOCKET, unix.SYS_SOCKETPAIR)
 	}
 

--- a/internal/ptrace/syscalls_test.go
+++ b/internal/ptrace/syscalls_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/agentsh/agentsh/internal/seccomp"
 	"golang.org/x/sys/unix"
 )
 
@@ -234,4 +235,45 @@ func TestNarrowTracedSyscallNumbers_CloseWithNetworkHandler(t *testing.T) {
 		}
 	}
 	t.Error("SYS_CLOSE missing when TraceNetwork=true and NetworkHandler is set")
+}
+
+func TestNarrowTracedSyscallNumbers_FamilyCheckerIncludesSocketCalls(t *testing.T) {
+	cfg := &TracerConfig{
+		FamilyChecker: NewFamilyChecker([]seccomp.BlockedFamily{
+			{Family: unix.AF_ALG, Action: seccomp.OnBlockErrno, Name: "AF_ALG"},
+		}),
+	}
+	nums := narrowTracedSyscallNumbers(cfg)
+
+	if !containsSyscall(nums, unix.SYS_SOCKET) {
+		t.Fatal("SYS_SOCKET missing when FamilyChecker is configured")
+	}
+	if !containsSyscall(nums, unix.SYS_SOCKETPAIR) {
+		t.Fatal("SYS_SOCKETPAIR missing when FamilyChecker is configured")
+	}
+}
+
+func TestNarrowTracedSyscallNumbers_SocketRuleCheckerIncludesSocketCalls(t *testing.T) {
+	cfg := &TracerConfig{
+		SocketRuleChecker: NewSocketRuleChecker([]seccomp.SocketRule{
+			{Family: unix.AF_NETLINK, Action: seccomp.OnBlockLogAndKill, Protocol: intPtr(unix.NETLINK_XFRM)},
+		}),
+	}
+	nums := narrowTracedSyscallNumbers(cfg)
+
+	if !containsSyscall(nums, unix.SYS_SOCKET) {
+		t.Fatal("SYS_SOCKET missing when SocketRuleChecker is configured")
+	}
+	if !containsSyscall(nums, unix.SYS_SOCKETPAIR) {
+		t.Fatal("SYS_SOCKETPAIR missing when SocketRuleChecker is configured")
+	}
+}
+
+func containsSyscall(nums []int, want int) bool {
+	for _, got := range nums {
+		if got == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -124,26 +124,27 @@ type SignalResult struct {
 
 // TracerConfig holds configuration for the ptrace tracer.
 type TracerConfig struct {
-	AttachMode       string
-	TargetPID        int
-	TargetPIDFile    string
-	TraceExecve      bool
-	TraceFile        bool
-	TraceNetwork     bool
-	TraceSignal      bool
-	MaskTracerPid    bool
-	SeccompPrefilter bool
-	ArgLevelFilter   bool
-	MaxTracees       int
-	MaxHoldMs        int
-	OnAttachFailure  string
-	ReadyFile        string // Path to write after successful attach (sentinel for workload readiness)
-	ExecHandler      ExecHandler
-	FileHandler      FileHandler
-	NetworkHandler   NetworkHandler
-	SignalHandler    SignalHandler
-	FamilyChecker    *FamilyChecker // nil disables socket-family blocking
-	Metrics          Metrics
+	AttachMode        string
+	TargetPID         int
+	TargetPIDFile     string
+	TraceExecve       bool
+	TraceFile         bool
+	TraceNetwork      bool
+	TraceSignal       bool
+	MaskTracerPid     bool
+	SeccompPrefilter  bool
+	ArgLevelFilter    bool
+	MaxTracees        int
+	MaxHoldMs         int
+	OnAttachFailure   string
+	ReadyFile         string // Path to write after successful attach (sentinel for workload readiness)
+	ExecHandler       ExecHandler
+	FileHandler       FileHandler
+	NetworkHandler    NetworkHandler
+	SignalHandler     SignalHandler
+	SocketRuleChecker *SocketRuleChecker // nil disables socket tuple-rule blocking
+	FamilyChecker     *FamilyChecker     // nil disables socket-family blocking
+	Metrics           Metrics
 }
 
 // TraceeState tracks the state of a single traced thread.
@@ -998,39 +999,76 @@ func (t *Tracer) handleSeccompStop(ctx context.Context, tid int) {
 
 // dispatchSyscall routes a syscall to the appropriate handler.
 func (t *Tracer) dispatchSyscall(ctx context.Context, tid int, nr int, sc *SyscallContext) {
-	// Socket-family blocking: check before all other handlers so that
-	// FamilyChecker rules take precedence over the generic network handler.
-	// SYS_SOCKET and SYS_SOCKETPAIR pass the AF_* family as arg0.
-	if t.cfg.FamilyChecker != nil &&
-		(nr == unix.SYS_SOCKET || nr == unix.SYS_SOCKETPAIR) {
+	// Socket tuple rules are the most-specific socket policy. Check them
+	// before family rules and the generic network handler so protocol-specific
+	// Dirty Frag rules are not shadowed by broad AF_* entries.
+	if nr == unix.SYS_SOCKET || nr == unix.SYS_SOCKETPAIR {
 		family := sc.Info.Args[0]
-		if bf, ok := t.cfg.FamilyChecker.Check(uint64(nr), family); ok {
-			tgid := tid
-			var sessionID string
-			t.mu.Lock()
-			if state := t.tracees[tid]; state != nil {
-				tgid = state.TGID
-				sessionID = state.SessionID
-			}
-			t.mu.Unlock()
+		typ := sc.Info.Args[1]
+		protocol := sc.Info.Args[2]
+		if t.cfg.SocketRuleChecker != nil {
+			if rule, ok := t.cfg.SocketRuleChecker.Check(uint64(nr), family, typ, protocol); ok {
+				tgid := tid
+				var sessionID string
+				t.mu.Lock()
+				if state := t.tracees[tid]; state != nil {
+					tgid = state.TGID
+					sessionID = state.SessionID
+				}
+				t.mu.Unlock()
 
-			err := t.cfg.FamilyChecker.Apply(tid, tgid, t, bf.Action, nr, bf, sessionID)
-			switch {
-			case errors.Is(err, PtraceKillRequested):
-				// Apply already delivered SIGKILL via Tgkill; allow the tracee
-				// to run so it receives the signal.
-				t.allowSyscall(tid)
-			case errors.Is(err, ptraceAlreadyResumed):
-				// denySyscall already resumed the tracee — nothing more to do.
-			case err != nil:
-				slog.Warn("ptrace: family check apply failed",
-					"tid", tid, "family", bf.Name, "error", err)
-				t.allowSyscall(tid)
-			default:
-				// Unknown action: allow proceeds.
-				t.allowSyscall(tid)
+				err := t.cfg.SocketRuleChecker.Apply(tid, tgid, t, rule.Action, nr, rule, sessionID)
+				switch {
+				case errors.Is(err, PtraceKillRequested):
+					// Apply already delivered SIGKILL via Tgkill; allow the tracee
+					// to run so it receives the signal.
+					t.allowSyscall(tid)
+				case errors.Is(err, ptraceAlreadyResumed):
+					// denySyscall already resumed the tracee — nothing more to do.
+				case err != nil:
+					slog.Warn("ptrace: socket rule apply failed",
+						"tid", tid, "rule", rule.Name, "error", err)
+					t.allowSyscall(tid)
+				default:
+					// Unknown action: allow proceeds.
+					t.allowSyscall(tid)
+				}
+				return
 			}
-			return
+		}
+
+		// Socket-family blocking: check before all other handlers so that
+		// FamilyChecker rules take precedence over the generic network handler.
+		// SYS_SOCKET and SYS_SOCKETPAIR pass the AF_* family as arg0.
+		if t.cfg.FamilyChecker != nil {
+			if bf, ok := t.cfg.FamilyChecker.Check(uint64(nr), family); ok {
+				tgid := tid
+				var sessionID string
+				t.mu.Lock()
+				if state := t.tracees[tid]; state != nil {
+					tgid = state.TGID
+					sessionID = state.SessionID
+				}
+				t.mu.Unlock()
+
+				err := t.cfg.FamilyChecker.Apply(tid, tgid, t, bf.Action, nr, bf, sessionID)
+				switch {
+				case errors.Is(err, PtraceKillRequested):
+					// Apply already delivered SIGKILL via Tgkill; allow the tracee
+					// to run so it receives the signal.
+					t.allowSyscall(tid)
+				case errors.Is(err, ptraceAlreadyResumed):
+					// denySyscall already resumed the tracee — nothing more to do.
+				case err != nil:
+					slog.Warn("ptrace: family check apply failed",
+						"tid", tid, "family", bf.Name, "error", err)
+					t.allowSyscall(tid)
+				default:
+					// Unknown action: allow proceeds.
+					t.allowSyscall(tid)
+				}
+				return
+			}
 		}
 	}
 

--- a/internal/seccomp/families.go
+++ b/internal/seccomp/families.go
@@ -28,6 +28,7 @@ var nameTable = map[string]int{
 	"AF_CAN":       29,
 	"AF_TIPC":      30,
 	"AF_BLUETOOTH": 31,
+	"AF_RXRPC":     33,
 	"AF_ALG":       38,
 	"AF_VSOCK":     40,
 	"AF_KCM":       41,

--- a/internal/seccomp/filter.go
+++ b/internal/seccomp/filter.go
@@ -7,17 +7,23 @@ type FilterConfig struct {
 	UnixSocketEnabled bool
 	BlockedSyscalls   []string
 	BlockedFamilies   []BlockedFamily
+	SocketRules       []SocketRule
 	OnBlock           OnBlockAction
 }
 
 // FilterConfigFromYAML creates a FilterConfig from config package types.
 // This is a separate function to avoid import cycles.
-func FilterConfigFromYAML(unixEnabled bool, blockedSyscalls []string, onBlock string, blockedFamilies []BlockedFamily) FilterConfig {
+func FilterConfigFromYAML(unixEnabled bool, blockedSyscalls []string, onBlock string, blockedFamilies []BlockedFamily, socketRules ...[]SocketRule) FilterConfig {
 	action, _ := ParseOnBlock(onBlock)
+	var rules []SocketRule
+	if len(socketRules) > 0 {
+		rules = socketRules[0]
+	}
 	return FilterConfig{
 		UnixSocketEnabled: unixEnabled,
 		BlockedSyscalls:   blockedSyscalls,
 		BlockedFamilies:   blockedFamilies,
+		SocketRules:       rules,
 		OnBlock:           action,
 	}
 }

--- a/internal/seccomp/socket_rules.go
+++ b/internal/seccomp/socket_rules.go
@@ -1,0 +1,99 @@
+package seccomp
+
+import "strconv"
+
+const (
+	SocketTypeMask         = 0xf
+	SocketTypeFlagNonblock = 0x800
+	SocketTypeFlagCloexec  = 0x80000
+)
+
+type SocketRule struct {
+	Name         string        `json:"name,omitempty"`
+	Family       int           `json:"family"`
+	FamilyName   string        `json:"family_name,omitempty"`
+	Type         *int          `json:"type,omitempty"`
+	TypeName     string        `json:"type_name,omitempty"`
+	Protocol     *int          `json:"protocol,omitempty"`
+	ProtocolName string        `json:"protocol_name,omitempty"`
+	Action       OnBlockAction `json:"action"`
+}
+
+var protocolNameTable = map[string]int{
+	"NETLINK_ROUTE":          0,
+	"NETLINK_USERSOCK":       2,
+	"NETLINK_FIREWALL":       3,
+	"NETLINK_SOCK_DIAG":      4,
+	"NETLINK_NFLOG":          5,
+	"NETLINK_XFRM":           6,
+	"NETLINK_SELINUX":        7,
+	"NETLINK_ISCSI":          8,
+	"NETLINK_AUDIT":          9,
+	"NETLINK_FIB_LOOKUP":     10,
+	"NETLINK_CONNECTOR":      11,
+	"NETLINK_NETFILTER":      12,
+	"NETLINK_KOBJECT_UEVENT": 15,
+	"NETLINK_GENERIC":        16,
+}
+
+var socketTypeNameTable = map[string]int{
+	"SOCK_STREAM":    1,
+	"SOCK_DGRAM":     2,
+	"SOCK_RAW":       3,
+	"SOCK_RDM":       4,
+	"SOCK_SEQPACKET": 5,
+}
+
+func ParseSocketProtocol(value string) (nr int, name string, ok bool) {
+	if value == "" {
+		return 0, "", false
+	}
+	if n, found := protocolNameTable[value]; found {
+		return n, value, true
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed < 0 || parsed >= 64 {
+		return 0, "", false
+	}
+	return parsed, "", true
+}
+
+func ParseSocketType(value string) (nr int, name string, ok bool) {
+	if value == "" {
+		return 0, "", false
+	}
+	if n, found := socketTypeNameTable[value]; found {
+		return n, value, true
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 || parsed > SocketTypeMask {
+		return 0, "", false
+	}
+	return parsed, "", true
+}
+
+func (r SocketRule) MatchesSocket(family, typ, protocol uint64) bool {
+	if uint64(r.Family) != family {
+		return false
+	}
+	if r.Type != nil && uint64(*r.Type) != (typ&SocketTypeMask) {
+		return false
+	}
+	if r.Protocol != nil && uint64(*r.Protocol) != protocol {
+		return false
+	}
+	return true
+}
+
+func (r SocketRule) MatchesSocketpair(family, typ uint64) bool {
+	if r.Protocol != nil {
+		return false
+	}
+	if uint64(r.Family) != family {
+		return false
+	}
+	if r.Type != nil && uint64(*r.Type) != (typ&SocketTypeMask) {
+		return false
+	}
+	return true
+}

--- a/internal/seccomp/socket_rules.go
+++ b/internal/seccomp/socket_rules.go
@@ -3,9 +3,12 @@ package seccomp
 import "strconv"
 
 const (
-	SocketTypeMask         = 0xf
+	// SocketTypeMask isolates the SOCK_* type bits from socket flags.
+	SocketTypeMask = 0xf
+	// SocketTypeFlagNonblock is the SOCK_NONBLOCK type flag.
 	SocketTypeFlagNonblock = 0x800
-	SocketTypeFlagCloexec  = 0x80000
+	// SocketTypeFlagCloexec is the SOCK_CLOEXEC type flag.
+	SocketTypeFlagCloexec = 0x80000
 )
 
 // SocketRule describes a socket or socketpair operation to block.

--- a/internal/seccomp/socket_rules.go
+++ b/internal/seccomp/socket_rules.go
@@ -8,6 +8,7 @@ const (
 	SocketTypeFlagCloexec  = 0x80000
 )
 
+// SocketRule describes a socket or socketpair operation to block.
 type SocketRule struct {
 	Name         string        `json:"name,omitempty"`
 	Family       int           `json:"family"`
@@ -44,6 +45,7 @@ var socketTypeNameTable = map[string]int{
 	"SOCK_SEQPACKET": 5,
 }
 
+// ParseSocketProtocol resolves a socket protocol name or numeric value.
 func ParseSocketProtocol(value string) (nr int, name string, ok bool) {
 	if value == "" {
 		return 0, "", false
@@ -52,12 +54,13 @@ func ParseSocketProtocol(value string) (nr int, name string, ok bool) {
 		return n, value, true
 	}
 	parsed, err := strconv.Atoi(value)
-	if err != nil || parsed < 0 || parsed >= 64 {
+	if err != nil || parsed < 0 || parsed > 255 {
 		return 0, "", false
 	}
 	return parsed, "", true
 }
 
+// ParseSocketType resolves a SOCK_* type name or numeric value.
 func ParseSocketType(value string) (nr int, name string, ok bool) {
 	if value == "" {
 		return 0, "", false
@@ -72,6 +75,7 @@ func ParseSocketType(value string) (nr int, name string, ok bool) {
 	return parsed, "", true
 }
 
+// MatchesSocket reports whether r applies to a socket syscall.
 func (r SocketRule) MatchesSocket(family, typ, protocol uint64) bool {
 	if uint64(r.Family) != family {
 		return false
@@ -85,14 +89,15 @@ func (r SocketRule) MatchesSocket(family, typ, protocol uint64) bool {
 	return true
 }
 
-func (r SocketRule) MatchesSocketpair(family, typ uint64) bool {
-	if r.Protocol != nil {
-		return false
-	}
+// MatchesSocketpair reports whether r applies to a socketpair syscall.
+func (r SocketRule) MatchesSocketpair(family, typ, protocol uint64) bool {
 	if uint64(r.Family) != family {
 		return false
 	}
 	if r.Type != nil && uint64(*r.Type) != (typ&SocketTypeMask) {
+		return false
+	}
+	if r.Protocol != nil && uint64(*r.Protocol) != protocol {
 		return false
 	}
 	return true

--- a/internal/seccomp/socket_rules_test.go
+++ b/internal/seccomp/socket_rules_test.go
@@ -1,0 +1,93 @@
+package seccomp
+
+import "testing"
+
+func TestParseFamilyIncludesRxRPC(t *testing.T) {
+	nr, name, ok := ParseFamily("AF_RXRPC")
+	if !ok {
+		t.Fatal("AF_RXRPC should parse")
+	}
+	if nr != 33 || name != "AF_RXRPC" {
+		t.Fatalf("ParseFamily(AF_RXRPC) = (%d, %q), want (33, AF_RXRPC)", nr, name)
+	}
+}
+
+func TestParseSocketProtocol(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantNr   int
+		wantName string
+		wantOK   bool
+	}{
+		{"NETLINK_XFRM", 6, "NETLINK_XFRM", true},
+		{"NETLINK_ROUTE", 0, "NETLINK_ROUTE", true},
+		{"6", 6, "", true},
+		{"NETLINK_NOT_REAL", 0, "", false},
+		{"-1", 0, "", false},
+		{"9999", 0, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			gotNr, gotName, gotOK := ParseSocketProtocol(tc.in)
+			if gotNr != tc.wantNr || gotName != tc.wantName || gotOK != tc.wantOK {
+				t.Fatalf("ParseSocketProtocol(%q) = (%d, %q, %v), want (%d, %q, %v)",
+					tc.in, gotNr, gotName, gotOK, tc.wantNr, tc.wantName, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestParseSocketType(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantNr   int
+		wantName string
+		wantOK   bool
+	}{
+		{"SOCK_STREAM", 1, "SOCK_STREAM", true},
+		{"SOCK_DGRAM", 2, "SOCK_DGRAM", true},
+		{"SOCK_SEQPACKET", 5, "SOCK_SEQPACKET", true},
+		{"3", 3, "", true},
+		{"SOCK_NOT_REAL", 0, "", false},
+		{"0", 0, "", false},
+		{"9999", 0, "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			gotNr, gotName, gotOK := ParseSocketType(tc.in)
+			if gotNr != tc.wantNr || gotName != tc.wantName || gotOK != tc.wantOK {
+				t.Fatalf("ParseSocketType(%q) = (%d, %q, %v), want (%d, %q, %v)",
+					tc.in, gotNr, gotName, gotOK, tc.wantNr, tc.wantName, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestSocketRuleMatches(t *testing.T) {
+	proto := 6
+	rule := SocketRule{
+		Name:         "dirtyfrag-xfrm",
+		Family:       16,
+		FamilyName:   "AF_NETLINK",
+		Protocol:     &proto,
+		ProtocolName: "NETLINK_XFRM",
+		Action:       OnBlockLogAndKill,
+	}
+	if !rule.MatchesSocket(16, 0, 6) {
+		t.Fatal("expected NETLINK_XFRM socket to match")
+	}
+	if rule.MatchesSocket(16, 0, 0) {
+		t.Fatal("NETLINK_ROUTE must not match NETLINK_XFRM rule")
+	}
+	if rule.MatchesSocketpair(16, 0) {
+		t.Fatal("protocol-constrained rules must not match socketpair")
+	}
+}
+
+func TestSocketRuleTypeMatchIgnoresFlags(t *testing.T) {
+	typ := 1
+	rule := SocketRule{Name: "stream", Family: 2, Type: &typ, Action: OnBlockErrno}
+	if !rule.MatchesSocket(2, 1|SocketTypeFlagCloexec|SocketTypeFlagNonblock, 0) {
+		t.Fatal("type matching should ignore SOCK_CLOEXEC and SOCK_NONBLOCK flags")
+	}
+}

--- a/internal/seccomp/socket_rules_test.go
+++ b/internal/seccomp/socket_rules_test.go
@@ -22,8 +22,10 @@ func TestParseSocketProtocol(t *testing.T) {
 		{"NETLINK_XFRM", 6, "NETLINK_XFRM", true},
 		{"NETLINK_ROUTE", 0, "NETLINK_ROUTE", true},
 		{"6", 6, "", true},
+		{"255", 255, "", true},
 		{"NETLINK_NOT_REAL", 0, "", false},
 		{"-1", 0, "", false},
+		{"256", 0, "", false},
 		{"9999", 0, "", false},
 	}
 	for _, tc := range cases {
@@ -79,8 +81,11 @@ func TestSocketRuleMatches(t *testing.T) {
 	if rule.MatchesSocket(16, 0, 0) {
 		t.Fatal("NETLINK_ROUTE must not match NETLINK_XFRM rule")
 	}
-	if rule.MatchesSocketpair(16, 0) {
-		t.Fatal("protocol-constrained rules must not match socketpair")
+	if !rule.MatchesSocketpair(16, 0, 6) {
+		t.Fatal("expected NETLINK_XFRM socketpair to match")
+	}
+	if rule.MatchesSocketpair(16, 0, 0) {
+		t.Fatal("NETLINK_ROUTE socketpair must not match NETLINK_XFRM rule")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add protocol-aware socket tuple mitigation support for the Dirty Frag advisory via `mitigation_sets`.
- Move `dirtyfrag-conservative` into embedded YAML and support optional external mitigation directories loaded only by requested ID.
- Add guardrails for external mitigation YAML: strict schema, invalid ID rejection, duplicate source rejection, non-regular file rejection, Unix world-writable file/dir rejection, and trailing-document rejection.
- Wire mitigation-expanded rules into seccomp wrapper config, notify dispatch, user-notify gating, ptrace fallback, and ptrace sync gating.
- Update docs and sample config to prefer `sandbox.seccomp.mitigation_sets` / `mitigation_dirs` while keeping `hardening_profiles` as a deprecated alias.

## Dirty Frag behavior

`dirtyfrag-conservative` blocks `AF_RXRPC` and `AF_NETLINK` scoped to protocol `NETLINK_XFRM`, both with `log_and_kill`. It does not block all `AF_NETLINK`.

## Validation

- `go test ./internal/config ./internal/api ./internal/netmonitor/unix ./internal/ptrace -run 'MitigationSets|HardeningProfiles|DirtyFrag|SocketRule|SocketRules|BlockListConfig|mainFilterUsesUserNotify|FamilyChecker' -count=1`
- `GOMAXPROCS=1 go test ./internal/netmonitor/unix -run 'TestDirtyFrag|TestSeccompSocketRuleBlock_Notify_LogDispatched|TestSeccompSocketRuleBlock_ErrnoTuple' -count=1 -timeout=60s -v`
- `go test ./... -count=1`
- `GOOS=windows go build ./...`
- `git diff --check`