### PR TITLE
fix(packaging): include agentsh-unixwrap in default make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ build:
 	mkdir -p bin $(GOCACHE) $(GOMODCACHE) $(GOPATH)
 	GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE) GOPATH=$(GOPATH) go build $(LDFLAGS) -o bin/agentsh ./cmd/agentsh
 	GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE) GOPATH=$(GOPATH) go build $(LDFLAGS) -o bin/agentsh-shell-shim ./cmd/agentsh-shell-shim
+	GOCACHE=$(GOCACHE) GOMODCACHE=$(GOMODCACHE) GOPATH=$(GOPATH) go build $(LDFLAGS) -o bin/agentsh-unixwrap ./cmd/agentsh-unixwrap
 
 build-shim:
 	mkdir -p bin $(GOCACHE) $(GOMODCACHE) $(GOPATH)


### PR DESCRIPTION
cmd/agentsh-unixwrap is in-tree but `make build` only produces `bin/agentsh` and `bin/agentsh-shell-shim`.

Downstream packagers (RPM, deb, brew) currently have to add an extra `go build ./cmd/agentsh-unixwrap` step.

Add the matching go build line so `make build`
produces all three binaries.