### PR TITLE
[codex] filter read-only openat file monitor events

### DIFF
--- a/cmd/agentsh-unixwrap/config.go
+++ b/cmd/agentsh-unixwrap/config.go
@@ -22,6 +22,7 @@ type WrapperConfig struct {
 	OnBlock             string                    `json:"on_block,omitempty"`
 
 	InterceptMetadata bool `json:"intercept_metadata,omitempty"`
+	WriteOnlyOpens    bool `json:"write_only_opens,omitempty"`
 	BlockIOUring      bool `json:"block_io_uring,omitempty"`
 
 	// Landlock filesystem restrictions

--- a/cmd/agentsh-unixwrap/config_test.go
+++ b/cmd/agentsh-unixwrap/config_test.go
@@ -51,8 +51,8 @@ func TestParseConfigJSON(t *testing.T) {
 	}{
 		{
 			name:  "valid config",
-			input: `{"unix_socket_enabled":true,"blocked_syscalls":["ptrace","mount"]}`,
-			want:  &WrapperConfig{UnixSocketEnabled: true, BlockedSyscalls: []string{"ptrace", "mount"}},
+			input: `{"unix_socket_enabled":true,"blocked_syscalls":["ptrace","mount"],"write_only_opens":true}`,
+			want:  &WrapperConfig{UnixSocketEnabled: true, BlockedSyscalls: []string{"ptrace", "mount"}, WriteOnlyOpens: true},
 		},
 		{
 			name:  "empty config",

--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -101,6 +101,7 @@ func main() {
 		ExecveEnabled:      cfg.ExecveEnabled,
 		FileMonitorEnabled: cfg.FileMonitorEnabled,
 		InterceptMetadata:  cfg.InterceptMetadata,
+		WriteOnlyOpens:     cfg.WriteOnlyOpens,
 		BlockIOUring:       cfg.BlockIOUring,
 		BlockedSyscalls:    blockedNrs,
 		BlockedFamilies:    cfg.BlockedFamilies,

--- a/docs/seccomp.md
+++ b/docs/seccomp.md
@@ -4,11 +4,12 @@ agentsh uses seccomp-bpf to enforce syscall-level security controls on agent pro
 
 ## Overview
 
-When enabled, seccomp filtering provides three types of protection:
+When enabled, seccomp filtering provides four types of protection:
 
 1. **Unix Socket Monitoring**: Intercepts socket operations for policy-based access control
-2. **Signal Interception**: Intercepts signal delivery for policy-based allow/deny/redirect
-3. **Syscall Blocking**: Denies (and optionally kills) processes that attempt blocked syscalls
+2. **File Monitoring**: Intercepts filesystem operations for policy-based access control
+3. **Signal Interception**: Intercepts signal delivery for policy-based allow/deny/redirect
+4. **Syscall Blocking**: Denies (and optionally kills) processes that attempt blocked syscalls
 
 ## Configuration
 
@@ -25,6 +26,12 @@ sandbox:
     signal_filter:
       enabled: true
       action: enforce  # enforce | audit
+
+    file_monitor:
+      enabled: true
+      enforce_without_fuse: true
+      intercept_metadata: false
+      write_only_opens: true  # default: true when intercept_metadata is false
 
     syscalls:
       default_action: allow  # allow | block
@@ -64,6 +71,12 @@ sandbox:
     #     protocol: NETLINK_XFRM
     #     action: log_and_kill
 ```
+
+## File Monitoring
+
+File monitoring uses `SECCOMP_RET_USER_NOTIF` to evaluate filesystem policy for file syscalls. When `write_only_opens` is true, the seccomp filter only traps `openat` and legacy `open` calls whose flags request write/create behavior (`O_WRONLY`, `O_RDWR`, `O_CREAT`, `O_TMPFILE`, `O_TRUNC`, or `O_APPEND`). Read-only opens stay on the kernel fast path and do not emit file-open events.
+
+`openat2` is still trapped when file monitoring is enabled because its flags live in the user-space `open_how` struct; seccomp-BPF cannot dereference that pointer safely in the kernel filter.
 
 ## Signal Interception
 

--- a/internal/api/seccomp_wrapper_config.go
+++ b/internal/api/seccomp_wrapper_config.go
@@ -24,6 +24,7 @@ type seccompWrapperConfig struct {
 
 	// File monitor sub-options
 	InterceptMetadata bool `json:"intercept_metadata,omitempty"`
+	WriteOnlyOpens    bool `json:"write_only_opens,omitempty"`
 	BlockIOUring      bool `json:"block_io_uring,omitempty"`
 
 	// Landlock filesystem restrictions
@@ -78,6 +79,12 @@ func (a *App) buildSeccompWrapperConfig(s *session.Session, p seccompWrapperPara
 
 	fmDefault := config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE, false)
 	seccompCfg.InterceptMetadata = config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata, fmDefault)
+	if seccompCfg.FileMonitorEnabled {
+		seccompCfg.WriteOnlyOpens = config.FileMonitorBoolWithDefault(
+			a.cfg.Sandbox.Seccomp.FileMonitor.WriteOnlyOpens,
+			!seccompCfg.InterceptMetadata,
+		)
+	}
 	seccompCfg.BlockIOUring = config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.BlockIOUring, fmDefault)
 
 	if a.cfg.Landlock.Enabled {

--- a/internal/api/seccomp_wrapper_test.go
+++ b/internal/api/seccomp_wrapper_test.go
@@ -286,6 +286,77 @@ func TestSetupSeccompWrapper_FileMonitorDefaults(t *testing.T) {
 	}
 }
 
+func TestBuildSeccompWrapperConfig_WriteOnlyOpensDefaultsFromInterceptMetadata(t *testing.T) {
+	trueVal := true
+	falseVal := false
+
+	cfg := &config.Config{}
+	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &trueVal
+	cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE = &trueVal
+	cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata = &falseVal
+	app := newTestAppForSeccomp(t, cfg)
+
+	got := app.buildSeccompWrapperConfig(nil, seccompWrapperParams{})
+	if !got.WriteOnlyOpens {
+		t.Fatal("write_only_opens should default true when intercept_metadata is false")
+	}
+
+	cfg.Sandbox.Seccomp.FileMonitor.WriteOnlyOpens = &falseVal
+	got = app.buildSeccompWrapperConfig(nil, seccompWrapperParams{})
+	if got.WriteOnlyOpens {
+		t.Fatal("explicit write_only_opens=false should override the intercept_metadata-derived default")
+	}
+
+	cfg.Sandbox.Seccomp.FileMonitor.WriteOnlyOpens = nil
+	cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata = &trueVal
+	got = app.buildSeccompWrapperConfig(nil, seccompWrapperParams{})
+	if got.WriteOnlyOpens {
+		t.Fatal("write_only_opens should default false when intercept_metadata is true")
+	}
+}
+
+func TestSetupSeccompWrapper_WriteOnlyOpensForwarded(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("seccomp wrapper only available on Linux")
+	}
+
+	enabled := true
+	disabled := false
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &enabled
+	cfg.Sandbox.Seccomp.FileMonitor.EnforceWithoutFUSE = &enabled
+	cfg.Sandbox.Seccomp.FileMonitor.InterceptMetadata = &disabled
+
+	app := newTestAppForSeccomp(t, cfg)
+	result := app.setupSeccompWrapper(types.ExecRequest{
+		Command: "/bin/echo",
+		Args:    []string{"hello"},
+	}, "test-session", nil)
+	if result == nil || result.extraCfg == nil {
+		t.Fatal("expected non-nil wrapper setup result with extraCfg")
+	}
+	defer func() {
+		if result.extraCfg.notifyParentSock != nil {
+			result.extraCfg.notifyParentSock.Close()
+		}
+		for _, f := range result.extraCfg.extraFiles {
+			if f != nil {
+				f.Close()
+			}
+		}
+	}()
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(result.wrappedReq.Env["AGENTSH_SECCOMP_CONFIG"]), &parsed); err != nil {
+		t.Fatalf("unmarshal seccomp config: %v", err)
+	}
+	if got, _ := parsed["write_only_opens"].(bool); !got {
+		t.Fatalf("write_only_opens = %v, want true", got)
+	}
+}
+
 func TestSetupSeccompWrapper_PtraceSync_MitigationSetFamilyLog(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("seccomp wrapper only available on Linux")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -525,6 +525,7 @@ type SandboxSeccompFileMonitorConfig struct {
 	Enabled            *bool `yaml:"enabled"`
 	EnforceWithoutFUSE *bool `yaml:"enforce_without_fuse"`
 	InterceptMetadata  *bool `yaml:"intercept_metadata"`
+	WriteOnlyOpens     *bool `yaml:"write_only_opens"`
 	OpenatEmulation    *bool `yaml:"openat_emulation"`
 	BlockIOUring       *bool `yaml:"block_io_uring"`
 }

--- a/internal/config/seccomp_test.go
+++ b/internal/config/seccomp_test.go
@@ -104,6 +104,22 @@ sandbox:
 		"applyDefaults must auto-enable omitted file_monitor")
 }
 
+func TestFileMonitorWriteOnlyOpensParsesExplicitFalse(t *testing.T) {
+	yamlData := []byte(`
+sandbox:
+  seccomp:
+    enabled: true
+    file_monitor:
+      write_only_opens: false
+`)
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal(yamlData, &cfg))
+
+	require.NotNil(t, cfg.Sandbox.Seccomp.FileMonitor.WriteOnlyOpens,
+		"explicit write_only_opens must parse as non-nil *bool")
+	require.False(t, *cfg.Sandbox.Seccomp.FileMonitor.WriteOnlyOpens)
+}
+
 func TestSeccompConfigDefaults(t *testing.T) {
 	yamlData := `
 sandbox:

--- a/internal/netmonitor/unix/file_syscalls_legacy_amd64.go
+++ b/internal/netmonitor/unix/file_syscalls_legacy_amd64.go
@@ -28,6 +28,10 @@ func legacyFileSyscallList() []int32 {
 	}
 }
 
+func legacyFlaggedOpenSyscallList() []int32 {
+	return []int32{unix.SYS_OPEN}
+}
+
 // isLegacyFileSyscall returns true if nr is a legacy (non-at) file syscall.
 func isLegacyFileSyscall(nr int32) bool {
 	switch nr {

--- a/internal/netmonitor/unix/file_syscalls_legacy_other.go
+++ b/internal/netmonitor/unix/file_syscalls_legacy_other.go
@@ -6,6 +6,8 @@ package unix
 // ARM64 and others only have the -at variants.
 func legacyFileSyscallList() []int32 { return nil }
 
+func legacyFlaggedOpenSyscallList() []int32 { return nil }
+
 // isLegacyFileSyscall returns false on non-amd64 architectures.
 func isLegacyFileSyscall(nr int32) bool { return false }
 

--- a/internal/netmonitor/unix/seccomp_linux.go
+++ b/internal/netmonitor/unix/seccomp_linux.go
@@ -245,6 +245,7 @@ type FilterConfig struct {
 	ExecveEnabled      bool
 	FileMonitorEnabled bool
 	InterceptMetadata  bool  // statx, newfstatat, faccessat2, readlinkat
+	WriteOnlyOpens     bool  // trap only write/create-style open/openat calls
 	BlockIOUring       bool  // io_uring_setup/enter/register → EPERM
 	BlockedSyscalls    []int // syscall numbers to block; action controlled by OnBlockAction
 	BlockedFamilies    []seccompkg.BlockedFamily
@@ -336,30 +337,11 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 
 	// File I/O monitoring via user-notify
 	if cfg.FileMonitorEnabled {
-		trap := seccomp.ActNotify
-		fileRules := []seccomp.ScmpSyscall{
-			seccomp.ScmpSyscall(unix.SYS_OPENAT),
-			seccomp.ScmpSyscall(unix.SYS_OPENAT2),
-			seccomp.ScmpSyscall(unix.SYS_UNLINKAT),
-			seccomp.ScmpSyscall(unix.SYS_MKDIRAT),
-			seccomp.ScmpSyscall(unix.SYS_RENAMEAT2),
-			seccomp.ScmpSyscall(unix.SYS_LINKAT),
-			seccomp.ScmpSyscall(unix.SYS_SYMLINKAT),
-			seccomp.ScmpSyscall(unix.SYS_FCHMODAT),
-			seccomp.ScmpSyscall(unix.SYS_FCHOWNAT),
+		added, err := installFileMonitorRules(filt, seccomp.ActNotify, cfg.WriteOnlyOpens)
+		if err != nil {
+			return nil, err
 		}
-		for _, sc := range fileRules {
-			if err := filt.AddRule(sc, trap); err != nil {
-				return nil, fmt.Errorf("add file monitor rule %v: %w", sc, err)
-			}
-		}
-		legacy := legacyFileSyscallList()
-		for _, sc := range legacy {
-			if err := filt.AddRule(seccomp.ScmpSyscall(sc), trap); err != nil {
-				return nil, fmt.Errorf("add legacy file rule %v: %w", sc, err)
-			}
-		}
-		ruleCounts["file_monitor"] = len(fileRules) + len(legacy)
+		ruleCounts["file_monitor"] = added
 	}
 
 	// Metadata syscalls via user-notify (when intercept_metadata is enabled)
@@ -377,14 +359,6 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 			}
 		}
 		ruleCounts["metadata"] = len(metadataRules)
-	}
-
-	// mknodat is always included with file monitoring (create-category)
-	if cfg.FileMonitorEnabled {
-		trap := seccomp.ActNotify
-		if err := filt.AddRule(seccomp.ScmpSyscall(unix.SYS_MKNODAT), trap); err != nil {
-			return nil, fmt.Errorf("add mknodat rule: %w", err)
-		}
 	}
 
 	// Blocked syscalls — action controlled by OnBlockAction.
@@ -550,6 +524,115 @@ func familyToScmpAction(a seccompkg.OnBlockAction) (seccomp.ScmpAction, error) {
 		return seccomp.ActNotify, nil
 	default:
 		return seccomp.ActAllow, fmt.Errorf("unknown family block action %q", a)
+	}
+}
+
+type fileMonitorRuleAdder interface {
+	AddRule(seccomp.ScmpSyscall, seccomp.ScmpAction) error
+	AddRuleConditional(seccomp.ScmpSyscall, seccomp.ScmpAction, []seccomp.ScmpCondition) error
+}
+
+func installFileMonitorRules(adder fileMonitorRuleAdder, action seccomp.ScmpAction, writeOnlyOpens bool) (int, error) {
+	added := 0
+	addRule := func(sc seccomp.ScmpSyscall, label string) error {
+		if err := adder.AddRule(sc, action); err != nil {
+			return fmt.Errorf("add %s rule %v: %w", label, sc, err)
+		}
+		added++
+		return nil
+	}
+
+	if writeOnlyOpens {
+		n, err := installFlaggedOpenNotifyRules(adder, seccomp.ScmpSyscall(unix.SYS_OPENAT), 2, action)
+		added += n
+		if err != nil {
+			return added, fmt.Errorf("add openat write-only rules: %w", err)
+		}
+		// openat2 stores flags in the user-space open_how struct, which seccomp
+		// BPF cannot dereference. Keep trapping it rather than allowing writes to
+		// bypass policy.
+		if err := addRule(seccomp.ScmpSyscall(unix.SYS_OPENAT2), "file monitor"); err != nil {
+			return added, err
+		}
+	} else {
+		for _, sc := range []seccomp.ScmpSyscall{
+			seccomp.ScmpSyscall(unix.SYS_OPENAT),
+			seccomp.ScmpSyscall(unix.SYS_OPENAT2),
+		} {
+			if err := addRule(sc, "file monitor"); err != nil {
+				return added, err
+			}
+		}
+	}
+
+	for _, sc := range []seccomp.ScmpSyscall{
+		seccomp.ScmpSyscall(unix.SYS_UNLINKAT),
+		seccomp.ScmpSyscall(unix.SYS_MKDIRAT),
+		seccomp.ScmpSyscall(unix.SYS_RENAMEAT2),
+		seccomp.ScmpSyscall(unix.SYS_LINKAT),
+		seccomp.ScmpSyscall(unix.SYS_SYMLINKAT),
+		seccomp.ScmpSyscall(unix.SYS_FCHMODAT),
+		seccomp.ScmpSyscall(unix.SYS_FCHOWNAT),
+		seccomp.ScmpSyscall(unix.SYS_MKNODAT),
+	} {
+		if err := addRule(sc, "file monitor"); err != nil {
+			return added, err
+		}
+	}
+
+	flaggedLegacyOpen := map[int32]bool{}
+	for _, sc := range legacyFlaggedOpenSyscallList() {
+		flaggedLegacyOpen[sc] = true
+		if writeOnlyOpens {
+			n, err := installFlaggedOpenNotifyRules(adder, seccomp.ScmpSyscall(sc), 1, action)
+			added += n
+			if err != nil {
+				return added, fmt.Errorf("add legacy open write-only rules %v: %w", sc, err)
+			}
+		} else if err := addRule(seccomp.ScmpSyscall(sc), "legacy file"); err != nil {
+			return added, err
+		}
+	}
+	for _, sc := range legacyFileSyscallList() {
+		if flaggedLegacyOpen[sc] {
+			continue
+		}
+		if err := addRule(seccomp.ScmpSyscall(sc), "legacy file"); err != nil {
+			return added, err
+		}
+	}
+
+	return added, nil
+}
+
+func installFlaggedOpenNotifyRules(adder fileMonitorRuleAdder, sc seccomp.ScmpSyscall, flagsArg uint, action seccomp.ScmpAction) (int, error) {
+	added := 0
+	for _, condition := range openWriteFlagConditions(flagsArg) {
+		if err := adder.AddRuleConditional(sc, action, []seccomp.ScmpCondition{condition}); err != nil {
+			return added, fmt.Errorf("add conditional rule for syscall %d: %w", sc, err)
+		}
+		added++
+	}
+	return added, nil
+}
+
+func openWriteFlagConditions(flagsArg uint) []seccomp.ScmpCondition {
+	return []seccomp.ScmpCondition{
+		maskedOpenFlagCondition(flagsArg, unix.O_ACCMODE, unix.O_WRONLY),
+		maskedOpenFlagCondition(flagsArg, unix.O_ACCMODE, unix.O_RDWR),
+		maskedOpenFlagCondition(flagsArg, unix.O_CREAT, unix.O_CREAT),
+		maskedOpenFlagCondition(flagsArg, unix.O_TRUNC, unix.O_TRUNC),
+		maskedOpenFlagCondition(flagsArg, unix.O_APPEND, unix.O_APPEND),
+		maskedOpenFlagCondition(flagsArg, unix.O_TMPFILE, unix.O_TMPFILE),
+	}
+}
+
+func maskedOpenFlagCondition(argument uint, mask, value int) seccomp.ScmpCondition {
+	return seccomp.ScmpCondition{
+		Argument: argument,
+		Op:       seccomp.CompareMaskedEqual,
+		Operand1: uint64(mask),
+		Operand2: uint64(value),
 	}
 }
 
@@ -808,6 +891,7 @@ func filterDiagnosticFields(filt *seccomp.ScmpFilter, cfg FilterConfig, waitKill
 		"cfg_execve_enabled", cfg.ExecveEnabled,
 		"cfg_file_monitor_enabled", cfg.FileMonitorEnabled,
 		"cfg_intercept_metadata", cfg.InterceptMetadata,
+		"cfg_write_only_opens", cfg.WriteOnlyOpens,
 		"cfg_block_io_uring", cfg.BlockIOUring,
 	}
 }

--- a/internal/netmonitor/unix/seccomp_linux_test.go
+++ b/internal/netmonitor/unix/seccomp_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	seccompkg "github.com/agentsh/agentsh/internal/seccomp"
+	seccomp "github.com/seccomp/libseccomp-golang"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
@@ -128,4 +129,107 @@ func TestInstallFilterWithConfig_UnknownOnBlockDegrades(t *testing.T) {
 	require.NoError(t, err, "unknown action must degrade, not error")
 	defer filt.Close()
 	require.Empty(t, filt.BlockListMap(), "unknown action must degrade to errno (no notify)")
+}
+
+func TestInstallFileMonitorRules_WriteOnlyOpenatUsesFlagConditions(t *testing.T) {
+	recorder := &recordingFileRuleAdder{}
+
+	added, err := installFileMonitorRules(recorder, seccomp.ActNotify, true)
+
+	require.NoError(t, err)
+	require.Greater(t, added, 0)
+	require.False(t, recorder.hasUnconditional(unix.SYS_OPENAT),
+		"write-only mode should not trap every openat")
+	require.True(t, recorder.hasUnconditional(unix.SYS_OPENAT2),
+		"openat2 flags live behind the open_how pointer, so the filter must keep trapping it")
+	require.True(t, recorder.hasUnconditional(unix.SYS_UNLINKAT),
+		"non-open mutating file syscalls must remain trapped")
+
+	openatConditions := recorder.conditionsFor(unix.SYS_OPENAT)
+	require.NotEmpty(t, openatConditions, "write-only mode should install conditional openat rules")
+	require.True(t, hasSingleCondition(openatConditions, maskedFlagCondition(2, unix.O_ACCMODE, unix.O_WRONLY)))
+	require.True(t, hasSingleCondition(openatConditions, maskedFlagCondition(2, unix.O_ACCMODE, unix.O_RDWR)))
+	require.True(t, hasSingleCondition(openatConditions, maskedFlagCondition(2, unix.O_CREAT, unix.O_CREAT)))
+	require.True(t, hasSingleCondition(openatConditions, maskedFlagCondition(2, unix.O_TRUNC, unix.O_TRUNC)))
+	require.True(t, hasSingleCondition(openatConditions, maskedFlagCondition(2, unix.O_APPEND, unix.O_APPEND)))
+	require.True(t, hasSingleCondition(openatConditions, maskedFlagCondition(2, unix.O_TMPFILE, unix.O_TMPFILE)))
+}
+
+func TestInstallFileMonitorRules_AllOpenModeTrapsOpenatUnconditionally(t *testing.T) {
+	recorder := &recordingFileRuleAdder{}
+
+	added, err := installFileMonitorRules(recorder, seccomp.ActNotify, false)
+
+	require.NoError(t, err)
+	require.Greater(t, added, 0)
+	require.True(t, recorder.hasUnconditional(unix.SYS_OPENAT))
+	require.Empty(t, recorder.conditionsFor(unix.SYS_OPENAT))
+}
+
+type recordingFileRuleAdder struct {
+	unconditional []recordedFileRule
+	conditional   []recordedFileConditionalRule
+}
+
+type recordedFileRule struct {
+	call   seccomp.ScmpSyscall
+	action seccomp.ScmpAction
+}
+
+type recordedFileConditionalRule struct {
+	call       seccomp.ScmpSyscall
+	action     seccomp.ScmpAction
+	conditions []seccomp.ScmpCondition
+}
+
+func (r *recordingFileRuleAdder) AddRule(call seccomp.ScmpSyscall, action seccomp.ScmpAction) error {
+	r.unconditional = append(r.unconditional, recordedFileRule{call: call, action: action})
+	return nil
+}
+
+func (r *recordingFileRuleAdder) AddRuleConditional(call seccomp.ScmpSyscall, action seccomp.ScmpAction, conditions []seccomp.ScmpCondition) error {
+	copied := append([]seccomp.ScmpCondition(nil), conditions...)
+	r.conditional = append(r.conditional, recordedFileConditionalRule{
+		call:       call,
+		action:     action,
+		conditions: copied,
+	})
+	return nil
+}
+
+func (r *recordingFileRuleAdder) hasUnconditional(nr int) bool {
+	for _, rule := range r.unconditional {
+		if rule.call == seccomp.ScmpSyscall(nr) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *recordingFileRuleAdder) conditionsFor(nr int) [][]seccomp.ScmpCondition {
+	var out [][]seccomp.ScmpCondition
+	for _, rule := range r.conditional {
+		if rule.call == seccomp.ScmpSyscall(nr) {
+			out = append(out, rule.conditions)
+		}
+	}
+	return out
+}
+
+func maskedFlagCondition(argument uint, mask, value int) seccomp.ScmpCondition {
+	return seccomp.ScmpCondition{
+		Argument: argument,
+		Op:       seccomp.CompareMaskedEqual,
+		Operand1: uint64(mask),
+		Operand2: uint64(value),
+	}
+}
+
+func hasSingleCondition(groups [][]seccomp.ScmpCondition, want seccomp.ScmpCondition) bool {
+	for _, conditions := range groups {
+		if len(conditions) == 1 && conditions[0] == want {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- Add `sandbox.seccomp.file_monitor.write_only_opens` and pass it through the wrapper config.
- Install conditional seccomp notify rules for `openat` and legacy `open` so read-only opens bypass user-notify when mutation-only monitoring is intended.
- Keep `openat2` trapped because seccomp-BPF cannot inspect its `open_how` pointer, and document the behavior in `docs/seccomp.md`.

Fixes #341.

## Validation
- `go test ./... -count=1`
- `GOOS=windows go build ./...`
- `gofmt -l cmd/agentsh-unixwrap/config.go cmd/agentsh-unixwrap/config_test.go cmd/agentsh-unixwrap/main.go internal/api/seccomp_wrapper_config.go internal/api/seccomp_wrapper_test.go internal/config/config.go internal/config/seccomp_test.go internal/netmonitor/unix/file_syscalls_legacy_amd64.go internal/netmonitor/unix/file_syscalls_legacy_other.go internal/netmonitor/unix/seccomp_linux.go internal/netmonitor/unix/seccomp_linux_test.go && git diff --check`
