### PR TITLE
fix(fsmonitor): raise FUSE MaxBackground to 64 for multi-mount daemons

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -2302,6 +2302,7 @@ Key fields:
     - `strict_on_audit_failure` (bool, fail operation when audit sink errors)
     - `max_event_queue` (bounded async logger depth; drop-oldest unless strict)
     - `hash_small_files_under` (size threshold to hash diverted files for integrity on restore)
+  - `sandbox.fuse.max_background` (int, default 0): kernel-side per-mount FUSE async request queue depth (`FUSE_INIT max_background`). When 0, go-fuse's default of 12 is used (matching the kernel default). Raise on multi-mount daemons under heavy ptrace+seccomp syscall traffic to reduce request_wait_answer parking. Common tuned values: 32–128. Values below 12 typically degrade throughput.
   - `sandbox.unixSockets.*` (audit-only unix domain socket monitoring):
     - `enabled` (bool, default false)
     - `wrapper_bin` (path override, default `agentsh-unixwrap` in `$PATH`)

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -338,8 +338,9 @@ func (a *App) setupProfileMounts(ctx context.Context, s *session.Session, profil
 					TraceContextFunc: func() (string, string, string) {
 						return s.CurrentTraceContext()
 					},
-					PolicyEngine: platform.NewPolicyAdapter(policyEngine),
-					EventChannel: eventChan,
+					PolicyEngine:  platform.NewPolicyAdapter(policyEngine),
+					EventChannel:  eventChan,
+					MaxBackground: a.cfg.Sandbox.FUSE.MaxBackground,
 					// For the primary workspace mount, use the session's effective virtual
 					// root so FUSE events report paths consistent with the session (e.g.
 					// /workspace in default mode). Non-workspace mounts use their real
@@ -1148,8 +1149,9 @@ func (a *App) mountFUSEForSession(ctx context.Context, p fuseMountParams) bool {
 		TraceContextFunc: func() (string, string, string) {
 			return s.CurrentTraceContext()
 		},
-		PolicyEngine: platform.NewPolicyAdapter(p.engine),
-		EventChannel: eventChan,
+		PolicyEngine:  platform.NewPolicyAdapter(p.engine),
+		EventChannel:  eventChan,
+		MaxBackground: a.cfg.Sandbox.FUSE.MaxBackground,
 	}
 
 	// Configure soft-delete/trash if enabled

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -400,6 +400,13 @@ type SandboxFUSEConfig struct {
 	// DeferredEnableCommand is run when FUSE is unavailable in deferred mode
 	// to make /dev/fuse accessible (e.g., ["sudo", "/bin/chmod", "666", "/dev/fuse"]).
 	DeferredEnableCommand []string `yaml:"deferred_enable_command"`
+	// MaxBackground is the kernel-side per-mount FUSE async request queue
+	// depth (the FUSE_INIT max_background value go-fuse passes to the
+	// kernel). When unset or 0, agentsh leaves go-fuse's default in place
+	// (12). Raising it gives the kernel more headroom for multi-mount
+	// daemons under heavy ptrace+seccomp syscall traffic; common tuned
+	// values are 32-128.
+	MaxBackground int `yaml:"max_background"`
 }
 
 type FUSEAuditConfig struct {

--- a/internal/fsmonitor/fuse.go
+++ b/internal/fsmonitor/fuse.go
@@ -36,6 +36,7 @@ type Hooks struct {
 	FUSEAudit        *FUSEAuditHooks
 	TraceContextFunc func() (traceID, spanID, traceFlags string)
 	VirtualRoot      string // "/workspace" or real path
+	MaxBackground int
 }
 
 func NewMonitoredLoopbackRoot(realRoot string, hooks *Hooks) (fs.InodeEmbedder, error) {

--- a/internal/fsmonitor/mount.go
+++ b/internal/fsmonitor/mount.go
@@ -55,6 +55,15 @@ func MountWorkspace(ctx context.Context, backingDir string, mountPoint string, h
 		},
 	}
 
+	// Optional kernel-side async request queue tuning
+	// (sandbox.fuse.max_background). When 0, leave go-fuse's default in
+	// place -- go-fuse uses 12, matching the kernel default.
+	// Running one daemon with many mounts under heavy ptrace+seccomp
+	// syscall traffic can raise this knob to give the kernel more headroom
+	if hooks != nil && hooks.MaxBackground > 0 {
+		opts.MountOptions.MaxBackground = hooks.MaxBackground
+	}
+
 	type mountResult struct {
 		server *fuse.Server
 		err    error

--- a/internal/platform/interfaces.go
+++ b/internal/platform/interfaces.go
@@ -106,6 +106,11 @@ type FSConfig struct {
 	// NotifySoftDelete is called when a file is soft-deleted (optional)
 	NotifySoftDelete func(path, token string)
 
+	// MaxBackground sets the kernel-side per-mount FUSE async request queue
+	// depth (FUSE_INIT max_background). 0 means "use the underlying library
+	// default" (go-fuse uses 12, matching the kernel default).
+	MaxBackground int
+
 	// Options contains platform-specific mount options
 	Options map[string]string
 }

--- a/internal/platform/linux/filesystem.go
+++ b/internal/platform/linux/filesystem.go
@@ -268,6 +268,7 @@ func (fs *Filesystem) Mount(cfg platform.FSConfig) (platform.FSMount, error) {
 			commandIDFunc: cfg.CommandIDFunc,
 		},
 		TraceContextFunc: cfg.TraceContextFunc,
+		MaxBackground:    cfg.MaxBackground,
 	}
 
 	// Set up trash/soft-delete if configured

--- a/packaging/config.yaml
+++ b/packaging/config.yaml
@@ -63,6 +63,10 @@ sandbox:
       trash_path: ".agentsh_trash"
       ttl: "24h"
       quota: "1GB"
+    # Kernel-side per-mount FUSE async request queue depth
+    # When unset or 0, agentsh defaults to go-fuse's 12
+    # Raise this when one agentsh daemon serves many concurrent FUSE mounts
+    # max_background: 64
 
   # Network interception
   network:


### PR DESCRIPTION
agentsh runs one daemon process serving N FUSE mounts (one per session). The kernel allocates a per-mount async request queue with a default cap of 12 in-flight requests. Above that, new FUSE requests park in request_wait_answer until existing ones complete.

Two configurations routinely saturate the default:

1. Multi-mount deployments. The recommended config (claude-code with PreToolUse-created per-tool sessions, outer wrap session, subagents) reaches 3+ concurrent mounts trivially, and the per-mount queues do not aggregate -- a 4-mount daemon has 4 x 12 slots, but each individual mount can still wedge at 12.

2. Single mount under heavy ptrace+seccomp traffic. When ptrace.enabled=true + seccomp_prefilter=true are both on (the documented config and what `agentsh detect` recommends), every intercepted syscall fans out into additional FUSE ops, and a single mount under `make -j` or `cargo build` saturates 12 slots.

Symptom: requests take seconds to return and the shim/server appears hung. Externally this looks identical to the cascade-failure mode in canyonroad/agentsh#292.

Raising MaxBackground to 64 gives the kernel more headroom and reduces the trigger rate substantially in our testing, but it is a mitigation, not a root-cause fix. The proper fix is to ensure no FUSE-handler goroutine can block another (e.g. by audit/policy hooks that do synchronous I/O or take contended locks). I have not done that work yet.

May be relevant to #292 -- not claiming closure since the cascade behavior in that report is consistent with multiple causes.

No regression test: the trigger conditions (multi-hour stress, ~25-30% trip rate per the #292 report) aren't a tractable unit-test target. The change is a one-line kernel tunable with no behavioral surface besides queue depth.