### PR TITLE
feat(tor): Tor access control (Phase 1, deny-by-default)

### DIFF
--- a/docs/superpowers/plans/2026-06-14-tor-access-control.md
+++ b/docs/superpowers/plans/2026-06-14-tor-access-control.md
@@ -1,0 +1,1876 @@
+# Tor Access Control (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a deny-by-default `tor:` policy block that blocks (or audits) a sandboxed agent's use of Tor across five vectors — client processes, local SOCKS/control ports, `.onion` DNS, `.onion` HTTP, and Tor relay IPs — emitting a uniform `tor_control` audit event per hit.
+
+**Architecture:** A coordinating `tor.Policy` object (new `internal/tor` package) resolves the `tor:` config once and answers three questions for the existing decision points: `EvalExecve`, `EvalConnect`, `EvalOnionName`. The policy engine consults it (via a `policy.TorChecker` interface, mirroring the existing `ThreatChecker`) at the top of `CheckExecve`, `CheckNetworkCtx`, and `CheckNetworkIP`: a `deny` verdict short-circuits and overrides user `allow` rules; an `audit` verdict attaches metadata and falls through to normal policy (never loosening a user `deny`). Relay-IP membership uses a new reusable `internal/ipset` primitive seeded with the hardcoded Tor directory authorities and optionally refreshed from onionoo. Each enforcement site emits a `tor_control` event when the returned decision carries Tor metadata.
+
+**Tech Stack:** Go; `github.com/gobwas/glob` (already used for matchers); existing `seccomp`/`ptrace`/`netmonitor`/`policy`/`threatfeed` patterns. No new third-party dependencies.
+
+---
+
+## File Structure
+
+**New:**
+- `internal/ipset/ipset.go` — IPv4/IPv6 + CIDR membership set (reusable primitive).
+- `internal/ipset/ipset_test.go`
+- `internal/config/tor.go` — `TorConfig` struct + `ResolveTorConfig` defaults resolution.
+- `internal/config/tor_test.go`
+- `internal/tor/seed.go` — hardcoded Tor directory-authority / fallback-dir IPs.
+- `internal/tor/policy.go` — `Policy`, `Verdict`, `Mode`, the three `Eval*` methods, `IsRelay`.
+- `internal/tor/feed.go` — onionoo relay-feed loader + `Syncer` + disk cache.
+- `internal/tor/event.go` — `BuildControlEvent` (the `tor_control` event constructor).
+- `internal/tor/adapter.go` — `PolicyAdapter` implementing `policy.TorChecker`.
+- `internal/tor/policy_test.go`, `internal/tor/seed_test.go`, `internal/tor/feed_test.go`
+
+**Modified:**
+- `internal/config/config.go` — add `Tor TorConfig` to the top-level `Config` struct (line 37 area).
+- `internal/events/types.go` — add `EventTorControl`, its `EventCategory` entry, and `AllEventTypes` entry.
+- `internal/ocsf/registry.go` — add `"tor_control"` to `pendingTypes`.
+- `internal/policy/engine.go` — add `TorVerdict`, `TorChecker`, `torChecker` field, `SetTorPolicy`, `Decision.Tor`, and the three pre-checks.
+- `internal/netmonitor/dns.go` — emit `tor_control` when `dec.Tor != nil` (vector `onion_dns`).
+- `internal/netmonitor/proxy.go` — emit `tor_control` when `dec.Tor != nil` (vector `onion_http`).
+- `internal/api/ptrace_handlers.go` — emit `tor_control` in `HandleNetwork` (vectors `socks_port`/`relay_ip`) and `HandleExecve` (vector `process`).
+- `internal/server/server.go` — build `tor.Policy` from `cfg.Tor`, call `engine.SetTorPolicy`, start the feed syncer.
+
+---
+
+## Task 1: `internal/ipset` — IP/CIDR membership primitive
+
+**Files:**
+- Create: `internal/ipset/ipset.go`
+- Test: `internal/ipset/ipset_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package ipset
+
+import (
+	"net"
+	"testing"
+)
+
+func TestSet_ContainsIPv4Exact(t *testing.T) {
+	s := New()
+	if err := s.Add("1.2.3.4"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !s.Contains(net.ParseIP("1.2.3.4")) {
+		t.Fatal("expected 1.2.3.4 to be a member")
+	}
+	if s.Contains(net.ParseIP("1.2.3.5")) {
+		t.Fatal("did not expect 1.2.3.5 to be a member")
+	}
+}
+
+func TestSet_ContainsCIDR(t *testing.T) {
+	s := New()
+	if err := s.Add("10.0.0.0/8"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !s.Contains(net.ParseIP("10.255.1.1")) {
+		t.Fatal("expected 10.255.1.1 inside 10.0.0.0/8")
+	}
+	if s.Contains(net.ParseIP("11.0.0.1")) {
+		t.Fatal("did not expect 11.0.0.1 inside 10.0.0.0/8")
+	}
+}
+
+func TestSet_IPv6(t *testing.T) {
+	s := New()
+	if err := s.Add("2001:db8::/32"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !s.Contains(net.ParseIP("2001:db8::1")) {
+		t.Fatal("expected 2001:db8::1 inside 2001:db8::/32")
+	}
+}
+
+func TestSet_NilAndEmpty(t *testing.T) {
+	s := New()
+	if s.Contains(nil) {
+		t.Fatal("nil IP must never be a member")
+	}
+	if s.Contains(net.ParseIP("1.2.3.4")) {
+		t.Fatal("empty set must contain nothing")
+	}
+	if s.Len() != 0 {
+		t.Fatalf("Len=%d, want 0", s.Len())
+	}
+}
+
+func TestSet_AddInvalid(t *testing.T) {
+	s := New()
+	if err := s.Add("not-an-ip"); err == nil {
+		t.Fatal("expected error for invalid entry")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/ipset/`
+Expected: FAIL — package/`New` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// Package ipset provides membership testing for sets of individual IP
+// addresses and CIDR ranges. A bare IP is stored as a /32 (IPv4) or
+// /128 (IPv6) prefix. Safe for concurrent reads after construction;
+// callers that mutate after publishing must provide their own locking
+// or swap whole sets.
+package ipset
+
+import (
+	"fmt"
+	"net"
+)
+
+// Set holds IP/CIDR prefixes for O(n) membership testing. n is the
+// number of distinct prefixes added (relay feeds: ~8k); linear scan is
+// adequate and avoids a trie dependency. Swap whole sets to update.
+type Set struct {
+	nets []*net.IPNet
+}
+
+// New returns an empty Set.
+func New() *Set { return &Set{} }
+
+// Add inserts an IP ("1.2.3.4", "2001:db8::1") or CIDR ("10.0.0.0/8").
+func (s *Set) Add(entry string) error {
+	if _, ipnet, err := net.ParseCIDR(entry); err == nil {
+		s.nets = append(s.nets, ipnet)
+		return nil
+	}
+	ip := net.ParseIP(entry)
+	if ip == nil {
+		return fmt.Errorf("ipset: invalid entry %q", entry)
+	}
+	bits := 32
+	if ip.To4() == nil {
+		bits = 128
+	}
+	mask := net.CIDRMask(bits, bits)
+	s.nets = append(s.nets, &net.IPNet{IP: ip, Mask: mask})
+	return nil
+}
+
+// Contains reports whether ip falls in any added prefix. nil → false.
+func (s *Set) Contains(ip net.IP) bool {
+	if s == nil || ip == nil {
+		return false
+	}
+	for _, n := range s.nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// Len returns the number of prefixes in the set.
+func (s *Set) Len() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.nets)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/ipset/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/ipset/
+git commit -m "feat(tor): add internal/ipset IP/CIDR membership primitive"
+```
+
+---
+
+## Task 2: `internal/config` — `TorConfig` + `ResolveTorConfig`
+
+**Files:**
+- Create: `internal/config/tor.go`
+- Test: `internal/config/tor_test.go`
+- Modify: `internal/config/config.go:37` (add field to `Config`)
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package config
+
+import "testing"
+
+func TestResolveTorConfig_AbsentBlockDeniesByDefault(t *testing.T) {
+	// Zero value = block omitted from YAML.
+	got := ResolveTorConfig(TorConfig{})
+	if !got.Enabled {
+		t.Fatal("absent tor block must resolve to enabled (deny-by-default)")
+	}
+	if got.Mode != "deny" {
+		t.Fatalf("Mode=%q, want deny", got.Mode)
+	}
+	for name, on := range map[string]bool{
+		"processes": got.Vectors.Processes, "socks_ports": got.Vectors.SocksPorts,
+		"onion_dns": got.Vectors.OnionDNS, "onion_http": got.Vectors.OnionHTTP,
+		"relay_ips": got.Vectors.RelayIPs,
+	} {
+		if !on {
+			t.Fatalf("vector %s must default on", name)
+		}
+	}
+	if len(got.ClientBinaries) == 0 || len(got.SocksPorts) == 0 {
+		t.Fatal("client_binaries and socks_ports must have defaults")
+	}
+}
+
+func TestResolveTorConfig_ExplicitDisable(t *testing.T) {
+	f := false
+	got := ResolveTorConfig(TorConfig{Enabled: &f})
+	if got.Enabled {
+		t.Fatal("enabled:false must disable Tor controls")
+	}
+}
+
+func TestResolveTorConfig_ExplicitAllowAndOverrides(t *testing.T) {
+	tr := true
+	got := ResolveTorConfig(TorConfig{
+		Enabled:      &tr,
+		Mode:         "allow",
+		SocksPorts:   []int{9999},
+		ClientBinaries: []string{"only-this"},
+	})
+	if got.Mode != "allow" {
+		t.Fatalf("Mode=%q, want allow", got.Mode)
+	}
+	if len(got.SocksPorts) != 1 || got.SocksPorts[0] != 9999 {
+		t.Fatalf("SocksPorts override not honored: %v", got.SocksPorts)
+	}
+	if len(got.ClientBinaries) != 1 || got.ClientBinaries[0] != "only-this" {
+		t.Fatalf("ClientBinaries override not honored: %v", got.ClientBinaries)
+	}
+}
+
+func TestResolveTorConfig_InvalidModeFallsBackToDeny(t *testing.T) {
+	got := ResolveTorConfig(TorConfig{Mode: "banana"})
+	if got.Mode != "deny" {
+		t.Fatalf("invalid mode must fall back to deny, got %q", got.Mode)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/config/ -run TestResolveTorConfig`
+Expected: FAIL — `TorConfig`/`ResolveTorConfig` undefined.
+
+- [ ] **Step 3: Write the config struct + resolver**
+
+Create `internal/config/tor.go`:
+
+```go
+package config
+
+import "time"
+
+// TorConfig is the raw, as-parsed `tor:` block. A missing block
+// deserializes to the zero value; ResolveTorConfig turns that into the
+// deny-by-default posture. Enabled is a *bool tri-state (nil → true),
+// matching the convention used by SandboxFUSEConfig and WaitKillable.
+type TorConfig struct {
+	Enabled        *bool          `yaml:"enabled"`
+	Mode           string         `yaml:"mode"` // deny | audit | allow
+	Vectors        TorVectors     `yaml:"vectors"`
+	ClientBinaries []string       `yaml:"client_binaries"`
+	SocksPorts     []int          `yaml:"socks_ports"`
+	ControlPorts   []int          `yaml:"control_ports"`
+	SocksLoopbackOnly *bool       `yaml:"socks_loopback_only"`
+	RelayFeed      TorRelayFeed   `yaml:"relay_feed"`
+}
+
+// TorVectors toggles each enforcement door. Pointers so an operator can
+// relax one door (set false) without the zero value disabling all.
+type TorVectors struct {
+	Processes  *bool `yaml:"processes"`
+	SocksPorts *bool `yaml:"socks_ports"`
+	OnionDNS   *bool `yaml:"onion_dns"`
+	OnionHTTP  *bool `yaml:"onion_http"`
+	RelayIPs   *bool `yaml:"relay_ips"`
+}
+
+// TorRelayFeed configures the optional onionoo relay-IP feed.
+type TorRelayFeed struct {
+	Enabled      bool          `yaml:"enabled"`
+	Sources      []string      `yaml:"sources"`
+	LocalLists   []string      `yaml:"local_lists"`
+	SyncInterval time.Duration `yaml:"sync_interval"`
+	CacheDir     string        `yaml:"cache_dir"`
+}
+
+// ResolvedTorConfig is the fully-defaulted, value-typed form consumed by
+// internal/tor. All bools are concrete; all lists are non-empty unless
+// the feature is disabled.
+type ResolvedTorConfig struct {
+	Enabled        bool
+	Mode           string
+	Vectors        ResolvedTorVectors
+	ClientBinaries []string
+	SocksPorts     []int
+	ControlPorts   []int
+	SocksLoopbackOnly bool
+	RelayFeed      TorRelayFeed
+}
+
+type ResolvedTorVectors struct {
+	Processes, SocksPorts, OnionDNS, OnionHTTP, RelayIPs bool
+}
+
+// DefaultTorClientBinaries is the recommended client-binary deny list.
+var DefaultTorClientBinaries = []string{
+	"tor", "obfs4proxy", "snowflake-client", "lyrebird", "meek-client", "torsocks",
+}
+
+// ResolveTorConfig applies deny-by-default semantics. Absent block (zero
+// value) → enabled, mode=deny, all vectors on, default binaries/ports.
+func ResolveTorConfig(in TorConfig) ResolvedTorConfig {
+	boolOr := func(p *bool, def bool) bool {
+		if p == nil {
+			return def
+		}
+		return *p
+	}
+	mode := in.Mode
+	switch mode {
+	case "deny", "audit", "allow":
+	default:
+		mode = "deny"
+	}
+	out := ResolvedTorConfig{
+		Enabled: boolOr(in.Enabled, true),
+		Mode:    mode,
+		Vectors: ResolvedTorVectors{
+			Processes:  boolOr(in.Vectors.Processes, true),
+			SocksPorts: boolOr(in.Vectors.SocksPorts, true),
+			OnionDNS:   boolOr(in.Vectors.OnionDNS, true),
+			OnionHTTP:  boolOr(in.Vectors.OnionHTTP, true),
+			RelayIPs:   boolOr(in.Vectors.RelayIPs, true),
+		},
+		ClientBinaries:    in.ClientBinaries,
+		SocksPorts:        in.SocksPorts,
+		ControlPorts:      in.ControlPorts,
+		SocksLoopbackOnly: boolOr(in.SocksLoopbackOnly, true),
+		RelayFeed:         in.RelayFeed,
+	}
+	if len(out.ClientBinaries) == 0 {
+		out.ClientBinaries = append([]string(nil), DefaultTorClientBinaries...)
+	}
+	if len(out.SocksPorts) == 0 {
+		out.SocksPorts = []int{9050, 9150}
+	}
+	if len(out.ControlPorts) == 0 {
+		out.ControlPorts = []int{9051}
+	}
+	return out
+}
+```
+
+- [ ] **Step 4: Add the field to the top-level `Config` struct**
+
+In `internal/config/config.go`, add the `Tor` field after line 37 (`ThreatFeeds`):
+
+```go
+	ThreatFeeds       ThreatFeedsConfig       `yaml:"threat_feeds"`
+	Tor               TorConfig               `yaml:"tor"`
+	PackageChecks     PackageChecksConfig     `yaml:"package_checks"`
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./internal/config/ -run TestResolveTorConfig`
+Expected: PASS.
+Run: `go build ./...`
+Expected: clean (new field parses).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/config/tor.go internal/config/tor_test.go internal/config/config.go
+git commit -m "feat(tor): add tor config block with deny-by-default resolution"
+```
+
+---
+
+## Task 3: `internal/tor` — directory-authority seed
+
+**Files:**
+- Create: `internal/tor/seed.go`
+- Test: `internal/tor/seed_test.go`
+
+> The Tor directory authorities are a small, near-static set published in
+> the Tor source (`src/app/config/auth_dirs.inc`). A Tor client must reach
+> one (or a fallback dir) to bootstrap, so blocking them breaks Tor without
+> any feed. Use the well-known authority IPv4 addresses below.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package tor
+
+import (
+	"net"
+	"testing"
+)
+
+func TestDirectoryAuthoritySeed_NonEmptyAndValid(t *testing.T) {
+	seed := DirectoryAuthoritySeed()
+	if len(seed) < 5 {
+		t.Fatalf("expected several authority IPs, got %d", len(seed))
+	}
+	for _, s := range seed {
+		if net.ParseIP(s) == nil {
+			t.Fatalf("seed entry %q is not a valid IP", s)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/tor/ -run TestDirectoryAuthoritySeed`
+Expected: FAIL — package/`DirectoryAuthoritySeed` undefined.
+
+- [ ] **Step 3: Write the seed**
+
+```go
+package tor
+
+// DirectoryAuthoritySeed returns the well-known Tor directory-authority
+// IPv4 addresses. These are near-static (changes require a Tor release)
+// and a client must contact one — or a fallback dir — to bootstrap, so
+// this list breaks Tor without any external feed. Source: Tor's
+// src/app/config/auth_dirs.inc. Operators extend coverage via the
+// onionoo relay feed (Task 5) or relay_feed.local_lists.
+func DirectoryAuthoritySeed() []string {
+	return []string{
+		"128.31.0.39",    // moria1
+		"86.59.21.38",    // tor26
+		"199.58.81.140",  // dizum
+		"192.36.123.159", // bastet
+		"66.111.2.131",   // Faravahar
+		"131.188.40.189", // gabelmoo
+		"193.23.244.244", // dannenberg
+		"171.25.193.9",   // maatuska
+		"154.35.175.225", // longclaw
+		"204.13.164.118", // serge
+	}
+}
+```
+
+> Note for implementer: if any authority IP has changed since this plan
+> was written, cross-check the current `auth_dirs.inc`. Staleness only
+> weakens the seed; the feed and other vectors remain authoritative.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/tor/ -run TestDirectoryAuthoritySeed`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tor/seed.go internal/tor/seed_test.go
+git commit -m "feat(tor): add directory-authority seed IPs"
+```
+
+---
+
+## Task 4: `internal/tor` — `Policy` core (the three Eval methods)
+
+**Files:**
+- Create: `internal/tor/policy.go`
+- Test: `internal/tor/policy_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package tor
+
+import (
+	"net"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+func newDenyPolicy(t *testing.T) *Policy {
+	t.Helper()
+	p, err := New(config.ResolveTorConfig(config.TorConfig{}))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return p
+}
+
+func TestPolicy_EvalExecve_DenyTorBinary(t *testing.T) {
+	p := newDenyPolicy(t)
+	v, ok := p.EvalExecve("/usr/bin/tor", []string{"tor"})
+	if !ok || v.Vector != "process" || v.Decision != "deny" {
+		t.Fatalf("got ok=%v verdict=%+v, want deny/process", ok, v)
+	}
+	v, ok = p.EvalExecve("/usr/bin/torsocks", []string{"torsocks", "curl"})
+	if !ok || v.Decision != "deny" {
+		t.Fatalf("torsocks should be denied: ok=%v v=%+v", ok, v)
+	}
+	if _, ok := p.EvalExecve("/usr/bin/curl", []string{"curl"}); ok {
+		t.Fatal("curl must not be a Tor match")
+	}
+}
+
+func TestPolicy_EvalConnect_SocksPortLoopback(t *testing.T) {
+	p := newDenyPolicy(t)
+	v, ok := p.EvalConnect(net.ParseIP("127.0.0.1"), 9050)
+	if !ok || v.Vector != "socks_port" || v.Decision != "deny" {
+		t.Fatalf("loopback :9050 should deny: ok=%v v=%+v", ok, v)
+	}
+	// Default socks_loopback_only=true: non-loopback :9050 is not Tor.
+	if _, ok := p.EvalConnect(net.ParseIP("203.0.113.7"), 9050); ok {
+		t.Fatal("non-loopback :9050 must not match when loopback_only")
+	}
+}
+
+func TestPolicy_EvalConnect_RelaySeedIP(t *testing.T) {
+	p := newDenyPolicy(t)
+	v, ok := p.EvalConnect(net.ParseIP("128.31.0.39"), 443) // moria1 authority
+	if !ok || v.Vector != "relay_ip" || v.Decision != "deny" {
+		t.Fatalf("authority IP should deny: ok=%v v=%+v", ok, v)
+	}
+	if _, ok := p.EvalConnect(net.ParseIP("1.1.1.1"), 443); ok {
+		t.Fatal("non-relay IP must not match")
+	}
+}
+
+func TestPolicy_EvalOnionName(t *testing.T) {
+	p := newDenyPolicy(t)
+	v, ok := p.EvalOnionName("abcdefghij234567.onion")
+	if !ok || v.Vector != "onion_dns" || v.Decision != "deny" {
+		t.Fatalf(".onion should deny: ok=%v v=%+v", ok, v)
+	}
+	if _, ok := p.EvalOnionName("example.com"); ok {
+		t.Fatal("clearnet host must not match")
+	}
+}
+
+func TestPolicy_AuditMode(t *testing.T) {
+	tr := true
+	p, _ := New(config.ResolveTorConfig(config.TorConfig{Enabled: &tr, Mode: "audit"}))
+	v, ok := p.EvalExecve("/usr/bin/tor", []string{"tor"})
+	if !ok || v.Decision != "audit" {
+		t.Fatalf("audit mode must report audit: ok=%v v=%+v", ok, v)
+	}
+}
+
+func TestPolicy_AllowMode_NoMatches(t *testing.T) {
+	tr := true
+	p, _ := New(config.ResolveTorConfig(config.TorConfig{Enabled: &tr, Mode: "allow"}))
+	if _, ok := p.EvalExecve("/usr/bin/tor", []string{"tor"}); ok {
+		t.Fatal("allow mode: Tor vectors must be no-ops")
+	}
+	if _, ok := p.EvalConnect(net.ParseIP("127.0.0.1"), 9050); ok {
+		t.Fatal("allow mode: connect must be a no-op")
+	}
+}
+
+func TestPolicy_DisabledVector(t *testing.T) {
+	tr, f := true, false
+	p, _ := New(config.ResolveTorConfig(config.TorConfig{
+		Enabled: &tr,
+		Vectors: config.TorVectors{Processes: &f},
+	}))
+	if _, ok := p.EvalExecve("/usr/bin/tor", []string{"tor"}); ok {
+		t.Fatal("processes vector disabled: must not match")
+	}
+	// other vectors still active
+	if _, ok := p.EvalOnionName("x.onion"); !ok {
+		t.Fatal("onion_dns still enabled: should match")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/tor/ -run TestPolicy`
+Expected: FAIL — `New`/`Policy`/`Verdict` undefined.
+
+- [ ] **Step 3: Write the policy**
+
+```go
+package tor
+
+import (
+	"net"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/ipset"
+)
+
+// Mode constants.
+const (
+	ModeDeny  = "deny"
+	ModeAudit = "audit"
+	ModeAllow = "allow"
+)
+
+// Vector constants (also used as the tor_control event's vector field).
+const (
+	VectorProcess   = "process"
+	VectorSocksPort = "socks_port"
+	VectorOnionDNS  = "onion_dns"
+	VectorOnionHTTP = "onion_http"
+	VectorRelayIP   = "relay_ip"
+)
+
+// Verdict is the result of a positive Tor match.
+type Verdict struct {
+	Vector   string // one of the Vector* constants
+	Mode     string // resolved policy mode
+	Decision string // "deny" or "audit" (allow mode never yields a verdict)
+	Target   string // binary path, ip:port, or onion host
+}
+
+// Policy answers Tor questions for the enforcement points. Construct once
+// via New; the relay set may be swapped concurrently via SetRelays.
+type Policy struct {
+	cfg          config.ResolvedTorConfig
+	binBasenames map[string]struct{}
+	socksPorts   map[int]struct{}
+	controlPorts map[int]struct{}
+	seed         *ipset.Set    // directory-authority seed (immutable)
+	relays       atomic.Pointer[ipset.Set] // feed-populated, hot-swappable
+}
+
+// New builds a Policy from resolved config. Returns a Policy even when
+// disabled (its Eval* methods are then no-ops).
+func New(cfg config.ResolvedTorConfig) (*Policy, error) {
+	p := &Policy{
+		cfg:          cfg,
+		binBasenames: map[string]struct{}{},
+		socksPorts:   map[int]struct{}{},
+		controlPorts: map[int]struct{}{},
+		seed:         ipset.New(),
+	}
+	for _, b := range cfg.ClientBinaries {
+		p.binBasenames[strings.ToLower(b)] = struct{}{}
+	}
+	for _, port := range cfg.SocksPorts {
+		p.socksPorts[port] = struct{}{}
+	}
+	for _, port := range cfg.ControlPorts {
+		p.controlPorts[port] = struct{}{}
+	}
+	for _, ip := range DirectoryAuthoritySeed() {
+		_ = p.seed.Add(ip) // seed entries are known-valid
+	}
+	p.relays.Store(ipset.New())
+	return p, nil
+}
+
+// Mode returns the resolved mode.
+func (p *Policy) Mode() string { return p.cfg.Mode }
+
+// active reports whether a verdict should be produced at all.
+func (p *Policy) active() bool {
+	return p != nil && p.cfg.Enabled && (p.cfg.Mode == ModeDeny || p.cfg.Mode == ModeAudit)
+}
+
+// decisionForMode maps the policy mode to a verdict decision.
+func (p *Policy) decisionForMode() string {
+	if p.cfg.Mode == ModeAudit {
+		return ModeAudit
+	}
+	return ModeDeny
+}
+
+func (p *Policy) verdict(vector, target string) (Verdict, bool) {
+	return Verdict{
+		Vector:   vector,
+		Mode:     p.cfg.Mode,
+		Decision: p.decisionForMode(),
+		Target:   target,
+	}, true
+}
+
+// EvalExecve reports whether filename is a Tor client binary.
+func (p *Policy) EvalExecve(filename string, argv []string) (Verdict, bool) {
+	if !p.active() || !p.cfg.Vectors.Processes {
+		return Verdict{}, false
+	}
+	base := strings.ToLower(filepath.Base(filename))
+	if _, ok := p.binBasenames[base]; ok {
+		return p.verdict(VectorProcess, filename)
+	}
+	return Verdict{}, false
+}
+
+// EvalConnect reports whether a connect to ip:port targets Tor (a local
+// SOCKS/control port, or a known relay IP).
+func (p *Policy) EvalConnect(ip net.IP, port int) (Verdict, bool) {
+	if !p.active() {
+		return Verdict{}, false
+	}
+	if p.cfg.Vectors.SocksPorts {
+		_, isSocks := p.socksPorts[port]
+		_, isCtrl := p.controlPorts[port]
+		if isSocks || isCtrl {
+			if !p.cfg.SocksLoopbackOnly || (ip != nil && ip.IsLoopback()) {
+				return p.verdict(VectorSocksPort, net.JoinHostPort(ipString(ip), itoa(port)))
+			}
+		}
+	}
+	if p.cfg.Vectors.RelayIPs && ip != nil {
+		if p.seed.Contains(ip) || p.relays.Load().Contains(ip) {
+			return p.verdict(VectorRelayIP, net.JoinHostPort(ipString(ip), itoa(port)))
+		}
+	}
+	return Verdict{}, false
+}
+
+// EvalOnionName reports whether host is a .onion address. vector is
+// onion_dns; callers in the HTTP path relabel to onion_http.
+func (p *Policy) EvalOnionName(host string) (Verdict, bool) {
+	if !p.active() || !p.cfg.Vectors.OnionDNS {
+		return Verdict{}, false
+	}
+	h := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	if h == "onion" || strings.HasSuffix(h, ".onion") {
+		return p.verdict(VectorOnionDNS, host)
+	}
+	return Verdict{}, false
+}
+
+// SetRelays swaps the feed-populated relay set (called by the Syncer).
+func (p *Policy) SetRelays(s *ipset.Set) {
+	if p == nil || s == nil {
+		return
+	}
+	p.relays.Store(s)
+}
+
+// RelayFeedEnabled reports whether the onionoo feed should run.
+func (p *Policy) RelayFeedEnabled() bool {
+	return p != nil && p.cfg.Enabled && p.cfg.Vectors.RelayIPs && p.cfg.RelayFeed.Enabled
+}
+
+// RelayFeedConfig exposes the feed config for the Syncer.
+func (p *Policy) RelayFeedConfig() config.TorRelayFeed { return p.cfg.RelayFeed }
+
+func ipString(ip net.IP) string {
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
+}
+
+func itoa(i int) string {
+	// strconv.Itoa without the import churn in callers that already use it.
+	return strconvItoa(i)
+}
+```
+
+Add a tiny helper file or inline `strconv`. Simplest: replace `itoa`/`ipString` usage with `strconv` directly. To avoid the indirection above, use this `policy.go` import block and drop the `itoa`/`strconvItoa` shim — change `itoa(port)` to `strconv.Itoa(port)` and import `"strconv"`. (Do this now: import `strconv`, delete the `itoa` and `strconvItoa` references, call `strconv.Itoa(port)`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/tor/ -run TestPolicy`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tor/policy.go internal/tor/policy_test.go
+git commit -m "feat(tor): add Policy with EvalExecve/EvalConnect/EvalOnionName"
+```
+
+---
+
+## Task 5: `internal/tor` — onionoo relay feed loader + syncer
+
+**Files:**
+- Create: `internal/tor/feed.go`
+- Test: `internal/tor/feed_test.go`
+
+> onionoo `details` returns `{"relays":[{"or_addresses":["1.2.3.4:9001","[2001:db8::1]:443"]},...]}`.
+> We extract the host of each `or_addresses` entry into an `ipset.Set`.
+> Modeled on `internal/threatfeed/syncer.go`: periodic fetch, last-good
+> reuse on failure, disk cache, plus a fold-in of `local_lists` and the
+> always-present directory-authority seed (held separately in Policy).
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+package tor
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestParseOnionoo(t *testing.T) {
+	body := `{"relays":[
+		{"or_addresses":["128.66.0.1:9001","[2001:db8::2]:443"]},
+		{"or_addresses":["128.66.0.2:443"]},
+		{"or_addresses":["garbage"]}
+	]}`
+	ips, err := parseOnionoo(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parseOnionoo: %v", err)
+	}
+	if len(ips) != 3 {
+		t.Fatalf("want 3 parseable IPs, got %d (%v)", len(ips), ips)
+	}
+	set := buildSet(ips)
+	if !set.Contains(net.ParseIP("128.66.0.1")) {
+		t.Fatal("expected 128.66.0.1 in set")
+	}
+	if !set.Contains(net.ParseIP("2001:db8::2")) {
+		t.Fatal("expected IPv6 relay in set")
+	}
+}
+
+func TestParseOnionoo_Malformed(t *testing.T) {
+	if _, err := parseOnionoo(strings.NewReader("{not json")); err == nil {
+		t.Fatal("expected error on malformed JSON")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/tor/ -run TestParseOnionoo`
+Expected: FAIL — `parseOnionoo`/`buildSet` undefined.
+
+- [ ] **Step 3: Write the feed**
+
+```go
+package tor
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/ipset"
+)
+
+const maxOnionooSize = 200 * 1024 * 1024 // 200 MB; onionoo details is large
+
+// parseOnionoo extracts relay host IPs from an onionoo `details` document.
+// Unparseable or_addresses entries are skipped (best-effort).
+func parseOnionoo(r io.Reader) ([]string, error) {
+	var doc struct {
+		Relays []struct {
+			OrAddresses []string `json:"or_addresses"`
+		} `json:"relays"`
+	}
+	if err := json.NewDecoder(r).Decode(&doc); err != nil {
+		return nil, err
+	}
+	var ips []string
+	for _, relay := range doc.Relays {
+		for _, addr := range relay.OrAddresses {
+			host, _, err := net.SplitHostPort(addr)
+			if err != nil {
+				continue
+			}
+			if net.ParseIP(host) == nil {
+				continue
+			}
+			ips = append(ips, host)
+		}
+	}
+	return ips, nil
+}
+
+// buildSet constructs an ipset.Set from a list of IP/CIDR strings,
+// skipping invalid entries.
+func buildSet(entries []string) *ipset.Set {
+	s := ipset.New()
+	for _, e := range entries {
+		_ = s.Add(e)
+	}
+	return s
+}
+
+// Syncer periodically refreshes a Policy's relay set from onionoo
+// sources + local lists. Modeled on internal/threatfeed.Syncer.
+type Syncer struct {
+	pol      *Policy
+	sources  []string
+	locals   []string
+	interval time.Duration
+	cacheDir string
+	client   *http.Client
+	logger   *slog.Logger
+	lastGood []string
+}
+
+// NewSyncer builds a relay-feed syncer for the given Policy.
+func NewSyncer(pol *Policy, logger *slog.Logger) *Syncer {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	cfg := pol.RelayFeedConfig()
+	interval := cfg.SyncInterval
+	if interval <= 0 {
+		interval = 6 * time.Hour
+	}
+	return &Syncer{
+		pol:      pol,
+		sources:  cfg.Sources,
+		locals:   cfg.LocalLists,
+		interval: interval,
+		cacheDir: cfg.CacheDir,
+		client:   &http.Client{Timeout: 60 * time.Second},
+		logger:   logger,
+	}
+}
+
+// Run loads the disk cache, performs an initial sync, then refreshes on
+// the configured interval until ctx is cancelled.
+func (s *Syncer) Run(ctx context.Context) {
+	if cached := s.loadCache(); len(cached) > 0 {
+		s.pol.SetRelays(buildSet(cached))
+		s.lastGood = cached
+		s.logger.Info("tor relay cache loaded", "ips", len(cached))
+	}
+	s.sync(ctx)
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.sync(ctx)
+		}
+	}
+}
+
+func (s *Syncer) sync(ctx context.Context) {
+	var all []string
+	anySucceeded := false
+	for _, src := range s.sources {
+		ips, err := s.fetch(ctx, src)
+		if err != nil {
+			s.logger.Warn("tor relay feed fetch failed", "source", src, "error", err)
+			continue
+		}
+		anySucceeded = true
+		all = append(all, ips...)
+	}
+	for _, path := range s.locals {
+		ips, err := s.parseLocal(path)
+		if err != nil {
+			s.logger.Warn("tor relay local list failed", "path", path, "error", err)
+			continue
+		}
+		anySucceeded = true
+		all = append(all, ips...)
+	}
+	if !anySucceeded {
+		// Keep last-good (already applied); seed in Policy still enforces.
+		s.logger.Warn("tor relay feed: all sources failed, retaining cache+seed",
+			"cached_ips", len(s.lastGood))
+		return
+	}
+	s.pol.SetRelays(buildSet(all))
+	s.lastGood = all
+	if err := s.saveCache(all); err != nil {
+		s.logger.Warn("tor relay cache save failed", "error", err)
+	}
+	s.logger.Info("tor relay feed synced", "ips", len(all))
+}
+
+func (s *Syncer) fetch(ctx context.Context, src string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", src, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return parseOnionoo(&io.LimitedReader{R: resp.Body, N: maxOnionooSize})
+}
+
+func (s *Syncer) parseLocal(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var ips []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		ips = append(ips, line) // IP or CIDR; ipset.Add validates
+	}
+	return ips, sc.Err()
+}
+
+func (s *Syncer) cachePath() string {
+	dir := s.cacheDir
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "tor-relays.txt")
+}
+
+func (s *Syncer) loadCache() []string {
+	p := s.cachePath()
+	if p == "" {
+		return nil
+	}
+	ips, err := s.parseLocal(p)
+	if err != nil {
+		return nil
+	}
+	return ips
+}
+
+func (s *Syncer) saveCache(ips []string) error {
+	p := s.cachePath()
+	if p == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(p, []byte(strings.Join(ips, "\n")), 0o644)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/tor/ -run TestParseOnionoo`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tor/feed.go internal/tor/feed_test.go
+git commit -m "feat(tor): add onionoo relay-feed loader and syncer"
+```
+
+---
+
+## Task 6: `tor_control` event type + OCSF registration + event constructor
+
+**Files:**
+- Modify: `internal/events/types.go` (3 spots)
+- Modify: `internal/ocsf/registry.go:26` (pendingTypes)
+- Create: `internal/tor/event.go`
+- Test: rely on existing `internal/ocsf` exhaustiveness test + a new constructor test.
+
+- [ ] **Step 1: Add the event type to `internal/events/types.go`**
+
+Add to the Network block (after line 29):
+
+```go
+	EventConnectRedirectFallback EventType = "connect_redirect_fallback"
+	EventTorControl              EventType = "tor_control"
+)
+```
+
+Add to `EventCategory` (in the Network section, after line 199):
+
+```go
+	EventConnectRedirectFallback: "network",
+	EventTorControl:              "network",
+```
+
+Add to `AllEventTypes` (in the Network line, line 291-292):
+
+```go
+	EventDNSRedirect, EventConnectRedirect, EventConnectRedirectFallback,
+	EventTorControl,
+```
+
+- [ ] **Step 2: Register in OCSF pendingTypes**
+
+In `internal/ocsf/registry.go`, add to the Network Activity group in `pendingTypes` (after line 66, `"transparent_net_setup": {},`):
+
+```go
+	"transparent_net_setup":  {},
+	"tor_control":            {},
+```
+
+- [ ] **Step 3: Run the exhaustiveness test to confirm it passes**
+
+Run: `go test ./internal/ocsf/`
+Expected: PASS (the new type is now in `pendingTypes`, so `TestExhaustiveness_AllEventTypesRegistered` is satisfied).
+
+> If you skip Step 2, this test FAILS with the new `tor_control` type
+> listed as unregistered. That is the gotcha this step prevents.
+
+- [ ] **Step 4: Write the event constructor test**
+
+Create `internal/tor/event_test.go`:
+
+```go
+package tor
+
+import "testing"
+
+func TestBuildControlEvent(t *testing.T) {
+	ev := BuildControlEvent("sess-1", "cmd-1", 4242, Verdict{
+		Vector: VectorProcess, Mode: ModeDeny, Decision: ModeDeny, Target: "/usr/bin/tor",
+	})
+	if ev.Type != "tor_control" {
+		t.Fatalf("Type=%q, want tor_control", ev.Type)
+	}
+	if ev.SessionID != "sess-1" || ev.CommandID != "cmd-1" {
+		t.Fatal("session/command not propagated")
+	}
+	if ev.Fields["vector"] != "process" || ev.Fields["decision"] != "deny" {
+		t.Fatalf("fields wrong: %+v", ev.Fields)
+	}
+	if ev.PID != 4242 {
+		t.Fatalf("PID=%d, want 4242", ev.PID)
+	}
+}
+```
+
+- [ ] **Step 5: Write the constructor**
+
+Create `internal/tor/event.go`:
+
+```go
+package tor
+
+import (
+	"time"
+
+	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/google/uuid"
+)
+
+// BuildControlEvent constructs a tor_control audit event from a Verdict.
+// Callers append+publish it via their session emitter.
+func BuildControlEvent(sessionID, commandID string, pid int, v Verdict) types.Event {
+	return types.Event{
+		ID:        uuid.NewString(),
+		Timestamp: time.Now().UTC(),
+		Type:      "tor_control",
+		SessionID: sessionID,
+		CommandID: commandID,
+		PID:       pid,
+		Fields: map[string]any{
+			"vector":   v.Vector,
+			"mode":     v.Mode,
+			"decision": v.Decision,
+			"target":   v.Target,
+			"rule":     "tor",
+		},
+	}
+}
+```
+
+> Verify `types.Event` has a `PID int` field; the existing seccomp events
+> set PID (see `internal/events/types.go` seccomp doc comment). If the
+> field name differs, adjust the assignment and the test.
+
+- [ ] **Step 6: Run tests**
+
+Run: `go test ./internal/tor/ ./internal/ocsf/ ./internal/events/`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/events/types.go internal/ocsf/registry.go internal/tor/event.go internal/tor/event_test.go
+git commit -m "feat(tor): add tor_control event type, OCSF registration, constructor"
+```
+
+---
+
+## Task 7: Policy engine — `TorChecker` interface, `Decision.Tor`, setter, adapter
+
+**Files:**
+- Modify: `internal/policy/engine.go` (Decision struct ~133, Engine struct ~38, add interface + setter near `SetThreatStore` ~398)
+- Create: `internal/tor/adapter.go`
+- Test: `internal/policy/engine_tor_test.go` (setter wiring) + adapter compile check
+
+- [ ] **Step 1: Add the interface, result type, field, and setter to `engine.go`**
+
+After the `ThreatChecker` interface (line 36), add:
+
+```go
+// TorVerdict mirrors tor.Verdict at the policy layer (avoids a policy→tor
+// import). tor.PolicyAdapter translates between the two.
+type TorVerdict struct {
+	Vector   string
+	Mode     string
+	Decision string // "deny" or "audit"
+	Target   string
+}
+
+// TorChecker is the optional Tor coordinator. internal/tor.PolicyAdapter
+// satisfies it. All methods return (verdict, true) only on a Tor match
+// the caller should act on (deny short-circuits; audit attaches+continues).
+type TorChecker interface {
+	EvalExecve(filename string, argv []string) (TorVerdict, bool)
+	EvalConnect(ip net.IP, port int) (TorVerdict, bool)
+	EvalOnionName(host string) (TorVerdict, bool)
+}
+```
+
+Add the field to the `Engine` struct (after line 73, `threatAction string`):
+
+```go
+	threatStore  ThreatChecker
+	threatAction string
+
+	// Optional Tor coordinator (deny-by-default Tor controls).
+	torChecker TorChecker
+```
+
+Add the `Tor` field to the `Decision` struct (after line 144, `ThreatAction string`):
+
+```go
+	ThreatAction string // "deny" or "audit" — set when a threat feed matched
+	Tor          *TorVerdict // non-nil when a Tor vector matched (deny or audit)
+```
+
+Add the setter near `SetThreatStore` (after line 404):
+
+```go
+// SetTorPolicy installs the optional Tor coordinator. Pass nil to disable.
+func (e *Engine) SetTorPolicy(tc TorChecker) {
+	e.torChecker = tc
+}
+```
+
+Confirm `net` is already imported in `engine.go` (it is — `CheckNetworkIP` uses `net.IP`).
+
+- [ ] **Step 2: Write the adapter test (compile + translate)**
+
+Create `internal/tor/adapter_test.go`:
+
+```go
+package tor
+
+import (
+	"net"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+func TestPolicyAdapter_ImplementsTorChecker(t *testing.T) {
+	p, _ := New(config.ResolveTorConfig(config.TorConfig{}))
+	var tc policy.TorChecker = &PolicyAdapter{Policy: p} // compile-time check
+	v, ok := tc.EvalConnect(net.ParseIP("127.0.0.1"), 9050)
+	if !ok || v.Vector != "socks_port" || v.Decision != "deny" {
+		t.Fatalf("adapter EvalConnect wrong: ok=%v v=%+v", ok, v)
+	}
+}
+```
+
+- [ ] **Step 3: Write the adapter**
+
+Create `internal/tor/adapter.go`:
+
+```go
+package tor
+
+import (
+	"net"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+// PolicyAdapter adapts *Policy to policy.TorChecker (policy→tor would be
+// an import cycle, so the bridge lives here, like threatfeed.PolicyAdapter).
+type PolicyAdapter struct {
+	Policy *Policy
+}
+
+func conv(v Verdict, ok bool) (policy.TorVerdict, bool) {
+	if !ok {
+		return policy.TorVerdict{}, false
+	}
+	return policy.TorVerdict{Vector: v.Vector, Mode: v.Mode, Decision: v.Decision, Target: v.Target}, true
+}
+
+func (a *PolicyAdapter) EvalExecve(filename string, argv []string) (policy.TorVerdict, bool) {
+	if a == nil || a.Policy == nil {
+		return policy.TorVerdict{}, false
+	}
+	return conv(a.Policy.EvalExecve(filename, argv))
+}
+
+func (a *PolicyAdapter) EvalConnect(ip net.IP, port int) (policy.TorVerdict, bool) {
+	if a == nil || a.Policy == nil {
+		return policy.TorVerdict{}, false
+	}
+	return conv(a.Policy.EvalConnect(ip, port))
+}
+
+func (a *PolicyAdapter) EvalOnionName(host string) (policy.TorVerdict, bool) {
+	if a == nil || a.Policy == nil {
+		return policy.TorVerdict{}, false
+	}
+	return conv(a.Policy.EvalOnionName(host))
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/tor/ ./internal/policy/`
+Expected: PASS (and no import cycle).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/policy/engine.go internal/tor/adapter.go internal/tor/adapter_test.go
+git commit -m "feat(tor): add TorChecker interface, Decision.Tor, adapter"
+```
+
+---
+
+## Task 8: Engine integration — Tor pre-checks in the three Check methods
+
+**Files:**
+- Modify: `internal/policy/engine.go` — `CheckExecve` (~1357), `CheckNetworkCtx` (~1056), `CheckNetworkIP` (~498)
+- Test: `internal/policy/engine_tor_test.go`
+
+> Pattern per method: a `deny` verdict short-circuits and overrides user
+> rules; an `audit` verdict attaches `dec.Tor` via a named-return + defer
+> so it never loosens normal evaluation. We use a small fake TorChecker in
+> tests.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `internal/policy/engine_tor_test.go`:
+
+```go
+package policy
+
+import (
+	"net"
+	"testing"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+type fakeTor struct {
+	execve, connect, onion *TorVerdict
+}
+
+func (f *fakeTor) EvalExecve(string, []string) (TorVerdict, bool) {
+	if f.execve == nil {
+		return TorVerdict{}, false
+	}
+	return *f.execve, true
+}
+func (f *fakeTor) EvalConnect(net.IP, int) (TorVerdict, bool) {
+	if f.connect == nil {
+		return TorVerdict{}, false
+	}
+	return *f.connect, true
+}
+func (f *fakeTor) EvalOnionName(string) (TorVerdict, bool) {
+	if f.onion == nil {
+		return TorVerdict{}, false
+	}
+	return *f.onion, true
+}
+
+func newAllowAllEngine(t *testing.T) *Engine {
+	t.Helper()
+	// A policy that would ALLOW everything, so we can prove Tor overrides it.
+	p := &Policy{
+		NetworkRules: []NetworkRule{{Name: "allow-all", Ports: []int{9050}, Decision: "allow"}},
+		CommandRules: []CommandRule{{Name: "allow-all"}},
+	}
+	e, err := NewEngine(p, false, false)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	return e
+}
+
+func TestCheckExecve_TorDenyOverridesAllow(t *testing.T) {
+	e := newAllowAllEngine(t)
+	e.SetTorPolicy(&fakeTor{execve: &TorVerdict{Vector: "process", Mode: "deny", Decision: "deny", Target: "/usr/bin/tor"}})
+	dec := e.CheckExecve("/usr/bin/tor", []string{"tor"}, 0)
+	if dec.EffectiveDecision != types.DecisionDeny {
+		t.Fatalf("EffectiveDecision=%v, want deny", dec.EffectiveDecision)
+	}
+	if dec.Tor == nil || dec.Tor.Vector != "process" {
+		t.Fatalf("dec.Tor missing/wrong: %+v", dec.Tor)
+	}
+}
+
+func TestCheckNetworkIP_TorDenySocksPort(t *testing.T) {
+	e := newAllowAllEngine(t)
+	e.SetTorPolicy(&fakeTor{connect: &TorVerdict{Vector: "socks_port", Mode: "deny", Decision: "deny", Target: "127.0.0.1:9050"}})
+	dec := e.CheckNetworkIP("", net.ParseIP("127.0.0.1"), 9050)
+	if dec.EffectiveDecision != types.DecisionDeny || dec.Tor == nil {
+		t.Fatalf("want tor deny, got dec=%+v tor=%+v", dec.EffectiveDecision, dec.Tor)
+	}
+}
+
+func TestCheckNetworkIP_TorAuditDoesNotLoosenUserDeny(t *testing.T) {
+	// Policy denies by default (no matching rule for this IP/port).
+	p := &Policy{NetworkRules: []NetworkRule{{Name: "deny-all", Decision: "deny"}}}
+	e, _ := NewEngine(p, false, false)
+	e.SetTorPolicy(&fakeTor{connect: &TorVerdict{Vector: "relay_ip", Mode: "audit", Decision: "audit", Target: "1.2.3.4:443"}})
+	dec := e.CheckNetworkIP("", net.ParseIP("1.2.3.4"), 443)
+	if dec.EffectiveDecision != types.DecisionDeny {
+		t.Fatalf("audit must not loosen a deny; got %v", dec.EffectiveDecision)
+	}
+	if dec.Tor == nil || dec.Tor.Decision != "audit" {
+		t.Fatalf("audit verdict must attach; got %+v", dec.Tor)
+	}
+}
+
+func TestCheckNetworkCtx_TorOnionDeny(t *testing.T) {
+	e := newAllowAllEngine(t)
+	e.SetTorPolicy(&fakeTor{onion: &TorVerdict{Vector: "onion_dns", Mode: "deny", Decision: "deny", Target: "x.onion"}})
+	dec := e.CheckNetworkCtx(nil, "x.onion", 53)
+	if dec.EffectiveDecision != types.DecisionDeny || dec.Tor == nil {
+		t.Fatalf("want onion deny, got dec=%+v tor=%+v", dec.EffectiveDecision, dec.Tor)
+	}
+}
+```
+
+> Adjust the literal `Policy`/`NetworkRule`/`CommandRule` field names in
+> `newAllowAllEngine` to match the actual structs in `internal/policy`
+> (read `model.go`/`engine.go`). The behavioral asserts are the contract.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/policy/ -run TestCheck.*Tor`
+Expected: FAIL — pre-checks not implemented (decisions come back `allow`/no `Tor`).
+
+- [ ] **Step 3: Add the pre-check to `CheckExecve`**
+
+Convert the signature to a named return and insert the Tor pre-check at the very top. Change line 1357 from:
+
+```go
+func (e *Engine) CheckExecve(filename string, argv []string, depth int) Decision {
+	cmdLower := strings.ToLower(filename)
+```
+
+to:
+
+```go
+func (e *Engine) CheckExecve(filename string, argv []string, depth int) (dec Decision) {
+	if e.torChecker != nil {
+		if v, ok := e.torChecker.EvalExecve(filename, argv); ok {
+			tv := TorVerdict(v)
+			if v.Decision == "deny" {
+				d := e.wrapDecision(string(types.DecisionDeny), "tor:"+v.Vector, "blocked by Tor policy", nil)
+				d.Tor = &tv
+				d.EnvPolicy = MergeEnvPolicy(e.policy.EnvPolicy, CommandRule{})
+				return d
+			}
+			defer func() { dec.Tor = &tv }() // audit: attach, don't loosen
+		}
+	}
+	cmdLower := strings.ToLower(filename)
+```
+
+Then change the two existing `return dec` statements in the function body (the matched-rule return at ~1428 and the default-deny return at ~1434) from `return dec` to keep working with the named return — they already assign `dec := e.wrapDecision(...)`. Rename those local `dec :=` to `dec =` so they target the named return:
+- Line ~1426: `dec := e.wrapDecision(...)` → `dec = e.wrapDecision(...)`
+- Line ~1432: `dec := e.wrapDecision(...)` → `dec = e.wrapDecision(...)`
+
+(Both already `return dec` immediately after, which now returns the named value so the deferred audit-attach runs.)
+
+- [ ] **Step 4: Add the pre-check to `CheckNetworkIP`**
+
+Change line 498 from:
+
+```go
+func (e *Engine) CheckNetworkIP(domain string, ip net.IP, port int) Decision {
+	if e.policy == nil {
+```
+
+to:
+
+```go
+func (e *Engine) CheckNetworkIP(domain string, ip net.IP, port int) (dec Decision) {
+	if e.torChecker != nil {
+		if v, ok := e.torChecker.EvalConnect(ip, port); ok {
+			tv := TorVerdict(v)
+			if v.Decision == "deny" {
+				d := e.wrapDecision(string(types.DecisionDeny), "tor:"+v.Vector, "blocked by Tor policy", nil)
+				d.Tor = &tv
+				return d
+			}
+			defer func() { dec.Tor = &tv }()
+		}
+	}
+	if e.policy == nil {
+```
+
+Then change every local `dec := e.wrapDecision(...)` inside `CheckNetworkIP` (lines ~566 and ~575) to `dec = e.wrapDecision(...)`, and the early `return Decision{...}` at line ~500 stays as-is (no Tor match path returns before the defer is registered only when ok; when policy==nil and no tor match, returning a literal is fine).
+
+> Note: the `if e.policy == nil { return Decision{...} }` early return at
+> line ~500 returns a literal, not the named `dec`. That is correct: if a
+> Tor `deny` matched we already returned above; if a Tor `audit` matched,
+> `e.policy == nil` is not a realistic path in production (engine always
+> has a policy), and returning allow-without-Tor-attach there is
+> acceptable. Leave it.
+
+- [ ] **Step 5: Add the pre-check to `CheckNetworkCtx`**
+
+Change line 1056 from:
+
+```go
+func (e *Engine) CheckNetworkCtx(ctx context.Context, domain string, port int) Decision {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+```
+
+to:
+
+```go
+func (e *Engine) CheckNetworkCtx(ctx context.Context, domain string, port int) (dec Decision) {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	if e.torChecker != nil {
+		if v, ok := e.torChecker.EvalOnionName(domain); ok {
+			tv := TorVerdict(v)
+			if v.Decision == "deny" {
+				d := e.wrapDecision(string(types.DecisionDeny), "tor:"+v.Vector, "blocked by Tor policy", nil)
+				d.Tor = &tv
+				return d
+			}
+			defer func() { dec.Tor = &tv }()
+		}
+	}
+```
+
+Then change every local `dec := e.wrapDecision(...)` inside `CheckNetworkCtx` (lines ~1064, ~1144, ~1153) to `dec = e.wrapDecision(...)`. The threat-feed `return dec` at ~1069 already returns; convert its `dec :=` to `dec =` as well so the named return is used consistently.
+
+> `TorVerdict(v)` is a direct conversion because the field sets are
+> identical; `tv` is addressable so `&tv` is safe to store.
+
+- [ ] **Step 6: Run tests**
+
+Run: `go test ./internal/policy/`
+Expected: PASS (new Tor tests + existing engine tests unaffected — verify no regressions).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/policy/engine.go internal/policy/engine_tor_test.go
+git commit -m "feat(tor): consult Tor coordinator in CheckExecve/CheckNetworkCtx/CheckNetworkIP"
+```
+
+---
+
+## Task 9: Emit `tor_control` at the enforcement points
+
+**Files:**
+- Modify: `internal/netmonitor/dns.go` (in `handle`, after `dec` computed ~line 120)
+- Modify: `internal/netmonitor/proxy.go` (in `handleHTTP`, after `dec` computed ~line 390)
+- Modify: `internal/api/ptrace_handlers.go` (`HandleNetwork` and `HandleExecve`, after the decision)
+
+> Each site already has an emitter and a `policy.Decision`. When
+> `dec.Tor != nil`, build and emit a `tor_control` event via
+> `tor.BuildControlEvent`. The HTTP site relabels the vector to
+> `onion_http` (the engine's `EvalOnionName` reports `onion_dns`). Import
+> `github.com/agentsh/agentsh/internal/tor` in each file.
+
+- [ ] **Step 1: DNS site — `internal/netmonitor/dns.go`**
+
+After line 120 (`dec = d.maybeApprove(ctx, commandID, dec, "dns", domain)`), add:
+
+```go
+	if dec.Tor != nil && d.emit != nil {
+		tev := tor.BuildControlEvent(d.sessionID, commandID, 0, tor.Verdict{
+			Vector: dec.Tor.Vector, Mode: dec.Tor.Mode, Decision: dec.Tor.Decision, Target: dec.Tor.Target,
+		})
+		_ = d.emit.AppendEvent(context.Background(), tev)
+		d.emit.Publish(tev)
+	}
+```
+
+Add `"github.com/agentsh/agentsh/internal/tor"` to the imports.
+
+- [ ] **Step 2: HTTP site — `internal/netmonitor/proxy.go`**
+
+After line 390 (`dec = p.maybeApprove(ctx, commandID, dec, "network", host)`), add (relabel vector to `onion_http`):
+
+```go
+	if dec.Tor != nil && p.emit != nil {
+		vector := dec.Tor.Vector
+		if vector == tor.VectorOnionDNS {
+			vector = tor.VectorOnionHTTP
+		}
+		tev := tor.BuildControlEvent(p.sessionID, commandID, 0, tor.Verdict{
+			Vector: vector, Mode: dec.Tor.Mode, Decision: dec.Tor.Decision, Target: dec.Tor.Target,
+		})
+		_ = p.emit.AppendEvent(context.Background(), tev)
+		p.emit.Publish(tev)
+	}
+```
+
+Add `"github.com/agentsh/agentsh/internal/tor"` to the imports.
+
+- [ ] **Step 3: ptrace network site — `internal/api/ptrace_handlers.go` `HandleNetwork`**
+
+After the `decision := pe.CheckNetwork(checkAddr, checkPort)` line, add (use the session's emitter — read how `HandleNetwork` already emits its `ptrace_network` event and reuse that emitter and PID):
+
+```go
+	if decision.Tor != nil {
+		tev := tor.BuildControlEvent(nc.SessionID, s.CurrentCommandID(), nc.PID, tor.Verdict{
+			Vector: decision.Tor.Vector, Mode: decision.Tor.Mode, Decision: decision.Tor.Decision, Target: decision.Tor.Target,
+		})
+		s.EmitEvent(ctx, tev) // use whatever emit helper this handler already uses
+	}
+```
+
+> Implementer: match the actual emit mechanism in `ptrace_handlers.go`
+> (e.g. `r.emit`, `s.Emit`, or an events sink). Read the surrounding
+> `HandleNetwork` body — it already emits a network event; emit the
+> `tor_control` event the same way. `tor.BuildControlEvent` is the only
+> new call. Add the `internal/tor` import.
+
+- [ ] **Step 4: ptrace execve site — `internal/api/ptrace_handlers.go` `HandleExecve`**
+
+After the execve decision is computed (the `CheckExecve` result, ~line 135), add:
+
+```go
+	if decision.Tor != nil {
+		tev := tor.BuildControlEvent(sessionID, s.CurrentCommandID(), pid, tor.Verdict{
+			Vector: decision.Tor.Vector, Mode: decision.Tor.Mode, Decision: decision.Tor.Decision, Target: decision.Tor.Target,
+		})
+		s.EmitEvent(ctx, tev) // same emit mechanism as the surrounding handler
+	}
+```
+
+> Use the same emit mechanism and the `pid`/`sessionID` variables already
+> present in `HandleExecve`.
+
+- [ ] **Step 5: Build and run package tests**
+
+Run: `go build ./... && go test ./internal/netmonitor/ ./internal/api/`
+Expected: clean build; tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/netmonitor/dns.go internal/netmonitor/proxy.go internal/api/ptrace_handlers.go
+git commit -m "feat(tor): emit tor_control events at DNS/HTTP/connect/execve sites"
+```
+
+---
+
+## Task 10: Server wiring
+
+**Files:**
+- Modify: `internal/server/server.go` (after the threat-feed block, ~line 198)
+
+- [ ] **Step 1: Build the Tor policy and wire it in**
+
+After the threat-feed wiring block (line 198) and before `limits := engine.Limits()` (line 200), add:
+
+```go
+	torCfg := config.ResolveTorConfig(cfg.Tor)
+	var torSyncer *tor.Syncer
+	if torCfg.Enabled {
+		torPol, err := tor.New(torCfg)
+		if err != nil {
+			return nil, fmt.Errorf("tor policy: %w", err)
+		}
+		engine.SetTorPolicy(&tor.PolicyAdapter{Policy: torPol})
+		slog.Info("tor access control enabled", "mode", torCfg.Mode)
+		if torPol.RelayFeedEnabled() {
+			if torCfg.RelayFeed.CacheDir == "" {
+				// default cache dir alongside threat-feeds
+				torCfg.RelayFeed.CacheDir = filepath.Join(config.GetDataDir(), "tor-relays")
+				torPol, _ = tor.New(torCfg) // rebuild with cache dir set
+				engine.SetTorPolicy(&tor.PolicyAdapter{Policy: torPol})
+			}
+			torSyncer = tor.NewSyncer(torPol, slog.Default())
+		}
+	}
+```
+
+> Simplify the cache-dir handling if `ResolveTorConfig` is extended to
+> default `RelayFeed.CacheDir`. The double-`New` above is a pragmatic
+> way to inject the default without changing the resolver; if you prefer,
+> add the default to `ResolveTorConfig` instead and delete the rebuild.
+
+- [ ] **Step 2: Start the syncer in the server's run/start path**
+
+Find where `threatSyncer.Run(ctx)` / `.Start()` is launched (search `threatSyncer` in `server.go`) and start the Tor syncer the same way, guarded by nil:
+
+```go
+	if torSyncer != nil {
+		go torSyncer.Run(ctx)
+	}
+```
+
+> Place this beside the existing `threatSyncer` goroutine launch so it
+> shares the same lifecycle context. If `threatSyncer` is started via a
+> struct field on the server, store `torSyncer` analogously (add a
+> `torSyncer *tor.Syncer` field next to `threatSyncer` at line 78).
+
+Add imports to `server.go`: `"github.com/agentsh/agentsh/internal/tor"` (and confirm `fmt`, `path/filepath`, `log/slog`, `config` already imported — they are).
+
+- [ ] **Step 3: Build**
+
+Run: `go build ./...`
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/server/server.go
+git commit -m "feat(tor): wire Tor policy and relay-feed syncer into server startup"
+```
+
+---
+
+## Task 11: End-to-end integration tests + gates
+
+**Files:**
+- Create: `internal/tor/integration_test.go` (engine-level end-to-end through the real `tor.Policy`)
+
+- [ ] **Step 1: Write an engine-level end-to-end test using the real Policy + adapter**
+
+Create `internal/tor/integration_test.go`:
+
+```go
+package tor_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/tor"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+func denyEngine(t *testing.T) *policy.Engine {
+	t.Helper()
+	// Minimal allow-all policy so any deny we see comes from Tor.
+	p := &policy.Policy{
+		CommandRules: []policy.CommandRule{{Name: "allow-all", Decision: "allow"}},
+		NetworkRules: []policy.NetworkRule{{Name: "allow-all", Decision: "allow"}},
+	}
+	e, err := policy.NewEngine(p, false, false)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	tp, _ := tor.New(config.ResolveTorConfig(config.TorConfig{}))
+	e.SetTorPolicy(&tor.PolicyAdapter{Policy: tp})
+	return e
+}
+
+func TestE2E_TorBlocksAllVectors(t *testing.T) {
+	e := denyEngine(t)
+
+	if d := e.CheckExecve("/usr/bin/tor", []string{"tor"}, 0); d.EffectiveDecision != types.DecisionDeny || d.Tor == nil {
+		t.Fatalf("process vector: %+v", d)
+	}
+	if d := e.CheckNetworkIP("", net.ParseIP("127.0.0.1"), 9050); d.EffectiveDecision != types.DecisionDeny || d.Tor == nil {
+		t.Fatalf("socks_port vector: %+v", d)
+	}
+	if d := e.CheckNetworkIP("", net.ParseIP("128.31.0.39"), 443); d.EffectiveDecision != types.DecisionDeny || d.Tor == nil {
+		t.Fatalf("relay_ip vector: %+v", d)
+	}
+	if d := e.CheckNetworkCtx(nil, "abc.onion", 53); d.EffectiveDecision != types.DecisionDeny || d.Tor == nil {
+		t.Fatalf("onion_dns vector: %+v", d)
+	}
+}
+```
+
+> Adjust `policy.Policy`/`CommandRule`/`NetworkRule` literals to the real
+> struct field names (read `internal/policy/model.go`). The four asserts
+> are the contract: deny-by-default blocks every vector through the real
+> coordinator.
+
+- [ ] **Step 2: Run the new test**
+
+Run: `go test ./internal/tor/`
+Expected: PASS.
+
+- [ ] **Step 3: Full test suite (catches the OCSF exhaustiveness cross-package test)**
+
+Run: `go test ./...`
+Expected: PASS. If `internal/ocsf` fails on `tor_control`, re-check Task 6 Step 2.
+
+- [ ] **Step 4: Cross-compile gate (per CLAUDE.md / AGENTS.md)**
+
+Run: `GOOS=windows go build ./...`
+Expected: clean (the `tor` config parses and builds on Windows; enforcement is Linux-runtime).
+
+- [ ] **Step 5: roborev gate (per standing rule)**
+
+Run roborev on the branch; fix every finding above `low` before proceeding.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/tor/integration_test.go
+git commit -m "test(tor): end-to-end deny-by-default coverage across all vectors"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Top-level `tor:` block, deny-by-default, tri-state Enabled → Task 2. ✓
+- Five vectors (process/socks_port/onion_dns/onion_http/relay_ip) → Tasks 4 (Eval), 8 (engine), 9 (emit). ✓
+- Coordinator (approach A: dedicated checks + shared Policy, deny overrides allow, audit never loosens) → Tasks 4, 7, 8. ✓
+- Built-in directory-authority seed (feed-independent) → Task 3, used in Task 4. ✓
+- Net-new `ipset` primitive → Task 1. ✓
+- Opt-in onionoo relay feed (all relays; disk cache; fail-closed to seed) → Task 5, wired in Task 10. ✓
+- One `tor_control` event + OCSF registration gotcha → Task 6. ✓
+- Honest subsystem scope: enforcement rides existing decision points (DNS/HTTP/ptrace-connect/execve); a door whose subsystem is off is a no-op → reflected by integrating at those exact sites (Task 9) and documented in the spec. ✓
+- Gates: full `go test ./...`, `GOOS=windows go build`, roborev → Task 11. ✓
+- Phase 2 (SOCKS gateway) intentionally absent. ✓
+
+**Placeholder scan:** No "TBD"/"implement later". The few implementer notes (emit mechanism in `ptrace_handlers.go`, exact `policy.Policy` literal field names) point at concrete code to read and adapt, with the behavioral contract pinned by tests — not deferred work.
+
+**Type consistency:** `Verdict`/`TorVerdict` field sets are identical (Vector/Mode/Decision/Target) so the `TorVerdict(v)` conversion in Task 8 and the `conv()` translation in Task 7 hold. Vector constants (`process`,`socks_port`,`onion_dns`,`onion_http`,`relay_ip`) are defined once in Task 4 and reused in Tasks 6/9. `EvalExecve/EvalConnect/EvalOnionName` signatures match across `tor.Policy` (Task 4), `policy.TorChecker` (Task 7), and the adapter (Task 7).
+
+**Known adaptation points (read-before-write, not placeholders):**
+1. `internal/policy` struct literal field names in tests (`Policy`, `CommandRule`, `NetworkRule`) — read `model.go`.
+2. The exact emit mechanism + PID/session variables in `ptrace_handlers.go` `HandleNetwork`/`HandleExecve` — mirror the handler's existing event emission.
+3. `types.Event.PID` field name — confirm in `pkg/types`.

--- a/docs/superpowers/specs/2026-06-14-tor-access-control-design.md
+++ b/docs/superpowers/specs/2026-06-14-tor-access-control-design.md
@@ -97,6 +97,14 @@ independently toggleable.
   dials a local SOCKS port). Relay-IP blocking is defense-in-depth for
   the daemon's *direct* egress, not the sole control. Documented, not
   pretended.
+- **Per-port precision on relay IPs.** Relay-IP matching (vector 5) is
+  IP-based and **port-agnostic**: a connection to *any* port of a seed
+  or feed relay IP is treated as Tor. A few directory-authority IPs sit
+  in netblocks shared with non-Tor services, so under deny-by-default a
+  sandboxed agent that legitimately dials such an IP on an unrelated
+  port is blocked as `relay_ip`. This is the intended conservative
+  posture (the same trade-off as the bridge limitation); the operator's
+  escape hatch is `vectors.relay_ips: false` or `tor.mode: audit`.
 - **Deep Tor protocol fingerprinting** (recognizing the Tor link
   handshake on an arbitrary TLS connection). Out of scope; the five
   vectors above are cheaper and sufficient.
@@ -297,6 +305,16 @@ Fields: `vector` (`process|socks_port|onion_dns|onion_http|relay_ip`),
 standard base process fields (pid, process name, executable, cmdline,
 uid/gid, username). `audit` mode emits the same event with
 `decision: audit`.
+
+**Attribution caveat.** The `pid`/`command_id` fields are populated only
+where the firing enforcement layer knows the originating process. The
+ptrace execve and network paths carry a real `pid` (with an empty
+`command_id`, matching the sibling `ptrace_execve`/`ptrace_network`
+events). The DNS, HTTP-proxy, and transparent-TCP layers operate on a
+query/connection and emit `pid: 0`, because the originating PID is not
+resolved at that layer; those records are correlated by session and
+`target` instead. Threading a PID into those layers is possible future
+work, not a Phase 1 guarantee.
 
 **Registration requirement.** Any new `events.EventType` must also be
 added to `internal/ocsf/registry.go` (`pendingTypes` or a real OCSF

--- a/docs/superpowers/specs/2026-06-14-tor-access-control-design.md
+++ b/docs/superpowers/specs/2026-06-14-tor-access-control-design.md
@@ -77,6 +77,13 @@ Vectors 1–4 do not depend on any feed. Vector 5 uses a built-in
 directory-authority seed (feed-independent) plus an optional onionoo
 relay feed.
 
+The `.onion` DNS (3) and `.onion` HTTP (4) rows are two enforcement
+points and two distinct `tor_control` event vectors (`onion_dns`,
+`onion_http`), but they share a single `vectors.onion` config toggle:
+blocking `.onion` over DNS while permitting it over the HTTP proxy is
+incoherent, so one toggle governs both. The other vectors remain
+independently toggleable.
+
 ## Non-Goals
 
 - **Per-`.onion` allow/deny in Phase 1.** Allowing `a.onion` while
@@ -128,8 +135,7 @@ tor:
   vectors:
     processes:   true
     socks_ports: true
-    onion_dns:   true
-    onion_http:  true
+    onion:       true   # one toggle for both .onion DNS and .onion HTTP
     relay_ips:   true
 
   client_binaries: [tor, obfs4proxy, snowflake-client, lyrebird, meek-client, torsocks]
@@ -232,8 +238,10 @@ enforcement points each gain a short pre-check that calls the relevant
   (a user `deny` still denies).
 - In `allow` mode the Tor vectors are no-ops; normal network policy is
   unchanged for non-Tor traffic.
-- Vectors 1–4 are independent of any feed and of each other; each holds
-  even if the others or the feed are unavailable.
+- Vectors 1–4 are independent of any feed; each holds even if the
+  others or the feed are unavailable. (The `.onion` DNS and HTTP
+  enforcement points share the single `vectors.onion` toggle — see "The
+  five vectors" — but are otherwise independent doors.)
 - If the relay feed fails to load: fall back to last-good disk cache →
   built-in directory-authority seed + `local_lists`. Never silent
   fail-open. A `tor_control` feed-status warning is logged/metered.

--- a/docs/superpowers/specs/2026-06-14-tor-access-control-design.md
+++ b/docs/superpowers/specs/2026-06-14-tor-access-control-design.md
@@ -1,0 +1,339 @@
+# Tor Access Control — Design
+
+**Date:** 2026-06-14
+**Status:** Draft, awaiting user review
+**Related:** `internal/policy/engine.go` (`CheckExecve`, `CheckNetworkIP`,
+`CheckNetworkCtx`), `internal/netmonitor/dns.go`, `internal/netmonitor/proxy.go`,
+`internal/netmonitor/transparent_tcp.go`, `internal/threatfeed/`,
+`internal/config/config.go`, `internal/events/types.go`,
+`internal/ocsf/registry.go`. Builds on the connect-redirect machinery
+(`docs/plans/2026-01-29-network-redirect-design.md`) and the Process
+Network ACL (`docs/plans/2026-01-13-process-network-acl-design.md`).
+
+## Summary
+
+Add a top-level **`tor:` policy block** that gives agentsh a single,
+declarative, **deny-by-default** posture toward the Tor network. The
+block is a *coordinating macro*: one intent (`deny | audit | allow`)
+expands into consistent enforcement across the five distinct ways a
+sandboxed process can reach Tor, and every hit emits a uniform
+`tor_control` audit event tagged with the vector that fired.
+
+The threat is evasion: an AI agent that runs `tor` (or `torsocks`, a
+bridge, a SOCKS proxy) to tunnel around agentsh's carefully-built
+network egress allowlist. Tor traffic is encrypted to relays, so once
+an agent is on the Tor network its real destinations are invisible to
+every IP/DNS/host control agentsh has. The only effective response is
+to stop the agent reaching the Tor network in the first place.
+
+**Deny-by-default.** With no `tor:` block configured at all, Tor is
+denied. Operators must explicitly opt out (`tor.mode: allow` or
+`tor.enabled: false`) to permit it. The default posture requires **no
+external network fetch** — it relies on the four cheap doors (client
+binaries, local SOCKS/control ports, `.onion` DNS, `.onion` HTTP) plus
+a built-in set of Tor directory-authority IPs that alone break Tor
+bootstrap.
+
+Phase 1 (this spec, the deliverable) is **category control**: block or
+audit Tor as a whole. Phase 2 (sketched, not built) is a SOCKS-aware
+onion gateway for per-`.onion` allow/deny when Tor is deliberately
+permitted.
+
+## Motivation
+
+agentsh's network controls — PNACL, `CheckNetworkIP/Ctx`, threat
+feeds, the HTTP/DB proxies — all reason about a connection's
+*destination*: its host, IP, CIDR, port, SNI, or HTTP Host. Tor
+defeats all of them at once. An agent that bootstraps a Tor client
+opens an encrypted circuit to a guard relay and then reaches anything
+— including any `.onion` service and any clearnet host — with the real
+target buried inside the encrypted stream. From agentsh's vantage the
+only thing visible is "a TLS connection to some relay IP," and the
+agent's entire egress policy is bypassed.
+
+Tor is therefore best treated as a *category* to be denied by default,
+the same way the socket-family-block spec treats niche kernel socket
+families: near-zero legitimate use inside an agent workload, high
+evasion value, so deny unless explicitly needed.
+
+The good news is that four of the five enforcement points already
+exist; this design coordinates them and adds one new primitive
+(IP/CIDR membership) plus the feed that populates it.
+
+## The five vectors
+
+A process reaches Tor through exactly one (or more) of these doors.
+Phase 1 closes all five.
+
+| # | Vector | What it catches | Hook |
+|---|---|---|---|
+| 1 | **Client processes** | Agent runs `tor`/`obfs4proxy`/`snowflake-client`/`lyrebird`/`meek-client`/`torsocks`/Tor Browser | `CheckExecve` → ptrace deny (**exists**) |
+| 2 | **Local SOCKS/control ports** | App speaks SOCKS to a local Tor daemon at `127.0.0.1:9050/9150`, control at `9051` | `connect()` seccomp-notify, sees loopback sockaddr (**exists, small wiring**) |
+| 3 | **`.onion` DNS** | A `.onion` name (RFC 7686) reaches the resolver | DNS interceptor name match → REFUSED (**exists**) |
+| 4 | **`.onion` HTTP** | A `.onion` Host fetched through agentsh's HTTP proxy | proxy Host match → 403 (**exists**) |
+| 5 | **Relay IPs** | The Tor daemon dials guard / middle / exit / dir-authority IPs directly | IP/CIDR match in `CheckNetworkIP` (**net-new**) |
+
+Vectors 1–4 do not depend on any feed. Vector 5 uses a built-in
+directory-authority seed (feed-independent) plus an optional onionoo
+relay feed.
+
+## Non-Goals
+
+- **Per-`.onion` allow/deny in Phase 1.** Allowing `a.onion` while
+  denying `b.onion` through the *same* local Tor requires reading the
+  `.onion` target out of the SOCKS5 CONNECT handshake — a stateful
+  MITM proxy. Deferred to Phase 2. Phase 1 blocking an onion is free
+  (kill the transport); *permitting a specific* onion is the hard part.
+- **Enumerating private bridges.** Bridges are deliberately unlisted,
+  so the relay-IP feed cannot know them. Bridge-based Tor is still
+  caught by vectors 1–4 (the agent still runs a client binary and
+  dials a local SOCKS port). Relay-IP blocking is defense-in-depth for
+  the daemon's *direct* egress, not the sole control. Documented, not
+  pretended.
+- **Deep Tor protocol fingerprinting** (recognizing the Tor link
+  handshake on an arbitrary TLS connection). Out of scope; the five
+  vectors above are cheaper and sufficient.
+- **Mandatory phone-home.** The onionoo feed is opt-in. The
+  deny-by-default posture must hold with zero external fetches.
+- **Replacing PNACL / threat feeds / network rules.** The `tor:` block
+  sits alongside them and takes precedence in `deny` mode; it does not
+  subsume general network policy.
+- **Non-Linux enforcement parity.** Enforcement is Linux-first
+  (matches the repo posture). Cross-platform hooks that already exist
+  (execve, DNS, HTTP proxy) carry over; the `connect()`/relay-IP path
+  rides the Linux seccomp/network layer. The config parses everywhere
+  (cross-compile builds clean); platforms without the underlying
+  subsystem degrade per "Honest scope" below.
+
+## Configuration
+
+New top-level block, sibling of `threat_feeds` and `policies`:
+
+```yaml
+tor:
+  # Tri-state, codebase convention (*bool): absent/nil → true.
+  # Deny-by-default: omitting the whole block denies Tor.
+  enabled: true
+
+  # deny (default) | audit | allow
+  #   deny  → on a Tor match, short-circuit to deny; emit tor_control{decision:deny}
+  #   audit → on a Tor match, do NOT block on account of Tor; emit
+  #           tor_control{decision:audit}, then fall through to normal
+  #           policy (a user rule may still deny it — audit never loosens)
+  #   allow → Tor vectors are no-ops (Tor permitted); normal policy still
+  #           applies to non-Tor traffic. Phase 2 attaches onion_rules here.
+  mode: deny
+
+  # All default true. Lets an operator relax one door without losing the rest.
+  vectors:
+    processes:   true
+    socks_ports: true
+    onion_dns:   true
+    onion_http:  true
+    relay_ips:   true
+
+  client_binaries: [tor, obfs4proxy, snowflake-client, lyrebird, meek-client, torsocks]
+  socks_ports:     [9050, 9150]
+  control_ports:   [9051]
+  socks_loopback_only: true   # only treat those ports as Tor when dest is loopback
+
+  relay_feed:
+    enabled: false            # opt-in; deny-by-default does NOT require this
+    sources: ["https://onionoo.torproject.org/details"]
+    local_lists: ["/etc/agentsh/tor-relays.txt"]
+    sync_interval: 6h
+```
+
+**Defaults resolution (`ResolveTorConfig`).** A missing block, or
+`enabled` unset, resolves to `enabled: true, mode: deny` with all
+vectors on and the built-in seed active. Empty `mode` → `deny`. This
+mirrors the `*bool` tri-state already used for `WaitKillable` and the
+"unset → recommended default" pattern in the socket-family-block spec.
+
+**Escape hatches.** `tor.enabled: false` disables Tor controls
+entirely; `tor.mode: allow` permits Tor (and, in Phase 2, scopes it
+via `onion_rules`).
+
+## Architecture
+
+### Coordinator, not rule synthesis
+
+Two ways to expand the macro were considered:
+
+- **(A, chosen) Dedicated checks consulting a shared `tor.Policy`.**
+  Each enforcement point asks `tor.Policy` "is this Tor, and what's the
+  mode?" before normal rule evaluation. A Tor match in `deny` mode
+  overrides any user `allow`. Every hit emits a uniform `tor_control`
+  event tagged with its vector. One config source of truth; clean
+  precedence; Tor-specific observability.
+- **(B, rejected) Rule synthesis.** Generate ordinary
+  execve/network/DNS rules from the `tor:` block at load. Less wiring,
+  but events surface as generic "network deny," precedence with user
+  rules is murky, and there is no "Tor" concept in the audit trail.
+
+`tor.Policy` (new, `internal/tor/`) holds the resolved config, the
+compiled client-binary matchers, the port sets, and the relay IP set.
+It exposes:
+
+- `EvalExecve(path, argv) (TorVerdict, ok)`
+- `EvalConnect(ip, port) (TorVerdict, ok)` — covers both SOCKS/control
+  ports (vector 2) and relay IPs (vector 5)
+- `EvalOnionName(host) (TorVerdict, ok)` — covers `.onion` for DNS and
+  HTTP (vectors 3, 4)
+
+`TorVerdict` carries `{vector, mode, decision, target}`. `ok=false`
+means "not Tor, fall through to normal policy." The existing
+enforcement points each gain a short pre-check that calls the relevant
+`Eval*` and, on `ok`, applies the verdict and emits the event.
+
+### Per-vector integration
+
+1. **Processes** — `CheckExecve` calls `EvalExecve`. Match (basename or
+   path glob against `client_binaries`) in `deny` mode → existing deny
+   path (`EACCES`). `audit` → allow + event.
+2. **SOCKS/control ports** — the `connect()` seccomp-notify handler
+   calls `EvalConnect`. Port ∈ `socks_ports ∪ control_ports` (and, if
+   `socks_loopback_only`, dest is loopback) → deny/audit. This path,
+   not iptables transparent redirect, is what sees loopback
+   destinations.
+3. **`.onion` DNS** — the DNS interceptor calls `EvalOnionName` on the
+   parsed QNAME. `.onion` suffix in `deny` mode → REFUSED response.
+4. **`.onion` HTTP** — the HTTP proxy calls `EvalOnionName` on the
+   extracted Host. `.onion` in `deny` mode → 403.
+5. **Relay IPs** — `CheckNetworkIP` calls `EvalConnect`; on relay-IP
+   membership in `deny` mode → deny. (Net-new; see below.)
+
+### Precedence and fail-closed
+
+- In `deny` mode a Tor verdict **short-circuits to deny** and overrides
+  any user `allow` rule at the same enforcement point — Tor checks run
+  first.
+- In `audit` mode a Tor verdict emits the event and **falls through**
+  to normal policy; it never loosens a decision a user rule would make
+  (a user `deny` still denies).
+- In `allow` mode the Tor vectors are no-ops; normal network policy is
+  unchanged for non-Tor traffic.
+- Vectors 1–4 are independent of any feed and of each other; each holds
+  even if the others or the feed are unavailable.
+- If the relay feed fails to load: fall back to last-good disk cache →
+  built-in directory-authority seed + `local_lists`. Never silent
+  fail-open. A `tor_control` feed-status warning is logged/metered.
+
+### Honest scope (subsystem dependence)
+
+Default-deny is enforced **per vector whose underlying subsystem is
+active**: vector 1 needs execve monitoring; vectors 2 and 5 need the
+connect/network interception layer; vector 3 needs the DNS
+interceptor; vector 4 needs the HTTP proxy. Where a subsystem is
+disabled, that door degrades to no-op (in `deny`) or is simply not
+observed. This is documented rather than papered over; the spec does
+not claim a door it cannot enforce.
+
+## The net-new mechanism: IP/CIDR membership + relay feed
+
+The threat-feed store matches **domains only** (`Check(domain)`), and
+`CheckNetworkIP` has no feed check today. Rather than overload the
+threat-feed subsystem with IP semantics, add a small reusable
+primitive and let `tor.Policy` own its relay set.
+
+- **`internal/ipset` (new, small).** Efficient IPv4/IPv6 + CIDR
+  membership (sorted ranges or a binary trie). Reusable; the
+  threat-feed store may adopt it later.
+- **`tor.Policy.IsRelay(ip)`** consults that set; wired into
+  `CheckNetworkIP` only when `vectors.relay_ips` is on.
+- **Built-in seed (feed-independent).** The ~9 Tor directory-authority
+  IPs plus bundled fallback-dir IPs ship hardcoded. A Tor client must
+  reach a dir authority / fallback dir to bootstrap, so this alone
+  breaks Tor — and it needs no fetch, which is what makes
+  deny-by-default work out of the box.
+- **Feed source: onionoo** (`onionoo.torproject.org/details`, the Tor
+  Project's official API). Parse every relay's `or_addresses` into the
+  set — **all relays, not just exits**, because the local daemon dials
+  *guard* (entry) nodes first; blocking only exits would not stop
+  bootstrap. Disk-cached, `sync_interval` refresh (default 6h),
+  `local_lists` for curated/air-gapped IPs. The feed dataset is large
+  (~8k relays); the loader streams/parses to the `ipset` and caches the
+  compiled set to disk (reuse the threatfeed syncer/cache pattern).
+- **Limitation:** bridges are unlisted (see Non-Goals).
+
+## Events / observability
+
+One new event type:
+
+```
+EventTorControl events.EventType = "tor_control"
+```
+
+Fields: `vector` (`process|socks_port|onion_dns|onion_http|relay_ip`),
+`mode` (`deny|audit|allow`), `decision` (`deny|audit|allow`), `target`
+(binary path / `.onion` host / `ip:port`), `rule: "tor"`, plus the
+standard base process fields (pid, process name, executable, cmdline,
+uid/gid, username). `audit` mode emits the same event with
+`decision: audit`.
+
+**Registration requirement.** Any new `events.EventType` must also be
+added to `internal/ocsf/registry.go` (`pendingTypes` or a real OCSF
+class mapping), or `TestExhaustiveness_AllEventTypesRegistered` fails —
+in a package this change does not otherwise touch. A full
+`go test ./...` is therefore part of "done." Map `tor_control` to an
+appropriate OCSF network/security-finding class in the registry.
+
+Feed status (loaded / stale / failed, relay-set size, last sync) goes
+to logs and metrics, **not** a second event type — keeping the OCSF
+surface to one new type.
+
+## Testing
+
+**Unit**
+- `tor.Policy` decisions across every vector × mode (`deny/audit/allow`).
+- `ipset` membership: IPv4, IPv6, CIDR boundaries, empty set.
+- onionoo parser: `or_addresses` extraction, IPv6 forms, malformed input.
+- Precedence: a Tor `deny` verdict overrides a user `allow` rule.
+- Degraded path: feed disabled/empty → built-in dir-authority seed
+  still blocks; feed fetch failure → last-good cache used, warning emitted.
+- Defaults resolution: absent block → `enabled+deny+all vectors`.
+
+**Integration (Linux)**
+- Fake `tor` binary → exec denied (`EACCES`) + one `tor_control` event.
+- Fake SOCKS listener on `127.0.0.1:9050` → `connect()` denied.
+- `.onion` DNS query → REFUSED.
+- `.onion` fetch via the HTTP proxy → 403.
+- `connect()` to a seeded relay IP → denied.
+- `audit` mode → each of the above is permitted but emits a
+  `tor_control{decision:audit}` event.
+- One `tor_control` event per fired vector, with correct `vector`/`target`.
+
+**Gates**
+- Full `go test ./...` (OCSF exhaustiveness lives outside the changed packages).
+- `GOOS=windows go build ./...` cross-compile (per CLAUDE.md / AGENTS.md).
+- roborev between tasks; fix everything above low before proceeding.
+
+## Phase 2 (sketch — documented, not built)
+
+When `tor.mode: allow` and an `onion_rules:` list is present, agentsh
+becomes a **managed Tor egress**:
+
+1. Redirect the app→`127.0.0.1:9050` connection, via the existing
+   connect-redirect machinery, into agentsh's own SOCKS5 front-end.
+2. New `internal/netmonitor/socks.go` parses the SOCKS5 greeting +
+   CONNECT request and extracts the target host (`.onion` or clearnet).
+3. Match the target against `onion_rules` (and clearnet-via-Tor rules)
+   through `tor.Policy`.
+4. Allowed streams are forwarded to the *real* Tor SOCKS daemon;
+   denied streams are reset. Stateful, fail-closed.
+
+Reuses connect-redirect, `tor.Policy`, and the `tor_control` event
+schema (new `vector: onion`). This is the only path that yields true
+per-`.onion` granularity, and it is deferred until there is a concrete
+need to *permit* specific onions rather than block Tor wholesale.
+
+```yaml
+# Phase 2 illustration only — not parsed in Phase 1.
+tor:
+  mode: allow
+  onion_rules:
+    - onion: "abcdefghij…234567.onion"
+      decision: allow
+    - onion: "*"
+      decision: deny
+```

--- a/docs/superpowers/specs/2026-06-14-tor-access-control-design.md
+++ b/docs/superpowers/specs/2026-06-14-tor-access-control-design.md
@@ -1,7 +1,7 @@
 # Tor Access Control — Design
 
 **Date:** 2026-06-14
-**Status:** Draft, awaiting user review
+**Status:** Approved — Phase 1 implemented
 **Related:** `internal/policy/engine.go` (`CheckExecve`, `CheckNetworkIP`,
 `CheckNetworkCtx`), `internal/netmonitor/dns.go`, `internal/netmonitor/proxy.go`,
 `internal/netmonitor/transparent_tcp.go`, `internal/threatfeed/`,
@@ -153,6 +153,25 @@ mirrors the `*bool` tri-state already used for `WaitKillable` and the
 **Escape hatches.** `tor.enabled: false` disables Tor controls
 entirely; `tor.mode: allow` permits Tor (and, in Phase 2, scopes it
 via `onion_rules`).
+
+**Upgrade / migration note (deny-by-default activates on upgrade).**
+Because `tor:` is deny-by-default, an existing deployment whose config
+has **no `tor:` block** will, on upgrade to a build containing this
+feature, immediately begin denying all five Tor vectors — client
+binaries, the local SOCKS/control ports (`9050/9150/9051`), `.onion`
+DNS/HTTP, and the built-in directory-authority IPs — for agents that
+never opted in. This is the intended posture, not a regression. An
+operator who needs Tor, or who wants a gentler rollout, must set one of
+the following **before** upgrading:
+
+- `tor.mode: audit` — observe via `tor_control{decision:audit}` events
+  without blocking, then tighten to `deny` once the impact is understood;
+  or
+- `tor.enabled: false` — disable the Tor controls entirely.
+
+This default-on, high-impact behavior change **must be called out in the
+release notes** for the version that ships Phase 1, so operators can opt
+out ahead of time.
 
 ## Architecture
 

--- a/internal/api/ptrace_handlers.go
+++ b/internal/api/ptrace_handlers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/agentsh/agentsh/internal/ptrace"
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/internal/store/composite"
+	"github.com/agentsh/agentsh/internal/tor"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/google/uuid"
 )
@@ -131,6 +132,14 @@ func (r *ptraceHandlerRouter) HandleExecve(ctx context.Context, ec ptrace.ExecCo
 	}
 	_ = r.store.AppendEvent(ctx, ev)
 	r.broker.Publish(ev)
+
+	if decision.Tor != nil {
+		tev := tor.BuildControlEvent(ec.SessionID, "", ec.PID, tor.Verdict{
+			Vector: decision.Tor.Vector, Mode: decision.Tor.Mode, Decision: decision.Tor.Decision, Target: decision.Tor.Target,
+		})
+		_ = r.store.AppendEvent(ctx, tev)
+		r.broker.Publish(tev)
+	}
 
 	switch decision.EffectiveDecision {
 	case types.DecisionDeny:
@@ -321,6 +330,14 @@ func (r *ptraceHandlerRouter) HandleNetwork(ctx context.Context, nc ptrace.Netwo
 	}
 	_ = r.store.AppendEvent(ctx, ev)
 	r.broker.Publish(ev)
+
+	if decision.Tor != nil {
+		tev := tor.BuildControlEvent(nc.SessionID, "", nc.PID, tor.Verdict{
+			Vector: decision.Tor.Vector, Mode: decision.Tor.Mode, Decision: decision.Tor.Decision, Target: decision.Tor.Target,
+		})
+		_ = r.store.AppendEvent(ctx, tev)
+		r.broker.Publish(tev)
+	}
 
 	switch decision.EffectiveDecision {
 	case types.DecisionDeny:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	Landlock          LandlockConfig          `yaml:"landlock"`
 	LinuxCapabilities CapabilitiesConfig      `yaml:"capabilities"`
 	ThreatFeeds       ThreatFeedsConfig       `yaml:"threat_feeds"`
+	Tor               TorConfig               `yaml:"tor"`
 	PackageChecks     PackageChecksConfig     `yaml:"package_checks"`
 	Skillcheck        SkillcheckConfig        `yaml:"skillcheck"`
 	PolicySocket      PolicySocketConfig      `yaml:"policy_socket"`

--- a/internal/config/tor.go
+++ b/internal/config/tor.go
@@ -22,8 +22,7 @@ type TorConfig struct {
 type TorVectors struct {
 	Processes  *bool `yaml:"processes"`
 	SocksPorts *bool `yaml:"socks_ports"`
-	OnionDNS   *bool `yaml:"onion_dns"`
-	OnionHTTP  *bool `yaml:"onion_http"`
+	Onion      *bool `yaml:"onion"`
 	RelayIPs   *bool `yaml:"relay_ips"`
 }
 
@@ -51,13 +50,17 @@ type ResolvedTorConfig struct {
 }
 
 type ResolvedTorVectors struct {
-	Processes, SocksPorts, OnionDNS, OnionHTTP, RelayIPs bool
+	Processes, SocksPorts, Onion, RelayIPs bool
 }
 
 // DefaultTorClientBinaries is the recommended client-binary deny list.
 var DefaultTorClientBinaries = []string{
 	"tor", "obfs4proxy", "snowflake-client", "lyrebird", "meek-client", "torsocks",
 }
+
+// DefaultOnionooSource is the canonical relay-feed source used when the
+// feed is enabled but no sources/local lists are configured.
+const DefaultOnionooSource = "https://onionoo.torproject.org/details"
 
 // ResolveTorConfig applies deny-by-default semantics. Absent block (zero
 // value) → enabled, mode=deny, all vectors on, default binaries/ports.
@@ -80,8 +83,7 @@ func ResolveTorConfig(in TorConfig) ResolvedTorConfig {
 		Vectors: ResolvedTorVectors{
 			Processes:  boolOr(in.Vectors.Processes, true),
 			SocksPorts: boolOr(in.Vectors.SocksPorts, true),
-			OnionDNS:   boolOr(in.Vectors.OnionDNS, true),
-			OnionHTTP:  boolOr(in.Vectors.OnionHTTP, true),
+			Onion:      boolOr(in.Vectors.Onion, true),
 			RelayIPs:   boolOr(in.Vectors.RelayIPs, true),
 		},
 		ClientBinaries:    in.ClientBinaries,
@@ -98,6 +100,9 @@ func ResolveTorConfig(in TorConfig) ResolvedTorConfig {
 	}
 	if len(out.ControlPorts) == 0 {
 		out.ControlPorts = []int{9051}
+	}
+	if out.RelayFeed.Enabled && len(out.RelayFeed.Sources) == 0 && len(out.RelayFeed.LocalLists) == 0 {
+		out.RelayFeed.Sources = []string{DefaultOnionooSource}
 	}
 	return out
 }

--- a/internal/config/tor.go
+++ b/internal/config/tor.go
@@ -1,0 +1,103 @@
+package config
+
+import "time"
+
+// TorConfig is the raw, as-parsed `tor:` block. A missing block
+// deserializes to the zero value; ResolveTorConfig turns that into the
+// deny-by-default posture. Enabled is a *bool tri-state (nil → true),
+// matching the convention used by SandboxFUSEConfig and WaitKillable.
+type TorConfig struct {
+	Enabled           *bool        `yaml:"enabled"`
+	Mode              string       `yaml:"mode"` // deny | audit | allow
+	Vectors           TorVectors   `yaml:"vectors"`
+	ClientBinaries    []string     `yaml:"client_binaries"`
+	SocksPorts        []int        `yaml:"socks_ports"`
+	ControlPorts      []int        `yaml:"control_ports"`
+	SocksLoopbackOnly *bool        `yaml:"socks_loopback_only"`
+	RelayFeed         TorRelayFeed `yaml:"relay_feed"`
+}
+
+// TorVectors toggles each enforcement door. Pointers so an operator can
+// relax one door (set false) without the zero value disabling all.
+type TorVectors struct {
+	Processes  *bool `yaml:"processes"`
+	SocksPorts *bool `yaml:"socks_ports"`
+	OnionDNS   *bool `yaml:"onion_dns"`
+	OnionHTTP  *bool `yaml:"onion_http"`
+	RelayIPs   *bool `yaml:"relay_ips"`
+}
+
+// TorRelayFeed configures the optional onionoo relay-IP feed.
+type TorRelayFeed struct {
+	Enabled      bool          `yaml:"enabled"`
+	Sources      []string      `yaml:"sources"`
+	LocalLists   []string      `yaml:"local_lists"`
+	SyncInterval time.Duration `yaml:"sync_interval"`
+	CacheDir     string        `yaml:"cache_dir"`
+}
+
+// ResolvedTorConfig is the fully-defaulted, value-typed form consumed by
+// internal/tor. All bools are concrete; all lists are non-empty unless
+// the feature is disabled.
+type ResolvedTorConfig struct {
+	Enabled           bool
+	Mode              string
+	Vectors           ResolvedTorVectors
+	ClientBinaries    []string
+	SocksPorts        []int
+	ControlPorts      []int
+	SocksLoopbackOnly bool
+	RelayFeed         TorRelayFeed
+}
+
+type ResolvedTorVectors struct {
+	Processes, SocksPorts, OnionDNS, OnionHTTP, RelayIPs bool
+}
+
+// DefaultTorClientBinaries is the recommended client-binary deny list.
+var DefaultTorClientBinaries = []string{
+	"tor", "obfs4proxy", "snowflake-client", "lyrebird", "meek-client", "torsocks",
+}
+
+// ResolveTorConfig applies deny-by-default semantics. Absent block (zero
+// value) → enabled, mode=deny, all vectors on, default binaries/ports.
+func ResolveTorConfig(in TorConfig) ResolvedTorConfig {
+	boolOr := func(p *bool, def bool) bool {
+		if p == nil {
+			return def
+		}
+		return *p
+	}
+	mode := in.Mode
+	switch mode {
+	case "deny", "audit", "allow":
+	default:
+		mode = "deny"
+	}
+	out := ResolvedTorConfig{
+		Enabled: boolOr(in.Enabled, true),
+		Mode:    mode,
+		Vectors: ResolvedTorVectors{
+			Processes:  boolOr(in.Vectors.Processes, true),
+			SocksPorts: boolOr(in.Vectors.SocksPorts, true),
+			OnionDNS:   boolOr(in.Vectors.OnionDNS, true),
+			OnionHTTP:  boolOr(in.Vectors.OnionHTTP, true),
+			RelayIPs:   boolOr(in.Vectors.RelayIPs, true),
+		},
+		ClientBinaries:    in.ClientBinaries,
+		SocksPorts:        in.SocksPorts,
+		ControlPorts:      in.ControlPorts,
+		SocksLoopbackOnly: boolOr(in.SocksLoopbackOnly, true),
+		RelayFeed:         in.RelayFeed,
+	}
+	if len(out.ClientBinaries) == 0 {
+		out.ClientBinaries = append([]string(nil), DefaultTorClientBinaries...)
+	}
+	if len(out.SocksPorts) == 0 {
+		out.SocksPorts = []int{9050, 9150}
+	}
+	if len(out.ControlPorts) == 0 {
+		out.ControlPorts = []int{9051}
+	}
+	return out
+}

--- a/internal/config/tor_test.go
+++ b/internal/config/tor_test.go
@@ -23,6 +23,12 @@ func TestResolveTorConfig_AbsentBlockDeniesByDefault(t *testing.T) {
 	if len(got.ClientBinaries) == 0 || len(got.SocksPorts) == 0 {
 		t.Fatal("client_binaries and socks_ports must have defaults")
 	}
+	if len(got.ControlPorts) == 0 {
+		t.Fatal("control_ports must have defaults")
+	}
+	if !got.SocksLoopbackOnly {
+		t.Fatal("socks_loopback_only must default true")
+	}
 }
 
 func TestResolveTorConfig_ExplicitDisable(t *testing.T) {

--- a/internal/config/tor_test.go
+++ b/internal/config/tor_test.go
@@ -1,0 +1,60 @@
+package config
+
+import "testing"
+
+func TestResolveTorConfig_AbsentBlockDeniesByDefault(t *testing.T) {
+	// Zero value = block omitted from YAML.
+	got := ResolveTorConfig(TorConfig{})
+	if !got.Enabled {
+		t.Fatal("absent tor block must resolve to enabled (deny-by-default)")
+	}
+	if got.Mode != "deny" {
+		t.Fatalf("Mode=%q, want deny", got.Mode)
+	}
+	for name, on := range map[string]bool{
+		"processes": got.Vectors.Processes, "socks_ports": got.Vectors.SocksPorts,
+		"onion_dns": got.Vectors.OnionDNS, "onion_http": got.Vectors.OnionHTTP,
+		"relay_ips": got.Vectors.RelayIPs,
+	} {
+		if !on {
+			t.Fatalf("vector %s must default on", name)
+		}
+	}
+	if len(got.ClientBinaries) == 0 || len(got.SocksPorts) == 0 {
+		t.Fatal("client_binaries and socks_ports must have defaults")
+	}
+}
+
+func TestResolveTorConfig_ExplicitDisable(t *testing.T) {
+	f := false
+	got := ResolveTorConfig(TorConfig{Enabled: &f})
+	if got.Enabled {
+		t.Fatal("enabled:false must disable Tor controls")
+	}
+}
+
+func TestResolveTorConfig_ExplicitAllowAndOverrides(t *testing.T) {
+	tr := true
+	got := ResolveTorConfig(TorConfig{
+		Enabled:        &tr,
+		Mode:           "allow",
+		SocksPorts:     []int{9999},
+		ClientBinaries: []string{"only-this"},
+	})
+	if got.Mode != "allow" {
+		t.Fatalf("Mode=%q, want allow", got.Mode)
+	}
+	if len(got.SocksPorts) != 1 || got.SocksPorts[0] != 9999 {
+		t.Fatalf("SocksPorts override not honored: %v", got.SocksPorts)
+	}
+	if len(got.ClientBinaries) != 1 || got.ClientBinaries[0] != "only-this" {
+		t.Fatalf("ClientBinaries override not honored: %v", got.ClientBinaries)
+	}
+}
+
+func TestResolveTorConfig_InvalidModeFallsBackToDeny(t *testing.T) {
+	got := ResolveTorConfig(TorConfig{Mode: "banana"})
+	if got.Mode != "deny" {
+		t.Fatalf("invalid mode must fall back to deny, got %q", got.Mode)
+	}
+}

--- a/internal/config/tor_test.go
+++ b/internal/config/tor_test.go
@@ -13,7 +13,7 @@ func TestResolveTorConfig_AbsentBlockDeniesByDefault(t *testing.T) {
 	}
 	for name, on := range map[string]bool{
 		"processes": got.Vectors.Processes, "socks_ports": got.Vectors.SocksPorts,
-		"onion_dns": got.Vectors.OnionDNS, "onion_http": got.Vectors.OnionHTTP,
+		"onion": got.Vectors.Onion,
 		"relay_ips": got.Vectors.RelayIPs,
 	} {
 		if !on {
@@ -62,5 +62,37 @@ func TestResolveTorConfig_InvalidModeFallsBackToDeny(t *testing.T) {
 	got := ResolveTorConfig(TorConfig{Mode: "banana"})
 	if got.Mode != "deny" {
 		t.Fatalf("invalid mode must fall back to deny, got %q", got.Mode)
+	}
+}
+
+func TestResolveTorConfig_RelayFeedEnabledDefaultsOnionooSource(t *testing.T) {
+	got := ResolveTorConfig(TorConfig{RelayFeed: TorRelayFeed{Enabled: true}})
+	if len(got.RelayFeed.Sources) != 1 || got.RelayFeed.Sources[0] != DefaultOnionooSource {
+		t.Fatalf("enabled feed with no sources must default to onionoo, got %v", got.RelayFeed.Sources)
+	}
+}
+
+func TestResolveTorConfig_RelayFeedExplicitSourcesPreserved(t *testing.T) {
+	got := ResolveTorConfig(TorConfig{RelayFeed: TorRelayFeed{Enabled: true, Sources: []string{"https://example/relays"}}})
+	if len(got.RelayFeed.Sources) != 1 || got.RelayFeed.Sources[0] != "https://example/relays" {
+		t.Fatalf("explicit sources must be preserved, got %v", got.RelayFeed.Sources)
+	}
+}
+
+func TestResolveTorConfig_RelayFeedDisabledNoDefaultSource(t *testing.T) {
+	got := ResolveTorConfig(TorConfig{RelayFeed: TorRelayFeed{Enabled: false}})
+	if len(got.RelayFeed.Sources) != 0 {
+		t.Fatalf("disabled feed must not gain a default source, got %v", got.RelayFeed.Sources)
+	}
+}
+
+func TestResolveTorConfig_OnionVectorDisable(t *testing.T) {
+	f := false
+	got := ResolveTorConfig(TorConfig{Vectors: TorVectors{Onion: &f}})
+	if got.Vectors.Onion {
+		t.Fatal("vectors.onion:false must disable the onion vector")
+	}
+	if !got.Vectors.Processes || !got.Vectors.RelayIPs {
+		t.Fatal("disabling onion must not affect other vectors")
 	}
 }

--- a/internal/events/types.go
+++ b/internal/events/types.go
@@ -27,6 +27,7 @@ const (
 	EventDNSRedirect             EventType = "dns_redirect"
 	EventConnectRedirect         EventType = "connect_redirect"
 	EventConnectRedirectFallback EventType = "connect_redirect_fallback"
+	EventTorControl              EventType = "tor_control"
 )
 
 // Process operation events.
@@ -197,6 +198,7 @@ var EventCategory = map[EventType]string{
 	EventDNSRedirect:             "network",
 	EventConnectRedirect:         "network",
 	EventConnectRedirectFallback: "network",
+	EventTorControl:              "network",
 
 	// Process
 	EventProcessStart: "process",
@@ -290,6 +292,7 @@ var AllEventTypes = []EventType{
 	// Network
 	EventDNSQuery, EventNetConnect, EventNetListen, EventNetAccept,
 	EventDNSRedirect, EventConnectRedirect, EventConnectRedirectFallback,
+	EventTorControl,
 	// Process
 	EventProcessStart, EventProcessSpawn, EventProcessExit, EventProcessTree,
 	// Environment

--- a/internal/ipset/ipset.go
+++ b/internal/ipset/ipset.go
@@ -1,0 +1,61 @@
+// Package ipset provides membership testing for sets of individual IP
+// addresses and CIDR ranges. A bare IP is stored as a /32 (IPv4) or
+// /128 (IPv6) prefix. Safe for concurrent reads after construction;
+// callers that mutate after publishing must provide their own locking
+// or swap whole sets.
+package ipset
+
+import (
+	"fmt"
+	"net"
+)
+
+// Set holds IP/CIDR prefixes for O(n) membership testing. n is the
+// number of distinct prefixes added (relay feeds: ~8k); linear scan is
+// adequate and avoids a trie dependency. Swap whole sets to update.
+type Set struct {
+	nets []*net.IPNet
+}
+
+// New returns an empty Set.
+func New() *Set { return &Set{} }
+
+// Add inserts an IP ("1.2.3.4", "2001:db8::1") or CIDR ("10.0.0.0/8").
+func (s *Set) Add(entry string) error {
+	if _, ipnet, err := net.ParseCIDR(entry); err == nil {
+		s.nets = append(s.nets, ipnet)
+		return nil
+	}
+	ip := net.ParseIP(entry)
+	if ip == nil {
+		return fmt.Errorf("ipset: invalid entry %q", entry)
+	}
+	bits := 32
+	if ip.To4() == nil {
+		bits = 128
+	}
+	mask := net.CIDRMask(bits, bits)
+	s.nets = append(s.nets, &net.IPNet{IP: ip, Mask: mask})
+	return nil
+}
+
+// Contains reports whether ip falls in any added prefix. nil → false.
+func (s *Set) Contains(ip net.IP) bool {
+	if s == nil || ip == nil {
+		return false
+	}
+	for _, n := range s.nets {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// Len returns the number of prefixes in the set.
+func (s *Set) Len() int {
+	if s == nil {
+		return 0
+	}
+	return len(s.nets)
+}

--- a/internal/ipset/ipset_test.go
+++ b/internal/ipset/ipset_test.go
@@ -1,0 +1,62 @@
+package ipset
+
+import (
+	"net"
+	"testing"
+)
+
+func TestSet_ContainsIPv4Exact(t *testing.T) {
+	s := New()
+	if err := s.Add("1.2.3.4"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !s.Contains(net.ParseIP("1.2.3.4")) {
+		t.Fatal("expected 1.2.3.4 to be a member")
+	}
+	if s.Contains(net.ParseIP("1.2.3.5")) {
+		t.Fatal("did not expect 1.2.3.5 to be a member")
+	}
+}
+
+func TestSet_ContainsCIDR(t *testing.T) {
+	s := New()
+	if err := s.Add("10.0.0.0/8"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !s.Contains(net.ParseIP("10.255.1.1")) {
+		t.Fatal("expected 10.255.1.1 inside 10.0.0.0/8")
+	}
+	if s.Contains(net.ParseIP("11.0.0.1")) {
+		t.Fatal("did not expect 11.0.0.1 inside 10.0.0.0/8")
+	}
+}
+
+func TestSet_IPv6(t *testing.T) {
+	s := New()
+	if err := s.Add("2001:db8::/32"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !s.Contains(net.ParseIP("2001:db8::1")) {
+		t.Fatal("expected 2001:db8::1 inside 2001:db8::/32")
+	}
+}
+
+func TestSet_NilAndEmpty(t *testing.T) {
+	s := New()
+	if s.Contains(nil) {
+		t.Fatal("nil IP must never be a member")
+	}
+	if s.Contains(net.ParseIP("1.2.3.4")) {
+		t.Fatal("empty set must contain nothing")
+	}
+	if s.Len() != 0 {
+		t.Fatalf("Len=%d, want 0", s.Len())
+	}
+}
+
+func TestSet_AddInvalid(t *testing.T) {
+	s := New()
+	if err := s.Add("not-an-ip"); err == nil {
+		t.Fatal("expected error for invalid entry")
+	}
+}

--- a/internal/ipset/ipset_test.go
+++ b/internal/ipset/ipset_test.go
@@ -41,6 +41,19 @@ func TestSet_IPv6(t *testing.T) {
 	}
 }
 
+func TestSet_IPv6Exact(t *testing.T) {
+	s := New()
+	if err := s.Add("2001:db8::1"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if !s.Contains(net.ParseIP("2001:db8::1")) {
+		t.Fatal("expected bare IPv6 /128 to be a member")
+	}
+	if s.Contains(net.ParseIP("2001:db8::2")) {
+		t.Fatal("did not expect sibling 2001:db8::2 to be a member")
+	}
+}
+
 func TestSet_NilAndEmpty(t *testing.T) {
 	s := New()
 	if s.Contains(nil) {

--- a/internal/netmonitor/dns.go
+++ b/internal/netmonitor/dns.go
@@ -14,6 +14,7 @@ import (
 	"github.com/agentsh/agentsh/internal/netmonitor/redirect"
 	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/tor"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/google/uuid"
 )
@@ -118,6 +119,14 @@ func (d *DNSInterceptor) handle(clientAddr net.Addr, query []byte) error {
 		dec.Rule = "dns-monitor-only"
 	}
 	dec = d.maybeApprove(ctx, commandID, dec, "dns", domain)
+
+	if dec.Tor != nil && d.emit != nil {
+		tev := tor.BuildControlEvent(d.sessionID, commandID, 0, tor.Verdict{
+			Vector: dec.Tor.Vector, Mode: dec.Tor.Mode, Decision: dec.Tor.Decision, Target: dec.Tor.Target,
+		})
+		_ = d.emit.AppendEvent(context.Background(), tev)
+		d.emit.Publish(tev)
+	}
 
 	ev := types.Event{
 		ID:        uuid.NewString(),

--- a/internal/netmonitor/dns_test.go
+++ b/internal/netmonitor/dns_test.go
@@ -338,3 +338,86 @@ func (s *stubThreatChecker) Check(domain string) (policy.ThreatCheckResult, bool
 	}
 	return policy.ThreatCheckResult{}, false
 }
+
+// stubTorChecker implements policy.TorChecker for testing the onion_dns
+// enforcement point. It denies any host ending in .onion.
+type stubTorChecker struct{}
+
+func (stubTorChecker) EvalExecve(filename string, argv []string) (policy.TorVerdict, bool) {
+	return policy.TorVerdict{}, false
+}
+
+func (stubTorChecker) EvalConnect(ip net.IP, port int) (policy.TorVerdict, bool) {
+	return policy.TorVerdict{}, false
+}
+
+func (stubTorChecker) EvalOnionName(host string) (policy.TorVerdict, bool) {
+	if strings.HasSuffix(host, ".onion") {
+		return policy.TorVerdict{
+			Vector:   "onion_dns",
+			Mode:     "deny",
+			Decision: "deny",
+			Target:   host,
+		}, true
+	}
+	return policy.TorVerdict{}, false
+}
+
+func TestDNSInterceptor_OnionEmitsTorControl(t *testing.T) {
+	up := startUDPUpstream(t)
+	defer up.Close()
+
+	serverPC, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "operation not permitted") {
+			t.Skipf("udp listen not permitted in this environment: %v", err)
+		}
+		t.Fatal(err)
+	}
+	defer serverPC.Close()
+
+	pol := &policy.Policy{
+		Version: 1,
+		Name:    "test",
+		NetworkRules: []policy.NetworkRule{
+			{Name: "allow-all", Domains: []string{"*"}, Ports: []int{53}, Decision: "allow"},
+		},
+	}
+	engine, err := policy.NewEngine(pol, false, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	engine.SetTorPolicy(stubTorChecker{})
+
+	em := &captureEmitter{}
+	d := &DNSInterceptor{
+		sessionID: "session-test",
+		pc:        serverPC,
+		upstream:  up.LocalAddr().String(),
+		emit:      em,
+		policy:    engine,
+	}
+
+	query := makeDNSQuery(t, "abcdefghij.onion", 0x0F0F)
+	_ = d.handle(serverPC.LocalAddr(), query)
+
+	var torEv *types.Event
+	for i := range em.events {
+		if em.events[i].Type == "tor_control" {
+			torEv = &em.events[i]
+			break
+		}
+	}
+	if torEv == nil {
+		t.Fatalf("expected a tor_control event, got %d events", len(em.events))
+	}
+	if got := torEv.Fields["vector"]; got != "onion_dns" {
+		t.Errorf("expected vector onion_dns, got %v", got)
+	}
+	if got := torEv.Fields["decision"]; got != "deny" {
+		t.Errorf("expected decision deny, got %v", got)
+	}
+	if got := torEv.Fields["target"]; got != "abcdefghij.onion" {
+		t.Errorf("expected target abcdefghij.onion, got %v", got)
+	}
+}

--- a/internal/netmonitor/proxy.go
+++ b/internal/netmonitor/proxy.go
@@ -17,6 +17,7 @@ import (
 	dbevents "github.com/agentsh/agentsh/internal/db/events"
 	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/tor"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/google/uuid"
 )
@@ -388,6 +389,17 @@ func (p *Proxy) handleHTTP(client net.Conn, req *http.Request) error {
 	ctx := req.Context()
 	dec := p.checkNetwork(ctx, host, port)
 	dec = p.maybeApprove(ctx, commandID, dec, "network", host)
+	if dec.Tor != nil && p.emit != nil {
+		vector := dec.Tor.Vector
+		if vector == tor.VectorOnionDNS {
+			vector = tor.VectorOnionHTTP
+		}
+		tev := tor.BuildControlEvent(p.sessionID, commandID, 0, tor.Verdict{
+			Vector: vector, Mode: dec.Tor.Mode, Decision: dec.Tor.Decision, Target: dec.Tor.Target,
+		})
+		_ = p.emit.AppendEvent(context.Background(), tev)
+		p.emit.Publish(tev)
+	}
 	connectEv := p.emitNetEvent(context.Background(), "net_connect", commandID, host, host, port, dec, map[string]any{
 		"method":      req.Method,
 		"resolved_ip": resolvedIP,

--- a/internal/netmonitor/proxy_test.go
+++ b/internal/netmonitor/proxy_test.go
@@ -3,6 +3,7 @@ package netmonitor
 import (
 	"context"
 	"net"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,11 +11,13 @@ import (
 	"time"
 
 	"github.com/agentsh/agentsh/internal/approvals"
+	"github.com/agentsh/agentsh/internal/config"
 	dbevents "github.com/agentsh/agentsh/internal/db/events"
 	dbservice "github.com/agentsh/agentsh/internal/db/service"
 	"github.com/agentsh/agentsh/internal/mcpregistry"
 	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/tor"
 	"github.com/agentsh/agentsh/pkg/types"
 )
 
@@ -807,4 +810,88 @@ func TestMCPConnectionTaggingNilEmitter(t *testing.T) {
 
 	// Should not panic with nil emitter
 	emitMCPConnectionIfMatched(context.Background(), sess, nil, "test-session", "cmd", "mcp.example.com", "mcp.example.com:443", 443)
+}
+
+// TestProxyHandleHTTPOnionRemapsVectorToOnionHTTP drives handleHTTP against a
+// .onion host and asserts the emitted tor_control event carries
+// vector == "onion_http". CheckNetworkCtx tags the Tor verdict with the
+// onion_dns vector (EvalOnionName always returns VectorOnionDNS); the HTTP
+// proxy path in handleHTTP (proxy.go:392-401) is the layer responsible for
+// relabeling it to onion_http. This guards that remap — the only non-trivial
+// logic among the five emit sites.
+func TestProxyHandleHTTPOnionRemapsVectorToOnionHTTP(t *testing.T) {
+	// Deny-by-default Tor policy with the onion vector on (zero TorConfig
+	// resolves to enabled, mode=deny, all vectors true).
+	torPol, err := tor.New(config.ResolveTorConfig(config.TorConfig{}))
+	if err != nil {
+		t.Fatalf("tor.New: %v", err)
+	}
+
+	// Allow-all base policy so the only deny comes from the Tor checker.
+	basePolicy := &policy.Policy{
+		Version: 1,
+		Name:    "allow-all",
+		NetworkRules: []policy.NetworkRule{
+			{Name: "allow-all", Domains: []string{"*"}, Decision: "allow"},
+		},
+	}
+	engine, err := policy.NewEngine(basePolicy, false, false)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	engine.SetTorPolicy(&tor.PolicyAdapter{Policy: torPol})
+
+	em := &stubEmitter{}
+	p := &Proxy{sessionID: "tor-session", policy: engine, emit: em}
+
+	// EvalOnionName matches any .onion suffix; use a syntactically valid
+	// v3-style onion host.
+	const onionHost = "abcdefghij234567abcdefghij234567abcdefghij234567abcdefghij234567.onion"
+	req := httptest.NewRequest("GET", "http://"+onionHost+"/", nil)
+
+	client, server := net.Pipe()
+
+	done := make(chan struct{})
+	go func() {
+		_ = p.handleHTTP(server, req)
+		close(done)
+	}()
+
+	// Drain the client side so handleHTTP's 403 write doesn't block the pipe.
+	go func() {
+		_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+		buf := make([]byte, 512)
+		for {
+			if _, e := client.Read(buf); e != nil {
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleHTTP did not return")
+	}
+	client.Close()
+
+	var torEv *types.Event
+	for i := range em.events {
+		if em.events[i].Type == "tor_control" {
+			torEv = &em.events[i]
+			break
+		}
+	}
+	if torEv == nil {
+		t.Fatalf("no tor_control event emitted; got %d events: %+v", len(em.events), em.events)
+	}
+	if torEv.Type != "tor_control" {
+		t.Fatalf("event type = %q, want tor_control", torEv.Type)
+	}
+	if got := torEv.Fields["vector"]; got != "onion_http" {
+		t.Fatalf("vector = %v, want onion_http (the handleHTTP remap from onion_dns)", got)
+	}
+	if got := torEv.Fields["decision"]; got != "deny" {
+		t.Fatalf("decision = %v, want deny", got)
+	}
 }

--- a/internal/netmonitor/transparent_tcp.go
+++ b/internal/netmonitor/transparent_tcp.go
@@ -18,6 +18,7 @@ import (
 	dbevents "github.com/agentsh/agentsh/internal/db/events"
 	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/tor"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/google/uuid"
 	"golang.org/x/sys/unix"
@@ -133,6 +134,13 @@ func (t *TransparentTCP) handle(conn net.Conn) error {
 	}
 
 	dec := t.checkConnectNetwork(context.Background(), commandID, domain, redirectHostPort, dstIP, dstPort, redirectResult)
+	if dec.Tor != nil && t.emit != nil {
+		tev := tor.BuildControlEvent(t.sessionID, commandID, 0, tor.Verdict{
+			Vector: dec.Tor.Vector, Mode: dec.Tor.Mode, Decision: dec.Tor.Decision, Target: dec.Tor.Target,
+		})
+		_ = t.emit.AppendEvent(context.Background(), tev)
+		t.emit.Publish(tev)
+	}
 	eventFields := map[string]any{}
 	if redirectResult != nil {
 		if redirectResult.RedirectTo != "" {

--- a/internal/ocsf/registry.go
+++ b/internal/ocsf/registry.go
@@ -66,6 +66,7 @@ var pendingTypes = map[string]struct{}{
 	"transparent_net_failed": {},
 	"transparent_net_ready":  {},
 	"transparent_net_setup":  {},
+	"tor_control":            {},
 	"mcp_network_connection": {},
 	// HTTP Activity (4002) — Task 19
 	"http":                       {},

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -35,6 +35,24 @@ type ThreatChecker interface {
 	Check(domain string) (ThreatCheckResult, bool)
 }
 
+// TorVerdict mirrors tor.Verdict at the policy layer (avoids a policy→tor
+// import). tor.PolicyAdapter translates between the two.
+type TorVerdict struct {
+	Vector   string
+	Mode     string
+	Decision string // "deny" or "audit"
+	Target   string
+}
+
+// TorChecker is the optional Tor coordinator. internal/tor.PolicyAdapter
+// satisfies it. All methods return (verdict, true) only on a Tor match
+// the caller should act on (deny short-circuits; audit attaches+continues).
+type TorChecker interface {
+	EvalExecve(filename string, argv []string) (TorVerdict, bool)
+	EvalConnect(ip net.IP, port int) (TorVerdict, bool)
+	EvalOnionName(host string) (TorVerdict, bool)
+}
+
 type Engine struct {
 	policy           *Policy
 	enforceApprovals bool
@@ -71,6 +89,9 @@ type Engine struct {
 	// Optional threat feed store for domain checking
 	threatStore  ThreatChecker
 	threatAction string
+
+	// Optional Tor coordinator (deny-by-default Tor controls).
+	torChecker TorChecker
 }
 
 type Limits struct {
@@ -141,7 +162,8 @@ type Decision struct {
 	EnvPolicy         ResolvedEnvPolicy
 	ThreatFeed        string
 	ThreatMatch       string
-	ThreatAction      string // "deny" or "audit" — set when a threat feed matched
+	ThreatAction      string      // "deny" or "audit" — set when a threat feed matched
+	Tor               *TorVerdict // non-nil when a Tor vector matched (deny or audit)
 }
 
 func NewEngine(p *Policy, enforceApprovals bool, enforceRedirects bool) (*Engine, error) {
@@ -403,6 +425,11 @@ func (e *Engine) SetThreatStore(store ThreatChecker, action string) {
 	default:
 		e.threatAction = "deny"
 	}
+}
+
+// SetTorPolicy installs the optional Tor coordinator. Pass nil to disable.
+func (e *Engine) SetTorPolicy(tc TorChecker) {
+	e.torChecker = tc
 }
 
 // expandPolicy creates a copy of the policy with all variables expanded.

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -522,7 +522,18 @@ func (e *Engine) Limits() Limits {
 
 // CheckNetworkIP evaluates network_rules using a known destination IP (no DNS resolution).
 // If domain is empty, only CIDR/port-based rules can match.
-func (e *Engine) CheckNetworkIP(domain string, ip net.IP, port int) Decision {
+func (e *Engine) CheckNetworkIP(domain string, ip net.IP, port int) (dec Decision) {
+	if e.torChecker != nil {
+		if v, ok := e.torChecker.EvalConnect(ip, port); ok {
+			tv := v
+			if v.Decision == "deny" {
+				d := e.wrapDecision(string(types.DecisionDeny), "tor:"+v.Vector, "blocked by Tor policy", nil)
+				d.Tor = &tv
+				return d
+			}
+			defer func() { dec.Tor = &tv }()
+		}
+	}
 	if e.policy == nil {
 		return Decision{PolicyDecision: types.DecisionAllow, EffectiveDecision: types.DecisionAllow}
 	}
@@ -533,7 +544,7 @@ func (e *Engine) CheckNetworkIP(domain string, ip net.IP, port int) Decision {
 	if e.threatStore != nil && domain != "" {
 		if result, matched := e.threatStore.Check(domain); matched {
 			if e.threatAction == "deny" {
-				dec := e.wrapDecision("deny", "threat-feed:"+result.FeedName,
+				dec = e.wrapDecision("deny", "threat-feed:"+result.FeedName,
 					"domain matched threat feed: "+result.FeedName+" (matched: "+result.MatchedDomain+")", nil)
 				dec.ThreatFeed = result.FeedName
 				dec.ThreatMatch = result.MatchedDomain
@@ -590,7 +601,7 @@ func (e *Engine) CheckNetworkIP(domain string, ip net.IP, port int) Decision {
 			}
 		}
 
-		dec := e.wrapDecision(r.rule.Decision, r.rule.Name, r.rule.Message, nil)
+		dec = e.wrapDecision(r.rule.Decision, r.rule.Name, r.rule.Message, nil)
 		if threatResult != nil {
 			dec.ThreatFeed = threatResult.FeedName
 			dec.ThreatMatch = threatResult.MatchedDomain
@@ -599,7 +610,7 @@ func (e *Engine) CheckNetworkIP(domain string, ip net.IP, port int) Decision {
 		return dec
 	}
 
-	dec := e.wrapDecision(string(types.DecisionDeny), "default-deny-network", "", nil)
+	dec = e.wrapDecision(string(types.DecisionDeny), "default-deny-network", "", nil)
 	if threatResult != nil {
 		dec.ThreatFeed = threatResult.FeedName
 		dec.ThreatMatch = threatResult.MatchedDomain
@@ -1080,15 +1091,26 @@ func (e *Engine) CheckNetwork(domain string, port int) Decision {
 // CheckNetworkCtx evaluates network_rules against a domain and port with context support.
 // If a rule requires CIDR matching and the domain is not an IP literal, DNS resolution
 // will be performed using the provided context for cancellation.
-func (e *Engine) CheckNetworkCtx(ctx context.Context, domain string, port int) Decision {
+func (e *Engine) CheckNetworkCtx(ctx context.Context, domain string, port int) (dec Decision) {
 	domain = strings.ToLower(strings.TrimSpace(domain))
+	if e.torChecker != nil {
+		if v, ok := e.torChecker.EvalOnionName(domain); ok {
+			tv := v
+			if v.Decision == "deny" {
+				d := e.wrapDecision(string(types.DecisionDeny), "tor:"+v.Vector, "blocked by Tor policy", nil)
+				d.Tor = &tv
+				return d
+			}
+			defer func() { dec.Tor = &tv }()
+		}
+	}
 
 	// Threat feed pre-check (skip for empty domain, consistent with CheckNetworkIP).
 	var threatResult *ThreatCheckResult
 	if e.threatStore != nil && domain != "" {
 		if entry, matched := e.threatStore.Check(domain); matched {
 			if e.threatAction == "deny" {
-				dec := e.wrapDecision("deny", "threat-feed:"+entry.FeedName,
+				dec = e.wrapDecision("deny", "threat-feed:"+entry.FeedName,
 					"domain matched threat feed: "+entry.FeedName+" (matched: "+entry.MatchedDomain+")", nil)
 				dec.ThreatFeed = entry.FeedName
 				dec.ThreatMatch = entry.MatchedDomain
@@ -1168,7 +1190,7 @@ func (e *Engine) CheckNetworkCtx(ctx context.Context, domain string, port int) D
 		}
 
 		// If rule has no selectors, it matches (e.g., approve unknown https by port only).
-		dec := e.wrapDecision(r.rule.Decision, r.rule.Name, r.rule.Message, nil)
+		dec = e.wrapDecision(r.rule.Decision, r.rule.Name, r.rule.Message, nil)
 		if threatResult != nil {
 			dec.ThreatFeed = threatResult.FeedName
 			dec.ThreatMatch = threatResult.MatchedDomain
@@ -1177,7 +1199,7 @@ func (e *Engine) CheckNetworkCtx(ctx context.Context, domain string, port int) D
 		return dec
 	}
 
-	dec := e.wrapDecision(string(types.DecisionDeny), "default-deny-network", "", nil)
+	dec = e.wrapDecision(string(types.DecisionDeny), "default-deny-network", "", nil)
 	if threatResult != nil {
 		dec.ThreatFeed = threatResult.FeedName
 		dec.ThreatMatch = threatResult.MatchedDomain
@@ -1381,7 +1403,19 @@ func (e *Engine) EvaluateConnectRedirect(hostPort string) *ConnectRedirectResult
 // CheckExecve evaluates an execve call against command rules with depth context support.
 // Returns the decision from the first matching rule, or default deny if none match.
 // The depth parameter represents the ancestry depth: 0 = direct (user-typed), 1+ = nested (script-spawned).
-func (e *Engine) CheckExecve(filename string, argv []string, depth int) Decision {
+func (e *Engine) CheckExecve(filename string, argv []string, depth int) (dec Decision) {
+	if e.torChecker != nil {
+		if v, ok := e.torChecker.EvalExecve(filename, argv); ok {
+			tv := v
+			if v.Decision == "deny" {
+				d := e.wrapDecision(string(types.DecisionDeny), "tor:"+v.Vector, "blocked by Tor policy", nil)
+				d.Tor = &tv
+				d.EnvPolicy = MergeEnvPolicy(e.policy.EnvPolicy, CommandRule{})
+				return d
+			}
+			defer func() { dec.Tor = &tv }() // audit: attach, don't loosen
+		}
+	}
 	cmdLower := strings.ToLower(filename)
 	cmdBase := strings.ToLower(filepath.Base(filename))
 
@@ -1450,13 +1484,13 @@ func (e *Engine) CheckExecve(filename string, argv []string, depth int) Decision
 			}
 		}
 
-		dec := e.wrapDecision(r.rule.Decision, r.rule.Name, r.rule.Message, r.rule.RedirectTo)
+		dec = e.wrapDecision(r.rule.Decision, r.rule.Name, r.rule.Message, r.rule.RedirectTo)
 		dec.EnvPolicy = MergeEnvPolicy(e.policy.EnvPolicy, r.rule)
 		return dec
 	}
 
 	// Default deny (consistent with other Check* methods)
-	dec := e.wrapDecision(string(types.DecisionDeny), "default-deny-execve", "", nil)
+	dec = e.wrapDecision(string(types.DecisionDeny), "default-deny-execve", "", nil)
 	dec.EnvPolicy = MergeEnvPolicy(e.policy.EnvPolicy, CommandRule{})
 	return dec
 }

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -1104,6 +1104,19 @@ func (e *Engine) CheckNetworkCtx(ctx context.Context, domain string, port int) (
 			defer func() { dec.Tor = &tv }() // audit: attach, don't loosen (returns below must assign named dec)
 		}
 	}
+	if e.torChecker != nil {
+		if ip := net.ParseIP(domain); ip != nil {
+			if v, ok := e.torChecker.EvalConnect(ip, port); ok {
+				tv := v
+				if v.Decision == "deny" {
+					d := e.wrapDecision(string(types.DecisionDeny), "tor:"+v.Vector, "blocked by Tor policy", nil)
+					d.Tor = &tv
+					return d
+				}
+				defer func() { dec.Tor = &tv }() // audit: attach, don't loosen (returns below must assign named dec)
+			}
+		}
+	}
 
 	// Threat feed pre-check (skip for empty domain, consistent with CheckNetworkIP).
 	var threatResult *ThreatCheckResult

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -531,7 +531,7 @@ func (e *Engine) CheckNetworkIP(domain string, ip net.IP, port int) (dec Decisio
 				d.Tor = &tv
 				return d
 			}
-			defer func() { dec.Tor = &tv }()
+			defer func() { dec.Tor = &tv }() // audit: attach, don't loosen (returns below must assign named dec)
 		}
 	}
 	if e.policy == nil {
@@ -1101,7 +1101,7 @@ func (e *Engine) CheckNetworkCtx(ctx context.Context, domain string, port int) (
 				d.Tor = &tv
 				return d
 			}
-			defer func() { dec.Tor = &tv }()
+			defer func() { dec.Tor = &tv }() // audit: attach, don't loosen (returns below must assign named dec)
 		}
 	}
 

--- a/internal/policy/engine_tor_test.go
+++ b/internal/policy/engine_tor_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -85,6 +86,50 @@ func TestCheckNetworkCtx_TorOnionDeny(t *testing.T) {
 	dec := e.CheckNetworkCtx(nil, "x.onion", 53)
 	if dec.EffectiveDecision != types.DecisionDeny || dec.Tor == nil {
 		t.Fatalf("want onion deny, got dec=%+v tor=%+v", dec.EffectiveDecision, dec.Tor)
+	}
+}
+
+func TestCheckNetworkCtx_TorDenySocksPort_LivePath(t *testing.T) {
+	// The ptrace connect path goes through CheckNetworkCtx with an IP-literal
+	// domain — NOT CheckNetworkIP. This is the path that was Tor-blind.
+	e := newAllowAllEngine(t)
+	e.SetTorPolicy(&fakeTor{connect: &TorVerdict{Vector: "socks_port", Mode: "deny", Decision: "deny", Target: "127.0.0.1:9050"}})
+	dec := e.CheckNetworkCtx(context.Background(), "127.0.0.1", 9050)
+	if dec.EffectiveDecision != types.DecisionDeny || dec.Tor == nil || dec.Tor.Vector != "socks_port" {
+		t.Fatalf("want socks_port deny via CheckNetworkCtx, got dec=%+v tor=%+v", dec.EffectiveDecision, dec.Tor)
+	}
+}
+
+func TestCheckNetworkCtx_TorDenyRelayIP_LivePath(t *testing.T) {
+	e := newAllowAllEngine(t)
+	e.SetTorPolicy(&fakeTor{connect: &TorVerdict{Vector: "relay_ip", Mode: "deny", Decision: "deny", Target: "1.2.3.4:443"}})
+	dec := e.CheckNetworkCtx(context.Background(), "1.2.3.4", 443)
+	if dec.EffectiveDecision != types.DecisionDeny || dec.Tor == nil || dec.Tor.Vector != "relay_ip" {
+		t.Fatalf("want relay_ip deny via CheckNetworkCtx, got dec=%+v tor=%+v", dec.EffectiveDecision, dec.Tor)
+	}
+}
+
+func TestCheckNetworkCtx_TorAuditConnectAttachesOnAllow(t *testing.T) {
+	// audit must attach .Tor without changing an allow, on the connect path.
+	e := newAllowAllEngine(t) // allows port 9050
+	e.SetTorPolicy(&fakeTor{connect: &TorVerdict{Vector: "relay_ip", Mode: "audit", Decision: "audit", Target: "1.2.3.4:9050"}})
+	dec := e.CheckNetworkCtx(context.Background(), "1.2.3.4", 9050)
+	if dec.EffectiveDecision != types.DecisionAllow {
+		t.Fatalf("audit must not change allow; got %v", dec.EffectiveDecision)
+	}
+	if dec.Tor == nil || dec.Tor.Decision != "audit" {
+		t.Fatalf("audit verdict must attach on connect-allow; got %+v", dec.Tor)
+	}
+}
+
+func TestCheckNetworkCtx_TorOnionStillWorks(t *testing.T) {
+	// Regression guard: the onion pre-check must still fire (the new connect
+	// block must not shadow it for non-IP domains).
+	e := newAllowAllEngine(t)
+	e.SetTorPolicy(&fakeTor{onion: &TorVerdict{Vector: "onion_dns", Mode: "deny", Decision: "deny", Target: "x.onion"}})
+	dec := e.CheckNetworkCtx(context.Background(), "x.onion", 53)
+	if dec.EffectiveDecision != types.DecisionDeny || dec.Tor == nil || dec.Tor.Vector != "onion_dns" {
+		t.Fatalf("onion deny must still work, got dec=%+v tor=%+v", dec.EffectiveDecision, dec.Tor)
 	}
 }
 

--- a/internal/policy/engine_tor_test.go
+++ b/internal/policy/engine_tor_test.go
@@ -1,0 +1,89 @@
+package policy
+
+import (
+	"net"
+	"testing"
+
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+type fakeTor struct {
+	execve, connect, onion *TorVerdict
+}
+
+func (f *fakeTor) EvalExecve(string, []string) (TorVerdict, bool) {
+	if f.execve == nil {
+		return TorVerdict{}, false
+	}
+	return *f.execve, true
+}
+func (f *fakeTor) EvalConnect(net.IP, int) (TorVerdict, bool) {
+	if f.connect == nil {
+		return TorVerdict{}, false
+	}
+	return *f.connect, true
+}
+func (f *fakeTor) EvalOnionName(string) (TorVerdict, bool) {
+	if f.onion == nil {
+		return TorVerdict{}, false
+	}
+	return *f.onion, true
+}
+
+func newAllowAllEngine(t *testing.T) *Engine {
+	t.Helper()
+	// A policy that would ALLOW everything, so we can prove Tor overrides it.
+	p := &Policy{
+		NetworkRules: []NetworkRule{{Name: "allow-all", Ports: []int{9050}, Decision: "allow"}},
+		CommandRules: []CommandRule{{Name: "allow-all", Decision: "allow"}},
+	}
+	e, err := NewEngine(p, false, false)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	return e
+}
+
+func TestCheckExecve_TorDenyOverridesAllow(t *testing.T) {
+	e := newAllowAllEngine(t)
+	e.SetTorPolicy(&fakeTor{execve: &TorVerdict{Vector: "process", Mode: "deny", Decision: "deny", Target: "/usr/bin/tor"}})
+	dec := e.CheckExecve("/usr/bin/tor", []string{"tor"}, 0)
+	if dec.EffectiveDecision != types.DecisionDeny {
+		t.Fatalf("EffectiveDecision=%v, want deny", dec.EffectiveDecision)
+	}
+	if dec.Tor == nil || dec.Tor.Vector != "process" {
+		t.Fatalf("dec.Tor missing/wrong: %+v", dec.Tor)
+	}
+}
+
+func TestCheckNetworkIP_TorDenySocksPort(t *testing.T) {
+	e := newAllowAllEngine(t)
+	e.SetTorPolicy(&fakeTor{connect: &TorVerdict{Vector: "socks_port", Mode: "deny", Decision: "deny", Target: "127.0.0.1:9050"}})
+	dec := e.CheckNetworkIP("", net.ParseIP("127.0.0.1"), 9050)
+	if dec.EffectiveDecision != types.DecisionDeny || dec.Tor == nil {
+		t.Fatalf("want tor deny, got dec=%+v tor=%+v", dec.EffectiveDecision, dec.Tor)
+	}
+}
+
+func TestCheckNetworkIP_TorAuditDoesNotLoosenUserDeny(t *testing.T) {
+	// Policy denies by default (no matching rule for this IP/port).
+	p := &Policy{NetworkRules: []NetworkRule{{Name: "deny-all", Decision: "deny"}}}
+	e, _ := NewEngine(p, false, false)
+	e.SetTorPolicy(&fakeTor{connect: &TorVerdict{Vector: "relay_ip", Mode: "audit", Decision: "audit", Target: "1.2.3.4:443"}})
+	dec := e.CheckNetworkIP("", net.ParseIP("1.2.3.4"), 443)
+	if dec.EffectiveDecision != types.DecisionDeny {
+		t.Fatalf("audit must not loosen a deny; got %v", dec.EffectiveDecision)
+	}
+	if dec.Tor == nil || dec.Tor.Decision != "audit" {
+		t.Fatalf("audit verdict must attach; got %+v", dec.Tor)
+	}
+}
+
+func TestCheckNetworkCtx_TorOnionDeny(t *testing.T) {
+	e := newAllowAllEngine(t)
+	e.SetTorPolicy(&fakeTor{onion: &TorVerdict{Vector: "onion_dns", Mode: "deny", Decision: "deny", Target: "x.onion"}})
+	dec := e.CheckNetworkCtx(nil, "x.onion", 53)
+	if dec.EffectiveDecision != types.DecisionDeny || dec.Tor == nil {
+		t.Fatalf("want onion deny, got dec=%+v tor=%+v", dec.EffectiveDecision, dec.Tor)
+	}
+}

--- a/internal/policy/engine_tor_test.go
+++ b/internal/policy/engine_tor_test.go
@@ -87,3 +87,17 @@ func TestCheckNetworkCtx_TorOnionDeny(t *testing.T) {
 		t.Fatalf("want onion deny, got dec=%+v tor=%+v", dec.EffectiveDecision, dec.Tor)
 	}
 }
+
+func TestCheckNetworkIP_TorAuditAttachesOnAllow(t *testing.T) {
+	// Audit verdict over an allow-all policy: decision stays allow, but the
+	// verdict must ride along via the deferred attach (the common case).
+	e := newAllowAllEngine(t)
+	e.SetTorPolicy(&fakeTor{connect: &TorVerdict{Vector: "relay_ip", Mode: "audit", Decision: "audit", Target: "1.2.3.4:443"}})
+	dec := e.CheckNetworkIP("", net.ParseIP("1.2.3.4"), 9050)
+	if dec.EffectiveDecision != types.DecisionAllow {
+		t.Fatalf("audit must not change an allow; got %v", dec.EffectiveDecision)
+	}
+	if dec.Tor == nil || dec.Tor.Decision != "audit" {
+		t.Fatalf("audit verdict must attach on allow; got %+v", dec.Tor)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -43,6 +43,7 @@ import (
 	"github.com/agentsh/agentsh/internal/store/sqlite"
 	"github.com/agentsh/agentsh/internal/store/webhook"
 	"github.com/agentsh/agentsh/internal/threatfeed"
+	"github.com/agentsh/agentsh/internal/tor"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
@@ -77,6 +78,8 @@ type Server struct {
 
 	threatSyncer *threatfeed.Syncer
 	threatStore  *threatfeed.Store
+
+	torSyncer *tor.Syncer
 
 	skillcheckDaemon *skillcheck.Daemon // nil when skillcheck.enabled=false
 
@@ -195,6 +198,24 @@ func New(cfg *config.Config) (*Server, error) {
 		}
 		engine.SetThreatStore(&threatfeed.PolicyAdapter{Store: threatStore}, cfg.ThreatFeeds.Action)
 		threatSyncer = threatfeed.NewSyncer(threatStore, cfg.ThreatFeeds, slog.Default())
+	}
+
+	torCfg := config.ResolveTorConfig(cfg.Tor)
+	var torSyncer *tor.Syncer
+	if torCfg.Enabled {
+		// Default the relay-feed cache dir alongside the threat-feed cache.
+		if torCfg.RelayFeed.Enabled && torCfg.RelayFeed.CacheDir == "" {
+			torCfg.RelayFeed.CacheDir = filepath.Join(config.GetDataDir(), "tor-relays")
+		}
+		torPol, err := tor.New(torCfg)
+		if err != nil {
+			return nil, fmt.Errorf("tor policy: %w", err)
+		}
+		engine.SetTorPolicy(&tor.PolicyAdapter{Policy: torPol})
+		slog.Info("tor access control enabled", "mode", torCfg.Mode)
+		if torPol.RelayFeedEnabled() {
+			torSyncer = tor.NewSyncer(torPol, slog.Default())
+		}
 	}
 
 	limits := engine.Limits()
@@ -758,6 +779,7 @@ func New(cfg *config.Config) (*Server, error) {
 		reapInterval:     reapInterval,
 		threatSyncer:     threatSyncer,
 		threatStore:      threatStore,
+		torSyncer:        torSyncer,
 		skillcheckDaemon: skillcheckDaemon,
 		app:              app,
 		kmsProvider:      kmsProvider,
@@ -1061,6 +1083,20 @@ func (s *Server) Run(ctx context.Context) error {
 		}()
 	}
 
+	var torSyncerDone chan struct{}
+	if s.torSyncer != nil {
+		torSyncerDone = make(chan struct{})
+		go func() {
+			defer close(torSyncerDone)
+			defer func() {
+				if r := recover(); r != nil {
+					slog.Error("tor syncer panicked", "panic", r)
+				}
+			}()
+			s.torSyncer.Run(ctx)
+		}()
+	}
+
 	var skillcheckDone chan struct{}
 	if s.skillcheckDaemon != nil {
 		skillcheckDone = make(chan struct{})
@@ -1123,6 +1159,9 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 		if syncerDone != nil {
 			<-syncerDone
+		}
+		if torSyncerDone != nil {
+			<-torSyncerDone
 		}
 		if skillcheckDone != nil {
 			<-skillcheckDone

--- a/internal/tor/adapter.go
+++ b/internal/tor/adapter.go
@@ -1,0 +1,41 @@
+package tor
+
+import (
+	"net"
+
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+// PolicyAdapter adapts *Policy to policy.TorChecker (policy→tor would be
+// an import cycle, so the bridge lives here, like threatfeed.PolicyAdapter).
+type PolicyAdapter struct {
+	Policy *Policy
+}
+
+func conv(v Verdict, ok bool) (policy.TorVerdict, bool) {
+	if !ok {
+		return policy.TorVerdict{}, false
+	}
+	return policy.TorVerdict{Vector: v.Vector, Mode: v.Mode, Decision: v.Decision, Target: v.Target}, true
+}
+
+func (a *PolicyAdapter) EvalExecve(filename string, argv []string) (policy.TorVerdict, bool) {
+	if a == nil || a.Policy == nil {
+		return policy.TorVerdict{}, false
+	}
+	return conv(a.Policy.EvalExecve(filename, argv))
+}
+
+func (a *PolicyAdapter) EvalConnect(ip net.IP, port int) (policy.TorVerdict, bool) {
+	if a == nil || a.Policy == nil {
+		return policy.TorVerdict{}, false
+	}
+	return conv(a.Policy.EvalConnect(ip, port))
+}
+
+func (a *PolicyAdapter) EvalOnionName(host string) (policy.TorVerdict, bool) {
+	if a == nil || a.Policy == nil {
+		return policy.TorVerdict{}, false
+	}
+	return conv(a.Policy.EvalOnionName(host))
+}

--- a/internal/tor/adapter_test.go
+++ b/internal/tor/adapter_test.go
@@ -1,0 +1,18 @@
+package tor
+
+import (
+	"net"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/policy"
+)
+
+func TestPolicyAdapter_ImplementsTorChecker(t *testing.T) {
+	p, _ := New(config.ResolveTorConfig(config.TorConfig{}))
+	var tc policy.TorChecker = &PolicyAdapter{Policy: p} // compile-time check
+	v, ok := tc.EvalConnect(net.ParseIP("127.0.0.1"), 9050)
+	if !ok || v.Vector != "socks_port" || v.Decision != "deny" {
+		t.Fatalf("adapter EvalConnect wrong: ok=%v v=%+v", ok, v)
+	}
+}

--- a/internal/tor/event.go
+++ b/internal/tor/event.go
@@ -1,0 +1,28 @@
+package tor
+
+import (
+	"time"
+
+	"github.com/agentsh/agentsh/pkg/types"
+	"github.com/google/uuid"
+)
+
+// BuildControlEvent constructs a tor_control audit event from a Verdict.
+// Callers append+publish it via their session emitter.
+func BuildControlEvent(sessionID, commandID string, pid int, v Verdict) types.Event {
+	return types.Event{
+		ID:        uuid.NewString(),
+		Timestamp: time.Now().UTC(),
+		Type:      "tor_control",
+		SessionID: sessionID,
+		CommandID: commandID,
+		PID:       pid,
+		Fields: map[string]any{
+			"vector":   v.Vector,
+			"mode":     v.Mode,
+			"decision": v.Decision,
+			"target":   v.Target,
+			"rule":     "tor",
+		},
+	}
+}

--- a/internal/tor/event_test.go
+++ b/internal/tor/event_test.go
@@ -1,0 +1,21 @@
+package tor
+
+import "testing"
+
+func TestBuildControlEvent(t *testing.T) {
+	ev := BuildControlEvent("sess-1", "cmd-1", 4242, Verdict{
+		Vector: VectorProcess, Mode: ModeDeny, Decision: ModeDeny, Target: "/usr/bin/tor",
+	})
+	if ev.Type != "tor_control" {
+		t.Fatalf("Type=%q, want tor_control", ev.Type)
+	}
+	if ev.SessionID != "sess-1" || ev.CommandID != "cmd-1" {
+		t.Fatal("session/command not propagated")
+	}
+	if ev.Fields["vector"] != "process" || ev.Fields["decision"] != "deny" {
+		t.Fatalf("fields wrong: %+v", ev.Fields)
+	}
+	if ev.PID != 4242 {
+		t.Fatalf("PID=%d, want 4242", ev.PID)
+	}
+}

--- a/internal/tor/event_test.go
+++ b/internal/tor/event_test.go
@@ -15,7 +15,13 @@ func TestBuildControlEvent(t *testing.T) {
 	if ev.Fields["vector"] != "process" || ev.Fields["decision"] != "deny" {
 		t.Fatalf("fields wrong: %+v", ev.Fields)
 	}
+	if ev.Fields["mode"] != "deny" || ev.Fields["target"] != "/usr/bin/tor" || ev.Fields["rule"] != "tor" {
+		t.Fatalf("fields mode/target/rule wrong: %+v", ev.Fields)
+	}
 	if ev.PID != 4242 {
 		t.Fatalf("PID=%d, want 4242", ev.PID)
+	}
+	if ev.ID == "" || ev.Timestamp.IsZero() {
+		t.Fatalf("ID/Timestamp not populated: id=%q ts=%v", ev.ID, ev.Timestamp)
 	}
 }

--- a/internal/tor/feed.go
+++ b/internal/tor/feed.go
@@ -66,7 +66,7 @@ type Syncer struct {
 	cacheDir string
 	client   *http.Client
 	logger   *slog.Logger
-	lastGood []string
+	lastGood map[string][]string // per-source ("local:"+path for files) last-good IPs
 }
 
 // NewSyncer builds a relay-feed syncer for the given Policy.
@@ -87,6 +87,7 @@ func NewSyncer(pol *Policy, logger *slog.Logger) *Syncer {
 		cacheDir: cfg.CacheDir,
 		client:   &http.Client{Timeout: 60 * time.Second},
 		logger:   logger,
+		lastGood: make(map[string][]string),
 	}
 }
 
@@ -95,7 +96,6 @@ func NewSyncer(pol *Policy, logger *slog.Logger) *Syncer {
 func (s *Syncer) Run(ctx context.Context) {
 	if cached := s.loadCache(); len(cached) > 0 {
 		s.pol.SetRelays(buildSet(cached))
-		s.lastGood = cached
 		s.logger.Info("tor relay cache loaded", "ips", len(cached))
 	}
 	s.sync(ctx)
@@ -112,34 +112,41 @@ func (s *Syncer) Run(ctx context.Context) {
 }
 
 func (s *Syncer) sync(ctx context.Context) {
+	if s.lastGood == nil {
+		s.lastGood = make(map[string][]string)
+	}
 	var all []string
-	anySucceeded := false
 	for _, src := range s.sources {
 		ips, err := s.fetch(ctx, src)
 		if err != nil {
-			s.logger.Warn("tor relay feed fetch failed", "source", src, "error", err)
+			s.logger.Warn("tor relay feed fetch failed, using last-good",
+				"source", src, "error", err, "last_good_ips", len(s.lastGood[src]))
+			all = append(all, s.lastGood[src]...) // substitute this source's last-good
 			continue
 		}
-		anySucceeded = true
+		s.lastGood[src] = ips
 		all = append(all, ips...)
 	}
 	for _, path := range s.locals {
+		key := "local:" + path
 		ips, err := s.parseLocal(path)
 		if err != nil {
-			s.logger.Warn("tor relay local list failed", "path", path, "error", err)
+			s.logger.Warn("tor relay local list failed, using last-good",
+				"path", path, "error", err, "last_good_ips", len(s.lastGood[key]))
+			all = append(all, s.lastGood[key]...)
 			continue
 		}
-		anySucceeded = true
+		s.lastGood[key] = ips
 		all = append(all, ips...)
 	}
-	if !anySucceeded {
-		// Keep last-good (already applied); seed in Policy still enforces.
-		s.logger.Warn("tor relay feed: all sources failed, retaining cache+seed",
-			"cached_ips", len(s.lastGood))
+	// An empty merged result is a non-success: retain the prior applied set
+	// (and the immutable seed in Policy). Covers all-sources-failed AND a
+	// source returning 200 with zero relays.
+	if len(all) == 0 {
+		s.logger.Warn("tor relay feed: empty merged result, retaining prior set+seed")
 		return
 	}
 	s.pol.SetRelays(buildSet(all))
-	s.lastGood = all
 	if err := s.saveCache(all); err != nil {
 		s.logger.Warn("tor relay cache save failed", "error", err)
 	}

--- a/internal/tor/feed.go
+++ b/internal/tor/feed.go
@@ -1,0 +1,212 @@
+package tor
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/ipset"
+)
+
+const maxOnionooSize = 200 * 1024 * 1024 // 200 MB; onionoo details is large
+
+// parseOnionoo extracts relay host IPs from an onionoo `details` document.
+// Unparseable or_addresses entries are skipped (best-effort).
+func parseOnionoo(r io.Reader) ([]string, error) {
+	var doc struct {
+		Relays []struct {
+			OrAddresses []string `json:"or_addresses"`
+		} `json:"relays"`
+	}
+	if err := json.NewDecoder(r).Decode(&doc); err != nil {
+		return nil, err
+	}
+	var ips []string
+	for _, relay := range doc.Relays {
+		for _, addr := range relay.OrAddresses {
+			host, _, err := net.SplitHostPort(addr)
+			if err != nil {
+				continue
+			}
+			if net.ParseIP(host) == nil {
+				continue
+			}
+			ips = append(ips, host)
+		}
+	}
+	return ips, nil
+}
+
+// buildSet constructs an ipset.Set from a list of IP/CIDR strings,
+// skipping invalid entries.
+func buildSet(entries []string) *ipset.Set {
+	s := ipset.New()
+	for _, e := range entries {
+		_ = s.Add(e)
+	}
+	return s
+}
+
+// Syncer periodically refreshes a Policy's relay set from onionoo
+// sources + local lists. Modeled on internal/threatfeed.Syncer.
+type Syncer struct {
+	pol      *Policy
+	sources  []string
+	locals   []string
+	interval time.Duration
+	cacheDir string
+	client   *http.Client
+	logger   *slog.Logger
+	lastGood []string
+}
+
+// NewSyncer builds a relay-feed syncer for the given Policy.
+func NewSyncer(pol *Policy, logger *slog.Logger) *Syncer {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	cfg := pol.RelayFeedConfig()
+	interval := cfg.SyncInterval
+	if interval <= 0 {
+		interval = 6 * time.Hour
+	}
+	return &Syncer{
+		pol:      pol,
+		sources:  cfg.Sources,
+		locals:   cfg.LocalLists,
+		interval: interval,
+		cacheDir: cfg.CacheDir,
+		client:   &http.Client{Timeout: 60 * time.Second},
+		logger:   logger,
+	}
+}
+
+// Run loads the disk cache, performs an initial sync, then refreshes on
+// the configured interval until ctx is cancelled.
+func (s *Syncer) Run(ctx context.Context) {
+	if cached := s.loadCache(); len(cached) > 0 {
+		s.pol.SetRelays(buildSet(cached))
+		s.lastGood = cached
+		s.logger.Info("tor relay cache loaded", "ips", len(cached))
+	}
+	s.sync(ctx)
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.sync(ctx)
+		}
+	}
+}
+
+func (s *Syncer) sync(ctx context.Context) {
+	var all []string
+	anySucceeded := false
+	for _, src := range s.sources {
+		ips, err := s.fetch(ctx, src)
+		if err != nil {
+			s.logger.Warn("tor relay feed fetch failed", "source", src, "error", err)
+			continue
+		}
+		anySucceeded = true
+		all = append(all, ips...)
+	}
+	for _, path := range s.locals {
+		ips, err := s.parseLocal(path)
+		if err != nil {
+			s.logger.Warn("tor relay local list failed", "path", path, "error", err)
+			continue
+		}
+		anySucceeded = true
+		all = append(all, ips...)
+	}
+	if !anySucceeded {
+		// Keep last-good (already applied); seed in Policy still enforces.
+		s.logger.Warn("tor relay feed: all sources failed, retaining cache+seed",
+			"cached_ips", len(s.lastGood))
+		return
+	}
+	s.pol.SetRelays(buildSet(all))
+	s.lastGood = all
+	if err := s.saveCache(all); err != nil {
+		s.logger.Warn("tor relay cache save failed", "error", err)
+	}
+	s.logger.Info("tor relay feed synced", "ips", len(all))
+}
+
+func (s *Syncer) fetch(ctx context.Context, src string) ([]string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", src, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+	return parseOnionoo(&io.LimitedReader{R: resp.Body, N: maxOnionooSize})
+}
+
+func (s *Syncer) parseLocal(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var ips []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		ips = append(ips, line) // IP or CIDR; ipset.Add validates
+	}
+	return ips, sc.Err()
+}
+
+func (s *Syncer) cachePath() string {
+	dir := s.cacheDir
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, "tor-relays.txt")
+}
+
+func (s *Syncer) loadCache() []string {
+	p := s.cachePath()
+	if p == "" {
+		return nil
+	}
+	ips, err := s.parseLocal(p)
+	if err != nil {
+		return nil
+	}
+	return ips
+}
+
+func (s *Syncer) saveCache(ips []string) error {
+	p := s.cachePath()
+	if p == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(p, []byte(strings.Join(ips, "\n")), 0o644)
+}

--- a/internal/tor/feed.go
+++ b/internal/tor/feed.go
@@ -56,17 +56,33 @@ func buildSet(entries []string) *ipset.Set {
 	return s
 }
 
+// dedupeStrings returns in with duplicates removed, preserving first-seen order.
+func dedupeStrings(in []string) []string {
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}
+
 // Syncer periodically refreshes a Policy's relay set from onionoo
 // sources + local lists. Modeled on internal/threatfeed.Syncer.
 type Syncer struct {
-	pol      *Policy
-	sources  []string
-	locals   []string
-	interval time.Duration
-	cacheDir string
-	client   *http.Client
-	logger   *slog.Logger
-	lastGood map[string][]string // per-source ("local:"+path for files) last-good IPs
+	pol       *Policy
+	sources   []string
+	locals    []string
+	interval  time.Duration
+	cacheDir  string
+	client    *http.Client
+	logger    *slog.Logger
+	lastGood  map[string][]string // per-source ("local:"+path for files) last-good IPs
+	cacheSeed []string            // flat disk cache, folded in until every source proves fresh
+	proven    map[string]bool     // sources/locals that have succeeded ≥once this lifetime
 }
 
 // NewSyncer builds a relay-feed syncer for the given Policy.
@@ -88,6 +104,7 @@ func NewSyncer(pol *Policy, logger *slog.Logger) *Syncer {
 		client:   &http.Client{Timeout: 60 * time.Second},
 		logger:   logger,
 		lastGood: make(map[string][]string),
+		proven:   map[string]bool{},
 	}
 }
 
@@ -95,6 +112,7 @@ func NewSyncer(pol *Policy, logger *slog.Logger) *Syncer {
 // the configured interval until ctx is cancelled.
 func (s *Syncer) Run(ctx context.Context) {
 	if cached := s.loadCache(); len(cached) > 0 {
+		s.cacheSeed = cached
 		s.pol.SetRelays(buildSet(cached))
 		s.logger.Info("tor relay cache loaded", "ips", len(cached))
 	}
@@ -115,6 +133,9 @@ func (s *Syncer) sync(ctx context.Context) {
 	if s.lastGood == nil {
 		s.lastGood = make(map[string][]string)
 	}
+	if s.proven == nil {
+		s.proven = map[string]bool{}
+	}
 	var all []string
 	for _, src := range s.sources {
 		ips, err := s.fetch(ctx, src)
@@ -125,6 +146,7 @@ func (s *Syncer) sync(ctx context.Context) {
 			continue
 		}
 		s.lastGood[src] = ips
+		s.proven[src] = true
 		all = append(all, ips...)
 	}
 	for _, path := range s.locals {
@@ -137,8 +159,17 @@ func (s *Syncer) sync(ctx context.Context) {
 			continue
 		}
 		s.lastGood[key] = ips
+		s.proven[key] = true
 		all = append(all, ips...)
 	}
+	totalSources := len(s.sources) + len(s.locals)
+	if len(s.proven) < totalSources {
+		// Not every source has reported fresh yet this lifetime: keep the
+		// disk-cache seed in play so a restart + a transient single-source
+		// failure cannot shrink the enforced set below what was persisted.
+		all = append(all, s.cacheSeed...)
+	}
+	all = dedupeStrings(all)
 	// An empty merged result is a non-success: retain the prior applied set
 	// (and the immutable seed in Policy). Covers all-sources-failed AND a
 	// source returning 200 with zero relays.

--- a/internal/tor/feed_test.go
+++ b/internal/tor/feed_test.go
@@ -180,3 +180,103 @@ func TestSyncer_EmptyResultRetainsPrior(t *testing.T) {
 		t.Fatal("empty 200 response must retain prior set, not wipe it")
 	}
 }
+
+func TestSyncer_RestartPartialFailureRetainsCachedRelays(t *testing.T) {
+	// Simulate a restart: cacheSeed is populated (as Run would from disk),
+	// per-source lastGood is empty, and one of two sources fails on the
+	// first sync. The cached relay IP of the failed source must remain
+	// enforced (folded from the cache seed), not be wiped.
+	bFail := false
+	srvA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"relays":[{"or_addresses":["198.51.100.1:9001"]}]}`))
+	}))
+	defer srvA.Close()
+	srvB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if bFail {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(`{"relays":[{"or_addresses":["203.0.113.1:443"]}]}`))
+	}))
+	defer srvB.Close()
+
+	cfg := config.ResolveTorConfig(config.TorConfig{})
+	cfg.RelayFeed.Enabled = true
+	cfg.RelayFeed.Sources = []string{srvA.URL, srvB.URL}
+	pol, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	s := NewSyncer(pol, nil)
+	// Emulate Run() having loaded a disk cache that contains B's relay IP.
+	s.cacheSeed = []string{"203.0.113.1"}
+	pol.SetRelays(buildSet(s.cacheSeed))
+
+	bFail = true
+	s.sync(t.Context()) // first post-restart sync: A ok, B fails
+	if _, ok := pol.EvalConnect(net.ParseIP("203.0.113.1"), 443); !ok {
+		t.Fatal("cached relay IP of the failed source must remain enforced after restart+partial failure")
+	}
+	if _, ok := pol.EvalConnect(net.ParseIP("198.51.100.1"), 9001); !ok {
+		t.Fatal("healthy source relay must be enforced")
+	}
+
+	// Once B recovers and all sources are proven, the stale cache seed is no
+	// longer folded; fresh per-source data takes over.
+	bFail = false
+	s.sync(t.Context())
+	if _, ok := pol.EvalConnect(net.ParseIP("203.0.113.1"), 443); !ok {
+		t.Fatal("B relay should still be enforced from its own fresh data")
+	}
+}
+
+func TestSyncer_CacheSeedDroppedAfterAllProven(t *testing.T) {
+	// A stale cache-seed IP that no live source serves must disappear once
+	// every source has reported fresh at least once (no unbounded staleness).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"relays":[{"or_addresses":["192.0.2.10:9001"]}]}`))
+	}))
+	defer srv.Close()
+	cfg := config.ResolveTorConfig(config.TorConfig{})
+	cfg.RelayFeed.Enabled = true
+	cfg.RelayFeed.Sources = []string{srv.URL}
+	pol, _ := New(cfg)
+	s := NewSyncer(pol, nil)
+	s.cacheSeed = []string{"198.51.100.222"} // stale, not served by any source
+	pol.SetRelays(buildSet(s.cacheSeed))
+
+	s.sync(t.Context()) // single source succeeds → all proven → seed dropped
+	if _, ok := pol.EvalConnect(net.ParseIP("192.0.2.10"), 9001); !ok {
+		t.Fatal("fresh relay must be enforced")
+	}
+	if _, ok := pol.EvalConnect(net.ParseIP("198.51.100.222"), 9001); ok {
+		t.Fatal("stale cache-seed IP must be dropped once all sources are proven")
+	}
+}
+
+func TestSyncer_DedupesMergedSet(t *testing.T) {
+	body := `{"relays":[{"or_addresses":["192.0.2.1:9001"]},{"or_addresses":["192.0.2.1:443"]}]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+	cfg := config.ResolveTorConfig(config.TorConfig{})
+	cfg.RelayFeed.Enabled = true
+	cfg.RelayFeed.Sources = []string{srv.URL}
+	dir := t.TempDir()
+	cfg.RelayFeed.CacheDir = dir
+	pol, _ := New(cfg)
+	s := NewSyncer(pol, nil)
+	s.sync(t.Context())
+	// 192.0.2.1 appears twice in the source; the persisted cache must contain it once.
+	loaded := s.loadCache()
+	count := 0
+	for _, ip := range loaded {
+		if ip == "192.0.2.1" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected 192.0.2.1 once in deduped cache, got %d (%v)", count, loaded)
+	}
+}

--- a/internal/tor/feed_test.go
+++ b/internal/tor/feed_test.go
@@ -102,3 +102,81 @@ func TestSyncer_FetchAndSync(t *testing.T) {
 		t.Fatalf("want vector %q, got %q", VectorRelayIP, v.Vector)
 	}
 }
+
+func TestSyncer_PartialFailureRetainsLastGood(t *testing.T) {
+	// Source A and B both serve valid relays initially; then A starts failing.
+	// A's relay IP must remain enforced (substituted from per-source last-good)
+	// rather than being silently dropped because A failed this run.
+	aFail := false
+	srvA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if aFail {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(`{"relays":[{"or_addresses":["198.51.100.1:9001"]}]}`))
+	}))
+	defer srvA.Close()
+	srvB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"relays":[{"or_addresses":["203.0.113.1:443"]}]}`))
+	}))
+	defer srvB.Close()
+
+	cfg := config.ResolveTorConfig(config.TorConfig{})
+	cfg.RelayFeed.Enabled = true
+	cfg.RelayFeed.Sources = []string{srvA.URL, srvB.URL}
+	pol, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	s := NewSyncer(pol, nil)
+
+	s.sync(t.Context()) // first sync: both succeed
+	if _, ok := pol.EvalConnect(net.ParseIP("198.51.100.1"), 9001); !ok {
+		t.Fatal("A relay should match after first sync")
+	}
+	if _, ok := pol.EvalConnect(net.ParseIP("203.0.113.1"), 443); !ok {
+		t.Fatal("B relay should match after first sync")
+	}
+
+	aFail = true
+	s.sync(t.Context()) // second sync: A fails, B succeeds
+	if _, ok := pol.EvalConnect(net.ParseIP("198.51.100.1"), 9001); !ok {
+		t.Fatal("A relay must STILL match after A fails (per-source last-good substitution)")
+	}
+	if _, ok := pol.EvalConnect(net.ParseIP("203.0.113.1"), 443); !ok {
+		t.Fatal("B relay should still match after second sync")
+	}
+}
+
+func TestSyncer_EmptyResultRetainsPrior(t *testing.T) {
+	// A single source first serves a relay, then returns 200 with zero relays.
+	// The empty merged result must NOT wipe the enforced set.
+	empty := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if empty {
+			_, _ = w.Write([]byte(`{"relays":[]}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"relays":[{"or_addresses":["192.0.2.50:9001"]}]}`))
+	}))
+	defer srv.Close()
+
+	cfg := config.ResolveTorConfig(config.TorConfig{})
+	cfg.RelayFeed.Enabled = true
+	cfg.RelayFeed.Sources = []string{srv.URL}
+	pol, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	s := NewSyncer(pol, nil)
+
+	s.sync(t.Context())
+	if _, ok := pol.EvalConnect(net.ParseIP("192.0.2.50"), 9001); !ok {
+		t.Fatal("relay should match after first sync")
+	}
+	empty = true
+	s.sync(t.Context())
+	if _, ok := pol.EvalConnect(net.ParseIP("192.0.2.50"), 9001); !ok {
+		t.Fatal("empty 200 response must retain prior set, not wipe it")
+	}
+}

--- a/internal/tor/feed_test.go
+++ b/internal/tor/feed_test.go
@@ -1,0 +1,104 @@
+package tor
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+func TestParseOnionoo(t *testing.T) {
+	body := `{"relays":[
+		{"or_addresses":["128.66.0.1:9001","[2001:db8::2]:443"]},
+		{"or_addresses":["128.66.0.2:443"]},
+		{"or_addresses":["garbage"]}
+	]}`
+	ips, err := parseOnionoo(strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("parseOnionoo: %v", err)
+	}
+	if len(ips) != 3 {
+		t.Fatalf("want 3 parseable IPs, got %d (%v)", len(ips), ips)
+	}
+	set := buildSet(ips)
+	if !set.Contains(net.ParseIP("128.66.0.1")) {
+		t.Fatal("expected 128.66.0.1 in set")
+	}
+	if !set.Contains(net.ParseIP("2001:db8::2")) {
+		t.Fatal("expected IPv6 relay in set")
+	}
+}
+
+func TestParseOnionoo_Malformed(t *testing.T) {
+	if _, err := parseOnionoo(strings.NewReader("{not json")); err == nil {
+		t.Fatal("expected error on malformed JSON")
+	}
+}
+
+func TestSyncer_CacheRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	syncer := &Syncer{cacheDir: dir}
+
+	ips := []string{"10.0.0.1", "10.0.0.2", "2001:db8::3"}
+	if err := syncer.saveCache(ips); err != nil {
+		t.Fatalf("saveCache: %v", err)
+	}
+	cpath := filepath.Join(dir, "tor-relays.txt")
+	if _, err := os.Stat(cpath); err != nil {
+		t.Fatalf("cache file not created: %v", err)
+	}
+	loaded := syncer.loadCache()
+	if len(loaded) != len(ips) {
+		t.Fatalf("want %d ips, got %d: %v", len(ips), len(loaded), loaded)
+	}
+	set := buildSet(loaded)
+	if !set.Contains(net.ParseIP("10.0.0.1")) {
+		t.Fatal("expected 10.0.0.1 in loaded set")
+	}
+	if !set.Contains(net.ParseIP("2001:db8::3")) {
+		t.Fatal("expected IPv6 in loaded set")
+	}
+}
+
+func TestSyncer_FetchAndSync(t *testing.T) {
+	body := `{"relays":[
+		{"or_addresses":["192.0.2.1:9001"]},
+		{"or_addresses":["[2001:db8::ff]:443"]}
+	]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	cfg := config.ResolveTorConfig(config.TorConfig{})
+	cfg.RelayFeed.Enabled = true
+	cfg.RelayFeed.Sources = []string{srv.URL}
+	pol, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	syncer := NewSyncer(pol, nil)
+	ips, err := syncer.fetch(t.Context(), srv.URL)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(ips) != 2 {
+		t.Fatalf("want 2 ips, got %d: %v", len(ips), ips)
+	}
+	pol.SetRelays(buildSet(ips))
+
+	v, ok := pol.EvalConnect(net.ParseIP("192.0.2.1"), 9001)
+	if !ok {
+		t.Fatal("expected match for fetched relay IP")
+	}
+	if v.Vector != VectorRelayIP {
+		t.Fatalf("want vector %q, got %q", VectorRelayIP, v.Vector)
+	}
+}

--- a/internal/tor/integration_test.go
+++ b/internal/tor/integration_test.go
@@ -1,0 +1,44 @@
+package tor_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/tor"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+func denyEngine(t *testing.T) *policy.Engine {
+	t.Helper()
+	// Minimal allow-all policy so any deny we see comes from Tor.
+	p := &policy.Policy{
+		CommandRules: []policy.CommandRule{{Name: "allow-all", Decision: "allow"}},
+		NetworkRules: []policy.NetworkRule{{Name: "allow-all", Decision: "allow"}},
+	}
+	e, err := policy.NewEngine(p, false, false)
+	if err != nil {
+		t.Fatalf("NewEngine: %v", err)
+	}
+	tp, _ := tor.New(config.ResolveTorConfig(config.TorConfig{}))
+	e.SetTorPolicy(&tor.PolicyAdapter{Policy: tp})
+	return e
+}
+
+func TestE2E_TorBlocksAllVectors(t *testing.T) {
+	e := denyEngine(t)
+
+	if d := e.CheckExecve("/usr/bin/tor", []string{"tor"}, 0); d.EffectiveDecision != types.DecisionDeny || d.Tor == nil {
+		t.Fatalf("process vector: %+v", d)
+	}
+	if d := e.CheckNetworkIP("", net.ParseIP("127.0.0.1"), 9050); d.EffectiveDecision != types.DecisionDeny || d.Tor == nil {
+		t.Fatalf("socks_port vector: %+v", d)
+	}
+	if d := e.CheckNetworkIP("", net.ParseIP("128.31.0.39"), 443); d.EffectiveDecision != types.DecisionDeny || d.Tor == nil {
+		t.Fatalf("relay_ip vector: %+v", d)
+	}
+	if d := e.CheckNetworkCtx(nil, "abc.onion", 53); d.EffectiveDecision != types.DecisionDeny || d.Tor == nil {
+		t.Fatalf("onion_dns vector: %+v", d)
+	}
+}

--- a/internal/tor/integration_test.go
+++ b/internal/tor/integration_test.go
@@ -1,6 +1,7 @@
 package tor_test
 
 import (
+	"context"
 	"net"
 	"testing"
 
@@ -40,5 +41,14 @@ func TestE2E_TorBlocksAllVectors(t *testing.T) {
 	}
 	if d := e.CheckNetworkCtx(nil, "abc.onion", 53); d.EffectiveDecision != types.DecisionDeny || d.Tor == nil {
 		t.Fatalf("onion_dns vector: %+v", d)
+	}
+
+	// ptrace connect path: CheckNetworkCtx with an IP-literal domain must also
+	// reach EvalConnect (this is the path the ptrace runtime actually uses).
+	if dec := e.CheckNetworkCtx(context.Background(), "127.0.0.1", 9050); dec.EffectiveDecision != types.DecisionDeny || dec.Tor == nil {
+		t.Fatalf("ptrace path: loopback :9050 must deny via CheckNetworkCtx, got dec=%+v tor=%+v", dec.EffectiveDecision, dec.Tor)
+	}
+	if dec := e.CheckNetworkCtx(context.Background(), "128.31.0.39", 443); dec.EffectiveDecision != types.DecisionDeny || dec.Tor == nil {
+		t.Fatalf("ptrace path: relay seed IP must deny via CheckNetworkCtx, got dec=%+v tor=%+v", dec.EffectiveDecision, dec.Tor)
 	}
 }

--- a/internal/tor/policy.go
+++ b/internal/tor/policy.go
@@ -40,6 +40,7 @@ type Verdict struct {
 type Policy struct {
 	cfg          config.ResolvedTorConfig
 	binBasenames map[string]struct{}
+	binPatterns  []string // lowercased raw client_binary entries, for glob matching
 	socksPorts   map[int]struct{}
 	controlPorts map[int]struct{}
 	seed         *ipset.Set                // directory-authority seed (immutable)
@@ -57,7 +58,9 @@ func New(cfg config.ResolvedTorConfig) (*Policy, error) {
 		seed:         ipset.New(),
 	}
 	for _, b := range cfg.ClientBinaries {
-		p.binBasenames[strings.ToLower(b)] = struct{}{}
+		lb := strings.ToLower(b)
+		p.binBasenames[lb] = struct{}{}
+		p.binPatterns = append(p.binPatterns, lb)
 	}
 	for _, port := range cfg.SocksPorts {
 		p.socksPorts[port] = struct{}{}
@@ -97,7 +100,9 @@ func (p *Policy) verdict(vector, target string) (Verdict, bool) {
 	}, true
 }
 
-// EvalExecve reports whether filename is a Tor client binary.
+// EvalExecve reports whether filename is a Tor client binary. Configured
+// entries match by exact basename (O(1) map) or as a path/basename glob
+// (filepath.Match against the full lowercased path and the basename).
 func (p *Policy) EvalExecve(filename string, argv []string) (Verdict, bool) {
 	if !p.active() || !p.cfg.Vectors.Processes {
 		return Verdict{}, false
@@ -105,6 +110,15 @@ func (p *Policy) EvalExecve(filename string, argv []string) (Verdict, bool) {
 	base := strings.ToLower(filepath.Base(filename))
 	if _, ok := p.binBasenames[base]; ok {
 		return p.verdict(VectorProcess, filename)
+	}
+	lf := strings.ToLower(filename)
+	for _, pat := range p.binPatterns {
+		if m, err := filepath.Match(pat, base); err == nil && m {
+			return p.verdict(VectorProcess, filename)
+		}
+		if m, err := filepath.Match(pat, lf); err == nil && m {
+			return p.verdict(VectorProcess, filename)
+		}
 	}
 	return Verdict{}, false
 }
@@ -132,10 +146,12 @@ func (p *Policy) EvalConnect(ip net.IP, port int) (Verdict, bool) {
 	return Verdict{}, false
 }
 
-// EvalOnionName reports whether host is a .onion address. vector is
-// onion_dns; callers in the HTTP path relabel to onion_http.
+// EvalOnionName reports whether host is a .onion address. The single
+// vectors.onion toggle governs both the DNS and HTTP enforcement points
+// (both flow through this method); events still tag the firing layer —
+// the DNS path uses onion_dns and the HTTP proxy relabels to onion_http.
 func (p *Policy) EvalOnionName(host string) (Verdict, bool) {
-	if !p.active() || !p.cfg.Vectors.OnionDNS {
+	if !p.active() || !p.cfg.Vectors.Onion {
 		return Verdict{}, false
 	}
 	h := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))

--- a/internal/tor/policy.go
+++ b/internal/tor/policy.go
@@ -1,0 +1,169 @@
+package tor
+
+import (
+	"net"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/ipset"
+)
+
+// Mode constants.
+const (
+	ModeDeny  = "deny"
+	ModeAudit = "audit"
+	ModeAllow = "allow"
+)
+
+// Vector constants (also used as the tor_control event's vector field).
+const (
+	VectorProcess   = "process"
+	VectorSocksPort = "socks_port"
+	VectorOnionDNS  = "onion_dns"
+	VectorOnionHTTP = "onion_http"
+	VectorRelayIP   = "relay_ip"
+)
+
+// Verdict is the result of a positive Tor match.
+type Verdict struct {
+	Vector   string // one of the Vector* constants
+	Mode     string // resolved policy mode
+	Decision string // "deny" or "audit" (allow mode never yields a verdict)
+	Target   string // binary path, ip:port, or onion host
+}
+
+// Policy answers Tor questions for the enforcement points. Construct once
+// via New; the relay set may be swapped concurrently via SetRelays.
+type Policy struct {
+	cfg          config.ResolvedTorConfig
+	binBasenames map[string]struct{}
+	socksPorts   map[int]struct{}
+	controlPorts map[int]struct{}
+	seed         *ipset.Set                // directory-authority seed (immutable)
+	relays       atomic.Pointer[ipset.Set] // feed-populated, hot-swappable
+}
+
+// New builds a Policy from resolved config. Returns a Policy even when
+// disabled (its Eval* methods are then no-ops).
+func New(cfg config.ResolvedTorConfig) (*Policy, error) {
+	p := &Policy{
+		cfg:          cfg,
+		binBasenames: map[string]struct{}{},
+		socksPorts:   map[int]struct{}{},
+		controlPorts: map[int]struct{}{},
+		seed:         ipset.New(),
+	}
+	for _, b := range cfg.ClientBinaries {
+		p.binBasenames[strings.ToLower(b)] = struct{}{}
+	}
+	for _, port := range cfg.SocksPorts {
+		p.socksPorts[port] = struct{}{}
+	}
+	for _, port := range cfg.ControlPorts {
+		p.controlPorts[port] = struct{}{}
+	}
+	for _, ip := range DirectoryAuthoritySeed() {
+		_ = p.seed.Add(ip) // seed entries are known-valid
+	}
+	p.relays.Store(ipset.New())
+	return p, nil
+}
+
+// Mode returns the resolved mode.
+func (p *Policy) Mode() string { return p.cfg.Mode }
+
+// active reports whether a verdict should be produced at all.
+func (p *Policy) active() bool {
+	return p != nil && p.cfg.Enabled && (p.cfg.Mode == ModeDeny || p.cfg.Mode == ModeAudit)
+}
+
+// decisionForMode maps the policy mode to a verdict decision.
+func (p *Policy) decisionForMode() string {
+	if p.cfg.Mode == ModeAudit {
+		return ModeAudit
+	}
+	return ModeDeny
+}
+
+func (p *Policy) verdict(vector, target string) (Verdict, bool) {
+	return Verdict{
+		Vector:   vector,
+		Mode:     p.cfg.Mode,
+		Decision: p.decisionForMode(),
+		Target:   target,
+	}, true
+}
+
+// EvalExecve reports whether filename is a Tor client binary.
+func (p *Policy) EvalExecve(filename string, argv []string) (Verdict, bool) {
+	if !p.active() || !p.cfg.Vectors.Processes {
+		return Verdict{}, false
+	}
+	base := strings.ToLower(filepath.Base(filename))
+	if _, ok := p.binBasenames[base]; ok {
+		return p.verdict(VectorProcess, filename)
+	}
+	return Verdict{}, false
+}
+
+// EvalConnect reports whether a connect to ip:port targets Tor (a local
+// SOCKS/control port, or a known relay IP).
+func (p *Policy) EvalConnect(ip net.IP, port int) (Verdict, bool) {
+	if !p.active() {
+		return Verdict{}, false
+	}
+	if p.cfg.Vectors.SocksPorts {
+		_, isSocks := p.socksPorts[port]
+		_, isCtrl := p.controlPorts[port]
+		if isSocks || isCtrl {
+			if !p.cfg.SocksLoopbackOnly || (ip != nil && ip.IsLoopback()) {
+				return p.verdict(VectorSocksPort, net.JoinHostPort(ipString(ip), strconv.Itoa(port)))
+			}
+		}
+	}
+	if p.cfg.Vectors.RelayIPs && ip != nil {
+		if p.seed.Contains(ip) || p.relays.Load().Contains(ip) {
+			return p.verdict(VectorRelayIP, net.JoinHostPort(ipString(ip), strconv.Itoa(port)))
+		}
+	}
+	return Verdict{}, false
+}
+
+// EvalOnionName reports whether host is a .onion address. vector is
+// onion_dns; callers in the HTTP path relabel to onion_http.
+func (p *Policy) EvalOnionName(host string) (Verdict, bool) {
+	if !p.active() || !p.cfg.Vectors.OnionDNS {
+		return Verdict{}, false
+	}
+	h := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	if h == "onion" || strings.HasSuffix(h, ".onion") {
+		return p.verdict(VectorOnionDNS, host)
+	}
+	return Verdict{}, false
+}
+
+// SetRelays swaps the feed-populated relay set (called by the Syncer).
+func (p *Policy) SetRelays(s *ipset.Set) {
+	if p == nil || s == nil {
+		return
+	}
+	p.relays.Store(s)
+}
+
+// RelayFeedEnabled reports whether the onionoo feed should run.
+func (p *Policy) RelayFeedEnabled() bool {
+	return p != nil && p.cfg.Enabled && p.cfg.Vectors.RelayIPs && p.cfg.RelayFeed.Enabled
+}
+
+// RelayFeedConfig exposes the feed config for the Syncer.
+func (p *Policy) RelayFeedConfig() config.TorRelayFeed { return p.cfg.RelayFeed }
+
+func ipString(ip net.IP) string {
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
+}

--- a/internal/tor/policy_test.go
+++ b/internal/tor/policy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/ipset"
 )
 
 func newDenyPolicy(t *testing.T) *Policy {
@@ -97,5 +98,46 @@ func TestPolicy_DisabledVector(t *testing.T) {
 	// other vectors still active
 	if _, ok := p.EvalOnionName("x.onion"); !ok {
 		t.Fatal("onion_dns still enabled: should match")
+	}
+}
+
+func TestPolicy_EvalConnect_ControlPort(t *testing.T) {
+	p := newDenyPolicy(t)
+	v, ok := p.EvalConnect(net.ParseIP("127.0.0.1"), 9051) // default control port
+	if !ok || v.Vector != "socks_port" || v.Decision != "deny" {
+		t.Fatalf("loopback :9051 control port should deny: ok=%v v=%+v", ok, v)
+	}
+}
+
+func TestPolicy_EvalOnionName_Normalization(t *testing.T) {
+	p := newDenyPolicy(t)
+	for _, host := range []string{"ABCDEF.onion", "abcdef.onion.", "  abc.onion  ", "onion"} {
+		if _, ok := p.EvalOnionName(host); !ok {
+			t.Fatalf("expected %q to match after normalization", host)
+		}
+	}
+	for _, host := range []string{"notonion", "foo.onionx", "onion.com"} {
+		if _, ok := p.EvalOnionName(host); ok {
+			t.Fatalf("did not expect %q to match", host)
+		}
+	}
+}
+
+func TestPolicy_SetRelays_HotSwapMatch(t *testing.T) {
+	p := newDenyPolicy(t)
+	// A non-seed public IP is initially not a relay.
+	ip := net.ParseIP("203.0.113.50")
+	if _, ok := p.EvalConnect(ip, 443); ok {
+		t.Fatal("IP should not match before feed swap")
+	}
+	// Swap in a relay set containing it; the next Eval must see it.
+	s := ipset.New()
+	if err := s.Add("203.0.113.0/24"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	p.SetRelays(s)
+	v, ok := p.EvalConnect(ip, 443)
+	if !ok || v.Vector != "relay_ip" || v.Decision != "deny" {
+		t.Fatalf("post-swap relay match failed: ok=%v v=%+v", ok, v)
 	}
 }

--- a/internal/tor/policy_test.go
+++ b/internal/tor/policy_test.go
@@ -1,0 +1,101 @@
+package tor
+
+import (
+	"net"
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+func newDenyPolicy(t *testing.T) *Policy {
+	t.Helper()
+	p, err := New(config.ResolveTorConfig(config.TorConfig{}))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return p
+}
+
+func TestPolicy_EvalExecve_DenyTorBinary(t *testing.T) {
+	p := newDenyPolicy(t)
+	v, ok := p.EvalExecve("/usr/bin/tor", []string{"tor"})
+	if !ok || v.Vector != "process" || v.Decision != "deny" {
+		t.Fatalf("got ok=%v verdict=%+v, want deny/process", ok, v)
+	}
+	v, ok = p.EvalExecve("/usr/bin/torsocks", []string{"torsocks", "curl"})
+	if !ok || v.Decision != "deny" {
+		t.Fatalf("torsocks should be denied: ok=%v v=%+v", ok, v)
+	}
+	if _, ok := p.EvalExecve("/usr/bin/curl", []string{"curl"}); ok {
+		t.Fatal("curl must not be a Tor match")
+	}
+}
+
+func TestPolicy_EvalConnect_SocksPortLoopback(t *testing.T) {
+	p := newDenyPolicy(t)
+	v, ok := p.EvalConnect(net.ParseIP("127.0.0.1"), 9050)
+	if !ok || v.Vector != "socks_port" || v.Decision != "deny" {
+		t.Fatalf("loopback :9050 should deny: ok=%v v=%+v", ok, v)
+	}
+	// Default socks_loopback_only=true: non-loopback :9050 is not Tor.
+	if _, ok := p.EvalConnect(net.ParseIP("203.0.113.7"), 9050); ok {
+		t.Fatal("non-loopback :9050 must not match when loopback_only")
+	}
+}
+
+func TestPolicy_EvalConnect_RelaySeedIP(t *testing.T) {
+	p := newDenyPolicy(t)
+	v, ok := p.EvalConnect(net.ParseIP("128.31.0.39"), 443) // moria1 authority
+	if !ok || v.Vector != "relay_ip" || v.Decision != "deny" {
+		t.Fatalf("authority IP should deny: ok=%v v=%+v", ok, v)
+	}
+	if _, ok := p.EvalConnect(net.ParseIP("1.1.1.1"), 443); ok {
+		t.Fatal("non-relay IP must not match")
+	}
+}
+
+func TestPolicy_EvalOnionName(t *testing.T) {
+	p := newDenyPolicy(t)
+	v, ok := p.EvalOnionName("abcdefghij234567.onion")
+	if !ok || v.Vector != "onion_dns" || v.Decision != "deny" {
+		t.Fatalf(".onion should deny: ok=%v v=%+v", ok, v)
+	}
+	if _, ok := p.EvalOnionName("example.com"); ok {
+		t.Fatal("clearnet host must not match")
+	}
+}
+
+func TestPolicy_AuditMode(t *testing.T) {
+	tr := true
+	p, _ := New(config.ResolveTorConfig(config.TorConfig{Enabled: &tr, Mode: "audit"}))
+	v, ok := p.EvalExecve("/usr/bin/tor", []string{"tor"})
+	if !ok || v.Decision != "audit" {
+		t.Fatalf("audit mode must report audit: ok=%v v=%+v", ok, v)
+	}
+}
+
+func TestPolicy_AllowMode_NoMatches(t *testing.T) {
+	tr := true
+	p, _ := New(config.ResolveTorConfig(config.TorConfig{Enabled: &tr, Mode: "allow"}))
+	if _, ok := p.EvalExecve("/usr/bin/tor", []string{"tor"}); ok {
+		t.Fatal("allow mode: Tor vectors must be no-ops")
+	}
+	if _, ok := p.EvalConnect(net.ParseIP("127.0.0.1"), 9050); ok {
+		t.Fatal("allow mode: connect must be a no-op")
+	}
+}
+
+func TestPolicy_DisabledVector(t *testing.T) {
+	tr, f := true, false
+	p, _ := New(config.ResolveTorConfig(config.TorConfig{
+		Enabled: &tr,
+		Vectors: config.TorVectors{Processes: &f},
+	}))
+	if _, ok := p.EvalExecve("/usr/bin/tor", []string{"tor"}); ok {
+		t.Fatal("processes vector disabled: must not match")
+	}
+	// other vectors still active
+	if _, ok := p.EvalOnionName("x.onion"); !ok {
+		t.Fatal("onion_dns still enabled: should match")
+	}
+}

--- a/internal/tor/policy_test.go
+++ b/internal/tor/policy_test.go
@@ -123,6 +123,42 @@ func TestPolicy_EvalOnionName_Normalization(t *testing.T) {
 	}
 }
 
+func TestPolicy_OnionVectorDisabled(t *testing.T) {
+	tr, f := true, false
+	p, _ := New(config.ResolveTorConfig(config.TorConfig{Enabled: &tr, Vectors: config.TorVectors{Onion: &f}}))
+	if _, ok := p.EvalOnionName("x.onion"); ok {
+		t.Fatal("onion vector disabled: .onion must not match")
+	}
+	// other vectors unaffected
+	if _, ok := p.EvalConnect(net.ParseIP("127.0.0.1"), 9050); !ok {
+		t.Fatal("socks_port vector should still match")
+	}
+}
+
+func TestPolicy_EvalExecve_PathAndGlob(t *testing.T) {
+	tr := true
+	p, _ := New(config.ResolveTorConfig(config.TorConfig{
+		Enabled:        &tr,
+		ClientBinaries: []string{"tor", "/opt/tor/bin/torbrowser", "obfs*"},
+	}))
+	// exact basename still works
+	if _, ok := p.EvalExecve("/usr/bin/tor", []string{"tor"}); !ok {
+		t.Fatal("exact basename must match")
+	}
+	// full-path entry matches the full path
+	if _, ok := p.EvalExecve("/opt/tor/bin/torbrowser", []string{"torbrowser"}); !ok {
+		t.Fatal("full-path client_binary entry must match")
+	}
+	// glob matches the basename
+	if _, ok := p.EvalExecve("/usr/bin/obfs4proxy", []string{"obfs4proxy"}); !ok {
+		t.Fatal("glob client_binary entry must match basename")
+	}
+	// non-Tor stays unmatched
+	if _, ok := p.EvalExecve("/usr/bin/curl", []string{"curl"}); ok {
+		t.Fatal("curl must not match")
+	}
+}
+
 func TestPolicy_SetRelays_HotSwapMatch(t *testing.T) {
 	p := newDenyPolicy(t)
 	// A non-seed public IP is initially not a relay.

--- a/internal/tor/seed.go
+++ b/internal/tor/seed.go
@@ -1,0 +1,22 @@
+package tor
+
+// DirectoryAuthoritySeed returns the well-known Tor directory-authority
+// IPv4 addresses. These are near-static (changes require a Tor release)
+// and a client must contact one — or a fallback dir — to bootstrap, so
+// this list breaks Tor without any external feed. Source: Tor's
+// src/app/config/auth_dirs.inc. Operators extend coverage via the
+// onionoo relay feed or relay_feed.local_lists.
+func DirectoryAuthoritySeed() []string {
+	return []string{
+		"128.31.0.39",    // moria1
+		"86.59.21.38",    // tor26
+		"199.58.81.140",  // dizum
+		"192.36.123.159", // bastet
+		"66.111.2.131",   // Faravahar
+		"131.188.40.189", // gabelmoo
+		"193.23.244.244", // dannenberg
+		"171.25.193.9",   // maatuska
+		"154.35.175.225", // longclaw
+		"204.13.164.118", // serge
+	}
+}

--- a/internal/tor/seed_test.go
+++ b/internal/tor/seed_test.go
@@ -1,0 +1,18 @@
+package tor
+
+import (
+	"net"
+	"testing"
+)
+
+func TestDirectoryAuthoritySeed_NonEmptyAndValid(t *testing.T) {
+	seed := DirectoryAuthoritySeed()
+	if len(seed) < 5 {
+		t.Fatalf("expected several authority IPs, got %d", len(seed))
+	}
+	for _, s := range seed {
+		if net.ParseIP(s) == nil {
+			t.Fatalf("seed entry %q is not a valid IP", s)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a top-level **`tor:` policy block** giving agentsh a single, declarative, **deny-by-default** posture toward the Tor network. One intent (`deny | audit | allow`) coordinates enforcement across the five ways a sandboxed process can reach Tor, and every hit emits a uniform `tor_control` audit event tagged with the firing vector.

**The five vectors**
1. **Client processes** — `tor`/`obfs4proxy`/`torsocks`/… via `CheckExecve` (basename + path-glob match)
2. **Local SOCKS/control ports** — `connect()` to `127.0.0.1:9050/9150/9051` (loopback-gated)
3. **`.onion` DNS** — DNS interceptor → REFUSED
4. **`.onion` HTTP** — HTTP proxy → 403
5. **Relay IPs** — built-in directory-authority seed (feed-independent, breaks bootstrap) + optional onionoo relay feed

**Key design points**
- **Deny-by-default**: an absent `tor:` block resolves to enabled + deny + all vectors on, requiring **zero** external fetch (seed + the four cheap doors). Operators opt out via `tor.enabled: false` or `tor.mode: allow`.
- **Coordinator architecture**: a `tor.Policy` consulted by the engine through a minimal `policy.TorChecker` interface (mirrors the `threatfeed` pattern; avoids an import cycle). `deny` short-circuits and overrides a user `allow`; `audit` attaches metadata via named-return + defer and never loosens a user `deny`; `allow` is a no-op.
- **Relay feed is fail-closed**: per-source last-good + disk-cache seed retained across restarts and partial-source failures; an empty merged result never wipes the enforced set.
- New `internal/ipset` IP/CIDR membership primitive; new `tor_control` event type (registered in the OCSF registry).

Phase 2 (SOCKS-aware per-`.onion` gateway) is documented but **not** built.

Spec: `docs/superpowers/specs/2026-06-14-tor-access-control-design.md`
Plan: `docs/superpowers/plans/2026-06-14-tor-access-control.md`

## Test Plan
- [ ] CI green (build + `go test ./...`, incl. cross-platform build)
- [x] `go build ./...` and `GOOS=windows go build ./...` clean locally
- [x] `go test ./... -p 1` green locally (one pre-existing, unrelated `internal/fsmonitor` FUSE local-env failure only)
- [x] Unit coverage per vector × mode; ipset boundaries; onionoo parser; feed partial-failure/empty/restart retention; engine precedence (deny-overrides-allow, audit-never-loosens); proxy `onion_dns→onion_http` remap; e2e deny-by-default across all vectors
- [x] roborev branch review: all findings above `low` resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)