### PR TITLE
fix(#411): graceful degradation for unenforceable per-command cgroup limits

### DIFF
--- a/docs/superpowers/plans/2026-06-01-cgroup-best-effort-limits.md
+++ b/docs/superpowers/plans/2026-06-01-cgroup-best-effort-limits.md
@@ -1,0 +1,707 @@
+# Graceful Degradation for Unenforceable cgroup Limits (#411) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the shell shim from fail-closing every command (`exit 126`) on hosts where the nested cgroup's `memory.max` is not writable, by making the probe honest, classifying the EPERM write error, and adding an opt-in best-effort degrade policy.
+
+**Architecture:** Three layers. (1) The startup probe write-tests a child `memory.max` so it downgrades out of `ModeTopLevel` honestly. (2) `CgroupManager.Apply` classifies an EPERM `.max` write as the typed `CgroupResourceLimitsUnavailableError` (backstop). (3) `applyCgroupV2` degrades that typed error to a warning + no-op when `sandbox.cgroups.best_effort: true` **and** no eBPF enforcement is configured; otherwise the deliberate fail-closed behavior is unchanged. A separate, independent fix downgrades a per-exec wrapper log line that pollutes command stderr.
+
+**Tech Stack:** Go, cgroup v2, `internal/limits` (build-tagged `//go:build linux`), `internal/api`, `internal/config`, `internal/events`.
+
+**Reference spec:** `docs/superpowers/specs/2026-06-01-cgroup-best-effort-limits-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `internal/config/config.go` | config schema | add `BestEffort bool` to `SandboxCgroupsConfig` |
+| `internal/config/config_test.go` | config parse test | assert `best_effort` parses |
+| `internal/events/types.go` | event taxonomy | add `EventCgroupLimitsDegraded` |
+| `internal/limits/cgroupv2_probe.go` | startup probe | write-test child `memory.max` in `tryTopLevel` |
+| `internal/limits/cgroup_fs_fake_test.go` | test fake | add `writeErrUnder` (ancestor-keyed write failure) |
+| `internal/limits/cgroupv2_probe_test.go` | probe tests | non-writable child → not `ModeTopLevel` |
+| `internal/limits/cgroupv2_manager.go` | per-command apply | classify EPERM `.max` write; remove orphan dir |
+| `internal/limits/cgroupv2_manager_test.go` | manager tests | EPERM write → typed error + dir removed |
+| `internal/api/cgroups.go` | wrap-time cgroup setup | best-effort degrade branch |
+| `internal/api/cgroups_linux_test.go` | api tests | degrade succeeds; eBPF keeps strict |
+| `internal/netmonitor/unix/seccomp_linux.go` | filter install | downgrade per-exec "filter loaded" to Debug |
+
+---
+
+## Task 1: Add `best_effort` config field
+
+**Files:**
+- Modify: `internal/config/config.go:485-491`
+- Test: `internal/config/config_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/config/config_test.go` (near the existing cgroups assertions around line 93):
+
+```go
+func TestConfig_CgroupsBestEffortParses(t *testing.T) {
+	yaml := `
+sandbox:
+  cgroups:
+    enabled: true
+    best_effort: true
+`
+	cfg, err := Load([]byte(yaml))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !cfg.Sandbox.Cgroups.BestEffort {
+		t.Fatalf("sandbox.cgroups.best_effort: got false, want true")
+	}
+}
+```
+
+> Note: confirm the package's loader entrypoint. If `Load([]byte)` does not exist, mirror the helper used by the adjacent test at `config_test.go:93` (it already loads a config and reads `cfg.Sandbox.Cgroups.Enabled`). Use the same loader.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/config/ -run TestConfig_CgroupsBestEffortParses -v`
+Expected: FAIL — `cfg.Sandbox.Cgroups.BestEffort` undefined (compile error).
+
+- [ ] **Step 3: Add the field**
+
+In `internal/config/config.go`, modify `SandboxCgroupsConfig`:
+
+```go
+type SandboxCgroupsConfig struct {
+	Enabled bool `yaml:"enabled"`
+	// BasePath is a cgroupfs directory under which per-command cgroups will be created.
+	// If empty, agentsh will default to the current process cgroup.
+	// Note: this should be a path under /sys/fs/cgroup (or relative to the current process cgroup dir).
+	BasePath string `yaml:"base_path"`
+	// BestEffort, when true, degrades unenforceable per-command resource limits
+	// (e.g. memory.max EPERM on a non-writable nested cgroup) to a logged warning
+	// and runs the command WITHOUT the limit, instead of fail-closing the wrap.
+	// Defaults to false (fail-closed) to preserve the resource-limit guarantee.
+	// Ignored when eBPF enforcement is configured: the cgroup egress path stays strict.
+	// See issue #411.
+	BestEffort bool `yaml:"best_effort"`
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/config/ -run TestConfig_CgroupsBestEffortParses -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/config.go internal/config/config_test.go
+git commit -m "feat(#411): add sandbox.cgroups.best_effort config field"
+```
+
+---
+
+## Task 2: Add `cgroup_limits_degraded` event type
+
+**Files:**
+- Modify: `internal/events/types.go:150-154`, `:273-277`, and the `AllEventTypes` list (around `:279`)
+
+- [ ] **Step 1: Add the constant**
+
+In `internal/events/types.go`, extend the cgroup event block:
+
+```go
+// Cgroup v2 probe and enforcement events (see issue #197).
+const (
+	EventCgroupMode               EventType = "cgroup_mode"
+	EventCgroupOrphansReaped      EventType = "cgroup_orphans_reaped"
+	EventCgroupUnavailableRefusal EventType = "cgroup_unavailable_refusal"
+	// EventCgroupLimitsDegraded is emitted when sandbox.cgroups.best_effort is on
+	// and a per-command resource limit could not be enforced; the command runs
+	// without the limit. See issue #411.
+	EventCgroupLimitsDegraded EventType = "cgroup_limits_degraded"
+)
+```
+
+- [ ] **Step 2: Register its category**
+
+In the category map (around line 273-277), add:
+
+```go
+	EventCgroupUnavailableRefusal: "cgroup",
+	EventCgroupLimitsDegraded:     "cgroup",
+```
+
+- [ ] **Step 3: Add to `AllEventTypes`**
+
+Find the line in `AllEventTypes` (around line 318) listing `EventCgroupMode, EventCgroupOrphansReaped, EventCgroupUnavailableRefusal,` and append `EventCgroupLimitsDegraded`:
+
+```go
+	EventCgroupMode, EventCgroupOrphansReaped, EventCgroupUnavailableRefusal,
+	EventCgroupLimitsDegraded,
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run: `go build ./internal/events/`
+Expected: builds clean.
+
+> If the events package has a test asserting `len(AllEventTypes)` or round-tripping every type's category, run `go test ./internal/events/` and update the expected count/coverage to include the new type.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/events/types.go
+git commit -m "feat(#411): add cgroup_limits_degraded event type"
+```
+
+---
+
+## Task 3: Probe write-tests child `memory.max` (honest mode)
+
+**Files:**
+- Modify: `internal/limits/cgroupv2_probe.go` (`tryTopLevel`, around `:333-342`; add helper near `probeNestedWritability` at `:253`)
+- Modify: `internal/limits/cgroup_fs_fake_test.go` (add `writeErrUnder`)
+- Test: `internal/limits/cgroupv2_probe_test.go`
+
+**Context:** `tryTopLevel` currently only `Stat`s `memory.max` as a canary (it confirms the file exists, never that it is writable). On Freestyle the file exists but writes EPERM. All callers of `tryTopLevel` already wrap the result in `maybeUpgradeToAttachOnly` (`cgroupv2_probe.go:118,127,144,167`), so returning `ModeUnavailable` from `tryTopLevel` will be auto-upgraded to `ModeAttachOnly` when pid-attach is feasible — which routes per-command applies through the typed `CgroupResourceLimitsUnavailableError`.
+
+- [ ] **Step 1: Add `writeErrUnder` to the test fake**
+
+In `internal/limits/cgroup_fs_fake_test.go`, add a field to `fakeCgroupFS` (after `mkdirErrUnder`):
+
+```go
+	// writeErrUnder injects an error returned by WriteFile for any path whose
+	// ancestor directory equals a key. Used to simulate hosts where a child
+	// cgroup can be created but its memory.max is not writable (#411).
+	writeErrUnder map[string]error
+```
+
+Initialize it in `newFakeCgroupFS()`:
+
+```go
+		mkdirErrUnder:        map[string]error{},
+		writeErrUnder:        map[string]error{},
+```
+
+In `WriteFile` (the method at `:91`), add the ancestor check at the top of the function, before the existing `writeErrs` lookup:
+
+```go
+func (f *fakeCgroupFS) WriteFile(p string, data []byte, perm os.FileMode) error {
+	p = path.Clean(p)
+	for anc := path.Dir(p); anc != "/" && anc != "."; anc = path.Dir(anc) {
+		if err, ok := f.writeErrUnder[anc]; ok {
+			return &fs.PathError{Op: "write", Path: p, Err: err}
+		}
+	}
+	// ... existing body (writeErrs lookup, etc.) unchanged ...
+```
+
+> Confirm `path` and `io/fs` are already imported in this file (they are — `path.Clean` and `fs.PathError` are used elsewhere in the fake).
+
+- [ ] **Step 2: Write the failing probe test**
+
+Add to `internal/limits/cgroupv2_probe_test.go`. Mirror the existing top-level setup (see the test seeding `agentsh.slice/memory.max` around line 64-95):
+
+```go
+func TestProbe_TopLevelMemoryMaxNotWritable_DowngradesFromTopLevel(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+	f.openErrs[own+"/cgroup.subtree_control:write"] = syscall.EBUSY // force fallback to top-level
+	f.seedFile(DefaultSliceDir+"/memory.max", "max")                // canary exists
+	f.writeErrUnder[DefaultSliceDir] = syscall.EPERM                // but child writes EPERM
+
+	// permitAttachOnly=false so the result is not upgraded; we assert the raw downgrade.
+	res, err := ProbeCgroupsV2(context.Background(), f, own, false)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode == ModeTopLevel {
+		t.Fatalf("mode: got ModeTopLevel, want a downgraded mode (memory.max not writable)")
+	}
+}
+
+func TestProbe_TopLevelMemoryMaxNotWritable_UpgradesToAttachOnly(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+	f.openErrs[own+"/cgroup.subtree_control:write"] = syscall.EBUSY
+	f.seedFile(DefaultSliceDir+"/memory.max", "max")
+	f.writeErrUnder[DefaultSliceDir] = syscall.EPERM
+
+	// permitAttachOnly=true: attach feasibility is checked against `own`, which
+	// allows mkdir + cgroup.procs writes, so the result upgrades to attach-only.
+	res, err := ProbeCgroupsV2(context.Background(), f, own, true)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeAttachOnly {
+		t.Fatalf("mode: got %q, want ModeAttachOnly", res.Mode)
+	}
+}
+```
+
+> Confirm the probe entrypoint name/signature. From `cgroupv2_manager.go:37` it is `ProbeCgroupsV2(ctx, fs, ownHint, permitAttachOnly)`. If `seedHealthyRoot`/`DefaultSliceDir`/`openErrs` usage differs, copy the exact setup from the passing test `TestManagerApply_TopLevelWritesUnderSlice` in `cgroupv2_manager_test.go:49`.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `go test ./internal/limits/ -run 'TestProbe_TopLevelMemoryMaxNotWritable' -v`
+Expected: FAIL — both currently return `ModeTopLevel` because the probe never tests writability.
+
+- [ ] **Step 4: Add the write-test helper**
+
+In `internal/limits/cgroupv2_probe.go`, add near `probeNestedWritability` (`:253`):
+
+```go
+// probeTopLevelLimitWritability verifies that a child cgroup created under
+// sliceDir accepts a write to its memory.max. On hosts where the slice exists
+// with controller files present but the nested cgroup is not writable (e.g.
+// Freestyle Firecracker), mkdir of the child succeeds yet writing memory.max
+// returns EPERM. Stat'ing memory.max (the old canary) does not catch this.
+// Writing the value "max" is a safe no-op the kernel always accepts when the
+// file is writable. The probe child is removed before returning. See #411.
+func probeTopLevelLimitWritability(fs cgroupFS, sliceDir string) error {
+	name := fmt.Sprintf("agentsh.limit-probe-%d-%d", os.Getpid(), time.Now().UnixNano())
+	probeDir := filepath.Join(sliceDir, name)
+	if err := fs.Mkdir(probeDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir probe child: %w", err)
+	}
+	writeErr := fs.WriteFile(filepath.Join(probeDir, "memory.max"), []byte("max"), 0o644)
+	_ = fs.Remove(probeDir)
+	if writeErr != nil {
+		return fmt.Errorf("write child memory.max: %w", writeErr)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 5: Wire it into `tryTopLevel`**
+
+In `internal/limits/cgroupv2_probe.go`, replace the canary block at `:333-342` so that after confirming `memory.max` exists, it also checks writability. The new code:
+
+```go
+	if _, err := fs.Stat(filepath.Join(DefaultSliceDir, "memory.max")); err != nil {
+		// memory.max is the canary: if it's missing, controller files weren't created
+		// even though mkdir succeeded — enforcement is not possible here.
+		return &CgroupProbeResult{
+			Mode:      ModeUnavailable,
+			Reason:    fmt.Sprintf("%s; %s missing controller files after mkdir", nestedFailureReason, DefaultSliceDir),
+			OwnCgroup: own,
+			SliceDir:  DefaultSliceDir,
+		}, nil
+	}
+	// The canary file exists, but on nested cgroups it may not be writable
+	// (mkdir of a child succeeds, memory.max write EPERMs). Verify before
+	// claiming ModeTopLevel; callers upgrade ModeUnavailable to ModeAttachOnly
+	// when pid-attach is still feasible. See #411.
+	if werr := probeTopLevelLimitWritability(fs, DefaultSliceDir); werr != nil {
+		return &CgroupProbeResult{
+			Mode:      ModeUnavailable,
+			Reason:    fmt.Sprintf("%s; %s child memory.max not writable: %v", nestedFailureReason, DefaultSliceDir, werr),
+			OwnCgroup: own,
+			SliceDir:  DefaultSliceDir,
+		}, nil
+	}
+```
+
+- [ ] **Step 6: Run the new tests to verify they pass**
+
+Run: `go test ./internal/limits/ -run 'TestProbe_TopLevelMemoryMaxNotWritable' -v`
+Expected: PASS — downgrade test gets a non-top-level mode; upgrade test gets `ModeAttachOnly`.
+
+- [ ] **Step 7: Run the full limits suite to catch regressions**
+
+Run: `go test ./internal/limits/ -v`
+Expected: PASS. The existing `ModeTopLevel` tests (e.g. `TestManagerApply_TopLevelWritesUnderSlice`) still pass because the probe's random child write succeeds in the fake (no `writeErrUnder` set).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/limits/cgroupv2_probe.go internal/limits/cgroupv2_probe_test.go internal/limits/cgroup_fs_fake_test.go
+git commit -m "fix(#411): probe write-tests child memory.max so top-level mode is honest"
+```
+
+---
+
+## Task 4: Classify EPERM `.max` write as typed error + clean orphan dir
+
+**Files:**
+- Modify: `internal/limits/cgroupv2_manager.go:96-100` (and the pids/cpu writes for consistency)
+- Test: `internal/limits/cgroupv2_manager_test.go`
+
+**Context:** Backstop for hosts that change after the probe snapshot. Currently an EPERM `memory.max` write returns a plain `fmt.Errorf`, which downstream falls through the generic abort path. We classify EPERM/EACCES as `CgroupResourceLimitsUnavailableError` and remove the just-created (empty) child dir to avoid orphan accumulation.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `internal/limits/cgroupv2_manager_test.go` (mirror `TestManagerApply_TopLevelWritesUnderSlice` at `:49`):
+
+```go
+func TestManagerApply_TopLevelMemoryMaxWriteEPERM_ReturnsTypedErrorAndCleansUp(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+	f.openErrs[own+"/cgroup.subtree_control:write"] = syscall.EBUSY
+	f.seedFile(DefaultSliceDir+"/memory.max", "max")
+
+	m, err := newCgroupManagerFS(context.Background(), f, own, false)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	if m.Probe().Mode != ModeTopLevel {
+		t.Fatalf("precondition: mode %q, want ModeTopLevel", m.Probe().Mode)
+	}
+
+	// Now make the per-command child memory.max write fail (deterministic path).
+	childMemMax := DefaultSliceDir + "/agentsh-sess-cmd/memory.max"
+	f.writeErrs[childMemMax] = syscall.EPERM
+
+	_, err = m.Apply("agentsh-sess-cmd", 1234, CgroupV2Limits{MaxMemoryBytes: 8 << 20})
+	var rlErr *CgroupResourceLimitsUnavailableError
+	if !errors.As(err, &rlErr) {
+		t.Fatalf("error type: got %T (%v), want *CgroupResourceLimitsUnavailableError", err, err)
+	}
+	// The empty child dir must have been removed.
+	if _, statErr := f.Stat(DefaultSliceDir + "/agentsh-sess-cmd"); statErr == nil {
+		t.Errorf("orphan child cgroup dir left behind after EPERM write")
+	}
+}
+```
+
+> The Probe in `newCgroupManagerFS` runs the Task 3 write-test against a *random* child and succeeds (no `writeErrUnder` set), so the mode is `ModeTopLevel`. We then set `writeErrs` on the *deterministic* per-command path used by `Apply` (the `name` arg, sanitized), so only the real apply write fails.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/limits/ -run TestManagerApply_TopLevelMemoryMaxWriteEPERM -v`
+Expected: FAIL — error is a plain `fmt.Errorf`, not the typed error; and the dir is left behind.
+
+- [ ] **Step 3: Classify the error and clean up**
+
+In `internal/limits/cgroupv2_manager.go`, replace the three `.max` write blocks (`:96-111`) so a permission failure returns the typed error after removing the empty dir. Add `"io/fs"` to imports if not present (for `fs.PathError` matching via `errors.Is` with `syscall.EPERM`/`EACCES`). Implementation:
+
+```go
+	writeLimit := func(file string, val []byte) error {
+		if err := m.fs.WriteFile(filepath.Join(dir, file), val, 0o644); err != nil {
+			if errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.EACCES) {
+				// Host won't permit the limit write even though mkdir succeeded
+				// (non-writable nested cgroup). Remove the empty child so we don't
+				// accumulate orphans, and surface the deliberate typed error so
+				// callers can apply best-effort policy instead of a generic abort.
+				_ = m.fs.Remove(dir)
+				return &CgroupResourceLimitsUnavailableError{
+					Reason: fmt.Sprintf("write %s (mode=%s, dir=%s): %v", file, m.probe.Mode, dir, err),
+					Limits: lim,
+				}
+			}
+			return fmt.Errorf("write %s (mode=%s, dir=%s): %w", file, m.probe.Mode, dir, err)
+		}
+		return nil
+	}
+
+	if lim.MaxMemoryBytes > 0 {
+		if err := writeLimit("memory.max", []byte(strconv.FormatInt(lim.MaxMemoryBytes, 10))); err != nil {
+			return nil, err
+		}
+	}
+	if lim.PidsMax > 0 {
+		if err := writeLimit("pids.max", []byte(strconv.Itoa(lim.PidsMax))); err != nil {
+			return nil, err
+		}
+	}
+	if lim.CPUQuotaPct > 0 {
+		q, p := cpuMaxFromPct(lim.CPUQuotaPct)
+		if err := writeLimit("cpu.max", []byte(fmt.Sprintf("%d %d", q, p))); err != nil {
+			return nil, err
+		}
+	}
+```
+
+> `errors` and `syscall` are already imported in this file (see `:6-11`). `os/io fs` is not needed — `errors.Is(err, syscall.EPERM)` unwraps the `*fs.PathError` returned by both the real `osCgroupFS.WriteFile` and the fake.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/limits/ -run TestManagerApply_TopLevelMemoryMaxWriteEPERM -v`
+Expected: PASS
+
+- [ ] **Step 5: Run the full limits suite**
+
+Run: `go test ./internal/limits/`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/limits/cgroupv2_manager.go internal/limits/cgroupv2_manager_test.go
+git commit -m "fix(#411): classify EPERM cgroup limit write as typed error, clean orphan dir"
+```
+
+---
+
+## Task 5: Best-effort degrade in `applyCgroupV2`
+
+**Files:**
+- Modify: `internal/api/cgroups.go:73-127` (the error switch)
+- Test: `internal/api/cgroups_linux_test.go`
+
+**Context:** When `Apply` returns `CgroupResourceLimitsUnavailableError` or `CgroupUnavailableError`, degrade to a no-op when `best_effort` is set AND no eBPF flag is on. eBPF egress depends on the cgroup, so any eBPF flag keeps the strict path. Test harness `newAppWithFakeCgroupManager` + `fakeCgroupManagerForAPITest{mode, applyErr}` already exists (see `cgroups_linux_test.go:477`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/api/cgroups_linux_test.go`:
+
+```go
+// best_effort + no eBPF + limits-unavailable → degrade (nil err, no-op cleanup, event emitted)
+func TestApplyCgroupV2_BestEffort_LimitsUnavailable_Degrades(t *testing.T) {
+	withEBPFHooks(t)
+	cgPath := t.TempDir()
+
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Cgroups.BestEffort = true
+	// eBPF off — pure resource-limit case.
+
+	app := newAppWithFakeCgroupManager(t, cfg, cgPath)
+	fake := app.cgroupMgr.(*fakeCgroupManagerForAPITest)
+	fake.mode = limits.ModeAttachOnly
+	fake.applyErr = &limits.CgroupResourceLimitsUnavailableError{
+		Reason: "child memory.max not writable: EPERM",
+		Limits: limits.CgroupV2Limits{MaxMemoryBytes: 16 << 20},
+	}
+
+	cleanup, err := applyCgroupV2(context.Background(),
+		storeEmitter{store: app.store, broker: app.broker}, app,
+		"sess", "cmd", 1234, policy.Limits{MaxMemoryMB: 16}, nil, nil)
+	if err != nil {
+		t.Fatalf("expected degrade (nil err), got %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("expected non-nil no-op cleanup")
+	}
+	_ = cleanup()
+}
+
+// best_effort=false → still fail closed
+func TestApplyCgroupV2_BestEffortDisabled_LimitsUnavailable_FailsClosed(t *testing.T) {
+	withEBPFHooks(t)
+	cgPath := t.TempDir()
+
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Cgroups.BestEffort = false
+
+	app := newAppWithFakeCgroupManager(t, cfg, cgPath)
+	fake := app.cgroupMgr.(*fakeCgroupManagerForAPITest)
+	fake.mode = limits.ModeAttachOnly
+	fake.applyErr = &limits.CgroupResourceLimitsUnavailableError{
+		Reason: "child memory.max not writable: EPERM",
+		Limits: limits.CgroupV2Limits{MaxMemoryBytes: 16 << 20},
+	}
+
+	_, err := applyCgroupV2(context.Background(),
+		storeEmitter{store: app.store, broker: app.broker}, app,
+		"sess", "cmd", 1234, policy.Limits{MaxMemoryMB: 16}, nil, nil)
+	var rlErr *limits.CgroupResourceLimitsUnavailableError
+	if !errors.As(err, &rlErr) {
+		t.Fatalf("expected typed error, got %T (%v)", err, err)
+	}
+}
+
+// best_effort=true BUT eBPF enabled → egress boundary preserved, still fail closed
+func TestApplyCgroupV2_BestEffort_WithEBPF_FailsClosed(t *testing.T) {
+	withEBPFHooks(t)
+	cgPath := t.TempDir()
+
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Cgroups.BestEffort = true
+	cfg.Sandbox.Network.EBPF.Enabled = true // egress boundary present
+
+	app := newAppWithFakeCgroupManager(t, cfg, cgPath)
+	fake := app.cgroupMgr.(*fakeCgroupManagerForAPITest)
+	fake.mode = limits.ModeAttachOnly
+	fake.applyErr = &limits.CgroupResourceLimitsUnavailableError{
+		Reason: "child memory.max not writable: EPERM",
+		Limits: limits.CgroupV2Limits{MaxMemoryBytes: 16 << 20},
+	}
+
+	_, err := applyCgroupV2(context.Background(),
+		storeEmitter{store: app.store, broker: app.broker}, app,
+		"sess", "cmd", 1234, policy.Limits{MaxMemoryMB: 16}, nil, nil)
+	if err == nil {
+		t.Fatal("expected fail-closed with eBPF enabled, got nil")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/api/ -run 'TestApplyCgroupV2_BestEffort' -v`
+Expected: the `_Degrades` test FAILs (error currently propagates); the other two may already pass — that's fine, they lock in behavior.
+
+- [ ] **Step 3: Implement the degrade branch**
+
+In `internal/api/cgroups.go`, add a helper above `applyCgroupV2`:
+
+```go
+// cgroupBestEffortDegradable reports whether an unenforceable resource-limit
+// error should degrade to a no-op (run without the limit) rather than fail
+// closed. Degradation requires sandbox.cgroups.best_effort AND the absence of
+// any eBPF flag — eBPF egress enforcement rides on the cgroup and must stay
+// strict. See issue #411.
+func cgroupBestEffortDegradable(cfg *config.Config) bool {
+	if cfg == nil || !cfg.Sandbox.Cgroups.BestEffort {
+		return false
+	}
+	e := cfg.Sandbox.Network.EBPF
+	return !e.Enabled && !e.Enforce && !e.Required
+}
+```
+
+Then, inside `applyCgroupV2`'s error switch (`:76-127`), add a degrade check at the top of **both** the `rlue` and `ue` cases, before emitting the refusal event and returning the error. For the `rlue` case:
+
+```go
+		case errors.As(err, &rlue):
+			if cgroupBestEffortDegradable(cfg) {
+				slog.Warn("cgroup: resource limits unenforceable; running without them (best_effort)",
+					"session_id", sessionID, "command_id", cmdID, "reason", rlue.Reason,
+					"max_memory_mb", lim.MaxMemoryMB, "cpu_quota_pct", lim.CPUQuotaPercent, "pids_max", lim.PidsMax)
+				ev := types.Event{
+					ID:        uuid.NewString(),
+					Timestamp: time.Now().UTC(),
+					Type:      string(events.EventCgroupLimitsDegraded),
+					SessionID: sessionID,
+					CommandID: cmdID,
+					Fields: map[string]any{
+						"reason":        rlue.Reason,
+						"max_memory_mb": lim.MaxMemoryMB,
+						"cpu_quota_pct": lim.CPUQuotaPercent,
+						"pids_max":      lim.PidsMax,
+					},
+				}
+				_ = emit.AppendEvent(ctx, ev)
+				emit.Publish(ev)
+				return func() error { return nil }, nil
+			}
+			ev := types.Event{
+				// ... existing refusal event unchanged ...
+```
+
+Apply the identical degrade prelude to the `ue` (`CgroupUnavailableError`) case, referencing `ue.Reason` instead of `rlue.Reason`.
+
+> `cfg` is already in scope (`cfg := app.cfg` at `:37`). `slog`, `events`, `types`, `uuid`, `time` are already imported.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/api/ -run 'TestApplyCgroupV2_BestEffort' -v`
+Expected: PASS (all three).
+
+- [ ] **Step 5: Run the api suite**
+
+Run: `go test ./internal/api/`
+Expected: PASS — existing `TestDefaultWrapCgroupSetup_*` tests unaffected (they set `best_effort=false` implicitly via zero value, or enable eBPF).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/api/cgroups.go internal/api/cgroups_linux_test.go
+git commit -m "fix(#411): best-effort degrade for unenforceable cgroup limits (no eBPF)"
+```
+
+---
+
+## Task 6: Stop the per-exec "seccomp: filter loaded" line polluting command stderr
+
+**Files:**
+- Modify: `internal/netmonitor/unix/seccomp_linux.go:518-523`
+
+**Context (independent of the cgroup fix):** This `slog.Info` is emitted by the `agentsh-unixwrap` wrapper process, whose slog default handler writes to **the wrapped command's stderr** (the wrapper uses stdlib `log`→stderr; slog default → stderr at Info). The wrapper has no log-forwarding channel to the server (server.log lines come from the server process), so per the spec's fallback we downgrade this single per-exec line to `Debug`. Operators who need the #369 `wait_killable` diagnostic can raise the wrapper's slog level.
+
+- [ ] **Step 1: Downgrade the line**
+
+In `internal/netmonitor/unix/seccomp_linux.go`, change the `slog.Info` at `:518` to `slog.Debug`:
+
+```go
+	// Per-exec diagnostic. Emitted from the unixwrap wrapper whose slog lands on
+	// the wrapped command's stderr; keep at Debug so machine-readable command
+	// output (e.g. `agentsh detect --output json`) is not corrupted. #369/#411.
+	slog.Debug("seccomp: filter loaded",
+		"fd", rawFd,
+		"wait_killable", gotWaitKill,
+		"wait_killable_source", cfg.WaitKillableSource,
+		"kernel_probe_supports", ProbeWaitKillable(),
+		"libseccomp_runtime", libVer)
+```
+
+- [ ] **Step 2: Verify no test asserts this line at Info**
+
+Run: `grep -rn "filter loaded" internal/ cmd/ --include=*_test.go`
+Expected: no test asserts the level/presence of this line. (If one does, update it to expect Debug.)
+
+- [ ] **Step 3: Build the package**
+
+Run: `go build ./internal/netmonitor/unix/`
+Expected: builds clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/netmonitor/unix/seccomp_linux.go
+git commit -m "fix(#411): downgrade per-exec 'seccomp: filter loaded' to Debug (stderr pollution)"
+```
+
+---
+
+## Task 7: Full verification
+
+- [ ] **Step 1: Build everything**
+
+Run: `go build ./...`
+Expected: clean.
+
+- [ ] **Step 2: Cross-compile for Windows (per CLAUDE.md)**
+
+Run: `GOOS=windows go build ./...`
+Expected: clean. (The `internal/limits` cgroup code is `//go:build linux`; ensure nothing leaked into a cross-platform file.)
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `go test ./...`
+Expected: PASS. Known pre-existing flakes unrelated to this change (per project memory): `TestFlushLoop_PeriodicSync` (Windows timer), `TestStore_*EmitsTransportLossOnWire` (load-sensitive), DB-proxy spine `-race` tests, and 3 local-env-only failures. Do not chase those.
+
+- [ ] **Step 4: Run targeted suites once more**
+
+Run: `go test ./internal/limits/ ./internal/api/ ./internal/config/ ./internal/events/ ./internal/netmonitor/unix/`
+Expected: PASS.
+
+- [ ] **Step 5: roborev the branch (per project workflow)**
+
+Per project memory (`feedback_roborev_between_tasks`): run roborev on the branch and fix all issues above low before proceeding to PR.
+
+Use the `roborev-review-branch` skill. Address findings, re-review until clean.
+
+- [ ] **Step 6: Final commit / ready for PR**
+
+Ensure the working tree is clean and all commits are present:
+
+```bash
+git log --oneline -8
+git status
+```
+
+---
+
+## Self-Review Notes (addressed)
+
+- **Spec §1 (probe write-test):** Task 3. Reuses `maybeUpgradeToAttachOnly` via existing `tryTopLevel` callers — no new wiring of the upgrade path needed.
+- **Spec §2 (classify EPERM + orphan cleanup):** Task 4, including the explicit `Remove(dir)` the spec self-review added.
+- **Spec §3 (best_effort knob, eBPF gate):** Tasks 1 + 5. eBPF gate verified by `TestApplyCgroupV2_BestEffort_WithEBPF_FailsClosed`.
+- **Spec §4 (sequencing):** No `wrap.go` change — degrade returns nil from `applyCgroupV2`, handshake proceeds. Confirmed via `defaultWrapCgroupSetupForNotify` → `applyCgroupV2` call chain.
+- **Spec §5 (stderr):** Task 6.
+- **Spec "non-permission errors still fail closed":** Task 4's `writeLimit` only classifies EPERM/EACCES; other errors keep the `%w` plain-error path → generic failure (unchanged).
+- **Event type name consistency:** `EventCgroupLimitsDegraded` / string `"cgroup_limits_degraded"` used identically in Tasks 2 and 5.
+- **Config field name consistency:** `BestEffort` / yaml `best_effort` used identically in Tasks 1 and 5.

--- a/docs/superpowers/specs/2026-06-01-cgroup-best-effort-limits-design.md
+++ b/docs/superpowers/specs/2026-06-01-cgroup-best-effort-limits-design.md
@@ -1,0 +1,193 @@
+# Design: Graceful degradation for unenforceable per-command cgroup limits (#411)
+
+**Date:** 2026-06-01
+**Issue:** #411
+**Status:** Proposed
+
+## Problem
+
+On hosts where agentsh's cgroup is nested under another service's slice and
+`cgroup.subtree_control` is not writable (e.g. Freestyle Firecracker VMs),
+**every command through the shell shim aborts with `exit 126`** /
+`server rejected wrap setup`.
+
+Root cause chain:
+
+1. **The startup probe is over-optimistic.** `tryTopLevel`
+   (`internal/limits/cgroupv2_probe.go:333`) uses `memory.max` *existence*
+   (`fs.Stat`) as its canary. The slice dir exists with controller files
+   present, so the probe returns `ModeTopLevel` — even though the file is not
+   actually **writable**.
+2. **The per-command write EPERMs and the error is unclassified.**
+   `CgroupManager.Apply` (`internal/limits/cgroupv2_manager.go:97`) does
+   `mkdir` (succeeds) then `WriteFile(memory.max)` → EPERM, returning a plain
+   `fmt.Errorf("write memory.max…")`. In `applyCgroupV2`
+   (`internal/api/cgroups.go:112`) that plain error falls through the
+   `default:` arm (not the deliberate typed fail-closed paths) and returns
+   `nil, err`.
+3. **It is on the before-ACK critical path.** `wrapNeedsCgroupBeforeAck`
+   returns true (`cgroups.enabled`), so `wrapCgroupSetupForNotifyHook` runs
+   before the notify-fd ACK (`internal/api/wrap.go:840`). Any error there
+   aborts the handshake → notify-status `false` → shim fail-closes → `exit
+   126` on *every* command.
+
+The limits were never enforceable on such a host anyway — this is a documented
+nested-cgroup gap that `agentsh detect` already warns about. The current
+failure is therefore neither a useful security refusal nor a graceful skip; it
+is an unhandled error that happens to abort the command with a cryptic code.
+
+### Design tension
+
+agentsh has a **deliberate fail-closed stance**: if a command requests a
+resource limit that cannot be enforced, refuse rather than run pretending to be
+sandboxed (the typed `CgroupUnavailableError` /
+`CgroupResourceLimitsUnavailableError`). The issue asks for the opposite —
+degrade and run. eBPF already models this graduation with `Enabled` /
+`Enforce` / `Required`.
+
+Critically, cgroup **resource limits (mem/cpu/pids) are QoS / DoS-protection,
+not a confinement boundary** — exceeding a memory cap does not *escape* the
+sandbox. The confinement boundaries are seccomp and eBPF egress, the latter of
+which rides on the same cgroup and must keep failing closed.
+
+## Approach
+
+Two robustness fixes ship unconditionally (they are simply *correct*); one
+opt-in policy knob enables degradation; one independent fix addresses the
+stderr-pollution side observation.
+
+### 1. Probe writability test (unconditional correctness fix)
+
+`internal/limits/cgroupv2_probe.go`
+
+After confirming `memory.max` exists in `tryTopLevel`, actually **test that a
+child cgroup's limit file is writable**: `mkdir` a throwaway probe child under
+the slice, attempt `WriteFile(memory.max, "max")` (a safe no-op value the
+kernel always accepts), then remove the child.
+
+- If the probe child `mkdir` fails → `ModeUnavailable` (cannot create children
+  at all).
+- If the limit write fails with EPERM/EACCES → reuse the existing
+  attach-feasibility logic (`maybeUpgradeToAttachOnly` /
+  `probeAttachOnlyFeasibility`) to land on `ModeAttachOnly` when pid-attach is
+  feasible, otherwise `ModeUnavailable`. The reason string records "memory.max
+  not writable in child cgroup".
+- If the write succeeds → `ModeTopLevel` as today (remove the probe child).
+
+Effect: `agentsh detect` now reports the truth on Freestyle-style hosts, and
+the per-command path naturally routes through the *typed*
+`CgroupResourceLimitsUnavailableError` (the `ModeAttachOnly` arm in `Apply`)
+instead of the over-optimistic `ModeTopLevel` write-and-fail path.
+
+### 2. Classify runtime `.max` write EPERM as typed error (unconditional, defense-in-depth)
+
+`internal/limits/cgroupv2_manager.go`
+
+The probe is a point-in-time snapshot; a host can change after startup. As a
+backstop, when a `.max` write in `Apply` fails with EPERM/EACCES, wrap it in
+`CgroupResourceLimitsUnavailableError` rather than a plain `fmt.Errorf`. This
+guarantees the failure is *legible* (a refusal/degrade event) regardless of
+whether the probe caught it, and never again falls through the generic
+`default:` abort arm. Because the `ModeTopLevel` arm `mkdir`s the child cgroup
+*before* attempting the write, this path must also `Remove` the just-created
+(empty) child dir before returning, so a degraded host does not accumulate
+orphan cgroups between the per-command failure and the next startup reap.
+
+### 3. Opt-in best-effort policy knob (the behavior change)
+
+`internal/config/config.go` — add to `SandboxCgroupsConfig`:
+
+```go
+type SandboxCgroupsConfig struct {
+    Enabled    bool   `yaml:"enabled"`
+    BasePath   string `yaml:"base_path"`
+    BestEffort bool   `yaml:"best_effort"` // NEW: degrade unenforceable resource limits instead of failing closed
+}
+```
+
+`BestEffort` defaults to `false` → **current fail-closed behavior is
+preserved** (zero-value additive). Chosen over a `Required *bool` pointer for
+self-documenting additivity; the eBPF graduated model is the conceptual
+precedent.
+
+In `applyCgroupV2` (`internal/api/cgroups.go`), when `Apply` returns
+`CgroupResourceLimitsUnavailableError` **or** `CgroupUnavailableError`:
+
+- **If** `cfg.Sandbox.Cgroups.BestEffort` is true **and** no eBPF enforcement
+  is in play (`!ebpfEnabled && !ebpfEnforce && !ebpfRequired`): log a warning,
+  emit a new `cgroup_limits_degraded` event (carrying the reason + requested
+  limits), and **return a no-op cleanup with nil error** so the wrap handshake
+  proceeds and the command runs *without* the limit.
+- **Else**: behave exactly as today (emit the refusal event, return the error,
+  fail closed).
+
+The eBPF gate is essential: eBPF egress enforcement depends on the cgroup
+existing with the process attached, so when any eBPF flag is set the cgroup
+path must still succeed (mkdir + attach do succeed on Freestyle; only the
+*limit writes* EPERM — but we keep the strict path here to avoid silently
+weakening an egress boundary).
+
+### 4. Sequencing
+
+No structural change to `wrap.go`. The degrade happens inside `applyCgroupV2`,
+which now returns a nil error in the best-effort case, so the before-ACK
+handshake proceeds naturally. Cgroup **create + attach** stay before the ACK
+(eBPF depends on them); only the **resource-limit unenforceability** is
+degradable. This satisfies the issue's "ideally don't fail the handshake"
+without a risky re-architecture of the critical path.
+
+### 5. Side observation: stderr pollution (independent fix)
+
+`internal/netmonitor/unix/seccomp_linux.go:518`
+
+The per-exec `slog.Info("seccomp: filter loaded", …)` is emitted by the
+wrapper process, whose slog output lands on the **wrapped command's stderr**,
+corrupting machine-readable stderr streams (notably `agentsh detect --output
+json`). Fix: route the wrapper's diagnostic logging off the user-visible
+stderr — preferred is to send it through the server-log channel; if no such
+channel is reachable from the wrapper, downgrade this line to `slog.Debug`.
+Tracked as a separate, lower-priority workstream from the cgroup fix.
+
+## Components & boundaries
+
+| Unit | Change | Depends on |
+|------|--------|-----------|
+| `cgroupv2_probe.go` | write-test child `memory.max`; honest mode | existing `maybeUpgradeToAttachOnly` |
+| `cgroupv2_manager.go` | classify EPERM `.max` write as typed error | error types in `cgroupv2_errors.go` |
+| `config.go` | add `BestEffort bool` | — |
+| `cgroups.go::applyCgroupV2` | degrade-on-typed-error when `BestEffort && !ebpf*` | config field, typed errors |
+| `seccomp_linux.go` | route filter-loaded line off command stderr | — (independent) |
+
+## Error handling
+
+- Unenforceable limits, `BestEffort=false` (default): fail closed, refusal
+  event — unchanged guarantee.
+- Unenforceable limits, `BestEffort=true`, no eBPF: warn + `cgroup_limits_degraded`
+  event + run without limit.
+- Unenforceable limits, `BestEffort=true`, eBPF enabled/enforce/required: fail
+  closed (egress boundary preserved).
+- Unexpected (non-permission) write errors: still fail closed regardless of
+  `BestEffort` (only EPERM/EACCES are classified as "unavailable"; other
+  errors remain hard failures).
+
+## Testing
+
+- **Probe** (`cgroupv2_probe_test.go`): fake FS where slice `memory.max`
+  exists but child `memory.max` write returns EPERM → assert `ModeAttachOnly`
+  (or `ModeUnavailable` when attach also fails), not `ModeTopLevel`.
+- **Manager** (`cgroupv2_manager_test.go`): EPERM on `.max` write →
+  `CgroupResourceLimitsUnavailableError`, not plain error.
+- **applyCgroupV2** (api tests): typed error + `BestEffort=true` + no eBPF →
+  nil error, no-op cleanup, `cgroup_limits_degraded` emitted; same +
+  `BestEffort=false` → error propagated; same + eBPF required → error
+  propagated even with `BestEffort=true`.
+- **Wrap** (`wrap_linux_test.go`): best-effort degrade path → handshake ACKs
+  successfully (no `exit 126`).
+- **Cross-compile:** `GOOS=windows go build ./...` (the limits package is
+  `//go:build linux`; ensure no Windows breakage).
+
+## Out of scope
+
+- Making nested-cgroup limits actually enforceable (kernel/host limitation).
+- Changing the default fail-closed posture for any other sandbox subsystem.
+- Reworking the before-ACK handshake architecture.

--- a/internal/api/cgroups.go
+++ b/internal/api/cgroups.go
@@ -47,6 +47,33 @@ func cgroupBestEffortDegradable(cfg *config.Config) bool {
 	return !e.Enabled && !e.Enforce && !e.Required
 }
 
+// emitCgroupDegradedAndContinue logs and emits a single cgroup_limits_degraded
+// event, then returns a no-op cleanup so the wrap proceeds without the limit.
+// errorType distinguishes the resource-limits-unavailable case from the
+// total-cgroup-unavailable case for downstream alerting. See issue #411.
+func emitCgroupDegradedAndContinue(ctx context.Context, emit storeEmitter, sessionID, cmdID, errorType, reason string, lim policy.Limits) (func() error, error) {
+	slog.Warn("cgroup: enforcement unavailable; running without it (best_effort)",
+		"session_id", sessionID, "command_id", cmdID, "error_type", errorType, "reason", reason,
+		"max_memory_mb", lim.MaxMemoryMB, "cpu_quota_pct", lim.CPUQuotaPercent, "pids_max", lim.PidsMax)
+	ev := types.Event{
+		ID:        uuid.NewString(),
+		Timestamp: time.Now().UTC(),
+		Type:      string(events.EventCgroupLimitsDegraded),
+		SessionID: sessionID,
+		CommandID: cmdID,
+		Fields: map[string]any{
+			"error_type":    errorType,
+			"reason":        reason,
+			"max_memory_mb": lim.MaxMemoryMB,
+			"cpu_quota_pct": lim.CPUQuotaPercent,
+			"pids_max":      lim.PidsMax,
+		},
+	}
+	_ = emit.AppendEvent(ctx, ev)
+	emit.Publish(ev)
+	return func() error { return nil }, nil
+}
+
 func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, cmdID string, pid int, lim policy.Limits, m *metrics.Collector, pol *policy.Engine) (func() error, error) {
 	cfg := app.cfg
 	needsCgroup := cfg != nil && (cfg.Sandbox.Cgroups.Enabled ||
@@ -90,25 +117,7 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 		switch {
 		case errors.As(err, &rlue):
 			if cgroupBestEffortDegradable(cfg) {
-				slog.Warn("cgroup: resource limits unenforceable; running without them (best_effort)",
-					"session_id", sessionID, "command_id", cmdID, "reason", rlue.Reason,
-					"max_memory_mb", lim.MaxMemoryMB, "cpu_quota_pct", lim.CPUQuotaPercent, "pids_max", lim.PidsMax)
-				ev := types.Event{
-					ID:        uuid.NewString(),
-					Timestamp: time.Now().UTC(),
-					Type:      string(events.EventCgroupLimitsDegraded),
-					SessionID: sessionID,
-					CommandID: cmdID,
-					Fields: map[string]any{
-						"reason":        rlue.Reason,
-						"max_memory_mb": lim.MaxMemoryMB,
-						"cpu_quota_pct": lim.CPUQuotaPercent,
-						"pids_max":      lim.PidsMax,
-					},
-				}
-				_ = emit.AppendEvent(ctx, ev)
-				emit.Publish(ev)
-				return func() error { return nil }, nil
+				return emitCgroupDegradedAndContinue(ctx, emit, sessionID, cmdID, "resource_limits_unavailable", rlue.Reason, lim)
 			}
 			ev := types.Event{
 				ID:        uuid.NewString(),
@@ -129,25 +138,7 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 			return nil, err
 		case errors.As(err, &ue):
 			if cgroupBestEffortDegradable(cfg) {
-				slog.Warn("cgroup: enforcement unavailable; running without cgroup (best_effort)",
-					"session_id", sessionID, "command_id", cmdID, "reason", ue.Reason,
-					"max_memory_mb", lim.MaxMemoryMB, "cpu_quota_pct", lim.CPUQuotaPercent, "pids_max", lim.PidsMax)
-				ev := types.Event{
-					ID:        uuid.NewString(),
-					Timestamp: time.Now().UTC(),
-					Type:      string(events.EventCgroupLimitsDegraded),
-					SessionID: sessionID,
-					CommandID: cmdID,
-					Fields: map[string]any{
-						"reason":        ue.Reason,
-						"max_memory_mb": lim.MaxMemoryMB,
-						"cpu_quota_pct": lim.CPUQuotaPercent,
-						"pids_max":      lim.PidsMax,
-					},
-				}
-				_ = emit.AppendEvent(ctx, ev)
-				emit.Publish(ev)
-				return func() error { return nil }, nil
+				return emitCgroupDegradedAndContinue(ctx, emit, sessionID, cmdID, "cgroup_unavailable", ue.Reason, lim)
 			}
 			ev := types.Event{
 				ID:        uuid.NewString(),

--- a/internal/api/cgroups.go
+++ b/internal/api/cgroups.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cilium/ebpf"
 
+	"github.com/agentsh/agentsh/internal/config"
 	"github.com/agentsh/agentsh/internal/events"
 	"github.com/agentsh/agentsh/internal/limits"
 	"github.com/agentsh/agentsh/internal/metrics"
@@ -32,6 +33,19 @@ var (
 	ebpfPopulateAllowlist     = ebpftrace.PopulateAllowlist
 	ebpfCleanupAllowlist      = ebpftrace.CleanupAllowlist
 )
+
+// cgroupBestEffortDegradable reports whether an unenforceable resource-limit
+// error should degrade to a no-op (run without the limit) rather than fail
+// closed. Degradation requires sandbox.cgroups.best_effort AND the absence of
+// any eBPF flag — eBPF egress enforcement rides on the cgroup and must stay
+// strict. See issue #411.
+func cgroupBestEffortDegradable(cfg *config.Config) bool {
+	if cfg == nil || !cfg.Sandbox.Cgroups.BestEffort {
+		return false
+	}
+	e := cfg.Sandbox.Network.EBPF
+	return !e.Enabled && !e.Enforce && !e.Required
+}
 
 func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, cmdID string, pid int, lim policy.Limits, m *metrics.Collector, pol *policy.Engine) (func() error, error) {
 	cfg := app.cfg
@@ -75,6 +89,27 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 		var rlue *limits.CgroupResourceLimitsUnavailableError
 		switch {
 		case errors.As(err, &rlue):
+			if cgroupBestEffortDegradable(cfg) {
+				slog.Warn("cgroup: resource limits unenforceable; running without them (best_effort)",
+					"session_id", sessionID, "command_id", cmdID, "reason", rlue.Reason,
+					"max_memory_mb", lim.MaxMemoryMB, "cpu_quota_pct", lim.CPUQuotaPercent, "pids_max", lim.PidsMax)
+				ev := types.Event{
+					ID:        uuid.NewString(),
+					Timestamp: time.Now().UTC(),
+					Type:      string(events.EventCgroupLimitsDegraded),
+					SessionID: sessionID,
+					CommandID: cmdID,
+					Fields: map[string]any{
+						"reason":        rlue.Reason,
+						"max_memory_mb": lim.MaxMemoryMB,
+						"cpu_quota_pct": lim.CPUQuotaPercent,
+						"pids_max":      lim.PidsMax,
+					},
+				}
+				_ = emit.AppendEvent(ctx, ev)
+				emit.Publish(ev)
+				return func() error { return nil }, nil
+			}
 			ev := types.Event{
 				ID:        uuid.NewString(),
 				Timestamp: time.Now().UTC(),
@@ -93,6 +128,27 @@ func applyCgroupV2(ctx context.Context, emit storeEmitter, app *App, sessionID, 
 			emit.Publish(ev)
 			return nil, err
 		case errors.As(err, &ue):
+			if cgroupBestEffortDegradable(cfg) {
+				slog.Warn("cgroup: enforcement unavailable; running without cgroup (best_effort)",
+					"session_id", sessionID, "command_id", cmdID, "reason", ue.Reason,
+					"max_memory_mb", lim.MaxMemoryMB, "cpu_quota_pct", lim.CPUQuotaPercent, "pids_max", lim.PidsMax)
+				ev := types.Event{
+					ID:        uuid.NewString(),
+					Timestamp: time.Now().UTC(),
+					Type:      string(events.EventCgroupLimitsDegraded),
+					SessionID: sessionID,
+					CommandID: cmdID,
+					Fields: map[string]any{
+						"reason":        ue.Reason,
+						"max_memory_mb": lim.MaxMemoryMB,
+						"cpu_quota_pct": lim.CPUQuotaPercent,
+						"pids_max":      lim.PidsMax,
+					},
+				}
+				_ = emit.AppendEvent(ctx, ev)
+				emit.Publish(ev)
+				return func() error { return nil }, nil
+			}
 			ev := types.Event{
 				ID:        uuid.NewString(),
 				Timestamp: time.Now().UTC(),

--- a/internal/api/cgroups.go
+++ b/internal/api/cgroups.go
@@ -44,6 +44,8 @@ func cgroupBestEffortDegradable(cfg *config.Config) bool {
 		return false
 	}
 	e := cfg.Sandbox.Network.EBPF
+	// EnforceWithoutDNS is intentionally omitted: it is a modifier that has no
+	// effect unless Enforce is set, which is already checked above. #411.
 	return !e.Enabled && !e.Enforce && !e.Required
 }
 

--- a/internal/api/cgroups_linux_test.go
+++ b/internal/api/cgroups_linux_test.go
@@ -565,6 +565,37 @@ func TestApplyCgroupV2_BestEffort_LimitsUnavailable_Degrades(t *testing.T) {
 	_ = cleanup()
 }
 
+// TestApplyCgroupV2_BestEffort_UnavailableError_Degrades verifies that when
+// best_effort=true and no eBPF flags are set, a CgroupUnavailableError
+// causes a degraded run (nil error, no-op cleanup) rather than a hard failure.
+func TestApplyCgroupV2_BestEffort_UnavailableError_Degrades(t *testing.T) {
+	withEBPFHooks(t)
+	cgPath := t.TempDir()
+
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Cgroups.BestEffort = true
+
+	app := newAppWithFakeCgroupManager(t, cfg, cgPath)
+	fake := app.cgroupMgr.(*fakeCgroupManagerForAPITest)
+	fake.mode = limits.ModeUnavailable
+	fake.applyErr = &limits.CgroupUnavailableError{
+		Reason: "cgroup subsystem unavailable",
+		Limits: limits.CgroupV2Limits{MaxMemoryBytes: 16 << 20},
+	}
+
+	cleanup, err := applyCgroupV2(context.Background(),
+		storeEmitter{store: app.store, broker: app.broker}, app,
+		"sess", "cmd", 1234, policy.Limits{MaxMemoryMB: 16}, nil, nil)
+	if err != nil {
+		t.Fatalf("expected degrade (nil err), got %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("expected non-nil no-op cleanup")
+	}
+	_ = cleanup()
+}
+
 // TestApplyCgroupV2_BestEffortDisabled_LimitsUnavailable_FailsClosed verifies
 // that best_effort=false keeps the existing fail-closed behavior.
 func TestApplyCgroupV2_BestEffortDisabled_LimitsUnavailable_FailsClosed(t *testing.T) {

--- a/internal/api/cgroups_linux_test.go
+++ b/internal/api/cgroups_linux_test.go
@@ -535,8 +535,10 @@ func TestDefaultWrapCgroupSetup_Unavailable_NotRequired_WarnContinues(t *testing
 }
 
 // drainCgroupEvents collects events published to the broker for the given
-// session without blocking, returning the first cgroup_limits_degraded event
-// (or nil) and whether any cgroup_unavailable_refusal event was seen.
+// session without blocking, returning the most recent cgroup_limits_degraded
+// event (or nil) and whether any cgroup_unavailable_refusal event was seen.
+// The degrade paths under test each emit exactly one degraded event, so "most
+// recent" and "only" coincide here.
 func drainCgroupEvents(ch <-chan types.Event) (degraded *types.Event, sawRefusal bool) {
 	for {
 		select {

--- a/internal/api/cgroups_linux_test.go
+++ b/internal/api/cgroups_linux_test.go
@@ -533,6 +533,93 @@ func TestDefaultWrapCgroupSetup_Unavailable_NotRequired_WarnContinues(t *testing
 	}
 }
 
+// TestApplyCgroupV2_BestEffort_LimitsUnavailable_Degrades verifies that when
+// best_effort=true and no eBPF flags are set, a CgroupResourceLimitsUnavailableError
+// causes a degraded run (nil error, no-op cleanup) rather than a hard failure.
+func TestApplyCgroupV2_BestEffort_LimitsUnavailable_Degrades(t *testing.T) {
+	withEBPFHooks(t)
+	cgPath := t.TempDir()
+
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Cgroups.BestEffort = true
+	// eBPF off — pure resource-limit case.
+
+	app := newAppWithFakeCgroupManager(t, cfg, cgPath)
+	fake := app.cgroupMgr.(*fakeCgroupManagerForAPITest)
+	fake.mode = limits.ModeAttachOnly
+	fake.applyErr = &limits.CgroupResourceLimitsUnavailableError{
+		Reason: "child memory.max not writable: EPERM",
+		Limits: limits.CgroupV2Limits{MaxMemoryBytes: 16 << 20},
+	}
+
+	cleanup, err := applyCgroupV2(context.Background(),
+		storeEmitter{store: app.store, broker: app.broker}, app,
+		"sess", "cmd", 1234, policy.Limits{MaxMemoryMB: 16}, nil, nil)
+	if err != nil {
+		t.Fatalf("expected degrade (nil err), got %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("expected non-nil no-op cleanup")
+	}
+	_ = cleanup()
+}
+
+// TestApplyCgroupV2_BestEffortDisabled_LimitsUnavailable_FailsClosed verifies
+// that best_effort=false keeps the existing fail-closed behavior.
+func TestApplyCgroupV2_BestEffortDisabled_LimitsUnavailable_FailsClosed(t *testing.T) {
+	withEBPFHooks(t)
+	cgPath := t.TempDir()
+
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Cgroups.BestEffort = false
+
+	app := newAppWithFakeCgroupManager(t, cfg, cgPath)
+	fake := app.cgroupMgr.(*fakeCgroupManagerForAPITest)
+	fake.mode = limits.ModeAttachOnly
+	fake.applyErr = &limits.CgroupResourceLimitsUnavailableError{
+		Reason: "child memory.max not writable: EPERM",
+		Limits: limits.CgroupV2Limits{MaxMemoryBytes: 16 << 20},
+	}
+
+	_, err := applyCgroupV2(context.Background(),
+		storeEmitter{store: app.store, broker: app.broker}, app,
+		"sess", "cmd", 1234, policy.Limits{MaxMemoryMB: 16}, nil, nil)
+	var rlErr *limits.CgroupResourceLimitsUnavailableError
+	if !errors.As(err, &rlErr) {
+		t.Fatalf("expected typed error, got %T (%v)", err, err)
+	}
+}
+
+// TestApplyCgroupV2_BestEffort_WithEBPF_FailsClosed verifies that when
+// best_effort=true but eBPF is enabled, egress enforcement must stay strict
+// and the error is still returned (fail closed).
+func TestApplyCgroupV2_BestEffort_WithEBPF_FailsClosed(t *testing.T) {
+	withEBPFHooks(t)
+	cgPath := t.TempDir()
+
+	cfg := &config.Config{}
+	cfg.Sandbox.Cgroups.Enabled = true
+	cfg.Sandbox.Cgroups.BestEffort = true
+	cfg.Sandbox.Network.EBPF.Enabled = true // egress boundary present
+
+	app := newAppWithFakeCgroupManager(t, cfg, cgPath)
+	fake := app.cgroupMgr.(*fakeCgroupManagerForAPITest)
+	fake.mode = limits.ModeAttachOnly
+	fake.applyErr = &limits.CgroupResourceLimitsUnavailableError{
+		Reason: "child memory.max not writable: EPERM",
+		Limits: limits.CgroupV2Limits{MaxMemoryBytes: 16 << 20},
+	}
+
+	_, err := applyCgroupV2(context.Background(),
+		storeEmitter{store: app.store, broker: app.broker}, app,
+		"sess", "cmd", 1234, policy.Limits{MaxMemoryMB: 16}, nil, nil)
+	if err == nil {
+		t.Fatal("expected fail-closed with eBPF enabled, got nil")
+	}
+}
+
 // TestDefaultWrapCgroupSetup_Unavailable_Required_HardFails verifies that
 // when the probe mode is ModeUnavailable and ebpf.required is true, the
 // CgroupUnavailableError propagates as a hard failure.

--- a/internal/api/cgroups_linux_test.go
+++ b/internal/api/cgroups_linux_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/internal/store/composite"
+	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/cilium/ebpf"
 )
 
@@ -533,6 +534,26 @@ func TestDefaultWrapCgroupSetup_Unavailable_NotRequired_WarnContinues(t *testing
 	}
 }
 
+// drainCgroupEvents collects events published to the broker for the given
+// session without blocking, returning the first cgroup_limits_degraded event
+// (or nil) and whether any cgroup_unavailable_refusal event was seen.
+func drainCgroupEvents(ch <-chan types.Event) (degraded *types.Event, sawRefusal bool) {
+	for {
+		select {
+		case ev := <-ch:
+			switch ev.Type {
+			case string(events.EventCgroupLimitsDegraded):
+				e := ev
+				degraded = &e
+			case string(events.EventCgroupUnavailableRefusal):
+				sawRefusal = true
+			}
+		default:
+			return degraded, sawRefusal
+		}
+	}
+}
+
 // TestApplyCgroupV2_BestEffort_LimitsUnavailable_Degrades verifies that when
 // best_effort=true and no eBPF flags are set, a CgroupResourceLimitsUnavailableError
 // causes a degraded run (nil error, no-op cleanup) rather than a hard failure.
@@ -553,6 +574,7 @@ func TestApplyCgroupV2_BestEffort_LimitsUnavailable_Degrades(t *testing.T) {
 		Limits: limits.CgroupV2Limits{MaxMemoryBytes: 16 << 20},
 	}
 
+	ch := app.broker.Subscribe("sess", 8)
 	cleanup, err := applyCgroupV2(context.Background(),
 		storeEmitter{store: app.store, broker: app.broker}, app,
 		"sess", "cmd", 1234, policy.Limits{MaxMemoryMB: 16}, nil, nil)
@@ -561,6 +583,16 @@ func TestApplyCgroupV2_BestEffort_LimitsUnavailable_Degrades(t *testing.T) {
 	}
 	if cleanup == nil {
 		t.Fatal("expected non-nil no-op cleanup")
+	}
+	degraded, sawRefusal := drainCgroupEvents(ch)
+	if degraded == nil {
+		t.Fatal("expected a cgroup_limits_degraded event to be published")
+	}
+	if degraded.Fields["error_type"] != "resource_limits_unavailable" {
+		t.Errorf("error_type: got %v, want resource_limits_unavailable", degraded.Fields["error_type"])
+	}
+	if sawRefusal {
+		t.Error("cgroup_unavailable_refusal must not be emitted on the degrade path")
 	}
 	_ = cleanup()
 }
@@ -584,6 +616,7 @@ func TestApplyCgroupV2_BestEffort_UnavailableError_Degrades(t *testing.T) {
 		Limits: limits.CgroupV2Limits{MaxMemoryBytes: 16 << 20},
 	}
 
+	ch := app.broker.Subscribe("sess", 8)
 	cleanup, err := applyCgroupV2(context.Background(),
 		storeEmitter{store: app.store, broker: app.broker}, app,
 		"sess", "cmd", 1234, policy.Limits{MaxMemoryMB: 16}, nil, nil)
@@ -592,6 +625,16 @@ func TestApplyCgroupV2_BestEffort_UnavailableError_Degrades(t *testing.T) {
 	}
 	if cleanup == nil {
 		t.Fatal("expected non-nil no-op cleanup")
+	}
+	degraded, sawRefusal := drainCgroupEvents(ch)
+	if degraded == nil {
+		t.Fatal("expected a cgroup_limits_degraded event to be published")
+	}
+	if degraded.Fields["error_type"] != "cgroup_unavailable" {
+		t.Errorf("error_type: got %v, want cgroup_unavailable", degraded.Fields["error_type"])
+	}
+	if sawRefusal {
+		t.Error("cgroup_unavailable_refusal must not be emitted on the degrade path")
 	}
 	_ = cleanup()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -488,6 +488,13 @@ type SandboxCgroupsConfig struct {
 	// If empty, agentsh will default to the current process cgroup.
 	// Note: this should be a path under /sys/fs/cgroup (or relative to the current process cgroup dir).
 	BasePath string `yaml:"base_path"`
+	// BestEffort, when true, degrades unenforceable per-command resource limits
+	// (e.g. memory.max EPERM on a non-writable nested cgroup) to a logged warning
+	// and runs the command WITHOUT the limit, instead of fail-closing the wrap.
+	// Defaults to false (fail-closed) to preserve the resource-limit guarantee.
+	// Ignored when eBPF enforcement is configured: the cgroup egress path stays strict.
+	// See issue #411.
+	BestEffort bool `yaml:"best_effort"`
 }
 
 type SandboxUnixSocketsConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2339,3 +2339,18 @@ func TestAuditWatchtowerConfig_BatchCompression_DefaultsExpand(t *testing.T) {
 		t.Errorf("default gzip_level = %d, want 6", got)
 	}
 }
+
+func TestConfig_CgroupsBestEffortParses(t *testing.T) {
+	cfg, err := loadFromString(t, `
+sandbox:
+  cgroups:
+    enabled: true
+    best_effort: true
+`)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !cfg.Sandbox.Cgroups.BestEffort {
+		t.Fatalf("sandbox.cgroups.best_effort: got false, want true")
+	}
+}

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -104,8 +104,8 @@ const (
 //
 // See docs/seccomp.md § "Audit Events" for the JSON wire format.
 const (
-	EventSeccompBlocked      EventType = "seccomp_blocked"
-	EventNotifyHandlerPanic  EventType = "notify_handler_panic"
+	EventSeccompBlocked     EventType = "seccomp_blocked"
+	EventNotifyHandlerPanic EventType = "notify_handler_panic"
 )
 
 // Signal events.
@@ -120,14 +120,14 @@ const (
 
 // MCP inspection events.
 const (
-	EventMCPToolSeen              EventType = "mcp_tool_seen"
-	EventMCPToolChanged           EventType = "mcp_tool_changed"
-	EventMCPToolCalled            EventType = "mcp_tool_called"
-	EventMCPDetection             EventType = "mcp_detection"
-	EventMCPToolCallIntercepted   EventType = "mcp_tool_call_intercepted"
-	EventMCPCrossServerBlocked    EventType = "mcp_cross_server_blocked"
-	EventMCPNetworkConnection     EventType = "mcp_network_connection"
-	EventMCPServerNameSimilarity  EventType = "mcp_server_name_similarity"
+	EventMCPToolSeen             EventType = "mcp_tool_seen"
+	EventMCPToolChanged          EventType = "mcp_tool_changed"
+	EventMCPToolCalled           EventType = "mcp_tool_called"
+	EventMCPDetection            EventType = "mcp_detection"
+	EventMCPToolCallIntercepted  EventType = "mcp_tool_call_intercepted"
+	EventMCPCrossServerBlocked   EventType = "mcp_cross_server_blocked"
+	EventMCPNetworkConnection    EventType = "mcp_network_connection"
+	EventMCPServerNameSimilarity EventType = "mcp_server_name_similarity"
 )
 
 // Package check events.
@@ -151,6 +151,10 @@ const (
 	EventCgroupMode               EventType = "cgroup_mode"
 	EventCgroupOrphansReaped      EventType = "cgroup_orphans_reaped"
 	EventCgroupUnavailableRefusal EventType = "cgroup_unavailable_refusal"
+	// EventCgroupLimitsDegraded is emitted when sandbox.cgroups.best_effort is on
+	// and a per-command resource limit could not be enforced; the command runs
+	// without the limit. See issue #411.
+	EventCgroupLimitsDegraded EventType = "cgroup_limits_degraded"
 )
 
 // PolicyLoadedEvent is emitted when a policy is loaded.
@@ -274,6 +278,7 @@ var EventCategory = map[EventType]string{
 	EventCgroupMode:               "cgroup",
 	EventCgroupOrphansReaped:      "cgroup",
 	EventCgroupUnavailableRefusal: "cgroup",
+	EventCgroupLimitsDegraded:     "cgroup",
 }
 
 // AllEventTypes lists all event types.
@@ -316,4 +321,5 @@ var AllEventTypes = []EventType{
 	EventPolicyLoaded, EventPolicyChanged,
 	// Cgroup
 	EventCgroupMode, EventCgroupOrphansReaped, EventCgroupUnavailableRefusal,
+	EventCgroupLimitsDegraded,
 }

--- a/internal/limits/cgroup_fs_fake_test.go
+++ b/internal/limits/cgroup_fs_fake_test.go
@@ -40,6 +40,10 @@ type fakeCgroupFS struct {
 	// cgroup.subtree_control reports delegated controllers but the kernel
 	// denies mkdir within the subtree (read-only delegation, MAC policies).
 	mkdirErrUnder map[string]error
+	// writeErrUnder injects an error returned by WriteFile for any path whose
+	// ancestor directory equals a key. Used to simulate hosts where a child
+	// cgroup can be created but its memory.max is not writable (#411).
+	writeErrUnder map[string]error
 }
 
 type fakeEntry struct {
@@ -55,6 +59,7 @@ func newFakeCgroupFS() *fakeCgroupFS {
 		openWriteErrsOnce:    map[string]error{},
 		openWriteContentErrs: map[string]error{},
 		mkdirErrUnder:        map[string]error{},
+		writeErrUnder:        map[string]error{},
 	}
 }
 
@@ -90,6 +95,11 @@ func (f *fakeCgroupFS) ReadFile(p string) ([]byte, error) {
 
 func (f *fakeCgroupFS) WriteFile(p string, data []byte, perm os.FileMode) error {
 	p = path.Clean(p)
+	for anc := path.Dir(p); anc != "/" && anc != "."; anc = path.Dir(anc) {
+		if err, ok := f.writeErrUnder[anc]; ok {
+			return &fs.PathError{Op: "write", Path: p, Err: err}
+		}
+	}
 	if err, ok := f.writeErrs[p]; ok {
 		return &fs.PathError{Op: "write", Path: p, Err: err}
 	}

--- a/internal/limits/cgroupv2_manager.go
+++ b/internal/limits/cgroupv2_manager.go
@@ -95,12 +95,14 @@ func (m *CgroupManager) Apply(name string, pid int, lim CgroupV2Limits) (*Cgroup
 
 	writeLimit := func(file string, val []byte) error {
 		if err := m.fs.WriteFile(filepath.Join(dir, file), val, 0o644); err != nil {
+			// errors.Is unwraps the *fs.PathError that os.WriteFile and the kernel return.
 			if errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.EACCES) {
 				// Host won't permit the limit write even though mkdir succeeded
 				// (non-writable nested cgroup). Remove the empty child so we don't
 				// accumulate orphans, and surface the deliberate typed error so
 				// callers can apply best-effort policy instead of a generic abort.
 				_ = m.fs.Remove(dir)
+				// Remove fails silently: EBUSY if the dir is populated (safe), ENOENT if already gone.
 				return &CgroupResourceLimitsUnavailableError{
 					Reason: fmt.Sprintf("write %s (mode=%s, dir=%s): %v", file, m.probe.Mode, dir, err),
 					Limits: lim,

--- a/internal/limits/cgroupv2_manager.go
+++ b/internal/limits/cgroupv2_manager.go
@@ -89,8 +89,14 @@ func (m *CgroupManager) Apply(name string, pid int, lim CgroupV2Limits) (*Cgroup
 	safe := sanitizeCgroupName(name)
 	dir := filepath.Join(parent, safe)
 
-	if err := m.fs.Mkdir(dir, 0o755); err != nil && !errors.Is(err, syscall.EEXIST) {
-		return nil, fmt.Errorf("mkdir cgroup (mode=%s, dir=%s): %w", m.probe.Mode, dir, err)
+	createdDir := true
+	if err := m.fs.Mkdir(dir, 0o755); err != nil {
+		if !errors.Is(err, syscall.EEXIST) {
+			return nil, fmt.Errorf("mkdir cgroup (mode=%s, dir=%s): %w", m.probe.Mode, dir, err)
+		}
+		// The dir already existed — this call did not create it, so the
+		// EPERM-cleanup below must not remove it.
+		createdDir = false
 	}
 
 	writeLimit := func(file string, val []byte) error {
@@ -98,11 +104,13 @@ func (m *CgroupManager) Apply(name string, pid int, lim CgroupV2Limits) (*Cgroup
 			// errors.Is unwraps the *fs.PathError that os.WriteFile and the kernel return.
 			if errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.EACCES) {
 				// Host won't permit the limit write even though mkdir succeeded
-				// (non-writable nested cgroup). Remove the empty child so we don't
-				// accumulate orphans, and surface the deliberate typed error so
-				// callers can apply best-effort policy instead of a generic abort.
-				_ = m.fs.Remove(dir)
-				// Remove fails silently: EBUSY if the dir is populated (safe), ENOENT if already gone.
+				// (non-writable nested cgroup). Remove the child we created so we
+				// don't accumulate orphans, and surface the deliberate typed error
+				// so callers can apply best-effort policy instead of a generic abort.
+				if createdDir {
+					// Remove fails silently: EBUSY if the dir is populated (safe), ENOENT if already gone.
+					_ = m.fs.Remove(dir)
+				}
 				return &CgroupResourceLimitsUnavailableError{
 					Reason: fmt.Sprintf("write %s (mode=%s, dir=%s): %v", file, m.probe.Mode, dir, err),
 					Limits: lim,

--- a/internal/limits/cgroupv2_manager.go
+++ b/internal/limits/cgroupv2_manager.go
@@ -93,20 +93,38 @@ func (m *CgroupManager) Apply(name string, pid int, lim CgroupV2Limits) (*Cgroup
 		return nil, fmt.Errorf("mkdir cgroup (mode=%s, dir=%s): %w", m.probe.Mode, dir, err)
 	}
 
+	writeLimit := func(file string, val []byte) error {
+		if err := m.fs.WriteFile(filepath.Join(dir, file), val, 0o644); err != nil {
+			if errors.Is(err, syscall.EPERM) || errors.Is(err, syscall.EACCES) {
+				// Host won't permit the limit write even though mkdir succeeded
+				// (non-writable nested cgroup). Remove the empty child so we don't
+				// accumulate orphans, and surface the deliberate typed error so
+				// callers can apply best-effort policy instead of a generic abort.
+				_ = m.fs.Remove(dir)
+				return &CgroupResourceLimitsUnavailableError{
+					Reason: fmt.Sprintf("write %s (mode=%s, dir=%s): %v", file, m.probe.Mode, dir, err),
+					Limits: lim,
+				}
+			}
+			return fmt.Errorf("write %s (mode=%s, dir=%s): %w", file, m.probe.Mode, dir, err)
+		}
+		return nil
+	}
+
 	if lim.MaxMemoryBytes > 0 {
-		if err := m.fs.WriteFile(filepath.Join(dir, "memory.max"), []byte(strconv.FormatInt(lim.MaxMemoryBytes, 10)), 0o644); err != nil {
-			return nil, fmt.Errorf("write memory.max (mode=%s, dir=%s): %w", m.probe.Mode, dir, err)
+		if err := writeLimit("memory.max", []byte(strconv.FormatInt(lim.MaxMemoryBytes, 10))); err != nil {
+			return nil, err
 		}
 	}
 	if lim.PidsMax > 0 {
-		if err := m.fs.WriteFile(filepath.Join(dir, "pids.max"), []byte(strconv.Itoa(lim.PidsMax)), 0o644); err != nil {
-			return nil, fmt.Errorf("write pids.max (mode=%s, dir=%s): %w", m.probe.Mode, dir, err)
+		if err := writeLimit("pids.max", []byte(strconv.Itoa(lim.PidsMax))); err != nil {
+			return nil, err
 		}
 	}
 	if lim.CPUQuotaPct > 0 {
 		q, p := cpuMaxFromPct(lim.CPUQuotaPct)
-		if err := m.fs.WriteFile(filepath.Join(dir, "cpu.max"), []byte(fmt.Sprintf("%d %d", q, p)), 0o644); err != nil {
-			return nil, fmt.Errorf("write cpu.max (mode=%s, dir=%s): %w", m.probe.Mode, dir, err)
+		if err := writeLimit("cpu.max", []byte(fmt.Sprintf("%d %d", q, p))); err != nil {
+			return nil, err
 		}
 	}
 

--- a/internal/limits/cgroupv2_manager_test.go
+++ b/internal/limits/cgroupv2_manager_test.go
@@ -228,6 +228,41 @@ func TestManagerApply_NestedMemoryMaxWriteEPERM_ReturnsTypedErrorAndCleansUp(t *
 	}
 }
 
+func TestManagerApply_TopLevelMultiLimitPartialWriteEPERM_CleansUp(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+	f.openErrs[own+"/cgroup.subtree_control:write"] = syscall.EBUSY
+	f.seedFile(DefaultSliceDir+"/memory.max", "max")
+
+	m, err := newCgroupManagerFS(context.Background(), f, own, false)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	if m.Probe().Mode != ModeTopLevel {
+		t.Fatalf("precondition: mode %q, want ModeTopLevel", m.Probe().Mode)
+	}
+
+	// Inject EPERM on pids.max only — memory.max must succeed first so the
+	// child dir is non-empty when pids.max fails, exercising partial-write cleanup.
+	f.writeErrs[DefaultSliceDir+"/agentsh-sess-cmd/pids.max"] = syscall.EPERM
+
+	_, err = m.Apply("agentsh-sess-cmd", 1234, CgroupV2Limits{MaxMemoryBytes: 8 << 20, PidsMax: 64})
+	var rlErr *CgroupResourceLimitsUnavailableError
+	if !errors.As(err, &rlErr) {
+		t.Fatalf("error type: got %T (%v), want *CgroupResourceLimitsUnavailableError", err, err)
+	}
+	// The fake's Remove(dir) deletes only the exact dir key. After memory.max was
+	// written (adding the child file key) and pids.max EPERM triggered Remove(dir),
+	// the dir entry itself is gone — Stat of the dir returns ENOENT even though
+	// the child file key may remain as an orphan in the flat map.
+	if _, statErr := f.Stat(DefaultSliceDir + "/agentsh-sess-cmd"); statErr == nil {
+		t.Errorf("orphan child cgroup dir left behind after partial-write EPERM")
+	}
+}
+
 func TestManagerApply_AttachOnly_WithLimits_Refuses(t *testing.T) {
 	f := newFakeCgroupFS()
 	seedHealthyRoot(f)

--- a/internal/limits/cgroupv2_manager_test.go
+++ b/internal/limits/cgroupv2_manager_test.go
@@ -186,7 +186,44 @@ func TestManagerApply_TopLevelMemoryMaxWriteEPERM_ReturnsTypedErrorAndCleansUp(t
 	if !errors.As(err, &rlErr) {
 		t.Fatalf("error type: got %T (%v), want *CgroupResourceLimitsUnavailableError", err, err)
 	}
+	if rlErr.Limits.MaxMemoryBytes != 8<<20 {
+		t.Errorf("typed error Limits: got %+v, want MaxMemoryBytes=%d", rlErr.Limits, 8<<20)
+	}
 	if _, statErr := f.Stat(DefaultSliceDir + "/agentsh-sess-cmd"); statErr == nil {
+		t.Errorf("orphan child cgroup dir left behind after EPERM write")
+	}
+}
+
+func TestManagerApply_NestedMemoryMaxWriteEPERM_ReturnsTypedErrorAndCleansUp(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "cpu memory pids")
+
+	m, err := newCgroupManagerFS(context.Background(), f, own, false)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	if m.Probe().Mode != ModeNested {
+		t.Fatalf("precondition: mode %q, want ModeNested", m.Probe().Mode)
+	}
+
+	// parentDir() for ModeNested returns OwnCgroup; inject EPERM only on the
+	// deterministic per-command child path so the probe's random-name child
+	// write succeeds and the precondition above holds.
+	childMemMax := own + "/agentsh-sess-cmd/memory.max"
+	f.writeErrs[childMemMax] = syscall.EPERM
+
+	_, err = m.Apply("agentsh-sess-cmd", 1234, CgroupV2Limits{MaxMemoryBytes: 8 << 20})
+	var rlErr *CgroupResourceLimitsUnavailableError
+	if !errors.As(err, &rlErr) {
+		t.Fatalf("error type: got %T (%v), want *CgroupResourceLimitsUnavailableError", err, err)
+	}
+	if rlErr.Limits.MaxMemoryBytes != 8<<20 {
+		t.Errorf("typed error Limits: got %+v, want MaxMemoryBytes=%d", rlErr.Limits, 8<<20)
+	}
+	if _, statErr := f.Stat(own + "/agentsh-sess-cmd"); statErr == nil {
 		t.Errorf("orphan child cgroup dir left behind after EPERM write")
 	}
 }

--- a/internal/limits/cgroupv2_manager_test.go
+++ b/internal/limits/cgroupv2_manager_test.go
@@ -160,6 +160,37 @@ func TestManagerApply_AttachOnly_EmptyLimits_Succeeds(t *testing.T) {
 	}
 }
 
+func TestManagerApply_TopLevelMemoryMaxWriteEPERM_ReturnsTypedErrorAndCleansUp(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+	f.openErrs[own+"/cgroup.subtree_control:write"] = syscall.EBUSY
+	f.seedFile(DefaultSliceDir+"/memory.max", "max")
+
+	m, err := newCgroupManagerFS(context.Background(), f, own, false)
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+	if m.Probe().Mode != ModeTopLevel {
+		t.Fatalf("precondition: mode %q, want ModeTopLevel", m.Probe().Mode)
+	}
+
+	// Make the per-command child memory.max write fail (deterministic path from the name arg).
+	childMemMax := DefaultSliceDir + "/agentsh-sess-cmd/memory.max"
+	f.writeErrs[childMemMax] = syscall.EPERM
+
+	_, err = m.Apply("agentsh-sess-cmd", 1234, CgroupV2Limits{MaxMemoryBytes: 8 << 20})
+	var rlErr *CgroupResourceLimitsUnavailableError
+	if !errors.As(err, &rlErr) {
+		t.Fatalf("error type: got %T (%v), want *CgroupResourceLimitsUnavailableError", err, err)
+	}
+	if _, statErr := f.Stat(DefaultSliceDir + "/agentsh-sess-cmd"); statErr == nil {
+		t.Errorf("orphan child cgroup dir left behind after EPERM write")
+	}
+}
+
 func TestManagerApply_AttachOnly_WithLimits_Refuses(t *testing.T) {
 	f := newFakeCgroupFS()
 	seedHealthyRoot(f)

--- a/internal/limits/cgroupv2_probe.go
+++ b/internal/limits/cgroupv2_probe.go
@@ -260,6 +260,27 @@ func probeNestedWritability(fs cgroupFS, own string) error {
 	return nil
 }
 
+// probeTopLevelLimitWritability verifies that a child cgroup created under
+// sliceDir accepts a write to its memory.max. On hosts where the slice exists
+// with controller files present but the nested cgroup is not writable (e.g.
+// Freestyle Firecracker), mkdir of the child succeeds yet writing memory.max
+// returns EPERM. Stat'ing memory.max (the old canary) does not catch this.
+// Writing the value "max" is a safe no-op the kernel always accepts when the
+// file is writable. The probe child is removed before returning. See #411.
+func probeTopLevelLimitWritability(fs cgroupFS, sliceDir string) error {
+	name := fmt.Sprintf("agentsh.limit-probe-%d-%d", os.Getpid(), time.Now().UnixNano())
+	probeDir := filepath.Join(sliceDir, name)
+	if err := fs.Mkdir(probeDir, 0o755); err != nil {
+		return fmt.Errorf("mkdir probe child: %w", err)
+	}
+	writeErr := fs.WriteFile(filepath.Join(probeDir, "memory.max"), []byte("max"), 0o644)
+	_ = fs.Remove(probeDir)
+	if writeErr != nil {
+		return fmt.Errorf("write child memory.max: %w", writeErr)
+	}
+	return nil
+}
+
 // tryLeafMove handles the EBUSY case: the own cgroup has internal processes
 // (including agentsh itself), preventing subtree_control writes. We create a
 // "agentsh.leaf" child cgroup, move the current process into it, and retry enabling
@@ -336,6 +357,19 @@ func tryTopLevel(ctx context.Context, fs cgroupFS, own, nestedFailureReason stri
 		return &CgroupProbeResult{
 			Mode:      ModeUnavailable,
 			Reason:    fmt.Sprintf("%s; %s missing controller files after mkdir", nestedFailureReason, DefaultSliceDir),
+			OwnCgroup: own,
+			SliceDir:  DefaultSliceDir,
+		}, nil
+	}
+
+	// The canary file exists, but on nested cgroups it may not be writable
+	// (mkdir of a child succeeds, memory.max write EPERMs). Verify before
+	// claiming ModeTopLevel; callers upgrade ModeUnavailable to ModeAttachOnly
+	// when pid-attach is still feasible. See #411.
+	if werr := probeTopLevelLimitWritability(fs, DefaultSliceDir); werr != nil {
+		return &CgroupProbeResult{
+			Mode:      ModeUnavailable,
+			Reason:    fmt.Sprintf("%s; %s child memory.max not writable: %v", nestedFailureReason, DefaultSliceDir, werr),
 			OwnCgroup: own,
 			SliceDir:  DefaultSliceDir,
 		}, nil

--- a/internal/limits/cgroupv2_probe.go
+++ b/internal/limits/cgroupv2_probe.go
@@ -267,6 +267,11 @@ func probeNestedWritability(fs cgroupFS, own string) error {
 // returns EPERM. Stat'ing memory.max (the old canary) does not catch this.
 // Writing the value "max" is a safe no-op the kernel always accepts when the
 // file is writable. The probe child is removed before returning. See #411.
+//
+// Any Mkdir error (including EEXIST) is treated as failure — a pre-existing
+// probe directory is stale evidence (perms may have changed since it was
+// created, cleanup may have failed for unrelated reasons), so we fail closed
+// rather than falsely claim writability.
 func probeTopLevelLimitWritability(fs cgroupFS, sliceDir string) error {
 	name := fmt.Sprintf("agentsh.limit-probe-%d-%d", os.Getpid(), time.Now().UnixNano())
 	probeDir := filepath.Join(sliceDir, name)

--- a/internal/limits/cgroupv2_probe_test.go
+++ b/internal/limits/cgroupv2_probe_test.go
@@ -667,8 +667,11 @@ func TestProbe_TopLevelMemoryMaxNotWritable_DowngradesFromTopLevel(t *testing.T)
 	if err != nil {
 		t.Fatalf("probe: %v", err)
 	}
-	if res.Mode == ModeTopLevel {
-		t.Fatalf("mode: got ModeTopLevel, want a downgraded mode (memory.max not writable)")
+	if res.Mode != ModeUnavailable {
+		t.Fatalf("mode: got %q, want ModeUnavailable (memory.max not writable, attach-only not permitted)", res.Mode)
+	}
+	if !strings.Contains(res.Reason, "memory.max not writable") {
+		t.Errorf("reason should contain 'memory.max not writable': %q", res.Reason)
 	}
 }
 
@@ -690,5 +693,8 @@ func TestProbe_TopLevelMemoryMaxNotWritable_UpgradesToAttachOnly(t *testing.T) {
 	}
 	if res.Mode != ModeAttachOnly {
 		t.Fatalf("mode: got %q, want ModeAttachOnly", res.Mode)
+	}
+	if !strings.Contains(res.Reason, "memory.max not writable") {
+		t.Errorf("reason should contain 'memory.max not writable' (maybeUpgradeToAttachOnly preserves original reason): %q", res.Reason)
 	}
 }

--- a/internal/limits/cgroupv2_probe_test.go
+++ b/internal/limits/cgroupv2_probe_test.go
@@ -651,3 +651,44 @@ func TestProbe_AttachOnly_FilteredWhenFeasibilityFails(t *testing.T) {
 		t.Fatalf("reason should contain 'attach-only also infeasible': %q", res.Reason)
 	}
 }
+
+func TestProbe_TopLevelMemoryMaxNotWritable_DowngradesFromTopLevel(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+	f.openErrs[own+"/cgroup.subtree_control:write"] = syscall.EBUSY // force fallback to top-level
+	f.seedFile(DefaultSliceDir+"/memory.max", "max")                // canary exists
+	f.writeErrUnder[DefaultSliceDir] = syscall.EPERM                // but child writes EPERM
+
+	// permitAttachOnly=false so the result is NOT upgraded; assert the raw downgrade.
+	res, err := ProbeCgroupsV2(context.Background(), f, own, false)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode == ModeTopLevel {
+		t.Fatalf("mode: got ModeTopLevel, want a downgraded mode (memory.max not writable)")
+	}
+}
+
+func TestProbe_TopLevelMemoryMaxNotWritable_UpgradesToAttachOnly(t *testing.T) {
+	f := newFakeCgroupFS()
+	seedHealthyRoot(f)
+	own := "/sys/fs/cgroup/system.slice/agentsh.service"
+	f.seedFile(own+"/cgroup.controllers", "cpu memory pids")
+	f.seedFile(own+"/cgroup.subtree_control", "")
+	f.openErrs[own+"/cgroup.subtree_control:write"] = syscall.EBUSY
+	f.seedFile(DefaultSliceDir+"/memory.max", "max")
+	f.writeErrUnder[DefaultSliceDir] = syscall.EPERM
+
+	// permitAttachOnly=true: attach feasibility checks `own`, which allows mkdir +
+	// cgroup.procs writes, so the result upgrades to attach-only.
+	res, err := ProbeCgroupsV2(context.Background(), f, own, true)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if res.Mode != ModeAttachOnly {
+		t.Fatalf("mode: got %q, want ModeAttachOnly", res.Mode)
+	}
+}

--- a/internal/ocsf/registry.go
+++ b/internal/ocsf/registry.go
@@ -104,6 +104,7 @@ var pendingTypes = map[string]struct{}{
 	"cgroup_cleanup_failed":       {},
 	"cgroup_orphans_reaped":       {},
 	"cgroup_unavailable_refusal":  {},
+	"cgroup_limits_degraded":      {},
 	"notify_handler_panic":        {},
 	"fuse_mounted":                {},
 	"fuse_mount_failed":           {},


### PR DESCRIPTION
Closes #411.

## Problem

On hosts where agentsh's cgroup is nested under another service's slice and `cgroup.subtree_control` isn't writable (e.g. Freestyle Firecracker VMs), **every command through the shell shim aborted with `exit 126`** / `server rejected wrap setup`.

Root cause chain:
1. **The startup probe was over-optimistic.** `tryTopLevel` used `memory.max` *existence* (`Stat`) as its canary but never tested *writability*, so it returned `ModeTopLevel` on hosts that can't actually write limits.
2. **The per-command EPERM write was unclassified.** `CgroupManager.Apply` returned a plain `fmt.Errorf` that fell through `applyCgroupV2`'s generic `default:` arm (not the deliberate typed fail-closed paths) and aborted the wrap handshake.
3. **It sat on the before-ACK critical path**, so the failure fail-closed the command.

## Fix (layered)

1. **Probe write-tests a child `memory.max`** (`probeTopLevelLimitWritability`) so it honestly downgrades out of `ModeTopLevel`; existing `maybeUpgradeToAttachOnly` wiring upgrades to `ModeAttachOnly` when pid-attach is still feasible. `agentsh detect` now reports the truth on such hosts.
2. **Classifies EPERM/EACCES `.max` writes** as the typed `CgroupResourceLimitsUnavailableError` (backstop for hosts that change after the probe snapshot), with orphan-dir cleanup scoped to dirs this call created.
3. **Opt-in `sandbox.cgroups.best_effort`** (default `false` — fail-closed preserved): when set **and no eBPF flag is configured**, an unenforceable limit logs a warning, emits a new `cgroup_limits_degraded` event (with an `error_type` discriminator), and the command runs *without* the limit. eBPF egress enforcement (`Enabled`/`Enforce`/`Required`) always stays strict — the cgroup is an egress boundary there.

No critical-path re-architecture: the degrade happens inside `applyCgroupV2`, so the handshake simply proceeds.

## Design / plan

- Spec: `docs/superpowers/specs/2026-06-01-cgroup-best-effort-limits-design.md`
- Plan: `docs/superpowers/plans/2026-06-01-cgroup-best-effort-limits.md`

## Testing

- New probe tests (non-writable child → not `ModeTopLevel`; upgrade → `ModeAttachOnly`), manager tests (single- and multi-limit EPERM → typed error + cleanup), and `applyCgroupV2` tests (degrade / fail-closed-when-disabled / fail-closed-when-eBPF), including assertions on the emitted `cgroup_limits_degraded` event + `error_type`.
- `go build ./...` and `GOOS=windows go build ./...` clean.
- Full `go test ./...` green except 3 pre-existing **local-env-only** failures (long `TMPDIR` socket/symlink, `/tmp` FUSE perms) that pass in CI.
- #369 `TestInstallFilter_*` regression tests pass.
- roborev branch review: clean (all findings were Low and have been addressed).

## Deferred (separate issue)

The secondary stderr-pollution observation in #411 (the per-exec `seccomp: filter loaded` line corrupting machine-readable command stderr) is **not** in this PR: the line is a deliberate #369 diagnostic with regression tests, so it deserves a focused fix (route the `agentsh-unixwrap` wrapper's slog off the command's stderr) rather than a downgrade bundled here. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)