### PR TITLE
fix(docker-test): probe wait_killable via unixwrap stderr, not server.log

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -242,19 +242,29 @@ fi
 # -------------------------------------------------------------------
 # Layer 1 (WAIT_KILLABLE_RECV) engagement check
 #
-# The new raw-seccomp(2) load path emits a structured Info log
-# "seccomp: filter loaded ... wait_killable=true" when the kernel
-# accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. On the GitHub
-# runner's host kernel (>=6.0) the flag is always supported, so
-# the log MUST contain wait_killable=true. False would mean Layer 1
-# silently degraded — exactly what this entire design exists to prevent.
+# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
+# structured Info log "seccomp: filter loaded ... wait_killable=true"
+# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
+# log goes to unixwrap's stderr, which the server captures per-command
+# and streams back through `agentsh exec` as stderr events. Create a
+# probe session, run a no-op exec with stderr redirected to a file,
+# then grep the file. On the GitHub runner's host kernel (>=6.0) the
+# flag is always supported, so the log MUST appear — false would mean
+# Layer 1 silently degraded, exactly what this entire design exists
+# to prevent.
 # -------------------------------------------------------------------
-if grep -q 'wait_killable=true' "$tmp/server.log" || grep -q '"wait_killable":true' "$tmp/server.log"; then
-  pass "server log shows wait_killable=true (Layer 1 engaged)"
+probe_sid_json="$(agentsh session create --workspace /tmp --json)"
+probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
+seccomp_probe_log="$tmp/seccomp_probe.log"
+agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
+if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
+  pass "wait_killable=true (Layer 1 engaged)"
 else
-  fail "server log shows wait_killable=true" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant server log lines ---" >&2
-  grep -i wait_killable "$tmp/server.log" >&2 || echo "(no wait_killable lines in log)" >&2
+  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
+  echo "--- relevant probe log lines ---" >&2
+  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
+  echo "--- full probe log (head -40) ---" >&2
+  head -40 "$seccomp_probe_log" >&2 || true
 fi
 
 # -------------------------------------------------------------------

--- a/Dockerfile.test.alpine
+++ b/Dockerfile.test.alpine
@@ -233,19 +233,29 @@ fi
 # -------------------------------------------------------------------
 # Layer 1 (WAIT_KILLABLE_RECV) engagement check
 #
-# The new raw-seccomp(2) load path emits a structured Info log
-# "seccomp: filter loaded ... wait_killable=true" when the kernel
-# accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. On the GitHub
-# runner's host kernel (>=6.0) the flag is always supported, so
-# the log MUST contain wait_killable=true. False would mean Layer 1
-# silently degraded — exactly what this entire design exists to prevent.
+# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
+# structured Info log "seccomp: filter loaded ... wait_killable=true"
+# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
+# log goes to unixwrap's stderr, which the server captures per-command
+# and streams back through `agentsh exec` as stderr events. Create a
+# probe session, run a no-op exec with stderr redirected to a file,
+# then grep the file. On the GitHub runner's host kernel (>=6.0) the
+# flag is always supported, so the log MUST appear — false would mean
+# Layer 1 silently degraded, exactly what this entire design exists
+# to prevent.
 # -------------------------------------------------------------------
-if grep -q 'wait_killable=true' "$tmp/server.log" || grep -q '"wait_killable":true' "$tmp/server.log"; then
-  pass "server log shows wait_killable=true (Layer 1 engaged)"
+probe_sid_json="$(agentsh session create --workspace /tmp --json)"
+probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
+seccomp_probe_log="$tmp/seccomp_probe.log"
+agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
+if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
+  pass "wait_killable=true (Layer 1 engaged)"
 else
-  fail "server log shows wait_killable=true" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant server log lines ---" >&2
-  grep -i wait_killable "$tmp/server.log" >&2 || echo "(no wait_killable lines in log)" >&2
+  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
+  echo "--- relevant probe log lines ---" >&2
+  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
+  echo "--- full probe log (head -40) ---" >&2
+  head -40 "$seccomp_probe_log" >&2 || true
 fi
 
 # -------------------------------------------------------------------

--- a/Dockerfile.test.arch
+++ b/Dockerfile.test.arch
@@ -239,19 +239,29 @@ fi
 # -------------------------------------------------------------------
 # Layer 1 (WAIT_KILLABLE_RECV) engagement check
 #
-# The new raw-seccomp(2) load path emits a structured Info log
-# "seccomp: filter loaded ... wait_killable=true" when the kernel
-# accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. On the GitHub
-# runner's host kernel (>=6.0) the flag is always supported, so
-# the log MUST contain wait_killable=true. False would mean Layer 1
-# silently degraded — exactly what this entire design exists to prevent.
+# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
+# structured Info log "seccomp: filter loaded ... wait_killable=true"
+# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
+# log goes to unixwrap's stderr, which the server captures per-command
+# and streams back through `agentsh exec` as stderr events. Create a
+# probe session, run a no-op exec with stderr redirected to a file,
+# then grep the file. On the GitHub runner's host kernel (>=6.0) the
+# flag is always supported, so the log MUST appear — false would mean
+# Layer 1 silently degraded, exactly what this entire design exists
+# to prevent.
 # -------------------------------------------------------------------
-if grep -q 'wait_killable=true' "$tmp/server.log" || grep -q '"wait_killable":true' "$tmp/server.log"; then
-  pass "server log shows wait_killable=true (Layer 1 engaged)"
+probe_sid_json="$(agentsh session create --workspace /tmp --json)"
+probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
+seccomp_probe_log="$tmp/seccomp_probe.log"
+agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
+if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
+  pass "wait_killable=true (Layer 1 engaged)"
 else
-  fail "server log shows wait_killable=true" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant server log lines ---" >&2
-  grep -i wait_killable "$tmp/server.log" >&2 || echo "(no wait_killable lines in log)" >&2
+  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
+  echo "--- relevant probe log lines ---" >&2
+  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
+  echo "--- full probe log (head -40) ---" >&2
+  head -40 "$seccomp_probe_log" >&2 || true
 fi
 
 # -------------------------------------------------------------------

--- a/Dockerfile.test.debian-trixie
+++ b/Dockerfile.test.debian-trixie
@@ -246,19 +246,29 @@ fi
 # -------------------------------------------------------------------
 # Layer 1 (WAIT_KILLABLE_RECV) engagement check
 #
-# The new raw-seccomp(2) load path emits a structured Info log
-# "seccomp: filter loaded ... wait_killable=true" when the kernel
-# accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. On the GitHub
-# runner's host kernel (>=6.0) the flag is always supported, so
-# the log MUST contain wait_killable=true. False would mean Layer 1
-# silently degraded — exactly what this entire design exists to prevent.
+# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
+# structured Info log "seccomp: filter loaded ... wait_killable=true"
+# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
+# log goes to unixwrap's stderr, which the server captures per-command
+# and streams back through `agentsh exec` as stderr events. Create a
+# probe session, run a no-op exec with stderr redirected to a file,
+# then grep the file. On the GitHub runner's host kernel (>=6.0) the
+# flag is always supported, so the log MUST appear — false would mean
+# Layer 1 silently degraded, exactly what this entire design exists
+# to prevent.
 # -------------------------------------------------------------------
-if grep -q 'wait_killable=true' "$tmp/server.log" || grep -q '"wait_killable":true' "$tmp/server.log"; then
-  pass "server log shows wait_killable=true (Layer 1 engaged)"
+probe_sid_json="$(agentsh session create --workspace /tmp --json)"
+probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
+seccomp_probe_log="$tmp/seccomp_probe.log"
+agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
+if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
+  pass "wait_killable=true (Layer 1 engaged)"
 else
-  fail "server log shows wait_killable=true" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant server log lines ---" >&2
-  grep -i wait_killable "$tmp/server.log" >&2 || echo "(no wait_killable lines in log)" >&2
+  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
+  echo "--- relevant probe log lines ---" >&2
+  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
+  echo "--- full probe log (head -40) ---" >&2
+  head -40 "$seccomp_probe_log" >&2 || true
 fi
 
 # -------------------------------------------------------------------

--- a/Dockerfile.test.rockylinux10
+++ b/Dockerfile.test.rockylinux10
@@ -242,19 +242,29 @@ fi
 # -------------------------------------------------------------------
 # Layer 1 (WAIT_KILLABLE_RECV) engagement check
 #
-# The new raw-seccomp(2) load path emits a structured Info log
-# "seccomp: filter loaded ... wait_killable=true" when the kernel
-# accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. On the GitHub
-# runner's host kernel (>=6.0) the flag is always supported, so
-# the log MUST contain wait_killable=true. False would mean Layer 1
-# silently degraded — exactly what this entire design exists to prevent.
+# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
+# structured Info log "seccomp: filter loaded ... wait_killable=true"
+# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
+# log goes to unixwrap's stderr, which the server captures per-command
+# and streams back through `agentsh exec` as stderr events. Create a
+# probe session, run a no-op exec with stderr redirected to a file,
+# then grep the file. On the GitHub runner's host kernel (>=6.0) the
+# flag is always supported, so the log MUST appear — false would mean
+# Layer 1 silently degraded, exactly what this entire design exists
+# to prevent.
 # -------------------------------------------------------------------
-if grep -q 'wait_killable=true' "$tmp/server.log" || grep -q '"wait_killable":true' "$tmp/server.log"; then
-  pass "server log shows wait_killable=true (Layer 1 engaged)"
+probe_sid_json="$(agentsh session create --workspace /tmp --json)"
+probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
+seccomp_probe_log="$tmp/seccomp_probe.log"
+agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
+if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
+  pass "wait_killable=true (Layer 1 engaged)"
 else
-  fail "server log shows wait_killable=true" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant server log lines ---" >&2
-  grep -i wait_killable "$tmp/server.log" >&2 || echo "(no wait_killable lines in log)" >&2
+  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
+  echo "--- relevant probe log lines ---" >&2
+  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
+  echo "--- full probe log (head -40) ---" >&2
+  head -40 "$seccomp_probe_log" >&2 || true
 fi
 
 # -------------------------------------------------------------------

--- a/Dockerfile.test.rpm
+++ b/Dockerfile.test.rpm
@@ -240,19 +240,29 @@ fi
 # -------------------------------------------------------------------
 # Layer 1 (WAIT_KILLABLE_RECV) engagement check
 #
-# The new raw-seccomp(2) load path emits a structured Info log
-# "seccomp: filter loaded ... wait_killable=true" when the kernel
-# accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. On the GitHub
-# runner's host kernel (>=6.0) the flag is always supported, so
-# the log MUST contain wait_killable=true. False would mean Layer 1
-# silently degraded — exactly what this entire design exists to prevent.
+# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
+# structured Info log "seccomp: filter loaded ... wait_killable=true"
+# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
+# log goes to unixwrap's stderr, which the server captures per-command
+# and streams back through `agentsh exec` as stderr events. Create a
+# probe session, run a no-op exec with stderr redirected to a file,
+# then grep the file. On the GitHub runner's host kernel (>=6.0) the
+# flag is always supported, so the log MUST appear — false would mean
+# Layer 1 silently degraded, exactly what this entire design exists
+# to prevent.
 # -------------------------------------------------------------------
-if grep -q 'wait_killable=true' "$tmp/server.log" || grep -q '"wait_killable":true' "$tmp/server.log"; then
-  pass "server log shows wait_killable=true (Layer 1 engaged)"
+probe_sid_json="$(agentsh session create --workspace /tmp --json)"
+probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
+seccomp_probe_log="$tmp/seccomp_probe.log"
+agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
+if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
+  pass "wait_killable=true (Layer 1 engaged)"
 else
-  fail "server log shows wait_killable=true" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant server log lines ---" >&2
-  grep -i wait_killable "$tmp/server.log" >&2 || echo "(no wait_killable lines in log)" >&2
+  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
+  echo "--- relevant probe log lines ---" >&2
+  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
+  echo "--- full probe log (head -40) ---" >&2
+  head -40 "$seccomp_probe_log" >&2 || true
 fi
 
 # -------------------------------------------------------------------

--- a/Dockerfile.test.ubuntu
+++ b/Dockerfile.test.ubuntu
@@ -248,19 +248,29 @@ fi
 # -------------------------------------------------------------------
 # Layer 1 (WAIT_KILLABLE_RECV) engagement check
 #
-# The new raw-seccomp(2) load path emits a structured Info log
-# "seccomp: filter loaded ... wait_killable=true" when the kernel
-# accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. On the GitHub
-# runner's host kernel (>=6.0) the flag is always supported, so
-# the log MUST contain wait_killable=true. False would mean Layer 1
-# silently degraded — exactly what this entire design exists to prevent.
+# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
+# structured Info log "seccomp: filter loaded ... wait_killable=true"
+# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
+# log goes to unixwrap's stderr, which the server captures per-command
+# and streams back through `agentsh exec` as stderr events. Create a
+# probe session, run a no-op exec with stderr redirected to a file,
+# then grep the file. On the GitHub runner's host kernel (>=6.0) the
+# flag is always supported, so the log MUST appear — false would mean
+# Layer 1 silently degraded, exactly what this entire design exists
+# to prevent.
 # -------------------------------------------------------------------
-if grep -q 'wait_killable=true' "$tmp/server.log" || grep -q '"wait_killable":true' "$tmp/server.log"; then
-  pass "server log shows wait_killable=true (Layer 1 engaged)"
+probe_sid_json="$(agentsh session create --workspace /tmp --json)"
+probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
+seccomp_probe_log="$tmp/seccomp_probe.log"
+agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
+if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
+  pass "wait_killable=true (Layer 1 engaged)"
 else
-  fail "server log shows wait_killable=true" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant server log lines ---" >&2
-  grep -i wait_killable "$tmp/server.log" >&2 || echo "(no wait_killable lines in log)" >&2
+  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
+  echo "--- relevant probe log lines ---" >&2
+  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
+  echo "--- full probe log (head -40) ---" >&2
+  head -40 "$seccomp_probe_log" >&2 || true
 fi
 
 # -------------------------------------------------------------------

--- a/Dockerfile.test.ubuntu2204
+++ b/Dockerfile.test.ubuntu2204
@@ -313,19 +313,29 @@ fi
 # -------------------------------------------------------------------
 # Layer 1 (WAIT_KILLABLE_RECV) engagement check
 #
-# The new raw-seccomp(2) load path emits a structured Info log
-# "seccomp: filter loaded ... wait_killable=true" when the kernel
-# accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. On the GitHub
-# runner's host kernel (>=6.0) the flag is always supported, so
-# the log MUST contain wait_killable=true. False would mean Layer 1
-# silently degraded — exactly what this entire design exists to prevent.
+# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
+# structured Info log "seccomp: filter loaded ... wait_killable=true"
+# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
+# log goes to unixwrap's stderr, which the server captures per-command
+# and streams back through `agentsh exec` as stderr events. Create a
+# probe session, run a no-op exec with stderr redirected to a file,
+# then grep the file. On the GitHub runner's host kernel (>=6.0) the
+# flag is always supported, so the log MUST appear — false would mean
+# Layer 1 silently degraded, exactly what this entire design exists
+# to prevent.
 # -------------------------------------------------------------------
-if grep -q 'wait_killable=true' "$tmp/server.log" || grep -q '"wait_killable":true' "$tmp/server.log"; then
-  pass "server log shows wait_killable=true (Layer 1 engaged)"
+probe_sid_json="$(agentsh session create --workspace /tmp --json)"
+probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
+seccomp_probe_log="$tmp/seccomp_probe.log"
+agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
+if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
+  pass "wait_killable=true (Layer 1 engaged)"
 else
-  fail "server log shows wait_killable=true" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant server log lines ---" >&2
-  grep -i wait_killable "$tmp/server.log" >&2 || echo "(no wait_killable lines in log)" >&2
+  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
+  echo "--- relevant probe log lines ---" >&2
+  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
+  echo "--- full probe log (head -40) ---" >&2
+  head -40 "$seccomp_probe_log" >&2 || true
 fi
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the docker-test failure that hit all 8 variants on v0.19.4-rc1's release pipeline:

\`\`\`
FAIL: server log shows wait_killable=true — Layer 1 silently disabled — check seccomp_load_linux.go
--- relevant server log lines ---
(no wait_killable lines in log)
=== Results: 47 passed, 1 failed, 48 total ===
\`\`\`

The check was introduced in #316 ("seccomp: link against system libseccomp 2.5"), which is the first time release.yml's docker-test job is exercising it. It greps \`\$tmp/server.log\` for \`wait_killable=true\`, but that log line is emitted by **agentsh-unixwrap** (the per-exec wrapper), not by the **agentsh server**. The server captures unixwrap's stderr into a byte buffer in \`exec_stream.go\` and streams it back to the CLI as SSE \`"stderr"\` events — it never lands in the server's own log file.

The check was also placed BEFORE session creation, so even if it had looked in the right place, no exec had run yet to install the seccomp filter and emit the log.

## Fix

Create a probe session, run \`agentsh exec ... -- /bin/true\` with stderr redirected to a file, and grep that file. The CLI writes incoming \`"stderr"\` SSE events to its \`os.Stderr\` (\`internal/cli/exec.go:296-302\`), so unixwrap's \`slog "wait_killable=true"\` line lands in the probe file.

Applied uniformly to all 8 \`Dockerfile.test.*\` variants (block was byte-identical across files).

## Test plan
- [x] No Go source changes; \`go test ./...\` not affected.
- [ ] Real validation runs in the next release-workflow firing (tag push). Plan: merge this, retag v0.19.4-rc1, watch the docker-test matrix.

## Note for follow-up

A stronger long-term fix is to have the **server** emit a \`wait_killable\` startup probe (spawn a child that does a no-op \`InstallFilterWithConfig\`, log the result) so operators see Layer 1 status in their server logs without inspecting per-exec stderr. Out of scope for this RC unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)