### PR TITLE
ebpf: warn when enabled but cgroups disabled; document docker prereq

### DIFF
--- a/docs/ebpf.md
+++ b/docs/ebpf.md
@@ -22,8 +22,18 @@ This requires `sandbox.cgroups.enabled: true`. If `sandbox.network.ebpf.required
 Domain rules are still enforced by resolving literal domains to IP/port map entries in userspace. eBPF does not match domain strings in the kernel. Wildcard domains, shared CDN IPs, cached DNS answers, hosts-file entries, and DNS-over-HTTPS keep the same caveats described above.
 
 ## Configuration (config.yml)
+
+> **Prerequisite:** the eBPF runtime is attached inside the cgroup-setup
+> path, so `sandbox.cgroups.enabled: true` is required. With `enabled:
+> true` (or `enforce: true`) but `cgroups.enabled: false`, the eBPF
+> backend is silently skipped — the server logs a startup `WARN` line
+> (`ebpf: enforcement configured but inactive`). Setting `required:
+> true` upgrades the silent skip to a hard startup error.
+
 ```yaml
 sandbox:
+  cgroups:
+    enabled: true                # REQUIRED for eBPF activation
   network:
     ebpf:
       enabled: true                # turn on connect tracing
@@ -65,5 +75,35 @@ Wildcard domains (`*.example.com`) disable strict/default-deny.
 ## Platform notes
 - Linux 5.4+ (5.15+ recommended); enforcement requires root and cgroup v2.
 - Maps are shared process-wide; map size overrides are set once at startup.
+
+### Stock Docker host-side prerequisite
+
+`sandbox.cgroups.enabled: true` is necessary but on stock Docker it isn't
+sufficient — Docker delegates a cgroup scope to each container but ships
+`cgroup.subtree_control` empty, and writing `+memory` to it from inside
+the container returns `ENOTSUP` even with `CAP_SYS_ADMIN`. The agentsh
+cgroup manager fails to enable the `memory` controller and the eBPF
+attach path never runs. `agentsh detect` surfaces this as:
+
+```
+RESOURCE LIMITS
+  cgroups-v2  -  unavailable: enable controller "memory" failed:
+                 write /sys/fs/cgroup/cgroup.subtree_control:
+                 operation not supported
+```
+
+Fix on the host:
+
+```ini
+# /etc/systemd/system/docker.service.d/cgroup-delegate.conf
+[Service]
+Delegate=memory pids cpu
+```
+
+Then `systemctl daemon-reload && systemctl restart docker` and rerun the
+container. `--cap-add SYS_ADMIN --cap-add BPF -v /sys/fs/bpf:/sys/fs/bpf:rw`
+on `docker run` are also required for the attach itself. See issue
+[#343](https://github.com/canyonroad/agentsh/issues/343) for the full
+reproduction.
 
 **Tip:** Use `agentsh detect` to check if eBPF is available in your environment. See [Cross-Platform Notes](cross-platform.md#detecting-available-capabilities).

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -122,6 +122,22 @@ func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Stor
 		slog.Warn("real_paths enabled but enforce_without_fuse is false: outside-workspace file access will be audit-only (not blocked)")
 	}
 
+	// EBPF activation depends on sandbox.cgroups.enabled (see
+	// internal/api/wrap.go wrapNeedsCgroupBeforeAck and
+	// internal/api/cgroups.go applyCgroupV2 — both short-circuit when
+	// cgroups are not enabled). Without this warning, an operator
+	// enabling sandbox.network.ebpf.{enabled,enforce} without also
+	// enabling sandbox.cgroups.enabled gets zero enforcement and zero
+	// feedback. (The Required=true case is already a hard error in
+	// wrap.go; only the Enabled/Enforce case is silent.) See issue #345.
+	if (cfg.Sandbox.Network.EBPF.Enabled || cfg.Sandbox.Network.EBPF.Enforce) && !cfg.Sandbox.Cgroups.Enabled {
+		slog.Warn("ebpf: enforcement configured but inactive — requires sandbox.cgroups.enabled=true",
+			"ebpf.enabled", cfg.Sandbox.Network.EBPF.Enabled,
+			"ebpf.enforce", cfg.Sandbox.Network.EBPF.Enforce,
+			"cgroups.enabled", cfg.Sandbox.Cgroups.Enabled,
+		)
+	}
+
 	var appCgroupMgr cgroupManager
 	if cgroupMgr != nil {
 		appCgroupMgr = cgroupMgr


### PR DESCRIPTION
Closes #345. Surfaces follow-ups from the discussion on #343 — including the newest comment ([4472815369](https://github.com/canyonroad/agentsh/issues/343#issuecomment-4472815369), [4472876732](https://github.com/canyonroad/agentsh/issues/343)).

## What this fixes

\`sandbox.network.ebpf.{enabled,enforce}: true\` was a silent no-op when \`sandbox.cgroups.enabled\` was false. The eBPF runtime is imported and linked (\`internal/api/app.go:27\`, \`//go:embed connect_bpfel.o\` in \`internal/netmonitor/ebpf/program.go:15\`), but the activation chain short-circuits earlier:

- \`internal/api/wrap.go:818-820\` — \`wrapNeedsCgroupBeforeAck\` returns false when \`!cfg.Sandbox.Cgroups.Enabled\`, regardless of ebpf settings. \`AttachConnectToCgroup\` never runs.
- \`internal/api/cgroups.go:42-56\` — same in the per-exec path; \`ebpfEnabled\` is read but only acted on inside \`applyCgroupV2\`, which is gated on cgroups.

Only \`ebpf.required: true\` was loud (\`wrap.go:839-841\` errors out). The much more common \`enabled: true\` case was silent.

## Changes

### Runtime warning (\`internal/api/app.go\`)

Emit \`slog.Warn\` at server startup when \`(ebpf.Enabled || ebpf.Enforce) && !cgroups.Enabled\`:

\`\`\`
WARN ebpf: enforcement configured but inactive — requires sandbox.cgroups.enabled=true
  ebpf.enabled=true ebpf.enforce=true cgroups.enabled=false
\`\`\`

Same shape as the existing \`real_paths\`/\`enforce_without_fuse\` warn at \`app.go:121-123\`.

### Documentation (\`docs/ebpf.md\`)

1. Promote the \`sandbox.cgroups.enabled\` prerequisite from a buried mention under "agentsh wrap" up into a callout in the **Configuration (config.yml)** section, and add \`cgroups.enabled: true\` to the example YAML next to the ebpf block.
2. New **Stock Docker host-side prerequisite** subsection under Platform notes documenting the \`Delegate=memory pids cpu\` docker.service drop-in needed because Docker ships container scopes with empty \`cgroup.subtree_control\`. Operator-reported in #343 — writing \`+memory\` returns ENOTSUP from inside the container even with \`CAP_SYS_ADMIN\`.

## What this does NOT do

- The "decouple cgroup_connect attach from cgroups.enabled" idea (controller-less child cgroup for BPF attach only) raised as Optional/larger in #343's latest comment is out of scope.
- Auto-promoting \`ebpf.enabled: true\` to also enable \`cgroups.enabled: true\` (mirroring the \`required → enabled\` auto-promote at \`config.go:1625-1632\`) — opted for the WARN instead because cgroups have other side effects (resource limits, etc.) and silently flipping them feels worse than nagging the operator.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`GOOS=windows go build ./...\` clean
- [x] \`go test ./internal/api/\` passes (28s)
- [ ] Manual: run \`agentsh server\` with \`sandbox.network.ebpf.enabled: true\` + \`sandbox.cgroups.enabled: false\`, confirm WARN appears in server.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)