### PR TITLE
fix(#369 #2): bail inject wait on vanished tracee + bound the exit-wait

### DIFF
--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -3,12 +3,25 @@
 package ptrace
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"golang.org/x/sys/unix"
 )
+
+// errInjectTraceeVanished is returned by the inject waits when the tracee has
+// disappeared from /proc mid-injection — its exit was reaped out from under us
+// (the steal #406 also recovers). Without this, the wpid==0 poll spins to the
+// timeout on every inject step, degrading every exec by seconds (#369 #2).
+var errInjectTraceeVanished = errors.New("inject: tracee vanished from /proc mid-injection (#369 #2)")
+
+// injectWaitTimeout bounds a single inject wait sequence. An injected syscall
+// completes in microseconds; this is generous headroom. waitForSyscallExitStop
+// shares ONE deadline across its advance-to-exit loop so the whole exit wait is
+// bounded by this, not injectMaxStopEvents × this (#369 #2).
+const injectWaitTimeout = 3 * time.Second
 
 // injectSyscall executes an arbitrary syscall inside a stopped tracee.
 //
@@ -200,12 +213,21 @@ const injectMaxStopEvents = 100
 // Handles both TRACESYSGOOD mode (syscall stops report SIGTRAP|0x80) and
 // prefilter/seccomp mode (syscall stops report plain SIGTRAP with no event).
 func (t *Tracer) waitForSyscallStop(tid int) error {
+	return t.waitForSyscallStopUntil(tid, time.Now().Add(injectWaitTimeout))
+}
+
+// waitForSyscallStopUntil is waitForSyscallStop with a caller-supplied absolute
+// deadline, so a multi-step wait (waitForSyscallExitStop) can bound its whole
+// sequence with one deadline rather than resetting the clock on every step.
+func (t *Tracer) waitForSyscallStopUntil(tid int, deadline time.Time) error {
 	const (
-		timeout   = 5 * time.Second
 		pollDelay = 200 * time.Microsecond
+		// Check /proc for a vanished tracee every ~this many idle polls
+		// (~10ms at pollDelay) — cheap relative to a stat per poll.
+		livenessEvery = 50
 	)
-	deadline := time.Now().Add(timeout)
 	stopEvents := 0
+	idlePolls := 0
 	for {
 		// Refresh the Run-loop heartbeat: an active inject poll is real progress,
 		// so a multi-second inject must not make the watchdog think the loop is
@@ -213,7 +235,7 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 		// runs this loop, so it still goes stale and is healed.
 		t.lastProgressNanos.Store(time.Now().UnixNano())
 		if time.Now().After(deadline) {
-			return fmt.Errorf("waitForSyscallStop tid %d: timed out after %v", tid, timeout)
+			return fmt.Errorf("waitForSyscallStop tid %d: timed out after %v", tid, injectWaitTimeout)
 		}
 		var status unix.WaitStatus
 		traceWaitCall("inject", tid)
@@ -226,10 +248,17 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 			return fmt.Errorf("wait4 tid %d: %w", tid, err)
 		}
 		if wpid == 0 {
-			// Tracee hasn't stopped yet.
+			// Tracee produced no stop. If it has vanished from /proc (its exit was
+			// reaped out from under us mid-inject — #369 #2), bail immediately
+			// instead of spinning to the timeout on every inject step.
+			idlePolls++
+			if idlePolls%livenessEvery == 0 && !procExists(tid) {
+				return errInjectTraceeVanished
+			}
 			time.Sleep(pollDelay)
 			continue
 		}
+		idlePolls = 0
 		if !status.Stopped() {
 			if status.Exited() || status.Signaled() {
 				// Clean up tracee bookkeeping before returning.
@@ -289,7 +318,11 @@ func (t *Tracer) waitForSyscallStop(tid int) error {
 // stop reached is the injected syscall's exit; intervening entry/seccomp stops
 // are resumed past.
 func (t *Tracer) waitForSyscallExitStop(tid int) error {
-	if err := t.waitForSyscallStop(tid); err != nil {
+	// One shared deadline for the whole advance-to-exit sequence, so it is
+	// bounded by injectWaitTimeout total — not injectMaxStopEvents × that (which
+	// let a stuck inject spin for tens of seconds per exec, #369 #2).
+	deadline := time.Now().Add(injectWaitTimeout)
+	if err := t.waitForSyscallStopUntil(tid, deadline); err != nil {
 		return err
 	}
 	if !t.hasSyscallInfo {
@@ -308,7 +341,7 @@ func (t *Tracer) waitForSyscallExitStop(tid int) error {
 		if err := unix.PtraceSyscall(tid, 0); err != nil {
 			return fmt.Errorf("inject advance-to-exit tid %d: %w", tid, err)
 		}
-		if err := t.waitForSyscallStop(tid); err != nil {
+		if err := t.waitForSyscallStopUntil(tid, deadline); err != nil {
 			return err // includes "tracee N exited during injection"
 		}
 	}

--- a/internal/ptrace/inject.go
+++ b/internal/ptrace/inject.go
@@ -228,6 +228,7 @@ func (t *Tracer) waitForSyscallStopUntil(tid int, deadline time.Time) error {
 	)
 	stopEvents := 0
 	idlePolls := 0
+	start := time.Now()
 	for {
 		// Refresh the Run-loop heartbeat: an active inject poll is real progress,
 		// so a multi-second inject must not make the watchdog think the loop is
@@ -235,7 +236,10 @@ func (t *Tracer) waitForSyscallStopUntil(tid int, deadline time.Time) error {
 		// runs this loop, so it still goes stale and is healed.
 		t.lastProgressNanos.Store(time.Now().UnixNano())
 		if time.Now().After(deadline) {
-			return fmt.Errorf("waitForSyscallStop tid %d: timed out after %v", tid, injectWaitTimeout)
+			// Report the actual elapsed wait, not the constant — with a shared
+			// deadline (waitForSyscallExitStop) later iterations start mid-budget,
+			// so the constant would overstate the wait during #369 #2 triage.
+			return fmt.Errorf("waitForSyscallStop tid %d: timed out after %v", tid, time.Since(start).Round(time.Millisecond))
 		}
 		var status unix.WaitStatus
 		traceWaitCall("inject", tid)

--- a/internal/ptrace/inject_wait_test.go
+++ b/internal/ptrace/inject_wait_test.go
@@ -1,0 +1,42 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestWaitForSyscallStopUntil_RespectsDeadline verifies the inject wait is bounded
+// by its deadline and returns promptly rather than spinning — the core of the
+// #369 #2 inject-spin fix (the previous 5s-per-call clock could compound to tens
+// of seconds per exec). With an already-past deadline it must return a timeout
+// error on the first iteration, before any Wait4.
+func TestWaitForSyscallStopUntil_RespectsDeadline(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+	start := time.Now()
+	err := tr.waitForSyscallStopUntil(1<<30, time.Now().Add(-time.Second))
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected a timeout error for a past deadline, got %v", err)
+	}
+	if d := time.Since(start); d > 250*time.Millisecond {
+		t.Errorf("waitForSyscallStopUntil must return promptly on a past deadline; took %v", d)
+	}
+}
+
+// TestErrInjectTraceeVanished_Distinct guards the sentinel used to abort an
+// inject when the tracee disappeared from /proc mid-injection (#369 #2), so the
+// caller can tell it apart from other inject errors if it ever needs to.
+func TestErrInjectTraceeVanished_Distinct(t *testing.T) {
+	if errInjectTraceeVanished == nil {
+		t.Fatal("errInjectTraceeVanished must be defined")
+	}
+	if !errors.Is(errInjectTraceeVanished, errInjectTraceeVanished) {
+		t.Error("errInjectTraceeVanished must match itself via errors.Is")
+	}
+	if errors.Is(errInjectTraceeVanished, errScratchUnmapped) {
+		t.Error("errInjectTraceeVanished must be distinct from errScratchUnmapped")
+	}
+}


### PR DESCRIPTION
## The artifact paid off

rc14's external watchdog produced the ring dump erans needed, and it **pinned the real degradation**: the inject-layer `Wait4(tid)` (`waitForSyscallStop`, run on every server-side exec that injects the seccomp prefilter) busy-polls `ret_tid=0` for a tracee that disappeared mid-injection — its exit was reaped out from under us (the #406 path also reports "tracee vanished from /proc"). The poll never sees the expected ptrace stop.

(Note: the `status="exited(code=0)"` in the dump is a decode artifact — when `Wait4` returns `wpid=0` the status buffer is zero, which the tracer's decoder renders as "exited(code=0)". The real signal is `ret_tid=0` spinning.)

Two compounding problems made each exec degrade to ~35s and eventually flip the server unhealthy:
1. the `wpid==0` poll had **no vanished-child check** — it spun to the timeout; and
2. `waitForSyscallExitStop` reset a **fresh 5s deadline on every** advance-to-exit iteration (up to `injectMaxStopEvents`), so the real bound was ~100 × 5s, not 5s.

## Fix

- **`waitForSyscallStopUntil(tid, deadline)`** — the `wpid==0` path now checks `procExists(tid)` every ~10ms and returns `errInjectTraceeVanished` the moment the tracee is gone, instead of spinning. The inject aborts and the exec is recovered via the existing `ESRCH`→`handleExit(ExitVanished)` fallback / #406 path.
- **Shared deadline** across `waitForSyscallExitStop`'s loop, so the whole exit wait is bounded by `injectWaitTimeout` total.
- **`injectWaitTimeout` 5s → 3s** (an injected syscall completes in µs; ample headroom, caps the rare alive-but-not-stopping case). Timeout message reports actual elapsed.

This completes the stolen-exit family coverage: the **watchdog** (ptrace-stopped signature) + **#406** (ECHILD signature) + **this** (inject-wait signature). Root-causing the steal at source (ensure only the tracer reaps the traced child) remains a follow-up.

## Verification

- `go test -race ./internal/ptrace/` ✅ — inject wait returns promptly on a past deadline (bounded, no spin); sentinel is distinct. `go build ./...` ✅, `GOOS=windows` ✅, `vet` ✅.
- **End-to-end (erans):** the sequential FUSE-on repro should no longer degrade per-exec to ~35s or flip the server unhealthy — a vanished-mid-inject child aborts the inject in ~ms and the exec returns/recovers, instead of the inject spinning. roborev: residual Lows only (tracked getdents follow-up; message accuracy, addressed).

Refs #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)