### PR TITLE
fix(#415): route unixwrap diagnostics off the wrapped command's stderr

### DIFF
--- a/cmd/agentsh-unixwrap/logging.go
+++ b/cmd/agentsh-unixwrap/logging.go
@@ -1,0 +1,78 @@
+//go:build linux && cgo
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"log/slog"
+	"os"
+	"strconv"
+
+	"github.com/agentsh/agentsh/internal/wrapperlog"
+	"golang.org/x/sys/unix"
+)
+
+// logDest is the routed diagnostics destination; nil means stderr (no
+// routing active). Set by setupLogging, consulted by writeFatal.
+var logDest *os.File
+
+// setupLogging routes the wrapper's diagnostics (default slog handler +
+// stdlib log) to the inherited fd named by wrapperlog.EnvKey, so the
+// per-exec "seccomp: filter loaded" line and friends land in the
+// parent's log sink instead of the wrapped command's stderr (issue
+// #415). Must run first thing in main(), before anything can log.
+//
+// Every failure path falls back to stderr (legacy behavior) — logging
+// must never abort an exec.
+func setupLogging() {
+	val := os.Getenv(wrapperlog.EnvKey)
+	// Strip unconditionally: syscall.Exec passes os.Environ() to the
+	// wrapped command, and a stale fd number inherited by a NESTED
+	// wrapper invocation (wrapped command → shell → shim → wrapper)
+	// could point at an unrelated fd reused by the intermediate
+	// process — the nested wrapper would write log lines onto it.
+	_ = os.Unsetenv(wrapperlog.EnvKey)
+	if val == "" {
+		return
+	}
+	fd, err := strconv.Atoi(val)
+	if err != nil || fd < 0 {
+		log.Printf("warning: invalid %s=%q; wrapper diagnostics stay on stderr", wrapperlog.EnvKey, val)
+		return
+	}
+	var st unix.Stat_t
+	if err := unix.Fstat(fd, &st); err != nil {
+		log.Printf("warning: %s=%d is not a usable fd (%v); wrapper diagnostics stay on stderr", wrapperlog.EnvKey, fd, err)
+		return
+	}
+	// Close-on-exec: the wrapped command must never inherit the log
+	// destination. All wrapper logging happens before syscall.Exec, and
+	// pipe-backed parents rely on this close for drain-goroutine EOF.
+	if _, err := unix.FcntlInt(uintptr(fd), unix.F_SETFD, unix.FD_CLOEXEC); err != nil {
+		log.Printf("warning: set FD_CLOEXEC on %s=%d: %v; wrapper diagnostics stay on stderr", wrapperlog.EnvKey, fd, err)
+		return
+	}
+	f := os.NewFile(uintptr(fd), "wrapper-log")
+	log.SetOutput(f)
+	slog.SetDefault(slog.New(slog.NewTextHandler(f, nil)))
+	logDest = f
+}
+
+// fatalf replaces log.Fatalf: a user whose command dies must still see
+// why on stderr even when diagnostics are routed elsewhere, and the
+// routed sink (server log / state file) must record it too.
+func fatalf(format string, args ...any) {
+	writeFatal(fmt.Sprintf(format, args...))
+	os.Exit(1)
+}
+
+// writeFatal writes msg to the routed destination (when active) and
+// always to stderr. Split from fatalf so the dual-write is testable
+// without os.Exit.
+func writeFatal(msg string) {
+	if logDest != nil {
+		fmt.Fprintln(logDest, msg)
+	}
+	fmt.Fprintln(os.Stderr, msg)
+}

--- a/cmd/agentsh-unixwrap/logging.go
+++ b/cmd/agentsh-unixwrap/logging.go
@@ -54,6 +54,10 @@ func setupLogging() {
 		return
 	}
 	f := os.NewFile(uintptr(fd), "wrapper-log")
+	if f == nil {
+		log.Printf("warning: cannot adopt %s=%d; wrapper diagnostics stay on stderr", wrapperlog.EnvKey, fd)
+		return
+	}
 	log.SetOutput(f)
 	slog.SetDefault(slog.New(slog.NewTextHandler(f, nil)))
 	logDest = f

--- a/cmd/agentsh-unixwrap/logging.go
+++ b/cmd/agentsh-unixwrap/logging.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/agentsh/agentsh/internal/wrapperlog"
 	"golang.org/x/sys/unix"
@@ -58,6 +59,17 @@ func setupLogging() {
 		log.Printf("warning: cannot adopt %s=%d; wrapper diagnostics stay on stderr", wrapperlog.EnvKey, fd)
 		return
 	}
+	// Warm the Local timezone cache NOW, before any seccomp filter
+	// exists. slog's TextHandler lazily loads tzdata (openat of
+	// /etc/localtime or zoneinfo) on its first time-formatted record —
+	// and the wrapper's first routed record ("seccomp: filter loaded")
+	// is emitted between filter load and notify-fd handoff. With the
+	// file monitor trapping openat and nobody draining notifications
+	// yet, that lazy load self-deadlocks the wrapper (#415 / PR #419
+	// CI: TestAlpineEnvInject hang). The pre-#415 stderr path never
+	// formatted time (stdlib log with SetFlags(0)), so this window was
+	// previously syscall-free.
+	_ = time.Now().Format(time.RFC3339)
 	log.SetOutput(f)
 	slog.SetDefault(slog.New(slog.NewTextHandler(f, nil)))
 	logDest = f

--- a/cmd/agentsh-unixwrap/logging_test.go
+++ b/cmd/agentsh-unixwrap/logging_test.go
@@ -200,6 +200,11 @@ func TestSetupLogging_NoSelfDeadlockUnderFileMonitor(t *testing.T) {
 	}
 	defer logR.Close()
 	defer logW.Close()
+	// Drain the routed sink so it can never backpressure the child:
+	// if wrapper diagnostics ever outgrow the pipe buffer, an undrained
+	// pipe would block the child post-filter and masquerade as the tz
+	// deadlock this test guards against.
+	go func() { _, _ = io.Copy(io.Discard, logR) }()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()

--- a/cmd/agentsh-unixwrap/logging_test.go
+++ b/cmd/agentsh-unixwrap/logging_test.go
@@ -1,0 +1,150 @@
+//go:build linux && cgo
+
+package main
+
+import (
+	"io"
+	"log"
+	"log/slog"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/wrapperlog"
+	"golang.org/x/sys/unix"
+)
+
+// resetLogging restores the process-global logging state mutated by
+// setupLogging so tests don't leak into each other.
+func resetLogging(origSlog *slog.Logger) {
+	log.SetOutput(os.Stderr)
+	slog.SetDefault(origSlog)
+	logDest = nil
+}
+
+func TestSetupLogging_RoutesBothSinksAndSetsCloexec(t *testing.T) {
+	orig := slog.Default()
+	defer resetLogging(orig)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	// Keep w reachable for the whole test: logDest wraps the same fd
+	// number, and w's finalizer must not close it mid-test.
+	defer runtime.KeepAlive(w)
+
+	t.Setenv(wrapperlog.EnvKey, strconv.Itoa(int(w.Fd())))
+
+	setupLogging()
+
+	if os.Getenv(wrapperlog.EnvKey) != "" {
+		t.Error("env var not stripped after setupLogging")
+	}
+	if logDest == nil {
+		t.Fatal("logDest not set for a valid fd")
+	}
+	flags, err := unix.FcntlInt(w.Fd(), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatalf("fcntl(F_GETFD): %v", err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		t.Error("FD_CLOEXEC not set on log fd")
+	}
+
+	log.Printf("stdlib-marker")
+	slog.Info("slog-marker")
+
+	logDest.Close() // closes the shared fd; reader gets EOF
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "stdlib-marker") {
+		t.Errorf("stdlib log not routed, got: %s", s)
+	}
+	if !strings.Contains(s, "slog-marker") {
+		t.Errorf("slog not routed, got: %s", s)
+	}
+}
+
+func TestSetupLogging_InvalidFDFallsBackToStderr(t *testing.T) {
+	orig := slog.Default()
+	defer resetLogging(orig)
+
+	// Learn a definitely-closed fd number.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	closedFD := int(w.Fd())
+	r.Close()
+	w.Close()
+
+	t.Setenv(wrapperlog.EnvKey, strconv.Itoa(closedFD))
+	setupLogging()
+	if logDest != nil {
+		t.Fatal("expected stderr fallback for closed fd")
+	}
+	if os.Getenv(wrapperlog.EnvKey) != "" {
+		t.Error("env var must be stripped even on fallback")
+	}
+}
+
+func TestSetupLogging_NonNumericFallsBackToStderr(t *testing.T) {
+	orig := slog.Default()
+	defer resetLogging(orig)
+
+	t.Setenv(wrapperlog.EnvKey, "not-a-number")
+	setupLogging()
+	if logDest != nil {
+		t.Fatal("expected stderr fallback for non-numeric value")
+	}
+}
+
+func TestSetupLogging_UnsetKeepsStderr(t *testing.T) {
+	orig := slog.Default()
+	defer resetLogging(orig)
+
+	t.Setenv(wrapperlog.EnvKey, "")
+	setupLogging()
+	if logDest != nil {
+		t.Fatal("expected no routing when env var unset")
+	}
+}
+
+func TestWriteFatal_DualWritesWhenRouted(t *testing.T) {
+	orig := slog.Default()
+	defer resetLogging(orig)
+
+	destR, destW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	logDest = destW
+
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = errW
+	defer func() { os.Stderr = origStderr }()
+
+	writeFatal("boom: 42")
+
+	destW.Close()
+	errW.Close()
+	destOut, _ := io.ReadAll(destR)
+	errOut, _ := io.ReadAll(errR)
+	if !strings.Contains(string(destOut), "boom: 42") {
+		t.Errorf("routed destination missing message: %q", destOut)
+	}
+	if !strings.Contains(string(errOut), "boom: 42") {
+		t.Errorf("stderr missing message: %q", errOut)
+	}
+}

--- a/cmd/agentsh-unixwrap/logging_test.go
+++ b/cmd/agentsh-unixwrap/logging_test.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"log/slog"
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -33,11 +32,17 @@ func TestSetupLogging_RoutesBothSinksAndSetsCloexec(t *testing.T) {
 		t.Fatalf("pipe: %v", err)
 	}
 	defer r.Close()
-	// Keep w reachable for the whole test: logDest wraps the same fd
-	// number, and w's finalizer must not close it mid-test.
-	defer runtime.KeepAlive(w)
+	defer w.Close()
 
-	t.Setenv(wrapperlog.EnvKey, strconv.Itoa(int(w.Fd())))
+	// Hand setupLogging a dup of the write end so logDest owns its fd
+	// exclusively; w keeps owning the original. Without the dup, two
+	// *os.File values share one fd and w's finalizer would re-close a
+	// possibly-reused fd number after logDest.Close().
+	dupFD, err := unix.Dup(int(w.Fd()))
+	if err != nil {
+		t.Fatalf("dup: %v", err)
+	}
+	t.Setenv(wrapperlog.EnvKey, strconv.Itoa(dupFD))
 
 	setupLogging()
 
@@ -47,7 +52,7 @@ func TestSetupLogging_RoutesBothSinksAndSetsCloexec(t *testing.T) {
 	if logDest == nil {
 		t.Fatal("logDest not set for a valid fd")
 	}
-	flags, err := unix.FcntlInt(w.Fd(), unix.F_GETFD, 0)
+	flags, err := unix.FcntlInt(uintptr(dupFD), unix.F_GETFD, 0)
 	if err != nil {
 		t.Fatalf("fcntl(F_GETFD): %v", err)
 	}
@@ -58,7 +63,8 @@ func TestSetupLogging_RoutesBothSinksAndSetsCloexec(t *testing.T) {
 	log.Printf("stdlib-marker")
 	slog.Info("slog-marker")
 
-	logDest.Close() // closes the shared fd; reader gets EOF
+	logDest.Close() // closes the dup — its sole owner
+	w.Close()       // close the original write end too so the reader sees EOF
 	out, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatalf("read: %v", err)
@@ -76,17 +82,10 @@ func TestSetupLogging_InvalidFDFallsBackToStderr(t *testing.T) {
 	orig := slog.Default()
 	defer resetLogging(orig)
 
-	// Learn a definitely-closed fd number. NOTE: this assumes the fd
-	// number is not reused by another goroutine between Close and the
-	// Fstat inside setupLogging — a tiny window we accept; if this test
-	// ever flakes, switch to a number above the process rlimit.
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	closedFD := int(w.Fd())
-	r.Close()
-	w.Close()
+	// Use an fd number far above any plausible rlimit so Fstat is
+	// guaranteed to fail with EBADF — no fd-reuse race window, unlike
+	// probing with a just-closed real fd.
+	const closedFD = 1 << 20
 
 	t.Setenv(wrapperlog.EnvKey, strconv.Itoa(closedFD))
 	setupLogging()

--- a/cmd/agentsh-unixwrap/logging_test.go
+++ b/cmd/agentsh-unixwrap/logging_test.go
@@ -76,7 +76,10 @@ func TestSetupLogging_InvalidFDFallsBackToStderr(t *testing.T) {
 	orig := slog.Default()
 	defer resetLogging(orig)
 
-	// Learn a definitely-closed fd number.
+	// Learn a definitely-closed fd number. NOTE: this assumes the fd
+	// number is not reused by another goroutine between Close and the
+	// Fstat inside setupLogging — a tiny window we accept; if this test
+	// ever flakes, switch to a number above the process rlimit.
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("pipe: %v", err)
@@ -103,6 +106,9 @@ func TestSetupLogging_NonNumericFallsBackToStderr(t *testing.T) {
 	setupLogging()
 	if logDest != nil {
 		t.Fatal("expected stderr fallback for non-numeric value")
+	}
+	if os.Getenv(wrapperlog.EnvKey) != "" {
+		t.Error("env var must be stripped even on parse failure")
 	}
 }
 

--- a/cmd/agentsh-unixwrap/logging_test.go
+++ b/cmd/agentsh-unixwrap/logging_test.go
@@ -3,14 +3,20 @@
 package main
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"io"
 	"log"
 	"log/slog"
 	"os"
+	"os/exec"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
+	unixmon "github.com/agentsh/agentsh/internal/netmonitor/unix"
 	"github.com/agentsh/agentsh/internal/wrapperlog"
 	"golang.org/x/sys/unix"
 )
@@ -151,5 +157,75 @@ func TestWriteFatal_DualWritesWhenRouted(t *testing.T) {
 	}
 	if !strings.Contains(string(errOut), "boom: 42") {
 		t.Errorf("stderr missing message: %q", errOut)
+	}
+}
+
+// wrapperFMHelperEnv gates the re-exec child body for
+// TestSetupLogging_NoSelfDeadlockUnderFileMonitor. Never set it outside
+// the parent->child dispatch: the child installs a real seccomp filter.
+const wrapperFMHelperEnv = "AGENTSH_TEST_WRAPPER_FM_HELPER"
+
+// TestSetupLogging_NoSelfDeadlockUnderFileMonitor re-execs the test
+// binary to reproduce the #415/PR#419 CI hang: with diagnostics routed
+// (AGENTSH_WRAPPER_LOG_FD set) and a file-monitor seccomp filter
+// installed, the first routed slog record must not perform a trapped
+// syscall (lazy tzdata openat) while nobody drains the notify fd —
+// that self-deadlocks the wrapper. The child routes its logs, installs
+// a FileMonitorEnabled filter, emits one slog record, and exits 0; the
+// parent fails if the child does not finish within a generous timeout.
+func TestSetupLogging_NoSelfDeadlockUnderFileMonitor(t *testing.T) {
+	if os.Getenv(wrapperFMHelperEnv) == "1" {
+		// Child: route diagnostics to the inherited fd (set by parent),
+		// install a file-monitor filter, then log — exactly the
+		// production sequence that deadlocked when tzdata loaded lazily.
+		setupLogging()
+		cfg := unixmon.FilterConfig{FileMonitorEnabled: true, InterceptMetadata: true}
+		if _, err := unixmon.InstallFilterWithConfig(cfg); err != nil {
+			// Mirror the skip conditions the parent checks for.
+			fmt.Fprintf(os.Stderr, "install filter: %v\n", err)
+			os.Exit(3)
+		}
+		slog.Info("post-filter routed record")
+		os.Exit(0)
+	}
+
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+
+	logR, logW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer logR.Close()
+	defer logW.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, exe, "-test.run=^TestSetupLogging_NoSelfDeadlockUnderFileMonitor$")
+	cmd.ExtraFiles = []*os.File{logW} // fd 3 in the child
+	cmd.Env = append(os.Environ(),
+		wrapperFMHelperEnv+"=1",
+		wrapperlog.EnvKey+"=3",
+	)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+
+	runErr := cmd.Run()
+	if ctx.Err() != nil {
+		t.Fatalf("child deadlocked under file-monitor filter (#415 tz lazy-load regression)\noutput:\n%s", out.String())
+	}
+	if runErr != nil {
+		if ee, ok := runErr.(*exec.ExitError); ok && ee.ExitCode() == 3 {
+			lower := strings.ToLower(out.String())
+			if strings.Contains(lower, "permission denied") ||
+				strings.Contains(lower, "operation not permitted") ||
+				strings.Contains(lower, "unsupported") {
+				t.Skipf("host cannot install seccomp filter; skipping.\n%s", out.String())
+			}
+		}
+		t.Fatalf("child failed: %v\noutput:\n%s", runErr, out.String())
 	}
 }

--- a/cmd/agentsh-unixwrap/main.go
+++ b/cmd/agentsh-unixwrap/main.go
@@ -29,19 +29,22 @@ import (
 
 func main() {
 	log.SetFlags(0)
+	// Route diagnostics off the wrapped command's stderr before anything
+	// can log (issue #415).
+	setupLogging()
 	if len(os.Args) < 3 || os.Args[1] != "--" {
-		log.Fatalf("usage: %s -- <command> [args...]", os.Args[0])
+		fatalf("usage: %s -- <command> [args...]", os.Args[0])
 	}
 
 	sockFD, err := notifySockFD()
 	if err != nil {
-		log.Fatalf("notify fd: %v", err)
+		fatalf("notify fd: %v", err)
 	}
 
 	// Load config from environment.
 	cfg, err := loadConfig()
 	if err != nil {
-		log.Fatalf("load config: %v", err)
+		fatalf("load config: %v", err)
 	}
 
 	// Authorize the server process to read our memory via ProcessVMReadv.
@@ -90,7 +93,7 @@ func main() {
 	cmd := os.Args[2]
 	cmdPath, err := resolveCommandPath(cmd)
 	if err != nil {
-		log.Fatalf("resolve command %q: %v", cmd, err)
+		fatalf("resolve command %q: %v", cmd, err)
 	}
 	args := applyArgv0Override(os.Args[2:], os.Getenv("AGENTSH_UNIXWRAP_ARGV0"))
 
@@ -118,7 +121,7 @@ func main() {
 		os.Exit(0)
 	}
 	if err != nil {
-		log.Fatalf("install seccomp filter: %v", err)
+		fatalf("install seccomp filter: %v", err)
 	}
 	defer filt.Close()
 
@@ -136,7 +139,7 @@ func main() {
 				// Without a working notification handler, the command cannot
 				// function at all — fail fast with a clear error.
 				filt.Close()
-				log.Fatalf("seccomp notify handler cannot operate: %v\n"+
+				fatalf("seccomp notify handler cannot operate: %v\n"+
 					"The seccomp filter was installed but the notification receive ioctl is\n"+
 					"blocked (likely by AppArmor or container security policy). Without a\n"+
 					"working notification handler, all intercepted syscalls will fail.\n"+
@@ -156,14 +159,14 @@ func main() {
 	// the filter returns fd=-1 and there is nothing to hand off.
 	if notifFD >= 0 {
 		if err := sendFD(sockFD, notifFD); err != nil {
-			log.Fatalf("send fd: %v", err)
+			fatalf("send fd: %v", err)
 		}
 
 		// Wait for ACK from the server confirming it has received the notify fd
 		// and started the handler. This prevents a race where we exec before the
 		// handler is ready to process seccomp notifications.
 		if err := waitForACK(func(b []byte) (int, error) { return unix.Read(sockFD, b) }); err != nil {
-			log.Fatalf("ACK handshake failed: %v", err)
+			fatalf("ACK handshake failed: %v", err)
 		}
 	}
 
@@ -179,7 +182,7 @@ func main() {
 			sigFD := sigFilter.NotifFD()
 			if sigFD >= 0 {
 				if err := sendFD(sigSockFD, sigFD); err != nil {
-					log.Fatalf("send signal fd: %v", err)
+					fatalf("send signal fd: %v", err)
 				}
 			}
 		}
@@ -199,7 +202,7 @@ func main() {
 	// Only runs when notifFD >= 0 (seccomp is active) and AGENTSH_PTRACE_SYNC=1.
 	if notifFD >= 0 && os.Getenv("AGENTSH_PTRACE_SYNC") == "1" {
 		if _, err := unix.Write(sockFD, []byte{'R'}); err != nil {
-			log.Fatalf("send READY byte: %v", err)
+			fatalf("send READY byte: %v", err)
 		}
 		// Set 30s receive timeout to prevent hanging if server crashes.
 		_ = unix.SetsockoptTimeval(sockFD, unix.SOL_SOCKET, unix.SO_RCVTIMEO, &unix.Timeval{Sec: 30})
@@ -212,10 +215,10 @@ func main() {
 			}
 			return n, err
 		}); err != nil {
-			log.Fatalf("wait for GO byte (30s timeout): %v", err)
+			fatalf("wait for GO byte (30s timeout): %v", err)
 		}
 		if goBuf[0] != 'G' {
-			log.Fatalf("unexpected GO byte: got 0x%02x, expected 'G'", goBuf[0])
+			fatalf("unexpected GO byte: got 0x%02x, expected 'G'", goBuf[0])
 		}
 	}
 
@@ -254,7 +257,7 @@ func main() {
 	// faccessat2 — see #283 bug B) do not get intercepted by the
 	// file-monitor notify handler.
 	if err := syscall.Exec(cmdPath, args, os.Environ()); err != nil {
-		log.Fatalf("exec %s failed: %v", cmd, err)
+		fatalf("exec %s failed: %v", cmd, err)
 	}
 }
 

--- a/docs/superpowers/plans/2026-06-06-issue-415-wrapper-log-routing.md
+++ b/docs/superpowers/plans/2026-06-06-issue-415-wrapper-log-routing.md
@@ -1,0 +1,1148 @@
+# Issue #415: Wrapper Log-FD Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route `agentsh-unixwrap` diagnostics (the per-exec `seccomp: filter loaded` slog line plus stdlib `log` noise) off the wrapped command's stderr via an inherited log fd, in all three spawn paths.
+
+**Architecture:** The wrapper reads `AGENTSH_WRAPPER_LOG_FD=<n>` at startup and points both its default slog handler and the stdlib `log` package at that fd (CLOEXEC so the wrapped command never inherits it; env var stripped before exec). The server exec path backs the fd with a pipe drained into the server log; the shim relay and `agentsh wrap` CLI paths back it with an `O_APPEND` state-dir file. Unset env var → stderr (today's behavior). The handshake protocol and `internal/netmonitor/unix` are untouched, so `TestInstallFilter_*` regression tests pass unchanged.
+
+**Tech Stack:** Go, `log/slog`, `os.Pipe`, `golang.org/x/sys/unix` (fcntl/fstat).
+
+**Spec:** `docs/superpowers/specs/2026-06-06-issue-415-wrapper-log-routing-design.md`
+
+**Project workflow notes:**
+- Work on a branch: `git checkout -b fix-415-wrapper-log-routing` before Task 1.
+- Per project convention, run `roborev` between tasks and fix all issues above "low" before proceeding.
+- Before final commit: `GOOS=windows go build ./...` must pass (CLAUDE.md requirement).
+- Some tests fail only in this local environment (long TMPDIR, workspace-policy mount, symlink sandbox) — they pass in CI and are not regressions; don't chase them.
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `internal/wrapperlog/wrapperlog.go` | Create | Shared env-key constant + state-dir log file opener |
+| `internal/wrapperlog/wrapperlog_test.go` | Create | Tests for the above |
+| `cmd/agentsh-unixwrap/logging.go` | Create | `setupLogging()` (fd routing, CLOEXEC, env strip) + `fatalf`/`writeFatal` |
+| `cmd/agentsh-unixwrap/logging_test.go` | Create | Tests for the above |
+| `cmd/agentsh-unixwrap/main.go` | Modify | Call `setupLogging()`; replace 13 `log.Fatalf` call sites with `fatalf` |
+| `internal/api/exec.go` | Modify | Two new `extraProcConfig` fields; close-write-end + start-drain in `startWrapperHandlers` |
+| `internal/api/wrapper_log.go` | Create | `startWrapperLogDrain` goroutine |
+| `internal/api/wrapper_log_test.go` | Create | Drain test |
+| `internal/api/core.go` | Modify | Create the pipe in `buildWrapperSetup`, set env, append ExtraFile |
+| `internal/shim/kernelinstall/install_linux.go` | Modify | Open state log file in `runRelay`, pass as fd 4; strip key in `filterShimInternalEnv` and `assembleWrapperEnv` |
+| `internal/shim/kernelinstall/install_linux_test.go` | Modify | Env-strip tests |
+| `internal/cli/wrap_linux.go` | Modify | Open state log file in `platformSetupWrap`, append to extraFiles + env |
+| `internal/integration/wrapper_log_routing_test.go` | Create | End-to-end server-path test |
+
+---
+
+### Task 1: `internal/wrapperlog` package
+
+**Files:**
+- Create: `internal/wrapperlog/wrapperlog.go`
+- Test: `internal/wrapperlog/wrapperlog_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package wrapperlog
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestOpenStateLogFile_CreatesDirAndAppends(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("XDG_STATE_HOME redirection is linux-only")
+	}
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	f, err := OpenStateLogFile()
+	if err != nil {
+		t.Fatalf("OpenStateLogFile: %v", err)
+	}
+	if _, err := f.WriteString("first\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f.Close()
+
+	// A second open must append, not truncate.
+	f2, err := OpenStateLogFile()
+	if err != nil {
+		t.Fatalf("OpenStateLogFile (second): %v", err)
+	}
+	if _, err := f2.WriteString("second\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f2.Close()
+
+	got, err := os.ReadFile(filepath.Join(stateHome, "agentsh", "logs", "unixwrap.log"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if string(got) != "first\nsecond\n" {
+		t.Fatalf("log content = %q, want %q", got, "first\nsecond\n")
+	}
+}
+
+func TestEnvKey_Value(t *testing.T) {
+	// The wrapper and all three parents must agree on this string;
+	// pin it so a rename can't silently desynchronize them.
+	if EnvKey != "AGENTSH_WRAPPER_LOG_FD" {
+		t.Fatalf("EnvKey = %q", EnvKey)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/wrapperlog/ -v`
+Expected: FAIL — package does not exist / `OpenStateLogFile` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+```go
+// Package wrapperlog defines the env contract and fallback file
+// destination for routing agentsh-unixwrap diagnostics off the wrapped
+// command's stderr (issue #415). The wrapper execs the real command in
+// place, so anything it logs to stderr lands on the user-visible stream
+// of the wrapped command; parents pass an inherited fd via EnvKey
+// instead.
+package wrapperlog
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+// EnvKey names the env var carrying the inherited fd number that
+// agentsh-unixwrap routes its diagnostics (slog + stdlib log) to.
+// Unset means stderr (legacy behavior).
+const EnvKey = "AGENTSH_WRAPPER_LOG_FD"
+
+// OpenStateLogFile opens <user-state-dir>/logs/unixwrap.log for append,
+// creating the directory as needed. Used by parents that have no live
+// log sink of their own (shell-shim relay, agentsh wrap CLI); O_APPEND
+// keeps concurrent wrapper invocations line-atomic.
+func OpenStateLogFile() (*os.File, error) {
+	dir := filepath.Join(config.GetUserStateDir(), "logs")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	return os.OpenFile(filepath.Join(dir, "unixwrap.log"),
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/wrapperlog/ -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/wrapperlog/
+git commit -m "feat(#415): add wrapperlog package — env contract + state-dir log file"
+```
+
+---
+
+### Task 2: Wrapper-side `setupLogging` + `fatalf`
+
+**Files:**
+- Create: `cmd/agentsh-unixwrap/logging.go`
+- Test: `cmd/agentsh-unixwrap/logging_test.go`
+
+Both files need the `//go:build linux && cgo` tag — every file in this package has it; an untagged file would break non-Linux builds of `./...`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+//go:build linux && cgo
+
+package main
+
+import (
+	"io"
+	"log"
+	"log/slog"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/wrapperlog"
+	"golang.org/x/sys/unix"
+)
+
+// resetLogging restores the process-global logging state mutated by
+// setupLogging so tests don't leak into each other.
+func resetLogging(origSlog *slog.Logger) {
+	log.SetOutput(os.Stderr)
+	slog.SetDefault(origSlog)
+	logDest = nil
+}
+
+func TestSetupLogging_RoutesBothSinksAndSetsCloexec(t *testing.T) {
+	orig := slog.Default()
+	defer resetLogging(orig)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	// Keep w reachable for the whole test: logDest wraps the same fd
+	// number, and w's finalizer must not close it mid-test.
+	defer runtime.KeepAlive(w)
+
+	t.Setenv(wrapperlog.EnvKey, strconv.Itoa(int(w.Fd())))
+
+	setupLogging()
+
+	if os.Getenv(wrapperlog.EnvKey) != "" {
+		t.Error("env var not stripped after setupLogging")
+	}
+	if logDest == nil {
+		t.Fatal("logDest not set for a valid fd")
+	}
+	flags, err := unix.FcntlInt(w.Fd(), unix.F_GETFD, 0)
+	if err != nil {
+		t.Fatalf("fcntl(F_GETFD): %v", err)
+	}
+	if flags&unix.FD_CLOEXEC == 0 {
+		t.Error("FD_CLOEXEC not set on log fd")
+	}
+
+	log.Printf("stdlib-marker")
+	slog.Info("slog-marker")
+
+	logDest.Close() // closes the shared fd; reader gets EOF
+	out, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	s := string(out)
+	if !strings.Contains(s, "stdlib-marker") {
+		t.Errorf("stdlib log not routed, got: %s", s)
+	}
+	if !strings.Contains(s, "slog-marker") {
+		t.Errorf("slog not routed, got: %s", s)
+	}
+}
+
+func TestSetupLogging_InvalidFDFallsBackToStderr(t *testing.T) {
+	orig := slog.Default()
+	defer resetLogging(orig)
+
+	// Learn a definitely-closed fd number.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	closedFD := int(w.Fd())
+	r.Close()
+	w.Close()
+
+	t.Setenv(wrapperlog.EnvKey, strconv.Itoa(closedFD))
+	setupLogging()
+	if logDest != nil {
+		t.Fatal("expected stderr fallback for closed fd")
+	}
+	if os.Getenv(wrapperlog.EnvKey) != "" {
+		t.Error("env var must be stripped even on fallback")
+	}
+}
+
+func TestSetupLogging_NonNumericFallsBackToStderr(t *testing.T) {
+	orig := slog.Default()
+	defer resetLogging(orig)
+
+	t.Setenv(wrapperlog.EnvKey, "not-a-number")
+	setupLogging()
+	if logDest != nil {
+		t.Fatal("expected stderr fallback for non-numeric value")
+	}
+}
+
+func TestSetupLogging_UnsetKeepsStderr(t *testing.T) {
+	orig := slog.Default()
+	defer resetLogging(orig)
+
+	t.Setenv(wrapperlog.EnvKey, "")
+	setupLogging()
+	if logDest != nil {
+		t.Fatal("expected no routing when env var unset")
+	}
+}
+
+func TestWriteFatal_DualWritesWhenRouted(t *testing.T) {
+	orig := slog.Default()
+	defer resetLogging(orig)
+
+	destR, destW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	logDest = destW
+
+	errR, errW, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = errW
+	defer func() { os.Stderr = origStderr }()
+
+	writeFatal("boom: 42")
+
+	destW.Close()
+	errW.Close()
+	destOut, _ := io.ReadAll(destR)
+	errOut, _ := io.ReadAll(errR)
+	if !strings.Contains(string(destOut), "boom: 42") {
+		t.Errorf("routed destination missing message: %q", destOut)
+	}
+	if !strings.Contains(string(errOut), "boom: 42") {
+		t.Errorf("stderr missing message: %q", errOut)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./cmd/agentsh-unixwrap/ -run 'TestSetupLogging|TestWriteFatal' -v`
+Expected: FAIL — `setupLogging`, `logDest`, `writeFatal` undefined.
+
+- [ ] **Step 3: Write the implementation**
+
+`cmd/agentsh-unixwrap/logging.go`:
+
+```go
+//go:build linux && cgo
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"log/slog"
+	"os"
+	"strconv"
+
+	"github.com/agentsh/agentsh/internal/wrapperlog"
+	"golang.org/x/sys/unix"
+)
+
+// logDest is the routed diagnostics destination; nil means stderr (no
+// routing active). Set by setupLogging, consulted by writeFatal.
+var logDest *os.File
+
+// setupLogging routes the wrapper's diagnostics (default slog handler +
+// stdlib log) to the inherited fd named by wrapperlog.EnvKey, so the
+// per-exec "seccomp: filter loaded" line and friends land in the
+// parent's log sink instead of the wrapped command's stderr (issue
+// #415). Must run first thing in main(), before anything can log.
+//
+// Every failure path falls back to stderr (legacy behavior) — logging
+// must never abort an exec.
+func setupLogging() {
+	val := os.Getenv(wrapperlog.EnvKey)
+	// Strip unconditionally: syscall.Exec passes os.Environ() to the
+	// wrapped command, and a stale fd number inherited by a NESTED
+	// wrapper invocation (wrapped command → shell → shim → wrapper)
+	// could point at an unrelated fd reused by the intermediate
+	// process — the nested wrapper would write log lines onto it.
+	_ = os.Unsetenv(wrapperlog.EnvKey)
+	if val == "" {
+		return
+	}
+	fd, err := strconv.Atoi(val)
+	if err != nil || fd < 0 {
+		log.Printf("warning: invalid %s=%q; wrapper diagnostics stay on stderr", wrapperlog.EnvKey, val)
+		return
+	}
+	var st unix.Stat_t
+	if err := unix.Fstat(fd, &st); err != nil {
+		log.Printf("warning: %s=%d is not a usable fd (%v); wrapper diagnostics stay on stderr", wrapperlog.EnvKey, fd, err)
+		return
+	}
+	// Close-on-exec: the wrapped command must never inherit the log
+	// destination. All wrapper logging happens before syscall.Exec, and
+	// pipe-backed parents rely on this close for drain-goroutine EOF.
+	if _, err := unix.FcntlInt(uintptr(fd), unix.F_SETFD, unix.FD_CLOEXEC); err != nil {
+		log.Printf("warning: set FD_CLOEXEC on %s=%d: %v; wrapper diagnostics stay on stderr", wrapperlog.EnvKey, fd, err)
+		return
+	}
+	f := os.NewFile(uintptr(fd), "wrapper-log")
+	log.SetOutput(f)
+	slog.SetDefault(slog.New(slog.NewTextHandler(f, nil)))
+	logDest = f
+}
+
+// fatalf replaces log.Fatalf: a user whose command dies must still see
+// why on stderr even when diagnostics are routed elsewhere, and the
+// routed sink (server log / state file) must record it too.
+func fatalf(format string, args ...any) {
+	writeFatal(fmt.Sprintf(format, args...))
+	os.Exit(1)
+}
+
+// writeFatal writes msg to the routed destination (when active) and
+// always to stderr. Split from fatalf so the dual-write is testable
+// without os.Exit.
+func writeFatal(msg string) {
+	if logDest != nil {
+		fmt.Fprintln(logDest, msg)
+	}
+	fmt.Fprintln(os.Stderr, msg)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./cmd/agentsh-unixwrap/ -run 'TestSetupLogging|TestWriteFatal' -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/agentsh-unixwrap/logging.go cmd/agentsh-unixwrap/logging_test.go
+git commit -m "feat(#415): unixwrap setupLogging — route slog+stdlib log to inherited fd"
+```
+
+---
+
+### Task 3: Wire `setupLogging` into wrapper `main()`
+
+**Files:**
+- Modify: `cmd/agentsh-unixwrap/main.go`
+
+- [ ] **Step 1: Call `setupLogging` first thing in `main()`**
+
+At `main.go:30-34`, change:
+
+```go
+func main() {
+	log.SetFlags(0)
+	if len(os.Args) < 3 || os.Args[1] != "--" {
+		log.Fatalf("usage: %s -- <command> [args...]", os.Args[0])
+	}
+```
+
+to:
+
+```go
+func main() {
+	log.SetFlags(0)
+	// Route diagnostics off the wrapped command's stderr before anything
+	// can log (issue #415).
+	setupLogging()
+	if len(os.Args) < 3 || os.Args[1] != "--" {
+		fatalf("usage: %s -- <command> [args...]", os.Args[0])
+	}
+```
+
+- [ ] **Step 2: Replace the remaining `log.Fatalf` call sites with `fatalf`**
+
+13 call sites total in `main.go` (line numbers pre-edit): 33 (done above), 38, 44, 93, 121, 139, 159, 166, 182, 202, 215, 218, 257. Mechanical replacement of `log.Fatalf(` → `fatalf(` — arguments unchanged at every site, including the multi-line message at 139. `log.Printf` call sites stay as-is (they follow `log.SetOutput` automatically).
+
+Verify none remain:
+
+Run: `grep -n "log.Fatalf" cmd/agentsh-unixwrap/main.go`
+Expected: no output.
+
+- [ ] **Step 3: Build and run the package tests**
+
+Run: `go build ./cmd/agentsh-unixwrap/ && go test ./cmd/agentsh-unixwrap/ -v`
+Expected: build OK, all tests PASS.
+
+- [ ] **Step 4: Confirm the #369 regression tests still pass un-adapted**
+
+Run: `go test ./internal/netmonitor/unix/ -run 'TestInstallFilter' -v`
+Expected: PASS (or SKIP on hosts where seccomp can't install — both fine; the point is no FAIL). These tests re-exec the test binary, never wrapper `main()`, so routing must not affect them.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/agentsh-unixwrap/main.go
+git commit -m "feat(#415): unixwrap main — activate log routing, dual-write fatals"
+```
+
+---
+
+### Task 4: Server exec path — pipe + drain into server log
+
+**Files:**
+- Create: `internal/api/wrapper_log.go`
+- Test: `internal/api/wrapper_log_test.go`
+- Modify: `internal/api/exec.go` (`extraProcConfig` ~line 28, `startWrapperHandlers` ~line 771)
+- Modify: `internal/api/core.go` (`buildWrapperSetup`, before the `return` at ~line 251)
+
+- [ ] **Step 1: Write the failing drain test**
+
+`internal/api/wrapper_log_test.go` (no build tag — pure `os.Pipe` + slog):
+
+```go
+package api
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// syncBuffer makes bytes.Buffer safe for the drain goroutine + test reader.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestStartWrapperLogDrain_ForwardsLinesToLogger(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+
+	var buf syncBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	done := startWrapperLogDrain(r, logger, "sess-1", "/bin/true")
+
+	if _, err := w.WriteString("seccomp: filter loaded fd=8 wait_killable=true\nlandlock: restrictions applied\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	w.Close() // EOF → drain goroutine exits
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("drain goroutine did not finish after EOF")
+	}
+
+	out := buf.String()
+	for _, want := range []string{
+		"seccomp: filter loaded",
+		"wait_killable=true",
+		"landlock: restrictions applied",
+		"session_id=sess-1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("drained log missing %q, got:\n%s", want, out)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/api/ -run TestStartWrapperLogDrain -v`
+Expected: FAIL — `startWrapperLogDrain` undefined.
+
+- [ ] **Step 3: Implement the drain**
+
+`internal/api/wrapper_log.go`:
+
+```go
+package api
+
+import (
+	"bufio"
+	"log/slog"
+	"os"
+)
+
+// startWrapperLogDrain forwards agentsh-unixwrap diagnostic lines from
+// the wrapper log pipe into the server log (issue #415). The wrapper
+// sets FD_CLOEXEC on its end, so EOF arrives when it execs the real
+// command (or exits) — the goroutine is short-lived by construction.
+// Lines are forwarded verbatim as an attr; no re-parsing or re-leveling,
+// so "wait_killable=..." stays greppable at the default level.
+//
+// The returned channel closes when the drain finishes (test hook).
+func startWrapperLogDrain(r *os.File, logger *slog.Logger, sessionID, command string) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer r.Close()
+		sc := bufio.NewScanner(r)
+		for sc.Scan() {
+			logger.Info("unixwrap", "session_id", sessionID, "command", command, "line", sc.Text())
+		}
+	}()
+	return done
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/api/ -run TestStartWrapperLogDrain -v`
+Expected: PASS.
+
+- [ ] **Step 5: Add the `extraProcConfig` fields**
+
+In `internal/api/exec.go`, after the `blockList` field (~line 38), add:
+
+```go
+	// Wrapper log routing (issue #415): pipe carrying unixwrap
+	// diagnostics into the server log. wrapperLogChild is the write end
+	// inherited by the wrapper via extraFiles; the parent's copy is
+	// closed in startWrapperHandlers so the drain goroutine sees EOF
+	// when the wrapper execs (its own copy is CLOEXEC).
+	wrapperLogParent *os.File
+	wrapperLogChild  *os.File
+```
+
+- [ ] **Step 6: Close write end + start drain in `startWrapperHandlers`**
+
+In `internal/api/exec.go:771`, `startWrapperHandlers` currently begins:
+
+```go
+func startWrapperHandlers(ctx context.Context, extra *extraProcConfig, pid, pgid int, ptraceReady chan<- error) {
+	if extra == nil {
+		return
+	}
+	if extra.notifyParentSock != nil {
+```
+
+Insert between the nil-check and the notify block:
+
+```go
+	// Wrapper log routing (issue #415): the child now owns its dup of
+	// the write end; close ours so the drain goroutine gets EOF at the
+	// wrapper's exec. Called from every post-start path (exec.go and
+	// exec_stream.go, hybrid and wrapper-only), exactly once.
+	if extra.wrapperLogChild != nil {
+		_ = extra.wrapperLogChild.Close()
+		extra.wrapperLogChild = nil
+	}
+	if extra.wrapperLogParent != nil {
+		_ = startWrapperLogDrain(extra.wrapperLogParent, slog.Default(), extra.notifySessionID, extra.origCommand)
+		extra.wrapperLogParent = nil
+	}
+```
+
+(`slog` is already imported in exec.go.)
+
+- [ ] **Step 7: Create the pipe in `buildWrapperSetup`**
+
+In `internal/api/core.go`, after the signal-filter block (ends ~line 249) and immediately before `return &wrapperSetupResult{wrappedReq: wrappedReq, extraCfg: extraCfg}`, add:
+
+```go
+	// Wrapper log routing (issue #415): hand the wrapper a pipe for its
+	// diagnostics (the "seccomp: filter loaded" line, landlock notices)
+	// so they land in the server log instead of the wrapped command's
+	// stderr. The fd number is the next ExtraFiles slot — 4 normally,
+	// 5 when the signal socket is present. On pipe failure the env var
+	// is omitted and the wrapper falls back to stderr (legacy behavior);
+	// logging must never block an exec.
+	if logR, logW, pipeErr := os.Pipe(); pipeErr == nil {
+		fdStr := strconv.Itoa(3 + len(extraCfg.extraFiles))
+		wrappedReq.Env[wrapperlog.EnvKey] = fdStr
+		extraCfg.env[wrapperlog.EnvKey] = fdStr
+		extraCfg.extraFiles = append(extraCfg.extraFiles, logW)
+		extraCfg.wrapperLogParent = logR
+		extraCfg.wrapperLogChild = logW
+	} else {
+		slog.Warn("wrapper log pipe unavailable; wrapper diagnostics will appear on command stderr",
+			"session_id", sessionID, "error", pipeErr)
+	}
+```
+
+Add the import `"github.com/agentsh/agentsh/internal/wrapperlog"` to core.go (`os`, `strconv`, `slog` are already imported).
+
+- [ ] **Step 8: Build and test the package**
+
+Run: `go build ./... && go test ./internal/api/ 2>&1 | tail -20`
+Expected: build OK; package tests pass (modulo known local-env failures noted in the header).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add internal/api/wrapper_log.go internal/api/wrapper_log_test.go internal/api/exec.go internal/api/core.go
+git commit -m "feat(#415): server exec path — pipe wrapper diagnostics into server log"
+```
+
+---
+
+### Task 5: Shim relay path — state-dir log file
+
+**Files:**
+- Modify: `internal/shim/kernelinstall/install_linux.go` (`runRelay` ~line 174, `assembleWrapperEnv` ~line 389, `filterShimInternalEnv` ~line 413)
+- Test: `internal/shim/kernelinstall/install_linux_test.go`
+
+- [ ] **Step 1: Write the failing env-hygiene tests**
+
+Append to `install_linux_test.go` (match its existing build tag and package; add imports as needed — `strings`, `github.com/agentsh/agentsh/internal/wrapperlog`):
+
+```go
+func TestFilterShimInternalEnv_StripsWrapperLogFD(t *testing.T) {
+	in := []string{"PATH=/bin", wrapperlog.EnvKey + "=7", "HOME=/root"}
+	out := filterShimInternalEnv(in)
+	for _, e := range out {
+		if strings.HasPrefix(e, wrapperlog.EnvKey+"=") {
+			t.Fatalf("inherited %s not stripped: %v", wrapperlog.EnvKey, out)
+		}
+	}
+	if len(out) != 2 {
+		t.Fatalf("unexpected env after strip: %v", out)
+	}
+}
+
+func TestAssembleWrapperEnv_DropsWrapperLogFDFromWrapperEnv(t *testing.T) {
+	env := assembleWrapperEnv(
+		[]string{"PATH=/bin"},
+		"",
+		map[string]string{
+			wrapperlog.EnvKey:        "9", // must NOT pass through — the relay sets its own
+			"AGENTSH_SECCOMP_CONFIG": "{}",
+		},
+		nil,
+	)
+	for _, e := range env {
+		if strings.HasPrefix(e, wrapperlog.EnvKey+"=") {
+			t.Fatalf("server-supplied %s leaked into wrapper env: %v", wrapperlog.EnvKey, env)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/shim/kernelinstall/ -run 'WrapperLogFD' -v`
+Expected: FAIL — `TestFilterShimInternalEnv_StripsWrapperLogFD` fails (key passes through); the `assembleWrapperEnv` test fails (key forwarded from wrapperEnv map).
+
+- [ ] **Step 3: Implement the env hygiene**
+
+In `filterShimInternalEnv` (line ~413), add the third prefix:
+
+```go
+func filterShimInternalEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	signalPrefix := signalSockFDKey + "="
+	argv0Prefix := argv0EnvKey + "="
+	logFDPrefix := wrapperlog.EnvKey + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, signalPrefix) || strings.HasPrefix(e, argv0Prefix) || strings.HasPrefix(e, logFDPrefix) {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+```
+
+In `assembleWrapperEnv`'s wrapperEnv loop (line ~403), extend the skip:
+
+```go
+	for k, v := range wrapperEnv {
+		if k == signalSockFDKey {
+			slog.Debug("kernelinstall: stripping signal sock fd from wrapper env (shim mode limitation)")
+			continue
+		}
+		if k == wrapperlog.EnvKey {
+			// The relay is the wrapper's parent here and sets its own
+			// authoritative log fd; a server-supplied value would point
+			// at an fd that does not exist in this process (issue #415).
+			continue
+		}
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+```
+
+Add the import `"github.com/agentsh/agentsh/internal/wrapperlog"`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/shim/kernelinstall/ -run 'WrapperLogFD' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the log file into `runRelay`**
+
+In `runRelay`, after `env := assembleWrapperEnv(...)` (line ~201), add:
+
+```go
+	// Wrapper log routing (issue #415): point the wrapper's diagnostics
+	// at the state-dir log file. The relay's own stderr IS the user's
+	// terminal, so draining a pipe into our slog would put the noise
+	// right back on screen; an O_APPEND file needs no drain goroutine
+	// and keeps concurrent shim execs line-atomic. Debug (not Warn) on
+	// failure for the same reason — the relay must not add stderr noise.
+	logFile, logErr := wrapperlog.OpenStateLogFile()
+	if logErr != nil {
+		slog.Debug("kernelinstall: wrapper log file unavailable; wrapper diagnostics stay on stderr", "error", logErr)
+	}
+```
+
+Change the `cmd` setup (lines ~210-217) from:
+
+```go
+	cmd := exec.Command(wrapperBin, wrapperArgs...)
+	cmd.Args[0] = filepath.Base(wrapperBin)
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	// ExtraFiles[0] becomes fd 3 in the child (0=stdin,1=stdout,2=stderr,3=ExtraFiles[0])
+	cmd.ExtraFiles = []*os.File{childFile}
+```
+
+to:
+
+```go
+	cmd := exec.Command(wrapperBin, wrapperArgs...)
+	cmd.Args[0] = filepath.Base(wrapperBin)
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	// ExtraFiles[0] becomes fd 3 in the child (0=stdin,1=stdout,2=stderr,3=ExtraFiles[0])
+	cmd.ExtraFiles = []*os.File{childFile}
+	if logFile != nil {
+		// ExtraFiles[1] = fd 4 — free in shim mode (the signal-filter
+		// socketpair is deliberately not replicated here).
+		cmd.ExtraFiles = append(cmd.ExtraFiles, logFile)
+		cmd.Env = append(cmd.Env, wrapperlog.EnvKey+"=4")
+	}
+```
+
+Update the start-failure cleanup (lines ~219-223) and the post-start close (line ~226):
+
+```go
+	if err := cmd.Start(); err != nil {
+		parentFile.Close()
+		childFile.Close()
+		if logFile != nil {
+			logFile.Close()
+		}
+		return Result{}, fmt.Errorf("start wrapper: %w", err)
+	}
+
+	// The wrapper owns childFile now; close our copy in the parent.
+	childFile.Close()
+	if logFile != nil {
+		logFile.Close()
+	}
+```
+
+- [ ] **Step 6: Write the relay wiring test (spec test item 4)**
+
+Append to `install_linux_test.go`, reusing the package's fake-wrapper harness (`buildFakeWrapperPrintEnv`, `serveNotifySetupStatus`, `makeWrapInitHandler`, `baseParams` — see `TestInstall_StripsSignalSockFdFromPEnv` for the pattern):
+
+```go
+// TestInstall_PassesWrapperLogFDAndCreatesStateLogFile verifies the
+// issue #415 relay wiring end-to-end: runRelay opens the state-dir log
+// file, passes it as ExtraFiles[1], and exports AGENTSH_WRAPPER_LOG_FD=4
+// to the wrapper. XDG_STATE_HOME is redirected to a temp dir so the test
+// owns the state-dir location.
+func TestInstall_PassesWrapperLogFDAndCreatesStateLogFile(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	wrapperBin := buildFakeWrapperPrintEnv(t)
+
+	sockDir := t.TempDir()
+	notifySockPath := filepath.Join(sockDir, "notify.sock")
+	ln, err := net.Listen("unix", notifySockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	serveNotifySetupStatus(ln, true)
+
+	wrapResp := types.WrapInitResponse{
+		WrapperBinary: wrapperBin,
+		NotifySocket:  notifySockPath,
+		WrapperEnv:    map[string]string{"FAKE_WRAPPER": "1"},
+	}
+	handler, _ := makeWrapInitHandler(200, wrapResp)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	p := baseParams(srv)
+	p.Mode = ModeOn
+	p.Env = []string{"HOME=/tmp"}
+
+	outFile, err := os.CreateTemp(t.TempDir(), "wrapper-env-*.txt")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	outPath := outFile.Name()
+	outFile.Close()
+	p.Env = append(p.Env, "FAKE_ENV_OUT="+outPath)
+
+	res, err := Install(p)
+	if err != nil {
+		t.Fatalf("Install returned error: %v", err)
+	}
+	if res.Action != ResultExec {
+		t.Fatalf("expected ResultExec, got %v (reason: %s)", res.Action, res.Reason)
+	}
+
+	envOutput, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read wrapper env output: %v", err)
+	}
+	if !strings.Contains(string(envOutput), wrapperlog.EnvKey+"=4") {
+		t.Errorf("wrapper env missing %s=4:\n%s", wrapperlog.EnvKey, envOutput)
+	}
+
+	logPath := filepath.Join(stateHome, "agentsh", "logs", "unixwrap.log")
+	if _, err := os.Stat(logPath); err != nil {
+		t.Errorf("state-dir log file not created at %s: %v", logPath, err)
+	}
+}
+```
+
+Run: `go test ./internal/shim/kernelinstall/ -run TestInstall_PassesWrapperLogFD -v`
+Expected: PASS.
+
+- [ ] **Step 7: Build and run the package tests**
+
+Run: `go build ./... && go test ./internal/shim/kernelinstall/`
+Expected: build OK, tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/shim/kernelinstall/install_linux.go internal/shim/kernelinstall/install_linux_test.go
+git commit -m "feat(#415): shim relay — wrapper diagnostics to state-dir log file"
+```
+
+---
+
+### Task 6: `agentsh wrap` CLI path — state-dir log file
+
+**Files:**
+- Modify: `internal/cli/wrap_linux.go` (`platformSetupWrap`, extraFiles assembly ~line 160)
+
+- [ ] **Step 1: Wire the log file in**
+
+In `wrap_linux.go`, the current extraFiles assembly (lines ~160-163):
+
+```go
+	extraFiles := []*os.File{childFile}
+	if hasSignalSocket {
+		extraFiles = append(extraFiles, signalChildFile)
+	}
+```
+
+becomes:
+
+```go
+	extraFiles := []*os.File{childFile}
+	if hasSignalSocket {
+		extraFiles = append(extraFiles, signalChildFile)
+	}
+	// Wrapper log routing (issue #415): the CLI's stderr is the user's
+	// terminal, so route wrapper diagnostics to the state-dir log file.
+	// fd number = next ExtraFiles slot (4, or 5 with the signal socket).
+	// Silent stderr fallback on failure — adding our own warning here
+	// would reintroduce the exact noise this removes. wrap.go closes
+	// every extraFiles entry after Start, so no extra cleanup is needed.
+	if logFile, err := wrapperlog.OpenStateLogFile(); err == nil {
+		env = append(env, fmt.Sprintf("%s=%d", wrapperlog.EnvKey, 3+len(extraFiles)))
+		extraFiles = append(extraFiles, logFile)
+	}
+```
+
+Add the import `"github.com/agentsh/agentsh/internal/wrapperlog"` (`fmt` is already imported).
+
+- [ ] **Step 2: Build and run the package tests**
+
+Run: `go build ./... && go test ./internal/cli/`
+Expected: build OK, tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/cli/wrap_linux.go
+git commit -m "feat(#415): agentsh wrap CLI — wrapper diagnostics to state-dir log file"
+```
+
+---
+
+### Task 7: Integration test — clean stderr + diagnostic in server log
+
+**Files:**
+- Create: `internal/integration/wrapper_log_routing_test.go`
+
+Reuses this package's existing harness: `buildSeccompBinaries`, `startWrapSeccompServerContainer`, `writeFile`, `mustMkdir`, `wrapStrongTestConfigYAML`, `wrapTestPolicyYAML`, `testAPIKeysYAML` (see `agentsh_wrap_linux_test.go`). The config already sets `logging.output: stdout`, so the server log is the container log.
+
+- [ ] **Step 1: Write the test**
+
+```go
+//go:build integration && linux
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/client"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// TestExecPath_WrapperLogRoutedOffCommandStderr is the end-to-end
+// acceptance test for issue #415: a wrapped command's stderr must not
+// carry the per-exec "seccomp: filter loaded" wrapper diagnostic, and
+// that diagnostic must instead appear in the server log (drained from
+// the wrapper log pipe) at the default level.
+func TestExecPath_WrapperLogRoutedOffCommandStderr(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	agentshBin, unixwrapBin := buildSeccompBinaries(t)
+	temp := t.TempDir()
+
+	configPath := filepath.Join(temp, "config.yaml")
+	writeFile(t, configPath, wrapStrongTestConfigYAML)
+	keysPath := filepath.Join(temp, "keys.yaml")
+	writeFile(t, keysPath, testAPIKeysYAML)
+
+	policiesDir := filepath.Join(temp, "policies")
+	mustMkdir(t, policiesDir)
+	writeFile(t, filepath.Join(policiesDir, "agent-default.yaml"), wrapTestPolicyYAML)
+
+	workspace := filepath.Join(temp, "workspace")
+	mustMkdir(t, workspace)
+
+	ctr, endpoint, cleanup := startWrapSeccompServerContainer(t, ctx, agentshBin, unixwrapBin, configPath, keysPath, policiesDir, workspace)
+	t.Cleanup(cleanup)
+
+	cli := client.New(endpoint, "test-key")
+
+	sess, err := cli.CreateSession(ctx, "/workspace", "agent-default")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cli.DestroySession(context.Background(), sess.ID); err != nil {
+			t.Logf("DestroySession: %v", err)
+		}
+	})
+
+	execCtx, execCancel := context.WithTimeout(ctx, 30*time.Second)
+	res, execErr := cli.Exec(execCtx, sess.ID, types.ExecRequest{
+		Command: "/bin/sh",
+		Args:    []string{"-c", "echo STDERR_MARKER >&2"},
+	})
+	execCancel()
+	if execErr != nil {
+		if errors.Is(execErr, context.DeadlineExceeded) || strings.Contains(execErr.Error(), "deadline exceeded") {
+			t.Skip("seccomp-user-notify appears unreliable in this environment (exec timeout)")
+		}
+		t.Fatalf("Exec: %v", execErr)
+	}
+	if res.Result.ExitCode != 0 {
+		t.Skipf("seccomp-user-notify may not be active in this environment (exit=%d, stderr=%q)", res.Result.ExitCode, res.Result.Stderr)
+	}
+
+	// (a) The command's own stderr arrives intact and uncontaminated.
+	if !strings.Contains(res.Result.Stderr, "STDERR_MARKER") {
+		t.Fatalf("command stderr lost: %q", res.Result.Stderr)
+	}
+	if strings.Contains(res.Result.Stderr, "seccomp: filter loaded") {
+		t.Fatalf("wrapper diagnostic leaked onto command stderr (issue #415 regression):\n%s", res.Result.Stderr)
+	}
+
+	// (b) The diagnostic landed in the server log instead, at default
+	// level (logging.level=info in the test config). The drained line
+	// is embedded as the `line` attr of the server's "unixwrap" record;
+	// the substring survives TextHandler quoting.
+	logsCtx, logsCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer logsCancel()
+	logsReader, err := ctr.Logs(logsCtx)
+	if err != nil {
+		t.Fatalf("container logs: %v", err)
+	}
+	defer logsReader.Close()
+	logBytes, err := io.ReadAll(logsReader)
+	if err != nil {
+		t.Fatalf("read container logs: %v", err)
+	}
+	serverLog := string(logBytes)
+	if !strings.Contains(serverLog, "seccomp: filter loaded") {
+		t.Fatalf("wait_killable diagnostic missing from server log (acceptance criterion #2)\nserver log:\n%s", serverLog)
+	}
+	if !strings.Contains(serverLog, "wait_killable") {
+		t.Fatalf("wait_killable field missing from drained diagnostic\nserver log:\n%s", serverLog)
+	}
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `go test -tags integration ./internal/integration/ -run TestExecPath_WrapperLogRoutedOffCommandStderr -v -timeout 10m`
+Expected: PASS (or SKIP on hosts where seccomp user-notify is unreliable — the probe-skip pattern matches the package's existing tests). Requires Docker.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/integration/wrapper_log_routing_test.go
+git commit -m "test(#415): integration — clean wrapped stderr, diagnostic drained to server log"
+```
+
+---
+
+### Task 8: Final verification
+
+- [ ] **Step 1: Full build, both platforms**
+
+Run: `go build ./... && GOOS=windows go build ./...`
+Expected: both succeed (CLAUDE.md pre-commit requirement).
+
+- [ ] **Step 2: Full test suite**
+
+Run: `go test ./... 2>&1 | grep -v "^ok" | head -40`
+Expected: no FAILs beyond the known local-env failures listed in the header notes and known flake families (`TestStore_*EmitsTransportLossOnWire`). In particular `./internal/netmonitor/unix/` (the #369 regression tests) and `./cmd/agentsh-unixwrap/` must pass.
+
+- [ ] **Step 3: Manual smoke test (acceptance criterion #1)**
+
+```bash
+go build -o /tmp/agentsh ./cmd/agentsh && go build -o /tmp/agentsh-unixwrap ./cmd/agentsh-unixwrap
+# In a running session (or via agentsh wrap), confirm:
+#   agentsh detect --output json   → stderr starts with '{', no "seccomp: filter loaded" prefix
+# and the server log (or ~/.local/state/agentsh/logs/unixwrap.log for
+# shim/CLI paths) contains the wait_killable line.
+```
+
+Expected: clean machine-readable stderr; diagnostic present in the routed destination.
+
+- [ ] **Step 4: Run roborev on the branch, fix findings above low**
+
+- [ ] **Step 5: Final commit (if any fixups) and hand off**
+
+Use superpowers:finishing-a-development-branch — PR referencing issue #415.

--- a/docs/superpowers/specs/2026-06-06-issue-415-wrapper-log-routing-design.md
+++ b/docs/superpowers/specs/2026-06-06-issue-415-wrapper-log-routing-design.md
@@ -1,0 +1,166 @@
+# Issue #415: Route wrapper diagnostics off the wrapped command's stderr
+
+**Date:** 2026-06-06
+**Issue:** [#415](https://github.com/canyonroad/agentsh/issues/415) — Per-exec
+"seccomp: filter loaded" line pollutes wrapped command's stderr (corrupts
+`agentsh detect --output json`)
+**Approach:** Option 3 from the issue — route, don't downgrade — implemented
+as a log-fd handoff via env var.
+
+## Problem
+
+`agentsh-unixwrap` execs the real command in place, so the wrapper's stderr
+*is* the wrapped command's stderr. Every successful filter install emits
+`slog.Info("seccomp: filter loaded", ...)`
+(`internal/netmonitor/unix/seccomp_linux.go:515`) via the wrapper's
+process-default slog handler → stderr → user-visible stream. Commands with
+machine-readable stderr (notably `agentsh detect --output json`) get a noise
+prefix consumers must strip.
+
+Downgrading to Debug was rejected in #411/#414: the line is a deliberate #369
+diagnostic (`wait_killable` / `wait_killable_source`), asserted on by
+`TestInstallFilter_EmitsWaitKillEngagedOnSupportedKernel` and
+`TestInstallFilter_HonorsOperatorOverride`, and must stay visible in the
+server log at default level.
+
+Beyond the slog line, the wrapper also emits stdlib `log` success-path noise
+(`landlock: restrictions applied` on every exec when Landlock is on,
+PR_SET_PTRACER warnings, etc.) on the same fd.
+
+## Decision summary
+
+| Question | Decision |
+|---|---|
+| Which spawn paths | All three: server exec, shim relay, `agentsh wrap` CLI |
+| What gets routed | All wrapper diagnostics (slog + stdlib `log`); fatals dual-write to routed dest + stderr |
+| Fallback when no destination given | stderr (status quo) |
+| Destination in shim/CLI paths | Local state-dir log file |
+
+## Design
+
+### Wrapper side (`cmd/agentsh-unixwrap`)
+
+New env contract: `AGENTSH_WRAPPER_LOG_FD=<n>` — the number of an inherited
+fd to receive all wrapper diagnostics.
+
+A `setupLogging()` runs first thing in `main()`, before anything can log:
+
+1. Env var unset → return; stderr remains the destination (manual
+   invocation, version skew, tests).
+2. Validate the fd with `fstat(2)`. Invalid → one warning to stderr, fall
+   back to stderr. Logging must never abort an exec.
+3. Valid → wrap in `*os.File` and point both sinks at it:
+   - `log.SetOutput(f)` — stdlib `log.Printf` noise (landlock line,
+     warnings).
+   - `slog.SetDefault(slog.New(slog.NewTextHandler(f, nil)))` — the
+     "seccomp: filter loaded" line emitted from `internal/netmonitor/unix`
+     through the process-default logger.
+4. Set `FD_CLOEXEC` on the fd: the final `syscall.Exec` closes it, the
+   wrapped command never sees it, and pipe readers get EOF exactly when
+   wrapper logging ends.
+
+`log.Fatalf` call sites (~12) move to a local `fatalf()` helper that writes
+to the routed destination **and** stderr, then exits 1 — a user whose
+command dies still sees why.
+
+**Env hygiene:** the wrapper execs with `os.Environ()`, so the env var would
+leak to the wrapped command. A nested wrapper invocation (wrapped command →
+shell → shim → wrapper) would inherit a stale fd number that may have been
+reused by the intermediate process — the nested wrapper would write log
+lines onto an arbitrary fd. Defenses:
+
+- Wrapper strips `AGENTSH_WRAPPER_LOG_FD` from the environment before
+  `syscall.Exec`.
+- The shim's `filterShimInternalEnv`
+  (`internal/shim/kernelinstall/install_linux.go`) adds the key to its strip
+  list, as it already does for `AGENTSH_SIGNAL_SOCK_FD` and the argv0
+  override. Each parent always sets its own authoritative value.
+
+### Parent side — three spawn paths
+
+**Server exec path** (`internal/api/core.go`, `buildWrapperSetup`):
+
+- Create `os.Pipe()`; append the write end to `extraCfg.extraFiles`; compute
+  the child fd dynamically (`3 + index` — 4 normally, 5 when the signal
+  socket is present); set `AGENTSH_WRAPPER_LOG_FD` in both `wrappedReq.Env`
+  and `extraCfg.env` (same dual-set pattern as the notify fd).
+- New `extraProcConfig` field (`wrapperLogParent *os.File`) carries the read
+  end. At spawn (alongside existing `notifyParentSock` handling): close the
+  parent's write-end copy, then a drain goroutine `bufio.Scanner`s to EOF,
+  emitting each line via server slog at Info:
+  `slog.Info("unixwrap", "session_id", sid, "command", origCommand, "line", <raw>)`.
+  No parsing or re-leveling — `wait_killable=...` stays greppable in the
+  server log at default level. CLOEXEC gives EOF at exec time, so the
+  goroutine is short-lived and self-terminating.
+
+**Shim relay path** (`internal/shim/kernelinstall/install_linux.go`,
+`runRelay`):
+
+- No pipe, no goroutine: open
+  `<config.GetUserStateDir()>/logs/unixwrap.log` with
+  `O_CREATE|O_WRONLY|O_APPEND`, mode 0600 (`MkdirAll` the parent dir). Pass
+  the file fd as `ExtraFiles[1]` (fd 4 — free in shim mode; the signal
+  socket is deliberately not replicated there) and append
+  `AGENTSH_WRAPPER_LOG_FD=4` in `assembleWrapperEnv`. `O_APPEND` writes are
+  atomic, so concurrent shim execs interleave at line granularity. Parent
+  closes its copy after `cmd.Start()`.
+
+**`agentsh wrap` CLI path** (`internal/cli/wrap_linux.go`,
+`platformSetupWrap`):
+
+- Same state-dir log file as the shim path. Appended after the conditional
+  signal socket; fd number computed (`3 + position` → 4 or 5) and exported
+  in the env it already assembles.
+
+### Error handling
+
+All failures fall open to stderr — logging must never break an exec:
+
+| Failure | Behavior |
+|---|---|
+| Env var unset | stderr, exactly as today |
+| Env var set, fd invalid (fstat fails) | one warning to stderr, then stderr fallback |
+| Parent can't create pipe / open log file | parent warns in its own log, omits the env var → wrapper falls back |
+| Wrapper hard-fails (`fatalf`) | dual-write: routed destination + stderr |
+| Pipe write blocks (server stuck) | accepted risk — a few hundred bytes per exec, far under the 64 KiB pipe buffer; cannot deadlock the handshake |
+
+The wrapped command cannot write to the routed fd: CLOEXEC closes it at exec
+and the stripped env var means nothing points there.
+
+### Non-goals
+
+- Log rotation for `unixwrap.log` (a handful of lines per exec; follow-up if
+  it ever matters).
+- Changing the handshake protocol or `wraphandoff` metadata — the fd is just
+  another inherited file, like the notify socket.
+- Touching `internal/netmonitor/unix` — the slog call site and its level are
+  unchanged.
+
+## Testing
+
+1. **Existing regression tests untouched:**
+   `TestInstallFilter_EmitsWaitKillEngagedOnSupportedKernel` and
+   `TestInstallFilter_HonorsOperatorOverride` re-exec the test binary
+   without `AGENTSH_WRAPPER_LOG_FD`; the slog line still lands on their
+   combined output. This was the central constraint from the issue.
+2. **Wrapper unit tests** (`cmd/agentsh-unixwrap`): `setupLogging` with a
+   valid fd routes both `log` and `slog` output there and sets CLOEXEC;
+   invalid fd falls back to stderr; the env var is stripped from the exec
+   environment.
+3. **Server-path integration test** (`internal/integration`): run a wrapped
+   command with machine-readable stderr; assert (a) command stderr contains
+   no `seccomp: filter loaded` line, (b) the server log does. Remove any
+   existing noise-prefix-stripping workarounds so regressions are caught.
+4. **Shim-path test** (`internal/shim/kernelinstall`): relay launches the
+   wrapper with a temp state dir; assert the line lands in
+   `logs/unixwrap.log` and not on inherited stderr.
+5. **Cross-compile:** touched parent files are Linux-gated;
+   `GOOS=windows go build ./...` must stay green.
+
+## Acceptance mapping
+
+| Acceptance criterion (issue #415) | How satisfied |
+|---|---|
+| `agentsh detect --output json` produces clean stderr | Routing in all three spawn paths; CLOEXEC + env strip keep the fd away from the command |
+| `wait_killable` diagnostic visible in server log at default level | Server drains the pipe and re-emits lines at Info |
+| `TestInstallFilter_*` regression tests still pass | They never run wrapper `main()`; `InstallFilterWithConfig` and its slog call are untouched |

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -213,6 +213,10 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 		envInject = make(map[string]string)
 	}
 	envInject["AGENTSH_PTRACE_SYNC"] = ptraceSyncValue
+	// The wrapper log fd is set authoritatively in wrappedReq.Env /
+	// extraCfg.env by the pipe block below; an operator env_inject copy
+	// would shadow it in the child env (issue #415).
+	delete(envInject, wrapperlog.EnvKey)
 
 	extraCfg := &extraProcConfig{
 		extraFiles:       []*os.File{sp.child},

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -255,7 +255,10 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 	// stderr. The fd number is the next ExtraFiles slot — 4 normally,
 	// 5 when the signal socket is present. On pipe failure the env var
 	// is omitted and the wrapper falls back to stderr (legacy behavior);
-	// logging must never block an exec.
+	// logging must never block an exec. Like the notify/signal
+	// socketpairs above, the pipe ends are not closed if cmd.Start()
+	// later fails — the *os.File finalizers reap them at the next GC
+	// (rare path; any future explicit cleanup should include these).
 	if logR, logW, pipeErr := os.Pipe(); pipeErr == nil {
 		fdStr := strconv.Itoa(3 + len(extraCfg.extraFiles))
 		wrappedReq.Env[wrapperlog.EnvKey] = fdStr

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -255,10 +255,10 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 	// stderr. The fd number is the next ExtraFiles slot — 4 normally,
 	// 5 when the signal socket is present. On pipe failure the env var
 	// is omitted and the wrapper falls back to stderr (legacy behavior);
-	// logging must never block an exec. Like the notify/signal
-	// socketpairs above, the pipe ends are not closed if cmd.Start()
-	// later fails — the *os.File finalizers reap them at the next GC
-	// (rare path; any future explicit cleanup should include these).
+	// logging must never block an exec. Unlike the notify/signal
+	// socketpairs above (left to finalizers), the pipe ends are
+	// explicitly released via closeWrapperLogPipe on the pre-start
+	// cancel and cmd.Start()-failure paths.
 	if logR, logW, pipeErr := os.Pipe(); pipeErr == nil {
 		fdStr := strconv.Itoa(3 + len(extraCfg.extraFiles))
 		wrappedReq.Env[wrapperlog.EnvKey] = fdStr

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -24,6 +24,7 @@ import (
 	"github.com/agentsh/agentsh/internal/policy/signing"
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/internal/signal"
+	"github.com/agentsh/agentsh/internal/wrapperlog"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -246,6 +247,25 @@ func (a *App) setupSeccompWrapper(req types.ExecRequest, sessionID string, s *se
 		extraCfg.signalEngine = sessionPolicy.SignalEngine()
 		extraCfg.signalRegistry = signal.NewPIDRegistry(sessionID, os.Getpid())
 		extraCfg.signalCommandID = func() string { return s.CurrentCommandID() }
+	}
+
+	// Wrapper log routing (issue #415): hand the wrapper a pipe for its
+	// diagnostics (the "seccomp: filter loaded" line, landlock notices)
+	// so they land in the server log instead of the wrapped command's
+	// stderr. The fd number is the next ExtraFiles slot — 4 normally,
+	// 5 when the signal socket is present. On pipe failure the env var
+	// is omitted and the wrapper falls back to stderr (legacy behavior);
+	// logging must never block an exec.
+	if logR, logW, pipeErr := os.Pipe(); pipeErr == nil {
+		fdStr := strconv.Itoa(3 + len(extraCfg.extraFiles))
+		wrappedReq.Env[wrapperlog.EnvKey] = fdStr
+		extraCfg.env[wrapperlog.EnvKey] = fdStr
+		extraCfg.extraFiles = append(extraCfg.extraFiles, logW)
+		extraCfg.wrapperLogParent = logR
+		extraCfg.wrapperLogChild = logW
+	} else {
+		slog.Warn("wrapper log pipe unavailable; wrapper diagnostics will appear on command stderr",
+			"session_id", sessionID, "error", pipeErr)
 	}
 
 	return &wrapperSetupResult{wrappedReq: wrappedReq, extraCfg: extraCfg}

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -291,6 +291,7 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 
 	// Fail fast if context is already cancelled (ptrace mode doesn't use CommandContext)
 	if tracer != nil && ctx.Err() != nil {
+		extra.closeWrapperLogPipe()
 		if stdoutPipeR != nil {
 			stdoutPipeR.Close()
 		}
@@ -311,6 +312,7 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 
 	if err := cmd.Start(); err != nil {
 		slog.Debug("exec command start failed", "command", req.Command, "error", err)
+		extra.closeWrapperLogPipe()
 		if stdoutPipeR != nil {
 			stdoutPipeR.Close()
 		}

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -274,10 +274,12 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 		var pipeErr error
 		stdoutPipeR, stdoutPipeW, pipeErr = os.Pipe()
 		if pipeErr != nil {
+			extra.closeWrapperLogPipe()
 			return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("stdout pipe: %w", pipeErr)
 		}
 		stderrPipeR, stderrPipeW, pipeErr = os.Pipe()
 		if pipeErr != nil {
+			extra.closeWrapperLogPipe()
 			stdoutPipeR.Close()
 			stdoutPipeW.Close()
 			return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("stderr pipe: %w", pipeErr)

--- a/internal/api/exec.go
+++ b/internal/api/exec.go
@@ -29,13 +29,13 @@ type extraProcConfig struct {
 	extraFiles       []*os.File
 	env              map[string]string
 	envInject        map[string]string // Operator-trusted env vars that bypass policy filtering
-	notifyParentSock *os.File       // Parent socket to receive seccomp notify fd (Linux only)
-	notifySessionID  string         // Session ID for notify handler
-	notifyStore      eventStore     // Event store for notify handler
-	notifyBroker     eventBroker    // Event broker for notify handler
-	notifyPolicy     *policy.Engine // Policy engine for notify handler
-	execveHandler    any            // Execve handler (*unixmon.ExecveHandler on Linux, nil otherwise)
-	blockList        any            // Seccomp block-list dispatch config (*unixmon.BlockListConfig on Linux, nil otherwise)
+	notifyParentSock *os.File          // Parent socket to receive seccomp notify fd (Linux only)
+	notifySessionID  string            // Session ID for notify handler
+	notifyStore      eventStore        // Event store for notify handler
+	notifyBroker     eventBroker       // Event broker for notify handler
+	notifyPolicy     *policy.Engine    // Policy engine for notify handler
+	execveHandler    any               // Execve handler (*unixmon.ExecveHandler on Linux, nil otherwise)
+	blockList        any               // Seccomp block-list dispatch config (*unixmon.BlockListConfig on Linux, nil otherwise)
 
 	// File monitor config
 	fileMonitorCfg  config.SandboxSeccompFileMonitorConfig
@@ -63,6 +63,14 @@ type extraProcConfig struct {
 	// ptraceSync indicates the READY/GO handshake is enabled for hybrid mode.
 	// Only true when ptrace is active AND seccomp notify features are enabled.
 	ptraceSync bool
+
+	// Wrapper log routing (issue #415): pipe carrying unixwrap
+	// diagnostics into the server log. wrapperLogChild is the write end
+	// inherited by the wrapper via extraFiles; the parent's copy is
+	// closed in startWrapperHandlers so the drain goroutine sees EOF
+	// when the wrapper execs (its own copy is CLOEXEC).
+	wrapperLogParent *os.File
+	wrapperLogChild  *os.File
 }
 
 // eventStore is the interface for storing events.
@@ -240,7 +248,12 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 		}
 	}
 	cmd.Env = env
-	slog.Debug("exec env final", "command", req.Command, "env_count", len(env), "has_extra", extra != nil, "envInject_count", func() int { if extra != nil { return len(extra.envInject) }; return 0 }())
+	slog.Debug("exec env final", "command", req.Command, "env_count", len(env), "has_extra", extra != nil, "envInject_count", func() int {
+		if extra != nil {
+			return len(extra.envInject)
+		}
+		return 0
+	}())
 	if extra != nil && len(extra.extraFiles) > 0 {
 		cmd.ExtraFiles = append(cmd.ExtraFiles, extra.extraFiles...)
 	}
@@ -278,10 +291,18 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 
 	// Fail fast if context is already cancelled (ptrace mode doesn't use CommandContext)
 	if tracer != nil && ctx.Err() != nil {
-		if stdoutPipeR != nil { stdoutPipeR.Close() }
-		if stderrPipeR != nil { stderrPipeR.Close() }
-		if stdoutPipeW != nil { stdoutPipeW.Close() }
-		if stderrPipeW != nil { stderrPipeW.Close() }
+		if stdoutPipeR != nil {
+			stdoutPipeR.Close()
+		}
+		if stderrPipeR != nil {
+			stderrPipeR.Close()
+		}
+		if stdoutPipeW != nil {
+			stdoutPipeW.Close()
+		}
+		if stderrPipeW != nil {
+			stderrPipeW.Close()
+		}
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return 124, nil, nil, 0, 0, false, false, types.ExecResources{}, ctx.Err()
 		}
@@ -290,10 +311,18 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 
 	if err := cmd.Start(); err != nil {
 		slog.Debug("exec command start failed", "command", req.Command, "error", err)
-		if stdoutPipeR != nil { stdoutPipeR.Close() }
-		if stderrPipeR != nil { stderrPipeR.Close() }
-		if stdoutPipeW != nil { stdoutPipeW.Close() }
-		if stderrPipeW != nil { stderrPipeW.Close() }
+		if stdoutPipeR != nil {
+			stdoutPipeR.Close()
+		}
+		if stderrPipeR != nil {
+			stderrPipeR.Close()
+		}
+		if stdoutPipeW != nil {
+			stdoutPipeW.Close()
+		}
+		if stderrPipeW != nil {
+			stderrPipeW.Close()
+		}
 		return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("start: %w", err)
 	}
 	slog.Debug("exec command started", "command", req.Command, "pid", cmd.Process.Pid)
@@ -303,8 +332,20 @@ func runCommandWithResources(ctx context.Context, s *session.Session, cmdID stri
 		stdoutPipeW.Close()
 		stderrPipeW.Close()
 		pipeWG.Add(2)
-		go func() { defer pipeWG.Done(); if _, err := io.Copy(stdoutW, stdoutPipeR); err != nil { slog.Debug("ptrace stdout drain error", "error", err) }; stdoutPipeR.Close() }()
-		go func() { defer pipeWG.Done(); if _, err := io.Copy(stderrW, stderrPipeR); err != nil { slog.Debug("ptrace stderr drain error", "error", err) }; stderrPipeR.Close() }()
+		go func() {
+			defer pipeWG.Done()
+			if _, err := io.Copy(stdoutW, stdoutPipeR); err != nil {
+				slog.Debug("ptrace stdout drain error", "error", err)
+			}
+			stdoutPipeR.Close()
+		}()
+		go func() {
+			defer pipeWG.Done()
+			if _, err := io.Copy(stderrW, stderrPipeR); err != nil {
+				slog.Debug("ptrace stderr drain error", "error", err)
+			}
+			stderrPipeR.Close()
+		}()
 	}
 
 	pgid := 0
@@ -771,6 +812,18 @@ func mergeEnv(base []string, s *session.Session, overrides map[string]string) []
 func startWrapperHandlers(ctx context.Context, extra *extraProcConfig, pid, pgid int, ptraceReady chan<- error) {
 	if extra == nil {
 		return
+	}
+	// Wrapper log routing (issue #415): the child now owns its dup of
+	// the write end; close ours so the drain goroutine gets EOF at the
+	// wrapper's exec. Called from every post-start path (exec.go and
+	// exec_stream.go, hybrid and wrapper-only), exactly once.
+	if extra.wrapperLogChild != nil {
+		_ = extra.wrapperLogChild.Close()
+		extra.wrapperLogChild = nil
+	}
+	if extra.wrapperLogParent != nil {
+		_ = startWrapperLogDrain(extra.wrapperLogParent, slog.Default(), extra.notifySessionID, extra.origCommand)
+		extra.wrapperLogParent = nil
 	}
 	if extra.notifyParentSock != nil {
 		startNotifyHandler(ctx, extra.notifyParentSock, extra.notifySessionID, extra.notifyPolicy, extra.notifyStore, extra.notifyBroker, extra.execveHandler, extra.fileMonitorCfg, extra.landlockEnabled, extra.blockList, ptraceReady)

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -357,10 +357,12 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 		var pipeErr error
 		stdoutPipeR, stdoutPipeW, pipeErr = os.Pipe()
 		if pipeErr != nil {
+			extra.closeWrapperLogPipe()
 			return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("stdout pipe: %w", pipeErr)
 		}
 		stderrPipeR, stderrPipeW, pipeErr = os.Pipe()
 		if pipeErr != nil {
+			extra.closeWrapperLogPipe()
 			stdoutPipeR.Close()
 			stdoutPipeW.Close()
 			return 127, nil, nil, 0, 0, false, false, types.ExecResources{}, fmt.Errorf("stderr pipe: %w", pipeErr)

--- a/internal/api/exec_stream.go
+++ b/internal/api/exec_stream.go
@@ -370,6 +370,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 	}
 
 	if tracer != nil && ctx.Err() != nil {
+		extra.closeWrapperLogPipe()
 		if stdoutPipeR != nil {
 			stdoutPipeR.Close()
 		}
@@ -389,6 +390,7 @@ func runCommandWithResourcesStreamingEmit(ctx context.Context, s *session.Sessio
 	}
 
 	if err := cmd.Start(); err != nil {
+		extra.closeWrapperLogPipe()
 		if stdoutPipeR != nil {
 			stdoutPipeR.Close()
 		}

--- a/internal/api/wrapper_log.go
+++ b/internal/api/wrapper_log.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"bufio"
+	"log/slog"
+	"os"
+)
+
+// startWrapperLogDrain forwards agentsh-unixwrap diagnostic lines from
+// the wrapper log pipe into the server log (issue #415). The wrapper
+// sets FD_CLOEXEC on its end, so EOF arrives when it execs the real
+// command (or exits) — the goroutine is short-lived by construction.
+// Lines are forwarded verbatim as an attr; no re-parsing or re-leveling,
+// so "wait_killable=..." stays greppable at the default level.
+//
+// The returned channel closes when the drain finishes (test hook).
+func startWrapperLogDrain(r *os.File, logger *slog.Logger, sessionID, command string) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer r.Close()
+		sc := bufio.NewScanner(r)
+		for sc.Scan() {
+			logger.Info("unixwrap", "session_id", sessionID, "command", command, "line", sc.Text())
+		}
+	}()
+	return done
+}

--- a/internal/api/wrapper_log.go
+++ b/internal/api/wrapper_log.go
@@ -6,6 +6,27 @@ import (
 	"os"
 )
 
+// closeWrapperLogPipe releases both wrapper-log pipe ends on exec paths
+// that fail before startWrapperHandlers runs (pre-start cancel,
+// cmd.Start() failure). Safe to call multiple times and on configs
+// without a log pipe. The pre-existing notify/signal socketpairs are
+// deliberately left to their finalizers on these paths (see
+// buildWrapperSetup); the pipe is closed here because it is new on
+// this branch and cheap to handle (issue #415).
+func (e *extraProcConfig) closeWrapperLogPipe() {
+	if e == nil {
+		return
+	}
+	if e.wrapperLogChild != nil {
+		_ = e.wrapperLogChild.Close()
+		e.wrapperLogChild = nil
+	}
+	if e.wrapperLogParent != nil {
+		_ = e.wrapperLogParent.Close()
+		e.wrapperLogParent = nil
+	}
+}
+
 // startWrapperLogDrain forwards agentsh-unixwrap diagnostic lines from
 // the wrapper log pipe into the server log (issue #415). The wrapper
 // sets FD_CLOEXEC on its end, so EOF arrives when it execs the real

--- a/internal/api/wrapper_log.go
+++ b/internal/api/wrapper_log.go
@@ -23,6 +23,12 @@ func startWrapperLogDrain(r *os.File, logger *slog.Logger, sessionID, command st
 		for sc.Scan() {
 			logger.Info("unixwrap", "session_id", sessionID, "command", command, "line", sc.Text())
 		}
+		// Normal exit is EOF (wrapper exec'd or died). Anything else —
+		// e.g. bufio.ErrTooLong past the 64KiB token cap — silently
+		// stops draining, so leave a trace for operators.
+		if err := sc.Err(); err != nil {
+			logger.Debug("unixwrap log drain stopped early", "session_id", sessionID, "error", err)
+		}
 	}()
 	return done
 }

--- a/internal/api/wrapper_log_test.go
+++ b/internal/api/wrapper_log_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// syncBuffer makes bytes.Buffer safe for the drain goroutine + test reader.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestStartWrapperLogDrain_ForwardsLinesToLogger(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+
+	var buf syncBuffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	done := startWrapperLogDrain(r, logger, "sess-1", "/bin/true")
+
+	if _, err := w.WriteString("seccomp: filter loaded fd=8 wait_killable=true\nlandlock: restrictions applied\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	w.Close() // EOF → drain goroutine exits
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("drain goroutine did not finish after EOF")
+	}
+
+	out := buf.String()
+	for _, want := range []string{
+		"seccomp: filter loaded",
+		"wait_killable=true",
+		"landlock: restrictions applied",
+		"session_id=sess-1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("drained log missing %q, got:\n%s", want, out)
+		}
+	}
+}

--- a/internal/api/wrapper_log_test.go
+++ b/internal/api/wrapper_log_test.go
@@ -10,6 +10,27 @@ import (
 	"time"
 )
 
+func TestCloseWrapperLogPipe_IdempotentAndNilSafe(t *testing.T) {
+	var nilCfg *extraProcConfig
+	nilCfg.closeWrapperLogPipe() // must not panic
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	cfg := &extraProcConfig{wrapperLogParent: r, wrapperLogChild: w}
+	cfg.closeWrapperLogPipe()
+	if cfg.wrapperLogParent != nil || cfg.wrapperLogChild != nil {
+		t.Fatal("fields not nil-ed after close")
+	}
+	// Second write end close must have happened: writing to a closed
+	// pipe *os.File errors immediately.
+	if _, err := w.Write([]byte("x")); err == nil {
+		t.Error("write end not closed")
+	}
+	cfg.closeWrapperLogPipe() // idempotent — must not panic
+}
+
 // syncBuffer makes bytes.Buffer safe for the drain goroutine + test reader.
 type syncBuffer struct {
 	mu  sync.Mutex

--- a/internal/cli/wrap_linux.go
+++ b/internal/cli/wrap_linux.go
@@ -167,10 +167,15 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 	// Wrapper log routing (issue #415): the CLI's stderr is the user's
 	// terminal, so route wrapper diagnostics to the state-dir log file.
 	// fd number = next ExtraFiles slot (4, or 5 with the signal socket).
-	// Silent stderr fallback on open failure — warning here would
-	// reintroduce the exact noise this removes. wrap.go closes every
-	// extraFiles entry after Start, so no extra cleanup is needed.
-	if logFile, err := wrapperlog.OpenStateLogFile(); err == nil {
+	// Debug-level fallback note on open failure — a Warn would reintroduce
+	// the exact noise this removes. wrap.go closes every extraFiles entry
+	// after Start, so no extra cleanup is needed.
+	logFile, logErr := wrapperlog.OpenStateLogFile()
+	if logErr != nil {
+		// Debug, not Warn: the CLI's stderr is the user's terminal and
+		// the wrapper falls back to it anyway (legacy behavior).
+		slog.Debug("wrap: wrapper log file unavailable; wrapper diagnostics stay on stderr", "error", logErr)
+	} else {
 		// os.Getenv returns the FIRST duplicate, so drop any copy of
 		// the key carried in by the inherited environment, env_inject,
 		// or server WrapperEnv before appending the authoritative one.
@@ -340,9 +345,8 @@ func reclaimTerminal() {
 }
 
 // stripEnvKey returns env without any KEY=... entries for key.
-// The env slice is filtered in-place (env[:0] alias) which is safe here
-// because env is locally owned via append chains and no reference to the
-// pre-strip slice is used afterward.
+// WARNING: filters in place via env[:0] — it mutates the input slice's
+// backing array, so callers must pass a slice they exclusively own.
 func stripEnvKey(env []string, key string) []string {
 	out := env[:0]
 	prefix := key + "="

--- a/internal/cli/wrap_linux.go
+++ b/internal/cli/wrap_linux.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"strings"
 	"syscall"
 	"time"
 	"unsafe"
@@ -17,6 +18,7 @@ import (
 	"github.com/agentsh/agentsh/internal/envinject"
 	"github.com/agentsh/agentsh/internal/wrapenv"
 	"github.com/agentsh/agentsh/internal/wraphandoff"
+	"github.com/agentsh/agentsh/internal/wrapperlog"
 	"github.com/agentsh/agentsh/pkg/types"
 	"golang.org/x/sys/unix"
 )
@@ -160,6 +162,21 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 	extraFiles := []*os.File{childFile}
 	if hasSignalSocket {
 		extraFiles = append(extraFiles, signalChildFile)
+	}
+
+	// Wrapper log routing (issue #415): the CLI's stderr is the user's
+	// terminal, so route wrapper diagnostics to the state-dir log file.
+	// fd number = next ExtraFiles slot (4, or 5 with the signal socket).
+	// Silent stderr fallback on open failure — warning here would
+	// reintroduce the exact noise this removes. wrap.go closes every
+	// extraFiles entry after Start, so no extra cleanup is needed.
+	if logFile, err := wrapperlog.OpenStateLogFile(); err == nil {
+		// os.Getenv returns the FIRST duplicate, so drop any copy of
+		// the key carried in by the inherited environment, env_inject,
+		// or server WrapperEnv before appending the authoritative one.
+		env = stripEnvKey(env, wrapperlog.EnvKey)
+		env = append(env, fmt.Sprintf("%s=%d", wrapperlog.EnvKey, 3+len(extraFiles)))
+		extraFiles = append(extraFiles, logFile)
 	}
 
 	return &wrapLaunchConfig{
@@ -320,4 +337,20 @@ func isTerminal(fd uintptr) bool {
 func reclaimTerminal() {
 	pgid := int32(unix.Getpgrp())
 	_, _, _ = unix.Syscall(unix.SYS_IOCTL, os.Stdin.Fd(), unix.TIOCSPGRP, uintptr(unsafe.Pointer(&pgid)))
+}
+
+// stripEnvKey returns env without any KEY=... entries for key.
+// The env slice is filtered in-place (env[:0] alias) which is safe here
+// because env is locally owned via append chains and no reference to the
+// pre-strip slice is used afterward.
+func stripEnvKey(env []string, key string) []string {
+	out := env[:0]
+	prefix := key + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
 }

--- a/internal/cli/wrap_linux.go
+++ b/internal/cli/wrap_linux.go
@@ -170,16 +170,19 @@ func platformSetupWrap(ctx context.Context, wrapResp types.WrapInitResponse, ses
 	// Debug-level fallback note on open failure — a Warn would reintroduce
 	// the exact noise this removes. wrap.go closes every extraFiles entry
 	// after Start, so no extra cleanup is needed.
+	// os.Getenv returns the FIRST duplicate, so drop any copy of the
+	// key carried in by the inherited environment, env_inject, or
+	// server WrapperEnv. Unconditional: even on open failure a stale
+	// value must not survive — inside the wrapper it could name a
+	// valid-but-unrelated fd (e.g. the signal socket at fd 4) and
+	// receive routed diagnostics.
+	env = stripEnvKey(env, wrapperlog.EnvKey)
 	logFile, logErr := wrapperlog.OpenStateLogFile()
 	if logErr != nil {
 		// Debug, not Warn: the CLI's stderr is the user's terminal and
 		// the wrapper falls back to it anyway (legacy behavior).
 		slog.Debug("wrap: wrapper log file unavailable; wrapper diagnostics stay on stderr", "error", logErr)
 	} else {
-		// os.Getenv returns the FIRST duplicate, so drop any copy of
-		// the key carried in by the inherited environment, env_inject,
-		// or server WrapperEnv before appending the authoritative one.
-		env = stripEnvKey(env, wrapperlog.EnvKey)
 		env = append(env, fmt.Sprintf("%s=%d", wrapperlog.EnvKey, 3+len(extraFiles)))
 		extraFiles = append(extraFiles, logFile)
 	}

--- a/internal/cli/wrap_linux_test.go
+++ b/internal/cli/wrap_linux_test.go
@@ -14,6 +14,15 @@ import (
 	"github.com/agentsh/agentsh/internal/wraphandoff"
 )
 
+func TestStripEnvKey(t *testing.T) {
+	in := []string{"A=1", "AGENTSH_WRAPPER_LOG_FD=9", "B=2", "AGENTSH_WRAPPER_LOG_FD=10"}
+	out := stripEnvKey(in, "AGENTSH_WRAPPER_LOG_FD")
+	want := []string{"A=1", "B=2"}
+	if len(out) != len(want) || out[0] != want[0] || out[1] != want[1] {
+		t.Fatalf("stripEnvKey = %v, want %v", out, want)
+	}
+}
+
 func TestForwardNotifyFDWithPIDWaitsForServerOK(t *testing.T) {
 	dir := t.TempDir()
 	socketPath := filepath.Join(dir, "notify.sock")

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -263,7 +263,7 @@ func TestSetupWrapInterception_CallsWrapInit(t *testing.T) {
 		assert.Equal(t, "/bin/true", lcfg.command, "command should be the wrapper binary")
 		assert.Equal(t, []string{"--", "/bin/echo", "hello"}, lcfg.args, "args should be -- agent-cmd agent-args")
 		assert.NotNil(t, lcfg.extraFiles, "extra files should be set (socket pair child)")
-		assert.Len(t, lcfg.extraFiles, 1, "should have exactly one extra file (child socket)")
+		assert.GreaterOrEqual(t, len(lcfg.extraFiles), 1, "should have at least one extra file (child socket); log file may also be appended")
 		assert.NotNil(t, lcfg.postStart, "postStart should be set")
 	} else if runtime.GOOS == "darwin" {
 		// On macOS with a wrapper binary, we get the wrapper command + args, but no extraFiles/postStart

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -235,6 +235,10 @@ func TestSetupWrapInterception_CallsWrapInit(t *testing.T) {
 		t.Skip("wrap interception requires Linux or macOS")
 	}
 
+	// Redirect the state dir: platformSetupWrap opens the wrapper log
+	// file (issue #415) and must not touch the real ~/.local/state.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
 	mc := &mockWrapClient{
 		wrapInitResp: types.WrapInitResponse{
 			WrapperBinary: "/bin/true",
@@ -263,7 +267,8 @@ func TestSetupWrapInterception_CallsWrapInit(t *testing.T) {
 		assert.Equal(t, "/bin/true", lcfg.command, "command should be the wrapper binary")
 		assert.Equal(t, []string{"--", "/bin/echo", "hello"}, lcfg.args, "args should be -- agent-cmd agent-args")
 		assert.NotNil(t, lcfg.extraFiles, "extra files should be set (socket pair child)")
-		assert.GreaterOrEqual(t, len(lcfg.extraFiles), 1, "should have at least one extra file (child socket); log file may also be appended")
+		// notify child + wrapper log file (state dir redirected above).
+		assert.Len(t, lcfg.extraFiles, 2)
 		assert.NotNil(t, lcfg.postStart, "postStart should be set")
 	} else if runtime.GOOS == "darwin" {
 		// On macOS with a wrapper binary, we get the wrapper command + args, but no extraFiles/postStart

--- a/internal/integration/wrapper_log_routing_test.go
+++ b/internal/integration/wrapper_log_routing_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/agentsh/agentsh/internal/client"
 	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/testcontainers/testcontainers-go"
 )
 
 // TestExecPath_WrapperLogRoutedOffCommandStderr is the end-to-end
@@ -110,26 +111,48 @@ func TestExecPath_WrapperLogRoutedOffCommandStderr(t *testing.T) {
 		t.Fatalf("wrapper diagnostic leaked onto command stderr (issue #415 regression):\n%s", res.Result.Stderr)
 	}
 
-	// (b) The diagnostic landed in the server log instead, at default
-	// level (logging.level=info in the test config). The drained line
-	// is embedded as the `line` attr of the server's "unixwrap" record;
-	// the substring survives TextHandler quoting.
+	// (b) The diagnostic lands in the server log at default level
+	// (logging.level=info in the test config). The drain goroutine is
+	// asynchronous to the Exec response (fire-and-forget in
+	// startWrapperHandlers) and Docker's log driver adds its own
+	// propagation delay, so poll rather than read once.
 	logsCtx, logsCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer logsCancel()
-	logsReader, err := ctr.Logs(logsCtx)
-	if err != nil {
-		t.Fatalf("container logs: %v", err)
+	var serverLog string
+	for {
+		serverLog = readContainerLogs(t, logsCtx, ctr)
+		if strings.Contains(serverLog, "seccomp: filter loaded") && strings.Contains(serverLog, "wait_killable") {
+			break
+		}
+		select {
+		case <-logsCtx.Done():
+			// fall through to the assertions below with the last read,
+			// so the failure message carries the full server log.
+		case <-time.After(500 * time.Millisecond):
+			continue
+		}
+		break
 	}
-	defer logsReader.Close()
-	logBytes, err := io.ReadAll(logsReader)
-	if err != nil {
-		t.Fatalf("read container logs: %v", err)
-	}
-	serverLog := string(logBytes)
 	if !strings.Contains(serverLog, "seccomp: filter loaded") {
 		t.Fatalf("wrapper diagnostic missing from server log (acceptance criterion #2)\nserver log:\n%s", serverLog)
 	}
 	if !strings.Contains(serverLog, "wait_killable") {
 		t.Fatalf("wait_killable field missing from drained diagnostic\nserver log:\n%s", serverLog)
 	}
+}
+
+// readContainerLogs returns the container's full log history; Logs
+// streams from the start on every call, so each poll sees everything.
+func readContainerLogs(t *testing.T, ctx context.Context, ctr testcontainers.Container) string {
+	t.Helper()
+	reader, err := ctr.Logs(ctx)
+	if err != nil {
+		t.Fatalf("container logs: %v", err)
+	}
+	defer reader.Close()
+	b, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read container logs: %v", err)
+	}
+	return string(b)
 }

--- a/internal/integration/wrapper_log_routing_test.go
+++ b/internal/integration/wrapper_log_routing_test.go
@@ -1,0 +1,135 @@
+//go:build integration && linux
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/client"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// TestExecPath_WrapperLogRoutedOffCommandStderr is the end-to-end
+// acceptance test for issue #415: a wrapped command's stderr must not
+// carry the per-exec "seccomp: filter loaded" wrapper diagnostic, and
+// that diagnostic must instead appear in the server log (drained from
+// the wrapper log pipe) at the default level.
+func TestExecPath_WrapperLogRoutedOffCommandStderr(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	agentshBin, unixwrapBin := buildSeccompBinaries(t)
+	temp := t.TempDir()
+
+	configPath := filepath.Join(temp, "config.yaml")
+	writeFile(t, configPath, wrapStrongTestConfigYAML)
+	keysPath := filepath.Join(temp, "keys.yaml")
+	writeFile(t, keysPath, testAPIKeysYAML)
+
+	policiesDir := filepath.Join(temp, "policies")
+	mustMkdir(t, policiesDir)
+	writeFile(t, filepath.Join(policiesDir, "agent-default.yaml"), wrapTestPolicyYAML)
+
+	workspace := filepath.Join(temp, "workspace")
+	mustMkdir(t, workspace)
+
+	ctr, endpoint, cleanup := startWrapSeccompServerContainer(t, ctx, agentshBin, unixwrapBin, configPath, keysPath, policiesDir, workspace)
+	t.Cleanup(cleanup)
+
+	cli := client.New(endpoint, "test-key")
+
+	// Probe exec: confirm seccomp-user-notify is operational in this
+	// environment before asserting anything about log routing.
+	// Mirror the same probe-skip pattern as TestWrapStrongMode_SetsInSessionMarker.
+	probeSess, err := cli.CreateSession(ctx, "/workspace", "agent-default")
+	if err != nil {
+		t.Fatalf("CreateSession probe: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cli.DestroySession(context.Background(), probeSess.ID); err != nil {
+			t.Logf("DestroySession probe: %v", err)
+		}
+	})
+
+	probeCtx, probeCancel := context.WithTimeout(ctx, 10*time.Second)
+	probeResult, probeErr := cli.Exec(probeCtx, probeSess.ID, types.ExecRequest{
+		Command: "/bin/echo",
+		Args:    []string{"probe"},
+	})
+	probeCancel()
+
+	if probeErr != nil {
+		if errors.Is(probeErr, context.DeadlineExceeded) || strings.Contains(probeErr.Error(), "deadline exceeded") {
+			t.Skip("seccomp-user-notify appears unreliable in this environment (probe timeout)")
+		}
+		t.Fatalf("Exec probe: %v", probeErr)
+	}
+	if probeResult.Result.ExitCode != 0 {
+		t.Skip("seccomp-user-notify may not be active in this environment (probe exit non-zero)")
+	}
+
+	// Main session: run a command that writes to stderr so we can verify
+	// the wrapper diagnostic is NOT mixed into it.
+	sess, err := cli.CreateSession(ctx, "/workspace", "agent-default")
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := cli.DestroySession(context.Background(), sess.ID); err != nil {
+			t.Logf("DestroySession: %v", err)
+		}
+	})
+
+	execCtx, execCancel := context.WithTimeout(ctx, 30*time.Second)
+	res, execErr := cli.Exec(execCtx, sess.ID, types.ExecRequest{
+		Command: "/bin/sh",
+		Args:    []string{"-c", "echo STDERR_MARKER >&2"},
+	})
+	execCancel()
+	if execErr != nil {
+		if errors.Is(execErr, context.DeadlineExceeded) || strings.Contains(execErr.Error(), "deadline exceeded") {
+			t.Skip("seccomp-user-notify appears unreliable in this environment (exec timeout)")
+		}
+		t.Fatalf("Exec: %v", execErr)
+	}
+	if res.Result.ExitCode != 0 {
+		t.Skipf("seccomp-user-notify may not be active in this environment (exit=%d, stderr=%q)", res.Result.ExitCode, res.Result.Stderr)
+	}
+
+	// (a) The command's own stderr arrives intact and uncontaminated.
+	if !strings.Contains(res.Result.Stderr, "STDERR_MARKER") {
+		t.Fatalf("command stderr lost: %q", res.Result.Stderr)
+	}
+	if strings.Contains(res.Result.Stderr, "seccomp: filter loaded") {
+		t.Fatalf("wrapper diagnostic leaked onto command stderr (issue #415 regression):\n%s", res.Result.Stderr)
+	}
+
+	// (b) The diagnostic landed in the server log instead, at default
+	// level (logging.level=info in the test config). The drained line
+	// is embedded as the `line` attr of the server's "unixwrap" record;
+	// the substring survives TextHandler quoting.
+	logsCtx, logsCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer logsCancel()
+	logsReader, err := ctr.Logs(logsCtx)
+	if err != nil {
+		t.Fatalf("container logs: %v", err)
+	}
+	defer logsReader.Close()
+	logBytes, err := io.ReadAll(logsReader)
+	if err != nil {
+		t.Fatalf("read container logs: %v", err)
+	}
+	serverLog := string(logBytes)
+	if !strings.Contains(serverLog, "seccomp: filter loaded") {
+		t.Fatalf("wrapper diagnostic missing from server log (acceptance criterion #2)\nserver log:\n%s", serverLog)
+	}
+	if !strings.Contains(serverLog, "wait_killable") {
+		t.Fatalf("wait_killable field missing from drained diagnostic\nserver log:\n%s", serverLog)
+	}
+}

--- a/internal/shim/kernelinstall/install_linux.go
+++ b/internal/shim/kernelinstall/install_linux.go
@@ -19,6 +19,7 @@ import (
 	"github.com/agentsh/agentsh/internal/envinject"
 	"github.com/agentsh/agentsh/internal/wrapenv"
 	"github.com/agentsh/agentsh/internal/wraphandoff"
+	"github.com/agentsh/agentsh/internal/wrapperlog"
 	"github.com/agentsh/agentsh/pkg/types"
 	"golang.org/x/sys/unix"
 )
@@ -200,6 +201,17 @@ func runRelay(p InstallParams, resp types.WrapInitResponse) (Result, error) {
 	// stripping rationale (issue #374).
 	env := assembleWrapperEnv(wrapenv.Filter(filterShimInternalEnv(p.Env), resp.EnvPolicy), p.Argv0, resp.WrapperEnv, resp.EnvInject)
 
+	// Wrapper log routing (issue #415): point the wrapper's diagnostics
+	// at the state-dir log file. The relay's own stderr IS the user's
+	// terminal, so draining a pipe into our slog would put the noise
+	// right back on screen; an O_APPEND file needs no drain goroutine
+	// and keeps concurrent shim execs line-atomic. Debug (not Warn) on
+	// failure for the same reason — the relay must not add stderr noise.
+	logFile, logErr := wrapperlog.OpenStateLogFile()
+	if logErr != nil {
+		slog.Debug("kernelinstall: wrapper log file unavailable; wrapper diagnostics stay on stderr", "error", logErr)
+	}
+
 	// Build wrapper argv: wrapperBin -- realShell shellArgs...
 	// argv[0] is the wrapper binary's basename (conventional).
 	wrapperArgs := make([]string, 0, 2+len(p.ShellArgs))
@@ -215,15 +227,27 @@ func runRelay(p InstallParams, resp types.WrapInitResponse) (Result, error) {
 	cmd.Stderr = os.Stderr
 	// ExtraFiles[0] becomes fd 3 in the child (0=stdin,1=stdout,2=stderr,3=ExtraFiles[0])
 	cmd.ExtraFiles = []*os.File{childFile}
+	if logFile != nil {
+		// ExtraFiles[1] = fd 4 — free in shim mode (the signal-filter
+		// socketpair is deliberately not replicated here).
+		cmd.ExtraFiles = append(cmd.ExtraFiles, logFile)
+		cmd.Env = append(cmd.Env, wrapperlog.EnvKey+"=4")
+	}
 
 	if err := cmd.Start(); err != nil {
 		parentFile.Close()
 		childFile.Close()
+		if logFile != nil {
+			logFile.Close()
+		}
 		return Result{}, fmt.Errorf("start wrapper: %w", err)
 	}
 
 	// The wrapper owns childFile now; close our copy in the parent.
 	childFile.Close()
+	if logFile != nil {
+		logFile.Close()
+	}
 
 	// Receive the seccomp notify fd from the wrapper via SCM_RIGHTS.
 	notifyFD, recvErr := recvNotifyFD(parentFile)
@@ -405,6 +429,12 @@ func assembleWrapperEnv(base []string, argv0 string, wrapperEnv, envInject map[s
 			slog.Debug("kernelinstall: stripping signal sock fd from wrapper env (shim mode limitation)")
 			continue
 		}
+		if k == wrapperlog.EnvKey {
+			// The relay is the wrapper's parent here and sets its own
+			// authoritative log fd; a server-supplied value would point
+			// at an fd that does not exist in this process (issue #415).
+			continue
+		}
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 	return env
@@ -414,8 +444,9 @@ func filterShimInternalEnv(env []string) []string {
 	out := make([]string, 0, len(env))
 	signalPrefix := signalSockFDKey + "="
 	argv0Prefix := argv0EnvKey + "="
+	logFDPrefix := wrapperlog.EnvKey + "="
 	for _, e := range env {
-		if strings.HasPrefix(e, signalPrefix) || strings.HasPrefix(e, argv0Prefix) {
+		if strings.HasPrefix(e, signalPrefix) || strings.HasPrefix(e, argv0Prefix) || strings.HasPrefix(e, logFDPrefix) {
 			continue
 		}
 		out = append(out, e)

--- a/internal/shim/kernelinstall/install_linux.go
+++ b/internal/shim/kernelinstall/install_linux.go
@@ -412,8 +412,13 @@ func filterSignalSockFD(env []string) []string {
 // socketpair, so the wrapper must not try to open that fd.
 func assembleWrapperEnv(base []string, argv0 string, wrapperEnv, envInject map[string]string) []string {
 	// Copy so appends never alias the caller's backing array (Apply may
-	// return base unchanged when envInject is empty).
-	env := append([]string(nil), envinject.Apply(base, envInject)...)
+	// return base unchanged when envInject is empty). Re-run the
+	// internal-marker filter AFTER Apply: env_inject is operator
+	// controlled and applied verbatim, and os.Getenv returns the FIRST
+	// duplicate — an injected AGENTSH_WRAPPER_LOG_FD / signal-fd /
+	// argv0 would otherwise shadow the authoritative values appended
+	// below (issue #415).
+	env := append([]string(nil), filterShimInternalEnv(envinject.Apply(base, envInject))...)
 	env = append(env, "AGENTSH_NOTIFY_SOCK_FD=3")
 	// Plumb the original invocation name (e.g. "/bin/sh") through to the
 	// wrapper so it can override argv[0] when execve'ing the real shell.

--- a/internal/shim/kernelinstall/install_linux_test.go
+++ b/internal/shim/kernelinstall/install_linux_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/agentsh/agentsh/internal/wraphandoff"
+	"github.com/agentsh/agentsh/internal/wrapperlog"
 	"github.com/agentsh/agentsh/pkg/types"
 )
 
@@ -1036,6 +1037,101 @@ func buildFakeWrapper(t *testing.T) string {
 		t.Skipf("compile fake wrapper: %v\n%s", err, out)
 	}
 	return binPath
+}
+
+// ─── Test: filterShimInternalEnv strips AGENTSH_WRAPPER_LOG_FD ──────────────
+
+func TestFilterShimInternalEnv_StripsWrapperLogFD(t *testing.T) {
+	in := []string{"PATH=/bin", wrapperlog.EnvKey + "=7", "HOME=/root"}
+	out := filterShimInternalEnv(in)
+	for _, e := range out {
+		if strings.HasPrefix(e, wrapperlog.EnvKey+"=") {
+			t.Fatalf("inherited %s not stripped: %v", wrapperlog.EnvKey, out)
+		}
+	}
+	if len(out) != 2 {
+		t.Fatalf("unexpected env after strip: %v", out)
+	}
+}
+
+func TestAssembleWrapperEnv_DropsWrapperLogFDFromWrapperEnv(t *testing.T) {
+	env := assembleWrapperEnv(
+		[]string{"PATH=/bin"},
+		"",
+		map[string]string{
+			wrapperlog.EnvKey:        "9", // must NOT pass through — the relay sets its own
+			"AGENTSH_SECCOMP_CONFIG": "{}",
+		},
+		nil,
+	)
+	for _, e := range env {
+		if strings.HasPrefix(e, wrapperlog.EnvKey+"=") {
+			t.Fatalf("server-supplied %s leaked into wrapper env: %v", wrapperlog.EnvKey, env)
+		}
+	}
+}
+
+// TestInstall_PassesWrapperLogFDAndCreatesStateLogFile verifies the
+// issue #415 relay wiring end-to-end: runRelay opens the state-dir log
+// file, passes it as ExtraFiles[1], and exports AGENTSH_WRAPPER_LOG_FD=4
+// to the wrapper. XDG_STATE_HOME is redirected to a temp dir so the test
+// owns the state-dir location.
+func TestInstall_PassesWrapperLogFDAndCreatesStateLogFile(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	wrapperBin := buildFakeWrapperPrintEnv(t)
+
+	sockDir := t.TempDir()
+	notifySockPath := filepath.Join(sockDir, "notify.sock")
+	ln, err := net.Listen("unix", notifySockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	serveNotifySetupStatus(ln, true)
+
+	wrapResp := types.WrapInitResponse{
+		WrapperBinary: wrapperBin,
+		NotifySocket:  notifySockPath,
+		WrapperEnv:    map[string]string{"FAKE_WRAPPER": "1"},
+	}
+	handler, _ := makeWrapInitHandler(200, wrapResp)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	p := baseParams(srv)
+	p.Mode = ModeOn
+	p.Env = []string{"HOME=/tmp"}
+
+	outFile, err := os.CreateTemp(t.TempDir(), "wrapper-env-*.txt")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	outPath := outFile.Name()
+	outFile.Close()
+	p.Env = append(p.Env, "FAKE_ENV_OUT="+outPath)
+
+	res, err := Install(p)
+	if err != nil {
+		t.Fatalf("Install returned error: %v", err)
+	}
+	if res.Action != ResultExec {
+		t.Fatalf("expected ResultExec, got %v (reason: %s)", res.Action, res.Reason)
+	}
+
+	envOutput, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read wrapper env output: %v", err)
+	}
+	if !strings.Contains(string(envOutput), wrapperlog.EnvKey+"=4") {
+		t.Errorf("wrapper env missing %s=4:\n%s", wrapperlog.EnvKey, envOutput)
+	}
+
+	logPath := filepath.Join(stateHome, "agentsh", "logs", "unixwrap.log")
+	if _, err := os.Stat(logPath); err != nil {
+		t.Errorf("state-dir log file not created at %s: %v", logPath, err)
+	}
 }
 
 // findModuleRoot walks up from the current working directory to find go.mod.

--- a/internal/shim/kernelinstall/install_linux_test.go
+++ b/internal/shim/kernelinstall/install_linux_test.go
@@ -1134,6 +1134,20 @@ func TestInstall_PassesWrapperLogFDAndCreatesStateLogFile(t *testing.T) {
 	}
 }
 
+func TestAssembleWrapperEnv_EnvInjectCannotShadowWrapperLogFD(t *testing.T) {
+	env := assembleWrapperEnv(
+		[]string{"PATH=/bin"},
+		"",
+		nil,
+		map[string]string{wrapperlog.EnvKey: "9"}, // operator env_inject
+	)
+	for _, e := range env {
+		if strings.HasPrefix(e, wrapperlog.EnvKey+"=") {
+			t.Fatalf("env_inject value for %s survived into wrapper env: %v", wrapperlog.EnvKey, env)
+		}
+	}
+}
+
 // findModuleRoot walks up from the current working directory to find go.mod.
 func findModuleRoot(t *testing.T) string {
 	t.Helper()

--- a/internal/wrapperlog/wrapperlog.go
+++ b/internal/wrapperlog/wrapperlog.go
@@ -1,0 +1,32 @@
+// Package wrapperlog defines the env contract and fallback file
+// destination for routing agentsh-unixwrap diagnostics off the wrapped
+// command's stderr (issue #415). The wrapper execs the real command in
+// place, so anything it logs to stderr lands on the user-visible stream
+// of the wrapped command; parents pass an inherited fd via EnvKey
+// instead.
+package wrapperlog
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+// EnvKey names the env var carrying the inherited fd number that
+// agentsh-unixwrap routes its diagnostics (slog + stdlib log) to.
+// Unset means stderr (legacy behavior).
+const EnvKey = "AGENTSH_WRAPPER_LOG_FD"
+
+// OpenStateLogFile opens <user-state-dir>/logs/unixwrap.log for append,
+// creating the directory as needed. Used by parents that have no live
+// log sink of their own (shell-shim relay, agentsh wrap CLI); O_APPEND
+// keeps concurrent wrapper invocations line-atomic.
+func OpenStateLogFile() (*os.File, error) {
+	dir := filepath.Join(config.GetUserStateDir(), "logs")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, err
+	}
+	return os.OpenFile(filepath.Join(dir, "unixwrap.log"),
+		os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+}

--- a/internal/wrapperlog/wrapperlog_test.go
+++ b/internal/wrapperlog/wrapperlog_test.go
@@ -1,0 +1,51 @@
+package wrapperlog
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestOpenStateLogFile_CreatesDirAndAppends(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("XDG_STATE_HOME redirection is linux-only")
+	}
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+
+	f, err := OpenStateLogFile()
+	if err != nil {
+		t.Fatalf("OpenStateLogFile: %v", err)
+	}
+	if _, err := f.WriteString("first\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f.Close()
+
+	// A second open must append, not truncate.
+	f2, err := OpenStateLogFile()
+	if err != nil {
+		t.Fatalf("OpenStateLogFile (second): %v", err)
+	}
+	if _, err := f2.WriteString("second\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	f2.Close()
+
+	got, err := os.ReadFile(filepath.Join(stateHome, "agentsh", "logs", "unixwrap.log"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if string(got) != "first\nsecond\n" {
+		t.Fatalf("log content = %q, want %q", got, "first\nsecond\n")
+	}
+}
+
+func TestEnvKey_Value(t *testing.T) {
+	// The wrapper and all three parents must agree on this string;
+	// pin it so a rename can't silently desynchronize them.
+	if EnvKey != "AGENTSH_WRAPPER_LOG_FD" {
+		t.Fatalf("EnvKey = %q", EnvKey)
+	}
+}


### PR DESCRIPTION
Closes #415.

## Summary

The per-exec `seccomp: filter loaded` slog line (and all stdlib `log` noise — landlock notices, Yama warnings) emitted by `agentsh-unixwrap` landed on the wrapped command's stderr, corrupting machine-readable streams like `agentsh detect --output json`. This routes it off — **without downgrading the #369 `wait_killable` diagnostic** (Option 3 from the issue).

- **Wrapper** (`cmd/agentsh-unixwrap`): new `setupLogging()` reads `AGENTSH_WRAPPER_LOG_FD`, points both default slog and stdlib `log` at the inherited fd (fstat-validated, `FD_CLOEXEC`, env var stripped before exec so nested wrappers can't inherit a stale fd number). Fatals dual-write to the routed sink **and** stderr so users still see why an exec died. Unset env → stderr, exactly as before (manual invocation / version skew safe).
- **Server exec path** (`internal/api`): backs the fd with a pipe; a short-lived goroutine drains lines into the server log at Info (`unixwrap` records tagged with `session_id`/`command`), so `wait_killable=...` stays greppable at default level. Pipe released on every pre-start failure path.
- **Shim relay + `agentsh wrap` CLI**: back the fd with an `O_APPEND` `<state-dir>/logs/unixwrap.log` (their stderr *is* the user's terminal; appends are line-atomic, no drain needed).
- **Env-shadowing defense in all three paths**: `os.Getenv` returns the first duplicate, and `env_inject` overrides `extra.env` on the server path — inherited env, `env_inject`, and server `WrapperEnv` copies of the key are all stripped before the parent appends its authoritative value.

## Acceptance (from #415)

- ✅ Wrapped commands produce clean, un-prefixed stderr — proven end-to-end by the new `TestExecPath_WrapperLogRoutedOffCommandStderr` integration test (containerized server, real seccomp)
- ✅ `wait_killable` diagnostic remains in the server log at default level — same test asserts the drained line
- ✅ `TestInstallFilter_EmitsWaitKillEngagedOnSupportedKernel` / `TestInstallFilter_HonorsOperatorOverride` pass **unchanged** — they re-exec the test binary, never wrapper `main()`; `internal/netmonitor/unix` is untouched

## Test plan

- [x] `go build ./...` and `GOOS=windows go build ./...`
- [x] Full `go test ./...` (green except 3 documented local-env-only failures, each verified failing identically on unmodified main)
- [x] Integration test passes 2× (async-drain race fixed with a bounded poll)
- [x] Every commit individually roborev-reviewed; all findings addressed or adjudicated (one known cosmetic: a nanosecond-window context race can degrade the integration test's *failure message* only)

Spec: `docs/superpowers/specs/2026-06-06-issue-415-wrapper-log-routing-design.md` · Plan: `docs/superpowers/plans/2026-06-06-issue-415-wrapper-log-routing.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)