### PR TITLE
fix(fsmonitor): use backing-path policy in FUSE extra-ops + cross-mount tests (#328)

### DIFF
--- a/docs/superpowers/specs/2026-05-16-fuse-extra-ops-policy-design.md
+++ b/docs/superpowers/specs/2026-05-16-fuse-extra-ops-policy-design.md
@@ -1,0 +1,57 @@
+# FUSE Extra Ops Test Policy Path Design
+
+## Context
+
+Issue #328 reports that `TestFUSE_InterceptsExtraOps` grants policy access to
+`/workspace` and `/workspace/**`, but FUSE policy evaluation in
+`checkWithExist` resolves virtual paths to the real backing workspace path before
+calling `CheckFile`. On hosts where the real FUSE mount runs, this can deny the
+operation because the resolved tempdir path does not match the virtual
+`/workspace` rule. On hosts where FUSE mounting skips, the mismatch is easy to
+miss.
+
+`TestFUSE_TruncateUnderSoftDelete` already documents the same path-resolution
+behavior and uses a policy shape that avoids testing the wrong failure mode.
+
+## Goal
+
+Make the extra-ops FUSE test validate intercepted operations, not a policy path
+mismatch. Also fix any adjacent FUSE test with the same virtual-only allow rule
+when that test routes through `checkWithExist`.
+
+## Design
+
+Add a small FUSE-test policy helper that allows the real backing workspace path:
+
+- exact backing tempdir path
+- recursive backing tempdir subtree
+
+Use that helper in `TestFUSE_InterceptsExtraOps` so create/stat/list/symlink and
+chmod operations are not denied by the resolved path. Use the same helper in the
+neighboring cross-mount FUSE test, which has the same `/workspace`-only policy
+shape and reaches policy checks through create/rename handling.
+
+Add a non-FUSE regression test for the helper policy. It should construct a
+backing tempdir, compile the helper policy, and assert that `CheckFile` allows a
+resolved path under that backing directory. This keeps coverage meaningful even
+on developer or CI hosts where FUSE mount setup skips because `/dev/fuse` or
+`allow_other` is unavailable.
+
+## Non-Goals
+
+- No production behavior changes.
+- No change to `checkWithExist` path resolution semantics.
+- No broad refactor of all FUSE tests beyond the exact same nearby mismatch.
+- No attempt to change host FUSE setup or `allow_other` behavior.
+
+## Testing
+
+Run a focused FUSE test selection that includes the non-FUSE helper regression,
+the extra-ops test, the cross-mount test, and the existing truncate regression.
+The real mount tests may skip locally when FUSE mounting is unavailable.
+
+Run the full Go suite and the Windows compile gate:
+
+- `go test ./...`
+- `GOOS=windows go build ./...`
+- `git diff --check`

--- a/internal/fsmonitor/fuse_cross_mount_test.go
+++ b/internal/fsmonitor/fuse_cross_mount_test.go
@@ -23,14 +23,7 @@ func TestFUSE_CrossMountIntoWorkspaceEmitsCreate(t *testing.T) {
 	backing := t.TempDir()
 	mountPoint := filepath.Join(t.TempDir(), "mnt")
 
-	pol := &policy.Policy{
-		Version: 1,
-		Name:    "allow-all",
-		FileRules: []policy.FileRule{
-			{Name: "allow-workspace", Paths: []string{"/workspace", "/workspace/**"}, Operations: []string{"*"}, Decision: "allow"},
-		},
-	}
-	engine, err := policy.NewEngine(pol, false, true)
+	engine, err := policy.NewEngine(fuseBackingAllowPolicy(backing), false, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/fsmonitor/fuse_ops_test.go
+++ b/internal/fsmonitor/fuse_ops_test.go
@@ -33,6 +33,36 @@ func (c *typeCaptureEmitter) snapshot() []string {
 	return append([]string(nil), c.types...)
 }
 
+func fuseBackingAllowPolicy(backing string) *policy.Policy {
+	return &policy.Policy{
+		Version: 1,
+		Name:    "allow-all",
+		FileRules: []policy.FileRule{
+			{
+				Name:       "allow-backing-workspace",
+				Paths:      []string{backing, filepath.Join(backing, "**")},
+				Operations: []string{"*"},
+				Decision:   "allow",
+			},
+		},
+	}
+}
+
+func TestFUSEBackingAllowPolicyAllowsResolvedPath(t *testing.T) {
+	backing := t.TempDir()
+	engine, err := policy.NewEngine(fuseBackingAllowPolicy(backing), false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resolvedPath := filepath.Join(backing, "a.txt")
+	dec := engine.CheckFile(resolvedPath, "write")
+	if dec.EffectiveDecision != types.DecisionAllow {
+		t.Fatalf("FUSE test policy denied resolved backing path %q: decision=%s rule=%s",
+			resolvedPath, dec.EffectiveDecision, dec.Rule)
+	}
+}
+
 // NOTE: this test mounts a real FUSE filesystem; it will skip if /dev/fuse is unavailable.
 func TestFUSE_InterceptsExtraOps(t *testing.T) {
 	if _, err := os.Stat("/dev/fuse"); err != nil {
@@ -42,14 +72,7 @@ func TestFUSE_InterceptsExtraOps(t *testing.T) {
 	backing := t.TempDir()
 	mountPoint := filepath.Join(t.TempDir(), "mnt")
 
-	pol := &policy.Policy{
-		Version: 1,
-		Name:    "allow-all",
-		FileRules: []policy.FileRule{
-			{Name: "allow-workspace", Paths: []string{"/workspace", "/workspace/**"}, Operations: []string{"*"}, Decision: "allow"},
-		},
-	}
-	engine, err := policy.NewEngine(pol, false, true)
+	engine, err := policy.NewEngine(fuseBackingAllowPolicy(backing), false, true)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

- `TestFUSE_InterceptsExtraOps` and `TestFUSE_CrossMountIntoWorkspaceEmitsCreate` both allowed virtual `/workspace` + `/workspace/**`, but `checkWithExist` resolves to the real backing tempdir before calling `CheckFile`. On hosts where the real FUSE mount runs, operations got denied by policy mismatch rather than exercising the intended intercepted code paths. On hosts where the mount skips (no `/dev/fuse`, `allow_other` unavailable), the mismatch was invisible.
- Adds a `fuseBackingAllowPolicy(backing)` helper that allows the exact backing path + recursive subtree — same shape PR #310 landed in `TestFUSE_TruncateUnderSoftDelete`.
- Adds `TestFUSEBackingAllowPolicyAllowsResolvedPath` as a non-FUSE regression so coverage is meaningful on dev/CI hosts where the real mount tests skip.

Fixes #328

## Test Plan

- [x] `go test ./internal/fsmonitor/... -run "TestFUSEBackingAllowPolicy|TestFUSE_InterceptsExtraOps|TestFUSE_CrossMount" -v` — regression test PASSES; mount tests SKIP locally (`user_allow_other` not set in `/etc/fuse.conf`)
- [x] `go test ./...` — full suite, 0 failures
- [x] `GOOS=windows go build ./...` — cross-compile clean
- [x] `roborev review --branch --wait --reasoning maximum` — no findings (job 9378)

CI will exercise the real-mount paths.

## Docs

- Spec: `docs/superpowers/specs/2026-05-16-fuse-extra-ops-policy-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)