### PR TITLE
fix(seccomp): scope unix-socket socket(2) notify to AF_UNIX so errno socket_rules survive

### DIFF
--- a/internal/netmonitor/unix/seccomp_linux.go
+++ b/internal/netmonitor/unix/seccomp_linux.go
@@ -327,14 +327,11 @@ func InstallFilterWithConfig(cfg FilterConfig) (*Filter, error) {
 
 	// Unix socket monitoring via user-notify
 	if cfg.UnixSocketEnabled {
-		trap := seccomp.ActNotify
-		rules := unixSocketNotifySyscalls()
-		for _, sc := range rules {
-			if err := filt.AddRule(sc, trap); err != nil {
-				return nil, fmt.Errorf("add notify rule %v: %w", sc, err)
-			}
+		added, err := installUnixSocketNotifyRules(filt, seccomp.ActNotify)
+		if err != nil {
+			return nil, err
 		}
-		ruleCounts["unix_socket"] = len(rules)
+		ruleCounts["unix_socket"] = added
 	}
 
 	// Execve interception via user-notify
@@ -563,6 +560,53 @@ func unixSocketNotifySyscalls() []seccomp.ScmpSyscall {
 		seccomp.ScmpSyscall(unix.SYS_LISTEN),
 		seccomp.ScmpSyscall(unix.SYS_SENDTO),
 	}
+}
+
+// unixSocketNotifyRuleAdder is the subset of *seccomp.ScmpFilter used to
+// install the unix-socket monitoring notify rules. Split out so the rule
+// shapes can be asserted in tests without loading a kernel filter.
+type unixSocketNotifyRuleAdder interface {
+	AddRule(seccomp.ScmpSyscall, seccomp.ScmpAction) error
+	AddRuleConditional(seccomp.ScmpSyscall, seccomp.ScmpAction, []seccomp.ScmpCondition) error
+}
+
+// installUnixSocketNotifyRules installs the user-notify rules that drive
+// AF_UNIX socket monitoring and returns the number of rules added.
+//
+// socket(2) is scoped to arg0==AF_UNIX rather than trapped unconditionally.
+// A catch-all notify on socket(2) routes every socket() call to the userspace
+// handler, which preempts the kernel-side conditional ActErrno rules that
+// socket_rules / blocked_socket_families install on the same syscall — those
+// errno rules are intentionally not mirrored into the notify handler's
+// block-list (see internal/api/blocklist_config_linux.go), so the catch-all
+// silently let non-AF_UNIX families (e.g. NETLINK_XFRM, AF_RXRPC) through.
+// Scoping to AF_UNIX keeps the monitor's coverage (it only cares about unix
+// sockets) while leaving other families on the kernel fast path.
+//
+// connect/bind/listen/sendto act on an already-created fd — the address family
+// is not in arg0 — so they stay unconditional; they do not collide with
+// socket_rules, which only match socket(2)/socketpair(2).
+func installUnixSocketNotifyRules(adder unixSocketNotifyRuleAdder, action seccomp.ScmpAction) (int, error) {
+	added := 0
+	for _, sc := range unixSocketNotifySyscalls() {
+		if sc == seccomp.ScmpSyscall(unix.SYS_SOCKET) {
+			cond := seccomp.ScmpCondition{
+				Argument: 0,
+				Op:       seccomp.CompareEqual,
+				Operand1: uint64(unix.AF_UNIX),
+			}
+			if err := adder.AddRuleConditional(sc, action, []seccomp.ScmpCondition{cond}); err != nil {
+				return added, fmt.Errorf("add notify rule %v (AF_UNIX): %w", sc, err)
+			}
+			added++
+			continue
+		}
+		if err := adder.AddRule(sc, action); err != nil {
+			return added, fmt.Errorf("add notify rule %v: %w", sc, err)
+		}
+		added++
+	}
+	return added, nil
 }
 
 // metadataNotifySyscalls returns the metadata syscalls the wrapper traps via

--- a/internal/netmonitor/unix/seccomp_socket_rules_test.go
+++ b/internal/netmonitor/unix/seccomp_socket_rules_test.go
@@ -25,6 +25,7 @@ import (
 
 const socketRuleHelperEnv = "AGENTSH_TEST_SOCKET_RULE_HELPER"
 const socketRuleHelperNotifyLog = "notify_log"
+const socketRuleHelperErrnoTupleUnix = "errno_tuple_unix"
 const socketRuleHelperDirtyFragNetlinkXFRM = "dirtyfrag_netlink_xfrm"
 const socketRuleHelperDirtyFragNetlinkRoute = "dirtyfrag_netlink_route"
 const socketRuleHelperDirtyFragRXRPC = "dirtyfrag_rxrpc"
@@ -277,6 +278,70 @@ func TestDirtyFragSocketpairNetlinkXFRM_MitigationSetProtocolRule(t *testing.T) 
 	require.Contains(t, combined, "audit_syscall=socketpair")
 	require.NotContains(t, combined, "audit_event=seccomp_socket_family_blocked")
 	require.NotContains(t, combined, "audit_event=seccomp_blocked")
+}
+
+// TestSeccompSocketRuleBlock_ErrnoTupleWithUnixMonitor is the regression guard
+// for the socket-rule shadow bug: an errno socket tuple rule must still be
+// enforced kernel-side when AF_UNIX socket monitoring is enabled. Before the
+// fix, the catch-all notify on socket(2) routed socket(NETLINK_XFRM) to the
+// (absent) userspace handler instead of the errno rule, so this hangs until the
+// harness timeout. After the fix, socket(2) notify is scoped to AF_UNIX and the
+// NETLINK_XFRM errno rule fires kernel-side → EAFNOSUPPORT.
+func TestSeccompSocketRuleBlock_ErrnoTupleWithUnixMonitor(t *testing.T) {
+	if os.Getenv(socketRuleHelperEnv) == socketRuleHelperErrnoTupleUnix {
+		runSocketRuleHelperErrnoTupleUnix(t)
+		return
+	}
+
+	combined := runSocketRuleHelperSubprocess(t, socketRuleHelperErrnoTupleUnix)
+	requireResultEAFNOSUPPORT(t, combined, "socket_result")
+}
+
+func runSocketRuleHelperErrnoTupleUnix(t *testing.T) {
+	t.Helper()
+
+	if err := DetectSupport(); err != nil {
+		t.Skipf("seccomp user-notify not supported: %v", err)
+	}
+
+	typ := int(gounix.SOCK_RAW)
+	protocol := int(gounix.NETLINK_XFRM)
+	cfg := FilterConfig{
+		UnixSocketEnabled: true,
+		SocketRules: []seccompkg.SocketRule{
+			{
+				Name:         "netlink_xfrm",
+				Family:       gounix.AF_NETLINK,
+				FamilyName:   "AF_NETLINK",
+				Type:         &typ,
+				TypeName:     "SOCK_RAW",
+				Protocol:     &protocol,
+				ProtocolName: "NETLINK_XFRM",
+				Action:       seccompkg.OnBlockErrno,
+			},
+		},
+	}
+	filt, err := InstallFilterWithConfig(cfg)
+	if err != nil {
+		lower := strings.ToLower(err.Error())
+		if strings.Contains(lower, "permission") || strings.Contains(lower, "operation not permitted") {
+			t.Skipf("cannot install seccomp filter (privilege): %v", err)
+		}
+		t.Fatalf("InstallFilterWithConfig: %v", err)
+	}
+	defer filt.Close()
+
+	// No notify handler is started. With the fix, socket(NETLINK_XFRM) does not
+	// match the AF_UNIX-scoped notify rule and is errno'd by the kernel. Before
+	// the fix it would trap to USER_NOTIF and block here forever (caught by the
+	// subprocess timeout in runSocketRuleHelperSubprocess).
+	fd, _, errno := gounix.Syscall(
+		gounix.SYS_SOCKET,
+		uintptr(gounix.AF_NETLINK),
+		uintptr(gounix.SOCK_RAW|gounix.SOCK_CLOEXEC),
+		uintptr(gounix.NETLINK_XFRM),
+	)
+	printRawSyscallResult("socket_result", fd, errno)
 }
 
 func runSocketRuleHelperSubprocess(t *testing.T, mode string) string {
@@ -802,6 +867,62 @@ func (r *recordingConditionalAdder) AddRuleConditional(call seccomp.ScmpSyscall,
 		syscall:    call,
 		action:     action,
 		conditions: copied,
+	})
+	if r.failOnCall != 0 && len(r.calls) == r.failOnCall {
+		return errors.New("synthetic add failure")
+	}
+	return nil
+}
+
+func TestInstallUnixSocketNotifyRules_SocketScopedToAFUnix(t *testing.T) {
+	recorder := &recordingConditionalAdder{}
+
+	added, err := installUnixSocketNotifyRules(recorder, seccomp.ActNotify)
+
+	require.NoError(t, err)
+	require.Equal(t, 5, added)
+
+	// socket(2) must be conditional on arg0==AF_UNIX. A catch-all notify on
+	// socket(2) traps every socket() call to userspace, which shadows the
+	// kernel-side conditional ActErrno socket_rules / blocked_families on other
+	// families (e.g. NETLINK_XFRM, AF_RXRPC) and silently lets them through.
+	var socketCall *recordedConditionalCall
+	for i := range recorder.calls {
+		if recorder.calls[i].syscall == seccomp.ScmpSyscall(gounix.SYS_SOCKET) {
+			socketCall = &recorder.calls[i]
+		}
+	}
+	require.NotNil(t, socketCall, "socket(2) notify rule must be installed")
+	require.Equal(t, seccomp.ActNotify, socketCall.action)
+	require.Contains(t, socketCall.conditions, seccomp.ScmpCondition{
+		Argument: 0,
+		Op:       seccomp.CompareEqual,
+		Operand1: uint64(gounix.AF_UNIX),
+	}, "socket(2) notify must be scoped to AF_UNIX, not catch-all")
+
+	// connect/bind/listen/sendto operate on an already-created fd (the family
+	// is not in arg0), so they remain unconditional notify.
+	for _, sc := range []seccomp.ScmpSyscall{
+		seccomp.ScmpSyscall(gounix.SYS_CONNECT),
+		seccomp.ScmpSyscall(gounix.SYS_BIND),
+		seccomp.ScmpSyscall(gounix.SYS_LISTEN),
+		seccomp.ScmpSyscall(gounix.SYS_SENDTO),
+	} {
+		found := false
+		for _, c := range recorder.calls {
+			if c.syscall == sc {
+				found = true
+				require.Empty(t, c.conditions, "%v notify should be unconditional", sc)
+			}
+		}
+		require.True(t, found, "%v notify rule must be installed", sc)
+	}
+}
+
+func (r *recordingConditionalAdder) AddRule(call seccomp.ScmpSyscall, action seccomp.ScmpAction) error {
+	r.calls = append(r.calls, recordedConditionalCall{
+		syscall: call,
+		action:  action,
 	})
 	if r.failOnCall != 0 && len(r.calls) == r.failOnCall {
 		return errors.New("synthetic add failure")

--- a/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
+++ b/internal/netmonitor/unix/wait_killable_probe_runner_linux.go
@@ -207,10 +207,8 @@ func runProbeChild() {
 // decision and the broadest composition is the fail-safe one to test.
 func addProbeFilterRules(adder fileMonitorRuleAdder) error {
 	trap := seccomp.ActNotify
-	for _, sc := range unixSocketNotifySyscalls() {
-		if err := adder.AddRule(sc, trap); err != nil {
-			return fmt.Errorf("add probe socket rule %v: %w", sc, err)
-		}
+	if _, err := installUnixSocketNotifyRules(adder, trap); err != nil {
+		return fmt.Errorf("add probe socket rules: %w", err)
 	}
 	if _, err := installFileMonitorRules(adder, trap, false); err != nil {
 		return fmt.Errorf("add probe file-monitor rules: %w", err)


### PR DESCRIPTION
## Problem

`errno`/`kill` `socket_rules` and `blocked_socket_families` are **silently unenforced** whenever `sandbox.unix_sockets.enabled: true`. A wrapped process could open `socket(AF_NETLINK, …, NETLINK_XFRM)`, `socket(AF_RXRPC, …)`, etc. despite a matching errno rule.

## Root cause

- The unix-socket monitor adds a **catch-all `SECCOMP_RET_USER_NOTIF`** rule on `socket(2)`.
- `socket_rules` / `blocked_socket_families` install **conditional `SECCOMP_RET_ERRNO`** rules on the *same* `socket(2)`.
- The catch-all notify preempts the conditional errno rule, so `socket(2)` traps to the userspace handler instead of being errno'd kernel-side.
- The handler's block-list intentionally excludes errno/kill rules (`buildBlockListConfigFor` only mirrors `log`/`log_and_kill`), on the assumption errno rules "never reach the handler" — false once the catch-all notify is present.

Net effect: the matching errno rule is neither kernel-enforced nor handler-enforced → the socket is allowed. (`syscalls.block` errno rules such as `request_key` were unaffected — they are not in the unix-socket notify set.)

Verified end-to-end: with `UnixSocketEnabled:true`, probing `socket(NETLINK_XFRM)` first **hangs** (trapped to USER_NOTIF, no handler); without unix monitoring it errno's immediately.

## Fix

Scope the `socket(2)` notify rule to `arg0 == AF_UNIX`. The monitor only cares about unix sockets, so coverage is unchanged, while non-AF_UNIX `socket()` calls stay on the kernel fast path where their conditional errno rules fire. `connect`/`bind`/`listen`/`sendto` act on an existing fd (family not in arg0) and don't collide with `socket_rules`, so they remain unconditional.

The WAIT_KILLABLE probe (#369) is routed through the same installer so its filter composition cannot drift from production.

## Tests

- `TestInstallUnixSocketNotifyRules_SocketScopedToAFUnix` — `socket(2)` notify is conditional on `AF_UNIX`; the other four stay unconditional.
- `TestSeccompSocketRuleBlock_ErrnoTupleWithUnixMonitor` — end-to-end guard: an errno `NETLINK_XFRM` rule returns `EAFNOSUPPORT` kernel-side with `UnixSocketEnabled:true` (pre-fix this hung, trapping to an absent handler).

Both watched RED→GREEN. Full `internal/netmonitor/unix`, `internal/seccomp`, and `internal/api` socket/blocklist/wrap suites pass (the 2 long-TMPDIR local-env failures are pre-existing and fail identically on base). `go build ./...` + `GOOS=windows go build ./...` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)