### PR TITLE
fix(wrap): skip wrap-init when sandbox.unix_sockets.enabled=false (#361)

### DIFF
--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -283,26 +283,29 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 		}, http.StatusOK, nil
 	}
 
-	// Mirror the exec-path gate at setupSeccompWrapper (core.go): when the
-	// operator has explicitly disabled sandbox.unix_sockets.enabled, the
-	// seccomp wrapper must not engage. Without this gate, the shim's
-	// kernel-install path launches agentsh-unixwrap, which loads its
-	// seccomp filter and tries to forward the notify FD to a server that
-	// has no live handler registered for it — the handshake aborts and the
-	// user's command silently exits with empty stdout / exit 1.
+	// Refuse wrap-init when sandbox.unix_sockets.enabled has been explicitly
+	// set to false. Without this gate, the shim's kernel-install path
+	// launches agentsh-unixwrap, which loads its seccomp filter and tries
+	// to forward the notify FD to a server that has no live handler — the
+	// handshake aborts and the user's command silently exits with empty
+	// stdout / exit 1. Returning 503 makes the shim's ModeAuto branch fall
+	// through to running the command unwrapped (issue #361 regression vs
+	// v0.19.3).
 	//
-	// Treat nil as "default true" (matches applyDefaults) so tests that
-	// build bare configs are unaffected; only an explicit false disengages.
-	// Returning 503 makes the shim's ModeAuto branch fall through to
-	// running the command unwrapped (issue #361 regression vs v0.19.3).
+	// Nil is treated as "default true" via unixSocketsConfigEnabled, which
+	// matches applyDefaults' production behavior and keeps bare-config tests
+	// working. The exec-path gate in core.go::setupSeccompWrapper uses a
+	// stricter "nil → disabled" check; in production that distinction is
+	// invisible because applyDefaults always populates the pointer, so the
+	// two paths agree on every real config. Pre-applyDefaults divergence is
+	// documented and intentional pending broader cleanup.
 	//
-	// Exception: when pre-ACK cgroup/eBPF setup is required, the wrapper
-	// MUST run regardless of the unix_sockets toggle — the server forces
-	// a user-notify rule below at line ~390 specifically to keep the
-	// handoff alive long enough to attach eBPF before exec. Skipping the
-	// wrapper in that case would silently disable eBPF enforcement.
-	if a.cfg.Sandbox.UnixSockets.Enabled != nil && !*a.cfg.Sandbox.UnixSockets.Enabled &&
-		!wrapNeedsCgroupBeforeAck(a, s) {
+	// Exception: when wrapNeedsCgroupBeforeAck reports true, the wrapper
+	// must still engage even with unix_sockets disabled — the
+	// forceNotifyForPreAckCgroup branch below forces a user-notify rule
+	// specifically to keep the wrapper alive long enough to attach eBPF
+	// before exec. Skipping it here would silently disable eBPF enforcement.
+	if !unixSocketsConfigEnabled(a.cfg) && !wrapNeedsCgroupBeforeAck(a, s) {
 		return types.WrapInitResponse{}, http.StatusServiceUnavailable,
 			fmt.Errorf("wrap-init: sandbox.unix_sockets.enabled is false; wrapper disabled")
 	}
@@ -832,6 +835,24 @@ func (a *App) acceptNotifyFD(ctx context.Context, listener net.Listener, socketP
 	if err := writeNotifyStatusForWrap(unixConn, true); err != nil {
 		slog.Debug("wrap: failed to write notify setup status", "session_id", sessionID, "error", err)
 	}
+}
+
+// unixSocketsConfigEnabled reports whether sandbox.unix_sockets.enabled
+// is on for the purposes of wrap-init. Nil is treated as true to match
+// applyDefaults' production behavior (the field defaults to true when
+// unset). Only an explicit false short-circuits.
+//
+// Callers that need the *exec-path* semantics ("nil → disabled") should
+// continue to use the inline check in core.go::setupSeccompWrapper —
+// see the comment in wrapInitCore explaining the documented divergence.
+func unixSocketsConfigEnabled(cfg *config.Config) bool {
+	if cfg == nil {
+		return false
+	}
+	if cfg.Sandbox.UnixSockets.Enabled == nil {
+		return true
+	}
+	return *cfg.Sandbox.UnixSockets.Enabled
 }
 
 func wrapNeedsCgroupBeforeAck(a *App, s *session.Session) bool {

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -283,6 +283,30 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 		}, http.StatusOK, nil
 	}
 
+	// Mirror the exec-path gate at setupSeccompWrapper (core.go): when the
+	// operator has explicitly disabled sandbox.unix_sockets.enabled, the
+	// seccomp wrapper must not engage. Without this gate, the shim's
+	// kernel-install path launches agentsh-unixwrap, which loads its
+	// seccomp filter and tries to forward the notify FD to a server that
+	// has no live handler registered for it — the handshake aborts and the
+	// user's command silently exits with empty stdout / exit 1.
+	//
+	// Treat nil as "default true" (matches applyDefaults) so tests that
+	// build bare configs are unaffected; only an explicit false disengages.
+	// Returning 503 makes the shim's ModeAuto branch fall through to
+	// running the command unwrapped (issue #361 regression vs v0.19.3).
+	//
+	// Exception: when pre-ACK cgroup/eBPF setup is required, the wrapper
+	// MUST run regardless of the unix_sockets toggle — the server forces
+	// a user-notify rule below at line ~390 specifically to keep the
+	// handoff alive long enough to attach eBPF before exec. Skipping the
+	// wrapper in that case would silently disable eBPF enforcement.
+	if a.cfg.Sandbox.UnixSockets.Enabled != nil && !*a.cfg.Sandbox.UnixSockets.Enabled &&
+		!wrapNeedsCgroupBeforeAck(a, s) {
+		return types.WrapInitResponse{}, http.StatusServiceUnavailable,
+			fmt.Errorf("wrap-init: sandbox.unix_sockets.enabled is false; wrapper disabled")
+	}
+
 	// Resolve wrapper binary
 	wrapperBin := strings.TrimSpace(a.cfg.Sandbox.UnixSockets.WrapperBin)
 	if wrapperBin == "" {

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -408,7 +408,7 @@ func TestWrapInit_UnixSocketsDisabledButEBPFRequiresWrapper(t *testing.T) {
 		t.Fatalf("create session: %v", err)
 	}
 
-	_, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
 		AgentCommand: "/bin/echo",
 	})
 	if err != nil {
@@ -416,6 +416,17 @@ func TestWrapInit_UnixSocketsDisabledButEBPFRequiresWrapper(t *testing.T) {
 	}
 	if code != http.StatusOK {
 		t.Errorf("expected status 200 (eBPF override), got %d", code)
+	}
+	// Pin the assertion to the post-gate path: a 200 here could otherwise
+	// come from an earlier branch (ptrace, etc.) that would also bypass
+	// the gate accidentally. WrapperBinary is populated only in the main
+	// path that follows the unix_sockets gate, so a non-empty value
+	// uniquely proves the override branch was taken.
+	if resp.WrapperBinary == "" {
+		t.Errorf("expected WrapperBinary set (override branch must produce a wrapper), got empty")
+	}
+	if resp.NotifySocket == "" {
+		t.Errorf("expected NotifySocket set (override branch must produce a socket), got empty")
 	}
 }
 

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -301,6 +301,124 @@ func TestWrapInit_NotLinux(t *testing.T) {
 	}
 }
 
+// TestWrapInit_UnixSocketsExplicitlyDisabled covers issue #361
+// (v0.20.0-rc1 regression): when the operator sets
+// sandbox.unix_sockets.enabled=false, wrap-init must refuse to engage
+// rather than returning a wrapper binary that the shim then launches
+// against a server with no notify-fd handler — which manifests as
+// "server rejected wrap setup" on Vercel/Daytona with empty stdout
+// and exit 1. Mirrors the exec-path gate in core.go::setupSeccompWrapper.
+func TestWrapInit_UnixSocketsExplicitlyDisabled(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	cfg := &config.Config{}
+	disabled := false
+	cfg.Sandbox.UnixSockets.Enabled = &disabled
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		AgentArgs:    []string{"hello"},
+	})
+
+	if err == nil {
+		t.Fatal("expected error when unix_sockets.enabled is false")
+	}
+	if code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d", code)
+	}
+	if !strings.Contains(err.Error(), "unix_sockets.enabled is false") {
+		t.Errorf("expected error to mention unix_sockets.enabled, got %q", err.Error())
+	}
+	if resp.WrapperBinary != "" || resp.NotifySocket != "" {
+		t.Errorf("expected empty WrapperBinary/NotifySocket on refusal, got %+v", resp)
+	}
+}
+
+// TestWrapInit_UnixSocketsNilDefaultsToEnabled verifies that the gate
+// added for #361 only fires on an explicit false. A nil Enabled (which
+// applyDefaults sets to true in production) must NOT short-circuit
+// wrap-init — otherwise every test that builds a bare Config would
+// regress.
+func TestWrapInit_UnixSocketsNilDefaultsToEnabled(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	cfg := &config.Config{}
+	// Sandbox.UnixSockets.Enabled is left nil (the pre-applyDefaults state).
+	cfg.Sandbox.UnixSockets.WrapperBin = "nonexistent-wrapper-binary-xyz-12345"
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	_, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		AgentArgs:    []string{"hello"},
+	})
+
+	// Should fall through to wrapper-resolution (errWrapperNotFound, 503),
+	// NOT the unix_sockets gate.
+	if err == nil {
+		t.Fatal("expected wrapper-not-found error")
+	}
+	if code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d", code)
+	}
+	if strings.Contains(err.Error(), "unix_sockets.enabled is false") {
+		t.Errorf("nil Enabled must not trigger the unix_sockets gate, got %q", err.Error())
+	}
+}
+
+// TestWrapInit_UnixSocketsDisabledButEBPFRequiresWrapper covers the
+// override branch of the #361 gate: when pre-ACK cgroup/eBPF setup is
+// required (Network.EBPF.Required, Cgroups.Enabled, etc.), the wrapper
+// must still engage even with sandbox.unix_sockets.enabled=false, because
+// the user-notify handoff is what keeps the wrapper alive long enough to
+// attach eBPF before exec. Skipping in that case would silently disable
+// eBPF enforcement.
+//
+// This is closely related to TestWrapInit_ForcesNotifyHandoffWhenEBPFRequiresPreAckCgroup
+// but documents the gate from the unix_sockets side rather than the
+// notify-handoff side.
+func TestWrapInit_UnixSocketsDisabledButEBPFRequiresWrapper(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	disabled := false
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &disabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.Network.EBPF.Required = true
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	_, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != http.StatusOK {
+		t.Errorf("expected status 200 (eBPF override), got %d", code)
+	}
+}
+
 func TestWrapInit_WrapperNotFound(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("wrap is Linux-only")


### PR DESCRIPTION
## Summary

- Fixes #361: v0.20.0-rc1 regression where `agentsh-unixwrap` engaged on Vercel/Daytona/Firecracker even when the operator had set `sandbox.unix_sockets.enabled: false` and `sandbox.seccomp.enabled: false`.
- Mirrors the existing exec-path gate in `core.go::setupSeccompWrapper`: `wrapInitCore` now returns 503 when `UnixSockets.Enabled` is explicitly false, so the shim's `ModeAuto` branch falls through to running the command unwrapped (restoring v0.19.3 behavior).
- Preserves the eBPF/cgroup pre-ACK override (`wrapNeedsCgroupBeforeAck`): when eBPF is required, the wrapper still engages — skipping it there would silently disable eBPF enforcement.
- Nil `Enabled` is treated as "default true" so bare test configs and `applyDefaults` continue to work; only an explicit `false` disengages.

## Test plan

- [x] `go build ./...`
- [x] `GOOS=windows go build ./...`
- [x] `go test ./...` (all pass)
- [x] `go test ./internal/api/ -run TestWrapInit_` (3 new tests + existing ForcesNotifyHandoffWhenEBPFRequiresPreAckCgroup pass)
- New tests:
  - `TestWrapInit_UnixSocketsExplicitlyDisabled` — primary regression case, asserts 503 + error message
  - `TestWrapInit_UnixSocketsNilDefaultsToEnabled` — guards against the gate firing on nil
  - `TestWrapInit_UnixSocketsDisabledButEBPFRequiresWrapper` — eBPF override branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)