### PR TITLE
fix(api): close eventChan on fs.Mount() error path in mountFUSEForSession

### DIFF
--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -1269,6 +1269,10 @@ func (a *App) mountFUSEForSession(ctx context.Context, p fuseMountParams) bool {
 
 	m, err := fs.Mount(fsCfg)
 	if err != nil {
+		// Mount failed: no FUSE server is attached to eventChan, so the
+		// processIOEvents goroutine started above would block on its
+		// receive forever. Close the channel here so it exits cleanly.
+		close(eventChan)
 		fields := map[string]any{
 			"mount_point":    mountPoint,
 			"error":          err.Error(),

--- a/internal/api/deferred_fuse_test.go
+++ b/internal/api/deferred_fuse_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -26,10 +27,10 @@ type mockFSMount struct {
 	closed     atomic.Bool
 }
 
-func (m *mockFSMount) Path() string                { return m.path }
-func (m *mockFSMount) SourcePath() string           { return m.sourcePath }
-func (m *mockFSMount) Stats() platform.FSStats      { return platform.FSStats{} }
-func (m *mockFSMount) Close() error                 { m.closed.Store(true); return nil }
+func (m *mockFSMount) Path() string            { return m.path }
+func (m *mockFSMount) SourcePath() string      { return m.sourcePath }
+func (m *mockFSMount) Stats() platform.FSStats { return platform.FSStats{} }
+func (m *mockFSMount) Close() error            { m.closed.Store(true); return nil }
 
 type mockFilesystem struct {
 	available      atomic.Bool
@@ -75,11 +76,11 @@ func (m *mockPlatform) Filesystem() platform.FilesystemInterceptor {
 	}
 	return m.fs
 }
-func (m *mockPlatform) Network() platform.NetworkInterceptor      { return nil }
-func (m *mockPlatform) Sandbox() platform.SandboxManager          { return nil }
-func (m *mockPlatform) Resources() platform.ResourceLimiter       { return nil }
+func (m *mockPlatform) Network() platform.NetworkInterceptor                  { return nil }
+func (m *mockPlatform) Sandbox() platform.SandboxManager                      { return nil }
+func (m *mockPlatform) Resources() platform.ResourceLimiter                   { return nil }
 func (m *mockPlatform) Initialize(_ context.Context, _ platform.Config) error { return nil }
-func (m *mockPlatform) Shutdown(_ context.Context) error          { return nil }
+func (m *mockPlatform) Shutdown(_ context.Context) error                      { return nil }
 
 // --- helpers ---
 
@@ -253,6 +254,56 @@ func TestEnsureFUSEMount_MountError(t *testing.T) {
 	if s.WorkspaceMount != s.Workspace {
 		t.Fatalf("expected WorkspaceMount unchanged after mount error (%q), got %q", s.Workspace, s.WorkspaceMount)
 	}
+}
+
+// TestEnsureFUSEMount_MountError_NoEventChanLeak is a regression test for the
+// processIOEvents goroutine leak on the fs.Mount() error path in
+// mountFUSEForSession. Before the fix, the function created eventChan and
+// spawned a processIOEvents goroutine to consume from it, then returned early
+// on mount failure without closing the channel -- so the goroutine blocked
+// on the receive forever. Repeated failed mounts (any deployment where FUSE
+// is unavailable or permission-denied) would leak a goroutine and a 1000-slot
+// channel per attempt. The fix is to close(eventChan) on the mount-error path
+// before returning.
+func TestEnsureFUSEMount_MountError_NoEventChanLeak(t *testing.T) {
+	st := newSQLiteStore(t)
+	store := composite.New(st, st)
+	mgr := session.NewManager(10)
+	s := newDeferredTestSession(t, mgr)
+
+	app := newDeferredTestApp(t, mgr, store)
+	mfs := &mockFilesystem{}
+	mfs.available.Store(true)
+	mfs.mountErr = errors.New("fuse: permission denied")
+	app.SetPlatformForTest(&mockPlatform{fs: mfs})
+
+	// Settle the goroutine count before capturing baseline -- earlier
+	// subtests in the package may still have transient goroutines in flight.
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	app.ensureFUSEMount(context.Background(), s)
+
+	if mfs.mountCalls.Load() != 1 {
+		t.Fatalf("expected 1 mount call, got %d", mfs.mountCalls.Load())
+	}
+
+	// processIOEvents exits when its eventChan is closed. Poll-wait for the
+	// goroutine count to drop back to baseline. With the leak, it stays at
+	// before+1 forever.
+	deadline := time.Now().Add(2 * time.Second)
+	var after int
+	for time.Now().Before(deadline) {
+		runtime.GC()
+		after = runtime.NumGoroutine()
+		if after <= before {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("processIOEvents goroutine leaked after mount error: before=%d after=%d "+
+		"(eventChan was not closed on fs.Mount() error path)", before, after)
 }
 
 func TestEnsureFUSEMount_Idempotent(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes a `processIOEvents` goroutine leak in `mountFUSEForSession` when `fs.Mount()` fails. Each failed mount attempt previously leaked one goroutine plus a 1000-slot channel.

## Context — relationship to #311

[#311](https://github.com/canyonroad/agentsh/pull/311) proposed a larger refactor for the FUSE event-emitter teardown race ("send on closed channel" panic). The panic itself is already fixed on `main` by `ad8d3b64` ("fix fuse event channel panic"), which reorders teardown so `m.Close()` happens before `close(eventChan)` and adds a `recover` guard in `AppendEvent` as defense-in-depth.

Reviewing #311 surfaced a **separate, unrelated bug** that `ad8d3b64` did not address: on the `fs.Mount()` error path in `mountFUSEForSession`, `eventChan` is never closed. This PR cherry-picks just that fix so #311 can be closed without losing it.

## The bug

In `internal/api/core.go`:

```go
eventChan := make(chan platform.IOEvent, 1000)
go a.processIOEvents(eventChan)
// ... build fsCfg ...
m, err := fs.Mount(fsCfg)
if err != nil {
    // logged + return false -- but eventChan was never closed,
    // so processIOEvents blocks on receive forever.
    return false
}
```

`processIOEvents` ranges over the channel, so it exits only when the channel is closed. The success path closes it via `SetWorkspaceUnmount(...)`. The error path doesn't.

Impact: any deployment where FUSE is unavailable or permission-denied (snapshot/sandbox environments, CI without `/dev/fuse`, etc.) leaks one goroutine and one buffered channel per `ensureFUSEMount` call.

The sibling site in `setupProfileMounts` (`core.go:359`) already had this `close(eventChan)` on its error path — this PR makes `mountFUSEForSession` consistent.

## The fix

One line, added immediately after the `fs.Mount()` error check:

```go
m, err := fs.Mount(fsCfg)
if err != nil {
    // Mount failed: no FUSE server is attached to eventChan, so the
    // processIOEvents goroutine started above would block on its
    // receive forever. Close the channel here so it exits cleanly.
    close(eventChan)
    // ... existing error logging ...
}
```

## Regression test

`TestEnsureFUSEMount_MountError_NoEventChanLeak` in `internal/api/deferred_fuse_test.go`:

- Uses the existing `mockFilesystem` infrastructure to force `fs.Mount()` to fail.
- Captures `runtime.NumGoroutine()` before, calls `ensureFUSEMount`, then polls until the count drops back to baseline within a 2-second deadline.
- With the leak, the count stays at `before+1` forever and the test times out with a precise failure message.

Verified red→green during development:
- Without the fix: `processIOEvents goroutine leaked after mount error: before=4 after=5`
- With the fix: passes (`processIOEvents` exits after the close).

## Verification

- `go test ./...` — full suite green
- `GOOS=windows go build ./...` — clean
- `gofmt -l internal/api/core.go internal/api/deferred_fuse_test.go` — clean

## Reversibility

`git revert` restores the previous state. The leak is silent (no panic, no test failure prior to this PR), so the only signal it ever produced was elevated goroutine counts under repeated mount failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)