### PR TITLE
fix(fsmonitor): pass through Fsync/Flush/Lseek on FUSE fileHandle

### DIFF
--- a/internal/fsmonitor/fuse.go
+++ b/internal/fsmonitor/fuse.go
@@ -379,6 +379,32 @@ func (f *fileHandle) Release(ctx context.Context) syscall.Errno {
 	return 0
 }
 
+// Fsync, Flush, and Lseek pass through to the underlying loopback handle.
+// Without explicit pass-throughs go-fuse responds ENOTSUP, which libuv-
+// based runtimes (notably Node's fs.writeFileSync via the libuv fsync
+// path) surface as the misleading default ENOTSUP message string
+// "operation not supported on socket, fsync".
+func (f *fileHandle) Fsync(ctx context.Context, flags uint32) syscall.Errno {
+	if s, ok := f.inner.(fs.FileFsyncer); ok {
+		return s.Fsync(ctx, flags)
+	}
+	return 0
+}
+
+func (f *fileHandle) Flush(ctx context.Context) syscall.Errno {
+	if s, ok := f.inner.(fs.FileFlusher); ok {
+		return s.Flush(ctx)
+	}
+	return 0
+}
+
+func (f *fileHandle) Lseek(ctx context.Context, off uint64, whence uint32) (uint64, syscall.Errno) {
+	if s, ok := f.inner.(fs.FileLseeker); ok {
+		return s.Lseek(ctx, off, whence)
+	}
+	return 0, syscall.ENOSYS
+}
+
 func (n *node) check(ctx context.Context, virtPath string, op string) policy.Decision {
 	mustExist := op != "create" && op != "mkdir"
 	return n.checkWithExist(ctx, virtPath, op, mustExist)

--- a/internal/fsmonitor/fuse_ops_test.go
+++ b/internal/fsmonitor/fuse_ops_test.go
@@ -111,3 +111,65 @@ func TestFUSE_InterceptsExtraOps(t *testing.T) {
 		}
 	}
 }
+
+// TestFUSE_FsyncFlushLseekPassthrough verifies that fsync(2), implicit flush
+// on close, and lseek(2) on a file opened through the agentsh FUSE mount
+// succeed instead of returning ENOTSUP. Without explicit Fsync/Flush/Lseek
+// pass-throughs on fileHandle, go-fuse falls back to ENOTSUP, which libuv-
+// based runtimes surface as "operation not supported on socket, fsync".
+func TestFUSE_FsyncFlushLseekPassthrough(t *testing.T) {
+	if _, err := os.Stat("/dev/fuse"); err != nil {
+		t.Skipf("fuse not available: %v", err)
+	}
+
+	backing := t.TempDir()
+	mountPoint := filepath.Join(t.TempDir(), "mnt")
+
+	pol := &policy.Policy{
+		Version: 1,
+		Name:    "allow-all",
+		FileRules: []policy.FileRule{
+			{Name: "allow-workspace", Paths: []string{"/workspace", "/workspace/**"}, Operations: []string{"*"}, Decision: "allow"},
+		},
+	}
+	engine, err := policy.NewEngine(pol, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hooks := &Hooks{
+		SessionID: "session-fsync",
+		Policy:    engine,
+		Emit:      &typeCaptureEmitter{},
+	}
+
+	m, err := MountWorkspace(context.Background(), backing, mountPoint, hooks)
+	if err != nil {
+		t.Skipf("mount failed (skipping): %v", err)
+	}
+	defer func() { _ = m.Unmount() }()
+
+	path := filepath.Join(mountPoint, "data.bin")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := f.Write([]byte("hello")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// fsync should succeed (was ENOTSUP without pass-through).
+	if err := f.Sync(); err != nil {
+		t.Fatalf("fsync returned %v; expected nil (ENOTSUP regression)", err)
+	}
+
+	// lseek(SEEK_SET, 0) should succeed.
+	if _, err := f.Seek(0, 0); err != nil {
+		t.Fatalf("lseek returned %v; expected nil", err)
+	}
+
+	// Close exercises the flush path; must not surface ENOTSUP either.
+	if err := f.Close(); err != nil {
+		t.Fatalf("close (flush) returned %v; expected nil", err)
+	}
+}


### PR DESCRIPTION
fileHandle in the FUSE layer didn't implement Fsync, Flush, or Lseek, so go-fuse fell back to ENOTSUP for those operations. libuv's default error message for ENOTSUP from fsync is the misleading string "operation not supported on socket, fsync"

Node code paths that fsync after write (notably fs.writeFileSync, which Claude Code uses heavily) hit this reliably on any agentsh-mounted workspace.

Add three thin pass-through methods that delegate to the underlying loopback handle when it implements the corresponding go-fuse interface, returning 0 (or ENOSYS for lseek) otherwise.

Also adds a regression test that opens, writes, fsyncs, lseeks, and closes a file through a real FUSE mount; without the pass-throughs the fsync call returns ENOTSUP.