### PR TITLE
[codex] DB Plan 12 redirect runtime integration

### DIFF
--- a/internal/api/db_lifecycle_sink.go
+++ b/internal/api/db_lifecycle_sink.go
@@ -59,6 +59,15 @@ func dbStatementToEvent(ev dbevents.DBEvent) types.Event {
 	if ev.Predicates != (dbevents.EventPredicates{}) {
 		fields["predicates"] = dbEventField(ev.Predicates)
 	}
+	if ev.Redirected {
+		fields["redirected"] = ev.Redirected
+		fields["redirect_rule"] = ev.RedirectRule
+		fields["rewritten_statement_digest"] = ev.RewrittenStatementDigest
+		fields["redirect_source_relation"] = ev.RedirectSourceRelation
+		fields["redirect_target_relation"] = ev.RedirectTargetRelation
+		fields["redirect_runtime_status"] = ev.RedirectRuntimeStatus
+		fields["redirect_rejection_reason"] = ev.RedirectRejectionReason
+	}
 
 	return types.Event{
 		ID:        ev.EventID,

--- a/internal/api/db_lifecycle_sink_test.go
+++ b/internal/api/db_lifecycle_sink_test.go
@@ -143,6 +143,33 @@ func TestDBStatementToEventMapsNormalizedFields(t *testing.T) {
 	}
 }
 
+func TestDBStatementToEventMapsRedirectFields(t *testing.T) {
+	ev := dbStatementToEvent(dbevents.DBEvent{
+		EventID:                  "db-redirect-api",
+		SessionID:                "sess-1",
+		Timestamp:                time.Unix(500, 0).UTC(),
+		DBService:                "appdb",
+		DBFamily:                 "postgres",
+		DBDialect:                "postgres",
+		StatementDigest:          "sha256:original",
+		Redirected:               true,
+		RedirectRule:             "redirect-users",
+		RewrittenStatementDigest: "sha256:rewritten",
+		RedirectSourceRelation:   "public.users",
+		RedirectTargetRelation:   "public.safe_users",
+		RedirectRuntimeStatus:    "executed",
+	})
+
+	if ev.Fields["redirected"] != true ||
+		ev.Fields["redirect_rule"] != "redirect-users" ||
+		ev.Fields["rewritten_statement_digest"] != "sha256:rewritten" ||
+		ev.Fields["redirect_source_relation"] != "public.users" ||
+		ev.Fields["redirect_target_relation"] != "public.safe_users" ||
+		ev.Fields["redirect_runtime_status"] != "executed" {
+		t.Fatalf("redirect fields = %+v", ev.Fields)
+	}
+}
+
 func TestDBStatementToEventMapsCatalogResolutionReason(t *testing.T) {
 	ev := dbStatementToEvent(dbevents.DBEvent{
 		EventID:                "db-resolved-api",

--- a/internal/db/events/event.go
+++ b/internal/db/events/event.go
@@ -41,6 +41,14 @@ type DBEvent struct {
 	StatementText      string    `json:"statement_text,omitempty"`
 	StatementRedaction Redaction `json:"statement_redaction"`
 
+	Redirected               bool   `json:"redirected,omitempty"`
+	RedirectRule             string `json:"redirect_rule,omitempty"`
+	RewrittenStatementDigest string `json:"rewritten_statement_digest,omitempty"`
+	RedirectSourceRelation   string `json:"redirect_source_relation,omitempty"`
+	RedirectTargetRelation   string `json:"redirect_target_relation,omitempty"`
+	RedirectRuntimeStatus    string `json:"redirect_runtime_status,omitempty"`
+	RedirectRejectionReason  string `json:"redirect_rejection_reason,omitempty"`
+
 	ParserBackend effects.ParserBackend `json:"parser_backend,omitempty"`
 
 	TLS        EventTLS        `json:"tls"`
@@ -58,7 +66,7 @@ type EventTLS struct {
 }
 
 // EventDecision mirrors spec §8 decision{}. Verb is one of "allow"|"deny"|
-// "approve"|"audit".
+// "approve"|"audit"|"redirect".
 type EventDecision struct {
 	Verb                   string   `json:"verb"`
 	RuleKind               string   `json:"rule_kind"`

--- a/internal/db/events/event_test.go
+++ b/internal/db/events/event_test.go
@@ -118,6 +118,87 @@ func TestDBEvent_ResolvedObjectMetadataRoundTrip(t *testing.T) {
 	}
 }
 
+func TestDBEvent_RedirectMetadataRoundTrip(t *testing.T) {
+	in := DBEvent{
+		EventID:                  "db-redirect-1",
+		SessionID:                "sess-1",
+		Timestamp:                time.Date(2026, 5, 14, 13, 0, 0, 0, time.UTC),
+		DBService:                "appdb",
+		DBFamily:                 "postgres",
+		DBDialect:                "postgres",
+		StatementDigest:          "sha256:original",
+		RewrittenStatementDigest: "sha256:rewritten",
+		Redirected:               true,
+		RedirectRule:             "redirect-users-to-safe-users",
+		RedirectSourceRelation:   "public.users",
+		RedirectTargetRelation:   "public.safe_users",
+		RedirectRuntimeStatus:    "executed",
+		StatementRedaction:       RedactionParametersRedacted,
+	}
+
+	raw, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	s := string(raw)
+	for _, want := range []string{
+		`"redirected":true`,
+		`"redirect_rule":"redirect-users-to-safe-users"`,
+		`"rewritten_statement_digest":"sha256:rewritten"`,
+		`"redirect_source_relation":"public.users"`,
+		`"redirect_target_relation":"public.safe_users"`,
+		`"redirect_runtime_status":"executed"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("json %s missing %s", s, want)
+		}
+	}
+
+	var out DBEvent
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if !out.Redirected || out.RedirectRule != in.RedirectRule || out.RewrittenStatementDigest != in.RewrittenStatementDigest {
+		t.Fatalf("redirect fields lost: %+v", out)
+	}
+	if out.StatementDigest != "sha256:original" {
+		t.Fatalf("StatementDigest = %q, want original digest", out.StatementDigest)
+	}
+}
+
+func TestDBEvent_RedirectRejectionRoundTrip(t *testing.T) {
+	in := DBEvent{
+		EventID:                 "db-redirect-reject-1",
+		SessionID:               "sess-1",
+		Timestamp:               time.Date(2026, 5, 14, 13, 1, 0, 0, time.UTC),
+		DBService:               "appdb",
+		DBFamily:                "postgres",
+		DBDialect:               "postgres",
+		StatementDigest:         "sha256:original",
+		Redirected:              true,
+		RedirectRule:            "redirect-users-to-safe-users",
+		RedirectSourceRelation:  "public.users",
+		RedirectTargetRelation:  "public.safe_users",
+		RedirectRuntimeStatus:   "rejected",
+		RedirectRejectionReason: "unsupported_statement",
+		StatementRedaction:      RedactionParametersRedacted,
+		Result:                  EventResult{ErrorCode: "0A000"},
+		TxContext:               EventTxContext{DenyAction: "none"},
+	}
+
+	raw, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var out DBEvent
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if out.RedirectRuntimeStatus != "rejected" || out.RedirectRejectionReason != "unsupported_statement" {
+		t.Fatalf("redirect rejection fields lost: %+v", out)
+	}
+}
+
 func TestDBEvent_Extended_RoundTrip(t *testing.T) {
 	rows := int64(7)
 	in := DBEvent{

--- a/internal/db/proxy/postgres/eventbuilder.go
+++ b/internal/db/proxy/postgres/eventbuilder.go
@@ -34,6 +34,18 @@ type buildArgs struct {
 	IsDeniedBySibling bool
 	BatchSHA          string // sha256 hex of the full Q.String; used for command_id
 	Parser            classify_pg.Parser
+	Redirect          redirectEventArgs
+}
+
+type redirectEventArgs struct {
+	Redirected               bool
+	Rule                     string
+	RewrittenSQL             string
+	RewrittenStatementDigest string
+	SourceRelation           string
+	TargetRelation           string
+	RuntimeStatus            string
+	RejectionReason          string
 }
 
 // buildStatementEvent returns a fully-populated events.DBEvent. Pure function
@@ -41,12 +53,13 @@ type buildArgs struct {
 func buildStatementEvent(a buildArgs) events.DBEvent {
 	slice := perStmtSlice(a.SQL, a.Stmt)
 
-	normalized, err := a.Parser.Normalize(slice)
-	if err != nil || normalized == "" {
-		normalized = strings.TrimSpace(slice)
+	normalized, _ := normalizeStatement(a.Parser, slice)
+	digest := statementDigest(a.Parser, slice)
+
+	rewrittenDigest := a.Redirect.RewrittenStatementDigest
+	if rewrittenDigest == "" && a.Redirect.RewrittenSQL != "" {
+		rewrittenDigest = statementDigest(a.Parser, a.Redirect.RewrittenSQL)
 	}
-	digestBytes := sha256.Sum256([]byte(normalized))
-	digest := "sha256:" + hex.EncodeToString(digestBytes[:])
 
 	var stmtText string
 	var redaction events.Redaction
@@ -94,34 +107,58 @@ func buildStatementEvent(a buildArgs) events.DBEvent {
 	opGroup, opGroupID, opSubtype := operationFromStatement(a.Stmt)
 
 	return events.DBEvent{
-		EventID:                newEventID(),
-		SessionID:              eventSessionID(a.Conn.agentSessionID, a.Conn.clientIdentity),
-		CommandID:              fmt.Sprintf("%s:%d", a.BatchSHA, a.StmtIndex),
-		Timestamp:              timeNow(),
-		DBService:              a.Conn.dbService,
-		DBFamily:               "postgres",
-		DBDialect:              "postgres",
-		DBUser:                 a.Conn.dbUser,
-		Database:               a.Conn.database,
-		ApplicationName:        a.Conn.appName,
-		ClientIdentity:         a.Conn.clientIdentity,
-		Effects:                a.Stmt.Effects,
-		OperationGroup:         opGroup,
-		OperationGroupID:       opGroupID,
-		OperationSubtype:       opSubtype,
-		RawVerb:                a.Stmt.RawVerb,
-		ObjectResolution:       a.Stmt.FoldResolution().String(),
-		ObjectResolutionReason: firstResolutionReason(a.Stmt),
-		ParserBackend:          a.Stmt.ParserBackend,
-		StatementText:          stmtText,
-		StatementDigest:        digest,
-		StatementRedaction:     redaction,
-		TLS:                    events.EventTLS{Mode: a.Conn.tlsMode, ClientSNI: a.Conn.sniHostname},
-		Decision:               dec,
-		Result:                 result,
-		TxContext:              tx,
-		Predicates:             predicates,
+		EventID:                  newEventID(),
+		SessionID:                eventSessionID(a.Conn.agentSessionID, a.Conn.clientIdentity),
+		CommandID:                fmt.Sprintf("%s:%d", a.BatchSHA, a.StmtIndex),
+		Timestamp:                timeNow(),
+		DBService:                a.Conn.dbService,
+		DBFamily:                 "postgres",
+		DBDialect:                "postgres",
+		DBUser:                   a.Conn.dbUser,
+		Database:                 a.Conn.database,
+		ApplicationName:          a.Conn.appName,
+		ClientIdentity:           a.Conn.clientIdentity,
+		Effects:                  a.Stmt.Effects,
+		OperationGroup:           opGroup,
+		OperationGroupID:         opGroupID,
+		OperationSubtype:         opSubtype,
+		RawVerb:                  a.Stmt.RawVerb,
+		ObjectResolution:         a.Stmt.FoldResolution().String(),
+		ObjectResolutionReason:   firstResolutionReason(a.Stmt),
+		ParserBackend:            a.Stmt.ParserBackend,
+		StatementText:            stmtText,
+		StatementDigest:          digest,
+		StatementRedaction:       redaction,
+		Redirected:               a.Redirect.Redirected,
+		RedirectRule:             a.Redirect.Rule,
+		RewrittenStatementDigest: rewrittenDigest,
+		RedirectSourceRelation:   a.Redirect.SourceRelation,
+		RedirectTargetRelation:   a.Redirect.TargetRelation,
+		RedirectRuntimeStatus:    a.Redirect.RuntimeStatus,
+		RedirectRejectionReason:  a.Redirect.RejectionReason,
+		TLS:                      events.EventTLS{Mode: a.Conn.tlsMode, ClientSNI: a.Conn.sniHostname},
+		Decision:                 dec,
+		Result:                   result,
+		TxContext:                tx,
+		Predicates:               predicates,
 	}
+}
+
+func normalizeStatement(parser classify_pg.Parser, sql string) (string, error) {
+	normalized, err := parser.Normalize(sql)
+	if err != nil || normalized == "" {
+		normalized = strings.TrimSpace(sql)
+	}
+	return normalized, err
+}
+
+func statementDigest(parser classify_pg.Parser, sql string) string {
+	normalized, err := normalizeStatement(parser, sql)
+	if err != nil || normalized == "" {
+		normalized = strings.TrimSpace(sql)
+	}
+	digestBytes := sha256.Sum256([]byte(normalized))
+	return "sha256:" + hex.EncodeToString(digestBytes[:])
 }
 
 func buildCancelEvent(entry cancelEntry, d policy.Decision, resultErr string) events.DBEvent {

--- a/internal/db/proxy/postgres/eventbuilder_test.go
+++ b/internal/db/proxy/postgres/eventbuilder_test.go
@@ -324,3 +324,63 @@ func TestBuildStatementEvent_SetsCatalogResolutionFields(t *testing.T) {
 		t.Fatalf("resolved oid = %+v", ev.Effects[0].ResolvedObjects[0])
 	}
 }
+
+func TestBuildStatementEvent_RedirectMetadataPreservesOriginalDigest(t *testing.T) {
+	parser := classify_pg.New(classify_pg.DialectPostgres)
+	stmt := effects.ClassifiedStatement{
+		RawVerb: "SELECT",
+		Effects: []effects.Effect{{
+			Group:      effects.GroupRead,
+			Resolution: effects.ResolutionCatalogResolved,
+			Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Schema: "public", Name: "users"}},
+		}},
+	}
+
+	ev := buildStatementEvent(buildArgs{
+		Stmt:       stmt,
+		StmtIndex:  0,
+		BatchTotal: 1,
+		Decision: policy.Decision{
+			Verb:                policy.VerbRedirect,
+			RuleKind:            policy.RuleKindStatement,
+			RuleName:            "redirect-users",
+			MatchingEffectIndex: 0,
+			MatchingEffectGroup: effects.GroupRead,
+		},
+		SQL:      "select id from public.users",
+		Tier:     policy.RedactParametersRedacted,
+		Conn:     connState{dbService: "appdb", smState: &statemachine.ConnState{LastUpstreamRFQ: 'I'}},
+		BatchSHA: sha256HexBatch("select id from public.users"),
+		Parser:   parser,
+		Redirect: redirectEventArgs{
+			Redirected:     true,
+			Rule:           "redirect-users",
+			RewrittenSQL:   "select id from public.safe_users",
+			SourceRelation: "public.users",
+			TargetRelation: "public.safe_users",
+			RuntimeStatus:  "executed",
+		},
+	})
+
+	if !ev.Redirected {
+		t.Fatalf("Redirected = false")
+	}
+	if ev.RedirectRule != "redirect-users" {
+		t.Fatalf("RedirectRule = %q", ev.RedirectRule)
+	}
+	if ev.RedirectSourceRelation != "public.users" || ev.RedirectTargetRelation != "public.safe_users" {
+		t.Fatalf("redirect relations = %q -> %q", ev.RedirectSourceRelation, ev.RedirectTargetRelation)
+	}
+	if ev.RedirectRuntimeStatus != "executed" {
+		t.Fatalf("RedirectRuntimeStatus = %q", ev.RedirectRuntimeStatus)
+	}
+	if ev.StatementDigest == "" || ev.RewrittenStatementDigest == "" {
+		t.Fatalf("digests missing: original=%q rewritten=%q", ev.StatementDigest, ev.RewrittenStatementDigest)
+	}
+	if ev.StatementDigest == ev.RewrittenStatementDigest {
+		t.Fatalf("original and rewritten digests must differ: %q", ev.StatementDigest)
+	}
+	if ev.StatementText != "select id from public.users" {
+		t.Fatalf("StatementText = %q, want original statement text", ev.StatementText)
+	}
+}

--- a/internal/db/proxy/postgres/extquery.go
+++ b/internal/db/proxy/postgres/extquery.go
@@ -34,6 +34,12 @@ func (pc *proxyConn) handleExtendedFrame(ctx context.Context, msg pgproto3.Front
 	if isParse {
 		parseStmts, _ = parser.Classify(parse.Query, classify_pg.SessionState{}, opts)
 	}
+	if isParse && len(parseStmts) > 0 {
+		handled, err := pc.tryHandleRedirectParse(ctx, parse, parseStmts)
+		if handled || err != nil {
+			return err
+		}
+	}
 	next, actions := statemachine.TransitionWithParser(
 		*pc.state.smState,
 		frame,
@@ -52,10 +58,99 @@ func (pc *proxyConn) handleExtendedFrame(ctx context.Context, msg pgproto3.Front
 			CatalogRefreshSnapshot:   snapshot,
 		})
 	}
+	if bind, ok := msg.(*pgproto3.Bind); ok && actionsCanForward(actions) {
+		pc.preserveRedirectPortalMetadata(bind)
+	}
 	if exec, ok := msg.(*pgproto3.Execute); ok {
 		pc.markCatalogRefreshPendingForExecute(exec, actions)
 	}
 	return pc.executeActions(ctx, msg, actions)
+}
+
+func (pc *proxyConn) tryHandleRedirectParse(ctx context.Context, parse *pgproto3.Parse, stmts []effects.ClassifiedStatement) (bool, error) {
+	rs := pc.srv.policy()
+	decisions := make([]policy.Decision, len(stmts))
+	redirectIndex := -1
+	for i, stmt := range stmts {
+		decisions[i] = policy.Evaluate(stmt, rs, policy.ServiceID(pc.svc.Name))
+		if decisions[i].Verb == policy.VerbDeny || decisions[i].Verb == policy.VerbApprove {
+			return false, nil
+		}
+		if decisions[i].Verb == policy.VerbRedirect && redirectIndex == -1 {
+			redirectIndex = i
+		}
+	}
+	if redirectIndex < 0 {
+		return false, nil
+	}
+	if len(stmts) != 1 || redirectIndex != 0 {
+		plan := redirectRuntimePlan{
+			Rule:            decisions[redirectIndex].RuleName,
+			RuntimeStatus:   "rejected",
+			RejectionReason: "multi_statement_redirect_unsupported",
+		}
+		pc.emitRedirectRejectedEvent(ctx, stmts[redirectIndex], decisions[redirectIndex], parse.Query, sha256HexBatch(parse.Query), plan)
+		return true, pc.executeActions(ctx, parse, statemachine.DenyRoute(*pc.state.smState, policy.StatementRule{}, "redirect rejected by AgentSH policy: multi-statement redirect unsupported", sqlstateRedirectRejected))
+	}
+	plan, ok := pc.planRuntimeRedirect(ctx, parse.Query, stmts[0], decisions[0])
+	if !ok {
+		pc.emitRedirectRejectedEvent(ctx, stmts[0], decisions[0], parse.Query, sha256HexBatch(parse.Query), plan)
+		actions := statemachine.DenyRoute(*pc.state.smState, policy.StatementRule{}, "redirect rejected by AgentSH policy: "+plan.RejectionReason, sqlstateRedirectRejected)
+		next := *pc.state.smState
+		if !containsCloseAction(actions) {
+			next.Absorbing = true
+		}
+		*pc.state.smState = next
+		return true, pc.executeActions(ctx, parse, actions)
+	}
+
+	searchPath, snapshot := statementsNeedCatalogRefresh(plan.RewrittenStatements)
+	pc.wireCache.Put(parse.Name, preparedcache.Entry{
+		Classification:           plan.RewrittenStatements[0],
+		CatalogRefreshSearchPath: searchPath,
+		CatalogRefreshSnapshot:   snapshot,
+		Redirect: &preparedcache.RedirectMetadata{
+			OriginalClassification:   stmts[0],
+			OriginalSQL:              parse.Query,
+			OriginalStatementDigest:  plan.OriginalStatementDigest,
+			RewrittenStatementDigest: plan.RewrittenStatementDigest,
+			Rule:                     plan.Rule,
+			SourceRelation:           plan.SourceRelation,
+			TargetRelation:           plan.TargetRelation,
+			PolicyIdentity:           decisions[0].RuleName,
+		},
+	})
+	forward := *parse
+	forward.Query = plan.RewrittenSQL
+	if pc.state.upstreamFE == nil {
+		return true, fmt.Errorf("postgres.redirect parse: upstreamFE not initialized")
+	}
+	pc.state.upstreamFE.Send(&forward)
+	if err := pc.state.upstreamFE.Flush(); err != nil {
+		return true, err
+	}
+	pc.state.smState.UpstreamDirtySinceSync = true
+	return true, nil
+}
+
+func containsCloseAction(actions []statemachine.Action) bool {
+	for _, action := range actions {
+		if _, ok := action.(*statemachine.ActionClose); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (pc *proxyConn) preserveRedirectPortalMetadata(bind *pgproto3.Bind) {
+	if bind == nil || pc.wireCache == nil {
+		return
+	}
+	entry, ok := pc.wireCache.Get(bind.PreparedStatement)
+	if !ok || entry.Redirect == nil {
+		return
+	}
+	pc.wireCache.Put(wirePortalCacheKey(bind.DestinationPortal), entry)
 }
 
 // executeActions runs each Action against the per-connection I/O.

--- a/internal/db/proxy/postgres/extquery.go
+++ b/internal/db/proxy/postgres/extquery.go
@@ -93,6 +93,10 @@ func (pc *proxyConn) tryHandleRedirectParse(ctx context.Context, parse *pgproto3
 			RuntimeStatus:   "rejected",
 			RejectionReason: "multi_statement_redirect_unsupported",
 		}
+		if decisions[redirectIndex].Redirect != nil {
+			plan.SourceRelation = decisions[redirectIndex].Redirect.SourceRelation
+			plan.TargetRelation = decisions[redirectIndex].Redirect.TargetRelation
+		}
 		pc.emitRedirectRejectedEvent(ctx, stmts[redirectIndex], decisions[redirectIndex], parse.Query, sha256HexBatch(parse.Query), plan)
 		return true, pc.executeActions(ctx, parse, statemachine.DenyRoute(*pc.state.smState, policy.StatementRule{}, "redirect rejected by AgentSH policy: multi-statement redirect unsupported", sqlstateRedirectRejected))
 	}

--- a/internal/db/proxy/postgres/extquery.go
+++ b/internal/db/proxy/postgres/extquery.go
@@ -15,6 +15,10 @@ import (
 	"github.com/agentsh/agentsh/internal/db/proxy/postgres/statemachine"
 )
 
+type pendingRedirectExecute struct {
+	Entry preparedcache.Entry
+}
+
 // handleExtendedFrame translates a pgproto3 frontend frame into a Transition
 // invocation and executes the returned Actions against the per-connection
 // I/O. Called from simpleQueryLoop for Parse/Bind/Describe/Execute/Sync/
@@ -200,9 +204,11 @@ func (pc *proxyConn) executeActions(ctx context.Context, origFrame pgproto3.Fron
 				return fmt.Errorf("upstream flush rollback: %w", err)
 			}
 		case *statemachine.ActionDrainUntilRFQ:
-			if _, err := pc.forwardUpstreamUntilRFQ(ctx, timeNow(), 0); err != nil {
+			result, err := pc.forwardUpstreamUntilRFQ(ctx, timeNow(), 0)
+			if err != nil {
 				return fmt.Errorf("drain: %w", err)
 			}
+			pc.emitPendingRedirectExecuteEvents(ctx, result)
 			pc.refreshPendingCatalogContext(ctx)
 		case *statemachine.ActionClose:
 			pc.closeUpstream()
@@ -237,7 +243,61 @@ func (pc *proxyConn) markCatalogRefreshPendingForExecute(exec *pgproto3.Execute,
 	if !ok {
 		return
 	}
+	if entry.Redirect != nil {
+		pc.pendingRedirectExec = append(pc.pendingRedirectExec, pendingRedirectExecute{Entry: entry})
+	}
 	pc.markCatalogRefreshPendingForNeeds(entry.CatalogRefreshSearchPath, entry.CatalogRefreshSnapshot)
+}
+
+func (pc *proxyConn) emitPendingRedirectExecuteEvents(ctx context.Context, result upstreamResult) {
+	if len(pc.pendingRedirectExec) == 0 {
+		return
+	}
+	pending := pc.pendingRedirectExec
+	pc.pendingRedirectExec = nil
+	parser := pc.srv.classifierFor(pc.svc.Dialect)
+	for i, p := range pending {
+		if p.Entry.Redirect == nil {
+			continue
+		}
+		var rowsReturned, rowsAffected *int64
+		if i < len(result.RowsByStmt) {
+			rowsReturned = result.RowsByStmt[i]
+		}
+		if i < len(result.AffectedByStmt) {
+			rowsAffected = result.AffectedByStmt[i]
+		}
+		redir := p.Entry.Redirect
+		ev := buildStatementEvent(buildArgs{
+			Stmt:            redir.OriginalClassification,
+			StmtIndex:       i,
+			BatchTotal:      len(pending),
+			Decision:        policy.Decision{Verb: policy.VerbRedirect, RuleKind: policy.RuleKindStatement, RuleName: redir.Rule, MatchingEffectIndex: 0},
+			SQL:             redir.OriginalSQL,
+			Tier:            pc.state.redactionTier,
+			Conn:            *pc.state,
+			BytesOut:        result.BytesOut,
+			LatencyMs:       result.LatencyMs,
+			RowsReturned:    rowsReturned,
+			RowsAffected:    rowsAffected,
+			UpstreamErrCode: result.ErrorCode,
+			DenyAction:      "none",
+			BatchSHA:        redir.OriginalStatementDigest,
+			Parser:          parser,
+			Redirect: redirectEventArgs{
+				Redirected:               true,
+				Rule:                     redir.Rule,
+				RewrittenStatementDigest: redir.RewrittenStatementDigest,
+				SourceRelation:           redir.SourceRelation,
+				TargetRelation:           redir.TargetRelation,
+				RuntimeStatus:            "executed",
+			},
+		})
+		if ev.StatementDigest == "" {
+			ev.StatementDigest = redir.OriginalStatementDigest
+		}
+		_ = pc.srv.cfg.Sink.EmitStatement(ctx, ev)
+	}
 }
 
 func (pc *proxyConn) cacheApprovedParse(parse *pgproto3.Parse, stmt effects.ClassifiedStatement) {

--- a/internal/db/proxy/postgres/extquery_spine_test.go
+++ b/internal/db/proxy/postgres/extquery_spine_test.go
@@ -6,10 +6,13 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgproto3"
+
+	"github.com/agentsh/agentsh/internal/db/events"
 )
 
 type clientBackendObservation struct {
@@ -434,6 +437,134 @@ func TestExtquery_RedirectParse_FailureDoesNotCacheOrForward(t *testing.T) {
 	}
 }
 
+func TestExtquery_RedirectExecute_UsesCachedMetadataAndEmitsEventAfterSync(t *testing.T) {
+	pc, clientFE, upBackend, _ := extqueryFixture(t, redirectExtqueryPolicyYAML())
+	pc.state.catalog = testCatalogContext()
+	planner := &fakeRedirectPlanner{plan: redirectRuntimePlan{
+		RewrittenSQL:   "select note from public.safe_users where id=$1",
+		Rule:           "redirect-users",
+		SourceRelation: "public.users",
+		TargetRelation: "public.safe_users",
+	}}
+	pc.redirectPlanner = planner
+	drainClientBackendMessages(clientFE)
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	clientFE.Send(&pgproto3.Parse{Name: "client_stmt", Query: "select note from public.users where id=$1"})
+	clientFE.Send(&pgproto3.Bind{DestinationPortal: "p1", PreparedStatement: "client_stmt"})
+	clientFE.Send(&pgproto3.Execute{Portal: "p1"})
+	clientFE.Send(&pgproto3.Sync{})
+	if err := clientFE.Flush(); err != nil {
+		t.Fatalf("client flush: %v", err)
+	}
+
+	for i := 0; i < 4; i++ {
+		if _, err := upBackend.Receive(); err != nil {
+			t.Fatalf("upstream Receive %d: %v", i, err)
+		}
+	}
+	upBackend.Send(&pgproto3.ParseComplete{})
+	upBackend.Send(&pgproto3.BindComplete{})
+	upBackend.Send(&pgproto3.CommandComplete{CommandTag: []byte("SELECT 0")})
+	upBackend.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+	if err := upBackend.Flush(); err != nil {
+		t.Fatalf("upstream flush: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	var evs []events.DBEvent
+	for time.Now().Before(deadline) {
+		evs = pc.srv.cfg.Sink.(*events.SyncSink).DrainStatements()
+		if len(evs) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("events = %d: %+v", len(evs), evs)
+	}
+	if !evs[0].Redirected || evs[0].RedirectRuntimeStatus != "executed" || evs[0].RedirectTargetRelation != "public.safe_users" {
+		t.Fatalf("redirect execute event = %+v", evs[0])
+	}
+	if planner.calls != 1 {
+		t.Fatalf("planner calls = %d, want Parse-only planning", planner.calls)
+	}
+
+	_ = pc.conn.Close()
+	select {
+	case <-loopErr:
+	case <-time.After(time.Second):
+	}
+}
+
+func TestExtquery_RedirectPolicyReloadKeepsPreparedPlanAndUsesNewPlanForNewParse(t *testing.T) {
+	pc, clientFE, upBackend, _ := extqueryFixture(t, redirectExtqueryPolicyYAML())
+	pc.state.catalog = testCatalogContext()
+	planner := &fakeRedirectPlanner{plan: redirectRuntimePlan{
+		RewrittenSQL:   "select note from public.safe_users_a where id=$1",
+		Rule:           "redirect-users-a",
+		SourceRelation: "public.users",
+		TargetRelation: "public.safe_users_a",
+	}}
+	pc.redirectPlanner = planner
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	clientFE.Send(&pgproto3.Parse{Name: "old_stmt", Query: "select note from public.users where id=$1"})
+	if err := clientFE.Flush(); err != nil {
+		t.Fatalf("client flush old parse: %v", err)
+	}
+	oldMsg, err := upBackend.Receive()
+	if err != nil {
+		t.Fatalf("old upstream Receive: %v", err)
+	}
+	oldParse := oldMsg.(*pgproto3.Parse)
+	if oldParse.Query != "select note from public.safe_users_a where id=$1" {
+		t.Fatalf("old rewritten SQL = %q", oldParse.Query)
+	}
+
+	pc.srv.SetPolicy(loadRuleSet(t, redirectExtqueryPolicyYAMLTarget("public.safe_users_b", "redirect-users-b")))
+	planner.plan = redirectRuntimePlan{
+		RewrittenSQL:   "select note from public.safe_users_b where id=$1",
+		Rule:           "redirect-users-b",
+		SourceRelation: "public.users",
+		TargetRelation: "public.safe_users_b",
+	}
+
+	clientFE.Send(&pgproto3.Parse{Name: "new_stmt", Query: "select note from public.users where id=$1"})
+	clientFE.Send(&pgproto3.Bind{DestinationPortal: "old_portal", PreparedStatement: "old_stmt"})
+	if err := clientFE.Flush(); err != nil {
+		t.Fatalf("client flush reload frames: %v", err)
+	}
+	newMsg, err := upBackend.Receive()
+	if err != nil {
+		t.Fatalf("new upstream Receive: %v", err)
+	}
+	newParse := newMsg.(*pgproto3.Parse)
+	if newParse.Query != "select note from public.safe_users_b where id=$1" {
+		t.Fatalf("new rewritten SQL = %q", newParse.Query)
+	}
+	bindMsg, err := upBackend.Receive()
+	if err != nil {
+		t.Fatalf("bind upstream Receive: %v", err)
+	}
+	if _, ok := bindMsg.(*pgproto3.Bind); !ok {
+		t.Fatalf("bind upstream got %T", bindMsg)
+	}
+	if oldPortal, ok := pc.wireCache.Get(wirePortalCacheKey("old_portal")); !ok || oldPortal.Redirect == nil || oldPortal.Redirect.TargetRelation != "public.safe_users_a" {
+		t.Fatalf("old prepared redirect was corrupted after reload: ok=%v entry=%+v", ok, oldPortal)
+	}
+
+	_ = pc.conn.Close()
+	select {
+	case <-loopErr:
+	case <-time.After(time.Second):
+	}
+}
+
 func redirectExtqueryPolicyYAML() string {
 	return `version: 1
 name: redirect-extquery
@@ -453,4 +584,12 @@ database_rules:
     redirect:
       relation: public.safe_users
 `
+}
+
+func redirectExtqueryPolicyYAMLTarget(target, ruleName string) string {
+	return strings.ReplaceAll(
+		strings.ReplaceAll(redirectExtqueryPolicyYAML(), "redirect-users", ruleName),
+		"public.safe_users",
+		target,
+	)
 }

--- a/internal/db/proxy/postgres/extquery_spine_test.go
+++ b/internal/db/proxy/postgres/extquery_spine_test.go
@@ -345,3 +345,112 @@ database_rules:
 	case <-time.After(time.Second):
 	}
 }
+
+func TestExtquery_RedirectParse_ForwardsRewrittenAndCachesMetadata(t *testing.T) {
+	pc, clientFE, upBackend, _ := extqueryFixture(t, redirectExtqueryPolicyYAML())
+	pc.state.catalog = testCatalogContext()
+	pc.redirectPlanner = &fakeRedirectPlanner{plan: redirectRuntimePlan{
+		RewrittenSQL:   "select note from public.safe_users where id=$1",
+		Rule:           "redirect-users",
+		SourceRelation: "public.users",
+		TargetRelation: "public.safe_users",
+	}}
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	clientFE.Send(&pgproto3.Parse{Name: "client_stmt", Query: "select note from public.users where id=$1"})
+	if err := clientFE.Flush(); err != nil {
+		t.Fatalf("client flush: %v", err)
+	}
+
+	msg, err := upBackend.Receive()
+	if err != nil {
+		t.Fatalf("upstream Receive: %v", err)
+	}
+	parse, ok := msg.(*pgproto3.Parse)
+	if !ok {
+		t.Fatalf("upstream got %T", msg)
+	}
+	if parse.Name != "client_stmt" {
+		t.Fatalf("Parse.Name = %q", parse.Name)
+	}
+	if parse.Query != "select note from public.safe_users where id=$1" {
+		t.Fatalf("Parse.Query = %q", parse.Query)
+	}
+
+	entry, ok := pc.wireCache.Get("client_stmt")
+	if !ok {
+		t.Fatal("wire cache missing client_stmt")
+	}
+	if entry.Redirect == nil {
+		t.Fatal("redirect metadata missing")
+	}
+	if entry.Redirect.TargetRelation != "public.safe_users" || entry.Classification.RawVerb != "SELECT" {
+		t.Fatalf("cache entry = %+v", entry)
+	}
+
+	_ = pc.conn.Close()
+	select {
+	case <-loopErr:
+	case <-time.After(time.Second):
+	}
+}
+
+func TestExtquery_RedirectParse_FailureDoesNotCacheOrForward(t *testing.T) {
+	pc, clientFE, upBackend, _ := extqueryFixture(t, redirectExtqueryPolicyYAML())
+	pc.state.catalog = testCatalogContext()
+	pc.redirectPlanner = &fakeRedirectPlanner{err: errors.New("unsupported_statement")}
+	drainClientBackendMessages(clientFE)
+
+	loopErr := make(chan error, 1)
+	go func() { loopErr <- pc.simpleQueryLoop(context.Background()) }()
+
+	clientFE.Send(&pgproto3.Parse{Name: "client_stmt", Query: "select note from public.users"})
+	if err := clientFE.Flush(); err != nil {
+		t.Fatalf("client flush: %v", err)
+	}
+
+	if _, ok := pc.wireCache.Get("client_stmt"); ok {
+		t.Fatal("failed redirect Parse must not cache statement")
+	}
+
+	upRecv := make(chan struct{}, 1)
+	go func() {
+		if _, err := upBackend.Receive(); err == nil {
+			upRecv <- struct{}{}
+		}
+	}()
+	select {
+	case <-upRecv:
+		t.Fatal("upstream received Parse after redirect failure")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	_ = pc.conn.Close()
+	select {
+	case <-loopErr:
+	case <-time.After(time.Second):
+	}
+}
+
+func redirectExtqueryPolicyYAML() string {
+	return `version: 1
+name: redirect-extquery
+db_services:
+  test: {family: postgres, dialect: postgres, upstream: "127.0.0.1:5432", tls_mode: terminate_reissue}
+database_rules:
+  - name: block-delete
+    db_service: test
+    operations: [delete]
+    decision: deny
+  - name: redirect-users
+    db_service: test
+    operations: [read]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: public.safe_users
+`
+}

--- a/internal/db/proxy/postgres/preparedcache/cache.go
+++ b/internal/db/proxy/postgres/preparedcache/cache.go
@@ -26,6 +26,21 @@ type Entry struct {
 	RedactionTier            policy.RedactionTier
 	CatalogRefreshSearchPath bool
 	CatalogRefreshSnapshot   bool
+	Redirect                 *RedirectMetadata
+}
+
+// RedirectMetadata captures parse-time redirect state for wire-protocol
+// prepared statements. Classification on Entry is the rewritten statement;
+// OriginalClassification keeps the client statement for audit.
+type RedirectMetadata struct {
+	OriginalClassification   effects.ClassifiedStatement
+	OriginalSQL              string
+	OriginalStatementDigest  string
+	RewrittenStatementDigest string
+	Rule                     string
+	SourceRelation           string
+	TargetRelation           string
+	PolicyIdentity           string
 }
 
 // Cache is a fixed-capacity LRU keyed by prepared-statement name. Empty name

--- a/internal/db/proxy/postgres/preparedcache/cache_test.go
+++ b/internal/db/proxy/postgres/preparedcache/cache_test.go
@@ -123,3 +123,49 @@ func TestCachePreservesResolvedObjects(t *testing.T) {
 		t.Fatalf("ResolvedObjects lost: %+v", got.Classification)
 	}
 }
+
+func TestCache_RedirectMetadataRoundTrip(t *testing.T) {
+	c := New(2)
+	entry := Entry{
+		Classification: effects.ClassifiedStatement{RawVerb: "SELECT"},
+		Redirect: &RedirectMetadata{
+			OriginalClassification:   effects.ClassifiedStatement{RawVerb: "SELECT"},
+			OriginalSQL:              "select note from public.users",
+			OriginalStatementDigest:  "sha256:original",
+			RewrittenStatementDigest: "sha256:rewritten",
+			Rule:                     "redirect-users",
+			SourceRelation:           "public.users",
+			TargetRelation:           "public.safe_users",
+			PolicyIdentity:           "redirect-users",
+		},
+	}
+	c.Put("stmt", entry)
+
+	got, ok := c.Get("stmt")
+	if !ok {
+		t.Fatal("cache miss")
+	}
+	if got.Redirect == nil {
+		t.Fatal("Redirect metadata missing")
+	}
+	if got.Redirect.Rule != "redirect-users" || got.Redirect.TargetRelation != "public.safe_users" {
+		t.Fatalf("Redirect metadata = %+v", got.Redirect)
+	}
+}
+
+func TestCache_RedirectMetadataReplacementClearsOldValue(t *testing.T) {
+	c := New(2)
+	c.Put("stmt", Entry{
+		Classification: effects.ClassifiedStatement{RawVerb: "SELECT"},
+		Redirect:       &RedirectMetadata{Rule: "redirect-users"},
+	})
+	c.Put("stmt", Entry{Classification: effects.ClassifiedStatement{RawVerb: "SELECT"}})
+
+	got, ok := c.Get("stmt")
+	if !ok {
+		t.Fatal("cache miss")
+	}
+	if got.Redirect != nil {
+		t.Fatalf("old redirect metadata leaked after replacement: %+v", got.Redirect)
+	}
+}

--- a/internal/db/proxy/postgres/proxyconn.go
+++ b/internal/db/proxy/postgres/proxyconn.go
@@ -93,6 +93,8 @@ type proxyConn struct {
 	state     *connState
 	wireCache *preparedcache.Cache // 05a wire-protocol Extended Query cache
 	sqlCache  *preparedcache.Cache // 05b SQL-level PREPARE cache (unused in 05a)
+
+	redirectPlanner redirectRuntimePlanner
 }
 
 func newProxyConn(srv *Server, svc Service, conn net.Conn, peerUID uint32) *proxyConn {

--- a/internal/db/proxy/postgres/proxyconn.go
+++ b/internal/db/proxy/postgres/proxyconn.go
@@ -94,7 +94,8 @@ type proxyConn struct {
 	wireCache *preparedcache.Cache // 05a wire-protocol Extended Query cache
 	sqlCache  *preparedcache.Cache // 05b SQL-level PREPARE cache (unused in 05a)
 
-	redirectPlanner redirectRuntimePlanner
+	redirectPlanner     redirectRuntimePlanner
+	pendingRedirectExec []pendingRedirectExecute
 }
 
 func newProxyConn(srv *Server, svc Service, conn net.Conn, peerUID uint32) *proxyConn {

--- a/internal/db/proxy/postgres/redirect_integration_test.go
+++ b/internal/db/proxy/postgres/redirect_integration_test.go
@@ -1,0 +1,232 @@
+//go:build integration && linux
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/agentsh/agentsh/internal/db/events"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/service"
+)
+
+func TestDB12RealPostgresDirectProxyPolicyReloadPreservesPreparedRedirect(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	hostDSN, upstream := startDB12Postgres(t, ctx)
+	seedDB12Postgres(t, ctx, hostDSN)
+
+	srv, sock, sink := startDB12DirectProxy(t, upstream, db12RedirectPolicyYAML(upstream, "plan12.users_target_a", "redirect-plan12-a"))
+	stop := runServer(t, srv)
+	defer stop()
+
+	sockDir := renameSocketForPgx(t, sock, 5452)
+	conn, err := pgx.Connect(ctx, db12PGXConnString(sockDir, 5452))
+	if err != nil {
+		t.Fatalf("pgx.Connect: %v", err)
+	}
+	defer conn.Close(context.Background())
+
+	if _, err := conn.Prepare(ctx, "old_redirect", "select note from plan12.users_source where id=$1"); err != nil {
+		t.Fatalf("Prepare old_redirect: %v", err)
+	}
+
+	var first string
+	if err := conn.QueryRow(ctx, "old_redirect", 1).Scan(&first); err != nil {
+		t.Fatalf("query old_redirect before reload: %v", err)
+	}
+	if first != "target-a" {
+		t.Fatalf("old_redirect before reload = %q, want target-a", first)
+	}
+
+	srv.SetPolicy(loadRuleSet(t, db12RedirectPolicyYAML(upstream, "plan12.users_target_b", "redirect-plan12-b")))
+
+	var second string
+	if err := conn.QueryRow(ctx, "old_redirect", 1).Scan(&second); err != nil {
+		t.Fatalf("query old_redirect after reload: %v", err)
+	}
+	if second != "target-a" {
+		t.Fatalf("old_redirect after reload = %q, want target-a", second)
+	}
+
+	var third string
+	if err := conn.QueryRow(ctx, "select note from plan12.users_source where id = $1", 1).Scan(&third); err != nil {
+		t.Fatalf("query new statement after reload: %v", err)
+	}
+	if third != "target-b" {
+		t.Fatalf("new statement after reload = %q, want target-b", third)
+	}
+
+	evs := collectDB12RedirectEvents(t, sink, 3, 3*time.Second)
+	targets := []string{evs[0].RedirectTargetRelation, evs[1].RedirectTargetRelation, evs[2].RedirectTargetRelation}
+	if fmt.Sprint(targets) != "[plan12.users_target_a plan12.users_target_a plan12.users_target_b]" {
+		t.Fatalf("redirect targets = %v", targets)
+	}
+}
+
+func startDB12Postgres(t *testing.T, ctx context.Context) (hostDSN string, upstream string) {
+	t.Helper()
+	req := testcontainers.ContainerRequest{
+		Image:        "postgres:16-alpine",
+		ExposedPorts: []string{"5432/tcp"},
+		Env: map[string]string{
+			"POSTGRES_USER":     "app",
+			"POSTGRES_PASSWORD": "secret",
+			"POSTGRES_DB":       "app",
+			"POSTGRES_INITDB_ARGS": strings.Join([]string{
+				"--auth-host=md5",
+				"--auth-local=trust",
+			}, " "),
+		},
+		Cmd: []string{"postgres", "-c", "password_encryption=md5"},
+		WaitingFor: wait.ForLog("database system is ready to accept connections").
+			WithOccurrence(2).
+			WithStartupTimeout(60 * time.Second),
+	}
+	pg, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{ContainerRequest: req, Started: true})
+	if err != nil {
+		t.Fatalf("start postgres container: %v", err)
+	}
+	t.Cleanup(func() { _ = pg.Terminate(context.Background()) })
+
+	host, err := pg.Host(ctx)
+	if err != nil {
+		t.Fatalf("postgres host: %v", err)
+	}
+	port, err := pg.MappedPort(ctx, "5432/tcp")
+	if err != nil {
+		t.Fatalf("postgres mapped port: %v", err)
+	}
+	return fmt.Sprintf("postgres://app:secret@%s:%s/app?sslmode=disable", host, port.Port()), fmt.Sprintf("%s:%s", host, port.Port())
+}
+
+func seedDB12Postgres(t *testing.T, ctx context.Context, dsn string) {
+	t.Helper()
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect host Postgres: %v", err)
+	}
+	defer conn.Close(ctx)
+	_, err = conn.Exec(ctx, `
+drop schema if exists plan12 cascade;
+create schema plan12;
+create table plan12.users_source(id int primary key, note text);
+create table plan12.users_target_a(id int primary key, note text);
+create table plan12.users_target_b(id int primary key, note text);
+insert into plan12.users_source(id, note) values (1, 'source');
+insert into plan12.users_target_a(id, note) values (1, 'target-a');
+insert into plan12.users_target_b(id, note) values (1, 'target-b');
+`)
+	if err != nil {
+		t.Fatalf("seed Postgres: %v", err)
+	}
+}
+
+func startDB12DirectProxy(t *testing.T, upstream, policyYAML string) (*Server, string, *events.SyncSink) {
+	t.Helper()
+	sockPath := filepath.Join(t.TempDir(), "appdb.sock")
+	sink := &events.SyncSink{}
+	srv, err := New(Config{
+		Unavoidability:  service.UnavoidabilityObserve,
+		StateDir:        t.TempDir(),
+		Sink:            sink,
+		AgentSessionID:  testAgentSessionID,
+		SessionResolver: staticResolver{sessionID: testAgentSessionID, ok: true},
+		Policy:          loadRuleSet(t, policyYAML),
+		Logger:          slog.New(slog.NewTextHandler(testWriter{t}, nil)),
+		Services: []Service{{
+			Name:     "appdb",
+			Family:   "postgres",
+			Dialect:  "postgres",
+			Upstream: upstream,
+			TLSMode:  "terminate_plaintext_upstream",
+			Listen:   ServiceListener{Kind: "unix", Path: sockPath},
+			Service: policy.DBService{
+				Name:           "appdb",
+				Family:         "postgres",
+				Dialect:        "postgres",
+				Upstream:       upstream,
+				TLSMode:        "terminate_plaintext_upstream",
+				TrustedNetwork: true,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return srv, sockPath, sink
+}
+
+func db12RedirectPolicyYAML(upstream, target, ruleName string) string {
+	return `version: 1
+name: db12-redirect
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: ` + upstream + `
+    tls_mode: terminate_plaintext_upstream
+    trusted_network: true
+database_connection_rules:
+  - name: allow-app-connect
+    db_service: appdb
+    db_user: ["app"]
+    database: app
+    decision: allow
+database_rules:
+  - name: ` + ruleName + `
+    db_service: appdb
+    operations: [read]
+    relations: ["plan12.users_source"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: ` + target + `
+  - name: allow-read
+    db_service: appdb
+    operations: [read]
+    decision: allow
+  - name: allow-session
+    db_service: appdb
+    operations: [session]
+    decision: allow
+  - name: allow-transaction
+    db_service: appdb
+    operations: [transaction]
+    decision: allow
+`
+}
+
+func db12PGXConnString(sockDir string, port int) string {
+	return fmt.Sprintf("host=%s port=%d user=app password=secret dbname=app sslmode=disable", sockDir, port)
+}
+
+func collectDB12RedirectEvents(t *testing.T, sink *events.SyncSink, want int, deadline time.Duration) []events.DBEvent {
+	t.Helper()
+	var out []events.DBEvent
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		for _, ev := range sink.DrainStatements() {
+			if ev.Redirected {
+				out = append(out, ev)
+			}
+		}
+		if len(out) >= want {
+			return out
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("redirect events = %d, want %d: %+v", len(out), want, out)
+	return nil
+}

--- a/internal/db/proxy/postgres/redirect_runtime.go
+++ b/internal/db/proxy/postgres/redirect_runtime.go
@@ -1,0 +1,177 @@
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	classify_pg "github.com/agentsh/agentsh/internal/db/classify/postgres"
+	"github.com/agentsh/agentsh/internal/db/effects"
+	"github.com/agentsh/agentsh/internal/db/policy"
+	"github.com/agentsh/agentsh/internal/db/redirect"
+)
+
+const sqlstateRedirectRejected = "0A000"
+
+type redirectRuntimePlanner interface {
+	PlanRedirect(context.Context, redirectRuntimeInput) (redirectRuntimePlan, error)
+}
+
+type redirectRuntimeInput struct {
+	SQL      string
+	Stmt     effects.ClassifiedStatement
+	Decision policy.Decision
+	Rule     policy.StatementRule
+	Service  policy.ServiceID
+}
+
+type redirectRuntimePlan struct {
+	RewrittenSQL             string
+	RewrittenStatements      []effects.ClassifiedStatement
+	OriginalStatementDigest  string
+	RewrittenStatementDigest string
+	Rule                     string
+	SourceRelation           string
+	TargetRelation           string
+	RuntimeStatus            string
+	RejectionReason          string
+}
+
+func (pc *proxyConn) activeRedirectPlanner() redirectRuntimePlanner {
+	if pc.redirectPlanner != nil {
+		return pc.redirectPlanner
+	}
+	dialect, ok := classify_pg.ParseDialect(pc.svc.Dialect)
+	if !ok {
+		return plan11RedirectPlanner{}
+	}
+	return plan11RedirectPlanner{backend: classify_pg.NewRewriteBackend(dialect)}
+}
+
+func (pc *proxyConn) planRuntimeRedirect(
+	ctx context.Context,
+	sql string,
+	stmt effects.ClassifiedStatement,
+	decision policy.Decision,
+) (redirectRuntimePlan, bool) {
+	parser := pc.resolvingParser(pc.svc.Dialect)
+	rule := lookupStatementRuleByName(pc.srv.policy(), decision.RuleName)
+	input := redirectRuntimeInput{
+		SQL:      sql,
+		Stmt:     stmt,
+		Decision: decision,
+		Rule:     rule,
+		Service:  policy.ServiceID(pc.svc.Name),
+	}
+	plan, err := pc.activeRedirectPlanner().PlanRedirect(ctx, input)
+	if err != nil {
+		plan.RejectionReason = err.Error()
+		plan.RuntimeStatus = "rejected"
+		return plan, false
+	}
+	if plan.Rule == "" {
+		plan.Rule = decision.RuleName
+	}
+	if plan.RewrittenSQL == "" {
+		plan.RejectionReason = "empty_rewritten_statement"
+		plan.RuntimeStatus = "rejected"
+		return plan, false
+	}
+
+	opts := classifierOptionsFromPolicy(pc.srv.policy())
+	rewritten, err := parser.Classify(plan.RewrittenSQL, classify_pg.SessionState{}, opts)
+	if err != nil || len(rewritten) != 1 {
+		plan.RejectionReason = "rewritten_statement_unclassifiable"
+		plan.RuntimeStatus = "rejected"
+		return plan, false
+	}
+	if !statementIsReadOnly(rewritten[0]) {
+		plan.RejectionReason = "rewritten_statement_not_read_only"
+		plan.RuntimeStatus = "rejected"
+		return plan, false
+	}
+	plan.RewrittenStatements = rewritten
+	plan.OriginalStatementDigest = statementDigest(parser, sql)
+	plan.RewrittenStatementDigest = statementDigest(parser, plan.RewrittenSQL)
+	plan.RuntimeStatus = "planned"
+	return plan, true
+}
+
+func statementIsReadOnly(stmt effects.ClassifiedStatement) bool {
+	if len(stmt.Effects) == 0 {
+		return false
+	}
+	for _, eff := range stmt.Effects {
+		if eff.Group != effects.GroupRead {
+			return false
+		}
+	}
+	return true
+}
+
+func redirectEventFromPlan(plan redirectRuntimePlan, status string) redirectEventArgs {
+	if status == "" {
+		status = plan.RuntimeStatus
+	}
+	return redirectEventArgs{
+		Redirected:               true,
+		Rule:                     plan.Rule,
+		RewrittenSQL:             plan.RewrittenSQL,
+		RewrittenStatementDigest: plan.RewrittenStatementDigest,
+		SourceRelation:           plan.SourceRelation,
+		TargetRelation:           plan.TargetRelation,
+		RuntimeStatus:            status,
+		RejectionReason:          plan.RejectionReason,
+	}
+}
+
+type plan11RedirectPlanner struct {
+	backend redirect.SQLBackend
+}
+
+func (p plan11RedirectPlanner) PlanRedirect(_ context.Context, input redirectRuntimeInput) (redirectRuntimePlan, error) {
+	if p.backend == nil {
+		return redirectRuntimePlan{}, fmt.Errorf("unsupported_redirect_dialect")
+	}
+	action, err := redirectActionFromRuntimeInput(input)
+	if err != nil {
+		return redirectRuntimePlan{}, err
+	}
+	plan, err := (redirect.Planner{Backend: p.backend}).Plan(redirect.Input{
+		SQL:       input.SQL,
+		Statement: input.Stmt,
+		Action:    action,
+	})
+	if err != nil {
+		return redirectRuntimePlan{}, err
+	}
+	return redirectRuntimePlan{
+		RewrittenSQL:   plan.RewrittenSQL,
+		Rule:           plan.RuleName,
+		SourceRelation: plan.SourceRelation,
+		TargetRelation: plan.TargetRelation,
+	}, nil
+}
+
+func redirectActionFromRuntimeInput(input redirectRuntimeInput) (redirect.Action, error) {
+	ruleName := input.Decision.RuleName
+	if ruleName == "" {
+		ruleName = input.Rule.Name
+	}
+	if input.Decision.Redirect != nil {
+		return redirect.Action{
+			RuleName:       ruleName,
+			SourceRelation: input.Decision.Redirect.SourceRelation,
+			TargetRelation: input.Decision.Redirect.TargetRelation,
+		}, nil
+	}
+	if len(input.Rule.Relations) == 1 && input.Rule.Redirect != nil {
+		return redirect.Action{
+			RuleName:       ruleName,
+			SourceRelation: input.Rule.Relations[0],
+			TargetRelation: input.Rule.Redirect.Relation,
+		}, nil
+	}
+	return redirect.Action{}, fmt.Errorf("missing_redirect_action")
+}

--- a/internal/db/proxy/postgres/redirect_runtime_test.go
+++ b/internal/db/proxy/postgres/redirect_runtime_test.go
@@ -1,0 +1,101 @@
+//go:build linux
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+	"github.com/agentsh/agentsh/internal/db/policy"
+)
+
+type fakeRedirectPlanner struct {
+	plan  redirectRuntimePlan
+	err   error
+	calls int
+}
+
+func (f *fakeRedirectPlanner) PlanRedirect(context.Context, redirectRuntimeInput) (redirectRuntimePlan, error) {
+	f.calls++
+	if f.err != nil {
+		return redirectRuntimePlan{}, f.err
+	}
+	return f.plan, nil
+}
+
+func TestRedirectRuntime_PlansAndClassifiesRewrittenSQL(t *testing.T) {
+	pc, _, _ := newSimpleQueryFixture(t)
+	planner := &fakeRedirectPlanner{plan: redirectRuntimePlan{
+		RewrittenSQL:   "select id from public.safe_users",
+		Rule:           "redirect-users",
+		SourceRelation: "public.users",
+		TargetRelation: "public.safe_users",
+		RuntimeStatus:  "planned",
+	}}
+	pc.redirectPlanner = planner
+
+	stmt := effects.ClassifiedStatement{
+		RawVerb: "SELECT",
+		Effects: []effects.Effect{{
+			Group:   effects.GroupRead,
+			Objects: []effects.ObjectRef{{Kind: effects.ObjectTable, Schema: "public", Name: "users"}},
+		}},
+	}
+	decision := policy.Decision{Verb: policy.VerbRedirect, RuleName: "redirect-users", RuleKind: policy.RuleKindStatement}
+
+	plan, ok := pc.planRuntimeRedirect(context.Background(), "select id from public.users", stmt, decision)
+	if !ok {
+		t.Fatalf("planRuntimeRedirect rejected: %+v", plan)
+	}
+	if planner.calls != 1 {
+		t.Fatalf("planner calls = %d, want 1", planner.calls)
+	}
+	if plan.RewrittenSQL != "select id from public.safe_users" || len(plan.RewrittenStatements) != 1 {
+		t.Fatalf("unexpected runtime plan: %+v", plan)
+	}
+	if plan.RewrittenStatements[0].RawVerb != "SELECT" {
+		t.Fatalf("rewritten classification = %+v", plan.RewrittenStatements)
+	}
+	if plan.RewrittenStatementDigest == "" {
+		t.Fatalf("rewritten digest missing")
+	}
+}
+
+func TestRedirectRuntime_FailsClosedOnPlannerError(t *testing.T) {
+	pc, _, _ := newSimpleQueryFixture(t)
+	pc.redirectPlanner = &fakeRedirectPlanner{err: errors.New("unsupported_statement")}
+
+	stmt := effects.ClassifiedStatement{RawVerb: "SELECT", Effects: []effects.Effect{{Group: effects.GroupRead}}}
+	decision := policy.Decision{Verb: policy.VerbRedirect, RuleName: "redirect-users", RuleKind: policy.RuleKindStatement}
+
+	plan, ok := pc.planRuntimeRedirect(context.Background(), "select 1", stmt, decision)
+	if ok {
+		t.Fatalf("planRuntimeRedirect unexpectedly succeeded: %+v", plan)
+	}
+	if plan.RejectionReason == "" {
+		t.Fatalf("rejection reason missing: %+v", plan)
+	}
+}
+
+func TestRedirectRuntime_FailsClosedOnUnsafeReclassification(t *testing.T) {
+	pc, _, _ := newSimpleQueryFixture(t)
+	pc.redirectPlanner = &fakeRedirectPlanner{plan: redirectRuntimePlan{
+		RewrittenSQL:   "delete from public.safe_users",
+		Rule:           "redirect-users",
+		SourceRelation: "public.users",
+		TargetRelation: "public.safe_users",
+	}}
+
+	stmt := effects.ClassifiedStatement{RawVerb: "SELECT", Effects: []effects.Effect{{Group: effects.GroupRead}}}
+	decision := policy.Decision{Verb: policy.VerbRedirect, RuleName: "redirect-users", RuleKind: policy.RuleKindStatement}
+
+	plan, ok := pc.planRuntimeRedirect(context.Background(), "select 1", stmt, decision)
+	if ok {
+		t.Fatalf("unsafe rewritten SQL unexpectedly accepted: %+v", plan)
+	}
+	if plan.RejectionReason != "rewritten_statement_not_read_only" {
+		t.Fatalf("RejectionReason = %q", plan.RejectionReason)
+	}
+}

--- a/internal/db/proxy/postgres/simplequery.go
+++ b/internal/db/proxy/postgres/simplequery.go
@@ -238,6 +238,10 @@ func (pc *proxyConn) runSimpleQueryRedirect(
 			RuntimeStatus:   "rejected",
 			RejectionReason: "multi_statement_redirect_unsupported",
 		}
+		if decisions[redirectIndex].Redirect != nil {
+			plan.SourceRelation = decisions[redirectIndex].Redirect.SourceRelation
+			plan.TargetRelation = decisions[redirectIndex].Redirect.TargetRelation
+		}
 		pc.emitRedirectRejectedEvent(ctx, stmts[redirectIndex], decisions[redirectIndex], q.String, batchSHA, plan)
 		return pc.synthErrorAndRFQ(sqlstateRedirectRejected, "redirect rejected by AgentSH policy: multi-statement redirect unsupported")
 	}

--- a/internal/db/proxy/postgres/simplequery.go
+++ b/internal/db/proxy/postgres/simplequery.go
@@ -123,11 +123,17 @@ func (pc *proxyConn) handleQuery(ctx context.Context, q *pgproto3.Query) error {
 	decisions := make([]policy.Decision, len(stmts))
 	anyDeny := false
 	approveIndex := -1
+	redirectIndex := -1
 	for i, s := range stmts {
 		decisions[i] = policy.Evaluate(s, rs, policy.ServiceID(pc.svc.Name))
 		if decisions[i].Verb == policy.VerbApprove {
 			if approveIndex == -1 {
 				approveIndex = i
+			}
+		}
+		if decisions[i].Verb == policy.VerbRedirect {
+			if redirectIndex == -1 {
+				redirectIndex = i
 			}
 		}
 		if decisions[i].Verb == policy.VerbDeny {
@@ -156,6 +162,10 @@ func (pc *proxyConn) handleQuery(ctx context.Context, q *pgproto3.Query) error {
 	}
 
 	batchSHA := sha256HexBatch(q.String)
+
+	if !anyDeny && redirectIndex >= 0 {
+		return pc.runSimpleQueryRedirect(ctx, q, stmts, decisions, redirectIndex, batchSHA)
+	}
 
 	if !anyDeny && approveIndex >= 0 {
 		return pc.runSimpleQueryApproval(ctx, q, stmts, decisions, approveIndex, batchSHA)
@@ -212,6 +222,92 @@ func (pc *proxyConn) handleQuery(ctx context.Context, q *pgproto3.Query) error {
 	rendered, sqlstate := pickDenySynth(decisions)
 	actions := statemachine.DenyRoute(*pc.state.smState, denyRule, rendered, sqlstate)
 	return pc.executeActions(ctx, q, actions)
+}
+
+func (pc *proxyConn) runSimpleQueryRedirect(
+	ctx context.Context,
+	q *pgproto3.Query,
+	stmts []effects.ClassifiedStatement,
+	decisions []policy.Decision,
+	redirectIndex int,
+	batchSHA string,
+) error {
+	if len(stmts) != 1 || redirectIndex != 0 {
+		plan := redirectRuntimePlan{
+			Rule:            decisions[redirectIndex].RuleName,
+			RuntimeStatus:   "rejected",
+			RejectionReason: "multi_statement_redirect_unsupported",
+		}
+		pc.emitRedirectRejectedEvent(ctx, stmts[redirectIndex], decisions[redirectIndex], q.String, batchSHA, plan)
+		return pc.synthErrorAndRFQ(sqlstateRedirectRejected, "redirect rejected by AgentSH policy: multi-statement redirect unsupported")
+	}
+
+	plan, ok := pc.planRuntimeRedirect(ctx, q.String, stmts[redirectIndex], decisions[redirectIndex])
+	if !ok {
+		pc.emitRedirectRejectedEvent(ctx, stmts[redirectIndex], decisions[redirectIndex], q.String, batchSHA, plan)
+		return pc.synthErrorAndRFQ(sqlstateRedirectRejected, "redirect rejected by AgentSH policy: "+plan.RejectionReason)
+	}
+
+	sentAt := timeNow()
+	pc.state.upstreamFE.Send(&pgproto3.Query{String: plan.RewrittenSQL})
+	if err := pc.state.upstreamFE.Flush(); err != nil {
+		return err
+	}
+	result, ferr := pc.forwardUpstreamUntilRFQ(ctx, sentAt, len(q.String))
+	pc.emitRedirectAllowEvent(ctx, stmts[redirectIndex], decisions[redirectIndex], q.String, batchSHA, plan, result)
+	pc.refreshCatalogAfterSuccessfulStatements(ctx, plan.RewrittenStatements, result)
+	return ferr
+}
+
+func (pc *proxyConn) emitRedirectAllowEvent(ctx context.Context, stmt effects.ClassifiedStatement, decision policy.Decision, sql, batchSHA string, plan redirectRuntimePlan, result upstreamResult) {
+	parser := pc.srv.classifierFor(pc.svc.Dialect)
+	var rowsReturned, rowsAffected *int64
+	if len(result.RowsByStmt) > 0 {
+		rowsReturned = result.RowsByStmt[0]
+	}
+	if len(result.AffectedByStmt) > 0 {
+		rowsAffected = result.AffectedByStmt[0]
+	}
+	ev := buildStatementEvent(buildArgs{
+		Stmt:            stmt,
+		StmtIndex:       0,
+		BatchTotal:      1,
+		Decision:        decision,
+		SQL:             sql,
+		Tier:            pc.state.redactionTier,
+		Conn:            *pc.state,
+		BytesIn:         int64(len(sql)),
+		BytesOut:        result.BytesOut,
+		LatencyMs:       result.LatencyMs,
+		RowsReturned:    rowsReturned,
+		RowsAffected:    rowsAffected,
+		UpstreamErrCode: result.ErrorCode,
+		DenyAction:      "none",
+		BatchSHA:        batchSHA,
+		Parser:          parser,
+		Redirect:        redirectEventFromPlan(plan, "executed"),
+	})
+	_ = pc.srv.cfg.Sink.EmitStatement(ctx, ev)
+}
+
+func (pc *proxyConn) emitRedirectRejectedEvent(ctx context.Context, stmt effects.ClassifiedStatement, decision policy.Decision, sql, batchSHA string, plan redirectRuntimePlan) {
+	parser := pc.srv.classifierFor(pc.svc.Dialect)
+	ev := buildStatementEvent(buildArgs{
+		Stmt:            stmt,
+		StmtIndex:       0,
+		BatchTotal:      1,
+		Decision:        decision,
+		SQL:             sql,
+		Tier:            pc.state.redactionTier,
+		Conn:            *pc.state,
+		BytesIn:         int64(len(sql)),
+		UpstreamErrCode: sqlstateRedirectRejected,
+		DenyAction:      "none",
+		BatchSHA:        batchSHA,
+		Parser:          parser,
+		Redirect:        redirectEventFromPlan(plan, "rejected"),
+	})
+	_ = pc.srv.cfg.Sink.EmitStatement(ctx, ev)
 }
 
 // denyActionForState returns the deny action string based on the current

--- a/internal/db/proxy/postgres/simplequery_test.go
+++ b/internal/db/proxy/postgres/simplequery_test.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"errors"
 	"net"
 	"os"
 	"strings"
@@ -352,6 +353,147 @@ func TestHandleQuery_CopyToStdout_EmitsBytesOut(t *testing.T) {
 		t.Fatalf("BytesOut=%d want at least copied data bytes", evs[0].Result.BytesOut)
 	}
 	_ = loopErr
+}
+
+func TestHandleQuery_RedirectForwardsRewrittenSQL(t *testing.T) {
+	pc, clientFE, sink := newSimpleQueryFixture(t)
+	pc.state.smState.LastUpstreamRFQ = 'I'
+	pc.state.catalog = testCatalogContext()
+	pc.srv.SetPolicy(redirectReadRuleSet(t))
+	pc.redirectPlanner = &fakeRedirectPlanner{plan: redirectRuntimePlan{
+		RewrittenSQL:   "select note from public.safe_users",
+		Rule:           "redirect-users",
+		SourceRelation: "public.users",
+		TargetRelation: "public.safe_users",
+	}}
+
+	upClient, upServer := net.Pipe()
+	t.Cleanup(func() { _ = upClient.Close(); _ = upServer.Close() })
+	pc.state.upstream = upServer
+	pc.state.upstreamFE = pgproto3.NewFrontend(upServer, upServer)
+	upBackend := pgproto3.NewBackend(upClient, upClient)
+	drainClientBackendMessages(clientFE)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- pc.handleQuery(context.Background(), &pgproto3.Query{String: "select note from public.users"})
+	}()
+
+	msg, err := upBackend.Receive()
+	if err != nil {
+		t.Fatalf("upstream Receive: %v", err)
+	}
+	q, ok := msg.(*pgproto3.Query)
+	if !ok {
+		t.Fatalf("upstream got %T", msg)
+	}
+	if q.String != "select note from public.safe_users" {
+		t.Fatalf("forwarded SQL = %q", q.String)
+	}
+	upBackend.Send(&pgproto3.CommandComplete{CommandTag: []byte("SELECT 0")})
+	upBackend.Send(&pgproto3.ReadyForQuery{TxStatus: 'I'})
+	if err := upBackend.Flush(); err != nil {
+		t.Fatalf("upstream flush: %v", err)
+	}
+	if err := <-done; err != nil {
+		t.Fatalf("handleQuery: %v", err)
+	}
+
+	evs := sink.DrainStatements()
+	if len(evs) != 1 {
+		t.Fatalf("events = %d: %+v", len(evs), evs)
+	}
+	ev := evs[0]
+	if !ev.Redirected || ev.RedirectRule != "redirect-users" || ev.RedirectRuntimeStatus != "executed" {
+		t.Fatalf("redirect event fields = %+v", ev)
+	}
+	if ev.StatementDigest == "" || ev.RewrittenStatementDigest == "" || ev.StatementDigest == ev.RewrittenStatementDigest {
+		t.Fatalf("bad digests: original=%q rewritten=%q", ev.StatementDigest, ev.RewrittenStatementDigest)
+	}
+}
+
+func TestHandleQuery_RedirectPlannerFailureFailsClosed(t *testing.T) {
+	pc, clientFE, sink := newSimpleQueryFixture(t)
+	pc.state.smState.LastUpstreamRFQ = 'I'
+	pc.state.catalog = testCatalogContext()
+	pc.srv.SetPolicy(redirectReadRuleSet(t))
+	pc.redirectPlanner = &fakeRedirectPlanner{err: errors.New("missing_target_relation")}
+
+	upClient, upServer := net.Pipe()
+	t.Cleanup(func() { _ = upClient.Close(); _ = upServer.Close() })
+	pc.state.upstream = upServer
+	pc.state.upstreamFE = pgproto3.NewFrontend(upServer, upServer)
+	upBackend := pgproto3.NewBackend(upClient, upClient)
+	drainClientBackendMessages(clientFE)
+
+	upRecv := make(chan pgproto3.FrontendMessage, 1)
+	go func() {
+		msg, err := upBackend.Receive()
+		if err == nil {
+			upRecv <- msg
+		}
+	}()
+	done := make(chan error, 1)
+	go func() {
+		done <- pc.handleQuery(context.Background(), &pgproto3.Query{String: "select note from public.users"})
+	}()
+
+	select {
+	case msg := <-upRecv:
+		t.Fatalf("upstream received original SQL after redirect rejection: %T", msg)
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("handleQuery returned transport error: %v", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	evs := sink.DrainStatements()
+	if len(evs) != 1 {
+		t.Fatalf("events = %d: %+v", len(evs), evs)
+	}
+	if evs[0].RedirectRuntimeStatus != "rejected" || evs[0].RedirectRejectionReason != "missing_target_relation" {
+		t.Fatalf("redirect rejection event = %+v", evs[0])
+	}
+	if evs[0].Result.ErrorCode != sqlstateRedirectRejected {
+		t.Fatalf("ErrorCode = %q", evs[0].Result.ErrorCode)
+	}
+}
+
+func drainClientBackendMessages(fe *pgproto3.Frontend) {
+	go func() {
+		for {
+			if _, err := fe.Receive(); err != nil {
+				return
+			}
+		}
+	}()
+}
+
+func redirectReadRuleSet(t *testing.T) *policy.RuleSet {
+	t.Helper()
+	return loadRuleSet(t, `version: 1
+name: redirect-test
+db_services:
+  test:
+    family: postgres
+    dialect: postgres
+    upstream: "127.0.0.1:5432"
+    tls_mode: terminate_reissue
+database_rules:
+  - name: block-delete
+    db_service: test
+    operations: [delete]
+    decision: deny
+  - name: redirect-users
+    db_service: test
+    operations: [read]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: public.safe_users
+`)
 }
 
 // denyDeletesRuleSet allows all read/session/ddl operations on service "test"

--- a/internal/integration/db07cclient/main.go
+++ b/internal/integration/db07cclient/main.go
@@ -34,7 +34,7 @@ func main() {
 	var (
 		dsn      = flag.String("dsn", "", "direct PostgreSQL DSN")
 		socket   = flag.String("socket", "", "AgentSH DB proxy Unix socket path")
-		mode     = flag.String("mode", "scalar", "scalar, exec, tx-deny, cancel, copy-to, or copy-from")
+		mode     = flag.String("mode", "scalar", "scalar, exec, tx-deny, cancel, copy-to, copy-from, or prepared-repeat")
 		sqlText  = flag.String("sql", "select 1", "SQL statement")
 		data     = flag.String("data", "", "COPY FROM STDIN payload")
 		user     = flag.String("user", "app", "startup user for socket mode")
@@ -117,6 +117,16 @@ func run(ctx context.Context, conn *pgx.Conn, mode, sqlText, data string) (outpu
 			return output{}, err
 		}
 		return output{Scalar: scalar}, nil
+	case "prepared-repeat":
+		var first string
+		var second string
+		if err := conn.QueryRow(ctx, sqlText, 1).Scan(&first); err != nil {
+			return output{}, err
+		}
+		if err := conn.QueryRow(ctx, sqlText, 1).Scan(&second); err != nil {
+			return output{}, err
+		}
+		return output{Scalar: first + "," + second}, nil
 	case "exec":
 		tag, err := conn.Exec(ctx, sqlText)
 		if err != nil {

--- a/internal/integration/db_postgres_07c_test.go
+++ b/internal/integration/db_postgres_07c_test.go
@@ -243,6 +243,71 @@ func TestDB09RealPostgresCatalogResolution(t *testing.T) {
 	}, "catalog_unresolved missing-object event")
 }
 
+func TestDB12RealPostgresSimpleQueryRedirect(t *testing.T) {
+	ctx := context.Background()
+	env := startDB07CEnvironment(t, ctx)
+	defer env.cleanup()
+
+	seedDB07C(t, ctx, env.hostDSN)
+	sess := createDB07CSession(t, ctx, env.client)
+	socket := filepath.Join(sess.DBProxySocketDir, "appdb.sock")
+
+	out := execDB07CClient(t, ctx, env.client, sess.ID, "-socket", socket, "-mode", "scalar", "-sql", "select note from plan12.users_source where id = 1", "-simple")
+	if out.Scalar != "target-a" {
+		t.Fatalf("plan12 simple redirect returned %+v", out)
+	}
+
+	waitForSessionEvent07C(t, ctx, env.client, sess.ID, func(ev types.Event) bool {
+		return isPlan12RedirectEvent(ev, "executed", "redirect-plan12-source-a", "plan12.users_target_a")
+	}, "db_statement plan12 simple redirect executed")
+}
+
+func TestDB12RealPostgresExtendedPreparedRedirect(t *testing.T) {
+	ctx := context.Background()
+	env := startDB07CEnvironment(t, ctx)
+	defer env.cleanup()
+
+	seedDB07C(t, ctx, env.hostDSN)
+	sess := createDB07CSession(t, ctx, env.client)
+	socket := filepath.Join(sess.DBProxySocketDir, "appdb.sock")
+
+	out := execDB07CClient(t, ctx, env.client, sess.ID, "-socket", socket, "-mode", "prepared-repeat", "-sql", "select note from plan12.users_source where id = $1")
+	if out.Scalar != "target-a,target-a" {
+		t.Fatalf("plan12 prepared redirect returned %+v", out)
+	}
+
+	waitForSessionEvent07C(t, ctx, env.client, sess.ID, func(ev types.Event) bool {
+		return isPlan12RedirectEvent(ev, "executed", "redirect-plan12-source-a", "plan12.users_target_a")
+	}, "db_statement plan12 prepared redirect executed")
+}
+
+func TestDB12RealPostgresRedirectUnsupportedFormsFailClosed(t *testing.T) {
+	ctx := context.Background()
+	env := startDB07CEnvironment(t, ctx)
+	defer env.cleanup()
+
+	seedDB07C(t, ctx, env.hostDSN)
+	sess := createDB07CSession(t, ctx, env.client)
+	socket := filepath.Join(sess.DBProxySocketDir, "appdb.sock")
+
+	multi := execDB07CClientAllowFailure(t, ctx, env.client, sess.ID, "-socket", socket, "-mode", "scalar", "-sql", "select note from plan12.users_source where id = 1; select note from plan12.users_source where id = 1", "-simple")
+	if multi.OK || multi.SQLState != "0A000" {
+		t.Fatalf("plan12 multi-statement redirect did not fail closed with 0A000: %+v", multi)
+	}
+	waitForSessionEvent07C(t, ctx, env.client, sess.ID, func(ev types.Event) bool {
+		if !isPlan12RedirectEvent(ev, "rejected", "redirect-plan12-source-a", "plan12.users_target_a") {
+			return false
+		}
+		return ev.Fields["redirect_rejection_reason"] == "multi_statement_redirect_unsupported"
+	}, "db_statement plan12 redirect rejected")
+
+	write := execDB07CClientAllowFailure(t, ctx, env.client, sess.ID, "-socket", socket, "-mode", "exec", "-sql", "insert into plan12.users_source(id, note) values (2, 'blocked')", "-simple")
+	if write.OK || write.SQLState == "" {
+		t.Fatalf("plan12 source write was not blocked: %+v", write)
+	}
+	assertPlan12SourceCount(t, ctx, env.hostDSN, 1)
+}
+
 func isPlan09CatalogAllowEvent(ev types.Event, object, statementNeedle string) bool {
 	if ev.Type != "db_statement" || ev.Fields["object_resolution"] != "catalog_resolved" {
 		return false
@@ -257,6 +322,29 @@ func isPlan09CatalogAllowEvent(ev types.Event, object, statementNeedle string) b
 	}
 	effects := fmt.Sprint(ev.Fields["effects"])
 	return strings.Contains(effects, "plan09") && strings.Contains(effects, object)
+}
+
+func isPlan12RedirectEvent(ev types.Event, status, rule, target string) bool {
+	if ev.Type != "db_statement" || ev.Fields["redirected"] != true {
+		return false
+	}
+	statementText, _ := ev.Fields["statement_text"].(string)
+	decision, _ := ev.Fields["decision"].(map[string]any)
+	rewrittenDigest, _ := ev.Fields["rewritten_statement_digest"].(string)
+	statementDigest, _ := ev.Fields["statement_digest"].(string)
+	if ev.Fields["redirect_runtime_status"] != status ||
+		ev.Fields["redirect_rule"] != rule ||
+		ev.Fields["redirect_source_relation"] != "plan12.users_source" ||
+		ev.Fields["redirect_target_relation"] != target ||
+		decision["verb"] != "redirect" ||
+		!strings.Contains(statementText, "plan12.users_source") ||
+		statementDigest == "" {
+		return false
+	}
+	if status == "executed" {
+		return rewrittenDigest != "" && statementDigest != rewrittenDigest
+	}
+	return rewrittenDigest == ""
 }
 
 func startDB07CEnvironment(t *testing.T, ctx context.Context) db07cEnv {
@@ -533,6 +621,14 @@ database_rules:
     objects: [users, active_users]
     match_object_resolution: catalog_resolved
     decision: allow
+  - name: redirect-plan12-source-a
+    db_service: appdb
+    operations: [read]
+    relations: ["plan12.users_source"]
+    match_object_resolution: catalog_resolved
+    decision: redirect
+    redirect:
+      relation: plan12.users_target_a
   - name: allow-read
     db_service: appdb
     operations: [read]
@@ -590,6 +686,14 @@ insert into plan09.users(id, note) values (1, 'schema-qualified');
 create or replace view plan09.active_users as select id, note from plan09.users;
 create or replace function plan09.identity_text(v text) returns text
 language sql immutable strict as $$ select v $$;
+drop schema if exists plan12 cascade;
+create schema plan12;
+create table plan12.users_source(id int primary key, note text);
+create table plan12.users_target_a(id int primary key, note text);
+create table plan12.users_target_b(id int primary key, note text);
+insert into plan12.users_source(id, note) values (1, 'source');
+insert into plan12.users_target_a(id, note) values (1, 'target-a');
+insert into plan12.users_target_b(id, note) values (1, 'target-b');
 alter role app in database app set search_path = plan09, public;
 `)
 	if err != nil {
@@ -667,6 +771,22 @@ func assertCopyRow07C(t *testing.T, ctx context.Context, dsn, note string) {
 	}
 	if count != 1 {
 		t.Fatalf("07c COPY FROM row count for %q = %d, want 1", note, count)
+	}
+}
+
+func assertPlan12SourceCount(t *testing.T, ctx context.Context, dsn string, want int) {
+	t.Helper()
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("07c connect host Postgres: %v", err)
+	}
+	defer conn.Close(ctx)
+	var got int
+	if err := conn.QueryRow(ctx, "select count(*) from plan12.users_source").Scan(&got); err != nil {
+		t.Fatalf("plan12 count source rows: %v", err)
+	}
+	if got != want {
+		t.Fatalf("plan12 source rows = %d, want %d", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Wires DB Plan 11 redirect plans into the Postgres proxy runtime for DB Plan 12.

- Adds redirect audit fields and API event projection for session-visible `db_statement` events.
- Executes redirects for Simple Query and Extended Query `Parse`, including prepared-cache redirect metadata and post-`Sync` execution events.
- Adds fail-closed rejection handling and real Postgres integration coverage for simple queries, prepared statements, unsupported forms, and policy reload behavior.

## Validation

- `go test ./internal/db/events ./internal/db/proxy/postgres/preparedcache ./internal/db/proxy/postgres -run 'Redirect|TestHandleQuery|TestExtquery|TestBuildStatementEvent' -count=1 -timeout=60s`
- `go test ./internal/db/... -count=1 -timeout=3m`
- `GOOS=windows go build ./...`
- `go test -v -tags=integration ./internal/integration -run 'TestDB07C|TestDB09|TestDB12' -count=1 -timeout=10m`
- `go test -v -tags=integration ./internal/db/proxy/postgres -run TestDB12RealPostgresDirectProxyPolicyReloadPreservesPreparedRedirect -count=1 -timeout=4m`
- `go test ./internal/api -run 'TestDBStatementToEventMaps' -count=1`
