### PR TITLE
fix(ebpf): pad AllowKey to 32 bytes (#349)

### DIFF
--- a/internal/netmonitor/ebpf/keysize_test.go
+++ b/internal/netmonitor/ebpf/keysize_test.go
@@ -1,0 +1,28 @@
+package ebpf
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// TestAllowKey_BinarySizeMatchesBPFMap asserts that AllowKey marshals to the
+// same number of bytes as the kernel BPF map's declared key_size for
+// `struct allow_key` in connect.bpf.c.
+//
+// The C struct compiles to 32 bytes because the trailing 16-byte addr is
+// followed by an implicit pad up to __u64 alignment (the leading
+// cgroup_id field). encoding/binary, used by cilium/ebpf for plain Go
+// structs that do not implement BinaryMarshaler, emits no trailing
+// padding — so without an explicit `_ [4]byte` tail, AllowKey marshals
+// to 28 bytes and cilium/ebpf rejects every Put with
+// "ebpf.AllowKey doesn't marshal to 32 bytes", silently disabling
+// connect-filter enforcement at runtime.
+//
+// See issue #349.
+func TestAllowKey_BinarySizeMatchesBPFMap(t *testing.T) {
+	const wantBytes = 32
+	got := binary.Size(AllowKey{})
+	if got != wantBytes {
+		t.Errorf("binary.Size(AllowKey{}) = %d, want %d (kernel BPF map declares key_size=32 due to __u64 alignment)", got, wantBytes)
+	}
+}

--- a/internal/netmonitor/ebpf/program.go
+++ b/internal/netmonitor/ebpf/program.go
@@ -132,6 +132,13 @@ type AllowKey struct {
 	Protocol uint8 // IPPROTO_TCP (6) or IPPROTO_UDP (17), 0 = any
 	Dport    uint16
 	Addr     [16]byte
+	// _pad matches the kernel BPF struct's trailing alignment. clang sizes
+	// `struct allow_key` at 32 bytes (__u64 head forces 8-byte struct
+	// alignment), but encoding/binary emits 28 bytes for the fields above.
+	// Without this pad, cilium/ebpf rejects every Put on the allow/deny
+	// maps with "doesn't marshal to 32 bytes" and silently disables
+	// connect-filter enforcement at runtime. See issue #349.
+	_ [4]byte
 }
 
 // AllowCIDR represents a CIDR prefix allowed for a cgroup.


### PR DESCRIPTION
## Summary

Closes #349. AllowKey marshalled to 28 bytes via `encoding/binary` but the kernel BPF map for `struct allow_key` declares `key_size=32` (clang adds 4 bytes of trailing pad to satisfy the `__u64` head's 8-byte struct alignment). cilium/ebpf rejects every Put on the allow/deny maps with `doesn't marshal to 32 bytes`, which the runtime surfaces as an `ebpf_enforce_disabled` event the moment PopulateAllowlist runs. BPF still loads and attaches, but allow/deny maps stay empty — every IPv4 connect passes through even when the policy lists exact-domain allows.

## Fix

Option (a) from the issue: add explicit `_ [4]byte` trailing pad to the Go `AllowKey` struct so `binary.Size(AllowKey{}) == 32`.

## Test plan

- [x] New unit test `TestAllowKey_BinarySizeMatchesBPFMap` asserts the marshal size invariant — RED before the fix (`binary.Size = 28`), GREEN after.
- [x] `go test ./...` — green
- [x] `GOOS=windows go build ./...` / `GOOS=darwin go build ./...` — clean

The test does not require root or BPF capabilities, so it runs in standard CI and will catch any future field-layout drift before it ships.

`AllowCIDR` was investigated alongside; it is not used as a BPF map key directly (`PopulateAllowlist` transcodes it into local `lpm4Key`/`lpm6Key` types matching the LPM trie key layouts), so it does not need the same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)