### PR TITLE
fix(#369): wait_killable probe installs the real production filter (incl. openat2)

### DIFF
--- a/internal/netmonitor/unix/seccomp_linux.go
+++ b/internal/netmonitor/unix/seccomp_linux.go
@@ -328,13 +328,7 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 	// Unix socket monitoring via user-notify
 	if cfg.UnixSocketEnabled {
 		trap := seccomp.ActNotify
-		rules := []seccomp.ScmpSyscall{
-			seccomp.ScmpSyscall(unix.SYS_SOCKET),
-			seccomp.ScmpSyscall(unix.SYS_CONNECT),
-			seccomp.ScmpSyscall(unix.SYS_BIND),
-			seccomp.ScmpSyscall(unix.SYS_LISTEN),
-			seccomp.ScmpSyscall(unix.SYS_SENDTO),
-		}
+		rules := unixSocketNotifySyscalls()
 		for _, sc := range rules {
 			if err := filt.AddRule(sc, trap); err != nil {
 				return nil, fmt.Errorf("add notify rule %v: %w", sc, err)
@@ -370,12 +364,7 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 	// Metadata syscalls via user-notify (when intercept_metadata is enabled)
 	if cfg.InterceptMetadata {
 		trap := seccomp.ActNotify
-		metadataRules := []seccomp.ScmpSyscall{
-			seccomp.ScmpSyscall(unix.SYS_STATX),
-			seccomp.ScmpSyscall(unix.SYS_NEWFSTATAT),
-			seccomp.ScmpSyscall(unix.SYS_FACCESSAT2),
-			seccomp.ScmpSyscall(unix.SYS_READLINKAT),
-		}
+		metadataRules := metadataNotifySyscalls()
 		for _, sc := range metadataRules {
 			if err := filt.AddRule(sc, trap); err != nil {
 				return nil, fmt.Errorf("add metadata rule %v: %w", sc, err)
@@ -560,6 +549,32 @@ func familyToScmpAction(a seccompkg.OnBlockAction) (seccomp.ScmpAction, error) {
 type fileMonitorRuleAdder interface {
 	AddRule(seccomp.ScmpSyscall, seccomp.ScmpAction) error
 	AddRuleConditional(seccomp.ScmpSyscall, seccomp.ScmpAction, []seccomp.ScmpCondition) error
+}
+
+// unixSocketNotifySyscalls returns the socket-family syscalls the wrapper traps
+// via user-notify. Shared between the production filter builder and the
+// WAIT_KILLABLE_RECV behavioral probe (buildProbeFilterBytes) so the two
+// filter compositions can't drift apart (issue #369).
+func unixSocketNotifySyscalls() []seccomp.ScmpSyscall {
+	return []seccomp.ScmpSyscall{
+		seccomp.ScmpSyscall(unix.SYS_SOCKET),
+		seccomp.ScmpSyscall(unix.SYS_CONNECT),
+		seccomp.ScmpSyscall(unix.SYS_BIND),
+		seccomp.ScmpSyscall(unix.SYS_LISTEN),
+		seccomp.ScmpSyscall(unix.SYS_SENDTO),
+	}
+}
+
+// metadataNotifySyscalls returns the metadata syscalls the wrapper traps via
+// user-notify when intercept_metadata is enabled. Shared with the
+// WAIT_KILLABLE_RECV behavioral probe (issue #369).
+func metadataNotifySyscalls() []seccomp.ScmpSyscall {
+	return []seccomp.ScmpSyscall{
+		seccomp.ScmpSyscall(unix.SYS_STATX),
+		seccomp.ScmpSyscall(unix.SYS_NEWFSTATAT),
+		seccomp.ScmpSyscall(unix.SYS_FACCESSAT2),
+		seccomp.ScmpSyscall(unix.SYS_READLINKAT),
+	}
 }
 
 func installFileMonitorRules(adder fileMonitorRuleAdder, action seccomp.ScmpAction, writeOnlyOpens bool) (int, error) {

--- a/internal/netmonitor/unix/wait_killable_probe_filter_test.go
+++ b/internal/netmonitor/unix/wait_killable_probe_filter_test.go
@@ -1,0 +1,111 @@
+//go:build linux && cgo
+// +build linux,cgo
+
+package unix
+
+import (
+	"testing"
+
+	seccomp "github.com/seccomp/libseccomp-golang"
+	"golang.org/x/sys/unix"
+)
+
+// recordingAdder implements fileMonitorRuleAdder, capturing every syscall
+// passed to it so tests can assert which syscalls a rule installer covers
+// without compiling a real BPF program.
+type recordingAdder struct{ syscalls []seccomp.ScmpSyscall }
+
+func (r *recordingAdder) AddRule(sc seccomp.ScmpSyscall, _ seccomp.ScmpAction) error {
+	r.syscalls = append(r.syscalls, sc)
+	return nil
+}
+
+func (r *recordingAdder) AddRuleConditional(sc seccomp.ScmpSyscall, _ seccomp.ScmpAction, _ []seccomp.ScmpCondition) error {
+	r.syscalls = append(r.syscalls, sc)
+	return nil
+}
+
+func (r *recordingAdder) has(nr int) bool {
+	for _, sc := range r.syscalls {
+		if int(sc) == nr {
+			return true
+		}
+	}
+	return false
+}
+
+// TestProbeFilterMirrorsProductionFileMonitor is the issue #369 Gap C1
+// regression guard. It drives the probe's ACTUAL rule composition
+// (addProbeFilterRules — the same path buildProbeFilterBytes uses) through a
+// recording adder and asserts it traps the full bug-prone composition,
+// crucially openat2. openat2's omission let the probe false-pass on glibc>=2.34
+// kernels (ld.so loads shared libraries via openat2, so the probe child's
+// /bin/true linker storm took the kernel fast path and never exercised the
+// notify-dispatch path the kernel bug lives on).
+//
+// Driving addProbeFilterRules (not installFileMonitorRules in isolation) is
+// what makes this a genuine guard: it fails if the probe drops the
+// file-monitor family, the socket family, or the metadata family.
+func TestProbeFilterMirrorsProductionFileMonitor(t *testing.T) {
+	rec := &recordingAdder{}
+	if err := addProbeFilterRules(rec); err != nil {
+		t.Fatalf("addProbeFilterRules: %v", err)
+	}
+
+	for _, want := range []struct {
+		nr   int
+		name string
+	}{
+		{unix.SYS_OPENAT2, "openat2"},       // the regression that caused the false-pass
+		{unix.SYS_OPENAT, "openat"},         // file_monitor
+		{unix.SYS_UNLINKAT, "unlinkat"},     // file_monitor at-family
+		{unix.SYS_RENAMEAT2, "renameat2"},   // file_monitor at-family
+		{unix.SYS_CONNECT, "connect"},       // socket family
+		{unix.SYS_SENDTO, "sendto"},         // socket family
+		{unix.SYS_STATX, "statx"},           // metadata family
+		{unix.SYS_FACCESSAT2, "faccessat2"}, // metadata family
+	} {
+		if !rec.has(want.nr) {
+			t.Errorf("probe filter composition does not trap %s (nr=%d); no longer mirrors production", want.name, want.nr)
+		}
+	}
+}
+
+// TestSharedNotifySyscallHelpers pins the socket and metadata syscall sets that
+// the wrapper and the probe now share (issue #369), so a future edit to one
+// can't silently desync the probe's composition from production.
+func TestSharedNotifySyscallHelpers(t *testing.T) {
+	socket := map[int]bool{}
+	for _, sc := range unixSocketNotifySyscalls() {
+		socket[int(sc)] = true
+	}
+	for _, nr := range []int{unix.SYS_SOCKET, unix.SYS_CONNECT, unix.SYS_BIND, unix.SYS_LISTEN, unix.SYS_SENDTO} {
+		if !socket[nr] {
+			t.Errorf("unixSocketNotifySyscalls missing nr=%d", nr)
+		}
+	}
+
+	meta := map[int]bool{}
+	for _, sc := range metadataNotifySyscalls() {
+		meta[int(sc)] = true
+	}
+	for _, nr := range []int{unix.SYS_STATX, unix.SYS_NEWFSTATAT, unix.SYS_FACCESSAT2, unix.SYS_READLINKAT} {
+		if !meta[nr] {
+			t.Errorf("metadataNotifySyscalls missing nr=%d", nr)
+		}
+	}
+}
+
+// TestBuildProbeFilterBytes_Compiles verifies the probe filter still compiles
+// to a non-empty BPF program after switching to the production composition
+// (erans's "add openat2, existing probe build still works on a healthy kernel"
+// check).
+func TestBuildProbeFilterBytes_Compiles(t *testing.T) {
+	prog, err := buildProbeFilterBytes()
+	if err != nil {
+		t.Fatalf("buildProbeFilterBytes: %v", err)
+	}
+	if len(prog) == 0 || len(prog)%8 != 0 {
+		t.Fatalf("unexpected BPF program length %d (want non-zero multiple of 8)", len(prog))
+	}
+}

--- a/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
+++ b/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
@@ -195,11 +195,47 @@ func runProbeChild() {
 	childSetupFailure("exec failed: %v", lastErr)
 }
 
-// buildProbeFilterBytes constructs the worst-case filter composition
-// (socket family + file/metadata family + execve trap) as raw BPF bytes
-// using the existing libseccomp + exportFilterBPF path. Filter is
-// ActAllow by default so syscalls not in the rule set pass through
-// unimpeded.
+// addProbeFilterRules installs the worst-case bug-prone notify composition
+// (socket family + the full file_monitor family + metadata family) onto adder,
+// reusing the production wrapper's installers so the probe filter cannot drift
+// from what the wrapper actually installs. Factored out of buildProbeFilterBytes
+// so tests can drive it with a recording adder and assert the real composition
+// (notably that openat2 is trapped — issue #369 Gap C1).
+//
+// WriteOnlyOpens is false (worst case: trap every open unconditionally),
+// independent of session config: the probe makes a single server-wide boot
+// decision and the broadest composition is the fail-safe one to test.
+func addProbeFilterRules(adder fileMonitorRuleAdder) error {
+	trap := seccomp.ActNotify
+	for _, sc := range unixSocketNotifySyscalls() {
+		if err := adder.AddRule(sc, trap); err != nil {
+			return fmt.Errorf("add probe socket rule %v: %w", sc, err)
+		}
+	}
+	if _, err := installFileMonitorRules(adder, trap, false); err != nil {
+		return fmt.Errorf("add probe file-monitor rules: %w", err)
+	}
+	for _, sc := range metadataNotifySyscalls() {
+		if err := adder.AddRule(sc, trap); err != nil {
+			return fmt.Errorf("add probe metadata rule %v: %w", sc, err)
+		}
+	}
+	return nil
+}
+
+// buildProbeFilterBytes compiles the probe composition (see addProbeFilterRules)
+// to raw BPF bytes, ActAllow by default so unlisted syscalls pass through.
+//
+// Issue #369 (Gap C1): the previous hand-picked 10-syscall set omitted openat2
+// (and ~18 other file_monitor rules). On glibc >= 2.34 the dynamic linker uses
+// openat2 for shared-library loads, so the probe child's /bin/true exec took
+// the kernel fast path for its linker storm and never exercised the
+// notify-dispatch path the WAIT_KILLABLE_RECV kernel bug lives on — the probe
+// false-passed.
+//
+// Also used by runInstallProbeChild (seccomp_install_probe_linux.go); the
+// larger filter is benign there since that probe only checks loadRawFilter
+// success and never execs or services notifications.
 func buildProbeFilterBytes() ([]byte, error) {
 	filt, err := seccomp.NewFilter(seccomp.ActAllow)
 	if err != nil {
@@ -207,23 +243,8 @@ func buildProbeFilterBytes() ([]byte, error) {
 	}
 	defer filt.Release()
 
-	trap := seccomp.ActNotify
-	syscalls := []seccomp.ScmpSyscall{
-		seccomp.ScmpSyscall(unix.SYS_SOCKET),
-		seccomp.ScmpSyscall(unix.SYS_CONNECT),
-		seccomp.ScmpSyscall(unix.SYS_BIND),
-		seccomp.ScmpSyscall(unix.SYS_LISTEN),
-		seccomp.ScmpSyscall(unix.SYS_SENDTO),
-		seccomp.ScmpSyscall(unix.SYS_OPENAT),
-		seccomp.ScmpSyscall(unix.SYS_STATX),
-		seccomp.ScmpSyscall(unix.SYS_NEWFSTATAT),
-		seccomp.ScmpSyscall(unix.SYS_FACCESSAT2),
-		seccomp.ScmpSyscall(unix.SYS_READLINKAT),
-	}
-	for _, sc := range syscalls {
-		if err := filt.AddRule(sc, trap); err != nil {
-			return nil, fmt.Errorf("add probe rule %v: %w", sc, err)
-		}
+	if err := addProbeFilterRules(filt); err != nil {
+		return nil, err
 	}
 	return exportFilterBPF(filt)
 }


### PR DESCRIPTION
## Summary

Issue #369 **Gap C1** (per @erans's v0.20.3-rc1 verification): the `WAIT_KILLABLE_RECV` behavioral probe (`internal/netmonitor/unix/wait_killable_probe_runner_linux.go`) installed a hand-picked **10-syscall** filter that **omitted `openat2`** (and ~18 other `file_monitor` rules), whereas production installs ~29 rules via `installFileMonitorRules`.

On glibc ≥ 2.34, `ld.so` loads shared libraries via **`openat2`**. So the probe child's `/bin/true` exec fired `openat2` against a filter with no rule for it → kernel fast path → **zero notify dispatches** → the probe never exercised the notify-dispatch path the kernel bug lives on, and **false-passed** (deciding `wait_killable=true` for a bug-prone composition). The probe was passing because of what it *didn't* trap.

## Fix

`buildProbeFilterBytes` now installs the **real worst-case production composition**, reusing the wrapper's own installers so the two can't drift:
- `unixSocketNotifySyscalls()` (socket family)
- `installFileMonitorRules(filt, ActNotify, false)` — `false` = WriteOnlyOpens worst case, traps `openat`/`openat2` unconditionally + the at-family + legacy
- `metadataNotifySyscalls()` (metadata family)

The socket and metadata inline lists in the production filter builder are extracted into the two shared helpers (byte-for-byte equivalent; production behavior unchanged), mirroring the centralization pattern from #394. A `addProbeFilterRules(adder)` seam lets the regression test drive the probe's *actual* composition and assert `openat2` (and the socket/file/metadata families) are trapped — it fails if any family is dropped.

## Scope / what this does NOT fix

This closes the probe's **false-pass on `WAIT_KILLABLE_RECV`**. @erans separately confirmed a **~20% baseline kill rate that persists even with `wait_killable` forced off** (vs v0.19.2's 100%) — a distinct v0.20.x regression independent of the flag (**Gap C2**), to be traced with a kernel/kill capture. Tracked on #369; not addressed here.

**Verification caveat:** the actual kernel-bug reproduction requires the exe.dev kernel (6.12.67, ProcessVMReadv=ENOSYS) and can't be reproduced in CI — this PR ensures the probe filter *faithfully mirrors production* so it can surface the bug there. @erans to test rc2.

## Test Plan
- [x] `go test ./internal/netmonitor/unix/ -count=1`
- [x] `go build ./...`, `GOOS=windows go build ./...`, `go vet ./internal/netmonitor/unix/`
- [x] New `TestProbeFilterMirrorsProductionFileMonitor` drives `addProbeFilterRules` and asserts `openat2` + socket/file/metadata families are trapped (would fail on the pre-fix 10-syscall filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)