### PR TITLE
fix(#369 #2): re-poll the idle ECHILD park + reconcile pending exit-notifies

### DIFF
--- a/internal/ptrace/trace_debug.go
+++ b/internal/ptrace/trace_debug.go
@@ -62,6 +62,7 @@ const (
 	evWaitRet                        // wait4 returned
 	evStop                           // a stop was dispatched to handleStop
 	evResume                         // a resume/park was issued
+	evNote                           // a milestone note (attach handshake, exit-notify, park)
 )
 
 func (k traceEventKind) String() string {
@@ -74,6 +75,8 @@ func (k traceEventKind) String() string {
 		return "stop"
 	case evResume:
 		return "resume"
+	case evNote:
+		return "note"
 	default:
 		return "?"
 	}
@@ -190,6 +193,16 @@ func (t *Tracer) traceResume(tid int, via string, sig int) {
 		s.awaitingResume = false
 	}
 	t.mu.Unlock()
+}
+
+// traceNote records a milestone (attach handshake step, exit-notify event, idle
+// park) to the ring. `layer` is the category ("attach"/"exit"/"idle"), `msg` a
+// short literal, `id` the relevant pid/tid. Call from the Run goroutine.
+func traceNote(layer, msg string, id int) {
+	if !ptraceTraceOn() {
+		return
+	}
+	ringAppend(traceEvent{kind: evNote, tid: id, layer: layer, via: msg})
 }
 
 // scanWedged is the v1 (consumed-but-not-resumed) alarm, retained as a secondary
@@ -319,6 +332,8 @@ func (t *Tracer) dumpTraceRing(reason string) {
 				"status", describeWaitStatus(unix.WaitStatus(ev.status)))
 		case evResume:
 			slog.Warn("ptrace-trace", "seq", ev.seq, "us", offUs, "ev", "resume", "tid", ev.tid, "via", ev.via, "sig", ev.arg)
+		case evNote:
+			slog.Warn("ptrace-trace", "seq", ev.seq, "us", offUs, "ev", "note", "layer", ev.layer, "msg", ev.via, "id", ev.tid)
 		}
 	}
 	slog.Warn("ptrace-trace ring DUMP END", "reason", reason)

--- a/internal/ptrace/trace_debug_test.go
+++ b/internal/ptrace/trace_debug_test.go
@@ -235,6 +235,69 @@ func TestRecoverVanishedTracees_NoneVanished(t *testing.T) {
 	}
 }
 
+func TestHasPendingExitNotify(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+	if tr.hasPendingExitNotify() {
+		t.Error("fresh tracer must have no pending exit notifications")
+	}
+	if _, err := tr.RegisterExitNotify(4321); err != nil {
+		t.Fatalf("RegisterExitNotify: %v", err)
+	}
+	if !tr.hasPendingExitNotify() {
+		t.Error("hasPendingExitNotify must be true after a registration")
+	}
+}
+
+// TestReconcileExitNotify is the rc13 fix: an exec whose registered pid has
+// vanished from /proc (exit never delivered) is unblocked with ExitVanished,
+// while a live registration is left intact.
+func TestReconcileExitNotify(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+
+	const goneTID = 1 << 30 // no such pid
+	goneCh, err := tr.RegisterExitNotify(goneTID)
+	if err != nil {
+		t.Fatalf("register gone: %v", err)
+	}
+	liveCh, err := tr.RegisterExitNotify(os.Getpid())
+	if err != nil {
+		t.Fatalf("register live: %v", err)
+	}
+
+	tr.lastExitRecon = time.Time{} // bypass throttle
+	if got := tr.reconcileExitNotify(); got != 1 {
+		t.Fatalf("reconcileExitNotify() = %d, want 1 (only the vanished pid)", got)
+	}
+
+	select {
+	case es := <-goneCh:
+		if es.Reason != ExitVanished {
+			t.Errorf("vanished exec Reason = %v, want ExitVanished", es.Reason)
+		}
+	default:
+		t.Error("vanished registration must be signalled (exec would otherwise hang)")
+	}
+	select {
+	case <-liveCh:
+		t.Error("live registration must NOT be signalled")
+	default:
+	}
+	if tr.hasPendingExitNotify() == false {
+		t.Error("live registration must remain pending after reconcile")
+	}
+}
+
+func TestReconcileExitNotify_Throttled(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+	tr.lastExitRecon = time.Now() // within throttle window
+	if _, err := tr.RegisterExitNotify(1 << 30); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	if got := tr.reconcileExitNotify(); got != 0 {
+		t.Errorf("reconcileExitNotify must no-op within the throttle window, got %d", got)
+	}
+}
+
 func TestEchildBackoff_Escalates(t *testing.T) {
 	// Early spins stay tight (catch transient ECHILD fast); a persistent wedge
 	// backs off and is capped so it never spins at ~200 Hz.

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -304,6 +304,8 @@ type Tracer struct {
 	lastProcScan  time.Time
 	lastEchildLog time.Time
 	echildSpins   int
+	lastExitRecon time.Time
+	idleParkLog   time.Time
 
 	stopped chan struct{}
 }
@@ -536,6 +538,7 @@ func (t *Tracer) RegisterExitNotify(pid int) (<-chan ExitStatus, error) {
 	if loaded {
 		return nil, fmt.Errorf("exit notify already registered for pid %d", pid)
 	}
+	traceNote("exit", "register", pid)
 	return ch, nil
 }
 
@@ -1786,6 +1789,7 @@ func (t *Tracer) handleExit(tid int, status unix.WaitStatus, rusage *unix.Rusage
 			} else if status.Signaled() {
 				es.Signal = int(status.Signal())
 			}
+			traceNote("exit", "notify", tgid)
 			ch <- es
 		}
 		if t.fds != nil {
@@ -2028,6 +2032,37 @@ func (t *Tracer) Run(ctx context.Context) error {
 					idleTimer.Reset(echildBackoff(t.echildSpins))
 					continue
 				}
+				// No tracees tracked. An exec may still be blocked on an
+				// exit-notify channel for a child whose exit we never saw (it
+				// vanished from /proc — reaped before we did). Reconcile pending
+				// exit-notify registrations against /proc and unblock any whose
+				// pid is gone. While execs are still pending, re-poll on a timer
+				// so a lost attach/resume wakeup can never wedge the loop here
+				// (this no-timer park is where rc10–rc12 hung — #369 #2). Only
+				// block indefinitely when nothing at all is in flight.
+				t.reconcileExitNotify()
+				if t.hasPendingExitNotify() {
+					t.onIdleParkWithPending()
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-t.stopped:
+						return nil
+					case req := <-t.attachQueue:
+						t.serviceAttachReq(req)
+					case req := <-t.resumeQueue:
+						t.handleResumeRequest(req)
+					case <-idleTimer.C:
+					}
+					if !idleTimer.Stop() {
+						select {
+						case <-idleTimer.C:
+						default:
+						}
+					}
+					idleTimer.Reset(idleEchildRepoll)
+					continue
+				}
 				select {
 				case <-ctx.Done():
 					return ctx.Err()
@@ -2095,21 +2130,98 @@ func (t *Tracer) Stop() {
 
 // serviceAttachReq processes one queued attach request and signals its waiter.
 func (t *Tracer) serviceAttachReq(req attachRequest) {
+	traceNote("attach", "recv", req.pid)
 	if err := t.attachProcess(req.pid, req.opts); err != nil {
 		slog.Error("attach from queue failed", "pid", req.pid, "error", err)
+		traceNote("attach", "attach-failed", req.pid)
 		t.signalAttachDone(req.pid, err)
 	} else {
+		traceNote("attach", "attached", req.pid)
 		t.signalAttachDone(req.pid, nil)
+	}
+}
+
+// idleEchildRepoll is how often the genuine-idle (no tracees) ECHILD path
+// re-polls Wait4 while execs are still pending, so a lost attach/resume wakeup
+// or a vanished-but-registered exec cannot wedge the loop. Slower than the
+// active 5ms tick because nothing is running to wait on.
+const idleEchildRepoll = 50 * time.Millisecond
+
+// hasPendingExitNotify reports whether any exec is still waiting on an
+// exit-notify channel (i.e. there is in-flight work the loop must not abandon).
+func (t *Tracer) hasPendingExitNotify() bool {
+	pending := false
+	t.exitNotify.Range(func(_, _ any) bool {
+		pending = true
+		return false
+	})
+	return pending
+}
+
+// reconcileExitNotify unblocks execs whose child has vanished. When an exec's
+// registered pid no longer exists in /proc but its exit was never delivered to
+// us (reaped out from under the tracer, or processed without firing the notify),
+// the exec's waitFn blocks forever. Signal ExitVanished for any registered pid
+// that is gone from /proc. This is the no-tracee analog of recoverVanishedTracees
+// and targets the rc12 wedge where the loop parks idle (TraceeCount==0) while an
+// exec is still waiting (#369 #2). Throttled. Returns the count recovered.
+func (t *Tracer) reconcileExitNotify() int {
+	now := time.Now()
+	if now.Sub(t.lastExitRecon) < 200*time.Millisecond {
+		return 0
+	}
+	t.lastExitRecon = now
+
+	var gone []int
+	t.exitNotify.Range(func(k, _ any) bool {
+		pid, ok := k.(int)
+		if ok && !procExists(pid) {
+			gone = append(gone, pid)
+		}
+		return true
+	})
+
+	recovered := 0
+	for _, pid := range gone {
+		v, ok := t.exitNotify.LoadAndDelete(pid)
+		if !ok {
+			continue // handleExit won the race and already delivered the real exit
+		}
+		slog.Warn("ptrace: recovering vanished exec — registered pid gone from /proc, no exit delivered (#369 #2)", "pid", pid)
+		traceNote("exit", "recover-vanished", pid)
+		select {
+		case v.(chan ExitStatus) <- ExitStatus{PID: pid, Reason: ExitVanished}:
+		default:
+		}
+		recovered++
+	}
+	return recovered
+}
+
+// onIdleParkWithPending surfaces the suspicious case where the loop is about to
+// park idle (no tracees) while execs are still pending — the rc10–rc12 wedge
+// shape. Throttled to once/second; dumps the trace ring when tracing is enabled.
+func (t *Tracer) onIdleParkWithPending() {
+	now := time.Now()
+	if now.Sub(t.idleParkLog) < time.Second {
+		return
+	}
+	t.idleParkLog = now
+	slog.Warn("ptrace: idle ECHILD park with execs still pending — re-polling (#369 #2)")
+	if ptraceTraceOn() {
+		t.dumpTraceRing("idle-echild-pending")
 	}
 }
 
 // onEchildWithTracees handles the #369 #2 anomaly: Wait4(-1) returned ECHILD even
 // though we still track tracees. It reaps tracees that have vanished from /proc
-// (recovering stolen exits), surfaces the anomaly at WARN (throttled to once per
-// second so a genuinely-stuck tracee does not spam), and runs the wedge
-// diagnostics. Returns the number of stolen exits recovered. Run goroutine only.
+// (recovering stolen exits), also reconciles pending exit-notify registrations,
+// surfaces the anomaly at WARN (throttled to once per second so a genuinely-stuck
+// tracee does not spam), and runs the wedge diagnostics. Returns the number of
+// stolen exits recovered. Run goroutine only.
 func (t *Tracer) onEchildWithTracees() int {
 	recovered := t.recoverVanishedTracees()
+	recovered += t.reconcileExitNotify()
 
 	now := time.Now()
 	if now.Sub(t.lastEchildLog) >= time.Second {

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -2088,12 +2088,7 @@ func (t *Tracer) Run(ctx context.Context) error {
 			case <-t.stopped:
 				return nil
 			case req := <-t.attachQueue:
-				if err := t.attachProcess(req.pid, req.opts); err != nil {
-					slog.Error("attach from queue failed", "pid", req.pid, "error", err)
-					t.signalAttachDone(req.pid, err)
-				} else {
-					t.signalAttachDone(req.pid, nil)
-				}
+				t.serviceAttachReq(req)
 			case req := <-t.resumeQueue:
 				t.handleResumeRequest(req)
 			case <-idleTimer.C:
@@ -2289,12 +2284,7 @@ func (t *Tracer) drainQueues(ctx context.Context) error {
 		case <-t.stopped:
 			return fmt.Errorf("tracer stopped")
 		case req := <-t.attachQueue:
-			if err := t.attachProcess(req.pid, req.opts); err != nil {
-				slog.Error("attach from queue failed", "pid", req.pid, "error", err)
-				t.signalAttachDone(req.pid, err)
-			} else {
-				t.signalAttachDone(req.pid, nil)
-			}
+			t.serviceAttachReq(req)
 		case req := <-t.resumeQueue:
 			t.handleResumeRequest(req)
 		default:


### PR DESCRIPTION
## Why rc12 missed

erans's rc12 dump showed `Tracer.Run` parked **11 min** in the ECHILD select for `TraceeCount()==0` (the genuine-idle branch) — the one select with **no re-poll timer**. rc12's recovery/re-poll lives behind `TraceeCount()>0`, so the loop parks *before* reaching it (`ECHILD count=0`, `recovering stolen exit=0`). That no-timer park is also where rc10/rc11 wedged.

And at that park `TraceeCount()==0`, so `recoverVanishedTracees` (iterates `t.tracees`) has nothing to reap — yet an exec is still blocked on `exitNotify[pid]` for a child that's no longer tracked. So a timer alone wouldn't unblock it.

## Fix

1. **`reconcileExitNotify`** — scan pending exit-notify registrations; any `pid` gone from `/proc` gets `ExitVanished`, unblocking the hung exec **even when it's no longer a tracee**. The no-tracee analog of `recoverVanishedTracees`. Throttled (200ms); races safely with `handleExit` via `LoadAndDelete`. Also runs in the `TraceeCount()>0` path.
2. **Idle ECHILD re-poll** — the genuine-idle select now re-polls on a 50ms timer **while execs are still pending** (`hasPendingExitNotify`), so a lost attach/resume wakeup or a vanished-but-registered exec can't wedge the loop there. With nothing in flight it still blocks efficiently.

## Instrumentation (backstop if another layer remains)

Trace-ring `note` events for the **attach handshake** (`recv`/`attached`/`attach-failed`, now via `serviceAttachReq` from *all* attach sites), the **exit-notify lifecycle** (`register`/`notify`/`recover-vanished`), and a throttled **idle-park-with-pending** WARN + ring dump. So if the hang persists, the next `AGENTSH_PTRACE_TRACE=1` dump shows the last `Wait4` result before the park and whether attach/exit-notify completed.

## Verification

- `go test -race ./internal/ptrace/` ✅ — `reconcileExitNotify` signals `ExitVanished` for the vanished pid, leaves the live one, throttles; `hasPendingExitNotify`; (plus the rc12 recovery/backoff tests). `go build ./...` ✅, `GOOS=windows` ✅, `vet` ✅.
- **End-to-end (erans):** the sequential FUSE-on hang should now self-recover — a vanished exec is unblocked (`recovering vanished exec ... pid=…`) and the idle select can no longer park indefinitely with execs pending. If anything still wedges, `AGENTSH_PTRACE_TRACE=1` now dumps the attach/exit/wait history.

roborev: only Lows (two pre-existing/tracked; the `serviceAttachReq` dedup addressed).

Refs #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)