### PR TITLE
fix(#369): wait_killable composition check + exec path honor top-level unix_sockets

### DIFF
--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -189,7 +189,7 @@ func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Stor
 	// startup. This drives buildSeccompWrapperConfig so every wrapper
 	// exec inherits the same boot-time choice. Issue #369.
 	decision, source := decideWaitKillable(context.Background(), waitKillableDeps{
-		cfg:            cfg.Sandbox.Seccomp,
+		cfg:            cfg.Sandbox,
 		kernelSupports: waitKillableKernelSupports,
 		probe:          waitKillableProbe,
 	})

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -171,7 +171,11 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 
 	// Pass seccomp configuration to the wrapper
 	seccompCfg := a.buildSeccompWrapperConfig(s, seccompWrapperParams{
-		UnixSocketEnabled:   a.cfg.Sandbox.Seccomp.UnixSocket.Enabled,
+		// Mirror wrap.go: the wrapper installs unix-socket notify rules from
+		// the OR of seccomp.unix_socket.enabled and top-level
+		// unix_sockets.enabled. Reading only the seccomp field here made the
+		// exec path disagree with the wrap path (issue #369 Gap B).
+		UnixSocketEnabled:   a.cfg.Sandbox.UnixSocketNotifyEnabled(),
 		SignalFilterEnabled: signalFilterActive,
 		ExecveEnabled:       execveEnabled,
 	})

--- a/internal/api/wait_killable_decision.go
+++ b/internal/api/wait_killable_decision.go
@@ -10,7 +10,7 @@ import (
 // inject the kernel-version probe and the behavioral probe without
 // crossing platform build tags.
 type waitKillableDeps struct {
-	cfg            config.SandboxSeccompConfig
+	cfg            config.SandboxConfig
 	kernelSupports func() bool
 	probe          func(context.Context) (bool, error)
 }
@@ -26,7 +26,7 @@ type waitKillableDeps struct {
 //  3. Filter composition cannot trigger the bug → true (probe unneeded).
 //  4. Behavioral probe → its result. Probe errors are fail-safe (false).
 func decideWaitKillable(ctx context.Context, deps waitKillableDeps) (bool, string) {
-	if v := deps.cfg.WaitKillable; v != nil {
+	if v := deps.cfg.Seccomp.WaitKillable; v != nil {
 		return *v, "config"
 	}
 	if !deps.kernelSupports() {

--- a/internal/api/wait_killable_decision_test.go
+++ b/internal/api/wait_killable_decision_test.go
@@ -16,17 +16,31 @@ func TestDecideWaitKillable(t *testing.T) {
 	probeFail := func(_ context.Context) (bool, error) { return false, nil }
 	probeErr := func(_ context.Context) (bool, error) { return false, errors.New("probe boom") }
 
-	compositionRisky := config.SandboxSeccompConfig{
-		UnixSocket:  config.SandboxSeccompUnixConfig{Enabled: true},
-		FileMonitor: config.SandboxSeccompFileMonitorConfig{Enabled: &tt},
+	// Socket family via seccomp.unix_socket + file_monitor → bug-prone composition.
+	compositionRisky := config.SandboxConfig{
+		Seccomp: config.SandboxSeccompConfig{
+			UnixSocket:  config.SandboxSeccompUnixConfig{Enabled: true},
+			FileMonitor: config.SandboxSeccompFileMonitorConfig{Enabled: &tt},
+		},
 	}
-	compositionSafe := config.SandboxSeccompConfig{
-		UnixSocket: config.SandboxSeccompUnixConfig{Enabled: true},
+	// Socket family via the TOP-LEVEL unix_sockets flag only (seccomp.unix_socket
+	// off) + file_monitor → still bug-prone. Issue #369 Gap A: pre-fix this was
+	// misclassified as safe and skipped the probe.
+	compositionRiskyTopLevel := config.SandboxConfig{
+		UnixSockets: config.SandboxUnixSocketsConfig{Enabled: &tt},
+		Seccomp: config.SandboxSeccompConfig{
+			FileMonitor: config.SandboxSeccompFileMonitorConfig{Enabled: &tt},
+		},
+	}
+	compositionSafe := config.SandboxConfig{
+		Seccomp: config.SandboxSeccompConfig{
+			UnixSocket: config.SandboxSeccompUnixConfig{Enabled: true},
+		},
 	}
 
 	cases := []struct {
 		name           string
-		cfg            config.SandboxSeccompConfig
+		cfg            config.SandboxConfig
 		kernelSupports bool
 		probe          func(context.Context) (bool, error)
 		wantDecision   bool
@@ -40,6 +54,10 @@ func TestDecideWaitKillable(t *testing.T) {
 		{name: "probe pass", cfg: compositionRisky, kernelSupports: true, probe: probeOK, wantDecision: true, wantSource: "behavioral_probe"},
 		{name: "probe fail", cfg: compositionRisky, kernelSupports: true, probe: probeFail, wantDecision: false, wantSource: "behavioral_probe"},
 		{name: "probe error fails safe", cfg: compositionRisky, kernelSupports: true, probe: probeErr, wantDecision: false, wantSource: "behavioral_probe_error"},
+		// #369 Gap A: top-level unix_sockets + file_monitor must reach the probe,
+		// not short-circuit to filter_composition_safe.
+		{name: "top-level unix_sockets reaches probe", cfg: compositionRiskyTopLevel, kernelSupports: true, probe: probeFail, wantDecision: false, wantSource: "behavioral_probe"},
+		{name: "top-level unix_sockets probe pass", cfg: compositionRiskyTopLevel, kernelSupports: true, probe: probeOK, wantDecision: true, wantSource: "behavioral_probe"},
 	}
 
 	for _, tc := range cases {
@@ -59,7 +77,7 @@ func TestDecideWaitKillable(t *testing.T) {
 	}
 }
 
-func configWithWait(cfg config.SandboxSeccompConfig, v *bool) config.SandboxSeccompConfig {
-	cfg.WaitKillable = v
+func configWithWait(cfg config.SandboxConfig, v *bool) config.SandboxConfig {
+	cfg.Seccomp.WaitKillable = v
 	return cfg
 }

--- a/internal/api/wrap.go
+++ b/internal/api/wrap.go
@@ -406,10 +406,7 @@ func (a *App) wrapInitCore(s *session.Session, sessionID string, req types.WrapI
 	// NOTE: Signal filter is disabled when execve interception is enabled because
 	// stacking two seccomp USER_NOTIF filters causes notification delivery failures
 	// (the signal filter's semaphore interferes with execve notification reception).
-	unixSocketEnabled := a.cfg.Sandbox.Seccomp.UnixSocket.Enabled
-	if a.cfg.Sandbox.UnixSockets.Enabled != nil && *a.cfg.Sandbox.UnixSockets.Enabled {
-		unixSocketEnabled = true
-	}
+	unixSocketEnabled := a.cfg.Sandbox.UnixSocketNotifyEnabled()
 	forceNotifyForPreAckCgroup := wrapNeedsCgroupBeforeAck(a, s)
 	if forceNotifyForPreAckCgroup {
 		// Pre-ACK cgroup/eBPF setup only happens after the wrapper hands a

--- a/internal/config/seccomp_wait_killable.go
+++ b/internal/config/seccomp_wait_killable.go
@@ -1,25 +1,46 @@
 package config
 
+// UnixSocketNotifyEnabled reports whether the seccomp wrapper will install
+// unix-socket (socket-family) USER_NOTIF rules based on config alone. It is
+// the OR of sandbox.seccomp.unix_socket.enabled and an explicitly-true
+// sandbox.unix_sockets.enabled, mirroring the wrapper's resolution in
+// internal/api/wrap.go (a nil top-level flag contributes nothing here, matching
+// that path; applyDefaults populates it in production).
+//
+// Centralised so the wait_killable filter-composition check, the wrap-init
+// path, and the direct exec path all agree on the wrapper's filter shape
+// instead of each re-deriving it from a single field. Issue #369: a
+// top-level-only `sandbox.unix_sockets.enabled` made the composition check miss
+// the socket family, short-circuit to "filter_composition_safe", and skip the
+// behavioral WAIT_KILLABLE_RECV probe entirely.
+func (c SandboxConfig) UnixSocketNotifyEnabled() bool {
+	if c.Seccomp.UnixSocket.Enabled {
+		return true
+	}
+	return c.UnixSockets.Enabled != nil && *c.UnixSockets.Enabled
+}
+
 // WaitKillableFilterCompositionTriggersBug returns true when the effective
 // seccomp filter for the given config would install notify rules from both
-// the socket family (unix_socket) AND the file/metadata family
-// (file_monitor or intercept_metadata). This is the known-bad combination
-// from issue #369: on kernels that lie about WAIT_KILLABLE_RECV support
-// (e.g. 6.12.67 with ProcessVMReadv=ENOSYS), the wrapped process is killed
-// by signal during the post-execve syscall storm when this combination is
-// present together with WAIT_KILLABLE_RECV.
+// the socket family (unix_socket / top-level unix_sockets) AND the
+// file/metadata family (file_monitor or intercept_metadata). This is the
+// known-bad combination from issue #369: on kernels that lie about
+// WAIT_KILLABLE_RECV support (e.g. 6.12.67 with ProcessVMReadv=ENOSYS), the
+// wrapped process is killed by signal during the post-execve syscall storm
+// when this combination is present together with WAIT_KILLABLE_RECV.
 //
-// The function operates on effective config (resolving FileMonitor.*
-// defaults exactly as buildSeccompWrapperConfig does) so that the gotcha
-// in the issue's bisection table — file_monitor.enabled=false with
-// enforce_without_fuse=true still installs metadata notify rules — is
-// caught correctly.
-func WaitKillableFilterCompositionTriggersBug(cfg SandboxSeccompConfig) bool {
-	socketFamily := cfg.UnixSocket.Enabled
+// It takes the whole SandboxConfig so socket-family detection uses the same
+// OR the wrapper does (UnixSocketNotifyEnabled), and resolves FileMonitor.*
+// defaults exactly as buildSeccompWrapperConfig does — so the gotcha in the
+// issue's bisection table (file_monitor.enabled=false with
+// enforce_without_fuse=true still installs metadata notify rules) is caught.
+func WaitKillableFilterCompositionTriggersBug(cfg SandboxConfig) bool {
+	socketFamily := cfg.UnixSocketNotifyEnabled()
 
-	fmDefault := FileMonitorBoolWithDefault(cfg.FileMonitor.EnforceWithoutFUSE, false)
-	fileFamily := FileMonitorBoolWithDefault(cfg.FileMonitor.Enabled, false) ||
-		FileMonitorBoolWithDefault(cfg.FileMonitor.InterceptMetadata, fmDefault)
+	fm := cfg.Seccomp.FileMonitor
+	fmDefault := FileMonitorBoolWithDefault(fm.EnforceWithoutFUSE, false)
+	fileFamily := FileMonitorBoolWithDefault(fm.Enabled, false) ||
+		FileMonitorBoolWithDefault(fm.InterceptMetadata, fmDefault)
 
 	return socketFamily && fileFamily
 }

--- a/internal/config/seccomp_wait_killable_test.go
+++ b/internal/config/seccomp_wait_killable_test.go
@@ -8,70 +8,90 @@ func TestWaitKillableFilterCompositionTriggersBug(t *testing.T) {
 	tt := boolPtr(true)
 	ff := boolPtr(false)
 
+	// seccompComposition wraps a SandboxSeccompConfig into a SandboxConfig so the
+	// existing socket-via-seccomp.unix_socket cases read unchanged.
+	seccompComposition := func(s SandboxSeccompConfig) SandboxConfig {
+		return SandboxConfig{Seccomp: s}
+	}
+
 	cases := []struct {
 		name string
-		cfg  SandboxSeccompConfig
+		cfg  SandboxConfig
 		want bool
 	}{
 		{
 			name: "all off",
-			cfg:  SandboxSeccompConfig{},
+			cfg:  SandboxConfig{},
 			want: false,
 		},
 		{
-			name: "only socket family",
-			cfg: SandboxSeccompConfig{
+			name: "only socket family (seccomp.unix_socket)",
+			cfg: seccompComposition(SandboxSeccompConfig{
 				UnixSocket: SandboxSeccompUnixConfig{Enabled: true},
-			},
+			}),
 			want: false,
 		},
 		{
 			name: "only file_monitor",
-			cfg: SandboxSeccompConfig{
+			cfg: seccompComposition(SandboxSeccompConfig{
 				FileMonitor: SandboxSeccompFileMonitorConfig{Enabled: tt},
-			},
+			}),
 			want: false,
 		},
 		{
 			name: "socket + file_monitor explicit on",
-			cfg: SandboxSeccompConfig{
+			cfg: seccompComposition(SandboxSeccompConfig{
 				UnixSocket:  SandboxSeccompUnixConfig{Enabled: true},
 				FileMonitor: SandboxSeccompFileMonitorConfig{Enabled: tt},
-			},
+			}),
 			want: true,
 		},
 		{
-			name: "socket + file_monitor disabled but enforce_without_fuse on (intercept_metadata defaults true)",
-			cfg: SandboxSeccompConfig{
-				UnixSocket: SandboxSeccompUnixConfig{Enabled: true},
-				FileMonitor: SandboxSeccompFileMonitorConfig{
-					Enabled:            ff,
-					EnforceWithoutFUSE: tt,
+			// Issue #369 Gap A regression: socket family comes ONLY from the
+			// top-level sandbox.unix_sockets.enabled (the public surface
+			// secure-sandbox emits), with seccomp.unix_socket.enabled left
+			// false. Pre-fix this returned false → probe skipped.
+			name: "top-level unix_sockets + file_monitor (seccomp.unix_socket off)",
+			cfg: SandboxConfig{
+				UnixSockets: SandboxUnixSocketsConfig{Enabled: tt},
+				Seccomp: SandboxSeccompConfig{
+					FileMonitor: SandboxSeccompFileMonitorConfig{Enabled: tt},
 				},
 			},
 			want: true,
 		},
 		{
+			name: "socket + file_monitor disabled but enforce_without_fuse on (intercept_metadata defaults true)",
+			cfg: seccompComposition(SandboxSeccompConfig{
+				UnixSocket: SandboxSeccompUnixConfig{Enabled: true},
+				FileMonitor: SandboxSeccompFileMonitorConfig{
+					Enabled:            ff,
+					EnforceWithoutFUSE: tt,
+				},
+			}),
+			want: true,
+		},
+		{
 			name: "socket + file_monitor disabled, enforce_without_fuse on, intercept_metadata explicitly off",
-			cfg: SandboxSeccompConfig{
+			cfg: seccompComposition(SandboxSeccompConfig{
 				UnixSocket: SandboxSeccompUnixConfig{Enabled: true},
 				FileMonitor: SandboxSeccompFileMonitorConfig{
 					Enabled:            ff,
 					EnforceWithoutFUSE: tt,
 					InterceptMetadata:  ff,
 				},
-			},
+			}),
 			want: false,
 		},
 		{
 			name: "socket + intercept_metadata explicit on, file_monitor explicit off",
-			cfg: SandboxSeccompConfig{
+			cfg: seccompComposition(SandboxSeccompConfig{
 				UnixSocket: SandboxSeccompUnixConfig{Enabled: true},
 				FileMonitor: SandboxSeccompFileMonitorConfig{
 					Enabled:           ff,
 					InterceptMetadata: tt,
 				},
-			},
+			}),
 			want: true,
 		},
 	}
@@ -80,6 +100,55 @@ func TestWaitKillableFilterCompositionTriggersBug(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := WaitKillableFilterCompositionTriggersBug(tc.cfg)
 			if got != tc.want {
+				t.Fatalf("got %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestUnixSocketNotifyEnabled(t *testing.T) {
+	tt := boolPtr(true)
+	ff := boolPtr(false)
+
+	cases := []struct {
+		name string
+		cfg  SandboxConfig
+		want bool
+	}{
+		{name: "both off", cfg: SandboxConfig{}, want: false},
+		{
+			name: "seccomp.unix_socket on",
+			cfg:  SandboxConfig{Seccomp: SandboxSeccompConfig{UnixSocket: SandboxSeccompUnixConfig{Enabled: true}}},
+			want: true,
+		},
+		{
+			name: "top-level unix_sockets explicitly true",
+			cfg:  SandboxConfig{UnixSockets: SandboxUnixSocketsConfig{Enabled: tt}},
+			want: true,
+		},
+		{
+			name: "top-level unix_sockets explicitly false, seccomp off",
+			cfg:  SandboxConfig{UnixSockets: SandboxUnixSocketsConfig{Enabled: ff}},
+			want: false,
+		},
+		{
+			name: "top-level nil contributes nothing (matches wrap.go)",
+			cfg:  SandboxConfig{UnixSockets: SandboxUnixSocketsConfig{Enabled: nil}},
+			want: false,
+		},
+		{
+			name: "either field true wins",
+			cfg: SandboxConfig{
+				UnixSockets: SandboxUnixSocketsConfig{Enabled: ff},
+				Seccomp:     SandboxSeccompConfig{UnixSocket: SandboxSeccompUnixConfig{Enabled: true}},
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.cfg.UnixSocketNotifyEnabled(); got != tc.want {
 				t.Fatalf("got %v want %v", got, tc.want)
 			}
 		})


### PR DESCRIPTION
## Summary

Reopened #369 (v0.20.2 verification by @erans). The seccomp wrapper decides whether to install unix-socket (socket-family) USER_NOTIF rules from the **OR** of `sandbox.seccomp.unix_socket.enabled` and the top-level `sandbox.unix_sockets.enabled` (`wrap.go`). Two other paths read only the seccomp field, so a config that sets **only** the top-level flag (what `secure-sandbox` emits) was handled inconsistently:

- **Gap A** — `WaitKillableFilterCompositionTriggersBug` saw only `seccomp.unix_socket.enabled`, so a top-level-only config was misclassified `filter_composition_safe`, **skipping the behavioral `WAIT_KILLABLE_RECV` probe** and loading the known-bug-prone composition with the flag on (0% success on the affected kernel).
- **Gap B** — `core.go`'s `buildSeccompWrapperConfig` call also read only the seccomp field, so the **exec path disagreed with the wrap path** for the same session/config.

## Fix

Centralize the wrapper's resolution into one helper and use it everywhere:

```go
func (c config.SandboxConfig) UnixSocketNotifyEnabled() bool // seccomp.unix_socket.enabled || (unix_sockets.enabled != nil && *.. )
```

- `WaitKillableFilterCompositionTriggersBug` now takes the full `SandboxConfig` and uses the helper (Gap A); `decideWaitKillable`/`waitKillableDeps` carry `SandboxConfig`; `app.go` passes `cfg.Sandbox`.
- `core.go:174` uses the helper (Gap B).
- `wrap.go` uses the helper in place of the inline OR (DRY; the `forceNotifyForPreAckCgroup` override is preserved on top).

Effect on the reported config: the behavioral probe now actually runs (raw `secure-sandbox` config **0% → ~80%**), and the exec/wrap paths agree.

## Out of scope — Gap C

@erans also found a **residual ~20% kill rate even with `wait_killable: false`** on kernel 6.12.67, vs v0.19.2's 100% — so something *besides* `WAIT_KILLABLE_RECV` also regressed in v0.20.x. That needs the exe.dev kernel to investigate (probe fidelity vs the real post-execve syscall sequence) and is tracked in #369. The `sandbox.seccomp.wait_killable: false` override remains the workaround meanwhile.

## Test Plan
- [x] `go test ./internal/config/... ./internal/api/...`
- [x] `go build ./...`, `GOOS=windows go build ./...`
- [x] New regression tests: top-level `unix_sockets` + `file_monitor` → composition `true` / reaches the probe (would fail pre-fix); direct `UnixSocketNotifyEnabled` table incl. nil-top-level → false (matches wrap.go)

🤖 Generated with [Claude Code](https://claude.com/claude-code)