### PR TITLE
[codex] db plan 05c copy approval runtime

### DIFF
--- a/internal/db/classify/postgres/ast_copy.go
+++ b/internal/db/classify/postgres/ast_copy.go
@@ -52,10 +52,12 @@ func classifyCopy(cs *effects.ClassifiedStatement, s *pg_query.CopyStmt, sess Se
 	case s.Relation != nil && !isFrom:
 		// COPY t TO STDOUT
 		appendCopyStdoutEffects(cs, s, sess)
+		cs.BulkOp = effects.BulkOpOut
 	case s.Relation != nil && isFrom:
 		// COPY t FROM STDIN
 		obj, res := extractRelation(s.Relation, sess, effects.ObjectTable)
 		cs.RawVerb = "COPY_FROM_STDIN"
+		cs.BulkOp = effects.BulkOpIn
 		cs.Effects = []effects.Effect{{
 			Group:      effects.GroupBulkLoad,
 			Subtype:    effects.SubtypeCopyFromStdin,
@@ -65,6 +67,7 @@ func classifyCopy(cs *effects.ClassifiedStatement, s *pg_query.CopyStmt, sess Se
 	case s.Query != nil:
 		// COPY (<query>) TO STDOUT
 		appendCopyQueryEffects(cs, s, sess, opts)
+		cs.BulkOp = effects.BulkOpOut
 	default:
 		cs.Effects = []effects.Effect{{Group: effects.GroupUnknown, Resolution: effects.ResolutionUnresolved}}
 		cs.Error = "unmapped form: COPY shape not recognized"

--- a/internal/db/classify/postgres/ast_copy_test.go
+++ b/internal/db/classify/postgres/ast_copy_test.go
@@ -14,6 +14,9 @@ func TestClassifyCopy_ToStdout(t *testing.T) {
 	if cs.RawVerb != "COPY_TO_STDOUT" {
 		t.Fatalf("RawVerb: got %q want COPY_TO_STDOUT", cs.RawVerb)
 	}
+	if cs.BulkOp != effects.BulkOpOut {
+		t.Fatalf("BulkOp: got %v want BulkOpOut", cs.BulkOp)
+	}
 	if len(cs.Effects) != 2 {
 		t.Fatalf("effect count: got %d want 2: %+v", len(cs.Effects), cs.Effects)
 	}
@@ -35,6 +38,9 @@ func TestClassifyCopy_FromStdin(t *testing.T) {
 	if cs.RawVerb != "COPY_FROM_STDIN" {
 		t.Fatalf("RawVerb: got %q want COPY_FROM_STDIN", cs.RawVerb)
 	}
+	if cs.BulkOp != effects.BulkOpIn {
+		t.Fatalf("BulkOp: got %v want BulkOpIn", cs.BulkOp)
+	}
 	if len(cs.Effects) != 1 {
 		t.Fatalf("effect count: got %d want 1", len(cs.Effects))
 	}
@@ -52,6 +58,9 @@ func TestClassifyCopy_ToPath(t *testing.T) {
 	cs := classifyOne(t, "COPY users TO '/tmp/x.csv'", SessionState{})
 	if cs.RawVerb != "COPY_TO_PATH" {
 		t.Fatalf("RawVerb: got %q want COPY_TO_PATH", cs.RawVerb)
+	}
+	if cs.BulkOp != effects.BulkOpNone {
+		t.Fatalf("BulkOp: got %v want BulkOpNone", cs.BulkOp)
 	}
 	if len(cs.Effects) != 3 {
 		t.Fatalf("effect count: got %d want 3: %+v", len(cs.Effects), cs.Effects)
@@ -133,6 +142,9 @@ func TestClassifyCopy_FromProgram(t *testing.T) {
 	if cs.RawVerb != "COPY_FROM_PROGRAM" {
 		t.Fatalf("RawVerb: got %q want COPY_FROM_PROGRAM", cs.RawVerb)
 	}
+	if cs.BulkOp != effects.BulkOpNone {
+		t.Fatalf("BulkOp: got %v want BulkOpNone", cs.BulkOp)
+	}
 	if cs.Effects[0].Group != effects.GroupUnsafeIO ||
 		cs.Effects[0].Subtype != effects.SubtypeCopyFromProgram {
 		t.Fatalf("primary: got %v/%v", cs.Effects[0].Group, cs.Effects[0].Subtype)
@@ -154,6 +166,9 @@ func TestClassifyCopy_QueryToStdout_Select(t *testing.T) {
 	cs := classifyOne(t, "COPY (SELECT * FROM customers) TO STDOUT", SessionState{})
 	if cs.RawVerb != "COPY_QUERY_TO_STDOUT" {
 		t.Fatalf("RawVerb: got %q want COPY_QUERY_TO_STDOUT", cs.RawVerb)
+	}
+	if cs.BulkOp != effects.BulkOpOut {
+		t.Fatalf("BulkOp: got %v want BulkOpOut", cs.BulkOp)
 	}
 	// Expect a bulk_export primary plus the inner SELECT's read effect.
 	if cs.Effects[0].Group != effects.GroupBulkExport ||

--- a/internal/db/effects/statement.go
+++ b/internal/db/effects/statement.go
@@ -1,6 +1,8 @@
 // internal/db/effects/statement.go
 package effects
 
+import "fmt"
+
 // ParserBackend identifies which parser produced a classification, per §7.8.
 type ParserBackend uint8
 
@@ -19,6 +21,46 @@ func (b ParserBackend) String() string {
 	default:
 		return ""
 	}
+}
+
+// BulkOpKind classifies whether a statement initiates a wire-protocol COPY
+// stream the proxy must follow. COPY to/from server paths or PROGRAM forms do
+// not set this because no client-side CopyData stream follows the Q frame.
+type BulkOpKind uint8
+
+const (
+	BulkOpNone BulkOpKind = iota
+	BulkOpIn
+	BulkOpOut
+)
+
+func (b BulkOpKind) String() string {
+	switch b {
+	case BulkOpIn:
+		return "copy_in"
+	case BulkOpOut:
+		return "copy_out"
+	default:
+		return ""
+	}
+}
+
+func (b BulkOpKind) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + b.String() + `"`), nil
+}
+
+func (b *BulkOpKind) UnmarshalJSON(bs []byte) error {
+	switch string(bs) {
+	case `""`, `null`:
+		*b = BulkOpNone
+	case `"copy_in"`:
+		*b = BulkOpIn
+	case `"copy_out"`:
+		*b = BulkOpOut
+	default:
+		return fmt.Errorf("unknown bulk_op %s", bs)
+	}
+	return nil
 }
 
 // ClassifiedStatement is the output of the Postgres classifier (Plan 03) and
@@ -40,6 +82,10 @@ type ClassifiedStatement struct {
 	// Empty for any other verb. For DEALLOCATE ALL, PreparedName is "" (the
 	// proxy's sqlprepared.Intercept distinguishes by RawVerb).
 	PreparedName string `json:"prepared_name,omitempty"`
+
+	// BulkOp is non-None for COPY statements that open a CopyData stream the
+	// proxy must follow.
+	BulkOp BulkOpKind `json:"bulk_op,omitempty"`
 }
 
 // Primary returns the first (canonical) effect. ok=false on empty effects list.

--- a/internal/db/effects/statement_test.go
+++ b/internal/db/effects/statement_test.go
@@ -162,3 +162,55 @@ func TestClassifiedStatement_PreparedName_OmitEmpty(t *testing.T) {
 		t.Fatalf("prepared_name should be omitted; got: %s", bs)
 	}
 }
+
+func TestBulkOpKind_String(t *testing.T) {
+	cases := []struct {
+		in   BulkOpKind
+		want string
+	}{
+		{BulkOpNone, ""},
+		{BulkOpIn, "copy_in"},
+		{BulkOpOut, "copy_out"},
+	}
+	for _, c := range cases {
+		if got := c.in.String(); got != c.want {
+			t.Errorf("BulkOpKind(%d).String()=%q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestClassifiedStatement_BulkOp_JSON_RoundTrip(t *testing.T) {
+	in := ClassifiedStatement{
+		Effects: []Effect{{Group: GroupBulkLoad, Subtype: SubtypeCopyFromStdin}},
+		RawVerb: "COPY",
+		BulkOp:  BulkOpIn,
+	}
+	bs, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(bs), `"bulk_op":"copy_in"`) {
+		t.Fatalf("bulk_op missing: %s", bs)
+	}
+	var out ClassifiedStatement
+	if err := json.Unmarshal(bs, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.BulkOp != BulkOpIn {
+		t.Fatalf("BulkOp=%v want BulkOpIn", out.BulkOp)
+	}
+}
+
+func TestClassifiedStatement_BulkOp_OmitNone(t *testing.T) {
+	in := ClassifiedStatement{
+		Effects: []Effect{{Group: GroupRead}},
+		RawVerb: "SELECT",
+	}
+	bs, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(bs), "bulk_op") {
+		t.Fatalf("bulk_op should be omitted for BulkOpNone: %s", bs)
+	}
+}

--- a/internal/db/events/event.go
+++ b/internal/db/events/event.go
@@ -52,8 +52,7 @@ type EventTLS struct {
 }
 
 // EventDecision mirrors spec §8 decision{}. Verb is one of "allow"|"deny"|
-// "approve"|"audit" (approve never emitted live in 04c; the runtime stubs it
-// out as deny + APPROVE_NOT_YET_SUPPORTED).
+// "approve"|"audit".
 type EventDecision struct {
 	Verb                   string   `json:"verb"`
 	RuleKind               string   `json:"rule_kind"`
@@ -75,9 +74,9 @@ type EventResult struct {
 	ErrorCode    string `json:"error_code,omitempty"`
 }
 
-// EventTxContext mirrors spec §8 tx_context{}. TxStartedAt is zero-valued
-// in 04c; Plan 05's state machine populates it. DenyAction is one of
-// "none"|"connection_terminated"|"rollback_injected" (last value Plan 05).
+// EventTxContext mirrors spec §8 tx_context{}. DenyAction is one of "none",
+// "connection_terminated", "rollback_injected", "approval_timeout",
+// "approval_denied", or "cancelled_during_approval".
 type EventTxContext struct {
 	InTransaction bool      `json:"in_transaction"`
 	TxStartedAt   time.Time `json:"tx_started_at,omitempty"`
@@ -88,4 +87,3 @@ type EventTxContext struct {
 type EventPredicates struct {
 	HasFilter bool `json:"has_filter"`
 }
-

--- a/internal/db/policy/approver.go
+++ b/internal/db/policy/approver.go
@@ -1,0 +1,34 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
+
+// ErrApproverNotConfigured is reserved for callers that require an explicit
+// approver. The proxy default is NopApprover{}.
+var ErrApproverNotConfigured = errors.New("policy: approver not configured")
+
+// Approver decides whether a statement awaiting approval should run.
+type Approver interface {
+	Decide(ctx context.Context, cs effects.ClassifiedStatement, timeout time.Duration) (approved bool, err error)
+}
+
+// NopApprover is the default. It blocks until context cancellation or timeout,
+// then denies by returning approved=false.
+type NopApprover struct{}
+
+func (NopApprover) Decide(ctx context.Context, _ effects.ClassifiedStatement, timeout time.Duration) (bool, error) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err()
+	case <-timer.C:
+		return false, nil
+	}
+}

--- a/internal/db/policy/approver_test.go
+++ b/internal/db/policy/approver_test.go
@@ -1,0 +1,40 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
+
+func TestNopApprover_Timeout_ReturnsFalseNoError(t *testing.T) {
+	a := NopApprover{}
+	approved, err := a.Decide(context.Background(), effects.ClassifiedStatement{}, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Decide err: %v", err)
+	}
+	if approved {
+		t.Error("NopApprover must always deny on timeout")
+	}
+}
+
+func TestNopApprover_CtxCancel_ReturnsCtxErr(t *testing.T) {
+	a := NopApprover{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	approved, err := a.Decide(ctx, effects.ClassifiedStatement{}, time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("err=%v want context.Canceled", err)
+	}
+	if approved {
+		t.Error("approved should be false on ctx cancel")
+	}
+}
+
+func TestErrApproverNotConfigured(t *testing.T) {
+	if ErrApproverNotConfigured == nil {
+		t.Fatal("ErrApproverNotConfigured should not be nil")
+	}
+}

--- a/internal/db/policy/decode_test.go
+++ b/internal/db/policy/decode_test.go
@@ -300,7 +300,7 @@ policies:
 	}
 }
 
-func TestDecode_WarnsOnApproveDecision(t *testing.T) {
+func TestDecode_ApproveDecision_NoLongerWarns(t *testing.T) {
 	src := `version: 1
 name: t
 db_services:
@@ -319,13 +319,9 @@ database_rules:
 	if err != nil {
 		t.Fatalf("Decode: %v", err)
 	}
-	found := false
 	for _, w := range warns {
 		if w.Code == "APPROVE_NOT_YET_SUPPORTED" && w.Rule == "review-deletes" {
-			found = true
+			t.Fatalf("APPROVE_NOT_YET_SUPPORTED warning should no longer be emitted: %#v", w)
 		}
-	}
-	if !found {
-		t.Fatalf("expected APPROVE_NOT_YET_SUPPORTED warning, got %v", warns)
 	}
 }

--- a/internal/db/policy/validate.go
+++ b/internal/db/policy/validate.go
@@ -140,18 +140,6 @@ func validateStatementRule(r *StatementRule, svcs map[ServiceID]*DBService) ([]e
 		}
 	}
 
-	// approve verb is parsed but treated as deny+APPROVE_NOT_YET_SUPPORTED
-	// at runtime until Plan 05 ships the approval workflow. Surface a
-	// loud warning at config load so operators are not surprised.
-	if r.Decision == "approve" {
-		warns = append(warns, Warning{
-			Rule:    r.Name,
-			Field:   "decision",
-			Code:    "APPROVE_NOT_YET_SUPPORTED",
-			Message: fmt.Sprintf("rule %q has decision: approve — Plan 04c treats approve as deny+APPROVE_NOT_YET_SUPPORTED at runtime; the real approval workflow lands in Plan 05", r.Name),
-		})
-	}
-
 	// deny_mode_in_tx is only valid on deny rules. §14.3/§14.4.
 	if r.DenyModeInTx != "" {
 		if r.Decision != "deny" {

--- a/internal/db/proxy/postgres/approvalwait.go
+++ b/internal/db/proxy/postgres/approvalwait.go
@@ -1,0 +1,206 @@
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/proxy/postgres/statemachine"
+)
+
+type approvalOutcome struct {
+	approved   bool
+	denyAction string
+	err        error
+}
+
+type approvalResult struct {
+	approved bool
+	err      error
+}
+
+func (pc *proxyConn) waitForApproval(ctx context.Context, a statemachine.ActionApproverWait) approvalOutcome {
+	approver := pc.srv.cfg.Approver
+	if approver == nil {
+		approver = policy.NopApprover{}
+	}
+	timeout := a.Timeout
+	if timeout == 0 {
+		timeout = 60 * time.Second
+	}
+
+	approveCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	resultCh := make(chan approvalResult, 1)
+	go func() {
+		approved, err := approver.Decide(approveCtx, a.Stmt, timeout)
+		resultCh <- approvalResult{approved: approved, err: err}
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	startedAt := time.Now()
+
+	select {
+	case <-ctx.Done():
+		return approvalOutcome{denyAction: "cancelled_during_approval", err: ctx.Err()}
+	case res := <-resultCh:
+		if res.err != nil || !res.approved {
+			if time.Since(startedAt) >= timeout {
+				return approvalOutcome{denyAction: "approval_timeout"}
+			}
+			return approvalOutcome{denyAction: "approval_denied"}
+		}
+		return approvalOutcome{approved: true, denyAction: "none"}
+	case <-timer.C:
+		cancel()
+		return approvalOutcome{denyAction: "approval_timeout"}
+	}
+}
+
+func (pc *proxyConn) runApprovalWait(ctx context.Context, origFrame pgproto3.FrontendMessage, a statemachine.ActionApproverWait) error {
+	out := pc.waitForApproval(ctx, a)
+	if out.err != nil {
+		pc.emitApprovalFrameEvent(ctx, origFrame, a, approvalDenyDecision(a.Rule, "cancelled during approval"), out.denyAction)
+		return out.err
+	}
+	if out.approved {
+		pc.emitApprovalFrameEvent(ctx, origFrame, a, approvalApproveDecision(a.Rule), "none")
+		pc.state.upstreamFE.Send(origFrame)
+		return pc.state.upstreamFE.Flush()
+	}
+	pc.emitApprovalFrameEvent(ctx, origFrame, a, approvalDenyDecision(a.Rule, approvalReason(out.denyAction)), out.denyAction)
+	actions := statemachine.DenyRoute(*pc.state.smState, a.Rule, "denied by AgentSH policy: "+approvalReason(out.denyAction), sqlstateInsufficientPrivilege)
+	return pc.executeActions(ctx, origFrame, actions)
+}
+
+func (pc *proxyConn) runSimpleQueryApproval(
+	ctx context.Context,
+	q *pgproto3.Query,
+	stmts []effects.ClassifiedStatement,
+	decisions []policy.Decision,
+	approveIndex int,
+	batchSHA string,
+) error {
+	rule := lookupStatementRuleByName(pc.srv.policy(), decisions[approveIndex].RuleName)
+	action := statemachine.ActionApproverWait{
+		Timeout: approvalTimeout(decisions[approveIndex], rule),
+		Stmt:    stmts[approveIndex],
+		Rule:    rule,
+	}
+	out := pc.waitForApproval(ctx, action)
+	if out.err != nil {
+		denyDecisions := decisionsWithApprovalDeny(decisions, approveIndex, "cancelled during approval")
+		pc.emitDenyEvents(ctx, stmts, denyDecisions, q.String, batchSHA, out.denyAction)
+		return out.err
+	}
+	if out.approved {
+		sentAt := timeNow()
+		pc.state.upstreamFE.Send(q)
+		if err := pc.state.upstreamFE.Flush(); err != nil {
+			return err
+		}
+		result, ferr := pc.forwardUpstreamUntilRFQ(ctx, sentAt, len(q.String))
+		pc.emitAllowEvents(ctx, stmts, decisions, q.String, batchSHA, result)
+		return ferr
+	}
+
+	denyDecisions := decisionsWithApprovalDeny(decisions, approveIndex, approvalReason(out.denyAction))
+	pc.emitDenyEvents(ctx, stmts, denyDecisions, q.String, batchSHA, out.denyAction)
+	actions := statemachine.DenyRoute(*pc.state.smState, rule, "denied by AgentSH policy: "+approvalReason(out.denyAction), sqlstateInsufficientPrivilege)
+	return pc.executeActions(ctx, q, actions)
+}
+
+func approvalTimeout(d policy.Decision, rule policy.StatementRule) time.Duration {
+	if rule.Timeout != 0 {
+		return rule.Timeout
+	}
+	if d.Approval != nil && d.Approval.Timeout != 0 {
+		return d.Approval.Timeout
+	}
+	return 60 * time.Second
+}
+
+func approvalApproveDecision(rule policy.StatementRule) policy.Decision {
+	return policy.Decision{
+		Verb:                policy.VerbApprove,
+		RuleKind:            policy.RuleKindStatement,
+		RuleName:            rule.Name,
+		MatchingEffectIndex: 0,
+		MatchingEffectGroup: effects.GroupUnknown,
+	}
+}
+
+func approvalDenyDecision(rule policy.StatementRule, reason string) policy.Decision {
+	return policy.Decision{
+		Verb:                policy.VerbDeny,
+		RuleKind:            policy.RuleKindStatement,
+		RuleName:            rule.Name,
+		MatchingEffectIndex: 0,
+		MatchingEffectGroup: effects.GroupUnknown,
+		Reason:              reason,
+	}
+}
+
+func decisionsWithApprovalDeny(in []policy.Decision, approveIndex int, reason string) []policy.Decision {
+	out := append([]policy.Decision(nil), in...)
+	if approveIndex >= 0 && approveIndex < len(out) {
+		out[approveIndex].Verb = policy.VerbDeny
+		out[approveIndex].Reason = reason
+	}
+	return out
+}
+
+func approvalReason(denyAction string) string {
+	switch denyAction {
+	case "approval_timeout":
+		return "approval timeout"
+	case "approval_denied":
+		return "approval denied"
+	case "cancelled_during_approval":
+		return "cancelled during approval"
+	default:
+		return "approval denied"
+	}
+}
+
+func (pc *proxyConn) emitApprovalFrameEvent(
+	ctx context.Context,
+	origFrame pgproto3.FrontendMessage,
+	a statemachine.ActionApproverWait,
+	d policy.Decision,
+	denyAction string,
+) {
+	if pc.srv.cfg.Sink == nil {
+		return
+	}
+	sql := ""
+	switch f := origFrame.(type) {
+	case *pgproto3.Query:
+		sql = f.String
+	case *pgproto3.Parse:
+		sql = f.Query
+	}
+	ev := buildStatementEvent(buildArgs{
+		Stmt:       a.Stmt,
+		StmtIndex:  0,
+		BatchTotal: 1,
+		Decision:   d,
+		SQL:        sql,
+		Tier:       pc.state.redactionTier,
+		Conn:       *pc.state,
+		BytesIn:    int64(len(sql)),
+		DenyAction: denyAction,
+		BatchSHA:   sha256HexBatch(sql),
+		Parser:     pc.srv.classifierFor(pc.svc.Dialect),
+	})
+	if err := pc.srv.cfg.Sink.EmitStatement(ctx, ev); err != nil {
+		pc.logger.Warn("emit approval event failed", "err", err)
+	}
+}

--- a/internal/db/proxy/postgres/approvalwait_test.go
+++ b/internal/db/proxy/postgres/approvalwait_test.go
@@ -1,0 +1,186 @@
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+	"github.com/agentsh/agentsh/internal/db/events"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/service"
+)
+
+type fakeApprover struct {
+	mu      sync.Mutex
+	calls   int
+	approve bool
+	hold    time.Duration
+}
+
+func (f *fakeApprover) Decide(ctx context.Context, _ effects.ClassifiedStatement, _ time.Duration) (bool, error) {
+	f.mu.Lock()
+	f.calls++
+	f.mu.Unlock()
+	if f.hold > 0 {
+		select {
+		case <-time.After(f.hold):
+		case <-ctx.Done():
+			return false, ctx.Err()
+		}
+	}
+	return f.approve, nil
+}
+
+func TestNew_DefaultsApproverToNop(t *testing.T) {
+	srv, err := New(Config{
+		Unavoidability: service.UnavoidabilityOff,
+		StateDir:       t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if _, ok := srv.cfg.Approver.(policy.NopApprover); !ok {
+		t.Fatalf("Approver = %T want policy.NopApprover", srv.cfg.Approver)
+	}
+}
+
+func approveDeletesRuleSet(t *testing.T, timeout string) *policy.RuleSet {
+	t.Helper()
+	if timeout == "" {
+		timeout = "60s"
+	}
+	return loadRuleSet(t, `version: 1
+name: test
+db_services:
+  test:
+    family: postgres
+    dialect: postgres
+    upstream: 127.0.0.1:5432
+    tls_mode: terminate_reissue
+database_rules:
+  - name: review-delete
+    db_service: test
+    operations: [DELETE]
+    decision: approve
+    timeout: `+timeout+`
+`)
+}
+
+func TestHandleQuery_ApprovalApprove_ForwardsAndEmitsApprove(t *testing.T) {
+	pc, clientFE, sink, script := allowPathFixture(t)
+	pc.state.smState.LastUpstreamRFQ = 'I'
+	pc.srv.SetPolicy(approveDeletesRuleSet(t, "100ms"))
+	pc.srv.cfg.Approver = &fakeApprover{approve: true}
+
+	script([]pgproto3.BackendMessage{
+		&pgproto3.CommandComplete{CommandTag: []byte("DELETE 1")},
+		&pgproto3.ReadyForQuery{TxStatus: 'I'},
+	})
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	mustSendFromClient(t, clientFE, &pgproto3.Query{String: "DELETE FROM t"})
+	frames := drainNFrames(t, clientFE, 2)
+	if _, ok := frames[1].(*pgproto3.ReadyForQuery); !ok {
+		t.Fatalf("last frame = %T want ReadyForQuery", frames[1])
+	}
+
+	evs := waitStatementEvents(t, sink, 1)
+	if evs[0].Decision.Verb != "approve" {
+		t.Fatalf("Decision.Verb = %q want approve", evs[0].Decision.Verb)
+	}
+	if evs[0].Decision.RuleName != "review-delete" {
+		t.Fatalf("RuleName = %q want review-delete", evs[0].Decision.RuleName)
+	}
+	_ = loopErr
+}
+
+func TestHandleQuery_ApprovalDenied_RoutesDeny(t *testing.T) {
+	pc, clientFE, sink := newSimpleQueryFixture(t)
+	pc.state.smState.LastUpstreamRFQ = 'I'
+	pc.srv.SetPolicy(approveDeletesRuleSet(t, "100ms"))
+	pc.srv.cfg.Approver = &fakeApprover{approve: false}
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	mustSendFromClient(t, clientFE, &pgproto3.Query{String: "DELETE FROM t"})
+	er := mustReceiveClientFrame(t, clientFE).(*pgproto3.ErrorResponse)
+	if er.Code != "42501" {
+		t.Fatalf("Code = %q want 42501", er.Code)
+	}
+	_ = mustReceiveClientFrame(t, clientFE).(*pgproto3.ReadyForQuery)
+
+	evs := waitStatementEvents(t, sink, 1)
+	if evs[0].Decision.Verb != "deny" {
+		t.Fatalf("Decision.Verb = %q want deny", evs[0].Decision.Verb)
+	}
+	if evs[0].TxContext.DenyAction != "approval_denied" {
+		t.Fatalf("DenyAction = %q want approval_denied", evs[0].TxContext.DenyAction)
+	}
+	_ = loopErr
+}
+
+func TestHandleQuery_ApprovalTimeout_RoutesDeny(t *testing.T) {
+	pc, clientFE, sink := newSimpleQueryFixture(t)
+	pc.state.smState.LastUpstreamRFQ = 'I'
+	pc.srv.SetPolicy(approveDeletesRuleSet(t, "20ms"))
+	pc.srv.cfg.Approver = &fakeApprover{approve: true, hold: time.Second}
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	start := time.Now()
+	mustSendFromClient(t, clientFE, &pgproto3.Query{String: "DELETE FROM t"})
+	_ = mustReceiveClientFrame(t, clientFE).(*pgproto3.ErrorResponse)
+	_ = mustReceiveClientFrame(t, clientFE).(*pgproto3.ReadyForQuery)
+	if elapsed := time.Since(start); elapsed < 15*time.Millisecond {
+		t.Fatalf("approval returned too quickly: %v", elapsed)
+	}
+
+	evs := waitStatementEvents(t, sink, 1)
+	if evs[0].TxContext.DenyAction != "approval_timeout" {
+		t.Fatalf("DenyAction = %q want approval_timeout", evs[0].TxContext.DenyAction)
+	}
+	_ = loopErr
+}
+
+func TestHandleQuery_NopApproverTimeout_RoutesApprovalTimeout(t *testing.T) {
+	pc, clientFE, sink := newSimpleQueryFixture(t)
+	pc.state.smState.LastUpstreamRFQ = 'I'
+	pc.srv.SetPolicy(approveDeletesRuleSet(t, "20ms"))
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	mustSendFromClient(t, clientFE, &pgproto3.Query{String: "DELETE FROM t"})
+	_ = mustReceiveClientFrame(t, clientFE).(*pgproto3.ErrorResponse)
+	_ = mustReceiveClientFrame(t, clientFE).(*pgproto3.ReadyForQuery)
+
+	evs := waitStatementEvents(t, sink, 1)
+	if evs[0].TxContext.DenyAction != "approval_timeout" {
+		t.Fatalf("DenyAction = %q want approval_timeout", evs[0].TxContext.DenyAction)
+	}
+	_ = loopErr
+}
+
+func waitStatementEvents(t *testing.T, sink *events.SyncSink, want int) []events.DBEvent {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		evs := sink.DrainStatements()
+		if len(evs) >= want {
+			return evs
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d statement events", want)
+	return nil
+}

--- a/internal/db/proxy/postgres/copyframes.go
+++ b/internal/db/proxy/postgres/copyframes.go
@@ -1,0 +1,127 @@
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+	"github.com/agentsh/agentsh/internal/db/proxy/postgres/statemachine"
+)
+
+func (pc *proxyConn) runCopyLoop(ctx context.Context, direction effects.BulkOpKind) (upstreamResult, error) {
+	switch direction {
+	case effects.BulkOpIn:
+		return pc.runCopyInLoop(ctx)
+	case effects.BulkOpOut:
+		return pc.runCopyOutLoop(ctx)
+	default:
+		return upstreamResult{}, fmt.Errorf("postgres.runCopyLoop: unknown COPY direction %v", direction)
+	}
+}
+
+func (pc *proxyConn) runCopyInLoop(ctx context.Context) (upstreamResult, error) {
+	var r upstreamResult
+	if pc.state.smState != nil {
+		pc.state.smState.Phase = statemachine.PhaseInCopyIn
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return r, err
+		}
+		msg, err := pc.backend.Receive()
+		if err != nil {
+			return r, fmt.Errorf("copy-in client recv: %w", err)
+		}
+		switch m := msg.(type) {
+		case *pgproto3.CopyData:
+			r.BytesIn += int64(len(m.Data))
+			pc.state.upstreamFE.Send(m)
+			if err := pc.state.upstreamFE.Flush(); err != nil {
+				return r, fmt.Errorf("copy-in upstream flush data: %w", err)
+			}
+		case *pgproto3.CopyDone:
+			pc.state.upstreamFE.Send(m)
+			if err := pc.state.upstreamFE.Flush(); err != nil {
+				return r, fmt.Errorf("copy-in upstream flush done: %w", err)
+			}
+			return pc.mergeCopyDrain(ctx, r, timeNow())
+		case *pgproto3.CopyFail:
+			pc.state.upstreamFE.Send(m)
+			if err := pc.state.upstreamFE.Flush(); err != nil {
+				return r, fmt.Errorf("copy-in upstream flush fail: %w", err)
+			}
+			return pc.mergeCopyDrain(ctx, r, timeNow())
+		case *pgproto3.Terminate:
+			pc.state.upstreamFE.Send(&pgproto3.CopyFail{Message: "client terminated mid-copy"})
+			_ = pc.state.upstreamFE.Flush()
+			return r, errInTxTerminate
+		default:
+			return r, fmt.Errorf("copy-in unexpected client frame %T", m)
+		}
+	}
+}
+
+func (pc *proxyConn) runCopyOutLoop(ctx context.Context) (upstreamResult, error) {
+	var r upstreamResult
+	if pc.state.smState != nil {
+		pc.state.smState.Phase = statemachine.PhaseInCopyOut
+	}
+	for {
+		if err := ctx.Err(); err != nil {
+			return r, err
+		}
+		msg, err := pc.state.upstreamFE.Receive()
+		if err != nil {
+			return r, fmt.Errorf("copy-out upstream recv: %w", err)
+		}
+		switch m := msg.(type) {
+		case *pgproto3.CopyData:
+			r.BytesOut += int64(len(m.Data))
+			pc.backend.Send(m)
+			if err := pc.backend.Flush(); err != nil {
+				return r, fmt.Errorf("copy-out client flush data: %w", err)
+			}
+		case *pgproto3.CopyDone:
+			r.BytesOut += int64(estimatedFrameSize(m))
+			pc.backend.Send(m)
+			if err := pc.backend.Flush(); err != nil {
+				return r, fmt.Errorf("copy-out client flush done: %w", err)
+			}
+			return pc.mergeCopyDrain(ctx, r, timeNow())
+		case *pgproto3.ErrorResponse:
+			if r.ErrorCode == "" {
+				r.ErrorCode = m.Code
+			}
+			r.BytesOut += int64(estimatedFrameSize(m))
+			pc.backend.Send(m)
+			if err := pc.backend.Flush(); err != nil {
+				return r, fmt.Errorf("copy-out client flush error: %w", err)
+			}
+			return pc.mergeCopyDrain(ctx, r, timeNow())
+		default:
+			r.BytesOut += int64(estimatedFrameSize(m))
+			pc.backend.Send(m)
+			if err := pc.backend.Flush(); err != nil {
+				return r, fmt.Errorf("copy-out client flush %T: %w", m, err)
+			}
+		}
+	}
+}
+
+func (pc *proxyConn) mergeCopyDrain(ctx context.Context, r upstreamResult, sentAt time.Time) (upstreamResult, error) {
+	drained, err := pc.forwardUpstreamUntilRFQ(ctx, sentAt, 0)
+	r.BytesIn += drained.BytesIn
+	r.BytesOut += drained.BytesOut
+	r.RowsByStmt = append(r.RowsByStmt, drained.RowsByStmt...)
+	r.AffectedByStmt = append(r.AffectedByStmt, drained.AffectedByStmt...)
+	r.LatencyMs = drained.LatencyMs
+	if drained.ErrorCode != "" {
+		r.ErrorCode = drained.ErrorCode
+	}
+	return r, err
+}

--- a/internal/db/proxy/postgres/copyframes_test.go
+++ b/internal/db/proxy/postgres/copyframes_test.go
@@ -1,0 +1,198 @@
+//go:build linux
+
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgproto3"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+	"github.com/agentsh/agentsh/internal/db/proxy/postgres/statemachine"
+)
+
+func copyLoopFixture(t *testing.T) (*proxyConn, *pgproto3.Frontend, *pgproto3.Backend) {
+	t.Helper()
+	pc, clientFE, _ := newSimpleQueryFixture(t)
+	upClient, upProxy := net.Pipe()
+	t.Cleanup(func() { _ = upClient.Close(); _ = upProxy.Close() })
+	pc.state.upstream = upProxy
+	pc.state.upstreamFE = pgproto3.NewFrontend(upProxy, upProxy)
+	return pc, clientFE, pgproto3.NewBackend(upClient, upClient)
+}
+
+func TestCopyLoop_BulkLoad_PassesBytesAndExitsOnCopyDone(t *testing.T) {
+	pc, clientFE, upstreamBE := copyLoopFixture(t)
+	pc.state.smState = &statemachine.ConnState{LastUpstreamRFQ: 'I', Phase: statemachine.PhaseInCopyIn}
+
+	clientDrain := make(chan struct{})
+	go func() {
+		defer close(clientDrain)
+		for i := 0; i < 2; i++ {
+			if _, err := clientFE.Receive(); err != nil {
+				return
+			}
+		}
+	}()
+
+	gotUpstream := make(chan []byte, 1)
+	go func() {
+		var got []byte
+		for {
+			msg, err := upstreamBE.Receive()
+			if err != nil {
+				return
+			}
+			switch m := msg.(type) {
+			case *pgproto3.CopyData:
+				got = append(got, m.Data...)
+			case *pgproto3.CopyDone:
+				upstreamBE.Send(&pgproto3.CommandComplete{CommandTag: []byte("COPY 2")})
+				upstreamBE.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+				_ = upstreamBE.Flush()
+				gotUpstream <- got
+				return
+			}
+		}
+	}()
+
+	go func() {
+		clientFE.Send(&pgproto3.CopyData{Data: []byte("row1\n")})
+		clientFE.Send(&pgproto3.CopyData{Data: []byte("row2\n")})
+		clientFE.Send(&pgproto3.CopyDone{})
+		_ = clientFE.Flush()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err := pc.runCopyLoop(ctx, effects.BulkOpIn)
+	if err != nil {
+		t.Fatalf("runCopyLoop: %v", err)
+	}
+	if got := <-gotUpstream; !bytes.Equal(got, []byte("row1\nrow2\n")) {
+		t.Fatalf("upstream CopyData = %q", got)
+	}
+	if result.BytesIn != int64(len("row1\nrow2\n")) {
+		t.Fatalf("BytesIn=%d want %d", result.BytesIn, len("row1\nrow2\n"))
+	}
+	if result.AffectedByStmt[0] == nil || *result.AffectedByStmt[0] != 2 {
+		t.Fatalf("AffectedByStmt=%v want COPY 2", result.AffectedByStmt)
+	}
+	if pc.state.smState.Phase != statemachine.PhaseIdle {
+		t.Fatalf("Phase=%v want idle", pc.state.smState.Phase)
+	}
+	<-clientDrain
+}
+
+func TestCopyLoop_BulkExport_PassesUpstreamBytes(t *testing.T) {
+	pc, clientFE, upstreamBE := copyLoopFixture(t)
+	pc.state.smState = &statemachine.ConnState{LastUpstreamRFQ: 'I', Phase: statemachine.PhaseInCopyOut}
+
+	gotClient := make(chan []byte, 1)
+	go func() {
+		var got []byte
+		for i := 0; i < 4; i++ {
+			msg, err := clientFE.Receive()
+			if err != nil {
+				return
+			}
+			if cd, ok := msg.(*pgproto3.CopyData); ok {
+				got = append(got, cd.Data...)
+			}
+		}
+		gotClient <- got
+	}()
+
+	go func() {
+		upstreamBE.Send(&pgproto3.CopyData{Data: []byte("hello\n")})
+		upstreamBE.Send(&pgproto3.CopyData{Data: []byte("world\n")})
+		upstreamBE.Send(&pgproto3.CopyDone{})
+		upstreamBE.Send(&pgproto3.CommandComplete{CommandTag: []byte("COPY 2")})
+		upstreamBE.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+		_ = upstreamBE.Flush()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err := pc.runCopyLoop(ctx, effects.BulkOpOut)
+	if err != nil {
+		t.Fatalf("runCopyLoop: %v", err)
+	}
+	if got := <-gotClient; !bytes.Equal(got, []byte("hello\nworld\n")) {
+		t.Fatalf("client CopyData = %q", got)
+	}
+	if result.BytesOut <= int64(len("hello\nworld\n")) {
+		t.Fatalf("BytesOut=%d want > copied data length", result.BytesOut)
+	}
+}
+
+func TestCopyLoop_BulkLoad_ClientTerminateSendsCopyFail(t *testing.T) {
+	pc, clientFE, upstreamBE := copyLoopFixture(t)
+	pc.state.smState = &statemachine.ConnState{LastUpstreamRFQ: 'I', Phase: statemachine.PhaseInCopyIn}
+
+	sawCopyFail := make(chan bool, 1)
+	go func() {
+		for {
+			msg, err := upstreamBE.Receive()
+			if err != nil {
+				return
+			}
+			if _, ok := msg.(*pgproto3.CopyFail); ok {
+				sawCopyFail <- true
+				return
+			}
+		}
+	}()
+
+	go func() {
+		clientFE.Send(&pgproto3.CopyData{Data: []byte("row1\n")})
+		clientFE.Send(&pgproto3.Terminate{})
+		_ = clientFE.Flush()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := pc.runCopyLoop(ctx, effects.BulkOpIn); err == nil {
+		t.Fatal("runCopyLoop should return an error on client Terminate")
+	}
+	if !<-sawCopyFail {
+		t.Fatal("expected CopyFail upstream")
+	}
+}
+
+func TestCopyLoop_BulkExport_MidCopyErrorResponse_ExitsCleanly(t *testing.T) {
+	pc, clientFE, upstreamBE := copyLoopFixture(t)
+	pc.state.smState = &statemachine.ConnState{LastUpstreamRFQ: 'I', Phase: statemachine.PhaseInCopyOut}
+
+	go func() {
+		for i := 0; i < 3; i++ {
+			if _, err := clientFE.Receive(); err != nil {
+				return
+			}
+		}
+	}()
+
+	go func() {
+		upstreamBE.Send(&pgproto3.CopyData{Data: []byte("partial")})
+		upstreamBE.Send(&pgproto3.ErrorResponse{Severity: "ERROR", Code: "57014", Message: "canceled"})
+		upstreamBE.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+		_ = upstreamBE.Flush()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	result, err := pc.runCopyLoop(ctx, effects.BulkOpOut)
+	if err != nil {
+		t.Fatalf("runCopyLoop: %v", err)
+	}
+	if result.ErrorCode != "57014" {
+		t.Fatalf("ErrorCode=%q want 57014", result.ErrorCode)
+	}
+	if pc.state.smState.Phase != statemachine.PhaseIdle {
+		t.Fatalf("Phase=%v want idle", pc.state.smState.Phase)
+	}
+}

--- a/internal/db/proxy/postgres/extquery.go
+++ b/internal/db/proxy/postgres/extquery.go
@@ -96,6 +96,10 @@ func (pc *proxyConn) executeActions(ctx context.Context, origFrame pgproto3.Fron
 			return errInTxTerminate
 		case *statemachine.ActionTrackUpstreamRFQ:
 			pc.state.smState.LastUpstreamRFQ = a.Status
+		case *statemachine.ActionApproverWait:
+			if err := pc.runApprovalWait(ctx, origFrame, *a); err != nil {
+				return err
+			}
 		default:
 			return fmt.Errorf("postgres: unknown statemachine action %T", a)
 		}

--- a/internal/db/proxy/postgres/extquery_spine_test.go
+++ b/internal/db/proxy/postgres/extquery_spine_test.go
@@ -12,6 +12,11 @@ import (
 	"github.com/jackc/pgx/v5/pgproto3"
 )
 
+type clientBackendObservation struct {
+	errorCode string
+	rfqStatus byte
+}
+
 // extqueryFixture wires a *proxyConn with both client and upstream net.Pipes.
 // Returns:
 //   - pc: the proxyConn under test
@@ -37,15 +42,6 @@ func extqueryFixture(t *testing.T, policyYAML string) (
 	upBackend = pgproto3.NewBackend(up1, up1)
 	upRaw = up1
 
-	// Drain client side in background so backend writes don't block.
-	go func() {
-		buf := make([]byte, 4096)
-		for {
-			if _, err := pc.conn.Read(buf); err != nil {
-				return
-			}
-		}
-	}()
 	return pc, clientFE, upBackend, upRaw
 }
 
@@ -74,10 +70,8 @@ database_rules:
 // Setup notes:
 //   newSimpleQueryFixture's clientFE is wired to the proxy-facing side of
 //   the net.Pipe, so any Frontend.Send from the test side writes bytes into
-//   the proxy's backend.Receive. Conversely we drain pc.conn in a goroutine
-//   so the proxy's ErrorResponse / RFQ writes don't deadlock; reading those
-//   back here is asynchronous and not strictly required for these tests
-//   because we assert on side effects (upstream frames, smState, cache).
+//   the proxy's backend.Receive. Tests that expect proxy responses must read
+//   them from clientFE; there must be no competing reader on pc.conn.
 
 func TestExtquery_Spine_Parse_AllowForwardsAndCaches(t *testing.T) {
 	pc, clientFE, upBackend, _ := extqueryFixture(t, extqueryDenyPolicyYAML())
@@ -136,7 +130,7 @@ func TestExtquery_Spine_Parse_DenyOutOfTx_SynthsError(t *testing.T) {
 	pc, clientFE, upBackend, _ := extqueryFixture(t, extqueryDenyPolicyYAML())
 
 	// Drain client side specifically with a Frontend so we can inspect frames.
-	cliRead := make(chan pgproto3.BackendMessage, 4)
+	cliRead := make(chan clientBackendObservation, 4)
 	clientRead := pgproto3.NewFrontend(pc.conn, pc.conn)
 	_ = clientRead
 
@@ -149,7 +143,14 @@ func TestExtquery_Spine_Parse_DenyOutOfTx_SynthsError(t *testing.T) {
 			if err != nil {
 				return
 			}
-			cliRead <- m
+			var obs clientBackendObservation
+			if er, ok := m.(*pgproto3.ErrorResponse); ok {
+				obs.errorCode = er.Code
+			}
+			if rfq, ok := m.(*pgproto3.ReadyForQuery); ok {
+				obs.rfqStatus = rfq.TxStatus
+			}
+			cliRead <- obs
 		}
 	}()
 
@@ -166,14 +167,14 @@ func TestExtquery_Spine_Parse_DenyOutOfTx_SynthsError(t *testing.T) {
 	var sawErr, sawRFQ bool
 	for time.Now().Before(deadline) {
 		select {
-		case m := <-cliRead:
-			if er, ok := m.(*pgproto3.ErrorResponse); ok {
-				if er.Code != "42501" {
-					t.Errorf("Code = %q want 42501", er.Code)
+		case obs := <-cliRead:
+			if obs.errorCode != "" {
+				if obs.errorCode != "42501" {
+					t.Errorf("Code = %q want 42501", obs.errorCode)
 				}
 				sawErr = true
 			}
-			if _, ok := m.(*pgproto3.ReadyForQuery); ok {
+			if obs.rfqStatus != 0 {
 				sawRFQ = true
 			}
 		case <-time.After(100 * time.Millisecond):
@@ -224,14 +225,21 @@ func TestExtquery_Spine_Query_InTx_RollbackThenContinue(t *testing.T) {
 	pc, clientFE, upBackend, upRaw := extqueryFixture(t, extqueryDenyPolicyYAML())
 	pc.state.smState.LastUpstreamRFQ = 'T' // simulate prior BEGIN
 
-	cliRead := make(chan pgproto3.BackendMessage, 8)
+	cliRead := make(chan clientBackendObservation, 8)
 	go func() {
 		for {
 			m, err := clientFE.Receive()
 			if err != nil {
 				return
 			}
-			cliRead <- m
+			var obs clientBackendObservation
+			if er, ok := m.(*pgproto3.ErrorResponse); ok {
+				obs.errorCode = er.Code
+			}
+			if rfq, ok := m.(*pgproto3.ReadyForQuery); ok {
+				obs.rfqStatus = rfq.TxStatus
+			}
+			cliRead <- obs
 		}
 	}()
 
@@ -265,16 +273,12 @@ func TestExtquery_Spine_Query_InTx_RollbackThenContinue(t *testing.T) {
 	var sawErr, sawRFQ bool
 	for time.Now().Before(deadline) && (!sawErr || !sawRFQ) {
 		select {
-		case m := <-cliRead:
-			switch v := m.(type) {
-			case *pgproto3.ErrorResponse:
-				if v.Code == "42501" {
-					sawErr = true
-				}
-			case *pgproto3.ReadyForQuery:
-				if v.TxStatus == 'I' {
-					sawRFQ = true
-				}
+		case obs := <-cliRead:
+			if obs.errorCode == "42501" {
+				sawErr = true
+			}
+			if obs.rfqStatus == 'I' {
+				sawRFQ = true
 			}
 		case <-time.After(100 * time.Millisecond):
 		}

--- a/internal/db/proxy/postgres/funccall.go
+++ b/internal/db/proxy/postgres/funccall.go
@@ -42,7 +42,33 @@ func (pc *proxyConn) handleFunctionCall(ctx context.Context, msg *pgproto3.Funct
 	}
 	d := policy.Evaluate(cs, rs, policy.ServiceID(pc.svc.Name))
 	if d.Verb == policy.VerbApprove {
-		d = synthApproveAsDeny(d)
+		rule := lookupStatementRuleByName(rs, d.RuleName)
+		out := pc.waitForApproval(ctx, statemachine.ActionApproverWait{
+			Timeout: approvalTimeout(d, rule),
+			Stmt:    cs,
+			Rule:    rule,
+		})
+		if out.err != nil {
+			denyDecision := d
+			denyDecision.Verb = policy.VerbDeny
+			denyDecision.Reason = approvalReason(out.denyAction)
+			pc.emitFunctionCallEvent(ctx, cs, denyDecision, out.denyAction, upstreamResult{})
+			return out.err
+		}
+		if out.approved {
+			pc.state.upstreamFE.Send(msg)
+			if err := pc.state.upstreamFE.Flush(); err != nil {
+				return err
+			}
+			result, ferr := pc.forwardUpstreamUntilRFQ(ctx, timeNow(), 0)
+			pc.emitFunctionCallEvent(ctx, cs, d, "none", result)
+			return ferr
+		}
+		d.Verb = policy.VerbDeny
+		d.Reason = approvalReason(out.denyAction)
+		pc.emitFunctionCallEvent(ctx, cs, d, out.denyAction, upstreamResult{})
+		actions := statemachine.DenyRoute(*pc.state.smState, rule, renderDenyMessage(d), sqlstateInsufficientPrivilege)
+		return pc.executeActions(ctx, msg, actions)
 	}
 
 	if d.Verb == policy.VerbDeny {
@@ -89,7 +115,7 @@ func (pc *proxyConn) emitFunctionCallEvent(
 		SQL:        "",
 		Tier:       pc.state.redactionTier,
 		Conn:       *pc.state,
-		BytesIn:    0,  // FunctionCall frames carry no SQL body to measure
+		BytesIn:    0, // FunctionCall frames carry no SQL body to measure
 		BytesOut:   r.BytesOut,
 		LatencyMs:  r.LatencyMs,
 		DenyAction: denyAction,

--- a/internal/db/proxy/postgres/server.go
+++ b/internal/db/proxy/postgres/server.go
@@ -25,8 +25,8 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/agentsh/agentsh/internal/db/events"
 	classify_pg "github.com/agentsh/agentsh/internal/db/classify/postgres"
+	"github.com/agentsh/agentsh/internal/db/events"
 	"github.com/agentsh/agentsh/internal/db/policy"
 	"github.com/agentsh/agentsh/internal/db/service"
 	"github.com/agentsh/agentsh/internal/db/tlsleaf"
@@ -66,6 +66,7 @@ type Config struct {
 	Sink           events.Sink
 	Logger         *slog.Logger
 	Policy         *policy.RuleSet // current rule set; nil means "no rules" (implicit deny). Hot-swappable in a later plan.
+	Approver       policy.Approver // defaults to policy.NopApprover{} when nil.
 
 	// MaxQueryBytes caps the 'Q' frame body. Default 1 MiB when zero.
 	// Statements above the cap get a synthetic ErrorResponse(54000) + close.
@@ -120,6 +121,9 @@ type Server struct {
 func New(cfg Config) (*Server, error) {
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
+	}
+	if cfg.Approver == nil {
+		cfg.Approver = policy.NopApprover{}
 	}
 	if cfg.StateDir == "" {
 		return nil, errors.New("postgres.New: StateDir is required")

--- a/internal/db/proxy/postgres/simplequery.go
+++ b/internal/db/proxy/postgres/simplequery.go
@@ -168,6 +168,22 @@ func (pc *proxyConn) handleQuery(ctx context.Context, q *pgproto3.Query) error {
 			return err
 		}
 		result, ferr := pc.forwardUpstreamUntilRFQ(ctx, sentAt, len(q.String))
+		if ferr == nil && (result.YieldedToCopyIn || result.YieldedToCopyOut) {
+			direction := effects.BulkOpIn
+			if result.YieldedToCopyOut {
+				direction = effects.BulkOpOut
+			}
+			copyResult, cerr := pc.runCopyLoop(ctx, direction)
+			result.BytesIn += copyResult.BytesIn
+			result.BytesOut += copyResult.BytesOut
+			result.RowsByStmt = append(result.RowsByStmt, copyResult.RowsByStmt...)
+			result.AffectedByStmt = append(result.AffectedByStmt, copyResult.AffectedByStmt...)
+			result.LatencyMs = copyResult.LatencyMs
+			if copyResult.ErrorCode != "" {
+				result.ErrorCode = copyResult.ErrorCode
+			}
+			ferr = cerr
+		}
 		pc.emitAllowEvents(ctx, stmts, decisions, q.String, batchSHA, result)
 		return ferr
 	}

--- a/internal/db/proxy/postgres/simplequery.go
+++ b/internal/db/proxy/postgres/simplequery.go
@@ -122,10 +122,13 @@ func (pc *proxyConn) handleQuery(ctx context.Context, q *pgproto3.Query) error {
 
 	decisions := make([]policy.Decision, len(stmts))
 	anyDeny := false
+	approveIndex := -1
 	for i, s := range stmts {
 		decisions[i] = policy.Evaluate(s, rs, policy.ServiceID(pc.svc.Name))
 		if decisions[i].Verb == policy.VerbApprove {
-			decisions[i] = synthApproveAsDeny(decisions[i])
+			if approveIndex == -1 {
+				approveIndex = i
+			}
 		}
 		if decisions[i].Verb == policy.VerbDeny {
 			anyDeny = true
@@ -153,6 +156,10 @@ func (pc *proxyConn) handleQuery(ctx context.Context, q *pgproto3.Query) error {
 	}
 
 	batchSHA := sha256HexBatch(q.String)
+
+	if !anyDeny && approveIndex >= 0 {
+		return pc.runSimpleQueryApproval(ctx, q, stmts, decisions, approveIndex, batchSHA)
+	}
 
 	if !anyDeny {
 		sentAt := timeNow()
@@ -236,8 +243,8 @@ func (pc *proxyConn) emitDenyEvents(
 		deniedBySibling := decisions[i].Verb != policy.VerbDeny
 		ev := buildStatementEvent(buildArgs{
 			Stmt: s, StmtIndex: i, BatchTotal: len(stmts),
-			Decision:          decisions[i],
-			SQL:               sql, Tier: pc.state.redactionTier,
+			Decision: decisions[i],
+			SQL:      sql, Tier: pc.state.redactionTier,
 			Conn:              *pc.state,
 			BytesIn:           int64(len(sql)),
 			DenyAction:        denyAction,
@@ -249,17 +256,6 @@ func (pc *proxyConn) emitDenyEvents(
 			pc.logger.Warn("emit statement event failed", "err", err)
 		}
 	}
-}
-
-// synthApproveAsDeny rewrites a Decision with Verb=approve into Verb=deny
-// with the APPROVE_NOT_YET_SUPPORTED stub marker. Per spec §14.5, approve
-// runtime lands in Plan 05; until then we surface a loud failure mode.
-func synthApproveAsDeny(d policy.Decision) policy.Decision {
-	d.Verb = policy.VerbDeny
-	if d.Reason == "" {
-		d.Reason = "APPROVE_NOT_YET_SUPPORTED"
-	}
-	return d
 }
 
 func sha256HexBatch(sql string) string {
@@ -300,17 +296,17 @@ func (pc *proxyConn) emitAllowEvents(
 		ev := buildStatementEvent(buildArgs{
 			Stmt: s, StmtIndex: i, BatchTotal: len(stmts),
 			Decision: decisions[i],
-			SQL: sql, Tier: pc.state.redactionTier,
-			Conn: *pc.state,
-			BytesIn: int64(len(sql)),
-			BytesOut: r.BytesOut,
-			LatencyMs: r.LatencyMs,
-			RowsReturned: rows,
-			RowsAffected: aff,
+			SQL:      sql, Tier: pc.state.redactionTier,
+			Conn:            *pc.state,
+			BytesIn:         int64(len(sql)),
+			BytesOut:        r.BytesOut,
+			LatencyMs:       r.LatencyMs,
+			RowsReturned:    rows,
+			RowsAffected:    aff,
 			UpstreamErrCode: errCode,
-			DenyAction: "none",
-			BatchSHA: batchSHA,
-			Parser: parser,
+			DenyAction:      "none",
+			BatchSHA:        batchSHA,
+			Parser:          parser,
 		})
 		if err := pc.srv.cfg.Sink.EmitStatement(ctx, ev); err != nil {
 			pc.logger.Warn("emit statement event failed", "err", err)

--- a/internal/db/proxy/postgres/simplequery_test.go
+++ b/internal/db/proxy/postgres/simplequery_test.go
@@ -313,6 +313,39 @@ func TestHandleQuery_AllowPath_MultiStmt(t *testing.T) {
 	_ = loopErr
 }
 
+func TestHandleQuery_CopyToStdout_EmitsBytesOut(t *testing.T) {
+	pc, clientFE, sink, script := allowPathFixture(t)
+	pc.state.smState.LastUpstreamRFQ = 'I'
+	pc.srv.SetPolicy(allowAllRuleSet(t))
+
+	script([]pgproto3.BackendMessage{
+		&pgproto3.CopyOutResponse{},
+		&pgproto3.CopyData{Data: []byte("alice\n")},
+		&pgproto3.CopyData{Data: []byte("bob\n")},
+		&pgproto3.CopyDone{},
+		&pgproto3.CommandComplete{CommandTag: []byte("COPY 2")},
+		&pgproto3.ReadyForQuery{TxStatus: 'I'},
+	})
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	mustSendFromClient(t, clientFE, &pgproto3.Query{String: "COPY users TO STDOUT"})
+	frames := drainNFrames(t, clientFE, 6)
+	if _, ok := frames[0].(*pgproto3.CopyOutResponse); !ok {
+		t.Fatalf("frames[0] = %T want CopyOutResponse", frames[0])
+	}
+	if _, ok := frames[5].(*pgproto3.ReadyForQuery); !ok {
+		t.Fatalf("frames[5] = %T want ReadyForQuery", frames[5])
+	}
+
+	evs := waitStatementEvents(t, sink, 1)
+	if evs[0].Result.BytesOut < int64(len("alice\nbob\n")) {
+		t.Fatalf("BytesOut=%d want at least copied data bytes", evs[0].Result.BytesOut)
+	}
+	_ = loopErr
+}
+
 // denyDeletesRuleSet allows all read/session/ddl operations on service "test"
 // but denies writes/deletes. Tuned so BEGIN/COMMIT are allowed (covered by
 // `["*"]` allow rule) while DELETE triggers a deny.

--- a/internal/db/proxy/postgres/spine_test.go
+++ b/internal/db/proxy/postgres/spine_test.go
@@ -831,7 +831,7 @@ func TestSpine_Plan04c_SimpleQuery_DenyPreTx(t *testing.T) {
 	// With deny pre-forward, the proxy must NOT forward the DELETE Q upstream,
 	// so the read should time out. We expose the observed state via closure.
 	var (
-		mu              sync.Mutex
+		mu               sync.Mutex
 		upstreamSawQuery bool
 	)
 	script := func(t *testing.T, be *pgproto3.Backend, conn net.Conn) error {
@@ -1143,6 +1143,172 @@ func TestSpine_SQLPrepare_DenyOverPGX(t *testing.T) {
 	}
 	if !gotDeny {
 		t.Errorf("expected deny event for PREPARE DELETE; got %+v", evs)
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Plan 05c — COPY bulk_export + approval timeout spine tests
+// ----------------------------------------------------------------------------
+
+func copyToStdoutScript(t *testing.T, be *pgproto3.Backend, conn net.Conn) error {
+	t.Helper()
+	if _, err := be.ReceiveStartupMessage(); err != nil {
+		return fmt.Errorf("receive startup: %w", err)
+	}
+	be.Send(&pgproto3.AuthenticationOk{})
+	be.Send(&pgproto3.ParameterStatus{Name: "standard_conforming_strings", Value: "on"})
+	be.Send(&pgproto3.ParameterStatus{Name: "client_encoding", Value: "UTF8"})
+	be.Send(&pgproto3.ParameterStatus{Name: "server_version", Value: "16.0"})
+	be.Send(&pgproto3.BackendKeyData{ProcessID: 42, SecretKey: append([]byte(nil), wantSecret...)})
+	be.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+	if err := be.Flush(); err != nil {
+		return fmt.Errorf("flush handshake: %w", err)
+	}
+	msg, err := be.Receive()
+	if err != nil {
+		return fmt.Errorf("receive COPY query: %w", err)
+	}
+	q, ok := msg.(*pgproto3.Query)
+	if !ok || !strings.Contains(strings.ToUpper(q.String), "COPY USERS TO STDOUT") {
+		return fmt.Errorf("expected COPY query, got %T %v", msg, msg)
+	}
+	be.Send(&pgproto3.CopyOutResponse{})
+	be.Send(&pgproto3.CopyData{Data: []byte("alice\n")})
+	be.Send(&pgproto3.CopyData{Data: []byte("bob\n")})
+	be.Send(&pgproto3.CopyDone{})
+	be.Send(&pgproto3.CommandComplete{CommandTag: []byte("COPY 2")})
+	be.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+	if err := be.Flush(); err != nil {
+		return fmt.Errorf("flush COPY response: %w", err)
+	}
+	buf := make([]byte, 256)
+	for {
+		_ = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+		if _, err := conn.Read(buf); err != nil {
+			return nil
+		}
+	}
+}
+
+func TestSpine_CopyToStdout_BytesOutCount(t *testing.T) {
+	up := newFakeUpstream(t, withFakeUpstreamScript(copyToStdoutScript))
+	upAddr := up.Address()
+
+	h := startSpineHarness(t, upstreamWithLocalhostHost(upAddr), "terminate_plaintext_upstream", nil, "")
+	h.srv.SetPolicy(loadRuleSet(t, pgxSpinePolicyYAML(upAddr, false)))
+
+	stop := runServer(t, h.srv)
+	defer stop()
+
+	sockDir := renameSocketForPgx(t, h.sock, 5444)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := pgx.Connect(ctx, pgxConnString(sockDir, 5444))
+	if err != nil {
+		t.Fatalf("pgx.Connect: %v", err)
+	}
+	defer conn.Close(context.Background())
+
+	var out bytes.Buffer
+	tag, err := conn.PgConn().CopyTo(ctx, &out, "COPY users TO STDOUT")
+	if err != nil {
+		t.Fatalf("CopyTo: %v", err)
+	}
+	if tag.String() != "COPY 2" {
+		t.Fatalf("CommandTag = %q want COPY 2", tag.String())
+	}
+	if out.String() != "alice\nbob\n" {
+		t.Fatalf("copy output = %q", out.String())
+	}
+
+	evs := drainStatements(h.sink, 1, 2*time.Second)
+	if len(evs) == 0 || evs[0].Result.BytesOut < int64(len("alice\nbob\n")) {
+		t.Fatalf("expected COPY event with BytesOut; got %+v", evs)
+	}
+}
+
+func approvalTimeoutPolicyYAML(upstream string) string {
+	return `version: 1
+name: approval-timeout-spine
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: ` + upstream + `
+    tls_mode: terminate_plaintext_upstream
+    trusted_network: true
+database_connection_rules:
+  - name: allow-everyone
+    db_service: appdb
+    decision: allow
+database_rules:
+  - name: review-delete
+    db_service: appdb
+    operations: [DELETE]
+    decision: approve
+    timeout: 20ms
+`
+}
+
+func approvalTimeoutScript(t *testing.T, be *pgproto3.Backend, conn net.Conn) error {
+	t.Helper()
+	if _, err := be.ReceiveStartupMessage(); err != nil {
+		return fmt.Errorf("receive startup: %w", err)
+	}
+	be.Send(&pgproto3.AuthenticationOk{})
+	be.Send(&pgproto3.ParameterStatus{Name: "standard_conforming_strings", Value: "on"})
+	be.Send(&pgproto3.ParameterStatus{Name: "client_encoding", Value: "UTF8"})
+	be.Send(&pgproto3.ParameterStatus{Name: "server_version", Value: "16.0"})
+	be.Send(&pgproto3.BackendKeyData{ProcessID: 42, SecretKey: append([]byte(nil), wantSecret...)})
+	be.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+	if err := be.Flush(); err != nil {
+		return fmt.Errorf("flush handshake: %w", err)
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
+	if msg, err := be.Receive(); err == nil {
+		if _, ok := msg.(*pgproto3.Query); ok {
+			return fmt.Errorf("approval timeout should not forward query upstream; got %T", msg)
+		}
+	}
+	return nil
+}
+
+func TestSpine_ApprovalTimeout_DenyAfterTimeout(t *testing.T) {
+	up := newFakeUpstream(t, withFakeUpstreamScript(approvalTimeoutScript))
+	upAddr := up.Address()
+
+	h := startSpineHarness(t, upstreamWithLocalhostHost(upAddr), "terminate_plaintext_upstream", nil, "")
+	h.srv.SetPolicy(loadRuleSet(t, approvalTimeoutPolicyYAML(upAddr)))
+
+	stop := runServer(t, h.srv)
+	defer stop()
+
+	sockDir := renameSocketForPgx(t, h.sock, 5445)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := pgx.Connect(ctx, pgxConnString(sockDir, 5445))
+	if err != nil {
+		t.Fatalf("pgx.Connect: %v", err)
+	}
+	defer conn.Close(context.Background())
+
+	start := time.Now()
+	_, err = conn.Exec(ctx, "DELETE FROM users")
+	if err == nil {
+		t.Fatal("expected approval timeout deny, got nil")
+	}
+	if code := pgxErrorCode(err); code != "42501" {
+		t.Fatalf("SQLSTATE = %q want 42501 (err=%v)", code, err)
+	}
+	if elapsed := time.Since(start); elapsed < 15*time.Millisecond {
+		t.Fatalf("approval returned too quickly: %v", elapsed)
+	}
+
+	evs := drainStatements(h.sink, 1, 2*time.Second)
+	if len(evs) == 0 || evs[0].TxContext.DenyAction != "approval_timeout" {
+		t.Fatalf("expected approval_timeout event; got %+v", evs)
 	}
 }
 

--- a/internal/db/proxy/postgres/statemachine/action.go
+++ b/internal/db/proxy/postgres/statemachine/action.go
@@ -2,6 +2,13 @@
 
 package statemachine
 
+import (
+	"time"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+	"github.com/agentsh/agentsh/internal/db/policy"
+)
+
 // Action is a single thing the dispatcher must execute after a Transition.
 // Concrete types are sealed via the private isAction() method so the dispatcher
 // can rely on a closed sum type. Cache mutations are NOT Actions — Transition
@@ -66,6 +73,14 @@ type ActionTrackUpstreamRFQ struct {
 	Status byte
 }
 
+// ActionApproverWait instructs the dispatcher to invoke the configured
+// Approver and wait up to Timeout before either forwarding or routing a deny.
+type ActionApproverWait struct {
+	Timeout time.Duration
+	Stmt    effects.ClassifiedStatement
+	Rule    policy.StatementRule
+}
+
 func (*ActionForward) isAction()            {}
 func (*ActionSynthError) isAction()         {}
 func (*ActionSynthReadyForQuery) isAction() {}
@@ -76,3 +91,4 @@ func (*ActionInjectRollback) isAction()     {}
 func (*ActionDrainUntilRFQ) isAction()      {}
 func (*ActionClose) isAction()              {}
 func (*ActionTrackUpstreamRFQ) isAction()   {}
+func (*ActionApproverWait) isAction()       {}

--- a/internal/db/proxy/postgres/statemachine/action_test.go
+++ b/internal/db/proxy/postgres/statemachine/action_test.go
@@ -1,0 +1,31 @@
+//go:build linux
+
+package statemachine
+
+import (
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+	"github.com/agentsh/agentsh/internal/db/policy"
+)
+
+var _ Action = (*ActionApproverWait)(nil)
+
+func TestActionApproverWait_Fields(t *testing.T) {
+	rule := policy.StatementRule{Name: "review-deletes", Decision: "approve"}
+	a := &ActionApproverWait{
+		Timeout: 60 * time.Second,
+		Stmt:    effects.ClassifiedStatement{RawVerb: "DELETE"},
+		Rule:    rule,
+	}
+	if a.Timeout != 60*time.Second {
+		t.Errorf("Timeout=%v", a.Timeout)
+	}
+	if a.Stmt.RawVerb != "DELETE" {
+		t.Errorf("Stmt.RawVerb=%q", a.Stmt.RawVerb)
+	}
+	if a.Rule.Name != "review-deletes" {
+		t.Errorf("Rule.Name=%q", a.Rule.Name)
+	}
+}

--- a/internal/db/proxy/postgres/statemachine/transition.go
+++ b/internal/db/proxy/postgres/statemachine/transition.go
@@ -3,6 +3,8 @@
 package statemachine
 
 import (
+	"time"
+
 	classify_pg "github.com/agentsh/agentsh/internal/db/classify/postgres"
 	"github.com/agentsh/agentsh/internal/db/effects"
 	"github.com/agentsh/agentsh/internal/db/policy"
@@ -118,11 +120,8 @@ func handleParse(
 	for _, cs := range stmts {
 		d := policy.Evaluate(cs, rules, svc)
 		if d.Verb == policy.VerbApprove {
-			// Plan 05a still stubs approve as deny + APPROVE_NOT_YET_SUPPORTED.
-			d.Verb = policy.VerbDeny
-			if d.Reason == "" {
-				d.Reason = "APPROVE_NOT_YET_SUPPORTED"
-			}
+			rule := lookupStatementRule(rules, d.RuleName)
+			return s, []Action{newApproverWaitAction(d, cs, rule)}
 		}
 		if d.Verb == policy.VerbDeny {
 			anyDeny = true
@@ -250,10 +249,8 @@ func handleQuery(
 	for _, cs := range stmts {
 		d := policy.Evaluate(cs, rules, svc)
 		if d.Verb == policy.VerbApprove {
-			d.Verb = policy.VerbDeny
-			if d.Reason == "" {
-				d.Reason = "APPROVE_NOT_YET_SUPPORTED"
-			}
+			rule := lookupStatementRule(rules, d.RuleName)
+			return s, []Action{newApproverWaitAction(d, cs, rule)}
 		}
 		if d.Verb == policy.VerbDeny {
 			anyDeny = true
@@ -269,6 +266,21 @@ func handleQuery(
 	msg := renderDenyMessage(denyDecision)
 	actions := DenyRoute(s, denyRule, msg, sqlstateForDecision(denyDecision))
 	return s, actions
+}
+
+func newApproverWaitAction(d policy.Decision, cs effects.ClassifiedStatement, rule policy.StatementRule) *ActionApproverWait {
+	timeout := rule.Timeout
+	if timeout == 0 && d.Approval != nil {
+		timeout = d.Approval.Timeout
+	}
+	if timeout == 0 {
+		timeout = 60 * time.Second
+	}
+	return &ActionApproverWait{
+		Timeout: timeout,
+		Stmt:    cs,
+		Rule:    rule,
+	}
 }
 
 // lookupStatementRule finds the named rule in rs.AllStatementRules().

--- a/internal/db/proxy/postgres/statemachine/transition_test.go
+++ b/internal/db/proxy/postgres/statemachine/transition_test.go
@@ -5,6 +5,7 @@ package statemachine
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -143,6 +144,48 @@ func TestTransition_Parse_Deny_OutOfTx(t *testing.T) {
 	}
 	if _, ok := cache.Get("del"); ok {
 		t.Error("denied Parse must not populate cache")
+	}
+}
+
+func TestTransition_Parse_Approve_EmitsApproverWait(t *testing.T) {
+	yaml := `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: "127.0.0.1:5432", tls_mode: terminate_reissue}
+database_rules:
+  - name: allow-read
+    db_service: appdb
+    operations: [read]
+    decision: allow
+  - name: review-deletes
+    db_service: appdb
+    operations: [delete]
+    decision: approve
+    timeout: 60s
+`
+	cache := NewFakeCacheView()
+	next, acts := Transition(ConnState{LastUpstreamRFQ: 'I'}, &ParseFrame{Name: "s1", SQL: "DELETE FROM users"}, cache, mustDecode(t, yaml), "appdb")
+	if len(acts) != 1 {
+		t.Fatalf("len(acts)=%d want 1", len(acts))
+	}
+	aw, ok := acts[0].(*ActionApproverWait)
+	if !ok {
+		t.Fatalf("acts[0]=%T want *ActionApproverWait", acts[0])
+	}
+	if aw.Rule.Name != "review-deletes" {
+		t.Errorf("Rule.Name=%q", aw.Rule.Name)
+	}
+	if aw.Timeout != 60*time.Second {
+		t.Errorf("Timeout=%v want 60s", aw.Timeout)
+	}
+	if aw.Stmt.RawVerb != "DELETE" {
+		t.Errorf("Stmt.RawVerb=%q want DELETE", aw.Stmt.RawVerb)
+	}
+	if next.Absorbing {
+		t.Error("approve wait must not enter absorbing state before a decision")
+	}
+	if _, ok := cache.Get("s1"); ok {
+		t.Error("approve wait should not populate cache before approval")
 	}
 }
 

--- a/internal/db/proxy/postgres/stub_other.go
+++ b/internal/db/proxy/postgres/stub_other.go
@@ -39,6 +39,7 @@ type Config struct {
 	Sink           events.Sink
 	Logger         *slog.Logger
 	Policy         *policy.RuleSet // current rule set; nil means "no rules" (implicit deny). Hot-swappable in a later plan.
+	Approver       policy.Approver
 }
 
 type Server struct {

--- a/internal/db/proxy/postgres/tls_test.go
+++ b/internal/db/proxy/postgres/tls_test.go
@@ -162,6 +162,7 @@ database_connection_rules:
 		t.Errorf("first post-startup byte = %q, want 'R' (Authentication)", first[0])
 	}
 
+	_ = tlsConn.Close()
 	cancel()
 	select {
 	case err := <-srvDone:

--- a/internal/db/proxy/postgres/upstreamread.go
+++ b/internal/db/proxy/postgres/upstreamread.go
@@ -19,6 +19,7 @@ import (
 // frames arrived in. Statements that did not produce a CommandComplete frame
 // (mid-batch ErrorResponse aborted them) get null counters at event-build time.
 type upstreamResult struct {
+	BytesIn        int64
 	BytesOut       int64
 	RowsByStmt     []*int64
 	AffectedByStmt []*int64

--- a/internal/db/proxy/postgres/upstreamread.go
+++ b/internal/db/proxy/postgres/upstreamread.go
@@ -19,12 +19,14 @@ import (
 // frames arrived in. Statements that did not produce a CommandComplete frame
 // (mid-batch ErrorResponse aborted them) get null counters at event-build time.
 type upstreamResult struct {
-	BytesIn        int64
-	BytesOut       int64
-	RowsByStmt     []*int64
-	AffectedByStmt []*int64
-	LatencyMs      int64
-	ErrorCode      string
+	BytesIn          int64
+	BytesOut         int64
+	RowsByStmt       []*int64
+	AffectedByStmt   []*int64
+	LatencyMs        int64
+	ErrorCode        string
+	YieldedToCopyIn  bool
+	YieldedToCopyOut bool
 }
 
 // forwardUpstreamUntilRFQ reads upstream frames one at a time and forwards
@@ -75,6 +77,32 @@ func (pc *proxyConn) forwardUpstreamUntilRFQ(ctx context.Context, sentAt time.Ti
 			}
 			r.BytesOut += int64(estimatedFrameSize(m))
 			pc.backend.Send(m)
+
+		case *pgproto3.CopyInResponse:
+			r.BytesOut += int64(estimatedFrameSize(m))
+			r.YieldedToCopyIn = true
+			pc.backend.Send(m)
+			if err := pc.backend.Flush(); err != nil {
+				return r, fmt.Errorf("flush copy-in response: %w", err)
+			}
+			r.LatencyMs = time.Since(sentAt).Milliseconds()
+			if pc.state.smState != nil {
+				pc.state.smState.Phase = statemachine.PhaseInCopyIn
+			}
+			return r, nil
+
+		case *pgproto3.CopyOutResponse:
+			r.BytesOut += int64(estimatedFrameSize(m))
+			r.YieldedToCopyOut = true
+			pc.backend.Send(m)
+			if err := pc.backend.Flush(); err != nil {
+				return r, fmt.Errorf("flush copy-out response: %w", err)
+			}
+			r.LatencyMs = time.Since(sentAt).Milliseconds()
+			if pc.state.smState != nil {
+				pc.state.smState.Phase = statemachine.PhaseInCopyOut
+			}
+			return r, nil
 
 		case *pgproto3.ReadyForQuery:
 			if pc.state.smState != nil {

--- a/internal/db/proxy/postgres/upstreamread_test.go
+++ b/internal/db/proxy/postgres/upstreamread_test.go
@@ -191,6 +191,37 @@ func TestForwardUpstreamUntilRFQ_MidBatchError(t *testing.T) {
 	}
 }
 
+func TestForwardUpstreamUntilRFQ_YieldsOnCopyOutResponse(t *testing.T) {
+	pc, scriptUpstream, clientFE := upstreamReadFixture(t)
+	pc.state.smState.LastUpstreamRFQ = 'I'
+
+	clientGot := make(chan pgproto3.BackendMessage, 1)
+	go func() {
+		msg, err := clientFE.Receive()
+		if err != nil {
+			return
+		}
+		clientGot <- msg
+	}()
+
+	scriptUpstream([]pgproto3.BackendMessage{
+		&pgproto3.CopyOutResponse{},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	r, err := pc.forwardUpstreamUntilRFQ(ctx, time.Now(), 16)
+	if err != nil {
+		t.Fatalf("forwardUpstreamUntilRFQ: %v", err)
+	}
+	if !r.YieldedToCopyOut {
+		t.Fatal("YieldedToCopyOut = false, want true")
+	}
+	if _, ok := (<-clientGot).(*pgproto3.CopyOutResponse); !ok {
+		t.Fatal("client did not receive CopyOutResponse")
+	}
+}
+
 func TestForwardUpstream_TracksTxStartedAt(t *testing.T) {
 	pc, scriptUpstream, clientFE := upstreamReadFixture(t)
 	pc.state.smState = &statemachine.ConnState{LastUpstreamRFQ: 'I'}


### PR DESCRIPTION
## Summary
- Add COPY data-frame passthrough for PostgreSQL COPY IN/OUT with byte accounting and BulkOp classifier metadata.
- Add the policy Approver interface, NopApprover default, and approval-wait runtime for approve decisions.
- Remove the old APPROVE_NOT_YET_SUPPORTED warning/stub and add proxy/spine coverage for COPY and approval timeout behavior.

## Validation
- `go test ./... -count=1 -timeout 240s`
- `go test -race ./internal/db/... -count=1 -timeout 240s`
- `GOOS=windows go build ./...`
- 05c artifact check: copyframes.go, approvalwait.go, approver.go present; approve warning removed from runtime policy/proxy code.

## Notes
- PR is draft by default per the publish workflow.
- The branch also includes race-detector-safe fixes for existing proxy spine/TLS test harnesses.