### PR TITLE
fix(#374): apply sandbox.env_inject on the wrap-init/kernel-install path

### DIFF
--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -280,6 +280,7 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 			PtraceMode:            true,
 			SafeToBypassShellShim: true,
 			NotifySocket:          notifySocketPath,
+			EnvInject:             mergeEnvInject(a.cfg, a.policyEngineFor(s)),
 		}, http.StatusOK, nil
 	}
 
@@ -511,6 +512,11 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 		NotifySocket:          notifySocketPath,
 		SignalSocket:          signalSocketPath,
 		WrapperEnv:            wrapperEnv,
+		// env_inject is delivered to the client for it to overlay onto the
+		// executed command's environment (the server does not spawn the
+		// process on this path). Operator-trusted; bypasses policy filtering,
+		// matching the server-spawned exec path. Issue #374.
+		EnvInject: mergeEnvInject(a.cfg, a.policyEngineFor(s)),
 	}, http.StatusOK, nil
 }
 

--- a/internal/api/wrap_envinject_test.go
+++ b/internal/api/wrap_envinject_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// TestWrapInit_ResponseCarriesEnvInject is the regression guard for issue #374:
+// on the client-spawned wrap (kernel-install) path the server never delivered
+// sandbox.env_inject to the shim, so injected vars (e.g. BASH_ENV hardening)
+// silently never reached executed commands. wrapInitCore must surface them in
+// the response so the client can apply them.
+func TestWrapInit_ResponseCarriesEnvInject(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	enabled := true
+	cfg := &config.Config{}
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+	cfg.Sandbox.EnvInject = map[string]string{
+		"BASH_ENV":          "/usr/lib/agentsh/bash_startup.sh",
+		"OTEL_SERVICE_NAME": "agentsh-blaxel",
+	}
+
+	app, mgr := newTestAppForWrap(t, cfg)
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	resp, code, err := app.wrapInitCore(s, s.ID, types.WrapInitRequest{
+		AgentCommand: "/bin/echo",
+		CallerUID:    nonzeroTestUID(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if code != 200 {
+		t.Fatalf("expected status 200, got %d", code)
+	}
+	if resp.NotifySocket != "" {
+		t.Cleanup(func() { _ = os.RemoveAll(resp.NotifySocket) })
+	}
+
+	if got := resp.EnvInject["BASH_ENV"]; got != "/usr/lib/agentsh/bash_startup.sh" {
+		t.Errorf("resp.EnvInject[BASH_ENV] = %q, want the configured hardening path", got)
+	}
+	if got := resp.EnvInject["OTEL_SERVICE_NAME"]; got != "agentsh-blaxel" {
+		t.Errorf("resp.EnvInject[OTEL_SERVICE_NAME] = %q, want agentsh-blaxel", got)
+	}
+}

--- a/internal/cli/wrap_linux.go
+++ b/internal/cli/wrap_linux.go
@@ -14,6 +14,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/agentsh/agentsh/internal/envinject"
 	"github.com/agentsh/agentsh/internal/wraphandoff"
 	"github.com/agentsh/agentsh/pkg/types"
 	"golang.org/x/sys/unix"
@@ -31,6 +32,9 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 		notifySocket := wrapResp.NotifySocket
 
 		env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
+		// Overlay sandbox.env_inject so injected vars reach the command in
+		// ptrace mode too, matching the seccomp/shim paths (issue #374).
+		env = envinject.Apply(env, wrapResp.EnvInject)
 
 		// connHolder stores the keepalive connection set by ptracePostStart.
 		var connHolder net.Conn
@@ -132,6 +136,10 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 
 	// Build env for the wrapped process
 	env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
+	// Overlay operator-configured sandbox.env_inject (override semantics)
+	// before the internal markers, matching the shim and server-spawned exec
+	// paths so injected vars reach the executed command (issue #374).
+	env = envinject.Apply(env, wrapResp.EnvInject)
 	env = append(env, "AGENTSH_NOTIFY_SOCK_FD=3") // fd 3 = ExtraFiles[0]
 	if hasSignalSocket {
 		env = append(env, "AGENTSH_SIGNAL_SOCK_FD=4") // fd 4 = ExtraFiles[1]

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -591,6 +591,77 @@ func TestWrapLaunchConfig_EnvContainsSessionAndWrapper(t *testing.T) {
 	}
 }
 
+func TestWrapLaunchConfig_AppliesEnvInject(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("agentsh-unixwrap env_inject path is Linux-only")
+	}
+
+	mc := &mockWrapClient{
+		wrapInitResp: types.WrapInitResponse{
+			WrapperBinary: "/bin/true",
+			NotifySocket:  "/tmp/agentsh-notify-test.sock",
+			WrapperEnv: map[string]string{
+				"AGENTSH_SECCOMP_CONFIG": `{"unix_socket_enabled":true}`,
+			},
+			EnvInject: map[string]string{
+				"BASH_ENV": "/usr/lib/agentsh/bash_startup.sh",
+			},
+		},
+	}
+
+	cfg := &clientConfig{serverAddr: "http://127.0.0.1:18080"}
+	lcfg, err := setupWrapInterception(context.Background(), mc, "test-session", "/bin/echo", nil, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, lcfg)
+
+	envMap := make(map[string]bool)
+	for _, e := range lcfg.env {
+		envMap[e] = true
+	}
+	assert.True(t, envMap["BASH_ENV=/usr/lib/agentsh/bash_startup.sh"],
+		"wrap env should contain injected BASH_ENV (issue #374)")
+
+	for _, f := range lcfg.extraFiles {
+		if f != nil {
+			f.Close()
+		}
+	}
+}
+
+func TestWrapLaunchConfig_AppliesEnvInject_PtraceMode(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("ptrace wrap mode is Linux-only")
+	}
+
+	mc := &mockWrapClient{
+		wrapInitResp: types.WrapInitResponse{
+			PtraceMode:   true,
+			NotifySocket: "/tmp/agentsh-ptrace-test.sock",
+			EnvInject: map[string]string{
+				"BASH_ENV": "/usr/lib/agentsh/bash_startup.sh",
+			},
+		},
+	}
+
+	cfg := &clientConfig{serverAddr: "http://127.0.0.1:18080"}
+	lcfg, err := setupWrapInterception(context.Background(), mc, "test-session", "/bin/echo", nil, cfg)
+	require.NoError(t, err)
+	require.NotNil(t, lcfg)
+
+	envMap := make(map[string]bool)
+	for _, e := range lcfg.env {
+		envMap[e] = true
+	}
+	assert.True(t, envMap["BASH_ENV=/usr/lib/agentsh/bash_startup.sh"],
+		"ptrace-mode wrap env should contain injected BASH_ENV (issue #374)")
+
+	for _, f := range lcfg.extraFiles {
+		if f != nil {
+			f.Close()
+		}
+	}
+}
+
 func TestWrapLaunchConfig_EnvIncludesInSessionWhenSafe(t *testing.T) {
 	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
 		t.Skip("wrap interception requires Linux or macOS")

--- a/internal/envinject/envinject.go
+++ b/internal/envinject/envinject.go
@@ -1,0 +1,35 @@
+// Package envinject applies operator-configured environment variable
+// injection (sandbox.env_inject) to a process environment.
+package envinject
+
+import "strings"
+
+// Apply overlays operator-configured env_inject values onto base, returning a
+// new "KEY=VALUE" slice. For every key in inject, all pre-existing occurrences
+// are removed from base and a single injected entry is appended. This mirrors
+// the server-spawned exec path (internal/api/exec.go) and guarantees the
+// injected value wins: POSIX getenv returns the first matching entry, so a
+// stale duplicate left earlier in the slice would otherwise shadow it.
+//
+// Keys not present in inject are preserved in their original order. When inject
+// is empty, base is returned unchanged.
+func Apply(base []string, inject map[string]string) []string {
+	if len(inject) == 0 {
+		return base
+	}
+
+	out := make([]string, 0, len(base)+len(inject))
+	for _, e := range base {
+		k, _, ok := strings.Cut(e, "=")
+		if ok {
+			if _, override := inject[k]; override {
+				continue // drop stale occurrence; injected value appended below
+			}
+		}
+		out = append(out, e)
+	}
+	for k, v := range inject {
+		out = append(out, k+"="+v)
+	}
+	return out
+}

--- a/internal/envinject/envinject_test.go
+++ b/internal/envinject/envinject_test.go
@@ -1,0 +1,91 @@
+package envinject
+
+import (
+	"strings"
+	"testing"
+)
+
+// envToMap parses a "KEY=VALUE" slice into a map and the count of entries per
+// key, so tests can assert both the resolved value and that no duplicate
+// occurrences of an injected key remain.
+func envToMap(env []string) (map[string]string, map[string]int) {
+	vals := make(map[string]string, len(env))
+	counts := make(map[string]int, len(env))
+	for _, e := range env {
+		k, v, ok := strings.Cut(e, "=")
+		if !ok {
+			continue
+		}
+		vals[k] = v
+		counts[k]++
+	}
+	return vals, counts
+}
+
+func TestApply_OverridesExistingKey(t *testing.T) {
+	base := []string{"BASH_ENV=/inherited", "PATH=/usr/bin", "HOME=/root"}
+	inject := map[string]string{"BASH_ENV": "/usr/lib/agentsh/bash_startup.sh"}
+
+	got := Apply(base, inject)
+
+	vals, counts := envToMap(got)
+	if vals["BASH_ENV"] != "/usr/lib/agentsh/bash_startup.sh" {
+		t.Fatalf("BASH_ENV = %q, want injected value", vals["BASH_ENV"])
+	}
+	if counts["BASH_ENV"] != 1 {
+		t.Fatalf("BASH_ENV appears %d times, want exactly 1 (stale entry not removed)", counts["BASH_ENV"])
+	}
+	if vals["PATH"] != "/usr/bin" || vals["HOME"] != "/root" {
+		t.Fatalf("untouched keys altered: PATH=%q HOME=%q", vals["PATH"], vals["HOME"])
+	}
+}
+
+func TestApply_AddsNewKey(t *testing.T) {
+	base := []string{"PATH=/usr/bin"}
+	inject := map[string]string{"OTEL_SERVICE_NAME": "agentsh-blaxel"}
+
+	got := Apply(base, inject)
+
+	vals, counts := envToMap(got)
+	if vals["OTEL_SERVICE_NAME"] != "agentsh-blaxel" {
+		t.Fatalf("OTEL_SERVICE_NAME = %q, want injected value", vals["OTEL_SERVICE_NAME"])
+	}
+	if counts["OTEL_SERVICE_NAME"] != 1 {
+		t.Fatalf("OTEL_SERVICE_NAME appears %d times, want 1", counts["OTEL_SERVICE_NAME"])
+	}
+}
+
+func TestApply_RemovesAllDuplicateOccurrences(t *testing.T) {
+	// POSIX getenv returns the first match; a stale earlier duplicate would
+	// shadow the injected value, so every prior occurrence must be removed.
+	base := []string{"X=first", "Y=keep", "X=second"}
+	inject := map[string]string{"X": "injected"}
+
+	got := Apply(base, inject)
+
+	vals, counts := envToMap(got)
+	if counts["X"] != 1 {
+		t.Fatalf("X appears %d times, want exactly 1", counts["X"])
+	}
+	if vals["X"] != "injected" {
+		t.Fatalf("X = %q, want injected", vals["X"])
+	}
+	if vals["Y"] != "keep" {
+		t.Fatalf("Y = %q, want keep", vals["Y"])
+	}
+}
+
+func TestApply_EmptyInjectReturnsBaseUnchanged(t *testing.T) {
+	base := []string{"PATH=/usr/bin", "HOME=/root"}
+
+	for _, inject := range []map[string]string{nil, {}} {
+		got := Apply(base, inject)
+		if len(got) != len(base) {
+			t.Fatalf("len(got) = %d, want %d for inject=%v", len(got), len(base), inject)
+		}
+		vals, _ := envToMap(got)
+		if vals["PATH"] != "/usr/bin" || vals["HOME"] != "/root" {
+			t.Fatalf("base altered with empty inject: %v", got)
+		}
+	}
+}

--- a/internal/shim/kernelinstall/assemble_env_test.go
+++ b/internal/shim/kernelinstall/assemble_env_test.go
@@ -1,0 +1,78 @@
+//go:build linux
+
+package kernelinstall
+
+import (
+	"strings"
+	"testing"
+)
+
+func envCount(env []string, key string) (string, int) {
+	val, n := "", 0
+	for _, e := range env {
+		k, v, ok := strings.Cut(e, "=")
+		if ok && k == key {
+			val = v
+			n++
+		}
+	}
+	return val, n
+}
+
+// TestAssembleWrapperEnv_AppliesEnvInject is the shim-side regression guard for
+// issue #374: env_inject from the wrap-init response must be overlaid onto the
+// wrapper child's environment, overriding inherited values, while the internal
+// AGENTSH_* markers stay authoritative.
+func TestAssembleWrapperEnv_AppliesEnvInject(t *testing.T) {
+	base := []string{
+		"BASH_ENV=/inherited",
+		"PATH=/usr/bin",
+	}
+	wrapperEnv := map[string]string{
+		"AGENTSH_SECCOMP_CONFIG": "{}",
+		signalSockFDKey:          "4", // must be stripped in shim mode
+	}
+	envInject := map[string]string{
+		"BASH_ENV":          "/usr/lib/agentsh/bash_startup.sh",
+		"OTEL_SERVICE_NAME": "agentsh-blaxel",
+	}
+
+	env := assembleWrapperEnv(base, "/bin/sh", wrapperEnv, envInject)
+
+	if v, n := envCount(env, "BASH_ENV"); v != "/usr/lib/agentsh/bash_startup.sh" || n != 1 {
+		t.Errorf("BASH_ENV = %q (count %d), want injected value exactly once", v, n)
+	}
+	if v, n := envCount(env, "OTEL_SERVICE_NAME"); v != "agentsh-blaxel" || n != 1 {
+		t.Errorf("OTEL_SERVICE_NAME = %q (count %d), want agentsh-blaxel once", v, n)
+	}
+	if v, _ := envCount(env, "PATH"); v != "/usr/bin" {
+		t.Errorf("PATH = %q, want untouched", v)
+	}
+	if v, n := envCount(env, "AGENTSH_NOTIFY_SOCK_FD"); v != "3" || n != 1 {
+		t.Errorf("AGENTSH_NOTIFY_SOCK_FD = %q (count %d), want 3 once", v, n)
+	}
+	if v, n := envCount(env, argv0EnvKey); v != "/bin/sh" || n != 1 {
+		t.Errorf("%s = %q (count %d), want /bin/sh once", argv0EnvKey, v, n)
+	}
+	if v, n := envCount(env, "AGENTSH_SECCOMP_CONFIG"); v != "{}" || n != 1 {
+		t.Errorf("AGENTSH_SECCOMP_CONFIG = %q (count %d), want {} once", v, n)
+	}
+	if _, n := envCount(env, signalSockFDKey); n != 0 {
+		t.Errorf("%s present %d times, want stripped in shim mode", signalSockFDKey, n)
+	}
+}
+
+func TestAssembleWrapperEnv_NoArgv0_NoEnvInject(t *testing.T) {
+	base := []string{"PATH=/usr/bin"}
+	env := assembleWrapperEnv(base, "", map[string]string{"AGENTSH_SECCOMP_CONFIG": "{}"}, nil)
+
+	if _, n := envCount(env, argv0EnvKey); n != 0 {
+		t.Errorf("%s present %d times, want absent when argv0 empty", argv0EnvKey, n)
+	}
+	if v, n := envCount(env, "AGENTSH_NOTIFY_SOCK_FD"); v != "3" || n != 1 {
+		t.Errorf("AGENTSH_NOTIFY_SOCK_FD = %q (count %d), want 3 once", v, n)
+	}
+	if v, _ := envCount(env, "PATH"); v != "/usr/bin" {
+		t.Errorf("PATH = %q, want untouched", v)
+	}
+}

--- a/internal/shim/kernelinstall/install_linux.go
+++ b/internal/shim/kernelinstall/install_linux.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/agentsh/agentsh/internal/client"
+	"github.com/agentsh/agentsh/internal/envinject"
 	"github.com/agentsh/agentsh/internal/wraphandoff"
 	"github.com/agentsh/agentsh/pkg/types"
 	"golang.org/x/sys/unix"
@@ -191,32 +192,12 @@ func runRelay(p InstallParams, resp types.WrapInitResponse) (Result, error) {
 		return Result{}, fmt.Errorf("fcntl clear cloexec: %w", errno)
 	}
 
-	// Build env: caller env + AGENTSH_NOTIFY_SOCK_FD=3 + filtered WrapperEnv.
-	// Strip AGENTSH_SIGNAL_SOCK_FD from p.Env AND WrapperEnv:
-	//  - from p.Env: a stale value inherited from a parent context (when the
-	//    shim runs inside an already-wrapped process) must not reach the wrapper.
-	//  - from WrapperEnv: shim mode does not replicate the signal-filter
-	//    socketpair, so the wrapper must not try to open that fd.
-	filteredBase := filterShimInternalEnv(p.Env)
-	env := make([]string, len(filteredBase))
-	copy(env, filteredBase)
-	env = append(env, "AGENTSH_NOTIFY_SOCK_FD=3")
-	// Plumb the original invocation name (e.g. "/bin/sh") through to the
-	// wrapper so it can override argv[0] when execve'ing the real shell.
-	// On Alpine, /bin/sh.real is a busybox binary; without this override,
-	// busybox derives applet name "sh.real" → "applet not found" → exit
-	// 127. The wrapper falls back to its os.Args[2] (the real shell path)
-	// when this is empty, which is correct on non-busybox systems.
-	if p.Argv0 != "" {
-		env = append(env, fmt.Sprintf("%s=%s", argv0EnvKey, p.Argv0))
-	}
-	for k, v := range resp.WrapperEnv {
-		if k == signalSockFDKey {
-			slog.Debug("kernelinstall: stripping signal sock fd from wrapper env (shim mode limitation)")
-			continue
-		}
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
-	}
+	// Build the wrapper child environment: caller env (shim-internal markers
+	// stripped) with sandbox.env_inject overlaid, then the internal AGENTSH_*
+	// markers (notify fd, argv0 override, wrapper config). See
+	// assembleWrapperEnv for the env_inject override and AGENTSH_SIGNAL_SOCK_FD
+	// stripping rationale (issue #374).
+	env := assembleWrapperEnv(filterShimInternalEnv(p.Env), p.Argv0, resp.WrapperEnv, resp.EnvInject)
 
 	// Build wrapper argv: wrapperBin -- realShell shellArgs...
 	// argv[0] is the wrapper binary's basename (conventional).
@@ -395,6 +376,39 @@ func filterSignalSockFD(env []string) []string {
 // empty); a stale inherited value from a re-entrant invocation would
 // otherwise silently win on Argv0=="" and contradict the documented
 // "empty falls back to the resolved real path" contract.
+// assembleWrapperEnv builds the environment for the agentsh-unixwrap child.
+// base is the caller environment with shim-internal markers already stripped
+// (filterShimInternalEnv). envInject overlays operator-configured
+// sandbox.env_inject values with override semantics — injected values win over
+// inherited ones, matching the server-spawned exec path (issue #374). The
+// internal AGENTSH_* markers (notify fd, argv0 override, wrapper config) are
+// appended afterward and remain authoritative. AGENTSH_SIGNAL_SOCK_FD from
+// wrapperEnv is dropped: shim mode does not replicate the signal-filter
+// socketpair, so the wrapper must not try to open that fd.
+func assembleWrapperEnv(base []string, argv0 string, wrapperEnv, envInject map[string]string) []string {
+	// Copy so appends never alias the caller's backing array (Apply may
+	// return base unchanged when envInject is empty).
+	env := append([]string(nil), envinject.Apply(base, envInject)...)
+	env = append(env, "AGENTSH_NOTIFY_SOCK_FD=3")
+	// Plumb the original invocation name (e.g. "/bin/sh") through to the
+	// wrapper so it can override argv[0] when execve'ing the real shell.
+	// On Alpine, /bin/sh.real is a busybox binary; without this override,
+	// busybox derives applet name "sh.real" → "applet not found" → exit
+	// 127. The wrapper falls back to its os.Args[2] (the real shell path)
+	// when this is empty, which is correct on non-busybox systems.
+	if argv0 != "" {
+		env = append(env, fmt.Sprintf("%s=%s", argv0EnvKey, argv0))
+	}
+	for k, v := range wrapperEnv {
+		if k == signalSockFDKey {
+			slog.Debug("kernelinstall: stripping signal sock fd from wrapper env (shim mode limitation)")
+			continue
+		}
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	return env
+}
+
 func filterShimInternalEnv(env []string) []string {
 	out := make([]string, 0, len(env))
 	signalPrefix := signalSockFDKey + "="

--- a/pkg/types/sessions.go
+++ b/pkg/types/sessions.go
@@ -160,4 +160,11 @@ type WrapInitResponse struct {
 	NotifySocket          string            `json:"notify_socket"`
 	SignalSocket          string            `json:"signal_socket,omitempty"`
 	WrapperEnv            map[string]string `json:"wrapper_env"`
+	// EnvInject carries operator-configured sandbox.env_inject values for the
+	// client (shell shim / CLI wrap) to overlay onto the executed command's
+	// environment. On the client-spawned wrap path the server does not build
+	// the child env itself, so these must be plumbed through the response and
+	// applied client-side; on the server-spawned exec path env_inject is
+	// applied directly in internal/api/exec.go instead. Issue #374.
+	EnvInject map[string]string `json:"env_inject,omitempty"`
 }


### PR DESCRIPTION
## Summary

Fixes #374 (part 1). On the client-spawned wrap path (shell shim kernel-install, and `agentsh wrap`), the `/wrap-init` response carried only the seccomp markers and **never delivered `sandbox.env_inject`**. The shim/CLI then `exec`'d the command with the inherited environment unchanged, so injected vars (e.g. `BASH_ENV` → `bash_startup.sh` hardening) silently never reached commands.

This regressed when the shim moved to kernel-install enforcement (0.19.1+), switching from the server-spawned exec path (which applies `env_inject` in `internal/api/exec.go`) to this path.

## Changes

- **`internal/envinject`** (new): `Apply(base, inject)` helper applying override semantics — prior occurrences of injected keys are removed before appending, so the injected value wins (POSIX `getenv` returns the first match). Mirrors the exec path.
- **`pkg/types`**: new `WrapInitResponse.EnvInject` field.
- **`internal/api/wrap.go`**: `wrapInitCore` populates `EnvInject` via `mergeEnvInject` on both success returns (seccomp + ptrace).
- **`internal/shim/kernelinstall/install_linux.go`**: extracted `assembleWrapperEnv`, which overlays `env_inject` before the internal `AGENTSH_*` markers.
- **`internal/cli/wrap_linux.go`**: applies `env_inject` in both the seccomp and ptrace-mode branches.

## Tests (TDD — each watched fail first)

- `envinject.Apply` override/dedup semantics.
- Server delivers `EnvInject` in the wrap-init response (regression guard for the reported bug).
- Shim `assembleWrapperEnv` overlays `env_inject` while keeping internal markers authoritative.
- CLI wrap applies `env_inject` in both seccomp and ptrace modes.

Verified: `go build ./...`, `GOOS=windows go build ./...`, `go vet`, `gofmt`, and tests for the affected packages all pass.

## Follow-up

`env_policy` allow/deny enforcement on this path (the 2nd part of #374) is tracked separately in #379 — it's a larger, behavior-changing fix (the wrap path inherits the full launcher env, vs the exec path's deny-by-default rebuild) and warrants a gated rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
