### PR TITLE
fix(fsmonitor): don't treat truncate as destructive under soft_delete

### DIFF
--- a/internal/fsmonitor/fuse.go
+++ b/internal/fsmonitor/fuse.go
@@ -85,12 +85,23 @@ func (n *node) Open(ctx context.Context, flags uint32) (fh fs.FileHandle, fuseFl
 
 	n.emitFileEvent(ctx, "file_open", virt, "open", 0, dec, false, nil)
 	if flags&uint32(syscall.O_TRUNC) != 0 {
+		// O_TRUNC truncates the file as part of open. Same reasoning as
+		// the Setattr(FATTR_SIZE) branch: truncate is an in-place
+		// content edit, not a delete, so don't route it through
+		// applyAuditPolicy with a nil divert -- that path returns EIO
+		// under audit.mode=soft_delete (soft_delete_no_handler), the
+		// same bug. Policy-check as a write (O_TRUNC already implies
+		// write access) via checkTruncate and emit a file_truncate
+		// audit event.
+		tdec := n.checkTruncate(ctx, virt)
+		if tdec.EffectiveDecision == types.DecisionDeny {
+			n.emitFileEvent(ctx, "file_truncate", virt, "truncate", 0, tdec, true, nil)
+			return nil, 0, syscall.EACCES
+		}
 		var inner fs.FileHandle
 		var fFlags uint32
-		errno = applyAuditPolicy(ctx, n.auditHooks(), n.hooksSessionID(), "truncate_open", virt, "", "", nil, func() syscall.Errno {
-			inner, fFlags, errno = n.LoopbackNode.Open(ctx, flags)
-			return errno
-		})
+		inner, fFlags, errno = n.LoopbackNode.Open(ctx, flags)
+		n.emitFileEvent(ctx, "file_truncate", virt, "truncate", 0, tdec, errno != 0, nil)
 		if errno != 0 {
 			return nil, 0, errno
 		}
@@ -294,9 +305,23 @@ func (n *node) Setattr(ctx context.Context, f fs.FileHandle, in *fuse.SetAttrIn,
 	}
 
 	if in.Valid&fuse.FATTR_SIZE != 0 {
-		return applyAuditPolicy(ctx, n.auditHooks(), n.hooksSessionID(), "truncate", virt, "", "", nil, func() syscall.Errno {
-			return n.LoopbackNode.Setattr(ctx, f, in, out)
-		})
+		// Truncate is editing, not deleting -- the inode stays, only the
+		// content shrinks. Don't route it through applyAuditPolicy with a
+		// nil divert: under audit.mode=soft_delete that returns EIO
+		// because there is no handler to divert to, breaking ordinary
+		// writes that pass O_TRUNC (e.g. `python -m venv` over an
+		// existing venv truncates venv/.gitignore, surfacing as
+		// "[Errno 5] Input/output error"). Policy-check as a write
+		// (see checkTruncate) and run; the audit event type stays
+		// file_truncate for visibility.
+		dec := n.checkTruncate(ctx, virt)
+		if dec.EffectiveDecision == types.DecisionDeny {
+			n.emitFileEvent(ctx, "file_truncate", virt, "truncate", 0, dec, true, nil)
+			return syscall.EACCES
+		}
+		errno := n.LoopbackNode.Setattr(ctx, f, in, out)
+		n.emitFileEvent(ctx, "file_truncate", virt, "truncate", int64(in.Size), dec, errno != 0, nil)
+		return errno
 	}
 
 	return n.LoopbackNode.Setattr(ctx, f, in, out)
@@ -383,6 +408,23 @@ func (f *fileHandle) Release(ctx context.Context) syscall.Errno {
 func (n *node) check(ctx context.Context, virtPath string, op string) policy.Decision {
 	mustExist := op != "create" && op != "mkdir"
 	return n.checkWithExist(ctx, virtPath, op, mustExist)
+}
+
+// checkTruncate evaluates policy for an in-place truncate. Truncate is a
+// content mutation, not a delete, so the policy operation is "write": it
+// matches the same file_rules as an ordinary write and does not require
+// operators to grant a separate "truncate" operation (matchOp is exact,
+// so a rule with operations: [write] would not match "truncate"). This
+// mirrors the older platform FUSE implementation, which already treats
+// truncate as FileOpWrite.
+//
+// Both Setattr(FATTR_SIZE) and Open(O_TRUNC) route through here so the
+// soft_delete EIO bug -- a nil divert handed to applyAuditPolicy, which
+// returns EIO under audit.mode=soft_delete -- cannot recur on either
+// truncate path. Callers emit the file_truncate audit event themselves.
+func (n *node) checkTruncate(ctx context.Context, virtPath string) policy.Decision {
+	dec := n.check(ctx, virtPath, "write")
+	return n.maybeApprove(ctx, dec, "file", virtPath, "write")
 }
 
 func (n *node) checkWithExist(_ context.Context, virtPath string, op string, mustExist bool) policy.Decision {

--- a/internal/fsmonitor/fuse_truncate_test.go
+++ b/internal/fsmonitor/fuse_truncate_test.go
@@ -1,0 +1,106 @@
+//go:build linux
+
+package fsmonitor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+// TestFUSE_TruncateUnderSoftDelete is a regression test for the bug where
+// truncating an existing file under audit.mode=soft_delete returned EIO.
+//
+// Before the fix, the FATTR_SIZE branch in Setattr routed truncate through
+// applyAuditPolicy with a nil divert; under soft_delete that handler
+// returned "soft_delete_no_handler" -> EIO. Ordinary writes that pass
+// O_TRUNC (e.g. `python -m venv` re-running over an existing venv, which
+// truncates venv/.gitignore) surfaced this as "[Errno 5] Input/output
+// error". Truncate is content-shrink, not delete -- the inode stays --
+// so it must not be treated as a destructive op for soft_delete.
+//
+// Both truncate entry points were fixed: Setattr(FATTR_SIZE) and the
+// Open(O_TRUNC) branch. This test exercises the Setattr path -- on Linux,
+// go-fuse does not advertise CAP_ATOMIC_O_TRUNC, so an open(O_TRUNC) is
+// split by the kernel into open() + a separate truncate(), and the
+// truncate lands in Setattr(FATTR_SIZE). The Open(O_TRUNC) fix is
+// defensive for mounts/kernels that do deliver atomic open-truncate.
+func TestFUSE_TruncateUnderSoftDelete(t *testing.T) {
+	if _, err := os.Stat("/dev/fuse"); err != nil {
+		t.Skipf("fuse not available: %v", err)
+	}
+
+	workspace := t.TempDir()
+	mountPoint := filepath.Join(t.TempDir(), "mnt")
+
+	target := filepath.Join(workspace, "data.txt")
+	if err := os.WriteFile(target, []byte("hello-world"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// checkWithExist resolves /workspace/... to the real backing path
+	// (the t.TempDir() workspace) before calling CheckFile, so a policy
+	// scoped to "/workspace/**" would not match on a host where the
+	// FUSE mount actually runs -- the truncate would then be denied by
+	// policy rather than exercising the soft_delete path this test is
+	// about. Use "/**" so the test validates the intended behavior
+	// regardless of where the resolved path lands.
+	pol := &policy.Policy{
+		Version: 1,
+		Name:    "allow-all",
+		FileRules: []policy.FileRule{
+			{Name: "allow-all", Paths: []string{"/**"}, Operations: []string{"*"}, Decision: "allow"},
+		},
+	}
+	engine, err := policy.NewEngine(pol, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	enabled := true
+	hooks := &Hooks{
+		SessionID: "session-trunc",
+		Policy:    engine,
+		Emit:      &typeCaptureEmitter{},
+		FUSEAudit: &FUSEAuditHooks{
+			Config: config.FUSEAuditConfig{
+				Enabled:   &enabled,
+				Mode:      "soft_delete",
+				TrashPath: ".agentsh_trash",
+			},
+		},
+	}
+
+	m, err := MountWorkspace(context.Background(), workspace, mountPoint, hooks)
+	if err != nil {
+		t.Skipf("mount failed (skipping): %v", err)
+	}
+	defer func() { _ = m.Unmount() }()
+
+	mountTarget := filepath.Join(mountPoint, "data.txt")
+
+	// 1. Explicit truncate(2).
+	if err := os.Truncate(mountTarget, 0); err != nil {
+		t.Fatalf("os.Truncate returned %v under soft_delete; expected nil "+
+			"(this is the EIO regression)", err)
+	}
+
+	// 2. Re-write via O_WRONLY|O_TRUNC (the path that breaks `python -m venv`).
+	if err := os.WriteFile(mountTarget, []byte("new"), 0o644); err != nil {
+		t.Fatalf("os.WriteFile (O_TRUNC) returned %v under soft_delete; "+
+			"expected nil", err)
+	}
+
+	// Sanity check: content was replaced, inode preserved.
+	got, err := os.ReadFile(mountTarget)
+	if err != nil {
+		t.Fatalf("readback: %v", err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("expected content %q, got %q", "new", string(got))
+	}
+}


### PR DESCRIPTION
The FATTR_SIZE branch in Setattr routed truncate(2)/ftruncate(2) (and the implicit truncate from open(O_TRUNC)) through applyAuditPolicy with a nil divert callback. Under audit.mode=soft_delete that returned EIO because there is no handler to divert to. Ordinary writes that pass O_TRUNC then failed with "[Errno 5] Input/output error" -- most visibly `python -m venv` re-running over an existing venv, which truncates venv/.gitignore on the second invocation.

Truncate is content-shrink, not delete: the inode stays, only the content goes. It does not belong on the soft-delete divert path.

Use the same direct check + LoopbackNode.Setattr + emitFileEvent pattern the other in-place edit ops already use, and emit a "file_truncate" audit event regardless of mode.

Adds a regression test that mounts a soft_delete workspace, runs os.Truncate and a re-write via O_WRONLY|O_TRUNC against an existing file, and asserts both succeed (pre-fix: both returned EIO).