### PR TITLE
fix(#388): detect seccomp-execve/user-notify from a real NEW_LISTENER install probe

### DIFF
--- a/docs/superpowers/plans/2026-05-25-issue-388-seccomp-install-probe.md
+++ b/docs/superpowers/plans/2026-05-25-issue-388-seccomp-install-probe.md
@@ -543,7 +543,10 @@ In `internal/capabilities/detect_linux.go`, add a helper (near the top of the fi
 
 ```go
 // seccompBackendDetail explains the seccomp verdict, distinguishing
-// "kernel-supported" from "installable here" (issue #388).
+// "kernel-supported" from "installable here" (issue #388). caps.SeccompInstallDetail
+// already reads like "NEW_LISTENER filter install failed: EBUSY (errno 16)"
+// (set by realCheckSeccompInstall), so this only prepends the kernel-support
+// context — no double "install failed" wording.
 func seccompBackendDetail(caps *SecurityCapabilities) string {
 	if caps.SeccompInstallable {
 		return ""
@@ -551,9 +554,9 @@ func seccompBackendDetail(caps *SecurityCapabilities) string {
 	if caps.Seccomp {
 		d := caps.SeccompInstallDetail
 		if d == "" {
-			d = "install failed"
+			d = "NEW_LISTENER install failed here"
 		}
-		return "kernel supports user-notify, but NEW_LISTENER install failed here: " + d
+		return "kernel supports user-notify, but " + d
 	}
 	return "" // kernel doesn't support user-notify; existing Available=false speaks for itself
 }

--- a/docs/superpowers/plans/2026-05-25-issue-388-seccomp-install-probe.md
+++ b/docs/superpowers/plans/2026-05-25-issue-388-seccomp-install-probe.md
@@ -1,0 +1,667 @@
+# Honest seccomp installability in `detect` (#388) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `agentsh detect` report `seccomp-execve`/`seccomp_user_notify` (and the Command Control score) from a real `NEW_LISTENER` install attempt — not a read-only probe — so environments where the install fails (e.g. Daytona EBUSY) are reported honestly.
+
+**Architecture:** A throwaway re-exec child (reusing the #369 two-factor-gate pattern) runs the exact `loadRawFilter` install the runtime uses and reports success or the failing errno. The parent (`capabilities`, non-cgo) reads the child's exit code/stderr; the child (cgo, linked into the agentsh binary) does the install. `detect`'s display + score derive from this new "installable here" signal; the read-only probe stays as the "kernel-supported" signal. Runtime/startup gating is untouched.
+
+**Tech Stack:** Go; `internal/netmonitor/unix` (cgo seccomp), `internal/capabilities`.
+
+**Spec:** `docs/superpowers/specs/2026-05-25-issue-388-seccomp-install-probe-design.md`
+
+**Verified facts (don't re-derive):**
+- Real install: `loadRawFilter(prog []byte, withWaitKill bool) (int, error)` (`internal/netmonitor/unix/seccomp_load_linux.go`, `//go:build linux && cgo`): does `runtime.LockOSThread()` → `prctl(PR_SET_NO_NEW_PRIVS)` → `seccomp(SET_MODE_FILTER, NEW_LISTENER[|WAIT_KILLABLE_RECV])`. Returns the listener fd or an error wrapping the errno.
+- `buildProbeFilterBytes() ([]byte, error)` and `exportFilterBPF` exist in the same package (`wait_killable_probe_runner_linux.go`, cgo): `ActAllow` default + `ActNotify` on socket/openat/etc. The default-allow means `close`/`write`/`exit_group` are NOT trapped.
+- Re-exec child precedent (`wait_killable_probe_runner_linux.go`): `init()` calls `isProbeChildInvocation()` (argv[1] == a sentinel AND env token len ≥ 16) and, if matched, runs the child then `os.Exit`. Parent builds argv via `os.Executable()` + sentinel and an env token. `internal/api` imports `netmonitor/unix`; `cmd/agentsh` imports `internal/api` → the child `init()` is linked into the `agentsh` binary (and into the package's own `go test` binary). The package has non-cgo stubs and does NOT import `internal/capabilities` (no cycle).
+- `boundedBuffer` (write-capped buffer) already exists in `wait_killable_probe_runner_linux.go` — reuse it for child stderr capture.
+- `internal/capabilities`: `SecurityCapabilities` struct is defined in BOTH `security_caps.go` (`//go:build linux`) and `security_caps_other.go` (non-linux), with fields `Seccomp bool` / `SeccompBasic bool`. Populated in `security_caps.go` (~L67): `caps.Seccomp = checkSeccompUserNotify().Available`. Check seams are package vars in `check.go` (`checkSeccompUserNotify = realCheckSeccompUserNotify`, etc.); `CheckResult{Feature string; ConfigKey string; Available bool; Error error; Suggestion string}`.
+- `detect_linux.go`: `buildLinuxDomains` sets `seccomp-notify` (L86) and `seccomp-execve` (L93) backends with `Available: caps.Seccomp`. `backwardCompatCaps` (L218) has `"seccomp": caps.Seccomp`, `"seccomp_user_notify": caps.Seccomp`, `"seccomp_basic": caps.SeccompBasic`. `ComputeScore` (`detect_result.go:74`) gives a domain its full Weight iff ANY backend is `Available`. **Do NOT touch** `detectFileEnforcementBackend` (L15), `SelectMode` (`security_caps.go:100`), or the `Active` labels — those feed runtime mode selection (non-goal).
+
+---
+
+## File Structure
+
+- `internal/netmonitor/unix/seccomp_install_probe_linux.go` (new, `linux && cgo`) — `InstallProbeResult`, `ProbeSeccompInstall` (cached), the classifier, the injectable `runInstallProbe` seam, the child `init()` + `runInstallProbeChild`, contract constants.
+- `internal/netmonitor/unix/seccomp_install_probe_stub.go` (new, `!linux || !cgo`) — stub `InstallProbeResult` + `ProbeSeccompInstall`.
+- `internal/netmonitor/unix/seccomp_install_probe_linux_test.go` (new) — classifier unit tests (injected seam) + a real re-exec integration test.
+- `internal/capabilities/check_seccomp_linux.go` — `realCheckSeccompInstall`; `internal/capabilities/check.go` — `checkSeccompInstall` seam var.
+- `internal/capabilities/security_caps.go` + `security_caps_other.go` — `SeccompInstallable bool` + `SeccompInstallDetail string` fields; populate in `security_caps.go`.
+- `internal/capabilities/detect_linux.go` — flip the two backend `Available` + add detail; update `backwardCompatCaps`.
+- `internal/capabilities/detect_linux_test.go` (new or existing) — verdict/score/detail tests.
+
+---
+
+## Task 1: Install-probe (child + parent classifier + stub)
+
+**Files:**
+- Create: `internal/netmonitor/unix/seccomp_install_probe_linux.go`
+- Create: `internal/netmonitor/unix/seccomp_install_probe_stub.go`
+- Create: `internal/netmonitor/unix/seccomp_install_probe_linux_test.go`
+
+- [ ] **Step 1: Write the failing classifier + stub-contract tests**
+
+Create `internal/netmonitor/unix/seccomp_install_probe_linux_test.go`:
+
+```go
+//go:build linux && cgo
+
+package unix
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+)
+
+func TestClassifyInstallProbe(t *testing.T) {
+	cases := []struct {
+		name       string
+		exitCode   int
+		stderr     string
+		spawnErr   error
+		wantInst   bool
+		wantErrno  syscall.Errno
+	}{
+		{"success", 0, "", nil, true, 0},
+		{"ebusy", 1, "install filter: ... INSTALL_ERRNO=16\n", nil, false, syscall.EBUSY},
+		{"eperm", 1, "INSTALL_ERRNO=1\n", nil, false, syscall.EPERM},
+		{"einval", 1, "INSTALL_ERRNO=22\n", nil, false, syscall.EINVAL},
+		{"nonerrno_setup_fail", 1, "build filter: boom\n", nil, false, 0},
+		{"spawn_error", -1, "", errors.New("fork failed"), false, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyInstallProbe(tc.exitCode, tc.stderr, tc.spawnErr)
+			if got.Installable != tc.wantInst {
+				t.Fatalf("Installable=%v, want %v (detail=%q)", got.Installable, tc.wantInst, got.Detail)
+			}
+			if got.Errno != tc.wantErrno {
+				t.Errorf("Errno=%v (%d), want %v (%d)", got.Errno, got.Errno, tc.wantErrno, tc.wantErrno)
+			}
+			if !got.Installable && got.Detail == "" {
+				t.Error("not-installable result must carry a non-empty Detail")
+			}
+		})
+	}
+}
+
+// Real end-to-end: re-exec this test binary as the install-probe child and
+// confirm the mechanism runs and returns a coherent verdict. On a kernel that
+// supports user-notify the install succeeds; otherwise it reports a recognized
+// errno (never a false positive). Skips only if the kernel lacks user-notify.
+func TestProbeSeccompInstall_Integration(t *testing.T) {
+	if probeSeccompUserNotifyKernel() != nil {
+		t.Skip("kernel lacks user-notify; install probe not meaningful here")
+	}
+	res := ProbeSeccompInstall()
+	if !res.Installable && res.Errno == 0 && res.Detail == "" {
+		t.Fatalf("incoherent probe result: %+v", res)
+	}
+	if !res.Installable {
+		t.Logf("install not available here: errno=%v detail=%q", res.Errno, res.Detail)
+	}
+}
+```
+
+(`probeSeccompUserNotifyKernel` is a tiny local helper for the skip guard — Step 3 defines it as a read-only `SECCOMP_GET_NOTIF_SIZES` check returning an error when unsupported.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/netmonitor/unix/ -run 'ClassifyInstallProbe|ProbeSeccompInstall_Integration' 2>&1 | head`
+Expected: FAIL — `classifyInstallProbe`, `ProbeSeccompInstall`, `probeSeccompUserNotifyKernel` undefined.
+
+- [ ] **Step 3: Implement the install-probe (cgo file)**
+
+Create `internal/netmonitor/unix/seccomp_install_probe_linux.go`:
+
+```go
+//go:build linux && cgo
+
+package unix
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Issue #388: detect must report seccomp enforcement from a REAL NEW_LISTENER
+// install, not a read-only capability probe. This probe re-execs a throwaway
+// child that runs the exact loadRawFilter install the runtime uses and reports
+// success or the failing errno.
+
+const (
+	installProbeArgvSentinel = "--agentsh-internal-seccomp-install-probe-child-v1"
+	installProbeEnv          = "AGENTSH_SECCOMP_INSTALL_PROBE_CHILD"
+	installProbeStderrCap    = 4096
+	// installErrnoPrefix is printed by the child on failure so the parent can
+	// recover the precise errno without encoding it in the exit status.
+	installErrnoPrefix = "INSTALL_ERRNO="
+)
+
+// InstallProbeResult reports whether agentsh can install its NEW_LISTENER
+// seccomp filter in this environment. Errno is 0 when Installable.
+type InstallProbeResult struct {
+	Installable bool
+	Errno       syscall.Errno
+	Detail      string
+}
+
+// runInstallProbe spawns the probe child and returns its exit code, captured
+// (bounded) stderr, and any spawn error. Injectable seam for tests.
+var runInstallProbe = realRunInstallProbe
+
+var (
+	installProbeOnce   sync.Once
+	installProbeResult InstallProbeResult
+)
+
+// ProbeSeccompInstall returns whether a NEW_LISTENER filter install succeeds
+// here. Cached per process. Fail-safe: any inability to run the probe yields
+// Installable=false with a descriptive Detail — never a false positive.
+func ProbeSeccompInstall() InstallProbeResult {
+	installProbeOnce.Do(func() {
+		code, stderr, err := runInstallProbe()
+		installProbeResult = classifyInstallProbe(code, stderr, err)
+	})
+	return installProbeResult
+}
+
+func classifyInstallProbe(exitCode int, stderr string, spawnErr error) InstallProbeResult {
+	if spawnErr != nil {
+		return InstallProbeResult{Installable: false, Detail: fmt.Sprintf("install probe could not run: %v", spawnErr)}
+	}
+	if exitCode == 0 {
+		return InstallProbeResult{Installable: true}
+	}
+	if errno := parseInstallErrno(stderr); errno != 0 {
+		return InstallProbeResult{Installable: false, Errno: errno, Detail: fmt.Sprintf("%s (errno %d)", errno, int(errno))}
+	}
+	detail := strings.TrimSpace(stderr)
+	if detail == "" {
+		detail = fmt.Sprintf("install probe exited %d", exitCode)
+	}
+	return InstallProbeResult{Installable: false, Detail: detail}
+}
+
+func parseInstallErrno(stderr string) syscall.Errno {
+	for _, line := range strings.Split(stderr, "\n") {
+		i := strings.Index(line, installErrnoPrefix)
+		if i < 0 {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimSpace(line[i+len(installErrnoPrefix):]))
+		if err == nil && n > 0 {
+			return syscall.Errno(n)
+		}
+	}
+	return 0
+}
+
+func realRunInstallProbe() (int, string, error) {
+	bin, err := os.Executable()
+	if err != nil {
+		return -1, "", fmt.Errorf("os.Executable: %w", err)
+	}
+	cmd := exec.Command(bin, installProbeArgvSentinel)
+	cmd.Env = append(os.Environ(), installProbeEnv+"="+ensureProbeChildToken())
+	stderr := &boundedBuffer{cap: installProbeStderrCap}
+	cmd.Stdout = nil
+	cmd.Stderr = stderr
+	cmd.Stdin = nil
+	runErr := cmd.Run()
+	if runErr == nil {
+		return 0, stderr.String(), nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		return exitErr.ExitCode(), stderr.String(), nil // non-zero exit, not a spawn failure
+	}
+	return -1, stderr.String(), runErr // could not start / other
+}
+
+// isInstallProbeChildInvocation gates probe-child mode (two-factor: argv
+// sentinel + env token length >= 16), mirroring isProbeChildInvocation.
+func isInstallProbeChildInvocation() bool {
+	if len(os.Args) < 2 || os.Args[1] != installProbeArgvSentinel {
+		return false
+	}
+	return len(os.Getenv(installProbeEnv)) >= 16
+}
+
+func init() {
+	if isInstallProbeChildInvocation() {
+		runInstallProbeChild()
+		os.Exit(0) // unreachable: runInstallProbeChild always exits
+	}
+}
+
+// runInstallProbeChild installs the probe filter via the SAME loadRawFilter the
+// runtime uses, then exits. The filter's ActAllow default means the child's own
+// close/write/exit syscalls are never trapped, so no servicing is needed and
+// the child cannot hang. Exits 0 on install success; on failure prints
+// INSTALL_ERRNO=<n> (when the error is an errno) and exits 1.
+func runInstallProbeChild() {
+	prog, err := buildProbeFilterBytes()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "seccomp install probe: build filter: %v\n", err)
+		os.Exit(1)
+	}
+	fd, err := loadRawFilter(prog, false)
+	if err != nil {
+		var errno syscall.Errno
+		if errors.As(err, &errno) {
+			fmt.Fprintf(os.Stderr, "seccomp install probe: install filter: %v %s%d\n", err, installErrnoPrefix, int(errno))
+		} else {
+			fmt.Fprintf(os.Stderr, "seccomp install probe: install filter: %v\n", err)
+		}
+		os.Exit(1)
+	}
+	_ = unix.Close(fd)
+	os.Exit(0)
+}
+
+// probeSeccompUserNotifyKernel is a read-only "does the kernel know user-notify"
+// check (SECCOMP_GET_NOTIF_SIZES), used only as a test skip guard. Returns nil
+// when supported.
+func probeSeccompUserNotifyKernel() error {
+	var sizes [3]uint16 // struct seccomp_notif_sizes { __u16 seccomp_notif, seccomp_notif_resp, seccomp_data; }
+	_, _, errno := unix.Syscall(unix.SYS_SECCOMP, unix.SECCOMP_GET_NOTIF_SIZES, 0, uintptr(unsafe.Pointer(&sizes)))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Implement the stub (non-cgo / non-linux)**
+
+Create `internal/netmonitor/unix/seccomp_install_probe_stub.go`:
+
+```go
+//go:build !linux || !cgo
+
+package unix
+
+import "syscall"
+
+// InstallProbeResult mirrors the cgo type so callers compile on every target.
+type InstallProbeResult struct {
+	Installable bool
+	Errno       syscall.Errno
+	Detail      string
+}
+
+// ProbeSeccompInstall is a stub for non-Linux / linux-without-cgo builds: there
+// is no probe-child handler compiled in, so there is nothing to re-exec.
+func ProbeSeccompInstall() InstallProbeResult {
+	return InstallProbeResult{Installable: false, Detail: "seccomp install probe unavailable (no cgo / unsupported OS)"}
+}
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `go test ./internal/netmonitor/unix/ -run 'ClassifyInstallProbe|ProbeSeccompInstall_Integration' -v`
+Expected: classifier cases PASS; integration test PASSes (Installable=true on a normal kernel) or skips if user-notify is unsupported.
+
+- [ ] **Step 6: Build (cgo + non-cgo) and full package**
+
+Run: `go build ./... && CGO_ENABLED=0 go build ./internal/netmonitor/unix/ && go test ./internal/netmonitor/unix/`
+Expected: both builds succeed (stub covers non-cgo); package tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/netmonitor/unix/seccomp_install_probe_linux.go internal/netmonitor/unix/seccomp_install_probe_stub.go internal/netmonitor/unix/seccomp_install_probe_linux_test.go
+git commit -m "feat(#388): seccomp NEW_LISTENER install probe (re-exec child)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: capabilities — `SeccompInstallable` signal
+
+**Files:**
+- Modify: `internal/capabilities/security_caps.go` (struct field + populate)
+- Modify: `internal/capabilities/security_caps_other.go` (struct field — non-linux parity)
+- Modify: `internal/capabilities/check.go` (seam var)
+- Modify: `internal/capabilities/check_seccomp_linux.go` (realCheckSeccompInstall)
+- Create: `internal/capabilities/seccomp_install_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/capabilities/seccomp_install_test.go`:
+
+```go
+//go:build linux
+
+package capabilities
+
+import "testing"
+
+// Issue #388: SeccompInstallable comes from the real install probe, distinct
+// from the read-only Seccomp (kernel-supported) signal.
+func TestDetectSecurityCapabilities_SeccompInstallable(t *testing.T) {
+	origUN, origInstall := checkSeccompUserNotify, checkSeccompInstall
+	defer func() { checkSeccompUserNotify, checkSeccompInstall = origUN, origInstall }()
+
+	checkSeccompUserNotify = func() CheckResult { return CheckResult{Feature: "seccomp-user-notify", Available: true} }
+	checkSeccompInstall = func() CheckResult { return CheckResult{Feature: "seccomp-install", Available: false, Error: errForTest("EBUSY (errno 16)")} }
+
+	caps := DetectSecurityCapabilities()
+	if !caps.Seccomp {
+		t.Error("Seccomp (kernel-supported) should be true")
+	}
+	if caps.SeccompInstallable {
+		t.Error("SeccompInstallable should be false when the install probe fails")
+	}
+	if caps.SeccompInstallDetail == "" {
+		t.Error("SeccompInstallDetail should carry the failure reason")
+	}
+}
+```
+
+Add a tiny test helper at the bottom of the same file:
+
+```go
+type testErr string
+
+func (e testErr) Error() string { return string(e) }
+func errForTest(s string) error { return testErr(s) }
+```
+
+(If `DetectSecurityCapabilities` is not the exported constructor name, use the actual one — confirm with `grep -n "func DetectSecurityCapabilities\|func DetectSecurity" internal/capabilities/security_caps.go`. The verified populate site is `security_caps.go:67`.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/capabilities/ -run TestDetectSecurityCapabilities_SeccompInstallable -v`
+Expected: FAIL — `checkSeccompInstall` / `caps.SeccompInstallable` / `caps.SeccompInstallDetail` undefined.
+
+- [ ] **Step 3: Add struct fields**
+
+In `internal/capabilities/security_caps.go`, add to `SecurityCapabilities` (immediately after `SeccompBasic bool`):
+
+```go
+	SeccompInstallable bool   // a real NEW_LISTENER filter install succeeds here (issue #388)
+	SeccompInstallDetail string // why install is unavailable, when SeccompInstallable is false
+```
+
+Add the **same two fields** to the `SecurityCapabilities` struct in `internal/capabilities/security_caps_other.go` (non-linux parity, so cross-compiles).
+
+- [ ] **Step 4: Add the check seam + real check**
+
+In `internal/capabilities/check.go`, add to the `var (...)` seam block:
+
+```go
+	checkSeccompInstall = realCheckSeccompInstall
+```
+
+In `internal/capabilities/check_seccomp_linux.go`, add (import `github.com/agentsh/agentsh/internal/netmonitor/unix` as `unixmon`):
+
+```go
+func realCheckSeccompInstall() CheckResult {
+	res := unixmon.ProbeSeccompInstall()
+	r := CheckResult{Feature: "seccomp-install", Available: res.Installable}
+	if !res.Installable {
+		r.Error = fmt.Errorf("NEW_LISTENER filter install failed: %s", res.Detail)
+	}
+	return r
+}
+```
+
+For non-linux builds, add a `realCheckSeccompInstall` returning `CheckResult{Feature: "seccomp-install", Available: false}` in the existing non-linux check file (mirror how `realCheckSeccompUserNotify` is stubbed for non-linux; if there's a `check_other.go`, add it there).
+
+- [ ] **Step 5: Populate in DetectSecurityCapabilities**
+
+In `internal/capabilities/security_caps.go`, immediately after `caps.SeccompBasic = checkSeccompBasic()` (~L68):
+
+```go
+	{
+		r := checkSeccompInstall()
+		caps.SeccompInstallable = r.Available
+		if r.Error != nil {
+			caps.SeccompInstallDetail = r.Error.Error()
+		}
+	}
+```
+
+- [ ] **Step 6: Run to verify it passes + build**
+
+Run: `go test ./internal/capabilities/ -run TestDetectSecurityCapabilities_SeccompInstallable -v && go build ./... && GOOS=windows go build ./...`
+Expected: test PASS; both builds OK (non-linux struct parity + check stub).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/capabilities/security_caps.go internal/capabilities/security_caps_other.go internal/capabilities/check.go internal/capabilities/check_seccomp_linux.go internal/capabilities/seccomp_install_test.go
+git commit -m "feat(#388): SeccompInstallable capability from the install probe
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+(If a non-linux check file also changed, add it to the `git add` list.)
+
+---
+
+## Task 3: detect display + score from `SeccompInstallable`
+
+**Files:**
+- Modify: `internal/capabilities/detect_linux.go` (two backends + backwardCompatCaps)
+- Modify/Create: `internal/capabilities/detect_linux_test.go`
+
+- [ ] **Step 1: Write the failing detect test**
+
+Add to `internal/capabilities/detect_linux_test.go` (create if absent, `//go:build linux`, `package capabilities`):
+
+```go
+//go:build linux
+
+package capabilities
+
+import "strings"
+import "testing"
+
+func TestBuildLinuxDomains_SeccompInstallFalseFlipsVerdictAndScore(t *testing.T) {
+	caps := &SecurityCapabilities{
+		Seccomp:              true,  // kernel-supported
+		SeccompInstallable:   false, // but install fails here (e.g. Daytona EBUSY)
+		SeccompInstallDetail: "EBUSY (errno 16)",
+	}
+	domains := buildLinuxDomains(caps)
+
+	exec := findBackend(t, domains, "Command Control", "seccomp-execve")
+	if exec.Available {
+		t.Error("seccomp-execve must be unavailable when install fails")
+	}
+	if !strings.Contains(exec.Detail, "EBUSY") || !strings.Contains(strings.ToLower(exec.Detail), "kernel") {
+		t.Errorf("seccomp-execve detail should name both kernel-support and the errno; got %q", exec.Detail)
+	}
+	notify := findBackend(t, domains, "File Protection", "seccomp-notify")
+	if notify.Available {
+		t.Error("seccomp-notify must be unavailable when install fails")
+	}
+
+	// With seccomp the only command backend, Command Control score must drop.
+	caps.Ptrace = false
+	domains = buildLinuxDomains(caps)
+	cc := findDomain(t, domains, "Command Control")
+	if ComputeScore([]ProtectionDomain{cc}) != 0 {
+		t.Error("Command Control should score 0 when neither seccomp-execve nor ptrace is available")
+	}
+}
+
+func TestBuildLinuxDomains_SeccompInstallTrueKeepsVerdict(t *testing.T) {
+	caps := &SecurityCapabilities{Seccomp: true, SeccompInstallable: true}
+	domains := buildLinuxDomains(caps)
+	if !findBackend(t, domains, "Command Control", "seccomp-execve").Available {
+		t.Error("seccomp-execve must be available when install succeeds")
+	}
+}
+
+func findDomain(t *testing.T, domains []ProtectionDomain, name string) ProtectionDomain {
+	t.Helper()
+	for _, d := range domains {
+		if d.Name == name {
+			return d
+		}
+	}
+	t.Fatalf("domain %q not found", name)
+	return ProtectionDomain{}
+}
+
+func findBackend(t *testing.T, domains []ProtectionDomain, domain, backend string) DetectedBackend {
+	t.Helper()
+	d := findDomain(t, domains, domain)
+	for _, b := range d.Backends {
+		if b.Name == backend {
+			return b
+		}
+	}
+	t.Fatalf("backend %q not found in %q", backend, domain)
+	return DetectedBackend{}
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `go test ./internal/capabilities/ -run TestBuildLinuxDomains_SeccompInstall -v`
+Expected: FAIL — `seccomp-execve`/`seccomp-notify` are still `Available: caps.Seccomp` (true), so the unavailable assertions fail.
+
+- [ ] **Step 3: Add a detail helper + flip the two backends**
+
+In `internal/capabilities/detect_linux.go`, add a helper (near the top of the file):
+
+```go
+// seccompBackendDetail explains the seccomp verdict, distinguishing
+// "kernel-supported" from "installable here" (issue #388).
+func seccompBackendDetail(caps *SecurityCapabilities) string {
+	if caps.SeccompInstallable {
+		return ""
+	}
+	if caps.Seccomp {
+		d := caps.SeccompInstallDetail
+		if d == "" {
+			d = "install failed"
+		}
+		return "kernel supports user-notify, but NEW_LISTENER install failed here: " + d
+	}
+	return "" // kernel doesn't support user-notify; existing Available=false speaks for itself
+}
+```
+
+In `buildLinuxDomains`, change the `seccomp-notify` backend (L86) and `seccomp-execve` backend (L93) from `Available: caps.Seccomp, Detail: ""` to:
+
+```go
+				{Name: "seccomp-notify", Available: caps.SeccompInstallable, Detail: seccompBackendDetail(caps), Description: "openat/stat enforcement", CheckMethod: "probe"},
+```
+```go
+				{Name: "seccomp-execve", Available: caps.SeccompInstallable, Detail: seccompBackendDetail(caps), Description: "execve interception", CheckMethod: "probe"},
+```
+
+- [ ] **Step 4: Update backwardCompatCaps**
+
+In `internal/capabilities/detect_linux.go` `backwardCompatCaps`, change the `seccomp_user_notify` entry and add a kernel-supported key:
+
+```go
+		"seccomp":                    caps.Seccomp,
+		"seccomp_user_notify":        caps.SeccompInstallable,        // installable here (issue #388)
+		"seccomp_user_notify_kernel": caps.Seccomp,                   // kernel-supported (read-only probe)
+		"seccomp_basic":              caps.SeccompBasic,
+```
+
+- [ ] **Step 4b: Clear `SeccompInstallable` when the wrapper is missing**
+
+In `internal/capabilities/detect_linux.go` `applyWrapperAvailability`, alongside the existing `secCaps.Seccomp = false` (the "Wrapper missing — clear secCaps fields" block, ~L156), add:
+
+```go
+	secCaps.SeccompInstallable = false
+```
+
+so the `seccomp_user_notify` map entry (now sourced from `SeccompInstallable`) is also false when the wrapper is absent. (The domain-loop already disables the `wrapperDependentBackends` seccomp backends, so this is for `backwardCompatCaps` consistency.)
+
+- [ ] **Step 4c: Fix the existing `TestApplyWrapperAvailability_Present`**
+
+That test (`internal/capabilities/detect_linux_test.go`) builds `caps := &SecurityCapabilities{Seccomp: true, Landlock: true, ...}` and asserts `seccomp-notify`/`seccomp-execve` are **available** when the wrapper is present. Now that those backends read `caps.SeccompInstallable`, add `SeccompInstallable: true` to that struct literal:
+
+```go
+	caps := &SecurityCapabilities{
+		Seccomp:            true,
+		SeccompInstallable: true,
+		Landlock:           true,
+		LandlockABI:        5,
+		FUSE:               true,
+		Ptrace:             true,
+	}
+```
+
+The wrapper-missing tests (`TestApplyWrapperAvailability_Missing*`, `TestDetect_WrapperMissing_Tip`) assert those backends are **un**available, which still holds (they default false), so they need no change.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `go test ./internal/capabilities/ -run TestBuildLinuxDomains_SeccompInstall -v`
+Expected: PASS (both).
+
+- [ ] **Step 6: Full capabilities package + build**
+
+Run: `go test ./internal/capabilities/ && go build ./... && GOOS=windows go build ./...`
+Expected: package tests pass (Step 4c already updated the one existing test that asserted the old verdict); builds OK.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/capabilities/detect_linux.go internal/capabilities/detect_linux_test.go
+git commit -m "fix(#388): detect seccomp verdicts + score from real install probe
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Build matrix**
+
+Run: `go build ./... && GOOS=windows go build ./... && CGO_ENABLED=0 go build ./internal/netmonitor/unix/ ./internal/capabilities/`
+Expected: all succeed (cgo + non-cgo + windows).
+
+- [ ] **Step 2: Vet + gofmt**
+
+Run: `go vet ./internal/netmonitor/unix/ ./internal/capabilities/ && gofmt -l internal/netmonitor/unix/seccomp_install_probe_linux.go internal/netmonitor/unix/seccomp_install_probe_stub.go internal/netmonitor/unix/seccomp_install_probe_linux_test.go internal/capabilities/security_caps.go internal/capabilities/security_caps_other.go internal/capabilities/check.go internal/capabilities/check_seccomp_linux.go internal/capabilities/detect_linux.go internal/capabilities/seccomp_install_test.go internal/capabilities/detect_linux_test.go`
+Expected: vet clean; `gofmt -l` prints nothing.
+
+- [ ] **Step 3: Affected package tests**
+
+Run: `go test ./internal/netmonitor/unix/ ./internal/capabilities/`
+Expected: ok for both.
+
+- [ ] **Step 4: Manual smoke (optional, informational)**
+
+Run: `go run ./cmd/agentsh detect 2>&1 | grep -iA1 seccomp || true`
+Expected: on this dev host (install works) `seccomp-execve` shows available; the point is no crash and the verdict reflects a real install.
+
+- [ ] **Step 5: Commit any formatting fixes (only if Step 2 changed files)**
+
+```bash
+git add -A && git commit -m "chore(#388): gofmt" || echo "nothing to commit"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** install-probe child+parent+stub reusing `buildProbeFilterBytes`/`loadRawFilter` (Task 1) ← spec §1; `SeccompInstallable` signal + seam (Task 2) ← spec §2; detect verdicts/score/detail from installability + dual-signal map, runtime untouched (Task 3) ← spec §2 + non-goals; cgo/non-cgo + windows builds (Tasks 1/2/4). Non-goals respected: `SelectMode`/`detectFileEnforcementBackend`/`Active` and runtime/startup gating untouched; read-only signal retained (`seccomp`, `seccomp_user_notify_kernel`); fail-safe classifier (spawn error / unparseable ⇒ not installable, never false positive).
+- **Type/name consistency:** `InstallProbeResult{Installable,Errno,Detail}`, `ProbeSeccompInstall()`, `classifyInstallProbe`, `runInstallProbe` seam, `installProbeArgvSentinel`/`installProbeEnv`, `checkSeccompInstall`/`realCheckSeccompInstall`, `caps.SeccompInstallable`/`SeccompInstallDetail`, `buildLinuxDomains`/`ComputeScore`/`DetectedBackend`/`ProtectionDomain` — consistent across tasks and match verified facts.
+- **Build-green per commit:** Task 1 = new files only; Task 2 consumes Task 1's `ProbeSeccompInstall`; Task 3 consumes Task 2's field. Each compiles.
+- **No placeholders:** every step has concrete code/commands. The constructor name (`DetectSecurityCapabilities`) and the one existing test that asserted the old verdict (`TestApplyWrapperAvailability_Present`, fixed in Task 3 Step 4c) are both verified, not open questions.

--- a/docs/superpowers/specs/2026-05-25-issue-388-seccomp-install-probe-design.md
+++ b/docs/superpowers/specs/2026-05-25-issue-388-seccomp-install-probe-design.md
@@ -1,0 +1,102 @@
+# Honest seccomp installability in `detect` Design
+
+Issue: #388
+
+## Summary
+
+`agentsh detect` reports `seccomp-execve ✓` and `seccomp_user_notify ✓` (Command Control 25/25) from **read-only** capability probes (`seccomp(SECCOMP_GET_ACTION_AVAIL)`, `seccomp(SECCOMP_GET_NOTIF_SIZES)`) that never install a filter. In environments where the actual user-notify filter install fails — e.g. Daytona sandboxes, where `SECCOMP_FILTER_FLAG_NEW_LISTENER` returns **EBUSY** — `detect` still reports the capability as available, while runtime `agentsh-unixwrap` dies with `seccomp: filter Load failed`. The verdict means *"the kernel knows this feature"*, not *"agentsh can install its filter here."* So `detect` and the protection score are a **false positive** for the enforcement that actually matters.
+
+This design adds a **behavioral install-probe**: a throwaway re-exec child that attempts the exact `NEW_LISTENER` install the runtime uses (`loadRawFilter`) and reports success or the failing errno. `detect`'s `seccomp-execve` / `seccomp_user_notify` verdicts and the Command Control score derive from **that** ("installable here"), while the existing read-only probe is retained as a distinct "kernel-supported" signal surfaced in the detail text.
+
+## Goals
+
+- `detect` reports `seccomp-execve` / `seccomp-notify` / `seccomp_user_notify` as available only when a real `NEW_LISTENER` filter install succeeds in this environment.
+- The Command Control protection score reflects installability, so an environment like Daytona (EBUSY) drops below 25/25 instead of falsely reporting full coverage.
+- When the kernel supports user-notify but the install fails here, `detect` surfaces **both** signals and the failing errno, e.g. `seccomp-execve ✗ — kernel supports user-notify, but NEW_LISTENER install failed here: EBUSY (errno 16)`.
+- The probe tests **exactly** what the runtime does (`loadRawFilter` → `prctl(NO_NEW_PRIVS)` + `seccomp(SET_MODE_FILTER, NEW_LISTENER)`), so the verdict can't diverge from runtime behavior.
+- Regression-safe: on environments where install succeeds (normal kernels), the verdict and score are unchanged (still `✓`, 25/25).
+
+## Non-Goals
+
+- **No change to runtime or server-startup gating.** This fixes the diagnostic's honesty. The runtime already surfaces the real EBUSY at install time (`agentsh-unixwrap` fails loudly). Aligning startup capability gating with the install-probe is a possible separate follow-up.
+- The probe reuses the existing `buildProbeFilterBytes()` + `loadRawFilter` rather than hand-rolling a separate filter/install — fidelity to the real runtime install is the point, and reuse avoids divergence.
+- No new behavioral KILL-bug logic; that is the separate `wait_killable` probe (#369).
+- No change to the read-only probes themselves; they remain as the "kernel-supported" signal.
+
+## Background
+
+- Read-only probes: `probeSeccompBasic()` (`SECCOMP_GET_ACTION_AVAIL`) and `probeSeccompUserNotify()` (`SECCOMP_GET_NOTIF_SIZES`) in `internal/capabilities/check_seccomp_linux.go` (`//go:build linux`, no cgo). `realCheckSeccompUserNotify()` (`check.go:38`) wraps the latter; `checkSeccompUserNotify` is a swappable package var (test seam).
+- `internal/capabilities/detect_linux.go` derives `seccomp-execve` (L93), `seccomp-notify` (L86), and the `seccomp_user_notify` map entry (L220) all from `caps.Seccomp` — i.e. from the read-only probe.
+- Real install: `loadRawFilter(prog []byte, withWaitKill bool) (int, error)` in `internal/netmonitor/unix/seccomp_load_linux.go` (`//go:build linux && cgo`): `runtime.LockOSThread()` → `prctl(PR_SET_NO_NEW_PRIVS)` → `seccomp(SET_MODE_FILTER, NEW_LISTENER[|WAIT_KILLABLE_RECV])`. The `NEW_LISTENER` flag is what EBUSYs on Daytona.
+- Proven re-exec child harness: `internal/netmonitor/unix/wait_killable_probe_runner_linux.go` (#369) already re-execs `os.Executable()` with a two-factor gate (argv sentinel `--agentsh-internal-...-v1` + random env token, validated in `init()`), and its child calls `loadRawFilter`. `internal/api` imports `netmonitor/unix` and `cmd/agentsh` imports `internal/api`, so the child `init()` handler is linked into the `agentsh` binary (and thus runs when `agentsh detect` re-execs itself). `netmonitor/unix` ships non-cgo stubs (`seccomp_stub.go`, `wait_killable_probe_stub.go`), and does **not** import `internal/capabilities` (no cycle).
+
+## Design
+
+### 1. Install-probe in `internal/netmonitor/unix`
+
+A new probe modeled on the wait_killable harness but stripped to a single install attempt.
+
+**Contract constants** (own two-factor gate, distinct from wait_killable):
+- argv sentinel `--agentsh-internal-seccomp-install-probe-child-v1`
+- env token var `AGENTSH_SECCOMP_INSTALL_PROBE_CHILD` (length ≥ 16)
+- exit codes: `0` = installed OK; a small fixed code per errno class (EBUSY, EPERM, EINVAL, ENOSYS, other) so the parent classifies without parsing stderr (stderr still captured, bounded, for the detail string).
+
+**Child (`linux && cgo`):** an `init()` branch (added to the package's probe-child detection) that, when the install-probe sentinel+token are present:
+1. builds the filter via the existing `buildProbeFilterBytes()` (the proven probe filter: `ActAllow` default + `ActNotify` on a fixed syscall set) — reused for fidelity to what the runtime installs;
+2. calls `loadRawFilter(prog, false)` (plain `NEW_LISTENER`, matching the issue's exact failing case);
+3. on success: close the returned fd, `os.Exit(0)`; on error: print the errno to stderr and `os.Exit(<errno-class code>)`.
+
+The child never services notifications and never execs. It is safe from the wait_killable child's "trap-on-exit" hazard precisely because the filter default is `ActAllow` and the child's own post-install syscalls (`close`, `write` to stderr, `exit_group`) are **not** in the notify set — so no notification is ever raised and nothing must service the fd.
+
+It never services notifications and never execs — it only answers "did the install syscall succeed?"
+
+**Parent (`linux && cgo`, paired with the child handler):**
+```go
+type InstallProbeResult struct {
+    Installable bool
+    Errno       syscall.Errno // 0 if installable
+    Detail      string        // human-readable, e.g. "EBUSY (errno 16)" or child stderr
+}
+func ProbeSeccompInstall() InstallProbeResult
+```
+re-execs `os.Executable()` with the sentinel argv + token env, captures exit code + bounded stderr, maps to `InstallProbeResult`. Result cached per-process via `sync.Once` (detect may query repeatedly). A re-exec / spawn failure is treated as `Installable:false` with a descriptive `Detail` (fail-safe: don't claim installable when we couldn't test). It lives in the cgo file because the re-exec is only meaningful when the cgo child handler is compiled into the binary.
+
+**Stub (`!cgo` / non-linux):** `ProbeSeccompInstall()` returns `{Installable:false, Detail:"seccomp install probe unavailable (no cgo / unsupported OS)"}` — no re-exec (there is no child handler to answer it).
+
+### 2. capabilities + detect wiring
+
+- Add a swappable check var `checkSeccompInstall = realCheckSeccompInstall` (test seam, mirroring `checkSeccompUserNotify`) that calls `unix.ProbeSeccompInstall()` and yields a new `caps` field, `SeccompInstallable bool` (+ a detail string for the errno).
+- Keep `caps.Seccomp` (read-only) as the **kernel-supported** signal.
+- `detect_linux.go`: `seccomp-execve`, `seccomp-notify`, and `seccomp_user_notify` **Available ← `caps.SeccompInstallable`**. The Command Control score weight now counts installability.
+- Detail text: when `caps.Seccomp && !caps.SeccompInstallable`, set the entry `Detail` to `kernel supports user-notify, but NEW_LISTENER install failed here: <errno>`; when both true, `✓` with empty/positive detail; when `!caps.Seccomp`, unchanged (kernel doesn't support it).
+
+### Why not other approaches
+
+- **Extend the wait_killable harness:** conflates the KILL-bug behavioral test (5 iterations, notify servicing, syscall storm) with a simple "can we install" check; heavier and entangles two concerns.
+- **In-process locked-thread probe:** installing `NEW_LISTENER` + `NO_NEW_PRIVS` on a `runtime.LockOSThread` thread permanently poisons that M (a seccomp'd/no-new-privs thread can't be safely returned to the Go runtime). A throwaway child is the clean isolation boundary.
+- **Self-contained probe in capabilities (hand-rolled install):** would duplicate the install syscall/flags and risk diverging from `loadRawFilter` — but fidelity to the real install is the entire point of the fix. Reusing `loadRawFilter` (child-side, in the cgo binary) guarantees the probe tests what runtime does.
+
+## Error handling
+
+The probe is fail-safe: any failure to *run* the probe (re-exec error, child crash, timeout) yields `Installable:false` with a `Detail` explaining why — never a false `✓`. Errno classification (EBUSY/EPERM/EINVAL/ENOSYS/other) drives the detail string; an unrecognized non-zero exit maps to `Installable:false` with the captured child stderr. No new error types surface to callers; `detect` renders the `Detail`.
+
+## Testing
+
+`internal/netmonitor/unix` (`linux && cgo`):
+- Child contract: invoking the binary with the install-probe sentinel+token exits `0` and the real `loadRawFilter` install succeeds on a normal CI kernel (skip if the CI kernel itself can't install, to avoid flakiness — gate on a quick precheck).
+- Parent classifier: a table mapping injected exit codes + stderr → `InstallProbeResult` (`0`→installable; each errno code→correct `Errno`/`Detail`; spawn failure→not installable). Use an injectable exec seam so the classifier is tested without a real child.
+
+`internal/capabilities`:
+- With `checkSeccompInstall` stubbed to `Installable:false` while `checkSeccompUserNotify` reports available (kernel-supported), assert: `seccomp-execve`/`seccomp_user_notify` verdicts are `✗`, the Command Control score drops accordingly, and the detail string names both signals + the errno.
+- With both stubbed available, assert verdicts `✓` and score unchanged (regression guard).
+
+Confirm existing `internal/capabilities`, `internal/netmonitor/unix`, and `internal/cli` suites stay green, and `GOOS=windows go build ./...` succeeds (the parent/stub split must compile cgo and non-cgo).
+
+## Affected files
+
+- `internal/netmonitor/unix/seccomp_install_probe_linux.go` (new, `linux && cgo`) — child `init()` handler + parent `ProbeSeccompInstall`.
+- `internal/netmonitor/unix/seccomp_install_probe_stub.go` (new, `!cgo` / non-linux) — stub `ProbeSeccompInstall`.
+- `internal/netmonitor/unix/*probe*_test.go` (new) — child contract + parent classifier tests.
+- `internal/capabilities/check.go` / `check_seccomp_linux.go` — `checkSeccompInstall` seam + `SeccompInstallable` field.
+- `internal/capabilities/detect_linux.go` — derive the three verdicts + score from `SeccompInstallable`; dual-signal detail text.
+- `internal/capabilities/*_test.go` — detect-level verdict/score/detail tests.

--- a/internal/capabilities/check.go
+++ b/internal/capabilities/check.go
@@ -28,6 +28,7 @@ type Check func() CheckResult
 // Check function variables - can be replaced in tests.
 var (
 	checkSeccompUserNotify       = realCheckSeccompUserNotify
+	checkSeccompInstall          = realCheckSeccompInstall
 	checkPtrace                  = realCheckPtrace
 	checkCgroupsV2ResourceLimits = realCheckCgroupsV2ResourceLimits
 	checkeBPF                    = realCheckeBPF

--- a/internal/capabilities/check_seccomp_linux.go
+++ b/internal/capabilities/check_seccomp_linux.go
@@ -7,6 +7,8 @@ import (
 	"unsafe"
 
 	"golang.org/x/sys/unix"
+
+	unixmon "github.com/agentsh/agentsh/internal/netmonitor/unix"
 )
 
 // probeSeccompBasic checks whether the seccomp() syscall supports BPF filtering
@@ -63,4 +65,17 @@ func probeSeccompUserNotify() ProbeResult {
 	default:
 		return ProbeResult{Available: false, Detail: fmt.Sprintf("%s (errno %d)", errno, errno)}
 	}
+}
+
+// realCheckSeccompInstall reports whether a real NEW_LISTENER seccomp filter
+// install succeeds in this environment (issue #388). It is sourced from the
+// install probe in internal/netmonitor/unix, distinct from the read-only
+// kernel-supported check (realCheckSeccompUserNotify).
+func realCheckSeccompInstall() CheckResult {
+	res := unixmon.ProbeSeccompInstall()
+	r := CheckResult{Feature: "seccomp-install", Available: res.Installable}
+	if !res.Installable {
+		r.Error = fmt.Errorf("NEW_LISTENER filter install failed: %s", res.Detail)
+	}
+	return r
 }

--- a/internal/capabilities/detect_linux.go
+++ b/internal/capabilities/detect_linux.go
@@ -25,6 +25,25 @@ func detectFileEnforcementBackend(caps *SecurityCapabilities) string {
 	return "none"
 }
 
+// seccompBackendDetail explains the seccomp verdict, distinguishing
+// "kernel-supported" from "installable here" (issue #388). caps.SeccompInstallDetail
+// already reads like "NEW_LISTENER filter install failed: EBUSY (errno 16)"
+// (set by realCheckSeccompInstall), so this only prepends the kernel-support
+// context — no double "install failed" wording.
+func seccompBackendDetail(caps *SecurityCapabilities) string {
+	if caps.SeccompInstallable {
+		return ""
+	}
+	if caps.Seccomp {
+		d := caps.SeccompInstallDetail
+		if d == "" {
+			d = "NEW_LISTENER install failed here"
+		}
+		return "kernel supports user-notify, but " + d
+	}
+	return "" // kernel doesn't support user-notify; existing Available=false speaks for itself
+}
+
 // buildLinuxDomains builds the five protection domains from cached probe results and capability flags.
 func buildLinuxDomains(caps *SecurityCapabilities) []ProtectionDomain {
 	fuseMountMethod := "none"
@@ -83,14 +102,14 @@ func buildLinuxDomains(caps *SecurityCapabilities) []ProtectionDomain {
 			Backends: []DetectedBackend{
 				{Name: "fuse", Available: caps.FUSE, Detail: fuseMountMethod, Description: "file interception, soft-delete, redirect", CheckMethod: "probe"},
 				{Name: "landlock", Available: caps.Landlock, Detail: landlockDetail, Description: "kernel path restrictions", CheckMethod: "syscall"},
-				{Name: "seccomp-notify", Available: caps.Seccomp, Detail: "", Description: "openat/stat enforcement", CheckMethod: "probe"},
+				{Name: "seccomp-notify", Available: caps.SeccompInstallable, Detail: seccompBackendDetail(caps), Description: "openat/stat enforcement", CheckMethod: "probe"},
 			},
 			Active: caps.FileEnforcement,
 		},
 		{
 			Name: "Command Control", Weight: WeightCommandControl,
 			Backends: []DetectedBackend{
-				{Name: "seccomp-execve", Available: caps.Seccomp, Detail: "", Description: "execve interception", CheckMethod: "probe"},
+				{Name: "seccomp-execve", Available: caps.SeccompInstallable, Detail: seccompBackendDetail(caps), Description: "execve interception", CheckMethod: "probe"},
 				{Name: "ptrace", Available: caps.Ptrace, Detail: "", Description: "syscall tracing", CheckMethod: "probe"},
 			},
 			Active: commandActive,
@@ -128,9 +147,9 @@ func buildLinuxDomains(caps *SecurityCapabilities) []ProtectionDomain {
 // wrapperDependentBackends lists backends that require agentsh-unixwrap.
 // These are marked unavailable when the wrapper binary is not on PATH.
 var wrapperDependentBackends = map[string]bool{
-	"seccomp-notify":  true,
-	"landlock":        true,
-	"seccomp-execve":  true,
+	"seccomp-notify":   true,
+	"landlock":         true,
+	"seccomp-execve":   true,
 	"landlock-network": true,
 }
 
@@ -154,6 +173,7 @@ func applyWrapperAvailability(domains []ProtectionDomain, secCaps *SecurityCapab
 	// These must be cleared before the domain loop because SelectMode() and
 	// the Active derivation read from secCaps.
 	secCaps.Seccomp = false
+	secCaps.SeccompInstallable = false
 	secCaps.Landlock = false
 	secCaps.LandlockNetwork = false
 
@@ -216,15 +236,16 @@ func applyWrapperAvailability(domains []ProtectionDomain, secCaps *SecurityCapab
 // backwardCompatCaps builds the flat capabilities map for backward compatibility.
 func backwardCompatCaps(caps *SecurityCapabilities, domains []ProtectionDomain) map[string]any {
 	m := map[string]any{
-		"seccomp":             caps.Seccomp,
-		"seccomp_user_notify": caps.Seccomp,
-		"seccomp_basic":       caps.SeccompBasic,
-		"landlock":            caps.Landlock,
-		"landlock_abi":        caps.LandlockABI,
-		"landlock_network":    caps.LandlockNetwork,
-		"fuse":                caps.FUSE,
-		"ptrace":              caps.Ptrace,
-		"file_enforcement":    caps.FileEnforcement,
+		"seccomp":                    caps.Seccomp,
+		"seccomp_user_notify":        caps.SeccompInstallable, // installable here (issue #388)
+		"seccomp_user_notify_kernel": caps.Seccomp,            // kernel-supported (read-only probe)
+		"seccomp_basic":              caps.SeccompBasic,
+		"landlock":                   caps.Landlock,
+		"landlock_abi":               caps.LandlockABI,
+		"landlock_network":           caps.LandlockNetwork,
+		"fuse":                       caps.FUSE,
+		"ptrace":                     caps.Ptrace,
+		"file_enforcement":           caps.FileEnforcement,
 	}
 	for _, d := range domains {
 		for _, b := range d.Backends {

--- a/internal/capabilities/detect_linux_test.go
+++ b/internal/capabilities/detect_linux_test.go
@@ -4,6 +4,7 @@ package capabilities
 
 import (
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -77,12 +78,13 @@ func TestApplyWrapperAvailability_Missing(t *testing.T) {
 
 	// Build domains with all backends available
 	caps := &SecurityCapabilities{
-		Seccomp:         true,
-		Landlock:        true,
-		LandlockABI:     5,
-		LandlockNetwork: true,
-		FUSE:            true,
-		Ptrace:          true,
+		Seccomp:            true,
+		SeccompInstallable: true,
+		Landlock:           true,
+		LandlockABI:        5,
+		LandlockNetwork:    true,
+		FUSE:               true,
+		Ptrace:             true,
 	}
 	caps.FileEnforcement = detectFileEnforcementBackend(caps)
 	domains := buildLinuxDomains(caps)
@@ -112,6 +114,9 @@ func TestApplyWrapperAvailability_Missing(t *testing.T) {
 	// secCaps fields should be cleared for wrapper-dependent capabilities
 	if caps.Seccomp {
 		t.Error("Seccomp should be false when wrapper missing")
+	}
+	if caps.SeccompInstallable {
+		t.Error("SeccompInstallable should be false when wrapper missing")
 	}
 	if caps.Landlock {
 		t.Error("Landlock should be false when wrapper missing")
@@ -158,6 +163,9 @@ func TestApplyWrapperAvailability_Missing_NoFUSE(t *testing.T) {
 	if caps.Seccomp {
 		t.Error("Seccomp should be false when wrapper missing")
 	}
+	if caps.SeccompInstallable {
+		t.Error("SeccompInstallable should be false when wrapper missing")
+	}
 	if caps.Landlock {
 		t.Error("Landlock should be false when wrapper missing")
 	}
@@ -174,11 +182,12 @@ func TestApplyWrapperAvailability_Present(t *testing.T) {
 	defer func() { wrapperLookPath = orig }()
 
 	caps := &SecurityCapabilities{
-		Seccomp:     true,
-		Landlock:    true,
-		LandlockABI: 5,
-		FUSE:        true,
-		Ptrace:      true,
+		Seccomp:            true,
+		SeccompInstallable: true,
+		Landlock:           true,
+		LandlockABI:        5,
+		FUSE:               true,
+		Ptrace:             true,
 	}
 	caps.FileEnforcement = detectFileEnforcementBackend(caps)
 	domains := buildLinuxDomains(caps)
@@ -261,4 +270,73 @@ func TestDetect_WrapperMissing_Tip(t *testing.T) {
 	if result.SecurityMode == "full" || result.SecurityMode == "landlock" {
 		t.Errorf("SecurityMode = %q, should not report full/landlock without wrapper", result.SecurityMode)
 	}
+}
+
+func TestBuildLinuxDomains_SeccompInstallFalseFlipsVerdictAndScore(t *testing.T) {
+	caps := &SecurityCapabilities{
+		Seccomp:              true,  // kernel-supported
+		SeccompInstallable:   false, // but install fails here (e.g. Daytona EBUSY)
+		SeccompInstallDetail: "EBUSY (errno 16)",
+	}
+	domains := buildLinuxDomains(caps)
+
+	exec := findBackend(t, domains, "Command Control", "seccomp-execve")
+	if exec.Available {
+		t.Error("seccomp-execve must be unavailable when install fails")
+	}
+	if !strings.Contains(exec.Detail, "EBUSY") || !strings.Contains(strings.ToLower(exec.Detail), "kernel") {
+		t.Errorf("seccomp-execve detail should name both kernel-support and the errno; got %q", exec.Detail)
+	}
+	notify := findBackend(t, domains, "File Protection", "seccomp-notify")
+	if notify.Available {
+		t.Error("seccomp-notify must be unavailable when install fails")
+	}
+
+	// ptrace is a genuine fallback: with ptrace available, Command Control
+	// keeps full weight even though seccomp cannot install here. Pins that the
+	// score tracks installability without keying off seccomp specifically.
+	caps.Ptrace = true
+	ccPtrace := findDomain(t, buildLinuxDomains(caps), "Command Control")
+	if got := ComputeScore([]ProtectionDomain{ccPtrace}); got != WeightCommandControl {
+		t.Errorf("Command Control should score %d when ptrace is available (seccomp uninstallable); got %d", WeightCommandControl, got)
+	}
+
+	// With seccomp the only command backend, Command Control score must drop.
+	caps.Ptrace = false
+	domains = buildLinuxDomains(caps)
+	cc := findDomain(t, domains, "Command Control")
+	if ComputeScore([]ProtectionDomain{cc}) != 0 {
+		t.Error("Command Control should score 0 when neither seccomp-execve nor ptrace is available")
+	}
+}
+
+func TestBuildLinuxDomains_SeccompInstallTrueKeepsVerdict(t *testing.T) {
+	caps := &SecurityCapabilities{Seccomp: true, SeccompInstallable: true}
+	domains := buildLinuxDomains(caps)
+	if !findBackend(t, domains, "Command Control", "seccomp-execve").Available {
+		t.Error("seccomp-execve must be available when install succeeds")
+	}
+}
+
+func findDomain(t *testing.T, domains []ProtectionDomain, name string) ProtectionDomain {
+	t.Helper()
+	for _, d := range domains {
+		if d.Name == name {
+			return d
+		}
+	}
+	t.Fatalf("domain %q not found", name)
+	return ProtectionDomain{}
+}
+
+func findBackend(t *testing.T, domains []ProtectionDomain, domain, backend string) DetectedBackend {
+	t.Helper()
+	d := findDomain(t, domains, domain)
+	for _, b := range d.Backends {
+		if b.Name == backend {
+			return b
+		}
+	}
+	t.Fatalf("backend %q not found in %q", backend, domain)
+	return DetectedBackend{}
 }

--- a/internal/capabilities/seccomp_install_test.go
+++ b/internal/capabilities/seccomp_install_test.go
@@ -1,0 +1,33 @@
+//go:build linux
+
+package capabilities
+
+import "testing"
+
+// Issue #388: SeccompInstallable comes from the real install probe, distinct
+// from the read-only Seccomp (kernel-supported) signal.
+func TestDetectSecurityCapabilities_SeccompInstallable(t *testing.T) {
+	origUN, origInstall := checkSeccompUserNotify, checkSeccompInstall
+	defer func() { checkSeccompUserNotify, checkSeccompInstall = origUN, origInstall }()
+
+	checkSeccompUserNotify = func() CheckResult { return CheckResult{Feature: "seccomp-user-notify", Available: true} }
+	checkSeccompInstall = func() CheckResult {
+		return CheckResult{Feature: "seccomp-install", Available: false, Error: errForTest("EBUSY (errno 16)")}
+	}
+
+	caps := DetectSecurityCapabilities()
+	if !caps.Seccomp {
+		t.Error("Seccomp (kernel-supported) should be true")
+	}
+	if caps.SeccompInstallable {
+		t.Error("SeccompInstallable should be false when the install probe fails")
+	}
+	if caps.SeccompInstallDetail == "" {
+		t.Error("SeccompInstallDetail should carry the failure reason")
+	}
+}
+
+type testErr string
+
+func (e testErr) Error() string { return string(e) }
+func errForTest(s string) error { return testErr(s) }

--- a/internal/capabilities/security_caps.go
+++ b/internal/capabilities/security_caps.go
@@ -23,19 +23,21 @@ import (
 // all" (mode selection, configuration generation) continue to read
 // Capabilities.
 type SecurityCapabilities struct {
-	Seccomp            bool   // seccomp-bpf + user-notify
-	SeccompBasic       bool   // seccomp-bpf without user-notify
-	Landlock           bool   // any Landlock support
-	LandlockABI        int    // 1-5, determines features
-	LandlockNetwork    bool   // ABI v4+, kernel 6.7+
-	EBPF               bool   // network monitoring
-	FUSE               bool   // filesystem interception
-	Capabilities       bool   // capability-drop mechanism available (always true on Linux)
-	CapabilitiesActive bool   // capability-drop probe reports this process has durably reduced its capability set
-	PIDNamespace       bool   // isolated PID namespace
-	Ptrace             bool   // SYS_PTRACE capability available
-	PtraceEnabled      bool   // ptrace enforcement enabled in config
-	FileEnforcement    string // "landlock", "fuse", "seccomp-notify", "none"
+	Seccomp              bool   // seccomp-bpf + user-notify
+	SeccompBasic         bool   // seccomp-bpf without user-notify
+	SeccompInstallable   bool   // a real NEW_LISTENER filter install succeeds here (issue #388)
+	SeccompInstallDetail string // why install is unavailable, when SeccompInstallable is false
+	Landlock             bool   // any Landlock support
+	LandlockABI          int    // 1-5, determines features
+	LandlockNetwork      bool   // ABI v4+, kernel 6.7+
+	EBPF                 bool   // network monitoring
+	FUSE                 bool   // filesystem interception
+	Capabilities         bool   // capability-drop mechanism available (always true on Linux)
+	CapabilitiesActive   bool   // capability-drop probe reports this process has durably reduced its capability set
+	PIDNamespace         bool   // isolated PID namespace
+	Ptrace               bool   // SYS_PTRACE capability available
+	PtraceEnabled        bool   // ptrace enforcement enabled in config
+	FileEnforcement      string // "landlock", "fuse", "seccomp-notify", "none"
 
 	// Cached probe results (populated by DetectSecurityCapabilities, reused by buildLinuxDomains)
 	EBPFProbe   ProbeResult
@@ -66,6 +68,13 @@ func DetectSecurityCapabilities() *SecurityCapabilities {
 	// Detect other capabilities via probes
 	caps.Seccomp = checkSeccompUserNotify().Available
 	caps.SeccompBasic = checkSeccompBasic()
+	{
+		r := checkSeccompInstall()
+		caps.SeccompInstallable = r.Available
+		if r.Error != nil {
+			caps.SeccompInstallDetail = r.Error.Error()
+		}
+	}
 	caps.FUSE = checkFUSE()
 	caps.Ptrace = checkPtraceCapability()
 
@@ -214,4 +223,3 @@ func probeMountSyscall() bool {
 		return false
 	}
 }
-

--- a/internal/capabilities/security_caps_other.go
+++ b/internal/capabilities/security_caps_other.go
@@ -13,19 +13,21 @@ package capabilities
 // populates it — callers asking "is privilege reduction protecting this
 // process" must use CapabilitiesActive to stay honest about that.
 type SecurityCapabilities struct {
-	Seccomp            bool   // seccomp-bpf + user-notify
-	SeccompBasic       bool   // seccomp-bpf without user-notify
-	Landlock           bool   // any Landlock support
-	LandlockABI        int    // 1-5, determines features
-	LandlockNetwork    bool   // ABI v4+, kernel 6.7+
-	EBPF               bool   // network monitoring
-	FUSE               bool   // filesystem interception
-	Capabilities       bool   // capability-drop mechanism available (always true)
-	CapabilitiesActive bool   // capability-drop probe reports this process has durably reduced its capability set
-	PIDNamespace       bool   // isolated PID namespace
-	Ptrace             bool   // SYS_PTRACE capability available
-	PtraceEnabled      bool   // ptrace enforcement enabled in config
-	FileEnforcement    string // "landlock", "fuse", "seccomp-notify", "none"
+	Seccomp              bool   // seccomp-bpf + user-notify
+	SeccompBasic         bool   // seccomp-bpf without user-notify
+	SeccompInstallable   bool   // a real NEW_LISTENER filter install succeeds here (issue #388)
+	SeccompInstallDetail string // why install is unavailable, when SeccompInstallable is false
+	Landlock             bool   // any Landlock support
+	LandlockABI          int    // 1-5, determines features
+	LandlockNetwork      bool   // ABI v4+, kernel 6.7+
+	EBPF                 bool   // network monitoring
+	FUSE                 bool   // filesystem interception
+	Capabilities         bool   // capability-drop mechanism available (always true)
+	CapabilitiesActive   bool   // capability-drop probe reports this process has durably reduced its capability set
+	PIDNamespace         bool   // isolated PID namespace
+	Ptrace               bool   // SYS_PTRACE capability available
+	PtraceEnabled        bool   // ptrace enforcement enabled in config
+	FileEnforcement      string // "landlock", "fuse", "seccomp-notify", "none"
 
 	// Cached probe results (populated by DetectSecurityCapabilities, reused by buildLinuxDomains)
 	EBPFProbe   ProbeResult

--- a/internal/netmonitor/unix/seccomp_install_probe_linux.go
+++ b/internal/netmonitor/unix/seccomp_install_probe_linux.go
@@ -1,0 +1,165 @@
+//go:build linux && cgo
+
+package unix
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Issue #388: detect must report seccomp enforcement from a REAL NEW_LISTENER
+// install, not a read-only capability probe. This probe re-execs a throwaway
+// child that runs the exact loadRawFilter install the runtime uses and reports
+// success or the failing errno.
+
+const (
+	installProbeArgvSentinel = "--agentsh-internal-seccomp-install-probe-child-v1"
+	installProbeEnv          = "AGENTSH_SECCOMP_INSTALL_PROBE_CHILD"
+	installProbeStderrCap    = 4096
+	// installErrnoPrefix is printed by the child on failure so the parent can
+	// recover the precise errno without encoding it in the exit status.
+	installErrnoPrefix = "INSTALL_ERRNO="
+)
+
+// InstallProbeResult reports whether agentsh can install its NEW_LISTENER
+// seccomp filter in this environment. Errno is 0 when Installable.
+type InstallProbeResult struct {
+	Installable bool
+	Errno       syscall.Errno
+	Detail      string
+}
+
+// runInstallProbe spawns the probe child and returns its exit code, captured
+// (bounded) stderr, and any spawn error. Injectable seam for tests.
+var runInstallProbe = realRunInstallProbe
+
+var (
+	installProbeOnce   sync.Once
+	installProbeResult InstallProbeResult
+)
+
+// ProbeSeccompInstall returns whether a NEW_LISTENER filter install succeeds
+// here. Cached per process. Fail-safe: any inability to run the probe yields
+// Installable=false with a descriptive Detail — never a false positive.
+func ProbeSeccompInstall() InstallProbeResult {
+	installProbeOnce.Do(func() {
+		code, stderr, err := runInstallProbe()
+		installProbeResult = classifyInstallProbe(code, stderr, err)
+	})
+	return installProbeResult
+}
+
+func classifyInstallProbe(exitCode int, stderr string, spawnErr error) InstallProbeResult {
+	if spawnErr != nil {
+		return InstallProbeResult{Installable: false, Detail: fmt.Sprintf("install probe could not run: %v", spawnErr)}
+	}
+	if exitCode == 0 {
+		return InstallProbeResult{Installable: true}
+	}
+	if errno := parseInstallErrno(stderr); errno != 0 {
+		return InstallProbeResult{Installable: false, Errno: errno, Detail: fmt.Sprintf("%s (errno %d)", errno, int(errno))}
+	}
+	detail := strings.TrimSpace(stderr)
+	if detail == "" {
+		detail = fmt.Sprintf("install probe exited %d", exitCode)
+	}
+	return InstallProbeResult{Installable: false, Detail: detail}
+}
+
+func parseInstallErrno(stderr string) syscall.Errno {
+	for _, line := range strings.Split(stderr, "\n") {
+		i := strings.Index(line, installErrnoPrefix)
+		if i < 0 {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimSpace(line[i+len(installErrnoPrefix):]))
+		if err == nil && n > 0 {
+			return syscall.Errno(n)
+		}
+	}
+	return 0
+}
+
+func realRunInstallProbe() (int, string, error) {
+	bin, err := os.Executable()
+	if err != nil {
+		return -1, "", fmt.Errorf("os.Executable: %w", err)
+	}
+	cmd := exec.Command(bin, installProbeArgvSentinel)
+	cmd.Env = append(os.Environ(), installProbeEnv+"="+ensureProbeChildToken())
+	stderr := &boundedBuffer{cap: installProbeStderrCap}
+	cmd.Stdout = nil
+	cmd.Stderr = stderr
+	cmd.Stdin = nil
+	runErr := cmd.Run()
+	if runErr == nil {
+		return 0, stderr.String(), nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		return exitErr.ExitCode(), stderr.String(), nil // non-zero exit, not a spawn failure
+	}
+	return -1, stderr.String(), runErr // could not start / other
+}
+
+// isInstallProbeChildInvocation gates probe-child mode (two-factor: argv
+// sentinel + env token length >= 16), mirroring isProbeChildInvocation.
+func isInstallProbeChildInvocation() bool {
+	if len(os.Args) < 2 || os.Args[1] != installProbeArgvSentinel {
+		return false
+	}
+	return len(os.Getenv(installProbeEnv)) >= 16
+}
+
+func init() {
+	if isInstallProbeChildInvocation() {
+		runInstallProbeChild()
+		os.Exit(0) // unreachable: runInstallProbeChild always exits
+	}
+}
+
+// runInstallProbeChild installs the probe filter via the SAME loadRawFilter the
+// runtime uses, then exits. The filter's ActAllow default means the child's own
+// close/write/exit syscalls are never trapped, so no servicing is needed and
+// the child cannot hang. Exits 0 on install success; on failure prints
+// INSTALL_ERRNO=<n> (when the error is an errno) and exits 1.
+func runInstallProbeChild() {
+	prog, err := buildProbeFilterBytes()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "seccomp install probe: build filter: %v\n", err)
+		os.Exit(1)
+	}
+	fd, err := loadRawFilter(prog, false)
+	if err != nil {
+		var errno syscall.Errno
+		if errors.As(err, &errno) {
+			fmt.Fprintf(os.Stderr, "seccomp install probe: install filter: %v %s%d\n", err, installErrnoPrefix, int(errno))
+		} else {
+			fmt.Fprintf(os.Stderr, "seccomp install probe: install filter: %v\n", err)
+		}
+		os.Exit(1)
+	}
+	_ = unix.Close(fd)
+	os.Exit(0)
+}
+
+// probeSeccompUserNotifyKernel is a read-only "does the kernel know user-notify"
+// check (SECCOMP_GET_NOTIF_SIZES), used only as a test skip guard. Returns nil
+// when supported.
+func probeSeccompUserNotifyKernel() error {
+	var sizes [3]uint16 // struct seccomp_notif_sizes { __u16 seccomp_notif, seccomp_notif_resp, seccomp_data; }
+	_, _, errno := unix.Syscall(unix.SYS_SECCOMP, unix.SECCOMP_GET_NOTIF_SIZES, 0, uintptr(unsafe.Pointer(&sizes)))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/internal/netmonitor/unix/seccomp_install_probe_linux_test.go
+++ b/internal/netmonitor/unix/seccomp_install_probe_linux_test.go
@@ -1,0 +1,58 @@
+//go:build linux && cgo
+
+package unix
+
+import (
+	"errors"
+	"syscall"
+	"testing"
+)
+
+func TestClassifyInstallProbe(t *testing.T) {
+	cases := []struct {
+		name      string
+		exitCode  int
+		stderr    string
+		spawnErr  error
+		wantInst  bool
+		wantErrno syscall.Errno
+	}{
+		{"success", 0, "", nil, true, 0},
+		{"ebusy", 1, "install filter: ... INSTALL_ERRNO=16\n", nil, false, syscall.EBUSY},
+		{"eperm", 1, "INSTALL_ERRNO=1\n", nil, false, syscall.EPERM},
+		{"einval", 1, "INSTALL_ERRNO=22\n", nil, false, syscall.EINVAL},
+		{"nonerrno_setup_fail", 1, "build filter: boom\n", nil, false, 0},
+		{"spawn_error", -1, "", errors.New("fork failed"), false, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyInstallProbe(tc.exitCode, tc.stderr, tc.spawnErr)
+			if got.Installable != tc.wantInst {
+				t.Fatalf("Installable=%v, want %v (detail=%q)", got.Installable, tc.wantInst, got.Detail)
+			}
+			if got.Errno != tc.wantErrno {
+				t.Errorf("Errno=%v (%d), want %v (%d)", got.Errno, got.Errno, tc.wantErrno, tc.wantErrno)
+			}
+			if !got.Installable && got.Detail == "" {
+				t.Error("not-installable result must carry a non-empty Detail")
+			}
+		})
+	}
+}
+
+// Real end-to-end: re-exec this test binary as the install-probe child and
+// confirm the mechanism runs and returns a coherent verdict. On a kernel that
+// supports user-notify the install succeeds; otherwise it reports a recognized
+// errno (never a false positive). Skips only if the kernel lacks user-notify.
+func TestProbeSeccompInstall_Integration(t *testing.T) {
+	if probeSeccompUserNotifyKernel() != nil {
+		t.Skip("kernel lacks user-notify; install probe not meaningful here")
+	}
+	res := ProbeSeccompInstall()
+	if !res.Installable && res.Errno == 0 && res.Detail == "" {
+		t.Fatalf("incoherent probe result: %+v", res)
+	}
+	if !res.Installable {
+		t.Logf("install not available here: errno=%v detail=%q", res.Errno, res.Detail)
+	}
+}

--- a/internal/netmonitor/unix/seccomp_install_probe_stub.go
+++ b/internal/netmonitor/unix/seccomp_install_probe_stub.go
@@ -1,0 +1,18 @@
+//go:build !linux || !cgo
+
+package unix
+
+import "syscall"
+
+// InstallProbeResult mirrors the cgo type so callers compile on every target.
+type InstallProbeResult struct {
+	Installable bool
+	Errno       syscall.Errno
+	Detail      string
+}
+
+// ProbeSeccompInstall is a stub for non-Linux / linux-without-cgo builds: there
+// is no probe-child handler compiled in, so there is nothing to re-exec.
+func ProbeSeccompInstall() InstallProbeResult {
+	return InstallProbeResult{Installable: false, Detail: "seccomp install probe unavailable (no cgo / unsupported OS)"}
+}


### PR DESCRIPTION
## Summary

`agentsh detect` reported `seccomp-execve ✓` / `seccomp_user_notify ✓` (Command Control 25/25) from **read-only** capability probes (`SECCOMP_GET_ACTION_AVAIL` / `SECCOMP_GET_NOTIF_SIZES`) that never install a filter. In environments where the real user-notify install fails — e.g. Daytona, where `SECCOMP_FILTER_FLAG_NEW_LISTENER` returns **EBUSY** — `detect` still claimed the capability was available while runtime `agentsh-unixwrap` died with `seccomp: filter Load failed`. The verdict meant *"the kernel knows this feature"*, not *"agentsh can install its filter here."*

This makes `detect`'s seccomp verdicts + the protection score derive from a **real `NEW_LISTENER` install**, while keeping the read-only probe as a distinct "kernel-supported" signal.

## How

- **Behavioral install-probe** (`internal/netmonitor/unix`): a throwaway re-exec child (reusing the #369 two-factor argv+env gate) runs the **exact** runtime install — `buildProbeFilterBytes()` + `loadRawFilter(prog, false)` — and reports success or the failing errno. Parent (`capabilities`, non-cgo) reads the child's exit code/stderr; child (cgo, linked into the agentsh binary) does the install. The `ActAllow`-default filter means the child's own `close`/`exit_group` aren't trapped, so it can't hang; non-cgo stub keeps `capabilities` cgo-free. **Fail-safe:** `Installable:true` only on child exit 0 — spawn error / unparseable / non-zero ⇒ not installable (never a false positive).
- **`SeccompInstallable` capability** sourced from the probe, distinct from the read-only `Seccomp` (kernel-supported).
- **`detect`**: `seccomp-execve` / `seccomp-notify` backends + Command Control / File Protection **score** derive from `SeccompInstallable`; detail shows both signals (e.g. `kernel supports user-notify, but NEW_LISTENER install failed here: EBUSY (errno 16)`); `backwardCompatCaps` exposes both `seccomp_user_notify` (installable) and `seccomp_user_notify_kernel` (kernel-supported); `applyWrapperAvailability` clears both flags when the wrapper is missing.

## Scope / non-goals

- **Runtime / startup gating untouched.** The runtime already surfaces the real EBUSY at install time; this fixes the *diagnostic's* honesty. `SelectMode`/`detectFileEnforcementBackend` still use the kernel-supported `Seccomp`, so the domain `Active` label can still read `seccomp-execve` while the backend shows `✗` — a known, scoped follow-up (reconciling the active-label derivation with installability is a runtime-mode-selection change deserving its own pass). The score and backend-detail rows already reflect reality.

## Test plan

- [x] `go build ./...`, `GOOS=windows go build ./...`, `CGO_ENABLED=0 go build ./internal/netmonitor/unix/ ./internal/capabilities/`
- [x] `go vet` + `gofmt -l` clean
- [x] `go test ./internal/netmonitor/unix/ ./internal/capabilities/` (incl. `-race`)
- [x] Classifier table (success / EBUSY / EPERM / EINVAL / unparseable / spawn-error → never false positive); real re-exec integration test (installs on a capable kernel); verdict flip; score drop-to-0 **and** ptrace-keeps-weight; wrapper-missing clears `SeccompInstallable`
- [x] Smoke: `agentsh detect` on an install-capable host still shows `seccomp-execve ✓`, 25/25, and the new `seccomp_user_notify_kernel` key

Closes #388.

🤖 Generated with [Claude Code](https://claude.com/claude-code)