### PR TITLE
fix(#369): authoritative exit-stop inject trigger + gadget/exec/scratch guards

### DIFF
--- a/docs/superpowers/plans/2026-05-27-issue-369-inject-trigger-gadget.md
+++ b/docs/superpowers/plans/2026-05-27-issue-369-inject-trigger-gadget.md
@@ -1,0 +1,184 @@
+# Ptrace inject: authoritative exit-stop trigger + gadget/exec verification — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Fix Gap C (#369) at its source — make the prefilter inject fire only at a true syscall-EXIT stop (authoritative `PTRACE_GET_SYSCALL_INFO`, not the desync-prone `InSyscall` toggle), verify the `RIP−2` gadget is a real `syscall`, verify the injected syscall actually executed, and fail-closed when the scratch `mmap` maps no VMA. Result: on exe.dev 6.12.90 the inject succeeds and commands run **with ptrace enforcing** (kill rate → 0), instead of phantom-address kills.
+
+**Spec:** `docs/superpowers/specs/2026-05-27-issue-369-inject-trigger-gadget-design.md`
+
+**Testing reality:** the 6.12.90 stop-desync is NOT reproducible on CI (CI stops don't desync), so there is no failing test to write for the bug itself. The guards are correct-by-construction; tests assert (a) no regression — the prefilter inject still works on the CI kernel with all guards active, and (b) unit-level correctness of the new predicates. End-to-end verified by erans on v0.20.3-rc7.
+
+---
+
+## Task 1: Authoritative exit-stop trigger classification (`tracer.go`)  [capable model]
+
+**Files:** Modify `internal/ptrace/tracer.go`. Test: `internal/ptrace/inject_trigger_test.go` (new) + `internal/ptrace/integration_test.go` (no-regression, existing).
+
+This is the delicate core fix. The `InSyscall` enter/exit toggle in `handleSyscallStop` desyncs on 6.12.90's post-exec stop storm; replace the **trigger decision** (not the toggle maintenance) with the authoritative op.
+
+- [ ] **Step 1: Add the helper** (near `syscallStopOp` consumers in `tracer.go`, or in `inject.go`):
+```go
+// atSyscallExitStop reports whether the tracee is at a syscall-EXIT stop. It
+// prefers the authoritative PTRACE_GET_SYSCALL_INFO op; the hand-maintained
+// InSyscall toggle is only a pre-5.3 fallback, because that toggle can desync
+// from the real stop sequence on kernels whose post-exec stop storm interleaves
+// PTRACE_EVENT/signal stops (#369). Call on the tracer thread at a ptrace stop.
+func (t *Tracer) atSyscallExitStop(tid int, inSyscall bool) bool {
+	if t.hasSyscallInfo {
+		if op, err := t.syscallStopOp(tid); err == nil {
+			return op == ptraceSyscallInfoExit
+		}
+	}
+	return inSyscall
+}
+```
+
+- [ ] **Step 2: Unit test the fallback** (`inject_trigger_test.go`, `//go:build linux`):
+```go
+func TestAtSyscallExitStop_FallbackToToggle(t *testing.T) {
+	tr := &Tracer{hasSyscallInfo: false} // no PTRACE_GET_SYSCALL_INFO → use toggle
+	if !tr.atSyscallExitStop(0, true) {
+		t.Fatal("fallback: inSyscall=true must report exit")
+	}
+	if tr.atSyscallExitStop(0, false) {
+		t.Fatal("fallback: inSyscall=false must report not-exit")
+	}
+}
+```
+Run: `go test ./internal/ptrace/ -run AtSyscallExitStop` → FAIL (undefined) then PASS after Step 1.
+
+- [ ] **Step 3: Restructure the prefilter trigger** in `handleSyscallStop` (`tracer.go:~889-925`). Replace the `if PendingPrefilter && !InSyscall {…} else if PendingPrefilter && InSyscall {…}` block with the authoritative classification, computing the op OUTSIDE the `t.mu` critical section (don't hold `t.mu` across the ptrace call):
+```go
+		t.mu.Lock()
+		state := t.tracees[tid]
+		pendingPrefilter := state != nil && state.PendingPrefilter
+		inSyscall := state != nil && state.InSyscall
+		t.mu.Unlock()
+
+		if pendingPrefilter && t.atSyscallExitStop(tid, inSyscall) {
+			// Confirmed syscall-EXIT: inject now. (Entry/unconfirmable stops fall
+			// through — the next exit stop will trigger injection.)
+			t.mu.Lock()
+			if s := t.tracees[tid]; s != nil {
+				s.PendingPrefilter = false
+				s.InSyscall = false // injectFromExit protocol
+			}
+			t.mu.Unlock()
+			if err := t.injectSeccompFilter(tid); err != nil {
+				slog.Warn("seccomp prefilter injection failed, falling back to TRACESYSGOOD", "tid", tid, "error", err)
+				t.mu.Lock()
+				if s := t.tracees[tid]; s != nil {
+					s.InSyscall = true
+				}
+				t.mu.Unlock()
+			} else {
+				t.mu.Lock()
+				if s := t.tracees[tid]; s != nil {
+					s.HasPrefilter = true
+					s.InSyscall = true
+				}
+				t.mu.Unlock()
+			}
+			// Fall through to normal exit handling (InSyscall=true restored).
+		}
+```
+Preserve the surrounding comments' intent and the "fall through, do NOT return" behavior. The `InSyscall` toggle is still maintained elsewhere for the legacy fallback + normal exit handling — do not remove that.
+
+- [ ] **Step 4: Apply the same classification to the escalation triggers** (`tracer.go:~935-980`). The read- and write-escalation blocks gate inject on `HasPrefilter && state.InSyscall && PendingXEscalation` and set pending on `HasPrefilter && !state.InSyscall`. Replace those `state.InSyscall` / `!state.InSyscall` enter/exit checks with `t.atSyscallExitStop(tid, state.InSyscall)` / `!t.atSyscallExitStop(...)`, computing the op outside the lock as in Step 3. Keep all flag side-effects identical.
+
+- [ ] **Step 5: Build + vet + no-regression.**
+Run: `go build ./internal/ptrace/ && go vet ./internal/ptrace/`
+Run: `go test ./internal/ptrace/` (unit) → PASS.
+Run (if kernel allows): `go test -tags 'integration linux' ./internal/ptrace/ 2>&1 | tail -30` → the prefilter-inject integration tests (`TestIntegration_*Allow/Deny/Redirect`, `MultipleRapidExecs`, etc.) must still PASS — on CI the authoritative op agrees with the old toggle, so the same stop is chosen. Report any that flip (those would reveal a behavior change).
+
+- [ ] **Step 6: Commit** (`fix(ptrace,#369): classify prefilter/escalation inject trigger via syscallStopOp==EXIT`).
+
+---
+
+## Task 2: Gadget + execution verification in the inject path (`inject.go` + arch files)
+
+**Files:** Modify `internal/ptrace/inject.go`, `internal/ptrace/inject_amd64.go`, `internal/ptrace/inject_arm64.go`. Test: `internal/ptrace/inject_guard_test.go` (new, arch-split or amd64-guarded).
+
+- [ ] **Step 1: Add a per-arch syscall-instruction predicate.**
+In `inject_amd64.go`:
+```go
+// isSyscallInsn reports whether b is the amd64 `syscall` instruction (0F 05).
+func isSyscallInsn(b []byte) bool { return len(b) >= 2 && b[0] == 0x0f && b[1] == 0x05 }
+```
+In `inject_arm64.go` (verify the encoding against the file; `svc #0` = `0xD4000001`, little-endian bytes `01 00 00 D4`):
+```go
+// isSyscallInsn reports whether b is the arm64 `svc #0` instruction.
+func isSyscallInsn(b []byte) bool {
+	return len(b) >= 4 && b[0] == 0x01 && b[1] == 0x00 && b[2] == 0x00 && b[3] == 0xd4
+}
+```
+(`syscallInsnSize` already exists per-arch: 2 on amd64, 4 on arm64 — use it for the read length.)
+
+- [ ] **Step 2: Unit-test the predicate** (`inject_guard_test.go`, `//go:build linux`; gate arch-specific bytes with `runtime.GOARCH` or build tags):
+```go
+func TestIsSyscallInsn(t *testing.T) {
+	// On amd64 the syscall insn is 0F 05; anything else must be rejected.
+	if runtime.GOARCH == "amd64" {
+		if !isSyscallInsn([]byte{0x0f, 0x05}) { t.Fatal("0f05 should be a syscall insn") }
+		if isSyscallInsn([]byte{0x48, 0x89}) { t.Fatal("mov must not be a syscall insn") }
+		if isSyscallInsn([]byte{0x0f}) { t.Fatal("short buf must be rejected") }
+	}
+}
+```
+
+- [ ] **Step 3: Fix (2) — verify the gadget** in `injectFromExit`, right after `gadget := syscallGadgetAddr(savedRegs)` and before `injRegs.SetInstructionPointer(gadget)`:
+```go
+	insn := make([]byte, syscallInsnSize)
+	if err := t.readBytes(tid, gadget, insn); err != nil {
+		return 0, fmt.Errorf("inject gadget read @0x%x: %w", gadget, err)
+	}
+	if !isSyscallInsn(insn) {
+		return 0, fmt.Errorf("inject gadget @0x%x not a syscall instruction (% x); stop misclassified (#369)", gadget, insn)
+	}
+```
+
+- [ ] **Step 4: Fix (3) — verify execution** in BOTH `injectFromEntry` and `injectFromExit`, immediately after `retRegs, err := t.getRegs(tid)` succeeds and BEFORE `ret := retRegs.ReturnValue()`:
+```go
+	if got := retRegs.SyscallNr(); got != nr {
+		injectErr = fmt.Errorf("injected syscall %d did not execute (orig_rax=%d at exit); stop misclassified (#369)", nr, got)
+		return 0, injectErr
+	}
+```
+(Inside the existing `injectErr` defer scope so registers are restored on this error.)
+
+- [ ] **Step 5: Build all arches + test.**
+Run: `go build ./internal/ptrace/ && GOARCH=arm64 go build ./internal/ptrace/ && go vet ./internal/ptrace/`
+Run: `go test ./internal/ptrace/ -run 'IsSyscallInsn'` → PASS.
+Run (if kernel allows): `go test -tags 'integration linux' ./internal/ptrace/ 2>&1 | tail -30` → prefilter-inject + redirect tests still PASS (on CI the gadget is a real syscall and `orig_rax==nr`, so the guards never reject a valid inject). Report any flips.
+
+- [ ] **Step 6: Commit** (`fix(ptrace,#369): verify inject gadget is a syscall insn + injected syscall executed`).
+
+---
+
+## Task 3: Fail-closed scratch page (`scratch.go`)
+
+**Files:** Modify `internal/ptrace/scratch.go`.
+
+- [ ] **Step 1: Replace the #398 WARN-only block** in `ensureScratchPage`. The current code logs a WARN when `!addrInMaps(tid, addr)` then builds `sp = &scratchPage{addr: addr, size: 4096}` regardless. Change to return an error so the phantom address is never used:
+```go
+	if !addrInMaps(tid, addr) {
+		return nil, fmt.Errorf("scratch mmap returned 0x%x but mapped no VMA (#369); new_mappings=%v",
+			addr, newMapRanges(tid, mapsBefore))
+	}
+```
+(Remove the `slog.Warn` it replaces; keep the `mapsBefore` snapshot for the error detail. The `slog` import may become unused in scratch.go — drop it if so.)
+
+- [ ] **Step 2: Build + vet + test.**
+Run: `go build ./internal/ptrace/ && go vet ./internal/ptrace/`
+Run: `go test ./internal/ptrace/` and (if kernel allows) `go test -tags 'integration linux' ./internal/ptrace/ 2>&1 | tail -20` → on CI the mmap maps, so `ensureScratchPage` returns success and prefilter-inject tests stay green.
+Note: `ptrace.ProbePtraceInject` (the #399 probe) calls `ensureScratchPage` and is fail-open on its error — so this new error path keeps the probe fail-open (no behavior change there). Confirm `go test ./internal/ptrace/ -tags 'integration linux' -run InjectProbe` still PASSes (Injectable=true on CI).
+
+- [ ] **Step 3: Commit** (`fix(ptrace,#369): fail-closed when injected scratch mmap maps no VMA`).
+
+---
+
+## Task 4: Full gates
+
+- [ ] **Step 1:** `go test ./...` — green except the known pre-existing `internal/fsmonitor` FUSE-mount env failure (rerun to confirm unrelated).
+- [ ] **Step 2:** `GOOS=windows go build ./...` and `GOARCH=arm64 go build ./...` — clean (the arch-split `isSyscallInsn`/`syscallInsnSize` keep both building).
+- [ ] **Step 3:** `gofmt -l` clean on all changed files; `go vet ./internal/ptrace/` clean.

--- a/docs/superpowers/plans/2026-05-27-issue-369-inject-trigger-gadget.md
+++ b/docs/superpowers/plans/2026-05-27-issue-369-inject-trigger-gadget.md
@@ -173,6 +173,8 @@ Run: `go build ./internal/ptrace/ && go vet ./internal/ptrace/`
 Run: `go test ./internal/ptrace/` and (if kernel allows) `go test -tags 'integration linux' ./internal/ptrace/ 2>&1 | tail -20` → on CI the mmap maps, so `ensureScratchPage` returns success and prefilter-inject tests stay green.
 Note: `ptrace.ProbePtraceInject` (the #399 probe) calls `ensureScratchPage` and is fail-open on its error — so this new error path keeps the probe fail-open (no behavior change there). Confirm `go test ./internal/ptrace/ -tags 'integration linux' -run InjectProbe` still PASSes (Injectable=true on CI).
 
+> **Correction (roborev follow-up):** the "keeps the probe fail-open (no behavior change)" note was wrong for the unmapped-VMA case — before this change the probe fail-**closed** there (its own `addrInMaps` check → Injectable=false/degrade). A plain error would have flipped it to fail-open. Final code instead wraps a sentinel (`errScratchUnmapped`) in `ensureScratchPage` and classifies it in the probe (`classifyScratchInjectErr`) to **preserve fail-closed** on the unmapped case; the wiring is locked by `inject_probe_classify_test.go`.
+
 - [ ] **Step 3: Commit** (`fix(ptrace,#369): fail-closed when injected scratch mmap maps no VMA`).
 
 ---

--- a/docs/superpowers/specs/2026-05-27-issue-369-inject-trigger-gadget-design.md
+++ b/docs/superpowers/specs/2026-05-27-issue-369-inject-trigger-gadget-design.md
@@ -48,6 +48,16 @@ instead of a silent phantom that later `EIO`s and kills the command.
   non-representative probe is a follow-up, tracked separately. (Its
   `ProbePtraceInject` reuse of `ensureScratchPage` is fail-open, so fix (4)'s new
   error path just makes the probe fail-open as before — no behavior change.)
+
+  > **Correction (roborev follow-up, superseding the parenthetical above):** the
+  > "no behavior change / fail-open as before" claim was wrong for the
+  > unmapped-VMA case. Before fix (4), a broken kernel returned `(addr, nil)` and
+  > the probe's own `addrInMaps` check made it fail-**closed** (Injectable=false,
+  > degrade). Fix (4) turning that into a generic error would have flipped it to
+  > fail-**open**. We therefore made `ensureScratchPage` wrap a sentinel
+  > (`errScratchUnmapped`) and had the probe classify it as the clean
+  > broken-kernel signal, **preserving fail-closed** on the unmapped case.
+  > Production inject paths still treat every `ensureScratchPage` error identically.
 - **The `TRACESYSGOOD` fallback hang is not addressed.** On inject failure the
   code logs "falling back to TRACESYSGOOD", which hangs on 6.12.90 (pre-existing,
   separate). With fix (1) correct, the inject succeeds, so this fallback is not

--- a/docs/superpowers/specs/2026-05-27-issue-369-inject-trigger-gadget-design.md
+++ b/docs/superpowers/specs/2026-05-27-issue-369-inject-trigger-gadget-design.md
@@ -1,0 +1,221 @@
+# Ptrace inject: authoritative exit-stop trigger + gadget/exec verification — Design
+
+Issue: #369 ("Gap C"). Supersedes the rc6 honest-degrade direction (#399) — the bug
+is **fixable**, not a kernel incapability.
+
+## Summary
+
+erans's source review (verified against `48d49782`) found the true root cause of
+Gap C, which rc2–rc6 all missed. The seccomp-prefilter inject decides "is this a
+syscall-EXIT stop?" using a **hand-toggled `state.InSyscall` bit**
+(`tracer.go:896`), not the authoritative `PTRACE_GET_SYSCALL_INFO` op. On exe.dev
+`6.12.90`, the post-exec `ld.so` syscall storm (interleaved `PTRACE_EVENT`/group/
+signal stops) **desyncs that toggle by one**, so the inject fires at a stop that
+isn't really an exit. `injectFromExit` then uses a **blind `RIP−2` gadget**
+(`inject_amd64.go`) with no verification it points at a `syscall` (`0F 05`)
+instruction — at a non-exit stop it doesn't, so the injected `mmap` executes
+against garbage, returns an address-like RAX, and maps **no VMA** (the `#398`
+phantom `new_mappings=[]`). "Works under strace" is the tell: serialization
+re-syncs the stop sequence (Heisenbug).
+
+This fixes the mis-execution at its source:
+1. **Classify the trigger authoritatively** — gate the inject on
+   `syscallStopOp == EXIT`, not `state.InSyscall` (reusing the `#396` accessor).
+2. **Verify the gadget** — require the bytes at `RIP−2` to be `0F 05` before use.
+3. **Verify execution** — after the injected syscall, require `ORIG_RAX == nr`.
+4. **Fail-closed scratch** — return an error when the injected `mmap` maps no VMA,
+   instead of building a phantom `scratchPage`.
+
+(1) is the core fix; (2)–(4) turn any residual misfire into a clean inject error
+instead of a silent phantom that later `EIO`s and kills the command.
+
+## Goals
+
+- On 6.12.90 the prefilter inject fires only at a true syscall-EXIT stop, the
+  gadget is a real `syscall`, the injected `mmap` actually maps, the prefilter
+  installs, and commands run **with ptrace enforcing** (kill rate → 0).
+- Zero behavior change on kernels where the toggle was already correct (the
+  authoritative op agrees with `InSyscall` there; same stop chosen).
+- Pre-5.3 kernels (no `PTRACE_GET_SYSCALL_INFO`) keep the legacy toggle behavior.
+- A genuinely failed inject (wrong gadget, syscall didn't run, mmap mapped
+  nothing) becomes a clean error, never a phantom address used downstream.
+
+## Non-Goals
+
+- **The `#399` self-probe / honest-degrade is NOT removed here.** Once the inject
+  works, the probe (which already always passed, since it bypasses the trigger)
+  stays passing → degrade never fires → dormant. Reworking/removing the
+  non-representative probe is a follow-up, tracked separately. (Its
+  `ProbePtraceInject` reuse of `ensureScratchPage` is fail-open, so fix (4)'s new
+  error path just makes the probe fail-open as before — no behavior change.)
+- **The `TRACESYSGOOD` fallback hang is not addressed.** On inject failure the
+  code logs "falling back to TRACESYSGOOD", which hangs on 6.12.90 (pre-existing,
+  separate). With fix (1) correct, the inject succeeds, so this fallback is not
+  reached on this kernel. Fixes (2)/(3)/(4) aborting would reach it — acceptable
+  as they should be dormant once (1) is right; not made worse here.
+- No change to `process_vm_*`, user-notify, cgroups, the wait_killable probe, or
+  darwin/windows.
+
+## Background (verified on this branch base)
+
+- Prefilter trigger: `tracer.go:892-925` — `if state.PendingPrefilter &&
+  !state.InSyscall { wait } else if state.PendingPrefilter && state.InSyscall {
+  inject }`. The escalation triggers (`tracer.go:935-975`) use the identical
+  `state.InSyscall` enter/exit pattern (`HasPrefilter && InSyscall &&
+  PendingReadEscalation`, etc.).
+- `syscallStopOp(tid) (uint8, error)` + op consts (`ptraceSyscallInfoEntry/Exit/
+  Seccomp/None`) exist in `syscall_context.go` (added in #396); `t.hasSyscallInfo`
+  is probed at startup. `PTRACE_O_TRACESYSGOOD` is always set, so at a SIGTRAP|0x80
+  stop the op is ENTRY or EXIT (authoritative).
+- Gadget: `inject_amd64.go:syscallGadgetAddr(regs) = regs.InstructionPointer()-2`
+  (arm64 has its own in `inject_arm64.go` — check and mirror the verification).
+- Return/orig-rax accessors: `args_amd64.go` — `ReturnValue()`=RAX,
+  `SyscallNr()`=`Orig_rax`. (arm64 equivalents in `args_arm64.go`.)
+- `injectFromExit`/`injectFromEntry` (`inject.go`): compute gadget, set regs,
+  resume, `waitForSyscallExitStop`, read `retRegs.ReturnValue()`, restore.
+- Scratch: `scratch.go:ensureScratchPage` — after the mmap inject, `#398` logs a
+  WARN when `!addrInMaps(tid, addr)` but **builds `sp = &scratchPage{addr: addr}`
+  anyway**. `t.readBytes(tid, addr, buf)` (`memory.go`) reads tracee memory
+  (process_vm_readv → /proc/mem); confirmed working on 6.12.90.
+
+## Design
+
+### Fix 1 — authoritative exit-stop classification (`tracer.go`)
+
+Add a helper:
+```go
+// atSyscallExitStop reports whether the tracee is at a syscall-EXIT stop. It
+// prefers the authoritative PTRACE_GET_SYSCALL_INFO op; the hand-maintained
+// InSyscall toggle is only a pre-5.3 fallback because that toggle can desync
+// from the real stop sequence on kernels whose post-exec stop storm interleaves
+// PTRACE_EVENT/signal stops (#369). Must be called on the tracer thread at a
+// ptrace stop.
+func (t *Tracer) atSyscallExitStop(tid int, inSyscall bool) bool {
+	if t.hasSyscallInfo {
+		if op, err := t.syscallStopOp(tid); err == nil {
+			return op == ptraceSyscallInfoExit
+		}
+	}
+	return inSyscall
+}
+```
+In `handleSyscallStop`, replace the three `state.InSyscall` enter/exit decisions
+(prefilter trigger + read-escalation + write-escalation) so the "this is an exit
+stop, inject now" branch is gated on `t.atSyscallExitStop(tid, state.InSyscall)`
+rather than the raw `state.InSyscall`. Compute the op **outside** the `t.mu`
+critical section (read `PendingPrefilter`/`InSyscall` under lock, drop the lock,
+classify, re-lock to mutate + inject) to avoid holding `t.mu` across a ptrace
+call. Preserve every existing side effect: `PendingPrefilter=false`,
+`InSyscall=false` before inject, the post-inject `InSyscall=true`/`HasPrefilter`
+restore, and the "fall through to normal exit handling" comment/behavior. The
+`InSyscall` toggle itself is still maintained for the legacy fallback and for the
+normal (non-inject) exit handling.
+
+### Fix 2 — gadget verification (`inject.go`, `injectFromExit`)
+
+After `gadget := syscallGadgetAddr(savedRegs)` and before `SetInstructionPointer`,
+read 2 bytes at `gadget` and require the `syscall` opcode:
+```go
+var op [2]byte
+if err := t.readBytes(tid, gadget, op[:]); err != nil {
+	return 0, fmt.Errorf("inject gadget read @0x%x: %w", gadget, err)
+}
+if op[0] != 0x0f || op[1] != 0x05 { // amd64 `syscall`
+	return 0, fmt.Errorf("inject gadget @0x%x is not a syscall instruction (0x%02x%02x); stop misclassified", gadget, op[1], op[0])
+}
+```
+(arm64: the `svc #0` encoding is `0xD4000001`; mirror the check in the arm64
+path/build if `injectFromExit` is shared — verify which file holds the arm64
+gadget and add an equivalent 4-byte check, or guard the check behind amd64 if the
+gadget helper is arch-split.)
+
+### Fix 3 — injected-syscall execution verification (`inject.go`)
+
+In both `injectFromEntry` and `injectFromExit`, after reaching the exit stop and
+reading `retRegs`, before trusting `ReturnValue()`:
+```go
+if got := retRegs.SyscallNr(); got != nr {
+	injectErr = fmt.Errorf("injected syscall %d did not execute (orig_rax=%d at exit); stop misclassified", nr, got)
+	return 0, injectErr
+}
+```
+(Place inside the existing `injectErr` defer-restore scope so registers are
+restored on this error.)
+
+### Fix 4 — fail-closed scratch page (`scratch.go`, `ensureScratchPage`)
+
+Replace the `#398` WARN-only block so an unmapped return is a hard error:
+```go
+if !addrInMaps(tid, addr) {
+	return nil, fmt.Errorf("scratch mmap returned 0x%x but mapped no VMA (#369); new_mappings=%v",
+		addr, newMapRanges(tid, mapsBefore))
+}
+```
+(Remove the now-redundant WARN; the error carries the same diagnostic. Keep the
+`mapsBefore` snapshot for the error detail.) `ensureScratchPage`'s callers already
+handle its error (the prefilter/escalation inject paths wrap and fall back).
+
+### Why this fixes 6.12.90
+
+With (1), the inject fires only at a real EXIT stop ⇒ `RIP` is just past a real
+`syscall` ⇒ `RIP−2` is `0F 05` ((2) passes) ⇒ the injected `mmap` actually runs
+((3) passes, `orig_rax==SYS_mmap`) ⇒ a VMA appears ((4) passes) ⇒ the prefilter
+installs ⇒ commands run with ptrace enforcing. (2)–(4) are guards: if the stop is
+ever still misclassified, they abort with a precise error instead of the phantom.
+
+## Decisions
+
+- **Authoritative op over the toggle**, with the toggle kept only as the pre-5.3
+  fallback. This is the minimal, surgical fix to the misclassification.
+- **Apply (1) at all three trigger points** (prefilter + read/write escalation) —
+  they share the identical desync-prone pattern; fixing only the prefilter would
+  leave the escalations latent once the prefilter starts installing.
+- **(2)/(3)/(4) abort to a clean error** rather than masking. They are
+  defense-in-depth and dormant once (1) is correct.
+- **#399 left dormant** (see Non-Goals) — out of scope; it does no harm once
+  injection works, and removing it is separate churn.
+
+## Error handling
+
+- Each guard returns a descriptive error through the existing inject error paths
+  (`injectSeccompFilter` → "falling back to TRACESYSGOOD" WARN). With (1) correct
+  these are not reached on a healthy or fixed kernel; on a truly-broken one they
+  yield a clean failure instead of a phantom-address `EIO` kill.
+- `readBytes` for the gadget uses the working `process_vm_readv`/`/proc/mem`
+  ladder; a read error aborts the inject (fail-safe).
+
+## Testing
+
+The 6.12.90 desync is not CI-reproducible (CI stops don't desync), so:
+
+- **No-regression (integration, `//go:build integration && linux`):** the existing
+  `TestIntegration_*` prefilter-inject tests (e.g. file/exec/network redirect,
+  `MultipleRapidExecs`) must stay green — on CI the authoritative op agrees with
+  the old toggle, the gadget is a real syscall, `orig_rax==nr`, and the mmap maps,
+  so nothing aborts. This is the primary guard against breaking healthy kernels.
+- **Unit (`//go:build linux`):** gadget-opcode check is a pure predicate — test
+  `0x0f,0x05 → ok`; anything else → error. `atSyscallExitStop` fallback when
+  `hasSyscallInfo=false` returns the toggle value (construct a `Tracer{hasSyscallInfo:false}`).
+- **Integration for the new primitive:** a live-tracee test (mirror
+  `syscall_stop_op_test.go`) that drives a child to a real exit stop and asserts
+  `atSyscallExitStop` is true there and false at an entry stop; and that
+  `injectFromExit` of a benign syscall (e.g. `getpid`) succeeds with the gadget +
+  orig_rax guards in place (proving they don't reject a valid inject).
+- Full `internal/ptrace` (+ dependent) suites green; `GOOS=windows go build ./...`;
+  gofmt/vet clean. arm64 cross-build if the gadget check is arch-specific.
+
+End-to-end on exe.dev 6.12.90 (kill rate → 0, prefilter installs, ptrace
+enforcing) verified by erans on v0.20.3-rc7.
+
+## Affected files
+
+- `internal/ptrace/tracer.go` — `atSyscallExitStop` helper + the 3 trigger
+  decisions in `handleSyscallStop`.
+- `internal/ptrace/inject.go` — gadget verification + `orig_rax==nr` check in
+  `injectFromExit`/`injectFromEntry`.
+- `internal/ptrace/scratch.go` — fail-closed `ensureScratchPage`.
+- `internal/ptrace/inject_arm64.go`/`args_arm64.go` — mirror gadget check if the
+  gadget helper is arch-split (verify during implementation).
+- Tests across `internal/ptrace/`.
+- `#399` probe/degrade, `process_vm_*`, user-notify, cgroups, darwin/windows —
+  unchanged.

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -86,7 +86,7 @@ func (t *Tracer) injectFromEntry(tid int, savedRegs Regs, nr int, args ...uint64
 		return 0, injectErr
 	}
 	if got := retRegs.SyscallNr(); got != nr {
-		injectErr = fmt.Errorf("injected syscall %d did not execute (orig_rax=%d at exit); stop misclassified (#369)", nr, got)
+		injectErr = fmt.Errorf("injected syscall %d did not execute (syscall_nr=%d at exit); stop misclassified (#369)", nr, got)
 		return 0, injectErr
 	}
 	ret := retRegs.ReturnValue()
@@ -172,7 +172,7 @@ func (t *Tracer) injectFromExit(tid int, savedRegs Regs, nr int, args ...uint64)
 		return 0, injectErr
 	}
 	if got := retRegs.SyscallNr(); got != nr {
-		injectErr = fmt.Errorf("injected syscall %d did not execute (orig_rax=%d at exit); stop misclassified (#369)", nr, got)
+		injectErr = fmt.Errorf("injected syscall %d did not execute (syscall_nr=%d at exit); stop misclassified (#369)", nr, got)
 		return 0, injectErr
 	}
 	ret := retRegs.ReturnValue()

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -85,6 +85,10 @@ func (t *Tracer) injectFromEntry(tid int, savedRegs Regs, nr int, args ...uint64
 		injectErr = fmt.Errorf("inject getRegs: %w", err)
 		return 0, injectErr
 	}
+	if got := retRegs.SyscallNr(); got != nr {
+		injectErr = fmt.Errorf("injected syscall %d did not execute (orig_rax=%d at exit); stop misclassified (#369)", nr, got)
+		return 0, injectErr
+	}
 	ret := retRegs.ReturnValue()
 
 	// Restore original registers.
@@ -108,6 +112,14 @@ func (t *Tracer) injectFromEntry(tid int, savedRegs Regs, nr int, args ...uint64
 // two cycles (enter + exit).
 func (t *Tracer) injectFromExit(tid int, savedRegs Regs, nr int, args ...uint64) (int64, error) {
 	gadget := syscallGadgetAddr(savedRegs)
+
+	insn := make([]byte, syscallInsnSize)
+	if err := t.readBytes(tid, gadget, insn); err != nil {
+		return 0, fmt.Errorf("inject gadget read @0x%x: %w", gadget, err)
+	}
+	if !isSyscallInsn(insn) {
+		return 0, fmt.Errorf("inject gadget @0x%x not a syscall instruction (% x); stop misclassified (#369)", gadget, insn)
+	}
 
 	injRegs := savedRegs.Clone()
 	injRegs.SetSyscallNr(nr)
@@ -157,6 +169,10 @@ func (t *Tracer) injectFromExit(tid int, savedRegs Regs, nr int, args ...uint64)
 	retRegs, err := t.getRegs(tid)
 	if err != nil {
 		injectErr = fmt.Errorf("inject getRegs: %w", err)
+		return 0, injectErr
+	}
+	if got := retRegs.SyscallNr(); got != nr {
+		injectErr = fmt.Errorf("injected syscall %d did not execute (orig_rax=%d at exit); stop misclassified (#369)", nr, got)
 		return 0, injectErr
 	}
 	ret := retRegs.ReturnValue()

--- a/internal/ptrace/inject_amd64.go
+++ b/internal/ptrace/inject_amd64.go
@@ -11,3 +11,6 @@ func syscallGadgetAddr(regs Regs) uint64 {
 
 // syscallInsnSize is the size of the syscall instruction on this architecture.
 const syscallInsnSize = 2
+
+// isSyscallInsn reports whether b is the amd64 `syscall` instruction (0F 05).
+func isSyscallInsn(b []byte) bool { return len(b) >= 2 && b[0] == 0x0f && b[1] == 0x05 }

--- a/internal/ptrace/inject_arm64.go
+++ b/internal/ptrace/inject_arm64.go
@@ -11,3 +11,8 @@ func syscallGadgetAddr(regs Regs) uint64 {
 
 // syscallInsnSize is the size of the syscall instruction on this architecture.
 const syscallInsnSize = 4
+
+// isSyscallInsn reports whether b is the arm64 `svc #0` instruction.
+func isSyscallInsn(b []byte) bool {
+	return len(b) >= 4 && b[0] == 0x01 && b[1] == 0x00 && b[2] == 0x00 && b[3] == 0xd4
+}

--- a/internal/ptrace/inject_exit_stop_test.go
+++ b/internal/ptrace/inject_exit_stop_test.go
@@ -1,0 +1,130 @@
+//go:build integration && linux
+
+package ptrace
+
+import (
+	"os/exec"
+	"runtime"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// driveToEntryStop starts a ptraced child, reaps its initial trace stop, sets
+// TRACESYSGOOD, and advances it to its first syscall-ENTRY stop. It returns the
+// child pid; the caller is responsible for killing/reaping it. The OS thread
+// must already be locked by the caller (ptrace requires same-thread calls).
+func driveToEntryStop(t *testing.T) int {
+	t.Helper()
+	cmd := exec.Command("/bin/true")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Ptrace: true}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	pid := cmd.Process.Pid
+	t.Cleanup(func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() })
+
+	var ws unix.WaitStatus
+	if _, err := unix.Wait4(pid, &ws, 0, nil); err != nil {
+		t.Fatalf("initial wait4: %v", err)
+	}
+	if err := unix.PtraceSetOptions(pid, unix.PTRACE_O_TRACESYSGOOD); err != nil {
+		t.Fatalf("PTRACE_SETOPTIONS TRACESYSGOOD: %v", err)
+	}
+	if err := unix.PtraceSyscall(pid, 0); err != nil {
+		t.Fatalf("ptracesyscall to entry: %v", err)
+	}
+	if _, err := unix.Wait4(pid, &ws, 0, nil); err != nil {
+		t.Fatalf("wait4 entry: %v", err)
+	}
+	if !ws.Stopped() {
+		t.Fatalf("expected stop at syscall-entry, status=%v", ws)
+	}
+	return pid
+}
+
+// TestAtSyscallExitStop_LiveTracee exercises the authoritative #369 trigger
+// predicate against a real tracee: it must report not-exit at a syscall-ENTRY
+// stop and exit at the matching EXIT stop, independent of the inSyscall
+// fallback argument (which it should ignore when PTRACE_GET_SYSCALL_INFO works).
+func TestAtSyscallExitStop_LiveTracee(t *testing.T) {
+	requirePtrace(t)
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	tr := &Tracer{hasSyscallInfo: probePtraceSyscallInfo()}
+	if !tr.hasSyscallInfo {
+		t.Skip("PTRACE_GET_SYSCALL_INFO unsupported on this kernel")
+	}
+
+	pid := driveToEntryStop(t)
+
+	// At the entry stop, atSyscallExitStop must return false even when the
+	// (deliberately wrong) fallback bool says true — proving it uses the op.
+	if tr.atSyscallExitStop(pid, true) {
+		t.Fatal("atSyscallExitStop reported EXIT at a syscall-ENTRY stop")
+	}
+
+	// Advance to the matching exit stop.
+	var ws unix.WaitStatus
+	if err := unix.PtraceSyscall(pid, 0); err != nil {
+		t.Fatalf("ptracesyscall to exit: %v", err)
+	}
+	if _, err := unix.Wait4(pid, &ws, 0, nil); err != nil {
+		t.Fatalf("wait4 exit: %v", err)
+	}
+	if !ws.Stopped() {
+		t.Fatalf("expected stop at syscall-exit, status=%v", ws)
+	}
+	// At the exit stop, it must return true even when the fallback bool says
+	// false.
+	if !tr.atSyscallExitStop(pid, false) {
+		t.Fatal("atSyscallExitStop reported not-EXIT at a syscall-EXIT stop")
+	}
+}
+
+// TestInjectFromExit_BenignSyscallThroughGuards proves the #369 Task 2 guards
+// (gadget-is-a-syscall-insn + injected-syscall-executed) do NOT reject a valid
+// inject on a healthy kernel: a getpid() injected from a between-syscalls EXIT
+// stop returns the tracee's own pid. This mirrors the production
+// ensureScratchPage path (advancePastEntry -> injectFromExit gadget protocol).
+func TestInjectFromExit_BenignSyscallThroughGuards(t *testing.T) {
+	requirePtrace(t)
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	tr := NewTracer(TracerConfig{})
+	tr.hasSyscallInfo = probePtraceSyscallInfo()
+	if !tr.hasSyscallInfo {
+		t.Skip("PTRACE_GET_SYSCALL_INFO unsupported on this kernel")
+	}
+
+	pid := driveToEntryStop(t)
+	tr.mu.Lock()
+	tr.tracees[pid] = &TraceeState{TID: pid, TGID: pid, InSyscall: false, MemFD: -1}
+	tr.mu.Unlock()
+
+	// Capture entry regs and advance to a between-syscalls EXIT stop so the
+	// injectFromExit gadget protocol applies (RIP-2 is the real `syscall` insn).
+	entryRegs, err := tr.getRegs(pid)
+	if err != nil {
+		t.Fatalf("getRegs at entry: %v", err)
+	}
+	if err := tr.advancePastEntry(pid, entryRegs); err != nil {
+		t.Fatalf("advancePastEntry: %v", err)
+	}
+	savedRegs, err := tr.getRegs(pid)
+	if err != nil {
+		t.Fatalf("getRegs after advancePastEntry: %v", err)
+	}
+
+	// Inject getpid() through the gadget + orig_rax guards.
+	ret, err := tr.injectFromExit(pid, savedRegs, unix.SYS_GETPID)
+	if err != nil {
+		t.Fatalf("injectFromExit(getpid) rejected a valid inject: %v", err)
+	}
+	if ret != int64(pid) {
+		t.Fatalf("injected getpid returned %d, want tracee pid %d", ret, pid)
+	}
+}

--- a/internal/ptrace/inject_exit_stop_test.go
+++ b/internal/ptrace/inject_exit_stop_test.go
@@ -11,37 +11,56 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// assertSyscallStop fails the test unless ws is a TRACESYSGOOD syscall-trap
+// stop (SIGTRAP|0x80). Without this, a stray group/signal stop would make
+// syscallStopOp read a non-syscall stop (op=NONE → fallback), and the test
+// would assert against a meaningless classification instead of failing loudly.
+func assertSyscallStop(t *testing.T, ws unix.WaitStatus, where string) {
+	t.Helper()
+	if !ws.Stopped() {
+		t.Fatalf("%s: expected a stop, status=%v", where, ws)
+	}
+	if ws.StopSignal() != unix.SIGTRAP|0x80 {
+		t.Fatalf("%s: expected syscall-trap stop (SIGTRAP|0x80), got signal %v", where, ws.StopSignal())
+	}
+}
+
 // driveToEntryStop starts a ptraced child, reaps its initial trace stop, sets
-// TRACESYSGOOD, and advances it to its first syscall-ENTRY stop. It returns the
-// child pid; the caller is responsible for killing/reaping it. The OS thread
-// must already be locked by the caller (ptrace requires same-thread calls).
-func driveToEntryStop(t *testing.T) int {
+// TRACESYSGOOD|EXITKILL, and advances it to its first syscall-ENTRY stop. It
+// returns the child pid and a cleanup func that kills+reaps it. The OS thread
+// must already be locked by the caller (ptrace requires same-thread calls), and
+// the caller must `defer cleanup()` AFTER its `defer runtime.UnlockOSThread()`
+// so the reaping wait4 runs on the still-locked tracer thread (LIFO order);
+// EXITKILL additionally bounds the child's lifetime to this process.
+func driveToEntryStop(t *testing.T) (pid int, cleanup func()) {
 	t.Helper()
 	cmd := exec.Command("/bin/true")
 	cmd.SysProcAttr = &syscall.SysProcAttr{Ptrace: true}
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
-	pid := cmd.Process.Pid
-	t.Cleanup(func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() })
+	pid = cmd.Process.Pid
+	cleanup = func() { _ = cmd.Process.Kill(); _, _ = cmd.Process.Wait() }
 
 	var ws unix.WaitStatus
 	if _, err := unix.Wait4(pid, &ws, 0, nil); err != nil {
+		cleanup()
 		t.Fatalf("initial wait4: %v", err)
 	}
-	if err := unix.PtraceSetOptions(pid, unix.PTRACE_O_TRACESYSGOOD); err != nil {
-		t.Fatalf("PTRACE_SETOPTIONS TRACESYSGOOD: %v", err)
+	if err := unix.PtraceSetOptions(pid, unix.PTRACE_O_TRACESYSGOOD|unix.PTRACE_O_EXITKILL); err != nil {
+		cleanup()
+		t.Fatalf("PTRACE_SETOPTIONS: %v", err)
 	}
 	if err := unix.PtraceSyscall(pid, 0); err != nil {
+		cleanup()
 		t.Fatalf("ptracesyscall to entry: %v", err)
 	}
 	if _, err := unix.Wait4(pid, &ws, 0, nil); err != nil {
+		cleanup()
 		t.Fatalf("wait4 entry: %v", err)
 	}
-	if !ws.Stopped() {
-		t.Fatalf("expected stop at syscall-entry, status=%v", ws)
-	}
-	return pid
+	assertSyscallStop(t, ws, "syscall-entry")
+	return pid, cleanup
 }
 
 // TestAtSyscallExitStop_LiveTracee exercises the authoritative #369 trigger
@@ -58,7 +77,8 @@ func TestAtSyscallExitStop_LiveTracee(t *testing.T) {
 		t.Skip("PTRACE_GET_SYSCALL_INFO unsupported on this kernel")
 	}
 
-	pid := driveToEntryStop(t)
+	pid, cleanup := driveToEntryStop(t)
+	defer cleanup()
 
 	// At the entry stop, atSyscallExitStop must return false even when the
 	// (deliberately wrong) fallback bool says true — proving it uses the op.
@@ -74,9 +94,7 @@ func TestAtSyscallExitStop_LiveTracee(t *testing.T) {
 	if _, err := unix.Wait4(pid, &ws, 0, nil); err != nil {
 		t.Fatalf("wait4 exit: %v", err)
 	}
-	if !ws.Stopped() {
-		t.Fatalf("expected stop at syscall-exit, status=%v", ws)
-	}
+	assertSyscallStop(t, ws, "syscall-exit")
 	// At the exit stop, it must return true even when the fallback bool says
 	// false.
 	if !tr.atSyscallExitStop(pid, false) {
@@ -100,7 +118,8 @@ func TestInjectFromExit_BenignSyscallThroughGuards(t *testing.T) {
 		t.Skip("PTRACE_GET_SYSCALL_INFO unsupported on this kernel")
 	}
 
-	pid := driveToEntryStop(t)
+	pid, cleanup := driveToEntryStop(t)
+	defer cleanup()
 	tr.mu.Lock()
 	tr.tracees[pid] = &TraceeState{TID: pid, TGID: pid, InSyscall: false, MemFD: -1}
 	tr.mu.Unlock()
@@ -119,7 +138,7 @@ func TestInjectFromExit_BenignSyscallThroughGuards(t *testing.T) {
 		t.Fatalf("getRegs after advancePastEntry: %v", err)
 	}
 
-	// Inject getpid() through the gadget + orig_rax guards.
+	// Inject getpid() through the gadget + syscall_nr guards.
 	ret, err := tr.injectFromExit(pid, savedRegs, unix.SYS_GETPID)
 	if err != nil {
 		t.Fatalf("injectFromExit(getpid) rejected a valid inject: %v", err)

--- a/internal/ptrace/inject_guard_test.go
+++ b/internal/ptrace/inject_guard_test.go
@@ -1,0 +1,33 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestIsSyscallInsn(t *testing.T) {
+	if runtime.GOARCH == "amd64" {
+		if !isSyscallInsn([]byte{0x0f, 0x05}) {
+			t.Fatal("0f05 should be a syscall insn")
+		}
+		if isSyscallInsn([]byte{0x48, 0x89}) {
+			t.Fatal("mov must not be a syscall insn")
+		}
+		if isSyscallInsn([]byte{0x0f}) {
+			t.Fatal("short buf must be rejected")
+		}
+	}
+	if runtime.GOARCH == "arm64" {
+		if !isSyscallInsn([]byte{0x01, 0x00, 0x00, 0xd4}) {
+			t.Fatal("01 00 00 d4 should be a syscall insn")
+		}
+		if isSyscallInsn([]byte{0x00, 0x00, 0x00, 0x00}) {
+			t.Fatal("nop must not be a syscall insn")
+		}
+		if isSyscallInsn([]byte{0x01, 0x00, 0x00}) {
+			t.Fatal("short buf must be rejected")
+		}
+	}
+}

--- a/internal/ptrace/inject_probe_classify_test.go
+++ b/internal/ptrace/inject_probe_classify_test.go
@@ -1,0 +1,44 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestScratchUnmappedError_WrapsSentinel locks the load-bearing %w wrap in
+// scratchUnmappedError: the no-VMA error MUST satisfy errors.Is(err,
+// errScratchUnmapped). The #399 probe's fail-closed broken-kernel signal
+// depends on it; a %w→%v regression here would silently revert the probe to
+// fail-open on the exact kernel class it exists to catch (#369).
+func TestScratchUnmappedError_WrapsSentinel(t *testing.T) {
+	err := scratchUnmappedError(0x1000, []string{"0x1000-0x2000"})
+	if !errors.Is(err, errScratchUnmapped) {
+		t.Fatalf("scratchUnmappedError must wrap errScratchUnmapped; got %v", err)
+	}
+}
+
+// TestClassifyScratchInjectErr locks the probe's fail-closed vs fail-open
+// decision: an unmapped-VMA error must DEGRADE (mapped=false, detail set, no
+// probe error → Injectable=false), while any other error must FAIL-OPEN
+// (probe error set → Injectable=true). This is the decision that silently
+// flipped in the original regression (#369).
+func TestClassifyScratchInjectErr(t *testing.T) {
+	// Unmapped VMA → fail-CLOSED.
+	mapped, detail, probeErr := classifyScratchInjectErr(scratchUnmappedError(0x1000, nil))
+	if mapped {
+		t.Error("unmapped case must report mapped=false")
+	}
+	if probeErr != nil {
+		t.Errorf("unmapped case must not be a probe error (would fail-open); got %v", probeErr)
+	}
+	if detail == "" {
+		t.Error("unmapped case must carry a detail for logs")
+	}
+
+	// Any other error → fail-OPEN.
+	if _, _, probeErr = classifyScratchInjectErr(errors.New("attach denied")); probeErr == nil {
+		t.Fatal("a generic inject error must be a probe error (fail-open)")
+	}
+}

--- a/internal/ptrace/inject_probe_linux.go
+++ b/internal/ptrace/inject_probe_linux.go
@@ -263,17 +263,29 @@ func injectProbeBody(pid int) (mapped bool, detail string, probeErr error) {
 	}
 
 	// 4. THE PRODUCTION GADGET MMAP INJECT. ensureScratchPage injects the mmap
-	// and itself verifies a real VMA appeared at the returned address (#369):
-	//   - nil error           → a VMA appeared, injection works on this kernel.
-	//   - errScratchUnmapped  → the injected mmap returned but mapped nothing;
-	//                            this is the clean broken-kernel signal the probe
-	//                            exists to catch (mapped==false → Injectable=false).
-	//   - any other error     → the probe could not run cleanly (fail-open).
+	// and itself verifies a real VMA appeared at the returned address (#369).
+	// classifyScratchInjectErr turns its result into the probe's contract.
 	if _, err := tr.ensureScratchPage(pid, pid, savedRegs); err != nil {
-		if errors.Is(err, errScratchUnmapped) {
-			return false, fmt.Sprintf("ptrace inject probe: %v", err), nil
-		}
-		return false, "", fmt.Errorf("ensureScratchPage: %w", err)
+		return classifyScratchInjectErr(err)
 	}
 	return true, "", nil
+}
+
+// classifyScratchInjectErr maps an ensureScratchPage error to the inject
+// probe's (mapped, detail, probeErr) contract (#369):
+//   - errScratchUnmapped → the injected mmap returned but mapped no VMA: the
+//     clean broken-kernel signal (mapped==false, no probe error), which makes
+//     runInjectProbe report Injectable=false and DEGRADE (fail-closed).
+//   - any other error → the probe could not run cleanly: a probe error, which
+//     makes runInjectProbe report Injectable=true (fail-open).
+//
+// This is the load-bearing fail-closed/fail-open decision: a regression here
+// (or dropping the %w wrap in scratchUnmappedError) silently reverts the probe
+// to fail-open on the exact broken-kernel class it exists to catch, so it is
+// unit-tested directly.
+func classifyScratchInjectErr(err error) (mapped bool, detail string, probeErr error) {
+	if errors.Is(err, errScratchUnmapped) {
+		return false, fmt.Sprintf("ptrace inject probe: %v", err), nil
+	}
+	return false, "", fmt.Errorf("ensureScratchPage: %w", err)
 }

--- a/internal/ptrace/inject_probe_linux.go
+++ b/internal/ptrace/inject_probe_linux.go
@@ -5,6 +5,7 @@ package ptrace
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -261,24 +262,18 @@ func injectProbeBody(pid int) (mapped bool, detail string, probeErr error) {
 		return false, "", fmt.Errorf("getRegs after advancePastEntry: %w", err)
 	}
 
-	// Snapshot mappings BEFORE the inject so we can report exactly what the
-	// injected mmap created (or didn't) on a clean failure.
-	before := mapStarts(pid)
-
-	// 4. THE PRODUCTION GADGET MMAP INJECT.
-	sp, err := tr.ensureScratchPage(pid, pid, savedRegs)
-	if err != nil {
-		// An inject error (not a clean unmapped return) is a probe error:
-		// fail-open. A broken kernel returns a plausible address with no
-		// mapping (err==nil, addr set), which is the mapped==false path below.
+	// 4. THE PRODUCTION GADGET MMAP INJECT. ensureScratchPage injects the mmap
+	// and itself verifies a real VMA appeared at the returned address (#369):
+	//   - nil error           → a VMA appeared, injection works on this kernel.
+	//   - errScratchUnmapped  → the injected mmap returned but mapped nothing;
+	//                            this is the clean broken-kernel signal the probe
+	//                            exists to catch (mapped==false → Injectable=false).
+	//   - any other error     → the probe could not run cleanly (fail-open).
+	if _, err := tr.ensureScratchPage(pid, pid, savedRegs); err != nil {
+		if errors.Is(err, errScratchUnmapped) {
+			return false, fmt.Sprintf("ptrace inject probe: %v", err), nil
+		}
 		return false, "", fmt.Errorf("ensureScratchPage: %w", err)
 	}
-
-	// 5. Did a real VMA appear at the returned address?
-	mapped = addrInMaps(pid, sp.addr)
-	if !mapped {
-		detail = fmt.Sprintf("ptrace inject probe: injected mmap returned 0x%x but created no mapping (#369); new_mappings=%v",
-			sp.addr, newMapRanges(pid, before))
-	}
-	return mapped, detail, nil
+	return true, "", nil
 }

--- a/internal/ptrace/inject_trigger_test.go
+++ b/internal/ptrace/inject_trigger_test.go
@@ -1,0 +1,15 @@
+//go:build linux
+
+package ptrace
+
+import "testing"
+
+func TestAtSyscallExitStop_FallbackToToggle(t *testing.T) {
+	tr := &Tracer{hasSyscallInfo: false}
+	if !tr.atSyscallExitStop(0, true) {
+		t.Fatal("fallback inSyscall=true must report exit")
+	}
+	if tr.atSyscallExitStop(0, false) {
+		t.Fatal("fallback inSyscall=false must report not-exit")
+	}
+}

--- a/internal/ptrace/scratch.go
+++ b/internal/ptrace/scratch.go
@@ -19,6 +19,17 @@ import (
 // with errors.Is.
 var errScratchUnmapped = errors.New("scratch mmap mapped no VMA")
 
+// scratchUnmappedError builds the error ensureScratchPage returns when the
+// injected mmap returns an address that maps no VMA (#369). It wraps
+// errScratchUnmapped (so the #399 probe can detect this specific case via
+// errors.Is) and carries the addr + the mappings the mmap actually created for
+// diagnostics. Keep the %w wrap: it is the load-bearing half of the probe's
+// fail-closed broken-kernel signal (see classifyScratchInjectErr).
+func scratchUnmappedError(addr uint64, newMappings []string) error {
+	return fmt.Errorf("scratch mmap returned 0x%x but mapped no VMA (#369); new_mappings=%v: %w",
+		addr, newMappings, errScratchUnmapped)
+}
+
 // scratchPage tracks a scratch memory page mmap'd into a tracee's address space.
 // Per-TGID: threads in the same process share address space.
 type scratchPage struct {
@@ -80,8 +91,7 @@ func (t *Tracer) ensureScratchPage(tid, tgid int, savedRegs Regs) (*scratchPage,
 	}
 
 	if !addrInMaps(tid, addr) {
-		return nil, fmt.Errorf("scratch mmap returned 0x%x but mapped no VMA (#369); new_mappings=%v: %w",
-			addr, newMapRanges(tid, mapsBefore), errScratchUnmapped)
+		return nil, scratchUnmappedError(addr, newMapRanges(tid, mapsBefore))
 	}
 
 	sp = &scratchPage{addr: addr, size: 4096}

--- a/internal/ptrace/scratch.go
+++ b/internal/ptrace/scratch.go
@@ -4,7 +4,6 @@ package ptrace
 
 import (
 	"fmt"
-	"log/slog"
 	"sync"
 
 	"golang.org/x/sys/unix"
@@ -70,15 +69,9 @@ func (t *Tracer) ensureScratchPage(tid, tgid int, savedRegs Regs) (*scratchPage,
 		return nil, fmt.Errorf("mmap injection: %w", err)
 	}
 
-	retMapped := addrInMaps(tid, addr)
-	if !retMapped {
-		// Anomaly path only (keeps the extra /proc/maps read off the happy path):
-		// dump the mappings the injected mmap actually created so we can tell a
-		// mis-read return (new mapping at a different address) from an mmap that
-		// did not take effect (no new mapping). #369.
-		slog.Warn("scratch mmap returned an unmapped address (#369 diag)",
-			"tid", tid, "tgid", tgid, "mmap_ret", fmt.Sprintf("0x%x", addr),
-			"new_mappings", newMapRanges(tid, mapsBefore))
+	if !addrInMaps(tid, addr) {
+		return nil, fmt.Errorf("scratch mmap returned 0x%x but mapped no VMA (#369); new_mappings=%v",
+			addr, newMapRanges(tid, mapsBefore))
 	}
 
 	sp = &scratchPage{addr: addr, size: 4096}

--- a/internal/ptrace/scratch.go
+++ b/internal/ptrace/scratch.go
@@ -3,11 +3,21 @@
 package ptrace
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
 	"golang.org/x/sys/unix"
 )
+
+// errScratchUnmapped is returned (wrapped) by ensureScratchPage when the
+// injected mmap returns an address that maps no VMA in the tracee (#369). It is
+// a sentinel so callers can distinguish this specific "injection produced no
+// mapping" outcome from a generic inject failure: the #399 inject self-probe
+// treats it as the clean broken-kernel degrade signal (Injectable=false),
+// whereas production inject paths treat any error the same (fall back). Test
+// with errors.Is.
+var errScratchUnmapped = errors.New("scratch mmap mapped no VMA")
 
 // scratchPage tracks a scratch memory page mmap'd into a tracee's address space.
 // Per-TGID: threads in the same process share address space.
@@ -70,8 +80,8 @@ func (t *Tracer) ensureScratchPage(tid, tgid int, savedRegs Regs) (*scratchPage,
 	}
 
 	if !addrInMaps(tid, addr) {
-		return nil, fmt.Errorf("scratch mmap returned 0x%x but mapped no VMA (#369); new_mappings=%v",
-			addr, newMapRanges(tid, mapsBefore))
+		return nil, fmt.Errorf("scratch mmap returned 0x%x but mapped no VMA (#369); new_mappings=%v: %w",
+			addr, newMapRanges(tid, mapsBefore), errScratchUnmapped)
 	}
 
 	sp = &scratchPage{addr: addr, size: 4096}

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -873,6 +873,20 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 	}
 }
 
+// atSyscallExitStop reports whether the tracee is at a syscall-EXIT stop. It
+// prefers the authoritative PTRACE_GET_SYSCALL_INFO op; the hand-maintained
+// InSyscall toggle is only a pre-5.3 fallback, because that toggle can desync
+// from the real stop sequence on kernels whose post-exec stop storm interleaves
+// PTRACE_EVENT/signal stops (#369). Call on the tracer thread at a ptrace stop.
+func (t *Tracer) atSyscallExitStop(tid int, inSyscall bool) bool {
+	if t.hasSyscallInfo {
+		if op, err := t.syscallStopOp(tid); err == nil {
+			return op == ptraceSyscallInfoExit
+		}
+	}
+	return inSyscall
+}
+
 // handleSyscallStop handles SIGTRAP|0x80 stops (TRACESYSGOOD mode).
 func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 	// Deferred seccomp prefilter and escalation injection are only relevant
@@ -884,16 +898,30 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		// drop the tracee's first real syscall). At exit, the syscall already
 		// completed, so injection is safe.
 		//
-		// State.InSyscall tracks what the PREVIOUS stop set:
-		//   InSyscall=false → this is an entry stop (first time)
-		//   InSyscall=true  → this is an exit stop (entry was processed)
+		// Whether this stop is a syscall EXIT. Prefer the authoritative
+		// PTRACE_GET_SYSCALL_INFO op over the hand-maintained InSyscall toggle,
+		// which can desync from the real stop sequence on kernels whose
+		// post-exec stop storm interleaves PTRACE_EVENT/signal stops (#369).
+		// Read the op ONCE here, outside t.mu (atSyscallExitStop issues a ptrace
+		// call — never hold t.mu across it), and reuse the boolean for both the
+		// prefilter and escalation decisions in this handler invocation.
+		//
+		// Historical note on the InSyscall toggle (still the pre-5.3 fallback):
+		//   InSyscall=false → entry stop (first time)
+		//   InSyscall=true  → exit stop (entry was processed)
 		t.mu.Lock()
 		state := t.tracees[tid]
-		if state != nil && state.PendingPrefilter && !state.InSyscall {
+		inSyscall := state != nil && state.InSyscall
+		t.mu.Unlock()
+		exit := t.atSyscallExitStop(tid, inSyscall)
+
+		t.mu.Lock()
+		state = t.tracees[tid]
+		if state != nil && state.PendingPrefilter && !exit {
 			// This is a syscall entry. Let normal handling process it.
 			// The next stop will be the exit, where we'll inject.
 			t.mu.Unlock()
-		} else if state != nil && state.PendingPrefilter && state.InSyscall {
+		} else if state != nil && state.PendingPrefilter && exit {
 			// This is a syscall exit — safe to inject now.
 			state.PendingPrefilter = false
 			// Set InSyscall=false before injection so injectSyscall uses the
@@ -925,12 +953,13 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		}
 
 		// Deferred BPF escalation: inject escalation filters at exit stops.
-		// Follows the same pattern as PendingPrefilter above.
+		// Follows the same pattern as PendingPrefilter above and reuses the same
+		// authoritative `exit` classification computed above.
 		// Only attempt injection when a seccomp prefilter is installed;
 		// without one, all syscalls are already traced via TRACESYSGOOD.
 		t.mu.Lock()
 		state = t.tracees[tid]
-		if state != nil && state.HasPrefilter && state.InSyscall && state.PendingReadEscalation {
+		if state != nil && state.HasPrefilter && exit && state.PendingReadEscalation {
 			state.PendingReadEscalation = false
 			state.InSyscall = false
 			t.mu.Unlock()
@@ -949,7 +978,7 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 				}
 				t.mu.Unlock()
 			}
-		} else if state != nil && state.HasPrefilter && state.InSyscall && state.PendingWriteEscalation {
+		} else if state != nil && state.HasPrefilter && exit && state.PendingWriteEscalation {
 			state.PendingWriteEscalation = false
 			state.InSyscall = false
 			t.mu.Unlock()
@@ -968,7 +997,7 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 				}
 				t.mu.Unlock()
 			}
-		} else if state != nil && state.HasPrefilter && !state.InSyscall {
+		} else if state != nil && state.HasPrefilter && !exit {
 			// Entry stop — set pending flags for next exit.
 			if state.NeedsReadEscalation && !state.ThreadHasReadEscalation {
 				state.PendingReadEscalation = true

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -906,14 +906,29 @@ func (t *Tracer) handleSyscallStop(ctx context.Context, tid int) {
 		// call — never hold t.mu across it), and reuse the boolean for both the
 		// prefilter and escalation decisions in this handler invocation.
 		//
+		// Skip the op read entirely unless a prefilter or escalation inject can
+		// actually fire at this stop. handleSyscallStop runs on EVERY traced
+		// syscall, so in steady state (prefilter installed, escalations applied,
+		// nothing pending) the per-stop PTRACE_GET_SYSCALL_INFO call would be
+		// pure overhead — this package is sensitive to per-syscall ptrace cost
+		// (#369). Every branch below that consults `exit` requires one of these
+		// flags, so leaving exit=false when none is set is behavior-preserving.
+		//
 		// Historical note on the InSyscall toggle (still the pre-5.3 fallback):
 		//   InSyscall=false → entry stop (first time)
 		//   InSyscall=true  → exit stop (entry was processed)
 		t.mu.Lock()
 		state := t.tracees[tid]
 		inSyscall := state != nil && state.InSyscall
+		mayInject := state != nil && (state.PendingPrefilter ||
+			(state.HasPrefilter && (state.PendingReadEscalation || state.PendingWriteEscalation ||
+				(state.NeedsReadEscalation && !state.ThreadHasReadEscalation) ||
+				(state.NeedsWriteEscalation && !state.ThreadHasWriteEscalation))))
 		t.mu.Unlock()
-		exit := t.atSyscallExitStop(tid, inSyscall)
+		exit := false
+		if mayInject {
+			exit = t.atSyscallExitStop(tid, inSyscall)
+		}
 
 		t.mu.Lock()
 		state = t.tracees[tid]


### PR DESCRIPTION
## Issue #369 "Gap C" — the *real* fix (supersedes the rc6 honest-degrade, #399)

The rc2–rc6 chase concluded ptrace syscall injection was *fundamentally unreliable* on exe.dev 6.12.90 and shipped an honest-degrade (#399). That conclusion was **wrong**. erans's source review found the true, fixable root cause: the seccomp-prefilter/escalation inject **trigger** decided "is this a syscall-EXIT stop?" using a hand-toggled `state.InSyscall` bit, not the authoritative `PTRACE_GET_SYSCALL_INFO` op. On 6.12.90's post-exec `ld.so` stop storm (interleaved `PTRACE_EVENT`/group/signal stops) that toggle **desyncs by one**, so the inject fired at a not-really-EXIT stop; the blind `RIP−2` gadget then landed on non-syscall bytes, the injected `mmap` never executed, returned an address-like RAX, and mapped **no VMA** (the #398 phantom). "Works under strace" was the tell — serialization re-syncs the stop sequence (Heisenbug).

## What this PR does

**Core fix**
1. **Authoritative exit-stop classification** — `atSyscallExitStop` gates the inject on `syscallStopOp == EXIT`; the `InSyscall` toggle remains only as the pre-5.3 fallback. Applied to the prefilter trigger and both read/write escalation triggers.

**Defense-in-depth guards** (dormant on a healthy kernel; turn any residual misfire into a clean error instead of a phantom)
2. **Gadget verification** — require the bytes at `RIP−2` to be a real `syscall` instruction (`isSyscallInsn`: amd64 `0F 05` / arm64 `svc #0`) before use in `injectFromExit`.
3. **Execution verification** — require `SyscallNr() == nr` after the injected syscall in `injectFromEntry`/`injectFromExit` (arch-neutral diagnostic wording).
4. **Fail-closed scratch** — `ensureScratchPage` returns an error (wrapping the `errScratchUnmapped` sentinel) when the injected `mmap` maps no VMA, instead of using the phantom address.

**Hardening**
- Gated the per-stop `PTRACE_GET_SYSCALL_INFO` read on `mayInject` so steady-state prefilter mode doesn't pay per-syscall op-read overhead (proven behavior-preserving).
- The #399 self-probe is left dormant (injection now works → probe passes → degrade never fires); `classifyScratchInjectErr` keeps it **fail-closed** on the unmapped case via the sentinel (correcting a silent fail-open flip the scratch change first introduced).
- Added live-tracee tests (`atSyscallExitStop` entry/exit, `injectFromExit(getpid)` through the guards) and unit tests locking the fail-closed probe wiring.

## Verification

- **roborev branch review: clean after 3 rounds** (1 High = the probe fail-open flip + 6 Low, all fixed). Final verdict: *logically sound and regression-free*.
- The 6.12.90 stop-desync is **not CI-reproducible**, so correctness is by-construction. The full `internal/ptrace` integration suite (~190 tests) returns a **byte-identical PASS/FAIL set** with and without each change; the 7 failing integration tests are pre-existing/environmental (identical on the pre-branch base `48d49782`).
- gofmt/vet clean; builds amd64 + arm64 + windows; full unit suite green except the known pre-existing `internal/fsmonitor` FUSE-mount env failure.

## Not covered here / follow-ups
- **End-to-end on exe.dev 6.12.90** (kill rate → 0 with ptrace *enforcing*, no degrade WARN — the opposite of rc6) must be confirmed by erans on v0.20.3-rc7; CI cannot prove it.
- The `TRACESYSGOOD` fallback hang and reworking/removing the non-representative #399 probe remain separate, pre-existing.

Spec/plan: `docs/superpowers/{specs,plans}/2026-05-27-issue-369-inject-trigger-gadget*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)