### PR TITLE
diag(#369 #2): wait-layer trace + /proc ground-truth alarm

### DIFF
--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -211,7 +211,9 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 			return fmt.Errorf("waitForSyscallStop tid %d: timed out after %v", tid, timeout)
 		}
 		var status unix.WaitStatus
+		traceWaitCall("inject", tid)
 		wpid, err := unix.Wait4(tid, &status, unix.WNOHANG|unix.WALL, nil)
+		traceWaitRet("inject", wpid, status, err)
 		if err != nil {
 			if err == unix.EINTR {
 				continue

--- a/internal/ptrace/trace_debug.go
+++ b/internal/ptrace/trace_debug.go
@@ -13,19 +13,29 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// #369 #2 diagnostic instrumentation.
+// #369 #2 diagnostic instrumentation (v2 — wait-layer + /proc ground truth).
 //
-// The FUSE-on hang on kernel 6.12.90 leaves the tracer goroutine idle in the
-// Run-loop select (tracer.go) while a child sits stopped-but-reapable: a stop was
-// consumed by handleStop, but no resume (PtraceCont/PtraceSyscall) or park
-// (PTRACE_LISTEN) was issued for it, so Wait4 never returns that tid again. The
-// branch responsible cannot be found by local inspection — it does not reproduce
-// off exe.dev. This trace lets a single repro name the un-resumed stop: it logs
-// every stop the Run loop dispatches and every resume/park issued, and an
-// idle-tick scan flags any tracee whose stop was consumed but never resumed.
+// The FUSE-on hang on kernel 6.12.90 leaves a child kernel-stopped-and-reapable
+// while the tracer goroutine idles in the Run-loop select, with NO server thread
+// in wait4. The rc10 trace (v1) proved the stop is lost UPSTREAM of handleStop:
+// its WEDGE alarm (consumed-but-not-resumed) never fired, because the stop is
+// never consumed by the Run loop in the first place. v1 also masked the hang —
+// per-event slog added enough latency to suppress the timing race (Heisenbug).
 //
-// Enabled only via the AGENTSH_PTRACE_TRACE env var. When off, the cost is one
-// relaxed atomic load per stop/resume and nothing is written to TraceeState.
+// v2 fixes both:
+//   - A lock-free in-memory RING BUFFER replaces per-event slog. All trace events
+//     (wait4 call/return at every layer, stop dispatch, resume/park) are appended
+//     by the single Run goroutine, so no locking is needed and the per-event cost
+//     is a struct copy — low enough not to perturb the race. The ring is dumped
+//     to slog only when an alarm fires (rare).
+//   - A /proc RECONCILIATION alarm: on the idle tick (throttled), any tracee the
+//     Run loop believes is running but that /proc reports kernel-stopped (State
+//     t/T) with TracerPid==us is flagged and the ring dumped. This is ground
+//     truth, independent of where the stop was lost — it fires even though the
+//     stop never reached handleStop.
+//
+// Enabled only via AGENTSH_PTRACE_TRACE. When off, every hook is one relaxed
+// atomic load and returns.
 
 var (
 	ptraceTraceEnabled atomic.Bool
@@ -33,35 +43,121 @@ var (
 )
 
 // wedgeThreshold is how long a tracee may sit with a consumed-but-unresumed stop
-// before the idle-tick reporter flags it. Generous enough never to flag a tracee
-// merely between a stop and its imminent resume on the same loop turn.
+// before the (v1) idle-tick reporter flags it. Retained as a secondary signal.
 const wedgeThreshold = 2 * time.Second
 
-// initPtraceTrace enables the stop/resume diagnostic when AGENTSH_PTRACE_TRACE is
-// set to a truthy value. Called once at the top of Run.
+// procStuckThreshold is how long a tracee must remain kernel-stopped (per /proc)
+// while we think it is running before the v2 reconciliation alarm fires.
+const procStuckThreshold = 1500 * time.Millisecond
+
+// procScanInterval throttles the /proc reconciliation scan so it adds negligible
+// overhead and does not itself perturb the race (it runs only on idle ticks).
+const procScanInterval = 500 * time.Millisecond
+
+// traceEventKind names a ring entry's category.
+type traceEventKind uint8
+
+const (
+	evWaitCall traceEventKind = iota // about to call wait4(arg)
+	evWaitRet                        // wait4 returned
+	evStop                           // a stop was dispatched to handleStop
+	evResume                         // a resume/park was issued
+)
+
+func (k traceEventKind) String() string {
+	switch k {
+	case evWaitCall:
+		return "wait_call"
+	case evWaitRet:
+		return "wait_ret"
+	case evStop:
+		return "stop"
+	case evResume:
+		return "resume"
+	default:
+		return "?"
+	}
+}
+
+// traceEvent is one ring entry. Fields are raw; formatting happens only on dump.
+// String fields hold interned literals (the wait layer / resume site), so an
+// append allocates nothing.
+type traceEvent struct {
+	seq    uint64
+	mono   int64 // time.Now().UnixNano()
+	kind   traceEventKind
+	tid    int   // returned/affected tid (or wait pid arg for evWaitCall)
+	arg    int64 // wait pid arg (evWaitCall), signal (evResume), or returned tid (evWaitRet)
+	status uint32
+	errno  int32
+	layer  string // "run" | "inject" | "attach" — for wait events
+	via    string // resume site
+}
+
+const traceRingSize = 8192
+
+// traceRing and traceRingIdx are written ONLY by the Run goroutine (every stop,
+// resume, and wait4 in the tracer runs there), so no synchronization is needed.
+// dumpTraceRing reads them, also from the Run goroutine (idle tick). The atomic
+// is used solely so a future off-goroutine reader could snapshot the index.
+var (
+	traceRing    [traceRingSize]traceEvent
+	traceRingIdx atomic.Uint64
+)
+
+// initPtraceTrace enables the diagnostic when AGENTSH_PTRACE_TRACE is truthy.
 func initPtraceTrace() {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("AGENTSH_PTRACE_TRACE"))) {
 	case "1", "true", "yes", "on":
 		ptraceTraceEnabled.Store(true)
-		slog.Info("ptrace-trace: stop/resume diagnostic enabled (#369)")
+		slog.Info("ptrace-trace: wait-layer + /proc diagnostic enabled (#369 #2)")
 	}
 }
 
-// ptraceTraceOn reports whether the diagnostic is active.
 func ptraceTraceOn() bool { return ptraceTraceEnabled.Load() }
 
-// traceStop records and logs a stop dispatched from the Run loop, arming the
-// wedge detector so the idle-tick scan can flag it if no resume or park follows.
-// Terminal stops (exit/signaled) need no resume and do not arm. Call with t.mu
-// NOT held.
+// ringAppend writes one event to the ring (Run goroutine only).
+func ringAppend(ev traceEvent) {
+	ev.seq = ptraceTraceSeq.Add(1)
+	ev.mono = time.Now().UnixNano()
+	i := traceRingIdx.Load()
+	traceRing[i%traceRingSize] = ev
+	traceRingIdx.Store(i + 1)
+}
+
+// traceWaitCall records that wait4(arg) is about to be called at layer.
+func traceWaitCall(layer string, arg int) {
+	if !ptraceTraceOn() {
+		return
+	}
+	ringAppend(traceEvent{kind: evWaitCall, tid: arg, arg: int64(arg), layer: layer})
+}
+
+// traceWaitRet records a wait4 return: which tid (0 = none), status, errno.
+func traceWaitRet(layer string, ret int, status unix.WaitStatus, err error) {
+	if !ptraceTraceOn() {
+		return
+	}
+	var errno int32
+	if err != nil {
+		if e, ok := err.(unix.Errno); ok {
+			errno = int32(e)
+		} else {
+			errno = -1
+		}
+	}
+	ringAppend(traceEvent{kind: evWaitRet, tid: ret, arg: int64(ret), status: uint32(status), errno: errno, layer: layer})
+}
+
+// traceStop records a stop dispatched from the Run loop and arms the (v1)
+// wedge detector. Call with t.mu NOT held.
 func (t *Tracer) traceStop(tid int, st unix.WaitStatus) {
 	if !ptraceTraceOn() {
 		return
 	}
-	desc := describeWaitStatus(st)
-	seq := ptraceTraceSeq.Add(1)
-	slog.Info("ptrace-trace stop", "seq", seq, "tid", tid, "status", desc)
+	ringAppend(traceEvent{kind: evStop, tid: tid, status: uint32(st)})
 
+	desc := describeWaitStatus(st)
 	terminal := st.Exited() || st.Signaled()
 	t.mu.Lock()
 	if s := t.tracees[tid]; s != nil {
@@ -70,7 +166,7 @@ func (t *Tracer) traceStop(tid int, st unix.WaitStatus) {
 		} else {
 			s.awaitingResume = true
 			s.lastStopDesc = desc
-			s.lastStopSeq = seq
+			s.lastStopSeq = ptraceTraceSeq.Load()
 			s.lastStopAt = time.Now()
 			s.wedgeLogged = false
 		}
@@ -78,16 +174,13 @@ func (t *Tracer) traceStop(tid int, st unix.WaitStatus) {
 	t.mu.Unlock()
 }
 
-// traceResume records and logs a resume or intentional park for a tracee and
-// clears the wedge-detector arm. `via` names the resume site (e.g.
-// "allowSyscall-cont", "resumeTracee-syscall", "listen", "detach"). Call with
+// traceResume records a resume/park and clears the (v1) wedge arm. Call with
 // t.mu NOT held.
 func (t *Tracer) traceResume(tid int, via string, sig int) {
 	if !ptraceTraceOn() {
 		return
 	}
-	seq := ptraceTraceSeq.Add(1)
-	slog.Info("ptrace-trace resume", "seq", seq, "tid", tid, "via", via, "sig", sig)
+	ringAppend(traceEvent{kind: evResume, tid: tid, arg: int64(sig), via: via})
 	t.mu.Lock()
 	if s := t.tracees[tid]; s != nil {
 		s.awaitingResume = false
@@ -95,43 +188,157 @@ func (t *Tracer) traceResume(tid int, via string, sig int) {
 	t.mu.Unlock()
 }
 
-// scanWedged reports, at most once each, any tracee whose stop was consumed but
-// never resumed for longer than wedgeThreshold. Called from the Run-loop idle
-// branch. This is the diagnostic's headline output: it names the wedged tid and
-// the stop type that went un-resumed, pinning the handleStop branch at fault.
+// scanWedged is the v1 (consumed-but-not-resumed) alarm, retained as a secondary
+// signal. rc10 showed it does not fire for #2, but if it ever does we want the
+// ring. Call from the Run-loop idle branch.
 func (t *Tracer) scanWedged() {
 	if !ptraceTraceOn() {
 		return
 	}
 	now := time.Now()
-	type victim struct {
-		tid  int
-		desc string
-		seq  uint64
-		age  time.Duration
-	}
-	var victims []victim
+	var victims []int
 	t.mu.Lock()
 	for tid, s := range t.tracees {
 		if s == nil || !s.awaitingResume || s.wedgeLogged {
 			continue
 		}
-		age := now.Sub(s.lastStopAt)
-		if age < wedgeThreshold {
+		if now.Sub(s.lastStopAt) < wedgeThreshold {
 			continue
 		}
 		s.wedgeLogged = true
-		victims = append(victims, victim{tid: tid, desc: s.lastStopDesc, seq: s.lastStopSeq, age: age})
+		victims = append(victims, tid)
 	}
 	t.mu.Unlock()
-	for _, v := range victims {
-		slog.Warn("ptrace-trace WEDGE: stop consumed but never resumed (#369)",
-			"tid", v.tid, "last_stop", v.desc, "stop_seq", v.seq, "age_ms", v.age.Milliseconds())
+	if len(victims) > 0 {
+		for _, tid := range victims {
+			slog.Warn("ptrace-trace WEDGE(v1): stop consumed but never resumed (#369)", "tid", tid)
+		}
+		t.dumpTraceRing("wedge-v1")
 	}
 }
 
+// reconcileProc is the v2 ground-truth alarm. On the idle tick (throttled to
+// procScanInterval) it reads /proc for every tracee the Run loop believes is
+// running; any that is kernel-stopped (State t/T) with TracerPid==us for longer
+// than procStuckThreshold is flagged and the trace ring dumped. This catches the
+// hang regardless of where the stop was lost, because /proc is ground truth.
+func (t *Tracer) reconcileProc() {
+	if !ptraceTraceOn() {
+		return
+	}
+	now := time.Now()
+	if now.Sub(t.lastProcScan) < procScanInterval {
+		return
+	}
+	t.lastProcScan = now
+
+	myPid := os.Getpid()
+
+	// Snapshot tids (and skip intentionally parked tracees) under the lock.
+	type cand struct{ tid int }
+	var cands []cand
+	t.mu.Lock()
+	for tid := range t.tracees {
+		if _, parked := t.parkedTracees[tid]; parked {
+			continue
+		}
+		cands = append(cands, cand{tid})
+	}
+	t.mu.Unlock()
+
+	var flagged []int
+	for _, c := range cands {
+		state, tracerPid, ok := readProcStopState(c.tid)
+		stuck := ok && (state == 't' || state == 'T') && tracerPid == myPid
+
+		t.mu.Lock()
+		s := t.tracees[c.tid]
+		if s == nil {
+			t.mu.Unlock()
+			continue
+		}
+		if !stuck {
+			s.procStuckSince = time.Time{}
+			t.mu.Unlock()
+			continue
+		}
+		if s.procStuckSince.IsZero() {
+			s.procStuckSince = now
+		}
+		fire := !s.procWedgeLogged && now.Sub(s.procStuckSince) >= procStuckThreshold
+		if fire {
+			s.procWedgeLogged = true
+		}
+		stuckMs := now.Sub(s.procStuckSince).Milliseconds()
+		t.mu.Unlock()
+
+		if fire {
+			slog.Warn("ptrace-trace WEDGE(v2): tracee kernel-stopped but Run loop not progressing it (#369 #2)",
+				"tid", c.tid, "proc_state", string(rune(state)), "tracer_pid", tracerPid, "stuck_ms", stuckMs)
+			flagged = append(flagged, c.tid)
+		}
+	}
+	if len(flagged) > 0 {
+		t.dumpTraceRing(fmt.Sprintf("wedge-v2 tids=%v", flagged))
+	}
+}
+
+// dumpTraceRing emits the whole ring oldest→newest to slog. Called only when an
+// alarm fires, so the slog cost is acceptable. BEGIN/END markers bracket the dump
+// for easy extraction; t0 is the first event's timestamp so offsets are relative.
+func (t *Tracer) dumpTraceRing(reason string) {
+	total := traceRingIdx.Load()
+	if total == 0 {
+		slog.Warn("ptrace-trace ring DUMP: empty", "reason", reason)
+		return
+	}
+	n := uint64(traceRingSize)
+	if total < n {
+		n = total
+	}
+	start := total - n
+	first := traceRing[start%traceRingSize]
+	t0 := first.mono
+
+	slog.Warn("ptrace-trace ring DUMP BEGIN", "reason", reason, "events", n)
+	for i := start; i < total; i++ {
+		ev := traceRing[i%traceRingSize]
+		offUs := (ev.mono - t0) / 1000
+		switch ev.kind {
+		case evWaitCall:
+			slog.Warn("ptrace-trace", "seq", ev.seq, "us", offUs, "ev", "wait_call", "layer", ev.layer, "pid_arg", ev.arg)
+		case evWaitRet:
+			slog.Warn("ptrace-trace", "seq", ev.seq, "us", offUs, "ev", "wait_ret", "layer", ev.layer,
+				"ret_tid", ev.arg, "status", describeWaitStatus(unix.WaitStatus(ev.status)), "errno", ev.errno)
+		case evStop:
+			slog.Warn("ptrace-trace", "seq", ev.seq, "us", offUs, "ev", "stop", "tid", ev.tid,
+				"status", describeWaitStatus(unix.WaitStatus(ev.status)))
+		case evResume:
+			slog.Warn("ptrace-trace", "seq", ev.seq, "us", offUs, "ev", "resume", "tid", ev.tid, "via", ev.via, "sig", ev.arg)
+		}
+	}
+	slog.Warn("ptrace-trace ring DUMP END", "reason", reason)
+}
+
+// readProcStopState reports whether tracee tid is currently kernel-stopped from
+// the OS's point of view, and who its tracer is. It reuses procStateChar (reads
+// /proc/<tid>/stat State char) and readProcStatusField (TracerPid). ok is false
+// if /proc could not be read (tracee vanished). State 't' = tracing stop,
+// 'T' = stopped (job control).
+func readProcStopState(tid int) (state byte, tracerPid int, ok bool) {
+	sc := procStateChar(tid)
+	if sc == "" {
+		return 0, 0, false
+	}
+	tp, err := readProcStatusField(tid, "TracerPid:")
+	if err != nil {
+		return sc[0], 0, false
+	}
+	return sc[0], tp, true
+}
+
 // describeWaitStatus decodes a wait status into the same classification handleStop
-// dispatches on, so each "stop" trace line names the branch that will run.
+// dispatches on, so each stop/wait line names the branch that will run.
 func describeWaitStatus(st unix.WaitStatus) string {
 	switch {
 	case st.Exited():

--- a/internal/ptrace/trace_debug_test.go
+++ b/internal/ptrace/trace_debug_test.go
@@ -5,16 +5,16 @@ package ptrace
 import (
 	"bytes"
 	"log/slog"
+	"os"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"golang.org/x/sys/unix"
 )
 
-// withTrace runs fn with the stop/resume diagnostic forced on and slog captured
-// to a buffer, restoring both afterwards. Returns the captured log text.
+// withTrace runs fn with the diagnostic forced on/off and slog captured to a
+// buffer, restoring both afterwards. Returns the captured log text.
 func withTrace(t *testing.T, on bool, fn func()) string {
 	t.Helper()
 	prevEnabled := ptraceTraceEnabled.Load()
@@ -36,14 +36,11 @@ func TestDescribeWaitStatus(t *testing.T) {
 		status unix.WaitStatus
 		want   string
 	}{
-		// stopped: low byte 0x7f, stop signal in bits 8-15.
 		{"syscall-stop", unix.WaitStatus(uint32(unix.SIGTRAP|0x80)<<8 | 0x7f), "syscall-stop"},
 		{"plain-sigtrap", unix.WaitStatus(uint32(unix.SIGTRAP)<<8 | 0x7f), "sigtrap(plain)"},
-		// SIGTRAP + PTRACE event in bits 16-23.
 		{"event-exec", unix.WaitStatus(uint32(unix.PTRACE_EVENT_EXEC)<<16 | uint32(unix.SIGTRAP)<<8 | 0x7f), "event:EXEC"},
 		{"event-seccomp", unix.WaitStatus(uint32(unix.PTRACE_EVENT_SECCOMP)<<16 | uint32(unix.SIGTRAP)<<8 | 0x7f), "event:SECCOMP"},
 		{"event-clone", unix.WaitStatus(uint32(unix.PTRACE_EVENT_CLONE)<<16 | uint32(unix.SIGTRAP)<<8 | 0x7f), "event:CLONE"},
-		// exited: low 7 bits zero, code in bits 8-15.
 		{"exited", unix.WaitStatus(42 << 8), "exited(code=42)"},
 	}
 	for _, tc := range cases {
@@ -53,10 +50,6 @@ func TestDescribeWaitStatus(t *testing.T) {
 			}
 		})
 	}
-
-	// A group-stop (non-SIGTRAP stop signal) and a kill signal decode to their
-	// own categories without panicking — assert the prefix only (signal-name
-	// strings are platform-dependent).
 	group := describeWaitStatus(unix.WaitStatus(uint32(unix.SIGSTOP)<<8 | 0x7f))
 	if !strings.HasPrefix(group, "signal-stop(") && !strings.HasPrefix(group, "group-stop(") {
 		t.Errorf("SIGSTOP stop decoded as %q, want signal-stop/group-stop", group)
@@ -66,97 +59,117 @@ func TestDescribeWaitStatus(t *testing.T) {
 	}
 }
 
+func TestReadProcStopState_SelfAndMissing(t *testing.T) {
+	// Reading our own process: it's running, not traced by us.
+	state, tracerPid, ok := readProcStopState(os.Getpid())
+	if !ok {
+		t.Fatal("readProcStopState(self) ok=false, want true")
+	}
+	// State should be a plausible scheduler state letter, never a stop ('t'/'T'),
+	// since we're actively running this test.
+	if state == 't' || state == 'T' {
+		t.Errorf("self proc_state = %q, did not expect a stop state", state)
+	}
+	_ = tracerPid // 0 normally; nonzero only under an external debugger.
+
+	// A pid that cannot exist must report ok=false.
+	if _, _, ok := readProcStopState(1 << 30); ok {
+		t.Error("readProcStopState(huge pid) ok=true, want false")
+	}
+}
+
 func TestTrace_DisabledIsSilentAndInert(t *testing.T) {
 	tr := NewTracer(TracerConfig{})
 	tr.tracees[100] = &TraceeState{TID: 100}
+	beforeIdx := traceRingIdx.Load()
 
 	out := withTrace(t, false, func() {
+		traceWaitCall("run", -1)
+		traceWaitRet("run", 0, 0, nil)
 		tr.traceStop(100, unix.WaitStatus(uint32(unix.SIGTRAP|0x80)<<8|0x7f))
 		tr.traceResume(100, "allowSyscall-cont", 0)
 		tr.scanWedged()
+		tr.reconcileProc()
 	})
 
 	if out != "" {
 		t.Errorf("disabled trace must emit nothing, got:\n%s", out)
 	}
-	// And it must not have armed the wedge detector.
+	if traceRingIdx.Load() != beforeIdx {
+		t.Error("disabled trace must not append to the ring")
+	}
 	if tr.tracees[100].awaitingResume {
 		t.Error("disabled traceStop must not arm awaitingResume")
 	}
 }
 
-func TestTrace_StopArmsResumeClears(t *testing.T) {
+func TestRing_AppendsAndDumps(t *testing.T) {
 	tr := NewTracer(TracerConfig{})
-	tr.tracees[200] = &TraceeState{TID: 200}
+	tr.tracees[7] = &TraceeState{TID: 7}
 
-	withTrace(t, true, func() {
-		tr.traceStop(200, unix.WaitStatus(uint32(unix.PTRACE_EVENT_SECCOMP)<<16|uint32(unix.SIGTRAP)<<8|0x7f))
-		if !tr.tracees[200].awaitingResume {
-			t.Fatal("traceStop must arm awaitingResume")
-		}
-		if tr.tracees[200].lastStopDesc != "event:SECCOMP" {
-			t.Errorf("lastStopDesc = %q, want event:SECCOMP", tr.tracees[200].lastStopDesc)
-		}
-		tr.traceResume(200, "denySyscall", 0)
-		if tr.tracees[200].awaitingResume {
-			t.Error("traceResume must clear awaitingResume")
-		}
+	out := withTrace(t, true, func() {
+		traceWaitCall("run", -1)
+		traceWaitRet("run", 7, unix.WaitStatus(uint32(unix.PTRACE_EVENT_SECCOMP)<<16|uint32(unix.SIGTRAP)<<8|0x7f), nil)
+		tr.traceStop(7, unix.WaitStatus(uint32(unix.PTRACE_EVENT_SECCOMP)<<16|uint32(unix.SIGTRAP)<<8|0x7f))
+		tr.traceResume(7, "denySyscall", 0)
+		tr.dumpTraceRing("unit-test")
 	})
+
+	for _, want := range []string{"DUMP BEGIN", "DUMP END", "wait_call", "wait_ret", "ev=stop", "ev=resume", "event:SECCOMP", "via=denySyscall"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("ring dump missing %q; got:\n%s", want, out)
+		}
+	}
 }
 
-func TestTrace_TerminalStopDoesNotArm(t *testing.T) {
+func TestScanWedged_v1_FlagsConsumedButUnresumedStop(t *testing.T) {
 	tr := NewTracer(TracerConfig{})
-	tr.tracees[300] = &TraceeState{TID: 300}
-	withTrace(t, true, func() {
-		tr.traceStop(300, unix.WaitStatus(7<<8)) // exited(code=7)
-		if tr.tracees[300].awaitingResume {
-			t.Error("a terminal (exited) stop must not arm the wedge detector")
-		}
-	})
-}
-
-func TestScanWedged_FlagsConsumedButUnresumedStop(t *testing.T) {
-	tr := NewTracer(TracerConfig{})
-	// Wedged: armed, aged past threshold.
 	tr.tracees[10] = &TraceeState{TID: 10, awaitingResume: true, lastStopDesc: "event:EXEC",
-		lastStopSeq: 99, lastStopAt: time.Now().Add(-3 * wedgeThreshold)}
-	// Recently armed: must NOT flag yet.
-	tr.tracees[11] = &TraceeState{TID: 11, awaitingResume: true, lastStopDesc: "syscall-stop",
-		lastStopAt: time.Now()}
-	// Resumed (parked/continued): must NOT flag.
+		lastStopAt: time.Now().Add(-3 * wedgeThreshold)}
+	tr.tracees[11] = &TraceeState{TID: 11, awaitingResume: true, lastStopAt: time.Now()}
 	tr.tracees[12] = &TraceeState{TID: 12, awaitingResume: false, lastStopAt: time.Now().Add(-3 * wedgeThreshold)}
 
 	out := withTrace(t, true, func() { tr.scanWedged() })
 
-	if !strings.Contains(out, "WEDGE") || !strings.Contains(out, "tid=10") || !strings.Contains(out, "event:EXEC") {
-		t.Errorf("scanWedged must flag the wedged tid 10 with its last stop; got:\n%s", out)
+	if !strings.Contains(out, "WEDGE(v1)") || !strings.Contains(out, "tid=10") {
+		t.Errorf("scanWedged must flag the aged-armed tid 10; got:\n%s", out)
 	}
 	if strings.Contains(out, "tid=11") || strings.Contains(out, "tid=12") {
-		t.Errorf("scanWedged must not flag recently-armed (11) or resumed (12) tracees; got:\n%s", out)
+		t.Errorf("scanWedged must not flag recently-armed (11) or resumed (12); got:\n%s", out)
 	}
 	if !tr.tracees[10].wedgeLogged {
 		t.Error("scanWedged must mark the flagged tracee wedgeLogged")
 	}
+}
 
-	// Second scan must not re-flag the same wedge (wedgeLogged set).
-	out2 := withTrace(t, true, func() { tr.scanWedged() })
-	if strings.Contains(out2, "tid=10") {
-		t.Errorf("scanWedged must not re-flag an already-reported wedge; got:\n%s", out2)
+func TestReconcileProc_RunningTraceeNotFlagged(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+	// Use our own (running) pid as a stand-in tracee: /proc says state R and
+	// TracerPid != us, so it must never be flagged as wedged.
+	tr.tracees[os.Getpid()] = &TraceeState{TID: os.Getpid()}
+
+	out := withTrace(t, true, func() {
+		tr.reconcileProc()                              // first scan records lastProcScan
+		tr.lastProcScan = time.Now().Add(-time.Second)  // bypass throttle
+		tr.reconcileProc()
+	})
+	if strings.Contains(out, "WEDGE(v2)") {
+		t.Errorf("a running tracee must not be flagged by reconcileProc; got:\n%s", out)
 	}
 }
 
-func TestTrace_SeqMonotonic(t *testing.T) {
+func TestReconcileProc_Throttled(t *testing.T) {
 	tr := NewTracer(TracerConfig{})
-	tr.tracees[400] = &TraceeState{TID: 400}
-	before := ptraceTraceSeq.Load()
 	withTrace(t, true, func() {
-		tr.traceStop(400, unix.WaitStatus(uint32(unix.SIGTRAP|0x80)<<8|0x7f))
-		tr.traceResume(400, "allowSyscall-cont", 0)
+		tr.lastProcScan = time.Time{}
+		tr.reconcileProc()
+		first := tr.lastProcScan
+		if first.IsZero() {
+			t.Fatal("reconcileProc must record lastProcScan on first run")
+		}
+		tr.reconcileProc() // within procScanInterval — must be a no-op
+		if !tr.lastProcScan.Equal(first) {
+			t.Error("reconcileProc must be throttled within procScanInterval")
+		}
 	})
-	if got := ptraceTraceSeq.Load(); got < before+2 {
-		t.Errorf("trace seq did not advance by >=2: before=%d after=%d", before, got)
-	}
-	// Sanity: the counter is a real atomic (compile-time guard against accidental
-	// type change away from atomic.Uint64).
-	var _ *atomic.Uint64 = &ptraceTraceSeq
 }

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -209,6 +209,12 @@ type TraceeState struct {
 	lastStopSeq    uint64
 	lastStopAt     time.Time
 	wedgeLogged    bool
+	// /proc reconciliation (#2 v2): ground-truth detection that this tracee is
+	// kernel-stopped (State t/T, TracerPid==us) while the Run loop believes it
+	// is running. procStuckSince is when we first observed it stuck; once it
+	// persists past the threshold we dump the trace ring and set procWedgeLogged.
+	procStuckSince  time.Time
+	procWedgeLogged bool
 }
 
 type resumeRequest struct {
@@ -289,6 +295,10 @@ type Tracer struct {
 	readyFileAttempts int
 
 	hasSyscallInfo bool // true if PTRACE_GET_SYSCALL_INFO is supported (Linux 5.3+)
+
+	// #369 #2 diagnostic — Run-goroutine-only, no lock. Throttles the /proc
+	// reconciliation scan (see trace_debug.go reconcileProc).
+	lastProcScan time.Time
 
 	stopped chan struct{}
 }
@@ -1968,7 +1978,9 @@ func (t *Tracer) Run(ctx context.Context) error {
 
 		var status unix.WaitStatus
 		var rusage unix.Rusage
+		traceWaitCall("run", -1)
 		tid, err := unix.Wait4(-1, &status, unix.WALL|unix.WNOHANG, &rusage)
+		traceWaitRet("run", tid, status, err)
 
 		if err != nil {
 			if err == unix.EINTR {
@@ -1998,6 +2010,7 @@ func (t *Tracer) Run(ctx context.Context) error {
 
 		if tid == 0 {
 			t.scanWedged()
+			t.reconcileProc()
 			select {
 			case <-ctx.Done():
 				return ctx.Err()


### PR DESCRIPTION
## What

Follow-up to rc10 (#403). erans's rc10 run **disproved the model that PR was built on**: the `WEDGE` alarm never fired for #2 — even on confirmed hangs — so the lost stop is **never consumed by the Run loop**, i.e. lost *upstream* of `handleStop`. rc10 also **masked** the hang (per-event `slog` added enough latency to suppress the timing race — a Heisenbug).

v2 reworks the diagnostic to (a) instrument the layer *below* `handleStop`, (b) use `/proc` as ground truth, and (c) replace per-event `slog` with a ring buffer so it stops perturbing the race.

## Changes (`internal/ptrace`)

- **Lock-free in-memory ring buffer** (single Run-goroutine writer → no locks, ~struct-copy cost) records every `wait4` **call/return**, every stop dispatched, and every resume/park. Dumped to `slog` **only on an alarm**.
- **`traceWaitCall`/`traceWaitRet`** at both `Wait4` sites: the Run-loop `Wait4(-1)` (`tracer.go`) and `waitForSyscallStop`'s `Wait4(tid)` (`inject.go`). The dump shows whether the kernel reports the stop and **which layer consumes it**.
- **`reconcileProc`**: idle-tick `/proc` reconciliation (throttled to 500ms). Flags any tracee the Run loop believes is running that `/proc` reports kernel-stopped (`State` `t`/`T`) with `TracerPid == us` for >1.5s, then dumps the ring. **Ground truth, independent of where the stop was lost** — fires even though the stop never reached `handleStop`. Reuses existing `procStateChar` + `readProcStatusField`.
- v1 `scanWedged` retained as a secondary signal (also dumps the ring if it ever fires).
- `TraceeState` gains `procStuckSince`/`procWedgeLogged` (written only when enabled).

## Verification

- `go test -race ./internal/ptrace/` ✅ (decode table, disabled-is-silent-and-inert incl. ring untouched, ring append+dump, `readProcStopState` self/missing, v1 scan, v2 running-tracee-not-flagged, v2 throttle), `go build ./...` ✅, `GOOS=windows go build ./...` ✅, `go vet` ✅.
- **End-to-end (erans):** with `AGENTSH_PTRACE_TRACE=1`, reproduce the FUSE-on hang **trace-off-reproduces-style** (the ring is low-overhead, unlike rc10's slog). On the `/proc` alarm the ring dumps the wait/stop/resume history → shows whether `Wait4(-1)` ever saw the stop or `waitForSyscallStop` ate it.

Still a **diagnostic**, not the #2 fix. Refined hypothesis to test: the stop is consumed by `waitForSyscallStop`'s `Wait4(tid)` during a FUSE-lengthened injection and never reaches the Run loop.

Refs #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)