### PR TITLE
fix(seccomp): pin OS thread before raw seccomp(2) syscall

### DIFF
--- a/internal/netmonitor/unix/seccomp_load_linux.go
+++ b/internal/netmonitor/unix/seccomp_load_linux.go
@@ -101,6 +101,23 @@ func loadRawFilter(prog []byte, withWaitKill bool) (int, error) {
 		return -1, fmt.Errorf("seccomp export produced unaligned filter: %d bytes (want multiple of 8)", len(prog))
 	}
 
+	// Pin the calling goroutine to the OS thread that will receive
+	// the seccomp filter. The filter applies only to the thread that
+	// makes the seccomp(2) syscall (we deliberately don't use
+	// SECCOMP_FILTER_FLAG_TSYNC because combining it with
+	// NEW_LISTENER has had kernel-version-dependent behavior in
+	// practice). In Go, goroutines migrate freely between Ms unless
+	// explicitly locked — so without this pin, the wrapper's main
+	// goroutine could land on a different M before reaching
+	// syscall.Exec, and the post-execve target would inherit the
+	// (unfiltered) seccomp state of THAT thread.
+	//
+	// We never UnlockOSThread: the caller of InstallFilterWithConfig
+	// is the unixwrap binary, which is about to execve and replace
+	// the entire process. Leaving the goroutine pinned through
+	// execve is the goal, not a side effect.
+	runtime.LockOSThread()
+
 	if err := prctlSetNoNewPrivs(); err != nil {
 		return -1, fmt.Errorf("prctl PR_SET_NO_NEW_PRIVS: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fixes the `TestSeccompOnBlock_LogAndKill_GCPressure` regression introduced by #316 (libseccomp 2.5 system-link).

**Root cause:** libseccomp-golang's `filt.Load()` set `SCMP_FLTATR_CTL_TSYNC=1` by default, so the filter sync'd across all threads of the task. The raw `seccomp(2)` syscall in `loadRawFilter` does not — it installs the filter on the calling thread only. In Go, the goroutine that called `loadRawFilter` can migrate to a different M before reaching `syscall.Exec`, leaving the post-execve target inheriting the **unfiltered** seccomp state of that other thread.

**Fix:** `runtime.LockOSThread()` before the prctl + seccomp(2) syscalls. Never unlocked — the caller (unixwrap) is about to execve and replace the entire process, so leaving the goroutine pinned through execve is the goal, not a side effect.

**Why not TSYNC?** Combining `SECCOMP_FILTER_FLAG_TSYNC` with `SECCOMP_FILTER_FLAG_NEW_LISTENER` has had kernel-version-dependent behavior in practice — on the test kernel the combo caused the syscall to stall instead of returning EINVAL. `LockOSThread` is the robust alternative.

## Test plan

- [x] Local: `go test -tags=integration ./internal/integration/ -run "^TestSeccompOnBlock_LogAndKill_GCPressure\$" -count=10` → 10/10 pass
- [x] Linux build clean
- [x] Windows cross-compile clean (`GOOS=windows go build ./...`)
- [ ] CI green on this branch