### PR TITLE
fix(#390): honest detect + SelectMode reporting for uninstallable seccomp

### DIFF
--- a/docs/superpowers/plans/2026-05-25-issue-390-detect-installable-honesty.md
+++ b/docs/superpowers/plans/2026-05-25-issue-390-detect-installable-honesty.md
@@ -359,6 +359,55 @@ No code change expected here. If a comment/detail string needed adjusting, commi
 
 ---
 
+### Task 4: `ValidateStrictMode` requires installable seccomp for `ModeFull` (folded-in scope)
+
+Added after the final review flagged that an explicitly-configured `mode: full` + `strict: true` on an uninstallable host still validated as OK (the auto path is already honest via Task 1). User approved folding this in.
+
+**Files:**
+- Modify: `internal/capabilities/validate.go` — `ValidateStrictMode`, `ModeFull` case (~line 19-22)
+- Test: `internal/capabilities/validate_test.go` — `TestValidateStrictMode` table (~line 8-103)
+
+- [ ] **Step 1: Update the test table.** In `TestValidateStrictMode`:
+  - Add `SeccompInstallable: true` to the caps of these three existing cases so they still reach their intended check: `"full mode with all caps"`, `"full mode missing eBPF"`, `"full mode missing FUSE"`.
+  - Leave `"full mode missing seccomp"` (Seccomp:false ⇒ SeccompInstallable:false) as-is — still `wantErr: true`.
+  - Add a new discriminating case:
+    ```go
+    {
+        name: "full mode seccomp kernel-supported but not installable",
+        mode: ModeFull,
+        caps: SecurityCapabilities{
+            Seccomp: true, SeccompInstallable: false, EBPF: true, FUSE: true,
+        },
+        wantErr: true,
+    },
+    ```
+
+- [ ] **Step 2: Run to verify the new case fails.**
+  Run: `go test ./internal/capabilities/ -run TestValidateStrictMode -v`
+  Expected: FAIL — `"full mode with all caps"` now errors (current code checks `caps.Seccomp` which is set, so it actually still passes) AND the new "kernel-supported but not installable" case does NOT error (current code passes it) → `wantErr true` violated. (At least the new case fails under current code.)
+
+- [ ] **Step 3: Change the `ModeFull` seccomp check.** In `internal/capabilities/validate.go`, `ValidateStrictMode`, `ModeFull` case:
+  ```go
+  case ModeFull:
+      if !caps.SeccompInstallable {
+          return fmt.Errorf("strict mode %q requires an installable seccomp filter", mode)
+      }
+      if !caps.EBPF {
+          return fmt.Errorf("strict mode %q requires eBPF", mode)
+      }
+      if !caps.FUSE {
+          return fmt.Errorf("strict mode %q requires FUSE", mode)
+      }
+  ```
+  (Only the first check changes: `!caps.Seccomp` → `!caps.SeccompInstallable`, and its message.)
+
+- [ ] **Step 4: Run to verify pass.**
+  Run: `go test ./internal/capabilities/ -run TestValidateStrictMode -v` → PASS (all cases).
+
+- [ ] **Step 5: Commit** (only `validate.go` + `validate_test.go`).
+
+---
+
 ## Self-Review
 
 **1. Spec coverage:**

--- a/docs/superpowers/plans/2026-05-25-issue-390-detect-installable-honesty.md
+++ b/docs/superpowers/plans/2026-05-25-issue-390-detect-installable-honesty.md
@@ -1,0 +1,375 @@
+# Detect honesty for uninstallable seccomp — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `agentsh detect` (and the shared `SelectMode`) consume the `SeccompInstallable` probe so the Command Control domain's `✓/-` marks, `active backend` label, and score agree on hosts where the seccomp `NEW_LISTENER` filter can't install (e.g. Daytona/`EBUSY`).
+
+**Architecture:** Three localized edits in `internal/capabilities` on the mode-selection/detect path. `SelectMode` gates `ModeFull` on `SeccompInstallable` (not kernel-support `Seccomp`); `buildLinuxDomains` makes the `ptrace` Command Control backend reflect *actual enforcement* (`Ptrace && PtraceEnabled`) and derives `commandActive` by priority. The existing any-backend `ComputeScore` then yields the correct number with no scorer change; darwin/windows builders and the runtime seccomp install path are untouched.
+
+**Tech Stack:** Go, `//go:build linux` files, standard `go test`.
+
+**Spec:** `docs/superpowers/specs/2026-05-25-issue-390-detect-installable-honesty-design.md`
+
+---
+
+### Task 1: `SelectMode()` requires installable seccomp for `ModeFull`
+
+**Files:**
+- Modify: `internal/capabilities/security_caps.go:111`
+- Test: `internal/capabilities/security_caps_test.go:31-79`
+
+- [ ] **Step 1: Update the test table — fix the existing "full" case and add a "not full when uninstallable" case**
+
+In `internal/capabilities/security_caps_test.go`, replace the `tests` slice in `TestSecurityCapabilities_SelectMode` (currently lines 32-69) with:
+
+```go
+	tests := []struct {
+		name     string
+		caps     SecurityCapabilities
+		expected string
+	}{
+		{
+			name: "full mode when all available and seccomp installable",
+			caps: SecurityCapabilities{
+				Seccomp: true, SeccompInstallable: true, EBPF: true, FUSE: true, Landlock: true,
+				Capabilities: true,
+			},
+			expected: "full",
+		},
+		{
+			name: "not full when seccomp kernel-supported but not installable (falls to landlock)",
+			caps: SecurityCapabilities{
+				Seccomp: true, SeccompInstallable: false, EBPF: true, FUSE: true, Landlock: true,
+				Capabilities: true,
+			},
+			expected: "landlock",
+		},
+		{
+			name: "landlock mode when seccomp unavailable",
+			caps: SecurityCapabilities{
+				Seccomp: false, EBPF: false, FUSE: true, Landlock: true,
+				Capabilities: true,
+			},
+			expected: "landlock",
+		},
+		{
+			name: "landlock-only when FUSE also unavailable",
+			caps: SecurityCapabilities{
+				Seccomp: false, EBPF: false, FUSE: false, Landlock: true,
+				Capabilities: true,
+			},
+			expected: "landlock-only",
+		},
+		{
+			name: "minimal when nothing available",
+			caps: SecurityCapabilities{
+				Seccomp: false, EBPF: false, FUSE: false, Landlock: false,
+				Capabilities: true,
+			},
+			expected: "minimal",
+		},
+	}
+```
+
+- [ ] **Step 2: Run the test to verify the new case fails**
+
+Run: `go test ./internal/capabilities/ -run TestSecurityCapabilities_SelectMode -v`
+Expected: FAIL — subtest `not_full_when_seccomp_kernel-supported_but_not_installable_(falls_to_landlock)` reports `expected mode "landlock", got "full"` (current code keys off `c.Seccomp`).
+
+- [ ] **Step 3: Change the `ModeFull` condition to use `SeccompInstallable`**
+
+In `internal/capabilities/security_caps.go`, in `SelectMode()` (line 109), change the first condition:
+
+```go
+func (c *SecurityCapabilities) SelectMode() string {
+	// Full mode requires a seccomp NEW_LISTENER filter that actually installs
+	// here, not merely kernel user-notify support (issue #390). On hosts where
+	// the kernel supports user-notify but the listener cannot install (e.g.
+	// Daytona/EBUSY), full mode would never actually enforce.
+	if c.SeccompInstallable && c.EBPF && c.FUSE {
+		return ModeFull
+	}
+
+	// Ptrace mode: SYS_PTRACE available and enabled
+	if c.Ptrace && c.PtraceEnabled {
+		return ModePtrace
+	}
+
+	// Landlock mode: Landlock + FUSE (no seccomp)
+	if c.Landlock && c.FUSE {
+		return ModeLandlock
+	}
+
+	// Landlock-only: just Landlock (no FUSE either)
+	if c.Landlock {
+		return ModeLandlockOnly
+	}
+
+	// Minimal: only capabilities dropping
+	return ModeMinimal
+}
+```
+
+(Only the first `if` changes: `c.Seccomp` → `c.SeccompInstallable`.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test ./internal/capabilities/ -run TestSecurityCapabilities_SelectMode -v`
+Expected: PASS (all five subtests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/capabilities/security_caps.go internal/capabilities/security_caps_test.go
+git commit -m "$(cat <<'EOF'
+fix(#390): SelectMode gates full mode on seccomp installability
+
+Full mode now requires SeccompInstallable (a real NEW_LISTENER install),
+not merely kernel user-notify support, so the reported mode is honest on
+hosts where the listener cannot install (e.g. Daytona/EBUSY).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Command Control backends reflect actual enforcement in `buildLinuxDomains`
+
+**Files:**
+- Modify: `internal/capabilities/detect_linux.go:65-69` (`commandActive`), `:113` (ptrace backend), and add `ptraceBackendDetail` helper near `seccompBackendDetail` (`:28-45`)
+- Test: `internal/capabilities/detect_linux_test.go` (new tests + update three existing ones)
+
+- [ ] **Step 1: Write/adjust the failing tests**
+
+In `internal/capabilities/detect_linux_test.go`:
+
+**(a)** Add two new tests:
+
+```go
+func TestBuildLinuxDomains_PtraceBackendReflectsEnforcement(t *testing.T) {
+	// Capability present but not enabled in config: not actively enforcing.
+	idle := buildLinuxDomains(&SecurityCapabilities{Ptrace: true, PtraceEnabled: false})
+	pb := findBackend(t, idle, "Command Control", "ptrace")
+	if pb.Available {
+		t.Error("ptrace backend must be unavailable when ptrace is a present-but-unengaged capability")
+	}
+	if pb.Detail != "available, not active (enable ptrace mode)" {
+		t.Errorf("ptrace detail = %q, want the actionable not-active message", pb.Detail)
+	}
+
+	// Capability present AND enabled: actively enforcing.
+	active := buildLinuxDomains(&SecurityCapabilities{Ptrace: true, PtraceEnabled: true})
+	ab := findBackend(t, active, "Command Control", "ptrace")
+	if !ab.Available {
+		t.Error("ptrace backend must be available when ptrace is enabled (actively enforcing)")
+	}
+	if ab.Detail != "" {
+		t.Errorf("ptrace detail = %q, want empty when actively enforcing", ab.Detail)
+	}
+}
+
+func TestBuildLinuxDomains_CommandActivePriority(t *testing.T) {
+	// seccomp installable -> seccomp-execve is the active backend.
+	d := buildLinuxDomains(&SecurityCapabilities{SeccompInstallable: true})
+	if got := findDomain(t, d, "Command Control").Active; got != "seccomp-execve" {
+		t.Errorf("active = %q, want seccomp-execve when seccomp is installable", got)
+	}
+
+	// seccomp not installable, ptrace not enforcing -> no active backend.
+	d = buildLinuxDomains(&SecurityCapabilities{SeccompInstallable: false, Ptrace: true, PtraceEnabled: false})
+	if got := findDomain(t, d, "Command Control").Active; got != "" {
+		t.Errorf("active = %q, want empty when nothing enforces command control", got)
+	}
+
+	// seccomp not installable, ptrace enforcing (mode==ptrace) -> ptrace active.
+	d = buildLinuxDomains(&SecurityCapabilities{SeccompInstallable: false, Ptrace: true, PtraceEnabled: true})
+	if got := findDomain(t, d, "Command Control").Active; got != "ptrace" {
+		t.Errorf("active = %q, want ptrace when ptrace is the actively-enforcing fallback", got)
+	}
+}
+```
+
+**(b)** Rewrite the ptrace block of `TestBuildLinuxDomains_SeccompInstallFalseFlipsVerdictAndScore` — replace lines 295-310 (everything after the `seccomp-notify` unavailable assertion, i.e. from the `// ptrace is a genuine fallback` comment to the end of the function) with:
+
+```go
+	// #390: a present-but-unengaged ptrace capability does NOT keep Command
+	// Control's weight — only an actively-enforcing backend scores.
+	caps.Ptrace = true
+	caps.PtraceEnabled = false
+	ccIdle := findDomain(t, buildLinuxDomains(caps), "Command Control")
+	if got := ComputeScore([]ProtectionDomain{ccIdle}); got != 0 {
+		t.Errorf("Command Control should score 0 when ptrace is present but not enabled; got %d", got)
+	}
+
+	// ptrace actively enforcing (capability present AND enabled) keeps the weight.
+	caps.PtraceEnabled = true
+	ccActive := findDomain(t, buildLinuxDomains(caps), "Command Control")
+	if got := ComputeScore([]ProtectionDomain{ccActive}); got != WeightCommandControl {
+		t.Errorf("Command Control should score %d when ptrace is actively enforcing; got %d", WeightCommandControl, got)
+	}
+
+	// Neither seccomp installable nor ptrace active -> score 0.
+	caps.Ptrace = false
+	caps.PtraceEnabled = false
+	ccNone := findDomain(t, buildLinuxDomains(caps), "Command Control")
+	if ComputeScore([]ProtectionDomain{ccNone}) != 0 {
+		t.Error("Command Control should score 0 when neither seccomp-execve nor ptrace is active")
+	}
+}
+```
+
+**(c)** In `TestApplyWrapperAvailability_Missing`, add `PtraceEnabled: true` to the caps literal (currently lines 80-88) so the ptrace backend is actually-enforcing and the existing "ptrace remains available when wrapper missing" assertion (lines 106-108) still holds (ptrace is not wrapper-dependent):
+
+```go
+	caps := &SecurityCapabilities{
+		Seccomp:            true,
+		SeccompInstallable: true,
+		Landlock:           true,
+		LandlockABI:        5,
+		LandlockNetwork:    true,
+		FUSE:               true,
+		Ptrace:             true,
+		PtraceEnabled:      true,
+	}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/capabilities/ -run 'TestBuildLinuxDomains|TestApplyWrapperAvailability_Missing' -v`
+Expected: FAIL —
+- `TestBuildLinuxDomains_PtraceBackendReflectsEnforcement`: ptrace backend currently `Available: caps.Ptrace` (true even when not enabled) and `Detail` empty.
+- `TestBuildLinuxDomains_CommandActivePriority`: `Active` currently hard-wired to `"seccomp-execve"`.
+- `TestBuildLinuxDomains_SeccompInstallFalseFlipsVerdictAndScore`: idle-ptrace case currently scores 25, not 0.
+- (`TestApplyWrapperAvailability_Missing` compiles and still passes — it's adjusted to stay green once the impl lands.)
+
+- [ ] **Step 3: Add the `ptraceBackendDetail` helper**
+
+In `internal/capabilities/detect_linux.go`, after `seccompBackendDetail` (ends line 45), add:
+
+```go
+// ptraceBackendDetail explains the ptrace Command Control backend's verdict.
+// ptrace enforcement is opt-in (config: sandbox ptrace mode), and detect is
+// config-agnostic, so on most hosts this reports the capability as
+// present-but-not-active. The capability itself stays visible in the flat
+// CAPABILITIES section (caps.Ptrace, via backwardCompatCaps). Issue #390.
+func ptraceBackendDetail(caps *SecurityCapabilities) string {
+	if caps.Ptrace && caps.PtraceEnabled {
+		return "" // actively enforcing; the ✓ speaks for itself
+	}
+	if caps.Ptrace {
+		return "available, not active (enable ptrace mode)"
+	}
+	return "" // capability absent; the - speaks for itself
+}
+```
+
+- [ ] **Step 4: Make `commandActive` priority-based**
+
+In `internal/capabilities/detect_linux.go`, replace the current `commandActive` block (lines 65-69):
+
+```go
+	mode := caps.SelectMode()
+	commandActive := "seccomp-execve"
+	if mode == ModePtrace {
+		commandActive = "ptrace"
+	}
+```
+
+with a priority chain mirroring the `networkActive` block below it:
+
+```go
+	mode := caps.SelectMode()
+	commandActive := ""
+	if caps.SeccompInstallable {
+		commandActive = "seccomp-execve"
+	} else if mode == ModePtrace {
+		commandActive = "ptrace"
+	}
+```
+
+- [ ] **Step 5: Make the ptrace backend reflect actual enforcement**
+
+In `internal/capabilities/detect_linux.go`, in the Command Control domain (line 113), change the ptrace backend from:
+
+```go
+				{Name: "ptrace", Available: caps.Ptrace, Detail: "", Description: "syscall tracing", CheckMethod: "probe"},
+```
+
+to:
+
+```go
+				{Name: "ptrace", Available: caps.Ptrace && caps.PtraceEnabled, Detail: ptraceBackendDetail(caps), Description: "syscall tracing", CheckMethod: "probe"},
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `go test ./internal/capabilities/ -run 'TestBuildLinuxDomains|TestApplyWrapperAvailability' -v`
+Expected: PASS (new tests, rewritten score test, and both wrapper-availability tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/capabilities/detect_linux.go internal/capabilities/detect_linux_test.go
+git commit -m "$(cat <<'EOF'
+fix(#390): Command Control reflects actual enforcement in detect
+
+The ptrace backend's Available now tracks actual enforcement
+(Ptrace && PtraceEnabled) rather than mere capability, and commandActive
+falls back by priority (seccomp-execve if installable -> ptrace if mode
+ptrace -> none). With both Command Control backends honest, the existing
+any-backend ComputeScore yields 0/25 on hosts where seccomp can't install
+and ptrace isn't engaged. ptrace capability stays visible in CAPABILITIES.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Whole-suite verification and cross-compile
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the capabilities and server suites**
+
+Run: `go test ./internal/capabilities/... ./internal/server/...`
+Expected: PASS (no regressions in validate, detect, config-generator, or security tests).
+
+- [ ] **Step 2: Build everything (native)**
+
+Run: `go build ./...`
+Expected: success, no output.
+
+- [ ] **Step 3: Verify Windows cross-compile**
+
+Run: `GOOS=windows go build ./...`
+Expected: success (changed files are `//go:build linux`; darwin/windows builders untouched).
+
+- [ ] **Step 4: Sanity-check detect output on this host**
+
+Run: `go run ./cmd/agentsh detect`
+Expected: the `COMMAND CONTROL` domain's `ptrace` row shows `-  available, not active (enable ptrace mode)`; if this host's seccomp install probe succeeds, `seccomp-execve` shows `✓` and `active backend: seccomp-execve` with `25/25`; if it fails, `seccomp-execve` shows `-`, no `active backend` line, and Command Control is `0/25`. `CAPABILITIES` still lists `ptrace ✓`.
+
+- [ ] **Step 5: Commit (only if Step 4 surfaced a doc/comment tweak; otherwise skip)**
+
+No code change expected here. If a comment/detail string needed adjusting, commit it with an explicit `git add` of just that file.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- SelectMode consumes `SeccompInstallable` → Task 1. ✓
+- `commandActive` priority chain → Task 2 Step 4. ✓
+- ptrace backend `Available` = actual enforcement + explanatory `Detail` → Task 2 Steps 3 & 5. ✓
+- `ComputeScore` unchanged, Daytona → CC 0/25 → verified by the rewritten score test (Task 2 Step 1b) and the detect sanity check (Task 3 Step 4). ✓
+- darwin/windows builders + runtime install path untouched → no task modifies them; cross-compile verified (Task 3 Step 3). ✓
+- ptrace capability stays in `CAPABILITIES` → unchanged `backwardCompatCaps`; asserted indirectly by existing `TestDetect_Linux` capability-key check and the Task 3 sanity check. ✓
+- Behavior change (honest mode / strict fail-fast) → falls out of the SelectMode change; existing `validate_test.go` passes explicit modes so stays green (Task 3 Step 1). ✓
+
+**2. Placeholder scan:** No TBD/TODO; every code step shows complete code and exact commands. ✓
+
+**3. Type consistency:** `ptraceBackendDetail(caps *SecurityCapabilities) string` matches the call site in Task 2 Step 5; `commandActive` remains a `string` assigned to the domain `Active`; `findDomain`/`findBackend` helpers already exist in `detect_linux_test.go:321-342`; `WeightCommandControl` is defined in `detect_result.go:66`. ✓

--- a/docs/superpowers/specs/2026-05-25-issue-390-detect-installable-honesty-design.md
+++ b/docs/superpowers/specs/2026-05-25-issue-390-detect-installable-honesty-design.md
@@ -1,0 +1,259 @@
+# Detect honesty for uninstallable seccomp Design
+
+Issue: #390 (follow-up to #388)
+
+## Summary
+
+After #388, `agentsh detect` distinguishes "kernel supports user-notify"
+(`seccomp_user_notify_kernel`) from "a real `NEW_LISTENER` filter installs here"
+(`SeccompInstallable`). The per-backend `✓/-` marks now read correctly. But the
+**domain scoring and the active-backend label still overstate** protection where
+the install probe fails (e.g. Daytona, `EBUSY`): `agentsh detect` reports
+`COMMAND CONTROL 25/25` with `active backend: seccomp-execve` while the
+`seccomp-execve` backend itself shows `-`, and the overall Protection Score does
+not drop.
+
+Three spots on the mode-selection / detect path never consumed the
+`SeccompInstallable` signal:
+
+1. `SelectMode()` keys `ModeFull` off `c.Seccomp` (kernel-supported), not
+   `c.SeccompInstallable`.
+2. `commandActive` in `buildLinuxDomains` is hard-wired to `"seccomp-execve"`
+   unless `ModePtrace`.
+3. The `ptrace` Command Control backend's `Available: caps.Ptrace` means
+   *capability present*, not *actively enforcing* — so `ComputeScore`
+   (full weight if **any** backend `Available`) awards Command Control its
+   full 25 on the strength of a latent, unengaged capability.
+
+This design makes the two Command Control backends' `Available` flags **honest**
+so the existing any-backend `ComputeScore` naturally yields the right number, and
+makes `SelectMode` report the mode that actually applies. `ComputeScore` and the
+darwin/windows domain builders are **not touched**.
+
+## Goals
+
+- On a host where the seccomp `NEW_LISTENER` install fails but the kernel
+  supports user-notify (Daytona/`EBUSY`): `agentsh detect` reports
+  `COMMAND CONTROL 0/25`, no `active backend` line for Command Control, and the
+  overall Protection Score drops accordingly.
+- The `✓/-` marks, the `active backend` label, and the domain score **agree**:
+  what shows `-` does not contribute to the score.
+- The startup-reported security mode is honest: on such a host the server
+  reports `landlock` (or lower), not `full`; `WarnDegraded` fires; strict/minimum
+  mode validation evaluates against the real mode (fail-fast at startup rather
+  than per-command failures later).
+- The ptrace *capability* remains visible to operators in the flat
+  `CAPABILITIES` section (`ptrace ✓`), with an actionable detail in the domain
+  view explaining why the domain backend shows `-`.
+
+## Non-Goals
+
+- **No change to what actually gets installed at runtime.** The seccomp filter
+  install is gated by config (`sandbox.seccomp.*.enabled`), not by the mode
+  string. This design changes reporting + the mode-selection/validation gates
+  only. A command that succeeded/failed before still does so.
+- **No runtime seccomp→ptrace auto-fallback.** When seccomp can't install,
+  command-control is simply reported as not enforced; the operator must enable
+  ptrace explicitly to regain it. (Considered and explicitly deferred — see
+  "Decisions" below.)
+- **No change to `ComputeScore`'s semantics** (stays "full weight if any backend
+  `Available`") and **no change to the darwin/windows domain builders.** Those
+  builders omit `Active` on several domains, so reinterpreting `ComputeScore`
+  around `Active` would zero their scores — out of scope and unnecessary here.
+- No change to the `seccomp_user_notify` / `seccomp_user_notify_kernel`
+  capability split from #388.
+
+## Background
+
+- `SelectMode()` (`internal/capabilities/security_caps.go:109`) is shared by
+  **both** `agentsh detect` (`detect_linux.go:65,305`) and the server runtime
+  (`internal/server/security.go:22`, via `DetectAndValidateSecurityMode`). It
+  feeds: the reported mode, `WarnDegraded` (`security.go:40`, warns when
+  `mode != ModeFull`), and `ValidateStrictMode`/`ValidateMinimumMode`
+  (`security.go:26-37`). It does **not** gate the seccomp install — a grep for
+  `ModeFull` / `mode == "full"` shows no install gate keys off it.
+- `buildLinuxDomains` (`detect_linux.go:48`) is used **only** by `agentsh
+  detect`. The server uses `DetectSecurityCapabilities` + `SelectMode` directly,
+  not the domain builder. So the ptrace-backend and `commandActive` edits affect
+  detect output only.
+- `ComputeScore` (`internal/capabilities/detect_result.go:74`): each domain
+  scores its full `Weight` if **any** backend has `Available == true`, else 0.
+  Shared across linux/darwin/windows.
+- `backwardCompatCaps` (`detect_linux.go:237`) sets `"ptrace": caps.Ptrace`
+  directly from the capability flag and does **not** read the ptrace domain
+  backend — so changing the domain backend's `Available` does not affect the
+  `CAPABILITIES` map; `ptrace ✓` stays.
+- `applyWrapperAvailability` (`detect_linux.go:165`) already re-derives Command
+  Control's `Active` as `"ptrace"` only when `mode == ModePtrace`
+  (`detect_linux.go:212`), consistent with the `commandActive` change below.
+- In `agentsh detect`, `DetectSecurityCapabilities` never sets `PtraceEnabled`
+  (it is a config-derived flag set in the server flow), so it is `false` in
+  detect. The ptrace domain backend therefore shows `-` in `agentsh detect` on
+  every host; the actionable detail explains this.
+
+## Design
+
+### 1. `SelectMode()` consumes installability
+
+`internal/capabilities/security_caps.go`:
+
+```go
+func (c *SecurityCapabilities) SelectMode() string {
+    // Full mode requires a seccomp NEW_LISTENER filter that actually installs
+    // here, not merely kernel user-notify support (issue #390).
+    if c.SeccompInstallable && c.EBPF && c.FUSE {
+        return ModeFull
+    }
+    if c.Ptrace && c.PtraceEnabled {
+        return ModePtrace
+    }
+    if c.Landlock && c.FUSE {
+        return ModeLandlock
+    }
+    if c.Landlock {
+        return ModeLandlockOnly
+    }
+    return ModeMinimal
+}
+```
+
+Only the first condition changes (`c.Seccomp` → `c.SeccompInstallable`).
+
+### 2. Honest Command Control backends in `buildLinuxDomains`
+
+`internal/capabilities/detect_linux.go`.
+
+Replace the hard-wired `commandActive` (currently `:66-69`) with a
+priority chain mirroring the existing `networkActive` block:
+
+```go
+mode := caps.SelectMode()
+
+commandActive := ""
+if caps.SeccompInstallable {
+    commandActive = "seccomp-execve"
+} else if mode == ModePtrace {
+    commandActive = "ptrace"
+}
+```
+
+Add a helper for the ptrace backend detail:
+
+```go
+// ptraceBackendDetail explains the ptrace Command Control backend's verdict.
+// ptrace enforcement is opt-in (config: sandbox ptrace mode), so detect — which
+// is config-agnostic — reports the capability as present-but-not-active. The
+// capability itself remains visible in the flat CAPABILITIES section
+// (caps.Ptrace). Issue #390.
+func ptraceBackendDetail(caps *SecurityCapabilities) string {
+    if caps.Ptrace && caps.PtraceEnabled {
+        return "" // actively enforcing; the ✓ speaks for itself
+    }
+    if caps.Ptrace {
+        return "available, not active (enable ptrace mode)"
+    }
+    return "" // capability absent; the - speaks for itself
+}
+```
+
+Change the ptrace backend in the Command Control domain (currently `:113`):
+
+```go
+{Name: "ptrace", Available: caps.Ptrace && caps.PtraceEnabled, Detail: ptraceBackendDetail(caps), Description: "syscall tracing", CheckMethod: "probe"},
+```
+
+The `seccomp-execve` backend is unchanged (`Available: caps.SeccompInstallable`,
+from #388). `commandActive` continues to be assigned to the domain's `Active`.
+
+### 3. `ComputeScore` — no change
+
+With both Command Control backends now honest:
+- seccomp installs here → `seccomp-execve` Available → Command Control 25.
+- seccomp can't install, ptrace not actively enforcing → both backends
+  unavailable → Command Control 0.
+- seccomp can't install, ptrace actively enforcing (`Ptrace && PtraceEnabled`,
+  `mode == ModePtrace`) → ptrace Available → Command Control 25, active=ptrace.
+
+### Resulting Daytona output
+
+```
+COMMAND CONTROL                          0/25
+  seccomp-execve  -  kernel supports user-notify, but NEW_LISTENER ...EBUSY  execve interception
+  ptrace          -  available, not active (enable ptrace mode)              syscall tracing
+```
+
+No `active backend` line (`Active == ""`; `Table()` already suppresses
+empty/`none`). Overall Protection Score drops by the Command Control weight
+(e.g. 85 → 60). `CAPABILITIES` still shows `ptrace ✓`.
+
+## Decisions
+
+- **Honest reporting, not auto-fallback.** When seccomp can't install and ptrace
+  is a present-but-unengaged capability, the fix reports Command Control as
+  unenforced (active=none, 0/25) rather than auto-engaging ptrace. Auto-engaging
+  ptrace is a larger runtime-enforcement change with real overhead and its own
+  unverified behavior on the affected platforms; it is deferred.
+- **`Available` means "counts toward this domain's protection."** Making the
+  ptrace backend's `Available` track actual enforcement (rather than mere
+  capability) keeps the `✓/-` marks, the `active backend` label, and the score
+  mutually consistent — the exact inconsistency #390 reports. The capability is
+  not lost; it remains in the `CAPABILITIES` section.
+- **Linux-only, `ComputeScore` untouched.** The darwin/windows builders omit
+  `Active` on several domains; an `Active`-based scorer would regress them.
+  Keeping the any-backend scorer and fixing the linux backends' honesty avoids
+  cross-platform scope and risk.
+
+## Behavior changes
+
+- On a host where seccomp can't install, the server reports `landlock`
+  (or lower) instead of `full`; `WarnDegraded` (if configured) fires.
+- `Security.Strict` (or `MinimumMode`) requiring a level seccomp can't provide
+  now fails at **startup** rather than surfacing as per-command seccomp install
+  failures later. This is the intended fail-fast.
+- `agentsh detect` shows the ptrace Command Control backend as `-` with the
+  detail `available, not active (enable ptrace mode)` (it is opt-in and detect
+  is config-agnostic).
+
+## Error handling
+
+No new error paths. `SeccompInstallable` is already fail-safe (true only on a
+clean exit-0 install probe; #388). The changes are pure boolean/label derivation.
+
+## Testing
+
+`internal/capabilities/security_caps_test.go`:
+- `{Seccomp:true, SeccompInstallable:false, EBPF:true, FUSE:true}` ⇒ `SelectMode()`
+  is **not** `ModeFull` (lands on `ModeLandlock`, since `Landlock`/`FUSE` per the
+  case).
+- `{SeccompInstallable:true, EBPF:true, FUSE:true}` ⇒ `ModeFull`.
+- Update any existing case that set only `Seccomp:true` and expected `ModeFull`
+  to also set `SeccompInstallable:true`.
+
+`internal/capabilities/detect_linux_test.go`:
+- ptrace backend `Available == false` when `{Ptrace:true, PtraceEnabled:false}`,
+  and its `Detail == "available, not active (enable ptrace mode)"`.
+- ptrace backend `Available == true` when `{Ptrace:true, PtraceEnabled:true}`.
+- `commandActive`/Command Control `Active`:
+  - `SeccompInstallable:true` ⇒ `"seccomp-execve"`.
+  - `SeccompInstallable:false`, not ptrace mode ⇒ `""`.
+- Integration: a Daytona-like `SecurityCapabilities`
+  (`Seccomp:true, SeccompInstallable:false, FUSE:true, Landlock:true, EBPF:true,
+  Ptrace:true, PtraceEnabled:false`) run through `buildLinuxDomains` +
+  `ComputeScore` ⇒ Command Control domain `Score == 0`; the same caps with
+  `SeccompInstallable:true` ⇒ Command Control `Score == 25`.
+- Confirm a host with `SeccompInstallable:true` still reports
+  `active backend: seccomp-execve` and Command Control 25 (no regression).
+
+Confirm existing `internal/capabilities`, `internal/server` suites stay green,
+darwin/windows detect tests are untouched, and `GOOS=windows go build ./...`
+succeeds (the changed files are `//go:build linux`).
+
+## Affected files
+
+- `internal/capabilities/security_caps.go` — `SelectMode()` first condition.
+- `internal/capabilities/detect_linux.go` — `commandActive` priority chain,
+  `ptraceBackendDetail` helper, ptrace backend `Available`/`Detail`.
+- Tests in `internal/capabilities/security_caps_test.go`,
+  `internal/capabilities/detect_linux_test.go`.
+- `ComputeScore`, darwin/windows builders, `backwardCompatCaps`, and the runtime
+  install path are intentionally **unchanged**.

--- a/internal/capabilities/detect_linux.go
+++ b/internal/capabilities/detect_linux.go
@@ -44,6 +44,21 @@ func seccompBackendDetail(caps *SecurityCapabilities) string {
 	return "" // kernel doesn't support user-notify; existing Available=false speaks for itself
 }
 
+// ptraceBackendDetail explains the ptrace Command Control backend's verdict.
+// ptrace enforcement is opt-in (config: sandbox ptrace mode), and detect is
+// config-agnostic, so on most hosts this reports the capability as
+// present-but-not-active. The capability itself stays visible in the flat
+// CAPABILITIES section (caps.Ptrace, via backwardCompatCaps). Issue #390.
+func ptraceBackendDetail(caps *SecurityCapabilities) string {
+	if caps.Ptrace && caps.PtraceEnabled {
+		return "" // actively enforcing; the ✓ speaks for itself
+	}
+	if caps.Ptrace {
+		return "available, not active (enable ptrace mode)"
+	}
+	return "" // capability absent; the - speaks for itself
+}
+
 // buildLinuxDomains builds the five protection domains from cached probe results and capability flags.
 func buildLinuxDomains(caps *SecurityCapabilities) []ProtectionDomain {
 	fuseMountMethod := "none"
@@ -63,8 +78,10 @@ func buildLinuxDomains(caps *SecurityCapabilities) []ProtectionDomain {
 	}
 
 	mode := caps.SelectMode()
-	commandActive := "seccomp-execve"
-	if mode == ModePtrace {
+	commandActive := ""
+	if caps.SeccompInstallable {
+		commandActive = "seccomp-execve"
+	} else if mode == ModePtrace {
 		commandActive = "ptrace"
 	}
 
@@ -110,7 +127,7 @@ func buildLinuxDomains(caps *SecurityCapabilities) []ProtectionDomain {
 			Name: "Command Control", Weight: WeightCommandControl,
 			Backends: []DetectedBackend{
 				{Name: "seccomp-execve", Available: caps.SeccompInstallable, Detail: seccompBackendDetail(caps), Description: "execve interception", CheckMethod: "probe"},
-				{Name: "ptrace", Available: caps.Ptrace, Detail: "", Description: "syscall tracing", CheckMethod: "probe"},
+				{Name: "ptrace", Available: caps.Ptrace && caps.PtraceEnabled, Detail: ptraceBackendDetail(caps), Description: "syscall tracing", CheckMethod: "probe"},
 			},
 			Active: commandActive,
 		},

--- a/internal/capabilities/detect_linux_test.go
+++ b/internal/capabilities/detect_linux_test.go
@@ -85,6 +85,7 @@ func TestApplyWrapperAvailability_Missing(t *testing.T) {
 		LandlockNetwork:    true,
 		FUSE:               true,
 		Ptrace:             true,
+		PtraceEnabled:      true,
 	}
 	caps.FileEnforcement = detectFileEnforcementBackend(caps)
 	domains := buildLinuxDomains(caps)
@@ -292,21 +293,28 @@ func TestBuildLinuxDomains_SeccompInstallFalseFlipsVerdictAndScore(t *testing.T)
 		t.Error("seccomp-notify must be unavailable when install fails")
 	}
 
-	// ptrace is a genuine fallback: with ptrace available, Command Control
-	// keeps full weight even though seccomp cannot install here. Pins that the
-	// score tracks installability without keying off seccomp specifically.
+	// #390: a present-but-unengaged ptrace capability does NOT keep Command
+	// Control's weight — only an actively-enforcing backend scores.
 	caps.Ptrace = true
-	ccPtrace := findDomain(t, buildLinuxDomains(caps), "Command Control")
-	if got := ComputeScore([]ProtectionDomain{ccPtrace}); got != WeightCommandControl {
-		t.Errorf("Command Control should score %d when ptrace is available (seccomp uninstallable); got %d", WeightCommandControl, got)
+	caps.PtraceEnabled = false
+	ccIdle := findDomain(t, buildLinuxDomains(caps), "Command Control")
+	if got := ComputeScore([]ProtectionDomain{ccIdle}); got != 0 {
+		t.Errorf("Command Control should score 0 when ptrace is present but not enabled; got %d", got)
 	}
 
-	// With seccomp the only command backend, Command Control score must drop.
+	// ptrace actively enforcing (capability present AND enabled) keeps the weight.
+	caps.PtraceEnabled = true
+	ccActive := findDomain(t, buildLinuxDomains(caps), "Command Control")
+	if got := ComputeScore([]ProtectionDomain{ccActive}); got != WeightCommandControl {
+		t.Errorf("Command Control should score %d when ptrace is actively enforcing; got %d", WeightCommandControl, got)
+	}
+
+	// Neither seccomp installable nor ptrace active -> score 0.
 	caps.Ptrace = false
-	domains = buildLinuxDomains(caps)
-	cc := findDomain(t, domains, "Command Control")
-	if ComputeScore([]ProtectionDomain{cc}) != 0 {
-		t.Error("Command Control should score 0 when neither seccomp-execve nor ptrace is available")
+	caps.PtraceEnabled = false
+	ccNone := findDomain(t, buildLinuxDomains(caps), "Command Control")
+	if ComputeScore([]ProtectionDomain{ccNone}) != 0 {
+		t.Error("Command Control should score 0 when neither seccomp-execve nor ptrace is active")
 	}
 }
 
@@ -315,6 +323,48 @@ func TestBuildLinuxDomains_SeccompInstallTrueKeepsVerdict(t *testing.T) {
 	domains := buildLinuxDomains(caps)
 	if !findBackend(t, domains, "Command Control", "seccomp-execve").Available {
 		t.Error("seccomp-execve must be available when install succeeds")
+	}
+}
+
+func TestBuildLinuxDomains_PtraceBackendReflectsEnforcement(t *testing.T) {
+	// Capability present but not enabled in config: not actively enforcing.
+	idle := buildLinuxDomains(&SecurityCapabilities{Ptrace: true, PtraceEnabled: false})
+	pb := findBackend(t, idle, "Command Control", "ptrace")
+	if pb.Available {
+		t.Error("ptrace backend must be unavailable when ptrace is a present-but-unengaged capability")
+	}
+	if pb.Detail != "available, not active (enable ptrace mode)" {
+		t.Errorf("ptrace detail = %q, want the actionable not-active message", pb.Detail)
+	}
+
+	// Capability present AND enabled: actively enforcing.
+	active := buildLinuxDomains(&SecurityCapabilities{Ptrace: true, PtraceEnabled: true})
+	ab := findBackend(t, active, "Command Control", "ptrace")
+	if !ab.Available {
+		t.Error("ptrace backend must be available when ptrace is enabled (actively enforcing)")
+	}
+	if ab.Detail != "" {
+		t.Errorf("ptrace detail = %q, want empty when actively enforcing", ab.Detail)
+	}
+}
+
+func TestBuildLinuxDomains_CommandActivePriority(t *testing.T) {
+	// seccomp installable -> seccomp-execve is the active backend.
+	d := buildLinuxDomains(&SecurityCapabilities{SeccompInstallable: true})
+	if got := findDomain(t, d, "Command Control").Active; got != "seccomp-execve" {
+		t.Errorf("active = %q, want seccomp-execve when seccomp is installable", got)
+	}
+
+	// seccomp not installable, ptrace not enforcing -> no active backend.
+	d = buildLinuxDomains(&SecurityCapabilities{SeccompInstallable: false, Ptrace: true, PtraceEnabled: false})
+	if got := findDomain(t, d, "Command Control").Active; got != "" {
+		t.Errorf("active = %q, want empty when nothing enforces command control", got)
+	}
+
+	// seccomp not installable, ptrace enforcing (mode==ptrace) -> ptrace active.
+	d = buildLinuxDomains(&SecurityCapabilities{SeccompInstallable: false, Ptrace: true, PtraceEnabled: true})
+	if got := findDomain(t, d, "Command Control").Active; got != "ptrace" {
+		t.Errorf("active = %q, want ptrace when ptrace is the actively-enforcing fallback", got)
 	}
 }
 

--- a/internal/capabilities/security_caps.go
+++ b/internal/capabilities/security_caps.go
@@ -107,8 +107,11 @@ func DetectSecurityCapabilities() *SecurityCapabilities {
 
 // SelectMode returns the best available security mode based on capabilities.
 func (c *SecurityCapabilities) SelectMode() string {
-	// Full mode: all features available
-	if c.Seccomp && c.EBPF && c.FUSE {
+	// Full mode requires a seccomp NEW_LISTENER filter that actually installs
+	// here, not merely kernel user-notify support (issue #390). On hosts where
+	// the kernel supports user-notify but the listener cannot install (e.g.
+	// Daytona/EBUSY), full mode would never actually enforce.
+	if c.SeccompInstallable && c.EBPF && c.FUSE {
 		return ModeFull
 	}
 

--- a/internal/capabilities/security_caps_other.go
+++ b/internal/capabilities/security_caps_other.go
@@ -54,8 +54,11 @@ func DetectSecurityCapabilities() *SecurityCapabilities {
 
 // SelectMode returns the best available security mode based on capabilities.
 func (c *SecurityCapabilities) SelectMode() string {
-	// Full mode: all features available
-	if c.Seccomp && c.EBPF && c.FUSE {
+	// Full mode requires a seccomp NEW_LISTENER filter that actually installs
+	// here, not merely kernel user-notify support (issue #390) — kept in sync
+	// with the Linux SelectMode predicate so the two implementations don't
+	// drift.
+	if c.SeccompInstallable && c.EBPF && c.FUSE {
 		return ModeFull
 	}
 

--- a/internal/capabilities/security_caps_test.go
+++ b/internal/capabilities/security_caps_test.go
@@ -35,12 +35,20 @@ func TestSecurityCapabilities_SelectMode(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "full mode when all available",
+			name: "full mode when all available and seccomp installable",
 			caps: SecurityCapabilities{
-				Seccomp: true, EBPF: true, FUSE: true, Landlock: true,
+				Seccomp: true, SeccompInstallable: true, EBPF: true, FUSE: true, Landlock: true,
 				Capabilities: true,
 			},
 			expected: "full",
+		},
+		{
+			name: "not full when seccomp kernel-supported but not installable (falls to landlock)",
+			caps: SecurityCapabilities{
+				Seccomp: true, SeccompInstallable: false, EBPF: true, FUSE: true, Landlock: true,
+				Capabilities: true,
+			},
+			expected: "landlock",
 		},
 		{
 			name: "landlock mode when seccomp unavailable",

--- a/internal/capabilities/validate.go
+++ b/internal/capabilities/validate.go
@@ -17,8 +17,8 @@ var modeRank = map[string]int{
 func ValidateStrictMode(mode string, caps *SecurityCapabilities) error {
 	switch mode {
 	case ModeFull:
-		if !caps.Seccomp {
-			return fmt.Errorf("strict mode %q requires seccomp", mode)
+		if !caps.SeccompInstallable {
+			return fmt.Errorf("strict mode %q requires an installable seccomp filter", mode)
 		}
 		if !caps.EBPF {
 			return fmt.Errorf("strict mode %q requires eBPF", mode)

--- a/internal/capabilities/validate_test.go
+++ b/internal/capabilities/validate_test.go
@@ -16,7 +16,7 @@ func TestValidateStrictMode(t *testing.T) {
 			name: "full mode with all caps",
 			mode: ModeFull,
 			caps: SecurityCapabilities{
-				Seccomp: true, EBPF: true, FUSE: true,
+				Seccomp: true, SeccompInstallable: true, EBPF: true, FUSE: true,
 			},
 			wantErr: false,
 		},
@@ -29,10 +29,18 @@ func TestValidateStrictMode(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "full mode seccomp kernel-supported but not installable",
+			mode: ModeFull,
+			caps: SecurityCapabilities{
+				Seccomp: true, SeccompInstallable: false, EBPF: true, FUSE: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "full mode missing eBPF",
 			mode: ModeFull,
 			caps: SecurityCapabilities{
-				Seccomp: true, EBPF: false, FUSE: true,
+				Seccomp: true, SeccompInstallable: true, EBPF: false, FUSE: true,
 			},
 			wantErr: true,
 		},
@@ -40,7 +48,7 @@ func TestValidateStrictMode(t *testing.T) {
 			name: "full mode missing FUSE",
 			mode: ModeFull,
 			caps: SecurityCapabilities{
-				Seccomp: true, EBPF: true, FUSE: false,
+				Seccomp: true, SeccompInstallable: true, EBPF: true, FUSE: false,
 			},
 			wantErr: true,
 		},


### PR DESCRIPTION
## Summary

Follow-up to #388. After #388, `agentsh detect` correctly distinguished "kernel supports user-notify" from "a real `NEW_LISTENER` filter installs here" (`SeccompInstallable`), but the **domain scoring, the active-backend label, and the reported mode still overstated** protection where the install probe fails (e.g. Daytona/`EBUSY`): `COMMAND CONTROL 25/25` with `active backend: seccomp-execve` while `seccomp-execve` showed `-`, and the Protection Score didn't drop.

This makes the mode-selection / detect path consume `SeccompInstallable`:

- **`SelectMode()`** gates `ModeFull` on `SeccompInstallable` (a real install), not `Seccomp` (kernel support only) — Linux and non-Linux kept in sync. The server now reports the actually-enforcing mode.
- **`buildLinuxDomains`**: the `ptrace` Command Control backend's `Available` now reflects *actual enforcement* (`Ptrace && PtraceEnabled`) with an actionable detail (`available, not active (enable ptrace mode)`), and `commandActive` is derived by priority (seccomp-execve if installable → ptrace if mode==ptrace → none). `ComputeScore` is unchanged; with both backends honest it now yields **0/25** on uninstallable+unengaged hosts. The ptrace *capability* stays visible in the flat `CAPABILITIES` section.
- **`ValidateStrictMode`**: strict `full` mode now requires `SeccompInstallable`, so an explicit `mode: full` + `strict: true` on an uninstallable host fails fast at startup instead of booting while claiming full enforcement.

`ComputeScore`, the darwin/windows domain builders, and the runtime seccomp install path are intentionally untouched.

### Behavior changes
- On a host where seccomp can't install, the reported mode is `landlock` (or lower), not `full`; `WarnDegraded` fires.
- Strict/minimum-mode requirements seccomp can't meet now fail at startup (fail-fast) rather than as per-command install failures later.

## Test Plan
- [x] `go test ./internal/capabilities/... ./internal/server/...` — pass
- [x] `go build ./...`, `GOOS=windows go build ./...`, `GOOS=darwin go build ./...` — pass
- [x] `agentsh detect` on a seccomp-installable host: `seccomp-execve ✓`, `active backend: seccomp-execve`, `25/25`; `ptrace` row `-  available, not active (enable ptrace mode)`; `ptrace ✓` still in CAPABILITIES
- [x] Unit tests pin the Daytona case: Command Control `0/25` when seccomp uninstallable + ptrace unengaged; `25/25` when ptrace actively enforcing
- Pre-existing, unrelated: `internal/fsmonitor/TestFUSE_FsyncFlushLseekPassthrough` fails identically on `main` (FUSE mount permission denied in this sandbox); not touched by this PR

Spec: `docs/superpowers/specs/2026-05-25-issue-390-detect-installable-honesty-design.md`
Plan: `docs/superpowers/plans/2026-05-25-issue-390-detect-installable-honesty.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)