### PR TITLE
fix(wrap): close policy-limits bypass in wrapNeedsCgroupBeforeAck (#361)

### DIFF
--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -865,13 +865,24 @@ func wrapNeedsCgroupBeforeAck(a *App, s *session.Session) bool {
 		a.cfg.Sandbox.Network.EBPF.Required {
 		return true
 	}
-	// Per-policy resource-limits check unchanged.
-	engine := a.policyEngineFor(s)
-	if engine == nil {
-		return false
-	}
-	lim := engine.Limits()
-	return lim.MaxMemoryMB > 0 || lim.CPUQuotaPercent > 0 || lim.PidsMax > 0
+	// Policy resource-limits ONLY justify engaging the wrapper when there
+	// is a cgroup/eBPF enforcement path available — otherwise the wrapper
+	// engages, the server tries to apply cgroups, applyCgroupV2 returns
+	// CgroupResourceLimitsUnavailableError (no soft-fail path), and the
+	// wrapper aborts the user's command with empty stdout / exit 1.
+	//
+	// This is the policy-limits arm of the #361 regression: secure-sandbox
+	// presets ship maxMemoryMb/cpuQuotaPercent/pidsMax for every adapter,
+	// which used to land here unconditionally and forced wrap to engage
+	// even on hosts that disabled both cgroups AND unix_sockets in their
+	// server config (Vercel Firecracker, Daytona). With no enforcement
+	// infrastructure configured, the limits cannot be enforced anyway —
+	// keeping the wrapper alive only to fail in applyCgroupV2 is strictly
+	// worse than not engaging at all. The first branch above already
+	// returns true when cgroups OR any eBPF flag is enabled, so reaching
+	// this point means "policy has limits but no enforcement is wired" —
+	// nothing to attach, nothing to gain by holding the handshake open.
+	return false
 }
 
 func defaultWrapCgroupSetupForNotify(ctx context.Context, a *App, s *session.Session, sessionID string, wrapperPID int) (func() error, error) {

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -430,6 +430,115 @@ func TestWrapInit_UnixSocketsDisabledButEBPFRequiresWrapper(t *testing.T) {
 	}
 }
 
+// TestWrapInit_UnixSocketsDisabledWithPolicyLimitsButNoCgroup covers the
+// follow-up regression reported in #361 after the initial 093e1852 fix.
+// secure-sandbox presets ship policy resource_limits (max_memory_mb /
+// cpu_quota_percent / pids_max) for every adapter. Before this fix,
+// wrapNeedsCgroupBeforeAck returned true whenever ANY policy limit was
+// non-zero, which forced the wrapper to engage on hosts that disabled
+// BOTH unix_sockets AND cgroups — defeating the unix_sockets gate. The
+// wrapper then loaded its seccomp filter, the server tried to apply
+// cgroups, applyCgroupV2 returned CgroupResourceLimitsUnavailableError
+// (no soft-fail), and the user's command silently died (empty stdout,
+// exit 1) — the same symptom this issue is supposed to prevent.
+//
+// With policy limits but no cgroup/eBPF enforcement configured, the
+// limits cannot be enforced anyway, so the wrapper must NOT engage and
+// the gate must fire.
+func TestWrapInit_UnixSocketsDisabledWithPolicyLimitsButNoCgroup(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	cfg := &config.Config{}
+	disabled := false
+	cfg.Sandbox.UnixSockets.Enabled = &disabled
+	// Explicitly leave Cgroups / Network.EBPF unconfigured — mirrors the
+	// Vercel/Daytona/Firecracker server config from secure-sandbox.
+
+	mgr := session.NewManager(5)
+	store := composite.New(mockEventStore{}, nil)
+	broker := events.NewBroker()
+	engine, err := policy.NewEngine(&policy.Policy{
+		Version: 1,
+		Name:    "test",
+		ResourceLimits: policy.ResourceLimits{
+			MaxMemoryMB:     8192,
+			CPUQuotaPercent: 100,
+			PidsMax:         500,
+		},
+		CommandRules: []policy.CommandRule{
+			{Name: "allow-all", Commands: []string{}, Decision: "allow"},
+		},
+	}, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	_, code, wrapErr := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		AgentArgs:    []string{"hello"},
+	})
+	if wrapErr == nil {
+		t.Fatal("expected wrap-init to refuse engagement when unix_sockets is disabled and no cgroup/eBPF enforcement is configured")
+	}
+	if code != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d", code)
+	}
+	if !strings.Contains(wrapErr.Error(), "unix_sockets.enabled is false") {
+		t.Errorf("expected unix_sockets gate to fire, got %q", wrapErr.Error())
+	}
+}
+
+// TestWrapNeedsCgroupBeforeAck_PolicyLimitsAloneInsufficient is the unit
+// counterpart for the #361 follow-up: pins the contract that policy
+// limits, on their own, are not enough to force the pre-ACK cgroup
+// engagement path. Without cgroups/eBPF configured, the limits cannot be
+// enforced anyway — keeping the wrapper alive would only lead to
+// applyCgroupV2 failing with CgroupResourceLimitsUnavailableError.
+func TestWrapNeedsCgroupBeforeAck_PolicyLimitsAloneInsufficient(t *testing.T) {
+	cfg := &config.Config{}
+	mgr := session.NewManager(5)
+	store := composite.New(mockEventStore{}, nil)
+	broker := events.NewBroker()
+	engine, err := policy.NewEngine(&policy.Policy{
+		Version: 1,
+		Name:    "test",
+		ResourceLimits: policy.ResourceLimits{
+			MaxMemoryMB:     1024,
+			CPUQuotaPercent: 50,
+			PidsMax:         100,
+		},
+	}, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	if wrapNeedsCgroupBeforeAck(app, s) {
+		t.Fatal("wrapNeedsCgroupBeforeAck must return false when policy has limits but no cgroup/eBPF enforcement is configured")
+	}
+
+	// Sanity: enabling cgroups must flip the result so the original
+	// pre-ACK engagement contract still holds for operators who actually
+	// configured enforcement.
+	cfg.Sandbox.Cgroups.Enabled = true
+	if !wrapNeedsCgroupBeforeAck(app, s) {
+		t.Fatal("wrapNeedsCgroupBeforeAck must return true when cgroups is enabled")
+	}
+}
+
 func TestWrapInit_WrapperNotFound(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("wrap is Linux-only")

--- a/internal/integration/seccomp_wrapper_test.go
+++ b/internal/integration/seccomp_wrapper_test.go
@@ -447,6 +447,104 @@ func TestSeccompWrapperDisabled_WrapInitRefuses(t *testing.T) {
 	}
 }
 
+// TestSeccompWrapperDisabled_WrapInitRefuses_WithPolicyLimits covers the
+// follow-up to #361: the policy-limits bypass path through
+// wrapNeedsCgroupBeforeAck. secure-sandbox presets ship resource_limits
+// (max_memory_mb / cpu_quota_percent / pids_max) on every adapter; before
+// the follow-up fix, those non-zero limits forced wrapNeedsCgroupBeforeAck
+// to return true, which defeated the unix_sockets gate even on hosts
+// that disabled cgroups too. The wrapper engaged, applyCgroupV2 returned
+// CgroupResourceLimitsUnavailableError on the hosted kernels, and the
+// user's command silently died with empty stdout / exit 1 — the exact
+// symptom the gate was added to prevent.
+//
+// This test pins the contract end-to-end with the secure-sandbox
+// agentDefault() preset's limits in policy.yml and no cgroup enforcement
+// configured. The unit test
+// TestWrapNeedsCgroupBeforeAck_PolicyLimitsAloneInsufficient covers the
+// same path in isolation; this one proves the bypass is closed under a
+// real HTTP server with the exact config secure-sandbox emits.
+func TestSeccompWrapperDisabled_WrapInitRefuses_WithPolicyLimits(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	agentshBin, unixwrapBin := buildSeccompBinaries(t)
+
+	temp := t.TempDir()
+
+	policiesDir := filepath.Join(temp, "policies")
+	mustMkdir(t, policiesDir)
+	writeFile(t, filepath.Join(policiesDir, "default.yaml"), seccompTestPolicyWithResourceLimitsYAML)
+
+	keysPath := filepath.Join(temp, "keys.yaml")
+	writeFile(t, keysPath, testAPIKeysYAML)
+
+	configPath := filepath.Join(temp, "config.yaml")
+	writeFile(t, configPath, seccompDisabledConfigYAML)
+
+	workspace := filepath.Join(temp, "workspace")
+	mustMkdir(t, workspace)
+
+	endpoint, cleanup := startSeccompServerContainer(t, ctx, agentshBin, unixwrapBin, configPath, policiesDir, workspace)
+	t.Cleanup(cleanup)
+
+	cli := client.New(endpoint, "test-key")
+
+	sess, err := createSessionWithRetry(ctx, cli, "/workspace", "default")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	t.Logf("Session created: %s", sess.ID)
+
+	// 1. wrap-init in shim mode must still be refused with 503 even with
+	//    non-zero policy resource_limits, because no cgroup/eBPF
+	//    enforcement is configured. Before the fix this returned 200 with
+	//    a wrapper binary and the shim then crashed.
+	_, wrapErr := cli.WrapInit(ctx, sess.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		AgentArgs:    []string{"hello"},
+		CallerUID:    0,
+		Mode:         "shim",
+	})
+	if wrapErr == nil {
+		t.Fatal("wrap-init succeeded with unix_sockets.enabled=false and policy limits (no cgroup config); expected 503 (regression #361 follow-up)")
+	}
+	var httpErr *client.HTTPError
+	if !errors.As(wrapErr, &httpErr) {
+		t.Fatalf("expected *client.HTTPError, got %T: %v", wrapErr, wrapErr)
+	}
+	if httpErr.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("expected status 503, got %d (body=%q)", httpErr.StatusCode, httpErr.Body)
+	}
+	if !strings.Contains(httpErr.Body, "unix_sockets.enabled is false") {
+		t.Errorf("expected error body to mention unix_sockets.enabled, got %q", httpErr.Body)
+	}
+
+	// 2. Exec must still produce real output. Pre-fix, the wrapper
+	//    engaged via the policy-limits bypass, applyCgroupV2 hard-failed,
+	//    and Exec returned empty stdout / non-zero exit.
+	execCtx, execCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer execCancel()
+	result, err := cli.Exec(execCtx, sess.ID, types.ExecRequest{
+		Command:    "/bin/echo",
+		Args:       []string{"hello", "from", "unwrapped"},
+		WorkingDir: "/workspace",
+	})
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	if result.Result.ExitCode != 0 {
+		t.Errorf("expected exit 0, got %d (stderr=%q)", result.Result.ExitCode, result.Result.Stderr)
+	}
+	if want := "hello from unwrapped\n"; result.Result.Stdout != want {
+		t.Errorf("expected stdout %q, got %q", want, result.Result.Stdout)
+	}
+
+	if err := cli.DestroySession(ctx, sess.ID); err != nil {
+		t.Fatalf("DestroySession: %v", err)
+	}
+}
+
 func buildSeccompBinaries(t *testing.T) (agentsh, unixwrap string) {
 	t.Helper()
 
@@ -717,6 +815,34 @@ resource_limits:
   command_timeout: 30s
   session_timeout: 1h
   idle_timeout: 30m
+`
+
+// seccompTestPolicyWithResourceLimitsYAML mirrors the limits that
+// @agentsh/secure-sandbox's agentDefault() preset ships for every
+// adapter (max_memory_mb: 8192, cpu_quota_percent: 100, pids_max: 500).
+// Used by TestSeccompWrapperDisabled_WrapInitRefuses_WithPolicyLimits
+// to exercise the policy-limits branch of wrapNeedsCgroupBeforeAck that
+// originally bypassed the unix_sockets gate (#361 follow-up).
+const seccompTestPolicyWithResourceLimitsYAML = `
+version: 1
+name: default
+description: seccomp integration test policy with secure-sandbox-style resource limits
+command_rules:
+  - name: allow-all
+    commands: []
+    decision: allow
+file_rules:
+  - name: allow-all
+    paths: ["/**"]
+    operations: [read, write, delete]
+    decision: allow
+resource_limits:
+  command_timeout: 30s
+  session_timeout: 1h
+  idle_timeout: 30m
+  max_memory_mb: 8192
+  cpu_quota_percent: 100
+  pids_max: 500
 `
 
 const seccompTestConfigYAML = `


### PR DESCRIPTION
## Summary

Follow-up to #362. The first fix added the unix_sockets gate with an eBPF/cgroup override via \`wrapNeedsCgroupBeforeAck\` — but that helper *also* returned true whenever policy \`resource_limits\` were non-zero, regardless of whether any enforcement infrastructure was actually configured. \`@agentsh/secure-sandbox\`'s \`agentDefault()\` preset ships \`max_memory_mb: 8192\` / \`cpu_quota_percent: 100\` / \`pids_max: 500\` for every adapter, so the bypass fired on every secure-sandbox session — defeating #362's gate on Vercel/Daytona/Firecracker and reproducing the original empty-stdout / exit-1 symptom.

## Fix

Drop the policy-limits branch in \`wrapNeedsCgroupBeforeAck\`. The first branch already returns true when \`Cgroups.Enabled\` or any \`Network.EBPF.*\` flag is on, so reaching the dropped branch means *no enforcement is wired*. With nothing to attach, keeping the wrapper alive only leads to \`applyCgroupV2\` returning \`CgroupResourceLimitsUnavailableError\` (no soft-fail) and the wrapper aborting the user's command.

## Tests

| Test | Level | What it pins |
|---|---|---|
| \`TestWrapNeedsCgroupBeforeAck_PolicyLimitsAloneInsufficient\` | unit | helper returns false when policy has limits but no cgroup config; flips to true when \`Cgroups.Enabled = true\` |
| \`TestWrapInit_UnixSocketsDisabledWithPolicyLimitsButNoCgroup\` | unit | wrap-init returns 503 + \"unix_sockets.enabled is false\" with the secure-sandbox limits in policy |
| \`TestSeccompWrapperDisabled_WrapInitRefuses_WithPolicyLimits\` | integration (\`integration && linux\`) | end-to-end with the secure-sandbox preset YAML against a real HTTP server in a container |

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./...\` (passes)
- [x] \`go test -tags 'integration linux' -run TestSeccompWrapperDisabled_WrapInitRefuses_WithPolicyLimits ./internal/integration/\` (passes, 9.8s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)