### PR TITLE
DB Plan 11 redirect planner

### DIFF
--- a/docs/agentsh-db-access-spec.md
+++ b/docs/agentsh-db-access-spec.md
@@ -71,18 +71,20 @@ Unavoidability rests on AgentSH's existing primitives: process interception, net
 - PostgreSQL wire protocol v3, normal frontend/backend mode.
 - Dialects: `postgres` (full), `aurora_postgres` (full), `redshift` (beta), `cockroachdb` (beta).
 - TLS modes: `terminate_reissue`, `passthrough` (connection-level rules only), `terminate_plaintext_upstream`.
-- Decision verbs: `allow`, `deny`, `approve`, `audit`.
+- Decision verbs: `allow`, `deny`, `approve`, `audit`, plus statement-level `redirect` policy/planner metadata. Runtime redirect execution is DB Plan 12.
 - Two rule families: `database_rules` (statement-level), `database_connection_rules` (connection-level).
 - Per-effect policy evaluation with strict multi-object semantics.
 - CancelRequest correlation (§15).
 - Startup-packet handling for SSLRequest / GSSENCRequest / CancelRequest / StartupMessage (§11.1).
+
+Plan 11 extends this scope by accepting statement-level redirect policy/planner metadata; proxy execution of redirected Simple Query and Extended Query traffic remains DB Plan 12.
 
 ### 2.2 Out of scope for Phase 1
 
 - Replication protocol (CopyBoth, `START_REPLICATION`, walsender, logical decoding). Default-deny per §11.1.
 - GSSAPI encryption (default-deny per §11.1).
 - Column-level masking, row redaction, result-set DLP (Phase 7).
-- Statement rewriting (`redirect`, Phase 2).
+- Runtime statement rewriting / proxy execution for `redirect` (DB Plan 12).
 - Credential brokering (Phase 4).
 - Catalog-aware metadata controls (Phase 7).
 - ORM-level rules.
@@ -94,7 +96,7 @@ Unavoidability rests on AgentSH's existing primitives: process interception, net
 | Phase | Adds |
 |-------|------|
 | Phase 1 | PostgreSQL adapter: classifier, policy evaluation, proxy, CancelRequest mapping, unavoidability bundle, and real-Postgres CI integration. |
-| Phase 2 | Object resolution via upstream catalog. Postgres `redirect` decision (statement rewriting). Improved policy ergonomics. |
+| Phase 2 | Object resolution via upstream catalog. Runtime Postgres `redirect` execution / statement rewriting. Improved policy ergonomics. |
 | Phase 3 | MySQL adapter. |
 | Phase 4 | Credential broker. |
 | Phase 5 | MongoDB adapter. |
@@ -702,12 +704,13 @@ database_rules:
 | `operations` | yes | Group names or aliases. Rule matches an effect whose `group` is in the list. |
 | `subtypes` | no | If specified, rule matches only effects whose `operation_subtype` is in the list. |
 | `match_object_resolution` | no | One of the resolution tags or `*`. Matches against the effect's per-effect resolution tag. |
-| `decision` | yes | `allow`, `deny`, `approve`, `audit`. |
+| `decision` | yes | `allow`, `deny`, `approve`, `audit`, `redirect`. `redirect` is statement-level only and requires `redirect.relation`, `relations`, `match_object_resolution: catalog_resolved`, read-only operations, and an eligible terminate-mode Postgres service. |
+| `redirect.relation` | only for `decision: redirect` | Canonical target relation formatted as `schema.name`. Plan 11 supports one source relation selected by a canonical `relations` entry and one target relation. Runtime execution is wired in DB Plan 12. |
 | `message` | no | Template with `{{.Operation}}, {{.Subtype}}, {{.Schema}}, {{.Object}}, {{.Verb}}, {{.StatementPreview}}`. |
 | `timeout` | only for `approve` | Default 60 seconds. Sized to be safe inside open transactions (§14.5). Operators with long-form approval workflows opt up explicitly per rule. |
 | `acknowledge_audit_on_dangerous` | no | Required `true` to silence the load-time warning emitted when `decision: audit` is paired with operations of risk tier ≥ high (§9.4, R13). |
 
-`objects` remains syntactic-only. `relations` and `functions` are catalog selectors and do not match unresolved or unavailable catalog metadata. Strict object coverage still applies: every object slot in an effect must be covered by an allow/audit/approve rule, and any matching deny rule still wins.
+`objects` remains syntactic-only. `relations` and `functions` are catalog selectors and do not match unresolved or unavailable catalog metadata. Strict object coverage still applies: every object slot in an effect must be covered by an allow/audit/redirect/approve rule, and any matching deny rule still wins.
 
 ### DB policy explain
 
@@ -767,7 +770,7 @@ Connection rules evaluate **before** any statement is classified. A connection-l
 - Statement rule referencing a `db_service` whose `tls_mode` is `passthrough` → **load error**.
 - Connection rule under a `passthrough` service that matches `db_user`, `database`, or `application_name` → load error. (Those fields are not visible in passthrough; see §13.2.)
 - Rule referencing a `db_service` that does not exist → load error.
-- Rule with `decision: redirect` in Phase 1 → load error.
+- Statement rule with malformed `decision: redirect` shape → load error. Connection-rule redirect remains invalid.
 - Rule with `subtypes` referencing a non-existent subtype → load error.
 - Rule with no `db_service` and no `db_family` and `decision: allow` and `operations: ["*"]` → load error (too broad).
 - Service with `tls_mode: terminate_plaintext_upstream` to a non-RFC1918, non-loopback destination without `trusted_network: true` → load error.
@@ -789,8 +792,9 @@ Connection rules evaluate **before** any statement is classified. A connection-l
 | `deny` | Synthesize `ErrorResponse` (SQLSTATE 42501). See §14. | See §13.3. |
 | `approve` | Held; approval flow. On approval, forward. On denial/timeout, behaves as `deny`. | Held until approval. |
 | `audit` | Forward, tag event. Functionally equivalent to allow at the wire; differs only in event labeling and downstream alerting/handling. | Connection established with audit tag. |
+| `redirect` | Statement-level policy decision with structured redirect metadata. Runtime Simple Query and Extended Query execution is DB Plan 12. | Invalid; connection-level redirect is not available. |
 
-`redirect` is Phase 2.
+Plan 11 accepts valid statement-level `redirect` rules and returns redirect policy/planner metadata. Runtime proxy execution remains DB Plan 12.
 
 > **Operator note: `audit` is allow-with-observation, not block-with-observation.** A statement whose final decision is `audit` is **forwarded to the database**. The agent gets a normal response. The only difference from `allow` is that the event carries `decision.verb: "audit"` and downstream Watchtower alerting policies can treat it differently (e.g., page on-call, send to a dedicated SOC queue). Operators who want "observe but block" should use `approve` (which holds the statement until a human decides) or `deny` (which blocks unconditionally). This is a common point of confusion; repeat it wherever sample policies appear.
 
@@ -812,26 +816,35 @@ DENY matching:
   e is denied by rule R if:
     - R.group/subtype matches e.group/e.subtype
     - R.match_object_resolution matches e.object_resolution (or R has none)
-    - any object in e.objects matches R.objects (or R has no objects: clause)
-  → If any deny rule fires for any object in e, decision_i = deny.
+    - any object slot in e matches R's object selector families, or R constrains
+      no object selector family
+  → If any deny rule fires for any object slot in e, decision_i = deny.
   Order-independent: any matching deny anywhere in the policy file produces deny.
 
-ALLOW / AUDIT / APPROVE coverage (strict):
-  Collect all allow/audit/approve rules whose group/subtype/resolution match e.
-  An object o ∈ e.objects is "covered" if some matching rule's objects glob matches o.
-  A rule with no objects: clause covers any object.
+ALLOW / AUDIT / REDIRECT / APPROVE coverage (strict):
+  Collect all allow/audit/redirect/approve rules whose group/subtype/resolution match e.
+  An object slot o is "covered" if some matching rule selects it through at
+  least one object selector family:
+    - objects: syntactic object fields
+    - relations: catalog-resolved relation canonical names for relation slots
+    - functions: catalog-resolved function identities for function slots
+  A rule with no object selector family constrained covers all object slots.
+  Redirect statement rules are not selector-less broad coverage: config
+  validation requires exactly one canonical relations source selector plus
+  redirect.relation.
   Order-independent: any matching coverage rule contributes regardless of position.
 
-  e is fully covered if every object in e.objects is covered by at least one rule.
+  e is fully covered if every object slot in e is covered by at least one rule.
 
   If e is fully covered AND no deny matched:
     The effect-level decision is the most-restrictive verb among the rules that
     cover the object set:
       - If any covering rule has decision: approve → decision_i = approve
+      - Else if any covering rule has decision: redirect → decision_i = redirect
       - Else if any covering rule has decision: audit → decision_i = audit
       - Else                                              decision_i = allow
 
-  If at least one object in e is uncovered:
+  If at least one object slot in e is uncovered:
     decision_i = implicit_deny (regardless of approve coverage on other objects).
 
   If multiple approve rules apply across objects, all approvers are notified;
@@ -841,18 +854,20 @@ ALLOW / AUDIT / APPROVE coverage (strict):
 **Restrictiveness order (most to least):**
 
 ```
-deny  ≡  implicit_deny  >  approve  >  audit  >  allow
+deny  ≡  implicit_deny  >  approve  >  redirect  >  audit  >  allow
 ```
 
 A final decision of `audit` forwards the statement unchanged to upstream. The difference from `allow` is event labeling (`decision.verb: "audit"`) and downstream alerting policies in Watchtower.
 
+A final decision of `redirect` carries structured redirect metadata for the statement. Runtime proxy execution of redirected Simple Query and Extended Query traffic remains DB Plan 12.
+
 A final decision of `approve` holds the statement until a human decides. After approval, the forwarded event carries `decision.verb: "approve"`. Audit-tagged rules that co-cover the object set are recorded in `decision.contributing_audit_rules` (array of rule names) but do not change the verb. Watchtower alerting that targets `decision.verb == audit` does not fire on approved events; alerting that targets `contributing_audit_rules` does.
 
-> **Operator note: `approve` does not cover unrelated uncovered objects.** A common misreading is "approve" = "ask a human for permission for the whole effect." It does not. Each object must independently be covered by `allow`, `audit`, or `approve`. If an effect has objects `{allowed_table, mystery_table}` and a rule says "approve READ on allowed_table" but no rule mentions `mystery_table`, the effect is denied (because `mystery_table` is uncovered → implicit_deny → wins over approve). To get human-in-the-loop on the whole effect, use a rule that matches the broader object set (e.g., `objects: ["*"]` with `decision: approve`), not a narrow rule that happens to match one of the touched objects.
+> **Operator note: `approve` does not cover unrelated uncovered objects.** A common misreading is "approve" = "ask a human for permission for the whole effect." It does not. Each object must independently be covered by `allow`, `audit`, `redirect`, or `approve`. If an effect has objects `{allowed_table, mystery_table}` and a rule says "approve READ on allowed_table" but no rule mentions `mystery_table`, the effect is denied (because `mystery_table` is uncovered → implicit_deny → wins over approve). To get human-in-the-loop on the whole effect, use a rule that matches the broader object set (e.g., `objects: ["*"]` with `decision: approve`), not a narrow rule that happens to match one of the touched objects.
 
 **`match_object_resolution` semantics.** When an effect contains multiple objects with potentially different individual resolution confidences, the effect's resolution tag is the **worst-confidence tag** across all objects in the effect (mirroring §6.2's top-level worst-case computation, applied per-effect). A rule with `match_object_resolution: qualified_syntactic` matches an effect only if every object in that effect is `qualified_syntactic`. This keeps resolution-aware policies conservative.
 
-**Why strict coverage for allow:** an effect that touches multiple objects (`SELECT * FROM allowed_table JOIN sensitive_table`) must have *all* objects covered by an allow rule. A rule that allows reads on `allowed_table` does not automatically allow reads on `sensitive_table`. Operators who want broad allow can still write `objects: ["*"]` or omit `objects:` entirely.
+**Why strict coverage for non-deny decisions:** an effect that touches multiple objects (`SELECT * FROM allowed_table JOIN sensitive_table`) must have *all* objects covered by a non-deny rule. A rule that allows, audits, redirects, or approves reads on `allowed_table` does not automatically cover reads on `sensitive_table`. Operators who want broad coverage can still write `objects: ["*"]` or omit `objects:` entirely.
 
 **Why "any object" for deny:** a single sensitive object in an effect's object set is enough to trigger a deny rule, even if other objects in the same effect are uncontroversial. This is the security-conservative posture. The same JOIN above, if a deny rule names `sensitive_table`, denies the whole statement.
 
@@ -917,9 +932,9 @@ A privacy-sensitive deployment sets `log_statements: parameters_redacted` (or `n
 For each individual effect, rule evaluation is **order-independent**:
 
 - Deny rules trigger on any object match regardless of position in the policy file.
-- Allow / audit / approve rules contribute to the per-object coverage set.
-- The final effect-level decision is the most-restrictive verb among rules that cover the object set, with `deny ≡ implicit_deny > approve > audit > allow` (§10.2).
-- No-match for any object in an effect → `implicit_deny`. Statements are denied unless every object in every effect is covered by at least one allow, audit, or approve rule, and no object is matched by a deny rule.
+- Allow / audit / redirect / approve rules contribute to the per-object coverage set.
+- The final effect-level decision is the most-restrictive verb among rules that cover the object set, with `deny ≡ implicit_deny > approve > redirect > audit > allow` (§10.2).
+- No-match for any object in an effect → `implicit_deny`. Statements are denied unless every object in every effect is covered by at least one allow, audit, redirect, or approve rule, and no object is matched by a deny rule.
 
 Two implementations of the policy evaluator that read this section will produce identical decisions for any (rules, statement) pair. Rule order in the policy file does not affect outcomes; operators may reorder rules for readability without changing semantics.
 
@@ -1369,7 +1384,7 @@ The default config bundle includes a sample `CREATE ROLE` script for Postgres th
 | Classifier panic | Connection terminated. Crash logged. Process does not exit. Per-connection isolation. |
 | Statement rule attached to passthrough service | Config load error. |
 | Connection rule matching invisible field under passthrough | Config load error. |
-| `decision: redirect` in Phase 1 policy | Config load error. |
+| Malformed statement-level `decision: redirect` shape or connection-rule redirect | Config load error. |
 
 ---
 
@@ -1379,7 +1394,7 @@ The default config bundle includes a sample `CREATE ROLE` script for Postgres th
 |-------|-------|--------|
 | 0 | This spec, reviewed and approved. | done |
 | 1 | Postgres adapter. Operation taxonomy with subtypes. Per-effect evaluation with strict object coverage. Two rule families. Event emission. Unavoidability bundle. Transaction correctness. SQL PREPARE/EXECUTE. FunctionCall default-deny. CancelRequest translation. Startup-packet handling. Replication & GSSENC default-deny. | done |
-| 2 | Object resolution via upstream catalog. `redirect` decision (statement rewriting). Improved policy ergonomics. | next |
+| 2 | Object resolution via upstream catalog. Runtime Postgres `redirect` execution / statement rewriting. Improved policy ergonomics. | next |
 | 3 | MySQL adapter. | |
 | 4 | Credential broker (resolves SCRAM-SHA-256-PLUS channel binding). | |
 | 5 | MongoDB adapter. | |
@@ -1574,15 +1589,15 @@ Each entry is a `(wire_bytes_in, expected_classification, expected_decision_unde
 - **Primary effect:** The effect with the highest risk tier, used as the headline classification.
 - **Secondary effects:** Additional effects beyond the primary; participate fully in policy evaluation, not audit-only.
 - **Per-effect evaluation:** Policy decision algorithm where each effect is matched independently against the rule list, with the final decision being the most-restrictive across effects.
-- **Strict object coverage:** For an effect to be allowed, every object in its object set must be covered by at least one allow / audit / approve rule, and no object may be matched by a deny rule.
-- **Asymmetric matching:** Allow / audit / approve use strict coverage; deny uses any-object match.
+- **Strict object coverage:** For an effect to be allowed, audited, redirected, or approved, every object in its object set must be covered by at least one allow / audit / redirect / approve rule, and no object may be matched by a deny rule.
+- **Asymmetric matching:** Allow / audit / redirect / approve use strict coverage; deny uses any-object match.
 - **Risk-tier-first ordering:** Primary effect is the effect with the highest risk tier; ties broken by canonical group order then stable AST traversal order (§5.2).
-- **Order-independent evaluation:** Rule position in the policy file does not affect outcomes. Deny matches anywhere produce deny; allow / audit / approve rules contribute to coverage; most-restrictive verb wins. Operators may reorder rules for readability without changing semantics. (§10.2, §10.4.)
+- **Order-independent evaluation:** Rule position in the policy file does not affect outcomes. Deny matches anywhere produce deny; allow / audit / redirect / approve rules contribute to coverage; most-restrictive verb wins. Operators may reorder rules for readability without changing semantics. (§10.2, §10.4.)
 - **Per-effect resolution:** Confidence tag on object identity, computed and stored independently for each effect.
 - **`implicit_deny`:** The effect-level decision when no rule covers the effect (or some object in it is uncovered). Equivalent to `deny` for restrictiveness purposes.
-- **Most-restrictive decision:** `deny ≡ implicit_deny > approve > audit > allow`.
+- **Most-restrictive decision:** `deny ≡ implicit_deny > approve > redirect > audit > allow`.
 - **Audit (as decision):** Allow-with-observation. The statement is forwarded to the database; the event carries `decision.verb: "audit"`. **Not a block.**
-- **Coverage (for an object):** An allow / audit / approve rule that matches the effect's group/subtype/resolution and whose `objects:` glob matches that specific object (or whose `objects:` clause is absent, which covers all objects).
+- **Coverage (for an object slot):** An allow / audit / redirect / approve rule that matches the effect's group/subtype/resolution and selects that slot through `objects`, `relations`, or `functions`; a rule with no object selector family covers all slots. Redirect statement rules are validated to use exactly one canonical `relations` source selector plus `redirect.relation`.
 - **Classifier:** Per-protocol component that parses a wire frame into a `ClassifiedStatement`.
 - **DBEvent:** Normalized per-statement event emitted by the proxy.
 - **db_service:** Operator-named upstream database, analogous to `http_services`.
@@ -1643,11 +1658,11 @@ Per §20. The policy evaluator should be implementable and testable independentl
 
 Required test categories:
 
-- Strict object coverage (allow, audit, approve cases).
+- Strict object coverage (allow, audit, redirect, approve cases).
 - Implicit deny on uncovered objects.
 - `audit` as coverage (forward + tag).
 - `approve` does not extend coverage to unrelated objects.
-- Deny precedence over allow / audit / approve.
+- Deny precedence over allow / audit / redirect / approve.
 - `match_object_resolution` per-effect.
 - Multi-effect statements with mixed decisions.
 - Risk-tier-first primary effect ordering.

--- a/docs/superpowers/plans/2026-05-14-db-plan-12-redirect-runtime-integration.md
+++ b/docs/superpowers/plans/2026-05-14-db-plan-12-redirect-runtime-integration.md
@@ -1,0 +1,1944 @@
+# DB Plan 12 Redirect Runtime Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire DB Plan 11 redirect plans into the Postgres proxy runtime for Simple Query and Extended Query `Parse`, with prepared-cache metadata, audit fields, fail-closed behavior, and real Postgres integration coverage.
+
+**Architecture:** Keep SQL rewrite logic in the Plan 11 redirect planner. Add a small Linux-only proxy runtime adapter that converts policy decisions plus classified/resolved statements into local redirect runtime plans. Simple Query forwards rewritten `Query` frames; Extended Query redirects only at `Parse`, caches rewritten metadata under the original client prepared statement name, preserves it through `Bind` portal cache copies, and emits redirect audit fields for redirected execution.
+
+**Tech Stack:** Go, `pgproto3`, `pgx/v5`, existing Postgres classifier/catalog/policy/proxy packages, existing `internal/integration` Docker-backed real Postgres harness.
+
+---
+
+## Dependency Gate
+
+This plan depends on DB Plan 11. Execute it only on a branch where the Plan 11 redirect planner contract is present.
+
+Required Plan 11 capabilities:
+
+- Policy decode accepts statement `decision: redirect`.
+- Policy evaluation can return a redirect decision without treating it as deny.
+- A planner package exists that accepts a resolved read-only statement plus redirect action and returns rewritten SQL, source relation, target relation, redirect rule id/name, and rejection reason.
+- The planner rejects writes, DDL, COPY, FunctionCall, unresolved objects, missing target relations, and multi-statement inputs.
+
+Do not implement planner logic in Plan 12. If this gate fails, stop and implement or merge DB Plan 11 first.
+
+---
+
+## File Structure
+
+- Modify `internal/db/events/event.go`: add redirect audit fields to `events.DBEvent`.
+- Modify `internal/db/events/event_test.go`: add redirect JSON round-trip coverage.
+- Modify `internal/db/proxy/postgres/eventbuilder.go`: add redirect inputs to `buildArgs`, compute rewritten digest, and populate DBEvent redirect fields.
+- Modify `internal/db/proxy/postgres/eventbuilder_test.go`: cover original digest preservation and rewritten digest population.
+- Modify `internal/db/proxy/postgres/preparedcache/cache.go`: add redirect metadata to prepared-cache entries.
+- Modify `internal/db/proxy/postgres/preparedcache/cache_test.go`: cover metadata round-trip and replacement.
+- Create `internal/db/proxy/postgres/redirect_runtime.go`: isolate the runtime adapter around the Plan 11 planner contract, digest helpers, and fail-closed redirect event helpers.
+- Create `internal/db/proxy/postgres/redirect_runtime_test.go`: unit-test adapter validation without touching the planner internals.
+- Modify `internal/db/proxy/postgres/simplequery.go`: redirect Simple Query before the allow path, forward rewritten SQL, and fail closed on runtime rejection.
+- Modify `internal/db/proxy/postgres/simplequery_test.go`: unit-test rewritten forwarding, deny precedence, fail-closed no-forward, and event fields.
+- Modify `internal/db/proxy/postgres/extquery.go`: handle redirected `Parse`, preserve full redirect metadata through `Bind`, queue redirected `Execute` audit entries, and emit them after `Sync` drain.
+- Modify `internal/db/proxy/postgres/extquery_spine_test.go`: unit-test redirected Parse forwarding, named prepared statement cache metadata, Bind/Execute no re-planning, and Parse fail-closed behavior.
+- Create `internal/db/proxy/postgres/redirect_integration_test.go`: direct-proxy real Postgres redirect tests for policy reload on an open connection.
+- Modify `internal/integration/db07cclient/main.go`: add helper modes for repeated prepared execution and policy reload probes.
+- Modify `internal/integration/db_postgres_07c_test.go`: add DB Plan 12 real Postgres redirect tests.
+
+---
+
+## Task 0: Verify Plan 11 Is Present
+
+**Files:**
+- Read: `internal/db/policy/types.go`
+- Read: `internal/db/policy/validate.go`
+- Read: Plan 11 planner package path from the branch under test
+- No code changes
+
+- [ ] **Step 1: Verify policy redirect support exists**
+
+Run:
+
+```bash
+rg -n "VerbRedirect|redirect" internal/db/policy
+```
+
+Expected: output includes a redirect decision verb or equivalent Plan 11 redirect action support. `internal/db/policy/validate.go` must not still reject statement `decision: redirect` with `redirect_not_supported_until_plan_11`.
+
+- [ ] **Step 2: Verify planner package exists**
+
+Run:
+
+```bash
+rg -n "type .*Plan|type .*Planner|RewrittenSQL|RejectionReason|TargetRelation" internal/db
+```
+
+Expected: output includes the Plan 11 redirect planner package and a result type carrying rewritten SQL, redirect rule, source relation, target relation, and rejection reason.
+
+- [ ] **Step 3: Stop if the gate fails**
+
+If Step 1 or Step 2 fails, do not continue with Plan 12. Finish DB Plan 11 first, then restart this plan from Task 1.
+
+No commit for this task.
+
+---
+
+## Task 1: Add Redirect Audit Fields
+
+**Files:**
+- Modify: `internal/db/events/event.go`
+- Modify: `internal/db/events/event_test.go`
+
+- [ ] **Step 1: Write failing DBEvent JSON test**
+
+Add this test to `internal/db/events/event_test.go`.
+
+```go
+func TestDBEvent_RedirectMetadataRoundTrip(t *testing.T) {
+	in := DBEvent{
+		EventID:                  "db-redirect-1",
+		SessionID:                "sess-1",
+		Timestamp:                time.Date(2026, 5, 14, 13, 0, 0, 0, time.UTC),
+		DBService:                "appdb",
+		DBFamily:                 "postgres",
+		DBDialect:                "postgres",
+		StatementDigest:          "sha256:original",
+		RewrittenStatementDigest: "sha256:rewritten",
+		Redirected:               true,
+		RedirectRule:             "redirect-users-to-safe-users",
+		RedirectSourceRelation:   "public.users",
+		RedirectTargetRelation:   "public.safe_users",
+		RedirectRuntimeStatus:    "executed",
+		StatementRedaction:       RedactionParametersRedacted,
+	}
+
+	raw, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	s := string(raw)
+	for _, want := range []string{
+		`"redirected":true`,
+		`"redirect_rule":"redirect-users-to-safe-users"`,
+		`"rewritten_statement_digest":"sha256:rewritten"`,
+		`"redirect_source_relation":"public.users"`,
+		`"redirect_target_relation":"public.safe_users"`,
+		`"redirect_runtime_status":"executed"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("json %s missing %s", s, want)
+		}
+	}
+
+	var out DBEvent
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !out.Redirected || out.RedirectRule != in.RedirectRule || out.RewrittenStatementDigest != in.RewrittenStatementDigest {
+		t.Fatalf("redirect fields lost: %+v", out)
+	}
+	if out.StatementDigest != "sha256:original" {
+		t.Fatalf("StatementDigest = %q, want original digest", out.StatementDigest)
+	}
+}
+
+func TestDBEvent_RedirectRejectionRoundTrip(t *testing.T) {
+	in := DBEvent{
+		EventID:                  "db-redirect-reject-1",
+		SessionID:                "sess-1",
+		Timestamp:                time.Date(2026, 5, 14, 13, 1, 0, 0, time.UTC),
+		DBService:                "appdb",
+		DBFamily:                 "postgres",
+		DBDialect:                "postgres",
+		StatementDigest:          "sha256:original",
+		Redirected:               true,
+		RedirectRule:             "redirect-users-to-safe-users",
+		RedirectSourceRelation:   "public.users",
+		RedirectTargetRelation:   "public.safe_users",
+		RedirectRuntimeStatus:    "rejected",
+		RedirectRejectionReason:  "unsupported_statement",
+		StatementRedaction:       RedactionParametersRedacted,
+		Result:                   EventResult{ErrorCode: "0A000"},
+		TxContext:                EventTxContext{DenyAction: "none"},
+	}
+
+	raw, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out DBEvent
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.RedirectRuntimeStatus != "rejected" || out.RedirectRejectionReason != "unsupported_statement" {
+		t.Fatalf("redirect rejection fields lost: %+v", out)
+	}
+}
+```
+
+- [ ] **Step 2: Run the failing event tests**
+
+Run:
+
+```bash
+go test ./internal/db/events -run 'TestDBEvent_Redirect.*RoundTrip' -count=1
+```
+
+Expected: FAIL because redirect fields do not exist on `DBEvent`.
+
+- [ ] **Step 3: Add fields to DBEvent**
+
+In `internal/db/events/event.go`, add these fields immediately after the statement fields.
+
+```go
+	StatementDigest    string    `json:"statement_digest,omitempty"`
+	StatementText      string    `json:"statement_text,omitempty"`
+	StatementRedaction Redaction `json:"statement_redaction"`
+
+	Redirected               bool   `json:"redirected,omitempty"`
+	RedirectRule             string `json:"redirect_rule,omitempty"`
+	RewrittenStatementDigest string `json:"rewritten_statement_digest,omitempty"`
+	RedirectSourceRelation   string `json:"redirect_source_relation,omitempty"`
+	RedirectTargetRelation   string `json:"redirect_target_relation,omitempty"`
+	RedirectRuntimeStatus    string `json:"redirect_runtime_status,omitempty"`
+	RedirectRejectionReason  string `json:"redirect_rejection_reason,omitempty"`
+```
+
+Update the `EventDecision` comment to include redirect:
+
+```go
+// EventDecision mirrors spec §8 decision{}. Verb is one of "allow"|"deny"|
+// "approve"|"audit"|"redirect".
+```
+
+- [ ] **Step 4: Run event tests**
+
+Run:
+
+```bash
+go test ./internal/db/events -run 'TestDBEvent_Redirect.*RoundTrip|TestDBEvent_' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit event schema**
+
+Run:
+
+```bash
+git add internal/db/events/event.go internal/db/events/event_test.go
+git commit -m "db/events: add redirect audit fields"
+```
+
+---
+
+## Task 2: Add Event Builder Redirect Inputs
+
+**Files:**
+- Modify: `internal/db/proxy/postgres/eventbuilder.go`
+- Modify: `internal/db/proxy/postgres/eventbuilder_test.go`
+
+- [ ] **Step 1: Write failing event builder test**
+
+Add this test to `internal/db/proxy/postgres/eventbuilder_test.go`.
+
+```go
+func TestBuildStatementEvent_RedirectMetadataPreservesOriginalDigest(t *testing.T) {
+	parser := classify_pg.New(classify_pg.DialectPostgres)
+	stmt := effects.ClassifiedStatement{
+		RawVerb: "SELECT",
+		Effects: []effects.Effect{{
+			Group:      effects.GroupRead,
+			Subtype:   effects.SubtypeSelect,
+			Resolution: effects.ResolutionCatalogResolved,
+			Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Schema: "public", Name: "users"}},
+		}},
+	}
+
+	ev := buildStatementEvent(buildArgs{
+		Stmt:       stmt,
+		StmtIndex:  0,
+		BatchTotal: 1,
+		Decision: policy.Decision{
+			Verb:                policy.VerbRedirect,
+			RuleKind:            policy.RuleKindStatement,
+			RuleName:            "redirect-users",
+			MatchingEffectIndex: 0,
+			MatchingEffectGroup: effects.GroupRead,
+		},
+		SQL:      "select id from public.users",
+		Tier:     policy.RedactParametersRedacted,
+		Conn:     connState{dbService: "appdb", smState: &statemachine.ConnState{LastUpstreamRFQ: 'I'}},
+		BatchSHA: sha256HexBatch("select id from public.users"),
+		Parser:   parser,
+		Redirect: redirectEventArgs{
+			Redirected:               true,
+			Rule:                     "redirect-users",
+			RewrittenSQL:             "select id from public.safe_users",
+			SourceRelation:           "public.users",
+			TargetRelation:           "public.safe_users",
+			RuntimeStatus:            "executed",
+		},
+	})
+
+	if !ev.Redirected {
+		t.Fatalf("Redirected = false")
+	}
+	if ev.RedirectRule != "redirect-users" {
+		t.Fatalf("RedirectRule = %q", ev.RedirectRule)
+	}
+	if ev.RedirectSourceRelation != "public.users" || ev.RedirectTargetRelation != "public.safe_users" {
+		t.Fatalf("redirect relations = %q -> %q", ev.RedirectSourceRelation, ev.RedirectTargetRelation)
+	}
+	if ev.RedirectRuntimeStatus != "executed" {
+		t.Fatalf("RedirectRuntimeStatus = %q", ev.RedirectRuntimeStatus)
+	}
+	if ev.StatementDigest == "" || ev.RewrittenStatementDigest == "" {
+		t.Fatalf("digests missing: original=%q rewritten=%q", ev.StatementDigest, ev.RewrittenStatementDigest)
+	}
+	if ev.StatementDigest == ev.RewrittenStatementDigest {
+		t.Fatalf("original and rewritten digests must differ: %q", ev.StatementDigest)
+	}
+	if ev.StatementText != "select id from public.users" {
+		t.Fatalf("StatementText = %q, want original statement text", ev.StatementText)
+	}
+}
+```
+
+- [ ] **Step 2: Run the failing event builder test**
+
+Run:
+
+```bash
+go test ./internal/db/proxy/postgres -run TestBuildStatementEvent_RedirectMetadataPreservesOriginalDigest -count=1
+```
+
+Expected: FAIL because `buildArgs.Redirect`, `redirectEventArgs`, and `policy.VerbRedirect` are missing until Plan 11 and this task land.
+
+- [ ] **Step 3: Add redirect event args and digest helper**
+
+In `internal/db/proxy/postgres/eventbuilder.go`, add:
+
+```go
+type redirectEventArgs struct {
+	Redirected              bool
+	Rule                    string
+	RewrittenSQL            string
+	RewrittenStatementDigest string
+	SourceRelation          string
+	TargetRelation          string
+	RuntimeStatus           string
+	RejectionReason         string
+}
+```
+
+Add this field to `buildArgs`:
+
+```go
+	Redirect redirectEventArgs
+```
+
+Extract the existing digest logic into a helper:
+
+```go
+func statementDigest(parser classify_pg.Parser, sql string) string {
+	normalized, err := parser.Normalize(sql)
+	if err != nil || normalized == "" {
+		normalized = strings.TrimSpace(sql)
+	}
+	digestBytes := sha256.Sum256([]byte(normalized))
+	return "sha256:" + hex.EncodeToString(digestBytes[:])
+}
+```
+
+Replace the existing inline digest calculation in `buildStatementEvent` with:
+
+```go
+	digest := statementDigest(a.Parser, slice)
+```
+
+Before the `return events.DBEvent{...}`, compute rewritten digest:
+
+```go
+	rewrittenDigest := a.Redirect.RewrittenStatementDigest
+	if rewrittenDigest == "" && a.Redirect.RewrittenSQL != "" {
+		rewrittenDigest = statementDigest(a.Parser, a.Redirect.RewrittenSQL)
+	}
+```
+
+Populate the event fields in the returned `events.DBEvent`:
+
+```go
+		Redirected:               a.Redirect.Redirected,
+		RedirectRule:             a.Redirect.Rule,
+		RewrittenStatementDigest: rewrittenDigest,
+		RedirectSourceRelation:   a.Redirect.SourceRelation,
+		RedirectTargetRelation:   a.Redirect.TargetRelation,
+		RedirectRuntimeStatus:    a.Redirect.RuntimeStatus,
+		RedirectRejectionReason:  a.Redirect.RejectionReason,
+```
+
+- [ ] **Step 4: Run event builder tests**
+
+Run:
+
+```bash
+go test ./internal/db/proxy/postgres -run 'TestBuildStatementEvent_RedirectMetadataPreservesOriginalDigest|TestBuildStatementEvent' -count=1
+```
+
+Expected: PASS after Plan 11 has introduced `policy.VerbRedirect`. If Plan 11 uses a different exported redirect constant, update only this test and any local comparisons to that actual constant.
+
+- [ ] **Step 5: Commit event builder wiring**
+
+Run:
+
+```bash
+git add internal/db/proxy/postgres/eventbuilder.go internal/db/proxy/postgres/eventbuilder_test.go
+git commit -m "db/proxy: populate redirect event metadata"
+```
+
+---
+
+## Task 3: Extend Prepared Cache Metadata
+
+**Files:**
+- Modify: `internal/db/proxy/postgres/preparedcache/cache.go`
+- Modify: `internal/db/proxy/postgres/preparedcache/cache_test.go`
+
+- [ ] **Step 1: Write failing cache tests**
+
+Add these tests to `internal/db/proxy/postgres/preparedcache/cache_test.go`.
+
+```go
+func TestCache_RedirectMetadataRoundTrip(t *testing.T) {
+	c := New(2)
+	entry := Entry{
+		Classification: effects.ClassifiedStatement{RawVerb: "SELECT"},
+		Redirect: &RedirectMetadata{
+			OriginalClassification: effects.ClassifiedStatement{RawVerb: "SELECT"},
+			OriginalSQL: "select note from public.users",
+			OriginalStatementDigest: "sha256:original",
+			RewrittenStatementDigest: "sha256:rewritten",
+			Rule: "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+			PolicyIdentity: "redirect-users",
+		},
+	}
+	c.Put("stmt", entry)
+
+	got, ok := c.Get("stmt")
+	if !ok {
+		t.Fatal("cache miss")
+	}
+	if got.Redirect == nil {
+		t.Fatal("Redirect metadata missing")
+	}
+	if got.Redirect.Rule != "redirect-users" || got.Redirect.TargetRelation != "public.safe_users" {
+		t.Fatalf("Redirect metadata = %+v", got.Redirect)
+	}
+}
+
+func TestCache_RedirectMetadataReplacementClearsOldValue(t *testing.T) {
+	c := New(2)
+	c.Put("stmt", Entry{
+		Classification: effects.ClassifiedStatement{RawVerb: "SELECT"},
+		Redirect:       &RedirectMetadata{Rule: "redirect-users"},
+	})
+	c.Put("stmt", Entry{Classification: effects.ClassifiedStatement{RawVerb: "SELECT"}})
+
+	got, ok := c.Get("stmt")
+	if !ok {
+		t.Fatal("cache miss")
+	}
+	if got.Redirect != nil {
+		t.Fatalf("old redirect metadata leaked after replacement: %+v", got.Redirect)
+	}
+}
+```
+
+- [ ] **Step 2: Run failing cache tests**
+
+Run:
+
+```bash
+go test ./internal/db/proxy/postgres/preparedcache -run 'TestCache_RedirectMetadata' -count=1
+```
+
+Expected: FAIL because `RedirectMetadata` and `Entry.Redirect` do not exist.
+
+- [ ] **Step 3: Add redirect metadata type**
+
+In `internal/db/proxy/postgres/preparedcache/cache.go`, add:
+
+```go
+// RedirectMetadata captures parse-time redirect state for wire-protocol
+// prepared statements. Classification on Entry is the rewritten statement;
+// OriginalClassification keeps the client statement for audit.
+type RedirectMetadata struct {
+	OriginalClassification effects.ClassifiedStatement
+	OriginalSQL string
+	OriginalStatementDigest string
+	RewrittenStatementDigest string
+	Rule string
+	SourceRelation string
+	TargetRelation string
+	PolicyIdentity string
+}
+```
+
+Add this field to `Entry`:
+
+```go
+	Redirect *RedirectMetadata
+```
+
+- [ ] **Step 4: Run cache tests**
+
+Run:
+
+```bash
+go test ./internal/db/proxy/postgres/preparedcache -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit cache metadata**
+
+Run:
+
+```bash
+git add internal/db/proxy/postgres/preparedcache/cache.go internal/db/proxy/postgres/preparedcache/cache_test.go
+git commit -m "db/proxy: cache redirect metadata for prepared statements"
+```
+
+---
+
+## Task 4: Add Redirect Runtime Adapter
+
+**Files:**
+- Create: `internal/db/proxy/postgres/redirect_runtime.go`
+- Create: `internal/db/proxy/postgres/redirect_runtime_test.go`
+
+- [ ] **Step 1: Create adapter tests with a fake planner**
+
+Create `internal/db/proxy/postgres/redirect_runtime_test.go`.
+
+```go
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+	"github.com/agentsh/agentsh/internal/db/policy"
+)
+
+type fakeRedirectPlanner struct {
+	plan redirectRuntimePlan
+	err  error
+	calls int
+}
+
+func (f *fakeRedirectPlanner) PlanRedirect(context.Context, redirectRuntimeInput) (redirectRuntimePlan, error) {
+	f.calls++
+	if f.err != nil {
+		return redirectRuntimePlan{}, f.err
+	}
+	return f.plan, nil
+}
+
+func TestRedirectRuntime_PlansAndClassifiesRewrittenSQL(t *testing.T) {
+	pc, _, _ := newSimpleQueryFixture(t)
+	planner := &fakeRedirectPlanner{plan: redirectRuntimePlan{
+		RewrittenSQL:    "select id from public.safe_users",
+		Rule:            "redirect-users",
+		SourceRelation:  "public.users",
+		TargetRelation:  "public.safe_users",
+		RuntimeStatus:   "planned",
+	}}
+	pc.redirectPlanner = planner
+
+	stmt := effects.ClassifiedStatement{
+		RawVerb: "SELECT",
+		Effects: []effects.Effect{{
+			Group: effects.GroupRead,
+			Objects: []effects.ObjectRef{{Kind: effects.ObjectTable, Schema: "public", Name: "users"}},
+		}},
+	}
+	decision := policy.Decision{Verb: policy.VerbRedirect, RuleName: "redirect-users", RuleKind: policy.RuleKindStatement}
+
+	plan, ok := pc.planRuntimeRedirect(context.Background(), "select id from public.users", stmt, decision)
+	if !ok {
+		t.Fatalf("planRuntimeRedirect rejected: %+v", plan)
+	}
+	if planner.calls != 1 {
+		t.Fatalf("planner calls = %d, want 1", planner.calls)
+	}
+	if plan.RewrittenSQL != "select id from public.safe_users" || len(plan.RewrittenStatements) != 1 {
+		t.Fatalf("unexpected runtime plan: %+v", plan)
+	}
+	if plan.RewrittenStatements[0].RawVerb != "SELECT" {
+		t.Fatalf("rewritten classification = %+v", plan.RewrittenStatements)
+	}
+	if plan.RewrittenStatementDigest == "" {
+		t.Fatalf("rewritten digest missing")
+	}
+}
+
+func TestRedirectRuntime_FailsClosedOnPlannerError(t *testing.T) {
+	pc, _, _ := newSimpleQueryFixture(t)
+	pc.redirectPlanner = &fakeRedirectPlanner{err: errors.New("unsupported_statement")}
+
+	stmt := effects.ClassifiedStatement{RawVerb: "SELECT", Effects: []effects.Effect{{Group: effects.GroupRead}}}
+	decision := policy.Decision{Verb: policy.VerbRedirect, RuleName: "redirect-users", RuleKind: policy.RuleKindStatement}
+
+	plan, ok := pc.planRuntimeRedirect(context.Background(), "select 1", stmt, decision)
+	if ok {
+		t.Fatalf("planRuntimeRedirect unexpectedly succeeded: %+v", plan)
+	}
+	if plan.RejectionReason == "" {
+		t.Fatalf("rejection reason missing: %+v", plan)
+	}
+}
+
+func TestRedirectRuntime_FailsClosedOnUnsafeReclassification(t *testing.T) {
+	pc, _, _ := newSimpleQueryFixture(t)
+	pc.redirectPlanner = &fakeRedirectPlanner{plan: redirectRuntimePlan{
+		RewrittenSQL:     "delete from public.safe_users",
+		Rule:             "redirect-users",
+		SourceRelation:   "public.users",
+		TargetRelation:   "public.safe_users",
+	}}
+
+	stmt := effects.ClassifiedStatement{RawVerb: "SELECT", Effects: []effects.Effect{{Group: effects.GroupRead}}}
+	decision := policy.Decision{Verb: policy.VerbRedirect, RuleName: "redirect-users", RuleKind: policy.RuleKindStatement}
+
+	plan, ok := pc.planRuntimeRedirect(context.Background(), "select 1", stmt, decision)
+	if ok {
+		t.Fatalf("unsafe rewritten SQL unexpectedly accepted: %+v", plan)
+	}
+	if plan.RejectionReason != "rewritten_statement_not_read_only" {
+		t.Fatalf("RejectionReason = %q", plan.RejectionReason)
+	}
+}
+```
+
+- [ ] **Step 2: Run failing adapter tests**
+
+Run:
+
+```bash
+go test ./internal/db/proxy/postgres -run TestRedirectRuntime -count=1
+```
+
+Expected: FAIL because the adapter types and `proxyConn.redirectPlanner` do not exist.
+
+- [ ] **Step 3: Add adapter implementation**
+
+Create `internal/db/proxy/postgres/redirect_runtime.go`.
+
+```go
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	classify_pg "github.com/agentsh/agentsh/internal/db/classify/postgres"
+	"github.com/agentsh/agentsh/internal/db/effects"
+	"github.com/agentsh/agentsh/internal/db/policy"
+)
+
+const sqlstateRedirectRejected = "0A000"
+
+type redirectRuntimePlanner interface {
+	PlanRedirect(context.Context, redirectRuntimeInput) (redirectRuntimePlan, error)
+}
+
+type redirectRuntimeInput struct {
+	SQL      string
+	Stmt     effects.ClassifiedStatement
+	Decision policy.Decision
+	Rule     policy.StatementRule
+	Service  policy.ServiceID
+}
+
+type redirectRuntimePlan struct {
+	RewrittenSQL             string
+	RewrittenStatements      []effects.ClassifiedStatement
+	OriginalStatementDigest  string
+	RewrittenStatementDigest string
+	Rule                     string
+	SourceRelation           string
+	TargetRelation           string
+	RuntimeStatus            string
+	RejectionReason          string
+}
+
+func (pc *proxyConn) activeRedirectPlanner() redirectRuntimePlanner {
+	if pc.redirectPlanner != nil {
+		return pc.redirectPlanner
+	}
+	return plan11RedirectPlanner{}
+}
+
+func (pc *proxyConn) planRuntimeRedirect(
+	ctx context.Context,
+	sql string,
+	stmt effects.ClassifiedStatement,
+	decision policy.Decision,
+) (redirectRuntimePlan, bool) {
+	parser := pc.resolvingParser(pc.svc.Dialect)
+	rule := lookupStatementRuleByName(pc.srv.policy(), decision.RuleName)
+	input := redirectRuntimeInput{
+		SQL:      sql,
+		Stmt:     stmt,
+		Decision: decision,
+		Rule:     rule,
+		Service:  policy.ServiceID(pc.svc.Name),
+	}
+	plan, err := pc.activeRedirectPlanner().PlanRedirect(ctx, input)
+	if err != nil {
+		plan.RejectionReason = err.Error()
+		plan.RuntimeStatus = "rejected"
+		return plan, false
+	}
+	if plan.Rule == "" {
+		plan.Rule = decision.RuleName
+	}
+	if plan.RewrittenSQL == "" {
+		plan.RejectionReason = "empty_rewritten_statement"
+		plan.RuntimeStatus = "rejected"
+		return plan, false
+	}
+	opts := classifierOptionsFromPolicy(pc.srv.policy())
+	rewritten, err := parser.Classify(plan.RewrittenSQL, classify_pg.SessionState{}, opts)
+	if err != nil || len(rewritten) != 1 {
+		plan.RejectionReason = "rewritten_statement_unclassifiable"
+		plan.RuntimeStatus = "rejected"
+		return plan, false
+	}
+	if !statementIsReadOnly(rewritten[0]) {
+		plan.RejectionReason = "rewritten_statement_not_read_only"
+		plan.RuntimeStatus = "rejected"
+		return plan, false
+	}
+	plan.RewrittenStatements = rewritten
+	plan.OriginalStatementDigest = statementDigest(parser, sql)
+	plan.RewrittenStatementDigest = statementDigest(parser, plan.RewrittenSQL)
+	plan.RuntimeStatus = "planned"
+	return plan, true
+}
+
+func statementIsReadOnly(stmt effects.ClassifiedStatement) bool {
+	if len(stmt.Effects) == 0 {
+		return false
+	}
+	for _, eff := range stmt.Effects {
+		if eff.Group != effects.GroupRead {
+			return false
+		}
+	}
+	return true
+}
+
+func redirectEventFromPlan(plan redirectRuntimePlan, status string) redirectEventArgs {
+	if status == "" {
+		status = plan.RuntimeStatus
+	}
+	return redirectEventArgs{
+		Redirected:                true,
+		Rule:                      plan.Rule,
+		RewrittenSQL:              plan.RewrittenSQL,
+		RewrittenStatementDigest:  plan.RewrittenStatementDigest,
+		SourceRelation:            plan.SourceRelation,
+		TargetRelation:            plan.TargetRelation,
+		RuntimeStatus:             status,
+		RejectionReason:           plan.RejectionReason,
+	}
+}
+
+type plan11RedirectPlanner struct{}
+
+func (plan11RedirectPlanner) PlanRedirect(ctx context.Context, input redirectRuntimeInput) (redirectRuntimePlan, error) {
+	_ = ctx
+	_ = input
+	return redirectRuntimePlan{}, fmt.Errorf("plan11_redirect_planner_unwired")
+}
+```
+
+Add this field to `proxyConn` in `internal/db/proxy/postgres/proxyconn.go`:
+
+```go
+	redirectPlanner redirectRuntimePlanner
+```
+
+After this compiles, replace the `plan11RedirectPlanner` stub body with the real Plan 11 package call. Keep all Plan 11 import and type mapping inside `redirect_runtime.go`. The final method must return a local `redirectRuntimePlan`, not Plan 11 package types.
+
+- [ ] **Step 4: Run adapter tests**
+
+Run:
+
+```bash
+go test ./internal/db/proxy/postgres -run TestRedirectRuntime -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit adapter**
+
+Run:
+
+```bash
+git add internal/db/proxy/postgres/redirect_runtime.go internal/db/proxy/postgres/redirect_runtime_test.go internal/db/proxy/postgres/proxyconn.go
+git commit -m "db/proxy: add redirect runtime adapter"
+```
+
+---
+
+## Task 5: Wire Simple Query Redirect
+
+**Files:**
+- Modify: `internal/db/proxy/postgres/simplequery.go`
+- Modify: `internal/db/proxy/postgres/simplequery_test.go`
+
+- [ ] **Step 1: Write failing Simple Query tests**
+
+Add tests to `internal/db/proxy/postgres/simplequery_test.go` that use `fakeRedirectPlanner`.
+Add `errors` to the import block; `net`, `pgproto3`, `events`, and `policy` are already imported in this file.
+
+```go
+func TestHandleQuery_RedirectForwardsRewrittenSQL(t *testing.T) {
+	pc, clientFE, sink := newSimpleQueryFixture(t)
+	pc.srv.SetPolicy(redirectReadRuleSet(t))
+	pc.redirectPlanner = &fakeRedirectPlanner{plan: redirectRuntimePlan{
+		RewrittenSQL:    "select note from public.safe_users",
+		Rule:            "redirect-users",
+		SourceRelation:  "public.users",
+		TargetRelation:  "public.safe_users",
+	}}
+
+	upClient, upServer := net.Pipe()
+	t.Cleanup(func() { _ = upClient.Close(); _ = upServer.Close() })
+	pc.state.upstream = upServer
+	pc.state.upstreamFE = pgproto3.NewFrontend(upServer, upServer)
+	upBackend := pgproto3.NewBackend(upClient, upClient)
+	drainClientBackendMessages(clientFE)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- pc.handleQuery(context.Background(), &pgproto3.Query{String: "select note from public.users"})
+	}()
+
+	msg, err := upBackend.Receive()
+	if err != nil {
+		t.Fatalf("upstream Receive: %v", err)
+	}
+	q, ok := msg.(*pgproto3.Query)
+	if !ok {
+		t.Fatalf("upstream got %T", msg)
+	}
+	if q.String != "select note from public.safe_users" {
+		t.Fatalf("forwarded SQL = %q", q.String)
+	}
+	upBackend.Send(&pgproto3.CommandComplete{CommandTag: []byte("SELECT 0")})
+	upBackend.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+	if err := upBackend.Flush(); err != nil {
+		t.Fatalf("upstream flush: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("handleQuery: %v", err)
+	}
+
+	evs := sink.DrainStatements()
+	if len(evs) != 1 {
+		t.Fatalf("events = %d: %+v", len(evs), evs)
+	}
+	ev := evs[0]
+	if !ev.Redirected || ev.RedirectRule != "redirect-users" || ev.RedirectRuntimeStatus != "executed" {
+		t.Fatalf("redirect event fields = %+v", ev)
+	}
+	if ev.StatementDigest == "" || ev.RewrittenStatementDigest == "" || ev.StatementDigest == ev.RewrittenStatementDigest {
+		t.Fatalf("bad digests: original=%q rewritten=%q", ev.StatementDigest, ev.RewrittenStatementDigest)
+	}
+}
+
+func TestHandleQuery_RedirectPlannerFailureFailsClosed(t *testing.T) {
+	pc, clientFE, sink := newSimpleQueryFixture(t)
+	pc.srv.SetPolicy(redirectReadRuleSet(t))
+	pc.redirectPlanner = &fakeRedirectPlanner{err: errors.New("missing_target_relation")}
+
+	upClient, upServer := net.Pipe()
+	t.Cleanup(func() { _ = upClient.Close(); _ = upServer.Close() })
+	pc.state.upstream = upServer
+	pc.state.upstreamFE = pgproto3.NewFrontend(upServer, upServer)
+	upBackend := pgproto3.NewBackend(upClient, upClient)
+	drainClientBackendMessages(clientFE)
+
+	err := pc.handleQuery(context.Background(), &pgproto3.Query{String: "select note from public.users"})
+	if err != nil {
+		t.Fatalf("handleQuery returned transport error: %v", err)
+	}
+
+	upRecv := make(chan pgproto3.FrontendMessage, 1)
+	go func() {
+		msg, err := upBackend.Receive()
+		if err == nil {
+			upRecv <- msg
+		}
+	}()
+	select {
+	case msg := <-upRecv:
+		t.Fatalf("upstream received original SQL after redirect rejection: %T", msg)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	evs := sink.DrainStatements()
+	if len(evs) != 1 {
+		t.Fatalf("events = %d: %+v", len(evs), evs)
+	}
+	if evs[0].RedirectRuntimeStatus != "rejected" || evs[0].RedirectRejectionReason != "missing_target_relation" {
+		t.Fatalf("redirect rejection event = %+v", evs[0])
+	}
+	if evs[0].Result.ErrorCode != sqlstateRedirectRejected {
+		t.Fatalf("ErrorCode = %q", evs[0].Result.ErrorCode)
+	}
+}
+```
+
+Add helper:
+
+```go
+func drainClientBackendMessages(fe *pgproto3.Frontend) {
+	go func() {
+		for {
+			if _, err := fe.Receive(); err != nil {
+				return
+			}
+		}
+	}()
+}
+
+func redirectReadRuleSet(t *testing.T) *policy.RuleSet {
+	t.Helper()
+	return loadRuleSet(t, `version: 1
+name: redirect-test
+db_services:
+  test:
+    family: postgres
+    dialect: postgres
+    upstream: "127.0.0.1:5432"
+    tls_mode: terminate_reissue
+database_rules:
+  - name: block-delete
+    db_service: test
+    operations: [delete]
+    decision: deny
+  - name: redirect-users
+    db_service: test
+    operations: [read]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: public.safe_users
+`)
+}
+```
+
+If Plan 11 chose a different YAML shape for redirect actions, use the exact Plan 11 YAML while keeping the rule name `redirect-users` and target relation `public.safe_users`.
+
+- [ ] **Step 2: Run failing Simple Query tests**
+
+Run:
+
+```bash
+go test ./internal/db/proxy/postgres -run 'TestHandleQuery_Redirect' -count=1
+```
+
+Expected: FAIL because `handleQuery` still forwards original SQL or denies redirect.
+
+- [ ] **Step 3: Add Simple Query redirect branch**
+
+In `handleQuery`, after decisions are computed and before approval/allow handling, add:
+
+```go
+	redirectIndex := -1
+	for i, d := range decisions {
+		if d.Verb == policy.VerbRedirect {
+			redirectIndex = i
+			break
+		}
+	}
+	if !anyDeny && redirectIndex >= 0 {
+		return pc.runSimpleQueryRedirect(ctx, q, stmts, decisions, redirectIndex, batchSHA)
+	}
+```
+
+Add helper in `simplequery.go`:
+
+```go
+func (pc *proxyConn) runSimpleQueryRedirect(
+	ctx context.Context,
+	q *pgproto3.Query,
+	stmts []effects.ClassifiedStatement,
+	decisions []policy.Decision,
+	redirectIndex int,
+	batchSHA string,
+) error {
+	if len(stmts) != 1 || redirectIndex != 0 {
+		plan := redirectRuntimePlan{
+			Rule:            decisions[redirectIndex].RuleName,
+			RuntimeStatus:   "rejected",
+			RejectionReason: "multi_statement_redirect_unsupported",
+		}
+		pc.emitRedirectRejectedEvent(ctx, stmts[redirectIndex], decisions[redirectIndex], q.String, batchSHA, plan)
+		return pc.synthErrorAndRFQ(sqlstateRedirectRejected, "redirect rejected by AgentSH policy: multi-statement redirect unsupported")
+	}
+
+	plan, ok := pc.planRuntimeRedirect(ctx, q.String, stmts[redirectIndex], decisions[redirectIndex])
+	if !ok {
+		pc.emitRedirectRejectedEvent(ctx, stmts[redirectIndex], decisions[redirectIndex], q.String, batchSHA, plan)
+		return pc.synthErrorAndRFQ(sqlstateRedirectRejected, "redirect rejected by AgentSH policy: "+plan.RejectionReason)
+	}
+
+	sentAt := timeNow()
+	pc.state.upstreamFE.Send(&pgproto3.Query{String: plan.RewrittenSQL})
+	if err := pc.state.upstreamFE.Flush(); err != nil {
+		return err
+	}
+	result, ferr := pc.forwardUpstreamUntilRFQ(ctx, sentAt, len(q.String))
+	pc.emitRedirectAllowEvent(ctx, stmts[redirectIndex], decisions[redirectIndex], q.String, batchSHA, plan, result)
+	pc.refreshCatalogAfterSuccessfulStatements(ctx, plan.RewrittenStatements, result)
+	return ferr
+}
+```
+
+Add emit helpers:
+
+```go
+func (pc *proxyConn) emitRedirectAllowEvent(ctx context.Context, stmt effects.ClassifiedStatement, decision policy.Decision, sql, batchSHA string, plan redirectRuntimePlan, result upstreamResult) {
+	parser := pc.srv.classifierFor(pc.svc.Dialect)
+	var rowsReturned, rowsAffected *int64
+	if len(result.RowsByStmt) > 0 {
+		rowsReturned = result.RowsByStmt[0]
+	}
+	if len(result.AffectedByStmt) > 0 {
+		rowsAffected = result.AffectedByStmt[0]
+	}
+	ev := buildStatementEvent(buildArgs{
+		Stmt:            stmt,
+		StmtIndex:       0,
+		BatchTotal:      1,
+		Decision:        decision,
+		SQL:             sql,
+		Tier:            pc.srv.policy().Redaction().Tier,
+		Conn:            *pc.state,
+		BytesIn:         int64(len(sql)),
+		BytesOut:        result.BytesOut,
+		LatencyMs:       result.LatencyMs,
+		RowsReturned:    rowsReturned,
+		RowsAffected:    rowsAffected,
+		UpstreamErrCode: result.ErrorCode,
+		DenyAction:      "none",
+		BatchSHA:        batchSHA,
+		Parser:          parser,
+		Redirect:        redirectEventFromPlan(plan, "executed"),
+	})
+	_ = pc.srv.cfg.Sink.EmitStatement(ctx, ev)
+}
+
+func (pc *proxyConn) emitRedirectRejectedEvent(ctx context.Context, stmt effects.ClassifiedStatement, decision policy.Decision, sql, batchSHA string, plan redirectRuntimePlan) {
+	parser := pc.srv.classifierFor(pc.svc.Dialect)
+	ev := buildStatementEvent(buildArgs{
+		Stmt:            stmt,
+		StmtIndex:       0,
+		BatchTotal:      1,
+		Decision:        decision,
+		SQL:             sql,
+		Tier:            pc.srv.policy().Redaction().Tier,
+		Conn:            *pc.state,
+		BytesIn:         int64(len(sql)),
+		UpstreamErrCode: sqlstateRedirectRejected,
+		DenyAction:      "none",
+		BatchSHA:        batchSHA,
+		Parser:          parser,
+		Redirect:        redirectEventFromPlan(plan, "rejected"),
+	})
+	_ = pc.srv.cfg.Sink.EmitStatement(ctx, ev)
+}
+```
+
+- [ ] **Step 4: Run Simple Query tests**
+
+Run:
+
+```bash
+go test ./internal/db/proxy/postgres -run 'TestHandleQuery_Redirect|TestHandleQuery_' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit Simple Query redirect**
+
+Run:
+
+```bash
+git add internal/db/proxy/postgres/simplequery.go internal/db/proxy/postgres/simplequery_test.go
+git commit -m "db/proxy: execute simple-query redirects"
+```
+
+---
+
+## Task 6: Wire Extended Query Parse Redirect
+
+**Files:**
+- Modify: `internal/db/proxy/postgres/extquery.go`
+- Modify: `internal/db/proxy/postgres/extquery_spine_test.go`
+
+- [ ] **Step 1: Write failing Extended Query Parse tests**
+
+Add tests to `internal/db/proxy/postgres/extquery_spine_test.go`.
+Add `github.com/agentsh/agentsh/internal/db/events` to the import block for the execute-audit test in Task 7.
+
+```go
+func TestExtquery_RedirectParse_ForwardsRewrittenAndCachesMetadata(t *testing.T) {
+	pc, clientFE, upBackend, _ := extqueryFixture(t, redirectExtqueryPolicyYAML())
+	pc.redirectPlanner = &fakeRedirectPlanner{plan: redirectRuntimePlan{
+		RewrittenSQL:   "select note from public.safe_users where id=$1",
+		Rule:           "redirect-users",
+		SourceRelation: "public.users",
+		TargetRelation: "public.safe_users",
+	}}
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	clientFE.Send(&pgproto3.Parse{Name: "client_stmt", Query: "select note from public.users where id=$1"})
+	if err := clientFE.Flush(); err != nil {
+		t.Fatalf("client flush: %v", err)
+	}
+
+	msg, err := upBackend.Receive()
+	if err != nil {
+		t.Fatalf("upstream Receive: %v", err)
+	}
+	parse, ok := msg.(*pgproto3.Parse)
+	if !ok {
+		t.Fatalf("upstream got %T", msg)
+	}
+	if parse.Name != "client_stmt" {
+		t.Fatalf("Parse.Name = %q", parse.Name)
+	}
+	if parse.Query != "select note from public.safe_users where id=$1" {
+		t.Fatalf("Parse.Query = %q", parse.Query)
+	}
+
+	entry, ok := pc.wireCache.Get("client_stmt")
+	if !ok {
+		t.Fatal("wire cache missing client_stmt")
+	}
+	if entry.Redirect == nil {
+		t.Fatal("redirect metadata missing")
+	}
+	if entry.Redirect.TargetRelation != "public.safe_users" || entry.Classification.RawVerb != "SELECT" {
+		t.Fatalf("cache entry = %+v", entry)
+	}
+
+	_ = pc.conn.Close()
+	select {
+	case <-loopErr:
+	case <-time.After(time.Second):
+	}
+}
+
+func TestExtquery_RedirectParse_FailureDoesNotCacheOrForward(t *testing.T) {
+	pc, clientFE, upBackend, _ := extqueryFixture(t, redirectExtqueryPolicyYAML())
+	pc.redirectPlanner = &fakeRedirectPlanner{err: errors.New("unsupported_statement")}
+	drainClientBackendMessages(clientFE)
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	clientFE.Send(&pgproto3.Parse{Name: "client_stmt", Query: "select note from public.users"})
+	if err := clientFE.Flush(); err != nil {
+		t.Fatalf("client flush: %v", err)
+	}
+
+	if _, ok := pc.wireCache.Get("client_stmt"); ok {
+		t.Fatal("failed redirect Parse must not cache statement")
+	}
+
+	upRecv := make(chan struct{}, 1)
+	go func() {
+		if _, err := upBackend.Receive(); err == nil {
+			upRecv <- struct{}{}
+		}
+	}()
+	select {
+	case <-upRecv:
+		t.Fatal("upstream received Parse after redirect failure")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	_ = pc.conn.Close()
+	select {
+	case <-loopErr:
+	case <-time.After(time.Second):
+	}
+}
+```
+
+Add helper YAML:
+
+```go
+func redirectExtqueryPolicyYAML() string {
+	return `version: 1
+name: redirect-extquery
+db_services:
+  test: {family: postgres, dialect: postgres, upstream: "127.0.0.1:5432", tls_mode: terminate_reissue}
+database_rules:
+  - name: block-delete
+    db_service: test
+    operations: [delete]
+    decision: deny
+  - name: redirect-users
+    db_service: test
+    operations: [read]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: public.safe_users
+`
+}
+```
+
+Use the exact Plan 11 redirect YAML if the action shape differs.
+
+- [ ] **Step 2: Run failing Extended Query tests**
+
+Run:
+
+```bash
+go test ./internal/db/proxy/postgres -run 'TestExtquery_RedirectParse' -count=1
+```
+
+Expected: FAIL because Parse still forwards original SQL or redirect fails through existing state machine behavior.
+
+- [ ] **Step 3: Add redirected Parse fast path**
+
+In `handleExtendedFrame`, after Parse classification and before `TransitionWithParser`, add:
+
+```go
+	if isParse && len(parseStmts) > 0 {
+		handled, err := pc.tryHandleRedirectParse(ctx, parse, parseStmts)
+		if handled || err != nil {
+			return err
+		}
+	}
+```
+
+Add helper:
+
+```go
+func (pc *proxyConn) tryHandleRedirectParse(ctx context.Context, parse *pgproto3.Parse, stmts []effects.ClassifiedStatement) (bool, error) {
+	rs := pc.srv.policy()
+	decisions := make([]policy.Decision, len(stmts))
+	redirectIndex := -1
+	for i, stmt := range stmts {
+		decisions[i] = policy.Evaluate(stmt, rs, policy.ServiceID(pc.svc.Name))
+		if decisions[i].Verb == policy.VerbDeny || decisions[i].Verb == policy.VerbApprove {
+			return false, nil
+		}
+		if decisions[i].Verb == policy.VerbRedirect && redirectIndex == -1 {
+			redirectIndex = i
+		}
+	}
+	if redirectIndex < 0 {
+		return false, nil
+	}
+	if len(stmts) != 1 || redirectIndex != 0 {
+		plan := redirectRuntimePlan{
+			Rule:            decisions[redirectIndex].RuleName,
+			RuntimeStatus:   "rejected",
+			RejectionReason: "multi_statement_redirect_unsupported",
+		}
+		pc.emitRedirectRejectedEvent(ctx, stmts[redirectIndex], decisions[redirectIndex], parse.Query, sha256HexBatch(parse.Query), plan)
+		return true, pc.executeActions(ctx, parse, statemachine.DenyRoute(*pc.state.smState, policy.StatementRule{}, "redirect rejected by AgentSH policy: multi-statement redirect unsupported", sqlstateRedirectRejected))
+	}
+	plan, ok := pc.planRuntimeRedirect(ctx, parse.Query, stmts[0], decisions[0])
+	if !ok {
+		pc.emitRedirectRejectedEvent(ctx, stmts[0], decisions[0], parse.Query, sha256HexBatch(parse.Query), plan)
+		actions := statemachine.DenyRoute(*pc.state.smState, policy.StatementRule{}, "redirect rejected by AgentSH policy: "+plan.RejectionReason, sqlstateRedirectRejected)
+		next := *pc.state.smState
+		if !containsCloseAction(actions) {
+			next.Absorbing = true
+		}
+		*pc.state.smState = next
+		return true, pc.executeActions(ctx, parse, actions)
+	}
+
+	searchPath, snapshot := statementsNeedCatalogRefresh(plan.RewrittenStatements)
+	pc.wireCache.Put(parse.Name, preparedcache.Entry{
+		Classification:           plan.RewrittenStatements[0],
+		CatalogRefreshSearchPath: searchPath,
+		CatalogRefreshSnapshot:   snapshot,
+		Redirect: &preparedcache.RedirectMetadata{
+			OriginalClassification:  stmts[0],
+			OriginalSQL:             parse.Query,
+			OriginalStatementDigest: plan.OriginalStatementDigest,
+			RewrittenStatementDigest: plan.RewrittenStatementDigest,
+			Rule:                    plan.Rule,
+			SourceRelation:          plan.SourceRelation,
+			TargetRelation:          plan.TargetRelation,
+			PolicyIdentity:          decisions[0].RuleName,
+		},
+	})
+	forward := *parse
+	forward.Query = plan.RewrittenSQL
+	pc.state.upstreamFE.Send(&forward)
+	if err := pc.state.upstreamFE.Flush(); err != nil {
+		return true, err
+	}
+	pc.state.smState.UpstreamDirtySinceSync = true
+	return true, nil
+}
+```
+
+Add helper:
+
+```go
+func containsCloseAction(actions []statemachine.Action) bool {
+	for _, action := range actions {
+		if _, ok := action.(*statemachine.ActionClose); ok {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 4: Preserve full redirect metadata through Bind**
+
+In `handleExtendedFrame`, after `TransitionWithParser` and before `Execute` handling, add:
+
+```go
+	if bind, ok := msg.(*pgproto3.Bind); ok && actionsCanForward(actions) {
+		pc.preserveRedirectPortalMetadata(bind)
+	}
+```
+
+Add helper:
+
+```go
+func (pc *proxyConn) preserveRedirectPortalMetadata(bind *pgproto3.Bind) {
+	if bind == nil || pc.wireCache == nil {
+		return
+	}
+	entry, ok := pc.wireCache.Get(bind.PreparedStatement)
+	if !ok || entry.Redirect == nil {
+		return
+	}
+	pc.wireCache.Put(wirePortalCacheKey(bind.DestinationPortal), entry)
+}
+```
+
+- [ ] **Step 5: Run Extended Query Parse tests**
+
+Run:
+
+```bash
+go test ./internal/db/proxy/postgres -run 'TestExtquery_RedirectParse|TestExtquery_Spine_Parse' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Extended Query Parse redirect**
+
+Run:
+
+```bash
+git add internal/db/proxy/postgres/extquery.go internal/db/proxy/postgres/extquery_spine_test.go
+git commit -m "db/proxy: execute redirects at extended-query parse"
+```
+
+---
+
+## Task 7: Emit Redirect Events For Extended Execute
+
+**Files:**
+- Modify: `internal/db/proxy/postgres/proxyconn.go`
+- Modify: `internal/db/proxy/postgres/extquery.go`
+- Modify: `internal/db/proxy/postgres/extquery_spine_test.go`
+
+- [ ] **Step 1: Write failing Bind/Execute audit test**
+
+Add this test to `internal/db/proxy/postgres/extquery_spine_test.go`.
+Add `strings` and `github.com/agentsh/agentsh/internal/db/events` to the import block.
+
+```go
+func TestExtquery_RedirectExecute_UsesCachedMetadataAndEmitsEventAfterSync(t *testing.T) {
+	pc, clientFE, upBackend, _ := extqueryFixture(t, redirectExtqueryPolicyYAML())
+	planner := &fakeRedirectPlanner{plan: redirectRuntimePlan{
+		RewrittenSQL:   "select note from public.safe_users where id=$1",
+		Rule:           "redirect-users",
+		SourceRelation: "public.users",
+		TargetRelation: "public.safe_users",
+	}}
+	pc.redirectPlanner = planner
+	drainClientBackendMessages(clientFE)
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	clientFE.Send(&pgproto3.Parse{Name: "client_stmt", Query: "select note from public.users where id=$1"})
+	clientFE.Send(&pgproto3.Bind{DestinationPortal: "p1", PreparedStatement: "client_stmt"})
+	clientFE.Send(&pgproto3.Execute{Portal: "p1"})
+	clientFE.Send(&pgproto3.Sync{})
+	if err := clientFE.Flush(); err != nil {
+		t.Fatalf("client flush: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := upBackend.Receive(); err != nil {
+			t.Fatalf("upstream Receive %d: %v", i, err)
+		}
+	}
+	upBackend.Send(&pgproto3.ParseComplete{})
+	upBackend.Send(&pgproto3.BindComplete{})
+	upBackend.Send(&pgproto3.CommandComplete{CommandTag: []byte("SELECT 0")})
+	upBackend.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+	if err := upBackend.Flush(); err != nil {
+		t.Fatalf("upstream flush: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var evs []events.DBEvent
+	for time.Now().Before(deadline) {
+		evs = pc.srv.cfg.Sink.(*events.SyncSink).DrainStatements()
+		if len(evs) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("events = %d: %+v", len(evs), evs)
+	}
+	if !evs[0].Redirected || evs[0].RedirectRuntimeStatus != "executed" || evs[0].RedirectTargetRelation != "public.safe_users" {
+		t.Fatalf("redirect execute event = %+v", evs[0])
+	}
+	if planner.calls != 1 {
+		t.Fatalf("planner calls = %d, want Parse-only planning", planner.calls)
+	}
+
+	_ = pc.conn.Close()
+	select {
+	case <-loopErr:
+	case <-time.After(time.Second):
+	}
+}
+```
+
+Add a second unit test for reload stability:
+
+```go
+func TestExtquery_RedirectPolicyReloadKeepsPreparedPlanAndUsesNewPlanForNewParse(t *testing.T) {
+	pc, clientFE, upBackend, _ := extqueryFixture(t, redirectExtqueryPolicyYAML())
+	planner := &fakeRedirectPlanner{plan: redirectRuntimePlan{
+		RewrittenSQL:   "select note from public.safe_users_a where id=$1",
+		Rule:           "redirect-users-a",
+		SourceRelation: "public.users",
+		TargetRelation: "public.safe_users_a",
+	}}
+	pc.redirectPlanner = planner
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	clientFE.Send(&pgproto3.Parse{Name: "old_stmt", Query: "select note from public.users where id=$1"})
+	if err := clientFE.Flush(); err != nil {
+		t.Fatalf("client flush old parse: %v", err)
+	}
+	oldMsg, err := upBackend.Receive()
+	if err != nil {
+		t.Fatalf("old upstream Receive: %v", err)
+	}
+	oldParse := oldMsg.(*pgproto3.Parse)
+	if oldParse.Query != "select note from public.safe_users_a where id=$1" {
+		t.Fatalf("old rewritten SQL = %q", oldParse.Query)
+	}
+
+	pc.srv.SetPolicy(loadRuleSet(t, redirectExtqueryPolicyYAMLTarget("public.safe_users_b", "redirect-users-b")))
+	planner.plan = redirectRuntimePlan{
+		RewrittenSQL:   "select note from public.safe_users_b where id=$1",
+		Rule:           "redirect-users-b",
+		SourceRelation: "public.users",
+		TargetRelation: "public.safe_users_b",
+	}
+
+	clientFE.Send(&pgproto3.Parse{Name: "new_stmt", Query: "select note from public.users where id=$1"})
+	clientFE.Send(&pgproto3.Bind{DestinationPortal: "old_portal", PreparedStatement: "old_stmt"})
+	if err := clientFE.Flush(); err != nil {
+		t.Fatalf("client flush reload frames: %v", err)
+	}
+	newMsg, err := upBackend.Receive()
+	if err != nil {
+		t.Fatalf("new upstream Receive: %v", err)
+	}
+	newParse := newMsg.(*pgproto3.Parse)
+	if newParse.Query != "select note from public.safe_users_b where id=$1" {
+		t.Fatalf("new rewritten SQL = %q", newParse.Query)
+	}
+	if oldPortal, ok := pc.wireCache.Get(wirePortalCacheKey("old_portal")); !ok || oldPortal.Redirect == nil || oldPortal.Redirect.TargetRelation != "public.safe_users_a" {
+		t.Fatalf("old prepared redirect was corrupted after reload: ok=%v entry=%+v", ok, oldPortal)
+	}
+
+	_ = pc.conn.Close()
+	select {
+	case <-loopErr:
+	case <-time.After(time.Second):
+	}
+}
+```
+
+Add helper:
+
+```go
+func redirectExtqueryPolicyYAMLTarget(target, ruleName string) string {
+	return strings.ReplaceAll(
+		strings.ReplaceAll(redirectExtqueryPolicyYAML(), "redirect-users", ruleName),
+		"public.safe_users",
+		target,
+	)
+}
+```
+
+- [ ] **Step 2: Run failing audit test**
+
+Run:
+
+```bash
+go test ./internal/db/proxy/postgres -run TestExtquery_RedirectExecute_UsesCachedMetadataAndEmitsEventAfterSync -count=1
+```
+
+Expected: FAIL because redirected Execute does not emit audit events.
+
+- [ ] **Step 3: Add pending redirected execute state**
+
+In `proxyConn` add:
+
+```go
+	pendingRedirectExec []pendingRedirectExecute
+```
+
+In `extquery.go`, add:
+
+```go
+type pendingRedirectExecute struct {
+	Entry preparedcache.Entry
+}
+```
+
+- [ ] **Step 4: Queue redirected Execute metadata**
+
+Update `markCatalogRefreshPendingForExecute` after portal cache lookup:
+
+```go
+	if entry.Redirect != nil {
+		pc.pendingRedirectExec = append(pc.pendingRedirectExec, pendingRedirectExecute{Entry: entry})
+	}
+```
+
+- [ ] **Step 5: Emit pending events after drain**
+
+In `executeActions`, change the drain case from discarding the result to capturing it:
+
+```go
+		case *statemachine.ActionDrainUntilRFQ:
+			result, err := pc.forwardUpstreamUntilRFQ(ctx, timeNow(), 0)
+			if err != nil {
+				return fmt.Errorf("drain: %w", err)
+			}
+			pc.emitPendingRedirectExecuteEvents(ctx, result)
+			pc.refreshPendingCatalogContext(ctx)
+```
+
+Add:
+
+```go
+func (pc *proxyConn) emitPendingRedirectExecuteEvents(ctx context.Context, result upstreamResult) {
+	if len(pc.pendingRedirectExec) == 0 {
+		return
+	}
+	pending := pc.pendingRedirectExec
+	pc.pendingRedirectExec = nil
+	parser := pc.srv.classifierFor(pc.svc.Dialect)
+	for i, p := range pending {
+		if p.Entry.Redirect == nil {
+			continue
+		}
+		var rowsReturned, rowsAffected *int64
+		if i < len(result.RowsByStmt) {
+			rowsReturned = result.RowsByStmt[i]
+		}
+		if i < len(result.AffectedByStmt) {
+			rowsAffected = result.AffectedByStmt[i]
+		}
+		redir := p.Entry.Redirect
+		ev := buildStatementEvent(buildArgs{
+			Stmt:            redir.OriginalClassification,
+			StmtIndex:       i,
+			BatchTotal:      len(pending),
+			Decision:        policy.Decision{Verb: policy.VerbRedirect, RuleKind: policy.RuleKindStatement, RuleName: redir.Rule, MatchingEffectIndex: 0},
+			SQL:             redir.OriginalSQL,
+			Tier:            pc.srv.policy().Redaction().Tier,
+			Conn:            *pc.state,
+			BytesOut:        result.BytesOut,
+			LatencyMs:       result.LatencyMs,
+			RowsReturned:    rowsReturned,
+			RowsAffected:    rowsAffected,
+			UpstreamErrCode: result.ErrorCode,
+			DenyAction:      "none",
+			BatchSHA:        redir.OriginalStatementDigest,
+			Parser:          parser,
+			Redirect: redirectEventArgs{
+				Redirected:                true,
+				Rule:                      redir.Rule,
+				RewrittenStatementDigest:  redir.RewrittenStatementDigest,
+				SourceRelation:            redir.SourceRelation,
+				TargetRelation:            redir.TargetRelation,
+				RuntimeStatus:             "executed",
+			},
+		})
+		if ev.StatementDigest == "" {
+			ev.StatementDigest = redir.OriginalStatementDigest
+		}
+		_ = pc.srv.cfg.Sink.EmitStatement(ctx, ev)
+	}
+}
+```
+
+The cached `OriginalSQL` is the client Parse SQL. Do not cache rewritten SQL text for audit; the rewritten digest and target relation fields carry that visibility without adding another raw-SQL exposure path.
+
+- [ ] **Step 6: Run Extended redirect tests**
+
+Run:
+
+```bash
+go test ./internal/db/proxy/postgres -run 'TestExtquery_Redirect|TestExtquery_Spine' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Extended redirect audit**
+
+Run:
+
+```bash
+git add internal/db/proxy/postgres/proxyconn.go internal/db/proxy/postgres/extquery.go internal/db/proxy/postgres/extquery_spine_test.go internal/db/proxy/postgres/preparedcache/cache.go
+git commit -m "db/proxy: emit extended-query redirect events"
+```
+
+---
+
+## Task 8: Add Real Postgres Plan 12 Integration Tests
+
+**Files:**
+- Modify: `internal/integration/db07cclient/main.go`
+- Modify: `internal/integration/db_postgres_07c_test.go`
+
+- [ ] **Step 1: Add client mode for repeated prepared execution**
+
+In `internal/integration/db07cclient/main.go`, update the mode flag help string:
+
+```go
+mode     = flag.String("mode", "scalar", "scalar, exec, prepared-repeat, tx-deny, cancel, copy-to, or copy-from")
+```
+
+Add this case to `run`:
+
+```go
+	case "prepared-repeat":
+		var first string
+		var second string
+		if err := conn.QueryRow(ctx, sqlText, 1).Scan(&first); err != nil {
+			return output{}, err
+		}
+		if err := conn.QueryRow(ctx, sqlText, 1).Scan(&second); err != nil {
+			return output{}, err
+		}
+		return output{Scalar: first + "," + second}, nil
+```
+
+- [ ] **Step 2: Seed redirect source and target relations**
+
+In `seedDB07C`, append:
+
+```sql
+drop table if exists plan12.users_source;
+drop table if exists plan12.users_target_a;
+drop table if exists plan12.users_target_b;
+create schema if not exists plan12;
+create table plan12.users_source(id int primary key, note text);
+create table plan12.users_target_a(id int primary key, note text);
+create table plan12.users_target_b(id int primary key, note text);
+insert into plan12.users_source(id, note) values (1, 'source');
+insert into plan12.users_target_a(id, note) values (1, 'target-a');
+insert into plan12.users_target_b(id, note) values (1, 'target-b');
+```
+
+- [ ] **Step 3: Add redirect rules to policy**
+
+In `db07cPolicyYAML`, add redirect rules before the generic `allow-read` rule:
+
+```yaml
+  - name: redirect-plan12-source-a
+    db_service: appdb
+    operations: [read]
+    relations: ["plan12.users_source"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: plan12.users_target_a
+```
+
+Use the exact Plan 11 redirect action field names if they differ from `redirect.relation`.
+
+- [ ] **Step 4: Add Simple Query integration test**
+
+Add:
+
+```go
+func TestDB12RealPostgresSimpleQueryRedirect(t *testing.T) {
+	ctx := context.Background()
+	env := startDB07CEnvironment(t, ctx)
+	defer env.cleanup()
+
+	seedDB07C(t, ctx, env.hostDSN)
+	sess := createDB07CSession(t, ctx, env.client)
+	socket := filepath.Join(sess.DBProxySocketDir, "appdb.sock")
+
+	out := execDB07CClient(t, ctx, env.client, sess.ID, "-socket", socket, "-mode", "scalar", "-sql", "select note from plan12.users_source where id = 1", "-simple")
+	if out.Scalar != "target-a" {
+		t.Fatalf("Plan 12 simple redirect returned %+v, want target-a", out)
+	}
+	waitForSessionEvent07C(t, ctx, env.client, sess.ID, func(ev types.Event) bool {
+		return ev.Type == "db_statement" &&
+			ev.Fields["redirected"] == true &&
+			ev.Fields["redirect_rule"] == "redirect-plan12-source-a" &&
+			ev.Fields["redirect_target_relation"] == "plan12.users_target_a" &&
+			ev.Fields["redirect_runtime_status"] == "executed"
+	}, "Plan 12 simple redirect event")
+}
+```
+
+- [ ] **Step 5: Add Extended Query prepared integration test**
+
+Add:
+
+```go
+func TestDB12RealPostgresExtendedPreparedRedirect(t *testing.T) {
+	ctx := context.Background()
+	env := startDB07CEnvironment(t, ctx)
+	defer env.cleanup()
+
+	seedDB07C(t, ctx, env.hostDSN)
+	sess := createDB07CSession(t, ctx, env.client)
+	socket := filepath.Join(sess.DBProxySocketDir, "appdb.sock")
+
+	out := execDB07CClient(t, ctx, env.client, sess.ID, "-socket", socket, "-mode", "prepared-repeat", "-sql", "select note from plan12.users_source where id = $1")
+	if out.Scalar != "target-a,target-a" {
+		t.Fatalf("Plan 12 prepared redirect returned %+v, want repeated target-a", out)
+	}
+	waitForSessionEvent07C(t, ctx, env.client, sess.ID, func(ev types.Event) bool {
+		return ev.Type == "db_statement" &&
+			ev.Fields["redirected"] == true &&
+			ev.Fields["redirect_rule"] == "redirect-plan12-source-a" &&
+			ev.Fields["redirect_target_relation"] == "plan12.users_target_a"
+	}, "Plan 12 extended redirect event")
+}
+```
+
+- [ ] **Step 6: Add unsupported-form integration test**
+
+Add:
+
+```go
+func TestDB12RealPostgresRedirectUnsupportedFormsFailClosed(t *testing.T) {
+	ctx := context.Background()
+	env := startDB07CEnvironment(t, ctx)
+	defer env.cleanup()
+
+	seedDB07C(t, ctx, env.hostDSN)
+	sess := createDB07CSession(t, ctx, env.client)
+	socket := filepath.Join(sess.DBProxySocketDir, "appdb.sock")
+
+	multi := execDB07CClientAllowFailure(t, ctx, env.client, sess.ID, "-socket", socket, "-mode", "scalar", "-sql", "select note from plan12.users_source where id = 1; select note from plan12.users_source where id = 1", "-simple")
+	if multi.OK {
+		t.Fatalf("multi-statement redirect unexpectedly succeeded: %+v", multi)
+	}
+
+	write := execDB07CClientAllowFailure(t, ctx, env.client, sess.ID, "-socket", socket, "-mode", "exec", "-sql", "insert into plan12.users_source(id, note) values (2, 'blocked')", "-simple")
+	if write.OK {
+		t.Fatalf("write through redirect policy unexpectedly succeeded: %+v", write)
+	}
+	waitForSessionEvent07C(t, ctx, env.client, sess.ID, func(ev types.Event) bool {
+		return ev.Type == "db_statement" &&
+			ev.Fields["redirected"] == true &&
+			ev.Fields["redirect_runtime_status"] == "rejected"
+	}, "Plan 12 redirect rejection event")
+}
+```
+
+- [ ] **Step 7: Add direct-proxy policy reload integration test**
+
+Create `internal/db/proxy/postgres/redirect_integration_test.go` with build tag `//go:build integration && linux`. Put it in package `postgres` so it can reuse `runServer`, `renameSocketForPgx`, `pgxConnString`, and `pgxErrorCode` from existing proxy spine tests.
+
+The test must start a real `postgres:16-alpine` container, seed `plan12.users_source`, `plan12.users_target_a`, and `plan12.users_target_b`, start a local `postgres.Server` pointed at that container, then call `srv.SetPolicy` while a pgx connection remains open.
+
+Add this assertion shape:
+
+```go
+func TestDB12RealPostgresPolicyReloadKeepsPreparedRedirectPlan(t *testing.T) {
+	ctx := context.Background()
+	pg := startDB12PostgresContainer(t, ctx)
+	seedDB12RedirectTables(t, ctx, pg.hostDSN)
+
+	srv, sockPath := startDB12DirectProxy(t, pg.upstream, db12RedirectPolicyYAML("plan12.users_target_a", "redirect-plan12-a"))
+	stop := runServer(t, srv)
+	defer stop()
+
+	sockDir := renameSocketForPgx(t, sockPath, 5452)
+	conn, err := pgx.Connect(ctx, pgxConnString(sockDir, 5452))
+	if err != nil {
+		t.Fatalf("pgx.Connect: %v", err)
+	}
+	defer conn.Close(ctx)
+
+	if _, err := conn.Prepare(ctx, "old_redirect", "select note from plan12.users_source where id=$1"); err != nil {
+		t.Fatalf("Prepare old_redirect: %v", err)
+	}
+	var oldBefore string
+	if err := conn.QueryRow(ctx, "old_redirect", 1).Scan(&oldBefore); err != nil {
+		t.Fatalf("old prepared before reload: %v", err)
+	}
+	if oldBefore != "target-a" {
+		t.Fatalf("old prepared before reload = %q", oldBefore)
+	}
+
+	srv.SetPolicy(db12RedirectPolicyYAML("plan12.users_target_b", "redirect-plan12-b"))
+
+	var oldAfter string
+	if err := conn.QueryRow(ctx, "old_redirect", 1).Scan(&oldAfter); err != nil {
+		t.Fatalf("old prepared after reload: %v", err)
+	}
+	if oldAfter != "target-a" {
+		t.Fatalf("old prepared after reload = %q, want parse-time target-a", oldAfter)
+	}
+
+	var newAfter string
+	if err := conn.QueryRow(ctx, "select note from plan12.users_source where id=$1", 1).Scan(&newAfter); err != nil {
+		t.Fatalf("new statement after reload: %v", err)
+	}
+	if newAfter != "target-b" {
+		t.Fatalf("new statement after reload = %q, want target-b", newAfter)
+	}
+}
+```
+
+Implement the helpers in the same file using `testcontainers-go`, `wait.ForLog("database system is ready to accept connections")`, `pgx.Connect` for seeding, and `postgres.New(Config{...})` following `startSpineHarness` but without `catalogLoaderForTest` so the real catalog loader resolves `plan12` relations.
+
+- [ ] **Step 8: Run DB Plan 12 integration tests**
+
+Run:
+
+```bash
+go test -v -tags=integration ./internal/integration ./internal/db/proxy/postgres -run TestDB12RealPostgres -count=1
+```
+
+Expected: PASS. If Docker is unavailable locally, note that explicitly and run the unit gates before pushing.
+
+- [ ] **Step 9: Commit integration coverage**
+
+Run:
+
+```bash
+git add internal/integration/db07cclient/main.go internal/integration/db_postgres_07c_test.go internal/db/proxy/postgres/redirect_integration_test.go
+git commit -m "test: add db plan 12 postgres redirect integration"
+```
+
+---
+
+## Task 9: Final Verification
+
+**Files:**
+- All files touched by prior tasks
+
+- [ ] **Step 1: Run focused unit tests**
+
+Run:
+
+```bash
+go test ./internal/db/events ./internal/db/proxy/postgres/preparedcache ./internal/db/proxy/postgres -run 'Redirect|TestHandleQuery|TestExtquery|TestBuildStatementEvent' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full DB unit packages**
+
+Run:
+
+```bash
+go test ./internal/db/...
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Verify Windows compilation**
+
+Run:
+
+```bash
+GOOS=windows go build ./...
+```
+
+Expected: PASS. Linux-only proxy files are guarded by build tags and platform-neutral event/cache changes compile on Windows.
+
+- [ ] **Step 4: Run real Postgres integration gate**
+
+Run:
+
+```bash
+go test -v -tags=integration ./internal/integration -run 'TestDB07C|TestDB09|TestDB12' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git log --oneline --max-count=10
+```
+
+Expected: working tree clean except unrelated pre-existing untracked files. Recent commits should show the Plan 12 task commits.
+
+---
+
+## Implementation Notes
+
+- Keep Plan 11 planner imports isolated in `redirect_runtime.go`.
+- Do not add redirect fallback-to-allow behavior.
+- Do not re-plan at `Bind` or `Execute`.
+- Do not emit client-facing `NoticeResponse`.
+- Preserve client prepared statement names exactly.
+- Use `filepath.Join` for any new filesystem paths in integration helpers.
+- Keep all Postgres proxy runtime files Linux-only unless a touched file is already platform-neutral.

--- a/docs/superpowers/plans/2026-05-15-db-plan-11-redirect-planner.md
+++ b/docs/superpowers/plans/2026-05-15-db-plan-11-redirect-planner.md
@@ -1,0 +1,1840 @@
+# DB Plan 11 Redirect Planner Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement DB Plan 11 so DB statement policy can return `decision: redirect` and a pure Postgres planner can safely rewrite one catalog-resolved source relation to one configured target relation in a single read-only `SELECT`.
+
+**Architecture:** Keep policy support in `internal/db/policy`, expose a narrow parse/deparse backend from `internal/db/classify/postgres`, and put AST rewrite planning in a new pure package `internal/db/redirect`. Runtime forwarding, prepared-cache changes, DB event fields, and client-visible redirect execution stay out of this plan for DB Plan 12.
+
+**Tech Stack:** Go, `github.com/pganalyze/pg_query_go/v6`, `github.com/wasilibs/go-pgquery`, existing DB policy/effects packages, Go unit tests, `GOOS=windows go build ./...`.
+
+---
+
+## Source Spec
+
+Implement the approved design:
+
+- `docs/superpowers/specs/2026-05-15-db-plan-11-redirect-planner-design.md`
+
+## File Structure
+
+Create:
+
+- `internal/db/redirect/types.go` - planner input, output, reason codes, rejection error type.
+- `internal/db/redirect/validate.go` - input and classified-statement safety checks.
+- `internal/db/redirect/planner.go` - parse, AST mutation, deparse orchestration.
+- `internal/db/redirect/walk.go` - relation-bearing `RangeVar` traversal for supported `SELECT` shapes.
+- `internal/db/redirect/planner_test.go` - planner rewrite and rejection tests.
+
+Modify:
+
+- `internal/db/policy/types.go` - add `VerbRedirect`, `StatementRule.Redirect`, redirect action/decision metadata types.
+- `internal/db/policy/validate.go` - accept statement redirect and validate redirect-specific shape.
+- `internal/db/policy/compile.go` - compile redirect verbs and target/source action metadata.
+- `internal/db/policy/evaluate.go` - fold redirect with precedence `deny == implicit_deny > approve > redirect > audit > allow`.
+- `internal/db/policy/types_test.go` - redirect verb string coverage.
+- `internal/db/policy/validate_test.go` - redirect validation coverage.
+- `internal/db/policy/decode_test.go` - YAML decode/round-trip coverage for redirect action.
+- `internal/db/policy/compile_test.go` - redirect compile coverage.
+- `internal/db/policy/evaluate_redirect_test.go` - redirect policy evaluation and precedence tests.
+- `internal/db/classify/postgres/parser.go` - define a rewrite backend interface.
+- `internal/db/classify/postgres/libpgquery.go` - cgo parse/deparse implementation.
+- `internal/db/classify/postgres/wasm.go` - WASM parse/deparse implementation.
+- `internal/db/classify/postgres/rewrite_backend_test.go` - parse/deparse backend coverage.
+- `docs/agentsh-db-access-spec.md` - update statement rule decision docs from Phase 1 redirect rejection to Phase 2 redirect support.
+
+Do not modify:
+
+- `internal/db/proxy/postgres/simplequery.go`
+- `internal/db/proxy/postgres/extquery.go`
+- `internal/db/proxy/postgres/preparedcache/*`
+- `internal/db/events/*`
+
+## Task 0: Worktree And Baseline
+
+**Files:**
+- No code files
+
+- [ ] **Step 1: Create an isolated worktree**
+
+Run from `/home/eran/work/agentsh`:
+
+```bash
+git status --short --branch
+git worktree add .worktrees/db-plan-11-redirect-planner -b feature/db-plan-11-redirect-planner
+cd .worktrees/db-plan-11-redirect-planner
+```
+
+Expected: new worktree on `feature/db-plan-11-redirect-planner`. Do not copy the untracked files from the main worktree.
+
+- [ ] **Step 2: Download modules**
+
+```bash
+go mod download
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Run focused baseline tests**
+
+```bash
+go test ./internal/db/policy ./internal/db/classify/postgres -count=1
+```
+
+Expected: PASS. If this fails before edits, stop and record the baseline failure.
+
+## Task 1: Policy Types And Redirect Validation
+
+**Files:**
+- Modify: `internal/db/policy/types.go`
+- Modify: `internal/db/policy/validate.go`
+- Modify: `internal/db/policy/types_test.go`
+- Modify: `internal/db/policy/validate_test.go`
+- Modify: `internal/db/policy/decode_test.go`
+
+- [ ] **Step 1: Add failing type and decode tests**
+
+In `internal/db/policy/types_test.go`, extend `TestDecisionVerbString` to include redirect:
+
+```go
+{VerbRedirect, "redirect"},
+```
+
+In `internal/db/policy/decode_test.go`, add:
+
+```go
+func TestDecode_RedirectStatementRule(t *testing.T) {
+	src := `version: 1
+name: t
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: terminate_reissue
+database_rules:
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: public.safe_users
+`
+	rs, warns, err := loadDB(t, src)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("warnings = %+v", warns)
+	}
+	rules := rs.AllStatementRules()
+	if len(rules) != 1 {
+		t.Fatalf("rules = %d, want 1", len(rules))
+	}
+	if rules[0].Redirect == nil || rules[0].Redirect.Relation != "public.safe_users" {
+		t.Fatalf("Redirect = %+v", rules[0].Redirect)
+	}
+}
+```
+
+In `internal/db/policy/validate_test.go`, replace `TestValidate_RuleDecisionRedirect` with:
+
+```go
+func TestValidate_RuleDecisionRedirect(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	stmt := []*StatementRule{{
+		Name:                  "redirect-users",
+		DBService:             "appdb",
+		Operations:            []string{"READ"},
+		Relations:             []string{"public.users"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+		Redirect:              &RedirectAction{Relation: "public.safe_users"},
+	}}
+	if _, err := helperValidate(t, svcs, stmt, nil); err != nil {
+		t.Fatalf("validate redirect statement rule: %v", err)
+	}
+}
+```
+
+Append these redirect validation tests to `internal/db/policy/validate_test.go`:
+
+```go
+func TestValidate_RedirectRequiresAction(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	stmt := []*StatementRule{{
+		Name:                  "redirect-users",
+		DBService:             "appdb",
+		Operations:            []string{"READ"},
+		Relations:             []string{"public.users"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+	}}
+	_, err := helperValidate(t, svcs, stmt, nil)
+	if err == nil || !strings.Contains(err.Error(), "redirect_relation_required") {
+		t.Fatalf("want redirect_relation_required, got %v", err)
+	}
+}
+
+func TestValidate_RedirectRequiresCanonicalTarget(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	stmt := []*StatementRule{{
+		Name:                  "redirect-users",
+		DBService:             "appdb",
+		Operations:            []string{"READ"},
+		Relations:             []string{"public.users"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+		Redirect:              &RedirectAction{Relation: "safe_users"},
+	}}
+	_, err := helperValidate(t, svcs, stmt, nil)
+	if err == nil || !strings.Contains(err.Error(), "redirect_relation_not_canonical") {
+		t.Fatalf("want redirect_relation_not_canonical, got %v", err)
+	}
+}
+
+func TestValidate_RedirectRequiresCanonicalSourceRelation(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	stmt := []*StatementRule{{
+		Name:                  "redirect-users",
+		DBService:             "appdb",
+		Operations:            []string{"READ"},
+		Relations:             []string{"public.*"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+		Redirect:              &RedirectAction{Relation: "public.safe_users"},
+	}}
+	_, err := helperValidate(t, svcs, stmt, nil)
+	if err == nil || !strings.Contains(err.Error(), "redirect_source_relation_not_canonical") {
+		t.Fatalf("want redirect_source_relation_not_canonical, got %v", err)
+	}
+}
+
+func TestValidate_RedirectRequiresRelations(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	stmt := []*StatementRule{{
+		Name:                  "redirect-users",
+		DBService:             "appdb",
+		Operations:            []string{"READ"},
+		Objects:               []string{"users"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+		Redirect:              &RedirectAction{Relation: "public.safe_users"},
+	}}
+	_, err := helperValidate(t, svcs, stmt, nil)
+	if err == nil || !strings.Contains(err.Error(), "redirect_source_relation_required") {
+		t.Fatalf("want redirect_source_relation_required, got %v", err)
+	}
+}
+
+func TestValidate_RedirectRequiresCatalogResolved(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	stmt := []*StatementRule{{
+		Name:       "redirect-users",
+		DBService:  "appdb",
+		Operations: []string{"READ"},
+		Relations:  []string{"public.users"},
+		Decision:   "redirect",
+		Redirect:   &RedirectAction{Relation: "public.safe_users"},
+	}}
+	_, err := helperValidate(t, svcs, stmt, nil)
+	if err == nil || !strings.Contains(err.Error(), "redirect_requires_catalog_resolved") {
+		t.Fatalf("want redirect_requires_catalog_resolved, got %v", err)
+	}
+}
+
+func TestValidate_RedirectRequiresReadOnlyOperations(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	stmt := []*StatementRule{{
+		Name:                  "redirect-users",
+		DBService:             "appdb",
+		Operations:            []string{"MUTATE"},
+		Relations:             []string{"public.users"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+		Redirect:              &RedirectAction{Relation: "public.safe_users"},
+	}}
+	_, err := helperValidate(t, svcs, stmt, nil)
+	if err == nil || !strings.Contains(err.Error(), "redirect_operations_must_be_read") {
+		t.Fatalf("want redirect_operations_must_be_read, got %v", err)
+	}
+}
+
+func TestValidate_RedirectRequiresTerminatePostgresService(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"legacy": {Name: "legacy", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "passthrough"},
+	}
+	stmt := []*StatementRule{{
+		Name:                  "redirect-users",
+		Operations:            []string{"READ"},
+		Relations:             []string{"public.users"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+		Redirect:              &RedirectAction{Relation: "public.safe_users"},
+	}}
+	_, err := helperValidate(t, svcs, stmt, nil)
+	if err == nil || !strings.Contains(err.Error(), "redirect_requires_terminate_postgres_service") {
+		t.Fatalf("want redirect_requires_terminate_postgres_service, got %v", err)
+	}
+}
+
+func TestValidate_ConnectionRuleRedirectStillInvalid(t *testing.T) {
+	conn := []*ConnectionRule{{Name: "c", Decision: "redirect"}}
+	_, err := helperValidate(t, nil, nil, conn)
+	if err == nil || !strings.Contains(err.Error(), "conn_redirect_invalid") {
+		t.Fatalf("want conn_redirect_invalid, got %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+go test ./internal/db/policy -run 'TestDecisionVerbString|TestDecode_RedirectStatementRule|TestValidate_.*Redirect' -count=1
+```
+
+Expected: FAIL with compile errors for `VerbRedirect`, `RedirectAction`, and `StatementRule.Redirect`.
+
+- [ ] **Step 3: Add policy types**
+
+In `internal/db/policy/types.go`, update `DecisionVerb`:
+
+```go
+const (
+	VerbAllow DecisionVerb = iota
+	VerbAudit
+	VerbRedirect
+	VerbApprove
+	VerbDeny
+)
+```
+
+Update `DecisionVerb.String()`:
+
+```go
+case VerbRedirect:
+	return "redirect"
+```
+
+Add the redirect action and decision metadata types near `StatementRule`:
+
+```go
+// RedirectAction is the on-disk action for statement-level decision: redirect.
+type RedirectAction struct {
+	Relation string `yaml:"relation"`
+}
+
+// RedirectDecision carries the selected source and target relation for a
+// statement-level redirect decision. Both names are canonical schema.name values.
+type RedirectDecision struct {
+	SourceRelation string
+	TargetRelation string
+}
+```
+
+Add the field to `StatementRule`:
+
+```go
+Redirect *RedirectAction `yaml:"redirect,omitempty"`
+```
+
+Add redirect metadata to `Decision`:
+
+```go
+Redirect *RedirectDecision
+```
+
+Update the restrictiveness comment above `DecisionVerb` to say:
+
+```go
+// The numeric ordering (Allow < Audit < Redirect < Approve < Deny) encodes
+// restrictiveness for public verbs. The evaluator uses internalVerb so
+// implicit deny can rank between approve and deny.
+```
+
+- [ ] **Step 4: Add validation helpers**
+
+In `internal/db/policy/validate.go`, change the statement decision switch so statement redirect is accepted:
+
+```go
+case "allow", "deny", "approve", "audit", "redirect":
+	// ok
+```
+
+Then call redirect validation after decision validation:
+
+```go
+if r.Decision == "redirect" {
+	errs = append(errs, validateRedirectStatementRule(r, svcs)...)
+}
+```
+
+In the connection rule decision switch, replace the redirect case with:
+
+```go
+case "redirect":
+	errs = append(errs, fmt.Errorf("conn_redirect_invalid: database_connection_rules[%q]: decision redirect is not valid for DB connection rules", r.Name))
+```
+
+Add these helpers to `internal/db/policy/validate.go`:
+
+```go
+func validateRedirectStatementRule(r *StatementRule, svcs map[ServiceID]*DBService) []error {
+	var errs []error
+	if r.Redirect == nil || strings.TrimSpace(r.Redirect.Relation) == "" {
+		errs = append(errs, fmt.Errorf("redirect_relation_required: database_rules[%q]: redirect.relation is required when decision is redirect", r.Name))
+	} else if !isCanonicalRelationName(r.Redirect.Relation) {
+		errs = append(errs, fmt.Errorf("redirect_relation_not_canonical: database_rules[%q]: redirect.relation %q must be canonical schema.name", r.Name, r.Redirect.Relation))
+	}
+	if len(r.Relations) == 0 {
+		errs = append(errs, fmt.Errorf("redirect_source_relation_required: database_rules[%q]: decision redirect requires exactly one canonical relations selector", r.Name))
+	} else if len(r.Relations) != 1 || !isCanonicalRelationName(r.Relations[0]) {
+		errs = append(errs, fmt.Errorf("redirect_source_relation_not_canonical: database_rules[%q]: decision redirect requires exactly one canonical relations selector, got %v", r.Name, r.Relations))
+	}
+	if r.MatchObjectResolution != "catalog_resolved" {
+		errs = append(errs, fmt.Errorf("redirect_requires_catalog_resolved: database_rules[%q]: decision redirect requires match_object_resolution: catalog_resolved", r.Name))
+	}
+	if !redirectOperationsReadOnly(r) {
+		errs = append(errs, fmt.Errorf("redirect_operations_must_be_read: database_rules[%q]: decision redirect supports read operations only", r.Name))
+	}
+	if !ruleMatchesTerminatePostgresService(r, svcs) {
+		errs = append(errs, fmt.Errorf("redirect_requires_terminate_postgres_service: database_rules[%q]: decision redirect requires at least one matching terminate-mode Postgres service", r.Name))
+	}
+	return errs
+}
+
+func redirectOperationsReadOnly(r *StatementRule) bool {
+	if len(r.Operations) == 0 {
+		return false
+	}
+	for _, op := range r.Operations {
+		groups, ok := effects.ExpandAlias(op)
+		if !ok {
+			return false
+		}
+		for _, g := range groups {
+			if g != effects.GroupRead {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isCanonicalRelationName(s string) bool {
+	parts := strings.Split(s, ".")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return false
+	}
+	return isPlainIdentifier(parts[0]) && isPlainIdentifier(parts[1])
+}
+
+func isPlainIdentifier(s string) bool {
+	for i, r := range s {
+		if r >= 'a' && r <= 'z' || r >= '0' && r <= '9' && i > 0 || r == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+```
+
+- [ ] **Step 5: Run and fix precedence of existing validation checks**
+
+```bash
+go test ./internal/db/policy -run 'TestDecisionVerbString|TestDecode_RedirectStatementRule|TestValidate_.*Redirect' -count=1
+```
+
+Expected: PASS for the new redirect type/validation tests.
+
+- [ ] **Step 6: Run the full policy package**
+
+```bash
+go test ./internal/db/policy -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/db/policy/types.go internal/db/policy/validate.go internal/db/policy/types_test.go internal/db/policy/validate_test.go internal/db/policy/decode_test.go
+git commit -m "feat: accept db redirect policy rules"
+```
+
+## Task 2: Compile And Evaluate Redirect Decisions
+
+**Files:**
+- Modify: `internal/db/policy/compile.go`
+- Modify: `internal/db/policy/evaluate.go`
+- Modify: `internal/db/policy/compile_test.go`
+- Create: `internal/db/policy/evaluate_redirect_test.go`
+
+- [ ] **Step 1: Add failing compile test**
+
+Append to `internal/db/policy/compile_test.go`:
+
+```go
+func TestCompileStatementRule_RedirectAction(t *testing.T) {
+	r := &StatementRule{
+		Name:                  "redirect-users",
+		Operations:            []string{"READ"},
+		Relations:             []string{"public.users"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+		Redirect:              &RedirectAction{Relation: "public.safe_users"},
+	}
+	c, err := compileStatementRule(r)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if c.verb != VerbRedirect {
+		t.Fatalf("verb = %v, want redirect", c.verb)
+	}
+	if c.redirect == nil || c.redirect.SourceRelation != "public.users" || c.redirect.TargetRelation != "public.safe_users" {
+		t.Fatalf("redirect = %+v", c.redirect)
+	}
+}
+```
+
+- [ ] **Step 2: Add failing evaluation tests**
+
+Create `internal/db/policy/evaluate_redirect_test.go`:
+
+```go
+package policy
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
+
+func catalogRead(schema, name string) effects.ClassifiedStatement {
+	return effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogResolved,
+		Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: name}},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			OID:    16384,
+			Schema: schema,
+			Name:   name,
+		}},
+	}}}
+}
+
+func TestEvaluate_RedirectCoversResolvedRelation(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect: {relation: public.safe_users}
+`)
+	d := Evaluate(catalogRead("public", "users"), rs, "appdb")
+	if d.Verb != VerbRedirect || d.RuleName != "redirect-users" {
+		t.Fatalf("decision = %+v, want redirect by redirect-users", d)
+	}
+	if d.Redirect == nil || d.Redirect.SourceRelation != "public.users" || d.Redirect.TargetRelation != "public.safe_users" {
+		t.Fatalf("redirect metadata = %+v", d.Redirect)
+	}
+}
+
+func TestEvaluate_DenyBeatsRedirect(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect: {relation: public.safe_users}
+  - name: deny-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: deny
+`)
+	d := Evaluate(catalogRead("public", "users"), rs, "appdb")
+	if d.Verb != VerbDeny || d.RuleName != "deny-users" {
+		t.Fatalf("decision = %+v, want deny by deny-users", d)
+	}
+}
+
+func TestEvaluate_ApproveBeatsRedirect(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect: {relation: public.safe_users}
+  - name: approve-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: approve
+`)
+	d := Evaluate(catalogRead("public", "users"), rs, "appdb")
+	if d.Verb != VerbApprove || d.RuleName != "approve-users" {
+		t.Fatalf("decision = %+v, want approve by approve-users", d)
+	}
+	if d.Redirect != nil {
+		t.Fatalf("approve decision should not carry redirect metadata: %+v", d.Redirect)
+	}
+}
+
+func TestEvaluate_RedirectBeatsAuditAndAllow(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - name: allow-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: allow
+  - name: audit-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: audit
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect: {relation: public.safe_users}
+`)
+	d := Evaluate(catalogRead("public", "users"), rs, "appdb")
+	if d.Verb != VerbRedirect || d.RuleName != "redirect-users" {
+		t.Fatalf("decision = %+v, want redirect by redirect-users", d)
+	}
+}
+
+func TestEvaluate_ImplicitDenyBeatsRedirect(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect: {relation: public.safe_users}
+`)
+	stmt := effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogResolved,
+		Objects: []effects.ObjectRef{
+			{Kind: effects.ObjectTable, Name: "users"},
+			{Kind: effects.ObjectTable, Name: "orders"},
+		},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			Schema: "public",
+			Name:   "users",
+		}, {
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			Schema: "public",
+			Name:   "orders",
+		}},
+	}}}
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbDeny || d.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny for uncovered orders", d)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests to verify failure**
+
+```bash
+go test ./internal/db/policy -run 'TestCompileStatementRule_RedirectAction|TestEvaluate_.*Redirect|TestEvaluate_DenyBeatsRedirect|TestEvaluate_ApproveBeatsRedirect|TestEvaluate_ImplicitDenyBeatsRedirect' -count=1
+```
+
+Expected: FAIL because compile/evaluation do not yet handle `VerbRedirect`.
+
+- [ ] **Step 4: Compile redirect rules**
+
+In `internal/db/policy/compile.go`, add a compiled redirect field:
+
+```go
+redirect *RedirectDecision
+```
+
+Update the decision switch:
+
+```go
+case "redirect":
+	c.verb = VerbRedirect
+	if r.Redirect != nil && len(r.Relations) == 1 {
+		c.redirect = &RedirectDecision{
+			SourceRelation: r.Relations[0],
+			TargetRelation: r.Redirect.Relation,
+		}
+	}
+```
+
+- [ ] **Step 5: Add internal redirect precedence**
+
+In `internal/db/policy/evaluate.go`, update the `internalVerb` constants and comments:
+
+```go
+const (
+	verbAllow internalVerb = iota
+	verbAudit
+	verbRedirect
+	verbApprove
+	verbImplicitDeny
+	verbDeny
+)
+```
+
+Add redirect state to `effectDecision`:
+
+```go
+redirect *RedirectDecision
+```
+
+In `foldCoverageRules`, add redirect tracking:
+
+```go
+redirectRules []*compiledStatementRule
+```
+
+Inside the rule loop:
+
+```go
+case VerbRedirect:
+	if verbRedirect > best {
+		best = verbRedirect
+	}
+	redirectRules = append(redirectRules, r)
+```
+
+In the primary selection switch:
+
+```go
+case verbRedirect:
+	primary = redirectRules[0]
+```
+
+In the returned `effectDecision`, include:
+
+```go
+redirect: redirectDecisionForRule(primary),
+```
+
+Add this helper:
+
+```go
+func redirectDecisionForRule(r *compiledStatementRule) *RedirectDecision {
+	if r == nil || r.redirect == nil {
+		return nil
+	}
+	return &RedirectDecision{
+		SourceRelation: r.redirect.SourceRelation,
+		TargetRelation: r.redirect.TargetRelation,
+	}
+}
+```
+
+In `foldEffects`, add a `verbRedirect` case before `verbApprove`:
+
+```go
+case verbRedirect:
+	return Decision{
+		Verb:                VerbRedirect,
+		RuleKind:            RuleKindStatement,
+		RuleName:            d.rule.src.Name,
+		MatchingEffectIndex: bestIdx,
+		MatchingEffectGroup: e.Group,
+		Reason:              d.rule.renderMessage(messageContextFor(e, stmt)),
+		Redirect:            d.redirect,
+	}
+```
+
+- [ ] **Step 6: Run policy tests**
+
+```bash
+go test ./internal/db/policy -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/db/policy/compile.go internal/db/policy/evaluate.go internal/db/policy/compile_test.go internal/db/policy/evaluate_redirect_test.go
+git commit -m "feat: evaluate db redirect decisions"
+```
+
+## Task 3: Postgres Rewrite Backend
+
+**Files:**
+- Modify: `internal/db/classify/postgres/parser.go`
+- Modify: `internal/db/classify/postgres/libpgquery.go`
+- Modify: `internal/db/classify/postgres/wasm.go`
+- Create: `internal/db/classify/postgres/rewrite_backend_test.go`
+
+- [ ] **Step 1: Add failing rewrite backend test**
+
+Create `internal/db/classify/postgres/rewrite_backend_test.go`:
+
+```go
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRewriteBackend_ParseDeparse(t *testing.T) {
+	backend := NewRewriteBackend(DialectPostgres)
+	tree, err := backend.Parse("SELECT * FROM public.users")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	out, err := backend.Deparse(tree)
+	if err != nil {
+		t.Fatalf("Deparse: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(out), "public.users") {
+		t.Fatalf("deparsed SQL = %q, want public.users", out)
+	}
+	if backend.Backend().String() == "" {
+		t.Fatalf("Backend string is empty")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+go test ./internal/db/classify/postgres -run TestRewriteBackend_ParseDeparse -count=1
+```
+
+Expected: FAIL with `undefined: NewRewriteBackend`.
+
+- [ ] **Step 3: Add the interface and constructor**
+
+In `internal/db/classify/postgres/parser.go`, add:
+
+```go
+// RewriteBackend exposes parse/deparse operations through the active
+// build-tag-selected libpg_query backend. It is intentionally narrower than
+// Parser so statement rewriting does not depend on classifier internals.
+type RewriteBackend interface {
+	Parse(sql string) (*pg_query.ParseResult, error)
+	Deparse(tree *pg_query.ParseResult) (string, error)
+	Backend() effects.ParserBackend
+}
+
+// NewRewriteBackend returns the rewrite backend for the given dialect.
+func NewRewriteBackend(d Dialect) RewriteBackend {
+	if d.String() == "" {
+		panic(fmt.Sprintf("postgres.NewRewriteBackend: unknown dialect %d", d))
+	}
+	return newRewriteBackend(d)
+}
+```
+
+- [ ] **Step 4: Implement cgo backend**
+
+In `internal/db/classify/postgres/libpgquery.go`, add:
+
+```go
+func newRewriteBackend(d Dialect) RewriteBackend {
+	return &cgoParser{dialect: d}
+}
+
+func (p *cgoParser) Parse(sql string) (*pg_query.ParseResult, error) {
+	return parseCGO(sql)
+}
+
+func (p *cgoParser) Deparse(tree *pg_query.ParseResult) (string, error) {
+	return pg_query.Deparse(tree)
+}
+
+func (p *cgoParser) Backend() effects.ParserBackend {
+	return effects.ParserBackendLibPgQuery
+}
+```
+
+- [ ] **Step 5: Implement WASM backend**
+
+In `internal/db/classify/postgres/wasm.go`, add:
+
+```go
+func newRewriteBackend(d Dialect) RewriteBackend {
+	return &wasmParser{dialect: d}
+}
+
+func (p *wasmParser) Parse(sql string) (*pg_query.ParseResult, error) {
+	return parseWASM(sql)
+}
+
+func (p *wasmParser) Deparse(tree *pg_query.ParseResult) (string, error) {
+	return pgquery_wasm.Deparse(tree)
+}
+
+func (p *wasmParser) Backend() effects.ParserBackend {
+	return effects.ParserBackendPureGo
+}
+```
+
+- [ ] **Step 6: Run focused and cross-platform checks**
+
+```bash
+go test ./internal/db/classify/postgres -run TestRewriteBackend_ParseDeparse -count=1
+GOOS=windows go build ./...
+```
+
+Expected: both commands PASS. The Windows build proves the planner can later import `internal/db/classify/postgres` without pulling in cgo-only deparse code.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/db/classify/postgres/parser.go internal/db/classify/postgres/libpgquery.go internal/db/classify/postgres/wasm.go internal/db/classify/postgres/rewrite_backend_test.go
+git commit -m "feat: expose postgres rewrite backend"
+```
+
+## Task 4: Redirect Planner Contract And Rejections
+
+**Files:**
+- Create: `internal/db/redirect/types.go`
+- Create: `internal/db/redirect/validate.go`
+- Create: `internal/db/redirect/planner.go`
+- Create: `internal/db/redirect/planner_test.go`
+
+- [ ] **Step 1: Add planner contract tests**
+
+Create `internal/db/redirect/planner_test.go`:
+
+```go
+package redirect
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/db/classify/postgres"
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
+
+func testPlanner() Planner {
+	return Planner{Backend: postgres.NewRewriteBackend(postgres.DialectPostgres)}
+}
+
+func testAction() Action {
+	return Action{
+		RuleName:       "redirect-users",
+		SourceRelation: "public.users",
+		TargetRelation: "public.safe_users",
+	}
+}
+
+func resolvedRead(name string) effects.ClassifiedStatement {
+	return effects.ClassifiedStatement{
+		RawVerb: "SELECT",
+		Effects: []effects.Effect{{
+			Group:      effects.GroupRead,
+			Resolution: effects.ResolutionCatalogResolved,
+			Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: name}},
+			ResolvedObjects: []effects.ResolvedObjectRef{{
+				Source: effects.ResolvedObjectSourceCatalog,
+				Kind:   effects.ResolvedObjectRelation,
+				Schema: "public",
+				Name:   name,
+			}},
+		}},
+	}
+}
+
+func rejectionReason(t *testing.T, err error) Reason {
+	t.Helper()
+	var r Rejection
+	if !errors.As(err, &r) {
+		t.Fatalf("error = %v, want Rejection", err)
+	}
+	return r.Reason
+}
+
+func TestPlannerRejectsMissingTarget(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users",
+		Statement: resolvedRead("users"),
+		Action:    Action{RuleName: "redirect-users", SourceRelation: "public.users"},
+	})
+	if got := rejectionReason(t, err); got != ReasonMissingRedirectTarget {
+		t.Fatalf("reason = %q, want %q", got, ReasonMissingRedirectTarget)
+	}
+}
+
+func TestPlannerRejectsUnresolvedObject(t *testing.T) {
+	stmt := resolvedRead("users")
+	stmt.Effects[0].Resolution = effects.ResolutionCatalogUnresolved
+	stmt.Effects[0].ResolvedObjects[0].UnresolvedReason = "missing"
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users",
+		Statement: stmt,
+		Action:    testAction(),
+	})
+	if got := rejectionReason(t, err); got != ReasonUnresolvedObject {
+		t.Fatalf("reason = %q, want %q", got, ReasonUnresolvedObject)
+	}
+}
+
+func TestPlannerRejectsWriteStatement(t *testing.T) {
+	stmt := effects.ClassifiedStatement{
+		RawVerb: "INSERT",
+		Effects: []effects.Effect{{
+			Group:      effects.GroupWrite,
+			Resolution: effects.ResolutionCatalogResolved,
+		}},
+	}
+	_, err := testPlanner().Plan(Input{
+		SQL:       "INSERT INTO public.users(id) VALUES (1)",
+		Statement: stmt,
+		Action:    testAction(),
+	})
+	if got := rejectionReason(t, err); got != ReasonWriteStatement {
+		t.Fatalf("reason = %q, want %q", got, ReasonWriteStatement)
+	}
+}
+
+func TestPlannerRejectsMultiStatement(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users; SELECT 1",
+		Statement: resolvedRead("users"),
+		Action:    testAction(),
+	})
+	if got := rejectionReason(t, err); got != ReasonMultiStatement {
+		t.Fatalf("reason = %q, want %q", got, ReasonMultiStatement)
+	}
+}
+
+func TestPlannerRejectsNonSelectStatement(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "EXPLAIN SELECT * FROM public.users",
+		Statement: resolvedRead("users"),
+		Action:    testAction(),
+	})
+	if got := rejectionReason(t, err); got != ReasonNonSelectStatement {
+		t.Fatalf("reason = %q, want %q", got, ReasonNonSelectStatement)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+go test ./internal/db/redirect -count=1
+```
+
+Expected: FAIL because package `internal/db/redirect` does not exist.
+
+- [ ] **Step 3: Add planner types**
+
+Create `internal/db/redirect/types.go`:
+
+```go
+package redirect
+
+import (
+	"fmt"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+)
+
+type Reason string
+
+const (
+	ReasonUnsupportedStatement  Reason = "unsupported_statement"
+	ReasonMultiStatement        Reason = "multi_statement"
+	ReasonNonSelectStatement    Reason = "non_select_statement"
+	ReasonWriteStatement        Reason = "write_statement"
+	ReasonDDLStatement          Reason = "ddl_statement"
+	ReasonCopyStatement         Reason = "copy_statement"
+	ReasonProceduralStatement   Reason = "procedural_statement"
+	ReasonFunctionCallProtocol  Reason = "function_call_protocol"
+	ReasonUnresolvedObject      Reason = "unresolved_object"
+	ReasonMissingRedirectTarget Reason = "missing_redirect_target"
+	ReasonAmbiguousSource       Reason = "ambiguous_redirect_source"
+	ReasonSourceNotFound        Reason = "source_relation_not_found"
+	ReasonDeparseFailed         Reason = "deparse_failed"
+)
+
+type Rejection struct {
+	Reason Reason
+	Err    error
+}
+
+func (r Rejection) Error() string {
+	if r.Err != nil {
+		return fmt.Sprintf("%s: %v", r.Reason, r.Err)
+	}
+	return string(r.Reason)
+}
+
+func (r Rejection) Unwrap() error { return r.Err }
+
+type Action struct {
+	RuleName       string
+	SourceRelation string
+	TargetRelation string
+}
+
+type Input struct {
+	SQL       string
+	Statement effects.ClassifiedStatement
+	Action    Action
+}
+
+type Plan struct {
+	RewrittenSQL   string
+	RuleName       string
+	SourceRelation string
+	TargetRelation string
+}
+
+type SQLBackend interface {
+	Parse(sql string) (*pg_query.ParseResult, error)
+	Deparse(tree *pg_query.ParseResult) (string, error)
+	Backend() effects.ParserBackend
+}
+
+type Planner struct {
+	Backend SQLBackend
+}
+```
+
+- [ ] **Step 4: Add validation**
+
+Create `internal/db/redirect/validate.go`:
+
+```go
+package redirect
+
+import (
+	"strings"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
+
+func validateInput(in Input) error {
+	if strings.TrimSpace(in.Action.TargetRelation) == "" {
+		return Rejection{Reason: ReasonMissingRedirectTarget}
+	}
+	if strings.TrimSpace(in.Action.SourceRelation) == "" {
+		return Rejection{Reason: ReasonSourceNotFound}
+	}
+	if len(in.Statement.Effects) == 0 {
+		return Rejection{Reason: ReasonUnsupportedStatement}
+	}
+	for _, eff := range in.Statement.Effects {
+		if eff.Subtype == effects.SubtypeFunctionCallProtocol {
+			return Rejection{Reason: ReasonFunctionCallProtocol}
+		}
+		switch eff.Group {
+		case effects.GroupRead:
+			if eff.Resolution != effects.ResolutionCatalogResolved {
+				return Rejection{Reason: ReasonUnresolvedObject}
+			}
+			for _, resolved := range eff.ResolvedObjects {
+				if resolved.UnresolvedReason != "" {
+					return Rejection{Reason: ReasonUnresolvedObject}
+				}
+			}
+		case effects.GroupWrite, effects.GroupModify, effects.GroupDelete:
+			return Rejection{Reason: ReasonWriteStatement}
+		case effects.GroupSchemaCreate, effects.GroupSchemaAlter, effects.GroupSchemaDestroy, effects.GroupPrivilege:
+			return Rejection{Reason: ReasonDDLStatement}
+		case effects.GroupBulkLoad, effects.GroupBulkExport:
+			return Rejection{Reason: ReasonCopyStatement}
+		case effects.GroupProcedural, effects.GroupUnsafeIO:
+			return Rejection{Reason: ReasonProceduralStatement}
+		case effects.GroupUnknown:
+			return Rejection{Reason: ReasonUnsupportedStatement}
+		default:
+			return Rejection{Reason: ReasonUnsupportedStatement}
+		}
+	}
+	if !statementContainsResolvedRelation(in.Statement, in.Action.SourceRelation) {
+		return Rejection{Reason: ReasonSourceNotFound}
+	}
+	return nil
+}
+
+func statementContainsResolvedRelation(stmt effects.ClassifiedStatement, canonical string) bool {
+	for _, eff := range stmt.Effects {
+		for _, resolved := range eff.ResolvedObjects {
+			if resolved.Source == effects.ResolvedObjectSourceCatalog &&
+				resolved.Kind == effects.ResolvedObjectRelation &&
+				resolved.UnresolvedReason == "" &&
+				resolved.CanonicalName() == canonical {
+				return true
+			}
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 5: Add planner orchestration**
+
+Create `internal/db/redirect/planner.go`:
+
+```go
+package redirect
+
+import pg_query "github.com/pganalyze/pg_query_go/v6"
+
+func (p Planner) Plan(in Input) (Plan, error) {
+	if err := validateInput(in); err != nil {
+		return Plan{}, err
+	}
+	if p.Backend == nil {
+		return Plan{}, Rejection{Reason: ReasonUnsupportedStatement}
+	}
+	tree, err := p.Backend.Parse(in.SQL)
+	if err != nil {
+		return Plan{}, Rejection{Reason: ReasonUnsupportedStatement, Err: err}
+	}
+	if tree == nil || len(tree.Stmts) != 1 {
+		return Plan{}, Rejection{Reason: ReasonMultiStatement}
+	}
+	raw := tree.Stmts[0]
+	if raw == nil || raw.Stmt == nil {
+		return Plan{}, Rejection{Reason: ReasonUnsupportedStatement}
+	}
+	node, ok := raw.Stmt.Node.(*pg_query.Node_SelectStmt)
+	if !ok || node.SelectStmt == nil {
+		return Plan{}, Rejection{Reason: ReasonNonSelectStatement}
+	}
+	if node.SelectStmt.IntoClause != nil {
+		return Plan{}, Rejection{Reason: ReasonDDLStatement}
+	}
+	if len(node.SelectStmt.LockingClause) > 0 {
+		return Plan{}, Rejection{Reason: ReasonUnsupportedStatement}
+	}
+	return Plan{}, Rejection{Reason: ReasonSourceNotFound}
+}
+```
+
+- [ ] **Step 6: Run rejection tests**
+
+```bash
+go test ./internal/db/redirect -run 'TestPlannerRejects' -count=1
+```
+
+Expected: PASS for the rejection tests added in this task.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/db/redirect/types.go internal/db/redirect/validate.go internal/db/redirect/planner.go internal/db/redirect/planner_test.go
+git commit -m "feat: add redirect planner contract"
+```
+
+## Task 5: Relation Rewrite For Simple SELECT And Joins
+
+**Files:**
+- Modify: `internal/db/redirect/planner.go`
+- Create: `internal/db/redirect/walk.go`
+- Modify: `internal/db/redirect/planner_test.go`
+
+- [ ] **Step 1: Add failing rewrite tests**
+
+Append to `internal/db/redirect/planner_test.go`:
+
+```go
+func TestPlannerRewritesQualifiedRelation(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users",
+		Statement: resolvedRead("users"),
+		Action:    testAction(),
+	})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if plan.RuleName != "redirect-users" || plan.SourceRelation != "public.users" || plan.TargetRelation != "public.safe_users" {
+		t.Fatalf("metadata = %+v", plan)
+	}
+	want := "public.safe_users"
+	if !strings.Contains(strings.ToLower(plan.RewrittenSQL), want) {
+		t.Fatalf("rewritten SQL = %q, want %s", plan.RewrittenSQL, want)
+	}
+	if strings.Contains(strings.ToLower(plan.RewrittenSQL), "public.users") {
+		t.Fatalf("rewritten SQL still contains source relation: %q", plan.RewrittenSQL)
+	}
+}
+
+func TestPlannerRewritesUnqualifiedResolvedRelation(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM users",
+		Statement: resolvedRead("users"),
+		Action:    testAction(),
+	})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(plan.RewrittenSQL), "public.safe_users") {
+		t.Fatalf("rewritten SQL = %q, want public.safe_users", plan.RewrittenSQL)
+	}
+}
+
+func TestPlannerPreservesAlias(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "SELECT u.id FROM public.users AS u WHERE u.id = $1",
+		Statement: resolvedRead("users"),
+		Action:    testAction(),
+	})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	lower := strings.ToLower(plan.RewrittenSQL)
+	if !strings.Contains(lower, "public.safe_users") || !strings.Contains(lower, "u") {
+		t.Fatalf("rewritten SQL = %q, want target relation and alias", plan.RewrittenSQL)
+	}
+}
+
+func TestPlannerRewritesOneRelationInJoin(t *testing.T) {
+	stmt := resolvedRead("users")
+	stmt.Effects[0].Objects = append(stmt.Effects[0].Objects, effects.ObjectRef{Kind: effects.ObjectTable, Name: "orders"})
+	stmt.Effects[0].ResolvedObjects = append(stmt.Effects[0].ResolvedObjects, effects.ResolvedObjectRef{
+		Source: effects.ResolvedObjectSourceCatalog,
+		Kind:   effects.ResolvedObjectRelation,
+		Schema: "public",
+		Name:   "orders",
+	})
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "SELECT u.id FROM public.users u JOIN public.orders o ON o.user_id = u.id",
+		Statement: stmt,
+		Action:    testAction(),
+	})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	lower := strings.ToLower(plan.RewrittenSQL)
+	if !strings.Contains(lower, "public.safe_users") || !strings.Contains(lower, "public.orders") {
+		t.Fatalf("rewritten SQL = %q, want rewritten users and unchanged orders", plan.RewrittenSQL)
+	}
+}
+```
+
+Add `strings` to the test imports:
+
+```go
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```bash
+go test ./internal/db/redirect -run 'TestPlannerRewrites|TestPlannerPreservesAlias' -count=1
+```
+
+Expected: FAIL with `source_relation_not_found`.
+
+- [ ] **Step 3: Add relation walker**
+
+Create `internal/db/redirect/walk.go`:
+
+```go
+package redirect
+
+import pg_query "github.com/pganalyze/pg_query_go/v6"
+
+func rewriteSelectRelations(sel *pg_query.SelectStmt, source, targetSchema, targetName string) (int, error) {
+	if sel == nil {
+		return 0, nil
+	}
+	if len(sel.LockingClause) > 0 {
+		return 0, Rejection{Reason: ReasonUnsupportedStatement}
+	}
+	total, err := rewriteRangeList(sel.FromClause, source, targetSchema, targetName)
+	if err != nil {
+		return 0, err
+	}
+	if sel.WithClause != nil {
+		for _, c := range sel.WithClause.Ctes {
+			count, err := rewriteCTE(c, source, targetSchema, targetName)
+			if err != nil {
+				return 0, err
+			}
+			total += count
+		}
+	}
+	if sel.Larg != nil {
+		count, err := rewriteSelectRelations(sel.Larg, source, targetSchema, targetName)
+		if err != nil {
+			return 0, err
+		}
+		total += count
+	}
+	if sel.Rarg != nil {
+		count, err := rewriteSelectRelations(sel.Rarg, source, targetSchema, targetName)
+		if err != nil {
+			return 0, err
+		}
+		total += count
+	}
+	return total, nil
+}
+
+func rewriteRangeList(list []*pg_query.Node, source, targetSchema, targetName string) (int, error) {
+	total := 0
+	for _, n := range list {
+		count, err := rewriteRangeNode(n, source, targetSchema, targetName)
+		if err != nil {
+			return 0, err
+		}
+		total += count
+	}
+	return total, nil
+}
+
+func rewriteRangeNode(n *pg_query.Node, source, targetSchema, targetName string) (int, error) {
+	if n == nil {
+		return 0, nil
+	}
+	switch v := n.Node.(type) {
+	case *pg_query.Node_RangeVar:
+		if v.RangeVar == nil {
+			return 0, nil
+		}
+		if !rangeVarMatchesSource(v.RangeVar, source) {
+			return 0, nil
+		}
+		v.RangeVar.Schemaname = targetSchema
+		v.RangeVar.Relname = targetName
+		return 1, nil
+	case *pg_query.Node_JoinExpr:
+		if v.JoinExpr == nil {
+			return 0, nil
+		}
+		left, err := rewriteRangeNode(v.JoinExpr.Larg, source, targetSchema, targetName)
+		if err != nil {
+			return 0, err
+		}
+		right, err := rewriteRangeNode(v.JoinExpr.Rarg, source, targetSchema, targetName)
+		if err != nil {
+			return 0, err
+		}
+		return left + right, nil
+	case *pg_query.Node_RangeSubselect:
+		if v.RangeSubselect == nil || v.RangeSubselect.Subquery == nil {
+			return 0, nil
+		}
+		sub, ok := v.RangeSubselect.Subquery.Node.(*pg_query.Node_SelectStmt)
+		if !ok || sub.SelectStmt == nil {
+			return 0, Rejection{Reason: ReasonUnsupportedStatement}
+		}
+		return rewriteSelectRelations(sub.SelectStmt, source, targetSchema, targetName)
+	case *pg_query.Node_RangeFunction:
+		return 0, Rejection{Reason: ReasonProceduralStatement}
+	default:
+		return 0, nil
+	}
+}
+
+func rewriteCTE(n *pg_query.Node, source, targetSchema, targetName string) (int, error) {
+	if n == nil {
+		return 0, nil
+	}
+	cte, ok := n.Node.(*pg_query.Node_CommonTableExpr)
+	if !ok || cte.CommonTableExpr == nil || cte.CommonTableExpr.Ctequery == nil {
+		return 0, nil
+	}
+	sub, ok := cte.CommonTableExpr.Ctequery.Node.(*pg_query.Node_SelectStmt)
+	if !ok || sub.SelectStmt == nil {
+		return 0, Rejection{Reason: ReasonWriteStatement}
+	}
+	return rewriteSelectRelations(sub.SelectStmt, source, targetSchema, targetName)
+}
+
+func rangeVarMatchesSource(r *pg_query.RangeVar, source string) bool {
+	if r == nil {
+		return false
+	}
+	if r.Schemaname != "" {
+		return r.Schemaname+"."+r.Relname == source
+	}
+	return r.Relname == relationName(source)
+}
+```
+
+- [ ] **Step 4: Complete planner rewrite**
+
+In `internal/db/redirect/planner.go`, after the `SelectStmt` checks, replace the `ReasonSourceNotFound` return with:
+
+```go
+targetSchema, targetName := splitCanonical(in.Action.TargetRelation)
+count, err := rewriteSelectRelations(node.SelectStmt, in.Action.SourceRelation, targetSchema, targetName)
+if err != nil {
+	return Plan{}, err
+}
+if count == 0 {
+	return Plan{}, Rejection{Reason: ReasonSourceNotFound}
+}
+if count > 1 {
+	return Plan{}, Rejection{Reason: ReasonAmbiguousSource}
+}
+rewritten, err := p.Backend.Deparse(tree)
+if err != nil {
+	return Plan{}, Rejection{Reason: ReasonDeparseFailed, Err: err}
+}
+return Plan{
+	RewrittenSQL:   rewritten,
+	RuleName:       in.Action.RuleName,
+	SourceRelation: in.Action.SourceRelation,
+	TargetRelation: in.Action.TargetRelation,
+}, nil
+```
+
+Add helpers to `internal/db/redirect/planner.go`:
+
+```go
+func splitCanonical(s string) (string, string) {
+	for i, r := range s {
+		if r == '.' {
+			return s[:i], s[i+1:]
+		}
+	}
+	return "", s
+}
+
+func relationName(canonical string) string {
+	_, name := splitCanonical(canonical)
+	return name
+}
+```
+
+- [ ] **Step 5: Run redirect planner tests**
+
+```bash
+go test ./internal/db/redirect -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/db/redirect/planner.go internal/db/redirect/walk.go internal/db/redirect/planner_test.go
+git commit -m "feat: rewrite redirected select relations"
+```
+
+## Task 6: Nested SELECT Forms And Safety Rejections
+
+**Files:**
+- Modify: `internal/db/redirect/planner_test.go`
+- Modify: `internal/db/redirect/walk.go`
+- Modify: `internal/db/redirect/validate.go`
+
+- [ ] **Step 1: Add nested rewrite and safety tests**
+
+Append to `internal/db/redirect/planner_test.go`:
+
+```go
+func TestPlannerRewritesNestedSubselect(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM (SELECT id FROM public.users) s",
+		Statement: resolvedRead("users"),
+		Action:    testAction(),
+	})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(plan.RewrittenSQL), "public.safe_users") {
+		t.Fatalf("rewritten SQL = %q, want public.safe_users", plan.RewrittenSQL)
+	}
+}
+
+func TestPlannerRewritesReadOnlyCTE(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "WITH u AS (SELECT id FROM public.users) SELECT * FROM u",
+		Statement: resolvedRead("users"),
+		Action:    testAction(),
+	})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(plan.RewrittenSQL), "public.safe_users") {
+		t.Fatalf("rewritten SQL = %q, want public.safe_users", plan.RewrittenSQL)
+	}
+}
+
+func TestPlannerRewritesSetOperation(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "SELECT id FROM public.users UNION ALL SELECT id FROM public.archive_users",
+		Statement: resolvedRead("users"),
+		Action:    testAction(),
+	})
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if !strings.Contains(strings.ToLower(plan.RewrittenSQL), "public.safe_users") {
+		t.Fatalf("rewritten SQL = %q, want public.safe_users", plan.RewrittenSQL)
+	}
+}
+
+func TestPlannerRejectsSelectInto(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * INTO new_users FROM public.users",
+		Statement: resolvedRead("users"),
+		Action:    testAction(),
+	})
+	if got := rejectionReason(t, err); got != ReasonDDLStatement {
+		t.Fatalf("reason = %q, want %q", got, ReasonDDLStatement)
+	}
+}
+
+func TestPlannerRejectsDataModifyingCTE(t *testing.T) {
+	stmt := resolvedRead("users")
+	stmt.Effects = append(stmt.Effects, effects.Effect{Group: effects.GroupDelete, Resolution: effects.ResolutionCatalogResolved})
+	_, err := testPlanner().Plan(Input{
+		SQL:       "WITH d AS (DELETE FROM public.users RETURNING id) SELECT * FROM d",
+		Statement: stmt,
+		Action:    testAction(),
+	})
+	if got := rejectionReason(t, err); got != ReasonWriteStatement {
+		t.Fatalf("reason = %q, want %q", got, ReasonWriteStatement)
+	}
+}
+
+func TestPlannerRejectsLockingClause(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users FOR UPDATE",
+		Statement: resolvedRead("users"),
+		Action:    testAction(),
+	})
+	if got := rejectionReason(t, err); got != ReasonUnsupportedStatement {
+		t.Fatalf("reason = %q, want %q", got, ReasonUnsupportedStatement)
+	}
+}
+
+func TestPlannerRejectsRangeFunction(t *testing.T) {
+	stmt := resolvedRead("users")
+	stmt.Effects = append(stmt.Effects, effects.Effect{Group: effects.GroupProcedural, Resolution: effects.ResolutionCatalogResolved})
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM generate_series(1, 3)",
+		Statement: stmt,
+		Action:    testAction(),
+	})
+	if got := rejectionReason(t, err); got != ReasonProceduralStatement {
+		t.Fatalf("reason = %q, want %q", got, ReasonProceduralStatement)
+	}
+}
+
+func TestPlannerRejectsMultipleSourceOccurrences(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users u1 JOIN public.users u2 ON u1.id = u2.id",
+		Statement: resolvedRead("users"),
+		Action:    testAction(),
+	})
+	if got := rejectionReason(t, err); got != ReasonAmbiguousSource {
+		t.Fatalf("reason = %q, want %q", got, ReasonAmbiguousSource)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+go test ./internal/db/redirect -count=1
+```
+
+Expected: PASS. The validation layer should reject data-modifying CTEs and procedural effects before AST rewrite reaches unsupported nodes.
+
+- [ ] **Step 3: Run policy and redirect packages together**
+
+```bash
+go test ./internal/db/policy ./internal/db/redirect -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/db/redirect/planner_test.go internal/db/redirect/walk.go internal/db/redirect/validate.go
+git commit -m "test: cover redirect planner safety boundaries"
+```
+
+## Task 7: Documentation And Final Verification
+
+**Files:**
+- Modify: `docs/agentsh-db-access-spec.md`
+- Read: `docs/superpowers/specs/2026-05-15-db-plan-11-redirect-planner-design.md`
+
+- [ ] **Step 1: Update DB access spec statement-rule field table**
+
+In `docs/agentsh-db-access-spec.md`, update the statement rule `decision` row from:
+
+```markdown
+| `decision` | yes | `allow`, `deny`, `approve`, `audit`. |
+```
+
+to:
+
+```markdown
+| `decision` | yes | `allow`, `deny`, `approve`, `audit`, `redirect`. `redirect` is statement-level only and requires `redirect.relation`, `relations`, `match_object_resolution: catalog_resolved`, read-only operations, and an eligible terminate-mode Postgres service. |
+```
+
+Add a row after `decision`:
+
+```markdown
+| `redirect.relation` | only for `decision: redirect` | Canonical target relation formatted as `schema.name`. Plan 11 supports one source relation selected by a canonical `relations` entry and one target relation. Runtime execution is wired in DB Plan 12. |
+```
+
+- [ ] **Step 2: Update Phase 1 redirect rejection text**
+
+Find the bullet:
+
+```markdown
+- Rule with `decision: redirect` in Phase 1 → load error.
+```
+
+Replace it with:
+
+```markdown
+- Statement rule with malformed `decision: redirect` shape → load error. Connection-rule redirect remains invalid.
+```
+
+- [ ] **Step 3: Run docs diff check**
+
+```bash
+git diff -- docs/agentsh-db-access-spec.md
+```
+
+Expected: diff only updates redirect policy documentation. It must not describe Simple Query or Extended Query redirect execution as implemented in this plan.
+
+- [ ] **Step 4: Run full verification**
+
+```bash
+go test ./internal/db/policy ./internal/db/classify/postgres ./internal/db/redirect -count=1
+GOOS=windows go build ./...
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 5: Confirm Plan 12 dependency gate**
+
+```bash
+rg -n "VerbRedirect|RedirectDecision|type Planner|func \\(p Planner\\) Plan|ReasonAmbiguousSource" internal/db/policy internal/db/redirect
+```
+
+Expected: output includes:
+
+- `VerbRedirect`
+- `RedirectDecision`
+- `type Planner`
+- `func (p Planner) Plan`
+- `ReasonAmbiguousSource`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/agentsh-db-access-spec.md
+git commit -m "docs: update db redirect policy spec"
+```
+
+## Task 8: Final Branch Check
+
+**Files:**
+- No code files
+
+- [ ] **Step 1: Run complete tests for touched DB packages**
+
+```bash
+go test ./internal/db/... -count=1
+```
+
+Expected: PASS. If unrelated integration tests require external Postgres and fail in the local environment, run the focused command from Task 7 Step 4 and record the exact skipped/failing package.
+
+- [ ] **Step 2: Run cross-platform build**
+
+```bash
+GOOS=windows go build ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Review final diff**
+
+```bash
+git status --short --branch
+git log --oneline --max-count=8
+```
+
+Expected: clean worktree on `feature/db-plan-11-redirect-planner`, with commits from Tasks 1-7.
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - Redirect YAML/action support: Task 1.
+  - Redirect validation for statement-only, terminate-mode Postgres, read-only, canonical source/target, catalog resolution: Task 1.
+  - Redirect precedence and policy metadata: Task 2.
+  - Cross-platform parse/deparse seam: Task 3.
+  - Planner contract and rejection reasons: Task 4.
+  - AST relation replacement with aliases, joins, nested subselects, CTEs, set operations: Tasks 5 and 6.
+  - Runtime boundaries: File Structure and Task 7 docs explicitly exclude proxy runtime changes.
+- Placeholder scan:
+  - The plan contains concrete tests, commands, expected results, and code snippets for each implementation step.
+- Type consistency:
+  - Policy uses `RedirectAction` for YAML and `RedirectDecision` for evaluated metadata.
+  - Planner uses `Action`, `Input`, `Plan`, `Reason`, `Rejection`, and `Planner.Plan`.
+  - Postgres rewrite seam uses `RewriteBackend`.

--- a/docs/superpowers/specs/2026-05-14-db-plan-12-redirect-runtime-integration-design.md
+++ b/docs/superpowers/specs/2026-05-14-db-plan-12-redirect-runtime-integration-design.md
@@ -1,0 +1,212 @@
+# DB Plan 12 Redirect Runtime Integration Design
+
+**Status:** Approved by operator direction on 2026-05-14.
+**Owner:** Canyon Road
+**Source specs:**
+- `docs/agentsh-db-access-spec.md` v0.8, Phase 2 row.
+- `docs/superpowers/specs/2026-05-14-db-phase-2-roadmap-design.md`
+- DB Plan 11 Redirect Planner contract.
+
+Plan 12 makes Postgres `decision: redirect` usable at runtime. It wires the Plan 11 redirect planner into the existing Postgres proxy, forwards rewritten read-only statements when safe, fails closed when unsafe, and records explicit redirect audit metadata.
+
+This plan is runtime integration only. SQL rewrite planning stays owned by Plan 11. If Plan 12 discovers a missing planner contract detail, it may add a narrow adapter seam, but it must not redesign planner behavior.
+
+---
+
+## 1. Goals
+
+- Execute safe redirect plans in Simple Query.
+- Execute safe redirect plans in Extended Query `Parse`.
+- Cache rewritten prepared-statement classification and redirect metadata without changing client-visible prepared statement names.
+- Emit DB events that preserve the original client statement identity and add redirect-specific audit fields.
+- Fail closed whenever redirect cannot be executed safely.
+- Prove the behavior with focused unit tests and real Postgres CI tests.
+
+External behavior: `decision: redirect` becomes usable for read-only Postgres relation replacement. Clients see normal query results or normal PostgreSQL errors. They do not receive redirect notices by default.
+
+---
+
+## 2. Architecture
+
+Plan 12 adds a thin runtime adapter between the existing proxy policy path and the Plan 11 redirect planner.
+
+Runtime entry points:
+
+- Simple Query: classify and resolve the statement, evaluate DB policy, ask the redirect planner when the winning decision is `redirect`, then forward rewritten SQL upstream.
+- Extended Query `Parse`: classify and resolve `Parse.Query`, evaluate DB policy, ask the redirect planner when the winning decision is `redirect`, forward rewritten SQL upstream, and cache rewritten metadata under the client-visible prepared statement name.
+- Extended Query `Bind` and `Execute`: use prepared-cache metadata only. They must not inspect SQL or re-plan redirect.
+- Audit sink: emit original digest, rewritten digest, redirect rule, source relation, target relation, planner status, and runtime status.
+- Error path: synthesize PostgreSQL protocol errors and preserve proxy state when redirect cannot be safely executed.
+
+Invariant: once policy returns `redirect`, the proxy must not forward the original SQL unless the planner returned a valid rewrite that intentionally preserves it. Unsafe redirect means fail closed, not fall back to allow.
+
+---
+
+## 3. Runtime Data Flow
+
+### Simple Query
+
+1. Receive a Simple Query SQL batch.
+2. Classify the statement and attach catalog resolution metadata.
+3. Evaluate policy.
+4. For `deny`, use the existing deny path.
+5. For existing non-redirect decisions, use the existing path.
+6. For `redirect`, call the Plan 11 planner with the resolved statement, policy action, and current resolver context.
+7. If planning succeeds, forward rewritten SQL upstream.
+8. Emit a DB event with original digest, rewritten digest, redirect rule, source relation, target relation, and runtime status.
+9. If planning fails or returns an unsafe result, synthesize an error and do not forward the original SQL.
+
+Multi-statement redirect candidates fail closed in Plan 12. Future plans can revisit whole-batch redirects after the single-statement runtime path is stable.
+
+### Extended Query
+
+1. On `Parse`, classify and resolve `Parse.Query`.
+2. Evaluate policy.
+3. For `redirect`, call the Plan 11 planner at `Parse` time only.
+4. If planning succeeds, send upstream `Parse` with rewritten SQL while preserving the original client prepared statement name.
+5. Store a prepared-cache entry containing original classification, rewritten classification, original digest, rewritten digest, redirect rule, source relation, target relation, and parse-time policy identity.
+6. On `Bind` and `Execute`, use the cached rewritten metadata. Do not re-plan.
+7. If `Parse` fails closed, do not create a usable prepared-cache entry.
+
+Prepared statements keep their parse-time redirect plan. Policy reload affects new Simple Query statements and new Extended Query `Parse` messages only.
+
+---
+
+## 4. Error Handling
+
+Redirect runtime failures are policy enforcement failures, not upstream database failures.
+
+Rules:
+
+- `deny` always wins before redirect execution.
+- If policy returns `redirect` and runtime cannot produce a valid rewritten statement, fail closed.
+- Never forward original SQL after a redirect decision unless the planner returned a valid rewrite that intentionally keeps the same SQL.
+- Do not emit `NoticeResponse` by default. Redirect is transparent to clients and explicit in audit.
+
+Fail-closed cases:
+
+- Planner rejects the statement form.
+- Target relation cannot be resolved.
+- Rewritten SQL is empty, unparsable, or reclassifies into an unsafe operation.
+- Source or target metadata is stale or inconsistent.
+- Multi-statement, write, DDL, COPY, FunctionCall, or another unsupported protocol/query form.
+- Prepared-cache lookup disagrees with expected redirect metadata.
+
+Protocol behavior:
+
+- Simple Query: synthesize a PostgreSQL `ErrorResponse`, preserve `ReadyForQuery` state, and emit a DB event with redirect rejection fields.
+- Extended Query `Parse`: synthesize `ErrorResponse`, do not forward `Parse` upstream, and do not create a usable prepared-cache entry.
+- Extended Query `Bind` and `Execute`: if cached redirect metadata is missing or corrupt, fail closed using the existing extended-protocol error path.
+- If rewritten SQL was safely forwarded and upstream Postgres returns an error, pass that error through. The DB event records redirect execution, not guaranteed query success.
+
+---
+
+## 5. Data Model
+
+Plan 12 keeps existing event fields compatible and adds redirect-specific fields beside them.
+
+The runtime adapter consumes a Plan 11 planner result with:
+
+- Rewritten SQL.
+- Rewritten statement digest.
+- Redirect rule id or name.
+- Source relation.
+- Target relation.
+- Rejection reason when unsupported.
+
+Prepared-cache entries gain redirect metadata:
+
+- Original classification and digest.
+- Rewritten classification and digest.
+- Redirect rule.
+- Source and target relation.
+- Parse-time policy identity.
+
+DB events keep the existing statement and digest as the original client statement. Redirect adds explicit fields:
+
+- `redirected`
+- `redirect_rule`
+- `rewritten_statement_digest`
+- `redirect_source_relation`
+- `redirect_target_relation`
+- `redirect_runtime_status`
+- `redirect_rejection_reason`
+
+Plan 12 does not store full rewritten SQL text by default unless existing statement-redaction settings already allow equivalent SQL text exposure. The rewritten digest plus rule/source/target metadata is enough for audit and avoids creating a new leakage path.
+
+---
+
+## 6. Policy And Prepared Statements
+
+Redirect sits after policy evaluation and before forwarding.
+
+- `deny` always wins.
+- `redirect` only executes when it is the final winning policy decision.
+- `approve`, `audit`, and `allow` keep their existing behavior unless the final winning policy action is explicitly `redirect`.
+- The runtime does not add a separate client-visible approval prompt or notice for redirect.
+- Redirect remains allow-like for audit semantics: successful redirect is an allowed upstream query with explicit redirect fields.
+- Policy reload affects new Simple Query statements and new Extended Query `Parse` messages.
+- Existing prepared statements keep their parse-time redirect plan after policy reload.
+- Prepared statement names stay client-visible as originally supplied; only upstream SQL and cached metadata use the rewritten target.
+
+This avoids surprising clients and prevents policy reload from retroactively changing already-parsed prepared statements.
+
+---
+
+## 7. Testing
+
+Plan 12 needs focused unit coverage plus real Postgres integration coverage.
+
+Unit coverage:
+
+- Simple Query redirects forward rewritten SQL and emit redirect event fields.
+- Simple Query redirect failures synthesize an error and never forward original SQL.
+- Extended Query `Parse` stores rewritten classification and redirect metadata.
+- `Bind` and `Execute` use cached metadata and never re-plan.
+- Deny precedence: deny beats redirect.
+- Policy reload affects new statements but not existing prepared entries.
+- Event builder preserves original digest and adds redirect fields.
+
+Real Postgres CI gate:
+
+- Simple Query `SELECT ... FROM source` returns rows from target.
+- Extended Query prepared statement stays redirected across repeated `Bind`/`Execute`.
+- Named prepared statements keep the original client name while upstream uses rewritten SQL.
+- Policy reload changes redirect target for new statements without corrupting existing prepared state.
+- Unsupported forms fail closed: writes, COPY, multi-statement, and unresolved target.
+
+Plan 12 does not add a separate transaction-behavior suite unless implementation uncovers a concrete transaction-state bug. Existing cross-platform expectations still apply: pure Go unit tests should build everywhere, and platform-specific integration harnesses should skip only when their dependencies are unavailable.
+
+---
+
+## 8. Scope
+
+### In Scope
+
+- Wire the Plan 11 redirect planner into Simple Query.
+- Wire the Plan 11 redirect planner into Extended Query `Parse`.
+- Extend prepared-cache metadata for rewritten classification and redirect audit data.
+- Emit redirect-specific DB event fields.
+- Fail closed with correct PostgreSQL protocol behavior.
+- Add unit tests and real Postgres integration tests.
+
+### Out of Scope
+
+- Redesigning the redirect planner.
+- Re-planning at `Bind` or `Execute`.
+- Redirecting writes, DDL, COPY, FunctionCall, or unsupported multi-statement batches.
+- Client-facing redirect notices.
+- Result-set rewriting or DLP transforms.
+- Cross-database or cross-service routing.
+- Broad policy language redesign.
+
+---
+
+## 9. Success Criteria
+
+- Redirected Simple Query and Extended Query paths execute rewritten SQL only after a valid planner result.
+- Original SQL is never forwarded after an unsafe redirect decision.
+- Prepared statements do not mix original and rewritten statement identity.
+- DB events identify both original client intent and redirect target.
+- Deny precedence and existing non-redirect policy behavior remain unchanged.
+- Real Postgres CI proves the supported redirect flows and unsupported fail-closed cases.

--- a/docs/superpowers/specs/2026-05-15-db-plan-11-redirect-planner-design.md
+++ b/docs/superpowers/specs/2026-05-15-db-plan-11-redirect-planner-design.md
@@ -1,0 +1,271 @@
+# DB Plan 11 Redirect Planner Design
+
+## Context
+
+DB Phase 2 introduces catalog-backed policy ergonomics and safe Postgres statement rewriting. DB Plan 10 added canonical relation/function selectors and intentionally kept `decision: redirect` invalid. DB Plan 12 is already scoped as runtime integration, but it depends on a Plan 11 contract that does not exist yet.
+
+Plan 11 fills that gap. It makes redirect a valid statement-level policy decision, defines a structured redirect action, and adds a pure Postgres rewrite planner that can safely replace one catalog-resolved source relation with one configured target relation in a single read-only `SELECT`.
+
+External behavior after this plan: policy files can validate redirect rules, policy evaluation can return a redirect decision, and pure planner tests can prove SQL rewrite behavior. The proxy still does not execute redirects until Plan 12.
+
+## Goals
+
+- Accept `decision: redirect` for `database_rules` with a structured target relation action.
+- Keep `decision: redirect` invalid for `database_connection_rules`.
+- Preserve strict DB policy coverage and deny precedence.
+- Add a pure redirect planner with stable rewrite metadata and stable rejection reasons.
+- Support one safe relation replacement in a single-statement read-only Postgres `SELECT`.
+- Preserve table aliases and schema-qualify rewritten target relations.
+- Keep runtime forwarding, prepared-cache behavior, DB events, and client-visible redirect errors out of Plan 11.
+
+## Non-Goals
+
+- Executing redirects in Simple Query or Extended Query.
+- Rewriting prepared-statement cache entries.
+- Emitting redirect event fields.
+- Rewriting writes, DDL, COPY, procedural statements, FunctionCall protocol frames, or multi-statement batches.
+- Supporting SQL templates, arbitrary fragment rewrites, column rewrites, result rewrites, or DLP transforms.
+- Doing catalog lookups inside the planner.
+
+## Policy Shape
+
+Plan 11 adds a redirect action to statement rules:
+
+```yaml
+database_rules:
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: "public.safe_users"
+```
+
+`redirect.relation` is the target relation. It must be a canonical `schema.name` value. The source relation is not repeated in the action; it comes from the actual catalog-resolved relation object covered by the redirect rule's `relations` selector.
+
+Redirect rules must:
+
+- Be statement rules.
+- Match at least one terminate-mode Postgres service. Validation fails when a redirect rule has no eligible terminate-mode Postgres service target.
+- Use only read operations. `operations: [READ]` is the expected common form; aliases are valid only if they expand exclusively to the read group.
+- Constrain `relations`; object-only redirect sources are invalid.
+- Use a canonical target relation in `redirect.relation`.
+
+Redirect rules should use `match_object_resolution: catalog_resolved`. Plan 11 should make this fatal for redirect rules rather than a warning, because the planner needs a catalog-resolved source relation to avoid syntactic ambiguity.
+
+Connection rules continue to reject `decision: redirect`.
+
+## Policy Semantics
+
+Plan 11 adds `VerbRedirect` to statement policy evaluation. Redirect joins the existing strict three-pass policy algorithm:
+
+1. Explicit deny wins if any deny rule matches an object in an effect.
+2. Every object in the effect must be covered by a non-deny rule.
+3. The most-restrictive covered verb becomes the effect-level decision.
+4. The most-restrictive effect-level decision becomes the statement decision.
+
+Restrictiveness order:
+
+```text
+deny == implicit_deny > approve > redirect > audit > allow
+```
+
+This means:
+
+- A matching deny rule blocks redirect.
+- Any uncovered object produces implicit deny, which blocks redirect.
+- An approve rule that covers the same object set beats redirect and preserves human review semantics.
+- Redirect beats audit and allow so the final decision can carry the redirect action when redirect is explicitly configured.
+- Existing allow, audit, approve, and deny behavior remains unchanged when no redirect rule covers the statement.
+
+`Decision` gains redirect action metadata only when `Verb == VerbRedirect`. The metadata must include:
+
+- rule name
+- source relation canonical name
+- target relation canonical name
+
+Audit rule contribution for redirect is not required in Plan 11. Plan 12 may record redirect event fields and treat successful redirect as an allowed upstream query with explicit redirect metadata.
+
+## Planner Contract
+
+Add a pure planner package, likely `internal/db/redirect`.
+
+The planner input should include:
+
+- original SQL text
+- the classified/resolved statement for the single statement being planned
+- the redirect action from the winning policy decision
+- the Postgres parser/deparser backend through the existing classifier backend seam
+
+The planner output should include:
+
+- rewritten SQL
+- redirect rule name
+- source relation canonical name
+- target relation canonical name
+
+Planner failures should be structured rejections with stable reason codes. Initial reason codes:
+
+- `unsupported_statement`
+- `multi_statement`
+- `non_select_statement`
+- `write_statement`
+- `ddl_statement`
+- `copy_statement`
+- `procedural_statement`
+- `function_call_protocol`
+- `unresolved_object`
+- `missing_redirect_target`
+- `ambiguous_redirect_source`
+- `source_relation_not_found`
+- `deparse_failed`
+
+The planner must not perform network I/O or catalog lookup. It trusts the resolver output already attached to the classified statement. If needed metadata is absent, it rejects.
+
+## Rewrite Mechanics
+
+Plan 11 rewrites by mutating the parsed Postgres AST and deparsing it back to SQL. It must not use ad hoc string replacement.
+
+Flow:
+
+1. Parse the original SQL.
+2. Require exactly one parsed statement.
+3. Require the statement node to be a `SelectStmt`.
+4. Reject classified statements with write, DDL, COPY, procedural, FunctionCall, unresolved, or unknown effects.
+5. Walk relation-bearing `RangeVar` nodes reachable through:
+   - `FROM`
+   - joins
+   - nested subselects
+   - read-only CTE bodies
+   - set-operation branches
+6. Match the source relation using catalog-resolved object metadata from the classified statement.
+7. Replace only `RangeVar.Schemaname` and `RangeVar.Relname`.
+8. Preserve aliases, joins, predicates, target lists, parameters, CTE names, and all other AST structure.
+9. Deparse the modified AST with the active backend:
+   - cgo `pg_query.Deparse` on linux+cgo
+   - `wasilibs/go-pgquery.Deparse` otherwise
+
+Deparse may normalize formatting and omit comments. That is acceptable. Plan 12 audit keeps the original statement identity and records the rewritten digest rather than depending on original formatting.
+
+## Safety Boundaries
+
+Plan 11 supports exactly one redirect source occurrence in the first cut. If more than one matching source occurrence is found, reject with `ambiguous_redirect_source`. This keeps CTE shadowing, self-joins, and repeated relation references conservative.
+
+Reject:
+
+- multi-statement SQL
+- non-`SELECT` statements
+- `SELECT INTO`
+- data-modifying CTEs
+- `INSERT ... SELECT`, `UPDATE`, `DELETE`, `MERGE`
+- DDL
+- COPY
+- statements with locking clauses such as `FOR UPDATE`
+- procedural/function-call effects that policy classified as procedural
+- FunctionCall protocol frames
+- unresolved or unknown objects
+- missing redirect target action
+- object-only redirect rules
+
+Plan 11 may support read-only nested subselects, read-only CTEs, joins with one redirected relation, and set operations when the same single-source constraint holds.
+
+## Parser/Deparser Seam
+
+The existing Postgres classifier already splits parser backends by build tag:
+
+- linux+cgo uses `github.com/pganalyze/pg_query_go/v6`
+- other builds use `github.com/wasilibs/go-pgquery`
+
+Plan 11 should expose a narrow internal helper from `internal/db/classify/postgres` rather than importing a cgo-only deparser directly from the planner. The helper should parse and deparse through the selected backend, preserving Windows and no-cgo builds.
+
+The acceptance build must include:
+
+```sh
+GOOS=windows go build ./...
+```
+
+## Tests
+
+Policy tests:
+
+- `decision: redirect` decodes and compiles for valid statement rules.
+- Connection-rule redirect still fails validation.
+- Redirect without `redirect.relation` fails.
+- Redirect with a non-canonical target fails.
+- Redirect with object-only source selectors fails.
+- Redirect without `match_object_resolution: catalog_resolved` fails.
+- Redirect with no eligible terminate-mode Postgres service target fails.
+- Deny beats redirect.
+- Implicit deny beats redirect.
+- Approve beats redirect.
+- Redirect beats audit and allow.
+
+Planner tests:
+
+- `SELECT * FROM public.users` rewrites to the configured target relation.
+- Unqualified source with catalog resolution rewrites to the qualified target.
+- Alias is preserved.
+- Join query with one redirected relation rewrites only that relation.
+- Nested subselect read-only query rewrites.
+- Read-only CTE query rewrites.
+- Set operation read-only query rewrites when only one source occurrence matches.
+- `SELECT INTO` rejects.
+- `INSERT ... SELECT`, `UPDATE`, `DELETE`, DDL, and COPY reject.
+- Unresolved object rejects.
+- Missing target rejects.
+- Multi-statement SQL rejects.
+- Procedural/function-call classified cases reject.
+- Multiple matching source occurrences reject.
+
+Regression tests:
+
+- Existing non-redirect policy tests still pass unchanged.
+- Existing classifier tests still pass unchanged.
+- Cross-platform build succeeds.
+
+## Acceptance Criteria
+
+- DB policy accepts valid statement redirect rules with structured target actions.
+- DB policy still rejects redirect on connection rules.
+- Policy evaluation can return `VerbRedirect` with rule/source/target metadata.
+- Existing non-redirect decisions keep their behavior.
+- The pure planner returns rewritten SQL and redirect metadata for supported single-`SELECT` cases.
+- The pure planner returns stable rejection reasons for unsupported cases.
+- Plan 12's dependency gate passes: redirect policy support and planner contract are present.
+
+## Implementation Boundaries
+
+Plan 11 should touch:
+
+- `internal/db/policy`
+  - add `VerbRedirect`
+  - add `StatementRule.Redirect`
+  - validate redirect shape and service scope
+  - compile redirect actions
+  - return redirect decisions from `Evaluate`
+- `internal/db/classify/postgres`
+  - expose a narrow parse/deparse helper for planner use while preserving cgo/WASM backend selection
+- `internal/db/redirect`
+  - pure planning API
+  - AST traversal and mutation
+  - structured rejection reasons
+  - planner unit tests
+
+Plan 11 should not touch:
+
+- Simple Query forwarding
+- Extended Query runtime behavior
+- prepared statement cache
+- DB event schema
+- audit sink
+- client-visible redirect error handling
+
+Those remain DB Plan 12.
+
+## Open Follow-Ups
+
+- Plan 12 wires this planner into Simple Query and Extended Query `Parse`.
+- A later plan may support multiple source occurrences when all occurrences are provably safe to rewrite.
+- A later plan may support richer source-to-target maps after the single-target runtime path is stable.

--- a/internal/db/classify/postgres/libpgquery.go
+++ b/internal/db/classify/postgres/libpgquery.go
@@ -12,12 +12,28 @@ func newParser(d Dialect) Parser {
 	return &cgoParser{dialect: d}
 }
 
+func newRewriteBackend(d Dialect) RewriteBackend {
+	return &cgoParser{dialect: d}
+}
+
 type cgoParser struct {
 	dialect Dialect
 }
 
 func (p *cgoParser) Classify(sql string, sess SessionState, opts Options) ([]effects.ClassifiedStatement, error) {
 	return classifyWithBackend(p.dialect, sql, sess, opts, parseCGO, effects.ParserBackendLibPgQuery)
+}
+
+func (p *cgoParser) Parse(sql string) (*pg_query.ParseResult, error) {
+	return parseCGO(sql)
+}
+
+func (p *cgoParser) Deparse(tree *pg_query.ParseResult) (string, error) {
+	return pg_query.Deparse(tree)
+}
+
+func (p *cgoParser) Backend() effects.ParserBackend {
+	return effects.ParserBackendLibPgQuery
 }
 
 func parseCGO(sql string) (*pg_query.ParseResult, error) {

--- a/internal/db/classify/postgres/parser.go
+++ b/internal/db/classify/postgres/parser.go
@@ -109,6 +109,13 @@ type Parser interface {
 	Normalize(sql string) (string, error)
 }
 
+// RewriteBackend exposes parse/deparse primitives for SQL rewrite callers.
+type RewriteBackend interface {
+	Parse(sql string) (*pg_query.ParseResult, error)
+	Deparse(tree *pg_query.ParseResult) (string, error)
+	Backend() effects.ParserBackend
+}
+
 // New returns the parser for the given dialect, using whichever libpg_query
 // embedding the active build tag selected. Panics on unknown dialect; the
 // dialect set is closed and a typo at construction time is a programmer error.
@@ -117,6 +124,15 @@ func New(d Dialect) Parser {
 		panic(fmt.Sprintf("postgres.New: unknown dialect %d", d))
 	}
 	return newParser(d)
+}
+
+// NewRewriteBackend returns parse/deparse primitives for the given dialect,
+// using the same build-tag-selected backend as New.
+func NewRewriteBackend(d Dialect) RewriteBackend {
+	if d.String() == "" {
+		panic(fmt.Sprintf("postgres.NewRewriteBackend: unknown dialect %d", d))
+	}
+	return newRewriteBackend(d)
 }
 
 // ApplyStatement evolves session state after the proxy has confirmed the

--- a/internal/db/classify/postgres/rewrite_backend_test.go
+++ b/internal/db/classify/postgres/rewrite_backend_test.go
@@ -1,0 +1,26 @@
+package postgres
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRewriteBackend_ParseDeparse(t *testing.T) {
+	backend := NewRewriteBackend(DialectPostgres)
+
+	tree, err := backend.Parse("SELECT * FROM public.users")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+
+	out, err := backend.Deparse(tree)
+	if err != nil {
+		t.Fatalf("Deparse() error = %v", err)
+	}
+	if !strings.Contains(strings.ToLower(out), "public.users") {
+		t.Fatalf("Deparse() = %q, want public.users", out)
+	}
+	if backend.Backend().String() == "" {
+		t.Fatal("Backend().String() is empty")
+	}
+}

--- a/internal/db/classify/postgres/wasm.go
+++ b/internal/db/classify/postgres/wasm.go
@@ -13,12 +13,28 @@ func newParser(d Dialect) Parser {
 	return &wasmParser{dialect: d}
 }
 
+func newRewriteBackend(d Dialect) RewriteBackend {
+	return &wasmParser{dialect: d}
+}
+
 type wasmParser struct {
 	dialect Dialect
 }
 
 func (p *wasmParser) Classify(sql string, sess SessionState, opts Options) ([]effects.ClassifiedStatement, error) {
 	return classifyWithBackend(p.dialect, sql, sess, opts, parseWASM, effects.ParserBackendPureGo)
+}
+
+func (p *wasmParser) Parse(sql string) (*pg_query.ParseResult, error) {
+	return parseWASM(sql)
+}
+
+func (p *wasmParser) Deparse(tree *pg_query.ParseResult) (string, error) {
+	return pgquery_wasm.Deparse(tree)
+}
+
+func (p *wasmParser) Backend() effects.ParserBackend {
+	return effects.ParserBackendPureGo
 }
 
 // parseWASM delegates to wasilibs/go-pgquery, which loads libpg_query into a

--- a/internal/db/policy/compile.go
+++ b/internal/db/policy/compile.go
@@ -126,6 +126,8 @@ func compileStatementRule(r *StatementRule) (*compiledStatementRule, error) {
 		c.verb = VerbApprove
 	case "audit":
 		c.verb = VerbAudit
+	case "redirect":
+		c.verb = VerbRedirect
 	default:
 		return nil, fmt.Errorf("compile: rule %q has unhandled decision %q (validate should have rejected)", r.Name, r.Decision)
 	}

--- a/internal/db/policy/compile.go
+++ b/internal/db/policy/compile.go
@@ -25,6 +25,7 @@ type compiledStatementRule struct {
 	functions     []glob.Glob // resolved function identity names
 	timeout       time.Duration
 	msgTemplate   *template.Template // nil = no message rendering
+	redirect      *RedirectDecision
 	serviceFilter serviceFilter
 }
 
@@ -130,6 +131,15 @@ func compileStatementRule(r *StatementRule) (*compiledStatementRule, error) {
 		c.verb = VerbRedirect
 	default:
 		return nil, fmt.Errorf("compile: rule %q has unhandled decision %q (validate should have rejected)", r.Name, r.Decision)
+	}
+	if c.verb == VerbRedirect {
+		if len(r.Relations) != 1 || r.Redirect == nil || r.Redirect.Relation == "" {
+			return nil, fmt.Errorf("compile: rule %q has incomplete redirect action (validate should have rejected)", r.Name)
+		}
+		c.redirect = &RedirectDecision{
+			SourceRelation: r.Relations[0],
+			TargetRelation: r.Redirect.Relation,
+		}
 	}
 
 	for _, op := range r.Operations {

--- a/internal/db/policy/compile_test.go
+++ b/internal/db/policy/compile_test.go
@@ -58,6 +58,33 @@ func TestCompileStatementRule_CanonicalOnlyDoesNotCoverSyntacticObject(t *testin
 	}
 }
 
+func TestCompileStatementRule_RedirectAction(t *testing.T) {
+	r := &StatementRule{
+		Name:                  "redirect-users",
+		Operations:            []string{"READ"},
+		Relations:             []string{"public.users"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+		Redirect:              &RedirectAction{Relation: "public.safe_users"},
+	}
+	c, err := compileStatementRule(r)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	if c.verb != VerbRedirect {
+		t.Fatalf("verb = %v, want redirect", c.verb)
+	}
+	if c.redirect == nil {
+		t.Fatal("redirect metadata nil")
+	}
+	if c.redirect.SourceRelation != "public.users" {
+		t.Errorf("SourceRelation = %q, want public.users", c.redirect.SourceRelation)
+	}
+	if c.redirect.TargetRelation != "public.safe_users" {
+		t.Errorf("TargetRelation = %q, want public.safe_users", c.redirect.TargetRelation)
+	}
+}
+
 func TestCompileStatementRule_ExternalEndpointHostMatch(t *testing.T) {
 	r := &StatementRule{Name: "endpoint", Objects: []string{"*.internal"},
 		Operations: []string{"READ"}, Decision: "deny"}

--- a/internal/db/policy/decode_test.go
+++ b/internal/db/policy/decode_test.go
@@ -142,6 +142,45 @@ database_rules:
 	}
 }
 
+func TestRuleSet_AllStatementRules_DeepCopiesRedirect(t *testing.T) {
+	src := `version: 1
+name: t
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: terminate_reissue
+database_rules:
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: public.safe_users
+`
+	rs, warns, err := loadDB(t, src)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("warnings = %+v", warns)
+	}
+
+	rules := rs.AllStatementRules()
+	if len(rules) != 1 || rules[0].Redirect == nil {
+		t.Fatalf("rules = %+v", rules)
+	}
+	rules[0].Redirect.Relation = "public.tampered"
+
+	rules = rs.AllStatementRules()
+	if rules[0].Redirect == nil || rules[0].Redirect.Relation != "public.safe_users" {
+		t.Fatalf("Redirect after external mutation = %+v, want public.safe_users", rules[0].Redirect)
+	}
+}
+
 func TestDecode_RedactionConfig(t *testing.T) {
 	src := `version: 1
 name: t

--- a/internal/db/policy/decode_test.go
+++ b/internal/db/policy/decode_test.go
@@ -181,6 +181,44 @@ database_rules:
 	}
 }
 
+func TestRuleSet_AllStatementRules_DeepCopiesSlices(t *testing.T) {
+	src := `version: 1
+name: t
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: terminate_reissue
+database_rules:
+  - name: canonical-read
+    db_service: appdb
+    schemas: ["public"]
+    relations: ["public.users"]
+    operations: [READ]
+    match_object_resolution: catalog_resolved
+    decision: allow
+`
+	rs, warns, err := loadDB(t, src)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("warnings = %+v", warns)
+	}
+
+	rules := rs.AllStatementRules()
+	if len(rules) != 1 || len(rules[0].Relations) != 1 {
+		t.Fatalf("rules = %+v", rules)
+	}
+	rules[0].Relations[0] = "public.tampered"
+
+	rules = rs.AllStatementRules()
+	if rules[0].Relations[0] != "public.users" {
+		t.Fatalf("Relations after external mutation = %+v, want public.users", rules[0].Relations)
+	}
+}
+
 func TestDecode_RedactionConfig(t *testing.T) {
 	src := `version: 1
 name: t

--- a/internal/db/policy/decode_test.go
+++ b/internal/db/policy/decode_test.go
@@ -107,6 +107,41 @@ database_rules:
 	}
 }
 
+func TestDecode_RedirectStatementRule(t *testing.T) {
+	src := `version: 1
+name: t
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: terminate_reissue
+database_rules:
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: public.safe_users
+`
+	rs, warns, err := loadDB(t, src)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Fatalf("warnings = %+v", warns)
+	}
+	rules := rs.AllStatementRules()
+	if len(rules) != 1 {
+		t.Fatalf("rules = %d, want 1", len(rules))
+	}
+	if rules[0].Redirect == nil || rules[0].Redirect.Relation != "public.safe_users" {
+		t.Fatalf("Redirect = %+v", rules[0].Redirect)
+	}
+}
+
 func TestDecode_RedactionConfig(t *testing.T) {
 	src := `version: 1
 name: t

--- a/internal/db/policy/evaluate.go
+++ b/internal/db/policy/evaluate.go
@@ -53,7 +53,8 @@ type effectDecision struct {
 // foldEffects can prefer explicit deny over implicit deny (preserving RuleName
 // per the design doc §7 tiebreak note).
 //
-// Ordering: verbAllow < verbAudit < verbApprove < verbImplicitDeny < verbDeny.
+// Ordering:
+// verbAllow < verbAudit < verbRedirect < verbApprove < verbImplicitDeny < verbDeny.
 // Higher value = more restrictive. verbImplicitDeny ranks just below verbDeny
 // so explicit deny wins ties, giving a non-empty RuleName whenever possible.
 type internalVerb uint8
@@ -61,7 +62,8 @@ type internalVerb uint8
 const (
 	verbAllow        internalVerb = iota
 	verbAudit                     // more restrictive than allow
-	verbApprove                   // more restrictive than audit
+	verbRedirect                  // more restrictive than audit
+	verbApprove                   // more restrictive than redirect
 	verbImplicitDeny              // more restrictive than approve; loses to explicit deny on tie
 	verbDeny                      // most restrictive
 )
@@ -433,11 +435,19 @@ func foldCoverageRules(coverage []*compiledStatementRule) effectDecision {
 		primary      *compiledStatementRule
 		approveRules []*compiledStatementRule
 		auditRules   []*compiledStatementRule
+		redirectRule *compiledStatementRule
 		approveSeen  = map[string]bool{}
 		auditSeen    = map[string]bool{}
 	)
 	for _, r := range coverage {
 		switch r.verb {
+		case VerbRedirect:
+			if verbRedirect > best {
+				best = verbRedirect
+			}
+			if redirectRule == nil {
+				redirectRule = r
+			}
 		case VerbApprove:
 			if verbApprove > best {
 				best = verbApprove
@@ -459,6 +469,8 @@ func foldCoverageRules(coverage []*compiledStatementRule) effectDecision {
 	switch best {
 	case verbApprove:
 		primary = approveRules[0]
+	case verbRedirect:
+		primary = redirectRule
 	case verbAudit:
 		primary = auditRules[0]
 	default:
@@ -528,6 +540,17 @@ func foldEffects(stmt effects.ClassifiedStatement, perEffect []effectDecision) D
 			Reason:              d.rule.renderMessage(messageContextFor(e, stmt)),
 		}
 
+	case verbRedirect:
+		return Decision{
+			Verb:                VerbRedirect,
+			RuleKind:            RuleKindStatement,
+			RuleName:            d.rule.src.Name,
+			MatchingEffectIndex: bestIdx,
+			MatchingEffectGroup: e.Group,
+			Reason:              d.rule.renderMessage(messageContextFor(e, stmt)),
+			Redirect:            copyRedirectDecision(d.rule.redirect),
+		}
+
 	case verbApprove:
 		// Shortest timeout wins (D-OQ2 — most-restrictive principle applied to time).
 		timeout := d.contributingApprove[0].timeout
@@ -579,9 +602,9 @@ func foldEffects(stmt effects.ClassifiedStatement, perEffect []effectDecision) D
 // Defined as a function (instead of inline `>`) so call sites read as
 // "this is a tiebreak comparison" rather than "this is integer math".
 //
-// Order: allow < audit < approve < implicit_deny < deny. implicit_deny
-// ranks just below explicit deny so the explicit deny path wins ties
-// (preserving Decision.RuleName).
+// Order: allow < audit < redirect < approve < implicit_deny < deny.
+// implicit_deny ranks just below explicit deny so the explicit deny path wins
+// ties (preserving Decision.RuleName).
 func compareInternalVerb(a, b internalVerb) int {
 	if a > b {
 		return 1
@@ -590,6 +613,16 @@ func compareInternalVerb(a, b internalVerb) int {
 		return -1
 	}
 	return 0
+}
+
+func copyRedirectDecision(r *RedirectDecision) *RedirectDecision {
+	if r == nil {
+		return nil
+	}
+	return &RedirectDecision{
+		SourceRelation: r.SourceRelation,
+		TargetRelation: r.TargetRelation,
+	}
 }
 
 // messageContextFor builds the template-render context for an effect.

--- a/internal/db/policy/evaluate.go
+++ b/internal/db/policy/evaluate.go
@@ -134,7 +134,7 @@ func evaluateEffect(e effects.Effect, applicable []*compiledStatementRule) effec
 
 	// Pass 3 — most-restrictive verb across covering rules. Fold in policy file
 	// order so same-verb primary RuleName ties are independent of object order.
-	return foldCoverageRules(coverageRulesInPolicyOrder(applicable, coverage, len(e.Objects)))
+	return foldObjectCoverageRules(applicable, coverage, len(e.Objects))
 }
 
 func resolvedObjectForSlot(e effects.Effect, idx int) (effects.ResolvedObjectRef, bool) {
@@ -293,6 +293,31 @@ func coverageRulesInPolicyOrder(applicable []*compiledStatementRule, coverage ma
 		}
 	}
 	return out
+}
+
+func foldObjectCoverageRules(applicable []*compiledStatementRule, coverage map[int][]*compiledStatementRule, objectCount int) effectDecision {
+	rules := coverageRulesInPolicyOrder(applicable, coverage, objectCount)
+	d := foldCoverageRules(rules)
+	if d.verb != verbRedirect {
+		return d
+	}
+	if redirectSourceCount(coverage, objectCount) != 1 {
+		return effectDecision{verb: verbImplicitDeny}
+	}
+	return d
+}
+
+func redirectSourceCount(coverage map[int][]*compiledStatementRule, objectCount int) int {
+	sources := map[string]struct{}{}
+	for i := 0; i < objectCount; i++ {
+		for _, r := range coverage[i] {
+			if r.verb != VerbRedirect || r.redirect == nil {
+				continue
+			}
+			sources[r.redirect.SourceRelation] = struct{}{}
+		}
+	}
+	return len(sources)
 }
 
 // isObjectlessGroup reports whether the group inherently has no objects

--- a/internal/db/policy/evaluate_redirect_test.go
+++ b/internal/db/policy/evaluate_redirect_test.go
@@ -1,0 +1,182 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
+
+func TestEvaluate_RedirectCoversResolvedRelation(t *testing.T) {
+	rs := loadRules(t, redirectPolicy(`
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: public.safe_users
+`))
+
+	d := Evaluate(catalogResolvedRead("public", "users"), rs, "appdb")
+	if d.Verb != VerbRedirect {
+		t.Fatalf("Verb = %v, want redirect; decision = %+v", d.Verb, d)
+	}
+	if d.RuleName != "redirect-users" {
+		t.Errorf("RuleName = %q, want redirect-users", d.RuleName)
+	}
+	if d.Redirect == nil {
+		t.Fatal("Redirect metadata nil")
+	}
+	if d.Redirect.SourceRelation != "public.users" {
+		t.Errorf("SourceRelation = %q, want public.users", d.Redirect.SourceRelation)
+	}
+	if d.Redirect.TargetRelation != "public.safe_users" {
+		t.Errorf("TargetRelation = %q, want public.safe_users", d.Redirect.TargetRelation)
+	}
+
+	d.Redirect.SourceRelation = "mutated.source"
+	d.Redirect.TargetRelation = "mutated.target"
+	d = Evaluate(catalogResolvedRead("public", "users"), rs, "appdb")
+	if d.Redirect == nil || d.Redirect.SourceRelation != "public.users" || d.Redirect.TargetRelation != "public.safe_users" {
+		t.Fatalf("Redirect after prior decision mutation = %+v, want fresh public.users -> public.safe_users", d.Redirect)
+	}
+}
+
+func TestEvaluate_DenyBeatsRedirect(t *testing.T) {
+	rs := loadRules(t, redirectPolicy(`
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: public.safe_users
+  - name: deny-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: deny
+`))
+
+	d := Evaluate(catalogResolvedRead("public", "users"), rs, "appdb")
+	if d.Verb != VerbDeny || d.RuleName != "deny-users" {
+		t.Fatalf("decision = %+v, want deny by deny-users", d)
+	}
+	if d.Redirect != nil {
+		t.Fatalf("Redirect = %+v, want nil", d.Redirect)
+	}
+}
+
+func TestEvaluate_ApproveBeatsRedirect(t *testing.T) {
+	rs := loadRules(t, redirectPolicy(`
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: public.safe_users
+  - name: approve-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: approve
+`))
+
+	d := Evaluate(catalogResolvedRead("public", "users"), rs, "appdb")
+	if d.Verb != VerbApprove || d.RuleName != "approve-users" {
+		t.Fatalf("decision = %+v, want approve by approve-users", d)
+	}
+	if d.Redirect != nil {
+		t.Fatalf("Redirect = %+v, want nil", d.Redirect)
+	}
+}
+
+func TestEvaluate_RedirectBeatsAuditAndAllow(t *testing.T) {
+	rs := loadRules(t, redirectPolicy(`
+  - name: allow-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: allow
+  - name: audit-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: audit
+    acknowledge_audit_on_dangerous: true
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: public.safe_users
+`))
+
+	d := Evaluate(catalogResolvedRead("public", "users"), rs, "appdb")
+	if d.Verb != VerbRedirect || d.RuleName != "redirect-users" {
+		t.Fatalf("decision = %+v, want redirect by redirect-users", d)
+	}
+}
+
+func TestEvaluate_ImplicitDenyBeatsRedirect(t *testing.T) {
+	rs := loadRules(t, redirectPolicy(`
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: public.safe_users
+`))
+
+	stmt := catalogResolvedRead("public", "users")
+	stmt.Effects[0].Objects = append(stmt.Effects[0].Objects, effects.ObjectRef{Kind: effects.ObjectTable, Name: "orders"})
+	stmt.Effects[0].ResolvedObjects = append(stmt.Effects[0].ResolvedObjects, effects.ResolvedObjectRef{
+		Source: effects.ResolvedObjectSourceCatalog,
+		Kind:   effects.ResolvedObjectRelation,
+		Schema: "public",
+		Name:   "orders",
+	})
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbDeny || d.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny", d)
+	}
+	if d.Redirect != nil {
+		t.Fatalf("Redirect = %+v, want nil", d.Redirect)
+	}
+}
+
+func redirectPolicy(rules string) string {
+	return `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+` + rules
+}
+
+func catalogResolvedRead(schema, name string) effects.ClassifiedStatement {
+	return effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogResolved,
+		Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Name: name}},
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			Schema: schema,
+			Name:   name,
+		}},
+	}}}
+}

--- a/internal/db/policy/evaluate_redirect_test.go
+++ b/internal/db/policy/evaluate_redirect_test.go
@@ -128,6 +128,83 @@ func TestEvaluate_RedirectBeatsAuditAndAllow(t *testing.T) {
 	}
 }
 
+func TestEvaluate_RedirectCoversOneRelationAndAllowCoversAnother(t *testing.T) {
+	rs := loadRules(t, redirectPolicy(`
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: public.safe_users
+  - name: allow-orders
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.orders"]
+    match_object_resolution: catalog_resolved
+    decision: allow
+`))
+
+	stmt := catalogResolvedRead("public", "users")
+	stmt.Effects[0].Objects = append(stmt.Effects[0].Objects, effects.ObjectRef{Kind: effects.ObjectTable, Name: "orders"})
+	stmt.Effects[0].ResolvedObjects = append(stmt.Effects[0].ResolvedObjects, effects.ResolvedObjectRef{
+		Source: effects.ResolvedObjectSourceCatalog,
+		Kind:   effects.ResolvedObjectRelation,
+		Schema: "public",
+		Name:   "orders",
+	})
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbRedirect || d.RuleName != "redirect-users" {
+		t.Fatalf("decision = %+v, want redirect by redirect-users", d)
+	}
+	if d.Redirect == nil {
+		t.Fatal("Redirect metadata nil")
+	}
+	if d.Redirect.SourceRelation != "public.users" || d.Redirect.TargetRelation != "public.safe_users" {
+		t.Fatalf("Redirect = %+v, want public.users -> public.safe_users", d.Redirect)
+	}
+}
+
+func TestEvaluate_TwoRedirectCoveredRelationsImplicitDeny(t *testing.T) {
+	rs := loadRules(t, redirectPolicy(`
+  - name: redirect-users
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: public.safe_users
+  - name: redirect-orders
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.orders"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: public.safe_orders
+`))
+
+	stmt := catalogResolvedRead("public", "users")
+	stmt.Effects[0].Objects = append(stmt.Effects[0].Objects, effects.ObjectRef{Kind: effects.ObjectTable, Name: "orders"})
+	stmt.Effects[0].ResolvedObjects = append(stmt.Effects[0].ResolvedObjects, effects.ResolvedObjectRef{
+		Source: effects.ResolvedObjectSourceCatalog,
+		Kind:   effects.ResolvedObjectRelation,
+		Schema: "public",
+		Name:   "orders",
+	})
+
+	d := Evaluate(stmt, rs, "appdb")
+	if d.Verb != VerbDeny || d.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny", d)
+	}
+	if d.Redirect != nil {
+		t.Fatalf("Redirect = %+v, want nil", d.Redirect)
+	}
+}
+
 func TestEvaluate_ImplicitDenyBeatsRedirect(t *testing.T) {
 	rs := loadRules(t, redirectPolicy(`
   - name: redirect-users

--- a/internal/db/policy/types.go
+++ b/internal/db/policy/types.go
@@ -244,7 +244,12 @@ func (rs *RuleSet) AllStatementRules() []StatementRule {
 	out := make([]StatementRule, 0, len(rs.statement))
 	for _, cr := range rs.statement {
 		if cr.src != nil {
-			out = append(out, *cr.src)
+			r := *cr.src
+			if cr.src.Redirect != nil {
+				redirect := *cr.src.Redirect
+				r.Redirect = &redirect
+			}
+			out = append(out, r)
 		}
 	}
 	return out

--- a/internal/db/policy/types.go
+++ b/internal/db/policy/types.go
@@ -18,7 +18,7 @@ type ServiceID string
 // verb; it is encoded as Verb == VerbDeny with RuleName == "" (see §7 of the
 // design doc and Decision below).
 //
-// The numeric ordering (Allow < Audit < Approve < Deny) encodes
+// The numeric ordering (Allow < Audit < Redirect < Approve < Deny) encodes
 // restrictiveness — the evaluator's hot path uses integer comparison
 // (max(verb, ...)) to fold per-effect verdicts. Do not reorder these values.
 type DecisionVerb uint8
@@ -26,6 +26,7 @@ type DecisionVerb uint8
 const (
 	VerbAllow DecisionVerb = iota
 	VerbAudit
+	VerbRedirect
 	VerbApprove
 	VerbDeny
 )
@@ -36,6 +37,8 @@ func (v DecisionVerb) String() string {
 		return "allow"
 	case VerbAudit:
 		return "audit"
+	case VerbRedirect:
+		return "redirect"
 	case VerbApprove:
 		return "approve"
 	case VerbDeny:
@@ -68,6 +71,18 @@ func (k RuleKind) String() string {
 	}
 }
 
+// RedirectAction is the on-disk action metadata for statement rules with
+// decision: redirect.
+type RedirectAction struct {
+	Relation string `yaml:"relation"`
+}
+
+// RedirectDecision is the evaluator output metadata for redirect decisions.
+type RedirectDecision struct {
+	SourceRelation string
+	TargetRelation string
+}
+
 // ConnectionMatchKind is the connection rule's match_kind field, used by
 // EvaluateConnection.
 type ConnectionMatchKind uint8
@@ -92,22 +107,23 @@ type DBService struct {
 
 // StatementRule is the on-disk shape of a database_rules entry per §9.2.
 type StatementRule struct {
-	Name                        string        `yaml:"name"`
-	DBService                   string        `yaml:"db_service,omitempty"`
-	DBFamily                    string        `yaml:"db_family,omitempty"`
-	DBDialect                   string        `yaml:"db_dialect,omitempty"`
-	Schemas                     []string      `yaml:"schemas,omitempty"`
-	Objects                     []string      `yaml:"objects,omitempty"`
-	Relations                   []string      `yaml:"relations,omitempty"`
-	Functions                   []string      `yaml:"functions,omitempty"`
-	Operations                  []string      `yaml:"operations"`
-	Subtypes                    []string      `yaml:"subtypes,omitempty"`
-	MatchObjectResolution       string        `yaml:"match_object_resolution,omitempty"`
-	Decision                    string        `yaml:"decision"`
-	Message                     string        `yaml:"message,omitempty"`
-	Timeout                     time.Duration `yaml:"timeout,omitempty"`
-	AcknowledgeAuditOnDangerous bool          `yaml:"acknowledge_audit_on_dangerous,omitempty"`
-	DenyModeInTx                string        `yaml:"deny_mode_in_tx,omitempty"`
+	Name                        string          `yaml:"name"`
+	DBService                   string          `yaml:"db_service,omitempty"`
+	DBFamily                    string          `yaml:"db_family,omitempty"`
+	DBDialect                   string          `yaml:"db_dialect,omitempty"`
+	Schemas                     []string        `yaml:"schemas,omitempty"`
+	Objects                     []string        `yaml:"objects,omitempty"`
+	Relations                   []string        `yaml:"relations,omitempty"`
+	Functions                   []string        `yaml:"functions,omitempty"`
+	Operations                  []string        `yaml:"operations"`
+	Subtypes                    []string        `yaml:"subtypes,omitempty"`
+	MatchObjectResolution       string          `yaml:"match_object_resolution,omitempty"`
+	Decision                    string          `yaml:"decision"`
+	Message                     string          `yaml:"message,omitempty"`
+	Timeout                     time.Duration   `yaml:"timeout,omitempty"`
+	Redirect                    *RedirectAction `yaml:"redirect,omitempty"`
+	AcknowledgeAuditOnDangerous bool            `yaml:"acknowledge_audit_on_dangerous,omitempty"`
+	DenyModeInTx                string          `yaml:"deny_mode_in_tx,omitempty"`
 }
 
 // ConnectionRule is the on-disk shape of a database_connection_rules entry per §9.3.
@@ -150,6 +166,7 @@ type Decision struct {
 	Reason                 string
 	ContributingAuditRules []string // populated only when Verb == VerbApprove
 	Approval               *ApprovalRequest
+	Redirect               *RedirectDecision
 }
 
 // ApprovalRequest carries data Plan 04 needs to spin up the approval flow.

--- a/internal/db/policy/types.go
+++ b/internal/db/policy/types.go
@@ -245,6 +245,12 @@ func (rs *RuleSet) AllStatementRules() []StatementRule {
 	for _, cr := range rs.statement {
 		if cr.src != nil {
 			r := *cr.src
+			r.Schemas = copyStringSlice(cr.src.Schemas)
+			r.Objects = copyStringSlice(cr.src.Objects)
+			r.Relations = copyStringSlice(cr.src.Relations)
+			r.Functions = copyStringSlice(cr.src.Functions)
+			r.Operations = copyStringSlice(cr.src.Operations)
+			r.Subtypes = copyStringSlice(cr.src.Subtypes)
 			if cr.src.Redirect != nil {
 				redirect := *cr.src.Redirect
 				r.Redirect = &redirect
@@ -253,6 +259,13 @@ func (rs *RuleSet) AllStatementRules() []StatementRule {
 		}
 	}
 	return out
+}
+
+func copyStringSlice(in []string) []string {
+	if in == nil {
+		return nil
+	}
+	return append([]string(nil), in...)
 }
 
 // UsesCanonicalSelectors reports whether any statement rule applicable to svc

--- a/internal/db/policy/types_test.go
+++ b/internal/db/policy/types_test.go
@@ -13,6 +13,7 @@ func TestDecisionVerbString(t *testing.T) {
 	}{
 		{VerbAllow, "allow"},
 		{VerbAudit, "audit"},
+		{VerbRedirect, "redirect"},
 		{VerbApprove, "approve"},
 		{VerbDeny, "deny"},
 	}

--- a/internal/db/policy/validate.go
+++ b/internal/db/policy/validate.go
@@ -268,6 +268,9 @@ func validateRedirectStatementRule(r *StatementRule, svcs map[ServiceID]*DBServi
 	} else if !isCanonicalRelationName(r.Relations[0]) {
 		errs = append(errs, fmt.Errorf("redirect_source_relation_not_canonical: database_rules[%q]: relations[0] %q must be canonical schema.name", r.Name, r.Relations[0]))
 	}
+	if len(r.Objects) > 0 || len(r.Functions) > 0 {
+		errs = append(errs, fmt.Errorf("redirect_source_relation_exclusive: database_rules[%q]: redirect rules cannot combine relations with objects or functions selectors", r.Name))
+	}
 	if r.MatchObjectResolution != "catalog_resolved" {
 		errs = append(errs, fmt.Errorf("redirect_requires_catalog_resolved: database_rules[%q]: redirect requires match_object_resolution: catalog_resolved", r.Name))
 	}

--- a/internal/db/policy/validate.go
+++ b/internal/db/policy/validate.go
@@ -75,10 +75,8 @@ func validateStatementRule(r *StatementRule, svcs map[ServiceID]*DBService) ([]e
 
 	// decision verb.
 	switch r.Decision {
-	case "allow", "deny", "approve", "audit":
+	case "allow", "deny", "approve", "audit", "redirect":
 		// ok
-	case "redirect":
-		errs = append(errs, fmt.Errorf("redirect_not_supported_until_plan_11: database_rules[%q]: decision redirect is supported starting in DB Plan 11", r.Name))
 	default:
 		errs = append(errs, fmt.Errorf("rule_unknown_decision: database_rules[%q]: unknown decision %q", r.Name, r.Decision))
 	}
@@ -107,6 +105,9 @@ func validateStatementRule(r *StatementRule, svcs map[ServiceID]*DBService) ([]e
 	// approve timeout.
 	if r.Decision == "approve" && r.Timeout > approveTimeoutMax {
 		errs = append(errs, fmt.Errorf("approve_timeout_exceeds_max: database_rules[%q]: timeout %s exceeds %s", r.Name, r.Timeout, approveTimeoutMax))
+	}
+	if r.Decision == "redirect" {
+		errs = append(errs, validateRedirectStatementRule(r, svcs, groups)...)
 	}
 
 	// rule_too_broad_allow.
@@ -227,7 +228,7 @@ func validateConnectionRule(r *ConnectionRule, svcs map[ServiceID]*DBService) ([
 	case "allow", "deny", "approve", "audit":
 		// ok
 	case "redirect":
-		errs = append(errs, fmt.Errorf("redirect_not_supported_until_plan_11: database_connection_rules[%q]: decision redirect is not valid for DB connection rules", r.Name))
+		errs = append(errs, fmt.Errorf("conn_redirect_invalid: database_connection_rules[%q]: decision redirect is not valid for DB connection rules", r.Name))
 	default:
 		errs = append(errs, fmt.Errorf("rule_unknown_decision: database_connection_rules[%q]: unknown decision %q", r.Name, r.Decision))
 	}
@@ -253,6 +254,30 @@ func validateConnectionRule(r *ConnectionRule, svcs map[ServiceID]*DBService) ([
 	}
 
 	return errs, warns
+}
+
+func validateRedirectStatementRule(r *StatementRule, svcs map[ServiceID]*DBService, groups map[effects.Group]struct{}) []error {
+	var errs []error
+	if r.Redirect == nil || r.Redirect.Relation == "" {
+		errs = append(errs, fmt.Errorf("redirect_relation_required: database_rules[%q]: redirect.relation is required", r.Name))
+	} else if !isCanonicalRelationName(r.Redirect.Relation) {
+		errs = append(errs, fmt.Errorf("redirect_relation_not_canonical: database_rules[%q]: redirect.relation %q must be canonical schema.name", r.Name, r.Redirect.Relation))
+	}
+	if len(r.Relations) != 1 {
+		errs = append(errs, fmt.Errorf("redirect_source_relation_required: database_rules[%q]: exactly one relations selector is required for redirect", r.Name))
+	} else if !isCanonicalRelationName(r.Relations[0]) {
+		errs = append(errs, fmt.Errorf("redirect_source_relation_not_canonical: database_rules[%q]: relations[0] %q must be canonical schema.name", r.Name, r.Relations[0]))
+	}
+	if r.MatchObjectResolution != "catalog_resolved" {
+		errs = append(errs, fmt.Errorf("redirect_requires_catalog_resolved: database_rules[%q]: redirect requires match_object_resolution: catalog_resolved", r.Name))
+	}
+	if !groupsOnlyRead(groups) {
+		errs = append(errs, fmt.Errorf("redirect_operations_must_be_read: database_rules[%q]: redirect operations must expand only to read", r.Name))
+	}
+	if !ruleMatchesTerminatePostgresService(r, svcs) {
+		errs = append(errs, fmt.Errorf("redirect_requires_terminate_postgres_service: database_rules[%q]: redirect requires at least one terminate-mode Postgres service", r.Name))
+	}
+	return errs
 }
 
 func ruleHasCanonicalSelectors(r *StatementRule) bool {
@@ -284,6 +309,17 @@ func expandedGroups(r *StatementRule) map[effects.Group]struct{} {
 	return groups
 }
 
+func groupsOnlyRead(groups map[effects.Group]struct{}) bool {
+	if len(groups) == 0 {
+		return false
+	}
+	if len(groups) != 1 {
+		return false
+	}
+	_, ok := groups[effects.GroupRead]
+	return ok
+}
+
 func allGroupsObjectless(groups map[effects.Group]struct{}) bool {
 	if len(groups) == 0 {
 		return false
@@ -313,6 +349,14 @@ func ruleMatchesTerminatePostgresService(r *StatementRule, svcs map[ServiceID]*D
 		}
 	}
 	return false
+}
+
+func isCanonicalRelationName(s string) bool {
+	if strings.ContainsAny(s, "*?[") {
+		return false
+	}
+	parts := strings.Split(s, ".")
+	return len(parts) == 2 && parts[0] != "" && parts[1] != ""
 }
 
 // validateConnectionRuleVsService returns a non-nil error if the rule matches

--- a/internal/db/policy/validate.go
+++ b/internal/db/policy/validate.go
@@ -352,11 +352,28 @@ func ruleMatchesTerminatePostgresService(r *StatementRule, svcs map[ServiceID]*D
 }
 
 func isCanonicalRelationName(s string) bool {
-	if strings.ContainsAny(s, "*?[") {
+	parts := strings.Split(s, ".")
+	return len(parts) == 2 && isPlainIdentifier(parts[0]) && isPlainIdentifier(parts[1])
+}
+
+func isPlainIdentifier(s string) bool {
+	if s == "" {
 		return false
 	}
-	parts := strings.Split(s, ".")
-	return len(parts) == 2 && parts[0] != "" && parts[1] != ""
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if i == 0 {
+			if (c >= 'a' && c <= 'z') || c == '_' {
+				continue
+			}
+			return false
+		}
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // validateConnectionRuleVsService returns a non-nil error if the rule matches

--- a/internal/db/policy/validate_test.go
+++ b/internal/db/policy/validate_test.go
@@ -98,10 +98,158 @@ func TestValidate_ConnPassthroughFieldUnavailable(t *testing.T) {
 }
 
 func TestValidate_RuleDecisionRedirect(t *testing.T) {
-	stmt := []*StatementRule{{Name: "r", Operations: []string{"READ"}, Decision: "redirect"}}
-	_, err := helperValidate(t, nil, stmt, nil)
-	if err == nil || !strings.Contains(err.Error(), "redirect_not_supported_until_plan_11") {
-		t.Fatalf("want redirect_not_supported_until_plan_11, got %v", err)
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	stmt := []*StatementRule{{
+		Name:                  "redirect-users",
+		DBService:             "appdb",
+		Operations:            []string{"READ"},
+		Relations:             []string{"public.users"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+		Redirect:              &RedirectAction{Relation: "public.safe_users"},
+	}}
+	if _, err := helperValidate(t, svcs, stmt, nil); err != nil {
+		t.Fatalf("validate redirect statement rule: %v", err)
+	}
+}
+
+func TestValidate_RedirectRequiresAction(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	stmt := []*StatementRule{{
+		Name:                  "redirect-users",
+		DBService:             "appdb",
+		Operations:            []string{"READ"},
+		Relations:             []string{"public.users"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+	}}
+	_, err := helperValidate(t, svcs, stmt, nil)
+	if err == nil || !strings.Contains(err.Error(), "redirect_relation_required") {
+		t.Fatalf("want redirect_relation_required, got %v", err)
+	}
+}
+
+func TestValidate_RedirectRequiresCanonicalTarget(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	stmt := []*StatementRule{{
+		Name:                  "redirect-users",
+		DBService:             "appdb",
+		Operations:            []string{"READ"},
+		Relations:             []string{"public.users"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+		Redirect:              &RedirectAction{Relation: "safe_users"},
+	}}
+	_, err := helperValidate(t, svcs, stmt, nil)
+	if err == nil || !strings.Contains(err.Error(), "redirect_relation_not_canonical") {
+		t.Fatalf("want redirect_relation_not_canonical, got %v", err)
+	}
+}
+
+func TestValidate_RedirectRequiresCanonicalSourceRelation(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	stmt := []*StatementRule{{
+		Name:                  "redirect-users",
+		DBService:             "appdb",
+		Operations:            []string{"READ"},
+		Relations:             []string{"public.*"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+		Redirect:              &RedirectAction{Relation: "public.safe_users"},
+	}}
+	_, err := helperValidate(t, svcs, stmt, nil)
+	if err == nil || !strings.Contains(err.Error(), "redirect_source_relation_not_canonical") {
+		t.Fatalf("want redirect_source_relation_not_canonical, got %v", err)
+	}
+}
+
+func TestValidate_RedirectRequiresSourceRelation(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	stmt := []*StatementRule{{
+		Name:                  "redirect-users",
+		DBService:             "appdb",
+		Operations:            []string{"READ"},
+		Objects:               []string{"users"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+		Redirect:              &RedirectAction{Relation: "public.safe_users"},
+	}}
+	_, err := helperValidate(t, svcs, stmt, nil)
+	if err == nil || !strings.Contains(err.Error(), "redirect_source_relation_required") {
+		t.Fatalf("want redirect_source_relation_required, got %v", err)
+	}
+}
+
+func TestValidate_RedirectRequiresCatalogResolved(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	stmt := []*StatementRule{{
+		Name:       "redirect-users",
+		DBService:  "appdb",
+		Operations: []string{"READ"},
+		Relations:  []string{"public.users"},
+		Decision:   "redirect",
+		Redirect:   &RedirectAction{Relation: "public.safe_users"},
+	}}
+	_, err := helperValidate(t, svcs, stmt, nil)
+	if err == nil || !strings.Contains(err.Error(), "redirect_requires_catalog_resolved") {
+		t.Fatalf("want redirect_requires_catalog_resolved, got %v", err)
+	}
+}
+
+func TestValidate_RedirectOperationsMustBeRead(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	stmt := []*StatementRule{{
+		Name:                  "redirect-users",
+		DBService:             "appdb",
+		Operations:            []string{"MUTATE"},
+		Relations:             []string{"public.users"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+		Redirect:              &RedirectAction{Relation: "public.safe_users"},
+	}}
+	_, err := helperValidate(t, svcs, stmt, nil)
+	if err == nil || !strings.Contains(err.Error(), "redirect_operations_must_be_read") {
+		t.Fatalf("want redirect_operations_must_be_read, got %v", err)
+	}
+}
+
+func TestValidate_RedirectRequiresTerminatePostgresService(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"legacy": {Name: "legacy", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "passthrough"},
+	}
+	stmt := []*StatementRule{{
+		Name:                  "redirect-users",
+		Operations:            []string{"READ"},
+		Relations:             []string{"public.users"},
+		MatchObjectResolution: "catalog_resolved",
+		Decision:              "redirect",
+		Redirect:              &RedirectAction{Relation: "public.safe_users"},
+	}}
+	_, err := helperValidate(t, svcs, stmt, nil)
+	if err == nil || !strings.Contains(err.Error(), "redirect_requires_terminate_postgres_service") {
+		t.Fatalf("want redirect_requires_terminate_postgres_service, got %v", err)
+	}
+}
+
+func TestValidate_ConnectionRuleRedirectInvalid(t *testing.T) {
+	conn := []*ConnectionRule{{Name: "conn-redirect", Decision: "redirect"}}
+	_, err := helperValidate(t, nil, nil, conn)
+	if err == nil || !strings.Contains(err.Error(), "conn_redirect_invalid") {
+		t.Fatalf("want conn_redirect_invalid, got %v", err)
 	}
 }
 

--- a/internal/db/policy/validate_test.go
+++ b/internal/db/policy/validate_test.go
@@ -194,6 +194,39 @@ func TestValidate_RedirectRequiresCanonicalSourceRelation(t *testing.T) {
 	}
 }
 
+func TestValidate_RedirectSourceRelationExclusive(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	cases := []struct {
+		name      string
+		objects   []string
+		functions []string
+	}{
+		{name: "objects", objects: []string{"users"}},
+		{name: "functions", functions: []string{"public.safe_fn(integer)"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt := []*StatementRule{{
+				Name:                  "redirect-users",
+				DBService:             "appdb",
+				Operations:            []string{"READ"},
+				Objects:               tc.objects,
+				Relations:             []string{"public.users"},
+				Functions:             tc.functions,
+				MatchObjectResolution: "catalog_resolved",
+				Decision:              "redirect",
+				Redirect:              &RedirectAction{Relation: "public.safe_users"},
+			}}
+			_, err := helperValidate(t, svcs, stmt, nil)
+			if err == nil || !strings.Contains(err.Error(), "redirect_source_relation_exclusive") {
+				t.Fatalf("want redirect_source_relation_exclusive, got %v", err)
+			}
+		})
+	}
+}
+
 func TestValidate_RedirectRejectsNonPlainSourceRelation(t *testing.T) {
 	svcs := map[ServiceID]*DBService{
 		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},

--- a/internal/db/policy/validate_test.go
+++ b/internal/db/policy/validate_test.go
@@ -152,6 +152,29 @@ func TestValidate_RedirectRequiresCanonicalTarget(t *testing.T) {
 	}
 }
 
+func TestValidate_RedirectRejectsNonPlainTargetRelation(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	for _, relation := range []string{"Public.Users", "public.user-name", " public.users", "public.123users"} {
+		t.Run(relation, func(t *testing.T) {
+			stmt := []*StatementRule{{
+				Name:                  "redirect-users",
+				DBService:             "appdb",
+				Operations:            []string{"READ"},
+				Relations:             []string{"public.users"},
+				MatchObjectResolution: "catalog_resolved",
+				Decision:              "redirect",
+				Redirect:              &RedirectAction{Relation: relation},
+			}}
+			_, err := helperValidate(t, svcs, stmt, nil)
+			if err == nil || !strings.Contains(err.Error(), "redirect_relation_not_canonical") {
+				t.Fatalf("want redirect_relation_not_canonical, got %v", err)
+			}
+		})
+	}
+}
+
 func TestValidate_RedirectRequiresCanonicalSourceRelation(t *testing.T) {
 	svcs := map[ServiceID]*DBService{
 		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
@@ -168,6 +191,29 @@ func TestValidate_RedirectRequiresCanonicalSourceRelation(t *testing.T) {
 	_, err := helperValidate(t, svcs, stmt, nil)
 	if err == nil || !strings.Contains(err.Error(), "redirect_source_relation_not_canonical") {
 		t.Fatalf("want redirect_source_relation_not_canonical, got %v", err)
+	}
+}
+
+func TestValidate_RedirectRejectsNonPlainSourceRelation(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	for _, relation := range []string{"Public.Users", "public.user-name", " public.users", "public.123users"} {
+		t.Run(relation, func(t *testing.T) {
+			stmt := []*StatementRule{{
+				Name:                  "redirect-users",
+				DBService:             "appdb",
+				Operations:            []string{"READ"},
+				Relations:             []string{relation},
+				MatchObjectResolution: "catalog_resolved",
+				Decision:              "redirect",
+				Redirect:              &RedirectAction{Relation: "public.safe_users"},
+			}}
+			_, err := helperValidate(t, svcs, stmt, nil)
+			if err == nil || !strings.Contains(err.Error(), "redirect_source_relation_not_canonical") {
+				t.Fatalf("want redirect_source_relation_not_canonical, got %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/db/redirect/planner.go
+++ b/internal/db/redirect/planner.go
@@ -14,10 +14,7 @@ func (p Planner) Plan(in Input) (Plan, error) {
 	if err != nil {
 		return Plan{}, reject(ReasonUnsupportedStatement, err)
 	}
-	if tree == nil {
-		return Plan{}, reject(ReasonUnsupportedStatement, nil)
-	}
-	if len(tree.Stmts) != 1 {
+	if tree == nil || len(tree.Stmts) != 1 {
 		return Plan{}, reject(ReasonMultiStatement, nil)
 	}
 
@@ -31,10 +28,6 @@ func (p Planner) Plan(in Input) (Plan, error) {
 	if len(selectStmt.LockingClause) > 0 {
 		return Plan{}, reject(ReasonUnsupportedStatement, nil)
 	}
-	if !sourceRelationExists(in.Statement, in.Action.SourceRelation) {
-		return Plan{}, reject(ReasonSourceNotFound, nil)
-	}
-
 	return Plan{}, reject(ReasonSourceNotFound, nil)
 }
 

--- a/internal/db/redirect/planner.go
+++ b/internal/db/redirect/planner.go
@@ -1,0 +1,51 @@
+package redirect
+
+import pg_query "github.com/pganalyze/pg_query_go/v6"
+
+func (p Planner) Plan(in Input) (Plan, error) {
+	if err := validateInput(in); err != nil {
+		return Plan{}, err
+	}
+	if p.Backend == nil {
+		return Plan{}, reject(ReasonUnsupportedStatement, nil)
+	}
+
+	tree, err := p.Backend.Parse(in.SQL)
+	if err != nil {
+		return Plan{}, reject(ReasonUnsupportedStatement, err)
+	}
+	if tree == nil {
+		return Plan{}, reject(ReasonUnsupportedStatement, nil)
+	}
+	if len(tree.Stmts) != 1 {
+		return Plan{}, reject(ReasonMultiStatement, nil)
+	}
+
+	selectStmt, err := singleSelect(tree)
+	if err != nil {
+		return Plan{}, err
+	}
+	if selectStmt.IntoClause != nil {
+		return Plan{}, reject(ReasonDDLStatement, nil)
+	}
+	if len(selectStmt.LockingClause) > 0 {
+		return Plan{}, reject(ReasonUnsupportedStatement, nil)
+	}
+	if !sourceRelationExists(in.Statement, in.Action.SourceRelation) {
+		return Plan{}, reject(ReasonSourceNotFound, nil)
+	}
+
+	return Plan{}, reject(ReasonSourceNotFound, nil)
+}
+
+func singleSelect(tree *pg_query.ParseResult) (*pg_query.SelectStmt, error) {
+	raw := tree.Stmts[0]
+	if raw == nil || raw.Stmt == nil || raw.Stmt.Node == nil {
+		return nil, reject(ReasonUnsupportedStatement, nil)
+	}
+	node, ok := raw.Stmt.Node.(*pg_query.Node_SelectStmt)
+	if !ok || node.SelectStmt == nil {
+		return nil, reject(ReasonNonSelectStatement, nil)
+	}
+	return node.SelectStmt, nil
+}

--- a/internal/db/redirect/planner.go
+++ b/internal/db/redirect/planner.go
@@ -29,8 +29,14 @@ func (p Planner) Plan(in Input) (Plan, error) {
 	if selectStmt.IntoClause != nil {
 		return Plan{}, reject(ReasonDDLStatement, nil)
 	}
+	if isTopLevelUnsupportedSelectSurface(selectStmt) {
+		return Plan{}, reject(ReasonUnsupportedStatement, nil)
+	}
 	if len(selectStmt.LockingClause) > 0 {
 		return Plan{}, reject(ReasonUnsupportedStatement, nil)
+	}
+	if err := validateSelectRelationMetadata(selectStmt, in.Statement); err != nil {
+		return Plan{}, err
 	}
 
 	sourceSchema, sourceName := splitRelation(in.Action.SourceRelation)
@@ -84,4 +90,8 @@ func singleSelect(tree *pg_query.ParseResult) (*pg_query.SelectStmt, error) {
 		return nil, reject(ReasonNonSelectStatement, nil)
 	}
 	return node.SelectStmt, nil
+}
+
+func isTopLevelUnsupportedSelectSurface(stmt *pg_query.SelectStmt) bool {
+	return stmt != nil && len(stmt.ValuesLists) > 0
 }

--- a/internal/db/redirect/planner.go
+++ b/internal/db/redirect/planner.go
@@ -35,6 +35,9 @@ func (p Planner) Plan(in Input) (Plan, error) {
 
 	sourceSchema, sourceName := splitRelation(in.Action.SourceRelation)
 	targetSchema, targetName := splitRelation(in.Action.TargetRelation)
+	if hasSchemaQualifiedSourceColumnRef(selectStmt, sourceSchema, sourceName) {
+		return Plan{}, reject(ReasonUnsupportedStatement, nil)
+	}
 	count, err := rewriteSelectRelations(selectStmt, relationRewrite{
 		sourceSchema: sourceSchema,
 		sourceName:   sourceName,

--- a/internal/db/redirect/planner.go
+++ b/internal/db/redirect/planner.go
@@ -1,6 +1,10 @@
 package redirect
 
-import pg_query "github.com/pganalyze/pg_query_go/v6"
+import (
+	"strings"
+
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+)
 
 func (p Planner) Plan(in Input) (Plan, error) {
 	if err := validateInput(in); err != nil {
@@ -28,7 +32,43 @@ func (p Planner) Plan(in Input) (Plan, error) {
 	if len(selectStmt.LockingClause) > 0 {
 		return Plan{}, reject(ReasonUnsupportedStatement, nil)
 	}
-	return Plan{}, reject(ReasonSourceNotFound, nil)
+
+	sourceSchema, sourceName := splitRelation(in.Action.SourceRelation)
+	targetSchema, targetName := splitRelation(in.Action.TargetRelation)
+	count, err := rewriteSelectRelations(selectStmt, relationRewrite{
+		sourceSchema: sourceSchema,
+		sourceName:   sourceName,
+		targetSchema: targetSchema,
+		targetName:   targetName,
+	})
+	if err != nil {
+		return Plan{}, err
+	}
+	switch {
+	case count == 0:
+		return Plan{}, reject(ReasonSourceNotFound, nil)
+	case count > 1:
+		return Plan{}, reject(ReasonAmbiguousRedirectSource, nil)
+	}
+
+	rewritten, err := p.Backend.Deparse(tree)
+	if err != nil {
+		return Plan{}, reject(ReasonDeparseFailed, err)
+	}
+	return Plan{
+		RewrittenSQL:   rewritten,
+		RuleName:       in.Action.RuleName,
+		SourceRelation: in.Action.SourceRelation,
+		TargetRelation: in.Action.TargetRelation,
+	}, nil
+}
+
+func splitRelation(relation string) (string, string) {
+	schema, name, ok := strings.Cut(strings.TrimSpace(relation), ".")
+	if !ok {
+		return "", strings.TrimSpace(relation)
+	}
+	return strings.TrimSpace(schema), strings.TrimSpace(name)
 }
 
 func singleSelect(tree *pg_query.ParseResult) (*pg_query.SelectStmt, error) {

--- a/internal/db/redirect/planner_test.go
+++ b/internal/db/redirect/planner_test.go
@@ -317,6 +317,25 @@ func TestPlannerRewritesReadOnlyCTE(t *testing.T) {
 	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
 }
 
+func TestPlannerRewritesCTEShadowingSourceName(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "WITH users AS (SELECT id FROM public.users) SELECT * FROM users",
+		Statement: readStatement("public", "users"),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	assertSQLContains(t, plan.RewrittenSQL, "public.safe_users")
+	assertSQLContains(t, plan.RewrittenSQL, "FROM users")
+	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
+}
+
 func TestPlannerRewritesSetOperation(t *testing.T) {
 	plan, err := testPlanner().Plan(Input{
 		SQL: "SELECT id FROM public.users UNION ALL SELECT id FROM public.archive_users",
@@ -463,6 +482,16 @@ func TestPlannerRejectsRangeFunction(t *testing.T) {
 	})
 
 	assertRejection(t, err, ReasonProceduralStatement)
+}
+
+func TestPlannerRejectsSampledSourceWithExpressionSubquery(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users TABLESAMPLE SYSTEM (1) WHERE EXISTS (SELECT 1 FROM public.users)",
+		Statement: readStatement("public", "users"),
+		Action:    testAction(),
+	})
+
+	assertRejection(t, err, ReasonUnsupportedStatement)
 }
 
 func TestPlannerRejectsMultipleSourceOccurrences(t *testing.T) {

--- a/internal/db/redirect/planner_test.go
+++ b/internal/db/redirect/planner_test.go
@@ -281,6 +281,64 @@ func TestPlannerRewritesJoinTableQualifiedReferenceWithImplicitAlias(t *testing.
 	assertSQLContains(t, plan.RewrittenSQL, "public.orders")
 }
 
+func TestPlannerRewritesNestedSubselect(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM (SELECT id FROM public.users) s",
+		Statement: readStatement("public", "users"),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	assertSQLContains(t, plan.RewrittenSQL, "public.safe_users")
+	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
+}
+
+func TestPlannerRewritesReadOnlyCTE(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "WITH u AS (SELECT id FROM public.users) SELECT * FROM u",
+		Statement: readStatement("public", "users"),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	assertSQLContains(t, plan.RewrittenSQL, "public.safe_users")
+	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
+}
+
+func TestPlannerRewritesSetOperation(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL: "SELECT id FROM public.users UNION ALL SELECT id FROM public.archive_users",
+		Statement: readStatementWithResolved(
+			resolvedRelation("public", "users"),
+			resolvedRelation("public", "archive_users"),
+		),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	assertSQLContains(t, plan.RewrittenSQL, "public.safe_users")
+	assertSQLContains(t, plan.RewrittenSQL, "public.archive_users")
+	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
+}
+
 func TestPlannerRejectsSchemaQualifiedSourceColumnReference(t *testing.T) {
 	_, err := testPlanner().Plan(Input{
 		SQL:       "SELECT public.users.id FROM public.users",
@@ -293,6 +351,56 @@ func TestPlannerRejectsSchemaQualifiedSourceColumnReference(t *testing.T) {
 	})
 
 	assertRejection(t, err, ReasonUnsupportedStatement)
+}
+
+func TestPlannerRejectsSelectInto(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * INTO temp_user_ids FROM public.users",
+		Statement: readStatement("public", "users"),
+		Action:    testAction(),
+	})
+
+	assertRejection(t, err, ReasonDDLStatement)
+}
+
+func TestPlannerRejectsDataModifyingCTE(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "WITH moved AS (DELETE FROM public.users RETURNING id) SELECT * FROM moved",
+		Statement: readStatement("public", "users"),
+		Action:    testAction(),
+	})
+
+	assertRejection(t, err, ReasonWriteStatement)
+}
+
+func TestPlannerRejectsLockingClause(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users FOR UPDATE",
+		Statement: readStatement("public", "users"),
+		Action:    testAction(),
+	})
+
+	assertRejection(t, err, ReasonUnsupportedStatement)
+}
+
+func TestPlannerRejectsRangeFunction(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users, generate_series(1, 3)",
+		Statement: readStatement("public", "users"),
+		Action:    testAction(),
+	})
+
+	assertRejection(t, err, ReasonProceduralStatement)
+}
+
+func TestPlannerRejectsMultipleSourceOccurrences(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users u1 JOIN public.users u2 ON u1.id = u2.id",
+		Statement: readStatement("public", "users"),
+		Action:    testAction(),
+	})
+
+	assertRejection(t, err, ReasonAmbiguousRedirectSource)
 }
 
 func TestRejectionValueImplementsError(t *testing.T) {
@@ -320,20 +428,28 @@ func testAction() Action {
 }
 
 func readStatement(schema, name string) effects.ClassifiedStatement {
-	return readStatementWithResolved(effects.ResolvedObjectRef{
+	return readStatementWithResolved(resolvedRelation(schema, name))
+}
+
+func readStatementWithResolved(resolved ...effects.ResolvedObjectRef) effects.ClassifiedStatement {
+	return effects.ClassifiedStatement{Effects: []effects.Effect{readEffect(resolved...)}}
+}
+
+func readEffect(resolved ...effects.ResolvedObjectRef) effects.Effect {
+	return effects.Effect{
+		Group:           effects.GroupRead,
+		Resolution:      effects.ResolutionCatalogResolved,
+		ResolvedObjects: resolved,
+	}
+}
+
+func resolvedRelation(schema, name string) effects.ResolvedObjectRef {
+	return effects.ResolvedObjectRef{
 		Source: effects.ResolvedObjectSourceCatalog,
 		Kind:   effects.ResolvedObjectRelation,
 		Schema: schema,
 		Name:   name,
-	})
-}
-
-func readStatementWithResolved(resolved effects.ResolvedObjectRef) effects.ClassifiedStatement {
-	return effects.ClassifiedStatement{Effects: []effects.Effect{{
-		Group:           effects.GroupRead,
-		Resolution:      effects.ResolutionCatalogResolved,
-		ResolvedObjects: []effects.ResolvedObjectRef{resolved},
-	}}}
+	}
 }
 
 func assertRejection(t *testing.T, err error, reason Reason) {

--- a/internal/db/redirect/planner_test.go
+++ b/internal/db/redirect/planner_test.go
@@ -10,6 +10,12 @@ import (
 	pg_query "github.com/pganalyze/pg_query_go/v6"
 )
 
+func TestReasonAmbiguousSourceAlias(t *testing.T) {
+	if ReasonAmbiguousSource != ReasonAmbiguousRedirectSource {
+		t.Fatalf("ReasonAmbiguousSource = %q, want %q", ReasonAmbiguousSource, ReasonAmbiguousRedirectSource)
+	}
+}
+
 func TestPlannerRejectsMissingTarget(t *testing.T) {
 	_, err := testPlanner().Plan(Input{
 		SQL:       "SELECT * FROM public.users",

--- a/internal/db/redirect/planner_test.go
+++ b/internal/db/redirect/planner_test.go
@@ -99,6 +99,48 @@ func TestPlannerRejectsMissingSourceRelationBeforeParsing(t *testing.T) {
 	}
 }
 
+func TestPlannerRejectsSourceRelationWithoutCatalogMetadataBeforeParsing(t *testing.T) {
+	tests := []struct {
+		name     string
+		resolved effects.ResolvedObjectRef
+	}{
+		{
+			name: "empty source",
+			resolved: effects.ResolvedObjectRef{
+				Kind:   effects.ResolvedObjectRelation,
+				Schema: "public",
+				Name:   "users",
+			},
+		},
+		{
+			name: "unresolved reason",
+			resolved: effects.ResolvedObjectRef{
+				Source:           effects.ResolvedObjectSourceCatalog,
+				Kind:             effects.ResolvedObjectRelation,
+				Schema:           "public",
+				Name:             "users",
+				UnresolvedReason: "not visible",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := &fakeBackend{t: t}
+			_, err := Planner{Backend: backend}.Plan(Input{
+				SQL:       "SELECT * FROM public.users",
+				Statement: readStatementWithResolved(tt.resolved),
+				Action:    testAction(),
+			})
+
+			assertRejection(t, err, ReasonSourceNotFound)
+			if backend.parseCalled {
+				t.Fatal("Parse called before catalog source relation validation")
+			}
+		})
+	}
+}
+
 func TestPlannerRejectsMultiStatement(t *testing.T) {
 	_, err := testPlanner().Plan(Input{
 		SQL:       "SELECT * FROM public.users; SELECT * FROM public.users",
@@ -154,15 +196,19 @@ func testAction() Action {
 }
 
 func readStatement(schema, name string) effects.ClassifiedStatement {
+	return readStatementWithResolved(effects.ResolvedObjectRef{
+		Source: effects.ResolvedObjectSourceCatalog,
+		Kind:   effects.ResolvedObjectRelation,
+		Schema: schema,
+		Name:   name,
+	})
+}
+
+func readStatementWithResolved(resolved effects.ResolvedObjectRef) effects.ClassifiedStatement {
 	return effects.ClassifiedStatement{Effects: []effects.Effect{{
-		Group:      effects.GroupRead,
-		Resolution: effects.ResolutionCatalogResolved,
-		ResolvedObjects: []effects.ResolvedObjectRef{{
-			Source: effects.ResolvedObjectSourceCatalog,
-			Kind:   effects.ResolvedObjectRelation,
-			Schema: schema,
-			Name:   name,
-		}},
+		Group:           effects.GroupRead,
+		Resolution:      effects.ResolutionCatalogResolved,
+		ResolvedObjects: []effects.ResolvedObjectRef{resolved},
 	}}}
 }
 

--- a/internal/db/redirect/planner_test.go
+++ b/internal/db/redirect/planner_test.go
@@ -191,6 +191,23 @@ func TestPlannerRewritesQualifiedRelation(t *testing.T) {
 	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
 }
 
+func TestPlannerRewritesTableQualifiedColumnReferenceWithImplicitAlias(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "SELECT users.id FROM public.users",
+		Statement: readStatement("public", "users"),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	assertRewrittenRelationAlias(t, plan.RewrittenSQL, "public.safe_users", "users")
+}
+
 func TestPlannerRewritesUnqualifiedResolvedRelation(t *testing.T) {
 	plan, err := testPlanner().Plan(Input{
 		SQL:       "SELECT * FROM users",
@@ -224,11 +241,7 @@ func TestPlannerPreservesAlias(t *testing.T) {
 		t.Fatalf("Plan() error = %v", err)
 	}
 
-	rewritten := strings.ToLower(plan.RewrittenSQL)
-	if !strings.Contains(rewritten, "public.safe_users as u") &&
-		!strings.Contains(rewritten, "public.safe_users u") {
-		t.Fatalf("rewritten SQL = %q, want rewritten FROM relation to keep alias u", plan.RewrittenSQL)
-	}
+	assertRewrittenRelationAlias(t, plan.RewrittenSQL, "public.safe_users", "u")
 }
 
 func TestPlannerRewritesOneRelationInJoin(t *testing.T) {
@@ -248,6 +261,38 @@ func TestPlannerRewritesOneRelationInJoin(t *testing.T) {
 	assertSQLContains(t, plan.RewrittenSQL, "public.safe_users")
 	assertSQLContains(t, plan.RewrittenSQL, "public.orders")
 	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
+}
+
+func TestPlannerRewritesJoinTableQualifiedReferenceWithImplicitAlias(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users JOIN public.orders ON users.id = orders.user_id",
+		Statement: readStatement("public", "users"),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	assertRewrittenRelationAlias(t, plan.RewrittenSQL, "public.safe_users", "users")
+	assertSQLContains(t, plan.RewrittenSQL, "public.orders")
+}
+
+func TestPlannerRejectsSchemaQualifiedSourceColumnReference(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT public.users.id FROM public.users",
+		Statement: readStatement("public", "users"),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+
+	assertRejection(t, err, ReasonUnsupportedStatement)
 }
 
 func TestRejectionValueImplementsError(t *testing.T) {
@@ -326,6 +371,17 @@ func assertSQLNotContains(t *testing.T, sql, unwanted string) {
 	t.Helper()
 	if strings.Contains(sql, unwanted) {
 		t.Fatalf("rewritten SQL = %q, want not to contain %q", sql, unwanted)
+	}
+}
+
+func assertRewrittenRelationAlias(t *testing.T, sql, relation, alias string) {
+	t.Helper()
+	rewritten := strings.ToLower(sql)
+	relation = strings.ToLower(relation)
+	alias = strings.ToLower(alias)
+	if !strings.Contains(rewritten, relation+" as "+alias) &&
+		!strings.Contains(rewritten, relation+" "+alias) {
+		t.Fatalf("rewritten SQL = %q, want rewritten FROM relation to keep alias %s", sql, alias)
 	}
 }
 

--- a/internal/db/redirect/planner_test.go
+++ b/internal/db/redirect/planner_test.go
@@ -319,7 +319,7 @@ func TestPlannerRewritesReadOnlyCTE(t *testing.T) {
 
 func TestPlannerRewritesCTEShadowingSourceName(t *testing.T) {
 	plan, err := testPlanner().Plan(Input{
-		SQL:       "WITH users AS (SELECT id FROM public.users) SELECT * FROM users",
+		SQL:       "WITH users AS (SELECT id FROM users) SELECT * FROM users",
 		Statement: readStatement("public", "users"),
 		Action: Action{
 			RuleName:       "redirect-users",

--- a/internal/db/redirect/planner_test.go
+++ b/internal/db/redirect/planner_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/agentsh/agentsh/internal/db/classify/postgres"
 	"github.com/agentsh/agentsh/internal/db/effects"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
 )
 
 func TestPlannerRejectsMissingTarget(t *testing.T) {
@@ -19,6 +20,34 @@ func TestPlannerRejectsMissingTarget(t *testing.T) {
 	})
 
 	assertRejection(t, err, ReasonMissingRedirectTarget)
+}
+
+func TestPlannerRejectsWhitespaceOnlyTarget(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users",
+		Statement: readStatement("public", "users"),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: " \t\n ",
+		},
+	})
+
+	assertRejection(t, err, ReasonMissingRedirectTarget)
+}
+
+func TestPlannerRejectsWhitespaceOnlySource(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users",
+		Statement: readStatement("public", "users"),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: " \t\n ",
+			TargetRelation: "archive.users",
+		},
+	})
+
+	assertRejection(t, err, ReasonSourceNotFound)
 }
 
 func TestPlannerRejectsUnresolvedObject(t *testing.T) {
@@ -56,6 +85,20 @@ func TestPlannerRejectsWriteStatement(t *testing.T) {
 	assertRejection(t, err, ReasonWriteStatement)
 }
 
+func TestPlannerRejectsMissingSourceRelationBeforeParsing(t *testing.T) {
+	backend := &fakeBackend{t: t}
+	_, err := Planner{Backend: backend}.Plan(Input{
+		SQL:       "SELECT * FROM public.users",
+		Statement: readStatement("public", "orders"),
+		Action:    testAction(),
+	})
+
+	assertRejection(t, err, ReasonSourceNotFound)
+	if backend.parseCalled {
+		t.Fatal("Parse called before source relation validation")
+	}
+}
+
 func TestPlannerRejectsMultiStatement(t *testing.T) {
 	_, err := testPlanner().Plan(Input{
 		SQL:       "SELECT * FROM public.users; SELECT * FROM public.users",
@@ -68,15 +111,34 @@ func TestPlannerRejectsMultiStatement(t *testing.T) {
 
 func TestPlannerRejectsNonSelectStatement(t *testing.T) {
 	_, err := testPlanner().Plan(Input{
-		SQL: "BEGIN",
-		Statement: effects.ClassifiedStatement{Effects: []effects.Effect{{
-			Group:      effects.GroupRead,
-			Resolution: effects.ResolutionCatalogResolved,
-		}}},
-		Action: testAction(),
+		SQL:       "BEGIN",
+		Statement: readStatement("public", "users"),
+		Action:    testAction(),
 	})
 
 	assertRejection(t, err, ReasonNonSelectStatement)
+}
+
+func TestPlannerRejectsNilParseResultAsMultiStatement(t *testing.T) {
+	_, err := Planner{Backend: &fakeBackend{parseResult: nil}}.Plan(Input{
+		SQL:       "SELECT * FROM public.users",
+		Statement: readStatement("public", "users"),
+		Action:    testAction(),
+	})
+
+	assertRejection(t, err, ReasonMultiStatement)
+}
+
+func TestRejectionValueImplementsError(t *testing.T) {
+	err := error(Rejection{Reason: ReasonUnsupportedStatement})
+
+	var rej Rejection
+	if !errors.As(err, &rej) {
+		t.Fatalf("errors.As() = false, want true for Rejection value")
+	}
+	if rej.Reason != ReasonUnsupportedStatement {
+		t.Fatalf("rejection reason = %q, want %q", rej.Reason, ReasonUnsupportedStatement)
+	}
 }
 
 func testPlanner() Planner {
@@ -106,11 +168,33 @@ func readStatement(schema, name string) effects.ClassifiedStatement {
 
 func assertRejection(t *testing.T, err error, reason Reason) {
 	t.Helper()
-	var rej *Rejection
+	var rej Rejection
 	if !errors.As(err, &rej) {
-		t.Fatalf("Plan() error = %T %v, want *Rejection", err, err)
+		t.Fatalf("Plan() error = %T %v, want Rejection", err, err)
 	}
 	if rej.Reason != reason {
 		t.Fatalf("rejection reason = %q, want %q", rej.Reason, reason)
 	}
+}
+
+type fakeBackend struct {
+	t           *testing.T
+	parseCalled bool
+	parseResult *pg_query.ParseResult
+}
+
+func (f *fakeBackend) Parse(string) (*pg_query.ParseResult, error) {
+	if f.t != nil {
+		f.t.Helper()
+	}
+	f.parseCalled = true
+	return f.parseResult, nil
+}
+
+func (f *fakeBackend) Deparse(*pg_query.ParseResult) (string, error) {
+	return "", nil
+}
+
+func (f *fakeBackend) Backend() effects.ParserBackend {
+	return effects.ParserBackendPureGo
 }

--- a/internal/db/redirect/planner_test.go
+++ b/internal/db/redirect/planner_test.go
@@ -2,6 +2,7 @@ package redirect
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/db/classify/postgres"
@@ -171,6 +172,81 @@ func TestPlannerRejectsNilParseResultAsMultiStatement(t *testing.T) {
 	assertRejection(t, err, ReasonMultiStatement)
 }
 
+func TestPlannerRewritesQualifiedRelation(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users",
+		Statement: readStatement("public", "users"),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	assertPlanMetadata(t, plan, "redirect-users", "public.users", "public.safe_users")
+	assertSQLContains(t, plan.RewrittenSQL, "public.safe_users")
+	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
+}
+
+func TestPlannerRewritesUnqualifiedResolvedRelation(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM users",
+		Statement: readStatement("public", "users"),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	assertPlanMetadata(t, plan, "redirect-users", "public.users", "public.safe_users")
+	assertSQLContains(t, plan.RewrittenSQL, "public.safe_users")
+	assertSQLNotContains(t, plan.RewrittenSQL, " FROM users")
+}
+
+func TestPlannerPreservesAlias(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "SELECT u.id FROM public.users AS u",
+		Statement: readStatement("public", "users"),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	assertSQLContains(t, plan.RewrittenSQL, "public.safe_users")
+	assertSQLContains(t, plan.RewrittenSQL, " u")
+}
+
+func TestPlannerRewritesOneRelationInJoin(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users JOIN public.orders ON users.id = orders.user_id",
+		Statement: readStatement("public", "users"),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	assertSQLContains(t, plan.RewrittenSQL, "public.safe_users")
+	assertSQLContains(t, plan.RewrittenSQL, "public.orders")
+	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
+}
+
 func TestRejectionValueImplementsError(t *testing.T) {
 	err := error(Rejection{Reason: ReasonUnsupportedStatement})
 
@@ -220,6 +296,33 @@ func assertRejection(t *testing.T, err error, reason Reason) {
 	}
 	if rej.Reason != reason {
 		t.Fatalf("rejection reason = %q, want %q", rej.Reason, reason)
+	}
+}
+
+func assertPlanMetadata(t *testing.T, plan Plan, ruleName, source, target string) {
+	t.Helper()
+	if plan.RuleName != ruleName {
+		t.Fatalf("RuleName = %q, want %q", plan.RuleName, ruleName)
+	}
+	if plan.SourceRelation != source {
+		t.Fatalf("SourceRelation = %q, want %q", plan.SourceRelation, source)
+	}
+	if plan.TargetRelation != target {
+		t.Fatalf("TargetRelation = %q, want %q", plan.TargetRelation, target)
+	}
+}
+
+func assertSQLContains(t *testing.T, sql, want string) {
+	t.Helper()
+	if !strings.Contains(sql, want) {
+		t.Fatalf("rewritten SQL = %q, want to contain %q", sql, want)
+	}
+}
+
+func assertSQLNotContains(t *testing.T, sql, unwanted string) {
+	t.Helper()
+	if strings.Contains(sql, unwanted) {
+		t.Fatalf("rewritten SQL = %q, want not to contain %q", sql, unwanted)
 	}
 }
 

--- a/internal/db/redirect/planner_test.go
+++ b/internal/db/redirect/planner_test.go
@@ -336,6 +336,26 @@ func TestPlannerRewritesCTEShadowingSourceName(t *testing.T) {
 	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
 }
 
+func TestPlannerRewritesCTESiblingReferenceNotSource(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "WITH users AS (SELECT id FROM public.users), x AS (SELECT * FROM users) SELECT * FROM x",
+		Statement: readStatement("public", "users"),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	assertSQLContains(t, plan.RewrittenSQL, "public.safe_users")
+	assertSQLContains(t, plan.RewrittenSQL, "FROM users")
+	assertSQLContains(t, plan.RewrittenSQL, "FROM x")
+	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
+}
+
 func TestPlannerRewritesSetOperation(t *testing.T) {
 	plan, err := testPlanner().Plan(Input{
 		SQL: "SELECT id FROM public.users UNION ALL SELECT id FROM public.archive_users",
@@ -504,6 +524,51 @@ func TestPlannerRejectsMultipleSourceOccurrences(t *testing.T) {
 	assertRejection(t, err, ReasonAmbiguousRedirectSource)
 }
 
+func TestRewriteRangeNodeRejectsMalformedRangeSubselect(t *testing.T) {
+	tests := []struct {
+		name string
+		node *pg_query.Node
+	}{
+		{
+			name: "missing subquery",
+			node: &pg_query.Node{Node: &pg_query.Node_RangeSubselect{
+				RangeSubselect: &pg_query.RangeSubselect{},
+			}},
+		},
+		{
+			name: "non-select subquery",
+			node: &pg_query.Node{Node: &pg_query.Node_RangeSubselect{
+				RangeSubselect: &pg_query.RangeSubselect{Subquery: &pg_query.Node{
+					Node: &pg_query.Node_InsertStmt{InsertStmt: &pg_query.InsertStmt{}},
+				}},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := rewriteRangeNode(tt.node, testRewrite())
+			assertRejection(t, err, ReasonUnsupportedStatement)
+		})
+	}
+}
+
+func TestRewriteRangeNodeRejectsUnsupportedRangeTableFunc(t *testing.T) {
+	_, err := rewriteRangeNode(&pg_query.Node{Node: &pg_query.Node_RangeTableFunc{
+		RangeTableFunc: &pg_query.RangeTableFunc{},
+	}}, testRewrite())
+
+	assertRejection(t, err, ReasonUnsupportedStatement)
+}
+
+func TestRewriteRangeNodeRejectsUnknownRangeVariant(t *testing.T) {
+	_, err := rewriteRangeNode(&pg_query.Node{Node: &pg_query.Node_RangeTblRef{
+		RangeTblRef: &pg_query.RangeTblRef{},
+	}}, testRewrite())
+
+	assertRejection(t, err, ReasonUnsupportedStatement)
+}
+
 func TestRejectionValueImplementsError(t *testing.T) {
 	err := error(Rejection{Reason: ReasonUnsupportedStatement})
 
@@ -525,6 +590,15 @@ func testAction() Action {
 		RuleName:       "redirect-users",
 		SourceRelation: "public.users",
 		TargetRelation: "archive.users",
+	}
+}
+
+func testRewrite() relationRewrite {
+	return relationRewrite{
+		sourceSchema: "public",
+		sourceName:   "users",
+		targetSchema: "public",
+		targetName:   "safe_users",
 	}
 }
 

--- a/internal/db/redirect/planner_test.go
+++ b/internal/db/redirect/planner_test.go
@@ -339,6 +339,78 @@ func TestPlannerRewritesSetOperation(t *testing.T) {
 	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
 }
 
+func TestPlannerRewritesWhereExistsSubquery(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL: "SELECT * FROM public.orders WHERE EXISTS (SELECT 1 FROM public.users WHERE users.id = orders.user_id)",
+		Statement: readStatementWithResolved(
+			resolvedRelation("public", "orders"),
+			resolvedRelation("public", "users"),
+		),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	assertSQLContains(t, plan.RewrittenSQL, "public.safe_users")
+	assertSQLContains(t, plan.RewrittenSQL, "public.orders")
+	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
+}
+
+func TestPlannerRejectsWhereExistsMultipleSourceOccurrences(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users WHERE EXISTS (SELECT 1 FROM public.users u2 WHERE u2.id = users.id)",
+		Statement: readStatement("public", "users"),
+		Action:    testAction(),
+	})
+
+	assertRejection(t, err, ReasonAmbiguousRedirectSource)
+}
+
+func TestPlannerRewritesScalarTargetListSubquery(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL:       "SELECT (SELECT id FROM public.users LIMIT 1) AS user_id",
+		Statement: readStatement("public", "users"),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	assertSQLContains(t, plan.RewrittenSQL, "public.safe_users")
+	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
+}
+
+func TestPlannerRewritesInSubquery(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL: "SELECT * FROM public.orders WHERE user_id IN (SELECT id FROM public.users)",
+		Statement: readStatementWithResolved(
+			resolvedRelation("public", "orders"),
+			resolvedRelation("public", "users"),
+		),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	assertSQLContains(t, plan.RewrittenSQL, "public.safe_users")
+	assertSQLContains(t, plan.RewrittenSQL, "public.orders")
+	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
+}
+
 func TestPlannerRejectsSchemaQualifiedSourceColumnReference(t *testing.T) {
 	_, err := testPlanner().Plan(Input{
 		SQL:       "SELECT public.users.id FROM public.users",

--- a/internal/db/redirect/planner_test.go
+++ b/internal/db/redirect/planner_test.go
@@ -1,0 +1,116 @@
+package redirect
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/db/classify/postgres"
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
+
+func TestPlannerRejectsMissingTarget(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users",
+		Statement: readStatement("public", "users"),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+		},
+	})
+
+	assertRejection(t, err, ReasonMissingRedirectTarget)
+}
+
+func TestPlannerRejectsUnresolvedObject(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL: "SELECT * FROM users",
+		Statement: effects.ClassifiedStatement{Effects: []effects.Effect{{
+			Group:      effects.GroupRead,
+			Resolution: effects.ResolutionUnresolved,
+			Objects: []effects.ObjectRef{{
+				Kind: effects.ObjectTable,
+				Name: "users",
+			}},
+		}}},
+		Action: testAction(),
+	})
+
+	assertRejection(t, err, ReasonUnresolvedObject)
+}
+
+func TestPlannerRejectsWriteStatement(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL: "INSERT INTO public.users (id) VALUES (1)",
+		Statement: effects.ClassifiedStatement{Effects: []effects.Effect{{
+			Group: effects.GroupWrite,
+			ResolvedObjects: []effects.ResolvedObjectRef{{
+				Kind:   effects.ResolvedObjectRelation,
+				Schema: "public",
+				Name:   "users",
+			}},
+			Resolution: effects.ResolutionCatalogResolved,
+		}}},
+		Action: testAction(),
+	})
+
+	assertRejection(t, err, ReasonWriteStatement)
+}
+
+func TestPlannerRejectsMultiStatement(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users; SELECT * FROM public.users",
+		Statement: readStatement("public", "users"),
+		Action:    testAction(),
+	})
+
+	assertRejection(t, err, ReasonMultiStatement)
+}
+
+func TestPlannerRejectsNonSelectStatement(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL: "BEGIN",
+		Statement: effects.ClassifiedStatement{Effects: []effects.Effect{{
+			Group:      effects.GroupRead,
+			Resolution: effects.ResolutionCatalogResolved,
+		}}},
+		Action: testAction(),
+	})
+
+	assertRejection(t, err, ReasonNonSelectStatement)
+}
+
+func testPlanner() Planner {
+	return Planner{Backend: postgres.NewRewriteBackend(postgres.DialectPostgres)}
+}
+
+func testAction() Action {
+	return Action{
+		RuleName:       "redirect-users",
+		SourceRelation: "public.users",
+		TargetRelation: "archive.users",
+	}
+}
+
+func readStatement(schema, name string) effects.ClassifiedStatement {
+	return effects.ClassifiedStatement{Effects: []effects.Effect{{
+		Group:      effects.GroupRead,
+		Resolution: effects.ResolutionCatalogResolved,
+		ResolvedObjects: []effects.ResolvedObjectRef{{
+			Source: effects.ResolvedObjectSourceCatalog,
+			Kind:   effects.ResolvedObjectRelation,
+			Schema: schema,
+			Name:   name,
+		}},
+	}}}
+}
+
+func assertRejection(t *testing.T, err error, reason Reason) {
+	t.Helper()
+	var rej *Rejection
+	if !errors.As(err, &rej) {
+		t.Fatalf("Plan() error = %T %v, want *Rejection", err, err)
+	}
+	if rej.Reason != reason {
+		t.Fatalf("rejection reason = %q, want %q", rej.Reason, reason)
+	}
+}

--- a/internal/db/redirect/planner_test.go
+++ b/internal/db/redirect/planner_test.go
@@ -224,8 +224,11 @@ func TestPlannerPreservesAlias(t *testing.T) {
 		t.Fatalf("Plan() error = %v", err)
 	}
 
-	assertSQLContains(t, plan.RewrittenSQL, "public.safe_users")
-	assertSQLContains(t, plan.RewrittenSQL, " u")
+	rewritten := strings.ToLower(plan.RewrittenSQL)
+	if !strings.Contains(rewritten, "public.safe_users as u") &&
+		!strings.Contains(rewritten, "public.safe_users u") {
+		t.Fatalf("rewritten SQL = %q, want rewritten FROM relation to keep alias u", plan.RewrittenSQL)
+	}
 }
 
 func TestPlannerRewritesOneRelationInJoin(t *testing.T) {

--- a/internal/db/redirect/planner_test.go
+++ b/internal/db/redirect/planner_test.go
@@ -252,8 +252,11 @@ func TestPlannerPreservesAlias(t *testing.T) {
 
 func TestPlannerRewritesOneRelationInJoin(t *testing.T) {
 	plan, err := testPlanner().Plan(Input{
-		SQL:       "SELECT * FROM public.users JOIN public.orders ON users.id = orders.user_id",
-		Statement: readStatement("public", "users"),
+		SQL: "SELECT * FROM public.users JOIN public.orders ON users.id = orders.user_id",
+		Statement: readStatementWithResolved(
+			resolvedRelation("public", "users"),
+			resolvedRelation("public", "orders"),
+		),
 		Action: Action{
 			RuleName:       "redirect-users",
 			SourceRelation: "public.users",
@@ -271,8 +274,11 @@ func TestPlannerRewritesOneRelationInJoin(t *testing.T) {
 
 func TestPlannerRewritesJoinTableQualifiedReferenceWithImplicitAlias(t *testing.T) {
 	plan, err := testPlanner().Plan(Input{
-		SQL:       "SELECT * FROM public.users JOIN public.orders ON users.id = orders.user_id",
-		Statement: readStatement("public", "users"),
+		SQL: "SELECT * FROM public.users JOIN public.orders ON users.id = orders.user_id",
+		Statement: readStatementWithResolved(
+			resolvedRelation("public", "users"),
+			resolvedRelation("public", "orders"),
+		),
 		Action: Action{
 			RuleName:       "redirect-users",
 			SourceRelation: "public.users",
@@ -406,6 +412,52 @@ func TestPlannerRewritesWhereExistsSubquery(t *testing.T) {
 	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
 }
 
+func TestPlannerRejectsHiddenExpressionSubqueryRelationMissingFromMetadata(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "SELECT * FROM public.users WHERE EXISTS (SELECT 1 FROM public.secrets)",
+		Statement: readStatement("public", "users"),
+		Action:    testAction(),
+	})
+
+	assertRejection(t, err, ReasonUnresolvedObject)
+}
+
+func TestPlannerPreservesExpressionSubqueryRelationPresentInMetadata(t *testing.T) {
+	plan, err := testPlanner().Plan(Input{
+		SQL: "SELECT * FROM public.users WHERE EXISTS (SELECT 1 FROM public.orders)",
+		Statement: readStatementWithResolved(
+			resolvedRelation("public", "users"),
+			resolvedRelation("public", "orders"),
+		),
+		Action: Action{
+			RuleName:       "redirect-users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	assertSQLContains(t, plan.RewrittenSQL, "public.safe_users")
+	assertSQLContains(t, plan.RewrittenSQL, "public.orders")
+	assertSQLNotContains(t, plan.RewrittenSQL, "public.users")
+}
+
+func TestPlannerRejectsAmbiguousUnqualifiedExpressionSubqueryRelationMetadata(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL: "SELECT * FROM public.users WHERE EXISTS (SELECT 1 FROM orders)",
+		Statement: readStatementWithResolved(
+			resolvedRelation("public", "users"),
+			resolvedRelation("public", "orders"),
+			resolvedRelation("archive", "orders"),
+		),
+		Action: testAction(),
+	})
+
+	assertRejection(t, err, ReasonUnresolvedObject)
+}
+
 func TestPlannerRejectsWhereExistsMultipleSourceOccurrences(t *testing.T) {
 	_, err := testPlanner().Plan(Input{
 		SQL:       "SELECT * FROM public.users WHERE EXISTS (SELECT 1 FROM public.users u2 WHERE u2.id = users.id)",
@@ -493,6 +545,16 @@ func TestPlannerRejectsDataModifyingCTE(t *testing.T) {
 func TestPlannerRejectsLockingClause(t *testing.T) {
 	_, err := testPlanner().Plan(Input{
 		SQL:       "SELECT * FROM public.users FOR UPDATE",
+		Statement: readStatement("public", "users"),
+		Action:    testAction(),
+	})
+
+	assertRejection(t, err, ReasonUnsupportedStatement)
+}
+
+func TestPlannerRejectsTopLevelValuesSelectStmt(t *testing.T) {
+	_, err := testPlanner().Plan(Input{
+		SQL:       "VALUES (1)",
 		Statement: readStatement("public", "users"),
 		Action:    testAction(),
 	})

--- a/internal/db/redirect/types.go
+++ b/internal/db/redirect/types.go
@@ -21,8 +21,10 @@ const (
 	ReasonUnresolvedObject        Reason = "unresolved_object"
 	ReasonMissingRedirectTarget   Reason = "missing_redirect_target"
 	ReasonAmbiguousRedirectSource Reason = "ambiguous_redirect_source"
-	ReasonSourceNotFound          Reason = "source_relation_not_found"
-	ReasonDeparseFailed           Reason = "deparse_failed"
+	// ReasonAmbiguousSource is a compatibility alias used by the Plan 12 dependency gate.
+	ReasonAmbiguousSource Reason = ReasonAmbiguousRedirectSource
+	ReasonSourceNotFound  Reason = "source_relation_not_found"
+	ReasonDeparseFailed   Reason = "deparse_failed"
 )
 
 type Rejection struct {

--- a/internal/db/redirect/types.go
+++ b/internal/db/redirect/types.go
@@ -1,0 +1,77 @@
+package redirect
+
+import (
+	"fmt"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+)
+
+type Reason string
+
+const (
+	ReasonUnsupportedStatement    Reason = "unsupported_statement"
+	ReasonMultiStatement          Reason = "multi_statement"
+	ReasonNonSelectStatement      Reason = "non_select_statement"
+	ReasonWriteStatement          Reason = "write_statement"
+	ReasonDDLStatement            Reason = "ddl_statement"
+	ReasonCopyStatement           Reason = "copy_statement"
+	ReasonProceduralStatement     Reason = "procedural_statement"
+	ReasonFunctionCallProtocol    Reason = "function_call_protocol"
+	ReasonUnresolvedObject        Reason = "unresolved_object"
+	ReasonMissingRedirectTarget   Reason = "missing_redirect_target"
+	ReasonAmbiguousRedirectSource Reason = "ambiguous_redirect_source"
+	ReasonSourceNotFound          Reason = "source_relation_not_found"
+	ReasonDeparseFailed           Reason = "deparse_failed"
+)
+
+type Rejection struct {
+	Reason Reason
+	Err    error
+}
+
+func (r *Rejection) Error() string {
+	if r == nil {
+		return ""
+	}
+	if r.Err != nil {
+		return fmt.Sprintf("%s: %v", r.Reason, r.Err)
+	}
+	return string(r.Reason)
+}
+
+func (r *Rejection) Unwrap() error {
+	if r == nil {
+		return nil
+	}
+	return r.Err
+}
+
+type Action struct {
+	RuleName       string
+	SourceRelation string
+	TargetRelation string
+}
+
+type Input struct {
+	SQL       string
+	Statement effects.ClassifiedStatement
+	Action    Action
+}
+
+type Plan struct {
+	RewrittenSQL   string
+	RuleName       string
+	SourceRelation string
+	TargetRelation string
+}
+
+type SQLBackend interface {
+	Parse(sql string) (*pg_query.ParseResult, error)
+	Deparse(tree *pg_query.ParseResult) (string, error)
+	Backend() effects.ParserBackend
+}
+
+type Planner struct {
+	Backend SQLBackend
+}

--- a/internal/db/redirect/types.go
+++ b/internal/db/redirect/types.go
@@ -30,20 +30,14 @@ type Rejection struct {
 	Err    error
 }
 
-func (r *Rejection) Error() string {
-	if r == nil {
-		return ""
-	}
+func (r Rejection) Error() string {
 	if r.Err != nil {
 		return fmt.Sprintf("%s: %v", r.Reason, r.Err)
 	}
 	return string(r.Reason)
 }
 
-func (r *Rejection) Unwrap() error {
-	if r == nil {
-		return nil
-	}
+func (r Rejection) Unwrap() error {
 	return r.Err
 }
 

--- a/internal/db/redirect/validate.go
+++ b/internal/db/redirect/validate.go
@@ -26,22 +26,16 @@ func validateInput(in Input) error {
 	}
 
 	for _, eff := range in.Statement.Effects {
-		switch eff.Group {
-		case effects.GroupRead:
+		if eff.Group == effects.GroupRead {
 			if eff.Resolution != effects.ResolutionCatalogResolved {
 				return reject(ReasonUnresolvedObject, nil)
 			}
-		case effects.GroupWrite, effects.GroupModify, effects.GroupDelete:
-			return reject(ReasonWriteStatement, nil)
-		case effects.GroupSchemaCreate, effects.GroupSchemaAlter, effects.GroupSchemaDestroy, effects.GroupPrivilege:
-			return reject(ReasonDDLStatement, nil)
-		case effects.GroupBulkLoad, effects.GroupBulkExport:
-			return reject(ReasonCopyStatement, nil)
-		case effects.GroupProcedural, effects.GroupUnsafeIO:
-			return reject(ReasonProceduralStatement, nil)
-		default:
-			return reject(ReasonUnsupportedStatement, nil)
+			continue
 		}
+		if reason, ok := rejectionForNonReadEffect(eff.Group); ok {
+			return reject(reason, nil)
+		}
+		return reject(ReasonUnsupportedStatement, nil)
 	}
 
 	if !sourceRelationExists(in.Statement, source) {
@@ -69,6 +63,21 @@ func sourceRelationExists(stmt effects.ClassifiedStatement, source string) bool 
 		}
 	}
 	return false
+}
+
+func rejectionForNonReadEffect(group effects.Group) (Reason, bool) {
+	switch group {
+	case effects.GroupWrite, effects.GroupModify, effects.GroupDelete:
+		return ReasonWriteStatement, true
+	case effects.GroupSchemaCreate, effects.GroupSchemaAlter, effects.GroupSchemaDestroy, effects.GroupPrivilege:
+		return ReasonDDLStatement, true
+	case effects.GroupBulkLoad, effects.GroupBulkExport:
+		return ReasonCopyStatement, true
+	case effects.GroupProcedural, effects.GroupUnsafeIO:
+		return ReasonProceduralStatement, true
+	default:
+		return "", false
+	}
 }
 
 func hasUnresolvedObject(objects []effects.ResolvedObjectRef) bool {

--- a/internal/db/redirect/validate.go
+++ b/internal/db/redirect/validate.go
@@ -28,7 +28,7 @@ func validateInput(in Input) error {
 	for _, eff := range in.Statement.Effects {
 		switch eff.Group {
 		case effects.GroupRead:
-			if eff.Resolution != effects.ResolutionCatalogResolved || hasUnresolvedObject(eff.ResolvedObjects) {
+			if eff.Resolution != effects.ResolutionCatalogResolved {
 				return reject(ReasonUnresolvedObject, nil)
 			}
 		case effects.GroupWrite, effects.GroupModify, effects.GroupDelete:
@@ -48,13 +48,22 @@ func validateInput(in Input) error {
 		return reject(ReasonSourceNotFound, nil)
 	}
 
+	for _, eff := range in.Statement.Effects {
+		if eff.Group == effects.GroupRead && hasUnresolvedObject(eff.ResolvedObjects) {
+			return reject(ReasonUnresolvedObject, nil)
+		}
+	}
+
 	return nil
 }
 
 func sourceRelationExists(stmt effects.ClassifiedStatement, source string) bool {
 	for _, eff := range stmt.Effects {
 		for _, obj := range eff.ResolvedObjects {
-			if obj.Kind == effects.ResolvedObjectRelation && obj.CanonicalName() == source {
+			if obj.Source == effects.ResolvedObjectSourceCatalog &&
+				obj.Kind == effects.ResolvedObjectRelation &&
+				obj.UnresolvedReason == "" &&
+				obj.CanonicalName() == source {
 				return true
 			}
 		}

--- a/internal/db/redirect/validate.go
+++ b/internal/db/redirect/validate.go
@@ -1,12 +1,18 @@
 package redirect
 
-import "github.com/agentsh/agentsh/internal/db/effects"
+import (
+	"strings"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+)
 
 func validateInput(in Input) error {
-	if in.Action.TargetRelation == "" {
+	target := strings.TrimSpace(in.Action.TargetRelation)
+	if target == "" {
 		return reject(ReasonMissingRedirectTarget, nil)
 	}
-	if in.Action.SourceRelation == "" {
+	source := strings.TrimSpace(in.Action.SourceRelation)
+	if source == "" {
 		return reject(ReasonSourceNotFound, nil)
 	}
 	if len(in.Statement.Effects) == 0 {
@@ -38,6 +44,10 @@ func validateInput(in Input) error {
 		}
 	}
 
+	if !sourceRelationExists(in.Statement, source) {
+		return reject(ReasonSourceNotFound, nil)
+	}
+
 	return nil
 }
 
@@ -62,5 +72,5 @@ func hasUnresolvedObject(objects []effects.ResolvedObjectRef) bool {
 }
 
 func reject(reason Reason, err error) error {
-	return &Rejection{Reason: reason, Err: err}
+	return Rejection{Reason: reason, Err: err}
 }

--- a/internal/db/redirect/validate.go
+++ b/internal/db/redirect/validate.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 
 	"github.com/agentsh/agentsh/internal/db/effects"
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 func validateInput(in Input) error {
@@ -87,6 +89,260 @@ func hasUnresolvedObject(objects []effects.ResolvedObjectRef) bool {
 		}
 	}
 	return false
+}
+
+type relationMetadata struct {
+	qualified map[string]struct{}
+	byName    map[string]map[string]struct{}
+}
+
+func validateSelectRelationMetadata(stmt *pg_query.SelectStmt, classified effects.ClassifiedStatement) error {
+	return validateSelectRelationsCovered(stmt, collectRelationMetadata(classified), relationRewrite{})
+}
+
+func collectRelationMetadata(stmt effects.ClassifiedStatement) relationMetadata {
+	metadata := relationMetadata{
+		qualified: map[string]struct{}{},
+		byName:    map[string]map[string]struct{}{},
+	}
+	for _, eff := range stmt.Effects {
+		for _, obj := range eff.ResolvedObjects {
+			if obj.Source != effects.ResolvedObjectSourceCatalog ||
+				obj.Kind != effects.ResolvedObjectRelation ||
+				obj.UnresolvedReason != "" {
+				continue
+			}
+			canonical := obj.CanonicalName()
+			metadata.qualified[canonical] = struct{}{}
+			if _, ok := metadata.byName[obj.Name]; !ok {
+				metadata.byName[obj.Name] = map[string]struct{}{}
+			}
+			metadata.byName[obj.Name][canonical] = struct{}{}
+		}
+	}
+	return metadata
+}
+
+func validateSelectRelationsCovered(stmt *pg_query.SelectStmt, metadata relationMetadata, scope relationRewrite) error {
+	if stmt == nil {
+		return nil
+	}
+
+	if err := validateCTERelationMetadata(stmt.WithClause, metadata, scope); err != nil {
+		return err
+	}
+	scoped := scope.withCTENames(stmt.WithClause)
+	if err := validateRangeNodesCovered(stmt.FromClause, metadata, scoped); err != nil {
+		return err
+	}
+	if err := validateSelectExpressionSubqueryRelationMetadata(stmt, metadata, scoped); err != nil {
+		return err
+	}
+	if err := validateSelectRelationsCovered(stmt.Larg, metadata, scoped); err != nil {
+		return err
+	}
+	return validateSelectRelationsCovered(stmt.Rarg, metadata, scoped)
+}
+
+func validateCTERelationMetadata(withClause *pg_query.WithClause, metadata relationMetadata, scope relationRewrite) error {
+	if withClause == nil {
+		return nil
+	}
+
+	bodyScope := scope
+	for _, node := range withClause.Ctes {
+		if node == nil {
+			continue
+		}
+		cteNode, ok := node.Node.(*pg_query.Node_CommonTableExpr)
+		if !ok || cteNode.CommonTableExpr == nil || cteNode.CommonTableExpr.Ctequery == nil {
+			continue
+		}
+		query, ok := cteNode.CommonTableExpr.Ctequery.Node.(*pg_query.Node_SelectStmt)
+		if !ok || query.SelectStmt == nil {
+			return reject(ReasonWriteStatement, nil)
+		}
+		if err := validateSelectRelationsCovered(query.SelectStmt, metadata, bodyScope); err != nil {
+			return err
+		}
+		bodyScope = bodyScope.withCTEName(cteNode.CommonTableExpr.Ctename)
+	}
+	return nil
+}
+
+func validateRangeNodesCovered(nodes []*pg_query.Node, metadata relationMetadata, scope relationRewrite) error {
+	for _, node := range nodes {
+		if err := validateRangeNodeCovered(node, metadata, scope); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRangeNodeCovered(node *pg_query.Node, metadata relationMetadata, scope relationRewrite) error {
+	if node == nil {
+		return nil
+	}
+
+	switch n := node.Node.(type) {
+	case *pg_query.Node_RangeVar:
+		if n.RangeVar == nil {
+			return reject(ReasonUnsupportedStatement, nil)
+		}
+		if rangeVarIsInScopeCTE(n.RangeVar, scope) {
+			return nil
+		}
+		if !metadata.covers(n.RangeVar) {
+			return reject(ReasonUnresolvedObject, nil)
+		}
+		return nil
+	case *pg_query.Node_JoinExpr:
+		if n.JoinExpr == nil || n.JoinExpr.Larg == nil || n.JoinExpr.Rarg == nil {
+			return reject(ReasonUnsupportedStatement, nil)
+		}
+		if err := validateRangeNodeCovered(n.JoinExpr.Larg, metadata, scope); err != nil {
+			return err
+		}
+		if err := validateRangeNodeCovered(n.JoinExpr.Rarg, metadata, scope); err != nil {
+			return err
+		}
+		return validateExpressionSubqueryRelationMetadataInNode(n.JoinExpr.Quals, metadata, scope)
+	case *pg_query.Node_RangeSubselect:
+		if n.RangeSubselect == nil || n.RangeSubselect.Subquery == nil {
+			return reject(ReasonUnsupportedStatement, nil)
+		}
+		subquery, ok := n.RangeSubselect.Subquery.Node.(*pg_query.Node_SelectStmt)
+		if !ok || subquery.SelectStmt == nil {
+			return reject(ReasonUnsupportedStatement, nil)
+		}
+		return validateSelectRelationsCovered(subquery.SelectStmt, metadata, scope)
+	case *pg_query.Node_RangeTableSample:
+		return reject(ReasonUnsupportedStatement, nil)
+	case *pg_query.Node_RangeFunction:
+		return reject(ReasonProceduralStatement, nil)
+	case *pg_query.Node_RangeTableFunc:
+		return reject(ReasonUnsupportedStatement, nil)
+	default:
+		return reject(ReasonUnsupportedStatement, nil)
+	}
+}
+
+func (metadata relationMetadata) covers(rv *pg_query.RangeVar) bool {
+	if rv == nil || rv.Catalogname != "" || rv.Relname == "" {
+		return false
+	}
+	if rv.Schemaname != "" {
+		_, ok := metadata.qualified[rv.Schemaname+"."+rv.Relname]
+		return ok
+	}
+	return len(metadata.byName[rv.Relname]) == 1
+}
+
+func rangeVarIsInScopeCTE(rv *pg_query.RangeVar, scope relationRewrite) bool {
+	if rv == nil || rv.Schemaname != "" || rv.Catalogname != "" {
+		return false
+	}
+	_, ok := scope.cteNames[rv.Relname]
+	return ok
+}
+
+func validateSelectExpressionSubqueryRelationMetadata(stmt *pg_query.SelectStmt, metadata relationMetadata, scope relationRewrite) error {
+	if err := validateExpressionSubqueryRelationMetadataInNodes(stmt.DistinctClause, metadata, scope); err != nil {
+		return err
+	}
+	for _, nodes := range [][]*pg_query.Node{
+		stmt.TargetList,
+		stmt.GroupClause,
+		stmt.WindowClause,
+		stmt.ValuesLists,
+		stmt.SortClause,
+	} {
+		if err := validateExpressionSubqueryRelationMetadataInNodes(nodes, metadata, scope); err != nil {
+			return err
+		}
+	}
+	for _, node := range []*pg_query.Node{
+		stmt.WhereClause,
+		stmt.HavingClause,
+		stmt.LimitOffset,
+		stmt.LimitCount,
+	} {
+		if err := validateExpressionSubqueryRelationMetadataInNode(node, metadata, scope); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateExpressionSubqueryRelationMetadataInNodes(nodes []*pg_query.Node, metadata relationMetadata, scope relationRewrite) error {
+	for _, node := range nodes {
+		if err := validateExpressionSubqueryRelationMetadataInNode(node, metadata, scope); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateExpressionSubqueryRelationMetadataInNode(node *pg_query.Node, metadata relationMetadata, scope relationRewrite) error {
+	if node == nil {
+		return nil
+	}
+	return validateExpressionSubqueryRelationMetadataInMessage(node.ProtoReflect(), metadata, scope)
+}
+
+func validateExpressionSubqueryRelationMetadataInMessage(msg protoreflect.Message, metadata relationMetadata, scope relationRewrite) error {
+	if !msg.IsValid() {
+		return nil
+	}
+	if subLink, ok := msg.Interface().(*pg_query.SubLink); ok {
+		return validateSubLinkRelationMetadata(subLink, metadata, scope)
+	}
+
+	var err error
+	msg.Range(func(fd protoreflect.FieldDescriptor, value protoreflect.Value) bool {
+		if fd.IsList() {
+			list := value.List()
+			for i := 0; i < list.Len(); i++ {
+				if err = validateExpressionSubqueryRelationMetadataInValue(fd, list.Get(i), metadata, scope); err != nil {
+					return false
+				}
+			}
+			return true
+		}
+		err = validateExpressionSubqueryRelationMetadataInValue(fd, value, metadata, scope)
+		return err == nil
+	})
+	return err
+}
+
+func validateExpressionSubqueryRelationMetadataInValue(fd protoreflect.FieldDescriptor, value protoreflect.Value, metadata relationMetadata, scope relationRewrite) error {
+	if fd.Kind() != protoreflect.MessageKind && fd.Kind() != protoreflect.GroupKind {
+		return nil
+	}
+	return validateExpressionSubqueryRelationMetadataInMessage(value.Message(), metadata, scope)
+}
+
+func validateSubLinkRelationMetadata(subLink *pg_query.SubLink, metadata relationMetadata, scope relationRewrite) error {
+	if subLink == nil {
+		return nil
+	}
+	if err := validateExpressionSubqueryRelationMetadataInNode(subLink.Xpr, metadata, scope); err != nil {
+		return err
+	}
+	if err := validateExpressionSubqueryRelationMetadataInNode(subLink.Testexpr, metadata, scope); err != nil {
+		return err
+	}
+	if err := validateExpressionSubqueryRelationMetadataInNodes(subLink.OperName, metadata, scope); err != nil {
+		return err
+	}
+	if subLink.Subselect == nil {
+		return reject(ReasonUnsupportedStatement, nil)
+	}
+	subquery, ok := subLink.Subselect.Node.(*pg_query.Node_SelectStmt)
+	if !ok || subquery.SelectStmt == nil {
+		return reject(ReasonUnsupportedStatement, nil)
+	}
+	return validateSelectRelationsCovered(subquery.SelectStmt, metadata, scope)
 }
 
 func reject(reason Reason, err error) error {

--- a/internal/db/redirect/validate.go
+++ b/internal/db/redirect/validate.go
@@ -1,0 +1,66 @@
+package redirect
+
+import "github.com/agentsh/agentsh/internal/db/effects"
+
+func validateInput(in Input) error {
+	if in.Action.TargetRelation == "" {
+		return reject(ReasonMissingRedirectTarget, nil)
+	}
+	if in.Action.SourceRelation == "" {
+		return reject(ReasonSourceNotFound, nil)
+	}
+	if len(in.Statement.Effects) == 0 {
+		return reject(ReasonUnsupportedStatement, nil)
+	}
+
+	for _, eff := range in.Statement.Effects {
+		if eff.Subtype == effects.SubtypeFunctionCallProtocol {
+			return reject(ReasonFunctionCallProtocol, nil)
+		}
+	}
+
+	for _, eff := range in.Statement.Effects {
+		switch eff.Group {
+		case effects.GroupRead:
+			if eff.Resolution != effects.ResolutionCatalogResolved || hasUnresolvedObject(eff.ResolvedObjects) {
+				return reject(ReasonUnresolvedObject, nil)
+			}
+		case effects.GroupWrite, effects.GroupModify, effects.GroupDelete:
+			return reject(ReasonWriteStatement, nil)
+		case effects.GroupSchemaCreate, effects.GroupSchemaAlter, effects.GroupSchemaDestroy, effects.GroupPrivilege:
+			return reject(ReasonDDLStatement, nil)
+		case effects.GroupBulkLoad, effects.GroupBulkExport:
+			return reject(ReasonCopyStatement, nil)
+		case effects.GroupProcedural, effects.GroupUnsafeIO:
+			return reject(ReasonProceduralStatement, nil)
+		default:
+			return reject(ReasonUnsupportedStatement, nil)
+		}
+	}
+
+	return nil
+}
+
+func sourceRelationExists(stmt effects.ClassifiedStatement, source string) bool {
+	for _, eff := range stmt.Effects {
+		for _, obj := range eff.ResolvedObjects {
+			if obj.Kind == effects.ResolvedObjectRelation && obj.CanonicalName() == source {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasUnresolvedObject(objects []effects.ResolvedObjectRef) bool {
+	for _, obj := range objects {
+		if obj.UnresolvedReason != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func reject(reason Reason, err error) error {
+	return &Rejection{Reason: reason, Err: err}
+}

--- a/internal/db/redirect/walk.go
+++ b/internal/db/redirect/walk.go
@@ -66,7 +66,6 @@ func (rewrite relationRewrite) withCTENames(withClause *pg_query.WithClause) rel
 	}
 
 	scoped := rewrite
-	copied := false
 	for _, node := range withClause.Ctes {
 		if node == nil {
 			continue
@@ -75,15 +74,22 @@ func (rewrite relationRewrite) withCTENames(withClause *pg_query.WithClause) rel
 		if !ok || cteNode.CommonTableExpr == nil || cteNode.CommonTableExpr.Ctename == "" {
 			continue
 		}
-		if !copied {
-			scoped.cteNames = make(map[string]struct{}, len(rewrite.cteNames)+len(withClause.Ctes))
-			for name := range rewrite.cteNames {
-				scoped.cteNames[name] = struct{}{}
-			}
-			copied = true
-		}
-		scoped.cteNames[cteNode.CommonTableExpr.Ctename] = struct{}{}
+		scoped = scoped.withCTEName(cteNode.CommonTableExpr.Ctename)
 	}
+	return scoped
+}
+
+func (rewrite relationRewrite) withCTEName(name string) relationRewrite {
+	if name == "" {
+		return rewrite
+	}
+
+	scoped := rewrite
+	scoped.cteNames = make(map[string]struct{}, len(rewrite.cteNames)+1)
+	for existing := range rewrite.cteNames {
+		scoped.cteNames[existing] = struct{}{}
+	}
+	scoped.cteNames[name] = struct{}{}
 	return scoped
 }
 
@@ -126,6 +132,7 @@ func rewriteCTEs(withClause *pg_query.WithClause, rewrite relationRewrite) (int,
 	}
 
 	count := 0
+	bodyRewrite := rewrite
 	for _, node := range withClause.Ctes {
 		if node == nil {
 			continue
@@ -138,11 +145,12 @@ func rewriteCTEs(withClause *pg_query.WithClause, rewrite relationRewrite) (int,
 		if !ok || query.SelectStmt == nil {
 			return 0, reject(ReasonWriteStatement, nil)
 		}
-		more, err := rewriteSelectRelations(query.SelectStmt, rewrite)
+		more, err := rewriteSelectRelations(query.SelectStmt, bodyRewrite)
 		if err != nil {
 			return 0, err
 		}
 		count += more
+		bodyRewrite = bodyRewrite.withCTEName(cteNode.CommonTableExpr.Ctename)
 	}
 	return count, nil
 }
@@ -166,7 +174,10 @@ func rewriteRangeNode(node *pg_query.Node, rewrite relationRewrite) (int, error)
 
 	switch n := node.Node.(type) {
 	case *pg_query.Node_RangeVar:
-		if n.RangeVar == nil || !rangeVarMatches(n.RangeVar, rewrite) {
+		if n.RangeVar == nil {
+			return 0, reject(ReasonUnsupportedStatement, nil)
+		}
+		if !rangeVarMatches(n.RangeVar, rewrite) {
 			return 0, nil
 		}
 		if n.RangeVar.Alias == nil {
@@ -176,8 +187,8 @@ func rewriteRangeNode(node *pg_query.Node, rewrite relationRewrite) (int, error)
 		n.RangeVar.Relname = rewrite.targetName
 		return 1, nil
 	case *pg_query.Node_JoinExpr:
-		if n.JoinExpr == nil {
-			return 0, nil
+		if n.JoinExpr == nil || n.JoinExpr.Larg == nil || n.JoinExpr.Rarg == nil {
+			return 0, reject(ReasonUnsupportedStatement, nil)
 		}
 		left, err := rewriteRangeNode(n.JoinExpr.Larg, rewrite)
 		if err != nil {
@@ -194,19 +205,21 @@ func rewriteRangeNode(node *pg_query.Node, rewrite relationRewrite) (int, error)
 		return left + right + quals, nil
 	case *pg_query.Node_RangeSubselect:
 		if n.RangeSubselect == nil || n.RangeSubselect.Subquery == nil {
-			return 0, nil
+			return 0, reject(ReasonUnsupportedStatement, nil)
 		}
 		subquery, ok := n.RangeSubselect.Subquery.Node.(*pg_query.Node_SelectStmt)
 		if !ok || subquery.SelectStmt == nil {
-			return 0, nil
+			return 0, reject(ReasonUnsupportedStatement, nil)
 		}
 		return rewriteSelectRelations(subquery.SelectStmt, rewrite)
 	case *pg_query.Node_RangeTableSample:
 		return 0, reject(ReasonUnsupportedStatement, nil)
 	case *pg_query.Node_RangeFunction:
 		return 0, reject(ReasonProceduralStatement, nil)
+	case *pg_query.Node_RangeTableFunc:
+		return 0, reject(ReasonUnsupportedStatement, nil)
 	default:
-		return 0, nil
+		return 0, reject(ReasonUnsupportedStatement, nil)
 	}
 }
 

--- a/internal/db/redirect/walk.go
+++ b/internal/db/redirect/walk.go
@@ -24,12 +24,15 @@ func rewriteSelectRelations(stmt *pg_query.SelectStmt, rewrite relationRewrite) 
 	if len(stmt.LockingClause) > 0 {
 		return 0, reject(ReasonUnsupportedStatement, nil)
 	}
+	if stmt.WithClause != nil && stmt.WithClause.Recursive {
+		return 0, reject(ReasonUnsupportedStatement, nil)
+	}
 
-	scopedRewrite := rewrite.withCTENames(stmt.WithClause)
-	count, err := rewriteCTEs(stmt.WithClause, scopedRewrite)
+	count, err := rewriteCTEs(stmt.WithClause, rewrite)
 	if err != nil {
 		return 0, err
 	}
+	scopedRewrite := rewrite.withCTENames(stmt.WithClause)
 	more, err := rewriteRangeNodes(stmt.FromClause, scopedRewrite)
 	if err != nil {
 		return 0, err

--- a/internal/db/redirect/walk.go
+++ b/internal/db/redirect/walk.go
@@ -10,6 +10,7 @@ type relationRewrite struct {
 	sourceName   string
 	targetSchema string
 	targetName   string
+	cteNames     map[string]struct{}
 }
 
 func rewriteSelectRelations(stmt *pg_query.SelectStmt, rewrite relationRewrite) (int, error) {
@@ -24,35 +25,63 @@ func rewriteSelectRelations(stmt *pg_query.SelectStmt, rewrite relationRewrite) 
 		return 0, reject(ReasonUnsupportedStatement, nil)
 	}
 
-	count, err := rewriteCTEs(stmt.WithClause, rewrite)
+	scopedRewrite := rewrite.withCTENames(stmt.WithClause)
+	count, err := rewriteCTEs(stmt.WithClause, scopedRewrite)
 	if err != nil {
 		return 0, err
 	}
-	more, err := rewriteRangeNodes(stmt.FromClause, rewrite)
+	more, err := rewriteRangeNodes(stmt.FromClause, scopedRewrite)
 	if err != nil {
 		return 0, err
 	}
 	count += more
-	more, err = rewriteSelectExpressionSubqueries(stmt, rewrite)
+	more, err = rewriteSelectExpressionSubqueries(stmt, scopedRewrite)
 	if err != nil {
 		return 0, err
 	}
 	count += more
 	if stmt.Larg != nil {
-		more, err := rewriteSelectRelations(stmt.Larg, rewrite)
+		more, err := rewriteSelectRelations(stmt.Larg, scopedRewrite)
 		if err != nil {
 			return 0, err
 		}
 		count += more
 	}
 	if stmt.Rarg != nil {
-		more, err := rewriteSelectRelations(stmt.Rarg, rewrite)
+		more, err := rewriteSelectRelations(stmt.Rarg, scopedRewrite)
 		if err != nil {
 			return 0, err
 		}
 		count += more
 	}
 	return count, nil
+}
+
+func (rewrite relationRewrite) withCTENames(withClause *pg_query.WithClause) relationRewrite {
+	if withClause == nil || len(withClause.Ctes) == 0 {
+		return rewrite
+	}
+
+	scoped := rewrite
+	copied := false
+	for _, node := range withClause.Ctes {
+		if node == nil {
+			continue
+		}
+		cteNode, ok := node.Node.(*pg_query.Node_CommonTableExpr)
+		if !ok || cteNode.CommonTableExpr == nil || cteNode.CommonTableExpr.Ctename == "" {
+			continue
+		}
+		if !copied {
+			scoped.cteNames = make(map[string]struct{}, len(rewrite.cteNames)+len(withClause.Ctes))
+			for name := range rewrite.cteNames {
+				scoped.cteNames[name] = struct{}{}
+			}
+			copied = true
+		}
+		scoped.cteNames[cteNode.CommonTableExpr.Ctename] = struct{}{}
+	}
+	return scoped
 }
 
 func rewriteSelectExpressionSubqueries(stmt *pg_query.SelectStmt, rewrite relationRewrite) (int, error) {
@@ -134,7 +163,7 @@ func rewriteRangeNode(node *pg_query.Node, rewrite relationRewrite) (int, error)
 
 	switch n := node.Node.(type) {
 	case *pg_query.Node_RangeVar:
-		if n.RangeVar == nil || !rangeVarMatches(n.RangeVar, rewrite.sourceSchema, rewrite.sourceName) {
+		if n.RangeVar == nil || !rangeVarMatches(n.RangeVar, rewrite) {
 			return 0, nil
 		}
 		if n.RangeVar.Alias == nil {
@@ -169,6 +198,8 @@ func rewriteRangeNode(node *pg_query.Node, rewrite relationRewrite) (int, error)
 			return 0, nil
 		}
 		return rewriteSelectRelations(subquery.SelectStmt, rewrite)
+	case *pg_query.Node_RangeTableSample:
+		return 0, reject(ReasonUnsupportedStatement, nil)
 	case *pg_query.Node_RangeFunction:
 		return 0, reject(ReasonProceduralStatement, nil)
 	default:
@@ -274,11 +305,14 @@ func rewriteSubLink(subLink *pg_query.SubLink, rewrite relationRewrite) (int, er
 	return count, nil
 }
 
-func rangeVarMatches(rv *pg_query.RangeVar, sourceSchema, sourceName string) bool {
+func rangeVarMatches(rv *pg_query.RangeVar, rewrite relationRewrite) bool {
 	if rv.Schemaname != "" {
-		return rv.Schemaname == sourceSchema && rv.Relname == sourceName
+		return rv.Schemaname == rewrite.sourceSchema && rv.Relname == rewrite.sourceName
 	}
-	return rv.Relname == sourceName
+	if _, ok := rewrite.cteNames[rv.Relname]; ok {
+		return false
+	}
+	return rv.Relname == rewrite.sourceName
 }
 
 func hasSchemaQualifiedSourceColumnRef(stmt *pg_query.SelectStmt, sourceSchema, sourceName string) bool {

--- a/internal/db/redirect/walk.go
+++ b/internal/db/redirect/walk.go
@@ -33,6 +33,11 @@ func rewriteSelectRelations(stmt *pg_query.SelectStmt, rewrite relationRewrite) 
 		return 0, err
 	}
 	count += more
+	more, err = rewriteSelectExpressionSubqueries(stmt, rewrite)
+	if err != nil {
+		return 0, err
+	}
+	count += more
 	if stmt.Larg != nil {
 		more, err := rewriteSelectRelations(stmt.Larg, rewrite)
 		if err != nil {
@@ -42,6 +47,39 @@ func rewriteSelectRelations(stmt *pg_query.SelectStmt, rewrite relationRewrite) 
 	}
 	if stmt.Rarg != nil {
 		more, err := rewriteSelectRelations(stmt.Rarg, rewrite)
+		if err != nil {
+			return 0, err
+		}
+		count += more
+	}
+	return count, nil
+}
+
+func rewriteSelectExpressionSubqueries(stmt *pg_query.SelectStmt, rewrite relationRewrite) (int, error) {
+	count, err := rewriteExpressionSubqueriesInNodes(stmt.DistinctClause, rewrite)
+	if err != nil {
+		return 0, err
+	}
+	for _, nodes := range [][]*pg_query.Node{
+		stmt.TargetList,
+		stmt.GroupClause,
+		stmt.WindowClause,
+		stmt.ValuesLists,
+		stmt.SortClause,
+	} {
+		more, err := rewriteExpressionSubqueriesInNodes(nodes, rewrite)
+		if err != nil {
+			return 0, err
+		}
+		count += more
+	}
+	for _, node := range []*pg_query.Node{
+		stmt.WhereClause,
+		stmt.HavingClause,
+		stmt.LimitOffset,
+		stmt.LimitCount,
+	} {
+		more, err := rewriteExpressionSubqueriesInNode(node, rewrite)
 		if err != nil {
 			return 0, err
 		}
@@ -117,7 +155,11 @@ func rewriteRangeNode(node *pg_query.Node, rewrite relationRewrite) (int, error)
 		if err != nil {
 			return 0, err
 		}
-		return left + right, nil
+		quals, err := rewriteExpressionSubqueriesInNode(n.JoinExpr.Quals, rewrite)
+		if err != nil {
+			return 0, err
+		}
+		return left + right + quals, nil
 	case *pg_query.Node_RangeSubselect:
 		if n.RangeSubselect == nil || n.RangeSubselect.Subquery == nil {
 			return 0, nil
@@ -132,6 +174,104 @@ func rewriteRangeNode(node *pg_query.Node, rewrite relationRewrite) (int, error)
 	default:
 		return 0, nil
 	}
+}
+
+func rewriteExpressionSubqueriesInNodes(nodes []*pg_query.Node, rewrite relationRewrite) (int, error) {
+	count := 0
+	for _, node := range nodes {
+		more, err := rewriteExpressionSubqueriesInNode(node, rewrite)
+		if err != nil {
+			return 0, err
+		}
+		count += more
+	}
+	return count, nil
+}
+
+func rewriteExpressionSubqueriesInNode(node *pg_query.Node, rewrite relationRewrite) (int, error) {
+	if node == nil {
+		return 0, nil
+	}
+	return rewriteExpressionSubqueriesInMessage(node.ProtoReflect(), rewrite)
+}
+
+func rewriteExpressionSubqueriesInMessage(msg protoreflect.Message, rewrite relationRewrite) (int, error) {
+	if !msg.IsValid() {
+		return 0, nil
+	}
+	if subLink, ok := msg.Interface().(*pg_query.SubLink); ok {
+		return rewriteSubLink(subLink, rewrite)
+	}
+
+	count := 0
+	var err error
+	msg.Range(func(fd protoreflect.FieldDescriptor, value protoreflect.Value) bool {
+		if fd.IsList() {
+			list := value.List()
+			for i := 0; i < list.Len(); i++ {
+				var more int
+				more, err = rewriteExpressionSubqueriesInValue(fd, list.Get(i), rewrite)
+				if err != nil {
+					return false
+				}
+				count += more
+			}
+			return true
+		}
+		more, valueErr := rewriteExpressionSubqueriesInValue(fd, value, rewrite)
+		if valueErr != nil {
+			err = valueErr
+			return false
+		}
+		count += more
+		return true
+	})
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func rewriteExpressionSubqueriesInValue(fd protoreflect.FieldDescriptor, value protoreflect.Value, rewrite relationRewrite) (int, error) {
+	if fd.Kind() != protoreflect.MessageKind && fd.Kind() != protoreflect.GroupKind {
+		return 0, nil
+	}
+	return rewriteExpressionSubqueriesInMessage(value.Message(), rewrite)
+}
+
+func rewriteSubLink(subLink *pg_query.SubLink, rewrite relationRewrite) (int, error) {
+	if subLink == nil {
+		return 0, nil
+	}
+
+	count, err := rewriteExpressionSubqueriesInNode(subLink.Xpr, rewrite)
+	if err != nil {
+		return 0, err
+	}
+	more, err := rewriteExpressionSubqueriesInNode(subLink.Testexpr, rewrite)
+	if err != nil {
+		return 0, err
+	}
+	count += more
+	more, err = rewriteExpressionSubqueriesInNodes(subLink.OperName, rewrite)
+	if err != nil {
+		return 0, err
+	}
+	count += more
+
+	if subLink.Subselect == nil {
+		return 0, reject(ReasonUnsupportedStatement, nil)
+	}
+	subquery, ok := subLink.Subselect.Node.(*pg_query.Node_SelectStmt)
+	if !ok || subquery.SelectStmt == nil {
+		return 0, reject(ReasonUnsupportedStatement, nil)
+	}
+	more, err = rewriteSelectRelations(subquery.SelectStmt, rewrite)
+	if err != nil {
+		return 0, err
+	}
+	count += more
+	return count, nil
 }
 
 func rangeVarMatches(rv *pg_query.RangeVar, sourceSchema, sourceName string) bool {

--- a/internal/db/redirect/walk.go
+++ b/internal/db/redirect/walk.go
@@ -17,10 +17,22 @@ func rewriteSelectRelations(stmt *pg_query.SelectStmt, rewrite relationRewrite) 
 		return 0, nil
 	}
 
-	count, err := rewriteRangeNodes(stmt.FromClause, rewrite)
+	if stmt.IntoClause != nil {
+		return 0, reject(ReasonDDLStatement, nil)
+	}
+	if len(stmt.LockingClause) > 0 {
+		return 0, reject(ReasonUnsupportedStatement, nil)
+	}
+
+	count, err := rewriteCTEs(stmt.WithClause, rewrite)
 	if err != nil {
 		return 0, err
 	}
+	more, err := rewriteRangeNodes(stmt.FromClause, rewrite)
+	if err != nil {
+		return 0, err
+	}
+	count += more
 	if stmt.Larg != nil {
 		more, err := rewriteSelectRelations(stmt.Larg, rewrite)
 		if err != nil {
@@ -30,6 +42,33 @@ func rewriteSelectRelations(stmt *pg_query.SelectStmt, rewrite relationRewrite) 
 	}
 	if stmt.Rarg != nil {
 		more, err := rewriteSelectRelations(stmt.Rarg, rewrite)
+		if err != nil {
+			return 0, err
+		}
+		count += more
+	}
+	return count, nil
+}
+
+func rewriteCTEs(withClause *pg_query.WithClause, rewrite relationRewrite) (int, error) {
+	if withClause == nil {
+		return 0, nil
+	}
+
+	count := 0
+	for _, node := range withClause.Ctes {
+		if node == nil {
+			continue
+		}
+		cteNode, ok := node.Node.(*pg_query.Node_CommonTableExpr)
+		if !ok || cteNode.CommonTableExpr == nil || cteNode.CommonTableExpr.Ctequery == nil {
+			continue
+		}
+		query, ok := cteNode.CommonTableExpr.Ctequery.Node.(*pg_query.Node_SelectStmt)
+		if !ok || query.SelectStmt == nil {
+			return 0, reject(ReasonWriteStatement, nil)
+		}
+		more, err := rewriteSelectRelations(query.SelectStmt, rewrite)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/db/redirect/walk.go
+++ b/internal/db/redirect/walk.go
@@ -1,6 +1,9 @@
 package redirect
 
-import pg_query "github.com/pganalyze/pg_query_go/v6"
+import (
+	pg_query "github.com/pganalyze/pg_query_go/v6"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
 
 type relationRewrite struct {
 	sourceSchema string
@@ -57,6 +60,9 @@ func rewriteRangeNode(node *pg_query.Node, rewrite relationRewrite) (int, error)
 		if n.RangeVar == nil || !rangeVarMatches(n.RangeVar, rewrite.sourceSchema, rewrite.sourceName) {
 			return 0, nil
 		}
+		if n.RangeVar.Alias == nil {
+			n.RangeVar.Alias = &pg_query.Alias{Aliasname: n.RangeVar.Relname}
+		}
 		n.RangeVar.Schemaname = rewrite.targetSchema
 		n.RangeVar.Relname = rewrite.targetName
 		return 1, nil
@@ -94,4 +100,67 @@ func rangeVarMatches(rv *pg_query.RangeVar, sourceSchema, sourceName string) boo
 		return rv.Schemaname == sourceSchema && rv.Relname == sourceName
 	}
 	return rv.Relname == sourceName
+}
+
+func hasSchemaQualifiedSourceColumnRef(stmt *pg_query.SelectStmt, sourceSchema, sourceName string) bool {
+	if stmt == nil || sourceSchema == "" || sourceName == "" {
+		return false
+	}
+	return hasSchemaQualifiedSourceColumnRefMessage(stmt.ProtoReflect(), sourceSchema, sourceName)
+}
+
+func hasSchemaQualifiedSourceColumnRefMessage(msg protoreflect.Message, sourceSchema, sourceName string) bool {
+	if !msg.IsValid() {
+		return false
+	}
+	if columnRef, ok := msg.Interface().(*pg_query.ColumnRef); ok {
+		return columnRefMatchesSourceRelation(columnRef, sourceSchema, sourceName)
+	}
+
+	found := false
+	msg.Range(func(fd protoreflect.FieldDescriptor, value protoreflect.Value) bool {
+		if fd.IsList() {
+			list := value.List()
+			for i := 0; i < list.Len(); i++ {
+				if hasSchemaQualifiedSourceColumnRefValue(fd, list.Get(i), sourceSchema, sourceName) {
+					found = true
+					return false
+				}
+			}
+			return true
+		}
+		found = hasSchemaQualifiedSourceColumnRefValue(fd, value, sourceSchema, sourceName)
+		return !found
+	})
+	return found
+}
+
+func hasSchemaQualifiedSourceColumnRefValue(fd protoreflect.FieldDescriptor, value protoreflect.Value, sourceSchema, sourceName string) bool {
+	if fd.Kind() != protoreflect.MessageKind && fd.Kind() != protoreflect.GroupKind {
+		return false
+	}
+	return hasSchemaQualifiedSourceColumnRefMessage(value.Message(), sourceSchema, sourceName)
+}
+
+func columnRefMatchesSourceRelation(columnRef *pg_query.ColumnRef, sourceSchema, sourceName string) bool {
+	if columnRef == nil || len(columnRef.Fields) < 3 {
+		return false
+	}
+	schema, ok := columnRefString(columnRef.Fields[0])
+	if !ok || schema != sourceSchema {
+		return false
+	}
+	name, ok := columnRefString(columnRef.Fields[1])
+	return ok && name == sourceName
+}
+
+func columnRefString(node *pg_query.Node) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	str, ok := node.Node.(*pg_query.Node_String_)
+	if !ok || str.String_ == nil {
+		return "", false
+	}
+	return str.String_.Sval, true
 }

--- a/internal/db/redirect/walk.go
+++ b/internal/db/redirect/walk.go
@@ -1,0 +1,97 @@
+package redirect
+
+import pg_query "github.com/pganalyze/pg_query_go/v6"
+
+type relationRewrite struct {
+	sourceSchema string
+	sourceName   string
+	targetSchema string
+	targetName   string
+}
+
+func rewriteSelectRelations(stmt *pg_query.SelectStmt, rewrite relationRewrite) (int, error) {
+	if stmt == nil {
+		return 0, nil
+	}
+
+	count, err := rewriteRangeNodes(stmt.FromClause, rewrite)
+	if err != nil {
+		return 0, err
+	}
+	if stmt.Larg != nil {
+		more, err := rewriteSelectRelations(stmt.Larg, rewrite)
+		if err != nil {
+			return 0, err
+		}
+		count += more
+	}
+	if stmt.Rarg != nil {
+		more, err := rewriteSelectRelations(stmt.Rarg, rewrite)
+		if err != nil {
+			return 0, err
+		}
+		count += more
+	}
+	return count, nil
+}
+
+func rewriteRangeNodes(nodes []*pg_query.Node, rewrite relationRewrite) (int, error) {
+	count := 0
+	for _, node := range nodes {
+		more, err := rewriteRangeNode(node, rewrite)
+		if err != nil {
+			return 0, err
+		}
+		count += more
+	}
+	return count, nil
+}
+
+func rewriteRangeNode(node *pg_query.Node, rewrite relationRewrite) (int, error) {
+	if node == nil {
+		return 0, nil
+	}
+
+	switch n := node.Node.(type) {
+	case *pg_query.Node_RangeVar:
+		if n.RangeVar == nil || !rangeVarMatches(n.RangeVar, rewrite.sourceSchema, rewrite.sourceName) {
+			return 0, nil
+		}
+		n.RangeVar.Schemaname = rewrite.targetSchema
+		n.RangeVar.Relname = rewrite.targetName
+		return 1, nil
+	case *pg_query.Node_JoinExpr:
+		if n.JoinExpr == nil {
+			return 0, nil
+		}
+		left, err := rewriteRangeNode(n.JoinExpr.Larg, rewrite)
+		if err != nil {
+			return 0, err
+		}
+		right, err := rewriteRangeNode(n.JoinExpr.Rarg, rewrite)
+		if err != nil {
+			return 0, err
+		}
+		return left + right, nil
+	case *pg_query.Node_RangeSubselect:
+		if n.RangeSubselect == nil || n.RangeSubselect.Subquery == nil {
+			return 0, nil
+		}
+		subquery, ok := n.RangeSubselect.Subquery.Node.(*pg_query.Node_SelectStmt)
+		if !ok || subquery.SelectStmt == nil {
+			return 0, nil
+		}
+		return rewriteSelectRelations(subquery.SelectStmt, rewrite)
+	case *pg_query.Node_RangeFunction:
+		return 0, reject(ReasonProceduralStatement, nil)
+	default:
+		return 0, nil
+	}
+}
+
+func rangeVarMatches(rv *pg_query.RangeVar, sourceSchema, sourceName string) bool {
+	if rv.Schemaname != "" {
+		return rv.Schemaname == sourceSchema && rv.Relname == sourceName
+	}
+	return rv.Relname == sourceName
+}


### PR DESCRIPTION
## Summary
- Add statement-level `redirect` policy validation, compilation, evaluation, and metadata copying.
- Add Postgres parse/deparse rewrite backend abstraction and pure redirect planner with fail-closed AST safety checks.
- Update DB access spec docs for Plan 11 redirect metadata while deferring runtime proxy execution to DB Plan 12.

## Test Plan
- `go test ./internal/db/... -count=1`
- `GOOS=windows go build ./...`
- Full branch review passed with no issues.