### PR TITLE
fix(docker-test): filter slog from all shim-test captures (ubuntu)

### DIFF
--- a/Dockerfile.test.ubuntu
+++ b/Dockerfile.test.ubuntu
@@ -278,7 +278,7 @@ fi
 echo ""
 echo "=== Shim tests ==="
 
-sh_out="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'echo hello_sh' 2>&1 | tr -d '\r' | tail -n 1)"
+sh_out="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'echo hello_sh' 2>&1 | grep -v 'INFO seccomp:' | tr -d '\r' | tail -n 1)"
 if [ "$sh_out" = "hello_sh" ]; then
   pass "echo through /bin/sh shim"
 else
@@ -288,7 +288,7 @@ fi
 # -------------------------------------------------------------------
 # Test: basic echo through /bin/bash shim
 # -------------------------------------------------------------------
-bash_out="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/bash -c 'echo hello_bash' 2>&1 | tr -d '\r' | tail -n 1)"
+bash_out="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/bash -c 'echo hello_bash' 2>&1 | grep -v 'INFO seccomp:' | tr -d '\r' | tail -n 1)"
 if [ "$bash_out" = "hello_bash" ]; then
   pass "echo through /bin/bash shim"
 else
@@ -301,7 +301,7 @@ fi
 # When AGENTSH_IN_SESSION is set, the shim should delegate directly to the
 # real shell without contacting the server. We set AGENTSH_BIN to a
 # nonexistent path to prove the shim doesn't try to call it.
-rec_out="$(AGENTSH_BIN=/nonexistent/agentsh AGENTSH_IN_SESSION=1 /bin/sh -c 'echo recursion_ok' 2>&1 | tr -d '\r' | tail -n 1)"
+rec_out="$(AGENTSH_BIN=/nonexistent/agentsh AGENTSH_IN_SESSION=1 /bin/sh -c 'echo recursion_ok' 2>&1 | grep -v 'INFO seccomp:' | tr -d '\r' | tail -n 1)"
 if [ "$rec_out" = "recursion_ok" ]; then
   pass "AGENTSH_IN_SESSION recursion guard"
 else
@@ -311,7 +311,7 @@ fi
 # -------------------------------------------------------------------
 # Test: multi-word arguments preserved
 # -------------------------------------------------------------------
-multi_out="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'echo "hello world"' 2>&1 | tr -d '\r' | tail -n 1)"
+multi_out="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'echo "hello world"' 2>&1 | grep -v 'INFO seccomp:' | tr -d '\r' | tail -n 1)"
 if [ "$multi_out" = "hello world" ]; then
   pass "multi-word arguments preserved"
 else
@@ -577,7 +577,7 @@ echo ""
 echo "=== Shim + policy integration ==="
 
 # Safe command through shim should work
-shim_safe="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'echo shim_policy_ok' 2>&1 | tr -d '\r' | tail -n 1)"
+shim_safe="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'echo shim_policy_ok' 2>&1 | grep -v 'INFO seccomp:' | tr -d '\r' | tail -n 1)"
 if [ "$shim_safe" = "shim_policy_ok" ]; then
   pass "safe command through shim works"
 else

--- a/Dockerfile.test.ubuntu2204
+++ b/Dockerfile.test.ubuntu2204
@@ -400,7 +400,7 @@ echo "=== Shim tests ==="
 # passthrough test further down deliberately omits this flag: its
 # purpose IS to exercise the bypass path, not the enforcement path.
 
-sh_out="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'echo hello_sh' 2>&1 | tr -d '\r' | tail -n 1)"
+sh_out="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'echo hello_sh' 2>&1 | grep -v 'INFO seccomp:' | tr -d '\r' | tail -n 1)"
 if [ "$sh_out" = "hello_sh" ]; then
   pass "echo through /bin/sh shim"
 else
@@ -410,7 +410,7 @@ fi
 # -------------------------------------------------------------------
 # Test: basic echo through /bin/bash shim
 # -------------------------------------------------------------------
-bash_out="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/bash -c 'echo hello_bash' 2>&1 | tr -d '\r' | tail -n 1)"
+bash_out="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/bash -c 'echo hello_bash' 2>&1 | grep -v 'INFO seccomp:' | tr -d '\r' | tail -n 1)"
 if [ "$bash_out" = "hello_bash" ]; then
   pass "echo through /bin/bash shim"
 else
@@ -426,7 +426,7 @@ fi
 # Do NOT set AGENTSH_SHIM_FORCE here — the shim's AGENTSH_IN_SESSION
 # recursion guard runs BEFORE the non-tty bypass check, so force would
 # be a no-op. This test is about the recursion guard, not enforcement.
-rec_out="$(AGENTSH_BIN=/nonexistent/agentsh AGENTSH_IN_SESSION=1 /bin/sh -c 'echo recursion_ok' 2>&1 | tr -d '\r' | tail -n 1)"
+rec_out="$(AGENTSH_BIN=/nonexistent/agentsh AGENTSH_IN_SESSION=1 /bin/sh -c 'echo recursion_ok' 2>&1 | grep -v 'INFO seccomp:' | tr -d '\r' | tail -n 1)"
 if [ "$rec_out" = "recursion_ok" ]; then
   pass "AGENTSH_IN_SESSION recursion guard"
 else
@@ -436,7 +436,7 @@ fi
 # -------------------------------------------------------------------
 # Test: multi-word arguments preserved
 # -------------------------------------------------------------------
-multi_out="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'echo "hello world"' 2>&1 | tr -d '\r' | tail -n 1)"
+multi_out="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'echo "hello world"' 2>&1 | grep -v 'INFO seccomp:' | tr -d '\r' | tail -n 1)"
 if [ "$multi_out" = "hello world" ]; then
   pass "multi-word arguments preserved"
 else
@@ -710,7 +710,7 @@ echo "=== Shim + policy integration ==="
 # stdin triggers the shim's bypass, which execs the real shell
 # directly and skips the policy path entirely — making this
 # "integration" test prove nothing about shim+policy.
-shim_safe="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'echo shim_policy_ok' 2>&1 | tr -d '\r' | tail -n 1)"
+shim_safe="$(AGENTSH_SESSION_ID="$sid" AGENTSH_SHIM_FORCE=1 /bin/sh -c 'echo shim_policy_ok' 2>&1 | grep -v 'INFO seccomp:' | tr -d '\r' | tail -n 1)"
 if [ "$shim_safe" = "shim_policy_ok" ]; then
   pass "safe command through shim works"
 else


### PR DESCRIPTION
## Summary

PR #337 fixed the slog stderr leak in the \`agentsh exec command\` test but missed the 5 other capture sites in each of the ubuntu dockerfiles that use the same \`2>&1 | tr -d '\\\\r' | tail -n 1\` pattern:

- echo through /bin/sh shim
- echo through /bin/bash shim
- AGENTSH_IN_SESSION recursion guard
- multi-word arguments preserved
- shim + policy integration

\`ubuntu2204\` happened to pass in the v0.19.4-rc1 (4th cut) run because the slog timing landed before each \`echo hello_<x>\`. Plain \`ubuntu\` (libseccomp 2.5.5 — different startup overhead than 2.5.3) lost the race on the bash shim test:

\`\`\`
FAIL: echo through /bin/bash shim — got: INFO seccomp: filter loaded fd=5 wait_killable=true kernel_probe_supports=true libseccomp_runtime=2.5.5
\`\`\`

## Fix

Apply \`grep -v 'INFO seccomp:'\` to all 5 occurrences in each file (10 lines total). The pattern is now \`2>&1 | grep -v 'INFO seccomp:' | tr -d '\\\\r' | tail -n 1\` everywhere.

## v0.19.4-rc1 (4th cut) state

7 of 8 docker-test variants passed: alpine, archlinux, debian, debian-trixie, fedora, rockylinux10, ubuntu2204. Only plain ubuntu remained red on the bash shim test.

## Test plan
- [x] No Go source changes; \`go test ./...\` not affected.
- [ ] Validation: merge → re-cut \`v0.19.4-rc1\` → confirm 8/8 docker-test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)