### PR TITLE
diag(#369 #2): capture the FUSE-on cliff — bigger trace ring + dump-on-stall

### DIFF
--- a/internal/ptrace/trace_debug.go
+++ b/internal/ptrace/trace_debug.go
@@ -97,7 +97,12 @@ type traceEvent struct {
 	via    string // resume site
 }
 
-const traceRingSize = 8192
+// traceRingSize holds enough events to retain well over a minute of trace under
+// sustained load. erans's rc15 capture showed the previous 8192 retained only
+// ~9s and WRAPPED before the ~35s FUSE-on cliff completed, losing the
+// terminating sequence. ~64k entries (~5MB at ~80B/event) retains ~70s, so a
+// cliff dump captures the full stall + the unblock (#369 #2).
+const traceRingSize = 65536
 
 // traceRing and traceRingIdx are written ONLY by the Run goroutine. Every append
 // site runs there: the Run-loop Wait4, handleStop and its dispatch handlers, the

--- a/internal/ptrace/trace_debug.go
+++ b/internal/ptrace/trace_debug.go
@@ -112,6 +112,11 @@ const traceRingSize = 65536
 // synchronization is needed. dumpTraceRing reads them, also from the Run goroutine
 // (idle tick). The atomic on the index is solely so a future off-goroutine reader
 // could snapshot it safely.
+//
+// ASSUMPTION: a single Tracer.Run() per process. agentsh runs exactly one ptrace
+// tracer (a.ptraceTracer), so this holds. The ring is package-global (rather than
+// per-Tracer) only to keep the trace hooks call-site-light; if a second concurrent
+// Tracer.Run() is ever introduced, move this state onto Tracer to avoid a race.
 var (
 	traceRing    [traceRingSize]traceEvent
 	traceRingIdx atomic.Uint64

--- a/internal/ptrace/watchdog_linux.go
+++ b/internal/ptrace/watchdog_linux.go
@@ -44,6 +44,12 @@ const (
 	// A busy-but-progressing loop refreshes lastProgressNanos on every stop, so a
 	// slow-but-alive loop never trips the killer (only a wedged one does).
 	watchdogLoopStale = 3 * time.Second
+	// watchdogExecStallDump is how long an exec's exit-notify may stay pending
+	// before the watchdog dumps the trace ring (capture-only, #369 #2). A normal
+	// exec resolves in ms; seconds means it is cliffing. The dump fires once
+	// during the stall and again when it resolves, so erans captures both the
+	// steady-state spin and the terminating sequence the ~35s cliff ends with.
+	watchdogExecStallDump = 10 * time.Second
 )
 
 // runStuckTraceeWatchdog is the watchdog goroutine. It must NOT LockOSThread:
@@ -52,8 +58,10 @@ const (
 func (t *Tracer) runStuckTraceeWatchdog(ctx context.Context) {
 	ticker := time.NewTicker(watchdogTick)
 	defer ticker.Stop()
-	stuckSince := make(map[int]time.Time) // tid -> first observed ptrace-stuck
-	diagged := make(map[int]bool)         // tid -> diagnostic already emitted
+	stuckSince := make(map[int]time.Time)    // tid -> first observed ptrace-stuck
+	diagged := make(map[int]bool)            // tid -> diagnostic already emitted
+	execFirstSeen := make(map[int]time.Time) // pid -> first observed pending exit-notify
+	execDumped := make(map[int]bool)         // pid -> stall dump already emitted
 	for {
 		select {
 		case <-ctx.Done():
@@ -63,6 +71,53 @@ func (t *Tracer) runStuckTraceeWatchdog(ctx context.Context) {
 		case <-ticker.C:
 		}
 		t.scanStuckTracees(stuckSince, diagged)
+		t.scanStalledExecs(execFirstSeen, execDumped)
+	}
+}
+
+// scanStalledExecs is a capture-only diagnostic (#369 #2): it watches pending
+// exit-notify registrations (one per in-flight exec) and dumps the trace ring
+// when one stays pending past watchdogExecStallDump — i.e. an exec is cliffing.
+// It dumps once during the stall (steady-state spin) and again when the exec
+// finally resolves (the terminating sequence). No-op when tracing is off (the
+// ring is empty). Runs on the watchdog goroutine; the maps carry state across
+// ticks. Changes nothing about enforcement or recovery.
+func (t *Tracer) scanStalledExecs(firstSeen map[int]time.Time, dumped map[int]bool) {
+	if !ptraceTraceOn() {
+		return
+	}
+	now := time.Now()
+	live := make(map[int]bool)
+	t.exitNotify.Range(func(k, _ any) bool {
+		pid, ok := k.(int)
+		if !ok {
+			return true
+		}
+		live[pid] = true
+		if firstSeen[pid].IsZero() {
+			firstSeen[pid] = now
+		}
+		if !dumped[pid] && now.Sub(firstSeen[pid]) >= watchdogExecStallDump {
+			dumped[pid] = true
+			slog.Warn("ptrace WATCHDOG: exec stalled — exit-notify pending past threshold, dumping trace ring (#369 #2)",
+				"pid", pid, "stalled_ms", now.Sub(firstSeen[pid]).Milliseconds(),
+				"run_thread_tid", t.runThreadTID)
+			t.dumpTraceRing(fmt.Sprintf("exec-stall pid=%d", pid))
+		}
+		return true
+	})
+	for pid := range firstSeen {
+		if live[pid] {
+			continue
+		}
+		// The exec resolved. If it had stalled, capture the terminating sequence
+		// (what finally unblocked it — the ~35s cliff's end).
+		if dumped[pid] {
+			slog.Warn("ptrace WATCHDOG: stalled exec resolved, dumping terminating trace ring (#369 #2)", "pid", pid)
+			t.dumpTraceRing(fmt.Sprintf("exec-stall-resolved pid=%d", pid))
+		}
+		delete(firstSeen, pid)
+		delete(dumped, pid)
 	}
 }
 

--- a/internal/ptrace/watchdog_test.go
+++ b/internal/ptrace/watchdog_test.go
@@ -4,6 +4,7 @@ package ptrace
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -107,5 +108,57 @@ func TestLoopIdleFor(t *testing.T) {
 	tr.lastProgressNanos.Store(now.Add(-10 * time.Second).UnixNano())
 	if d := tr.loopIdleFor(now); d < 9*time.Second {
 		t.Errorf("stale loopIdleFor = %v, want ~10s", d)
+	}
+}
+
+// TestScanStalledExecs confirms the capture-only dump-on-cliff: an exec whose
+// exit-notify has been pending past the threshold triggers a ring dump, then a
+// terminating dump when it resolves; a fresh one does not; and it's a no-op when
+// tracing is off.
+func TestScanStalledExecs(t *testing.T) {
+	tr := NewTracer(TracerConfig{})
+	const pid = 4078
+	if _, err := tr.RegisterExitNotify(pid); err != nil {
+		t.Fatalf("RegisterExitNotify: %v", err)
+	}
+
+	// Tracing off: pure no-op, no bookkeeping recorded.
+	firstSeen := map[int]time.Time{}
+	dumped := map[int]bool{}
+	out := withTrace(t, false, func() { tr.scanStalledExecs(firstSeen, dumped) })
+	if out != "" || len(firstSeen) != 0 {
+		t.Errorf("scanStalledExecs must be a no-op when tracing is off; out=%q firstSeen=%v", out, firstSeen)
+	}
+
+	// Tracing on, freshly pending: recorded but NOT dumped yet.
+	out = withTrace(t, true, func() { tr.scanStalledExecs(firstSeen, dumped) })
+	if strings.Contains(out, "exec stalled") {
+		t.Errorf("a freshly-pending exec must not be flagged as stalled; got:\n%s", out)
+	}
+	if firstSeen[pid].IsZero() {
+		t.Fatal("scanStalledExecs must record first-seen for a pending exec")
+	}
+
+	// Age it past the threshold → stall dump fires once.
+	firstSeen[pid] = time.Now().Add(-2 * watchdogExecStallDump)
+	out = withTrace(t, true, func() {
+		traceWaitCall("run", -1) // seed one ring event so the dump is non-empty
+		tr.scanStalledExecs(firstSeen, dumped)
+	})
+	if !strings.Contains(out, "exec stalled") || !strings.Contains(out, "DUMP BEGIN") {
+		t.Errorf("an aged-pending exec must dump the ring; got:\n%s", out)
+	}
+	if !dumped[pid] {
+		t.Error("scanStalledExecs must mark the exec dumped")
+	}
+
+	// Resolve it (exit-notify gone) → terminating dump fires, bookkeeping cleared.
+	tr.exitNotify.LoadAndDelete(pid)
+	out = withTrace(t, true, func() { tr.scanStalledExecs(firstSeen, dumped) })
+	if !strings.Contains(out, "resolved") {
+		t.Errorf("a resolved stalled exec must emit a terminating dump; got:\n%s", out)
+	}
+	if _, ok := firstSeen[pid]; ok {
+		t.Error("scanStalledExecs must clear bookkeeping for a resolved exec")
 	}
 }


### PR DESCRIPTION
## Capture-first (no new fix)

rc15's vanished-bail was built on a **wrong hypothesis** — erans's ring dump shows the inject `Wait4` spins on a child that is **alive-but-not-stopping** (the `procExists` bail fired 2× against 5,317 spins), and the real drivers are the **inject trigger misclassification** (`66 90` NOP gadget) plus a **fixed ~35.4s cliff bound** the trace ring *wrapped before capturing* (8192 events retained only ~9s). Six prior #2 changes were all recovery/mitigation; per the debugging discipline we capture the missing evidence before the next fix.

This is **diagnostic-only** — it changes nothing about enforcement or recovery — and does exactly what erans asked for:

- **`traceRingSize` 8192 → 65536** (~5MB, retains ~70s) so a dump covers the *entire* ~35s cliff plus its terminating sequence, not just the last ~9s.
- **`scanStalledExecs`** on the off-loop watchdog: watches pending exit-notify registrations (one per in-flight exec) and, when one stays pending past 10s (an exec is cliffing), **dumps the trace ring once during the stall** (steady-state spin) **and again when it resolves** (the terminating sequence — what finally unblocks at ~35s). No-op when `AGENTSH_PTRACE_TRACE` is off.

## What this gives erans

On the next FUSE-on repro with `AGENTSH_PTRACE_TRACE=1`, a cliffing exec produces two ring dumps — `exec-stall pid=…` (mid-stall) and `exec-stall-resolved pid=…` (terminating) — each backed by a 70s ring, so the **full ~35.4s sequence is captured** and the bound's source is finally pinned. That drives the real fix (whether it's the inject trigger classification, an independent timeout, or a resource leak).

## Verification

- `go test -race ./internal/ptrace/` ✅ — `scanStalledExecs` dumps on an aged-pending exec, again on resolve, not on a fresh one, no-op when tracing off. `go build ./...` ✅, `GOOS=windows` ✅, `vet` ✅.

roborev: residual Lows only (the tracked file_handler catch-all-rule-name concern; the trace-ring single-tracer assumption, now documented).

Refs #369.

🤖 Generated with [Claude Code](https://claude.com/claude-code)