### PR TITLE
fix(#369): read injected ptrace syscall return only at a confirmed EXIT stop

### DIFF
--- a/docs/superpowers/plans/2026-05-26-issue-369-inject-exit-stop.md
+++ b/docs/superpowers/plans/2026-05-26-issue-369-inject-exit-stop.md
@@ -1,0 +1,336 @@
+# Ptrace inject EXIT-stop readback — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the ptrace inject path read an injected syscall's return value only at a confirmed syscall-EXIT stop (via `PTRACE_GET_SYSCALL_INFO`), so interleaved `PTRACE_EVENT_SECCOMP`/entry stops on kernels like exe.dev's `6.12.90` can no longer make it read the `-ENOSYS` entry placeholder (issue #369, Gap C).
+
+**Architecture:** Add a raw stop-op accessor and an exit-confirming wait in `internal/ptrace`, then route the three return-value/exit waits in `inject.go` through it. Gated on `t.hasSyscallInfo` (Linux 5.3+); pre-5.3 keeps legacy behavior. No change to `process_vm_*`, user-notify, `WAIT_KILLABLE`, cgroups, or darwin/windows.
+
+**Tech Stack:** Go, `golang.org/x/sys/unix`, raw `PTRACE_GET_SYSCALL_INFO` (`0x420e`), `//go:build linux` (+ `integration` for live-tracee tests).
+
+**Spec:** `docs/superpowers/specs/2026-05-26-issue-369-inject-exit-stop-design.md`
+
+**Testing reality (read first):** The exe.dev desync is stop-delivery-timing specific to `6.12.90` and is **not** reproducible deterministically on a normal CI kernel (a single filtered syscall yields seccomp→exit, which the legacy 2-cycle path already handles). So there is no failing end-to-end test to write for the bug itself. We TDD the load-bearing primitive (`syscallStopOp`) against a live tracee, keep the existing suites green, and rely on erans verifying the end-to-end fix on `v0.20.3-rc3`. This is a deliberate, documented exception to "write a failing test that reproduces the bug."
+
+---
+
+## Task 1: Raw stop-op accessor `syscallStopOp`
+
+**Files:**
+- Modify: `internal/ptrace/syscall_context.go`
+- Test (new): `internal/ptrace/syscall_stop_op_test.go`
+
+- [ ] **Step 1: Write the failing test (live tracee, deterministic on 5.3+)**
+
+Create `internal/ptrace/syscall_stop_op_test.go`:
+
+```go
+//go:build integration && linux
+
+package ptrace
+
+import (
+	"os/exec"
+	"runtime"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestSyscallStopOp_EntryThenExit verifies syscallStopOp classifies a
+// syscall-entry stop as ENTRY(1) and the matching exit stop as EXIT(2).
+// This is the load-bearing primitive for the inject EXIT-stop fix (#369).
+func TestSyscallStopOp_EntryThenExit(t *testing.T) {
+	requirePtrace(t)
+	// ptrace requires all calls for one tracee to come from the same OS thread.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	cmd := exec.Command("/bin/true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Ptrace: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pid := cmd.Process.Pid
+	defer func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() }()
+
+	// Initial stop is the exec/TRACEME stop; reap it.
+	var ws unix.WaitStatus
+	if _, err := unix.Wait4(pid, &ws, 0, nil); err != nil {
+		t.Fatalf("initial wait4: %v", err)
+	}
+
+	tr := &Tracer{hasSyscallInfo: probePtraceSyscallInfo()}
+	if !tr.hasSyscallInfo {
+		t.Skip("PTRACE_GET_SYSCALL_INFO unsupported on this kernel")
+	}
+
+	// Advance to a syscall-entry stop.
+	if err := unix.PtraceSyscall(pid, 0); err != nil {
+		t.Fatalf("ptracesyscall to entry: %v", err)
+	}
+	if _, err := unix.Wait4(pid, &ws, 0, nil); err != nil {
+		t.Fatalf("wait4 entry: %v", err)
+	}
+	if !ws.Stopped() {
+		t.Fatalf("expected stop at entry, status=%v", ws)
+	}
+	op, err := tr.syscallStopOp(pid)
+	if err != nil {
+		t.Fatalf("syscallStopOp entry: %v", err)
+	}
+	if op != ptraceSyscallInfoEntry {
+		t.Fatalf("entry stop op = %d, want %d (ENTRY)", op, ptraceSyscallInfoEntry)
+	}
+
+	// Advance to the matching syscall-exit stop.
+	if err := unix.PtraceSyscall(pid, 0); err != nil {
+		t.Fatalf("ptracesyscall to exit: %v", err)
+	}
+	if _, err := unix.Wait4(pid, &ws, 0, nil); err != nil {
+		t.Fatalf("wait4 exit: %v", err)
+	}
+	if !ws.Stopped() {
+		t.Fatalf("expected stop at exit, status=%v", ws)
+	}
+	op, err = tr.syscallStopOp(pid)
+	if err != nil {
+		t.Fatalf("syscallStopOp exit: %v", err)
+	}
+	if op != ptraceSyscallInfoExit {
+		t.Fatalf("exit stop op = %d, want %d (EXIT)", op, ptraceSyscallInfoExit)
+	}
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails to compile (symbols undefined)**
+
+Run: `go test -tags 'integration linux' ./internal/ptrace/ -run TestSyscallStopOp_EntryThenExit`
+Expected: build failure — `undefined: ptraceSyscallInfoEntry`, `undefined: ... syscallStopOp`.
+
+- [ ] **Step 3: Implement the constants + accessor**
+
+In `internal/ptrace/syscall_context.go`, add after the `ptraceGetSyscallInfo` const (`:13`):
+
+```go
+// ptrace_syscall_info op values (uapi/linux/ptrace.h, PTRACE_SYSCALL_INFO_*).
+const (
+	ptraceSyscallInfoNone    uint8 = 0
+	ptraceSyscallInfoEntry   uint8 = 1
+	ptraceSyscallInfoExit    uint8 = 2
+	ptraceSyscallInfoSeccomp uint8 = 3
+)
+```
+
+And add this method (place after `getSyscallEntryInfo`):
+
+```go
+// syscallStopOp returns the PTRACE_GET_SYSCALL_INFO op for the tracee's current
+// stop (none/entry/exit/seccomp). Valid only at a ptrace syscall or seccomp
+// stop. Unlike getSyscallEntryInfo it does not reject the exit op — the inject
+// path uses it to confirm a syscall-EXIT stop before trusting the return reg.
+func (t *Tracer) syscallStopOp(tid int) (uint8, error) {
+	var info ptraceSyscallInfo
+	_, _, errno := unix.Syscall6(
+		unix.SYS_PTRACE,
+		uintptr(ptraceGetSyscallInfo),
+		uintptr(tid),
+		uintptr(ptraceSyscallInfoSize),
+		uintptr(unsafe.Pointer(&info)),
+		0, 0,
+	)
+	if errno != 0 {
+		return ptraceSyscallInfoNone, fmt.Errorf("PTRACE_GET_SYSCALL_INFO: %w", errno)
+	}
+	return info.Op, nil
+}
+```
+
+(Optional cleanup, not required: replace the literal `1`/`3` in `getSyscallEntryInfo`'s check with `ptraceSyscallInfoEntry`/`ptraceSyscallInfoSeccomp`.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `go test -tags 'integration linux' ./internal/ptrace/ -run TestSyscallStopOp_EntryThenExit -v`
+Expected: PASS (or SKIP only if the kernel lacks `PTRACE_GET_SYSCALL_INFO`, which CI kernels ≥5.3 do not). If it fails because the first post-exec syscall stop is a signal stop, insert a loop that re-`PtraceSyscall`s until `ws.StopSignal()` is a syscall stop before the first `syscallStopOp` — but on `/bin/true` the entry stop is reached directly.
+
+- [ ] **Step 5: Confirm the non-integration build still compiles**
+
+Run: `go build ./internal/ptrace/ && go vet ./internal/ptrace/`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/ptrace/syscall_context.go internal/ptrace/syscall_stop_op_test.go
+git commit -m "feat(ptrace,#369): add syscallStopOp raw PTRACE_GET_SYSCALL_INFO op accessor
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `waitForSyscallExitStop` and route the readback waits through it
+
+**Files:**
+- Modify: `internal/ptrace/inject.go` (add func; promote `maxStopEvents`; edit 3 call sites)
+
+- [ ] **Step 1: Promote the stop-event cap to a package const**
+
+In `internal/ptrace/inject.go`, inside `waitForSyscallStop` the `const ( maxStopEvents = 100; timeout = ...; pollDelay = ... )` block currently lives in-function. Add a package-level const above `waitForSyscallStop`:
+
+```go
+// injectMaxStopEvents bounds how many non-progress stops the inject waits
+// tolerate before giving up, guarding against an unexpected stop storm.
+const injectMaxStopEvents = 100
+```
+
+Then change the in-function block to drop `maxStopEvents` and reference `injectMaxStopEvents` at its two existing use sites (`:233`, `:244`):
+
+```go
+const (
+	timeout   = 5 * time.Second
+	pollDelay = 200 * time.Microsecond
+)
+```
+and replace `stopEvents >= maxStopEvents` (×2) with `stopEvents >= injectMaxStopEvents`, and the two error strings `exceeded %d ... , maxStopEvents` with `injectMaxStopEvents`.
+
+- [ ] **Step 2: Add `waitForSyscallExitStop`**
+
+Add immediately after `waitForSyscallStop` (after `:251`):
+
+```go
+// waitForSyscallExitStop drives the tracee to a genuine syscall-EXIT stop and
+// returns once there. When PTRACE_GET_SYSCALL_INFO is unavailable it degrades
+// to waitForSyscallStop (legacy cycle-counting; unchanged for pre-5.3 kernels).
+//
+// Background (#369): on kernels that interleave PTRACE_EVENT_SECCOMP / entry
+// stops with the PTRACE_SYSCALL enter/exit pairs (e.g. exe.dev 6.12.90), the
+// fixed-cycle accounting could land the return-value read on an entry/seccomp
+// stop, where rax holds the -ENOSYS entry placeholder rather than the syscall
+// result. Injected syscalls run in isolation (the tracer controls the
+// registers, so no other syscall executes between resumes), so the first EXIT
+// stop reached is the injected syscall's exit; intervening entry/seccomp stops
+// are resumed past.
+func (t *Tracer) waitForSyscallExitStop(tid int) error {
+	if err := t.waitForSyscallStop(tid); err != nil {
+		return err
+	}
+	if !t.hasSyscallInfo {
+		return nil // pre-5.3: cannot distinguish entry vs exit; keep legacy behavior
+	}
+	for i := 0; i < injectMaxStopEvents; i++ {
+		op, err := t.syscallStopOp(tid)
+		if err != nil {
+			// Can't classify this stop; trust the legacy stop (no worse than before).
+			return nil
+		}
+		if op == ptraceSyscallInfoExit {
+			return nil
+		}
+		// Entry/seccomp/none stop — advance to the injected syscall's exit.
+		if err := unix.PtraceSyscall(tid, 0); err != nil {
+			return fmt.Errorf("inject advance-to-exit tid %d: %w", tid, err)
+		}
+		if err := t.waitForSyscallStop(tid); err != nil {
+			return err // includes "tracee N exited during injection"
+		}
+	}
+	return fmt.Errorf("waitForSyscallExitStop tid %d: no exit stop within %d events", tid, injectMaxStopEvents)
+}
+```
+
+- [ ] **Step 3: Route the three readback/exit waits through it**
+
+In `injectFromEntry`, the wait-exit at `:78`:
+```go
+	if err := t.waitForSyscallStop(tid); err != nil {
+		injectErr = fmt.Errorf("inject wait-exit: %w", err)
+		return 0, injectErr
+	}
+```
+becomes:
+```go
+	if err := t.waitForSyscallExitStop(tid); err != nil {
+		injectErr = fmt.Errorf("inject wait-exit: %w", err)
+		return 0, injectErr
+	}
+```
+
+In `injectFromExit`, the **phase-2** wait-exit at `:152` (NOT the phase-1 wait-enter at `:142`):
+```go
+	if err := t.waitForSyscallStop(tid); err != nil {
+		injectErr = fmt.Errorf("inject wait-exit: %w", err)
+		return 0, injectErr
+	}
+```
+becomes `t.waitForSyscallExitStop(tid)` (same error wrapping). Leave the phase-1 wait at `:142` (`inject wait-enter`) as `waitForSyscallStop` — it positions at a pre-execution stop.
+
+In `advancePastEntry`, the wait at `:280`:
+```go
+	if err := t.waitForSyscallStop(tid); err != nil {
+		return fmt.Errorf("advance wait: %w", err)
+	}
+```
+becomes `t.waitForSyscallExitStop(tid)` (same error wrapping). Its purpose is to reach the exit stop so `InSyscall=false` is accurate.
+
+- [ ] **Step 4: Review `redirect_exec.go:174`**
+
+Read `internal/ptrace/redirect_exec.go` around `:174`. If that `waitForSyscallStop` immediately precedes a `ReturnValue()`/return-value read, change it to `waitForSyscallExitStop`. If it is positioning only (no return read), leave it. Note the decision in the commit message.
+
+- [ ] **Step 5: Build + vet**
+
+Run: `go build ./internal/ptrace/ && go vet ./internal/ptrace/`
+Expected: clean (no unused `maxStopEvents`, no undefined symbols).
+
+- [ ] **Step 6: Run the existing ptrace unit tests (non-integration)**
+
+Run: `go test ./internal/ptrace/`
+Expected: PASS (these are `//go:build linux` tests; they must be unaffected).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/ptrace/inject.go internal/ptrace/redirect_exec.go
+git commit -m "fix(ptrace,#369): read injected syscall return only at confirmed EXIT stop
+
+waitForSyscallExitStop drives the tracee past interleaved entry/seccomp stops
+to a genuine syscall-EXIT stop (op==2 via PTRACE_GET_SYSCALL_INFO) before the
+inject path reads rax, so it can no longer read the -ENOSYS entry placeholder
+on kernels that interleave PTRACE_EVENT_SECCOMP with the syscall enter/exit
+pairs (exe.dev 6.12.90). Gated on hasSyscallInfo; pre-5.3 keeps legacy behavior.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: No-regression verification (existing inject path on a normal kernel)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the ptrace integration suite if a ptrace-capable kernel is available**
+
+Run: `go test -tags 'integration linux' ./internal/ptrace/ 2>&1 | tail -40`
+Expected: PASS (or individual SKIPs where `requirePtrace` can't seize). The injection-exercising tests (`TestIntegration_FileRedirect`, `TestIntegration_*` under prefilter, `TestSyscallStopOp_EntryThenExit`) must pass — confirming the EXIT-confirming wait returns immediately on the happy path (op==EXIT on first check) with no behavior change.
+
+- [ ] **Step 2: Full module test**
+
+Run: `go test ./...`
+Expected: PASS (modulo the known pre-existing flakes noted in repo memory; rerun any flaky package to confirm it is not newly broken).
+
+---
+
+## Task 4: Cross-compile + final gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Windows cross-compile (changed files are linux-only)**
+
+Run: `GOOS=windows go build ./...`
+Expected: success — the changes are under `//go:build linux`, so the Windows build must be unaffected.
+
+- [ ] **Step 2: gofmt check on changed files**
+
+Run: `gofmt -l internal/ptrace/`
+Expected: no output (all formatted).

--- a/docs/superpowers/specs/2026-05-26-issue-369-inject-exit-stop-design.md
+++ b/docs/superpowers/specs/2026-05-26-issue-369-inject-exit-stop-design.md
@@ -1,0 +1,282 @@
+# Ptrace inject: read syscall return only at a confirmed EXIT stop — Design
+
+Issue: #369 ("Gap C") — ptrace `seccomp_prefilter` injection intermittently
+loses the tracee on exe.dev kernel `6.12.90`, surfacing as `exit_code=-1`
+(~50–75% of execs).
+
+## Summary
+
+agentsh installs the ptrace `seccomp_prefilter` (and performs file/exec
+redirects) by **injecting syscalls into a stopped tracee**: it rewrites the
+tracee's registers (`PTRACE_SETREGS`), resumes with `PTRACE_SYSCALL`, and reads
+the injected syscall's return value out of `rax` (`PTRACE_GETREGS`). The read
+point assumes a fixed number of resume cycles lands the tracee at the
+syscall-**exit** stop.
+
+erans's strace on kernel `6.12.90` (agentsh `0.20.3-rc2`, no shim) pinned the
+root cause: the readback happens at the syscall-**entry** stop instead of the
+**exit** stop. `injected syscall 9 (mmap) returned -38` is decisive — `-38`
+(`-ENOSYS`) is exactly the placeholder Linux parks in `rax` at the syscall-entry
+ptrace stop. The same desync makes the injected `seccomp`/`prctl` readbacks
+garbage and, when it runs the tracee off the end of the expected stops, leaves
+the tracee to exit mid-injection (`tracee N exited during injection`).
+
+The trigger is `PTRACE_EVENT_SECCOMP` stops interleaving with the
+`PTRACE_SYSCALL` enter/exit pairs once a `RET_TRACE` filter is active. The
+existing cycle-counting accounting in `waitForSyscallStop` does not distinguish
+entry from exit, so when the kernel's stop delivery on this kernel inserts an
+extra stop, the fixed-cycle readback lands one stop early.
+
+This design makes the injected-syscall readback **authoritative**: when
+`PTRACE_GET_SYSCALL_INFO` is available, the inject path confirms the tracee is at
+a syscall-**exit** stop (`op == PTRACE_SYSCALL_INFO_EXIT`) before reading `rax`,
+resuming past any non-exit (entry/seccomp) stops to reach it. `process_vm_*`
+access, the user-notify path, `WAIT_KILLABLE`, and cgroups are **not** touched —
+erans confirmed `process_vm_writev` works on this kernel and the EIO writes were
+a downstream artifact of the same desync.
+
+## Goals
+
+- On a kernel that interleaves `PTRACE_EVENT_SECCOMP` stops with syscall
+  enter/exit stops, `injectSyscall` reads the injected syscall's return value
+  only at the genuine syscall-exit stop — never the `-ENOSYS` entry placeholder.
+- The fix is correct-by-construction: it does not depend on *how many* extra
+  stops the kernel inserts, only on identifying the exit stop authoritatively.
+- Zero behavior change on the current happy path (normal kernels, where the
+  readback already lands at the exit stop): no extra resumes, identical result.
+- Pre-5.3 kernels (no `PTRACE_GET_SYSCALL_INFO`) keep today's behavior exactly.
+
+## Non-Goals
+
+- **No defensive "don't kill the command on inject failure" guard.** The only
+  fallback paths (pure `TRACESYSGOOD`, or running without the prefilter) are
+  themselves broken/unsafe on this kernel (TRACESYSGOOD hangs every exec, 8/8;
+  prefilter-less exec silently drops execve interception). Deferred — kept in
+  reserve only if rc3 shows the readback fix is incomplete.
+- **No startup ptrace-inject honesty probe.** Moot if the readback fix repairs
+  the inject. Deferred.
+- No change to `process_vm_readv/writev`, `/proc/<pid>/mem` access, the
+  user-notify (`netmonitor/unix`) path, `WAIT_KILLABLE`, or cgroups.
+- No change to the gadget/`injectFromEntry`/`injectFromExit` resume *protocol*
+  itself beyond where the return value is read.
+
+## Background
+
+Relevant code (all `//go:build linux`, package `internal/ptrace`):
+
+- `inject.go`
+  - `injectSyscall` → dispatches to `injectFromEntry` (tracee at syscall-enter,
+    one resume cycle) or `injectFromExit` (between syscalls; gadget + two resume
+    cycles).
+  - `injectFromEntry` (`:45`): after one `PtraceSyscall` + `waitForSyscallStop`
+    (`:78`), reads `retRegs.ReturnValue()` (`:88`).
+  - `injectFromExit` (`:109`): phase-1 wait (`:142`, enter), phase-2
+    `PtraceSyscall` + `waitForSyscallStop` (`:152`, exit), then
+    `retRegs.ReturnValue()` (`:162`).
+  - `waitForSyscallStop` (`:182`): returns at the *first* stop that is either a
+    TRACESYSGOOD syscall stop (`SIGTRAP|0x80`) **or** a `PTRACE_EVENT_SECCOMP`
+    stop, with no entry/exit distinction. Already handles tracee-exit
+    (`:207–212`), bounded re-resume on other event/signal stops.
+  - `advancePastEntry` (`:270`): nullifies the current syscall (`ORIG_RAX=-1`),
+    resumes to the next stop (`:280`), restores; used to move from an entry stop
+    to an exit stop so subsequent injections use the gadget protocol.
+- `syscall_context.go`
+  - `ptraceGetSyscallInfo = 0x420e`; `ptraceSyscallInfo` struct with `Op uint8`
+    (kernel: `NONE=0, ENTRY=1, EXIT=2, SECCOMP=3, RSEQ=4`).
+  - `getSyscallEntryInfo` (`:63`): reads syscall info but **rejects** `op != 1
+    && op != 3` (entry/seccomp only) — cannot be reused as-is for exit detection.
+  - `probePtraceSyscallInfo` (`:114`) sets `t.hasSyscallInfo` at tracer init
+    (`tracer.go:1868`); true on Linux 5.3+ (so true on `6.12.90`).
+- Inject consumers that go through `injectSyscall` (all fixed centrally by this
+  change): `scratch.go:55` (mmap scratch page), `inject_seccomp.go:191,205,300`
+  (prctl/seccomp prefilter + escalation), `redirect_file.go` (openat/mkdirat/
+  renameat2), `redirect_exec.go:230,236,248,254,261` (pidfd_open/getfd/fcntl/dup3).
+
+Why the existing seccomp-stop handling is not enough: treating
+`PTRACE_EVENT_SECCOMP` as an enter-equivalent stop keeps the 2-cycle model
+correct for a *single* filtered syscall (seccomp-stop → exit-stop). The bug
+appears only when the kernel inserts an *additional* stop (e.g. a seccomp stop
+**and** a separate enter stop, or an extra interleaved event), shifting the
+fixed-cycle readback one stop early. That extra-stop choreography is what differs
+on `6.12.90`.
+
+## Design
+
+### 1. Raw stop-op accessor (`syscall_context.go`)
+
+Add a helper that returns the raw `Op` of the current syscall-stop without the
+entry-only rejection in `getSyscallEntryInfo`:
+
+```go
+// ptrace_syscall_info op values (uapi/linux/ptrace.h).
+const (
+    ptraceSyscallInfoNone    uint8 = 0
+    ptraceSyscallInfoEntry   uint8 = 1
+    ptraceSyscallInfoExit    uint8 = 2
+    ptraceSyscallInfoSeccomp uint8 = 3
+)
+
+// syscallStopOp returns the PTRACE_GET_SYSCALL_INFO op for the tracee's current
+// stop (entry/exit/seccomp/none). Only valid at a ptrace syscall/seccomp stop.
+func (t *Tracer) syscallStopOp(tid int) (uint8, error) {
+    var info ptraceSyscallInfo
+    _, _, errno := unix.Syscall6(unix.SYS_PTRACE, uintptr(ptraceGetSyscallInfo),
+        uintptr(tid), uintptr(ptraceSyscallInfoSize), uintptr(unsafe.Pointer(&info)), 0, 0)
+    if errno != 0 {
+        return ptraceSyscallInfoNone, fmt.Errorf("PTRACE_GET_SYSCALL_INFO: %w", errno)
+    }
+    return info.Op, nil
+}
+```
+
+(`getSyscallEntryInfo` is left unchanged. The named op constants may also replace
+the magic `1`/`3` in its existing check, but that is optional cleanup.)
+
+### 2. Exit-confirming wait (`inject.go`)
+
+Add a wait that lands the tracee at a genuine syscall-**exit** stop when
+`PTRACE_GET_SYSCALL_INFO` is available, and otherwise preserves today's behavior:
+
+```go
+// waitForSyscallExitStop drives the tracee to a syscall-EXIT stop and returns
+// once there. When PTRACE_GET_SYSCALL_INFO is unavailable it degrades to
+// waitForSyscallStop (legacy cycle-counting behavior, unchanged).
+//
+// Injected syscalls run in isolation (the tracer controls the registers, so no
+// other syscall executes between resumes); therefore the first EXIT stop reached
+// is the injected syscall's exit. Any intervening entry/seccomp stops are
+// resumed past. Bounded by the same guards as waitForSyscallStop.
+func (t *Tracer) waitForSyscallExitStop(tid int) error {
+    if err := t.waitForSyscallStop(tid); err != nil {
+        return err
+    }
+    if !t.hasSyscallInfo {
+        return nil // pre-5.3: cannot distinguish; keep legacy behavior
+    }
+    for i := 0; i < maxStopEvents; i++ {
+        op, err := t.syscallStopOp(tid)
+        if err != nil {
+            // Can't classify this stop; trust the legacy stop (no worse than today).
+            return nil
+        }
+        if op == ptraceSyscallInfoExit {
+            return nil
+        }
+        // Entry/seccomp/none stop — advance to the injected syscall's exit.
+        if err := unix.PtraceSyscall(tid, 0); err != nil {
+            return fmt.Errorf("inject advance-to-exit tid %d: %w", tid, err)
+        }
+        if err := t.waitForSyscallStop(tid); err != nil {
+            return err // includes "tracee N exited during injection"
+        }
+    }
+    return fmt.Errorf("waitForSyscallExitStop tid %d: no exit stop within %d events", tid, maxStopEvents)
+}
+```
+
+`maxStopEvents`/`timeout`/`pollDelay` are reused from `waitForSyscallStop`
+(promote the consts to package/function scope as needed).
+
+### 3. Use the exit-confirming wait at every readback point (`inject.go`)
+
+Replace only the waits that immediately precede a return-value read or that exist
+to reach the exit stop:
+
+- `injectFromEntry` `:78` → `waitForSyscallExitStop` (the single resume must land
+  at exit before `ReturnValue()` at `:88`).
+- `injectFromExit` `:152` (phase 2) → `waitForSyscallExitStop` (before
+  `ReturnValue()` at `:162`). Phase-1 `:142` stays `waitForSyscallStop` (it is
+  positioning at a pre-execution stop; reaching exit there would be wrong).
+- `advancePastEntry` `:280` → `waitForSyscallExitStop` (its purpose is to reach
+  the exit stop so `InSyscall=false` is accurate).
+
+`redirect_exec.go:174`'s `waitForSyscallStop` is reviewed during implementation;
+it is changed only if it precedes a return-value read (otherwise left as-is).
+
+### Resulting behavior on the failing kernel
+
+When an interleaved seccomp/entry stop lands where the old code read `rax`,
+`waitForSyscallExitStop` sees `op != EXIT`, resumes once more, reaches the true
+exit stop, and reads the real return value (e.g. the mmap scratch address instead
+of `-38`). The prefilter installs, the command exits normally.
+
+### Happy-path equivalence
+
+On a normal kernel the phase that previously landed at the exit stop now calls
+`syscallStopOp`, gets `EXIT` on the first check, and returns with **no** extra
+`PtraceSyscall`. Identical resume count, identical register read, identical
+result. The only added cost is one `PTRACE_GET_SYSCALL_INFO` per injected
+syscall (microseconds), already used elsewhere in the hot path.
+
+## Decisions
+
+- **Trust `rax` via `getRegs` once at the confirmed exit stop**, rather than
+  reading `rval` from the `PTRACE_GET_SYSCALL_INFO` exit-union variant. `getRegs`
+  is already needed for the post-inject register restore and is the established
+  read path; using the op only as a *gate* keeps the change minimal and reuses
+  tested code. (The exit-variant `rval` read is a possible future simplification,
+  not needed here.)
+- **Gate on `t.hasSyscallInfo`.** Pre-5.3 kernels keep the legacy cycle-counting
+  behavior verbatim — the bug does not manifest there, and there is no
+  authoritative exit signal to use.
+- **Fix centrally in `injectSyscall`'s waits**, not per-caller. The same machinery
+  backs mmap, prctl/seccomp, and file/exec redirects; one fix covers all.
+- **No graceful-degrade / honesty probe** (see Non-Goals): the fallbacks are
+  unsafe on this kernel and the readback fix should make them unnecessary.
+
+## Error handling
+
+- Tracee exits during the extra resume(s): `waitForSyscallStop` already detects
+  `Exited()/Signaled()`, runs `handleExit`, and returns
+  `"tracee N exited during injection"`. The existing `defer` in
+  `injectFromEntry`/`injectFromExit` restores `savedRegs` on error. No new
+  failure surface; the lost-tracee case is *reduced*, not newly introduced.
+- `syscallStopOp` errno: treated as "cannot classify" → fall back to the legacy
+  stop (behavior no worse than today).
+- Bounded loop (`maxStopEvents`) prevents an unbounded spin if the kernel never
+  reports an exit stop; returns a descriptive error that the existing inject
+  callers already wrap (`inject prctl: …`, `scratch page: …`).
+
+## Testing
+
+The exe.dev desync is stop-delivery-timing specific to `6.12.90` and **cannot be
+reproduced deterministically on a normal CI kernel** (a single filtered syscall
+yields seccomp→exit, which the legacy 2-cycle path already handles). Tests
+therefore target the new primitive's correctness and the no-regression
+guarantee; the end-to-end fix is verified by erans on `v0.20.3-rc3`.
+
+`internal/ptrace` (integration-tagged where a live tracee is needed,
+`//go:build integration && linux`, matching existing `integration_test.go`):
+
+1. **`syscallStopOp` classification** — attach a child, stop it at a syscall
+   entry: assert `syscallStopOp` returns `ENTRY`; `PtraceSyscall` to exit: assert
+   `EXIT`. Install a `RET_TRACE` filter on a benign syscall, trigger it: assert
+   `SECCOMP` at the seccomp stop. Deterministic on any 5.3+ kernel.
+2. **`injectSyscall` returns the true result, not the entry placeholder** —
+   inject a benign syscall (e.g. `getpid`/`getuid`) and assert the returned value
+   equals the real result and is not `-ENOSYS`. Run with the tracee under a
+   `RET_TRACE` prefilter (the prefilter mode) and without it; both must return the
+   correct value. Guards against a regression where a readback lands at a non-exit
+   stop.
+3. **Prefilter inject still succeeds end-to-end** on the CI kernel
+   (`injectSeccompFilter` → command runs and exits 0). No-regression check.
+4. **`hasSyscallInfo=false` path** — a unit test (no live tracee) asserting
+   `waitForSyscallExitStop` reduces to `waitForSyscallStop` when the capability
+   flag is false (e.g. via a tracer with `hasSyscallInfo=false` and a fake/stubbed
+   stop), so pre-5.3 behavior is preserved.
+
+Also: full `internal/ptrace` suite stays green; `go test ./...`;
+`GOOS=windows go build ./...` (changed files are `//go:build linux`, so the
+Windows build must remain unaffected).
+
+## Affected files
+
+- `internal/ptrace/syscall_context.go` — add `syscallStopOp` + op constants.
+- `internal/ptrace/inject.go` — add `waitForSyscallExitStop`; use it at the three
+  readback/exit waits (`injectFromEntry`, `injectFromExit` phase 2,
+  `advancePastEntry`).
+- `internal/ptrace/redirect_exec.go` — only if a `waitForSyscallStop` there
+  precedes a return-value read (verified during implementation).
+- Tests in `internal/ptrace/` (new cases per above).
+- Everything else — `process_vm_*`, user-notify, `WAIT_KILLABLE`, cgroups,
+  darwin/windows — intentionally **unchanged**.

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -75,7 +75,7 @@ func (t *Tracer) injectFromEntry(tid int, savedRegs Regs, nr int, args ...uint64
 		injectErr = fmt.Errorf("inject resume: %w", err)
 		return 0, injectErr
 	}
-	if err := t.waitForSyscallStop(tid); err != nil {
+	if err := t.waitForSyscallExitStop(tid); err != nil {
 		injectErr = fmt.Errorf("inject wait-exit: %w", err)
 		return 0, injectErr
 	}
@@ -149,7 +149,7 @@ func (t *Tracer) injectFromExit(tid int, savedRegs Regs, nr int, args ...uint64)
 		injectErr = fmt.Errorf("inject resume-exit: %w", err)
 		return 0, injectErr
 	}
-	if err := t.waitForSyscallStop(tid); err != nil {
+	if err := t.waitForSyscallExitStop(tid); err != nil {
 		injectErr = fmt.Errorf("inject wait-exit: %w", err)
 		return 0, injectErr
 	}
@@ -168,6 +168,10 @@ func (t *Tracer) injectFromExit(tid int, savedRegs Regs, nr int, args ...uint64)
 	return ret, nil
 }
 
+// injectMaxStopEvents bounds how many non-progress stops the inject waits
+// tolerate before giving up, guarding against an unexpected stop storm.
+const injectMaxStopEvents = 100
+
 // waitForSyscallStop waits for the specified tid to hit a syscall stop.
 // It uses waitpid with the specific tid to avoid consuming other tracees' events.
 // Returns an error if the tracee exits during the wait, after performing
@@ -181,9 +185,8 @@ func (t *Tracer) injectFromExit(tid int, savedRegs Regs, nr int, args ...uint64)
 // prefilter/seccomp mode (syscall stops report plain SIGTRAP with no event).
 func (t *Tracer) waitForSyscallStop(tid int) error {
 	const (
-		maxStopEvents = 100 // guard against infinite loop from unexpected stop events
-		timeout       = 5 * time.Second
-		pollDelay     = 200 * time.Microsecond
+		timeout   = 5 * time.Second
+		pollDelay = 200 * time.Microsecond
 	)
 	deadline := time.Now().Add(timeout)
 	stopEvents := 0
@@ -230,8 +233,8 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 		// SIGTRAP with a non-zero TrapCause. Resume with signal 0.
 		if sig == unix.SIGTRAP && status.TrapCause() != 0 {
 			stopEvents++
-			if stopEvents >= maxStopEvents {
-				return fmt.Errorf("waitForSyscallStop tid %d: exceeded %d non-progress stop events", tid, maxStopEvents)
+			if stopEvents >= injectMaxStopEvents {
+				return fmt.Errorf("waitForSyscallStop tid %d: exceeded %d non-progress stop events", tid, injectMaxStopEvents)
 			}
 			if err := unix.PtraceSyscall(tid, 0); err != nil {
 				return fmt.Errorf("inject re-resume tid %d: %w", tid, err)
@@ -241,13 +244,52 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 
 		// Real signal delivery: reinject the signal.
 		stopEvents++
-		if stopEvents >= maxStopEvents {
-			return fmt.Errorf("waitForSyscallStop tid %d: exceeded %d non-progress stop events", tid, maxStopEvents)
+		if stopEvents >= injectMaxStopEvents {
+			return fmt.Errorf("waitForSyscallStop tid %d: exceeded %d non-progress stop events", tid, injectMaxStopEvents)
 		}
 		if err := unix.PtraceSyscall(tid, int(sig)); err != nil {
 			return fmt.Errorf("inject re-resume tid %d: %w", tid, err)
 		}
 	}
+}
+
+// waitForSyscallExitStop drives the tracee to a genuine syscall-EXIT stop and
+// returns once there. When PTRACE_GET_SYSCALL_INFO is unavailable it degrades
+// to waitForSyscallStop (legacy cycle-counting; unchanged for pre-5.3 kernels).
+//
+// Background (#369): on kernels that interleave PTRACE_EVENT_SECCOMP / entry
+// stops with the PTRACE_SYSCALL enter/exit pairs (e.g. exe.dev 6.12.90), the
+// fixed-cycle accounting could land the return-value read on an entry/seccomp
+// stop, where rax holds the -ENOSYS entry placeholder rather than the syscall
+// result. Injected syscalls run in isolation (the tracer controls the
+// registers, so no other syscall executes between resumes), so the first EXIT
+// stop reached is the injected syscall's exit; intervening entry/seccomp stops
+// are resumed past.
+func (t *Tracer) waitForSyscallExitStop(tid int) error {
+	if err := t.waitForSyscallStop(tid); err != nil {
+		return err
+	}
+	if !t.hasSyscallInfo {
+		return nil // pre-5.3: cannot distinguish entry vs exit; keep legacy behavior
+	}
+	for i := 0; i < injectMaxStopEvents; i++ {
+		op, err := t.syscallStopOp(tid)
+		if err != nil || op == ptraceSyscallInfoNone {
+			// Can't classify this stop; trust the legacy stop (no worse than before).
+			return nil
+		}
+		if op == ptraceSyscallInfoExit {
+			return nil
+		}
+		// Entry/seccomp stop — advance to the injected syscall's exit.
+		if err := unix.PtraceSyscall(tid, 0); err != nil {
+			return fmt.Errorf("inject advance-to-exit tid %d: %w", tid, err)
+		}
+		if err := t.waitForSyscallStop(tid); err != nil {
+			return err // includes "tracee N exited during injection"
+		}
+	}
+	return fmt.Errorf("waitForSyscallExitStop tid %d: no exit stop within %d events", tid, injectMaxStopEvents)
 }
 
 // injectSyscallRet is a convenience that returns an error if the injected
@@ -277,7 +319,7 @@ func (t *Tracer) advancePastEntry(tid int, savedRegs Regs) error {
 	if err := unix.PtraceSyscall(tid, 0); err != nil {
 		return fmt.Errorf("advance resume: %w", err)
 	}
-	if err := t.waitForSyscallStop(tid); err != nil {
+	if err := t.waitForSyscallExitStop(tid); err != nil {
 		return fmt.Errorf("advance wait: %w", err)
 	}
 	if err := t.setRegs(tid, savedRegs); err != nil {

--- a/internal/ptrace/syscall_context.go
+++ b/internal/ptrace/syscall_context.go
@@ -12,6 +12,14 @@ import (
 // ptraceGetSyscallInfo is the ptrace request for PTRACE_GET_SYSCALL_INFO (Linux 5.3+).
 const ptraceGetSyscallInfo = 0x420e
 
+// ptrace_syscall_info op values (uapi/linux/ptrace.h, PTRACE_SYSCALL_INFO_*).
+const (
+	ptraceSyscallInfoNone    uint8 = 0
+	ptraceSyscallInfoEntry   uint8 = 1
+	ptraceSyscallInfoExit    uint8 = 2
+	ptraceSyscallInfoSeccomp uint8 = 3
+)
+
 // SyscallEntryInfo holds syscall number and arguments extracted at entry time.
 type SyscallEntryInfo struct {
 	Nr   int
@@ -80,6 +88,26 @@ func (t *Tracer) getSyscallEntryInfo(tid int) (*SyscallEntryInfo, error) {
 		Nr:   int(info.EntryNr),
 		Args: info.EntryArgs,
 	}, nil
+}
+
+// syscallStopOp returns the PTRACE_GET_SYSCALL_INFO op for the tracee's current
+// stop (none/entry/exit/seccomp). Valid only at a ptrace syscall or seccomp
+// stop. Unlike getSyscallEntryInfo it does not reject the exit op — the inject
+// path uses it to confirm a syscall-EXIT stop before trusting the return reg.
+func (t *Tracer) syscallStopOp(tid int) (uint8, error) {
+	var info ptraceSyscallInfo
+	_, _, errno := unix.Syscall6(
+		unix.SYS_PTRACE,
+		uintptr(ptraceGetSyscallInfo),
+		uintptr(tid),
+		uintptr(ptraceSyscallInfoSize),
+		uintptr(unsafe.Pointer(&info)),
+		0, 0,
+	)
+	if errno != 0 {
+		return ptraceSyscallInfoNone, fmt.Errorf("PTRACE_GET_SYSCALL_INFO: %w", errno)
+	}
+	return info.Op, nil
 }
 
 // buildSyscallContext constructs a SyscallContext for a stopped tracee.

--- a/internal/ptrace/syscall_context.go
+++ b/internal/ptrace/syscall_context.go
@@ -81,8 +81,9 @@ func (t *Tracer) getSyscallEntryInfo(tid int) (*SyscallEntryInfo, error) {
 	if errno != 0 {
 		return nil, fmt.Errorf("PTRACE_GET_SYSCALL_INFO: %w", errno)
 	}
-	if info.Op != 1 && info.Op != 3 {
-		return nil, fmt.Errorf("PTRACE_GET_SYSCALL_INFO: unexpected op %d (want entry=1 or seccomp=3)", info.Op)
+	if info.Op != ptraceSyscallInfoEntry && info.Op != ptraceSyscallInfoSeccomp {
+		return nil, fmt.Errorf("PTRACE_GET_SYSCALL_INFO: unexpected op %d (want entry=%d or seccomp=%d)",
+			info.Op, ptraceSyscallInfoEntry, ptraceSyscallInfoSeccomp)
 	}
 	return &SyscallEntryInfo{
 		Nr:   int(info.EntryNr),

--- a/internal/ptrace/syscall_stop_op_test.go
+++ b/internal/ptrace/syscall_stop_op_test.go
@@ -1,0 +1,85 @@
+//go:build integration && linux
+
+package ptrace
+
+import (
+	"os/exec"
+	"runtime"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestSyscallStopOp_EntryThenExit verifies syscallStopOp classifies a
+// syscall-entry stop as ENTRY(1) and the matching exit stop as EXIT(2).
+// This is the load-bearing primitive for the inject EXIT-stop fix (#369).
+func TestSyscallStopOp_EntryThenExit(t *testing.T) {
+	requirePtrace(t)
+	// ptrace requires all calls for one tracee to come from the same OS thread.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	cmd := exec.Command("/bin/true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Ptrace: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pid := cmd.Process.Pid
+	defer func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() }()
+
+	// Initial stop is the exec/TRACEME stop; reap it.
+	var ws unix.WaitStatus
+	if _, err := unix.Wait4(pid, &ws, 0, nil); err != nil {
+		t.Fatalf("initial wait4: %v", err)
+	}
+
+	tr := &Tracer{hasSyscallInfo: probePtraceSyscallInfo()}
+	if !tr.hasSyscallInfo {
+		t.Skip("PTRACE_GET_SYSCALL_INFO unsupported on this kernel")
+	}
+
+	// PTRACE_O_TRACESYSGOOD is required: without it, syscall stops appear as
+	// plain SIGTRAP and PTRACE_GET_SYSCALL_INFO returns op=NONE (0) for all
+	// stops. With it, syscall stops are SIGTRAP|0x80 and the kernel correctly
+	// populates the op field.
+	if err := unix.PtraceSetOptions(pid, unix.PTRACE_O_TRACESYSGOOD); err != nil {
+		t.Fatalf("PTRACE_SETOPTIONS TRACESYSGOOD: %v", err)
+	}
+
+	// Advance to a syscall-entry stop.
+	if err := unix.PtraceSyscall(pid, 0); err != nil {
+		t.Fatalf("ptracesyscall to entry: %v", err)
+	}
+	if _, err := unix.Wait4(pid, &ws, 0, nil); err != nil {
+		t.Fatalf("wait4 entry: %v", err)
+	}
+	if !ws.Stopped() {
+		t.Fatalf("expected stop at entry, status=%v", ws)
+	}
+	op, err := tr.syscallStopOp(pid)
+	if err != nil {
+		t.Fatalf("syscallStopOp entry: %v", err)
+	}
+	if op != ptraceSyscallInfoEntry {
+		t.Fatalf("entry stop op = %d, want %d (ENTRY)", op, ptraceSyscallInfoEntry)
+	}
+
+	// Advance to the matching syscall-exit stop.
+	if err := unix.PtraceSyscall(pid, 0); err != nil {
+		t.Fatalf("ptracesyscall to exit: %v", err)
+	}
+	if _, err := unix.Wait4(pid, &ws, 0, nil); err != nil {
+		t.Fatalf("wait4 exit: %v", err)
+	}
+	if !ws.Stopped() {
+		t.Fatalf("expected stop at exit, status=%v", ws)
+	}
+	op, err = tr.syscallStopOp(pid)
+	if err != nil {
+		t.Fatalf("syscallStopOp exit: %v", err)
+	}
+	if op != ptraceSyscallInfoExit {
+		t.Fatalf("exit stop op = %d, want %d (EXIT)", op, ptraceSyscallInfoExit)
+	}
+}


### PR DESCRIPTION
## Summary

Addresses **#369 ("Gap C")** — agentsh's ptrace `seccomp_prefilter` injection intermittently loses the tracee on exe.dev kernel `6.12.90`, surfacing as `exit_code=-1` (~50–75% of execs), surviving `wait_killable: false`.

erans's strace on `6.12.90` pinned the root cause: the inject path reads the injected syscall's return register (`rax`) at the syscall-**entry** stop instead of the **exit** stop. `injected syscall 9 (mmap) returned -38` is decisive — `-38` (`-ENOSYS`) is exactly the placeholder Linux parks in `rax` at the syscall-entry ptrace stop. Once a `RET_TRACE` prefilter is live, `PTRACE_EVENT_SECCOMP` stops interleave with the `PTRACE_SYSCALL` enter/exit pairs, and `waitForSyscallStop`'s fixed-cycle accounting (which doesn't distinguish entry from exit) lands the readback one stop early. (erans also confirmed `process_vm_writev` *works* on this kernel — the earlier EIO-write theory was a downstream artifact of the same desync, not degraded memory access.)

This is **not** a user-notify / `WAIT_KILLABLE_RECV` issue — #371/#394/#395 addressed that layer; this is a separate, deeper bug in the ptrace inject readback shared by mmap (scratch page), the seccomp prefilter, and the file/exec redirects.

## What changed

- **`syscallStopOp`** (`syscall_context.go`) — raw `PTRACE_GET_SYSCALL_INFO` accessor returning the current stop's `op` (none=0/entry=1/exit=2/seccomp=3), without `getSyscallEntryInfo`'s entry-only rejection.
- **`waitForSyscallExitStop`** (`inject.go`) — when `PTRACE_GET_SYSCALL_INFO` is available, resumes past interleaved entry/seccomp stops until a confirmed `op==EXIT` stop before the inject reads `rax`. The three return-value readback waits (`injectFromEntry`, `injectFromExit` phase-2, `advancePastEntry`) route through it. `injectFromExit` phase-1 (enter positioning) and `redirect_exec.go`'s execve-entry wait are deliberately left as `waitForSyscallStop`.
- Gated on `t.hasSyscallInfo` — **pre-5.3 kernels keep exact legacy behavior**. On a normal kernel the readback reaches `op==EXIT` on the first check, so the happy path is unchanged (zero extra `PtraceSyscall` calls).
- Minor cleanup: `getSyscallEntryInfo` now uses the named op constants.

Scope is **readback fix only** by design. The don't-kill-on-inject-failure guard and a startup ptrace-inject honesty probe were considered and explicitly deferred (the only fallbacks — pure TRACESYSGOOD, or prefilter-less exec — are themselves broken/unsafe on this kernel).

Design + plan: `docs/superpowers/specs/2026-05-26-issue-369-inject-exit-stop-design.md`, `docs/superpowers/plans/2026-05-26-issue-369-inject-exit-stop.md`.

## Test plan

- [x] `go build ./...` and `GOOS=windows go build ./...` (changes are `//go:build linux`)
- [x] `go test ./internal/ptrace/` green; `go vet`, gofmt clean on changed files
- [x] New `TestSyscallStopOp_EntryThenExit` (integration) validates the load-bearing primitive (ENTRY then EXIT classification) deterministically on any 5.3+ kernel
- [ ] **End-to-end verification on a real exe.dev `6.12.90` kernel (erans, v0.20.3-rc3)** — the timing-dependent desync is **not** reproducible deterministically on a normal CI kernel (a single filtered syscall yields seccomp→exit, which the legacy path already handles), so the production kill can only be confirmed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)