### PR TITLE
fix(#369 #2): recover stolen child-exits in the Run-loop ECHILD branch

### DIFF
--- a/internal/ptrace/proc_helpers.go
+++ b/internal/ptrace/proc_helpers.go
@@ -30,3 +30,11 @@ func readProcStatusField(tid int, field string) (int, error) {
 	}
 	return 0, fmt.Errorf("%s not found in /proc/%d/status", field, tid)
 }
+
+// procExists reports whether /proc/<tid> still exists. A thread that has exited
+// and been reaped has no /proc entry; used to detect tracees whose exit was
+// reaped out from under the tracer (#369 #2).
+func procExists(tid int) bool {
+	_, err := os.Stat(fmt.Sprintf("/proc/%d", tid))
+	return err == nil
+}

--- a/internal/ptrace/trace_debug.go
+++ b/internal/ptrace/trace_debug.go
@@ -96,10 +96,14 @@ type traceEvent struct {
 
 const traceRingSize = 8192
 
-// traceRing and traceRingIdx are written ONLY by the Run goroutine (every stop,
-// resume, and wait4 in the tracer runs there), so no synchronization is needed.
-// dumpTraceRing reads them, also from the Run goroutine (idle tick). The atomic
-// is used solely so a future off-goroutine reader could snapshot the index.
+// traceRing and traceRingIdx are written ONLY by the Run goroutine. Every append
+// site runs there: the Run-loop Wait4, handleStop and its dispatch handlers, the
+// resume primitives, and waitForSyscallStop (which is only ever called inline
+// from the Run goroutine — by handleStop's inject paths and by the #399 startup
+// self-probe, which runs during Run() startup, also on the Run goroutine). So no
+// synchronization is needed. dumpTraceRing reads them, also from the Run goroutine
+// (idle tick). The atomic on the index is solely so a future off-goroutine reader
+// could snapshot it safely.
 var (
 	traceRing    [traceRingSize]traceEvent
 	traceRingIdx atomic.Uint64

--- a/internal/ptrace/trace_debug_test.go
+++ b/internal/ptrace/trace_debug_test.go
@@ -149,8 +149,8 @@ func TestReconcileProc_RunningTraceeNotFlagged(t *testing.T) {
 	tr.tracees[os.Getpid()] = &TraceeState{TID: os.Getpid()}
 
 	out := withTrace(t, true, func() {
-		tr.reconcileProc()                              // first scan records lastProcScan
-		tr.lastProcScan = time.Now().Add(-time.Second)  // bypass throttle
+		tr.reconcileProc()                             // first scan records lastProcScan
+		tr.lastProcScan = time.Now().Add(-time.Second) // bypass throttle
 		tr.reconcileProc()
 	})
 	if strings.Contains(out, "WEDGE(v2)") {
@@ -235,3 +235,26 @@ func TestRecoverVanishedTracees_NoneVanished(t *testing.T) {
 	}
 }
 
+func TestEchildBackoff_Escalates(t *testing.T) {
+	// Early spins stay tight (catch transient ECHILD fast); a persistent wedge
+	// backs off and is capped so it never spins at ~200 Hz.
+	if d := echildBackoff(0); d != 5*time.Millisecond {
+		t.Errorf("echildBackoff(0) = %v, want 5ms", d)
+	}
+	if d := echildBackoff(6); d <= 5*time.Millisecond {
+		t.Errorf("echildBackoff(6) = %v, want > 5ms", d)
+	}
+	cap250 := echildBackoff(1000)
+	if cap250 != 250*time.Millisecond {
+		t.Errorf("echildBackoff(1000) = %v, want 250ms cap", cap250)
+	}
+	// Monotonic non-decreasing.
+	prev := time.Duration(0)
+	for n := 0; n <= 40; n++ {
+		d := echildBackoff(n)
+		if d < prev {
+			t.Errorf("echildBackoff(%d)=%v decreased below %v", n, d, prev)
+		}
+		prev = d
+	}
+}

--- a/internal/ptrace/trace_debug_test.go
+++ b/internal/ptrace/trace_debug_test.go
@@ -173,3 +173,65 @@ func TestReconcileProc_Throttled(t *testing.T) {
 		}
 	})
 }
+
+func TestProcExists(t *testing.T) {
+	if !procExists(os.Getpid()) {
+		t.Error("procExists(self) = false, want true")
+	}
+	if procExists(1 << 30) {
+		t.Error("procExists(huge pid) = true, want false")
+	}
+}
+
+// TestRecoverVanishedTracees is the core #2 fix: a tracee that has vanished from
+// /proc (its exit was reaped out from under the tracer) is reaped via handleExit,
+// which unblocks the exec waiting on its exit-notify channel.
+func TestRecoverVanishedTracees(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+
+	const goneTID = 1 << 30 // no such pid → procExists==false
+	tr.tracees[goneTID] = &TraceeState{TID: goneTID, TGID: goneTID, MemFD: -1}
+	exitCh, err := tr.RegisterExitNotify(goneTID)
+	if err != nil {
+		t.Fatalf("RegisterExitNotify: %v", err)
+	}
+
+	// A live tracee (our own pid) must NOT be reaped.
+	livePID := os.Getpid()
+	tr.tracees[livePID] = &TraceeState{TID: livePID, TGID: livePID, MemFD: -1}
+
+	got := tr.recoverVanishedTracees()
+	if got != 1 {
+		t.Fatalf("recoverVanishedTracees() = %d, want 1 (only the vanished tracee)", got)
+	}
+
+	tr.mu.Lock()
+	_, goneStillTracked := tr.tracees[goneTID]
+	_, liveStillTracked := tr.tracees[livePID]
+	tr.mu.Unlock()
+	if goneStillTracked {
+		t.Error("vanished tracee must be removed from t.tracees")
+	}
+	if !liveStillTracked {
+		t.Error("live tracee must NOT be reaped")
+	}
+
+	// The waiter must be unblocked with ExitVanished so the exec doesn't hang.
+	select {
+	case es := <-exitCh:
+		if es.Reason != ExitVanished {
+			t.Errorf("exit notify Reason = %v, want ExitVanished", es.Reason)
+		}
+	default:
+		t.Error("recovery must signal the exit-notify channel (exec would otherwise hang)")
+	}
+}
+
+func TestRecoverVanishedTracees_NoneVanished(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+	tr.tracees[os.Getpid()] = &TraceeState{TID: os.Getpid(), TGID: os.Getpid(), MemFD: -1}
+	if got := tr.recoverVanishedTracees(); got != 0 {
+		t.Errorf("recoverVanishedTracees() = %d, want 0 when all tracees are live", got)
+	}
+}
+

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -298,9 +298,12 @@ type Tracer struct {
 
 	// #369 #2 diagnostic — Run-goroutine-only, no lock. Throttles the /proc
 	// reconciliation scan (see trace_debug.go reconcileProc) and the ECHILD
-	// stolen-exit anomaly log (see onEchildWithTracees).
+	// stolen-exit anomaly log (see onEchildWithTracees). echildSpins counts
+	// consecutive ECHILD-with-tracees ticks that recovered nothing, so the
+	// re-poll backs off instead of spinning at ~200 Hz on a persistent wedge.
 	lastProcScan  time.Time
 	lastEchildLog time.Time
+	echildSpins   int
 
 	stopped chan struct{}
 }
@@ -2000,7 +2003,11 @@ func (t *Tracer) Run(ctx context.Context) error {
 				// ECHILD cannot wedge the loop. Only block efficiently (the
 				// original behaviour) when there are genuinely no tracees left.
 				if t.TraceeCount() > 0 {
-					t.onEchildWithTracees()
+					if t.onEchildWithTracees() > 0 {
+						t.echildSpins = 0
+					} else {
+						t.echildSpins++
+					}
 					select {
 					case <-ctx.Done():
 						return ctx.Err()
@@ -2018,7 +2025,7 @@ func (t *Tracer) Run(ctx context.Context) error {
 						default:
 						}
 					}
-					idleTimer.Reset(5 * time.Millisecond)
+					idleTimer.Reset(echildBackoff(t.echildSpins))
 					continue
 				}
 				select {
@@ -2066,6 +2073,7 @@ func (t *Tracer) Run(ctx context.Context) error {
 			continue
 		}
 
+		t.echildSpins = 0
 		t.traceStop(tid, status)
 		t.handleStop(ctx, tid, status, &rusage)
 	}
@@ -2099,8 +2107,8 @@ func (t *Tracer) serviceAttachReq(req attachRequest) {
 // though we still track tracees. It reaps tracees that have vanished from /proc
 // (recovering stolen exits), surfaces the anomaly at WARN (throttled to once per
 // second so a genuinely-stuck tracee does not spam), and runs the wedge
-// diagnostics. Run goroutine only.
-func (t *Tracer) onEchildWithTracees() {
+// diagnostics. Returns the number of stolen exits recovered. Run goroutine only.
+func (t *Tracer) onEchildWithTracees() int {
 	recovered := t.recoverVanishedTracees()
 
 	now := time.Now()
@@ -2115,6 +2123,24 @@ func (t *Tracer) onEchildWithTracees() {
 
 	t.scanWedged()
 	t.reconcileProc()
+	return recovered
+}
+
+// echildBackoff maps the count of consecutive ECHILD-with-tracees ticks that
+// recovered nothing to a re-poll delay. Early ticks stay at 5ms so a transient
+// ECHILD or a freshly-vanished tracee is caught fast; a persistent wedge (no
+// recovery possible) backs off to 250ms so the loop doesn't spin at ~200 Hz.
+func echildBackoff(spins int) time.Duration {
+	switch {
+	case spins <= 4:
+		return 5 * time.Millisecond
+	case spins <= 8:
+		return 25 * time.Millisecond
+	case spins <= 16:
+		return 100 * time.Millisecond
+	default:
+		return 250 * time.Millisecond
+	}
 }
 
 // recoverVanishedTracees reaps tracees that have vanished from /proc. When

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -297,8 +297,10 @@ type Tracer struct {
 	hasSyscallInfo bool // true if PTRACE_GET_SYSCALL_INFO is supported (Linux 5.3+)
 
 	// #369 #2 diagnostic — Run-goroutine-only, no lock. Throttles the /proc
-	// reconciliation scan (see trace_debug.go reconcileProc).
-	lastProcScan time.Time
+	// reconciliation scan (see trace_debug.go reconcileProc) and the ECHILD
+	// stolen-exit anomaly log (see onEchildWithTracees).
+	lastProcScan  time.Time
+	lastEchildLog time.Time
 
 	stopped chan struct{}
 }
@@ -1987,18 +1989,45 @@ func (t *Tracer) Run(ctx context.Context) error {
 				continue
 			}
 			if err == unix.ECHILD {
+				// ECHILD means the kernel reports no waitable children/tracees.
+				// If we still track tracees, this is the #369 #2 stolen-exit
+				// anomaly: the child's exit was reaped out from under us (Go
+				// runtime / cmd.Wait racing our Wait4 — see attachThread), so
+				// handleExit never ran and the exec's waitFn blocks forever on
+				// its exit channel. Recover instead of parking: reap tracees that
+				// have vanished from /proc (which unblocks their waiters), run the
+				// wedge diagnostics, and re-poll on the idle timer so a transient
+				// ECHILD cannot wedge the loop. Only block efficiently (the
+				// original behaviour) when there are genuinely no tracees left.
+				if t.TraceeCount() > 0 {
+					t.onEchildWithTracees()
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-t.stopped:
+						return nil
+					case req := <-t.attachQueue:
+						t.serviceAttachReq(req)
+					case req := <-t.resumeQueue:
+						t.handleResumeRequest(req)
+					case <-idleTimer.C:
+					}
+					if !idleTimer.Stop() {
+						select {
+						case <-idleTimer.C:
+						default:
+						}
+					}
+					idleTimer.Reset(5 * time.Millisecond)
+					continue
+				}
 				select {
 				case <-ctx.Done():
 					return ctx.Err()
 				case <-t.stopped:
 					return nil
 				case req := <-t.attachQueue:
-					if err := t.attachProcess(req.pid, req.opts); err != nil {
-						slog.Error("attach from queue failed", "pid", req.pid, "error", err)
-						t.signalAttachDone(req.pid, err)
-					} else {
-						t.signalAttachDone(req.pid, nil)
-					}
+					t.serviceAttachReq(req)
 					continue
 				case req := <-t.resumeQueue:
 					t.handleResumeRequest(req)
@@ -2054,6 +2083,64 @@ func (t *Tracer) Stop() {
 	default:
 		close(t.stopped)
 	}
+}
+
+// serviceAttachReq processes one queued attach request and signals its waiter.
+func (t *Tracer) serviceAttachReq(req attachRequest) {
+	if err := t.attachProcess(req.pid, req.opts); err != nil {
+		slog.Error("attach from queue failed", "pid", req.pid, "error", err)
+		t.signalAttachDone(req.pid, err)
+	} else {
+		t.signalAttachDone(req.pid, nil)
+	}
+}
+
+// onEchildWithTracees handles the #369 #2 anomaly: Wait4(-1) returned ECHILD even
+// though we still track tracees. It reaps tracees that have vanished from /proc
+// (recovering stolen exits), surfaces the anomaly at WARN (throttled to once per
+// second so a genuinely-stuck tracee does not spam), and runs the wedge
+// diagnostics. Run goroutine only.
+func (t *Tracer) onEchildWithTracees() {
+	recovered := t.recoverVanishedTracees()
+
+	now := time.Now()
+	if now.Sub(t.lastEchildLog) >= time.Second {
+		t.lastEchildLog = now
+		slog.Warn("ptrace: Wait4 ECHILD while tracees tracked — stolen-exit/wedge anomaly (#369 #2)",
+			"tracee_count", t.TraceeCount(), "recovered", recovered)
+		if ptraceTraceOn() {
+			t.dumpTraceRing("echild-with-tracees")
+		}
+	}
+
+	t.scanWedged()
+	t.reconcileProc()
+}
+
+// recoverVanishedTracees reaps tracees that have vanished from /proc. When
+// Wait4(-1) returns ECHILD but we still track a tracee, that tracee's exit was
+// reaped out from under us (Go runtime / cmd.Wait racing our Wait4 — see
+// attachThread). Our handleExit never ran, so its exit notification never fired
+// and the exec's waitFn blocks forever on its exit channel. Synthesize the exit
+// (ExitVanished) so the waiter unblocks. Returns the count recovered.
+func (t *Tracer) recoverVanishedTracees() int {
+	t.mu.Lock()
+	tids := make([]int, 0, len(t.tracees))
+	for tid := range t.tracees {
+		tids = append(tids, tid)
+	}
+	t.mu.Unlock()
+
+	recovered := 0
+	for _, tid := range tids {
+		if procExists(tid) {
+			continue // still present (running or ptrace-stopped) — not a stolen exit
+		}
+		slog.Warn("ptrace: recovering stolen exit — tracee vanished from /proc under ECHILD (#369 #2)", "tid", tid)
+		t.handleExit(tid, unix.WaitStatus(0), nil, ExitVanished)
+		recovered++
+	}
+	return recovered
 }
 
 func (t *Tracer) drainQueues(ctx context.Context) error {


### PR DESCRIPTION
## Root cause (finally pinned)

erans's rc11 goroutine dump pinned the FUSE-on hang. `Tracer.Run` was parked in the **`Wait4` ECHILD branch** for 14 min while an exec's `waitFn` blocked on its exit channel and **35 execs piled up** behind the held session mutex.

The dump's `exec_ptrace_linux.go:58` is `status := <-exitCh` — the **exit-wait**, reached only *after* `WaitAttached` succeeds. So attach is fine; the traced child's exit was **reaped out from under the tracer** (the Go runtime / `cmd.Wait` racing our `Wait4` — a race already documented at `attachThread`, `attach.go:65-67`). `Wait4(-1)` then returned **ECHILD**, `handleExit` never ran, the exit notification never fired, and the exec hung forever.

Two latent gaps turned that into a hard wedge:
1. The **ECHILD branch had no re-poll timer** (the `tid==0` idle branch does) — it blocked on `ctx/stopped/attachQueue/resumeQueue` and parked indefinitely.
2. The wedge diagnostics (`scanWedged`/`reconcileProc`) only ran in the `tid==0` branch, so v1/v2 were structurally blind to a loop parked on ECHILD.

## Fix

When `Wait4(-1)` returns ECHILD **but we still track tracees**:
- **`recoverVanishedTracees()`** reaps any tracee that has vanished from `/proc` via `handleExit(ExitVanished)` — which fires its exit notification and **unblocks the waiting exec** instead of hanging until SIGQUIT.
- **Re-poll on the idle timer** instead of parking, so a transient ECHILD can't wedge the loop. A backoff (5ms → 25/100/250ms cap) avoids a busy-spin when a tracee is genuinely stuck-but-present.
- Run the wedge diagnostics + a throttled (1/s) anomaly `WARN` + ring dump there.

Genuine idle (no tracees) still blocks efficiently on `attachQueue`. The recovery + re-poll run **unconditionally** (the actual remedy); the ring dump stays gated by `AGENTSH_PTRACE_TRACE`. Adds `procExists()`, `serviceAttachReq()`, `echildBackoff()`.

## Verification

- `go test -race ./internal/ptrace/` ✅ — `recoverVanishedTracees` reaps the `/proc`-gone tracee and signals `ExitVanished` on its notify channel while leaving a live tracee tracked; none-vanished is a no-op; `echildBackoff` escalates/caps; `procExists` self/missing.
- `go build ./...` ✅, `GOOS=windows go build ./...` ✅, `go vet` ✅.
- **End-to-end (erans):** the FUSE-on hang should now self-recover — execs unblock (exit code reported as vanished for a stolen exit) instead of hanging, and the session-mutex pile-up clears. With `AGENTSH_PTRACE_TRACE=1`, a `Wait4 ECHILD while tracees tracked` WARN + ring dump confirms the path; `recovered=N` shows stolen exits reclaimed.

Fixes the #2 hang for #369. (roborev: only Lows; two pre-existing/already-tracked, two addressed here.)

Refs #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)