### PR TITLE
fix(docker-test): rocky image path + ubuntu slog stderr leak

### DIFF
--- a/Dockerfile.test.rockylinux10
+++ b/Dockerfile.test.rockylinux10
@@ -12,7 +12,7 @@
 # Run:
 #   docker run --rm agentsh-test-rockylinux10:latest
 
-FROM rockylinux:10
+FROM rockylinux/rockylinux:10
 
 ARG AGENTSH_REPO=canyonroad/agentsh
 ARG AGENTSH_TAG=v0.10.1

--- a/Dockerfile.test.ubuntu
+++ b/Dockerfile.test.ubuntu
@@ -352,8 +352,14 @@ rm -f /tmp/test_binary
 # This test runs sh under the seccomp wrapper. The shim runs under seccomp
 # user-notify, so all its stat/exec calls are intercepted. Retry once on
 # failure to handle transient races in notification handler startup.
+#
+# We filter "INFO seccomp:" lines from the captured output because
+# agentsh-unixwrap emits a structured slog line to its stderr when it
+# installs the Layer 1 filter ("INFO seccomp: filter loaded ... wait_killable=...").
+# That line propagates back to the CLI's stderr via the SSE stderr
+# stream and would otherwise become the tail line, masking exec_ok.
 set +e
-exec_full="$(agentsh exec "$sid" -- sh -c 'echo exec_ok' 2>&1)"
+exec_full="$(agentsh exec "$sid" -- sh -c 'echo exec_ok' 2>&1 | grep -v 'INFO seccomp:')"
 exec_rc=$?
 set -e
 exec_out="$(echo "$exec_full" | tr -d '\r' | tail -n 1)"
@@ -365,7 +371,7 @@ else
   echo "  first attempt output: $exec_full" >&2
   sleep 0.5
   set +e
-  exec_full="$(agentsh exec "$sid" -- sh -c 'echo exec_ok' 2>&1)"
+  exec_full="$(agentsh exec "$sid" -- sh -c 'echo exec_ok' 2>&1 | grep -v 'INFO seccomp:')"
   exec_rc=$?
   set -e
   exec_out="$(echo "$exec_full" | tr -d '\r' | tail -n 1)"

--- a/Dockerfile.test.ubuntu2204
+++ b/Dockerfile.test.ubuntu2204
@@ -480,8 +480,14 @@ rm -f /tmp/test_binary
 # This test runs sh under the seccomp wrapper. The shim runs under seccomp
 # user-notify, so all its stat/exec calls are intercepted. Retry once on
 # failure to handle transient races in notification handler startup.
+#
+# We filter "INFO seccomp:" lines from the captured output because
+# agentsh-unixwrap emits a structured slog line to its stderr when it
+# installs the Layer 1 filter ("INFO seccomp: filter loaded ... wait_killable=...").
+# That line propagates back to the CLI's stderr via the SSE stderr
+# stream and would otherwise become the tail line, masking exec_ok.
 set +e
-exec_full="$(agentsh exec "$sid" -- sh -c 'echo exec_ok' 2>&1)"
+exec_full="$(agentsh exec "$sid" -- sh -c 'echo exec_ok' 2>&1 | grep -v 'INFO seccomp:')"
 exec_rc=$?
 set -e
 exec_out="$(echo "$exec_full" | tr -d '\r' | tail -n 1)"
@@ -493,7 +499,7 @@ else
   echo "  first attempt output: $exec_full" >&2
   sleep 0.5
   set +e
-  exec_full="$(agentsh exec "$sid" -- sh -c 'echo exec_ok' 2>&1)"
+  exec_full="$(agentsh exec "$sid" -- sh -c 'echo exec_ok' 2>&1 | grep -v 'INFO seccomp:')"
   exec_rc=$?
   set -e
   exec_out="$(echo "$exec_full" | tr -d '\r' | tail -n 1)"


### PR DESCRIPTION
## Summary

Two pre-existing bugs surfaced after #334 dropped the misplaced wait_killable check that was short-circuiting these tests. Both were introduced in #316 (libseccomp 2.5 system-link work) but never hit on a release because the broken wait_killable check failed first with \`exit 1\`.

## Fix 1: Rocky 10 image path

\`Dockerfile.test.rockylinux10\` used \`FROM rockylinux:10\`, which doesn't exist at \`docker.io/library/\`:

\`\`\`
ERROR: failed to build: docker.io/library/rockylinux:10: not found
\`\`\`

The canonical Rocky 10 image lives at \`rockylinux/rockylinux:10\` on Docker Hub. Switch to that.

## Fix 2: Ubuntu slog stderr leak

\`Dockerfile.test.ubuntu\` and \`Dockerfile.test.ubuntu2204\` both enable \`sandbox.unix_sockets: true\`, so \`agentsh-unixwrap\` runs on every exec and emits a structured slog line to its stderr:

\`\`\`
INFO seccomp: filter loaded fd=5 wait_killable=true kernel_probe_supports=true libseccomp_runtime=2.5.3
\`\`\`

The server forwards that stderr through the SSE \`"stderr"\` stream → CLI \`os.Stderr\` → the test's \`2>&1\`-captured output. \`tail -n 1\` then picks up the slog line instead of \`exec_ok\`, failing \`agentsh exec command\` despite a successful exec.

Filter the line with \`grep -v 'INFO seccomp:'\` before tailing. Applied to both attempts (first and retry) in both ubuntu variants.

## Test plan
- [x] No Go source changes; \`go test ./...\` not affected.
- [ ] Validation: merge → re-cut \`v0.19.4-rc1\` → confirm 8/8 docker-test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)