### PR TITLE
fix(#369): allow the dynamic loader's reads under file_monitor (shim exec on deny-by-default policies)

### DIFF
--- a/configs/default-policy.yaml
+++ b/configs/default-policy.yaml
@@ -77,6 +77,12 @@ file_rules:
   - name: allow-system-read
     description: Read access to standard system paths
     paths:
+      - "/usr"
+      - "/lib"
+      - "/lib64"
+      - "/bin"
+      - "/sbin"
+      - "/opt"
       - "/usr/**"
       - "/lib/**"
       - "/lib64/**"

--- a/configs/default-policy.yaml
+++ b/configs/default-policy.yaml
@@ -109,6 +109,13 @@ file_rules:
       - "/etc/mime.types"
       - "/etc/protocols"
       - "/etc/services"
+      # Dynamic linker / NSS runtime files — needed by every dynamically-linked
+      # program on startup (#369).
+      - "/etc/ld.so.cache"
+      - "/etc/ld.so.preload"
+      - "/etc/ld.so.conf"
+      - "/etc/ld.so.conf.d/**"
+      - "/etc/nsswitch.conf"
     operations:
       - read
       - open

--- a/configs/policies/agent-sandbox.yaml
+++ b/configs/policies/agent-sandbox.yaml
@@ -76,6 +76,11 @@ file_rules:
   - name: allow-system-read
     description: Read access to system paths
     paths:
+      - "/usr"
+      - "/lib"
+      - "/lib64"
+      - "/bin"
+      - "/sbin"
       - "/usr/**"
       - "/lib/**"
       - "/lib64/**"
@@ -108,6 +113,7 @@ file_rules:
       - "/etc/gai.conf"
     operations:
       - read
+      - open
       - stat
     decision: allow
 

--- a/configs/policies/bench-realistic.yaml
+++ b/configs/policies/bench-realistic.yaml
@@ -268,6 +268,12 @@ file_rules:
   - name: allow-system-read
     description: Read access to system paths
     paths:
+      - "/usr"
+      - "/lib"
+      - "/lib64"
+      - "/bin"
+      - "/sbin"
+      - "/opt"
       - "/usr/**"
       - "/lib/**"
       - "/lib64/**"

--- a/configs/policies/ci-strict.yaml
+++ b/configs/policies/ci-strict.yaml
@@ -48,6 +48,12 @@ file_rules:
   - name: allow-system-read
     description: Read-only access to system paths
     paths:
+      - "/usr"
+      - "/lib"
+      - "/lib64"
+      - "/bin"
+      - "/sbin"
+      - "/opt"
       - "/usr/**"
       - "/lib/**"
       - "/lib64/**"

--- a/configs/policies/dev-safe.yaml
+++ b/configs/policies/dev-safe.yaml
@@ -90,6 +90,12 @@ file_rules:
   - name: allow-system-read
     description: Read access to standard system paths
     paths:
+      - "/usr"
+      - "/lib"
+      - "/lib64"
+      - "/bin"
+      - "/sbin"
+      - "/opt"
       - "/usr/**"
       - "/lib/**"
       - "/lib64/**"

--- a/default-policy.yml
+++ b/default-policy.yml
@@ -75,6 +75,12 @@ file_rules:
   - name: allow-system-read
     description: Read access to standard system paths
     paths:
+      - "/usr"
+      - "/lib"
+      - "/lib64"
+      - "/bin"
+      - "/sbin"
+      - "/opt"
       - "/usr/**"
       - "/lib/**"
       - "/lib64/**"

--- a/default-policy.yml
+++ b/default-policy.yml
@@ -107,6 +107,13 @@ file_rules:
       - "/etc/mime.types"
       - "/etc/protocols"
       - "/etc/services"
+      # Dynamic linker / NSS runtime files — needed by every dynamically-linked
+      # program on startup (#369).
+      - "/etc/ld.so.cache"
+      - "/etc/ld.so.preload"
+      - "/etc/ld.so.conf"
+      - "/etc/ld.so.conf.d/**"
+      - "/etc/nsswitch.conf"
     operations:
       - read
       - open

--- a/internal/netmonitor/unix/file_handler.go
+++ b/internal/netmonitor/unix/file_handler.go
@@ -4,6 +4,7 @@ package unix
 
 import (
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -135,6 +136,20 @@ func (h *FileHandler) Handle(req FileRequest) (FileResult, *types.Event) {
 			// Audit-only mode: log but allow.
 			return FileResult{Action: ActionContinue}, h.buildFileEvent(req, dec, false, false)
 		}
+		// #369 loader-safe guard: never DENY a read-only access to an essential
+		// system/loader path. A deny-by-default policy would otherwise make every
+		// dynamically-linked program un-loadable under file_monitor — the dynamic
+		// loader reads /etc/ld.so.cache and walks /lib, /usr, ... during startup,
+		// and those opens fall through a policy's allow-system-read (its /lib/**
+		// globs don't match the bare dirs) to the default-deny-files catch-all.
+		// The ptrace enforcer effectively allows these, so file_monitor must too.
+		// Read-only only — writes/creates/deletes to these paths stay enforced.
+		if isReadOnlyFileOp(req.Syscall, req.Flags) && isLoaderSafeSystemPath(req.Path) {
+			slog.Debug("file_monitor: loader-safe read override (#369)",
+				"path", req.Path, "operation", req.Operation, "policy_rule", dec.Rule, "session", req.SessionID)
+			// shadowDeny=true records that policy said deny but we did not enforce.
+			return FileResult{Action: ActionContinue}, h.buildFileEvent(req, dec, false, true)
+		}
 		// Enforced deny.
 		return FileResult{Action: ActionDeny, Errno: int32(sysunix.EACCES)}, h.buildFileEvent(req, dec, true, false)
 	}
@@ -184,4 +199,27 @@ func (h *FileHandler) buildFileEvent(req FileRequest, dec FilePolicyDecision, bl
 	}
 
 	return ev
+}
+
+// loaderSafeReadPrefixes are system paths whose READ-ONLY access must never be
+// denied: the dynamic loader and libc must read these to start any program
+// (ld.so.cache/preload/conf, and the standard system library + binary trees the
+// loader resolves through). This mirrors the established system-readonly path
+// set and the ptrace enforcer's effective behavior (#369). Matching is
+// exact-or-subtree, so "/lib" covers both the bare directory open the loader
+// performs during search-path resolution and every file beneath it.
+var loaderSafeReadPrefixes = []string{
+	"/usr", "/lib", "/lib64", "/lib32", "/libx32", "/bin", "/sbin", "/opt",
+	"/etc/ld.so.cache", "/etc/ld.so.preload", "/etc/ld.so.conf", "/etc/ld.so.conf.d",
+}
+
+// isLoaderSafeSystemPath reports whether p is one of the loader-essential system
+// paths (exact match or a subtree element).
+func isLoaderSafeSystemPath(p string) bool {
+	for _, pre := range loaderSafeReadPrefixes {
+		if p == pre || strings.HasPrefix(p, pre+"/") {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/netmonitor/unix/file_handler.go
+++ b/internal/netmonitor/unix/file_handler.go
@@ -212,9 +212,11 @@ func (h *FileHandler) buildFileEvent(req FileRequest, dec FilePolicyDecision, bl
 // loader resolves through). This mirrors the established system-readonly path
 // set and the ptrace enforcer's effective behavior (#369). Matching is
 // exact-or-subtree, so "/lib" covers both the bare directory open the loader
-// performs during search-path resolution and every file beneath it.
+// performs during search-path resolution and every file beneath it. Note: /opt
+// is intentionally excluded — the loader never searches it, and some policies
+// (e.g. agent-sandbox) deliberately do not grant it system-read.
 var loaderSafeReadPrefixes = []string{
-	"/usr", "/lib", "/lib64", "/lib32", "/libx32", "/bin", "/sbin", "/opt",
+	"/usr", "/lib", "/lib64", "/lib32", "/libx32", "/bin", "/sbin",
 	"/etc/ld.so.cache", "/etc/ld.so.preload", "/etc/ld.so.conf", "/etc/ld.so.conf.d",
 }
 

--- a/internal/netmonitor/unix/file_handler.go
+++ b/internal/netmonitor/unix/file_handler.go
@@ -137,14 +137,19 @@ func (h *FileHandler) Handle(req FileRequest) (FileResult, *types.Event) {
 			return FileResult{Action: ActionContinue}, h.buildFileEvent(req, dec, false, false)
 		}
 		// #369 loader-safe guard: never DENY a read-only access to an essential
-		// system/loader path. A deny-by-default policy would otherwise make every
-		// dynamically-linked program un-loadable under file_monitor — the dynamic
-		// loader reads /etc/ld.so.cache and walks /lib, /usr, ... during startup,
-		// and those opens fall through a policy's allow-system-read (its /lib/**
-		// globs don't match the bare dirs) to the default-deny-files catch-all.
-		// The ptrace enforcer effectively allows these, so file_monitor must too.
-		// Read-only only — writes/creates/deletes to these paths stay enforced.
-		if isReadOnlyFileOp(req.Syscall, req.Flags) && isLoaderSafeSystemPath(req.Path) {
+		// system/loader path when the denial came from a catch-all default rule.
+		// A deny-by-default policy would otherwise make every dynamically-linked
+		// program un-loadable under file_monitor — the loader reads
+		// /etc/ld.so.cache and walks /lib, /usr, ... during startup, and those
+		// opens fall through allow-system-read (its /lib/** globs don't match the
+		// bare dirs) to the default-deny-files catch-all. The ptrace enforcer
+		// effectively allows these, so file_monitor must too.
+		//
+		// Scoped to the catch-all rule ONLY: an operator's EXPLICIT deny rule on a
+		// system subpath (e.g. `deny read /opt/app/secrets/**`) is still honored,
+		// matching ptrace's first-match-explicit-deny semantics. Read-only only —
+		// writes/creates/deletes to these paths stay enforced.
+		if isDefaultDenyRule(dec.Rule) && isReadOnlyFileOp(req.Syscall, req.Flags) && isLoaderSafeSystemPath(req.Path) {
 			slog.Debug("file_monitor: loader-safe read override (#369)",
 				"path", req.Path, "operation", req.Operation, "policy_rule", dec.Rule, "session", req.SessionID)
 			// shadowDeny=true records that policy said deny but we did not enforce.
@@ -212,6 +217,20 @@ var loaderSafeReadPrefixes = []string{
 	"/usr", "/lib", "/lib64", "/lib32", "/libx32", "/bin", "/sbin", "/opt",
 	"/etc/ld.so.cache", "/etc/ld.so.preload", "/etc/ld.so.conf", "/etc/ld.so.conf.d",
 }
+
+// defaultDenyRuleNames are the catch-all "deny everything not explicitly
+// allowed" rule names. The loader-safe override fires only when a loader read
+// was denied by one of these — never by an operator's explicit deny rule
+// targeting a specific path, which must still be honored (matching the ptrace
+// enforcer's first-match-explicit-deny semantics). "default-deny-files" is both
+// the shipped policies' catch-all rule name and the engine's no-match fallback.
+var defaultDenyRuleNames = map[string]bool{
+	"default-deny-files": true,
+}
+
+// isDefaultDenyRule reports whether a deny decision came from a catch-all
+// default rule rather than an explicit, path-specific operator deny.
+func isDefaultDenyRule(rule string) bool { return defaultDenyRuleNames[rule] }
 
 // isLoaderSafeSystemPath reports whether p is one of the loader-essential system
 // paths (exact match or a subtree element).

--- a/internal/netmonitor/unix/loader_safe_guard_test.go
+++ b/internal/netmonitor/unix/loader_safe_guard_test.go
@@ -76,13 +76,13 @@ func TestFileHandler_LoaderSafeReadOverride(t *testing.T) {
 }
 
 func TestIsLoaderSafeSystemPath(t *testing.T) {
-	safe := []string{"/lib", "/lib/x", "/usr", "/usr/lib/libc.so.6", "/etc/ld.so.cache", "/etc/ld.so.conf.d/x.conf", "/bin", "/sbin", "/opt/foo"}
+	safe := []string{"/lib", "/lib/x", "/usr", "/usr/lib/libc.so.6", "/etc/ld.so.cache", "/etc/ld.so.conf.d/x.conf", "/bin", "/sbin"}
 	for _, p := range safe {
 		if !isLoaderSafeSystemPath(p) {
 			t.Errorf("isLoaderSafeSystemPath(%q) = false, want true", p)
 		}
 	}
-	unsafe := []string{"/home/user", "/etc/shadow", "/etc/ld.so.cache.evil", "/libfoo", "/", "/var/lib", "/tmp"}
+	unsafe := []string{"/home/user", "/etc/shadow", "/etc/ld.so.cache.evil", "/libfoo", "/", "/var/lib", "/tmp", "/opt", "/opt/foo"}
 	for _, p := range unsafe {
 		if isLoaderSafeSystemPath(p) {
 			t.Errorf("isLoaderSafeSystemPath(%q) = true, want false", p)

--- a/internal/netmonitor/unix/loader_safe_guard_test.go
+++ b/internal/netmonitor/unix/loader_safe_guard_test.go
@@ -73,6 +73,43 @@ func TestFileHandler_LoaderSafeReadOverride(t *testing.T) {
 			t.Errorf("explicit (non-catch-all) deny on a system subpath must be honored, got %s", res.Action)
 		}
 	})
+
+	// An overridden read must be recorded as a shadow-deny — the only forensic
+	// trace that policy denied but file_monitor allowed it.
+	t.Run("override emits shadow-deny event", func(t *testing.T) {
+		policy := denyAll("/lib")
+		res, ev := NewFileHandler(policy, NewMountRegistry(), &mockFileEmitter{}, true).Handle(FileRequest{
+			PID: 1234, Syscall: int32(unix.SYS_OPENAT), Path: "/lib", Operation: "open",
+			Flags: unix.O_RDONLY | unix.O_DIRECTORY, SessionID: "sess-1",
+		})
+		if res.Action != ActionContinue {
+			t.Fatalf("expected override to allow, got %s", res.Action)
+		}
+		if ev == nil {
+			t.Fatal("expected an audit event for the override")
+		}
+		if v, ok := ev.Fields["shadow_deny"]; !ok || v != true {
+			t.Errorf("override event must carry shadow_deny=true; got %v (ok=%v)", v, ok)
+		}
+	})
+
+	// In audit-only mode (enforce=false) the deny short-circuits to allow BEFORE
+	// the override runs, so it must NOT be marked as a loader-safe shadow-deny.
+	t.Run("enforce=false does not take the override path", func(t *testing.T) {
+		policy := denyAll("/lib")
+		res, ev := NewFileHandler(policy, NewMountRegistry(), &mockFileEmitter{}, false).Handle(FileRequest{
+			PID: 1234, Syscall: int32(unix.SYS_OPENAT), Path: "/lib", Operation: "open",
+			Flags: unix.O_RDONLY | unix.O_DIRECTORY, SessionID: "sess-1",
+		})
+		if res.Action != ActionContinue {
+			t.Fatalf("audit-only should allow, got %s", res.Action)
+		}
+		if ev != nil {
+			if v, ok := ev.Fields["shadow_deny"]; ok && v == true {
+				t.Error("audit-only allow must not be marked as a loader-safe shadow-deny override")
+			}
+		}
+	})
 }
 
 func TestIsLoaderSafeSystemPath(t *testing.T) {

--- a/internal/netmonitor/unix/loader_safe_guard_test.go
+++ b/internal/netmonitor/unix/loader_safe_guard_test.go
@@ -1,0 +1,75 @@
+//go:build linux && cgo
+
+package unix
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestFileHandler_LoaderSafeReadOverride verifies the #369 loader-safe guard:
+// a policy that DENIES the dynamic loader's essential system reads must not
+// prevent programs from starting under file_monitor. Read-only opens of
+// loader-essential system paths are overridden to allow; writes to the same
+// paths and reads of non-system paths are still denied.
+func TestFileHandler_LoaderSafeReadOverride(t *testing.T) {
+	denyAll := func(paths ...string) *mockFilePolicy {
+		m := &mockFilePolicy{decisions: map[string]FilePolicyDecision{}}
+		for _, p := range paths {
+			m.decisions[p] = FilePolicyDecision{
+				Decision: "deny", EffectiveDecision: "deny", Rule: "default-deny-files",
+			}
+		}
+		return m
+	}
+
+	cases := []struct {
+		name    string
+		path    string
+		op      string
+		syscall int32
+		flags   uint32
+		want    string // ActionContinue or ActionDeny
+	}{
+		{"ld.so.cache read", "/etc/ld.so.cache", "open", int32(unix.SYS_OPENAT), unix.O_RDONLY, ActionContinue},
+		{"ld.so.preload read", "/etc/ld.so.preload", "open", int32(unix.SYS_OPENAT), unix.O_RDONLY, ActionContinue},
+		{"bare /lib dir open", "/lib", "open", int32(unix.SYS_OPENAT), unix.O_RDONLY | unix.O_DIRECTORY, ActionContinue},
+		{"bare /usr dir open", "/usr", "open", int32(unix.SYS_OPENAT), unix.O_RDONLY | unix.O_DIRECTORY, ActionContinue},
+		{"libc.so read", "/usr/lib/x86_64-linux-gnu/libc.so.6", "open", int32(unix.SYS_OPENAT), unix.O_RDONLY, ActionContinue},
+		{"system stat", "/lib64", "stat", int32(unix.SYS_NEWFSTATAT), 0, ActionContinue},
+		// Mutating op on a system path is NOT overridden — still denied.
+		{"write to /lib", "/lib/evil.so", "write", int32(unix.SYS_OPENAT), unix.O_WRONLY | unix.O_CREAT, ActionDeny},
+		// Read of a non-system path is NOT overridden — still denied.
+		{"non-system read", "/home/user/secret", "open", int32(unix.SYS_OPENAT), unix.O_RDONLY, ActionDeny},
+		{"etc non-loader read", "/etc/shadow", "open", int32(unix.SYS_OPENAT), unix.O_RDONLY, ActionDeny},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			policy := denyAll(tc.path)
+			handler := NewFileHandler(policy, NewMountRegistry(), &mockFileEmitter{}, true) // enforce=true
+			res, _ := handler.Handle(FileRequest{
+				PID: 1234, Syscall: tc.syscall, Path: tc.path, Operation: tc.op, Flags: tc.flags, SessionID: "sess-1",
+			})
+			if res.Action != tc.want {
+				t.Errorf("Handle(%s %s) action = %s, want %s", tc.op, tc.path, res.Action, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsLoaderSafeSystemPath(t *testing.T) {
+	safe := []string{"/lib", "/lib/x", "/usr", "/usr/lib/libc.so.6", "/etc/ld.so.cache", "/etc/ld.so.conf.d/x.conf", "/bin", "/sbin", "/opt/foo"}
+	for _, p := range safe {
+		if !isLoaderSafeSystemPath(p) {
+			t.Errorf("isLoaderSafeSystemPath(%q) = false, want true", p)
+		}
+	}
+	unsafe := []string{"/home/user", "/etc/shadow", "/etc/ld.so.cache.evil", "/libfoo", "/", "/var/lib", "/tmp"}
+	for _, p := range unsafe {
+		if isLoaderSafeSystemPath(p) {
+			t.Errorf("isLoaderSafeSystemPath(%q) = true, want false", p)
+		}
+	}
+}

--- a/internal/netmonitor/unix/loader_safe_guard_test.go
+++ b/internal/netmonitor/unix/loader_safe_guard_test.go
@@ -57,6 +57,22 @@ func TestFileHandler_LoaderSafeReadOverride(t *testing.T) {
 			}
 		})
 	}
+
+	// An operator's EXPLICIT deny rule on a system subpath must still be honored
+	// — only the catch-all default deny is overridden (matches ptrace).
+	t.Run("explicit deny on system subpath is honored", func(t *testing.T) {
+		policy := &mockFilePolicy{decisions: map[string]FilePolicyDecision{
+			"/usr/lib/app/secret.key": {Decision: "deny", EffectiveDecision: "deny", Rule: "deny-app-secrets"},
+		}}
+		handler := NewFileHandler(policy, NewMountRegistry(), &mockFileEmitter{}, true)
+		res, _ := handler.Handle(FileRequest{
+			PID: 1234, Syscall: int32(unix.SYS_OPENAT), Path: "/usr/lib/app/secret.key",
+			Operation: "open", Flags: unix.O_RDONLY, SessionID: "sess-1",
+		})
+		if res.Action != ActionDeny {
+			t.Errorf("explicit (non-catch-all) deny on a system subpath must be honored, got %s", res.Action)
+		}
+	})
 }
 
 func TestIsLoaderSafeSystemPath(t *testing.T) {

--- a/internal/policy/issue369_linker_reads_test.go
+++ b/internal/policy/issue369_linker_reads_test.go
@@ -106,8 +106,12 @@ func TestIssue369_ShippedPoliciesAllowLoaderReads(t *testing.T) {
 			if err != nil {
 				// Root default-policy.yml + configs/default-policy.yaml carry a
 				// command-rule arg pattern NewEngine rejects as a regexp — an
-				// unrelated pre-existing issue. Skip rather than conflate it.
-				t.Skipf("engine %s: %v", rel, err)
+				// unrelated pre-existing issue. Skip ONLY that specific failure;
+				// any other load failure in a protected policy must fail loudly.
+				if strings.Contains(err.Error(), "compile command rule") {
+					t.Skipf("engine %s: %v", rel, err)
+				}
+				t.Fatalf("engine %s: %v", rel, err)
 			}
 			for _, path := range loaderEssentialReads {
 				dec := e.CheckFile(path, "open")

--- a/internal/policy/issue369_linker_reads_test.go
+++ b/internal/policy/issue369_linker_reads_test.go
@@ -80,14 +80,15 @@ file_rules:
 // and that this fix modifies. The write-scoped-catch-all policies (default.yaml,
 // agent-default.yaml) allow loader reads via the engine's default-allow-reads
 // fallback and are intentionally excluded — asserting an explicit allow rule
-// there would wrongly fail.
+// there would wrongly fail. The two default-policy files are also excluded:
+// they don't load via NewEngine (unrelated command-rule regex) so they'd only
+// ever be always-skipped rows overstating coverage; their loader-read support
+// is verified by the runtime guard test instead.
 var denyByDefaultPoliciesWithSystemRead = []string{
 	"../../configs/policies/agent-sandbox.yaml",
 	"../../configs/policies/dev-safe.yaml",
 	"../../configs/policies/ci-strict.yaml",
 	"../../configs/policies/bench-realistic.yaml",
-	"../../default-policy.yml",
-	"../../configs/default-policy.yaml",
 }
 
 // TestIssue369_ShippedPoliciesAllowLoaderReads asserts the deny-by-default
@@ -104,13 +105,6 @@ func TestIssue369_ShippedPoliciesAllowLoaderReads(t *testing.T) {
 			}
 			e, err := NewEngine(p, false, true)
 			if err != nil {
-				// Root default-policy.yml + configs/default-policy.yaml carry a
-				// command-rule arg pattern NewEngine rejects as a regexp — an
-				// unrelated pre-existing issue. Skip ONLY that specific failure;
-				// any other load failure in a protected policy must fail loudly.
-				if strings.Contains(err.Error(), "compile command rule") {
-					t.Skipf("engine %s: %v", rel, err)
-				}
 				t.Fatalf("engine %s: %v", rel, err)
 			}
 			for _, path := range loaderEssentialReads {

--- a/internal/policy/issue369_linker_reads_test.go
+++ b/internal/policy/issue369_linker_reads_test.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -19,26 +20,82 @@ var loaderEssentialReads = []string{
 	"/lib/x86_64-linux-gnu/libc.so.6",
 }
 
-// shippedPoliciesWithSystemRead are the policy files that ship the
-// allow-system-read rule (relative to internal/policy/).
-var shippedPoliciesWithSystemRead = []string{
-	"../../default-policy.yml",
-	"../../configs/default-policy.yaml",
-	"../../configs/policies/agent-default.yaml",
+// TestIssue369_BareDirsAreLoadBearing is the controlled, non-tautological proof
+// that the bare-directory additions to allow-system-read matter: against a
+// deny-by-default policy (catch-all default-deny-files on every op), the bare
+// dir /lib is DENIED without the bare-dir entry and ALLOWED (via the explicit
+// allow-system-read rule) with it. The libc *file* path matches /lib/** either
+// way — only the bare dir exercises the fix.
+func TestIssue369_BareDirsAreLoadBearing(t *testing.T) {
+	const withoutBareDirs = `
+version: 1
+name: repro-369-without
+file_rules:
+  - name: allow-system-read
+    paths: ["/lib/**"]
+    operations: [read, open, stat, list, readlink]
+    decision: allow
+  - name: default-deny-files
+    paths: ["**"]
+    operations: ["*"]
+    decision: deny
+`
+	const withBareDirs = `
+version: 1
+name: repro-369-with
+file_rules:
+  - name: allow-system-read
+    paths: ["/lib", "/lib/**"]
+    operations: [read, open, stat, list, readlink]
+    decision: allow
+  - name: default-deny-files
+    paths: ["**"]
+    operations: ["*"]
+    decision: deny
+`
+	mustEngine := func(yaml string) *Engine {
+		p, err := LoadFromBytes([]byte(yaml))
+		if err != nil {
+			t.Fatalf("load: %v", err)
+		}
+		e, err := NewEngine(p, false, true)
+		if err != nil {
+			t.Fatalf("engine: %v", err)
+		}
+		return e
+	}
+
+	// Without the bare dir, the loader's directory open of /lib is denied.
+	if dec := mustEngine(withoutBareDirs).CheckFile("/lib", "open"); dec.EffectiveDecision != "deny" || dec.Rule != "default-deny-files" {
+		t.Fatalf("control: /lib without bare dir should hit default-deny-files; got %s/%s", dec.EffectiveDecision, dec.Rule)
+	}
+	// With the bare dir, it is allowed via the explicit allow-system-read rule.
+	if dec := mustEngine(withBareDirs).CheckFile("/lib", "open"); dec.EffectiveDecision != "allow" || dec.Rule != "allow-system-read" {
+		t.Fatalf("/lib with bare dir should be allowed via allow-system-read; got %s/%s", dec.EffectiveDecision, dec.Rule)
+	}
+}
+
+// denyByDefaultPoliciesWithSystemRead are the shipped policies whose catch-all
+// default-deny-files matches read ops (so loader reads can actually be denied)
+// and that this fix modifies. The write-scoped-catch-all policies (default.yaml,
+// agent-default.yaml) allow loader reads via the engine's default-allow-reads
+// fallback and are intentionally excluded — asserting an explicit allow rule
+// there would wrongly fail.
+var denyByDefaultPoliciesWithSystemRead = []string{
 	"../../configs/policies/agent-sandbox.yaml",
-	"../../configs/policies/default.yaml",
 	"../../configs/policies/dev-safe.yaml",
 	"../../configs/policies/ci-strict.yaml",
 	"../../configs/policies/bench-realistic.yaml",
+	"../../default-policy.yml",
+	"../../configs/default-policy.yaml",
 }
 
-// TestIssue369_ShippedPoliciesAllowLoaderReads asserts every shipped policy
-// that ships allow-system-read permits the dynamic loader's essential reads
-// for op=open. Currently RED for the bare dirs + ld.so.cache (they hit the
-// default-deny-files catch-all); turns GREEN once allow-system-read /
-// allow-etc-read-safe are broadened.
+// TestIssue369_ShippedPoliciesAllowLoaderReads asserts the deny-by-default
+// shipped policies permit the dynamic loader's essential reads for op=open VIA
+// AN EXPLICIT ALLOW RULE (not the permissive default-allow-reads fallback), so
+// removing the bare-dir / etc-open edits would fail this test.
 func TestIssue369_ShippedPoliciesAllowLoaderReads(t *testing.T) {
-	for _, rel := range shippedPoliciesWithSystemRead {
+	for _, rel := range denyByDefaultPoliciesWithSystemRead {
 		rel := rel
 		t.Run(filepath.Base(rel), func(t *testing.T) {
 			p, err := LoadFromFile(rel)
@@ -47,10 +104,9 @@ func TestIssue369_ShippedPoliciesAllowLoaderReads(t *testing.T) {
 			}
 			e, err := NewEngine(p, false, true)
 			if err != nil {
-				// Some shipped files (root default-policy.yml,
-				// configs/default-policy.yaml) carry a command-rule arg pattern
-				// that NewEngine rejects as a regexp — an unrelated pre-existing
-				// issue. Skip rather than conflate it with the loader-reads check.
+				// Root default-policy.yml + configs/default-policy.yaml carry a
+				// command-rule arg pattern NewEngine rejects as a regexp — an
+				// unrelated pre-existing issue. Skip rather than conflate it.
 				t.Skipf("engine %s: %v", rel, err)
 			}
 			for _, path := range loaderEssentialReads {
@@ -58,6 +114,12 @@ func TestIssue369_ShippedPoliciesAllowLoaderReads(t *testing.T) {
 				if dec.EffectiveDecision != "allow" {
 					t.Errorf("CheckFile(%q, open) = %s (rule=%s); loader read must be allowed",
 						path, dec.EffectiveDecision, dec.Rule)
+					continue
+				}
+				if !strings.HasPrefix(dec.Rule, "allow-") {
+					t.Errorf("CheckFile(%q, open) allowed via %q; expected an explicit allow- rule "+
+						"(default-allow-reads fallback means the loader path isn't intentionally allowed)",
+						path, dec.Rule)
 				}
 			}
 		})

--- a/internal/policy/issue369_linker_reads_test.go
+++ b/internal/policy/issue369_linker_reads_test.go
@@ -1,0 +1,65 @@
+package policy
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// loaderEssentialReads are paths the dynamic linker opens on essentially every
+// program startup. Under file_monitor enforcement (FUSE off) these must resolve
+// to "allow", or no dynamically-linked program can start. See issue #369.
+var loaderEssentialReads = []string{
+	"/etc/ld.so.cache",
+	"/etc/ld.so.preload",
+	"/lib",
+	"/lib64",
+	"/usr",
+	"/bin",
+	"/sbin",
+	"/lib/x86_64-linux-gnu/libc.so.6",
+}
+
+// shippedPoliciesWithSystemRead are the policy files that ship the
+// allow-system-read rule (relative to internal/policy/).
+var shippedPoliciesWithSystemRead = []string{
+	"../../default-policy.yml",
+	"../../configs/default-policy.yaml",
+	"../../configs/policies/agent-default.yaml",
+	"../../configs/policies/agent-sandbox.yaml",
+	"../../configs/policies/default.yaml",
+	"../../configs/policies/dev-safe.yaml",
+	"../../configs/policies/ci-strict.yaml",
+	"../../configs/policies/bench-realistic.yaml",
+}
+
+// TestIssue369_ShippedPoliciesAllowLoaderReads asserts every shipped policy
+// that ships allow-system-read permits the dynamic loader's essential reads
+// for op=open. Currently RED for the bare dirs + ld.so.cache (they hit the
+// default-deny-files catch-all); turns GREEN once allow-system-read /
+// allow-etc-read-safe are broadened.
+func TestIssue369_ShippedPoliciesAllowLoaderReads(t *testing.T) {
+	for _, rel := range shippedPoliciesWithSystemRead {
+		rel := rel
+		t.Run(filepath.Base(rel), func(t *testing.T) {
+			p, err := LoadFromFile(rel)
+			if err != nil {
+				t.Fatalf("load %s: %v", rel, err)
+			}
+			e, err := NewEngine(p, false, true)
+			if err != nil {
+				// Some shipped files (root default-policy.yml,
+				// configs/default-policy.yaml) carry a command-rule arg pattern
+				// that NewEngine rejects as a regexp — an unrelated pre-existing
+				// issue. Skip rather than conflate it with the loader-reads check.
+				t.Skipf("engine %s: %v", rel, err)
+			}
+			for _, path := range loaderEssentialReads {
+				dec := e.CheckFile(path, "open")
+				if dec.EffectiveDecision != "allow" {
+					t.Errorf("CheckFile(%q, open) = %s (rule=%s); loader read must be allowed",
+						path, dec.EffectiveDecision, dec.Rule)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue #369 — third failure: shim-routed commands fail under file_monitor

After the inject fix (#400, v0.20.3-rc7) and the FUSE-off mitigation, erans found that **every shim-routed command failed** on exe.dev (FUSE off, `seccomp.file_monitor` on): the dynamic loader's reads were denied. Confirmed both in production (event log) and reproduced locally:

```
file_open | /etc/ld.so.cache | open | deny | default-deny-files
file_open | /lib /lib64 /usr | open | deny | default-deny-files
file_open | /lib/x86_64-linux-gnu/libc.so.6 | open | allow | allow-system-read
```

**Root cause:** `allow-system-read`'s globs (`/lib/**`, …) match library *files* but not the **bare directories** the loader opens during search-path resolution (`/lib`, `/lib64`, `/usr`), and don't cover `/etc/ld.so.cache`. In deny-by-default policies (catch-all `default-deny-files` with `operations: ["*"]`) those opens fall through to the catch-all and are denied → the loader can't start any program. Policies whose catch-all is write-scoped were already fine.

This is the `file_monitor` (seccomp-notify) enforcement path — distinct from the server-side ptrace path that `agentsh exec` uses (which is why CLI exec into the same session worked but the shim didn't).

## Fix — two layers

**1. Policy (`fix(policy,#369)`):** add the bare loader dirs to `allow-system-read` in the deny-by-default shipped policies (`agent-sandbox`, `dev-safe`, `ci-strict`, `bench-realistic`, + the two `default-policy` files), and add the loader/NSS `/etc/ld.so.*` + `nsswitch.conf` entries (with the `open` op) so the loader's reads resolve via an explicit allow rule.

**2. Code guard (`fix(seccomp,#369)`):** a defense-in-depth override in the `file_monitor` file handler so **no** policy — shipped or custom — can make a dynamically-linked program un-loadable. Before enforcing a deny, it overrides DENY→ALLOW when:
- the operation is **read-only** (via the existing `isReadOnlyFileOp(syscall, flags)`; writes/creates/deletes stay enforced), **and**
- the path is **loader-essential** (`/usr`, `/lib`, `/lib64`, `/lib32`, `/libx32`, `/bin`, `/sbin` subtrees + `/etc/ld.so.{cache,preload,conf,conf.d}`; `/opt` intentionally excluded — not loader-essential), **and**
- the deny came from a **catch-all** rule (`default-deny-files`), **not** an operator's explicit path-specific deny — which is still honored, matching the ptrace enforcer.

Each override is logged and recorded as a `shadow_deny` audit event.

## Tests
- `internal/policy/issue369_linker_reads_test.go`: a controlled fixture proving the bare-dir addition is load-bearing (denied without it, allowed via `allow-system-read` with it), plus the four deny-by-default shipped policies asserting loader reads resolve via an **explicit** allow rule.
- `internal/netmonitor/unix/loader_safe_guard_test.go`: override allows read-only loader paths; writes & non-system reads still denied; **explicit** deny on a system subpath still honored; override emits a `shadow_deny` event; `enforce=false` doesn't take the override path.
- gofmt/vet clean; builds amd64 + arm64 + windows; full suite green except the known pre-existing `fsmonitor` FUSE env failure.

## Review
roborev branch review: clean after three rounds (1 Medium = explicit-deny bypass [fixed by catch-all scoping]; Lows = tautological test [fixed], policy consistency [fixed], `/opt` over-breadth [fixed]).

## Follow-ups (out of scope here)
- The root `default-policy.yml` + `configs/default-policy.yaml` don't load via `NewEngine` (pre-existing `block-dangerous-rm` arg-pattern `*-rf*` regex). Their loader-read fix is backstopped by the runtime guard; the regex bug is separate.
- `tracer.go`'s `mayInject` gate (from #400) hand-mirrors the inject branch conditions; a focused test asserting the mirror would prevent silent drift (noted by roborev; belongs with #400).
- exe.dev's exact policy identity pending erans's confirmation (asked on #369); the runtime guard covers it regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)