### PR TITLE
diag(#369): env-gated ptrace stop/resume trace to pin the FUSE-on hang

### DIFF
--- a/internal/ptrace/redirect_exec.go
+++ b/internal/ptrace/redirect_exec.go
@@ -165,6 +165,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	}
 
 	// Resume → gadget's syscall instruction → execve ENTRY stop.
+	t.traceResume(tid, "redirect-exec-entry", 0)
 	if err := unix.PtraceSyscall(tid, 0); err != nil {
 		slog.Warn("redirectExec: resume to entry failed", "tid", tid, "error", err)
 		t.cleanupInjectedFD(tid, savedRegs, stubFDNum, savedFD)
@@ -198,6 +199,7 @@ func (t *Tracer) redirectExec(ctx context.Context, tid int, regs Regs, result Ex
 	// Use PtraceSyscall (not allowSyscall) to ensure we catch the exec
 	// exit stop even in prefilter/seccomp mode. This is needed so the
 	// PendingExecStubFD cleanup runs on exec failure.
+	t.traceResume(tid, "redirect-exec-resume", 0)
 	if err := unix.PtraceSyscall(tid, 0); err != nil {
 		if errors.Is(err, unix.ESRCH) {
 			t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)

--- a/internal/ptrace/trace_debug.go
+++ b/internal/ptrace/trace_debug.go
@@ -1,0 +1,178 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// #369 #2 diagnostic instrumentation.
+//
+// The FUSE-on hang on kernel 6.12.90 leaves the tracer goroutine idle in the
+// Run-loop select (tracer.go) while a child sits stopped-but-reapable: a stop was
+// consumed by handleStop, but no resume (PtraceCont/PtraceSyscall) or park
+// (PTRACE_LISTEN) was issued for it, so Wait4 never returns that tid again. The
+// branch responsible cannot be found by local inspection — it does not reproduce
+// off exe.dev. This trace lets a single repro name the un-resumed stop: it logs
+// every stop the Run loop dispatches and every resume/park issued, and an
+// idle-tick scan flags any tracee whose stop was consumed but never resumed.
+//
+// Enabled only via the AGENTSH_PTRACE_TRACE env var. When off, the cost is one
+// relaxed atomic load per stop/resume and nothing is written to TraceeState.
+
+var (
+	ptraceTraceEnabled atomic.Bool
+	ptraceTraceSeq     atomic.Uint64
+)
+
+// wedgeThreshold is how long a tracee may sit with a consumed-but-unresumed stop
+// before the idle-tick reporter flags it. Generous enough never to flag a tracee
+// merely between a stop and its imminent resume on the same loop turn.
+const wedgeThreshold = 2 * time.Second
+
+// initPtraceTrace enables the stop/resume diagnostic when AGENTSH_PTRACE_TRACE is
+// set to a truthy value. Called once at the top of Run.
+func initPtraceTrace() {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("AGENTSH_PTRACE_TRACE"))) {
+	case "1", "true", "yes", "on":
+		ptraceTraceEnabled.Store(true)
+		slog.Info("ptrace-trace: stop/resume diagnostic enabled (#369)")
+	}
+}
+
+// ptraceTraceOn reports whether the diagnostic is active.
+func ptraceTraceOn() bool { return ptraceTraceEnabled.Load() }
+
+// traceStop records and logs a stop dispatched from the Run loop, arming the
+// wedge detector so the idle-tick scan can flag it if no resume or park follows.
+// Terminal stops (exit/signaled) need no resume and do not arm. Call with t.mu
+// NOT held.
+func (t *Tracer) traceStop(tid int, st unix.WaitStatus) {
+	if !ptraceTraceOn() {
+		return
+	}
+	desc := describeWaitStatus(st)
+	seq := ptraceTraceSeq.Add(1)
+	slog.Info("ptrace-trace stop", "seq", seq, "tid", tid, "status", desc)
+
+	terminal := st.Exited() || st.Signaled()
+	t.mu.Lock()
+	if s := t.tracees[tid]; s != nil {
+		if terminal {
+			s.awaitingResume = false
+		} else {
+			s.awaitingResume = true
+			s.lastStopDesc = desc
+			s.lastStopSeq = seq
+			s.lastStopAt = time.Now()
+			s.wedgeLogged = false
+		}
+	}
+	t.mu.Unlock()
+}
+
+// traceResume records and logs a resume or intentional park for a tracee and
+// clears the wedge-detector arm. `via` names the resume site (e.g.
+// "allowSyscall-cont", "resumeTracee-syscall", "listen", "detach"). Call with
+// t.mu NOT held.
+func (t *Tracer) traceResume(tid int, via string, sig int) {
+	if !ptraceTraceOn() {
+		return
+	}
+	seq := ptraceTraceSeq.Add(1)
+	slog.Info("ptrace-trace resume", "seq", seq, "tid", tid, "via", via, "sig", sig)
+	t.mu.Lock()
+	if s := t.tracees[tid]; s != nil {
+		s.awaitingResume = false
+	}
+	t.mu.Unlock()
+}
+
+// scanWedged reports, at most once each, any tracee whose stop was consumed but
+// never resumed for longer than wedgeThreshold. Called from the Run-loop idle
+// branch. This is the diagnostic's headline output: it names the wedged tid and
+// the stop type that went un-resumed, pinning the handleStop branch at fault.
+func (t *Tracer) scanWedged() {
+	if !ptraceTraceOn() {
+		return
+	}
+	now := time.Now()
+	type victim struct {
+		tid  int
+		desc string
+		seq  uint64
+		age  time.Duration
+	}
+	var victims []victim
+	t.mu.Lock()
+	for tid, s := range t.tracees {
+		if s == nil || !s.awaitingResume || s.wedgeLogged {
+			continue
+		}
+		age := now.Sub(s.lastStopAt)
+		if age < wedgeThreshold {
+			continue
+		}
+		s.wedgeLogged = true
+		victims = append(victims, victim{tid: tid, desc: s.lastStopDesc, seq: s.lastStopSeq, age: age})
+	}
+	t.mu.Unlock()
+	for _, v := range victims {
+		slog.Warn("ptrace-trace WEDGE: stop consumed but never resumed (#369)",
+			"tid", v.tid, "last_stop", v.desc, "stop_seq", v.seq, "age_ms", v.age.Milliseconds())
+	}
+}
+
+// describeWaitStatus decodes a wait status into the same classification handleStop
+// dispatches on, so each "stop" trace line names the branch that will run.
+func describeWaitStatus(st unix.WaitStatus) string {
+	switch {
+	case st.Exited():
+		return fmt.Sprintf("exited(code=%d)", st.ExitStatus())
+	case st.Signaled():
+		return fmt.Sprintf("signaled(sig=%s)", st.Signal())
+	case st.Continued():
+		return "continued"
+	case st.Stopped():
+		sig := st.StopSignal()
+		switch {
+		case sig == unix.SIGTRAP|0x80:
+			return "syscall-stop"
+		case sig == unix.SIGTRAP:
+			switch st.TrapCause() {
+			case unix.PTRACE_EVENT_FORK:
+				return "event:FORK"
+			case unix.PTRACE_EVENT_VFORK:
+				return "event:VFORK"
+			case unix.PTRACE_EVENT_CLONE:
+				return "event:CLONE"
+			case unix.PTRACE_EVENT_EXEC:
+				return "event:EXEC"
+			case unix.PTRACE_EVENT_VFORK_DONE:
+				return "event:VFORK_DONE"
+			case unix.PTRACE_EVENT_SECCOMP:
+				return "event:SECCOMP"
+			case unix.PTRACE_EVENT_EXIT:
+				return "event:EXIT"
+			case unix.PTRACE_EVENT_STOP:
+				return "event:STOP"
+			default:
+				return "sigtrap(plain)"
+			}
+		default:
+			if st.TrapCause() == unix.PTRACE_EVENT_STOP {
+				return fmt.Sprintf("group-stop(sig=%s)", sig)
+			}
+			return fmt.Sprintf("signal-stop(sig=%s)", sig)
+		}
+	default:
+		return fmt.Sprintf("unknown(0x%x)", uint32(st))
+	}
+}

--- a/internal/ptrace/trace_debug_test.go
+++ b/internal/ptrace/trace_debug_test.go
@@ -1,0 +1,162 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// withTrace runs fn with the stop/resume diagnostic forced on and slog captured
+// to a buffer, restoring both afterwards. Returns the captured log text.
+func withTrace(t *testing.T, on bool, fn func()) string {
+	t.Helper()
+	prevEnabled := ptraceTraceEnabled.Load()
+	prevDefault := slog.Default()
+	var buf bytes.Buffer
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	ptraceTraceEnabled.Store(on)
+	t.Cleanup(func() {
+		ptraceTraceEnabled.Store(prevEnabled)
+		slog.SetDefault(prevDefault)
+	})
+	fn()
+	return buf.String()
+}
+
+func TestDescribeWaitStatus(t *testing.T) {
+	cases := []struct {
+		name   string
+		status unix.WaitStatus
+		want   string
+	}{
+		// stopped: low byte 0x7f, stop signal in bits 8-15.
+		{"syscall-stop", unix.WaitStatus(uint32(unix.SIGTRAP|0x80)<<8 | 0x7f), "syscall-stop"},
+		{"plain-sigtrap", unix.WaitStatus(uint32(unix.SIGTRAP)<<8 | 0x7f), "sigtrap(plain)"},
+		// SIGTRAP + PTRACE event in bits 16-23.
+		{"event-exec", unix.WaitStatus(uint32(unix.PTRACE_EVENT_EXEC)<<16 | uint32(unix.SIGTRAP)<<8 | 0x7f), "event:EXEC"},
+		{"event-seccomp", unix.WaitStatus(uint32(unix.PTRACE_EVENT_SECCOMP)<<16 | uint32(unix.SIGTRAP)<<8 | 0x7f), "event:SECCOMP"},
+		{"event-clone", unix.WaitStatus(uint32(unix.PTRACE_EVENT_CLONE)<<16 | uint32(unix.SIGTRAP)<<8 | 0x7f), "event:CLONE"},
+		// exited: low 7 bits zero, code in bits 8-15.
+		{"exited", unix.WaitStatus(42 << 8), "exited(code=42)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := describeWaitStatus(tc.status); got != tc.want {
+				t.Errorf("describeWaitStatus(0x%x) = %q, want %q", uint32(tc.status), got, tc.want)
+			}
+		})
+	}
+
+	// A group-stop (non-SIGTRAP stop signal) and a kill signal decode to their
+	// own categories without panicking — assert the prefix only (signal-name
+	// strings are platform-dependent).
+	group := describeWaitStatus(unix.WaitStatus(uint32(unix.SIGSTOP)<<8 | 0x7f))
+	if !strings.HasPrefix(group, "signal-stop(") && !strings.HasPrefix(group, "group-stop(") {
+		t.Errorf("SIGSTOP stop decoded as %q, want signal-stop/group-stop", group)
+	}
+	if killed := describeWaitStatus(unix.WaitStatus(uint32(unix.SIGKILL))); !strings.HasPrefix(killed, "signaled(") {
+		t.Errorf("SIGKILL decoded as %q, want signaled(...)", killed)
+	}
+}
+
+func TestTrace_DisabledIsSilentAndInert(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+	tr.tracees[100] = &TraceeState{TID: 100}
+
+	out := withTrace(t, false, func() {
+		tr.traceStop(100, unix.WaitStatus(uint32(unix.SIGTRAP|0x80)<<8|0x7f))
+		tr.traceResume(100, "allowSyscall-cont", 0)
+		tr.scanWedged()
+	})
+
+	if out != "" {
+		t.Errorf("disabled trace must emit nothing, got:\n%s", out)
+	}
+	// And it must not have armed the wedge detector.
+	if tr.tracees[100].awaitingResume {
+		t.Error("disabled traceStop must not arm awaitingResume")
+	}
+}
+
+func TestTrace_StopArmsResumeClears(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+	tr.tracees[200] = &TraceeState{TID: 200}
+
+	withTrace(t, true, func() {
+		tr.traceStop(200, unix.WaitStatus(uint32(unix.PTRACE_EVENT_SECCOMP)<<16|uint32(unix.SIGTRAP)<<8|0x7f))
+		if !tr.tracees[200].awaitingResume {
+			t.Fatal("traceStop must arm awaitingResume")
+		}
+		if tr.tracees[200].lastStopDesc != "event:SECCOMP" {
+			t.Errorf("lastStopDesc = %q, want event:SECCOMP", tr.tracees[200].lastStopDesc)
+		}
+		tr.traceResume(200, "denySyscall", 0)
+		if tr.tracees[200].awaitingResume {
+			t.Error("traceResume must clear awaitingResume")
+		}
+	})
+}
+
+func TestTrace_TerminalStopDoesNotArm(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+	tr.tracees[300] = &TraceeState{TID: 300}
+	withTrace(t, true, func() {
+		tr.traceStop(300, unix.WaitStatus(7<<8)) // exited(code=7)
+		if tr.tracees[300].awaitingResume {
+			t.Error("a terminal (exited) stop must not arm the wedge detector")
+		}
+	})
+}
+
+func TestScanWedged_FlagsConsumedButUnresumedStop(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+	// Wedged: armed, aged past threshold.
+	tr.tracees[10] = &TraceeState{TID: 10, awaitingResume: true, lastStopDesc: "event:EXEC",
+		lastStopSeq: 99, lastStopAt: time.Now().Add(-3 * wedgeThreshold)}
+	// Recently armed: must NOT flag yet.
+	tr.tracees[11] = &TraceeState{TID: 11, awaitingResume: true, lastStopDesc: "syscall-stop",
+		lastStopAt: time.Now()}
+	// Resumed (parked/continued): must NOT flag.
+	tr.tracees[12] = &TraceeState{TID: 12, awaitingResume: false, lastStopAt: time.Now().Add(-3 * wedgeThreshold)}
+
+	out := withTrace(t, true, func() { tr.scanWedged() })
+
+	if !strings.Contains(out, "WEDGE") || !strings.Contains(out, "tid=10") || !strings.Contains(out, "event:EXEC") {
+		t.Errorf("scanWedged must flag the wedged tid 10 with its last stop; got:\n%s", out)
+	}
+	if strings.Contains(out, "tid=11") || strings.Contains(out, "tid=12") {
+		t.Errorf("scanWedged must not flag recently-armed (11) or resumed (12) tracees; got:\n%s", out)
+	}
+	if !tr.tracees[10].wedgeLogged {
+		t.Error("scanWedged must mark the flagged tracee wedgeLogged")
+	}
+
+	// Second scan must not re-flag the same wedge (wedgeLogged set).
+	out2 := withTrace(t, true, func() { tr.scanWedged() })
+	if strings.Contains(out2, "tid=10") {
+		t.Errorf("scanWedged must not re-flag an already-reported wedge; got:\n%s", out2)
+	}
+}
+
+func TestTrace_SeqMonotonic(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+	tr.tracees[400] = &TraceeState{TID: 400}
+	before := ptraceTraceSeq.Load()
+	withTrace(t, true, func() {
+		tr.traceStop(400, unix.WaitStatus(uint32(unix.SIGTRAP|0x80)<<8|0x7f))
+		tr.traceResume(400, "allowSyscall-cont", 0)
+	})
+	if got := ptraceTraceSeq.Load(); got < before+2 {
+		t.Errorf("trace seq did not advance by >=2: before=%d after=%d", before, got)
+	}
+	// Sanity: the counter is a real atomic (compile-time guard against accidental
+	// type change away from atomic.Uint64).
+	var _ *atomic.Uint64 = &ptraceTraceSeq
+}

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -199,6 +199,16 @@ type TraceeState struct {
 	// (allow + pass-through) from "non-empty unknown SessionID"
 	// (fail-closed bug).
 	SessionlessPIDAttach bool
+
+	// #369 #2 diagnostic — only written when AGENTSH_PTRACE_TRACE is set (see
+	// trace_debug.go). awaitingResume records that a stop was consumed but no
+	// resume/park has been issued yet; the idle-tick scan flags any tracee that
+	// stays armed past wedgeThreshold. Guarded by t.mu.
+	awaitingResume bool
+	lastStopDesc   string
+	lastStopSeq    uint64
+	lastStopAt     time.Time
+	wedgeLogged    bool
 }
 
 type resumeRequest struct {
@@ -616,6 +626,7 @@ func (t *Tracer) allowSyscall(tid int) {
 	// Fast path: without seccomp prefilter, hasPrefilter is always false,
 	// so the result is always PtraceSyscall. Skip the mutex entirely.
 	if !t.cfg.SeccompPrefilter {
+		t.traceResume(tid, "allowSyscall-syscall", 0)
 		if err := unix.PtraceSyscall(tid, 0); err != nil && errors.Is(err, unix.ESRCH) {
 			t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
 		}
@@ -632,11 +643,14 @@ func (t *Tracer) allowSyscall(tid int) {
 	t.mu.Unlock()
 
 	var err error
+	via := "allowSyscall-syscall"
 	if hasPrefilter && !needExit {
+		via = "allowSyscall-cont"
 		err = unix.PtraceCont(tid, 0)
 	} else {
 		err = unix.PtraceSyscall(tid, 0)
 	}
+	t.traceResume(tid, via, 0)
 	if err != nil && errors.Is(err, unix.ESRCH) {
 		t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
 	}
@@ -676,6 +690,7 @@ func (t *Tracer) denySyscall(tid int, errno int) error {
 	}
 	t.mu.Unlock()
 
+	t.traceResume(tid, "denySyscall", 0)
 	if err := unix.PtraceSyscall(tid, 0); err != nil {
 		if errors.Is(err, unix.ESRCH) {
 			t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
@@ -692,6 +707,7 @@ func (t *Tracer) denySyscall(tid int, errno int) error {
 func (t *Tracer) resumeTracee(tid int, sig int) {
 	// Fast path: without seccomp prefilter, always use PtraceSyscall.
 	if !t.cfg.SeccompPrefilter {
+		t.traceResume(tid, "resumeTracee-syscall", sig)
 		unix.PtraceSyscall(tid, sig)
 		return
 	}
@@ -706,8 +722,10 @@ func (t *Tracer) resumeTracee(tid int, sig int) {
 	t.mu.Unlock()
 
 	if hasPrefilter && !needExit {
+		t.traceResume(tid, "resumeTracee-cont", sig)
 		unix.PtraceCont(tid, sig)
 	} else {
+		t.traceResume(tid, "resumeTracee-syscall", sig)
 		unix.PtraceSyscall(tid, sig)
 	}
 }
@@ -782,6 +800,7 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 						slog.Warn("ptrace: detach after exec failed, resuming instead", "tid", tid, "err", err)
 						t.resumeTracee(tid, 0)
 					} else {
+						t.traceResume(tid, "detach-after-exec", 0)
 						t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
 					}
 				} else {
@@ -851,6 +870,7 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 				}
 
 				ptraceListen(tid)
+				t.traceResume(tid, "listen", 0)
 				break
 			}
 
@@ -1697,6 +1717,7 @@ func (t *Tracer) handleExitEvent(tid int) {
 			t.resumeTracee(tid, 0)
 			return
 		}
+		t.traceResume(tid, "detach-on-exit", 0)
 		t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
 		return
 	}
@@ -1909,6 +1930,8 @@ func (t *Tracer) Run(ctx context.Context) error {
 	defer t.cancelPendingAttachWaiters()
 	defer t.cancelPendingExitWaiters()
 
+	initPtraceTrace()
+
 	t.hasSyscallInfo = probePtraceSyscallInfo()
 	if t.hasSyscallInfo {
 		slog.Info("ptrace: PTRACE_GET_SYSCALL_INFO supported")
@@ -1974,6 +1997,7 @@ func (t *Tracer) Run(ctx context.Context) error {
 		}
 
 		if tid == 0 {
+			t.scanWedged()
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -2000,6 +2024,7 @@ func (t *Tracer) Run(ctx context.Context) error {
 			continue
 		}
 
+		t.traceStop(tid, status)
 		t.handleStop(ctx, tid, status, &rusage)
 	}
 }


### PR DESCRIPTION
## What

#369's remaining failure (#2) is a **hang only with FUSE on**, on exe.dev kernel 6.12.90. erans's goroutine dump shows the tracer goroutine idle in the Run-loop `select` while a child sits **stopped-but-reapable** — i.e. a stop was consumed by `handleStop` but no resume (`PtraceCont`/`PtraceSyscall`) or park (`PTRACE_LISTEN`) was issued, so `Wait4` never returns that tid again. The responsible branch can't be found by local inspection: it doesn't reproduce off exe.dev.

This adds a **zero-overhead-when-off**, env-gated diagnostic (`AGENTSH_PTRACE_TRACE=1`) that:
- logs every stop the Run loop dispatches (`ptrace-trace stop seq=… tid=… status=<decoded>`),
- logs every resume/park issued (`ptrace-trace resume … via=<site>`),
- on each idle tick, scans for any tracee whose stop was **consumed but never resumed** past a 2s threshold and logs one `ptrace-trace WEDGE tid=… last_stop=… age_ms=…` line — naming the wedged tid and the exact stop type, which pins the offending `handleStop` branch from a single repro.

**This is a diagnostic build, not the #2 fix.** The fix follows once erans's trace identifies the un-resumed stop.

## How

- **`internal/ptrace/trace_debug.go`** (new): atomic enabled flag (set from env in `Run`), monotonic seq, `traceStop`/`traceResume`, `describeWaitStatus` (mirrors `handleStop`'s classification), `scanWedged`.
- **`internal/ptrace/tracer.go`**: `initPtraceTrace()` in `Run`; `traceStop` before `handleStop`; `traceResume` at `allowSyscall`/`denySyscall`/`resumeTracee`/`ptraceListen` and both `PtraceDetach` sites; `scanWedged` in the idle branch; new `TraceeState` wedge fields (written only when the trace is enabled).
- **`internal/ptrace/redirect_exec.go`**: `traceResume` at the two `PtraceSyscall` handback sites.
- **`internal/ptrace/trace_debug_test.go`** (new): decode table, disabled-is-silent-and-inert, arm/clear, terminal-doesn't-arm, wedge scan flags only the aged-armed tracee once, seq monotonic.

## Verification

- `go test -race ./internal/ptrace/` ✅, `go build ./...` ✅, `GOOS=windows go build ./...` ✅, `go vet ./internal/ptrace/` ✅.
- Disabled cost: one relaxed atomic load per stop/resume; nothing written to `TraceeState`.
- **End-to-end (erans, exe.dev 6.12.90):** run the wedged FUSE-on scenario with `AGENTSH_PTRACE_TRACE=1`; expect a `ptrace-trace WEDGE` line identifying the un-resumed stop.

Refs #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)