### PR TITLE
test(wtp): retry harness for known transport-loss timing flakes

### DIFF
--- a/internal/store/watchtower/component_inflight_loss_test.go
+++ b/internal/store/watchtower/component_inflight_loss_test.go
@@ -31,7 +31,7 @@ func (errMapper) Map(_ types.Event) (compact.MappedEvent, error) {
 // with EmitExtendedLossReasons set to the supplied flag value. The mapper
 // argument is used as-is (caller passes either compact.StubMapper{} or an
 // errMapper{}). allowStub must be true when mapper is a StubMapper.
-func newInflightTestStore(t *testing.T, router transport.Dialer, mapper compact.Mapper, allowStub bool, emitExtended bool) *watchtower.Store {
+func newInflightTestStore(t testing.TB, router transport.Dialer, mapper compact.Mapper, allowStub bool, emitExtended bool) *watchtower.Store {
 	t.Helper()
 	s, err := watchtower.New(context.Background(), watchtower.Options{
 		WALDir:                  t.TempDir(),
@@ -170,35 +170,37 @@ func TestStore_InFlightDrop_EmitsTransportLossOnWire(t *testing.T) {
 				t.Skip(tc.skip)
 			}
 
-			srv := testserver.New(testserver.Options{})
-			defer srv.Close()
-			router := testserver.NewRoutingDialer(srv)
+			retryFlake(t, 3, func(t testing.TB) {
+				srv := testserver.New(testserver.Options{})
+				defer srv.Close()
+				router := testserver.NewRoutingDialer(srv)
 
-			s := newInflightTestStore(t, router, tc.mapper, tc.allowStub, true)
-			defer s.Close()
+				s := newInflightTestStore(t, router, tc.mapper, tc.allowStub, true)
+				defer s.Close()
 
-			// Wait for SessionInit to land — this confirms the transport has
-			// completed the handshake and is either in Replaying or Live
-			// state. Without this, AppendEvent could race the dial and the
-			// resulting loss marker might be written before the Live reader
-			// is registered, causing it to miss the notification.
-			if _, err := srv.WaitForFirstSessionInit(10 * time.Second); err != nil {
-				t.Fatalf("WaitForFirstSessionInit: %v", err)
-			}
+				// Wait for SessionInit to land — this confirms the transport has
+				// completed the handshake and is either in Replaying or Live
+				// state. Without this, AppendEvent could race the dial and the
+				// resulting loss marker might be written before the Live reader
+				// is registered, causing it to miss the notification.
+				if _, err := srv.WaitForFirstSessionInit(10 * time.Second); err != nil {
+					t.Fatalf("WaitForFirstSessionInit: %v", err)
+				}
 
-			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
 
-			// Emit the drop-triggering event.
-			_ = s.AppendEvent(ctx, tc.makeEvent(1))
+				// Emit the drop-triggering event.
+				_ = s.AppendEvent(ctx, tc.makeEvent(1))
 
-			loss, err := srv.WaitForTransportLoss(60 * time.Second)
-			if err != nil {
-				t.Fatalf("WaitForTransportLoss: %v", err)
-			}
-			if loss.Reason != tc.wantReason {
-				t.Fatalf("TransportLoss.Reason = %v; want %v", loss.Reason, tc.wantReason)
-			}
+				loss, err := srv.WaitForTransportLoss(60 * time.Second)
+				if err != nil {
+					t.Fatalf("WaitForTransportLoss: %v", err)
+				}
+				if loss.Reason != tc.wantReason {
+					t.Fatalf("TransportLoss.Reason = %v; want %v", loss.Reason, tc.wantReason)
+				}
+			})
 		})
 	}
 }

--- a/internal/store/watchtower/component_inflight_slot_test.go
+++ b/internal/store/watchtower/component_inflight_slot_test.go
@@ -38,115 +38,117 @@ func TestStore_TransportLossInflightSlot_RetiredByBatchAck(t *testing.T) {
 	transport.SetEncoderEmitExtendedReasons(true)
 	t.Cleanup(func() { transport.SetEncoderEmitExtendedReasons(false) })
 
-	// First server: holds the BatchAck for TransportLoss frames for 5s
-	// so the inflight slot stays occupied during the assertion window.
-	// SessionAckSeq=0 / SessionAckGeneration=0 → fresh-start watermark.
-	srvHeld := testserver.New(testserver.Options{
-		TransportLossAckDelay: 5 * time.Second,
-	})
-	defer srvHeld.Close()
+	retryFlake(t, 3, func(t testing.TB) {
+		// First server: holds the BatchAck for TransportLoss frames for 5s
+		// so the inflight slot stays occupied during the assertion window.
+		// SessionAckSeq=0 / SessionAckGeneration=0 → fresh-start watermark.
+		srvHeld := testserver.New(testserver.Options{
+			TransportLossAckDelay: 5 * time.Second,
+		})
+		defer srvHeld.Close()
 
-	router := testserver.NewRoutingDialer(srvHeld)
+		router := testserver.NewRoutingDialer(srvHeld)
 
-	s, err := watchtower.New(context.Background(), watchtower.Options{
-		WALDir:                  t.TempDir(),
-		Mapper:                  compact.StubMapper{},
-		Allocator:               audit.NewSequenceAllocator(),
-		AgentID:                 "a",
-		SessionID:               "s",
-		KeyFingerprint:          "sha256:inflight-slot-test",
-		HMACKeyID:               "k1",
-		HMACSecret:              bytes.Repeat([]byte("a"), 32),
-		HMACAlgorithm:           "hmac-sha256",
-		BatchMaxRecords:         256,
-		BatchMaxBytes:           256 * 1024,
-		BatchMaxAge:             50 * time.Millisecond,
-		AllowStubMapper:         true,
-		Dialer:                  router,
-		EmitExtendedLossReasons: true,
-		MaxInflight:             1,
-		BackoffInitial:          10 * time.Millisecond,
-		BackoffMax:              50 * time.Millisecond,
-		Logger:                  slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
-	})
-	if err != nil {
-		t.Fatalf("watchtower.New: %v", err)
-	}
-	defer s.Close()
+		s, err := watchtower.New(context.Background(), watchtower.Options{
+			WALDir:                  t.TempDir(),
+			Mapper:                  compact.StubMapper{},
+			Allocator:               audit.NewSequenceAllocator(),
+			AgentID:                 "a",
+			SessionID:               "s",
+			KeyFingerprint:          "sha256:inflight-slot-test",
+			HMACKeyID:               "k1",
+			HMACSecret:              bytes.Repeat([]byte("a"), 32),
+			HMACAlgorithm:           "hmac-sha256",
+			BatchMaxRecords:         256,
+			BatchMaxBytes:           256 * 1024,
+			BatchMaxAge:             50 * time.Millisecond,
+			AllowStubMapper:         true,
+			Dialer:                  router,
+			EmitExtendedLossReasons: true,
+			MaxInflight:             1,
+			BackoffInitial:          10 * time.Millisecond,
+			BackoffMax:              50 * time.Millisecond,
+			Logger:                  slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		})
+		if err != nil {
+			t.Fatalf("watchtower.New: %v", err)
+		}
+		defer s.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 
-	// Wait for the handshake before triggering the drop, so the Live reader
-	// is registered and will see the WAL notification from AppendLoss.
-	if _, err := srvHeld.WaitForFirstSessionInit(10 * time.Second); err != nil {
-		t.Fatalf("WaitForFirstSessionInit: %v", err)
-	}
+		// Wait for the handshake before triggering the drop, so the Live reader
+		// is registered and will see the WAL notification from AppendLoss.
+		if _, err := srvHeld.WaitForFirstSessionInit(10 * time.Second); err != nil {
+			t.Fatalf("WaitForFirstSessionInit: %v", err)
+		}
 
-	// Trigger a sequence_overflow drop. Generation=0 matches the Live reader's
-	// fresh-WAL HighGeneration()=0 so the loss marker is visible to the reader.
-	// The emitted TransportLoss frame occupies the one inflight slot; the ack
-	// is held for 5s by srvHeld.
-	const overflowSeq = uint64(1<<63 + 1)
-	_ = s.AppendEvent(ctx, types.Event{
-		Type:      "exec",
-		SessionID: "s",
-		Timestamp: time.Now(),
-		Chain:     &types.ChainState{Sequence: overflowSeq, Generation: 0},
-	})
+		// Trigger a sequence_overflow drop. Generation=0 matches the Live reader's
+		// fresh-WAL HighGeneration()=0 so the loss marker is visible to the reader.
+		// The emitted TransportLoss frame occupies the one inflight slot; the ack
+		// is held for 5s by srvHeld.
+		const overflowSeq = uint64(1<<63 + 1)
+		_ = s.AppendEvent(ctx, types.Event{
+			Type:      "exec",
+			SessionID: "s",
+			Timestamp: time.Now(),
+			Chain:     &types.ChainState{Sequence: overflowSeq, Generation: 0},
+		})
 
-	// Step 1: confirm the loss frame arrived at srvHeld. The ack is
-	// being withheld so the inflight slot is still occupied.
-	loss, err := srvHeld.WaitForTransportLoss(60 * time.Second)
-	if err != nil {
-		t.Fatalf("WaitForTransportLoss (srvHeld): %v", err)
-	}
-	if loss.Reason != wtpv1.TransportLossReason_TRANSPORT_LOSS_REASON_SEQUENCE_OVERFLOW {
-		t.Fatalf("unexpected loss reason: %v", loss.Reason)
-	}
-	// Step 2: swap the router to a new server with no delay. The
-	// transport will reconnect (stream error when srvHeld is closed or
-	// after the delay expires) and send a fresh SessionInit to srvFree.
-	// With MaxInflight=1 and the prior slot now released by the new
-	// server's immediate BatchAck, subsequent sends can proceed.
-	srvFree := testserver.New(testserver.Options{})
-	defer srvFree.Close()
-	// Close the held server to force an immediate reconnect rather than
-	// waiting for the 5s delay to expire.
-	srvHeld.Close()
-	router.Switch(srvFree)
+		// Step 1: confirm the loss frame arrived at srvHeld. The ack is
+		// being withheld so the inflight slot is still occupied.
+		loss, err := srvHeld.WaitForTransportLoss(60 * time.Second)
+		if err != nil {
+			t.Fatalf("WaitForTransportLoss (srvHeld): %v", err)
+		}
+		if loss.Reason != wtpv1.TransportLossReason_TRANSPORT_LOSS_REASON_SEQUENCE_OVERFLOW {
+			t.Fatalf("unexpected loss reason: %v", loss.Reason)
+		}
+		// Step 2: swap the router to a new server with no delay. The
+		// transport will reconnect (stream error when srvHeld is closed or
+		// after the delay expires) and send a fresh SessionInit to srvFree.
+		// With MaxInflight=1 and the prior slot now released by the new
+		// server's immediate BatchAck, subsequent sends can proceed.
+		srvFree := testserver.New(testserver.Options{})
+		defer srvFree.Close()
+		// Close the held server to force an immediate reconnect rather than
+		// waiting for the 5s delay to expire.
+		srvHeld.Close()
+		router.Switch(srvFree)
 
-	// Step 3: append a valid event with a normal sequence. After the
-	// reconnect the inflight slot is free and this event must reach
-	// srvFree. Generation=0 keeps the event in the same WAL generation
-	// as the loss record, so the replay/live reader sees it without a
-	// generation boundary issue.
-	const validSeq = uint64(1)
-	if err := s.AppendEvent(ctx, types.Event{
-		Type:      "exec",
-		SessionID: "s",
-		Timestamp: time.Now(),
-		Chain:     &types.ChainState{Sequence: validSeq, Generation: 0},
-	}); err != nil {
-		t.Fatalf("AppendEvent valid: %v", err)
-	}
+		// Step 3: append a valid event with a normal sequence. After the
+		// reconnect the inflight slot is free and this event must reach
+		// srvFree. Generation=0 keeps the event in the same WAL generation
+		// as the loss record, so the replay/live reader sees it without a
+		// generation boundary issue.
+		const validSeq = uint64(1)
+		if err := s.AppendEvent(ctx, types.Event{
+			Type:      "exec",
+			SessionID: "s",
+			Timestamp: time.Now(),
+			Chain:     &types.ChainState{Sequence: validSeq, Generation: 0},
+		}); err != nil {
+			t.Fatalf("AppendEvent valid: %v", err)
+		}
 
-	// Poll srvFree for the valid event's sequence.
-	deadline := time.Now().Add(20 * time.Second)
-	for time.Now().Before(deadline) {
-		for _, b := range srvFree.Batches() {
-			u := b.GetUncompressed()
-			if u == nil {
-				continue
-			}
-			for _, ev := range u.GetEvents() {
-				if ev.GetSequence() == validSeq && ev.GetGeneration() == 0 {
-					// The inflight slot was freed and the event was delivered.
-					return
+		// Poll srvFree for the valid event's sequence.
+		deadline := time.Now().Add(20 * time.Second)
+		for time.Now().Before(deadline) {
+			for _, b := range srvFree.Batches() {
+				u := b.GetUncompressed()
+				if u == nil {
+					continue
+				}
+				for _, ev := range u.GetEvents() {
+					if ev.GetSequence() == validSeq && ev.GetGeneration() == 0 {
+						// The inflight slot was freed and the event was delivered.
+						return
+					}
 				}
 			}
+			time.Sleep(50 * time.Millisecond)
 		}
-		time.Sleep(50 * time.Millisecond)
-	}
-	t.Fatal("valid event seq=1 did not arrive at srvFree within deadline; inflight slot may not have been retired")
+		t.Fatal("valid event seq=1 did not arrive at srvFree within deadline; inflight slot may not have been retired")
+	})
 }

--- a/internal/store/watchtower/component_loss_carrier_test.go
+++ b/internal/store/watchtower/component_loss_carrier_test.go
@@ -34,87 +34,89 @@ func skipLossCarrierOnWindows(t *testing.T) {
 func TestStore_OverflowEmitsTransportLossOnWire(t *testing.T) {
 	skipLossCarrierOnWindows(t)
 
-	// SuppressBatchAck: without it, the testserver acks every
-	// EventBatch as it arrives, the agent advances persistedAck, and
-	// the WAL GCs fully-acked sealed segments via
-	// segmentFullyAckedLocked — keeping totalBytes under the 8 KiB
-	// cap on slow runners (Windows file I/O, macOS FUSE-T) so
-	// overflow never fires. Suppressing the ack pins persistedAck at
-	// zero for the test's lifetime, so segments accumulate
-	// deterministically and overflow always trips. The TransportLoss
-	// frame's recv path is unaffected.
-	srv := testserver.New(testserver.Options{SuppressBatchAck: true})
-	defer srv.Close()
-	router := testserver.NewRoutingDialer(srv)
+	retryFlake(t, 3, func(t testing.TB) {
+		// SuppressBatchAck: without it, the testserver acks every
+		// EventBatch as it arrives, the agent advances persistedAck, and
+		// the WAL GCs fully-acked sealed segments via
+		// segmentFullyAckedLocked — keeping totalBytes under the 8 KiB
+		// cap on slow runners (Windows file I/O, macOS FUSE-T) so
+		// overflow never fires. Suppressing the ack pins persistedAck at
+		// zero for the test's lifetime, so segments accumulate
+		// deterministically and overflow always trips. The TransportLoss
+		// frame's recv path is unaffected.
+		srv := testserver.New(testserver.Options{SuppressBatchAck: true})
+		defer srv.Close()
+		router := testserver.NewRoutingDialer(srv)
 
-	// WALSegmentSize=4 KiB, WALMaxTotalSize=8 KiB. validate() requires
-	// WALSegmentSize <= WALMaxTotalSize/2, so this is the tightest valid
-	// budget. Each ~1 KiB payload record takes roughly one segment;
-	// after 2 sealed segments we hit the cap and overflow fires.
-	s, err := watchtower.New(context.Background(), watchtower.Options{
-		WALDir:          t.TempDir(),
-		WALSegmentSize:  4 * 1024,
-		WALMaxTotalSize: 8 * 1024,
-		Mapper:          compact.StubMapper{},
-		Allocator:       audit.NewSequenceAllocator(),
-		AgentID:         "a",
-		SessionID:       "s",
-		KeyFingerprint:  "sha256:overflow-test",
-		HMACKeyID:       "k1",
-		HMACSecret:      bytes.Repeat([]byte("a"), 32),
-		HMACAlgorithm:   "hmac-sha256",
-		BatchMaxRecords: 1,
-		BatchMaxBytes:   4 * 1024,
-		BatchMaxAge:     5 * time.Millisecond,
-		AllowStubMapper: true,
-		Dialer:          router,
-		BackoffInitial:  10 * time.Millisecond,
-		BackoffMax:      50 * time.Millisecond,
-		Logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
-	})
-	if err != nil {
-		t.Fatalf("watchtower.New: %v", err)
-	}
-	defer s.Close()
-
-	// Pump enough events to overflow the WAL while the server is reachable.
-	// Each event carries a padded argv to ensure the record payload is large
-	// enough to fill a segment quickly.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	padding := strings.Repeat("x", 512)
-	for i := uint64(1); i <= 200; i++ {
-		ev := types.Event{
-			Type:      "exec",
-			SessionID: "s",
-			Timestamp: time.Now(),
-			Chain:     &types.ChainState{Sequence: i, Generation: 1},
-			Filename:  "/usr/bin/test",
-			Argv:      []string{padding},
+		// WALSegmentSize=4 KiB, WALMaxTotalSize=8 KiB. validate() requires
+		// WALSegmentSize <= WALMaxTotalSize/2, so this is the tightest valid
+		// budget. Each ~1 KiB payload record takes roughly one segment;
+		// after 2 sealed segments we hit the cap and overflow fires.
+		s, err := watchtower.New(context.Background(), watchtower.Options{
+			WALDir:          t.TempDir(),
+			WALSegmentSize:  4 * 1024,
+			WALMaxTotalSize: 8 * 1024,
+			Mapper:          compact.StubMapper{},
+			Allocator:       audit.NewSequenceAllocator(),
+			AgentID:         "a",
+			SessionID:       "s",
+			KeyFingerprint:  "sha256:overflow-test",
+			HMACKeyID:       "k1",
+			HMACSecret:      bytes.Repeat([]byte("a"), 32),
+			HMACAlgorithm:   "hmac-sha256",
+			BatchMaxRecords: 1,
+			BatchMaxBytes:   4 * 1024,
+			BatchMaxAge:     5 * time.Millisecond,
+			AllowStubMapper: true,
+			Dialer:          router,
+			BackoffInitial:  10 * time.Millisecond,
+			BackoffMax:      50 * time.Millisecond,
+			Logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		})
+		if err != nil {
+			t.Fatalf("watchtower.New: %v", err)
 		}
-		// Ignore append errors — overflow is the goal and the store
-		// may reject some appends once the WAL is full.
-		_ = s.AppendEvent(ctx, ev)
-	}
+		defer s.Close()
 
-	// Wait for the testserver to observe at least one TransportLoss.
-	loss, err := srv.WaitForTransportLoss(60 * time.Second)
-	if err != nil {
-		t.Fatalf("WaitForTransportLoss: %v", err)
-	}
-	if loss.Reason != wtpv1.TransportLossReason_TRANSPORT_LOSS_REASON_OVERFLOW {
-		t.Fatalf("TransportLoss.Reason = %v; want OVERFLOW", loss.Reason)
-	}
+		// Pump enough events to overflow the WAL while the server is reachable.
+		// Each event carries a padded argv to ensure the record payload is large
+		// enough to fill a segment quickly.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		padding := strings.Repeat("x", 512)
+		for i := uint64(1); i <= 200; i++ {
+			ev := types.Event{
+				Type:      "exec",
+				SessionID: "s",
+				Timestamp: time.Now(),
+				Chain:     &types.ChainState{Sequence: i, Generation: 1},
+				Filename:  "/usr/bin/test",
+				Argv:      []string{padding},
+			}
+			// Ignore append errors — overflow is the goal and the store
+			// may reject some appends once the WAL is full.
+			_ = s.AppendEvent(ctx, ev)
+		}
 
-	// Regression: session must not have restarted — the overflow must NOT
-	// have caused ErrRecordLossEncountered → session teardown.
-	got, err := srv.WaitForSessionInits(1, 5*time.Second)
-	if err != nil {
-		t.Fatalf("WaitForSessionInits: %v", err)
-	}
-	if got != 1 {
-		t.Fatalf("SessionInits = %d; want exactly 1 (no session restart)", got)
-	}
+		// Wait for the testserver to observe at least one TransportLoss.
+		loss, err := srv.WaitForTransportLoss(60 * time.Second)
+		if err != nil {
+			t.Fatalf("WaitForTransportLoss: %v", err)
+		}
+		if loss.Reason != wtpv1.TransportLossReason_TRANSPORT_LOSS_REASON_OVERFLOW {
+			t.Fatalf("TransportLoss.Reason = %v; want OVERFLOW", loss.Reason)
+		}
+
+		// Regression: session must not have restarted — the overflow must NOT
+		// have caused ErrRecordLossEncountered → session teardown.
+		got, err := srv.WaitForSessionInits(1, 5*time.Second)
+		if err != nil {
+			t.Fatalf("WaitForSessionInits: %v", err)
+		}
+		if got != 1 {
+			t.Fatalf("SessionInits = %d; want exactly 1 (no session restart)", got)
+		}
+	})
 }
 
 // TestStore_CRCCorruptionEmitsTransportLossOnWire manufactures CRC
@@ -124,119 +126,121 @@ func TestStore_OverflowEmitsTransportLossOnWire(t *testing.T) {
 func TestStore_CRCCorruptionEmitsTransportLossOnWire(t *testing.T) {
 	skipLossCarrierOnWindows(t)
 
-	// SuppressBatchAck: without it, the testserver acks every
-	// EventBatch as it arrives, the agent advances persistedAck, and
-	// the WAL GCs fully-acked sealed segments via
-	// segmentFullyAckedLocked before s1.Close returns on slow runners
-	// (macOS FUSE-T, Windows file I/O). corruptOneSegment then finds
-	// only the live INPROGRESS segment and the test fails. Pinning
-	// the per-batch ack at zero keeps sealed segments alive across
-	// the close → corruption → reopen sequence. The s2 replay's
-	// CRC_CORRUPTION TransportLoss is delivered independently of the
-	// per-batch ack path.
-	srv := testserver.New(testserver.Options{SuppressBatchAck: true})
-	defer srv.Close()
-	router := testserver.NewRoutingDialer(srv)
+	retryFlake(t, 3, func(t testing.TB) {
+		// SuppressBatchAck: without it, the testserver acks every
+		// EventBatch as it arrives, the agent advances persistedAck, and
+		// the WAL GCs fully-acked sealed segments via
+		// segmentFullyAckedLocked before s1.Close returns on slow runners
+		// (macOS FUSE-T, Windows file I/O). corruptOneSegment then finds
+		// only the live INPROGRESS segment and the test fails. Pinning
+		// the per-batch ack at zero keeps sealed segments alive across
+		// the close → corruption → reopen sequence. The s2 replay's
+		// CRC_CORRUPTION TransportLoss is delivered independently of the
+		// per-batch ack path.
+		srv := testserver.New(testserver.Options{SuppressBatchAck: true})
+		defer srv.Close()
+		router := testserver.NewRoutingDialer(srv)
 
-	walDir := t.TempDir()
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
+		walDir := t.TempDir()
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
 
-	// Step A: write some records, close the store cleanly. The records
-	// reach the testserver via normal flow; we want them durable on
-	// disk so the next-store replay traverses the same segment.
-	//
-	// WALSegmentSize=512 gives a record budget of 496 bytes, which is
-	// enough for a fully-marshalled CompactEvent (IntegrityRecord +
-	// StubMapper JSON payload ~ 300-400 bytes). Five appends produce
-	// multiple sealed segments plus one live INPROGRESS.
-	// Corrupting a sealed segment ensures it survives the reopen (recovery
-	// only truncates the live INPROGRESS tail).
-	s1, err := watchtower.New(ctx, watchtower.Options{
-		WALDir:          walDir,
-		WALSegmentSize:  512,
-		WALMaxTotalSize: 512 * 1024,
-		Mapper:          compact.StubMapper{},
-		Allocator:       audit.NewSequenceAllocator(),
-		AgentID:         "a",
-		SessionID:       "s",
-		KeyFingerprint:  "sha256:crc-test",
-		HMACKeyID:       "k1",
-		HMACSecret:      bytes.Repeat([]byte("a"), 32),
-		HMACAlgorithm:   "hmac-sha256",
-		BatchMaxRecords: 5,
-		BatchMaxBytes:   4 * 1024,
-		BatchMaxAge:     20 * time.Millisecond,
-		AllowStubMapper: true,
-		Dialer:          router,
-		BackoffInitial:  10 * time.Millisecond,
-		BackoffMax:      50 * time.Millisecond,
-		Logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
-	})
-	if err != nil {
-		t.Fatalf("watchtower.New(s1): %v", err)
-	}
-	for i := uint64(1); i <= 5; i++ {
-		ev := types.Event{
-			Type:      "exec",
-			SessionID: "s",
-			Timestamp: time.Now(),
-			Chain:     &types.ChainState{Sequence: i, Generation: 1},
+		// Step A: write some records, close the store cleanly. The records
+		// reach the testserver via normal flow; we want them durable on
+		// disk so the next-store replay traverses the same segment.
+		//
+		// WALSegmentSize=512 gives a record budget of 496 bytes, which is
+		// enough for a fully-marshalled CompactEvent (IntegrityRecord +
+		// StubMapper JSON payload ~ 300-400 bytes). Five appends produce
+		// multiple sealed segments plus one live INPROGRESS.
+		// Corrupting a sealed segment ensures it survives the reopen (recovery
+		// only truncates the live INPROGRESS tail).
+		s1, err := watchtower.New(ctx, watchtower.Options{
+			WALDir:          walDir,
+			WALSegmentSize:  512,
+			WALMaxTotalSize: 512 * 1024,
+			Mapper:          compact.StubMapper{},
+			Allocator:       audit.NewSequenceAllocator(),
+			AgentID:         "a",
+			SessionID:       "s",
+			KeyFingerprint:  "sha256:crc-test",
+			HMACKeyID:       "k1",
+			HMACSecret:      bytes.Repeat([]byte("a"), 32),
+			HMACAlgorithm:   "hmac-sha256",
+			BatchMaxRecords: 5,
+			BatchMaxBytes:   4 * 1024,
+			BatchMaxAge:     20 * time.Millisecond,
+			AllowStubMapper: true,
+			Dialer:          router,
+			BackoffInitial:  10 * time.Millisecond,
+			BackoffMax:      50 * time.Millisecond,
+			Logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		})
+		if err != nil {
+			t.Fatalf("watchtower.New(s1): %v", err)
 		}
-		if err := s1.AppendEvent(ctx, ev); err != nil {
-			t.Fatalf("AppendEvent[%d]: %v", i, err)
+		for i := uint64(1); i <= 5; i++ {
+			ev := types.Event{
+				Type:      "exec",
+				SessionID: "s",
+				Timestamp: time.Now(),
+				Chain:     &types.ChainState{Sequence: i, Generation: 1},
+			}
+			if err := s1.AppendEvent(ctx, ev); err != nil {
+				t.Fatalf("AppendEvent[%d]: %v", i, err)
+			}
 		}
-	}
-	s1.Close()
+		s1.Close()
 
-	// Step B: corrupt one sealed segment's CRC on disk.
-	corruptOneSegment(t, walDir)
+		// Step B: corrupt one sealed segment's CRC on disk.
+		corruptOneSegment(t, walDir)
 
-	// Step C: open a new store on the same WAL; replay walks the
-	// corrupted segment and emits a CRC_CORRUPTION TransportLoss.
-	s2, err := watchtower.New(ctx, watchtower.Options{
-		WALDir:          walDir,
-		WALSegmentSize:  512,
-		WALMaxTotalSize: 512 * 1024,
-		Mapper:          compact.StubMapper{},
-		Allocator:       audit.NewSequenceAllocator(),
-		AgentID:         "a",
-		SessionID:       "s",
-		KeyFingerprint:  "sha256:crc-test",
-		HMACKeyID:       "k1",
-		HMACSecret:      bytes.Repeat([]byte("a"), 32),
-		HMACAlgorithm:   "hmac-sha256",
-		BatchMaxRecords: 5,
-		BatchMaxBytes:   4 * 1024,
-		BatchMaxAge:     20 * time.Millisecond,
-		AllowStubMapper: true,
-		Dialer:          router,
-		BackoffInitial:  10 * time.Millisecond,
-		BackoffMax:      50 * time.Millisecond,
-		Logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		// Step C: open a new store on the same WAL; replay walks the
+		// corrupted segment and emits a CRC_CORRUPTION TransportLoss.
+		s2, err := watchtower.New(ctx, watchtower.Options{
+			WALDir:          walDir,
+			WALSegmentSize:  512,
+			WALMaxTotalSize: 512 * 1024,
+			Mapper:          compact.StubMapper{},
+			Allocator:       audit.NewSequenceAllocator(),
+			AgentID:         "a",
+			SessionID:       "s",
+			KeyFingerprint:  "sha256:crc-test",
+			HMACKeyID:       "k1",
+			HMACSecret:      bytes.Repeat([]byte("a"), 32),
+			HMACAlgorithm:   "hmac-sha256",
+			BatchMaxRecords: 5,
+			BatchMaxBytes:   4 * 1024,
+			BatchMaxAge:     20 * time.Millisecond,
+			AllowStubMapper: true,
+			Dialer:          router,
+			BackoffInitial:  10 * time.Millisecond,
+			BackoffMax:      50 * time.Millisecond,
+			Logger:          slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		})
+		if err != nil {
+			t.Fatalf("watchtower.New(s2): %v", err)
+		}
+		defer s2.Close()
+
+		loss, err := srv.WaitForTransportLoss(60 * time.Second)
+		if err != nil {
+			t.Fatalf("WaitForTransportLoss: %v", err)
+		}
+		if loss.Reason != wtpv1.TransportLossReason_TRANSPORT_LOSS_REASON_CRC_CORRUPTION {
+			t.Fatalf("Reason = %v; want CRC_CORRUPTION", loss.Reason)
+		}
+
+		// SessionInits should be 2 (one per Store), not 3+ (no client-side
+		// restart on top of the two distinct lifetimes).
+		got, err := srv.WaitForSessionInits(2, 5*time.Second)
+		if err != nil {
+			t.Fatalf("WaitForSessionInits: %v", err)
+		}
+		if got != 2 {
+			t.Fatalf("SessionInits = %d; want exactly 2 (one per Store, no extra restarts)", got)
+		}
 	})
-	if err != nil {
-		t.Fatalf("watchtower.New(s2): %v", err)
-	}
-	defer s2.Close()
-
-	loss, err := srv.WaitForTransportLoss(60 * time.Second)
-	if err != nil {
-		t.Fatalf("WaitForTransportLoss: %v", err)
-	}
-	if loss.Reason != wtpv1.TransportLossReason_TRANSPORT_LOSS_REASON_CRC_CORRUPTION {
-		t.Fatalf("Reason = %v; want CRC_CORRUPTION", loss.Reason)
-	}
-
-	// SessionInits should be 2 (one per Store), not 3+ (no client-side
-	// restart on top of the two distinct lifetimes).
-	got, err := srv.WaitForSessionInits(2, 5*time.Second)
-	if err != nil {
-		t.Fatalf("WaitForSessionInits: %v", err)
-	}
-	if got != 2 {
-		t.Fatalf("SessionInits = %d; want exactly 2 (one per Store, no extra restarts)", got)
-	}
 }
 
 // corruptOneSegment finds a sealed *.seg file in walDir/segments and flips
@@ -244,7 +248,7 @@ func TestStore_CRCCorruptionEmitsTransportLossOnWire(t *testing.T) {
 // Mirrors the approach used in internal/store/watchtower/wal/crc_test.go:
 // corrupt offset = SegmentHeaderSize(16) + 30, well into the first record's
 // payload region.
-func corruptOneSegment(t *testing.T, walDir string) {
+func corruptOneSegment(t testing.TB, walDir string) {
 	t.Helper()
 	segDir := filepath.Join(walDir, "segments")
 	entries, err := os.ReadDir(segDir)

--- a/internal/store/watchtower/flakyretry_test.go
+++ b/internal/store/watchtower/flakyretry_test.go
@@ -1,0 +1,168 @@
+package watchtower_test
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// flakyTestT wraps a testing.TB to capture Fatalf/Errorf messages
+// without failing the outer test, so a retry harness can decide whether
+// the failure matches a known-flake fingerprint and re-run.
+//
+// Methods that DON'T fail or log assertion data (Helper, TempDir,
+// Cleanup, Logf, Name, etc.) pass through to the embedded testing.TB
+// unchanged. The body of a retried test must use t.Cleanup-via-defer
+// for per-attempt teardown — anything registered through t.Cleanup on
+// the embedded TB runs once at end-of-parent-test, not per-attempt, so
+// it WILL leak resources across retries if used inside the body.
+//
+// Embedding testing.TB (not *testing.T) lets flakyTestT itself satisfy
+// the testing.TB interface (including TB's unexported private() method)
+// via method promotion. The retry body therefore takes a testing.TB
+// parameter rather than *testing.T.
+type flakyTestT struct {
+	testing.TB
+	mu     sync.Mutex
+	errors []string
+}
+
+// Errorf captures the message without marking the embedded T failed.
+// retryFlake inspects ft.errors afterwards.
+func (f *flakyTestT) Errorf(format string, args ...interface{}) {
+	f.mu.Lock()
+	f.errors = append(f.errors, fmt.Sprintf(format, args...))
+	f.mu.Unlock()
+}
+
+// Fatalf captures the message then exits the body goroutine via
+// Goexit. Deferred cleanups in the body still run. retryFlake decides
+// based on the captured message whether this is a known flake.
+func (f *flakyTestT) Fatalf(format string, args ...interface{}) {
+	f.mu.Lock()
+	f.errors = append(f.errors, fmt.Sprintf(format, args...))
+	f.mu.Unlock()
+	runtime.Goexit()
+}
+
+// Fatal mirrors Fatalf for the no-format case.
+func (f *flakyTestT) Fatal(args ...interface{}) {
+	f.mu.Lock()
+	f.errors = append(f.errors, fmt.Sprint(args...))
+	f.mu.Unlock()
+	runtime.Goexit()
+}
+
+// Error mirrors Errorf for the no-format case.
+func (f *flakyTestT) Error(args ...interface{}) {
+	f.mu.Lock()
+	f.errors = append(f.errors, fmt.Sprint(args...))
+	f.mu.Unlock()
+}
+
+// Failed reports whether any error/fatal message was captured.
+func (f *flakyTestT) Failed() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.errors) > 0
+}
+
+// FailNow exits the body without recording a message. retryFlake
+// treats this as a non-flake failure (no fingerprint to match).
+func (f *flakyTestT) FailNow() {
+	f.mu.Lock()
+	f.errors = append(f.errors, "FailNow called")
+	f.mu.Unlock()
+	runtime.Goexit()
+}
+
+// isKnownWTPTransportLossFlake reports whether msg matches the
+// fingerprint of the known timing-flake family in the watchtower
+// integration tests: any of the testserver.WaitFor* polling helpers
+// times out under CI load while the watchtower itself logged the
+// expected event as emitted. See project_wtp_transportloss_flakes
+// memory and PRs #265 / #266.
+//
+// Three helper-shapes count as flake fingerprints:
+//   - WaitForTransportLoss: deadline N elapsed
+//   - WaitForFirstSessionInit: deadline N elapsed
+//   - WaitForSessionInits: want N, got M after Ts
+//
+// All three are time-based polls on testserver state. None is a
+// correctness contract — the watchtower's own behavior is verified
+// elsewhere. Only failures matching one of these shapes are
+// retry-eligible; any other Fatalf/Errorf is a genuine regression and
+// propagates.
+func isKnownWTPTransportLossFlake(msg string) bool {
+	switch {
+	case strings.Contains(msg, "WaitForTransportLoss") && strings.Contains(msg, "deadline"):
+		return true
+	case strings.Contains(msg, "WaitForFirstSessionInit") && strings.Contains(msg, "deadline"):
+		return true
+	case strings.Contains(msg, "WaitForSessionInits") && strings.Contains(msg, "got"):
+		return true
+	}
+	return false
+}
+
+// retryFlake runs body up to maxAttempts times against a flakyTestT
+// that captures Fatalf/Errorf without failing the outer test. If body
+// fails with EVERY captured message matching the
+// isKnownWTPTransportLossFlake fingerprint, retryFlake reruns body
+// (with fresh resources owned by the body itself via defer). If body
+// fails with any non-flake error, the first such error is escalated
+// as the outer test's failure immediately — no retry.
+//
+// On success, retryFlake returns normally. On exhausted retries, it
+// fails the outer test with the last captured flake message.
+//
+// IMPORTANT: body MUST manage its own per-attempt teardown via defer.
+// t.Cleanup calls inside body register on the OUTER test and won't
+// fire between attempts. Use defer for closing servers, watchtowers,
+// and any other per-attempt resources.
+//
+// body's argument is testing.TB, not *testing.T, because flakyTestT
+// satisfies testing.TB (via embedding) but cannot satisfy *testing.T
+// (Go has no inheritance). Tests that need *testing.T-specific methods
+// like Run/Parallel should keep them at the outer level, outside
+// retryFlake.
+func retryFlake(t *testing.T, maxAttempts int, body func(t testing.TB)) {
+	t.Helper()
+	var lastMessages []string
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		ft := &flakyTestT{TB: t}
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			body(ft)
+		}()
+		<-done
+
+		if !ft.Failed() {
+			if attempt > 1 {
+				t.Logf("retryFlake: passed on attempt %d (after %d known-flake retries)", attempt, attempt-1)
+			}
+			return
+		}
+
+		lastMessages = ft.errors
+		allFlake := true
+		for _, msg := range lastMessages {
+			if !isKnownWTPTransportLossFlake(msg) {
+				allFlake = false
+				break
+			}
+		}
+		if !allFlake {
+			t.Fatalf("retryFlake attempt %d failed (not a known flake): %s",
+				attempt, strings.Join(lastMessages, "; "))
+		}
+		if attempt < maxAttempts {
+			t.Logf("retryFlake: attempt %d hit known WTP transport-loss flake, retrying (see project_wtp_transportloss_flakes memory)", attempt)
+		}
+	}
+	t.Fatalf("retryFlake: all %d attempts hit the known WTP transport-loss flake. Last messages: %s",
+		maxAttempts, strings.Join(lastMessages, "; "))
+}


### PR DESCRIPTION
## Summary

Adds a per-test retry harness for the pre-existing `internal/store/watchtower` transport-loss timing flakes that have been blocking CI runs (most recently on the libseccomp 2.5 PR #316 and its post-merge main run). The harness retries up to 3 times when the failure matches one of three documented timing fingerprints, and surfaces any other failure immediately.

This is a mitigation, not a fix. The underlying "missing seq N" bug in the watchtower transport → testserver path remains unresolved (see `project_wtp_transportloss_flakes` memory and the existing instrumentation from PR #266).

## Why

Per the memory and the prior PRs (#265 deadline+backoff bump, #266 diagnostics), the family has three timing fingerprints, all in testserver polling helpers:

- `WaitForTransportLoss: deadline N elapsed`
- `WaitForFirstSessionInit: deadline N elapsed`
- `WaitForSessionInits: want N, got M after Ts`

The memory explicitly says **"do not bump deadlines further"** and **"do not block merges on it."** This PR honors both — no deadlines move, and the existing CI red is recovered by retry rather than by masking the test.

## What

`internal/store/watchtower/flakyretry_test.go` adds:

- `flakyTestT` — a `testing.TB` wrapper that captures `Fatalf`/`Errorf` messages into a slice without marking the embedded TB failed.
- `isKnownWTPTransportLossFlake(msg)` — fingerprint match against the three message shapes above.
- `retryFlake(t, maxAttempts, body)` — runs `body` up to N times. On a captured failure whose messages all match the fingerprint, retries with a fresh body invocation. On ANY non-fingerprint failure, immediately escalates as a real test failure on the outer `t`.

Four tests are wrapped:
- `TestStore_TransportLossInflightSlot_RetiredByBatchAck`
- `TestStore_OverflowEmitsTransportLossOnWire`
- `TestStore_CRCCorruptionEmitsTransportLossOnWire`
- `TestStore_InFlightDrop_EmitsTransportLossOnWire` (each table-driven sub-test)

`TestStore_AckRegressionAfterGC_EmitsTransportLoss` is intentionally NOT wrapped — it already self-skips with `t.Skipf` on its own deadline. Two helper functions (`newInflightTestStore`, `corruptOneSegment`) take `testing.TB` instead of `*testing.T` so they work with the harness.

## Design notes

- The outer-level `transport.SetEncoderEmitExtendedReasons(true)` + `t.Cleanup(...)` calls stay at the outer test scope so the encoder flag is set once and reset once per test (NOT per attempt).
- Per-attempt teardown lives inside the body as `defer` so it fires correctly on `runtime.Goexit()` from a captured `Fatalf`.
- `flakyTestT` embeds `testing.TB` (not `*testing.T`) so it can satisfy `testing.TB` via method promotion of the unexported `private()` method. Test bodies inside `retryFlake` take `testing.TB` rather than `*testing.T`.
- Any failure shape outside the three fingerprints — including assertion mismatches like wrong loss reason or generation-count drift — is treated as a real regression and propagates immediately. The retry only catches the documented timing-flake class.

## Test plan

- [x] `go test ./internal/store/watchtower/ -count=1 -timeout 300s` — passes locally (124s)
- [x] `go build ./...` and `GOOS=windows go build ./...` clean
- [ ] CI: post-merge main run that previously hit `TestStore_InFlightDrop_EmitsTransportLossOnWire/mapper_failure` deadline elapses should now pass on first attempt or recover via retry

## Reversibility

`git revert` restores the original tests. Memory and PRs #265/#266 still document the underlying bug; the retry harness is removed cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)