### PR TITLE
fix(#369 #2): default_permissions + attr/entry caching to break FUSE<->clone deadlock

### DIFF
--- a/internal/fsmonitor/mount.go
+++ b/internal/fsmonitor/mount.go
@@ -19,11 +19,6 @@ type Mount struct {
 	Server     *fuse.Server
 }
 
-type Options struct {
-	EntryTimeout time.Duration
-	AttrTimeout  time.Duration
-}
-
 func MountWorkspace(ctx context.Context, backingDir string, mountPoint string, hooks *Hooks) (*Mount, error) {
 	if backingDir == "" {
 		return nil, fmt.Errorf("backingDir is empty")
@@ -46,23 +41,7 @@ func MountWorkspace(ctx context.Context, backingDir string, mountPoint string, h
 		return nil, err
 	}
 
-	opts := &fs.Options{
-		MountOptions: fuse.MountOptions{
-			FsName:        "agentsh-workspace",
-			Name:          "agentsh",
-			DisableXAttrs: false,
-			AllowOther:    true,
-		},
-	}
-
-	// Optional kernel-side async request queue tuning
-	// (sandbox.fuse.max_background). When 0, leave go-fuse's default in
-	// place -- go-fuse uses 12, matching the kernel default.
-	// Running one daemon with many mounts under heavy ptrace+seccomp
-	// syscall traffic can raise this knob to give the kernel more headroom
-	if hooks != nil && hooks.MaxBackground > 0 {
-		opts.MountOptions.MaxBackground = hooks.MaxBackground
-	}
+	opts := buildMountOptions(hooks)
 
 	type mountResult struct {
 		server *fuse.Server
@@ -91,6 +70,64 @@ func MountWorkspace(ctx context.Context, backingDir string, mountPoint string, h
 	case <-ctx.Done():
 		return nil, fmt.Errorf("FUSE mount timed out at %s (likely blocked by container runtime)", mountPoint)
 	}
+}
+
+// buildMountOptions assembles the go-fuse mount options for the workspace.
+//
+// #369 #2 -- default_permissions + attribute/entry caching are a matched pair
+// that together close a FUSE<->clone deadlock on kernel 6.12.x under sustained
+// FUSE-on load:
+//
+//   - An exec child chdir()s into this workspace mount during Go's forkExec
+//     (between clone and execve). The kernel's path-walk permission check on
+//     the workspace directory issues a FUSE request that blocks in
+//     request_wait_answer waiting on a go-fuse reader goroutine. The Go runtime
+//     cannot schedule that reader while a sibling thread is stuck D-state in
+//     kernel_clone (spawning a new M also needs clone), so the request is never
+//     answered and the exec wedges until the client-side timeout.
+//
+//   - default_permissions makes the kernel perform the standard unix-mode
+//     permission check LOCALLY rather than round-tripping FUSE_ACCESS to this
+//     in-process daemon. That is exactly what go-fuse's default Access op did
+//     (Getattr + HasAccess, a pure unix-mode test); agentsh enforces policy on
+//     open/read/write/create/delete/rename/etc. in the node ops, never on
+//     access(), so policy enforcement is unchanged.
+//
+//   - The local check still needs the directory's cached attributes and
+//     dentries. agentsh otherwise runs with attr/entry timeout 0 (go-fuse only
+//     defaults these to 1s when opts==nil, and we pass non-nil opts), so the
+//     kernel would treat them as always-stale and re-issue GETATTR/LOOKUP in
+//     the same forkExec window -- the same deadlock, differently named. A 1s
+//     EntryTimeout/AttrTimeout lets the kernel serve the chdir permission check
+//     from cache with no FUSE round-trip. Entry/lookup caching has no audit or
+//     policy cost (there is no Lookup node op); attr caching only coalesces
+//     repeat stat()s of the same file within 1s -- distinct-file stats, and all
+//     content operations, are still forwarded and audited.
+func buildMountOptions(hooks *Hooks) *fs.Options {
+	attrTimeout := time.Second
+	entryTimeout := time.Second
+	opts := &fs.Options{
+		EntryTimeout: &entryTimeout,
+		AttrTimeout:  &attrTimeout,
+		MountOptions: fuse.MountOptions{
+			FsName:        "agentsh-workspace",
+			Name:          "agentsh",
+			DisableXAttrs: false,
+			AllowOther:    true,
+			Options:       []string{"default_permissions"},
+		},
+	}
+
+	// Optional kernel-side async request queue tuning
+	// (sandbox.fuse.max_background). When 0, leave go-fuse's default in
+	// place -- go-fuse uses 12, matching the kernel default.
+	// Running one daemon with many mounts under heavy ptrace+seccomp
+	// syscall traffic can raise this knob to give the kernel more headroom.
+	if hooks != nil && hooks.MaxBackground > 0 {
+		opts.MountOptions.MaxBackground = hooks.MaxBackground
+	}
+
+	return opts
 }
 
 func (m *Mount) Unmount() error {

--- a/internal/fsmonitor/mount_test.go
+++ b/internal/fsmonitor/mount_test.go
@@ -1,0 +1,53 @@
+//go:build !windows
+
+package fsmonitor
+
+import (
+	"slices"
+	"testing"
+	"time"
+)
+
+// TestBuildMountOptions_DefaultPermissionsAndCaching locks in the #369 #2
+// FUSE<->clone deadlock fix. The workspace mount MUST carry the
+// default_permissions option (so the kernel serves a child's chdir/path-walk
+// permission check locally instead of round-tripping FUSE_ACCESS to this
+// in-process daemon mid-forkExec) AND MUST set non-zero Entry/Attr timeouts
+// (so that local check is served from cache with no GETATTR/LOOKUP round-trip
+// in the same forkExec window). Dropping either reopens the deadlock on kernel
+// 6.12.x under sustained FUSE-on load.
+func TestBuildMountOptions_DefaultPermissionsAndCaching(t *testing.T) {
+	opts := buildMountOptions(nil)
+
+	if !slices.Contains(opts.MountOptions.Options, "default_permissions") {
+		t.Errorf("mount Options must contain default_permissions (#369 #2); got %v", opts.MountOptions.Options)
+	}
+	if opts.EntryTimeout == nil || *opts.EntryTimeout != time.Second {
+		t.Errorf("EntryTimeout must be 1s (#369 #2); got %v", opts.EntryTimeout)
+	}
+	if opts.AttrTimeout == nil || *opts.AttrTimeout != time.Second {
+		t.Errorf("AttrTimeout must be 1s (#369 #2); got %v", opts.AttrTimeout)
+	}
+
+	// Existing identity options must be preserved by the refactor.
+	if opts.MountOptions.FsName != "agentsh-workspace" {
+		t.Errorf("FsName = %q, want agentsh-workspace", opts.MountOptions.FsName)
+	}
+	if opts.MountOptions.Name != "agentsh" {
+		t.Errorf("Name = %q, want agentsh", opts.MountOptions.Name)
+	}
+	if !opts.MountOptions.AllowOther {
+		t.Error("AllowOther must stay true")
+	}
+}
+
+// TestBuildMountOptions_MaxBackground confirms the optional kernel async-queue
+// knob is still wired from hooks, and left at the go-fuse default when unset.
+func TestBuildMountOptions_MaxBackground(t *testing.T) {
+	if mb := buildMountOptions(nil).MountOptions.MaxBackground; mb != 0 {
+		t.Errorf("MaxBackground with nil hooks = %d, want 0 (go-fuse default)", mb)
+	}
+	if mb := buildMountOptions(&Hooks{MaxBackground: 64}).MountOptions.MaxBackground; mb != 64 {
+		t.Errorf("MaxBackground = %d, want 64", mb)
+	}
+}


### PR DESCRIPTION
## What

Closes the #369 **#2** failure: a hang that occurs only when FUSE is **ON**, on exe.dev's kernel 6.12.x under sustained load. (#1 shipped rc7/#400; #3 shipped rc8–9/#401–402.)

## Root cause (FUSE↔clone deadlock)

An exec child `chdir()`s into the workspace mount during Go's `forkExec` (between `clone` and `execve`). The kernel's path-walk permission check issues a FUSE request (`fuse_access`) that blocks in `request_wait_answer` waiting on a go-fuse reader goroutine. The Go runtime **cannot schedule that reader** while a sibling thread is stuck D-state in `kernel_clone` (spawning a new M also needs `clone`), so the request is never answered and the exec wedges until the client-side `agentsh exec` timeout (~35s).

Confirmed via erans's rc16 kernel stacks + a discriminator run (`cgroups.enabled:false` still cliffs → it's the chdir-into-FUSE, not cgroup migration).

## Fix

1. **`default_permissions`** mount option — the kernel performs the unix-mode permission check **locally** instead of round-tripping `FUSE_ACCESS` to the in-process daemon.
2. **`EntryTimeout`/`AttrTimeout` = 1s** — agentsh runs with attr/entry timeout 0 (go-fuse only defaults to 1s when `opts==nil`; we pass non-nil), so without caching `default_permissions` would just convert the blocking `ACCESS` into a blocking `GETATTR` in the same forkExec window. The 1s cache lets the kernel serve the chdir check with **no FUSE round-trip**.

## Why it's security-neutral

- `default_permissions` delegates only the **coarse unix-mode check** — identical to what go-fuse's default `Access` op already did (`Getattr` + `HasAccess`).
- **Policy enforcement is unchanged**: agentsh's `CheckFile` runs in the node ops (`Open`/`Create`/`Read`/`Write`/`Unlink`/`Rename`/`Getattr`/…), never on `access()`. Those ops are always forwarded.
- There is **no `Lookup` node op**, so entry caching has no policy/audit cost.
- Attr caching only coalesces **repeat `stat()`s of the same file within 1s**; distinct-file stats and all content ops are still forwarded and audited.

roborev (standard + security passes): *"well-reasoned FUSE deadlock fix… real policy enforcement stays in the node ops… No exploitable path there."*

## Tests

- New `TestBuildMountOptions_*` lock in `default_permissions` + the 1s timeouts (regression guard against silently dropping the fix).
- Full suite: no new failures vs. `main`.
- `GOOS=windows go build ./...` clean (file is `!windows`).

## Verification

This is the fix for #369 #2; erans verifies on exe.dev 6.12.x under sustained FUSE-on load (rc17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
