### PR TITLE
fix(#376): enforce sandbox+signing schema invariants in config validate

### DIFF
--- a/docs/superpowers/plans/2026-05-24-issue-376-config-validate-schema-parity.md
+++ b/docs/superpowers/plans/2026-05-24-issue-376-config-validate-schema-parity.md
@@ -1,0 +1,215 @@
+# config validate / startup schema-validation parity — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `agentsh config validate` reject the configs the server rejects at startup, by wiring the two config-schema cross-field validators (`cfg.Sandbox.Validate()`, `cfg.Policies.Signing.Validate()`) into `config.validateConfig`.
+
+**Architecture:** `config.Load`/`LoadWithSource` (used by `config validate`, the server, and shim auto-start) run `validateConfig`. Append the two validators — currently called only at `server.New` — to the end of `validateConfig`, with error prefixes copied verbatim from `server.go` so messages are identical. Keep the startup calls as defense-in-depth with a guardrail comment. Host/environment checks stay at startup.
+
+**Tech Stack:** Go; `internal/config`, `internal/server`.
+
+**Spec:** `docs/superpowers/specs/2026-05-24-issue-376-config-validate-schema-parity-design.md`
+
+**Verified facts (don't re-derive):**
+- `validateConfig(cfg *Config) error` is at `internal/config/config.go:2140`; its final `return nil` is at `config.go:2441`. Insert the new calls immediately before that `return nil`.
+- `applyDefaults(&Config{})` followed by `validateConfig` returns `nil` (baseline is fully valid) — confirmed empirically. So tests build `&Config{}`, call `applyDefaults(cfg)`, override the field under test, then call `validateConfig(cfg)`.
+- `applyDefaults` does NOT populate `Sandbox.Ptrace`; tests that enable ptrace must set `cfg.Sandbox.Ptrace = DefaultPtraceConfig()` first (gives valid `attach_mode`/`on_attach_failure`/`mask_tracer_pid`/`max_hold_ms`). `DefaultPtraceConfig()` has `Enabled:false` and `Trace{Execve,File,Network,Signal}` all `true` (i.e. NOT execve-only — matches the issue repro).
+- `SandboxConfig.Validate()` checks, in order: (1) `Ptrace.Enabled && Seccomp.Execve.Enabled` → `"…mutually exclusive…"`; (2) `Ptrace.Enabled && *UnixSockets.Enabled && !Ptrace.IsExecveOnly()` → `"…requires execve-only tracing…"`; (3) `Ptrace.Validate()` (returns nil when ptrace disabled).
+- `SigningConfig.Validate()` errors with `"signing.trust_store is required when signing.mode is \"enforce\""` when `Mode` is `enforce`/`warn` and `TrustStore == ""`. Field path: `cfg.Policies.Signing.{Mode,TrustStore}`.
+- `server.go:143-149` wraps these as `fmt.Errorf("sandbox config: %w", err)` and `fmt.Errorf("signing config: %w", err)`.
+- Test files in `internal/config` are `package config` and call the unexported `applyDefaults`/`validateConfig` directly (see `internal/config/pkgcheck_test.go`).
+
+---
+
+## File Structure
+
+- `internal/config/config.go` — append two validator calls to the end of `validateConfig` (the only behavioral change).
+- `internal/config/validate_sandbox_signing_test.go` (new) — regression tests proving the validators are wired into `validateConfig`.
+- `internal/server/server.go` — guardrail comment above the existing startup validation calls (no behavior change).
+
+---
+
+## Task 1: Wire schema validators into `validateConfig` (+ tests + guardrail comment)
+
+**Files:**
+- Create: `internal/config/validate_sandbox_signing_test.go`
+- Modify: `internal/config/config.go` (before the `return nil` at line 2441)
+- Modify: `internal/server/server.go` (comment above line 143)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/config/validate_sandbox_signing_test.go`:
+
+```go
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #376: validateConfig (run by config.Load and `agentsh config validate`)
+// must enforce the config-schema cross-field invariants the server also checks
+// at startup, with the same messages, so misconfig is caught pre-deploy.
+
+func TestValidateConfig_RejectsPtraceUnixSocketsNonExecveOnly(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	enabled := true
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.Seccomp.Execve.Enabled = false // isolate the unix_sockets path (else mutual-exclusion fires first)
+	cfg.Sandbox.Ptrace = DefaultPtraceConfig()  // valid sub-fields; Trace.* all true => NOT execve-only
+	cfg.Sandbox.Ptrace.Enabled = true
+
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("ptrace + unix_sockets with non-execve-only tracing must fail validation")
+	}
+	if !strings.Contains(err.Error(), "sandbox config:") || !strings.Contains(err.Error(), "requires execve-only tracing") {
+		t.Errorf("error should match the startup message; got: %v", err)
+	}
+}
+
+func TestValidateConfig_RejectsPtraceWithSeccompExecve(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.Sandbox.Ptrace = DefaultPtraceConfig()
+	cfg.Sandbox.Ptrace.Enabled = true
+	cfg.Sandbox.Seccomp.Execve.Enabled = true
+
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("ptrace + seccomp.execve must fail validation (mutually exclusive)")
+	}
+	if !strings.Contains(err.Error(), "sandbox config:") || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should match the startup message; got: %v", err)
+	}
+}
+
+func TestValidateConfig_RejectsSigningEnforceWithoutTrustStore(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.Policies.Signing.Mode = "enforce"
+	cfg.Policies.Signing.TrustStore = ""
+
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("signing mode=enforce without trust_store must fail validation")
+	}
+	if !strings.Contains(err.Error(), "signing config:") || !strings.Contains(err.Error(), "trust_store is required") {
+		t.Errorf("error should match the startup message; got: %v", err)
+	}
+}
+
+func TestValidateConfig_AcceptsDefaultBaseline(t *testing.T) {
+	// Regression guard: the newly-wired validators must NOT reject a normal
+	// default config. (Also confirms validateConfig still reaches its tail.)
+	cfg := &Config{}
+	applyDefaults(cfg)
+	if err := validateConfig(cfg); err != nil {
+		t.Fatalf("default config must validate cleanly; got: %v", err)
+	}
+}
+
+func TestValidateConfig_AcceptsExecveOnlyPtraceWithUnixSockets(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	enabled := true
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.Seccomp.Execve.Enabled = false
+	cfg.Sandbox.Ptrace = DefaultPtraceConfig()
+	cfg.Sandbox.Ptrace.Enabled = true
+	cfg.Sandbox.Ptrace.Trace.File = false
+	cfg.Sandbox.Ptrace.Trace.Network = false
+	cfg.Sandbox.Ptrace.Trace.Signal = false // now execve-only
+
+	if err := validateConfig(cfg); err != nil {
+		t.Fatalf("execve-only ptrace + unix_sockets must validate cleanly; got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/config/ -run 'TestValidateConfig_Rejects(PtraceUnixSocketsNonExecveOnly|PtraceWithSeccompExecve|SigningEnforceWithoutTrustStore)' -v`
+Expected: all three **reject** tests FAIL (`validateConfig` returns nil today, so each hits its `t.Fatal("…must fail validation")`). The two `Accepts*` tests already PASS.
+
+- [ ] **Step 3: Wire the validators into `validateConfig`**
+
+In `internal/config/config.go`, immediately before the final `return nil` of `validateConfig` (line 2441), insert:
+
+```go
+	// Config-schema cross-field invariants that the server also enforces at
+	// startup. Validated here so `agentsh config validate` (and the shim's
+	// auto-start path) catch them before deploy rather than surfacing as a
+	// generic "server unreachable" at runtime (issue #376). Host/environment
+	// checks (capabilities, etc.) intentionally stay at server startup.
+	if err := cfg.Sandbox.Validate(); err != nil {
+		return fmt.Errorf("sandbox config: %w", err)
+	}
+	if err := cfg.Policies.Signing.Validate(); err != nil {
+		return fmt.Errorf("signing config: %w", err)
+	}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/config/ -run TestValidateConfig_ -v`
+Expected: all five tests PASS (three reject, two accept).
+
+- [ ] **Step 5: Add the guardrail comment in `server.go`**
+
+In `internal/server/server.go`, directly above the `if err := cfg.Sandbox.Validate(); err != nil {` line (currently line 143), insert:
+
+```go
+	// These config-schema invariants are also enforced by config.validateConfig
+	// (run by config.Load), so `agentsh config validate` catches them pre-deploy
+	// (issue #376). The calls here are defense-in-depth for any server built from
+	// a config that did not pass through config.Load. New config-schema invariants
+	// belong in config.validateConfig, not here.
+```
+
+- [ ] **Step 6: Build and commit**
+
+Run: `go build ./... && go test ./internal/config/ ./internal/server/`
+Expected: build OK; both packages pass.
+
+```bash
+git add internal/config/config.go internal/config/validate_sandbox_signing_test.go internal/server/server.go
+git commit -m "fix(#376): enforce sandbox+signing schema invariants in config validate"
+```
+
+---
+
+## Task 2: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build + Windows cross-compile**
+
+Run: `go build ./... && GOOS=windows go build ./...`
+Expected: both succeed (no output).
+
+- [ ] **Step 2: Vet + gofmt**
+
+Run: `go vet ./internal/config/ ./internal/server/ && gofmt -l internal/config/config.go internal/config/validate_sandbox_signing_test.go internal/server/server.go`
+Expected: vet clean; `gofmt -l` prints nothing.
+
+- [ ] **Step 3: Affected package tests**
+
+Run: `go test ./internal/config/ ./internal/server/`
+Expected: ok for both (no existing fixture relied on loading an invalid config successfully).
+
+- [ ] **Step 4: Commit any formatting fixes (only if Step 2 changed files)**
+
+```bash
+git add -A && git commit -m "chore(#376): gofmt" || echo "nothing to commit"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** validator wiring (Task 1 Step 3) covers Sandbox + Signing; message parity via verbatim prefixes; guardrail comment (Task 1 Step 5); env checks untouched (no task touches `capabilities.CheckAll`); tests for both reject and accept paths (Task 1 Step 1), including the default-baseline regression guard. Non-goals respected (no env checks moved, no startup calls removed, no other startup checks relocated).
+- **Type consistency:** `validateConfig`, `applyDefaults`, `DefaultPtraceConfig`, `SandboxConfig.Validate`, `SigningConfig.Validate`, field paths `cfg.Sandbox.Ptrace.Trace.{Execve,File,Network,Signal}`, `cfg.Sandbox.UnixSockets.Enabled (*bool)`, `cfg.Sandbox.Seccomp.Execve.Enabled`, `cfg.Policies.Signing.{Mode,TrustStore}` all match the verified facts.
+- **No placeholders:** every code/command step is concrete with expected output.

--- a/docs/superpowers/specs/2026-05-24-issue-376-config-validate-schema-parity-design.md
+++ b/docs/superpowers/specs/2026-05-24-issue-376-config-validate-schema-parity-design.md
@@ -1,0 +1,95 @@
+# config validate / startup schema-validation parity Design
+
+Issue: #376
+
+## Summary
+
+`agentsh config validate` reports `ok` for configs the server then rejects at startup, so misconfiguration surfaces at runtime as a generic "connection refused" (via the shim) instead of a clear validation error pre-deploy. The reported case is the `sandbox.ptrace` + `unix_sockets` "execve-only" constraint, which is enforced only at server startup (`cfg.Sandbox.Validate()`), not in the `config.Load` path that `config validate` uses.
+
+This design makes `config.Load`'s `validateConfig` the single authority for **config-schema** validation by adding the two pure config-schema cross-field validators currently enforced only at startup — `cfg.Sandbox.Validate()` and `cfg.Policies.Signing.Validate()` — with error messages identical to the startup messages. Host/environment checks (capabilities, etc.) intentionally stay at startup.
+
+## Goals
+
+- `config validate` (and `config.Load`, hence the server and shim auto-start) rejects the `sandbox.ptrace` + `unix_sockets` non-execve-only config with the same message the server prints today.
+- Close the identical latent gap for `cfg.Policies.Signing.Validate()` in the same change (same bug class).
+- Establish and document the dividing principle: config-file invariants validate in `validateConfig`; host/environment checks stay at startup.
+- Add regression tests so the gap cannot silently reopen.
+
+## Non-Goals
+
+- Do not move host/environment checks (`capabilities.CheckAll`, duration parsing, etc.) into `config validate` — they validate the machine, not the file, and would cause false failures when validating a config destined for another host.
+- Do not relocate the other config-only startup checks (approvals-requires-auth, pkgcheck/skillcheck provider/dir requirements) — larger, entangled with `server.New`, and unreported. Possible follow-up.
+- Do not remove the startup validation calls; keep them as defense-in-depth.
+
+## Background
+
+- `config validate` → `loadLocalConfig` → `config.LoadWithSource` → `config.Load` → `validateConfig(cfg)` (`internal/config/config.go`, ~L2365-2441). `validateConfig` checks many enums/bounds (package_checks, landlock self-lockout, watchtower, blocked_socket_families, …) but does **not** call `cfg.Sandbox.Validate()` or `cfg.Policies.Signing.Validate()`.
+- `cfg.Sandbox.Validate()` (`config.go:368`) enforces: `ptrace` + `seccomp.execve` mutual exclusion; `ptrace` + `unix_sockets` requires execve-only tracing; and delegates to `Ptrace.Validate()`.
+- These two validators are called only at `internal/server/server.go:143` (`sandbox config: %w`) and `:147` (`signing config: %w`).
+- The server always obtains its config via `config.Load` (single production `server.New` call site, fed by `loadLocalConfig`), so anything added to `validateConfig` runs before the server sees the config.
+
+## Design
+
+### 1. Add the two validators to `validateConfig`
+
+At the end of `validateConfig` (before its final `return nil`), add:
+
+```go
+// Config-schema cross-field invariants that the server also enforces at
+// startup. Validated here so `agentsh config validate` (and the shim's
+// auto-start path) catch them before deploy rather than surfacing as a
+// generic "server unreachable" at runtime (issue #376). Host/environment
+// checks (capabilities, etc.) intentionally stay at server startup.
+if err := cfg.Sandbox.Validate(); err != nil {
+    return fmt.Errorf("sandbox config: %w", err)
+}
+if err := cfg.Policies.Signing.Validate(); err != nil {
+    return fmt.Errorf("signing config: %w", err)
+}
+```
+
+The `sandbox config:` / `signing config:` prefixes match `server.go:144,148` verbatim, so the messages from `config validate` and startup are identical.
+
+### 2. Guardrail comment at `server.go`
+
+Above the `cfg.Sandbox.Validate()` / `cfg.Policies.Signing.Validate()` calls (`server.go:143-149`), add a comment:
+
+```go
+// These config-schema invariants are also enforced by config.validateConfig
+// (so `agentsh config validate` catches them pre-deploy, issue #376). The
+// calls here are defense-in-depth for any server built from a config that did
+// not pass through config.Load. New config-schema invariants belong in
+// config.validateConfig, not here.
+```
+
+The calls stay (defense-in-depth; no behavior removed). For a config that came through `Load`, they re-run and pass.
+
+### 3. Environment checks unchanged
+
+`capabilities.CheckAll(cfg)` and the other startup-only operational/duration checks remain at `server.New`.
+
+## Error handling
+
+No new error types. The two added checks return the existing validator errors wrapped with the existing prefixes. A config that previously passed `config validate` but is invalid will now fail at `validateConfig` time (the intended fix); failure modes and messages are unchanged from startup.
+
+## Testing
+
+In `internal/config` (model on existing validation tests; use `validateConfig` or `Load` against in-memory/temp configs):
+
+1. **ptrace + unix_sockets non-execve-only → rejected:** `sandbox.ptrace.enabled=true`, `unix_sockets.enabled=true`, `ptrace.trace.execve=true` with `file/network/signal=true` → error contains `sandbox config:` and `requires execve-only tracing`.
+2. **ptrace + seccomp.execve → rejected:** both enabled → error contains `sandbox config:` and `mutually exclusive`.
+3. **signing mode enforce without trust store → rejected:** error contains `signing config:`.
+4. **valid baseline config → accepted:** a representative valid config (e.g. defaults, or execve-only ptrace + unix_sockets) passes `validateConfig`/`Load`.
+
+Confirm the existing `internal/config` and `internal/server` suites still pass (no fixture relied on loading an invalid config successfully).
+
+## Affected files
+
+- `internal/config/config.go` — two validator calls appended to `validateConfig`.
+- `internal/config/validate_sandbox_signing_test.go` (new) — regression tests, following the existing `TestValidateConfig_*` convention (e.g. `pkgcheck_test.go`).
+- `internal/server/server.go` — guardrail comment above the existing startup validation calls.
+
+## Out of scope (possible follow-up)
+
+- Moving approvals-requires-auth, pkgcheck/skillcheck provider+dir requirements, and duration parsing into `validateConfig` for full startup-invariant parity.
+- The orphaned `ResolverConfig.Validate()` (defined, never called).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2438,5 +2438,16 @@ func validateConfig(cfg *Config) error {
 			"blocked_socket_families", loaded.BlockedSocketFamilies,
 			"syscalls", loaded.Syscalls)
 	}
+	// Config-schema cross-field invariants that the server also enforces at
+	// startup. Validated here so `agentsh config validate` (and the shim's
+	// auto-start path) catch them before deploy rather than surfacing as a
+	// generic "server unreachable" at runtime (issue #376). Host/environment
+	// checks (capabilities, etc.) intentionally stay at server startup.
+	if err := cfg.Sandbox.Validate(); err != nil {
+		return fmt.Errorf("sandbox config: %w", err)
+	}
+	if err := cfg.Policies.Signing.Validate(); err != nil {
+		return fmt.Errorf("signing config: %w", err)
+	}
 	return nil
 }

--- a/internal/config/validate_sandbox_signing_test.go
+++ b/internal/config/validate_sandbox_signing_test.go
@@ -1,0 +1,101 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #376: validateConfig (run by config.Load and `agentsh config validate`)
+// must enforce the config-schema cross-field invariants the server also checks
+// at startup, with the same messages, so misconfig is caught pre-deploy.
+
+func TestValidateConfig_RejectsPtraceUnixSocketsNonExecveOnly(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	enabled := true
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.Seccomp.Execve.Enabled = false // isolate the unix_sockets path (else ptrace+seccomp.execve mutual-exclusion fires first)
+	cfg.Sandbox.Ptrace = DefaultPtraceConfig() // valid sub-fields; Trace.* all true => NOT execve-only
+	cfg.Sandbox.Ptrace.Enabled = true
+
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("ptrace + unix_sockets with non-execve-only tracing must fail validation")
+	}
+	if !strings.Contains(err.Error(), "sandbox config:") || !strings.Contains(err.Error(), "requires execve-only tracing") {
+		t.Errorf("error should match the startup message; got: %v", err)
+	}
+}
+
+func TestValidateConfig_RejectsPtraceWithSeccompExecve(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.Sandbox.Ptrace = DefaultPtraceConfig()
+	cfg.Sandbox.Ptrace.Enabled = true
+	cfg.Sandbox.Seccomp.Execve.Enabled = true
+
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("ptrace + seccomp.execve must fail validation (mutually exclusive)")
+	}
+	if !strings.Contains(err.Error(), "sandbox config:") || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("error should match the startup message; got: %v", err)
+	}
+}
+
+func TestValidateConfig_RejectsSigningEnforceWithoutTrustStore(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.Policies.Signing.Mode = "enforce"
+	cfg.Policies.Signing.TrustStore = ""
+
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("signing mode=enforce without trust_store must fail validation")
+	}
+	if !strings.Contains(err.Error(), "signing config:") || !strings.Contains(err.Error(), "trust_store is required") {
+		t.Errorf("error should match the startup message; got: %v", err)
+	}
+}
+
+func TestValidateConfig_RejectsSigningWarnWithoutTrustStore(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	cfg.Policies.Signing.Mode = "warn"
+	cfg.Policies.Signing.TrustStore = ""
+
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("signing mode=warn without trust_store must fail validation")
+	}
+	if !strings.Contains(err.Error(), "signing config:") || !strings.Contains(err.Error(), "trust_store is required") {
+		t.Errorf("error should match the startup message; got: %v", err)
+	}
+}
+
+func TestValidateConfig_AcceptsDefaultBaseline(t *testing.T) {
+	// Regression guard: the newly-wired validators must NOT reject a normal
+	// default config (also confirms validateConfig still reaches its tail).
+	cfg := &Config{}
+	applyDefaults(cfg)
+	if err := validateConfig(cfg); err != nil {
+		t.Fatalf("default config must validate cleanly; got: %v", err)
+	}
+}
+
+func TestValidateConfig_AcceptsExecveOnlyPtraceWithUnixSockets(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	enabled := true
+	cfg.Sandbox.UnixSockets.Enabled = &enabled
+	cfg.Sandbox.Seccomp.Execve.Enabled = false
+	cfg.Sandbox.Ptrace = DefaultPtraceConfig()
+	cfg.Sandbox.Ptrace.Enabled = true
+	cfg.Sandbox.Ptrace.Trace.File = false
+	cfg.Sandbox.Ptrace.Trace.Network = false
+	cfg.Sandbox.Ptrace.Trace.Signal = false // now execve-only
+
+	if err := validateConfig(cfg); err != nil {
+		t.Fatalf("execve-only ptrace + unix_sockets must validate cleanly; got: %v", err)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -140,6 +140,11 @@ func New(cfg *config.Config) (*Server, error) {
 		}
 	}
 
+	// These config-schema invariants are also enforced by config.validateConfig
+	// (run by config.Load), so `agentsh config validate` catches them pre-deploy
+	// (issue #376). The calls here are defense-in-depth for any server built from
+	// a config that did not pass through config.Load. New config-schema invariants
+	// belong in config.validateConfig, not here.
 	if err := cfg.Sandbox.Validate(); err != nil {
 		return nil, fmt.Errorf("sandbox config: %w", err)
 	}


### PR DESCRIPTION
## Summary

Fixes #376. `agentsh config validate` reported `ok` for configs the server then rejects at startup, so misconfiguration surfaced at runtime as a generic "connection refused" (via the shim) instead of a clear pre-deploy validation error. The reported case is the `sandbox.ptrace` + `unix_sockets` "execve-only" constraint.

Root cause: two config-schema cross-field validators were called only at `server.New` (`internal/server/server.go`), not in the `config.Load` path that `config validate` uses.

## Changes

- `internal/config/config.go`: wire `cfg.Sandbox.Validate()` and `cfg.Policies.Signing.Validate()` into `validateConfig` (run by `config.Load` → `config validate`, server, and shim auto-start), with `sandbox config:` / `signing config:` prefixes copied verbatim from `server.go` so the messages are identical to startup.
- `internal/server/server.go`: guardrail comment above the existing startup calls — they stay as defense-in-depth for any server built from a non-`Load` config; new config-schema invariants belong in `validateConfig`.
- `internal/config/validate_sandbox_signing_test.go` (new): 6 tests — reject (ptrace+unix_sockets non-execve-only, ptrace+seccomp.execve, signing `enforce`/`warn` without trust store) and accept (default baseline, execve-only ptrace+unix_sockets).

Scope is deliberately the pure config-schema invariants. Host/environment checks (`capabilities.CheckAll`, etc.) stay at startup — `config validate` must validate the file, not the machine it happens to run on.

## Safety

The two validators short-circuit on default/disabled states (`Ptrace.Validate()` returns nil when ptrace disabled; `Signing.Validate()` accepts `""`/`off`), so no previously-valid config is newly rejected — only configs the server already rejects now fail earlier, with the same message.

## Test Plan

- [x] `go test ./internal/config/ ./internal/server/`
- [x] `go build ./...` and `GOOS=windows go build ./...`
- [x] `go vet` clean; new test file gofmt-clean

Spec & plan: `docs/superpowers/specs/2026-05-24-issue-376-config-validate-schema-parity-design.md`, `docs/superpowers/plans/2026-05-24-issue-376-config-validate-schema-parity.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
