### PR TITLE
fix(wrap): harden ebpf coverage

### DIFF
--- a/docs/ebpf.md
+++ b/docs/ebpf.md
@@ -13,6 +13,14 @@ agentsh can observe outbound TCP connections and, optionally, enforce per-sessio
 - Wildcard domains stay non-strict (default-deny disabled); an event `ebpf_enforce_non_strict` is emitted.
 - Domains are resolved and refreshed on a jittered interval bounded by `dns_max_ttl_seconds`; DNS cache is bounded.
 
+## `agentsh wrap`
+
+On Linux, `agentsh wrap` attaches the wrapped agent process tree to cgroup eBPF before `agentsh-unixwrap` is acknowledged and allowed to exec the real agent. This protects wrapped subprocesses even when they remove `HTTP_PROXY`, `HTTPS_PROXY`, or related proxy environment variables.
+
+This requires `sandbox.cgroups.enabled: true`. If `sandbox.network.ebpf.required: true` and cgroups or eBPF setup cannot complete, wrap setup fails before the real agent starts.
+
+Domain rules are still enforced by resolving literal domains to IP/port map entries in userspace. eBPF does not match domain strings in the kernel. Wildcard domains, shared CDN IPs, cached DNS answers, hosts-file entries, and DNS-over-HTTPS keep the same caveats described above.
+
 ## Configuration (config.yml)
 ```yaml
 sandbox:

--- a/docs/superpowers/plans/2026-05-16-wrap-ebpf-hardening.md
+++ b/docs/superpowers/plans/2026-05-16-wrap-ebpf-hardening.md
@@ -1,0 +1,1531 @@
+# Wrap eBPF Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden `agentsh wrap` so wrapped agents receive session network proxy env and, on Linux, cannot exec the real agent until cgroup/eBPF setup has succeeded or explicitly degraded according to config.
+
+**Architecture:** Keep proxy env injection in the CLI wrap launch path. Add a small Linux-only notify handoff helper package so the CLI, shim relay, and API agree on sending the seccomp notify fd plus wrapper PID metadata and receiving a server setup status. On the server, apply the existing cgroup/eBPF setup to the wrapper PID before acknowledging the wrapper, and clean it up when the notify handler exits.
+
+**Tech Stack:** Go, Unix domain sockets with `SCM_RIGHTS`, cgroup v2 manager, existing cgroup eBPF connect/sendmsg programs, existing `agentsh-unixwrap` ACK handshake.
+
+---
+
+## File Structure
+
+- Create `internal/wraphandoff/handoff_linux.go`
+  - Linux-only helper for forwarding notify fds with wrapper PID metadata and one-byte server status.
+
+- Create `internal/wraphandoff/handoff_linux_test.go`
+  - Unit tests for metadata round trip, legacy fd-only receive, and status read/write behavior.
+
+- Modify `internal/cli/wrap.go`
+  - Keep `sess.ProxyURL` in `runWrap`.
+  - Add and call a CLI env helper that injects network proxy variables.
+  - Change `wrapLaunchConfig.postStart` to receive the wrapper child PID.
+
+- Modify `internal/cli/wrap_linux.go`
+  - Forward wrapper PID metadata to the server.
+  - Wait for server setup success before ACKing `agentsh-unixwrap`.
+  - Keep signal fd forwarding on the legacy no-status path.
+
+- Modify `internal/cli/wrap_test.go`
+  - Add proxy env helper tests.
+  - Update postStart signature expectations where needed.
+
+- Modify `internal/shim/kernelinstall/install_linux.go`
+  - Use the same handoff helper for the shim notify relay.
+  - Wait for server success before ACKing the wrapper.
+
+- Modify `internal/shim/kernelinstall/install_linux_test.go`
+  - Add server-reject coverage proving the shim does not ACK the wrapper.
+
+- Modify `internal/api/wrap.go`
+  - Receive notify fd metadata.
+  - Reject required pre-ACK cgroup/eBPF setup when no wrapper PID is available.
+  - Write server setup status to the CLI/shim relay.
+
+- Modify `internal/api/wrap_linux.go`
+  - Add cleanup support to `startNotifyHandlerForWrap`.
+  - Apply cgroup/eBPF setup before the server success status is written.
+
+- Modify `internal/api/wrap_linux_test.go`
+  - Add metadata, server status, pre-ACK ordering, missing PID, and cleanup tests.
+
+- Modify `internal/api/cgroups.go`
+  - Treat eBPF-enabled setup as requiring a concrete cgroup, even when resource limits are empty.
+
+- Modify or create `internal/api/cgroups_test.go`
+  - Add focused tests for eBPF requiring a concrete cgroup.
+
+- Modify `docs/ebpf.md`
+  - Document `agentsh wrap` coverage and the cgroups requirement.
+
+---
+
+### Task 1: Add CLI Network Proxy Env For Wrap
+
+**Files:**
+- Modify: `internal/cli/wrap.go`
+- Modify: `internal/cli/wrap_test.go`
+
+- [ ] **Step 1: Write failing proxy env helper tests**
+
+Add these helpers near the existing `buildWrapEnv` tests in `internal/cli/wrap_test.go`:
+
+```go
+func envSliceToMap(env []string) map[string]string {
+	out := make(map[string]string, len(env))
+	for _, kv := range env {
+		k, v, ok := strings.Cut(kv, "=")
+		if ok {
+			out[k] = v
+		}
+	}
+	return out
+}
+```
+
+Add `strings` to the import block:
+
+```go
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/url"
+	"os"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/client"
+	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+```
+
+Add these tests:
+
+```go
+func TestAppendWrapNetworkProxyEnv_AddsSessionProxyVars(t *testing.T) {
+	env := appendWrapNetworkProxyEnv([]string{"PATH=/usr/bin"}, "http://127.0.0.1:18081")
+	got := envSliceToMap(env)
+
+	for _, key := range []string{
+		"HTTP_PROXY",
+		"HTTPS_PROXY",
+		"ALL_PROXY",
+		"http_proxy",
+		"https_proxy",
+		"all_proxy",
+	} {
+		assert.Equal(t, "http://127.0.0.1:18081", got[key], key)
+	}
+	assert.Contains(t, got["NO_PROXY"], "localhost")
+	assert.Contains(t, got["NO_PROXY"], "127.0.0.1")
+	assert.Equal(t, got["NO_PROXY"], got["no_proxy"])
+}
+
+func TestAppendWrapNetworkProxyEnv_ReplacesInheritedProxyVars(t *testing.T) {
+	env := appendWrapNetworkProxyEnv([]string{
+		"PATH=/usr/bin",
+		"HTTP_PROXY=http://stale",
+		"https_proxy=http://stale",
+		"NO_PROXY=example.test",
+	}, "http://127.0.0.1:18081")
+	got := envSliceToMap(env)
+
+	assert.Equal(t, "http://127.0.0.1:18081", got["HTTP_PROXY"])
+	assert.Equal(t, "http://127.0.0.1:18081", got["https_proxy"])
+	assert.Contains(t, got["NO_PROXY"], "example.test")
+	assert.Contains(t, got["NO_PROXY"], "localhost")
+	assert.Contains(t, got["NO_PROXY"], "127.0.0.1")
+}
+
+func TestAppendWrapNetworkProxyEnv_NoProxyWhenSessionProxyEmpty(t *testing.T) {
+	env := appendWrapNetworkProxyEnv([]string{
+		"PATH=/usr/bin",
+		"HTTP_PROXY=http://host-proxy",
+	}, "")
+	got := envSliceToMap(env)
+
+	assert.Equal(t, "http://host-proxy", got["HTTP_PROXY"])
+	assert.Equal(t, "/usr/bin", got["PATH"])
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+go test ./internal/cli -run 'TestAppendWrapNetworkProxyEnv' -count=1
+```
+
+Expected: compile failure because `appendWrapNetworkProxyEnv` does not exist.
+
+- [ ] **Step 3: Implement the proxy env helper**
+
+Add this helper after `buildWrapEnv` in `internal/cli/wrap.go`:
+
+```go
+func appendWrapNetworkProxyEnv(base []string, proxyURL string) []string {
+	if strings.TrimSpace(proxyURL) == "" {
+		return base
+	}
+
+	const noProxyDefault = "localhost,127.0.0.1"
+	proxyKeys := map[string]struct{}{
+		"HTTP_PROXY":  {},
+		"HTTPS_PROXY": {},
+		"ALL_PROXY":   {},
+		"http_proxy":  {},
+		"https_proxy": {},
+		"all_proxy":   {},
+		"NO_PROXY":    {},
+		"no_proxy":    {},
+	}
+
+	out := make([]string, 0, len(base)+8)
+	noProxy := ""
+	for _, e := range base {
+		key, val, found := strings.Cut(e, "=")
+		if !found {
+			out = append(out, e)
+			continue
+		}
+		if strings.EqualFold(key, "NO_PROXY") {
+			if noProxy == "" {
+				noProxy = val
+			}
+			continue
+		}
+		if _, ok := proxyKeys[key]; ok {
+			continue
+		}
+		out = append(out, e)
+	}
+
+	if noProxy == "" {
+		noProxy = noProxyDefault
+	} else {
+		if !strings.Contains(noProxy, "localhost") {
+			if !strings.HasSuffix(noProxy, ",") {
+				noProxy += ","
+			}
+			noProxy += "localhost"
+		}
+		if !strings.Contains(noProxy, "127.0.0.1") {
+			if !strings.HasSuffix(noProxy, ",") {
+				noProxy += ","
+			}
+			noProxy += "127.0.0.1"
+		}
+	}
+
+	out = append(out,
+		fmt.Sprintf("HTTP_PROXY=%s", proxyURL),
+		fmt.Sprintf("HTTPS_PROXY=%s", proxyURL),
+		fmt.Sprintf("ALL_PROXY=%s", proxyURL),
+		fmt.Sprintf("http_proxy=%s", proxyURL),
+		fmt.Sprintf("https_proxy=%s", proxyURL),
+		fmt.Sprintf("all_proxy=%s", proxyURL),
+		fmt.Sprintf("NO_PROXY=%s", noProxy),
+		fmt.Sprintf("no_proxy=%s", noProxy),
+	)
+	return out
+}
+```
+
+- [ ] **Step 4: Wire the helper into `runWrap`**
+
+In `internal/cli/wrap.go`, after this existing block:
+
+```go
+	sessID := sess.ID
+	workspaceMount := sess.WorkspaceMount
+	llmProxyURL := sess.LLMProxyURL
+```
+
+change it to:
+
+```go
+	sessID := sess.ID
+	workspaceMount := sess.WorkspaceMount
+	networkProxyURL := sess.ProxyURL
+	llmProxyURL := sess.LLMProxyURL
+```
+
+Then, after the direct/wrapper `agentProc` is created and before the FUSE mount env block, add:
+
+```go
+	agentProc.Env = appendWrapNetworkProxyEnv(agentProc.Env, networkProxyURL)
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+go test ./internal/cli -run 'TestAppendWrapNetworkProxyEnv|TestBuildWrapEnv' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/cli/wrap.go internal/cli/wrap_test.go
+git commit -m "fix(wrap): inject network proxy env"
+```
+
+---
+
+### Task 2: Add Linux Notify Handoff Helper
+
+**Files:**
+- Create: `internal/wraphandoff/handoff_linux.go`
+- Create: `internal/wraphandoff/handoff_linux_test.go`
+
+- [ ] **Step 1: Write failing handoff tests**
+
+Create `internal/wraphandoff/handoff_linux_test.go`:
+
+```go
+//go:build linux
+
+package wraphandoff
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func socketPairConns(t *testing.T) (*net.UnixConn, *net.UnixConn) {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "handoff.sock")
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	clientCh := make(chan *net.UnixConn, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		c, err := net.Dial("unix", path)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		clientCh <- c.(*net.UnixConn)
+	}()
+
+	serverConn, err := ln.Accept()
+	if err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+	var clientConn *net.UnixConn
+	select {
+	case clientConn = <-clientCh:
+	case err := <-errCh:
+		t.Fatalf("dial: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for client dial")
+	}
+
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+	return clientConn, serverConn.(*net.UnixConn)
+}
+
+func TestNotifyHandoffRoundTripWithWrapperPID(t *testing.T) {
+	client, server := socketPairConns(t)
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	go func() {
+		_ = SendNotifyFD(client, int(r.Fd()), Metadata{WrapperPID: 4321})
+	}()
+
+	fd, meta, hasMeta, err := RecvNotifyFD(server)
+	if err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	t.Cleanup(func() { _ = fd.Close() })
+	if !hasMeta {
+		t.Fatal("expected metadata")
+	}
+	if meta.WrapperPID != 4321 {
+		t.Fatalf("WrapperPID = %d, want 4321", meta.WrapperPID)
+	}
+}
+
+func TestSetupStatusRoundTrip(t *testing.T) {
+	client, server := socketPairConns(t)
+
+	go func() {
+		_ = WriteStatus(server, true)
+	}()
+	if err := ReadStatus(client); err != nil {
+		t.Fatalf("read success status: %v", err)
+	}
+
+	go func() {
+		_ = WriteStatus(server, false)
+	}()
+	if err := ReadStatus(client); err == nil {
+		t.Fatal("expected reject status error")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail**
+
+Run:
+
+```bash
+go test ./internal/wraphandoff -count=1
+```
+
+Expected: package or symbol missing errors.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `internal/wraphandoff/handoff_linux.go`:
+
+```go
+//go:build linux
+
+package wraphandoff
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	protocolMagic byte = 0xA7
+	StatusReject  byte = 0
+	StatusOK      byte = 1
+)
+
+type Metadata struct {
+	WrapperPID int
+}
+
+func SendNotifyFD(conn *net.UnixConn, notifyFD int, meta Metadata) error {
+	if conn == nil {
+		return errors.New("nil unix connection")
+	}
+	if notifyFD < 0 {
+		return fmt.Errorf("invalid notify fd %d", notifyFD)
+	}
+	payload := make([]byte, 5)
+	payload[0] = protocolMagic
+	binary.LittleEndian.PutUint32(payload[1:], uint32(meta.WrapperPID))
+	rights := unix.UnixRights(notifyFD)
+	_, _, err := conn.WriteMsgUnix(payload, rights, nil)
+	if err != nil {
+		return fmt.Errorf("send notify fd: %w", err)
+	}
+	return nil
+}
+
+func RecvNotifyFD(conn *net.UnixConn) (*os.File, Metadata, bool, error) {
+	if conn == nil {
+		return nil, Metadata{}, false, errors.New("nil unix connection")
+	}
+
+	buf := make([]byte, 16)
+	oob := make([]byte, unix.CmsgSpace(4))
+	n, oobn, _, _, err := conn.ReadMsgUnix(buf, oob)
+	if err != nil {
+		return nil, Metadata{}, false, fmt.Errorf("recvmsg: %w", err)
+	}
+	if n == 0 || oobn == 0 {
+		return nil, Metadata{}, false, fmt.Errorf("no fd received (n=%d, oobn=%d)", n, oobn)
+	}
+
+	msgs, err := unix.ParseSocketControlMessage(oob[:oobn])
+	if err != nil {
+		return nil, Metadata{}, false, fmt.Errorf("parse control message: %w", err)
+	}
+	fd := -1
+	for _, m := range msgs {
+		fds, err := unix.ParseUnixRights(&m)
+		if err != nil {
+			continue
+		}
+		if len(fds) > 0 {
+			fd = fds[0]
+			break
+		}
+	}
+	if fd < 0 {
+		return nil, Metadata{}, false, errors.New("no fd in control message")
+	}
+
+	meta := Metadata{}
+	hasMeta := n >= 5 && buf[0] == protocolMagic
+	if hasMeta {
+		meta.WrapperPID = int(binary.LittleEndian.Uint32(buf[1:5]))
+	}
+	return os.NewFile(uintptr(fd), "wrap-notif-fd"), meta, hasMeta, nil
+}
+
+func WriteStatus(w io.Writer, ok bool) error {
+	if w == nil {
+		return errors.New("nil writer")
+	}
+	b := StatusReject
+	if ok {
+		b = StatusOK
+	}
+	_, err := w.Write([]byte{b})
+	return err
+}
+
+func ReadStatus(r io.Reader) error {
+	if r == nil {
+		return errors.New("nil reader")
+	}
+	buf := []byte{0}
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return fmt.Errorf("read setup status: %w", err)
+	}
+	switch buf[0] {
+	case StatusOK:
+		return nil
+	case StatusReject:
+		return errors.New("server rejected wrap setup")
+	default:
+		return fmt.Errorf("unexpected setup status byte %d", buf[0])
+	}
+}
+```
+
+- [ ] **Step 4: Run helper tests**
+
+Run:
+
+```bash
+go test ./internal/wraphandoff -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/wraphandoff/handoff_linux.go internal/wraphandoff/handoff_linux_test.go
+git commit -m "internal: add wrap notify handoff protocol"
+```
+
+---
+
+### Task 3: Make CLI Notify Forwarding Wait For Server Setup
+
+**Files:**
+- Modify: `internal/cli/wrap.go`
+- Modify: `internal/cli/wrap_linux.go`
+- Modify: `internal/cli/wrap_test.go`
+
+- [ ] **Step 1: Update the launch config shape**
+
+In `internal/cli/wrap.go`, change:
+
+```go
+	postStart   func()    // Called after the process starts (e.g., to forward notify fd)
+```
+
+to:
+
+```go
+	postStart   func(childPID int) // Called after process start to forward notify fd with child PID
+```
+
+Then change the call site in `runWrap` from:
+
+```go
+		if wrapCfg.postStart != nil {
+			go wrapCfg.postStart()
+		}
+```
+
+to:
+
+```go
+		if wrapCfg.postStart != nil {
+			go wrapCfg.postStart(agentProc.Process.Pid)
+		}
+```
+
+- [ ] **Step 2: Update Linux forwarder to send PID and wait for status**
+
+In `internal/cli/wrap_linux.go`, add the import:
+
+```go
+	"github.com/agentsh/agentsh/internal/wraphandoff"
+```
+
+Change the notify `postStart` closure from:
+
+```go
+		postStart: func() {
+```
+
+to:
+
+```go
+		postStart: func(childPID int) {
+```
+
+Inside that closure, replace:
+
+```go
+			if err := forwardNotifyFD(notifySocket, notifyFD); err != nil {
+				slog.Error("wrap: failed to forward notify fd to server", "error", err, "session_id", sessID)
+				return
+			}
+			slog.Info("wrap: notify fd forwarded to server", "session_id", sessID, "socket", notifySocket)
+```
+
+with:
+
+```go
+			if err := forwardNotifyFDWithPID(notifySocket, notifyFD, childPID); err != nil {
+				slog.Error("wrap: failed to forward notify fd to server", "error", err, "session_id", sessID)
+				return
+			}
+			slog.Info("wrap: notify fd accepted by server", "session_id", sessID, "socket", notifySocket, "wrapper_pid", childPID)
+```
+
+Keep the existing wrapper ACK write after this block.
+
+- [ ] **Step 3: Add PID-aware forward helper**
+
+In `internal/cli/wrap_linux.go`, replace the existing `forwardNotifyFD` helper with two helpers:
+
+```go
+func forwardNotifyFDWithPID(socketPath string, notifyFD int, wrapperPID int) error {
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", socketPath, err)
+	}
+	defer conn.Close()
+
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return fmt.Errorf("not a unix connection")
+	}
+
+	if err := wraphandoff.SendNotifyFD(unixConn, notifyFD, wraphandoff.Metadata{WrapperPID: wrapperPID}); err != nil {
+		return err
+	}
+	if err := wraphandoff.ReadStatus(unixConn); err != nil {
+		return err
+	}
+	return nil
+}
+
+func forwardNotifyFD(socketPath string, notifyFD int) error {
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", socketPath, err)
+	}
+	defer conn.Close()
+
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return fmt.Errorf("not a unix connection")
+	}
+
+	file, err := unixConn.File()
+	if err != nil {
+		return fmt.Errorf("get file from connection: %w", err)
+	}
+	defer file.Close()
+
+	rights := unix.UnixRights(notifyFD)
+	if err := unix.Sendmsg(int(file.Fd()), []byte{0}, rights, nil, 0); err != nil {
+		return fmt.Errorf("sendmsg: %w", err)
+	}
+	return nil
+}
+```
+
+The legacy `forwardNotifyFD` remains for signal fd forwarding.
+
+- [ ] **Step 4: Add focused CLI forwarder tests**
+
+Add Linux-only tests in `internal/cli/wrap_linux_test.go`. If the file does not exist, create it:
+
+```go
+//go:build linux
+
+package cli
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/wraphandoff"
+)
+
+func TestForwardNotifyFDWithPIDWaitsForServerOK(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "notify.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	serverDone := make(chan struct{})
+	go func() {
+		defer close(serverDone)
+		conn, err := ln.Accept()
+		if err != nil {
+			t.Errorf("accept: %v", err)
+			return
+		}
+		defer conn.Close()
+		unixConn := conn.(*net.UnixConn)
+		fd, meta, hasMeta, err := wraphandoff.RecvNotifyFD(unixConn)
+		if err != nil {
+			t.Errorf("recv notify fd: %v", err)
+			return
+		}
+		_ = fd.Close()
+		if !hasMeta || meta.WrapperPID != 2468 {
+			t.Errorf("metadata = %+v, hasMeta=%v", meta, hasMeta)
+			return
+		}
+		_ = wraphandoff.WriteStatus(unixConn, true)
+	}()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	if err := forwardNotifyFDWithPID(socketPath, int(r.Fd()), 2468); err != nil {
+		t.Fatalf("forward: %v", err)
+	}
+	<-serverDone
+}
+
+func TestForwardNotifyFDWithPIDRejectStatusReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "notify.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		unixConn := conn.(*net.UnixConn)
+		fd, _, _, err := wraphandoff.RecvNotifyFD(unixConn)
+		if err == nil {
+			_ = fd.Close()
+		}
+		_ = wraphandoff.WriteStatus(unixConn, false)
+	}()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	if err := forwardNotifyFDWithPID(socketPath, int(r.Fd()), 2468); err == nil {
+		t.Fatal("expected reject status error")
+	}
+}
+```
+
+- [ ] **Step 5: Run focused tests**
+
+Run:
+
+```bash
+go test ./internal/cli -run 'TestForwardNotifyFDWithPID|TestSetupWrapInterception|TestWrapLaunchConfig' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/cli/wrap.go internal/cli/wrap_linux.go internal/cli/wrap_linux_test.go internal/cli/wrap_test.go
+git commit -m "fix(wrap): wait for server notify setup"
+```
+
+---
+
+### Task 4: Update Shim Relay To Use Server Setup Status
+
+**Files:**
+- Modify: `internal/shim/kernelinstall/install_linux.go`
+- Modify: `internal/shim/kernelinstall/install_linux_test.go`
+
+- [ ] **Step 1: Update shim forward helper to send wrapper PID**
+
+In `internal/shim/kernelinstall/install_linux.go`, add:
+
+```go
+	"github.com/agentsh/agentsh/internal/wraphandoff"
+```
+
+Replace:
+
+```go
+	if fwdErr := forwardNotifyFD(notifySocket, notifyFD); fwdErr != nil {
+```
+
+with:
+
+```go
+	if fwdErr := forwardNotifyFDWithPID(notifySocket, notifyFD, cmd.Process.Pid); fwdErr != nil {
+```
+
+Replace the existing `forwardNotifyFD` helper with:
+
+```go
+func forwardNotifyFDWithPID(socketPath string, notifyFD int, wrapperPID int) error {
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", socketPath, err)
+	}
+	defer conn.Close()
+
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return fmt.Errorf("not a unix connection")
+	}
+
+	if err := wraphandoff.SendNotifyFD(unixConn, notifyFD, wraphandoff.Metadata{WrapperPID: wrapperPID}); err != nil {
+		return err
+	}
+	if err := wraphandoff.ReadStatus(unixConn); err != nil {
+		return err
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: Add shim server-reject test**
+
+Add a test near `TestInstall_RelayForwardFail_NoACK_ResultFailClosed` in `internal/shim/kernelinstall/install_linux_test.go`:
+
+```go
+func TestInstall_RelayServerReject_NoACK_ResultFailClosed(t *testing.T) {
+	wrapperBin := buildFakeWrapperNoACKExit(t)
+
+	notifyDir := t.TempDir()
+	notifySocket := filepath.Join(notifyDir, "notify.sock")
+	ln, err := net.Listen("unix", notifySocket)
+	if err != nil {
+		t.Fatalf("listen notify socket: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		unixConn := conn.(*net.UnixConn)
+		fd, _, _, err := wraphandoff.RecvNotifyFD(unixConn)
+		if err == nil {
+			_ = fd.Close()
+		}
+		_ = wraphandoff.WriteStatus(unixConn, false)
+	}()
+
+	wrapResp := types.WrapInitResponse{
+		WrapperBinary: wrapperBin,
+		NotifySocket:  notifySocket,
+		WrapperEnv:    map[string]string{},
+	}
+	handler, _ := makeWrapInitHandler(200, wrapResp)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	p := baseParams(srv)
+	p.Mode = ModeOn
+
+	res, err := Install(p)
+	if err != nil {
+		t.Fatalf("Install returned error: %v", err)
+	}
+	if res.Action != ResultFailClosed {
+		t.Fatalf("expected ResultFailClosed, got %v (reason: %s)", res.Action, res.Reason)
+	}
+	if !strings.Contains(res.Reason, "server rejected wrap setup") {
+		t.Fatalf("expected server rejection in reason, got %q", res.Reason)
+	}
+}
+```
+
+Add imports if missing:
+
+```go
+	"net"
+	"path/filepath"
+
+	"github.com/agentsh/agentsh/internal/wraphandoff"
+```
+
+- [ ] **Step 3: Run focused shim tests**
+
+Run:
+
+```bash
+go test ./internal/shim/kernelinstall -run 'TestInstall_RelayForwardFail_NoACK_ResultFailClosed|TestInstall_RelayServerReject_NoACK_ResultFailClosed' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/shim/kernelinstall/install_linux.go internal/shim/kernelinstall/install_linux_test.go
+git commit -m "fix(shim): wait for wrap setup status"
+```
+
+---
+
+### Task 5: Server Receives Wrapper PID And Applies Pre-ACK Cgroup Setup
+
+**Files:**
+- Modify: `internal/api/wrap.go`
+- Modify: `internal/api/wrap_linux.go`
+- Modify: `internal/api/wrap_linux_test.go`
+
+- [ ] **Step 1: Add cgroup setup hook and helper**
+
+In `internal/api/wrap.go`, near `startNotifyHandlerForWrapHook`, add:
+
+```go
+	wrapCgroupSetupForNotifyHook = defaultWrapCgroupSetupForNotify
+```
+
+Add this helper near `acceptNotifyFD`:
+
+```go
+func wrapNeedsCgroupBeforeAck(a *App, s *session.Session) bool {
+	if a == nil || a.cfg == nil {
+		return false
+	}
+	if a.cfg.Sandbox.Network.EBPF.Required {
+		return true
+	}
+	if !a.cfg.Sandbox.Cgroups.Enabled {
+		return false
+	}
+	if a.cfg.Sandbox.Network.EBPF.Enabled || a.cfg.Sandbox.Network.EBPF.Enforce {
+		return true
+	}
+	engine := a.policyEngineFor(s)
+	if engine == nil {
+		return false
+	}
+	lim := engine.Limits()
+	return lim.MaxMemoryMB > 0 || lim.CPUQuotaPercent > 0 || lim.PidsMax > 0
+}
+
+func defaultWrapCgroupSetupForNotify(ctx context.Context, a *App, s *session.Session, sessionID string, wrapperPID int) (func() error, error) {
+	if !wrapNeedsCgroupBeforeAck(a, s) {
+		return nil, nil
+	}
+	if wrapperPID <= 0 {
+		return nil, fmt.Errorf("wrap cgroup setup requires wrapper pid")
+	}
+	if a.cfg.Sandbox.Network.EBPF.Required && !a.cfg.Sandbox.Cgroups.Enabled {
+		return nil, fmt.Errorf("ebpf required but sandbox.cgroups.enabled=false")
+	}
+	if !a.cfg.Sandbox.Cgroups.Enabled {
+		return nil, nil
+	}
+
+	engine := a.policyEngineFor(s)
+	lim := policy.Limits{}
+	if engine != nil {
+		lim = engine.Limits()
+	}
+	cmdID := "wrap-" + uuid.NewString()
+	em := storeEmitter{store: a.store, broker: a.broker}
+	return applyCgroupV2(ctx, em, a, sessionID, cmdID, wrapperPID, lim, a.metrics, engine)
+}
+```
+
+Ensure `internal/api/wrap.go` imports `github.com/google/uuid` and already has `fmt`, `context`, `session`, and `policy` available. If `policy` is not imported in this file, add:
+
+```go
+	"github.com/agentsh/agentsh/internal/policy"
+```
+
+- [ ] **Step 2: Change notify handler signature to accept cleanup**
+
+In `internal/api/wrap_linux.go`, change:
+
+```go
+func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session) {
+```
+
+to:
+
+```go
+func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) {
+```
+
+Inside the goroutine, after the existing `defer notifyFD.Close()`, add:
+
+```go
+		if cleanup != nil {
+			defer func() {
+				if err := cleanup(); err != nil {
+					slog.Warn("wrap: cgroup cleanup failed", "session_id", sessionID, "error", err)
+				}
+			}()
+		}
+```
+
+Update the Windows and other platform stubs to accept the same `cleanup func() error` argument.
+
+- [ ] **Step 3: Use the new handoff receive path in `acceptNotifyFD`**
+
+In `internal/api/wrap.go`, add:
+
+```go
+	"github.com/agentsh/agentsh/internal/wraphandoff"
+```
+
+Replace the block that calls `unixConn.File()` and `recvFDFromConn(file)` with:
+
+```go
+	notifyFD, meta, hasMeta, err := wraphandoff.RecvNotifyFD(unixConn)
+	if err != nil {
+		slog.Debug("wrap: failed to receive notify fd", "session_id", sessionID, "error", err)
+		_ = wraphandoff.WriteStatus(unixConn, false)
+		return
+	}
+	if notifyFD == nil {
+		slog.Debug("wrap: received nil notify fd", "session_id", sessionID)
+		_ = wraphandoff.WriteStatus(unixConn, false)
+		return
+	}
+
+	wrapperPID := notifyPeerPID
+	if hasMeta && meta.WrapperPID > 0 {
+		wrapperPID = meta.WrapperPID
+	}
+
+	var cleanup func() error
+	if wrapNeedsCgroupBeforeAck(a, s) {
+		if !hasMeta || meta.WrapperPID <= 0 {
+			_ = notifyFD.Close()
+			_ = wraphandoff.WriteStatus(unixConn, false)
+			slog.Warn("wrap: rejecting notify setup without wrapper pid", "session_id", sessionID)
+			return
+		}
+		cleanup, err = wrapCgroupSetupForNotifyHook(ctx, a, s, sessionID, wrapperPID)
+		if err != nil {
+			_ = notifyFD.Close()
+			_ = wraphandoff.WriteStatus(unixConn, false)
+			slog.Warn("wrap: cgroup setup failed before wrapper ACK", "session_id", sessionID, "wrapper_pid", wrapperPID, "error", err)
+			return
+		}
+	}
+
+	slog.Info("wrap: received notify fd", "session_id", sessionID, "fd", notifyFD.Fd(), "wrapper_pid", wrapperPID)
+
+	startNotifyHandlerForWrapHook(ctx, notifyFD, sessionID, a, execveEnabled, wrapperPID, s, cleanup)
+	if err := wraphandoff.WriteStatus(unixConn, true); err != nil {
+		slog.Debug("wrap: failed to write setup status", "session_id", sessionID, "error", err)
+	}
+```
+
+Remove the old `startNotifyHandlerForWrapHook(ctx, notifyFD, sessionID, a, execveEnabled, notifyPeerPID, s)` call.
+
+- [ ] **Step 4: Update test hook signatures**
+
+In `internal/api/wrap_linux_test.go`, update `withNotifyHandoffHook`:
+
+```go
+func withNotifyHandoffHook(t *testing.T) chan struct{} {
+	t.Helper()
+
+	called := make(chan struct{})
+	prev := startNotifyHandlerForWrapHook
+	startNotifyHandlerForWrapHook = func(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) {
+		if cleanup != nil {
+			_ = cleanup()
+		}
+		if notifyFD != nil {
+			_ = notifyFD.Close()
+		}
+		close(called)
+	}
+	t.Cleanup(func() {
+		startNotifyHandlerForWrapHook = prev
+	})
+	return called
+}
+```
+
+- [ ] **Step 5: Add server metadata and ordering tests**
+
+Add this test to `internal/api/wrap_linux_test.go`:
+
+```go
+func TestAcceptNotifyFD_UsesMetadataWrapperPIDForCgroupBeforeAck(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Network.EBPF.Enabled = true
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	prevSetup := wrapCgroupSetupForNotifyHook
+	prevStart := startNotifyHandlerForWrapHook
+	setupCalled := make(chan int, 1)
+	startCalled := make(chan struct{})
+	wrapCgroupSetupForNotifyHook = func(ctx context.Context, a *App, s *session.Session, sessionID string, wrapperPID int) (func() error, error) {
+		setupCalled <- wrapperPID
+		return func() error { return nil }, nil
+	}
+	startNotifyHandlerForWrapHook = func(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) {
+		_ = notifyFD.Close()
+		if cleanup != nil {
+			_ = cleanup()
+		}
+		close(startCalled)
+	}
+	t.Cleanup(func() {
+		wrapCgroupSetupForNotifyHook = prevSetup
+		startNotifyHandlerForWrapHook = prevStart
+	})
+
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "notify.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptNotifyFD(context.Background(), listener, socketPath, s.ID, s, false, 0, false)
+	}()
+
+	conn := dialUnixConn(t, socketPath)
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = pipeR.Close()
+		_ = pipeW.Close()
+	})
+
+	if err := wraphandoff.SendNotifyFD(conn, int(pipeR.Fd()), wraphandoff.Metadata{WrapperPID: 7777}); err != nil {
+		t.Fatalf("send handoff: %v", err)
+	}
+	if err := wraphandoff.ReadStatus(conn); err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+
+	if got := <-setupCalled; got != 7777 {
+		t.Fatalf("cgroup setup pid = %d, want 7777", got)
+	}
+	<-startCalled
+	waitForTestDone(t, done)
+}
+```
+
+Add this rejection test:
+
+```go
+func TestAcceptNotifyFD_RejectsMissingMetadataWhenEBPFRequired(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Network.EBPF.Enabled = true
+	cfg.Sandbox.Network.EBPF.Required = true
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	called := withNotifyHandoffHook(t)
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "notify.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptNotifyFD(context.Background(), listener, socketPath, s.ID, s, false, 0, false)
+	}()
+
+	conn := dialUnixConn(t, socketPath)
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = pipeR.Close()
+		_ = pipeW.Close()
+	})
+
+	sendFDOverUnixConn(t, conn, int(pipeR.Fd()))
+	if err := wraphandoff.ReadStatus(conn); err == nil {
+		t.Fatal("expected server rejection status")
+	}
+
+	select {
+	case <-called:
+		t.Fatal("notify handler should not start")
+	default:
+	}
+	waitForTestDone(t, done)
+}
+```
+
+Add imports if missing:
+
+```go
+	"github.com/agentsh/agentsh/internal/wraphandoff"
+```
+
+- [ ] **Step 6: Run focused API tests**
+
+Run:
+
+```bash
+go test ./internal/api -run 'TestAcceptNotifyFD' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/api/wrap.go internal/api/wrap_linux.go internal/api/wrap_windows.go internal/api/wrap_other.go internal/api/wrap_linux_test.go
+git commit -m "fix(wrap): attach cgroup before wrapper ack"
+```
+
+---
+
+### Task 6: Require Concrete Cgroup For eBPF Setup
+
+**Files:**
+- Modify: `internal/api/cgroups.go`
+- Modify or create: `internal/api/cgroups_test.go`
+
+- [ ] **Step 1: Write failing tests for eBPF with no cgroup manager**
+
+Create `internal/api/cgroups_test.go` if it does not exist:
+
+```go
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/events"
+	"github.com/agentsh/agentsh/internal/limits"
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/store/composite"
+)
+
+func TestApplyCgroupV2_EBPFEnabledRequiresCgroupManager(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Network.EBPF.Enabled = true
+
+	app := NewApp(
+		cfg,
+		session.NewManager(1),
+		composite.New(mockEventStore{}, nil),
+		nil,
+		events.NewBroker(),
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	_, err := applyCgroupV2(context.Background(), storeEmitter{store: app.store, broker: app.broker}, app, "sess", "cmd", 1234, policy.Limits{}, nil, nil)
+	if err == nil {
+		t.Fatal("expected error when ebpf is enabled without cgroup manager")
+	}
+	var unavailable *limits.CgroupUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("expected CgroupUnavailableError, got %T: %v", err, err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test and verify it fails**
+
+Run:
+
+```bash
+go test ./internal/api -run 'TestApplyCgroupV2_EBPFEnabledRequiresCgroupManager' -count=1
+```
+
+Expected: FAIL because current code returns a no-op cleanup when limits are empty.
+
+- [ ] **Step 3: Update `applyCgroupV2`**
+
+In `internal/api/cgroups.go`, after `cgLimits` is built, add:
+
+```go
+	needsConcreteCgroup := !cgLimits.IsEmpty() || ebpfEnabled
+```
+
+Replace:
+
+```go
+	if app.cgroupMgr == nil {
+		if cgLimits.IsEmpty() {
+			return func() error { return nil }, nil
+		}
+		return nil, &limits.CgroupUnavailableError{
+			Reason: "cgroup manager not initialized",
+			Limits: cgLimits,
+		}
+	}
+```
+
+with:
+
+```go
+	if app.cgroupMgr == nil {
+		if !needsConcreteCgroup {
+			return func() error { return nil }, nil
+		}
+		return nil, &limits.CgroupUnavailableError{
+			Reason: "cgroup manager not initialized",
+			Limits: cgLimits,
+		}
+	}
+```
+
+Replace:
+
+```go
+	// If unavailable mode allowed us (empty limits), cg is nil. Treat as no-op.
+	if cg == nil {
+		return func() error { return nil }, nil
+	}
+```
+
+with:
+
+```go
+	// If unavailable mode allowed us with no concrete cgroup need, treat as no-op.
+	if cg == nil {
+		if needsConcreteCgroup {
+			return nil, &limits.CgroupUnavailableError{
+				Reason: "cgroup manager returned no cgroup",
+				Limits: cgLimits,
+			}
+		}
+		return func() error { return nil }, nil
+	}
+```
+
+- [ ] **Step 4: Run focused cgroup tests**
+
+Run:
+
+```bash
+go test ./internal/api -run 'TestApplyCgroupV2_EBPFEnabledRequiresCgroupManager|TestEBPF' -count=1
+```
+
+Expected: PASS or eBPF integration tests skip when unsupported.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/api/cgroups.go internal/api/cgroups_test.go
+git commit -m "fix(ebpf): require cgroup for ebpf setup"
+```
+
+---
+
+### Task 7: Document Wrap eBPF Semantics
+
+**Files:**
+- Modify: `docs/ebpf.md`
+
+- [ ] **Step 1: Update eBPF docs**
+
+In `docs/ebpf.md`, after the "Enforcement model" section, add:
+
+```markdown
+## `agentsh wrap`
+
+On Linux, `agentsh wrap` attaches the wrapped agent process tree to cgroup eBPF before `agentsh-unixwrap` is acknowledged and allowed to exec the real agent. This protects wrapped subprocesses even when they remove `HTTP_PROXY`, `HTTPS_PROXY`, or related proxy environment variables.
+
+This requires `sandbox.cgroups.enabled: true`. If `sandbox.network.ebpf.required: true` and cgroups or eBPF setup cannot complete, wrap setup fails before the real agent starts.
+
+Domain rules are still enforced by resolving literal domains to IP/port map entries in userspace. eBPF does not match domain strings in the kernel. Wildcard domains, shared CDN IPs, cached DNS answers, hosts-file entries, and DNS-over-HTTPS keep the same caveats described above.
+```
+
+- [ ] **Step 2: Run docs grep to verify wording**
+
+Run:
+
+```bash
+rg -n "agentsh wrap|sandbox.cgroups.enabled|domain strings" docs/ebpf.md
+```
+
+Expected: output includes the new `agentsh wrap` section and cgroups requirement.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/ebpf.md
+git commit -m "docs: describe wrap ebpf coverage"
+```
+
+---
+
+### Task 8: Full Verification
+
+**Files:**
+- No source changes unless verification exposes a regression.
+
+- [ ] **Step 1: Run focused package tests**
+
+Run:
+
+```bash
+go test ./internal/wraphandoff ./internal/cli ./internal/api ./internal/shim/kernelinstall -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run full Go tests**
+
+Run:
+
+```bash
+go test ./...
+```
+
+Expected: PASS. If long-running integration tests skip due missing platform capabilities, confirm the skip message is expected.
+
+- [ ] **Step 3: Verify Windows compilation**
+
+Run:
+
+```bash
+GOOS=windows go build ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Verify macOS compilation**
+
+Run:
+
+```bash
+GOOS=darwin go build ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff --stat HEAD
+```
+
+Expected: only files from this plan are modified. Existing unrelated dirty files from before this work should remain untouched and should not be included in commits.
+
+- [ ] **Step 6: Optional privileged eBPF smoke test**
+
+Run only on a Linux host with writable cgroup v2 and eBPF permissions:
+
+```bash
+go test ./internal/api -run TestEBPFConnectEventFlow -count=1
+```
+
+Expected: PASS or skip with a clear eBPF/cgroup capability message.
+
+- [ ] **Step 7: Final commit if verification required changes**
+
+If verification forced fixes, commit them:
+
+```bash
+git add internal/wraphandoff internal/cli internal/api internal/shim/kernelinstall docs/ebpf.md
+git commit -m "test: verify wrap ebpf hardening"
+```
+
+Skip this commit if there were no additional changes after Task 7.
+
+---
+
+## Plan Self-Review
+
+- Spec coverage: the plan covers proxy env injection, PID metadata handoff, server setup status, pre-ACK cgroup/eBPF attach, cleanup, cgroup requirement tightening, docs, and verification.
+- Placeholder scan: no steps use unresolved markers or open-ended test instructions without code.
+- Type consistency: `wraphandoff.Metadata`, `SendNotifyFD`, `RecvNotifyFD`, `WriteStatus`, and `ReadStatus` are introduced before other tasks use them.
+- Scope: DNS syscall interception is excluded, matching the approved design.

--- a/docs/superpowers/specs/2026-05-16-wrap-ebpf-hardening-design.md
+++ b/docs/superpowers/specs/2026-05-16-wrap-ebpf-hardening-design.md
@@ -1,0 +1,318 @@
+# Wrap eBPF Hardening - Design Spec
+
+**Date:** 2026-05-16
+**Status:** Approved
+**Author:** design session between Eran Sandler and Codex
+
+## Problem
+
+Issue #343 reports that domain-based `network_rules` can be bypassed under
+`agentsh wrap` when a wrapped process or subprocess removes `HTTP_PROXY`,
+`HTTPS_PROXY`, or related proxy environment variables.
+
+The report is directionally correct, and the local code shows the gap is
+broader than child env stripping:
+
+- `agentsh exec` injects the session network proxy into command env.
+- `agentsh wrap` only injects LLM base URLs and does not inject the session
+  network proxy env.
+- eBPF network enforcement is attached through the exec cgroup hook.
+- the Linux wrap path starts the seccomp notify handler but never moves the
+  wrapped agent tree into a cgroup with eBPF attached.
+
+As a result, a direct network connection from a wrapped process may bypass the
+proxy and avoid domain-based policy evaluation. CIDR and port rules remain
+enforceable only through mechanisms that see the final IP/port.
+
+## Goal
+
+Make `agentsh wrap` use the same two-layer network posture as `agentsh exec`
+for this issue:
+
+1. normal HTTP clients receive the session network proxy env; and
+2. the wrapped agent process tree is attached to cgroup/eBPF before the real
+   agent is allowed to exec.
+
+This should close the proxy-env bypass for `agentsh wrap` without adding DNS
+syscall parsing in this change.
+
+## Non-Goals
+
+- Do not implement DNS packet parsing or DNS syscall interception.
+- Do not implement native domain matching inside the BPF program.
+- Do not change the policy language.
+- Do not redesign the LLM proxy env behavior.
+- Do not change macOS or Windows wrap behavior beyond preserving existing
+  build compatibility.
+
+## Current Architecture
+
+### Exec path
+
+`internal/api/exec.go` builds the command env with `buildPolicyEnv`. When
+`Session.ProxyURL()` is present, it sets:
+
+- `HTTP_PROXY`
+- `HTTPS_PROXY`
+- `ALL_PROXY`
+- `http_proxy`
+- `https_proxy`
+- `all_proxy`
+- `NO_PROXY`
+- `no_proxy`
+
+The exec path also calls `a.cgroupHook(...)`, which delegates to
+`applyCgroupV2`. That function creates a per-command cgroup and, when
+configured, attaches the existing cgroup eBPF connect/sendmsg programs.
+
+### Wrap path
+
+`internal/cli/wrap.go` fetches or creates a session and keeps
+`sess.LLMProxyURL`, but does not keep or apply `sess.ProxyURL`.
+
+On Linux, `internal/cli/wrap_linux.go` starts `agentsh-unixwrap`, passes it a
+socketpair, and starts a `postStart` goroutine. The wrapper installs seccomp
+notify, sends the notify fd to the CLI over the socketpair, and then waits for
+an ACK from the CLI before execing the real agent.
+
+The CLI forwards the notify fd to the server over the `wrap-init` Unix socket.
+The server receives the fd in `internal/api/wrap.go` and starts
+`startNotifyHandlerForWrap`. Today the server sees the CLI process as the Unix
+socket peer, not the wrapper child PID, so it cannot attach the correct process
+to a cgroup.
+
+## Recommended Design
+
+### 1. Inject network proxy env in `agentsh wrap`
+
+Extend the wrap env construction so the CLI keeps `sess.ProxyURL` and appends
+the same network proxy variables that `agentsh exec` uses.
+
+The env helper should be local to the CLI package unless a clean shared helper
+already exists at implementation time. It should:
+
+- remove stale proxy keys from the inherited environment before appending
+  session-controlled values;
+- set uppercase and lowercase proxy variables to `sess.ProxyURL`;
+- preserve existing `NO_PROXY` / `no_proxy` values where possible;
+- ensure `localhost,127.0.0.1` are present in both `NO_PROXY` and `no_proxy`;
+- keep LLM proxy env handling separate from network proxy env handling.
+
+This layer is for compatibility and observability. It is not treated as the
+security boundary.
+
+### 2. Add a server-acknowledged notify-fd handshake
+
+Change the Linux notify-fd forwarding protocol between the CLI and server.
+
+The CLI should send the seccomp notify fd together with metadata containing the
+`agentsh-unixwrap` child PID. After sending, the CLI must wait for a one-byte
+server response:
+
+- `1`: server finished pre-ACK setup and started the notify handler;
+- `0`: server rejected setup.
+
+Only after receiving `1` may the CLI ACK `agentsh-unixwrap`. If the server
+rejects setup or the response is missing, the CLI must not ACK the wrapper.
+The wrapper will fail before execing the real agent, which is the desired
+fail-closed behavior for this setup phase.
+
+The protocol should remain compatible with existing shim forwarding paths:
+
+- if no metadata is present, the server may continue without wrap eBPF attach
+  when eBPF is disabled;
+- if cgroup/eBPF attach is required but no wrapper PID is provided, the server
+  should reject setup before the wrapper ACK.
+
+### 3. Attach cgroup/eBPF before wrapper ACK
+
+After the server receives the notify fd and wrapper PID, it should apply the
+existing cgroup/eBPF setup to the wrapper PID before it tells the CLI to ACK
+the wrapper.
+
+The server-side order should be:
+
+1. receive notify fd and metadata;
+2. validate wrapper PID is positive;
+3. create a per-wrap command ID, such as `wrap-<short-uuid>`;
+4. apply the cgroup/eBPF hook to the wrapper PID;
+5. start the seccomp notify handler;
+6. write success to the CLI connection;
+7. clean up the cgroup/eBPF resources when the notify handler exits.
+
+Because `agentsh-unixwrap` waits for the CLI ACK before execing the real agent,
+this avoids a window where the agent could connect before eBPF is attached.
+Child processes inherit the wrapper's cgroup, so the whole wrapped process tree
+is covered.
+
+### 4. Make eBPF-enabled cgroup creation explicit
+
+`applyCgroupV2` currently treats empty resource limits as a reason to skip
+cgroup creation when cgroup enforcement is unavailable. That is acceptable for
+pure resource limits but not for eBPF, because eBPF attach requires a cgroup
+even when memory/CPU/PID limits are zero.
+
+Update this path so `sandbox.network.ebpf.enabled=true` is considered a reason
+to require a concrete cgroup. If cgroups are unavailable and eBPF is required,
+the caller should fail closed. If eBPF is merely enabled but not required, the
+current non-required behavior may continue to degrade with an event, but it
+must not silently imply that wrap is protected.
+
+This change benefits both `exec` and `wrap` and prevents false-positive eBPF
+configuration.
+
+### 5. Keep failure semantics explicit
+
+For `agentsh wrap`:
+
+- if cgroups/eBPF are disabled, existing wrap behavior continues plus proxy env
+  injection when `ProxyURL` is set;
+- if eBPF attach succeeds, the wrapper is ACKed and the agent starts;
+- if eBPF is required and attach fails, the server rejects the setup and the
+  wrapper is not ACKed;
+- if cgroups are unavailable and eBPF is required, the wrapper is not ACKed;
+- if cgroups/eBPF are optional and attach fails, emit the same style of
+  `ebpf_unavailable` or `ebpf_attach_failed` event used by exec and continue
+  only when the existing config semantics allow it.
+
+## Domain Enforcement Notes
+
+This design does not make BPF match domain strings. The current BPF program
+sees IP address, port, protocol, and cgroup ID. Domain-based rules are mapped
+to IP/port entries by resolving literal domains in userspace and refreshing
+those entries on a configured interval.
+
+That means:
+
+- literal domain rules can be enforced as resolved IP/port maps;
+- wildcard domains remain non-strict;
+- shared CDN IPs and fast-changing DNS still have the usual IP-mapping caveats;
+- DNS-over-HTTPS, DNS-over-TLS, `/etc/hosts`, cached results, and hardcoded IPs
+  are not solved by DNS syscall interception in this change.
+
+The reason this still fixes #343 is that a process which strips proxy env no
+longer gets an unmonitored direct connect path under `agentsh wrap`; eBPF sees
+the final connect attempt from the wrapped cgroup.
+
+## Files Expected To Change
+
+- `internal/cli/wrap.go`
+  - keep `sess.ProxyURL`;
+  - append network proxy env for wrapped agents.
+
+- `internal/cli/wrap_linux.go`
+  - send wrapper PID metadata with the notify fd;
+  - wait for server success before ACKing `agentsh-unixwrap`.
+
+- `internal/shim/kernelinstall/install_linux.go`
+  - preserve compatibility with the server's notify handshake, or update the
+    shim relay to send equivalent PID metadata when feasible.
+
+- `internal/api/wrap.go`
+  - receive notify fd metadata;
+  - reject required eBPF setup when no wrapper PID is available;
+  - coordinate server response to the CLI.
+
+- `internal/api/wrap_linux.go`
+  - apply cgroup/eBPF setup to the wrapper PID before starting the notify
+    handler or before acknowledging success;
+  - clean up cgroup/eBPF resources when the notify handler exits.
+
+- `internal/api/cgroups.go`
+  - treat eBPF-enabled setup as requiring a concrete cgroup, not only resource
+    limits.
+
+- Tests under `internal/cli`, `internal/api`, and `internal/shim/kernelinstall`.
+
+- Docs under `docs/ebpf.md` or `docs/security-modes.md`.
+
+## Test Strategy
+
+### Unit tests
+
+- `internal/cli`
+  - `buildWrapEnv` or the new helper adds network proxy env from `ProxyURL`.
+  - inherited stale proxy env is replaced by the session proxy.
+  - existing `NO_PROXY` is preserved and extended with localhost entries.
+  - LLM proxy env remains separate from network proxy env.
+  - Linux notify forwarding waits for server success before wrapper ACK.
+  - Linux notify forwarding returns an error on server rejection.
+
+- `internal/api`
+  - notify fd receiver parses wrapper PID metadata.
+  - missing PID is accepted only when cgroup/eBPF setup is not required.
+  - required eBPF with missing PID rejects setup.
+  - cgroup/eBPF setup is called with the wrapper PID before success is written.
+  - cleanup returned by the cgroup/eBPF setup runs when the notify handler
+    exits.
+  - `applyCgroupV2` requires a concrete cgroup when eBPF is enabled.
+
+- `internal/shim/kernelinstall`
+  - relay forwarding remains compatible with the server handshake.
+
+### Integration or best-effort tests
+
+Where the environment supports cgroup v2 and eBPF:
+
+- run a wrapped process that strips proxy env and attempts a direct TCP
+  connection;
+- verify a `net_connect` or blocked event is emitted from eBPF;
+- verify the connection is denied when policy-derived BPF maps deny it.
+
+These tests should skip when eBPF or writable cgroups are unavailable.
+
+## Rollout
+
+This is a Linux-only hardening change for the wrap path. Non-Linux builds must
+continue to compile with stubs unchanged.
+
+The safest rollout sequence is:
+
+1. add proxy env injection tests and implementation;
+2. add the server-acknowledged notify-fd protocol tests and implementation;
+3. add cgroup/eBPF pre-ACK attach tests and implementation;
+4. tighten `applyCgroupV2` behavior for eBPF-enabled setup;
+5. add docs and best-effort integration coverage.
+
+Each step can be committed independently.
+
+## Open Constraints
+
+- The implementation must not rely on `/tmp`; use `os.TempDir()` or existing
+  helpers for temporary paths.
+- Path construction must use `filepath.Join`.
+- Windows and macOS builds must remain green.
+- The server must not trust the Unix socket peer PID for the wrapper PID,
+  because the peer is the CLI relay process.
+- The CLI must not ACK `agentsh-unixwrap` until the server has completed the
+  cgroup/eBPF setup decision.
+
+## Alternatives Considered
+
+### Proxy env only
+
+Rejected as the complete fix. It improves normal client behavior but remains
+bypassable by clearing env.
+
+### eBPF/cgroup only
+
+Rejected as the complete fix. It provides the hard enforcement layer but misses
+the compatibility and observability benefits of proxy env injection for normal
+HTTP clients.
+
+### DNS syscall interception in this change
+
+Rejected for this issue scope. DNS syscall interception helps attribution and
+can improve domain policy behavior for normal UDP DNS, but it does not close
+hardcoded-IP, cached-DNS, DoH, DoT, or hosts-file paths. The security boundary
+for this fix should be final connect enforcement via cgroup/eBPF.
+
+## Self-Review
+
+- The design covers the accepted scope: proxy env injection plus cgroup/eBPF
+  attachment for `agentsh wrap`.
+- It explicitly excludes DNS syscall interception.
+- It defines the required ordering to avoid the pre-exec race.
+- It identifies the important compatibility risk with shim forwarding.
+- It calls out the existing `applyCgroupV2` empty-limits behavior that could
+  otherwise make eBPF appear enabled without a concrete cgroup.

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -53,7 +53,7 @@ type App struct {
 	broker   *events.Broker
 	dbBypass *dbevents.BypassEmitter
 
-	cgroupMgr *limits.CgroupManager // issue #197: per-process cgroup manager, nil on non-Linux
+	cgroupMgr cgroupManager // issue #197: per-process cgroup manager, nil on non-Linux
 
 	apiKeyAuth *auth.APIKeyAuth
 	oidcAuth   *auth.OIDCAuth
@@ -122,6 +122,11 @@ func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Stor
 		slog.Warn("real_paths enabled but enforce_without_fuse is false: outside-workspace file access will be audit-only (not blocked)")
 	}
 
+	var appCgroupMgr cgroupManager
+	if cgroupMgr != nil {
+		appCgroupMgr = cgroupMgr
+	}
+
 	app := &App{
 		cfg:          cfg,
 		sessions:     sessions,
@@ -129,7 +134,7 @@ func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Stor
 		policy:       engine,
 		broker:       broker,
 		dbBypass:     dbevents.NewBypassEmitter(storeEmitter{store: store, broker: broker}),
-		cgroupMgr:    cgroupMgr,
+		cgroupMgr:    appCgroupMgr,
 		apiKeyAuth:   apiKeyAuth,
 		oidcAuth:     oidcAuth,
 		approvals:    approvalsMgr,

--- a/internal/api/cgroups.go
+++ b/internal/api/cgroups.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -16,6 +17,20 @@ import (
 	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/google/uuid"
+)
+
+type cgroupManager interface {
+	Apply(name string, pid int, lim limits.CgroupV2Limits) (*limits.CgroupV2, error)
+	Probe() *limits.CgroupProbeResult
+}
+
+var (
+	ebpfCheckSupport          = ebpftrace.CheckSupport
+	ebpfAttachConnectToCgroup = ebpftrace.AttachConnectToCgroup
+	ebpfStartCollector        = ebpftrace.StartCollector
+	ebpfCgroupID              = ebpftrace.CgroupID
+	ebpfPopulateAllowlist     = ebpftrace.PopulateAllowlist
+	ebpfCleanupAllowlist      = ebpftrace.CleanupAllowlist
 )
 
 func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, cmdID string, pid int, lim policy.Limits, m *metrics.Collector, pol *policy.Engine) (func() error, error) {
@@ -119,12 +134,52 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 	var allowlistColl *ebpf.Collection
 	var allowCgid uint64
 	var refreshCancel context.CancelFunc
+	cleanupResources := func() error {
+		if ebpfCollector != nil {
+			_ = ebpfCollector.Close()
+		}
+		if ebpfDetach != nil {
+			// best-effort clean allowlist before detaching/closing collection
+			if allowlistColl != nil && allowCgid != 0 {
+				_ = ebpfCleanupAllowlist(allowlistColl, allowCgid)
+			}
+			if refreshCancel != nil {
+				refreshCancel()
+			}
+			_ = ebpfDetach()
+		}
+		cctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		if err := cg.Close(cctx); err != nil {
+			ev := types.Event{
+				ID:        uuid.NewString(),
+				Timestamp: time.Now().UTC(),
+				Type:      "cgroup_cleanup_failed",
+				SessionID: sessionID,
+				CommandID: cmdID,
+				Fields: map[string]any{
+					"path":  cg.Path,
+					"error": err.Error(),
+				},
+			}
+			_ = emit.AppendEvent(context.Background(), ev)
+			emit.Publish(ev)
+			return err
+		}
+		return nil
+	}
+	cleanupAfterSetupFailure := func() {
+		if err := cleanupResources(); err != nil {
+			slog.Warn("cgroup: cleanup after setup failure failed",
+				"session_id", sessionID, "command_id", cmdID, "path", cg.Path, "error", err)
+		}
+	}
 	refreshInterval := cfg.Sandbox.Network.EBPF.DNSRefreshSeconds
 	if refreshInterval <= 0 {
 		refreshInterval = 0
 	}
 	if ebpfEnabled {
-		status := ebpftrace.CheckSupport()
+		status := ebpfCheckSupport()
 		if !status.Supported {
 			ev := types.Event{
 				ID:        uuid.NewString(),
@@ -142,10 +197,11 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 				m.IncEBPFUnavailable()
 			}
 			if ebpfRequired {
+				cleanupAfterSetupFailure()
 				return nil, fmt.Errorf("ebpf required but unsupported: %s", status.Reason)
 			}
 		} else {
-			if coll, detach, err := ebpftrace.AttachConnectToCgroup(cg.Path); err != nil {
+			if coll, detach, err := ebpfAttachConnectToCgroup(cg.Path); err != nil {
 				ev := types.Event{
 					ID:        uuid.NewString(),
 					Timestamp: time.Now().UTC(),
@@ -163,11 +219,12 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 					m.IncEBPFAttachFail()
 				}
 				if ebpfRequired {
+					cleanupAfterSetupFailure()
 					return nil, fmt.Errorf("ebpf attach failed and required: %w", err)
 				}
 			} else {
 				ebpfDetach = detach
-				collector, cerr := ebpftrace.StartCollector(coll, 4096)
+				collector, cerr := ebpfStartCollector(coll, 4096)
 				if cerr != nil {
 					ev := types.Event{
 						ID:        uuid.NewString(),
@@ -182,9 +239,11 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 					_ = emit.AppendEvent(ctx, ev)
 					emit.Publish(ev)
 					if ebpfRequired {
+						cleanupAfterSetupFailure()
 						return nil, fmt.Errorf("ebpf collector failed and required: %w", cerr)
 					}
 					_ = detach()
+					ebpfDetach = nil
 				} else {
 					collector.SetOnDrop(func() {
 						if m != nil {
@@ -194,7 +253,7 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 
 					// Populate allowlist if enforcement is requested.
 					if ebpfEnforce {
-						cgid, cgErr := ebpftrace.CgroupID(cg.Path)
+						cgid, cgErr := ebpfCgroupID(cg.Path)
 						if cgErr != nil {
 							ev := types.Event{
 								ID:        uuid.NewString(),
@@ -217,7 +276,7 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 								// disable default deny when we couldn't resolve anything
 								strict = false
 							}
-							if err := ebpftrace.PopulateAllowlist(coll, cgid, ep, cidrs, denyKeys, denyCidrs, strict); err != nil {
+							if err := ebpfPopulateAllowlist(coll, cgid, ep, cidrs, denyKeys, denyCidrs, strict); err != nil {
 								ev := types.Event{
 									ID:        uuid.NewString(),
 									Timestamp: time.Now().UTC(),
@@ -234,7 +293,7 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 									m.IncEBPFAttachFail()
 								}
 								// best effort disable default deny and clear entries
-								_ = ebpftrace.CleanupAllowlist(coll, cgid)
+								_ = ebpfCleanupAllowlist(coll, cgid)
 							}
 							if ebpfEnforce && !strict {
 								ev := types.Event{
@@ -268,7 +327,7 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 											return
 										case <-t.C:
 											ep2, cidrs2, deny2, denyCidrs2, strict2, _, ttl2 := buildAllowedEndpoints(pol, base)
-											if err := ebpftrace.PopulateAllowlist(coll, cgid, ep2, cidrs2, deny2, denyCidrs2, strict2); err != nil {
+											if err := ebpfPopulateAllowlist(coll, cgid, ep2, cidrs2, deny2, denyCidrs2, strict2); err != nil {
 												ev := types.Event{
 													ID:        uuid.NewString(),
 													Timestamp: time.Now().UTC(),
@@ -313,40 +372,7 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 		}
 	}
 
-	return func() error {
-		if ebpfCollector != nil {
-			_ = ebpfCollector.Close()
-		}
-		if ebpfDetach != nil {
-			// best-effort clean allowlist before detaching/closing collection
-			if allowlistColl != nil && allowCgid != 0 {
-				_ = ebpftrace.CleanupAllowlist(allowlistColl, allowCgid)
-			}
-			if refreshCancel != nil {
-				refreshCancel()
-			}
-			_ = ebpfDetach()
-		}
-		cctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-		defer cancel()
-		if err := cg.Close(cctx); err != nil {
-			ev := types.Event{
-				ID:        uuid.NewString(),
-				Timestamp: time.Now().UTC(),
-				Type:      "cgroup_cleanup_failed",
-				SessionID: sessionID,
-				CommandID: cmdID,
-				Fields: map[string]any{
-					"path":  cg.Path,
-					"error": err.Error(),
-				},
-			}
-			_ = emit.AppendEvent(context.Background(), ev)
-			emit.Publish(ev)
-			return err
-		}
-		return nil
-	}, nil
+	return cleanupResources, nil
 }
 
 func sanitizeCgroupTag(s string) string {

--- a/internal/api/cgroups.go
+++ b/internal/api/cgroups.go
@@ -38,9 +38,10 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 		CPUQuotaPct:    lim.CPUQuotaPercent,
 		PidsMax:        lim.PidsMax,
 	}
+	needsConcreteCgroup := !cgLimits.IsEmpty() || ebpfEnabled
 
 	if app.cgroupMgr == nil {
-		if cgLimits.IsEmpty() {
+		if !needsConcreteCgroup {
 			return func() error { return nil }, nil
 		}
 		return nil, &limits.CgroupUnavailableError{
@@ -85,8 +86,14 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 		return nil, err
 	}
 
-	// If unavailable mode allowed us (empty limits), cg is nil. Treat as no-op.
+	// If unavailable mode allowed us with no concrete cgroup need, treat as no-op.
 	if cg == nil {
+		if needsConcreteCgroup {
+			return nil, &limits.CgroupUnavailableError{
+				Reason: "cgroup manager returned no cgroup",
+				Limits: cgLimits,
+			}
+		}
 		return func() error { return nil }, nil
 	}
 

--- a/internal/api/cgroups.go
+++ b/internal/api/cgroups.go
@@ -224,6 +224,119 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 				}
 			} else {
 				ebpfDetach = detach
+
+				// Populate allowlist before starting the collector. When eBPF is
+				// required, enforcement setup failures must reject the wrap before
+				// the wrapper is ACKed.
+				if ebpfEnforce {
+					cgid, cgErr := ebpfCgroupID(cg.Path)
+					if cgErr != nil {
+						ev := types.Event{
+							ID:        uuid.NewString(),
+							Timestamp: time.Now().UTC(),
+							Type:      "ebpf_enforce_disabled",
+							SessionID: sessionID,
+							CommandID: cmdID,
+							Fields: map[string]any{
+								"error": cgErr.Error(),
+							},
+						}
+						_ = emit.AppendEvent(ctx, ev)
+						emit.Publish(ev)
+						if ebpfRequired {
+							cleanupAfterSetupFailure()
+							return nil, fmt.Errorf("ebpf enforcement setup failed and required: cgroup id: %w", cgErr)
+						}
+					} else {
+						allowlistColl = coll
+						allowCgid = cgid
+						maxTTL := time.Duration(cfg.Sandbox.Network.EBPF.DNSMaxTTLSeconds) * time.Second
+						ep, cidrs, denyKeys, denyCidrs, strict, hasDomains, ttlHint := buildAllowedEndpoints(pol, maxTTL)
+						if len(ep) == 0 && len(cidrs) == 0 && !enforceNoDNS {
+							// disable default deny when we couldn't resolve anything
+							strict = false
+						}
+						if err := ebpfPopulateAllowlist(coll, cgid, ep, cidrs, denyKeys, denyCidrs, strict); err != nil {
+							ev := types.Event{
+								ID:        uuid.NewString(),
+								Timestamp: time.Now().UTC(),
+								Type:      "ebpf_enforce_disabled",
+								SessionID: sessionID,
+								CommandID: cmdID,
+								Fields: map[string]any{
+									"error": err.Error(),
+								},
+							}
+							_ = emit.AppendEvent(ctx, ev)
+							emit.Publish(ev)
+							if m != nil {
+								m.IncEBPFAttachFail()
+							}
+							if ebpfRequired {
+								cleanupAfterSetupFailure()
+								return nil, fmt.Errorf("ebpf enforcement setup failed and required: populate allowlist: %w", err)
+							}
+							// best effort disable default deny and clear entries
+							_ = ebpfCleanupAllowlist(coll, cgid)
+						}
+						if ebpfEnforce && !strict {
+							ev := types.Event{
+								ID:        uuid.NewString(),
+								Timestamp: time.Now().UTC(),
+								Type:      "ebpf_enforce_non_strict",
+								SessionID: sessionID,
+								CommandID: cmdID,
+								Fields: map[string]any{
+									"reason": "rules include wildcards or cidrs; default-deny disabled",
+								},
+							}
+							_ = emit.AppendEvent(ctx, ev)
+							emit.Publish(ev)
+						}
+
+						// Optional DNS refresh loop for domain-based rules.
+						if hasDomains && strict && refreshInterval > 0 {
+							refreshCtx, cancel := context.WithCancel(ctx)
+							refreshCancel = cancel
+							go func() {
+								base := time.Duration(refreshInterval) * time.Second
+								if ttlHint > 0 && ttlHint < base {
+									base = ttlHint
+								}
+								t := time.NewTimer(jitterInterval(base))
+								defer t.Stop()
+								for {
+									select {
+									case <-refreshCtx.Done():
+										return
+									case <-t.C:
+										ep2, cidrs2, deny2, denyCidrs2, strict2, _, ttl2 := buildAllowedEndpoints(pol, base)
+										if err := ebpfPopulateAllowlist(coll, cgid, ep2, cidrs2, deny2, denyCidrs2, strict2); err != nil {
+											ev := types.Event{
+												ID:        uuid.NewString(),
+												Timestamp: time.Now().UTC(),
+												Type:      "ebpf_enforce_refresh_failed",
+												SessionID: sessionID,
+												CommandID: cmdID,
+												Fields: map[string]any{
+													"error": err.Error(),
+												},
+											}
+											_ = emit.AppendEvent(ctx, ev)
+											emit.Publish(ev)
+										}
+										next := base
+										if ttl2 > 0 && ttl2 < next {
+											next = ttl2
+										}
+										t.Reset(jitterInterval(next))
+									}
+								}
+							}()
+						}
+					}
+				}
+
 				collector, cerr := ebpfStartCollector(coll, 4096)
 				if cerr != nil {
 					ev := types.Event{
@@ -245,115 +358,12 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 					_ = detach()
 					ebpfDetach = nil
 				} else {
+					ebpfCollector = collector
 					collector.SetOnDrop(func() {
 						if m != nil {
 							m.IncEBPFDropped()
 						}
 					})
-
-					// Populate allowlist if enforcement is requested.
-					if ebpfEnforce {
-						cgid, cgErr := ebpfCgroupID(cg.Path)
-						if cgErr != nil {
-							ev := types.Event{
-								ID:        uuid.NewString(),
-								Timestamp: time.Now().UTC(),
-								Type:      "ebpf_enforce_disabled",
-								SessionID: sessionID,
-								CommandID: cmdID,
-								Fields: map[string]any{
-									"error": cgErr.Error(),
-								},
-							}
-							_ = emit.AppendEvent(ctx, ev)
-							emit.Publish(ev)
-						} else {
-							allowlistColl = coll
-							allowCgid = cgid
-							maxTTL := time.Duration(cfg.Sandbox.Network.EBPF.DNSMaxTTLSeconds) * time.Second
-							ep, cidrs, denyKeys, denyCidrs, strict, hasDomains, ttlHint := buildAllowedEndpoints(pol, maxTTL)
-							if len(ep) == 0 && len(cidrs) == 0 && !enforceNoDNS {
-								// disable default deny when we couldn't resolve anything
-								strict = false
-							}
-							if err := ebpfPopulateAllowlist(coll, cgid, ep, cidrs, denyKeys, denyCidrs, strict); err != nil {
-								ev := types.Event{
-									ID:        uuid.NewString(),
-									Timestamp: time.Now().UTC(),
-									Type:      "ebpf_enforce_disabled",
-									SessionID: sessionID,
-									CommandID: cmdID,
-									Fields: map[string]any{
-										"error": err.Error(),
-									},
-								}
-								_ = emit.AppendEvent(ctx, ev)
-								emit.Publish(ev)
-								if m != nil {
-									m.IncEBPFAttachFail()
-								}
-								// best effort disable default deny and clear entries
-								_ = ebpfCleanupAllowlist(coll, cgid)
-							}
-							if ebpfEnforce && !strict {
-								ev := types.Event{
-									ID:        uuid.NewString(),
-									Timestamp: time.Now().UTC(),
-									Type:      "ebpf_enforce_non_strict",
-									SessionID: sessionID,
-									CommandID: cmdID,
-									Fields: map[string]any{
-										"reason": "rules include wildcards or cidrs; default-deny disabled",
-									},
-								}
-								_ = emit.AppendEvent(ctx, ev)
-								emit.Publish(ev)
-							}
-
-							// Optional DNS refresh loop for domain-based rules.
-							if hasDomains && strict && refreshInterval > 0 {
-								refreshCtx, cancel := context.WithCancel(ctx)
-								refreshCancel = cancel
-								go func() {
-									base := time.Duration(refreshInterval) * time.Second
-									if ttlHint > 0 && ttlHint < base {
-										base = ttlHint
-									}
-									t := time.NewTimer(jitterInterval(base))
-									defer t.Stop()
-									for {
-										select {
-										case <-refreshCtx.Done():
-											return
-										case <-t.C:
-											ep2, cidrs2, deny2, denyCidrs2, strict2, _, ttl2 := buildAllowedEndpoints(pol, base)
-											if err := ebpfPopulateAllowlist(coll, cgid, ep2, cidrs2, deny2, denyCidrs2, strict2); err != nil {
-												ev := types.Event{
-													ID:        uuid.NewString(),
-													Timestamp: time.Now().UTC(),
-													Type:      "ebpf_enforce_refresh_failed",
-													SessionID: sessionID,
-													CommandID: cmdID,
-													Fields: map[string]any{
-														"error": err.Error(),
-													},
-												}
-												_ = emit.AppendEvent(ctx, ev)
-												emit.Publish(ev)
-											}
-											next := base
-											if ttl2 > 0 && ttl2 < next {
-												next = ttl2
-											}
-											t.Reset(jitterInterval(next))
-										}
-									}
-								}()
-							}
-						}
-					}
-
-					ebpfCollector = collector
 					go forwardConnectEvents(ctx, collector.Events(), emit, sessionID, cmdID, m)
 				}
 				ev := types.Event{

--- a/internal/api/cgroups.go
+++ b/internal/api/cgroups.go
@@ -134,20 +134,27 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 	var allowlistColl *ebpf.Collection
 	var allowCgid uint64
 	var refreshCancel context.CancelFunc
-	cleanupResources := func() error {
+	cleanupEBPFResources := func() {
 		if ebpfCollector != nil {
 			_ = ebpfCollector.Close()
+			ebpfCollector = nil
+		}
+		if refreshCancel != nil {
+			refreshCancel()
+			refreshCancel = nil
+		}
+		if allowlistColl != nil && allowCgid != 0 {
+			_ = ebpfCleanupAllowlist(allowlistColl, allowCgid)
+			allowlistColl = nil
+			allowCgid = 0
 		}
 		if ebpfDetach != nil {
-			// best-effort clean allowlist before detaching/closing collection
-			if allowlistColl != nil && allowCgid != 0 {
-				_ = ebpfCleanupAllowlist(allowlistColl, allowCgid)
-			}
-			if refreshCancel != nil {
-				refreshCancel()
-			}
 			_ = ebpfDetach()
+			ebpfDetach = nil
 		}
+	}
+	cleanupResources := func() error {
+		cleanupEBPFResources()
 		cctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		defer cancel()
 		if err := cg.Close(cctx); err != nil {
@@ -278,6 +285,8 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 							}
 							// best effort disable default deny and clear entries
 							_ = ebpfCleanupAllowlist(coll, cgid)
+							allowlistColl = nil
+							allowCgid = 0
 						}
 						if ebpfEnforce && !strict {
 							ev := types.Event{
@@ -355,8 +364,7 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 						cleanupAfterSetupFailure()
 						return nil, fmt.Errorf("ebpf collector failed and required: %w", cerr)
 					}
-					_ = detach()
-					ebpfDetach = nil
+					cleanupEBPFResources()
 				} else {
 					ebpfCollector = collector
 					collector.SetOnDrop(func() {

--- a/internal/api/cgroups_linux_test.go
+++ b/internal/api/cgroups_linux_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -59,10 +60,16 @@ func withEBPFHooks(t *testing.T) {
 	prevCheck := ebpfCheckSupport
 	prevAttach := ebpfAttachConnectToCgroup
 	prevStart := ebpfStartCollector
+	prevCgroupID := ebpfCgroupID
+	prevPopulate := ebpfPopulateAllowlist
+	prevCleanup := ebpfCleanupAllowlist
 	t.Cleanup(func() {
 		ebpfCheckSupport = prevCheck
 		ebpfAttachConnectToCgroup = prevAttach
 		ebpfStartCollector = prevStart
+		ebpfCgroupID = prevCgroupID
+		ebpfPopulateAllowlist = prevPopulate
+		ebpfCleanupAllowlist = prevCleanup
 	})
 }
 
@@ -104,7 +111,7 @@ func TestApplyCgroupV2_DetachesAndCleansCgroupWhenRequiredCollectorStartFails(t 
 		return ebpftrace.SupportStatus{Supported: true}
 	}
 	ebpfAttachConnectToCgroup = func(path string) (*ebpf.Collection, func() error, error) {
-		return nil, func() error {
+		return &ebpf.Collection{}, func() error {
 			detachCalls.Add(1)
 			return nil
 		}, nil
@@ -122,5 +129,122 @@ func TestApplyCgroupV2_DetachesAndCleansCgroupWhenRequiredCollectorStartFails(t 
 	}
 	if _, statErr := os.Stat(cgPath); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("expected cgroup cleanup after required collector failure, stat err = %v", statErr)
+	}
+}
+
+func TestApplyCgroupV2_DetachesAndCleansCgroupWhenRequiredEnforceCgroupIDFails(t *testing.T) {
+	withEBPFHooks(t)
+
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Network.EBPF.Enabled = true
+	cfg.Sandbox.Network.EBPF.Required = true
+	cfg.Sandbox.Network.EBPF.Enforce = true
+	cgPath := filepath.Join(t.TempDir(), "agentsh-test-cgroup")
+	app := newAppWithFakeCgroupManager(t, cfg, cgPath)
+
+	var detachCalls atomic.Int32
+	var cgroupIDCalls atomic.Int32
+	var startCollectorCalls atomic.Int32
+	ebpfCheckSupport = func() ebpftrace.SupportStatus {
+		return ebpftrace.SupportStatus{Supported: true}
+	}
+	ebpfAttachConnectToCgroup = func(path string) (*ebpf.Collection, func() error, error) {
+		return &ebpf.Collection{}, func() error {
+			detachCalls.Add(1)
+			return nil
+		}, nil
+	}
+	ebpfCgroupID = func(path string) (uint64, error) {
+		cgroupIDCalls.Add(1)
+		return 0, errors.New("cgroup id failed")
+	}
+	ebpfStartCollector = func(coll *ebpf.Collection, bufSize int) (*ebpftrace.Collector, error) {
+		startCollectorCalls.Add(1)
+		return nil, errors.New("collector should not start before enforcement setup")
+	}
+
+	_, err := applyCgroupV2(context.Background(), storeEmitter{store: app.store, broker: app.broker}, app, "sess", "cmd", 1234, policy.Limits{}, nil, nil)
+	if err == nil {
+		t.Fatal("expected required ebpf enforcement error")
+	}
+	if !strings.Contains(err.Error(), "cgroup id failed") {
+		t.Fatalf("expected cgroup id failure, got %v", err)
+	}
+	if got := cgroupIDCalls.Load(); got != 1 {
+		t.Fatalf("cgroup id calls = %d, want 1", got)
+	}
+	if got := startCollectorCalls.Load(); got != 0 {
+		t.Fatalf("collector start calls = %d, want 0 before enforcement setup succeeds", got)
+	}
+	if got := detachCalls.Load(); got != 1 {
+		t.Fatalf("detach calls = %d, want 1", got)
+	}
+	if _, statErr := os.Stat(cgPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected cgroup cleanup after required enforce setup failure, stat err = %v", statErr)
+	}
+}
+
+func TestApplyCgroupV2_DetachesAndCleansCgroupWhenRequiredEnforcePopulateFails(t *testing.T) {
+	withEBPFHooks(t)
+
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Network.EBPF.Enabled = true
+	cfg.Sandbox.Network.EBPF.Required = true
+	cfg.Sandbox.Network.EBPF.Enforce = true
+	cgPath := filepath.Join(t.TempDir(), "agentsh-test-cgroup")
+	app := newAppWithFakeCgroupManager(t, cfg, cgPath)
+
+	var detachCalls atomic.Int32
+	var populateCalls atomic.Int32
+	var cleanupAllowlistCalls atomic.Int32
+	var startCollectorCalls atomic.Int32
+	ebpfCheckSupport = func() ebpftrace.SupportStatus {
+		return ebpftrace.SupportStatus{Supported: true}
+	}
+	ebpfAttachConnectToCgroup = func(path string) (*ebpf.Collection, func() error, error) {
+		return &ebpf.Collection{}, func() error {
+			detachCalls.Add(1)
+			return nil
+		}, nil
+	}
+	ebpfCgroupID = func(path string) (uint64, error) {
+		return 42, nil
+	}
+	ebpfPopulateAllowlist = func(coll *ebpf.Collection, cgroupID uint64, allow []ebpftrace.AllowKey, allowCIDRs []ebpftrace.AllowCIDR, deny []ebpftrace.AllowKey, denyCIDRs []ebpftrace.AllowCIDR, defaultDeny bool) error {
+		populateCalls.Add(1)
+		return errors.New("populate failed")
+	}
+	ebpfCleanupAllowlist = func(coll *ebpf.Collection, cgroupID uint64) error {
+		cleanupAllowlistCalls.Add(1)
+		return nil
+	}
+	ebpfStartCollector = func(coll *ebpf.Collection, bufSize int) (*ebpftrace.Collector, error) {
+		startCollectorCalls.Add(1)
+		return nil, errors.New("collector should not start before enforcement setup")
+	}
+
+	_, err := applyCgroupV2(context.Background(), storeEmitter{store: app.store, broker: app.broker}, app, "sess", "cmd", 1234, policy.Limits{}, nil, nil)
+	if err == nil {
+		t.Fatal("expected required ebpf enforcement error")
+	}
+	if !strings.Contains(err.Error(), "populate failed") {
+		t.Fatalf("expected populate failure, got %v", err)
+	}
+	if got := populateCalls.Load(); got != 1 {
+		t.Fatalf("populate calls = %d, want 1", got)
+	}
+	if got := startCollectorCalls.Load(); got != 0 {
+		t.Fatalf("collector start calls = %d, want 0 before enforcement setup succeeds", got)
+	}
+	if got := cleanupAllowlistCalls.Load(); got != 1 {
+		t.Fatalf("cleanup allowlist calls = %d, want 1", got)
+	}
+	if got := detachCalls.Load(); got != 1 {
+		t.Fatalf("detach calls = %d, want 1", got)
+	}
+	if _, statErr := os.Stat(cgPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected cgroup cleanup after required populate failure, stat err = %v", statErr)
 	}
 }

--- a/internal/api/cgroups_linux_test.go
+++ b/internal/api/cgroups_linux_test.go
@@ -1,0 +1,126 @@
+//go:build linux
+
+package api
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/events"
+	"github.com/agentsh/agentsh/internal/limits"
+	ebpftrace "github.com/agentsh/agentsh/internal/netmonitor/ebpf"
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/store/composite"
+	"github.com/cilium/ebpf"
+)
+
+type fakeCgroupManagerForAPITest struct {
+	path string
+}
+
+func (m *fakeCgroupManagerForAPITest) Apply(name string, pid int, lim limits.CgroupV2Limits) (*limits.CgroupV2, error) {
+	if err := os.MkdirAll(m.path, 0o755); err != nil {
+		return nil, err
+	}
+	return &limits.CgroupV2{Path: m.path}, nil
+}
+
+func (m *fakeCgroupManagerForAPITest) Probe() *limits.CgroupProbeResult {
+	return &limits.CgroupProbeResult{Mode: limits.ModeNested}
+}
+
+func newAppWithFakeCgroupManager(t *testing.T, cfg *config.Config, cgPath string) *App {
+	t.Helper()
+	app := NewApp(
+		cfg,
+		session.NewManager(1),
+		composite.New(mockEventStore{}, nil),
+		nil,
+		events.NewBroker(),
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+	app.cgroupMgr = &fakeCgroupManagerForAPITest{path: cgPath}
+	return app
+}
+
+func withEBPFHooks(t *testing.T) {
+	t.Helper()
+	prevCheck := ebpfCheckSupport
+	prevAttach := ebpfAttachConnectToCgroup
+	prevStart := ebpfStartCollector
+	t.Cleanup(func() {
+		ebpfCheckSupport = prevCheck
+		ebpfAttachConnectToCgroup = prevAttach
+		ebpfStartCollector = prevStart
+	})
+}
+
+func TestApplyCgroupV2_CleansCgroupWhenRequiredEBPFUnsupported(t *testing.T) {
+	withEBPFHooks(t)
+
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Network.EBPF.Enabled = true
+	cfg.Sandbox.Network.EBPF.Required = true
+	cgPath := filepath.Join(t.TempDir(), "agentsh-test-cgroup")
+	app := newAppWithFakeCgroupManager(t, cfg, cgPath)
+
+	ebpfCheckSupport = func() ebpftrace.SupportStatus {
+		return ebpftrace.SupportStatus{Supported: false, Reason: "test unsupported"}
+	}
+
+	_, err := applyCgroupV2(context.Background(), storeEmitter{store: app.store, broker: app.broker}, app, "sess", "cmd", 1234, policy.Limits{}, nil, nil)
+	if err == nil {
+		t.Fatal("expected required ebpf error")
+	}
+	if _, statErr := os.Stat(cgPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected cgroup cleanup after required ebpf failure, stat err = %v", statErr)
+	}
+}
+
+func TestApplyCgroupV2_DetachesAndCleansCgroupWhenRequiredCollectorStartFails(t *testing.T) {
+	withEBPFHooks(t)
+
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Network.EBPF.Enabled = true
+	cfg.Sandbox.Network.EBPF.Required = true
+	cgPath := filepath.Join(t.TempDir(), "agentsh-test-cgroup")
+	app := newAppWithFakeCgroupManager(t, cfg, cgPath)
+
+	var detachCalls atomic.Int32
+	ebpfCheckSupport = func() ebpftrace.SupportStatus {
+		return ebpftrace.SupportStatus{Supported: true}
+	}
+	ebpfAttachConnectToCgroup = func(path string) (*ebpf.Collection, func() error, error) {
+		return nil, func() error {
+			detachCalls.Add(1)
+			return nil
+		}, nil
+	}
+	ebpfStartCollector = func(coll *ebpf.Collection, bufSize int) (*ebpftrace.Collector, error) {
+		return nil, errors.New("collector failed")
+	}
+
+	_, err := applyCgroupV2(context.Background(), storeEmitter{store: app.store, broker: app.broker}, app, "sess", "cmd", 1234, policy.Limits{}, nil, nil)
+	if err == nil {
+		t.Fatal("expected required ebpf collector error")
+	}
+	if got := detachCalls.Load(); got != 1 {
+		t.Fatalf("detach calls = %d, want 1", got)
+	}
+	if _, statErr := os.Stat(cgPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected cgroup cleanup after required collector failure, stat err = %v", statErr)
+	}
+}

--- a/internal/api/cgroups_linux_test.go
+++ b/internal/api/cgroups_linux_test.go
@@ -5,11 +5,13 @@ package api
 import (
 	"context"
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/events"
@@ -73,6 +75,33 @@ func withEBPFHooks(t *testing.T) {
 	})
 }
 
+func withDomainResolverHook(t *testing.T, fn func(string, time.Duration) ([]net.IP, time.Duration)) {
+	t.Helper()
+	prev := resolveDomainWithTTL
+	resolveDomainWithTTL = fn
+	t.Cleanup(func() {
+		resolveDomainWithTTL = prev
+	})
+}
+
+func networkPolicyEngineForCgroupTest(t *testing.T) *policy.Engine {
+	t.Helper()
+	engine, err := policy.NewEngine(&policy.Policy{
+		Version: 1,
+		Name:    "cgroup-ebpf-test",
+		NetworkRules: []policy.NetworkRule{{
+			Name:     "allow-example",
+			Domains:  []string{"example.test"},
+			Ports:    []int{443},
+			Decision: "allow",
+		}},
+	}, false, true)
+	if err != nil {
+		t.Fatalf("build policy engine: %v", err)
+	}
+	return engine
+}
+
 func TestApplyCgroupV2_CleansCgroupWhenRequiredEBPFUnsupported(t *testing.T) {
 	withEBPFHooks(t)
 
@@ -93,6 +122,43 @@ func TestApplyCgroupV2_CleansCgroupWhenRequiredEBPFUnsupported(t *testing.T) {
 	}
 	if _, statErr := os.Stat(cgPath); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("expected cgroup cleanup after required ebpf failure, stat err = %v", statErr)
+	}
+}
+
+func TestApplyCgroupV2_CleansCgroupWhenRequiredAttachFails(t *testing.T) {
+	withEBPFHooks(t)
+
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Network.EBPF.Enabled = true
+	cfg.Sandbox.Network.EBPF.Required = true
+	cgPath := filepath.Join(t.TempDir(), "agentsh-test-cgroup")
+	app := newAppWithFakeCgroupManager(t, cfg, cgPath)
+
+	var startCollectorCalls atomic.Int32
+	ebpfCheckSupport = func() ebpftrace.SupportStatus {
+		return ebpftrace.SupportStatus{Supported: true}
+	}
+	ebpfAttachConnectToCgroup = func(path string) (*ebpf.Collection, func() error, error) {
+		return nil, nil, errors.New("attach failed")
+	}
+	ebpfStartCollector = func(coll *ebpf.Collection, bufSize int) (*ebpftrace.Collector, error) {
+		startCollectorCalls.Add(1)
+		return nil, errors.New("collector should not start after attach failure")
+	}
+
+	_, err := applyCgroupV2(context.Background(), storeEmitter{store: app.store, broker: app.broker}, app, "sess", "cmd", 1234, policy.Limits{}, nil, nil)
+	if err == nil {
+		t.Fatal("expected required ebpf attach error")
+	}
+	if !strings.Contains(err.Error(), "attach failed") {
+		t.Fatalf("expected attach failure, got %v", err)
+	}
+	if got := startCollectorCalls.Load(); got != 0 {
+		t.Fatalf("collector start calls = %d, want 0 after attach failure", got)
+	}
+	if _, statErr := os.Stat(cgPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("expected cgroup cleanup after required attach failure, stat err = %v", statErr)
 	}
 }
 
@@ -129,6 +195,72 @@ func TestApplyCgroupV2_DetachesAndCleansCgroupWhenRequiredCollectorStartFails(t 
 	}
 	if _, statErr := os.Stat(cgPath); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("expected cgroup cleanup after required collector failure, stat err = %v", statErr)
+	}
+}
+
+func TestApplyCgroupV2_CleansEBPFResourcesWhenOptionalEnforceCollectorStartFails(t *testing.T) {
+	withEBPFHooks(t)
+	withDomainResolverHook(t, func(domain string, maxTTL time.Duration) ([]net.IP, time.Duration) {
+		return []net.IP{net.ParseIP("203.0.113.10")}, time.Second
+	})
+
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Network.EBPF.Enabled = true
+	cfg.Sandbox.Network.EBPF.Enforce = true
+	cfg.Sandbox.Network.EBPF.DNSRefreshSeconds = 1
+	cgPath := filepath.Join(t.TempDir(), "agentsh-test-cgroup")
+	app := newAppWithFakeCgroupManager(t, cfg, cgPath)
+	engine := networkPolicyEngineForCgroupTest(t)
+
+	var detachCalls atomic.Int32
+	var populateCalls atomic.Int32
+	var cleanupAllowlistCalls atomic.Int32
+	ebpfCheckSupport = func() ebpftrace.SupportStatus {
+		return ebpftrace.SupportStatus{Supported: true}
+	}
+	ebpfAttachConnectToCgroup = func(path string) (*ebpf.Collection, func() error, error) {
+		return &ebpf.Collection{}, func() error {
+			detachCalls.Add(1)
+			return nil
+		}, nil
+	}
+	ebpfCgroupID = func(path string) (uint64, error) {
+		return 42, nil
+	}
+	ebpfPopulateAllowlist = func(coll *ebpf.Collection, cgroupID uint64, allow []ebpftrace.AllowKey, allowCIDRs []ebpftrace.AllowCIDR, deny []ebpftrace.AllowKey, denyCIDRs []ebpftrace.AllowCIDR, defaultDeny bool) error {
+		populateCalls.Add(1)
+		return nil
+	}
+	ebpfCleanupAllowlist = func(coll *ebpf.Collection, cgroupID uint64) error {
+		cleanupAllowlistCalls.Add(1)
+		return nil
+	}
+	ebpfStartCollector = func(coll *ebpf.Collection, bufSize int) (*ebpftrace.Collector, error) {
+		return nil, errors.New("collector failed")
+	}
+
+	cleanup, err := applyCgroupV2(context.Background(), storeEmitter{store: app.store, broker: app.broker}, app, "sess", "cmd", 1234, policy.Limits{}, nil, engine)
+	if err != nil {
+		t.Fatalf("optional collector failure should degrade without returning error: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("expected cgroup cleanup function")
+	}
+	if got := populateCalls.Load(); got != 1 {
+		t.Fatalf("populate calls = %d, want 1", got)
+	}
+	if got := cleanupAllowlistCalls.Load(); got != 1 {
+		t.Fatalf("cleanup allowlist calls = %d, want 1 after optional collector failure", got)
+	}
+	if got := detachCalls.Load(); got != 1 {
+		t.Fatalf("detach calls = %d, want 1", got)
+	}
+	if _, statErr := os.Stat(cgPath); statErr != nil {
+		t.Fatalf("optional collector failure should leave cgroup for normal cleanup, stat err = %v", statErr)
+	}
+	if err := cleanup(); err != nil {
+		t.Fatalf("cleanup: %v", err)
 	}
 }
 

--- a/internal/api/cgroups_test.go
+++ b/internal/api/cgroups_test.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/events"
+	"github.com/agentsh/agentsh/internal/limits"
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/store/composite"
+)
+
+func TestApplyCgroupV2_EBPFEnabledRequiresCgroupManager(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Network.EBPF.Enabled = true
+
+	app := NewApp(
+		cfg,
+		session.NewManager(1),
+		composite.New(mockEventStore{}, nil),
+		nil,
+		events.NewBroker(),
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+
+	_, err := applyCgroupV2(context.Background(), storeEmitter{store: app.store, broker: app.broker}, app, "sess", "cmd", 1234, policy.Limits{}, nil, nil)
+	if err == nil {
+		t.Fatal("expected error when ebpf is enabled without cgroup manager")
+	}
+	var unavailable *limits.CgroupUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("expected CgroupUnavailableError, got %T: %v", err, err)
+	}
+}

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/landlock"
+	"github.com/agentsh/agentsh/internal/policy"
 	seccomppkg "github.com/agentsh/agentsh/internal/seccomp"
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/pkg/types"
@@ -29,7 +30,12 @@ var (
 	wrapChown                     = os.Chown
 	wrapChmod                     = os.Chmod
 	startNotifyHandlerForWrapHook = startNotifyHandlerForWrap
+	wrapCgroupSetupForNotifyHook  = defaultWrapCgroupSetupForNotify
 )
+
+type wrapNotifyMetadata struct {
+	WrapperPID int
+}
 
 // wrapInit handles POST /api/v1/sessions/{id}/wrap-init.
 // It returns the seccomp wrapper configuration for the CLI to launch the agent
@@ -708,28 +714,101 @@ func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketP
 
 	unixConn := conn.(*net.UnixConn)
 
-	file, err := unixConn.File()
-	if err != nil {
-		slog.Debug("wrap: failed to get file from connection", "session_id", sessionID, "error", err)
-		return
-	}
-
-	// Use the existing RecvFD infrastructure to receive the notify fd
-	notifyFD, err := recvFDFromConn(file)
-	file.Close()
+	notifyFD, meta, hasMeta, err := recvNotifyFDForWrap(unixConn)
 	if err != nil {
 		slog.Debug("wrap: failed to receive notify fd", "session_id", sessionID, "error", err)
+		if statusErr := writeNotifyStatusForWrap(unixConn, false); statusErr != nil {
+			slog.Debug("wrap: failed to write notify setup rejection", "session_id", sessionID, "error", statusErr)
+		}
 		return
 	}
 	if notifyFD == nil {
 		slog.Debug("wrap: received nil notify fd", "session_id", sessionID)
+		if statusErr := writeNotifyStatusForWrap(unixConn, false); statusErr != nil {
+			slog.Debug("wrap: failed to write notify setup rejection", "session_id", sessionID, "error", statusErr)
+		}
 		return
 	}
 
-	slog.Info("wrap: received notify fd", "session_id", sessionID, "fd", notifyFD.Fd())
+	wrapperPID := notifyPeerPID
+	if hasMeta && meta.WrapperPID > 0 {
+		wrapperPID = meta.WrapperPID
+	}
+
+	var cleanup func() error
+	if wrapNeedsCgroupBeforeAck(a, s) {
+		if !hasMeta || meta.WrapperPID <= 0 {
+			_ = notifyFD.Close()
+			if statusErr := writeNotifyStatusForWrap(unixConn, false); statusErr != nil {
+				slog.Debug("wrap: failed to write notify setup rejection", "session_id", sessionID, "error", statusErr)
+			}
+			slog.Warn("wrap: rejecting notify fd without wrapper pid metadata", "session_id", sessionID)
+			return
+		}
+		cgroupCleanup, err := wrapCgroupSetupForNotifyHook(ctx, a, s, sessionID, wrapperPID)
+		if err != nil {
+			_ = notifyFD.Close()
+			if statusErr := writeNotifyStatusForWrap(unixConn, false); statusErr != nil {
+				slog.Debug("wrap: failed to write notify setup rejection", "session_id", sessionID, "error", statusErr)
+			}
+			slog.Warn("wrap: cgroup setup before ack failed", "session_id", sessionID, "wrapper_pid", wrapperPID, "error", err)
+			return
+		}
+		cleanup = cgroupCleanup
+	}
+
+	slog.Info("wrap: received notify fd", "session_id", sessionID, "fd", notifyFD.Fd(), "wrapper_pid", wrapperPID)
 
 	// Start the notify handler using existing infrastructure
-	startNotifyHandlerForWrapHook(ctx, notifyFD, sessionID, a, execveEnabled, notifyPeerPID, s)
+	startNotifyHandlerForWrapHook(ctx, notifyFD, sessionID, a, execveEnabled, wrapperPID, s, cleanup)
+	if err := writeNotifyStatusForWrap(unixConn, true); err != nil {
+		slog.Debug("wrap: failed to write notify setup status", "session_id", sessionID, "error", err)
+	}
+}
+
+func wrapNeedsCgroupBeforeAck(a *App, s *session.Session) bool {
+	if a == nil || a.cfg == nil {
+		return false
+	}
+	if a.cfg.Sandbox.Network.EBPF.Required {
+		return true
+	}
+	if !a.cfg.Sandbox.Cgroups.Enabled {
+		return false
+	}
+	if a.cfg.Sandbox.Network.EBPF.Enabled || a.cfg.Sandbox.Network.EBPF.Enforce {
+		return true
+	}
+	engine := a.policyEngineFor(s)
+	if engine == nil {
+		return false
+	}
+	lim := engine.Limits()
+	return lim.MaxMemoryMB > 0 || lim.CPUQuotaPercent > 0 || lim.PidsMax > 0
+}
+
+func defaultWrapCgroupSetupForNotify(ctx context.Context, a *App, s *session.Session, sessionID string, wrapperPID int) (func() error, error) {
+	if !wrapNeedsCgroupBeforeAck(a, s) {
+		return nil, nil
+	}
+	if wrapperPID <= 0 {
+		return nil, fmt.Errorf("wrap cgroup setup requires wrapper pid")
+	}
+	if a.cfg.Sandbox.Network.EBPF.Required && !a.cfg.Sandbox.Cgroups.Enabled {
+		return nil, fmt.Errorf("ebpf required but sandbox.cgroups.enabled=false")
+	}
+	if !a.cfg.Sandbox.Cgroups.Enabled {
+		return nil, nil
+	}
+
+	engine := a.policyEngineFor(s)
+	lim := policy.Limits{}
+	if engine != nil {
+		lim = engine.Limits()
+	}
+	cmdID := "wrap-" + uuid.NewString()
+	em := storeEmitter{store: a.store, broker: a.broker}
+	return applyCgroupV2(ctx, em, a, sessionID, cmdID, wrapperPID, lim, a.metrics, engine)
 }
 
 // acceptSignalFD listens on the Unix socket for a single connection from the CLI,

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -760,7 +760,13 @@ func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketP
 	slog.Info("wrap: received notify fd", "session_id", sessionID, "fd", notifyFD.Fd(), "wrapper_pid", wrapperPID)
 
 	// Start the notify handler using existing infrastructure
-	startNotifyHandlerForWrapHook(ctx, notifyFD, sessionID, a, execveEnabled, wrapperPID, s, cleanup)
+	if err := startNotifyHandlerForWrapHook(ctx, notifyFD, sessionID, a, execveEnabled, wrapperPID, s, cleanup); err != nil {
+		if statusErr := writeNotifyStatusForWrap(unixConn, false); statusErr != nil {
+			slog.Debug("wrap: failed to write notify setup rejection", "session_id", sessionID, "error", statusErr)
+		}
+		slog.Warn("wrap: notify handler failed before ack", "session_id", sessionID, "wrapper_pid", wrapperPID, "error", err)
+		return
+	}
 	if err := writeNotifyStatusForWrap(unixConn, true); err != nil {
 		slog.Debug("wrap: failed to write notify setup status", "session_id", sessionID, "error", err)
 	}

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -27,10 +27,11 @@ import (
 )
 
 var (
-	wrapChown                     = os.Chown
-	wrapChmod                     = os.Chmod
-	startNotifyHandlerForWrapHook = startNotifyHandlerForWrap
-	wrapCgroupSetupForNotifyHook  = defaultWrapCgroupSetupForNotify
+	wrapChown                       = os.Chown
+	wrapChmod                       = os.Chmod
+	startNotifyHandlerForWrapHook   = startNotifyHandlerForWrap
+	wrapCgroupSetupForNotifyHook    = defaultWrapCgroupSetupForNotify
+	validateWrapperPIDForNotifyHook = validateWrapperPIDForNotify
 )
 
 type wrapNotifyMetadata struct {
@@ -374,11 +375,24 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 	// NOTE: Signal filter is disabled when execve interception is enabled because
 	// stacking two seccomp USER_NOTIF filters causes notification delivery failures
 	// (the signal filter's semaphore interferes with execve notification reception).
+	unixSocketEnabled := a.cfg.Sandbox.Seccomp.UnixSocket.Enabled
+	if a.cfg.Sandbox.UnixSockets.Enabled != nil && *a.cfg.Sandbox.UnixSockets.Enabled {
+		unixSocketEnabled = true
+	}
+	forceNotifyForPreAckCgroup := wrapNeedsCgroupBeforeAck(a, s)
+	if forceNotifyForPreAckCgroup {
+		// Pre-ACK cgroup/eBPF setup only happens after the wrapper hands a
+		// seccomp notify fd to this listener. Force a user-notify rule so the
+		// wrapper cannot skip the handoff and exec before eBPF is attached.
+		unixSocketEnabled = true
+	}
+
 	var signalSocketPath string
 	// signalFilterEnabled routes through a helper so the gate can be
 	// exercised in tests end-to-end without standing up seccomp (see
 	// TestWrap_SignalFilterUsesSessionPolicy).
-	signalFilterEnabled := a.signalFilterEnabled(s, execveEnabled)
+	signalUnixSocketEnabled := a.cfg.Sandbox.Seccomp.UnixSocket.Enabled || forceNotifyForPreAckCgroup
+	signalFilterEnabled := a.signalFilterEnabledForMainFilter(s, execveEnabled, signalUnixSocketEnabled)
 	if signalFilterEnabled {
 		signalSocketPath = filepath.Join(notifyDir, "signal-"+safeID+".sock")
 		signalListener, err := net.Listen("unix", signalSocketPath)
@@ -402,11 +416,6 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 			}
 			go a.acceptSignalFD(ctx, signalListener, signalSocketPath, sessionID, s, req.CallerUID)
 		}
-	}
-
-	unixSocketEnabled := a.cfg.Sandbox.Seccomp.UnixSocket.Enabled
-	if a.cfg.Sandbox.UnixSockets.Enabled != nil && *a.cfg.Sandbox.UnixSockets.Enabled {
-		unixSocketEnabled = true
 	}
 
 	seccompCfg := a.buildSeccompWrapperConfig(s, seccompWrapperParams{
@@ -523,7 +532,15 @@ func (a *App) deriveLandlockAllowPaths(s *session.Session) (execute, read, write
 // tested end-to-end without standing up seccomp. See
 // TestWrap_SignalFilterUsesSessionPolicy.
 func (a *App) signalFilterEnabled(s *session.Session, execveEnabled bool) bool {
-	if a.mainFilterUsesUserNotify(execveEnabled) {
+	unixSocketEnabled := false
+	if a.cfg != nil {
+		unixSocketEnabled = a.cfg.Sandbox.Seccomp.UnixSocket.Enabled
+	}
+	return a.signalFilterEnabledForMainFilter(s, execveEnabled, unixSocketEnabled)
+}
+
+func (a *App) signalFilterEnabledForMainFilter(s *session.Session, execveEnabled bool, unixSocketEnabled bool) bool {
+	if a.mainFilterUsesUserNotifyForWrap(execveEnabled, unixSocketEnabled) {
 		return false
 	}
 	engine := a.policyEngineFor(s)
@@ -549,13 +566,21 @@ func (a *App) signalFilterEnabled(s *session.Session, execveEnabled bool) bool {
 // Returns false when a.cfg is nil: tests construct bare Apps without
 // a config, and in that case no wrapper-installed filter exists.
 func (a *App) mainFilterUsesUserNotify(execveEnabled bool) bool {
+	unixSocketEnabled := false
+	if a.cfg != nil {
+		unixSocketEnabled = a.cfg.Sandbox.Seccomp.UnixSocket.Enabled
+	}
+	return a.mainFilterUsesUserNotifyForWrap(execveEnabled, unixSocketEnabled)
+}
+
+func (a *App) mainFilterUsesUserNotifyForWrap(execveEnabled bool, unixSocketEnabled bool) bool {
 	if execveEnabled {
 		return true
 	}
 	if a.cfg == nil {
 		return false
 	}
-	if a.cfg.Sandbox.Seccomp.UnixSocket.Enabled {
+	if unixSocketEnabled {
 		return true
 	}
 	if config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.Enabled, false) {
@@ -673,6 +698,7 @@ func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketP
 
 	var conn net.Conn
 	var notifyPeerPID int
+	var notifyPeerUID uint32
 	for {
 		nextConn, err := listener.Accept()
 		if err != nil {
@@ -690,6 +716,7 @@ func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketP
 		// Read the notify-socket peer credentials and enforce the expected UID.
 		creds := getConnPeerCreds(unixConn)
 		notifyPeerPID = creds.PID
+		notifyPeerUID = creds.UID
 		if notifyPeerPID > 0 {
 			slog.Debug("wrap: got notify-socket peer credentials",
 				"peer_pid", notifyPeerPID, "peer_uid", creds.UID, "session_id", sessionID)
@@ -743,6 +770,15 @@ func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketP
 				slog.Debug("wrap: failed to write notify setup rejection", "session_id", sessionID, "error", statusErr)
 			}
 			slog.Warn("wrap: rejecting notify fd without wrapper pid metadata", "session_id", sessionID)
+			return
+		}
+		if err := validateWrapperPIDForNotifyHook(meta.WrapperPID, notifyPeerPID, notifyPeerUID); err != nil {
+			_ = notifyFD.Close()
+			if statusErr := writeNotifyStatusForWrap(unixConn, false); statusErr != nil {
+				slog.Debug("wrap: failed to write notify setup rejection", "session_id", sessionID, "error", statusErr)
+			}
+			slog.Warn("wrap: rejecting notify fd with untrusted wrapper pid metadata",
+				"session_id", sessionID, "wrapper_pid", meta.WrapperPID, "peer_pid", notifyPeerPID, "peer_uid", notifyPeerUID, "error", err)
 			return
 		}
 		cgroupCleanup, err := wrapCgroupSetupForNotifyHook(ctx, a, s, sessionID, wrapperPID)

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -14,6 +14,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	unixmon "github.com/agentsh/agentsh/internal/netmonitor/unix"
@@ -237,6 +239,81 @@ func (a *App) wrapInitWindows(_ context.Context, _ *session.Session, _ string, _
 type peerCreds struct {
 	PID int
 	UID uint32
+}
+
+type wrapperProcStatus struct {
+	PPid int
+	UIDs []uint32
+}
+
+func validateWrapperPIDForNotify(wrapperPID, peerPID int, peerUID uint32) error {
+	if wrapperPID <= 0 {
+		return fmt.Errorf("invalid wrapper pid %d", wrapperPID)
+	}
+	if peerPID <= 0 {
+		return fmt.Errorf("missing notify peer pid for wrapper pid %d", wrapperPID)
+	}
+	status, err := readWrapperProcStatus(wrapperPID)
+	if err != nil {
+		return err
+	}
+	if status.PPid != peerPID {
+		return fmt.Errorf("wrapper pid %d parent pid %d does not match notify peer pid %d", wrapperPID, status.PPid, peerPID)
+	}
+	for _, uid := range status.UIDs {
+		if uid == peerUID {
+			return nil
+		}
+	}
+	return fmt.Errorf("wrapper pid %d uid set %v does not include notify peer uid %d", wrapperPID, status.UIDs, peerUID)
+}
+
+func readWrapperProcStatus(pid int) (wrapperProcStatus, error) {
+	data, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "status"))
+	if err != nil {
+		return wrapperProcStatus{}, fmt.Errorf("read wrapper proc status for pid %d: %w", pid, err)
+	}
+	status, err := parseWrapperProcStatus(data)
+	if err != nil {
+		return wrapperProcStatus{}, fmt.Errorf("parse wrapper proc status for pid %d: %w", pid, err)
+	}
+	return status, nil
+}
+
+func parseWrapperProcStatus(data []byte) (wrapperProcStatus, error) {
+	var status wrapperProcStatus
+	ppidSet := false
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		switch fields[0] {
+		case "PPid:":
+			ppid, err := strconv.Atoi(fields[1])
+			if err != nil {
+				return wrapperProcStatus{}, fmt.Errorf("invalid PPid %q: %w", fields[1], err)
+			}
+			status.PPid = ppid
+			ppidSet = true
+		case "Uid:":
+			status.UIDs = status.UIDs[:0]
+			for _, field := range fields[1:] {
+				uid64, err := strconv.ParseUint(field, 10, 32)
+				if err != nil {
+					return wrapperProcStatus{}, fmt.Errorf("invalid Uid %q: %w", field, err)
+				}
+				status.UIDs = append(status.UIDs, uint32(uid64))
+			}
+		}
+	}
+	if !ppidSet {
+		return wrapperProcStatus{}, errors.New("missing PPid")
+	}
+	if len(status.UIDs) == 0 {
+		return wrapperProcStatus{}, errors.New("missing Uid")
+	}
+	return status, nil
 }
 
 // getConnPeerCreds extracts the peer process credentials from a Unix connection.

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -19,6 +19,7 @@ import (
 	unixmon "github.com/agentsh/agentsh/internal/netmonitor/unix"
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/internal/signal"
+	"github.com/agentsh/agentsh/internal/wraphandoff"
 	"github.com/agentsh/agentsh/pkg/types"
 	"golang.org/x/sys/unix"
 )
@@ -55,10 +56,22 @@ func recvFDFromConn(sock *os.File) (*os.File, error) {
 	return nil, fmt.Errorf("no fd in control message")
 }
 
+func recvNotifyFDForWrap(conn *net.UnixConn) (*os.File, wrapNotifyMetadata, bool, error) {
+	notifyFD, meta, hasMeta, err := wraphandoff.RecvNotifyFD(conn)
+	if err != nil {
+		return nil, wrapNotifyMetadata{}, false, err
+	}
+	return notifyFD, wrapNotifyMetadata{WrapperPID: meta.WrapperPID}, hasMeta, nil
+}
+
+func writeNotifyStatusForWrap(w io.Writer, ok bool) error {
+	return wraphandoff.WriteStatus(w, ok)
+}
+
 // startNotifyHandlerForWrap starts the seccomp notify handler for a wrap session.
 // Unlike the exec path where the notify fd comes from a socketpair, here it comes
 // from the CLI via a Unix socket connection.
-func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session) {
+func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) {
 	emitter := &notifyEmitterAdapter{store: a.store, broker: a.broker}
 
 	// Prefer session-specific policy engine (has expanded ${PROJECT_ROOT} etc.)
@@ -151,6 +164,13 @@ func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID
 
 	go func() {
 		defer notifyFD.Close()
+		if cleanup != nil {
+			defer func() {
+				if err := cleanup(); err != nil {
+					slog.Warn("wrap: cgroup cleanup failed", "session_id", sessionID, "error", err)
+				}
+			}()
+		}
 		if cleanupSymlink != nil {
 			defer cleanupSymlink()
 		}

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -71,7 +71,7 @@ func writeNotifyStatusForWrap(w io.Writer, ok bool) error {
 // startNotifyHandlerForWrap starts the seccomp notify handler for a wrap session.
 // Unlike the exec path where the notify fd comes from a socketpair, here it comes
 // from the CLI via a Unix socket connection.
-func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) {
+func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) error {
 	emitter := &notifyEmitterAdapter{store: a.store, broker: a.broker}
 
 	// Prefer session-specific policy engine (has expanded ${PROJECT_ROOT} etc.)
@@ -112,13 +112,13 @@ func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID
 							stubPath = abs
 						}
 					}
-					symlinkPath, cleanup, err := unixmon.CreateStubSymlink(stubPath)
+					symlinkPath, symlinkCleanup, err := unixmon.CreateStubSymlink(stubPath)
 					if err != nil {
 						slog.Warn("wrap: failed to create stub symlink, redirect will deny",
 							"error", err, "session_id", sessionID)
 					} else {
 						execveHandler.SetStubSymlinkPath(symlinkPath)
-						cleanupSymlink = cleanup
+						cleanupSymlink = symlinkCleanup
 						slog.Debug("wrap: created stub symlink",
 							"symlink", symlinkPath, "target", stubPath, "session_id", sessionID)
 					}
@@ -153,7 +153,7 @@ func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID
 				if cleanupSymlink != nil {
 					cleanupSymlink()
 				}
-				return
+				return fmt.Errorf("wrap notify handler startup probe failed for wrapper pid %d: pvr_error=%v mem_error=%v", wrapperPID, pvrErr, memErr)
 			}
 			slog.Warn("wrap: ProcessVMReadv probe failed, monitoring may be degraded",
 				"wrapper_pid", wrapperPID, "pvr_error", pvrErr, "mem_error", memErr)
@@ -192,6 +192,7 @@ func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID
 		unixmon.ServeNotifyWithExecve(ctx, notifyFD, sessionID, sessionPolicy, emitter, execveHandler, fileHandler, bl)
 		slog.Info("wrap: notify handler returned", "session_id", sessionID)
 	}()
+	return nil
 }
 
 // startSignalHandlerForWrap starts the signal filter handler for a wrap session.

--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -81,6 +81,14 @@ func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID
 	// Create execve handler if enabled
 	var execveHandler *unixmon.ExecveHandler
 	var cleanupSymlink func()
+	runCleanup := func() {
+		if cleanup == nil {
+			return
+		}
+		if err := cleanup(); err != nil {
+			slog.Warn("wrap: cgroup cleanup failed", "session_id", sessionID, "error", err)
+		}
+	}
 	if execveEnabled {
 		if h := createExecveHandler(a.cfg.Sandbox.Seccomp.Execve, sessionPolicy, a.approvals); h != nil {
 			execveHandler, _ = h.(*unixmon.ExecveHandler)
@@ -141,6 +149,7 @@ func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID
 						"or set sandbox.seccomp.file_monitor.enabled: false")
 				// Clean up resources that would normally be handled by the goroutine.
 				notifyFD.Close()
+				runCleanup()
 				if cleanupSymlink != nil {
 					cleanupSymlink()
 				}
@@ -165,11 +174,7 @@ func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID
 	go func() {
 		defer notifyFD.Close()
 		if cleanup != nil {
-			defer func() {
-				if err := cleanup(); err != nil {
-					slog.Warn("wrap: cgroup cleanup failed", "session_id", sessionID, "error", err)
-				}
-			}()
+			defer runCleanup()
 		}
 		if cleanupSymlink != nil {
 			defer cleanupSymlink()

--- a/internal/api/wrap_linux_test.go
+++ b/internal/api/wrap_linux_test.go
@@ -83,7 +83,7 @@ func withNotifyHandoffHook(t *testing.T) chan struct{} {
 
 	called := make(chan struct{})
 	prev := startNotifyHandlerForWrapHook
-	startNotifyHandlerForWrapHook = func(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) {
+	startNotifyHandlerForWrapHook = func(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) error {
 		if cleanup != nil {
 			_ = cleanup()
 		}
@@ -91,6 +91,7 @@ func withNotifyHandoffHook(t *testing.T) chan struct{} {
 			_ = notifyFD.Close()
 		}
 		close(called)
+		return nil
 	}
 	t.Cleanup(func() {
 		startNotifyHandlerForWrapHook = prev
@@ -119,7 +120,9 @@ func TestStartNotifyHandlerForWrap_CleansUpAfterProbeFailure(t *testing.T) {
 		return nil
 	}
 
-	startNotifyHandlerForWrap(context.Background(), notifyFD, "test-session", app, false, 999999999, nil, cleanup)
+	if err := startNotifyHandlerForWrap(context.Background(), notifyFD, "test-session", app, false, 999999999, nil, cleanup); err == nil {
+		t.Fatal("expected synchronous handler startup failure")
+	}
 
 	if got := cleanupCalls.Load(); got != 1 {
 		t.Fatalf("cleanup calls = %d, want 1", got)
@@ -352,12 +355,13 @@ func TestAcceptNotifyFD_UsesMetadataWrapperPIDForCgroupBeforeAck(t *testing.T) {
 		setupCalled <- wrapperPID
 		return func() error { return nil }, nil
 	}
-	startNotifyHandlerForWrapHook = func(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) {
+	startNotifyHandlerForWrapHook = func(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) error {
 		_ = notifyFD.Close()
 		if cleanup != nil {
 			_ = cleanup()
 		}
 		close(startCalled)
+		return nil
 	}
 	t.Cleanup(func() {
 		wrapCgroupSetupForNotifyHook = prevSetup
@@ -449,6 +453,78 @@ func TestAcceptNotifyFD_RejectsMissingMetadataWhenEBPFRequired(t *testing.T) {
 	default:
 	}
 	waitForTestDone(t, done)
+}
+
+func TestAcceptNotifyFD_RejectsWhenNotifyHandlerFailsBeforeAck(t *testing.T) {
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Network.EBPF.Enabled = true
+	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &enabled
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	const missingWrapperPID = 999999999
+	prevSetup := wrapCgroupSetupForNotifyHook
+	setupCalled := make(chan int, 1)
+	var cleanupCalls atomic.Int32
+	wrapCgroupSetupForNotifyHook = func(ctx context.Context, a *App, s *session.Session, sessionID string, wrapperPID int) (func() error, error) {
+		setupCalled <- wrapperPID
+		return func() error {
+			cleanupCalls.Add(1)
+			return nil
+		}, nil
+	}
+	t.Cleanup(func() {
+		wrapCgroupSetupForNotifyHook = prevSetup
+	})
+
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "notify.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptNotifyFD(context.Background(), listener, socketPath, s.ID, s, false, 0, false)
+	}()
+
+	conn := dialUnixConn(t, socketPath)
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = pipeR.Close()
+		_ = pipeW.Close()
+	})
+
+	if err := wraphandoff.SendNotifyFD(conn, int(pipeR.Fd()), wraphandoff.Metadata{WrapperPID: missingWrapperPID}); err != nil {
+		t.Fatalf("send handoff: %v", err)
+	}
+	if err := wraphandoff.ReadStatus(conn); err == nil {
+		t.Fatal("expected server rejection status")
+	}
+	waitForTestDone(t, done)
+
+	select {
+	case got := <-setupCalled:
+		if got != missingWrapperPID {
+			t.Fatalf("cgroup setup pid = %d, want %d", got, missingWrapperPID)
+		}
+	default:
+		t.Fatal("expected cgroup setup to be called")
+	}
+	if got := cleanupCalls.Load(); got != 1 {
+		t.Fatalf("cleanup calls = %d, want 1", got)
+	}
 }
 
 func TestAcceptNotifyFD_ContinuesAfterWrongUID(t *testing.T) {

--- a/internal/api/wrap_linux_test.go
+++ b/internal/api/wrap_linux_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/wraphandoff"
 	"golang.org/x/sys/unix"
 )
 
@@ -81,7 +82,10 @@ func withNotifyHandoffHook(t *testing.T) chan struct{} {
 
 	called := make(chan struct{})
 	prev := startNotifyHandlerForWrapHook
-	startNotifyHandlerForWrapHook = func(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session) {
+	startNotifyHandlerForWrapHook = func(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) {
+		if cleanup != nil {
+			_ = cleanup()
+		}
 		if notifyFD != nil {
 			_ = notifyFD.Close()
 		}
@@ -299,6 +303,123 @@ func TestAcceptNotifyFD_AcceptsLegacyZeroUID(t *testing.T) {
 	default:
 		t.Fatal("expected notify handoff to be called")
 	}
+}
+
+func TestAcceptNotifyFD_UsesMetadataWrapperPIDForCgroupBeforeAck(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Network.EBPF.Enabled = true
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	prevSetup := wrapCgroupSetupForNotifyHook
+	prevStart := startNotifyHandlerForWrapHook
+	setupCalled := make(chan int, 1)
+	startCalled := make(chan struct{})
+	wrapCgroupSetupForNotifyHook = func(ctx context.Context, a *App, s *session.Session, sessionID string, wrapperPID int) (func() error, error) {
+		setupCalled <- wrapperPID
+		return func() error { return nil }, nil
+	}
+	startNotifyHandlerForWrapHook = func(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) {
+		_ = notifyFD.Close()
+		if cleanup != nil {
+			_ = cleanup()
+		}
+		close(startCalled)
+	}
+	t.Cleanup(func() {
+		wrapCgroupSetupForNotifyHook = prevSetup
+		startNotifyHandlerForWrapHook = prevStart
+	})
+
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "notify.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptNotifyFD(context.Background(), listener, socketPath, s.ID, s, false, 0, false)
+	}()
+
+	conn := dialUnixConn(t, socketPath)
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = pipeR.Close()
+		_ = pipeW.Close()
+	})
+
+	if err := wraphandoff.SendNotifyFD(conn, int(pipeR.Fd()), wraphandoff.Metadata{WrapperPID: 7777}); err != nil {
+		t.Fatalf("send handoff: %v", err)
+	}
+	if err := wraphandoff.ReadStatus(conn); err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+
+	if got := <-setupCalled; got != 7777 {
+		t.Fatalf("cgroup setup pid = %d, want 7777", got)
+	}
+	<-startCalled
+	waitForTestDone(t, done)
+}
+
+func TestAcceptNotifyFD_RejectsMissingMetadataWhenEBPFRequired(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Network.EBPF.Enabled = true
+	cfg.Sandbox.Network.EBPF.Required = true
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	called := withNotifyHandoffHook(t)
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "notify.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptNotifyFD(context.Background(), listener, socketPath, s.ID, s, false, 0, false)
+	}()
+
+	conn := dialUnixConn(t, socketPath)
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = pipeR.Close()
+		_ = pipeW.Close()
+	})
+
+	sendFDOverUnixConn(t, conn, int(pipeR.Fd()))
+	if err := wraphandoff.ReadStatus(conn); err == nil {
+		t.Fatal("expected server rejection status")
+	}
+
+	select {
+	case <-called:
+		t.Fatal("notify handler should not start")
+	default:
+	}
+	waitForTestDone(t, done)
 }
 
 func TestAcceptNotifyFD_ContinuesAfterWrongUID(t *testing.T) {

--- a/internal/api/wrap_linux_test.go
+++ b/internal/api/wrap_linux_test.go
@@ -99,6 +99,15 @@ func withNotifyHandoffHook(t *testing.T) chan struct{} {
 	return called
 }
 
+func withWrapperPIDValidationHook(t *testing.T, fn func(wrapperPID, peerPID int, peerUID uint32) error) {
+	t.Helper()
+	prev := validateWrapperPIDForNotifyHook
+	validateWrapperPIDForNotifyHook = fn
+	t.Cleanup(func() {
+		validateWrapperPIDForNotifyHook = prev
+	})
+}
+
 func TestStartNotifyHandlerForWrap_CleansUpAfterProbeFailure(t *testing.T) {
 	enabled := true
 	cfg := &config.Config{}
@@ -363,6 +372,9 @@ func TestAcceptNotifyFD_UsesMetadataWrapperPIDForCgroupBeforeAck(t *testing.T) {
 		close(startCalled)
 		return nil
 	}
+	withWrapperPIDValidationHook(t, func(wrapperPID, peerPID int, peerUID uint32) error {
+		return nil
+	})
 	t.Cleanup(func() {
 		wrapCgroupSetupForNotifyHook = prevSetup
 		startNotifyHandlerForWrapHook = prevStart
@@ -404,6 +416,71 @@ func TestAcceptNotifyFD_UsesMetadataWrapperPIDForCgroupBeforeAck(t *testing.T) {
 	}
 	<-startCalled
 	waitForTestDone(t, done)
+}
+
+func TestAcceptNotifyFD_RejectsMetadataPIDThatIsNotPeerChild(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Network.EBPF.Required = true
+	app, mgr := newTestAppForWrap(t, cfg)
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	prevSetup := wrapCgroupSetupForNotifyHook
+	setupCalled := make(chan struct{}, 1)
+	wrapCgroupSetupForNotifyHook = func(ctx context.Context, a *App, s *session.Session, sessionID string, wrapperPID int) (func() error, error) {
+		setupCalled <- struct{}{}
+		return func() error { return nil }, nil
+	}
+	t.Cleanup(func() {
+		wrapCgroupSetupForNotifyHook = prevSetup
+	})
+	called := withNotifyHandoffHook(t)
+
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "notify.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptNotifyFD(context.Background(), listener, socketPath, s.ID, s, false, os.Getuid(), false)
+	}()
+
+	conn := dialUnixConn(t, socketPath)
+	pipeR, pipeW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = pipeR.Close()
+		_ = pipeW.Close()
+	})
+
+	if err := wraphandoff.SendNotifyFD(conn, int(pipeR.Fd()), wraphandoff.Metadata{WrapperPID: os.Getpid()}); err != nil {
+		t.Fatalf("send handoff: %v", err)
+	}
+	if err := wraphandoff.ReadStatus(conn); err == nil {
+		t.Fatal("expected server rejection status")
+	}
+	waitForTestDone(t, done)
+
+	select {
+	case <-setupCalled:
+		t.Fatal("cgroup setup should not run for untrusted wrapper PID metadata")
+	default:
+	}
+	select {
+	case <-called:
+		t.Fatal("notify handler should not start for untrusted wrapper PID metadata")
+	default:
+	}
 }
 
 func TestAcceptNotifyFD_RejectsMissingMetadataWhenEBPFRequired(t *testing.T) {
@@ -478,6 +555,9 @@ func TestAcceptNotifyFD_RejectsWhenNotifyHandlerFailsBeforeAck(t *testing.T) {
 			return nil
 		}, nil
 	}
+	withWrapperPIDValidationHook(t, func(wrapperPID, peerPID int, peerUID uint32) error {
+		return nil
+	})
 	t.Cleanup(func() {
 		wrapCgroupSetupForNotifyHook = prevSetup
 	})

--- a/internal/api/wrap_linux_test.go
+++ b/internal/api/wrap_linux_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -95,6 +96,34 @@ func withNotifyHandoffHook(t *testing.T) chan struct{} {
 		startNotifyHandlerForWrapHook = prev
 	})
 	return called
+}
+
+func TestStartNotifyHandlerForWrap_CleansUpAfterProbeFailure(t *testing.T) {
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.Seccomp.FileMonitor.Enabled = &enabled
+	app, _ := newTestAppForWrap(t, cfg)
+
+	notifyFD, notifyW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = notifyFD.Close()
+		_ = notifyW.Close()
+	})
+
+	var cleanupCalls atomic.Int32
+	cleanup := func() error {
+		cleanupCalls.Add(1)
+		return nil
+	}
+
+	startNotifyHandlerForWrap(context.Background(), notifyFD, "test-session", app, false, 999999999, nil, cleanup)
+
+	if got := cleanupCalls.Load(); got != 1 {
+		t.Fatalf("cleanup calls = %d, want 1", got)
+	}
 }
 
 func TestAcceptNotifyFD_RejectsWrongUID(t *testing.T) {

--- a/internal/api/wrap_other.go
+++ b/internal/api/wrap_other.go
@@ -36,8 +36,9 @@ func writeNotifyStatusForWrap(w io.Writer, ok bool) error {
 	return errWrapNotSupported
 }
 
-func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) {
+func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) error {
 	// No-op on non-Linux platforms
+	return nil
 }
 
 func startSignalHandlerForWrap(ctx context.Context, signalFD *os.File, sessionID string, a *App, s *session.Session) {

--- a/internal/api/wrap_other.go
+++ b/internal/api/wrap_other.go
@@ -55,6 +55,10 @@ func getConnPeerCreds(conn *net.UnixConn) peerCreds {
 	return peerCreds{}
 }
 
+func validateWrapperPIDForNotify(wrapperPID, peerPID int, peerUID uint32) error {
+	return nil
+}
+
 func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string, expectedUID int) {
 	listener.Close()
 }

--- a/internal/api/wrap_other.go
+++ b/internal/api/wrap_other.go
@@ -5,6 +5,7 @@ package api
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -27,7 +28,15 @@ func recvFDFromConn(sock *os.File) (*os.File, error) {
 	return nil, errWrapNotSupported
 }
 
-func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session) {
+func recvNotifyFDForWrap(conn *net.UnixConn) (*os.File, wrapNotifyMetadata, bool, error) {
+	return nil, wrapNotifyMetadata{}, false, errWrapNotSupported
+}
+
+func writeNotifyStatusForWrap(w io.Writer, ok bool) error {
+	return errWrapNotSupported
+}
+
+func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) {
 	// No-op on non-Linux platforms
 }
 

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -905,6 +905,39 @@ func TestWrapInit_SeccompConfigContent(t *testing.T) {
 	}
 }
 
+func TestWrapInit_ForcesNotifyHandoffWhenEBPFRequiresPreAckCgroup(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	disabled := false
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &disabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Network.EBPF.Required = true
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", code)
+	}
+
+	var parsed seccompWrapperConfig
+	require.NoError(t, json.Unmarshal([]byte(resp.SeccompConfig), &parsed))
+	require.True(t, parsed.UnixSocketEnabled, "pre-ACK cgroup/eBPF setup requires a user-notify handoff before wrapper exec")
+}
+
 func TestWrapInit_SeccompConfigContent_MitigationSetsForwardSocketRules(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("wrap is Linux-only")

--- a/internal/api/wrap_windows.go
+++ b/internal/api/wrap_windows.go
@@ -49,8 +49,9 @@ func writeNotifyStatusForWrap(w io.Writer, ok bool) error {
 	return errWrapNotSupported
 }
 
-func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) {
+func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) error {
 	// Not used on Windows — the driver handles exec interception directly.
+	return nil
 }
 
 func getConnPeerCreds(conn *net.UnixConn) peerCreds {

--- a/internal/api/wrap_windows.go
+++ b/internal/api/wrap_windows.go
@@ -58,6 +58,10 @@ func getConnPeerCreds(conn *net.UnixConn) peerCreds {
 	return peerCreds{}
 }
 
+func validateWrapperPIDForNotify(wrapperPID, peerPID int, peerUID uint32) error {
+	return nil
+}
+
 func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socketPath string, sessionID string, expectedUID int) {
 	listener.Close()
 }

--- a/internal/api/wrap_windows.go
+++ b/internal/api/wrap_windows.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -40,7 +41,15 @@ func recvFDFromConn(sock *os.File) (*os.File, error) {
 	return nil, fmt.Errorf("SCM_RIGHTS not available on Windows")
 }
 
-func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session) {
+func recvNotifyFDForWrap(conn *net.UnixConn) (*os.File, wrapNotifyMetadata, bool, error) {
+	return nil, wrapNotifyMetadata{}, false, errWrapNotSupported
+}
+
+func writeNotifyStatusForWrap(w io.Writer, ok bool) error {
+	return errWrapNotSupported
+}
+
+func startNotifyHandlerForWrap(ctx context.Context, notifyFD *os.File, sessionID string, a *App, execveEnabled bool, wrapperPID int, s *session.Session, cleanup func() error) {
 	// Not used on Windows — the driver handles exec interception directly.
 }
 

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -101,6 +101,7 @@ func runWrap(ctx context.Context, cfg *clientConfig, opts wrapOptions) error {
 	}
 	sessID := sess.ID
 	workspaceMount := sess.WorkspaceMount
+	networkProxyURL := sess.ProxyURL
 	llmProxyURL := sess.LLMProxyURL
 	if opts.sessionID == "" {
 		fmt.Fprintf(os.Stderr, "agentsh: session %s created (policy: %s)\n", sessID, opts.policy)
@@ -149,6 +150,8 @@ func runWrap(ctx context.Context, cfg *clientConfig, opts wrapOptions) error {
 		agentProc.Stderr = os.Stderr
 		agentProc.Env = buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, false)
 	}
+
+	agentProc.Env = appendWrapNetworkProxyEnv(agentProc.Env, networkProxyURL)
 
 	// If FUSE mount is active, add it to the environment and set the working
 	// directory so the child process starts inside the mount. This ensures even
@@ -339,6 +342,77 @@ func buildWrapEnv(base []string, sessionID string, serverAddr string, bypassShel
 		env = append(env, "AGENTSH_IN_SESSION=1")
 	}
 	return env
+}
+
+func appendWrapNetworkProxyEnv(base []string, proxyURL string) []string {
+	if strings.TrimSpace(proxyURL) == "" {
+		return base
+	}
+
+	const noProxyDefault = "localhost,127.0.0.1"
+	proxyKeys := map[string]struct{}{
+		"HTTP_PROXY":  {},
+		"HTTPS_PROXY": {},
+		"ALL_PROXY":   {},
+		"http_proxy":  {},
+		"https_proxy": {},
+		"all_proxy":   {},
+		"NO_PROXY":    {},
+		"no_proxy":    {},
+	}
+
+	out := make([]string, 0, len(base)+8)
+	noProxyTokens := make([]string, 0)
+	noProxySeen := map[string]struct{}{}
+	for _, e := range base {
+		key, val, found := strings.Cut(e, "=")
+		if !found {
+			out = append(out, e)
+			continue
+		}
+		if strings.EqualFold(key, "NO_PROXY") {
+			for _, token := range strings.Split(val, ",") {
+				token = strings.TrimSpace(token)
+				if token == "" {
+					continue
+				}
+				if _, ok := noProxySeen[token]; ok {
+					continue
+				}
+				noProxySeen[token] = struct{}{}
+				noProxyTokens = append(noProxyTokens, token)
+			}
+			continue
+		}
+		if _, ok := proxyKeys[key]; ok {
+			continue
+		}
+		out = append(out, e)
+	}
+
+	if len(noProxyTokens) == 0 {
+		noProxyTokens = strings.Split(noProxyDefault, ",")
+	} else {
+		if _, ok := noProxySeen["localhost"]; !ok {
+			noProxyTokens = append(noProxyTokens, "localhost")
+		}
+		if _, ok := noProxySeen["127.0.0.1"]; !ok {
+			noProxyTokens = append(noProxyTokens, "127.0.0.1")
+		}
+	}
+	noProxy := strings.Join(noProxyTokens, ",")
+
+	out = append(out,
+		fmt.Sprintf("HTTP_PROXY=%s", proxyURL),
+		fmt.Sprintf("HTTPS_PROXY=%s", proxyURL),
+		fmt.Sprintf("ALL_PROXY=%s", proxyURL),
+		fmt.Sprintf("http_proxy=%s", proxyURL),
+		fmt.Sprintf("https_proxy=%s", proxyURL),
+		fmt.Sprintf("all_proxy=%s", proxyURL),
+		fmt.Sprintf("NO_PROXY=%s", noProxy),
+		fmt.Sprintf("no_proxy=%s", noProxy),
+	)
+	return out
 }
 
 // fetchSessionForWrap resolves the session for runWrap, either by reusing

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -233,7 +233,7 @@ func runWrap(ctx context.Context, cfg *clientConfig, opts wrapOptions) error {
 		fmt.Fprintf(os.Stderr, "agentsh: agent %s started with %s interception (pid: %d)\n", opts.agentCmd, mechanism, agentProc.Process.Pid)
 		// Forward the notify fd to the server in the background
 		if wrapCfg.postStart != nil {
-			go wrapCfg.postStart()
+			go wrapCfg.postStart(agentProc.Process.Pid)
 		}
 	} else {
 		fmt.Fprintf(os.Stderr, "agentsh: agent %s started (pid: %d)\n", opts.agentCmd, agentProc.Process.Pid)
@@ -281,9 +281,9 @@ type wrapLaunchConfig struct {
 	env         []string
 	extraFiles  []*os.File
 	sysProcAttr *syscall.SysProcAttr
-	postStart   func()    // Called after the process starts (e.g., to forward notify fd)
-	postWait    func()    // Called after the process exits (e.g., to reclaim terminal)
-	keepAlive   io.Closer // Held open during shell lifetime (e.g., ptrace handshake conn)
+	postStart   func(childPID int) // Called after process start to forward notify fd with child PID
+	postWait    func()             // Called after the process exits (e.g., to reclaim terminal)
+	keepAlive   io.Closer          // Held open during shell lifetime (e.g., ptrace handshake conn)
 	// ptracePostStart is called after the child is started with the child PID.
 	// It performs the ptrace handshake (send PID, wait for ACK).
 	ptracePostStart func(childPID int) error

--- a/internal/cli/wrap_linux.go
+++ b/internal/cli/wrap_linux.go
@@ -5,16 +5,21 @@ package cli
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
 	"os"
 	"syscall"
+	"time"
 	"unsafe"
 
+	"github.com/agentsh/agentsh/internal/wraphandoff"
 	"github.com/agentsh/agentsh/pkg/types"
 	"golang.org/x/sys/unix"
 )
+
+var notifySetupStatusTimeout = 30 * time.Second
 
 // platformSetupWrap creates a socket pair, configures the wrapper launch, and
 // returns a postStart function that receives the notify fd from the wrapper and
@@ -170,7 +175,7 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 				reclaimTerminal()
 			}
 		},
-		postStart: func() {
+		postStart: func(childPID int) {
 			defer parentFile.Close()
 			// Receive the seccomp notify fd from the wrapper
 			notifyFD, err := recvNotifyFD(parentFile)
@@ -181,11 +186,11 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 			defer func() { unix.Close(notifyFD) }()
 
 			// Forward the notify fd to the server's Unix listener socket
-			if err := forwardNotifyFD(notifySocket, notifyFD); err != nil {
+			if err := forwardNotifyFDWithPID(notifySocket, notifyFD, childPID); err != nil {
 				slog.Error("wrap: failed to forward notify fd to server", "error", err, "session_id", sessID)
 				return
 			}
-			slog.Info("wrap: notify fd forwarded to server", "session_id", sessID, "socket", notifySocket)
+			slog.Info("wrap: notify fd accepted by server", "session_id", sessID, "socket", notifySocket, "wrapper_pid", childPID)
 
 			// Send ACK to wrapper so it knows the handler is ready before exec.
 			// This prevents a race where the wrapper execs before the seccomp
@@ -241,8 +246,34 @@ func recvNotifyFD(sock *os.File) (int, error) {
 	return -1, fmt.Errorf("no fd in control message")
 }
 
-// forwardNotifyFD connects to the server's Unix listener socket and sends the
-// notify fd using SCM_RIGHTS.
+func forwardNotifyFDWithPID(socketPath string, notifyFD int, wrapperPID int) error {
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", socketPath, err)
+	}
+	defer conn.Close()
+
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return fmt.Errorf("not a unix connection")
+	}
+
+	if err := wraphandoff.SendNotifyFD(unixConn, notifyFD, wraphandoff.Metadata{WrapperPID: wrapperPID}); err != nil {
+		return err
+	}
+	if err := unixConn.SetReadDeadline(time.Now().Add(notifySetupStatusTimeout)); err != nil {
+		return fmt.Errorf("set notify setup status deadline: %w", err)
+	}
+	if err := wraphandoff.ReadStatus(unixConn); err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return fmt.Errorf("timed out waiting for notify setup status after %s: %w", notifySetupStatusTimeout, err)
+		}
+		return fmt.Errorf("read notify setup status: %w", err)
+	}
+	return nil
+}
+
 func forwardNotifyFD(socketPath string, notifyFD int) error {
 	conn, err := net.Dial("unix", socketPath)
 	if err != nil {

--- a/internal/cli/wrap_linux_test.go
+++ b/internal/cli/wrap_linux_test.go
@@ -1,0 +1,200 @@
+//go:build linux
+
+package cli
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/wraphandoff"
+)
+
+func TestForwardNotifyFDWithPIDWaitsForServerOK(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "notify.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer conn.Close()
+
+		unixConn := conn.(*net.UnixConn)
+		if err := unixConn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+			serverDone <- err
+			return
+		}
+		fd, meta, hasMeta, err := wraphandoff.RecvNotifyFD(unixConn)
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		_ = fd.Close()
+		if !hasMeta || meta.WrapperPID != 2468 {
+			serverDone <- fmt.Errorf("metadata = %+v, hasMeta=%v", meta, hasMeta)
+			return
+		}
+		serverDone <- wraphandoff.WriteStatus(unixConn, true)
+	}()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	if err := forwardNotifyFDWithPID(socketPath, int(r.Fd()), 2468); err != nil {
+		t.Fatalf("forward: %v", err)
+	}
+
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatalf("server: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for server")
+	}
+}
+
+func TestForwardNotifyFDWithPIDRejectStatusReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "notify.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer conn.Close()
+
+		unixConn := conn.(*net.UnixConn)
+		if err := unixConn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+			serverDone <- err
+			return
+		}
+		fd, _, _, err := wraphandoff.RecvNotifyFD(unixConn)
+		if err == nil {
+			_ = fd.Close()
+		}
+		if err := wraphandoff.WriteStatus(unixConn, false); err != nil {
+			serverDone <- err
+			return
+		}
+		serverDone <- nil
+	}()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	if err := forwardNotifyFDWithPID(socketPath, int(r.Fd()), 2468); err == nil {
+		t.Fatal("expected reject status error")
+	}
+
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatalf("server: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for server")
+	}
+}
+
+func TestForwardNotifyFDWithPIDTimeoutReturnsError(t *testing.T) {
+	origTimeout := notifySetupStatusTimeout
+	notifySetupStatusTimeout = 20 * time.Millisecond
+	t.Cleanup(func() { notifySetupStatusTimeout = origTimeout })
+
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "notify.sock")
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	releaseServer := make(chan struct{})
+	defer close(releaseServer)
+	serverDone := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		defer conn.Close()
+
+		unixConn := conn.(*net.UnixConn)
+		if err := unixConn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+			serverDone <- err
+			return
+		}
+		fd, _, _, err := wraphandoff.RecvNotifyFD(unixConn)
+		if err != nil {
+			serverDone <- err
+			return
+		}
+		_ = fd.Close()
+		serverDone <- nil
+		<-releaseServer
+	}()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	forwardDone := make(chan error, 1)
+	go func() {
+		forwardDone <- forwardNotifyFDWithPID(socketPath, int(r.Fd()), 2468)
+	}()
+
+	select {
+	case err = <-forwardDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for forwardNotifyFDWithPID")
+	}
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out waiting for notify setup status") {
+		t.Fatalf("error = %v, want timeout status error", err)
+	}
+
+	select {
+	case err := <-serverDone:
+		if err != nil {
+			t.Fatalf("server: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for server")
+	}
+}

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -428,6 +429,123 @@ func TestBuildWrapEnv_ReplacesInheritedMixedCaseAgentshVarsWhenBypassEnabled(t *
 	assert.Equal(t, 0, envMap["agentsh_session_id=stale-session"])
 	assert.Equal(t, 0, envMap["Agentsh_Server=http://stale"])
 	assert.Equal(t, 0, envMap["agentsh_in_session=1"])
+}
+
+func envSliceToMap(env []string) map[string]string {
+	out := make(map[string]string, len(env))
+	for _, kv := range env {
+		k, v, ok := strings.Cut(kv, "=")
+		if ok {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func envKeyCounts(env []string) map[string]int {
+	out := make(map[string]int, len(env))
+	for _, kv := range env {
+		k, _, ok := strings.Cut(kv, "=")
+		if ok {
+			out[k]++
+		}
+	}
+	return out
+}
+
+func splitNoProxyTokens(noProxy string) []string {
+	parts := strings.Split(noProxy, ",")
+	tokens := make([]string, 0, len(parts))
+	for _, part := range parts {
+		tokens = append(tokens, strings.TrimSpace(part))
+	}
+	return tokens
+}
+
+func TestAppendWrapNetworkProxyEnv_AddsSessionProxyVars(t *testing.T) {
+	env := appendWrapNetworkProxyEnv([]string{"PATH=/usr/bin"}, "http://127.0.0.1:18081")
+	got := envSliceToMap(env)
+
+	for _, key := range []string{
+		"HTTP_PROXY",
+		"HTTPS_PROXY",
+		"ALL_PROXY",
+		"http_proxy",
+		"https_proxy",
+		"all_proxy",
+	} {
+		assert.Equal(t, "http://127.0.0.1:18081", got[key], key)
+	}
+	assert.Contains(t, got["NO_PROXY"], "localhost")
+	assert.Contains(t, got["NO_PROXY"], "127.0.0.1")
+	assert.Equal(t, got["NO_PROXY"], got["no_proxy"])
+}
+
+func TestAppendWrapNetworkProxyEnv_ReplacesInheritedProxyVars(t *testing.T) {
+	env := appendWrapNetworkProxyEnv([]string{
+		"PATH=/usr/bin",
+		"HTTP_PROXY=http://stale",
+		"https_proxy=http://stale",
+		"NO_PROXY=example.test",
+	}, "http://127.0.0.1:18081")
+	got := envSliceToMap(env)
+	counts := envKeyCounts(env)
+
+	assert.Equal(t, "http://127.0.0.1:18081", got["HTTP_PROXY"])
+	assert.Equal(t, "http://127.0.0.1:18081", got["https_proxy"])
+	assert.NotContains(t, env, "HTTP_PROXY=http://stale")
+	assert.NotContains(t, env, "https_proxy=http://stale")
+	assert.Equal(t, 1, counts["HTTP_PROXY"])
+	assert.Equal(t, 1, counts["https_proxy"])
+	assert.Equal(t, 1, counts["NO_PROXY"])
+	assert.Equal(t, 1, counts["no_proxy"])
+	assert.Contains(t, got["NO_PROXY"], "example.test")
+	assert.Contains(t, got["NO_PROXY"], "localhost")
+	assert.Contains(t, got["NO_PROXY"], "127.0.0.1")
+}
+
+func TestAppendWrapNetworkProxyEnv_AppendsDistinctNoProxyTokens(t *testing.T) {
+	env := appendWrapNetworkProxyEnv([]string{
+		"PATH=/usr/bin",
+		"NO_PROXY=notlocalhost.example,127.0.0.10",
+	}, "http://127.0.0.1:18081")
+	got := envSliceToMap(env)
+	noProxyTokens := splitNoProxyTokens(got["NO_PROXY"])
+
+	assert.Contains(t, noProxyTokens, "notlocalhost.example")
+	assert.Contains(t, noProxyTokens, "127.0.0.10")
+	assert.Contains(t, noProxyTokens, "localhost")
+	assert.Contains(t, noProxyTokens, "127.0.0.1")
+	assert.Equal(t, got["NO_PROXY"], got["no_proxy"])
+}
+
+func TestAppendWrapNetworkProxyEnv_MergesInheritedNoProxyVariants(t *testing.T) {
+	env := appendWrapNetworkProxyEnv([]string{
+		"PATH=/usr/bin",
+		"NO_PROXY=api.internal, shared.internal",
+		"no_proxy=metadata.internal,shared.internal",
+	}, "http://127.0.0.1:18081")
+	got := envSliceToMap(env)
+	noProxyTokens := splitNoProxyTokens(got["NO_PROXY"])
+
+	assert.Equal(t, []string{
+		"api.internal",
+		"shared.internal",
+		"metadata.internal",
+		"localhost",
+		"127.0.0.1",
+	}, noProxyTokens)
+	assert.Equal(t, got["NO_PROXY"], got["no_proxy"])
+}
+
+func TestAppendWrapNetworkProxyEnv_NoProxyWhenSessionProxyEmpty(t *testing.T) {
+	base := []string{
+		"PATH=/usr/bin",
+		"HTTP_PROXY=http://host-proxy",
+	}
+	env := appendWrapNetworkProxyEnv(base, "")
+
+	assert.Equal(t, base, env)
 }
 
 func TestWrapLaunchConfig_EnvContainsSessionAndWrapper(t *testing.T) {

--- a/internal/shim/kernelinstall/install_linux.go
+++ b/internal/shim/kernelinstall/install_linux.go
@@ -4,6 +4,7 @@ package kernelinstall
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -15,11 +16,14 @@ import (
 	"time"
 
 	"github.com/agentsh/agentsh/internal/client"
+	"github.com/agentsh/agentsh/internal/wraphandoff"
 	"github.com/agentsh/agentsh/pkg/types"
 	"golang.org/x/sys/unix"
 )
 
 const wrapInitTimeout = 10 * time.Second
+
+var notifySetupStatusTimeout = 30 * time.Second
 
 // signalSockFDKey is the env var that the CLI injects for the signal filter
 // socketpair fd.  The shim does NOT replicate the signal-filter second
@@ -263,7 +267,7 @@ func runRelay(p InstallParams, resp types.WrapInitResponse) (Result, error) {
 	// the wrapper's waitForACK read returns EOF/error, causing the wrapper to
 	// exit with a fatal log.  Then wait for the wrapper and return
 	// ResultFailClosed so the shim aborts rather than running the command.
-	if fwdErr := forwardNotifyFD(notifySocket, notifyFD); fwdErr != nil {
+	if fwdErr := forwardNotifyFDWithPID(notifySocket, notifyFD, cmd.Process.Pid); fwdErr != nil {
 		unix.Close(notifyFD)
 		slog.Error("kernelinstall: failed to forward notify fd — closing parent fd to abort wrapper", "error", fwdErr)
 		// Close parentFile: wrapper's waitForACK will see EOF/EBADF and fatal.
@@ -337,10 +341,9 @@ func recvNotifyFD(sock *os.File) (int, error) {
 	return -1, fmt.Errorf("no fd in control message")
 }
 
-// forwardNotifyFD connects to the server's Unix listener socket and sends the
-// notify fd using SCM_RIGHTS.  Mirrors internal/cli/wrap_linux.go
-// forwardNotifyFD.
-func forwardNotifyFD(socketPath string, notifyFD int) error {
+// forwardNotifyFDWithPID connects to the server's Unix listener socket, sends
+// the notify fd plus wrapper PID metadata, and waits for server setup status.
+func forwardNotifyFDWithPID(socketPath string, notifyFD int, wrapperPID int) error {
 	conn, err := net.Dial("unix", socketPath)
 	if err != nil {
 		return fmt.Errorf("dial %s: %w", socketPath, err)
@@ -352,15 +355,18 @@ func forwardNotifyFD(socketPath string, notifyFD int) error {
 		return fmt.Errorf("not a unix connection")
 	}
 
-	file, err := unixConn.File()
-	if err != nil {
-		return fmt.Errorf("get file from connection: %w", err)
+	if err := wraphandoff.SendNotifyFD(unixConn, notifyFD, wraphandoff.Metadata{WrapperPID: wrapperPID}); err != nil {
+		return err
 	}
-	defer file.Close()
-
-	rights := unix.UnixRights(notifyFD)
-	if err := unix.Sendmsg(int(file.Fd()), []byte{0}, rights, nil, 0); err != nil {
-		return fmt.Errorf("sendmsg: %w", err)
+	if err := unixConn.SetReadDeadline(time.Now().Add(notifySetupStatusTimeout)); err != nil {
+		return fmt.Errorf("set notify setup status deadline: %w", err)
+	}
+	if err := wraphandoff.ReadStatus(unixConn); err != nil {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return fmt.Errorf("timed out waiting for notify setup status after %s: %w", notifySetupStatusTimeout, err)
+		}
+		return fmt.Errorf("read notify setup status: %w", err)
 	}
 	return nil
 }

--- a/internal/shim/kernelinstall/install_linux_test.go
+++ b/internal/shim/kernelinstall/install_linux_test.go
@@ -9,9 +9,12 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/agentsh/agentsh/internal/wraphandoff"
 	"github.com/agentsh/agentsh/pkg/types"
 )
 
@@ -43,6 +46,23 @@ func baseParams(srv *httptest.Server) InstallParams {
 		ShellArgs:     []string{"-c", "echo hello"},
 		Env:           []string{"HOME=/tmp"},
 	}
+}
+
+func serveNotifySetupStatus(ln net.Listener, okStatus bool) {
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		unixConn := conn.(*net.UnixConn)
+		fd, _, _, err := wraphandoff.RecvNotifyFD(unixConn)
+		if err == nil {
+			_ = fd.Close()
+			_ = wraphandoff.WriteStatus(unixConn, okStatus)
+		}
+	}()
 }
 
 // ─── Test 1: ModeOff returns ResultSkip without any HTTP call ───────────────
@@ -307,21 +327,13 @@ func TestInstall_StripsSignalSockFdFromPEnv(t *testing.T) {
 
 	// Start a fake notify-socket listener.
 	sockDir := t.TempDir()
-	notifySockPath := sockDir + "/notify.sock"
+	notifySockPath := filepath.Join(sockDir, "notify.sock")
 	ln, err := net.Listen("unix", notifySockPath)
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 	defer ln.Close()
-	go func() {
-		conn, _ := ln.Accept()
-		if conn != nil {
-			buf := make([]byte, 1)
-			oob := make([]byte, 64)
-			conn.(*net.UnixConn).ReadMsgUnix(buf, oob) //nolint:errcheck
-			conn.Close()
-		}
-	}()
+	serveNotifySetupStatus(ln, true)
 
 	wrapResp := types.WrapInitResponse{
 		WrapperBinary: wrapperBin,
@@ -388,21 +400,13 @@ func TestInstall_PassesArgv0ToWrapper(t *testing.T) {
 	wrapperBin := buildFakeWrapperPrintEnv(t)
 
 	sockDir := t.TempDir()
-	notifySockPath := sockDir + "/notify.sock"
+	notifySockPath := filepath.Join(sockDir, "notify.sock")
 	ln, err := net.Listen("unix", notifySockPath)
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 	defer ln.Close()
-	go func() {
-		conn, _ := ln.Accept()
-		if conn != nil {
-			buf := make([]byte, 1)
-			oob := make([]byte, 64)
-			conn.(*net.UnixConn).ReadMsgUnix(buf, oob) //nolint:errcheck
-			conn.Close()
-		}
-	}()
+	serveNotifySetupStatus(ln, true)
 
 	handler, _ := makeWrapInitHandler(200, types.WrapInitResponse{
 		WrapperBinary: wrapperBin,
@@ -449,21 +453,13 @@ func TestInstall_OmitsArgv0WhenEmpty(t *testing.T) {
 	wrapperBin := buildFakeWrapperPrintEnv(t)
 
 	sockDir := t.TempDir()
-	notifySockPath := sockDir + "/notify.sock"
+	notifySockPath := filepath.Join(sockDir, "notify.sock")
 	ln, err := net.Listen("unix", notifySockPath)
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 	defer ln.Close()
-	go func() {
-		conn, _ := ln.Accept()
-		if conn != nil {
-			buf := make([]byte, 1)
-			oob := make([]byte, 64)
-			conn.(*net.UnixConn).ReadMsgUnix(buf, oob) //nolint:errcheck
-			conn.Close()
-		}
-	}()
+	serveNotifySetupStatus(ln, true)
 
 	handler, _ := makeWrapInitHandler(200, types.WrapInitResponse{
 		WrapperBinary: wrapperBin,
@@ -512,21 +508,13 @@ func TestInstall_StripsStaleArgv0FromInheritedEnv(t *testing.T) {
 	wrapperBin := buildFakeWrapperPrintEnv(t)
 
 	sockDir := t.TempDir()
-	notifySockPath := sockDir + "/notify.sock"
+	notifySockPath := filepath.Join(sockDir, "notify.sock")
 	ln, err := net.Listen("unix", notifySockPath)
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 	defer ln.Close()
-	go func() {
-		conn, _ := ln.Accept()
-		if conn != nil {
-			buf := make([]byte, 1)
-			oob := make([]byte, 64)
-			conn.(*net.UnixConn).ReadMsgUnix(buf, oob) //nolint:errcheck
-			conn.Close()
-		}
-	}()
+	serveNotifySetupStatus(ln, true)
 
 	handler, _ := makeWrapInitHandler(200, types.WrapInitResponse{
 		WrapperBinary: wrapperBin,
@@ -589,8 +577,8 @@ func TestFilterShimInternalEnv(t *testing.T) {
 		}
 	}
 	want := map[string]bool{
-		"OTHER=x":                            true,
-		"HOME=/tmp":                          true,
+		"OTHER=x":                              true,
+		"HOME=/tmp":                            true,
 		"AGENTSH_UNIXWRAP_ARGV0_NOT_OURS=keep": true,
 	}
 	got := map[string]bool{}
@@ -667,12 +655,12 @@ func buildFakeWrapperPrintEnv(t *testing.T) string {
 	}
 	t.Cleanup(func() { os.RemoveAll(srcDir) })
 
-	if err := os.WriteFile(srcDir+"/main.go", []byte(fakeWrapperPrintEnvSrc), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte(fakeWrapperPrintEnvSrc), 0644); err != nil {
 		t.Fatalf("write fake wrapper printenv source: %v", err)
 	}
 
 	binDir := t.TempDir()
-	binPath := binDir + "/fakewrap-printenv"
+	binPath := filepath.Join(binDir, "fakewrap-printenv")
 
 	buildCmd := exec.Command(goExe, "build", "-o", binPath, srcDir)
 	buildCmd.Dir = modRoot
@@ -726,6 +714,125 @@ func TestInstall_RelayForwardFail_NoACK_ResultFailClosed(t *testing.T) {
 	}
 	if !strings.Contains(res.Reason, "forward notify fd failed") {
 		t.Errorf("expected Reason to contain 'forward notify fd failed', got %q", res.Reason)
+	}
+}
+
+func TestInstall_RelayServerReject_NoACK_ResultFailClosed(t *testing.T) {
+	wrapperBin := buildFakeWrapperNoACKExit(t)
+
+	notifyDir := t.TempDir()
+	notifySocket := filepath.Join(notifyDir, "notify.sock")
+	ln, err := net.Listen("unix", notifySocket)
+	if err != nil {
+		t.Fatalf("listen notify socket: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		unixConn := conn.(*net.UnixConn)
+		fd, _, _, err := wraphandoff.RecvNotifyFD(unixConn)
+		if err == nil {
+			_ = fd.Close()
+		}
+		_ = wraphandoff.WriteStatus(unixConn, false)
+	}()
+
+	wrapResp := types.WrapInitResponse{
+		WrapperBinary: wrapperBin,
+		NotifySocket:  notifySocket,
+		WrapperEnv:    map[string]string{},
+	}
+	handler, _ := makeWrapInitHandler(200, wrapResp)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	p := baseParams(srv)
+	p.Mode = ModeOn
+
+	res, err := Install(p)
+	if err != nil {
+		t.Fatalf("Install returned error: %v", err)
+	}
+	if res.Action != ResultFailClosed {
+		t.Fatalf("expected ResultFailClosed, got %v (reason: %s)", res.Action, res.Reason)
+	}
+	if !strings.Contains(res.Reason, "server rejected wrap setup") {
+		t.Fatalf("expected server rejection in reason, got %q", res.Reason)
+	}
+}
+
+func TestInstall_RelaySetupStatusTimeout_NoACK_ResultFailClosed(t *testing.T) {
+	wrapperBin := buildFakeWrapperNoACKExit(t)
+
+	origTimeout := notifySetupStatusTimeout
+	notifySetupStatusTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { notifySetupStatusTimeout = origTimeout })
+
+	notifyDir := t.TempDir()
+	notifySocket := filepath.Join(notifyDir, "notify.sock")
+	ln, err := net.Listen("unix", notifySocket)
+	if err != nil {
+		t.Fatalf("listen notify socket: %v", err)
+	}
+	defer ln.Close()
+
+	releaseServer := make(chan struct{})
+	defer close(releaseServer)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		unixConn := conn.(*net.UnixConn)
+		fd, _, _, err := wraphandoff.RecvNotifyFD(unixConn)
+		if err == nil {
+			_ = fd.Close()
+		}
+		<-releaseServer
+	}()
+
+	wrapResp := types.WrapInitResponse{
+		WrapperBinary: wrapperBin,
+		NotifySocket:  notifySocket,
+		WrapperEnv:    map[string]string{},
+	}
+	handler, _ := makeWrapInitHandler(200, wrapResp)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	p := baseParams(srv)
+	p.Mode = ModeOn
+
+	type installResult struct {
+		res Result
+		err error
+	}
+	done := make(chan installResult, 1)
+	go func() {
+		res, err := Install(p)
+		done <- installResult{res: res, err: err}
+	}()
+
+	select {
+	case got := <-done:
+		if got.err != nil {
+			t.Fatalf("Install returned error: %v", got.err)
+		}
+		if got.res.Action != ResultFailClosed {
+			t.Fatalf("expected ResultFailClosed, got %v (reason: %s)", got.res.Action, got.res.Reason)
+		}
+		if !strings.Contains(got.res.Reason, "timed out waiting for notify setup status") {
+			t.Fatalf("expected timeout in reason, got %q", got.res.Reason)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Install did not return after notify setup status timeout")
 	}
 }
 
@@ -788,12 +895,12 @@ func buildFakeWrapperNoACKExit(t *testing.T) string {
 	}
 	t.Cleanup(func() { os.RemoveAll(srcDir) })
 
-	if err := os.WriteFile(srcDir+"/main.go", []byte(fakeWrapperNoACKExitSrc), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte(fakeWrapperNoACKExitSrc), 0644); err != nil {
 		t.Fatalf("write fake wrapper no-ack source: %v", err)
 	}
 
 	binDir := t.TempDir()
-	binPath := binDir + "/fakewrap-noack"
+	binPath := filepath.Join(binDir, "fakewrap-noack")
 
 	buildCmd := exec.Command(goExe, "build", "-o", binPath, srcDir)
 	buildCmd.Dir = modRoot
@@ -813,7 +920,7 @@ func buildFakeWrapperNoACKExit(t *testing.T) string {
 //   3. Reads the ACK byte.
 //   4. Exits with code 42.
 //
-// The fake server listener accepts the forwarded fd and closes immediately.
+// The fake server listener accepts the forwarded fd and writes OK setup status.
 // If the Go toolchain is unavailable the test is skipped.
 
 func TestInstall_RelayHappyPath(t *testing.T) {
@@ -822,24 +929,14 @@ func TestInstall_RelayHappyPath(t *testing.T) {
 
 	// Start a fake notify-socket listener.
 	sockDir := t.TempDir()
-	notifySockPath := sockDir + "/notify.sock"
+	notifySockPath := filepath.Join(sockDir, "notify.sock")
 	ln, err := net.Listen("unix", notifySockPath)
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 	defer ln.Close()
 
-	// Accept and close in background (emulates server receiving the notify fd).
-	go func() {
-		conn, _ := ln.Accept()
-		if conn != nil {
-			// Drain SCM_RIGHTS payload so the sender doesn't block.
-			buf := make([]byte, 1)
-			oob := make([]byte, 64)
-			conn.(*net.UnixConn).ReadMsgUnix(buf, oob) //nolint:errcheck
-			conn.Close()
-		}
-	}()
+	serveNotifySetupStatus(ln, true)
 
 	// httptest server that returns a populated WrapInitResponse.
 	wrapResp := types.WrapInitResponse{
@@ -925,12 +1022,12 @@ func buildFakeWrapper(t *testing.T) string {
 	}
 	t.Cleanup(func() { os.RemoveAll(srcDir) })
 
-	if err := os.WriteFile(srcDir+"/main.go", []byte(fakeWrapperSrc), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, "main.go"), []byte(fakeWrapperSrc), 0644); err != nil {
 		t.Fatalf("write fake wrapper source: %v", err)
 	}
 
 	binDir := t.TempDir()
-	binPath := binDir + "/fakewrap"
+	binPath := filepath.Join(binDir, "fakewrap")
 
 	buildCmd := exec.Command(goExe, "build", "-o", binPath, srcDir)
 	buildCmd.Dir = modRoot
@@ -949,13 +1046,13 @@ func findModuleRoot(t *testing.T) string {
 		t.Fatalf("getwd: %v", err)
 	}
 	for {
-		if _, err := os.Stat(dir + "/go.mod"); err == nil {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
 			return dir
 		}
-		idx := strings.LastIndex(dir, "/")
-		if idx <= 0 {
+		parent := filepath.Dir(dir)
+		if parent == dir {
 			t.Fatal("could not find go.mod")
 		}
-		dir = dir[:idx]
+		dir = parent
 	}
 }

--- a/internal/wraphandoff/handoff_linux.go
+++ b/internal/wraphandoff/handoff_linux.go
@@ -1,0 +1,140 @@
+//go:build linux
+
+package wraphandoff
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	protocolMagic byte = 0xA7
+	StatusReject  byte = 0
+	StatusOK      byte = 1
+)
+
+type Metadata struct {
+	WrapperPID int
+}
+
+func SendNotifyFD(conn *net.UnixConn, notifyFD int, meta Metadata) error {
+	if conn == nil {
+		return errors.New("nil unix connection")
+	}
+	if notifyFD < 0 {
+		return fmt.Errorf("invalid notify fd %d", notifyFD)
+	}
+
+	payload := make([]byte, 5)
+	payload[0] = protocolMagic
+	binary.LittleEndian.PutUint32(payload[1:], uint32(meta.WrapperPID))
+	rights := unix.UnixRights(notifyFD)
+	n, oobn, err := conn.WriteMsgUnix(payload, rights, nil)
+	if err != nil {
+		return fmt.Errorf("send notify fd: %w", err)
+	}
+	if n != len(payload) || oobn != len(rights) {
+		return fmt.Errorf("send notify fd: %w (n=%d/%d, oobn=%d/%d)", io.ErrShortWrite, n, len(payload), oobn, len(rights))
+	}
+	return nil
+}
+
+func RecvNotifyFD(conn *net.UnixConn) (*os.File, Metadata, bool, error) {
+	if conn == nil {
+		return nil, Metadata{}, false, errors.New("nil unix connection")
+	}
+
+	buf := make([]byte, 16)
+	oob := make([]byte, unix.CmsgSpace(4*8))
+	n, oobn, flags, _, err := conn.ReadMsgUnix(buf, oob)
+	if err != nil {
+		return nil, Metadata{}, false, fmt.Errorf("recvmsg: %w", err)
+	}
+	if n == 0 || oobn == 0 {
+		return nil, Metadata{}, false, fmt.Errorf("no fd received (n=%d, oobn=%d)", n, oobn)
+	}
+
+	msgs, err := unix.ParseSocketControlMessage(oob[:oobn])
+	if err != nil {
+		if flags&unix.MSG_CTRUNC != 0 {
+			return nil, Metadata{}, false, fmt.Errorf("truncated control message: %w", err)
+		}
+		return nil, Metadata{}, false, fmt.Errorf("parse control message: %w", err)
+	}
+
+	var receivedFDs []int
+	for _, m := range msgs {
+		fds, err := unix.ParseUnixRights(&m)
+		if err != nil {
+			continue
+		}
+		receivedFDs = append(receivedFDs, fds...)
+	}
+	if flags&unix.MSG_CTRUNC != 0 {
+		closeFDs(receivedFDs)
+		return nil, Metadata{}, false, errors.New("truncated control message")
+	}
+	if len(receivedFDs) != 1 {
+		closeFDs(receivedFDs)
+		return nil, Metadata{}, false, fmt.Errorf("expected exactly one fd, received %d", len(receivedFDs))
+	}
+
+	fd := receivedFDs[0]
+	unix.CloseOnExec(fd)
+	meta := Metadata{}
+	hasMeta := n >= 5 && buf[0] == protocolMagic
+	if hasMeta {
+		meta.WrapperPID = int(binary.LittleEndian.Uint32(buf[1:5]))
+	}
+	return os.NewFile(uintptr(fd), "wrap-notif-fd"), meta, hasMeta, nil
+}
+
+func closeFDs(fds []int) {
+	for _, fd := range fds {
+		_ = unix.Close(fd)
+	}
+}
+
+func WriteStatus(w io.Writer, ok bool) error {
+	if w == nil {
+		return errors.New("nil writer")
+	}
+
+	b := StatusReject
+	if ok {
+		b = StatusOK
+	}
+	n, err := w.Write([]byte{b})
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return io.ErrShortWrite
+	}
+	return nil
+}
+
+func ReadStatus(r io.Reader) error {
+	if r == nil {
+		return errors.New("nil reader")
+	}
+
+	buf := []byte{0}
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return fmt.Errorf("read setup status: %w", err)
+	}
+	switch buf[0] {
+	case StatusOK:
+		return nil
+	case StatusReject:
+		return errors.New("server rejected wrap setup")
+	default:
+		return fmt.Errorf("unexpected setup status byte %d", buf[0])
+	}
+}

--- a/internal/wraphandoff/handoff_linux_test.go
+++ b/internal/wraphandoff/handoff_linux_test.go
@@ -1,0 +1,287 @@
+//go:build linux
+
+package wraphandoff
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func socketPairConns(t *testing.T) (*net.UnixConn, *net.UnixConn) {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "handoff.sock")
+	ln, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	clientCh := make(chan *net.UnixConn, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		c, err := net.Dial("unix", path)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		clientCh <- c.(*net.UnixConn)
+	}()
+
+	serverConn, err := ln.Accept()
+	if err != nil {
+		t.Fatalf("accept: %v", err)
+	}
+	var clientConn *net.UnixConn
+	select {
+	case clientConn = <-clientCh:
+	case err := <-errCh:
+		t.Fatalf("dial: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for client dial")
+	}
+
+	t.Cleanup(func() {
+		_ = clientConn.Close()
+		_ = serverConn.Close()
+	})
+	return clientConn, serverConn.(*net.UnixConn)
+}
+
+func setReadDeadline(t *testing.T, conn *net.UnixConn) {
+	t.Helper()
+
+	if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("set read deadline: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.SetReadDeadline(time.Time{}) })
+}
+
+func waitForAsync(t *testing.T, label string, errCh <-chan error) {
+	t.Helper()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("%s: %v", label, err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", label)
+	}
+}
+
+func sendNotifyFDAsync(conn *net.UnixConn, notifyFD int, meta Metadata) <-chan error {
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- SendNotifyFD(conn, notifyFD, meta)
+	}()
+	return errCh
+}
+
+func sendFDsAsync(conn *net.UnixConn, payload []byte, fds ...int) <-chan error {
+	errCh := make(chan error, 1)
+	go func() {
+		rights := unix.UnixRights(fds...)
+		n, oobn, err := conn.WriteMsgUnix(payload, rights, nil)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if n != len(payload) || oobn != len(rights) {
+			errCh <- fmt.Errorf("short unix write: n=%d/%d oobn=%d/%d", n, len(payload), oobn, len(rights))
+			return
+		}
+		errCh <- nil
+	}()
+	return errCh
+}
+
+func writeStatusAsync(w io.Writer, ok bool) <-chan error {
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- WriteStatus(w, ok)
+	}()
+	return errCh
+}
+
+func openFDCount(t *testing.T) int {
+	t.Helper()
+
+	entries, err := os.ReadDir(filepath.Join(string(filepath.Separator), "proc", "self", "fd"))
+	if err != nil {
+		t.Fatalf("read fd directory: %v", err)
+	}
+	return len(entries)
+}
+
+func TestNotifyHandoffRoundTripWithWrapperPID(t *testing.T) {
+	client, server := socketPairConns(t)
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	sendErr := sendNotifyFDAsync(client, int(r.Fd()), Metadata{WrapperPID: 4321})
+
+	setReadDeadline(t, server)
+	fd, meta, hasMeta, err := RecvNotifyFD(server)
+	if err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	waitForAsync(t, "send notify fd", sendErr)
+	t.Cleanup(func() { _ = fd.Close() })
+	if !hasMeta {
+		t.Fatal("expected metadata")
+	}
+	if meta.WrapperPID != 4321 {
+		t.Fatalf("WrapperPID = %d, want 4321", meta.WrapperPID)
+	}
+}
+
+func TestRecvNotifyFDLegacyFDOnly(t *testing.T) {
+	client, server := socketPairConns(t)
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	sendErr := sendFDsAsync(client, []byte{0}, int(r.Fd()))
+
+	setReadDeadline(t, server)
+	fd, meta, hasMeta, err := RecvNotifyFD(server)
+	if err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	waitForAsync(t, "send legacy fd", sendErr)
+	t.Cleanup(func() { _ = fd.Close() })
+	if hasMeta {
+		t.Fatal("expected no metadata")
+	}
+	if meta != (Metadata{}) {
+		t.Fatalf("metadata = %+v, want zero value", meta)
+	}
+	gotInfo, err := fd.Stat()
+	if err != nil {
+		t.Fatalf("received fd stat: %v", err)
+	}
+	wantInfo, err := r.Stat()
+	if err != nil {
+		t.Fatalf("source fd stat: %v", err)
+	}
+	if !os.SameFile(gotInfo, wantInfo) {
+		t.Fatal("received fd does not match source fd")
+	}
+}
+
+func TestRecvNotifyFDRejectsMultipleFDs(t *testing.T) {
+	client, server := socketPairConns(t)
+	r1, w1, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe 1: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = r1.Close()
+		_ = w1.Close()
+	})
+	r2, w2, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe 2: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = r2.Close()
+		_ = w2.Close()
+	})
+
+	before := openFDCount(t)
+	sendErr := sendFDsAsync(client, []byte{0}, int(r1.Fd()), int(r2.Fd()))
+
+	setReadDeadline(t, server)
+	fd, _, _, err := RecvNotifyFD(server)
+	if fd != nil {
+		_ = fd.Close()
+	}
+	waitForAsync(t, "send multiple fds", sendErr)
+	if err == nil {
+		t.Fatal("expected multiple fd rejection error")
+	}
+	if after := openFDCount(t); after != before {
+		t.Fatalf("open fd count after rejected receive = %d, want %d", after, before)
+	}
+}
+
+func TestRecvNotifyFDSetsCloseOnExec(t *testing.T) {
+	client, server := socketPairConns(t)
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	sendErr := sendNotifyFDAsync(client, int(r.Fd()), Metadata{WrapperPID: 4321})
+
+	setReadDeadline(t, server)
+	fd, _, _, err := RecvNotifyFD(server)
+	if err != nil {
+		t.Fatalf("recv: %v", err)
+	}
+	waitForAsync(t, "send notify fd", sendErr)
+	t.Cleanup(func() { _ = fd.Close() })
+
+	flags, err := unix.FcntlInt(fd.Fd(), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatalf("fcntl getfd: %v", err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		t.Fatal("received fd is missing FD_CLOEXEC")
+	}
+}
+
+type shortWriter struct{}
+
+func (shortWriter) Write([]byte) (int, error) {
+	return 0, nil
+}
+
+func TestWriteStatusShortWrite(t *testing.T) {
+	if err := WriteStatus(shortWriter{}, true); !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("WriteStatus short write error = %v, want %v", err, io.ErrShortWrite)
+	}
+}
+
+func TestSetupStatusRoundTrip(t *testing.T) {
+	client, server := socketPairConns(t)
+
+	successErr := writeStatusAsync(server, true)
+	setReadDeadline(t, client)
+	if err := ReadStatus(client); err != nil {
+		t.Fatalf("read success status: %v", err)
+	}
+	waitForAsync(t, "write success status", successErr)
+
+	rejectErr := writeStatusAsync(server, false)
+	setReadDeadline(t, client)
+	if err := ReadStatus(client); err == nil {
+		t.Fatal("expected reject status error")
+	}
+	waitForAsync(t, "write reject status", rejectErr)
+}


### PR DESCRIPTION
## Summary
- inject proxy environment into `agentsh wrap` launches
- add notify handoff status/metadata flow and wait for server setup before wrapper exec
- attach cgroup/eBPF before ACK, validate wrapper PID metadata, and fail closed/cleanup on required setup failures
- document wrap eBPF coverage

Fixes #343

## Testing
- `go test ./internal/api -count=1`
- `go test ./internal/wraphandoff ./internal/cli ./internal/api ./internal/shim/kernelinstall -count=1`
- `go test ./...`
- `GOOS=windows go build ./...`
- `GOOS=darwin go build ./...`
- `git diff --check`