### PR TITLE
fix(fsmonitor): policy-check symlink leaf ops on the link, fall through to target eval

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2307,6 +2307,7 @@ Key fields:
     - `enabled` (bool, default false)
     - `wrapper_bin` (path override, default `agentsh-unixwrap` in `$PATH`)
 - `policies.*`
+  - `policies.symlink_escape`: `"evaluate"` (default) | `"deny"`. Controls FUSE-layer handling of workspace symlinks whose targets lie outside the workspace root, for operations whose policy subject is the target (open/read/write/exec). `evaluate` resolves the symlink and evaluates the resolved outside path against the normal `file_rules`, letting Python venvs (`venv/bin/python -> /usr/bin/python3`) work out of the box; operators express deny via a regular rule on `/usr/bin/**` etc. `deny` restores the historical blanket `workspace-escape` deny — any symlink target outside the workspace is refused regardless of `file_rules`. Leaf-only operations (`stat`, `readlink`, `delete`, `rmdir`) are always checked against the symlink path itself and are unaffected by this setting.
 - `approvals.*`
 
 ### 15.2 Policy Configuration

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -338,9 +338,10 @@ func (a *App) setupProfileMounts(ctx context.Context, s *session.Session, profil
 					TraceContextFunc: func() (string, string, string) {
 						return s.CurrentTraceContext()
 					},
-					PolicyEngine:  platform.NewPolicyAdapter(policyEngine),
-					EventChannel:  eventChan,
-					MaxBackground: a.cfg.Sandbox.FUSE.MaxBackground,
+					PolicyEngine:      platform.NewPolicyAdapter(policyEngine),
+					EventChannel:      eventChan,
+					MaxBackground:     a.cfg.Sandbox.FUSE.MaxBackground,
+					SymlinkEscapeDeny: a.cfg.Policies.SymlinkEscapeDeny(),
 					// For the primary workspace mount, use the session's effective virtual
 					// root so FUSE events report paths consistent with the session (e.g.
 					// /workspace in default mode). Non-workspace mounts use their real
@@ -1149,9 +1150,10 @@ func (a *App) mountFUSEForSession(ctx context.Context, p fuseMountParams) bool {
 		TraceContextFunc: func() (string, string, string) {
 			return s.CurrentTraceContext()
 		},
-		PolicyEngine:  platform.NewPolicyAdapter(p.engine),
-		EventChannel:  eventChan,
-		MaxBackground: a.cfg.Sandbox.FUSE.MaxBackground,
+		PolicyEngine:      platform.NewPolicyAdapter(p.engine),
+		EventChannel:      eventChan,
+		MaxBackground:     a.cfg.Sandbox.FUSE.MaxBackground,
+		SymlinkEscapeDeny: a.cfg.Policies.SymlinkEscapeDeny(),
 	}
 
 	// Configure soft-delete/trash if enabled

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -802,6 +802,14 @@ type PoliciesConfig struct {
 	ReloadInterval    string          `yaml:"reload_interval"`
 	DetectProjectRoot *bool           `yaml:"detect_project_root"` // nil means true (default enabled)
 	ProjectMarkers    []string        `yaml:"project_markers"`     // Override default markers
+	SymlinkEscape     string          `yaml:"symlink_escape"`      // "evaluate"/"deny"
+}
+
+// SymlinkEscapeDeny reports whether the workspace-escape blanket deny
+// is in effect (i.e. the user set "deny"). Default is "evaluate" --
+// any value other than literal "deny" returns false.
+func (c *PoliciesConfig) SymlinkEscapeDeny() bool {
+	return c.SymlinkEscape == "deny"
 }
 
 // ShouldDetectProjectRoot returns whether project root detection is enabled.
@@ -2106,6 +2114,12 @@ func validateConfig(cfg *Config) error {
 	case "monitor", "soft_block", "soft_delete", "strict":
 	default:
 		return fmt.Errorf("invalid sandbox.fuse.audit.mode %q", cfg.Sandbox.FUSE.Audit.Mode)
+	}
+	switch cfg.Policies.SymlinkEscape {
+	case "", "evaluate", "deny":
+		// "" gets normalized to "evaluate" by SymlinkEscapeDeny().
+	default:
+		return fmt.Errorf("invalid policies.symlink_escape %q: must be one of \"evaluate\" or \"deny\"", cfg.Policies.SymlinkEscape)
 	}
 	switch cfg.Sandbox.Seccomp.Syscalls.OnBlock {
 	case "", "errno", "kill", "log", "log_and_kill":

--- a/internal/config/symlink_escape_test.go
+++ b/internal/config/symlink_escape_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateConfig_RejectsBadSymlinkEscape mirrors the existing
+// validator-rejection style (see TestValidateConfig_RejectsBadFailMode):
+// an unrecognized policies.symlink_escape value must fail validation at
+// load time, not silently default.
+func TestValidateConfig_RejectsBadSymlinkEscape(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.Policies.SymlinkEscape = "loosey-goosey"
+
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("invalid policies.symlink_escape must fail validation")
+	}
+	if !strings.Contains(err.Error(), "symlink_escape") ||
+		!strings.Contains(err.Error(), "loosey-goosey") {
+		t.Errorf("error should mention symlink_escape and the bad value; got: %v", err)
+	}
+}
+
+// TestValidateConfig_AcceptsValidSymlinkEscape covers the documented
+// values ("" gets normalized to "evaluate" by SymlinkEscapeDeny()).
+func TestValidateConfig_AcceptsValidSymlinkEscape(t *testing.T) {
+	for _, v := range []string{"", "evaluate", "deny"} {
+		cfg := &Config{}
+		applyDefaults(cfg)
+		cfg.Policies.SymlinkEscape = v
+		if err := validateConfig(cfg); err != nil {
+			if strings.Contains(err.Error(), "symlink_escape") {
+				t.Errorf("valid symlink_escape %q should not be rejected; got: %v", v, err)
+			}
+		}
+	}
+}
+
+// TestPoliciesConfig_SymlinkEscapeDeny covers the helper's semantics
+// directly. Validator already rejects anything not in {"", "evaluate",
+// "deny"}, but the helper is defensive against future schema drift.
+func TestPoliciesConfig_SymlinkEscapeDeny(t *testing.T) {
+	cases := []struct {
+		in   string
+		deny bool
+	}{
+		{"", false},
+		{"evaluate", false},
+		{"deny", true},
+		{"DENY", false}, // case-sensitive on purpose; matches the validator's literal set
+		{"anything-else", false},
+	}
+	for _, c := range cases {
+		got := (&PoliciesConfig{SymlinkEscape: c.in}).SymlinkEscapeDeny()
+		if got != c.deny {
+			t.Errorf("SymlinkEscape=%q: got deny=%v, want %v", c.in, got, c.deny)
+		}
+	}
+}

--- a/internal/fsmonitor/check_symlink_test.go
+++ b/internal/fsmonitor/check_symlink_test.go
@@ -1,0 +1,272 @@
+//go:build !windows
+
+package fsmonitor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/hanwen/go-fuse/v2/fs"
+)
+
+func newCheckTestNode(t *testing.T, workspace string, pol *policy.Policy) *node {
+	t.Helper()
+	return newCheckTestNodeWithEscape(t, workspace, pol, false)
+}
+
+// newCheckTestNodeWithEscape lets a test pick the SymlinkEscapeDeny mode
+// without rewriting the whole node construction. escapeDeny=false (default)
+// matches the policies.symlink_escape="evaluate" mode; escapeDeny=true
+// matches the historical workspace-escape blanket-deny ("deny" mode).
+func newCheckTestNodeWithEscape(t *testing.T, workspace string, pol *policy.Policy, escapeDeny bool) *node {
+	t.Helper()
+	engine, err := policy.NewEngine(pol, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &node{
+		LoopbackNode: fs.LoopbackNode{RootData: &fs.LoopbackRoot{Path: workspace}},
+		hooks: &Hooks{
+			SessionID:         "session-symlink",
+			Policy:            engine,
+			VirtualRoot:       "/workspace",
+			SymlinkEscapeDeny: escapeDeny,
+		},
+	}
+}
+
+// realRoot returns the symlink-resolved form of dir, matching what
+// resolveRealPathUnderRoot uses internally (macOS resolves /var -> /private/var,
+// and t.TempDir() on some systems returns a path under /var).
+func realRoot(t *testing.T, dir string) string {
+	t.Helper()
+	r, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return filepath.Clean(dir)
+	}
+	return filepath.Clean(r)
+}
+
+// TestCheck_StatOnSymlinkLeafDoesNotResolveTarget is a regression test
+// for the venv/bin/python case: an lstat/readlink/delete/rmdir on a
+// workspace symlink whose target lies outside the workspace must
+// evaluate the policy on the symlink path itself, not on the target.
+// Pre-fix, check() always called the resolver with mustExist=true, which
+// dereferenced the leaf symlink and routed the policy check to the
+// target (e.g. /usr/bin/python3), denying a normal operation on a
+// symlink the agent itself just created.
+func TestCheck_StatOnSymlinkLeafDoesNotResolveTarget(t *testing.T) {
+	workspace := t.TempDir()
+	outsideDir := t.TempDir()
+	outsideTarget := filepath.Join(outsideDir, "system-binary")
+	if err := os.WriteFile(outsideTarget, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(workspace, "venv", "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Mimic venv/bin/python -> <outside>/system-binary.
+	if err := os.Symlink(outsideTarget, filepath.Join(workspace, "venv", "bin", "python")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	// Policy: deny the outside target, allow the workspace.
+	// Pre-fix, all four ops resolved to <outside>/system-binary and
+	// matched the deny rule. Post-fix, the policy check runs against
+	// the link path under the workspace and matches the allow rule.
+	pol := &policy.Policy{
+		Version: 1,
+		Name:    "venv-test",
+		FileRules: []policy.FileRule{
+			{Name: "deny-outside", Paths: []string{realRoot(t, outsideDir) + "/**"}, Operations: []string{"*"}, Decision: "deny"},
+			{Name: "allow-workspace", Paths: []string{realRoot(t, workspace) + "/**"}, Operations: []string{"*"}, Decision: "allow"},
+		},
+	}
+	n := newCheckTestNode(t, workspace, pol)
+
+	for _, op := range []string{"stat", "readlink", "delete", "rmdir"} {
+		dec := n.check(context.Background(), "/workspace/venv/bin/python", op)
+		if dec.EffectiveDecision == types.DecisionDeny {
+			t.Errorf("op=%q on workspace symlink leaf was denied (rule=%q); "+
+				"expected allow -- check() must not dereference leaf for this op",
+				op, dec.Rule)
+		}
+		if dec.Rule == "deny-outside" {
+			t.Errorf("op=%q matched deny-outside rule; check() resolved leaf to target", op)
+		}
+	}
+}
+
+// TestCheck_OpenOnSymlinkFallsThroughToTargetPolicy verifies the other
+// half of the fix: for operations whose subject IS the target
+// (open/read/write), checkWithExist no longer blanket-denies when the
+// target lies outside the workspace. Instead it falls through to
+// evalEscapedSymlink and evaluates the policy against the resolved
+// outside path. Operators that want to block system symlinks can do so
+// with a regular file_rule deny on the target path.
+func TestCheck_OpenOnSymlinkFallsThroughToTargetPolicy(t *testing.T) {
+	workspace := t.TempDir()
+	outsideDir := t.TempDir()
+	outsideTarget := filepath.Join(outsideDir, "system-binary")
+	if err := os.WriteFile(outsideTarget, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(workspace, "venv", "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideTarget, filepath.Join(workspace, "venv", "bin", "python")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	outsideGlob := realRoot(t, outsideDir) + "/**"
+	workspaceGlob := realRoot(t, workspace) + "/**"
+
+	// First: allow the outside target explicitly -- the resolved-outside
+	// path should match the allow rule, not the old hardcoded
+	// "workspace-escape" deny.
+	allowPol := &policy.Policy{
+		Version: 1,
+		Name:    "allow-outside",
+		FileRules: []policy.FileRule{
+			{Name: "allow-outside", Paths: []string{outsideGlob}, Operations: []string{"*"}, Decision: "allow"},
+			{Name: "allow-workspace", Paths: []string{workspaceGlob}, Operations: []string{"*"}, Decision: "allow"},
+		},
+	}
+	n := newCheckTestNode(t, workspace, allowPol)
+	dec := n.check(context.Background(), "/workspace/venv/bin/python", "read")
+	if dec.EffectiveDecision == types.DecisionDeny {
+		t.Errorf("read with outside allowed: rule=%q decision=%v; expected allow",
+			dec.Rule, dec.EffectiveDecision)
+	}
+	if dec.Rule == "workspace-escape" {
+		t.Errorf("rule=workspace-escape; should have fallen through to file_rule eval")
+	}
+
+	// Second: deny the outside target -- now the symlink-target eval
+	// should deny via the regular file rule, not via workspace-escape.
+	denyPol := &policy.Policy{
+		Version: 1,
+		Name:    "deny-outside",
+		FileRules: []policy.FileRule{
+			{Name: "deny-outside", Paths: []string{outsideGlob}, Operations: []string{"*"}, Decision: "deny"},
+			{Name: "allow-workspace", Paths: []string{workspaceGlob}, Operations: []string{"*"}, Decision: "allow"},
+		},
+	}
+	n2 := newCheckTestNode(t, workspace, denyPol)
+	dec = n2.check(context.Background(), "/workspace/venv/bin/python", "read")
+	if dec.EffectiveDecision != types.DecisionDeny {
+		t.Errorf("read with outside denied: rule=%q decision=%v; expected deny",
+			dec.Rule, dec.EffectiveDecision)
+	}
+	if dec.Rule == "workspace-escape" {
+		t.Errorf("rule=workspace-escape; should be the regular deny-outside file rule")
+	}
+}
+
+// TestCheck_SymlinkEscapeDenyRestoresBlanketDeny verifies that with
+// policies.symlink_escape="deny" (SymlinkEscapeDeny=true), a workspace
+// symlink whose target lies outside the workspace root returns the
+// historical "workspace-escape" deny -- even when a file_rule would
+// otherwise allow the resolved target. This is the opt-in strict
+// posture the maintainer asked for in the PR #313 review.
+func TestCheck_SymlinkEscapeDenyRestoresBlanketDeny(t *testing.T) {
+	workspace := t.TempDir()
+	outsideDir := t.TempDir()
+	outsideTarget := filepath.Join(outsideDir, "system-binary")
+	if err := os.WriteFile(outsideTarget, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(workspace, "venv", "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outsideTarget, filepath.Join(workspace, "venv", "bin", "python")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	// Policy explicitly allows the outside target. Under
+	// SymlinkEscapeDeny=true the workspace-escape rule must still win.
+	pol := &policy.Policy{
+		Version: 1,
+		Name:    "allow-outside",
+		FileRules: []policy.FileRule{
+			{Name: "allow-outside", Paths: []string{realRoot(t, outsideDir) + "/**"}, Operations: []string{"*"}, Decision: "allow"},
+			{Name: "allow-workspace", Paths: []string{realRoot(t, workspace) + "/**"}, Operations: []string{"*"}, Decision: "allow"},
+		},
+	}
+	n := newCheckTestNodeWithEscape(t, workspace, pol, true)
+	dec := n.check(context.Background(), "/workspace/venv/bin/python", "read")
+	if dec.EffectiveDecision != types.DecisionDeny {
+		t.Fatalf("with SymlinkEscapeDeny=true, escaped-target read must deny; got %v rule=%q",
+			dec.EffectiveDecision, dec.Rule)
+	}
+	if dec.Rule != "workspace-escape" {
+		t.Errorf("rule=%q; want workspace-escape (strict-mode blanket)", dec.Rule)
+	}
+}
+
+// TestCheck_DotDotEscapeStillDeniesAsWorkspaceEscape verifies that
+// "..":-style escapes (paths above the workspace root) remain a hard
+// "workspace-escape" deny even after the fall-through is added.
+func TestCheck_DotDotEscapeStillDeniesAsWorkspaceEscape(t *testing.T) {
+	workspace := t.TempDir()
+	pol := &policy.Policy{
+		Version: 1,
+		Name:    "allow-all",
+		FileRules: []policy.FileRule{
+			{Name: "allow-all", Paths: []string{"/**"}, Operations: []string{"*"}, Decision: "allow"},
+		},
+	}
+	n := newCheckTestNode(t, workspace, pol)
+	// "/workspace/../etc/hostname" is not under /workspace and must deny.
+	dec := n.check(context.Background(), "/workspace/../etc/hostname", "read")
+	if dec.EffectiveDecision != types.DecisionDeny {
+		t.Fatalf("..-style escape must deny; got %v rule=%q", dec.EffectiveDecision, dec.Rule)
+	}
+	if dec.Rule != "workspace-escape" {
+		t.Errorf("..-style escape rule=%q; want workspace-escape", dec.Rule)
+	}
+}
+
+// the previous TestCheck_DotDot... test only passed because /workspace/../etc/hostname
+// resolves to a path that does not exist under the temp parent (EvalSymlinks errors -> "" ->
+// workspace-escape). With a real sibling on disk and a broad "/**" allow
+// rule, the ".."-escape would have resolved to the sibling and been
+// allowed before the evalEscapedSymlink containment guard. It must still
+// deny as workspace-escape.
+func TestCheck_DotDotEscapeToExistingSiblingDeniesAsWorkspaceEscape(t *testing.T) {
+	parent := t.TempDir()
+	workspace := filepath.Join(parent, "workspace")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Real sibling of the workspace root with an existing file, so a
+	// ".." escape that reached EvalSymlinks would succeed.
+	sibling := filepath.Join(parent, "outside")
+	if err := os.MkdirAll(sibling, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sibling, "secret"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pol := &policy.Policy{
+		Version: 1,
+		Name:    "allow-all",
+		FileRules: []policy.FileRule{
+			{Name: "allow-all", Paths: []string{"/**"}, Operations: []string{"*"}, Decision: "allow"},
+		},
+	}
+	n := newCheckTestNode(t, workspace, pol)
+
+	dec := n.check(context.Background(), "/workspace/../outside/secret", "read")
+	if dec.EffectiveDecision != types.DecisionDeny {
+		t.Fatalf("..-escape to existing sibling must deny; got %v rule=%q", dec.EffectiveDecision, dec.Rule)
+	}
+	if dec.Rule != "workspace-escape" {
+		t.Errorf("..-escape to existing sibling rule=%q; want workspace-escape", dec.Rule)
+	}
+}

--- a/internal/fsmonitor/fuse.go
+++ b/internal/fsmonitor/fuse.go
@@ -28,15 +28,16 @@ type Emitter interface {
 }
 
 type Hooks struct {
-	SessionID        string
-	Session          *session.Session
-	Policy           *policy.Engine
-	Approvals        *approvals.Manager
-	Emit             Emitter
-	FUSEAudit        *FUSEAuditHooks
-	TraceContextFunc func() (traceID, spanID, traceFlags string)
-	VirtualRoot      string // "/workspace" or real path
-	MaxBackground int
+	SessionID         string
+	Session           *session.Session
+	Policy            *policy.Engine
+	Approvals         *approvals.Manager
+	Emit              Emitter
+	FUSEAudit         *FUSEAuditHooks
+	TraceContextFunc  func() (traceID, spanID, traceFlags string)
+	VirtualRoot       string // "/workspace" or real path
+	MaxBackground     int
+	SymlinkEscapeDeny bool
 }
 
 func NewMonitoredLoopbackRoot(realRoot string, hooks *Hooks) (fs.InodeEmbedder, error) {
@@ -381,7 +382,21 @@ func (f *fileHandle) Release(ctx context.Context) syscall.Errno {
 }
 
 func (n *node) check(ctx context.Context, virtPath string, op string) policy.Decision {
-	mustExist := op != "create" && op != "mkdir"
+	// Operations whose policy subject is the path itself, not what a
+	// leaf symlink points to: stat, readlink, delete, rmdir. For these,
+	// treat the path like create/mkdir for the resolver -- only resolve
+	// the parent directory, leave the leaf symlink alone.
+	//
+	// Without this, an lstat/unlink on a workspace symlink whose target
+	// lies outside the workspace (e.g. venv/bin/python -> /usr/bin/python3,
+	// or venv/lib64 -> lib) re-routes the policy check to the target,
+	// which the per-session policy may not allow, surfacing as EACCES
+	// for a perfectly normal operation on a symlink the agent itself
+	// just created. unlink/rmdir remove the symlink; the target is
+	// untouched, so checking the target is the wrong subject.
+	mustExist := op != "create" && op != "mkdir" &&
+		op != "stat" && op != "readlink" &&
+		op != "delete" && op != "rmdir"
 	return n.checkWithExist(ctx, virtPath, op, mustExist)
 }
 
@@ -398,14 +413,41 @@ func (n *node) checkWithExist(_ context.Context, virtPath string, op string, mus
 	if realRoot != "" {
 		resolved, err := resolveRealPathUnderRoot(realRoot, virtPath, mustExist, n.vroot())
 		if err != nil {
-			return policy.Decision{
-				PolicyDecision:    types.DecisionDeny,
-				EffectiveDecision: types.DecisionDeny,
-				Rule:              "workspace-escape",
-				Message:           err.Error(),
+			// When resolveRealPathUnderRoot fails because a symlink in the
+			// workspace points to a real path outside the workspace root
+			// (Python venvs do this with /usr/bin/python3 by default), the
+			// default behavior is to fall through to evaluate the policy on
+			// the resolved outside path instead of an automatic deny.
+			// Operators who want to block system symlinks can express that
+			// as a regular file_rule deny on the relevant paths.
+			//
+			// Deployments that prefer the historical blanket deny can opt
+			// back in via policies.symlink_escape: "deny" (in that mode
+			// we skip the fallthrough and return the workspace-escape rule
+			// for any symlink target outside the workspace root).
+			//
+			// "..":-style escapes (paths above the workspace root) and
+			// resolution failures (broken link, missing parent) remain a
+			// hard deny in both modes since there is no useful real path
+			// to evaluate.
+			escapeDeny := n.hooks != nil && n.hooks.SymlinkEscapeDeny
+			var escaped string
+			if !escapeDeny {
+				escaped = evalEscapedSymlink(realRoot, virtPath, n.vroot())
 			}
+			if escaped != "" {
+				policyPath = escaped
+			} else {
+				return policy.Decision{
+					PolicyDecision:    types.DecisionDeny,
+					EffectiveDecision: types.DecisionDeny,
+					Rule:              "workspace-escape",
+					Message:           err.Error(),
+				}
+			}
+		} else {
+			policyPath = resolved
 		}
-		policyPath = resolved
 	}
 
 	if n.hooks == nil || n.hooks.Policy == nil {

--- a/internal/fsmonitor/path.go
+++ b/internal/fsmonitor/path.go
@@ -62,3 +62,51 @@ func resolveRealPathUnderRoot(realRoot string, virtPath string, mustExist bool, 
 	}
 	return out, nil
 }
+
+// evalEscapedSymlink resolves virtPath fully through symlinks when the
+// in-workspace candidate path resolves, via a symlink, to a target
+// outside realRoot. Returns the cleaned real target, or the empty
+// string if this is not a legitimate symlink-target escape (broken
+// link, missing parent, or a "..":-style path escape).
+//
+// Used by checkWithExist to fall back from a blanket "workspace-escape"
+// deny to a regular policy evaluation when the only "escape" is via a
+// symlink whose target is outside the workspace. Lets a policy
+// explicitly govern common system symlink targets (e.g. /usr/bin/python3
+// for Python venvs, /usr/lib for venv/lib64) via the usual file_rules
+// instead of agentsh's hardcoded blanket deny.
+//
+// Important: only *symlink-target* escapes fall through. A "..":-style
+// path escape (e.g. /workspace/../outside/secret) must NOT, even when
+// the sibling exists on disk -- otherwise a broad rule like /** would
+// allow reading arbitrary sibling paths. filepath.Join cleans the
+// candidate, so such a path lands outside rootClean before any symlink
+// resolution; we check containment of the pre-resolution candidate and
+// bail (returning "" -> caller keeps the workspace-escape deny) when it
+// is not under rootClean. This mirrors the fast ".." escape check in
+// resolveRealPathUnderRoot.
+func evalEscapedSymlink(realRoot, virtPath, virtualRoot string) string {
+	if !pathutil.IsUnderRoot(virtPath, virtualRoot) {
+		return ""
+	}
+	rel := pathutil.TrimRootPrefix(virtPath, virtualRoot)
+	rel = strings.TrimPrefix(rel, "/")
+	rootClean, err := filepath.EvalSymlinks(filepath.Clean(realRoot))
+	if err != nil {
+		rootClean = filepath.Clean(realRoot)
+	}
+	candidate := filepath.Join(rootClean, filepath.FromSlash(rel))
+	// Reject ".."-style escapes before touching the filesystem: the
+	// candidate itself must stay under the workspace root. Only the
+	// final symlink *target* is allowed to point outside (handled by
+	// the resolve below). filepath.Join has already cleaned candidate,
+	// so an escaping rel has consumed the root prefix here.
+	if !pathutil.IsRealPathUnder(candidate, rootClean) {
+		return ""
+	}
+	resolved, err := filepath.EvalSymlinks(candidate)
+	if err != nil {
+		return ""
+	}
+	return filepath.Clean(resolved)
+}

--- a/internal/fsmonitor/path_test.go
+++ b/internal/fsmonitor/path_test.go
@@ -54,3 +54,77 @@ func TestResolveRealPathUnderRoot_UsesParentForCreate(t *testing.T) {
 		t.Fatalf("expected escape error")
 	}
 }
+
+func TestEvalEscapedSymlink_ResolvesOutsideTarget(t *testing.T) {
+	// Simulates a venv-style symlink: workspace/bin/python -> /etc/hostname
+	// (using /etc/hostname instead of /usr/bin/python3 so the test runs on
+	// systems with arbitrary Python installs).
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("/etc/hostname", filepath.Join(root, "bin", "python")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	// Sanity: resolveRealPathUnderRoot rejects this with a symlink-escape error.
+	if _, err := resolveRealPathUnderRoot(root, "/workspace/bin/python", true, "/workspace"); err == nil {
+		t.Fatalf("expected resolveRealPathUnderRoot to fail on escaping symlink")
+	}
+
+	// evalEscapedSymlink should return the resolved outside path so the
+	// caller can policy-check it instead of blanket-denying.
+	got := evalEscapedSymlink(root, "/workspace/bin/python", "/workspace")
+	want, err := filepath.EvalSymlinks("/etc/hostname")
+	if err != nil {
+		t.Skipf("/etc/hostname not resolvable: %v", err)
+	}
+	if got != filepath.Clean(want) {
+		t.Fatalf("evalEscapedSymlink = %q; want %q", got, filepath.Clean(want))
+	}
+}
+
+func TestEvalEscapedSymlink_BrokenLinkReturnsEmpty(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Symlink("/no/such/path/anywhere", filepath.Join(root, "broken")); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+	if got := evalEscapedSymlink(root, "/workspace/broken", "/workspace"); got != "" {
+		t.Fatalf("broken link should return empty; got %q", got)
+	}
+}
+
+func TestEvalEscapedSymlink_PathNotUnderRootReturnsEmpty(t *testing.T) {
+	root := t.TempDir()
+	if got := evalEscapedSymlink(root, "/elsewhere/foo", "/workspace"); got != "" {
+		t.Fatalf("non-/workspace path should return empty; got %q", got)
+	}
+}
+
+// a "..":-style escape whose resolved sibling actually exists on disk
+// must NOT fall through to file_rules. pathutil.IsUnderRoot only checks
+// the raw virtual prefix (which "/workspace/../sibling/secret" passes),
+// but filepath.Join cleans the candidate to a real sibling of the workspace root.
+// evalEscapedSymlink must reject it (return "") before resolving so the caller keeps the
+// workspace-escape deny -- otherwise a broad allow rule like /** could
+// read arbitrary sibling paths.
+func TestEvalEscapedSymlink_DotDotEscapeToExistingSiblingReturnsEmpty(t *testing.T) {
+	parent := t.TempDir()
+	root := filepath.Join(parent, "workspace")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Real sibling next to the workspace root, with an existing file, so
+	// EvalSymlinks would succeed if we ever reached it.
+	sibling := filepath.Join(parent, "outside")
+	if err := os.MkdirAll(sibling, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sibling, "secret"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := evalEscapedSymlink(root, "/workspace/../outside/secret", "/workspace"); got != "" {
+		t.Fatalf("..-escape to existing sibling must return empty (stay workspace-escape); got %q", got)
+	}
+}

--- a/internal/platform/interfaces.go
+++ b/internal/platform/interfaces.go
@@ -111,6 +111,13 @@ type FSConfig struct {
 	// default" (go-fuse uses 12, matching the kernel default).
 	MaxBackground int
 
+	// SymlinkEscapeDeny, when true, restores the historical blanket
+	// "workspace-escape" deny for workspace symlinks pointing outside
+	// the workspace root. When false (default), the resolved outside
+	// path is evaluated against the normal file_rules instead.
+	// Plumbed from policies.symlink_escape: "deny" | "evaluate".
+	SymlinkEscapeDeny bool
+
 	// Options contains platform-specific mount options
 	Options map[string]string
 }

--- a/internal/platform/linux/filesystem.go
+++ b/internal/platform/linux/filesystem.go
@@ -267,8 +267,9 @@ func (fs *Filesystem) Mount(cfg platform.FSConfig) (platform.FSMount, error) {
 			sessionID:     cfg.SessionID,
 			commandIDFunc: cfg.CommandIDFunc,
 		},
-		TraceContextFunc: cfg.TraceContextFunc,
-		MaxBackground:    cfg.MaxBackground,
+		TraceContextFunc:  cfg.TraceContextFunc,
+		MaxBackground:     cfg.MaxBackground,
+		SymlinkEscapeDeny: cfg.SymlinkEscapeDeny,
 	}
 
 	// Set up trash/soft-delete if configured

--- a/packaging/config.yaml
+++ b/packaging/config.yaml
@@ -110,6 +110,9 @@ dlp:
 policies:
   dir: "/etc/agentsh/policies"
   default: "default"
+  # symlink's target that evaluate to outside the workspace
+  # get evaluated (against file_rule) or flat out denied.
+  symlink_escape: "evaluate"   # Options: evaluate, deny
 
 # Approvals configuration
 approvals:


### PR DESCRIPTION
Two related issues with how the FUSE policy layer handles symlinks in the workspace, both triggered by ordinary Python venv usage (`python -m venv venv` -- the most common thing an agent does with Python):

1. Leaf-symlink subject mismatch.

   check() always called resolveRealPathUnderRoot with mustExist=true, which dereferenced the leaf symlink before policy lookup. For ops whose subject is the path itself (stat, readlink, delete, rmdir), this re-routed the check to the symlink's target. So `ls venv/bin` (lstat on each entry) and `rm -rf venv` (unlink each entry) denied on the `venv/bin/python -> /usr/bin/python3` link with EACCES, because the policy has no rule for /usr/bin/**.

   Fix: extend the mustExist=false set in check() to include stat, readlink, delete, and rmdir. The resolver then only walks the parent directory and leaves the leaf symlink alone. unlink/rmdir remove the symlink; the target is untouched, so checking the target was the wrong subject.

2. Workspace-escape blanket deny on system-symlink targets.

   When the resolved target of a symlink falls outside the workspace root, checkWithExist returned a hardcoded "workspace-escape" deny. That made it impossible to express "allow read via /usr/bin/python3" in policy -- every venv read/exec was an automatic deny regardless of file_rules.

   Fix: on resolveRealPathUnderRoot failure, call a new helper evalEscapedSymlink(realRoot, virtPath, virtualRoot) that fully resolves through symlinks even when the result lies outside the workspace. If it returns a resolvable real path, evaluate the policy on that path. Operators who want to block system symlinks can still do so via a regular file_rule deny on /usr/bin/** etc. "..":-style escapes and unresolvable links remain a hard deny since there is no useful real path to evaluate.

Tests:
- internal/fsmonitor/path_test.go: unit tests for evalEscapedSymlink (resolves outside target, returns "" on broken link, returns "" when path is not under virtual root).
- internal/fsmonitor/check_symlink_test.go: behavioral tests on a minimal node{} that exercise check() directly:
  - stat/readlink/delete/rmdir on a workspace symlink-to-outside no longer dereferences the leaf;
  - read on a workspace symlink-to-outside falls through to the file_rule governing the target (allow or deny), not the hardcoded workspace-escape rule;
  - "..":-style escapes still deny as workspace-escape.

Note: part 2 is a policy-semantics change. If maintainers prefer the fallthrough gated behind a config flag (e.g. policy.symlink_escape: "evaluate" | "deny"), happy to add that -- but the current default (evaluate, with operators expressing deny via regular file_rules) seems closer to the principle of least surprise: agentsh shouldn't have hardcoded path policy that operators can't override.