### PR TITLE
DB Phase 2 roadmap and catalog resolver foundation

### DIFF
--- a/docs/agentsh-db-access-spec.md
+++ b/docs/agentsh-db-access-spec.md
@@ -1,7 +1,7 @@
 # AgentSH Database Access Control — v0.8
 
-**Status:** APPROVED FOR PHASE 1 IMPLEMENTATION. Supersedes v0.7.
-**Implementation target:** PostgreSQL only (Phase 1 of the roadmap in §18).
+**Status:** PHASE 1 IMPLEMENTED. Supersedes v0.7.
+**Implementation target:** PostgreSQL Phase 1 is complete; Phase 2 planning is tracked in `docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md`.
 **Owner:** Canyon Road
 **Scope:** AgentSH OSS, Watchtower commercial control plane
 
@@ -60,7 +60,7 @@ The thesis:
 
 Unavoidability rests on AgentSH's existing primitives: process interception, network rules, file rules over Unix sockets, and DNS interception. §12 spells out the threat model in full.
 
-**Spec revision:** v0.8. **Implementation target:** Phase 1 (PostgreSQL).
+**Spec revision:** v0.8. **Implementation target:** Phase 1 implemented; Phase 2 planned separately.
 
 ---
 
@@ -93,8 +93,8 @@ Unavoidability rests on AgentSH's existing primitives: process interception, net
 
 | Phase | Adds |
 |-------|------|
-| Phase 1 | This spec. |
-| Phase 2 | Object resolution via upstream catalog. Postgres `redirect` decision (statement rewriting). |
+| Phase 1 | PostgreSQL adapter: classifier, policy evaluation, proxy, CancelRequest mapping, unavoidability bundle, and real-Postgres CI integration. |
+| Phase 2 | Object resolution via upstream catalog. Postgres `redirect` decision (statement rewriting). Improved policy ergonomics. |
 | Phase 3 | MySQL adapter. |
 | Phase 4 | Credential broker. |
 | Phase 5 | MongoDB adapter. |
@@ -1364,8 +1364,8 @@ The default config bundle includes a sample `CREATE ROLE` script for Postgres th
 | Phase | Scope | Status |
 |-------|-------|--------|
 | 0 | This spec, reviewed and approved. | done |
-| 1 | Postgres adapter. Operation taxonomy with subtypes. Per-effect evaluation with strict object coverage. Two rule families. Event emission. Unavoidability bundle. Transaction correctness. SQL PREPARE/EXECUTE. FunctionCall default-deny. CancelRequest translation. Startup-packet handling. Replication & GSSENC default-deny. | next |
-| 2 | Object resolution via upstream catalog. `redirect` decision (statement rewriting). Improved policy ergonomics. | |
+| 1 | Postgres adapter. Operation taxonomy with subtypes. Per-effect evaluation with strict object coverage. Two rule families. Event emission. Unavoidability bundle. Transaction correctness. SQL PREPARE/EXECUTE. FunctionCall default-deny. CancelRequest translation. Startup-packet handling. Replication & GSSENC default-deny. | done |
+| 2 | Object resolution via upstream catalog. `redirect` decision (statement rewriting). Improved policy ergonomics. | next |
 | 3 | MySQL adapter. | |
 | 4 | Credential broker (resolves SCRAM-SHA-256-PLUS channel binding). | |
 | 5 | MongoDB adapter. | |

--- a/docs/superpowers/plans/2026-05-14-db-plan-08-catalog-resolver-foundation.md
+++ b/docs/superpowers/plans/2026-05-14-db-plan-08-catalog-resolver-foundation.md
@@ -1,0 +1,792 @@
+# DB Plan 08 Catalog Resolver Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a pure Postgres catalog resolver foundation for Phase 2 without changing runtime proxy behavior.
+
+**Architecture:** Introduce `internal/db/catalog` as a platform-agnostic package. It owns catalog data types, a small query interface, snapshot loading from Postgres catalog rows, and deterministic name resolution against an explicit search path. Proxy integration is intentionally deferred to DB Plan 09.
+
+**Tech Stack:** Go, `context`, `database/sql`-style row scanning interfaces, existing `internal/db/effects` object kinds.
+
+---
+
+## File Structure
+
+- Create: `internal/db/catalog/types.go` - catalog identity types, relation/function structs, unresolved reason enum.
+- Create: `internal/db/catalog/snapshot.go` - immutable snapshot indexes and lookup helpers.
+- Create: `internal/db/catalog/postgres.go` - Postgres catalog SQL and loader using a tiny `Queryer` interface.
+- Create: `internal/db/catalog/resolve.go` - relation and function resolution against a snapshot plus search path.
+- Create: `internal/db/catalog/fake_test.go` - fake rows/queryer for loader tests.
+- Create: `internal/db/catalog/types_test.go` - enum/string and canonical-name tests.
+- Create: `internal/db/catalog/snapshot_test.go` - duplicate indexing and lookup tests.
+- Create: `internal/db/catalog/postgres_test.go` - loader tests using fake query rows.
+- Create: `internal/db/catalog/resolve_test.go` - qualified, unqualified, search-path, duplicate, and missing-object tests.
+- Modify: `docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md` - mark Plan 08 complete after implementation.
+
+---
+
+## Task 1: Add Catalog Types
+
+**Files:**
+- Create: `internal/db/catalog/types.go`
+- Create: `internal/db/catalog/types_test.go`
+
+- [ ] **Step 1: Write enum and canonical-name tests**
+
+Create `internal/db/catalog/types_test.go`:
+
+```go
+package catalog
+
+import "testing"
+
+func TestRelationKindString(t *testing.T) {
+	tests := map[RelationKind]string{
+		RelationTable:             "table",
+		RelationPartitionedTable:  "partitioned_table",
+		RelationView:              "view",
+		RelationMaterializedView:  "materialized_view",
+		RelationForeignTable:      "foreign_table",
+		RelationSequence:          "sequence",
+	}
+	for kind, want := range tests {
+		if got := kind.String(); got != want {
+			t.Fatalf("RelationKind(%d).String() = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+func TestCanonicalNameString(t *testing.T) {
+	name := Name{Schema: "public", Name: "orders"}
+	if got := name.String(); got != "public.orders" {
+		t.Fatalf("Name.String() = %q", got)
+	}
+}
+
+func TestUnresolvedReasonString(t *testing.T) {
+	if got := UnresolvedMissing.String(); got != "missing" {
+		t.Fatalf("UnresolvedMissing.String() = %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+go test ./internal/db/catalog
+```
+
+Expected: FAIL because package `internal/db/catalog` does not exist.
+
+- [ ] **Step 3: Add catalog type definitions**
+
+Create `internal/db/catalog/types.go`:
+
+```go
+package catalog
+
+import "fmt"
+
+type OID uint32
+
+type Name struct {
+	Schema string
+	Name   string
+}
+
+func (n Name) String() string {
+	if n.Schema == "" {
+		return n.Name
+	}
+	return fmt.Sprintf("%s.%s", n.Schema, n.Name)
+}
+
+type RelationKind uint8
+
+const (
+	RelationTable RelationKind = iota + 1
+	RelationPartitionedTable
+	RelationView
+	RelationMaterializedView
+	RelationForeignTable
+	RelationSequence
+)
+
+func (k RelationKind) String() string {
+	switch k {
+	case RelationTable:
+		return "table"
+	case RelationPartitionedTable:
+		return "partitioned_table"
+	case RelationView:
+		return "view"
+	case RelationMaterializedView:
+		return "materialized_view"
+	case RelationForeignTable:
+		return "foreign_table"
+	case RelationSequence:
+		return "sequence"
+	default:
+		return ""
+	}
+}
+
+type FunctionVolatility uint8
+
+const (
+	VolatilityImmutable FunctionVolatility = iota + 1
+	VolatilityStable
+	VolatilityVolatile
+)
+
+type Column struct {
+	Name     string
+	TypeOID  OID
+	NotNull  bool
+	Position int
+}
+
+type Relation struct {
+	OID     OID
+	Name    Name
+	Kind    RelationKind
+	Owner   string
+	Columns []Column
+}
+
+type Function struct {
+	OID          OID
+	Name         Name
+	IdentityArgs string
+	Volatility   FunctionVolatility
+	Strict       bool
+	ReturnTypeOID OID
+}
+
+type UnresolvedReason uint8
+
+const (
+	UnresolvedNone UnresolvedReason = iota
+	UnresolvedMissing
+	UnresolvedAmbiguous
+	UnresolvedUnsupported
+	UnresolvedCatalogError
+)
+
+func (r UnresolvedReason) String() string {
+	switch r {
+	case UnresolvedMissing:
+		return "missing"
+	case UnresolvedAmbiguous:
+		return "ambiguous"
+	case UnresolvedUnsupported:
+		return "unsupported"
+	case UnresolvedCatalogError:
+		return "catalog_error"
+	default:
+		return ""
+	}
+}
+
+type ResolvedRelation struct {
+	Relation Relation
+	Reason   UnresolvedReason
+}
+
+func (r ResolvedRelation) OK() bool {
+	return r.Reason == UnresolvedNone
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run:
+
+```bash
+go test ./internal/db/catalog
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/db/catalog/types.go internal/db/catalog/types_test.go
+git commit -m "db: add catalog identity types"
+```
+
+---
+
+## Task 2: Build Snapshot Indexes
+
+**Files:**
+- Create: `internal/db/catalog/snapshot.go`
+- Create: `internal/db/catalog/snapshot_test.go`
+
+- [ ] **Step 1: Write snapshot lookup tests**
+
+Create `internal/db/catalog/snapshot_test.go`:
+
+```go
+package catalog
+
+import "testing"
+
+func TestSnapshotRelationLookup(t *testing.T) {
+	snap := NewSnapshot([]Relation{
+		{OID: 10, Name: Name{Schema: "public", Name: "orders"}, Kind: RelationTable},
+		{OID: 11, Name: Name{Schema: "audit", Name: "orders"}, Kind: RelationTable},
+	}, nil)
+
+	if rel, ok := snap.RelationByOID(10); !ok || rel.Name.String() != "public.orders" {
+		t.Fatalf("RelationByOID(10) = %+v, %v", rel, ok)
+	}
+	if got := snap.RelationsByUnqualifiedName("orders"); len(got) != 2 {
+		t.Fatalf("RelationsByUnqualifiedName returned %d candidates, want 2", len(got))
+	}
+	if rel, ok := snap.RelationByName(Name{Schema: "audit", Name: "orders"}); !ok || rel.OID != 11 {
+		t.Fatalf("RelationByName(audit.orders) = %+v, %v", rel, ok)
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+go test ./internal/db/catalog
+```
+
+Expected: FAIL because `NewSnapshot` is undefined.
+
+- [ ] **Step 3: Add immutable snapshot indexes**
+
+Create `internal/db/catalog/snapshot.go`:
+
+```go
+package catalog
+
+type Snapshot struct {
+	relationsByOID   map[OID]Relation
+	relationsByName  map[Name]Relation
+	relationsByBare  map[string][]Relation
+	functionsByOID   map[OID]Function
+	functionsByName   map[Name][]Function
+}
+
+func NewSnapshot(relations []Relation, functions []Function) Snapshot {
+	s := Snapshot{
+		relationsByOID:  make(map[OID]Relation, len(relations)),
+		relationsByName: make(map[Name]Relation, len(relations)),
+		relationsByBare: make(map[string][]Relation, len(relations)),
+		functionsByOID:  make(map[OID]Function, len(functions)),
+		functionsByName:  make(map[Name][]Function, len(functions)),
+	}
+	for _, rel := range relations {
+		s.relationsByOID[rel.OID] = rel
+		s.relationsByName[rel.Name] = rel
+		s.relationsByBare[rel.Name.Name] = append(s.relationsByBare[rel.Name.Name], rel)
+	}
+	for _, fn := range functions {
+		s.functionsByOID[fn.OID] = fn
+		s.functionsByName[fn.Name] = append(s.functionsByName[fn.Name], fn)
+	}
+	return s
+}
+
+func (s Snapshot) RelationByOID(oid OID) (Relation, bool) {
+	rel, ok := s.relationsByOID[oid]
+	return rel, ok
+}
+
+func (s Snapshot) RelationByName(name Name) (Relation, bool) {
+	rel, ok := s.relationsByName[name]
+	return rel, ok
+}
+
+func (s Snapshot) RelationsByUnqualifiedName(name string) []Relation {
+	in := s.relationsByBare[name]
+	out := make([]Relation, len(in))
+	copy(out, in)
+	return out
+}
+
+func (s Snapshot) FunctionByOID(oid OID) (Function, bool) {
+	fn, ok := s.functionsByOID[oid]
+	return fn, ok
+}
+
+func (s Snapshot) FunctionsByName(name Name) []Function {
+	in := s.functionsByName[name]
+	out := make([]Function, len(in))
+	copy(out, in)
+	return out
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+go test ./internal/db/catalog
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/db/catalog/snapshot.go internal/db/catalog/snapshot_test.go
+git commit -m "db: index catalog snapshots"
+```
+
+---
+
+## Task 3: Load Postgres Catalog Rows
+
+**Files:**
+- Create: `internal/db/catalog/postgres.go`
+- Create: `internal/db/catalog/fake_test.go`
+- Create: `internal/db/catalog/postgres_test.go`
+
+- [ ] **Step 1: Write loader tests**
+
+Create `internal/db/catalog/postgres_test.go`:
+
+```go
+package catalog
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLoadPostgresSnapshotLoadsRelationsAndFunctions(t *testing.T) {
+	q := fakeQueryer{
+		relations: [][]any{
+			{uint32(10), "public", "orders", "r", "app"},
+		},
+		functions: [][]any{
+			{uint32(20), "public", "calculate_total", "integer", "s", true, uint32(23)},
+		},
+	}
+	snap, err := LoadPostgresSnapshot(context.Background(), q)
+	if err != nil {
+		t.Fatalf("LoadPostgresSnapshot: %v", err)
+	}
+	rel, ok := snap.RelationByName(Name{Schema: "public", Name: "orders"})
+	if !ok || rel.OID != 10 || rel.Kind != RelationTable {
+		t.Fatalf("loaded relation = %+v, %v", rel, ok)
+	}
+	fn, ok := snap.FunctionByOID(20)
+	if !ok || fn.Volatility != VolatilityStable || !fn.Strict {
+		t.Fatalf("loaded function = %+v, %v", fn, ok)
+	}
+}
+```
+
+- [ ] **Step 2: Add fake query rows**
+
+Create `internal/db/catalog/fake_test.go`:
+
+```go
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type fakeQueryer struct {
+	relations [][]any
+	functions [][]any
+}
+
+func (q fakeQueryer) Query(ctx context.Context, sql string, args ...any) (Rows, error) {
+	switch {
+	case strings.Contains(sql, "pg_catalog.pg_class"):
+		return &fakeRows{rows: q.relations}, nil
+	case strings.Contains(sql, "pg_catalog.pg_proc"):
+		return &fakeRows{rows: q.functions}, nil
+	default:
+		return nil, fmt.Errorf("unexpected query: %s", sql)
+	}
+}
+
+type fakeRows struct {
+	rows [][]any
+	idx  int
+}
+
+func (r *fakeRows) Next() bool {
+	return r.idx < len(r.rows)
+}
+
+func (r *fakeRows) Scan(dest ...any) error {
+	if r.idx >= len(r.rows) {
+		return fmt.Errorf("scan past end")
+	}
+	row := r.rows[r.idx]
+	r.idx++
+	if len(row) != len(dest) {
+		return fmt.Errorf("scan got %d dests, want %d", len(dest), len(row))
+	}
+	for i := range row {
+		switch d := dest[i].(type) {
+		case *uint32:
+			*d = row[i].(uint32)
+		case *string:
+			*d = row[i].(string)
+		case *bool:
+			*d = row[i].(bool)
+		default:
+			return fmt.Errorf("unsupported dest %T", dest[i])
+		}
+	}
+	return nil
+}
+
+func (r *fakeRows) Close() error { return nil }
+func (r *fakeRows) Err() error   { return nil }
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run:
+
+```bash
+go test ./internal/db/catalog
+```
+
+Expected: FAIL because `LoadPostgresSnapshot` and `Rows` are undefined.
+
+- [ ] **Step 4: Add Postgres loader**
+
+Create `internal/db/catalog/postgres.go`:
+
+```go
+package catalog
+
+import (
+	"context"
+	"fmt"
+)
+
+type Queryer interface {
+	Query(ctx context.Context, sql string, args ...any) (Rows, error)
+}
+
+type Rows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Close() error
+	Err() error
+}
+
+const relationSQL = `
+select c.oid::int4, n.nspname, c.relname, c.relkind::text, pg_get_userbyid(c.relowner)
+from pg_catalog.pg_class c
+join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+where c.relkind in ('r', 'p', 'v', 'm', 'f', 'S')
+  and n.nspname not like 'pg_toast%'
+order by n.nspname, c.relname`
+
+const functionSQL = `
+select p.oid::int4, n.nspname, p.proname,
+       pg_catalog.pg_get_function_identity_arguments(p.oid),
+       p.provolatile::text, p.proisstrict, p.prorettype::int4
+from pg_catalog.pg_proc p
+join pg_catalog.pg_namespace n on n.oid = p.pronamespace
+where n.nspname not like 'pg_toast%'
+order by n.nspname, p.proname, p.oid`
+
+func LoadPostgresSnapshot(ctx context.Context, q Queryer) (Snapshot, error) {
+	relations, err := loadRelations(ctx, q)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	functions, err := loadFunctions(ctx, q)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return NewSnapshot(relations, functions), nil
+}
+
+func loadRelations(ctx context.Context, q Queryer) ([]Relation, error) {
+	rows, err := q.Query(ctx, relationSQL)
+	if err != nil {
+		return nil, fmt.Errorf("query relations: %w", err)
+	}
+	defer rows.Close()
+	var out []Relation
+	for rows.Next() {
+		var oid uint32
+		var schema, name, relkind, owner string
+		if err := rows.Scan(&oid, &schema, &name, &relkind, &owner); err != nil {
+			return nil, fmt.Errorf("scan relation: %w", err)
+		}
+		kind, ok := parseRelationKind(relkind)
+		if !ok {
+			continue
+		}
+		out = append(out, Relation{OID: OID(oid), Name: Name{Schema: schema, Name: name}, Kind: kind, Owner: owner})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate relations: %w", err)
+	}
+	return out, nil
+}
+
+func loadFunctions(ctx context.Context, q Queryer) ([]Function, error) {
+	rows, err := q.Query(ctx, functionSQL)
+	if err != nil {
+		return nil, fmt.Errorf("query functions: %w", err)
+	}
+	defer rows.Close()
+	var out []Function
+	for rows.Next() {
+		var oid, ret uint32
+		var schema, name, args, volatility string
+		var strict bool
+		if err := rows.Scan(&oid, &schema, &name, &args, &volatility, &strict, &ret); err != nil {
+			return nil, fmt.Errorf("scan function: %w", err)
+		}
+		vol, ok := parseVolatility(volatility)
+		if !ok {
+			continue
+		}
+		out = append(out, Function{
+			OID: OID(oid), Name: Name{Schema: schema, Name: name}, IdentityArgs: args,
+			Volatility: vol, Strict: strict, ReturnTypeOID: OID(ret),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate functions: %w", err)
+	}
+	return out, nil
+}
+
+func parseRelationKind(s string) (RelationKind, bool) {
+	switch s {
+	case "r":
+		return RelationTable, true
+	case "p":
+		return RelationPartitionedTable, true
+	case "v":
+		return RelationView, true
+	case "m":
+		return RelationMaterializedView, true
+	case "f":
+		return RelationForeignTable, true
+	case "S":
+		return RelationSequence, true
+	default:
+		return 0, false
+	}
+}
+
+func parseVolatility(s string) (FunctionVolatility, bool) {
+	switch s {
+	case "i":
+		return VolatilityImmutable, true
+	case "s":
+		return VolatilityStable, true
+	case "v":
+		return VolatilityVolatile, true
+	default:
+		return 0, false
+	}
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+go test ./internal/db/catalog
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/db/catalog/postgres.go internal/db/catalog/fake_test.go internal/db/catalog/postgres_test.go
+git commit -m "db: load postgres catalog snapshots"
+```
+
+---
+
+## Task 4: Resolve Relations Against Search Path
+
+**Files:**
+- Create: `internal/db/catalog/resolve.go`
+- Create: `internal/db/catalog/resolve_test.go`
+
+- [ ] **Step 1: Write relation resolver tests**
+
+Create `internal/db/catalog/resolve_test.go`:
+
+```go
+package catalog
+
+import "testing"
+
+func TestResolveQualifiedRelation(t *testing.T) {
+	snap := NewSnapshot([]Relation{{OID: 10, Name: Name{Schema: "public", Name: "orders"}, Kind: RelationTable}}, nil)
+	got := ResolveRelation(snap, Name{Schema: "public", Name: "orders"}, nil)
+	if !got.OK() || got.Relation.OID != 10 {
+		t.Fatalf("ResolveRelation qualified = %+v", got)
+	}
+}
+
+func TestResolveUnqualifiedRelationUsesSearchPath(t *testing.T) {
+	snap := NewSnapshot([]Relation{
+		{OID: 10, Name: Name{Schema: "public", Name: "orders"}, Kind: RelationTable},
+		{OID: 11, Name: Name{Schema: "tenant", Name: "orders"}, Kind: RelationTable},
+	}, nil)
+	got := ResolveRelation(snap, Name{Name: "orders"}, []string{"tenant", "public"})
+	if !got.OK() || got.Relation.OID != 11 {
+		t.Fatalf("ResolveRelation search path = %+v", got)
+	}
+}
+
+func TestResolveUnqualifiedRelationReportsMissing(t *testing.T) {
+	snap := NewSnapshot(nil, nil)
+	got := ResolveRelation(snap, Name{Name: "orders"}, []string{"public"})
+	if got.Reason != UnresolvedMissing {
+		t.Fatalf("missing reason = %s", got.Reason.String())
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+go test ./internal/db/catalog
+```
+
+Expected: FAIL because `ResolveRelation` is undefined.
+
+- [ ] **Step 3: Add relation resolver**
+
+Create `internal/db/catalog/resolve.go`:
+
+```go
+package catalog
+
+func ResolveRelation(snap Snapshot, name Name, searchPath []string) ResolvedRelation {
+	if name.Schema != "" {
+		rel, ok := snap.RelationByName(name)
+		if !ok {
+			return ResolvedRelation{Reason: UnresolvedMissing}
+		}
+		return ResolvedRelation{Relation: rel}
+	}
+	for _, schema := range searchPath {
+		if rel, ok := snap.RelationByName(Name{Schema: schema, Name: name.Name}); ok {
+			return ResolvedRelation{Relation: rel}
+		}
+	}
+	candidates := snap.RelationsByUnqualifiedName(name.Name)
+	switch len(candidates) {
+	case 0:
+		return ResolvedRelation{Reason: UnresolvedMissing}
+	case 1:
+		return ResolvedRelation{Relation: candidates[0]}
+	default:
+		return ResolvedRelation{Reason: UnresolvedAmbiguous}
+	}
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+go test ./internal/db/catalog
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/db/catalog/resolve.go internal/db/catalog/resolve_test.go
+git commit -m "db: resolve catalog relations"
+```
+
+---
+
+## Task 5: Verify Full Repository And Mark Plan 08 Ready
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md`
+
+- [ ] **Step 1: Run package tests**
+
+Run:
+
+```bash
+go test ./internal/db/catalog
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full tests**
+
+Run:
+
+```bash
+go test ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Verify cross-platform build**
+
+Run:
+
+```bash
+GOOS=windows go build ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Update roadmap status**
+
+In `docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md`, change the Plan 08 external behavior sentence from:
+
+```markdown
+External behavior: none. Existing Phase 1 runtime remains unchanged.
+```
+
+to:
+
+```markdown
+External behavior: none. Existing Phase 1 runtime remains unchanged. Plan 08 is implemented and ready for DB Plan 09 runtime integration.
+```
+
+- [ ] **Step 5: Check docs and commit**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output.
+
+Commit:
+
+```bash
+git add docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md
+git commit -m "docs: mark db plan 08 ready"
+```

--- a/docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md
+++ b/docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md
@@ -76,7 +76,7 @@ Deliverables:
 - Safe failure modes: missing catalog row, duplicate candidate, unsupported relation kind, and query failure all return typed unresolved results.
 - Unit tests using fake query rows. No Docker or proxy integration in this plan.
 
-External behavior: none. Existing Phase 1 runtime remains unchanged.
+External behavior: none. Existing Phase 1 runtime remains unchanged. Plan 08 is implemented and ready for DB Plan 09 runtime integration.
 
 ### DB Plan 09 - Runtime Resolution Integration
 

--- a/docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md
+++ b/docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md
@@ -1,0 +1,166 @@
+# DB Phase 2 Roadmap Design
+
+**Status:** Approved by operator direction on 2026-05-14.
+**Owner:** Canyon Road
+**Source spec:** `docs/agentsh-db-access-spec.md` v0.8, Phase 2 row.
+
+This document decomposes DB Phase 2 into sequential implementation plans. Phase 1 is now complete: the Postgres proxy, policy evaluator, CancelRequest mapping, unavoidability bundle, lifecycle events, and real-Postgres CI integration have all landed on `main`.
+
+Phase 2 starts from that working proxy and adds three capabilities:
+
+1. Catalog-backed object resolution.
+2. Postgres `redirect` decisions implemented as statement rewriting.
+3. Policy ergonomics that make resolved-object policies easier to author and debug.
+
+This is a roadmap, not the full product spec for every sub-plan. Each plan still gets its own focused implementation plan before code work starts.
+
+---
+
+## 1. Phase Boundary
+
+### In Scope
+
+- Resolve syntactic Postgres object references against the upstream catalog.
+- Resolve relation identity to canonical schema/name/OID metadata.
+- Resolve function identity enough to support FunctionCall OID labeling and safer `escalate_unknown_functions` behavior.
+- Preserve Phase 1's fail-closed semantics when catalog resolution is unavailable, stale, ambiguous, or unsupported.
+- Add policy authoring helpers that explain object coverage and resolution results without weakening strict coverage by default.
+- Add `decision: redirect` for Postgres statement rewriting, scoped initially to read-only relation replacement.
+- Prove the Phase 2 behavior against real Postgres in CI.
+
+### Out of Scope
+
+- Result-set DLP, row-count caps, and catalog-aware column metadata controls. Those remain Phase 7.
+- MySQL, MongoDB, Snowflake, BigQuery, Databricks, ClickHouse, MSSQL, Cassandra, Redis, and Oracle. Those remain later phases.
+- Replication protocol classification. That remains future work.
+- Credential brokering and SCRAM-SHA-256-PLUS channel-binding support. That remains Phase 4.
+- Inspecting arbitrary function bodies for side effects. Phase 2 resolves function identity and volatility metadata, but it does not prove function purity.
+- A loose-coverage mode that silently allows uncovered objects. Phase 2 may improve diagnostics and selectors, but strict coverage remains the enforcement default.
+
+---
+
+## 2. Design Constraints
+
+Phase 2 must not regress Phase 1's high-assurance claim. Catalog resolution is an improvement in confidence, not a reason to allow statements when the resolver cannot prove identity.
+
+The proxy already has an upstream authenticated Postgres connection. Phase 2 should use that connection to build and refresh catalog metadata, not introduce a separate privileged side channel. Catalog queries must run under the same effective database identity unless an explicit future plan introduces an admin-side resolver credential.
+
+Resolution metadata should augment existing classified objects rather than replacing the syntactic object set in one step. Phase 1 policy and event consumers expect `effects.ObjectRef` and `effects.Resolution`; Phase 2 can add resolved identity fields and new resolution tags, but the migration must be incremental.
+
+Statement rewriting must be conservative. The first redirect surface should rewrite read-only relation references to configured relation/view targets. It should reject writes, DDL, procedural statements, COPY, multi-statement batches, unknown statements, and any rewrite that would need semantic reasoning beyond relation replacement.
+
+---
+
+## 3. Decomposition
+
+Phase 2 is split into five implementation plans:
+
+```
+DB Plan 08 Catalog Resolver Foundation
+  -> DB Plan 09 Runtime Resolution Integration
+  -> DB Plan 10 Policy Ergonomics
+  -> DB Plan 11 Redirect Planner
+  -> DB Plan 12 Redirect Runtime And Integration
+```
+
+### DB Plan 08 - Catalog Resolver Foundation
+
+Goal: add the catalog package and pure resolver model without changing proxy behavior.
+
+Deliverables:
+
+- `internal/db/catalog/` package with Postgres catalog types, snapshot loading, canonical name lookup, and test fakes.
+- Relation metadata: OID, schema, name, relation kind, owner, and columns.
+- Function metadata: OID, schema, name, identity args, volatility, strictness, and return type.
+- Search-path model that resolves unqualified names using an explicit schema path.
+- Safe failure modes: missing catalog row, duplicate candidate, unsupported relation kind, and query failure all return typed unresolved results.
+- Unit tests using fake query rows. No Docker or proxy integration in this plan.
+
+External behavior: none. Existing Phase 1 runtime remains unchanged.
+
+### DB Plan 09 - Runtime Resolution Integration
+
+Goal: feed catalog resolution into existing classification, policy evaluation, and DB events.
+
+Deliverables:
+
+- Per-service catalog snapshot lifecycle in the Postgres proxy.
+- Per-connection resolver context derived from StartupMessage database/user and upstream `current_schemas(true)`.
+- Resolved object metadata attached to classified effects before policy evaluation.
+- Resolution tag upgrade from syntactic tags to catalog-backed tags when every object in an effect resolves cleanly.
+- DBEvent fields for canonical object identity and resolution source.
+- Fallback behavior: if catalog data cannot be obtained, keep Phase 1 syntactic objects and fail closed under `match_object_resolution` policies.
+- Real Postgres integration coverage for schema-qualified, unqualified, temp-shadowed, view, function, and missing-object cases.
+
+External behavior: operators can write stricter policies that require catalog-backed resolution, while existing syntactic policies keep working.
+
+### DB Plan 10 - Policy Ergonomics
+
+Goal: make resolved-object policies usable without weakening enforcement.
+
+Deliverables:
+
+- Policy decode support for canonical selectors such as `relations`, `schemas`, and `functions`, compiled into existing statement-rule matching.
+- A DB policy explain command that shows classification, resolution, object coverage, and final decision for a statement under a policy file.
+- Config-load warnings for common mistakes: object rules that can never match, redirect rules on unsupported services, and resolution-sensitive rules without catalog-backed services.
+- Sample policies that show Phase 1 syntactic rules next to Phase 2 resolved-object rules.
+- Documentation updates for operator workflows.
+
+External behavior: policy authoring and debugging improve; default enforcement semantics remain strict.
+
+### DB Plan 11 - Redirect Planner
+
+Goal: define and test safe statement-rewrite planning before proxy runtime changes.
+
+Deliverables:
+
+- `decision: redirect` accepted by DB policy decode with a structured redirect action.
+- Redirect validation limited to terminate-mode Postgres services.
+- Planner that converts a resolved read-only statement plus redirect rules into a rewrite plan.
+- Relation replacement support for table/view references, including alias preservation and schema qualification.
+- Rejection reasons for writes, DDL, COPY, procedural statements, FunctionCall frames, unresolved objects, multi-statement batches, and missing redirect targets.
+- Pure tests over AST input and expected rewritten SQL.
+
+External behavior: policy files can be validated for redirect support, but the proxy does not execute redirects yet.
+
+### DB Plan 12 - Redirect Runtime And Integration
+
+Goal: execute safe redirect plans in the Postgres proxy and prove them against real Postgres.
+
+Deliverables:
+
+- Simple Query and Extended Query redirect execution paths.
+- Statement digest and DBEvent fields for original statement, rewritten statement digest, redirect rule, and target relation.
+- Prepared statement cache interaction: redirected Parse caches the rewritten classification and never mixes original and rewritten names.
+- Approval/audit interaction: redirect remains an allow-like action with explicit event fields; deny still wins.
+- Real Postgres tests for Simple Query, Extended Query, prepared statements, policy reload, and unsupported rewrite forms.
+
+External behavior: `decision: redirect` becomes usable for read-only Postgres relation replacement.
+
+---
+
+## 4. Recommended Next Work
+
+Start with DB Plan 08. It is the dependency for the rest of Phase 2, has no runtime behavior change, and lets the team settle the canonical identity model before touching the proxy.
+
+Success criteria for Plan 08:
+
+- The catalog package builds on every platform.
+- Postgres-specific SQL remains isolated behind a small query interface.
+- Unit tests prove deterministic resolution for qualified and unqualified names.
+- Failures return explicit unresolved reasons, not ad hoc errors.
+- No Phase 1 policy or proxy behavior changes.
+
+---
+
+## 5. Open Design Decisions
+
+These should be settled in the relevant implementation plans, not in this roadmap:
+
+- Whether the catalog snapshot refresh is time-based, invalidation-based, or both.
+- Whether redirect should support cross-service routing after same-service relation replacement is stable.
+- Whether function volatility metadata should feed the default `escalate_unknown_functions` behavior or remain opt-in.
+- Whether policy explain should live under `agentsh policy db explain` or extend `cmd/dbclassify-pg`.
+- Whether resolved object metadata should be stored directly on `effects.ObjectRef` or in a parallel `ResolvedObjectRef` slice during the transition.
+
+The first Plan 08 implementation should prefer the transition-friendly parallel metadata model unless the code review shows that extending `ObjectRef` is simpler and does not break existing JSON consumers.

--- a/internal/db/catalog/fake_test.go
+++ b/internal/db/catalog/fake_test.go
@@ -1,0 +1,64 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type fakeQueryer struct {
+	relations [][]any
+	columns   [][]any
+	functions [][]any
+}
+
+func (q fakeQueryer) Query(_ context.Context, sql string, _ ...any) (Rows, error) {
+	switch {
+	case strings.Contains(sql, "pg_catalog.pg_attribute"):
+		return &fakeRows{rows: q.columns}, nil
+	case strings.Contains(sql, "pg_catalog.pg_class"):
+		return &fakeRows{rows: q.relations}, nil
+	case strings.Contains(sql, "pg_catalog.pg_proc"):
+		return &fakeRows{rows: q.functions}, nil
+	default:
+		return nil, fmt.Errorf("unexpected query: %s", sql)
+	}
+}
+
+type fakeRows struct {
+	rows [][]any
+	idx  int
+}
+
+func (r *fakeRows) Next() bool {
+	return r.idx < len(r.rows)
+}
+
+func (r *fakeRows) Scan(dest ...any) error {
+	if r.idx >= len(r.rows) {
+		return fmt.Errorf("scan past end")
+	}
+	row := r.rows[r.idx]
+	r.idx++
+	if len(row) != len(dest) {
+		return fmt.Errorf("scan got %d dests, want %d", len(dest), len(row))
+	}
+	for i := range row {
+		switch d := dest[i].(type) {
+		case *uint32:
+			*d = row[i].(uint32)
+		case *string:
+			*d = row[i].(string)
+		case *bool:
+			*d = row[i].(bool)
+		case *int:
+			*d = row[i].(int)
+		default:
+			return fmt.Errorf("unsupported dest %T", dest[i])
+		}
+	}
+	return nil
+}
+
+func (r *fakeRows) Close() error { return nil }
+func (r *fakeRows) Err() error   { return nil }

--- a/internal/db/catalog/postgres.go
+++ b/internal/db/catalog/postgres.go
@@ -1,0 +1,191 @@
+package catalog
+
+import (
+	"context"
+	"fmt"
+)
+
+type Queryer interface {
+	Query(ctx context.Context, sql string, args ...any) (Rows, error)
+}
+
+type Rows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Close() error
+	Err() error
+}
+
+const relationSQL = `
+select c.oid, n.nspname, c.relname, c.relkind::text, pg_catalog.pg_get_userbyid(c.relowner)
+from pg_catalog.pg_class c
+join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+where c.relkind in ('r', 'p', 'v', 'm', 'f', 'S')
+  and n.nspname not like 'pg_toast%'
+order by n.nspname, c.relname`
+
+const columnSQL = `
+select a.attrelid, a.attname, a.atttypid, a.attnotnull, a.attnum::int4
+from pg_catalog.pg_attribute a
+join pg_catalog.pg_class c on c.oid = a.attrelid
+join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+where c.relkind in ('r', 'p', 'v', 'm', 'f', 'S')
+  and n.nspname not like 'pg_toast%'
+  and a.attnum > 0
+  and not a.attisdropped
+order by a.attrelid, a.attnum`
+
+const functionSQL = `
+select p.oid, n.nspname, p.proname,
+       pg_catalog.pg_get_function_identity_arguments(p.oid),
+       p.provolatile::text, p.proisstrict, p.prorettype
+from pg_catalog.pg_proc p
+join pg_catalog.pg_namespace n on n.oid = p.pronamespace
+where n.nspname not like 'pg_toast%'
+order by n.nspname, p.proname, p.oid`
+
+func LoadPostgresSnapshot(ctx context.Context, q Queryer) (Snapshot, error) {
+	relations, err := loadRelations(ctx, q)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	columns, err := loadColumns(ctx, q)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	for i := range relations {
+		relations[i].Columns = append([]Column(nil), columns[relations[i].OID]...)
+	}
+	functions, err := loadFunctions(ctx, q)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return NewSnapshot(relations, functions), nil
+}
+
+func loadRelations(ctx context.Context, q Queryer) ([]Relation, error) {
+	rows, err := q.Query(ctx, relationSQL)
+	if err != nil {
+		return nil, fmt.Errorf("query relations: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Relation
+	for rows.Next() {
+		var oid uint32
+		var schema, name, relkind, owner string
+		if err := rows.Scan(&oid, &schema, &name, &relkind, &owner); err != nil {
+			return nil, fmt.Errorf("scan relation: %w", err)
+		}
+		kind, ok := parseRelationKind(relkind)
+		if !ok {
+			continue
+		}
+		out = append(out, Relation{
+			OID:   OID(oid),
+			Name:  Name{Schema: schema, Name: name},
+			Kind:  kind,
+			Owner: owner,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate relations: %w", err)
+	}
+	return out, nil
+}
+
+func loadColumns(ctx context.Context, q Queryer) (map[OID][]Column, error) {
+	rows, err := q.Query(ctx, columnSQL)
+	if err != nil {
+		return nil, fmt.Errorf("query columns: %w", err)
+	}
+	defer rows.Close()
+
+	out := make(map[OID][]Column)
+	for rows.Next() {
+		var relOID, typeOID uint32
+		var name string
+		var notNull bool
+		var position int
+		if err := rows.Scan(&relOID, &name, &typeOID, &notNull, &position); err != nil {
+			return nil, fmt.Errorf("scan column: %w", err)
+		}
+		key := OID(relOID)
+		out[key] = append(out[key], Column{
+			Name:     name,
+			TypeOID:  OID(typeOID),
+			NotNull:  notNull,
+			Position: position,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate columns: %w", err)
+	}
+	return out, nil
+}
+
+func loadFunctions(ctx context.Context, q Queryer) ([]Function, error) {
+	rows, err := q.Query(ctx, functionSQL)
+	if err != nil {
+		return nil, fmt.Errorf("query functions: %w", err)
+	}
+	defer rows.Close()
+
+	var out []Function
+	for rows.Next() {
+		var oid, ret uint32
+		var schema, name, args, volatility string
+		var strict bool
+		if err := rows.Scan(&oid, &schema, &name, &args, &volatility, &strict, &ret); err != nil {
+			return nil, fmt.Errorf("scan function: %w", err)
+		}
+		vol, ok := parseVolatility(volatility)
+		if !ok {
+			continue
+		}
+		out = append(out, Function{
+			OID:           OID(oid),
+			Name:          Name{Schema: schema, Name: name},
+			IdentityArgs:  args,
+			Volatility:    vol,
+			Strict:        strict,
+			ReturnTypeOID: OID(ret),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate functions: %w", err)
+	}
+	return out, nil
+}
+
+func parseRelationKind(s string) (RelationKind, bool) {
+	switch s {
+	case "r":
+		return RelationTable, true
+	case "p":
+		return RelationPartitionedTable, true
+	case "v":
+		return RelationView, true
+	case "m":
+		return RelationMaterializedView, true
+	case "f":
+		return RelationForeignTable, true
+	case "S":
+		return RelationSequence, true
+	default:
+		return 0, false
+	}
+}
+
+func parseVolatility(s string) (FunctionVolatility, bool) {
+	switch s {
+	case "i":
+		return VolatilityImmutable, true
+	case "s":
+		return VolatilityStable, true
+	case "v":
+		return VolatilityVolatile, true
+	default:
+		return 0, false
+	}
+}

--- a/internal/db/catalog/postgres_test.go
+++ b/internal/db/catalog/postgres_test.go
@@ -1,0 +1,36 @@
+package catalog
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLoadPostgresSnapshotLoadsRelationsColumnsAndFunctions(t *testing.T) {
+	q := fakeQueryer{
+		relations: [][]any{
+			{uint32(10), "public", "orders", "r", "app"},
+		},
+		columns: [][]any{
+			{uint32(10), "id", uint32(23), true, 1},
+			{uint32(10), "note", uint32(25), false, 2},
+		},
+		functions: [][]any{
+			{uint32(20), "public", "calculate_total", "integer", "s", true, uint32(23)},
+		},
+	}
+	snap, err := LoadPostgresSnapshot(context.Background(), q)
+	if err != nil {
+		t.Fatalf("LoadPostgresSnapshot: %v", err)
+	}
+	rel, ok := snap.RelationByName(Name{Schema: "public", Name: "orders"})
+	if !ok || rel.OID != 10 || rel.Kind != RelationTable {
+		t.Fatalf("loaded relation = %+v, %v", rel, ok)
+	}
+	if len(rel.Columns) != 2 || rel.Columns[0].Name != "id" || rel.Columns[1].TypeOID != 25 {
+		t.Fatalf("loaded columns = %+v", rel.Columns)
+	}
+	fn, ok := snap.FunctionByOID(20)
+	if !ok || fn.Volatility != VolatilityStable || !fn.Strict {
+		t.Fatalf("loaded function = %+v, %v", fn, ok)
+	}
+}

--- a/internal/db/catalog/resolve.go
+++ b/internal/db/catalog/resolve.go
@@ -1,0 +1,33 @@
+package catalog
+
+func ResolveRelation(snap Snapshot, name Name, searchPath []string) ResolvedRelation {
+	if name.Schema != "" {
+		rel, ok := snap.RelationByName(name)
+		if !ok {
+			return ResolvedRelation{Reason: UnresolvedMissing}
+		}
+		return ResolvedRelation{Relation: rel}
+	}
+	for _, schema := range searchPath {
+		if rel, ok := snap.RelationByName(Name{Schema: schema, Name: name.Name}); ok {
+			return ResolvedRelation{Relation: rel}
+		}
+	}
+	candidates := snap.RelationsByUnqualifiedName(name.Name)
+	switch len(candidates) {
+	case 0:
+		return ResolvedRelation{Reason: UnresolvedMissing}
+	case 1:
+		return ResolvedRelation{Relation: candidates[0]}
+	default:
+		return ResolvedRelation{Reason: UnresolvedAmbiguous}
+	}
+}
+
+func ResolveFunctionByOID(snap Snapshot, oid OID) ResolvedFunction {
+	fn, ok := snap.FunctionByOID(oid)
+	if !ok {
+		return ResolvedFunction{Reason: UnresolvedMissing}
+	}
+	return ResolvedFunction{Function: fn}
+}

--- a/internal/db/catalog/resolve_test.go
+++ b/internal/db/catalog/resolve_test.go
@@ -1,0 +1,51 @@
+package catalog
+
+import "testing"
+
+func TestResolveQualifiedRelation(t *testing.T) {
+	snap := NewSnapshot([]Relation{{OID: 10, Name: Name{Schema: "public", Name: "orders"}, Kind: RelationTable}}, nil)
+	got := ResolveRelation(snap, Name{Schema: "public", Name: "orders"}, nil)
+	if !got.OK() || got.Relation.OID != 10 {
+		t.Fatalf("ResolveRelation qualified = %+v", got)
+	}
+}
+
+func TestResolveUnqualifiedRelationUsesSearchPath(t *testing.T) {
+	snap := NewSnapshot([]Relation{
+		{OID: 10, Name: Name{Schema: "public", Name: "orders"}, Kind: RelationTable},
+		{OID: 11, Name: Name{Schema: "tenant", Name: "orders"}, Kind: RelationTable},
+	}, nil)
+	got := ResolveRelation(snap, Name{Name: "orders"}, []string{"tenant", "public"})
+	if !got.OK() || got.Relation.OID != 11 {
+		t.Fatalf("ResolveRelation search path = %+v", got)
+	}
+}
+
+func TestResolveUnqualifiedRelationReportsAmbiguousWithoutSearchPathMatch(t *testing.T) {
+	snap := NewSnapshot([]Relation{
+		{OID: 10, Name: Name{Schema: "public", Name: "orders"}, Kind: RelationTable},
+		{OID: 11, Name: Name{Schema: "tenant", Name: "orders"}, Kind: RelationTable},
+	}, nil)
+	got := ResolveRelation(snap, Name{Name: "orders"}, []string{"missing"})
+	if got.Reason != UnresolvedAmbiguous {
+		t.Fatalf("ambiguous reason = %s", got.Reason.String())
+	}
+}
+
+func TestResolveUnqualifiedRelationReportsMissing(t *testing.T) {
+	snap := NewSnapshot(nil, nil)
+	got := ResolveRelation(snap, Name{Name: "orders"}, []string{"public"})
+	if got.Reason != UnresolvedMissing {
+		t.Fatalf("missing reason = %s", got.Reason.String())
+	}
+}
+
+func TestResolveFunctionByOID(t *testing.T) {
+	snap := NewSnapshot(nil, []Function{
+		{OID: 20, Name: Name{Schema: "public", Name: "calculate_total"}, IdentityArgs: "integer"},
+	})
+	got := ResolveFunctionByOID(snap, 20)
+	if !got.OK() || got.Function.Name.String() != "public.calculate_total" {
+		t.Fatalf("ResolveFunctionByOID = %+v", got)
+	}
+}

--- a/internal/db/catalog/snapshot.go
+++ b/internal/db/catalog/snapshot.go
@@ -1,0 +1,58 @@
+package catalog
+
+type Snapshot struct {
+	relationsByOID  map[OID]Relation
+	relationsByName map[Name]Relation
+	relationsByBare map[string][]Relation
+	functionsByOID  map[OID]Function
+	functionsByName map[Name][]Function
+}
+
+func NewSnapshot(relations []Relation, functions []Function) Snapshot {
+	s := Snapshot{
+		relationsByOID:  make(map[OID]Relation, len(relations)),
+		relationsByName: make(map[Name]Relation, len(relations)),
+		relationsByBare: make(map[string][]Relation, len(relations)),
+		functionsByOID:  make(map[OID]Function, len(functions)),
+		functionsByName: make(map[Name][]Function, len(functions)),
+	}
+	for _, rel := range relations {
+		s.relationsByOID[rel.OID] = rel
+		s.relationsByName[rel.Name] = rel
+		s.relationsByBare[rel.Name.Name] = append(s.relationsByBare[rel.Name.Name], rel)
+	}
+	for _, fn := range functions {
+		s.functionsByOID[fn.OID] = fn
+		s.functionsByName[fn.Name] = append(s.functionsByName[fn.Name], fn)
+	}
+	return s
+}
+
+func (s Snapshot) RelationByOID(oid OID) (Relation, bool) {
+	rel, ok := s.relationsByOID[oid]
+	return rel, ok
+}
+
+func (s Snapshot) RelationByName(name Name) (Relation, bool) {
+	rel, ok := s.relationsByName[name]
+	return rel, ok
+}
+
+func (s Snapshot) RelationsByUnqualifiedName(name string) []Relation {
+	in := s.relationsByBare[name]
+	out := make([]Relation, len(in))
+	copy(out, in)
+	return out
+}
+
+func (s Snapshot) FunctionByOID(oid OID) (Function, bool) {
+	fn, ok := s.functionsByOID[oid]
+	return fn, ok
+}
+
+func (s Snapshot) FunctionsByName(name Name) []Function {
+	in := s.functionsByName[name]
+	out := make([]Function, len(in))
+	copy(out, in)
+	return out
+}

--- a/internal/db/catalog/snapshot_test.go
+++ b/internal/db/catalog/snapshot_test.go
@@ -1,0 +1,34 @@
+package catalog
+
+import "testing"
+
+func TestSnapshotRelationLookup(t *testing.T) {
+	snap := NewSnapshot([]Relation{
+		{OID: 10, Name: Name{Schema: "public", Name: "orders"}, Kind: RelationTable},
+		{OID: 11, Name: Name{Schema: "audit", Name: "orders"}, Kind: RelationTable},
+	}, nil)
+
+	if rel, ok := snap.RelationByOID(10); !ok || rel.Name.String() != "public.orders" {
+		t.Fatalf("RelationByOID(10) = %+v, %v", rel, ok)
+	}
+	if got := snap.RelationsByUnqualifiedName("orders"); len(got) != 2 {
+		t.Fatalf("RelationsByUnqualifiedName returned %d candidates, want 2", len(got))
+	}
+	if rel, ok := snap.RelationByName(Name{Schema: "audit", Name: "orders"}); !ok || rel.OID != 11 {
+		t.Fatalf("RelationByName(audit.orders) = %+v, %v", rel, ok)
+	}
+}
+
+func TestSnapshotFunctionLookup(t *testing.T) {
+	snap := NewSnapshot(nil, []Function{
+		{OID: 20, Name: Name{Schema: "public", Name: "calculate_total"}, IdentityArgs: "integer"},
+		{OID: 21, Name: Name{Schema: "public", Name: "calculate_total"}, IdentityArgs: "integer, integer"},
+	})
+
+	if fn, ok := snap.FunctionByOID(20); !ok || fn.IdentityArgs != "integer" {
+		t.Fatalf("FunctionByOID(20) = %+v, %v", fn, ok)
+	}
+	if got := snap.FunctionsByName(Name{Schema: "public", Name: "calculate_total"}); len(got) != 2 {
+		t.Fatalf("FunctionsByName returned %d candidates, want 2", len(got))
+	}
+}

--- a/internal/db/catalog/types.go
+++ b/internal/db/catalog/types.go
@@ -1,0 +1,116 @@
+package catalog
+
+import "fmt"
+
+// OID is a PostgreSQL object identifier.
+type OID uint32
+
+// Name is a canonical catalog name. Schema is empty when the source reference
+// is still unqualified.
+type Name struct {
+	Schema string
+	Name   string
+}
+
+func (n Name) String() string {
+	if n.Schema == "" {
+		return n.Name
+	}
+	return fmt.Sprintf("%s.%s", n.Schema, n.Name)
+}
+
+type RelationKind uint8
+
+const (
+	RelationTable RelationKind = iota + 1
+	RelationPartitionedTable
+	RelationView
+	RelationMaterializedView
+	RelationForeignTable
+	RelationSequence
+)
+
+func (k RelationKind) String() string {
+	switch k {
+	case RelationTable:
+		return "table"
+	case RelationPartitionedTable:
+		return "partitioned_table"
+	case RelationView:
+		return "view"
+	case RelationMaterializedView:
+		return "materialized_view"
+	case RelationForeignTable:
+		return "foreign_table"
+	case RelationSequence:
+		return "sequence"
+	default:
+		return ""
+	}
+}
+
+type FunctionVolatility uint8
+
+const (
+	VolatilityImmutable FunctionVolatility = iota + 1
+	VolatilityStable
+	VolatilityVolatile
+)
+
+type Column struct {
+	Name     string
+	TypeOID  OID
+	NotNull  bool
+	Position int
+}
+
+type Relation struct {
+	OID     OID
+	Name    Name
+	Kind    RelationKind
+	Owner   string
+	Columns []Column
+}
+
+type Function struct {
+	OID           OID
+	Name          Name
+	IdentityArgs  string
+	Volatility    FunctionVolatility
+	Strict        bool
+	ReturnTypeOID OID
+}
+
+type UnresolvedReason uint8
+
+const (
+	UnresolvedNone UnresolvedReason = iota
+	UnresolvedMissing
+	UnresolvedAmbiguous
+	UnresolvedUnsupported
+	UnresolvedCatalogError
+)
+
+func (r UnresolvedReason) String() string {
+	switch r {
+	case UnresolvedMissing:
+		return "missing"
+	case UnresolvedAmbiguous:
+		return "ambiguous"
+	case UnresolvedUnsupported:
+		return "unsupported"
+	case UnresolvedCatalogError:
+		return "catalog_error"
+	default:
+		return ""
+	}
+}
+
+type ResolvedRelation struct {
+	Relation Relation
+	Reason   UnresolvedReason
+}
+
+func (r ResolvedRelation) OK() bool {
+	return r.Reason == UnresolvedNone
+}

--- a/internal/db/catalog/types.go
+++ b/internal/db/catalog/types.go
@@ -114,3 +114,12 @@ type ResolvedRelation struct {
 func (r ResolvedRelation) OK() bool {
 	return r.Reason == UnresolvedNone
 }
+
+type ResolvedFunction struct {
+	Function Function
+	Reason   UnresolvedReason
+}
+
+func (r ResolvedFunction) OK() bool {
+	return r.Reason == UnresolvedNone
+}

--- a/internal/db/catalog/types_test.go
+++ b/internal/db/catalog/types_test.go
@@ -1,0 +1,32 @@
+package catalog
+
+import "testing"
+
+func TestRelationKindString(t *testing.T) {
+	tests := map[RelationKind]string{
+		RelationTable:            "table",
+		RelationPartitionedTable: "partitioned_table",
+		RelationView:             "view",
+		RelationMaterializedView: "materialized_view",
+		RelationForeignTable:     "foreign_table",
+		RelationSequence:         "sequence",
+	}
+	for kind, want := range tests {
+		if got := kind.String(); got != want {
+			t.Fatalf("RelationKind(%d).String() = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+func TestCanonicalNameString(t *testing.T) {
+	name := Name{Schema: "public", Name: "orders"}
+	if got := name.String(); got != "public.orders" {
+		t.Fatalf("Name.String() = %q", got)
+	}
+}
+
+func TestUnresolvedReasonString(t *testing.T) {
+	if got := UnresolvedMissing.String(); got != "missing" {
+		t.Fatalf("UnresolvedMissing.String() = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Mark DB Phase 1 complete and add the DB Phase 2 roadmap split.
- Add DB Plan 08 for the catalog resolver foundation.
- Implement the new `internal/db/catalog` package with catalog identity types, snapshot indexes, Postgres catalog loading, relation columns, and relation/function resolution.

## Test Plan
- [x] `go test ./...`
- [x] `GOOS=windows go build ./...`
- [x] `git diff --check 3848124e..HEAD`
