### PR TITLE
fix(store): retry Windows sidecar MoveFileEx to deflake TestFlushLoop_PeriodicSync

### DIFF
--- a/internal/audit/fsync_dir_windows.go
+++ b/internal/audit/fsync_dir_windows.go
@@ -2,11 +2,17 @@
 
 package audit
 
-import "golang.org/x/sys/windows"
+import (
+	"errors"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
 
 func syncDir(string) error { return nil }
 
-func replaceFile(from, to string) error {
+// moveFileReplace performs the raw atomic replace via MoveFileEx.
+func moveFileReplace(from, to string) error {
 	fromPtr, err := windows.UTF16PtrFromString(from)
 	if err != nil {
 		return err
@@ -16,4 +22,24 @@ func replaceFile(from, to string) error {
 		return err
 	}
 	return windows.MoveFileEx(fromPtr, toPtr, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+}
+
+// isTransientReplaceErr reports whether a MoveFileEx failure is the transient
+// kind caused by another handle briefly holding the destination open. Windows
+// surfaces this as ERROR_ACCESS_DENIED (a concurrent reader without
+// FILE_SHARE_DELETE, or antivirus/the search indexer) or
+// ERROR_SHARING_VIOLATION. Both clear within milliseconds, so the replace is
+// worth retrying rather than failing the whole sidecar write (and the audit
+// flush). Issue: TestFlushLoop_PeriodicSync Windows flake.
+func isTransientReplaceErr(err error) bool {
+	return errors.Is(err, windows.ERROR_ACCESS_DENIED) ||
+		errors.Is(err, windows.ERROR_SHARING_VIOLATION)
+}
+
+func replaceFile(from, to string) error {
+	return retryReplace(
+		func() error { return moveFileReplace(from, to) },
+		isTransientReplaceErr,
+		replaceMaxAttempts, replaceBackoff, time.Sleep,
+	)
 }

--- a/internal/audit/replace.go
+++ b/internal/audit/replace.go
@@ -1,0 +1,40 @@
+package audit
+
+import "time"
+
+// Tunables for the Windows atomic-replace retry. On Windows, MoveFileEx with
+// MOVEFILE_REPLACE_EXISTING can return ERROR_ACCESS_DENIED / ERROR_SHARING_
+// VIOLATION when another handle briefly holds the destination sidecar open
+// (a concurrent reader, antivirus, or the search indexer). Those clear within
+// a few milliseconds; replaceMaxAttempts × replaceBackoff bounds the wait at
+// roughly 200ms before surfacing the error.
+const (
+	replaceMaxAttempts = 10
+	replaceBackoff     = 20 * time.Millisecond
+)
+
+// retryReplace invokes move, retrying up to maxAttempts total times on errors
+// the transient predicate accepts, sleeping backoff between attempts. A
+// non-transient error returns immediately; exhausting all attempts returns the
+// last error. move/transient/sleep are injected so the retry behavior is
+// testable without a real filesystem race. Used by the Windows replaceFile
+// (see fsync_dir_windows.go); the unix path uses os.Rename, which does not
+// suffer this race.
+func retryReplace(move func() error, transient func(error) bool, maxAttempts int, backoff time.Duration, sleep func(time.Duration)) error {
+	if maxAttempts < 1 {
+		maxAttempts = 1 // always attempt the move at least once
+	}
+	var err error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err = move(); err == nil {
+			return nil
+		}
+		if !transient(err) {
+			return err
+		}
+		if attempt < maxAttempts-1 {
+			sleep(backoff)
+		}
+	}
+	return err
+}

--- a/internal/audit/replace_test.go
+++ b/internal/audit/replace_test.go
@@ -1,0 +1,98 @@
+package audit
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// retryReplace is the platform-neutral retry wrapper used by the Windows
+// replaceFile to ride out transient MoveFileEx failures (ERROR_ACCESS_DENIED /
+// ERROR_SHARING_VIOLATION) that occur when another handle briefly holds the
+// destination sidecar open. These tests exercise the retry behavior with
+// injected fakes so they run on every platform.
+
+func TestRetryReplace_SucceedsAfterTransientErrors(t *testing.T) {
+	transientErr := errors.New("Access is denied.")
+	transient := func(err error) bool { return errors.Is(err, transientErr) }
+
+	calls, sleeps := 0, 0
+	move := func() error {
+		calls++
+		if calls < 3 {
+			return transientErr
+		}
+		return nil
+	}
+
+	err := retryReplace(move, transient, 10, time.Millisecond, func(time.Duration) { sleeps++ })
+	if err != nil {
+		t.Fatalf("err = %v, want nil after transient retries succeed", err)
+	}
+	if calls != 3 {
+		t.Fatalf("move called %d times, want 3", calls)
+	}
+	if sleeps != 2 {
+		t.Fatalf("slept %d times, want 2 (between the 3 attempts)", sleeps)
+	}
+}
+
+func TestRetryReplace_NonTransientReturnsImmediately(t *testing.T) {
+	permanent := errors.New("not a directory")
+	transient := func(error) bool { return false }
+
+	calls := 0
+	move := func() error { calls++; return permanent }
+
+	err := retryReplace(move, transient, 10, time.Millisecond, func(time.Duration) {
+		t.Fatal("must not sleep/retry on a non-transient error")
+	})
+	if !errors.Is(err, permanent) {
+		t.Fatalf("err = %v, want permanent error returned immediately", err)
+	}
+	if calls != 1 {
+		t.Fatalf("move called %d times, want 1 (no retry on non-transient)", calls)
+	}
+}
+
+func TestRetryReplace_ExhaustsAttemptsAndReturnsLastError(t *testing.T) {
+	transientErr := errors.New("The process cannot access the file because it is being used by another process.")
+	transient := func(err error) bool { return errors.Is(err, transientErr) }
+
+	calls := 0
+	move := func() error { calls++; return transientErr }
+
+	err := retryReplace(move, transient, 4, time.Millisecond, func(time.Duration) {})
+	if !errors.Is(err, transientErr) {
+		t.Fatalf("err = %v, want the last transient error after exhausting attempts", err)
+	}
+	if calls != 4 {
+		t.Fatalf("move called %d times, want 4 (maxAttempts)", calls)
+	}
+}
+
+func TestRetryReplace_SucceedsFirstTry(t *testing.T) {
+	calls := 0
+	move := func() error { calls++; return nil }
+
+	err := retryReplace(move, func(error) bool { return true }, 10, time.Millisecond, func(time.Duration) {
+		t.Fatal("must not sleep when the first attempt succeeds")
+	})
+	if err != nil || calls != 1 {
+		t.Fatalf("err=%v calls=%d, want nil and 1 call", err, calls)
+	}
+}
+
+func TestRetryReplace_NonPositiveAttemptsStillMovesOnce(t *testing.T) {
+	// A misconfigured maxAttempts must never silently "succeed" without
+	// attempting the move; it should still try exactly once.
+	calls := 0
+	move := func() error { calls++; return nil }
+
+	if err := retryReplace(move, func(error) bool { return true }, 0, time.Millisecond, func(time.Duration) {}); err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Fatalf("move called %d times with maxAttempts=0, want exactly 1", calls)
+	}
+}


### PR DESCRIPTION
## Summary

Deflakes `TestFlushLoop_PeriodicSync` (`internal/store`), which intermittently fails on the **Windows** CI runner with `audit flush failed … rename sidecar: Access is denied` → `timed out waiting for sidecar sequence 1; got 0`.

## Root cause

`audit.WriteSidecar` writes a temp file and atomically replaces the sidecar via `replaceFile`. On Windows that's a single `MoveFileEx(..., MOVEFILE_REPLACE_EXISTING|MOVEFILE_WRITE_THROUGH)` with **no retry**. `MoveFileEx`-replace returns `ERROR_ACCESS_DENIED` when another handle briefly holds the destination sidecar open — the test polls `ReadSidecar`/`os.ReadFile` every 10ms, and on a real host antivirus or the search indexer do the same. A single unlucky collision fails the sidecar write (and the audit flush), so the sidecar never advances and the test times out.

The codebase already retries transient Windows sharing/access errors on the **read** side (`shouldRetrySidecarRead`); the **write/rename** side had no symmetric retry. This is a genuine production-robustness gap on Windows, not just test noise.

## Fix

- New platform-neutral `retryReplace` helper (`internal/audit/replace.go`): bounded retry (10 attempts × 20ms ≈ 180ms cap) that retries only on transient errors, returns non-transient errors immediately, and returns the last error on exhaustion. Fully unit-tested with injected fakes (`replace_test.go`) — runs on all platforms.
- Windows `replaceFile` (`fsync_dir_windows.go`) now wraps `MoveFileEx` in `retryReplace`, classifying `ERROR_ACCESS_DENIED` / `ERROR_SHARING_VIOLATION` as transient.
- Unix `os.Rename` is unchanged — POSIX renames over open files without error.

No change to failure semantics: a genuine permanent permission error still surfaces (after a bounded ~180ms), and `WriteSidecar` still cleans up its temp file on exhaustion.

## Test Plan

- [x] `go test ./internal/audit/ ./internal/store/` (Linux) — `retryReplace` unit tests + flush-loop tests pass
- [x] `GOOS=windows go build ./...` and `GOOS=windows go vet ./internal/audit/` — Windows path compiles & vets clean
- [x] `gofmt` clean
- [ ] **Windows CI job** is the real validation that the flake is gone (cannot run Windows locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
