### PR TITLE
fix(#369): file_monitor override read-only opens of standard system dir nodes

### DIFF
--- a/internal/netmonitor/unix/file_handler.go
+++ b/internal/netmonitor/unix/file_handler.go
@@ -136,24 +136,33 @@ func (h *FileHandler) Handle(req FileRequest) (FileResult, *types.Event) {
 			// Audit-only mode: log but allow.
 			return FileResult{Action: ActionContinue}, h.buildFileEvent(req, dec, false, false)
 		}
-		// #369 loader-safe guard: never DENY a read-only access to an essential
-		// system/loader path when the denial came from a catch-all default rule.
-		// A deny-by-default policy would otherwise make every dynamically-linked
-		// program un-loadable under file_monitor — the loader reads
-		// /etc/ld.so.cache and walks /lib, /usr, ... during startup, and those
-		// opens fall through allow-system-read (its /lib/** globs don't match the
-		// bare dirs) to the default-deny-files catch-all. The ptrace enforcer
-		// effectively allows these, so file_monitor must too.
-		//
-		// Scoped to the catch-all rule ONLY: an operator's EXPLICIT deny rule on a
-		// system subpath (e.g. `deny read /opt/app/secrets/**`) is still honored,
-		// matching ptrace's first-match-explicit-deny semantics. Read-only only —
-		// writes/creates/deletes to these paths stay enforced.
-		if isDefaultDenyRule(dec.Rule) && isReadOnlyFileOp(req.Syscall, req.Flags) && isLoaderSafeSystemPath(req.Path) {
-			slog.Debug("file_monitor: loader-safe read override (#369)",
-				"path", req.Path, "operation", req.Operation, "policy_rule", dec.Rule, "session", req.SessionID)
-			// shadowDeny=true records that policy said deny but we did not enforce.
-			return FileResult{Action: ActionContinue}, h.buildFileEvent(req, dec, false, true)
+		// #369 loader-safe + system-dir-node guards: file_monitor must not deny
+		// the read-only opens / stats every wrapped program needs to start, or a
+		// deny-by-default policy makes every dynamically-linked command fail.
+		// The ptrace enforcer effectively allows both classes below; file_monitor
+		// matches it. Read-only only — writes/creates/deletes stay enforced.
+		if isReadOnlyFileOp(req.Syscall, req.Flags) {
+			// (1) Standard system DIRECTORY NODES (/, /dev, /proc/self, /etc, ...).
+			// EXACT match — does NOT extend to contents (a deny of /etc/secret
+			// still stands). Overrides ANY deny rule (catch-all or explicit) for
+			// these specific bare nodes, because they are universally read-safe
+			// (every program stats them) and the wrapped shell can't start
+			// without them; operator denies on /proc/self etc. are about the
+			// CONTENTS (maps, cmdline, environ), which exact-match preserves.
+			if isSystemDirNode(req.Path) {
+				slog.Debug("file_monitor: system-dir-node read override (#369)",
+					"path", req.Path, "operation", req.Operation, "policy_rule", dec.Rule, "session", req.SessionID)
+				return FileResult{Action: ActionContinue}, h.buildFileEvent(req, dec, false, true)
+			}
+			// (2) Loader-essential subtrees (/lib, /usr, ld.so.cache, ...). Subtree
+			// match. Scoped to the CATCH-ALL deny only: an operator's explicit
+			// deny rule on a system subpath (e.g. `deny read /opt/app/secrets/**`)
+			// is still honored, matching ptrace's first-match-explicit-deny.
+			if isDefaultDenyRule(dec.Rule) && isLoaderSafeSystemPath(req.Path) {
+				slog.Debug("file_monitor: loader-safe read override (#369)",
+					"path", req.Path, "operation", req.Operation, "policy_rule", dec.Rule, "session", req.SessionID)
+				return FileResult{Action: ActionContinue}, h.buildFileEvent(req, dec, false, true)
+			}
 		}
 		// Enforced deny.
 		return FileResult{Action: ActionDeny, Errno: int32(sysunix.EACCES)}, h.buildFileEvent(req, dec, true, false)
@@ -219,6 +228,42 @@ var loaderSafeReadPrefixes = []string{
 	"/usr", "/lib", "/lib64", "/lib32", "/libx32", "/bin", "/sbin",
 	"/etc/ld.so.cache", "/etc/ld.so.preload", "/etc/ld.so.conf", "/etc/ld.so.conf.d",
 }
+
+// systemDirNodeReads are the bare system DIRECTORY NODES every wrapped program
+// stats/opens during normal startup (the shell walking `/`, libc consulting
+// `/proc/self`, programs touching `/dev`, `/etc`, `/tmp`, ...). In a
+// deny-by-default policy, allow rules typically write `"/etc/ssl/**"` style
+// globs that match contents but not the bare directory node, so the node's
+// `openat(O_DIRECTORY)` or `stat` falls to the catch-all (or to a broad
+// deny-proc-sys-style explicit rule) and is denied — preventing the program
+// from starting. The override is EXACT match only (the entries listed below),
+// so reads of CONTENTS (e.g., `/etc/secret`, `/proc/self/maps`) remain
+// policy-controlled. Unlike loaderSafeReadPrefixes, this set overrides ANY
+// deny rule for these specific bare nodes — they are universally read-safe
+// and the ptrace enforcer effectively allows them; operator deny rules over
+// these paths are aimed at the CONTENTS (which exact-match preserves).
+var systemDirNodeReads = map[string]bool{
+	"/":                    true,
+	"/dev":                 true,
+	"/dev/pts":             true,
+	"/dev/fd":              true,
+	"/proc":                true,
+	"/proc/self":           true,
+	"/proc/thread-self":    true,
+	"/sys":                 true,
+	"/etc":                 true,
+	"/etc/ca-certificates": true,
+	"/etc/ssl":             true,
+	"/etc/ssl/certs":       true,
+	"/tmp":                 true,
+	"/var":                 true,
+	"/var/tmp":             true,
+	"/run":                 true,
+}
+
+// isSystemDirNode reports whether p is exactly one of the bare system directory
+// nodes whose read-only stat/open must always succeed (exact match only).
+func isSystemDirNode(p string) bool { return systemDirNodeReads[p] }
 
 // defaultDenyRuleNames are the catch-all "deny everything not explicitly
 // allowed" rule names. The loader-safe override fires only when a loader read

--- a/internal/netmonitor/unix/file_handler.go
+++ b/internal/netmonitor/unix/file_handler.go
@@ -229,36 +229,38 @@ var loaderSafeReadPrefixes = []string{
 	"/etc/ld.so.cache", "/etc/ld.so.preload", "/etc/ld.so.conf", "/etc/ld.so.conf.d",
 }
 
-// systemDirNodeReads are the bare system DIRECTORY NODES every wrapped program
-// stats/opens during normal startup (the shell walking `/`, libc consulting
-// `/proc/self`, programs touching `/dev`, `/etc`, `/tmp`, ...). In a
-// deny-by-default policy, allow rules typically write `"/etc/ssl/**"` style
-// globs that match contents but not the bare directory node, so the node's
-// `openat(O_DIRECTORY)` or `stat` falls to the catch-all (or to a broad
-// deny-proc-sys-style explicit rule) and is denied — preventing the program
-// from starting. The override is EXACT match only (the entries listed below),
-// so reads of CONTENTS (e.g., `/etc/secret`, `/proc/self/maps`) remain
-// policy-controlled. Unlike loaderSafeReadPrefixes, this set overrides ANY
-// deny rule for these specific bare nodes — they are universally read-safe
-// and the ptrace enforcer effectively allows them; operator deny rules over
-// these paths are aimed at the CONTENTS (which exact-match preserves).
+// systemDirNodeReads are the bare KERNEL / PROCESS directory nodes whose
+// read-only stat/open every dynamically-linked program performs at startup
+// (the shell walking `/`, libc consulting `/proc/self`, programs touching
+// `/dev`, `/etc`). In a deny-by-default policy, allow rules typically write
+// `"/etc/ssl/**"` style globs that match contents but not the bare node, so
+// the node's `openat(O_DIRECTORY)` or `stat` falls to the catch-all (or to a
+// broad `deny-proc-sys`-style explicit rule) and is denied — preventing the
+// program from starting. The override is EXACT match only, so reads of
+// CONTENTS (e.g., `/etc/secret`, `/proc/self/maps`) remain policy-controlled.
+//
+// Unlike loaderSafeReadPrefixes, this set overrides ANY deny rule for these
+// specific bare nodes — they are universally read-safe (the kernel/libc
+// invariants every program relies on), the ptrace enforcer already allows
+// them, and operator deny rules over these paths are aimed at the CONTENTS
+// (which exact-match preserves).
+//
+// Deliberately NARROW: this list is kernel/process essentials only. Paths
+// that are sometimes-but-not-universally needed (`/tmp`, `/var`, `/run`,
+// `/etc/ssl`, `/etc/ssl/certs`, `/etc/ca-certificates`) intentionally fall
+// to policy — an operator who denies them clearly means it, and a policy
+// that needs them should add an explicit allow rule (matching what
+// shipped deny-by-default policies will eventually carry).
 var systemDirNodeReads = map[string]bool{
-	"/":                    true,
-	"/dev":                 true,
-	"/dev/pts":             true,
-	"/dev/fd":              true,
-	"/proc":                true,
-	"/proc/self":           true,
-	"/proc/thread-self":    true,
-	"/sys":                 true,
-	"/etc":                 true,
-	"/etc/ca-certificates": true,
-	"/etc/ssl":             true,
-	"/etc/ssl/certs":       true,
-	"/tmp":                 true,
-	"/var":                 true,
-	"/var/tmp":             true,
-	"/run":                 true,
+	"/":                 true,
+	"/dev":              true,
+	"/dev/pts":          true,
+	"/dev/fd":           true,
+	"/proc":             true,
+	"/proc/self":        true,
+	"/proc/thread-self": true,
+	"/sys":              true,
+	"/etc":              true,
 }
 
 // isSystemDirNode reports whether p is exactly one of the bare system directory

--- a/internal/netmonitor/unix/loader_safe_guard_test.go
+++ b/internal/netmonitor/unix/loader_safe_guard_test.go
@@ -74,6 +74,51 @@ func TestFileHandler_LoaderSafeReadOverride(t *testing.T) {
 		}
 	})
 
+	// Bare system directory nodes are overridden regardless of which deny rule
+	// fired — these are universally read-safe and the wrapped shell can't start
+	// without them. Matches the ptrace enforcer; matches erans's working policy.
+	t.Run("dir-node override applies to non-catch-all deny", func(t *testing.T) {
+		// e.g. an explicit deny-proc-sys rule denying /proc/self — still overridden
+		// for the bare directory node (contents like /proc/self/maps are not).
+		policy := &mockFilePolicy{decisions: map[string]FilePolicyDecision{
+			"/proc/self": {Decision: "deny", EffectiveDecision: "deny", Rule: "deny-proc-sys"},
+		}}
+		res, _ := NewFileHandler(policy, NewMountRegistry(), &mockFileEmitter{}, true).Handle(FileRequest{
+			PID: 1234, Syscall: int32(unix.SYS_OPENAT), Path: "/proc/self", Operation: "open",
+			Flags: unix.O_RDONLY | unix.O_DIRECTORY, SessionID: "sess-1",
+		})
+		if res.Action != ActionContinue {
+			t.Errorf("/proc/self bare dir-node must be overridden even on an explicit deny rule, got %s", res.Action)
+		}
+	})
+
+	// Dir-node CONTENTS are NOT covered by the exact-match override — a deny of
+	// /proc/self/maps still stands (exact match doesn't catch subpaths).
+	t.Run("dir-node override does NOT cover subpath contents", func(t *testing.T) {
+		policy := &mockFilePolicy{decisions: map[string]FilePolicyDecision{
+			"/proc/self/maps": {Decision: "deny", EffectiveDecision: "deny", Rule: "deny-proc-sys"},
+		}}
+		res, _ := NewFileHandler(policy, NewMountRegistry(), &mockFileEmitter{}, true).Handle(FileRequest{
+			PID: 1234, Syscall: int32(unix.SYS_OPENAT), Path: "/proc/self/maps", Operation: "open",
+			Flags: unix.O_RDONLY, SessionID: "sess-1",
+		})
+		if res.Action != ActionDeny {
+			t.Errorf("contents of a system dir-node must remain policy-controlled, got %s", res.Action)
+		}
+	})
+
+	// Writes to a system dir node are still enforced.
+	t.Run("write to dir node is still denied", func(t *testing.T) {
+		policy := denyAll("/etc/new.conf")
+		res, _ := NewFileHandler(policy, NewMountRegistry(), &mockFileEmitter{}, true).Handle(FileRequest{
+			PID: 1234, Syscall: int32(unix.SYS_OPENAT), Path: "/etc/new.conf", Operation: "write",
+			Flags: unix.O_WRONLY | unix.O_CREAT, SessionID: "sess-1",
+		})
+		if res.Action != ActionDeny {
+			t.Errorf("write to /etc/new.conf must stay denied, got %s", res.Action)
+		}
+	})
+
 	// An overridden read must be recorded as a shadow-deny — the only forensic
 	// trace that policy denied but file_monitor allowed it.
 	t.Run("override emits shadow-deny event", func(t *testing.T) {
@@ -110,6 +155,22 @@ func TestFileHandler_LoaderSafeReadOverride(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestIsSystemDirNode(t *testing.T) {
+	safe := []string{"/", "/dev", "/dev/pts", "/proc", "/proc/self", "/proc/thread-self", "/etc", "/etc/ssl", "/tmp", "/var", "/run"}
+	for _, p := range safe {
+		if !isSystemDirNode(p) {
+			t.Errorf("isSystemDirNode(%q) = false, want true", p)
+		}
+	}
+	// Exact-match only — subpaths and similarly-named paths must NOT match.
+	unsafe := []string{"/proc/self/maps", "/etc/secret", "/etc/ssl/private", "/home/user", "/devnull", "/tmpfoo", "/var/log/secret", "/proc/1", ""}
+	for _, p := range unsafe {
+		if isSystemDirNode(p) {
+			t.Errorf("isSystemDirNode(%q) = true, want false (exact match only)", p)
+		}
+	}
 }
 
 func TestIsLoaderSafeSystemPath(t *testing.T) {

--- a/internal/netmonitor/unix/loader_safe_guard_test.go
+++ b/internal/netmonitor/unix/loader_safe_guard_test.go
@@ -158,17 +158,23 @@ func TestFileHandler_LoaderSafeReadOverride(t *testing.T) {
 }
 
 func TestIsSystemDirNode(t *testing.T) {
-	safe := []string{"/", "/dev", "/dev/pts", "/proc", "/proc/self", "/proc/thread-self", "/etc", "/etc/ssl", "/tmp", "/var", "/run"}
+	// Kernel / process essentials — universally read-safe; override applies.
+	safe := []string{"/", "/dev", "/dev/pts", "/dev/fd", "/proc", "/proc/self", "/proc/thread-self", "/sys", "/etc"}
 	for _, p := range safe {
 		if !isSystemDirNode(p) {
 			t.Errorf("isSystemDirNode(%q) = false, want true", p)
 		}
 	}
-	// Exact-match only — subpaths and similarly-named paths must NOT match.
-	unsafe := []string{"/proc/self/maps", "/etc/secret", "/etc/ssl/private", "/home/user", "/devnull", "/tmpfoo", "/var/log/secret", "/proc/1", ""}
+	// Exact-match only — subpaths must NOT match. Plus paths intentionally left
+	// OUT of the override (operator-policy territory: /tmp, /var, /etc/ssl, ...).
+	unsafe := []string{
+		"/proc/self/maps", "/etc/secret", "/etc/ssl/private", "/home/user",
+		"/devnull", "/tmpfoo", "/var/log/secret", "/proc/1", "",
+		"/tmp", "/var", "/var/tmp", "/run", "/etc/ssl", "/etc/ssl/certs", "/etc/ca-certificates",
+	}
 	for _, p := range unsafe {
 		if isSystemDirNode(p) {
-			t.Errorf("isSystemDirNode(%q) = true, want false (exact match only)", p)
+			t.Errorf("isSystemDirNode(%q) = true, want false (exact-match-only / outside narrowed set)", p)
 		}
 	}
 }


### PR DESCRIPTION
## Finish-fix for #369 / #3 — wrapped shell needed bare system *directory nodes*

erans's rc8 test of #401 confirmed the loader-file coverage works (84 loader reads allowed) but the wrapped shell still fails on read-only opens/stats of bare **directory nodes** (`/`, `/dev`, `/dev/pts`, `/dev/fd`, `/proc`, `/proc/self`, `/proc/thread-self`, `/sys`, `/etc`). In a deny-by-default policy, allow rules typically write `/etc/ssl/**`-style globs that match contents but not the bare node, so `openat(O_DIRECTORY)`/`stat` of the node falls to the catch-all (or to a broad `deny-proc-sys`) and is denied — preventing every program from starting.

## What this PR does

Adds a second override in the `file_monitor` file handler for these kernel/process-essential bare dir nodes:

- **EXACT match** on a narrowly-scoped set: `/`, `/dev`, `/dev/pts`, `/dev/fd`, `/proc`, `/proc/self`, `/proc/thread-self`, `/sys`, `/etc`. Contents (`/proc/self/maps`, `/etc/secret`, `/etc/ssl/private`, ...) remain policy-controlled.
- **Read-only ops only** (`open` without write flags, `stat`, `list`, `readlink`, `access`). Writes/creates/deletes stay enforced.
- **Overrides ANY deny rule** (not just catch-all) — these are universally read-safe (the kernel/libc invariants every program relies on); the ptrace enforcer already allows them; an operator deny rule like `deny-proc-sys` is aimed at *contents* (maps, cmdline, environ), which exact-match preserves.

The existing loader-subtree override (`/lib`, `/usr`, `ld.so.cache`, …) is unchanged — still scoped to catch-all denies only, still honors explicit deny rules on system subpaths.

### Deliberately *not* included in the override
`/tmp`, `/var`, `/var/tmp`, `/run`, `/etc/ssl`, `/etc/ssl/certs`, `/etc/ca-certificates` — these are sometimes-but-not-universally needed, and an operator denying them clearly means it. Policies that need them must add an explicit allow rule (matching erans's working policy). Shipped-policy edits to add them as out-of-the-box dir-node allows are a separate follow-up — the code guard already makes file_monitor-on viable for *any* policy whose wrapped commands only need the kernel/process essentials.

## Tests
- `dir-node override applies to non-catch-all deny` — proves the broader override scope (vs the catch-all-only loader subtree).
- `dir-node override does NOT cover subpath contents` — `/proc/self/maps` still denied.
- `write to dir node is still denied` — read-only only.
- `explicit deny on system subpath is honored` — existing loader-subtree behavior preserved.
- `override emits shadow-deny event` + `enforce=false does not take the override path` — audit invariants preserved.
- `TestIsSystemDirNode` — exact-match boundary cases, including the deliberately-excluded `/tmp`, `/var`, `/etc/ssl`, `/run` etc.

## Review
roborev round on first push flagged the override as too broad (silently weakened explicit operator denies on `/tmp`, `/var`, `/etc/ssl`, ...). Fixed by narrowing to kernel/process essentials per reviewer's option (b). Build / vet / test / cross-compile clean.

## Follow-up (out of scope here, noted in memory)
Shipped deny-by-default policies (agent-sandbox, dev-safe, ci-strict, bench-realistic, and the two non-loadable default-policy files) should eventually carry explicit allow rules for `/tmp`, `/var`, `/run`, `/etc/ssl`, etc., so deny-by-default deployments need no manual policy edits for TLS/temp-file-using wrapped commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)