### PR TITLE
fix(docker-test): drop misplaced wait_killable check

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -239,33 +239,14 @@ else
   exit 1
 fi
 
-# -------------------------------------------------------------------
-# Layer 1 (WAIT_KILLABLE_RECV) engagement check
-#
-# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
-# structured Info log "seccomp: filter loaded ... wait_killable=true"
-# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
-# log goes to unixwrap's stderr, which the server captures per-command
-# and streams back through `agentsh exec` as stderr events. Create a
-# probe session, run a no-op exec with stderr redirected to a file,
-# then grep the file. On the GitHub runner's host kernel (>=6.0) the
-# flag is always supported, so the log MUST appear — false would mean
-# Layer 1 silently degraded, exactly what this entire design exists
-# to prevent.
-# -------------------------------------------------------------------
-probe_sid_json="$(agentsh session create --workspace /tmp --json)"
-probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
-seccomp_probe_log="$tmp/seccomp_probe.log"
-agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
-if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
-  pass "wait_killable=true (Layer 1 engaged)"
-else
-  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant probe log lines ---" >&2
-  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
-  echo "--- full probe log (head -40) ---" >&2
-  head -40 "$seccomp_probe_log" >&2 || true
-fi
+# Layer 1 (WAIT_KILLABLE_RECV) is validated by the unit test
+# TestInstallFilter_EmitsWaitKillEngagedOnSupportedKernel in
+# internal/netmonitor/unix/sigurg_probe_test.go, which re-execs itself
+# with a minimal seccomp filter config and asserts the raw seccomp(2)
+# load path emits wait_killable=true. We don't repeat that check here
+# because this Dockerfile.test config disables sandbox.unix_sockets,
+# so agentsh-unixwrap is never invoked and no Layer 1 filter is
+# installed for the docker matrix to observe.
 
 # -------------------------------------------------------------------
 # Create a session

--- a/Dockerfile.test.alpine
+++ b/Dockerfile.test.alpine
@@ -230,33 +230,14 @@ else
   exit 1
 fi
 
-# -------------------------------------------------------------------
-# Layer 1 (WAIT_KILLABLE_RECV) engagement check
-#
-# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
-# structured Info log "seccomp: filter loaded ... wait_killable=true"
-# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
-# log goes to unixwrap's stderr, which the server captures per-command
-# and streams back through `agentsh exec` as stderr events. Create a
-# probe session, run a no-op exec with stderr redirected to a file,
-# then grep the file. On the GitHub runner's host kernel (>=6.0) the
-# flag is always supported, so the log MUST appear — false would mean
-# Layer 1 silently degraded, exactly what this entire design exists
-# to prevent.
-# -------------------------------------------------------------------
-probe_sid_json="$(agentsh session create --workspace /tmp --json)"
-probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
-seccomp_probe_log="$tmp/seccomp_probe.log"
-agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
-if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
-  pass "wait_killable=true (Layer 1 engaged)"
-else
-  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant probe log lines ---" >&2
-  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
-  echo "--- full probe log (head -40) ---" >&2
-  head -40 "$seccomp_probe_log" >&2 || true
-fi
+# Layer 1 (WAIT_KILLABLE_RECV) is validated by the unit test
+# TestInstallFilter_EmitsWaitKillEngagedOnSupportedKernel in
+# internal/netmonitor/unix/sigurg_probe_test.go, which re-execs itself
+# with a minimal seccomp filter config and asserts the raw seccomp(2)
+# load path emits wait_killable=true. We don't repeat that check here
+# because this Dockerfile.test config disables sandbox.unix_sockets,
+# so agentsh-unixwrap is never invoked and no Layer 1 filter is
+# installed for the docker matrix to observe.
 
 # -------------------------------------------------------------------
 # Create a session

--- a/Dockerfile.test.arch
+++ b/Dockerfile.test.arch
@@ -236,33 +236,14 @@ else
   exit 1
 fi
 
-# -------------------------------------------------------------------
-# Layer 1 (WAIT_KILLABLE_RECV) engagement check
-#
-# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
-# structured Info log "seccomp: filter loaded ... wait_killable=true"
-# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
-# log goes to unixwrap's stderr, which the server captures per-command
-# and streams back through `agentsh exec` as stderr events. Create a
-# probe session, run a no-op exec with stderr redirected to a file,
-# then grep the file. On the GitHub runner's host kernel (>=6.0) the
-# flag is always supported, so the log MUST appear — false would mean
-# Layer 1 silently degraded, exactly what this entire design exists
-# to prevent.
-# -------------------------------------------------------------------
-probe_sid_json="$(agentsh session create --workspace /tmp --json)"
-probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
-seccomp_probe_log="$tmp/seccomp_probe.log"
-agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
-if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
-  pass "wait_killable=true (Layer 1 engaged)"
-else
-  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant probe log lines ---" >&2
-  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
-  echo "--- full probe log (head -40) ---" >&2
-  head -40 "$seccomp_probe_log" >&2 || true
-fi
+# Layer 1 (WAIT_KILLABLE_RECV) is validated by the unit test
+# TestInstallFilter_EmitsWaitKillEngagedOnSupportedKernel in
+# internal/netmonitor/unix/sigurg_probe_test.go, which re-execs itself
+# with a minimal seccomp filter config and asserts the raw seccomp(2)
+# load path emits wait_killable=true. We don't repeat that check here
+# because this Dockerfile.test config disables sandbox.unix_sockets,
+# so agentsh-unixwrap is never invoked and no Layer 1 filter is
+# installed for the docker matrix to observe.
 
 # -------------------------------------------------------------------
 # Create a session

--- a/Dockerfile.test.debian-trixie
+++ b/Dockerfile.test.debian-trixie
@@ -243,33 +243,14 @@ else
   exit 1
 fi
 
-# -------------------------------------------------------------------
-# Layer 1 (WAIT_KILLABLE_RECV) engagement check
-#
-# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
-# structured Info log "seccomp: filter loaded ... wait_killable=true"
-# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
-# log goes to unixwrap's stderr, which the server captures per-command
-# and streams back through `agentsh exec` as stderr events. Create a
-# probe session, run a no-op exec with stderr redirected to a file,
-# then grep the file. On the GitHub runner's host kernel (>=6.0) the
-# flag is always supported, so the log MUST appear — false would mean
-# Layer 1 silently degraded, exactly what this entire design exists
-# to prevent.
-# -------------------------------------------------------------------
-probe_sid_json="$(agentsh session create --workspace /tmp --json)"
-probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
-seccomp_probe_log="$tmp/seccomp_probe.log"
-agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
-if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
-  pass "wait_killable=true (Layer 1 engaged)"
-else
-  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant probe log lines ---" >&2
-  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
-  echo "--- full probe log (head -40) ---" >&2
-  head -40 "$seccomp_probe_log" >&2 || true
-fi
+# Layer 1 (WAIT_KILLABLE_RECV) is validated by the unit test
+# TestInstallFilter_EmitsWaitKillEngagedOnSupportedKernel in
+# internal/netmonitor/unix/sigurg_probe_test.go, which re-execs itself
+# with a minimal seccomp filter config and asserts the raw seccomp(2)
+# load path emits wait_killable=true. We don't repeat that check here
+# because this Dockerfile.test config disables sandbox.unix_sockets,
+# so agentsh-unixwrap is never invoked and no Layer 1 filter is
+# installed for the docker matrix to observe.
 
 # -------------------------------------------------------------------
 # Create a session

--- a/Dockerfile.test.rockylinux10
+++ b/Dockerfile.test.rockylinux10
@@ -239,33 +239,14 @@ else
   exit 1
 fi
 
-# -------------------------------------------------------------------
-# Layer 1 (WAIT_KILLABLE_RECV) engagement check
-#
-# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
-# structured Info log "seccomp: filter loaded ... wait_killable=true"
-# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
-# log goes to unixwrap's stderr, which the server captures per-command
-# and streams back through `agentsh exec` as stderr events. Create a
-# probe session, run a no-op exec with stderr redirected to a file,
-# then grep the file. On the GitHub runner's host kernel (>=6.0) the
-# flag is always supported, so the log MUST appear — false would mean
-# Layer 1 silently degraded, exactly what this entire design exists
-# to prevent.
-# -------------------------------------------------------------------
-probe_sid_json="$(agentsh session create --workspace /tmp --json)"
-probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
-seccomp_probe_log="$tmp/seccomp_probe.log"
-agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
-if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
-  pass "wait_killable=true (Layer 1 engaged)"
-else
-  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant probe log lines ---" >&2
-  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
-  echo "--- full probe log (head -40) ---" >&2
-  head -40 "$seccomp_probe_log" >&2 || true
-fi
+# Layer 1 (WAIT_KILLABLE_RECV) is validated by the unit test
+# TestInstallFilter_EmitsWaitKillEngagedOnSupportedKernel in
+# internal/netmonitor/unix/sigurg_probe_test.go, which re-execs itself
+# with a minimal seccomp filter config and asserts the raw seccomp(2)
+# load path emits wait_killable=true. We don't repeat that check here
+# because this Dockerfile.test config disables sandbox.unix_sockets,
+# so agentsh-unixwrap is never invoked and no Layer 1 filter is
+# installed for the docker matrix to observe.
 
 # -------------------------------------------------------------------
 # Create a session

--- a/Dockerfile.test.rpm
+++ b/Dockerfile.test.rpm
@@ -237,33 +237,14 @@ else
   exit 1
 fi
 
-# -------------------------------------------------------------------
-# Layer 1 (WAIT_KILLABLE_RECV) engagement check
-#
-# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
-# structured Info log "seccomp: filter loaded ... wait_killable=true"
-# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
-# log goes to unixwrap's stderr, which the server captures per-command
-# and streams back through `agentsh exec` as stderr events. Create a
-# probe session, run a no-op exec with stderr redirected to a file,
-# then grep the file. On the GitHub runner's host kernel (>=6.0) the
-# flag is always supported, so the log MUST appear — false would mean
-# Layer 1 silently degraded, exactly what this entire design exists
-# to prevent.
-# -------------------------------------------------------------------
-probe_sid_json="$(agentsh session create --workspace /tmp --json)"
-probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
-seccomp_probe_log="$tmp/seccomp_probe.log"
-agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
-if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
-  pass "wait_killable=true (Layer 1 engaged)"
-else
-  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant probe log lines ---" >&2
-  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
-  echo "--- full probe log (head -40) ---" >&2
-  head -40 "$seccomp_probe_log" >&2 || true
-fi
+# Layer 1 (WAIT_KILLABLE_RECV) is validated by the unit test
+# TestInstallFilter_EmitsWaitKillEngagedOnSupportedKernel in
+# internal/netmonitor/unix/sigurg_probe_test.go, which re-execs itself
+# with a minimal seccomp filter config and asserts the raw seccomp(2)
+# load path emits wait_killable=true. We don't repeat that check here
+# because this Dockerfile.test config disables sandbox.unix_sockets,
+# so agentsh-unixwrap is never invoked and no Layer 1 filter is
+# installed for the docker matrix to observe.
 
 # -------------------------------------------------------------------
 # Create a session

--- a/Dockerfile.test.ubuntu
+++ b/Dockerfile.test.ubuntu
@@ -245,33 +245,14 @@ else
   exit 1
 fi
 
-# -------------------------------------------------------------------
-# Layer 1 (WAIT_KILLABLE_RECV) engagement check
-#
-# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
-# structured Info log "seccomp: filter loaded ... wait_killable=true"
-# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
-# log goes to unixwrap's stderr, which the server captures per-command
-# and streams back through `agentsh exec` as stderr events. Create a
-# probe session, run a no-op exec with stderr redirected to a file,
-# then grep the file. On the GitHub runner's host kernel (>=6.0) the
-# flag is always supported, so the log MUST appear — false would mean
-# Layer 1 silently degraded, exactly what this entire design exists
-# to prevent.
-# -------------------------------------------------------------------
-probe_sid_json="$(agentsh session create --workspace /tmp --json)"
-probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
-seccomp_probe_log="$tmp/seccomp_probe.log"
-agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
-if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
-  pass "wait_killable=true (Layer 1 engaged)"
-else
-  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant probe log lines ---" >&2
-  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
-  echo "--- full probe log (head -40) ---" >&2
-  head -40 "$seccomp_probe_log" >&2 || true
-fi
+# Layer 1 (WAIT_KILLABLE_RECV) is validated by the unit test
+# TestInstallFilter_EmitsWaitKillEngagedOnSupportedKernel in
+# internal/netmonitor/unix/sigurg_probe_test.go, which re-execs itself
+# with a minimal seccomp filter config and asserts the raw seccomp(2)
+# load path emits wait_killable=true. We don't repeat that check here
+# because this Dockerfile.test config disables sandbox.unix_sockets,
+# so agentsh-unixwrap is never invoked and no Layer 1 filter is
+# installed for the docker matrix to observe.
 
 # -------------------------------------------------------------------
 # Create a session

--- a/Dockerfile.test.ubuntu2204
+++ b/Dockerfile.test.ubuntu2204
@@ -310,33 +310,14 @@ else
   exit 1
 fi
 
-# -------------------------------------------------------------------
-# Layer 1 (WAIT_KILLABLE_RECV) engagement check
-#
-# unixwrap (the seccomp-installing wrapper invoked per exec) emits a
-# structured Info log "seccomp: filter loaded ... wait_killable=true"
-# when the kernel accepts SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. That
-# log goes to unixwrap's stderr, which the server captures per-command
-# and streams back through `agentsh exec` as stderr events. Create a
-# probe session, run a no-op exec with stderr redirected to a file,
-# then grep the file. On the GitHub runner's host kernel (>=6.0) the
-# flag is always supported, so the log MUST appear — false would mean
-# Layer 1 silently degraded, exactly what this entire design exists
-# to prevent.
-# -------------------------------------------------------------------
-probe_sid_json="$(agentsh session create --workspace /tmp --json)"
-probe_sid="$(echo "$probe_sid_json" | jq -r '.id')"
-seccomp_probe_log="$tmp/seccomp_probe.log"
-agentsh exec "$probe_sid" -- /bin/true >/dev/null 2>"$seccomp_probe_log" || true
-if grep -q 'wait_killable=true' "$seccomp_probe_log" || grep -q '"wait_killable":true' "$seccomp_probe_log"; then
-  pass "wait_killable=true (Layer 1 engaged)"
-else
-  fail "wait_killable=true in unixwrap stderr" "Layer 1 silently disabled — check seccomp_load_linux.go"
-  echo "--- relevant probe log lines ---" >&2
-  grep -i wait_killable "$seccomp_probe_log" >&2 || echo "(no wait_killable lines in probe log)" >&2
-  echo "--- full probe log (head -40) ---" >&2
-  head -40 "$seccomp_probe_log" >&2 || true
-fi
+# Layer 1 (WAIT_KILLABLE_RECV) is validated by the unit test
+# TestInstallFilter_EmitsWaitKillEngagedOnSupportedKernel in
+# internal/netmonitor/unix/sigurg_probe_test.go, which re-execs itself
+# with a minimal seccomp filter config and asserts the raw seccomp(2)
+# load path emits wait_killable=true. We don't repeat that check here
+# because this Dockerfile.test config disables sandbox.unix_sockets,
+# so agentsh-unixwrap is never invoked and no Layer 1 filter is
+# installed for the docker matrix to observe.
 
 # -------------------------------------------------------------------
 # CGO Linux binaries: libseccomp must be a dynamic dependency


### PR DESCRIPTION
## Summary

The Layer 1 (\`WAIT_KILLABLE_RECV\`) check introduced in #316 was internally inconsistent with the docker-test config: the test runs \`agentsh server\` with \`sandbox.unix_sockets.enabled: false\`, which means \`setupSeccompWrapper\` short-circuits in \`internal/api/core.go\` and \`agentsh-unixwrap\` is never invoked. Without unixwrap running, no Layer 1 seccomp filter is installed, so the \`"seccomp: filter loaded ... wait_killable=true"\` slog line the check greps for cannot exist anywhere — server.log, captured stderr, or any other surface.

PR #332 attempted to fix this by probing through \`agentsh exec\`, but the exec endpoint also short-circuits the wrapper under that config, so the probe stderr came back empty and all 8 docker-test variants kept failing on the v0.19.4-rc1 re-cut.

## Fix

Drop the check from all 8 \`Dockerfile.test.*\` variants. Replace the check block with a comment pointing operators to where Layer 1 IS validated.

## Where Layer 1 is still covered

- **Unit test:** \`internal/netmonitor/unix/sigurg_probe_test.go\` — \`TestInstallFilter_EmitsWaitKillEngagedOnSupportedKernel\` re-execs the test binary with \`FilterConfig{ExecveEnabled:true}\` and asserts \`wait_killable=true\` is present in the combined output. Runs on every \`test-linux\` CI job, so a regression in the raw seccomp(2) load path will fail \`ci.yml\` before any release pipeline runs.
- **Docker matrix:** the \`sigurg_probe\` step still runs against the bind-mounted probe binary in each distro container, verifying the downstream SIGURG behavior \`WAIT_KILLABLE_RECV\` is meant to enable.

## Follow-up

To re-add an end-to-end Layer 1 check in the docker matrix, either:
1. Enable \`sandbox.unix_sockets\` in the test config so unixwrap actually runs, OR
2. Add a \`--probe\` mode to \`agentsh-unixwrap\` that installs the filter, logs the result, and exits.

Both are out of scope for unblocking v0.19.4-rc1.

## Test plan
- [x] No Go source changes; \`go test ./...\` not affected.
- [ ] Validation: merge → re-cut \`v0.19.4-rc1\` → confirm docker-test matrix is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)