### PR TITLE
feat(#379): enforce env_policy (allow/deny) on the wrap path (opt-in)

### DIFF
--- a/docs/superpowers/plans/2026-05-24-issue-379-wrap-env-policy.md
+++ b/docs/superpowers/plans/2026-05-24-issue-379-wrap-env-policy.md
@@ -1,0 +1,542 @@
+# Enforce env_policy on the wrap path (#379) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enforce env `allow`/`deny`/`max_*` on the client-spawned wrap path (shell shim / kernel-install / `agentsh wrap`) by plumbing the resolved policy through `WrapInitResponse` and applying a subtractive `policy.BuildEnv` filter client-side — gated behind `sandbox.wrap_env_policy.enabled` (default off), fail-open.
+
+**Architecture:** Server resolves the env policy for the wrapped command and (only when the flag is on) sends it as a new `EnvPolicyWire` field on `WrapInitResponse`. A new `internal/wrapenv.Filter` helper maps the wire type to `policy.ResolvedEnvPolicy` and runs `policy.BuildEnv` over the **inherited** launcher env (subtractive), fail-open. Both client launch sites filter the inherited base *before* adding agentsh markers / `env_inject`, so those always survive.
+
+**Tech Stack:** Go; `pkg/types`, `internal/config`, `internal/policy`, `internal/wrapenv` (new), `internal/api`, `internal/cli`, `internal/shim/kernelinstall`.
+
+**Spec:** `docs/superpowers/specs/2026-05-24-issue-379-wrap-env-policy-design.md`
+
+**Verified facts (don't re-derive):**
+- `WrapInitResponse` is in `pkg/types/sessions.go`; it currently ends with `EnvInject map[string]string `json:"env_inject,omitempty"``. `pkg/types` must NOT import `internal/policy` (so the wire type is primitive).
+- `policy.ResolvedEnvPolicy{Allow []string; Deny []string; MaxBytes int; MaxKeys int; BlockIteration bool}` (`internal/policy/env_policy.go:13`). `policy.BuildEnv(pol ResolvedEnvPolicy, baseEnv []string, addKeys map[string]string) ([]string, error)` (env_policy.go:55): no allow patterns ⇒ keep all except `deny` + `defaultSecretDeny`; allow patterns ⇒ keep only allowed; then `max_bytes`/`max_keys`. `AWS_SECRET_ACCESS_KEY` is in `defaultSecretDeny`.
+- `internal/policy` already imports `pkg/types`, so `internal/wrapenv` importing both `pkg/types` and `internal/policy` creates no cycle.
+- `SandboxConfig` (`internal/config/config.go:~345`) holds sub-structs like `UnixSockets`, `Seccomp`, `Ptrace`. `internal/config` imports `gopkg.in/yaml.v3` as `yaml`. Config tests are `package config`.
+- The wrap handler `wrapInitCore` (`internal/api/wrap.go:124`) sets `EnvInject: mergeEnvInject(a.cfg, a.policyEngineFor(s))` at two response sites: ptrace (`wrap.go:283`) and seccomp (`wrap.go:519`, the final `return types.WrapInitResponse{`). `dec` at `wrap.go:164` is scoped to the `req.Mode == "shim"` block — NOT in scope at those sites; resolve via a helper instead.
+- `a.policyEngineFor(s)` returns `*policy.Engine` (or nil). `engine.CheckCommandWithExecve(cmd, args, a.execveEnforcementActive(), a.shellCOpaqueMode()).EnvPolicy` yields the resolved `policy.ResolvedEnvPolicy`. `App` (package `api`) has unexported fields `cfg *config.Config` and `policy *policy.Engine` (settable in-package tests); `policyEngineFor(nil)` falls back to `a.policy`.
+- `internal/cli/wrap_linux.go` imports `internal/envinject`, `pkg/types`. Both env builds are `env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)` — ptrace branch (~L33) and seccomp branch (~L138).
+- `internal/shim/kernelinstall/install_linux.go` imports `internal/envinject`, `pkg/types`. Site (L200): `env := assembleWrapperEnv(filterShimInternalEnv(p.Env), p.Argv0, resp.WrapperEnv, resp.EnvInject)`. `assembleWrapperEnv(base []string, argv0 string, wrapperEnv, envInject map[string]string) []string` (L388) is a pure function that overlays `envInject` then appends `AGENTSH_*` markers.
+
+---
+
+## File Structure
+
+- `pkg/types/sessions.go` — `EnvPolicyWire` type + `EnvPolicy *EnvPolicyWire` field on `WrapInitResponse`.
+- `internal/config/config.go` — `SandboxWrapEnvPolicyConfig{Enabled bool}` + `WrapEnvPolicy` field on `SandboxConfig`.
+- `internal/wrapenv/wrapenv.go` (new) + `wrapenv_test.go` — the `Filter` helper (the only logic unit).
+- `internal/api/wrap.go` — `wrapEnvPolicyWire` helper; populate `EnvPolicy` at both response sites.
+- `internal/cli/wrap_linux.go`, `internal/shim/kernelinstall/install_linux.go` — filter the inherited base.
+
+---
+
+## Task 1: Wire type + opt-in config flag
+
+**Files:**
+- Modify: `pkg/types/sessions.go`
+- Modify: `internal/config/config.go`
+- Create: `internal/config/wrap_env_policy_test.go`
+
+- [ ] **Step 1: Write the failing config test**
+
+Create `internal/config/wrap_env_policy_test.go`:
+
+```go
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Issue #379: sandbox.wrap_env_policy.enabled is an opt-in flag, default false.
+
+func TestWrapEnvPolicy_DefaultsOff(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	if cfg.Sandbox.WrapEnvPolicy.Enabled {
+		t.Error("sandbox.wrap_env_policy.enabled must default to false")
+	}
+}
+
+func TestWrapEnvPolicy_UnmarshalsTrue(t *testing.T) {
+	var cfg Config
+	if err := yaml.Unmarshal([]byte("sandbox:\n  wrap_env_policy:\n    enabled: true\n"), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !cfg.Sandbox.WrapEnvPolicy.Enabled {
+		t.Error("sandbox.wrap_env_policy.enabled should be true after unmarshal")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/config/ -run TestWrapEnvPolicy -v`
+Expected: FAIL — compile error `cfg.Sandbox.WrapEnvPolicy undefined`.
+
+- [ ] **Step 3: Add the wire type to pkg/types**
+
+In `pkg/types/sessions.go`, add (above `WrapInitResponse`):
+
+```go
+// EnvPolicyWire carries the resolved env allow/deny/limits for the client
+// (shell shim / CLI wrap) to filter the executed command's inherited
+// environment. Nil/omitted means "no filtering" — the field is only populated
+// when sandbox.wrap_env_policy.enabled is true, which also makes mixed-version
+// deployments degrade safely. block_iteration is intentionally not carried: it
+// is not enforceable on the wrap path (shells read environ directly). Issue #379.
+type EnvPolicyWire struct {
+	Allow    []string `json:"allow,omitempty"`
+	Deny     []string `json:"deny,omitempty"`
+	MaxBytes int      `json:"max_bytes,omitempty"`
+	MaxKeys  int      `json:"max_keys,omitempty"`
+}
+```
+
+and add a field at the end of the `WrapInitResponse` struct (after `EnvInject`):
+
+```go
+	// EnvPolicy carries the resolved env allow/deny/limits for the client to
+	// filter the executed command's inherited environment, when
+	// sandbox.wrap_env_policy.enabled is set. Nil ⇒ no filtering. Issue #379.
+	EnvPolicy *EnvPolicyWire `json:"env_policy,omitempty"`
+```
+
+- [ ] **Step 4: Add the config flag**
+
+In `internal/config/config.go`, add the struct (near the other `Sandbox*` sub-structs):
+
+```go
+// SandboxWrapEnvPolicyConfig opts into enforcing env_policy (allow/deny/max_*)
+// on the client-spawned wrap path (shell shim / kernel-install / agentsh wrap).
+// Default off; fail-open. Issue #379.
+type SandboxWrapEnvPolicyConfig struct {
+	Enabled bool `yaml:"enabled"`
+}
+```
+
+and add a field to `SandboxConfig` (next to `Ptrace`/`Seccomp`):
+
+```go
+	WrapEnvPolicy SandboxWrapEnvPolicyConfig `yaml:"wrap_env_policy"`
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `go test ./internal/config/ -run TestWrapEnvPolicy -v && go build ./...`
+Expected: both tests PASS; build OK.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/types/sessions.go internal/config/config.go internal/config/wrap_env_policy_test.go
+git commit -m "feat(#379): WrapInitResponse.EnvPolicy wire + sandbox.wrap_env_policy flag
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `internal/wrapenv.Filter` helper
+
+**Files:**
+- Create: `internal/wrapenv/wrapenv.go`
+- Create: `internal/wrapenv/wrapenv_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/wrapenv/wrapenv_test.go`:
+
+```go
+package wrapenv
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+func has(env []string, kv string) bool { return slices.Contains(env, kv) }
+
+func TestFilter_NilWireIsIdentity(t *testing.T) {
+	base := []string{"PATH=/bin", "FOO=bar"}
+	got := Filter(base, nil)
+	if !slices.Equal(got, base) {
+		t.Errorf("nil wire must return base unchanged; got %v", got)
+	}
+}
+
+func TestFilter_DenyStripsMatchKeepsRest(t *testing.T) {
+	base := []string{"PATH=/bin", "SECRET_TOKEN=x", "HOME=/h"}
+	got := Filter(base, &types.EnvPolicyWire{Deny: []string{"SECRET_*"}})
+	if has(got, "SECRET_TOKEN=x") {
+		t.Error("denied var must be stripped")
+	}
+	if !has(got, "PATH=/bin") || !has(got, "HOME=/h") {
+		t.Error("non-denied vars must be kept")
+	}
+}
+
+func TestFilter_DefaultSecretDenyWhenNoAllow(t *testing.T) {
+	base := []string{"PATH=/bin", "AWS_SECRET_ACCESS_KEY=zzz"}
+	got := Filter(base, &types.EnvPolicyWire{}) // empty policy, no allow
+	if has(got, "AWS_SECRET_ACCESS_KEY=zzz") {
+		t.Error("default-secret-deny var must be stripped when no allow patterns")
+	}
+	if !has(got, "PATH=/bin") {
+		t.Error("ordinary var must be kept")
+	}
+}
+
+func TestFilter_AllowIsAllowlist(t *testing.T) {
+	base := []string{"PATH=/bin", "HOME=/h", "OTHER=1"}
+	got := Filter(base, &types.EnvPolicyWire{Allow: []string{"PATH", "HOME"}})
+	if has(got, "OTHER=1") {
+		t.Error("non-allowed var must be dropped under allowlist")
+	}
+	if !has(got, "PATH=/bin") || !has(got, "HOME=/h") {
+		t.Error("allowed vars must be kept")
+	}
+}
+
+func TestFilter_MaxKeys(t *testing.T) {
+	base := []string{"A=1", "B=2", "C=3", "D=4"}
+	got := Filter(base, &types.EnvPolicyWire{MaxKeys: 2})
+	if len(got) > 2 {
+		t.Errorf("max_keys=2 must cap key count; got %d", len(got))
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/wrapenv/ -v`
+Expected: FAIL — package/`Filter` does not exist.
+
+- [ ] **Step 3: Implement Filter**
+
+Create `internal/wrapenv/wrapenv.go`:
+
+```go
+// Package wrapenv applies env_policy filtering to the inherited environment on
+// the client-spawned wrap path (shell shim / kernel-install / agentsh wrap),
+// the counterpart to server-side buildPolicyEnv. Issue #379.
+package wrapenv
+
+import (
+	"log/slog"
+
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// Filter applies the wrapped command's env policy subtractively over the
+// inherited base environment. A nil wire returns base unchanged (fail-open for
+// the default-off and mixed-version cases). On a BuildEnv error it returns base
+// unchanged with a warning — env filtering must never block a command.
+func Filter(base []string, wire *types.EnvPolicyWire) []string {
+	if wire == nil {
+		return base
+	}
+	pol := policy.ResolvedEnvPolicy{
+		Allow:    wire.Allow,
+		Deny:     wire.Deny,
+		MaxBytes: wire.MaxBytes,
+		MaxKeys:  wire.MaxKeys,
+	}
+	out, err := policy.BuildEnv(pol, base, nil)
+	if err != nil {
+		slog.Warn("wrap env policy filter failed; passing inherited env unfiltered", "error", err)
+		return base
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `go test ./internal/wrapenv/ -v`
+Expected: PASS (all 5).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/wrapenv/wrapenv.go internal/wrapenv/wrapenv_test.go
+git commit -m "feat(#379): wrapenv.Filter subtractive env-policy filter
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Server — resolve + populate `EnvPolicy`
+
+**Files:**
+- Modify: `internal/api/wrap.go` (helper + two response sites)
+- Create: `internal/api/wrap_env_policy_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/api/wrap_env_policy_test.go`:
+
+```go
+package api
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+func newWrapEnvTestApp(t *testing.T, enabled bool, p *policy.Policy) *App {
+	t.Helper()
+	eng, err := policy.NewEngine(p, false, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	cfg := &config.Config{}
+	cfg.Sandbox.WrapEnvPolicy.Enabled = enabled
+	return &App{cfg: cfg, policy: eng}
+}
+
+func TestWrapEnvPolicyWire_NilWhenDisabled(t *testing.T) {
+	p := &policy.Policy{
+		EnvPolicy:    policy.EnvPolicy{Deny: []string{"FOO"}},
+		CommandRules: []policy.CommandRule{{Name: "allow-sh", Commands: []string{"sh"}, Decision: "allow"}},
+	}
+	a := newWrapEnvTestApp(t, false, p)
+	if w := a.wrapEnvPolicyWire(nil, types.WrapInitRequest{AgentCommand: "/bin/sh", AgentArgs: []string{"-c", "echo hi"}}); w != nil {
+		t.Errorf("flag off must yield nil wire; got %+v", w)
+	}
+}
+
+func TestWrapEnvPolicyWire_PopulatedWhenEnabled(t *testing.T) {
+	p := &policy.Policy{
+		EnvPolicy:    policy.EnvPolicy{Deny: []string{"FOO"}},
+		CommandRules: []policy.CommandRule{{Name: "allow-sh", Commands: []string{"sh"}, Decision: "allow"}},
+	}
+	a := newWrapEnvTestApp(t, true, p)
+	w := a.wrapEnvPolicyWire(nil, types.WrapInitRequest{AgentCommand: "/bin/sh", AgentArgs: []string{"-c", "echo hi"}})
+	if w == nil {
+		t.Fatal("flag on must yield a non-nil wire")
+	}
+	found := false
+	for _, d := range w.Deny {
+		if d == "FOO" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("wire.Deny should contain FOO from the resolved policy; got %v", w.Deny)
+	}
+}
+```
+
+(If `policy.Policy`/`policy.EnvPolicy` field names differ, adjust to the actual exported fields — the resolved `Deny` must surface `FOO`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/api/ -run TestWrapEnvPolicyWire -v`
+Expected: FAIL — `a.wrapEnvPolicyWire` undefined.
+
+- [ ] **Step 3: Add the helper**
+
+In `internal/api/wrap.go`, add:
+
+```go
+// wrapEnvPolicyWire resolves the env policy for the wrapped command and returns
+// it as a wire value for the client to filter the inherited environment, when
+// sandbox.wrap_env_policy.enabled is set. Returns nil when disabled or when no
+// engine is available (fail-open). Even an empty (no allow/deny/max) policy
+// yields a non-nil wire so the client still applies the default-secret-deny
+// baseline. Issue #379.
+func (a *App) wrapEnvPolicyWire(s *session.Session, req types.WrapInitRequest) *types.EnvPolicyWire {
+	if !a.cfg.Sandbox.WrapEnvPolicy.Enabled {
+		return nil
+	}
+	engine := a.policyEngineFor(s)
+	if engine == nil {
+		return nil
+	}
+	pol := engine.CheckCommandWithExecve(req.AgentCommand, req.AgentArgs, a.execveEnforcementActive(), a.shellCOpaqueMode()).EnvPolicy
+	return &types.EnvPolicyWire{
+		Allow:    pol.Allow,
+		Deny:     pol.Deny,
+		MaxBytes: pol.MaxBytes,
+		MaxKeys:  pol.MaxKeys,
+	}
+}
+```
+
+(Confirm `session` is already imported in `wrap.go`; it is used throughout the file.)
+
+- [ ] **Step 4: Populate the two response sites**
+
+In `internal/api/wrap.go`, in the ptrace response (the `return types.WrapInitResponse{` at ~L279, which sets `EnvInject:`), add a field:
+
+```go
+			EnvPolicy:             a.wrapEnvPolicyWire(s, req),
+```
+
+and in the seccomp response (the final `return types.WrapInitResponse{` at ~L507, which sets `EnvInject:`), add:
+
+```go
+		EnvPolicy: a.wrapEnvPolicyWire(s, req),
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `go test ./internal/api/ -run TestWrapEnvPolicyWire -v && go build ./...`
+Expected: both tests PASS; build OK.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/api/wrap.go internal/api/wrap_env_policy_test.go
+git commit -m "feat(#379): server resolves + sends wrap EnvPolicy when flag enabled
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Client — filter the inherited base
+
+**Files:**
+- Modify: `internal/cli/wrap_linux.go` (two sites + import)
+- Modify: `internal/shim/kernelinstall/install_linux.go` (one site + import)
+- Create: `internal/shim/kernelinstall/wrap_env_policy_test.go`
+
+- [ ] **Step 1: Write the failing ordering test**
+
+Create `internal/shim/kernelinstall/wrap_env_policy_test.go`:
+
+```go
+package kernelinstall
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/wrapenv"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// Issue #379: filtering applies to the inherited base BEFORE agentsh markers and
+// env_inject are added, so a denied var is dropped while markers and injected
+// values survive.
+func TestAssembleWrapperEnv_FiltersBaseKeepsMarkersAndInject(t *testing.T) {
+	base := []string{"PATH=/bin", "SECRET_TOKEN=x"}
+	wire := &types.EnvPolicyWire{Deny: []string{"SECRET_*"}}
+
+	filtered := wrapenv.Filter(base, wire)
+	env := assembleWrapperEnv(filtered, "", map[string]string{}, map[string]string{"INJECTED": "1"})
+
+	for _, kv := range env {
+		if kv == "SECRET_TOKEN=x" {
+			t.Error("denied var must not survive filtering")
+		}
+	}
+	if !slices.Contains(env, "INJECTED=1") {
+		t.Error("env_inject value must survive (applied after filter)")
+	}
+	if !slices.Contains(env, "AGENTSH_NOTIFY_SOCK_FD=3") {
+		t.Error("agentsh marker must survive (appended after filter)")
+	}
+	if !slices.Contains(env, "PATH=/bin") {
+		t.Error("non-denied inherited var must survive")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/shim/kernelinstall/ -run TestAssembleWrapperEnv_FiltersBase -v`
+Expected: FAIL — `internal/wrapenv` not yet imported here / test references compile but the production call isn't wired (this test exercises the composition directly, so it will actually PASS once Step 1 compiles — if it already passes, that's fine: it locks in the ordering contract. The real production wiring is Steps 3-4, verified by build.)
+
+(Note: this test validates the helper composition; the production change in Steps 3-4 is verified by `go build` + the full suite. If the test passes immediately, proceed — it is a guard, not red-green for new logic, which lives in `wrapenv` Task 2.)
+
+- [ ] **Step 3: Wire kernelinstall**
+
+In `internal/shim/kernelinstall/install_linux.go`, add `"github.com/agentsh/agentsh/internal/wrapenv"` to the import block, and change the base at L200 from:
+
+```go
+	env := assembleWrapperEnv(filterShimInternalEnv(p.Env), p.Argv0, resp.WrapperEnv, resp.EnvInject)
+```
+
+to:
+
+```go
+	env := assembleWrapperEnv(wrapenv.Filter(filterShimInternalEnv(p.Env), resp.EnvPolicy), p.Argv0, resp.WrapperEnv, resp.EnvInject)
+```
+
+- [ ] **Step 4: Wire cli/wrap_linux.go (both branches)**
+
+In `internal/cli/wrap_linux.go`, add `"github.com/agentsh/agentsh/internal/wrapenv"` to the import block. In BOTH the ptrace branch (~L33) and seccomp branch (~L138), change:
+
+```go
+	env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
+```
+
+to:
+
+```go
+	env := buildWrapEnv(wrapenv.Filter(os.Environ(), wrapResp.EnvPolicy), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
+```
+
+- [ ] **Step 5: Run tests + build**
+
+Run: `go test ./internal/shim/kernelinstall/ -run TestAssembleWrapperEnv_FiltersBase -v && go build ./... && GOOS=windows go build ./...`
+Expected: test PASS; both builds OK.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/cli/wrap_linux.go internal/shim/kernelinstall/install_linux.go internal/shim/kernelinstall/wrap_env_policy_test.go
+git commit -m "feat(#379): filter inherited env on wrap launch paths
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build + Windows cross-compile**
+
+Run: `go build ./... && GOOS=windows go build ./...`
+Expected: both succeed.
+
+- [ ] **Step 2: Vet + gofmt**
+
+Run: `go vet ./pkg/types/ ./internal/config/ ./internal/wrapenv/ ./internal/api/ ./internal/cli/ ./internal/shim/kernelinstall/ && gofmt -l pkg/types/sessions.go internal/config/config.go internal/config/wrap_env_policy_test.go internal/wrapenv/wrapenv.go internal/wrapenv/wrapenv_test.go internal/api/wrap.go internal/api/wrap_env_policy_test.go internal/cli/wrap_linux.go internal/shim/kernelinstall/install_linux.go internal/shim/kernelinstall/wrap_env_policy_test.go`
+Expected: vet clean; `gofmt -l` prints nothing.
+
+- [ ] **Step 3: Affected package tests**
+
+Run: `go test ./pkg/types/ ./internal/config/ ./internal/wrapenv/ ./internal/api/ ./internal/cli/ ./internal/shim/kernelinstall/ ./internal/policy/`
+Expected: ok for all.
+
+- [ ] **Step 4: Commit any formatting fixes (only if Step 2 changed files)**
+
+```bash
+git add -A && git commit -m "chore(#379): gofmt" || echo "nothing to commit"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** wire type + flag (Task 1) ← spec §1,§2; `wrapenv.Filter` subtractive fail-open (Task 2) ← spec §3; server resolve+populate when enabled (Task 3) ← spec §2; client apply-before-markers in all 3 sites (Task 4) ← spec §4; verification incl. Windows (Task 5). Non-goals respected: no minimal-rebuild, `block_iteration` not carried (wire omits it), no exec-path change, default-off (flag), fail-open (Filter returns base on nil/error).
+- **Type/name consistency:** `types.EnvPolicyWire{Allow,Deny,MaxBytes,MaxKeys}`, `WrapInitResponse.EnvPolicy *EnvPolicyWire`, `config.SandboxWrapEnvPolicyConfig{Enabled}` at `cfg.Sandbox.WrapEnvPolicy.Enabled`, `wrapenv.Filter(base, wire)`, `(a *App) wrapEnvPolicyWire(s, req)`, `policy.ResolvedEnvPolicy`/`policy.BuildEnv` — consistent across tasks.
+- **Build stays green per commit:** Task 1 pure additions; Task 2 new package; Task 3 uses Task 1's type; Task 4 uses Task 1+2. Each compiles independently.
+- **No placeholders:** every step has concrete code/commands. (Task 3 test notes a fallback if `policy.Policy` field names differ; Task 4 Step 2 notes the guard-test may pass immediately by design.)

--- a/docs/superpowers/plans/2026-05-24-issue-379-wrap-env-policy.md
+++ b/docs/superpowers/plans/2026-05-24-issue-379-wrap-env-policy.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Enforce env `allow`/`deny`/`max_*` on the client-spawned wrap path (shell shim / kernel-install / `agentsh wrap`) by plumbing the resolved policy through `WrapInitResponse` and applying a subtractive `policy.BuildEnv` filter client-side — gated behind `sandbox.wrap_env_policy.enabled` (default off), fail-open.
+**Goal:** Enforce env `allow`/`deny` on the client-spawned wrap path (shell shim / kernel-install / `agentsh wrap`) by plumbing the resolved policy through `WrapInitResponse` and applying a subtractive `policy.BuildEnv` filter client-side — gated behind `sandbox.wrap_env_policy.enabled` (default off), fail-open. (`max_*`/`block_iteration` are out of scope — see the spec Non-Goals.)
 
 **Architecture:** Server resolves the env policy for the wrapped command and (only when the flag is on) sends it as a new `EnvPolicyWire` field on `WrapInitResponse`. A new `internal/wrapenv.Filter` helper maps the wire type to `policy.ResolvedEnvPolicy` and runs `policy.BuildEnv` over the **inherited** launcher env (subtractive), fail-open. Both client launch sites filter the inherited base *before* adding agentsh markers / `env_inject`, so those always survive.
 
@@ -90,10 +90,8 @@ In `pkg/types/sessions.go`, add (above `WrapInitResponse`):
 // deployments degrade safely. block_iteration is intentionally not carried: it
 // is not enforceable on the wrap path (shells read environ directly). Issue #379.
 type EnvPolicyWire struct {
-	Allow    []string `json:"allow,omitempty"`
-	Deny     []string `json:"deny,omitempty"`
-	MaxBytes int      `json:"max_bytes,omitempty"`
-	MaxKeys  int      `json:"max_keys,omitempty"`
+	Allow []string `json:"allow,omitempty"`
+	Deny  []string `json:"deny,omitempty"`
 }
 ```
 
@@ -204,11 +202,17 @@ func TestFilter_AllowIsAllowlist(t *testing.T) {
 	}
 }
 
-func TestFilter_MaxKeys(t *testing.T) {
-	base := []string{"A=1", "B=2", "C=3", "D=4"}
-	got := Filter(base, &types.EnvPolicyWire{MaxKeys: 2})
-	if len(got) > 2 {
-		t.Errorf("max_keys=2 must cap key count; got %d", len(got))
+// max_bytes/max_keys are NOT carried on the wrap path (#379): BuildEnv errors
+// on overflow, which under fail-open reverts to the full unfiltered env. So a
+// large env is filtered by allow/deny only and never rejected.
+func TestFilter_NoMaxEnforcementLargeEnvNotRejected(t *testing.T) {
+	base := []string{"A=1", "B=2", "C=3", "D=4", "SECRET_TOKEN=x"}
+	got := Filter(base, &types.EnvPolicyWire{Deny: []string{"SECRET_*"}})
+	if has(got, "SECRET_TOKEN=x") {
+		t.Error("denied var must be stripped")
+	}
+	if len(got) != 4 {
+		t.Errorf("large env must pass through (minus denied), not be rejected; got %d: %v", len(got), got)
 	}
 }
 ```
@@ -244,10 +248,8 @@ func Filter(base []string, wire *types.EnvPolicyWire) []string {
 		return base
 	}
 	pol := policy.ResolvedEnvPolicy{
-		Allow:    wire.Allow,
-		Deny:     wire.Deny,
-		MaxBytes: wire.MaxBytes,
-		MaxKeys:  wire.MaxKeys,
+		Allow: wire.Allow,
+		Deny:  wire.Deny,
 	}
 	out, err := policy.BuildEnv(pol, base, nil)
 	if err != nil {
@@ -367,10 +369,8 @@ func (a *App) wrapEnvPolicyWire(s *session.Session, req types.WrapInitRequest) *
 	}
 	pol := engine.CheckCommandWithExecve(req.AgentCommand, req.AgentArgs, a.execveEnforcementActive(), a.shellCOpaqueMode()).EnvPolicy
 	return &types.EnvPolicyWire{
-		Allow:    pol.Allow,
-		Deny:     pol.Deny,
-		MaxBytes: pol.MaxBytes,
-		MaxKeys:  pol.MaxKeys,
+		Allow: pol.Allow,
+		Deny:  pol.Deny,
 	}
 }
 ```
@@ -537,6 +537,6 @@ git add -A && git commit -m "chore(#379): gofmt" || echo "nothing to commit"
 ## Self-review notes
 
 - **Spec coverage:** wire type + flag (Task 1) ← spec §1,§2; `wrapenv.Filter` subtractive fail-open (Task 2) ← spec §3; server resolve+populate when enabled (Task 3) ← spec §2; client apply-before-markers in all 3 sites (Task 4) ← spec §4; verification incl. Windows (Task 5). Non-goals respected: no minimal-rebuild, `block_iteration` not carried (wire omits it), no exec-path change, default-off (flag), fail-open (Filter returns base on nil/error).
-- **Type/name consistency:** `types.EnvPolicyWire{Allow,Deny,MaxBytes,MaxKeys}`, `WrapInitResponse.EnvPolicy *EnvPolicyWire`, `config.SandboxWrapEnvPolicyConfig{Enabled}` at `cfg.Sandbox.WrapEnvPolicy.Enabled`, `wrapenv.Filter(base, wire)`, `(a *App) wrapEnvPolicyWire(s, req)`, `policy.ResolvedEnvPolicy`/`policy.BuildEnv` — consistent across tasks.
+- **Type/name consistency:** `types.EnvPolicyWire{Allow,Deny}`, `WrapInitResponse.EnvPolicy *EnvPolicyWire`, `config.SandboxWrapEnvPolicyConfig{Enabled}` at `cfg.Sandbox.WrapEnvPolicy.Enabled`, `wrapenv.Filter(base, wire)`, `(a *App) wrapEnvPolicyWire(s, req)`, `policy.ResolvedEnvPolicy`/`policy.BuildEnv` — consistent across tasks.
 - **Build stays green per commit:** Task 1 pure additions; Task 2 new package; Task 3 uses Task 1's type; Task 4 uses Task 1+2. Each compiles independently.
 - **No placeholders:** every step has concrete code/commands. (Task 3 test notes a fallback if `policy.Policy` field names differ; Task 4 Step 2 notes the guard-test may pass immediately by design.)

--- a/docs/superpowers/specs/2026-05-24-issue-379-wrap-env-policy-design.md
+++ b/docs/superpowers/specs/2026-05-24-issue-379-wrap-env-policy-design.md
@@ -10,7 +10,7 @@ The fix plumbs the resolved env policy through `WrapInitResponse` (exactly as #3
 
 ## Goals
 
-- When enabled, the wrap path filters the executed command's environment per the resolved env policy: `deny` + the built-in `defaultSecretDeny` list strip secrets; `env_allow` (when set) tightens to allowlist; `max_bytes`/`max_keys` apply.
+- When enabled, the wrap path filters the executed command's environment per the resolved env policy: `deny` + the built-in `defaultSecretDeny` list strip secrets; `env_allow` (when set) tightens to allowlist. (`max_bytes`/`max_keys`/`block_iteration` are out of scope — see Non-Goals.)
 - Default-off: no change to any existing wrap/shim deployment until `sandbox.wrap_env_policy.enabled: true`.
 - Fail-open: any filter error falls back to the unfiltered inherited env; a command is never blocked by env filtering.
 - Mixed-version safe: old server / new client and new server / old client both degrade to today's behavior (no filtering).
@@ -19,7 +19,7 @@ The fix plumbs the resolved env policy through `WrapInitResponse` (exactly as #3
 ## Non-Goals
 
 - **No minimal-base rebuild** (the exec path's deny-by-default minimal base). We keep the inherited env as the base and subtract — preserving the inheritance the wrap path's platforms (Blaxel/E2B/Daytona) and the documented `BASH_ENV`/`env_inject` workaround depend on.
-- **`block_iteration` is not applied** on the wrap path. It relies on replacing `environ`, which is incompatible with shells (documented in `exec.go` `maybeAddShimEnv`). Only allow/deny/max are enforced.
+- **`block_iteration` and `max_bytes`/`max_keys` are not applied** on the wrap path. `block_iteration` relies on replacing `environ`, which is incompatible with shells (documented in `exec.go` `maybeAddShimEnv`). `max_bytes`/`max_keys` are excluded because `policy.BuildEnv` treats an overflow as a hard *error* (it does not truncate); under the wrap path's fail-open contract that error reverts to the **full unfiltered** env, which would silently bypass the very allow/deny stripping the operator configured. The wrap filter is therefore **allow/deny only** (plus the built-in `defaultSecretDeny`).
 - No per-inner-command env rebuild: the filter applies once to the wrapped shell's env at launch; nested commands inherit it. (Coarser than exec by nature; documented.)
 - No change to the server-spawned exec path, Windows/darwin wrap, or `block_iteration` semantics elsewhere.
 - Not flipping the default to on (a later, separately-decided rollout step).
@@ -53,24 +53,23 @@ No default needed (zero value `false` = off); no validation needed (bool).
 In `pkg/types/sessions.go`:
 
 ```go
-// EnvPolicyWire carries the resolved env allow/deny/limits for the client
-// (shell shim / CLI wrap) to filter the executed command's inherited
-// environment. Nil/omitted means "no filtering" (the field is only populated
-// when sandbox.wrap_env_policy.enabled is true), which also makes mixed-version
-// deployments degrade safely. block_iteration is intentionally not carried:
-// it is not enforceable on the wrap path (shells read environ directly).
-// Issue #379.
+// EnvPolicyWire carries the resolved env allow/deny for the client (shell shim
+// / CLI wrap) to filter the executed command's inherited environment. Nil/
+// omitted means "no filtering" (only populated when
+// sandbox.wrap_env_policy.enabled is true), which makes mixed-version
+// deployments degrade safely. Only allow/deny are carried — block_iteration
+// (replaces environ; incompatible with shells) and max_bytes/max_keys
+// (BuildEnv errors on overflow, which fail-open would revert to the full env)
+// are intentionally not enforced on the wrap path. Issue #379.
 type EnvPolicyWire struct {
-    Allow    []string `json:"allow,omitempty"`
-    Deny     []string `json:"deny,omitempty"`
-    MaxBytes int      `json:"max_bytes,omitempty"`
-    MaxKeys  int      `json:"max_keys,omitempty"`
+    Allow []string `json:"allow,omitempty"`
+    Deny  []string `json:"deny,omitempty"`
 }
 ```
 
 and add `EnvPolicy *EnvPolicyWire `json:"env_policy,omitempty"`` to `WrapInitResponse`.
 
-Server: a helper `(a *App) wrapEnvPolicyWire(s *session.Session, req types.WrapInitRequest) *types.EnvPolicyWire` returns `nil` when `!a.cfg.Sandbox.WrapEnvPolicy.Enabled`; otherwise it resolves the env policy for the wrapped command (`a.policyEngineFor(s).CheckCommandWithExecve(req.AgentCommand, req.AgentArgs, a.execveEnforcementActive(), a.shellCOpaqueMode()).EnvPolicy`) and maps `{Allow, Deny, MaxBytes, MaxKeys}` to `EnvPolicyWire`. It is set alongside `EnvInject:` at both response sites (`wrap.go:283`, `wrap.go:519`).
+Server: a helper `(a *App) wrapEnvPolicyWire(s *session.Session, req types.WrapInitRequest) *types.EnvPolicyWire` returns `nil` when `!a.cfg.Sandbox.WrapEnvPolicy.Enabled`; otherwise it resolves the env policy for the wrapped command (`a.policyEngineFor(s).CheckCommandWithExecve(req.AgentCommand, req.AgentArgs, a.execveEnforcementActive(), a.shellCOpaqueMode()).EnvPolicy`) and maps `{Allow, Deny}` to `EnvPolicyWire`. It is set alongside `EnvInject:` at both response sites (`wrap.go:283`, `wrap.go:519`).
 
 ### 3. Subtractive filter helper (new package `internal/wrapenv`)
 
@@ -86,7 +85,6 @@ func Filter(base []string, wire *types.EnvPolicyWire) []string {
     }
     pol := policy.ResolvedEnvPolicy{
         Allow: wire.Allow, Deny: wire.Deny,
-        MaxBytes: wire.MaxBytes, MaxKeys: wire.MaxKeys,
     }
     out, err := policy.BuildEnv(pol, base, nil)
     if err != nil {
@@ -125,12 +123,12 @@ No new error types. `Filter` is fail-open: nil wire or `BuildEnv` error ⇒ inhe
 - deny `["SECRET_*"]`, no allow ⇒ `SECRET_TOKEN` stripped, `PATH`/`HOME` kept.
 - no allow, no deny ⇒ a `defaultSecretDeny`-listed var (e.g. `AWS_SECRET_ACCESS_KEY`) stripped, ordinary vars kept (confirms baseline secret protection).
 - allow `["PATH","HOME"]` ⇒ only those kept.
-- `max_keys` / `max_bytes` enforced.
+- a large env is filtered by allow/deny only and is **not** rejected (confirms `max_*` is not enforced on this path).
 - a var named like an agentsh marker is irrelevant here (markers are added by callers after Filter) — covered by the caller-order tests below.
 
 `internal/api` (wrap helper):
 - flag off ⇒ `wrapEnvPolicyWire` returns `nil` (and the response `EnvPolicy` is nil).
-- flag on with a policy that denies `FOO` ⇒ returns a wire whose `Deny` contains `FOO`; `Allow`/`MaxBytes`/`MaxKeys` mirror the resolved policy.
+- flag on with a policy that denies `FOO` ⇒ returns a wire whose `Deny` contains `FOO`; `Allow` mirrors the resolved policy.
 
 `internal/cli` / `internal/shim/kernelinstall` (ordering): a focused test that, given a base containing a denied var plus an agentsh marker added after Filter, the denied var is removed while the marker and an `env_inject` value survive. (If a full wrap launch is impractical to unit-test, assert the helper composition: `envinject.Apply(buildWrapEnv(wrapenv.Filter(base, wire), …), inject)` keeps markers + inject and drops denied vars.)
 

--- a/docs/superpowers/specs/2026-05-24-issue-379-wrap-env-policy-design.md
+++ b/docs/superpowers/specs/2026-05-24-issue-379-wrap-env-policy-design.md
@@ -1,0 +1,149 @@
+# Enforce env_policy on the wrap path Design
+
+Issue: #379 (follow-up to #374)
+
+## Summary
+
+On the client-spawned wrap path (shell shim / kernel-install and `agentsh wrap`), the executed command inherits the launcher's full environment (`syscall.Exec(cmdPath, args, os.Environ())` in `cmd/agentsh-unixwrap/main.go`). `policy.BuildEnv` — which enforces env `allow`/`deny`/`max_bytes`/`max_keys` — runs only on the server-spawned exec path (`internal/api/exec.go`). So env_policy allow/deny isolation never runs on the wrap path: commands (including any secrets in the launcher env) see everything. #374 plumbed `env_inject` through this path; this closes the env_policy gap.
+
+The fix plumbs the resolved env policy through `WrapInitResponse` (exactly as #374 did for `EnvInject`) and applies a **subtractive** `policy.BuildEnv` filter client-side over the inherited environment, **gated behind an opt-in config flag**, **fail-open**. Default-off means zero behavior change for existing deployments until an operator enables it.
+
+## Goals
+
+- When enabled, the wrap path filters the executed command's environment per the resolved env policy: `deny` + the built-in `defaultSecretDeny` list strip secrets; `env_allow` (when set) tightens to allowlist; `max_bytes`/`max_keys` apply.
+- Default-off: no change to any existing wrap/shim deployment until `sandbox.wrap_env_policy.enabled: true`.
+- Fail-open: any filter error falls back to the unfiltered inherited env; a command is never blocked by env filtering.
+- Mixed-version safe: old server / new client and new server / old client both degrade to today's behavior (no filtering).
+- agentsh's own markers (`AGENTSH_*`, notify/signal FDs, wrapper env, proxy markers) and operator `env_inject` are never stripped.
+
+## Non-Goals
+
+- **No minimal-base rebuild** (the exec path's deny-by-default minimal base). We keep the inherited env as the base and subtract — preserving the inheritance the wrap path's platforms (Blaxel/E2B/Daytona) and the documented `BASH_ENV`/`env_inject` workaround depend on.
+- **`block_iteration` is not applied** on the wrap path. It relies on replacing `environ`, which is incompatible with shells (documented in `exec.go` `maybeAddShimEnv`). Only allow/deny/max are enforced.
+- No per-inner-command env rebuild: the filter applies once to the wrapped shell's env at launch; nested commands inherit it. (Coarser than exec by nature; documented.)
+- No change to the server-spawned exec path, Windows/darwin wrap, or `block_iteration` semantics elsewhere.
+- Not flipping the default to on (a later, separately-decided rollout step).
+
+## Background
+
+- Server exec resolves the env policy as `dec.EnvPolicy` (`policy.ResolvedEnvPolicy{Allow, Deny, MaxBytes, MaxKeys, BlockIteration}`) from the command `Decision` and passes it to `buildPolicyEnv` → `policy.BuildEnv(pol, minimalBase, add)` (`internal/api/core.go:1071`, `exec.go:705`).
+- `policy.BuildEnv(pol, baseEnv, addKeys)` (`internal/policy/env_policy.go:55`): with no `allow` patterns it keeps everything except `deny` matches and a built-in `defaultSecretDeny` list; with `allow` patterns it keeps only allowed keys; then applies `max_bytes`/`max_keys`; `addKeys` are merged after filtering. Applying it over the **full** inherited env (not a minimal base) yields the subtractive behavior we want.
+- The wrap handler `wrapInitCore` (`internal/api/wrap.go:124`) already builds the response and sets `EnvInject: mergeEnvInject(a.cfg, a.policyEngineFor(s))` at two sites: ptrace (`wrap.go:283`) and seccomp (`wrap.go:519`). `dec` (the command decision at `wrap.go:164`) is scoped to the `req.Mode == "shim"` block, so env-policy resolution for the response uses a dedicated helper rather than that `dec`.
+- `WrapInitResponse` is in `pkg/types/sessions.go`, which must not import `internal/policy`; the wire type is therefore a primitive struct mapped to/from `policy.ResolvedEnvPolicy` on each side.
+- Clients build the wrapped env in two places, both of which already `import` `internal/envinject` and apply `envinject.Apply`:
+  - `internal/cli/wrap_linux.go`: ptrace branch (~L30) and seccomp branch (~L138) — base is `os.Environ()`, then `buildWrapEnv(base, …)` adds markers, then `envinject.Apply`.
+  - `internal/shim/kernelinstall/install_linux.go:200`: `assembleWrapperEnv(filterShimInternalEnv(p.Env), p.Argv0, resp.WrapperEnv, resp.EnvInject)`.
+
+## Design
+
+### 1. Opt-in config flag
+
+Add `WrapEnvPolicy SandboxWrapEnvPolicyConfig `yaml:"wrap_env_policy"`` to `SandboxConfig`, where:
+
+```go
+type SandboxWrapEnvPolicyConfig struct {
+    Enabled bool `yaml:"enabled"` // default false; opt-in (issue #379)
+}
+```
+
+No default needed (zero value `false` = off); no validation needed (bool).
+
+### 2. Wire the resolved policy through `WrapInitResponse`
+
+In `pkg/types/sessions.go`:
+
+```go
+// EnvPolicyWire carries the resolved env allow/deny/limits for the client
+// (shell shim / CLI wrap) to filter the executed command's inherited
+// environment. Nil/omitted means "no filtering" (the field is only populated
+// when sandbox.wrap_env_policy.enabled is true), which also makes mixed-version
+// deployments degrade safely. block_iteration is intentionally not carried:
+// it is not enforceable on the wrap path (shells read environ directly).
+// Issue #379.
+type EnvPolicyWire struct {
+    Allow    []string `json:"allow,omitempty"`
+    Deny     []string `json:"deny,omitempty"`
+    MaxBytes int      `json:"max_bytes,omitempty"`
+    MaxKeys  int      `json:"max_keys,omitempty"`
+}
+```
+
+and add `EnvPolicy *EnvPolicyWire `json:"env_policy,omitempty"`` to `WrapInitResponse`.
+
+Server: a helper `(a *App) wrapEnvPolicyWire(s *session.Session, req types.WrapInitRequest) *types.EnvPolicyWire` returns `nil` when `!a.cfg.Sandbox.WrapEnvPolicy.Enabled`; otherwise it resolves the env policy for the wrapped command (`a.policyEngineFor(s).CheckCommandWithExecve(req.AgentCommand, req.AgentArgs, a.execveEnforcementActive(), a.shellCOpaqueMode()).EnvPolicy`) and maps `{Allow, Deny, MaxBytes, MaxKeys}` to `EnvPolicyWire`. It is set alongside `EnvInject:` at both response sites (`wrap.go:283`, `wrap.go:519`).
+
+### 3. Subtractive filter helper (new package `internal/wrapenv`)
+
+```go
+// Filter applies the wrapped command's env policy subtractively over the
+// inherited base environment. nil wire ⇒ base returned unchanged (fail-open
+// for default-off and mixed-version). On BuildEnv error ⇒ base returned
+// unchanged with a slog.Warn (fail-open: env filtering never blocks a command).
+// Issue #379.
+func Filter(base []string, wire *types.EnvPolicyWire) []string {
+    if wire == nil {
+        return base
+    }
+    pol := policy.ResolvedEnvPolicy{
+        Allow: wire.Allow, Deny: wire.Deny,
+        MaxBytes: wire.MaxBytes, MaxKeys: wire.MaxKeys,
+    }
+    out, err := policy.BuildEnv(pol, base, nil)
+    if err != nil {
+        slog.Warn("wrap env policy filter failed; passing inherited env unfiltered", "error", err)
+        return base
+    }
+    return out
+}
+```
+
+(`internal/wrapenv` may import both `pkg/types` and `internal/policy`.)
+
+### 4. Apply client-side, before markers
+
+The filter runs on the **inherited launcher env only**, before agentsh adds its own vars — so markers, wrapper env, proxy, and `env_inject` are never stripped and `env_inject` still overrides:
+
+- `internal/cli/wrap_linux.go`, both branches: `base := wrapenv.Filter(os.Environ(), wrapResp.EnvPolicy)` then the existing `buildWrapEnv(base, …)` → `envinject.Apply(…)`.
+- `internal/shim/kernelinstall/install_linux.go:200`: wrap the base — `assembleWrapperEnv(wrapenv.Filter(filterShimInternalEnv(p.Env), resp.EnvPolicy), p.Argv0, resp.WrapperEnv, resp.EnvInject)`.
+
+Note: as on the exec path, a restrictive `env_allow` will also exclude infra vars (proxy/LLM) unless the operator lists them — identical to `buildPolicyEnv`'s behavior, and documented.
+
+### Why not other approaches
+
+- **Filter inside `agentsh-unixwrap` before `execve`:** single chokepoint, but the wrapper is a minimal static stub; it would require serializing allow/deny globs into its env and reimplementing `BuildEnv`. The Go client already imports `policy`/`envinject` and reuses `BuildEnv` directly — DRY and consistent with how #374 applied `env_inject`.
+- **Server returns a fully-filtered env set:** impossible — the launcher env (`os.Environ()`) exists only client-side; the server can send the policy, not the filtered result.
+- **Minimal-base rebuild (exec parity):** rejected as a non-goal — breaks inheritance on the exact platforms this path serves.
+
+## Error handling
+
+No new error types. `Filter` is fail-open: nil wire or `BuildEnv` error ⇒ inherited env unchanged (logged). The server helper returns `nil` when disabled. Mixed-version: absent `EnvPolicy` (old server) ⇒ client filters nothing; unknown field (old client) ⇒ ignored.
+
+## Testing
+
+`internal/wrapenv` (table tests):
+- nil wire ⇒ identity (same slice contents).
+- deny `["SECRET_*"]`, no allow ⇒ `SECRET_TOKEN` stripped, `PATH`/`HOME` kept.
+- no allow, no deny ⇒ a `defaultSecretDeny`-listed var (e.g. `AWS_SECRET_ACCESS_KEY`) stripped, ordinary vars kept (confirms baseline secret protection).
+- allow `["PATH","HOME"]` ⇒ only those kept.
+- `max_keys` / `max_bytes` enforced.
+- a var named like an agentsh marker is irrelevant here (markers are added by callers after Filter) — covered by the caller-order tests below.
+
+`internal/api` (wrap helper):
+- flag off ⇒ `wrapEnvPolicyWire` returns `nil` (and the response `EnvPolicy` is nil).
+- flag on with a policy that denies `FOO` ⇒ returns a wire whose `Deny` contains `FOO`; `Allow`/`MaxBytes`/`MaxKeys` mirror the resolved policy.
+
+`internal/cli` / `internal/shim/kernelinstall` (ordering): a focused test that, given a base containing a denied var plus an agentsh marker added after Filter, the denied var is removed while the marker and an `env_inject` value survive. (If a full wrap launch is impractical to unit-test, assert the helper composition: `envinject.Apply(buildWrapEnv(wrapenv.Filter(base, wire), …), inject)` keeps markers + inject and drops denied vars.)
+
+`internal/config`: `sandbox.wrap_env_policy.enabled` defaults to false; round-trips true from YAML.
+
+Confirm existing `internal/api`, `internal/cli`, `internal/config`, `internal/policy` suites stay green and `GOOS=windows go build ./...` succeeds.
+
+## Affected files
+
+- `pkg/types/sessions.go` — `EnvPolicyWire` type + `EnvPolicy *EnvPolicyWire` field on `WrapInitResponse`.
+- `internal/config/config.go` — `SandboxWrapEnvPolicyConfig{Enabled}` + `WrapEnvPolicy` field on `SandboxConfig`.
+- `internal/wrapenv/wrapenv.go` (new) + test — the `Filter` helper.
+- `internal/api/wrap.go` — `wrapEnvPolicyWire` helper; populate `EnvPolicy` at both response sites.
+- `internal/cli/wrap_linux.go` — filter the inherited base in both branches.
+- `internal/shim/kernelinstall/install_linux.go` — filter the base in the `assembleWrapperEnv` call.
+- Tests in `internal/wrapenv`, `internal/api`, `internal/config`.

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -281,6 +281,7 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 			SafeToBypassShellShim: true,
 			NotifySocket:          notifySocketPath,
 			EnvInject:             mergeEnvInject(a.cfg, a.policyEngineFor(s)),
+			EnvPolicy:             a.wrapEnvPolicyWire(s, req),
 		}, http.StatusOK, nil
 	}
 
@@ -517,7 +518,30 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 		// process on this path). Operator-trusted; bypasses policy filtering,
 		// matching the server-spawned exec path. Issue #374.
 		EnvInject: mergeEnvInject(a.cfg, a.policyEngineFor(s)),
+		EnvPolicy: a.wrapEnvPolicyWire(s, req),
 	}, http.StatusOK, nil
+}
+
+// wrapEnvPolicyWire resolves the env policy for the wrapped command and returns
+// it as a wire value for the client to filter the inherited environment, when
+// sandbox.wrap_env_policy.enabled is set. Returns nil when disabled or when no
+// engine is available (fail-open). Even an empty (no allow/deny) policy yields a
+// non-nil wire so the client still applies the default-secret-deny baseline.
+// Only allow/deny are carried; max_*/block_iteration are not enforced on the
+// wrap path. Issue #379.
+func (a *App) wrapEnvPolicyWire(s *session.Session, req types.WrapInitRequest) *types.EnvPolicyWire {
+	if !a.cfg.Sandbox.WrapEnvPolicy.Enabled {
+		return nil
+	}
+	engine := a.policyEngineFor(s)
+	if engine == nil {
+		return nil
+	}
+	pol := engine.CheckCommandWithExecve(req.AgentCommand, req.AgentArgs, a.execveEnforcementActive(), a.shellCOpaqueMode()).EnvPolicy
+	return &types.EnvPolicyWire{
+		Allow: pol.Allow,
+		Deny:  pol.Deny,
+	}
 }
 
 // deriveLandlockAllowPaths returns the execute/read/write allow-path lists

--- a/internal/api/wrap_env_policy_test.go
+++ b/internal/api/wrap_env_policy_test.go
@@ -1,0 +1,63 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+func newWrapEnvTestApp(t *testing.T, enabled bool, p *policy.Policy) *App {
+	t.Helper()
+	eng, err := policy.NewEngine(p, false, true)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	cfg := &config.Config{}
+	cfg.Sandbox.WrapEnvPolicy.Enabled = enabled
+	return &App{cfg: cfg, policy: eng}
+}
+
+func TestWrapEnvPolicyWire_NilWhenDisabled(t *testing.T) {
+	p := &policy.Policy{
+		EnvPolicy:    policy.EnvPolicy{Deny: []string{"FOO"}},
+		CommandRules: []policy.CommandRule{{Name: "allow-sh", Commands: []string{"sh"}, Decision: "allow"}},
+	}
+	a := newWrapEnvTestApp(t, false, p)
+	if w := a.wrapEnvPolicyWire(nil, types.WrapInitRequest{AgentCommand: "/bin/sh", AgentArgs: []string{"-c", "echo hi"}}); w != nil {
+		t.Errorf("flag off must yield nil wire; got %+v", w)
+	}
+}
+
+func TestWrapEnvPolicyWire_PopulatedWhenEnabled(t *testing.T) {
+	p := &policy.Policy{
+		EnvPolicy:    policy.EnvPolicy{Deny: []string{"FOO"}},
+		CommandRules: []policy.CommandRule{{Name: "allow-sh", Commands: []string{"sh"}, Decision: "allow"}},
+	}
+	a := newWrapEnvTestApp(t, true, p)
+	w := a.wrapEnvPolicyWire(nil, types.WrapInitRequest{AgentCommand: "/bin/sh", AgentArgs: []string{"-c", "echo hi"}})
+	if w == nil {
+		t.Fatal("flag on must yield a non-nil wire")
+	}
+	found := false
+	for _, d := range w.Deny {
+		if d == "FOO" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("wire.Deny should contain FOO from the resolved policy; got %v", w.Deny)
+	}
+}
+
+// Fail-open: flag on but no policy engine available ⇒ nil wire (no filtering),
+// rather than blocking the command. Security-relevant path. Issue #379.
+func TestWrapEnvPolicyWire_NilWhenNoEngine(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Sandbox.WrapEnvPolicy.Enabled = true
+	a := &App{cfg: cfg, policy: nil} // policyEngineFor(nil) -> a.Policy() -> nil
+	if w := a.wrapEnvPolicyWire(nil, types.WrapInitRequest{AgentCommand: "/bin/sh", AgentArgs: []string{"-c", "echo hi"}}); w != nil {
+		t.Errorf("flag on but nil engine must yield nil wire (fail-open); got %+v", w)
+	}
+}

--- a/internal/cli/wrap_linux.go
+++ b/internal/cli/wrap_linux.go
@@ -15,6 +15,7 @@ import (
 	"unsafe"
 
 	"github.com/agentsh/agentsh/internal/envinject"
+	"github.com/agentsh/agentsh/internal/wrapenv"
 	"github.com/agentsh/agentsh/internal/wraphandoff"
 	"github.com/agentsh/agentsh/pkg/types"
 	"golang.org/x/sys/unix"
@@ -31,7 +32,7 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 	if wrapResp.PtraceMode {
 		notifySocket := wrapResp.NotifySocket
 
-		env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
+		env := buildWrapEnv(wrapenv.Filter(os.Environ(), wrapResp.EnvPolicy), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
 		// Overlay sandbox.env_inject so injected vars reach the command in
 		// ptrace mode too, matching the seccomp/shim paths (issue #374).
 		env = envinject.Apply(env, wrapResp.EnvInject)
@@ -135,7 +136,7 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 	}
 
 	// Build env for the wrapped process
-	env := buildWrapEnv(os.Environ(), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
+	env := buildWrapEnv(wrapenv.Filter(os.Environ(), wrapResp.EnvPolicy), sessID, cfg.serverAddr, wrapResp.SafeToBypassShellShim)
 	// Overlay operator-configured sandbox.env_inject (override semantics)
 	// before the internal markers, matching the shim and server-spawned exec
 	// paths so injected vars reach the executed command (issue #374).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -366,8 +366,8 @@ type SandboxConfig struct {
 	WrapEnvPolicy SandboxWrapEnvPolicyConfig `yaml:"wrap_env_policy"`
 }
 
-// SandboxWrapEnvPolicyConfig opts into enforcing env_policy (allow/deny/max_*)
-// on the client-spawned wrap path (shell shim / kernel-install / agentsh wrap).
+// SandboxWrapEnvPolicyConfig opts into enforcing env_policy (allow/deny) on the
+// client-spawned wrap path (shell shim / kernel-install / agentsh wrap).
 // Default off; fail-open. Issue #379.
 type SandboxWrapEnvPolicyConfig struct {
 	Enabled bool `yaml:"enabled"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -362,6 +362,15 @@ type SandboxConfig struct {
 	// EnvInject specifies environment variables to inject into every command execution.
 	// These bypass policy filtering as they are operator-configured (trusted).
 	EnvInject map[string]string `yaml:"env_inject"`
+
+	WrapEnvPolicy SandboxWrapEnvPolicyConfig `yaml:"wrap_env_policy"`
+}
+
+// SandboxWrapEnvPolicyConfig opts into enforcing env_policy (allow/deny/max_*)
+// on the client-spawned wrap path (shell shim / kernel-install / agentsh wrap).
+// Default off; fail-open. Issue #379.
+type SandboxWrapEnvPolicyConfig struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 // Validate checks cross-field constraints in the sandbox configuration.

--- a/internal/config/wrap_env_policy_test.go
+++ b/internal/config/wrap_env_policy_test.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Issue #379: sandbox.wrap_env_policy.enabled is an opt-in flag, default false.
+
+func TestWrapEnvPolicy_DefaultsOff(t *testing.T) {
+	cfg := &Config{}
+	applyDefaults(cfg)
+	if cfg.Sandbox.WrapEnvPolicy.Enabled {
+		t.Error("sandbox.wrap_env_policy.enabled must default to false")
+	}
+}
+
+func TestWrapEnvPolicy_UnmarshalsTrue(t *testing.T) {
+	var cfg Config
+	if err := yaml.Unmarshal([]byte("sandbox:\n  wrap_env_policy:\n    enabled: true\n"), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !cfg.Sandbox.WrapEnvPolicy.Enabled {
+		t.Error("sandbox.wrap_env_policy.enabled should be true after unmarshal")
+	}
+}

--- a/internal/shim/kernelinstall/install_linux.go
+++ b/internal/shim/kernelinstall/install_linux.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/agentsh/agentsh/internal/client"
 	"github.com/agentsh/agentsh/internal/envinject"
+	"github.com/agentsh/agentsh/internal/wrapenv"
 	"github.com/agentsh/agentsh/internal/wraphandoff"
 	"github.com/agentsh/agentsh/pkg/types"
 	"golang.org/x/sys/unix"
@@ -197,7 +198,7 @@ func runRelay(p InstallParams, resp types.WrapInitResponse) (Result, error) {
 	// markers (notify fd, argv0 override, wrapper config). See
 	// assembleWrapperEnv for the env_inject override and AGENTSH_SIGNAL_SOCK_FD
 	// stripping rationale (issue #374).
-	env := assembleWrapperEnv(filterShimInternalEnv(p.Env), p.Argv0, resp.WrapperEnv, resp.EnvInject)
+	env := assembleWrapperEnv(wrapenv.Filter(filterShimInternalEnv(p.Env), resp.EnvPolicy), p.Argv0, resp.WrapperEnv, resp.EnvInject)
 
 	// Build wrapper argv: wrapperBin -- realShell shellArgs...
 	// argv[0] is the wrapper binary's basename (conventional).

--- a/internal/shim/kernelinstall/wrap_env_policy_test.go
+++ b/internal/shim/kernelinstall/wrap_env_policy_test.go
@@ -1,0 +1,37 @@
+//go:build linux
+
+package kernelinstall
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/wrapenv"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// Issue #379: filtering applies to the inherited base BEFORE agentsh markers and
+// env_inject are added, so a denied var is dropped while markers and injected
+// values survive.
+func TestAssembleWrapperEnv_FiltersBaseKeepsMarkersAndInject(t *testing.T) {
+	base := []string{"PATH=/bin", "SECRET_TOKEN=x"}
+	wire := &types.EnvPolicyWire{Deny: []string{"SECRET_*"}}
+
+	filtered := wrapenv.Filter(base, wire)
+	env := assembleWrapperEnv(filtered, "", map[string]string{}, map[string]string{"INJECTED": "1"})
+
+	for _, kv := range env {
+		if kv == "SECRET_TOKEN=x" {
+			t.Error("denied var must not survive filtering")
+		}
+	}
+	if !slices.Contains(env, "INJECTED=1") {
+		t.Error("env_inject value must survive (applied after filter)")
+	}
+	if !slices.Contains(env, "AGENTSH_NOTIFY_SOCK_FD=3") {
+		t.Error("agentsh marker must survive (appended after filter)")
+	}
+	if !slices.Contains(env, "PATH=/bin") {
+		t.Error("non-denied inherited var must survive")
+	}
+}

--- a/internal/wrapenv/wrapenv.go
+++ b/internal/wrapenv/wrapenv.go
@@ -19,10 +19,8 @@ func Filter(base []string, wire *types.EnvPolicyWire) []string {
 		return base
 	}
 	pol := policy.ResolvedEnvPolicy{
-		Allow:    wire.Allow,
-		Deny:     wire.Deny,
-		MaxBytes: wire.MaxBytes,
-		MaxKeys:  wire.MaxKeys,
+		Allow: wire.Allow,
+		Deny:  wire.Deny,
 	}
 	out, err := policy.BuildEnv(pol, base, nil)
 	if err != nil {

--- a/internal/wrapenv/wrapenv.go
+++ b/internal/wrapenv/wrapenv.go
@@ -1,0 +1,33 @@
+// Package wrapenv applies env_policy filtering to the inherited environment on
+// the client-spawned wrap path (shell shim / kernel-install / agentsh wrap),
+// the counterpart to server-side buildPolicyEnv. Issue #379.
+package wrapenv
+
+import (
+	"log/slog"
+
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// Filter applies the wrapped command's env policy subtractively over the
+// inherited base environment. A nil wire returns base unchanged (fail-open for
+// the default-off and mixed-version cases). On a BuildEnv error it returns base
+// unchanged with a warning — env filtering must never block a command.
+func Filter(base []string, wire *types.EnvPolicyWire) []string {
+	if wire == nil {
+		return base
+	}
+	pol := policy.ResolvedEnvPolicy{
+		Allow:    wire.Allow,
+		Deny:     wire.Deny,
+		MaxBytes: wire.MaxBytes,
+		MaxKeys:  wire.MaxKeys,
+	}
+	out, err := policy.BuildEnv(pol, base, nil)
+	if err != nil {
+		slog.Warn("wrap env policy filter failed; passing inherited env unfiltered", "error", err)
+		return base
+	}
+	return out
+}

--- a/internal/wrapenv/wrapenv_test.go
+++ b/internal/wrapenv/wrapenv_test.go
@@ -50,14 +50,17 @@ func TestFilter_AllowIsAllowlist(t *testing.T) {
 	}
 }
 
-func TestFilter_MaxKeys(t *testing.T) {
-	base := []string{"A=1", "B=2", "C=3", "D=4"}
-	got := Filter(base, &types.EnvPolicyWire{MaxKeys: 2})
-	// BuildEnv returns an error when max_keys is exceeded (does not truncate).
-	// Filter's error-path returns base unchanged, so got == base (4 entries).
-	// The policy violation is enforced by rejecting the env outright; the
-	// caller (Filter) falls back to base to avoid blocking the command.
-	if len(got) == 0 {
-		t.Error("max_keys error path must not return empty env")
+// max_bytes/max_keys are intentionally NOT carried on the wrap path (#379):
+// BuildEnv errors on overflow, which under fail-open would revert to the full
+// unfiltered env. EnvPolicyWire therefore has no such fields; a large env is
+// filtered by allow/deny only and never rejected.
+func TestFilter_NoMaxEnforcementLargeEnvNotRejected(t *testing.T) {
+	base := []string{"A=1", "B=2", "C=3", "D=4", "SECRET_TOKEN=x"}
+	got := Filter(base, &types.EnvPolicyWire{Deny: []string{"SECRET_*"}})
+	if has(got, "SECRET_TOKEN=x") {
+		t.Error("denied var must be stripped")
+	}
+	if len(got) != 4 {
+		t.Errorf("large env must pass through (minus denied), not be rejected; got %d entries: %v", len(got), got)
 	}
 }

--- a/internal/wrapenv/wrapenv_test.go
+++ b/internal/wrapenv/wrapenv_test.go
@@ -1,0 +1,63 @@
+package wrapenv
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+func has(env []string, kv string) bool { return slices.Contains(env, kv) }
+
+func TestFilter_NilWireIsIdentity(t *testing.T) {
+	base := []string{"PATH=/bin", "FOO=bar"}
+	got := Filter(base, nil)
+	if !slices.Equal(got, base) {
+		t.Errorf("nil wire must return base unchanged; got %v", got)
+	}
+}
+
+func TestFilter_DenyStripsMatchKeepsRest(t *testing.T) {
+	base := []string{"PATH=/bin", "SECRET_TOKEN=x", "HOME=/h"}
+	got := Filter(base, &types.EnvPolicyWire{Deny: []string{"SECRET_*"}})
+	if has(got, "SECRET_TOKEN=x") {
+		t.Error("denied var must be stripped")
+	}
+	if !has(got, "PATH=/bin") || !has(got, "HOME=/h") {
+		t.Error("non-denied vars must be kept")
+	}
+}
+
+func TestFilter_DefaultSecretDenyWhenNoAllow(t *testing.T) {
+	base := []string{"PATH=/bin", "AWS_SECRET_ACCESS_KEY=zzz"}
+	got := Filter(base, &types.EnvPolicyWire{}) // empty policy, no allow
+	if has(got, "AWS_SECRET_ACCESS_KEY=zzz") {
+		t.Error("default-secret-deny var must be stripped when no allow patterns")
+	}
+	if !has(got, "PATH=/bin") {
+		t.Error("ordinary var must be kept")
+	}
+}
+
+func TestFilter_AllowIsAllowlist(t *testing.T) {
+	base := []string{"PATH=/bin", "HOME=/h", "OTHER=1"}
+	got := Filter(base, &types.EnvPolicyWire{Allow: []string{"PATH", "HOME"}})
+	if has(got, "OTHER=1") {
+		t.Error("non-allowed var must be dropped under allowlist")
+	}
+	if !has(got, "PATH=/bin") || !has(got, "HOME=/h") {
+		t.Error("allowed vars must be kept")
+	}
+}
+
+func TestFilter_MaxKeys(t *testing.T) {
+	base := []string{"A=1", "B=2", "C=3", "D=4"}
+	got := Filter(base, &types.EnvPolicyWire{MaxKeys: 2})
+	// BuildEnv returns an error when max_keys is exceeded (does not truncate).
+	// Filter's error-path returns base unchanged, so got == base (4 entries).
+	// The policy violation is enforced by rejecting the env outright; the
+	// caller (Filter) falls back to base to avoid blocking the command.
+	if len(got) == 0 {
+		t.Error("max_keys error path must not return empty env")
+	}
+}

--- a/pkg/types/sessions.go
+++ b/pkg/types/sessions.go
@@ -140,17 +140,21 @@ type WrapInitRequest struct {
 	Mode string `json:"mode,omitempty"`
 }
 
-// EnvPolicyWire carries the resolved env allow/deny/limits for the client
-// (shell shim / CLI wrap) to filter the executed command's inherited
-// environment. Nil/omitted means "no filtering" — the field is only populated
-// when sandbox.wrap_env_policy.enabled is true, which also makes mixed-version
-// deployments degrade safely. block_iteration is intentionally not carried: it
-// is not enforceable on the wrap path (shells read environ directly). Issue #379.
+// EnvPolicyWire carries the resolved env allow/deny for the client (shell shim
+// / CLI wrap) to filter the executed command's inherited environment. Nil/
+// omitted means "no filtering" — the field is only populated when
+// sandbox.wrap_env_policy.enabled is true, which also makes mixed-version
+// deployments degrade safely.
+//
+// Only allow/deny are carried. block_iteration (replaces environ, incompatible
+// with shells) and max_bytes/max_keys are intentionally NOT enforced on the
+// wrap path: BuildEnv treats a max_* overflow as a hard error, which under the
+// wrap path's fail-open contract would revert to the FULL unfiltered env —
+// silently bypassing the very allow/deny stripping the operator wanted. So the
+// wrap filter is allow/deny (+ the built-in default-secret-deny) only. Issue #379.
 type EnvPolicyWire struct {
-	Allow    []string `json:"allow,omitempty"`
-	Deny     []string `json:"deny,omitempty"`
-	MaxBytes int      `json:"max_bytes,omitempty"`
-	MaxKeys  int      `json:"max_keys,omitempty"`
+	Allow []string `json:"allow,omitempty"`
+	Deny  []string `json:"deny,omitempty"`
 }
 
 // WrapInitResponse returns the seccomp wrapper configuration to the caller.

--- a/pkg/types/sessions.go
+++ b/pkg/types/sessions.go
@@ -140,6 +140,19 @@ type WrapInitRequest struct {
 	Mode string `json:"mode,omitempty"`
 }
 
+// EnvPolicyWire carries the resolved env allow/deny/limits for the client
+// (shell shim / CLI wrap) to filter the executed command's inherited
+// environment. Nil/omitted means "no filtering" — the field is only populated
+// when sandbox.wrap_env_policy.enabled is true, which also makes mixed-version
+// deployments degrade safely. block_iteration is intentionally not carried: it
+// is not enforceable on the wrap path (shells read environ directly). Issue #379.
+type EnvPolicyWire struct {
+	Allow    []string `json:"allow,omitempty"`
+	Deny     []string `json:"deny,omitempty"`
+	MaxBytes int      `json:"max_bytes,omitempty"`
+	MaxKeys  int      `json:"max_keys,omitempty"`
+}
+
 // WrapInitResponse returns the seccomp wrapper configuration to the caller.
 //
 // To decide whether to install kernel filters, the caller MUST inspect the
@@ -167,4 +180,8 @@ type WrapInitResponse struct {
 	// applied client-side; on the server-spawned exec path env_inject is
 	// applied directly in internal/api/exec.go instead. Issue #374.
 	EnvInject map[string]string `json:"env_inject,omitempty"`
+	// EnvPolicy carries the resolved env allow/deny/limits for the client to
+	// filter the executed command's inherited environment, when
+	// sandbox.wrap_env_policy.enabled is set. Nil ⇒ no filtering. Issue #379.
+	EnvPolicy *EnvPolicyWire `json:"env_policy,omitempty"`
 }

--- a/pkg/types/sessions.go
+++ b/pkg/types/sessions.go
@@ -184,7 +184,7 @@ type WrapInitResponse struct {
 	// applied client-side; on the server-spawned exec path env_inject is
 	// applied directly in internal/api/exec.go instead. Issue #374.
 	EnvInject map[string]string `json:"env_inject,omitempty"`
-	// EnvPolicy carries the resolved env allow/deny/limits for the client to
+	// EnvPolicy carries the resolved env allow/deny for the client to
 	// filter the executed command's inherited environment, when
 	// sandbox.wrap_env_policy.enabled is set. Nil ⇒ no filtering. Issue #379.
 	EnvPolicy *EnvPolicyWire `json:"env_policy,omitempty"`


### PR DESCRIPTION
## Summary

On the client-spawned wrap path (shell shim / kernel-install / `agentsh wrap`), the executed command inherited the launcher's **full environment** with no env-policy filtering — `policy.BuildEnv` ran only on the server-spawned exec path. So `env_policy` allow/deny provided **no isolation** on the wrap path: commands (including any secrets in the launcher env) saw everything. #374 plumbed `env_inject` through this path; this closes the env_policy gap.

This adds an **opt-in** flag `sandbox.wrap_env_policy.enabled` (default **off**). When enabled, the server resolves the wrapped command's env policy and sends it via `WrapInitResponse.EnvPolicy`; the client applies a **subtractive** `policy.BuildEnv` filter over the inherited env. **Default-off ⇒ zero change** for existing deployments.

## Behavior (when enabled)

- `deny` + the built-in `defaultSecretDeny` list strip secrets; `env_allow` (when set) tightens to an allowlist.
- Filtering runs on the **inherited launcher env only, before** agentsh markers and `env_inject` are added — so agentsh's own vars and operator `env_inject` always survive, and `env_inject` still overrides.
- **Fail-open:** nil engine / nil wire / `BuildEnv` error ⇒ inherited env unchanged; a command is never blocked by env filtering.
- **Mixed-version safe:** old server ⇒ field absent ⇒ no filtering; old client ⇒ ignores the field ⇒ no filtering.

## Scope (intentional non-enforcement on this path)

- `block_iteration` — relies on replacing `environ`, incompatible with shells.
- `max_bytes` / `max_keys` — `policy.BuildEnv` *errors* (doesn't truncate) on overflow; under the fail-open contract that would revert to the **full** unfiltered env, silently bypassing the allow/deny stripping. So the wrap filter is **allow/deny (+ default-secret-deny) only**. Documented on the config field and wire type.

## Changes

- `pkg/types/sessions.go` — `EnvPolicyWire{Allow,Deny}` (primitive; `pkg/types` can't import `internal/policy`) + `EnvPolicy *EnvPolicyWire` on `WrapInitResponse`.
- `internal/config/config.go` — `sandbox.wrap_env_policy.enabled` (default off).
- `internal/wrapenv/wrapenv.go` (new) — `Filter(base, wire)`: subtractive, fail-open.
- `internal/api/wrap.go` — `wrapEnvPolicyWire` (nil when disabled / no engine); populates `EnvPolicy` at both response sites.
- `internal/cli/wrap_linux.go` (ptrace + seccomp) and `internal/shim/kernelinstall/install_linux.go` — filter the inherited base before markers.

## Test plan

- [x] `go build ./...` and `GOOS=windows go build ./...`
- [x] `go vet` + `gofmt -l` clean
- [x] `go test ./pkg/types/ ./internal/config/ ./internal/wrapenv/ ./internal/api/ ./internal/cli/ ./internal/shim/kernelinstall/ ./internal/policy/`
- [x] `wrapenv.Filter` matrix (nil-identity, deny, default-secret-deny, allowlist, no-max-enforcement); server gating incl. nil-engine fail-open; kernelinstall ordering (denied dropped, markers + env_inject survive)
- Note: pre-existing/environmental `TestFUSE_FsyncFlushLseekPassthrough` (FUSE mount perms) is unrelated and fails identically on `main`.

Closes #379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)