### PR TITLE
fix(#377): allow command -v/-V introspection in shell-c pre-check

### DIFF
--- a/docs/superpowers/plans/2026-05-24-issue-377-command-v-introspection.md
+++ b/docs/superpowers/plans/2026-05-24-issue-377-command-v-introspection.md
@@ -1,0 +1,216 @@
+# Allow `command -v` / `command -V` introspection — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the shell-c pre-check from denying `bash -c 'command -v NAME'` / `command -V NAME` as `shellc-wrapper-bypass`, by treating those introspection forms as benign builtins.
+
+**Architecture:** In `internal/shellparse/stripWrappers`, special-case `command -v`/`-V` to stop wrapper-stripping and leave `command` as the head token; `parseSimpleShellC`'s existing `isShellBuiltin("command")` check then returns `statusFallback`, so the engine applies the operator's allow-shell rule. `command -p` (executes) and `command NAME` (no flag, derives to NAME) are unchanged.
+
+**Tech Stack:** Go; `internal/shellparse`, `internal/policy`.
+
+**Spec:** `docs/superpowers/specs/2026-05-24-issue-377-command-v-introspection-design.md`
+
+**Verified facts (don't re-derive):**
+- `stripWrappers` is at `internal/shellparse/shellparse.go:819`. Its catch-all bypass `return nil, true` is the line to guard before. Current body:
+  ```go
+  func stripWrappers(tokens []string) ([]string, bool) {
+  	for len(tokens) >= 2 && isTransparentWrapper(tokens[0]) {
+  		wrapper := tokens[0]
+  		next := tokens[1]
+  		if !strings.HasPrefix(next, "-") {
+  			tokens = tokens[1:]
+  			continue
+  		}
+  		// nice -n INCREMENT CMD … : the one flag form we parse.
+  		if wrapper == "nice" && next == "-n" && len(tokens) >= 3 && isNumericIncrement(tokens[2]) {
+  			tokens = tokens[3:]
+  			continue
+  		}
+  		return nil, true
+  	}
+  	return tokens, false
+  }
+  ```
+- `isShellBuiltin("command")` returns `true` (confirmed). `parseSimpleShellC` calls `if isShellBuiltin(tokens[0]) { return "", nil, statusFallback }` after `stripWrappers`.
+- Public API: `IsShellCBypassAttempt(command string, args []string) bool` and `DerivePolicyTarget(command string, args []string) (string, []string, bool)` (both in package `shellparse`).
+- `internal/policy` tests are `package policy`; build a `&Policy{CommandRules: []CommandRule{...}}`, call `NewEngine(p, false, true)`, then `e.CheckCommand(cmd, args)` returning a `Decision` with `.PolicyDecision` (compare to `types.DecisionAllow`/`types.DecisionDeny`) and `.Rule`. Model: `internal/policy/command_shellc_test.go`.
+
+---
+
+## File Structure
+
+- `internal/shellparse/shellparse.go` — add the `command -v`/`-V` guard in `stripWrappers` (the only behavioral change).
+- `internal/shellparse/command_v_test.go` (new) — shellparse-level regression tests (bypass classification + derive behavior).
+- `internal/policy/command_v_introspection_test.go` (new) — engine-level test proving `command -v ls` is allowed and `command shutdown` still denies.
+
+---
+
+## Task 1: Allow `command -v`/`-V` introspection in `stripWrappers`
+
+**Files:**
+- Create: `internal/shellparse/command_v_test.go`
+- Create: `internal/policy/command_v_introspection_test.go`
+- Modify: `internal/shellparse/shellparse.go` (inside `stripWrappers`, before `return nil, true`)
+
+- [ ] **Step 1: Write the failing shellparse tests**
+
+Create `internal/shellparse/command_v_test.go`:
+
+```go
+package shellparse
+
+import "testing"
+
+// Issue #377: `command -v`/`-V NAME` is read-only introspection (prints whether
+// NAME exists / its type; never executes NAME). It must not be classified as a
+// wrapper-bypass. `command -p` (executes NAME) and `command NAME` (no flag,
+// forwards to NAME) keep their existing behavior.
+
+func TestIsShellCBypassAttempt_CommandIntrospection(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"command -v is introspection, not bypass", []string{"-c", "command -v ls"}, false},
+		{"command -V is introspection, not bypass", []string{"-c", "command -V ls"}, false},
+		{"command -p executes, still bypass", []string{"-c", "command -p ls"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsShellCBypassAttempt("/bin/sh", tc.args); got != tc.want {
+				t.Errorf("IsShellCBypassAttempt(sh, %v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDerivePolicyTarget_CommandForms(t *testing.T) {
+	// No-flag `command shutdown` still derives to the inner binary so command
+	// rules (e.g. deny shutdown) fire.
+	if cmd, _, ok := DerivePolicyTarget("/bin/sh", []string{"-c", "command shutdown"}); !ok || cmd != "shutdown" {
+		t.Errorf("DerivePolicyTarget(command shutdown) = (%q, ok=%v), want (\"shutdown\", true)", cmd, ok)
+	}
+	// `command -v ls` is introspection: nothing to derive (falls back to the
+	// outer shell rule), so ok must be false (and it must NOT be a bypass).
+	if _, _, ok := DerivePolicyTarget("/bin/sh", []string{"-c", "command -v ls"}); ok {
+		t.Error("DerivePolicyTarget(command -v ls) ok=true, want false (introspection)")
+	}
+}
+```
+
+- [ ] **Step 2: Write the failing engine test**
+
+Create `internal/policy/command_v_introspection_test.go`:
+
+```go
+package policy
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// Issue #377: `command -v NAME` must be allowed (it's introspection), not
+// denied as shellc-wrapper-bypass, while `command shutdown` (no flag) still
+// derives to shutdown so a deny rule fires.
+func TestCheckCommand_CommandVAllowed(t *testing.T) {
+	p := &Policy{
+		CommandRules: []CommandRule{
+			{Name: "deny-shutdown", Commands: []string{"shutdown"}, Decision: "deny"},
+			{Name: "allow-shells", Commands: []string{"sh", "bash", "dash", "zsh"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "command -v ls"})
+	if dec.Rule == "shellc-wrapper-bypass" {
+		t.Errorf("command -v ls denied as wrapper-bypass; want allow")
+	}
+	if dec.PolicyDecision != types.DecisionAllow {
+		t.Errorf("command -v ls decision = %s (rule=%q), want allow", dec.PolicyDecision, dec.Rule)
+	}
+
+	denied := e.CheckCommand("/bin/sh", []string{"-c", "command shutdown"})
+	if denied.PolicyDecision != types.DecisionDeny || denied.Rule != "deny-shutdown" {
+		t.Errorf("command shutdown = %s rule=%q, want deny deny-shutdown", denied.PolicyDecision, denied.Rule)
+	}
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `go test ./internal/shellparse/ -run 'TestIsShellCBypassAttempt_CommandIntrospection|TestDerivePolicyTarget_CommandForms' -v && go test ./internal/policy/ -run TestCheckCommand_CommandVAllowed -v`
+Expected: FAIL — the `command -v`/`-V` cases currently classify as bypass (`IsShellCBypassAttempt` returns true; `DerivePolicyTarget(command -v ls)` ok=false is actually already true today, but the engine test's first assertion fails because `command -v ls` is denied as `shellc-wrapper-bypass`). Specifically: `TestIsShellCBypassAttempt_CommandIntrospection` fails on the `-v`/`-V` rows, and `TestCheckCommand_CommandVAllowed` fails with `dec.Rule == "shellc-wrapper-bypass"`.
+
+- [ ] **Step 4: Add the guard in `stripWrappers`**
+
+In `internal/shellparse/shellparse.go`, inside `stripWrappers`, immediately before the catch-all `return nil, true`, insert:
+
+```go
+		// `command -v`/`-V NAME` is introspection: it prints whether NAME
+		// exists / its type and does NOT execute it. Stop stripping so the
+		// builtin classifier (isShellBuiltin("command")) hands this back to the
+		// outer shell rule rather than flagging a wrapper-bypass. `command -p`
+		// (which executes NAME under a default PATH) is intentionally excluded.
+		// Issue #377.
+		if wrapper == "command" && (next == "-v" || next == "-V") {
+			return tokens, false
+		}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `go test ./internal/shellparse/ -run 'TestIsShellCBypassAttempt_CommandIntrospection|TestDerivePolicyTarget_CommandForms' -v && go test ./internal/policy/ -run TestCheckCommand_CommandVAllowed -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the full packages (no regressions)**
+
+Run: `go test ./internal/shellparse/ ./internal/policy/`
+Expected: ok for both (existing shellparse/policy suites still pass).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/shellparse/shellparse.go internal/shellparse/command_v_test.go internal/policy/command_v_introspection_test.go
+git commit -m "fix(#377): allow command -v/-V introspection in shell-c pre-check"
+```
+
+---
+
+## Task 2: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build + Windows cross-compile**
+
+Run: `go build ./... && GOOS=windows go build ./...`
+Expected: both succeed (no output).
+
+- [ ] **Step 2: Vet + gofmt**
+
+Run: `go vet ./internal/shellparse/ ./internal/policy/ && gofmt -l internal/shellparse/shellparse.go internal/shellparse/command_v_test.go internal/policy/command_v_introspection_test.go`
+Expected: vet clean; `gofmt -l` prints nothing.
+
+- [ ] **Step 3: Affected package tests**
+
+Run: `go test ./internal/shellparse/ ./internal/policy/`
+Expected: ok for both.
+
+- [ ] **Step 4: Commit any formatting fixes (only if Step 2 changed files)**
+
+```bash
+git add -A && git commit -m "chore(#377): gofmt" || echo "nothing to commit"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** the `stripWrappers` guard (Task 1 Step 4) implements the only behavioral change; `-v`/`-V` allowed and `-p`/no-flag preserved are all covered by tests (Task 1 Steps 1-2). Non-goals respected (no other wrapper touched; `-p` stays bypass).
+- **Type consistency:** `IsShellCBypassAttempt`, `DerivePolicyTarget`, `NewEngine(p, false, true)`, `Decision.PolicyDecision`, `Decision.Rule`, `types.DecisionAllow`/`DecisionDeny` all match the verified facts and `command_shellc_test.go`.
+- **No placeholders:** every code/command step is concrete with expected output.

--- a/docs/superpowers/specs/2026-05-24-issue-377-command-v-introspection-design.md
+++ b/docs/superpowers/specs/2026-05-24-issue-377-command-v-introspection-design.md
@@ -1,0 +1,79 @@
+# Allow `command -v` / `command -V` introspection in shell-c pre-check Design
+
+Issue: #377 (part 1 of 2)
+
+## Summary
+
+On the shell-shim path, `bash -c 'command -v ls'` is denied as `shellc-wrapper-bypass` (exit 126). `command -v NAME` / `command -V NAME` are common, read-only ways to check whether a binary exists or print its type; they do **not** execute NAME. Denying them breaks ordinary setup/probe scripts. This design makes the shell-c parser treat `command -v`/`-V` as benign builtin introspection so it falls through to the operator's `allow sh`/`bash` rule instead of being flagged as a wrapper-bypass.
+
+This is part 1 of #377. Part 2 (`symlink_escape: deny` blocking commands on a symlinked cwd) is a separate, independent fix tracked under #377 and handled in its own spec/PR.
+
+## Goals
+
+- `bash -c 'command -v NAME'` and `bash -c 'command -V NAME'` are no longer denied as `shellc-wrapper-bypass`; they run under the operator's allow-shell rule.
+- Keep `command -p NAME …` (which executes NAME under a default PATH) classified as a bypass — conservative, unchanged.
+- Keep `command NAME …` (no flag, which executes NAME) deriving to NAME so command rules (e.g. `deny shutdown`) still fire.
+- Regression tests so the introspection allowance and the conservative `-p`/no-flag behavior cannot silently regress.
+
+## Non-Goals
+
+- Do not change handling of other wrappers (`exec`, `nohup`, `nice`, `time`, `env`).
+- Do not allow `command -p` (it executes a command and alters PATH resolution).
+- Do not touch part 2 of #377 (symlink cwd).
+
+## Background
+
+`internal/shellparse/parseSimpleShellC` classifies a `<shell> -c "<script>"` invocation as `statusOK` (derivable target), `statusBypass`, `statusOpaque`, or `statusFallback` (hand back to the outer shell rule). The policy engine denies `statusBypass` as `shellc-wrapper-bypass` (`internal/policy/engine.go:622-633`).
+
+For `command -v ls`: the script tokenizes to `["command","-v","ls"]` (no opaque bytes), then `stripWrappers` sees the transparent wrapper `command` followed by a flag (`-v`) and returns bypass (`shellparse.go` `stripWrappers`, the catch-all `return nil, true`). Hence `statusBypass` → deny.
+
+Key facts:
+- `command` is in both the transparent-wrapper set (`isTransparentWrapper`) — because `command NAME args` forwards-executes NAME — and the shell-builtin set (`isShellBuiltin`).
+- `parseSimpleShellC` already returns `statusFallback` for a leading shell builtin: `if isShellBuiltin(tokens[0]) { return "", nil, statusFallback }` (after `stripWrappers`).
+- `command -v NAME` / `command -V NAME` is pure introspection: it performs a name lookup and prints the result; it never executes NAME. So allowing it leaks nothing even for `command -v shutdown` — nothing runs.
+
+## Design
+
+In `internal/shellparse/shellparse.go`, in `stripWrappers`, add a guard immediately before the catch-all `return nil, true`:
+
+```go
+// `command -v`/`-V NAME` is introspection: it prints whether NAME exists /
+// its type and does NOT execute it. Stop stripping so the builtin classifier
+// (isShellBuiltin("command")) hands this back to the outer shell rule rather
+// than flagging a wrapper-bypass. `command -p` (which executes NAME under a
+// default PATH) is intentionally NOT included. Issue #377.
+if wrapper == "command" && (next == "-v" || next == "-V") {
+    return tokens, false
+}
+```
+
+Returning `(tokens, false)` leaves `command` as `tokens[0]`. Back in `parseSimpleShellC`, the existing `isShellBuiltin(tokens[0])` check matches (`command` is a builtin) and returns `statusFallback`. The engine then finds `DerivePolicyTarget` ok=false, `IsShellCBypassAttempt` false, and `IsOpaqueShellC` false, so it applies the operator's allow-shell rule → the command runs.
+
+### Why not other approaches
+
+- **Drop `command` from the transparent-wrapper set:** unsafe — `command shutdown` would then no longer derive to `shutdown`, so a `deny shutdown` rule wouldn't fire (a real bypass).
+- **Detect the introspection form up in `parseSimpleShellC`:** more code for the same effect; the fix belongs in `stripWrappers`, where the bypass currently originates.
+
+## Error handling
+
+No new errors. The change only reclassifies `command -v`/`-V` from `statusBypass` to `statusFallback`; all other inputs are unchanged.
+
+## Testing
+
+`internal/shellparse` (model on existing `shellparse_test.go`):
+- `IsShellCBypassAttempt("/bin/sh", []string{"-c", "command -v ls"})` → false.
+- `IsShellCBypassAttempt("/bin/sh", []string{"-c", "command -V ls"})` → false.
+- `IsShellCBypassAttempt("/bin/sh", []string{"-c", "command -p ls"})` → true (still bypass).
+- `DerivePolicyTarget("/bin/sh", []string{"-c", "command shutdown"})` → derives to `shutdown` (no-flag forwarding preserved).
+
+`internal/policy` (model on `command_shellc_test.go`, which builds a policy with `deny-shutdown` + `allow sh`):
+- `CheckCommand("/bin/sh", []string{"-c", "command -v ls"})` → allow (rule is the allow-shell rule, NOT `shellc-wrapper-bypass`).
+- `CheckCommand("/bin/sh", []string{"-c", "command shutdown"})` → deny `deny-shutdown` (bypass-via-no-flag still caught).
+
+Confirm existing `internal/shellparse` and `internal/policy` suites stay green.
+
+## Affected files
+
+- `internal/shellparse/shellparse.go` — the `stripWrappers` guard (~5 lines).
+- `internal/shellparse/command_v_test.go` (new) — shellparse-level regression tests.
+- `internal/policy/command_v_introspection_test.go` (new) — engine-level allow assertion (modeled on `command_shellc_test.go`).

--- a/internal/policy/command_shellc_test.go
+++ b/internal/policy/command_shellc_test.go
@@ -525,7 +525,7 @@ func TestEngine_CheckCommand_ShellCDerive_BypassFailsClosed(t *testing.T) {
 		args    []string
 	}{
 		{"exec -a custom argv0", "/bin/sh", []string{"-c", "exec -a foo shutdown"}},
-		{"command -v (probe form)", "/bin/sh", []string{"-c", "command -v shutdown"}},
+		// command -v/-V is introspection (issue #377): removed from bypass table.
 		{"nohup --help", "/bin/sh", []string{"-c", "nohup --help shutdown"}},
 		{"nohup -x", "/bin/sh", []string{"-c", "nohup -x shutdown"}},
 		{"nice -n bogus (non-numeric)", "/bin/sh", []string{"-c", "nice -n bogus shutdown"}},
@@ -548,7 +548,7 @@ func TestEngine_CheckCommand_ShellCDerive_BypassFailsClosed(t *testing.T) {
 		// the assignment but the inner form is still unparsable).
 		{"assign + exec -a", "/bin/sh", []string{"-c", "VAR=x exec -a foo shutdown"}},
 		{"assign + nohup --preserve-status", "/bin/sh", []string{"-c", "PATH=/tmp nohup --preserve-status=1 shutdown"}},
-		{"assign + command -v", "/bin/sh", []string{"-c", "FOO=1 command -v shutdown"}},
+		// assign + command -v is introspection (issue #377): removed from bypass table.
 		// Env-assignment with a dirty VALUE (byte outside the narrow
 		// allowlist). The shell accepts these, but we can't safely
 		// parse-through, so fail closed.

--- a/internal/policy/command_v_introspection_test.go
+++ b/internal/policy/command_v_introspection_test.go
@@ -1,0 +1,54 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// Issue #377: `command -v NAME` must be allowed (introspection), not denied as
+// shellc-wrapper-bypass, while `command shutdown` (no flag) still derives to
+// shutdown so a deny rule fires.
+func TestCheckCommand_CommandVAllowed(t *testing.T) {
+	p := &Policy{
+		CommandRules: []CommandRule{
+			{Name: "deny-shutdown", Commands: []string{"shutdown"}, Decision: "deny"},
+			{Name: "allow-shells", Commands: []string{"sh", "bash", "dash", "zsh"}, Decision: "allow"},
+		},
+	}
+	e, err := NewEngine(p, false, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+
+	dec := e.CheckCommand("/bin/sh", []string{"-c", "command -v ls"})
+	if dec.Rule == "shellc-wrapper-bypass" {
+		t.Errorf("command -v ls denied as wrapper-bypass; want allow")
+	}
+	if dec.PolicyDecision != types.DecisionAllow {
+		t.Errorf("command -v ls decision = %s (rule=%q), want allow", dec.PolicyDecision, dec.Rule)
+	}
+
+	decAssign := e.CheckCommand("/bin/sh", []string{"-c", "FOO=1 command -v ls"})
+	if decAssign.PolicyDecision != types.DecisionAllow {
+		t.Errorf("FOO=1 command -v ls decision = %s (rule=%q), want allow", decAssign.PolicyDecision, decAssign.Rule)
+	}
+
+	// The reported scenario: introspection on a deny-listed binary must still
+	// be allowed — `command -v shutdown` checks existence, it does not run it.
+	decVShutdown := e.CheckCommand("/bin/sh", []string{"-c", "command -v shutdown"})
+	if decVShutdown.PolicyDecision != types.DecisionAllow {
+		t.Errorf("command -v shutdown decision = %s (rule=%q), want allow", decVShutdown.PolicyDecision, decVShutdown.Rule)
+	}
+
+	// `command -V` (uppercase, verbose type) is also introspection → allowed.
+	decBigV := e.CheckCommand("/bin/sh", []string{"-c", "command -V ls"})
+	if decBigV.PolicyDecision != types.DecisionAllow {
+		t.Errorf("command -V ls decision = %s (rule=%q), want allow", decBigV.PolicyDecision, decBigV.Rule)
+	}
+
+	denied := e.CheckCommand("/bin/sh", []string{"-c", "command shutdown"})
+	if denied.PolicyDecision != types.DecisionDeny || denied.Rule != "deny-shutdown" {
+		t.Errorf("command shutdown = %s rule=%q, want deny deny-shutdown", denied.PolicyDecision, denied.Rule)
+	}
+}

--- a/internal/shellparse/command_v_test.go
+++ b/internal/shellparse/command_v_test.go
@@ -1,0 +1,39 @@
+package shellparse
+
+import "testing"
+
+// Issue #377: `command -v`/`-V NAME` is read-only introspection (prints whether
+// NAME exists / its type; never executes NAME). It must not be classified as a
+// wrapper-bypass. `command -p` (executes NAME) and `command NAME` (no flag,
+// forwards to NAME) keep their existing behavior.
+
+func TestIsShellCBypassAttempt_CommandIntrospection(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"command -v is introspection, not bypass", []string{"-c", "command -v ls"}, false},
+		{"command -V is introspection, not bypass", []string{"-c", "command -V ls"}, false},
+		{"command -p executes, still bypass", []string{"-c", "command -p ls"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsShellCBypassAttempt("/bin/sh", tc.args); got != tc.want {
+				t.Errorf("IsShellCBypassAttempt(sh, %v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDerivePolicyTarget_CommandForms(t *testing.T) {
+	if cmd, _, ok := DerivePolicyTarget("/bin/sh", []string{"-c", "command shutdown"}); !ok || cmd != "shutdown" {
+		t.Errorf("DerivePolicyTarget(command shutdown) = (%q, ok=%v), want (\"shutdown\", true)", cmd, ok)
+	}
+	if _, _, ok := DerivePolicyTarget("/bin/sh", []string{"-c", "command -v ls"}); ok {
+		t.Error("DerivePolicyTarget(command -v ls) ok=true, want false (introspection)")
+	}
+	if _, _, ok := DerivePolicyTarget("/bin/sh", []string{"-c", "command -V ls"}); ok {
+		t.Error("DerivePolicyTarget(command -V ls) ok=true, want false (introspection)")
+	}
+}

--- a/internal/shellparse/shellparse.go
+++ b/internal/shellparse/shellparse.go
@@ -800,8 +800,10 @@ func isUnquotedAllowedByte(b byte) bool {
 //   - exec -a NAME CMD … : `-a` sets a custom argv0. We don't parse it
 //     (one could, but we'd need to validate NAME and the subsequent CMD
 //     shape), so any `-` after `exec` fails closed.
-//   - command -v / -V / -p : these print info or change the PATH; none
-//     are transparent forwarding.
+//   - command -p : executes NAME under a default PATH; bypass.
+//     command -v / -V : read-only introspection (prints whether NAME
+//     exists / its type). These are returned as-is (bypass=false) so the
+//     builtin classifier hands them to the outer shell rule (issue #377).
 //   - nohup -FLAG … : POSIX nohup has no options; GNU nohup only has
 //     --help / --version, neither of which runs a command. Any `-` is
 //     either a deliberate bypass or a no-op.
@@ -828,6 +830,15 @@ func stripWrappers(tokens []string) ([]string, bool) {
 		if wrapper == "nice" && next == "-n" && len(tokens) >= 3 && isNumericIncrement(tokens[2]) {
 			tokens = tokens[3:]
 			continue
+		}
+		// `command -v`/`-V NAME` is introspection: it prints whether NAME
+		// exists / its type and does NOT execute it. Stop stripping so the
+		// builtin classifier (isShellBuiltin("command")) hands this back to the
+		// outer shell rule rather than flagging a wrapper-bypass. `command -p`
+		// (which executes NAME under a default PATH) is intentionally excluded.
+		// Issue #377.
+		if wrapper == "command" && (next == "-v" || next == "-V") {
+			return tokens, false
 		}
 		return nil, true
 	}
@@ -995,10 +1006,12 @@ func hasShellCWithUnsafeOptions(shellArgs []string) bool {
 // `nohup` (a bare name with no rule) as the policy target and falling
 // through to the outer shell allow.
 //
-// Wrappers followed by any flag token (e.g. `exec -a`, `command -v`,
-// `nice -n 19`, `env -i`, `time -p`) are rejected by the caller — flag
-// parsing is wrapper-specific and out of scope; failing to derive at all
-// is the safe default.
+// Wrappers followed by any flag token are handled by the caller: most
+// are rejected (e.g. `exec -a`, `command -p`, `env -i`, `time -p`) as
+// bypass — flag parsing is wrapper-specific and out of scope; failing to
+// derive is the safe default. The exception is `command -v`/`-V`, which
+// is introspection (never executes NAME) and is returned as-is; see
+// stripWrappers (issue #377).
 func isTransparentWrapper(tok string) bool {
 	switch tok {
 	case "exec", "command", "nohup", "nice", "time", "env":

--- a/internal/shellparse/shellparse_test.go
+++ b/internal/shellparse/shellparse_test.go
@@ -308,7 +308,9 @@ func TestIsShellCBypassAttempt(t *testing.T) {
 	}{
 		// Bypass — flag forms we refuse to parse.
 		{"exec -a NAME CMD", "sh", []string{"-c", "exec -a foo shutdown"}, true},
-		{"command -v CMD", "sh", []string{"-c", "command -v shutdown"}, true},
+		// command -v/-V is introspection (issue #377): prints whether NAME exists,
+		// does NOT execute it → not a bypass.
+		{"command -v CMD (introspection)", "sh", []string{"-c", "command -v shutdown"}, false},
 		{"command -p CMD", "sh", []string{"-c", "command -p shutdown"}, true},
 		{"nohup --help CMD", "sh", []string{"-c", "nohup --help shutdown"}, true},
 		{"nohup -x CMD", "sh", []string{"-c", "nohup -x shutdown"}, true},
@@ -351,7 +353,9 @@ func TestIsShellCBypassAttempt(t *testing.T) {
 		// Bypass — env-assignment prefix followed by a wrapper in an
 		// UNPARSABLE flag form (inner bypass survives the parse-through).
 		{"assign + exec -a", "sh", []string{"-c", "VAR=x exec -a foo shutdown"}, true},
-		{"assign + command -v", "sh", []string{"-c", "FOO=1 command -v shutdown"}, true},
+		// command -v is introspection (issue #377): not a bypass even with an
+		// env-assignment prefix, because command -v still doesn't execute NAME.
+		{"assign + command -v (introspection)", "sh", []string{"-c", "FOO=1 command -v shutdown"}, false},
 		{"assign + nohup --preserve-status", "sh", []string{"-c", "PATH=/tmp nohup --preserve-status=1 shutdown"}, true},
 
 		// Bypass — env-assignment with a VALUE byte outside the narrow


### PR DESCRIPTION
## Summary

Fixes #377 (part 1 of 2). On the shell-shim path, `bash -c 'command -v ls'` was denied as `shellc-wrapper-bypass` (exit 126). `command -v NAME` / `command -V NAME` are read-only introspection — they print whether NAME exists / its type and **never execute** NAME — so denying them broke ordinary setup/probe scripts.

## Change

In `internal/shellparse/stripWrappers`, a single guard: when the transparent wrapper is `command` and the next token is `-v` or `-V`, return the tokens unchanged (not a bypass). `command` then stays the head token, `isShellBuiltin("command")` yields `statusFallback`, and the policy engine applies the operator's `allow sh`/`bash` rule.

Preserved, conservative behavior:
- `command -p NAME` (executes NAME under a default PATH) → still `shellc-wrapper-bypass`.
- `command NAME` (no flag) → still derives to NAME, so a `deny NAME` rule still fires.

Two now-inaccurate doc comments in `shellparse.go` were corrected, and two pre-existing tests that asserted the old "`command -v` is a bypass" behavior were flipped.

## Safety

`command -v`/`-V` performs only a name lookup and prints the result — it executes nothing — so allowing it leaks nothing, even for `command -v shutdown` (pinned by a test: introspection on a deny-listed binary is allowed; nothing runs). The guard uses exact token equality, so `command -vp` / `command -v=foo` still fall through to bypass.

## Test Plan

- [x] `go test ./internal/shellparse/ ./internal/policy/`
- [x] `go build ./...` and `GOOS=windows go build ./...`; `go vet` clean
- [x] New tests: `command -v`/`-V` allowed (incl. `command -v shutdown` with a `deny shutdown` rule), `command -p` still bypass, `command shutdown` still derives to `shutdown`, `FOO=1 command -v ls` allowed

Part 2 of #377 (`symlink_escape: deny` blocking commands on a symlinked cwd) is a separate, independent fix in its own PR.

Spec & plan: `docs/superpowers/specs/2026-05-24-issue-377-command-v-introspection-design.md`, `docs/superpowers/plans/2026-05-24-issue-377-command-v-introspection.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
