### PR TITLE
fix(#369): bounded retry on transient EIO for ptrace tracee-memory access

### DIFF
--- a/docs/superpowers/specs/2026-05-26-issue-369-eio-retry-design.md
+++ b/docs/superpowers/specs/2026-05-26-issue-369-eio-retry-design.md
@@ -1,0 +1,198 @@
+# Ptrace tracee-memory EIO retry + diagnostics — Design
+
+Issue: #369 ("Gap C"), follow-up to #396. rc3 (#396) fixed the return-register
+readback but exposed the dominant remaining failure: race-sensitive `EIO` on
+ptrace cross-process tracee-memory access.
+
+## Summary
+
+On exe.dev kernel `6.12.90`, agentsh's cross-process tracee-memory access
+intermittently fails with `EIO` — both writes (`write BPF to tracee`,
+`inject_seccomp.go:182`, ×15 in one rc3 run) and reads (`handleExecve: cannot
+read filename`, `tracer.go:1780`). agentsh's access ladder is `process_vm_*` →
+`/proc/<pid>/mem` (`memory.go`); **both rungs `EIO`**, and there is no
+`PTRACE_PEEK/POKE` fallback.
+
+The decisive clue (erans's strace): the access **succeeds when serialized under
+strace** and fails `EIO` un-straced. That is a timing window, not a capability
+gap — both `process_vm_*` and `/proc/<pid>/mem` converge on the kernel's
+`access_process_vm`/`get_user_pages` path, which transiently `EIO`s right after a
+ptrace stop transition (the `mm` appears momentarily inaccessible, notably around
+the execve address-space switch). strace's per-syscall latency closes the window.
+
+This design adds a **bounded retry on `EIO`** around the existing access ladder
+(replicating strace's latency cheaply) plus **diagnostic logging** that, when a
+retry sequence is exhausted, records why the access failed — without strace
+masking it. It is both a hypothesis test (does added latency fix it? → confirms
+the transient-window theory) and, if confirmed, the fix.
+
+## Goals
+
+- A transient `EIO` on `process_vm_*`/`/proc/<pid>/mem` is retried (bounded) so a
+  recoverable race no longer aborts the prefilter inject / execve read → no
+  spurious `exit -1` kill.
+- Zero behavior/perf change on healthy kernels: `EIO` does not occur there, so
+  the retry path is never entered.
+- When retries are exhausted, emit enough context to localize the cause
+  (is the tracee actually stopped? is the address mapped? which method? errno?),
+  observable without strace.
+- A `DEBUG` line on retry **success** (attempt count) so a kill-rate drop plus
+  "succeeded after N retries" confirms the transient-window hypothesis.
+
+## Non-Goals
+
+- **No `EFAULT` retry.** `EFAULT` is frequently a legitimate bad-pointer result
+  (e.g. `readString` crossing a page boundary at end-of-mapping); retrying it
+  would add latency to normal operation. `EIO` is the dominant, clearly-transient
+  failure (×15 vs no `EFAULT` in the rc3 kill breakdown). Revisit only if rc4
+  shows residual `EFAULT`-driven kills.
+- **No `PTRACE_PEEK/POKE` fallback.** It shares the same underlying
+  `access_process_vm` path, so it would likely `EIO` too; not worth the
+  word-at-a-time complexity until evidence says otherwise.
+- **No change to the access ladder order** (`process_vm_*` first, then
+  `/proc/<pid>/mem`) or to the inject/stop protocol.
+- **No backend-degrade / honesty probe.** If retry proves insufficient (EIO is
+  persistent, not transient), that becomes the next decision — out of scope here.
+
+## Background
+
+- Reads: `vmReader.read` (`memory.go:35`) tries `process_vm_readv`, falls back to
+  `procMemReader.read` (`/proc/<tid>/mem` pread). Used via `getMemReader` by
+  `readBytes`/`readString` (and thus `handleExecve`'s filename read, `tracer.go:1780`).
+- Writes: `Tracer.writeBytes` (`memory.go:144`) tries `process_vm_writev`, falls
+  back to `/proc/<tid>/mem` pwrite. Used by the BPF-program write
+  (`inject_seccomp.go:182`), file/exec/net redirects, etc.
+- The tracee is ptrace-stopped during all these accesses (inject runs inside the
+  tracer's stop handler). `vmReader` already carries `tid`; `writeBytes` has `tid`.
+
+## Design
+
+### 1. Transient-error classification + retry helper (`memory.go`)
+
+```go
+// isTransientMemErr reports whether a tracee-memory access error looks like the
+// race-sensitive EIO seen on some kernels (exe.dev 6.12.90, #369) where
+// process_vm_*/proc-mem transiently fail right after a stop transition. EFAULT
+// is intentionally NOT treated as transient (often a legitimate bad pointer).
+func isTransientMemErr(err error) bool {
+    return errors.Is(err, unix.EIO)
+}
+
+// memRetryMaxAttempts and the escalating backoff bound the retry. Injected
+// accesses normally complete in microseconds, so the retry cost is paid only on
+// the rare transient EIO. Total worst-case sleep ≈ 1+2+4+8 = 15ms.
+const memRetryMaxAttempts = 5
+
+// retryTransientMem runs access (the full process_vm_* → /proc-mem ladder),
+// retrying on a transient EIO with escalating backoff. On exhaustion it logs
+// diagnostic context (tracee stop state, address mapping) and returns the error.
+func retryTransientMem(tid int, addr uint64, op string, access func() error) error {
+    var err error
+    for attempt := 0; attempt < memRetryMaxAttempts; attempt++ {
+        if attempt > 0 {
+            time.Sleep(time.Duration(1<<(attempt-1)) * time.Millisecond) // 1,2,4,8ms
+        }
+        err = access()
+        if err == nil {
+            if attempt > 0 {
+                slog.Debug("ptrace mem access recovered after retry",
+                    "tid", tid, "addr", fmt.Sprintf("0x%x", addr), "op", op, "attempts", attempt+1)
+            }
+            return nil
+        }
+        if !isTransientMemErr(err) {
+            return err
+        }
+    }
+    logMemErrContext(tid, addr, op, err)
+    return err
+}
+```
+
+### 2. Diagnostic context on exhaustion (`memory.go`)
+
+```go
+// logMemErrContext records, at WARN, why a tracee-memory access kept failing:
+// the tracee's scheduler state char from /proc/<tid>/stat (expected 't'/'T' when
+// ptrace-stopped) and whether addr falls inside any /proc/<tid>/maps region.
+// Best-effort; never fatal. (#369)
+func logMemErrContext(tid int, addr uint64, op string, accessErr error) {
+    state := procStateChar(tid)            // "" if unreadable
+    mapped := addrInMaps(tid, addr)        // bool; false if maps unreadable/absent
+    slog.Warn("ptrace mem access failed after retries",
+        "tid", tid, "addr", fmt.Sprintf("0x%x", addr), "op", op,
+        "error", accessErr, "tracee_state", state, "addr_mapped", mapped,
+        "attempts", memRetryMaxAttempts)
+}
+```
+
+- `procStateChar(tid)` reads `/proc/<tid>/stat`, parses the state char *after the
+  last `)`* (comm may contain spaces/parens). Returns "" on any error.
+- `addrInMaps(tid, addr)` scans `/proc/<tid>/maps` for a `start-end` range
+  containing `addr`. Returns false on any error. Bounded line scan.
+
+### 3. Wire retry into both ladders (`memory.go`)
+
+- `writeBytes`: rename the current body to `writeBytesOnce(tid, addr, buf)` and
+  make `writeBytes` call `retryTransientMem(tid, addr, "write", func() error { return t.writeBytesOnce(tid, addr, buf) })`.
+- `vmReader.read`: rename the current body to `readOnce`; `read` wraps it with
+  `retryTransientMem(r.tid, addr, "read", func() error { return r.readOnce(addr, buf) })`.
+
+The retry wraps the **whole ladder** (so a retry re-tries `process_vm_*` and then
+`/proc/<pid>/mem`), matching the observation that both rungs fail together during
+the transient window.
+
+## Decisions
+
+- **Retry, not a new access method.** The "works under strace" evidence points at
+  a latency-closable timing window; bounded retry is the minimal faithful
+  replication. `PEEK/POKE` shares the failing kernel path and is not added.
+- **`EIO` only** (see Non-Goals) — surgical, avoids penalizing legitimate `EFAULT`.
+- **Retry inside `memory.go`** so every caller (inject writes + `handleExecve`
+  read + redirects) is covered uniformly with one change.
+- **Diagnostics are best-effort and only on exhaustion** — they cost nothing on
+  success and are not masked by strace (internal logging), giving a clean answer
+  if retry turns out insufficient.
+
+## Error handling / safety
+
+- On a healthy kernel `EIO` never occurs, so the retry loop runs exactly once and
+  returns immediately — no added latency, no new code path exercised.
+- Non-`EIO` errors return immediately (including the existing `/proc/mem`
+  fallback's error), preserving current semantics.
+- `logMemErrContext` helpers swallow their own errors; a diagnostic read failure
+  never changes the returned access error.
+
+## Testing
+
+The 6.12.90 `EIO` is not reproducible on CI, but the **retry logic is fully
+unit-testable** with a fake access func (deterministic, no kernel):
+
+`internal/ptrace/memory_retry_test.go` (`//go:build linux`):
+- `retryTransientMem` returns success when `access` fails `EIO` N(<5) times then
+  succeeds; asserts the success-after-retry path (and that it retried, e.g. via a
+  call counter).
+- `retryTransientMem` returns the error after exhausting attempts when `access`
+  always fails `EIO`.
+- A **non-transient** error (e.g. `EFAULT`/`EPERM`) returns immediately with no
+  retry (call counter == 1).
+- `isTransientMemErr`: true for `EIO` (incl. wrapped via `fmt.Errorf("...: %w")`),
+  false for `EFAULT`/`nil`/others.
+- `procStateChar` parser: feed a sample `/proc/stat`-style line with parens/space
+  in comm; assert the correct state char is extracted (parse the helper on a
+  string to keep it kernel-independent — factor the parse into a pure function).
+
+Plus: existing `internal/ptrace` suites stay green; `go test ./...`;
+`GOOS=windows go build ./...` (changed file is `//go:build linux`).
+
+End-to-end (`EIO` actually recovered → kill rate ~100%) is verified by erans on a
+real `6.12.90` VM via v0.20.3-rc4.
+
+## Affected files
+
+- `internal/ptrace/memory.go` — add `isTransientMemErr`, `retryTransientMem`,
+  `logMemErrContext` + `procStateChar`/`addrInMaps` (and a pure parse helper);
+  split `writeBytes`/`vmReader.read` into `*Once` + retry wrapper. Imports:
+  `errors`, `log/slog`, `time`, `strings`/`bufio` for the diag helpers.
+- `internal/ptrace/memory_retry_test.go` — new unit tests.
+- Inject/stop protocol, access-ladder order, darwin/windows — unchanged.

--- a/internal/ptrace/memory.go
+++ b/internal/ptrace/memory.go
@@ -3,8 +3,15 @@
 package ptrace
 
 import (
+	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -36,6 +43,15 @@ func (r *vmReader) read(addr uint64, buf []byte) error {
 	if len(buf) == 0 {
 		return nil
 	}
+	return retryTransientMem(r.tid, addr, "read", func() error {
+		return r.readOnce(addr, buf)
+	})
+}
+
+// readOnce performs a single read attempt: process_vm_readv, falling back to
+// /proc/<tid>/mem pread. retryTransientMem retries this whole ladder on a
+// transient EIO (#369).
+func (r *vmReader) readOnce(addr uint64, buf []byte) error {
 	liov := unix.Iovec{Base: &buf[0], Len: uint64(len(buf))}
 	riov := unix.RemoteIovec{Base: uintptr(addr), Len: len(buf)}
 	_, err := unix.ProcessVMReadv(r.tid, []unix.Iovec{liov}, []unix.RemoteIovec{riov}, 0)
@@ -145,6 +161,15 @@ func (t *Tracer) writeBytes(tid int, addr uint64, buf []byte) error {
 	if len(buf) == 0 {
 		return nil
 	}
+	return retryTransientMem(tid, addr, "write", func() error {
+		return t.writeBytesOnce(tid, addr, buf)
+	})
+}
+
+// writeBytesOnce performs a single write attempt: process_vm_writev, falling
+// back to /proc/<tid>/mem pwrite. retryTransientMem retries this whole ladder on
+// a transient EIO (#369).
+func (t *Tracer) writeBytesOnce(tid int, addr uint64, buf []byte) error {
 	// Try process_vm_writev first (direct address-space copy, no VFS overhead).
 	liov := unix.Iovec{Base: &buf[0], Len: uint64(len(buf))}
 	riov := unix.RemoteIovec{Base: uintptr(addr), Len: len(buf)}
@@ -159,6 +184,119 @@ func (t *Tracer) writeBytes(tid int, addr uint64, buf []byte) error {
 	}
 	_, err = unix.Pwrite(fd, buf, int64(addr))
 	return err
+}
+
+// memRetryMaxAttempts bounds retries of a tracee-memory access on a transient
+// EIO. Injected accesses normally complete in microseconds, so the escalating
+// backoff (1+2+4+8 ≈ 15ms worst case) is paid only on the rare transient error.
+const memRetryMaxAttempts = 5
+
+// isTransientMemErr reports whether a tracee-memory access error looks like the
+// race-sensitive EIO observed on some kernels (exe.dev 6.12.90, #369), where
+// process_vm_* / /proc/<pid>/mem transiently fail right after a ptrace stop
+// transition (the access succeeds when serialized under strace). EFAULT is
+// intentionally NOT treated as transient — it is frequently a legitimate
+// bad-pointer result (e.g. readString crossing a page boundary), and retrying it
+// would add latency to normal operation.
+func isTransientMemErr(err error) bool {
+	return errors.Is(err, unix.EIO)
+}
+
+// retryTransientMem runs access (the full process_vm_* → /proc-mem ladder),
+// retrying on a transient EIO with escalating backoff. This replicates the
+// latency that makes the same access succeed under strace. On a healthy kernel
+// EIO never occurs, so access runs exactly once with no added latency. On
+// exhaustion it logs diagnostic context and returns the last error. (#369)
+func retryTransientMem(tid int, addr uint64, op string, access func() error) error {
+	var err error
+	for attempt := 0; attempt < memRetryMaxAttempts; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(1<<(attempt-1)) * time.Millisecond) // 1,2,4,8ms
+		}
+		err = access()
+		if err == nil {
+			if attempt > 0 {
+				slog.Debug("ptrace mem access recovered after retry",
+					"tid", tid, "addr", fmt.Sprintf("0x%x", addr), "op", op, "attempts", attempt+1)
+			}
+			return nil
+		}
+		if !isTransientMemErr(err) {
+			return err
+		}
+	}
+	logMemErrContext(tid, addr, op, err)
+	return err
+}
+
+// logMemErrContext records, at WARN, why a tracee-memory access kept failing:
+// the tracee's scheduler state char from /proc/<tid>/stat (expected 't'/'T' when
+// ptrace-stopped) and whether addr falls inside any /proc/<tid>/maps region.
+// Best-effort and observable without strace; never alters the returned error. (#369)
+func logMemErrContext(tid int, addr uint64, op string, accessErr error) {
+	slog.Warn("ptrace mem access failed after retries",
+		"tid", tid, "addr", fmt.Sprintf("0x%x", addr), "op", op,
+		"error", accessErr, "tracee_state", procStateChar(tid),
+		"addr_mapped", addrInMaps(tid, addr), "attempts", memRetryMaxAttempts)
+}
+
+// procStateChar returns the process state char from /proc/<tid>/stat ("" on error).
+func procStateChar(tid int) string {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", tid))
+	if err != nil {
+		return ""
+	}
+	return parseProcStatState(data)
+}
+
+// parseProcStatState extracts the state char (field 3) from /proc/<pid>/stat
+// content. comm (field 2) may contain spaces and parens, so the state char is
+// the first whitespace-delimited token after the LAST ')'. Returns "" if the
+// input is malformed.
+func parseProcStatState(data []byte) string {
+	i := bytes.LastIndexByte(data, ')')
+	if i < 0 || i+1 >= len(data) {
+		return ""
+	}
+	rest := strings.TrimLeft(string(data[i+1:]), " \t")
+	if rest == "" {
+		return ""
+	}
+	if sp := strings.IndexAny(rest, " \t\n"); sp >= 0 {
+		return rest[:sp]
+	}
+	return rest
+}
+
+// addrInMaps reports whether addr falls inside any mapped region in
+// /proc/<tid>/maps. Returns false on any error (best-effort diagnostic).
+func addrInMaps(tid int, addr uint64) bool {
+	f, err := os.Open(fmt.Sprintf("/proc/%d/maps", tid))
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text() // "start-end perms offset dev inode pathname"
+		dash := strings.IndexByte(line, '-')
+		if dash < 0 {
+			continue
+		}
+		sp := strings.IndexByte(line[dash:], ' ')
+		if sp < 0 {
+			continue
+		}
+		start, err1 := strconv.ParseUint(line[:dash], 16, 64)
+		end, err2 := strconv.ParseUint(line[dash+1:dash+sp], 16, 64)
+		if err1 != nil || err2 != nil {
+			continue
+		}
+		if addr >= start && addr < end {
+			return true
+		}
+	}
+	return false
 }
 
 // writeString writes a NUL-terminated string to the tracee's memory.

--- a/internal/ptrace/memory_retry_test.go
+++ b/internal/ptrace/memory_retry_test.go
@@ -1,0 +1,91 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestIsTransientMemErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"eio", unix.EIO, true},
+		{"wrapped eio", fmt.Errorf("write BPF to tracee: %w", unix.EIO), true},
+		{"efault", unix.EFAULT, false},
+		{"eperm", unix.EPERM, false},
+		{"nil", nil, false},
+	}
+	for _, c := range cases {
+		if got := isTransientMemErr(c.err); got != c.want {
+			t.Errorf("%s: isTransientMemErr(%v)=%v want %v", c.name, c.err, got, c.want)
+		}
+	}
+}
+
+func TestRetryTransientMem_RecoversAfterEIO(t *testing.T) {
+	calls := 0
+	err := retryTransientMem(0, 0x1000, "test", func() error {
+		calls++
+		if calls < 3 {
+			return unix.EIO
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls (2 EIO + 1 ok), got %d", calls)
+	}
+}
+
+func TestRetryTransientMem_ExhaustsOnPersistentEIO(t *testing.T) {
+	calls := 0
+	err := retryTransientMem(0, 0x1000, "test", func() error {
+		calls++
+		return unix.EIO
+	})
+	if !errors.Is(err, unix.EIO) {
+		t.Fatalf("expected EIO after exhaustion, got %v", err)
+	}
+	if calls != memRetryMaxAttempts {
+		t.Fatalf("expected %d calls, got %d", memRetryMaxAttempts, calls)
+	}
+}
+
+func TestRetryTransientMem_NonTransientReturnsImmediately(t *testing.T) {
+	calls := 0
+	err := retryTransientMem(0, 0x1000, "test", func() error {
+		calls++
+		return unix.EFAULT
+	})
+	if !errors.Is(err, unix.EFAULT) {
+		t.Fatalf("expected EFAULT, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call (no retry on non-transient), got %d", calls)
+	}
+}
+
+func TestParseProcStatState(t *testing.T) {
+	// comm (field 2) contains spaces and a paren; state char follows the LAST ')'.
+	line := []byte("1234 (weird )name) t 1 1234 1234 0 -1 4194304 123 0 0 0")
+	if got := parseProcStatState(line); got != "t" {
+		t.Fatalf("parseProcStatState = %q, want \"t\"", got)
+	}
+	// Simple comm, running state.
+	if got := parseProcStatState([]byte("42 (cat) R 1 42 42")); got != "R" {
+		t.Fatalf("parseProcStatState(simple) = %q, want \"R\"", got)
+	}
+	// Malformed input → empty, never panics.
+	if got := parseProcStatState([]byte("garbage with no paren")); got != "" {
+		t.Fatalf("parseProcStatState(garbage) = %q, want \"\"", got)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #396 for **#369 ("Gap C")**. rc3 (#396) fixed the return-register readback, but erans's rc3 test showed the *dominant* remaining failure is one layer down: ptrace cross-process tracee-memory access intermittently returns **`EIO`** — both the BPF-program write (`write BPF to tracee`, `inject_seccomp.go`, ×15 in one run) and the execve filename read (`handleExecve: cannot read filename`). agentsh's access ladder is `process_vm_*` → `/proc/<pid>/mem`; **both rungs `EIO`** and there's no `PTRACE_PEEK/POKE` fallback. Kill rate stayed ~80%.

The decisive clue: the access **succeeds when serialized under strace** and fails un-straced — a timing window (both methods converge on the kernel's `access_process_vm`/`get_user_pages` path, which transiently `EIO`s right after a stop transition while the tracee `mm` is in flux, notably around the execve address-space switch), not a capability gap.

## What changed

- **`writeBytes` and `vmReader.read` retry the whole access ladder on a transient `EIO`** (escalating backoff 1→2→4→8 ms, ≤~15 ms, bounded at 5 attempts) — replicating strace's latency. Split into `writeBytesOnce`/`readOnce` + a `retryTransientMem` wrapper.
- **`EIO` only** — `EFAULT` is intentionally not retried (often a legitimate bad pointer, e.g. `readString` crossing a page boundary; retrying would penalize normal operation).
- **Zero behavior/latency change on healthy kernels:** `EIO` doesn't occur there, so the access runs exactly once.
- **Diagnostics on exhaustion:** `logMemErrContext` records the tracee's `/proc/<tid>/stat` state char and whether the addr is in `/proc/<tid>/maps`, plus a `DEBUG` line on retry *success* (attempt count). Observable **without** strace — so if retry proves insufficient, the logs localize the cause (not-stopped vs unmapped vs mm-in-flux) in one rc cycle.

This is both a hypothesis test (does added latency recover the access? → confirms the transient-window theory) and, if confirmed, the fix.

Design: `docs/superpowers/specs/2026-05-26-issue-369-eio-retry-design.md`.

## Test plan

- [x] `go build ./...` + `GOOS=windows go build ./...` (changed file is `//go:build linux`)
- [x] `go test ./internal/ptrace/` green; new `memory_retry_test.go` unit-tests the retry/classification/parse logic deterministically (recover-after-N-EIO, exhaustion, non-transient-immediate-return, `parseProcStatState` with parens/spaces in comm); `go vet` + gofmt clean
- [ ] **End-to-end on a real exe.dev `6.12.90` VM (erans, v0.20.3-rc4):** n=20 `/bin/echo` kill-rate expected back toward v0.19.2's 100%. If kills remain, the new exhaustion diagnostics pinpoint the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)