### PR TITLE
fix(#369): WAIT_KILLABLE_RECV behavioral probe + operator override

### DIFF
--- a/cmd/agentsh-unixwrap/config.go
+++ b/cmd/agentsh-unixwrap/config.go
@@ -25,6 +25,13 @@ type WrapperConfig struct {
 	WriteOnlyOpens    bool `json:"write_only_opens,omitempty"`
 	BlockIOUring      bool `json:"block_io_uring,omitempty"`
 
+	// WaitKillable, when non-nil, forces SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
+	// on or off, bypassing the wrapper's legacy kernel-version probe. The
+	// server makes this decision (boot-time behavioral probe + optional
+	// config override) and forwards the result; nil means "fall back to
+	// ProbeWaitKillable()" for direct/test invocations. Issue #369.
+	WaitKillable *bool `json:"wait_killable,omitempty"`
+
 	// Landlock filesystem restrictions
 	LandlockEnabled bool     `json:"landlock_enabled,omitempty"`
 	LandlockABI     int      `json:"landlock_abi,omitempty"`

--- a/cmd/agentsh-unixwrap/config.go
+++ b/cmd/agentsh-unixwrap/config.go
@@ -32,6 +32,13 @@ type WrapperConfig struct {
 	// ProbeWaitKillable()" for direct/test invocations. Issue #369.
 	WaitKillable *bool `json:"wait_killable,omitempty"`
 
+	// WaitKillableSource records why WaitKillable was chosen
+	// ("config", "kernel_unsupported", "filter_composition_safe",
+	// "behavioral_probe", "behavioral_probe_error"). Forwarded into the
+	// per-exec "seccomp: filter loaded" log line so a single grep tells
+	// an operator why this exec saw a given flag value. Issue #369.
+	WaitKillableSource string `json:"wait_killable_source,omitempty"`
+
 	// Landlock filesystem restrictions
 	LandlockEnabled bool     `json:"landlock_enabled,omitempty"`
 	LandlockABI     int      `json:"landlock_abi,omitempty"`

--- a/cmd/agentsh-unixwrap/config_test.go
+++ b/cmd/agentsh-unixwrap/config_test.go
@@ -118,4 +118,31 @@ func TestWrapperConfig_WaitKillable_JSON(t *testing.T) {
 	}
 }
 
+// TestWrapperConfig_WaitKillableSource_JSON covers the diagnostic source
+// string the server forwards alongside the WaitKillable bool. Issue #369.
+func TestWrapperConfig_WaitKillableSource_JSON(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+		want string
+	}{
+		{name: "absent", json: `{"unix_socket_enabled":true}`, want: ""},
+		{name: "behavioral_probe", json: `{"unix_socket_enabled":true,"wait_killable_source":"behavioral_probe"}`, want: "behavioral_probe"},
+		{name: "config", json: `{"unix_socket_enabled":true,"wait_killable_source":"config"}`, want: "config"},
+		{name: "kernel_unsupported", json: `{"unix_socket_enabled":true,"wait_killable_source":"kernel_unsupported"}`, want: "kernel_unsupported"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AGENTSH_SECCOMP_CONFIG", tc.json)
+			cfg, err := loadConfig()
+			if err != nil {
+				t.Fatalf("loadConfig: %v", err)
+			}
+			if cfg.WaitKillableSource != tc.want {
+				t.Fatalf("want %q got %q", tc.want, cfg.WaitKillableSource)
+			}
+		})
+	}
+}
+
 func boolPtr(v bool) *bool { return &v }

--- a/cmd/agentsh-unixwrap/config_test.go
+++ b/cmd/agentsh-unixwrap/config_test.go
@@ -88,3 +88,34 @@ func TestParseConfigJSON_OnBlock(t *testing.T) {
 		})
 	}
 }
+
+func TestWrapperConfig_WaitKillable_JSON(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+		want *bool
+	}{
+		{name: "absent", json: `{"unix_socket_enabled":true}`, want: nil},
+		{name: "true", json: `{"unix_socket_enabled":true,"wait_killable":true}`, want: boolPtr(true)},
+		{name: "false", json: `{"unix_socket_enabled":true,"wait_killable":false}`, want: boolPtr(false)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AGENTSH_SECCOMP_CONFIG", tc.json)
+			cfg, err := loadConfig()
+			if err != nil {
+				t.Fatalf("loadConfig: %v", err)
+			}
+			switch {
+			case tc.want == nil && cfg.WaitKillable != nil:
+				t.Fatalf("want nil, got &%v", *cfg.WaitKillable)
+			case tc.want != nil && cfg.WaitKillable == nil:
+				t.Fatalf("want &%v, got nil", *tc.want)
+			case tc.want != nil && *cfg.WaitKillable != *tc.want:
+				t.Fatalf("want %v got %v", *tc.want, *cfg.WaitKillable)
+			}
+		})
+	}
+}
+
+func boolPtr(v bool) *bool { return &v }

--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -108,6 +108,7 @@ func main() {
 		SocketRules:        cfg.SocketRules,
 		OnBlockAction:      onBlock,
 		WaitKillable:       cfg.WaitKillable,
+		WaitKillableSource: cfg.WaitKillableSource,
 	}
 
 	// Install seccomp filter.

--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -107,6 +107,7 @@ func main() {
 		BlockedFamilies:    cfg.BlockedFamilies,
 		SocketRules:        cfg.SocketRules,
 		OnBlockAction:      onBlock,
+		WaitKillable:       cfg.WaitKillable,
 	}
 
 	// Install seccomp filter.

--- a/docs/superpowers/plans/2026-05-22-issue-369-wait-killable-recv-fix.md
+++ b/docs/superpowers/plans/2026-05-22-issue-369-wait-killable-recv-fix.md
@@ -1,0 +1,1828 @@
+# Issue #369 — WAIT_KILLABLE_RECV Behavioral Probe Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace `ProbeWaitKillable` (uname version check) with a server-side behavioral probe and an operator override (`sandbox.seccomp.wait_killable`), so wrapped commands stop being killed on exe.dev-class kernels where the kernel-version probe lies.
+
+**Architecture:** Server decides once at boot via a four-branch switch (config override → kernel<6 → safe composition → behavioral probe), memoizes the result, and passes it to every wrapper through the existing `AGENTSH_SECCOMP_CONFIG` env var. Wrapper consumes the bool and feeds it into `InstallFilterWithConfig`. Spec at `docs/superpowers/specs/2026-05-22-issue-369-wait-killable-recv-fix-design.md`.
+
+**Tech Stack:** Go 1.x, `golang.org/x/sys/unix`, `github.com/seccomp/libseccomp-golang`, `slog`.
+
+---
+
+## Standing rules for every task
+
+- **TDD discipline:** failing test → run test (verify fails) → implementation → run test (verify passes) → commit.
+- **Cross-compile check** after any code change: `GOOS=windows go build ./...` must succeed (CLAUDE.md requirement).
+- **After every commit, run `roborev-refine`** on the current branch. Fix every issue at severity above `low`. Iterate until only `low` issues remain or returns are diminishing, *then* move to the next task. The memory `feedback_roborev_between_tasks.md` is the source of truth for this rule.
+- **Conventional commit subjects** scoped by area (`feat(config):`, `feat(seccomp):`, `test(...):`).
+
+## File map
+
+| File | New/Modify | Responsibility |
+|---|---|---|
+| `internal/config/config.go` | Modify (line 489-507) | Add `SandboxSeccompConfig.WaitKillable *bool` |
+| `internal/config/seccomp_wait_killable.go` | **New** | Pure heuristic `WaitKillableFilterCompositionTriggersBug` |
+| `internal/config/seccomp_wait_killable_test.go` | **New** | Heuristic table test |
+| `internal/api/seccomp_wrapper_config.go` | Modify (line 15-43) | Add `seccompWrapperConfig.WaitKillable *bool` + serializer wires `&a.waitKillableDecision` |
+| `internal/api/seccomp_wrapper_test.go` | Modify | Assert JSON round-trip preserves `nil`/`&true`/`&false` |
+| `cmd/agentsh-unixwrap/config.go` | Modify (line 14-41) | Add `WrapperConfig.WaitKillable *bool` |
+| `cmd/agentsh-unixwrap/config_test.go` | Modify | Assert wrapper-side JSON parse for all three values |
+| `cmd/agentsh-unixwrap/main.go` | Modify (line 99-110) | Wire `cfg.WaitKillable` → `filterCfg.WaitKillable` |
+| `internal/netmonitor/unix/seccomp_linux.go` | Modify (lines 243-254, 303) | Add `FilterConfig.WaitKillable *bool`; consult it before falling back to `ProbeWaitKillable()` |
+| `internal/netmonitor/unix/seccomp_linux_test.go` | Modify | Assert override behavior via `loadFilterSyscall` injection seam |
+| `internal/netmonitor/unix/wait_killable_probe_linux.go` | **New** | `ProbeWaitKillableBehavior(ctx, iterations)` + per-iteration runner |
+| `internal/netmonitor/unix/wait_killable_probe_stub.go` | **New** | Non-Linux stub returns `(false, nil)` |
+| `internal/netmonitor/unix/wait_killable_probe_linux_test.go` | **New** | Mocked-runner unit + real-Linux integration |
+| `internal/api/wait_killable_decision.go` | **New** | Pure switch over (config, kernel, composition, probe) → `(bool, string)` — testable on every platform |
+| `internal/api/wait_killable_decision_test.go` | **New** | Seven-row table test of the switch |
+| `internal/api/app.go` | Modify (lines 49-112, 162-178) | Add `waitKillableDecision bool` + `waitKillableSource string` fields; populate in `NewApp` via `decideWaitKillable` |
+| `internal/netmonitor/unix/sigurg_probe_test.go` | Modify | Add sub-test asserting operator override flows end-to-end |
+
+---
+
+### Task 1: Add the `WaitKillable *bool` field to `SandboxSeccompConfig`
+
+**Files:**
+- Modify: `internal/config/config.go:489-507`
+
+- [ ] **Step 1: Add the field**
+
+Open `internal/config/config.go`. Locate the `SandboxSeccompConfig` struct around line 489 and insert the new field after `MitigationDirs`:
+
+```go
+type SandboxSeccompConfig struct {
+	Enabled     bool                            `yaml:"enabled"`
+	Mode        string                          `yaml:"mode"`
+	UnixSocket  SandboxSeccompUnixConfig        `yaml:"unix_socket"`
+	Syscalls    SandboxSeccompSyscallConfig     `yaml:"syscalls"`
+	Execve      ExecveConfig                    `yaml:"execve"`
+	FileMonitor SandboxSeccompFileMonitorConfig `yaml:"file_monitor"`
+
+	BlockedSocketFamilies []SandboxSeccompSocketFamilyConfig `yaml:"blocked_socket_families"`
+	SocketRules           []SandboxSeccompSocketRuleConfig   `yaml:"socket_rules"`
+	MitigationSets        []string                           `yaml:"mitigation_sets"`
+	MitigationDirs        []string                           `yaml:"mitigation_dirs"`
+
+	// WaitKillable tri-states SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV:
+	//   nil   = auto-detect via boot-time behavioral probe
+	//   &true = force on (skip probe)
+	//   &false = force off (skip probe)
+	// Issue #369: kernels >=6 may accept the flag and then misbehave when
+	// the filter combines socket-family and file/metadata-family notify rules.
+	WaitKillable *bool `yaml:"wait_killable"`
+}
+```
+
+- [ ] **Step 2: Verify the project still builds and tests pass**
+
+Run: `go build ./... && GOOS=windows go build ./... && go test ./internal/config/... -count=1`
+Expected: PASS on both builds and the config-package test suite.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/config/config.go
+git commit -m "feat(config): add sandbox.seccomp.wait_killable tri-state knob
+
+Pure field addition for issue #369. No callers yet — wired in later
+tasks. Nil = auto-detect via behavioral probe; non-nil = operator override."
+```
+
+- [ ] **Step 4: Run roborev-refine and clear non-low issues**
+
+Use the `roborev-refine` skill on the current branch. Fix every issue at severity above `low`. Stop only when remaining findings are all `low` or returns are diminishing.
+
+---
+
+### Task 2: Pure filter-composition heuristic
+
+**Files:**
+- Create: `internal/config/seccomp_wait_killable.go`
+- Create: `internal/config/seccomp_wait_killable_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/config/seccomp_wait_killable_test.go`:
+
+```go
+package config
+
+import (
+	"testing"
+)
+
+func TestWaitKillableFilterCompositionTriggersBug(t *testing.T) {
+	tt := boolPtr(true)
+	ff := boolPtr(false)
+
+	cases := []struct {
+		name string
+		cfg  SandboxSeccompConfig
+		want bool
+	}{
+		{
+			name: "all off",
+			cfg:  SandboxSeccompConfig{},
+			want: false,
+		},
+		{
+			name: "only socket family",
+			cfg: SandboxSeccompConfig{
+				UnixSocket: SandboxSeccompUnixConfig{Enabled: true},
+			},
+			want: false,
+		},
+		{
+			name: "only file_monitor",
+			cfg: SandboxSeccompConfig{
+				FileMonitor: SandboxSeccompFileMonitorConfig{Enabled: tt},
+			},
+			want: false,
+		},
+		{
+			name: "socket + file_monitor explicit on",
+			cfg: SandboxSeccompConfig{
+				UnixSocket:  SandboxSeccompUnixConfig{Enabled: true},
+				FileMonitor: SandboxSeccompFileMonitorConfig{Enabled: tt},
+			},
+			want: true,
+		},
+		{
+			name: "socket + file_monitor disabled but enforce_without_fuse on (intercept_metadata defaults true)",
+			cfg: SandboxSeccompConfig{
+				UnixSocket: SandboxSeccompUnixConfig{Enabled: true},
+				FileMonitor: SandboxSeccompFileMonitorConfig{
+					Enabled:            ff,
+					EnforceWithoutFUSE: tt,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "socket + file_monitor disabled, enforce_without_fuse on, intercept_metadata explicitly off",
+			cfg: SandboxSeccompConfig{
+				UnixSocket: SandboxSeccompUnixConfig{Enabled: true},
+				FileMonitor: SandboxSeccompFileMonitorConfig{
+					Enabled:            ff,
+					EnforceWithoutFUSE: tt,
+					InterceptMetadata:  ff,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "socket + intercept_metadata explicit on, file_monitor explicit off",
+			cfg: SandboxSeccompConfig{
+				UnixSocket: SandboxSeccompUnixConfig{Enabled: true},
+				FileMonitor: SandboxSeccompFileMonitorConfig{
+					Enabled:           ff,
+					InterceptMetadata: tt,
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := WaitKillableFilterCompositionTriggersBug(tc.cfg)
+			if got != tc.want {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Verify test fails**
+
+Run: `go test ./internal/config/ -run TestWaitKillableFilterCompositionTriggersBug -count=1`
+Expected: FAIL — `WaitKillableFilterCompositionTriggersBug` undefined.
+
+- [ ] **Step 3: Implement the heuristic**
+
+Create `internal/config/seccomp_wait_killable.go`:
+
+```go
+package config
+
+// WaitKillableFilterCompositionTriggersBug returns true when the effective
+// seccomp filter for the given config would install notify rules from both
+// the socket family (unix_socket) AND the file/metadata family
+// (file_monitor or intercept_metadata). This is the known-bad combination
+// from issue #369: on kernels that lie about WAIT_KILLABLE_RECV support
+// (e.g. 6.12.67 with ProcessVMReadv=ENOSYS), the wrapped process is killed
+// by signal during the post-execve syscall storm when this combination is
+// present together with WAIT_KILLABLE_RECV.
+//
+// The function operates on effective config (resolving FileMonitor.*
+// defaults exactly as buildSeccompWrapperConfig does) so that the gotcha
+// in the issue's bisection table — file_monitor.enabled=false with
+// enforce_without_fuse=true still installs metadata notify rules — is
+// caught correctly.
+func WaitKillableFilterCompositionTriggersBug(cfg SandboxSeccompConfig) bool {
+	socketFamily := cfg.UnixSocket.Enabled
+
+	fmDefault := FileMonitorBoolWithDefault(cfg.FileMonitor.EnforceWithoutFUSE, false)
+	fileFamily := FileMonitorBoolWithDefault(cfg.FileMonitor.Enabled, false) ||
+		FileMonitorBoolWithDefault(cfg.FileMonitor.InterceptMetadata, fmDefault)
+
+	return socketFamily && fileFamily
+}
+```
+
+- [ ] **Step 4: Verify test passes**
+
+Run: `go test ./internal/config/ -run TestWaitKillableFilterCompositionTriggersBug -count=1 -v`
+Expected: PASS — all 7 sub-cases.
+
+- [ ] **Step 5: Cross-compile + full config-package test**
+
+Run: `GOOS=windows go build ./... && go test ./internal/config/... -count=1`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/seccomp_wait_killable.go internal/config/seccomp_wait_killable_test.go
+git commit -m "feat(config): heuristic for WAIT_KILLABLE_RECV trigger composition
+
+Pure function: returns true when the effective seccomp filter would
+combine socket-family and file/metadata-family notify rules. Operates
+on resolved defaults so that EnforceWithoutFUSE=true is correctly
+detected as a file-family trigger even when file_monitor.enabled=false.
+
+Issue #369."
+```
+
+- [ ] **Step 7: Run roborev-refine and clear non-low issues.**
+
+---
+
+### Task 3: Wrapper-side JSON field
+
+**Files:**
+- Modify: `cmd/agentsh-unixwrap/config.go:14-41`
+- Modify: `cmd/agentsh-unixwrap/config_test.go`
+
+- [ ] **Step 1: Add the field to `WrapperConfig`**
+
+Open `cmd/agentsh-unixwrap/config.go`. Inside `WrapperConfig`, after `BlockIOUring`:
+
+```go
+	BlockIOUring      bool `json:"block_io_uring,omitempty"`
+
+	// WaitKillable, when non-nil, forces SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
+	// on or off, bypassing the wrapper's legacy kernel-version probe. The
+	// server makes this decision (boot-time behavioral probe + optional
+	// config override) and forwards the result; nil means "fall back to
+	// ProbeWaitKillable()" for direct/test invocations. Issue #369.
+	WaitKillable *bool `json:"wait_killable,omitempty"`
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `cmd/agentsh-unixwrap/config_test.go`:
+
+```go
+func TestWrapperConfig_WaitKillable_JSON(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+		want *bool
+	}{
+		{name: "absent", json: `{"unix_socket_enabled":true}`, want: nil},
+		{name: "true", json: `{"unix_socket_enabled":true,"wait_killable":true}`, want: boolPtr(true)},
+		{name: "false", json: `{"unix_socket_enabled":true,"wait_killable":false}`, want: boolPtr(false)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("AGENTSH_SECCOMP_CONFIG", tc.json)
+			cfg, err := loadConfig()
+			if err != nil {
+				t.Fatalf("loadConfig: %v", err)
+			}
+			switch {
+			case tc.want == nil && cfg.WaitKillable != nil:
+				t.Fatalf("want nil, got &%v", *cfg.WaitKillable)
+			case tc.want != nil && cfg.WaitKillable == nil:
+				t.Fatalf("want &%v, got nil", *tc.want)
+			case tc.want != nil && *cfg.WaitKillable != *tc.want:
+				t.Fatalf("want %v got %v", *tc.want, *cfg.WaitKillable)
+			}
+		})
+	}
+}
+
+func boolPtr(v bool) *bool { return &v }
+```
+
+If `boolPtr` already exists in the test file, drop the helper at the end.
+
+- [ ] **Step 3: Run the test**
+
+Run: `go test ./cmd/agentsh-unixwrap/ -run TestWrapperConfig_WaitKillable_JSON -count=1 -v`
+Expected: PASS — the JSON tag was already added in Step 1, so all three sub-cases pass.
+
+- [ ] **Step 4: Cross-compile**
+
+Run: `GOOS=windows go build ./...`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/agentsh-unixwrap/config.go cmd/agentsh-unixwrap/config_test.go
+git commit -m "feat(unixwrap): accept wait_killable in AGENTSH_SECCOMP_CONFIG
+
+Tri-state passthrough from server's wait_killable decision. Nil means
+'wrapper falls back to legacy probe' for direct/test invocations.
+
+Issue #369."
+```
+
+- [ ] **Step 6: Run roborev-refine and clear non-low issues.**
+
+---
+
+### Task 4: Server-side JSON field
+
+**Files:**
+- Modify: `internal/api/seccomp_wrapper_config.go:15-43`
+- Modify: `internal/api/seccomp_wrapper_test.go`
+
+- [ ] **Step 1: Add the field to `seccompWrapperConfig`**
+
+In `internal/api/seccomp_wrapper_config.go`, add after `BlockIOUring`:
+
+```go
+	BlockIOUring      bool `json:"block_io_uring,omitempty"`
+
+	// WaitKillable forwards the server's wait_killable decision to the
+	// wrapper. nil only if the App somehow has no decision set (treated as
+	// "wrapper falls back to legacy probe"). Issue #369.
+	WaitKillable *bool `json:"wait_killable,omitempty"`
+```
+
+- [ ] **Step 2: Don't wire it into `buildSeccompWrapperConfig` yet**
+
+The App-level `waitKillableDecision` field doesn't exist yet (Task 8). Leave the serializer-side field present but unset; verify it serializes as omitted.
+
+- [ ] **Step 3: Append a JSON round-trip test**
+
+Append to `internal/api/seccomp_wrapper_test.go`:
+
+```go
+func TestSeccompWrapperConfig_WaitKillable_JSON(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          *bool
+		wantSubstr  string
+		wantAbsent  bool
+	}{
+		{name: "absent", in: nil, wantAbsent: true},
+		{name: "true", in: boolPtrLocal(true), wantSubstr: `"wait_killable":true`},
+		{name: "false", in: boolPtrLocal(false), wantSubstr: `"wait_killable":false`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := seccompWrapperConfig{WaitKillable: tc.in}
+			b, err := json.Marshal(cfg)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			s := string(b)
+			if tc.wantAbsent && strings.Contains(s, "wait_killable") {
+				t.Fatalf("expected wait_killable to be omitted, got %s", s)
+			}
+			if !tc.wantAbsent && !strings.Contains(s, tc.wantSubstr) {
+				t.Fatalf("expected %q in %s", tc.wantSubstr, s)
+			}
+		})
+	}
+}
+
+func boolPtrLocal(v bool) *bool { return &v }
+```
+
+Add `encoding/json` and `strings` imports at the top of the file if not already present.
+
+- [ ] **Step 4: Run the test**
+
+Run: `go test ./internal/api/ -run TestSeccompWrapperConfig_WaitKillable_JSON -count=1 -v`
+Expected: PASS.
+
+- [ ] **Step 5: Cross-compile + package test**
+
+Run: `GOOS=windows go build ./... && go test ./internal/api/... -count=1`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/api/seccomp_wrapper_config.go internal/api/seccomp_wrapper_test.go
+git commit -m "feat(api): serialize wait_killable into AGENTSH_SECCOMP_CONFIG
+
+Field added now; wired to the App-level decision in a later task.
+
+Issue #369."
+```
+
+- [ ] **Step 7: Run roborev-refine and clear non-low issues.**
+
+---
+
+### Task 5: `FilterConfig.WaitKillable` + override in `InstallFilterWithConfig`
+
+**Files:**
+- Modify: `internal/netmonitor/unix/seccomp_linux.go:243-254, 303`
+- Modify: `internal/netmonitor/unix/seccomp_linux_test.go`
+- Modify: `cmd/agentsh-unixwrap/main.go:99-110`
+
+- [ ] **Step 1: Write the failing test**
+
+Open `internal/netmonitor/unix/seccomp_linux_test.go`. There's an existing pattern that uses the `loadFilterSyscall` seam (see `seccomp_retry_test.go` for inspiration). Add a new test:
+
+```go
+// TestInstallFilterWithConfig_WaitKillableOverride asserts that
+// FilterConfig.WaitKillable, when non-nil, controls the
+// SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV bit on the seccomp(2) flags
+// argument regardless of host kernel support.
+//
+// Issue #369: the operator override path must not be subordinate to the
+// kernel-version probe.
+func TestInstallFilterWithConfig_WaitKillableOverride(t *testing.T) {
+	bt := true
+	bf := false
+	cases := []struct {
+		name      string
+		cfgValue  *bool
+		wantFlag  bool
+	}{
+		{name: "explicit true", cfgValue: &bt, wantFlag: true},
+		{name: "explicit false", cfgValue: &bf, wantFlag: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			origLoad := loadFilterSyscall
+			origPrctl := prctlSetNoNewPrivs
+			t.Cleanup(func() {
+				loadFilterSyscall = origLoad
+				prctlSetNoNewPrivs = origPrctl
+			})
+
+			var capturedFlags uintptr
+			loadFilterSyscall = func(flags uintptr, _ *unix.SockFprog) (int, error) {
+				capturedFlags = flags
+				return 99, nil // pretend success, fd=99
+			}
+			prctlSetNoNewPrivs = func() error { return nil }
+
+			cfg := FilterConfig{
+				UnixSocketEnabled: true,
+				WaitKillable:      tc.cfgValue,
+			}
+			_, err := InstallFilterWithConfig(cfg)
+			if err != nil {
+				t.Fatalf("install: %v", err)
+			}
+			gotFlag := capturedFlags&unix.SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV != 0
+			if gotFlag != tc.wantFlag {
+				t.Fatalf("WAIT_KILLABLE_RECV bit: got %v want %v (flags=0x%x)",
+					gotFlag, tc.wantFlag, capturedFlags)
+			}
+		})
+	}
+}
+```
+
+Imports needed at the top of the file: `golang.org/x/sys/unix`. Already imported in `seccomp_load_linux.go`; verify the test file imports it too.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/netmonitor/unix/ -run TestInstallFilterWithConfig_WaitKillableOverride -count=1 -v`
+Expected: FAIL — `FilterConfig.WaitKillable` is not yet a field.
+
+- [ ] **Step 3: Add the field**
+
+In `internal/netmonitor/unix/seccomp_linux.go`, modify `FilterConfig` (around line 243):
+
+```go
+type FilterConfig struct {
+	UnixSocketEnabled  bool
+	ExecveEnabled      bool
+	FileMonitorEnabled bool
+	InterceptMetadata  bool
+	WriteOnlyOpens     bool
+	BlockIOUring       bool
+	BlockedSyscalls    []int
+	BlockedFamilies    []seccompkg.BlockedFamily
+	SocketRules        []seccompkg.SocketRule
+	OnBlockAction      seccompkg.OnBlockAction
+
+	// WaitKillable, when non-nil, overrides the legacy kernel-version
+	// probe for SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. Nil keeps the
+	// legacy ProbeWaitKillable() fallback for direct/test invocations
+	// where the server hasn't computed a decision. Issue #369.
+	WaitKillable *bool
+}
+```
+
+- [ ] **Step 4: Honor it inside `InstallFilterWithConfig`**
+
+In the same file, replace line 303 (`wantWaitKill := ProbeWaitKillable()`) with:
+
+```go
+	var wantWaitKill bool
+	if cfg.WaitKillable != nil {
+		wantWaitKill = *cfg.WaitKillable
+	} else {
+		// Legacy fallback for direct/test invocations: when no explicit
+		// decision is provided, fall back to the kernel-version probe.
+		// Server-side decisions (issue #369) always set WaitKillable, so
+		// this path only runs when the wrapper is invoked outside the
+		// normal server flow.
+		wantWaitKill = ProbeWaitKillable()
+	}
+```
+
+- [ ] **Step 5: Run the test, verify it passes**
+
+Run: `go test ./internal/netmonitor/unix/ -run TestInstallFilterWithConfig_WaitKillableOverride -count=1 -v`
+Expected: PASS — both sub-cases.
+
+- [ ] **Step 6: Run existing seccomp + sigurg tests to verify no regression**
+
+Run: `go test ./internal/netmonitor/unix/ -run 'Seccomp|Sigurg|InstallFilter|WaitKill' -count=1`
+Expected: PASS.
+
+- [ ] **Step 7: Wire `WaitKillable` through the wrapper main**
+
+In `cmd/agentsh-unixwrap/main.go`, locate the `unixmon.FilterConfig{...}` construction (around line 99). Add the new field:
+
+```go
+	filterCfg := unixmon.FilterConfig{
+		UnixSocketEnabled:  cfg.UnixSocketEnabled,
+		ExecveEnabled:      cfg.ExecveEnabled,
+		FileMonitorEnabled: cfg.FileMonitorEnabled,
+		InterceptMetadata:  cfg.InterceptMetadata,
+		WriteOnlyOpens:     cfg.WriteOnlyOpens,
+		BlockIOUring:       cfg.BlockIOUring,
+		BlockedSyscalls:    blockedNrs,
+		BlockedFamilies:    cfg.BlockedFamilies,
+		SocketRules:        cfg.SocketRules,
+		OnBlockAction:      onBlock,
+		WaitKillable:       cfg.WaitKillable,
+	}
+```
+
+- [ ] **Step 8: Cross-compile + full build**
+
+Run: `go build ./... && GOOS=windows go build ./... && go test ./internal/netmonitor/unix/... ./cmd/agentsh-unixwrap/... -count=1`
+Expected: PASS on all.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/netmonitor/unix/seccomp_linux.go internal/netmonitor/unix/seccomp_linux_test.go cmd/agentsh-unixwrap/main.go
+git commit -m "feat(seccomp): honor FilterConfig.WaitKillable in install path
+
+When the server passes a definitive bool, use it directly instead of
+the legacy uname-based ProbeWaitKillable(). Keeps the legacy probe as
+fallback for wrapper invocations that bypass the server (tests,
+direct CLI).
+
+Issue #369."
+```
+
+- [ ] **Step 10: Run roborev-refine and clear non-low issues.**
+
+---
+
+### Task 6: Behavioral probe — non-Linux stub + Linux file skeleton
+
+**Files:**
+- Create: `internal/netmonitor/unix/wait_killable_probe_stub.go`
+- Create: `internal/netmonitor/unix/wait_killable_probe_linux.go`
+
+This task introduces the function signature and the per-iteration runner injection seam *without* the real fork/exec body. Real implementation lands in Task 7. Doing it in two halves lets us test the decision logic (all-pass, first-fail, all-error) without involving fork.
+
+- [ ] **Step 1: Create the non-Linux stub**
+
+```go
+//go:build !linux
+// +build !linux
+
+package unix
+
+import "context"
+
+// ProbeWaitKillableBehavior is a non-Linux stub. Returns (false, nil) so
+// non-Linux callers behave as if WAIT_KILLABLE_RECV is not safe, which
+// is also true: the flag is Linux-only.
+func ProbeWaitKillableBehavior(_ context.Context, _ int) (bool, error) {
+	return false, nil
+}
+```
+
+Save as `internal/netmonitor/unix/wait_killable_probe_stub.go`.
+
+- [ ] **Step 2: Create the Linux file with the signature + injectable runner**
+
+```go
+//go:build linux && cgo
+// +build linux,cgo
+
+package unix
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// IterationResult classifies one probe iteration.
+type IterationResult int
+
+const (
+	IterPass IterationResult = iota
+	IterKilled
+	IterTimeout
+)
+
+// runProbeIteration runs a single probe iteration. Production
+// implementation lands in wait_killable_probe_runner_linux.go (Task 7).
+// Exposed as a package var so the decision-logic test can inject a
+// mocked runner.
+var runProbeIteration = func(ctx context.Context) (IterationResult, error) {
+	return 0, errors.New("runProbeIteration not implemented yet")
+}
+
+// ProbeWaitKillableBehavior runs `iterations` real probes of the
+// production filter composition under WAIT_KILLABLE_RECV. Returns true
+// only when every iteration's child exits cleanly (exit_status=0).
+// Short-circuits on the first iteration that fails.
+//
+// Errors from runProbeIteration (fork/socketpair/filter-install failures)
+// cause this function to return the error so callers can apply
+// fail-safe semantics. Iteration outcomes IterKilled and IterTimeout
+// both indicate the kernel bug from issue #369 and cause (false, nil).
+func ProbeWaitKillableBehavior(ctx context.Context, iterations int) (bool, error) {
+	if iterations <= 0 {
+		return false, fmt.Errorf("ProbeWaitKillableBehavior: iterations must be >0, got %d", iterations)
+	}
+	for i := 1; i <= iterations; i++ {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		default:
+		}
+		res, err := runProbeIteration(ctx)
+		if err != nil {
+			return false, err
+		}
+		switch res {
+		case IterPass:
+			continue
+		case IterKilled, IterTimeout:
+			return false, nil
+		default:
+			return false, fmt.Errorf("ProbeWaitKillableBehavior: unknown IterationResult %d", res)
+		}
+	}
+	return true, nil
+}
+```
+
+Save as `internal/netmonitor/unix/wait_killable_probe_linux.go`.
+
+- [ ] **Step 3: Write the decision-logic unit test**
+
+Create `internal/netmonitor/unix/wait_killable_probe_linux_test.go`:
+
+```go
+//go:build linux && cgo
+// +build linux,cgo
+
+package unix
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestProbeWaitKillableBehavior_AllPass(t *testing.T) {
+	orig := runProbeIteration
+	t.Cleanup(func() { runProbeIteration = orig })
+
+	calls := 0
+	runProbeIteration = func(_ context.Context) (IterationResult, error) {
+		calls++
+		return IterPass, nil
+	}
+	ok, err := ProbeWaitKillableBehavior(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatal("want true")
+	}
+	if calls != 5 {
+		t.Fatalf("want 5 iterations, got %d", calls)
+	}
+}
+
+func TestProbeWaitKillableBehavior_FirstFailShortCircuits(t *testing.T) {
+	orig := runProbeIteration
+	t.Cleanup(func() { runProbeIteration = orig })
+
+	calls := 0
+	runProbeIteration = func(_ context.Context) (IterationResult, error) {
+		calls++
+		return IterKilled, nil
+	}
+	ok, err := ProbeWaitKillableBehavior(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatal("want false")
+	}
+	if calls != 1 {
+		t.Fatalf("want short-circuit after 1 iteration, got %d", calls)
+	}
+}
+
+func TestProbeWaitKillableBehavior_MidFail(t *testing.T) {
+	orig := runProbeIteration
+	t.Cleanup(func() { runProbeIteration = orig })
+
+	calls := 0
+	runProbeIteration = func(_ context.Context) (IterationResult, error) {
+		calls++
+		if calls == 3 {
+			return IterTimeout, nil
+		}
+		return IterPass, nil
+	}
+	ok, err := ProbeWaitKillableBehavior(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatal("want false (timeout at iter 3 must fail the probe)")
+	}
+	if calls != 3 {
+		t.Fatalf("want 3 iterations, got %d", calls)
+	}
+}
+
+func TestProbeWaitKillableBehavior_ErrorPropagates(t *testing.T) {
+	orig := runProbeIteration
+	t.Cleanup(func() { runProbeIteration = orig })
+
+	want := errors.New("fork failed")
+	runProbeIteration = func(_ context.Context) (IterationResult, error) {
+		return 0, want
+	}
+	ok, err := ProbeWaitKillableBehavior(context.Background(), 5)
+	if !errors.Is(err, want) {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+	if ok {
+		t.Fatal("want false on error")
+	}
+}
+
+func TestProbeWaitKillableBehavior_CancelledContext(t *testing.T) {
+	orig := runProbeIteration
+	t.Cleanup(func() { runProbeIteration = orig })
+
+	runProbeIteration = func(_ context.Context) (IterationResult, error) {
+		return IterPass, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ok, err := ProbeWaitKillableBehavior(ctx, 5)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+	if ok {
+		t.Fatal("want false on cancel")
+	}
+}
+
+func TestProbeWaitKillableBehavior_ZeroIterations(t *testing.T) {
+	_, err := ProbeWaitKillableBehavior(context.Background(), 0)
+	if err == nil {
+		t.Fatal("want error for iterations=0")
+	}
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `go test ./internal/netmonitor/unix/ -run TestProbeWaitKillableBehavior_ -count=1 -v`
+Expected: PASS for all six sub-tests.
+
+- [ ] **Step 5: Cross-compile**
+
+Run: `GOOS=windows go build ./...`
+Expected: PASS (the stub takes over).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/netmonitor/unix/wait_killable_probe_linux.go internal/netmonitor/unix/wait_killable_probe_stub.go internal/netmonitor/unix/wait_killable_probe_linux_test.go
+git commit -m "feat(seccomp): WAIT_KILLABLE_RECV behavioral probe skeleton
+
+Decision logic + injectable per-iteration runner. Tests cover all-pass,
+short-circuit, error propagation, context cancel, and zero-iterations
+guard. Real per-iteration runner (fork/seccomp/execve + waitpid) lands
+in the next task.
+
+Issue #369."
+```
+
+- [ ] **Step 7: Run roborev-refine and clear non-low issues.**
+
+---
+
+### Task 7: Behavioral probe — real per-iteration runner
+
+**Files:**
+- Create: `internal/netmonitor/unix/wait_killable_probe_runner_linux.go`
+- Modify: `internal/netmonitor/unix/wait_killable_probe_linux_test.go` (add real-fork integration test)
+
+- [ ] **Step 1: Implement the per-iteration runner**
+
+The runner must:
+
+1. Build a minimal seccomp filter program (BPF bytes) with notify rules for both syscall families. Use the existing `exportFilterBPF` + `loadRawFilter` pattern from `seccomp_load_linux.go`.
+2. `fork()` via `unix.ForkExec` is too high-level; we need a raw fork to do prctl + seccomp before exec. Use `syscall.RawSyscall(SYS_FORK, ...)` or `syscall.ForkLock` + manual `fork`. Production reference: the existing wrapper code in `cmd/agentsh-unixwrap/main.go` uses `runtime.LockOSThread` + `prctl` + `seccomp` + `syscall.Exec` in the same goroutine — but that's *after* fork. For a probe we need to do this in a child. The cleanest approach is to re-exec our own binary in a "probe child" mode using `os/exec`, where the child entrypoint installs the filter and then execs `/bin/true`.
+
+   **Chosen approach: probe child re-execs the current binary with a sentinel arg.** The current binary (server or wrapper) recognizes the sentinel, installs the filter, and execs `/bin/true`. This avoids fragile manual-fork code in Go and reuses the existing `loadRawFilter` path.
+
+2. Plumb the sentinel:
+   - Add an `init()` to the probe-runner file that checks for `AGENTSH_WAIT_KILLABLE_PROBE_CHILD=1` and, if set, runs the child sequence and never returns.
+   - The child sequence: build the same BPF program (in-process); call `loadRawFilter(prog, withWaitKill=true)` to install with WAIT_KILLABLE_RECV; send the returned notify fd to the parent over an inherited socketpair fd (passed in env `AGENTSH_WAIT_KILLABLE_PROBE_SOCK`); then `syscall.Exec("/bin/true", ...)`.
+3. Parent sequence:
+   - `socketpair(AF_UNIX, SOCK_STREAM, …)` for fd handoff.
+   - `os/exec.Command(os.Args[0])` with `Env` containing the sentinel and the socket fd; `ExtraFiles: [parent end]`; `Stderr: io.Discard`.
+   - `cmd.Start()`.
+   - Goroutine: read notify fd from socketpair; service all incoming `SECCOMP_IOCTL_NOTIF_RECV` notifications with `SECCOMP_USER_NOTIF_FLAG_CONTINUE` responses until the child exits.
+   - `cmd.Wait()` with a 1-second deadline via `context.WithTimeout`; on timeout, `cmd.Process.Kill()` and treat as `IterTimeout`.
+   - Classify: `*exec.ExitError` with `WIFEXITED && status 0` → `IterPass`. `WIFSIGNALED` → `IterKilled`. Timeout → `IterTimeout`. Anything else → return as `(0, err)`.
+
+The full implementation:
+
+```go
+//go:build linux && cgo
+// +build linux,cgo
+
+package unix
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+	"time"
+
+	seccomp "github.com/seccomp/libseccomp-golang"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	probeChildEnv    = "AGENTSH_WAIT_KILLABLE_PROBE_CHILD"
+	probeChildSockFD = "AGENTSH_WAIT_KILLABLE_PROBE_SOCK"
+	probeBinaryPath  = "/bin/true"
+)
+
+// init wires the production runner and detects probe-child mode. When
+// invoked as a probe child the process never returns: it either execs
+// /bin/true (success path) or os.Exit(70)s. Otherwise it just installs
+// realRunProbeIteration over the placeholder from
+// wait_killable_probe_linux.go.
+func init() {
+	if os.Getenv(probeChildEnv) == "1" {
+		runProbeChild()
+		// runProbeChild never returns on success (it execs). If it does
+		// return, treat as fatal child-side error.
+		os.Exit(70)
+	}
+	runProbeIteration = realRunProbeIteration
+}
+
+func runProbeChild() {
+	sockStr := os.Getenv(probeChildSockFD)
+	sockFD, err := strconv.Atoi(sockStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wait_killable probe child: bad %s=%q: %v\n",
+			probeChildSockFD, sockStr, err)
+		return
+	}
+
+	prog, err := buildProbeFilterBytes()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wait_killable probe child: build filter: %v\n", err)
+		return
+	}
+
+	notifyFD, err := loadRawFilter(prog, true)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wait_killable probe child: install filter: %v\n", err)
+		return
+	}
+
+	// Hand notifyFD to the parent.
+	if err := sendProbeFD(sockFD, notifyFD); err != nil {
+		fmt.Fprintf(os.Stderr, "wait_killable probe child: send fd: %v\n", err)
+		return
+	}
+	_ = unix.Close(notifyFD)
+	_ = unix.Close(sockFD)
+
+	// Exec /bin/true to fire the post-execve syscall storm under the
+	// installed filter. Falls back to /bin/echo if /bin/true is missing.
+	bin := probeBinaryPath
+	if _, err := os.Stat(bin); err != nil {
+		bin = "/bin/echo"
+	}
+	_ = syscall.Exec(bin, []string{bin}, []string{})
+	fmt.Fprintf(os.Stderr, "wait_killable probe child: exec failed\n")
+}
+
+// buildProbeFilterBytes constructs the worst-case filter composition
+// (socket family + file/metadata family + execve trap) as raw BPF bytes
+// using the existing libseccomp + exportFilterBPF path. Filter is
+// ActAllow by default so syscalls not in the rule set pass through
+// unimpeded.
+func buildProbeFilterBytes() ([]byte, error) {
+	filt, err := seccomp.NewFilter(seccomp.ActAllow)
+	if err != nil {
+		return nil, err
+	}
+	defer filt.Release()
+
+	trap := seccomp.ActNotify
+	syscalls := []seccomp.ScmpSyscall{
+		seccomp.ScmpSyscall(unix.SYS_SOCKET),
+		seccomp.ScmpSyscall(unix.SYS_CONNECT),
+		seccomp.ScmpSyscall(unix.SYS_BIND),
+		seccomp.ScmpSyscall(unix.SYS_LISTEN),
+		seccomp.ScmpSyscall(unix.SYS_SENDTO),
+		seccomp.ScmpSyscall(unix.SYS_OPENAT),
+		seccomp.ScmpSyscall(unix.SYS_STATX),
+		seccomp.ScmpSyscall(unix.SYS_NEWFSTATAT),
+		seccomp.ScmpSyscall(unix.SYS_FACCESSAT2),
+		seccomp.ScmpSyscall(unix.SYS_READLINKAT),
+	}
+	for _, sc := range syscalls {
+		if err := filt.AddRule(sc, trap); err != nil {
+			return nil, fmt.Errorf("add probe rule %v: %w", sc, err)
+		}
+	}
+	return exportFilterBPF(filt)
+}
+
+// sendProbeFD writes notifyFD over sockFD using SCM_RIGHTS.
+func sendProbeFD(sockFD, notifyFD int) error {
+	rights := unix.UnixRights(notifyFD)
+	return unix.Sendmsg(sockFD, []byte{'F'}, rights, nil, 0)
+}
+
+// recvProbeFD reads one fd from sockFD over SCM_RIGHTS.
+func recvProbeFD(sockFD int) (int, error) {
+	buf := make([]byte, 1)
+	oob := make([]byte, unix.CmsgSpace(4))
+	_, oobn, _, _, err := unix.Recvmsg(sockFD, buf, oob, 0)
+	if err != nil {
+		return -1, err
+	}
+	cmsgs, err := unix.ParseSocketControlMessage(oob[:oobn])
+	if err != nil {
+		return -1, err
+	}
+	for _, c := range cmsgs {
+		fds, err := unix.ParseUnixRights(&c)
+		if err == nil && len(fds) > 0 {
+			return fds[0], nil
+		}
+	}
+	return -1, errors.New("no fd received")
+}
+
+// realRunProbeIteration is the production runner installed in init().
+func realRunProbeIteration(ctx context.Context) (IterationResult, error) {
+	pair, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return 0, fmt.Errorf("socketpair: %w", err)
+	}
+	parentSock, childSock := pair[0], pair[1]
+	defer unix.Close(parentSock)
+
+	binaryPath, err := os.Executable()
+	if err != nil {
+		unix.Close(childSock)
+		return 0, fmt.Errorf("os.Executable: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, binaryPath)
+	cmd.Env = []string{
+		probeChildEnv + "=1",
+		probeChildSockFD + "=3", // ExtraFiles index 0 = fd 3
+	}
+	cmd.ExtraFiles = []*os.File{os.NewFile(uintptr(childSock), "probe-sock")}
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	cmd.Stdin = nil
+
+	if err := cmd.Start(); err != nil {
+		unix.Close(childSock)
+		return 0, fmt.Errorf("start probe child: %w", err)
+	}
+	// The fd was duped into the child; close our end.
+	_ = unix.Close(childSock)
+
+	notifyFD, err := recvProbeFD(parentSock)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		return 0, fmt.Errorf("recv probe fd: %w", err)
+	}
+	defer unix.Close(notifyFD)
+
+	// Service notifications until the child exits.
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	serviceCtx, serviceCancel := context.WithCancel(ctx)
+	defer serviceCancel()
+	go serviceProbeNotifications(serviceCtx, notifyFD)
+
+	timeout := time.NewTimer(time.Second)
+	defer timeout.Stop()
+
+	select {
+	case err := <-done:
+		serviceCancel()
+		return classifyProbeExit(err)
+	case <-timeout.C:
+		serviceCancel()
+		_ = cmd.Process.Kill()
+		<-done
+		return IterTimeout, nil
+	}
+}
+
+// serviceProbeNotifications drains the notify fd and responds CONTINUE
+// to every notification until ctx is cancelled or the fd errors.
+//
+// Uses libseccomp-golang's seccomp.NotifReceive (the same call site as
+// internal/netmonitor/unix/handler.go:41) for receive, and the existing
+// NotifRespondContinue helper from addfd_linux.go for the response.
+func serviceProbeNotifications(ctx context.Context, notifyFD int) {
+	scmpFD := seccomp.ScmpFd(notifyFD)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		notif, err := seccomp.NotifReceive(scmpFD)
+		if err != nil {
+			if !errors.Is(err, unix.EINTR) {
+				slog.Debug("wait_killable probe: notify recv ended", "error", err)
+			}
+			return
+		}
+		if err := NotifRespondContinue(notifyFD, notif.ID); err != nil {
+			slog.Debug("wait_killable probe: notify respond failed", "error", err)
+			return
+		}
+	}
+}
+
+// classifyProbeExit maps cmd.Wait()'s result to an IterationResult.
+func classifyProbeExit(err error) (IterationResult, error) {
+	if err == nil {
+		return IterPass, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+			if ws.Signaled() {
+				return IterKilled, nil
+			}
+			if ws.Exited() && ws.ExitStatus() == 0 {
+				return IterPass, nil
+			}
+			return IterKilled, nil
+		}
+	}
+	return 0, fmt.Errorf("wait_killable probe: unclassified exit: %w", err)
+}
+```
+
+Save as `internal/netmonitor/unix/wait_killable_probe_runner_linux.go`.
+
+- [ ] **Step 2: Add real-fork integration test (Linux only, gated on `testing.Short`)**
+
+Append to `internal/netmonitor/unix/wait_killable_probe_linux_test.go`:
+
+```go
+func TestProbeWaitKillableBehavior_RealKernel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real-fork probe test in short mode")
+	}
+	if _, err := os.Stat("/bin/true"); err != nil {
+		t.Skip("/bin/true missing on this host")
+	}
+	if !ProbeWaitKillable() {
+		t.Skip("kernel <6: WAIT_KILLABLE_RECV not supported on this host")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	start := time.Now()
+	ok, err := ProbeWaitKillableBehavior(ctx, 2)
+	dur := time.Since(start)
+	if err != nil {
+		t.Fatalf("probe error: %v", err)
+	}
+	t.Logf("probe result: ok=%v duration=%v", ok, dur)
+	if !ok {
+		t.Fatal("probe expected to succeed on stock CI kernel — if this fails, document the kernel posture")
+	}
+	if dur > 5*time.Second {
+		t.Errorf("probe took too long: %v (expected <5s)", dur)
+	}
+}
+```
+
+Add imports for `os` and `time` at the top of the test file if not already present.
+
+- [ ] **Step 3: Run all probe tests**
+
+Run: `go test ./internal/netmonitor/unix/ -run TestProbeWaitKillableBehavior -count=1 -v`
+Expected: PASS — six unit tests + one real-kernel test (on Linux CI with stock kernel).
+
+- [ ] **Step 4: Run the full netmonitor/unix test suite to catch regressions**
+
+Run: `go test ./internal/netmonitor/unix/... -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Cross-compile**
+
+Run: `GOOS=windows go build ./...`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/netmonitor/unix/wait_killable_probe_runner_linux.go internal/netmonitor/unix/wait_killable_probe_linux_test.go
+git commit -m "feat(seccomp): real per-iteration runner for wait_killable probe
+
+Self-exec sentinel child installs the worst-case filter composition
+under WAIT_KILLABLE_RECV, sends notify fd to parent over socketpair,
+and execs /bin/true. Parent services notifications with CONTINUE and
+classifies child exit as IterPass/IterKilled/IterTimeout.
+
+Real-kernel integration test runs on Linux CI; mocked-runner tests
+cover the decision logic on every platform.
+
+Issue #369."
+```
+
+- [ ] **Step 7: Run roborev-refine and clear non-low issues.**
+
+---
+
+### Task 8: Server-side decision logic (pure switch)
+
+**Files:**
+- Create: `internal/api/wait_killable_decision.go`
+- Create: `internal/api/wait_killable_decision_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/api/wait_killable_decision_test.go`:
+
+```go
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+func TestDecideWaitKillable(t *testing.T) {
+	tt := true
+	ff := false
+
+	probeOK := func(_ context.Context) (bool, error) { return true, nil }
+	probeFail := func(_ context.Context) (bool, error) { return false, nil }
+	probeErr := func(_ context.Context) (bool, error) { return false, errors.New("probe boom") }
+
+	compositionRisky := SandboxSeccompConfig{
+		UnixSocket:  config.SandboxSeccompUnixConfig{Enabled: true},
+		FileMonitor: config.SandboxSeccompFileMonitorConfig{Enabled: &tt},
+	}
+	compositionSafe := SandboxSeccompConfig{
+		UnixSocket: config.SandboxSeccompUnixConfig{Enabled: true},
+	}
+
+	cases := []struct {
+		name              string
+		cfg               config.SandboxSeccompConfig
+		kernelSupports    bool
+		probe             func(context.Context) (bool, error)
+		wantDecision      bool
+		wantSource        string
+	}{
+		{name: "config &true wins", cfg: configWithWait(compositionRisky, &tt), kernelSupports: true, probe: probeFail, wantDecision: true, wantSource: "config"},
+		{name: "config &false wins", cfg: configWithWait(compositionRisky, &ff), kernelSupports: true, probe: probeOK, wantDecision: false, wantSource: "config"},
+		{name: "kernel <6 forces off", cfg: compositionRisky, kernelSupports: false, probe: probeOK, wantDecision: false, wantSource: "kernel_unsupported"},
+		{name: "safe composition skips probe", cfg: compositionSafe, kernelSupports: true, probe: probeFail, wantDecision: true, wantSource: "filter_composition_safe"},
+		{name: "probe pass", cfg: compositionRisky, kernelSupports: true, probe: probeOK, wantDecision: true, wantSource: "behavioral_probe"},
+		{name: "probe fail", cfg: compositionRisky, kernelSupports: true, probe: probeFail, wantDecision: false, wantSource: "behavioral_probe"},
+		{name: "probe error fails safe", cfg: compositionRisky, kernelSupports: true, probe: probeErr, wantDecision: false, wantSource: "behavioral_probe_error"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotDecision, gotSource := decideWaitKillable(context.Background(), waitKillableDeps{
+				cfg:            tc.cfg,
+				kernelSupports: func() bool { return tc.kernelSupports },
+				probe:          tc.probe,
+			})
+			if gotDecision != tc.wantDecision {
+				t.Errorf("decision: got %v want %v", gotDecision, tc.wantDecision)
+			}
+			if gotSource != tc.wantSource {
+				t.Errorf("source: got %q want %q", gotSource, tc.wantSource)
+			}
+		})
+	}
+}
+
+func configWithWait(cfg config.SandboxSeccompConfig, v *bool) config.SandboxSeccompConfig {
+	cfg.WaitKillable = v
+	return cfg
+}
+```
+
+If the test file is in package `api`, but the production code uses `config.SandboxSeccompConfig` directly, the test may need to reference `config.SandboxSeccompConfig` qualified (as above) or you can use a type alias. Keep the qualified form for clarity.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/api/ -run TestDecideWaitKillable -count=1 -v`
+Expected: FAIL — `decideWaitKillable` and `waitKillableDeps` undefined.
+
+- [ ] **Step 3: Implement the decision logic**
+
+Create `internal/api/wait_killable_decision.go`:
+
+```go
+package api
+
+import (
+	"context"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+// waitKillableDeps wraps the inputs to decideWaitKillable so tests can
+// inject the kernel-version probe and the behavioral probe without
+// crossing platform build tags.
+type waitKillableDeps struct {
+	cfg            config.SandboxSeccompConfig
+	kernelSupports func() bool
+	probe          func(context.Context) (bool, error)
+}
+
+// decideWaitKillable applies the four-branch decision from issue #369
+// and returns (decision, source). Source is a stable string suitable for
+// inclusion in log lines so operators can grep one line to triage.
+//
+// Branches, in priority order:
+//
+//  1. Operator override (cfg.WaitKillable non-nil) → use as-is.
+//  2. Kernel <6 → false (the flag doesn't exist).
+//  3. Filter composition cannot trigger the bug → true (probe unneeded).
+//  4. Behavioral probe → its result. Probe errors are fail-safe (false).
+func decideWaitKillable(ctx context.Context, deps waitKillableDeps) (bool, string) {
+	if v := deps.cfg.WaitKillable; v != nil {
+		return *v, "config"
+	}
+	if !deps.kernelSupports() {
+		return false, "kernel_unsupported"
+	}
+	if !config.WaitKillableFilterCompositionTriggersBug(deps.cfg) {
+		return true, "filter_composition_safe"
+	}
+	ok, err := deps.probe(ctx)
+	if err != nil {
+		return false, "behavioral_probe_error"
+	}
+	return ok, "behavioral_probe"
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./internal/api/ -run TestDecideWaitKillable -count=1 -v`
+Expected: PASS — all 7 sub-cases.
+
+- [ ] **Step 5: Cross-compile + package test**
+
+Run: `GOOS=windows go build ./... && go test ./internal/api/... -count=1`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/api/wait_killable_decision.go internal/api/wait_killable_decision_test.go
+git commit -m "feat(api): server-side wait_killable decision switch
+
+Pure four-branch decision: config override > kernel<6 > safe
+composition > behavioral probe. Returns (decision, source) so the
+existing seccomp:filter loaded log line can announce the source for
+incident triage.
+
+Issue #369."
+```
+
+- [ ] **Step 7: Run roborev-refine and clear non-low issues.**
+
+---
+
+### Task 9: Wire the decision into `NewApp` and `buildSeccompWrapperConfig`
+
+**Files:**
+- Modify: `internal/api/app.go:49-112, 162-178`
+- Modify: `internal/api/seccomp_wrapper_config.go:51-64`
+
+- [ ] **Step 1: Add fields to `App`**
+
+In `internal/api/app.go`, inside the `App` struct (after `acceptNotifyFDForTest`):
+
+```go
+	// waitKillableDecision is the server-process boot-time decision for
+	// SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. Populated once in NewApp
+	// and read by buildSeccompWrapperConfig on every exec. Issue #369.
+	waitKillableDecision bool
+	waitKillableSource   string
+```
+
+- [ ] **Step 2: Compute the decision in `NewApp`**
+
+In `NewApp`, after the App struct is constructed (around line 176) and before `app.initPtraceTracer()`, add:
+
+```go
+	decision, source := decideWaitKillable(context.Background(), waitKillableDeps{
+		cfg:            cfg.Sandbox.Seccomp,
+		kernelSupports: waitKillableKernelSupports,
+		probe:          waitKillableProbe,
+	})
+	app.waitKillableDecision = decision
+	app.waitKillableSource = source
+```
+
+- [ ] **Step 3: Define the platform glue**
+
+Create `internal/api/wait_killable_glue_linux.go`:
+
+```go
+//go:build linux && cgo
+// +build linux,cgo
+
+package api
+
+import (
+	"context"
+
+	unixmon "github.com/agentsh/agentsh/internal/netmonitor/unix"
+)
+
+const waitKillableProbeIterations = 5
+
+func waitKillableKernelSupports() bool { return unixmon.ProbeWaitKillable() }
+
+func waitKillableProbe(ctx context.Context) (bool, error) {
+	return unixmon.ProbeWaitKillableBehavior(ctx, waitKillableProbeIterations)
+}
+```
+
+Create `internal/api/wait_killable_glue_stub.go`:
+
+```go
+//go:build !linux || !cgo
+// +build !linux !cgo
+
+package api
+
+import "context"
+
+// Non-Linux: WAIT_KILLABLE_RECV doesn't exist; decision is always false
+// regardless of config. The decideWaitKillable switch handles this via
+// the kernel_unsupported branch.
+func waitKillableKernelSupports() bool { return false }
+
+func waitKillableProbe(_ context.Context) (bool, error) { return false, nil }
+```
+
+- [ ] **Step 4: Wire `seccompWrapperConfig.WaitKillable` in `buildSeccompWrapperConfig`**
+
+In `internal/api/seccomp_wrapper_config.go`, inside `buildSeccompWrapperConfig`, after the existing `seccompCfg.BlockIOUring = …` line:
+
+```go
+	// Pass the boot-time decision to every wrapper. Issue #369.
+	seccompCfg.WaitKillable = &a.waitKillableDecision
+```
+
+- [ ] **Step 5: Add an integration test asserting the field flows through**
+
+Append to `internal/api/seccomp_wrapper_test.go`:
+
+```go
+func TestBuildSeccompWrapperConfig_PropagatesWaitKillable(t *testing.T) {
+	app := &App{
+		cfg:                  testConfig(t),
+		waitKillableDecision: false,
+		waitKillableSource:   "behavioral_probe",
+	}
+	got := app.buildSeccompWrapperConfig(nil, seccompWrapperParams{})
+	if got.WaitKillable == nil {
+		t.Fatal("WaitKillable not set")
+	}
+	if *got.WaitKillable != false {
+		t.Fatalf("want false, got true")
+	}
+
+	app.waitKillableDecision = true
+	got = app.buildSeccompWrapperConfig(nil, seccompWrapperParams{})
+	if got.WaitKillable == nil || *got.WaitKillable != true {
+		t.Fatal("want &true after flipping decision")
+	}
+}
+```
+
+`testConfig(t)` is the existing test helper in the same file; reuse it. If it doesn't exist, find the helper that the other `buildSeccompWrapperConfig` tests use (look near line 299) and call that.
+
+- [ ] **Step 6: Run the new test**
+
+Run: `go test ./internal/api/ -run TestBuildSeccompWrapperConfig_PropagatesWaitKillable -count=1 -v`
+Expected: PASS.
+
+- [ ] **Step 7: Run the full api package tests**
+
+Run: `go test ./internal/api/... -count=1`
+Expected: PASS.
+
+- [ ] **Step 8: Cross-compile**
+
+Run: `GOOS=windows go build ./...`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/api/app.go internal/api/seccomp_wrapper_config.go internal/api/seccomp_wrapper_test.go internal/api/wait_killable_glue_linux.go internal/api/wait_killable_glue_stub.go
+git commit -m "feat(api): wire wait_killable decision into NewApp + wrapper config
+
+App now computes the decision once at startup (kernel-supports probe +
+behavioral probe + composition heuristic) and stamps it on every
+seccompWrapperConfig via the new WaitKillable field. Per-platform glue
+in wait_killable_glue_*.go isolates the cgo-bound probe.
+
+Issue #369."
+```
+
+- [ ] **Step 10: Run roborev-refine and clear non-low issues.**
+
+---
+
+### Task 10: Diagnostic log lines
+
+**Files:**
+- Modify: `internal/api/app.go` (NewApp)
+- Modify: `internal/api/wait_killable_decision.go` (or new helper)
+- Modify: `internal/netmonitor/unix/wait_killable_probe_linux.go`
+- Modify: `internal/netmonitor/unix/seccomp_linux.go:500-504`
+
+- [ ] **Step 1: Add per-iteration log in the probe runner**
+
+In `internal/netmonitor/unix/wait_killable_probe_linux.go`, add `slog` import and log lines inside `ProbeWaitKillableBehavior`:
+
+```go
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+func ProbeWaitKillableBehavior(ctx context.Context, iterations int) (bool, error) {
+	if iterations <= 0 {
+		return false, fmt.Errorf("ProbeWaitKillableBehavior: iterations must be >0, got %d", iterations)
+	}
+	slog.Info("seccomp: wait_killable behavioral probe starting",
+		"iterations", iterations,
+		"timeout_per_iter_ms", 1000)
+	overallStart := time.Now()
+	for i := 1; i <= iterations; i++ {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		default:
+		}
+		start := time.Now()
+		res, err := runProbeIteration(ctx)
+		dur := time.Since(start)
+		if err != nil {
+			slog.Warn("seccomp: wait_killable iteration error",
+				"iteration", i, "duration_ms", dur.Milliseconds(), "error", err)
+			return false, err
+		}
+		slog.Info("seccomp: wait_killable iteration",
+			"iteration", i, "result", iterationName(res), "duration_ms", dur.Milliseconds())
+		if res != IterPass {
+			slog.Info("seccomp: wait_killable probe complete",
+				"decision", false,
+				"reason", fmt.Sprintf("iteration %d %s", i, iterationName(res)),
+				"total_duration_ms", time.Since(overallStart).Milliseconds())
+			return false, nil
+		}
+	}
+	slog.Info("seccomp: wait_killable probe complete",
+		"decision", true,
+		"reason", "all iterations passed",
+		"total_duration_ms", time.Since(overallStart).Milliseconds())
+	return true, nil
+}
+
+func iterationName(r IterationResult) string {
+	switch r {
+	case IterPass:
+		return "pass"
+	case IterKilled:
+		return "killed"
+	case IterTimeout:
+		return "timeout"
+	default:
+		return fmt.Sprintf("unknown_%d", r)
+	}
+}
+```
+
+- [ ] **Step 2: Add the boot-decision log in `NewApp`**
+
+In `internal/api/app.go`, immediately after the `app.waitKillableDecision = decision` line, add:
+
+```go
+	if source == "behavioral_probe" || source == "behavioral_probe_error" {
+		// Probe logged its own per-iteration lines; emit only the
+		// final decision line for readability.
+	} else {
+		slog.Info("seccomp: wait_killable decision",
+			"value", decision,
+			"source", source)
+	}
+```
+
+The probe-path final-decision line is emitted from inside `ProbeWaitKillableBehavior` (Step 1); the non-probe paths emit it here.
+
+- [ ] **Step 3: Surface the source on the per-exec line**
+
+In `internal/netmonitor/unix/seccomp_linux.go`, around line 500, extend the existing log line and add a `WaitKillableSource` field to `FilterConfig`:
+
+```go
+type FilterConfig struct {
+	// ... existing fields ...
+	WaitKillable       *bool
+	WaitKillableSource string // free-form diagnostic source string; included verbatim in the loaded-filter log line
+}
+```
+
+And in `InstallFilterWithConfig`:
+
+```go
+	slog.Info("seccomp: filter loaded",
+		"fd", rawFd,
+		"wait_killable", gotWaitKill,
+		"wait_killable_source", cfg.WaitKillableSource,
+		"kernel_probe_supports", wantWaitKill,
+		"libseccomp_runtime", libVer)
+```
+
+Plumb `WaitKillableSource` through:
+
+- `seccompWrapperConfig.WaitKillableSource string` json:"wait_killable_source,omitempty"
+- `buildSeccompWrapperConfig` sets `seccompCfg.WaitKillableSource = a.waitKillableSource`
+- `cmd/agentsh-unixwrap/config.go` `WrapperConfig.WaitKillableSource string` json:"wait_killable_source,omitempty"
+- `cmd/agentsh-unixwrap/main.go` passes `cfg.WaitKillableSource` into `filterCfg.WaitKillableSource`
+
+Update the JSON round-trip tests in Tasks 3 and 4 to also assert the new field round-trips (add as sub-tests; don't break existing assertions).
+
+- [ ] **Step 4: Build + run all touched packages**
+
+Run: `go build ./... && GOOS=windows go build ./... && go test ./internal/config/... ./internal/api/... ./internal/netmonitor/unix/... ./cmd/agentsh-unixwrap/... -count=1`
+Expected: PASS.
+
+- [ ] **Step 5: Manual log inspection (Linux only, optional)**
+
+Run a stock Linux build of the server briefly; grep the log output for:
+- `seccomp: wait_killable behavioral probe starting`
+- `seccomp: wait_killable iteration`
+- `seccomp: wait_killable probe complete decision=true`
+- `seccomp: filter loaded ... wait_killable_source=behavioral_probe`
+
+Confirms the per-exec line now carries the source. Document the observation in the commit message.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/api/app.go internal/api/seccomp_wrapper_config.go internal/api/seccomp_wrapper_test.go internal/netmonitor/unix/wait_killable_probe_linux.go internal/netmonitor/unix/seccomp_linux.go cmd/agentsh-unixwrap/config.go cmd/agentsh-unixwrap/main.go internal/api/wait_killable_decision.go
+git commit -m "feat(seccomp): diagnostic logging for wait_killable decisions
+
+Boot-time emits one line per iteration plus a final decision line.
+Non-probe paths (config override, kernel<6, safe composition) emit a
+single decision line directly from NewApp. The existing per-exec
+'seccomp: filter loaded' line now carries wait_killable_source so a
+single grep tells an operator why this exec saw a given flag value.
+
+Issue #369."
+```
+
+- [ ] **Step 7: Run roborev-refine and clear non-low issues.**
+
+---
+
+### Task 11: End-to-end test — operator override flows through
+
+**Files:**
+- Modify: `internal/netmonitor/unix/sigurg_probe_test.go`
+
+- [ ] **Step 1: Inspect the existing test**
+
+Open `internal/netmonitor/unix/sigurg_probe_test.go`. It already re-execs the test binary and asserts the loaded-filter log contains `wait_killable=true` on supported kernels (line 27+). The pattern we need is the same, but with `AGENTSH_SECCOMP_CONFIG` set to `{"wait_killable": false}` and the assertion inverted.
+
+- [ ] **Step 2: Add a new sub-test**
+
+Add at the end of `sigurg_probe_test.go`:
+
+```go
+// TestInstallFilter_HonorsOperatorOverride re-execs the test binary
+// with AGENTSH_SECCOMP_CONFIG carrying an explicit wait_killable=false
+// and asserts that:
+//  1. The 'seccomp: filter loaded' line announces wait_killable=false.
+//  2. The wait_killable_source field is "config".
+// Issue #369 — end-to-end coverage of the operator override path.
+func TestInstallFilter_HonorsOperatorOverride(t *testing.T) {
+	if testing.Short() {
+		t.Skip("re-exec test skipped in short mode")
+	}
+	if !ProbeWaitKillable() {
+		t.Skip("kernel <6: WAIT_KILLABLE_RECV not supported")
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	cmd := exec.Command(exe, "-test.run=^TestInstallFilter_HonorsOperatorOverride_Child$")
+	cmd.Env = append(os.Environ(),
+		"AGENTSH_TEST_CHILD=1",
+		`AGENTSH_SECCOMP_CONFIG={"unix_socket_enabled":true,"wait_killable":false}`,
+	)
+	out, _ := cmd.CombinedOutput()
+	s := string(out)
+	if !strings.Contains(s, "wait_killable=false") && !strings.Contains(s, `"wait_killable":false`) {
+		t.Fatalf("override not honored — output:\n%s", s)
+	}
+	if !strings.Contains(s, `wait_killable_source=config`) && !strings.Contains(s, `"wait_killable_source":"config"`) {
+		t.Fatalf("wait_killable_source not 'config' — output:\n%s", s)
+	}
+}
+
+// TestInstallFilter_HonorsOperatorOverride_Child runs inside the
+// re-exec'd child. It loads the wrapper config from env, runs
+// InstallFilterWithConfig, and exits.
+func TestInstallFilter_HonorsOperatorOverride_Child(t *testing.T) {
+	if os.Getenv("AGENTSH_TEST_CHILD") != "1" {
+		t.Skip()
+	}
+	cfg := FilterConfig{
+		UnixSocketEnabled:  true,
+		WaitKillable:       boolPtrLocal(false),
+		WaitKillableSource: "config",
+	}
+	filt, err := InstallFilterWithConfig(cfg)
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	defer filt.Close()
+}
+
+func boolPtrLocal(v bool) *bool { return &v }
+```
+
+Imports as needed: `os`, `os/exec`, `strings`.
+
+> The child test loads the FilterConfig directly rather than parsing `AGENTSH_SECCOMP_CONFIG` (that's the wrapper binary's job, not this test's). The parent's env-var setting is illustrative only — what we actually assert is that `FilterConfig.WaitKillable = &false` + `WaitKillableSource = "config"` produces the expected log line.
+
+- [ ] **Step 3: Run the test**
+
+Run: `go test ./internal/netmonitor/unix/ -run 'TestInstallFilter_HonorsOperatorOverride' -count=1 -v`
+Expected: PASS.
+
+- [ ] **Step 4: Run the sigurg suite to verify no regression**
+
+Run: `go test ./internal/netmonitor/unix/ -run 'Sigurg|InstallFilter' -count=1 -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/netmonitor/unix/sigurg_probe_test.go
+git commit -m "test(seccomp): end-to-end coverage for wait_killable override
+
+Re-execs the test binary with FilterConfig.WaitKillable=&false +
+WaitKillableSource='config' and asserts both fields show up in the
+loaded-filter log line. Verifies the operator override flows through
+the install path.
+
+Issue #369."
+```
+
+- [ ] **Step 6: Run roborev-refine and clear non-low issues.**
+
+---
+
+### Task 12: Final integration verification
+
+**Files:** none — this task is a verification gate, no commits unless issues are found.
+
+- [ ] **Step 1: Full test suite**
+
+Run: `go test ./... -count=1`
+Expected: PASS across the repository.
+
+- [ ] **Step 2: Cross-compile both targets**
+
+Run: `go build ./... && GOOS=windows go build ./...`
+Expected: PASS.
+
+- [ ] **Step 3: Re-read the spec against the tasks**
+
+Open `docs/superpowers/specs/2026-05-22-issue-369-wait-killable-recv-fix-design.md`. Walk through every section of the spec and confirm:
+- Architecture diagram realized in Tasks 5, 8, 9.
+- Behavioral probe (Section 1 of the spec) realized in Tasks 6, 7.
+- Filter-composition heuristic (Section 2) realized in Task 2.
+- Config plumbing (Section 3) realized in Tasks 1, 3, 4, 5.
+- Diagnosability (Section 4) realized in Task 10.
+- Operator UX table reflected by the override path in Task 5 + Task 11.
+- All six testing surfaces covered: Tasks 2, 4, 3, 5, 6+7, 11.
+
+If any spec requirement is unimplemented, open a new task here and address it before merging.
+
+- [ ] **Step 4: Run roborev-refine one more time on the full branch**
+
+Use `roborev-refine` on the branch. Address every non-low issue. Once only low issues remain, the branch is ready for PR.
+
+- [ ] **Step 5: Open the PR**
+
+Use the `superpowers:finishing-a-development-branch` skill to decide between merge, PR, or further cleanup. The spec and plan are both committed; the PR description should reference both.
+
+---
+
+## Spec coverage checklist (self-review)
+
+- [x] `SandboxSeccompConfig.WaitKillable` → Task 1
+- [x] `WaitKillableFilterCompositionTriggersBug` heuristic → Task 2
+- [x] `seccompWrapperConfig.WaitKillable` + JSON tag → Task 4
+- [x] `WrapperConfig.WaitKillable` + JSON tag → Task 3
+- [x] `FilterConfig.WaitKillable` + override in `InstallFilterWithConfig` → Task 5
+- [x] `ProbeWaitKillableBehavior` skeleton + decision unit tests → Task 6
+- [x] Real per-iteration runner (self-exec + socketpair + SCM_RIGHTS + `/bin/true` + waitpid + classify) → Task 7
+- [x] `decideWaitKillable` four-branch switch + table test → Task 8
+- [x] App-level wiring (`NewApp` decision + `buildSeccompWrapperConfig` propagation) → Task 9
+- [x] Diagnostic log lines (probe iterations, boot decision, per-exec source) → Task 10
+- [x] End-to-end operator-override test → Task 11
+- [x] Cross-compile checks → every task
+- [x] roborev-refine after every commit → every task standing rule
+
+No placeholders. No "similar to Task N." Every step shows code, command, or commit message verbatim.

--- a/docs/superpowers/specs/2026-05-22-issue-369-wait-killable-recv-fix-design.md
+++ b/docs/superpowers/specs/2026-05-22-issue-369-wait-killable-recv-fix-design.md
@@ -1,0 +1,204 @@
+# Issue #369 — WAIT_KILLABLE_RECV regression fix (behavioral probe)
+
+**Date:** 2026-05-22
+**Status:** Design — pending implementation
+**Tracking issue:** [#369](https://github.com/agentsh/agentsh/issues/369)
+
+## Problem
+
+Since #316 (v0.20.x), `agentsh-unixwrap` sets `SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV` on the raw `seccomp(2)` syscall whenever the kernel reports a major version ≥6. On exe.dev VMs (kernel `6.12.67`, with `ProcessVMReadv` returning `ENOSYS`), every wrapped command launched with both `unix_socket` notify rules and file/metadata notify rules in the same filter is killed by signal within ~80 ms of filter install — before any policy events fire. The same configuration on the same VM worked under v0.19.2 because the libseccomp 2.5.3 path used by v0.19.2 had `SetWaitKill` as a silent no-op (the API arrived in libseccomp 2.6), so the flag was never actually on the kernel ABI mask. The intent of #316 is correct; this design addresses the latent kernel quirk it exposed.
+
+The current detection function, `ProbeWaitKillable` (`internal/netmonitor/unix/addfd_linux.go:117`), is a uname-based version check. It is a guess, not a probe. On `6.12.67` it returns `true` while the kernel's WAIT_KILLABLE_RECV implementation, when combined with the production filter composition, kills wrapped processes.
+
+The existing EINVAL-retry path (`seccomp_load_linux.go:185`) only catches kernels that reject the flag at filter-load time. This kernel accepts the flag and misbehaves at runtime; the retry never fires.
+
+## Goals
+
+- Replace the version-based probe with a behavioral check that reflects actual kernel behavior under the filter composition we'll install.
+- Provide an operator-visible override (force on / force off) for cases the probe gets wrong.
+- Surface enough log signal that an operator triaging an incident on a future broken kernel can self-diagnose.
+- Fail-safe in both directions: if uncertain, prefer the degradation cost (SIGURG-induced ERESTARTSYS noise) over the catastrophic cost (every wrapped command dies).
+
+## Non-goals
+
+- Diagnosing the kernel-side root cause. The interaction is opaque from userspace; we treat the kernel as a black box.
+- Persisting probe results across server restarts. Kernels change between boots; re-probe each time.
+- Reproducing the bad kernel in CI. We test the probe's logic and the decision flow; the bad-kernel path is the field safety net.
+- Changing how `WAIT_KILLABLE_RECV` interacts with libseccomp. The raw-syscall path from #316 stays.
+
+## Architecture overview
+
+Two-layer decision: server-process makes the call once at startup; wrapper-process consumes the decision via the existing `AGENTSH_SECCOMP_CONFIG` env var.
+
+```
+Server startup (once per process)
+  cfg.Sandbox.Seccomp.WaitKillable *bool
+       │
+       ├── non-nil ─────────────► use as-is              (source: config)
+       │
+       └── nil ─► kernel <6 ────► false                  (source: kernel_unsupported)
+              ─► composition safe► true                  (source: filter_composition_safe)
+              ─► probe success ──► true                  (source: behavioral_probe)
+              ─► probe killed ───► false                 (source: behavioral_probe)
+              ─► probe errored ──► false (fail-safe)     (source: behavioral_probe_error)
+
+  Result + source memoized on App; passed to every wrapper via JSON.
+```
+
+`ProbeWaitKillable` (uname check) is retained as a fast pre-filter — kernels <6 don't have the flag and need no behavioral check. Kernels ≥6 enter the behavioral path.
+
+## Detailed design
+
+### 1. Behavioral probe (`internal/netmonitor/unix/wait_killable_probe_linux.go`)
+
+Signature:
+
+```go
+func ProbeWaitKillableBehavior(ctx context.Context, iterations int) (bool, error)
+```
+
+Per iteration:
+
+1. `socketpair(AF_UNIX, SOCK_STREAM, …)` for notify-fd handoff.
+2. `fork()`.
+3. **Child:**
+   - `prctl(PR_SET_NO_NEW_PRIVS, 1, …)`.
+   - `seccomp(SET_MODE_FILTER, NEW_LISTENER|WAIT_KILLABLE_RECV, …)` with a hardcoded filter containing notify rules for both the socket family (`socket`, `connect`, `bind`, `listen`, `sendto`) and the file/metadata family (the union of `installFileMonitorRules`' syscalls plus `statx`, `newfstatat`, `faccessat2`, `readlinkat`).
+   - Send notify fd to parent via `SCM_RIGHTS`.
+   - `execve("/bin/true", …)`. Fall back to `/bin/echo` if `/bin/true` is missing; if neither exists, the probe returns `(false, ErrNoProbeBinary)` and the decision goes to `behavioral_probe_error`.
+4. **Parent:**
+   - Receive notify fd from child.
+   - Goroutine: read notifications from the fd, respond with `SECCOMP_USER_NOTIF_FLAG_CONTINUE` to each, until child exits.
+   - `waitpid(child, …)` with a 1-second deadline; on timeout `kill(child, SIGKILL)` and treat as fail.
+   - Close notify fd and socketpair.
+   - Classify:
+     - `WIFEXITED && exit_status == 0` → iteration pass.
+     - `WIFSIGNALED` with any signal → iteration fail (the bug).
+     - Timeout → iteration fail.
+     - System errors during fork/socketpair/recv → return error to caller.
+5. Short-circuit: first failed iteration returns `(false, nil)` immediately.
+6. All iterations pass → returns `(true, nil)`.
+
+Constants:
+- Default iterations: 5. Rationale: with the issue's ~50% kill rate, P(all-5-pass on broken kernel) ≈ 3%; doubling to 10 reduces to ~0.1% at 2× boot cost. The operator override is the final guarantee.
+- Per-iteration timeout: 1 s. Worst-case boot ≤ `iterations × timeout` = 5 s.
+
+Non-Linux stub: `wait_killable_probe_stub.go` returns `(false, nil)` on `!linux`.
+
+### 2. Filter-composition heuristic (`filterCompositionCouldTriggerBug`)
+
+```go
+func filterCompositionCouldTriggerBug(cfg SandboxSeccompConfig) bool {
+    socketFamily := cfg.UnixSocket.Enabled
+    fmDefault := FileMonitorBoolWithDefault(cfg.FileMonitor.EnforceWithoutFUSE, false)
+    fileFamily := FileMonitorBoolWithDefault(cfg.FileMonitor.Enabled, false) ||
+                  FileMonitorBoolWithDefault(cfg.FileMonitor.InterceptMetadata, fmDefault)
+    return socketFamily && fileFamily
+}
+```
+
+The function operates on the *effective* config after defaults are resolved (matching the logic in `seccomp_wrapper_config.go`), not on the raw YAML toggles. This catches the gotcha that produced the issue's misleading bisection row: `file_monitor.enabled=false` with `enforce_without_fuse=true` *still* installs metadata notify rules, so the composition is still risky.
+
+When this returns `false`, no behavioral probe is needed — `WAIT_KILLABLE_RECV` is safe by current kernel evidence. When it returns `true`, the probe runs.
+
+### 3. Config plumbing
+
+Four files; all add a `WaitKillable *bool` (tri-state: nil = auto, true = force on, false = force off):
+
+| File | Field | Surface |
+|---|---|---|
+| `internal/config/config.go` | `SandboxSeccompConfig.WaitKillable *bool` | YAML: `sandbox.seccomp.wait_killable` |
+| `internal/api/seccomp_wrapper_config.go` | `seccompWrapperConfig.WaitKillable *bool` | JSON tag `wait_killable` |
+| `cmd/agentsh-unixwrap/config.go` | `WrapperConfig.WaitKillable *bool` | JSON tag `wait_killable` |
+| `internal/netmonitor/unix/seccomp_linux.go` | `FilterConfig.WaitKillable *bool` | in-process struct |
+
+Server side, in `App` (or the equivalent startup context): decide once, memoize on `a.waitKillableDecision bool` and `a.waitKillableSource string`. `buildSeccompWrapperConfig` sets `seccompCfg.WaitKillable = &a.waitKillableDecision` on every session.
+
+Wrapper side: `cmd/agentsh-unixwrap/main.go` already wires `WrapperConfig` → `FilterConfig`; add the new field to that mapping.
+
+`InstallFilterWithConfig` (`seccomp_linux.go:303`):
+
+```go
+var wantWaitKill bool
+if cfg.WaitKillable != nil {
+    wantWaitKill = *cfg.WaitKillable
+} else {
+    wantWaitKill = ProbeWaitKillable() // legacy fallback for direct/test invocations
+}
+```
+
+When `AGENTSH_SECCOMP_CONFIG` is unset (defaults path in `loadConfig`, used by some tests), `cfg.WaitKillable` is nil and the legacy uname-based probe is used. The new behavioral probe runs in the server process only; the wrapper never probes.
+
+### 4. Diagnosability
+
+Five log lines, all named consistently:
+
+**Boot, behavioral-probe path:**
+
+```
+seccomp: wait_killable behavioral probe starting iterations=5 timeout_per_iter_ms=1000
+seccomp: wait_killable iteration iteration=1 result=pass duration_ms=42
+seccomp: wait_killable iteration iteration=2 result=killed signal=9 duration_ms=83
+seccomp: wait_killable decision value=false source=behavioral_probe reason="iteration 2 killed by signal" total_duration_ms=125
+```
+
+**Boot, probe-skipped path** (one line, no iterations):
+
+```
+seccomp: wait_killable decision value=true  source=config
+seccomp: wait_killable decision value=false source=kernel_unsupported
+seccomp: wait_killable decision value=true  source=filter_composition_safe
+```
+
+**Per-exec, in the existing `seccomp: filter loaded` line** (`seccomp_linux.go:500`), add `wait_killable_source`:
+
+```
+seccomp: filter loaded fd=4 wait_killable=true wait_killable_source=behavioral_probe kernel_probe_supports=true libseccomp_runtime=2.5.3
+```
+
+An operator triaging a kill incident greps one line to see the *source* of the decision on that exec.
+
+## Performance
+
+| Phase | Cost |
+|---|---|
+| Server boot, `WaitKillable` set in config | 0 (probe skipped) |
+| Server boot, filter composition safe | 0 (probe skipped) |
+| Server boot, kernel <6 | 0 (probe skipped, ProbeWaitKillable is a fast uname call) |
+| Server boot, probe runs (5 iters, healthy kernel) | ~100–350 ms one-time |
+| Server boot, probe runs (5 iters, broken kernel, short-circuit on iter 1–2) | ~20–150 ms one-time |
+| Per wrapped exec | Faster than today: removes the per-exec `unix.Uname()` call in the wrapper |
+
+Worst-case bound: `iterations × per-iteration timeout` = 5 s on a pathologically hung kernel.
+
+## Testing
+
+Six test surfaces, all gated correctly for platform:
+
+1. **Decision-logic unit test** (`internal/api/wait_killable_decision_test.go`): table-driven over the seven branches of the startup switch. Pure logic; runs on all platforms. Inject `ProbeWaitKillable`, `filterCompositionCouldTriggerBug`, and the behavioral probe via a small interface.
+2. **Composition-heuristic unit test**: matrix covering `unix_socket.enabled`, `file_monitor.enabled`, `enforce_without_fuse`, explicit `intercept_metadata`. Catches the bisection-misleading row from the issue.
+3. **JSON plumbing round-trip tests**: extend `internal/api/seccomp_wrapper_test.go` and `cmd/agentsh-unixwrap/config_test.go` to assert `*bool` survives marshal/unmarshal for `nil` / `&true` / `&false`.
+4. **`InstallFilterWithConfig` override test** (`internal/netmonitor/unix/seccomp_linux_test.go`): reuse the existing `loadFilterSyscall` injection seam to verify the `WAIT_KILLABLE_RECV` bit on the syscall flags arg for each combination of `cfg.WaitKillable` and host `ProbeWaitKillable()`.
+5. **Probe tests** (`internal/netmonitor/unix/wait_killable_probe_linux_test.go`):
+   - **5a (mocked iteration runner):** inject the per-iteration runner as a function; verify all-pass → true, first-fail → false (short-circuit), all-error → error.
+   - **5b (real iteration, Linux only):** run probe with iterations=2 on stock CI kernel; assert `(true, nil)` and duration < 2 s. Second test: force the iteration child to `kill(getpid(), SIGKILL)` right after notify-fd handoff to verify the "saw a death" path returns `(false, nil)`. Skip when `/bin/true` missing.
+6. **Sigurg-probe test extension** (`internal/netmonitor/unix/sigurg_probe_test.go`): add an assertion that when `AGENTSH_SECCOMP_CONFIG` carries `"wait_killable": false`, the loaded-filter log line emits `wait_killable=false` and `wait_killable_source=config`. Proves the operator override flows end-to-end.
+
+**Out of scope**: simulating the exe.dev-style broken kernel in CI. We don't have it; the probe is the production safety net. If we ever obtain a reproducible image, we add a CI lane in a follow-up.
+
+## Operator UX
+
+| Situation | Operator action |
+|---|---|
+| Stock kernel, no quirk | None. Probe runs ~300 ms at boot, decides `true`. |
+| exe.dev-style broken kernel | None. Probe catches it, decides `false`, logs reason. |
+| Operator knows their kernel is fine, wants faster boot | `sandbox.seccomp.wait_killable: true` → probe skipped. |
+| Operator on a new broken kernel where probe got fooled | Greps log for `wait_killable_source`, sets `sandbox.seccomp.wait_killable: false`. |
+| Test environment with synthetic kernel | Set explicitly either way; never relies on the probe. |
+
+## Open questions / follow-ups
+
+- **Disk-cached probe result**: rejected for v1. Re-probe each boot to handle kernel upgrades, container image swaps, live patches. If boot latency becomes a hot issue, the explicit `wait_killable: true` knob is the operator's escape hatch.
+- **Per-invocation adaptive retry** (option B from brainstorming): not in v1. Added later only if we discover a kernel where the boot probe is insufficient — e.g., where the bug is so non-deterministic that 10 iterations still get fooled. Not over-engineered preemptively.
+- **CI lane on a reproducer image**: separate follow-up issue if we obtain one (Docker, AMI, etc.).
+- **Telemetry on decision source**: today only logged. If we later add server-emitted metrics, `wait_killable_source` is a useful label for tracking how many fleets land in each branch.

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -114,7 +114,11 @@ type App struct {
 	// SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. Populated once in NewApp
 	// and read by buildSeccompWrapperConfig on every exec. Issue #369.
 	waitKillableDecision bool
-	waitKillableSource   string
+	// waitKillableSource records why waitKillableDecision was chosen
+	// ("config", "kernel_unsupported", "filter_composition_safe",
+	// "behavioral_probe", "behavioral_probe_error"). Consumed by the
+	// diagnostic log lines added in a later task.
+	waitKillableSource string
 }
 
 func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Store, engine *policy.Engine, broker *events.Broker, apiKeyAuth *auth.APIKeyAuth, oidcAuth *auth.OIDCAuth, approvalsMgr *approvals.Manager, metricsCollector *metrics.Collector, policyLoader PolicyLoader, cgroupMgr *limits.CgroupManager) *App {

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -109,6 +109,12 @@ type App struct {
 	// acceptNotifyFD so tests can observe its lifecycle. Production code
 	// passes nil and the goroutine is launched directly via `go fn()`.
 	acceptNotifyFDForTest func(fn func())
+
+	// waitKillableDecision is the server-process boot-time decision for
+	// SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. Populated once in NewApp
+	// and read by buildSeccompWrapperConfig on every exec. Issue #369.
+	waitKillableDecision bool
+	waitKillableSource   string
 }
 
 func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Store, engine *policy.Engine, broker *events.Broker, apiKeyAuth *auth.APIKeyAuth, oidcAuth *auth.OIDCAuth, approvalsMgr *approvals.Manager, metricsCollector *metrics.Collector, policyLoader PolicyLoader, cgroupMgr *limits.CgroupManager) *App {
@@ -174,6 +180,18 @@ func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Stor
 		platform:     plat,
 		policyLoader: policyLoader,
 	}
+
+	// Compute the server-process WAIT_KILLABLE_RECV decision once at
+	// startup. This drives buildSeccompWrapperConfig so every wrapper
+	// exec inherits the same boot-time choice. Issue #369.
+	decision, source := decideWaitKillable(context.Background(), waitKillableDeps{
+		cfg:            cfg.Sandbox.Seccomp,
+		kernelSupports: waitKillableKernelSupports,
+		probe:          waitKillableProbe,
+	})
+	app.waitKillableDecision = decision
+	app.waitKillableSource = source
+
 	app.initPtraceTracer()
 	return app
 }

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -195,6 +195,14 @@ func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Stor
 	})
 	app.waitKillableDecision = decision
 	app.waitKillableSource = source
+	if source != "behavioral_probe" && source != "behavioral_probe_error" {
+		// Probe paths emit their own per-iteration + final-decision lines.
+		// Non-probe paths (config, kernel_unsupported, filter_composition_safe)
+		// need a single line here so operators can grep one log point.
+		slog.Info("seccomp: wait_killable decision",
+			"value", decision,
+			"source", source)
+	}
 
 	app.initPtraceTracer()
 	return app

--- a/internal/api/seccomp_wrapper_config.go
+++ b/internal/api/seccomp_wrapper_config.go
@@ -27,6 +27,11 @@ type seccompWrapperConfig struct {
 	WriteOnlyOpens    bool `json:"write_only_opens,omitempty"`
 	BlockIOUring      bool `json:"block_io_uring,omitempty"`
 
+	// WaitKillable forwards the server's wait_killable decision to the
+	// wrapper. nil only if the App somehow has no decision set (treated as
+	// "wrapper falls back to legacy probe"). Issue #369.
+	WaitKillable *bool `json:"wait_killable,omitempty"`
+
 	// Landlock filesystem restrictions
 	LandlockEnabled bool     `json:"landlock_enabled,omitempty"`
 	LandlockABI     int      `json:"landlock_abi,omitempty"`

--- a/internal/api/seccomp_wrapper_config.go
+++ b/internal/api/seccomp_wrapper_config.go
@@ -93,6 +93,10 @@ func (a *App) buildSeccompWrapperConfig(s *session.Session, p seccompWrapperPara
 	}
 	seccompCfg.BlockIOUring = config.FileMonitorBoolWithDefault(a.cfg.Sandbox.Seccomp.FileMonitor.BlockIOUring, fmDefault)
 
+	// Pass the boot-time decision to every wrapper. The pointer is
+	// per-exec; the bool storage is the server-process App field. Issue #369.
+	seccompCfg.WaitKillable = &a.waitKillableDecision
+
 	if a.cfg.Landlock.Enabled {
 		llResult := capabilities.DetectLandlock()
 		if llResult.Available {

--- a/internal/api/seccomp_wrapper_config.go
+++ b/internal/api/seccomp_wrapper_config.go
@@ -27,9 +27,10 @@ type seccompWrapperConfig struct {
 	WriteOnlyOpens    bool `json:"write_only_opens,omitempty"`
 	BlockIOUring      bool `json:"block_io_uring,omitempty"`
 
-	// WaitKillable forwards the server's wait_killable decision to the
-	// wrapper. nil only if the App somehow has no decision set (treated as
-	// "wrapper falls back to legacy probe"). Issue #369.
+	// WaitKillable forwards the server's decision (boot-time probe +
+	// optional config override) to the wrapper, which uses it in place
+	// of its own ProbeWaitKillable() fallback. nil means the server made
+	// no decision and the wrapper should probe locally. Issue #369.
 	WaitKillable *bool `json:"wait_killable,omitempty"`
 
 	// Landlock filesystem restrictions

--- a/internal/api/seccomp_wrapper_config.go
+++ b/internal/api/seccomp_wrapper_config.go
@@ -33,6 +33,14 @@ type seccompWrapperConfig struct {
 	// no decision and the wrapper should probe locally. Issue #369.
 	WaitKillable *bool `json:"wait_killable,omitempty"`
 
+	// WaitKillableSource records why the WaitKillable decision was made
+	// ("config", "kernel_unsupported", "filter_composition_safe",
+	// "behavioral_probe", "behavioral_probe_error"). Forwarded so the
+	// wrapper's per-exec "seccomp: filter loaded" log line can record the
+	// source — one grep tells an operator why this exec saw a given flag
+	// value. Issue #369.
+	WaitKillableSource string `json:"wait_killable_source,omitempty"`
+
 	// Landlock filesystem restrictions
 	LandlockEnabled bool     `json:"landlock_enabled,omitempty"`
 	LandlockABI     int      `json:"landlock_abi,omitempty"`
@@ -96,6 +104,7 @@ func (a *App) buildSeccompWrapperConfig(s *session.Session, p seccompWrapperPara
 	// Pass the boot-time decision to every wrapper. The pointer is
 	// per-exec; the bool storage is the server-process App field. Issue #369.
 	seccompCfg.WaitKillable = &a.waitKillableDecision
+	seccompCfg.WaitKillableSource = a.waitKillableSource
 
 	if a.cfg.Landlock.Enabled {
 		llResult := capabilities.DetectLandlock()

--- a/internal/api/seccomp_wrapper_test.go
+++ b/internal/api/seccomp_wrapper_test.go
@@ -442,3 +442,29 @@ func TestSeccompWrapperConfig_WaitKillable_JSON(t *testing.T) {
 }
 
 func boolPtrLocal(v bool) *bool { return &v }
+
+// TestBuildSeccompWrapperConfig_PropagatesWaitKillable asserts the
+// boot-time decision stored on App flows through to every wrapper
+// config. The test bypasses NewApp (and therefore the behavioral probe)
+// by constructing App directly — it covers only the propagation contract.
+// Issue #369.
+func TestBuildSeccompWrapperConfig_PropagatesWaitKillable(t *testing.T) {
+	app := &App{
+		cfg:                  &config.Config{},
+		waitKillableDecision: false,
+		waitKillableSource:   "behavioral_probe",
+	}
+	got := app.buildSeccompWrapperConfig(nil, seccompWrapperParams{})
+	if got.WaitKillable == nil {
+		t.Fatal("WaitKillable not set")
+	}
+	if *got.WaitKillable != false {
+		t.Fatalf("want false, got true")
+	}
+
+	app.waitKillableDecision = true
+	got = app.buildSeccompWrapperConfig(nil, seccompWrapperParams{})
+	if got.WaitKillable == nil || *got.WaitKillable != true {
+		t.Fatal("want &true after flipping decision")
+	}
+}

--- a/internal/api/seccomp_wrapper_test.go
+++ b/internal/api/seccomp_wrapper_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"encoding/json"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/config"
@@ -410,3 +411,34 @@ seccomp:
 		t.Fatalf("AGENTSH_PTRACE_SYNC = %q, want 1", got)
 	}
 }
+
+func TestSeccompWrapperConfig_WaitKillable_JSON(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         *bool
+		wantSubstr string
+		wantAbsent bool
+	}{
+		{name: "absent", in: nil, wantAbsent: true},
+		{name: "true", in: boolPtrLocal(true), wantSubstr: `"wait_killable":true`},
+		{name: "false", in: boolPtrLocal(false), wantSubstr: `"wait_killable":false`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := seccompWrapperConfig{WaitKillable: tc.in}
+			b, err := json.Marshal(cfg)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			s := string(b)
+			if tc.wantAbsent && strings.Contains(s, "wait_killable") {
+				t.Fatalf("expected wait_killable to be omitted, got %s", s)
+			}
+			if !tc.wantAbsent && !strings.Contains(s, tc.wantSubstr) {
+				t.Fatalf("expected %q in %s", tc.wantSubstr, s)
+			}
+		})
+	}
+}
+
+func boolPtrLocal(v bool) *bool { return &v }

--- a/internal/api/seccomp_wrapper_test.go
+++ b/internal/api/seccomp_wrapper_test.go
@@ -443,6 +443,40 @@ func TestSeccompWrapperConfig_WaitKillable_JSON(t *testing.T) {
 
 func boolPtrLocal(v bool) *bool { return &v }
 
+// TestSeccompWrapperConfig_WaitKillableSource_JSON covers the source
+// string field that travels alongside the WaitKillable bool to give
+// operators a one-line answer for why a given exec saw a given flag.
+// Issue #369.
+func TestSeccompWrapperConfig_WaitKillableSource_JSON(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         string
+		wantSubstr string
+		wantAbsent bool
+	}{
+		{name: "absent", in: "", wantAbsent: true},
+		{name: "behavioral_probe", in: "behavioral_probe", wantSubstr: `"wait_killable_source":"behavioral_probe"`},
+		{name: "config", in: "config", wantSubstr: `"wait_killable_source":"config"`},
+		{name: "kernel_unsupported", in: "kernel_unsupported", wantSubstr: `"wait_killable_source":"kernel_unsupported"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := seccompWrapperConfig{WaitKillableSource: tc.in}
+			b, err := json.Marshal(cfg)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			s := string(b)
+			if tc.wantAbsent && strings.Contains(s, "wait_killable_source") {
+				t.Fatalf("expected wait_killable_source to be omitted, got %s", s)
+			}
+			if !tc.wantAbsent && !strings.Contains(s, tc.wantSubstr) {
+				t.Fatalf("expected %q in %s", tc.wantSubstr, s)
+			}
+		})
+	}
+}
+
 // TestBuildSeccompWrapperConfig_PropagatesWaitKillable asserts the
 // boot-time decision stored on App flows through to every wrapper
 // config. The test bypasses NewApp (and therefore the behavioral probe)
@@ -461,10 +495,17 @@ func TestBuildSeccompWrapperConfig_PropagatesWaitKillable(t *testing.T) {
 	if *got.WaitKillable != false {
 		t.Fatalf("want false, got true")
 	}
+	if got.WaitKillableSource != "behavioral_probe" {
+		t.Fatalf("WaitKillableSource = %q, want behavioral_probe", got.WaitKillableSource)
+	}
 
 	app.waitKillableDecision = true
+	app.waitKillableSource = "config"
 	got = app.buildSeccompWrapperConfig(nil, seccompWrapperParams{})
 	if got.WaitKillable == nil || *got.WaitKillable != true {
 		t.Fatal("want &true after flipping decision")
+	}
+	if got.WaitKillableSource != "config" {
+		t.Fatalf("WaitKillableSource = %q, want config", got.WaitKillableSource)
 	}
 }

--- a/internal/api/wait_killable_decision.go
+++ b/internal/api/wait_killable_decision.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"context"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+// waitKillableDeps wraps the inputs to decideWaitKillable so tests can
+// inject the kernel-version probe and the behavioral probe without
+// crossing platform build tags.
+type waitKillableDeps struct {
+	cfg            config.SandboxSeccompConfig
+	kernelSupports func() bool
+	probe          func(context.Context) (bool, error)
+}
+
+// decideWaitKillable applies the four-branch decision from issue #369
+// and returns (decision, source). Source is a stable string suitable for
+// inclusion in log lines so operators can grep one line to triage.
+//
+// Branches, in priority order:
+//
+//  1. Operator override (cfg.WaitKillable non-nil) → use as-is.
+//  2. Kernel <6 → false (the flag doesn't exist).
+//  3. Filter composition cannot trigger the bug → true (probe unneeded).
+//  4. Behavioral probe → its result. Probe errors are fail-safe (false).
+func decideWaitKillable(ctx context.Context, deps waitKillableDeps) (bool, string) {
+	if v := deps.cfg.WaitKillable; v != nil {
+		return *v, "config"
+	}
+	if !deps.kernelSupports() {
+		return false, "kernel_unsupported"
+	}
+	if !config.WaitKillableFilterCompositionTriggersBug(deps.cfg) {
+		return true, "filter_composition_safe"
+	}
+	ok, err := deps.probe(ctx)
+	if err != nil {
+		return false, "behavioral_probe_error"
+	}
+	return ok, "behavioral_probe"
+}

--- a/internal/api/wait_killable_decision_test.go
+++ b/internal/api/wait_killable_decision_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+func TestDecideWaitKillable(t *testing.T) {
+	tt := true
+	ff := false
+
+	probeOK := func(_ context.Context) (bool, error) { return true, nil }
+	probeFail := func(_ context.Context) (bool, error) { return false, nil }
+	probeErr := func(_ context.Context) (bool, error) { return false, errors.New("probe boom") }
+
+	compositionRisky := config.SandboxSeccompConfig{
+		UnixSocket:  config.SandboxSeccompUnixConfig{Enabled: true},
+		FileMonitor: config.SandboxSeccompFileMonitorConfig{Enabled: &tt},
+	}
+	compositionSafe := config.SandboxSeccompConfig{
+		UnixSocket: config.SandboxSeccompUnixConfig{Enabled: true},
+	}
+
+	cases := []struct {
+		name           string
+		cfg            config.SandboxSeccompConfig
+		kernelSupports bool
+		probe          func(context.Context) (bool, error)
+		wantDecision   bool
+		wantSource     string
+	}{
+		{name: "config &true wins", cfg: configWithWait(compositionRisky, &tt), kernelSupports: true, probe: probeFail, wantDecision: true, wantSource: "config"},
+		{name: "config &false wins", cfg: configWithWait(compositionRisky, &ff), kernelSupports: true, probe: probeOK, wantDecision: false, wantSource: "config"},
+		{name: "kernel <6 forces off", cfg: compositionRisky, kernelSupports: false, probe: probeOK, wantDecision: false, wantSource: "kernel_unsupported"},
+		{name: "safe composition skips probe", cfg: compositionSafe, kernelSupports: true, probe: probeFail, wantDecision: true, wantSource: "filter_composition_safe"},
+		{name: "probe pass", cfg: compositionRisky, kernelSupports: true, probe: probeOK, wantDecision: true, wantSource: "behavioral_probe"},
+		{name: "probe fail", cfg: compositionRisky, kernelSupports: true, probe: probeFail, wantDecision: false, wantSource: "behavioral_probe"},
+		{name: "probe error fails safe", cfg: compositionRisky, kernelSupports: true, probe: probeErr, wantDecision: false, wantSource: "behavioral_probe_error"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotDecision, gotSource := decideWaitKillable(context.Background(), waitKillableDeps{
+				cfg:            tc.cfg,
+				kernelSupports: func() bool { return tc.kernelSupports },
+				probe:          tc.probe,
+			})
+			if gotDecision != tc.wantDecision {
+				t.Errorf("decision: got %v want %v", gotDecision, tc.wantDecision)
+			}
+			if gotSource != tc.wantSource {
+				t.Errorf("source: got %q want %q", gotSource, tc.wantSource)
+			}
+		})
+	}
+}
+
+func configWithWait(cfg config.SandboxSeccompConfig, v *bool) config.SandboxSeccompConfig {
+	cfg.WaitKillable = v
+	return cfg
+}

--- a/internal/api/wait_killable_decision_test.go
+++ b/internal/api/wait_killable_decision_test.go
@@ -34,6 +34,7 @@ func TestDecideWaitKillable(t *testing.T) {
 	}{
 		{name: "config &true wins", cfg: configWithWait(compositionRisky, &tt), kernelSupports: true, probe: probeFail, wantDecision: true, wantSource: "config"},
 		{name: "config &false wins", cfg: configWithWait(compositionRisky, &ff), kernelSupports: true, probe: probeOK, wantDecision: false, wantSource: "config"},
+		{name: "config beats kernel<6", cfg: configWithWait(compositionRisky, &tt), kernelSupports: false, probe: probeFail, wantDecision: true, wantSource: "config"},
 		{name: "kernel <6 forces off", cfg: compositionRisky, kernelSupports: false, probe: probeOK, wantDecision: false, wantSource: "kernel_unsupported"},
 		{name: "safe composition skips probe", cfg: compositionSafe, kernelSupports: true, probe: probeFail, wantDecision: true, wantSource: "filter_composition_safe"},
 		{name: "probe pass", cfg: compositionRisky, kernelSupports: true, probe: probeOK, wantDecision: true, wantSource: "behavioral_probe"},

--- a/internal/api/wait_killable_glue_linux.go
+++ b/internal/api/wait_killable_glue_linux.go
@@ -1,0 +1,27 @@
+//go:build linux && cgo
+// +build linux,cgo
+
+package api
+
+import (
+	"context"
+
+	unixmon "github.com/agentsh/agentsh/internal/netmonitor/unix"
+)
+
+// waitKillableProbeIterations is the spec-recommended iteration count for
+// the behavioral probe (issue #369). Five iterations balance signal
+// strength against the ~100-700ms wall-clock cost on a healthy kernel.
+const waitKillableProbeIterations = 5
+
+// waitKillableKernelSupports reports whether the running kernel exposes
+// SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. Wraps the cgo-bound probe.
+func waitKillableKernelSupports() bool { return unixmon.ProbeWaitKillable() }
+
+// waitKillableProbe runs the behavioral probe to detect the kernel bug
+// described in issue #369. Returns (true, nil) when the flag is safe to
+// set, (false, nil) when the bug reproduces, and (false, err) on probe
+// setup failure (callers treat errors as fail-safe = false).
+func waitKillableProbe(ctx context.Context) (bool, error) {
+	return unixmon.ProbeWaitKillableBehavior(ctx, waitKillableProbeIterations)
+}

--- a/internal/api/wait_killable_glue_stub.go
+++ b/internal/api/wait_killable_glue_stub.go
@@ -5,12 +5,12 @@ package api
 
 import "context"
 
-// Non-Linux (or linux-without-cgo): WAIT_KILLABLE_RECV doesn't exist on
-// these platforms, so the decision is always false regardless of config.
-// The decideWaitKillable switch handles this via the kernel_unsupported
-// branch (kernelSupports returns false, so the cfg override is the only
-// way to coerce true — which would be a config error on these targets,
-// but is intentionally honored as an explicit operator choice).
+// Non-Linux (or linux-without-cgo): the kernel feature WAIT_KILLABLE_RECV
+// is unavailable on these platforms by default, so kernelSupports
+// reports false and the decision lands on the kernel_unsupported branch
+// in decideWaitKillable. An explicit operator override via cfg still
+// wins per the switch's priority order — honored as an intentional
+// operator choice even though the underlying kernel constant is absent.
 func waitKillableKernelSupports() bool { return false }
 
 func waitKillableProbe(_ context.Context) (bool, error) { return false, nil }

--- a/internal/api/wait_killable_glue_stub.go
+++ b/internal/api/wait_killable_glue_stub.go
@@ -1,0 +1,16 @@
+//go:build !linux || !cgo
+// +build !linux !cgo
+
+package api
+
+import "context"
+
+// Non-Linux (or linux-without-cgo): WAIT_KILLABLE_RECV doesn't exist on
+// these platforms, so the decision is always false regardless of config.
+// The decideWaitKillable switch handles this via the kernel_unsupported
+// branch (kernelSupports returns false, so the cfg override is the only
+// way to coerce true — which would be a config error on these targets,
+// but is intentionally honored as an explicit operator choice).
+func waitKillableKernelSupports() bool { return false }
+
+func waitKillableProbe(_ context.Context) (bool, error) { return false, nil }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -504,6 +504,14 @@ type SandboxSeccompConfig struct {
 	SocketRules           []SandboxSeccompSocketRuleConfig   `yaml:"socket_rules"`
 	MitigationSets        []string                           `yaml:"mitigation_sets"`
 	MitigationDirs        []string                           `yaml:"mitigation_dirs"`
+
+	// WaitKillable tri-states SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV:
+	//   nil   = auto-detect via boot-time behavioral probe
+	//   &true = force on (skip probe)
+	//   &false = force off (skip probe)
+	// Issue #369: kernels >=6 may accept the flag and then misbehave when
+	// the filter combines socket-family and file/metadata-family notify rules.
+	WaitKillable *bool `yaml:"wait_killable"`
 }
 
 // SandboxSeccompUnixConfig configures unix socket monitoring via seccomp.

--- a/internal/config/seccomp_wait_killable.go
+++ b/internal/config/seccomp_wait_killable.go
@@ -1,0 +1,25 @@
+package config
+
+// WaitKillableFilterCompositionTriggersBug returns true when the effective
+// seccomp filter for the given config would install notify rules from both
+// the socket family (unix_socket) AND the file/metadata family
+// (file_monitor or intercept_metadata). This is the known-bad combination
+// from issue #369: on kernels that lie about WAIT_KILLABLE_RECV support
+// (e.g. 6.12.67 with ProcessVMReadv=ENOSYS), the wrapped process is killed
+// by signal during the post-execve syscall storm when this combination is
+// present together with WAIT_KILLABLE_RECV.
+//
+// The function operates on effective config (resolving FileMonitor.*
+// defaults exactly as buildSeccompWrapperConfig does) so that the gotcha
+// in the issue's bisection table — file_monitor.enabled=false with
+// enforce_without_fuse=true still installs metadata notify rules — is
+// caught correctly.
+func WaitKillableFilterCompositionTriggersBug(cfg SandboxSeccompConfig) bool {
+	socketFamily := cfg.UnixSocket.Enabled
+
+	fmDefault := FileMonitorBoolWithDefault(cfg.FileMonitor.EnforceWithoutFUSE, false)
+	fileFamily := FileMonitorBoolWithDefault(cfg.FileMonitor.Enabled, false) ||
+		FileMonitorBoolWithDefault(cfg.FileMonitor.InterceptMetadata, fmDefault)
+
+	return socketFamily && fileFamily
+}

--- a/internal/config/seccomp_wait_killable_test.go
+++ b/internal/config/seccomp_wait_killable_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestWaitKillableFilterCompositionTriggersBug(t *testing.T) {
+	tt := boolPtr(true)
+	ff := boolPtr(false)
+
+	cases := []struct {
+		name string
+		cfg  SandboxSeccompConfig
+		want bool
+	}{
+		{
+			name: "all off",
+			cfg:  SandboxSeccompConfig{},
+			want: false,
+		},
+		{
+			name: "only socket family",
+			cfg: SandboxSeccompConfig{
+				UnixSocket: SandboxSeccompUnixConfig{Enabled: true},
+			},
+			want: false,
+		},
+		{
+			name: "only file_monitor",
+			cfg: SandboxSeccompConfig{
+				FileMonitor: SandboxSeccompFileMonitorConfig{Enabled: tt},
+			},
+			want: false,
+		},
+		{
+			name: "socket + file_monitor explicit on",
+			cfg: SandboxSeccompConfig{
+				UnixSocket:  SandboxSeccompUnixConfig{Enabled: true},
+				FileMonitor: SandboxSeccompFileMonitorConfig{Enabled: tt},
+			},
+			want: true,
+		},
+		{
+			name: "socket + file_monitor disabled but enforce_without_fuse on (intercept_metadata defaults true)",
+			cfg: SandboxSeccompConfig{
+				UnixSocket: SandboxSeccompUnixConfig{Enabled: true},
+				FileMonitor: SandboxSeccompFileMonitorConfig{
+					Enabled:            ff,
+					EnforceWithoutFUSE: tt,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "socket + file_monitor disabled, enforce_without_fuse on, intercept_metadata explicitly off",
+			cfg: SandboxSeccompConfig{
+				UnixSocket: SandboxSeccompUnixConfig{Enabled: true},
+				FileMonitor: SandboxSeccompFileMonitorConfig{
+					Enabled:            ff,
+					EnforceWithoutFUSE: tt,
+					InterceptMetadata:  ff,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "socket + intercept_metadata explicit on, file_monitor explicit off",
+			cfg: SandboxSeccompConfig{
+				UnixSocket: SandboxSeccompUnixConfig{Enabled: true},
+				FileMonitor: SandboxSeccompFileMonitorConfig{
+					Enabled:           ff,
+					InterceptMetadata: tt,
+				},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := WaitKillableFilterCompositionTriggersBug(tc.cfg)
+			if got != tc.want {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/netmonitor/unix/seccomp_linux.go
+++ b/internal/netmonitor/unix/seccomp_linux.go
@@ -257,6 +257,13 @@ type FilterConfig struct {
 	// legacy ProbeWaitKillable() fallback for direct/test invocations
 	// where the server hasn't computed a decision. Issue #369.
 	WaitKillable *bool
+
+	// WaitKillableSource is a stable string identifying why WaitKillable
+	// was chosen ("config", "kernel_unsupported", "filter_composition_safe",
+	// "behavioral_probe", "behavioral_probe_error"). Forwarded from the
+	// server so the per-exec "seccomp: filter loaded" log line can record
+	// it. Issue #369.
+	WaitKillableSource string
 }
 
 // DefaultFilterConfig returns config for unix socket monitoring only.
@@ -513,10 +520,17 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 	// pass NEW_LISTENER (kernel returns the fd even for filters
 	// without ActNotify rules — it's just never readable).
 	libVer := libseccompRuntimeVersion()
+	// kernel_probe_supports reflects the raw kernel probe, independent of
+	// the resolved decision in wait_killable. Logging both lets an
+	// operator see why an exec saw a given flag (wait_killable_source)
+	// alongside what the kernel itself reports. ProbeWaitKillable is
+	// cheap (a Uname()+parse) so calling it twice per filter install is
+	// fine. Issue #369.
 	slog.Info("seccomp: filter loaded",
 		"fd", rawFd,
 		"wait_killable", gotWaitKill,
-		"kernel_probe_supports", wantWaitKill,
+		"wait_killable_source", cfg.WaitKillableSource,
+		"kernel_probe_supports", ProbeWaitKillable(),
 		"libseccomp_runtime", libVer)
 
 	if !filterConfigNeedsNotifyFD(cfg, blockListMap, blockedFamilyMap, socketRules) {

--- a/internal/netmonitor/unix/seccomp_linux.go
+++ b/internal/netmonitor/unix/seccomp_linux.go
@@ -251,6 +251,12 @@ type FilterConfig struct {
 	BlockedFamilies    []seccompkg.BlockedFamily
 	SocketRules        []seccompkg.SocketRule
 	OnBlockAction      seccompkg.OnBlockAction
+
+	// WaitKillable, when non-nil, overrides the legacy kernel-version
+	// probe for SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV. Nil keeps the
+	// legacy ProbeWaitKillable() fallback for direct/test invocations
+	// where the server hasn't computed a decision. Issue #369.
+	WaitKillable *bool
 }
 
 // DefaultFilterConfig returns config for unix socket monitoring only.
@@ -300,7 +306,17 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 	// whose silent-no-op behavior on pre-2.6 headers motivated this
 	// design. The flag value is a kernel ABI constant in x/sys/unix.
 	// See docs/superpowers/specs/2026-05-11-libseccomp25-system-link-design.md.
-	wantWaitKill := ProbeWaitKillable()
+	var wantWaitKill bool
+	if cfg.WaitKillable != nil {
+		wantWaitKill = *cfg.WaitKillable
+	} else {
+		// Legacy fallback for direct/test invocations: when no explicit
+		// decision is provided, fall back to the kernel-version probe.
+		// Server-side decisions (issue #369) always set WaitKillable, so
+		// this path only runs when the wrapper is invoked outside the
+		// normal server flow.
+		wantWaitKill = ProbeWaitKillable()
+	}
 
 	// Unix socket monitoring via user-notify
 	if cfg.UnixSocketEnabled {

--- a/internal/netmonitor/unix/seccomp_linux_test.go
+++ b/internal/netmonitor/unix/seccomp_linux_test.go
@@ -61,6 +61,9 @@ func TestFilterConfig_WithExecve(t *testing.T) {
 // Issue #369: the operator override path must not be subordinate to the
 // kernel-version probe.
 func TestInstallFilterWithConfig_WaitKillableOverride(t *testing.T) {
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify unsupported on this host: %v", err)
+	}
 	bt := true
 	bf := false
 	cases := []struct {

--- a/internal/netmonitor/unix/seccomp_linux_test.go
+++ b/internal/netmonitor/unix/seccomp_linux_test.go
@@ -53,6 +53,57 @@ func TestFilterConfig_WithExecve(t *testing.T) {
 	require.True(t, cfg.UnixSocketEnabled)
 }
 
+// TestInstallFilterWithConfig_WaitKillableOverride asserts that
+// FilterConfig.WaitKillable, when non-nil, controls the
+// SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV bit on the seccomp(2) flags
+// argument regardless of host kernel support.
+//
+// Issue #369: the operator override path must not be subordinate to the
+// kernel-version probe.
+func TestInstallFilterWithConfig_WaitKillableOverride(t *testing.T) {
+	bt := true
+	bf := false
+	cases := []struct {
+		name     string
+		cfgValue *bool
+		wantFlag bool
+	}{
+		{name: "explicit true", cfgValue: &bt, wantFlag: true},
+		{name: "explicit false", cfgValue: &bf, wantFlag: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			origLoad := loadFilterSyscall
+			origPrctl := prctlSetNoNewPrivs
+			t.Cleanup(func() {
+				loadFilterSyscall = origLoad
+				prctlSetNoNewPrivs = origPrctl
+			})
+
+			var capturedFlags uintptr
+			loadFilterSyscall = func(flags uintptr, _ *unix.SockFprog) (int, error) {
+				capturedFlags = flags
+				return 99, nil // pretend success, fd=99
+			}
+			prctlSetNoNewPrivs = func() error { return nil }
+
+			cfg := FilterConfig{
+				UnixSocketEnabled: true,
+				WaitKillable:      tc.cfgValue,
+			}
+			_, err := InstallFilterWithConfig(cfg)
+			if err != nil {
+				t.Fatalf("install: %v", err)
+			}
+			gotFlag := capturedFlags&unix.SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV != 0
+			if gotFlag != tc.wantFlag {
+				t.Fatalf("WAIT_KILLABLE_RECV bit: got %v want %v (flags=0x%x)",
+					gotFlag, tc.wantFlag, capturedFlags)
+			}
+		})
+	}
+}
+
 func TestInstallFilterWithConfig_OnBlockErrno(t *testing.T) {
 	if err := DetectSupport(); err != nil {
 		t.Skip("seccomp user-notify not supported:", err)

--- a/internal/netmonitor/unix/sigurg_probe_test.go
+++ b/internal/netmonitor/unix/sigurg_probe_test.go
@@ -76,3 +76,84 @@ func TestInstallFilter_EmitsWaitKillEngagedOnSupportedKernel(t *testing.T) {
 // outside this test's parent->child dispatch is unsupported; the child
 // will install a seccomp filter in whatever process reads the env var.
 const sigurgProbeHelperEnv = "AGENTSH_TEST_SIGURG_PROBE_HELPER"
+
+// TestInstallFilter_HonorsOperatorOverride re-execs the test binary
+// with FilterConfig.WaitKillable=&false + WaitKillableSource="config"
+// and asserts that:
+//  1. The "seccomp: filter loaded" line announces wait_killable=false.
+//  2. The wait_killable_source field is "config".
+//
+// Issue #369 — end-to-end coverage of the operator override path. The
+// child runs InstallFilterWithConfig with the override pinned off; the
+// parent parses combined stdout+stderr and verifies the structured log
+// line carries both fields through the install path even on a kernel
+// that would otherwise enable WAIT_KILLABLE_RECV.
+func TestInstallFilter_HonorsOperatorOverride(t *testing.T) {
+	if os.Getenv(sigurgOverrideHelperEnv) == "1" {
+		// Re-exec child path: install a minimal filter with the
+		// operator override pinned to false and exit. The parent
+		// asserts on combined stdout+stderr.
+		cfg := FilterConfig{
+			UnixSocketEnabled:  true,
+			WaitKillable:       boolPtrLocalSigurg(false),
+			WaitKillableSource: "config",
+		}
+		filt, err := InstallFilterWithConfig(cfg)
+		if err != nil {
+			t.Fatalf("InstallFilterWithConfig: %v", err)
+		}
+		_ = filt
+		return
+	}
+
+	if testing.Short() {
+		t.Skip("re-exec test skipped in short mode")
+	}
+	if !ProbeWaitKillable() {
+		t.Skip("kernel <6.0: WAIT_KILLABLE_RECV not supported on this host")
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	cmd := exec.Command(exe, "-test.run=^TestInstallFilter_HonorsOperatorOverride$")
+	cmd.Env = append(os.Environ(), sigurgOverrideHelperEnv+"=1")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	runErr := cmd.Run()
+	combined := out.String()
+
+	if runErr != nil {
+		lower := strings.ToLower(combined)
+		if strings.Contains(lower, "permission denied") ||
+			strings.Contains(lower, "operation not permitted") ||
+			strings.Contains(lower, "seccomp not supported") ||
+			strings.Contains(lower, "lacks user notify") {
+			t.Skipf("host cannot install seccomp filter in this environment; skipping.\nhelper output:\n%s", combined)
+		}
+		t.Fatalf("override helper subprocess failed: %v\ncombined output:\n%s", runErr, combined)
+	}
+
+	hasWKFalseText := strings.Contains(combined, `wait_killable=false`)
+	hasWKFalseJSON := strings.Contains(combined, `"wait_killable":false`)
+	if !hasWKFalseText && !hasWKFalseJSON {
+		t.Fatalf("operator override not honored at install time — want wait_killable=false in load log.\ncombined output:\n%s", combined)
+	}
+	hasSrcText := strings.Contains(combined, `wait_killable_source=config`)
+	hasSrcJSON := strings.Contains(combined, `"wait_killable_source":"config"`)
+	if !hasSrcText && !hasSrcJSON {
+		t.Fatalf("wait_killable_source not 'config' in load log — Task 10 plumbing broken.\ncombined output:\n%s", combined)
+	}
+}
+
+// sigurgOverrideHelperEnv gates the re-exec child body for
+// TestInstallFilter_HonorsOperatorOverride. Like sigurgProbeHelperEnv,
+// it must not be set outside the parent->child dispatch.
+const sigurgOverrideHelperEnv = "AGENTSH_TEST_SIGURG_OVERRIDE_HELPER"
+
+// boolPtrLocalSigurg returns a pointer to v. Local helper to keep the
+// override test self-contained without depending on test fixtures
+// elsewhere in the package.
+func boolPtrLocalSigurg(v bool) *bool { return &v }

--- a/internal/netmonitor/unix/wait_killable_probe_linux.go
+++ b/internal/netmonitor/unix/wait_killable_probe_linux.go
@@ -90,6 +90,14 @@ func ProbeWaitKillableBehavior(ctx context.Context, iterations int) (bool, error
 				"iteration", i,
 				"duration_ms", iterDur.Milliseconds(),
 				"error", err.Error())
+			// Emit a final "probe complete" line on the error path too,
+			// so the probe-complete log is symmetric with the killed and
+			// timeout paths. Lets operators grep one line for the final
+			// decision regardless of which terminal branch fired.
+			slog.Info("seccomp: wait_killable probe complete",
+				"decision", false,
+				"reason", fmt.Sprintf("iteration %d error: %v", i, err),
+				"total_duration_ms", time.Since(probeStart).Milliseconds())
 			return false, err
 		}
 		slog.Info("seccomp: wait_killable iteration",

--- a/internal/netmonitor/unix/wait_killable_probe_linux.go
+++ b/internal/netmonitor/unix/wait_killable_probe_linux.go
@@ -1,0 +1,62 @@
+//go:build linux && cgo
+// +build linux,cgo
+
+package unix
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// IterationResult classifies one probe iteration.
+type IterationResult int
+
+const (
+	IterPass IterationResult = iota
+	IterKilled
+	IterTimeout
+)
+
+// runProbeIteration runs a single probe iteration. Production
+// implementation lands in wait_killable_probe_runner_linux.go (Task 7).
+// Exposed as a package var so the decision-logic test can inject a
+// mocked runner.
+var runProbeIteration = func(ctx context.Context) (IterationResult, error) {
+	return 0, errors.New("runProbeIteration not implemented yet")
+}
+
+// ProbeWaitKillableBehavior runs `iterations` real probes of the
+// production filter composition under WAIT_KILLABLE_RECV. Returns true
+// only when every iteration's child exits cleanly (exit_status=0).
+// Short-circuits on the first iteration that fails.
+//
+// Errors from runProbeIteration (fork/socketpair/filter-install failures)
+// cause this function to return the error so callers can apply
+// fail-safe semantics. Iteration outcomes IterKilled and IterTimeout
+// both indicate the kernel bug from issue #369 and cause (false, nil).
+func ProbeWaitKillableBehavior(ctx context.Context, iterations int) (bool, error) {
+	if iterations <= 0 {
+		return false, fmt.Errorf("ProbeWaitKillableBehavior: iterations must be >0, got %d", iterations)
+	}
+	for i := 1; i <= iterations; i++ {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		default:
+		}
+		res, err := runProbeIteration(ctx)
+		if err != nil {
+			return false, err
+		}
+		switch res {
+		case IterPass:
+			continue
+		case IterKilled, IterTimeout:
+			return false, nil
+		default:
+			return false, fmt.Errorf("ProbeWaitKillableBehavior: unknown IterationResult %d", res)
+		}
+	}
+	return true, nil
+}

--- a/internal/netmonitor/unix/wait_killable_probe_linux.go
+++ b/internal/netmonitor/unix/wait_killable_probe_linux.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
+	"time"
 )
 
 // IterationResult classifies one probe iteration's outcome. Issue #369:
@@ -36,6 +38,23 @@ var runProbeIteration = func(ctx context.Context) (IterationResult, error) {
 	return 0, errors.New("runProbeIteration not implemented yet")
 }
 
+// iterationName maps an IterationResult to a stable log-friendly string
+// for the per-iteration log lines emitted by ProbeWaitKillableBehavior.
+// Unknown values yield "unknown_N" so a future enum addition without a
+// corresponding case update is still grep-able.
+func iterationName(r IterationResult) string {
+	switch r {
+	case IterPass:
+		return "pass"
+	case IterKilled:
+		return "killed"
+	case IterTimeout:
+		return "timeout"
+	default:
+		return fmt.Sprintf("unknown_%d", int(r))
+	}
+}
+
 // ProbeWaitKillableBehavior runs `iterations` real probes of the
 // production filter composition under WAIT_KILLABLE_RECV. Returns true
 // only when every iteration's child exits cleanly (exit_status=0).
@@ -49,24 +68,50 @@ func ProbeWaitKillableBehavior(ctx context.Context, iterations int) (bool, error
 	if iterations <= 0 {
 		return false, fmt.Errorf("ProbeWaitKillableBehavior: iterations must be >0, got %d", iterations)
 	}
+	// timeout_per_iter_ms matches the 1s deadline the production runner
+	// applies in runProbeIteration. Hardcoded here to keep the log line
+	// self-contained — a slight drift from a future runner change is
+	// acceptable; the log is operator triage, not telemetry.
+	slog.Info("seccomp: wait_killable behavioral probe starting",
+		"iterations", iterations,
+		"timeout_per_iter_ms", 1000)
+	probeStart := time.Now()
 	for i := 1; i <= iterations; i++ {
 		select {
 		case <-ctx.Done():
 			return false, ctx.Err()
 		default:
 		}
+		iterStart := time.Now()
 		res, err := runProbeIteration(ctx)
+		iterDur := time.Since(iterStart)
 		if err != nil {
+			slog.Info("seccomp: wait_killable iteration error",
+				"iteration", i,
+				"duration_ms", iterDur.Milliseconds(),
+				"error", err.Error())
 			return false, err
 		}
+		slog.Info("seccomp: wait_killable iteration",
+			"iteration", i,
+			"result", iterationName(res),
+			"duration_ms", iterDur.Milliseconds())
 		switch res {
 		case IterPass:
 			continue
 		case IterKilled, IterTimeout:
+			slog.Info("seccomp: wait_killable probe complete",
+				"decision", false,
+				"reason", fmt.Sprintf("iteration %d %s", i, iterationName(res)),
+				"total_duration_ms", time.Since(probeStart).Milliseconds())
 			return false, nil
 		default:
 			return false, fmt.Errorf("ProbeWaitKillableBehavior: unknown IterationResult %d", res)
 		}
 	}
+	slog.Info("seccomp: wait_killable probe complete",
+		"decision", true,
+		"reason", "all iterations passed",
+		"total_duration_ms", time.Since(probeStart).Milliseconds())
 	return true, nil
 }

--- a/internal/netmonitor/unix/wait_killable_probe_linux.go
+++ b/internal/netmonitor/unix/wait_killable_probe_linux.go
@@ -9,19 +9,29 @@ import (
 	"fmt"
 )
 
-// IterationResult classifies one probe iteration.
+// IterationResult classifies one probe iteration's outcome. Issue #369:
+// the kernel bug manifests as the child being killed by signal during
+// its post-execve syscall storm, or as a notify-recv that never returns
+// (which the parent times out).
 type IterationResult int
 
 const (
+	// IterPass: child exec'd /bin/true and exited cleanly. The kernel
+	// did not exhibit the bug for this iteration.
 	IterPass IterationResult = iota
+	// IterKilled: child terminated by signal (WIFSIGNALED) instead of
+	// exiting normally. Strong signal of the issue #369 kernel bug.
 	IterKilled
+	// IterTimeout: child still alive after the per-iteration deadline.
+	// Treated as a failure mode equivalent to IterKilled — a wedged
+	// notify handshake is just as broken as an outright kill.
 	IterTimeout
 )
 
-// runProbeIteration runs a single probe iteration. Production
-// implementation lands in wait_killable_probe_runner_linux.go (Task 7).
-// Exposed as a package var so the decision-logic test can inject a
-// mocked runner.
+// runProbeIteration runs a single probe iteration. The real fork/exec
+// implementation lands in a follow-up task; this placeholder lets the
+// decision logic be tested in isolation. Exposed as a package var so
+// tests can inject a mocked runner.
 var runProbeIteration = func(ctx context.Context) (IterationResult, error) {
 	return 0, errors.New("runProbeIteration not implemented yet")
 }

--- a/internal/netmonitor/unix/wait_killable_probe_linux_test.go
+++ b/internal/netmonitor/unix/wait_killable_probe_linux_test.go
@@ -146,10 +146,13 @@ func TestProbeWaitKillableBehavior_RealKernel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("probe error: %v", err)
 	}
-	t.Logf("probe result: ok=%v duration=%v", ok, dur)
-	if !ok {
-		t.Fatal("probe expected to succeed on stock CI kernel — if this fails, document the kernel posture")
-	}
+	// Do NOT assert ok==true here: this test runs on real kernels, and
+	// on a host that genuinely exhibits the issue #369 kernel bug the
+	// probe will (correctly) return false. That outcome is the whole
+	// point of the probe — failing the test in that case would mean
+	// the test breaks precisely when the code works as designed. The
+	// real assertion is "no error, ran in reasonable time".
+	t.Logf("probe result: ok=%v duration=%v (note for triage if ok=false on this host)", ok, dur)
 	if dur > 5*time.Second {
 		t.Errorf("probe took too long: %v (expected <5s)", dur)
 	}

--- a/internal/netmonitor/unix/wait_killable_probe_linux_test.go
+++ b/internal/netmonitor/unix/wait_killable_probe_linux_test.go
@@ -116,3 +116,10 @@ func TestProbeWaitKillableBehavior_ZeroIterations(t *testing.T) {
 		t.Fatal("want error for iterations=0")
 	}
 }
+
+func TestProbeWaitKillableBehavior_NegativeIterations(t *testing.T) {
+	_, err := ProbeWaitKillableBehavior(context.Background(), -1)
+	if err == nil {
+		t.Fatal("want error for iterations=-1")
+	}
+}

--- a/internal/netmonitor/unix/wait_killable_probe_linux_test.go
+++ b/internal/netmonitor/unix/wait_killable_probe_linux_test.go
@@ -6,7 +6,9 @@ package unix
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
+	"time"
 )
 
 func TestProbeWaitKillableBehavior_AllPass(t *testing.T) {
@@ -121,5 +123,34 @@ func TestProbeWaitKillableBehavior_NegativeIterations(t *testing.T) {
 	_, err := ProbeWaitKillableBehavior(context.Background(), -1)
 	if err == nil {
 		t.Fatal("want error for iterations=-1")
+	}
+}
+
+func TestProbeWaitKillableBehavior_RealKernel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real-fork probe test in short mode")
+	}
+	if _, err := os.Stat("/bin/true"); err != nil {
+		t.Skip("/bin/true missing on this host")
+	}
+	if !ProbeWaitKillable() {
+		t.Skip("kernel <6: WAIT_KILLABLE_RECV not supported on this host")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	t.Cleanup(cancel)
+
+	start := time.Now()
+	ok, err := ProbeWaitKillableBehavior(ctx, 2)
+	dur := time.Since(start)
+	if err != nil {
+		t.Fatalf("probe error: %v", err)
+	}
+	t.Logf("probe result: ok=%v duration=%v", ok, dur)
+	if !ok {
+		t.Fatal("probe expected to succeed on stock CI kernel — if this fails, document the kernel posture")
+	}
+	if dur > 5*time.Second {
+		t.Errorf("probe took too long: %v (expected <5s)", dur)
 	}
 }

--- a/internal/netmonitor/unix/wait_killable_probe_linux_test.go
+++ b/internal/netmonitor/unix/wait_killable_probe_linux_test.go
@@ -1,0 +1,118 @@
+//go:build linux && cgo
+// +build linux,cgo
+
+package unix
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestProbeWaitKillableBehavior_AllPass(t *testing.T) {
+	orig := runProbeIteration
+	t.Cleanup(func() { runProbeIteration = orig })
+
+	calls := 0
+	runProbeIteration = func(_ context.Context) (IterationResult, error) {
+		calls++
+		return IterPass, nil
+	}
+	ok, err := ProbeWaitKillableBehavior(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !ok {
+		t.Fatal("want true")
+	}
+	if calls != 5 {
+		t.Fatalf("want 5 iterations, got %d", calls)
+	}
+}
+
+func TestProbeWaitKillableBehavior_FirstFailShortCircuits(t *testing.T) {
+	orig := runProbeIteration
+	t.Cleanup(func() { runProbeIteration = orig })
+
+	calls := 0
+	runProbeIteration = func(_ context.Context) (IterationResult, error) {
+		calls++
+		return IterKilled, nil
+	}
+	ok, err := ProbeWaitKillableBehavior(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatal("want false")
+	}
+	if calls != 1 {
+		t.Fatalf("want short-circuit after 1 iteration, got %d", calls)
+	}
+}
+
+func TestProbeWaitKillableBehavior_MidFail(t *testing.T) {
+	orig := runProbeIteration
+	t.Cleanup(func() { runProbeIteration = orig })
+
+	calls := 0
+	runProbeIteration = func(_ context.Context) (IterationResult, error) {
+		calls++
+		if calls == 3 {
+			return IterTimeout, nil
+		}
+		return IterPass, nil
+	}
+	ok, err := ProbeWaitKillableBehavior(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if ok {
+		t.Fatal("want false (timeout at iter 3 must fail the probe)")
+	}
+	if calls != 3 {
+		t.Fatalf("want 3 iterations, got %d", calls)
+	}
+}
+
+func TestProbeWaitKillableBehavior_ErrorPropagates(t *testing.T) {
+	orig := runProbeIteration
+	t.Cleanup(func() { runProbeIteration = orig })
+
+	want := errors.New("fork failed")
+	runProbeIteration = func(_ context.Context) (IterationResult, error) {
+		return 0, want
+	}
+	ok, err := ProbeWaitKillableBehavior(context.Background(), 5)
+	if !errors.Is(err, want) {
+		t.Fatalf("want %v, got %v", want, err)
+	}
+	if ok {
+		t.Fatal("want false on error")
+	}
+}
+
+func TestProbeWaitKillableBehavior_CancelledContext(t *testing.T) {
+	orig := runProbeIteration
+	t.Cleanup(func() { runProbeIteration = orig })
+
+	runProbeIteration = func(_ context.Context) (IterationResult, error) {
+		return IterPass, nil
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	ok, err := ProbeWaitKillableBehavior(ctx, 5)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+	if ok {
+		t.Fatal("want false on cancel")
+	}
+}
+
+func TestProbeWaitKillableBehavior_ZeroIterations(t *testing.T) {
+	_, err := ProbeWaitKillableBehavior(context.Background(), 0)
+	if err == nil {
+		t.Fatal("want error for iterations=0")
+	}
+}

--- a/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
+++ b/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
@@ -4,14 +4,17 @@
 package unix
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"os"
 	"os/exec"
 	"strconv"
+	"sync"
 	"syscall"
 	"time"
 
@@ -20,18 +23,59 @@ import (
 )
 
 const (
+	// probeChildEnv is set to a per-invocation random token by the parent
+	// and checked by the child's init(). A leaked or inherited "=1"-style
+	// sentinel would silently turn unrelated subprocesses into probe
+	// children; gating on a fresh random token written only by the
+	// immediate parent prevents that.
 	probeChildEnv    = "AGENTSH_WAIT_KILLABLE_PROBE_CHILD"
 	probeChildSockFD = "AGENTSH_WAIT_KILLABLE_PROBE_SOCK"
 	probeBinaryPath  = "/bin/true"
+
+	// probeChildStderrCap bounds how much child stderr we propagate back
+	// to the parent on failure. Child diagnostics are short
+	// fmt.Fprintf(os.Stderr, ...) lines; 4 KiB is ample headroom.
+	probeChildStderrCap = 4096
 )
+
+// probeChildToken is the per-process random token the parent uses to
+// authenticate probe-child invocations. It is generated lazily on first
+// use in the parent and matched against probeChildEnv in the child's
+// init(). A non-empty, well-formed token is required; the bare literal
+// "1" is not accepted.
+var (
+	probeChildTokenOnce sync.Once
+	probeChildToken     string
+)
+
+func ensureProbeChildToken() string {
+	probeChildTokenOnce.Do(func() {
+		var b [16]byte
+		if _, err := rand.Read(b[:]); err != nil {
+			// Fall back to a process-pid-derived token. Still
+			// per-invocation in the sense that crashed neighbours
+			// won't share it, and good enough since this is a
+			// defence-in-depth measure (not a security boundary).
+			probeChildToken = fmt.Sprintf("pid-%d-time-%d", os.Getpid(), time.Now().UnixNano())
+			return
+		}
+		probeChildToken = hex.EncodeToString(b[:])
+	})
+	return probeChildToken
+}
 
 // init wires the production runner and detects probe-child mode. When
 // invoked as a probe child the process never returns: it either execs
 // /bin/true (success path) or os.Exit(70)s. Otherwise it just installs
 // realRunProbeIteration over the placeholder from
 // wait_killable_probe_linux.go.
+//
+// Child detection requires probeChildEnv to be set to a well-formed
+// hex/identifier value (length >=16). A short value (e.g. "1") is
+// rejected so a stray export in a developer shell does not turn
+// arbitrary subprocesses into probe children.
 func init() {
-	if os.Getenv(probeChildEnv) == "1" {
+	if tok := os.Getenv(probeChildEnv); len(tok) >= 16 {
 		runProbeChild()
 		// runProbeChild never returns on success (it execs). If it does
 		// return, treat as fatal child-side error so the rest of the
@@ -56,6 +100,9 @@ func runProbeChild() {
 		return
 	}
 
+	// loadRawFilter sets PR_SET_NO_NEW_PRIVS internally (see
+	// seccomp_load_linux.go:121) before invoking seccomp(2), so a
+	// non-root probe child can install the filter without CAP_SYS_ADMIN.
 	notifyFD, err := loadRawFilter(prog, true)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "wait_killable probe child: install filter: %v\n", err)
@@ -149,62 +196,111 @@ func realRunProbeIteration(ctx context.Context) (IterationResult, error) {
 	parentSock, childSock := pair[0], pair[1]
 	defer unix.Close(parentSock)
 
+	// Wrap childSock immediately so the *os.File owns the fd: cmd.Start
+	// dups it into the child as fd 3, and we close our end via
+	// childFile.Close() (which clears the runtime finalizer). Calling
+	// unix.Close(childSock) directly here would double-close once the
+	// finalizer ran, potentially nuking an unrelated fd that took the
+	// number after the first close.
+	childFile := os.NewFile(uintptr(childSock), "probe-sock")
+	// Defensive: if we never reach a normal close path, the deferred
+	// Close still releases the fd exactly once. Close() on an already
+	// closed *os.File is a no-op modulo a returned EBADF that we
+	// deliberately ignore here.
+	defer childFile.Close()
+
 	binaryPath, err := os.Executable()
 	if err != nil {
-		unix.Close(childSock)
 		return 0, fmt.Errorf("os.Executable: %w", err)
 	}
 
 	cmd := exec.CommandContext(ctx, binaryPath)
 	cmd.Env = []string{
-		probeChildEnv + "=1",
+		probeChildEnv + "=" + ensureProbeChildToken(),
 		probeChildSockFD + "=3", // ExtraFiles index 0 = fd 3
 	}
-	cmd.ExtraFiles = []*os.File{os.NewFile(uintptr(childSock), "probe-sock")}
-	cmd.Stdout = io.Discard
-	cmd.Stderr = io.Discard
+	cmd.ExtraFiles = []*os.File{childFile}
+	// Capture child stderr (bounded) so operators can see why a probe
+	// child failed. Without this, classifyProbeExit returns a generic
+	// wrapper error and the real cause (bad filter, EPERM, missing
+	// /bin/true, etc.) is lost.
+	stderrBuf := &boundedBuffer{cap: probeChildStderrCap}
+	cmd.Stdout = nil
+	cmd.Stderr = stderrBuf
 	cmd.Stdin = nil
 
 	if err := cmd.Start(); err != nil {
-		unix.Close(childSock)
 		return 0, fmt.Errorf("start probe child: %w", err)
 	}
-	// The fd was duped into the child; close our end.
-	_ = unix.Close(childSock)
+	// The fd was duped into the child; close our end. Closing via the
+	// *os.File wrapper (not unix.Close) keeps ownership single-rooted.
+	_ = childFile.Close()
 
 	notifyFD, err := recvProbeFD(parentSock)
 	if err != nil {
 		_ = cmd.Process.Kill()
 		_, _ = cmd.Process.Wait()
-		return 0, fmt.Errorf("recv probe fd: %w", err)
+		return 0, fmt.Errorf("recv probe fd: %w (child stderr: %q)", err, stderrBuf.String())
 	}
-	defer unix.Close(notifyFD)
+	// notifyFD ownership: closed below before we wait on `done`, so
+	// the service goroutine's NotifReceive unblocks.
 
 	// Service notifications until the child exits.
 	done := make(chan error, 1)
 	go func() { done <- cmd.Wait() }()
 
 	serviceCtx, serviceCancel := context.WithCancel(ctx)
-	defer serviceCancel()
-	go serviceProbeNotifications(serviceCtx, notifyFD)
+	serviceDone := make(chan struct{})
+	go func() {
+		defer close(serviceDone)
+		serviceProbeNotifications(serviceCtx, notifyFD)
+	}()
 
 	timeout := time.NewTimer(time.Second)
 	defer timeout.Stop()
 
+	// finish performs the common cleanup of the service goroutine.
+	// Closing notifyFD wakes any in-flight seccomp.NotifReceive (the
+	// kernel returns EBADF/ENOENT), guaranteeing the goroutine exits
+	// even though it spends most of its time blocked inside a syscall
+	// that ignores serviceCancel.
+	finish := func() {
+		serviceCancel()
+		_ = unix.Close(notifyFD)
+		<-serviceDone
+	}
+
 	select {
-	case err := <-done:
-		serviceCancel()
-		return classifyProbeExit(err)
+	case waitErr := <-done:
+		finish()
+		// If the iteration was cancelled out from under us
+		// (ctx.Done before child exit), cmd.Wait()'s ExitError will
+		// show WIFSIGNALED because exec.CommandContext SIGKILLs the
+		// child on ctx-cancel. Treating that as IterKilled would
+		// silently flip the wait_killable decision to false because
+		// shutdown happened to race the probe. Propagate the ctx
+		// error instead.
+		if cerr := ctx.Err(); cerr != nil {
+			return 0, cerr
+		}
+		return classifyProbeExit(waitErr, stderrBuf.String())
 	case <-timeout.C:
-		serviceCancel()
 		_ = cmd.Process.Kill()
 		<-done
+		finish()
 		return IterTimeout, nil
 	}
 }
 
 // serviceProbeNotifications drains the notify fd and responds CONTINUE
 // to every notification until ctx is cancelled or the fd errors.
+//
+// Termination: seccomp.NotifReceive blocks inside an ioctl that does
+// NOT observe ctx. The goroutine is freed when the caller closes
+// notifyFD (the kernel returns an error and we exit). The ctx select
+// at the top of the loop only short-circuits the rare window between
+// notifications where the goroutine has already returned from
+// NotifReceive and is about to loop.
 //
 // Uses libseccomp-golang's seccomp.NotifReceive (the same call site as
 // internal/netmonitor/unix/handler.go:41) for receive, and the existing
@@ -232,7 +328,10 @@ func serviceProbeNotifications(ctx context.Context, notifyFD int) {
 }
 
 // classifyProbeExit maps cmd.Wait()'s result to an IterationResult.
-func classifyProbeExit(err error) (IterationResult, error) {
+// childStderr is the captured child stderr (bounded) and is included
+// in the error return for the "unclassified" case so operators can
+// see what the child actually printed before it died.
+func classifyProbeExit(err error, childStderr string) (IterationResult, error) {
 	if err == nil {
 		return IterPass, nil
 	}
@@ -248,5 +347,37 @@ func classifyProbeExit(err error) (IterationResult, error) {
 			return IterKilled, nil
 		}
 	}
+	if childStderr != "" {
+		return 0, fmt.Errorf("wait_killable probe: unclassified exit: %w (child stderr: %q)", err, childStderr)
+	}
 	return 0, fmt.Errorf("wait_killable probe: unclassified exit: %w", err)
+}
+
+// boundedBuffer is a write-only buffer that caps growth at `cap` bytes,
+// silently dropping later writes. Used to bound child stderr so a
+// pathological child can't blow up the parent's memory.
+type boundedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+	cap int
+}
+
+func (b *boundedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	remaining := b.cap - b.buf.Len()
+	if remaining <= 0 {
+		return len(p), nil // pretend success; data is dropped
+	}
+	if len(p) > remaining {
+		_, _ = b.buf.Write(p[:remaining])
+		return len(p), nil
+	}
+	return b.buf.Write(p)
+}
+
+func (b *boundedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
+++ b/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
@@ -24,10 +24,12 @@ import (
 
 const (
 	// probeChildEnv carries a per-invocation random token written by
-	// the parent and inspected by the child's init(). The gate also
-	// requires probeChildArgvSentinel in argv[1]; both must match.
-	// Together they prevent stray inherited env or a lone misconfigured
-	// arg from hijacking the binary.
+	// the parent. The env var is length-validated (>=16 chars) to
+	// reject trivial sentinels like "1"/"true"/"yes"; only the argv[1]
+	// sentinel below is matched by string equality. Together they form
+	// a defence-in-depth gate, not a security boundary: a deliberate
+	// caller who knows the contract and supplies both factors can
+	// still invoke probe-child mode.
 	probeChildEnv    = "AGENTSH_WAIT_KILLABLE_PROBE_CHILD"
 	probeChildSockFD = "AGENTSH_WAIT_KILLABLE_PROBE_SOCK"
 	probeBinaryPath  = "/bin/true"
@@ -54,6 +56,12 @@ const (
 	// internally on libseccomp filter compilation and the seccomp(2)
 	// syscall, neither of which should ever exceed sub-second; 2s is
 	// generous headroom for slow CI VMs.
+	//
+	// Per-iteration worst case is therefore probeRecvTimeout +
+	// (post-handoff 1s timer in realRunProbeIteration) = ~3s. With
+	// the recommended 5 iterations the upper bound on probe latency
+	// is ~15s. The design spec's 5s figure is for the happy path
+	// (each iteration completes in tens of ms on healthy kernels).
 	probeRecvTimeout = 2 * time.Second
 )
 
@@ -165,6 +173,15 @@ func runProbeChild() {
 	// just a stat-miss — also covers e.g. /bin/true existing but being
 	// non-executable), fall back to /bin/echo. Only after both fail do
 	// we treat this as a setup failure.
+	//
+	// IMPORTANT: the seccomp filter is already installed by this point,
+	// so the second Exec attempt runs under the same filter as the
+	// first. If the kernel bug is present the first failed Exec may
+	// have already triggered the issue #369 kill-signal in the
+	// parent's classifier; the fallback is therefore not a pristine
+	// retry. This is acceptable because both candidates produce the
+	// same observable post-execve syscall storm (libc startup + a
+	// handful of trivial syscalls before exit).
 	candidates := []string{probeBinaryPath, "/bin/echo"}
 	var lastErr error
 	for _, bin := range candidates {

--- a/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
+++ b/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
@@ -80,6 +80,15 @@ func ensureProbeChildToken() string {
 	return probeChildToken
 }
 
+// buildProbeChildArgv returns the argv the parent must use when
+// re-execing itself as a probe child. Centralised so the two ends of
+// the contract — parent construction here vs. child detection in
+// isProbeChildInvocation — never decouple. If you change the shape,
+// update both call sites in this file.
+func buildProbeChildArgv(binaryPath string) []string {
+	return []string{binaryPath, probeChildArgvSentinel}
+}
+
 // isProbeChildInvocation reports whether the current process was
 // launched as a probe child. The gate is a two-factor check:
 //
@@ -90,7 +99,7 @@ func ensureProbeChildToken() string {
 // developer shell could hijack arbitrary subprocesses (env-only), and
 // argv[0]/argv[1] inspection alone would miss the actual cross-check
 // the parent uses (argv-only). Requiring both narrows the gate to
-// invocations the parent itself constructed.
+// invocations the parent itself constructed (see buildProbeChildArgv).
 func isProbeChildInvocation() bool {
 	if len(os.Args) < 2 || os.Args[1] != probeChildArgvSentinel {
 		return false
@@ -152,13 +161,21 @@ func runProbeChild() {
 	_ = unix.Close(sockFD)
 
 	// Exec /bin/true to fire the post-execve syscall storm under the
-	// installed filter. Falls back to /bin/echo if /bin/true is missing.
-	bin := probeBinaryPath
-	if _, err := os.Stat(bin); err != nil {
-		bin = "/bin/echo"
+	// installed filter. Try /bin/true first; if Exec itself fails (not
+	// just a stat-miss — also covers e.g. /bin/true existing but being
+	// non-executable), fall back to /bin/echo. Only after both fail do
+	// we treat this as a setup failure.
+	candidates := []string{probeBinaryPath, "/bin/echo"}
+	var lastErr error
+	for _, bin := range candidates {
+		if _, statErr := os.Stat(bin); statErr != nil {
+			lastErr = statErr
+			continue
+		}
+		// syscall.Exec only returns on failure.
+		lastErr = syscall.Exec(bin, []string{bin}, []string{})
 	}
-	_ = syscall.Exec(bin, []string{bin}, []string{})
-	childSetupFailure("exec %s failed", bin)
+	childSetupFailure("exec failed: %v", lastErr)
 }
 
 // buildProbeFilterBytes constructs the worst-case filter composition
@@ -230,6 +247,22 @@ func realRunProbeIteration(ctx context.Context) (IterationResult, error) {
 	parentSock, childSock := pair[0], pair[1]
 	defer unix.Close(parentSock)
 
+	// Apply a recv timeout to parentSock so a hung child (stuck inside
+	// loadRawFilter or before reaching sendProbeFD) cannot wedge the
+	// parent. Set BEFORE cmd.Start so the guard is in place from the
+	// instant the child can begin executing — there's no race window
+	// where a wedged child could outrace SO_RCVTIMEO application.
+	// The per-iteration 1-second timer below only arms after
+	// recvProbeFD returns, so without this the failure mode would be
+	// "parent hangs forever". SO_RCVTIMEO causes Recvmsg to return
+	// EAGAIN/EWOULDBLOCK when the timeout fires.
+	tv := unix.NsecToTimeval(probeRecvTimeout.Nanoseconds())
+	if err := unix.SetsockoptTimeval(parentSock, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &tv); err != nil {
+		// Non-fatal: log and continue. Worst case we lose the
+		// guard but keep the rest of the iteration.
+		slog.Debug("wait_killable probe: SO_RCVTIMEO failed", "error", err)
+	}
+
 	// Wrap childSock immediately so the *os.File owns the fd: cmd.Start
 	// dups it into the child as fd 3, and we close our end via
 	// childFile.Close() (which clears the runtime finalizer). Calling
@@ -259,7 +292,7 @@ func realRunProbeIteration(ctx context.Context) (IterationResult, error) {
 	cmd := exec.CommandContext(ctx, binaryPath)
 	// argv[1] sentinel + per-invocation random env token form a
 	// two-factor gate for probe-child mode (see isProbeChildInvocation).
-	cmd.Args = []string{binaryPath, probeChildArgvSentinel}
+	cmd.Args = buildProbeChildArgv(binaryPath)
 	// Inherit the parent's environment so loader-related variables
 	// (LD_LIBRARY_PATH, LD_PRELOAD, NixOS / Alpine / sanitizer
 	// RPATH-substitution env) survive into the child. A wholesale
@@ -290,19 +323,6 @@ func realRunProbeIteration(ctx context.Context) (IterationResult, error) {
 	// block indefinitely on an early child crash because we'd still
 	// be a writer on the socketpair.
 	closeChild()
-
-	// Apply a recv timeout to parentSock so a hung child (stuck inside
-	// loadRawFilter or before reaching sendProbeFD) cannot wedge the
-	// parent. The per-iteration 1-second timer below only arms after
-	// recvProbeFD returns, so without this the failure mode would be
-	// "parent hangs forever". SO_RCVTIMEO causes Recvmsg to return
-	// EAGAIN/EWOULDBLOCK when the timeout fires.
-	tv := unix.NsecToTimeval(probeRecvTimeout.Nanoseconds())
-	if err := unix.SetsockoptTimeval(parentSock, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &tv); err != nil {
-		// Non-fatal: log and continue. Worst case we lose the
-		// guard but keep the rest of the iteration.
-		slog.Debug("wait_killable probe: SO_RCVTIMEO failed", "error", err)
-	}
 
 	notifyFD, err := recvProbeFD(parentSock)
 	if err != nil {
@@ -429,11 +449,20 @@ func classifyProbeExit(err error, childStderr string) (IterationResult, error) {
 					return 0, fmt.Errorf("wait_killable probe: child setup failed (exit %d, stderr: %q)", ws.ExitStatus(), childStderr)
 				}
 			}
-			// Non-signaled, non-setup-failure exit: the child made
-			// it past the seccomp install and the exec call but
-			// exited non-zero. Treat as a kernel-bug-style failure
-			// (the post-execve syscall storm did not complete
-			// cleanly). Include stderr for triage.
+			// Non-signaled exit that did not match a known
+			// setup-failure code. In the current design the child
+			// only exits via childSetupFailure (status 71), the
+			// init() fallback (status 70), or by exec'ing
+			// /bin/true|echo (status 0 on success → caught by
+			// `err == nil` above). So this branch in practice
+			// catches /bin/true returning non-zero (which would
+			// be unusual but possible if the post-execve syscall
+			// storm disrupted it) or /bin/echo returning non-zero.
+			// Treat as a kernel-bug-style failure.
+			//
+			// NOTE: any future addition of a non-setup-failure
+			// os.Exit path in the child MUST update the switch
+			// above; the compiler cannot enforce this.
 			if childStderr != "" {
 				slog.Debug("wait_killable probe: child exited non-zero", "stderr", childStderr)
 			}

--- a/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
+++ b/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
@@ -23,11 +23,15 @@ import (
 )
 
 const (
-	// probeChildEnv is set to a per-invocation random token by the parent
-	// and checked by the child's init(). A leaked or inherited "=1"-style
-	// sentinel would silently turn unrelated subprocesses into probe
-	// children; gating on a fresh random token written only by the
-	// immediate parent prevents that.
+	// probeChildEnv carries a per-invocation random token written by
+	// the parent and inspected by the child's init(). The gate is a
+	// length filter (>=16 chars), not a cryptographic match: the parent
+	// cannot share its in-process token with the child without writing
+	// it via this same env var. The defence is therefore against
+	// trivial sentinels like "1"/"true"/"yes" — a deliberate caller
+	// who knows the contract and supplies any 16+ char value can still
+	// invoke probe-child mode, which is acceptable (this is a private
+	// internal contract, not a security boundary).
 	probeChildEnv    = "AGENTSH_WAIT_KILLABLE_PROBE_CHILD"
 	probeChildSockFD = "AGENTSH_WAIT_KILLABLE_PROBE_SOCK"
 	probeBinaryPath  = "/bin/true"
@@ -215,10 +219,17 @@ func realRunProbeIteration(ctx context.Context) (IterationResult, error) {
 	}
 
 	cmd := exec.CommandContext(ctx, binaryPath)
-	cmd.Env = []string{
-		probeChildEnv + "=" + ensureProbeChildToken(),
-		probeChildSockFD + "=3", // ExtraFiles index 0 = fd 3
-	}
+	// Inherit the parent's environment so loader-related variables
+	// (LD_LIBRARY_PATH, LD_PRELOAD, NixOS / Alpine / sanitizer
+	// RPATH-substitution env) survive into the child. A wholesale
+	// replacement would render the probe non-functional on those
+	// hosts. probeChildEnv is appended last so a pre-existing
+	// AGENTSH_WAIT_KILLABLE_PROBE_CHILD in the parent's environment
+	// cannot override our per-invocation token.
+	cmd.Env = append(os.Environ(),
+		probeChildEnv+"="+ensureProbeChildToken(),
+		probeChildSockFD+"=3", // ExtraFiles index 0 = fd 3
+	)
 	cmd.ExtraFiles = []*os.File{childFile}
 	// Capture child stderr (bounded) so operators can see why a probe
 	// child failed. Without this, classifyProbeExit returns a generic
@@ -239,7 +250,10 @@ func realRunProbeIteration(ctx context.Context) (IterationResult, error) {
 	notifyFD, err := recvProbeFD(parentSock)
 	if err != nil {
 		_ = cmd.Process.Kill()
-		_, _ = cmd.Process.Wait()
+		// cmd.Wait() (not cmd.Process.Wait) drains os/exec's internal
+		// stderr-copy goroutine before returning, so stderrBuf is
+		// fully populated by the time we read it below.
+		_ = cmd.Wait()
 		return 0, fmt.Errorf("recv probe fd: %w (child stderr: %q)", err, stderrBuf.String())
 	}
 	// notifyFD ownership: closed below before we wait on `done`, so
@@ -341,9 +355,12 @@ func classifyProbeExit(err error, childStderr string) (IterationResult, error) {
 			if ws.Signaled() {
 				return IterKilled, nil
 			}
-			if ws.Exited() && ws.ExitStatus() == 0 {
-				return IterPass, nil
-			}
+			// cmd.Wait returns nil for status-0 exits, so an
+			// ExitError here implies a non-zero exit; treat any
+			// non-signaled failure as IterKilled (the child died
+			// before reaching exec or /bin/true returned non-zero
+			// — both indicate the iteration didn't cleanly survive
+			// the post-execve syscall storm).
 			return IterKilled, nil
 		}
 	}

--- a/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
+++ b/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
@@ -24,29 +24,41 @@ import (
 
 const (
 	// probeChildEnv carries a per-invocation random token written by
-	// the parent and inspected by the child's init(). The gate is a
-	// length filter (>=16 chars), not a cryptographic match: the parent
-	// cannot share its in-process token with the child without writing
-	// it via this same env var. The defence is therefore against
-	// trivial sentinels like "1"/"true"/"yes" — a deliberate caller
-	// who knows the contract and supplies any 16+ char value can still
-	// invoke probe-child mode, which is acceptable (this is a private
-	// internal contract, not a security boundary).
+	// the parent and inspected by the child's init(). The gate also
+	// requires probeChildArgvSentinel in argv[1]; both must match.
+	// Together they prevent stray inherited env or a lone misconfigured
+	// arg from hijacking the binary.
 	probeChildEnv    = "AGENTSH_WAIT_KILLABLE_PROBE_CHILD"
 	probeChildSockFD = "AGENTSH_WAIT_KILLABLE_PROBE_SOCK"
 	probeBinaryPath  = "/bin/true"
+
+	// probeChildArgvSentinel is the marker the parent injects as argv[1]
+	// of the probe child. The child's init() requires this exact value
+	// before honouring the env-var token. A version suffix lets us bump
+	// the protocol later without colliding with old in-flight tests.
+	probeChildArgvSentinel = "--agentsh-internal-wait-killable-probe-child-v1"
 
 	// probeChildStderrCap bounds how much child stderr we propagate back
 	// to the parent on failure. Child diagnostics are short
 	// fmt.Fprintf(os.Stderr, ...) lines; 4 KiB is ample headroom.
 	probeChildStderrCap = 4096
+
+	// Exit codes used by the probe child. The parent's classifier
+	// treats these specifically so a setup failure does not look like
+	// a kernel-bug hit.
+	probeExitSetupFailure = 71 // any runProbeChild early-return (bad env, filter build, install, fd send, etc.)
+	probeExitFallback     = 70 // runProbeChild returned past the exec call without any explicit early-return (shouldn't happen)
+
+	// probeRecvTimeout caps how long the parent waits for the child to
+	// send its notify fd before giving up. The child only blocks
+	// internally on libseccomp filter compilation and the seccomp(2)
+	// syscall, neither of which should ever exceed sub-second; 2s is
+	// generous headroom for slow CI VMs.
+	probeRecvTimeout = 2 * time.Second
 )
 
 // probeChildToken is the per-process random token the parent uses to
-// authenticate probe-child invocations. It is generated lazily on first
-// use in the parent and matched against probeChildEnv in the child's
-// init(). A non-empty, well-formed token is required; the bare literal
-// "1" is not accepted.
+// authenticate probe-child invocations.
 var (
 	probeChildTokenOnce sync.Once
 	probeChildToken     string
@@ -68,40 +80,60 @@ func ensureProbeChildToken() string {
 	return probeChildToken
 }
 
+// isProbeChildInvocation reports whether the current process was
+// launched as a probe child. The gate is a two-factor check:
+//
+//   - argv[1] must equal probeChildArgvSentinel (a stable internal marker)
+//   - the probeChildEnv variable must be set to a value of length >= 16
+//
+// Either alone would be too permissive: a stray env export in a
+// developer shell could hijack arbitrary subprocesses (env-only), and
+// argv[0]/argv[1] inspection alone would miss the actual cross-check
+// the parent uses (argv-only). Requiring both narrows the gate to
+// invocations the parent itself constructed.
+func isProbeChildInvocation() bool {
+	if len(os.Args) < 2 || os.Args[1] != probeChildArgvSentinel {
+		return false
+	}
+	if tok := os.Getenv(probeChildEnv); len(tok) >= 16 {
+		return true
+	}
+	return false
+}
+
 // init wires the production runner and detects probe-child mode. When
 // invoked as a probe child the process never returns: it either execs
-// /bin/true (success path) or os.Exit(70)s. Otherwise it just installs
-// realRunProbeIteration over the placeholder from
-// wait_killable_probe_linux.go.
-//
-// Child detection requires probeChildEnv to be set to a well-formed
-// hex/identifier value (length >=16). A short value (e.g. "1") is
-// rejected so a stray export in a developer shell does not turn
-// arbitrary subprocesses into probe children.
+// /bin/true (success path) or exits with a setup-failure status.
+// Otherwise it installs realRunProbeIteration over the placeholder
+// from wait_killable_probe_linux.go.
 func init() {
-	if tok := os.Getenv(probeChildEnv); len(tok) >= 16 {
+	if isProbeChildInvocation() {
 		runProbeChild()
-		// runProbeChild never returns on success (it execs). If it does
-		// return, treat as fatal child-side error so the rest of the
-		// binary's init()s and main() never run.
-		os.Exit(70)
+		// runProbeChild never returns on success (it execs); any
+		// return is a setup failure that the parent decodes via
+		// probeExitSetupFailure.
+		os.Exit(probeExitFallback)
 	}
 	runProbeIteration = realRunProbeIteration
+}
+
+// childSetupFailure prints msg to stderr and exits with the
+// setup-failure status the parent's classifier recognises.
+func childSetupFailure(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "wait_killable probe child: "+format+"\n", args...)
+	os.Exit(probeExitSetupFailure)
 }
 
 func runProbeChild() {
 	sockStr := os.Getenv(probeChildSockFD)
 	sockFD, err := strconv.Atoi(sockStr)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "wait_killable probe child: bad %s=%q: %v\n",
-			probeChildSockFD, sockStr, err)
-		return
+		childSetupFailure("bad %s=%q: %v", probeChildSockFD, sockStr, err)
 	}
 
 	prog, err := buildProbeFilterBytes()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "wait_killable probe child: build filter: %v\n", err)
-		return
+		childSetupFailure("build filter: %v", err)
 	}
 
 	// loadRawFilter sets PR_SET_NO_NEW_PRIVS internally (see
@@ -109,14 +141,12 @@ func runProbeChild() {
 	// non-root probe child can install the filter without CAP_SYS_ADMIN.
 	notifyFD, err := loadRawFilter(prog, true)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "wait_killable probe child: install filter: %v\n", err)
-		return
+		childSetupFailure("install filter: %v", err)
 	}
 
 	// Hand notifyFD to the parent.
 	if err := sendProbeFD(sockFD, notifyFD); err != nil {
-		fmt.Fprintf(os.Stderr, "wait_killable probe child: send fd: %v\n", err)
-		return
+		childSetupFailure("send fd: %v", err)
 	}
 	_ = unix.Close(notifyFD)
 	_ = unix.Close(sockFD)
@@ -128,7 +158,7 @@ func runProbeChild() {
 		bin = "/bin/echo"
 	}
 	_ = syscall.Exec(bin, []string{bin}, []string{})
-	fmt.Fprintf(os.Stderr, "wait_killable probe child: exec failed\n")
+	childSetupFailure("exec %s failed", bin)
 }
 
 // buildProbeFilterBytes constructs the worst-case filter composition
@@ -203,15 +233,23 @@ func realRunProbeIteration(ctx context.Context) (IterationResult, error) {
 	// Wrap childSock immediately so the *os.File owns the fd: cmd.Start
 	// dups it into the child as fd 3, and we close our end via
 	// childFile.Close() (which clears the runtime finalizer). Calling
-	// unix.Close(childSock) directly here would double-close once the
-	// finalizer ran, potentially nuking an unrelated fd that took the
-	// number after the first close.
+	// unix.Close(childSock) directly would double-close once the
+	// finalizer ran, potentially nuking an unrelated fd.
+	//
+	// We do NOT defer childFile.Close(): the recvProbeFD path requires
+	// the parent's copy of the child socket to be CLOSED so the kernel
+	// can signal EOF if the child dies before sending. We close
+	// explicitly immediately after cmd.Start() succeeds and rely on a
+	// `closed` guard for the failure paths.
 	childFile := os.NewFile(uintptr(childSock), "probe-sock")
-	// Defensive: if we never reach a normal close path, the deferred
-	// Close still releases the fd exactly once. Close() on an already
-	// closed *os.File is a no-op modulo a returned EBADF that we
-	// deliberately ignore here.
-	defer childFile.Close()
+	childFileClosed := false
+	closeChild := func() {
+		if !childFileClosed {
+			_ = childFile.Close()
+			childFileClosed = true
+		}
+	}
+	defer closeChild()
 
 	binaryPath, err := os.Executable()
 	if err != nil {
@@ -219,6 +257,9 @@ func realRunProbeIteration(ctx context.Context) (IterationResult, error) {
 	}
 
 	cmd := exec.CommandContext(ctx, binaryPath)
+	// argv[1] sentinel + per-invocation random env token form a
+	// two-factor gate for probe-child mode (see isProbeChildInvocation).
+	cmd.Args = []string{binaryPath, probeChildArgvSentinel}
 	// Inherit the parent's environment so loader-related variables
 	// (LD_LIBRARY_PATH, LD_PRELOAD, NixOS / Alpine / sanitizer
 	// RPATH-substitution env) survive into the child. A wholesale
@@ -243,9 +284,25 @@ func realRunProbeIteration(ctx context.Context) (IterationResult, error) {
 	if err := cmd.Start(); err != nil {
 		return 0, fmt.Errorf("start probe child: %w", err)
 	}
-	// The fd was duped into the child; close our end. Closing via the
-	// *os.File wrapper (not unix.Close) keeps ownership single-rooted.
-	_ = childFile.Close()
+	// The fd was duped into the child; close our end immediately so
+	// the kernel can signal EOF on parentSock if the child dies
+	// before reaching sendProbeFD. Without this, recvProbeFD would
+	// block indefinitely on an early child crash because we'd still
+	// be a writer on the socketpair.
+	closeChild()
+
+	// Apply a recv timeout to parentSock so a hung child (stuck inside
+	// loadRawFilter or before reaching sendProbeFD) cannot wedge the
+	// parent. The per-iteration 1-second timer below only arms after
+	// recvProbeFD returns, so without this the failure mode would be
+	// "parent hangs forever". SO_RCVTIMEO causes Recvmsg to return
+	// EAGAIN/EWOULDBLOCK when the timeout fires.
+	tv := unix.NsecToTimeval(probeRecvTimeout.Nanoseconds())
+	if err := unix.SetsockoptTimeval(parentSock, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &tv); err != nil {
+		// Non-fatal: log and continue. Worst case we lose the
+		// guard but keep the rest of the iteration.
+		slog.Debug("wait_killable probe: SO_RCVTIMEO failed", "error", err)
+	}
 
 	notifyFD, err := recvProbeFD(parentSock)
 	if err != nil {
@@ -343,8 +400,19 @@ func serviceProbeNotifications(ctx context.Context, notifyFD int) {
 
 // classifyProbeExit maps cmd.Wait()'s result to an IterationResult.
 // childStderr is the captured child stderr (bounded) and is included
-// in the error return for the "unclassified" case so operators can
-// see what the child actually printed before it died.
+// in the error returns for the setup-failure and unclassified cases.
+//
+// Exit-status decoding:
+//   - nil error                  → IterPass
+//   - WIFSIGNALED                → IterKilled (kernel bug suspect)
+//   - WIFEXITED status=71        → error (probe child setup failed before
+//     reaching exec; the kernel was never exercised, so reporting
+//     IterKilled would silently disable wait_killable on broken hosts)
+//   - WIFEXITED status=70        → error (runProbeChild returned past
+//     the exec call; shouldn't happen but treat as setup failure)
+//   - WIFEXITED other non-zero   → IterKilled (post-exec child exited
+//     non-zero, e.g. /bin/true returned 1 because the syscall storm
+//     was disrupted — counts as a kernel-bug hit)
 func classifyProbeExit(err error, childStderr string) (IterationResult, error) {
 	if err == nil {
 		return IterPass, nil
@@ -355,12 +423,20 @@ func classifyProbeExit(err error, childStderr string) (IterationResult, error) {
 			if ws.Signaled() {
 				return IterKilled, nil
 			}
-			// cmd.Wait returns nil for status-0 exits, so an
-			// ExitError here implies a non-zero exit; treat any
-			// non-signaled failure as IterKilled (the child died
-			// before reaching exec or /bin/true returned non-zero
-			// — both indicate the iteration didn't cleanly survive
-			// the post-execve syscall storm).
+			if ws.Exited() {
+				switch ws.ExitStatus() {
+				case probeExitSetupFailure, probeExitFallback:
+					return 0, fmt.Errorf("wait_killable probe: child setup failed (exit %d, stderr: %q)", ws.ExitStatus(), childStderr)
+				}
+			}
+			// Non-signaled, non-setup-failure exit: the child made
+			// it past the seccomp install and the exec call but
+			// exited non-zero. Treat as a kernel-bug-style failure
+			// (the post-execve syscall storm did not complete
+			// cleanly). Include stderr for triage.
+			if childStderr != "" {
+				slog.Debug("wait_killable probe: child exited non-zero", "stderr", childStderr)
+			}
 			return IterKilled, nil
 		}
 	}

--- a/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
+++ b/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
@@ -1,0 +1,252 @@
+//go:build linux && cgo
+// +build linux,cgo
+
+package unix
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+	"time"
+
+	seccomp "github.com/seccomp/libseccomp-golang"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	probeChildEnv    = "AGENTSH_WAIT_KILLABLE_PROBE_CHILD"
+	probeChildSockFD = "AGENTSH_WAIT_KILLABLE_PROBE_SOCK"
+	probeBinaryPath  = "/bin/true"
+)
+
+// init wires the production runner and detects probe-child mode. When
+// invoked as a probe child the process never returns: it either execs
+// /bin/true (success path) or os.Exit(70)s. Otherwise it just installs
+// realRunProbeIteration over the placeholder from
+// wait_killable_probe_linux.go.
+func init() {
+	if os.Getenv(probeChildEnv) == "1" {
+		runProbeChild()
+		// runProbeChild never returns on success (it execs). If it does
+		// return, treat as fatal child-side error so the rest of the
+		// binary's init()s and main() never run.
+		os.Exit(70)
+	}
+	runProbeIteration = realRunProbeIteration
+}
+
+func runProbeChild() {
+	sockStr := os.Getenv(probeChildSockFD)
+	sockFD, err := strconv.Atoi(sockStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wait_killable probe child: bad %s=%q: %v\n",
+			probeChildSockFD, sockStr, err)
+		return
+	}
+
+	prog, err := buildProbeFilterBytes()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wait_killable probe child: build filter: %v\n", err)
+		return
+	}
+
+	notifyFD, err := loadRawFilter(prog, true)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "wait_killable probe child: install filter: %v\n", err)
+		return
+	}
+
+	// Hand notifyFD to the parent.
+	if err := sendProbeFD(sockFD, notifyFD); err != nil {
+		fmt.Fprintf(os.Stderr, "wait_killable probe child: send fd: %v\n", err)
+		return
+	}
+	_ = unix.Close(notifyFD)
+	_ = unix.Close(sockFD)
+
+	// Exec /bin/true to fire the post-execve syscall storm under the
+	// installed filter. Falls back to /bin/echo if /bin/true is missing.
+	bin := probeBinaryPath
+	if _, err := os.Stat(bin); err != nil {
+		bin = "/bin/echo"
+	}
+	_ = syscall.Exec(bin, []string{bin}, []string{})
+	fmt.Fprintf(os.Stderr, "wait_killable probe child: exec failed\n")
+}
+
+// buildProbeFilterBytes constructs the worst-case filter composition
+// (socket family + file/metadata family + execve trap) as raw BPF bytes
+// using the existing libseccomp + exportFilterBPF path. Filter is
+// ActAllow by default so syscalls not in the rule set pass through
+// unimpeded.
+func buildProbeFilterBytes() ([]byte, error) {
+	filt, err := seccomp.NewFilter(seccomp.ActAllow)
+	if err != nil {
+		return nil, err
+	}
+	defer filt.Release()
+
+	trap := seccomp.ActNotify
+	syscalls := []seccomp.ScmpSyscall{
+		seccomp.ScmpSyscall(unix.SYS_SOCKET),
+		seccomp.ScmpSyscall(unix.SYS_CONNECT),
+		seccomp.ScmpSyscall(unix.SYS_BIND),
+		seccomp.ScmpSyscall(unix.SYS_LISTEN),
+		seccomp.ScmpSyscall(unix.SYS_SENDTO),
+		seccomp.ScmpSyscall(unix.SYS_OPENAT),
+		seccomp.ScmpSyscall(unix.SYS_STATX),
+		seccomp.ScmpSyscall(unix.SYS_NEWFSTATAT),
+		seccomp.ScmpSyscall(unix.SYS_FACCESSAT2),
+		seccomp.ScmpSyscall(unix.SYS_READLINKAT),
+	}
+	for _, sc := range syscalls {
+		if err := filt.AddRule(sc, trap); err != nil {
+			return nil, fmt.Errorf("add probe rule %v: %w", sc, err)
+		}
+	}
+	return exportFilterBPF(filt)
+}
+
+// sendProbeFD writes notifyFD over sockFD using SCM_RIGHTS.
+func sendProbeFD(sockFD, notifyFD int) error {
+	rights := unix.UnixRights(notifyFD)
+	return unix.Sendmsg(sockFD, []byte{'F'}, rights, nil, 0)
+}
+
+// recvProbeFD reads one fd from sockFD over SCM_RIGHTS.
+func recvProbeFD(sockFD int) (int, error) {
+	buf := make([]byte, 1)
+	oob := make([]byte, unix.CmsgSpace(4))
+	_, oobn, _, _, err := unix.Recvmsg(sockFD, buf, oob, 0)
+	if err != nil {
+		return -1, err
+	}
+	cmsgs, err := unix.ParseSocketControlMessage(oob[:oobn])
+	if err != nil {
+		return -1, err
+	}
+	for _, c := range cmsgs {
+		fds, err := unix.ParseUnixRights(&c)
+		if err == nil && len(fds) > 0 {
+			return fds[0], nil
+		}
+	}
+	return -1, errors.New("no fd received")
+}
+
+// realRunProbeIteration is the production runner installed in init().
+func realRunProbeIteration(ctx context.Context) (IterationResult, error) {
+	pair, err := unix.Socketpair(unix.AF_UNIX, unix.SOCK_STREAM, 0)
+	if err != nil {
+		return 0, fmt.Errorf("socketpair: %w", err)
+	}
+	parentSock, childSock := pair[0], pair[1]
+	defer unix.Close(parentSock)
+
+	binaryPath, err := os.Executable()
+	if err != nil {
+		unix.Close(childSock)
+		return 0, fmt.Errorf("os.Executable: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, binaryPath)
+	cmd.Env = []string{
+		probeChildEnv + "=1",
+		probeChildSockFD + "=3", // ExtraFiles index 0 = fd 3
+	}
+	cmd.ExtraFiles = []*os.File{os.NewFile(uintptr(childSock), "probe-sock")}
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	cmd.Stdin = nil
+
+	if err := cmd.Start(); err != nil {
+		unix.Close(childSock)
+		return 0, fmt.Errorf("start probe child: %w", err)
+	}
+	// The fd was duped into the child; close our end.
+	_ = unix.Close(childSock)
+
+	notifyFD, err := recvProbeFD(parentSock)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+		return 0, fmt.Errorf("recv probe fd: %w", err)
+	}
+	defer unix.Close(notifyFD)
+
+	// Service notifications until the child exits.
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	serviceCtx, serviceCancel := context.WithCancel(ctx)
+	defer serviceCancel()
+	go serviceProbeNotifications(serviceCtx, notifyFD)
+
+	timeout := time.NewTimer(time.Second)
+	defer timeout.Stop()
+
+	select {
+	case err := <-done:
+		serviceCancel()
+		return classifyProbeExit(err)
+	case <-timeout.C:
+		serviceCancel()
+		_ = cmd.Process.Kill()
+		<-done
+		return IterTimeout, nil
+	}
+}
+
+// serviceProbeNotifications drains the notify fd and responds CONTINUE
+// to every notification until ctx is cancelled or the fd errors.
+//
+// Uses libseccomp-golang's seccomp.NotifReceive (the same call site as
+// internal/netmonitor/unix/handler.go:41) for receive, and the existing
+// NotifRespondContinue helper from addfd_linux.go for the response.
+func serviceProbeNotifications(ctx context.Context, notifyFD int) {
+	scmpFD := seccomp.ScmpFd(notifyFD)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		notif, err := seccomp.NotifReceive(scmpFD)
+		if err != nil {
+			if !errors.Is(err, unix.EINTR) {
+				slog.Debug("wait_killable probe: notify recv ended", "error", err)
+			}
+			return
+		}
+		if err := NotifRespondContinue(notifyFD, notif.ID); err != nil {
+			slog.Debug("wait_killable probe: notify respond failed", "error", err)
+			return
+		}
+	}
+}
+
+// classifyProbeExit maps cmd.Wait()'s result to an IterationResult.
+func classifyProbeExit(err error) (IterationResult, error) {
+	if err == nil {
+		return IterPass, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if ws, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+			if ws.Signaled() {
+				return IterKilled, nil
+			}
+			if ws.Exited() && ws.ExitStatus() == 0 {
+				return IterPass, nil
+			}
+			return IterKilled, nil
+		}
+	}
+	return 0, fmt.Errorf("wait_killable probe: unclassified exit: %w", err)
+}

--- a/internal/netmonitor/unix/wait_killable_probe_stub.go
+++ b/internal/netmonitor/unix/wait_killable_probe_stub.go
@@ -1,13 +1,19 @@
-//go:build !linux
-// +build !linux
+//go:build !linux || !cgo
+// +build !linux !cgo
 
 package unix
 
 import "context"
 
-// ProbeWaitKillableBehavior is a non-Linux stub. Returns (false, nil) so
-// non-Linux callers behave as if WAIT_KILLABLE_RECV is not safe, which
-// is also true: the flag is Linux-only.
+// ProbeWaitKillableBehavior is a stub for non-Linux and linux-without-cgo
+// builds. Returns (false, nil) so callers behave as if WAIT_KILLABLE_RECV
+// is not safe — which is also true: the real probe requires cgo, and the
+// flag itself is Linux-only.
+//
+// The build-tag pair (`!linux || !cgo` here vs. `linux && cgo` in
+// wait_killable_probe_linux.go) ensures `ProbeWaitKillableBehavior` is
+// always exported from package unix, so glue code compiled under
+// `linux && !cgo` still links.
 func ProbeWaitKillableBehavior(_ context.Context, _ int) (bool, error) {
 	return false, nil
 }

--- a/internal/netmonitor/unix/wait_killable_probe_stub.go
+++ b/internal/netmonitor/unix/wait_killable_probe_stub.go
@@ -1,0 +1,13 @@
+//go:build !linux
+// +build !linux
+
+package unix
+
+import "context"
+
+// ProbeWaitKillableBehavior is a non-Linux stub. Returns (false, nil) so
+// non-Linux callers behave as if WAIT_KILLABLE_RECV is not safe, which
+// is also true: the flag is Linux-only.
+func ProbeWaitKillableBehavior(_ context.Context, _ int) (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
## Summary

Fixes #369. Replaces the uname-based `ProbeWaitKillable` (a guess) with a server-side behavioral probe that exercises the production filter composition under `WAIT_KILLABLE_RECV` before deciding whether to use the flag. Adds a `sandbox.seccomp.wait_killable` operator override as the escape hatch for any kernel posture the probe gets wrong.

Spec: `docs/superpowers/specs/2026-05-22-issue-369-wait-killable-recv-fix-design.md`
Plan: `docs/superpowers/plans/2026-05-22-issue-369-wait-killable-recv-fix.md`

### What changed

- **Config knob** `sandbox.seccomp.wait_killable: *bool` (tri-state: auto / force-on / force-off).
- **Pure heuristic** `WaitKillableFilterCompositionTriggersBug` — skips the probe when the filter composition can't trigger the issue-369 bug.
- **Behavioral probe** `ProbeWaitKillableBehavior(ctx, iterations=5)` that self-execs a sentinel child, installs the worst-case filter (socket + file/metadata notify rules) under `WAIT_KILLABLE_RECV`, services notifications with `CONTINUE`, applies a 1s/iter timeout, and classifies child exit (`IterPass` / `IterKilled` / `IterTimeout`).
- **Decision switch** `decideWaitKillable` with documented branch priority: config override → kernel<6 → safe-composition → behavioral-probe → fail-safe.
- **Plumbing** through 4 layers: `SandboxSeccompConfig` → `seccompWrapperConfig` (JSON) → `WrapperConfig` (JSON) → `FilterConfig`.
- **Diagnostic logging**: per-iteration probe lines, boot-decision line for non-probe sources, `wait_killable_source` on every per-exec `seccomp: filter loaded` line. Re-separates `kernel_probe_supports` from the resolved decision (carry-over fix from the existing Task 5 work).

### Failure-mode posture

- Probe error → `false` (fail-safe; SIGURG-induced ERESTARTSYS noise is acceptable degradation; catastrophic wrapper kills are not).
- Operator override always wins, in both directions.

## Test plan

- [x] `go test ./internal/config/ ./internal/api/ ./internal/netmonitor/unix/ ./cmd/agentsh-unixwrap/ -count=1` — all green
- [x] `go build ./... && GOOS=windows go build ./... && CGO_ENABLED=0 go build ./internal/... ./cmd/...` — all clean
- [x] Real-kernel behavioral probe runs in ~14ms on stock 7.0.3 (ok=true)
- [x] End-to-end re-exec test asserts `wait_killable=false` + `wait_killable_source=config` flow through the install path
- [x] 8-row decision switch table test (covers config-beats-kernel<6, all probe outcomes)
- [x] 7-row composition heuristic test (catches the `enforce_without_fuse=true` gotcha from the issue's bisection)
- [x] Pre-existing FUSE test (`TestFUSE_FsyncFlushLseekPassthrough`) fails identically on `main` — environmental, unrelated to this branch
- [ ] Verify on an exe.dev-class kernel (out of scope for CI — operator can flip `wait_killable: false` if probe gets fooled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)