### PR TITLE
[codex] db unavoidability bundle

### DIFF
--- a/docs/superpowers/plans/2026-05-13-db-plan-07a-unavoidability-bundle.md
+++ b/docs/superpowers/plans/2026-05-13-db-plan-07a-unavoidability-bundle.md
@@ -1,0 +1,1450 @@
+# DB Plan 07a Unavoidability Bundle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate a DB unavoidability policy bundle from declared `db_services`, including Unix-socket connect redirects, direct destination denies, local socket denies, bypass-tool command denies, and stable DB rule metadata.
+
+**Architecture:** Keep generation in `internal/db/service` because the bundle is derived from static DB service config, not observed session activity. Extend existing policy primitives narrowly: add an explicit Unix target for `connect_redirects` and top-level rule metadata so later Plan 07b event mapping can identify DB-generated denies without rule-name inference. Apply generated rules to the governed agent session policy; the DB proxy runs under a separate session whose policy does not include these deny rules.
+
+**Tech Stack:** Go, existing `internal/policy` rule model/engine, existing `internal/netmonitor` CONNECT proxy, existing `internal/db/service` config types, table-driven Go tests.
+
+---
+
+## File Structure
+
+**Created:**
+
+- `internal/db/service/bundle.go` - DB unavoidability bundle types and `GenerateBundle`.
+- `internal/db/service/bundle_test.go` - bundle generation, metadata, DNS behavior, and compile tests.
+
+**Modified:**
+
+- `internal/policy/model.go` - add `Policy.Metadata`, `RuleMetadata`, and `ConnectRedirectRule.RedirectToUnix`.
+- `internal/policy/engine.go` - return `RedirectToUnix` from `EvaluateConnectRedirect`.
+- `internal/policy/redirect_test.go` - validate Unix redirect target semantics and evaluator output.
+- `internal/netmonitor/proxy.go` - dial Unix sockets when a connect redirect resolves to `redirect_to_unix`.
+- `internal/netmonitor/proxy_test.go` - unit-test CONNECT dial target selection for Unix redirects.
+
+---
+
+### Task 1: Add Explicit Unix Targets To Connect Redirect Rules
+
+**Files:**
+- Modify: `internal/policy/model.go`
+- Modify: `internal/policy/engine.go`
+- Modify: `internal/policy/redirect_test.go`
+
+- [ ] **Step 1: Write failing validation and evaluator tests**
+
+Append these tests to `internal/policy/redirect_test.go` near the existing connect redirect tests:
+
+```go
+func TestConnectRedirectRuleValidation_UnixTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    ConnectRedirectRule
+		wantErr bool
+	}{
+		{
+			name: "valid unix target",
+			rule: ConnectRedirectRule{
+				Name:           "db-appdb-redirect",
+				Match:          "^db\\.internal:5432$",
+				RedirectToUnix: "/run/agentsh/sessions/sess-1/db/appdb.sock",
+			},
+		},
+		{
+			name: "both tcp and unix targets",
+			rule: ConnectRedirectRule{
+				Name:           "db-appdb-redirect",
+				Match:          "^db\\.internal:5432$",
+				RedirectTo:     "proxy.internal:15432",
+				RedirectToUnix: "/run/agentsh/sessions/sess-1/db/appdb.sock",
+			},
+			wantErr: true,
+		},
+		{
+			name: "no target",
+			rule: ConnectRedirectRule{
+				Name:  "db-appdb-redirect",
+				Match: "^db\\.internal:5432$",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Policy{
+				Version:              1,
+				Name:                 "test",
+				ConnectRedirectRules: []ConnectRedirectRule{tt.rule},
+			}
+			err := p.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEvaluateConnectRedirect_UnixTarget(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		ConnectRedirectRules: []ConnectRedirectRule{
+			{
+				Name:           "db-appdb-redirect",
+				Match:          "^db\\.internal:5432$",
+				RedirectToUnix: "/run/agentsh/sessions/sess-1/db/appdb.sock",
+				Message:        "Routed through AgentSH DB proxy",
+			},
+		},
+	}
+	engine, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	got := engine.EvaluateConnectRedirect("DB.Internal:5432")
+	if !got.Matched {
+		t.Fatal("EvaluateConnectRedirect did not match")
+	}
+	if got.RedirectTo != "" {
+		t.Fatalf("RedirectTo = %q, want empty tcp target", got.RedirectTo)
+	}
+	if got.RedirectToUnix != "/run/agentsh/sessions/sess-1/db/appdb.sock" {
+		t.Fatalf("RedirectToUnix = %q", got.RedirectToUnix)
+	}
+	if got.Rule != "db-appdb-redirect" {
+		t.Fatalf("Rule = %q", got.Rule)
+	}
+	if got.Message != "Routed through AgentSH DB proxy" {
+		t.Fatalf("Message = %q", got.Message)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+go test ./internal/policy -run 'TestConnectRedirectRuleValidation_UnixTarget|TestEvaluateConnectRedirect_UnixTarget' -count=1
+```
+
+Expected: FAIL because `ConnectRedirectRule.RedirectToUnix` and `ConnectRedirectResult.RedirectToUnix` do not exist.
+
+- [ ] **Step 3: Implement the model and evaluator changes**
+
+In `internal/policy/model.go`, update `ConnectRedirectRule`:
+
+```go
+// ConnectRedirectRule redirects TCP connections for matching host:port.
+// Exactly one target must be set:
+//   - redirect_to for TCP host:port targets
+//   - redirect_to_unix for Unix-socket targets
+type ConnectRedirectRule struct {
+	Name           string                    `yaml:"name"`
+	Match          string                    `yaml:"match"` // regex pattern for host:port
+	RedirectTo     string                    `yaml:"redirect_to,omitempty"`
+	RedirectToUnix string                    `yaml:"redirect_to_unix,omitempty"`
+	TLS            *ConnectRedirectTLSConfig `yaml:"tls,omitempty"`
+	Visibility     string                    `yaml:"visibility,omitempty"` // silent, audit_only, warn
+	Message        string                    `yaml:"message,omitempty"`
+	OnFailure      string                    `yaml:"on_failure,omitempty"` // fail_closed, fail_open, retry_original
+}
+```
+
+In `Policy.Validate`, replace the existing `redirect_to` required check with:
+
+```go
+targets := 0
+if r.RedirectTo != "" {
+	targets++
+}
+if r.RedirectToUnix != "" {
+	targets++
+}
+if targets != 1 {
+	return fmt.Errorf("connect_redirects[%d]: exactly one of redirect_to or redirect_to_unix is required", i)
+}
+```
+
+In `internal/policy/engine.go`, update `ConnectRedirectResult`:
+
+```go
+type ConnectRedirectResult struct {
+	Matched        bool
+	Rule           string
+	RedirectTo     string
+	RedirectToUnix string
+	TLSMode        string
+	SNI            string
+	Visibility     string
+	Message        string
+	OnFailure      string
+}
+```
+
+In `EvaluateConnectRedirect`, populate the Unix target:
+
+```go
+return &ConnectRedirectResult{
+	Matched:        true,
+	Rule:           r.rule.Name,
+	RedirectTo:     r.rule.RedirectTo,
+	RedirectToUnix: r.rule.RedirectToUnix,
+	TLSMode:        tlsMode,
+	SNI:            sni,
+	Visibility:     visibility,
+	Message:        r.rule.Message,
+	OnFailure:      onFailure,
+}
+```
+
+- [ ] **Step 4: Run policy tests**
+
+Run:
+
+```bash
+go test ./internal/policy -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/policy/model.go internal/policy/engine.go internal/policy/redirect_test.go
+git commit -m "policy: support unix connect redirect targets"
+```
+
+---
+
+### Task 2: Teach Netmonitor CONNECT Redirects To Dial Unix Targets
+
+**Files:**
+- Modify: `internal/netmonitor/proxy.go`
+- Modify: `internal/netmonitor/proxy_test.go`
+
+- [ ] **Step 1: Write failing dial-target tests**
+
+Append these tests to `internal/netmonitor/proxy_test.go`:
+
+```go
+func TestConnectDialTarget_UnixRedirect(t *testing.T) {
+	got := connectDialTarget(connectDialTargetInput{
+		OriginalHostPort: "db.internal:5432",
+		ResolvedIP:      "10.0.0.10",
+		OriginalPort:    "5432",
+		Redirect: &policy.ConnectRedirectResult{
+			Matched:        true,
+			RedirectToUnix: "/run/agentsh/sessions/sess-1/db/appdb.sock",
+		},
+	})
+	if got.Network != "unix" {
+		t.Fatalf("Network = %q, want unix", got.Network)
+	}
+	if got.Address != "/run/agentsh/sessions/sess-1/db/appdb.sock" {
+		t.Fatalf("Address = %q", got.Address)
+	}
+}
+
+func TestConnectDialTarget_TCPRedirectWinsOverResolvedIP(t *testing.T) {
+	got := connectDialTarget(connectDialTargetInput{
+		OriginalHostPort: "api.example.com:443",
+		ResolvedIP:      "10.0.0.10",
+		OriginalPort:    "443",
+		Redirect: &policy.ConnectRedirectResult{
+			Matched:    true,
+			RedirectTo: "proxy.internal:8443",
+		},
+	})
+	if got.Network != "tcp" {
+		t.Fatalf("Network = %q, want tcp", got.Network)
+	}
+	if got.Address != "proxy.internal:8443" {
+		t.Fatalf("Address = %q", got.Address)
+	}
+}
+
+func TestConnectDialTarget_ResolvedIPFallback(t *testing.T) {
+	got := connectDialTarget(connectDialTargetInput{
+		OriginalHostPort: "api.example.com:443",
+		ResolvedIP:      "10.0.0.10",
+		OriginalPort:    "443",
+	})
+	if got.Network != "tcp" {
+		t.Fatalf("Network = %q, want tcp", got.Network)
+	}
+	if got.Address != "10.0.0.10:443" {
+		t.Fatalf("Address = %q", got.Address)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+go test ./internal/netmonitor -run 'TestConnectDialTarget_' -count=1
+```
+
+Expected: FAIL because `connectDialTarget` and `connectDialTargetInput` do not exist.
+
+- [ ] **Step 3: Implement dial-target selection**
+
+In `internal/netmonitor/proxy.go`, add this helper near `handleCONNECT`:
+
+```go
+type connectDialTargetInput struct {
+	OriginalHostPort string
+	ResolvedIP      string
+	OriginalPort    string
+	Redirect        *policy.ConnectRedirectResult
+}
+
+type resolvedConnectDialTarget struct {
+	Network string
+	Address string
+}
+
+func connectDialTarget(in connectDialTargetInput) resolvedConnectDialTarget {
+	if in.Redirect != nil && in.Redirect.RedirectToUnix != "" {
+		return resolvedConnectDialTarget{Network: "unix", Address: in.Redirect.RedirectToUnix}
+	}
+	if in.Redirect != nil && in.Redirect.RedirectTo != "" {
+		return resolvedConnectDialTarget{Network: "tcp", Address: in.Redirect.RedirectTo}
+	}
+	if in.ResolvedIP != "" {
+		return resolvedConnectDialTarget{
+			Network: "tcp",
+			Address: net.JoinHostPort(in.ResolvedIP, in.OriginalPort),
+		}
+	}
+	return resolvedConnectDialTarget{Network: "tcp", Address: in.OriginalHostPort}
+}
+```
+
+In `handleCONNECT`, keep the full `redirectResult` instead of splitting only strings:
+
+```go
+var redirectResult *policy.ConnectRedirectResult
+if p.policy != nil {
+	result := p.policy.EvaluateConnectRedirect(hostPort)
+	if result.Matched {
+		redirectResult = result
+		redirectTLS = result.TLSMode
+		redirectSNI = result.SNI
+		if result.Visibility != "silent" {
+			p.emitConnectRedirectEvent(context.Background(), commandID, host, hostPort, port, result)
+		}
+	}
+}
+```
+
+When adding event fields:
+
+```go
+if redirectResult != nil {
+	if redirectResult.RedirectTo != "" {
+		eventFields["redirect_to"] = redirectResult.RedirectTo
+	}
+	if redirectResult.RedirectToUnix != "" {
+		eventFields["redirect_to_unix"] = redirectResult.RedirectToUnix
+	}
+	eventFields["redirect_tls"] = redirectTLS
+	if redirectSNI != "" {
+		eventFields["redirect_sni"] = redirectSNI
+	}
+}
+```
+
+Replace the existing dial-target block:
+
+```go
+dialTarget := connectDialTarget(connectDialTargetInput{
+	OriginalHostPort: hostPort,
+	ResolvedIP:      resolvedIP,
+	OriginalPort:    portStr,
+	Redirect:        redirectResult,
+})
+
+up, err := net.DialTimeout(dialTarget.Network, dialTarget.Address, 20*time.Second)
+```
+
+- [ ] **Step 4: Run netmonitor tests**
+
+Run:
+
+```bash
+go test ./internal/netmonitor -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/netmonitor/proxy.go internal/netmonitor/proxy_test.go
+git commit -m "netmonitor: dial unix connect redirect targets"
+```
+
+---
+
+### Task 3: Add Stable Rule Metadata To Policy Model
+
+**Files:**
+- Modify: `internal/policy/model.go`
+- Modify: `internal/policy/redirect_test.go`
+
+- [ ] **Step 1: Write failing metadata validation tests**
+
+Append these tests to `internal/policy/redirect_test.go`:
+
+```go
+func TestPolicyMetadataValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		meta    []RuleMetadata
+		wantErr bool
+	}{
+		{
+			name: "valid db metadata",
+			meta: []RuleMetadata{{
+				RuleName:    "db-appdb-deny-direct",
+				Source:      "db_unavoidability",
+				DBService:   "appdb",
+				BypassMode:  "tcp_direct",
+				Destination: "db.internal:5432",
+			}},
+		},
+		{
+			name: "missing rule name",
+			meta: []RuleMetadata{{
+				Source:      "db_unavoidability",
+				DBService:   "appdb",
+				BypassMode:  "tcp_direct",
+				Destination: "db.internal:5432",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "missing source",
+			meta: []RuleMetadata{{
+				RuleName:    "db-appdb-deny-direct",
+				DBService:   "appdb",
+				BypassMode:  "tcp_direct",
+				Destination: "db.internal:5432",
+			}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Policy{Version: 1, Name: "test", Metadata: tt.meta}
+			err := p.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+go test ./internal/policy -run TestPolicyMetadataValidation -count=1
+```
+
+Expected: FAIL because `RuleMetadata` and `Policy.Metadata` do not exist.
+
+- [ ] **Step 3: Implement metadata fields and validation**
+
+In `internal/policy/model.go`, add the metadata field to `Policy`:
+
+```go
+Metadata []RuleMetadata `yaml:"metadata,omitempty"`
+```
+
+Add the struct near the rule model types:
+
+```go
+// RuleMetadata is non-enforcing metadata attached to generated policy rules.
+// The policy engine ignores it for decisions; consumers use it to correlate
+// generic rule names back to higher-level generated bundles.
+type RuleMetadata struct {
+	RuleName    string `yaml:"rule_name"`
+	Source      string `yaml:"source"`
+	DBService   string `yaml:"db_service,omitempty"`
+	BypassMode  string `yaml:"bypass_mode,omitempty"`
+	Destination string `yaml:"destination,omitempty"`
+}
+```
+
+At the beginning of `Policy.Validate`, after the name/version checks, add:
+
+```go
+for i, m := range p.Metadata {
+	if m.RuleName == "" {
+		return fmt.Errorf("metadata[%d]: rule_name is required", i)
+	}
+	if m.Source == "" {
+		return fmt.Errorf("metadata[%d]: source is required", i)
+	}
+}
+```
+
+- [ ] **Step 4: Run policy tests**
+
+Run:
+
+```bash
+go test ./internal/policy -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/policy/model.go internal/policy/redirect_test.go
+git commit -m "policy: preserve generated rule metadata"
+```
+
+---
+
+### Task 4: Add DB Bundle Types And Option Validation
+
+**Files:**
+- Create: `internal/db/service/bundle.go`
+- Create: `internal/db/service/bundle_test.go`
+
+- [ ] **Step 1: Write failing validation tests**
+
+Create `internal/db/service/bundle_test.go`:
+
+```go
+package service
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestGenerateBundle_RequiresSessionID(t *testing.T) {
+	_, err := GenerateBundle(Config{Services: []Service{validBundleService("appdb")}}, BundleOptions{
+		Mode: UnavoidabilityEnforce,
+	})
+	if !errors.Is(err, ErrBundleInvalidOptions) {
+		t.Fatalf("GenerateBundle err = %v, want ErrBundleInvalidOptions", err)
+	}
+}
+
+func TestGenerateBundle_RejectsTCPListenerInEnforce(t *testing.T) {
+	svc := validBundleService("appdb")
+	svc.Listen = Listener{Kind: "tcp", Host: "127.0.0.1", Port: 15432}
+
+	_, err := GenerateBundle(Config{Services: []Service{svc}}, BundleOptions{
+		SessionID:      "sess-1",
+		ProxySessionID: "db-proxy-sess",
+		Mode:           UnavoidabilityEnforce,
+	})
+	if err == nil {
+		t.Fatal("GenerateBundle returned nil error")
+	}
+	if !strings.Contains(err.Error(), "spec section 12.5") {
+		t.Fatalf("error = %v, want spec section 12.5 reference", err)
+	}
+}
+
+func validBundleService(name string) Service {
+	return Service{
+		Name:    name,
+		Family:  "postgres",
+		Dialect: "postgres",
+		Upstream: Endpoint{
+			Host: "db.internal",
+			Port: 5432,
+		},
+		Listen: Listener{
+			Kind: "unix",
+			Path: "/run/agentsh/sessions/sess-1/db/" + name + ".sock",
+		},
+		TLSMode: "terminate_reissue",
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+go test ./internal/db/service -run 'TestGenerateBundle_RequiresSessionID|TestGenerateBundle_RejectsTCPListenerInEnforce' -count=1
+```
+
+Expected: FAIL because bundle types and `GenerateBundle` do not exist.
+
+- [ ] **Step 3: Implement bundle skeleton and validation**
+
+Create `internal/db/service/bundle.go`:
+
+```go
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+const (
+	RuleSourceDBUnavoidability = "db_unavoidability"
+
+	BypassModeTCPDirect       = "tcp_direct"
+	BypassModeUnixSocket      = "unix_socket"
+	BypassModePortForwardTool = "port_forward_tool"
+	BypassModeDNSAlias        = "dns_alias"
+	BypassModeCustomTunnel    = "custom_tunnel"
+)
+
+var ErrBundleInvalidOptions = errors.New("db unavoidability bundle invalid options")
+
+type IPResolver interface {
+	LookupIP(ctx context.Context, host string) ([]net.IP, error)
+}
+
+type BundleOptions struct {
+	SessionID                  string
+	ProxySessionID             string
+	SocketBaseDir              string
+	IncludeToolRules           bool
+	Mode                       Unavoidability
+	AllowHostnameOnlyInEnforce bool
+	Resolver                   IPResolver
+}
+
+type BundleWarning struct {
+	Code    string
+	Service string
+	Message string
+}
+
+type Bundle struct {
+	Policy   policy.Policy
+	Metadata []policy.RuleMetadata
+	Warnings []BundleWarning
+}
+
+func GenerateBundle(cfg Config, opts BundleOptions) (Bundle, error) {
+	if err := validateBundleOptions(cfg, opts); err != nil {
+		return Bundle{}, err
+	}
+	return Bundle{
+		Policy: policy.Policy{
+			Version:     1,
+			Name:        "db-unavoidability-" + sanitizeRulePart(opts.SessionID),
+			Description: "Generated DB unavoidability bundle for AgentSH session " + opts.SessionID,
+		},
+	}, nil
+}
+
+func validateBundleOptions(cfg Config, opts BundleOptions) error {
+	if opts.SessionID == "" {
+		return fmt.Errorf("%w: SessionID is required", ErrBundleInvalidOptions)
+	}
+	if opts.ProxySessionID == "" {
+		return fmt.Errorf("%w: ProxySessionID is required", ErrBundleInvalidOptions)
+	}
+	if opts.Mode != UnavoidabilityObserve && opts.Mode != UnavoidabilityEnforce {
+		return fmt.Errorf("%w: Mode must be observe or enforce", ErrBundleInvalidOptions)
+	}
+	for i, svc := range cfg.Services {
+		if svc.Listen.Kind == "tcp" && opts.Mode == UnavoidabilityEnforce {
+			return fmt.Errorf("services[%d] %s: tcp listeners are not supported for DB enforce mode in spec section 12.5", i, svc.Name)
+		}
+	}
+	return nil
+}
+
+func sanitizeRulePart(s string) string {
+	if s == "" {
+		return "empty"
+	}
+	out := make([]byte, 0, len(s))
+	lastDash := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+			out = append(out, c)
+			lastDash = false
+		case c >= 'A' && c <= 'Z':
+			out = append(out, c+'a'-'A')
+			lastDash = false
+		case c >= '0' && c <= '9':
+			out = append(out, c)
+			lastDash = false
+		default:
+			if !lastDash {
+				out = append(out, '-')
+				lastDash = true
+			}
+		}
+	}
+	for len(out) > 0 && out[len(out)-1] == '-' {
+		out = out[:len(out)-1]
+	}
+	if len(out) == 0 {
+		return "empty"
+	}
+	return string(out)
+}
+```
+
+- [ ] **Step 4: Run service tests**
+
+Run:
+
+```bash
+go test ./internal/db/service -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/db/service/bundle.go internal/db/service/bundle_test.go
+git commit -m "db: add unavoidability bundle skeleton"
+```
+
+---
+
+### Task 5: Generate Core Redirect, Network, Unix Socket Rules, And Metadata
+
+**Files:**
+- Modify: `internal/db/service/bundle.go`
+- Modify: `internal/db/service/bundle_test.go`
+
+- [ ] **Step 1: Write failing core bundle tests**
+
+Append to `internal/db/service/bundle_test.go`:
+
+```go
+func TestGenerateBundle_SingleServiceCoreRules(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService("appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+
+	if len(b.Policy.ConnectRedirectRules) != 1 {
+		t.Fatalf("connect redirects = %d, want 1", len(b.Policy.ConnectRedirectRules))
+	}
+	redirect := b.Policy.ConnectRedirectRules[0]
+	if redirect.Name != "db-appdb-redirect" {
+		t.Fatalf("redirect name = %q", redirect.Name)
+	}
+	if redirect.RedirectToUnix != "/run/agentsh/sessions/sess-1/db/appdb.sock" {
+		t.Fatalf("redirect_to_unix = %q", redirect.RedirectToUnix)
+	}
+	if redirect.RedirectTo != "" {
+		t.Fatalf("redirect_to = %q, want empty", redirect.RedirectTo)
+	}
+
+	if len(b.Policy.NetworkRules) != 1 {
+		t.Fatalf("network rules = %d, want 1", len(b.Policy.NetworkRules))
+	}
+	netRule := b.Policy.NetworkRules[0]
+	if netRule.Name != "db-appdb-deny-direct" {
+		t.Fatalf("network rule name = %q", netRule.Name)
+	}
+	if len(netRule.Domains) != 1 || netRule.Domains[0] != "db.internal" {
+		t.Fatalf("network domains = %+v", netRule.Domains)
+	}
+	if len(netRule.Ports) != 1 || netRule.Ports[0] != 5432 {
+		t.Fatalf("network ports = %+v", netRule.Ports)
+	}
+	if netRule.Decision != "deny" {
+		t.Fatalf("network decision = %q", netRule.Decision)
+	}
+
+	if len(b.Policy.UnixRules) != 1 {
+		t.Fatalf("unix rules = %d, want 1", len(b.Policy.UnixRules))
+	}
+	if b.Policy.UnixRules[0].Decision != "deny" {
+		t.Fatalf("unix decision = %q", b.Policy.UnixRules[0].Decision)
+	}
+
+	if len(b.Metadata) != len(b.Policy.Metadata) {
+		t.Fatalf("Bundle.Metadata length = %d, Policy.Metadata length = %d", len(b.Metadata), len(b.Policy.Metadata))
+	}
+	assertMetadata(t, b.Metadata, "db-appdb-redirect", "appdb", BypassModeTCPDirect, "db.internal:5432")
+	assertMetadata(t, b.Metadata, "db-appdb-deny-direct", "appdb", BypassModeTCPDirect, "db.internal:5432")
+	assertMetadata(t, b.Metadata, "db-appdb-deny-local-postgres-sockets", "appdb", BypassModeUnixSocket, "postgres-local-sockets")
+}
+
+func TestGenerateBundle_MultipleServicesHaveStableNames(t *testing.T) {
+	app := validBundleService("appdb")
+	warehouse := validBundleService("warehouse-db")
+	warehouse.Upstream.Host = "warehouse.internal"
+	warehouse.Upstream.Port = 15432
+	warehouse.Listen.Path = "/run/agentsh/sessions/sess-1/db/warehouse.sock"
+
+	b, err := GenerateBundle(Config{Services: []Service{app, warehouse}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+
+	seen := map[string]bool{}
+	for _, m := range b.Metadata {
+		if seen[m.RuleName] {
+			t.Fatalf("duplicate metadata rule name %q", m.RuleName)
+		}
+		seen[m.RuleName] = true
+	}
+	for _, name := range []string{
+		"db-appdb-redirect",
+		"db-warehouse-db-redirect",
+		"db-appdb-deny-direct",
+		"db-warehouse-db-deny-direct",
+	} {
+		if !seen[name] {
+			t.Fatalf("missing metadata for %q in %+v", name, b.Metadata)
+		}
+	}
+}
+
+func TestGenerateBundle_PolicyCompiles(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService("appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+	if err := b.Policy.Validate(); err != nil {
+		t.Fatalf("Policy.Validate: %v", err)
+	}
+	if _, err := policy.NewEngine(&b.Policy, false, true); err != nil {
+		t.Fatalf("policy.NewEngine: %v", err)
+	}
+}
+
+func assertMetadata(t *testing.T, got []policy.RuleMetadata, ruleName, service, mode, destination string) {
+	t.Helper()
+	for _, m := range got {
+		if m.RuleName == ruleName {
+			if m.Source != RuleSourceDBUnavoidability || m.DBService != service || m.BypassMode != mode || m.Destination != destination {
+				t.Fatalf("metadata for %q = %+v", ruleName, m)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing metadata for rule %q in %+v", ruleName, got)
+}
+```
+
+Add the import to `internal/db/service/bundle_test.go`:
+
+```go
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+go test ./internal/db/service -run 'TestGenerateBundle_SingleServiceCoreRules|TestGenerateBundle_MultipleServicesHaveStableNames|TestGenerateBundle_PolicyCompiles' -count=1
+```
+
+Expected: FAIL because the skeleton does not generate rules or metadata.
+
+- [ ] **Step 3: Implement core bundle generation**
+
+In `internal/db/service/bundle.go`, update `GenerateBundle`:
+
+```go
+func GenerateBundle(cfg Config, opts BundleOptions) (Bundle, error) {
+	if err := validateBundleOptions(cfg, opts); err != nil {
+		return Bundle{}, err
+	}
+	b := Bundle{
+		Policy: policy.Policy{
+			Version:     1,
+			Name:        "db-unavoidability-" + sanitizeRulePart(opts.SessionID),
+			Description: "Generated DB unavoidability bundle for AgentSH session " + opts.SessionID,
+		},
+	}
+	for _, svc := range cfg.Services {
+		addCoreServiceRules(&b, svc)
+	}
+	b.Policy.Metadata = append([]policy.RuleMetadata(nil), b.Metadata...)
+	return b, nil
+}
+```
+
+Add helpers:
+
+```go
+func addCoreServiceRules(b *Bundle, svc Service) {
+	servicePart := sanitizeRulePart(svc.Name)
+	destination := serviceDestination(svc)
+	redirectName := "db-" + servicePart + "-redirect"
+	networkName := "db-" + servicePart + "-deny-direct"
+	unixName := "db-" + servicePart + "-deny-local-postgres-sockets"
+
+	b.Policy.ConnectRedirectRules = append(b.Policy.ConnectRedirectRules, policy.ConnectRedirectRule{
+		Name:           redirectName,
+		Match:          "^" + regexp.QuoteMeta(destination) + "$",
+		RedirectToUnix: svc.Listen.Path,
+		Visibility:     "audit_only",
+		OnFailure:      "fail_closed",
+		Message:        "Routed through AgentSH DB proxy",
+	})
+	addMetadata(b, redirectName, svc.Name, BypassModeTCPDirect, destination)
+
+	b.Policy.NetworkRules = append(b.Policy.NetworkRules, policy.NetworkRule{
+		Name:        networkName,
+		Description: "Deny direct DB egress; traffic must use AgentSH DB proxy",
+		Domains:     []string{strings.ToLower(svc.Upstream.Host)},
+		Ports:       []int{svc.Upstream.Port},
+		Decision:    "deny",
+		Message:     "Direct database egress is blocked; use the AgentSH DB proxy",
+	})
+	addMetadata(b, networkName, svc.Name, BypassModeTCPDirect, destination)
+
+	b.Policy.UnixRules = append(b.Policy.UnixRules, policy.UnixSocketRule{
+		Name:        unixName,
+		Description: "Deny direct local Postgres Unix socket access for DB unavoidability",
+		Paths: []string{
+			"/var/run/postgresql/.s.PGSQL.*",
+			"/tmp/.s.PGSQL.*",
+		},
+		Operations: []string{"connect"},
+		Decision:   "deny",
+		Message:    "Direct local database socket access is blocked; use the AgentSH DB proxy",
+	})
+	addMetadata(b, unixName, svc.Name, BypassModeUnixSocket, "postgres-local-sockets")
+}
+
+func addMetadata(b *Bundle, ruleName, serviceName, bypassMode, destination string) {
+	b.Metadata = append(b.Metadata, policy.RuleMetadata{
+		RuleName:    ruleName,
+		Source:      RuleSourceDBUnavoidability,
+		DBService:   serviceName,
+		BypassMode:  bypassMode,
+		Destination: destination,
+	})
+}
+
+func serviceDestination(svc Service) string {
+	return net.JoinHostPort(strings.ToLower(svc.Upstream.Host), strconv.Itoa(svc.Upstream.Port))
+}
+```
+
+Add imports:
+
+```go
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+```
+
+- [ ] **Step 4: Run service tests**
+
+Run:
+
+```bash
+go test ./internal/db/service -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/db/service/bundle.go internal/db/service/bundle_test.go
+git commit -m "db: generate core unavoidability bundle rules"
+```
+
+---
+
+### Task 6: Add DNS Resolution Expansion With Observe/Enforce Semantics
+
+**Files:**
+- Modify: `internal/db/service/bundle.go`
+- Modify: `internal/db/service/bundle_test.go`
+
+- [ ] **Step 1: Write failing DNS expansion tests**
+
+Append to `internal/db/service/bundle_test.go`:
+
+```go
+type fakeIPResolver struct {
+	ips []net.IP
+	err error
+}
+
+func (f fakeIPResolver) LookupIP(ctx context.Context, host string) ([]net.IP, error) {
+	return f.ips, f.err
+}
+
+func TestGenerateBundle_AddsResolvedIPDenies(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService("appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+		Resolver: fakeIPResolver{ips: []net.IP{
+			net.ParseIP("10.0.0.15"),
+			net.ParseIP("2001:db8::15"),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+
+	assertMetadata(t, b.Metadata, "db-appdb-deny-ip-10-0-0-15", "appdb", BypassModeDNSAlias, "10.0.0.15:5432")
+	assertMetadata(t, b.Metadata, "db-appdb-deny-ip-2001-db8-15", "appdb", BypassModeDNSAlias, "[2001:db8::15]:5432")
+}
+
+func TestGenerateBundle_DNSFailureObserveWarns(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService("appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityObserve,
+		IncludeToolRules: false,
+		Resolver:         fakeIPResolver{err: errors.New("dns unavailable")},
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+	if len(b.Warnings) != 1 {
+		t.Fatalf("warnings = %+v, want one warning", b.Warnings)
+	}
+	if b.Warnings[0].Code != "DNS_EXPANSION_FAILED" {
+		t.Fatalf("warning code = %q", b.Warnings[0].Code)
+	}
+}
+
+func TestGenerateBundle_DNSFailureEnforceFailsUnlessAllowed(t *testing.T) {
+	_, err := GenerateBundle(Config{Services: []Service{validBundleService("appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+		Resolver:         fakeIPResolver{err: errors.New("dns unavailable")},
+	})
+	if err == nil {
+		t.Fatal("GenerateBundle returned nil error")
+	}
+
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService("appdb")}}, BundleOptions{
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		IncludeToolRules:           false,
+		AllowHostnameOnlyInEnforce: true,
+		Resolver:                   fakeIPResolver{err: errors.New("dns unavailable")},
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle with hostname-only override: %v", err)
+	}
+	if len(b.Warnings) != 1 {
+		t.Fatalf("warnings = %+v, want one warning", b.Warnings)
+	}
+}
+```
+
+Update imports:
+
+```go
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+go test ./internal/db/service -run 'TestGenerateBundle_AddsResolvedIPDenies|TestGenerateBundle_DNSFailure' -count=1
+```
+
+Expected: FAIL because DNS expansion is not implemented.
+
+- [ ] **Step 3: Implement resolver-backed IP deny expansion**
+
+Update imports:
+
+```go
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+```
+
+Inside the service loop, after `addCoreServiceRules`, call:
+
+```go
+if err := addResolvedIPRules(context.Background(), &b, svc, opts); err != nil {
+	return Bundle{}, err
+}
+```
+
+Add helpers:
+
+```go
+func addResolvedIPRules(ctx context.Context, b *Bundle, svc Service, opts BundleOptions) error {
+	if opts.Resolver == nil {
+		return nil
+	}
+	if net.ParseIP(svc.Upstream.Host) != nil {
+		return nil
+	}
+	resolveCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	ips, err := opts.Resolver.LookupIP(resolveCtx, svc.Upstream.Host)
+	if err != nil {
+		w := BundleWarning{
+			Code:    "DNS_EXPANSION_FAILED",
+			Service: svc.Name,
+			Message: "could not resolve " + svc.Upstream.Host + ": " + err.Error(),
+		}
+		b.Warnings = append(b.Warnings, w)
+		if opts.Mode == UnavoidabilityEnforce && !opts.AllowHostnameOnlyInEnforce {
+			return fmt.Errorf("%w: %s", ErrBundleInvalidOptions, w.Message)
+		}
+		return nil
+	}
+
+	for _, ip := range ips {
+		if ip == nil {
+			continue
+		}
+		cidr := ipCIDR(ip)
+		ipString := ip.String()
+		name := "db-" + sanitizeRulePart(svc.Name) + "-deny-ip-" + sanitizeRulePart(ipString)
+		destination := net.JoinHostPort(ipString, strconv.Itoa(svc.Upstream.Port))
+		b.Policy.NetworkRules = append(b.Policy.NetworkRules, policy.NetworkRule{
+			Name:        name,
+			Description: "Deny direct DB egress to resolved upstream IP",
+			CIDRs:       []string{cidr},
+			Ports:       []int{svc.Upstream.Port},
+			Decision:    "deny",
+			Message:     "Direct database egress is blocked; use the AgentSH DB proxy",
+		})
+		addMetadata(b, name, svc.Name, BypassModeDNSAlias, destination)
+	}
+	return nil
+}
+
+func ipCIDR(ip net.IP) string {
+	if v4 := ip.To4(); v4 != nil {
+		return v4.String() + "/32"
+	}
+	return ip.String() + "/128"
+}
+```
+
+- [ ] **Step 4: Run service tests**
+
+Run:
+
+```bash
+go test ./internal/db/service -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/db/service/bundle.go internal/db/service/bundle_test.go
+git commit -m "db: add dns-expanded unavoidability denies"
+```
+
+---
+
+### Task 7: Generate Bypass-Tool Command Rules
+
+**Files:**
+- Modify: `internal/db/service/bundle.go`
+- Modify: `internal/db/service/bundle_test.go`
+
+- [ ] **Step 1: Write failing bypass-tool tests**
+
+Append to `internal/db/service/bundle_test.go`:
+
+```go
+func TestGenerateBundle_BypassToolRules(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService("appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: true,
+		Resolver:         fakeIPResolver{},
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+
+	wantCommands := map[string]string{
+		"ssh":             "db-bypass-ssh-forward",
+		"socat":           "db-bypass-socat",
+		"kubectl":         "db-bypass-kubectl-port-forward",
+		"cloud-sql-proxy": "db-bypass-cloud-sql-proxy",
+		"gcloud":          "db-bypass-gcloud-sql-connect",
+		"aws":             "db-bypass-aws-rds-connect",
+		"chisel":          "db-bypass-chisel",
+		"gost":            "db-bypass-gost",
+		"frpc":            "db-bypass-frpc",
+		"nc":              "db-bypass-netcat",
+		"ncat":            "db-bypass-netcat",
+		"docker":          "db-bypass-container-net-host",
+	}
+
+	seen := map[string]string{}
+	for _, r := range b.Policy.CommandRules {
+		for _, cmd := range r.Commands {
+			seen[cmd] = r.Name
+		}
+		if r.Decision != "deny" {
+			t.Fatalf("command rule %q decision = %q", r.Name, r.Decision)
+		}
+	}
+	for cmd, ruleName := range wantCommands {
+		if seen[cmd] != ruleName {
+			t.Fatalf("command %q mapped to rule %q, want %q; all seen=%+v", cmd, seen[cmd], ruleName, seen)
+		}
+		assertMetadata(t, b.Metadata, ruleName, "*", BypassModePortForwardTool, "db-service-ports")
+	}
+}
+
+func TestGenerateBundle_BypassToolRulesOptional(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService("appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+		Resolver:         fakeIPResolver{},
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+	if len(b.Policy.CommandRules) != 0 {
+		t.Fatalf("command rules = %+v, want none", b.Policy.CommandRules)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+go test ./internal/db/service -run 'TestGenerateBundle_BypassToolRules' -count=1
+```
+
+Expected: FAIL because `IncludeToolRules` does not add command rules.
+
+- [ ] **Step 3: Implement bypass-tool rules**
+
+In `GenerateBundle`, after the service loop:
+
+```go
+if opts.IncludeToolRules {
+	addBypassToolRules(&b, cfg.Services)
+}
+b.Policy.Metadata = append([]policy.RuleMetadata(nil), b.Metadata...)
+return b, nil
+```
+
+Add helpers:
+
+```go
+func addBypassToolRules(b *Bundle, services []Service) {
+	portPattern := dbPortPattern(services)
+	rules := []policy.CommandRule{
+		{Name: "db-bypass-ssh-forward", Commands: []string{"ssh"}, ArgsPatterns: []string{"(^|\\s)-L(\\s|[^\\s]*:).*:(" + portPattern + ")(\\s|$)"}, Decision: "deny", Message: "DB port forwarding is blocked by AgentSH DB unavoidability"},
+		{Name: "db-bypass-socat", Commands: []string{"socat"}, ArgsPatterns: []string{"(?i)(tcp-listen|listen|tcp:).*(" + portPattern + ")"}, Decision: "deny", Message: "DB socket forwarding is blocked by AgentSH DB unavoidability"},
+		{Name: "db-bypass-kubectl-port-forward", Commands: []string{"kubectl"}, ArgsPatterns: []string{"(^|\\s)port-forward(\\s|$).*(:" + portPattern + "|\\s" + portPattern + ":)"}, Decision: "deny", Message: "DB port forwarding is blocked by AgentSH DB unavoidability"},
+		{Name: "db-bypass-cloud-sql-proxy", Commands: []string{"cloud-sql-proxy"}, ArgsPatterns: []string{".*"}, Decision: "deny", Message: "Cloud SQL proxy is blocked by AgentSH DB unavoidability"},
+		{Name: "db-bypass-gcloud-sql-connect", Commands: []string{"gcloud"}, ArgsPatterns: []string{"(^|\\s)sql\\s+connect(\\s|$)"}, Decision: "deny", Message: "gcloud SQL connect is blocked by AgentSH DB unavoidability"},
+		{Name: "db-bypass-aws-rds-connect", Commands: []string{"aws"}, ArgsPatterns: []string{"(^|\\s)rds\\s+connect(\\s|$)"}, Decision: "deny", Message: "AWS RDS connect is blocked by AgentSH DB unavoidability"},
+		{Name: "db-bypass-chisel", Commands: []string{"chisel"}, ArgsPatterns: []string{".*"}, Decision: "deny", Message: "Tunnel tool is blocked by AgentSH DB unavoidability"},
+		{Name: "db-bypass-gost", Commands: []string{"gost"}, ArgsPatterns: []string{".*"}, Decision: "deny", Message: "Tunnel tool is blocked by AgentSH DB unavoidability"},
+		{Name: "db-bypass-frpc", Commands: []string{"frpc"}, ArgsPatterns: []string{".*"}, Decision: "deny", Message: "Tunnel tool is blocked by AgentSH DB unavoidability"},
+		{Name: "db-bypass-netcat", Commands: []string{"nc", "ncat"}, ArgsPatterns: []string{"(?i)(-l|--listen|(" + portPattern + "))"}, Decision: "deny", Message: "Raw TCP forwarding is blocked by AgentSH DB unavoidability"},
+		{Name: "db-bypass-container-net-host", Commands: []string{"docker", "podman", "nerdctl"}, ArgsPatterns: []string{"(^|\\s)(run|create)(\\s|$).*(--net=host|--network=host)"}, Decision: "deny", Message: "Host-network containers are blocked by AgentSH DB unavoidability"},
+	}
+	for _, r := range rules {
+		r.Description = "Convenience detection for DB proxy bypass attempts; destination egress deny is the security boundary"
+		b.Policy.CommandRules = append(b.Policy.CommandRules, r)
+		addMetadata(b, r.Name, "*", BypassModePortForwardTool, "db-service-ports")
+	}
+}
+
+func dbPortPattern(services []Service) string {
+	seen := map[int]bool{}
+	ports := make([]int, 0, len(services))
+	for _, svc := range services {
+		if !seen[svc.Upstream.Port] {
+			seen[svc.Upstream.Port] = true
+			ports = append(ports, svc.Upstream.Port)
+		}
+	}
+	sort.Ints(ports)
+	parts := make([]string, 0, len(ports))
+	for _, port := range ports {
+		parts = append(parts, strconv.Itoa(port))
+	}
+	return strings.Join(parts, "|")
+}
+```
+
+Add `sort` to imports.
+
+- [ ] **Step 4: Run service tests**
+
+Run:
+
+```bash
+go test ./internal/db/service -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/db/service/bundle.go internal/db/service/bundle_test.go
+git commit -m "db: generate bypass tool detection rules"
+```
+
+---
+
+### Task 8: Final Verification For 07a
+
+**Files:**
+- No new files.
+
+- [ ] **Step 1: Run focused package tests**
+
+Run:
+
+```bash
+go test ./internal/policy ./internal/netmonitor ./internal/db/service -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run DB package tests**
+
+Run:
+
+```bash
+go test ./internal/db/... -count=1 -timeout 240s
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Verify Windows build**
+
+Run:
+
+```bash
+GOOS=windows go build ./...
+```
+
+Expected: PASS. The new bundle code is platform-neutral; Unix-socket redirect fields are data model only and must compile on Windows.
+
+- [ ] **Step 4: Run diff whitespace check**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Commit verification fixes if needed**
+
+If any verification step required code fixes, commit the fixes:
+
+```bash
+git add internal/policy internal/netmonitor internal/db/service
+git commit -m "db: finish unavoidability bundle verification"
+```
+
+Expected: either a small follow-up commit exists, or `git status --short` shows no uncommitted tracked changes.
+
+## Completion Criteria
+
+Plan 07a is complete when:
+
+- DB services generate compileable policy bundles with Unix connect redirects.
+- Direct host and resolved-IP egress denies are generated.
+- Local Postgres Unix socket denies are generated.
+- Bypass-tool command denies are generated when requested.
+- Every generated DB rule has stable metadata available in both `Bundle.Metadata` and `Policy.Metadata`.
+- Netmonitor can dial Unix redirect targets.
+- Focused tests, DB tests, Windows build, and `git diff --check` pass.
+
+Plan 07b can start after 07a lands because it consumes the rule metadata and listener socket path behavior produced here.

--- a/docs/superpowers/specs/2026-05-13-db-plan-07-split-unavoidability-design.md
+++ b/docs/superpowers/specs/2026-05-13-db-plan-07-split-unavoidability-design.md
@@ -1,0 +1,275 @@
+# DB Access Plan 07 Split - Unavoidability Design
+
+**Status:** Draft for user review.
+**Date:** 2026-05-13
+**Source roadmap:** `docs/superpowers/specs/2026-05-08-db-access-phase-1-roadmap-design.md`
+**Source spec:** `docs/agentsh-db-access-spec.md` v0.8, sections 11.1, 12, 17, and 23.4 steps 10-11.
+
+## Goal
+
+Close DB Access Phase 1 by making declared `db_services` unavoidable for processes inside the AgentSH-governed process tree, then prove the end-to-end behavior against a real Postgres server.
+
+The original roadmap Plan 07 is intentionally split into three sequential plans so each PR is reviewable and each phase has a clear security boundary.
+
+## Plan Split
+
+### Plan 07a - Unavoidability Bundle Generator
+
+Build `internal/db/service/bundle.go`.
+
+The generator consumes declared `db_services` plus session/proxy context and emits existing policy primitives:
+
+- `connect_redirects` from declared upstream host/port to the per-session DB proxy Unix socket, including the narrow policy-model extension needed for Unix-socket redirect targets.
+- `network_rules` that deny direct egress to declared DB destinations for the agent session.
+- DNS/IP expansion metadata for declared upstream hostnames, including CNAME and IPv6 coverage where existing policy supports it.
+- `unix_socket_rules` that deny common local Postgres socket paths for non-proxy processes.
+- `command_rules` for known bypass tools and patterns.
+
+Generated rules carry minimal DB metadata so later enforcement can map generic policy decisions back to DB bypass events without guessing from names.
+
+### Plan 07b - Listener Session Auth And Bypass Events
+
+Replace Plan 04a's UID-only listener auth with SessionID-based authentication:
+
+- Accept only Unix-socket listeners in Phase 1 enforce mode.
+- On accept, read SO_PEERCRED pid/uid/gid.
+- Resolve pid to AgentSH SessionID through an injected resolver interface.
+- Accept only when the resolved peer SessionID matches the configured agent SessionID.
+- Unknown or mismatched SessionID fails closed and emits `db_listener_auth_fail`.
+
+Plan 07b also maps DB-generated deny decisions into normalized `db_bypass_attempt` lifecycle events and deduplicates those events per `(session_id, process_identity, destination_tuple)` for 60 seconds.
+
+### Plan 07c - Integration Suite And Enforce Recommendation
+
+Add integration coverage that exercises the full path:
+
+- Generated bundle.
+- DB proxy listener.
+- Real Postgres upstream.
+- Client traffic through the redirected path.
+- Direct bypass attempts.
+
+Plan 07c closes Phase 1 by updating documentation and defaults so `policies.db.unavoidability: enforce` is the high-assurance recommendation.
+
+## Architecture
+
+Plan 07 should not add a DB-specific policy evaluator. The bundle generator emits existing policy rule families that the current engine can compile and enforce. The one required model extension is a Unix-socket target for `connect_redirects`, because the current `ConnectRedirectRule.RedirectTo` shape redirects TCP host:port to TCP host:port while spec section 12.5 requires redirecting the client's protected DB `connect()` to a per-session Unix socket. DB-specific metadata is carried alongside generated rules and consumed only by DB event mapping.
+
+This keeps the security boundary in existing primitives:
+
+- Destination egress denial catches direct TCP and custom tunnel binaries.
+- Connect redirect sends normal client DB connections to the proxy Unix-socket listener.
+- Unix socket file rules close common local socket bypass paths.
+- Command rules are convenience detection, not the boundary.
+
+## Rule Metadata
+
+Generated DB rules must have stable metadata keyed by rule name. Metadata must survive the handoff from generation to enforcement; it may be carried as an in-memory sidecar in the `Bundle`, and exported policy files should include an equivalent top-level metadata block rather than relying only on rule-name prefixes.
+
+Recommended metadata fields:
+
+```go
+type GeneratedRuleMetadata struct {
+    RuleName    string
+    Source      string // "db_unavoidability"
+    DBService   string
+    BypassMode  string // tcp_direct, unix_socket, port_forward_tool, dns_alias, custom_tunnel, listener_auth_fail
+    Destination string // host:port, CIDR/port, or unix-socket path
+}
+```
+
+`RuleName` must be deterministic for a given service and rule purpose. Multiple services must not collide. Metadata is not the enforcement mechanism; it is the event-correlation contract between 07a and 07b.
+
+## 07a API
+
+The generator should live in `internal/db/service` rather than generic `internal/policygen`, because it is derived from static `db_services` config rather than from recorded session activity.
+
+Recommended API:
+
+```go
+type BundleOptions struct {
+    SessionID        string
+    ProxySessionID   string
+    SocketBaseDir    string
+    IncludeToolRules bool
+    Mode             Unavoidability // observe or enforce
+}
+
+type Bundle struct {
+    Policy   policy.Policy
+    Metadata []GeneratedRuleMetadata
+    Warnings []BundleWarning
+}
+
+func GenerateBundle(cfg Config, opts BundleOptions) (Bundle, error)
+```
+
+`SessionID` identifies the governed agent session. `ProxySessionID` identifies the DB proxy exemption session. `SocketBaseDir` is used to derive per-session Unix socket listener paths when services do not provide an explicit path.
+
+The output policy must be directly compileable by `internal/policy.NewEngine`.
+
+07a also owns the backward-compatible `connect_redirect` target extension. Existing host:port redirects must keep working unchanged. DB-generated redirects should use an explicit Unix target field or target kind, for example:
+
+```yaml
+connect_redirects:
+  - name: db-appdb-redirect
+    match: '^db\.internal:5432$'
+    redirect_to_unix: /run/agentsh/sessions/sess-123/db/appdb.sock
+```
+
+The final field spelling can be chosen during implementation planning, but the design requirement is fixed: the target type must be explicit and must not overload `redirect_to` with a Unix path.
+
+## 07a Generated Policy Shape
+
+For each service:
+
+- Add a connect redirect from upstream `host:port` to the service's Unix socket listener path using the Unix-target redirect extension.
+- Add direct network deny rules for the declared upstream host/port.
+- Add deny rules for resolved IPs when resolution data is available.
+- Add Unix socket deny rules for common Postgres paths:
+  - `/var/run/postgresql/.s.PGSQL.*`
+  - `/tmp/.s.PGSQL.*`
+  - service-specific socket path if configured.
+- Add command deny/detect rules for known bypass tools when `IncludeToolRules` is true.
+
+Bypass command coverage should include at least:
+
+- `ssh` with local forwarding patterns.
+- `socat` TCP listener/forwarder patterns.
+- `kubectl port-forward`.
+- `cloud-sql-proxy`.
+- `gcloud sql connect`.
+- `aws rds connect`.
+- `chisel`.
+- `gost`.
+- `frpc`.
+- raw `nc` / `ncat` with DB ports.
+- container runtime `--net=host` patterns when the command-rule model can express them.
+
+The design must explicitly state that these command rules are non-exhaustive convenience detection. The direct destination deny remains the security boundary.
+
+## 07b Listener Auth API
+
+Listener auth should depend on an interface so tests do not depend on ptrace internals.
+
+```go
+type SessionResolver interface {
+    ResolveSessionID(pid int32) (sessionID string, ok bool)
+}
+```
+
+Production wires this to the AgentSH ptrace/session registry. Tests use a fake resolver.
+
+Auth behavior:
+
+- SO_PEERCRED failure: close connection and emit `db_listener_auth_fail`.
+- Resolver miss: close connection and emit `db_listener_auth_fail` with `peer_session_id` set to `unknown`.
+- Session mismatch: close connection and emit `db_listener_auth_fail`.
+- Session match: continue to Postgres startup packet handling.
+
+UID may still be recorded in events, but UID equality must not be the authorization boundary in 07b.
+
+## 07b Bypass Events
+
+07b adds a mapper from generic policy denials to DB lifecycle events:
+
+```go
+type BypassAttempt struct {
+    SessionID     string
+    ProcessID     int
+    ProcessIdentity string
+    DBService     string
+    BypassMode    string
+    Destination   string
+    RuleName      string
+    SuppressedCount int
+}
+```
+
+When a deny decision has generated DB metadata, emit `db_bypass_attempt`. If a deny does not have DB metadata, keep the normal deny behavior and do not emit a DB bypass event.
+
+Dedup key:
+
+```text
+(session_id, process_identity, destination_tuple)
+```
+
+The canonical event for a 60-second window carries `suppressed_count`, updated as matching attempts are absorbed. The exact update mechanics can be in-memory for Phase 1.
+
+## 07c Integration Coverage
+
+Plan 07c should use a real Postgres server as the required integration target. Testcontainers are preferred when available in CI; otherwise the tests should be gated with explicit environment variables and skipped with clear messages.
+
+Required flows:
+
+- Simple Query allow path.
+- Simple Query deny pre-forward.
+- Extended Query allow path.
+- Extended Query deny path.
+- In-transaction deny behavior.
+- CancelRequest via Plan 06 mapping.
+- COPY bulk export/load event and redaction behavior.
+- Direct TCP bypass denied.
+- Direct listener cross-session access denied.
+- Full bundle plus proxy plus client smoke test.
+
+Aurora PG, Redshift, and CockroachDB remain best-effort for Phase 1. If no reliable container image exists, Plan 07c should document manual validation rather than blocking the core Postgres gate.
+
+## Error Handling
+
+Fail closed where the boundary would otherwise weaken:
+
+- Invalid `db_services` input: return a structured error and generate no partial bundle.
+- TCP listener in enforce mode: reject with an error referencing spec section 12.5.
+- Session resolver miss or mismatch: close silently at the protocol layer and emit lifecycle event.
+- Missing DB metadata on an ordinary deny: deny normally, no DB bypass event.
+- DNS expansion failure:
+  - `observe`: generate hostname-based denies and return an operational warning.
+  - `enforce`: fail bundle generation unless the caller explicitly opts into hostname-only enforcement.
+
+## Tests
+
+### 07a Unit Tests
+
+- Generates redirect, network, Unix socket, command, and metadata entries for one Postgres service.
+- Handles multiple services without rule-name collisions.
+- Metadata maps back to generated rule names.
+- Rejects unsupported TCP listener in enforce mode.
+- DNS expansion warning/error behavior differs correctly between observe and enforce.
+- Generated policy compiles with `internal/policy.NewEngine`.
+
+### 07b Unit Tests
+
+- Listener accepts matching SessionID.
+- Listener rejects mismatched SessionID.
+- Listener rejects unknown peer pid/session.
+- `db_listener_auth_fail` contains peer pid, uid, peer session when known, and reason.
+- DB-generated network deny maps to `db_bypass_attempt`.
+- Non-DB deny does not emit DB bypass event.
+- Deduper suppresses repeated attempts for 60 seconds and reports `suppressed_count`.
+
+### 07c Integration Tests
+
+- Real Postgres happy path through proxy.
+- Policy deny prevents upstream execution.
+- Extended Query and transaction state paths still work through generated bundle.
+- Cancel mapping still forwards real upstream cancel keys.
+- Direct TCP bypass is blocked.
+- Direct listener cross-session connection is blocked.
+
+## Non-Goals
+
+- No MySQL/MariaDB unavoidability in Phase 1.
+- No TCP listener support in enforce mode.
+- No new DB-specific policy evaluator.
+- No claim for processes outside the AgentSH-governed process tree.
+- No claim when the supervisor or DB proxy is compromised.
+- No exhaustive bypass-tool command list; command rules are detection only.
+
+## Rollout
+
+1. Land 07a with bundle generation and compile-only tests.
+2. Land 07b with SessionID listener auth and bypass-event mapping.
+3. Land 07c with integration tests and documentation updates.
+
+After 07c passes, the roadmap's Plan 07 is complete and DB Access Phase 1 can claim `policies.db.unavoidability: enforce` as the high-assurance default for declared DB services.

--- a/internal/db/service/bundle.go
+++ b/internal/db/service/bundle.go
@@ -130,24 +130,29 @@ func addResolvedIPRules(ctx context.Context, b *Bundle, svc Service, servicePart
 
 	ips, err := opts.Resolver.LookupIP(resolveCtx, svc.Upstream.Host)
 	if err != nil {
-		warning := BundleWarning{
-			Code:    "DNS_EXPANSION_FAILED",
-			Service: svc.Name,
-			Message: "could not resolve " + svc.Upstream.Host + ": " + err.Error(),
-		}
-		b.Warnings = append(b.Warnings, warning)
-		if opts.Mode == UnavoidabilityEnforce && !opts.AllowHostnameOnlyInEnforce {
-			return fmt.Errorf("%w: %s", ErrBundleInvalidOptions, warning.Message)
-		}
-		return nil
+		return addDNSExpansionFailure(b, svc, opts, "could not resolve "+svc.Upstream.Host+": "+err.Error())
 	}
 
-	for _, ip := range ips {
-		if ip == nil {
+	usableIPs := make([]net.IP, 0, len(ips))
+	seenIPs := make(map[string]struct{}, len(ips))
+	for _, resolvedIP := range ips {
+		ip, ipString, ok := normalizedIP(resolvedIP)
+		if !ok {
 			continue
 		}
+		if _, exists := seenIPs[ipString]; exists {
+			continue
+		}
+		seenIPs[ipString] = struct{}{}
+		usableIPs = append(usableIPs, ip)
+	}
+	if len(usableIPs) == 0 {
+		return addDNSExpansionFailure(b, svc, opts, "could not resolve "+svc.Upstream.Host+": no usable IPs returned")
+	}
+
+	for _, ip := range usableIPs {
 		ipString := canonicalIPString(ip)
-		name := "db-" + servicePart + "-deny-ip-" + sanitizeRulePart(ipString)
+		name := "db-" + servicePart + "-deny-ip-" + ipRulePart(ip)
 		destination := net.JoinHostPort(ipString, strconv.Itoa(svc.Upstream.Port))
 		b.Policy.NetworkRules = append(b.Policy.NetworkRules, policy.NetworkRule{
 			Name:        name,
@@ -162,11 +167,44 @@ func addResolvedIPRules(ctx context.Context, b *Bundle, svc Service, servicePart
 	return nil
 }
 
+func addDNSExpansionFailure(b *Bundle, svc Service, opts BundleOptions, message string) error {
+	warning := BundleWarning{
+		Code:    "DNS_EXPANSION_FAILED",
+		Service: svc.Name,
+		Message: message,
+	}
+	b.Warnings = append(b.Warnings, warning)
+	if opts.Mode == UnavoidabilityEnforce && !opts.AllowHostnameOnlyInEnforce {
+		return fmt.Errorf("%w: %s", ErrBundleInvalidOptions, warning.Message)
+	}
+	return nil
+}
+
+func normalizedIP(ip net.IP) (net.IP, string, bool) {
+	if v4 := ip.To4(); v4 != nil {
+		return v4, v4.String(), true
+	}
+	if v16 := ip.To16(); v16 != nil {
+		return v16, v16.String(), true
+	}
+	return nil, "", false
+}
+
 func canonicalIPString(ip net.IP) string {
 	if v4 := ip.To4(); v4 != nil {
 		return v4.String()
 	}
 	return ip.String()
+}
+
+func ipRulePart(ip net.IP) string {
+	if v4 := ip.To4(); v4 != nil {
+		return "v4-" + hex.EncodeToString(v4)
+	}
+	if v16 := ip.To16(); v16 != nil {
+		return "v6-" + hex.EncodeToString(v16)
+	}
+	return "invalid"
 }
 
 func ipCIDR(ip net.IP) string {

--- a/internal/db/service/bundle.go
+++ b/internal/db/service/bundle.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -72,6 +73,9 @@ func GenerateBundle(cfg Config, opts BundleOptions) (Bundle, error) {
 		if err := addResolvedIPRules(context.Background(), &b, svc, serviceParts[i], opts); err != nil {
 			return Bundle{}, err
 		}
+	}
+	if opts.IncludeToolRules {
+		addBypassToolRules(&b, cfg.Services)
 	}
 	b.Policy.Metadata = append([]policy.RuleMetadata(nil), b.Metadata...)
 	return b, nil
@@ -178,6 +182,113 @@ func addDNSExpansionFailure(b *Bundle, svc Service, opts BundleOptions, message 
 		return fmt.Errorf("%w: %s", ErrBundleInvalidOptions, warning.Message)
 	}
 	return nil
+}
+
+func addBypassToolRules(b *Bundle, services []Service) {
+	portPattern := dbPortPattern(services)
+	rules := []policy.CommandRule{
+		{
+			Name:         "db-bypass-ssh-forward",
+			Commands:     []string{"ssh"},
+			ArgsPatterns: []string{"(^|\\s)-L(\\s|[^\\s]*:).*:(" + portPattern + ")(\\s|$)"},
+			Decision:     "deny",
+			Message:      "DB port forwarding is blocked by AgentSH DB unavoidability",
+		},
+		{
+			Name:         "db-bypass-socat",
+			Commands:     []string{"socat"},
+			ArgsPatterns: []string{"(?i)(tcp-listen|listen|tcp:).*(" + portPattern + ")"},
+			Decision:     "deny",
+			Message:      "DB socket forwarding is blocked by AgentSH DB unavoidability",
+		},
+		{
+			Name:         "db-bypass-kubectl-port-forward",
+			Commands:     []string{"kubectl"},
+			ArgsPatterns: []string{"(^|\\s)port-forward(\\s|$).*(:(" + portPattern + ")|\\s(" + portPattern + "):)"},
+			Decision:     "deny",
+			Message:      "DB port forwarding is blocked by AgentSH DB unavoidability",
+		},
+		{
+			Name:         "db-bypass-cloud-sql-proxy",
+			Commands:     []string{"cloud-sql-proxy"},
+			ArgsPatterns: []string{".*"},
+			Decision:     "deny",
+			Message:      "Cloud SQL proxy is blocked by AgentSH DB unavoidability",
+		},
+		{
+			Name:         "db-bypass-gcloud-sql-connect",
+			Commands:     []string{"gcloud"},
+			ArgsPatterns: []string{"(^|\\s)sql\\s+connect(\\s|$)"},
+			Decision:     "deny",
+			Message:      "gcloud SQL connect is blocked by AgentSH DB unavoidability",
+		},
+		{
+			Name:         "db-bypass-aws-rds-connect",
+			Commands:     []string{"aws"},
+			ArgsPatterns: []string{"(^|\\s)rds\\s+connect(\\s|$)"},
+			Decision:     "deny",
+			Message:      "AWS RDS connect is blocked by AgentSH DB unavoidability",
+		},
+		{
+			Name:         "db-bypass-chisel",
+			Commands:     []string{"chisel"},
+			ArgsPatterns: []string{".*"},
+			Decision:     "deny",
+			Message:      "Tunnel tool is blocked by AgentSH DB unavoidability",
+		},
+		{
+			Name:         "db-bypass-gost",
+			Commands:     []string{"gost"},
+			ArgsPatterns: []string{".*"},
+			Decision:     "deny",
+			Message:      "Tunnel tool is blocked by AgentSH DB unavoidability",
+		},
+		{
+			Name:         "db-bypass-frpc",
+			Commands:     []string{"frpc"},
+			ArgsPatterns: []string{".*"},
+			Decision:     "deny",
+			Message:      "Tunnel tool is blocked by AgentSH DB unavoidability",
+		},
+		{
+			Name:         "db-bypass-netcat",
+			Commands:     []string{"nc", "ncat", "netcat"},
+			ArgsPatterns: []string{"(?i)(-l|--listen|(" + portPattern + "))"},
+			Decision:     "deny",
+			Message:      "Raw TCP forwarding is blocked by AgentSH DB unavoidability",
+		},
+		{
+			Name:         "db-bypass-container-net-host",
+			Commands:     []string{"docker", "podman", "nerdctl"},
+			ArgsPatterns: []string{"(^|\\s)(run|create)(\\s|$).*(--net=host|--network=host)"},
+			Decision:     "deny",
+			Message:      "Host-network containers are blocked by AgentSH DB unavoidability",
+		},
+	}
+	for _, r := range rules {
+		r.Description = "Convenience detection for DB proxy bypass attempts; destination egress deny is the security boundary"
+		b.Policy.CommandRules = append(b.Policy.CommandRules, r)
+		addMetadata(b, r.Name, "*", BypassModePortForwardTool, "db-service-ports")
+	}
+}
+
+func dbPortPattern(services []Service) string {
+	seen := map[int]bool{}
+	ports := make([]int, 0, len(services))
+	for _, svc := range services {
+		if seen[svc.Upstream.Port] {
+			continue
+		}
+		seen[svc.Upstream.Port] = true
+		ports = append(ports, svc.Upstream.Port)
+	}
+	sort.Ints(ports)
+
+	parts := make([]string, 0, len(ports))
+	for _, port := range ports {
+		parts = append(parts, strconv.Itoa(port))
+	}
+	return strings.Join(parts, "|")
 }
 
 func normalizedIP(ip net.IP) (net.IP, string, bool) {

--- a/internal/db/service/bundle.go
+++ b/internal/db/service/bundle.go
@@ -186,6 +186,10 @@ func addDNSExpansionFailure(b *Bundle, svc Service, opts BundleOptions, message 
 
 func addBypassToolRules(b *Bundle, services []Service) {
 	portPattern := dbPortPattern(services)
+	if portPattern == "" {
+		return
+	}
+	portTokenPattern := "(^|[^0-9])(" + portPattern + ")([^0-9]|$)"
 	rules := []policy.CommandRule{
 		{
 			Name:         "db-bypass-ssh-forward",
@@ -197,14 +201,14 @@ func addBypassToolRules(b *Bundle, services []Service) {
 		{
 			Name:         "db-bypass-socat",
 			Commands:     []string{"socat"},
-			ArgsPatterns: []string{"(?i)(tcp-listen|listen|tcp:).*(" + portPattern + ")"},
+			ArgsPatterns: []string{"(?i)(tcp-listen|listen|tcp:).*" + portTokenPattern},
 			Decision:     "deny",
 			Message:      "DB socket forwarding is blocked by AgentSH DB unavoidability",
 		},
 		{
 			Name:         "db-bypass-kubectl-port-forward",
 			Commands:     []string{"kubectl"},
-			ArgsPatterns: []string{"(^|\\s)port-forward(\\s|$).*(:(" + portPattern + ")|\\s(" + portPattern + "):)"},
+			ArgsPatterns: []string{"(^|\\s)port-forward(\\s|$).*(:(" + portPattern + ")([^0-9]|$)|\\s(" + portPattern + "):)"},
 			Decision:     "deny",
 			Message:      "DB port forwarding is blocked by AgentSH DB unavoidability",
 		},
@@ -253,7 +257,7 @@ func addBypassToolRules(b *Bundle, services []Service) {
 		{
 			Name:         "db-bypass-netcat",
 			Commands:     []string{"nc", "ncat", "netcat"},
-			ArgsPatterns: []string{"(?i)(-l|--listen|(" + portPattern + "))"},
+			ArgsPatterns: []string{"(?i)(-l|--listen|" + portTokenPattern + ")"},
 			Decision:     "deny",
 			Message:      "Raw TCP forwarding is blocked by AgentSH DB unavoidability",
 		},

--- a/internal/db/service/bundle.go
+++ b/internal/db/service/bundle.go
@@ -57,6 +57,9 @@ type Bundle struct {
 }
 
 func GenerateBundle(cfg Config, opts BundleOptions) (Bundle, error) {
+	if err := cfg.validate(); err != nil {
+		return Bundle{}, fmt.Errorf("%w: %v", ErrBundleInvalidOptions, err)
+	}
 	if err := validateBundleOptions(cfg, opts); err != nil {
 		return Bundle{}, err
 	}
@@ -122,11 +125,11 @@ func addCoreServiceRules(b *Bundle, svc Service, servicePart string) {
 }
 
 func addResolvedIPRules(ctx context.Context, b *Bundle, svc Service, servicePart string, opts BundleOptions) error {
-	if opts.Resolver == nil {
-		return nil
-	}
 	if net.ParseIP(svc.Upstream.Host) != nil {
 		return nil
+	}
+	if opts.Resolver == nil {
+		return addDNSExpansionFailure(b, svc, opts, "could not resolve "+svc.Upstream.Host+": no resolver configured")
 	}
 
 	resolveCtx, cancel := context.WithTimeout(ctx, dnsResolutionTimeout)

--- a/internal/db/service/bundle.go
+++ b/internal/db/service/bundle.go
@@ -1,0 +1,113 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+const (
+	RuleSourceDBUnavoidability = "db_unavoidability"
+
+	BypassModeTCPDirect       = "tcp_direct"
+	BypassModeUnixSocket      = "unix_socket"
+	BypassModePortForwardTool = "port_forward_tool"
+	BypassModeDNSAlias        = "dns_alias"
+	BypassModeCustomTunnel    = "custom_tunnel"
+)
+
+var ErrBundleInvalidOptions = errors.New("db unavoidability bundle invalid options")
+
+type IPResolver interface {
+	LookupIP(ctx context.Context, host string) ([]net.IP, error)
+}
+
+type BundleOptions struct {
+	SessionID                  string
+	ProxySessionID             string
+	SocketBaseDir              string
+	IncludeToolRules           bool
+	Mode                       Unavoidability
+	AllowHostnameOnlyInEnforce bool
+	Resolver                   IPResolver
+}
+
+type BundleWarning struct {
+	Code    string
+	Service string
+	Message string
+}
+
+type Bundle struct {
+	Policy   policy.Policy
+	Metadata []policy.RuleMetadata
+	Warnings []BundleWarning
+}
+
+func GenerateBundle(cfg Config, opts BundleOptions) (Bundle, error) {
+	if err := validateBundleOptions(cfg, opts); err != nil {
+		return Bundle{}, err
+	}
+	return Bundle{
+		Policy: policy.Policy{
+			Version:     1,
+			Name:        "db-unavoidability-" + sanitizeRulePart(opts.SessionID),
+			Description: "Generated DB unavoidability bundle for AgentSH session " + opts.SessionID,
+		},
+	}, nil
+}
+
+func validateBundleOptions(cfg Config, opts BundleOptions) error {
+	if opts.SessionID == "" {
+		return fmt.Errorf("%w: SessionID is required", ErrBundleInvalidOptions)
+	}
+	if opts.ProxySessionID == "" {
+		return fmt.Errorf("%w: ProxySessionID is required", ErrBundleInvalidOptions)
+	}
+	if opts.Mode != UnavoidabilityObserve && opts.Mode != UnavoidabilityEnforce {
+		return fmt.Errorf("%w: Mode must be observe or enforce", ErrBundleInvalidOptions)
+	}
+	for i, svc := range cfg.Services {
+		if svc.Listen.Kind == "tcp" && opts.Mode == UnavoidabilityEnforce {
+			return fmt.Errorf("services[%d] %s: tcp listeners are not supported for DB enforce mode in spec section 12.5", i, svc.Name)
+		}
+	}
+	return nil
+}
+
+func sanitizeRulePart(s string) string {
+	if s == "" {
+		return "empty"
+	}
+	out := make([]byte, 0, len(s))
+	lastDash := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+			out = append(out, c)
+			lastDash = false
+		case c >= 'A' && c <= 'Z':
+			out = append(out, c+'a'-'A')
+			lastDash = false
+		case c >= '0' && c <= '9':
+			out = append(out, c)
+			lastDash = false
+		default:
+			if !lastDash {
+				out = append(out, '-')
+				lastDash = true
+			}
+		}
+	}
+	for len(out) > 0 && out[len(out)-1] == '-' {
+		out = out[:len(out)-1]
+	}
+	if len(out) == 0 {
+		return "empty"
+	}
+	return string(out)
+}

--- a/internal/db/service/bundle.go
+++ b/internal/db/service/bundle.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
@@ -61,18 +63,18 @@ func GenerateBundle(cfg Config, opts BundleOptions) (Bundle, error) {
 			Description: "Generated DB unavoidability bundle for AgentSH session " + opts.SessionID,
 		},
 	}
-	for _, svc := range cfg.Services {
-		addCoreServiceRules(&b, svc)
+	serviceParts := serviceRuleParts(cfg.Services)
+	for i, svc := range cfg.Services {
+		addCoreServiceRules(&b, svc, serviceParts[i])
 	}
 	b.Policy.Metadata = append([]policy.RuleMetadata(nil), b.Metadata...)
 	return b, nil
 }
 
-func addCoreServiceRules(b *Bundle, svc Service) {
-	servicePart := sanitizeRulePart(svc.Name)
+func addCoreServiceRules(b *Bundle, svc Service, servicePart string) {
 	destination := serviceDestination(svc)
 	redirectName := "db-" + servicePart + "-redirect"
-	networkName := "db-" + servicePart + "-deny-direct"
+	networkName := "db-" + servicePart + "-allow-redirect"
 	unixName := "db-" + servicePart + "-deny-local-postgres-sockets"
 
 	b.Policy.ConnectRedirectRules = append(b.Policy.ConnectRedirectRules, policy.ConnectRedirectRule{
@@ -87,11 +89,11 @@ func addCoreServiceRules(b *Bundle, svc Service) {
 
 	b.Policy.NetworkRules = append(b.Policy.NetworkRules, policy.NetworkRule{
 		Name:        networkName,
-		Description: "Deny direct DB egress; traffic must use AgentSH DB proxy",
+		Description: "Allow DB destination precheck so connect redirect can reach AgentSH DB proxy",
 		Domains:     []string{strings.ToLower(svc.Upstream.Host)},
 		Ports:       []int{svc.Upstream.Port},
-		Decision:    "deny",
-		Message:     "Direct database egress is blocked; use the AgentSH DB proxy",
+		Decision:    "allow",
+		Message:     "Database traffic is routed through the AgentSH DB proxy",
 	})
 	addMetadata(b, networkName, svc.Name, BypassModeTCPDirect, destination)
 
@@ -121,6 +123,31 @@ func addMetadata(b *Bundle, ruleName, serviceName, bypassMode, destination strin
 
 func serviceDestination(svc Service) string {
 	return net.JoinHostPort(strings.ToLower(svc.Upstream.Host), strconv.Itoa(svc.Upstream.Port))
+}
+
+func serviceRuleParts(services []Service) []string {
+	bases := make([]string, len(services))
+	counts := make(map[string]int, len(services))
+	for i, svc := range services {
+		base := sanitizeRulePart(svc.Name)
+		bases[i] = base
+		counts[base]++
+	}
+
+	parts := make([]string, len(services))
+	for i, svc := range services {
+		part := bases[i]
+		if counts[part] > 1 {
+			part += "-" + ruleNameHash(svc.Name)
+		}
+		parts[i] = part
+	}
+	return parts
+}
+
+func ruleNameHash(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])[:8]
 }
 
 func validateBundleOptions(cfg Config, opts BundleOptions) error {

--- a/internal/db/service/bundle.go
+++ b/internal/db/service/bundle.go
@@ -74,7 +74,7 @@ func GenerateBundle(cfg Config, opts BundleOptions) (Bundle, error) {
 func addCoreServiceRules(b *Bundle, svc Service, servicePart string) {
 	destination := serviceDestination(svc)
 	redirectName := "db-" + servicePart + "-redirect"
-	networkName := "db-" + servicePart + "-allow-redirect"
+	networkName := "db-" + servicePart + "-deny-direct"
 	unixName := "db-" + servicePart + "-deny-local-postgres-sockets"
 
 	b.Policy.ConnectRedirectRules = append(b.Policy.ConnectRedirectRules, policy.ConnectRedirectRule{
@@ -89,11 +89,11 @@ func addCoreServiceRules(b *Bundle, svc Service, servicePart string) {
 
 	b.Policy.NetworkRules = append(b.Policy.NetworkRules, policy.NetworkRule{
 		Name:        networkName,
-		Description: "Allow DB destination precheck so connect redirect can reach AgentSH DB proxy",
+		Description: "Deny direct DB egress; traffic must use AgentSH DB proxy",
 		Domains:     []string{strings.ToLower(svc.Upstream.Host)},
 		Ports:       []int{svc.Upstream.Port},
-		Decision:    "allow",
-		Message:     "Database traffic is routed through the AgentSH DB proxy",
+		Decision:    "deny",
+		Message:     "Direct database egress is blocked; use the AgentSH DB proxy",
 	})
 	addMetadata(b, networkName, svc.Name, BypassModeTCPDirect, destination)
 

--- a/internal/db/service/bundle.go
+++ b/internal/db/service/bundle.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/agentsh/agentsh/internal/policy"
 )
@@ -23,6 +24,8 @@ const (
 	BypassModeDNSAlias        = "dns_alias"
 	BypassModeCustomTunnel    = "custom_tunnel"
 )
+
+const dnsResolutionTimeout = 2 * time.Second
 
 var ErrBundleInvalidOptions = errors.New("db unavoidability bundle invalid options")
 
@@ -66,6 +69,9 @@ func GenerateBundle(cfg Config, opts BundleOptions) (Bundle, error) {
 	serviceParts := serviceRuleParts(cfg.Services)
 	for i, svc := range cfg.Services {
 		addCoreServiceRules(&b, svc, serviceParts[i])
+		if err := addResolvedIPRules(context.Background(), &b, svc, serviceParts[i], opts); err != nil {
+			return Bundle{}, err
+		}
 	}
 	b.Policy.Metadata = append([]policy.RuleMetadata(nil), b.Metadata...)
 	return b, nil
@@ -109,6 +115,65 @@ func addCoreServiceRules(b *Bundle, svc Service, servicePart string) {
 		Message:    "Direct local database socket access is blocked; use the AgentSH DB proxy",
 	})
 	addMetadata(b, unixName, svc.Name, BypassModeUnixSocket, "postgres-local-sockets")
+}
+
+func addResolvedIPRules(ctx context.Context, b *Bundle, svc Service, servicePart string, opts BundleOptions) error {
+	if opts.Resolver == nil {
+		return nil
+	}
+	if net.ParseIP(svc.Upstream.Host) != nil {
+		return nil
+	}
+
+	resolveCtx, cancel := context.WithTimeout(ctx, dnsResolutionTimeout)
+	defer cancel()
+
+	ips, err := opts.Resolver.LookupIP(resolveCtx, svc.Upstream.Host)
+	if err != nil {
+		warning := BundleWarning{
+			Code:    "DNS_EXPANSION_FAILED",
+			Service: svc.Name,
+			Message: "could not resolve " + svc.Upstream.Host + ": " + err.Error(),
+		}
+		b.Warnings = append(b.Warnings, warning)
+		if opts.Mode == UnavoidabilityEnforce && !opts.AllowHostnameOnlyInEnforce {
+			return fmt.Errorf("%w: %s", ErrBundleInvalidOptions, warning.Message)
+		}
+		return nil
+	}
+
+	for _, ip := range ips {
+		if ip == nil {
+			continue
+		}
+		ipString := canonicalIPString(ip)
+		name := "db-" + servicePart + "-deny-ip-" + sanitizeRulePart(ipString)
+		destination := net.JoinHostPort(ipString, strconv.Itoa(svc.Upstream.Port))
+		b.Policy.NetworkRules = append(b.Policy.NetworkRules, policy.NetworkRule{
+			Name:        name,
+			Description: "Deny direct DB egress to resolved upstream IP",
+			CIDRs:       []string{ipCIDR(ip)},
+			Ports:       []int{svc.Upstream.Port},
+			Decision:    "deny",
+			Message:     "Direct database egress is blocked; use the AgentSH DB proxy",
+		})
+		addMetadata(b, name, svc.Name, BypassModeDNSAlias, destination)
+	}
+	return nil
+}
+
+func canonicalIPString(ip net.IP) string {
+	if v4 := ip.To4(); v4 != nil {
+		return v4.String()
+	}
+	return ip.String()
+}
+
+func ipCIDR(ip net.IP) string {
+	if v4 := ip.To4(); v4 != nil {
+		return v4.String() + "/32"
+	}
+	return ip.String() + "/128"
 }
 
 func addMetadata(b *Bundle, ruleName, serviceName, bypassMode, destination string) {

--- a/internal/db/service/bundle.go
+++ b/internal/db/service/bundle.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"regexp"
+	"strconv"
+	"strings"
 
 	"github.com/agentsh/agentsh/internal/policy"
 )
@@ -51,13 +54,73 @@ func GenerateBundle(cfg Config, opts BundleOptions) (Bundle, error) {
 	if err := validateBundleOptions(cfg, opts); err != nil {
 		return Bundle{}, err
 	}
-	return Bundle{
+	b := Bundle{
 		Policy: policy.Policy{
 			Version:     1,
 			Name:        "db-unavoidability-" + sanitizeRulePart(opts.SessionID),
 			Description: "Generated DB unavoidability bundle for AgentSH session " + opts.SessionID,
 		},
-	}, nil
+	}
+	for _, svc := range cfg.Services {
+		addCoreServiceRules(&b, svc)
+	}
+	b.Policy.Metadata = append([]policy.RuleMetadata(nil), b.Metadata...)
+	return b, nil
+}
+
+func addCoreServiceRules(b *Bundle, svc Service) {
+	servicePart := sanitizeRulePart(svc.Name)
+	destination := serviceDestination(svc)
+	redirectName := "db-" + servicePart + "-redirect"
+	networkName := "db-" + servicePart + "-deny-direct"
+	unixName := "db-" + servicePart + "-deny-local-postgres-sockets"
+
+	b.Policy.ConnectRedirectRules = append(b.Policy.ConnectRedirectRules, policy.ConnectRedirectRule{
+		Name:           redirectName,
+		Match:          "^" + regexp.QuoteMeta(destination) + "$",
+		RedirectToUnix: svc.Listen.Path,
+		Visibility:     "audit_only",
+		OnFailure:      "fail_closed",
+		Message:        "Routed through AgentSH DB proxy",
+	})
+	addMetadata(b, redirectName, svc.Name, BypassModeTCPDirect, destination)
+
+	b.Policy.NetworkRules = append(b.Policy.NetworkRules, policy.NetworkRule{
+		Name:        networkName,
+		Description: "Deny direct DB egress; traffic must use AgentSH DB proxy",
+		Domains:     []string{strings.ToLower(svc.Upstream.Host)},
+		Ports:       []int{svc.Upstream.Port},
+		Decision:    "deny",
+		Message:     "Direct database egress is blocked; use the AgentSH DB proxy",
+	})
+	addMetadata(b, networkName, svc.Name, BypassModeTCPDirect, destination)
+
+	b.Policy.UnixRules = append(b.Policy.UnixRules, policy.UnixSocketRule{
+		Name:        unixName,
+		Description: "Deny direct local Postgres Unix socket access for DB unavoidability",
+		Paths: []string{
+			"/var/run/postgresql/.s.PGSQL.*",
+			"/tmp/.s.PGSQL.*",
+		},
+		Operations: []string{"connect"},
+		Decision:   "deny",
+		Message:    "Direct local database socket access is blocked; use the AgentSH DB proxy",
+	})
+	addMetadata(b, unixName, svc.Name, BypassModeUnixSocket, "postgres-local-sockets")
+}
+
+func addMetadata(b *Bundle, ruleName, serviceName, bypassMode, destination string) {
+	b.Metadata = append(b.Metadata, policy.RuleMetadata{
+		RuleName:    ruleName,
+		Source:      RuleSourceDBUnavoidability,
+		DBService:   serviceName,
+		BypassMode:  bypassMode,
+		Destination: destination,
+	})
+}
+
+func serviceDestination(svc Service) string {
+	return net.JoinHostPort(strings.ToLower(svc.Upstream.Host), strconv.Itoa(svc.Upstream.Port))
 }
 
 func validateBundleOptions(cfg Config, opts BundleOptions) error {

--- a/internal/db/service/bundle_test.go
+++ b/internal/db/service/bundle_test.go
@@ -483,6 +483,24 @@ func TestGenerateBundle_BypassToolRulesOptional(t *testing.T) {
 	}
 }
 
+func TestGenerateBundle_BypassToolRulesSkippedWithoutServices(t *testing.T) {
+	b, err := GenerateBundle(Config{}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+	if len(b.Policy.CommandRules) != 0 {
+		t.Fatalf("command rules = %+v, want none without DB service ports", b.Policy.CommandRules)
+	}
+	if len(b.Metadata) != 0 || len(b.Policy.Metadata) != 0 {
+		t.Fatalf("metadata = %+v policy metadata = %+v, want none without DB service ports", b.Metadata, b.Policy.Metadata)
+	}
+}
+
 func TestGenerateBundle_BypassToolPortPatternsAreDeterministic(t *testing.T) {
 	services := []Service{
 		validBundleService(t, "analytics"),
@@ -514,11 +532,12 @@ func TestGenerateBundle_BypassToolPortPatternsAreDeterministic(t *testing.T) {
 		t.Fatalf("GenerateBundle second: %v", err)
 	}
 
+	ports := "5432|15432"
 	wantPatterns := map[string]string{
-		"db-bypass-ssh-forward":          "(^|\\s)-L(\\s|[^\\s]*:).*:(5432|15432)(\\s|$)",
-		"db-bypass-socat":                "(?i)(tcp-listen|listen|tcp:).*(5432|15432)",
-		"db-bypass-kubectl-port-forward": "(^|\\s)port-forward(\\s|$).*(:(5432|15432)|\\s(5432|15432):)",
-		"db-bypass-netcat":               "(?i)(-l|--listen|(5432|15432))",
+		"db-bypass-ssh-forward":          "(^|\\s)-L(\\s|[^\\s]*:).*:(" + ports + ")(\\s|$)",
+		"db-bypass-socat":                "(?i)(tcp-listen|listen|tcp:).*(^|[^0-9])(" + ports + ")([^0-9]|$)",
+		"db-bypass-kubectl-port-forward": "(^|\\s)port-forward(\\s|$).*(:(" + ports + ")([^0-9]|$)|\\s(" + ports + "):)",
+		"db-bypass-netcat":               "(?i)(-l|--listen|(^|[^0-9])(" + ports + ")([^0-9]|$))",
 	}
 	for ruleName, wantPattern := range wantPatterns {
 		firstRule := commandRuleByName(t, first.Policy.CommandRules, ruleName)
@@ -529,6 +548,55 @@ func TestGenerateBundle_BypassToolPortPatternsAreDeterministic(t *testing.T) {
 		if len(firstRule.ArgsPatterns) != 1 || firstRule.ArgsPatterns[0] != wantPattern {
 			t.Fatalf("command rule %q patterns = %+v, want [%q]", ruleName, firstRule.ArgsPatterns, wantPattern)
 		}
+	}
+}
+
+func TestGenerateBundle_BypassToolRulesDoNotMatchAdjacentDigitPorts(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+	engine, err := policy.NewEngine(&b.Policy, false, true)
+	if err != nil {
+		t.Fatalf("policy.NewEngine: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name       string
+		command    string
+		args       []string
+		bypassRule string
+	}{
+		{
+			name:       "socat adjacent destination port",
+			command:    "socat",
+			args:       []string{"TCP-LISTEN:15432,fork", "TCP:db.internal:54320"},
+			bypassRule: "db-bypass-socat",
+		},
+		{
+			name:       "kubectl adjacent destination port",
+			command:    "kubectl",
+			args:       []string{"port-forward", "svc/postgres", "15432:54320"},
+			bypassRule: "db-bypass-kubectl-port-forward",
+		},
+		{
+			name:       "netcat adjacent destination port",
+			command:    "nc",
+			args:       []string{"db.internal", "54320"},
+			bypassRule: "db-bypass-netcat",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dec := engine.CheckCommand(tc.command, tc.args)
+			if dec.Rule == tc.bypassRule {
+				t.Fatalf("CheckCommand(%q, %+v) matched %q for adjacent digits", tc.command, tc.args, tc.bypassRule)
+			}
+		})
 	}
 }
 
@@ -560,6 +628,12 @@ func TestGenerateBundle_BypassToolRulesCompileAndMatch(t *testing.T) {
 			wantRule: "db-bypass-ssh-forward",
 		},
 		{
+			name:     "socat exact db port",
+			command:  "socat",
+			args:     []string{"TCP-LISTEN:15432,fork", "TCP:db.internal:5432"},
+			wantRule: "db-bypass-socat",
+		},
+		{
 			name:     "kubectl port forward",
 			command:  "kubectl",
 			args:     []string{"port-forward", "svc/postgres", "15432:5432"},
@@ -582,6 +656,12 @@ func TestGenerateBundle_BypassToolRulesCompileAndMatch(t *testing.T) {
 			command:  "aws",
 			args:     []string{"rds", "connect", "--db-instance-identifier", "appdb"},
 			wantRule: "db-bypass-aws-rds-connect",
+		},
+		{
+			name:     "netcat exact db port",
+			command:  "nc",
+			args:     []string{"db.internal", "5432"},
+			wantRule: "db-bypass-netcat",
 		},
 		{
 			name:     "host network container",

--- a/internal/db/service/bundle_test.go
+++ b/internal/db/service/bundle_test.go
@@ -64,7 +64,7 @@ func TestGenerateBundle_SingleServiceCoreRules(t *testing.T) {
 		t.Fatalf("network rules = %d, want 1", len(b.Policy.NetworkRules))
 	}
 	netRule := b.Policy.NetworkRules[0]
-	if netRule.Name != "db-appdb-allow-redirect" {
+	if netRule.Name != "db-appdb-deny-direct" {
 		t.Fatalf("network rule name = %q", netRule.Name)
 	}
 	if len(netRule.Domains) != 1 || netRule.Domains[0] != "db.internal" {
@@ -73,7 +73,7 @@ func TestGenerateBundle_SingleServiceCoreRules(t *testing.T) {
 	if len(netRule.Ports) != 1 || netRule.Ports[0] != 5432 {
 		t.Fatalf("network ports = %+v", netRule.Ports)
 	}
-	if netRule.Decision != "allow" {
+	if netRule.Decision != "deny" {
 		t.Fatalf("network decision = %q", netRule.Decision)
 	}
 
@@ -88,7 +88,7 @@ func TestGenerateBundle_SingleServiceCoreRules(t *testing.T) {
 		t.Fatalf("Bundle.Metadata length = %d, Policy.Metadata length = %d", len(b.Metadata), len(b.Policy.Metadata))
 	}
 	assertMetadata(t, b.Metadata, "db-appdb-redirect", "appdb", BypassModeTCPDirect, "db.internal:5432")
-	assertMetadata(t, b.Metadata, "db-appdb-allow-redirect", "appdb", BypassModeTCPDirect, "db.internal:5432")
+	assertMetadata(t, b.Metadata, "db-appdb-deny-direct", "appdb", BypassModeTCPDirect, "db.internal:5432")
 	assertMetadata(t, b.Metadata, "db-appdb-deny-local-postgres-sockets", "appdb", BypassModeUnixSocket, "postgres-local-sockets")
 }
 
@@ -119,8 +119,8 @@ func TestGenerateBundle_MultipleServicesHaveStableNames(t *testing.T) {
 	for _, name := range []string{
 		"db-appdb-redirect",
 		"db-warehouse-db-redirect",
-		"db-appdb-allow-redirect",
-		"db-warehouse-db-allow-redirect",
+		"db-appdb-deny-direct",
+		"db-warehouse-db-deny-direct",
 	} {
 		if !seen[name] {
 			t.Fatalf("missing metadata for %q in %+v", name, b.Metadata)
@@ -128,7 +128,7 @@ func TestGenerateBundle_MultipleServicesHaveStableNames(t *testing.T) {
 	}
 }
 
-func TestGenerateBundle_RedirectTargetAllowedByNetworkPolicy(t *testing.T) {
+func TestGenerateBundle_RedirectTargetDeniedByNetworkPolicy(t *testing.T) {
 	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
 		SessionID:        "sess-1",
 		ProxySessionID:   "db-proxy-sess",
@@ -148,8 +148,8 @@ func TestGenerateBundle_RedirectTargetAllowedByNetworkPolicy(t *testing.T) {
 		t.Fatalf("EvaluateConnectRedirect = %+v", redirect)
 	}
 	network := engine.CheckNetwork("db.internal", 5432)
-	if string(network.EffectiveDecision) != "allow" {
-		t.Fatalf("CheckNetwork decision = %+v, want allow so CONNECT can dial redirected unix target", network)
+	if string(network.EffectiveDecision) != "deny" {
+		t.Fatalf("CheckNetwork decision = %+v, want deny for direct DB egress", network)
 	}
 }
 

--- a/internal/db/service/bundle_test.go
+++ b/internal/db/service/bundle_test.go
@@ -1,8 +1,11 @@
 package service
 
 import (
+	"context"
 	"errors"
+	"net"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -186,6 +189,133 @@ func TestGenerateBundle_CollidingSanitizedServiceNamesAreUnique(t *testing.T) {
 	}
 }
 
+func TestGenerateBundle_AddsResolvedIPDenies(t *testing.T) {
+	resolver := &fakeIPResolver{ips: []net.IP{
+		net.ParseIP("10.0.0.15"),
+		net.ParseIP("2001:db8::15"),
+	}}
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+		Resolver:         resolver,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+	if len(resolver.calls) != 1 || resolver.calls[0] != "db.internal" {
+		t.Fatalf("resolver calls = %+v, want [db.internal]", resolver.calls)
+	}
+	if !resolver.sawDeadline {
+		t.Fatal("resolver context had no deadline")
+	}
+
+	assertNetworkRule(t, b.Policy.NetworkRules, "db-appdb-deny-ip-10-0-0-15", "10.0.0.15/32", 5432)
+	assertNetworkRule(t, b.Policy.NetworkRules, "db-appdb-deny-ip-2001-db8-15", "2001:db8::15/128", 5432)
+	assertMetadata(t, b.Metadata, "db-appdb-deny-ip-10-0-0-15", "appdb", BypassModeDNSAlias, "10.0.0.15:5432")
+	assertMetadata(t, b.Metadata, "db-appdb-deny-ip-2001-db8-15", "appdb", BypassModeDNSAlias, "[2001:db8::15]:5432")
+}
+
+func TestGenerateBundle_SkipsDNSExpansionForIPLiteralUpstream(t *testing.T) {
+	resolver := &fakeIPResolver{ips: []net.IP{net.ParseIP("10.0.0.15")}}
+	svc := validBundleService(t, "appdb")
+	svc.Upstream.Host = "10.0.0.20"
+
+	b, err := GenerateBundle(Config{Services: []Service{svc}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+		Resolver:         resolver,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+	if len(resolver.calls) != 0 {
+		t.Fatalf("resolver calls = %+v, want none", resolver.calls)
+	}
+	if len(b.Policy.NetworkRules) != 1 {
+		t.Fatalf("network rules = %d, want only core direct deny", len(b.Policy.NetworkRules))
+	}
+}
+
+func TestGenerateBundle_DNSFailureObserveWarns(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityObserve,
+		IncludeToolRules: false,
+		Resolver:         &fakeIPResolver{err: errors.New("dns unavailable")},
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+	assertDNSExpansionWarning(t, b.Warnings, "appdb", "db.internal")
+}
+
+func TestGenerateBundle_DNSFailureEnforceFailsUnlessAllowed(t *testing.T) {
+	_, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+		Resolver:         &fakeIPResolver{err: errors.New("dns unavailable")},
+	})
+	if err == nil {
+		t.Fatal("GenerateBundle returned nil error")
+	}
+
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		IncludeToolRules:           false,
+		AllowHostnameOnlyInEnforce: true,
+		Resolver:                   &fakeIPResolver{err: errors.New("dns unavailable")},
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle with hostname-only override: %v", err)
+	}
+	assertDNSExpansionWarning(t, b.Warnings, "appdb", "db.internal")
+}
+
+func TestGenerateBundle_ResolvedIPRuleNamesUseCollisionResistantServiceParts(t *testing.T) {
+	services := []Service{
+		validBundleService(t, "app_db"),
+		validBundleService(t, "app-db"),
+		validBundleService(t, "app/db"),
+	}
+	for i := range services {
+		services[i].Listen.Path = filepath.Join(t.TempDir(), "db", services[i].Name+".sock")
+		services[i].Upstream.Port = 5432 + i
+	}
+
+	b, err := GenerateBundle(Config{Services: services}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+		Resolver:         &fakeIPResolver{ips: []net.IP{net.ParseIP("10.0.0.15")}},
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+
+	for _, svc := range services {
+		ruleName := "db-app-db-" + ruleNameHash(svc.Name) + "-deny-ip-10-0-0-15"
+		destination := net.JoinHostPort("10.0.0.15", strconv.Itoa(svc.Upstream.Port))
+		assertMetadata(t, b.Metadata, ruleName, svc.Name, BypassModeDNSAlias, destination)
+	}
+	seen := map[string]bool{}
+	for _, m := range b.Metadata {
+		if seen[m.RuleName] {
+			t.Fatalf("duplicate metadata rule name %q in %+v", m.RuleName, b.Metadata)
+		}
+		seen[m.RuleName] = true
+	}
+}
+
 func TestGenerateBundle_PolicyCompiles(t *testing.T) {
 	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
 		SessionID:        "sess-1",
@@ -204,6 +334,21 @@ func TestGenerateBundle_PolicyCompiles(t *testing.T) {
 	}
 }
 
+type fakeIPResolver struct {
+	ips         []net.IP
+	err         error
+	calls       []string
+	sawDeadline bool
+}
+
+func (f *fakeIPResolver) LookupIP(ctx context.Context, host string) ([]net.IP, error) {
+	f.calls = append(f.calls, host)
+	if _, ok := ctx.Deadline(); ok {
+		f.sawDeadline = true
+	}
+	return f.ips, f.err
+}
+
 func assertMetadata(t *testing.T, got []policy.RuleMetadata, ruleName, service, mode, destination string) {
 	t.Helper()
 	for _, m := range got {
@@ -215,6 +360,42 @@ func assertMetadata(t *testing.T, got []policy.RuleMetadata, ruleName, service, 
 		}
 	}
 	t.Fatalf("missing metadata for rule %q in %+v", ruleName, got)
+}
+
+func assertNetworkRule(t *testing.T, got []policy.NetworkRule, name, cidr string, port int) {
+	t.Helper()
+	for _, rule := range got {
+		if rule.Name != name {
+			continue
+		}
+		if len(rule.CIDRs) != 1 || rule.CIDRs[0] != cidr {
+			t.Fatalf("network rule %q CIDRs = %+v, want [%s]", name, rule.CIDRs, cidr)
+		}
+		if len(rule.Ports) != 1 || rule.Ports[0] != port {
+			t.Fatalf("network rule %q ports = %+v, want [%d]", name, rule.Ports, port)
+		}
+		if rule.Decision != "deny" {
+			t.Fatalf("network rule %q decision = %q, want deny", name, rule.Decision)
+		}
+		return
+	}
+	t.Fatalf("missing network rule %q in %+v", name, got)
+}
+
+func assertDNSExpansionWarning(t *testing.T, got []BundleWarning, service, host string) {
+	t.Helper()
+	if len(got) != 1 {
+		t.Fatalf("warnings = %+v, want one warning", got)
+	}
+	if got[0].Code != "DNS_EXPANSION_FAILED" {
+		t.Fatalf("warning code = %q, want DNS_EXPANSION_FAILED", got[0].Code)
+	}
+	if got[0].Service != service {
+		t.Fatalf("warning service = %q, want %q", got[0].Service, service)
+	}
+	if !strings.Contains(got[0].Message, host) {
+		t.Fatalf("warning message = %q, want host %q", got[0].Message, host)
+	}
 }
 
 func validBundleService(t *testing.T, name string) Service {

--- a/internal/db/service/bundle_test.go
+++ b/internal/db/service/bundle_test.go
@@ -38,12 +38,31 @@ func TestGenerateBundle_RejectsTCPListenerInEnforce(t *testing.T) {
 	}
 }
 
+func TestGenerateBundle_RejectsInvalidServiceConfig(t *testing.T) {
+	svc := validBundleService(t, "appdb")
+	svc.Listen.Path = ""
+
+	_, err := GenerateBundle(Config{Services: []Service{svc}}, BundleOptions{
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		AllowHostnameOnlyInEnforce: true,
+	})
+	if !errors.Is(err, ErrBundleInvalidOptions) {
+		t.Fatalf("GenerateBundle err = %v, want ErrBundleInvalidOptions", err)
+	}
+	if !strings.Contains(err.Error(), "listen.path") {
+		t.Fatalf("error = %v, want listen.path context", err)
+	}
+}
+
 func TestGenerateBundle_SingleServiceCoreRules(t *testing.T) {
 	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
-		SessionID:        "sess-1",
-		ProxySessionID:   "db-proxy-sess",
-		Mode:             UnavoidabilityEnforce,
-		IncludeToolRules: false,
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		IncludeToolRules:           false,
+		AllowHostnameOnlyInEnforce: true,
 	})
 	if err != nil {
 		t.Fatalf("GenerateBundle: %v", err)
@@ -103,10 +122,11 @@ func TestGenerateBundle_MultipleServicesHaveStableNames(t *testing.T) {
 	warehouse.Listen.Path = filepath.Join(t.TempDir(), "db", "warehouse.sock")
 
 	b, err := GenerateBundle(Config{Services: []Service{app, warehouse}}, BundleOptions{
-		SessionID:        "sess-1",
-		ProxySessionID:   "db-proxy-sess",
-		Mode:             UnavoidabilityEnforce,
-		IncludeToolRules: false,
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		IncludeToolRules:           false,
+		AllowHostnameOnlyInEnforce: true,
 	})
 	if err != nil {
 		t.Fatalf("GenerateBundle: %v", err)
@@ -133,10 +153,11 @@ func TestGenerateBundle_MultipleServicesHaveStableNames(t *testing.T) {
 
 func TestGenerateBundle_RedirectTargetDeniedByNetworkPolicy(t *testing.T) {
 	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
-		SessionID:        "sess-1",
-		ProxySessionID:   "db-proxy-sess",
-		Mode:             UnavoidabilityEnforce,
-		IncludeToolRules: false,
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		IncludeToolRules:           false,
+		AllowHostnameOnlyInEnforce: true,
 	})
 	if err != nil {
 		t.Fatalf("GenerateBundle: %v", err)
@@ -168,10 +189,11 @@ func TestGenerateBundle_CollidingSanitizedServiceNamesAreUnique(t *testing.T) {
 	}
 
 	b, err := GenerateBundle(Config{Services: services}, BundleOptions{
-		SessionID:        "sess-1",
-		ProxySessionID:   "db-proxy-sess",
-		Mode:             UnavoidabilityEnforce,
-		IncludeToolRules: false,
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		IncludeToolRules:           false,
+		AllowHostnameOnlyInEnforce: true,
 	})
 	if err != nil {
 		t.Fatalf("GenerateBundle: %v", err)
@@ -323,6 +345,33 @@ func TestGenerateBundle_DNSFailureEnforceFailsUnlessAllowed(t *testing.T) {
 	assertDNSExpansionWarning(t, b.Warnings, "appdb", "db.internal")
 }
 
+func TestGenerateBundle_MissingResolverEnforceFailsUnlessAllowed(t *testing.T) {
+	_, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+	})
+	if err == nil {
+		t.Fatal("GenerateBundle returned nil error")
+	}
+	if !errors.Is(err, ErrBundleInvalidOptions) {
+		t.Fatalf("GenerateBundle err = %v, want ErrBundleInvalidOptions", err)
+	}
+
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		IncludeToolRules:           false,
+		AllowHostnameOnlyInEnforce: true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle with hostname-only override: %v", err)
+	}
+	assertDNSExpansionWarning(t, b.Warnings, "appdb", "db.internal")
+}
+
 func TestGenerateBundle_EmptyDNSResultsObserveWarns(t *testing.T) {
 	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
 		SessionID:        "sess-1",
@@ -419,10 +468,11 @@ func TestGenerateBundle_BypassToolRules(t *testing.T) {
 	services[2].Upstream.Port = 5432
 
 	b, err := GenerateBundle(Config{Services: services}, BundleOptions{
-		SessionID:        "sess-1",
-		ProxySessionID:   "db-proxy-sess",
-		Mode:             UnavoidabilityEnforce,
-		IncludeToolRules: true,
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		IncludeToolRules:           true,
+		AllowHostnameOnlyInEnforce: true,
 	})
 	if err != nil {
 		t.Fatalf("GenerateBundle: %v", err)
@@ -470,10 +520,11 @@ func TestGenerateBundle_BypassToolRules(t *testing.T) {
 
 func TestGenerateBundle_BypassToolRulesOptional(t *testing.T) {
 	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
-		SessionID:        "sess-1",
-		ProxySessionID:   "db-proxy-sess",
-		Mode:             UnavoidabilityEnforce,
-		IncludeToolRules: false,
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		IncludeToolRules:           false,
+		AllowHostnameOnlyInEnforce: true,
 	})
 	if err != nil {
 		t.Fatalf("GenerateBundle: %v", err)
@@ -514,19 +565,21 @@ func TestGenerateBundle_BypassToolPortPatternsAreDeterministic(t *testing.T) {
 	reversed := []Service{services[2], services[1], services[0]}
 
 	first, err := GenerateBundle(Config{Services: services}, BundleOptions{
-		SessionID:        "sess-1",
-		ProxySessionID:   "db-proxy-sess",
-		Mode:             UnavoidabilityEnforce,
-		IncludeToolRules: true,
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		IncludeToolRules:           true,
+		AllowHostnameOnlyInEnforce: true,
 	})
 	if err != nil {
 		t.Fatalf("GenerateBundle first: %v", err)
 	}
 	second, err := GenerateBundle(Config{Services: reversed}, BundleOptions{
-		SessionID:        "sess-1",
-		ProxySessionID:   "db-proxy-sess",
-		Mode:             UnavoidabilityEnforce,
-		IncludeToolRules: true,
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		IncludeToolRules:           true,
+		AllowHostnameOnlyInEnforce: true,
 	})
 	if err != nil {
 		t.Fatalf("GenerateBundle second: %v", err)
@@ -553,10 +606,11 @@ func TestGenerateBundle_BypassToolPortPatternsAreDeterministic(t *testing.T) {
 
 func TestGenerateBundle_BypassToolRulesDoNotMatchAdjacentDigitPorts(t *testing.T) {
 	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
-		SessionID:        "sess-1",
-		ProxySessionID:   "db-proxy-sess",
-		Mode:             UnavoidabilityEnforce,
-		IncludeToolRules: true,
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		IncludeToolRules:           true,
+		AllowHostnameOnlyInEnforce: true,
 	})
 	if err != nil {
 		t.Fatalf("GenerateBundle: %v", err)
@@ -602,10 +656,11 @@ func TestGenerateBundle_BypassToolRulesDoNotMatchAdjacentDigitPorts(t *testing.T
 
 func TestGenerateBundle_BypassToolRulesCompileAndMatch(t *testing.T) {
 	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
-		SessionID:        "sess-1",
-		ProxySessionID:   "db-proxy-sess",
-		Mode:             UnavoidabilityEnforce,
-		IncludeToolRules: true,
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		IncludeToolRules:           true,
+		AllowHostnameOnlyInEnforce: true,
 	})
 	if err != nil {
 		t.Fatalf("GenerateBundle: %v", err)
@@ -681,10 +736,11 @@ func TestGenerateBundle_BypassToolRulesCompileAndMatch(t *testing.T) {
 
 func TestGenerateBundle_PolicyCompiles(t *testing.T) {
 	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
-		SessionID:        "sess-1",
-		ProxySessionID:   "db-proxy-sess",
-		Mode:             UnavoidabilityEnforce,
-		IncludeToolRules: false,
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		IncludeToolRules:           false,
+		AllowHostnameOnlyInEnforce: true,
 	})
 	if err != nil {
 		t.Fatalf("GenerateBundle: %v", err)

--- a/internal/db/service/bundle_test.go
+++ b/internal/db/service/bundle_test.go
@@ -1,0 +1,53 @@
+package service
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateBundle_RequiresSessionID(t *testing.T) {
+	_, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		Mode: UnavoidabilityEnforce,
+	})
+	if !errors.Is(err, ErrBundleInvalidOptions) {
+		t.Fatalf("GenerateBundle err = %v, want ErrBundleInvalidOptions", err)
+	}
+}
+
+func TestGenerateBundle_RejectsTCPListenerInEnforce(t *testing.T) {
+	svc := validBundleService(t, "appdb")
+	svc.Listen = Listener{Kind: "tcp", Host: "127.0.0.1", Port: 15432}
+
+	_, err := GenerateBundle(Config{Services: []Service{svc}}, BundleOptions{
+		SessionID:      "sess-1",
+		ProxySessionID: "db-proxy-sess",
+		Mode:           UnavoidabilityEnforce,
+	})
+	if err == nil {
+		t.Fatal("GenerateBundle returned nil error")
+	}
+	if !strings.Contains(err.Error(), "spec section 12.5") {
+		t.Fatalf("error = %v, want spec section 12.5 reference", err)
+	}
+}
+
+func validBundleService(t *testing.T, name string) Service {
+	t.Helper()
+
+	return Service{
+		Name:    name,
+		Family:  "postgres",
+		Dialect: "postgres",
+		Upstream: Endpoint{
+			Host: "db.internal",
+			Port: 5432,
+		},
+		Listen: Listener{
+			Kind: "unix",
+			Path: filepath.Join(t.TempDir(), "sessions", "sess-1", "db", name+".sock"),
+		},
+		TLSMode: "terminate_reissue",
+	}
+}

--- a/internal/db/service/bundle_test.go
+++ b/internal/db/service/bundle_test.go
@@ -211,10 +211,53 @@ func TestGenerateBundle_AddsResolvedIPDenies(t *testing.T) {
 		t.Fatal("resolver context had no deadline")
 	}
 
-	assertNetworkRule(t, b.Policy.NetworkRules, "db-appdb-deny-ip-10-0-0-15", "10.0.0.15/32", 5432)
-	assertNetworkRule(t, b.Policy.NetworkRules, "db-appdb-deny-ip-2001-db8-15", "2001:db8::15/128", 5432)
-	assertMetadata(t, b.Metadata, "db-appdb-deny-ip-10-0-0-15", "appdb", BypassModeDNSAlias, "10.0.0.15:5432")
-	assertMetadata(t, b.Metadata, "db-appdb-deny-ip-2001-db8-15", "appdb", BypassModeDNSAlias, "[2001:db8::15]:5432")
+	assertNetworkRule(t, b.Policy.NetworkRules, "db-appdb-deny-ip-v4-0a00000f", "10.0.0.15/32", 5432)
+	assertNetworkRule(t, b.Policy.NetworkRules, "db-appdb-deny-ip-v6-20010db8000000000000000000000015", "2001:db8::15/128", 5432)
+	assertMetadata(t, b.Metadata, "db-appdb-deny-ip-v4-0a00000f", "appdb", BypassModeDNSAlias, "10.0.0.15:5432")
+	assertMetadata(t, b.Metadata, "db-appdb-deny-ip-v6-20010db8000000000000000000000015", "appdb", BypassModeDNSAlias, "[2001:db8::15]:5432")
+}
+
+func TestGenerateBundle_ResolvedIPRuleNamesDistinguishIPv6Collisions(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+		Resolver: &fakeIPResolver{ips: []net.IP{
+			net.ParseIP("2001:db8::1:5"),
+			net.ParseIP("2001:db8:1::5"),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+
+	assertNetworkRule(t, b.Policy.NetworkRules, "db-appdb-deny-ip-v6-20010db8000000000000000000010005", "2001:db8::1:5/128", 5432)
+	assertNetworkRule(t, b.Policy.NetworkRules, "db-appdb-deny-ip-v6-20010db8000100000000000000000005", "2001:db8:1::5/128", 5432)
+	assertUniqueMetadataRuleNames(t, b.Metadata)
+}
+
+func TestGenerateBundle_DedupesResolvedIPs(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+		Resolver: &fakeIPResolver{ips: []net.IP{
+			net.ParseIP("10.0.0.15"),
+			net.ParseIP("10.0.0.15"),
+			net.ParseIP("::ffff:10.0.0.15"),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+
+	assertNetworkRule(t, b.Policy.NetworkRules, "db-appdb-deny-ip-v4-0a00000f", "10.0.0.15/32", 5432)
+	if countDNSAliasMetadata(b.Metadata) != 1 {
+		t.Fatalf("dns alias metadata count = %d, want 1: %+v", countDNSAliasMetadata(b.Metadata), b.Metadata)
+	}
+	assertUniqueMetadataRuleNames(t, b.Metadata)
 }
 
 func TestGenerateBundle_SkipsDNSExpansionForIPLiteralUpstream(t *testing.T) {
@@ -280,6 +323,59 @@ func TestGenerateBundle_DNSFailureEnforceFailsUnlessAllowed(t *testing.T) {
 	assertDNSExpansionWarning(t, b.Warnings, "appdb", "db.internal")
 }
 
+func TestGenerateBundle_EmptyDNSResultsObserveWarns(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityObserve,
+		IncludeToolRules: false,
+		Resolver:         &fakeIPResolver{},
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+	assertDNSExpansionWarning(t, b.Warnings, "appdb", "db.internal")
+}
+
+func TestGenerateBundle_EmptyDNSResultsEnforceFailsUnlessAllowed(t *testing.T) {
+	_, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+		Resolver:         &fakeIPResolver{},
+	})
+	if err == nil {
+		t.Fatal("GenerateBundle returned nil error")
+	}
+
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:                  "sess-1",
+		ProxySessionID:             "db-proxy-sess",
+		Mode:                       UnavoidabilityEnforce,
+		IncludeToolRules:           false,
+		AllowHostnameOnlyInEnforce: true,
+		Resolver:                   &fakeIPResolver{},
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle with hostname-only override: %v", err)
+	}
+	assertDNSExpansionWarning(t, b.Warnings, "appdb", "db.internal")
+}
+
+func TestGenerateBundle_NilOnlyDNSResultsAreUnusable(t *testing.T) {
+	_, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+		Resolver:         &fakeIPResolver{ips: []net.IP{nil}},
+	})
+	if err == nil {
+		t.Fatal("GenerateBundle returned nil error")
+	}
+}
+
 func TestGenerateBundle_ResolvedIPRuleNamesUseCollisionResistantServiceParts(t *testing.T) {
 	services := []Service{
 		validBundleService(t, "app_db"),
@@ -303,17 +399,11 @@ func TestGenerateBundle_ResolvedIPRuleNamesUseCollisionResistantServiceParts(t *
 	}
 
 	for _, svc := range services {
-		ruleName := "db-app-db-" + ruleNameHash(svc.Name) + "-deny-ip-10-0-0-15"
+		ruleName := "db-app-db-" + ruleNameHash(svc.Name) + "-deny-ip-v4-0a00000f"
 		destination := net.JoinHostPort("10.0.0.15", strconv.Itoa(svc.Upstream.Port))
 		assertMetadata(t, b.Metadata, ruleName, svc.Name, BypassModeDNSAlias, destination)
 	}
-	seen := map[string]bool{}
-	for _, m := range b.Metadata {
-		if seen[m.RuleName] {
-			t.Fatalf("duplicate metadata rule name %q in %+v", m.RuleName, b.Metadata)
-		}
-		seen[m.RuleName] = true
-	}
+	assertUniqueMetadataRuleNames(t, b.Metadata)
 }
 
 func TestGenerateBundle_PolicyCompiles(t *testing.T) {
@@ -360,6 +450,27 @@ func assertMetadata(t *testing.T, got []policy.RuleMetadata, ruleName, service, 
 		}
 	}
 	t.Fatalf("missing metadata for rule %q in %+v", ruleName, got)
+}
+
+func assertUniqueMetadataRuleNames(t *testing.T, got []policy.RuleMetadata) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, m := range got {
+		if seen[m.RuleName] {
+			t.Fatalf("duplicate metadata rule name %q in %+v", m.RuleName, got)
+		}
+		seen[m.RuleName] = true
+	}
+}
+
+func countDNSAliasMetadata(got []policy.RuleMetadata) int {
+	count := 0
+	for _, m := range got {
+		if m.BypassMode == BypassModeDNSAlias {
+			count++
+		}
+	}
+	return count
 }
 
 func assertNetworkRule(t *testing.T, got []policy.NetworkRule, name, cidr string, port int) {

--- a/internal/db/service/bundle_test.go
+++ b/internal/db/service/bundle_test.go
@@ -406,6 +406,199 @@ func TestGenerateBundle_ResolvedIPRuleNamesUseCollisionResistantServiceParts(t *
 	assertUniqueMetadataRuleNames(t, b.Metadata)
 }
 
+func TestGenerateBundle_BypassToolRules(t *testing.T) {
+	services := []Service{
+		validBundleService(t, "analytics"),
+		validBundleService(t, "appdb"),
+		validBundleService(t, "replica"),
+	}
+	services[0].Upstream.Host = "analytics.internal"
+	services[0].Upstream.Port = 15432
+	services[1].Upstream.Port = 5432
+	services[2].Upstream.Host = "replica.internal"
+	services[2].Upstream.Port = 5432
+
+	b, err := GenerateBundle(Config{Services: services}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+
+	wantCommands := map[string]string{
+		"ssh":             "db-bypass-ssh-forward",
+		"socat":           "db-bypass-socat",
+		"kubectl":         "db-bypass-kubectl-port-forward",
+		"cloud-sql-proxy": "db-bypass-cloud-sql-proxy",
+		"gcloud":          "db-bypass-gcloud-sql-connect",
+		"aws":             "db-bypass-aws-rds-connect",
+		"chisel":          "db-bypass-chisel",
+		"gost":            "db-bypass-gost",
+		"frpc":            "db-bypass-frpc",
+		"nc":              "db-bypass-netcat",
+		"ncat":            "db-bypass-netcat",
+		"netcat":          "db-bypass-netcat",
+		"docker":          "db-bypass-container-net-host",
+		"podman":          "db-bypass-container-net-host",
+		"nerdctl":         "db-bypass-container-net-host",
+	}
+
+	seen := map[string]string{}
+	for _, r := range b.Policy.CommandRules {
+		if r.Decision != "deny" {
+			t.Fatalf("command rule %q decision = %q, want deny", r.Name, r.Decision)
+		}
+		if r.Description != "Convenience detection for DB proxy bypass attempts; destination egress deny is the security boundary" {
+			t.Fatalf("command rule %q description = %q", r.Name, r.Description)
+		}
+		for _, cmd := range r.Commands {
+			seen[cmd] = r.Name
+		}
+		assertMetadata(t, b.Metadata, r.Name, "*", BypassModePortForwardTool, "db-service-ports")
+		assertMetadata(t, b.Policy.Metadata, r.Name, "*", BypassModePortForwardTool, "db-service-ports")
+	}
+	for cmd, ruleName := range wantCommands {
+		if seen[cmd] != ruleName {
+			t.Fatalf("command %q mapped to rule %q, want %q; all seen=%+v", cmd, seen[cmd], ruleName, seen)
+		}
+	}
+	assertUniqueMetadataRuleNames(t, b.Metadata)
+}
+
+func TestGenerateBundle_BypassToolRulesOptional(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+	if len(b.Policy.CommandRules) != 0 {
+		t.Fatalf("command rules = %+v, want none", b.Policy.CommandRules)
+	}
+}
+
+func TestGenerateBundle_BypassToolPortPatternsAreDeterministic(t *testing.T) {
+	services := []Service{
+		validBundleService(t, "analytics"),
+		validBundleService(t, "appdb"),
+		validBundleService(t, "replica"),
+	}
+	services[0].Upstream.Port = 15432
+	services[1].Upstream.Port = 5432
+	services[2].Upstream.Port = 5432
+
+	reversed := []Service{services[2], services[1], services[0]}
+
+	first, err := GenerateBundle(Config{Services: services}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle first: %v", err)
+	}
+	second, err := GenerateBundle(Config{Services: reversed}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle second: %v", err)
+	}
+
+	wantPatterns := map[string]string{
+		"db-bypass-ssh-forward":          "(^|\\s)-L(\\s|[^\\s]*:).*:(5432|15432)(\\s|$)",
+		"db-bypass-socat":                "(?i)(tcp-listen|listen|tcp:).*(5432|15432)",
+		"db-bypass-kubectl-port-forward": "(^|\\s)port-forward(\\s|$).*(:(5432|15432)|\\s(5432|15432):)",
+		"db-bypass-netcat":               "(?i)(-l|--listen|(5432|15432))",
+	}
+	for ruleName, wantPattern := range wantPatterns {
+		firstRule := commandRuleByName(t, first.Policy.CommandRules, ruleName)
+		secondRule := commandRuleByName(t, second.Policy.CommandRules, ruleName)
+		if strings.Join(firstRule.ArgsPatterns, "\n") != strings.Join(secondRule.ArgsPatterns, "\n") {
+			t.Fatalf("command rule %q patterns differ by service order: %+v vs %+v", ruleName, firstRule.ArgsPatterns, secondRule.ArgsPatterns)
+		}
+		if len(firstRule.ArgsPatterns) != 1 || firstRule.ArgsPatterns[0] != wantPattern {
+			t.Fatalf("command rule %q patterns = %+v, want [%q]", ruleName, firstRule.ArgsPatterns, wantPattern)
+		}
+	}
+}
+
+func TestGenerateBundle_BypassToolRulesCompileAndMatch(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: true,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+	engine, err := policy.NewEngine(&b.Policy, false, true)
+	if err != nil {
+		t.Fatalf("policy.NewEngine: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		command  string
+		args     []string
+		wantRule string
+	}{
+		{
+			name:     "ssh forward",
+			command:  "ssh",
+			args:     []string{"-L", "15432:db.internal:5432", "bastion"},
+			wantRule: "db-bypass-ssh-forward",
+		},
+		{
+			name:     "kubectl port forward",
+			command:  "kubectl",
+			args:     []string{"port-forward", "svc/postgres", "15432:5432"},
+			wantRule: "db-bypass-kubectl-port-forward",
+		},
+		{
+			name:     "cloud sql proxy",
+			command:  "cloud-sql-proxy",
+			args:     []string{"project:region:instance"},
+			wantRule: "db-bypass-cloud-sql-proxy",
+		},
+		{
+			name:     "gcloud sql connect",
+			command:  "gcloud",
+			args:     []string{"sql", "connect", "appdb"},
+			wantRule: "db-bypass-gcloud-sql-connect",
+		},
+		{
+			name:     "aws rds connect",
+			command:  "aws",
+			args:     []string{"rds", "connect", "--db-instance-identifier", "appdb"},
+			wantRule: "db-bypass-aws-rds-connect",
+		},
+		{
+			name:     "host network container",
+			command:  "docker",
+			args:     []string{"run", "--network=host", "postgres"},
+			wantRule: "db-bypass-container-net-host",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dec := engine.CheckCommand(tc.command, tc.args)
+			if string(dec.EffectiveDecision) != "deny" || dec.Rule != tc.wantRule {
+				t.Fatalf("CheckCommand(%q, %+v) = decision %q rule %q, want deny %q", tc.command, tc.args, dec.EffectiveDecision, dec.Rule, tc.wantRule)
+			}
+		})
+	}
+}
+
 func TestGenerateBundle_PolicyCompiles(t *testing.T) {
 	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
 		SessionID:        "sess-1",
@@ -461,6 +654,17 @@ func assertUniqueMetadataRuleNames(t *testing.T, got []policy.RuleMetadata) {
 		}
 		seen[m.RuleName] = true
 	}
+}
+
+func commandRuleByName(t *testing.T, got []policy.CommandRule, name string) policy.CommandRule {
+	t.Helper()
+	for _, rule := range got {
+		if rule.Name == name {
+			return rule
+		}
+	}
+	t.Fatalf("missing command rule %q in %+v", name, got)
+	return policy.CommandRule{}
 }
 
 func countDNSAliasMetadata(got []policy.RuleMetadata) int {

--- a/internal/db/service/bundle_test.go
+++ b/internal/db/service/bundle_test.go
@@ -64,7 +64,7 @@ func TestGenerateBundle_SingleServiceCoreRules(t *testing.T) {
 		t.Fatalf("network rules = %d, want 1", len(b.Policy.NetworkRules))
 	}
 	netRule := b.Policy.NetworkRules[0]
-	if netRule.Name != "db-appdb-deny-direct" {
+	if netRule.Name != "db-appdb-allow-redirect" {
 		t.Fatalf("network rule name = %q", netRule.Name)
 	}
 	if len(netRule.Domains) != 1 || netRule.Domains[0] != "db.internal" {
@@ -73,7 +73,7 @@ func TestGenerateBundle_SingleServiceCoreRules(t *testing.T) {
 	if len(netRule.Ports) != 1 || netRule.Ports[0] != 5432 {
 		t.Fatalf("network ports = %+v", netRule.Ports)
 	}
-	if netRule.Decision != "deny" {
+	if netRule.Decision != "allow" {
 		t.Fatalf("network decision = %q", netRule.Decision)
 	}
 
@@ -88,7 +88,7 @@ func TestGenerateBundle_SingleServiceCoreRules(t *testing.T) {
 		t.Fatalf("Bundle.Metadata length = %d, Policy.Metadata length = %d", len(b.Metadata), len(b.Policy.Metadata))
 	}
 	assertMetadata(t, b.Metadata, "db-appdb-redirect", "appdb", BypassModeTCPDirect, "db.internal:5432")
-	assertMetadata(t, b.Metadata, "db-appdb-deny-direct", "appdb", BypassModeTCPDirect, "db.internal:5432")
+	assertMetadata(t, b.Metadata, "db-appdb-allow-redirect", "appdb", BypassModeTCPDirect, "db.internal:5432")
 	assertMetadata(t, b.Metadata, "db-appdb-deny-local-postgres-sockets", "appdb", BypassModeUnixSocket, "postgres-local-sockets")
 }
 
@@ -119,12 +119,70 @@ func TestGenerateBundle_MultipleServicesHaveStableNames(t *testing.T) {
 	for _, name := range []string{
 		"db-appdb-redirect",
 		"db-warehouse-db-redirect",
-		"db-appdb-deny-direct",
-		"db-warehouse-db-deny-direct",
+		"db-appdb-allow-redirect",
+		"db-warehouse-db-allow-redirect",
 	} {
 		if !seen[name] {
 			t.Fatalf("missing metadata for %q in %+v", name, b.Metadata)
 		}
+	}
+}
+
+func TestGenerateBundle_RedirectTargetAllowedByNetworkPolicy(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+	engine, err := policy.NewEngine(&b.Policy, false, true)
+	if err != nil {
+		t.Fatalf("policy.NewEngine: %v", err)
+	}
+
+	redirect := engine.EvaluateConnectRedirect("db.internal:5432")
+	if !redirect.Matched || redirect.RedirectToUnix == "" {
+		t.Fatalf("EvaluateConnectRedirect = %+v", redirect)
+	}
+	network := engine.CheckNetwork("db.internal", 5432)
+	if string(network.EffectiveDecision) != "allow" {
+		t.Fatalf("CheckNetwork decision = %+v, want allow so CONNECT can dial redirected unix target", network)
+	}
+}
+
+func TestGenerateBundle_CollidingSanitizedServiceNamesAreUnique(t *testing.T) {
+	services := []Service{
+		validBundleService(t, "app_db"),
+		validBundleService(t, "app-db"),
+		validBundleService(t, "app/db"),
+	}
+	for i := range services {
+		services[i].Listen.Path = filepath.Join(t.TempDir(), "db", services[i].Name+".sock")
+		services[i].Upstream.Port = 5432 + i
+	}
+
+	b, err := GenerateBundle(Config{Services: services}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+
+	seen := map[string]bool{}
+	for _, m := range b.Metadata {
+		if seen[m.RuleName] {
+			t.Fatalf("duplicate metadata rule name %q in %+v", m.RuleName, b.Metadata)
+		}
+		seen[m.RuleName] = true
+	}
+	if len(seen) != len(b.Metadata) {
+		t.Fatalf("unique metadata names = %d, metadata = %d", len(seen), len(b.Metadata))
 	}
 }
 

--- a/internal/db/service/bundle_test.go
+++ b/internal/db/service/bundle_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/agentsh/agentsh/internal/policy"
 )
 
 func TestGenerateBundle_RequiresSessionID(t *testing.T) {
@@ -31,6 +33,130 @@ func TestGenerateBundle_RejectsTCPListenerInEnforce(t *testing.T) {
 	if !strings.Contains(err.Error(), "spec section 12.5") {
 		t.Fatalf("error = %v, want spec section 12.5 reference", err)
 	}
+}
+
+func TestGenerateBundle_SingleServiceCoreRules(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+
+	if len(b.Policy.ConnectRedirectRules) != 1 {
+		t.Fatalf("connect redirects = %d, want 1", len(b.Policy.ConnectRedirectRules))
+	}
+	redirect := b.Policy.ConnectRedirectRules[0]
+	if redirect.Name != "db-appdb-redirect" {
+		t.Fatalf("redirect name = %q", redirect.Name)
+	}
+	if redirect.RedirectToUnix == "" {
+		t.Fatal("redirect_to_unix is empty")
+	}
+	if redirect.RedirectTo != "" {
+		t.Fatalf("redirect_to = %q, want empty", redirect.RedirectTo)
+	}
+
+	if len(b.Policy.NetworkRules) != 1 {
+		t.Fatalf("network rules = %d, want 1", len(b.Policy.NetworkRules))
+	}
+	netRule := b.Policy.NetworkRules[0]
+	if netRule.Name != "db-appdb-deny-direct" {
+		t.Fatalf("network rule name = %q", netRule.Name)
+	}
+	if len(netRule.Domains) != 1 || netRule.Domains[0] != "db.internal" {
+		t.Fatalf("network domains = %+v", netRule.Domains)
+	}
+	if len(netRule.Ports) != 1 || netRule.Ports[0] != 5432 {
+		t.Fatalf("network ports = %+v", netRule.Ports)
+	}
+	if netRule.Decision != "deny" {
+		t.Fatalf("network decision = %q", netRule.Decision)
+	}
+
+	if len(b.Policy.UnixRules) != 1 {
+		t.Fatalf("unix rules = %d, want 1", len(b.Policy.UnixRules))
+	}
+	if b.Policy.UnixRules[0].Decision != "deny" {
+		t.Fatalf("unix decision = %q", b.Policy.UnixRules[0].Decision)
+	}
+
+	if len(b.Metadata) != len(b.Policy.Metadata) {
+		t.Fatalf("Bundle.Metadata length = %d, Policy.Metadata length = %d", len(b.Metadata), len(b.Policy.Metadata))
+	}
+	assertMetadata(t, b.Metadata, "db-appdb-redirect", "appdb", BypassModeTCPDirect, "db.internal:5432")
+	assertMetadata(t, b.Metadata, "db-appdb-deny-direct", "appdb", BypassModeTCPDirect, "db.internal:5432")
+	assertMetadata(t, b.Metadata, "db-appdb-deny-local-postgres-sockets", "appdb", BypassModeUnixSocket, "postgres-local-sockets")
+}
+
+func TestGenerateBundle_MultipleServicesHaveStableNames(t *testing.T) {
+	app := validBundleService(t, "appdb")
+	warehouse := validBundleService(t, "warehouse-db")
+	warehouse.Upstream.Host = "warehouse.internal"
+	warehouse.Upstream.Port = 15432
+	warehouse.Listen.Path = filepath.Join(t.TempDir(), "db", "warehouse.sock")
+
+	b, err := GenerateBundle(Config{Services: []Service{app, warehouse}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+
+	seen := map[string]bool{}
+	for _, m := range b.Metadata {
+		if seen[m.RuleName] {
+			t.Fatalf("duplicate metadata rule name %q", m.RuleName)
+		}
+		seen[m.RuleName] = true
+	}
+	for _, name := range []string{
+		"db-appdb-redirect",
+		"db-warehouse-db-redirect",
+		"db-appdb-deny-direct",
+		"db-warehouse-db-deny-direct",
+	} {
+		if !seen[name] {
+			t.Fatalf("missing metadata for %q in %+v", name, b.Metadata)
+		}
+	}
+}
+
+func TestGenerateBundle_PolicyCompiles(t *testing.T) {
+	b, err := GenerateBundle(Config{Services: []Service{validBundleService(t, "appdb")}}, BundleOptions{
+		SessionID:        "sess-1",
+		ProxySessionID:   "db-proxy-sess",
+		Mode:             UnavoidabilityEnforce,
+		IncludeToolRules: false,
+	})
+	if err != nil {
+		t.Fatalf("GenerateBundle: %v", err)
+	}
+	if err := b.Policy.Validate(); err != nil {
+		t.Fatalf("Policy.Validate: %v", err)
+	}
+	if _, err := policy.NewEngine(&b.Policy, false, true); err != nil {
+		t.Fatalf("policy.NewEngine: %v", err)
+	}
+}
+
+func assertMetadata(t *testing.T, got []policy.RuleMetadata, ruleName, service, mode, destination string) {
+	t.Helper()
+	for _, m := range got {
+		if m.RuleName == ruleName {
+			if m.Source != RuleSourceDBUnavoidability || m.DBService != service || m.BypassMode != mode || m.Destination != destination {
+				t.Fatalf("metadata for %q = %+v", ruleName, m)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing metadata for rule %q in %+v", ruleName, got)
 }
 
 func validBundleService(t *testing.T, name string) Service {

--- a/internal/netmonitor/proxy.go
+++ b/internal/netmonitor/proxy.go
@@ -200,8 +200,7 @@ func (p *Proxy) handleConnect(client net.Conn, req *http.Request) error {
 	}
 
 	ctx := req.Context()
-	dec := p.checkNetwork(ctx, host, port)
-	dec = p.maybeApprove(ctx, commandID, dec, "network", hostPort)
+	dec := p.checkConnectNetwork(ctx, commandID, host, hostPort, port, redirectResult)
 	eventFields := map[string]any{
 		"method":      "CONNECT",
 		"resolved_ip": resolvedIP,
@@ -430,6 +429,20 @@ func (p *Proxy) checkNetwork(ctx context.Context, domain string, port int) polic
 		return policy.Decision{PolicyDecision: types.DecisionAllow, EffectiveDecision: types.DecisionAllow}
 	}
 	return p.policy.CheckNetworkCtx(ctx, domain, port)
+}
+
+func (p *Proxy) checkConnectNetwork(ctx context.Context, commandID string, host string, hostPort string, port int, redirect *policy.ConnectRedirectResult) policy.Decision {
+	dec := p.checkNetwork(ctx, host, port)
+	dec = p.maybeApprove(ctx, commandID, dec, "network", hostPort)
+	if redirect != nil && redirect.RedirectToUnix != "" && dec.EffectiveDecision == types.DecisionDeny {
+		return policy.Decision{
+			PolicyDecision:    types.DecisionAllow,
+			EffectiveDecision: types.DecisionAllow,
+			Rule:              redirect.Rule,
+			Message:           redirect.Message,
+		}
+	}
+	return dec
 }
 
 func (p *Proxy) maybeApprove(ctx context.Context, commandID string, dec policy.Decision, kind string, target string) policy.Decision {

--- a/internal/netmonitor/proxy.go
+++ b/internal/netmonitor/proxy.go
@@ -107,6 +107,34 @@ func (p *Proxy) handleConn(c net.Conn) error {
 	return p.handleHTTP(c, req)
 }
 
+type connectDialTargetInput struct {
+	OriginalHostPort string
+	ResolvedIP       string
+	OriginalPort     string
+	Redirect         *policy.ConnectRedirectResult
+}
+
+type resolvedConnectDialTarget struct {
+	Network string
+	Address string
+}
+
+func connectDialTarget(in connectDialTargetInput) resolvedConnectDialTarget {
+	if in.Redirect != nil && in.Redirect.RedirectToUnix != "" {
+		return resolvedConnectDialTarget{Network: "unix", Address: in.Redirect.RedirectToUnix}
+	}
+	if in.Redirect != nil && in.Redirect.RedirectTo != "" {
+		return resolvedConnectDialTarget{Network: "tcp", Address: in.Redirect.RedirectTo}
+	}
+	if in.ResolvedIP != "" {
+		return resolvedConnectDialTarget{
+			Network: "tcp",
+			Address: net.JoinHostPort(in.ResolvedIP, in.OriginalPort),
+		}
+	}
+	return resolvedConnectDialTarget{Network: "tcp", Address: in.OriginalHostPort}
+}
+
 func (p *Proxy) handleConnect(client net.Conn, req *http.Request) error {
 	hostPort := req.Host
 	host, portStr, err := net.SplitHostPort(hostPort)
@@ -156,16 +184,17 @@ func (p *Proxy) handleConnect(client net.Conn, req *http.Request) error {
 	resolvedIP := p.resolveAndEmitDNS(context.Background(), commandID, host)
 
 	// Check for connect redirect rules
-	var redirectTo, redirectTLS, redirectSNI string
+	var redirectResult *policy.ConnectRedirectResult
+	var redirectTLS, redirectSNI string
 	if p.policy != nil {
-		redirectResult := p.policy.EvaluateConnectRedirect(hostPort)
-		if redirectResult.Matched {
-			redirectTo = redirectResult.RedirectTo
-			redirectTLS = redirectResult.TLSMode
-			redirectSNI = redirectResult.SNI
+		result := p.policy.EvaluateConnectRedirect(hostPort)
+		if result.Matched {
+			redirectResult = result
+			redirectTLS = result.TLSMode
+			redirectSNI = result.SNI
 			// Emit redirect event if visibility is not silent
-			if redirectResult.Visibility != "silent" {
-				p.emitConnectRedirectEvent(context.Background(), commandID, host, hostPort, port, redirectResult)
+			if result.Visibility != "silent" {
+				p.emitConnectRedirectEvent(context.Background(), commandID, host, hostPort, port, result)
 			}
 		}
 	}
@@ -177,8 +206,13 @@ func (p *Proxy) handleConnect(client net.Conn, req *http.Request) error {
 		"method":      "CONNECT",
 		"resolved_ip": resolvedIP,
 	}
-	if redirectTo != "" {
-		eventFields["redirect_to"] = redirectTo
+	if redirectResult != nil {
+		if redirectResult.RedirectTo != "" {
+			eventFields["redirect_to"] = redirectResult.RedirectTo
+		}
+		if redirectResult.RedirectToUnix != "" {
+			eventFields["redirect_to_unix"] = redirectResult.RedirectToUnix
+		}
 		eventFields["redirect_tls"] = redirectTLS
 		if redirectSNI != "" {
 			eventFields["redirect_sni"] = redirectSNI
@@ -197,14 +231,14 @@ func (p *Proxy) handleConnect(client net.Conn, req *http.Request) error {
 	emitMCPConnectionIfMatched(context.Background(), p.sess, p.emit, p.sessionID, commandID, host, hostPort, port)
 
 	// Determine dial target: redirect destination or original
-	dialTarget := hostPort
-	if redirectTo != "" {
-		dialTarget = redirectTo
-	} else if resolvedIP != "" {
-		dialTarget = net.JoinHostPort(resolvedIP, portStr)
-	}
+	dialTarget := connectDialTarget(connectDialTargetInput{
+		OriginalHostPort: hostPort,
+		ResolvedIP:       resolvedIP,
+		OriginalPort:     portStr,
+		Redirect:         redirectResult,
+	})
 
-	up, err := net.DialTimeout("tcp", dialTarget, 20*time.Second)
+	up, err := net.DialTimeout(dialTarget.Network, dialTarget.Address, 20*time.Second)
 	if err != nil {
 		_, _ = io.WriteString(client, "HTTP/1.1 502 Bad Gateway\r\n\r\n")
 		return nil

--- a/internal/netmonitor/proxy.go
+++ b/internal/netmonitor/proxy.go
@@ -497,12 +497,17 @@ func (p *Proxy) emitConnectRedirectEvent(ctx context.Context, commandID string, 
 		Domain:    strings.ToLower(domain),
 		Remote:    hostPort,
 		Fields: map[string]any{
-			"rule":        result.Rule,
-			"redirect_to": result.RedirectTo,
-			"tls_mode":    result.TLSMode,
-			"message":     result.Message,
-			"visibility":  result.Visibility,
+			"rule":       result.Rule,
+			"tls_mode":   result.TLSMode,
+			"message":    result.Message,
+			"visibility": result.Visibility,
 		},
+	}
+	if result.RedirectTo != "" {
+		ev.Fields["redirect_to"] = result.RedirectTo
+	}
+	if result.RedirectToUnix != "" {
+		ev.Fields["redirect_to_unix"] = result.RedirectToUnix
 	}
 	if result.SNI != "" {
 		ev.Fields["sni"] = result.SNI

--- a/internal/netmonitor/proxy.go
+++ b/internal/netmonitor/proxy.go
@@ -433,16 +433,36 @@ func (p *Proxy) checkNetwork(ctx context.Context, domain string, port int) polic
 
 func (p *Proxy) checkConnectNetwork(ctx context.Context, commandID string, host string, hostPort string, port int, redirect *policy.ConnectRedirectResult) policy.Decision {
 	dec := p.checkNetwork(ctx, host, port)
+	if redirect != nil && redirect.RedirectToUnix != "" && dec.EffectiveDecision == types.DecisionDeny && p.isDBUnavoidabilityTCPDirectRule(dec.Rule) {
+		return allowConnectRedirectDecision(redirect)
+	}
 	dec = p.maybeApprove(ctx, commandID, dec, "network", hostPort)
-	if redirect != nil && redirect.RedirectToUnix != "" && dec.EffectiveDecision == types.DecisionDeny {
-		return policy.Decision{
-			PolicyDecision:    types.DecisionAllow,
-			EffectiveDecision: types.DecisionAllow,
-			Rule:              redirect.Rule,
-			Message:           redirect.Message,
+	return dec
+}
+
+func (p *Proxy) isDBUnavoidabilityTCPDirectRule(ruleName string) bool {
+	if p == nil || p.policy == nil || ruleName == "" {
+		return false
+	}
+	pol := p.policy.Policy()
+	if pol == nil {
+		return false
+	}
+	for _, m := range pol.Metadata {
+		if m.RuleName == ruleName && m.Source == "db_unavoidability" && m.BypassMode == "tcp_direct" {
+			return true
 		}
 	}
-	return dec
+	return false
+}
+
+func allowConnectRedirectDecision(redirect *policy.ConnectRedirectResult) policy.Decision {
+	return policy.Decision{
+		PolicyDecision:    types.DecisionAllow,
+		EffectiveDecision: types.DecisionAllow,
+		Rule:              redirect.Rule,
+		Message:           redirect.Message,
+	}
 }
 
 func (p *Proxy) maybeApprove(ctx context.Context, commandID string, dec policy.Decision, kind string, target string) policy.Decision {

--- a/internal/netmonitor/proxy.go
+++ b/internal/netmonitor/proxy.go
@@ -433,7 +433,7 @@ func (p *Proxy) checkNetwork(ctx context.Context, domain string, port int) polic
 
 func (p *Proxy) checkConnectNetwork(ctx context.Context, commandID string, host string, hostPort string, port int, redirect *policy.ConnectRedirectResult) policy.Decision {
 	dec := p.checkNetwork(ctx, host, port)
-	if redirect != nil && redirect.RedirectToUnix != "" && dec.EffectiveDecision == types.DecisionDeny && p.isDBUnavoidabilityTCPDirectRule(dec.Rule) {
+	if allowUnixRedirectForDBUnavoidability(p.policy, dec, redirect) {
 		return allowConnectRedirectDecision(redirect)
 	}
 	dec = p.maybeApprove(ctx, commandID, dec, "network", hostPort)
@@ -441,10 +441,25 @@ func (p *Proxy) checkConnectNetwork(ctx context.Context, commandID string, host 
 }
 
 func (p *Proxy) isDBUnavoidabilityTCPDirectRule(ruleName string) bool {
-	if p == nil || p.policy == nil || ruleName == "" {
+	if p == nil {
 		return false
 	}
-	pol := p.policy.Policy()
+	return isDBUnavoidabilityTCPDirectRule(p.policy, ruleName)
+}
+
+func allowUnixRedirectForDBUnavoidability(engine *policy.Engine, dec policy.Decision, redirect *policy.ConnectRedirectResult) bool {
+	return redirect != nil &&
+		redirect.RedirectToUnix != "" &&
+		dec.EffectiveDecision == types.DecisionDeny &&
+		isDBUnavoidabilityTCPDirectRule(engine, dec.Rule) &&
+		isDBUnavoidabilityTCPDirectRule(engine, redirect.Rule)
+}
+
+func isDBUnavoidabilityTCPDirectRule(engine *policy.Engine, ruleName string) bool {
+	if engine == nil || ruleName == "" {
+		return false
+	}
+	pol := engine.Policy()
 	if pol == nil {
 		return false
 	}
@@ -518,14 +533,21 @@ func (p *Proxy) emitNetEvent(ctx context.Context, evType string, commandID strin
 }
 
 func (p *Proxy) emitConnectRedirectEvent(ctx context.Context, commandID string, domain string, hostPort string, port int, result *policy.ConnectRedirectResult) {
-	if p.emit == nil {
+	if p == nil {
+		return
+	}
+	emitConnectRedirectEvent(ctx, p.emit, p.sessionID, commandID, domain, hostPort, port, result)
+}
+
+func emitConnectRedirectEvent(ctx context.Context, emit Emitter, sessionID string, commandID string, domain string, hostPort string, port int, result *policy.ConnectRedirectResult) {
+	if emit == nil {
 		return
 	}
 	ev := types.Event{
 		ID:        uuid.NewString(),
 		Timestamp: time.Now().UTC(),
 		Type:      "connect_redirect",
-		SessionID: p.sessionID,
+		SessionID: sessionID,
 		CommandID: commandID,
 		Domain:    strings.ToLower(domain),
 		Remote:    hostPort,
@@ -545,8 +567,8 @@ func (p *Proxy) emitConnectRedirectEvent(ctx context.Context, commandID string, 
 	if result.SNI != "" {
 		ev.Fields["sni"] = result.SNI
 	}
-	_ = p.emit.AppendEvent(ctx, ev)
-	p.emit.Publish(ev)
+	_ = emit.AppendEvent(ctx, ev)
+	emit.Publish(ev)
 }
 
 // emitMCPConnectionIfMatched checks whether the connection target is a known

--- a/internal/netmonitor/proxy_test.go
+++ b/internal/netmonitor/proxy_test.go
@@ -284,6 +284,11 @@ func TestHandleConnect_UnixRedirectBypassesOriginalNetworkDeny(t *testing.T) {
 				Source:     "db_unavoidability",
 				BypassMode: "tcp_direct",
 			},
+			{
+				RuleName:   "db-unix-redirect",
+				Source:     "db_unavoidability",
+				BypassMode: "tcp_direct",
+			},
 		},
 		NetworkRules: []policy.NetworkRule{
 			{Name: "deny-db-direct", Decision: "deny", Domains: []string{"db.internal"}, Ports: []int{5432}},
@@ -319,6 +324,56 @@ func TestHandleConnect_UnixRedirectBypassesOriginalNetworkDeny(t *testing.T) {
 	n, _ := client.Read(buf)
 	if !strings.Contains(string(buf[:n]), "502 Bad Gateway") {
 		t.Fatalf("expected 502 response for missing unix socket, got %q", string(buf[:n]))
+	}
+	client.Close()
+	<-done
+}
+
+func TestHandleConnect_UnixRedirectDoesNotBypassDBDenyWithoutRedirectMetadata(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "db", "appdb.sock")
+	pol := &policy.Policy{
+		Version: 1,
+		Metadata: []policy.RuleMetadata{
+			{
+				RuleName:   "deny-db-direct",
+				Source:     "db_unavoidability",
+				BypassMode: "tcp_direct",
+			},
+		},
+		NetworkRules: []policy.NetworkRule{
+			{Name: "deny-db-direct", Decision: "deny", Domains: []string{"db.internal"}, Ports: []int{5432}},
+		},
+		ConnectRedirectRules: []policy.ConnectRedirectRule{
+			{
+				Name:           "non-db-unix-redirect",
+				Match:          `^db\.internal:5432$`,
+				RedirectToUnix: socketPath,
+				Visibility:     "audit_only",
+			},
+		},
+	}
+	engine, err := policy.NewEngine(pol, false, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	em := &stubEmitter{}
+	p := &Proxy{sessionID: "s", policy: engine, emit: em}
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	done := make(chan struct{})
+	go func() {
+		_ = p.handleConn(server)
+		close(done)
+	}()
+
+	_, _ = client.Write([]byte("CONNECT db.internal:5432 HTTP/1.1\r\nHost: db.internal:5432\r\n\r\n"))
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 128)
+	n, _ := client.Read(buf)
+	if !strings.Contains(string(buf[:n]), "403 Forbidden") {
+		t.Fatalf("expected 403 response for non-DB redirect despite DB deny, got %q", string(buf[:n]))
 	}
 	client.Close()
 	<-done

--- a/internal/netmonitor/proxy_test.go
+++ b/internal/netmonitor/proxy_test.go
@@ -2,6 +2,10 @@ package netmonitor
 
 import (
 	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -151,11 +155,12 @@ func TestEmitConnectRedirectEventWithUnixRedirect(t *testing.T) {
 		sessionID: "test-session",
 		emit:      em,
 	}
+	socketPath := filepath.Join(t.TempDir(), "db", "appdb.sock")
 
 	result := &policy.ConnectRedirectResult{
 		Matched:        true,
 		Rule:           "db-unix-redirect",
-		RedirectToUnix: "/run/agentsh/sessions/sess-1/db/appdb.sock",
+		RedirectToUnix: socketPath,
 		TLSMode:        "passthrough",
 		Visibility:     "audit_only",
 		Message:        "Routed to local database socket",
@@ -168,7 +173,7 @@ func TestEmitConnectRedirectEventWithUnixRedirect(t *testing.T) {
 	}
 
 	ev := em.events[0]
-	if ev.Fields["redirect_to_unix"] != "/run/agentsh/sessions/sess-1/db/appdb.sock" {
+	if ev.Fields["redirect_to_unix"] != socketPath {
 		t.Errorf("expected redirect_to_unix socket path, got %v", ev.Fields["redirect_to_unix"])
 	}
 	if _, ok := ev.Fields["redirect_to"]; ok {
@@ -193,21 +198,80 @@ func TestEmitConnectRedirectEventNilEmitter(t *testing.T) {
 }
 
 func TestConnectDialTarget_UnixRedirect(t *testing.T) {
+	socketPath := filepath.Join(os.TempDir(), "agentsh", "sessions", "sess-1", "db", "appdb.sock")
+
 	got := connectDialTarget(connectDialTargetInput{
 		OriginalHostPort: "db.internal:5432",
 		ResolvedIP:       "10.0.0.10",
 		OriginalPort:     "5432",
 		Redirect: &policy.ConnectRedirectResult{
 			Matched:        true,
-			RedirectToUnix: "/run/agentsh/sessions/sess-1/db/appdb.sock",
+			RedirectToUnix: socketPath,
 		},
 	})
 	if got.Network != "unix" {
 		t.Fatalf("Network = %q, want unix", got.Network)
 	}
-	if got.Address != "/run/agentsh/sessions/sess-1/db/appdb.sock" {
+	if got.Address != socketPath {
 		t.Fatalf("Address = %q", got.Address)
 	}
+}
+
+func TestHandleConnect_UnixRedirectNetConnectFields(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "db", "appdb.sock")
+	pol := &policy.Policy{
+		Version: 1,
+		NetworkRules: []policy.NetworkRule{
+			{Name: "allow-db", Decision: "allow", Domains: []string{"127.0.0.1"}, Ports: []int{5432}},
+		},
+		ConnectRedirectRules: []policy.ConnectRedirectRule{
+			{
+				Name:           "db-unix-redirect",
+				Match:          `^127\.0\.0\.1:5432$`,
+				RedirectToUnix: socketPath,
+				Visibility:     "audit_only",
+			},
+		},
+	}
+	engine, err := policy.NewEngine(pol, false, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	em := &stubEmitter{}
+	p := &Proxy{sessionID: "s", policy: engine, emit: em}
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	done := make(chan struct{})
+	go func() {
+		_ = p.handleConn(server)
+		close(done)
+	}()
+
+	_, _ = client.Write([]byte("CONNECT 127.0.0.1:5432 HTTP/1.1\r\nHost: 127.0.0.1:5432\r\n\r\n"))
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 128)
+	n, _ := client.Read(buf)
+	if !strings.Contains(string(buf[:n]), "502 Bad Gateway") {
+		t.Fatalf("expected 502 response for missing unix socket, got %q", string(buf[:n]))
+	}
+	client.Close()
+	<-done
+
+	for _, ev := range em.events {
+		if ev.Type != "net_connect" {
+			continue
+		}
+		if ev.Fields["redirect_to_unix"] != socketPath {
+			t.Fatalf("redirect_to_unix = %v, want %q in event %+v", ev.Fields["redirect_to_unix"], socketPath, ev)
+		}
+		if _, ok := ev.Fields["redirect_to"]; ok {
+			t.Fatalf("did not expect redirect_to for unix redirect, got %v in event %+v", ev.Fields["redirect_to"], ev)
+		}
+		return
+	}
+	t.Fatalf("expected net_connect event, got %+v", em.events)
 }
 
 func TestConnectDialTarget_TCPRedirectWinsOverResolvedIP(t *testing.T) {

--- a/internal/netmonitor/proxy_test.go
+++ b/internal/netmonitor/proxy_test.go
@@ -278,6 +278,13 @@ func TestHandleConnect_UnixRedirectBypassesOriginalNetworkDeny(t *testing.T) {
 	socketPath := filepath.Join(t.TempDir(), "db", "appdb.sock")
 	pol := &policy.Policy{
 		Version: 1,
+		Metadata: []policy.RuleMetadata{
+			{
+				RuleName:   "deny-db-direct",
+				Source:     "db_unavoidability",
+				BypassMode: "tcp_direct",
+			},
+		},
 		NetworkRules: []policy.NetworkRule{
 			{Name: "deny-db-direct", Decision: "deny", Domains: []string{"db.internal"}, Ports: []int{5432}},
 		},
@@ -317,6 +324,49 @@ func TestHandleConnect_UnixRedirectBypassesOriginalNetworkDeny(t *testing.T) {
 	<-done
 }
 
+func TestHandleConnect_UnixRedirectDoesNotBypassNonDBNetworkDeny(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "db", "appdb.sock")
+	pol := &policy.Policy{
+		Version: 1,
+		NetworkRules: []policy.NetworkRule{
+			{Name: "deny-db-direct", Decision: "deny", Domains: []string{"db.internal"}, Ports: []int{5432}},
+		},
+		ConnectRedirectRules: []policy.ConnectRedirectRule{
+			{
+				Name:           "db-unix-redirect",
+				Match:          `^db\.internal:5432$`,
+				RedirectToUnix: socketPath,
+				Visibility:     "audit_only",
+			},
+		},
+	}
+	engine, err := policy.NewEngine(pol, false, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	em := &stubEmitter{}
+	p := &Proxy{sessionID: "s", policy: engine, emit: em}
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	done := make(chan struct{})
+	go func() {
+		_ = p.handleConn(server)
+		close(done)
+	}()
+
+	_, _ = client.Write([]byte("CONNECT db.internal:5432 HTTP/1.1\r\nHost: db.internal:5432\r\n\r\n"))
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 128)
+	n, _ := client.Read(buf)
+	if !strings.Contains(string(buf[:n]), "403 Forbidden") {
+		t.Fatalf("expected 403 response for non-DB deny despite unix redirect, got %q", string(buf[:n]))
+	}
+	client.Close()
+	<-done
+}
+
 func TestHandleConnect_NonRedirectedNetworkDenyReturnsForbidden(t *testing.T) {
 	pol := &policy.Policy{
 		Version: 1,
@@ -349,6 +399,35 @@ func TestHandleConnect_NonRedirectedNetworkDenyReturnsForbidden(t *testing.T) {
 	}
 	client.Close()
 	<-done
+}
+
+func TestCheckConnectNetwork_DeniedApprovalWithUnixRedirectStaysDenied(t *testing.T) {
+	pol := &policy.Policy{
+		Version: 1,
+		NetworkRules: []policy.NetworkRule{
+			{Name: "approve-db", Decision: "approve", Domains: []string{"db.internal"}, Ports: []int{5432}},
+		},
+	}
+	engine, err := policy.NewEngine(pol, true, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	em := &stubEmitter{}
+	p := &Proxy{
+		sessionID: "s",
+		policy:    engine,
+		approvals: approvals.New("remote", 1*time.Millisecond, em),
+		emit:      em,
+	}
+
+	dec := p.checkConnectNetwork(context.Background(), "cmd", "db.internal", "db.internal:5432", 5432, &policy.ConnectRedirectResult{
+		Matched:        true,
+		Rule:           "db-unix-redirect",
+		RedirectToUnix: filepath.Join(t.TempDir(), "db", "appdb.sock"),
+	})
+	if dec.EffectiveDecision != types.DecisionDeny {
+		t.Fatalf("EffectiveDecision = %v, want deny", dec.EffectiveDecision)
+	}
 }
 
 func TestConnectDialTarget_TCPRedirectWinsOverResolvedIP(t *testing.T) {

--- a/internal/netmonitor/proxy_test.go
+++ b/internal/netmonitor/proxy_test.go
@@ -161,6 +161,56 @@ func TestEmitConnectRedirectEventNilEmitter(t *testing.T) {
 	p.emitConnectRedirectEvent(context.Background(), "cmd", "example.com", "example.com:443", 443, result)
 }
 
+func TestConnectDialTarget_UnixRedirect(t *testing.T) {
+	got := connectDialTarget(connectDialTargetInput{
+		OriginalHostPort: "db.internal:5432",
+		ResolvedIP:       "10.0.0.10",
+		OriginalPort:     "5432",
+		Redirect: &policy.ConnectRedirectResult{
+			Matched:        true,
+			RedirectToUnix: "/run/agentsh/sessions/sess-1/db/appdb.sock",
+		},
+	})
+	if got.Network != "unix" {
+		t.Fatalf("Network = %q, want unix", got.Network)
+	}
+	if got.Address != "/run/agentsh/sessions/sess-1/db/appdb.sock" {
+		t.Fatalf("Address = %q", got.Address)
+	}
+}
+
+func TestConnectDialTarget_TCPRedirectWinsOverResolvedIP(t *testing.T) {
+	got := connectDialTarget(connectDialTargetInput{
+		OriginalHostPort: "api.example.com:443",
+		ResolvedIP:       "10.0.0.10",
+		OriginalPort:     "443",
+		Redirect: &policy.ConnectRedirectResult{
+			Matched:    true,
+			RedirectTo: "proxy.internal:8443",
+		},
+	})
+	if got.Network != "tcp" {
+		t.Fatalf("Network = %q, want tcp", got.Network)
+	}
+	if got.Address != "proxy.internal:8443" {
+		t.Fatalf("Address = %q", got.Address)
+	}
+}
+
+func TestConnectDialTarget_ResolvedIPFallback(t *testing.T) {
+	got := connectDialTarget(connectDialTargetInput{
+		OriginalHostPort: "api.example.com:443",
+		ResolvedIP:       "10.0.0.10",
+		OriginalPort:     "443",
+	})
+	if got.Network != "tcp" {
+		t.Fatalf("Network = %q, want tcp", got.Network)
+	}
+	if got.Address != "10.0.0.10:443" {
+		t.Fatalf("Address = %q", got.Address)
+	}
+}
+
 func newSessionWithRegistry(addrs map[string]string) *session.Session {
 	sess := &session.Session{ID: "test-session"}
 	reg := mcpregistry.NewRegistry()

--- a/internal/netmonitor/proxy_test.go
+++ b/internal/netmonitor/proxy_test.go
@@ -274,6 +274,83 @@ func TestHandleConnect_UnixRedirectNetConnectFields(t *testing.T) {
 	t.Fatalf("expected net_connect event, got %+v", em.events)
 }
 
+func TestHandleConnect_UnixRedirectBypassesOriginalNetworkDeny(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "db", "appdb.sock")
+	pol := &policy.Policy{
+		Version: 1,
+		NetworkRules: []policy.NetworkRule{
+			{Name: "deny-db-direct", Decision: "deny", Domains: []string{"db.internal"}, Ports: []int{5432}},
+		},
+		ConnectRedirectRules: []policy.ConnectRedirectRule{
+			{
+				Name:           "db-unix-redirect",
+				Match:          `^db\.internal:5432$`,
+				RedirectToUnix: socketPath,
+				Visibility:     "audit_only",
+			},
+		},
+	}
+	engine, err := policy.NewEngine(pol, false, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	em := &stubEmitter{}
+	p := &Proxy{sessionID: "s", policy: engine, emit: em}
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	done := make(chan struct{})
+	go func() {
+		_ = p.handleConn(server)
+		close(done)
+	}()
+
+	_, _ = client.Write([]byte("CONNECT db.internal:5432 HTTP/1.1\r\nHost: db.internal:5432\r\n\r\n"))
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 128)
+	n, _ := client.Read(buf)
+	if !strings.Contains(string(buf[:n]), "502 Bad Gateway") {
+		t.Fatalf("expected 502 response for missing unix socket, got %q", string(buf[:n]))
+	}
+	client.Close()
+	<-done
+}
+
+func TestHandleConnect_NonRedirectedNetworkDenyReturnsForbidden(t *testing.T) {
+	pol := &policy.Policy{
+		Version: 1,
+		NetworkRules: []policy.NetworkRule{
+			{Name: "deny-db-direct", Decision: "deny", Domains: []string{"127.0.0.1"}, Ports: []int{5432}},
+		},
+	}
+	engine, err := policy.NewEngine(pol, false, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	em := &stubEmitter{}
+	p := &Proxy{sessionID: "s", policy: engine, emit: em}
+
+	client, server := net.Pipe()
+	defer client.Close()
+
+	done := make(chan struct{})
+	go func() {
+		_ = p.handleConn(server)
+		close(done)
+	}()
+
+	_, _ = client.Write([]byte("CONNECT 127.0.0.1:5432 HTTP/1.1\r\nHost: 127.0.0.1:5432\r\n\r\n"))
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	buf := make([]byte, 128)
+	n, _ := client.Read(buf)
+	if !strings.Contains(string(buf[:n]), "403 Forbidden") {
+		t.Fatalf("expected 403 response for denied non-redirected CONNECT, got %q", string(buf[:n]))
+	}
+	client.Close()
+	<-done
+}
+
 func TestConnectDialTarget_TCPRedirectWinsOverResolvedIP(t *testing.T) {
 	got := connectDialTarget(connectDialTargetInput{
 		OriginalHostPort: "api.example.com:443",

--- a/internal/netmonitor/proxy_test.go
+++ b/internal/netmonitor/proxy_test.go
@@ -145,6 +145,37 @@ func TestEmitConnectRedirectEventWithSNI(t *testing.T) {
 	}
 }
 
+func TestEmitConnectRedirectEventWithUnixRedirect(t *testing.T) {
+	em := &stubEmitter{}
+	p := &Proxy{
+		sessionID: "test-session",
+		emit:      em,
+	}
+
+	result := &policy.ConnectRedirectResult{
+		Matched:        true,
+		Rule:           "db-unix-redirect",
+		RedirectToUnix: "/run/agentsh/sessions/sess-1/db/appdb.sock",
+		TLSMode:        "passthrough",
+		Visibility:     "audit_only",
+		Message:        "Routed to local database socket",
+	}
+
+	p.emitConnectRedirectEvent(context.Background(), "cmd-789", "db.internal", "db.internal:5432", 5432, result)
+
+	if len(em.events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(em.events))
+	}
+
+	ev := em.events[0]
+	if ev.Fields["redirect_to_unix"] != "/run/agentsh/sessions/sess-1/db/appdb.sock" {
+		t.Errorf("expected redirect_to_unix socket path, got %v", ev.Fields["redirect_to_unix"])
+	}
+	if _, ok := ev.Fields["redirect_to"]; ok {
+		t.Errorf("did not expect redirect_to for unix redirect, got %v", ev.Fields["redirect_to"])
+	}
+}
+
 func TestEmitConnectRedirectEventNilEmitter(t *testing.T) {
 	p := &Proxy{
 		sessionID: "test-session",

--- a/internal/netmonitor/transparent_tcp.go
+++ b/internal/netmonitor/transparent_tcp.go
@@ -105,9 +105,34 @@ func (t *TransparentTCP) handle(conn net.Conn) error {
 			domain = d
 		}
 	}
-	dec := t.policyDecision(domain, dstIP, dstPort)
-	dec = t.maybeApprove(context.Background(), commandID, dec, "network", remote)
-	connectEv := t.netEvent("net_connect", commandID, domain, remote, dstPort, dec, nil)
+
+	redirectHostPort := net.JoinHostPort(domain, fmt.Sprintf("%d", dstPort))
+	var redirectResult *policy.ConnectRedirectResult
+	if t.policy != nil {
+		result := t.policy.EvaluateConnectRedirect(redirectHostPort)
+		if result.Matched {
+			redirectResult = result
+			if result.Visibility != "silent" {
+				emitConnectRedirectEvent(context.Background(), t.emit, t.sessionID, commandID, domain, redirectHostPort, dstPort, result)
+			}
+		}
+	}
+
+	dec := t.checkConnectNetwork(context.Background(), commandID, domain, redirectHostPort, dstIP, dstPort, redirectResult)
+	eventFields := map[string]any{}
+	if redirectResult != nil {
+		if redirectResult.RedirectTo != "" {
+			eventFields["redirect_to"] = redirectResult.RedirectTo
+		}
+		if redirectResult.RedirectToUnix != "" {
+			eventFields["redirect_to_unix"] = redirectResult.RedirectToUnix
+		}
+		eventFields["redirect_tls"] = redirectResult.TLSMode
+		if redirectResult.SNI != "" {
+			eventFields["redirect_sni"] = redirectResult.SNI
+		}
+	}
+	connectEv := t.netEvent("net_connect", commandID, domain, remote, dstPort, dec, eventFields)
 	_ = t.emit.AppendEvent(context.Background(), connectEv)
 	t.emit.Publish(connectEv)
 
@@ -117,7 +142,12 @@ func (t *TransparentTCP) handle(conn net.Conn) error {
 
 	emitMCPConnectionIfMatched(context.Background(), t.sess, t.emit, t.sessionID, commandID, domain, remote, dstPort)
 
-	up, err := net.DialTimeout("tcp", remote, 20*time.Second)
+	dialTarget := connectDialTarget(connectDialTargetInput{
+		OriginalHostPort: remote,
+		OriginalPort:     fmt.Sprintf("%d", dstPort),
+		Redirect:         redirectResult,
+	})
+	up, err := net.DialTimeout(dialTarget.Network, dialTarget.Address, 20*time.Second)
 	if err != nil {
 		return nil
 	}
@@ -149,6 +179,15 @@ func (t *TransparentTCP) policyDecision(domain string, ip net.IP, port int) poli
 		return policy.Decision{PolicyDecision: types.DecisionAllow, EffectiveDecision: types.DecisionAllow}
 	}
 	return t.policy.CheckNetworkIP(domain, ip, port)
+}
+
+func (t *TransparentTCP) checkConnectNetwork(ctx context.Context, commandID string, domain string, hostPort string, ip net.IP, port int, redirect *policy.ConnectRedirectResult) policy.Decision {
+	dec := t.policyDecision(domain, ip, port)
+	if allowUnixRedirectForDBUnavoidability(t.policy, dec, redirect) {
+		return allowConnectRedirectDecision(redirect)
+	}
+	dec = t.maybeApprove(ctx, commandID, dec, "network", hostPort)
+	return dec
 }
 
 func (t *TransparentTCP) maybeApprove(ctx context.Context, commandID string, dec policy.Decision, kind string, target string) policy.Decision {

--- a/internal/netmonitor/transparent_tcp_test.go
+++ b/internal/netmonitor/transparent_tcp_test.go
@@ -6,6 +6,7 @@ package netmonitor
 import (
 	"context"
 	"net"
+	"path/filepath"
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/policy"
@@ -27,6 +28,40 @@ func TestTransparentTCPMaybeApproveWithoutManager(t *testing.T) {
 	out := tcp.maybeApprove(context.Background(), "", in, "network", "t")
 	if out.EffectiveDecision != types.DecisionApprove {
 		t.Fatalf("expected unchanged decision without approvals manager")
+	}
+}
+
+func TestTransparentTCPCheckConnectNetwork_DBUnixRedirectBypassesGeneratedDeny(t *testing.T) {
+	engine := newTransparentDBRedirectEngine(t, true)
+	redirect := engine.EvaluateConnectRedirect("db.internal:5432")
+	if !redirect.Matched || redirect.RedirectToUnix == "" {
+		t.Fatalf("EvaluateConnectRedirect = %+v", redirect)
+	}
+
+	tcp := &TransparentTCP{policy: engine}
+	dec := tcp.checkConnectNetwork(context.Background(), "", "db.internal", "db.internal:5432", net.ParseIP("10.0.0.15"), 5432, redirect)
+	if dec.EffectiveDecision != types.DecisionAllow {
+		t.Fatalf("EffectiveDecision = %v, want allow", dec.EffectiveDecision)
+	}
+	if dec.Rule != "db-unix-redirect" {
+		t.Fatalf("Rule = %q, want redirect rule", dec.Rule)
+	}
+}
+
+func TestTransparentTCPCheckConnectNetwork_RequiresDBRedirectMetadata(t *testing.T) {
+	engine := newTransparentDBRedirectEngine(t, false)
+	redirect := engine.EvaluateConnectRedirect("db.internal:5432")
+	if !redirect.Matched || redirect.RedirectToUnix == "" {
+		t.Fatalf("EvaluateConnectRedirect = %+v", redirect)
+	}
+
+	tcp := &TransparentTCP{policy: engine}
+	dec := tcp.checkConnectNetwork(context.Background(), "", "db.internal", "db.internal:5432", net.ParseIP("10.0.0.15"), 5432, redirect)
+	if dec.EffectiveDecision != types.DecisionDeny {
+		t.Fatalf("EffectiveDecision = %v, want deny", dec.EffectiveDecision)
+	}
+	if dec.Rule != "deny-db-direct" {
+		t.Fatalf("Rule = %q, want deny rule", dec.Rule)
 	}
 }
 
@@ -72,4 +107,44 @@ func TestTransparentTCPNetEventNoThreatMetadata(t *testing.T) {
 	if ev.Policy.ThreatAction != "" {
 		t.Errorf("expected empty ThreatAction, got %q", ev.Policy.ThreatAction)
 	}
+}
+
+func newTransparentDBRedirectEngine(t *testing.T, includeRedirectMetadata bool) *policy.Engine {
+	t.Helper()
+
+	metadata := []policy.RuleMetadata{
+		{
+			RuleName:   "deny-db-direct",
+			Source:     "db_unavoidability",
+			BypassMode: "tcp_direct",
+		},
+	}
+	if includeRedirectMetadata {
+		metadata = append(metadata, policy.RuleMetadata{
+			RuleName:   "db-unix-redirect",
+			Source:     "db_unavoidability",
+			BypassMode: "tcp_direct",
+		})
+	}
+
+	pol := &policy.Policy{
+		Version:  1,
+		Metadata: metadata,
+		NetworkRules: []policy.NetworkRule{
+			{Name: "deny-db-direct", Decision: "deny", Domains: []string{"db.internal"}, Ports: []int{5432}},
+		},
+		ConnectRedirectRules: []policy.ConnectRedirectRule{
+			{
+				Name:           "db-unix-redirect",
+				Match:          `^db\.internal:5432$`,
+				RedirectToUnix: filepath.Join(t.TempDir(), "agentsh-db.sock"),
+				Visibility:     "audit_only",
+			},
+		},
+	}
+	engine, err := policy.NewEngine(pol, false, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	return engine
 }

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -1219,14 +1219,15 @@ func (e *Engine) EvaluateDnsRedirect(hostname string) *DnsRedirectResult {
 
 // ConnectRedirectResult contains the result of connect redirect evaluation
 type ConnectRedirectResult struct {
-	Matched    bool
-	Rule       string
-	RedirectTo string
-	TLSMode    string
-	SNI        string
-	Visibility string
-	Message    string
-	OnFailure  string
+	Matched        bool
+	Rule           string
+	RedirectTo     string
+	RedirectToUnix string
+	TLSMode        string
+	SNI            string
+	Visibility     string
+	Message        string
+	OnFailure      string
 }
 
 // EvaluateConnectRedirect checks if a connection should be redirected.
@@ -1259,14 +1260,15 @@ func (e *Engine) EvaluateConnectRedirect(hostPort string) *ConnectRedirectResult
 				sni = r.rule.TLS.SNI
 			}
 			return &ConnectRedirectResult{
-				Matched:    true,
-				Rule:       r.rule.Name,
-				RedirectTo: r.rule.RedirectTo,
-				TLSMode:    tlsMode,
-				SNI:        sni,
-				Visibility: visibility,
-				Message:    r.rule.Message,
-				OnFailure:  onFailure,
+				Matched:        true,
+				Rule:           r.rule.Name,
+				RedirectTo:     r.rule.RedirectTo,
+				RedirectToUnix: r.rule.RedirectToUnix,
+				TLSMode:        tlsMode,
+				SNI:            sni,
+				Visibility:     visibility,
+				Message:        r.rule.Message,
+				OnFailure:      onFailure,
 			}
 		}
 	}

--- a/internal/policy/model.go
+++ b/internal/policy/model.go
@@ -188,15 +188,19 @@ type DnsRedirectRule struct {
 	OnFailure  string `yaml:"on_failure,omitempty"` // fail_closed, fail_open, retry_original
 }
 
-// ConnectRedirectRule redirects TCP connections for matching host:port
+// ConnectRedirectRule redirects TCP connections for matching host:port.
+// Exactly one target must be set:
+//   - redirect_to for TCP host:port targets
+//   - redirect_to_unix for Unix-socket targets
 type ConnectRedirectRule struct {
-	Name       string                    `yaml:"name"`
-	Match      string                    `yaml:"match"`       // regex pattern for host:port
-	RedirectTo string                    `yaml:"redirect_to"` // new host:port destination
-	TLS        *ConnectRedirectTLSConfig `yaml:"tls,omitempty"`
-	Visibility string                    `yaml:"visibility,omitempty"` // silent, audit_only, warn
-	Message    string                    `yaml:"message,omitempty"`
-	OnFailure  string                    `yaml:"on_failure,omitempty"` // fail_closed, fail_open, retry_original
+	Name           string                    `yaml:"name"`
+	Match          string                    `yaml:"match"` // regex pattern for host:port
+	RedirectTo     string                    `yaml:"redirect_to,omitempty"`
+	RedirectToUnix string                    `yaml:"redirect_to_unix,omitempty"`
+	TLS            *ConnectRedirectTLSConfig `yaml:"tls,omitempty"`
+	Visibility     string                    `yaml:"visibility,omitempty"` // silent, audit_only, warn
+	Message        string                    `yaml:"message,omitempty"`
+	OnFailure      string                    `yaml:"on_failure,omitempty"` // fail_closed, fail_open, retry_original
 }
 
 // ConnectRedirectTLSConfig controls TLS handling for connect redirects
@@ -509,8 +513,15 @@ func (p Policy) Validate() error {
 		if _, err := regexp.Compile(r.Match); err != nil {
 			return fmt.Errorf("connect_redirects[%d]: invalid match regex: %w", i, err)
 		}
-		if r.RedirectTo == "" {
-			return fmt.Errorf("connect_redirects[%d]: redirect_to is required", i)
+		targets := 0
+		if r.RedirectTo != "" {
+			targets++
+		}
+		if r.RedirectToUnix != "" {
+			targets++
+		}
+		if targets != 1 {
+			return fmt.Errorf("connect_redirects[%d]: exactly one of redirect_to or redirect_to_unix is required", i)
 		}
 		if r.TLS != nil {
 			if r.TLS.Mode != "" && r.TLS.Mode != "passthrough" && r.TLS.Mode != "rewrite_sni" {

--- a/internal/policy/model.go
+++ b/internal/policy/model.go
@@ -10,9 +10,10 @@ import (
 )
 
 type Policy struct {
-	Version     int    `yaml:"version"`
-	Name        string `yaml:"name"`
-	Description string `yaml:"description"`
+	Version     int            `yaml:"version"`
+	Name        string         `yaml:"name"`
+	Description string         `yaml:"description"`
+	Metadata    []RuleMetadata `yaml:"metadata,omitempty"`
 
 	FileRules            []FileRule            `yaml:"file_rules"`
 	NetworkRules         []NetworkRule         `yaml:"network_rules"`
@@ -65,6 +66,17 @@ type Policy struct {
 	// (e.g. policies.db is owned by internal/db/policy). Each sub-package
 	// reads its own slice via yaml.Marshal/Unmarshal round-trip.
 	Policies yaml.Node `yaml:"policies,omitempty"`
+}
+
+// RuleMetadata is non-enforcing metadata attached to generated policy rules.
+// The policy engine ignores it for decisions; consumers use it to correlate
+// generic rule names back to higher-level generated bundles.
+type RuleMetadata struct {
+	RuleName    string `yaml:"rule_name"`
+	Source      string `yaml:"source"`
+	DBService   string `yaml:"db_service,omitempty"`
+	BypassMode  string `yaml:"bypass_mode,omitempty"`
+	Destination string `yaml:"destination,omitempty"`
 }
 
 type FileRule struct {
@@ -468,6 +480,15 @@ func (p Policy) Validate() error {
 	}
 	if p.Name == "" {
 		return fmt.Errorf("name is required")
+	}
+
+	for i, m := range p.Metadata {
+		if m.RuleName == "" {
+			return fmt.Errorf("metadata[%d]: rule_name is required", i)
+		}
+		if m.Source == "" {
+			return fmt.Errorf("metadata[%d]: source is required", i)
+		}
 	}
 
 	// Validate DNS redirect rules

--- a/internal/policy/redirect_test.go
+++ b/internal/policy/redirect_test.go
@@ -707,6 +707,55 @@ func TestConnectRedirectRuleValidation(t *testing.T) {
 	}
 }
 
+func TestConnectRedirectRuleValidation_UnixTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    ConnectRedirectRule
+		wantErr bool
+	}{
+		{
+			name: "valid unix target",
+			rule: ConnectRedirectRule{
+				Name:           "db-appdb-redirect",
+				Match:          "^db\\.internal:5432$",
+				RedirectToUnix: "/run/agentsh/sessions/sess-1/db/appdb.sock",
+			},
+		},
+		{
+			name: "both tcp and unix targets",
+			rule: ConnectRedirectRule{
+				Name:           "db-appdb-redirect",
+				Match:          "^db\\.internal:5432$",
+				RedirectTo:     "proxy.internal:15432",
+				RedirectToUnix: "/run/agentsh/sessions/sess-1/db/appdb.sock",
+			},
+			wantErr: true,
+		},
+		{
+			name: "no target",
+			rule: ConnectRedirectRule{
+				Name:  "db-appdb-redirect",
+				Match: "^db\\.internal:5432$",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Policy{
+				Version:              1,
+				Name:                 "test",
+				ConnectRedirectRules: []ConnectRedirectRule{tt.rule},
+			}
+			err := p.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestEvaluateDnsRedirect(t *testing.T) {
 	p := &Policy{
 		Version: 1,
@@ -885,6 +934,42 @@ func TestEvaluateConnectRedirect(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestEvaluateConnectRedirect_UnixTarget(t *testing.T) {
+	p := &Policy{
+		Version: 1,
+		Name:    "test",
+		ConnectRedirectRules: []ConnectRedirectRule{
+			{
+				Name:           "db-appdb-redirect",
+				Match:          "^db\\.internal:5432$",
+				RedirectToUnix: "/run/agentsh/sessions/sess-1/db/appdb.sock",
+				Message:        "Routed through AgentSH DB proxy",
+			},
+		},
+	}
+	engine, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	got := engine.EvaluateConnectRedirect("DB.Internal:5432")
+	if !got.Matched {
+		t.Fatal("EvaluateConnectRedirect did not match")
+	}
+	if got.RedirectTo != "" {
+		t.Fatalf("RedirectTo = %q, want empty tcp target", got.RedirectTo)
+	}
+	if got.RedirectToUnix != "/run/agentsh/sessions/sess-1/db/appdb.sock" {
+		t.Fatalf("RedirectToUnix = %q", got.RedirectToUnix)
+	}
+	if got.Rule != "db-appdb-redirect" {
+		t.Fatalf("Rule = %q", got.Rule)
+	}
+	if got.Message != "Routed through AgentSH DB proxy" {
+		t.Fatalf("Message = %q", got.Message)
 	}
 }
 

--- a/internal/policy/redirect_test.go
+++ b/internal/policy/redirect_test.go
@@ -1203,3 +1203,52 @@ func TestEvaluateConnectRedirect_CaseNormalization(t *testing.T) {
 		})
 	}
 }
+
+func TestPolicyMetadataValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		meta    []RuleMetadata
+		wantErr bool
+	}{
+		{
+			name: "valid db metadata",
+			meta: []RuleMetadata{{
+				RuleName:    "db-appdb-deny-direct",
+				Source:      "db_unavoidability",
+				DBService:   "appdb",
+				BypassMode:  "tcp_direct",
+				Destination: "db.internal:5432",
+			}},
+		},
+		{
+			name: "missing rule name",
+			meta: []RuleMetadata{{
+				Source:      "db_unavoidability",
+				DBService:   "appdb",
+				BypassMode:  "tcp_direct",
+				Destination: "db.internal:5432",
+			}},
+			wantErr: true,
+		},
+		{
+			name: "missing source",
+			meta: []RuleMetadata{{
+				RuleName:    "db-appdb-deny-direct",
+				DBService:   "appdb",
+				BypassMode:  "tcp_direct",
+				Destination: "db.internal:5432",
+			}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := Policy{Version: 1, Name: "test", Metadata: tt.meta}
+			err := p.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add generated unavoidability bundles for configured database services, including core deny/redirect rules, DNS alias expansion, and optional bypass-tool detection.
- Extend policy and netmonitor paths so generated TCP deny rules can be paired with Unix-socket CONNECT redirects without weakening user-authored deny rules.
- Preserve generated metadata through bundle/policy conversion and validate DB service configuration for enforce-mode safety.

## Validation

- `go test ./internal/policy ./internal/netmonitor ./internal/db/service -count=1`
- `GOOS=windows go build ./...`
- `go test ./internal/db/... -count=1 -timeout 240s`
- `git diff --check`

## Notes

This branch is based on the local DB plan 07 design/plan commits, so those docs are included in the PR diff until they land on `main`.