### PR TITLE
DB Plan 10 policy ergonomics

### DIFF
--- a/docs/agentsh-db-access-spec.md
+++ b/docs/agentsh-db-access-spec.md
@@ -695,8 +695,10 @@ database_rules:
 | `db_service` | no | If omitted, matches across all services. |
 | `db_family` | no | |
 | `db_dialect` | no | |
-| `schemas` | no | Glob. Matches `objects[].schema` of any object in the effect. |
+| `schemas` | no | Glob. Matches `objects[].schema` for syntactic refs and successful `resolved_objects[].schema` for catalog-resolved refs. |
 | `objects` | no | Glob list. Matches `objects[].name` (or kind-specific structured field per §6.4) of any object in the effect. A rule with `objects: ["a", "b"]` covers an object whose name globs against `a` or `b`. Coverage is per-object: with effect objects `{a, c}`, this rule covers `a` only. **Syntactic match only**. For `session` operations, matches GUC name (lowercased). |
+| `relations` | no | Glob list. Matches catalog-resolved relation canonical names formatted as `schema.name`. A selector only matches when the effect contains a successful catalog `resolved_objects[]` relation. Recommended with `match_object_resolution: catalog_resolved`. |
+| `functions` | no | Glob list. Matches catalog-resolved function identities formatted as `schema.name(identity_args)`. Use `schema.name(*)` to match all overloads for a function name. Recommended with `match_object_resolution: catalog_resolved`. |
 | `operations` | yes | Group names or aliases. Rule matches an effect whose `group` is in the list. |
 | `subtypes` | no | If specified, rule matches only effects whose `operation_subtype` is in the list. |
 | `match_object_resolution` | no | One of the resolution tags or `*`. Matches against the effect's per-effect resolution tag. |
@@ -704,6 +706,18 @@ database_rules:
 | `message` | no | Template with `{{.Operation}}, {{.Subtype}}, {{.Schema}}, {{.Object}}, {{.Verb}}, {{.StatementPreview}}`. |
 | `timeout` | only for `approve` | Default 60 seconds. Sized to be safe inside open transactions (§14.5). Operators with long-form approval workflows opt up explicitly per rule. |
 | `acknowledge_audit_on_dangerous` | no | Required `true` to silence the load-time warning emitted when `decision: audit` is paired with operations of risk tier ≥ high (§9.4, R13). |
+
+`objects` remains syntactic-only. `relations` and `functions` are catalog selectors and do not match unresolved or unavailable catalog metadata. Strict object coverage still applies: every object slot in an effect must be covered by an allow/audit/approve rule, and any matching deny rule still wins.
+
+### DB policy explain
+
+Operators can inspect DB policy behavior offline:
+
+```bash
+agentsh policy db explain ./policy.yaml --service appdb --sql 'SELECT * FROM users'
+```
+
+The command reports classifier effects, syntactic objects, catalog-resolved objects when a fixture is supplied, per-object coverage, policy warnings, and the final decision. Catalog fixtures are YAML snapshots used for local debugging; they are not live DB connections and are not used by the proxy runtime.
 
 ### 9.3 Connection rules (`database_connection_rules`)
 

--- a/docs/superpowers/plans/2026-05-14-db-plan-10-policy-ergonomics.md
+++ b/docs/superpowers/plans/2026-05-14-db-plan-10-policy-ergonomics.md
@@ -1,0 +1,2347 @@
+# DB Plan 10 Policy Ergonomics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add catalog-resolved DB policy selectors, policy explanation data, and `agentsh policy db explain` without weakening strict coverage.
+
+**Architecture:** Keep enforcement in `internal/db/policy` pure and platform-neutral. Add canonical selector matching against Plan 09 `effects.ResolvedObjectRef`, then build a separate `internal/db/policyexplain` package for offline classification, catalog fixture resolution, and CLI output shaping. Wire the operator command under the existing `agentsh policy` tree.
+
+**Tech Stack:** Go, `gopkg.in/yaml.v3`, `github.com/gobwas/glob`, Cobra CLI, existing Postgres classifier/catalog/effects/policy packages.
+
+---
+
+## File Structure
+
+- Modify `internal/db/policy/types.go`: add `Relations` and `Functions` fields to `StatementRule`.
+- Modify `internal/db/policy/compile.go`: compile canonical selector globs and add resolved relation/function match helpers.
+- Modify `internal/db/policy/validate.go`: emit new warning codes and update redirect error wording.
+- Modify `internal/db/policy/evaluate.go`: share evaluation with an explanation path and use canonical selector coverage.
+- Create `internal/db/policy/explain.go`: exported explanation API types and `ExplainStatement`.
+- Modify tests in `internal/db/policy/*_test.go`: decode, compile, validate, canonical evaluation, explanation.
+- Create `internal/db/policyexplain/fixture.go`: YAML fixture decode into `catalog.Snapshot` plus search path.
+- Create `internal/db/policyexplain/resolve.go`: platform-neutral catalog resolution for classified statements.
+- Create `internal/db/policyexplain/run.go`: classify SQL, optionally resolve via fixture, call policy explanation API.
+- Create `internal/db/policyexplain/types.go`: stable JSON report structs for CLI output.
+- Create tests in `internal/db/policyexplain/*_test.go`.
+- Modify `internal/cli/policy_cmd.go`: add `policy db explain` and make `policy validate` surface DB warnings.
+- Create `internal/cli/policy_db_explain_test.go`.
+- Modify `internal/db/policy/testdata/sample-policy.yaml`: add canonical selector examples.
+- Modify `docs/agentsh-db-access-spec.md`: document `relations`, `functions`, resolved `schemas`, and offline explain.
+
+---
+
+## Task 1: Decode, Compile, And Warn For Canonical Selectors
+
+**Files:**
+- Modify: `internal/db/policy/types.go`
+- Modify: `internal/db/policy/compile.go`
+- Modify: `internal/db/policy/validate.go`
+- Modify: `internal/db/policy/decode_test.go`
+- Modify: `internal/db/policy/compile_test.go`
+- Modify: `internal/db/policy/validate_test.go`
+
+- [ ] **Step 1: Write decode and compile tests for selector fields**
+
+Add these tests to `internal/db/policy/decode_test.go` and `internal/db/policy/compile_test.go`.
+
+```go
+func TestDecode_CanonicalSelectors(t *testing.T) {
+	src := `version: 1
+name: t
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: terminate_reissue
+database_rules:
+  - name: canonical-read
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users", "sales.*"]
+    functions: ["public.safe_fn(integer)", "pg_catalog.*"]
+    match_object_resolution: catalog_resolved
+    decision: allow
+`
+	rs, warns, err := loadDB(t, src)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("warnings = %+v", warns)
+	}
+	rules := rs.AllStatementRules()
+	if len(rules) != 1 {
+		t.Fatalf("rules = %d, want 1", len(rules))
+	}
+	if got := rules[0].Relations; len(got) != 2 || got[0] != "public.users" || got[1] != "sales.*" {
+		t.Fatalf("Relations = %#v", got)
+	}
+	if got := rules[0].Functions; len(got) != 2 || got[0] != "public.safe_fn(integer)" || got[1] != "pg_catalog.*" {
+		t.Fatalf("Functions = %#v", got)
+	}
+}
+
+func TestCompileStatementRule_CanonicalSelectorGlobs(t *testing.T) {
+	r := &StatementRule{
+		Name:       "canonical",
+		Operations: []string{"READ"},
+		Relations:  []string{"public.users", "sales.*"},
+		Functions:  []string{"public.safe_fn(integer)", "pg_catalog.*"},
+		Decision:   "allow",
+	}
+	c, err := compileStatementRule(r)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	rel := effects.ResolvedObjectRef{
+		Source: effects.ResolvedObjectSourceCatalog,
+		Kind:   effects.ResolvedObjectRelation,
+		Schema: "public",
+		Name:   "users",
+	}
+	if !c.relationMatches(rel) {
+		t.Fatalf("public.users relation should match")
+	}
+	fn := effects.ResolvedObjectRef{
+		Source:               effects.ResolvedObjectSourceCatalog,
+		Kind:                 effects.ResolvedObjectFunction,
+		Schema:               "public",
+		Name:                 "safe_fn",
+		FunctionIdentityArgs: "integer",
+	}
+	if !c.functionMatches(fn) {
+		t.Fatalf("public.safe_fn(integer) function should match")
+	}
+}
+
+func TestCompileStatementRule_BadCanonicalGlob(t *testing.T) {
+	_, err := compileStatementRule(&StatementRule{
+		Name:       "bad-relation",
+		Operations: []string{"READ"},
+		Relations:  []string{"["},
+		Decision:   "allow",
+	})
+	if err == nil || !strings.Contains(err.Error(), "glob_compile") || !strings.Contains(err.Error(), "relations") {
+		t.Fatalf("want relation glob_compile error, got %v", err)
+	}
+
+	_, err = compileStatementRule(&StatementRule{
+		Name:       "bad-function",
+		Operations: []string{"READ"},
+		Functions:  []string{"["},
+		Decision:   "allow",
+	})
+	if err == nil || !strings.Contains(err.Error(), "glob_compile") || !strings.Contains(err.Error(), "functions") {
+		t.Fatalf("want function glob_compile error, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run selector decode/compile tests and verify they fail**
+
+Run:
+
+```bash
+go test ./internal/db/policy -run 'TestDecode_CanonicalSelectors|TestCompileStatementRule_CanonicalSelectorGlobs|TestCompileStatementRule_BadCanonicalGlob' -count=1
+```
+
+Expected: FAIL because `StatementRule.Relations`, `StatementRule.Functions`, `compiledStatementRule.relationMatches`, and `compiledStatementRule.functionMatches` do not exist.
+
+- [ ] **Step 3: Add selector fields and compiled matcher fields**
+
+Update `internal/db/policy/types.go`.
+
+```go
+type StatementRule struct {
+	Name                        string        `yaml:"name"`
+	DBService                   string        `yaml:"db_service,omitempty"`
+	DBFamily                    string        `yaml:"db_family,omitempty"`
+	DBDialect                   string        `yaml:"db_dialect,omitempty"`
+	Schemas                     []string      `yaml:"schemas,omitempty"`
+	Objects                     []string      `yaml:"objects,omitempty"`
+	Relations                   []string      `yaml:"relations,omitempty"`
+	Functions                   []string      `yaml:"functions,omitempty"`
+	Operations                  []string      `yaml:"operations"`
+	Subtypes                    []string      `yaml:"subtypes,omitempty"`
+	MatchObjectResolution       string        `yaml:"match_object_resolution,omitempty"`
+	Decision                    string        `yaml:"decision"`
+	Message                     string        `yaml:"message,omitempty"`
+	Timeout                     time.Duration `yaml:"timeout,omitempty"`
+	AcknowledgeAuditOnDangerous bool          `yaml:"acknowledge_audit_on_dangerous,omitempty"`
+	DenyModeInTx                string        `yaml:"deny_mode_in_tx,omitempty"`
+}
+```
+
+Update `compiledStatementRule` in `internal/db/policy/compile.go`.
+
+```go
+type compiledStatementRule struct {
+	src           *StatementRule
+	verb          DecisionVerb
+	groups        map[effects.Group]struct{}
+	subtypes      map[effects.Subtype]struct{} // empty = all subtypes match
+	resolution    resolutionMatcher
+	schemas       []glob.Glob // empty = all schemas match
+	objects       []glob.Glob // syntactic objects; empty = all objects match
+	relations     []glob.Glob // resolved relation canonical names
+	functions     []glob.Glob // resolved function identity names
+	timeout       time.Duration
+	msgTemplate   *template.Template // nil = no message rendering
+	serviceFilter serviceFilter
+}
+```
+
+- [ ] **Step 4: Compile canonical selector globs**
+
+In `compileStatementRule`, after compiling `Objects`, add:
+
+```go
+for _, pat := range r.Relations {
+	g, err := glob.Compile(pat)
+	if err != nil {
+		return nil, fmt.Errorf("glob_compile: rule %q relations %q: %w", r.Name, pat, err)
+	}
+	c.relations = append(c.relations, g)
+}
+for _, pat := range r.Functions {
+	g, err := glob.Compile(pat)
+	if err != nil {
+		return nil, fmt.Errorf("glob_compile: rule %q functions %q: %w", r.Name, pat, err)
+	}
+	c.functions = append(c.functions, g)
+}
+```
+
+- [ ] **Step 5: Add canonical selector helper methods**
+
+Add these helpers to `internal/db/policy/compile.go`.
+
+```go
+func (c *compiledStatementRule) hasObjectSelectors() bool {
+	return len(c.objects) > 0 || len(c.relations) > 0 || len(c.functions) > 0
+}
+
+func (c *compiledStatementRule) relationMatches(r effects.ResolvedObjectRef) bool {
+	if len(c.relations) == 0 {
+		return false
+	}
+	if r.Source != effects.ResolvedObjectSourceCatalog ||
+		r.Kind != effects.ResolvedObjectRelation ||
+		r.UnresolvedReason != "" {
+		return false
+	}
+	target := r.CanonicalName()
+	for _, g := range c.relations {
+		if g.Match(target) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *compiledStatementRule) functionMatches(r effects.ResolvedObjectRef) bool {
+	if len(c.functions) == 0 {
+		return false
+	}
+	if r.Source != effects.ResolvedObjectSourceCatalog ||
+		r.Kind != effects.ResolvedObjectFunction ||
+		r.UnresolvedReason != "" {
+		return false
+	}
+	target := resolvedFunctionIdentity(r)
+	for _, g := range c.functions {
+		if g.Match(target) {
+			return true
+		}
+	}
+	return false
+}
+
+func resolvedFunctionIdentity(r effects.ResolvedObjectRef) string {
+	name := r.CanonicalName()
+	return name + "(" + r.FunctionIdentityArgs + ")"
+}
+```
+
+- [ ] **Step 6: Run selector compile tests and verify they pass**
+
+Run:
+
+```bash
+go test ./internal/db/policy -run 'TestDecode_CanonicalSelectors|TestCompileStatementRule_CanonicalSelectorGlobs|TestCompileStatementRule_BadCanonicalGlob' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Write warning tests**
+
+Add these tests to `internal/db/policy/validate_test.go`.
+
+```go
+func TestValidate_CanonicalSelectorWarnings(t *testing.T) {
+	src := `version: 1
+name: t
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: terminate_reissue
+database_rules:
+  - name: canonical-without-resolution
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    decision: allow
+  - name: selector-on-transaction
+    db_service: appdb
+    operations: [transaction]
+    relations: ["public.users"]
+    decision: allow
+`
+	_, warns, err := loadDB(t, src)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	assertWarningCode(t, warns, "canonical_selector_without_resolution_guard")
+	assertWarningCode(t, warns, "selector_on_objectless_operation")
+}
+
+func TestValidate_CanonicalSelectorWithoutCatalogServiceWarning(t *testing.T) {
+	src := `version: 1
+name: t
+db_services:
+  legacy:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: passthrough
+database_rules:
+  - name: canonical-wide
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: allow
+`
+	_, warns, err := loadDB(t, src)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	assertWarningCode(t, warns, "canonical_selector_without_catalog_service")
+}
+
+func assertWarningCode(t *testing.T, warns []Warning, code string) {
+	t.Helper()
+	for _, w := range warns {
+		if w.Code == code {
+			return
+		}
+	}
+	t.Fatalf("warning %q not found in %+v", code, warns)
+}
+```
+
+- [ ] **Step 8: Run warning tests and verify they fail**
+
+Run:
+
+```bash
+go test ./internal/db/policy -run 'TestValidate_CanonicalSelector' -count=1
+```
+
+Expected: FAIL because the warning logic is not implemented.
+
+- [ ] **Step 9: Add warning logic**
+
+Add these helpers to `internal/db/policy/validate.go`.
+
+```go
+func ruleHasCanonicalSelectors(r *StatementRule) bool {
+	return len(r.Relations) > 0 || len(r.Functions) > 0
+}
+
+func ruleHasAnyObjectSelector(r *StatementRule) bool {
+	return len(r.Objects) > 0 || len(r.Relations) > 0 || len(r.Functions) > 0
+}
+
+func expandedGroups(r *StatementRule) map[effects.Group]struct{} {
+	groups := map[effects.Group]struct{}{}
+	for _, op := range r.Operations {
+		gs, ok := effects.ExpandAlias(op)
+		if !ok {
+			continue
+		}
+		for _, g := range gs {
+			groups[g] = struct{}{}
+		}
+	}
+	return groups
+}
+
+func allGroupsObjectless(groups map[effects.Group]struct{}) bool {
+	if len(groups) == 0 {
+		return false
+	}
+	for g := range groups {
+		if !isObjectlessGroup(g) {
+			return false
+		}
+	}
+	return true
+}
+```
+
+Inside `validateStatementRule`, reuse the local `groups` map and append warnings:
+
+```go
+if ruleHasCanonicalSelectors(r) {
+	if r.MatchObjectResolution != "catalog_resolved" {
+		warns = append(warns, Warning{
+			Rule:    r.Name,
+			Field:   "match_object_resolution",
+			Code:    "canonical_selector_without_resolution_guard",
+			Message: fmt.Sprintf("rule %q uses catalog selectors without match_object_resolution: catalog_resolved", r.Name),
+		})
+	}
+	if !ruleMatchesTerminatePostgresService(r, svcs) {
+		warns = append(warns, Warning{
+			Rule:    r.Name,
+			Field:   "relations",
+			Code:    "canonical_selector_without_catalog_service",
+			Message: fmt.Sprintf("rule %q uses catalog selectors but matches no terminate-mode Postgres service", r.Name),
+		})
+	}
+}
+if ruleHasAnyObjectSelector(r) && allGroupsObjectless(groups) {
+	warns = append(warns, Warning{
+		Rule:    r.Name,
+		Field:   "objects",
+		Code:    "selector_on_objectless_operation",
+		Message: fmt.Sprintf("rule %q constrains object selectors on objectless operations", r.Name),
+	})
+}
+```
+
+Add the service helper in `validate.go`:
+
+```go
+func ruleMatchesTerminatePostgresService(r *StatementRule, svcs map[ServiceID]*DBService) bool {
+	for id, svc := range svcs {
+		if svc == nil {
+			continue
+		}
+		if svc.Family != "postgres" {
+			continue
+		}
+		if svc.TLSMode == "passthrough" {
+			continue
+		}
+		filter := serviceFilter{service: ServiceID(r.DBService), family: r.DBFamily, dialect: r.DBDialect}
+		if filter.matches(id, svc) {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 10: Update redirect error wording**
+
+Change both redirect validation errors in `validate.go`:
+
+```go
+errs = append(errs, fmt.Errorf("redirect_not_supported_until_plan_11: database_rules[%q]: decision redirect is supported starting in DB Plan 11", r.Name))
+```
+
+For connection rules:
+
+```go
+errs = append(errs, fmt.Errorf("redirect_not_supported_until_plan_11: database_connection_rules[%q]: decision redirect is not valid for DB connection rules", r.Name))
+```
+
+Update existing tests that asserted `rule_decision_redirect` to assert `redirect_not_supported_until_plan_11`.
+
+- [ ] **Step 11: Run policy package tests**
+
+Run:
+
+```bash
+go test ./internal/db/policy -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 12: Commit Task 1**
+
+Run:
+
+```bash
+git add internal/db/policy
+git commit -m "db/policy: decode canonical selectors"
+```
+
+---
+
+## Task 2: Apply Canonical Selectors In Policy Evaluation
+
+**Files:**
+- Modify: `internal/db/policy/evaluate.go`
+- Modify: `internal/db/policy/compile.go`
+- Create: `internal/db/policy/evaluate_canonical_test.go`
+
+- [ ] **Step 1: Write relation selector evaluation tests**
+
+Create `internal/db/policy/evaluate_canonical_test.go`.
+
+```go
+package policy
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
+
+func TestEvaluate_RelationSelectorCoversResolvedRelation(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: canonical-read, db_service: appdb, operations: [READ], relations: ["public.users"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogResolved,
+		Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "users"}},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			OID:    16384,
+			Schema: "public",
+			Name:   "users",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbAllow || d.RuleName != "canonical-read" {
+		t.Fatalf("decision = %+v, want allow by canonical-read", d)
+	}
+}
+
+func TestEvaluate_RelationSelectorDoesNotCoverUnresolvedRelation(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: canonical-read, db_service: appdb, operations: [READ], relations: ["public.users"], match_object_resolution: catalog_unresolved, decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogUnresolved,
+		Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "users"}},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source:           effects.ResolvedObjectSourceCatalog,
+			Kind:             effects.ResolvedObjectRelation,
+			Schema:           "public",
+			Name:             "users",
+			UnresolvedReason: "missing",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbDeny || d.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny", d)
+	}
+}
+```
+
+- [ ] **Step 2: Write function and resolved-schema tests**
+
+Append to `evaluate_canonical_test.go`.
+
+```go
+func TestEvaluate_FunctionSelectorCoversResolvedFunction(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: safe-fn, db_service: appdb, operations: [procedural], functions: ["public.safe_fn(integer)"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	oid := int32(2200)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:       effects.GroupProcedural,
+		Resolution:  effects.ResolutionCatalogResolved,
+		FunctionOID: &oid,
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source:               effects.ResolvedObjectSourceCatalog,
+			Kind:                 effects.ResolvedObjectFunction,
+			OID:                  2200,
+			Schema:               "public",
+			Name:                 "safe_fn",
+			FunctionIdentityArgs: "integer",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbAllow || d.RuleName != "safe-fn" {
+		t.Fatalf("decision = %+v, want allow by safe-fn", d)
+	}
+}
+
+func TestEvaluate_SchemasMatchesResolvedSchema(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: sales-read, db_service: appdb, operations: [READ], schemas: ["sales"], relations: ["sales.orders"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogResolved,
+		Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "orders"}},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			Schema: "sales",
+			Name:   "orders",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbAllow || d.RuleName != "sales-read" {
+		t.Fatalf("decision = %+v, want allow by sales-read", d)
+	}
+}
+
+func TestEvaluate_MixedSelectorsCoverByEitherFamily(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: migration-read, db_service: appdb, operations: [READ], objects: ["legacy_users"], relations: ["public.users"], decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogResolved,
+		Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "users"}},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			Schema: "public",
+			Name:   "users",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbAllow || d.RuleName != "migration-read" {
+		t.Fatalf("decision = %+v, want allow by migration-read", d)
+	}
+}
+```
+
+- [ ] **Step 3: Run canonical evaluation tests and verify they fail**
+
+Run:
+
+```bash
+go test ./internal/db/policy -run 'TestEvaluate_(RelationSelector|FunctionSelector|SchemasMatchesResolved|MixedSelectors)' -count=1
+```
+
+Expected: FAIL because evaluation still checks only syntactic object matching and treats procedural FunctionCall effects as objectless.
+
+- [ ] **Step 4: Add object slot helpers**
+
+In `internal/db/policy/evaluate.go`, add helpers near `evaluateEffect`.
+
+```go
+func resolvedForObjectIndex(e effects.Effect, idx int) (effects.ResolvedObjectRef, bool) {
+	if idx < 0 || idx >= len(e.ResolvedObjects) {
+		return effects.ResolvedObjectRef{}, false
+	}
+	return e.ResolvedObjects[idx], true
+}
+
+func functionResolvedObject(e effects.Effect) (effects.ResolvedObjectRef, bool) {
+	for _, r := range e.ResolvedObjects {
+		if r.Kind == effects.ResolvedObjectFunction {
+			return r, true
+		}
+	}
+	return effects.ResolvedObjectRef{}, false
+}
+
+func ruleMatchesObjectSlot(r *compiledStatementRule, e effects.Effect, idx int) (bool, string) {
+	o := e.Objects[idx]
+	resolved, hasResolved := resolvedObjectAt(e, idx)
+	if !r.schemaMatchesObjectSlot(o, resolved, hasResolved) {
+		return false, ""
+	}
+	if !r.hasObjectSelectors() {
+		return true, "all"
+	}
+	if len(r.objects) > 0 && r.objectMatches(o) {
+		return true, "objects"
+	}
+	if hasResolved && r.relationMatches(resolved) {
+		return true, "relations"
+	}
+	if hasResolved && r.functionMatches(resolved) {
+		return true, "functions"
+	}
+	return false, ""
+}
+
+func resolvedObjectAt(e effects.Effect, idx int) (effects.ResolvedObjectRef, bool) {
+	if idx < 0 || idx >= len(e.ResolvedObjects) {
+		return effects.ResolvedObjectRef{}, false
+	}
+	return e.ResolvedObjects[idx], true
+}
+```
+
+Then add a method in `compile.go`:
+
+```go
+func (c *compiledStatementRule) schemaMatchesObjectSlot(o effects.ObjectRef, resolved effects.ResolvedObjectRef, hasResolved bool) bool {
+	if len(c.schemas) == 0 {
+		return true
+	}
+	for _, g := range c.schemas {
+		if o.Schema != "" && g.Match(o.Schema) {
+			return true
+		}
+		if hasResolved && resolved.Schema != "" && g.Match(resolved.Schema) {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 5: Use object slot helpers in deny and coverage passes**
+
+In `evaluateEffect`, replace:
+
+```go
+if !r.schemaMatches(o) {
+	continue
+}
+if r.objectMatches(o) {
+	return effectDecision{verb: verbDeny, rule: r, denyMatchingObject: o}
+}
+```
+
+with:
+
+```go
+if ok, _ := ruleMatchesObjectSlot(r, e, i); ok {
+	return effectDecision{verb: verbDeny, rule: r, denyMatchingObject: o}
+}
+```
+
+Also replace the non-deny coverage checks:
+
+```go
+if !r.schemaMatches(o) {
+	continue
+}
+if !r.objectMatches(o) {
+	continue
+}
+coverage[i] = append(coverage[i], r)
+```
+
+with:
+
+```go
+if ok, _ := ruleMatchesObjectSlot(r, e, i); ok {
+	coverage[i] = append(coverage[i], r)
+}
+```
+
+- [ ] **Step 6: Support function-only effects with resolved function metadata**
+
+Update `isObjectlessEffect` in `evaluate.go` so a function selector can cover an OID-only FunctionCall effect:
+
+```go
+func isObjectlessEffect(e effects.Effect) bool {
+	if isObjectlessGroup(e.Group) {
+		return true
+	}
+	if e.Subtype == effects.SubtypeFunctionCallProtocol && len(e.ResolvedObjects) == 0 {
+		return true
+	}
+	return false
+}
+```
+
+At the start of `evaluateEffect`, before the objectless branch, add:
+
+```go
+if len(e.Objects) == 0 && len(e.ResolvedObjects) > 0 {
+	return evaluateEffectResolvedOnly(e, applicable)
+}
+```
+
+Add `evaluateEffectResolvedOnly`:
+
+```go
+func evaluateEffectResolvedOnly(e effects.Effect, applicable []*compiledStatementRule) effectDecision {
+	for _, r := range applicable {
+		if r.verb != VerbDeny || !ruleMatchesEffectMeta(r, e) {
+			continue
+		}
+		for _, resolved := range e.ResolvedObjects {
+			if r.functionMatches(resolved) || r.relationMatches(resolved) {
+				return effectDecision{verb: verbDeny, rule: r}
+			}
+		}
+	}
+
+	var coverage []*compiledStatementRule
+	for _, r := range applicable {
+		if r.verb == VerbDeny || !ruleMatchesEffectMeta(r, e) {
+			continue
+		}
+		for _, resolved := range e.ResolvedObjects {
+			if r.functionMatches(resolved) || r.relationMatches(resolved) || !r.hasObjectSelectors() {
+				coverage = append(coverage, r)
+				break
+			}
+		}
+	}
+	if len(coverage) == 0 {
+		return effectDecision{verb: verbImplicitDeny}
+	}
+	return foldCoverageRules(coverage)
+}
+```
+
+Extract the repeated objectless coverage fold into a helper:
+
+```go
+func foldCoverageRules(coverage []*compiledStatementRule) effectDecision {
+	var (
+		best         internalVerb = verbAllow
+		primary      *compiledStatementRule
+		approveRules []*compiledStatementRule
+		auditRules   []*compiledStatementRule
+		approveSeen  = map[string]bool{}
+		auditSeen    = map[string]bool{}
+	)
+	for _, r := range coverage {
+		switch r.verb {
+		case VerbApprove:
+			if verbApprove > best {
+				best = verbApprove
+			}
+			if !approveSeen[r.src.Name] {
+				approveSeen[r.src.Name] = true
+				approveRules = append(approveRules, r)
+			}
+		case VerbAudit:
+			if verbAudit > best {
+				best = verbAudit
+			}
+			if !auditSeen[r.src.Name] {
+				auditSeen[r.src.Name] = true
+				auditRules = append(auditRules, r)
+			}
+		}
+	}
+	switch best {
+	case verbApprove:
+		primary = approveRules[0]
+	case verbAudit:
+		primary = auditRules[0]
+	default:
+		primary = coverage[0]
+	}
+	return effectDecision{
+		verb:                best,
+		rule:                primary,
+		contributingApprove: approveRules,
+		contributingAudit:   auditRules,
+	}
+}
+```
+
+Use `foldCoverageRules(coverage)` inside `evaluateEffectObjectless` to remove duplicated fold logic.
+
+- [ ] **Step 7: Run canonical evaluation tests**
+
+Run:
+
+```bash
+go test ./internal/db/policy -run 'TestEvaluate_(RelationSelector|FunctionSelector|SchemasMatchesResolved|MixedSelectors)' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run full policy package tests**
+
+Run:
+
+```bash
+go test ./internal/db/policy -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit Task 2**
+
+Run:
+
+```bash
+git add internal/db/policy
+git commit -m "db/policy: match canonical selectors"
+```
+
+---
+
+## Task 3: Add Policy Explanation API
+
+**Files:**
+- Create: `internal/db/policy/explain.go`
+- Modify: `internal/db/policy/evaluate.go`
+- Create: `internal/db/policy/explain_test.go`
+
+- [ ] **Step 1: Write explanation API tests**
+
+Create `internal/db/policy/explain_test.go`.
+
+```go
+package policy
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
+
+func TestExplainStatement_ReturnsCoverageAndDecision(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: canonical-read, db_service: appdb, operations: [READ], relations: ["public.users"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{RawVerb: "SELECT", Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogResolved,
+		Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "users"}},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			Schema: "public",
+			Name:   "users",
+		}},
+	}}}
+
+	ex := ExplainStatement(stmt, rs, "appdb")
+	if ex.Decision.Verb != VerbAllow || ex.Decision.RuleName != "canonical-read" {
+		t.Fatalf("decision = %+v", ex.Decision)
+	}
+	if len(ex.Effects) != 1 || len(ex.Effects[0].Coverage) != 1 {
+		t.Fatalf("coverage = %+v", ex.Effects)
+	}
+	cov := ex.Effects[0].Coverage[0]
+	if !cov.Covered {
+		t.Fatalf("coverage = %+v, want covered", cov)
+	}
+	if len(cov.CoveringRules) != 1 || cov.CoveringRules[0].RuleName != "canonical-read" {
+		t.Fatalf("covering rules = %+v", cov.CoveringRules)
+	}
+	if cov.CoveringRules[0].Selector != "relations" {
+		t.Fatalf("selector = %q, want relations", cov.CoveringRules[0].Selector)
+	}
+}
+
+func TestExplainStatement_ReportsUncoveredObject(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: read-users, db_service: appdb, operations: [READ], objects: ["users"], decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionQualified,
+		Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "payments"}},
+	}}}
+
+	ex := ExplainStatement(stmt, rs, "appdb")
+	if ex.Decision.Verb != VerbDeny || ex.Decision.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny", ex.Decision)
+	}
+	if len(ex.Effects) != 1 || len(ex.Effects[0].Coverage) != 1 {
+		t.Fatalf("coverage = %+v", ex.Effects)
+	}
+	cov := ex.Effects[0].Coverage[0]
+	if cov.Covered || cov.UncoveredReason == "" {
+		t.Fatalf("coverage = %+v, want uncovered reason", cov)
+	}
+}
+```
+
+- [ ] **Step 2: Run explanation tests and verify they fail**
+
+Run:
+
+```bash
+go test ./internal/db/policy -run TestExplainStatement -count=1
+```
+
+Expected: FAIL because `ExplainStatement` and explanation types do not exist.
+
+- [ ] **Step 3: Add explanation types**
+
+Create `internal/db/policy/explain.go`.
+
+```go
+package policy
+
+import "github.com/agentsh/agentsh/internal/db/effects"
+
+type StatementExplanation struct {
+	Decision        Decision
+	ApplicableRules []string
+	Effects         []EffectExplanation
+}
+
+type EffectExplanation struct {
+	Index      int
+	Group      effects.Group
+	Subtype    effects.Subtype
+	Resolution effects.Resolution
+	Coverage   []ObjectCoverage
+	DenyRules  []RuleMatch
+}
+
+type ObjectCoverage struct {
+	Index            int
+	Object           effects.ObjectRef
+	ResolvedObject   *effects.ResolvedObjectRef
+	Covered          bool
+	CoveringRules    []RuleMatch
+	UncoveredReason  string
+}
+
+type RuleMatch struct {
+	RuleName string
+	Verb     DecisionVerb
+	Selector string
+}
+
+func ExplainStatement(stmt effects.ClassifiedStatement, rs *RuleSet, svc ServiceID) StatementExplanation {
+	if rs == nil {
+		return StatementExplanation{Decision: implicitDeny(stmt, 0, "policy not loaded")}
+	}
+	applicable := rs.statementRulesFor(svc)
+	perEffect := make([]effectDecision, len(stmt.Effects))
+	effectsOut := make([]EffectExplanation, len(stmt.Effects))
+	for i, e := range stmt.Effects {
+		perEffect[i], effectsOut[i] = explainEffect(i, e, applicable)
+	}
+	applicableNames := make([]string, 0, len(applicable))
+	for _, r := range applicable {
+		applicableNames = append(applicableNames, r.src.Name)
+	}
+	if len(stmt.Effects) == 0 {
+		return StatementExplanation{Decision: implicitDeny(stmt, 0, "no effects on statement"), ApplicableRules: applicableNames}
+	}
+	return StatementExplanation{
+		Decision:        foldEffects(stmt, perEffect),
+		ApplicableRules: applicableNames,
+		Effects:         effectsOut,
+	}
+}
+```
+
+- [ ] **Step 4: Implement `explainEffect` for object-bearing effects**
+
+Add to `explain.go`.
+
+```go
+func explainEffect(index int, e effects.Effect, applicable []*compiledStatementRule) (effectDecision, EffectExplanation) {
+	d := evaluateEffect(e, applicable)
+	ex := EffectExplanation{
+		Index:      index,
+		Group:      e.Group,
+		Subtype:    e.Subtype,
+		Resolution: e.Resolution,
+	}
+	if len(e.Objects) == 0 {
+		return d, ex
+	}
+	for i, obj := range e.Objects {
+		cov := ObjectCoverage{Index: i, Object: obj}
+		if resolved, ok := resolvedObjectAt(e, i); ok {
+			r := resolved
+			cov.ResolvedObject = &r
+		}
+		for _, r := range applicable {
+			if !ruleMatchesEffectMeta(r, e) {
+				continue
+			}
+			ok, selector := ruleMatchesObjectSlot(r, e, i)
+			if !ok {
+				continue
+			}
+			if r.verb == VerbDeny {
+				ex.DenyRules = append(ex.DenyRules, RuleMatch{RuleName: r.src.Name, Verb: r.verb, Selector: selector})
+				continue
+			}
+			cov.Covered = true
+			cov.CoveringRules = append(cov.CoveringRules, RuleMatch{RuleName: r.src.Name, Verb: r.verb, Selector: selector})
+		}
+		if !cov.Covered {
+			cov.UncoveredReason = "no matching non-deny rule covers object"
+		}
+		ex.Coverage = append(ex.Coverage, cov)
+	}
+	return d, ex
+}
+```
+
+- [ ] **Step 5: Preserve enforcement behavior**
+
+Do not change the exported `Evaluate` signature. Keep `Evaluate` returning only
+`Decision`, and ensure `ExplainStatement` calls the same `evaluateEffect`
+function that `Evaluate` calls. The enforcement and explanation paths must
+share `ruleMatchesEffectMeta`, `ruleMatchesObjectSlot`, and `foldEffects`.
+
+- [ ] **Step 6: Run explanation tests**
+
+Run:
+
+```bash
+go test ./internal/db/policy -run TestExplainStatement -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run policy package tests**
+
+Run:
+
+```bash
+go test ./internal/db/policy -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit Task 3**
+
+Run:
+
+```bash
+git add internal/db/policy
+git commit -m "db/policy: explain statement coverage"
+```
+
+---
+
+## Task 4: Build Offline DB Policy Explain Runner
+
+**Files:**
+- Create: `internal/db/policyexplain/types.go`
+- Create: `internal/db/policyexplain/fixture.go`
+- Create: `internal/db/policyexplain/resolve.go`
+- Create: `internal/db/policyexplain/run.go`
+- Create: `internal/db/policyexplain/fixture_test.go`
+- Create: `internal/db/policyexplain/run_test.go`
+
+- [ ] **Step 1: Write fixture loader test**
+
+Create `internal/db/policyexplain/fixture_test.go`.
+
+```go
+package policyexplain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadCatalogFixture(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "catalog.yaml")
+	err := os.WriteFile(path, []byte(`search_path: [public, pg_catalog]
+relations:
+  - oid: 16384
+    schema: public
+    name: users
+    kind: table
+functions:
+  - oid: 2200
+    schema: public
+    name: safe_fn
+    identity_args: integer
+    volatility: stable
+    strict: true
+    return_type_oid: 23
+`), 0644)
+	if err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	fixture, err := LoadCatalogFixture(path)
+	if err != nil {
+		t.Fatalf("LoadCatalogFixture: %v", err)
+	}
+	if got := fixture.SearchPath; len(got) != 2 || got[0] != "public" || got[1] != "pg_catalog" {
+		t.Fatalf("SearchPath = %#v", got)
+	}
+	if rel, ok := fixture.Snapshot.RelationByOID(16384); !ok || rel.Name.String() != "public.users" {
+		t.Fatalf("relation lookup = %+v, %v", rel, ok)
+	}
+	if fn, ok := fixture.Snapshot.FunctionByOID(2200); !ok || fn.IdentityArgs != "integer" {
+		t.Fatalf("function lookup = %+v, %v", fn, ok)
+	}
+}
+```
+
+- [ ] **Step 2: Run fixture test and verify it fails**
+
+Run:
+
+```bash
+go test ./internal/db/policyexplain -run TestLoadCatalogFixture -count=1
+```
+
+Expected: FAIL because package `internal/db/policyexplain` does not exist.
+
+- [ ] **Step 3: Add report and fixture types**
+
+Create `internal/db/policyexplain/types.go`.
+
+```go
+package policyexplain
+
+import (
+	dbpolicy "github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
+
+type Options struct {
+	SQL            string
+	Service        dbpolicy.ServiceID
+	Dialect        string
+	SearchPath     []string
+	TempTables      []string
+	CatalogFixture string
+}
+
+type Report struct {
+	Service       string            `json:"service"`
+	Dialect       string            `json:"dialect"`
+	CatalogSource string            `json:"catalog_source"`
+	Statements    []StatementReport `json:"statements"`
+	Warnings      []WarningReport   `json:"warnings,omitempty"`
+}
+
+type StatementReport struct {
+	Index         int                  `json:"index"`
+	RawVerb       string               `json:"raw_verb,omitempty"`
+	ParserBackend string               `json:"parser_backend,omitempty"`
+	Effects       []EffectReport       `json:"effects"`
+	Decision      DecisionReport       `json:"decision"`
+	Error         string               `json:"error,omitempty"`
+}
+
+type EffectReport struct {
+	Index           int                         `json:"index"`
+	Operation       string                      `json:"operation"`
+	Subtype         string                      `json:"subtype,omitempty"`
+	Resolution      string                      `json:"resolution"`
+	Objects         []effects.ObjectRef         `json:"objects,omitempty"`
+	ResolvedObjects []effects.ResolvedObjectRef `json:"resolved_objects,omitempty"`
+	Coverage        []CoverageReport            `json:"coverage,omitempty"`
+}
+
+type CoverageReport struct {
+	Object          string       `json:"object,omitempty"`
+	ResolvedObject  string       `json:"resolved_object,omitempty"`
+	Covered         bool         `json:"covered"`
+	CoveringRules   []RuleReport `json:"covering_rules,omitempty"`
+	UncoveredReason string       `json:"uncovered_reason,omitempty"`
+	Selector        string       `json:"selector,omitempty"`
+}
+
+type RuleReport struct {
+	RuleName string `json:"rule_name"`
+	Verb     string `json:"verb"`
+	Selector string `json:"selector,omitempty"`
+}
+
+type DecisionReport struct {
+	Verb                string `json:"verb"`
+	RuleKind            string `json:"rule_kind,omitempty"`
+	RuleName            string `json:"rule_name,omitempty"`
+	MatchingEffectIndex int    `json:"matching_effect_index"`
+	MatchingEffectGroup string `json:"matching_effect_group,omitempty"`
+	Reason              string `json:"reason,omitempty"`
+}
+
+type WarningReport struct {
+	Rule    string `json:"rule,omitempty"`
+	Field   string `json:"field,omitempty"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+```
+
+Create `internal/db/policyexplain/fixture.go`.
+
+```go
+package policyexplain
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/agentsh/agentsh/internal/db/catalog"
+	"gopkg.in/yaml.v3"
+)
+
+type CatalogFixture struct {
+	SearchPath []string
+	Snapshot   catalog.Snapshot
+}
+
+type fixtureYAML struct {
+	SearchPath []string          `yaml:"search_path"`
+	Relations  []fixtureRelation `yaml:"relations"`
+	Functions  []fixtureFunction `yaml:"functions"`
+}
+
+type fixtureRelation struct {
+	OID    uint32 `yaml:"oid"`
+	Schema string `yaml:"schema"`
+	Name   string `yaml:"name"`
+	Kind   string `yaml:"kind"`
+	Owner  string `yaml:"owner"`
+}
+
+type fixtureFunction struct {
+	OID           uint32 `yaml:"oid"`
+	Schema        string `yaml:"schema"`
+	Name          string `yaml:"name"`
+	IdentityArgs  string `yaml:"identity_args"`
+	Volatility    string `yaml:"volatility"`
+	Strict        bool   `yaml:"strict"`
+	ReturnTypeOID uint32 `yaml:"return_type_oid"`
+}
+```
+
+- [ ] **Step 4: Implement fixture parsing**
+
+Add to `fixture.go`.
+
+```go
+func LoadCatalogFixture(path string) (CatalogFixture, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return CatalogFixture{}, fmt.Errorf("read catalog fixture: %w", err)
+	}
+	var in fixtureYAML
+	if err := yaml.Unmarshal(raw, &in); err != nil {
+		return CatalogFixture{}, fmt.Errorf("parse catalog fixture: %w", err)
+	}
+	relations := make([]catalog.Relation, 0, len(in.Relations))
+	for i, rel := range in.Relations {
+		kind, ok := parseRelationKind(rel.Kind)
+		if !ok {
+			return CatalogFixture{}, fmt.Errorf("relations[%d].kind: unknown relation kind %q", i, rel.Kind)
+		}
+		relations = append(relations, catalog.Relation{
+			OID:   catalog.OID(rel.OID),
+			Name:  catalog.Name{Schema: rel.Schema, Name: rel.Name},
+			Kind:  kind,
+			Owner: rel.Owner,
+		})
+	}
+	functions := make([]catalog.Function, 0, len(in.Functions))
+	for i, fn := range in.Functions {
+		vol, ok := parseVolatility(fn.Volatility)
+		if !ok {
+			return CatalogFixture{}, fmt.Errorf("functions[%d].volatility: unknown volatility %q", i, fn.Volatility)
+		}
+		functions = append(functions, catalog.Function{
+			OID:           catalog.OID(fn.OID),
+			Name:          catalog.Name{Schema: fn.Schema, Name: fn.Name},
+			IdentityArgs:  fn.IdentityArgs,
+			Volatility:    vol,
+			Strict:        fn.Strict,
+			ReturnTypeOID: catalog.OID(fn.ReturnTypeOID),
+		})
+	}
+	return CatalogFixture{
+		SearchPath: append([]string(nil), in.SearchPath...),
+		Snapshot:   catalog.NewSnapshot(relations, functions),
+	}, nil
+}
+
+func parseRelationKind(s string) (catalog.RelationKind, bool) {
+	switch s {
+	case "table":
+		return catalog.RelationTable, true
+	case "partitioned_table":
+		return catalog.RelationPartitionedTable, true
+	case "view":
+		return catalog.RelationView, true
+	case "materialized_view":
+		return catalog.RelationMaterializedView, true
+	case "foreign_table":
+		return catalog.RelationForeignTable, true
+	case "sequence":
+		return catalog.RelationSequence, true
+	default:
+		return 0, false
+	}
+}
+
+func parseVolatility(s string) (catalog.FunctionVolatility, bool) {
+	switch s {
+	case "", "volatile":
+		return catalog.VolatilityVolatile, true
+	case "stable":
+		return catalog.VolatilityStable, true
+	case "immutable":
+		return catalog.VolatilityImmutable, true
+	default:
+		return 0, false
+	}
+}
+```
+
+- [ ] **Step 5: Run fixture test**
+
+Run:
+
+```bash
+go test ./internal/db/policyexplain -run TestLoadCatalogFixture -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Write runner test**
+
+Create `internal/db/policyexplain/run_test.go`.
+
+```go
+package policyexplain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	dbpolicy "github.com/agentsh/agentsh/internal/db/policy"
+	rootpolicy "github.com/agentsh/agentsh/internal/policy"
+)
+
+func TestRun_WithCatalogFixtureAllowsCanonicalRelation(t *testing.T) {
+	rs := loadRuleSetForExplain(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: canonical-read, db_service: appdb, operations: [READ], relations: ["public.users"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "catalog.yaml")
+	if err := os.WriteFile(fixture, []byte(`search_path: [public]
+relations:
+  - oid: 16384
+    schema: public
+    name: users
+    kind: table
+`), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	report, err := Run(rs, []dbpolicy.Warning(nil), Options{
+		SQL:            "SELECT * FROM users",
+		Service:        "appdb",
+		Dialect:        "postgres",
+		CatalogFixture: fixture,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if report.CatalogSource != "fixture" {
+		t.Fatalf("CatalogSource = %q", report.CatalogSource)
+	}
+	if len(report.Statements) != 1 {
+		t.Fatalf("statements = %d", len(report.Statements))
+	}
+	dec := report.Statements[0].Decision
+	if dec.Verb != "allow" || dec.RuleName != "canonical-read" {
+		t.Fatalf("decision = %+v", dec)
+	}
+}
+
+func loadRuleSetForExplain(t *testing.T, src string) *dbpolicy.RuleSet {
+	t.Helper()
+	p, err := rootpolicy.LoadFromBytes([]byte(src))
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+	rs, _, err := dbpolicy.Decode(p)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	return rs
+}
+```
+
+- [ ] **Step 7: Run runner test and verify it fails**
+
+Run:
+
+```bash
+go test ./internal/db/policyexplain -run TestRun_WithCatalogFixtureAllowsCanonicalRelation -count=1
+```
+
+Expected: FAIL because `Run` and fixture resolution do not exist.
+
+- [ ] **Step 8: Implement platform-neutral resolution**
+
+Create `internal/db/policyexplain/resolve.go`.
+
+```go
+package policyexplain
+
+import (
+	"github.com/agentsh/agentsh/internal/db/catalog"
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
+
+func resolveStatements(stmts []effects.ClassifiedStatement, fixture CatalogFixture) []effects.ClassifiedStatement {
+	out := make([]effects.ClassifiedStatement, len(stmts))
+	for i := range stmts {
+		out[i] = resolveStatement(stmts[i], fixture)
+	}
+	return out
+}
+
+func resolveStatement(stmt effects.ClassifiedStatement, fixture CatalogFixture) effects.ClassifiedStatement {
+	out := stmt
+	out.Effects = make([]effects.Effect, len(stmt.Effects))
+	for i, eff := range stmt.Effects {
+		out.Effects[i] = resolveEffect(eff, fixture)
+	}
+	return out
+}
+
+func resolveEffect(eff effects.Effect, fixture CatalogFixture) effects.Effect {
+	out := eff
+	resolved := make([]effects.ResolvedObjectRef, 0, len(eff.Objects)+1)
+	allResolved := true
+	for _, obj := range eff.Objects {
+		ref := resolveObject(obj, fixture)
+		if ref.UnresolvedReason != "" {
+			allResolved = false
+		}
+		resolved = append(resolved, ref)
+	}
+	if eff.FunctionOID != nil {
+		ref := resolveFunctionOID(*eff.FunctionOID, fixture)
+		if ref.UnresolvedReason != "" {
+			allResolved = false
+		}
+		resolved = append(resolved, ref)
+	}
+	if len(resolved) == 0 {
+		return out
+	}
+	out.ResolvedObjects = resolved
+	if allResolved {
+		out.Resolution = effects.ResolutionCatalogResolved
+	} else {
+		out.Resolution = effects.ResolutionCatalogUnresolved
+	}
+	return out
+}
+
+func resolveObject(obj effects.ObjectRef, fixture CatalogFixture) effects.ResolvedObjectRef {
+	if obj.Kind != effects.ObjectTable && obj.Kind != effects.ObjectView && obj.Kind != effects.ObjectSequence {
+		return effects.ResolvedObjectRef{
+			Source:           effects.ResolvedObjectSourceCatalog,
+			Kind:             effects.ResolvedObjectRelation,
+			Schema:           obj.Schema,
+			Name:             obj.Name,
+			UnresolvedReason: "unsupported",
+		}
+	}
+	res := catalog.ResolveRelation(fixture.Snapshot, catalog.Name{Schema: obj.Schema, Name: obj.Name}, fixture.SearchPath)
+	if !res.OK() {
+		return effects.ResolvedObjectRef{
+			Source:           effects.ResolvedObjectSourceCatalog,
+			Kind:             effects.ResolvedObjectRelation,
+			Schema:           obj.Schema,
+			Name:             obj.Name,
+			UnresolvedReason: res.Reason.String(),
+		}
+	}
+	rel := res.Relation
+	return effects.ResolvedObjectRef{
+		Source:       effects.ResolvedObjectSourceCatalog,
+		Kind:         effects.ResolvedObjectRelation,
+		OID:          uint32(rel.OID),
+		Schema:       rel.Name.Schema,
+		Name:         rel.Name.Name,
+		RelationKind: rel.Kind.String(),
+	}
+}
+
+func resolveFunctionOID(oid int32, fixture CatalogFixture) effects.ResolvedObjectRef {
+	res := catalog.ResolveFunctionByOID(fixture.Snapshot, catalog.OID(oid))
+	if !res.OK() {
+		return effects.ResolvedObjectRef{
+			Source:           effects.ResolvedObjectSourceCatalog,
+			Kind:             effects.ResolvedObjectFunction,
+			OID:              uint32(oid),
+			UnresolvedReason: res.Reason.String(),
+		}
+	}
+	fn := res.Function
+	return effects.ResolvedObjectRef{
+		Source:               effects.ResolvedObjectSourceCatalog,
+		Kind:                 effects.ResolvedObjectFunction,
+		OID:                  uint32(fn.OID),
+		Schema:               fn.Name.Schema,
+		Name:                 fn.Name.Name,
+		FunctionIdentityArgs: fn.IdentityArgs,
+		FunctionVolatility:   functionVolatility(fn.Volatility),
+	}
+}
+
+func functionVolatility(v catalog.FunctionVolatility) string {
+	switch v {
+	case catalog.VolatilityImmutable:
+		return "immutable"
+	case catalog.VolatilityStable:
+		return "stable"
+	case catalog.VolatilityVolatile:
+		return "volatile"
+	default:
+		return ""
+	}
+}
+```
+
+- [ ] **Step 9: Implement `Run`**
+
+Create `internal/db/policyexplain/run.go`.
+
+```go
+package policyexplain
+
+import (
+	"fmt"
+	"strings"
+
+	classify_pg "github.com/agentsh/agentsh/internal/db/classify/postgres"
+	"github.com/agentsh/agentsh/internal/db/effects"
+	dbpolicy "github.com/agentsh/agentsh/internal/db/policy"
+)
+
+func Run(rs *dbpolicy.RuleSet, warns []dbpolicy.Warning, opts Options) (Report, error) {
+	dialect, ok := classify_pg.ParseDialect(defaultString(opts.Dialect, "postgres"))
+	if !ok {
+		return Report{}, fmt.Errorf("unknown dialect %q", opts.Dialect)
+	}
+	sess := classify_pg.SessionState{SearchPath: append([]string(nil), opts.SearchPath...)}
+	if len(opts.TempTables) > 0 {
+		sess.TempTables = make(map[string]struct{}, len(opts.TempTables))
+		for _, name := range opts.TempTables {
+			sess.TempTables[strings.ToLower(strings.TrimSpace(name))] = struct{}{}
+		}
+	}
+	stmts, err := classify_pg.New(dialect).Classify(opts.SQL, sess, classify_pg.Options{})
+	if err != nil {
+		return Report{}, err
+	}
+	catalogSource := "none"
+	if opts.CatalogFixture != "" {
+		fixture, err := LoadCatalogFixture(opts.CatalogFixture)
+		if err != nil {
+			return Report{}, err
+		}
+		stmts = resolveStatements(stmts, fixture)
+		catalogSource = "fixture"
+	}
+	report := Report{
+		Service:       string(opts.Service),
+		Dialect:       dialect.String(),
+		CatalogSource: catalogSource,
+		Warnings:      warningReports(warns),
+	}
+	for i, stmt := range stmts {
+		report.Statements = append(report.Statements, statementReport(i, stmt, dbpolicy.ExplainStatement(stmt, rs, opts.Service)))
+	}
+	return report, nil
+}
+
+func defaultString(s, fallback string) string {
+	if strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return s
+}
+
+func warningReports(warns []dbpolicy.Warning) []WarningReport {
+	out := make([]WarningReport, 0, len(warns))
+	for _, w := range warns {
+		out = append(out, WarningReport{Rule: w.Rule, Field: w.Field, Code: w.Code, Message: w.Message})
+	}
+	return out
+}
+
+func statementReport(index int, stmt effects.ClassifiedStatement, ex dbpolicy.StatementExplanation) StatementReport {
+	out := StatementReport{
+		Index:         index,
+		RawVerb:       stmt.RawVerb,
+		ParserBackend: stmt.ParserBackend.String(),
+		Decision: DecisionReport{
+			Verb:                ex.Decision.Verb.String(),
+			RuleKind:            ex.Decision.RuleKind.String(),
+			RuleName:            ex.Decision.RuleName,
+			MatchingEffectIndex: ex.Decision.MatchingEffectIndex,
+			MatchingEffectGroup: ex.Decision.MatchingEffectGroup.String(),
+			Reason:              ex.Decision.Reason,
+		},
+		Error: stmt.Error,
+	}
+	for _, eff := range ex.Effects {
+		out.Effects = append(out.Effects, effectReport(eff, stmt.Effects[eff.Index]))
+	}
+	return out
+}
+```
+
+Add effect conversion helpers to `run.go`.
+
+```go
+func effectReport(ex dbpolicy.EffectExplanation, eff effects.Effect) EffectReport {
+	out := EffectReport{
+		Index:           ex.Index,
+		Operation:       ex.Group.String(),
+		Resolution:      ex.Resolution.String(),
+		Objects:         append([]effects.ObjectRef(nil), eff.Objects...),
+		ResolvedObjects: append([]effects.ResolvedObjectRef(nil), eff.ResolvedObjects...),
+	}
+	if ex.Subtype != effects.SubtypeNone {
+		out.Subtype = ex.Subtype.String()
+	}
+	for _, cov := range ex.Coverage {
+		out.Coverage = append(out.Coverage, coverageReport(cov))
+	}
+	return out
+}
+
+func coverageReport(cov dbpolicy.ObjectCoverage) CoverageReport {
+	out := CoverageReport{
+		Object:          objectName(cov.Object),
+		Covered:         cov.Covered,
+		UncoveredReason: cov.UncoveredReason,
+	}
+	if cov.ResolvedObject != nil {
+		out.ResolvedObject = cov.ResolvedObject.CanonicalName()
+	}
+	for _, r := range cov.CoveringRules {
+		out.CoveringRules = append(out.CoveringRules, RuleReport{
+			RuleName: r.RuleName,
+			Verb:     r.Verb.String(),
+			Selector: r.Selector,
+		})
+		if out.Selector == "" {
+			out.Selector = r.Selector
+		}
+	}
+	return out
+}
+
+func objectName(o effects.ObjectRef) string {
+	switch o.Kind {
+	case effects.ObjectExternalEndpoint:
+		return o.Host
+	case effects.ObjectFilesystemPath:
+		return o.Path
+	case effects.ObjectProgram:
+		return o.Argv0
+	default:
+		if o.Schema == "" {
+			return o.Name
+		}
+		return o.Schema + "." + o.Name
+	}
+}
+```
+
+- [ ] **Step 10: Run policyexplain tests**
+
+Run:
+
+```bash
+go test ./internal/db/policyexplain -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 11: Run Windows build for the new package path**
+
+Run:
+
+```bash
+GOOS=windows go build ./internal/db/policyexplain
+```
+
+Expected: PASS. This confirms the package did not import Linux-only proxy runtime files.
+
+- [ ] **Step 12: Commit Task 4**
+
+Run:
+
+```bash
+git add internal/db/policyexplain
+git commit -m "db/policyexplain: add offline explain runner"
+```
+
+---
+
+## Task 5: Wire `agentsh policy db explain` And DB Warnings
+
+**Files:**
+- Modify: `internal/cli/policy_cmd.go`
+- Create: `internal/cli/policy_db_explain_test.go`
+- Modify: `internal/cli/policy_config_test.go`
+- Modify: `internal/api/db_proxy.go`
+
+- [ ] **Step 1: Write CLI tests**
+
+Create `internal/cli/policy_db_explain_test.go`.
+
+```go
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPolicyDBExplainJSONWithSQLFlag(t *testing.T) {
+	dir := t.TempDir()
+	policyPath := filepath.Join(dir, "policy.yaml")
+	fixturePath := filepath.Join(dir, "catalog.yaml")
+	writeFile(t, policyPath, `version: 1
+name: t
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: x:1
+    tls_mode: terminate_reissue
+database_rules:
+  - name: canonical-read
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: allow
+`)
+	writeFile(t, fixturePath, `search_path: [public]
+relations:
+  - oid: 16384
+    schema: public
+    name: users
+    kind: table
+`)
+
+	root := NewRoot("test")
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"policy", "db", "explain", policyPath, "--service", "appdb", "--catalog-fixture", fixturePath, "--sql", "SELECT * FROM users"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v\n%s", err, out.String())
+	}
+	body := out.String()
+	if !strings.Contains(body, `"verb": "allow"`) {
+		t.Fatalf("missing allow decision:\n%s", body)
+	}
+	if !strings.Contains(body, `"rule_name": "canonical-read"`) {
+		t.Fatalf("missing rule name:\n%s", body)
+	}
+	if !strings.Contains(body, `"resolved_object": "public.users"`) {
+		t.Fatalf("missing resolved object:\n%s", body)
+	}
+}
+
+func TestPolicyDBExplainTextFromStdin(t *testing.T) {
+	dir := t.TempDir()
+	policyPath := filepath.Join(dir, "policy.yaml")
+	writeFile(t, policyPath, `version: 1
+name: t
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: x:1
+    tls_mode: terminate_reissue
+database_rules:
+  - {name: read-all, db_service: appdb, operations: [READ], decision: allow}
+`)
+	root := NewRoot("test")
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetIn(strings.NewReader("SELECT 1"))
+	root.SetArgs([]string{"policy", "db", "explain", policyPath, "--service", "appdb", "--output", "text"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v\n%s", err, out.String())
+	}
+	body := out.String()
+	if !strings.Contains(body, "decision: allow") || !strings.Contains(body, "rule: read-all") {
+		t.Fatalf("unexpected text output:\n%s", body)
+	}
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+```
+
+- [ ] **Step 2: Run CLI explain tests and verify they fail**
+
+Run:
+
+```bash
+go test ./internal/cli -run TestPolicyDBExplain -count=1
+```
+
+Expected: FAIL because the command is not wired.
+
+- [ ] **Step 3: Add DB policy command wiring**
+
+Update imports in `internal/cli/policy_cmd.go`:
+
+```go
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	dbpolicy "github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/policyexplain"
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/policygen"
+	"github.com/agentsh/agentsh/internal/policy/signing"
+	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/spf13/cobra"
+)
+```
+
+Add this command registration before `return cmd` in `newPolicyCmd`:
+
+```go
+cmd.AddCommand(newPolicyDBCmd(configPath, dir))
+```
+
+Add helpers near the bottom of `policy_cmd.go`.
+
+```go
+func newPolicyDBCmd(configPath, dir string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "db",
+		Short: "Inspect database policy behavior",
+	}
+	cmd.AddCommand(newPolicyDBExplainCmd(configPath, dir))
+	return cmd
+}
+
+func newPolicyDBExplainCmd(configPath, dir string) *cobra.Command {
+	var serviceName string
+	var dialect string
+	var searchPath string
+	var tempTables string
+	var catalogFixture string
+	var sqlFlag string
+	var output string
+
+	cmd := &cobra.Command{
+		Use:   "explain POLICY_OR_PATH",
+		Short: "Explain DB policy classification, resolution, coverage, and decision",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(serviceName) == "" {
+				return fmt.Errorf("--service is required")
+			}
+			pdir, err := resolvePolicyDir(configPath, dir)
+			if err != nil {
+				return err
+			}
+			policyPath, err := resolvePolicyPath(pdir, args[0])
+			if err != nil {
+				return err
+			}
+			rootPolicy, err := policy.LoadFromFile(policyPath)
+			if err != nil {
+				return err
+			}
+			rs, warns, err := dbpolicy.Decode(rootPolicy)
+			if err != nil {
+				return err
+			}
+			sqlText := sqlFlag
+			if sqlText == "" {
+				raw, err := io.ReadAll(cmd.InOrStdin())
+				if err != nil {
+					return err
+				}
+				sqlText = string(raw)
+			}
+			if strings.TrimSpace(sqlText) == "" {
+				return fmt.Errorf("SQL is required via --sql or stdin")
+			}
+			if dialect == "" {
+				if svc, ok := rs.Service(dbpolicy.ServiceID(serviceName)); ok && svc.Dialect != "" {
+					dialect = svc.Dialect
+				} else {
+					dialect = "postgres"
+				}
+			}
+			report, err := policyexplain.Run(rs, warns, policyexplain.Options{
+				SQL:            sqlText,
+				Service:        dbpolicy.ServiceID(serviceName),
+				Dialect:        dialect,
+				SearchPath:     splitCSV(searchPath),
+				TempTables:      splitCSV(tempTables),
+				CatalogFixture: catalogFixture,
+			})
+			if err != nil {
+				return err
+			}
+			switch output {
+			case "", "json":
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(report)
+			case "text":
+				return printDBExplainText(cmd, report)
+			default:
+				return fmt.Errorf("--output must be json or text")
+			}
+		},
+	}
+	cmd.Flags().StringVar(&serviceName, "service", "", "DB service name (required)")
+	cmd.Flags().StringVar(&dialect, "dialect", "", "postgres|aurora_postgres|cockroachdb|redshift")
+	cmd.Flags().StringVar(&searchPath, "search-path", "", "comma-separated search path")
+	cmd.Flags().StringVar(&tempTables, "temp-tables", "", "comma-separated temp table names")
+	cmd.Flags().StringVar(&catalogFixture, "catalog-fixture", "", "YAML catalog fixture path")
+	cmd.Flags().StringVar(&sqlFlag, "sql", "", "SQL statement text (default: stdin)")
+	cmd.Flags().StringVar(&output, "output", "json", "json|text")
+	return cmd
+}
+```
+
+- [ ] **Step 4: Add CLI formatting helpers**
+
+Add to `policy_cmd.go`.
+
+```go
+func splitCSV(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		p := strings.TrimSpace(part)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func printDBExplainText(cmd *cobra.Command, report policyexplain.Report) error {
+	for _, stmt := range report.Statements {
+		fmt.Fprintf(cmd.OutOrStdout(), "statement %d: %s\n", stmt.Index, stmt.RawVerb)
+		fmt.Fprintf(cmd.OutOrStdout(), "decision: %s\n", stmt.Decision.Verb)
+		if stmt.Decision.RuleName != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "rule: %s\n", stmt.Decision.RuleName)
+		}
+		for _, eff := range stmt.Effects {
+			fmt.Fprintf(cmd.OutOrStdout(), "effect %d: %s resolution=%s\n", eff.Index, eff.Operation, eff.Resolution)
+			for _, cov := range eff.Coverage {
+				if cov.Covered {
+					fmt.Fprintf(cmd.OutOrStdout(), "  covered: %s selector=%s\n", cov.Object, cov.Selector)
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "  uncovered: %s reason=%s\n", cov.Object, cov.UncoveredReason)
+				}
+			}
+		}
+	}
+	if len(report.Warnings) > 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "warnings:")
+		for _, w := range report.Warnings {
+			fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s\n", w.Code, w.Message)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Surface DB warnings in `policy validate`**
+
+In the existing `validate` subcommand, after `policy.NewEngine`, add:
+
+```go
+if _, warns, err := dbpolicy.Decode(po); err != nil {
+	return err
+} else {
+	for _, w := range warns {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning[%s]", w.Code)
+		if w.Rule != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), " rule=%s", w.Rule)
+		}
+		if w.Field != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), " field=%s", w.Field)
+		}
+		fmt.Fprintf(cmd.ErrOrStderr(), ": %s\n", w.Message)
+	}
+}
+```
+
+- [ ] **Step 6: Surface DB warnings during session policy compilation**
+
+Update `internal/api/db_proxy.go` so `loadDBRuleSet` returns warnings:
+
+```go
+func loadDBRuleSet(p *rootpolicy.Policy) (*dbpolicy.RuleSet, []dbpolicy.Warning, error) {
+	if p == nil {
+		return nil, nil, nil
+	}
+	rs, warns, err := dbpolicy.Decode(p)
+	if err != nil {
+		return nil, warns, fmt.Errorf("loadDBRuleSet: decode db policy: %w", err)
+	}
+	return rs, warns, nil
+}
+```
+
+Update the caller in `internal/api/db_unavoidability.go`:
+
+```go
+rs, warns, err := loadDBRuleSet(base)
+if err != nil {
+	return nil, nil, "", err
+}
+for _, w := range warns {
+	slog.Warn("db policy warning", "code", w.Code, "rule", w.Rule, "field", w.Field, "message", w.Message)
+}
+```
+
+`internal/api/db_unavoidability.go` already imports `log/slog`; keep that
+import and use the package-level logger shown above.
+
+- [ ] **Step 7: Run CLI tests**
+
+Run:
+
+```bash
+go test ./internal/cli -run 'TestPolicyDBExplain|TestRoot_WiresPolicyAndConfig' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run API compile tests for changed signature**
+
+Run:
+
+```bash
+go test ./internal/api -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit Task 5**
+
+Run:
+
+```bash
+git add internal/cli internal/api
+git commit -m "cli: add db policy explain"
+```
+
+---
+
+## Task 6: Update Samples, Docs, And Final Verification
+
+**Files:**
+- Modify: `internal/db/policy/testdata/sample-policy.yaml`
+- Modify: `internal/db/policy/sample_test.go`
+- Modify: `docs/agentsh-db-access-spec.md`
+- Modify: `docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md`
+
+- [ ] **Step 1: Add sample canonical policies**
+
+Modify `internal/db/policy/testdata/sample-policy.yaml` by adding these rules after `app-read-and-update`.
+
+```yaml
+  - name: app-read-users-canonical
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: allow
+
+  - name: app-safe-functions-canonical
+    db_service: appdb
+    operations: [procedural]
+    functions: ["public.safe_fn(*)"]
+    match_object_resolution: catalog_resolved
+    decision: approve
+```
+
+- [ ] **Step 2: Run sample tests**
+
+`internal/db/policy/sample_test.go` currently checks worked examples only, so no
+test change is required for the new sample rules.
+
+Run:
+
+```bash
+go test ./internal/db/policy -run TestSample -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Document new rule fields in the DB access spec**
+
+In `docs/agentsh-db-access-spec.md`, update the statement-rule field table with these rows near `objects` and `schemas`:
+
+```markdown
+| `relations` | no | Glob list. Matches catalog-resolved relation canonical names formatted as `schema.name`. A selector only matches when the effect contains a successful catalog `resolved_objects[]` relation. Recommended with `match_object_resolution: catalog_resolved`. |
+| `functions` | no | Glob list. Matches catalog-resolved function identities formatted as `schema.name(identity_args)`. Use `schema.name(*)` to match all overloads for a function name. Recommended with `match_object_resolution: catalog_resolved`. |
+```
+
+Update the `schemas` row to:
+
+```markdown
+| `schemas` | no | Glob. Matches `objects[].schema` for syntactic refs and successful `resolved_objects[].schema` for catalog-resolved refs. |
+```
+
+Add this paragraph after the field table:
+
+```markdown
+`objects` remains syntactic-only. `relations` and `functions` are catalog selectors and do not match unresolved or unavailable catalog metadata. Strict object coverage still applies: every object slot in an effect must be covered by an allow/audit/approve rule, and any matching deny rule still wins.
+```
+
+- [ ] **Step 4: Document offline explain command**
+
+Add this subsection near the DB policy authoring documentation in `docs/agentsh-db-access-spec.md`.
+
+````markdown
+### DB policy explain
+
+Operators can inspect DB policy behavior offline:
+
+```bash
+agentsh policy db explain ./policy.yaml --service appdb --sql 'SELECT * FROM users'
+```
+
+The command reports classifier effects, syntactic objects, catalog-resolved objects when a fixture is supplied, per-object coverage, policy warnings, and the final decision. Catalog fixtures are YAML snapshots used for local debugging; they are not live DB connections and are not used by the proxy runtime.
+````
+
+- [ ] **Step 5: Update Phase 2 roadmap status**
+
+In `docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md`, change the Plan 10 external behavior paragraph from future wording to implementation-ready wording:
+
+```markdown
+External behavior: policy authoring and debugging improve; default enforcement semantics remain strict. Plan 10 is implemented and ready for DB Plan 11 redirect planner work.
+```
+
+Only make this wording change after code and tests in Tasks 1-5 pass.
+
+- [ ] **Step 6: Run focused DB and CLI tests**
+
+Run:
+
+```bash
+go test ./internal/db/policy ./internal/db/policyexplain ./internal/cli -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run full verification**
+
+Run:
+
+```bash
+go test ./...
+```
+
+Expected: PASS.
+
+Then run:
+
+```bash
+GOOS=windows go build ./...
+```
+
+Expected: PASS.
+
+Then run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 8: Commit Task 6**
+
+Run:
+
+```bash
+git add internal/db/policy/testdata/sample-policy.yaml internal/db/policy/sample_test.go docs/agentsh-db-access-spec.md docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md
+git commit -m "docs: explain db policy ergonomics"
+```
+
+When staging, include `internal/db/policy/sample_test.go` only if the file has
+local modifications.
+
+---
+
+## Final Checklist
+
+- [ ] `go test ./internal/db/policy ./internal/db/policyexplain ./internal/cli -count=1` passes.
+- [ ] `go test ./...` passes.
+- [ ] `GOOS=windows go build ./...` passes.
+- [ ] `git diff --check` passes.
+- [ ] `agentsh policy db explain` works with `--sql` and stdin.
+- [ ] Canonical selectors only match successful catalog-resolved objects.
+- [ ] Existing syntactic policies keep the same decisions.
+- [ ] DB warning codes are visible in `policy validate`.

--- a/docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md
+++ b/docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md
@@ -106,7 +106,7 @@ Deliverables:
 - Sample policies that show Phase 1 syntactic rules next to Phase 2 resolved-object rules.
 - Documentation updates for operator workflows.
 
-External behavior: policy authoring and debugging improve; default enforcement semantics remain strict.
+External behavior: policy authoring and debugging improve; default enforcement semantics remain strict. Plan 10 is implemented and ready for DB Plan 11 redirect planner work.
 
 ### DB Plan 11 - Redirect Planner
 

--- a/docs/superpowers/specs/2026-05-14-db-plan-10-policy-ergonomics-design.md
+++ b/docs/superpowers/specs/2026-05-14-db-plan-10-policy-ergonomics-design.md
@@ -1,0 +1,465 @@
+# DB Plan 10 Policy Ergonomics Design
+
+**Status:** Draft approved for implementation planning on 2026-05-14.
+**Owner:** Canyon Road
+**Source roadmap:** `docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md`
+**Depends on:** DB Plan 09 Runtime Resolution Integration
+
+## 1. Goal
+
+Make catalog-resolved DB policies practical to author and debug without
+weakening Phase 1 strict coverage or changing existing syntactic policy
+semantics.
+
+Plan 09 already attaches catalog-backed `ResolvedObjectRef` metadata to
+classified effects at runtime. Plan 10 teaches the policy layer to match that
+metadata with canonical selectors, adds an operator explain command, and
+surfaces policy authoring mistakes as non-fatal warnings.
+
+## 2. Scope
+
+### In Scope
+
+- Add `relations` and `functions` selectors to statement rules.
+- Extend `schemas` so it can match either syntactic object schemas or
+  catalog-resolved schemas.
+- Keep `objects` syntactic-only for backward compatibility.
+- Add evaluator explanation data for rule matches, coverage, uncovered objects,
+  and final decision.
+- Add `agentsh policy db explain` as the operator-facing explain command.
+- Support offline catalog fixtures for explain-mode resolution; no live DB
+  connection is required for Plan 10.
+- Add config-load warnings for canonical selector misuse, unsupported service
+  scopes, and selectors attached to objectless operations.
+- Update sample policies and docs to show syntactic and resolved-object rules
+  side by side.
+
+### Out of Scope
+
+- Live catalog loading from the CLI.
+- Statement rewriting or accepting `decision: redirect`.
+- Redirect validation, planning, or runtime execution.
+- Changing proxy hot-path policy decisions except where canonical selectors
+  intentionally add new coverage.
+- Replacing `objects` with canonical matching.
+- Loose coverage mode or fallback allow behavior when catalog resolution is
+  unavailable.
+- Result-set DLP, row-count limits, or Describe metadata filtering.
+
+## 3. Design Decisions
+
+### 3.1 Selector Semantics
+
+`objects` remains the existing syntactic selector. It matches
+`effects.ObjectRef` fields exactly as it does today and does not inspect
+`ResolvedObjectRef`.
+
+Plan 10 adds canonical selector families:
+
+- `relations`: glob patterns over catalog-resolved relation canonical names,
+  formatted as `schema.name`.
+- `functions`: glob patterns over catalog-resolved function identity names,
+  formatted as `schema.name(identity_args)`.
+- `schemas`: glob patterns over schema names. A schema match can come from the
+  syntactic object schema or the resolved object schema.
+
+For one effect object slot, a rule covers that slot when all effect-level
+filters match and:
+
+1. The schema constraint is absent, or it matches the syntactic schema, or it
+   matches the resolved schema.
+2. At least one object selector family matches, or no object selector family is
+   present.
+
+The object selector families are:
+
+- `objects`, matched against syntactic `ObjectRef`.
+- `relations`, matched against a successful resolved relation.
+- `functions`, matched against a successful resolved function.
+
+If none of `objects`, `relations`, or `functions` is present, the rule keeps
+the current behavior and covers all object slots that pass operation, subtype,
+resolution, service, and schema filters.
+
+Canonical selectors only match resolved objects with:
+
+- `source: catalog`
+- empty `unresolved_reason`
+- the matching resolved kind (`relation` or `function`)
+
+An unresolved, unavailable, or unsupported catalog result does not satisfy a
+canonical selector. If no syntactic selector covers that object slot, strict
+coverage produces the same implicit deny behavior as Phase 1.
+
+### 3.2 Mixed Selectors
+
+Rules may contain both syntactic and canonical selectors. This is useful during
+migration:
+
+```yaml
+database_rules:
+  - name: app-read-users-during-migration
+    db_service: appdb
+    operations: [READ]
+    objects: ["users"]
+    relations: ["public.users"]
+    decision: allow
+```
+
+The selector families are additive for coverage: either the syntactic object
+selector or the canonical relation selector can cover the object slot, subject
+to the shared schema filter. This lets operators roll out canonical rules
+without duplicating entire policies.
+
+For high-assurance policies, operators should pair canonical selectors with:
+
+```yaml
+match_object_resolution: catalog_resolved
+```
+
+Plan 10 warns when canonical selectors appear without that guard. It remains a
+warning rather than a load error because migration policies may deliberately
+allow both syntactic and catalog-resolved coverage.
+
+### 3.3 Function Selector Format
+
+Function selectors match the identity string:
+
+```text
+schema.name(identity_args)
+```
+
+Examples:
+
+- `pg_catalog.lower(text)`
+- `public.safe_fn(integer, text)`
+- `public.safe_fn(*)`
+- `public.*`
+
+The identity arguments come from Postgres `pg_get_function_identity_arguments`.
+Overloaded functions are distinct unless the operator uses a glob. A bare
+`schema.name` pattern does not match a function with identity args; operators
+who want all overloads use `schema.name(*)`.
+
+### 3.4 Evaluation API
+
+The current `Evaluate` hot path should keep returning `Decision`. Plan 10 adds
+an explanation-oriented API in `internal/db/policy` and has `Evaluate` share the
+same internal implementation so explain output cannot drift from enforcement.
+
+The explanation API returns:
+
+- Applicable statement rules for the service.
+- Per-effect operation, subtype, resolution, and object list.
+- Per-object-slot coverage records.
+- Matching deny rules and deny-matched object.
+- Covering allow/audit/approve rules.
+- Uncovered object details for implicit deny.
+- Final folded `Decision`.
+
+This API must remain pure and platform-agnostic. It does not read policy files,
+open sockets, or query databases.
+
+## 4. Components
+
+### 4.1 `internal/db/policy`
+
+Extend statement-rule decode, validate, compile, and evaluation:
+
+- Add `Relations []string` and `Functions []string` to `StatementRule`.
+- Compile relation/function glob patterns beside existing object/schema globs.
+- Keep `objectMatches` syntactic-only.
+- Add resolved relation/function matchers that operate on
+  `effects.ResolvedObjectRef`.
+- Refactor per-effect evaluation to build reusable coverage detail.
+- Add `ExplainStatement` or an equivalent exported explanation API that returns
+  the exact decision plus match details.
+- Preserve rule-order tiebreaks and most-restrictive decision ordering.
+
+Existing tests for syntactic `objects`, `schemas`, `match_object_resolution`,
+implicit deny, deny precedence, audit/approve coverage, and order independence
+must keep passing unchanged.
+
+### 4.2 `internal/db/policy/explain` or Focused Helper Package
+
+Add a small package for CLI explain orchestration if keeping it inside
+`internal/db/policy` would make the evaluator package too broad.
+
+Responsibilities:
+
+- Classify SQL using the existing Postgres classifier.
+- Optionally apply catalog fixture resolution to the classified statements.
+- Call the policy explanation API for each statement.
+- Shape stable JSON and text output for the CLI.
+
+This package may depend on `internal/db/catalog` and
+`internal/db/classify/postgres`. The lower-level evaluator must not depend on
+the classifier or catalog package.
+
+### 4.3 Catalog Fixture Support
+
+Plan 10 explain mode is offline. To demonstrate canonical selectors, the CLI
+accepts an optional catalog fixture:
+
+```yaml
+search_path: [public, pg_catalog]
+relations:
+  - oid: 16384
+    schema: public
+    name: users
+    kind: table
+  - oid: 16385
+    schema: analytics
+    name: users_summary
+    kind: view
+functions:
+  - oid: 2200
+    schema: public
+    name: safe_fn
+    identity_args: integer
+    volatility: stable
+    strict: false
+    return_type_oid: 23
+```
+
+The fixture loader converts this file into a `catalog.Snapshot` and an explicit
+search path, then applies the same catalog resolver rules as runtime resolution:
+
+- Qualified relations resolve by `schema.name`.
+- Unqualified relations resolve through `search_path`.
+- Missing or ambiguous relations produce `catalog_unresolved`.
+- No fixture produces `catalog_unavailable` for explain-mode canonical
+  matching.
+
+The fixture is an operator/debugging aid, not a production catalog cache file.
+It should be documented as an approximation of what the runtime would see from
+the upstream DB identity.
+
+### 4.4 `agentsh policy db explain`
+
+Add a `db` subcommand under the existing `policy` command:
+
+```text
+agentsh policy db explain POLICY_OR_PATH --service appdb [--sql "SELECT * FROM users"]
+agentsh policy db explain POLICY_OR_PATH --service appdb < statement.sql
+```
+
+Flags:
+
+- `--service`: required DB service name used for service-scoped rule matching.
+- `--dialect`: optional, defaults to the service dialect when available and
+  otherwise to `postgres`.
+- `--search-path`: optional comma-separated search path used for syntactic
+  classifier session state when no catalog fixture is supplied.
+- `--temp-tables`: optional comma-separated temp table names for syntactic
+  classifier session state.
+- `--catalog-fixture`: optional YAML fixture for offline catalog resolution.
+- `--sql`: optional SQL string. When absent, read SQL from stdin.
+- `--output`: `json` or `text`, default `json`.
+
+JSON output is the stable automation surface. Text output is a concise human
+summary for local debugging.
+
+Minimum JSON shape:
+
+```json
+{
+  "service": "appdb",
+  "dialect": "postgres",
+  "catalog_source": "fixture",
+  "statements": [
+    {
+      "index": 0,
+      "raw_verb": "SELECT",
+      "parser_backend": "libpg_query",
+      "effects": [
+        {
+          "index": 0,
+          "operation": "read",
+          "subtype": "",
+          "resolution": "catalog_resolved",
+          "objects": [
+            {"kind": "table", "schema": "", "name": "users"}
+          ],
+          "resolved_objects": [
+            {
+              "source": "catalog",
+              "kind": "relation",
+              "oid": 16384,
+              "schema": "public",
+              "name": "users",
+              "relation_kind": "table"
+            }
+          ],
+          "coverage": [
+            {
+              "object": "users",
+              "resolved_object": "public.users",
+              "covered": true,
+              "covering_rules": ["app-read-users"],
+              "selector": "relations"
+            }
+          ]
+        }
+      ],
+      "decision": {
+        "verb": "allow",
+        "rule_kind": "statement",
+        "rule_name": "app-read-users",
+        "matching_effect_index": 0,
+        "matching_effect_group": "read",
+        "reason": ""
+      }
+    }
+  ],
+  "warnings": []
+}
+```
+
+`warnings` includes policy decode warnings and explain-only warnings such as
+missing catalog fixtures for canonical selectors.
+
+### 4.5 Policy Validation And Runtime Warning Surfacing
+
+`dbpolicy.Decode` already returns warnings, but some callers discard them.
+Plan 10 should make warnings visible in two places:
+
+- `agentsh policy validate` should run DB policy decode when DB blocks are
+  present and print warnings before `ok`.
+- Session DB policy compilation should preserve current fatal-error behavior
+  and surface warnings through the existing server logging path.
+
+Warning codes are stable strings. Plan 10 adds:
+
+- `canonical_selector_without_resolution_guard`: a rule has `relations` or
+  `functions` but does not set `match_object_resolution: catalog_resolved`.
+- `canonical_selector_without_catalog_service`: a rule with canonical selectors
+  matches no terminate-mode Postgres service.
+- `selector_on_objectless_operation`: a rule constrains object selectors but
+  all expanded operations are inherently objectless, such as transaction-only
+  rules.
+- `redirect_not_supported_until_plan_11`: `decision: redirect` remains a load
+  error, with an updated message that points to DB Plan 11.
+
+The warning set is intentionally narrow. Plan 10 should not attempt static
+proof that every glob matches a real catalog object because that requires a
+specific database catalog snapshot and identity.
+
+## 5. Data Flow
+
+### Runtime Policy Evaluation
+
+1. The proxy classifies SQL and Plan 09 attaches resolved metadata.
+2. `policy.Evaluate` receives the augmented classified statement.
+3. The evaluator filters rules by service, operation, subtype, and resolution.
+4. For each effect object slot, it evaluates syntactic and canonical selector
+   coverage.
+5. Deny still fires on any matching object.
+6. Allow/audit/approve still require every object slot to be covered.
+7. The most-restrictive decision fold is unchanged.
+
+### Explain Command
+
+1. The CLI loads the root policy and DB policy rule set.
+2. The CLI reads SQL from `--sql` or stdin.
+3. The Postgres classifier emits syntactic statements.
+4. If `--catalog-fixture` is present, explain mode applies offline catalog
+   resolution; otherwise it leaves syntactic classification intact and records
+   catalog source `none`.
+5. The CLI calls the policy explanation API for each statement.
+6. The CLI writes JSON or text output with effects, coverage, warnings, and
+   final decisions.
+
+## 6. Failure Semantics
+
+- A policy containing `relations` or `functions` decodes successfully when the
+  selectors are valid globs.
+- Bad relation/function glob patterns are fatal load errors with the existing
+  `glob_compile` style.
+- A canonical selector never matches unresolved catalog metadata.
+- If explain mode has no catalog fixture, canonical selectors can be reported
+  as configured but uncovered for the classified statement.
+- If a catalog fixture is malformed, `agentsh policy db explain` exits nonzero
+  and names the fixture field that failed to parse.
+- If policy validation finds warnings only, it exits zero and prints warnings.
+- `decision: redirect` remains a fatal load error until Plan 11.
+
+## 7. Testing Strategy
+
+### Unit Tests
+
+- Decode accepts `relations` and `functions`.
+- Compile rejects invalid glob patterns in `relations` and `functions`.
+- Relation selectors match only successful resolved relations.
+- Function selectors match only successful resolved functions.
+- `schemas` matches resolved schemas as well as syntactic schemas.
+- Mixed syntactic and canonical selectors cover an object slot when either
+  selector family matches.
+- Canonical selectors do not cover unresolved, unavailable, or unsupported
+  resolved objects.
+- Existing syntactic-only policies produce identical decisions before and
+  after Plan 10.
+- Warning codes are emitted for the documented misuse cases.
+
+### Explain Tests
+
+- `agentsh policy db explain` reads SQL from stdin and from `--sql`.
+- JSON output includes effects, resolved objects, coverage, uncovered objects,
+  warnings, and decision fields.
+- Text output includes the statement verb, final decision, matching rule, and
+  uncovered object summary.
+- Catalog fixture resolution covers qualified and unqualified relation names.
+- Missing fixture catalog rows show canonical selectors as uncovered.
+
+### Cross-Platform Verification
+
+Plan 10 touches policy and CLI code that must build on every supported target:
+
+- `go test ./...`
+- `GOOS=windows go build ./...`
+
+The explain command must not import Linux-only proxy runtime files. Catalog
+fixture resolution should use platform-agnostic catalog and classifier
+packages.
+
+## 8. Documentation And Samples
+
+Update the sample DB policy with a resolved-object example:
+
+```yaml
+database_rules:
+  - name: app-read-users-syntactic
+    db_service: appdb
+    operations: [READ]
+    objects: ["users"]
+    decision: allow
+
+  - name: app-read-users-canonical
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: allow
+```
+
+Documentation must state:
+
+- `objects` is syntactic.
+- `relations` and `functions` require catalog-resolved metadata to match.
+- Strict object coverage still applies.
+- `match_object_resolution: catalog_resolved` is the recommended guard for
+  high-assurance canonical rules.
+- `audit` is allow-with-observation, not block-with-observation.
+- Plan 10 explain is offline unless a catalog fixture is supplied.
+
+## 9. Acceptance Criteria
+
+- Existing Phase 1 and Plan 09 policies keep their current decisions.
+- Operators can author `relations` and `functions` selectors in DB statement
+  rules.
+- Canonical selectors only match successful catalog-backed resolved objects.
+- `agentsh policy db explain` reports classification, resolution, coverage,
+  warnings, and final decision for a statement under a policy file.
+- Policy validation surfaces Plan 10 warnings without blocking load.
+- `decision: redirect` is still rejected and points operators to Plan 11.
+- `go test ./...` and `GOOS=windows go build ./...` pass.

--- a/internal/api/db_proxy.go
+++ b/internal/api/db_proxy.go
@@ -105,15 +105,15 @@ func startDBProxyWithStartError(ctx context.Context, deps dbProxyDeps) (*postgre
 // Returns nil when no DB rules are present (decoding succeeds with an empty
 // services map). Errors are returned to the caller; they should be fatal
 // because misconfigured DB policy should not silently disable interception.
-func loadDBRuleSet(p *rootpolicy.Policy) (*dbpolicy.RuleSet, error) {
+func loadDBRuleSet(p *rootpolicy.Policy) (*dbpolicy.RuleSet, []dbpolicy.Warning, error) {
 	if p == nil {
-		return nil, nil
+		return nil, nil, nil
 	}
-	rs, _, err := dbpolicy.Decode(p)
+	rs, warns, err := dbpolicy.Decode(p)
 	if err != nil {
-		return nil, fmt.Errorf("loadDBRuleSet: decode db policy: %w", err)
+		return nil, warns, fmt.Errorf("loadDBRuleSet: decode db policy: %w", err)
 	}
-	return rs, nil
+	return rs, warns, nil
 }
 
 // collectDBProxyServices enumerates every declared db_service in rs and

--- a/internal/api/db_unavoidability.go
+++ b/internal/api/db_unavoidability.go
@@ -91,9 +91,12 @@ func (a *App) compileDBPolicyForSession(ctx context.Context, s *session.Session,
 	if base == nil {
 		return a.policy, nil, "", nil
 	}
-	rs, err := loadDBRuleSet(base)
+	rs, warns, err := loadDBRuleSet(base)
 	if err != nil {
 		return nil, nil, "", err
+	}
+	for _, w := range warns {
+		slog.Warn("db policy warning", "code", w.Code, "rule", w.Rule, "field", w.Field, "message", w.Message)
 	}
 	if rs.Unavoidability() == dbservice.UnavoidabilityOff || len(rs.AllServices()) == 0 {
 		engine, err := policy.NewEngineWithVariables(base, enforceApprovals, true, policyVars)

--- a/internal/cli/policy_cmd.go
+++ b/internal/cli/policy_cmd.go
@@ -1,15 +1,19 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
+	dbpolicy "github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/policyexplain"
 	"github.com/agentsh/agentsh/internal/policy"
-	"github.com/agentsh/agentsh/internal/policygen"
 	"github.com/agentsh/agentsh/internal/policy/signing"
+	"github.com/agentsh/agentsh/internal/policygen"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -92,6 +96,11 @@ func newPolicyCmd() *cobra.Command {
 			}
 			if _, err := policy.NewEngine(po, false, true); err != nil {
 				return err
+			}
+			if _, warns, err := dbpolicy.Decode(po); err != nil {
+				return err
+			} else {
+				printDBPolicyWarnings(cmd, warns)
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "ok")
 			return nil
@@ -275,6 +284,8 @@ Examples:
 	verifyCmd.Flags().StringVar(&verifyKeyDir, "key-dir", "", "Path to trust store directory (required)")
 	cmd.AddCommand(verifyCmd)
 
+	cmd.AddCommand(newPolicyDBCmd(configPath, dir))
+
 	return cmd
 }
 
@@ -294,25 +305,25 @@ func resolvePolicyDir(configPath, override string) (string, error) {
 }
 
 func resolvePolicyPath(dir, nameOrPath string) (string, error) {
-    if nameOrPath == "" {
-        return "", fmt.Errorf("policy name/path is required")
-    }
-    if strings.ContainsRune(nameOrPath, os.PathSeparator) || strings.HasSuffix(nameOrPath, ".yml") || strings.HasSuffix(nameOrPath, ".yaml") {
-        p := nameOrPath
-        if !filepath.IsAbs(p) {
-            p = filepath.Clean(p)
-        }
-        if _, err := os.Stat(p); err == nil {
-            return p, nil
-        }
-        // If it's a relative path inside dir, try that.
-        p2 := filepath.Join(dir, nameOrPath)
-        if _, err := os.Stat(p2); err == nil {
-            return p2, nil
-        }
-    }
-    // CLI resolution remains permissive for direct paths; allowlist enforcement is server-side.
-    return policy.ResolvePolicyPath(dir, nameOrPath)
+	if nameOrPath == "" {
+		return "", fmt.Errorf("policy name/path is required")
+	}
+	if strings.ContainsRune(nameOrPath, os.PathSeparator) || strings.HasSuffix(nameOrPath, ".yml") || strings.HasSuffix(nameOrPath, ".yaml") {
+		p := nameOrPath
+		if !filepath.IsAbs(p) {
+			p = filepath.Clean(p)
+		}
+		if _, err := os.Stat(p); err == nil {
+			return p, nil
+		}
+		// If it's a relative path inside dir, try that.
+		p2 := filepath.Join(dir, nameOrPath)
+		if _, err := os.Stat(p2); err == nil {
+			return p2, nil
+		}
+	}
+	// CLI resolution remains permissive for direct paths; allowlist enforcement is server-side.
+	return policy.ResolvePolicyPath(dir, nameOrPath)
 }
 
 func truncateSessionID(id string) string {
@@ -320,4 +331,152 @@ func truncateSessionID(id string) string {
 		return id[:8]
 	}
 	return id
+}
+
+func newPolicyDBCmd(configPath, dir string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "db",
+		Short: "Inspect database policy behavior",
+	}
+	cmd.AddCommand(newPolicyDBExplainCmd(configPath, dir))
+	return cmd
+}
+
+func newPolicyDBExplainCmd(configPath, dir string) *cobra.Command {
+	var serviceName string
+	var dialect string
+	var searchPath string
+	var tempTables string
+	var catalogFixture string
+	var sqlFlag string
+	var output string
+
+	cmd := &cobra.Command{
+		Use:   "explain POLICY_OR_PATH",
+		Short: "Explain DB policy classification, resolution, coverage, and decision",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if strings.TrimSpace(serviceName) == "" {
+				return fmt.Errorf("--service is required")
+			}
+			pdir, err := resolvePolicyDir(configPath, dir)
+			if err != nil {
+				return err
+			}
+			policyPath, err := resolvePolicyPath(pdir, args[0])
+			if err != nil {
+				return err
+			}
+			rootPolicy, err := policy.LoadFromFile(policyPath)
+			if err != nil {
+				return err
+			}
+			rs, warns, err := dbpolicy.Decode(rootPolicy)
+			if err != nil {
+				return err
+			}
+			sqlText := sqlFlag
+			if sqlText == "" {
+				raw, err := io.ReadAll(cmd.InOrStdin())
+				if err != nil {
+					return err
+				}
+				sqlText = string(raw)
+			}
+			if strings.TrimSpace(sqlText) == "" {
+				return fmt.Errorf("SQL is required via --sql or stdin")
+			}
+			if dialect == "" {
+				if svc, ok := rs.Service(dbpolicy.ServiceID(serviceName)); ok && svc.Dialect != "" {
+					dialect = svc.Dialect
+				} else {
+					dialect = "postgres"
+				}
+			}
+			report, err := policyexplain.Run(rs, warns, policyexplain.Options{
+				SQL:            sqlText,
+				Service:        dbpolicy.ServiceID(serviceName),
+				Dialect:        dialect,
+				SearchPath:     splitCSV(searchPath),
+				TempTables:     splitCSV(tempTables),
+				CatalogFixture: catalogFixture,
+			})
+			if err != nil {
+				return err
+			}
+			switch output {
+			case "", "json":
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				enc.SetIndent("", "  ")
+				return enc.Encode(report)
+			case "text":
+				return printDBExplainText(cmd, report)
+			default:
+				return fmt.Errorf("--output must be json or text")
+			}
+		},
+	}
+	cmd.Flags().StringVar(&serviceName, "service", "", "DB service name (required)")
+	cmd.Flags().StringVar(&dialect, "dialect", "", "postgres|aurora_postgres|cockroachdb|redshift")
+	cmd.Flags().StringVar(&searchPath, "search-path", "", "comma-separated search path")
+	cmd.Flags().StringVar(&tempTables, "temp-tables", "", "comma-separated temp table names")
+	cmd.Flags().StringVar(&catalogFixture, "catalog-fixture", "", "YAML catalog fixture path")
+	cmd.Flags().StringVar(&sqlFlag, "sql", "", "SQL statement text (default: stdin)")
+	cmd.Flags().StringVar(&output, "output", "json", "json|text")
+	return cmd
+}
+
+func splitCSV(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		p := strings.TrimSpace(part)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func printDBExplainText(cmd *cobra.Command, report policyexplain.Report) error {
+	for _, stmt := range report.Statements {
+		fmt.Fprintf(cmd.OutOrStdout(), "statement %d: %s\n", stmt.Index, stmt.RawVerb)
+		fmt.Fprintf(cmd.OutOrStdout(), "decision: %s\n", stmt.Decision.Verb)
+		if stmt.Decision.RuleName != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "rule: %s\n", stmt.Decision.RuleName)
+		}
+		for _, eff := range stmt.Effects {
+			fmt.Fprintf(cmd.OutOrStdout(), "effect %d: %s resolution=%s\n", eff.Index, eff.Operation, eff.Resolution)
+			for _, cov := range eff.Coverage {
+				if cov.Covered {
+					fmt.Fprintf(cmd.OutOrStdout(), "  covered: %s selector=%s\n", cov.Object, cov.Selector)
+				} else {
+					fmt.Fprintf(cmd.OutOrStdout(), "  uncovered: %s reason=%s\n", cov.Object, cov.UncoveredReason)
+				}
+			}
+		}
+	}
+	if len(report.Warnings) > 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "warnings:")
+		for _, w := range report.Warnings {
+			fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s\n", w.Code, w.Message)
+		}
+	}
+	return nil
+}
+
+func printDBPolicyWarnings(cmd *cobra.Command, warns []dbpolicy.Warning) {
+	for _, w := range warns {
+		fmt.Fprintf(cmd.ErrOrStderr(), "warning[%s]", w.Code)
+		if w.Rule != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), " rule=%s", w.Rule)
+		}
+		if w.Field != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), " field=%s", w.Field)
+		}
+		fmt.Fprintf(cmd.ErrOrStderr(), ": %s\n", w.Message)
+	}
 }

--- a/internal/cli/policy_config_test.go
+++ b/internal/cli/policy_config_test.go
@@ -1,6 +1,11 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestRoot_WiresPolicyAndConfig(t *testing.T) {
 	root := NewRoot("test")
@@ -19,5 +24,41 @@ func TestRoot_WiresPolicyAndConfig(t *testing.T) {
 	}
 	if !foundConfig {
 		t.Fatalf("expected config command to be registered")
+	}
+}
+
+func TestPolicyValidate_PrintsDBWarnings(t *testing.T) {
+	dir := t.TempDir()
+	policyPath := filepath.Join(dir, "policy.yaml")
+	writeFile(t, policyPath, `version: 1
+name: t
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: x:1
+    tls_mode: terminate_reissue
+database_rules:
+  - name: canonical-read
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    decision: allow
+`)
+
+	root := NewRoot("test")
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&errOut)
+	root.SetArgs([]string{"policy", "validate", policyPath})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v\nstdout:\n%s\nstderr:\n%s", err, out.String(), errOut.String())
+	}
+	if !strings.Contains(out.String(), "ok") {
+		t.Fatalf("stdout = %q, want ok", out.String())
+	}
+	if !strings.Contains(errOut.String(), "warning[canonical_selector_without_resolution_guard]") {
+		t.Fatalf("stderr = %q, want canonical selector warning", errOut.String())
 	}
 }

--- a/internal/cli/policy_db_explain_test.go
+++ b/internal/cli/policy_db_explain_test.go
@@ -1,0 +1,93 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPolicyDBExplainJSONWithSQLFlag(t *testing.T) {
+	dir := t.TempDir()
+	policyPath := filepath.Join(dir, "policy.yaml")
+	fixturePath := filepath.Join(dir, "catalog.yaml")
+	writeFile(t, policyPath, `version: 1
+name: t
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: x:1
+    tls_mode: terminate_reissue
+database_rules:
+  - name: canonical-read
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: allow
+`)
+	writeFile(t, fixturePath, `search_path: [public]
+relations:
+  - oid: 16384
+    schema: public
+    name: users
+    kind: table
+`)
+
+	root := NewRoot("test")
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"policy", "db", "explain", policyPath, "--service", "appdb", "--catalog-fixture", fixturePath, "--sql", "SELECT * FROM users"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v\n%s", err, out.String())
+	}
+	body := out.String()
+	if !strings.Contains(body, `"verb": "allow"`) {
+		t.Fatalf("missing allow decision:\n%s", body)
+	}
+	if !strings.Contains(body, `"rule_name": "canonical-read"`) {
+		t.Fatalf("missing rule name:\n%s", body)
+	}
+	if !strings.Contains(body, `"resolved_object": "public.users"`) {
+		t.Fatalf("missing resolved object:\n%s", body)
+	}
+}
+
+func TestPolicyDBExplainTextFromStdin(t *testing.T) {
+	dir := t.TempDir()
+	policyPath := filepath.Join(dir, "policy.yaml")
+	writeFile(t, policyPath, `version: 1
+name: t
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: x:1
+    tls_mode: terminate_reissue
+database_rules:
+  - {name: read-all, db_service: appdb, operations: [READ], decision: allow}
+`)
+	root := NewRoot("test")
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetIn(strings.NewReader("SELECT * FROM users"))
+	root.SetArgs([]string{"policy", "db", "explain", policyPath, "--service", "appdb", "--output", "text"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute: %v\n%s", err, out.String())
+	}
+	body := out.String()
+	if !strings.Contains(body, "decision: allow") || !strings.Contains(body, "rule: read-all") {
+		t.Fatalf("unexpected text output:\n%s", body)
+	}
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/db/policy/compile.go
+++ b/internal/db/policy/compile.go
@@ -20,7 +20,7 @@ type compiledStatementRule struct {
 	subtypes      map[effects.Subtype]struct{} // empty = all subtypes match
 	resolution    resolutionMatcher
 	schemas       []glob.Glob // empty = all schemas match
-	objects       []glob.Glob // syntactic objects; empty = all objects match
+	objects       []glob.Glob // syntactic object selectors
 	relations     []glob.Glob // resolved relation canonical names
 	functions     []glob.Glob // resolved function identity names
 	timeout       time.Duration
@@ -215,7 +215,8 @@ func (c *compiledStatementRule) matchesResolution(r effects.Resolution) bool {
 
 // objectMatches reports whether any of the rule's `objects` globs matches
 // the given ObjectRef per the kind→field table in this plan's File Structure
-// section. Returns true unconditionally when c.objects is empty.
+// section. Returns true unconditionally only when no object selector family is
+// constrained.
 func (c *compiledStatementRule) objectMatches(o effects.ObjectRef) bool {
 	if c.coversAllObjects() {
 		return true
@@ -229,18 +230,30 @@ func (c *compiledStatementRule) objectMatches(o effects.ObjectRef) bool {
 	return false
 }
 
-// schemaMatches reports whether the schemas: clause is absent or any glob in
-// it matches the object's schema. Non-relation objects (no schema) are treated
-// as covered when schemas: is absent and uncovered when it is present.
-func (c *compiledStatementRule) schemaMatches(o effects.ObjectRef) bool {
+func (c *compiledStatementRule) schemaMatchesObjectSlot(o effects.ObjectRef, resolved effects.ResolvedObjectRef, hasResolved bool) bool {
 	if len(c.schemas) == 0 {
 		return true
 	}
-	if o.Schema == "" {
+	for _, g := range c.schemas {
+		if o.Schema != "" && g.Match(o.Schema) {
+			return true
+		}
+		if hasResolved && resolved.Schema != "" && g.Match(resolved.Schema) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *compiledStatementRule) schemaMatchesResolvedObject(resolved effects.ResolvedObjectRef) bool {
+	if len(c.schemas) == 0 {
+		return true
+	}
+	if resolved.Schema == "" {
 		return false
 	}
 	for _, g := range c.schemas {
-		if g.Match(o.Schema) {
+		if g.Match(resolved.Schema) {
 			return true
 		}
 	}

--- a/internal/db/policy/compile.go
+++ b/internal/db/policy/compile.go
@@ -20,7 +20,9 @@ type compiledStatementRule struct {
 	subtypes      map[effects.Subtype]struct{} // empty = all subtypes match
 	resolution    resolutionMatcher
 	schemas       []glob.Glob // empty = all schemas match
-	objects       []glob.Glob // empty = all objects match
+	objects       []glob.Glob // syntactic objects; empty = all objects match
+	relations     []glob.Glob // resolved relation canonical names
+	functions     []glob.Glob // resolved function identity names
 	timeout       time.Duration
 	msgTemplate   *template.Template // nil = no message rendering
 	serviceFilter serviceFilter
@@ -170,6 +172,20 @@ func compileStatementRule(r *StatementRule) (*compiledStatementRule, error) {
 		}
 		c.objects = append(c.objects, g)
 	}
+	for _, pat := range r.Relations {
+		g, err := glob.Compile(pat)
+		if err != nil {
+			return nil, fmt.Errorf("glob_compile: rule %q relations %q: %w", r.Name, pat, err)
+		}
+		c.relations = append(c.relations, g)
+	}
+	for _, pat := range r.Functions {
+		g, err := glob.Compile(pat)
+		if err != nil {
+			return nil, fmt.Errorf("glob_compile: rule %q functions %q: %w", r.Name, pat, err)
+		}
+		c.functions = append(c.functions, g)
+	}
 
 	if strings.TrimSpace(r.Message) != "" {
 		tmpl, err := template.New("msg").Parse(r.Message)
@@ -187,7 +203,11 @@ func compileStatementRule(r *StatementRule) (*compiledStatementRule, error) {
 	return c, nil
 }
 
-func (c *compiledStatementRule) coversAllObjects() bool { return len(c.objects) == 0 }
+func (c *compiledStatementRule) coversAllObjects() bool { return !c.hasObjectSelectors() }
+
+func (c *compiledStatementRule) hasObjectSelectors() bool {
+	return len(c.objects) > 0 || len(c.relations) > 0 || len(c.functions) > 0
+}
 
 func (c *compiledStatementRule) matchesResolution(r effects.Resolution) bool {
 	return c.resolution.matches(r)
@@ -225,6 +245,47 @@ func (c *compiledStatementRule) schemaMatches(o effects.ObjectRef) bool {
 		}
 	}
 	return false
+}
+
+func (c *compiledStatementRule) relationMatches(r effects.ResolvedObjectRef) bool {
+	if len(c.relations) == 0 {
+		return false
+	}
+	if r.Source != effects.ResolvedObjectSourceCatalog ||
+		r.Kind != effects.ResolvedObjectRelation ||
+		r.UnresolvedReason != "" {
+		return false
+	}
+	target := r.CanonicalName()
+	for _, g := range c.relations {
+		if g.Match(target) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *compiledStatementRule) functionMatches(r effects.ResolvedObjectRef) bool {
+	if len(c.functions) == 0 {
+		return false
+	}
+	if r.Source != effects.ResolvedObjectSourceCatalog ||
+		r.Kind != effects.ResolvedObjectFunction ||
+		r.UnresolvedReason != "" {
+		return false
+	}
+	target := resolvedFunctionIdentity(r)
+	for _, g := range c.functions {
+		if g.Match(target) {
+			return true
+		}
+	}
+	return false
+}
+
+func resolvedFunctionIdentity(r effects.ResolvedObjectRef) string {
+	name := r.CanonicalName()
+	return name + "(" + r.FunctionIdentityArgs + ")"
 }
 
 // renderMessage applies the rule's message template, or returns the raw

--- a/internal/db/policy/compile_test.go
+++ b/internal/db/policy/compile_test.go
@@ -39,6 +39,25 @@ func TestCompileStatementRule_NoObjectsCoversAll(t *testing.T) {
 	}
 }
 
+func TestCompileStatementRule_CanonicalOnlyDoesNotCoverSyntacticObject(t *testing.T) {
+	r := &StatementRule{
+		Name:       "canonical-only",
+		Operations: []string{"READ"},
+		Relations:  []string{"public.users"},
+		Decision:   "allow",
+	}
+	c, err := compileStatementRule(r)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if c.coversAllObjects() {
+		t.Fatal("canonical selector-only rule should not cover all syntactic objects")
+	}
+	if c.objectMatches(effects.ObjectRef{Kind: effects.ObjectTable, Schema: "public", Name: "users"}) {
+		t.Fatal("canonical selector-only rule should not cover a syntactic object without resolved canonical matching")
+	}
+}
+
 func TestCompileStatementRule_ExternalEndpointHostMatch(t *testing.T) {
 	r := &StatementRule{Name: "endpoint", Objects: []string{"*.internal"},
 		Operations: []string{"READ"}, Decision: "deny"}
@@ -87,6 +106,61 @@ func TestCompileStatementRule_BadGlob(t *testing.T) {
 	_, err := compileStatementRule(r)
 	if err == nil || !strings.Contains(err.Error(), "glob_compile") {
 		t.Fatalf("want glob_compile error, got %v", err)
+	}
+}
+
+func TestCompileStatementRule_CanonicalSelectorGlobs(t *testing.T) {
+	r := &StatementRule{
+		Name:       "canonical",
+		Operations: []string{"READ"},
+		Relations:  []string{"public.users", "sales.*"},
+		Functions:  []string{"public.safe_fn(integer)", "pg_catalog.*"},
+		Decision:   "allow",
+	}
+	c, err := compileStatementRule(r)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	rel := effects.ResolvedObjectRef{
+		Source: effects.ResolvedObjectSourceCatalog,
+		Kind:   effects.ResolvedObjectRelation,
+		Schema: "public",
+		Name:   "users",
+	}
+	if !c.relationMatches(rel) {
+		t.Fatalf("public.users relation should match")
+	}
+	fn := effects.ResolvedObjectRef{
+		Source:               effects.ResolvedObjectSourceCatalog,
+		Kind:                 effects.ResolvedObjectFunction,
+		Schema:               "public",
+		Name:                 "safe_fn",
+		FunctionIdentityArgs: "integer",
+	}
+	if !c.functionMatches(fn) {
+		t.Fatalf("public.safe_fn(integer) function should match")
+	}
+}
+
+func TestCompileStatementRule_BadCanonicalGlob(t *testing.T) {
+	_, err := compileStatementRule(&StatementRule{
+		Name:       "bad-relation",
+		Operations: []string{"READ"},
+		Relations:  []string{"["},
+		Decision:   "allow",
+	})
+	if err == nil || !strings.Contains(err.Error(), "glob_compile") || !strings.Contains(err.Error(), "relations") {
+		t.Fatalf("want relation glob_compile error, got %v", err)
+	}
+
+	_, err = compileStatementRule(&StatementRule{
+		Name:       "bad-function",
+		Operations: []string{"READ"},
+		Functions:  []string{"["},
+		Decision:   "allow",
+	})
+	if err == nil || !strings.Contains(err.Error(), "glob_compile") || !strings.Contains(err.Error(), "functions") {
+		t.Fatalf("want function glob_compile error, got %v", err)
 	}
 }
 

--- a/internal/db/policy/decode_test.go
+++ b/internal/db/policy/decode_test.go
@@ -70,6 +70,43 @@ database_connection_rules:
 	}
 }
 
+func TestDecode_CanonicalSelectors(t *testing.T) {
+	src := `version: 1
+name: t
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: terminate_reissue
+database_rules:
+  - name: canonical-read
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users", "sales.*"]
+    functions: ["public.safe_fn(integer)", "pg_catalog.*"]
+    match_object_resolution: catalog_resolved
+    decision: allow
+`
+	rs, warns, err := loadDB(t, src)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("warnings = %+v", warns)
+	}
+	rules := rs.AllStatementRules()
+	if len(rules) != 1 {
+		t.Fatalf("rules = %d, want 1", len(rules))
+	}
+	if got := rules[0].Relations; len(got) != 2 || got[0] != "public.users" || got[1] != "sales.*" {
+		t.Fatalf("Relations = %#v", got)
+	}
+	if got := rules[0].Functions; len(got) != 2 || got[0] != "public.safe_fn(integer)" || got[1] != "pg_catalog.*" {
+		t.Fatalf("Functions = %#v", got)
+	}
+}
+
 func TestDecode_RedactionConfig(t *testing.T) {
 	src := `version: 1
 name: t

--- a/internal/db/policy/evaluate.go
+++ b/internal/db/policy/evaluate.go
@@ -59,11 +59,11 @@ type effectDecision struct {
 type internalVerb uint8
 
 const (
-	verbAllow       internalVerb = iota
-	verbAudit                    // more restrictive than allow
-	verbApprove                  // more restrictive than audit
-	verbImplicitDeny             // more restrictive than approve; loses to explicit deny on tie
-	verbDeny                     // most restrictive
+	verbAllow        internalVerb = iota
+	verbAudit                     // more restrictive than allow
+	verbApprove                   // more restrictive than audit
+	verbImplicitDeny              // more restrictive than approve; loses to explicit deny on tie
+	verbDeny                      // most restrictive
 )
 
 // evaluateEffect runs the three-pass §10.2 algorithm for a single effect.
@@ -75,10 +75,13 @@ func evaluateEffect(e effects.Effect, applicable []*compiledStatementRule) effec
 	//
 	// Exception: groups that *inherently* have no objects — Transaction,
 	// Session, Notify — would otherwise be unreachable through the §10.2
-	// coverage rules. Treat those as covered by any non-objects-constrained
-	// rule whose effect-meta matches. isObjectlessEffect also covers
-	// SubtypeFunctionCallProtocol (FunctionCall 'F' frames carry only an OID).
+	// coverage rules. Treat those as covered by any rule with no object selector
+	// family whose effect-meta matches. Resolved-only procedural function effects
+	// use canonical selector coverage below.
 	if len(e.Objects) == 0 {
+		if isResolvedOnlyFunctionEffect(e) {
+			return evaluateEffectResolvedOnly(e, applicable)
+		}
 		if isObjectlessEffect(e) {
 			return evaluateEffectObjectless(e, applicable)
 		}
@@ -96,11 +99,8 @@ func evaluateEffect(e effects.Effect, applicable []*compiledStatementRule) effec
 			continue
 		}
 		// Find the first matching object (deterministic: object list order).
-		for _, o := range e.Objects {
-			if !r.schemaMatches(o) {
-				continue
-			}
-			if r.objectMatches(o) {
+		for i, o := range e.Objects {
+			if ok, _ := ruleMatchesObjectSlot(r, e, i); ok {
 				return effectDecision{verb: verbDeny, rule: r, denyMatchingObject: o}
 			}
 		}
@@ -109,7 +109,7 @@ func evaluateEffect(e effects.Effect, applicable []*compiledStatementRule) effec
 	// Pass 2 — coverage. For each object, collect non-deny rules that cover it.
 	// coverage[i] holds the covering rules for e.Objects[i].
 	coverage := make(map[int][]*compiledStatementRule, len(e.Objects))
-	for i, o := range e.Objects {
+	for i := range e.Objects {
 		for _, r := range applicable {
 			if r.verb == VerbDeny {
 				continue
@@ -117,13 +117,9 @@ func evaluateEffect(e effects.Effect, applicable []*compiledStatementRule) effec
 			if !ruleMatchesEffectMeta(r, e) {
 				continue
 			}
-			if !r.schemaMatches(o) {
-				continue
+			if ok, _ := ruleMatchesObjectSlot(r, e, i); ok {
+				coverage[i] = append(coverage[i], r)
 			}
-			if !r.objectMatches(o) {
-				continue
-			}
-			coverage[i] = append(coverage[i], r)
 		}
 	}
 
@@ -134,62 +130,89 @@ func evaluateEffect(e effects.Effect, applicable []*compiledStatementRule) effec
 		}
 	}
 
-	// Pass 3 — most-restrictive verb across covering rules.
-	// Walk coverage in object order, preserving rule order within each bucket
-	// (rules stay in policy file order because `applicable` preserves that order).
-	// This guarantees R14 order-independence of OUTCOMES: the result depends on
-	// the rule set, not on evaluation path; only the RuleName tiebreak (D-OQ3)
-	// uses file order.
-	var (
-		best        internalVerb = verbAllow
-		primary     *compiledStatementRule
-		approveRules []*compiledStatementRule
-		auditRules   []*compiledStatementRule
-		approveSeen  = map[string]bool{}
-		auditSeen    = map[string]bool{}
-	)
-	for i := range e.Objects {
+	// Pass 3 — most-restrictive verb across covering rules. Fold in policy file
+	// order so same-verb primary RuleName ties are independent of object order.
+	return foldCoverageRules(coverageRulesInPolicyOrder(applicable, coverage, len(e.Objects)))
+}
+
+func resolvedObjectForSlot(e effects.Effect, idx int) (effects.ResolvedObjectRef, bool) {
+	if idx < 0 || idx >= len(e.Objects) {
+		return effects.ResolvedObjectRef{}, false
+	}
+	o := e.Objects[idx]
+	for _, resolved := range e.ResolvedObjects {
+		if resolvedObjectCompatibleWithSlot(o, resolved) {
+			return resolved, true
+		}
+	}
+	return effects.ResolvedObjectRef{}, false
+}
+
+func resolvedObjectCompatibleWithSlot(o effects.ObjectRef, resolved effects.ResolvedObjectRef) bool {
+	if o.Name == "" || resolved.Name == "" || o.Name != resolved.Name {
+		return false
+	}
+	if o.Schema != "" && o.Schema != resolved.Schema {
+		return false
+	}
+	switch resolved.Kind {
+	case effects.ResolvedObjectRelation:
+		return isRelationObjectKind(o.Kind)
+	case effects.ResolvedObjectFunction:
+		return o.Kind == effects.ObjectFunction
+	default:
+		return false
+	}
+}
+
+func isRelationObjectKind(kind effects.ObjectKind) bool {
+	switch kind {
+	case effects.ObjectTable, effects.ObjectView, effects.ObjectSequence:
+		return true
+	default:
+		return false
+	}
+}
+
+func ruleMatchesObjectSlot(r *compiledStatementRule, e effects.Effect, idx int) (bool, string) {
+	if idx < 0 || idx >= len(e.Objects) {
+		return false, ""
+	}
+	o := e.Objects[idx]
+	resolved, hasResolved := resolvedObjectForSlot(e, idx)
+	if !r.schemaMatchesObjectSlot(o, resolved, hasResolved) {
+		return false, ""
+	}
+	if !r.hasObjectSelectors() {
+		return true, "all"
+	}
+	if len(r.objects) > 0 && r.objectMatches(o) {
+		return true, "objects"
+	}
+	if hasResolved && r.relationMatches(resolved) {
+		return true, "relations"
+	}
+	if hasResolved && r.functionMatches(resolved) {
+		return true, "functions"
+	}
+	return false, ""
+}
+
+func coverageRulesInPolicyOrder(applicable []*compiledStatementRule, coverage map[int][]*compiledStatementRule, objectCount int) []*compiledStatementRule {
+	covered := map[*compiledStatementRule]bool{}
+	for i := 0; i < objectCount; i++ {
 		for _, r := range coverage[i] {
-			switch r.verb {
-			case VerbApprove:
-				if verbApprove > best {
-					best = verbApprove
-				}
-				if !approveSeen[r.src.Name] {
-					approveSeen[r.src.Name] = true
-					approveRules = append(approveRules, r)
-				}
-			case VerbAudit:
-				if verbAudit > best {
-					best = verbAudit
-				}
-				if !auditSeen[r.src.Name] {
-					auditSeen[r.src.Name] = true
-					auditRules = append(auditRules, r)
-				}
-			// VerbAllow contributes coverage but no verb escalation. The primary
-			// rule for an allow outcome is selected later (coverage[0][0]).
-			}
+			covered[r] = true
 		}
 	}
 
-	// Determine primary rule (D-OQ3: first by policy file order).
-	switch best {
-	case verbApprove:
-		primary = approveRules[0]
-	case verbAudit:
-		primary = auditRules[0]
-	default:
-		// Allow: pick the first covering rule for the first object.
-		primary = coverage[0][0]
+	out := make([]*compiledStatementRule, 0, len(covered))
+	for _, r := range applicable {
+		if covered[r] {
+			out = append(out, r)
+		}
 	}
-
-	return effectDecision{
-		verb:                best,
-		rule:                primary,
-		contributingApprove: approveRules,
-		contributingAudit:   auditRules,
-	}
+	return out
 }
 
 // isObjectlessGroup reports whether the group inherently has no objects
@@ -208,9 +231,9 @@ func isObjectlessGroup(g effects.Group) bool {
 // isObjectlessEffect reports whether the effect is inherently object-less and
 // should be evaluated using the degenerate per-group path rather than returning
 // verbImplicitDeny. This extends isObjectlessGroup for cases where the group
-// alone is insufficient: FunctionCall protocol effects (Subtype ==
-// SubtypeFunctionCallProtocol) carry only a function OID with no resolvable
-// object name, so they must be reachable through object-less coverage rules.
+// alone is insufficient: unresolved FunctionCall protocol effects (Subtype ==
+// SubtypeFunctionCallProtocol) carry only a function OID with no object name,
+// so they must be reachable through object-less coverage rules.
 // SQL-escalated unknown-function procedural effects (Group == GroupProcedural,
 // Subtype == 0) remain implicit-deny by design (fail-closed escalation).
 func isObjectlessEffect(e effects.Effect) bool {
@@ -218,22 +241,74 @@ func isObjectlessEffect(e effects.Effect) bool {
 		return true
 	}
 	// FunctionCall protocol: OID-only effect, no resolvable Objects.
-	return e.Subtype == effects.SubtypeFunctionCallProtocol
+	return e.Subtype == effects.SubtypeFunctionCallProtocol && len(e.ResolvedObjects) == 0
+}
+
+func isResolvedOnlyFunctionEffect(e effects.Effect) bool {
+	if len(e.Objects) != 0 || e.Group != effects.GroupProcedural {
+		return false
+	}
+	for _, resolved := range e.ResolvedObjects {
+		if resolved.Kind == effects.ResolvedObjectFunction {
+			return true
+		}
+	}
+	return false
+}
+
+func evaluateEffectResolvedOnly(e effects.Effect, applicable []*compiledStatementRule) effectDecision {
+	for _, r := range applicable {
+		if r.verb != VerbDeny || !ruleMatchesEffectMeta(r, e) {
+			continue
+		}
+		for _, resolved := range e.ResolvedObjects {
+			if !resolvedOnlyFunctionRuleMatches(r, resolved) {
+				continue
+			}
+			if !r.hasObjectSelectors() || r.functionMatches(resolved) {
+				return effectDecision{verb: verbDeny, rule: r}
+			}
+		}
+	}
+
+	var coverage []*compiledStatementRule
+	for _, r := range applicable {
+		if r.verb == VerbDeny || !ruleMatchesEffectMeta(r, e) {
+			continue
+		}
+		for _, resolved := range e.ResolvedObjects {
+			if !resolvedOnlyFunctionRuleMatches(r, resolved) {
+				continue
+			}
+			if !r.hasObjectSelectors() || r.functionMatches(resolved) {
+				coverage = append(coverage, r)
+				break
+			}
+		}
+	}
+	if len(coverage) == 0 {
+		return effectDecision{verb: verbImplicitDeny}
+	}
+	return foldCoverageRules(coverage)
+}
+
+func resolvedOnlyFunctionRuleMatches(r *compiledStatementRule, resolved effects.ResolvedObjectRef) bool {
+	return resolved.Kind == effects.ResolvedObjectFunction && r.schemaMatchesResolvedObject(resolved)
 }
 
 // evaluateEffectObjectless handles effects with no Objects (e.g. transaction
 // or session effects from BEGIN/COMMIT/SET). The §10.2 three-pass algorithm
 // is per-object; for object-less effects we apply a degenerate version:
 //
-//   - A deny rule whose effect-meta matches and whose `objects:` filter is
-//     empty (coversAllObjects) short-circuits to deny.
+//   - A deny rule whose effect-meta matches and has no object selector family
+//     short-circuits to deny.
 //   - Otherwise, the effect is covered by any non-deny rule whose effect-meta
-//     matches and whose `objects:` filter is empty. The most-restrictive verb
+//     matches and has no object selector family. The most-restrictive verb
 //     across covering rules wins.
 //   - If no rule covers the effect, fall back to implicit deny.
 //
-// A rule that constrains `objects:` (non-empty) cannot match an object-less
-// effect — there is no object to match against.
+// A rule that constrains any object selector family cannot match an object-less
+// effect.
 func evaluateEffectObjectless(e effects.Effect, applicable []*compiledStatementRule) effectDecision {
 	// Pass 1 — deny.
 	for _, r := range applicable {
@@ -249,8 +324,8 @@ func evaluateEffectObjectless(e effects.Effect, applicable []*compiledStatementR
 		return effectDecision{verb: verbDeny, rule: r}
 	}
 
-	// Pass 2 — coverage: any non-deny rule whose effect-meta matches and
-	// whose objects filter is empty.
+	// Pass 2 — coverage: any non-deny rule whose effect-meta matches and has no
+	// object selector family.
 	var (
 		coverage []*compiledStatementRule
 	)
@@ -271,6 +346,10 @@ func evaluateEffectObjectless(e effects.Effect, applicable []*compiledStatementR
 	}
 
 	// Pass 3 — most-restrictive verb across covering rules.
+	return foldCoverageRules(coverage)
+}
+
+func foldCoverageRules(coverage []*compiledStatementRule) effectDecision {
 	var (
 		best         internalVerb = verbAllow
 		primary      *compiledStatementRule
@@ -316,7 +395,7 @@ func evaluateEffectObjectless(e effects.Effect, applicable []*compiledStatementR
 }
 
 // ruleMatchesEffectMeta checks group/subtype/resolution for an effect.
-// Per-object matching (schema + object globs) is done by the caller.
+// Per-object selector matching is done by the caller.
 func ruleMatchesEffectMeta(r *compiledStatementRule, e effects.Effect) bool {
 	if _, ok := r.groups[e.Group]; !ok {
 		return false

--- a/internal/db/policy/evaluate.go
+++ b/internal/db/policy/evaluate.go
@@ -140,12 +140,17 @@ func resolvedObjectForSlot(e effects.Effect, idx int) (effects.ResolvedObjectRef
 		return effects.ResolvedObjectRef{}, false
 	}
 	o := e.Objects[idx]
-	if hasRelationObjectSlot(e.Objects) {
-		if !isRelationObjectKind(o.Kind) {
-			return effects.ResolvedObjectRef{}, false
-		}
+	switch {
+	case isRelationObjectKind(o.Kind):
 		ordinal := relationObjectSlotOrdinal(e.Objects, idx)
 		resolved, ok := resolvedRelationObjectAtOrdinal(e.ResolvedObjects, ordinal)
+		if !ok || !resolvedObjectCompatibleWithSlot(o, resolved) {
+			return effects.ResolvedObjectRef{}, false
+		}
+		return resolved, true
+	case o.Kind == effects.ObjectFunction:
+		ordinal := functionObjectSlotOrdinal(e.Objects, idx)
+		resolved, ok := resolvedFunctionObjectAtOrdinal(e.ResolvedObjects, ordinal)
 		if !ok || !resolvedObjectCompatibleWithSlot(o, resolved) {
 			return effects.ResolvedObjectRef{}, false
 		}
@@ -159,19 +164,24 @@ func resolvedObjectForSlot(e effects.Effect, idx int) (effects.ResolvedObjectRef
 	return effects.ResolvedObjectRef{}, false
 }
 
-func hasRelationObjectSlot(objects []effects.ObjectRef) bool {
-	for _, o := range objects {
-		if isRelationObjectKind(o.Kind) {
-			return true
-		}
-	}
-	return false
-}
-
 func relationObjectSlotOrdinal(objects []effects.ObjectRef, idx int) int {
 	ordinal := 0
 	for i := 0; i <= idx && i < len(objects); i++ {
 		if !isRelationObjectKind(objects[i].Kind) {
+			continue
+		}
+		if i == idx {
+			return ordinal
+		}
+		ordinal++
+	}
+	return -1
+}
+
+func functionObjectSlotOrdinal(objects []effects.ObjectRef, idx int) int {
+	ordinal := 0
+	for i := 0; i <= idx && i < len(objects); i++ {
+		if objects[i].Kind != effects.ObjectFunction {
 			continue
 		}
 		if i == idx {
@@ -189,6 +199,23 @@ func resolvedRelationObjectAtOrdinal(resolvedObjects []effects.ResolvedObjectRef
 	count := 0
 	for _, resolved := range resolvedObjects {
 		if resolved.Kind != effects.ResolvedObjectRelation {
+			continue
+		}
+		if count == ordinal {
+			return resolved, true
+		}
+		count++
+	}
+	return effects.ResolvedObjectRef{}, false
+}
+
+func resolvedFunctionObjectAtOrdinal(resolvedObjects []effects.ResolvedObjectRef, ordinal int) (effects.ResolvedObjectRef, bool) {
+	if ordinal < 0 {
+		return effects.ResolvedObjectRef{}, false
+	}
+	count := 0
+	for _, resolved := range resolvedObjects {
+		if resolved.Kind != effects.ResolvedObjectFunction {
 			continue
 		}
 		if count == ordinal {

--- a/internal/db/policy/evaluate.go
+++ b/internal/db/policy/evaluate.go
@@ -140,10 +140,61 @@ func resolvedObjectForSlot(e effects.Effect, idx int) (effects.ResolvedObjectRef
 		return effects.ResolvedObjectRef{}, false
 	}
 	o := e.Objects[idx]
+	if hasRelationObjectSlot(e.Objects) {
+		if !isRelationObjectKind(o.Kind) {
+			return effects.ResolvedObjectRef{}, false
+		}
+		ordinal := relationObjectSlotOrdinal(e.Objects, idx)
+		resolved, ok := resolvedRelationObjectAtOrdinal(e.ResolvedObjects, ordinal)
+		if !ok || !resolvedObjectCompatibleWithSlot(o, resolved) {
+			return effects.ResolvedObjectRef{}, false
+		}
+		return resolved, true
+	}
 	for _, resolved := range e.ResolvedObjects {
 		if resolvedObjectCompatibleWithSlot(o, resolved) {
 			return resolved, true
 		}
+	}
+	return effects.ResolvedObjectRef{}, false
+}
+
+func hasRelationObjectSlot(objects []effects.ObjectRef) bool {
+	for _, o := range objects {
+		if isRelationObjectKind(o.Kind) {
+			return true
+		}
+	}
+	return false
+}
+
+func relationObjectSlotOrdinal(objects []effects.ObjectRef, idx int) int {
+	ordinal := 0
+	for i := 0; i <= idx && i < len(objects); i++ {
+		if !isRelationObjectKind(objects[i].Kind) {
+			continue
+		}
+		if i == idx {
+			return ordinal
+		}
+		ordinal++
+	}
+	return -1
+}
+
+func resolvedRelationObjectAtOrdinal(resolvedObjects []effects.ResolvedObjectRef, ordinal int) (effects.ResolvedObjectRef, bool) {
+	if ordinal < 0 {
+		return effects.ResolvedObjectRef{}, false
+	}
+	count := 0
+	for _, resolved := range resolvedObjects {
+		if resolved.Kind != effects.ResolvedObjectRelation {
+			continue
+		}
+		if count == ordinal {
+			return resolved, true
+		}
+		count++
 	}
 	return effects.ResolvedObjectRef{}, false
 }

--- a/internal/db/policy/evaluate_canonical_test.go
+++ b/internal/db/policy/evaluate_canonical_test.go
@@ -33,6 +33,42 @@ database_rules:
 	}
 }
 
+func TestEvaluate_RelationSelectorUsesResolvedRelationSlotOrder(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: public-users, db_service: appdb, operations: [READ], relations: ["public.users"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogResolved,
+		Objects: []effects.ObjectRef{
+			{Kind: effects.ObjectTable, Schema: "public", Name: "users"},
+			{Kind: effects.ObjectTable, Name: "users"},
+		},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			OID:    16384,
+			Schema: "public",
+			Name:   "users",
+		}, {
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			OID:    16385,
+			Schema: "audit",
+			Name:   "users",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbDeny || d.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny because second users slot resolved to audit.users", d)
+	}
+}
+
 func TestEvaluate_RelationSelectorDoesNotCoverUnresolvedRelation(t *testing.T) {
 	rs := loadRules(t, `version: 1
 name: t

--- a/internal/db/policy/evaluate_canonical_test.go
+++ b/internal/db/policy/evaluate_canonical_test.go
@@ -1,0 +1,280 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
+
+func TestEvaluate_RelationSelectorCoversResolvedRelation(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: canonical-read, db_service: appdb, operations: [READ], relations: ["public.users"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogResolved,
+		Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "users"}},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			OID:    16384,
+			Schema: "public",
+			Name:   "users",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbAllow || d.RuleName != "canonical-read" {
+		t.Fatalf("decision = %+v, want allow by canonical-read", d)
+	}
+}
+
+func TestEvaluate_RelationSelectorDoesNotCoverUnresolvedRelation(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: canonical-read, db_service: appdb, operations: [READ], relations: ["public.users"], match_object_resolution: catalog_unresolved, decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogUnresolved,
+		Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "users"}},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source:           effects.ResolvedObjectSourceCatalog,
+			Kind:             effects.ResolvedObjectRelation,
+			Schema:           "public",
+			Name:             "users",
+			UnresolvedReason: "missing",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbDeny || d.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny", d)
+	}
+}
+
+func TestEvaluate_RelationSelectorDoesNotCoverCompressedNonRelationSlot(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: trigger-create, db_service: appdb, operations: [CREATE], objects: ["users"], relations: ["public.users"], decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupSchemaCreate,
+		Resolution: effects.ResolutionCatalogResolved,
+		Objects: []effects.ObjectRef{
+			{Kind: effects.ObjectFunction, Name: "trg"},
+			{Kind: effects.ObjectTable, Name: "users"},
+		},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			OID:    16384,
+			Schema: "public",
+			Name:   "users",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbDeny || d.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny", d)
+	}
+}
+
+func TestEvaluate_FunctionSelectorCoversResolvedFunction(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: safe-fn, db_service: appdb, operations: [procedural], functions: ["public.safe_fn(integer)"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	oid := int32(2200)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:       effects.GroupProcedural,
+		Resolution:  effects.ResolutionCatalogResolved,
+		FunctionOID: &oid,
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source:               effects.ResolvedObjectSourceCatalog,
+			Kind:                 effects.ResolvedObjectFunction,
+			OID:                  2200,
+			Schema:               "public",
+			Name:                 "safe_fn",
+			FunctionIdentityArgs: "integer",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbAllow || d.RuleName != "safe-fn" {
+		t.Fatalf("decision = %+v, want allow by safe-fn", d)
+	}
+}
+
+func TestEvaluate_ResolvedOnlyBroadDenyPrecedesFunctionAllow(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: deny-procedural, db_service: appdb, operations: [procedural], decision: deny}
+  - {name: safe-fn, db_service: appdb, operations: [procedural], functions: ["public.safe_fn(integer)"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	oid := int32(2200)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:       effects.GroupProcedural,
+		Resolution:  effects.ResolutionCatalogResolved,
+		FunctionOID: &oid,
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source:               effects.ResolvedObjectSourceCatalog,
+			Kind:                 effects.ResolvedObjectFunction,
+			OID:                  2200,
+			Schema:               "public",
+			Name:                 "safe_fn",
+			FunctionIdentityArgs: "integer",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbDeny || d.RuleName != "deny-procedural" {
+		t.Fatalf("decision = %+v, want deny by deny-procedural", d)
+	}
+}
+
+func TestEvaluate_ResolvedOnlyRelationDoesNotUseFunctionPath(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: read-all, db_service: appdb, operations: [READ], decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogResolved,
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			OID:    16384,
+			Schema: "public",
+			Name:   "users",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbDeny || d.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny", d)
+	}
+}
+
+func TestEvaluate_FunctionSelectorRequiresResolvedSchemaMatch(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: sales-fn, db_service: appdb, operations: [procedural], schemas: ["sales"], functions: ["*"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	oid := int32(2200)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:       effects.GroupProcedural,
+		Resolution:  effects.ResolutionCatalogResolved,
+		FunctionOID: &oid,
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source:               effects.ResolvedObjectSourceCatalog,
+			Kind:                 effects.ResolvedObjectFunction,
+			OID:                  2200,
+			Schema:               "public",
+			Name:                 "safe_fn",
+			FunctionIdentityArgs: "integer",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbDeny || d.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny", d)
+	}
+}
+
+func TestEvaluate_AuditTiePrimaryUsesPolicyOrderAcrossObjects(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: audit-orders, db_service: appdb, operations: [READ], objects: ["orders"], decision: audit}
+  - {name: audit-users, db_service: appdb, operations: [READ], objects: ["users"], decision: audit}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group: effects.GroupRead,
+		Objects: []effects.ObjectRef{
+			{Kind: effects.ObjectTable, Name: "users"},
+			{Kind: effects.ObjectTable, Name: "orders"},
+		},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbAudit || d.RuleName != "audit-orders" {
+		t.Fatalf("decision = %+v, want audit by audit-orders", d)
+	}
+}
+
+func TestEvaluate_SchemasMatchesResolvedSchema(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: sales-read, db_service: appdb, operations: [READ], schemas: ["sales"], relations: ["sales.orders"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogResolved,
+		Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "orders"}},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			Schema: "sales",
+			Name:   "orders",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbAllow || d.RuleName != "sales-read" {
+		t.Fatalf("decision = %+v, want allow by sales-read", d)
+	}
+}
+
+func TestEvaluate_MixedSelectorsCoverByEitherFamily(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: migration-read, db_service: appdb, operations: [READ], objects: ["legacy_users"], relations: ["public.users"], decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogResolved,
+		Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "users"}},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			Schema: "public",
+			Name:   "users",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbAllow || d.RuleName != "migration-read" {
+		t.Fatalf("decision = %+v, want allow by migration-read", d)
+	}
+}

--- a/internal/db/policy/evaluate_canonical_test.go
+++ b/internal/db/policy/evaluate_canonical_test.go
@@ -126,6 +126,43 @@ database_rules:
 	}
 }
 
+func TestEvaluate_FunctionSelectorCoversMixedResolvedFunctionSlot(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: mixed-canonical, db_service: appdb, operations: [CREATE], relations: ["public.users"], functions: ["public.safe_fn(integer)"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupSchemaCreate,
+		Resolution: effects.ResolutionCatalogResolved,
+		Objects: []effects.ObjectRef{
+			{Kind: effects.ObjectFunction, Name: "safe_fn"},
+			{Kind: effects.ObjectTable, Name: "users"},
+		},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			OID:    16384,
+			Schema: "public",
+			Name:   "users",
+		}, {
+			Source:               effects.ResolvedObjectSourceCatalog,
+			Kind:                 effects.ResolvedObjectFunction,
+			OID:                  2200,
+			Schema:               "public",
+			Name:                 "safe_fn",
+			FunctionIdentityArgs: "integer",
+		}},
+	}}}
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbAllow || d.RuleName != "mixed-canonical" {
+		t.Fatalf("decision = %+v, want allow by mixed-canonical", d)
+	}
+}
+
 func TestEvaluate_FunctionSelectorCoversResolvedFunction(t *testing.T) {
 	rs := loadRules(t, `version: 1
 name: t

--- a/internal/db/policy/explain.go
+++ b/internal/db/policy/explain.go
@@ -1,0 +1,172 @@
+package policy
+
+import "github.com/agentsh/agentsh/internal/db/effects"
+
+type StatementExplanation struct {
+	Decision        Decision
+	ApplicableRules []string
+	Effects         []EffectExplanation
+}
+
+type EffectExplanation struct {
+	Index         int
+	Group         effects.Group
+	Subtype       effects.Subtype
+	Resolution    effects.Resolution
+	Coverage      []ObjectCoverage
+	CoveringRules []RuleMatch
+	DenyRules     []RuleMatch
+}
+
+type ObjectCoverage struct {
+	Index           int
+	Object          effects.ObjectRef
+	ResolvedObject  *effects.ResolvedObjectRef
+	Covered         bool
+	CoveringRules   []RuleMatch
+	UncoveredReason string
+}
+
+type RuleMatch struct {
+	RuleName string
+	Verb     DecisionVerb
+	Selector string
+}
+
+func ExplainStatement(stmt effects.ClassifiedStatement, rs *RuleSet, svc ServiceID) StatementExplanation {
+	if rs == nil {
+		return StatementExplanation{Decision: implicitDeny(stmt, 0, "policy not loaded")}
+	}
+	applicable := rs.statementRulesFor(svc)
+	perEffect := make([]effectDecision, len(stmt.Effects))
+	effectsOut := make([]EffectExplanation, len(stmt.Effects))
+	for i, e := range stmt.Effects {
+		perEffect[i], effectsOut[i] = explainEffect(i, e, applicable)
+	}
+	applicableNames := make([]string, 0, len(applicable))
+	for _, r := range applicable {
+		applicableNames = append(applicableNames, r.src.Name)
+	}
+	if len(stmt.Effects) == 0 {
+		return StatementExplanation{Decision: implicitDeny(stmt, 0, "no effects on statement"), ApplicableRules: applicableNames}
+	}
+	return StatementExplanation{
+		Decision:        foldEffects(stmt, perEffect),
+		ApplicableRules: applicableNames,
+		Effects:         effectsOut,
+	}
+}
+
+func explainEffect(index int, e effects.Effect, applicable []*compiledStatementRule) (effectDecision, EffectExplanation) {
+	d := evaluateEffect(e, applicable)
+	ex := EffectExplanation{
+		Index:      index,
+		Group:      e.Group,
+		Subtype:    e.Subtype,
+		Resolution: e.Resolution,
+	}
+	if len(e.Objects) == 0 {
+		explainNoObjectEffect(e, applicable, &ex)
+		return d, ex
+	}
+	denySeen := map[string]struct{}{}
+	for i, obj := range e.Objects {
+		cov := ObjectCoverage{Index: i, Object: obj}
+		if resolved, ok := resolvedObjectForSlot(e, i); ok {
+			r := resolved
+			cov.ResolvedObject = &r
+		}
+		for _, r := range applicable {
+			if !ruleMatchesEffectMeta(r, e) {
+				continue
+			}
+			ok, selector := ruleMatchesObjectSlot(r, e, i)
+			if !ok {
+				continue
+			}
+			if r.verb == VerbDeny {
+				ex.DenyRules = appendRuleMatchUnique(ex.DenyRules, denySeen, RuleMatch{RuleName: r.src.Name, Verb: r.verb, Selector: selector})
+				continue
+			}
+			cov.Covered = true
+			cov.CoveringRules = append(cov.CoveringRules, RuleMatch{RuleName: r.src.Name, Verb: r.verb, Selector: selector})
+		}
+		if !cov.Covered {
+			cov.UncoveredReason = "no matching non-deny rule covers object"
+		}
+		ex.Coverage = append(ex.Coverage, cov)
+	}
+	return d, ex
+}
+
+func explainNoObjectEffect(e effects.Effect, applicable []*compiledStatementRule, ex *EffectExplanation) {
+	switch {
+	case isResolvedOnlyFunctionEffect(e):
+		explainResolvedOnlyFunctionEffect(e, applicable, ex)
+	case isObjectlessEffect(e):
+		explainObjectlessEffect(e, applicable, ex)
+	}
+}
+
+func explainResolvedOnlyFunctionEffect(e effects.Effect, applicable []*compiledStatementRule, ex *EffectExplanation) {
+	coverSeen := map[string]struct{}{}
+	denySeen := map[string]struct{}{}
+	for _, r := range applicable {
+		if !ruleMatchesEffectMeta(r, e) {
+			continue
+		}
+		selector, ok := resolvedOnlyFunctionRuleSelector(r, e)
+		if !ok {
+			continue
+		}
+		match := RuleMatch{RuleName: r.src.Name, Verb: r.verb, Selector: selector}
+		if r.verb == VerbDeny {
+			ex.DenyRules = appendRuleMatchUnique(ex.DenyRules, denySeen, match)
+			continue
+		}
+		ex.CoveringRules = appendRuleMatchUnique(ex.CoveringRules, coverSeen, match)
+	}
+}
+
+func resolvedOnlyFunctionRuleSelector(r *compiledStatementRule, e effects.Effect) (string, bool) {
+	for _, resolved := range e.ResolvedObjects {
+		if !resolvedOnlyFunctionRuleMatches(r, resolved) {
+			continue
+		}
+		if !r.hasObjectSelectors() {
+			return "all", true
+		}
+		if r.functionMatches(resolved) {
+			return "functions", true
+		}
+	}
+	return "", false
+}
+
+func explainObjectlessEffect(e effects.Effect, applicable []*compiledStatementRule, ex *EffectExplanation) {
+	coverSeen := map[string]struct{}{}
+	denySeen := map[string]struct{}{}
+	for _, r := range applicable {
+		if !ruleMatchesEffectMeta(r, e) {
+			continue
+		}
+		if !r.coversAllObjects() {
+			continue
+		}
+		match := RuleMatch{RuleName: r.src.Name, Verb: r.verb, Selector: "all"}
+		if r.verb == VerbDeny {
+			ex.DenyRules = appendRuleMatchUnique(ex.DenyRules, denySeen, match)
+			continue
+		}
+		ex.CoveringRules = appendRuleMatchUnique(ex.CoveringRules, coverSeen, match)
+	}
+}
+
+func appendRuleMatchUnique(matches []RuleMatch, seen map[string]struct{}, match RuleMatch) []RuleMatch {
+	key := match.RuleName + "\x00" + match.Selector
+	if _, ok := seen[key]; ok {
+		return matches
+	}
+	seen[key] = struct{}{}
+	return append(matches, match)
+}

--- a/internal/db/policy/explain_test.go
+++ b/internal/db/policy/explain_test.go
@@ -1,0 +1,207 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
+
+func TestExplainStatement_ReturnsCoverageAndDecision(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: canonical-read, db_service: appdb, operations: [READ], relations: ["public.users"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{RawVerb: "SELECT", Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogResolved,
+		Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "users"}},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			Schema: "public",
+			Name:   "users",
+		}},
+	}}}
+
+	ex := ExplainStatement(stmt, rs, "appdb")
+	if ex.Decision.Verb != VerbAllow || ex.Decision.RuleName != "canonical-read" {
+		t.Fatalf("decision = %+v", ex.Decision)
+	}
+	if len(ex.Effects) != 1 || len(ex.Effects[0].Coverage) != 1 {
+		t.Fatalf("coverage = %+v", ex.Effects)
+	}
+	cov := ex.Effects[0].Coverage[0]
+	if !cov.Covered {
+		t.Fatalf("coverage = %+v, want covered", cov)
+	}
+	if len(cov.CoveringRules) != 1 || cov.CoveringRules[0].RuleName != "canonical-read" {
+		t.Fatalf("covering rules = %+v", cov.CoveringRules)
+	}
+	if cov.CoveringRules[0].Selector != "relations" {
+		t.Fatalf("selector = %q, want relations", cov.CoveringRules[0].Selector)
+	}
+}
+
+func TestExplainStatement_ReportsUncoveredObject(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: read-users, db_service: appdb, operations: [READ], objects: ["users"], decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionQualified,
+		Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "payments"}},
+	}}}
+
+	ex := ExplainStatement(stmt, rs, "appdb")
+	if ex.Decision.Verb != VerbDeny || ex.Decision.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny", ex.Decision)
+	}
+	if len(ex.Effects) != 1 || len(ex.Effects[0].Coverage) != 1 {
+		t.Fatalf("coverage = %+v", ex.Effects)
+	}
+	cov := ex.Effects[0].Coverage[0]
+	if cov.Covered || cov.UncoveredReason == "" {
+		t.Fatalf("coverage = %+v, want uncovered reason", cov)
+	}
+}
+
+func TestExplainStatement_ResolvedOnlyFunctionReportsFunctionCoverage(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: safe-fn, db_service: appdb, operations: [procedural], functions: ["public.safe_fn(integer)"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	oid := int32(2200)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:       effects.GroupProcedural,
+		Resolution:  effects.ResolutionCatalogResolved,
+		FunctionOID: &oid,
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source:               effects.ResolvedObjectSourceCatalog,
+			Kind:                 effects.ResolvedObjectFunction,
+			OID:                  2200,
+			Schema:               "public",
+			Name:                 "safe_fn",
+			FunctionIdentityArgs: "integer",
+		}},
+	}}}
+
+	ex := ExplainStatement(stmt, rs, "appdb")
+	if ex.Decision.Verb != VerbAllow || ex.Decision.RuleName != "safe-fn" {
+		t.Fatalf("decision = %+v, want allow by safe-fn", ex.Decision)
+	}
+	if len(ex.Effects) != 1 || len(ex.Effects[0].CoveringRules) != 1 {
+		t.Fatalf("effect explanation = %+v, want one covering rule", ex.Effects)
+	}
+	match := ex.Effects[0].CoveringRules[0]
+	if match.RuleName != "safe-fn" || match.Selector != "functions" {
+		t.Fatalf("covering rule = %+v, want safe-fn functions", match)
+	}
+	if len(ex.Effects[0].Coverage) != 0 {
+		t.Fatalf("coverage = %+v, want no object coverage", ex.Effects[0].Coverage)
+	}
+}
+
+func TestExplainStatement_ResolvedOnlyFunctionReportsBroadDeny(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: deny-procedural, db_service: appdb, operations: [procedural], decision: deny}
+  - {name: safe-fn, db_service: appdb, operations: [procedural], functions: ["public.safe_fn(integer)"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	oid := int32(2200)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:       effects.GroupProcedural,
+		Resolution:  effects.ResolutionCatalogResolved,
+		FunctionOID: &oid,
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source:               effects.ResolvedObjectSourceCatalog,
+			Kind:                 effects.ResolvedObjectFunction,
+			OID:                  2200,
+			Schema:               "public",
+			Name:                 "safe_fn",
+			FunctionIdentityArgs: "integer",
+		}},
+	}}}
+
+	ex := ExplainStatement(stmt, rs, "appdb")
+	if ex.Decision.Verb != VerbDeny || ex.Decision.RuleName != "deny-procedural" {
+		t.Fatalf("decision = %+v, want deny by deny-procedural", ex.Decision)
+	}
+	if len(ex.Effects) != 1 || len(ex.Effects[0].DenyRules) != 1 {
+		t.Fatalf("effect explanation = %+v, want one deny rule", ex.Effects)
+	}
+	match := ex.Effects[0].DenyRules[0]
+	if match.RuleName != "deny-procedural" || match.Selector != "all" {
+		t.Fatalf("deny rule = %+v, want deny-procedural all", match)
+	}
+}
+
+func TestExplainStatement_ObjectlessEffectReportsBroadCoverage(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: tx-allow, db_service: appdb, operations: [transaction], decision: allow}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group: effects.GroupTransaction,
+	}}}
+
+	ex := ExplainStatement(stmt, rs, "appdb")
+	if ex.Decision.Verb != VerbAllow || ex.Decision.RuleName != "tx-allow" {
+		t.Fatalf("decision = %+v, want allow by tx-allow", ex.Decision)
+	}
+	if len(ex.Effects) != 1 || len(ex.Effects[0].CoveringRules) != 1 {
+		t.Fatalf("effect explanation = %+v, want one covering rule", ex.Effects)
+	}
+	match := ex.Effects[0].CoveringRules[0]
+	if match.RuleName != "tx-allow" || match.Selector != "all" {
+		t.Fatalf("covering rule = %+v, want tx-allow all", match)
+	}
+	if len(ex.Effects[0].Coverage) != 0 {
+		t.Fatalf("coverage = %+v, want no object coverage", ex.Effects[0].Coverage)
+	}
+}
+
+func TestExplainStatement_DeDuplicatesDenyRules(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: deny-read, db_service: appdb, operations: [READ], decision: deny}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionQualified,
+		Objects: []effects.ObjectRef{
+			{Kind: effects.ObjectTable, Name: "users"},
+			{Kind: effects.ObjectTable, Name: "payments"},
+		},
+	}}}
+
+	ex := ExplainStatement(stmt, rs, "appdb")
+	if ex.Decision.Verb != VerbDeny || ex.Decision.RuleName != "deny-read" {
+		t.Fatalf("decision = %+v, want deny by deny-read", ex.Decision)
+	}
+	if len(ex.Effects) != 1 || len(ex.Effects[0].DenyRules) != 1 {
+		t.Fatalf("deny rules = %+v, want one de-duplicated deny rule", ex.Effects)
+	}
+	match := ex.Effects[0].DenyRules[0]
+	if match.RuleName != "deny-read" || match.Selector != "all" {
+		t.Fatalf("deny rule = %+v, want deny-read all", match)
+	}
+}

--- a/internal/db/policy/testdata/sample-policy.yaml
+++ b/internal/db/policy/testdata/sample-policy.yaml
@@ -24,6 +24,20 @@ database_rules:
     operations: [READ, UPDATE]
     decision: allow
 
+  - name: app-read-users-canonical
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: allow
+
+  - name: app-safe-functions-canonical
+    db_service: appdb
+    operations: [procedural]
+    functions: ["public.safe_fn(*)"]
+    match_object_resolution: catalog_resolved
+    decision: approve
+
   - name: app-allow-tx-control
     db_service: appdb
     operations: [transaction]

--- a/internal/db/policy/types.go
+++ b/internal/db/policy/types.go
@@ -98,6 +98,8 @@ type StatementRule struct {
 	DBDialect                   string        `yaml:"db_dialect,omitempty"`
 	Schemas                     []string      `yaml:"schemas,omitempty"`
 	Objects                     []string      `yaml:"objects,omitempty"`
+	Relations                   []string      `yaml:"relations,omitempty"`
+	Functions                   []string      `yaml:"functions,omitempty"`
 	Operations                  []string      `yaml:"operations"`
 	Subtypes                    []string      `yaml:"subtypes,omitempty"`
 	MatchObjectResolution       string        `yaml:"match_object_resolution,omitempty"`

--- a/internal/db/policy/types.go
+++ b/internal/db/policy/types.go
@@ -233,6 +233,20 @@ func (rs *RuleSet) AllStatementRules() []StatementRule {
 	return out
 }
 
+// UsesCanonicalSelectors reports whether any statement rule applicable to svc
+// constrains catalog-backed relation or function selectors.
+func (rs *RuleSet) UsesCanonicalSelectors(svc ServiceID) bool {
+	if rs == nil {
+		return false
+	}
+	for _, r := range rs.statementRulesFor(svc) {
+		if len(r.relations) > 0 || len(r.functions) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // Unavoidability returns the policies.db.unavoidability mode. Returns
 // UnavoidabilityOff when rs is nil so startup code holding a not-yet-loaded
 // *RuleSet does not panic.

--- a/internal/db/policy/validate.go
+++ b/internal/db/policy/validate.go
@@ -78,7 +78,7 @@ func validateStatementRule(r *StatementRule, svcs map[ServiceID]*DBService) ([]e
 	case "allow", "deny", "approve", "audit":
 		// ok
 	case "redirect":
-		errs = append(errs, fmt.Errorf("rule_decision_redirect: database_rules[%q]: redirect is Phase 2", r.Name))
+		errs = append(errs, fmt.Errorf("redirect_not_supported_until_plan_11: database_rules[%q]: decision redirect is supported starting in DB Plan 11", r.Name))
 	default:
 		errs = append(errs, fmt.Errorf("rule_unknown_decision: database_rules[%q]: unknown decision %q", r.Name, r.Decision))
 	}
@@ -87,15 +87,10 @@ func validateStatementRule(r *StatementRule, svcs map[ServiceID]*DBService) ([]e
 	if len(r.Operations) == 0 {
 		errs = append(errs, fmt.Errorf("rule_operations_required: database_rules[%q]: operations is required", r.Name))
 	}
-	groups := map[effects.Group]struct{}{}
+	groups := expandedGroups(r)
 	for _, op := range r.Operations {
-		gs, ok := effects.ExpandAlias(op)
-		if !ok {
+		if _, ok := effects.ExpandAlias(op); !ok {
 			errs = append(errs, fmt.Errorf("rule_unknown_operation: database_rules[%q]: unknown operations token %q", r.Name, op))
-			continue
-		}
-		for _, g := range gs {
-			groups[g] = struct{}{}
 		}
 	}
 	for _, st := range r.Subtypes {
@@ -138,6 +133,33 @@ func validateStatementRule(r *StatementRule, svcs map[ServiceID]*DBService) ([]e
 				Message: fmt.Sprintf("rule %q audits operations of risk tier >= high; set acknowledge_audit_on_dangerous: true to silence", r.Name),
 			})
 		}
+	}
+
+	if ruleHasCanonicalSelectors(r) {
+		if r.MatchObjectResolution != "catalog_resolved" {
+			warns = append(warns, Warning{
+				Rule:    r.Name,
+				Field:   "match_object_resolution",
+				Code:    "canonical_selector_without_resolution_guard",
+				Message: fmt.Sprintf("rule %q uses catalog selectors without match_object_resolution: catalog_resolved", r.Name),
+			})
+		}
+		if !ruleMatchesTerminatePostgresService(r, svcs) {
+			warns = append(warns, Warning{
+				Rule:    r.Name,
+				Field:   canonicalSelectorWarningField(r),
+				Code:    "canonical_selector_without_catalog_service",
+				Message: fmt.Sprintf("rule %q uses catalog selectors but matches no terminate-mode Postgres service", r.Name),
+			})
+		}
+	}
+	if ruleHasAnyObjectSelector(r) && allGroupsObjectless(groups) {
+		warns = append(warns, Warning{
+			Rule:    r.Name,
+			Field:   "objects",
+			Code:    "selector_on_objectless_operation",
+			Message: fmt.Sprintf("rule %q constrains object selectors on objectless operations", r.Name),
+		})
 	}
 
 	// deny_mode_in_tx is only valid on deny rules. §14.3/§14.4.
@@ -205,7 +227,7 @@ func validateConnectionRule(r *ConnectionRule, svcs map[ServiceID]*DBService) ([
 	case "allow", "deny", "approve", "audit":
 		// ok
 	case "redirect":
-		errs = append(errs, fmt.Errorf("rule_decision_redirect: database_connection_rules[%q]: redirect is Phase 2", r.Name))
+		errs = append(errs, fmt.Errorf("redirect_not_supported_until_plan_11: database_connection_rules[%q]: decision redirect is not valid for DB connection rules", r.Name))
 	default:
 		errs = append(errs, fmt.Errorf("rule_unknown_decision: database_connection_rules[%q]: unknown decision %q", r.Name, r.Decision))
 	}
@@ -231,6 +253,66 @@ func validateConnectionRule(r *ConnectionRule, svcs map[ServiceID]*DBService) ([
 	}
 
 	return errs, warns
+}
+
+func ruleHasCanonicalSelectors(r *StatementRule) bool {
+	return len(r.Relations) > 0 || len(r.Functions) > 0
+}
+
+func ruleHasAnyObjectSelector(r *StatementRule) bool {
+	return len(r.Objects) > 0 || len(r.Relations) > 0 || len(r.Functions) > 0
+}
+
+func canonicalSelectorWarningField(r *StatementRule) string {
+	if len(r.Relations) > 0 {
+		return "relations"
+	}
+	return "functions"
+}
+
+func expandedGroups(r *StatementRule) map[effects.Group]struct{} {
+	groups := map[effects.Group]struct{}{}
+	for _, op := range r.Operations {
+		gs, ok := effects.ExpandAlias(op)
+		if !ok {
+			continue
+		}
+		for _, g := range gs {
+			groups[g] = struct{}{}
+		}
+	}
+	return groups
+}
+
+func allGroupsObjectless(groups map[effects.Group]struct{}) bool {
+	if len(groups) == 0 {
+		return false
+	}
+	for g := range groups {
+		if !isObjectlessGroup(g) {
+			return false
+		}
+	}
+	return true
+}
+
+func ruleMatchesTerminatePostgresService(r *StatementRule, svcs map[ServiceID]*DBService) bool {
+	for id, svc := range svcs {
+		if svc == nil {
+			continue
+		}
+		if svc.Family != "postgres" {
+			continue
+		}
+		if svc.TLSMode == "passthrough" {
+			continue
+		}
+		filter := serviceFilter{service: ServiceID(r.DBService), family: r.DBFamily, dialect: r.DBDialect}
+		if filter.matches(id, svc) {
+			return true
+		}
+	}
+	return false
 }
 
 // validateConnectionRuleVsService returns a non-nil error if the rule matches

--- a/internal/db/policy/validate_test.go
+++ b/internal/db/policy/validate_test.go
@@ -100,8 +100,8 @@ func TestValidate_ConnPassthroughFieldUnavailable(t *testing.T) {
 func TestValidate_RuleDecisionRedirect(t *testing.T) {
 	stmt := []*StatementRule{{Name: "r", Operations: []string{"READ"}, Decision: "redirect"}}
 	_, err := helperValidate(t, nil, stmt, nil)
-	if err == nil || !strings.Contains(err.Error(), "rule_decision_redirect") {
-		t.Fatalf("want rule_decision_redirect, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "redirect_not_supported_until_plan_11") {
+		t.Fatalf("want redirect_not_supported_until_plan_11, got %v", err)
 	}
 }
 
@@ -191,6 +191,84 @@ func TestValidate_WarnAuditOnDangerous_SilencedByAcknowledgement(t *testing.T) {
 			t.Errorf("acknowledge_audit_on_dangerous: true should silence the warning, got %+v", w)
 		}
 	}
+}
+
+func TestValidate_CanonicalSelectorWarnings(t *testing.T) {
+	src := `version: 1
+name: t
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: terminate_reissue
+database_rules:
+  - name: canonical-without-resolution
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    decision: allow
+  - name: selector-on-transaction
+    db_service: appdb
+    operations: [transaction]
+    relations: ["public.users"]
+    decision: allow
+`
+	_, warns, err := loadDB(t, src)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	assertWarningCode(t, warns, "canonical_selector_without_resolution_guard")
+	assertWarningCode(t, warns, "selector_on_objectless_operation")
+}
+
+func TestValidate_CanonicalSelectorWithoutCatalogServiceWarning(t *testing.T) {
+	src := `version: 1
+name: t
+db_services:
+  legacy:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: passthrough
+database_rules:
+  - name: canonical-relation-wide
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: allow
+  - name: canonical-function-wide
+    operations: [READ]
+    functions: ["public.safe_fn(integer)"]
+    match_object_resolution: catalog_resolved
+    decision: allow
+`
+	_, warns, err := loadDB(t, src)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	assertWarning(t, warns, "canonical_selector_without_catalog_service", "canonical-relation-wide", "relations")
+	assertWarning(t, warns, "canonical_selector_without_catalog_service", "canonical-function-wide", "functions")
+}
+
+func assertWarningCode(t *testing.T, warns []Warning, code string) {
+	t.Helper()
+	for _, w := range warns {
+		if w.Code == code {
+			return
+		}
+	}
+	t.Fatalf("warning %q not found in %+v", code, warns)
+}
+
+func assertWarning(t *testing.T, warns []Warning, code, rule, field string) {
+	t.Helper()
+	for _, w := range warns {
+		if w.Code == code && w.Rule == rule && w.Field == field {
+			return
+		}
+	}
+	t.Fatalf("warning code=%q rule=%q field=%q not found in %+v", code, rule, field, warns)
 }
 
 func TestValidate_WarnApproveOnReplication(t *testing.T) {

--- a/internal/db/policyexplain/fixture.go
+++ b/internal/db/policyexplain/fixture.go
@@ -1,0 +1,113 @@
+package policyexplain
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/agentsh/agentsh/internal/db/catalog"
+	"gopkg.in/yaml.v3"
+)
+
+type CatalogFixture struct {
+	SearchPath []string
+	Snapshot   catalog.Snapshot
+}
+
+type fixtureYAML struct {
+	SearchPath []string          `yaml:"search_path"`
+	Relations  []fixtureRelation `yaml:"relations"`
+	Functions  []fixtureFunction `yaml:"functions"`
+}
+
+type fixtureRelation struct {
+	OID    uint32 `yaml:"oid"`
+	Schema string `yaml:"schema"`
+	Name   string `yaml:"name"`
+	Kind   string `yaml:"kind"`
+	Owner  string `yaml:"owner"`
+}
+
+type fixtureFunction struct {
+	OID           uint32 `yaml:"oid"`
+	Schema        string `yaml:"schema"`
+	Name          string `yaml:"name"`
+	IdentityArgs  string `yaml:"identity_args"`
+	Volatility    string `yaml:"volatility"`
+	Strict        bool   `yaml:"strict"`
+	ReturnTypeOID uint32 `yaml:"return_type_oid"`
+}
+
+func LoadCatalogFixture(path string) (CatalogFixture, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return CatalogFixture{}, fmt.Errorf("read catalog fixture: %w", err)
+	}
+	var in fixtureYAML
+	if err := yaml.Unmarshal(raw, &in); err != nil {
+		return CatalogFixture{}, fmt.Errorf("parse catalog fixture: %w", err)
+	}
+	relations := make([]catalog.Relation, 0, len(in.Relations))
+	for i, rel := range in.Relations {
+		kind, ok := parseRelationKind(rel.Kind)
+		if !ok {
+			return CatalogFixture{}, fmt.Errorf("relations[%d].kind: unknown relation kind %q", i, rel.Kind)
+		}
+		relations = append(relations, catalog.Relation{
+			OID:   catalog.OID(rel.OID),
+			Name:  catalog.Name{Schema: rel.Schema, Name: rel.Name},
+			Kind:  kind,
+			Owner: rel.Owner,
+		})
+	}
+	functions := make([]catalog.Function, 0, len(in.Functions))
+	for i, fn := range in.Functions {
+		vol, ok := parseVolatility(fn.Volatility)
+		if !ok {
+			return CatalogFixture{}, fmt.Errorf("functions[%d].volatility: unknown volatility %q", i, fn.Volatility)
+		}
+		functions = append(functions, catalog.Function{
+			OID:           catalog.OID(fn.OID),
+			Name:          catalog.Name{Schema: fn.Schema, Name: fn.Name},
+			IdentityArgs:  fn.IdentityArgs,
+			Volatility:    vol,
+			Strict:        fn.Strict,
+			ReturnTypeOID: catalog.OID(fn.ReturnTypeOID),
+		})
+	}
+	return CatalogFixture{
+		SearchPath: append([]string(nil), in.SearchPath...),
+		Snapshot:   catalog.NewSnapshot(relations, functions),
+	}, nil
+}
+
+func parseRelationKind(s string) (catalog.RelationKind, bool) {
+	switch s {
+	case "table":
+		return catalog.RelationTable, true
+	case "partitioned_table":
+		return catalog.RelationPartitionedTable, true
+	case "view":
+		return catalog.RelationView, true
+	case "materialized_view":
+		return catalog.RelationMaterializedView, true
+	case "foreign_table":
+		return catalog.RelationForeignTable, true
+	case "sequence":
+		return catalog.RelationSequence, true
+	default:
+		return 0, false
+	}
+}
+
+func parseVolatility(s string) (catalog.FunctionVolatility, bool) {
+	switch s {
+	case "", "volatile":
+		return catalog.VolatilityVolatile, true
+	case "stable":
+		return catalog.VolatilityStable, true
+	case "immutable":
+		return catalog.VolatilityImmutable, true
+	default:
+		return 0, false
+	}
+}

--- a/internal/db/policyexplain/fixture_test.go
+++ b/internal/db/policyexplain/fixture_test.go
@@ -1,0 +1,43 @@
+package policyexplain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadCatalogFixture(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "catalog.yaml")
+	err := os.WriteFile(path, []byte(`search_path: [public, pg_catalog]
+relations:
+  - oid: 16384
+    schema: public
+    name: users
+    kind: table
+functions:
+  - oid: 2200
+    schema: public
+    name: safe_fn
+    identity_args: integer
+    volatility: stable
+    strict: true
+    return_type_oid: 23
+`), 0644)
+	if err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	fixture, err := LoadCatalogFixture(path)
+	if err != nil {
+		t.Fatalf("LoadCatalogFixture: %v", err)
+	}
+	if got := fixture.SearchPath; len(got) != 2 || got[0] != "public" || got[1] != "pg_catalog" {
+		t.Fatalf("SearchPath = %#v", got)
+	}
+	if rel, ok := fixture.Snapshot.RelationByOID(16384); !ok || rel.Name.String() != "public.users" {
+		t.Fatalf("relation lookup = %+v, %v", rel, ok)
+	}
+	if fn, ok := fixture.Snapshot.FunctionByOID(2200); !ok || fn.IdentityArgs != "integer" {
+		t.Fatalf("function lookup = %+v, %v", fn, ok)
+	}
+}

--- a/internal/db/policyexplain/resolve.go
+++ b/internal/db/policyexplain/resolve.go
@@ -10,25 +10,34 @@ import (
 const catalogSessionStateChangedReason = "session_state_changed"
 
 type resolveContext struct {
-	fixture           CatalogFixture
-	unavailableReason string
+	fixture                     CatalogFixture
+	defaultSearchPath           []string
+	snapshotUnavailableReason   string
+	searchPathUnavailableReason string
+	localSearchPathActive       bool
+	localSearchPathBase         []string
+}
+
+func newResolveContext(fixture CatalogFixture) resolveContext {
+	fixture.SearchPath = append([]string(nil), fixture.SearchPath...)
+	return resolveContext{
+		fixture:           fixture,
+		defaultSearchPath: append([]string(nil), fixture.SearchPath...),
+	}
 }
 
 func resolveStatements(stmts []effects.ClassifiedStatement, fixture CatalogFixture) []effects.ClassifiedStatement {
 	out := make([]effects.ClassifiedStatement, len(stmts))
-	current := resolveContext{fixture: fixture}
+	current := newResolveContext(fixture)
 	for i := range stmts {
 		out[i] = resolveStatementWithContext(stmts[i], current)
-		if statementInvalidatesCatalogContext(stmts[i]) {
-			current.unavailableReason = catalogSessionStateChangedReason
-			current.fixture.SearchPath = nil
-		}
+		current = applyStatementCatalogContext(current, stmts[i])
 	}
 	return out
 }
 
 func resolveStatement(stmt effects.ClassifiedStatement, fixture CatalogFixture) effects.ClassifiedStatement {
-	return resolveStatementWithContext(stmt, resolveContext{fixture: fixture})
+	return resolveStatementWithContext(stmt, newResolveContext(fixture))
 }
 
 func resolveStatementWithContext(stmt effects.ClassifiedStatement, ctx resolveContext) effects.ClassifiedStatement {
@@ -41,7 +50,7 @@ func resolveStatementWithContext(stmt effects.ClassifiedStatement, ctx resolveCo
 }
 
 func resolveEffect(eff effects.Effect, fixture CatalogFixture) effects.Effect {
-	return resolveEffectWithContext(eff, resolveContext{fixture: fixture})
+	return resolveEffectWithContext(eff, newResolveContext(fixture))
 }
 
 func resolveEffectWithContext(eff effects.Effect, ctx resolveContext) effects.Effect {
@@ -49,6 +58,7 @@ func resolveEffectWithContext(eff effects.Effect, ctx resolveContext) effects.Ef
 	out.ResolvedObjects = nil
 	resolved := make([]effects.ResolvedObjectRef, 0, len(eff.Objects)+1)
 	allResolved := true
+	hasUnavailable := false
 	hasRelationObject := hasCatalogRelationObject(eff.Objects)
 	for _, obj := range eff.Objects {
 		if hasRelationObject && !isCatalogRelationObject(obj.Kind) {
@@ -57,6 +67,7 @@ func resolveEffectWithContext(eff effects.Effect, ctx resolveContext) effects.Ef
 		ref := resolveObjectWithContext(obj, ctx)
 		if ref.UnresolvedReason != "" {
 			allResolved = false
+			hasUnavailable = hasUnavailable || isCatalogUnavailableReason(ref.UnresolvedReason)
 		}
 		resolved = append(resolved, ref)
 	}
@@ -64,6 +75,7 @@ func resolveEffectWithContext(eff effects.Effect, ctx resolveContext) effects.Ef
 		ref := resolveFunctionOIDWithContext(*eff.FunctionOID, ctx)
 		if ref.UnresolvedReason != "" {
 			allResolved = false
+			hasUnavailable = hasUnavailable || isCatalogUnavailableReason(ref.UnresolvedReason)
 		}
 		resolved = append(resolved, ref)
 	}
@@ -71,7 +83,7 @@ func resolveEffectWithContext(eff effects.Effect, ctx resolveContext) effects.Ef
 		return out
 	}
 	out.ResolvedObjects = resolved
-	if ctx.unavailableReason != "" {
+	if hasUnavailable {
 		out.Resolution = effects.ResolutionCatalogUnavailable
 	} else if allResolved {
 		out.Resolution = effects.ResolutionCatalogResolved
@@ -95,13 +107,22 @@ func resolveObjectWithContext(obj effects.ObjectRef, ctx resolveContext) effects
 			UnresolvedReason: "unsupported",
 		}
 	}
-	if ctx.unavailableReason != "" {
+	if ctx.snapshotUnavailableReason != "" {
 		return effects.ResolvedObjectRef{
 			Source:           effects.ResolvedObjectSourceCatalog,
 			Kind:             effects.ResolvedObjectRelation,
 			Schema:           obj.Schema,
 			Name:             obj.Name,
-			UnresolvedReason: ctx.unavailableReason,
+			UnresolvedReason: ctx.snapshotUnavailableReason,
+		}
+	}
+	if obj.Schema == "" && ctx.searchPathUnavailableReason != "" {
+		return effects.ResolvedObjectRef{
+			Source:           effects.ResolvedObjectSourceCatalog,
+			Kind:             effects.ResolvedObjectRelation,
+			Schema:           obj.Schema,
+			Name:             obj.Name,
+			UnresolvedReason: ctx.searchPathUnavailableReason,
 		}
 	}
 	res := catalog.ResolveRelation(ctx.fixture.Snapshot, catalog.Name{Schema: obj.Schema, Name: obj.Name}, ctx.fixture.SearchPath)
@@ -144,16 +165,16 @@ func isCatalogRelationObject(kind effects.ObjectKind) bool {
 }
 
 func resolveFunctionOID(oid int32, fixture CatalogFixture) effects.ResolvedObjectRef {
-	return resolveFunctionOIDWithContext(oid, resolveContext{fixture: fixture})
+	return resolveFunctionOIDWithContext(oid, newResolveContext(fixture))
 }
 
 func resolveFunctionOIDWithContext(oid int32, ctx resolveContext) effects.ResolvedObjectRef {
-	if ctx.unavailableReason != "" {
+	if ctx.snapshotUnavailableReason != "" {
 		return effects.ResolvedObjectRef{
 			Source:           effects.ResolvedObjectSourceCatalog,
 			Kind:             effects.ResolvedObjectFunction,
 			OID:              uint32(oid),
-			UnresolvedReason: ctx.unavailableReason,
+			UnresolvedReason: ctx.snapshotUnavailableReason,
 		}
 	}
 	res := catalog.ResolveFunctionByOID(ctx.fixture.Snapshot, catalog.OID(uint32(oid)))
@@ -188,20 +209,6 @@ func functionVolatility(v catalog.FunctionVolatility) string {
 	default:
 		return ""
 	}
-}
-
-func statementInvalidatesCatalogContext(stmt effects.ClassifiedStatement) bool {
-	for _, eff := range stmt.Effects {
-		if effectInvalidatesCatalogContext(eff, stmt.RawVerb) {
-			return true
-		}
-	}
-	return false
-}
-
-func effectInvalidatesCatalogContext(eff effects.Effect, rawVerb string) bool {
-	searchPath, snapshot := effectCatalogRefreshNeeds(eff, rawVerb)
-	return searchPath || snapshot
 }
 
 func effectCatalogRefreshNeeds(eff effects.Effect, rawVerb string) (searchPath bool, snapshot bool) {
@@ -248,6 +255,117 @@ func effectCatalogRefreshNeeds(eff effects.Effect, rawVerb string) (searchPath b
 		return false, true
 	}
 	return false, false
+}
+
+func applyStatementCatalogContext(ctx resolveContext, stmt effects.ClassifiedStatement) resolveContext {
+	for _, eff := range stmt.Effects {
+		ctx = applyEffectCatalogContext(ctx, eff, stmt.RawVerb)
+	}
+	return ctx
+}
+
+func applyEffectCatalogContext(ctx resolveContext, eff effects.Effect, rawVerb string) resolveContext {
+	switch eff.Subtype {
+	case effects.SubtypeSetSearchPath:
+		if path, ok := parseSetSearchPathRawVerb(rawVerb); ok {
+			ctx.fixture.SearchPath = path
+			ctx.searchPathUnavailableReason = ""
+		} else {
+			ctx.searchPathUnavailableReason = catalogSessionStateChangedReason
+			ctx.fixture.SearchPath = nil
+		}
+		return ctx
+	case effects.SubtypeReset:
+		if effectHasAnyGUC(eff, "search_path") {
+			ctx.fixture.SearchPath = append([]string(nil), ctx.defaultSearchPath...)
+			ctx.searchPathUnavailableReason = ""
+		}
+		if effectHasAnyGUC(eff, "role", "session_authorization") {
+			ctx.searchPathUnavailableReason = catalogSessionStateChangedReason
+			ctx.fixture.SearchPath = nil
+		}
+		return ctx
+	case effects.SubtypeResetAll, effects.SubtypeDiscardAll:
+		ctx.fixture.SearchPath = append([]string(nil), ctx.defaultSearchPath...)
+		ctx.searchPathUnavailableReason = ""
+		ctx.localSearchPathActive = false
+		ctx.localSearchPathBase = nil
+		return ctx
+	case effects.SubtypeSetRole, effects.SubtypeSetSessionAuthorization:
+		ctx.searchPathUnavailableReason = catalogSessionStateChangedReason
+		ctx.fixture.SearchPath = nil
+		return ctx
+	case effects.SubtypeSetLocal:
+		if effectHasAnyGUC(eff, "search_path", "role", "session_authorization") && !ctx.localSearchPathActive {
+			ctx.localSearchPathActive = true
+			ctx.localSearchPathBase = append([]string(nil), ctx.fixture.SearchPath...)
+		}
+		if effectHasAnyGUC(eff, "search_path") {
+			if path, ok := parseSetLocalSearchPathRawVerb(rawVerb); ok {
+				ctx.fixture.SearchPath = path
+				ctx.searchPathUnavailableReason = ""
+			} else {
+				ctx.searchPathUnavailableReason = catalogSessionStateChangedReason
+				ctx.fixture.SearchPath = nil
+			}
+			return ctx
+		}
+		if effectHasAnyGUC(eff, "role", "session_authorization") {
+			ctx.searchPathUnavailableReason = catalogSessionStateChangedReason
+			ctx.fixture.SearchPath = nil
+			return ctx
+		}
+	}
+
+	if eff.Group == effects.GroupTransaction && transactionCanRestoreLocalSearchPath(rawVerb) {
+		if ctx.localSearchPathActive {
+			ctx.fixture.SearchPath = append([]string(nil), ctx.localSearchPathBase...)
+			ctx.searchPathUnavailableReason = ""
+			ctx.localSearchPathActive = false
+			ctx.localSearchPathBase = nil
+		}
+		return ctx
+	}
+
+	_, snapshot := effectCatalogRefreshNeeds(eff, rawVerb)
+	if snapshot {
+		ctx.snapshotUnavailableReason = catalogSessionStateChangedReason
+	}
+	return ctx
+}
+
+func parseSetSearchPathRawVerb(rawVerb string) ([]string, bool) {
+	const prefix = "SET_SEARCH_PATH="
+	if !strings.HasPrefix(rawVerb, prefix) {
+		return nil, false
+	}
+	return splitSearchPathRawVerb(rawVerb[len(prefix):]), true
+}
+
+func parseSetLocalSearchPathRawVerb(rawVerb string) ([]string, bool) {
+	const prefix = "SET_LOCAL=search_path:"
+	if !strings.HasPrefix(rawVerb, prefix) {
+		return nil, false
+	}
+	return splitSearchPathRawVerb(rawVerb[len(prefix):]), true
+}
+
+func splitSearchPathRawVerb(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		part = strings.Trim(part, `"`)
+		part = strings.ToLower(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func isCatalogUnavailableReason(reason string) bool {
+	return reason == catalogSessionStateChangedReason
 }
 
 func transactionCanRestoreLocalSearchPath(rawVerb string) bool {

--- a/internal/db/policyexplain/resolve.go
+++ b/internal/db/policyexplain/resolve.go
@@ -1,0 +1,278 @@
+package policyexplain
+
+import (
+	"strings"
+
+	"github.com/agentsh/agentsh/internal/db/catalog"
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
+
+const catalogSessionStateChangedReason = "session_state_changed"
+
+type resolveContext struct {
+	fixture           CatalogFixture
+	unavailableReason string
+}
+
+func resolveStatements(stmts []effects.ClassifiedStatement, fixture CatalogFixture) []effects.ClassifiedStatement {
+	out := make([]effects.ClassifiedStatement, len(stmts))
+	current := resolveContext{fixture: fixture}
+	for i := range stmts {
+		out[i] = resolveStatementWithContext(stmts[i], current)
+		if statementInvalidatesCatalogContext(stmts[i]) {
+			current.unavailableReason = catalogSessionStateChangedReason
+			current.fixture.SearchPath = nil
+		}
+	}
+	return out
+}
+
+func resolveStatement(stmt effects.ClassifiedStatement, fixture CatalogFixture) effects.ClassifiedStatement {
+	return resolveStatementWithContext(stmt, resolveContext{fixture: fixture})
+}
+
+func resolveStatementWithContext(stmt effects.ClassifiedStatement, ctx resolveContext) effects.ClassifiedStatement {
+	out := stmt
+	out.Effects = make([]effects.Effect, len(stmt.Effects))
+	for i, eff := range stmt.Effects {
+		out.Effects[i] = resolveEffectWithContext(eff, ctx)
+	}
+	return out
+}
+
+func resolveEffect(eff effects.Effect, fixture CatalogFixture) effects.Effect {
+	return resolveEffectWithContext(eff, resolveContext{fixture: fixture})
+}
+
+func resolveEffectWithContext(eff effects.Effect, ctx resolveContext) effects.Effect {
+	out := eff
+	out.ResolvedObjects = nil
+	resolved := make([]effects.ResolvedObjectRef, 0, len(eff.Objects)+1)
+	allResolved := true
+	hasRelationObject := hasCatalogRelationObject(eff.Objects)
+	for _, obj := range eff.Objects {
+		if hasRelationObject && !isCatalogRelationObject(obj.Kind) {
+			continue
+		}
+		ref := resolveObjectWithContext(obj, ctx)
+		if ref.UnresolvedReason != "" {
+			allResolved = false
+		}
+		resolved = append(resolved, ref)
+	}
+	if eff.FunctionOID != nil {
+		ref := resolveFunctionOIDWithContext(*eff.FunctionOID, ctx)
+		if ref.UnresolvedReason != "" {
+			allResolved = false
+		}
+		resolved = append(resolved, ref)
+	}
+	if len(resolved) == 0 {
+		return out
+	}
+	out.ResolvedObjects = resolved
+	if ctx.unavailableReason != "" {
+		out.Resolution = effects.ResolutionCatalogUnavailable
+	} else if allResolved {
+		out.Resolution = effects.ResolutionCatalogResolved
+	} else {
+		out.Resolution = effects.ResolutionCatalogUnresolved
+	}
+	return out
+}
+
+func resolveObject(obj effects.ObjectRef, fixture CatalogFixture) effects.ResolvedObjectRef {
+	return resolveObjectWithContext(obj, resolveContext{fixture: fixture})
+}
+
+func resolveObjectWithContext(obj effects.ObjectRef, ctx resolveContext) effects.ResolvedObjectRef {
+	if !isCatalogRelationObject(obj.Kind) {
+		return effects.ResolvedObjectRef{
+			Source:           effects.ResolvedObjectSourceCatalog,
+			Kind:             effects.ResolvedObjectRelation,
+			Schema:           obj.Schema,
+			Name:             obj.Name,
+			UnresolvedReason: "unsupported",
+		}
+	}
+	if ctx.unavailableReason != "" {
+		return effects.ResolvedObjectRef{
+			Source:           effects.ResolvedObjectSourceCatalog,
+			Kind:             effects.ResolvedObjectRelation,
+			Schema:           obj.Schema,
+			Name:             obj.Name,
+			UnresolvedReason: ctx.unavailableReason,
+		}
+	}
+	res := catalog.ResolveRelation(ctx.fixture.Snapshot, catalog.Name{Schema: obj.Schema, Name: obj.Name}, ctx.fixture.SearchPath)
+	if !res.OK() {
+		return effects.ResolvedObjectRef{
+			Source:           effects.ResolvedObjectSourceCatalog,
+			Kind:             effects.ResolvedObjectRelation,
+			Schema:           obj.Schema,
+			Name:             obj.Name,
+			UnresolvedReason: res.Reason.String(),
+		}
+	}
+	rel := res.Relation
+	return effects.ResolvedObjectRef{
+		Source:       effects.ResolvedObjectSourceCatalog,
+		Kind:         effects.ResolvedObjectRelation,
+		OID:          uint32(rel.OID),
+		Schema:       rel.Name.Schema,
+		Name:         rel.Name.Name,
+		RelationKind: rel.Kind.String(),
+	}
+}
+
+func hasCatalogRelationObject(objects []effects.ObjectRef) bool {
+	for _, obj := range objects {
+		if isCatalogRelationObject(obj.Kind) {
+			return true
+		}
+	}
+	return false
+}
+
+func isCatalogRelationObject(kind effects.ObjectKind) bool {
+	switch kind {
+	case effects.ObjectTable, effects.ObjectView, effects.ObjectSequence:
+		return true
+	default:
+		return false
+	}
+}
+
+func resolveFunctionOID(oid int32, fixture CatalogFixture) effects.ResolvedObjectRef {
+	return resolveFunctionOIDWithContext(oid, resolveContext{fixture: fixture})
+}
+
+func resolveFunctionOIDWithContext(oid int32, ctx resolveContext) effects.ResolvedObjectRef {
+	if ctx.unavailableReason != "" {
+		return effects.ResolvedObjectRef{
+			Source:           effects.ResolvedObjectSourceCatalog,
+			Kind:             effects.ResolvedObjectFunction,
+			OID:              uint32(oid),
+			UnresolvedReason: ctx.unavailableReason,
+		}
+	}
+	res := catalog.ResolveFunctionByOID(ctx.fixture.Snapshot, catalog.OID(uint32(oid)))
+	if !res.OK() {
+		return effects.ResolvedObjectRef{
+			Source:           effects.ResolvedObjectSourceCatalog,
+			Kind:             effects.ResolvedObjectFunction,
+			OID:              uint32(oid),
+			UnresolvedReason: res.Reason.String(),
+		}
+	}
+	fn := res.Function
+	return effects.ResolvedObjectRef{
+		Source:               effects.ResolvedObjectSourceCatalog,
+		Kind:                 effects.ResolvedObjectFunction,
+		OID:                  uint32(fn.OID),
+		Schema:               fn.Name.Schema,
+		Name:                 fn.Name.Name,
+		FunctionIdentityArgs: fn.IdentityArgs,
+		FunctionVolatility:   functionVolatility(fn.Volatility),
+	}
+}
+
+func functionVolatility(v catalog.FunctionVolatility) string {
+	switch v {
+	case catalog.VolatilityImmutable:
+		return "immutable"
+	case catalog.VolatilityStable:
+		return "stable"
+	case catalog.VolatilityVolatile:
+		return "volatile"
+	default:
+		return ""
+	}
+}
+
+func statementInvalidatesCatalogContext(stmt effects.ClassifiedStatement) bool {
+	for _, eff := range stmt.Effects {
+		if effectInvalidatesCatalogContext(eff, stmt.RawVerb) {
+			return true
+		}
+	}
+	return false
+}
+
+func effectInvalidatesCatalogContext(eff effects.Effect, rawVerb string) bool {
+	searchPath, snapshot := effectCatalogRefreshNeeds(eff, rawVerb)
+	return searchPath || snapshot
+}
+
+func effectCatalogRefreshNeeds(eff effects.Effect, rawVerb string) (searchPath bool, snapshot bool) {
+	switch eff.Subtype {
+	case effects.SubtypeSetSearchPath,
+		effects.SubtypeResetAll,
+		effects.SubtypeDiscardAll,
+		effects.SubtypeSetRole,
+		effects.SubtypeSetSessionAuthorization:
+		return true, false
+	case effects.SubtypeSetLocal:
+		if effectHasAnyGUC(eff, "search_path", "role", "session_authorization") {
+			return true, false
+		}
+	case effects.SubtypeReset:
+		if effectHasAnyGUC(eff, "search_path", "role", "session_authorization") {
+			return true, false
+		}
+	case effects.SubtypeDiscardTemp:
+		return true, true
+	case effects.SubtypeCreateTable:
+		if strings.Contains(rawVerb, "TEMP") {
+			return true, true
+		}
+		return false, true
+	case effects.SubtypeCreateIndex,
+		effects.SubtypeCreateView,
+		effects.SubtypeCreateSchema,
+		effects.SubtypeCreateFunction,
+		effects.SubtypeCreateMaterializedView,
+		effects.SubtypeCreateExtension,
+		effects.SubtypeDropTable,
+		effects.SubtypeDropSchema,
+		effects.SubtypeDropIndex,
+		effects.SubtypeDropView,
+		effects.SubtypeDropFunction:
+		return false, true
+	}
+	if eff.Group == effects.GroupTransaction && transactionCanRestoreLocalSearchPath(rawVerb) {
+		return true, false
+	}
+	switch eff.Group {
+	case effects.GroupSchemaCreate, effects.GroupSchemaAlter, effects.GroupSchemaDestroy:
+		return false, true
+	}
+	return false, false
+}
+
+func transactionCanRestoreLocalSearchPath(rawVerb string) bool {
+	switch rawVerb {
+	case "COMMIT", "ROLLBACK", "ROLLBACK_TO", "END":
+		return true
+	default:
+		return false
+	}
+}
+
+func effectHasAnyGUC(eff effects.Effect, names ...string) bool {
+	for _, name := range names {
+		if effectHasGUC(eff, name) {
+			return true
+		}
+	}
+	return false
+}
+
+func effectHasGUC(eff effects.Effect, name string) bool {
+	for _, obj := range eff.Objects {
+		if obj.Kind == effects.ObjectGUC && strings.EqualFold(obj.Name, name) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/db/policyexplain/run.go
+++ b/internal/db/policyexplain/run.go
@@ -1,0 +1,156 @@
+package policyexplain
+
+import (
+	"fmt"
+	"strings"
+
+	classify_pg "github.com/agentsh/agentsh/internal/db/classify/postgres"
+	"github.com/agentsh/agentsh/internal/db/effects"
+	dbpolicy "github.com/agentsh/agentsh/internal/db/policy"
+)
+
+func Run(rs *dbpolicy.RuleSet, warns []dbpolicy.Warning, opts Options) (Report, error) {
+	dialect, ok := classify_pg.ParseDialect(defaultString(opts.Dialect, "postgres"))
+	if !ok {
+		return Report{}, fmt.Errorf("unknown dialect %q", opts.Dialect)
+	}
+	searchPath := append([]string(nil), opts.SearchPath...)
+	sess := classify_pg.SessionState{
+		SearchPath:        searchPath,
+		DefaultSearchPath: append([]string(nil), searchPath...),
+	}
+	if len(opts.TempTables) > 0 {
+		sess.TempTables = make(map[string]struct{}, len(opts.TempTables))
+		for _, name := range opts.TempTables {
+			sess.TempTables[strings.ToLower(strings.TrimSpace(name))] = struct{}{}
+		}
+	}
+	stmts, err := classify_pg.New(dialect).Classify(opts.SQL, sess, classify_pg.Options{})
+	if err != nil {
+		return Report{}, err
+	}
+	catalogSource := "none"
+	if opts.CatalogFixture != "" {
+		fixture, err := LoadCatalogFixture(opts.CatalogFixture)
+		if err != nil {
+			return Report{}, err
+		}
+		stmts = resolveStatements(stmts, fixture)
+		catalogSource = "fixture"
+	}
+	report := Report{
+		Service:       string(opts.Service),
+		Dialect:       dialect.String(),
+		CatalogSource: catalogSource,
+		Warnings:      warningReports(warns),
+	}
+	for i, stmt := range stmts {
+		report.Statements = append(report.Statements, statementReport(i, stmt, dbpolicy.ExplainStatement(stmt, rs, opts.Service)))
+	}
+	return report, nil
+}
+
+func defaultString(s, fallback string) string {
+	if strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return s
+}
+
+func warningReports(warns []dbpolicy.Warning) []WarningReport {
+	out := make([]WarningReport, 0, len(warns))
+	for _, w := range warns {
+		out = append(out, WarningReport{Rule: w.Rule, Field: w.Field, Code: w.Code, Message: w.Message})
+	}
+	return out
+}
+
+func statementReport(index int, stmt effects.ClassifiedStatement, ex dbpolicy.StatementExplanation) StatementReport {
+	out := StatementReport{
+		Index:         index,
+		RawVerb:       stmt.RawVerb,
+		ParserBackend: stmt.ParserBackend.String(),
+		Decision: DecisionReport{
+			Verb:                ex.Decision.Verb.String(),
+			RuleKind:            ex.Decision.RuleKind.String(),
+			RuleName:            ex.Decision.RuleName,
+			MatchingEffectIndex: ex.Decision.MatchingEffectIndex,
+			MatchingEffectGroup: ex.Decision.MatchingEffectGroup.String(),
+			Reason:              ex.Decision.Reason,
+		},
+		Error: stmt.Error,
+	}
+	for _, eff := range ex.Effects {
+		out.Effects = append(out.Effects, effectReport(eff, stmt.Effects[eff.Index]))
+	}
+	return out
+}
+
+func effectReport(ex dbpolicy.EffectExplanation, eff effects.Effect) EffectReport {
+	out := EffectReport{
+		Index:           ex.Index,
+		Operation:       ex.Group.String(),
+		Resolution:      ex.Resolution.String(),
+		Objects:         append([]effects.ObjectRef(nil), eff.Objects...),
+		ResolvedObjects: append([]effects.ResolvedObjectRef(nil), eff.ResolvedObjects...),
+	}
+	if ex.Subtype != effects.SubtypeNone {
+		out.Subtype = ex.Subtype.String()
+	}
+	for _, cov := range ex.Coverage {
+		out.Coverage = append(out.Coverage, coverageReport(cov))
+	}
+	out.CoveringRules = ruleReports(ex.CoveringRules)
+	out.DenyRules = ruleReports(ex.DenyRules)
+	return out
+}
+
+func coverageReport(cov dbpolicy.ObjectCoverage) CoverageReport {
+	out := CoverageReport{
+		Object:          objectName(cov.Object),
+		Covered:         cov.Covered,
+		UncoveredReason: cov.UncoveredReason,
+	}
+	if cov.ResolvedObject != nil {
+		out.ResolvedObject = cov.ResolvedObject.CanonicalName()
+	}
+	for _, r := range cov.CoveringRules {
+		out.CoveringRules = append(out.CoveringRules, ruleReport(r))
+		if out.Selector == "" {
+			out.Selector = r.Selector
+		}
+	}
+	return out
+}
+
+func ruleReports(matches []dbpolicy.RuleMatch) []RuleReport {
+	out := make([]RuleReport, 0, len(matches))
+	for _, r := range matches {
+		out = append(out, ruleReport(r))
+	}
+	return out
+}
+
+func ruleReport(match dbpolicy.RuleMatch) RuleReport {
+	return RuleReport{
+		RuleName: match.RuleName,
+		Verb:     match.Verb.String(),
+		Selector: match.Selector,
+	}
+}
+
+func objectName(o effects.ObjectRef) string {
+	switch o.Kind {
+	case effects.ObjectExternalEndpoint:
+		return o.Host
+	case effects.ObjectFilesystemPath:
+		return o.Path
+	case effects.ObjectProgram:
+		return o.Argv0
+	default:
+		if o.Schema == "" {
+			return o.Name
+		}
+		return o.Schema + "." + o.Name
+	}
+}

--- a/internal/db/policyexplain/run.go
+++ b/internal/db/policyexplain/run.go
@@ -44,6 +44,12 @@ func Run(rs *dbpolicy.RuleSet, warns []dbpolicy.Warning, opts Options) (Report, 
 		CatalogSource: catalogSource,
 		Warnings:      warningReports(warns),
 	}
+	if catalogSource == "none" && rs.UsesCanonicalSelectors(opts.Service) {
+		report.Warnings = append(report.Warnings, WarningReport{
+			Code:    "catalog_fixture_missing_for_canonical_selector",
+			Message: "catalog fixture not supplied; canonical relation and function selectors cannot match offline classification",
+		})
+	}
 	for i, stmt := range stmts {
 		report.Statements = append(report.Statements, statementReport(i, stmt, dbpolicy.ExplainStatement(stmt, rs, opts.Service)))
 	}

--- a/internal/db/policyexplain/run_test.go
+++ b/internal/db/policyexplain/run_test.go
@@ -1,0 +1,252 @@
+package policyexplain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/db/catalog"
+	"github.com/agentsh/agentsh/internal/db/effects"
+	dbpolicy "github.com/agentsh/agentsh/internal/db/policy"
+	rootpolicy "github.com/agentsh/agentsh/internal/policy"
+)
+
+func TestRun_WithCatalogFixtureAllowsCanonicalRelation(t *testing.T) {
+	rs := loadRuleSetForExplain(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: canonical-read, db_service: appdb, operations: [READ], relations: ["public.users"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "catalog.yaml")
+	if err := os.WriteFile(fixture, []byte(`search_path: [public]
+relations:
+  - oid: 16384
+    schema: public
+    name: users
+    kind: table
+`), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	report, err := Run(rs, []dbpolicy.Warning(nil), Options{
+		SQL:            "SELECT * FROM users",
+		Service:        "appdb",
+		Dialect:        "postgres",
+		CatalogFixture: fixture,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if report.CatalogSource != "fixture" {
+		t.Fatalf("CatalogSource = %q", report.CatalogSource)
+	}
+	if len(report.Statements) != 1 {
+		t.Fatalf("statements = %d", len(report.Statements))
+	}
+	dec := report.Statements[0].Decision
+	if dec.Verb != "allow" || dec.RuleName != "canonical-read" {
+		t.Fatalf("decision = %+v", dec)
+	}
+}
+
+func TestRun_WithSearchPathAndCatalogFixtureAllowsCanonicalRelation(t *testing.T) {
+	rs := loadRuleSetForExplain(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: canonical-read, db_service: appdb, operations: [READ], relations: ["public.users"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	fixture := writeUsersFixture(t)
+	report, err := Run(rs, nil, Options{
+		SQL:            "SELECT * FROM users",
+		Service:        "appdb",
+		Dialect:        "postgres",
+		SearchPath:     []string{"public"},
+		CatalogFixture: fixture,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(report.Statements) != 1 || len(report.Statements[0].Effects) != 1 {
+		t.Fatalf("report statements = %+v", report.Statements)
+	}
+	eff := report.Statements[0].Effects[0]
+	if eff.Resolution == effects.ResolutionAmbiguousAfterSearchPath.String() {
+		t.Fatalf("resolution = %q, want non-stale search path", eff.Resolution)
+	}
+	dec := report.Statements[0].Decision
+	if dec.Verb != "allow" || dec.RuleName != "canonical-read" {
+		t.Fatalf("decision = %+v", dec)
+	}
+}
+
+func TestRun_SearchPathInitializesDefaultSearchPath(t *testing.T) {
+	rs := loadRuleSetForExplain(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: unqualified-read, db_service: appdb, operations: [READ], objects: ["users"], match_object_resolution: unqualified_syntactic, decision: allow}
+`)
+	report, err := Run(rs, nil, Options{
+		SQL:        "SELECT * FROM users",
+		Service:    "appdb",
+		Dialect:    "postgres",
+		SearchPath: []string{"public"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(report.Statements) != 1 || len(report.Statements[0].Effects) != 1 {
+		t.Fatalf("report statements = %+v", report.Statements)
+	}
+	if got := report.Statements[0].Effects[0].Resolution; got != effects.ResolutionUnqualified.String() {
+		t.Fatalf("resolution = %q, want %q", got, effects.ResolutionUnqualified)
+	}
+	dec := report.Statements[0].Decision
+	if dec.Verb != "allow" || dec.RuleName != "unqualified-read" {
+		t.Fatalf("decision = %+v", dec)
+	}
+}
+
+func TestResolveEffect_MixedRelationSkipsUnsupportedSlotsAndPolicyStillDenies(t *testing.T) {
+	fixture := catalogFixtureForUsers()
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupSchemaCreate,
+		Resolution: effects.ResolutionUnqualified,
+		Objects: []effects.ObjectRef{
+			{Kind: effects.ObjectFunction, Name: "users_trigger"},
+			{Kind: effects.ObjectTable, Name: "users"},
+		},
+	}}}
+
+	got := resolveStatement(stmt, fixture)
+	eff := got.Effects[0]
+	if eff.Resolution != effects.ResolutionCatalogResolved {
+		t.Fatalf("resolution = %v, want catalog_resolved", eff.Resolution)
+	}
+	if len(eff.ResolvedObjects) != 1 || eff.ResolvedObjects[0].CanonicalName() != "public.users" {
+		t.Fatalf("resolved objects = %+v, want only public.users", eff.ResolvedObjects)
+	}
+
+	rs := loadRuleSetForExplain(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: create-users, db_service: appdb, operations: [CREATE], objects: ["users"], relations: ["public.users"], decision: allow}
+`)
+	ex := dbpolicy.ExplainStatement(got, rs, "appdb")
+	if ex.Decision.Verb != dbpolicy.VerbDeny || ex.Decision.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny for trigger object", ex.Decision)
+	}
+}
+
+func TestResolveStatements_InvalidatesFixtureAfterSessionStateChange(t *testing.T) {
+	stmts := []effects.ClassifiedStatement{{
+		RawVerb: "SET_SEARCH_PATH=app",
+		Effects: []effects.Effect{{
+			Group:   effects.GroupSession,
+			Subtype: effects.SubtypeSetSearchPath,
+			Objects: []effects.ObjectRef{{Kind: effects.ObjectGUC, Name: "search_path"}},
+		}},
+	}, {
+		RawVerb: "SELECT",
+		Effects: []effects.Effect{{
+			Group:      effects.GroupRead,
+			Resolution: effects.ResolutionUnqualified,
+			Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "users"}},
+		}},
+	}}
+
+	got := resolveStatements(stmts, catalogFixtureForUsers())
+	eff := got[1].Effects[0]
+	if eff.Resolution != effects.ResolutionCatalogUnavailable {
+		t.Fatalf("second statement resolution = %v, want catalog_unavailable", eff.Resolution)
+	}
+	if len(eff.ResolvedObjects) != 1 || eff.ResolvedObjects[0].UnresolvedReason != "session_state_changed" {
+		t.Fatalf("second statement resolved objects = %+v", eff.ResolvedObjects)
+	}
+
+	rs := loadRuleSetForExplain(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: canonical-read, db_service: appdb, operations: [READ], relations: ["public.users"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	ex := dbpolicy.ExplainStatement(got[1], rs, "appdb")
+	if ex.Decision.Verb != dbpolicy.VerbDeny || ex.Decision.RuleName != "" {
+		t.Fatalf("decision = %+v, want canonical rule not to allow stale fixture resolution", ex.Decision)
+	}
+}
+
+func TestResolveStatements_InvalidatesFixtureAfterSchemaAlterWithoutSubtype(t *testing.T) {
+	stmts := []effects.ClassifiedStatement{{
+		RawVerb: "ALTER_TABLE",
+		Effects: []effects.Effect{{
+			Group:      effects.GroupSchemaAlter,
+			Resolution: effects.ResolutionUnqualified,
+			Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "users"}},
+		}},
+	}, {
+		RawVerb: "SELECT",
+		Effects: []effects.Effect{{
+			Group:      effects.GroupRead,
+			Resolution: effects.ResolutionUnqualified,
+			Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "users"}},
+		}},
+	}}
+
+	got := resolveStatements(stmts, catalogFixtureForUsers())
+	eff := got[1].Effects[0]
+	if eff.Resolution != effects.ResolutionCatalogUnavailable {
+		t.Fatalf("second statement resolution = %v, want catalog_unavailable", eff.Resolution)
+	}
+	if len(eff.ResolvedObjects) != 1 || eff.ResolvedObjects[0].UnresolvedReason != "session_state_changed" {
+		t.Fatalf("second statement resolved objects = %+v", eff.ResolvedObjects)
+	}
+}
+
+func loadRuleSetForExplain(t *testing.T, src string) *dbpolicy.RuleSet {
+	t.Helper()
+	p, err := rootpolicy.LoadFromBytes([]byte(src))
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+	rs, _, err := dbpolicy.Decode(p)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	return rs
+}
+
+func writeUsersFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	fixture := filepath.Join(dir, "catalog.yaml")
+	if err := os.WriteFile(fixture, []byte(`search_path: [public]
+relations:
+  - oid: 16384
+    schema: public
+    name: users
+    kind: table
+`), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return fixture
+}
+
+func catalogFixtureForUsers() CatalogFixture {
+	return CatalogFixture{
+		SearchPath: []string{"public"},
+		Snapshot: catalog.NewSnapshot([]catalog.Relation{{
+			OID:  catalog.OID(16384),
+			Name: catalog.Name{Schema: "public", Name: "users"},
+			Kind: catalog.RelationTable,
+		}}, nil),
+	}
+}

--- a/internal/db/policyexplain/run_test.go
+++ b/internal/db/policyexplain/run_test.go
@@ -112,6 +112,33 @@ database_rules:
 	}
 }
 
+func TestRun_WithoutCatalogFixtureWarnsForCanonicalSelectors(t *testing.T) {
+	rs := loadRuleSetForExplain(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: canonical-read, db_service: appdb, operations: [READ], relations: ["public.users"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	report, err := Run(rs, nil, Options{
+		SQL:        "SELECT * FROM users",
+		Service:    "appdb",
+		Dialect:    "postgres",
+		SearchPath: []string{"public"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if report.CatalogSource != "none" {
+		t.Fatalf("CatalogSource = %q, want none", report.CatalogSource)
+	}
+	dec := report.Statements[0].Decision
+	if dec.Verb != "deny" || dec.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny without fixture resolution", dec)
+	}
+	assertExplainWarning(t, report.Warnings, "catalog_fixture_missing_for_canonical_selector")
+}
+
 func TestResolveEffect_MixedRelationSkipsUnsupportedSlotsAndPolicyStillDenies(t *testing.T) {
 	fixture := catalogFixtureForUsers()
 	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
@@ -181,13 +208,13 @@ database_rules:
 	}
 }
 
-func TestResolveStatements_InvalidatesFixtureAfterSessionStateChange(t *testing.T) {
+func TestResolveStatements_InvalidatesFixtureAfterRoleChange(t *testing.T) {
 	stmts := []effects.ClassifiedStatement{{
-		RawVerb: "SET_SEARCH_PATH=app",
+		RawVerb: "SET_ROLE=app",
 		Effects: []effects.Effect{{
 			Group:   effects.GroupSession,
-			Subtype: effects.SubtypeSetSearchPath,
-			Objects: []effects.ObjectRef{{Kind: effects.ObjectGUC, Name: "search_path"}},
+			Subtype: effects.SubtypeSetRole,
+			Objects: []effects.ObjectRef{{Kind: effects.ObjectRole, Name: "app"}},
 		}},
 	}, {
 		RawVerb: "SELECT",
@@ -217,6 +244,58 @@ database_rules:
 	ex := dbpolicy.ExplainStatement(got[1], rs, "appdb")
 	if ex.Decision.Verb != dbpolicy.VerbDeny || ex.Decision.RuleName != "" {
 		t.Fatalf("decision = %+v, want canonical rule not to allow stale fixture resolution", ex.Decision)
+	}
+}
+
+func TestResolveStatements_SetSearchPathUpdatesFixtureSearchPath(t *testing.T) {
+	stmts := []effects.ClassifiedStatement{{
+		RawVerb: "SET_SEARCH_PATH=audit,public",
+		Effects: []effects.Effect{{
+			Group:   effects.GroupSession,
+			Subtype: effects.SubtypeSetSearchPath,
+			Objects: []effects.ObjectRef{{Kind: effects.ObjectGUC, Name: "search_path"}},
+		}},
+	}, {
+		RawVerb: "SELECT",
+		Effects: []effects.Effect{{
+			Group:      effects.GroupRead,
+			Resolution: effects.ResolutionUnqualified,
+			Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "users"}},
+		}},
+	}}
+
+	got := resolveStatements(stmts, catalogFixtureForDuplicateUsers())
+	eff := got[1].Effects[0]
+	if eff.Resolution != effects.ResolutionCatalogResolved {
+		t.Fatalf("second statement resolution = %v, want catalog_resolved", eff.Resolution)
+	}
+	if len(eff.ResolvedObjects) != 1 || eff.ResolvedObjects[0].CanonicalName() != "audit.users" {
+		t.Fatalf("second statement resolved objects = %+v, want audit.users", eff.ResolvedObjects)
+	}
+}
+
+func TestResolveStatements_TransactionBoundaryWithoutLocalSearchPathKeepsFixture(t *testing.T) {
+	stmts := []effects.ClassifiedStatement{{
+		RawVerb: "COMMIT",
+		Effects: []effects.Effect{{
+			Group: effects.GroupTransaction,
+		}},
+	}, {
+		RawVerb: "SELECT",
+		Effects: []effects.Effect{{
+			Group:      effects.GroupRead,
+			Resolution: effects.ResolutionUnqualified,
+			Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: "users"}},
+		}},
+	}}
+
+	got := resolveStatements(stmts, catalogFixtureForUsers())
+	eff := got[1].Effects[0]
+	if eff.Resolution != effects.ResolutionCatalogResolved {
+		t.Fatalf("second statement resolution = %v, want catalog_resolved", eff.Resolution)
+	}
+	if len(eff.ResolvedObjects) != 1 || eff.ResolvedObjects[0].CanonicalName() != "public.users" {
+		t.Fatalf("second statement resolved objects = %+v, want public.users", eff.ResolvedObjects)
 	}
 }
 
@@ -258,6 +337,16 @@ func loadRuleSetForExplain(t *testing.T, src string) *dbpolicy.RuleSet {
 		t.Fatalf("Decode: %v", err)
 	}
 	return rs
+}
+
+func assertExplainWarning(t *testing.T, warns []WarningReport, code string) {
+	t.Helper()
+	for _, w := range warns {
+		if w.Code == code {
+			return
+		}
+	}
+	t.Fatalf("warnings = %+v, want code %q", warns, code)
 }
 
 func writeUsersFixture(t *testing.T) string {

--- a/internal/db/policyexplain/run_test.go
+++ b/internal/db/policyexplain/run_test.go
@@ -145,6 +145,42 @@ database_rules:
 	}
 }
 
+func TestResolveEffect_DuplicateRelationNamesPreserveSlotOrder(t *testing.T) {
+	fixture := catalogFixtureForDuplicateUsers()
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionUnqualified,
+		Objects: []effects.ObjectRef{
+			{Kind: effects.ObjectTable, Schema: "public", Name: "users"},
+			{Kind: effects.ObjectTable, Name: "users"},
+		},
+	}}}
+
+	got := resolveStatement(stmt, fixture)
+	eff := got.Effects[0]
+	if eff.Resolution != effects.ResolutionCatalogResolved {
+		t.Fatalf("resolution = %v, want catalog_resolved", eff.Resolution)
+	}
+	if len(eff.ResolvedObjects) != 2 {
+		t.Fatalf("resolved objects = %+v, want two resolved relations", eff.ResolvedObjects)
+	}
+	if eff.ResolvedObjects[0].CanonicalName() != "public.users" || eff.ResolvedObjects[1].CanonicalName() != "audit.users" {
+		t.Fatalf("resolved objects = %+v, want public.users then audit.users", eff.ResolvedObjects)
+	}
+
+	rs := loadRuleSetForExplain(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - {name: public-users, db_service: appdb, operations: [READ], relations: ["public.users"], match_object_resolution: catalog_resolved, decision: allow}
+`)
+	ex := dbpolicy.ExplainStatement(got, rs, "appdb")
+	if ex.Decision.Verb != dbpolicy.VerbDeny || ex.Decision.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny because second users slot resolved to audit.users", ex.Decision)
+	}
+}
+
 func TestResolveStatements_InvalidatesFixtureAfterSessionStateChange(t *testing.T) {
 	stmts := []effects.ClassifiedStatement{{
 		RawVerb: "SET_SEARCH_PATH=app",
@@ -246,6 +282,21 @@ func catalogFixtureForUsers() CatalogFixture {
 		Snapshot: catalog.NewSnapshot([]catalog.Relation{{
 			OID:  catalog.OID(16384),
 			Name: catalog.Name{Schema: "public", Name: "users"},
+			Kind: catalog.RelationTable,
+		}}, nil),
+	}
+}
+
+func catalogFixtureForDuplicateUsers() CatalogFixture {
+	return CatalogFixture{
+		SearchPath: []string{"audit", "public"},
+		Snapshot: catalog.NewSnapshot([]catalog.Relation{{
+			OID:  catalog.OID(16384),
+			Name: catalog.Name{Schema: "public", Name: "users"},
+			Kind: catalog.RelationTable,
+		}, {
+			OID:  catalog.OID(16385),
+			Name: catalog.Name{Schema: "audit", Name: "users"},
 			Kind: catalog.RelationTable,
 		}}, nil),
 	}

--- a/internal/db/policyexplain/types.go
+++ b/internal/db/policyexplain/types.go
@@ -1,0 +1,75 @@
+package policyexplain
+
+import (
+	"github.com/agentsh/agentsh/internal/db/effects"
+	dbpolicy "github.com/agentsh/agentsh/internal/db/policy"
+)
+
+type Options struct {
+	SQL            string
+	Service        dbpolicy.ServiceID
+	Dialect        string
+	SearchPath     []string
+	TempTables     []string
+	CatalogFixture string
+}
+
+type Report struct {
+	Service       string            `json:"service"`
+	Dialect       string            `json:"dialect"`
+	CatalogSource string            `json:"catalog_source"`
+	Statements    []StatementReport `json:"statements"`
+	Warnings      []WarningReport   `json:"warnings,omitempty"`
+}
+
+type StatementReport struct {
+	Index         int            `json:"index"`
+	RawVerb       string         `json:"raw_verb,omitempty"`
+	ParserBackend string         `json:"parser_backend,omitempty"`
+	Effects       []EffectReport `json:"effects"`
+	Decision      DecisionReport `json:"decision"`
+	Error         string         `json:"error,omitempty"`
+}
+
+type EffectReport struct {
+	Index           int                         `json:"index"`
+	Operation       string                      `json:"operation"`
+	Subtype         string                      `json:"subtype,omitempty"`
+	Resolution      string                      `json:"resolution"`
+	Objects         []effects.ObjectRef         `json:"objects,omitempty"`
+	ResolvedObjects []effects.ResolvedObjectRef `json:"resolved_objects,omitempty"`
+	Coverage        []CoverageReport            `json:"coverage,omitempty"`
+	CoveringRules   []RuleReport                `json:"covering_rules,omitempty"`
+	DenyRules       []RuleReport                `json:"deny_rules,omitempty"`
+}
+
+type CoverageReport struct {
+	Object          string       `json:"object,omitempty"`
+	ResolvedObject  string       `json:"resolved_object,omitempty"`
+	Covered         bool         `json:"covered"`
+	CoveringRules   []RuleReport `json:"covering_rules,omitempty"`
+	UncoveredReason string       `json:"uncovered_reason,omitempty"`
+	Selector        string       `json:"selector,omitempty"`
+}
+
+type RuleReport struct {
+	RuleName string `json:"rule_name"`
+	Verb     string `json:"verb"`
+	Selector string `json:"selector,omitempty"`
+}
+
+type DecisionReport struct {
+	Verb                string `json:"verb"`
+	RuleKind            string `json:"rule_kind,omitempty"`
+	RuleName            string `json:"rule_name,omitempty"`
+	MatchingEffectIndex int    `json:"matching_effect_index"`
+	MatchingEffectGroup string `json:"matching_effect_group,omitempty"`
+	Reason              string `json:"reason,omitempty"`
+}
+
+type WarningReport struct {
+	Rule    string `json:"rule,omitempty"`
+	Field   string `json:"field,omitempty"`
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}


### PR DESCRIPTION
## Summary
- Add canonical DB policy selectors for resolved relations/functions and resolved-schema matching.
- Add DB policy explanation APIs plus offline catalog fixture resolution.
- Wire `agentsh policy db explain`, DB warning surfacing, samples, and docs.

## Test Plan
- `go test ./internal/db/policy ./internal/db/policyexplain ./internal/cli -count=1`
- `go test ./...`
- `GOOS=windows go build ./...`
- `git diff --check`