### PR TITLE
[codex] Add require_where DB policy guard

### DIFF
--- a/docs/agentsh-db-access-spec.md
+++ b/docs/agentsh-db-access-spec.md
@@ -704,6 +704,7 @@ database_rules:
 | `operations` | yes | Group names or aliases. Rule matches an effect whose `group` is in the list. |
 | `subtypes` | no | If specified, rule matches only effects whose `operation_subtype` is in the list. |
 | `match_object_resolution` | no | One of the resolution tags or `*`. Matches against the effect's per-effect resolution tag. |
+| `require_where` | no | Boolean. When true, this rule covers Postgres `modify`/`delete` effects only if the top-level `UPDATE` or `DELETE` statement has a syntactic `WHERE` clause. Valid only when `operations` expands exclusively to `modify` and/or `delete`. |
 | `decision` | yes | `allow`, `deny`, `approve`, `audit`, `redirect`. `redirect` is statement-level only and requires `redirect.relation`, `relations`, `match_object_resolution: catalog_resolved`, read-only operations, and an eligible terminate-mode Postgres service. |
 | `redirect.relation` | only for `decision: redirect` | Canonical target relation formatted as `schema.name`. Plan 11 supports one source relation selected by a canonical `relations` entry and one target relation. Runtime execution is wired in DB Plan 12. |
 | `message` | no | Template with `{{.Operation}}, {{.Subtype}}, {{.Schema}}, {{.Object}}, {{.Verb}}, {{.StatementPreview}}`. |
@@ -711,6 +712,8 @@ database_rules:
 | `acknowledge_audit_on_dangerous` | no | Required `true` to silence the load-time warning emitted when `decision: audit` is paired with operations of risk tier ≥ high (§9.4, R13). |
 
 `objects` remains syntactic-only. `relations` and `functions` are catalog selectors and do not match unresolved or unavailable catalog metadata. Strict object coverage still applies: every object slot in an effect must be covered by an allow/audit/redirect/approve rule, and any matching deny rule still wins.
+
+`require_where: true` is a syntactic mutation guard for Postgres `UPDATE` and `DELETE`. It does not prove predicate selectivity; `WHERE true` satisfies the guard. Operators who need tenant, primary-key, or row-count constraints must enforce those separately with database-native controls or a future predicate-aware policy feature.
 
 ### DB policy explain
 

--- a/docs/agentsh-db-access-spec.md
+++ b/docs/agentsh-db-access-spec.md
@@ -775,6 +775,7 @@ Connection rules evaluate **before** any statement is classified. A connection-l
 - Rule referencing a `db_service` that does not exist → load error.
 - Statement rule with malformed `decision: redirect` shape → load error. Connection-rule redirect remains invalid.
 - Rule with `subtypes` referencing a non-existent subtype → load error.
+- Rule with `require_where: true` paired with operations that do not expand exclusively to `modify` and/or `delete` → `rule_require_where_invalid_operation` load error.
 - Rule with no `db_service` and no `db_family` and `decision: allow` and `operations: ["*"]` → load error (too broad).
 - Service with `tls_mode: terminate_plaintext_upstream` to a non-RFC1918, non-loopback destination without `trusted_network: true` → load error.
 - Connection rule with `match_kind: cancel` and `decision: approve` → load error. Cancel is a real-time signal that cannot be held for human approval (§15.2, R19).

--- a/docs/operations/policies.md
+++ b/docs/operations/policies.md
@@ -450,7 +450,7 @@ database_rules:
     decision: allow
 ```
 
-This allows `UPDATE public.users SET disabled = true WHERE id = 123` when the relation selector matches, but it does not cover `UPDATE public.users SET disabled = true`. The guard checks only that a top-level `WHERE` exists; it does not prove the predicate is selective or tenant-safe.
+This rule allows `UPDATE public.users SET disabled = true WHERE id = 123` when the relation selector matches, but it does not cover `UPDATE public.users SET disabled = true`. The guard checks only that a top-level `WHERE` exists; it does not prove the predicate is selective or tenant-safe. It is also only a rule matcher: if another unguarded `allow`, `audit`, or `approve` rule covers the same `modify` or `delete` effect, a no-WHERE mutation can still be permitted.
 
 ## HTTP Services
 

--- a/docs/operations/policies.md
+++ b/docs/operations/policies.md
@@ -433,6 +433,25 @@ When transparent unwrapping occurs, audit events include additional fields:
 
 These fields help detect bypass attempts in audit logs.
 
+## Database Policies
+
+### Require WHERE For Sensitive Mutations
+
+Use `require_where: true` on narrow mutation rules when accidental full-table updates or deletes are the main risk:
+
+```yaml
+database_rules:
+  - name: allow-scoped-user-mutations
+    db_service: appdb
+    operations: [modify, delete]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    require_where: true
+    decision: allow
+```
+
+This allows `UPDATE public.users SET disabled = true WHERE id = 123` when the relation selector matches, but it does not cover `UPDATE public.users SET disabled = true`. The guard checks only that a top-level `WHERE` exists; it does not prove the predicate is selective or tenant-safe.
+
 ## HTTP Services
 
 `http_services:` declares named HTTP upstreams that child processes can reach through the proxy gateway. Declaring a service also blocks direct HTTP/HTTPS connections to its upstream host (and any aliases) from the child process — traffic must flow through the gateway where the declared rules are enforced.

--- a/docs/superpowers/plans/2026-05-20-db-require-where-policy.md
+++ b/docs/superpowers/plans/2026-05-20-db-require-where-policy.md
@@ -1,0 +1,823 @@
+# DB Require WHERE Policy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `require_where: true` database statement-rule guard that allows Postgres `UPDATE` and `DELETE` mutation effects only when the top-level statement has a syntactic `WHERE` clause.
+
+**Architecture:** Capture top-level `WHERE` presence on the mutation `effects.Effect`, compile `require_where` into statement rules, and let the existing policy coverage model fail closed when a guarded rule does not match. Keep the feature Postgres-only and limited to `modify` and `delete` operation groups in v1.
+
+**Tech Stack:** Go, `github.com/pganalyze/pg_query_go/v5`, existing AgentSH DB classifier, DB policy evaluator, Postgres proxy tests, YAML policy config.
+
+---
+
+## File Structure
+
+- `internal/db/effects/effect.go`: add `HasWhere bool` observed-shape metadata to `Effect`.
+- `internal/db/effects/statement_test.go`: add JSON tests proving `has_where` is emitted only when true.
+- `internal/db/classify/postgres/ast_dml.go`: set `HasWhere` on primary `UPDATE` and `DELETE` effects.
+- `internal/db/classify/postgres/ast_dml_test.go`: add classifier tests for with-WHERE and no-WHERE `UPDATE`/`DELETE`.
+- `internal/db/policy/types.go`: add `RequireWhere bool` to `StatementRule`.
+- `internal/db/policy/compile.go`: add `requireWhere` to `compiledStatementRule` and copy it from `StatementRule`.
+- `internal/db/policy/validate.go`: reject `require_where` unless the expanded operation groups are exactly a subset of `modify` and `delete`.
+- `internal/db/policy/validate_test.go`: add validation accept/reject coverage.
+- `internal/db/policy/evaluate.go`: make `ruleMatchesEffectMeta` require `e.HasWhere` when compiled `requireWhere` is true.
+- `internal/db/policy/evaluate_require_where_test.go`: add focused evaluator tests for allow and implicit-deny behavior.
+- `internal/db/proxy/postgres/simplequery_test.go`: add a simple-query regression proving no-WHERE mutations are denied before forwarding.
+- `docs/agentsh-db-access-spec.md`: document the statement-rule field and semantics.
+- `docs/operations/policies.md`: add an operator example.
+- `skills/agentsh-policy-shared/schema-reference.md`: add the field to the policy skill schema reference.
+- `skills/agentsh-policy-create/SKILL.md`: mention the guard during DB policy creation.
+- `skills/agentsh-policy-edit/SKILL.md`: mention the guard during DB policy edits.
+
+### Task 1: Record WHERE Presence In Classified Effects
+
+**Files:**
+- Modify: `internal/db/effects/effect.go`
+- Modify: `internal/db/effects/statement_test.go`
+- Modify: `internal/db/classify/postgres/ast_dml.go`
+- Modify: `internal/db/classify/postgres/ast_dml_test.go`
+
+- [ ] **Step 1: Write failing JSON tests for `Effect.HasWhere`**
+
+Append these tests to `internal/db/effects/statement_test.go`:
+
+```go
+func TestEffect_HasWhere_JSON(t *testing.T) {
+	in := ClassifiedStatement{
+		Effects: []Effect{{Group: GroupModify, HasWhere: true}},
+		RawVerb: "UPDATE",
+	}
+	bs, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(bs), `"has_where":true`) {
+		t.Fatalf("has_where missing: %s", bs)
+	}
+}
+
+func TestEffect_HasWhere_OmitFalse(t *testing.T) {
+	in := ClassifiedStatement{
+		Effects: []Effect{{Group: GroupModify}},
+		RawVerb: "UPDATE",
+	}
+	bs, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(bs), "has_where") {
+		t.Fatalf("has_where should be omitted when false: %s", bs)
+	}
+}
+```
+
+- [ ] **Step 2: Run the JSON tests and verify they fail**
+
+Run:
+
+```bash
+go test ./internal/db/effects -run 'TestEffect_HasWhere' -count=1
+```
+
+Expected: fail with an output containing `has_where missing`.
+
+- [ ] **Step 3: Add `HasWhere` to `effects.Effect`**
+
+In `internal/db/effects/effect.go`, update `Effect`:
+
+```go
+type Effect struct {
+	Group           Group
+	Subtype         Subtype
+	Objects         []ObjectRef
+	ResolvedObjects []ResolvedObjectRef `json:"resolved_objects,omitempty"`
+	Resolution      Resolution
+
+	// HasWhere is observed statement-shape metadata. It is set only on
+	// mutation effects whose owning statement has a top-level WHERE clause.
+	HasWhere bool `json:"has_where,omitempty"`
+
+	// FunctionOID is populated for procedural effects with Subtype
+	// SubtypeFunctionCallProtocol (the Postgres 'F' FunctionCall frame) or
+	// SubtypeEscalatedFunctionCall (when classifier escalation produced
+	// the effect). Pointer so JSON omits zero.
+	FunctionOID *int32 `json:"function_oid,omitempty"`
+}
+```
+
+- [ ] **Step 4: Run the JSON tests and verify they pass**
+
+Run:
+
+```bash
+go test ./internal/db/effects -run 'TestEffect_HasWhere' -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Write failing classifier tests**
+
+Add these tests to `internal/db/classify/postgres/ast_dml_test.go` near the existing update/delete smoke tests:
+
+```go
+func TestClassifyUpdate_HasWhere(t *testing.T) {
+	cs := classifyOne(t, "UPDATE users SET active = false WHERE id = 1", SessionState{})
+	prim, _ := cs.Primary()
+	if prim.Group != effects.GroupModify {
+		t.Fatalf("primary group: got %v want modify", prim.Group)
+	}
+	if !prim.HasWhere {
+		t.Fatalf("UPDATE with WHERE should set HasWhere on primary effect: %+v", prim)
+	}
+}
+
+func TestClassifyUpdate_NoWhere(t *testing.T) {
+	cs := classifyOne(t, "UPDATE users SET active = false", SessionState{})
+	prim, _ := cs.Primary()
+	if prim.Group != effects.GroupModify {
+		t.Fatalf("primary group: got %v want modify", prim.Group)
+	}
+	if prim.HasWhere {
+		t.Fatalf("UPDATE without WHERE should not set HasWhere: %+v", prim)
+	}
+}
+
+func TestClassifyUpdate_HasWhereOnlyOnModifyEffect(t *testing.T) {
+	cs := classifyOne(t, "UPDATE users SET active = false FROM logins WHERE users.id = logins.user_id", SessionState{})
+	if len(cs.Effects) != 2 {
+		t.Fatalf("effects count: got %d want 2: %+v", len(cs.Effects), cs.Effects)
+	}
+	if !cs.Effects[0].HasWhere {
+		t.Fatalf("primary modify effect should have HasWhere: %+v", cs.Effects[0])
+	}
+	if cs.Effects[1].Group != effects.GroupRead {
+		t.Fatalf("secondary effect group = %v want read", cs.Effects[1].Group)
+	}
+	if cs.Effects[1].HasWhere {
+		t.Fatalf("secondary read effect should not inherit HasWhere: %+v", cs.Effects[1])
+	}
+}
+
+func TestClassifyDelete_HasWhere(t *testing.T) {
+	cs := classifyOne(t, "DELETE FROM users WHERE id = 1", SessionState{})
+	prim, _ := cs.Primary()
+	if prim.Group != effects.GroupDelete {
+		t.Fatalf("primary group: got %v want delete", prim.Group)
+	}
+	if !prim.HasWhere {
+		t.Fatalf("DELETE with WHERE should set HasWhere on primary effect: %+v", prim)
+	}
+}
+
+func TestClassifyDelete_NoWhere(t *testing.T) {
+	cs := classifyOne(t, "DELETE FROM users", SessionState{})
+	prim, _ := cs.Primary()
+	if prim.Group != effects.GroupDelete {
+		t.Fatalf("primary group: got %v want delete", prim.Group)
+	}
+	if prim.HasWhere {
+		t.Fatalf("DELETE without WHERE should not set HasWhere: %+v", prim)
+	}
+}
+```
+
+- [ ] **Step 6: Run the classifier tests and verify they fail**
+
+Run:
+
+```bash
+go test ./internal/db/classify/postgres -run 'TestClassify(Update|Delete)_(HasWhere|NoWhere|HasWhereOnlyOnModifyEffect)' -count=1
+```
+
+Expected: fail because `HasWhere` is false for the with-WHERE cases.
+
+- [ ] **Step 7: Set `HasWhere` in update/delete classification**
+
+In `internal/db/classify/postgres/ast_dml.go`, update the primary effects in `classifyUpdate` and `classifyDelete`:
+
+```go
+	cs.Effects = append(cs.Effects, effects.Effect{
+		Group:      effects.GroupModify,
+		Objects:    []effects.ObjectRef{tgt},
+		Resolution: tgtRes,
+		HasWhere:   s.WhereClause != nil,
+	})
+```
+
+```go
+	cs.Effects = append(cs.Effects, effects.Effect{
+		Group:      effects.GroupDelete,
+		Objects:    []effects.ObjectRef{tgt},
+		Resolution: tgtRes,
+		HasWhere:   s.WhereClause != nil,
+	})
+```
+
+- [ ] **Step 8: Run task tests**
+
+Run:
+
+```bash
+go test ./internal/db/effects ./internal/db/classify/postgres -run 'TestEffect_HasWhere|TestClassify(Update|Delete)_(HasWhere|NoWhere|HasWhereOnlyOnModifyEffect)' -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 9: Commit Task 1**
+
+```bash
+git add internal/db/effects/effect.go internal/db/effects/statement_test.go internal/db/classify/postgres/ast_dml.go internal/db/classify/postgres/ast_dml_test.go
+git commit -m "Track WHERE presence on DB mutation effects"
+```
+
+### Task 2: Add Policy Validation And Evaluator Support
+
+**Files:**
+- Modify: `internal/db/policy/types.go`
+- Modify: `internal/db/policy/compile.go`
+- Modify: `internal/db/policy/validate.go`
+- Modify: `internal/db/policy/validate_test.go`
+- Modify: `internal/db/policy/evaluate.go`
+- Create: `internal/db/policy/evaluate_require_where_test.go`
+
+- [ ] **Step 1: Write failing validation tests**
+
+Append to `internal/db/policy/validate_test.go`:
+
+```go
+func TestValidate_RequireWhereAllowsModifyAndDeleteOnly(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	cases := []struct {
+		name string
+		ops  []string
+	}{
+		{name: "modify", ops: []string{"modify"}},
+		{name: "delete", ops: []string{"delete"}},
+		{name: "modify_delete", ops: []string{"modify", "delete"}},
+		{name: "UPDATE_alias", ops: []string{"UPDATE"}},
+		{name: "DELETE_alias", ops: []string{"DELETE"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt := []*StatementRule{{
+				Name:         "guarded",
+				DBService:    "appdb",
+				Operations:   tc.ops,
+				Decision:     "allow",
+				RequireWhere: true,
+			}}
+			if _, err := helperValidate(t, svcs, stmt, nil); err != nil {
+				t.Fatalf("validate: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidate_RequireWhereRejectsUnsupportedOperations(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	cases := []struct {
+		name string
+		ops  []string
+	}{
+		{name: "read", ops: []string{"read"}},
+		{name: "star", ops: []string{"*"}},
+		{name: "read_delete", ops: []string{"read", "delete"}},
+		{name: "MUTATE_includes_write", ops: []string{"MUTATE"}},
+		{name: "transaction", ops: []string{"transaction"}},
+		{name: "schema_destroy", ops: []string{"schema_destroy"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt := []*StatementRule{{
+				Name:         "guarded",
+				DBService:    "appdb",
+				Operations:   tc.ops,
+				Decision:     "allow",
+				RequireWhere: true,
+			}}
+			_, err := helperValidate(t, svcs, stmt, nil)
+			if err == nil || !strings.Contains(err.Error(), "rule_require_where_invalid_operation") {
+				t.Fatalf("want rule_require_where_invalid_operation, got %v", err)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run validation tests and verify they fail to compile**
+
+Run:
+
+```bash
+go test ./internal/db/policy -run 'TestValidate_RequireWhere' -count=1
+```
+
+Expected: fail to compile because `StatementRule.RequireWhere` does not exist.
+
+- [ ] **Step 3: Add the YAML field and validation helper**
+
+In `internal/db/policy/types.go`, add `RequireWhere` near `MatchObjectResolution`:
+
+```go
+	MatchObjectResolution       string          `yaml:"match_object_resolution,omitempty"`
+	RequireWhere                bool            `yaml:"require_where,omitempty"`
+	Decision                    string          `yaml:"decision"`
+```
+
+In `internal/db/policy/validate.go`, add this check after `groups := expandedGroups(r)` and after unknown operation validation:
+
+```go
+	if r.RequireWhere && !groupsOnlyModifyDelete(groups) {
+		errs = append(errs, fmt.Errorf("rule_require_where_invalid_operation: database_rules[%q]: require_where is supported only for modify/delete operations", r.Name))
+	}
+```
+
+Add this helper near `groupsOnlyRead`:
+
+```go
+func groupsOnlyModifyDelete(groups map[effects.Group]struct{}) bool {
+	if len(groups) == 0 {
+		return false
+	}
+	for g := range groups {
+		if g != effects.GroupModify && g != effects.GroupDelete {
+			return false
+		}
+	}
+	return true
+}
+```
+
+- [ ] **Step 4: Run validation tests and verify they pass**
+
+Run:
+
+```bash
+go test ./internal/db/policy -run 'TestValidate_RequireWhere' -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Write failing evaluator tests**
+
+Create `internal/db/policy/evaluate_require_where_test.go`:
+
+```go
+package policy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+	rootpolicy "github.com/agentsh/agentsh/internal/policy"
+)
+
+func mutationStmt(group effects.Group, hasWhere bool) effects.ClassifiedStatement {
+	return effects.ClassifiedStatement{
+		RawVerb: "UPDATE",
+		Effects: []effects.Effect{{
+			Group:      group,
+			Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Schema: "public", Name: "users"}},
+			Resolution: effects.ResolutionQualified,
+			HasWhere:   hasWhere,
+		}},
+	}
+}
+
+func TestDecode_RequireWhereAccepted(t *testing.T) {
+	p, err := rootpolicy.LoadFromBytes([]byte(`version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - name: guarded
+    db_service: appdb
+    operations: [modify, delete]
+    objects: [users]
+    require_where: true
+    decision: allow
+`))
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+	rs, _, err := Decode(p)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	rules := rs.AllStatementRules()
+	if len(rules) != 1 || !rules[0].RequireWhere {
+		t.Fatalf("RequireWhere not decoded: %+v", rules)
+	}
+}
+
+func TestEvaluate_RequireWhereAllowsMutationWithWhere(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - name: guarded
+    db_service: appdb
+    operations: [modify]
+    objects: [users]
+    require_where: true
+    decision: allow
+`)
+	d := Evaluate(mutationStmt(effects.GroupModify, true), rs, "appdb")
+	if d.Verb != VerbAllow || d.RuleName != "guarded" {
+		t.Fatalf("decision = %+v, want allow by guarded", d)
+	}
+}
+
+func TestEvaluate_RequireWhereDeniesMutationWithoutWhere(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - name: guarded
+    db_service: appdb
+    operations: [modify]
+    objects: [users]
+    require_where: true
+    decision: allow
+`)
+	d := Evaluate(mutationStmt(effects.GroupModify, false), rs, "appdb")
+	if d.Verb != VerbDeny || d.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny", d)
+	}
+	if !strings.Contains(d.Reason, "no rule covers") {
+		t.Fatalf("Reason = %q, want coverage failure", d.Reason)
+	}
+}
+
+func TestEvaluate_RequireWhereDoesNotBlockRuleWithoutGuard(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - name: unguarded
+    db_service: appdb
+    operations: [delete]
+    objects: [users]
+    decision: allow
+`)
+	d := Evaluate(mutationStmt(effects.GroupDelete, false), rs, "appdb")
+	if d.Verb != VerbAllow || d.RuleName != "unguarded" {
+		t.Fatalf("decision = %+v, want allow by unguarded", d)
+	}
+}
+```
+
+- [ ] **Step 6: Run evaluator tests and verify the guarded no-WHERE case fails**
+
+Run:
+
+```bash
+go test ./internal/db/policy -run 'TestDecode_RequireWhereAccepted|TestEvaluate_RequireWhere' -count=1
+```
+
+Expected: fail because `require_where` decodes but is not compiled/evaluated yet.
+
+- [ ] **Step 7: Compile and enforce `require_where`**
+
+In `internal/db/policy/compile.go`, update `compiledStatementRule`:
+
+```go
+type compiledStatementRule struct {
+	src           *StatementRule
+	verb          DecisionVerb
+	groups        map[effects.Group]struct{}
+	subtypes      map[effects.Subtype]struct{} // empty = all subtypes match
+	requireWhere  bool
+	resolution    resolutionMatcher
+	schemas       []glob.Glob // empty = all schemas match
+	objects       []glob.Glob // syntactic object selectors
+	relations     []glob.Glob // resolved relation canonical names
+	functions     []glob.Glob // resolved function identity names
+	timeout       time.Duration
+	msgTemplate   *template.Template // nil = no message rendering
+	redirect      *RedirectDecision
+	serviceFilter serviceFilter
+}
+```
+
+In `compileStatementRule`, set the field in the struct literal:
+
+```go
+	c := &compiledStatementRule{
+		src:           r,
+		groups:        map[effects.Group]struct{}{},
+		subtypes:      map[effects.Subtype]struct{}{},
+		requireWhere:  r.RequireWhere,
+		serviceFilter: serviceFilter{service: ServiceID(r.DBService), family: r.DBFamily, dialect: r.DBDialect},
+	}
+```
+
+In `internal/db/policy/evaluate.go`, update `ruleMatchesEffectMeta`:
+
+```go
+func ruleMatchesEffectMeta(r *compiledStatementRule, e effects.Effect) bool {
+	if _, ok := r.groups[e.Group]; !ok {
+		return false
+	}
+	if r.requireWhere && !e.HasWhere {
+		return false
+	}
+	if len(r.subtypes) > 0 {
+		if _, ok := r.subtypes[e.Subtype]; !ok {
+			return false
+		}
+	}
+	if !r.matchesResolution(e.Resolution) {
+		return false
+	}
+	return true
+}
+```
+
+- [ ] **Step 8: Run policy package tests**
+
+Run:
+
+```bash
+go test ./internal/db/policy -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 9: Commit Task 2**
+
+```bash
+git add internal/db/policy/types.go internal/db/policy/compile.go internal/db/policy/validate.go internal/db/policy/validate_test.go internal/db/policy/evaluate.go internal/db/policy/evaluate_require_where_test.go
+git commit -m "Enforce require_where in DB policy rules"
+```
+
+### Task 3: Prove Proxy Enforcement Before Forwarding
+
+**Files:**
+- Modify: `internal/db/proxy/postgres/simplequery_test.go`
+
+- [ ] **Step 1: Write a proxy regression test**
+
+Add this helper and test near `denyDeletesRuleSet` in `internal/db/proxy/postgres/simplequery_test.go`:
+
+```go
+func requireWhereRuleSet(t *testing.T) *policy.RuleSet {
+	t.Helper()
+	return loadRuleSet(t, `version: 1
+name: test
+db_services:
+  test:
+    family: postgres
+    dialect: postgres
+    upstream: 127.0.0.1:5432
+    tls_mode: terminate_reissue
+database_rules:
+  - name: allow-where-updates
+    db_service: test
+    operations: [modify]
+    objects: [users]
+    require_where: true
+    decision: allow
+`)
+}
+
+func TestHandleQuery_RequireWhere_DeniesNoWhereBeforeForward(t *testing.T) {
+	pc, clientFE, sink := newSimpleQueryFixture(t)
+	pc.state.smState.LastUpstreamRFQ = 'I'
+	pc.srv.SetPolicy(requireWhereRuleSet(t))
+
+	upClient, upServer := net.Pipe()
+	t.Cleanup(func() { _ = upClient.Close(); _ = upServer.Close() })
+	pc.state.upstream = upServer
+	pc.state.upstreamFE = pgproto3.NewFrontend(upServer, upServer)
+	upBackend := pgproto3.NewBackend(upClient, upClient)
+	drainClientBackendMessages(clientFE)
+
+	upRecv := make(chan pgproto3.FrontendMessage, 1)
+	go func() {
+		msg, err := upBackend.Receive()
+		if err == nil {
+			upRecv <- msg
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- pc.handleQuery(context.Background(), &pgproto3.Query{String: "UPDATE users SET active = false"})
+	}()
+
+	select {
+	case msg := <-upRecv:
+		t.Fatalf("upstream received no-WHERE mutation: %T", msg)
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("handleQuery returned transport error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleQuery did not return")
+	}
+
+	var evs []events.DBEvent
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		evs = sink.DrainStatements()
+		if len(evs) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("statement events = %+v", evs)
+	}
+	if evs[0].Decision.Verb != "deny" || evs[0].Decision.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny", evs[0].Decision)
+	}
+}
+```
+
+- [ ] **Step 2: Run the proxy test**
+
+Run:
+
+```bash
+go test ./internal/db/proxy/postgres -run TestHandleQuery_RequireWhere_DeniesNoWhereBeforeForward -count=1
+```
+
+Expected: pass after Tasks 1 and 2.
+
+- [ ] **Step 3: Run neighboring simple-query tests**
+
+Run:
+
+```bash
+go test ./internal/db/proxy/postgres -run 'TestHandleQuery_(DenyPath|RequireWhere)' -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit Task 3**
+
+```bash
+git add internal/db/proxy/postgres/simplequery_test.go
+git commit -m "Test require_where proxy enforcement"
+```
+
+### Task 4: Document Operator Semantics And Skill Guidance
+
+**Files:**
+- Modify: `docs/agentsh-db-access-spec.md`
+- Modify: `docs/operations/policies.md`
+- Modify: `skills/agentsh-policy-shared/schema-reference.md`
+- Modify: `skills/agentsh-policy-create/SKILL.md`
+- Modify: `skills/agentsh-policy-edit/SKILL.md`
+
+- [ ] **Step 1: Update the DB access spec field table**
+
+In `docs/agentsh-db-access-spec.md`, add this row after `match_object_resolution`:
+
+```markdown
+| `require_where` | no | Boolean. When true, this rule covers Postgres `modify`/`delete` effects only if the top-level `UPDATE` or `DELETE` statement has a syntactic `WHERE` clause. Valid only when `operations` expands exclusively to `modify` and/or `delete`. |
+```
+
+After the paragraph beginning `` `objects` remains syntactic-only. ``, add:
+
+```markdown
+`require_where: true` is a syntactic mutation guard for Postgres `UPDATE` and `DELETE`. It does not prove predicate selectivity; `WHERE true` satisfies the guard. Operators who need tenant, primary-key, or row-count constraints must enforce those separately with database-native controls or a future predicate-aware policy feature.
+```
+
+- [ ] **Step 2: Update the skill schema reference**
+
+In `skills/agentsh-policy-shared/schema-reference.md`, add this row after `match_object_resolution`:
+
+```markdown
+| require_where | bool | no | For Postgres `modify`/`delete` rules only: require the top-level `UPDATE` or `DELETE` statement to include a syntactic `WHERE` clause |
+```
+
+After the alias paragraph that starts `Uppercase aliases are also supported`, add:
+
+```markdown
+`require_where: true` is valid only when `operations` expands exclusively to `modify` and/or `delete`; `MUTATE` is rejected because it also includes `write`. The guard is syntactic only, so `WHERE true` satisfies it.
+```
+
+- [ ] **Step 3: Add an operator example**
+
+In `docs/operations/policies.md`, add this example in the database policy section:
+
+````markdown
+### Require WHERE For Sensitive Mutations
+
+Use `require_where: true` on narrow mutation rules when accidental full-table updates or deletes are the main risk:
+
+```yaml
+database_rules:
+  - name: allow-scoped-user-mutations
+    db_service: appdb
+    operations: [modify, delete]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    require_where: true
+    decision: allow
+```
+
+This allows `UPDATE public.users SET disabled = true WHERE id = 123` when the relation selector matches, but it does not cover `UPDATE public.users SET disabled = true`. The guard checks only that a top-level `WHERE` exists; it does not prove the predicate is selective or tenant-safe.
+````
+
+- [ ] **Step 4: Update policy creation guidance**
+
+In `skills/agentsh-policy-create/SKILL.md`, add this bullet in the DB policy authoring guidance:
+
+```markdown
+- For Postgres `UPDATE`/`DELETE` access to sensitive relations, ask whether accidental full-table mutation should be blocked. Use `require_where: true` only on rules whose `operations` expand exclusively to `modify` and/or `delete`; explain that it is syntactic and `WHERE true` still satisfies it.
+```
+
+- [ ] **Step 5: Update policy edit guidance**
+
+In `skills/agentsh-policy-edit/SKILL.md`, add this bullet in the DB rule editing guidance:
+
+```markdown
+- When editing mutation allow/approve/audit rules, preserve or add `require_where: true` for sensitive Postgres `modify`/`delete` rules when the operator wants no-WHERE mutations to fail closed. Do not add it to `MUTATE`, `*`, `read`, DDL, session, transaction, or procedural rules.
+```
+
+- [ ] **Step 6: Run docs/skill checks**
+
+Run:
+
+```bash
+python3 /home/eran/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/agentsh-policy-create
+python3 /home/eran/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/agentsh-policy-edit
+```
+
+Expected: both pass.
+
+- [ ] **Step 7: Commit Task 4**
+
+```bash
+git add docs/agentsh-db-access-spec.md docs/operations/policies.md skills/agentsh-policy-shared/schema-reference.md skills/agentsh-policy-create/SKILL.md skills/agentsh-policy-edit/SKILL.md
+git commit -m "Document require_where DB policy guard"
+```
+
+### Task 5: Final Verification
+
+**Files:**
+- No source changes.
+
+- [ ] **Step 1: Run focused package tests**
+
+Run:
+
+```bash
+go test ./internal/db/effects ./internal/db/classify/postgres ./internal/db/policy ./internal/db/proxy/postgres -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run DB service regression tests**
+
+Run:
+
+```bash
+go test ./internal/db/service ./internal/db/effects ./internal/db/policy -count=1
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Verify Windows compilation**
+
+Run:
+
+```bash
+GOOS=windows go build ./...
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Check staged cleanliness**
+
+Run:
+
+```bash
+git status --short
+git diff --check
+```
+
+Expected: only unrelated pre-existing dirty files may remain; no whitespace errors.
+
+- [ ] **Step 5: Summarize implemented behavior**
+
+Report these points:
+
+```text
+- require_where is decoded on database_rules and validated for modify/delete-only operation sets.
+- Postgres UPDATE/DELETE classification records top-level WHERE presence on the primary mutation effect.
+- Rules with require_where do not cover no-WHERE mutation effects, so existing implicit deny behavior blocks them.
+- Proxy simple-query tests prove no-WHERE mutations are denied before upstream forwarding.
+- Docs and policy skills describe the syntactic-only limitation.
+```

--- a/docs/superpowers/specs/2026-05-20-db-require-where-policy-design.md
+++ b/docs/superpowers/specs/2026-05-20-db-require-where-policy-design.md
@@ -1,0 +1,149 @@
+# DB Require WHERE Policy Design
+
+**Status:** Draft approved in brainstorming on 2026-05-20.
+**Owner:** Canyon Road
+**Source context:** `docs/agentsh-db-access-spec.md`, DB statement policy evaluator, Postgres classifier.
+
+## 1. Purpose
+
+AgentSH database policies can scope statement decisions by service, operation group, object selectors, resolution confidence, and decision verb. They cannot currently express "this mutation is allowed only when the SQL statement contains a `WHERE` clause."
+
+This feature adds a small, syntactic guard for Postgres-family `UPDATE` and `DELETE` statements:
+
+```yaml
+database_rules:
+  - name: allow-scoped-user-mutations
+    db_service: appdb
+    operations: [modify, delete]
+    relations: ["public.users"]
+    match_object_resolution: catalog_resolved
+    require_where: true
+    decision: allow
+```
+
+The intent is to prevent accidental full-table mutations when an allow, audit, approve, or redirect-like future rule would otherwise cover the mutation effect. This is not row-level predicate analysis. `WHERE true` satisfies the first version because the guard checks for a syntactic top-level `WHERE` clause only.
+
+## 2. Scope
+
+### In Scope
+
+- Add `require_where: true` to `database_rules`.
+- Support Postgres-family top-level `UPDATE` and `DELETE` statements.
+- Preserve the existing per-effect coverage model: a rule with `require_where: true` does not cover a mutation effect unless the classifier observed a `WHERE` clause.
+- Fail closed naturally through existing implicit-deny behavior when no rule covers the mutation effect.
+- Reject misleading configs where `require_where` is paired with operation groups outside `modify` and `delete`.
+- Document the feature in the DB access spec and policy skill schema references.
+
+### Out of Scope
+
+- Proving predicate selectivity or safety.
+- Rejecting tautologies such as `WHERE true`.
+- Requiring tenant predicates, primary-key predicates, row limits, or parameterized predicates.
+- Supporting `SELECT`, DDL, session, transaction, COPY, procedural, or unknown statement groups.
+- Supporting non-Postgres dialects in the first implementation.
+- Changing the meaning of existing policies that do not set `require_where`.
+
+## 3. Policy Semantics
+
+`require_where` is a statement-rule matcher. It is not a new decision verb and not a special deny path.
+
+A statement rule with `require_where: true` can match a `modify` or `delete` effect only when that effect carries classifier metadata saying the top-level statement has a `WHERE` clause.
+
+Examples:
+
+- `UPDATE public.users SET disabled = true WHERE id = 123` has a top-level `WHERE`, so a matching `require_where: true` rule can cover the `modify` effect.
+- `UPDATE public.users SET disabled = true` has no top-level `WHERE`, so that rule does not cover the `modify` effect.
+- `DELETE FROM public.users WHERE disabled = true` has a top-level `WHERE`, so the rule can cover the `delete` effect.
+- `DELETE FROM public.users` has no top-level `WHERE`, so the rule does not cover the `delete` effect.
+
+If another rule without `require_where` covers the same mutation effect, the existing evaluator semantics still apply. Operators who want a strict guard must ensure their mutation allow/approve/audit coverage rules for the sensitive object also require `WHERE`, or add explicit deny rules for broader cases.
+
+## 4. Implementation Shape
+
+### Effects Model
+
+Add observed statement-shape metadata to the classified effect:
+
+```go
+type Effect struct {
+    Group    Group
+    Subtype  Subtype
+    Objects  []ObjectRef
+    HasWhere bool `json:"has_where,omitempty"`
+    // existing fields...
+}
+```
+
+`HasWhere` describes the SQL shape observed by the classifier. It must not be named as if it were a policy requirement.
+
+### Postgres Classifier
+
+Set `HasWhere` on the primary mutation effect:
+
+- `classifyUpdate`: `HasWhere: s.WhereClause != nil`
+- `classifyDelete`: `HasWhere: s.WhereClause != nil`
+
+Do not propagate `HasWhere` to secondary read effects, CTE effects, COPY effects, or function-escalation effects. Data-modifying CTEs should keep their own classification behavior through the existing nested statement classification path.
+
+### Policy Decode And Compile
+
+Add the on-disk field:
+
+```go
+RequireWhere bool `yaml:"require_where,omitempty"`
+```
+
+Compile it onto `compiledStatementRule`.
+
+Extend `ruleMatchesEffectMeta` so:
+
+- if `require_where` is false, existing behavior is unchanged;
+- if `require_where` is true and the effect group is `modify` or `delete`, the rule matches only when `e.HasWhere` is true;
+- validation should prevent `require_where` from reaching unsupported groups.
+
+### Validation
+
+Validation should reject `require_where: true` unless the expanded operation group set is non-empty and every group is one of:
+
+- `modify`
+- `delete`
+
+This means mixed or broad aliases are rejected when they expand outside the supported set, including:
+
+- `operations: [read]`
+- `operations: ["*"]`
+- `operations: [read, delete]`
+- `operations: [MUTATE]` if `MUTATE` expands beyond `modify` and `delete`
+
+Use a stable error code such as `rule_require_where_invalid_operation`.
+
+## 5. Testing
+
+Add focused coverage at the same layers as the existing DB policy work:
+
+- Validation accepts `require_where: true` for `operations: [modify]`, `[delete]`, and `[modify, delete]`.
+- Validation rejects unsupported operation sets with `rule_require_where_invalid_operation`.
+- Postgres classifier marks `UPDATE ... WHERE ...` and `DELETE ... WHERE ...` mutation effects with `HasWhere`.
+- Postgres classifier leaves `UPDATE ...` and `DELETE ...` mutation effects without `HasWhere`.
+- Policy evaluator allows a covered mutation with `WHERE` when the only covering allow rule has `require_where: true`.
+- Policy evaluator denies the same mutation without `WHERE` through implicit coverage failure.
+- Simple Query proxy integration denies a no-`WHERE` mutation before forwarding when the only matching mutation allow rule requires `WHERE`.
+
+Regression tests should include a rule with the same object selector and `require_where: true` to prove that object coverage alone does not bypass the shape guard.
+
+## 6. Documentation Updates
+
+Update these surfaces:
+
+- `docs/agentsh-db-access-spec.md`: add `require_where` to the `database_rules` field table and statement matching semantics.
+- `docs/operations/policies.md`: add an operator example for sensitive table mutations.
+- `skills/agentsh-policy-shared/schema-reference.md`: add the field and the supported operation limitation.
+- `skills/agentsh-policy-create/SKILL.md` and `skills/agentsh-policy-edit/SKILL.md`: mention the guard when authoring DB mutation policies.
+
+## 7. Compatibility And Risks
+
+Existing policies remain unchanged because the new field defaults to false.
+
+The main operator risk is overestimating the protection. `require_where` prevents accidental omission of a `WHERE` clause; it does not prove that the predicate is selective, tenant-safe, indexed, parameterized, or non-tautological. Documentation and skill guidance should call this out directly.
+
+The main implementation risk is placing `HasWhere` at the wrong level. It belongs on the mutation effect generated from the statement that owns the `WHERE` clause, not on the whole classified statement, because multi-effect statements already fold decisions per effect.

--- a/internal/db/classify/postgres/ast_copy.go
+++ b/internal/db/classify/postgres/ast_copy.go
@@ -154,7 +154,7 @@ func appendCopyQueryEffects(cs *effects.ClassifiedStatement, s *pg_query.CopyStm
 	if s.Query == nil {
 		return
 	}
-	inner := classifyRawStmt(DialectPostgres, &pg_query.RawStmt{Stmt: s.Query}, sess, opts, cs.ParserBackend)
+	inner := classifyNestedRawStmt(DialectPostgres, &pg_query.RawStmt{Stmt: s.Query}, sess, opts, cs.ParserBackend)
 	cs.Effects = append(cs.Effects, inner.Effects...)
 }
 

--- a/internal/db/classify/postgres/ast_dml.go
+++ b/internal/db/classify/postgres/ast_dml.go
@@ -98,7 +98,7 @@ func classifyInsert(cs *effects.ClassifiedStatement, s *pg_query.InsertStmt, ses
 	}
 }
 
-func classifyUpdate(cs *effects.ClassifiedStatement, s *pg_query.UpdateStmt, sess SessionState, opts Options) {
+func classifyUpdate(cs *effects.ClassifiedStatement, s *pg_query.UpdateStmt, sess SessionState, opts Options, topLevel bool) {
 	cs.RawVerb = "UPDATE"
 	if s == nil {
 		cs.Effects = []effects.Effect{{Group: effects.GroupUnknown, Resolution: effects.ResolutionUnresolved}}
@@ -110,7 +110,7 @@ func classifyUpdate(cs *effects.ClassifiedStatement, s *pg_query.UpdateStmt, ses
 		Group:      effects.GroupModify,
 		Objects:    []effects.ObjectRef{tgt},
 		Resolution: tgtRes,
-		HasWhere:   s.WhereClause != nil,
+		HasWhere:   topLevel && s.WhereClause != nil,
 	})
 	rels, res := walkRangeRelations(s.FromClause, sess)
 	if len(rels) > 0 {
@@ -125,7 +125,7 @@ func classifyUpdate(cs *effects.ClassifiedStatement, s *pg_query.UpdateStmt, ses
 	}
 }
 
-func classifyDelete(cs *effects.ClassifiedStatement, s *pg_query.DeleteStmt, sess SessionState, opts Options) {
+func classifyDelete(cs *effects.ClassifiedStatement, s *pg_query.DeleteStmt, sess SessionState, opts Options, topLevel bool) {
 	cs.RawVerb = "DELETE"
 	if s == nil {
 		cs.Effects = []effects.Effect{{Group: effects.GroupUnknown, Resolution: effects.ResolutionUnresolved}}
@@ -137,7 +137,7 @@ func classifyDelete(cs *effects.ClassifiedStatement, s *pg_query.DeleteStmt, ses
 		Group:      effects.GroupDelete,
 		Objects:    []effects.ObjectRef{tgt},
 		Resolution: tgtRes,
-		HasWhere:   s.WhereClause != nil,
+		HasWhere:   topLevel && s.WhereClause != nil,
 	})
 	if hasReturningList(s.ReturningList) {
 		cs.Effects = append(cs.Effects, effects.Effect{
@@ -210,7 +210,7 @@ func classifyExplain(cs *effects.ClassifiedStatement, s *pg_query.ExplainStmt, s
 	}
 	if analyze && s.Query != nil {
 		// EXPLAIN ANALYZE <inner> matches inner statement.
-		inner := classifyRawStmt(DialectPostgres, &pg_query.RawStmt{Stmt: s.Query}, sess, opts, cs.ParserBackend)
+		inner := classifyNestedRawStmt(DialectPostgres, &pg_query.RawStmt{Stmt: s.Query}, sess, opts, cs.ParserBackend)
 		cs.RawVerb = "EXPLAIN_ANALYZE"
 		cs.Effects = inner.Effects
 		// Inherit the inner statement's diagnostic Error (if any) so callers
@@ -232,7 +232,7 @@ func classifyPrepare(cs *effects.ClassifiedStatement, s *pg_query.PrepareStmt, s
 		return
 	}
 	cs.PreparedName = s.Name
-	inner := classifyRawStmt(DialectPostgres, &pg_query.RawStmt{Stmt: s.Query}, sess, opts, cs.ParserBackend)
+	inner := classifyNestedRawStmt(DialectPostgres, &pg_query.RawStmt{Stmt: s.Query}, sess, opts, cs.ParserBackend)
 	cs.Effects = inner.Effects
 	if inner.RawVerb != "" {
 		cs.RawVerb = "PREPARE_" + inner.RawVerb
@@ -372,7 +372,7 @@ func appendCTEEffects(cs *effects.ClassifiedStatement, with *pg_query.WithClause
 		if !ok || cn.CommonTableExpr == nil || cn.CommonTableExpr.Ctequery == nil {
 			continue
 		}
-		inner := classifyRawStmt(DialectPostgres, &pg_query.RawStmt{Stmt: cn.CommonTableExpr.Ctequery}, sess, opts, cs.ParserBackend)
+		inner := classifyNestedRawStmt(DialectPostgres, &pg_query.RawStmt{Stmt: cn.CommonTableExpr.Ctequery}, sess, opts, cs.ParserBackend)
 		cs.Effects = append(cs.Effects, inner.Effects...)
 	}
 }

--- a/internal/db/classify/postgres/ast_dml.go
+++ b/internal/db/classify/postgres/ast_dml.go
@@ -110,6 +110,7 @@ func classifyUpdate(cs *effects.ClassifiedStatement, s *pg_query.UpdateStmt, ses
 		Group:      effects.GroupModify,
 		Objects:    []effects.ObjectRef{tgt},
 		Resolution: tgtRes,
+		HasWhere:   s.WhereClause != nil,
 	})
 	rels, res := walkRangeRelations(s.FromClause, sess)
 	if len(rels) > 0 {
@@ -136,6 +137,7 @@ func classifyDelete(cs *effects.ClassifiedStatement, s *pg_query.DeleteStmt, ses
 		Group:      effects.GroupDelete,
 		Objects:    []effects.ObjectRef{tgt},
 		Resolution: tgtRes,
+		HasWhere:   s.WhereClause != nil,
 	})
 	if hasReturningList(s.ReturningList) {
 		cs.Effects = append(cs.Effects, effects.Effect{

--- a/internal/db/classify/postgres/ast_dml_test.go
+++ b/internal/db/classify/postgres/ast_dml_test.go
@@ -105,6 +105,44 @@ func TestClassifyUpdate_Smoke(t *testing.T) {
 	}
 }
 
+func TestClassifyUpdate_HasWhere(t *testing.T) {
+	cs := classifyOne(t, "UPDATE users SET active = false WHERE id = 1", SessionState{})
+	prim, _ := cs.Primary()
+	if prim.Group != effects.GroupModify {
+		t.Fatalf("primary group: got %v want modify", prim.Group)
+	}
+	if !prim.HasWhere {
+		t.Fatalf("UPDATE with WHERE should set HasWhere on primary effect: %+v", prim)
+	}
+}
+
+func TestClassifyUpdate_NoWhere(t *testing.T) {
+	cs := classifyOne(t, "UPDATE users SET active = false", SessionState{})
+	prim, _ := cs.Primary()
+	if prim.Group != effects.GroupModify {
+		t.Fatalf("primary group: got %v want modify", prim.Group)
+	}
+	if prim.HasWhere {
+		t.Fatalf("UPDATE without WHERE should not set HasWhere: %+v", prim)
+	}
+}
+
+func TestClassifyUpdate_HasWhereOnlyOnModifyEffect(t *testing.T) {
+	cs := classifyOne(t, "UPDATE users SET active = false FROM logins WHERE users.id = logins.user_id", SessionState{})
+	if len(cs.Effects) != 2 {
+		t.Fatalf("effects count: got %d want 2: %+v", len(cs.Effects), cs.Effects)
+	}
+	if !cs.Effects[0].HasWhere {
+		t.Fatalf("primary modify effect should have HasWhere: %+v", cs.Effects[0])
+	}
+	if cs.Effects[1].Group != effects.GroupRead {
+		t.Fatalf("secondary effect group = %v want read", cs.Effects[1].Group)
+	}
+	if cs.Effects[1].HasWhere {
+		t.Fatalf("secondary read effect should not inherit HasWhere: %+v", cs.Effects[1])
+	}
+}
+
 func TestClassifyUpdate_FromClauseAddsRead(t *testing.T) {
 	cs := classifyOne(t, "UPDATE users SET active = false FROM logins WHERE users.id = logins.user_id", SessionState{})
 	if len(cs.Effects) != 2 {
@@ -126,6 +164,28 @@ func TestClassifyDelete_Smoke(t *testing.T) {
 	prim, _ := cs.Primary()
 	if prim.Group != effects.GroupDelete {
 		t.Fatalf("primary group: got %v want delete", prim.Group)
+	}
+}
+
+func TestClassifyDelete_HasWhere(t *testing.T) {
+	cs := classifyOne(t, "DELETE FROM users WHERE id = 1", SessionState{})
+	prim, _ := cs.Primary()
+	if prim.Group != effects.GroupDelete {
+		t.Fatalf("primary group: got %v want delete", prim.Group)
+	}
+	if !prim.HasWhere {
+		t.Fatalf("DELETE with WHERE should set HasWhere on primary effect: %+v", prim)
+	}
+}
+
+func TestClassifyDelete_NoWhere(t *testing.T) {
+	cs := classifyOne(t, "DELETE FROM users", SessionState{})
+	prim, _ := cs.Primary()
+	if prim.Group != effects.GroupDelete {
+		t.Fatalf("primary group: got %v want delete", prim.Group)
+	}
+	if prim.HasWhere {
+		t.Fatalf("DELETE without WHERE should not set HasWhere: %+v", prim)
 	}
 }
 

--- a/internal/db/classify/postgres/ast_dml_test.go
+++ b/internal/db/classify/postgres/ast_dml_test.go
@@ -143,6 +143,14 @@ func TestClassifyUpdate_HasWhereOnlyOnModifyEffect(t *testing.T) {
 	}
 }
 
+func TestClassifyUpdate_HasWhereWithCTE(t *testing.T) {
+	cs := classifyOne(t, "WITH r AS (SELECT id FROM logins) UPDATE users SET active = false WHERE id IN (SELECT id FROM r)", SessionState{})
+	e := requireEffectGroup(t, cs, effects.GroupModify)
+	if !e.HasWhere {
+		t.Fatalf("top-level UPDATE with CTE and WHERE should set HasWhere: %+v", e)
+	}
+}
+
 func TestClassifyUpdate_FromClauseAddsRead(t *testing.T) {
 	cs := classifyOne(t, "UPDATE users SET active = false FROM logins WHERE users.id = logins.user_id", SessionState{})
 	if len(cs.Effects) != 2 {
@@ -186,6 +194,30 @@ func TestClassifyDelete_NoWhere(t *testing.T) {
 	}
 	if prim.HasWhere {
 		t.Fatalf("DELETE without WHERE should not set HasWhere: %+v", prim)
+	}
+}
+
+func TestClassifyPrepare_UpdateHasWhereNestedOnly(t *testing.T) {
+	cs := classifyOne(t, "PREPARE q AS UPDATE users SET active = false WHERE id = 1", SessionState{})
+	e := requireEffectGroup(t, cs, effects.GroupModify)
+	if e.HasWhere {
+		t.Fatalf("nested PREPARE UPDATE should not set HasWhere: %+v", e)
+	}
+}
+
+func TestClassifyWithUpdateHasWhereNestedOnly(t *testing.T) {
+	cs := classifyOne(t, "WITH u AS (UPDATE users SET active = false WHERE id = 1 RETURNING id) SELECT * FROM u", SessionState{})
+	e := requireEffectGroup(t, cs, effects.GroupModify)
+	if e.HasWhere {
+		t.Fatalf("data-modifying CTE UPDATE should not set HasWhere: %+v", e)
+	}
+}
+
+func TestClassifyCopyQueryDeleteHasWhereNestedOnly(t *testing.T) {
+	cs := classifyOne(t, "COPY (DELETE FROM users WHERE id = 1 RETURNING *) TO STDOUT", SessionState{})
+	e := requireEffectGroup(t, cs, effects.GroupDelete)
+	if e.HasWhere {
+		t.Fatalf("COPY query DELETE should not set HasWhere: %+v", e)
 	}
 }
 
@@ -384,4 +416,15 @@ func TestClassifyDeallocate_All(t *testing.T) {
 	if got[0].PreparedName != "" {
 		t.Fatalf("PreparedName=%q want \"\" for DEALLOCATE ALL", got[0].PreparedName)
 	}
+}
+
+func requireEffectGroup(t *testing.T, cs effects.ClassifiedStatement, group effects.Group) effects.Effect {
+	t.Helper()
+	for _, e := range cs.Effects {
+		if e.Group == group {
+			return e
+		}
+	}
+	t.Fatalf("missing effect group %v in %+v", group, cs.Effects)
+	return effects.Effect{}
 }

--- a/internal/db/classify/postgres/ast_walk.go
+++ b/internal/db/classify/postgres/ast_walk.go
@@ -23,6 +23,14 @@ import (
 // with the unknown sentinel + a diagnostic Error; Order canonicalises the
 // resulting slice in-place before return.
 func classifyRawStmt(d Dialect, raw *pg_query.RawStmt, sess SessionState, opts Options, backend effects.ParserBackend) effects.ClassifiedStatement {
+	return classifyRawStmtWithContext(d, raw, sess, opts, backend, true)
+}
+
+func classifyNestedRawStmt(d Dialect, raw *pg_query.RawStmt, sess SessionState, opts Options, backend effects.ParserBackend) effects.ClassifiedStatement {
+	return classifyRawStmtWithContext(d, raw, sess, opts, backend, false)
+}
+
+func classifyRawStmtWithContext(d Dialect, raw *pg_query.RawStmt, sess SessionState, opts Options, backend effects.ParserBackend, topLevel bool) effects.ClassifiedStatement {
 	if raw == nil || raw.Stmt == nil {
 		return unknownStatement(backend, "unmapped form: nil RawStmt")
 	}
@@ -36,9 +44,9 @@ func classifyRawStmt(d Dialect, raw *pg_query.RawStmt, sess SessionState, opts O
 	case *pg_query.Node_InsertStmt:
 		classifyInsert(&cs, n.InsertStmt, sess, opts)
 	case *pg_query.Node_UpdateStmt:
-		classifyUpdate(&cs, n.UpdateStmt, sess, opts)
+		classifyUpdate(&cs, n.UpdateStmt, sess, opts, topLevel)
 	case *pg_query.Node_DeleteStmt:
-		classifyDelete(&cs, n.DeleteStmt, sess, opts)
+		classifyDelete(&cs, n.DeleteStmt, sess, opts, topLevel)
 	case *pg_query.Node_MergeStmt:
 		classifyMerge(&cs, n.MergeStmt, sess, opts)
 	case *pg_query.Node_ExplainStmt:

--- a/internal/db/effects/effect.go
+++ b/internal/db/effects/effect.go
@@ -11,6 +11,10 @@ type Effect struct {
 	ResolvedObjects []ResolvedObjectRef `json:"resolved_objects,omitempty"`
 	Resolution      Resolution
 
+	// HasWhere is observed statement-shape metadata. It is set only on
+	// mutation effects whose owning statement has a top-level WHERE clause.
+	HasWhere bool `json:"has_where,omitempty"`
+
 	// FunctionOID is populated for procedural effects with Subtype
 	// SubtypeFunctionCallProtocol (the Postgres 'F' FunctionCall frame) or
 	// SubtypeEscalatedFunctionCall (when classifier escalation produced

--- a/internal/db/effects/statement_test.go
+++ b/internal/db/effects/statement_test.go
@@ -214,3 +214,31 @@ func TestClassifiedStatement_BulkOp_OmitNone(t *testing.T) {
 		t.Fatalf("bulk_op should be omitted for BulkOpNone: %s", bs)
 	}
 }
+
+func TestEffect_HasWhere_JSON(t *testing.T) {
+	in := ClassifiedStatement{
+		Effects: []Effect{{Group: GroupModify, HasWhere: true}},
+		RawVerb: "UPDATE",
+	}
+	bs, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(bs), `"has_where":true`) {
+		t.Fatalf("has_where missing: %s", bs)
+	}
+}
+
+func TestEffect_HasWhere_OmitFalse(t *testing.T) {
+	in := ClassifiedStatement{
+		Effects: []Effect{{Group: GroupModify}},
+		RawVerb: "UPDATE",
+	}
+	bs, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(bs), "has_where") {
+		t.Fatalf("has_where should be omitted when false: %s", bs)
+	}
+}

--- a/internal/db/policy/compile.go
+++ b/internal/db/policy/compile.go
@@ -18,6 +18,7 @@ type compiledStatementRule struct {
 	verb          DecisionVerb
 	groups        map[effects.Group]struct{}
 	subtypes      map[effects.Subtype]struct{} // empty = all subtypes match
+	requireWhere  bool
 	resolution    resolutionMatcher
 	schemas       []glob.Glob // empty = all schemas match
 	objects       []glob.Glob // syntactic object selectors
@@ -116,6 +117,7 @@ func compileStatementRule(r *StatementRule) (*compiledStatementRule, error) {
 		src:           r,
 		groups:        map[effects.Group]struct{}{},
 		subtypes:      map[effects.Subtype]struct{}{},
+		requireWhere:  r.RequireWhere,
 		serviceFilter: serviceFilter{service: ServiceID(r.DBService), family: r.DBFamily, dialect: r.DBDialect},
 	}
 	switch r.Decision {

--- a/internal/db/policy/evaluate.go
+++ b/internal/db/policy/evaluate.go
@@ -515,6 +515,9 @@ func ruleMatchesEffectMeta(r *compiledStatementRule, e effects.Effect) bool {
 	if _, ok := r.groups[e.Group]; !ok {
 		return false
 	}
+	if r.requireWhere && !e.HasWhere {
+		return false
+	}
 	if len(r.subtypes) > 0 {
 		if _, ok := r.subtypes[e.Subtype]; !ok {
 			return false

--- a/internal/db/policy/evaluate_require_where_test.go
+++ b/internal/db/policy/evaluate_require_where_test.go
@@ -1,0 +1,106 @@
+package policy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/db/effects"
+	rootpolicy "github.com/agentsh/agentsh/internal/policy"
+)
+
+func mutationStmt(group effects.Group, hasWhere bool) effects.ClassifiedStatement {
+	return effects.ClassifiedStatement{
+		RawVerb: "UPDATE",
+		Effects: []effects.Effect{{
+			Group:      group,
+			Objects:    []effects.ObjectRef{{Kind: effects.ObjectTable, Schema: "public", Name: "users"}},
+			Resolution: effects.ResolutionQualified,
+			HasWhere:   hasWhere,
+		}},
+	}
+}
+
+func TestDecode_RequireWhereAccepted(t *testing.T) {
+	p, err := rootpolicy.LoadFromBytes([]byte(`version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - name: guarded
+    db_service: appdb
+    operations: [modify, delete]
+    objects: [users]
+    require_where: true
+    decision: allow
+`))
+	if err != nil {
+		t.Fatalf("LoadFromBytes: %v", err)
+	}
+	rs, _, err := Decode(p)
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	rules := rs.AllStatementRules()
+	if len(rules) != 1 || !rules[0].RequireWhere {
+		t.Fatalf("RequireWhere not decoded: %+v", rules)
+	}
+}
+
+func TestEvaluate_RequireWhereAllowsMutationWithWhere(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - name: guarded
+    db_service: appdb
+    operations: [modify]
+    objects: [users]
+    require_where: true
+    decision: allow
+`)
+	d := Evaluate(mutationStmt(effects.GroupModify, true), rs, "appdb")
+	if d.Verb != VerbAllow || d.RuleName != "guarded" {
+		t.Fatalf("decision = %+v, want allow by guarded", d)
+	}
+}
+
+func TestEvaluate_RequireWhereDeniesMutationWithoutWhere(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - name: guarded
+    db_service: appdb
+    operations: [modify]
+    objects: [users]
+    require_where: true
+    decision: allow
+`)
+	d := Evaluate(mutationStmt(effects.GroupModify, false), rs, "appdb")
+	if d.Verb != VerbDeny || d.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny", d)
+	}
+	if !strings.Contains(d.Reason, "no rule covers") {
+		t.Fatalf("Reason = %q, want coverage failure", d.Reason)
+	}
+}
+
+func TestEvaluate_RequireWhereDoesNotBlockRuleWithoutGuard(t *testing.T) {
+	rs := loadRules(t, `version: 1
+name: t
+db_services:
+  appdb: {family: postgres, dialect: postgres, upstream: x:1, tls_mode: terminate_reissue}
+database_rules:
+  - name: unguarded
+    db_service: appdb
+    operations: [delete]
+    objects: [users]
+    decision: allow
+`)
+	d := Evaluate(mutationStmt(effects.GroupDelete, false), rs, "appdb")
+	if d.Verb != VerbAllow || d.RuleName != "unguarded" {
+		t.Fatalf("decision = %+v, want allow by unguarded", d)
+	}
+}

--- a/internal/db/policy/types.go
+++ b/internal/db/policy/types.go
@@ -118,6 +118,7 @@ type StatementRule struct {
 	Operations                  []string        `yaml:"operations"`
 	Subtypes                    []string        `yaml:"subtypes,omitempty"`
 	MatchObjectResolution       string          `yaml:"match_object_resolution,omitempty"`
+	RequireWhere                bool            `yaml:"require_where,omitempty"`
 	Decision                    string          `yaml:"decision"`
 	Message                     string          `yaml:"message,omitempty"`
 	Timeout                     time.Duration   `yaml:"timeout,omitempty"`

--- a/internal/db/policy/validate.go
+++ b/internal/db/policy/validate.go
@@ -91,6 +91,9 @@ func validateStatementRule(r *StatementRule, svcs map[ServiceID]*DBService) ([]e
 			errs = append(errs, fmt.Errorf("rule_unknown_operation: database_rules[%q]: unknown operations token %q", r.Name, op))
 		}
 	}
+	if r.RequireWhere && !groupsOnlyModifyDelete(groups) {
+		errs = append(errs, fmt.Errorf("rule_require_where_invalid_operation: database_rules[%q]: require_where is supported only for modify/delete operations", r.Name))
+	}
 	for _, st := range r.Subtypes {
 		if _, ok := effects.ParseSubtype(st); !ok {
 			errs = append(errs, fmt.Errorf("rule_unknown_subtype: database_rules[%q]: unknown subtypes token %q", r.Name, st))
@@ -321,6 +324,18 @@ func groupsOnlyRead(groups map[effects.Group]struct{}) bool {
 	}
 	_, ok := groups[effects.GroupRead]
 	return ok
+}
+
+func groupsOnlyModifyDelete(groups map[effects.Group]struct{}) bool {
+	if len(groups) == 0 {
+		return false
+	}
+	for g := range groups {
+		if g != effects.GroupModify && g != effects.GroupDelete {
+			return false
+		}
+	}
+	return true
 }
 
 func allGroupsObjectless(groups map[effects.Group]struct{}) bool {

--- a/internal/db/policy/validate_test.go
+++ b/internal/db/policy/validate_test.go
@@ -819,3 +819,65 @@ database_rules:
 		t.Fatalf("unexpected err: %v", err)
 	}
 }
+
+func TestValidate_RequireWhereAllowsModifyAndDeleteOnly(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	cases := []struct {
+		name string
+		ops  []string
+	}{
+		{name: "modify", ops: []string{"modify"}},
+		{name: "delete", ops: []string{"delete"}},
+		{name: "modify_delete", ops: []string{"modify", "delete"}},
+		{name: "UPDATE_alias", ops: []string{"UPDATE"}},
+		{name: "DELETE_alias", ops: []string{"DELETE"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt := []*StatementRule{{
+				Name:         "guarded",
+				DBService:    "appdb",
+				Operations:   tc.ops,
+				Decision:     "allow",
+				RequireWhere: true,
+			}}
+			if _, err := helperValidate(t, svcs, stmt, nil); err != nil {
+				t.Fatalf("validate: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidate_RequireWhereRejectsUnsupportedOperations(t *testing.T) {
+	svcs := map[ServiceID]*DBService{
+		"appdb": {Name: "appdb", Family: "postgres", Dialect: "postgres", Upstream: "x:1", TLSMode: "terminate_reissue"},
+	}
+	cases := []struct {
+		name string
+		ops  []string
+	}{
+		{name: "read", ops: []string{"read"}},
+		{name: "star", ops: []string{"*"}},
+		{name: "read_delete", ops: []string{"read", "delete"}},
+		{name: "MUTATE_includes_write", ops: []string{"MUTATE"}},
+		{name: "transaction", ops: []string{"transaction"}},
+		{name: "schema_destroy", ops: []string{"schema_destroy"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stmt := []*StatementRule{{
+				Name:         "guarded",
+				DBService:    "appdb",
+				Operations:   tc.ops,
+				Decision:     "allow",
+				RequireWhere: true,
+			}}
+			_, err := helperValidate(t, svcs, stmt, nil)
+			if err == nil || !strings.Contains(err.Error(), "rule_require_where_invalid_operation") {
+				t.Fatalf("want rule_require_where_invalid_operation, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/db/proxy/postgres/simplequery_test.go
+++ b/internal/db/proxy/postgres/simplequery_test.go
@@ -520,6 +520,79 @@ database_rules:
 `)
 }
 
+func requireWhereRuleSet(t *testing.T) *policy.RuleSet {
+	t.Helper()
+	return loadRuleSet(t, `version: 1
+name: test
+db_services:
+  test:
+    family: postgres
+    dialect: postgres
+    upstream: 127.0.0.1:5432
+    tls_mode: terminate_reissue
+database_rules:
+  - name: allow-where-updates
+    db_service: test
+    operations: [modify]
+    objects: [users]
+    require_where: true
+    decision: allow
+`)
+}
+
+func TestHandleQuery_RequireWhere_DeniesNoWhereBeforeForward(t *testing.T) {
+	pc, clientFE, sink := newSimpleQueryFixture(t)
+	pc.state.smState.LastUpstreamRFQ = 'I'
+	pc.srv.SetPolicy(requireWhereRuleSet(t))
+
+	upClient, upServer := net.Pipe()
+	t.Cleanup(func() { _ = upClient.Close(); _ = upServer.Close() })
+	pc.state.upstream = upServer
+	pc.state.upstreamFE = pgproto3.NewFrontend(upServer, upServer)
+	upBackend := pgproto3.NewBackend(upClient, upClient)
+	drainClientBackendMessages(clientFE)
+
+	upRecv := make(chan pgproto3.FrontendMessage, 1)
+	go func() {
+		msg, err := upBackend.Receive()
+		if err == nil {
+			upRecv <- msg
+		}
+	}()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- pc.handleQuery(context.Background(), &pgproto3.Query{String: "UPDATE users SET active = false"})
+	}()
+
+	select {
+	case msg := <-upRecv:
+		t.Fatalf("upstream received no-WHERE mutation: %T", msg)
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("handleQuery returned transport error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("handleQuery did not return")
+	}
+
+	var evs []events.DBEvent
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		evs = sink.DrainStatements()
+		if len(evs) > 0 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(evs) != 1 {
+		t.Fatalf("statement events = %+v", evs)
+	}
+	if evs[0].Decision.Verb != "deny" || evs[0].Decision.RuleName != "" {
+		t.Fatalf("decision = %+v, want implicit deny", evs[0].Decision)
+	}
+}
+
 func TestHandleQuery_DenyPath_PreTx(t *testing.T) {
 	pc, clientFE, sink, _ := allowPathFixture(t)
 	pc.state.smState.LastUpstreamRFQ = 'I'

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,10 +6,10 @@ AI-assistant skills for creating and editing AgentSH security policies. Works in
 
 | Skill | Description |
 |-------|-------------|
-| **agentsh-policy-create** | Create new policies from built-in templates (default, dev-safe, ci-strict, agent-sandbox) |
-| **agentsh-policy-edit** | Add, remove, or update rules in existing policies with first-match-wins ordering awareness |
+| **agentsh-policy-create** | Create new policies from built-in templates, including agent sandbox, CI, HTTP service, and Postgres-family DB policy use cases |
+| **agentsh-policy-edit** | Add, remove, or update rules in existing policies with rule-ordering and DB coverage awareness |
 
-Both skills reference a shared schema in `agentsh-policy-shared/schema-reference.md` covering all 17 rule categories.
+Both skills reference a shared schema in `agentsh-policy-shared/schema-reference.md` covering core policy rule categories plus declared HTTP services, secret providers, and Postgres-family database policy blocks.
 
 ## Installation
 

--- a/skills/agentsh-policy-create/SKILL.md
+++ b/skills/agentsh-policy-create/SKILL.md
@@ -82,6 +82,7 @@ Create new AgentSH security policies from built-in templates, customized to the 
 - Do not invent runtime support for non-Postgres databases. Current DB enforcement is Postgres-family only.
 - For `http_services`, prefer path/method rules over broad network allows when the user needs audited API surface control.
 - For `database_rules`, remember DB evaluation is not simple first-match-wins: any matching deny wins, non-deny rules must cover every object slot, and uncovered objects fail closed.
+- For Postgres `UPDATE`/`DELETE` access to sensitive relations, ask whether accidental full-table mutation should be blocked. Use `require_where: true` only on rules whose `operations` expand exclusively to `modify` and/or `delete`; explain that it is syntactic and `WHERE true` still satisfies it.
 - For DB `redirect`, only author safe read-only Postgres relation replacement: one canonical source in `relations`, `match_object_resolution: catalog_resolved`, and `redirect.relation`.
 
 ## Schema Reference

--- a/skills/agentsh-policy-create/SKILL.md
+++ b/skills/agentsh-policy-create/SKILL.md
@@ -82,7 +82,7 @@ Create new AgentSH security policies from built-in templates, customized to the 
 - Do not invent runtime support for non-Postgres databases. Current DB enforcement is Postgres-family only.
 - For `http_services`, prefer path/method rules over broad network allows when the user needs audited API surface control.
 - For `database_rules`, remember DB evaluation is not simple first-match-wins: any matching deny wins, non-deny rules must cover every object slot, and uncovered objects fail closed.
-- For Postgres `UPDATE`/`DELETE` access to sensitive relations, ask whether accidental full-table mutation should be blocked. Use `require_where: true` only on rules whose `operations` expand exclusively to `modify` and/or `delete`; explain that it is syntactic and `WHERE true` still satisfies it.
+- For Postgres `UPDATE`/`DELETE` access to sensitive relations, ask whether accidental full-table mutation should be blocked. Use `require_where: true` only on rules whose `operations` expand exclusively to `modify` and/or `delete`; explain that it is syntactic, `WHERE true` still satisfies it, and another unguarded non-deny rule can still cover the same effect.
 - For DB `redirect`, only author safe read-only Postgres relation replacement: one canonical source in `relations`, `match_object_resolution: catalog_resolved`, and `redirect.relation`.
 
 ## Schema Reference

--- a/skills/agentsh-policy-create/SKILL.md
+++ b/skills/agentsh-policy-create/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: agentsh-policy-create
-description: Use when creating a new AgentSH security policy, making a policy for an agent sandbox, CI pipeline, or development environment, or asking for a new policy YAML file
+description: Use when creating a new AgentSH security policy, including agent sandboxes, CI pipelines, development environments, HTTP service gateways, or Postgres-family database access policies
 ---
 
 # Create AgentSH Policy
 
 ## Overview
 
-Create new AgentSH security policies from built-in templates, customized to the user's use case. Produces valid YAML policy files with correct structure, evaluation semantics, and defensive defaults.
+Create new AgentSH security policies from built-in templates, customized to the user's use case. Produces valid YAML policy files with correct structure, evaluation semantics, and defensive defaults for file, network, command, HTTP service, and Postgres-family database controls.
 
 ## When to Use
 
 - User asks to create/make/generate a new policy
 - User describes a use case that needs a policy ("policy for my CI pipeline")
 - User wants to set up AgentSH for the first time
+- User wants controlled access to a declared HTTP API or Postgres-family database
 - NOT for editing existing policies (use agentsh-policy-edit)
 
 ## Flow
@@ -33,6 +34,8 @@ Create new AgentSH security policies from built-in templates, customized to the 
    | Local development | `dev-safe` |
    | Strict agent sandbox | `agent-sandbox` |
    | Observation/profiling | `agent-observe` |
+   | Declared HTTP API gateway | Start from `default` |
+   | Postgres-family database access | Start from `default` |
    | Custom / other | Start from `default` |
 
 3. **Select template**
@@ -45,6 +48,15 @@ Create new AgentSH security policies from built-in templates, customized to the 
    - "Which domains does your app need to reach?" → add network rules
    - "Any paths outside the workspace it needs?" → add file rules
    - "Any commands to block or require approval?" → add command rules
+   - "Should any HTTP APIs be exposed through AgentSH?" → add `http_services` plus `providers` when credential substitution is needed
+   - "Should any Postgres-family databases be mediated?" → add `db_services`, `database_connection_rules`, `database_rules`, and `policies.db`
+
+   For database policies, ask for:
+   - service name, dialect (`postgres`, `aurora_postgres`, `redshift`, `cockroachdb`), upstream `host:port`, and `tls_mode`
+   - connection constraints: DB user, database name, application name, replication/cancel handling
+   - statement intent: read/write/admin operations, schemas/objects, catalog selectors (`relations`, `functions`) if known
+   - redaction preference: `policies.db.log_statements`, `approval_statement_preview`, and `approval_statement_preview_chars`
+   - unavoidability posture: `off`, `observe`, or `enforce`
 
 5. **Name & write**
    - Ask for a policy name
@@ -67,6 +79,10 @@ Create new AgentSH security policies from built-in templates, customized to the 
 - Use descriptive rule names in `verb-noun` format (e.g., `allow-npm`, `deny-ssh-keys`)
 - Include section comment headers matching built-in policy style
 - First match wins — place specific rules before general ones
+- Do not invent runtime support for non-Postgres databases. Current DB enforcement is Postgres-family only.
+- For `http_services`, prefer path/method rules over broad network allows when the user needs audited API surface control.
+- For `database_rules`, remember DB evaluation is not simple first-match-wins: any matching deny wins, non-deny rules must cover every object slot, and uncovered objects fail closed.
+- For DB `redirect`, only author safe read-only Postgres relation replacement: one canonical source in `relations`, `match_object_resolution: catalog_resolved`, and `redirect.relation`.
 
 ## Schema Reference
 

--- a/skills/agentsh-policy-edit/SKILL.md
+++ b/skills/agentsh-policy-edit/SKILL.md
@@ -74,7 +74,7 @@ DB policy evaluation is different from file/network/command ordering:
 - `passthrough` DB services can use connection rules only; statement rules are unavailable because AgentSH cannot inspect SQL.
 - `decision: redirect` is statement-level only. It requires read-only operations, exactly one canonical `relations` source selector, `match_object_resolution: catalog_resolved`, and `redirect.relation` as a canonical `schema.name` target.
 - `policies.db.unavoidability: enforce` should be paired with declared `db_services`; it blocks direct DB egress from governed processes and routes through AgentSH-generated DB proxy redirects.
-- When editing mutation allow/approve/audit rules, preserve or add `require_where: true` for sensitive Postgres `modify`/`delete` rules when the operator wants no-WHERE mutations to fail closed. Do not add it to `MUTATE`, `*`, `read`, DDL, session, transaction, or procedural rules.
+- When editing mutation allow/approve/audit rules, preserve or add `require_where: true` for sensitive Postgres `modify`/`delete` rules when the operator wants no-WHERE mutations to fail closed. Do not add it to `MUTATE`, `*`, `read`, DDL, session, transaction, or procedural rules. Check for overlapping unguarded non-deny rules, because `require_where` only constrains the rule it appears on.
 
 When editing DB rules, prefer adding narrow denies for risky operations and explicit non-deny coverage for intended objects. Avoid broad `allow` rules across all services unless the user explicitly asks for that posture.
 

--- a/skills/agentsh-policy-edit/SKILL.md
+++ b/skills/agentsh-policy-edit/SKILL.md
@@ -74,6 +74,7 @@ DB policy evaluation is different from file/network/command ordering:
 - `passthrough` DB services can use connection rules only; statement rules are unavailable because AgentSH cannot inspect SQL.
 - `decision: redirect` is statement-level only. It requires read-only operations, exactly one canonical `relations` source selector, `match_object_resolution: catalog_resolved`, and `redirect.relation` as a canonical `schema.name` target.
 - `policies.db.unavoidability: enforce` should be paired with declared `db_services`; it blocks direct DB egress from governed processes and routes through AgentSH-generated DB proxy redirects.
+- When editing mutation allow/approve/audit rules, preserve or add `require_where: true` for sensitive Postgres `modify`/`delete` rules when the operator wants no-WHERE mutations to fail closed. Do not add it to `MUTATE`, `*`, `read`, DDL, session, transaction, or procedural rules.
 
 When editing DB rules, prefer adding narrow denies for risky operations and explicit non-deny coverage for intended objects. Avoid broad `allow` rules across all services unless the user explicitly asks for that posture.
 

--- a/skills/agentsh-policy-edit/SKILL.md
+++ b/skills/agentsh-policy-edit/SKILL.md
@@ -1,15 +1,17 @@
 ---
 name: agentsh-policy-edit
-description: Use when adding, removing, or updating rules in an existing AgentSH policy, modifying security permissions, changing resource limits, or editing policy YAML files
+description: Use when adding, removing, or updating rules in an existing AgentSH policy, modifying security permissions, HTTP service declarations, Postgres-family database rules, resource limits, or policy YAML files
 ---
 
 # Edit AgentSH Policy
 
 ## Overview
-Make targeted edits to existing AgentSH security policies — add, remove, or update rules. Understands first-match-wins evaluation semantics and correct insertion ordering.
+Make targeted edits to existing AgentSH security policies — add, remove, or update rules and declarations. Understands first-match-wins policy categories plus the separate Postgres-family database rule semantics.
 
 ## When to Use
 - User asks to add/remove/update a policy rule ("allow stripe.com", "block file deletes")
+- User asks to change declared HTTP API access (`http_services`, `providers`)
+- User asks to change Postgres-family DB access (`db_services`, `database_rules`, `database_connection_rules`, `policies.db`)
 - User wants to change resource limits or audit settings
 - User mentions modifying an existing policy
 - NOT for creating new policies from scratch (use agentsh-policy-create)
@@ -25,7 +27,7 @@ Make targeted edits to existing AgentSH security policies — add, remove, or up
 
 2. **Understand the intent**
    Map the user's request to:
-   - **Rule category** — file_rules, network_rules, command_rules, unix_socket_rules, registry_rules, signal_rules, dns_redirects, connect_redirects, resource_limits, env_policy, audit, mcp_rules, package_rules, process_contexts, process_identities, env_inject, transparent_commands
+   - **Rule category** — file_rules, network_rules, command_rules, unix_socket_rules, registry_rules, signal_rules, dns_redirects, connect_redirects, http_services, providers, db_services, database_rules, database_connection_rules, policies.db, resource_limits, env_policy, audit, mcp_rules, package_rules, process_contexts, process_identities, env_inject, transparent_commands
    - **Operation** — add a new rule, remove an existing rule, or modify an existing rule
    - **Insertion position** — where in the rule order (for new rules)
 
@@ -35,6 +37,7 @@ Make targeted edits to existing AgentSH security policies — add, remove, or up
    - Place allow rules before the default-deny catch-all at the end
    - Place more specific rules before less specific ones
    - When in doubt: deny rules go before the first non-deny rule in that category; allow rules go before the default-deny
+   - Do not apply this first-match-wins shortcut to `database_rules` or `database_connection_rules`; see DB rules below.
 
 4. **Make the edit**
    Use the Edit tool:
@@ -62,6 +65,27 @@ Make targeted edits to existing AgentSH security policies — add, remove, or up
 | Uncertain (deny) | Before the first non-deny rule in that category |
 | Uncertain (allow) | Immediately before the default-deny rule for that category |
 
+## Database Rules
+
+DB policy evaluation is different from file/network/command ordering:
+
+- `database_rules`: any matching deny wins, regardless of order. Non-deny decisions (`allow`, `audit`, `redirect`, `approve`) must cover every object slot in the effect; uncovered objects become implicit deny. Rule order only breaks ties for reporting the primary contributing rule.
+- `database_connection_rules`: all matching rules are considered and the most restrictive verb wins (`deny > approve > audit > allow`).
+- `passthrough` DB services can use connection rules only; statement rules are unavailable because AgentSH cannot inspect SQL.
+- `decision: redirect` is statement-level only. It requires read-only operations, exactly one canonical `relations` source selector, `match_object_resolution: catalog_resolved`, and `redirect.relation` as a canonical `schema.name` target.
+- `policies.db.unavoidability: enforce` should be paired with declared `db_services`; it blocks direct DB egress from governed processes and routes through AgentSH-generated DB proxy redirects.
+
+When editing DB rules, prefer adding narrow denies for risky operations and explicit non-deny coverage for intended objects. Avoid broad `allow` rules across all services unless the user explicitly asks for that posture.
+
+## HTTP Services
+
+Use `http_services` when the user needs method/path-level API control or credential substitution for a declared upstream. Keep ordinary `network_rules` for simple host/port access.
+
+- `http_services[].upstream` must be HTTPS in normal policy files.
+- If `secret` is present, ensure a matching top-level `providers` entry exists and `inject.header.template` contains `{{secret}}`.
+- `expose_as` must be a valid environment variable name and must not collide with LLM proxy env vars.
+- `services:` is obsolete; use `http_services:`.
+
 ## Guardrails
 
 - **Minimal edits only** — only touch the rules the user asked about
@@ -70,6 +94,7 @@ Make targeted edits to existing AgentSH security policies — add, remove, or up
 - **Name new rules** in `verb-noun` format matching the existing policy style
 - **Warn about shadowing** — if a new rule would be unreachable because an earlier rule matches the same pattern, warn the user
 - **Warn about removal side-effects** — removing a deny rule may expose an allow rule that was previously unreachable; removing an allow rule may expose a deny. Explain the ordering impact when summarizing.
+- **Warn about DB coverage gaps** — a DB `allow`, `audit`, `redirect`, or `approve` that covers only one relation/function does not cover other objects touched by the same SQL statement.
 
 ## Schema Reference
 

--- a/skills/agentsh-policy-shared/schema-reference.md
+++ b/skills/agentsh-policy-shared/schema-reference.md
@@ -322,6 +322,7 @@ Statement-level database rules apply after the Postgres proxy classifies a state
 | relations | string[] | no | Catalog-resolved relation selectors, formatted as `schema.name` |
 | functions | string[] | no | Catalog-resolved function selectors, formatted as `schema.name(identity_args)`; `schema.name(*)` matches overloads |
 | match_object_resolution | string | no | Resolution tag such as `catalog_resolved`, `qualified_syntactic`, `unqualified_syntactic`, `catalog_unresolved`, or `*` |
+| require_where | bool | no | For Postgres `modify`/`delete` rules only: require the top-level `UPDATE` or `DELETE` statement to include a syntactic `WHERE` clause |
 | decision | string | yes | `allow`, `deny`, `approve`, `audit`, or statement-level `redirect` |
 | message | string | no | Template shown on deny/approve paths |
 | timeout | duration | no | Approval timeout |
@@ -332,6 +333,8 @@ Statement-level database rules apply after the Postgres proxy classifies a state
 Operation groups are lowercase canonical names: `read`, `write`, `modify`, `delete`, `bulk_load`, `bulk_export`, `schema_create`, `schema_alter`, `schema_destroy`, `privilege`, `transaction`, `session`, `maintenance`, `lock`, `notify`, `procedural`, `unsafe_io`, `unknown`.
 
 Uppercase aliases are also supported: `READ`, `INSERT`, `UPDATE`, `DELETE`, `REMOVE`, `CREATE`, `DROP`, `ALTER`, `TRUNCATE`, `EXPORT`, `LOAD`, `MUTATE`, `SCHEMA`, `MAINTENANCE`, `LOCK_TABLES`, `LISTEN_NOTIFY`, `DANGEROUS`. `*` expands to all known groups except `unknown`.
+
+`require_where: true` is valid only when `operations` expands exclusively to `modify` and/or `delete`; `MUTATE` is rejected because it also includes `write`. The guard is syntactic only, so `WHERE true` satisfies it.
 
 `decision: redirect` is Postgres-only and supports safe read-only relation replacement. It requires `operations` that expand only to read, exactly one canonical `relations` source selector, `match_object_resolution: catalog_resolved`, an eligible terminate-mode Postgres service, and `redirect.relation`.
 

--- a/skills/agentsh-policy-shared/schema-reference.md
+++ b/skills/agentsh-policy-shared/schema-reference.md
@@ -16,6 +16,7 @@ name: "policy-name"           # Required. Alphanumeric, hyphens, underscores.
 description: |                # Required. Multi-line description.
   What this policy does.
 
+metadata: []                  # Optional non-enforcing rule metadata
 file_rules: []                # File operation rules
 network_rules: []             # Network connection rules
 command_rules: []             # Command execution rules
@@ -24,6 +25,12 @@ registry_rules: []            # Windows registry rules
 signal_rules: []              # Signal sending rules
 dns_redirects: []             # DNS redirect rules
 connect_redirects: []         # TCP connect redirect rules
+providers: {}                 # Secret provider declarations for http_services
+http_services: []             # Declared HTTP API gateway services
+db_services: {}               # Declared database upstreams (Postgres-family only today)
+database_rules: []            # Database statement rules
+database_connection_rules: [] # Database connection/cancel/replication rules
+policies: {}                  # Opaque policy sub-blocks, currently policies.db
 resource_limits: {}           # Resource limits
 env_policy: {}                # Environment variable policy
 audit: {}                     # Audit settings
@@ -38,6 +45,18 @@ transparent_commands: {}      # Override transparent command set
 ---
 
 ## Rule Types
+
+### metadata[]
+
+Metadata is non-enforcing. AgentSH-generated policy bundles use it to correlate generic rule names back to higher-level sources such as DB unavoidability.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| rule_name | string | yes | Name of the rule this metadata describes |
+| source | string | yes | Metadata producer, e.g. `db_unavoidability` |
+| db_service | string | no | Related DB service name |
+| bypass_mode | string | no | Bypass class such as `tcp_direct`, `unix_socket`, `dns_alias`, `port_forward_tool`, `custom_tunnel` |
+| destination | string | no | Related destination tuple or local socket class |
 
 ### file_rules[]
 
@@ -179,11 +198,14 @@ Default (if omitted): all depths (`min_depth: 0`, `max_depth: -1`).
 |-------|------|----------|-------------|
 | name | string | yes | Rule identifier |
 | match | string | yes | Regex pattern for `host:port` |
-| redirect_to | string | yes | New `host:port` destination |
+| redirect_to | string | conditional | New TCP `host:port` destination |
+| redirect_to_unix | string | conditional | Unix socket path destination |
 | tls | object | no | `{mode, sni?}`. Modes: `passthrough`, `rewrite_sni` |
 | visibility | string | no | `silent`, `audit_only`, `warn` |
 | message | string | no | Human-readable message |
 | on_failure | string | no | `fail_closed`, `fail_open`, `retry_original` |
+
+Exactly one of `redirect_to` or `redirect_to_unix` is required. DB unavoidability bundles use `redirect_to_unix` to route direct Postgres TCP attempts through the per-session DB proxy socket.
 
 **connect_redirects[].tls object:**
 
@@ -191,6 +213,152 @@ Default (if omitted): all depths (`min_depth: 0`, `max_depth: -1`).
 |-------|------|-------------|
 | mode | string | `passthrough` or `rewrite_sni` |
 | sni | string | Required when mode is `rewrite_sni` |
+
+### providers{}
+
+`providers` is a map keyed by provider name. Each entry must include `type`; provider-specific fields are decoded by the secrets subsystem. `http_services[].secret.ref` schemes must match one declared provider type.
+
+Supported provider types: `keyring`, `vault`, `aws-sm`, `gcp-sm`, `azure-kv`, `op`.
+
+Common reference URI examples:
+
+```yaml
+providers:
+  local_keyring:
+    type: keyring
+  corp_vault:
+    type: vault
+    address: https://vault.internal
+    token_ref: keyring://agentsh/vault_token
+```
+
+### http_services[]
+
+Declared HTTP services expose selected upstream API paths to child processes through the AgentSH proxy as `/svc/<name>/...`. Use this when the policy needs method/path control, approval gates, credential substitution, or audited HTTP service traffic. Use `network_rules` instead for simple host/port access.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | URL-safe service name (`[A-Za-z0-9._-]+`) |
+| upstream | string | yes | HTTPS base URL |
+| expose_as | string | no | Env var name for service URL. Default is `<NAME>_API_URL` |
+| aliases | string[] | no | Extra upstream host aliases for direct-access blocking |
+| allow_direct | bool | no | Escape hatch; default false blocks direct upstream access |
+| default | string | no | `allow` or `deny`; default is fail-closed when rules exist |
+| rules | object[] | no | Method/path rules, evaluated first-match-wins |
+| secret | object | no | Credential substitution config `{ref, format}` |
+| inject | object | no | Request injection config, currently `{header: {name, template}}` |
+| scrub_response | bool | no | Whether to scrub fake/real credentials from responses |
+
+**http_services[].rules[]:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| methods | string[] | no | HTTP methods; empty or `*` means any |
+| paths | string[] | yes | `/`-separated glob patterns |
+| decision | string | yes | `allow`, `deny`, `approve`, `audit` |
+| message | string | no | Human-readable message |
+| timeout | duration | no | Approval timeout |
+
+**Credential substitution:**
+
+```yaml
+http_services:
+  - name: github
+    upstream: https://api.github.com
+    secret:
+      ref: vault://kv/data/github#token
+      format: ghp_{rand:36}
+    inject:
+      header:
+        name: Authorization
+        template: Bearer {{secret}}
+    rules:
+      - name: allow-read-issues
+        methods: [GET]
+        paths: ["/repos/*/*/issues*"]
+        decision: allow
+```
+
+If `secret` is present, `providers` must declare a matching provider type. `inject.header.template` must contain `{{secret}}`. The old top-level `services:` key is invalid; use `http_services:`.
+
+### db_services{} (Postgres-family only)
+
+`db_services` is a map keyed by service name. Current runtime database support is Postgres-family only: `family` must be `postgres`; supported dialect values are `postgres`, `aurora_postgres`, `redshift`, and `cockroachdb`. MySQL, MongoDB, Snowflake, BigQuery, Databricks, ClickHouse, MSSQL, Cassandra, Redis, and Oracle are not current runtime targets.
+
+```yaml
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: pg.internal:5432
+    tls_mode: terminate_reissue
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| family | string | yes | Must be `postgres` today |
+| dialect | string | yes | `postgres`, `aurora_postgres`, `redshift`, or `cockroachdb` |
+| upstream | string | yes | Upstream `host:port` |
+| tls_mode | string | yes | `terminate_reissue`, `terminate_plaintext_upstream`, or `passthrough` |
+| trusted_network | bool | no | Required for unsafe plaintext upstreams |
+| allow_function_call_protocol | bool | no | Opt into PostgreSQL FunctionCall protocol forwarding; default denies it |
+| allow_gss_encryption | bool | no | Opt into GSS encryption passthrough with degraded statement visibility |
+
+### database_rules[]
+
+Statement-level database rules apply after the Postgres proxy classifies a statement into effects. Strict coverage applies: every object slot in an effect must be covered by a non-deny rule, and any matching deny wins.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| db_service | string | no | Match one `db_services` entry |
+| db_family | string | no | Currently `postgres` |
+| db_dialect | string | no | Match one Postgres-family dialect |
+| operations | string[] | yes | Operation groups or aliases, e.g. `read`, `write`, `modify`, `delete`, `session`, `transaction`, `bulk_export`, `unknown`, `READ`, `MUTATE`, `*` |
+| subtypes | string[] | no | Operation subtype filters |
+| objects | string[] | no | Syntactic object-name globs |
+| schemas | string[] | no | Schema-name globs |
+| relations | string[] | no | Catalog-resolved relation selectors, formatted as `schema.name` |
+| functions | string[] | no | Catalog-resolved function selectors, formatted as `schema.name(identity_args)`; `schema.name(*)` matches overloads |
+| match_object_resolution | string | no | Resolution tag such as `catalog_resolved`, `qualified_syntactic`, `unqualified_syntactic`, `catalog_unresolved`, or `*` |
+| decision | string | yes | `allow`, `deny`, `approve`, `audit`, or statement-level `redirect` |
+| message | string | no | Template shown on deny/approve paths |
+| timeout | duration | no | Approval timeout |
+| deny_mode_in_tx | string | no | For deny rules in transactions: `terminate` or `rollback_then_continue` |
+| acknowledge_audit_on_dangerous | bool | no | Required to silence warnings for `audit` on high-risk operations |
+| redirect | object | no | Required for `decision: redirect`; see below |
+
+Operation groups are lowercase canonical names: `read`, `write`, `modify`, `delete`, `bulk_load`, `bulk_export`, `schema_create`, `schema_alter`, `schema_destroy`, `privilege`, `transaction`, `session`, `maintenance`, `lock`, `notify`, `procedural`, `unsafe_io`, `unknown`.
+
+Uppercase aliases are also supported: `READ`, `INSERT`, `UPDATE`, `DELETE`, `REMOVE`, `CREATE`, `DROP`, `ALTER`, `TRUNCATE`, `EXPORT`, `LOAD`, `MUTATE`, `SCHEMA`, `MAINTENANCE`, `LOCK_TABLES`, `LISTEN_NOTIFY`, `DANGEROUS`. `*` expands to all known groups except `unknown`.
+
+`decision: redirect` is Postgres-only and supports safe read-only relation replacement. It requires `operations` that expand only to read, exactly one canonical `relations` source selector, `match_object_resolution: catalog_resolved`, an eligible terminate-mode Postgres service, and `redirect.relation`.
+
+**database_rules[].redirect object:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| relation | string | Canonical target relation formatted as `schema.name` |
+
+### database_connection_rules[]
+
+Connection-level database rules apply to Postgres StartupMessage, CancelRequest, and replication-request handling.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| name | string | yes | Rule identifier |
+| db_service | string | no | Match one `db_services` entry |
+| match_kind | string | no | `connect` (default), `cancel`, or `replication` |
+| db_user | string[] | no | Startup user globs; unavailable under passthrough |
+| database | string | no | Startup database name; unavailable under passthrough |
+| application_name | string | no | Startup application name; unavailable under passthrough |
+| client_identity | string | no | AgentSH client identity selector |
+| decision | string | yes | `allow`, `deny`, `approve`, or `audit`; `redirect` is invalid here |
+| message | string | no | Message returned to the client where protocol mode allows it |
+| timeout | duration | no | Approval timeout; invalid for `match_kind: cancel` |
+
+Rules that match a `passthrough` service cannot use `db_user`, `database`, or `application_name`, because AgentSH cannot inspect StartupMessage fields through passthrough TLS. `approve` is invalid for `match_kind: cancel`. `redirect` is invalid for all connection rules.
 
 ---
 
@@ -254,6 +422,19 @@ env_inject:
 | server_policy | string | Server list policy |
 | version_pinning | object | `{enabled, on_change?, auto_trust_first?}` |
 | cross_server | object | `{enabled, read_then_send?: {enabled}}` |
+
+### policies.db
+
+Database runtime settings live under `policies.db`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| unavoidability | string | `off`, `observe`, or `enforce`; `enforce` blocks direct access to declared DB upstreams from governed processes |
+| log_statements | string | `none`, `parameters_redacted` (default), or `full` |
+| approval_statement_preview | string | `none`, `redacted` (default), or `full` |
+| approval_statement_preview_chars | int | Max preview length, default 200 |
+| escalate_unknown_functions | bool | Treat unknown function calls in SELECT as `procedural` unless allowlisted |
+| safe_function_allowlist | string[] | Function names that remain read-safe when escalation is enabled |
 
 ### package_rules[]
 
@@ -334,7 +515,9 @@ Each platform object accepts arrays of patterns:
 
 ## Evaluation Semantics
 
-- **First match wins**: Rules within each category are evaluated top-to-bottom. The first rule whose pattern matches determines the decision. Order matters.
+- **First match wins**: File, network, command, unix socket, registry, signal, DNS redirect, connect redirect, HTTP service, and package rules are evaluated top-to-bottom within their category. The first matching rule determines the decision. Order matters.
+- **DB statement rules**: `database_rules` are not simple first-match-wins. Any matching deny wins. Otherwise every object slot in each classified effect must be covered by at least one matching `allow`, `audit`, `redirect`, or `approve` rule; uncovered objects fail closed as implicit deny.
+- **DB connection rules**: all matching `database_connection_rules` are considered and the most restrictive decision wins: `deny > approve > audit > allow`.
 - **Default deny**: Convention is to end each rule category with a catch-all deny rule (e.g., `paths: ["**"]`, `domains: ["*"]`).
 - **Variable expansion**: `${PROJECT_ROOT}`, `${HOME}`, `${GIT_ROOT}` are expanded at load time.
 - **Glob syntax**: `*` matches any characters except `/`. `**` matches any characters including `/`. `?` matches one character.
@@ -386,4 +569,71 @@ Each platform object accepts arrays of patterns:
   redirect_to:
     command: echo
     args: ["rm -rf blocked. Use targeted deletes instead."]
+```
+
+**Declare an HTTP service with credential substitution:**
+```yaml
+providers:
+  local_keyring:
+    type: keyring
+
+http_services:
+  - name: stripe
+    upstream: https://api.stripe.com
+    secret:
+      ref: keyring://agentsh/stripe_api_key
+      format: sk_live_{rand:32}
+    inject:
+      header:
+        name: Authorization
+        template: Bearer {{secret}}
+    rules:
+      - name: allow-read-customers
+        methods: [GET]
+        paths: ["/v1/customers*"]
+        decision: allow
+      - name: approve-writes
+        methods: [POST, DELETE]
+        paths: ["/v1/**"]
+        decision: approve
+```
+
+**Declare Postgres DB policy with redacted logging:**
+```yaml
+db_services:
+  appdb:
+    family: postgres
+    dialect: postgres
+    upstream: db.internal:5432
+    tls_mode: terminate_reissue
+
+policies:
+  db:
+    unavoidability: enforce
+    log_statements: parameters_redacted
+    approval_statement_preview: redacted
+    approval_statement_preview_chars: 200
+
+database_connection_rules:
+  - name: allow-app-user
+    db_service: appdb
+    db_user: [app_agent]
+    database: app
+    decision: allow
+  - name: deny-replication
+    db_service: appdb
+    match_kind: replication
+    decision: deny
+
+database_rules:
+  - name: allow-public-reads
+    db_service: appdb
+    operations: [READ]
+    relations: ["public.*"]
+    match_object_resolution: catalog_resolved
+    decision: allow
+  - name: deny-dangerous
+    db_service: appdb
+    operations: [DANGEROUS]
+    decision: deny
 ```

--- a/skills/agentsh-policy-shared/schema-reference.md
+++ b/skills/agentsh-policy-shared/schema-reference.md
@@ -334,7 +334,7 @@ Operation groups are lowercase canonical names: `read`, `write`, `modify`, `dele
 
 Uppercase aliases are also supported: `READ`, `INSERT`, `UPDATE`, `DELETE`, `REMOVE`, `CREATE`, `DROP`, `ALTER`, `TRUNCATE`, `EXPORT`, `LOAD`, `MUTATE`, `SCHEMA`, `MAINTENANCE`, `LOCK_TABLES`, `LISTEN_NOTIFY`, `DANGEROUS`. `*` expands to all known groups except `unknown`.
 
-`require_where: true` is valid only when `operations` expands exclusively to `modify` and/or `delete`; `MUTATE` is rejected because it also includes `write`. The guard is syntactic only, so `WHERE true` satisfies it.
+`require_where: true` is valid only when `operations` expands exclusively to `modify` and/or `delete`; `MUTATE` is rejected because it also includes `write`. The guard is syntactic only, so `WHERE true` satisfies it. It is a matcher on that rule only; another unguarded non-deny rule can still cover the same effect.
 
 `decision: redirect` is Postgres-only and supports safe read-only relation replacement. It requires `operations` that expand only to read, exactly one canonical `relations` source selector, `match_object_resolution: catalog_resolved`, an eligible terminate-mode Postgres service, and `redirect.relation`.
 


### PR DESCRIPTION
## Summary
- Update AgentSH policy skills and shared schema docs for current HTTP service and DB policy config values.
- Add a Postgres `require_where` database rule guard for top-level `UPDATE`/`DELETE` effects, including validation, evaluation, and proxy regression coverage.
- Document the syntactic and rule-local semantics, including `WHERE true` and overlapping unguarded-rule caveats.

## Test Plan
- [x] `go test ./internal/db/effects ./internal/db/classify/postgres ./internal/db/policy ./internal/db/proxy/postgres -count=1`
- [x] `go test ./internal/db/service ./internal/db/effects ./internal/db/policy -count=1`
- [x] `python3 /home/eran/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/agentsh-policy-create`
- [x] `python3 /home/eran/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/agentsh-policy-edit`
- [x] `GOOS=windows go build ./...`
- [x] `git diff --check`

## Notes
- This PR includes the earlier local commits for the policy skill/config update and the `require_where` design/implementation plan because local `main` was ahead of `origin/main` when the feature branch was created.
