### PR TITLE
fix(#369 #2): external watchdog recovers ptrace-stopped-but-unadvanced tracees

### DIFF
--- a/internal/ptrace/attach.go
+++ b/internal/ptrace/attach.go
@@ -41,6 +41,7 @@ func (t *Tracer) attachProcess(pid int, opts attachOpts) error {
 }
 
 func (t *Tracer) attachThread(tid int, opts attachOpts) error {
+	traceNote("attach", "seize", tid)
 	err := unix.PtraceSeize(tid)
 	if err != nil {
 		reason := "other"
@@ -68,7 +69,9 @@ func (t *Tracer) attachThread(tid int, opts attachOpts) error {
 	var status unix.WaitStatus
 	deadline := time.Now().Add(2 * time.Second)
 	for {
+		traceWaitCall("attach", tid)
 		wpid, werr := unix.Wait4(tid, &status, unix.WNOHANG|unix.WALL, nil)
+		traceWaitRet("attach", wpid, status, werr)
 		if werr != nil {
 			if werr == unix.EINTR {
 				continue
@@ -194,7 +197,9 @@ func (t *Tracer) safeDetach(tid int) {
 	var status unix.WaitStatus
 	deadline := time.Now().Add(500 * time.Millisecond)
 	for {
+		traceWaitCall("detach", tid)
 		wpid, err := unix.Wait4(tid, &status, unix.WNOHANG|unix.WALL, nil)
+		traceWaitRet("detach", wpid, status, err)
 		if err != nil {
 			// Wait4 failed — try best-effort detach.
 			unix.PtraceDetach(tid)

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -207,6 +207,11 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 	deadline := time.Now().Add(timeout)
 	stopEvents := 0
 	for {
+		// Refresh the Run-loop heartbeat: an active inject poll is real progress,
+		// so a multi-second inject must not make the watchdog think the loop is
+		// wedged and heal an unrelated tracee (#369 #2). The idle-spin wedge never
+		// runs this loop, so it still goes stale and is healed.
+		t.lastProgressNanos.Store(time.Now().UnixNano())
 		if time.Now().After(deadline) {
 			return fmt.Errorf("waitForSyscallStop tid %d: timed out after %v", tid, timeout)
 		}

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -811,10 +811,16 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 	// #369 #2 watchdog coordination: record that the Run loop is making progress
 	// (handling a stop), mark the tid it is actively servicing so the watchdog
 	// never heals a tracee mid-handling, and clear the listening flag — any stop
-	// event means the tracee is no longer idly held in PTRACE_LISTEN.
+	// event means the tracee is no longer idly held in PTRACE_LISTEN. The
+	// heartbeat is refreshed on exit too (and inside the inject poll loop, see
+	// waitForSyscallStop) so a long-but-progressing handleStop never looks
+	// stale; only the idle-spin wedge (no handleStop at all) goes stale.
 	t.lastProgressNanos.Store(time.Now().UnixNano())
 	t.currentHandlingTID.Store(int64(tid))
-	defer t.currentHandlingTID.Store(0)
+	defer func() {
+		t.currentHandlingTID.Store(0)
+		t.lastProgressNanos.Store(time.Now().UnixNano())
+	}()
 	t.mu.Lock()
 	if s := t.tracees[tid]; s != nil {
 		s.listening = false

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -306,6 +306,10 @@ type Tracer struct {
 	echildSpins   int
 	lastExitRecon time.Time
 	idleParkLog   time.Time
+	// runThreadTID is the OS thread id (gettid) the Run loop is locked to, set
+	// once at Run start. The watchdog logs it so a stop owned by a different
+	// thread than this one is visible in the dump (#369 #2).
+	runThreadTID int
 
 	stopped chan struct{}
 }
@@ -1950,6 +1954,13 @@ func (t *Tracer) Run(ctx context.Context) error {
 	defer t.cancelPendingExitWaiters()
 
 	initPtraceTrace()
+	t.runThreadTID = unix.Gettid()
+
+	// External wedge watchdog (#369 #2): detects ptrace-stopped-but-unadvanced
+	// tracees by /proc ground truth from OUTSIDE this loop, and force-recovers
+	// them so a blocked exec returns instead of hanging. Runs for the lifetime
+	// of the tracer.
+	go t.runStuckTraceeWatchdog(ctx)
 
 	t.hasSyscallInfo = probePtraceSyscallInfo()
 	if t.hasSyscallInfo {

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/sys/unix"
@@ -215,6 +216,12 @@ type TraceeState struct {
 	// persists past the threshold we dump the trace ring and set procWedgeLogged.
 	procStuckSince  time.Time
 	procWedgeLogged bool
+	// listening is true while this tracee is held in PTRACE_LISTEN (a job-control
+	// group-stop the tracer is deliberately letting sit). Such tracees are
+	// legitimately stopped indefinitely, so the watchdog must NOT treat them as
+	// wedged. Set before ptraceListen, cleared when the tracee is next handled.
+	// Guarded by t.mu. (#369 #2)
+	listening bool
 }
 
 type resumeRequest struct {
@@ -310,6 +317,13 @@ type Tracer struct {
 	// once at Run start. The watchdog logs it so a stop owned by a different
 	// thread than this one is visible in the dump (#369 #2).
 	runThreadTID int
+	// lastProgressNanos is updated on every dispatched stop; the watchdog only
+	// heals when it is stale (the Run loop is genuinely not progressing), so a
+	// busy-but-progressing loop never trips the killer. currentHandlingTID is
+	// the tid the Run loop is actively in handleStop for; the watchdog never
+	// heals it (avoids killing a tracee mid-handling). Both are #369 #2.
+	lastProgressNanos  atomic.Int64
+	currentHandlingTID atomic.Int64
 
 	stopped chan struct{}
 }
@@ -794,6 +808,19 @@ func (t *Tracer) applyReturnOverride(tid int, retval int64) {
 
 // handleStop dispatches a tracee stop event.
 func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus, rusage *unix.Rusage) {
+	// #369 #2 watchdog coordination: record that the Run loop is making progress
+	// (handling a stop), mark the tid it is actively servicing so the watchdog
+	// never heals a tracee mid-handling, and clear the listening flag — any stop
+	// event means the tracee is no longer idly held in PTRACE_LISTEN.
+	t.lastProgressNanos.Store(time.Now().UnixNano())
+	t.currentHandlingTID.Store(int64(tid))
+	defer t.currentHandlingTID.Store(0)
+	t.mu.Lock()
+	if s := t.tracees[tid]; s != nil {
+		s.listening = false
+	}
+	t.mu.Unlock()
+
 	switch {
 	case status.Exited() || status.Signaled():
 		t.handleExit(tid, status, rusage, ExitNormal)
@@ -891,6 +918,11 @@ func (t *Tracer) handleStop(ctx context.Context, tid int, status unix.WaitStatus
 					break
 				}
 
+				t.mu.Lock()
+				if s := t.tracees[tid]; s != nil {
+					s.listening = true // watchdog must not treat a LISTEN'd group-stop as wedged (#369 #2)
+				}
+				t.mu.Unlock()
 				ptraceListen(tid)
 				t.traceResume(tid, "listen", 0)
 				break
@@ -1955,6 +1987,7 @@ func (t *Tracer) Run(ctx context.Context) error {
 
 	initPtraceTrace()
 	t.runThreadTID = unix.Gettid()
+	t.lastProgressNanos.Store(time.Now().UnixNano())
 
 	// External wedge watchdog (#369 #2): detects ptrace-stopped-but-unadvanced
 	// tracees by /proc ground truth from OUTSIDE this loop, and force-recovers

--- a/internal/ptrace/watchdog_linux.go
+++ b/internal/ptrace/watchdog_linux.go
@@ -1,0 +1,171 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+// #369 #2: external wedge watchdog.
+//
+// Every prior diagnostic/fix (rc10–rc13) observed and acted from INSIDE the Run
+// loop — which is exactly the goroutine that parks when the wedge occurs, so it
+// was structurally blind: WEDGE alarms never fired, ring dumps never triggered,
+// and the ECHILD recovery was never reached. This watchdog runs on its OWN
+// goroutine and detects the wedge by /proc GROUND TRUTH, independent of where
+// the Run loop is parked.
+//
+// Mechanism: a tracee we still track that the kernel reports ptrace-stopped
+// (State 't'/'T') with TracerPid == our process, for longer than a threshold,
+// means the Run loop is failing to advance it (a stop was consumed but never
+// resumed, or never re-reported by wait4). Normal ptrace stops are serviced in
+// microseconds; seconds in 't' is always a wedge (parked/keep-stopped tracees,
+// which legitimately sit stopped awaiting approval/resume, are excluded).
+//
+// On detection the watchdog (1) logs it and, when AGENTSH_PTRACE_TRACE is set,
+// dumps the trace ring to pin the mechanism, and (2) self-heals after a longer
+// grace period: SIGKILL the wedged tracee (releasing the leaked ptrace-stop so
+// the Run loop reaps it and runs proper cleanup on its own thread) and fire the
+// blocked exec's exit-notify directly, so the exec returns instead of hanging.
+
+const (
+	watchdogTick      = 1 * time.Second
+	watchdogDiagAfter = 3 * time.Second  // log + ring dump (observe)
+	watchdogHealAfter = 15 * time.Second // SIGKILL + unblock the waiting exec (recover)
+)
+
+// runStuckTraceeWatchdog is the watchdog goroutine. It must NOT LockOSThread:
+// it has to stay schedulable on any OS thread, independent of the (possibly
+// wedged) Run-loop thread. Started from Run.
+func (t *Tracer) runStuckTraceeWatchdog(ctx context.Context) {
+	ticker := time.NewTicker(watchdogTick)
+	defer ticker.Stop()
+	stuckSince := make(map[int]time.Time) // tid -> first observed ptrace-stuck
+	diagged := make(map[int]bool)         // tid -> diagnostic already emitted
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.stopped:
+			return
+		case <-ticker.C:
+		}
+		t.scanStuckTracees(stuckSince, diagged)
+	}
+}
+
+// scanStuckTracees does one /proc sweep of tracked (non-parked) tracees, logging
+// and healing any that have been ptrace-stopped past the thresholds. The
+// stuckSince/diagged maps carry state across ticks (watchdog goroutine only).
+func (t *Tracer) scanStuckTracees(stuckSince map[int]time.Time, diagged map[int]bool) {
+	myPid := os.Getpid()
+	now := time.Now()
+
+	// Snapshot tracked tids, skipping intentionally-parked tracees (keepStopped
+	// for the cgroup hook, or parked awaiting approval) — those are stopped on
+	// purpose and must not be reaped by the watchdog.
+	t.mu.Lock()
+	tids := make([]int, 0, len(t.tracees))
+	for tid := range t.tracees {
+		if _, parked := t.parkedTracees[tid]; parked {
+			continue
+		}
+		tids = append(tids, tid)
+	}
+	t.mu.Unlock()
+
+	live := make(map[int]bool, len(tids))
+	for _, tid := range tids {
+		live[tid] = true
+		state, tracerPid, ok := readProcStopState(tid)
+		stuck := ok && (state == 't' || state == 'T') && tracerPid == myPid
+		if !stuck {
+			delete(stuckSince, tid)
+			delete(diagged, tid)
+			continue
+		}
+		if stuckSince[tid].IsZero() {
+			stuckSince[tid] = now
+		}
+		dur := now.Sub(stuckSince[tid])
+
+		if dur >= watchdogDiagAfter && !diagged[tid] {
+			diagged[tid] = true
+			slog.Warn("ptrace WATCHDOG: tracee ptrace-stopped but Run loop not advancing it (#369 #2)",
+				"tid", tid, "proc_state", string(rune(state)),
+				"syscall", procSyscallSummary(tid), "stuck_ms", dur.Milliseconds(),
+				"run_thread_tid", t.runThreadTID, "watchdog_tid", unix.Gettid())
+			if ptraceTraceOn() {
+				t.dumpTraceRing(fmt.Sprintf("watchdog tid=%d stuck=%dms", tid, dur.Milliseconds()))
+			}
+		}
+
+		if dur >= watchdogHealAfter {
+			t.healStuckTracee(tid)
+			delete(stuckSince, tid)
+			delete(diagged, tid)
+		}
+	}
+
+	// Drop bookkeeping for tids no longer tracked.
+	for tid := range stuckSince {
+		if !live[tid] {
+			delete(stuckSince, tid)
+			delete(diagged, tid)
+		}
+	}
+}
+
+// healStuckTracee force-recovers a wedged tracee from OFF the Run thread. It does
+// only goroutine-safe operations: Tgkill (no ptrace ownership required) and a
+// sync.Map LoadAndDelete + non-blocking channel send. It deliberately does NOT
+// call handleExit (which mutates Run-goroutine-only state like t.fds and the
+// scratch maps); instead the SIGKILL makes the tracee exit, and the Run loop's
+// wait4 reaps it and runs handleExit properly on its own thread. The direct
+// exit-notify fire unblocks the waiting exec immediately, and LoadAndDelete
+// makes the later handleExit a no-op so there is no double-send.
+func (t *Tracer) healStuckTracee(tid int) {
+	t.mu.Lock()
+	state := t.tracees[tid]
+	tgid := tid
+	if state != nil {
+		tgid = state.TGID
+	}
+	t.mu.Unlock()
+
+	slog.Warn("ptrace WATCHDOG: force-recovering wedged tracee — SIGKILL + unblock exec (#369 #2)",
+		"tid", tid, "tgid", tgid)
+
+	// Release the leaked ptrace-stop. SIGKILL is fatal even under ptrace; the
+	// Run loop's wait4 then sees the exit and cleans up on its own thread.
+	if err := unix.Tgkill(tgid, tid, unix.SIGKILL); err != nil {
+		slog.Warn("ptrace WATCHDOG: SIGKILL failed", "tid", tid, "tgid", tgid, "error", err)
+	}
+
+	// Unblock the blocked exec immediately rather than waiting for the reap.
+	if v, ok := t.exitNotify.LoadAndDelete(tgid); ok {
+		select {
+		case v.(chan ExitStatus) <- ExitStatus{PID: tgid, Reason: ExitVanished}:
+		default:
+		}
+	}
+}
+
+// procSyscallSummary reads /proc/<tid>/syscall for the watchdog diagnostic: the
+// current syscall number + args while in-kernel, or "running"/"-1 ..." between
+// syscalls. Best-effort; returns "?" on error.
+func procSyscallSummary(tid int) string {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(tid) + "/syscall")
+	if err != nil {
+		return "?"
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/internal/ptrace/watchdog_linux.go
+++ b/internal/ptrace/watchdog_linux.go
@@ -40,6 +40,10 @@ const (
 	watchdogTick      = 1 * time.Second
 	watchdogDiagAfter = 3 * time.Second  // log + ring dump (observe)
 	watchdogHealAfter = 15 * time.Second // SIGKILL + unblock the waiting exec (recover)
+	// watchdogLoopStale gates healing on the Run loop genuinely not progressing.
+	// A busy-but-progressing loop refreshes lastProgressNanos on every stop, so a
+	// slow-but-alive loop never trips the killer (only a wedged one does).
+	watchdogLoopStale = 3 * time.Second
 )
 
 // runStuckTraceeWatchdog is the watchdog goroutine. It must NOT LockOSThread:
@@ -70,12 +74,16 @@ func (t *Tracer) scanStuckTracees(stuckSince map[int]time.Time, diagged map[int]
 	now := time.Now()
 
 	// Snapshot tracked tids, skipping intentionally-parked tracees (keepStopped
-	// for the cgroup hook, or parked awaiting approval) — those are stopped on
+	// for the cgroup hook, or parked awaiting approval) and tracees held in
+	// PTRACE_LISTEN (job-control group-stops) — all of those are stopped on
 	// purpose and must not be reaped by the watchdog.
 	t.mu.Lock()
 	tids := make([]int, 0, len(t.tracees))
-	for tid := range t.tracees {
+	for tid, s := range t.tracees {
 		if _, parked := t.parkedTracees[tid]; parked {
+			continue
+		}
+		if s != nil && s.listening {
 			continue
 		}
 		tids = append(tids, tid)
@@ -102,13 +110,19 @@ func (t *Tracer) scanStuckTracees(stuckSince map[int]time.Time, diagged map[int]
 			slog.Warn("ptrace WATCHDOG: tracee ptrace-stopped but Run loop not advancing it (#369 #2)",
 				"tid", tid, "proc_state", string(rune(state)),
 				"syscall", procSyscallSummary(tid), "stuck_ms", dur.Milliseconds(),
-				"run_thread_tid", t.runThreadTID, "watchdog_tid", unix.Gettid())
+				"run_thread_tid", t.runThreadTID, "watchdog_tid", unix.Gettid(),
+				"loop_progress_ms_ago", t.loopIdleFor(now).Milliseconds())
 			if ptraceTraceOn() {
 				t.dumpTraceRing(fmt.Sprintf("watchdog tid=%d stuck=%dms", tid, dur.Milliseconds()))
 			}
 		}
 
-		if dur >= watchdogHealAfter {
+		// Heal only when (a) the tracee has been stuck long enough, (b) the Run
+		// loop is itself not progressing (so a slow-but-alive loop is never the
+		// trigger), and (c) the loop is not actively handling THIS tid right now.
+		if dur >= watchdogHealAfter &&
+			t.loopIdleFor(now) >= watchdogLoopStale &&
+			t.currentHandlingTID.Load() != int64(tid) {
 			t.healStuckTracee(tid)
 			delete(stuckSince, tid)
 			delete(diagged, tid)
@@ -168,4 +182,16 @@ func procSyscallSummary(tid int) string {
 		return "?"
 	}
 	return strings.TrimSpace(string(data))
+}
+
+// loopIdleFor reports how long since the Run loop last dispatched a stop. The
+// watchdog uses it to heal only when the loop is genuinely not progressing — a
+// busy-but-progressing loop refreshes the heartbeat on every stop. Initialized
+// at Run start, so it is non-zero whenever the watchdog runs.
+func (t *Tracer) loopIdleFor(now time.Time) time.Duration {
+	last := t.lastProgressNanos.Load()
+	if last == 0 {
+		return 0 // not yet initialized; treat as just-progressed (do not heal)
+	}
+	return now.Sub(time.Unix(0, last))
 }

--- a/internal/ptrace/watchdog_test.go
+++ b/internal/ptrace/watchdog_test.go
@@ -47,7 +47,8 @@ func TestHealStuckTracee(t *testing.T) {
 }
 
 // TestScanStuckTracees_RunningAndParkedNotFlagged confirms the watchdog never
-// flags or heals a tracee that is not ptrace-stopped, nor a parked one.
+// flags or heals a tracee that is not ptrace-stopped, nor a parked one, nor one
+// held in PTRACE_LISTEN (job-control group-stop).
 func TestScanStuckTracees_RunningAndParkedNotFlagged(t *testing.T) {
 	tr := NewTracer(TracerConfig{})
 
@@ -62,9 +63,13 @@ func TestScanStuckTracees_RunningAndParkedNotFlagged(t *testing.T) {
 	tr.parkedTracees[parked] = struct{}{}
 	parkedCh, _ := tr.RegisterExitNotify(parked)
 
+	// A LISTEN'd (group-stopped) tracee must be skipped — never SIGKILL'd.
+	const listening = (1 << 30) + 1
+	tr.tracees[listening] = &TraceeState{TID: listening, TGID: listening, MemFD: -1, listening: true}
+	listeningCh, _ := tr.RegisterExitNotify(listening)
+
 	stuckSince := map[int]time.Time{}
 	diagged := map[int]bool{}
-	// Several sweeps; even far past the heal threshold nothing should fire.
 	for i := 0; i < 3; i++ {
 		tr.scanStuckTracees(stuckSince, diagged)
 	}
@@ -74,9 +79,33 @@ func TestScanStuckTracees_RunningAndParkedNotFlagged(t *testing.T) {
 		t.Error("a running tracee must not be healed")
 	case <-parkedCh:
 		t.Error("a parked tracee must not be healed")
+	case <-listeningCh:
+		t.Error("a PTRACE_LISTEN'd (group-stopped) tracee must not be healed")
 	default:
 	}
 	if _, ok := stuckSince[parked]; ok {
 		t.Error("parked tracee must be skipped (never recorded as stuck)")
+	}
+	if _, ok := stuckSince[listening]; ok {
+		t.Error("listening tracee must be skipped (never recorded as stuck)")
+	}
+}
+
+// TestLoopIdleFor confirms the heartbeat gate: a fresh heartbeat reads ~0, a
+// stale one reads the elapsed time, and an uninitialized one reads 0 (don't heal).
+func TestLoopIdleFor(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+	now := time.Now()
+
+	if d := tr.loopIdleFor(now); d != 0 {
+		t.Errorf("uninitialized loopIdleFor = %v, want 0", d)
+	}
+	tr.lastProgressNanos.Store(now.UnixNano())
+	if d := tr.loopIdleFor(now); d > 5*time.Millisecond {
+		t.Errorf("fresh loopIdleFor = %v, want ~0", d)
+	}
+	tr.lastProgressNanos.Store(now.Add(-10 * time.Second).UnixNano())
+	if d := tr.loopIdleFor(now); d < 9*time.Second {
+		t.Errorf("stale loopIdleFor = %v, want ~10s", d)
 	}
 }

--- a/internal/ptrace/watchdog_test.go
+++ b/internal/ptrace/watchdog_test.go
@@ -1,0 +1,82 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestProcSyscallSummary(t *testing.T) {
+	if s := procSyscallSummary(os.Getpid()); s == "?" || s == "" {
+		t.Errorf("procSyscallSummary(self) = %q, want a real /proc/self/syscall line", s)
+	}
+	if s := procSyscallSummary(1 << 30); s != "?" {
+		t.Errorf("procSyscallSummary(huge pid) = %q, want %q", s, "?")
+	}
+}
+
+// TestHealStuckTracee verifies the watchdog's off-Run-thread recovery: it fires
+// the blocked exec's exit-notify with ExitVanished (so the exec returns) without
+// calling handleExit. The Tgkill targets a nonexistent tgid (ESRCH, harmless).
+func TestHealStuckTracee(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+	const tid = 1 << 30 // nonexistent → Tgkill ESRCH, readProc* miss
+	tr.tracees[tid] = &TraceeState{TID: tid, TGID: tid, MemFD: -1}
+	exitCh, err := tr.RegisterExitNotify(tid)
+	if err != nil {
+		t.Fatalf("RegisterExitNotify: %v", err)
+	}
+
+	tr.healStuckTracee(tid)
+
+	select {
+	case es := <-exitCh:
+		if es.Reason != ExitVanished {
+			t.Errorf("heal exit Reason = %v, want ExitVanished", es.Reason)
+		}
+	default:
+		t.Error("healStuckTracee must fire the exit-notify so the exec unblocks")
+	}
+	// The exit-notify registration must be consumed (LoadAndDelete), so a later
+	// handleExit reap does not double-send.
+	if _, ok := tr.exitNotify.Load(tid); ok {
+		t.Error("healStuckTracee must LoadAndDelete the exit-notify registration")
+	}
+}
+
+// TestScanStuckTracees_RunningAndParkedNotFlagged confirms the watchdog never
+// flags or heals a tracee that is not ptrace-stopped, nor a parked one.
+func TestScanStuckTracees_RunningAndParkedNotFlagged(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+
+	// A "running" tracee: our own pid (State R/S, TracerPid 0 != us) → never stuck.
+	self := os.Getpid()
+	tr.tracees[self] = &TraceeState{TID: self, TGID: self, MemFD: -1}
+	selfCh, _ := tr.RegisterExitNotify(self)
+
+	// A parked tracee (keepStopped) must be skipped entirely.
+	const parked = 1 << 30
+	tr.tracees[parked] = &TraceeState{TID: parked, TGID: parked, MemFD: -1}
+	tr.parkedTracees[parked] = struct{}{}
+	parkedCh, _ := tr.RegisterExitNotify(parked)
+
+	stuckSince := map[int]time.Time{}
+	diagged := map[int]bool{}
+	// Several sweeps; even far past the heal threshold nothing should fire.
+	for i := 0; i < 3; i++ {
+		tr.scanStuckTracees(stuckSince, diagged)
+	}
+
+	select {
+	case <-selfCh:
+		t.Error("a running tracee must not be healed")
+	case <-parkedCh:
+		t.Error("a parked tracee must not be healed")
+	default:
+	}
+	if _, ok := stuckSince[parked]; ok {
+		t.Error("parked tracee must be skipped (never recorded as stuck)")
+	}
+}


### PR DESCRIPTION
## The reframe (why rc10–rc13 all missed)

Every prior #2 build observed and acted from **inside** the Run loop — the exact goroutine that parks when the wedge occurs. So the WEDGE alarm never fired, the ring never dumped, and the ECHILD recovery (rc12/rc13) was never reached. They were structurally blind.

erans's rc7/rc11/rc12 dumps consistently show the real failure: a child **ptrace-stopped** (`state=t`, `TracerPid=us`) on a *benign* syscall (`set_robust_list`, `mmap` — not notify syscalls, so `WAIT_KILLABLE_RECV` isn't holding it) while `Tracer.Run` sits idle in `select`. A stop was consumed but never re-reported/resumed, through a nested wait (`attachThread`/`waitForSyscallStop`) that bypasses `handleStop` — invisible to all prior instrumentation. The ECHILD/idle park I chased was downstream.

## The fix: observe + recover from *outside* the loop

A watchdog goroutine that does **not** `LockOSThread` and detects the wedge by `/proc` ground truth, independent of where the Run loop is parked:

- **Detect** (`watchdogDiagAfter`, 3s): a tracked, non-parked, non-`PTRACE_LISTEN` tracee the kernel reports ptrace-stopped (`t`/`T`, `TracerPid=us`) for seconds (normal stops clear in µs) is wedged. Logs tid, `/proc` state, `/proc/<tid>/syscall`, Run-loop tid vs watchdog tid, and loop-idle time; dumps the trace ring when `AGENTSH_PTRACE_TRACE` is set — finally pinning the mechanism from outside.
- **Recover** (`watchdogHealAfter`, 15s): SIGKILL the wedged tracee (releasing the leaked stop so the Run loop reaps it and cleans up on its own thread) and fire the blocked exec's exit-notify directly, so the exec returns instead of hanging indefinitely. `healStuckTracee` does only goroutine-safe ops (Tgkill + `sync.Map` `LoadAndDelete` + buffered send) — never `handleExit` (Run-goroutine-only state); `LoadAndDelete` makes the later reap a no-op.

### Safety guards (from roborev review)
1. **`listening` flag** — `PTRACE_LISTEN`'d job-control group-stops (SIGSTOP/Ctrl-Z) are excluded, so a suspended user process is never killed.
2. **`lastProgressNanos` heartbeat** — heal only when the Run loop has genuinely not progressed for 3s; a busy/slow-but-alive loop refreshes it on every stop, on handleStop exit, and on every inject poll. Never the trigger.
3. **`currentHandlingTID`** — the watchdog never heals the tracee the loop is actively in `handleStop` for.

Also records `runThreadTID` and instruments the previously un-traced nested waits (`attachThread`, `safeDetach`) + SEIZE into the ring, so the dump shows the full attach/stop/resume history and any thread-ownership mismatch.

## Verification

- `go test -race ./internal/ptrace/` ✅ — heal fires `ExitVanished` + consumes the registration; running/parked/listening tracees all excluded; `loopIdleFor` fresh/stale/uninitialized. `go build ./...` ✅, `GOOS=windows` ✅, `vet` ✅.
- **End-to-end (erans):** the sequential FUSE-on wedge should now (a) emit `ptrace WATCHDOG: tracee ptrace-stopped but Run loop not advancing it` within ~3s with `/proc/<tid>/syscall` + the ring dump (mechanism, finally), and (b) auto-recover within 15s — the exec returns (vanished/-1) and the session-mutex pile-up clears, instead of a 14-minute hang.

Self-heal runs unconditionally (the remedy); the ring dump stays env-gated. roborev: residual Lows only (the tracked file_handler getdents doc follow-up; the heartbeat-semantics note, addressed here).

Refs #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)