### PR TITLE
fix(#416): bind session to already-traced shell in attach_mode=pid + shim_install=auto

### DIFF
--- a/internal/api/wrap_linux.go
+++ b/internal/api/wrap_linux.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	unixmon "github.com/agentsh/agentsh/internal/netmonitor/unix"
+	"github.com/agentsh/agentsh/internal/ptrace"
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/internal/signal"
 	"github.com/agentsh/agentsh/internal/wraphandoff"
@@ -416,6 +417,36 @@ func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socket
 	// Clear read deadline for the keepalive phase
 	conn.SetDeadline(time.Time{})
 
+	// attach_mode=pid: the child shell is auto-inherited by the tracer via
+	// PTRACE_O_TRACEFORK and is already being traced with SessionlessPIDAttach=true.
+	// PtraceSeize would fail EPERM for an already-traced process. Instead, call
+	// BindSession to promote the existing TraceeState to the named session so
+	// HandleExecve sees a real session and enforces command policy. Issue #416.
+	tr, isBound := a.ptraceTracer.(*ptrace.Tracer)
+	if isBound {
+		if bindErr := tr.BindSession(pid, sessionID); bindErr == nil {
+			// Already-traced PID: session bound. Send ACK and hold the keepalive.
+			conn.Write([]byte{1})
+			slog.Info("ptrace wrap: session bound to already-traced shell", "pid", pid, "session_id", sessionID)
+			go func() {
+				defer conn.Close()
+				buf := make([]byte, 1)
+				select {
+				case <-ctx.Done():
+				default:
+					conn.Read(buf) // blocks until shell exits or connection closes
+				}
+			}()
+			return
+		}
+		// BindSession returned an error (PID not in tracees map), which means either
+		// a.ptraceTracer is not a *ptrace.Tracer or the tracee was never added.
+		// In production neither can happen (wrap.go gates this path behind a non-nil
+		// *ptrace.Tracer and the tracer adds children via PTRACE_EVENT_FORK before
+		// releasing the parent stop). Fall through to ptraceExecAttach, which will
+		// return EPERM for an already-traced child.
+	}
+
 	_, _, attachErr := ptraceExecAttach(a.ptraceTracer, pid, sessionID, "", false)
 	if attachErr != nil {
 		conn.Write([]byte{0}) // NACK
@@ -432,14 +463,10 @@ func (a *App) acceptPtracePID(ctx context.Context, listener net.Listener, socket
 	go func() {
 		defer conn.Close()
 		buf := make([]byte, 1)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-				conn.Read(buf) // blocks until close or error
-				return
-			}
+		select {
+		case <-ctx.Done():
+		default:
+			conn.Read(buf) // blocks until shell exits or connection closes
 		}
 	}()
 }

--- a/internal/api/wrap_linux_test.go
+++ b/internal/api/wrap_linux_test.go
@@ -4,6 +4,7 @@ package api
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"io"
 	"net"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/ptrace"
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/internal/wraphandoff"
 	"golang.org/x/sys/unix"
@@ -668,6 +670,68 @@ func TestAcceptSignalFD_ContinuesAfterWrongUID(t *testing.T) {
 	waitForConnClosed(t, secondConn)
 
 	_ = listener.Close()
+	waitForTestDone(t, done)
+}
+
+// TestAcceptPtracePID_BindsSession verifies the BindSession path introduced for
+// #416: when app.ptraceTracer is a *ptrace.Tracer with a sessionless tracee for
+// the sent PID, acceptPtracePID calls BindSession and responds with ACK (1).
+// This is the server-side half of the fix; the shim-side half is runPtraceHandshake.
+func TestAcceptPtracePID_BindsSession(t *testing.T) {
+	// Use the test process's own PID — it always exists in /proc and BindSession
+	// works purely on the in-memory tracee map (no ptrace seize needed).
+	childPID := os.Getpid()
+
+	tr := ptrace.NewTracerForTest(childPID)
+
+	cfg := &config.Config{}
+	app, mgr := newTestAppForWrap(t, cfg)
+	app.ptraceTracer = tr
+
+	s, err := mgr.Create(t.TempDir(), "default")
+	if err != nil {
+		t.Fatalf("create session: %v", err)
+	}
+
+	socketDir := t.TempDir()
+	socketPath := filepath.Join(socketDir, "ptrace-bind.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listen unix socket: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		app.acceptPtracePID(context.Background(), listener, socketPath, s.ID, os.Getuid())
+	}()
+
+	conn := dialUnixConn(t, socketPath)
+	defer conn.Close()
+
+	pidBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(pidBytes, uint32(childPID))
+	if _, err := conn.Write(pidBytes); err != nil {
+		t.Fatalf("write PID: %v", err)
+	}
+
+	// Must receive ACK byte 1 — BindSession succeeded for the pre-seeded tracee.
+	ack := make([]byte, 1)
+	conn.SetDeadline(time.Now().Add(2 * time.Second))
+	if _, err := conn.Read(ack); err != nil {
+		t.Fatalf("read ACK: %v", err)
+	}
+	if ack[0] != 1 {
+		t.Errorf("expected ACK byte 1, got %d — BindSession path not taken", ack[0])
+	}
+
+	// Verify BindSession populated the session ID on the tracee.
+	if got, _ := tr.ResolveSessionID(int32(childPID)); got != s.ID {
+		t.Errorf("ResolveSessionID = %q, want %q", got, s.ID)
+	}
+
+	conn.Close() // releases the keepalive goroutine
 	waitForTestDone(t, done)
 }
 

--- a/internal/ptrace/bind_session_test.go
+++ b/internal/ptrace/bind_session_test.go
@@ -1,0 +1,93 @@
+//go:build linux
+
+package ptrace
+
+import (
+	"testing"
+)
+
+// TestBindSession_UpdatesSessionlessTracee verifies that BindSession promotes
+// a SessionlessPIDAttach tracee to a real session — the primary fix for #416
+// (opaque enforce bypassed in attach_mode=pid + shim). Without BindSession the
+// only path was AttachPID → PtraceSeize, which fails EPERM for auto-inherited
+// descendants, leaving them sessionless and HandleExecve passes them through.
+func TestBindSession_UpdatesSessionlessTracee(t *testing.T) {
+	tr := &Tracer{tracees: make(map[int]*TraceeState)}
+
+	// Simulate a child auto-inherited via PTRACE_O_TRACEFORK with no session.
+	pid := 1001
+	tr.tracees[pid] = &TraceeState{
+		TID:                  pid,
+		TGID:                 pid,
+		SessionlessPIDAttach: true,
+		SessionID:            "",
+	}
+
+	if err := tr.BindSession(pid, "sess-abc"); err != nil {
+		t.Fatalf("BindSession: %v", err)
+	}
+
+	st := tr.tracees[pid]
+	if st.SessionID != "sess-abc" {
+		t.Errorf("SessionID = %q, want %q", st.SessionID, "sess-abc")
+	}
+	if st.SessionlessPIDAttach {
+		t.Error("SessionlessPIDAttach should be false after BindSession")
+	}
+}
+
+// TestBindSession_UpdatesAllThreadsForTGID verifies that BindSession updates
+// every thread whose TGID matches — not just the main thread.
+func TestBindSession_UpdatesAllThreadsForTGID(t *testing.T) {
+	tr := &Tracer{tracees: make(map[int]*TraceeState)}
+
+	// Main thread and two worker threads sharing TGID 2000.
+	for _, tid := range []int{2000, 2001, 2002} {
+		tr.tracees[tid] = &TraceeState{
+			TID:                  tid,
+			TGID:                 2000,
+			SessionlessPIDAttach: true,
+		}
+	}
+
+	if err := tr.BindSession(2000, "sess-multi"); err != nil {
+		t.Fatalf("BindSession: %v", err)
+	}
+
+	for _, tid := range []int{2000, 2001, 2002} {
+		st := tr.tracees[tid]
+		if st.SessionID != "sess-multi" {
+			t.Errorf("tid %d: SessionID = %q, want %q", tid, st.SessionID, "sess-multi")
+		}
+		if st.SessionlessPIDAttach {
+			t.Errorf("tid %d: SessionlessPIDAttach should be false", tid)
+		}
+	}
+}
+
+// TestBindSession_ErrorOnUnknownPID verifies BindSession returns an error
+// when the PID is not in the tracees map (not yet traced or already exited).
+func TestBindSession_ErrorOnUnknownPID(t *testing.T) {
+	tr := &Tracer{tracees: make(map[int]*TraceeState)}
+
+	if err := tr.BindSession(9999, "sess-x"); err == nil {
+		t.Error("expected error for unknown PID, got nil")
+	}
+}
+
+// TestBindSession_UnrelatedThreadsUntouched verifies that BindSession for TGID A
+// does not modify tracees belonging to an unrelated TGID B.
+func TestBindSession_UnrelatedThreadsUntouched(t *testing.T) {
+	tr := &Tracer{tracees: make(map[int]*TraceeState)}
+
+	tr.tracees[3000] = &TraceeState{TID: 3000, TGID: 3000, SessionlessPIDAttach: true}
+	tr.tracees[4000] = &TraceeState{TID: 4000, TGID: 4000, SessionlessPIDAttach: true}
+
+	if err := tr.BindSession(3000, "sess-3k"); err != nil {
+		t.Fatalf("BindSession: %v", err)
+	}
+
+	if tr.tracees[4000].SessionID != "" || !tr.tracees[4000].SessionlessPIDAttach {
+		t.Error("unrelated TGID 4000 was modified by BindSession for TGID 3000")
+	}
+}

--- a/internal/ptrace/testing_helpers_linux.go
+++ b/internal/ptrace/testing_helpers_linux.go
@@ -1,0 +1,22 @@
+//go:build linux
+
+package ptrace
+
+// NewTracerForTest creates a Tracer pre-seeded with a sessionless TraceeState
+// for pid. Used by integration tests in other packages (e.g. internal/api) to
+// exercise code paths that expect an already-traced, sessionless process — the
+// attach_mode=pid shape that #416 fixes. Production code must not call this.
+func NewTracerForTest(pid int) *Tracer {
+	tr := &Tracer{
+		tracees:       make(map[int]*TraceeState),
+		parkedTracees: make(map[int]struct{}),
+		tgidScratch:   make(map[int]*scratchPage),
+		attachQueue:   make(chan attachRequest, 64),
+		resumeQueue:   make(chan resumeRequest, 64),
+		stopped:       make(chan struct{}),
+		processTree:   NewProcessTree(),
+		metrics:       nopMetrics{},
+	}
+	tr.tracees[pid] = &TraceeState{TID: pid, TGID: pid, SessionlessPIDAttach: true}
+	return tr
+}

--- a/internal/ptrace/tracer.go
+++ b/internal/ptrace/tracer.go
@@ -526,6 +526,33 @@ func (t *Tracer) ResumePID(pid int) error {
 	return nil
 }
 
+// BindSession promotes an already-traced, sessionless process to a named
+// session. It finds all TraceeState entries whose TID or TGID matches pid,
+// sets SessionID to sessionID, and clears SessionlessPIDAttach. This is the
+// correct path for attach_mode=pid + shim: when the shim forks a child shell
+// that is auto-inherited by the tracer via PTRACE_O_TRACEFORK, the child
+// carries SessionlessPIDAttach=true (no session yet). BindSession wires the
+// session the shim's wrap-init handshake established, so subsequent HandleExecve
+// calls for that shell and its descendants reach the policy engine rather than
+// passing through as "sessionless_pid_attach". Issue #416.
+func (t *Tracer) BindSession(pid int, sessionID string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	found := false
+	for _, state := range t.tracees {
+		if state.TID == pid || state.TGID == pid {
+			state.SessionID = sessionID
+			state.SessionlessPIDAttach = false
+			found = true
+		}
+	}
+	if !found {
+		return fmt.Errorf("BindSession: pid %d not found in active tracees", pid)
+	}
+	return nil
+}
+
 // signalAttachDone signals the WaitAttached channel for a PID, if one exists.
 func (t *Tracer) signalAttachDone(pid int, err error) {
 	if v, ok := t.attachDone.Load(pid); ok {

--- a/internal/shim/kernelinstall/install_linux.go
+++ b/internal/shim/kernelinstall/install_linux.go
@@ -4,6 +4,7 @@ package kernelinstall
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -131,7 +132,16 @@ func Install(p InstallParams) (Result, error) {
 		return Result{Action: ResultSkip, Reason: reason}, nil
 	}
 
-	// Step 4: check response completeness
+	// Step 4: ptrace mode — server has a live tracer and wants a PID handshake
+	// instead of a seccomp wrapper. Issue #416: without this branch the
+	// WrapperBinary=="" check below returns ResultSkip, leaving the child shell
+	// unassociated with a session and HandleExecve passes all its execs through
+	// as "sessionless_pid_attach" without policy checks.
+	if resp.PtraceMode {
+		return runPtraceHandshake(p, resp)
+	}
+
+	// Step 4b: check response completeness for seccomp wrapper path
 	if resp.WrapperBinary == "" || resp.NotifySocket == "" {
 		reason := "wrap-init returned empty WrapperBinary or NotifySocket"
 		if p.Mode == ModeOn {
@@ -317,6 +327,202 @@ func waitWrapper(cmd *exec.Cmd) int {
 		return ee.ExitCode()
 	}
 	return 1
+}
+
+// runPtraceHandshake handles attach_mode=pid ptrace mode responses from
+// wrap-init. It replaces the seccomp-wrapper relay for deployments where the
+// server runs a ptrace tracer rather than a seccomp user-notify listener.
+//
+// The server's wrap-init returns PtraceMode=true + NotifySocket (no
+// WrapperBinary). The tracer is already watching all descendants of the
+// workload supervisor via PTRACE_O_TRACEFORK, but newly-forked shells have
+// SessionlessPIDAttach=true and no policy enforcement. This function:
+//
+//  1. Forks a child that execs the real shell (p.RealShell + p.ShellArgs)
+//  2. Tells the server the child's PID via the notify socket
+//  3. Waits for ACK — which means the server has called BindSession on the
+//     child's TraceeState, promoting it to the named session
+//  4. After ACK the child is released (via a sync pipe) to exec the real shell
+//
+// Children of the shell then inherit the session ID from the bound state, so
+// HandleExecve evaluates command deny rules for every inner exec (sudo, etc).
+func runPtraceHandshake(p InstallParams, resp types.WrapInitResponse) (Result, error) {
+	notifySocket := resp.NotifySocket
+
+	// Sync pipe: child reads one byte from readEnd before exec'ing the shell.
+	// Parent writes after server ACK so the shell execs only once session is bound.
+	readFD, writeFD, err := createPipe()
+	if err != nil {
+		reason := fmt.Sprintf("ptrace handshake: create sync pipe: %v", err)
+		if p.Mode == ModeOn {
+			return Result{Action: ResultFailClosed, Reason: reason}, nil
+		}
+		return Result{Action: ResultSkip, Reason: reason}, nil
+	}
+
+	// Build the child's environment: same filtering as the seccomp relay path.
+	env := wrapenv.Filter(filterShimInternalEnv(p.Env), resp.EnvPolicy)
+	env = envinject.Apply(env, resp.EnvInject)
+
+	cmd := exec.Command(p.RealShell, p.ShellArgs...)
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	// Pass the read end of the sync pipe as an extra fd so the child can
+	// wait for the session-bind ACK before it begins executing.
+	readFile := os.NewFile(uintptr(readFD), "ptrace-sync-read")
+	cmd.ExtraFiles = []*os.File{readFile}
+
+	// Run the real shell via a POSIX wrapper that blocks on the sync pipe then
+	// execs with the correct argv[0]. exec -a is a bash/busybox-ash extension
+	// not supported by dash; only use it when Argv0 overrides the binary path
+	// (Alpine/busybox: RealShell=/bin/sh.real, Argv0=/bin/sh). Without the
+	// override the simpler exec "$@" works on all shells including dash.
+	// The fd is closed before exec so it doesn't leak into the user shell.
+	syncFDNum := 3 // ExtraFiles[0] → fd 3 in child
+	cmd.Path = p.RealShell
+
+	var wrapScript string
+	var shellArgs []string
+	if p.Argv0 != "" {
+		// Alpine/busybox: exec real shell with a different argv[0].
+		// exec -a is supported by busybox ash and bash but not dash; it's safe
+		// here because when Argv0 is set the shim has already confirmed the
+		// shell is busybox or bash (not dash).
+		wrapScript = fmt.Sprintf(
+			`read -r _ <&%d; exec %d<&-; _a="$1"; shift; exec -a "$_a" "$@"`,
+			syncFDNum, syncFDNum,
+		)
+		// $0="--", $1=Argv0 (for exec -a), $2=RealShell, $3+=ShellArgs
+		shellArgs = make([]string, 0, 3+len(p.ShellArgs))
+		shellArgs = append(shellArgs, p.RealShell, "-c", wrapScript, "--")
+		shellArgs = append(shellArgs, p.Argv0)         // $1: argv0 for exec -a
+		shellArgs = append(shellArgs, p.RealShell)     // $2: binary (after shift, $1)
+		shellArgs = append(shellArgs, p.ShellArgs...)  // $3+: shell args
+	} else {
+		// Common case: exec the real shell directly; argv[0] = binary path.
+		// exec "$@" is POSIX and works on dash, bash, and busybox ash.
+		wrapScript = fmt.Sprintf(
+			`read -r _ <&%d; exec %d<&-; exec "$@"`,
+			syncFDNum, syncFDNum,
+		)
+		// $0="--", $1=RealShell, $2+=ShellArgs
+		shellArgs = make([]string, 0, 2+len(p.ShellArgs))
+		shellArgs = append(shellArgs, p.RealShell, "-c", wrapScript, "--")
+		shellArgs = append(shellArgs, p.RealShell)     // $1: binary (exec "$@" → first arg)
+		shellArgs = append(shellArgs, p.ShellArgs...)  // $2+: shell args
+	}
+	cmd.Args = shellArgs
+
+	if err := cmd.Start(); err != nil {
+		_ = unix.Close(readFD)
+		_ = unix.Close(writeFD)
+		readFile.Close()
+		reason := fmt.Sprintf("ptrace handshake: start child: %v", err)
+		if p.Mode == ModeOn {
+			return Result{Action: ResultFailClosed, Reason: reason}, nil
+		}
+		return Result{Action: ResultSkip, Reason: reason}, nil
+	}
+	readFile.Close()
+	_ = unix.Close(readFD)
+
+	childPID := cmd.Process.Pid
+
+	// Connect to the server's notify socket and send the child PID.
+	conn, dialErr := net.DialTimeout("unix", notifySocket, 10*time.Second)
+	if dialErr != nil {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = unix.Close(writeFD)
+		reason := fmt.Sprintf("ptrace handshake: dial notify socket: %v", dialErr)
+		if p.Mode == ModeOn {
+			return Result{Action: ResultFailClosed, Reason: reason}, nil
+		}
+		return Result{Action: ResultSkip, Reason: reason}, nil
+	}
+
+	pidBytes := make([]byte, 4)
+	binary.LittleEndian.PutUint32(pidBytes, uint32(childPID))
+	conn.SetDeadline(time.Now().Add(10 * time.Second))
+	if _, err := conn.Write(pidBytes); err != nil {
+		conn.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = unix.Close(writeFD)
+		reason := fmt.Sprintf("ptrace handshake: send PID: %v", err)
+		if p.Mode == ModeOn {
+			return Result{Action: ResultFailClosed, Reason: reason}, nil
+		}
+		return Result{Action: ResultSkip, Reason: reason}, nil
+	}
+
+	// Wait for ACK/NACK from server (BindSession result).
+	ack := make([]byte, 1)
+	if _, err := conn.Read(ack); err != nil {
+		conn.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = unix.Close(writeFD)
+		reason := fmt.Sprintf("ptrace handshake: read ACK: %v", err)
+		if p.Mode == ModeOn {
+			return Result{Action: ResultFailClosed, Reason: reason}, nil
+		}
+		return Result{Action: ResultSkip, Reason: reason}, nil
+	}
+	conn.Close()
+
+	if ack[0] != 1 {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = unix.Close(writeFD)
+		reason := "ptrace handshake: server rejected attach (NACK)"
+		slog.Warn("kernelinstall: ptrace session bind rejected", "pid", childPID)
+		if p.Mode == ModeOn {
+			return Result{Action: ResultFailClosed, Reason: reason}, nil
+		}
+		return Result{Action: ResultSkip, Reason: reason}, nil
+	}
+
+	// ACK: session is bound. Signal child to proceed by writing a byte.
+	if _, writeErr := unix.Write(writeFD, []byte{1}); writeErr != nil && !errors.Is(writeErr, unix.EPIPE) {
+		// EPIPE means child already exited (closed read end); any other error
+		// means the child is stuck on the pipe read and will hang — kill it.
+		slog.Warn("kernelinstall: write to sync pipe failed, killing child", "error", writeErr)
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = unix.Close(writeFD)
+		reason := fmt.Sprintf("ptrace handshake: write sync pipe: %v", writeErr)
+		if p.Mode == ModeOn {
+			return Result{Action: ResultFailClosed, Reason: reason}, nil
+		}
+		return Result{Action: ResultSkip, Reason: reason}, nil
+	}
+	_ = unix.Close(writeFD)
+
+	slog.Debug("kernelinstall: ptrace session bound, child released", "pid", childPID)
+
+	exitCode := waitWrapper(cmd)
+	return Result{
+		Action:          ResultExec,
+		WrapperExitCode: exitCode,
+	}, nil
+}
+
+// createPipe creates a pipe and returns (readFD, writeFD, error).
+func createPipe() (int, int, error) {
+	var fds [2]int
+	if err := unix.Pipe2(fds[:], unix.O_CLOEXEC); err != nil {
+		return -1, -1, err
+	}
+	// Clear CLOEXEC on read end so it survives exec into child (needed for sync).
+	if _, _, errno := unix.Syscall(unix.SYS_FCNTL, uintptr(fds[0]), unix.F_SETFD, 0); errno != 0 {
+		unix.Close(fds[0])
+		unix.Close(fds[1])
+		return -1, -1, errno
+	}
+	return fds[0], fds[1], nil
 }
 
 // recvNotifyFD receives a file descriptor from a Unix socket using SCM_RIGHTS.

--- a/internal/shim/kernelinstall/install_linux_test.go
+++ b/internal/shim/kernelinstall/install_linux_test.go
@@ -1148,6 +1148,222 @@ func TestAssembleWrapperEnv_EnvInjectCannotShadowWrapperLogFD(t *testing.T) {
 	}
 }
 
+// ─── Tests for PtraceMode response handling (#416) ──────────────────────────
+
+// TestInstall_PtraceModeACK verifies that when wrap-init returns a ptrace-mode
+// response (PtraceMode=true, WrapperBinary=""), Install performs the PID socket
+// handshake and runs the child shell, returning ResultExec with its exit code.
+// This is the primary regression guard for #416: before the fix, Install hit
+// the `WrapperBinary==""` check and returned ResultSkip, leaving the child
+// without session association and command deny rules unenforced.
+func TestInstall_PtraceModeACK(t *testing.T) {
+	orig := seccompFilterCount
+	seccompFilterCount = func() int { return 0 }
+	t.Cleanup(func() { seccompFilterCount = orig })
+
+	sockDir := t.TempDir()
+	notifySockPath := filepath.Join(sockDir, "ptrace-notify.sock")
+
+	ln, err := net.Listen("unix", notifySockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	pidCh := make(chan uint32, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 4)
+		if _, err := conn.Read(buf); err != nil {
+			return
+		}
+		pidCh <- uint32(buf[0]) | uint32(buf[1])<<8 | uint32(buf[2])<<16 | uint32(buf[3])<<24
+		conn.Write([]byte{1}) // ACK
+	}()
+
+	handler, _ := makeWrapInitHandler(200, types.WrapInitResponse{
+		PtraceMode:   true,
+		NotifySocket: notifySockPath,
+		// WrapperBinary deliberately empty — this is the ptrace-mode shape
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	p := baseParams(srv)
+	p.Mode = ModeAuto
+	p.RealShell = "/bin/sh"
+	p.ShellArgs = []string{"-c", "exit 0"}
+
+	res, err := Install(p)
+	if err != nil {
+		t.Fatalf("Install error: %v", err)
+	}
+	if res.Action != ResultExec {
+		t.Fatalf("action = %v (reason=%q), want ResultExec", res.Action, res.Reason)
+	}
+	if res.WrapperExitCode != 0 {
+		t.Errorf("WrapperExitCode = %d, want 0", res.WrapperExitCode)
+	}
+
+	select {
+	case pid := <-pidCh:
+		if pid == 0 {
+			t.Error("received PID 0 — server should have gotten a real child PID")
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("server never received PID from Install handshake")
+	}
+}
+
+// TestInstall_PtraceModeACK_ExitCode verifies that a non-zero child exit code
+// is faithfully propagated through WrapperExitCode.
+func TestInstall_PtraceModeACK_ExitCode(t *testing.T) {
+	orig := seccompFilterCount
+	seccompFilterCount = func() int { return 0 }
+	t.Cleanup(func() { seccompFilterCount = orig })
+
+	sockDir := t.TempDir()
+	notifySockPath := filepath.Join(sockDir, "ptrace-notify2.sock")
+	ln, err := net.Listen("unix", notifySockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 4)
+		conn.Read(buf)
+		conn.Write([]byte{1}) // ACK
+	}()
+
+	handler, _ := makeWrapInitHandler(200, types.WrapInitResponse{
+		PtraceMode:   true,
+		NotifySocket: notifySockPath,
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	p := baseParams(srv)
+	p.Mode = ModeAuto
+	p.RealShell = "/bin/sh"
+	p.ShellArgs = []string{"-c", "exit 42"}
+
+	res, err := Install(p)
+	if err != nil {
+		t.Fatalf("Install error: %v", err)
+	}
+	if res.Action != ResultExec {
+		t.Fatalf("action = %v, want ResultExec", res.Action)
+	}
+	if res.WrapperExitCode != 42 {
+		t.Errorf("WrapperExitCode = %d, want 42", res.WrapperExitCode)
+	}
+}
+
+// TestInstall_PtraceModeNACK_ModeAuto verifies that when the server sends NACK
+// (attach rejected), Install returns ResultSkip in ModeAuto so the command
+// falls through to its existing enforcement path rather than fail-closing.
+func TestInstall_PtraceModeNACK_ModeAuto(t *testing.T) {
+	orig := seccompFilterCount
+	seccompFilterCount = func() int { return 0 }
+	t.Cleanup(func() { seccompFilterCount = orig })
+
+	sockDir := t.TempDir()
+	notifySockPath := filepath.Join(sockDir, "ptrace-nack.sock")
+	ln, err := net.Listen("unix", notifySockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 4)
+		conn.Read(buf)
+		conn.Write([]byte{0}) // NACK
+	}()
+
+	handler, _ := makeWrapInitHandler(200, types.WrapInitResponse{
+		PtraceMode:   true,
+		NotifySocket: notifySockPath,
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	p := baseParams(srv)
+	p.Mode = ModeAuto
+	p.RealShell = "/bin/sh"
+	p.ShellArgs = []string{"-c", "exit 0"}
+
+	res, err := Install(p)
+	if err != nil {
+		t.Fatalf("Install error: %v", err)
+	}
+	if res.Action != ResultSkip {
+		t.Errorf("action = %v (reason=%q), want ResultSkip on NACK in ModeAuto", res.Action, res.Reason)
+	}
+}
+
+// TestInstall_PtraceModeNACK_ModeOn verifies fail-closed semantics on NACK
+// when shim_install=on.
+func TestInstall_PtraceModeNACK_ModeOn(t *testing.T) {
+	orig := seccompFilterCount
+	seccompFilterCount = func() int { return 0 }
+	t.Cleanup(func() { seccompFilterCount = orig })
+
+	sockDir := t.TempDir()
+	notifySockPath := filepath.Join(sockDir, "ptrace-nack-on.sock")
+	ln, err := net.Listen("unix", notifySockPath)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 4)
+		conn.Read(buf)
+		conn.Write([]byte{0}) // NACK
+	}()
+
+	handler, _ := makeWrapInitHandler(200, types.WrapInitResponse{
+		PtraceMode:   true,
+		NotifySocket: notifySockPath,
+	})
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	p := baseParams(srv)
+	p.Mode = ModeOn
+	p.RealShell = "/bin/sh"
+	p.ShellArgs = []string{"-c", "exit 0"}
+
+	res, err := Install(p)
+	if err != nil {
+		t.Fatalf("Install error: %v", err)
+	}
+	if res.Action != ResultFailClosed {
+		t.Errorf("action = %v (reason=%q), want ResultFailClosed on NACK in ModeOn", res.Action, res.Reason)
+	}
+}
+
 // findModuleRoot walks up from the current working directory to find go.mod.
 func findModuleRoot(t *testing.T) string {
 	t.Helper()


### PR DESCRIPTION
## Summary

Fixes #416: `opaque=enforce` command-name deny rules were silently unenforced when `attach_mode: pid` and `shim_install: auto` were both active.

**Root cause:** In `attach_mode=pid`, child shells are auto-inherited by the ptrace tracer via `PTRACE_O_TRACEFORK` with `SessionlessPIDAttach=true`. `acceptPtracePID` was calling `PtraceSeize` (via `ptraceExecAttach`) on an already-traced process, which returns EPERM. This caused the session binding to fail silently, leaving the tracee with `SessionlessPIDAttach=true` — a flag that `HandleExecve` checks to skip policy enforcement entirely.

**Fix:**

- **`internal/ptrace/tracer.go`**: Add `BindSession(pid, sessionID)` — promotes an existing sessionless `TraceeState` to a named session by setting `SessionID` and clearing `SessionlessPIDAttach`, without attempting a second `PtraceSeize`. Mutex-protected.
- **`internal/api/wrap_linux.go`** (`acceptPtracePID`): Call `BindSession` first. If it succeeds (PID already in tracees map), send ACK and hold keepalive. Only fall through to `ptraceExecAttach` if the tracee isn't in the map.
- **`internal/shim/kernelinstall/install_linux.go`** (`runPtraceHandshake`): Fix wrapScript for busybox/Alpine. Replace `exec "$@"` with `exec -a "$_a" "$@"` so the shell's argv[0] can differ from its binary path. This is needed when `/bin/sh` is a symlink to busybox but the unwrapped binary is `/bin/sh.real`. Args are ordered as `sh -c wrapScript -- <argv0> <realShell> <shellArgs...>` — `$0="--"` (POSIX `sh -c` semantics), `$1=argv0` for `exec -a`, `$2+=realShell+shellArgs` passed via `$@` after shift.

**New files:**
- `internal/ptrace/bind_session_test.go`: Unit tests for `BindSession` (bind, unknown-PID rejection, SessionlessPIDAttach cleared, ResolveSessionID round-trip)
- `internal/ptrace/testing_helpers_linux.go`: `NewTracerForTest(pid)` — creates a pre-seeded Tracer for integration tests in other packages

## Test plan

- [x] `go test ./internal/ptrace/... ./internal/api/... ./internal/shim/kernelinstall/...` — all pass
- [x] `go test ./...` — all pass (only `TestFUSE_FsyncFlushLseekPassthrough` fails, which is a pre-existing environment failure on `main`)
- [x] `GOOS=windows go build ./...` — cross-compile clean