### PR TITLE
wtp: ServerHeartbeat.generation hard cutover (#352)

### DIFF
--- a/docs/superpowers/plans/2026-05-22-issue-352-wtp-heartbeat-generation.md
+++ b/docs/superpowers/plans/2026-05-22-issue-352-wtp-heartbeat-generation.md
@@ -652,7 +652,7 @@ If `TestFlushLoop_PeriodicSync` (internal/store) or `TestStore_*EmitsTransportLo
 - [ ] **Step 4: Manual diff sanity check**
 
 Run: `git log --oneline main..HEAD` and review each commit.
-Expected: 6 focused commits (Tasks 1, 2, 3, 4, 5, 6, 7 each produced one — Task 8 has no commit).
+Expected: 7 focused commits (Tasks 1, 2, 3, 4, 5, 6, 7 each produced one — Task 8 has no commit).
 
 - [ ] **Step 5: Run roborev between tasks per project preference**
 

--- a/docs/superpowers/plans/2026-05-22-issue-352-wtp-heartbeat-generation.md
+++ b/docs/superpowers/plans/2026-05-22-issue-352-wtp-heartbeat-generation.md
@@ -1,0 +1,671 @@
+# Issue #352 — `ServerHeartbeat.generation` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `generation` to the `ServerHeartbeat` wire frame; hard-cutover the client to use the wire value; delete the FIFO-order substitution workaround.
+
+**Architecture:** Single-PR surgical change in 8 tasks. Proto field add → validator tightening (reject `gen == 0`) → recv-multiplexer passthrough → state handlers stop substituting → comment cleanup → cross-compile + full test. Each task is TDD where it changes behavior, mechanical where it changes wiring.
+
+**Tech Stack:** Go 1.21+, protoc-gen-go, standard `go test`. Spec: `docs/superpowers/specs/2026-05-22-issue-352-wtp-heartbeat-generation-design.md`.
+
+---
+
+## Pre-flight context (read once before starting)
+
+The substitution being removed lives in three places. Recv-multiplexer pushes events with `gen=0` for heartbeats; both state handlers substitute `t.persistedAck.Generation` at apply time. The substitution is "safe only because FIFO order on `eventCh` guarantees any earlier `BatchAck` has already advanced `persistedAck.Generation`" (load-bearing comment at `recv_multiplexer.go:24-31`).
+
+After this plan: the wire carries `(gen, seq)`, the client trusts the wire value, and the substitution code + its rationale comments are deleted. Validator rejects `generation == 0` outright — no v0.4.x compat fallback. Safe because no production server emits `ServerHeartbeat` today (only `recv_multiplexer_integration_test.go` constructs synthetic frames).
+
+`Makefile:32-45` regenerates proto via `protoc`. Build/test commands per `CLAUDE.md`: `go build ./...`, `go test ./...`, `GOOS=windows go build ./...`.
+
+---
+
+## Task 1: Add `generation` field to `ServerHeartbeat` proto
+
+**Files:**
+- Modify: `proto/canyonroad/wtp/v1/wtp.proto:184-186`
+- Regen: `proto/canyonroad/wtp/v1/wtp.pb.go`
+
+- [ ] **Step 1: Edit the proto**
+
+Change `proto/canyonroad/wtp/v1/wtp.proto:184-186` from:
+
+```protobuf
+message ServerHeartbeat {
+  uint64 ack_high_watermark_seq = 1;
+}
+```
+
+to:
+
+```protobuf
+message ServerHeartbeat {
+  uint64 ack_high_watermark_seq = 1;
+  uint32 generation             = 2;
+}
+```
+
+- [ ] **Step 2: Regenerate the Go bindings**
+
+Run: `make proto`
+Expected: `wtp.pb.go` is regenerated, no errors. Diff shows a new `Generation uint32` field and `GetGeneration()` accessor on `*ServerHeartbeat`.
+
+If `make proto` is unavailable in the environment, run the protoc invocation from `Makefile:32-45` directly.
+
+- [ ] **Step 3: Verify the build still compiles**
+
+Run: `go build ./...`
+Expected: PASS. No callers reference the new field yet, so no test fails.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add proto/canyonroad/wtp/v1/wtp.proto proto/canyonroad/wtp/v1/wtp.pb.go
+git commit -m "wtp: add ServerHeartbeat.generation field (#352)"
+```
+
+---
+
+## Task 2: Tighten `ValidateServerHeartbeat` to reject `generation == 0` (TDD)
+
+**Files:**
+- Test: `proto/canyonroad/wtp/v1/validate_test.go:222-237`
+- Modify: `proto/canyonroad/wtp/v1/validate.go:366-376`
+
+- [ ] **Step 1: Write the failing test for zero-gen rejection**
+
+Append to `proto/canyonroad/wtp/v1/validate_test.go` (after the existing `TestValidateServerHeartbeat_HappyPath`):
+
+```go
+func TestValidateServerHeartbeat_ZeroGeneration(t *testing.T) {
+	err := ValidateServerHeartbeat(&ServerHeartbeat{
+		AckHighWatermarkSeq: 42,
+		Generation:          0,
+	})
+	if err == nil {
+		t.Fatal("ValidateServerHeartbeat(gen=0): want error, got nil")
+	}
+	var ve *ValidationError
+	if !errors.As(err, &ve) || ve.Reason != ReasonUnknown {
+		t.Fatalf("err = %v; want *ValidationError with Reason=%q", err, ReasonUnknown)
+	}
+	if !errors.Is(err, ErrInvalidFrame) {
+		t.Fatalf("err = %v; want errors.Is(ErrInvalidFrame) true", err)
+	}
+}
+```
+
+- [ ] **Step 2: Update the happy-path test to set `Generation`**
+
+Change `proto/canyonroad/wtp/v1/validate_test.go:233-237` from:
+
+```go
+func TestValidateServerHeartbeat_HappyPath(t *testing.T) {
+	if err := ValidateServerHeartbeat(&ServerHeartbeat{AckHighWatermarkSeq: 42}); err != nil {
+		t.Errorf("ValidateServerHeartbeat: %v", err)
+	}
+}
+```
+
+to:
+
+```go
+func TestValidateServerHeartbeat_HappyPath(t *testing.T) {
+	if err := ValidateServerHeartbeat(&ServerHeartbeat{
+		AckHighWatermarkSeq: 42,
+		Generation:          1,
+	}); err != nil {
+		t.Errorf("ValidateServerHeartbeat: %v", err)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests — expect zero-gen test to FAIL**
+
+Run: `go test ./proto/canyonroad/wtp/v1/ -run TestValidateServerHeartbeat -v`
+Expected: `TestValidateServerHeartbeat_ZeroGeneration` FAILS with "want error, got nil"; the other two heartbeat tests PASS.
+
+- [ ] **Step 4: Implement the validator change**
+
+Change `proto/canyonroad/wtp/v1/validate.go:366-376` from:
+
+```go
+// ValidateServerHeartbeat rejects a nil ServerHeartbeat. No other
+// stateless invariants apply.
+func ValidateServerHeartbeat(hb *ServerHeartbeat) error {
+	if hb == nil {
+		return &ValidationError{
+			Reason: ReasonUnknown,
+			Inner:  fmt.Errorf("%w: server_heartbeat is nil", ErrInvalidFrame),
+		}
+	}
+	return nil
+}
+```
+
+to:
+
+```go
+// ValidateServerHeartbeat rejects a nil ServerHeartbeat or one whose
+// generation is zero. Generation is REQUIRED in WTP v0.5 — old v0.4.x
+// servers that omit it are not interoperable with v0.5 clients (issue #352).
+func ValidateServerHeartbeat(hb *ServerHeartbeat) error {
+	if hb == nil {
+		return &ValidationError{
+			Reason: ReasonUnknown,
+			Inner:  fmt.Errorf("%w: server_heartbeat is nil", ErrInvalidFrame),
+		}
+	}
+	if hb.GetGeneration() == 0 {
+		return &ValidationError{
+			Reason: ReasonUnknown,
+			Inner:  fmt.Errorf("%w: server_heartbeat.generation must be > 0", ErrInvalidFrame),
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Run tests — expect all heartbeat tests to PASS**
+
+Run: `go test ./proto/canyonroad/wtp/v1/ -run TestValidateServerHeartbeat -v`
+Expected: all three tests PASS.
+
+- [ ] **Step 6: Run the full validator test suite to catch regressions**
+
+Run: `go test ./proto/canyonroad/wtp/v1/...`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add proto/canyonroad/wtp/v1/validate.go proto/canyonroad/wtp/v1/validate_test.go
+git commit -m "wtp: validator rejects ServerHeartbeat with generation=0 (#352)"
+```
+
+---
+
+## Task 3: Wire heartbeat `gen` through recv-multiplexer (TDD via integration test)
+
+**Files:**
+- Modify: `internal/store/watchtower/transport/recv_multiplexer_integration_test.go:103-114, 173-186`
+- Modify: `internal/store/watchtower/transport/recv_multiplexer.go:24-31, 286-291`
+
+This task atomically updates the integration test expectation (heartbeat events now carry the wire gen, not zero) and the recv-mux code that produces them.
+
+- [ ] **Step 1: Update the `recvHeartbeat` helper signature**
+
+Change `internal/store/watchtower/transport/recv_multiplexer_integration_test.go:103-114` from:
+
+```go
+// recvHeartbeat is a one-line constructor for a ServerHeartbeat server
+// message. The proto carries no generation field; the recv multiplexer
+// substitutes t.persistedAck.Generation at apply time.
+func recvHeartbeat(seq uint64) *wtpv1.ServerMessage {
+	return &wtpv1.ServerMessage{
+		Msg: &wtpv1.ServerMessage_ServerHeartbeat{
+			ServerHeartbeat: &wtpv1.ServerHeartbeat{
+				AckHighWatermarkSeq: seq,
+			},
+		},
+	}
+}
+```
+
+to:
+
+```go
+// recvHeartbeat is a one-line constructor for a ServerHeartbeat server
+// message. Generation is REQUIRED on the wire in WTP v0.5 (issue #352);
+// the recv multiplexer surfaces it directly without substitution.
+func recvHeartbeat(gen uint32, seq uint64) *wtpv1.ServerMessage {
+	return &wtpv1.ServerMessage{
+		Msg: &wtpv1.ServerMessage_ServerHeartbeat{
+			ServerHeartbeat: &wtpv1.ServerHeartbeat{
+				AckHighWatermarkSeq: seq,
+				Generation:          gen,
+			},
+		},
+	}
+}
+```
+
+- [ ] **Step 2: Update integration-test push table to expect wire gen**
+
+Change `internal/store/watchtower/transport/recv_multiplexer_integration_test.go:173-186` from:
+
+```go
+	// Wire-order push: BatchAck(1, 100), HB(99), BatchAck(1, 200), HB(150).
+	// Heartbeats keep gen=0 on the wire (the multiplexer leaves it zero
+	// and substitutes at apply time on the main goroutine).
+	pushSeq := []struct {
+		frame string
+		gen   uint32
+		seq   uint64
+		msg   *wtpv1.ServerMessage
+	}{
+		{"batch_ack", 1, 100, recvBatchAck(1, 100)},
+		{"server_heartbeat", 0, 99, recvHeartbeat(99)},
+		{"batch_ack", 1, 200, recvBatchAck(1, 200)},
+		{"server_heartbeat", 0, 150, recvHeartbeat(150)},
+	}
+```
+
+to:
+
+```go
+	// Wire-order push: BatchAck(1, 100), HB(1, 99), BatchAck(1, 200), HB(1, 150).
+	// Per issue #352, ServerHeartbeat now carries generation on the wire;
+	// the multiplexer surfaces it directly without substitution.
+	pushSeq := []struct {
+		frame string
+		gen   uint32
+		seq   uint64
+		msg   *wtpv1.ServerMessage
+	}{
+		{"batch_ack", 1, 100, recvBatchAck(1, 100)},
+		{"server_heartbeat", 1, 99, recvHeartbeat(1, 99)},
+		{"batch_ack", 1, 200, recvBatchAck(1, 200)},
+		{"server_heartbeat", 1, 150, recvHeartbeat(1, 150)},
+	}
+```
+
+- [ ] **Step 3: Run the integration test — expect FAIL**
+
+Run: `go test ./internal/store/watchtower/transport/ -run TestRecvMultiplexer.*Integration -v`
+Expected: FAILS on the heartbeat gen assertion (`event[1] gen: got 0, want 1`) because the multiplexer is still emitting `ev.gen = 0`.
+
+- [ ] **Step 4: Update the recv-multiplexer dispatch**
+
+Change `internal/store/watchtower/transport/recv_multiplexer.go:286-291` from:
+
+```go
+			h := m.ServerHeartbeat
+			ev := recvAckEvent{
+				kind: recvAckEventHeartbeat,
+				// gen left zero; main substitutes t.persistedAck.Generation
+				// at apply time per the FIFO-order invariant.
+				seq: h.GetAckHighWatermarkSeq(),
+			}
+```
+
+to:
+
+```go
+			h := m.ServerHeartbeat
+			ev := recvAckEvent{
+				kind: recvAckEventHeartbeat,
+				gen:  h.GetGeneration(),
+				seq:  h.GetAckHighWatermarkSeq(),
+			}
+```
+
+- [ ] **Step 5: Update the `recvAckEventHeartbeat` doc comment**
+
+Change `internal/store/watchtower/transport/recv_multiplexer.go:24-31` from:
+
+```go
+	// recvAckEventHeartbeat wraps a *wtpv1.ServerMessage_ServerHeartbeat
+	// demux. Only seq is populated from the wire frame; gen is zero
+	// because the proto carries no generation field. The main goroutine
+	// substitutes t.persistedAck.Generation at apply time — safe ONLY
+	// because strict FIFO order on eventCh guarantees any earlier
+	// BatchAck has already been processed (and may have advanced
+	// t.persistedAck.Generation) before this heartbeat reaches the
+	// dispatch site. See round-22 Finding 1.
+	recvAckEventHeartbeat
+```
+
+to:
+
+```go
+	// recvAckEventHeartbeat wraps a *wtpv1.ServerMessage_ServerHeartbeat
+	// demux. gen + seq are populated from the wire frame (issue #352);
+	// the discriminator distinguishes heartbeats from BatchAcks because
+	// state handlers apply different inflight/release semantics.
+	recvAckEventHeartbeat
+```
+
+- [ ] **Step 6: Run the integration test — expect PASS**
+
+Run: `go test ./internal/store/watchtower/transport/ -run TestRecvMultiplexer.*Integration -v`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/store/watchtower/transport/recv_multiplexer.go internal/store/watchtower/transport/recv_multiplexer_integration_test.go
+git commit -m "wtp: recv multiplexer carries ServerHeartbeat.generation from wire (#352)"
+```
+
+---
+
+## Task 4: Drop substitution in `state_live`; add cross-gen heartbeat test (TDD)
+
+**Files:**
+- Test: `internal/store/watchtower/transport/recv_multiplexer_test.go` (new test added to the existing `Heartbeat_advancing_returns_Adopted` neighborhood around line 704)
+- Modify: `internal/store/watchtower/transport/state_live.go:247-266`
+
+- [ ] **Step 1: Write the failing cross-gen heartbeat test**
+
+Find the existing `t.Run("Heartbeat_advancing_returns_Adopted", ...` block at `internal/store/watchtower/transport/recv_multiplexer_test.go:704`. Add a sibling subtest immediately after the closing brace of that `t.Run`:
+
+```go
+	t.Run("Heartbeat_with_higher_gen_applies_wire_gen", func(t *testing.T) {
+		// Issue #352: ServerHeartbeat now carries generation on the
+		// wire. applyAckFromRecv MUST be driven with the wire gen, not
+		// the persisted gen — otherwise a heartbeat that follows a
+		// roll-up to gen+1 (where the BatchAck that advanced the
+		// generation was dropped) would be silently mis-applied at the
+		// old generation.
+		env := newClampTestEnv(t, Options{
+			InitialAckTuple: &AckTuple{Sequence: 50, Generation: 1, Present: true},
+		})
+		SetAckAnomalyLimiterForTest(env.tr, permissiveLimiter())
+		appendDataInGen(t, env.w, 1, 2, 100)
+
+		got := env.tr.applyAckFromRecv("server_heartbeat", 2, 80)
+		if got != AckOutcomeAdopted {
+			t.Fatalf("applyAckFromRecv outcome: got %v, want AckOutcomeAdopted", got)
+		}
+		if persisted := PersistedAckForTest(env.tr); persisted.Generation != 2 {
+			t.Fatalf("persistedAck.Generation: got %d, want 2 (cross-gen adopt)", persisted.Generation)
+		}
+	})
+```
+
+- [ ] **Step 2: Run the new test — expect PASS (sanity check, since the test calls `applyAckFromRecv` directly with wire gen)**
+
+Run: `go test ./internal/store/watchtower/transport/ -run Heartbeat_with_higher_gen -v`
+Expected: PASS. This test pins the unit-level contract that `applyAckFromRecv` already handles cross-gen acks correctly — it documents the *behavior* the state-handler change below will start exercising in production.
+
+(If the test FAILS, stop: the `applyAckFromRecv` cross-gen path itself is broken and the design assumption — "no new stateful logic" — is wrong. Surface this finding before continuing.)
+
+- [ ] **Step 3: Update `state_live.go` to pass `ev.gen` through**
+
+Change `internal/store/watchtower/transport/state_live.go:247-266` from:
+
+```go
+			case recvAckEventHeartbeat:
+				// Heartbeat carries no gen on the wire; FIFO order on
+				// eventCh guarantees any earlier BatchAck has already
+				// advanced t.persistedAck.Generation, so substituting
+				// here is safe (round-22 Finding 1 invariant).
+				//
+				// Heartbeats use the SAME ack clamp as BatchAck and
+				// may carry an ack advance when a BatchAck was
+				// missed (per spec). Release every covered batch on
+				// an Adopted heartbeat — otherwise the sender would
+				// wedge at MaxInflight until reconnect (roborev
+				// Medium round-4).
+				outcome := t.applyAckFromRecv("server_heartbeat", t.persistedAck.Generation, ev.seq)
+				if outcome == AckOutcomeAdopted {
+					inflight.Release(t.persistedAck.Generation, ev.seq)
+					if err := drainAvailable(); err != nil {
+						teardownForReconnect()
+						return StateConnecting, err
+					}
+				}
+```
+
+to:
+
+```go
+			case recvAckEventHeartbeat:
+				// Heartbeats use the SAME ack clamp as BatchAck and
+				// may carry an ack advance when a BatchAck was
+				// missed (per spec). Release every covered batch on
+				// an Adopted heartbeat — otherwise the sender would
+				// wedge at MaxInflight until reconnect (roborev
+				// Medium round-4).
+				outcome := t.applyAckFromRecv("server_heartbeat", ev.gen, ev.seq)
+				if outcome == AckOutcomeAdopted {
+					inflight.Release(ev.gen, ev.seq)
+					if err := drainAvailable(); err != nil {
+						teardownForReconnect()
+						return StateConnecting, err
+					}
+				}
+```
+
+- [ ] **Step 4: Run state_live and recv-mux tests**
+
+Run: `go test ./internal/store/watchtower/transport/ -run "TestRecvMultiplexer|TestRunLive|TestState_?[Ll]ive" -v`
+Expected: PASS. Verified via pre-flight grep: no test other than the integration test (already updated in Task 3) constructs a `ServerHeartbeat` frame and feeds it through the recv goroutine; the direct `applyAckFromRecv("server_heartbeat", ...)` test sites (`recv_multiplexer_test.go:388, 428, 714`) all pass an explicit gen and are unaffected by this change.
+
+- [ ] **Step 5: Run the full transport test suite**
+
+Run: `go test ./internal/store/watchtower/transport/...`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/store/watchtower/transport/state_live.go internal/store/watchtower/transport/recv_multiplexer_test.go
+git commit -m "wtp: state_live uses ev.gen for heartbeat ack/release (#352)"
+```
+
+---
+
+## Task 5: Drop substitution in `state_replaying`
+
+**Files:**
+- Modify: `internal/store/watchtower/transport/state_replaying.go:77-82`
+
+- [ ] **Step 1: Update `state_replaying.go`**
+
+Change `internal/store/watchtower/transport/state_replaying.go:77-82` from:
+
+```go
+			case recvAckEventHeartbeat:
+				// Heartbeat carries no gen on the wire; FIFO order
+				// guarantees any earlier BatchAck has already
+				// advanced t.persistedAck.Generation.
+				t.applyAckFromRecv("server_heartbeat", t.persistedAck.Generation, ev.seq)
+			}
+```
+
+to:
+
+```go
+			case recvAckEventHeartbeat:
+				// Heartbeat carries gen on the wire (issue #352);
+				// pass it through directly. Unlike state_live, no
+				// inflight.Release here — runReplaying is draining,
+				// not sending.
+				t.applyAckFromRecv("server_heartbeat", ev.gen, ev.seq)
+			}
+```
+
+- [ ] **Step 2: Run state_replaying tests**
+
+Run: `go test ./internal/store/watchtower/transport/ -run "TestState_?[Rr]eplaying|TestRunReplaying" -v`
+Expected: PASS. Same reasoning as Task 4 Step 4: no test outside the integration test constructs a heartbeat frame and feeds it through the recv goroutine in replaying state.
+
+- [ ] **Step 3: Run the full transport test suite**
+
+Run: `go test ./internal/store/watchtower/transport/...`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/store/watchtower/transport/state_replaying.go
+git commit -m "wtp: state_replaying uses ev.gen for heartbeat ack (#352)"
+```
+
+---
+
+## Task 6: Add fail-closed test for `generation == 0` heartbeat
+
+**Files:**
+- Test: `internal/store/watchtower/transport/recv_multiplexer_failclosed_test.go` (append after the last existing test)
+
+- [ ] **Step 1: Write the fail-closed test**
+
+Append to `internal/store/watchtower/transport/recv_multiplexer_failclosed_test.go`:
+
+```go
+// TestRecvMultiplexer_FailClosedHeartbeatZeroGeneration verifies that a
+// ServerHeartbeat with generation=0 (an invalid v0.5 frame per issue
+// #352) is rejected by ValidateServerHeartbeat, drives the errCh
+// sentinel, and tears down the recv session. The frame is
+// schema-valid (the wire decoded cleanly) but semantically invalid —
+// classified as ReasonUnknown / ErrInvalidFrame.
+func TestRecvMultiplexer_FailClosedHeartbeatZeroGeneration(t *testing.T) {
+	fc := newRecvFakeConn()
+	tr, _ := newFailClosedTransport(t, fc, false)
+
+	msg := &wtpv1.ServerMessage{
+		Msg: &wtpv1.ServerMessage_ServerHeartbeat{
+			ServerHeartbeat: &wtpv1.ServerHeartbeat{
+				AckHighWatermarkSeq: 42,
+				// Generation deliberately omitted (zero value).
+			},
+		},
+	}
+	if err := driveFailClosed(t, tr, fc, msg); err == nil {
+		t.Fatal("expected errCh sentinel after fail-closed zero-gen heartbeat")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test — expect PASS (validator already enforces this from Task 2)**
+
+Run: `go test ./internal/store/watchtower/transport/ -run TestRecvMultiplexer_FailClosedHeartbeatZeroGeneration -v`
+Expected: PASS. This test is regression-protection for the wire/validator integration.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/store/watchtower/transport/recv_multiplexer_failclosed_test.go
+git commit -m "wtp: fail-closed test for zero-generation ServerHeartbeat (#352)"
+```
+
+---
+
+## Task 7: FIFO-rationale comment audit + cleanup
+
+**Files:**
+- Audit and possibly modify: `internal/store/watchtower/transport/recv_multiplexer.go:44-50, 77`
+
+The eventCh FIFO comment block at `recv_multiplexer.go:44-50` reads:
+
+```go
+// Wire-ordering invariant (round-22 Finding 1, load-bearing): events on
+// eventCh are processed in strict FIFO order on the main goroutine. The
+// recv goroutine pushes them in receive order; the main goroutine
+// selects one at a time and runs applyAckFromRecv to completion before
+// pulling the next. The heartbeat-generation substitution rule (see
+// recvAckEventHeartbeat) depends on this invariant — any change to the
+// recv-event ordering MUST be reviewed against the substitution rule.
+```
+
+The heartbeat-substitution rule is gone. Audit whether anything else in the transport depends on strict FIFO order on `eventCh`.
+
+- [ ] **Step 1: Audit FIFO dependents**
+
+Run: `grep -rn "FIFO\|recvAckEvent\|eventCh" internal/store/watchtower/transport/ | grep -v _test.go`
+
+Read every match. Look for code that depends on strict ordering between `BatchAck`, `Heartbeat`, and `PolicyPush` events on `eventCh`. Examples of what would still be load-bearing: any apply-time logic that requires the *last* BatchAck of a gen to land before a subsequent event; any clamp logic that walks generations forward and would mis-clamp under reordering.
+
+- [ ] **Step 2A (if no remaining dependent): delete the FIFO comment**
+
+If the audit finds no remaining FIFO dependent, replace `recv_multiplexer.go:44-50`:
+
+```go
+// Wire-ordering invariant (round-22 Finding 1, load-bearing): events on
+// eventCh are processed in strict FIFO order on the main goroutine. The
+// recv goroutine pushes them in receive order; the main goroutine
+// selects one at a time and runs applyAckFromRecv to completion before
+// pulling the next. The heartbeat-generation substitution rule (see
+// recvAckEventHeartbeat) depends on this invariant — any change to the
+// recv-event ordering MUST be reviewed against the substitution rule.
+```
+
+with:
+
+```go
+// Events on eventCh are processed in receive order on the main
+// goroutine: the recv goroutine pushes in receive order; the main
+// goroutine selects one at a time and runs applyAckFromRecv to
+// completion before pulling the next.
+```
+
+- [ ] **Step 2B (if dependents remain): trim the comment to name them**
+
+If the audit finds remaining dependents, replace the comment with a version that names the specific reasons FIFO is still load-bearing and removes the heartbeat-substitution sentence. Example shape:
+
+```go
+// Wire-ordering invariant: events on eventCh are processed in strict
+// FIFO order on the main goroutine. The recv goroutine pushes them in
+// receive order; the main goroutine selects one at a time and runs
+// applyAckFromRecv to completion before pulling the next. Load-bearing
+// for: <list the specific reasons found in the audit>.
+```
+
+- [ ] **Step 3: Verify the comment at line 77 still reads sensibly**
+
+Check `recv_multiplexer.go:77`:
+
+```go
+// eventCh carries demuxed BatchAck and ServerHeartbeat events in
+```
+
+…and read the surrounding paragraph. If it references the substitution rationale, trim it; if it only describes the channel mechanics, leave it.
+
+- [ ] **Step 4: Run the full transport test suite**
+
+Run: `go test ./internal/store/watchtower/transport/...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/store/watchtower/transport/recv_multiplexer.go
+git commit -m "wtp: drop heartbeat-substitution rationale from FIFO comments (#352)"
+```
+
+---
+
+## Task 8: Cross-compile + full test suite verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Linux build**
+
+Run: `go build ./...`
+Expected: PASS.
+
+- [ ] **Step 2: Windows cross-compile (per CLAUDE.md)**
+
+Run: `GOOS=windows go build ./...`
+Expected: PASS.
+
+- [ ] **Step 3: Full test suite**
+
+Run: `go test ./...`
+Expected: PASS.
+
+If `TestFlushLoop_PeriodicSync` (internal/store) or `TestStore_*EmitsTransportLossOnWire` family flakes on Linux/Windows CI, that is pre-existing and unrelated to this change (per memory `project_flushloop_windows_flake.md` and `project_wtp_transportloss_flakes.md`). Re-run once; if still flaky, note in the PR description and proceed — do NOT chase those flakes here.
+
+- [ ] **Step 4: Manual diff sanity check**
+
+Run: `git log --oneline main..HEAD` and review each commit.
+Expected: 6 focused commits (Tasks 1, 2, 3, 4, 5, 6, 7 each produced one — Task 8 has no commit).
+
+- [ ] **Step 5: Run roborev between tasks per project preference**
+
+(See memory `feedback_roborev_between_tasks.md`.) The plan is complete; the user typically runs roborev at this point. No commit from this step.
+
+---
+
+## Done criteria
+
+- `ServerHeartbeat.generation` exists on the wire (Task 1).
+- Validator rejects `generation == 0` with `ErrInvalidFrame` (Task 2).
+- Recv multiplexer surfaces wire gen on `recvAckEvent` (Task 3).
+- `state_live` and `state_replaying` no longer reference `t.persistedAck.Generation` on the heartbeat path (Tasks 4, 5).
+- A fail-closed test pins the zero-gen rejection at the wire boundary (Task 6).
+- The FIFO-substitution rationale comments are gone or trimmed (Task 7).
+- `go build ./...`, `GOOS=windows go build ./...`, and `go test ./...` all pass (Task 8).

--- a/docs/superpowers/plans/2026-05-22-issue-352-wtp-heartbeat-generation.md
+++ b/docs/superpowers/plans/2026-05-22-issue-352-wtp-heartbeat-generation.md
@@ -86,8 +86,8 @@ func TestValidateServerHeartbeat_ZeroGeneration(t *testing.T) {
 		t.Fatal("ValidateServerHeartbeat(gen=0): want error, got nil")
 	}
 	var ve *ValidationError
-	if !errors.As(err, &ve) || ve.Reason != ReasonUnknown {
-		t.Fatalf("err = %v; want *ValidationError with Reason=%q", err, ReasonUnknown)
+	if !errors.As(err, &ve) || ve.Reason != ReasonHeartbeatGenerationInvalid {
+		t.Fatalf("err = %v; want *ValidationError with Reason=%q", err, ReasonHeartbeatGenerationInvalid)
 	}
 	if !errors.Is(err, ErrInvalidFrame) {
 		t.Fatalf("err = %v; want errors.Is(ErrInvalidFrame) true", err)
@@ -146,9 +146,11 @@ func ValidateServerHeartbeat(hb *ServerHeartbeat) error {
 to:
 
 ```go
-// ValidateServerHeartbeat rejects a nil ServerHeartbeat or one whose
-// generation is zero. Generation is REQUIRED in WTP v0.5 — old v0.4.x
-// servers that omit it are not interoperable with v0.5 clients (issue #352).
+// ValidateServerHeartbeat returns ReasonHeartbeatGenerationInvalid
+// when the inbound ServerHeartbeat has generation == 0 (issue #352:
+// generation is REQUIRED in WTP v0.5; no prior server version emitted
+// ServerHeartbeat, so there is no compat path for unset generation).
+// Returns ReasonUnknown for nil.
 func ValidateServerHeartbeat(hb *ServerHeartbeat) error {
 	if hb == nil {
 		return &ValidationError{
@@ -156,9 +158,9 @@ func ValidateServerHeartbeat(hb *ServerHeartbeat) error {
 			Inner:  fmt.Errorf("%w: server_heartbeat is nil", ErrInvalidFrame),
 		}
 	}
-	if hb.GetGeneration() == 0 {
+	if hb.Generation == 0 {
 		return &ValidationError{
-			Reason: ReasonUnknown,
+			Reason: ReasonHeartbeatGenerationInvalid,
 			Inner:  fmt.Errorf("%w: server_heartbeat.generation must be > 0", ErrInvalidFrame),
 		}
 	}
@@ -511,7 +513,7 @@ Append to `internal/store/watchtower/transport/recv_multiplexer_failclosed_test.
 // #352) is rejected by ValidateServerHeartbeat, drives the errCh
 // sentinel, and tears down the recv session. The frame is
 // schema-valid (the wire decoded cleanly) but semantically invalid —
-// classified as ReasonUnknown / ErrInvalidFrame.
+// classified as ReasonHeartbeatGenerationInvalid / ErrInvalidFrame.
 func TestRecvMultiplexer_FailClosedHeartbeatZeroGeneration(t *testing.T) {
 	fc := newRecvFakeConn()
 	tr, _ := newFailClosedTransport(t, fc, false)

--- a/docs/superpowers/specs/2026-05-22-issue-352-wtp-heartbeat-generation-design.md
+++ b/docs/superpowers/specs/2026-05-22-issue-352-wtp-heartbeat-generation-design.md
@@ -1,0 +1,162 @@
+# Issue #352 — `ServerHeartbeat.generation` design
+
+**Status:** approved, ready for implementation plan
+**Date:** 2026-05-22
+**Issue:** [#352](https://github.com/canyonroad/agentsh/issues/352) — WTP v0.5: ServerHeartbeat.generation — carry full watermark tuple
+**Label:** `wtp-v0.5`
+
+## Problem
+
+`ServerHeartbeat` (`proto/canyonroad/wtp/v1/wtp.proto:184-186`) carries only
+`ack_high_watermark_seq`. The recv multiplexer pushes heartbeat events onto
+`eventCh` with `gen = 0`, and the main goroutine substitutes
+`t.persistedAck.Generation` at apply time
+(`state_live.go:259`, `state_replaying.go:81`). This substitution is safe only
+under a strict FIFO-order invariant on `eventCh` (any earlier `BatchAck` has
+been applied before the heartbeat is dispatched), documented load-bearing at
+`recv_multiplexer.go:24-31` and `44-50`.
+
+The substitution is a workaround for a missing wire field. It couples client
+correctness to an event-ordering rule that is otherwise an implementation
+detail of the dispatcher. Adding `generation` to `ServerHeartbeat` makes the
+watermark tuple `(gen, seq)` explicit on every server frame — matching
+`SessionAck` and `BatchAck` — and removes the workaround.
+
+## Decision: hard cutover (v0.5)
+
+- v0.5 wire only. The validator rejects `generation == 0`.
+- The substitution code and its FIFO-substitution comments are deleted.
+- No fallback path for v0.4.x servers. Safe because no production server
+  currently emits `ServerHeartbeat` — only `recv_multiplexer_integration_test.go`
+  constructs synthetic frames.
+- Scope is proto + client + validator + tests. No server emitter wiring
+  (testserver or production) lands in this change.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `proto/canyonroad/wtp/v1/wtp.proto:184-186` | Add `uint32 generation = 2;` to `ServerHeartbeat` |
+| `proto/canyonroad/wtp/v1/wtp.pb.go` | Regenerated via `make proto` |
+| `proto/canyonroad/wtp/v1/validate.go:368-374` | Reject `generation == 0` (in addition to existing nil check) |
+| `proto/canyonroad/wtp/v1/validate_test.go:222-235` | Add zero-gen rejection case; update happy path to set `Generation` |
+| `internal/store/watchtower/transport/recv_multiplexer.go:24-31, 44-50, 286-291` | Populate `ev.gen` from wire; delete heartbeat-substitution rationale |
+| `internal/store/watchtower/transport/state_live.go:247-261` | Pass `ev.gen` to `applyAckFromRecv` and `inflight.Release` instead of `t.persistedAck.Generation` |
+| `internal/store/watchtower/transport/state_replaying.go:77-81` | Same: `ev.gen` instead of `t.persistedAck.Generation` |
+| `internal/store/watchtower/transport/recv_multiplexer_integration_test.go:103-114` | `recvHeartbeat(seq)` → `recvHeartbeat(gen, seq)`; update call sites |
+| Other transport tests calling `recvHeartbeat` | Pass explicit gen at every call site |
+
+The FIFO-order invariant on `eventCh` itself stays as a runtime guarantee.
+Only the *heartbeat-substitution rationale* is removed from the comments.
+Implementation step: grep `recv_multiplexer.go`, `state_live.go`,
+`state_replaying.go` for other documented reasons FIFO order is load-bearing
+(e.g., ordered processing of intermixed `BatchAck` + `PolicyPush`). If any
+remain, leave a trimmed comment naming them; if none, delete the comments
+cleanly.
+
+## Data flow
+
+**Before:**
+server → `ServerHeartbeat{seq}` → recv goroutine emits
+`recvAckEvent{kind: Heartbeat, gen: 0, seq}` → main goroutine substitutes
+`t.persistedAck.Generation` → `applyAckFromRecv(persisted.gen, seq)`.
+
+**After:**
+server → `ServerHeartbeat{gen, seq}` → recv goroutine emits
+`recvAckEvent{kind: Heartbeat, gen: wire, seq}` → main goroutine passes
+`ev.gen` directly → `applyAckFromRecv(ev.gen, ev.seq)`.
+
+The `recvAckEventHeartbeat` kind discriminator is retained — it still selects
+different behavior from `recvAckEventBatchAck` (heartbeat doesn't drive
+`inflight.Release` in `state_replaying`; in `state_live` it now releases with
+the wire gen).
+
+## Error handling
+
+### Stateless validation
+
+`ValidateServerHeartbeat` adds a zero-gen check returning:
+
+```go
+&ValidationError{
+    Reason: ReasonUnknown,
+    Inner:  fmt.Errorf("%w: server_heartbeat.generation must be > 0", ErrInvalidFrame),
+}
+```
+
+Same error shape as the existing nil check. Routes through
+`ClassifyAndIncInvalidFrame` at `recv_multiplexer.go:279` exactly like every
+other invalid-frame failure.
+
+### Stateful handling
+
+No new logic. The heartbeat now feeds `applyAckFromRecv` with the same
+`(gen, seq)` shape as `BatchAck`. Existing cross-generation handling
+(regression detection, future-gen, replay-cursor anomaly) applies uniformly
+to both event kinds.
+
+### Inflight release semantic flip (highest-risk line)
+
+`state_live.go:261` changes from
+`inflight.Release(t.persistedAck.Generation, ev.seq)` to
+`inflight.Release(ev.gen, ev.seq)`. This is a real semantic change:
+
+- **Before:** a heartbeat could only release inflight at the persisted gen
+  (because the wire carried no gen).
+- **After:** a heartbeat carrying a higher gen drives the cross-gen release
+  path.
+
+This is the intended tightening — it was only impossible to express on the
+wire before — but the implementation plan must include an explicit positive
+test exercising this new code path.
+
+## Testing
+
+1. **`proto/canyonroad/wtp/v1/validate_test.go`**
+   - `TestValidateServerHeartbeat_ZeroGeneration`: gen=0 returns
+     `ErrInvalidFrame`-wrapped error.
+   - Update `TestValidateServerHeartbeat_HappyPath` to include `Generation: 1`.
+
+2. **`internal/store/watchtower/transport/recv_multiplexer_integration_test.go`**
+   - Heartbeat with explicit wire gen propagates to dispatch: assert
+     `ev.gen` equals the wire value (not zero, not persisted).
+
+3. **New positive test in `state_live` or recv-mux integration**
+   - Heartbeat with `gen > persistedAck.Generation` drives
+     `applyAckFromRecv`'s cross-gen path and `inflight.Release(ev.gen, …)`.
+     Confirms the old substitution wasn't masking a behavior we now want
+     exposed.
+
+4. **`internal/store/watchtower/transport/recv_multiplexer_failclosed_test.go`**
+   - Extend with gen==0 case: heartbeat with zero gen triggers
+     `ClassifyAndIncInvalidFrame` and fail-closed teardown.
+
+5. **Existing tests using `recvHeartbeat(seq)`**
+   - Each call site updates to pass the gen the surrounding assertion
+     implicitly expected (usually the test's persisted gen). Mechanical.
+
+## Migration
+
+- v0.5 wire only. No staged rollout, no compat shim, no fallback.
+- After merge, any `ServerHeartbeat` with `generation == 0` is rejected as an
+  invalid frame.
+- Safe because no production server emits `ServerHeartbeat` today — only
+  test scaffolding does.
+- `make proto` regenerates `wtp.pb.go` (uses `protoc` per `Makefile:32-45`).
+
+## Non-goals
+
+- Wiring `cmd/wtp-testserver` to emit heartbeats. (Belongs with whatever
+  feature first needs heartbeats on the wire.)
+- Production server-side emitter. (Same — out of scope until needed.)
+- Any change to `BatchAck`, `SessionAck`, or other ack frames. They already
+  carry generation.
+
+## Out-of-band confirmations needed during implementation
+
+- Confirm whether deleting the FIFO-substitution comment leaves any
+  remaining behavior that depends on FIFO order for reasons unrelated to
+  heartbeat gen. If yes, keep a trimmed-down comment explaining the
+  remaining reason. If no, delete cleanly.
+- Audit any test that observed `gen == 0` on a dispatched heartbeat event —
+  those assertions invert under this change.

--- a/internal/metrics/wtp.go
+++ b/internal/metrics/wtp.go
@@ -638,10 +638,10 @@ const (
 	WTPInvalidFrameReasonSessionInitAlgorithmUnspec     WTPInvalidFrameReason = "session_init_algorithm_unspecified"
 	WTPInvalidFrameReasonPayloadTooLarge                WTPInvalidFrameReason = "payload_too_large"
 	WTPInvalidFrameReasonDecompressError                WTPInvalidFrameReason = "decompress_error"
-	WTPInvalidFrameReasonGoawayCodeUnspec          WTPInvalidFrameReason = "goaway_code_unspecified"
-	WTPInvalidFrameReasonHeartbeatGenerationInvalid WTPInvalidFrameReason = "heartbeat_generation_invalid"
+	WTPInvalidFrameReasonGoawayCodeUnspec               WTPInvalidFrameReason = "goaway_code_unspecified"
+	WTPInvalidFrameReasonHeartbeatGenerationInvalid     WTPInvalidFrameReason = "heartbeat_generation_invalid"
 	WTPInvalidFrameReasonSessionUpdateGenerationInvalid WTPInvalidFrameReason = "session_update_generation_invalid"
-	WTPInvalidFrameReasonPolicyPushInvalid         WTPInvalidFrameReason = "policy_push_invalid"
+	WTPInvalidFrameReasonPolicyPushInvalid              WTPInvalidFrameReason = "policy_push_invalid"
 	// WTPInvalidFrameReasonClassifierBypass is the metrics-only reason
 	// emitted by the receiver-side errors.As-false defense-in-depth
 	// guard AND by IncDroppedInvalidFrame's invalid-label collapse.
@@ -658,10 +658,10 @@ var wtpInvalidFrameReasonsValid = map[WTPInvalidFrameReason]struct{}{
 	WTPInvalidFrameReasonSessionInitAlgorithmUnspec:     {},
 	WTPInvalidFrameReasonPayloadTooLarge:                {},
 	WTPInvalidFrameReasonDecompressError:                {},
-	WTPInvalidFrameReasonGoawayCodeUnspec:          {},
-	WTPInvalidFrameReasonHeartbeatGenerationInvalid: {},
+	WTPInvalidFrameReasonGoawayCodeUnspec:               {},
+	WTPInvalidFrameReasonHeartbeatGenerationInvalid:     {},
 	WTPInvalidFrameReasonSessionUpdateGenerationInvalid: {},
-	WTPInvalidFrameReasonPolicyPushInvalid:         {},
+	WTPInvalidFrameReasonPolicyPushInvalid:              {},
 	WTPInvalidFrameReasonClassifierBypass:               {},
 	WTPInvalidFrameReasonUnknown:                        {},
 }

--- a/internal/metrics/wtp.go
+++ b/internal/metrics/wtp.go
@@ -639,6 +639,7 @@ const (
 	WTPInvalidFrameReasonPayloadTooLarge                WTPInvalidFrameReason = "payload_too_large"
 	WTPInvalidFrameReasonDecompressError                WTPInvalidFrameReason = "decompress_error"
 	WTPInvalidFrameReasonGoawayCodeUnspec          WTPInvalidFrameReason = "goaway_code_unspecified"
+	WTPInvalidFrameReasonHeartbeatGenerationInvalid WTPInvalidFrameReason = "heartbeat_generation_invalid"
 	WTPInvalidFrameReasonSessionUpdateGenerationInvalid WTPInvalidFrameReason = "session_update_generation_invalid"
 	WTPInvalidFrameReasonPolicyPushInvalid         WTPInvalidFrameReason = "policy_push_invalid"
 	// WTPInvalidFrameReasonClassifierBypass is the metrics-only reason
@@ -658,6 +659,7 @@ var wtpInvalidFrameReasonsValid = map[WTPInvalidFrameReason]struct{}{
 	WTPInvalidFrameReasonPayloadTooLarge:                {},
 	WTPInvalidFrameReasonDecompressError:                {},
 	WTPInvalidFrameReasonGoawayCodeUnspec:          {},
+	WTPInvalidFrameReasonHeartbeatGenerationInvalid: {},
 	WTPInvalidFrameReasonSessionUpdateGenerationInvalid: {},
 	WTPInvalidFrameReasonPolicyPushInvalid:         {},
 	WTPInvalidFrameReasonClassifierBypass:               {},
@@ -675,6 +677,7 @@ var wtpInvalidFrameReasonsEmitOrder = []WTPInvalidFrameReason{
 	WTPInvalidFrameReasonEventBatchCompressionMismatch,
 	WTPInvalidFrameReasonEventBatchCompressionUnspec,
 	WTPInvalidFrameReasonGoawayCodeUnspec,
+	WTPInvalidFrameReasonHeartbeatGenerationInvalid,
 	WTPInvalidFrameReasonPayloadTooLarge,
 	WTPInvalidFrameReasonPolicyPushInvalid,
 	WTPInvalidFrameReasonSessionInitAlgorithmUnspec,
@@ -696,6 +699,7 @@ var validationReasonsShared = []WTPInvalidFrameReason{
 	WTPInvalidFrameReasonSessionInitAlgorithmUnspec,
 	WTPInvalidFrameReasonPayloadTooLarge,
 	WTPInvalidFrameReasonGoawayCodeUnspec,
+	WTPInvalidFrameReasonHeartbeatGenerationInvalid,
 	WTPInvalidFrameReasonSessionUpdateGenerationInvalid,
 	WTPInvalidFrameReasonPolicyPushInvalid,
 	WTPInvalidFrameReasonUnknown,

--- a/internal/store/watchtower/transport/recv_multiplexer.go
+++ b/internal/store/watchtower/transport/recv_multiplexer.go
@@ -37,13 +37,10 @@ const (
 // pushes onto recvSession.eventCh. The kind discriminator selects the
 // dispatch on the main goroutine; gen/seq carry the ack tuple.
 //
-// Wire-ordering invariant (round-22 Finding 1, load-bearing): events on
-// eventCh are processed in strict FIFO order on the main goroutine. The
-// recv goroutine pushes them in receive order; the main goroutine
-// selects one at a time and runs applyAckFromRecv to completion before
-// pulling the next. The heartbeat-generation substitution rule (see
-// recvAckEventHeartbeat) depends on this invariant — any change to the
-// recv-event ordering MUST be reviewed against the substitution rule.
+// Wire-ordering invariant: events on eventCh are processed in strict
+// FIFO order on the main goroutine. The recv goroutine pushes them in
+// receive order; the main goroutine selects one at a time and runs
+// applyAckFromRecv to completion before pulling the next.
 type recvAckEvent struct {
 	kind recvAckEventKind
 	gen  uint32

--- a/internal/store/watchtower/transport/recv_multiplexer.go
+++ b/internal/store/watchtower/transport/recv_multiplexer.go
@@ -24,7 +24,8 @@ const (
 	// recvAckEventHeartbeat wraps a *wtpv1.ServerMessage_ServerHeartbeat
 	// demux. gen + seq are populated from the wire frame (issue #352);
 	// the discriminator distinguishes heartbeats from BatchAcks because
-	// state handlers apply different inflight/release semantics.
+	// state handlers apply different inflight/release semantics
+	// (state_live releases inflight on Adopted; state_replaying does not).
 	recvAckEventHeartbeat
 	// recvAckEventPolicyPush wraps a *wtpv1.ServerMessage_PolicyPush
 	// demux. gen + seq are unused (PolicyPush carries no ack tuple);
@@ -67,9 +68,9 @@ type recvAckEvent struct {
 type recvSession struct {
 	ctx      context.Context
 	cancelFn context.CancelFunc
-	// eventCh carries demuxed BatchAck and ServerHeartbeat events in
-	// strict wire order. Depth 4 absorbs steady-state burstiness; the
-	// recv goroutine blocks on send when the channel is full and
+	// eventCh carries demuxed BatchAck, ServerHeartbeat, and PolicyPush
+	// events in strict wire order. Depth 4 absorbs steady-state burstiness;
+	// the recv goroutine blocks on send when the channel is full and
 	// unblocks via ctx cancellation. Single-channel-FIFO design per
 	// round-22 Finding 1.
 	eventCh chan recvAckEvent

--- a/internal/store/watchtower/transport/recv_multiplexer.go
+++ b/internal/store/watchtower/transport/recv_multiplexer.go
@@ -22,13 +22,9 @@ const (
 	// gen + seq are populated from the wire frame.
 	recvAckEventBatchAck recvAckEventKind = iota + 1
 	// recvAckEventHeartbeat wraps a *wtpv1.ServerMessage_ServerHeartbeat
-	// demux. Only seq is populated from the wire frame; gen is zero
-	// because the proto carries no generation field. The main goroutine
-	// substitutes t.persistedAck.Generation at apply time — safe ONLY
-	// because strict FIFO order on eventCh guarantees any earlier
-	// BatchAck has already been processed (and may have advanced
-	// t.persistedAck.Generation) before this heartbeat reaches the
-	// dispatch site. See round-22 Finding 1.
+	// demux. gen + seq are populated from the wire frame (issue #352);
+	// the discriminator distinguishes heartbeats from BatchAcks because
+	// state handlers apply different inflight/release semantics.
 	recvAckEventHeartbeat
 	// recvAckEventPolicyPush wraps a *wtpv1.ServerMessage_PolicyPush
 	// demux. gen + seq are unused (PolicyPush carries no ack tuple);
@@ -272,9 +268,8 @@ func (t *Transport) runRecv(rs *recvSession) {
 			h := m.ServerHeartbeat
 			ev := recvAckEvent{
 				kind: recvAckEventHeartbeat,
-				// gen left zero; main substitutes t.persistedAck.Generation
-				// at apply time per the FIFO-order invariant.
-				seq: h.GetAckHighWatermarkSeq(),
+				gen:  h.GetGeneration(),
+				seq:  h.GetAckHighWatermarkSeq(),
 			}
 			select {
 			case rs.eventCh <- ev:

--- a/internal/store/watchtower/transport/recv_multiplexer_failclosed_test.go
+++ b/internal/store/watchtower/transport/recv_multiplexer_failclosed_test.go
@@ -486,5 +486,28 @@ func checkAttrBool(t *testing.T, attrs map[string]slog.Value, key string, want b
 	}
 }
 
+// TestRecvMultiplexer_FailClosedHeartbeatZeroGeneration verifies that a
+// ServerHeartbeat with generation=0 (an invalid v0.5 frame per issue
+// #352) is rejected by ValidateServerHeartbeat, drives the errCh
+// sentinel, and tears down the recv session. The frame is
+// schema-valid (the wire decoded cleanly) but semantically invalid —
+// classified as ReasonHeartbeatGenerationInvalid / ErrInvalidFrame.
+func TestRecvMultiplexer_FailClosedHeartbeatZeroGeneration(t *testing.T) {
+	fc := newRecvFakeConn()
+	tr, _ := newFailClosedTransport(t, fc, false)
+
+	msg := &wtpv1.ServerMessage{
+		Msg: &wtpv1.ServerMessage_ServerHeartbeat{
+			ServerHeartbeat: &wtpv1.ServerHeartbeat{
+				AckHighWatermarkSeq: 42,
+				// Generation deliberately omitted (zero value).
+			},
+		},
+	}
+	if err := driveFailClosed(t, tr, fc, msg); err == nil {
+		t.Fatal("expected errCh sentinel after fail-closed zero-gen heartbeat")
+	}
+}
+
 // silence unused-import linter if errors import drifts later.
 var _ = errors.New

--- a/internal/store/watchtower/transport/recv_multiplexer_integration_test.go
+++ b/internal/store/watchtower/transport/recv_multiplexer_integration_test.go
@@ -101,13 +101,14 @@ func recvBatchAck(gen uint32, seq uint64) *wtpv1.ServerMessage {
 }
 
 // recvHeartbeat is a one-line constructor for a ServerHeartbeat server
-// message. The proto carries no generation field; the recv multiplexer
-// substitutes t.persistedAck.Generation at apply time.
-func recvHeartbeat(seq uint64) *wtpv1.ServerMessage {
+// message. Generation is REQUIRED on the wire in WTP v0.5 (issue #352);
+// the recv multiplexer surfaces it directly without substitution.
+func recvHeartbeat(gen uint32, seq uint64) *wtpv1.ServerMessage {
 	return &wtpv1.ServerMessage{
 		Msg: &wtpv1.ServerMessage_ServerHeartbeat{
 			ServerHeartbeat: &wtpv1.ServerHeartbeat{
 				AckHighWatermarkSeq: seq,
+				Generation:          gen,
 			},
 		},
 	}
@@ -170,9 +171,9 @@ func TestRecvMultiplexer_PreservesWireOrderingAcrossBatchAckAndHeartbeat(t *test
 	defer transport.TeardownRecvForTest(tr)
 	defer fc.Close()
 
-	// Wire-order push: BatchAck(1, 100), HB(99), BatchAck(1, 200), HB(150).
-	// Heartbeats keep gen=0 on the wire (the multiplexer leaves it zero
-	// and substitutes at apply time on the main goroutine).
+	// Wire-order push: BatchAck(1, 100), HB(1, 99), BatchAck(1, 200), HB(1, 150).
+	// Per issue #352, ServerHeartbeat now carries generation on the wire;
+	// the multiplexer surfaces it directly without substitution.
 	pushSeq := []struct {
 		frame string
 		gen   uint32
@@ -180,9 +181,9 @@ func TestRecvMultiplexer_PreservesWireOrderingAcrossBatchAckAndHeartbeat(t *test
 		msg   *wtpv1.ServerMessage
 	}{
 		{"batch_ack", 1, 100, recvBatchAck(1, 100)},
-		{"server_heartbeat", 0, 99, recvHeartbeat(99)},
+		{"server_heartbeat", 1, 99, recvHeartbeat(1, 99)},
 		{"batch_ack", 1, 200, recvBatchAck(1, 200)},
-		{"server_heartbeat", 0, 150, recvHeartbeat(150)},
+		{"server_heartbeat", 1, 150, recvHeartbeat(1, 150)},
 	}
 	for _, p := range pushSeq {
 		fc.Push(p.msg)

--- a/internal/store/watchtower/transport/recv_multiplexer_test.go
+++ b/internal/store/watchtower/transport/recv_multiplexer_test.go
@@ -716,6 +716,28 @@ func TestRecvMultiplexer_BatchAckReturnsOutcomeKind(t *testing.T) {
 			t.Fatalf("Adopted heartbeat ack: got outcome %v, want AckOutcomeAdopted", got)
 		}
 	})
+
+	t.Run("Heartbeat_with_higher_gen_applies_wire_gen", func(t *testing.T) {
+		// Issue #352: ServerHeartbeat now carries generation on the
+		// wire. applyAckFromRecv MUST be driven with the wire gen, not
+		// the persisted gen — otherwise a heartbeat that follows a
+		// roll-up to gen+1 (where the BatchAck that advanced the
+		// generation was dropped) would be silently mis-applied at the
+		// old generation.
+		env := newClampTestEnv(t, Options{
+			InitialAckTuple: &AckTuple{Sequence: 50, Generation: 1, Present: true},
+		})
+		SetAckAnomalyLimiterForTest(env.tr, permissiveLimiter())
+		appendDataInGen(t, env.w, 1, 2, 100)
+
+		got := env.tr.applyAckFromRecv("server_heartbeat", 2, 80)
+		if got != AckOutcomeAdopted {
+			t.Fatalf("applyAckFromRecv outcome: got %v, want AckOutcomeAdopted", got)
+		}
+		if persisted := PersistedAckForTest(env.tr); persisted.Generation != 2 {
+			t.Fatalf("persistedAck.Generation: got %d, want 2 (cross-gen adopt)", persisted.Generation)
+		}
+	})
 }
 
 // silence unused import warnings for wal package; the wal package is needed

--- a/internal/store/watchtower/transport/state_live.go
+++ b/internal/store/watchtower/transport/state_live.go
@@ -239,6 +239,11 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 				// Medium round-4).
 				outcome := t.applyAckFromRecv("server_heartbeat", ev.gen, ev.seq)
 				if outcome == AckOutcomeAdopted {
+					// inflight.Release uses lexicographic (gen, seq) ordering
+					// (see inflight.go:38-42), so a wire-gen heartbeat with
+					// ev.gen > pending entries' gen correctly releases the
+					// older-gen entries; same-gen at or below seq follows the
+					// existing release contract.
 					inflight.Release(ev.gen, ev.seq)
 					if err := drainAvailable(); err != nil {
 						teardownForReconnect()

--- a/internal/store/watchtower/transport/state_live.go
+++ b/internal/store/watchtower/transport/state_live.go
@@ -231,20 +231,15 @@ func (t *Transport) runLive(ctx context.Context, rdr *wal.Reader, opts LiveOptio
 					}
 				}
 			case recvAckEventHeartbeat:
-				// Heartbeat carries no gen on the wire; FIFO order on
-				// eventCh guarantees any earlier BatchAck has already
-				// advanced t.persistedAck.Generation, so substituting
-				// here is safe (round-22 Finding 1 invariant).
-				//
 				// Heartbeats use the SAME ack clamp as BatchAck and
 				// may carry an ack advance when a BatchAck was
 				// missed (per spec). Release every covered batch on
 				// an Adopted heartbeat — otherwise the sender would
 				// wedge at MaxInflight until reconnect (roborev
 				// Medium round-4).
-				outcome := t.applyAckFromRecv("server_heartbeat", t.persistedAck.Generation, ev.seq)
+				outcome := t.applyAckFromRecv("server_heartbeat", ev.gen, ev.seq)
 				if outcome == AckOutcomeAdopted {
-					inflight.Release(t.persistedAck.Generation, ev.seq)
+					inflight.Release(ev.gen, ev.seq)
 					if err := drainAvailable(); err != nil {
 						teardownForReconnect()
 						return StateConnecting, err

--- a/internal/store/watchtower/transport/state_replaying.go
+++ b/internal/store/watchtower/transport/state_replaying.go
@@ -74,10 +74,11 @@ func (t *Transport) runReplaying(ctx context.Context, r *Replayer) (State, error
 			case recvAckEventBatchAck:
 				t.applyAckFromRecv("batch_ack", ev.gen, ev.seq)
 			case recvAckEventHeartbeat:
-				// Heartbeat carries no gen on the wire; FIFO order
-				// guarantees any earlier BatchAck has already
-				// advanced t.persistedAck.Generation.
-				t.applyAckFromRecv("server_heartbeat", t.persistedAck.Generation, ev.seq)
+				// Heartbeat carries gen on the wire (issue #352);
+				// pass it through directly. Unlike state_live, no
+				// inflight.Release here — runReplaying is draining,
+				// not sending.
+				t.applyAckFromRecv("server_heartbeat", ev.gen, ev.seq)
 			}
 		case err := <-recvErrCh:
 			t.opts.Logger.LogAttrs(context.Background(), slog.LevelWarn,

--- a/proto/canyonroad/wtp/v1/validate.go
+++ b/proto/canyonroad/wtp/v1/validate.go
@@ -78,6 +78,13 @@ const (
 	// generation per the WTP client design.
 	ReasonSessionUpdateGenerationInvalid ValidationReason = "session_update_generation_invalid"
 
+	// ReasonHeartbeatGenerationInvalid is returned by
+	// ValidateServerHeartbeat when the inbound ServerHeartbeat has
+	// generation == 0. Generation is REQUIRED in WTP v0.5 (issue #352);
+	// old v0.4.x servers that omit it are not interoperable with v0.5
+	// clients.
+	ReasonHeartbeatGenerationInvalid ValidationReason = "heartbeat_generation_invalid"
+
 	// ReasonPolicyPushInvalid is returned by ValidatePolicyPush when the
 	// inbound PolicyPush is nil, missing required fields, or contains
 	// invalid content hashes.
@@ -159,6 +166,7 @@ var allValidationReasons = []ValidationReason{
 	ReasonPayloadTooLarge,
 	ReasonGoawayCodeUnspecified,
 	ReasonSessionUpdateGenerationInvalid,
+	ReasonHeartbeatGenerationInvalid,
 	ReasonPolicyPushInvalid,
 	ReasonUnknown,
 }
@@ -363,9 +371,10 @@ func ValidateBatchAck(ack *BatchAck) error {
 	return nil
 }
 
-// ValidateServerHeartbeat rejects a nil ServerHeartbeat or one whose
-// generation is zero. Generation is REQUIRED in WTP v0.5 — old v0.4.x
-// servers that omit it are not interoperable with v0.5 clients (issue #352).
+// ValidateServerHeartbeat returns ReasonHeartbeatGenerationInvalid
+// when the inbound ServerHeartbeat has generation == 0 (issue #352:
+// generation is REQUIRED in WTP v0.5; old v0.4.x servers that omit it
+// are not interoperable with v0.5 clients). Returns ReasonUnknown for nil.
 func ValidateServerHeartbeat(hb *ServerHeartbeat) error {
 	if hb == nil {
 		return &ValidationError{
@@ -373,9 +382,9 @@ func ValidateServerHeartbeat(hb *ServerHeartbeat) error {
 			Inner:  fmt.Errorf("%w: server_heartbeat is nil", ErrInvalidFrame),
 		}
 	}
-	if hb.GetGeneration() == 0 {
+	if hb.Generation == 0 {
 		return &ValidationError{
-			Reason: ReasonUnknown,
+			Reason: ReasonHeartbeatGenerationInvalid,
 			Inner:  fmt.Errorf("%w: server_heartbeat.generation must be > 0", ErrInvalidFrame),
 		}
 	}

--- a/proto/canyonroad/wtp/v1/validate.go
+++ b/proto/canyonroad/wtp/v1/validate.go
@@ -363,13 +363,20 @@ func ValidateBatchAck(ack *BatchAck) error {
 	return nil
 }
 
-// ValidateServerHeartbeat rejects a nil ServerHeartbeat. No other
-// stateless invariants apply.
+// ValidateServerHeartbeat rejects a nil ServerHeartbeat or one whose
+// generation is zero. Generation is REQUIRED in WTP v0.5 — old v0.4.x
+// servers that omit it are not interoperable with v0.5 clients (issue #352).
 func ValidateServerHeartbeat(hb *ServerHeartbeat) error {
 	if hb == nil {
 		return &ValidationError{
 			Reason: ReasonUnknown,
 			Inner:  fmt.Errorf("%w: server_heartbeat is nil", ErrInvalidFrame),
+		}
+	}
+	if hb.GetGeneration() == 0 {
+		return &ValidationError{
+			Reason: ReasonUnknown,
+			Inner:  fmt.Errorf("%w: server_heartbeat.generation must be > 0", ErrInvalidFrame),
 		}
 	}
 	return nil

--- a/proto/canyonroad/wtp/v1/validate.go
+++ b/proto/canyonroad/wtp/v1/validate.go
@@ -81,8 +81,8 @@ const (
 	// ReasonHeartbeatGenerationInvalid is returned by
 	// ValidateServerHeartbeat when the inbound ServerHeartbeat has
 	// generation == 0. Generation is REQUIRED in WTP v0.5 (issue #352);
-	// old v0.4.x servers that omit it are not interoperable with v0.5
-	// clients.
+	// no prior server version emitted ServerHeartbeat, so there is no
+	// compat path for unset generation.
 	ReasonHeartbeatGenerationInvalid ValidationReason = "heartbeat_generation_invalid"
 
 	// ReasonPolicyPushInvalid is returned by ValidatePolicyPush when the
@@ -373,8 +373,9 @@ func ValidateBatchAck(ack *BatchAck) error {
 
 // ValidateServerHeartbeat returns ReasonHeartbeatGenerationInvalid
 // when the inbound ServerHeartbeat has generation == 0 (issue #352:
-// generation is REQUIRED in WTP v0.5; old v0.4.x servers that omit it
-// are not interoperable with v0.5 clients). Returns ReasonUnknown for nil.
+// generation is REQUIRED in WTP v0.5; no prior server version emitted
+// ServerHeartbeat, so there is no compat path for unset generation).
+// Returns ReasonUnknown for nil.
 func ValidateServerHeartbeat(hb *ServerHeartbeat) error {
 	if hb == nil {
 		return &ValidationError{

--- a/proto/canyonroad/wtp/v1/validate_reason_test.go
+++ b/proto/canyonroad/wtp/v1/validate_reason_test.go
@@ -170,6 +170,7 @@ func TestAllValidationReasons_ContainsCanonicalSet(t *testing.T) {
 		wtpv1.ReasonPayloadTooLarge:                  {},
 		wtpv1.ReasonGoawayCodeUnspecified:            {},
 		wtpv1.ReasonSessionUpdateGenerationInvalid:   {},
+		wtpv1.ReasonHeartbeatGenerationInvalid:       {},
 		wtpv1.ReasonPolicyPushInvalid:                {},
 		wtpv1.ReasonUnknown:                          {},
 	}

--- a/proto/canyonroad/wtp/v1/validate_test.go
+++ b/proto/canyonroad/wtp/v1/validate_test.go
@@ -231,8 +231,28 @@ func TestValidateServerHeartbeat_Nil(t *testing.T) {
 }
 
 func TestValidateServerHeartbeat_HappyPath(t *testing.T) {
-	if err := ValidateServerHeartbeat(&ServerHeartbeat{AckHighWatermarkSeq: 42}); err != nil {
+	if err := ValidateServerHeartbeat(&ServerHeartbeat{
+		AckHighWatermarkSeq: 42,
+		Generation:          1,
+	}); err != nil {
 		t.Errorf("ValidateServerHeartbeat: %v", err)
+	}
+}
+
+func TestValidateServerHeartbeat_ZeroGeneration(t *testing.T) {
+	err := ValidateServerHeartbeat(&ServerHeartbeat{
+		AckHighWatermarkSeq: 42,
+		Generation:          0,
+	})
+	if err == nil {
+		t.Fatal("ValidateServerHeartbeat(gen=0): want error, got nil")
+	}
+	var ve *ValidationError
+	if !errors.As(err, &ve) || ve.Reason != ReasonUnknown {
+		t.Fatalf("err = %v; want *ValidationError with Reason=%q", err, ReasonUnknown)
+	}
+	if !errors.Is(err, ErrInvalidFrame) {
+		t.Fatalf("err = %v; want errors.Is(ErrInvalidFrame) true", err)
 	}
 }
 

--- a/proto/canyonroad/wtp/v1/validate_test.go
+++ b/proto/canyonroad/wtp/v1/validate_test.go
@@ -248,8 +248,8 @@ func TestValidateServerHeartbeat_ZeroGeneration(t *testing.T) {
 		t.Fatal("ValidateServerHeartbeat(gen=0): want error, got nil")
 	}
 	var ve *ValidationError
-	if !errors.As(err, &ve) || ve.Reason != ReasonUnknown {
-		t.Fatalf("err = %v; want *ValidationError with Reason=%q", err, ReasonUnknown)
+	if !errors.As(err, &ve) || ve.Reason != ReasonHeartbeatGenerationInvalid {
+		t.Fatalf("err = %v; want *ValidationError with Reason=%q", err, ReasonHeartbeatGenerationInvalid)
 	}
 	if !errors.Is(err, ErrInvalidFrame) {
 		t.Fatalf("err = %v; want errors.Is(ErrInvalidFrame) true", err)

--- a/proto/canyonroad/wtp/v1/wtp.pb.go
+++ b/proto/canyonroad/wtp/v1/wtp.pb.go
@@ -1450,6 +1450,7 @@ func (x *Heartbeat) GetGeneration() uint32 {
 type ServerHeartbeat struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	AckHighWatermarkSeq uint64                 `protobuf:"varint,1,opt,name=ack_high_watermark_seq,json=ackHighWatermarkSeq,proto3" json:"ack_high_watermark_seq,omitempty"`
+	Generation          uint32                 `protobuf:"varint,2,opt,name=generation,proto3" json:"generation,omitempty"`
 	unknownFields       protoimpl.UnknownFields
 	sizeCache           protoimpl.SizeCache
 }
@@ -1487,6 +1488,13 @@ func (*ServerHeartbeat) Descriptor() ([]byte, []int) {
 func (x *ServerHeartbeat) GetAckHighWatermarkSeq() uint64 {
 	if x != nil {
 		return x.AckHighWatermarkSeq
+	}
+	return 0
+}
+
+func (x *ServerHeartbeat) GetGeneration() uint32 {
+	if x != nil {
+		return x.Generation
 	}
 	return 0
 }
@@ -1837,9 +1845,12 @@ const file_canyonroad_wtp_v1_wtp_proto_rawDesc = "" +
 	"\x16wal_high_watermark_seq\x18\x01 \x01(\x04R\x13walHighWatermarkSeq\x12\x1e\n" +
 	"\n" +
 	"generation\x18\x02 \x01(\rR\n" +
-	"generation\"F\n" +
+	"generation\"f\n" +
 	"\x0fServerHeartbeat\x123\n" +
-	"\x16ack_high_watermark_seq\x18\x01 \x01(\x04R\x13ackHighWatermarkSeq\"_\n" +
+	"\x16ack_high_watermark_seq\x18\x01 \x01(\x04R\x13ackHighWatermarkSeq\x12\x1e\n" +
+	"\n" +
+	"generation\x18\x02 \x01(\rR\n" +
+	"generation\"_\n" +
 	"\bBatchAck\x123\n" +
 	"\x16ack_high_watermark_seq\x18\x01 \x01(\x04R\x13ackHighWatermarkSeq\x12\x1e\n" +
 	"\n" +

--- a/proto/canyonroad/wtp/v1/wtp.proto
+++ b/proto/canyonroad/wtp/v1/wtp.proto
@@ -183,6 +183,7 @@ message Heartbeat {
 
 message ServerHeartbeat {
   uint64 ack_high_watermark_seq = 1;
+  uint32 generation             = 2;
 }
 
 message BatchAck {


### PR DESCRIPTION
## Summary

Closes #352. Adds `generation` to the `ServerHeartbeat` wire frame and removes the FIFO-order substitution workaround in the recv multiplexer.

- Proto: `uint32 generation = 2` on `ServerHeartbeat`
- Validator: dedicated `ReasonHeartbeatGenerationInvalid`; rejects `generation == 0` (no v0.4.x compat — no prior server emits `ServerHeartbeat`)
- Recv multiplexer: surfaces `ev.gen` from the wire frame; deletes the heartbeat-substitution rationale
- `state_live` + `state_replaying`: switch from `t.persistedAck.Generation` substitution to `ev.gen` (state_live's `inflight.Release` also flips to wire gen — documented at the call site)
- Metrics: register `WTPInvalidFrameReasonHeartbeatGenerationInvalid` to keep the validator↔metrics parity test green
- Tests: validator zero-gen rejection, integration test asserts wire gen propagates, cross-gen unit test for `applyAckFromRecv`, fail-closed regression for `gen == 0`

Design spec: `docs/superpowers/specs/2026-05-22-issue-352-wtp-heartbeat-generation-design.md`
Implementation plan: `docs/superpowers/plans/2026-05-22-issue-352-wtp-heartbeat-generation.md`

## Test plan

- [x] `go build ./...`
- [x] `GOOS=windows go build ./...`
- [x] `go test ./proto/canyonroad/wtp/v1/...`
- [x] `go test ./internal/store/watchtower/transport/...`
- [x] `go test ./internal/metrics/...`
- [x] `go test ./...` (sole failure is `TestFUSE_FsyncFlushLseekPassthrough` — pre-existing FUSE-mount permission-denied in `internal/fsmonitor`, unrelated subsystem)
- [x] roborev branch review × 5 cycles, final clean ("No issues found")

🤖 Generated with [Claude Code](https://claude.com/claude-code)