### PR TITLE
[codex] fix FUSE event channel panic

### DIFF
--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -377,8 +377,9 @@ func (a *App) setupProfileMounts(ctx context.Context, s *session.Session, profil
 					PolicyEngine: policyEngine,
 					Unmount: func() error {
 						deregisterFUSEMount(sessionID, capturedMountPoint)
+						err := m.Close()
 						close(eventChan)
-						return m.Close()
+						return err
 					},
 				})
 			}
@@ -1298,8 +1299,9 @@ func (a *App) mountFUSEForSession(ctx context.Context, p fuseMountParams) bool {
 	capturedMountPoint := mountPoint
 	s.SetWorkspaceUnmount(func() error {
 		deregisterFUSEMount(sessionID, capturedMountPoint)
+		err := m.Close()
 		close(eventChan)
-		return m.Close()
+		return err
 	})
 
 	fields := map[string]any{

--- a/internal/platform/linux/filesystem.go
+++ b/internal/platform/linux/filesystem.go
@@ -434,10 +434,19 @@ type eventEmitter struct {
 }
 
 // AppendEvent implements fsmonitor.Emitter.
-func (e *eventEmitter) AppendEvent(ctx context.Context, ev types.Event) error {
+func (e *eventEmitter) AppendEvent(ctx context.Context, ev types.Event) (err error) {
 	if e.eventChan == nil {
 		return nil
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			if fmt.Sprint(r) == "send on closed channel" {
+				err = nil
+				return
+			}
+			panic(r)
+		}
+	}()
 
 	// Use session/command from config if not in event
 	sessionID := ev.SessionID

--- a/internal/platform/linux/filesystem_event_test.go
+++ b/internal/platform/linux/filesystem_event_test.go
@@ -1,0 +1,38 @@
+//go:build linux
+
+package linux
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/platform"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+func TestEventEmitterAppendEventDropsAfterChannelClosed(t *testing.T) {
+	ch := make(chan platform.IOEvent, 1)
+	close(ch)
+
+	emitter := &eventEmitter{
+		eventChan: ch,
+		sessionID: "session-1",
+	}
+
+	ev := types.Event{
+		Timestamp: time.Now(),
+		Type:      "file_stat",
+		Path:      "/workspace/app.py",
+		Operation: "stat",
+		Policy: &types.PolicyInfo{
+			Decision:          types.DecisionAudit,
+			EffectiveDecision: types.DecisionAllow,
+			Rule:              "audit-app-files",
+		},
+	}
+
+	if err := emitter.AppendEvent(context.Background(), ev); err != nil {
+		t.Fatalf("AppendEvent returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #338.

This hardens Linux FUSE audit event emission against late callbacks during mount teardown. The issue stack trace pointed at `eventEmitter.AppendEvent`; current source line mapping shows the panic is the non-blocking send on a closed `eventChan`, not a nested nil policy field.

## Root Cause

The API unmount closures closed the FUSE event channel before closing/unmounting the FUSE mount. A concurrent or late FUSE callback, such as `Getattr` for a broad audit `stat`, could still call `AppendEvent` and send into the closed channel. A send on a closed channel panics even inside a non-blocking `select`.

## Changes

- Move event channel closure until after `m.Close()` in both FUSE unmount paths.
- Make `eventEmitter.AppendEvent` drop late events when the event channel is already closed, while re-panicking unrelated panics.
- Add a regression test for `AppendEvent` receiving a late audit/stat event after channel closure.

## Validation

- `gofmt -l internal/platform/linux/filesystem.go internal/platform/linux/filesystem_event_test.go internal/api/core.go && git diff --check HEAD~1..HEAD`
- `go test ./...`
- `GOOS=windows go build ./...`
