### PR TITLE
diag(#369): verify injected scratch mmap actually maps in the tracee

### DIFF
--- a/internal/ptrace/memory.go
+++ b/internal/ptrace/memory.go
@@ -345,3 +345,76 @@ func nativeEndianUint64(b []byte) uint64 {
 	return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24 |
 		uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56
 }
+
+// --- #369 scratch-mmap diagnostics ---
+//
+// These let us confirm whether an injected mmap actually creates a mapping in
+// the tracee, and at the address the return register reported. Used by
+// ensureScratchPage to diagnose the structural EIO on exe.dev 6.12.90 where the
+// injected mmap returns a plausible page-aligned address that is not mapped.
+
+// mapStarts returns the set of mapping start addresses in /proc/<tid>/maps
+// (nil on error). Snapshot before an injected mmap to diff afterward.
+func mapStarts(tid int) map[uint64]struct{} {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/maps", tid))
+	if err != nil {
+		return nil
+	}
+	return parseMapStarts(data)
+}
+
+// newMapRanges returns the "start-end" ranges in /proc/<tid>/maps whose start
+// was not present in before (i.e. mappings created since the snapshot).
+func newMapRanges(tid int, before map[uint64]struct{}) []string {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/maps", tid))
+	if err != nil {
+		return nil
+	}
+	return parseNewMapRanges(data, before)
+}
+
+func parseMapStarts(data []byte) map[uint64]struct{} {
+	out := make(map[uint64]struct{})
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	for sc.Scan() {
+		line := sc.Text()
+		dash := strings.IndexByte(line, '-')
+		if dash <= 0 {
+			continue
+		}
+		start, err := strconv.ParseUint(line[:dash], 16, 64)
+		if err != nil {
+			continue
+		}
+		out[start] = struct{}{}
+	}
+	return out
+}
+
+func parseNewMapRanges(data []byte, before map[uint64]struct{}) []string {
+	var out []string
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	for sc.Scan() {
+		line := sc.Text()
+		dash := strings.IndexByte(line, '-')
+		if dash <= 0 {
+			continue
+		}
+		sp := strings.IndexByte(line[dash:], ' ')
+		if sp < 0 {
+			continue
+		}
+		start, err := strconv.ParseUint(line[:dash], 16, 64)
+		if err != nil {
+			continue
+		}
+		if _, seen := before[start]; seen {
+			continue
+		}
+		out = append(out, line[:dash+sp]) // "start-end"
+		if len(out) >= 16 {
+			break
+		}
+	}
+	return out
+}

--- a/internal/ptrace/memory_maps_diag_test.go
+++ b/internal/ptrace/memory_maps_diag_test.go
@@ -1,0 +1,44 @@
+//go:build linux
+
+package ptrace
+
+import "testing"
+
+func TestParseMapStartsAndNewRanges(t *testing.T) {
+	before := []byte(
+		"55000000-55001000 r--p 00000000 00:00 0 \n" +
+			"7f0000000000-7f0000001000 rw-p 00000000 00:00 0 \n")
+	after := []byte(
+		"55000000-55001000 r--p 00000000 00:00 0 \n" +
+			"7f0000000000-7f0000001000 rw-p 00000000 00:00 0 \n" +
+			"5616ca43d000-5616ca43e000 rw-p 00000000 00:00 0 \n")
+
+	starts := parseMapStarts(before)
+	if len(starts) != 2 {
+		t.Fatalf("parseMapStarts: got %d starts, want 2", len(starts))
+	}
+	if _, ok := starts[0x55000000]; !ok {
+		t.Fatal("expected 0x55000000 among before starts")
+	}
+
+	newR := parseNewMapRanges(after, starts)
+	if len(newR) != 1 || newR[0] != "5616ca43d000-5616ca43e000" {
+		t.Fatalf("parseNewMapRanges: got %v, want [5616ca43d000-5616ca43e000]", newR)
+	}
+
+	// No new mappings when after == before set.
+	if got := parseNewMapRanges(before, starts); len(got) != 0 {
+		t.Fatalf("parseNewMapRanges(before): got %v, want empty", got)
+	}
+}
+
+func TestParseMapStarts_MalformedLinesSkipped(t *testing.T) {
+	data := []byte("garbage\n-\nzz-zz perms\n7f00-7f01 rw-p 0 0:0 0\n")
+	starts := parseMapStarts(data)
+	if len(starts) != 1 {
+		t.Fatalf("got %d starts, want 1 (only the valid line)", len(starts))
+	}
+	if _, ok := starts[0x7f00]; !ok {
+		t.Fatal("expected 0x7f00 from the one valid line")
+	}
+}

--- a/internal/ptrace/scratch.go
+++ b/internal/ptrace/scratch.go
@@ -4,6 +4,7 @@ package ptrace
 
 import (
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"golang.org/x/sys/unix"
@@ -51,6 +52,12 @@ func (t *Tracer) ensureScratchPage(tid, tgid int, savedRegs Regs) (*scratchPage,
 		return sp, nil
 	}
 
+	// #369 diagnostic: snapshot the tracee's mappings, inject mmap, then verify
+	// the mmap actually created a mapping at the returned address. A new mapping
+	// at a different address than addr ⇒ the return register is mis-read; no new
+	// mapping ⇒ the injected mmap did not take effect on this kernel.
+	mapsBefore := mapStarts(tid)
+
 	// Inject mmap(NULL, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0)
 	addr, err := t.injectSyscallRet(tid, savedRegs, unix.SYS_MMAP,
 		0, 4096,
@@ -61,6 +68,17 @@ func (t *Tracer) ensureScratchPage(tid, tgid int, savedRegs Regs) (*scratchPage,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("mmap injection: %w", err)
+	}
+
+	retMapped := addrInMaps(tid, addr)
+	if !retMapped {
+		// Anomaly path only (keeps the extra /proc/maps read off the happy path):
+		// dump the mappings the injected mmap actually created so we can tell a
+		// mis-read return (new mapping at a different address) from an mmap that
+		// did not take effect (no new mapping). #369.
+		slog.Warn("scratch mmap returned an unmapped address (#369 diag)",
+			"tid", tid, "tgid", tgid, "mmap_ret", fmt.Sprintf("0x%x", addr),
+			"new_mappings", newMapRanges(tid, mapsBefore))
 	}
 
 	sp = &scratchPage{addr: addr, size: 4096}


### PR DESCRIPTION
## Summary

**Diagnostic-only** follow-up to #397, for **#369 ("Gap C")**. rc4's diagnostic showed the dominant kill is a *structural* `EIO`: the injected scratch-page `mmap` returns a plausible page-aligned address that is **not actually mapped** in the tracee (`addr_mapped=false`, ×14/14). Confirmed in code that this is **not** a stale-cache bug — `handleExecEvent` invalidates the per-TGID scratch page on `PTRACE_EVENT_EXEC` and reopens `/proc/mem`, so the post-exec inject allocates a *fresh* `mmap`.

This adds a `/proc/<tid>/maps` before/after diff around the `mmap` inject in `ensureScratchPage`. On the anomaly path (returned addr not mapped) it logs the returned address plus the mappings the `mmap` *actually* created — which decisively distinguishes:
- **(a) mis-read return register** → a new mapping appears at a **different** address than `mmap_ret` (`#396` didn't fully fix the readback) → a concrete, fixable agentsh bug.
- **(b) `mmap` doesn't take effect** → **no** new mapping → kernel-fundamental; no inject fix will help, and the honest resolution is to degrade the ptrace backend on this kernel.

## What changed

- `ensureScratchPage` (`scratch.go`): snapshot map starts before the inject; if the returned addr isn't mapped, `WARN` with `mmap_ret` + `new_mappings`.
- `memory.go`: `mapStarts`/`newMapRanges` + pure `parseMapStarts`/`parseNewMapRanges` helpers (unit-tested).
- Anomaly-path only: one extra snapshot read per process; the diff read runs solely when the bug reproduces. **Diagnostic — to be reverted once the root cause is confirmed.**

## Test plan

- [x] `go test ./internal/ptrace/` green (new `memory_maps_diag_test.go` covers the parsers, incl. malformed lines); `go vet` + gofmt clean; `GOOS=windows go build ./...`
- [ ] **Capture on a real exe.dev 6.12.90 VM (erans, v0.20.3-rc5):** the `WARN scratch mmap returned an unmapped address (#369 diag)` line's `mmap_ret` + `new_mappings` decide (a) vs (b).

🤖 Generated with [Claude Code](https://claude.com/claude-code)