### PR TITLE
db: Plan 04a — PostgreSQL proxy listener skeleton

### DIFF
--- a/docs/superpowers/plans/2026-05-10-db-plan-04a-listener-skeleton.md
+++ b/docs/superpowers/plans/2026-05-10-db-plan-04a-listener-skeleton.md
@@ -1,0 +1,2323 @@
+# db-access Plan 04a — Listener Skeleton Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a Linux-only PostgreSQL proxy *listener* that binds Unix-socket listeners per declared `db_service`, authenticates peers by UID via SO_PEERCRED, and accepts/closes connections cleanly. No protocol semantics — Plan 04b adds handshake/TLS, Plan 04c adds Simple Query.
+
+**Architecture:** New package `internal/db/proxy/postgres/` (`//go:build linux`; non-Linux stub returns `errors.ErrUnsupported`). Server lifecycle (`New` / `Start` / `Shutdown`) bound by an internal `errgroup`. Connection handler is a no-op that closes the conn after peercred check. The `policies.db.unavoidability` flag (default `off`) gates listener bind; with `off` the package is a no-op. DBEvent emission via a new `events.Sink` interface (in-memory `SyncSink` for tests; real sink wiring deferred to a later plan).
+
+**Tech Stack:** Go (`//go:build linux` for the active code), `golang.org/x/sys/unix` (already a dep) for SO_PEERCRED, `golang.org/x/sync/errgroup` (already a dep), stdlib `net`, `slog`. Existing packages: `internal/db/service`, `internal/db/policy`, `internal/db/events`, `internal/policy`. Macro design: `docs/superpowers/specs/2026-05-10-db-plan-04-pg-proxy-skeleton-design.md`.
+
+---
+
+## File Structure
+
+**Created:**
+
+- `internal/db/service/flag.go` — `Unavoidability` enum (`UnavoidabilityOff | UnavoidabilityObserve | UnavoidabilityEnforce`), `String`, `ParseUnavoidability`.
+- `internal/db/service/flag_test.go` — table-driven tests for `ParseUnavoidability` + `String`.
+- `internal/db/events/sink.go` — `Sink` interface, `NopSink`, `SyncSink`.
+- `internal/db/events/sink_test.go` — tests for `NopSink` + `SyncSink`.
+- `internal/db/events/lifecycle.go` — `LifecycleEvent` value type for non-statement events (listener-auth failures, handshake failures, degraded-visibility warnings).
+- `internal/db/events/lifecycle_test.go` — round-trip JSON test for `LifecycleEvent`.
+- `internal/db/proxy/postgres/stub_other.go` — `//go:build !linux`; `New` returns a sentinel server whose `Start` returns `errors.ErrUnsupported`.
+- `internal/db/proxy/postgres/server.go` — `//go:build linux`; `Config`, `Server`, `New`, `Start`, `Shutdown`. Sentinel-server short-circuit when `Unavoidability == off`.
+- `internal/db/proxy/postgres/server_test.go` — server lifecycle tests on Linux.
+- `internal/db/proxy/postgres/peercred_linux.go` — `//go:build linux`; SO_PEERCRED + UID-equality check.
+- `internal/db/proxy/postgres/peercred_linux_test.go` — `socketpair`-based round-trip test for SO_PEERCRED.
+
+**Modified:**
+
+- `internal/db/policy/decode.go` — extend `dbPoliciesWrapper` to include `Unavoidability string`; add `decodeUnavoidability`; surface it on `RuleSet`.
+- `internal/db/policy/types.go` — extend `RuleSet` with `unavoidability service.Unavoidability` field + `Unavoidability()` accessor.
+- `internal/db/policy/decode_test.go` — add cases covering the new field.
+- `internal/db/policy/validate.go` — reject connection rules under `tls_mode: passthrough` that match passthrough-invisible fields (`db_user`, `database`, `application_name`).
+- `internal/db/policy/validate_test.go` — add cases covering the new validation.
+- `internal/api/db_proxy.go` — proxy boot helper (NEW) wrapping `postgres.New` + `postgres.Server.Start`/`Shutdown`.
+- `internal/api/db_proxy_test.go` — tests for the helper.
+- `internal/server/server.go` — call `startDBProxy` next to the existing `app := api.NewApp(...)` site (around line 507) and chain its `Shutdown` into the existing `appCloser` defer.
+
+**Sentinel server contract:** `Server.New` always returns a non-nil `*Server`. When `cfg.Unavoidability == UnavoidabilityOff`, `Start` is a no-op (logs once at info, returns nil immediately) and `Shutdown` is a no-op. Callers do not have to special-case the `off` flag.
+
+**Listener path contract:** `Server.Start` binds each declared `db_service` whose `Listen.Kind == "unix"`. Listen kinds other than `unix` are accepted but not bound in 04a (they will bind in 04b once TCP framing exists for tests). For each Unix listener: parent dir must exist and be owned by current uid; existing socket file at the path is removed before bind (this is intentional — a stale socket from a prior crash should not block startup); after `bind` we call `chmod(0700)` on the socket file; `listen` with backlog 64. On `Shutdown` the socket file is unlinked.
+
+---
+
+## Task 1: Preflight — `Unavoidability` enum and `policies.db.unavoidability` decode
+
+**Why:** The proxy `Server` needs to know which mode the operator selected. The flag rides on the existing `policies.db` YAML block (already parsed by `internal/db/policy/decode.go` for redaction). Adding it here means the proxy package only needs to call `ruleSet.Unavoidability()`.
+
+**Files:**
+- Create: `internal/db/service/flag.go`
+- Create: `internal/db/service/flag_test.go`
+- Modify: `internal/db/policy/decode.go`
+- Modify: `internal/db/policy/types.go`
+- Modify: `internal/db/policy/decode_test.go`
+
+- [ ] **Step 1: Write the failing test for `ParseUnavoidability` and `String`**
+
+Create `internal/db/service/flag_test.go`:
+
+```go
+package service
+
+import "testing"
+
+func TestUnavoidability_StringAndParse(t *testing.T) {
+	tests := []struct {
+		s    string
+		want Unavoidability
+		ok   bool
+	}{
+		{"off", UnavoidabilityOff, true},
+		{"observe", UnavoidabilityObserve, true},
+		{"enforce", UnavoidabilityEnforce, true},
+		{"", UnavoidabilityOff, false},
+		{"OFF", UnavoidabilityOff, false},        // case-sensitive
+		{"unknown", UnavoidabilityOff, false},
+	}
+	for _, tc := range tests {
+		got, ok := ParseUnavoidability(tc.s)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("ParseUnavoidability(%q) = (%v,%v), want (%v,%v)", tc.s, got, ok, tc.want, tc.ok)
+		}
+		if ok && got.String() != tc.s {
+			t.Errorf("Unavoidability(%v).String() = %q, want %q", got, got.String(), tc.s)
+		}
+	}
+}
+
+func TestUnavoidability_ZeroValueIsOff(t *testing.T) {
+	var u Unavoidability
+	if u != UnavoidabilityOff {
+		t.Fatalf("zero-value Unavoidability is %v, want UnavoidabilityOff", u)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/db/service/ -run TestUnavoidability -v`
+Expected: FAIL with "undefined: Unavoidability" / "undefined: ParseUnavoidability".
+
+- [ ] **Step 3: Implement `internal/db/service/flag.go`**
+
+```go
+package service
+
+// Unavoidability is the policies.db.unavoidability flag per
+// docs/agentsh-db-access-spec.md §11.1. Operators select one of three modes:
+//
+//   off     (default): proxy is inert; no listeners are bound.
+//   observe: listeners bind; declared services are intercepted; events emit.
+//   enforce: same as observe in Plan 04a (and through Plan 04c). Plan 07
+//            generates the unavoidability bundle (egress denial, SessionID-
+//            keyed proxy identity) and makes enforce the high-assurance default.
+//
+// The zero value is UnavoidabilityOff, which is the safe default for any
+// caller holding a not-yet-decoded RuleSet.
+type Unavoidability uint8
+
+const (
+	UnavoidabilityOff Unavoidability = iota
+	UnavoidabilityObserve
+	UnavoidabilityEnforce
+)
+
+func (u Unavoidability) String() string {
+	switch u {
+	case UnavoidabilityOff:
+		return "off"
+	case UnavoidabilityObserve:
+		return "observe"
+	case UnavoidabilityEnforce:
+		return "enforce"
+	default:
+		return ""
+	}
+}
+
+// ParseUnavoidability accepts the canonical lowercase mode names. Empty input
+// returns ok=false (callers may want to apply a default at a higher level).
+func ParseUnavoidability(s string) (Unavoidability, bool) {
+	switch s {
+	case "off":
+		return UnavoidabilityOff, true
+	case "observe":
+		return UnavoidabilityObserve, true
+	case "enforce":
+		return UnavoidabilityEnforce, true
+	default:
+		return UnavoidabilityOff, false
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/db/service/ -run TestUnavoidability -v`
+Expected: PASS for both subtests.
+
+- [ ] **Step 5: Write the failing test for `RuleSet.Unavoidability()` decode**
+
+Add to `internal/db/policy/decode_test.go`:
+
+```go
+func TestDecode_PoliciesDB_Unavoidability(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want service.Unavoidability
+	}{
+		{
+			name: "missing block defaults to off",
+			yaml: `version: 1
+name: test
+`,
+			want: service.UnavoidabilityOff,
+		},
+		{
+			name: "explicit off",
+			yaml: `version: 1
+name: test
+policies:
+  db:
+    unavoidability: off
+`,
+			want: service.UnavoidabilityOff,
+		},
+		{
+			name: "observe",
+			yaml: `version: 1
+name: test
+policies:
+  db:
+    unavoidability: observe
+`,
+			want: service.UnavoidabilityObserve,
+		},
+		{
+			name: "enforce",
+			yaml: `version: 1
+name: test
+policies:
+  db:
+    unavoidability: enforce
+`,
+			want: service.UnavoidabilityEnforce,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rp, err := rootpolicy.LoadFromBytes([]byte(tc.yaml))
+			if err != nil {
+				t.Fatalf("LoadFromBytes: %v", err)
+			}
+			rs, _, err := Decode(rp)
+			if err != nil {
+				t.Fatalf("Decode: %v", err)
+			}
+			if got := rs.Unavoidability(); got != tc.want {
+				t.Errorf("Unavoidability() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecode_PoliciesDB_Unavoidability_Unknown(t *testing.T) {
+	yaml := `version: 1
+name: test
+policies:
+  db:
+    unavoidability: bogus
+`
+	rp, err := rootpolicy.LoadFromBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+	if _, _, err := Decode(rp); err == nil {
+		t.Fatal("Decode: expected error for unknown unavoidability value, got nil")
+	}
+}
+```
+
+The `service` import is `"github.com/agentsh/agentsh/internal/db/service"`. The test file already imports `rootpolicy "github.com/agentsh/agentsh/internal/policy"` from earlier tests (verify before adding).
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `go test ./internal/db/policy/ -run TestDecode_PoliciesDB_Unavoidability -v`
+Expected: FAIL with "rs.Unavoidability undefined" / "Decode unknown field unavoidability".
+
+- [ ] **Step 7: Extend `internal/db/policy/decode.go` to decode the field**
+
+Find the `redactionYAML` struct (around line 111) and extend it:
+
+```go
+type redactionYAML struct {
+	LogStatements                 string `yaml:"log_statements,omitempty"`
+	ApprovalStatementPreview      string `yaml:"approval_statement_preview,omitempty"`
+	ApprovalStatementPreviewChars int    `yaml:"approval_statement_preview_chars,omitempty"`
+	Unavoidability                string `yaml:"unavoidability,omitempty"`
+}
+```
+
+Add a new helper just below `decodeRedaction`:
+
+```go
+// decodeUnavoidability reads policies.db.unavoidability. Default: UnavoidabilityOff.
+// Unknown values are an error.
+func decodeUnavoidability(p *rootpolicy.Policy) (service.Unavoidability, error) {
+	if p.Policies.IsZero() {
+		return service.UnavoidabilityOff, nil
+	}
+	var w dbPoliciesWrapper
+	if err := strictDecode(p.Policies, &w); err != nil {
+		return service.UnavoidabilityOff, fmt.Errorf("decode policies.db: %w", err)
+	}
+	if w.DB.Unavoidability == "" {
+		return service.UnavoidabilityOff, nil
+	}
+	u, ok := service.ParseUnavoidability(w.DB.Unavoidability)
+	if !ok {
+		return service.UnavoidabilityOff, fmt.Errorf("unknown policies.db.unavoidability: %q", w.DB.Unavoidability)
+	}
+	return u, nil
+}
+```
+
+Add the import:
+
+```go
+"github.com/agentsh/agentsh/internal/db/service"
+```
+
+Find `Decode` in the same file. Locate the call to `decodeRedaction` and add a sibling call to `decodeUnavoidability`. Wire its result into the `RuleSet` value being constructed (next step).
+
+- [ ] **Step 8: Add `Unavoidability` field + accessor to `RuleSet`**
+
+In `internal/db/policy/types.go`, extend the `RuleSet` struct. After the existing `redaction RedactionConfig` field add:
+
+```go
+unavoidability service.Unavoidability
+```
+
+Add the import:
+
+```go
+"github.com/agentsh/agentsh/internal/db/service"
+```
+
+Add the accessor below the existing `Service(...)` method:
+
+```go
+// Unavoidability returns the policies.db.unavoidability mode. Returns
+// UnavoidabilityOff when rs is nil so startup code holding a not-yet-loaded
+// *RuleSet does not panic.
+func (rs *RuleSet) Unavoidability() service.Unavoidability {
+	if rs == nil {
+		return service.UnavoidabilityOff
+	}
+	return rs.unavoidability
+}
+```
+
+Then in `internal/db/policy/decode.go`'s `Decode` function, plumb `decodeUnavoidability`'s result into the `RuleSet` being returned. The construction site (search for `redaction:` in the file) should now also set `unavoidability:`.
+
+- [ ] **Step 9: Run all `internal/db/policy` tests**
+
+Run: `go test ./internal/db/policy/... -v`
+Expected: all pass, including the new ones.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/db/service/flag.go internal/db/service/flag_test.go \
+        internal/db/policy/decode.go internal/db/policy/types.go \
+        internal/db/policy/decode_test.go
+git commit -m "$(cat <<'EOF'
+db: add Unavoidability flag and policies.db.unavoidability decode
+
+Plan 04a preflight. Adds internal/db/service.Unavoidability enum
+(off/observe/enforce; default off) and decodes policies.db.unavoidability
+into RuleSet.Unavoidability() so the proxy can gate listener bind.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Validate.go extension — passthrough-invisible-fields rejection
+
+**Why:** Spec §13.2 states `db_user`, `database`, `application_name` are not visible under `tls_mode: passthrough`. A connection rule under a passthrough service that matches one of those fields can never fire. We catch that at config-load with a clear error rather than silently misbehaving at runtime.
+
+**Files:**
+- Modify: `internal/db/policy/validate.go`
+- Modify: `internal/db/policy/validate_test.go`
+
+- [ ] **Step 1: Read the existing `validate.go` to find the connection-rule validator**
+
+Run: `grep -n "ConnectionRule\|connection_rule\|validateConn" internal/db/policy/validate.go | head -20`
+Identify the per-rule validation function (likely `validateConnectionRule` or similar).
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `internal/db/policy/validate_test.go` a new test:
+
+```go
+func TestValidate_PassthroughInvisibleFieldRule(t *testing.T) {
+	tests := []struct {
+		name      string
+		yaml      string
+		wantError bool
+	}{
+		{
+			name: "db_user under passthrough rejected",
+			yaml: `version: 1
+name: test
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: passthrough
+database_connection_rules:
+  - name: r1
+    db_service: appdb
+    db_user: ["admin"]
+    decision: deny
+`,
+			wantError: true,
+		},
+		{
+			name: "database under passthrough rejected",
+			yaml: `version: 1
+name: test
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: passthrough
+database_connection_rules:
+  - name: r1
+    db_service: appdb
+    database: prod
+    decision: deny
+`,
+			wantError: true,
+		},
+		{
+			name: "application_name under passthrough rejected",
+			yaml: `version: 1
+name: test
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: passthrough
+database_connection_rules:
+  - name: r1
+    db_service: appdb
+    application_name: psql
+    decision: deny
+`,
+			wantError: true,
+		},
+		{
+			name: "client_identity under passthrough is allowed (visible pre-handshake)",
+			yaml: `version: 1
+name: test
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: passthrough
+database_connection_rules:
+  - name: r1
+    db_service: appdb
+    client_identity: agent
+    decision: deny
+`,
+			wantError: false,
+		},
+		{
+			name: "db_user under terminate_reissue is allowed",
+			yaml: `version: 1
+name: test
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: terminate_reissue
+database_connection_rules:
+  - name: r1
+    db_service: appdb
+    db_user: ["admin"]
+    decision: deny
+`,
+			wantError: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rp, err := rootpolicy.LoadFromBytes([]byte(tc.yaml))
+			if err != nil {
+				t.Fatalf("LoadFromBytes: %v", err)
+			}
+			_, _, err = Decode(rp)
+			gotErr := err != nil
+			if gotErr != tc.wantError {
+				t.Fatalf("Decode error = %v, wantError = %v", err, tc.wantError)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test ./internal/db/policy/ -run TestValidate_PassthroughInvisibleFieldRule -v`
+Expected: FAIL — first three subtests pass without error currently.
+
+- [ ] **Step 4: Implement the validation in `internal/db/policy/validate.go`**
+
+Locate the connection-rule validator and add a service-aware check. Sketch (adapt to the file's existing style):
+
+```go
+// validateConnectionRuleVsService returns a non-nil error if the rule
+// matches a field that is invisible under the service's tls_mode.
+// Per spec §13.2: db_user, database, application_name are invisible under
+// tls_mode: passthrough. client_identity and SNI are visible.
+func validateConnectionRuleVsService(rule ConnectionRule, svc DBService) error {
+	if svc.TLSMode != "passthrough" {
+		return nil
+	}
+	if len(rule.DBUser) > 0 {
+		return fmt.Errorf("connection_rule %q: db_user match is invisible under tls_mode: passthrough", rule.Name)
+	}
+	if rule.Database != "" {
+		return fmt.Errorf("connection_rule %q: database match is invisible under tls_mode: passthrough", rule.Name)
+	}
+	if rule.ApplicationName != "" {
+		return fmt.Errorf("connection_rule %q: application_name match is invisible under tls_mode: passthrough", rule.Name)
+	}
+	return nil
+}
+```
+
+Wire this into the existing connection-rule validation loop (find where each `ConnectionRule` is validated and a `DBService` is in scope; if it is not, plumb the service map through). The error should bubble up through `Decode` so the test passes.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `go test ./internal/db/policy/ -run TestValidate_PassthroughInvisibleFieldRule -v`
+Expected: PASS for all five subtests.
+
+- [ ] **Step 6: Run all policy tests to verify no regressions**
+
+Run: `go test ./internal/db/policy/... -v`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/db/policy/validate.go internal/db/policy/validate_test.go
+git commit -m "$(cat <<'EOF'
+db: reject passthrough-invisible-field rules under tls_mode: passthrough
+
+Spec §13.2: db_user, database, application_name are not visible under
+tls_mode: passthrough. Connection rules referencing them under passthrough
+services can never fire; reject at config-load with a clear error.
+client_identity remains valid (visible pre-handshake).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: `events.Sink` interface, `NopSink`, `SyncSink`, and `LifecycleEvent`
+
+**Why:** Plan 04a's listener-auth path needs to emit `db_listener_auth_fail` events. We declare the proxy's emission interface here so 04a/04b/04c all consume the same surface. The test fake `SyncSink` is the in-memory event store unit tests assert against. `LifecycleEvent` carries connection-lifecycle events (listener-auth-fail, handshake-fail in 04b, degraded-visibility in 04b, etc.) — separate from the per-statement `DBEvent` because the schema is much smaller.
+
+**Files:**
+- Create: `internal/db/events/sink.go`
+- Create: `internal/db/events/sink_test.go`
+- Create: `internal/db/events/lifecycle.go`
+- Create: `internal/db/events/lifecycle_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/db/events/sink_test.go`:
+
+```go
+package events
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNopSink_EmitNeverFails(t *testing.T) {
+	s := NopSink{}
+	if err := s.EmitStatement(context.Background(), DBEvent{}); err != nil {
+		t.Fatalf("EmitStatement: %v", err)
+	}
+	if err := s.EmitLifecycle(context.Background(), LifecycleEvent{}); err != nil {
+		t.Fatalf("EmitLifecycle: %v", err)
+	}
+}
+
+func TestSyncSink_DrainReturnsEventsInOrder(t *testing.T) {
+	s := &SyncSink{}
+	for i := 0; i < 3; i++ {
+		if err := s.EmitStatement(context.Background(), DBEvent{EventID: string(rune('A' + i))}); err != nil {
+			t.Fatalf("EmitStatement: %v", err)
+		}
+	}
+	if err := s.EmitLifecycle(context.Background(), LifecycleEvent{Kind: "db_listener_auth_fail"}); err != nil {
+		t.Fatalf("EmitLifecycle: %v", err)
+	}
+	stmts := s.DrainStatements()
+	if len(stmts) != 3 || stmts[0].EventID != "A" || stmts[2].EventID != "C" {
+		t.Fatalf("DrainStatements = %+v", stmts)
+	}
+	if got := s.DrainStatements(); len(got) != 0 {
+		t.Fatalf("DrainStatements after drain = %+v, want empty", got)
+	}
+	lcs := s.DrainLifecycle()
+	if len(lcs) != 1 || lcs[0].Kind != "db_listener_auth_fail" {
+		t.Fatalf("DrainLifecycle = %+v", lcs)
+	}
+}
+
+func TestSyncSink_ConcurrentEmitIsSafe(t *testing.T) {
+	s := &SyncSink{}
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = s.EmitStatement(context.Background(), DBEvent{Timestamp: time.Now()})
+		}()
+	}
+	wg.Wait()
+	if got := len(s.DrainStatements()); got != 100 {
+		t.Fatalf("DrainStatements len = %d, want 100", got)
+	}
+}
+
+func TestSyncSink_ContextCancelled_ReturnsError(t *testing.T) {
+	s := &SyncSink{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := s.EmitStatement(ctx, DBEvent{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("EmitStatement err = %v, want context.Canceled", err)
+	}
+}
+```
+
+Create `internal/db/events/lifecycle_test.go`:
+
+```go
+package events
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestLifecycleEvent_JSONRoundTrip(t *testing.T) {
+	in := LifecycleEvent{
+		EventID:        "01HJ...",
+		SessionID:      "sess-1",
+		Timestamp:      time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC),
+		DBService:      "appdb",
+		ClientIdentity: "uid:1000",
+		Kind:           "db_listener_auth_fail",
+		Reason:         "uid_mismatch",
+		PeerUID:        2000,
+		PeerPID:        12345,
+	}
+	bs, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out LifecycleEvent
+	if err := json.Unmarshal(bs, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch:\n got %+v\nwant %+v", out, in)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/db/events/ -run "TestNopSink|TestSyncSink|TestLifecycleEvent" -v`
+Expected: FAIL with "undefined: NopSink" / "undefined: SyncSink" / "undefined: LifecycleEvent".
+
+- [ ] **Step 3: Implement `internal/db/events/sink.go`**
+
+```go
+package events
+
+import (
+	"context"
+	"sync"
+)
+
+// Sink is the event emission surface for the DB proxy. Implementations may
+// fan out to a real audit pipeline (production), to nothing (tests that do
+// not care about events), or to an in-memory buffer (unit tests asserting
+// emission). Sinks must be safe for concurrent use.
+//
+// Errors from Emit* are advisory: the proxy logs them at warn but does not
+// fail the connection. Spec §8 is silent on emission durability; Plan 04a
+// adopts best-effort semantics, leaving durability concerns to the audit-
+// pipeline implementation a later plan provides.
+type Sink interface {
+	EmitStatement(ctx context.Context, ev DBEvent) error
+	EmitLifecycle(ctx context.Context, ev LifecycleEvent) error
+}
+
+// NopSink discards every event. Useful when the proxy is wired into a
+// runtime that does not care about audit (tests of unrelated code).
+type NopSink struct{}
+
+func (NopSink) EmitStatement(context.Context, DBEvent) error      { return nil }
+func (NopSink) EmitLifecycle(context.Context, LifecycleEvent) error { return nil }
+
+// SyncSink buffers every emitted event in memory. Tests call DrainStatements
+// or DrainLifecycle to inspect what was emitted. Concurrent use is safe.
+//
+// Drain* returns the buffered events in emission order and resets the buffer.
+type SyncSink struct {
+	mu        sync.Mutex
+	stmt      []DBEvent
+	lifecycle []LifecycleEvent
+}
+
+func (s *SyncSink) EmitStatement(ctx context.Context, ev DBEvent) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.stmt = append(s.stmt, ev)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *SyncSink) EmitLifecycle(ctx context.Context, ev LifecycleEvent) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.lifecycle = append(s.lifecycle, ev)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *SyncSink) DrainStatements() []DBEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := s.stmt
+	s.stmt = nil
+	return out
+}
+
+func (s *SyncSink) DrainLifecycle() []LifecycleEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := s.lifecycle
+	s.lifecycle = nil
+	return out
+}
+```
+
+- [ ] **Step 4: Implement `internal/db/events/lifecycle.go`**
+
+```go
+package events
+
+import "time"
+
+// LifecycleEvent is a non-statement DB-proxy event: listener-auth failures,
+// handshake failures (Plan 04b), degraded-visibility warnings (Plan 04b).
+// Carries less data than DBEvent because there is no statement to redact.
+//
+// Kind is a small enumerated string ("db_listener_auth_fail",
+// "db_handshake_fail", "degraded_visibility_warning"); each plan that emits
+// a new kind is responsible for documenting the value in plan release notes.
+type LifecycleEvent struct {
+	EventID        string    `json:"event_id"`
+	SessionID      string    `json:"session_id,omitempty"`
+	Timestamp      time.Time `json:"ts"`
+	DBService      string    `json:"db_service,omitempty"`
+	ClientIdentity string    `json:"client_identity,omitempty"`
+
+	Kind   string `json:"kind"`
+	Reason string `json:"reason,omitempty"`
+
+	// Listener-auth specific (Plan 04a). Zero when not applicable.
+	PeerUID uint32 `json:"peer_uid,omitempty"`
+	PeerPID int32  `json:"peer_pid,omitempty"`
+
+	// Handshake/error specific (Plan 04b). Zero when not applicable.
+	ErrorCode string `json:"error_code,omitempty"`
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/db/events/ -v`
+Expected: PASS for all (including any pre-existing `event_test.go` tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/db/events/sink.go internal/db/events/sink_test.go \
+        internal/db/events/lifecycle.go internal/db/events/lifecycle_test.go
+git commit -m "$(cat <<'EOF'
+db/events: add Sink interface, NopSink, SyncSink, LifecycleEvent
+
+Plan 04a's listener-auth path needs to emit db_listener_auth_fail events.
+Declare the proxy's emission interface here so 04a/04b/04c all consume
+the same surface. SyncSink is the in-memory test fake. LifecycleEvent
+carries connection-lifecycle events (listener-auth, handshake fail,
+degraded-visibility); separate from per-statement DBEvent.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Package skeleton — `Server` type, sentinel short-circuit, non-Linux stub
+
+**Why:** Establishes the `internal/db/proxy/postgres` package surface (`Config`, `Server`, `New`, `Start`, `Shutdown`) without any protocol code. The sentinel short-circuit (when `Unavoidability == off`) means callers never special-case the flag. The non-Linux stub keeps `GOOS=windows go build ./...` green per CLAUDE.md.
+
+**Files:**
+- Create: `internal/db/proxy/postgres/server.go` (`//go:build linux`)
+- Create: `internal/db/proxy/postgres/stub_other.go` (`//go:build !linux`)
+- Create: `internal/db/proxy/postgres/server_test.go` (`//go:build linux`)
+
+- [ ] **Step 1: Write the failing test for the public surface and sentinel**
+
+Create `internal/db/proxy/postgres/server_test.go`:
+
+```go
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/service"
+)
+
+func TestServer_New_ZeroConfigRejected(t *testing.T) {
+	_, err := New(Config{})
+	if err == nil {
+		t.Fatal("New(Config{}): want error, got nil")
+	}
+}
+
+func TestServer_OffMode_StartIsNoop(t *testing.T) {
+	cfg := Config{
+		Unavoidability: service.UnavoidabilityOff,
+		StateDir:       t.TempDir(),
+		Sink:           &events.SyncSink{},
+		Logger:         slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+	}
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if s == nil {
+		t.Fatal("New returned nil server")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("Start (off mode): %v", err)
+	}
+	if err := s.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown (off mode): %v", err)
+	}
+}
+
+func TestServer_ObserveMode_RequiresAtLeastOneService(t *testing.T) {
+	cfg := Config{
+		Unavoidability: service.UnavoidabilityObserve,
+		StateDir:       t.TempDir(),
+		Sink:           &events.SyncSink{},
+		Logger:         slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+	}
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("New (observe, no services): want error, got nil")
+	}
+}
+
+func TestServer_New_MissingSink(t *testing.T) {
+	cfg := Config{
+		Unavoidability: service.UnavoidabilityObserve,
+		StateDir:       t.TempDir(),
+		Services:       []policy.DBService{{Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "db.internal:5432", TLSMode: "terminate_reissue"}},
+	}
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("New (no sink): want error, got nil")
+	}
+}
+
+// testWriter wires slog output into t.Log so tests preserve context on failure.
+type testWriter struct{ t *testing.T }
+
+func (w testWriter) Write(p []byte) (int, error) { w.t.Log(string(p)); return len(p), nil }
+```
+
+Note: `policy.DBService` is the type already shipped in Plan 02. The `Listener` shape is owned by `internal/db/service.Service`, but for Plan 04a the proxy receives services + listen paths via a flatter shape. Settle the exact `Config.Services` element type in the implementation step.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/db/proxy/postgres/ -v`
+Expected: FAIL with "no Go files in ..." or "undefined: New".
+
+- [ ] **Step 3: Implement `internal/db/proxy/postgres/server.go`**
+
+```go
+//go:build linux
+
+// Package postgres implements the AgentSH PostgreSQL proxy per
+// docs/agentsh-db-access-spec.md §11–§14 and the macro design at
+// docs/superpowers/specs/2026-05-10-db-plan-04-pg-proxy-skeleton-design.md.
+//
+// Plan 04a ships only the listener skeleton: bind Unix sockets per declared
+// db_service, peer-authenticate via SO_PEERCRED + UID-equality, accept and
+// immediately close. Plan 04b adds the handshake / TLS layer; Plan 04c adds
+// Simple Query classification and DBEvent emission.
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/service"
+)
+
+// Service is the proxy-internal flattened view of one db_service. The proxy
+// needs the listener path (from internal/db/service.Listener) and the
+// upstream + tls_mode metadata (from internal/db/policy.DBService). Callers
+// in internal/api are responsible for joining them.
+type Service struct {
+	Name     string                  // matches policy.DBService.Name
+	Family   string                  // "postgres"
+	Dialect  string                  // postgres / aurora_postgres / cockroachdb / redshift
+	Upstream string                  // host:port
+	TLSMode  string                  // terminate_reissue / passthrough / terminate_plaintext_upstream
+	Listen   ServiceListener         // unix-socket path or tcp host:port
+	Service  policy.DBService        // full DBService for downstream evaluation
+}
+
+// ServiceListener mirrors internal/db/service.Listener but is the package-
+// local concrete type the proxy operates on. Plan 04a only binds Kind=="unix".
+type ServiceListener struct {
+	Kind string // "unix" or "tcp"
+	Path string // when Kind == "unix"
+	Host string // when Kind == "tcp"
+	Port int    // when Kind == "tcp"
+}
+
+// Config captures the supervisor-supplied parameters for a Server. All
+// fields are required when Unavoidability != UnavoidabilityOff except
+// Logger (defaults to slog.Default) and the Plan 04b/04c-only fields
+// (Classifier, Policy) which Plan 04a accepts but does not use.
+type Config struct {
+	Unavoidability service.Unavoidability
+	Services       []Service
+	StateDir       string
+	Sink           events.Sink
+	Logger         *slog.Logger
+}
+
+// Server runs the AgentSH PostgreSQL proxy listeners.
+type Server struct {
+	cfg       Config
+	logger    *slog.Logger
+	sentinel  bool // true when Unavoidability == off; Start/Shutdown are no-ops
+	mu        sync.Mutex
+	started   bool
+	shutdown  bool
+}
+
+// New validates cfg and returns a *Server. When cfg.Unavoidability ==
+// UnavoidabilityOff, returns a sentinel server whose Start/Shutdown are
+// no-ops. Returns an error when required fields are missing.
+func New(cfg Config) (*Server, error) {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	if cfg.Unavoidability == service.UnavoidabilityOff {
+		return &Server{cfg: cfg, logger: cfg.Logger, sentinel: true}, nil
+	}
+	if cfg.StateDir == "" {
+		return nil, errors.New("postgres.New: StateDir is required when Unavoidability != off")
+	}
+	if cfg.Sink == nil {
+		return nil, errors.New("postgres.New: Sink is required when Unavoidability != off")
+	}
+	if len(cfg.Services) == 0 {
+		return nil, errors.New("postgres.New: at least one Service is required when Unavoidability != off")
+	}
+	for i, svc := range cfg.Services {
+		if svc.Name == "" {
+			return nil, fmt.Errorf("postgres.New: services[%d].Name is empty", i)
+		}
+		if svc.Listen.Kind != "unix" && svc.Listen.Kind != "tcp" {
+			return nil, fmt.Errorf("postgres.New: services[%d].Listen.Kind = %q; want unix or tcp", i, svc.Listen.Kind)
+		}
+		if svc.Listen.Kind == "unix" && svc.Listen.Path == "" {
+			return nil, fmt.Errorf("postgres.New: services[%d].Listen.Path is empty for unix listener", i)
+		}
+	}
+	return &Server{cfg: cfg, logger: cfg.Logger}, nil
+}
+
+// Start binds listeners and runs accept loops until ctx is cancelled.
+// Returns nil for sentinel servers. Returns the first listener-bind error;
+// subsequent listeners are torn down.
+//
+// Plan 04a: connection handler is a no-op that closes the conn after the
+// peercred check. Plan 04b plugs in the real handshake handler.
+func (s *Server) Start(ctx context.Context) error {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return errors.New("postgres.Server: Start called twice")
+	}
+	s.started = true
+	s.mu.Unlock()
+
+	if s.sentinel {
+		s.logger.Info("postgres.Server: sentinel mode (Unavoidability == off); not binding listeners")
+		return nil
+	}
+
+	// Listener bind + accept loop is implemented in Task 5.
+	return errors.New("postgres.Server.Start: listener bind not yet implemented (Plan 04a Task 5)")
+}
+
+// Shutdown stops accept loops, waits for in-flight conns to close, and
+// unlinks Unix sockets. Returns nil for sentinel servers.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.shutdown {
+		return nil
+	}
+	s.shutdown = true
+	if s.sentinel {
+		return nil
+	}
+	// Implemented in Task 5.
+	return nil
+}
+```
+
+- [ ] **Step 4: Implement `internal/db/proxy/postgres/stub_other.go`**
+
+```go
+//go:build !linux
+
+// Package postgres provides a non-Linux stub so cross-compilation
+// (GOOS=windows go build ./...) stays green. The proxy is Linux-only;
+// callers on other platforms get errors.ErrUnsupported when starting it.
+package postgres
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/service"
+)
+
+type Service struct {
+	Name     string
+	Family   string
+	Dialect  string
+	Upstream string
+	TLSMode  string
+	Listen   ServiceListener
+	Service  policy.DBService
+}
+
+type ServiceListener struct {
+	Kind string
+	Path string
+	Host string
+	Port int
+}
+
+type Config struct {
+	Unavoidability service.Unavoidability
+	Services       []Service
+	StateDir       string
+	Sink           events.Sink
+	Logger         *slog.Logger
+}
+
+type Server struct {
+	sentinel bool
+}
+
+// New on non-Linux always succeeds and returns a sentinel that refuses to
+// start unless Unavoidability == off (in which case Start is a no-op too).
+func New(cfg Config) (*Server, error) {
+	return &Server{sentinel: cfg.Unavoidability == service.UnavoidabilityOff}, nil
+}
+
+func (s *Server) Start(ctx context.Context) error {
+	if s.sentinel {
+		return nil
+	}
+	return errors.ErrUnsupported
+}
+
+func (s *Server) Shutdown(ctx context.Context) error { return nil }
+```
+
+- [ ] **Step 5: Run tests to verify only the unimplemented-bind test path fails for the right reason**
+
+Run: `go test ./internal/db/proxy/postgres/ -run "TestServer_New|TestServer_OffMode" -v`
+Expected: PASS for `TestServer_New_ZeroConfigRejected`, `TestServer_OffMode_StartIsNoop`, `TestServer_ObserveMode_RequiresAtLeastOneService`, `TestServer_New_MissingSink`. (The full Start/Shutdown test arrives in Task 5.)
+
+- [ ] **Step 6: Verify cross-compile**
+
+Run: `GOOS=windows go build ./internal/db/proxy/postgres/...`
+Expected: build success.
+
+Run: `GOOS=darwin go build ./internal/db/proxy/postgres/...`
+Expected: build success.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/db/proxy/postgres/server.go \
+        internal/db/proxy/postgres/stub_other.go \
+        internal/db/proxy/postgres/server_test.go
+git commit -m "$(cat <<'EOF'
+db/proxy/postgres: package skeleton with sentinel short-circuit
+
+Plan 04a Task 4. Establishes Config / Server / New / Start / Shutdown
+public surface plus a non-Linux stub for cross-compilation. Sentinel
+mode (Unavoidability == off) is a no-op so callers do not special-case
+the flag. Listener bind arrives in Task 5.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Server lifecycle — bind, accept loop, Shutdown drain
+
+**Why:** Implements `Start` / `Shutdown` for the non-sentinel case. Listener bind, accept loop in its own goroutine per service, graceful drain on cancel, Unix-socket unlink on close. The connection handler is still a no-op that closes the conn — Task 6 plugs in peercred auth, Plan 04b plugs in handshake.
+
+**Files:**
+- Modify: `internal/db/proxy/postgres/server.go`
+- Modify: `internal/db/proxy/postgres/server_test.go`
+- Create: `internal/db/proxy/postgres/listener_unix.go` (`//go:build linux`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/db/proxy/postgres/server_test.go`:
+
+```go
+func TestServer_StartShutdown_BindsAndUnlinksUnixSocket(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "appdb.sock")
+	cfg := Config{
+		Unavoidability: service.UnavoidabilityObserve,
+		StateDir:       t.TempDir(),
+		Sink:           &events.SyncSink{},
+		Logger:         slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		Services: []Service{{
+			Name:     "appdb",
+			Family:   "postgres",
+			Dialect:  "postgres",
+			Upstream: "127.0.0.1:5432",
+			TLSMode:  "terminate_reissue",
+			Listen:   ServiceListener{Kind: "unix", Path: sockPath},
+			Service:  policy.DBService{Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "127.0.0.1:5432", TLSMode: "terminate_reissue"},
+		}},
+	}
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startErr := make(chan error, 1)
+	go func() { startErr <- s.Start(ctx) }()
+
+	// Wait until the socket exists. Start spawns goroutines synchronously
+	// after bind, so a short poll loop is sufficient.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if fi, err := os.Stat(sockPath); err == nil && fi.Mode()&os.ModeSocket != 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if fi, err := os.Stat(sockPath); err != nil || fi.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("socket %q not bound: stat=%v, err=%v", sockPath, fi, err)
+	}
+	if fi, _ := os.Stat(sockPath); fi.Mode()&0777 != 0700 {
+		t.Errorf("socket %q perms = %#o, want 0700", sockPath, fi.Mode()&0777)
+	}
+
+	// A Unix-socket dial should succeed and immediately see EOF (handler is no-op).
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	buf := make([]byte, 1)
+	conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	if _, err := conn.Read(buf); err == nil || (err.Error() != "EOF" && !errors.Is(err, io.EOF) && !os.IsTimeout(err)) {
+		t.Fatalf("Read after dial: err=%v, want EOF or close", err)
+	}
+	conn.Close()
+
+	// Cancel context and assert Shutdown completes and unlinks the socket.
+	cancel()
+	if err := s.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if err := <-startErr; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("Start returned: %v", err)
+	}
+	if _, err := os.Stat(sockPath); !os.IsNotExist(err) {
+		t.Fatalf("socket %q still present after Shutdown: stat err=%v", sockPath, err)
+	}
+}
+
+func TestServer_StartTwice_ReturnsError(t *testing.T) {
+	cfg := Config{
+		Unavoidability: service.UnavoidabilityObserve,
+		StateDir:       t.TempDir(),
+		Sink:           &events.SyncSink{},
+		Services: []Service{{
+			Name:     "appdb",
+			Listen:   ServiceListener{Kind: "unix", Path: filepath.Join(t.TempDir(), "appdb.sock")},
+			Service:  policy.DBService{Name: "appdb"},
+			TLSMode:  "terminate_reissue",
+		}},
+	}
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+	if err := s.Start(ctx); err == nil {
+		t.Fatal("second Start: want error, got nil")
+	}
+}
+```
+
+Add the necessary imports:
+
+```go
+"errors"
+"io"
+"net"
+"os"
+"path/filepath"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/db/proxy/postgres/ -run "TestServer_StartShutdown|TestServer_StartTwice" -v`
+Expected: FAIL — `Start` returns the "not yet implemented" sentinel error.
+
+- [ ] **Step 3: Implement `internal/db/proxy/postgres/listener_unix.go`**
+
+```go
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// unixListener wraps a net.UnixListener with the Plan 04a setup contract:
+// remove stale socket → bind → chmod 0700. On Close, unlinks the socket.
+type unixListener struct {
+	path string
+	ln   *net.UnixListener
+}
+
+func bindUnixListener(path string) (*unixListener, error) {
+	parent := filepath.Dir(path)
+	fi, err := os.Stat(parent)
+	if err != nil {
+		return nil, fmt.Errorf("stat listener parent dir %q: %w", parent, err)
+	}
+	if !fi.IsDir() {
+		return nil, fmt.Errorf("listener parent %q is not a directory", parent)
+	}
+	// Remove stale socket from a prior crash. Existing non-socket file is a
+	// hard error to avoid clobbering operator data.
+	if existing, err := os.Stat(path); err == nil {
+		if existing.Mode()&os.ModeSocket == 0 {
+			return nil, fmt.Errorf("listener path %q exists and is not a socket", path)
+		}
+		if err := os.Remove(path); err != nil {
+			return nil, fmt.Errorf("remove stale socket %q: %w", path, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("stat listener path %q: %w", path, err)
+	}
+	addr, err := net.ResolveUnixAddr("unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %q: %w", path, err)
+	}
+	ln, err := net.ListenUnix("unix", addr)
+	if err != nil {
+		return nil, fmt.Errorf("listen %q: %w", path, err)
+	}
+	if err := os.Chmod(path, 0o700); err != nil {
+		ln.Close()
+		os.Remove(path)
+		return nil, fmt.Errorf("chmod 0700 %q: %w", path, err)
+	}
+	return &unixListener{path: path, ln: ln}, nil
+}
+
+func (l *unixListener) Accept(ctx context.Context) (net.Conn, error) {
+	// Plumb ctx cancel into Accept by setting a deadline that is bumped
+	// forward periodically. Simpler than juggling a goroutine + close.
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		// 250ms cancellation latency is fine for shutdown.
+		_ = l.ln.SetDeadline(timeNow().Add(250 * time.Millisecond))
+		conn, err := l.ln.AcceptUnix()
+		if err == nil {
+			return conn, nil
+		}
+		var ne net.Error
+		if errors.As(err, &ne) && ne.Timeout() {
+			continue
+		}
+		return nil, err
+	}
+}
+
+func (l *unixListener) Close() error {
+	err := l.ln.Close()
+	if rmErr := os.Remove(l.path); rmErr != nil && !os.IsNotExist(rmErr) {
+		if err == nil {
+			err = fmt.Errorf("remove %q: %w", l.path, rmErr)
+		}
+	}
+	return err
+}
+
+// activeConns is a small concurrent set of in-flight conns the Server cancels
+// at Shutdown. The set is keyed by conn pointer; conn handlers Add themselves
+// at start and Remove themselves on return.
+type activeConns struct {
+	mu sync.Mutex
+	m  map[net.Conn]struct{}
+}
+
+func newActiveConns() *activeConns { return &activeConns{m: make(map[net.Conn]struct{})} }
+
+func (a *activeConns) Add(c net.Conn) {
+	a.mu.Lock()
+	a.m[c] = struct{}{}
+	a.mu.Unlock()
+}
+
+func (a *activeConns) Remove(c net.Conn) {
+	a.mu.Lock()
+	delete(a.m, c)
+	a.mu.Unlock()
+}
+
+func (a *activeConns) CloseAll() {
+	a.mu.Lock()
+	for c := range a.m {
+		_ = c.Close()
+	}
+	a.mu.Unlock()
+}
+
+func (a *activeConns) Len() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.m)
+}
+```
+
+Add the `time` import and a small `timeNow` shim at the top of the file:
+
+```go
+import (
+	"time"
+)
+
+var timeNow = time.Now // overridable in tests if needed
+```
+
+- [ ] **Step 4: Replace `Server.Start` and `Server.Shutdown` in `server.go`**
+
+Replace the Plan-04a-Task-4 stubs with full implementations:
+
+```go
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/service"
+)
+
+// (Service, ServiceListener, Config types unchanged from Task 4.)
+
+type Server struct {
+	cfg      Config
+	logger   *slog.Logger
+	sentinel bool
+
+	mu       sync.Mutex
+	started  bool
+	shutdown bool
+
+	// Populated on Start. Owned by the goroutine that called Start.
+	cancel    context.CancelFunc
+	eg        *errgroup.Group
+	listeners []*unixListener
+	conns     *activeConns
+}
+
+func (s *Server) Start(ctx context.Context) error {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return errors.New("postgres.Server: Start called twice")
+	}
+	s.started = true
+	s.mu.Unlock()
+
+	if s.sentinel {
+		s.logger.Info("postgres.Server: sentinel mode (Unavoidability == off); not binding listeners")
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	// Bind all listeners up-front so a partial failure tears the rest down.
+	var bound []*unixListener
+	for _, svc := range s.cfg.Services {
+		if svc.Listen.Kind != "unix" {
+			s.logger.Warn("postgres.Server: skipping non-unix listener (Plan 04a binds unix only)",
+				"service", svc.Name, "kind", svc.Listen.Kind)
+			continue
+		}
+		ln, err := bindUnixListener(svc.Listen.Path)
+		if err != nil {
+			for _, b := range bound {
+				_ = b.Close()
+			}
+			return fmt.Errorf("bind listener for service %q: %w", svc.Name, err)
+		}
+		bound = append(bound, ln)
+		s.logger.Info("postgres.Server: bound listener", "service", svc.Name, "path", svc.Listen.Path)
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	s.mu.Lock()
+	s.cancel = cancel
+	s.listeners = bound
+	s.conns = newActiveConns()
+	s.eg, _ = errgroup.WithContext(runCtx)
+	s.mu.Unlock()
+
+	for i, svc := range s.cfg.Services {
+		if svc.Listen.Kind != "unix" {
+			continue
+		}
+		ln := bound[i] // index alignment: only unix listeners go into bound
+		svcCopy := svc
+		s.eg.Go(func() error {
+			return s.acceptLoop(runCtx, svcCopy, ln)
+		})
+	}
+
+	err := s.eg.Wait()
+	if errors.Is(err, context.Canceled) {
+		err = nil
+	}
+	return err
+}
+
+// Bound listeners are aligned with cfg.Services entries that have Kind=="unix".
+// The index map above is wrong — replace with: keep a per-service ln pointer.
+// (See Step 5: refactor the bound slice into a per-service map.)
+```
+
+The index-alignment shortcut above is **wrong** when some services have non-unix listeners. Replace `bound []*unixListener` with `bound map[string]*unixListener` keyed by service name; index the per-service goroutine by name. Update the code accordingly.
+
+```go
+type Server struct {
+	// ... same as above except:
+	listeners map[string]*unixListener
+}
+
+// In Start:
+bound := make(map[string]*unixListener, len(s.cfg.Services))
+for _, svc := range s.cfg.Services {
+	if svc.Listen.Kind != "unix" {
+		s.logger.Warn(...)
+		continue
+	}
+	ln, err := bindUnixListener(svc.Listen.Path)
+	if err != nil {
+		for _, b := range bound { _ = b.Close() }
+		return fmt.Errorf("bind listener for service %q: %w", svc.Name, err)
+	}
+	bound[svc.Name] = ln
+}
+// ...
+s.listeners = bound
+// ...
+for _, svc := range s.cfg.Services {
+	ln, ok := bound[svc.Name]
+	if !ok { continue }
+	svcCopy, lnCopy := svc, ln
+	s.eg.Go(func() error {
+		return s.acceptLoop(runCtx, svcCopy, lnCopy)
+	})
+}
+```
+
+- [ ] **Step 5: Implement `acceptLoop` and the no-op handler in `server.go`**
+
+```go
+func (s *Server) acceptLoop(ctx context.Context, svc Service, ln *unixListener) error {
+	for {
+		conn, err := ln.Accept(ctx)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			s.logger.Warn("postgres.Server: accept error", "service", svc.Name, "err", err)
+			return err
+		}
+		s.conns.Add(conn)
+		go func() {
+			defer s.conns.Remove(conn)
+			defer conn.Close()
+			s.handleConn(ctx, svc, conn)
+		}()
+	}
+}
+
+// handleConn is the per-connection handler. Plan 04a: peercred check (Task 6),
+// then close. Plan 04b plugs in the real handshake.
+func (s *Server) handleConn(ctx context.Context, svc Service, conn net.Conn) {
+	// Task 6 inserts the peercred check here; for Task 5 the body is empty
+	// (and the conn is closed by the deferred Close in acceptLoop).
+}
+```
+
+- [ ] **Step 6: Implement `Server.Shutdown`**
+
+```go
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.mu.Lock()
+	if s.shutdown {
+		s.mu.Unlock()
+		return nil
+	}
+	s.shutdown = true
+	cancel := s.cancel
+	listeners := s.listeners
+	conns := s.conns
+	eg := s.eg
+	s.mu.Unlock()
+
+	if s.sentinel || cancel == nil {
+		return nil
+	}
+	cancel()
+	for _, ln := range listeners {
+		_ = ln.Close()
+	}
+	if conns != nil {
+		conns.CloseAll()
+	}
+	if eg != nil {
+		// eg.Wait already happens in Start; here we just respect the caller's ctx.
+		done := make(chan error, 1)
+		go func() { done <- eg.Wait() }()
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `go test ./internal/db/proxy/postgres/ -v`
+Expected: PASS for all tests including the new bind/unbind and double-Start cases.
+
+- [ ] **Step 8: Cross-compile**
+
+Run: `GOOS=windows go build ./...`
+Expected: build success.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/db/proxy/postgres/server.go \
+        internal/db/proxy/postgres/listener_unix.go \
+        internal/db/proxy/postgres/server_test.go
+git commit -m "$(cat <<'EOF'
+db/proxy/postgres: bind, accept loop, graceful Shutdown
+
+Plan 04a Task 5. Server.Start binds Unix listeners per declared service
+(0700 perms; stale socket removed before bind), runs an accept loop per
+listener under errgroup, and tracks in-flight conns. Connection handler
+is still a no-op that closes the conn (Task 6 adds peercred auth).
+Shutdown cancels accept, closes listeners (unlinking socket files),
+and closes in-flight conns within the caller's deadline.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: SO_PEERCRED + UID-equality listener auth
+
+**Why:** Spec §12.5 requires the listener to verify peer identity. Plan 04a uses the simplest correct check: `getsockopt(SO_PEERCRED)` plus equality with the proxy's own uid. Plan 07 tightens this to SO_PEERCRED → SessionID via the ptrace registry. On mismatch the connection is closed silently and a `db_listener_auth_fail` lifecycle event is emitted.
+
+**Files:**
+- Create: `internal/db/proxy/postgres/peercred_linux.go` (`//go:build linux`)
+- Create: `internal/db/proxy/postgres/peercred_linux_test.go` (`//go:build linux`)
+- Modify: `internal/db/proxy/postgres/server.go` (wire peercred into `handleConn`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/db/proxy/postgres/peercred_linux_test.go`:
+
+```go
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestReadPeerCredUID_FromSocketpair(t *testing.T) {
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("Socketpair: %v", err)
+	}
+	defer unix.Close(fds[0])
+	defer unix.Close(fds[1])
+
+	// Wrap fd[0] as a net.UnixConn so we can call our helper on it.
+	f := os.NewFile(uintptr(fds[0]), "peer")
+	conn, err := net.FileConn(f)
+	if err != nil {
+		t.Fatalf("FileConn: %v", err)
+	}
+	f.Close() // FileConn dup'd the fd
+	defer conn.Close()
+
+	uc, ok := conn.(*net.UnixConn)
+	if !ok {
+		t.Fatalf("conn is %T, want *net.UnixConn", conn)
+	}
+
+	gotUID, gotPID, err := readPeerCred(uc)
+	if err != nil {
+		t.Fatalf("readPeerCred: %v", err)
+	}
+	if gotUID != uint32(os.Getuid()) {
+		t.Errorf("readPeerCred uid = %d, want %d", gotUID, os.Getuid())
+	}
+	if gotPID != int32(os.Getpid()) {
+		t.Errorf("readPeerCred pid = %d, want %d", gotPID, os.Getpid())
+	}
+}
+
+func TestReadPeerCredUID_OnNonUnixConn_Errors(t *testing.T) {
+	r, w := net.Pipe()
+	defer r.Close()
+	defer w.Close()
+	if _, _, err := readPeerCred(r); err == nil {
+		t.Fatal("readPeerCred(net.Pipe): want error, got nil")
+	}
+}
+
+func TestServer_PeercredMismatch_ClosesAndEmitsLifecycle(t *testing.T) {
+	// We cannot easily impersonate a different uid in unit tests; instead,
+	// inject a checkUID function that always returns false. This exercises
+	// the failure branch end-to-end.
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "appdb.sock")
+	sink := &events.SyncSink{}
+	cfg := Config{
+		Unavoidability: service.UnavoidabilityObserve,
+		StateDir:       t.TempDir(),
+		Sink:           sink,
+		Services: []Service{{
+			Name:     "appdb",
+			Family:   "postgres",
+			Dialect:  "postgres",
+			Upstream: "127.0.0.1:5432",
+			TLSMode:  "terminate_reissue",
+			Listen:   ServiceListener{Kind: "unix", Path: sockPath},
+			Service:  policy.DBService{Name: "appdb"},
+		}},
+	}
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Override the equality check for this test only.
+	s.uidAllowed = func(uint32) bool { return false }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.Start(ctx)
+	waitForSocket(t, sockPath)
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Server should close the conn silently after peercred check.
+	conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); !errors.Is(err, io.EOF) && !isClosedConnError(err) {
+		t.Errorf("Read after peercred mismatch: err=%v, want EOF or closed-conn", err)
+	}
+
+	// Allow a brief moment for the lifecycle event to land.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if len(sink.DrainLifecycle()) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// Drain again to inspect (the prior loop may have drained on a hit).
+	// Re-emit by triggering once more is overkill; instead, capture the
+	// lifecycle slice on first non-empty Drain.
+}
+
+// helper: wait until socket file exists and is a socket
+func waitForSocket(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if fi, err := os.Stat(path); err == nil && fi.Mode()&os.ModeSocket != 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("socket %q never bound", path)
+}
+
+func isClosedConnError(err error) bool {
+	return err != nil && (errors.Is(err, net.ErrClosed) || strings.Contains(err.Error(), "use of closed"))
+}
+```
+
+The test shape above has a small issue (the second drain after the deadline loop is unsound). Replace the post-loop assertion with a single drained slice captured inside the loop:
+
+```go
+var lcs []events.LifecycleEvent
+deadline := time.Now().Add(500 * time.Millisecond)
+for time.Now().Before(deadline) {
+    if got := sink.DrainLifecycle(); len(got) > 0 {
+        lcs = got
+        break
+    }
+    time.Sleep(10 * time.Millisecond)
+}
+if len(lcs) != 1 || lcs[0].Kind != "db_listener_auth_fail" {
+    t.Fatalf("DrainLifecycle = %+v, want one db_listener_auth_fail", lcs)
+}
+if lcs[0].DBService != "appdb" {
+    t.Errorf("DBService = %q, want appdb", lcs[0].DBService)
+}
+if lcs[0].PeerUID != uint32(os.Getuid()) {
+    t.Errorf("PeerUID = %d, want %d", lcs[0].PeerUID, os.Getuid())
+}
+```
+
+Also add the new `time`, `strings`, `io` imports if missing.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/db/proxy/postgres/ -run "TestReadPeerCred|TestServer_Peercred" -v`
+Expected: FAIL with "undefined: readPeerCred" / "s.uidAllowed undefined".
+
+- [ ] **Step 3: Implement `internal/db/proxy/postgres/peercred_linux.go`**
+
+```go
+//go:build linux
+
+package postgres
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+// readPeerCred returns the peer's uid and pid via SO_PEERCRED on a Unix
+// socket connection. Returns an error if conn is not a *net.UnixConn or the
+// getsockopt call fails.
+//
+// Spec §12.5: SO_PEERCRED is the listener-auth primitive in Plan 04a.
+// Plan 07 hardens this to a SessionID resolution via the ptrace registry.
+func readPeerCred(conn net.Conn) (uid uint32, pid int32, err error) {
+	uc, ok := conn.(*net.UnixConn)
+	if !ok {
+		return 0, 0, fmt.Errorf("readPeerCred: conn is %T, want *net.UnixConn", conn)
+	}
+	raw, err := uc.SyscallConn()
+	if err != nil {
+		return 0, 0, fmt.Errorf("readPeerCred: SyscallConn: %w", err)
+	}
+	var ucred *unix.Ucred
+	var sysErr error
+	ctrlErr := raw.Control(func(fd uintptr) {
+		ucred, sysErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	})
+	if ctrlErr != nil {
+		return 0, 0, fmt.Errorf("readPeerCred: Control: %w", ctrlErr)
+	}
+	if sysErr != nil {
+		return 0, 0, fmt.Errorf("readPeerCred: SO_PEERCRED: %w", sysErr)
+	}
+	if ucred == nil {
+		return 0, 0, errors.New("readPeerCred: ucred is nil")
+	}
+	return ucred.Uid, ucred.Pid, nil
+}
+```
+
+- [ ] **Step 4: Wire peercred into `handleConn`**
+
+Modify `internal/db/proxy/postgres/server.go`:
+
+Add `uidAllowed` to the `Server` struct (overrideable in tests):
+
+```go
+type Server struct {
+	// ... existing fields ...
+	uidAllowed func(uint32) bool // default: equality with os.Getuid()
+}
+```
+
+In `New`, initialize `uidAllowed`:
+
+```go
+me := uint32(os.Getuid())
+srv := &Server{
+	cfg:        cfg,
+	logger:     cfg.Logger,
+	sentinel:   cfg.Unavoidability == service.UnavoidabilityOff,
+	uidAllowed: func(u uint32) bool { return u == me },
+}
+return srv, nil
+```
+
+(Adjust the existing `New` body to use `srv` and the sentinel-short-circuit appropriately. Imports: add `os`.)
+
+Replace `handleConn` with:
+
+```go
+func (s *Server) handleConn(ctx context.Context, svc Service, conn net.Conn) {
+	uid, pid, err := readPeerCred(conn)
+	if err != nil {
+		s.logger.Warn("postgres.Server: peercred read failed; closing", "service", svc.Name, "err", err)
+		s.emitListenerAuthFail(ctx, svc, 0, 0, "peercred_read_failed")
+		return
+	}
+	if !s.uidAllowed(uid) {
+		s.emitListenerAuthFail(ctx, svc, uid, pid, "uid_mismatch")
+		return
+	}
+	// Plan 04a: peercred passed; close the conn (handshake lands in 04b).
+	// The deferred Close in acceptLoop handles the actual close.
+}
+
+func (s *Server) emitListenerAuthFail(ctx context.Context, svc Service, uid uint32, pid int32, reason string) {
+	if s.cfg.Sink == nil {
+		return
+	}
+	ev := events.LifecycleEvent{
+		EventID:   newEventID(),
+		Timestamp: timeNow(),
+		DBService: svc.Name,
+		Kind:      "db_listener_auth_fail",
+		Reason:    reason,
+		PeerUID:   uid,
+		PeerPID:   pid,
+	}
+	if err := s.cfg.Sink.EmitLifecycle(ctx, ev); err != nil {
+		s.logger.Warn("postgres.Server: sink emit failed", "kind", ev.Kind, "err", err)
+	}
+}
+```
+
+Add a small `newEventID` helper in a new `internal/db/proxy/postgres/eventid.go`:
+
+```go
+//go:build linux
+
+package postgres
+
+import "github.com/google/uuid"
+
+// newEventID returns a UUIDv7 string for event correlation.
+// Plan 04 spec §8: event_id is uuid-v7. uuid v1.6.0 ships v7 support.
+func newEventID() string {
+	id, err := uuid.NewV7()
+	if err != nil {
+		// NewV7 only fails if the random source fails; fall back to V4.
+		return uuid.NewString()
+	}
+	return id.String()
+}
+```
+
+(Verify `github.com/google/uuid` is already a direct dep — `go.mod` line 34 confirms `github.com/google/uuid v1.6.0`.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/db/proxy/postgres/ -v`
+Expected: PASS for all tests.
+
+- [ ] **Step 6: Cross-compile**
+
+Run: `GOOS=windows go build ./...`
+Expected: build success.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/db/proxy/postgres/peercred_linux.go \
+        internal/db/proxy/postgres/peercred_linux_test.go \
+        internal/db/proxy/postgres/server.go \
+        internal/db/proxy/postgres/eventid.go
+git commit -m "$(cat <<'EOF'
+db/proxy/postgres: SO_PEERCRED + UID-equality listener auth
+
+Plan 04a Task 6. handleConn now reads SO_PEERCRED and compares the peer
+uid to the proxy's own uid. Mismatch silently closes the conn and emits
+a db_listener_auth_fail lifecycle event. uidAllowed is overrideable in
+tests so the failure branch is exercised end-to-end without changing
+process credentials.
+
+Spec §12.5: this is the Plan 04a listener-auth primitive. Plan 07
+hardens it to SessionID resolution via the ptrace registry.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `internal/api` wiring — instantiate the proxy at startup
+
+**Why:** The proxy is useless without something starting it. `internal/api` already owns subsystem boot and shutdown for the supervisor process; we add a small block that constructs the proxy `Server` from the loaded `RuleSet` + `db_services` and attaches `Shutdown` to the supervisor's lifecycle.
+
+**Files:**
+- Create: `internal/api/db_proxy.go` — proxy boot helper.
+- Create: `internal/api/db_proxy_test.go` — exercises boot + shutdown wiring.
+- Modify: `internal/server/server.go` — call `startDBProxy` after `api.NewApp` and register `Shutdown` into the existing `appCloser` defer chain (around line 507).
+
+The boot site is `internal/server/server.go` (a `grep -n "api.NewApp" internal/server/server.go` confirms one hit). The DB proxy is process-global (not per-session), so it lives next to `app := api.NewApp(...)` rather than inside `internal/api/app.go`'s per-session paths.
+
+- [ ] **Step 1: Read the existing supervisor boot site**
+
+Run: `grep -n "api.NewApp\|appCloser" internal/server/server.go`
+Identify line ~507 where `app := api.NewApp(...)` is called and the `appCloser` defer chain is established. The DB proxy boot block lands immediately after `app := api.NewApp(...)`. Read the surrounding 30 lines to confirm the policyLoader / engine / store names available in scope.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `internal/api/db_proxy_test.go`:
+
+```go
+package api
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	dbservice "github.com/agentsh/agentsh/internal/db/service"
+)
+
+func TestStartDBProxy_Off_NoListener(t *testing.T) {
+	dir := t.TempDir()
+	deps := dbProxyDeps{
+		Unavoidability: dbservice.UnavoidabilityOff,
+		Services:       nil,
+		StateDir:       dir,
+		Sink:           &events.SyncSink{},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv, err := startDBProxy(ctx, deps)
+	if err != nil {
+		t.Fatalf("startDBProxy: %v", err)
+	}
+	if srv == nil {
+		t.Fatal("startDBProxy returned nil")
+	}
+	if err := srv.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}
+
+func TestStartDBProxy_Observe_BindsListener(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "appdb.sock")
+	deps := dbProxyDeps{
+		Unavoidability: dbservice.UnavoidabilityObserve,
+		Services: []dbProxyService{{
+			Name:       "appdb",
+			DBService:  policy.DBService{Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "127.0.0.1:5432", TLSMode: "terminate_reissue"},
+			ListenKind: "unix",
+			ListenPath: sockPath,
+		}},
+		StateDir: dir,
+		Sink:     &events.SyncSink{},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv, err := startDBProxy(ctx, deps)
+	if err != nil {
+		t.Fatalf("startDBProxy: %v", err)
+	}
+	defer srv.Shutdown(context.Background())
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(sockPath); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("listener never bound at %q", sockPath)
+}
+
+func TestStartDBProxy_Observe_NoServices_Errors(t *testing.T) {
+	deps := dbProxyDeps{
+		Unavoidability: dbservice.UnavoidabilityObserve,
+		Services:       nil,
+		StateDir:       t.TempDir(),
+		Sink:           &events.SyncSink{},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if _, err := startDBProxy(ctx, deps); err == nil {
+		t.Fatal("startDBProxy (observe, no services): want error, got nil")
+	}
+}
+```
+
+(Add `os` import.)
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `go test ./internal/api/ -run TestStartDBProxy -v`
+Expected: FAIL with "undefined: dbProxyDeps" / "undefined: startDBProxy".
+
+- [ ] **Step 4: Implement `internal/api/db_proxy.go`**
+
+```go
+package api
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/proxy/postgres"
+	dbservice "github.com/agentsh/agentsh/internal/db/service"
+)
+
+// dbProxyService is the per-service input to startDBProxy. The api layer
+// joins the listener config (from internal/db/service) with the policy-side
+// DBService (from internal/db/policy) into this flat shape so the proxy
+// package never has to import internal/db/service's listener types.
+type dbProxyService struct {
+	Name       string
+	DBService  policy.DBService
+	ListenKind string // "unix" or "tcp"
+	ListenPath string // when ListenKind == "unix"
+	ListenHost string // when ListenKind == "tcp"
+	ListenPort int    // when ListenKind == "tcp"
+}
+
+type dbProxyDeps struct {
+	Unavoidability dbservice.Unavoidability
+	Services       []dbProxyService
+	StateDir       string
+	Sink           events.Sink
+}
+
+// startDBProxy constructs and starts the AgentSH PostgreSQL proxy. Returns
+// the *Server so the caller can wire Shutdown into supervisor lifecycle.
+//
+// Plan 04a: under Unavoidability == off, returns a sentinel server that
+// does nothing. Under observe/enforce, binds Unix-socket listeners.
+func startDBProxy(ctx context.Context, deps dbProxyDeps) (*postgres.Server, error) {
+	cfg := postgres.Config{
+		Unavoidability: deps.Unavoidability,
+		StateDir:       deps.StateDir,
+		Sink:           deps.Sink,
+	}
+	for _, s := range deps.Services {
+		cfg.Services = append(cfg.Services, postgres.Service{
+			Name:     s.Name,
+			Family:   s.DBService.Family,
+			Dialect:  s.DBService.Dialect,
+			Upstream: s.DBService.Upstream,
+			TLSMode:  s.DBService.TLSMode,
+			Listen: postgres.ServiceListener{
+				Kind: s.ListenKind,
+				Path: s.ListenPath,
+				Host: s.ListenHost,
+				Port: s.ListenPort,
+			},
+			Service: s.DBService,
+		})
+	}
+	srv, err := postgres.New(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("startDBProxy: new server: %w", err)
+	}
+	go func() {
+		if err := srv.Start(ctx); err != nil {
+			// Log via the supervisor's logger; not propagated here because
+			// Start runs for the lifetime of ctx. Shutdown is the merge point.
+			_ = err
+		}
+	}()
+	return srv, nil
+}
+```
+
+- [ ] **Step 5: Wire `startDBProxy` into the supervisor boot site**
+
+In `internal/server/server.go`, just after the `app := api.NewApp(...)` call (line ~507) and the `appCloser` defer block, add:
+
+```go
+// DB proxy (Phase 1, Plan 04a). Bound only when policies.db.unavoidability != off.
+// The DB rule set is loaded lazily by policyLoader.Engine() — read it once at
+// boot. If the operator changes the unavoidability flag at runtime, a SIGHUP
+// reload will rewire the proxy in a later plan.
+{
+	rs := loadDBRuleSet(policyLoader) // helper added below; returns *dbpolicy.RuleSet or nil
+	deps := dbProxyDeps{
+		Unavoidability: dbRuleSetUnavoidability(rs),
+		StateDir:       cfg.StateDir, // verify the field name in cfg; fall back to filepath.Join(cfg.Sessions.BaseDir, "state") if absent
+		Sink:           dbevents.NopSink{},
+		Services:       collectDBProxyServices(policyLoader), // helper joins listener + DBService entries
+	}
+	dbSrv, err := startDBProxy(ctx, deps)
+	if err != nil {
+		return nil, fmt.Errorf("start db proxy: %w", err)
+	}
+	prevAppCloser := appCloser
+	appCloser = func() {
+		_ = dbSrv.Shutdown(context.Background())
+		if prevAppCloser != nil {
+			prevAppCloser()
+		}
+	}
+}
+```
+
+Define the two helpers `loadDBRuleSet` and `collectDBProxyServices` and `dbRuleSetUnavoidability` in `internal/api/db_proxy.go`. They wrap `policyLoader.Engine()` (or whichever method exposes the loaded `*internal/policy.Policy`), call `dbpolicy.Decode(p)` to get a `*dbpolicy.RuleSet`, and assemble the `[]dbProxyService` slice from the parsed `db_services` listener entries.
+
+If the supervisor boot site uses an early-return pattern instead of `appCloser`, mirror its style — the goal is "Shutdown is called once on supervisor teardown."
+
+The exact `cfg` field for state dir: confirm against `internal/config/config.go`. If neither `cfg.StateDir` nor `cfg.Sessions.BaseDir` is the right place to persist the (still-Plan-04b) CA, use `filepath.Join(os.UserConfigDir(), "agentsh", "state")` as a Plan 04a placeholder; Plan 04b will revisit when the CA actually persists.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `go test ./internal/api/ -run TestStartDBProxy -v`
+Expected: PASS for all three subtests.
+
+Run: `go test ./internal/api/...`
+Expected: no regressions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/api/db_proxy.go internal/api/db_proxy_test.go internal/server/server.go
+git commit -m "$(cat <<'EOF'
+api: wire AgentSH PostgreSQL proxy into supervisor boot
+
+Plan 04a Task 7. startDBProxy joins the policy-side DBService with the
+listener-side config and constructs a postgres.Server, starting it under
+the supervisor's ctx and registering Shutdown into the supervisor's
+shutdown chain. Bound only when policies.db.unavoidability != off and at
+least one db_service is declared.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Final verification
+
+**Why:** Belt-and-suspenders pass before declaring 04a done.
+
+**Files:** None (verification only).
+
+- [ ] **Step 1: Run the full repo test suite**
+
+Run: `go test ./...`
+Expected: all pass on Linux. Pre-existing flakes documented in `MEMORY.md` (e.g. `TestFlushLoop_PeriodicSync`) are not regressions; rerun once if they trip.
+
+- [ ] **Step 2: Run cross-compile for Windows and macOS**
+
+Run: `GOOS=windows go build ./...`
+Expected: build success.
+
+Run: `GOOS=darwin go build ./...`
+Expected: build success.
+
+- [ ] **Step 3: Manual `nc -U` smoke test (informational)**
+
+Build a tiny driver under `cmd/dbproxy-smoke/main.go` (do **not** commit) that constructs a `postgres.Server` with one Unix-socket service, starts it, prints the socket path, and waits for SIGINT. Run it and connect with `nc -U <path>`; observe the connection accepting and immediately closing. Verify a `db_listener_auth_fail` event lands when running `nc -U` from a different user (skip if no second user is available).
+
+- [ ] **Step 4: Confirm roborev between-tasks per project memory**
+
+Per `feedback_roborev_between_tasks.md`: run roborev review after each major step before proceeding. Run `roborev-review-branch` on the current branch and address any findings above `low` severity before merging.
+
+- [ ] **Step 5: Update plan checkboxes**
+
+Confirm every checkbox above this section is checked. Open follow-up tasks for any defect found during verification.
+
+- [ ] **Step 6: Final commit (only if any verification fixes were needed)**
+
+```bash
+git status
+# If clean, nothing to commit. Otherwise:
+git add <files>
+git commit -m "db: Plan 04a verification fixes
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+"
+```
+
+---
+
+## Out-of-scope reminders (do NOT do in Plan 04a)
+
+- pgproto3 framing or any startup-packet handling — Plan 04b.
+- `internal/db/tlsleaf` package, CA generation, leaf reissue — Plan 04b.
+- TLS modes (`terminate_reissue`, `passthrough`, `terminate_plaintext_upstream`) — Plan 04b.
+- SSLRequest / GSSENCRequest / CancelRequest / StartupMessage dispatch — Plan 04b.
+- Replication detection and degraded_visibility_warning emission — Plan 04b.
+- Connect-kind connection-rule evaluation — Plan 04b (just consume Plan 02's `EvaluateConnection`).
+- Upstream TCP connect, auth-byte forwarding, SCRAM-SHA-256-PLUS detection — Plan 04b.
+- `'Q'` frame classify + evaluate, RFQ tracker, deny synthesis, eventbuilder, redaction tiers, `statement_digest`, `MaxQueryBytes` — Plan 04c.
+- `approve` runtime, `db_handshake_fail`, `degraded_visibility_warning` (these are 04b/04c kinds reserved on `LifecycleEvent` but emitted later).
+- Out-of-process proxy under distinct SessionID, SO_PEERCRED → SessionID resolution, unavoidability bundle (network/file rules) generation, real-PG integration tests — Plan 07.
+
+The `LifecycleEvent.Kind` values reserved here for later plans (`db_handshake_fail`, `degraded_visibility_warning`) are documented in this plan but only `db_listener_auth_fail` is emitted in 04a.

--- a/docs/superpowers/specs/2026-05-08-db-access-phase-1-roadmap-design.md
+++ b/docs/superpowers/specs/2026-05-08-db-access-phase-1-roadmap-design.md
@@ -10,15 +10,15 @@ This document is the *roadmap*, not the spec. It commits to plan decomposition, 
 
 ## 1. Decomposition
 
-Seven plans. Plans 01–03 are pure libraries; Plan 04 introduces the first socket; Plans 05–06 are siblings on top of Plan 04; Plan 07 closes the loop with unavoidability and integration tests.
+Seven plans, with Plan 04 split into three sub-plans during 2026-05-10 brainstorming. Plans 01–03 are pure libraries; Plan 04a introduces the first socket (no protocol semantics); Plan 04b adds handshake and TLS; Plan 04c adds the Simple Query path; Plans 05–06 are siblings on top of Plan 04c; Plan 07 closes the loop with unavoidability and integration tests.
 
 ```
 [01 taxonomy/effects]──┐
                        ├─→[03 pg classifier]─┐
 [02 policy evaluator]──┘                     │
-                                             ├─→[04 wire+simple+startup+TLS]─┬─→[05 extended+tx]─┐
-                                                                             ├─→[06 cancel mapping]─┤
-                                                                                                  └─→[07 unavoidability+listener+integration]
+                                             ├─→[04a listener]─→[04b handshake+TLS]─→[04c simple+events]─┬─→[05 extended+tx]─┐
+                                                                                                         ├─→[06 cancel mapping]─┤
+                                                                                                                              └─→[07 unavoidability+listener-hardening+integration]
 ```
 
 Dependency notes:
@@ -26,14 +26,16 @@ Dependency notes:
 - Plan 01 unblocks Plans 02 and 03.
 - Plan 02 depends only on Plan 01 — it operates on `ClassifiedStatement`, which Plan 01 defines.
 - Plan 03 depends on Plans 01 and 02. The §23.1 golden corpus rows include `expected_decision_under_sample_policy`, so Plan 02's evaluator and `corpus/sample-policy.yaml` must be merged before Plan 03's CI gate can be wired.
-- Plan 04 depends on Plans 01–03 — Simple Query path is meaningful only when classifier and evaluator exist.
-- Plans 05 and 06 are siblings on top of Plan 04. Extended Query / transaction state (Plan 05) and CancelRequest mapping (Plan 06) touch different parts of the proxy and may proceed in parallel after Plan 04 lands.
-- Plan 07 depends on Plans 04–06 — integration tests need a real proxy.
+- **Plan 04 was split during brainstorming on 2026-05-10** when the unified scope became too large for a single plan. The three sub-plans are sequential: 04a (listener skeleton, no protocol), 04b (handshake + TLS + upstream auth), 04c (Simple Query + DBEvent emission). The shared design doc `2026-05-10-db-plan-04-pg-proxy-skeleton-design.md` covers all three; each sub-plan has its own implementation plan.
+- Plan 04a depends on Plans 01–02 only (no classifier needed for an empty listener). Plan 04b depends on 04a. Plan 04c depends on 04b and on Plan 03 (Simple Query path needs the classifier).
+- Plans 05 and 06 are siblings on top of Plan 04c. Extended Query / transaction state (Plan 05) and CancelRequest mapping (Plan 06) touch different parts of the proxy and may proceed in parallel after Plan 04c lands.
+- Plan 07 depends on Plans 04c–06 — integration tests need a real proxy.
 
 Externally visible behavior:
 
 - Plans 01–03 ship on `main` with no behavior change (types, pure functions, CLI tool only).
-- Plan 04 introduces recognition of `db_services` config and the first proxy listener, gated behind `policies.db.unavoidability: off` (default).
+- Plans 04a–04c ship behind `policies.db.unavoidability: off` (default). With flag = `off`, no listener is bound and the package is a no-op. With flag = `observe`, listeners bind from Plan 04a, complete handshakes from Plan 04b, and emit `db_statement` events from Plan 04c.
+- Plan 04c introduces recognition of `db_services` config end-to-end (declared services intercept queries when flag is `observe`).
 - Plan 07 ships the unavoidability bundle and makes `enforce` the recommended high-assurance default.
 
 ## 2. Package layout
@@ -126,22 +128,63 @@ Tests: corpus-driven; backend cross-validation tests where libpg_query and fallb
 
 External behavior: new CLI binary; no runtime change.
 
-### Plan 04 — `db-plan-04-pg-proxy-skeleton.md`
+### Plan 04 — split into 04a / 04b / 04c during 2026-05-10 brainstorming
 
-Spec-§: 7.1, 8, 11.1, 11.2, 11.3, 13; §23.4 steps 5+7.
+The unified Plan 04 was split into three sub-plans during brainstorming when the combined scope (framing + handshake + TLS + simple-query + listener auth + events) became too large for a single plan. The shared design doc `2026-05-10-db-plan-04-pg-proxy-skeleton-design.md` covers all three sub-plans; each has its own implementation plan file. Spec-section coverage and roadmap §23.4 step coverage are unchanged in aggregate.
+
+#### Plan 04a — `db-plan-04a-listener-skeleton.md`
+
+Spec-§: 11.3 (listener part), 12.5 (UID-only listener auth subset); §23.4 step 5 (skeleton work).
 
 Deliverables:
 
-- `internal/db/proxy/postgres/` (`//go:build linux`): pgproto3 framing, StartupMessage / SSLRequest / GSSENCRequest / CancelRequest dispatch (§11.1 with R6 passthrough begins at StartupMessage acceptance).
-- TLS modes `terminate_reissue`, `passthrough` (connection-level rules only), `terminate_plaintext_upstream` per §13. R9 SNI footnote captured: SNI under passthrough is best-effort. Connection-level deny across modes per §13.3.
-- Simple Query path: invokes Plan 03's classifier and Plan 02's evaluator; emits `DBEvent` (§8). No transaction state yet — first deny in tx falls back to the simplest mode.
-- Replication and GSSENC: default-deny per §11.1.
-- `db_services` recognition: declared service produces a `dest` rule plus a Unix-socket listener via Plan 01's `service` package. Listener auth in this plan is UID-match only; Plan 07 hardens it.
-- Feature flag: `policies.db.unavoidability: enforce | observe | off`, default `off`.
+- `internal/db/service/flag.go`: `Unavoidability` enum (`off | observe | enforce`); `internal/policy/load.go` parses `policies.db.unavoidability`.
+- `internal/db/proxy/postgres/` package skeleton (`//go:build linux`); non-Linux stub returning `errors.ErrUnsupported`.
+- `Server` lifecycle: `New` / `Start` / `Shutdown`; binds Unix-socket listeners per declared `db_service`, accept loop, graceful drain, listener cleanup. Sentinel-server short-circuit when flag = `off`.
+- SO_PEERCRED + UID-equality listener auth on Linux; emits `db_listener_auth_fail` event on mismatch and silently closes.
+- `internal/db/events/sink.go`: `Sink` interface, `NopSink`, in-memory `SyncSink` test fake.
+- `internal/db/policy/validate.go` extension: reject connection rules under `tls_mode: passthrough` that match passthrough-invisible fields (`db_user`, `database`, `application_name`).
+- `internal/api` wiring: instantiate `Server` at startup when flag != `off` and `db_services` non-empty.
 
-Tests: in-process pgproto3 round-trip tests; redaction-level tests; deny pre-forward semantics (§14.4 R18 — pre-deny upstream responses still forward to client).
+Tests: bind/unbind, peercred mismatch, peercred match, shutdown drains in-flight, sentinel server is no-op, validate.go rejects passthrough-invisible field rules.
 
-External behavior: declared services are intercepted when flag is `observe`; `enforce` not yet recommended.
+External behavior under flag = `observe`: declared `db_service` listener exists; connections are accepted from the right uid and immediately closed (no protocol code yet).
+
+#### Plan 04b — `db-plan-04b-handshake-tls.md`
+
+Spec-§: 7.1 (framing), 11.1 (startup-packet dispatch), 11.3 (handshake parts), 13 (TLS modes); §23.4 step 5 (handshake/TLS work) + step 7 (degraded-visibility events).
+
+Deliverables:
+
+- pgproto3 dependency (`github.com/jackc/pgx/v5/pgproto3`) and per-connection framing wrappers.
+- `internal/db/tlsleaf/`: lazy self-signed CA (load-or-create under StateDir) + per-hostname leaf issuer with in-process LRU cache.
+- Startup-packet dispatch: `SSLRequest`, `GSSENCRequest`, `CancelRequest`, `StartupMessage`.
+- Three TLS modes: `terminate_reissue`, `terminate_plaintext_upstream` (with config-load loopback/RFC1918 check), `passthrough` (with best-effort SNI extraction and `degraded_visibility_warning` at first connect).
+- Replication detection → default-deny; opt-in path enters byte-passthrough and emits `degraded_visibility_warning`.
+- `connect`-kind connection-rule evaluation via Plan 02's existing `policy.EvaluateConnection`. `cancel`-kind eval too; CancelRequest forwards un-mapped (Plan 06 owns mapping).
+- Upstream TCP connect + auth-byte forwarding; SCRAM-SHA-256-PLUS detection at upstream auth → fail-closed with `db_handshake_fail` event.
+
+Tests: per-mode TLS round-trip with fake upstream, SCRAM fail-closed, replication default-deny, cancel un-mapped forward, degraded_visibility events.
+
+External behavior under flag = `observe`: clients can complete a handshake and reach `ReadyForQuery` through the proxy. The proxy then drops the connection because no statement path exists yet.
+
+#### Plan 04c — `db-plan-04c-simple-query-events.md`
+
+Spec-§: 8 (DBEvent), 11.2 (architecture diagram for simple-query parts), 14.1 / 14.4 (Simple Query semantics, pre-forward); §23.4 step 5 (statement path) + step 7 (DBEvent emission).
+
+Deliverables:
+
+- RFQ status-byte tracker per connection (one byte; updated on observed `ReadyForQuery` from upstream).
+- `'Q'` frame classify (Plan 03's `Parser`) + evaluate (Plan 02's `Evaluate`) per-statement; multi-statement parse-all-before-forward.
+- Deny synthesis: `ErrorResponse` + `ReadyForQuery('I')` locally when out-of-tx; in-tx terminate (close upstream + client) when `lastUpstreamRFQ ∈ {T, E}`.
+- `approve` → `deny + APPROVE_NOT_YET_SUPPORTED` runtime stub + config-load warning when any rule has `decision: approve`.
+- Frame budget cap (`MaxQueryBytes`, default 1 MiB) → synthetic `54000` + close.
+- Eventbuilder: `ClassifiedStatement` + `Decision` → `DBEvent` with redaction tiers (`full` / `parameters_redacted` / `none`); `statement_digest` = SHA-256 of the normalized form.
+- Spine integration test: real `jackc/pgx/v5` client → real `Server` (terminate_reissue) → fake upstream goroutine; assert query result reaches client + one `db_statement` event in `SyncSink`.
+
+Tests: classify+evaluate+forward (allow/audit), deny synth out-of-tx, in-tx terminate, multi-statement deny semantics, approve→deny stub, redaction tiers, statement_digest stability across tiers, spine round-trip.
+
+External behavior under flag = `observe`: declared services intercept `SELECT 1` (allow) and a denied `DELETE` (deny synth); operators see `db_statement` events; `enforce` not yet recommended (unavoidability bundle is Plan 07).
 
 ### Plan 05 — `db-plan-05-pg-extended-tx.md`
 

--- a/docs/superpowers/specs/2026-05-10-db-plan-04-pg-proxy-skeleton-design.md
+++ b/docs/superpowers/specs/2026-05-10-db-plan-04-pg-proxy-skeleton-design.md
@@ -23,7 +23,7 @@ This document captures the package-shape, lifecycle, and interface decisions the
 - Feature flag `policies.db.unavoidability: enforce | observe | off`, default `off`. With `off`, listeners are **not** bound — package is a no-op. With `observe` or `enforce`, listeners bind and the full simple-query path runs. Plan 04 does **not** generate the unavoidability bundle (network/file rules); that is Plan 07.
 - DBEvent emission via a new `events.Sink` interface declared in the existing `internal/db/events` package, with a thin adapter to `internal/audit.SinkChain` and an in-memory test fake.
 - Self-signed AgentSH-DB CA: `internal/db/tlsleaf/`. Lazily generated and persisted under the AgentSH state dir (path injected, not hard-coded). Leaves issued at connect time per upstream hostname, cached per-process. SCRAM-SHA-256-PLUS detected at upstream auth → fail-closed with structured error.
-- Connection-level rule evaluation hook (a small extension to `internal/db/policy`'s `RuleSet` to evaluate `database_connection_rules` for `connect`-kind matches).
+- Wire `internal/db/policy.EvaluateConnection` (already shipped in Plan 02) into the proxy at handshake time, with per-TLS-mode field-visibility validation extending Plan 02's existing `validate.go`.
 
 ### Out of scope (deferred to later plans)
 
@@ -71,7 +71,8 @@ internal/db/events/                          (existing — extended)
 └── audit_adapter.go                         NEW: adapter that emits DBEvent through internal/audit.SinkChain
 
 internal/db/policy/                          (existing — extended)
-└── connect.go                               NEW: EvaluateConnect(ConnectionContext, RuleSet) → ConnectionDecision
+└── validate.go                              MODIFIED: reject connection rules under tls_mode: passthrough that match passthrough-invisible fields (db_user, database, application_name)
+                                                                        EvaluateConnection itself is already shipped in Plan 02 and used as-is.
 
 internal/db/service/                         (existing — extended; minor)
 └── flag.go                                  NEW: Unavoidability enum (off|observe|enforce) parsed from policies.db.unavoidability
@@ -82,7 +83,7 @@ internal/api/                                MODIFIED: at startup, if Unavoidabi
 
 ### Boundary calls
 
-- `internal/db/proxy/postgres` depends on `effects`, `policy` (incl. new `connect.go`), `classify/postgres`, `events` (incl. new `Sink`), `service`, `tlsleaf`. It does **not** import `internal/api`, `internal/audit`, or `internal/proxy`. The supervisor wiring lives in `internal/api`.
+- `internal/db/proxy/postgres` depends on `effects`, `policy` (consuming the existing `EvaluateConnection` and `Evaluate` plus a small `validate.go` extension), `classify/postgres`, `events` (incl. new `Sink`), `service`, `tlsleaf`. It does **not** import `internal/api`, `internal/audit`, or `internal/proxy`. The supervisor wiring lives in `internal/api`.
 - `internal/db/tlsleaf` is its own package because it is reusable by Plans 05/06 and trivially testable in isolation.
 - `events.Sink` lives in the existing `internal/db/events` package (not in `proxy/postgres`) so the audit adapter does not pull the proxy package into the audit graph.
 - `peercred_linux.go` uses Go's `_linux` filename suffix; no explicit build tag required.

--- a/docs/superpowers/specs/2026-05-10-db-plan-04-pg-proxy-skeleton-design.md
+++ b/docs/superpowers/specs/2026-05-10-db-plan-04-pg-proxy-skeleton-design.md
@@ -1,0 +1,373 @@
+# db-access Plan 04 — PostgreSQL Proxy Skeleton (design)
+
+Status: design approved 2026-05-10. Implementation plan to follow via writing-plans.
+
+Cross-references:
+- Roadmap: `docs/superpowers/specs/2026-05-08-db-access-phase-1-roadmap-design.md` §3 Plan 04.
+- Spec: `docs/agentsh-db-access-spec.md` v0.8 §7.1 (wire framing), §8 (DBEvent), §11 (interception architecture), §13 (TLS), §14.1 / §14.4 (Simple Query and pre-forward semantics).
+- Predecessors: Plans 01–03 already shipped (`internal/db/effects`, `internal/db/policy`, `internal/db/events` skeleton, `internal/db/service` config schema, `internal/db/classify/postgres`).
+
+This document captures the package-shape, lifecycle, and interface decisions the spec leaves to the implementer for the first plan that introduces a wire-protocol surface. The §11 architecture and §13 TLS-mode contracts are authoritative upstream and are not re-derived here.
+
+## 1. Scope
+
+### In scope
+
+- New package `internal/db/proxy/postgres/` (`//go:build linux`; non-Linux stub returns `errors.ErrUnsupported`).
+- pgproto3 framing for client-facing and upstream-facing wire I/O.
+- Startup-packet dispatch: `SSLRequest`, `GSSENCRequest`, `CancelRequest`, normal `StartupMessage` (§11.1).
+- Three TLS modes per service: `passthrough`, `terminate_reissue`, `terminate_plaintext_upstream` (§13). Connection-level deny across modes (§13.3).
+- Simple Query (`Q`) path only: classify → evaluate → forward-or-synthesize-deny → emit `DBEvent`.
+- Default-deny replication and GSSENC; opt-in surfaces present and rule-evaluated but the proxy does no replication-protocol work — it enters byte-level passthrough on accept.
+- `db_services` config recognition: at proxy boot, each declared service gets a Unix-socket listener bound at the configured path with `0700` perms; the proxy `accept()`s, reads `SO_PEERCRED` and verifies `peer_uid == proxy_uid`. (TCP listeners supported for tests but flagged in docs as test-only; UID match is meaningless without SO_PEERCRED on TCP.)
+- Feature flag `policies.db.unavoidability: enforce | observe | off`, default `off`. With `off`, listeners are **not** bound — package is a no-op. With `observe` or `enforce`, listeners bind and the full simple-query path runs. Plan 04 does **not** generate the unavoidability bundle (network/file rules); that is Plan 07.
+- DBEvent emission via a new `events.Sink` interface declared in the existing `internal/db/events` package, with a thin adapter to `internal/audit.SinkChain` and an in-memory test fake.
+- Self-signed AgentSH-DB CA: `internal/db/tlsleaf/`. Lazily generated and persisted under the AgentSH state dir (path injected, not hard-coded). Leaves issued at connect time per upstream hostname, cached per-process. SCRAM-SHA-256-PLUS detected at upstream auth → fail-closed with structured error.
+- Connection-level rule evaluation hook (a small extension to `internal/db/policy`'s `RuleSet` to evaluate `database_connection_rules` for `connect`-kind matches).
+
+### Out of scope (deferred to later plans)
+
+- Extended Query (`Parse`/`Bind`/`Describe`/`Execute`/`Sync`/`Flush`/`Close`), SQL-level prepared cache, COPY data-frame handling, full transaction state machine, function-call escalation — Plan 05.
+- `CancelRequest` mapping table — Plan 06. Plan 04 receives `CancelRequest`, evaluates connection rules with `match_kind: cancel`, and either drops or forwards to upstream **un-mapped**. This is broken-by-design until Plan 06 lands; documented in plan release notes.
+- SO_PEERCRED → SessionID resolution, supervisor-spawned proxy under distinct SessionID, unavoidability bundle generation, integration test suite — Plan 07.
+
+## 2. Architectural decisions
+
+These decisions were settled during brainstorming and govern the rest of the design.
+
+**D1. In-process library; Plan 07 lifts it.** Spec §12.4 mandates a separate-process proxy under a distinct SessionID, but the unavoidability bundle (which requires that distinct SessionID for egress denial) is explicitly Plan 07's deliverable. Plan 04 ships `internal/db/proxy/postgres` as a library with a `Server` type that the existing supervisor process (`internal/api`) instantiates and runs. Listener auth is SO_PEERCRED + UID-equality only. Plan 07 lifts the proxy into its own process and adds SessionID-aware listener auth. Public API is shaped to allow that lift without changing call sites.
+
+**D2. Self-signed CA, lazy, persisted.** A single AgentSH-DB CA at `${StateDir}/db-ca.{key,crt}` (0600 / 0644), generated on first `terminate_reissue` connection, persisted across proxy restarts. Per-hostname leaves issued at connect time and cached in-process (LRU, capacity 256). No auto-distribution: operators copy the CA cert into client `sslrootcert`. SCRAM-SHA-256-PLUS detected at upstream handshake → fail-closed per spec §13.1.
+
+**D3. RFQ-byte-only transaction tracking.** Plan 04 keeps a single byte of per-connection state — the latest `ReadyForQuery` status (`I`/`T`/`E`) observed from upstream — and uses it to switch deny semantics: outside-tx (or pre-auth) denies synthesize `ErrorResponse + ReadyForQuery(I)` locally per §14.4; in-tx denies (`T`/`E`) terminate the connection per §14.3 default. No BEGIN/COMMIT parser, no Extended Query state, no `upstream_dirty_since_sync`. Plan 05 replaces this with the full state machine.
+
+**D4. `events.Sink` interface; thin audit adapter.** `internal/db/events` gains a `Sink` interface (`Emit(ctx, DBEvent) error`), a `NopSink`, and an `audit_adapter.go` that funnels events into the existing `internal/audit.SinkChain`. The proxy depends only on the interface; tests use a `SyncSink` that captures events for assertion. This keeps `internal/db/proxy/postgres` decoupled from `internal/audit` and trivially unit-testable.
+
+**D5. `approve` verb is config-loadable but runtime-blocked.** Plan 04 treats `approve` rules as `deny + APPROVE_NOT_YET_SUPPORTED` because the approval mechanism (out-of-band waiting + timeouts) overlaps Plan 05's in-tx approval handling (§14.5). Config-load surfaces a warning when any rule has `decision: approve` and `Unavoidability != off`, so the operator is told plainly. Live verbs in Plan 04: `allow`, `audit`, `deny`.
+
+## 3. Package layout
+
+```
+internal/db/proxy/postgres/                  //go:build linux
+├── stub_other.go                            //go:build !linux  — Server stub returning errors.ErrUnsupported
+├── server.go                                Server type: lifecycle, listener bind/close, ctx-driven shutdown
+├── conn.go                                  perConnection state: client+upstream net.Conn, pgproto3.Frontend/Backend pair, last upstream RFQ status byte
+├── handshake.go                             startup-packet dispatch (SSLRequest/GSSENC/Cancel/Startup), replication detection
+├── tls.go                                   per-mode TLS plumbing (passthrough/terminate_reissue/terminate_plaintext_upstream)
+├── auth.go                                  upstream auth forwarding; SCRAM-SHA-256-PLUS detection → fail-closed
+├── simplequery.go                           Q-frame classify+evaluate+forward-or-deny loop
+├── deny.go                                  ErrorResponse/ReadyForQuery synthesis; in-tx terminate path
+├── eventbuilder.go                          ClassifiedStatement+Decision → DBEvent (with redaction tier applied)
+├── peercred_linux.go                        SO_PEERCRED + UID-equality listener auth
+└── *_test.go                                in-process pgproto3 round-trip tests, table-driven per file
+
+internal/db/tlsleaf/
+├── ca.go                                    lazy self-signed CA load-or-generate; persisted under StateDir
+├── leaf.go                                  per-hostname leaf issuer with in-process LRU cache
+└── *_test.go
+
+internal/db/events/                          (existing — extended)
+├── sink.go                                  NEW: Sink interface; NopSink; SyncSink test fake
+└── audit_adapter.go                         NEW: adapter that emits DBEvent through internal/audit.SinkChain
+
+internal/db/policy/                          (existing — extended)
+└── connect.go                               NEW: EvaluateConnect(ConnectionContext, RuleSet) → ConnectionDecision
+
+internal/db/service/                         (existing — extended; minor)
+└── flag.go                                  NEW: Unavoidability enum (off|observe|enforce) parsed from policies.db.unavoidability
+
+internal/policy/load.go                      MODIFIED: accept policies.db.unavoidability field
+internal/api/                                MODIFIED: at startup, if Unavoidability != off and Config.DBServices non-empty, instantiate Server and attach to lifecycle
+```
+
+### Boundary calls
+
+- `internal/db/proxy/postgres` depends on `effects`, `policy` (incl. new `connect.go`), `classify/postgres`, `events` (incl. new `Sink`), `service`, `tlsleaf`. It does **not** import `internal/api`, `internal/audit`, or `internal/proxy`. The supervisor wiring lives in `internal/api`.
+- `internal/db/tlsleaf` is its own package because it is reusable by Plans 05/06 and trivially testable in isolation.
+- `events.Sink` lives in the existing `internal/db/events` package (not in `proxy/postgres`) so the audit adapter does not pull the proxy package into the audit graph.
+- `peercred_linux.go` uses Go's `_linux` filename suffix; no explicit build tag required.
+
+## 4. Public surface and lifecycle
+
+`internal/db/proxy/postgres/server.go`:
+
+```go
+type Config struct {
+    Services       []service.Service       // already-validated; from internal/db/service
+    Unavoidability service.Unavoidability  // off|observe|enforce
+    StateDir       string                  // for tlsleaf CA persistence
+    Sink           events.Sink             // events drain here
+    Policy         *policy.Snapshot        // current rule set; reloaded externally, swapped via Server.SetPolicy
+    Classifier     postgres.Parser         // shared classifier (one per process)
+    Logger         *slog.Logger
+    Clock          clock.Clock             // injectable for tests
+    MaxQueryBytes  int                     // default 1 MiB; statements above this get a synthetic 54000 + close
+}
+
+type Server struct { /* unexported state */ }
+
+func New(cfg Config) (*Server, error)                  // validates config; lazy-loads CA if any service uses terminate_reissue
+func (s *Server) Start(ctx context.Context) error      // binds all listeners; returns when first listener fails to bind
+func (s *Server) Shutdown(ctx context.Context) error   // graceful: stop accept, drain in-flight, close listeners
+func (s *Server) SetPolicy(p *policy.Snapshot)         // hot-swap; atomic; takes effect on next statement evaluation
+```
+
+### Lifecycle
+
+1. `New(cfg)` validates `cfg`. If `Unavoidability == off`, returns a sentinel server whose `Start` is a no-op so callers do not have to special-case.
+2. `Start(ctx)` iterates services. For each: validates the listener path's parent dir exists and is owned by current uid; `unix` listener calls `socket(AF_UNIX, SOCK_STREAM)` + `bind` + `chmod(0700)` + `listen`. Per-listener accept loop is its own goroutine; each accepted conn becomes a per-connection goroutine.
+3. `ctx` cancellation triggers shutdown: stop accept, signal in-flight conns to close their client side, drain upstream cleanly, close listeners, unlink Unix socket paths.
+
+### Per-connection flow
+
+```
+accept                                         peercred_linux.go
+  → SO_PEERCRED, peer_uid == proxy_uid?        (deny → close silently + db_listener_auth_fail event)
+  → handshake.go: read first message (4-byte length + body, no type byte)
+      → SSLRequest        → tls.go             negotiate per service.tls_mode
+      → GSSENCRequest     → respond 'N'        (allow_gss_encryption opt-in deferred to Plan 05)
+      → CancelRequest     → policy.EvaluateConnect(match_kind: cancel)
+                                deny  → close
+                                allow → forward un-mapped to upstream (Plan 06 will do mapping)
+      → StartupMessage    → extract user/database/application_name; replication=true → connection-rule eval
+                                replication denied (default) → ErrorResponse(28000) + close
+                                replication allowed → degraded_visibility_warning event + byte-level passthrough
+                                normal → connection-rule eval (match_kind: connect)
+                                  deny  → §13.3 (synthesize ErrorResponse or close TCP)
+                                  allow → upstream connect → simplequery.go
+  → simplequery.go: read frame
+      'Q' (Query) → classify → policy.Evaluate per statement → forward all or synthesize deny
+      'X' (Terminate) → forward + close
+      'p' (Auth response) → forward (during auth phase only)
+      anything else (Parse/Bind/Execute/etc.) → ErrorResponse + close, "Extended Query not supported in Phase 1 build N"
+```
+
+### Shutdown ordering
+
+Listener-stop → per-conn cancel → drain upstream → close client → unlink. Single `errgroup` rooted at the server's ctx; `Shutdown` cancels it and waits with the caller's deadline.
+
+## 5. TLS, CA, and SCRAM-SHA-256-PLUS
+
+### Modes
+
+| Mode | Inbound | Upstream | Visibility |
+|------|---------|----------|------------|
+| `passthrough` | `SSLRequest` → respond `S`, then byte-level passthrough of the encrypted stream both ways. SNI extracted best-effort from ClientHello. | Encrypted bytes forwarded as-is. | Connection-level only; no statement classification. |
+| `terminate_reissue` | `SSLRequest` → respond `S`, then `tls.Server` with leaf reissued for the upstream hostname (CA from `tlsleaf`). | New `tls.Client` to upstream using upstream's actual cert chain (verified via system roots, not our CA). | Full. |
+| `terminate_plaintext_upstream` | Same inbound termination as `terminate_reissue`. | Plaintext to upstream. Config-load rejects this mode if upstream is not loopback / RFC1918. | Full. |
+
+### ClientHello SNI extraction (passthrough only)
+
+A 4 KiB peeked buffer plus a hand-rolled ClientHello parser; no full TLS state machine. If ClientHello is fragmented across records or SNI is absent, the proxy records `sni: null` and continues. SNI is advisory per spec §13.2's footnote.
+
+### `internal/db/tlsleaf` package
+
+```go
+type CA struct { /* unexported */ }
+
+func LoadOrCreate(stateDir string, clock clock.Clock) (*CA, error)
+    // ${stateDir}/db-ca.key (0600), ${stateDir}/db-ca.crt
+    // CN: "AgentSH DB Proxy CA"; 10-year validity; 4096-bit RSA
+    // First call generates; subsequent calls load.
+
+func (c *CA) IssueLeaf(hostname string) (*tls.Certificate, error)
+    // In-process LRU cache, capacity 256; key = hostname.
+    // Leaf: 90-day validity, P-256, SAN = [hostname], rotated on hostname change only.
+```
+
+The CA cert path is logged at `Server.Start` so operators can copy it into client `sslrootcert`. There is no auto-distribution machinery in Plan 04.
+
+### SCRAM-SHA-256-PLUS detection
+
+During upstream auth forwarding (`auth.go`), the proxy parses each `AuthenticationSASL` frame's mechanism list. If the list contains `SCRAM-SHA-256-PLUS`, the proxy:
+
+1. Closes upstream cleanly (does not respond).
+2. Sends `ErrorResponse(SQLSTATE 28000, message="AgentSH DB proxy cannot terminate channel-bound SCRAM (SCRAM-SHA-256-PLUS). Disable channel binding upstream or use TLS passthrough; see docs/agentsh-db-access-spec.md §13.")` to client.
+3. Closes client.
+4. Emits a `db_handshake_fail` DBEvent with `result.error_code: SCRAM_PLUS_FAIL_CLOSED`.
+
+This applies to `terminate_reissue` and `terminate_plaintext_upstream` only; under `passthrough` the proxy never sees the auth frames. Spec §13.1 mandates this fail-closed.
+
+### Connection-rule timing under TLS modes
+
+Connection rules that match only fields visible after StartupMessage (e.g. `db_user`) cannot fire under `passthrough` and are rejected at config-load by Plan 02's existing validator. Plan 04 extends that validator with a small one-line table of which fields are passthrough-invisible. `client_identity` rules can fire pre-handshake; they close the TCP connection and emit no protocol-level error, per §13.3.
+
+## 6. Simple Query path
+
+### Per-connection state (Plan 04 minimum)
+
+```go
+type connState struct {
+    lastUpstreamRFQ byte    // 'I' | 'T' | 'E' | 0 (pre-auth)
+    awaitingAuth    bool
+    sessionID       string
+    dbService       string
+    dbUser          string
+    database        string
+    appName         string
+    clientIdentity  string  // "uid:<peer_uid>" placeholder; Plan 07 swaps in real SessionID
+    sniHostname     string  // passthrough only
+    redactionLevel  events.Redaction  // resolved per-service from policy.Snapshot
+}
+```
+
+`lastUpstreamRFQ` is updated on every observed `ReadyForQuery` byte from upstream (the type-`'Z'` frame, body byte 0). That is the entire transaction-state model in Plan 04. `awaitingAuth` flips to `false` on the first upstream `ReadyForQuery`.
+
+### Simple Query (`Q`) flow
+
+```
+1. Read 'Q' frame from client; body = NUL-terminated SQL string.
+2. Classify via cfg.Classifier.Classify(sql, sessionState{}, opts) → []ClassifiedStatement.
+   sessionState{} is empty: Plan 04 does not track SET search_path / SET ROLE. Spec §7.7 says
+   unqualified objects under no search_path → object_resolution=unresolved, which is fine and
+   matches Plan 03 corpus expectations.
+3. For each ClassifiedStatement:
+     decision = policy.Evaluate(cs, ruleset)
+     append to []decisions
+4. anyDeny := any(decisions[i].verb == deny)
+5. If !anyDeny:
+     forward the original 'Q' frame upstream as-is (no modification — preserves bytes for
+     SCRAM channel-binding edge cases and avoids classifier-vs-server disagreement).
+     emit one DBEvent per ClassifiedStatement with verb from decisions[i] (allow/audit;
+     approve→deny+APPROVE_NOT_YET_SUPPORTED per D5).
+6. If anyDeny:
+     forward NOTHING upstream (per §14.1: parse-all-before-forward).
+     emit one DBEvent per ClassifiedStatement (deny statement gets verb=deny;
+     others verb=denied_by_sibling).
+     synthesize the deny per the RFQ tracker:
+       lastUpstreamRFQ in {0, 'I'}: ErrorResponse + ReadyForQuery('I') → client. Done.
+       lastUpstreamRFQ in {'T', 'E'}: ErrorResponse → client; close upstream + client.
+                                      tx_context.deny_action = "connection_terminated".
+```
+
+### Deny synthesis (`deny.go`)
+
+- `synthesizeDeny(rendered string, code string)` writes one `ErrorResponse{Severity: "ERROR", SQLState: "28000", Message: rendered}` plus `ReadyForQuery{TxStatus: 'I'}`.
+- Rendered message comes from the rule's `deny_message` template (Plan 02 already supports templates) or a default `"denied by AgentSH policy: <rule_name>"`.
+- For terminate-on-tx case: write `ErrorResponse` only; no RFQ; close.
+
+### Frame budget
+
+Simple Query bodies can be large (up to PG's 1 GiB protocol cap). Plan 04 caps client SQL at 1 MiB at the framer (`Server.Config.MaxQueryBytes`, default 1 MiB). Anything bigger gets a synthetic `ErrorResponse(54000, "statement too large for AgentSH proxy: NN bytes > 1 MiB cap")` and connection close. Spec does not mandate this; we adopt a generous-but-bounded cap to avoid memory griefing.
+
+## 7. DBEvent, redaction, and Sink
+
+### `internal/db/events/sink.go` (NEW)
+
+```go
+type Sink interface {
+    Emit(ctx context.Context, ev DBEvent) error
+}
+
+type NopSink struct{}
+func (NopSink) Emit(context.Context, DBEvent) error { return nil }
+
+// SyncSink is in-memory; tests grab events synchronously.
+type SyncSink struct { /* mutex-guarded slice */ }
+func (s *SyncSink) Emit(...) error
+func (s *SyncSink) Drain() []DBEvent
+```
+
+### `internal/db/events/audit_adapter.go` (NEW)
+
+Wraps `internal/audit.SinkChain`. Marshals `DBEvent` to canonical JSON (the existing SinkChain expects an opaque payload + an event-kind tag) and emits with kind `db_statement` (statement events) or `db_lifecycle` (connection events: `db_handshake_fail`, `degraded_visibility_warning`, `db_listener_auth_fail`). The `event_id` field uses UUIDv7 (already imported in Plan 01).
+
+### Event types Plan 04 emits
+
+| Kind | Trigger | Carries |
+|------|---------|---------|
+| `db_statement` | Each ClassifiedStatement in a Simple Query | full §8 envelope (decision, effects, redacted statement_text per redaction tier, `parser_backend` from Plan 03) |
+| `db_handshake_fail` | SCRAM-SHA-256-PLUS detected; replication denied; SSL/GSSENC malformed | minimal envelope: session_id, db_service, client_identity, kind, error_code |
+| `db_listener_auth_fail` | SO_PEERCRED uid mismatch | session_id, db_service, peer_uid, peer_pid (best-effort, may be 0 on Linux variants) |
+| `degraded_visibility_warning` | Replication-allowed connection or `tls_mode: passthrough` first connect | per spec §11.1: `reason: replication_passthrough | tls_passthrough` |
+
+### Redaction tiers (§10.3)
+
+Plan 02's evaluator already produces `redaction_level` per-statement. Plan 04 honors it:
+
+| Tier | `statement_text` |
+|------|------------------|
+| `full` | Verbatim SQL bytes (decoded UTF-8). |
+| `parameters_redacted` (default) | `pg_query_normalize` from libpg_query (Linux+CGO) or `wasilibs/go-pgquery`'s normalize (else). Replaces literals/parameters with `$N` placeholders, leaving structure visible. Non-Linux fall back to a regex-based scrubber over numeric/string literals — documented as best-effort. |
+| `none` | Field omitted entirely. `statement_digest` (SHA-256 of normalized form) still present so events remain joinable. |
+
+`statement_digest` is computed against the *normalized* form for `parameters_redacted` and `none`, and against the verbatim text for `full`. Tests fix the digest's input form so this does not drift.
+
+### `client_identity` in Plan 04
+
+Spec §12.4 says it is the AgentSH SessionID. Plan 07 wires SessionID resolution from SO_PEERCRED → ptrace registry. Plan 04 has SO_PEERCRED but no SessionID lookup, so `client_identity` is set to `"uid:<peer_uid>"` as a stable placeholder. The DBEvent field stays a string (no schema change); Plan 07 swaps in the real SessionID and operators reading event streams see the format flip from `uid:1000` to a session UUID. Documented in plan release notes.
+
+## 8. Testing strategy
+
+### Unit tests, table-driven, per file
+
+| File | What it tests |
+|------|---------------|
+| `handshake_test.go` | Startup-packet dispatch — handcrafted bytes for SSLRequest / GSSENCRequest / CancelRequest / StartupMessage / replication-startup. Asserts correct response and next-state. Uses `net.Pipe()` for client side; no upstream. |
+| `tls_test.go` | Each mode end-to-end with `crypto/tls` client and a fake upstream. Verifies leaf cert chains to the AgentSH CA in reissue mode; verifies plaintext-upstream refuses non-loopback at config-load. |
+| `auth_test.go` | SCRAM-SHA-256-PLUS detection: synthetic upstream `AuthenticationSASL` listing `SCRAM-SHA-256-PLUS`. Asserts client gets `28000` and `db_handshake_fail` event with `SCRAM_PLUS_FAIL_CLOSED`. Mirror test with non-PLUS mech list passes through. |
+| `simplequery_test.go` | Big table of `{sql, policy_yaml, classifier_result_stub, want_forwarded, want_synthesized, want_events}`. Covers allow, audit, deny pre-forward, multi-statement deny, anyDeny→noneForwarded invariant, denied_by_sibling event tagging, `approve→deny+APPROVE_NOT_YET_SUPPORTED`. Classifier injected via `cfg.Classifier`; no real pg_query needed. |
+| `deny_test.go` | RFQ-tracker behavior: lastRFQ ∈ {0, I} → local synth; lastRFQ ∈ {T, E} → terminate. Including a sequence test that simulates `BEGIN` forwarded, `T` observed, then deny → terminate. |
+| `eventbuilder_test.go` | Redaction tiers: `full` round-trips text; `parameters_redacted` matches the libpg_query-normalized form on Linux+CGO and the regex fallback elsewhere; `none` strips text but keeps digest stable across tiers. Has both build-tag variants. |
+| `peercred_linux_test.go` | UID-equality auth: real `socketpair`, real SO_PEERCRED, asserts mismatch → silent close + `db_listener_auth_fail` event. Linux-only. |
+| `tlsleaf/ca_test.go` | LoadOrCreate: first call creates files with 0600 perms; second call loads. Cross-process semantics not tested (single-process is the contract). |
+| `tlsleaf/leaf_test.go` | Issues for hostname A and B; asserts SAN contents, validity windows, cache hit on repeat issue. |
+
+### In-process round-trip test (the "skeleton spine" test)
+
+One end-to-end test in `simplequery_test.go` that wires:
+
+- Real `Server` with one service in `terminate_reissue` mode.
+- Fake upstream: a goroutine speaking `pgproto3.Backend`, accepting one `Q`, replying with one `RowDescription` + `DataRow` + `CommandComplete` + `ReadyForQuery('I')`.
+- Real `pgx` client (test-only dep) connecting via Unix socket through the proxy with the AgentSH CA in its trust store.
+- Asserts: query result reaches client; one `db_statement` DBEvent in `SyncSink`.
+
+This is the "does the whole shape compose" test. Everything else is a unit test against a smaller surface.
+
+### Property tests
+
+None for Plan 04 — the protocol surface here is enumerated, not algebraic. Plan 05's state machine is where property tests pay off.
+
+### Cross-compile
+
+`GOOS=windows go build ./...` runs in CI per CLAUDE.md. The non-Linux stub keeps this green.
+
+### No integration tests with real Postgres in Plan 04
+
+Real-PG integration lives in Plan 07 with testcontainers. Plan 04's spine test uses a fake upstream because we want to be able to inject malformed frames, slow responses, etc., and that is ergonomic only when we own both sides.
+
+### Test isolation
+
+All tests use `t.TempDir()` for the StateDir; no `/tmp` collisions, no test ordering dependencies, no shared CA.
+
+## 9. Open questions and risks
+
+### Open questions to flag (not blockers)
+
+1. **`approve` semantics in observe mode.** With Plan 04 treating `approve` as `deny+APPROVE_NOT_YET_SUPPORTED`, an operator under flag=`observe` can never run any approve workflow — events stream but every approve-targeted statement returns an error to the client. Plan 05's in-tx approval (§14.5) brings the actual mechanism. Until then the only "live" verbs are `allow`, `audit`, `deny`.
+2. **CancelRequest without mapping.** Plan 04 evaluates connection rules for `match_kind: cancel` but forwards the `CancelRequest` un-mapped (with the client's syn_pid/syn_secret). Upstream rejects these because they do not match a real backend. Broken-by-design until Plan 06; documented in release notes.
+3. **GSSENC opt-in deferred to Plan 05.** Spec §11.1 supports `allow_gss_encryption: true` per service. The config field is parsed (no error on load) but ignored in Plan 04. Every GSSENCRequest gets `'N'`.
+4. **`statement_digest` algorithm choice.** SHA-256 of the normalized form. Spec §8 does not pin an algorithm; we declare it here for cross-event joinability.
+5. **CA persistence path.** `${StateDir}/db-ca.{key,crt}`. If the host operator rotates the AgentSH state dir, the CA regenerates and clients with the old CA pinned will see hostname verification failures. Documented but not solved here.
+
+### Risks
+
+- **Self-signed CA distribution.** Operators install the AgentSH-DB CA into PG client trust stores manually. For agent runtimes that build short-lived containers, this is friction. Mitigation in spec docs only; no code in Plan 04.
+- **`approve→deny` surprise.** An operator pre-loading approve rules expecting them to gate may find every targeted statement failing. Loud, unambiguous error code helps but it is still surprising. Mitigation: a CONFIG-LOAD warning when any rule has `decision: approve` and `Unavoidability != off`.
+- **Connection churn.** RFQ-byte deny→terminate inside `T` can churn connections under chatty agents. Acceptable for Plan 04 rollout (flag=`off` default; `observe` for early adopters). Plan 05 fixes with proper §14.3 modes.
+- **CGO + libpg_query transitively imported by the proxy.** Plan 03 isolated this behind the `Parser` interface; Plan 04 just consumes the interface. CGO build is still required on Linux for `terminate_reissue` to be useful (since classification matters there).
+
+### Deferred
+
+- **To Plan 05.** Extended Query, SQL-level prepared cache, COPY data-frame handling, function-call escalation, full §14 deny flows including `rollback_then_continue`, `approve` runtime, GSSENC opt-in.
+- **To Plan 06.** BackendKeyData mapping table, cancel governance via mapping lookup, R20 commit ordering.
+- **To Plan 07.** Out-of-process proxy under distinct SessionID, SO_PEERCRED → SessionID resolution, unavoidability bundle (network/file rules) generation from `db_services`, real-PG integration tests, bypass-tool detection, recommendation flip to `enforce`.
+
+## 10. Done definition
+
+Plan 04 is done when:
+
+- `internal/db/proxy/postgres` builds on Linux and stubs cleanly elsewhere; `GOOS=windows go build ./...` is green.
+- All unit tests above pass, including the spine in-process round-trip test with real `pgx` against a fake upstream.
+- A YAML config containing `policies.db.unavoidability: observe` and one `db_services` entry causes the supervisor to bind the configured Unix socket; an external `pgx` client with the AgentSH CA installed connects through it, runs a `SELECT`, and observes one `db_statement` event in the audit sink.
+- A YAML config with `policies.db.unavoidability: off` is a no-op: no listener bound, no events emitted, no behavior change from `main`.

--- a/internal/api/db_proxy.go
+++ b/internal/api/db_proxy.go
@@ -1,0 +1,153 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+	dbpolicy "github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/proxy/postgres"
+	dbservice "github.com/agentsh/agentsh/internal/db/service"
+	rootpolicy "github.com/agentsh/agentsh/internal/policy"
+)
+
+// dbProxyService is the per-service input to startDBProxy. The api layer
+// joins the policy-side DBService (from internal/db/policy) with a
+// supervisor-derived listener path into this flat shape so the proxy
+// package never has to know how listener paths are computed.
+type dbProxyService struct {
+	Name       string
+	DBService  dbpolicy.DBService
+	ListenKind string // "unix" or "tcp"
+	ListenPath string // when ListenKind == "unix"
+	ListenHost string // when ListenKind == "tcp"
+	ListenPort int    // when ListenKind == "tcp"
+}
+
+type dbProxyDeps struct {
+	Unavoidability dbservice.Unavoidability
+	Services       []dbProxyService
+	StateDir       string
+	Sink           events.Sink
+}
+
+// buildDBProxyConfig assembles a postgres.Config from deps and ensures
+// listener parent directories exist for unix listeners.
+func buildDBProxyConfig(deps dbProxyDeps) (postgres.Config, error) {
+	cfg := postgres.Config{
+		Unavoidability: deps.Unavoidability,
+		StateDir:       deps.StateDir,
+		Sink:           deps.Sink,
+	}
+	for _, s := range deps.Services {
+		if s.ListenKind == "unix" && s.ListenPath != "" {
+			if err := os.MkdirAll(filepath.Dir(s.ListenPath), 0o700); err != nil {
+				return postgres.Config{}, fmt.Errorf("buildDBProxyConfig: mkdir for service %q listener: %w", s.Name, err)
+			}
+		}
+		cfg.Services = append(cfg.Services, postgres.Service{
+			Name:     s.Name,
+			Family:   s.DBService.Family,
+			Dialect:  s.DBService.Dialect,
+			Upstream: s.DBService.Upstream,
+			TLSMode:  s.DBService.TLSMode,
+			Listen: postgres.ServiceListener{
+				Kind: s.ListenKind,
+				Path: s.ListenPath,
+				Host: s.ListenHost,
+				Port: s.ListenPort,
+			},
+			Service: s.DBService,
+		})
+	}
+	return cfg, nil
+}
+
+// startDBProxy constructs and starts the AgentSH PostgreSQL proxy. Returns
+// the *postgres.Server so the caller can wire Shutdown into supervisor lifecycle.
+//
+// Plan 04a: under Unavoidability == off, returns a sentinel server that
+// does nothing. Under observe/enforce, binds Unix-socket listeners.
+//
+// For unix listeners, the parent directory of each ListenPath is created
+// (mkdir -p style) before bind so a fresh StateDir works on first boot.
+func startDBProxy(ctx context.Context, deps dbProxyDeps) (*postgres.Server, error) {
+	cfg, err := buildDBProxyConfig(deps)
+	if err != nil {
+		return nil, fmt.Errorf("startDBProxy: %w", err)
+	}
+	srv, err := postgres.New(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("startDBProxy: new server: %w", err)
+	}
+	go func() {
+		// Start runs for the lifetime of ctx. Errors are absorbed here
+		// because Shutdown is the merge point; a fatal Start error would
+		// also be visible via the slog handler the caller configured.
+		_ = srv.Start(ctx)
+	}()
+	return srv, nil
+}
+
+// loadDBRuleSet decodes the supervisor's loaded policy into a *dbpolicy.RuleSet.
+// Returns nil when no DB rules are present (decoding succeeds with an empty
+// services map). Errors are returned to the caller; they should be fatal
+// because misconfigured DB policy should not silently disable interception.
+func loadDBRuleSet(p *rootpolicy.Policy) (*dbpolicy.RuleSet, error) {
+	if p == nil {
+		return nil, nil
+	}
+	rs, _, err := dbpolicy.Decode(p)
+	if err != nil {
+		return nil, fmt.Errorf("loadDBRuleSet: decode db policy: %w", err)
+	}
+	return rs, nil
+}
+
+// collectDBProxyServices enumerates every declared db_service in rs and
+// synthesizes the supervisor-derived listener path. Plan 04a convention:
+// ${stateDir}/db-services/${name}.sock for each service.
+func collectDBProxyServices(rs *dbpolicy.RuleSet, stateDir string) []dbProxyService {
+	if rs == nil {
+		return nil
+	}
+	services := rs.AllServices()
+	if len(services) == 0 {
+		return nil
+	}
+	out := make([]dbProxyService, 0, len(services))
+	for _, s := range services {
+		out = append(out, dbProxyService{
+			Name:       s.Name,
+			DBService:  s,
+			ListenKind: "unix",
+			ListenPath: filepath.Join(stateDir, "db-services", s.Name+".sock"),
+		})
+	}
+	return out
+}
+
+// NewDBProxy builds a *postgres.Server from the loaded policy without starting
+// it. The caller is responsible for calling Start(ctx) and eventually Shutdown.
+// This is the supervisor-facing constructor when the lifetime ctx is not yet
+// available at construction time (e.g., inside server.New before server.Run is
+// called).
+func NewDBProxy(p *rootpolicy.Policy, stateDir string, sink events.Sink) (*postgres.Server, error) {
+	rs, err := loadDBRuleSet(p)
+	if err != nil {
+		return nil, err
+	}
+	deps := dbProxyDeps{
+		Unavoidability: rs.Unavoidability(),
+		StateDir:       stateDir,
+		Sink:           sink,
+		Services:       collectDBProxyServices(rs, stateDir),
+	}
+	cfg, err := buildDBProxyConfig(deps)
+	if err != nil {
+		return nil, fmt.Errorf("NewDBProxy: %w", err)
+	}
+	return postgres.New(cfg)
+}

--- a/internal/api/db_proxy_test.go
+++ b/internal/api/db_proxy_test.go
@@ -1,0 +1,83 @@
+//go:build linux
+
+package api
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+	dbpolicy "github.com/agentsh/agentsh/internal/db/policy"
+	dbservice "github.com/agentsh/agentsh/internal/db/service"
+)
+
+func TestStartDBProxy_Off_NoListener(t *testing.T) {
+	dir := t.TempDir()
+	deps := dbProxyDeps{
+		Unavoidability: dbservice.UnavoidabilityOff,
+		Services:       nil,
+		StateDir:       dir,
+		Sink:           &events.SyncSink{},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv, err := startDBProxy(ctx, deps)
+	if err != nil {
+		t.Fatalf("startDBProxy: %v", err)
+	}
+	if srv == nil {
+		t.Fatal("startDBProxy returned nil")
+	}
+	if err := srv.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+}
+
+func TestStartDBProxy_Observe_BindsListener(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "db-services", "appdb.sock")
+	deps := dbProxyDeps{
+		Unavoidability: dbservice.UnavoidabilityObserve,
+		Services: []dbProxyService{{
+			Name:       "appdb",
+			DBService:  dbpolicy.DBService{Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "127.0.0.1:5432", TLSMode: "terminate_reissue"},
+			ListenKind: "unix",
+			ListenPath: sockPath,
+		}},
+		StateDir: dir,
+		Sink:     &events.SyncSink{},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv, err := startDBProxy(ctx, deps)
+	if err != nil {
+		t.Fatalf("startDBProxy: %v", err)
+	}
+	defer srv.Shutdown(context.Background())
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(sockPath); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("listener never bound at %q", sockPath)
+}
+
+func TestStartDBProxy_Observe_NoServices_Errors(t *testing.T) {
+	deps := dbProxyDeps{
+		Unavoidability: dbservice.UnavoidabilityObserve,
+		Services:       nil,
+		StateDir:       t.TempDir(),
+		Sink:           &events.SyncSink{},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if _, err := startDBProxy(ctx, deps); err == nil {
+		t.Fatal("startDBProxy (observe, no services): want error, got nil")
+	}
+}

--- a/internal/db/events/lifecycle.go
+++ b/internal/db/events/lifecycle.go
@@ -1,0 +1,28 @@
+package events
+
+import "time"
+
+// LifecycleEvent is a non-statement DB-proxy event: listener-auth failures,
+// handshake failures (Plan 04b), degraded-visibility warnings (Plan 04b).
+// Carries less data than DBEvent because there is no statement to redact.
+//
+// Kind is a small enumerated string ("db_listener_auth_fail",
+// "db_handshake_fail", "degraded_visibility_warning"); each plan that emits
+// a new kind is responsible for documenting the value in plan release notes.
+type LifecycleEvent struct {
+	EventID        string    `json:"event_id"`
+	SessionID      string    `json:"session_id,omitempty"`
+	Timestamp      time.Time `json:"ts"`
+	DBService      string    `json:"db_service,omitempty"`
+	ClientIdentity string    `json:"client_identity,omitempty"`
+
+	Kind   string `json:"kind"`
+	Reason string `json:"reason,omitempty"`
+
+	// Listener-auth specific (Plan 04a). Zero when not applicable.
+	PeerUID uint32 `json:"peer_uid,omitempty"`
+	PeerPID int32  `json:"peer_pid,omitempty"`
+
+	// Handshake/error specific (Plan 04b). Zero when not applicable.
+	ErrorCode string `json:"error_code,omitempty"`
+}

--- a/internal/db/events/lifecycle_test.go
+++ b/internal/db/events/lifecycle_test.go
@@ -1,0 +1,32 @@
+package events
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestLifecycleEvent_JSONRoundTrip(t *testing.T) {
+	in := LifecycleEvent{
+		EventID:        "01HJ...",
+		SessionID:      "sess-1",
+		Timestamp:      time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC),
+		DBService:      "appdb",
+		ClientIdentity: "uid:1000",
+		Kind:           "db_listener_auth_fail",
+		Reason:         "uid_mismatch",
+		PeerUID:        2000,
+		PeerPID:        12345,
+	}
+	bs, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out LifecycleEvent
+	if err := json.Unmarshal(bs, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out != in {
+		t.Fatalf("round-trip mismatch:\n got %+v\nwant %+v", out, in)
+	}
+}

--- a/internal/db/events/sink.go
+++ b/internal/db/events/sink.go
@@ -1,0 +1,75 @@
+package events
+
+import (
+	"context"
+	"sync"
+)
+
+// Sink is the event emission surface for the DB proxy. Implementations may
+// fan out to a real audit pipeline (production), to nothing (tests that do
+// not care about events), or to an in-memory buffer (unit tests asserting
+// emission). Sinks must be safe for concurrent use.
+//
+// Errors from Emit* are advisory: the proxy logs them at warn but does not
+// fail the connection. Spec §8 is silent on emission durability; Plan 04a
+// adopts best-effort semantics, leaving durability concerns to the audit-
+// pipeline implementation a later plan provides.
+type Sink interface {
+	EmitStatement(ctx context.Context, ev DBEvent) error
+	EmitLifecycle(ctx context.Context, ev LifecycleEvent) error
+}
+
+// NopSink discards every event. Useful when the proxy is wired into a
+// runtime that does not care about audit (tests of unrelated code).
+type NopSink struct{}
+
+func (NopSink) EmitStatement(context.Context, DBEvent) error      { return nil }
+func (NopSink) EmitLifecycle(context.Context, LifecycleEvent) error { return nil }
+
+// SyncSink buffers every emitted event in memory. Tests call DrainStatements
+// or DrainLifecycle to inspect what was emitted. Concurrent use is safe.
+//
+// Drain* returns the buffered events in emission order and resets the buffer.
+// The returned slice is owned by the caller; subsequent Emit calls do not
+// write into it. Callers must not append to the returned slice.
+type SyncSink struct {
+	mu        sync.Mutex
+	stmt      []DBEvent
+	lifecycle []LifecycleEvent
+}
+
+func (s *SyncSink) EmitStatement(ctx context.Context, ev DBEvent) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.stmt = append(s.stmt, ev)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *SyncSink) EmitLifecycle(ctx context.Context, ev LifecycleEvent) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.lifecycle = append(s.lifecycle, ev)
+	s.mu.Unlock()
+	return nil
+}
+
+func (s *SyncSink) DrainStatements() []DBEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := s.stmt
+	s.stmt = nil
+	return out
+}
+
+func (s *SyncSink) DrainLifecycle() []LifecycleEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := s.lifecycle
+	s.lifecycle = nil
+	return out
+}

--- a/internal/db/events/sink_test.go
+++ b/internal/db/events/sink_test.go
@@ -1,0 +1,84 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNopSink_EmitNeverFails(t *testing.T) {
+	s := NopSink{}
+	if err := s.EmitStatement(context.Background(), DBEvent{}); err != nil {
+		t.Fatalf("EmitStatement: %v", err)
+	}
+	if err := s.EmitLifecycle(context.Background(), LifecycleEvent{}); err != nil {
+		t.Fatalf("EmitLifecycle: %v", err)
+	}
+}
+
+func TestSyncSink_DrainReturnsEventsInOrder(t *testing.T) {
+	s := &SyncSink{}
+	for i := 0; i < 3; i++ {
+		if err := s.EmitStatement(context.Background(), DBEvent{EventID: string(rune('A' + i))}); err != nil {
+			t.Fatalf("EmitStatement: %v", err)
+		}
+	}
+	if err := s.EmitLifecycle(context.Background(), LifecycleEvent{Kind: "db_listener_auth_fail"}); err != nil {
+		t.Fatalf("EmitLifecycle: %v", err)
+	}
+	stmts := s.DrainStatements()
+	if len(stmts) != 3 || stmts[0].EventID != "A" || stmts[2].EventID != "C" {
+		t.Fatalf("DrainStatements = %+v", stmts)
+	}
+	if got := s.DrainStatements(); len(got) != 0 {
+		t.Fatalf("DrainStatements after drain = %+v, want empty", got)
+	}
+	lcs := s.DrainLifecycle()
+	if len(lcs) != 1 || lcs[0].Kind != "db_listener_auth_fail" {
+		t.Fatalf("DrainLifecycle = %+v", lcs)
+	}
+}
+
+func TestSyncSink_ConcurrentEmitIsSafe(t *testing.T) {
+	s := &SyncSink{}
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = s.EmitStatement(context.Background(), DBEvent{Timestamp: time.Now()})
+		}()
+	}
+	wg.Wait()
+	if got := len(s.DrainStatements()); got != 100 {
+		t.Fatalf("DrainStatements len = %d, want 100", got)
+	}
+}
+
+func TestSyncSink_ConcurrentLifecycleEmitIsSafe(t *testing.T) {
+	s := &SyncSink{}
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = s.EmitLifecycle(context.Background(), LifecycleEvent{Timestamp: time.Now(), Kind: "db_listener_auth_fail"})
+		}()
+	}
+	wg.Wait()
+	if got := len(s.DrainLifecycle()); got != 100 {
+		t.Fatalf("DrainLifecycle len = %d, want 100", got)
+	}
+}
+
+func TestSyncSink_ContextCancelled_ReturnsError(t *testing.T) {
+	s := &SyncSink{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := s.EmitStatement(ctx, DBEvent{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("EmitStatement err = %v, want context.Canceled", err)
+	}
+}

--- a/internal/db/policy/decode.go
+++ b/internal/db/policy/decode.go
@@ -6,6 +6,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/agentsh/agentsh/internal/db/service"
 	rootpolicy "github.com/agentsh/agentsh/internal/policy"
 )
 
@@ -41,6 +42,10 @@ func Decode(p *rootpolicy.Policy) (*RuleSet, []Warning, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	unavoid, err := decodeUnavoidability(p)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// Phase B.
 	warns, err := validate(svcs, stmtRules, connRules)
@@ -49,7 +54,7 @@ func Decode(p *rootpolicy.Policy) (*RuleSet, []Warning, error) {
 	}
 
 	// Phase C.
-	rs := &RuleSet{services: svcs, redaction: red}
+	rs := &RuleSet{services: svcs, redaction: red, unavoidability: unavoid}
 	for _, r := range stmtRules {
 		c, err := compileStatementRule(r)
 		if err != nil {
@@ -106,12 +111,13 @@ func decodeConnectionRules(n yaml.Node) ([]*ConnectionRule, error) {
 }
 
 // redactionYAML is the on-disk shape of the policies.db block. Only the
-// statement-redaction-related fields are decoded here; the rest of the
+// redaction and unavoidability fields are decoded here; the rest of the
 // policies block is owned by other packages.
 type redactionYAML struct {
 	LogStatements                 string `yaml:"log_statements,omitempty"`
 	ApprovalStatementPreview      string `yaml:"approval_statement_preview,omitempty"`
 	ApprovalStatementPreviewChars int    `yaml:"approval_statement_preview_chars,omitempty"`
+	Unavoidability                string `yaml:"unavoidability,omitempty"`
 }
 
 // dbPoliciesWrapper is the on-disk shape of the policies block as far as
@@ -155,6 +161,26 @@ func decodeRedaction(p *rootpolicy.Policy) (RedactionConfig, error) {
 		out.ApprovalStatementChars = rb.ApprovalStatementPreviewChars
 	}
 	return out, nil
+}
+
+// decodeUnavoidability reads policies.db.unavoidability. Default: UnavoidabilityOff.
+// Unknown values are an error.
+func decodeUnavoidability(p *rootpolicy.Policy) (service.Unavoidability, error) {
+	if p.Policies.IsZero() {
+		return service.UnavoidabilityOff, nil
+	}
+	var w dbPoliciesWrapper
+	if err := strictDecode(p.Policies, &w); err != nil {
+		return service.UnavoidabilityOff, fmt.Errorf("decode policies.db: %w", err)
+	}
+	if w.DB.Unavoidability == "" {
+		return service.UnavoidabilityOff, nil
+	}
+	u, ok := service.ParseUnavoidability(w.DB.Unavoidability)
+	if !ok {
+		return service.UnavoidabilityOff, fmt.Errorf("unknown policies.db.unavoidability: %q", w.DB.Unavoidability)
+	}
+	return u, nil
 }
 
 // parseApprovalPreviewTier handles the §10.3 alias: in approval_statement_preview,

--- a/internal/db/policy/decode_test.go
+++ b/internal/db/policy/decode_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/agentsh/agentsh/internal/db/service"
 	"github.com/agentsh/agentsh/internal/policy"
 )
 
@@ -160,5 +161,82 @@ database_rules:
 	}
 	if !found {
 		t.Errorf("expected audit_on_dangerous warning, got %v", warns)
+	}
+}
+
+func TestDecode_PoliciesDB_Unavoidability(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want service.Unavoidability
+	}{
+		{
+			name: "missing block defaults to off",
+			yaml: `version: 1
+name: test
+`,
+			want: service.UnavoidabilityOff,
+		},
+		{
+			name: "explicit off",
+			yaml: `version: 1
+name: test
+policies:
+  db:
+    unavoidability: off
+`,
+			want: service.UnavoidabilityOff,
+		},
+		{
+			name: "observe",
+			yaml: `version: 1
+name: test
+policies:
+  db:
+    unavoidability: observe
+`,
+			want: service.UnavoidabilityObserve,
+		},
+		{
+			name: "enforce",
+			yaml: `version: 1
+name: test
+policies:
+  db:
+    unavoidability: enforce
+`,
+			want: service.UnavoidabilityEnforce,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rp, err := policy.LoadFromBytes([]byte(tc.yaml))
+			if err != nil {
+				t.Fatalf("LoadFromBytes: %v", err)
+			}
+			rs, _, err := Decode(rp)
+			if err != nil {
+				t.Fatalf("Decode: %v", err)
+			}
+			if got := rs.Unavoidability(); got != tc.want {
+				t.Errorf("Unavoidability() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecode_PoliciesDB_Unavoidability_Unknown(t *testing.T) {
+	yaml := `version: 1
+name: test
+policies:
+  db:
+    unavoidability: bogus
+`
+	rp, err := policy.LoadFromBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+	if _, _, err := Decode(rp); err == nil {
+		t.Fatal("Decode: expected error for unknown unavoidability value, got nil")
 	}
 }

--- a/internal/db/policy/types.go
+++ b/internal/db/policy/types.go
@@ -200,6 +200,20 @@ func (rs *RuleSet) Service(id ServiceID) (DBService, bool) {
 	return *s, true
 }
 
+// AllServices returns a copy of every declared db_service. Order is not
+// guaranteed; callers that need stable ordering should sort by Name.
+// Returns nil when rs is nil.
+func (rs *RuleSet) AllServices() []DBService {
+	if rs == nil || len(rs.services) == 0 {
+		return nil
+	}
+	out := make([]DBService, 0, len(rs.services))
+	for _, s := range rs.services {
+		out = append(out, *s)
+	}
+	return out
+}
+
 // Unavoidability returns the policies.db.unavoidability mode. Returns
 // UnavoidabilityOff when rs is nil so startup code holding a not-yet-loaded
 // *RuleSet does not panic.

--- a/internal/db/policy/types.go
+++ b/internal/db/policy/types.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/agentsh/agentsh/internal/db/effects"
+	"github.com/agentsh/agentsh/internal/db/service"
 )
 
 // ServiceID is the operator-supplied identifier of a db_service.
@@ -170,10 +171,11 @@ type Warning struct {
 // Internals are private; callers consume via Evaluate / EvaluateConnection /
 // Redaction / Service.
 type RuleSet struct {
-	services   map[ServiceID]*DBService
-	statement  []*compiledStatementRule
-	connection []*compiledConnectionRule
-	redaction  RedactionConfig
+	services       map[ServiceID]*DBService
+	statement      []*compiledStatementRule
+	connection     []*compiledConnectionRule
+	redaction      RedactionConfig
+	unavoidability service.Unavoidability
 }
 
 // Redaction returns the policies.db block configuration. Returns the zero
@@ -196,4 +198,14 @@ func (rs *RuleSet) Service(id ServiceID) (DBService, bool) {
 		return DBService{}, false
 	}
 	return *s, true
+}
+
+// Unavoidability returns the policies.db.unavoidability mode. Returns
+// UnavoidabilityOff when rs is nil so startup code holding a not-yet-loaded
+// *RuleSet does not panic.
+func (rs *RuleSet) Unavoidability() service.Unavoidability {
+	if rs == nil {
+		return service.UnavoidabilityOff
+	}
+	return rs.unavoidability
 }

--- a/internal/db/policy/types_test.go
+++ b/internal/db/policy/types_test.go
@@ -1,6 +1,10 @@
 package policy
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
 
 func TestDecisionVerbString(t *testing.T) {
 	cases := []struct {
@@ -68,5 +72,48 @@ func TestParseRedactionTier(t *testing.T) {
 		if got != c.want || ok != c.ok {
 			t.Errorf("ParseRedactionTier(%q) = (%v, %v), want (%v, %v)", c.in, got, ok, c.want, c.ok)
 		}
+	}
+}
+
+func TestRuleSet_AllServices(t *testing.T) {
+	yaml := `version: 1
+name: test
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: terminate_reissue
+  reportsdb:
+    family: postgres
+    dialect: postgres
+    upstream: reports.internal:5432
+    tls_mode: passthrough
+`
+	rp, err := policy.LoadFromBytes([]byte(yaml))
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+	rs, _, err := Decode(rp)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	got := rs.AllServices()
+	if len(got) != 2 {
+		t.Fatalf("AllServices len = %d, want 2", len(got))
+	}
+	seen := map[string]bool{}
+	for _, s := range got {
+		seen[s.Name] = true
+	}
+	if !seen["appdb"] || !seen["reportsdb"] {
+		t.Errorf("AllServices missing expected names: %+v", got)
+	}
+}
+
+func TestRuleSet_AllServices_Nil(t *testing.T) {
+	var rs *RuleSet
+	if got := rs.AllServices(); got != nil {
+		t.Errorf("nil receiver: got %+v, want nil", got)
 	}
 }

--- a/internal/db/policy/validate.go
+++ b/internal/db/policy/validate.go
@@ -162,9 +162,19 @@ func validateConnectionRule(r *ConnectionRule, svcs map[ServiceID]*DBService) ([
 			svc = s
 		}
 	}
-	if svc != nil && svc.TLSMode == "passthrough" {
-		if len(r.DBUser) > 0 || r.Database != "" || r.ApplicationName != "" {
-			errs = append(errs, fmt.Errorf("conn_passthrough_field_unavailable: database_connection_rules[%q]: db_user/database/application_name not visible under passthrough", r.Name))
+	if svc != nil {
+		// Named service: check only that specific service.
+		if err := validateConnectionRuleVsService(r, svc); err != nil {
+			errs = append(errs, err)
+		}
+	} else if r.DBService == "" {
+		// Wildcard rule (no db_service): reject if any passthrough service exists
+		// and the rule uses invisible fields — the rule can never fire there.
+		for _, s := range svcs {
+			if err := validateConnectionRuleVsService(r, s); err != nil {
+				errs = append(errs, fmt.Errorf("%w (triggered by service %q)", err, s.Name))
+				break
+			}
 		}
 	}
 
@@ -207,6 +217,28 @@ func validateConnectionRule(r *ConnectionRule, svcs map[ServiceID]*DBService) ([
 	}
 
 	return errs, warns
+}
+
+// validateConnectionRuleVsService returns a non-nil error if the rule matches
+// a field that is invisible under the service's tls_mode.
+// Per spec §13.2: db_user, database, application_name are not visible under
+// tls_mode: passthrough (they are sent in the StartupMessage after TLS
+// negotiation). client_identity and SNI are visible pre-handshake and remain
+// valid under all tls_mode values.
+func validateConnectionRuleVsService(r *ConnectionRule, svc *DBService) error {
+	if svc.TLSMode != "passthrough" {
+		return nil
+	}
+	if len(r.DBUser) > 0 {
+		return fmt.Errorf("conn_passthrough_field_unavailable: database_connection_rules[%q]: db_user/database/application_name not visible under passthrough", r.Name)
+	}
+	if r.Database != "" {
+		return fmt.Errorf("conn_passthrough_field_unavailable: database_connection_rules[%q]: db_user/database/application_name not visible under passthrough", r.Name)
+	}
+	if r.ApplicationName != "" {
+		return fmt.Errorf("conn_passthrough_field_unavailable: database_connection_rules[%q]: db_user/database/application_name not visible under passthrough", r.Name)
+	}
+	return nil
 }
 
 // hasHighRisk reports whether the alias-expanded group set includes any

--- a/internal/db/policy/validate_test.go
+++ b/internal/db/policy/validate_test.go
@@ -218,6 +218,171 @@ func TestValidate_ApproveTimeoutExceedsMax_ConnectionRule(t *testing.T) {
 	}
 }
 
+func TestValidate_PassthroughInvisibleFieldRule(t *testing.T) {
+	tests := []struct {
+		name         string
+		yaml         string
+		wantError    bool
+		wantCode     string
+		wantContains []string
+	}{
+		{
+			name: "db_user under passthrough rejected",
+			yaml: `version: 1
+name: test
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: passthrough
+database_connection_rules:
+  - name: r1
+    db_service: appdb
+    db_user: ["admin"]
+    decision: deny
+`,
+			wantError: true,
+			wantCode:  "conn_passthrough_field_unavailable",
+		},
+		{
+			name: "database under passthrough rejected",
+			yaml: `version: 1
+name: test
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: passthrough
+database_connection_rules:
+  - name: r1
+    db_service: appdb
+    database: prod
+    decision: deny
+`,
+			wantError: true,
+			wantCode:  "conn_passthrough_field_unavailable",
+		},
+		{
+			name: "application_name under passthrough rejected",
+			yaml: `version: 1
+name: test
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: passthrough
+database_connection_rules:
+  - name: r1
+    db_service: appdb
+    application_name: psql
+    decision: deny
+`,
+			wantError: true,
+			wantCode:  "conn_passthrough_field_unavailable",
+		},
+		{
+			name: "client_identity under passthrough is allowed (visible pre-handshake)",
+			yaml: `version: 1
+name: test
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: passthrough
+database_connection_rules:
+  - name: r1
+    db_service: appdb
+    client_identity: agent
+    decision: deny
+`,
+			wantError: false,
+		},
+		{
+			name: "db_user under terminate_reissue is allowed",
+			yaml: `version: 1
+name: test
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: terminate_reissue
+database_connection_rules:
+  - name: r1
+    db_service: appdb
+    db_user: ["admin"]
+    decision: deny
+`,
+			wantError: false,
+		},
+		{
+			name: "db_user wildcard rule rejected when any service is passthrough",
+			yaml: `version: 1
+name: test
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: passthrough
+  otherdb:
+    family: postgres
+    dialect: postgres
+    upstream: db2.internal:5432
+    tls_mode: terminate_reissue
+database_connection_rules:
+  - name: r1
+    db_user: ["admin"]
+    decision: deny
+`,
+			wantError:    true,
+			wantContains: []string{"conn_passthrough_field_unavailable", "triggered by service"},
+		},
+		{
+			name: "db_user wildcard rule allowed when no service is passthrough",
+			yaml: `version: 1
+name: test
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: terminate_reissue
+database_connection_rules:
+  - name: r1
+    db_user: ["admin"]
+    decision: deny
+`,
+			wantError: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rp, err := rootpolicy.LoadFromBytes([]byte(tc.yaml))
+			if err != nil {
+				t.Fatalf("LoadFromBytes: %v", err)
+			}
+			_, _, err = Decode(rp)
+			gotErr := err != nil
+			if gotErr != tc.wantError {
+				t.Fatalf("Decode error = %v, wantError = %v", err, tc.wantError)
+			}
+			if tc.wantCode != "" && !strings.Contains(err.Error(), tc.wantCode) {
+				t.Fatalf("Decode error = %q, wantCode contains %q", err.Error(), tc.wantCode)
+			}
+			for _, want := range tc.wantContains {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("Decode error = %q, wantContains %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
 func TestValidate_GlobCompileViaDecode(t *testing.T) {
 	src := `version: 1
 name: t

--- a/internal/db/proxy/postgres/eventid.go
+++ b/internal/db/proxy/postgres/eventid.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+package postgres
+
+import "github.com/google/uuid"
+
+// newEventID returns a UUIDv7 string for event correlation.
+// Spec §8: event_id is uuid-v7. uuid v1.6.0 (already a direct dep) ships v7
+// support. Falls back to v4 only if v7's random source fails (extremely rare).
+func newEventID() string {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return uuid.NewString()
+	}
+	return id.String()
+}

--- a/internal/db/proxy/postgres/listener_unix.go
+++ b/internal/db/proxy/postgres/listener_unix.go
@@ -1,0 +1,130 @@
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// timeNow is package-level so tests can override it. Today no test does.
+var timeNow = time.Now
+
+// unixListener wraps a net.UnixListener with the Plan 04a setup contract:
+// remove stale socket → bind → chmod 0700. On Close, unlinks the socket.
+type unixListener struct {
+	path string
+	ln   *net.UnixListener
+}
+
+func bindUnixListener(path string) (*unixListener, error) {
+	parent := filepath.Dir(path)
+	fi, err := os.Stat(parent)
+	if err != nil {
+		return nil, fmt.Errorf("stat listener parent dir %q: %w", parent, err)
+	}
+	if !fi.IsDir() {
+		return nil, fmt.Errorf("listener parent %q is not a directory", parent)
+	}
+	// Remove stale socket from a prior crash. Existing non-socket file is a
+	// hard error to avoid clobbering operator data.
+	if existing, err := os.Stat(path); err == nil {
+		if existing.Mode()&os.ModeSocket == 0 {
+			return nil, fmt.Errorf("listener path %q exists and is not a socket", path)
+		}
+		if err := os.Remove(path); err != nil {
+			return nil, fmt.Errorf("remove stale socket %q: %w", path, err)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("stat listener path %q: %w", path, err)
+	}
+	addr, err := net.ResolveUnixAddr("unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %q: %w", path, err)
+	}
+	ln, err := net.ListenUnix("unix", addr)
+	if err != nil {
+		return nil, fmt.Errorf("listen %q: %w", path, err)
+	}
+	if err := os.Chmod(path, 0o700); err != nil {
+		ln.Close()
+		os.Remove(path)
+		return nil, fmt.Errorf("chmod 0700 %q: %w", path, err)
+	}
+	return &unixListener{path: path, ln: ln}, nil
+}
+
+// Accept blocks until a connection arrives or ctx is cancelled. Cancellation
+// latency is bounded by the 250ms accept deadline (we bump it forward in
+// the loop).
+func (l *unixListener) Accept(ctx context.Context) (net.Conn, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		_ = l.ln.SetDeadline(timeNow().Add(250 * time.Millisecond))
+		conn, err := l.ln.AcceptUnix()
+		if err == nil {
+			return conn, nil
+		}
+		var ne net.Error
+		if errors.As(err, &ne) && ne.Timeout() {
+			continue
+		}
+		return nil, err
+	}
+}
+
+func (l *unixListener) Close() error {
+	err := l.ln.Close()
+	if rmErr := os.Remove(l.path); rmErr != nil && !os.IsNotExist(rmErr) {
+		if err == nil {
+			err = fmt.Errorf("remove %q: %w", l.path, rmErr)
+		}
+	}
+	return err
+}
+
+// activeConns is a small concurrent set of in-flight conns the Server cancels
+// at Shutdown. The set is keyed by conn pointer; conn handlers Add themselves
+// at start and Remove themselves on return.
+type activeConns struct {
+	mu sync.Mutex
+	m  map[net.Conn]struct{}
+}
+
+func newActiveConns() *activeConns { return &activeConns{m: make(map[net.Conn]struct{})} }
+
+func (a *activeConns) Add(c net.Conn) {
+	a.mu.Lock()
+	a.m[c] = struct{}{}
+	a.mu.Unlock()
+}
+
+func (a *activeConns) Remove(c net.Conn) {
+	a.mu.Lock()
+	delete(a.m, c)
+	a.mu.Unlock()
+}
+
+func (a *activeConns) CloseAll() {
+	a.mu.Lock()
+	for c := range a.m {
+		_ = c.Close()
+	}
+	a.mu.Unlock()
+}
+
+func (a *activeConns) Len() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.m)
+}

--- a/internal/db/proxy/postgres/peercred_linux.go
+++ b/internal/db/proxy/postgres/peercred_linux.go
@@ -1,0 +1,43 @@
+//go:build linux
+
+package postgres
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+// readPeerCred returns the peer's uid and pid via SO_PEERCRED on a Unix
+// socket connection. Returns an error if conn is not a *net.UnixConn or the
+// getsockopt call fails.
+//
+// Spec §12.5: SO_PEERCRED is the listener-auth primitive in Plan 04a.
+// Plan 07 hardens this to a SessionID resolution via the ptrace registry.
+func readPeerCred(conn net.Conn) (uid uint32, pid int32, err error) {
+	uc, ok := conn.(*net.UnixConn)
+	if !ok {
+		return 0, 0, fmt.Errorf("readPeerCred: conn is %T, want *net.UnixConn", conn)
+	}
+	raw, err := uc.SyscallConn()
+	if err != nil {
+		return 0, 0, fmt.Errorf("readPeerCred: SyscallConn: %w", err)
+	}
+	var ucred *unix.Ucred
+	var sysErr error
+	ctrlErr := raw.Control(func(fd uintptr) {
+		ucred, sysErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	})
+	if ctrlErr != nil {
+		return 0, 0, fmt.Errorf("readPeerCred: Control: %w", ctrlErr)
+	}
+	if sysErr != nil {
+		return 0, 0, fmt.Errorf("readPeerCred: SO_PEERCRED: %w", sysErr)
+	}
+	if ucred == nil {
+		return 0, 0, errors.New("readPeerCred: ucred is nil")
+	}
+	return ucred.Uid, ucred.Pid, nil
+}

--- a/internal/db/proxy/postgres/peercred_linux_test.go
+++ b/internal/db/proxy/postgres/peercred_linux_test.go
@@ -1,0 +1,159 @@
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/service"
+)
+
+func TestReadPeerCredUID_FromSocketpair(t *testing.T) {
+	fds, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("Socketpair: %v", err)
+	}
+	defer unix.Close(fds[1])
+
+	// Wrap fd[0] as a net.UnixConn so we can call our helper on it.
+	f := os.NewFile(uintptr(fds[0]), "peer")
+	conn, err := net.FileConn(f)
+	if err != nil {
+		unix.Close(fds[0])
+		t.Fatalf("FileConn: %v", err)
+	}
+	f.Close() // FileConn dup'd the fd
+	defer conn.Close()
+
+	uc, ok := conn.(*net.UnixConn)
+	if !ok {
+		t.Fatalf("conn is %T, want *net.UnixConn", conn)
+	}
+
+	gotUID, gotPID, err := readPeerCred(uc)
+	if err != nil {
+		t.Fatalf("readPeerCred: %v", err)
+	}
+	if gotUID != uint32(os.Getuid()) {
+		t.Errorf("readPeerCred uid = %d, want %d", gotUID, os.Getuid())
+	}
+	if gotPID != int32(os.Getpid()) {
+		t.Errorf("readPeerCred pid = %d, want %d", gotPID, os.Getpid())
+	}
+}
+
+func TestReadPeerCredUID_OnNonUnixConn_Errors(t *testing.T) {
+	r, w := net.Pipe()
+	defer r.Close()
+	defer w.Close()
+	if _, _, err := readPeerCred(r); err == nil {
+		t.Fatal("readPeerCred(net.Pipe): want error, got nil")
+	}
+}
+
+func TestServer_PeercredMismatch_ClosesAndEmitsLifecycle(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "appdb.sock")
+	sink := &events.SyncSink{}
+	cfg := Config{
+		Unavoidability: service.UnavoidabilityObserve,
+		StateDir:       t.TempDir(),
+		Sink:           sink,
+		Logger:         slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		Services: []Service{{
+			Name:     "appdb",
+			Family:   "postgres",
+			Dialect:  "postgres",
+			Upstream: "127.0.0.1:5432",
+			TLSMode:  "terminate_reissue",
+			Listen:   ServiceListener{Kind: "unix", Path: sockPath},
+			Service:  policy.DBService{Name: "appdb"},
+		}},
+	}
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// Override the equality check for this test only.
+	s.uidAllowed = func(uint32) bool { return false }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.Start(ctx)
+	waitForSocket(t, sockPath)
+
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Server should close the conn silently after peercred check.
+	conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	buf := make([]byte, 1)
+	if _, err := conn.Read(buf); !errors.Is(err, io.EOF) && !isClosedConnError(err) {
+		t.Errorf("Read after peercred mismatch: err=%v, want EOF or closed-conn", err)
+	}
+
+	// Capture the lifecycle slice on first non-empty Drain (avoid double-drain).
+	var lcs []events.LifecycleEvent
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if got := sink.DrainLifecycle(); len(got) > 0 {
+			lcs = got
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(lcs) != 1 || lcs[0].Kind != "db_listener_auth_fail" {
+		t.Fatalf("DrainLifecycle = %+v, want one db_listener_auth_fail", lcs)
+	}
+	if lcs[0].DBService != "appdb" {
+		t.Errorf("DBService = %q, want appdb", lcs[0].DBService)
+	}
+	if lcs[0].PeerUID != uint32(os.Getuid()) {
+		t.Errorf("PeerUID = %d, want %d", lcs[0].PeerUID, os.Getuid())
+	}
+	if lcs[0].Reason != "uid_mismatch" {
+		t.Errorf("Reason = %q, want uid_mismatch", lcs[0].Reason)
+	}
+	if lcs[0].EventID == "" {
+		t.Errorf("EventID is empty, want non-empty UUIDv7")
+	}
+	if lcs[0].Timestamp.IsZero() {
+		t.Errorf("Timestamp is zero, want non-zero")
+	}
+	if lcs[0].PeerPID == 0 {
+		t.Errorf("PeerPID = 0, want non-zero (real peer pid from net.Dial)")
+	}
+}
+
+// helper: wait until socket file exists and is a socket
+func waitForSocket(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if fi, err := os.Stat(path); err == nil && fi.Mode()&os.ModeSocket != 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("socket %q never bound", path)
+}
+
+func isClosedConnError(err error) bool {
+	return err != nil && (errors.Is(err, net.ErrClosed) || strings.Contains(err.Error(), "use of closed"))
+}

--- a/internal/db/proxy/postgres/server.go
+++ b/internal/db/proxy/postgres/server.go
@@ -1,0 +1,141 @@
+//go:build linux
+
+// Package postgres implements the AgentSH PostgreSQL proxy per
+// docs/agentsh-db-access-spec.md §11–§14 and the macro design at
+// docs/superpowers/specs/2026-05-10-db-plan-04-pg-proxy-skeleton-design.md.
+//
+// Plan 04a ships only the listener skeleton: bind Unix sockets per declared
+// db_service, peer-authenticate via SO_PEERCRED + UID-equality, accept and
+// immediately close. Plan 04b adds the handshake / TLS layer; Plan 04c adds
+// Simple Query classification and DBEvent emission.
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/service"
+)
+
+// Service is the proxy-internal flattened view of one db_service. The proxy
+// needs the listener path (from internal/db/service.Listener) and the
+// upstream + tls_mode metadata (from internal/db/policy.DBService). Callers
+// in internal/api are responsible for joining them.
+type Service struct {
+	Name     string           // matches policy.DBService.Name
+	Family   string           // "postgres"
+	Dialect  string           // postgres / aurora_postgres / cockroachdb / redshift
+	Upstream string           // host:port
+	TLSMode  string           // terminate_reissue / passthrough / terminate_plaintext_upstream
+	Listen   ServiceListener  // unix-socket path or tcp host:port
+	Service  policy.DBService // full DBService for downstream evaluation
+}
+
+// ServiceListener mirrors internal/db/service.Listener but is the package-
+// local concrete type the proxy operates on. Plan 04a only binds Kind=="unix".
+type ServiceListener struct {
+	Kind string // "unix" or "tcp"
+	Path string // when Kind == "unix"
+	Host string // when Kind == "tcp"
+	Port int    // when Kind == "tcp"
+}
+
+// Config captures the supervisor-supplied parameters for a Server.
+// StateDir is always required. Services and Sink are required only when
+// Unavoidability != UnavoidabilityOff. Logger defaults to slog.Default
+// when nil.
+type Config struct {
+	Unavoidability service.Unavoidability
+	Services       []Service
+	StateDir       string
+	Sink           events.Sink
+	Logger         *slog.Logger
+}
+
+// Server runs the AgentSH PostgreSQL proxy listeners.
+type Server struct {
+	cfg      Config
+	logger   *slog.Logger
+	sentinel bool // true when Unavoidability == off; Start/Shutdown are no-ops
+	mu       sync.Mutex
+	started  bool
+	shutdown bool
+}
+
+// New validates cfg and returns a *Server. When cfg.Unavoidability ==
+// UnavoidabilityOff, returns a sentinel server whose Start/Shutdown are
+// no-ops. Returns an error when required fields are missing.
+func New(cfg Config) (*Server, error) {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	if cfg.StateDir == "" {
+		return nil, errors.New("postgres.New: StateDir is required")
+	}
+	if cfg.Unavoidability == service.UnavoidabilityOff {
+		return &Server{cfg: cfg, logger: cfg.Logger, sentinel: true}, nil
+	}
+	if cfg.Sink == nil {
+		return nil, errors.New("postgres.New: Sink is required when Unavoidability != off")
+	}
+	if len(cfg.Services) == 0 {
+		return nil, errors.New("postgres.New: at least one Service is required when Unavoidability != off")
+	}
+	for i, svc := range cfg.Services {
+		if svc.Name == "" {
+			return nil, fmt.Errorf("postgres.New: services[%d].Name is empty", i)
+		}
+		if svc.Listen.Kind != "unix" && svc.Listen.Kind != "tcp" {
+			return nil, fmt.Errorf("postgres.New: services[%d].Listen.Kind = %q; want unix or tcp", i, svc.Listen.Kind)
+		}
+		if svc.Listen.Kind == "unix" && svc.Listen.Path == "" {
+			return nil, fmt.Errorf("postgres.New: services[%d].Listen.Path is empty for unix listener", i)
+		}
+	}
+	return &Server{cfg: cfg, logger: cfg.Logger}, nil
+}
+
+// Start binds listeners and runs accept loops until ctx is cancelled.
+// Returns nil for sentinel servers. Returns the first listener-bind error;
+// subsequent listeners are torn down.
+//
+// Plan 04a: connection handler is a no-op that closes the conn after the
+// peercred check. Plan 04b plugs in the real handshake handler.
+func (s *Server) Start(ctx context.Context) error {
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return errors.New("postgres.Server: Start called twice")
+	}
+	s.started = true
+	s.mu.Unlock()
+
+	if s.sentinel {
+		s.logger.Info("postgres.Server: sentinel mode (Unavoidability == off); not binding listeners")
+		return nil
+	}
+
+	// Listener bind + accept loop is implemented in Task 5.
+	return errors.New("postgres.Server.Start: listener bind not yet implemented (Plan 04a Task 5)")
+}
+
+// Shutdown stops accept loops, waits for in-flight conns to close, and
+// unlinks Unix sockets. Returns nil for sentinel servers.
+func (s *Server) Shutdown(ctx context.Context) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.shutdown {
+		return nil
+	}
+	s.shutdown = true
+	if s.sentinel {
+		return nil
+	}
+	// Implemented in Task 5.
+	return nil
+}

--- a/internal/db/proxy/postgres/server.go
+++ b/internal/db/proxy/postgres/server.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net"
+	"os"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
@@ -80,6 +81,10 @@ type Server struct {
 	// after the started guard commits). Shutdown selects on it to drain
 	// accept loops without calling eg.Wait directly.
 	done chan struct{}
+
+	// uidAllowed reports whether a peer uid is permitted to connect.
+	// Default: equality with os.Getuid(). Overrideable in tests.
+	uidAllowed func(uint32) bool
 }
 
 // New validates cfg and returns a *Server. When cfg.Unavoidability ==
@@ -93,7 +98,9 @@ func New(cfg Config) (*Server, error) {
 		return nil, errors.New("postgres.New: StateDir is required")
 	}
 	if cfg.Unavoidability == service.UnavoidabilityOff {
-		return &Server{cfg: cfg, logger: cfg.Logger, sentinel: true, done: make(chan struct{})}, nil
+		srv := &Server{cfg: cfg, logger: cfg.Logger, sentinel: true, done: make(chan struct{})}
+		srv.uidAllowed = func(uid uint32) bool { return uid == uint32(os.Getuid()) }
+		return srv, nil
 	}
 	if cfg.Sink == nil {
 		return nil, errors.New("postgres.New: Sink is required when Unavoidability != off")
@@ -112,13 +119,19 @@ func New(cfg Config) (*Server, error) {
 			return nil, fmt.Errorf("postgres.New: services[%d].Listen.Path is empty for unix listener", i)
 		}
 	}
-	return &Server{cfg: cfg, logger: cfg.Logger, done: make(chan struct{})}, nil
+	return &Server{
+		cfg:        cfg,
+		logger:     cfg.Logger,
+		done:       make(chan struct{}),
+		uidAllowed: func(uid uint32) bool { return uid == uint32(os.Getuid()) },
+	}, nil
 }
 
 // Start binds listeners and runs accept loops until ctx is cancelled.
-// For sentinel servers (Unavoidability == off), blocks until ctx is cancelled
-// and returns ctx.Err(). Returns the first listener-bind error; subsequent
-// listeners are torn down.
+// For sentinel servers (Unavoidability == off), Start binds no listeners and
+// blocks on ctx.Done() so callers can use a single goroutine pattern
+// regardless of mode; returns ctx.Err().
+// Returns the first listener-bind error; subsequent listeners are torn down.
 //
 // Plan 04a: connection handler is a no-op that closes the conn after the
 // peercred check. Plan 04b plugs in the real handshake handler.
@@ -269,10 +282,46 @@ func (s *Server) acceptLoop(ctx context.Context, svc Service, ln *unixListener) 
 	}
 }
 
-// handleConn is the per-connection handler. Plan 04a Task 5 is a no-op
-// (the conn is closed by the deferred Close in acceptLoop). Task 6
-// inserts the SO_PEERCRED + UID-equality check; Plan 04b plugs in the
-// real handshake.
+// handleConn is the per-connection handler. Reads SO_PEERCRED from the peer,
+// compares the peer uid to the proxy's own uid, and on mismatch silently
+// closes the conn while emitting a db_listener_auth_fail lifecycle event.
+// Plan 04a: successful peercred is a no-op (conn closed by deferred Close in
+// acceptLoop). Plan 04b plugs in the real handshake.
 func (s *Server) handleConn(ctx context.Context, svc Service, conn net.Conn) {
-	// intentionally empty for Plan 04a Task 5
+	uid, pid, err := readPeerCred(conn)
+	if err != nil {
+		s.logger.Warn("postgres.Server: peercred read failed; closing", "service", svc.Name, "err", err)
+		s.emitListenerAuthFail(ctx, svc, 0, 0, "peercred_read_failed")
+		return
+	}
+	if !s.uidAllowed(uid) {
+		s.emitListenerAuthFail(ctx, svc, uid, pid, "uid_mismatch")
+		return
+	}
+	// Plan 04a: peercred passed; close the conn (handshake lands in 04b).
+	// The deferred Close in acceptLoop handles the actual close.
+}
+
+// emitListenerAuthFail emits a db_listener_auth_fail lifecycle event via the
+// configured Sink. The ctx is the per-connection runCtx, which Shutdown
+// cancels — under shutdown races the event may be dropped (the sink emit
+// returns context.Canceled and we log warn). Acceptable for Plan 04a; Plan
+// 04b's real sink may want a background ctx with a short timeout to ensure
+// shutdown-race events still survive.
+func (s *Server) emitListenerAuthFail(ctx context.Context, svc Service, uid uint32, pid int32, reason string) {
+	if s.cfg.Sink == nil {
+		return
+	}
+	ev := events.LifecycleEvent{
+		EventID:   newEventID(),
+		Timestamp: timeNow(),
+		DBService: svc.Name,
+		Kind:      "db_listener_auth_fail",
+		Reason:    reason,
+		PeerUID:   uid,
+		PeerPID:   pid,
+	}
+	if err := s.cfg.Sink.EmitLifecycle(ctx, ev); err != nil {
+		s.logger.Warn("postgres.Server: sink emit failed", "kind", ev.Kind, "err", err)
+	}
 }

--- a/internal/db/proxy/postgres/server.go
+++ b/internal/db/proxy/postgres/server.go
@@ -15,7 +15,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"sync"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/agentsh/agentsh/internal/db/events"
 	"github.com/agentsh/agentsh/internal/db/policy"
@@ -61,10 +64,22 @@ type Config struct {
 type Server struct {
 	cfg      Config
 	logger   *slog.Logger
-	sentinel bool // true when Unavoidability == off; Start/Shutdown are no-ops
+	sentinel bool // true when Unavoidability == off; Start blocks on ctx, Shutdown is a no-op
+
 	mu       sync.Mutex
 	started  bool
 	shutdown bool
+
+	// Populated under mu before started=true so Shutdown always sees them.
+	cancel    context.CancelFunc
+	eg        *errgroup.Group
+	listeners map[string]*unixListener
+	conns     *activeConns
+
+	// done is closed by Start when it returns (including early-error paths
+	// after the started guard commits). Shutdown selects on it to drain
+	// accept loops without calling eg.Wait directly.
+	done chan struct{}
 }
 
 // New validates cfg and returns a *Server. When cfg.Unavoidability ==
@@ -78,7 +93,7 @@ func New(cfg Config) (*Server, error) {
 		return nil, errors.New("postgres.New: StateDir is required")
 	}
 	if cfg.Unavoidability == service.UnavoidabilityOff {
-		return &Server{cfg: cfg, logger: cfg.Logger, sentinel: true}, nil
+		return &Server{cfg: cfg, logger: cfg.Logger, sentinel: true, done: make(chan struct{})}, nil
 	}
 	if cfg.Sink == nil {
 		return nil, errors.New("postgres.New: Sink is required when Unavoidability != off")
@@ -97,12 +112,13 @@ func New(cfg Config) (*Server, error) {
 			return nil, fmt.Errorf("postgres.New: services[%d].Listen.Path is empty for unix listener", i)
 		}
 	}
-	return &Server{cfg: cfg, logger: cfg.Logger}, nil
+	return &Server{cfg: cfg, logger: cfg.Logger, done: make(chan struct{})}, nil
 }
 
 // Start binds listeners and runs accept loops until ctx is cancelled.
-// Returns nil for sentinel servers. Returns the first listener-bind error;
-// subsequent listeners are torn down.
+// For sentinel servers (Unavoidability == off), blocks until ctx is cancelled
+// and returns ctx.Err(). Returns the first listener-bind error; subsequent
+// listeners are torn down.
 //
 // Plan 04a: connection handler is a no-op that closes the conn after the
 // peercred check. Plan 04b plugs in the real handshake handler.
@@ -112,30 +128,151 @@ func (s *Server) Start(ctx context.Context) error {
 		s.mu.Unlock()
 		return errors.New("postgres.Server: Start called twice")
 	}
+	if s.shutdown {
+		s.mu.Unlock()
+		return errors.New("postgres.Server: Start after Shutdown")
+	}
+
+	// Initialise all run-state fields while still holding the lock, before
+	// setting started=true. This closes the window where Shutdown could run
+	// between started=true and the fields being populated, and find cancel==nil.
+	runCtx, cancel := context.WithCancel(ctx)
+	eg := new(errgroup.Group)
+	s.cancel = cancel
+	s.eg = eg
+	s.conns = newActiveConns()
+	s.listeners = make(map[string]*unixListener)
 	s.started = true
 	s.mu.Unlock()
 
+	// done is closed when Start returns, regardless of how it exits. This
+	// lets Shutdown drain without calling eg.Wait itself (Finding 2).
+	defer close(s.done)
+
 	if s.sentinel {
 		s.logger.Info("postgres.Server: sentinel mode (Unavoidability == off); not binding listeners")
-		return nil
+		<-runCtx.Done()
+		return runCtx.Err()
 	}
 
-	// Listener bind + accept loop is implemented in Task 5.
-	return errors.New("postgres.Server.Start: listener bind not yet implemented (Plan 04a Task 5)")
+	// Bind all listeners up-front; a partial failure tears the rest down.
+	// Indexed by service name so a future tcp-listener service does not
+	// disturb the alignment between cfg.Services and bound listeners.
+	bound := make(map[string]*unixListener, len(s.cfg.Services))
+	for _, svc := range s.cfg.Services {
+		if svc.Listen.Kind != "unix" {
+			s.logger.Warn("postgres.Server: skipping non-unix listener (Plan 04a binds unix only)",
+				"service", svc.Name, "kind", svc.Listen.Kind)
+			continue
+		}
+		ln, err := bindUnixListener(svc.Listen.Path)
+		if err != nil {
+			for _, b := range bound {
+				_ = b.Close()
+			}
+			return fmt.Errorf("bind listener for service %q: %w", svc.Name, err)
+		}
+		bound[svc.Name] = ln
+		s.logger.Info("postgres.Server: bound listener", "service", svc.Name, "path", svc.Listen.Path)
+	}
+
+	// Hand listeners over to the Server so Shutdown can close them.
+	// If Shutdown already ran during the bind phase, runCtx is already
+	// cancelled; close anything we just bound and return.
+	s.mu.Lock()
+	s.listeners = bound
+	alreadyShutdown := s.shutdown
+	s.mu.Unlock()
+
+	if alreadyShutdown {
+		for _, ln := range bound {
+			_ = ln.Close()
+		}
+		return runCtx.Err()
+	}
+
+	for _, svc := range s.cfg.Services {
+		ln, ok := bound[svc.Name]
+		if !ok {
+			continue
+		}
+		svcCopy := svc
+		lnCopy := ln
+		eg.Go(func() error {
+			return s.acceptLoop(runCtx, svcCopy, lnCopy)
+		})
+	}
+
+	err := eg.Wait()
+	if errors.Is(err, context.Canceled) {
+		err = nil
+	}
+	return err
 }
 
 // Shutdown stops accept loops, waits for in-flight conns to close, and
 // unlinks Unix sockets. Returns nil for sentinel servers.
 func (s *Server) Shutdown(ctx context.Context) error {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.shutdown {
+		s.mu.Unlock()
 		return nil
 	}
 	s.shutdown = true
-	if s.sentinel {
+	cancel := s.cancel
+	listeners := s.listeners
+	conns := s.conns
+	sentinel := s.sentinel
+	s.mu.Unlock()
+
+	if cancel == nil {
+		// Start was never called; nothing to do.
 		return nil
 	}
-	// Implemented in Task 5.
+	cancel()
+	if sentinel {
+		return nil
+	}
+	for _, ln := range listeners {
+		_ = ln.Close()
+	}
+	if conns != nil {
+		conns.CloseAll()
+	}
+	// Wait for Start (and therefore all accept loops) to finish, bounded
+	// by the caller's deadline. Only Start calls eg.Wait; Shutdown waits
+	// on the done channel that Start closes on its way out.
+	select {
+	case <-s.done:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 	return nil
+}
+
+func (s *Server) acceptLoop(ctx context.Context, svc Service, ln *unixListener) error {
+	for {
+		conn, err := ln.Accept(ctx)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			s.logger.Warn("postgres.Server: accept error", "service", svc.Name, "err", err)
+			return err
+		}
+		s.conns.Add(conn)
+		go func() {
+			defer s.conns.Remove(conn)
+			defer conn.Close()
+			s.handleConn(ctx, svc, conn)
+		}()
+	}
+}
+
+// handleConn is the per-connection handler. Plan 04a Task 5 is a no-op
+// (the conn is closed by the deferred Close in acceptLoop). Task 6
+// inserts the SO_PEERCRED + UID-equality check; Plan 04b plugs in the
+// real handshake.
+func (s *Server) handleConn(ctx context.Context, svc Service, conn net.Conn) {
+	// intentionally empty for Plan 04a Task 5
 }

--- a/internal/db/proxy/postgres/server_test.go
+++ b/internal/db/proxy/postgres/server_test.go
@@ -1,0 +1,84 @@
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/service"
+)
+
+func TestServer_New_ZeroConfigRejected(t *testing.T) {
+	_, err := New(Config{})
+	if err == nil {
+		t.Fatal("New(Config{}): want error, got nil")
+	}
+}
+
+func TestServer_OffMode_StartIsNoop(t *testing.T) {
+	cfg := Config{
+		Unavoidability: service.UnavoidabilityOff,
+		StateDir:       t.TempDir(),
+		Sink:           &events.SyncSink{},
+		Logger:         slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+	}
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if s == nil {
+		t.Fatal("New returned nil server")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("Start (off mode): %v", err)
+	}
+	if err := s.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown (off mode): %v", err)
+	}
+}
+
+func TestServer_ObserveMode_RequiresAtLeastOneService(t *testing.T) {
+	cfg := Config{
+		Unavoidability: service.UnavoidabilityObserve,
+		StateDir:       t.TempDir(),
+		Sink:           &events.SyncSink{},
+		Logger:         slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+	}
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("New (observe, no services): want error, got nil")
+	}
+}
+
+func TestServer_New_MissingSink(t *testing.T) {
+	cfg := Config{
+		Unavoidability: service.UnavoidabilityObserve,
+		StateDir:       t.TempDir(),
+		Services: []Service{{
+			Name:     "appdb",
+			Family:   "postgres",
+			Dialect:  "postgres",
+			Upstream: "db.internal:5432",
+			TLSMode:  "terminate_reissue",
+			Listen:   ServiceListener{Kind: "unix", Path: "/tmp/test-appdb.sock"},
+			Service:  policy.DBService{Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "db.internal:5432", TLSMode: "terminate_reissue"},
+		}},
+	}
+	_, err := New(cfg)
+	if err == nil {
+		t.Fatal("New (no sink): want error, got nil")
+	}
+}
+
+// testWriter wires slog output into t.Log so tests preserve context on failure.
+type testWriter struct{ t *testing.T }
+
+func (w testWriter) Write(p []byte) (int, error) { w.t.Log(string(p)); return len(p), nil }

--- a/internal/db/proxy/postgres/server_test.go
+++ b/internal/db/proxy/postgres/server_test.go
@@ -4,7 +4,12 @@ package postgres
 
 import (
 	"context"
+	"errors"
+	"io"
 	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -35,9 +40,10 @@ func TestServer_OffMode_StartIsNoop(t *testing.T) {
 		t.Fatal("New returned nil server")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
-	if err := s.Start(ctx); err != nil {
+	err = s.Start(ctx)
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("Start (off mode): %v", err)
 	}
 	if err := s.Shutdown(context.Background()); err != nil {
@@ -82,3 +88,96 @@ func TestServer_New_MissingSink(t *testing.T) {
 type testWriter struct{ t *testing.T }
 
 func (w testWriter) Write(p []byte) (int, error) { w.t.Log(string(p)); return len(p), nil }
+
+func TestServer_StartShutdown_BindsAndUnlinksUnixSocket(t *testing.T) {
+	dir := t.TempDir()
+	sockPath := filepath.Join(dir, "appdb.sock")
+	cfg := Config{
+		Unavoidability: service.UnavoidabilityObserve,
+		StateDir:       t.TempDir(),
+		Sink:           &events.SyncSink{},
+		Logger:         slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		Services: []Service{{
+			Name:     "appdb",
+			Family:   "postgres",
+			Dialect:  "postgres",
+			Upstream: "127.0.0.1:5432",
+			TLSMode:  "terminate_reissue",
+			Listen:   ServiceListener{Kind: "unix", Path: sockPath},
+			Service:  policy.DBService{Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "127.0.0.1:5432", TLSMode: "terminate_reissue"},
+		}},
+	}
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	startErr := make(chan error, 1)
+	go func() { startErr <- s.Start(ctx) }()
+
+	// Wait until the socket exists.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if fi, err := os.Stat(sockPath); err == nil && fi.Mode()&os.ModeSocket != 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if fi, err := os.Stat(sockPath); err != nil || fi.Mode()&os.ModeSocket == 0 {
+		t.Fatalf("socket %q not bound: stat=%v, err=%v", sockPath, fi, err)
+	}
+	if fi, _ := os.Stat(sockPath); fi.Mode()&0777 != 0700 {
+		t.Errorf("socket %q perms = %#o, want 0700", sockPath, fi.Mode()&0777)
+	}
+
+	// A Unix-socket dial should succeed and immediately see EOF (handler is no-op).
+	conn, err := net.Dial("unix", sockPath)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	buf := make([]byte, 1)
+	conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	if _, err := conn.Read(buf); err == nil || (err.Error() != "EOF" && !errors.Is(err, io.EOF) && !os.IsTimeout(err)) {
+		t.Fatalf("Read after dial: err=%v, want EOF or close", err)
+	}
+	conn.Close()
+
+	// Cancel context and assert Shutdown completes and unlinks the socket.
+	cancel()
+	if err := s.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	if err := <-startErr; err != nil && !errors.Is(err, context.Canceled) {
+		t.Fatalf("Start returned: %v", err)
+	}
+	if _, err := os.Stat(sockPath); !os.IsNotExist(err) {
+		t.Fatalf("socket %q still present after Shutdown: stat err=%v", sockPath, err)
+	}
+}
+
+func TestServer_StartTwice_ReturnsError(t *testing.T) {
+	cfg := Config{
+		Unavoidability: service.UnavoidabilityObserve,
+		StateDir:       t.TempDir(),
+		Sink:           &events.SyncSink{},
+		Services: []Service{{
+			Name:    "appdb",
+			Listen:  ServiceListener{Kind: "unix", Path: filepath.Join(t.TempDir(), "appdb.sock")},
+			Service: policy.DBService{Name: "appdb"},
+			TLSMode: "terminate_reissue",
+		}},
+	}
+	s, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go s.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+	if err := s.Start(ctx); err == nil {
+		t.Fatal("second Start: want error, got nil")
+	}
+}

--- a/internal/db/proxy/postgres/stub_other.go
+++ b/internal/db/proxy/postgres/stub_other.go
@@ -1,0 +1,60 @@
+//go:build !linux
+
+// Package postgres provides a non-Linux stub so cross-compilation
+// (GOOS=windows go build ./...) stays green. The proxy is Linux-only;
+// callers on other platforms get errors.ErrUnsupported when starting it.
+package postgres
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/service"
+)
+
+type Service struct {
+	Name     string
+	Family   string
+	Dialect  string
+	Upstream string
+	TLSMode  string
+	Listen   ServiceListener
+	Service  policy.DBService
+}
+
+type ServiceListener struct {
+	Kind string
+	Path string
+	Host string
+	Port int
+}
+
+type Config struct {
+	Unavoidability service.Unavoidability
+	Services       []Service
+	StateDir       string
+	Sink           events.Sink
+	Logger         *slog.Logger
+}
+
+type Server struct {
+	sentinel bool
+}
+
+// New on non-Linux always succeeds and returns a sentinel that refuses to
+// start unless Unavoidability == off (in which case Start is a no-op too).
+func New(cfg Config) (*Server, error) {
+	return &Server{sentinel: cfg.Unavoidability == service.UnavoidabilityOff}, nil
+}
+
+func (s *Server) Start(ctx context.Context) error {
+	if s.sentinel {
+		return nil
+	}
+	return errors.ErrUnsupported
+}
+
+func (s *Server) Shutdown(ctx context.Context) error { return nil }

--- a/internal/db/service/flag.go
+++ b/internal/db/service/flag.go
@@ -1,0 +1,48 @@
+package service
+
+// Unavoidability is the policies.db.unavoidability flag per
+// docs/agentsh-db-access-spec.md §11.1. Operators select one of three modes:
+//
+//	off     (default): proxy is inert; no listeners are bound.
+//	observe: listeners bind; declared services are intercepted; events emit.
+//	enforce: same as observe in Plan 04a (and through Plan 04c). Plan 07
+//	         generates the unavoidability bundle (egress denial, SessionID-
+//	         keyed proxy identity) and makes enforce the high-assurance default.
+//
+// The zero value is UnavoidabilityOff, which is the safe default for any
+// caller holding a not-yet-decoded RuleSet.
+type Unavoidability uint8
+
+const (
+	UnavoidabilityOff Unavoidability = iota
+	UnavoidabilityObserve
+	UnavoidabilityEnforce
+)
+
+func (u Unavoidability) String() string {
+	switch u {
+	case UnavoidabilityOff:
+		return "off"
+	case UnavoidabilityObserve:
+		return "observe"
+	case UnavoidabilityEnforce:
+		return "enforce"
+	default:
+		return ""
+	}
+}
+
+// ParseUnavoidability accepts the canonical lowercase mode names. Empty input
+// returns ok=false (callers may want to apply a default at a higher level).
+func ParseUnavoidability(s string) (Unavoidability, bool) {
+	switch s {
+	case "off":
+		return UnavoidabilityOff, true
+	case "observe":
+		return UnavoidabilityObserve, true
+	case "enforce":
+		return UnavoidabilityEnforce, true
+	default:
+		return UnavoidabilityOff, false
+	}
+}

--- a/internal/db/service/flag_test.go
+++ b/internal/db/service/flag_test.go
@@ -1,0 +1,34 @@
+package service
+
+import "testing"
+
+func TestUnavoidability_StringAndParse(t *testing.T) {
+	tests := []struct {
+		s    string
+		want Unavoidability
+		ok   bool
+	}{
+		{"off", UnavoidabilityOff, true},
+		{"observe", UnavoidabilityObserve, true},
+		{"enforce", UnavoidabilityEnforce, true},
+		{"", UnavoidabilityOff, false},
+		{"OFF", UnavoidabilityOff, false},        // case-sensitive
+		{"unknown", UnavoidabilityOff, false},
+	}
+	for _, tc := range tests {
+		got, ok := ParseUnavoidability(tc.s)
+		if ok != tc.ok || got != tc.want {
+			t.Errorf("ParseUnavoidability(%q) = (%v,%v), want (%v,%v)", tc.s, got, ok, tc.want, tc.ok)
+		}
+		if ok && got.String() != tc.s {
+			t.Errorf("Unavoidability(%v).String() = %q, want %q", got, got.String(), tc.s)
+		}
+	}
+}
+
+func TestUnavoidability_ZeroValueIsOff(t *testing.T) {
+	var u Unavoidability
+	if u != UnavoidabilityOff {
+		t.Fatalf("zero-value Unavoidability is %v, want UnavoidabilityOff", u)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -25,6 +25,8 @@ import (
 	"github.com/agentsh/agentsh/internal/auth"
 	"github.com/agentsh/agentsh/internal/capabilities"
 	"github.com/agentsh/agentsh/internal/config"
+	dbevents "github.com/agentsh/agentsh/internal/db/events"
+	dbproxy "github.com/agentsh/agentsh/internal/db/proxy/postgres"
 	"github.com/agentsh/agentsh/internal/events"
 	limitspkg "github.com/agentsh/agentsh/internal/limits"
 	"github.com/agentsh/agentsh/internal/mcpregistry"
@@ -80,6 +82,8 @@ type Server struct {
 	skillcheckDaemon *skillcheck.Daemon // nil when skillcheck.enabled=false
 
 	app *api.App // for lifecycle management (ptrace tracer shutdown)
+
+	dbSrv *dbproxy.Server // DB proxy; always non-nil after New (sentinel in off-mode)
 
 	kmsProvider io.Closer // audit/kms.Provider for HMAC key lifecycle
 
@@ -512,6 +516,27 @@ func New(cfg *config.Config) (*Server, error) {
 		}
 	}()
 
+	// DB proxy (Phase 1, Plan 04a). Bound only when policies.db.unavoidability != off.
+	// The proxy is constructed here; Start is called from Run using the server
+	// lifetime context. Shutdown is wired into appCloser for error-path cleanup.
+	// srv is not yet initialised here so dbSrv is assigned to srv after srv :=.
+	var dbSrv *dbproxy.Server
+	{
+		dbStateDir := filepath.Join(config.GetUserStateDir(), "db-proxy")
+		var err error
+		dbSrv, err = api.NewDBProxy(engine.Policy(), dbStateDir, dbevents.NopSink{})
+		if err != nil {
+			return nil, fmt.Errorf("new db proxy: %w", err)
+		}
+		prevAppCloser := appCloser
+		appCloser = func() {
+			if prevAppCloser != nil {
+				prevAppCloser()
+			}
+			_ = dbSrv.Shutdown(context.Background())
+		}
+	}
+
 	// Initialize package checker (optional).
 	if cfg.PackageChecks.Enabled {
 		// Resolve and apply fail mode so Snyk/Socket OnFailure reflects
@@ -725,6 +750,7 @@ func New(cfg *config.Config) (*Server, error) {
 		skillcheckDaemon: skillcheckDaemon,
 		app:              app,
 		kmsProvider:      kmsProvider,
+		dbSrv:            dbSrv,
 	}
 
 	// Start the policy socket server (macOS only; no-op on other platforms).
@@ -996,6 +1022,9 @@ func (s *Server) Run(ctx context.Context) error {
 		go func() { _ = pprofServer.Serve(pprofLn) }()
 	}
 
+	// Start the DB proxy listener goroutine for the server lifetime.
+	go func() { _ = s.dbSrv.Start(ctx) }()
+
 	if s.sessionTimeout > 0 || s.idleTimeout > 0 {
 		ticker := time.NewTicker(s.reapInterval)
 		defer ticker.Stop()
@@ -1085,6 +1114,7 @@ func (s *Server) Run(ctx context.Context) error {
 		if app != nil {
 			app.Close()
 		}
+		_ = s.dbSrv.Shutdown(shutdownCtx)
 		if syncerDone != nil {
 			<-syncerDone
 		}
@@ -1144,6 +1174,7 @@ func (s *Server) Close() error {
 	if s.app != nil {
 		s.app.Close()
 	}
+	_ = s.dbSrv.Shutdown(context.Background())
 	if s.sessions != nil {
 		for _, sess := range s.sessions.List() {
 			_ = sess.CloseNetNS()


### PR DESCRIPTION
## Summary

First of three sub-plans (04a/04b/04c) replacing the original Plan 04 (the unified plan was too large for one PR). This sub-plan ships a Linux-only PostgreSQL proxy *listener* that binds Unix sockets per declared `db_service`, peer-authenticates via SO_PEERCRED + UID-equality, and accepts/closes connections cleanly. **No protocol semantics yet** — Plan 04b adds handshake/TLS, Plan 04c adds Simple Query.

7 commits across 5 packages:

- `db/service.Unavoidability` enum + `policies.db.unavoidability` decode (default `off`).
- `db/policy/validate.go` rejects connection rules under `tls_mode: passthrough` that match passthrough-invisible fields (`db_user`, `database`, `application_name`).
- `db/events.Sink` interface + `NopSink` + in-memory `SyncSink` test fake; new `LifecycleEvent` value type for non-statement events.
- `db/proxy/postgres` package (Linux-only; non-Linux stub returns `errors.ErrUnsupported`): `Server` lifecycle (`New` / `Start` / `Shutdown`), bind one Unix listener per service (parent-dir validation, stale-socket removal, `chmod 0700`), accept loop per listener under errgroup, graceful drain, listener unlink on close. Sentinel-server short-circuit when flag = `off`.
- SO_PEERCRED + UID listener auth via `golang.org/x/sys/unix.GetsockoptUcred`. Mismatched-uid connections are silently closed; `db_listener_auth_fail` lifecycle event emitted via the Sink.
- `internal/api.NewDBProxy` decodes the loaded policy into a `*dbpolicy.RuleSet`, synthesizes listener paths at `${UserStateDir}/db-proxy/db-services/${name}.sock`, and constructs the proxy. `internal/server/server.go` calls it next to `api.NewApp`, starts the proxy in `Run(ctx)` via goroutine, and chains `Shutdown` into the `appCloser` defer + `Run` shutdown closure + `Close()` (idempotent across all three).

External behavior under the default `off` flag: no listener is bound; package is a no-op.
External behavior under `observe`: declared services bind a Unix socket; non-matching uid connections silently dropped (with audit event); matching-uid connections immediately closed (Plan 04b adds the handshake).

## Test Plan

- [ ] CI: `go test ./...` (Linux + macOS) green
- [ ] CI: `GOOS=windows go build ./...` green
- [ ] All Plan 04a-touched packages pass under `-race`: `internal/db/{service,policy,events,proxy/postgres}`, `internal/api`
- [ ] Manual smoke (informational, not gating): with `policies.db.unavoidability: observe` and one declared `db_service`, `nc -U ${UserStateDir}/db-proxy/db-services/<name>.sock` from the same uid succeeds + immediately closes; from a different uid silently closes and emits `db_listener_auth_fail`

## Notes

- Pre-existing `-race` flakes in `internal/api` notify-handler tests (`TestStartNotifyHandler_*`, `TestNotifyHandler_*`) are unrelated to this branch — same races present on the base commit.
- Two follow-ups noted by final review for Plan 04b: collapse the duplicate `strictDecode` call in `internal/db/policy/decode.go`'s `decodeRedaction`/`decodeUnavoidability`; make `validateConnectionRuleVsService` error messages name the specific field that triggered (currently lists all three).
- Roadmap and macro design doc (committed earlier on `main`):
  - `docs/superpowers/specs/2026-05-08-db-access-phase-1-roadmap-design.md` (Plan 04 split)
  - `docs/superpowers/specs/2026-05-10-db-plan-04-pg-proxy-skeleton-design.md` (covers all three 04a/04b/04c)
  - `docs/superpowers/plans/2026-05-10-db-plan-04a-listener-skeleton.md` (this PR's implementation plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)