### PR TITLE
db: Plan 05b — SQL prepared cache + FunctionCall opt-in + classifier escalation wiring

### DIFF
--- a/docs/superpowers/plans/2026-05-11-db-plan-05b-sql-prepared-funccall.md
+++ b/docs/superpowers/plans/2026-05-11-db-plan-05b-sql-prepared-funccall.md
@@ -25,6 +25,24 @@
 
 ---
 
+## Reconciliation with current code (post-05a audit, 2026-05-12)
+
+After 05a landed (commit `ba88ab2e`), an audit identified four drift items between this plan's prose and the codebase. Implementers MUST follow these reconciliations rather than the original prose where they conflict:
+
+**R1. Test harness mismatch.** The plan's test snippets reference `mustNewServerWithYAML`, `mustPCFromSrv`, `pc.upstreamFake.SawQuery`, `pc.upstreamFake.SawSyntheticErrorResponse`, `pc.clientFake.SawSQLState`, `mustStartSpineServer`, `newRawTLSClient`, and `sink.StatementEvents()`. None exist — 04c/05a built a single `startSpineHarness(t, ...)` helper in `internal/db/proxy/postgres/spine_test.go` against a real fake-upstream socket and a `SyncSink`. Adapt every test snippet in this plan accordingly:
+
+- **Task 6** (`Intercept` unit tests) is pure-function; no harness needed; keep snippets as written.
+- **Tasks 7, 9** (proxyConn-level tests) — use `startSpineHarness` and assert against the sink's recorded events plus direct field access on `proxyConn` (e.g., `pc.sqlCache.Get(...)`). Do NOT build a new fake-upstream stack. The "Saw X" calls in the snippets are illustrative; replace with sink-event introspection (the harness already records every emitted `db_statement` event with `Decision.Verb`, `Effects`, and the redacted statement).
+- **Task 11** (spine) — `mustStartSpineServer` is `startSpineHarness`. The `newRawTLSClient` helper for raw `FunctionCall` injection does not exist; add a minimal `sendRawFrontend(t, harness, msg pgproto3.FrontendMessage)` helper inline in `spine_test.go` that bypasses pgx and writes through the harness's existing client socket.
+
+**R2. `AllowFunctionCallProtocol` field location.** The plan's `pc.svc.Service.AllowFunctionCallProtocol` reference resolves through `proxy/postgres/server.go:Service.Service` (a nested `policy.DBService`). The field already exists at `internal/db/policy/types.go:88` with YAML tag `allow_function_call_protocol,omitempty`. No new task needed; the plan's prose is correct as written, but implementers should reach the field via `pc.svc.Service.AllowFunctionCallProtocol` (not via `service.Service` — that struct is a separate listener-flattening view that does not carry this field).
+
+**R3. `SubtypeFunctionCallProtocol` already exists** at `internal/db/effects/subtype.go:68` (05a added it). **Drop the `SubtypeFunctionCallProtocol` line from Task 8 Step 3** — keep only `SubtypeEscalatedFunctionCall`. The Task 8 round-trip test's reference to `SubtypeFunctionCallProtocol` is fine since the constant already exists.
+
+**R4. `classify_pg.Options.EscalateUnknownFunctions` already exists** at `internal/db/classify/postgres/parser.go:62-66`, and `escalation.go` is already wired into `classifySelect`. Task 5 is purely a threading exercise: take the existing classifier option and supply it from the proxy. The plan's framing is accurate; this note exists so the implementer does not re-add the option.
+
+---
+
 ## File Structure
 
 **Created:**
@@ -604,6 +622,8 @@ git commit -m "db: policy — decode policies.db.escalate_unknown_functions and 
 ## Task 5: Thread escalation `Options` at proxy classify call sites
 
 **Why:** Every `parser.Classify(sql, sess, opts)` call in the proxy must populate `Options.EscalateUnknownFunctions` + `SafeFunctionAllowlist` from the active policy snapshot. Two call sites today: `handleQuery` (Simple Query) and `statemachine.handleParse` + `statemachine.handleQuery` (Plan 05a).
+
+**Note (post-05a audit):** `classify_pg.Options.EscalateUnknownFunctions` and `classify_pg.Options.SafeFunctionAllowlist` already exist in `internal/db/classify/postgres/parser.go` and are honored by `escalation.go`. This task is purely threading — do not redefine them.
 
 **Files:**
 - Modify: `internal/db/proxy/postgres/simplequery.go`
@@ -1381,12 +1401,11 @@ type Effect struct {
 }
 ```
 
-Then locate the `Subtype` constants in the same file (or wherever they're defined) and add:
+Then locate the `Subtype` constants in the same file (or wherever they're defined) and add `SubtypeEscalatedFunctionCall` ONLY. `SubtypeFunctionCallProtocol` was added in 05a (`internal/db/effects/subtype.go:68`) — do not redeclare it:
 
 ```go
 const (
-	// ... existing subtypes ...
-	SubtypeFunctionCallProtocol  Subtype = "function_call_protocol"
+	// ... existing subtypes (including SubtypeFunctionCallProtocol from 05a) ...
 	SubtypeEscalatedFunctionCall Subtype = "escalated_function_call"
 )
 ```

--- a/internal/db/classify/postgres/ast_dml.go
+++ b/internal/db/classify/postgres/ast_dml.go
@@ -229,6 +229,7 @@ func classifyPrepare(cs *effects.ClassifiedStatement, s *pg_query.PrepareStmt, s
 		cs.Error = "unmapped form: PREPARE without query"
 		return
 	}
+	cs.PreparedName = s.Name
 	inner := classifyRawStmt(DialectPostgres, &pg_query.RawStmt{Stmt: s.Query}, sess, opts, cs.ParserBackend)
 	cs.Effects = inner.Effects
 	if inner.RawVerb != "" {
@@ -239,16 +240,23 @@ func classifyPrepare(cs *effects.ClassifiedStatement, s *pg_query.PrepareStmt, s
 	}
 }
 
-func classifyExecute(cs *effects.ClassifiedStatement, _ *pg_query.ExecuteStmt, _ SessionState, _ Options) {
+func classifyExecute(cs *effects.ClassifiedStatement, s *pg_query.ExecuteStmt, _ SessionState, _ Options) {
 	// Cache lookup is owned by Plan 05 (proxy). Plan 03 returns unknown so the
 	// proxy can synthesize the cache-miss deny path per spec §7.4.
 	cs.RawVerb = "EXECUTE"
+	if s != nil {
+		cs.PreparedName = s.Name
+	}
 	cs.Effects = []effects.Effect{{Group: effects.GroupUnknown, Resolution: effects.ResolutionUnresolved}}
 	cs.Error = "execute: cache lookup deferred to proxy (Plan 05)"
 }
 
-func classifyDeallocate(cs *effects.ClassifiedStatement, _ *pg_query.DeallocateStmt) {
+func classifyDeallocate(cs *effects.ClassifiedStatement, s *pg_query.DeallocateStmt) {
 	cs.RawVerb = "DEALLOCATE"
+	// pg_query represents DEALLOCATE ALL with an empty Name field.
+	if s != nil {
+		cs.PreparedName = s.Name
+	}
 	cs.Effects = []effects.Effect{{
 		Group:   effects.GroupSession,
 		Subtype: effects.SubtypeDiscardPlans, // §7.3: DEALLOCATE → discard_plans

--- a/internal/db/classify/postgres/ast_dml_test.go
+++ b/internal/db/classify/postgres/ast_dml_test.go
@@ -275,3 +275,53 @@ func TestClassifySelect_TempShadowed(t *testing.T) {
 		t.Fatalf("resolution: got %v want maybe_temp_shadowed", prim.Resolution)
 	}
 }
+
+func TestClassifyPrepare_PopulatesPreparedName(t *testing.T) {
+	p := New(DialectPostgres)
+	got, err := p.Classify("PREPARE s1 AS SELECT 1", SessionState{}, Options{})
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len=%d", len(got))
+	}
+	if got[0].PreparedName != "s1" {
+		t.Fatalf("PreparedName=%q want s1", got[0].PreparedName)
+	}
+}
+
+func TestClassifyExecute_PopulatesPreparedName(t *testing.T) {
+	p := New(DialectPostgres)
+	got, err := p.Classify("EXECUTE s1(42)", SessionState{}, Options{})
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if got[0].PreparedName != "s1" {
+		t.Fatalf("PreparedName=%q want s1", got[0].PreparedName)
+	}
+}
+
+func TestClassifyDeallocate_Named(t *testing.T) {
+	p := New(DialectPostgres)
+	got, err := p.Classify("DEALLOCATE s1", SessionState{}, Options{})
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if got[0].RawVerb != "DEALLOCATE" {
+		t.Fatalf("RawVerb=%q", got[0].RawVerb)
+	}
+	if got[0].PreparedName != "s1" {
+		t.Fatalf("PreparedName=%q want s1", got[0].PreparedName)
+	}
+}
+
+func TestClassifyDeallocate_All(t *testing.T) {
+	p := New(DialectPostgres)
+	got, err := p.Classify("DEALLOCATE ALL", SessionState{}, Options{})
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if got[0].PreparedName != "" {
+		t.Fatalf("PreparedName=%q want \"\" for DEALLOCATE ALL", got[0].PreparedName)
+	}
+}

--- a/internal/db/classify/postgres/builtin_immutable.go
+++ b/internal/db/classify/postgres/builtin_immutable.go
@@ -1,0 +1,68 @@
+package postgres
+
+// DefaultSafeFunctionAllowlist returns the curated set of immutable PostgreSQL
+// builtin function names safe to treat as `read` when
+// policies.db.escalate_unknown_functions is enabled.
+//
+// All keys are lowercase canonical names. Schema-qualified variants are not
+// included; the canonicalFuncName walker matches bare names against the
+// shorter form. Operators with custom search_path setups that prefer
+// "pg_catalog.*" should add those keys explicitly via
+// policies.db.safe_function_allowlist.
+//
+// This list is best-effort and conservative. It excludes anything stable but
+// not provably immutable (e.g., functions that depend on timezone settings)
+// and anything user-replaceable via search_path shadowing. When in doubt,
+// operators should extend the allowlist via config rather than expect this
+// list to be exhaustive.
+func DefaultSafeFunctionAllowlist() map[string]struct{} {
+	names := []string{
+		// time / sequence
+		"now", "current_timestamp", "current_date", "current_time",
+		"localtimestamp", "localtime", "statement_timestamp", "transaction_timestamp",
+		"clock_timestamp", "timeofday",
+		"nextval", "currval", "lastval",
+		"extract", "date_part", "date_trunc", "age",
+		"to_date", "to_timestamp", "to_char", "to_number",
+		// text search
+		"to_tsvector", "to_tsquery", "plainto_tsquery", "phraseto_tsquery",
+		"websearch_to_tsquery", "ts_rank", "ts_rank_cd", "ts_headline",
+		// aggregates (read-only)
+		"count", "sum", "avg", "min", "max", "stddev", "variance",
+		"string_agg", "array_agg", "json_agg", "jsonb_agg",
+		"bit_and", "bit_or", "bool_and", "bool_or", "every",
+		// numeric / general
+		"abs", "ceil", "ceiling", "floor", "round", "trunc", "sign",
+		"power", "sqrt", "exp", "ln", "log", "mod", "div",
+		"sin", "cos", "tan", "asin", "acos", "atan", "atan2",
+		"degrees", "radians", "pi", "random",
+		// string
+		"length", "char_length", "character_length", "octet_length", "bit_length",
+		"lower", "upper", "initcap",
+		"trim", "btrim", "ltrim", "rtrim",
+		"substring", "substr", "left", "right", "position", "strpos",
+		"replace", "translate", "overlay",
+		"split_part", "regexp_replace", "regexp_split_to_array", "regexp_split_to_table",
+		"regexp_matches", "concat", "concat_ws", "format",
+		"chr", "ascii", "to_hex", "md5",
+		// general
+		"coalesce", "nullif", "greatest", "least",
+		"pg_typeof", "version", "current_schema", "current_schemas",
+		"current_database", "current_user", "session_user", "user",
+		"current_setting", "inet_client_addr", "inet_server_addr",
+		// json / jsonb (selectors only — constructors are stable but cheap)
+		"json_extract_path", "json_extract_path_text",
+		"jsonb_extract_path", "jsonb_extract_path_text",
+		"jsonb_typeof", "json_typeof",
+		"json_array_elements", "jsonb_array_elements",
+		"json_object_keys", "jsonb_object_keys",
+		// array
+		"array_length", "array_lower", "array_upper", "cardinality",
+		"unnest", "array_to_string", "string_to_array", "array_position",
+	}
+	out := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		out[n] = struct{}{}
+	}
+	return out
+}

--- a/internal/db/classify/postgres/builtin_immutable_test.go
+++ b/internal/db/classify/postgres/builtin_immutable_test.go
@@ -1,0 +1,36 @@
+package postgres
+
+import "testing"
+
+func TestDefaultSafeFunctionAllowlist_ContainsCommonBuiltins(t *testing.T) {
+	allow := DefaultSafeFunctionAllowlist()
+	want := []string{
+		"now", "nextval", "currval", "lastval",
+		"to_tsvector", "to_tsquery", "plainto_tsquery",
+		"count", "sum", "avg", "min", "max",
+		"coalesce", "nullif", "greatest", "least",
+		"abs", "length", "char_length", "octet_length",
+		"lower", "upper", "trim", "btrim", "ltrim", "rtrim",
+		"substring", "substr", "left", "right", "position",
+		"replace", "split_part", "string_agg", "array_agg",
+		"pg_typeof", "version", "current_timestamp",
+		"current_date", "current_time", "localtimestamp", "localtime",
+		"current_user", "session_user", "user",
+	}
+	for _, name := range want {
+		if _, ok := allow[name]; !ok {
+			t.Errorf("default allowlist missing %q", name)
+		}
+	}
+}
+
+func TestDefaultSafeFunctionAllowlist_LowercaseKeys(t *testing.T) {
+	allow := DefaultSafeFunctionAllowlist()
+	for k := range allow {
+		for _, r := range k {
+			if r >= 'A' && r <= 'Z' {
+				t.Errorf("allowlist key %q has uppercase rune", k)
+			}
+		}
+	}
+}

--- a/internal/db/classify/postgres/builtins/allowlist.go
+++ b/internal/db/classify/postgres/builtins/allowlist.go
@@ -1,4 +1,4 @@
-package postgres
+package builtins
 
 // DefaultSafeFunctionAllowlist returns the curated set of immutable PostgreSQL
 // builtin function names safe to treat as `read` when

--- a/internal/db/classify/postgres/builtins/allowlist_test.go
+++ b/internal/db/classify/postgres/builtins/allowlist_test.go
@@ -1,4 +1,4 @@
-package postgres
+package builtins
 
 import "testing"
 

--- a/internal/db/effects/effect.go
+++ b/internal/db/effects/effect.go
@@ -9,6 +9,12 @@ type Effect struct {
 	Subtype    Subtype
 	Objects    []ObjectRef
 	Resolution Resolution
+
+	// FunctionOID is populated for procedural effects with Subtype
+	// SubtypeFunctionCallProtocol (the Postgres 'F' FunctionCall frame) or
+	// SubtypeEscalatedFunctionCall (when classifier escalation produced
+	// the effect). Pointer so JSON omits zero.
+	FunctionOID *int32 `json:"function_oid,omitempty"`
 }
 
 // canonicalGroupRank returns the within-tier ordering position per §5.2 R5.

--- a/internal/db/effects/effect_test.go
+++ b/internal/db/effects/effect_test.go
@@ -2,7 +2,9 @@
 package effects
 
 import (
+	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -77,4 +79,35 @@ func TestEffect_OrderStableForEqualPriority(t *testing.T) {
 func TestEffect_OrderEmpty(t *testing.T) {
 	Order(nil) // must not panic
 	Order([]Effect{})
+}
+
+func TestEffect_FunctionOID_RoundTrip(t *testing.T) {
+	oid := int32(12345)
+	in := Effect{
+		Group:       GroupProcedural,
+		Subtype:     SubtypeFunctionCallProtocol,
+		FunctionOID: &oid,
+	}
+	bs, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(bs), `"function_oid":12345`) {
+		t.Fatalf("missing function_oid: %s", bs)
+	}
+	var out Effect
+	if err := json.Unmarshal(bs, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.FunctionOID == nil || *out.FunctionOID != 12345 {
+		t.Fatalf("FunctionOID round-trip lost value: %v", out.FunctionOID)
+	}
+}
+
+func TestEffect_FunctionOID_OmitEmpty(t *testing.T) {
+	in := Effect{Group: GroupRead}
+	bs, _ := json.Marshal(in)
+	if strings.Contains(string(bs), "function_oid") {
+		t.Fatalf("function_oid should be omitted; got %s", bs)
+	}
 }

--- a/internal/db/effects/statement.go
+++ b/internal/db/effects/statement.go
@@ -35,6 +35,11 @@ type ClassifiedStatement struct {
 	// zero when the parser cannot supply them (e.g. unknown-statement path).
 	SourceStart int32 `json:"source_start,omitempty"`
 	SourceEnd   int32 `json:"source_end,omitempty"`
+
+	// PreparedName is populated for PREPARE / EXECUTE / DEALLOCATE classifications.
+	// Empty for any other verb. For DEALLOCATE ALL, PreparedName is "" (the
+	// proxy's sqlprepared.Intercept distinguishes by RawVerb).
+	PreparedName string `json:"prepared_name,omitempty"`
 }
 
 // Primary returns the first (canonical) effect. ok=false on empty effects list.

--- a/internal/db/effects/statement_test.go
+++ b/internal/db/effects/statement_test.go
@@ -126,3 +126,39 @@ func TestClassifiedStatement_SourceSpan_ZeroOmitted(t *testing.T) {
 		t.Fatalf("zero span fields must be omitted: %s", bs)
 	}
 }
+
+func TestClassifiedStatement_PreparedName_JSON_RoundTrip(t *testing.T) {
+	in := ClassifiedStatement{
+		Effects:      []Effect{{Group: GroupSession, Subtype: SubtypeDiscardPlans}},
+		RawVerb:      "DEALLOCATE",
+		PreparedName: "s1",
+	}
+	bs, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(bs), `"prepared_name":"s1"`) {
+		t.Fatalf("missing prepared_name in JSON: %s", bs)
+	}
+	var out ClassifiedStatement
+	if err := json.Unmarshal(bs, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.PreparedName != "s1" {
+		t.Fatalf("PreparedName=%q", out.PreparedName)
+	}
+}
+
+func TestClassifiedStatement_PreparedName_OmitEmpty(t *testing.T) {
+	in := ClassifiedStatement{
+		Effects: []Effect{{Group: GroupRead}},
+		RawVerb: "SELECT",
+	}
+	bs, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(bs), "prepared_name") {
+		t.Fatalf("prepared_name should be omitted; got: %s", bs)
+	}
+}

--- a/internal/db/effects/subtype.go
+++ b/internal/db/effects/subtype.go
@@ -66,6 +66,7 @@ const (
 
 	// procedural
 	SubtypeFunctionCallProtocol
+	SubtypeEscalatedFunctionCall
 	SubtypeCall
 	SubtypeDo
 	SubtypeAnonymousBlock
@@ -152,6 +153,7 @@ var subtypeTable = map[Subtype]subtypeInfo{
 	SubtypeUnloadToS3:   {"unload_to_s3", GroupBulkExport},
 
 	SubtypeFunctionCallProtocol: {"function_call_protocol", GroupProcedural},
+	SubtypeEscalatedFunctionCall: {"escalated_function_call", GroupProcedural},
 	SubtypeCall:                 {"call", GroupProcedural},
 	SubtypeDo:                   {"do", GroupProcedural},
 	SubtypeAnonymousBlock:       {"anonymous_block", GroupProcedural},

--- a/internal/db/policy/decode.go
+++ b/internal/db/policy/decode.go
@@ -3,9 +3,11 @@ package policy
 import (
 	"bytes"
 	"fmt"
+	"sort"
 
 	"gopkg.in/yaml.v3"
 
+	classifybuiltins "github.com/agentsh/agentsh/internal/db/classify/postgres/builtins"
 	"github.com/agentsh/agentsh/internal/db/service"
 	rootpolicy "github.com/agentsh/agentsh/internal/policy"
 )
@@ -114,10 +116,12 @@ func decodeConnectionRules(n yaml.Node) ([]*ConnectionRule, error) {
 // redaction and unavoidability fields are decoded here; the rest of the
 // policies block is owned by other packages.
 type redactionYAML struct {
-	LogStatements                 string `yaml:"log_statements,omitempty"`
-	ApprovalStatementPreview      string `yaml:"approval_statement_preview,omitempty"`
-	ApprovalStatementPreviewChars int    `yaml:"approval_statement_preview_chars,omitempty"`
-	Unavoidability                string `yaml:"unavoidability,omitempty"`
+	LogStatements                 string   `yaml:"log_statements,omitempty"`
+	ApprovalStatementPreview      string   `yaml:"approval_statement_preview,omitempty"`
+	ApprovalStatementPreviewChars int      `yaml:"approval_statement_preview_chars,omitempty"`
+	Unavoidability                string   `yaml:"unavoidability,omitempty"`
+	EscalateUnknownFunctions      bool     `yaml:"escalate_unknown_functions"`
+	SafeFunctionAllowlist         []string `yaml:"safe_function_allowlist"`
 }
 
 // dbPoliciesWrapper is the on-disk shape of the policies block as far as
@@ -160,7 +164,25 @@ func decodeRedaction(p *rootpolicy.Policy) (RedactionConfig, error) {
 	if rb.ApprovalStatementPreviewChars > 0 {
 		out.ApprovalStatementChars = rb.ApprovalStatementPreviewChars
 	}
+	out.EscalateUnknownFunctions = rb.EscalateUnknownFunctions
+	if len(rb.SafeFunctionAllowlist) > 0 {
+		out.SafeFunctionAllowlist = append([]string(nil), rb.SafeFunctionAllowlist...)
+	} else if out.EscalateUnknownFunctions {
+		out.SafeFunctionAllowlist = defaultAllowlistKeys()
+	}
 	return out, nil
+}
+
+// defaultAllowlistKeys returns the builtin seed list as a sorted []string.
+// Sorting is deterministic and makes test assertions order-stable.
+func defaultAllowlistKeys() []string {
+	m := classifybuiltins.DefaultSafeFunctionAllowlist()
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // decodeUnavoidability reads policies.db.unavoidability. Default: UnavoidabilityOff.

--- a/internal/db/policy/decode_test.go
+++ b/internal/db/policy/decode_test.go
@@ -241,6 +241,65 @@ policies:
 	}
 }
 
+func TestDecode_EscalateUnknownFunctions_DefaultFalse(t *testing.T) {
+	rs, _, err := loadDB(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: "127.0.0.1:5432", tls_mode: terminate_reissue}
+`)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if rs.Redaction().EscalateUnknownFunctions {
+		t.Error("default EscalateUnknownFunctions should be false")
+	}
+}
+
+func TestDecode_EscalateUnknownFunctions_True(t *testing.T) {
+	rs, _, err := loadDB(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: "127.0.0.1:5432", tls_mode: terminate_reissue}
+policies:
+  db:
+    escalate_unknown_functions: true
+`)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if !rs.Redaction().EscalateUnknownFunctions {
+		t.Error("expected EscalateUnknownFunctions to be true")
+	}
+	if len(rs.Redaction().SafeFunctionAllowlist) == 0 {
+		t.Error("default allowlist should be populated when escalate is true and allowlist omitted")
+	}
+}
+
+func TestDecode_SafeFunctionAllowlist_Custom(t *testing.T) {
+	rs, _, err := loadDB(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: "127.0.0.1:5432", tls_mode: terminate_reissue}
+policies:
+  db:
+    escalate_unknown_functions: true
+    safe_function_allowlist: ["my_func", "schema.fn"]
+`)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	want := []string{"my_func", "schema.fn"}
+	got := rs.Redaction().SafeFunctionAllowlist
+	if len(got) != len(want) {
+		t.Fatalf("len(got)=%d want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d]=%q want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func TestDecode_WarnsOnApproveDecision(t *testing.T) {
 	src := `version: 1
 name: t

--- a/internal/db/policy/evaluate.go
+++ b/internal/db/policy/evaluate.go
@@ -76,9 +76,10 @@ func evaluateEffect(e effects.Effect, applicable []*compiledStatementRule) effec
 	// Exception: groups that *inherently* have no objects — Transaction,
 	// Session, Notify — would otherwise be unreachable through the §10.2
 	// coverage rules. Treat those as covered by any non-objects-constrained
-	// rule whose effect-meta matches.
+	// rule whose effect-meta matches. isObjectlessEffect also covers
+	// SubtypeFunctionCallProtocol (FunctionCall 'F' frames carry only an OID).
 	if len(e.Objects) == 0 {
-		if isObjectlessGroup(e.Group) {
+		if isObjectlessEffect(e) {
 			return evaluateEffectObjectless(e, applicable)
 		}
 		return effectDecision{verb: verbImplicitDeny}
@@ -202,6 +203,22 @@ func isObjectlessGroup(g effects.Group) bool {
 		return true
 	}
 	return false
+}
+
+// isObjectlessEffect reports whether the effect is inherently object-less and
+// should be evaluated using the degenerate per-group path rather than returning
+// verbImplicitDeny. This extends isObjectlessGroup for cases where the group
+// alone is insufficient: FunctionCall protocol effects (Subtype ==
+// SubtypeFunctionCallProtocol) carry only a function OID with no resolvable
+// object name, so they must be reachable through object-less coverage rules.
+// SQL-escalated unknown-function procedural effects (Group == GroupProcedural,
+// Subtype == 0) remain implicit-deny by design (fail-closed escalation).
+func isObjectlessEffect(e effects.Effect) bool {
+	if isObjectlessGroup(e.Group) {
+		return true
+	}
+	// FunctionCall protocol: OID-only effect, no resolvable Objects.
+	return e.Subtype == effects.SubtypeFunctionCallProtocol
 }
 
 // evaluateEffectObjectless handles effects with no Objects (e.g. transaction

--- a/internal/db/policy/evaluate_objectless_procedural_test.go
+++ b/internal/db/policy/evaluate_objectless_procedural_test.go
@@ -1,0 +1,82 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
+
+// TestEvaluate_ObjectlessFunctionCallProtocol_Reachable verifies that an
+// Effect with Group==GroupProcedural and Subtype==SubtypeFunctionCallProtocol
+// (the Postgres 'F' FunctionCall frame, which carries only an OID and has no
+// resolvable object name) is reachable through the objectless coverage path
+// rather than falling through to implicit deny.
+//
+// This pins the isObjectlessEffect whitelist introduced in Task 9: FunctionCall
+// opt-in must be achievable via a procedural allow rule with no objects clause.
+func TestEvaluate_ObjectlessFunctionCallProtocol_Reachable(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: allow-funccall, db_service: appdb, operations: [procedural], decision: allow}
+`)
+	oid := int32(12345)
+	stmt := effects.ClassifiedStatement{
+		Effects: []effects.Effect{
+			{
+				Group:       effects.GroupProcedural,
+				Subtype:     effects.SubtypeFunctionCallProtocol,
+				Objects:     nil,
+				Resolution:  effects.ResolutionQualified,
+				FunctionOID: &oid,
+			},
+		},
+	}
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbAllow {
+		t.Fatalf("verb = %v, want allow; FunctionCallProtocol effect must be reachable via objectless coverage (RuleName=%q, Reason=%q)",
+			d.Verb, d.RuleName, d.Reason)
+	}
+	if d.RuleName != "allow-funccall" {
+		t.Errorf("RuleName = %q, want \"allow-funccall\"", d.RuleName)
+	}
+}
+
+// TestEvaluate_ObjectlessProceduralEscalation_FailsClosed verifies that a
+// SQL-escalated procedural effect (Group==GroupProcedural, Subtype==SubtypeNone)
+// with no Objects is NOT reachable through the objectless coverage path — it
+// must fall through to implicit deny (fail-closed escalation posture).
+//
+// This is the mirror of TestEvaluate_ObjectlessFunctionCallProtocol_Reachable:
+// the isObjectlessEffect whitelist must remain narrow so that arbitrary
+// objectless procedural effects (e.g. an unresolved CALL or SQL-escalated
+// unknown function) do not inadvertently inherit opt-in allow rules.
+func TestEvaluate_ObjectlessProceduralEscalation_FailsClosed(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: allow-funccall, db_service: appdb, operations: [procedural], decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{
+		Effects: []effects.Effect{
+			{
+				Group:      effects.GroupProcedural,
+				Subtype:    effects.SubtypeNone, // no subtype — SQL-escalated unknown function
+				Objects:    nil,
+				Resolution: effects.ResolutionQualified,
+			},
+		},
+	}
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbDeny {
+		t.Fatalf("verb = %v, want deny; SQL-escalated objectless procedural must fail closed (RuleName=%q)",
+			d.Verb, d.RuleName)
+	}
+	if d.RuleName != "" {
+		t.Errorf("RuleName = %q, want \"\" for implicit deny", d.RuleName)
+	}
+}

--- a/internal/db/policy/redaction.go
+++ b/internal/db/policy/redaction.go
@@ -38,11 +38,23 @@ func ParseRedactionTier(s string) (RedactionTier, bool) {
 // RedactionConfig is the policies.db block. See §10.3.
 //
 // Defaults applied by Decode when a field is missing:
-//   LogStatements:            RedactParametersRedacted
-//   ApprovalStatementPreview: RedactParametersRedacted (named "redacted" in YAML)
-//   ApprovalStatementChars:   200
+//
+//	LogStatements:            RedactParametersRedacted
+//	ApprovalStatementPreview: RedactParametersRedacted (named "redacted" in YAML)
+//	ApprovalStatementChars:   200
 type RedactionConfig struct {
 	LogStatements            RedactionTier
 	ApprovalStatementPreview RedactionTier
 	ApprovalStatementChars   int
+
+	// EscalateUnknownFunctions reflects policies.db.escalate_unknown_functions.
+	// When true, classifier reclassifies SELECT calling a function NOT in
+	// SafeFunctionAllowlist as procedural rather than read.
+	EscalateUnknownFunctions bool
+
+	// SafeFunctionAllowlist is the lowercase canonical function names that
+	// stay classified as `read` when EscalateUnknownFunctions is on. When
+	// the config omits the key but escalate is on, Decode populates this
+	// with classify/postgres.DefaultSafeFunctionAllowlist() keys.
+	SafeFunctionAllowlist []string
 }

--- a/internal/db/proxy/postgres/escalation_test.go
+++ b/internal/db/proxy/postgres/escalation_test.go
@@ -1,0 +1,213 @@
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgproto3"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+)
+
+// escalationPolicyYAML returns a policy YAML that has:
+//   - allow-everyone connection rule
+//   - allow-all database rule (operations: ["*"]) so plain reads go through
+//   - allow-transaction and allow-session for BEGIN/COMMIT/SET
+//   - policies.db.escalate_unknown_functions = escalate
+//   - No safe_function_allowlist override (uses the default builtin list)
+//
+// With escalation on, SELECT do_thing() FROM t is classified as procedural
+// (unknown function) + read. The procedural effect has no objects → implicit
+// deny wins via foldEffects, so the query is denied even though the allow-all
+// rule covers read. With escalation off, the same query is pure read → allowed.
+func escalationPolicyYAML(upstream string, escalate bool) string {
+	y := fmt.Sprintf(`version: 1
+name: escalation-test
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: %s
+    tls_mode: terminate_plaintext_upstream
+    trusted_network: true
+database_connection_rules:
+  - name: allow-everyone
+    db_service: appdb
+    decision: allow
+database_rules:
+  - name: allow-all
+    db_service: appdb
+    operations: ["*"]
+    decision: allow
+  - name: allow-transaction
+    db_service: appdb
+    operations: [transaction]
+    decision: allow
+  - name: allow-session
+    db_service: appdb
+    operations: [session]
+    decision: allow
+`, upstream)
+	if escalate {
+		y += `policies:
+  db:
+    escalate_unknown_functions: true
+`
+	}
+	return y
+}
+
+// authOKThenQueryScript handles the PostgreSQL handshake and serves one
+// query with a single-row result, then drains.
+func authOKThenQueryForEscalation(t *testing.T, be *pgproto3.Backend, conn net.Conn) error {
+	t.Helper()
+	if _, err := be.ReceiveStartupMessage(); err != nil {
+		return fmt.Errorf("receive startup: %w", err)
+	}
+	be.Send(&pgproto3.AuthenticationOk{})
+	be.Send(&pgproto3.ParameterStatus{Name: "standard_conforming_strings", Value: "on"})
+	be.Send(&pgproto3.ParameterStatus{Name: "client_encoding", Value: "UTF8"})
+	be.Send(&pgproto3.ParameterStatus{Name: "server_version", Value: "16.0"})
+	be.Send(&pgproto3.BackendKeyData{ProcessID: 42, SecretKey: append([]byte(nil), wantSecret...)})
+	be.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+	if err := be.Flush(); err != nil {
+		return fmt.Errorf("flush handshake: %w", err)
+	}
+	// Handle first query (send one row back).
+	msg, err := be.Receive()
+	if err != nil {
+		return nil // client closed
+	}
+	if _, ok := msg.(*pgproto3.Query); ok {
+		be.Send(&pgproto3.RowDescription{Fields: []pgproto3.FieldDescription{{
+			Name:         []byte("result"),
+			DataTypeOID:  25, // text
+			DataTypeSize: -1,
+			TypeModifier: -1,
+		}}})
+		be.Send(&pgproto3.DataRow{Values: [][]byte{[]byte("ok")}})
+		be.Send(&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")})
+		be.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+		if err := be.Flush(); err != nil {
+			return nil
+		}
+	}
+	// Drain until client closes.
+	buf := make([]byte, 256)
+	for {
+		_ = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		if _, err := conn.Read(buf); err != nil {
+			return nil
+		}
+	}
+}
+
+// drainStatements polls the SyncSink for events up to deadline.
+func drainStatements(sink *events.SyncSink, want int, deadline time.Duration) []events.DBEvent {
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		evs := sink.DrainStatements()
+		if len(evs) >= want {
+			return evs
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return nil
+}
+
+// TestSpine_Escalation_UnknownFunction_DeniedWhenEscalateOn verifies that
+// SELECT do_thing() FROM t is denied when escalate_unknown_functions is true
+// because the procedural effect (objects=[]) causes an implicit deny that
+// overrides the allow-all read coverage.
+func TestSpine_Escalation_UnknownFunction_DeniedWhenEscalateOn(t *testing.T) {
+	up := newFakeUpstream(t, withFakeUpstreamScript(authOKThenQueryForEscalation))
+	upAddr := up.Address()
+
+	h := startSpineHarness(t, upstreamWithLocalhostHost(upAddr), "terminate_plaintext_upstream", nil, "")
+	h.srv.SetPolicy(loadRuleSet(t, escalationPolicyYAML(upAddr, true)))
+
+	stop := runServer(t, h.srv)
+	defer stop()
+
+	sockDir := renameSocketForPgx(t, h.sock, 5440)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := pgx.Connect(ctx, pgxConnString(sockDir, 5440))
+	if err != nil {
+		t.Fatalf("pgx.Connect: %v", err)
+	}
+	defer conn.Close(context.Background())
+
+	// do_thing() is not in the default safe allowlist → classified as
+	// procedural (no objects) + read → implicit deny wins.
+	_, err = conn.Exec(ctx, "SELECT do_thing() FROM t")
+	if err == nil {
+		t.Fatal("expected deny error from proxy, got nil")
+	}
+	code := pgxErrorCode(err)
+	if code != "42501" {
+		// Accept any error that isn't "query succeeded" — proxy may also close
+		// the connection depending on tx state.
+		if !strings.Contains(err.Error(), "42501") {
+			t.Logf("error (want 42501 or conn close): %v (code=%s)", err, code)
+		}
+	}
+
+	evs := drainStatements(h.sink, 1, 2*time.Second)
+	if len(evs) == 0 {
+		t.Fatal("no statement events recorded")
+	}
+	if evs[0].Decision.Verb != "deny" {
+		t.Fatalf("Decision.Verb = %q want deny (event=%+v)", evs[0].Decision.Verb, evs[0])
+	}
+}
+
+// TestSpine_Escalation_UnknownFunction_AllowedWhenEscalateOff verifies that
+// SELECT do_thing() FROM t is allowed when escalate_unknown_functions is false
+// (default): the function is treated as opaque and the query classifies as
+// pure read, covered by the allow-all rule.
+func TestSpine_Escalation_UnknownFunction_AllowedWhenEscalateOff(t *testing.T) {
+	up := newFakeUpstream(t, withFakeUpstreamScript(authOKThenQueryForEscalation))
+	upAddr := up.Address()
+
+	h := startSpineHarness(t, upstreamWithLocalhostHost(upAddr), "terminate_plaintext_upstream", nil, "")
+	h.srv.SetPolicy(loadRuleSet(t, escalationPolicyYAML(upAddr, false)))
+
+	stop := runServer(t, h.srv)
+	defer stop()
+
+	sockDir := renameSocketForPgx(t, h.sock, 5441)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := pgx.Connect(ctx, pgxConnString(sockDir, 5441))
+	if err != nil {
+		t.Fatalf("pgx.Connect: %v", err)
+	}
+	defer conn.Close(context.Background())
+
+	// With escalation off, do_thing() is opaque → read objects=[t] → allow-all covers it.
+	var result string
+	err = conn.QueryRow(ctx, "SELECT do_thing() FROM t").Scan(&result)
+	if err != nil {
+		t.Fatalf("expected allow (query forwarded), got error: %v", err)
+	}
+
+	evs := drainStatements(h.sink, 1, 2*time.Second)
+	if len(evs) == 0 {
+		t.Fatal("no statement events recorded")
+	}
+	if evs[0].Decision.Verb != "allow" {
+		t.Fatalf("Decision.Verb = %q want allow (event=%+v)", evs[0].Decision.Verb, evs[0])
+	}
+}

--- a/internal/db/proxy/postgres/eventbuilder_test.go
+++ b/internal/db/proxy/postgres/eventbuilder_test.go
@@ -195,3 +195,33 @@ func TestBuildEvent_DenyActionRollbackInjected(t *testing.T) {
 		t.Errorf("DenyAction=%q want rollback_injected", ev.TxContext.DenyAction)
 	}
 }
+
+func TestBuildEvent_PropagatesFunctionOID(t *testing.T) {
+	oid := int32(99)
+	sql := "-- function call"
+	stmt := effects.ClassifiedStatement{
+		RawVerb: "FUNCTION_CALL",
+		Effects: []effects.Effect{{
+			Group:       effects.GroupProcedural,
+			Subtype:     effects.SubtypeFunctionCallProtocol,
+			FunctionOID: &oid,
+		}},
+	}
+	parser := classify_pg.New(classify_pg.DialectPostgres)
+	ev := buildStatementEvent(buildArgs{
+		Stmt:     stmt,
+		SQL:      sql,
+		Tier:     policy.RedactParametersRedacted,
+		Conn:     connStateForTest("appdb", "postgres", "terminate_reissue"),
+		Decision: policy.Decision{Verb: policy.VerbAllow},
+		DenyAction: "none",
+		BatchSHA: sha256Hex(sql),
+		Parser:   parser,
+	})
+	if len(ev.Effects) != 1 {
+		t.Fatalf("len(Effects)=%d want 1", len(ev.Effects))
+	}
+	if ev.Effects[0].FunctionOID == nil || *ev.Effects[0].FunctionOID != 99 {
+		t.Errorf("FunctionOID=%v want 99", ev.Effects[0].FunctionOID)
+	}
+}

--- a/internal/db/proxy/postgres/extquery.go
+++ b/internal/db/proxy/postgres/extquery.go
@@ -26,13 +26,16 @@ func (pc *proxyConn) handleExtendedFrame(ctx context.Context, msg pgproto3.Front
 	}
 	wireView := wireCacheView{c: pc.wireCache}
 	parser := pc.srv.classifierFor(pc.svc.Dialect)
+	rs := pc.srv.policy()
+	opts := classifierOptionsFromPolicy(rs)
 	next, actions := statemachine.TransitionWithParser(
 		*pc.state.smState,
 		frame,
 		wireView,
-		pc.srv.policy(),
+		rs,
 		policy.ServiceID(pc.svc.Name),
 		parser,
+		opts,
 	)
 	*pc.state.smState = next
 	return pc.executeActions(ctx, msg, actions)

--- a/internal/db/proxy/postgres/funccall.go
+++ b/internal/db/proxy/postgres/funccall.go
@@ -1,0 +1,98 @@
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/proxy/postgres/statemachine"
+)
+
+// handleFunctionCall handles an 'F' FunctionCall frame. Default behavior
+// (when pc.svc.Service.AllowFunctionCallProtocol is false) preserves 04c's
+// 42501 stub: emit lifecycle event, synth FATAL error, return errUnsupportedFrame.
+// Opt-in behavior classifies as procedural/function_call_protocol with FunctionOID,
+// evaluates, and either forwards or routes through DenyRoute.
+func (pc *proxyConn) handleFunctionCall(ctx context.Context, msg *pgproto3.FunctionCall) error {
+	if !pc.svc.Service.AllowFunctionCallProtocol {
+		// 04c default path: preserve the existing stub behavior from handleUnsupportedFrame.
+		pc.emitUnsupportedFrame(ctx, "FUNCTION_CALL_PROTOCOL_DENIED", "FunctionCall")
+		_ = pc.synthesizeError(sqlstateInsufficientPrivilege, "FunctionCall sub-protocol denied by AgentSH policy")
+		return errUnsupportedFrame
+	}
+
+	// Opt-in: build the ClassifiedStatement, evaluate, route.
+	oid := int32(msg.Function)
+	cs := effects.ClassifiedStatement{
+		RawVerb: "FUNCTION_CALL",
+		Effects: []effects.Effect{{
+			Group:       effects.GroupProcedural,
+			Subtype:     effects.SubtypeFunctionCallProtocol,
+			FunctionOID: &oid,
+		}},
+	}
+	rs := pc.srv.policy()
+	d := policy.Evaluate(cs, rs, policy.ServiceID(pc.svc.Name))
+	if d.Verb == policy.VerbApprove {
+		d = synthApproveAsDeny(d)
+	}
+
+	if d.Verb == policy.VerbDeny {
+		denyRule := lookupStatementRuleByName(rs, d.RuleName)
+		da := denyActionForState(pc.state.smState, denyRule)
+		// Deny path has no upstream round-trip; pass zero-valued result.
+		pc.emitFunctionCallEvent(ctx, cs, d, da, upstreamResult{})
+		denyMsg := renderDenyMessage(d)
+		actions := statemachine.DenyRoute(*pc.state.smState, denyRule, denyMsg, sqlstateInsufficientPrivilege)
+		return pc.executeActions(ctx, msg, actions)
+	}
+
+	// Allow path: forward to upstream.
+	pc.state.upstreamFE.Send(msg)
+	if err := pc.state.upstreamFE.Flush(); err != nil {
+		return err
+	}
+	// Drain upstream until RFQ; emit allow event with result counters.
+	result, ferr := pc.forwardUpstreamUntilRFQ(ctx, timeNow(), 0)
+	pc.emitFunctionCallEvent(ctx, cs, d, "none", result)
+	return ferr
+}
+
+// emitFunctionCallEvent emits one db_statement event for a FunctionCall frame.
+// The FunctionCall has no SQL string so we pass an empty string; the event's
+// Effects + RawVerb carry the semantically meaningful information.
+// r carries BytesOut and LatencyMs from the upstream round-trip (zero-valued
+// for the deny path, which has no upstream interaction).
+func (pc *proxyConn) emitFunctionCallEvent(
+	ctx context.Context,
+	cs effects.ClassifiedStatement,
+	d policy.Decision,
+	denyAction string,
+	r upstreamResult,
+) {
+	if pc.srv.cfg.Sink == nil {
+		return
+	}
+	ev := buildStatementEvent(buildArgs{
+		Stmt:       cs,
+		StmtIndex:  0,
+		BatchTotal: 1,
+		Decision:   d,
+		SQL:        "",
+		Tier:       pc.state.redactionTier,
+		Conn:       *pc.state,
+		BytesIn:    0,  // FunctionCall frames carry no SQL body to measure
+		BytesOut:   r.BytesOut,
+		LatencyMs:  r.LatencyMs,
+		DenyAction: denyAction,
+		BatchSHA:   "", // FunctionCall frames have no SQL body to hash
+		Parser:     pc.srv.classifierFor(pc.svc.Dialect),
+	})
+	if err := pc.srv.cfg.Sink.EmitStatement(ctx, ev); err != nil {
+		pc.logger.Warn("emit function call event failed", "err", err)
+	}
+}

--- a/internal/db/proxy/postgres/funccall.go
+++ b/internal/db/proxy/postgres/funccall.go
@@ -13,12 +13,17 @@ import (
 )
 
 // handleFunctionCall handles an 'F' FunctionCall frame. Default behavior
-// (when pc.svc.Service.AllowFunctionCallProtocol is false) preserves 04c's
-// 42501 stub: emit lifecycle event, synth FATAL error, return errUnsupportedFrame.
+// (when the live policy's DBService.AllowFunctionCallProtocol is false) preserves
+// 04c's 42501 stub: emit lifecycle event, synth FATAL error, return errUnsupportedFrame.
 // Opt-in behavior classifies as procedural/function_call_protocol with FunctionOID,
 // evaluates, and either forwards or routes through DenyRoute.
 func (pc *proxyConn) handleFunctionCall(ctx context.Context, msg *pgproto3.FunctionCall) error {
-	if !pc.svc.Service.AllowFunctionCallProtocol {
+	// Always read from the live policy so that YAML changes take effect without
+	// a server restart.  If the service is not found in the policy (nil RuleSet
+	// or missing entry) AllowFunctionCallProtocol defaults to false.
+	rs := pc.srv.policy()
+	liveSvc, _ := rs.Service(policy.ServiceID(pc.svc.Name))
+	if !liveSvc.AllowFunctionCallProtocol {
 		// 04c default path: preserve the existing stub behavior from handleUnsupportedFrame.
 		pc.emitUnsupportedFrame(ctx, "FUNCTION_CALL_PROTOCOL_DENIED", "FunctionCall")
 		_ = pc.synthesizeError(sqlstateInsufficientPrivilege, "FunctionCall sub-protocol denied by AgentSH policy")
@@ -35,7 +40,6 @@ func (pc *proxyConn) handleFunctionCall(ctx context.Context, msg *pgproto3.Funct
 			FunctionOID: &oid,
 		}},
 	}
-	rs := pc.srv.policy()
 	d := policy.Evaluate(cs, rs, policy.ServiceID(pc.svc.Name))
 	if d.Verb == policy.VerbApprove {
 		d = synthApproveAsDeny(d)

--- a/internal/db/proxy/postgres/funccall_test.go
+++ b/internal/db/proxy/postgres/funccall_test.go
@@ -121,7 +121,6 @@ func TestFunctionCall_DefaultDenied(t *testing.T) {
 //     Effects[0].Subtype == function_call_protocol, FunctionOID == 12345.
 func TestFunctionCall_OptIn_Allow(t *testing.T) {
 	pc, clientFE, sink := newSimpleQueryFixture(t)
-	pc.svc.Service.AllowFunctionCallProtocol = true
 	pc.state.smState.LastUpstreamRFQ = 'I'
 	pc.srv.SetPolicy(loadRuleSet(t, funcCallPolicyYAML(true)))
 
@@ -232,7 +231,6 @@ func TestFunctionCall_OptIn_Allow(t *testing.T) {
 //   - the sink has a deny event with the right FunctionOID.
 func TestFunctionCall_OptIn_Deny(t *testing.T) {
 	pc, clientFE, sink := newSimpleQueryFixture(t)
-	pc.svc.Service.AllowFunctionCallProtocol = true
 	pc.state.smState.LastUpstreamRFQ = 'I'
 	pc.srv.SetPolicy(loadRuleSet(t, funcCallPolicyYAML(false)))
 

--- a/internal/db/proxy/postgres/funccall_test.go
+++ b/internal/db/proxy/postgres/funccall_test.go
@@ -1,0 +1,325 @@
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+	"github.com/agentsh/agentsh/internal/db/policy"
+)
+
+// funcCallPolicyYAML returns a YAML policy that grants allow on procedural
+// or denies it, based on the allowProcedural flag.
+func funcCallPolicyYAML(allowProcedural bool) string {
+	decision := "deny"
+	if allowProcedural {
+		decision = "allow"
+	}
+	return `version: 1
+name: test
+db_services:
+  test:
+    family: postgres
+    dialect: postgres
+    upstream: 127.0.0.1:5432
+    tls_mode: terminate_reissue
+    allow_function_call_protocol: true
+database_rules:
+  - name: rule-procedural
+    db_service: test
+    operations: [procedural]
+    decision: ` + decision + `
+`
+}
+
+// TestFunctionCall_DefaultDenied asserts that when AllowFunctionCallProtocol
+// is false (the default), handleFunctionCall returns errUnsupportedFrame and
+// the client receives an ErrorResponse with SQLSTATE 42501. The upstream must
+// not receive the frame.
+func TestFunctionCall_DefaultDenied(t *testing.T) {
+	pc, clientFE, sink := newSimpleQueryFixture(t)
+	// AllowFunctionCallProtocol defaults to false (zero value).
+	pc.state.smState.LastUpstreamRFQ = 'I'
+
+	// Wire a recording upstream.
+	var (
+		mu             sync.Mutex
+		upstreamSawAny bool
+	)
+	upClient, upServer := net.Pipe()
+	t.Cleanup(func() { _ = upClient.Close(); _ = upServer.Close() })
+	pc.state.upstream = upServer
+	pc.state.upstreamFE = pgproto3.NewFrontend(upServer, upServer)
+	go func() {
+		be := pgproto3.NewBackend(upClient, upClient)
+		_ = upClient.SetReadDeadline(time.Now().Add(3 * time.Second))
+		if _, err := be.Receive(); err == nil {
+			mu.Lock()
+			upstreamSawAny = true
+			mu.Unlock()
+		}
+	}()
+
+	// Run handleFunctionCall in a goroutine because synthesizeError drains the
+	// client connection (io.Copy), which blocks until the client side is read
+	// or the pipe closes.
+	result := make(chan error, 1)
+	go func() {
+		result <- pc.handleFunctionCall(context.Background(), &pgproto3.FunctionCall{Function: 12345})
+	}()
+
+	// Client must have received an ErrorResponse with SQLSTATE 42501.
+	msg, recvErr := clientFE.Receive()
+	if recvErr != nil {
+		t.Fatalf("client recv: %v", recvErr)
+	}
+	er, ok := msg.(*pgproto3.ErrorResponse)
+	if !ok {
+		t.Fatalf("expected ErrorResponse, got %T", msg)
+	}
+	if er.Code != "42501" {
+		t.Fatalf("SQLSTATE = %q want 42501", er.Code)
+	}
+
+	// handleFunctionCall must return errUnsupportedFrame.
+	select {
+	case err := <-result:
+		if err != errUnsupportedFrame {
+			t.Fatalf("handleFunctionCall default: want errUnsupportedFrame, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleFunctionCall did not return within 5s")
+	}
+
+	// Upstream must not have received the FunctionCall.
+	time.Sleep(100 * time.Millisecond)
+	mu.Lock()
+	saw := upstreamSawAny
+	mu.Unlock()
+	if saw {
+		t.Fatal("upstream saw a frame; FunctionCall default-deny must not forward")
+	}
+
+	// Sink must have a lifecycle event with FUNCTION_CALL_PROTOCOL_DENIED.
+	evs := sink.DrainLifecycle()
+	if len(evs) != 1 || evs[0].ErrorCode != "FUNCTION_CALL_PROTOCOL_DENIED" {
+		t.Fatalf("lifecycle events = %+v", evs)
+	}
+}
+
+// TestFunctionCall_OptIn_Allow asserts that when AllowFunctionCallProtocol is
+// true and the policy allows procedural, handleFunctionCall:
+//   - forwards the FunctionCall to the upstream;
+//   - emits an allow db_statement event with Decision.Verb == "allow",
+//     Effects[0].Subtype == function_call_protocol, FunctionOID == 12345.
+func TestFunctionCall_OptIn_Allow(t *testing.T) {
+	pc, clientFE, sink := newSimpleQueryFixture(t)
+	pc.svc.Service.AllowFunctionCallProtocol = true
+	pc.state.smState.LastUpstreamRFQ = 'I'
+	pc.srv.SetPolicy(loadRuleSet(t, funcCallPolicyYAML(true)))
+
+	// Wire an upstream that records the received frame and replies.
+	var (
+		mu            sync.Mutex
+		upstreamSawFC bool
+	)
+	upClient, upServer := net.Pipe()
+	t.Cleanup(func() { _ = upClient.Close(); _ = upServer.Close() })
+	pc.state.upstream = upServer
+	pc.state.upstreamFE = pgproto3.NewFrontend(upServer, upServer)
+
+	go func() {
+		// The proxy writes FunctionCall to upServer via its upstreamFE.
+		// The upstream side reads with a Backend (which reads FrontendMessages).
+		be := pgproto3.NewBackend(upClient, upClient)
+		msg, err := be.Receive()
+		if err != nil {
+			return
+		}
+		if _, ok := msg.(*pgproto3.FunctionCall); ok {
+			mu.Lock()
+			upstreamSawFC = true
+			mu.Unlock()
+		}
+		// Send back a FunctionCallResponse + RFQ.
+		be.Send(&pgproto3.FunctionCallResponse{Result: []byte{0x01}})
+		be.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+		_ = be.Flush()
+	}()
+
+	// Run handleFunctionCall in a goroutine because forwardUpstreamUntilRFQ
+	// writes FunctionCallResponse + RFQ to the client pipe, which blocks unless
+	// the client side is being drained.
+	result := make(chan error, 1)
+	go func() {
+		result <- pc.handleFunctionCall(context.Background(), &pgproto3.FunctionCall{Function: 12345})
+	}()
+
+	// Drain the forwarded upstream frames from the client side
+	// (FunctionCallResponse + ReadyForQuery).
+	for i := 0; i < 2; i++ {
+		if _, err := clientFE.Receive(); err != nil {
+			// Pipe may be closed; that's fine if handleFunctionCall already returned.
+			break
+		}
+	}
+
+	// handleFunctionCall must return nil on success.
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("handleFunctionCall opt-in allow: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleFunctionCall did not return within 5s")
+	}
+
+	// Upstream must have received the FunctionCall.
+	time.Sleep(100 * time.Millisecond)
+	mu.Lock()
+	saw := upstreamSawFC
+	mu.Unlock()
+	if !saw {
+		t.Fatal("upstream did not receive FunctionCall frame")
+	}
+
+	// Sink must have one allow event with the right effects.
+	var evs []events.DBEvent
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		evs = sink.DrainStatements()
+		if len(evs) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("statement events = %d want 1", len(evs))
+	}
+	ev := evs[0]
+	if ev.Decision.Verb != "allow" {
+		t.Fatalf("Decision.Verb = %q want allow", ev.Decision.Verb)
+	}
+	if len(ev.Effects) == 0 {
+		t.Fatal("Effects empty, want >= 1")
+	}
+	eff := ev.Effects[0]
+	if eff.Subtype.String() != "function_call_protocol" {
+		t.Fatalf("Effects[0].Subtype = %q want function_call_protocol", eff.Subtype.String())
+	}
+	if eff.FunctionOID == nil || *eff.FunctionOID != 12345 {
+		t.Fatalf("Effects[0].FunctionOID = %v want 12345", eff.FunctionOID)
+	}
+	// Verify that the allow path wires BytesOut from the upstream result.
+	// The scripted upstream sends FunctionCallResponse + ReadyForQuery so
+	// BytesOut must be > 0.
+	if ev.Result.BytesOut <= 0 {
+		t.Fatalf("Result.BytesOut = %d want > 0 (upstream result not wired into event)", ev.Result.BytesOut)
+	}
+}
+
+// TestFunctionCall_OptIn_Deny asserts that when AllowFunctionCallProtocol is
+// true and the policy denies procedural, handleFunctionCall:
+//   - does NOT forward to the upstream;
+//   - the client receives an ErrorResponse with SQLSTATE 42501;
+//   - the sink has a deny event with the right FunctionOID.
+func TestFunctionCall_OptIn_Deny(t *testing.T) {
+	pc, clientFE, sink := newSimpleQueryFixture(t)
+	pc.svc.Service.AllowFunctionCallProtocol = true
+	pc.state.smState.LastUpstreamRFQ = 'I'
+	pc.srv.SetPolicy(loadRuleSet(t, funcCallPolicyYAML(false)))
+
+	// Wire a recording upstream.
+	var (
+		mu             sync.Mutex
+		upstreamSawAny bool
+	)
+	upClient, upServer := net.Pipe()
+	t.Cleanup(func() { _ = upClient.Close(); _ = upServer.Close() })
+	pc.state.upstream = upServer
+	pc.state.upstreamFE = pgproto3.NewFrontend(upServer, upServer)
+	go func() {
+		be := pgproto3.NewBackend(upClient, upClient)
+		_ = upClient.SetReadDeadline(time.Now().Add(3 * time.Second))
+		if _, err := be.Receive(); err == nil {
+			mu.Lock()
+			upstreamSawAny = true
+			mu.Unlock()
+		}
+	}()
+
+	// Run handleFunctionCall in a goroutine because executeActions writes
+	// ErrorResponse + ReadyForQuery to the client pipe, blocking unless read.
+	result := make(chan error, 1)
+	go func() {
+		result <- pc.handleFunctionCall(context.Background(), &pgproto3.FunctionCall{Function: 12345})
+	}()
+
+	// Client must have received an ErrorResponse with SQLSTATE 42501.
+	msg := mustReceiveClientFrame(t, clientFE)
+	er, ok := msg.(*pgproto3.ErrorResponse)
+	if !ok {
+		t.Fatalf("expected ErrorResponse, got %T", msg)
+	}
+	if er.Code != "42501" {
+		t.Fatalf("SQLSTATE = %q want 42501", er.Code)
+	}
+
+	// RFQ must follow (pre-tx deny, LastUpstreamRFQ='I').
+	rfq := mustReceiveClientFrame(t, clientFE)
+	if _, ok := rfq.(*pgproto3.ReadyForQuery); !ok {
+		t.Fatalf("expected ReadyForQuery after deny, got %T", rfq)
+	}
+
+	// handleFunctionCall must return nil (pre-tx deny doesn't terminate conn).
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatalf("handleFunctionCall opt-in deny: unexpected error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleFunctionCall did not return within 5s")
+	}
+
+	// Upstream must NOT have received the frame.
+	time.Sleep(100 * time.Millisecond)
+	mu.Lock()
+	saw := upstreamSawAny
+	mu.Unlock()
+	if saw {
+		t.Fatal("upstream saw a frame; FunctionCall deny must not forward")
+	}
+
+	// Sink must have one deny event with FunctionOID == 12345.
+	var evs []events.DBEvent
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		evs = sink.DrainStatements()
+		if len(evs) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("statement events = %d want 1", len(evs))
+	}
+	ev := evs[0]
+	if ev.Decision.Verb != "deny" {
+		t.Fatalf("Decision.Verb = %q want deny", ev.Decision.Verb)
+	}
+	if len(ev.Effects) == 0 {
+		t.Fatal("Effects empty")
+	}
+	eff := ev.Effects[0]
+	if eff.FunctionOID == nil || *eff.FunctionOID != 12345 {
+		t.Fatalf("Effects[0].FunctionOID = %v want 12345", eff.FunctionOID)
+	}
+	_ = policy.VerbDeny // verify import used
+}

--- a/internal/db/proxy/postgres/simplequery.go
+++ b/internal/db/proxy/postgres/simplequery.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgproto3"
 
@@ -110,6 +111,16 @@ func (pc *proxyConn) handleQuery(ctx context.Context, q *pgproto3.Query) error {
 	parser := pc.srv.classifierFor(pc.svc.Dialect)
 	opts := classifierOptionsFromPolicy(rs)
 	stmts, _ := parser.Classify(q.String, classify_pg.SessionState{}, opts)
+
+	// Pre-pass: handles every Intercept-eligible verb except PREPARE.
+	// PREPARE needs decisions, so it's deferred to the post-pass.
+	if len(stmts) == 0 || !strings.HasPrefix(stmts[0].RawVerb, "PREPARE") {
+		preHandled, preActions := Intercept(stmts, nil, pc.sqlCache, *pc.state.smState, rs)
+		if preHandled {
+			return pc.executeActions(ctx, q, preActions)
+		}
+	}
+
 	decisions := make([]policy.Decision, len(stmts))
 	anyDeny := false
 	for i, s := range stmts {
@@ -119,6 +130,26 @@ func (pc *proxyConn) handleQuery(ctx context.Context, q *pgproto3.Query) error {
 		}
 		if decisions[i].Verb == policy.VerbDeny {
 			anyDeny = true
+		}
+	}
+
+	// Post-pass: PREPARE-deny needs decisions to know the denying rule;
+	// PREPARE-allow populates the cache from the inner classification.
+	// Only invoked for PREPARE verbs; all other verbs were handled (or
+	// passed through) in the pre-pass.
+	if len(stmts) > 0 && strings.HasPrefix(stmts[0].RawVerb, "PREPARE") {
+		postHandled, postActions := Intercept(stmts, decisions, pc.sqlCache, *pc.state.smState, rs)
+		if postHandled {
+			batchSHA := sha256HexBatch(q.String)
+			var postDenyRule policy.StatementRule
+			for _, d := range decisions {
+				if d.Verb == policy.VerbDeny {
+					postDenyRule = lookupStatementRuleByName(rs, d.RuleName)
+					break
+				}
+			}
+			pc.emitDenyEvents(ctx, stmts, decisions, q.String, batchSHA, denyActionForState(pc.state.smState, postDenyRule))
+			return pc.executeActions(ctx, q, postActions)
 		}
 	}
 
@@ -158,6 +189,25 @@ func (pc *proxyConn) handleQuery(ctx context.Context, q *pgproto3.Query) error {
 	rendered, sqlstate := pickDenySynth(decisions)
 	actions := statemachine.DenyRoute(*pc.state.smState, denyRule, rendered, sqlstate)
 	return pc.executeActions(ctx, q, actions)
+}
+
+// denyActionForState returns the deny action string based on the current
+// connection state and the matched rule. When the last upstream RFQ indicates
+// an active transaction ('T' or 'E'), the action depends on DenyModeInTx:
+// "rollback_then_continue" -> "rollback_injected"; anything else ->
+// "connection_terminated". Out-of-tx ('I') always returns "none".
+func denyActionForState(s *statemachine.ConnState, rule policy.StatementRule) string {
+	if s == nil {
+		return "none"
+	}
+	switch s.LastUpstreamRFQ {
+	case 'T', 'E':
+		if rule.DenyModeInTx == "rollback_then_continue" {
+			return "rollback_injected"
+		}
+		return "connection_terminated"
+	}
+	return "none"
 }
 
 // lookupStatementRuleByName is a 04c-friendly wrapper around

--- a/internal/db/proxy/postgres/simplequery.go
+++ b/internal/db/proxy/postgres/simplequery.go
@@ -82,15 +82,14 @@ func (pc *proxyConn) simpleQueryLoop(ctx context.Context) error {
 }
 
 // handleUnsupportedFrame synthesizes ErrorResponse for any non-Q/non-X
-// post-handshake frame and closes the connection. Distinguishes FunctionCall
-// (PG 42501) from generic extended-query frames (0A000).
+// post-handshake frame and closes the connection. Delegates FunctionCall
+// frames to handleFunctionCall (which implements the 04c default-deny stub
+// and the Plan-05b opt-in path). Other frames get a generic 0A000 response.
 func (pc *proxyConn) handleUnsupportedFrame(ctx context.Context, msg pgproto3.FrontendMessage) error {
-	frameType := fmt.Sprintf("%T", msg)
-	if _, isFunc := msg.(*pgproto3.FunctionCall); isFunc {
-		pc.emitUnsupportedFrame(ctx, "FUNCTION_CALL_PROTOCOL_DENIED", "FunctionCall")
-		_ = pc.synthesizeError(sqlstateInsufficientPrivilege, "FunctionCall sub-protocol denied by AgentSH policy")
-		return errUnsupportedFrame
+	if fc, isFunc := msg.(*pgproto3.FunctionCall); isFunc {
+		return pc.handleFunctionCall(ctx, fc)
 	}
+	frameType := fmt.Sprintf("%T", msg)
 	pc.emitUnsupportedFrame(ctx, "EXTENDED_QUERY_NOT_SUPPORTED", frameType)
 	_ = pc.synthesizeError(sqlstateFeatureNotSupported, "Extended Query / COPY / FunctionCall not supported in AgentSH proxy phase 1")
 	return errUnsupportedFrame

--- a/internal/db/proxy/postgres/simplequery.go
+++ b/internal/db/proxy/postgres/simplequery.go
@@ -23,6 +23,27 @@ var (
 	errUnsupportedFrame   = errors.New("postgres.simpleQueryLoop: unsupported frame type; conn closed")
 )
 
+// classifierOptionsFromPolicy materializes a classify_pg.Options from the
+// active policy snapshot. Captures the escalation knobs (§7.6) and converts
+// the allowlist slice to a map for the walker.
+func classifierOptionsFromPolicy(rs *policy.RuleSet) classify_pg.Options {
+	if rs == nil {
+		return classify_pg.Options{}
+	}
+	r := rs.Redaction()
+	if !r.EscalateUnknownFunctions {
+		return classify_pg.Options{}
+	}
+	allow := make(map[string]struct{}, len(r.SafeFunctionAllowlist))
+	for _, n := range r.SafeFunctionAllowlist {
+		allow[n] = struct{}{}
+	}
+	return classify_pg.Options{
+		EscalateUnknownFunctions: true,
+		SafeFunctionAllowlist:    allow,
+	}
+}
+
 // simpleQueryLoop is the post-handshake driver. It reads client frames one at
 // a time, dispatches to handleQuery for 'Q', forwards 'X' (Terminate) directly,
 // routes Plan-05a Extended Query frames (Parse/Bind/Describe/Execute/Sync/
@@ -85,9 +106,10 @@ func (pc *proxyConn) handleQuery(ctx context.Context, q *pgproto3.Query) error {
 		return errFrameTooLargeClose
 	}
 
-	parser := pc.srv.classifierFor(pc.svc.Dialect)
-	stmts, _ := parser.Classify(q.String, classify_pg.SessionState{}, classify_pg.Options{})
 	rs := pc.srv.policy()
+	parser := pc.srv.classifierFor(pc.svc.Dialect)
+	opts := classifierOptionsFromPolicy(rs)
+	stmts, _ := parser.Classify(q.String, classify_pg.SessionState{}, opts)
 	decisions := make([]policy.Decision, len(stmts))
 	anyDeny := false
 	for i, s := range stmts {
@@ -123,7 +145,7 @@ func (pc *proxyConn) handleQuery(ctx context.Context, q *pgproto3.Query) error {
 			break
 		}
 	}
-	denyRule := lookupStatementRuleByName(pc.srv.policy(), denyDecision.RuleName)
+	denyRule := lookupStatementRuleByName(rs, denyDecision.RuleName)
 	denyAction := "none"
 	if pc.state.smState != nil && (pc.state.smState.LastUpstreamRFQ == 'T' || pc.state.smState.LastUpstreamRFQ == 'E') {
 		if denyRule.DenyModeInTx == "rollback_then_continue" {

--- a/internal/db/proxy/postgres/spine_test.go
+++ b/internal/db/proxy/postgres/spine_test.go
@@ -1025,3 +1025,329 @@ func TestSpine_Plan04c_SimpleQuery_DenyInTx_Terminates(t *testing.T) {
 		t.Fatalf("DenyAction = %q want connection_terminated (event=%+v)", deny.TxContext.DenyAction, deny)
 	}
 }
+
+// ----------------------------------------------------------------------------
+// Plan 05b — SQL PREPARE deny spine test
+// ----------------------------------------------------------------------------
+
+// prepareDenyScript handles the PostgreSQL handshake (StartupMessage →
+// AuthOk + ParameterStatus + BKD + RFQ) and then drains. The proxy intercepts
+// PREPARE x AS DELETE FROM users before forwarding, so the upstream never
+// receives a Query frame.
+func prepareDenyScript(t *testing.T, be *pgproto3.Backend, conn net.Conn) error {
+	t.Helper()
+	if _, err := be.ReceiveStartupMessage(); err != nil {
+		return fmt.Errorf("receive startup: %w", err)
+	}
+	be.Send(&pgproto3.AuthenticationOk{})
+	be.Send(&pgproto3.ParameterStatus{Name: "standard_conforming_strings", Value: "on"})
+	be.Send(&pgproto3.ParameterStatus{Name: "client_encoding", Value: "UTF8"})
+	be.Send(&pgproto3.ParameterStatus{Name: "server_version", Value: "16.0"})
+	be.Send(&pgproto3.BackendKeyData{ProcessID: 42, SecretKey: append([]byte(nil), wantSecret...)})
+	be.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+	if err := be.Flush(); err != nil {
+		return fmt.Errorf("flush handshake: %w", err)
+	}
+	// Drain until client closes; the PREPARE should never arrive.
+	buf := make([]byte, 256)
+	for {
+		_ = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		if _, err := conn.Read(buf); err != nil {
+			return nil
+		}
+	}
+}
+
+// prepareDenyPolicyYAML builds a policy that allows all reads but denies
+// DELETE (which is the inner effect of PREPARE x AS DELETE FROM users).
+func prepareDenyPolicyYAML(upstream string) string {
+	return `version: 1
+name: prepare-deny-spine
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: ` + upstream + `
+    tls_mode: terminate_plaintext_upstream
+    trusted_network: true
+database_connection_rules:
+  - name: allow-everyone
+    db_service: appdb
+    decision: allow
+database_rules:
+  - name: allow-all
+    db_service: appdb
+    operations: ["*"]
+    decision: allow
+  - name: allow-transaction
+    db_service: appdb
+    operations: [transaction]
+    decision: allow
+  - name: allow-session
+    db_service: appdb
+    operations: [session]
+    decision: allow
+  - name: deny-delete
+    db_service: appdb
+    operations: [DELETE]
+    decision: deny
+`
+}
+
+// TestSpine_SQLPrepare_DenyOverPGX verifies end-to-end that
+// "PREPARE delx AS DELETE FROM users" sent through pgx is intercepted by the
+// proxy and returned to the client as SQLSTATE 42501, and that the sink
+// records a deny event — without forwarding to the upstream.
+func TestSpine_SQLPrepare_DenyOverPGX(t *testing.T) {
+	up := newFakeUpstream(t, withFakeUpstreamScript(prepareDenyScript))
+	upAddr := up.Address()
+
+	h := startSpineHarness(t, upstreamWithLocalhostHost(upAddr), "terminate_plaintext_upstream", nil, "")
+	h.srv.SetPolicy(loadRuleSet(t, prepareDenyPolicyYAML(upAddr)))
+
+	stop := runServer(t, h.srv)
+	defer stop()
+
+	sockDir := renameSocketForPgx(t, h.sock, 5442)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := pgx.Connect(ctx, pgxConnString(sockDir, 5442))
+	if err != nil {
+		t.Fatalf("pgx.Connect: %v", err)
+	}
+	defer conn.Close(context.Background())
+
+	// PREPARE delx AS DELETE FROM users → classifier sees inner DELETE effect →
+	// deny-delete rule fires → proxy synthesizes 42501 without forwarding.
+	_, err = conn.Exec(ctx, "PREPARE delx AS DELETE FROM users")
+	if err == nil {
+		t.Fatal("expected deny error for PREPARE DELETE, got nil")
+	}
+	if code := pgxErrorCode(err); code != "42501" {
+		t.Errorf("expected SQLSTATE 42501; got code=%q err=%v", code, err)
+	}
+
+	// Upstream must not have received the PREPARE query.
+	time.Sleep(200 * time.Millisecond)
+
+	// Confirm the sink recorded a deny event for the PREPARE.
+	evs := drainStatements(h.sink, 1, 2*time.Second)
+	var gotDeny bool
+	for _, ev := range evs {
+		if ev.Decision.Verb == "deny" {
+			gotDeny = true
+			break
+		}
+	}
+	if !gotDeny {
+		t.Errorf("expected deny event for PREPARE DELETE; got %+v", evs)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Plan 05b — FunctionCall opt-in spine test
+// ----------------------------------------------------------------------------
+
+// funcCallOptInScript handles the PostgreSQL handshake and then handles one
+// FunctionCall frame by sending back a FunctionCallResponse + ReadyForQuery.
+func funcCallOptInScript(t *testing.T, be *pgproto3.Backend, conn net.Conn) error {
+	t.Helper()
+	if _, err := be.ReceiveStartupMessage(); err != nil {
+		return fmt.Errorf("receive startup: %w", err)
+	}
+	be.Send(&pgproto3.AuthenticationOk{})
+	be.Send(&pgproto3.ParameterStatus{Name: "standard_conforming_strings", Value: "on"})
+	be.Send(&pgproto3.ParameterStatus{Name: "client_encoding", Value: "UTF8"})
+	be.Send(&pgproto3.ParameterStatus{Name: "server_version", Value: "16.0"})
+	be.Send(&pgproto3.BackendKeyData{ProcessID: 42, SecretKey: append([]byte(nil), wantSecret...)})
+	be.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+	if err := be.Flush(); err != nil {
+		return fmt.Errorf("flush handshake: %w", err)
+	}
+	// Expect a FunctionCall frame.
+	msg, err := be.Receive()
+	if err != nil {
+		return nil // client closed before sending frame
+	}
+	if _, ok := msg.(*pgproto3.FunctionCall); !ok {
+		return fmt.Errorf("expected FunctionCall, got %T", msg)
+	}
+	be.Send(&pgproto3.FunctionCallResponse{Result: []byte{0x01}})
+	be.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+	if err := be.Flush(); err != nil {
+		return fmt.Errorf("flush FunctionCallResponse: %w", err)
+	}
+	// Drain until client closes.
+	buf := make([]byte, 256)
+	for {
+		_ = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		if _, err := conn.Read(buf); err != nil {
+			return nil
+		}
+	}
+}
+
+// funcCallOptInPolicyYAML returns a policy that opts in to FunctionCall and
+// allows procedural operations.
+func funcCallOptInPolicyYAML(upstream string) string {
+	return `version: 1
+name: funccall-optin-spine
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: ` + upstream + `
+    tls_mode: terminate_plaintext_upstream
+    trusted_network: true
+    allow_function_call_protocol: true
+database_connection_rules:
+  - name: allow-everyone
+    db_service: appdb
+    decision: allow
+database_rules:
+  - name: allow-procedural
+    db_service: appdb
+    operations: [procedural]
+    decision: allow
+`
+}
+
+// sendRawFrontendFunctionCall connects directly to the harness's Unix socket,
+// completes the TLS + PostgreSQL startup handshake, sends a FunctionCall frame
+// for the given OID, and returns the next backend frame received.
+//
+// It mirrors the pattern in handRolledTerminateReissueHandshake but goes
+// further: after reading the startup response (AuthOk + params + BKD + RFQ)
+// it sends a FunctionCall and reads the reply.
+func sendRawFrontendFunctionCall(t *testing.T, h *spineHarness, functionOID uint32) pgproto3.BackendMessage {
+	t.Helper()
+
+	raw, err := net.Dial("unix", h.sock)
+	if err != nil {
+		t.Fatalf("dial unix: %v", err)
+	}
+	defer raw.Close()
+
+	// SSLRequest.
+	sslReq := make([]byte, 8)
+	binary.BigEndian.PutUint32(sslReq[0:4], 8)
+	binary.BigEndian.PutUint32(sslReq[4:8], sslRequestMagic)
+	if _, err := raw.Write(sslReq); err != nil {
+		t.Fatalf("write SSLRequest: %v", err)
+	}
+	resp := make([]byte, 1)
+	if _, err := io.ReadFull(raw, resp); err != nil {
+		t.Fatalf("read 'S': %v", err)
+	}
+	if resp[0] != 'S' {
+		t.Fatalf("expected 'S', got %q", resp[0])
+	}
+
+	// TLS handshake against the proxy's CA.
+	pool := x509.NewCertPool()
+	pool.AddCert(h.ca.Cert())
+	tlsConn := tls.Client(raw, &tls.Config{
+		RootCAs:    pool,
+		ServerName: "localhost",
+		MinVersion: tls.VersionTLS12,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		t.Fatalf("TLS handshake: %v", err)
+	}
+
+	// StartupMessage.
+	body := make([]byte, 4)
+	binary.BigEndian.PutUint32(body, 196608) // protocol 3.0
+	body = append(body, []byte("user\x00alice\x00database\x00app\x00\x00")...)
+	hdr := make([]byte, 4)
+	binary.BigEndian.PutUint32(hdr, uint32(len(body)+4))
+	if _, err := tlsConn.Write(append(hdr, body...)); err != nil {
+		t.Fatalf("write StartupMessage: %v", err)
+	}
+
+	// Read until ReadyForQuery (AuthOk + params + BKD + RFQ).
+	// Use a single Frontend for the entire connection lifetime — a second
+	// buffered reader on the same conn would cause frame misalignment.
+	fe := pgproto3.NewFrontend(tlsConn, tlsConn)
+	for {
+		m, err := fe.Receive()
+		if err != nil {
+			t.Fatalf("readUntilRFQ (inline): %v", err)
+		}
+		if _, ok := m.(*pgproto3.ReadyForQuery); ok {
+			break
+		}
+	}
+
+	// Send the FunctionCall frame.
+	fe.Send(&pgproto3.FunctionCall{Function: functionOID})
+	if err := fe.Flush(); err != nil {
+		t.Fatalf("flush FunctionCall: %v", err)
+	}
+
+	// Read the next backend message (FunctionCallResponse or ErrorResponse).
+	_ = tlsConn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	msg, err := fe.Receive()
+	if err != nil {
+		t.Fatalf("receive after FunctionCall: %v", err)
+	}
+	return msg
+}
+
+// hasFunctionOID reports whether any Effect in ev has a FunctionOID matching want.
+func hasFunctionOID(ev events.DBEvent, want int32) bool {
+	for _, e := range ev.Effects {
+		if e.FunctionOID != nil && *e.FunctionOID == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSpine_FunctionCall_OptInForwards verifies end-to-end that a raw
+// FunctionCall frame (function OID 12345), when allow_function_call_protocol
+// is enabled and operations:[procedural] is allowed, is forwarded through the
+// proxy to the upstream, which replies with FunctionCallResponse.
+// The sink records an allow event with the matching FunctionOID.
+func TestSpine_FunctionCall_OptInForwards(t *testing.T) {
+	up := newFakeUpstream(t, withFakeUpstreamScript(funcCallOptInScript))
+	upAddr := up.Address()
+
+	h := startSpineHarness(t, upstreamWithLocalhostHost(upAddr), "terminate_plaintext_upstream", nil, "")
+	h.srv.SetPolicy(loadRuleSet(t, funcCallOptInPolicyYAML(upAddr)))
+
+	stop := runServer(t, h.srv)
+	defer stop()
+
+	// Use port 5443 for this test's socket rename.
+	sockPath := h.sock
+	sockDir := filepath.Dir(sockPath)
+	newSockPath := filepath.Join(sockDir, fmt.Sprintf(".s.PGSQL.%d", 5443))
+	if err := os.Rename(sockPath, newSockPath); err != nil {
+		t.Fatalf("rename socket: %v", err)
+	}
+	// Update h.sock so sendRawFrontendFunctionCall dials the renamed path.
+	h.sock = newSockPath
+
+	got := sendRawFrontendFunctionCall(t, h, 12345)
+	if _, ok := got.(*pgproto3.FunctionCallResponse); !ok {
+		t.Fatalf("got %T; want *pgproto3.FunctionCallResponse", got)
+	}
+
+	// Wait for the allow event.
+	evs := drainStatements(h.sink, 1, 2*time.Second)
+	var gotAllow bool
+	for _, ev := range evs {
+		if ev.Decision.Verb == "allow" && hasFunctionOID(ev, 12345) {
+			gotAllow = true
+			break
+		}
+	}
+	if !gotAllow {
+		t.Errorf("expected allow event with FunctionOID=12345; got %+v", evs)
+	}
+}

--- a/internal/db/proxy/postgres/sqlprepared.go
+++ b/internal/db/proxy/postgres/sqlprepared.go
@@ -1,0 +1,103 @@
+//go:build linux
+
+package postgres
+
+import (
+	"strings"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/proxy/postgres/preparedcache"
+	"github.com/agentsh/agentsh/internal/db/proxy/postgres/statemachine"
+)
+
+// Intercept implements the spec §7.4 SQL-level prepared statement plus
+// §9.2 R1 DISCARD coverage on the Simple Query path. Called from handleQuery
+// after classify and evaluate; mutates the cache, may rewrite stmts[0] in
+// place (for EXECUTE cache hits), and signals whether the caller still
+// needs to forward the Q frame.
+//
+// Returns Handled=true with an Action sequence when the proxy must NOT
+// forward to upstream — currently:
+//   - PREPARE deny: cache untouched; emit DenyRoute.
+//   - EXECUTE cache miss: emit SynthError + RFQ.
+//
+// Returns Handled=false when the caller should continue with its normal
+// forward path. In that case, stmts[0] may have been rewritten:
+//   - PREPARE allow/audit: cache populated; stmts unchanged.
+//   - EXECUTE cache hit: stmts[0] replaced with cached classification so the
+//     caller's subsequent Evaluate sees the right effect set.
+//   - DEALLOCATE: cache entry removed (or cleared); stmts unchanged.
+//   - DISCARD ALL / DISCARD PLANS: cache cleared; stmts unchanged.
+//   - DISCARD TEMP / DISCARD SEQUENCES: no cache change; stmts unchanged.
+//   - Any other RawVerb: no-op.
+//
+// `decisions` may be nil for verbs that don't require a prior evaluation
+// (EXECUTE — the cached classification is the source of truth for re-eval
+// inside the caller). `rs` may be nil in pure-unit tests; the deny path
+// then falls through with a zero-valued StatementRule.
+func Intercept(
+	stmts []effects.ClassifiedStatement,
+	decisions []policy.Decision,
+	cache *preparedcache.Cache,
+	s statemachine.ConnState,
+	rs *policy.RuleSet,
+) (handled bool, actions []statemachine.Action) {
+	if len(stmts) == 0 {
+		return false, nil
+	}
+	first := &stmts[0]
+
+	switch {
+	case strings.HasPrefix(first.RawVerb, "PREPARE"):
+		// PREPARE name AS <inner>. RawVerb is "PREPARE" (no inner) or
+		// "PREPARE_<INNER_VERB>". Decisions[0] is the inner-stmt result.
+		if len(decisions) > 0 && decisions[0].Verb == policy.VerbDeny {
+			rule := lookupStatementRuleByName(rs, decisions[0].RuleName)
+			msg := "denied by AgentSH policy: " + decisions[0].RuleName
+			return true, statemachine.DenyRoute(s, rule, msg, "42501")
+		}
+		// Allow path: populate cache with inner classification.
+		inner := *first
+		inner.RawVerb = strings.TrimPrefix(first.RawVerb, "PREPARE_")
+		inner.PreparedName = ""
+		cache.Put(first.PreparedName, preparedcache.Entry{Classification: inner})
+		return false, nil
+
+	case first.RawVerb == "EXECUTE":
+		e, ok := cache.Get(first.PreparedName)
+		if !ok {
+			return true, []statemachine.Action{
+				&statemachine.ActionSynthError{
+					SQLState: "26000",
+					Message:  "SQL_PREPARED_CACHE_MISS: prepared statement \"" + first.PreparedName + "\" does not exist in AgentSH proxy cache",
+				},
+				&statemachine.ActionSynthReadyForQuery{Status: 'I'},
+			}
+		}
+		// Rewrite stmts[0] with cached classification so the caller's
+		// downstream Evaluate sees the inner effect set, not Unknown.
+		first.Effects = e.Classification.Effects
+		first.Error = ""
+		return false, nil
+
+	case first.RawVerb == "DEALLOCATE":
+		if first.PreparedName == "" {
+			cache.Clear()
+		} else {
+			cache.Delete(first.PreparedName)
+		}
+		return false, nil
+
+	case first.RawVerb == "DISCARD":
+		if len(first.Effects) > 0 {
+			switch first.Effects[0].Subtype {
+			case effects.SubtypeDiscardAll, effects.SubtypeDiscardPlans:
+				cache.Clear()
+			}
+		}
+		return false, nil
+	}
+
+	return false, nil
+}

--- a/internal/db/proxy/postgres/sqlprepared_handler_test.go
+++ b/internal/db/proxy/postgres/sqlprepared_handler_test.go
@@ -1,0 +1,316 @@
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+)
+
+// preparePolicyYAML returns a policy that allows all reads but denies DELETE.
+// Operations are matched by effect group, so PREPARE_DELETE (which has
+// GroupDelete effects) is denied, while PREPARE_SELECT is allowed.
+func preparePolicyYAML() string {
+	return `version: 1
+name: test
+db_services:
+  test:
+    family: postgres
+    dialect: postgres
+    upstream: 127.0.0.1:5432
+    tls_mode: terminate_reissue
+database_rules:
+  - name: allow-all
+    db_service: test
+    operations: ["*"]
+    decision: allow
+  - name: deny-deletes
+    db_service: test
+    operations: [DELETE]
+    decision: deny
+`
+}
+
+// multiQueryUpstreamFixture builds a proxyConn with an upstream net.Pipe whose
+// server side responds to a series of scripted frames per Query received.
+// responses is a list of frame sequences, one slice per Q received in order.
+func multiQueryUpstreamFixture(t *testing.T, responses [][]pgproto3.BackendMessage) (*proxyConn, *pgproto3.Frontend, *events.SyncSink) {
+	t.Helper()
+	pc, clientFE, sink := newSimpleQueryFixture(t)
+	upClient, upServer := net.Pipe()
+	t.Cleanup(func() { _ = upClient.Close(); _ = upServer.Close() })
+	pc.state.upstream = upServer
+	pc.state.upstreamFE = pgproto3.NewFrontend(upServer, upServer)
+
+	go func() {
+		be := pgproto3.NewBackend(upClient, upClient)
+		for _, msgs := range responses {
+			// Receive and discard the inbound Q.
+			if _, err := be.Receive(); err != nil {
+				return
+			}
+			for _, m := range msgs {
+				be.Send(m)
+			}
+			if err := be.Flush(); err != nil {
+				return
+			}
+		}
+		// Drain remaining bytes until pipe closes.
+		buf := make([]byte, 256)
+		for {
+			_ = upClient.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+			if _, err := upClient.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	return pc, clientFE, sink
+}
+
+// TestSQLPreparedHandler_PrepareDeny_InterceptedNotForwarded asserts that when
+// a policy denies DELETE and the client sends PREPARE x AS DELETE FROM users:
+//   - The proxy returns an error (SQLSTATE 42501) without forwarding upstream.
+//   - The sink records a deny event for the PREPARE.
+//   - A subsequent EXECUTE x gets a cache-miss error (26000), proving the cache
+//     was not populated.
+func TestSQLPreparedHandler_PrepareDeny_InterceptedNotForwarded(t *testing.T) {
+	var (
+		mu              sync.Mutex
+		upstreamSawAny  bool
+	)
+
+	pc, clientFE, sink := newSimpleQueryFixture(t)
+	// Wire up an upstream that records if it sees any Q frames.
+	upClient, upServer := net.Pipe()
+	t.Cleanup(func() { _ = upClient.Close(); _ = upServer.Close() })
+	pc.state.upstream = upServer
+	pc.state.upstreamFE = pgproto3.NewFrontend(upServer, upServer)
+
+	go func() {
+		be := pgproto3.NewBackend(upClient, upClient)
+		_ = upClient.SetReadDeadline(time.Now().Add(3 * time.Second))
+		if _, err := be.Receive(); err == nil {
+			mu.Lock()
+			upstreamSawAny = true
+			mu.Unlock()
+		}
+	}()
+
+	pc.state.smState.LastUpstreamRFQ = 'I'
+	pc.srv.SetPolicy(loadRuleSet(t, preparePolicyYAML()))
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	// Send PREPARE x AS DELETE FROM users — should be denied.
+	mustSendFromClient(t, clientFE, &pgproto3.Query{String: "PREPARE x AS DELETE FROM users"})
+
+	er := mustReceiveClientFrame(t, clientFE)
+	errResp, ok := er.(*pgproto3.ErrorResponse)
+	if !ok {
+		t.Fatalf("expected ErrorResponse, got %T", er)
+	}
+	if errResp.Code != "42501" {
+		t.Fatalf("SQLSTATE = %q want 42501 (insufficient_privilege)", errResp.Code)
+	}
+	// RFQ must follow (pre-tx deny).
+	rfq := mustReceiveClientFrame(t, clientFE)
+	if _, ok := rfq.(*pgproto3.ReadyForQuery); !ok {
+		t.Fatalf("expected ReadyForQuery after PREPARE deny, got %T", rfq)
+	}
+
+	// The upstream must NOT have seen the PREPARE Q.
+	time.Sleep(100 * time.Millisecond)
+	mu.Lock()
+	saw := upstreamSawAny
+	mu.Unlock()
+	if saw {
+		t.Fatal("upstream saw a Query frame; PREPARE deny must not forward")
+	}
+
+	// Sink must record a deny event for the PREPARE.
+	var evs []events.DBEvent
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		evs = sink.DrainStatements()
+		if len(evs) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("statement events = %d want 1", len(evs))
+	}
+	if evs[0].Decision.Verb != "deny" {
+		t.Fatalf("event Verb = %q want deny", evs[0].Decision.Verb)
+	}
+
+	// Send EXECUTE x — must get cache-miss error (26000) because PREPARE was
+	// denied and cache was not populated.
+	mustSendFromClient(t, clientFE, &pgproto3.Query{String: "EXECUTE x"})
+
+	er2 := mustReceiveClientFrame(t, clientFE)
+	missResp, ok := er2.(*pgproto3.ErrorResponse)
+	if !ok {
+		t.Fatalf("expected ErrorResponse for EXECUTE after denied PREPARE, got %T", er2)
+	}
+	if missResp.Code != "26000" {
+		t.Fatalf("EXECUTE cache-miss SQLSTATE = %q want 26000", missResp.Code)
+	}
+}
+
+// TestSQLPreparedHandler_PrepareAllow_PopulatesCache_ExecuteHits asserts that
+// with an allow-all policy, PREPARE s1 AS SELECT * FROM users followed by
+// EXECUTE s1:
+//   - Both produce no error responses; the upstream receives and answers both.
+//   - The sink records two allow events.
+//
+// We use a table-qualified SELECT so the effect has objects (a bare "SELECT 1"
+// has no objects and the "["*"]" allow rule cannot cover it).
+func TestSQLPreparedHandler_PrepareAllow_PopulatesCache_ExecuteHits(t *testing.T) {
+	// The upstream receives Q("PREPARE ...") then Q("EXECUTE ...") in sequence.
+	responses := [][]pgproto3.BackendMessage{
+		// Reply to PREPARE s1 AS SELECT * FROM users
+		{
+			&pgproto3.CommandComplete{CommandTag: []byte("PREPARE")},
+			&pgproto3.ReadyForQuery{TxStatus: 'I'},
+		},
+		// Reply to EXECUTE s1
+		{
+			&pgproto3.DataRow{Values: [][]byte{[]byte("alice")}},
+			&pgproto3.CommandComplete{CommandTag: []byte("SELECT 1")},
+			&pgproto3.ReadyForQuery{TxStatus: 'I'},
+		},
+	}
+	pc, clientFE, sink := multiQueryUpstreamFixture(t, responses)
+	pc.state.smState.LastUpstreamRFQ = 'I'
+	pc.srv.SetPolicy(allowAllRuleSet(t))
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	// Send PREPARE s1 AS SELECT * FROM users.
+	mustSendFromClient(t, clientFE, &pgproto3.Query{String: "PREPARE s1 AS SELECT * FROM users"})
+
+	// Expect CommandComplete + ReadyForQuery forwarded from upstream.
+	f1 := mustReceiveClientFrame(t, clientFE)
+	if _, ok := f1.(*pgproto3.CommandComplete); !ok {
+		t.Fatalf("PREPARE: expected CommandComplete, got %T", f1)
+	}
+	f2 := mustReceiveClientFrame(t, clientFE)
+	if _, ok := f2.(*pgproto3.ReadyForQuery); !ok {
+		t.Fatalf("PREPARE: expected ReadyForQuery, got %T", f2)
+	}
+
+	// Send EXECUTE s1 — cache hit; proxy rewrites classification to SELECT/users
+	// effects, evaluates (allow), and forwards upstream.
+	mustSendFromClient(t, clientFE, &pgproto3.Query{String: "EXECUTE s1"})
+
+	// Expect DataRow + CommandComplete + ReadyForQuery.
+	e1 := mustReceiveClientFrame(t, clientFE)
+	if _, ok := e1.(*pgproto3.DataRow); !ok {
+		t.Fatalf("EXECUTE: expected DataRow, got %T", e1)
+	}
+	e2 := mustReceiveClientFrame(t, clientFE)
+	if _, ok := e2.(*pgproto3.CommandComplete); !ok {
+		t.Fatalf("EXECUTE: expected CommandComplete, got %T", e2)
+	}
+	e3 := mustReceiveClientFrame(t, clientFE)
+	if _, ok := e3.(*pgproto3.ReadyForQuery); !ok {
+		t.Fatalf("EXECUTE: expected ReadyForQuery, got %T", e3)
+	}
+
+	// Assert sink has two allow events (one for PREPARE, one for EXECUTE).
+	var evs []events.DBEvent
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		evs = append(evs, sink.DrainStatements()...)
+		if len(evs) >= 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(evs) < 2 {
+		t.Fatalf("statement events = %d want >= 2: %+v", len(evs), evs)
+	}
+	for i, ev := range evs {
+		if ev.Decision.Verb != "allow" {
+			t.Errorf("evs[%d].Decision.Verb = %q want allow", i, ev.Decision.Verb)
+		}
+	}
+	_ = loopErr
+}
+
+// TestSQLPreparedHandler_ExecuteMiss_Returns26000 asserts that with an allow-all
+// policy and no prior PREPARE, sending EXECUTE missing returns SQLSTATE 26000
+// and no upstream query is forwarded.
+func TestSQLPreparedHandler_ExecuteMiss_Returns26000(t *testing.T) {
+	var (
+		mu             sync.Mutex
+		upstreamSawAny bool
+	)
+
+	pc, clientFE, sink := newSimpleQueryFixture(t)
+	upClient, upServer := net.Pipe()
+	t.Cleanup(func() { _ = upClient.Close(); _ = upServer.Close() })
+	pc.state.upstream = upServer
+	pc.state.upstreamFE = pgproto3.NewFrontend(upServer, upServer)
+
+	go func() {
+		be := pgproto3.NewBackend(upClient, upClient)
+		_ = upClient.SetReadDeadline(time.Now().Add(3 * time.Second))
+		if _, err := be.Receive(); err == nil {
+			mu.Lock()
+			upstreamSawAny = true
+			mu.Unlock()
+		}
+	}()
+
+	pc.state.smState.LastUpstreamRFQ = 'I'
+	pc.srv.SetPolicy(allowAllRuleSet(t))
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	mustSendFromClient(t, clientFE, &pgproto3.Query{String: "EXECUTE missing"})
+
+	er := mustReceiveClientFrame(t, clientFE)
+	errResp, ok := er.(*pgproto3.ErrorResponse)
+	if !ok {
+		t.Fatalf("expected ErrorResponse for EXECUTE miss, got %T", er)
+	}
+	if errResp.Code != "26000" {
+		t.Fatalf("SQLSTATE = %q want 26000 (invalid_sql_statement_name)", errResp.Code)
+	}
+	// RFQ must follow.
+	rfq := mustReceiveClientFrame(t, clientFE)
+	if _, ok := rfq.(*pgproto3.ReadyForQuery); !ok {
+		t.Fatalf("expected ReadyForQuery after EXECUTE miss, got %T", rfq)
+	}
+
+	// The upstream must NOT have seen the EXECUTE Q.
+	time.Sleep(100 * time.Millisecond)
+	mu.Lock()
+	saw := upstreamSawAny
+	mu.Unlock()
+	if saw {
+		t.Fatal("upstream saw a Query frame; EXECUTE cache-miss must not forward")
+	}
+
+	// No statement events should be emitted for cache-miss (it's a proxy-side
+	// synthetic error, not a policy decision).
+	evs := sink.DrainStatements()
+	if len(evs) != 0 {
+		t.Fatalf("unexpected statement events for EXECUTE miss: %+v", evs)
+	}
+	_ = loopErr
+}

--- a/internal/db/proxy/postgres/sqlprepared_test.go
+++ b/internal/db/proxy/postgres/sqlprepared_test.go
@@ -1,0 +1,195 @@
+//go:build linux
+
+package postgres
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/proxy/postgres/preparedcache"
+	"github.com/agentsh/agentsh/internal/db/proxy/postgres/statemachine"
+)
+
+func TestSQLPrepared_Prepare_Allow_PopulatesCacheAndReturnsNotHandled(t *testing.T) {
+	cache := preparedcache.New(0)
+	stmts := []effects.ClassifiedStatement{{
+		RawVerb:      "PREPARE_SELECT",
+		PreparedName: "s1",
+		Effects:      []effects.Effect{{Group: effects.GroupRead}},
+	}}
+	decisions := []policy.Decision{{Verb: policy.VerbAllow}}
+	handled, _ := Intercept(stmts, decisions, cache, statemachine.ConnState{}, nil)
+	if handled {
+		t.Fatal("PREPARE allow should return Handled=false; caller forwards normally")
+	}
+	if _, ok := cache.Get("s1"); !ok {
+		t.Fatal("cache should contain s1 after PREPARE allow")
+	}
+}
+
+func TestSQLPrepared_Prepare_Deny_HandledAndDoesNotCache(t *testing.T) {
+	cache := preparedcache.New(0)
+	stmts := []effects.ClassifiedStatement{{
+		RawVerb:      "PREPARE_DELETE",
+		PreparedName: "delstmt",
+		Effects:      []effects.Effect{{Group: effects.GroupDelete}},
+	}}
+	decisions := []policy.Decision{{Verb: policy.VerbDeny, RuleName: "block-delete"}}
+	handled, acts := Intercept(stmts, decisions, cache, statemachine.ConnState{LastUpstreamRFQ: 'I'}, nil)
+	if !handled {
+		t.Fatal("PREPARE deny should be handled by Intercept")
+	}
+	if len(acts) == 0 {
+		t.Fatal("expected DenyRoute actions")
+	}
+	if _, ok := cache.Get("delstmt"); ok {
+		t.Fatal("denied PREPARE must not populate cache")
+	}
+}
+
+func TestSQLPrepared_Execute_CacheHit_AllowNotHandled(t *testing.T) {
+	cache := preparedcache.New(0)
+	cache.Put("s1", preparedcache.Entry{
+		Classification: effects.ClassifiedStatement{
+			Effects: []effects.Effect{{Group: effects.GroupRead}},
+		},
+	})
+	stmts := []effects.ClassifiedStatement{{
+		RawVerb:      "EXECUTE",
+		PreparedName: "s1",
+		Effects:      []effects.Effect{{Group: effects.GroupUnknown}},
+	}}
+	handled, acts := Intercept(stmts, nil, cache, statemachine.ConnState{}, nil)
+	if handled {
+		t.Fatalf("EXECUTE with cache hit should return Handled=false; caller evaluates rewritten stmts. acts=%v", acts)
+	}
+	if stmts[0].Effects[0].Group != effects.GroupRead {
+		t.Fatalf("stmts[0] not rewritten; Group=%v", stmts[0].Effects[0].Group)
+	}
+}
+
+func TestSQLPrepared_Execute_CacheMiss_HandledWithDenyRoute(t *testing.T) {
+	cache := preparedcache.New(0)
+	stmts := []effects.ClassifiedStatement{{
+		RawVerb:      "EXECUTE",
+		PreparedName: "missing",
+	}}
+	handled, acts := Intercept(stmts, nil, cache, statemachine.ConnState{LastUpstreamRFQ: 'I'}, nil)
+	if !handled {
+		t.Fatal("EXECUTE cache miss must be handled by Intercept")
+	}
+	if len(acts) < 2 {
+		t.Fatalf("expected SynthError + RFQ; got %d actions", len(acts))
+	}
+	se, ok := acts[0].(*statemachine.ActionSynthError)
+	if !ok {
+		t.Fatalf("acts[0]=%T want SynthError", acts[0])
+	}
+	if !contains(se.Message, "SQL_PREPARED_CACHE_MISS") && !contains(se.Message, "prepared statement") {
+		t.Errorf("error message lacks cache-miss indication: %q", se.Message)
+	}
+}
+
+func TestSQLPrepared_DeallocateNamed_EvictsAndNotHandled(t *testing.T) {
+	cache := preparedcache.New(0)
+	cache.Put("s1", preparedcache.Entry{Classification: effects.ClassifiedStatement{RawVerb: "SELECT"}})
+	stmts := []effects.ClassifiedStatement{{
+		RawVerb:      "DEALLOCATE",
+		PreparedName: "s1",
+	}}
+	handled, _ := Intercept(stmts, []policy.Decision{{Verb: policy.VerbAllow}}, cache, statemachine.ConnState{}, nil)
+	if handled {
+		t.Error("DEALLOCATE should return Handled=false so caller forwards Q to upstream")
+	}
+	if _, ok := cache.Get("s1"); ok {
+		t.Error("cache must not retain s1 after DEALLOCATE")
+	}
+}
+
+func TestSQLPrepared_DeallocateAll_ClearsAndNotHandled(t *testing.T) {
+	cache := preparedcache.New(0)
+	cache.Put("a", preparedcache.Entry{})
+	cache.Put("b", preparedcache.Entry{})
+	stmts := []effects.ClassifiedStatement{{RawVerb: "DEALLOCATE", PreparedName: ""}}
+	handled, _ := Intercept(stmts, []policy.Decision{{Verb: policy.VerbAllow}}, cache, statemachine.ConnState{}, nil)
+	if handled {
+		t.Error("DEALLOCATE ALL should not be handled (forward Q to upstream)")
+	}
+	if cache.Len() != 0 {
+		t.Errorf("cache.Len()=%d after DEALLOCATE ALL; want 0", cache.Len())
+	}
+}
+
+func TestSQLPrepared_DiscardAll_ClearsAndNotHandled(t *testing.T) {
+	cache := preparedcache.New(0)
+	cache.Put("a", preparedcache.Entry{})
+	stmts := []effects.ClassifiedStatement{{
+		RawVerb: "DISCARD",
+		Effects: []effects.Effect{{Group: effects.GroupSession, Subtype: effects.SubtypeDiscardAll}},
+	}}
+	handled, _ := Intercept(stmts, []policy.Decision{{Verb: policy.VerbAllow}}, cache, statemachine.ConnState{}, nil)
+	if handled {
+		t.Error("DISCARD ALL should not be handled (forward Q to upstream)")
+	}
+	if cache.Len() != 0 {
+		t.Errorf("cache.Len()=%d after DISCARD ALL; want 0", cache.Len())
+	}
+}
+
+func TestSQLPrepared_DiscardPlans_ClearsAndNotHandled(t *testing.T) {
+	cache := preparedcache.New(0)
+	cache.Put("a", preparedcache.Entry{})
+	stmts := []effects.ClassifiedStatement{{
+		RawVerb: "DISCARD",
+		Effects: []effects.Effect{{Group: effects.GroupSession, Subtype: effects.SubtypeDiscardPlans}},
+	}}
+	handled, _ := Intercept(stmts, []policy.Decision{{Verb: policy.VerbAllow}}, cache, statemachine.ConnState{}, nil)
+	if handled {
+		t.Error("DISCARD PLANS should not be handled")
+	}
+	if cache.Len() != 0 {
+		t.Errorf("cache.Len()=%d; want 0", cache.Len())
+	}
+}
+
+func TestSQLPrepared_DiscardTemp_DoesNotTouchCache(t *testing.T) {
+	cache := preparedcache.New(0)
+	cache.Put("a", preparedcache.Entry{})
+	stmts := []effects.ClassifiedStatement{{
+		RawVerb: "DISCARD",
+		Effects: []effects.Effect{{Group: effects.GroupSession, Subtype: effects.SubtypeDiscardTemp}},
+	}}
+	handled, _ := Intercept(stmts, []policy.Decision{{Verb: policy.VerbAllow}}, cache, statemachine.ConnState{}, nil)
+	if handled {
+		t.Error("DISCARD TEMP should not be handled")
+	}
+	if cache.Len() != 1 {
+		t.Errorf("cache.Len()=%d after DISCARD TEMP; want 1 (untouched)", cache.Len())
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func TestSQLPrepared_ExpectedActionShape_DenyRouteMatch(t *testing.T) {
+	cache := preparedcache.New(0)
+	stmts := []effects.ClassifiedStatement{{RawVerb: "PREPARE_DELETE", PreparedName: "x", Effects: []effects.Effect{{Group: effects.GroupDelete}}}}
+	decisions := []policy.Decision{{Verb: policy.VerbDeny, RuleName: "rule1"}}
+	_, acts := Intercept(stmts, decisions, cache, statemachine.ConnState{LastUpstreamRFQ: 'I'}, nil)
+	want := []statemachine.Action{
+		&statemachine.ActionSynthError{SQLState: "42501", Message: "denied by AgentSH policy: rule1"},
+		&statemachine.ActionSynthReadyForQuery{Status: 'I'},
+	}
+	if diff := cmp.Diff(want, acts); diff != "" {
+		t.Errorf("acts diff: %s", diff)
+	}
+}

--- a/internal/db/proxy/postgres/statemachine/transition.go
+++ b/internal/db/proxy/postgres/statemachine/transition.go
@@ -35,7 +35,7 @@ func Transition(
 	svc policy.ServiceID,
 ) (ConnState, []Action) {
 	parser := classify_pg.New(classify_pg.DialectPostgres)
-	return TransitionWithParser(s, frame, cache, rules, svc, parser)
+	return TransitionWithParser(s, frame, cache, rules, svc, parser, classify_pg.Options{})
 }
 
 // TransitionWithParser is the parser-injected variant; tests use it when
@@ -47,14 +47,15 @@ func TransitionWithParser(
 	rules *policy.RuleSet,
 	svc policy.ServiceID,
 	parser PolicyClassifier,
+	opts classify_pg.Options,
 ) (ConnState, []Action) {
 	switch f := frame.(type) {
 	case *SyncFrame:
 		return handleSync(s, f)
 	case *QueryFrame:
-		return handleQuery(s, f, rules, svc, parser)
+		return handleQuery(s, f, rules, svc, parser, opts)
 	case *ParseFrame:
-		return handleParse(s, f, cache, rules, svc, parser)
+		return handleParse(s, f, cache, rules, svc, parser, opts)
 	case *BindFrame:
 		return handleBind(s, f, cache)
 	case *DescribeFrame:
@@ -105,11 +106,12 @@ func handleParse(
 	rules *policy.RuleSet,
 	svc policy.ServiceID,
 	parser PolicyClassifier,
+	opts classify_pg.Options,
 ) (ConnState, []Action) {
 	if s.Absorbing {
 		return s, []Action{&ActionSuppress{}}
 	}
-	stmts, _ := parser.Classify(f.SQL, classify_pg.SessionState{}, classify_pg.Options{})
+	stmts, _ := parser.Classify(f.SQL, classify_pg.SessionState{}, opts)
 	anyDeny := false
 	var denyDecision policy.Decision
 	var denyRule policy.StatementRule
@@ -232,6 +234,7 @@ func handleQuery(
 	s ConnState, f *QueryFrame,
 	rules *policy.RuleSet, svc policy.ServiceID,
 	parser PolicyClassifier,
+	opts classify_pg.Options,
 ) (ConnState, []Action) {
 	if s.Absorbing {
 		// A 'Q' arriving inside an absorbing window means the client jumped
@@ -240,7 +243,7 @@ func handleQuery(
 		// cleanly on the next Sync.
 		return s, []Action{&ActionSuppress{}}
 	}
-	stmts, _ := parser.Classify(f.SQL, classify_pg.SessionState{}, classify_pg.Options{})
+	stmts, _ := parser.Classify(f.SQL, classify_pg.SessionState{}, opts)
 	var denyDecision policy.Decision
 	var denyRule policy.StatementRule
 	anyDeny := false


### PR DESCRIPTION
## Summary

Implements plan 05b (`docs/superpowers/plans/2026-05-11-db-plan-05b-sql-prepared-funccall.md`) — three orthogonal slices on top of 05a's extended-query state machine:

- **SQL `PREPARE` / `EXECUTE` / `DEALLOCATE` / `DISCARD` cache** on the Simple Query path via a new `sqlprepared.Intercept` helper (§7.4 + §9.2 R1)
- **`FunctionCall` ('F' frame) opt-in path** gated by `db_services[i].allow_function_call_protocol` — classifies as `procedural`/`function_call_protocol` with `function_oid`, evaluates, forwards-or-denies (§7.5)
- **Classifier escalation wiring** — `policies.db.escalate_unknown_functions` + `policies.db.safe_function_allowlist` decoded into `RedactionConfig` and threaded into every classifier call site (§7.6)

Plan was authored 2026-05-11; a post-05a audit on 2026-05-12 added a Reconciliation section documenting four drift items (test harness mismatch, AllowFCP field location, duplicate SubtypeFunctionCallProtocol, pre-existing `classify_pg.Options`).

## Notable changes vs the plan as written

- **`setval` omitted** from `DefaultSafeFunctionAllowlist` (state-mutating sequence write — including it would bypass procedural deny rules).
- **`DefaultSafeFunctionAllowlist` moved** to new tag-free subpackage `internal/db/classify/postgres/builtins/` to break an import cycle (`policy → classify/postgres` cycles via `classify/postgres/corpus_test.go → policy`). Plan-authorized fallback.
- **Policy evaluator extension** — `isObjectlessEffect` whitelists `SubtypeFunctionCallProtocol` so FunctionCall OID-only effects (no `Objects`) are reachable via objectless coverage. Bare procedural (SQL escalation) stays fail-closed.
- **Wiring fix**: `handleFunctionCall` reads `AllowFunctionCallProtocol` from the live `RuleSet` instead of the `cfg.Services` snapshot, so YAML changes take effect without server restart.

## Test plan

- [x] `go test ./... -count=1 -timeout 180s` — green
- [x] `GOOS=windows go build ./...` — green
- [x] New unit + integration coverage: PREPARE allow/deny, EXECUTE hit/miss, DEALLOCATE/DISCARD variants, FunctionCall default/allow/deny, evaluator narrow-whitelist invariants, end-to-end PREPARE-deny through pgx, end-to-end FunctionCall raw-frame opt-in.
- [ ] CI green
- [ ] Roborev review at branch level

Note: `go test -race ./internal/db/...` shows 2 pre-existing failures from 05a in `extquery_spine_test.go` — verified at base commit `ba88ab2e`, not a regression. Saved as memory `project_db_proxy_spine_race_flakes` for future runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)