### PR TITLE
fix(#375): make opaque shell-c pre-deny interception-aware

### DIFF
--- a/docs/superpowers/plans/2026-05-23-issue-375-shellc-opaque-interception-aware.md
+++ b/docs/superpowers/plans/2026-05-23-issue-375-shellc-opaque-interception-aware.md
@@ -343,6 +343,18 @@ git commit -m "fix(#375): pass execve-enforcement signal into command pre-check 
 
 ---
 
+## Task 3b: Shim wrap-init guard (found in review)
+
+The shell-shim kernel-install path hits a separate command pre-check in `wrapInitCore` (`internal/api/wrap.go`, the `req.Mode == "shim"` branch). Left on plain `CheckCommand`, an opaque shim command is denied here → HTTP 403 → the shim falls back to `agentsh exec`, bypassing the kernel-install wrapper entirely (defeating enforcement for Daytona-style all-`bash -c` traffic). Make it interception-aware too.
+
+**Files:** Modify `internal/api/wrap.go` (one line in the shim branch); Test `internal/api/wrap_shim_opaque_test.go`.
+
+- [ ] Write `TestWrapInit_ShimGuard_OpaqueInterceptionAware`: build an App via `newTestAppForWrap` + `SwapPolicy` with a restrictive policy (`deny-shutdown` + `allow-shells`); call `wrapInitCore` with `Mode:"shim"`, `AgentCommand:"/bin/sh"`, `AgentArgs:["-c","echo $HOME | head"]`. Assert: execve OFF → code 403; execve ON (`cfg.Sandbox.Seccomp.Execve.Enabled=true`, `WrapperBin:"/bin/true"`, unix sockets enabled) → code 200. Run: expect execve-ON subtest to FAIL (403) first.
+- [ ] In `wrap.go` change `dec := engine.CheckCommand(req.AgentCommand, req.AgentArgs)` → `dec := engine.CheckCommandWithExecve(req.AgentCommand, req.AgentArgs, a.execveEnforcementActive())`. Run: both subtests PASS.
+- [ ] Commit: `fix(#375): make shim wrap-init opaque guard interception-aware`.
+
+---
+
 ## Task 4: Full verification
 
 **Files:** none (verification only)

--- a/docs/superpowers/plans/2026-05-23-issue-375-shellc-opaque-interception-aware.md
+++ b/docs/superpowers/plans/2026-05-23-issue-375-shellc-opaque-interception-aware.md
@@ -1,0 +1,382 @@
+# Interception-Aware Opaque Shell-C Pre-Check — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the shell-shim policy pre-check from denying benign `bash -c`/`sh -c` scripts when runtime `execve` enforcement is active, while keeping the hard-deny when it is not.
+
+**Architecture:** `policy.Engine.CheckCommand`'s opaque-script pre-deny becomes conditional on an `execveEnforcementActive` flag passed in by the caller. When true (seccomp-execve or ptrace active), the opaque script is allowed to run and its inner `execve` calls are policed at depth by the existing `CheckExecve` path; when false, behavior is byte-for-byte unchanged. The flag is computed by the `App` (`cfg.Sandbox.Seccomp.Execve.Enabled || a.ptraceTracer != nil`) and threaded only through the five command pre-check call sites.
+
+**Tech Stack:** Go; existing `internal/policy` engine and `internal/api` server.
+
+**Spec:** `docs/superpowers/specs/2026-05-23-issue-375-shellc-opaque-interception-aware-design.md`
+
+---
+
+## File Structure
+
+- `internal/policy/engine.go` — split `CheckCommand` into an internal `checkCommand(command, args, execveEnforcementActive bool)`; keep `CheckCommand` as a `false` wrapper; add `CheckCommandWithExecve`. Gate the `shellc-opaque-script` branch on `!execveEnforcementActive`.
+- `internal/policy/command_shellc_interception_test.go` (new) — interception-on/off behavior + reporter battery + inner-deny-still-enforced.
+- `internal/api/session_policy.go` — add `App.execveEnforcementActive()` helper.
+- `internal/api/exec_stream.go`, `internal/api/pty_core.go`, `internal/api/grpc.go`, `internal/api/core.go` (×2) — switch the command pre-check call to `CheckCommandWithExecve(..., <app>.execveEnforcementActive())`.
+- `internal/api/session_policy_test.go` (new or existing) — unit test for `execveEnforcementActive()`.
+
+---
+
+## Task 1: Engine — interception-aware opaque gate
+
+**Files:**
+- Modify: `internal/policy/engine.go` (function `CheckCommand`, currently at `engine.go:583`; opaque branch at `engine.go:618`)
+- Test: `internal/policy/command_shellc_interception_test.go` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/policy/command_shellc_interception_test.go`:
+
+```go
+package policy
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// newInterceptionTestEngine builds an engine whose policy has a restrictive
+// command rule (deny-shutdown), so hasRestrictiveCommandRule is set and the
+// opaque pre-deny gate is reachable. Mirrors command_shellc_test.go.
+func newInterceptionTestEngine(t *testing.T) *Engine {
+	t.Helper()
+	p := &Policy{
+		CommandRules: []CommandRule{
+			{Name: "deny-shutdown", Commands: []string{"shutdown"}, Decision: "deny"},
+			{Name: "allow-shells", Commands: []string{"sh", "bash", "dash", "zsh"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	return e
+}
+
+// Issue #375: with execve enforcement active, opaque shell-c scripts must NOT
+// be statically pre-denied — inner execs are policed at runtime by CheckExecve.
+func TestCheckCommand_OpaqueAllowedWhenExecveEnforced(t *testing.T) {
+	e := newInterceptionTestEngine(t)
+
+	battery := []string{
+		"echo $HOME",
+		"ls /tmp | head",
+		"echo x > /tmp/a",
+		"true && true",
+		"echo $(date)",
+		"for i in 1 2; do echo $i; done",
+		"curl https://example.com",
+	}
+	for _, script := range battery {
+		dec := e.CheckCommandWithExecve("/bin/sh", []string{"-c", script}, true)
+		if dec.Rule == "shellc-opaque-script" {
+			t.Errorf("script %q: pre-denied as opaque with execve enforcement active; want fall-through to allow", script)
+		}
+		if dec.PolicyDecision != types.DecisionAllow {
+			t.Errorf("script %q: decision = %s (rule=%q), want allow", script, dec.PolicyDecision, dec.Rule)
+		}
+	}
+}
+
+// Without execve enforcement, the current hard-deny is preserved.
+func TestCheckCommand_OpaqueDeniedWhenNoExecveEnforcement(t *testing.T) {
+	e := newInterceptionTestEngine(t)
+
+	dec := e.CheckCommandWithExecve("/bin/sh", []string{"-c", "echo $HOME | head"}, false)
+	if dec.PolicyDecision != types.DecisionDeny || dec.Rule != "shellc-opaque-script" {
+		t.Errorf("got %s rule=%q, want deny shellc-opaque-script", dec.PolicyDecision, dec.Rule)
+	}
+
+	// Plain CheckCommand (no execve param) must keep the legacy hard-deny too.
+	dec2 := e.CheckCommand("/bin/sh", []string{"-c", "echo $HOME | head"})
+	if dec2.PolicyDecision != types.DecisionDeny || dec2.Rule != "shellc-opaque-script" {
+		t.Errorf("CheckCommand: got %s rule=%q, want deny shellc-opaque-script", dec2.PolicyDecision, dec2.Rule)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails to compile/fail**
+
+Run: `go test ./internal/policy/ -run TestCheckCommand_Opaque -v`
+Expected: FAIL — `e.CheckCommandWithExecve` undefined (method not yet added).
+
+- [ ] **Step 3: Implement the engine change**
+
+In `internal/policy/engine.go`, replace the `CheckCommand` signature line (`engine.go:583`):
+
+```go
+func (e *Engine) CheckCommand(command string, args []string) Decision {
+```
+
+with these three definitions (the body that followed `CheckCommand` now belongs to `checkCommand`):
+
+```go
+// CheckCommand evaluates a command against the policy with no assumption of
+// runtime execve interception (opaque shell-c scripts are pre-denied when a
+// restrictive command rule is present). See CheckCommandWithExecve for callers
+// on an execve-policed execution path.
+func (e *Engine) CheckCommand(command string, args []string) Decision {
+	return e.checkCommand(command, args, false)
+}
+
+// CheckCommandWithExecve is CheckCommand for callers whose execution path has
+// runtime execve interception active (seccomp USER_NOTIF or ptrace), so every
+// inner execve is policed by CheckExecve. When execveEnforcementActive is true
+// the opaque shell-c pre-deny is skipped — the script runs and its inner
+// commands are enforced precisely at exec time. Issue #375.
+func (e *Engine) CheckCommandWithExecve(command string, args []string, execveEnforcementActive bool) Decision {
+	return e.checkCommand(command, args, execveEnforcementActive)
+}
+
+func (e *Engine) checkCommand(command string, args []string, execveEnforcementActive bool) Decision {
+```
+
+Then change the opaque-deny gate (currently `engine.go:618`) from:
+
+```go
+			} else if e.hasRestrictiveCommandRule && shellparse.IsOpaqueShellC(cur, curArgs) {
+```
+
+to:
+
+```go
+			} else if e.hasRestrictiveCommandRule && !execveEnforcementActive && shellparse.IsOpaqueShellC(cur, curArgs) {
+```
+
+Leave the body of the function (everything after the opening brace) unchanged.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./internal/policy/ -run TestCheckCommand_Opaque -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Run the full policy package + the existing shellc test**
+
+Run: `go test ./internal/policy/`
+Expected: ok (existing `command_shellc_test.go` still passes — it uses `CheckCommand`, which now defaults `false`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/policy/engine.go internal/policy/command_shellc_interception_test.go
+git commit -m "fix(#375): make opaque shell-c pre-deny interception-aware in policy engine"
+```
+
+---
+
+## Task 2: App — execveEnforcementActive() helper
+
+**Files:**
+- Modify: `internal/api/session_policy.go`
+- Test: `internal/api/session_policy_test.go` (create if absent)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/api/session_policy_test.go` (or append if it exists):
+
+```go
+package api
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+func TestExecveEnforcementActive(t *testing.T) {
+	tests := []struct {
+		name    string
+		seccomp bool
+		ptrace  bool // simulate a.ptraceTracer != nil
+		want    bool
+	}{
+		{"none", false, false, false},
+		{"seccomp execve", true, false, true},
+		{"ptrace", false, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Sandbox.Seccomp.Execve.Enabled = tt.seccomp
+			a := &App{cfg: cfg}
+			if tt.ptrace {
+				a.ptraceTracer = struct{}{}
+			}
+			if got := a.execveEnforcementActive(); got != tt.want {
+				t.Errorf("execveEnforcementActive() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `go test ./internal/api/ -run TestExecveEnforcementActive -v`
+Expected: FAIL — `a.execveEnforcementActive` undefined.
+
+- [ ] **Step 3: Implement the helper**
+
+In `internal/api/session_policy.go`, add at the end of the file:
+
+```go
+// execveEnforcementActive reports whether inner execve calls will be policed at
+// runtime for sandboxed commands on this host: either seccomp execve
+// interception is enabled, or a ptrace tracer is attached. Used to relax the
+// opaque shell-c pre-deny (issue #375) — when true, CheckExecve enforces the
+// command policy on every inner exec, so the static pre-deny is redundant.
+func (a *App) execveEnforcementActive() bool {
+	return a.cfg.Sandbox.Seccomp.Execve.Enabled || a.ptraceTracer != nil
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./internal/api/ -run TestExecveEnforcementActive -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/api/session_policy.go internal/api/session_policy_test.go
+git commit -m "feat(#375): add App.execveEnforcementActive helper"
+```
+
+---
+
+## Task 3: Wire the command pre-check call sites
+
+**Files (modify the single `CheckCommand` call on each listed line):**
+- `internal/api/exec_stream.go:60`
+- `internal/api/pty_core.go:60`
+- `internal/api/grpc.go:293`
+- `internal/api/core.go:861`
+- `internal/api/core.go:1070`
+
+- [ ] **Step 1: Update `exec_stream.go`**
+
+Change:
+
+```go
+	pre := a.policyEngineFor(s).CheckCommand(req.Command, req.Args)
+```
+
+to:
+
+```go
+	pre := a.policyEngineFor(s).CheckCommandWithExecve(req.Command, req.Args, a.execveEnforcementActive())
+```
+
+- [ ] **Step 2: Update `pty_core.go`**
+
+Change:
+
+```go
+	pre := a.policyEngineFor(sess).CheckCommand(req.Command, req.Args)
+```
+
+to:
+
+```go
+	pre := a.policyEngineFor(sess).CheckCommandWithExecve(req.Command, req.Args, a.execveEnforcementActive())
+```
+
+- [ ] **Step 3: Update `grpc.go`** (the App is `s.app` here)
+
+Change:
+
+```go
+	pre := s.app.policyEngineFor(sess).CheckCommand(execReq.Command, execReq.Args)
+```
+
+to:
+
+```go
+	pre := s.app.policyEngineFor(sess).CheckCommandWithExecve(execReq.Command, execReq.Args, s.app.execveEnforcementActive())
+```
+
+- [ ] **Step 4: Update `core.go:861`**
+
+Change:
+
+```go
+	pre := a.policyEngineFor(s).CheckCommand(req.Command, req.Args)
+```
+
+to:
+
+```go
+	pre := a.policyEngineFor(s).CheckCommandWithExecve(req.Command, req.Args, a.execveEnforcementActive())
+```
+
+- [ ] **Step 5: Update `core.go:1070`**
+
+Change:
+
+```go
+	cmdDecision := a.policyEngineFor(s).CheckCommand(wrappedReq.Command, wrappedReq.Args)
+```
+
+to:
+
+```go
+	cmdDecision := a.policyEngineFor(s).CheckCommandWithExecve(wrappedReq.Command, wrappedReq.Args, a.execveEnforcementActive())
+```
+
+- [ ] **Step 6: Verify build and that no other intended call sites were missed**
+
+Run: `go build ./... && grep -rn "policyEngineFor(.*)\.CheckCommand(" internal/api/*.go | grep -v _test.go`
+Expected: build OK; the grep returns **no** results (all five execution-path sites now use `CheckCommandWithExecve`). Other `CheckCommand` callers (platform adapters, `context_eval`) intentionally remain.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/api/exec_stream.go internal/api/pty_core.go internal/api/grpc.go internal/api/core.go
+git commit -m "fix(#375): pass execve-enforcement signal into command pre-check on exec paths"
+```
+
+---
+
+## Task 4: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build + Windows cross-compile**
+
+Run: `go build ./... && GOOS=windows go build ./...`
+Expected: both succeed (no output).
+
+- [ ] **Step 2: Vet + gofmt**
+
+Run: `go vet ./internal/policy/ ./internal/api/ && gofmt -l internal/policy/ internal/api/session_policy.go`
+Expected: vet clean; `gofmt -l` prints nothing.
+
+- [ ] **Step 3: Run affected unit tests**
+
+Run: `go test ./internal/policy/ ./internal/api/`
+Expected: ok for both.
+
+- [ ] **Step 4: Confirm runtime execve enforcement is still intact (depth-1 denial)**
+
+Run: `go test ./internal/integration/ -run TestExecve`
+Expected: ok — nested/inner `execve` denial behavior is unchanged (this proves the security argument: inner commands are still blocked at exec time).
+
+- [ ] **Step 5: Commit any formatting fixes (if Step 2 changed files)**
+
+```bash
+git add -A && git commit -m "chore(#375): gofmt" || echo "nothing to commit"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** opaque gate change (Task 1), signal definition + helper (Task 2), call-site wiring at the five exec paths named in the spec (Task 3), tests for both interception states + reporter battery + inner-deny intact (Tasks 1 & 4). No-interception path unchanged (Task 1 Step 5 + `CheckCommand` default `false`). Non-goals (no config knob, no byte-set change, `shellc-wrapper-bypass`/`shellc-depth-exceeded` untouched) respected.
+- **Type consistency:** `CheckCommandWithExecve(command string, args []string, execveEnforcementActive bool) Decision` and `App.execveEnforcementActive() bool` are used identically in Tasks 1–3.
+- **No placeholders:** every code/command step shows concrete content and expected output.

--- a/docs/superpowers/specs/2026-05-23-issue-375-shellc-opaque-interception-aware-design.md
+++ b/docs/superpowers/specs/2026-05-23-issue-375-shellc-opaque-interception-aware-design.md
@@ -45,20 +45,23 @@ When `execveEnforcementActive` is true, the opaque script falls through to norma
 
 ### Plumbing `execveEnforcementActive`
 
-The signal reflects whether inner `execve` will actually be policed for the session:
+`execve` enforcement is a property of the **execution path**, not of the policy itself, so the signal is passed in at the command pre-check call site rather than stored on the engine:
+
+- Refactor `CheckCommand` into an internal `checkCommand(command, args, execveEnforcementActive bool)` holding the existing logic, with the opaque gate becoming `... && !execveEnforcementActive && shellparse.IsOpaqueShellC(...)`.
+- `CheckCommand(command, args)` stays as a thin wrapper calling `checkCommand(command, args, false)` — every existing caller (tests, non-Linux platform adapters, `context_eval`) is untouched and keeps today's hard-deny behavior.
+- Add `CheckCommandWithExecve(command, args, execveEnforcementActive bool)` calling `checkCommand(command, args, execveEnforcementActive)`.
+- Add an `App` helper computing the signal once:
 
 ```
-execveEnforcementActive = cfg.Sandbox.Seccomp.Execve.Enabled || (a.ptraceTracer != nil)
+func (a *App) execveEnforcementActive() bool {
+    return a.cfg.Sandbox.Seccomp.Execve.Enabled || a.ptraceTracer != nil
+}
 ```
 
-- `cfg.Sandbox.Seccomp.Execve.Enabled` is the seccomp-execve intent; a runtime probe failure fails closed in `agentsh-unixwrap` (see security analysis), so the config bool is safe to trust here.
-- `a.ptraceTracer != nil` is the App's existing *runtime* signal that ptrace is actually attached/handling execve (the same check `core.go` uses), rather than the config intent `Sandbox.Ptrace.Enabled` — so a ptrace that failed to initialize does not wrongly relax the pre-check.
-
-(`sandbox.seccomp.execve` and `sandbox.ptrace` are mutually exclusive per config validation, so at most one term is true.)
-
-- Add an immutable field `execveEnforcementActive bool` to `policy.Engine`, alongside `hasRestrictiveCommandRule`, with a setter `SetExecveEnforcementActive(bool)`.
-- The `App` computes the flag once from its config and applies it to every engine it builds: the global engine (policy loader / `SwapPolicy`) and the per-session engine (`internal/api/core.go`, `NewEngineWithVariables`).
-- Engines constructed elsewhere (tests, platform adapters that don't run the Linux wrapper) leave the field `false` — i.e. the safe, current hard-deny behavior. This avoids threading a new parameter through every `NewEngine` caller.
+  - `cfg.Sandbox.Seccomp.Execve.Enabled` is the seccomp-execve intent; a runtime probe failure fails closed in `agentsh-unixwrap` (see security analysis), so the config bool is safe to trust.
+  - `a.ptraceTracer != nil` is the App's existing *runtime* signal that ptrace is attached (the same check `core.go` uses), rather than the config intent `Sandbox.Ptrace.Enabled`, so a ptrace that failed to initialize does not wrongly relax the pre-check.
+  - (`sandbox.seccomp.execve` and `sandbox.ptrace` are mutually exclusive per config validation, so at most one term is true.)
+- Update the command pre-check call sites that run the Linux execve-intercepted path to call `CheckCommandWithExecve(cmd, args, a.execveEnforcementActive())`: `internal/api/exec_stream.go`, `internal/api/pty_core.go`, `internal/api/grpc.go`, and the two sites in `internal/api/core.go`. All have `App` access. Non-execution callers keep `CheckCommand` (i.e. `false`).
 
 ### Why this is safe (security analysis)
 
@@ -83,8 +86,8 @@ execveEnforcementActive = cfg.Sandbox.Seccomp.Execve.Enabled || (a.ptraceTracer 
 
 ## Affected files
 
-- `internal/policy/engine.go` — new field + setter; gate at the opaque-deny branch.
-- `internal/api` — `App` computes the flag and applies it to global + per-session engines (policy loader / `SwapPolicy`, `core.go` engine build).
+- `internal/policy/engine.go` — split `CheckCommand` into `checkCommand(…, execveEnforcementActive bool)` + `CheckCommand` (passes `false`) + `CheckCommandWithExecve`; gate the opaque-deny branch on `!execveEnforcementActive`.
+- `internal/api` — add `App.execveEnforcementActive()`; switch the five command pre-check call sites (`exec_stream.go`, `pty_core.go`, `grpc.go`, two in `core.go`) to `CheckCommandWithExecve`.
 - Tests in `internal/policy` (and a confirmation run of `internal/integration`).
 
 ## Out of scope (tracked separately if desired)

--- a/docs/superpowers/specs/2026-05-23-issue-375-shellc-opaque-interception-aware-design.md
+++ b/docs/superpowers/specs/2026-05-23-issue-375-shellc-opaque-interception-aware-design.md
@@ -61,7 +61,9 @@ func (a *App) execveEnforcementActive() bool {
   - `cfg.Sandbox.Seccomp.Execve.Enabled` is the seccomp-execve intent; a runtime probe failure fails closed in `agentsh-unixwrap` (see security analysis), so the config bool is safe to trust.
   - `a.ptraceTracer != nil` is the App's existing *runtime* signal that ptrace is attached (the same check `core.go` uses), rather than the config intent `Sandbox.Ptrace.Enabled`, so a ptrace that failed to initialize does not wrongly relax the pre-check.
   - (`sandbox.seccomp.execve` and `sandbox.ptrace` are mutually exclusive per config validation, so at most one term is true.)
-- Update the command pre-check call sites that run the Linux execve-intercepted path to call `CheckCommandWithExecve(cmd, args, a.execveEnforcementActive())`: `internal/api/exec_stream.go`, `internal/api/pty_core.go`, `internal/api/grpc.go`, and the two sites in `internal/api/core.go`. All have `App` access. Non-execution callers keep `CheckCommand` (i.e. `false`).
+- Update the command pre-check call sites that run the Linux execve-intercepted path to call `CheckCommandWithExecve(cmd, args, a.execveEnforcementActive())`: `internal/api/exec_stream.go`, `internal/api/pty_core.go`, `internal/api/grpc.go`, the two sites in `internal/api/core.go`, **and the shim wrap-init guard in `internal/api/wrap.go` (`wrapInitCore`, the `req.Mode == "shim"` branch)**. All have `App` access. Non-execution callers keep `CheckCommand` (i.e. `false`).
+
+  The shim wrap-init guard is essential, not optional: it is the pre-check the shell-shim kernel-install path hits (the reporter's exact scenario — Daytona runs every command as `bash -c "<script>"`). Without making it interception-aware, an opaque shim command is denied here, returns HTTP 403, and the shim falls back to the `agentsh exec` path — so the command runs but **bypasses the kernel-install wrapper entirely**, defeating the enforcement path for essentially all of the reporter's traffic. Making the guard interception-aware lets wrap-init proceed so the shim runs the wrapper directly, with inner execs policed at depth. Genuinely-denied *derivable* commands (e.g. `sh -c "shutdown"`) still derive to their deny rule and 403 as before; only the blunt opaque deny is relaxed.
 
 ### Why this is safe (security analysis)
 
@@ -87,7 +89,7 @@ func (a *App) execveEnforcementActive() bool {
 ## Affected files
 
 - `internal/policy/engine.go` — split `CheckCommand` into `checkCommand(…, execveEnforcementActive bool)` + `CheckCommand` (passes `false`) + `CheckCommandWithExecve`; gate the opaque-deny branch on `!execveEnforcementActive`.
-- `internal/api` — add `App.execveEnforcementActive()`; switch the five command pre-check call sites (`exec_stream.go`, `pty_core.go`, `grpc.go`, two in `core.go`) to `CheckCommandWithExecve`.
+- `internal/api` — add `App.execveEnforcementActive()`; switch the six command pre-check call sites (`exec_stream.go`, `pty_core.go`, `grpc.go`, two in `core.go`, and the shim wrap-init guard in `wrap.go`) to `CheckCommandWithExecve`.
 - Tests in `internal/policy` (and a confirmation run of `internal/integration`).
 
 ## Out of scope (tracked separately if desired)

--- a/docs/superpowers/specs/2026-05-23-issue-375-shellc-opaque-interception-aware-design.md
+++ b/docs/superpowers/specs/2026-05-23-issue-375-shellc-opaque-interception-aware-design.md
@@ -1,0 +1,93 @@
+# Interception-Aware Opaque Shell-C Pre-Check Design
+
+Issue: #375
+
+## Summary
+
+The shell-shim policy pre-check (`policy.Engine.CheckCommand`) statically denies any `bash -c` / `sh -c` invocation whose script it cannot fully parse, with `rule=shellc-opaque-script` (exit 126). The "opaque" classifier treats almost any shell-significant byte — pipes, `$`, redirects, `&&`, `$(…)`, globs, `;` — as un-parseable, so a large range of ordinary commands is rejected. On platforms that run every command as `bash -c "<script>"` (e.g. Daytona) this breaks most of the command surface. It is a regression from v0.18.0 and reproduces on current `main`.
+
+This design makes the opaque pre-deny **interception-aware**: when runtime `execve` enforcement is active for the session, the static pre-deny is skipped and the script is allowed to run, because every inner `execve` is already evaluated against the same command policy at runtime (`CheckExecve(filename, argv, depth)`, enforced with `EACCES`). When no `execve` interception is active, behavior is unchanged — the static hard-deny remains the security boundary.
+
+## Goals
+
+- Stop denying benign `bash -c` / `sh -c` scripts (pipes, variables, redirects, `&&`, `$(…)`, loops) when runtime `execve` enforcement will police the inner commands.
+- Preserve the exact current behavior when no `execve` interception is active.
+- No security regression: every binary the policy forbids is still blocked, just precisely at `execve` time instead of via a blunt static pre-deny.
+- Add regression tests covering both the interception-on and interception-off paths.
+
+## Non-Goals
+
+- No new policy/config knob (e.g. `shellc_opaque: allow|deny|require_interception`).
+- No widening of the opaque-byte allow-set (`isUnquotedAllowedByte`).
+- No change to the `shellc-wrapper-bypass` or `shellc-depth-exceeded` denials — this targets only `shellc-opaque-script`.
+- No change to the no-interception code path.
+
+## Background: the two enforcement layers
+
+1. **Static pre-check** — `policy.Engine.CheckCommand` (`internal/policy/engine.go:583`). Runs at session/command start. Walks `sh -c` forms via `shellparse`; if the script is opaque and `e.hasRestrictiveCommandRule` is set, fails closed with `shellc-opaque-script` (`engine.go:618-633`). This fires regardless of whether runtime interception is active — the bug.
+2. **Runtime per-execve check** — `policy.Engine.CheckExecve(filename, argv, depth)` (`engine.go:1289`). Invoked by the seccomp `USER_NOTIF` execve handler (`internal/netmonitor/unix/execve_handler.go:350`) and the ptrace execve handler (`internal/api/ptrace_handlers.go:114`). Evaluates each inner `execve` against the same compiled command rules with depth context; a `deny` returns `EACCES` and blocks the exec. Covered by `internal/integration/execve_interception_test.go` (nested `curl` blocked at depth 1, allowed at depth 0).
+
+The static pre-deny is a blunt failsafe ("can't parse → deny all"). When layer 2 is active it is redundant and over-broad.
+
+## Design
+
+### Core change
+
+In the `CheckCommand` derive loop, gate the opaque deny on the absence of runtime enforcement:
+
+```go
+} else if e.hasRestrictiveCommandRule && !e.execveEnforcementActive && shellparse.IsOpaqueShellC(cur, curArgs) {
+    // ... existing shellc-opaque-script deny ...
+}
+```
+
+When `execveEnforcementActive` is true, the opaque script falls through to normal command-rule matching (typically the operator's `allow sh`/`allow bash` rule) and runs; its inner `execve` calls are policed by `CheckExecve` at depth.
+
+### Plumbing `execveEnforcementActive`
+
+The signal reflects whether inner `execve` will actually be policed for the session:
+
+```
+execveEnforcementActive = cfg.Sandbox.Seccomp.Execve.Enabled || (a.ptraceTracer != nil)
+```
+
+- `cfg.Sandbox.Seccomp.Execve.Enabled` is the seccomp-execve intent; a runtime probe failure fails closed in `agentsh-unixwrap` (see security analysis), so the config bool is safe to trust here.
+- `a.ptraceTracer != nil` is the App's existing *runtime* signal that ptrace is actually attached/handling execve (the same check `core.go` uses), rather than the config intent `Sandbox.Ptrace.Enabled` — so a ptrace that failed to initialize does not wrongly relax the pre-check.
+
+(`sandbox.seccomp.execve` and `sandbox.ptrace` are mutually exclusive per config validation, so at most one term is true.)
+
+- Add an immutable field `execveEnforcementActive bool` to `policy.Engine`, alongside `hasRestrictiveCommandRule`, with a setter `SetExecveEnforcementActive(bool)`.
+- The `App` computes the flag once from its config and applies it to every engine it builds: the global engine (policy loader / `SwapPolicy`) and the per-session engine (`internal/api/core.go`, `NewEngineWithVariables`).
+- Engines constructed elsewhere (tests, platform adapters that don't run the Linux wrapper) leave the field `false` — i.e. the safe, current hard-deny behavior. This avoids threading a new parameter through every `NewEngine` caller.
+
+### Why this is safe (security analysis)
+
+- **Precise instead of blunt.** With interception active, `sh -c "shutdown; :"` runs `sh` (allowed), then `shutdown` execs at depth 1 → `CheckExecve` denies it with `EACCES` *iff* the policy denies `shutdown`. That is identical to the operator running `shutdown` directly — consistent, not a bypass. The pre-deny previously blocked all opaque scripts whether or not their inner commands were actually forbidden.
+- **The command policy guards new binaries; that is exactly what layer 2 covers** at every depth. Pure shell builtins (`echo`, redirects) spawn no binary, so the command policy has nothing to enforce on them anyway; filesystem effects remain governed by Landlock/fsmonitor, unchanged.
+- **Fail-closed end-to-end.** If `execve` interception is *configured* but the runtime probe fails (e.g. AppArmor blocks the seccomp notify ioctl), `agentsh-unixwrap` already `Fatal`s before exec (`cmd/agentsh-unixwrap/main.go`), so "pre-check allowed it" cannot translate into unpoliced execution.
+
+### Edge cases
+
+- `exec shutdown` (in-place execve via the `exec` builtin) is still an `execve` → evaluated by `CheckExecve` against the `shutdown` rules. Caught.
+- Depth-scoped rules (`MinDepth`/`MaxDepth`) continue to apply at runtime exactly as today.
+- `shellc-depth-exceeded` and `shellc-wrapper-bypass` are deliberately unchanged; only `shellc-opaque-script` becomes interception-aware.
+
+## Testing
+
+1. **Engine unit tests** (`internal/policy`), with a restrictive command rule present:
+   - `execveEnforcementActive=false` → opaque `sh -c "echo $HOME | head"` still denied `shellc-opaque-script` (current behavior preserved).
+   - `execveEnforcementActive=true` → same script is **not** pre-denied (falls through to the allow-shell rule).
+   - `execveEnforcementActive=true` + a `deny shutdown` rule → `CheckExecve("shutdown", …, depth=1)` still denies (inner enforcement intact).
+2. **Reporter battery** as a table test, asserting the pre-check no longer denies when enforcement is active: `echo $HOME`, `ls /tmp | head`, `echo x > /tmp/a`, `true && true`, `echo $(date)`, `for i in 1 2; do echo $i; done`.
+3. Confirm `internal/integration/execve_interception_test.go` still passes (depth-1 denial unaffected).
+
+## Affected files
+
+- `internal/policy/engine.go` — new field + setter; gate at the opaque-deny branch.
+- `internal/api` — `App` computes the flag and applies it to global + per-session engines (policy loader / `SwapPolicy`, `core.go` engine build).
+- Tests in `internal/policy` (and a confirmation run of `internal/integration`).
+
+## Out of scope (tracked separately if desired)
+
+- Config knob for explicit operator override.
+- Narrowing the opaque-byte allow-set to let benign literals through on the no-interception path.

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -858,7 +858,7 @@ func (a *App) execInSessionCore(ctx context.Context, id string, req types.ExecRe
 		includeEvents = "all"
 	}
 
-	pre := a.policyEngineFor(s).CheckCommand(req.Command, req.Args)
+	pre := a.policyEngineFor(s).CheckCommandWithExecve(req.Command, req.Args, a.execveEnforcementActive())
 	redirected, originalCmd, originalArgs := applyCommandRedirect(&req.Command, &req.Args, pre)
 	approvalErr := error(nil)
 	pkgApprovalDenied := false
@@ -1067,7 +1067,7 @@ func (a *App) execInSessionCore(ctx context.Context, id string, req types.ExecRe
 	a.broker.Publish(startEv)
 
 	limits := a.policyEngineFor(s).Limits()
-	cmdDecision := a.policyEngineFor(s).CheckCommand(wrappedReq.Command, wrappedReq.Args)
+	cmdDecision := a.policyEngineFor(s).CheckCommandWithExecve(wrappedReq.Command, wrappedReq.Args, a.execveEnforcementActive())
 	exitCode, stdoutB, stderrB, stdoutTotal, stderrTotal, stdoutTrunc, stderrTrunc, resources, execErr := runCommandWithResources(ctx, s, cmdID, wrappedReq, a.cfg, cmdDecision.EnvPolicy, limits.CommandTimeout, a.cgroupHook(id, cmdID, limits), extraCfg, a.ptraceTracer, id)
 
 	// Check if process was killed by seccomp (SIGSYS) and emit event

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -57,7 +57,7 @@ func (a *App) execInSessionStream(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	pre := a.policyEngineFor(s).CheckCommand(req.Command, req.Args)
+	pre := a.policyEngineFor(s).CheckCommandWithExecve(req.Command, req.Args, a.execveEnforcementActive())
 	redirected, originalCmd, originalArgs := applyCommandRedirect(&req.Command, &req.Args, pre)
 	approvalErr := error(nil)
 	if pre.PolicyDecision == types.DecisionApprove && pre.EffectiveDecision == types.DecisionApprove && a.approvals != nil {

--- a/internal/api/grpc.go
+++ b/internal/api/grpc.go
@@ -290,7 +290,7 @@ func (s *grpcServer) ExecStream(in *structpb.Struct, stream grpc.ServerStream) e
 		}
 	}
 
-	pre := s.app.policyEngineFor(sess).CheckCommand(execReq.Command, execReq.Args)
+	pre := s.app.policyEngineFor(sess).CheckCommandWithExecve(execReq.Command, execReq.Args, s.app.execveEnforcementActive())
 	redirected, originalCmd, originalArgs := applyCommandRedirect(&execReq.Command, &execReq.Args, pre)
 	approvalErr := error(nil)
 	if pre.PolicyDecision == types.DecisionApprove && pre.EffectiveDecision == types.DecisionApprove && s.app.approvals != nil {

--- a/internal/api/pty_core.go
+++ b/internal/api/pty_core.go
@@ -57,7 +57,7 @@ func (a *App) startPTY(ctx context.Context, sessionID string, req ptyStartParams
 	unlock := sess.LockExec()
 	sess.SetCurrentCommandID(cmdID)
 
-	pre := a.policyEngineFor(sess).CheckCommand(req.Command, req.Args)
+	pre := a.policyEngineFor(sess).CheckCommandWithExecve(req.Command, req.Args, a.execveEnforcementActive())
 	redirected, originalCmd, originalArgs := applyCommandRedirect(&req.Command, &req.Args, pre)
 	approvalErr := error(nil)
 	if pre.PolicyDecision == types.DecisionApprove && pre.EffectiveDecision == types.DecisionApprove && a.approvals != nil {

--- a/internal/api/session_policy.go
+++ b/internal/api/session_policy.go
@@ -57,3 +57,12 @@ func (a *App) SwapPolicy(eng *policy.Engine) *policy.Engine {
 	a.policy = eng
 	return prev
 }
+
+// execveEnforcementActive reports whether inner execve calls will be policed at
+// runtime for sandboxed commands on this host: either seccomp execve
+// interception is enabled, or a ptrace tracer is attached. Used to relax the
+// opaque shell-c pre-deny (issue #375) — when true, CheckExecve enforces the
+// command policy on every inner exec, so the static pre-deny is redundant.
+func (a *App) execveEnforcementActive() bool {
+	return a.cfg.Sandbox.Seccomp.Execve.Enabled || a.ptraceTracer != nil
+}

--- a/internal/api/session_policy.go
+++ b/internal/api/session_policy.go
@@ -64,5 +64,11 @@ func (a *App) SwapPolicy(eng *policy.Engine) *policy.Engine {
 // opaque shell-c pre-deny (issue #375) — when true, CheckExecve enforces the
 // command policy on every inner exec, so the static pre-deny is redundant.
 func (a *App) execveEnforcementActive() bool {
-	return a.cfg.Sandbox.Seccomp.Execve.Enabled || a.ptraceTracer != nil
+	if a.ptraceTracer != nil {
+		return true
+	}
+	// Seccomp execve enforcement is installed by the unix-socket notify
+	// wrapper; without unix sockets the wrapper is skipped and inner execve
+	// calls are NOT policed, so the opaque shell-c pre-deny must stay. Issue #375.
+	return a.cfg.Sandbox.Seccomp.Execve.Enabled && unixSocketsConfigEnabled(a.cfg)
 }

--- a/internal/api/session_policy_test.go
+++ b/internal/api/session_policy_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"testing"
 
+	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/pkg/types"
@@ -90,5 +91,31 @@ func TestPolicyEngineFor_NilSessionFallsBackToGlobal(t *testing.T) {
 	got := app.policyEngineFor(nil)
 	if got != globalEngine {
 		t.Fatalf("expected global engine for nil session, got %p", got)
+	}
+}
+
+func TestExecveEnforcementActive(t *testing.T) {
+	tests := []struct {
+		name    string
+		seccomp bool
+		ptrace  bool // simulate a.ptraceTracer != nil
+		want    bool
+	}{
+		{"none", false, false, false},
+		{"seccomp execve", true, false, true},
+		{"ptrace", false, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.Sandbox.Seccomp.Execve.Enabled = tt.seccomp
+			a := &App{cfg: cfg}
+			if tt.ptrace {
+				a.ptraceTracer = struct{}{}
+			}
+			if got := a.execveEnforcementActive(); got != tt.want {
+				t.Errorf("execveEnforcementActive() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/api/session_policy_test.go
+++ b/internal/api/session_policy_test.go
@@ -96,20 +96,27 @@ func TestPolicyEngineFor_NilSessionFallsBackToGlobal(t *testing.T) {
 
 func TestExecveEnforcementActive(t *testing.T) {
 	tests := []struct {
-		name    string
-		seccomp bool
-		ptrace  bool // simulate a.ptraceTracer != nil
-		want    bool
+		name         string
+		seccomp      bool
+		unixDisabled bool // explicitly set unix_sockets.enabled=false
+		ptrace       bool // simulate a.ptraceTracer != nil
+		want         bool
 	}{
-		{"none", false, false, false},
-		{"seccomp execve", true, false, true},
-		{"ptrace", false, true, true},
-		{"both", true, true, true},
+		{"none", false, false, false, false},
+		{"seccomp execve, unix sockets default-on", true, false, false, true},
+		{"seccomp execve but unix sockets disabled", true, true, false, false},
+		{"ptrace", false, false, true, true},
+		{"both", true, false, true, true},
+		{"ptrace with unix sockets disabled still true", false, true, true, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config.Config{}
 			cfg.Sandbox.Seccomp.Execve.Enabled = tt.seccomp
+			if tt.unixDisabled {
+				disabled := false
+				cfg.Sandbox.UnixSockets.Enabled = &disabled
+			}
 			a := &App{cfg: cfg}
 			if tt.ptrace {
 				a.ptraceTracer = struct{}{}

--- a/internal/api/session_policy_test.go
+++ b/internal/api/session_policy_test.go
@@ -104,6 +104,7 @@ func TestExecveEnforcementActive(t *testing.T) {
 		{"none", false, false, false},
 		{"seccomp execve", true, false, true},
 		{"ptrace", false, true, true},
+		{"both", true, true, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -161,7 +161,7 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 			return types.WrapInitResponse{}, http.StatusServiceUnavailable,
 				fmt.Errorf("shim wrap-init: no policy engine available for session")
 		}
-		dec := engine.CheckCommand(req.AgentCommand, req.AgentArgs)
+		dec := engine.CheckCommandWithExecve(req.AgentCommand, req.AgentArgs, a.execveEnforcementActive())
 		// We must check BOTH the underlying PolicyDecision and the
 		// EffectiveDecision. Some decisions resolve to effective-allow
 		// even though they carry semantics the shim path does not

--- a/internal/api/wrap_shim_opaque_test.go
+++ b/internal/api/wrap_shim_opaque_test.go
@@ -1,0 +1,79 @@
+package api
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// Issue #375: the shim wrap-init guard must be interception-aware. With execve
+// enforcement off, an opaque shim command is denied by the guard (403). With it
+// on, the guard must let wrap-init proceed (the wrapper runs the command and
+// inner execs are policed by CheckExecve).
+func TestWrapInit_ShimGuard_OpaqueInterceptionAware(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("wrap is Linux-only")
+	}
+
+	buildApp := func(t *testing.T, execve bool) (*App, *session.Manager) {
+		enabled := true
+		cfg := &config.Config{}
+		cfg.Sandbox.UnixSockets.Enabled = &enabled
+		cfg.Sandbox.UnixSockets.WrapperBin = "/bin/true"
+		cfg.Sandbox.Seccomp.Execve.Enabled = execve
+		app, mgr := newTestAppForWrap(t, cfg)
+		p := &policy.Policy{
+			CommandRules: []policy.CommandRule{
+				{Name: "deny-shutdown", Commands: []string{"shutdown"}, Decision: "deny"},
+				{Name: "allow-shells", Commands: []string{"sh", "bash", "dash", "zsh"}, Decision: "allow"},
+			},
+		}
+		eng, err := policy.NewEngine(p, false, true)
+		if err != nil {
+			t.Fatalf("NewEngine: %v", err)
+		}
+		app.SwapPolicy(eng)
+		return app, mgr
+	}
+
+	req := types.WrapInitRequest{
+		Mode:         "shim",
+		AgentCommand: "/bin/sh",
+		AgentArgs:    []string{"-c", "echo $HOME | head"},
+		CallerUID:    nonzeroTestUID(),
+	}
+
+	t.Run("no execve enforcement denies opaque (403)", func(t *testing.T) {
+		app, mgr := buildApp(t, false)
+		s, err := mgr.Create(t.TempDir(), "default")
+		if err != nil {
+			t.Fatalf("create session: %v", err)
+		}
+		_, code, err := app.wrapInitCore(s, s.ID, req)
+		if code != http.StatusForbidden {
+			t.Fatalf("code = %d (err=%v), want 403 (opaque denied by shim guard)", code, err)
+		}
+	})
+
+	t.Run("execve enforcement lets opaque proceed (not 403)", func(t *testing.T) {
+		app, mgr := buildApp(t, true)
+		s, err := mgr.Create(t.TempDir(), "default")
+		if err != nil {
+			t.Fatalf("create session: %v", err)
+		}
+		resp, code, err := app.wrapInitCore(s, s.ID, req)
+		if code == http.StatusForbidden {
+			t.Fatalf("code = 403 (err=%v), want non-403 (opaque allowed when execve enforced)", err)
+		}
+		if resp.NotifySocket != "" {
+			t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(resp.NotifySocket)) })
+		}
+	})
+}

--- a/internal/api/wrap_shim_opaque_test.go
+++ b/internal/api/wrap_shim_opaque_test.go
@@ -69,8 +69,8 @@ func TestWrapInit_ShimGuard_OpaqueInterceptionAware(t *testing.T) {
 			t.Fatalf("create session: %v", err)
 		}
 		resp, code, err := app.wrapInitCore(s, s.ID, req)
-		if code == http.StatusForbidden {
-			t.Fatalf("code = 403 (err=%v), want non-403 (opaque allowed when execve enforced)", err)
+		if code != http.StatusOK {
+			t.Fatalf("code = %d (err=%v), want 200 (opaque allowed/wrap-init proceeds when execve enforced)", code, err)
 		}
 		if resp.NotifySocket != "" {
 			t.Cleanup(func() { _ = os.RemoveAll(filepath.Dir(resp.NotifySocket)) })

--- a/internal/policy/command_shellc_interception_test.go
+++ b/internal/policy/command_shellc_interception_test.go
@@ -64,3 +64,15 @@ func TestCheckCommand_OpaqueDeniedWhenNoExecveEnforcement(t *testing.T) {
 		t.Errorf("CheckCommand: got %s rule=%q, want deny shellc-opaque-script", dec2.PolicyDecision, dec2.Rule)
 	}
 }
+
+// Even with execve enforcement active, a genuinely-denied DERIVABLE command
+// (not opaque) must still be denied at pre-check — only the blunt opaque
+// pre-deny is relaxed, never real policy. This is the security invariant the
+// whole interception-aware change depends on (issue #375).
+func TestCheckCommand_DerivableDenyStillDeniedWhenExecveEnforced(t *testing.T) {
+	e := newInterceptionTestEngine(t)
+	dec := e.CheckCommandWithExecve("/bin/sh", []string{"-c", "shutdown now"}, true)
+	if dec.PolicyDecision != types.DecisionDeny || dec.Rule != "deny-shutdown" {
+		t.Fatalf("got %s rule=%q, want deny rule=deny-shutdown (derivable deny must survive execve relaxation)", dec.PolicyDecision, dec.Rule)
+	}
+}

--- a/internal/policy/command_shellc_interception_test.go
+++ b/internal/policy/command_shellc_interception_test.go
@@ -1,0 +1,66 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// newInterceptionTestEngine builds an engine whose policy has a restrictive
+// command rule (deny-shutdown), so hasRestrictiveCommandRule is set and the
+// opaque pre-deny gate is reachable. Mirrors command_shellc_test.go.
+func newInterceptionTestEngine(t *testing.T) *Engine {
+	t.Helper()
+	p := &Policy{
+		CommandRules: []CommandRule{
+			{Name: "deny-shutdown", Commands: []string{"shutdown"}, Decision: "deny"},
+			{Name: "allow-shells", Commands: []string{"sh", "bash", "dash", "zsh"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	return e
+}
+
+// Issue #375: with execve enforcement active, opaque shell-c scripts must NOT
+// be statically pre-denied — inner execs are policed at runtime by CheckExecve.
+func TestCheckCommand_OpaqueAllowedWhenExecveEnforced(t *testing.T) {
+	e := newInterceptionTestEngine(t)
+
+	battery := []string{
+		"echo $HOME",
+		"ls /tmp | head",
+		"echo x > /tmp/a",
+		"true && true",
+		"echo $(date)",
+		"for i in 1 2; do echo $i; done",
+		"curl https://example.com",
+	}
+	for _, script := range battery {
+		dec := e.CheckCommandWithExecve("/bin/sh", []string{"-c", script}, true)
+		if dec.Rule == "shellc-opaque-script" {
+			t.Errorf("script %q: pre-denied as opaque with execve enforcement active; want fall-through to allow", script)
+		}
+		if dec.PolicyDecision != types.DecisionAllow {
+			t.Errorf("script %q: decision = %s (rule=%q), want allow", script, dec.PolicyDecision, dec.Rule)
+		}
+	}
+}
+
+// Without execve enforcement, the current hard-deny is preserved.
+func TestCheckCommand_OpaqueDeniedWhenNoExecveEnforcement(t *testing.T) {
+	e := newInterceptionTestEngine(t)
+
+	dec := e.CheckCommandWithExecve("/bin/sh", []string{"-c", "echo $HOME | head"}, false)
+	if dec.PolicyDecision != types.DecisionDeny || dec.Rule != "shellc-opaque-script" {
+		t.Errorf("got %s rule=%q, want deny shellc-opaque-script", dec.PolicyDecision, dec.Rule)
+	}
+
+	// Plain CheckCommand (no execve param) must keep the legacy hard-deny too.
+	dec2 := e.CheckCommand("/bin/sh", []string{"-c", "echo $HOME | head"})
+	if dec2.PolicyDecision != types.DecisionDeny || dec2.Rule != "shellc-opaque-script" {
+		t.Errorf("CheckCommand: got %s rule=%q, want deny shellc-opaque-script", dec2.PolicyDecision, dec2.Rule)
+	}
+}

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -580,7 +580,24 @@ func (e *Engine) CheckNetworkIP(domain string, ip net.IP, port int) Decision {
 	return dec
 }
 
+// CheckCommand evaluates a command against the policy with no assumption of
+// runtime execve interception (opaque shell-c scripts are pre-denied when a
+// restrictive command rule is present). See CheckCommandWithExecve for callers
+// on an execve-policed execution path.
 func (e *Engine) CheckCommand(command string, args []string) Decision {
+	return e.checkCommand(command, args, false)
+}
+
+// CheckCommandWithExecve is CheckCommand for callers whose execution path has
+// runtime execve interception active (seccomp USER_NOTIF or ptrace), so every
+// inner execve is policed by CheckExecve. When execveEnforcementActive is true
+// the opaque shell-c pre-deny is skipped — the script runs and its inner
+// commands are enforced precisely at exec time. Issue #375.
+func (e *Engine) CheckCommandWithExecve(command string, args []string, execveEnforcementActive bool) Decision {
+	return e.checkCommand(command, args, execveEnforcementActive)
+}
+
+func (e *Engine) checkCommand(command string, args []string, execveEnforcementActive bool) Decision {
 	result, _ := e.matchCommandRules(command, args)
 	// For `<shell> -c "<simple-cmd>"` invocations, also evaluate the
 	// underlying binary so a rule like `deny bin=shutdown` fires for
@@ -615,7 +632,7 @@ func (e *Engine) CheckCommand(command string, args []string) Decision {
 					result = dec
 					resultStrictness = decisionStrictness(dec.PolicyDecision)
 				}
-			} else if e.hasRestrictiveCommandRule && shellparse.IsOpaqueShellC(cur, curArgs) {
+			} else if e.hasRestrictiveCommandRule && !execveEnforcementActive && shellparse.IsOpaqueShellC(cur, curArgs) {
 				// Opaque scripts (metachars, pipes, subshells, globs, …) can
 				// execute binaries we can't predict. With any restrictive
 				// command rule in the policy, silently falling through to


### PR DESCRIPTION
## Summary

Fixes #375. The shell-shim policy pre-check denied any `bash -c`/`sh -c` script it couldn't fully parse (`rule=shellc-opaque-script`, exit 126) even when runtime `execve` interception was active and would police every inner exec — breaking orchestrators (e.g. Daytona) that run every command as `bash -c "<script>"`. A regression from v0.18.0.

This makes the opaque pre-deny **interception-aware**: when seccomp-`execve` (with unix sockets) or ptrace is active, the opaque script is allowed to run and its inner `execve` calls are policed at depth by the existing `CheckExecve` path (enforced with `EACCES`). With no interception active, behavior is byte-for-byte unchanged (hard-deny preserved).

## Changes

- `policy.Engine`: split `CheckCommand` into `checkCommand(…, execveEnforcementActive bool)`; the `shellc-opaque-script` branch is gated on `!execveEnforcementActive`. Added `CheckCommandWithExecve`. `CheckCommand` keeps the legacy default (`false`), so non-execution callers (PolicyCheck RPC, platform adapters, `context_eval`) are untouched.
- `App.execveEnforcementActive()` = `ptraceTracer != nil`, or `seccomp.execve.enabled && unix_sockets enabled` (seccomp execve enforcement is installed by the unix-socket wrapper; requiring unix sockets avoids relaxing the pre-deny when execve wouldn't actually be policed).
- Six command pre-check call sites switched to `CheckCommandWithExecve(…)`: `exec_stream.go`, `pty_core.go`, `grpc.go`, two in `core.go`, and the **shim wrap-init guard** in `wrap.go` (the path the kernel-install shim hits — without it, opaque shim commands 403'd and fell back to `agentsh exec`, bypassing the kernel-install wrapper entirely).

## Security

Only the blunt opaque pre-deny relaxes, and only when `execve` enforcement is active. Genuinely-denied **derivable** commands (`sh -c "shutdown now"` → `deny-shutdown`) still deny at pre-check; `shellc-wrapper-bypass` and `shellc-depth-exceeded` are untouched; inner execs of an opaque script (`sh -c "shutdown; :"`) are still blocked at depth by `CheckExecve`. Tests lock the derivable-deny invariant and both interception states.

## Test Plan

- [x] `go test ./internal/policy/ ./internal/api/`
- [x] `go test -tags integration ./internal/integration/ -run TestExecveInterception` (depth-1 denial intact)
- [x] `go build ./...` and `GOOS=windows go build ./...`
- [x] `go vet` + `gofmt` clean on changed files

Spec & plan: `docs/superpowers/specs/2026-05-23-issue-375-shellc-opaque-interception-aware-design.md`, `docs/superpowers/plans/2026-05-23-issue-375-shellc-opaque-interception-aware.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
