### PR TITLE
feat(tor): Tor access control Phase 2 — onion gateway

### DIFF
--- a/docs/superpowers/specs/2026-06-14-tor-access-control-design.md
+++ b/docs/superpowers/specs/2026-06-14-tor-access-control-design.md
@@ -1,7 +1,7 @@
 # Tor Access Control — Design
 
 **Date:** 2026-06-14
-**Status:** Approved — Phase 1 implemented
+**Status:** Approved — Phase 1 + Phase 2 implemented
 **Related:** `internal/policy/engine.go` (`CheckExecve`, `CheckNetworkIP`,
 `CheckNetworkCtx`), `internal/netmonitor/dns.go`, `internal/netmonitor/proxy.go`,
 `internal/netmonitor/transparent_tcp.go`, `internal/threatfeed/`,
@@ -353,7 +353,7 @@ surface to one new type.
 - `GOOS=windows go build ./...` cross-compile (per CLAUDE.md / AGENTS.md).
 - roborev between tasks; fix everything above low before proceeding.
 
-## Phase 2 (sketch — documented, not built)
+## Phase 2 (onion gateway — implemented)
 
 When `tor.mode: allow` and an `onion_rules:` list is present, agentsh
 becomes a **managed Tor egress**:
@@ -382,3 +382,16 @@ tor:
     - onion: "*"
       decision: deny
 ```
+
+**Honest scope (Phase 2).** Per-`.onion` filtering applies to Tor SOCKS
+connections that reach agentsh's transparent-TCP interceptor (original
+destination = a configured `socks_ports` entry). A `.onion`/clearnet target
+matching no `onion_rules` entry is denied (fail-closed); allowed targets are
+forwarded to the real Tor SOCKS daemon at `127.0.0.1:<socks_ports[0]>`. In
+sandbox modes where the app reaches a loopback Tor daemon that is *not* within
+agentsh's interception, allow-mode degrades to Phase-1 allow (Tor permitted,
+unfiltered) — the operator must route the Tor SOCKS port through agentsh's
+transparent interception for the gateway to take effect. The gateway emits one
+`tor_control{vector: onion, decision: allow|deny}` event per CONNECT; like the
+other connection-layer vectors it reports `pid: 0` and is correlated by session
+and target.

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -702,7 +702,6 @@ func (a *App) tryStartTransparentNetwork(ctx context.Context, s *session.Session
 	}
 	if pol, upstream, socksPorts, ok := a.torGateway(); ok {
 		tcp.SetTorGateway(pol, upstream, socksPorts)
-		s.SetTorGatewayAddr(upstream)
 		slog.Info("tor onion gateway active for session", "session", s.ID, "upstream", upstream)
 	}
 	dns, dnsPort, err := netmonitor.StartDNS("0.0.0.0:0", "8.8.8.8:53", s.ID, s, dnsCache, a.policy, a.approvals, em, correlationMap)

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -700,6 +700,11 @@ func (a *App) tryStartTransparentNetwork(ctx context.Context, s *session.Session
 	if err != nil {
 		return err
 	}
+	if pol, upstream, socksPorts, ok := a.torGateway(); ok {
+		tcp.SetTorGateway(pol, upstream, socksPorts)
+		s.SetTorGatewayAddr(upstream)
+		slog.Info("tor onion gateway active for session", "session", s.ID, "upstream", upstream)
+	}
 	dns, dnsPort, err := netmonitor.StartDNS("0.0.0.0:0", "8.8.8.8:53", s.ID, s, dnsCache, a.policy, a.approvals, em, correlationMap)
 	if err != nil {
 		_ = tcp.Close()

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -34,6 +34,7 @@ import (
 	"github.com/agentsh/agentsh/internal/proxy"
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/internal/store/composite"
+	"github.com/agentsh/agentsh/internal/tor"
 	"github.com/agentsh/agentsh/internal/trash"
 	"github.com/agentsh/agentsh/pkg/types"
 	"github.com/go-chi/chi/v5"
@@ -124,9 +125,12 @@ type App struct {
 	// "behavioral_probe", "behavioral_probe_error"). Consumed by the
 	// diagnostic log lines added in a later task.
 	waitKillableSource string
+
+	// torPolicy is the Phase 2 tor gateway policy; nil when tor is disabled.
+	torPolicy *tor.Policy
 }
 
-func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Store, engine *policy.Engine, broker *events.Broker, apiKeyAuth *auth.APIKeyAuth, oidcAuth *auth.OIDCAuth, approvalsMgr *approvals.Manager, metricsCollector *metrics.Collector, policyLoader PolicyLoader, cgroupMgr *limits.CgroupManager) *App {
+func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Store, engine *policy.Engine, broker *events.Broker, apiKeyAuth *auth.APIKeyAuth, oidcAuth *auth.OIDCAuth, approvalsMgr *approvals.Manager, metricsCollector *metrics.Collector, policyLoader PolicyLoader, cgroupMgr *limits.CgroupManager, torPolicy *tor.Policy) *App {
 	// Apply EBPF map size overrides once per process (global maps); no-op if zero values.
 	ebpftrace.SetMapSizeOverrides(
 		uint32(cfg.Sandbox.Network.EBPF.MapAllowEntries),
@@ -188,6 +192,7 @@ func NewApp(cfg *config.Config, sessions *session.Manager, store *composite.Stor
 		metrics:      metricsCollector,
 		platform:     plat,
 		policyLoader: policyLoader,
+		torPolicy:    torPolicy,
 	}
 
 	// Compute the server-process WAIT_KILLABLE_RECV decision once at
@@ -242,6 +247,14 @@ func (a *App) SetSessionTracker(t interface {
 // Close releases resources held by the app (e.g., ptrace tracer).
 func (a *App) Close() {
 	a.closePtraceTracer()
+}
+
+// torGateway reports the Phase 2 onion-gateway wiring when active.
+func (a *App) torGateway() (pol *tor.Policy, upstream string, socksPorts []int, ok bool) {
+	if a == nil || a.torPolicy == nil || !a.torPolicy.GatewayActive() {
+		return nil, "", nil, false
+	}
+	return a.torPolicy, a.torPolicy.UpstreamSocksAddr(), a.torPolicy.ConfiguredSocksPorts(), true
 }
 
 type ctxKey string

--- a/internal/api/app_destroy_test.go
+++ b/internal/api/app_destroy_test.go
@@ -53,7 +53,7 @@ func TestDestroySessionPurgesTrash(t *testing.T) {
 		t.Fatalf("expected trash entry before destroy")
 	}
 
-	app := NewApp(cfg, mgr, composite.New(memEventStore{}, nil), nil, events.NewBroker(), nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, composite.New(memEventStore{}, nil), nil, events.NewBroker(), nil, nil, nil, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("DELETE", "/api/v1/sessions/sess1", nil)
 	rctx := chi.NewRouteContext()

--- a/internal/api/app_ptrace_init_linux_test.go
+++ b/internal/api/app_ptrace_init_linux_test.go
@@ -75,7 +75,7 @@ func newPtraceTestApp(t *testing.T, mutate func(*config.Config)) *App {
 	mgr := session.NewManager(5)
 	store := composite.New(mockEventStore{}, nil)
 	broker := events.NewBroker()
-	app := NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil, nil)
 	t.Cleanup(func() { app.closePtraceTracer() })
 	return app
 }

--- a/internal/api/app_ptrace_probe_test.go
+++ b/internal/api/app_ptrace_probe_test.go
@@ -30,7 +30,7 @@ func newProbeTestApp(t *testing.T) *App {
 	mgr := session.NewManager(5)
 	store := composite.New(mockEventStore{}, nil)
 	broker := events.NewBroker()
-	app := NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil, nil)
 	t.Cleanup(func() { app.closePtraceTracer() })
 	return app
 }

--- a/internal/api/app_test.go
+++ b/internal/api/app_test.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/tor"
+)
+
+func TestApp_torGateway(t *testing.T) {
+	pol, err := tor.New(config.ResolvedTorConfig{
+		Enabled: true, Mode: tor.ModeAllow, SocksPorts: []int{9050},
+		OnionRules: []config.TorOnionRule{{Onion: "*", Decision: "deny"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	a := &App{torPolicy: pol}
+	p, upstream, ports, ok := a.torGateway()
+	if !ok || p == nil || upstream != "127.0.0.1:9050" || len(ports) != 1 {
+		t.Fatalf("torGateway() = %v %q %v %v", p, upstream, ports, ok)
+	}
+
+	// Inactive when no policy.
+	if _, _, _, ok := (&App{}).torGateway(); ok {
+		t.Error("nil torPolicy must be inactive")
+	}
+}

--- a/internal/api/authz_test.go
+++ b/internal/api/authz_test.go
@@ -49,7 +49,7 @@ func TestApprovalsEndpointsRequireApproverRole(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), apiKeyAuth, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), apiKeyAuth, nil, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	// Agent key: forbidden.
@@ -83,7 +83,7 @@ func TestApprovalsEndpointsForbiddenWhenAuthDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/approvals", nil)
@@ -114,7 +114,7 @@ func TestApprovalsEndpointsForbiddenWhenDevelopmentDisableAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/approvals", nil)
@@ -155,7 +155,7 @@ func TestOIDCAuthModeWithValidToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	// Agent token: forbidden for approvals endpoint
@@ -200,7 +200,7 @@ func TestOIDCAuthMissingToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	// No Authorization header
@@ -226,7 +226,7 @@ func TestOIDCAuthEmptyToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	// Empty Bearer token
@@ -262,7 +262,7 @@ func TestOIDCAuthInvalidToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	// Token not in cache (invalid)
@@ -314,7 +314,7 @@ func TestHybridAuthModeAPIKeyFirst(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), apiKeyAuth, oidcAuth, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), apiKeyAuth, oidcAuth, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	// API key takes precedence in hybrid mode
@@ -362,7 +362,7 @@ func TestHybridAuthModeOIDCFallback(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	// OIDC should work when API key not provided
@@ -400,7 +400,7 @@ func TestHybridAuthModeNeitherSucceeds(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, oidcAuth, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	// No valid credentials - should fail

--- a/internal/api/cgroups_linux_test.go
+++ b/internal/api/cgroups_linux_test.go
@@ -62,6 +62,7 @@ func newAppWithFakeCgroupManager(t *testing.T, cfg *config.Config, cgPath string
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	app.cgroupMgr = &fakeCgroupManagerForAPITest{path: cgPath}
 	return app

--- a/internal/api/cgroups_test.go
+++ b/internal/api/cgroups_test.go
@@ -30,6 +30,7 @@ func TestApplyCgroupV2_EBPFEnabledRequiresCgroupManager(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	_, err := applyCgroupV2(context.Background(), storeEmitter{store: app.store, broker: app.broker}, app, "sess", "cmd", 1234, policy.Limits{}, nil, nil)

--- a/internal/api/db_unavoidability_test.go
+++ b/internal/api/db_unavoidability_test.go
@@ -510,7 +510,7 @@ func TestCreateSessionCore_NoPolicyDirUsesGlobalEngine(t *testing.T) {
 	cfg.Sessions.BaseDir = t.TempDir()
 	mgr := session.NewManager(10)
 	store := composite.New(mockEventStore{}, nil)
-	app := NewApp(cfg, mgr, store, globalEngine, appevents.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, mgr, store, globalEngine, appevents.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 
 	snap, code, err := app.createSessionCore(context.Background(), types.CreateSessionRequest{
 		ID:        "sess-global-engine",
@@ -574,7 +574,7 @@ func newDBUnavoidabilityTestApp(t *testing.T, policyYAML string) (*App, *session
 	mgr := session.NewManager(10)
 	st := newSQLiteStore(t)
 	store := composite.New(st, st)
-	app := NewApp(cfg, mgr, store, nil, appevents.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, mgr, store, nil, appevents.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 	return app, mgr
 }
 
@@ -596,7 +596,7 @@ func newDBCommandBypassFixture(t *testing.T) *dbCommandBypassFixture {
 	mgr := session.NewManager(5)
 	captured := &capturingEventStore{}
 	store := composite.New(captured, nil)
-	app := NewApp(cfg, mgr, store, nil, appevents.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, mgr, store, nil, appevents.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
 		t.Fatalf("create session: %v", err)

--- a/internal/api/deferred_fuse_test.go
+++ b/internal/api/deferred_fuse_test.go
@@ -114,7 +114,7 @@ func newDeferredTestApp(t *testing.T, sessions *session.Manager, store *composit
 	if err != nil {
 		t.Fatal(err)
 	}
-	return NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	return NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 }
 
 func newDeferredTestSession(t *testing.T, mgr *session.Manager) *session.Session {
@@ -364,7 +364,7 @@ func TestEnsureFUSEMount_NilPolicyAndEmitter(t *testing.T) {
 		},
 	}, false, true)
 
-	app := NewApp(cfg, mgr, store, engine, events.NewBroker(), nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, engine, events.NewBroker(), nil, nil, nil, nil, nil, nil, nil)
 
 	mfs := &mockFilesystem{}
 	mfs.available.Store(true)
@@ -405,7 +405,7 @@ func TestMountFUSEForSession_DeferredEventField(t *testing.T) {
 		},
 	}, false, true)
 
-	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, metrics.New(), nil, nil, nil)
 
 	mfs := &mockFilesystem{}
 	mfs.available.Store(true)

--- a/internal/api/ebpf_integration_test.go
+++ b/internal/api/ebpf_integration_test.go
@@ -49,7 +49,7 @@ func TestEBPFConnectEventFlow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 
 	// Create command cgroup and attach ebpf via hook.
 	hook := app.cgroupHook(sess.ID, "cmd-test", policy.Limits{})

--- a/internal/api/exec_include_events_test.go
+++ b/internal/api/exec_include_events_test.go
@@ -100,7 +100,7 @@ func TestExec_IncludeEventsSummary_CapsBlockedOps(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	// Trigger a command policy deny (rm -rf) which returns blocked_operations in response.

--- a/internal/api/file_monitor_linux_test.go
+++ b/internal/api/file_monitor_linux_test.go
@@ -199,7 +199,7 @@ func TestMountFUSEForSession_RegistersMountPointNotSourcePath(t *testing.T) {
 	}, false, true)
 	require.NoError(t, err)
 
-	app := NewApp(cfg, mgr, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, mgr, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 
 	mfs := &mockFilesystem{}
 	mfs.available.Store(true)

--- a/internal/api/llmproxy_integration_test.go
+++ b/internal/api/llmproxy_integration_test.go
@@ -67,7 +67,7 @@ func TestIntegration_LLMProxyStartedOnSessionCreate(t *testing.T) {
 	}
 
 	broker := events.NewBroker()
-	app := NewApp(cfg, sessions, store, engine, broker, nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, broker, nil, nil, nil, metrics.New(), nil, nil, nil)
 
 	// Create a session - this should start the LLM proxy
 	ctx := context.Background()
@@ -183,7 +183,7 @@ func TestIntegration_LLMProxyEnvVarsInSession(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 
 	ctx := context.Background()
 	req := types.CreateSessionRequest{Workspace: ws}
@@ -244,7 +244,7 @@ func TestIntegration_LLMProxyNotStartedWhenDisabled(t *testing.T) {
 	}
 
 	broker := events.NewBroker()
-	app := NewApp(cfg, sessions, store, engine, broker, nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, broker, nil, nil, nil, metrics.New(), nil, nil, nil)
 
 	ctx := context.Background()
 	req := types.CreateSessionRequest{Workspace: ws}
@@ -323,7 +323,7 @@ func TestIntegration_LLMProxyBothDialects(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 
 	ctx := context.Background()
 	snap, _, err := app.createSessionCore(ctx, types.CreateSessionRequest{Workspace: t.TempDir()})

--- a/internal/api/mcp_query_test.go
+++ b/internal/api/mcp_query_test.go
@@ -25,7 +25,7 @@ func newMCPTestApp(t *testing.T, st *sqlite.Store) http.Handler {
 	cfg.Metrics.Enabled = false
 	cfg.Health.Path = "/health"
 	cfg.Health.ReadinessPath = "/ready"
-	app := NewApp(cfg, sessions, store, nil, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, nil, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 	return app.Router()
 }
 

--- a/internal/api/metrics_test.go
+++ b/internal/api/metrics_test.go
@@ -27,7 +27,7 @@ func TestRouter_MetricsEnabledServesPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, composite.New(nil, nil), engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rr := httptest.NewRecorder()

--- a/internal/api/policies_test.go
+++ b/internal/api/policies_test.go
@@ -30,7 +30,7 @@ func newTestAppForPolicies(t *testing.T) *App {
 	mgr := session.NewManager(5)
 	store := composite.New(mockEventStore{}, nil)
 	broker := events.NewBroker()
-	return NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil)
+	return NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func TestValidatePolicyRules(t *testing.T) {

--- a/internal/api/profile_session_test.go
+++ b/internal/api/profile_session_test.go
@@ -59,7 +59,7 @@ func TestCreateSessionWithProfile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	body := `{"profile":"test-profile"}`
@@ -108,7 +108,7 @@ func TestCreateSessionWithProfile_ProfileNotFound(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	body := `{"profile":"nonexistent-profile"}`
@@ -155,7 +155,7 @@ func TestCreateSessionWithProfile_MissingMountPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	body := `{"profile":"bad-path-profile"}`
@@ -215,7 +215,7 @@ func TestCreateSessionWithProfile_RealPaths(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	body := `{"profile":"test-profile","real_paths":true}`
@@ -275,7 +275,7 @@ func TestCreateSessionWithProfile_RealPathsDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	// Request with real_paths=false overrides config default

--- a/internal/api/profiles_test.go
+++ b/internal/api/profiles_test.go
@@ -33,7 +33,7 @@ func TestListProfiles_Empty(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/profiles", nil)
@@ -94,7 +94,7 @@ func TestListProfiles_MultipleProfiles(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/profiles", nil)
@@ -172,7 +172,7 @@ func TestListProfiles_ContentType(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 	h := app.Router()
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/profiles", nil)

--- a/internal/api/pty_grpc_policy_test.go
+++ b/internal/api/pty_grpc_policy_test.go
@@ -62,7 +62,7 @@ func TestGRPC_PTY_RespectsCommandPolicyDeny(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 
 	lis := bufconn.Listen(1024 * 1024)
 	t.Cleanup(func() { _ = lis.Close() })

--- a/internal/api/pty_ws_policy_test.go
+++ b/internal/api/pty_ws_policy_test.go
@@ -57,7 +57,7 @@ func TestPTYWebSocket_RespectsCommandPolicyDeny(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	app := NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 
 	srv := newHTTPTestServerOrSkip(t, app.Router())
 

--- a/internal/api/seccomp_wrapper_test.go
+++ b/internal/api/seccomp_wrapper_test.go
@@ -18,7 +18,7 @@ func newTestAppForSeccomp(t *testing.T, cfg *config.Config) *App {
 	mgr := session.NewManager(5)
 	store := composite.New(mockEventStore{}, nil)
 	broker := events.NewBroker()
-	return NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil)
+	return NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil, nil)
 }
 
 func TestSetupSeccompWrapper_DisabledByConfig(t *testing.T) {

--- a/internal/api/session_patch_kill_test.go
+++ b/internal/api/session_patch_kill_test.go
@@ -49,7 +49,7 @@ func newTestApp(t *testing.T, sessions *session.Manager, store *composite.Store)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil)
+	return NewApp(cfg, sessions, store, engine, events.NewBroker(), nil, nil, nil, metrics.New(), nil, nil, nil)
 }
 
 func newSQLiteStore(t *testing.T) *sqlite.Store {

--- a/internal/api/session_policy_integration_test.go
+++ b/internal/api/session_policy_integration_test.go
@@ -76,7 +76,7 @@ func TestExecInSessionCore_PrecheckConsultsSessionPolicy(t *testing.T) {
 	broker := events.NewBroker()
 
 	cfg := &config.Config{}
-	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil, nil, nil)
 
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
@@ -172,7 +172,7 @@ func newSessionPolicyFixture(t *testing.T) *sessionPolicyFixture {
 	broker := events.NewBroker()
 
 	cfg := &config.Config{}
-	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil, nil, nil)
 
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
@@ -558,7 +558,7 @@ func TestPolicyTest_HonorsSessionID(t *testing.T) {
 	store := composite.New(captured, nil)
 	broker := events.NewBroker()
 	cfg := &config.Config{}
-	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil, nil, nil)
 
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
@@ -661,7 +661,7 @@ func TestGRPCPolicyTest_HonorsSessionID(t *testing.T) {
 	store := composite.New(captured, nil)
 	broker := events.NewBroker()
 	cfg := &config.Config{}
-	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, globalEngine, broker, nil, nil, nil, nil, nil, nil, nil)
 
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {

--- a/internal/api/shim_install_test_helpers_linux_test.go
+++ b/internal/api/shim_install_test_helpers_linux_test.go
@@ -157,7 +157,7 @@ func startTestServerWithLandlockDenyOpts(t *testing.T, denyPath string, extraAll
 	store := composite.New(mockEventStore{}, nil)
 	broker := events.NewBroker()
 
-	app := NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil, nil)
 
 	// Pre-create the session so wrap-init finds it.
 	ws := t.TempDir()

--- a/internal/api/wrap_shim_mode_test.go
+++ b/internal/api/wrap_shim_mode_test.go
@@ -40,7 +40,7 @@ func newTestAppForWrapWithPermissivePolicy(t *testing.T, cfg *config.Config) (*A
 	mgr := session.NewManager(5)
 	store := composite.New(mockEventStore{}, nil)
 	broker := events.NewBroker()
-	app := NewApp(cfg, mgr, store, permissiveTestEngine(t), broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, permissiveTestEngine(t), broker, nil, nil, nil, nil, nil, nil, nil)
 	return app, mgr
 }
 

--- a/internal/api/wrap_test.go
+++ b/internal/api/wrap_test.go
@@ -27,7 +27,7 @@ func newTestAppForWrap(t *testing.T, cfg *config.Config) (*App, *session.Manager
 	mgr := session.NewManager(5)
 	store := composite.New(mockEventStore{}, nil)
 	broker := events.NewBroker()
-	app := NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, nil, broker, nil, nil, nil, nil, nil, nil, nil)
 	return app, mgr
 }
 
@@ -474,7 +474,7 @@ func TestWrapInit_UnixSocketsDisabledWithPolicyLimitsButNoCgroup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil, nil)
 
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
@@ -519,7 +519,7 @@ func TestWrapNeedsCgroupBeforeAck_PolicyLimitsAloneInsufficient(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil, nil)
 
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
@@ -590,7 +590,7 @@ func TestWrapInit_ShimMode_PolicyDeny(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil, nil)
 
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
@@ -634,7 +634,7 @@ func TestWrapInit_ShimMode_PolicyApprove(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil, nil)
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
 		t.Fatalf("create session: %v", err)
@@ -669,7 +669,7 @@ func TestWrapInit_ShimMode_PolicyRedirect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil, nil)
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
 		t.Fatalf("create session: %v", err)
@@ -709,7 +709,7 @@ func TestWrapInit_ShimMode_PolicySoftDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil, nil)
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
 		t.Fatalf("create session: %v", err)
@@ -749,7 +749,7 @@ func TestWrapInit_ShimMode_PolicyAuditAllowed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil, nil)
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
 		t.Fatalf("create session: %v", err)
@@ -794,7 +794,7 @@ func TestWrapInit_ShimMode_PolicyAllow(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil, nil)
 
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
@@ -838,7 +838,7 @@ func TestWrapInit_AgentMode_PolicyNotChecked(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil, nil)
 
 	s, err := mgr.Create(t.TempDir(), "default")
 	if err != nil {
@@ -1368,7 +1368,7 @@ func newTestAppForWrapWithSignalPolicy(t *testing.T, cfg *config.Config) (*App, 
 	if err != nil {
 		t.Fatalf("create policy engine: %v", err)
 	}
-	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil)
+	app := NewApp(cfg, mgr, store, engine, broker, nil, nil, nil, nil, nil, nil, nil)
 	return app, mgr
 }
 

--- a/internal/config/tor.go
+++ b/internal/config/tor.go
@@ -7,14 +7,15 @@ import "time"
 // deny-by-default posture. Enabled is a *bool tri-state (nil → true),
 // matching the convention used by SandboxFUSEConfig and WaitKillable.
 type TorConfig struct {
-	Enabled           *bool        `yaml:"enabled"`
-	Mode              string       `yaml:"mode"` // deny | audit | allow
-	Vectors           TorVectors   `yaml:"vectors"`
-	ClientBinaries    []string     `yaml:"client_binaries"`
-	SocksPorts        []int        `yaml:"socks_ports"`
-	ControlPorts      []int        `yaml:"control_ports"`
-	SocksLoopbackOnly *bool        `yaml:"socks_loopback_only"`
-	RelayFeed         TorRelayFeed `yaml:"relay_feed"`
+	Enabled           *bool          `yaml:"enabled"`
+	Mode              string         `yaml:"mode"` // deny | audit | allow
+	Vectors           TorVectors     `yaml:"vectors"`
+	ClientBinaries    []string       `yaml:"client_binaries"`
+	SocksPorts        []int          `yaml:"socks_ports"`
+	ControlPorts      []int          `yaml:"control_ports"`
+	SocksLoopbackOnly *bool          `yaml:"socks_loopback_only"`
+	RelayFeed         TorRelayFeed   `yaml:"relay_feed"`
+	OnionRules        []TorOnionRule `yaml:"onion_rules"`
 }
 
 // TorVectors toggles each enforcement door. Pointers so an operator can
@@ -35,6 +36,14 @@ type TorRelayFeed struct {
 	CacheDir     string        `yaml:"cache_dir"`
 }
 
+// TorOnionRule is one Phase 2 gateway rule: match a SOCKS CONNECT target
+// host (a .onion address or a clearnet host, with filepath.Match globbing)
+// and allow or deny it. Evaluated in listed order, first match wins.
+type TorOnionRule struct {
+	Onion    string `yaml:"onion"`
+	Decision string `yaml:"decision"` // allow | deny
+}
+
 // ResolvedTorConfig is the fully-defaulted, value-typed form consumed by
 // internal/tor. All bools are concrete; all lists are non-empty unless
 // the feature is disabled.
@@ -47,6 +56,7 @@ type ResolvedTorConfig struct {
 	ControlPorts      []int
 	SocksLoopbackOnly bool
 	RelayFeed         TorRelayFeed
+	OnionRules        []TorOnionRule
 }
 
 type ResolvedTorVectors struct {
@@ -103,6 +113,13 @@ func ResolveTorConfig(in TorConfig) ResolvedTorConfig {
 	}
 	if out.RelayFeed.Enabled && len(out.RelayFeed.Sources) == 0 && len(out.RelayFeed.LocalLists) == 0 {
 		out.RelayFeed.Sources = []string{DefaultOnionooSource}
+	}
+	for _, r := range in.OnionRules {
+		decision := "deny"
+		if r.Decision == "allow" {
+			decision = "allow"
+		}
+		out.OnionRules = append(out.OnionRules, TorOnionRule{Onion: r.Onion, Decision: decision})
 	}
 	return out
 }

--- a/internal/config/tor_test.go
+++ b/internal/config/tor_test.go
@@ -96,3 +96,34 @@ func TestResolveTorConfig_OnionVectorDisable(t *testing.T) {
 		t.Fatal("disabling onion must not affect other vectors")
 	}
 }
+
+func TestResolveTorConfig_OnionRules(t *testing.T) {
+	in := TorConfig{
+		Mode: "allow",
+		OnionRules: []TorOnionRule{
+			{Onion: "abc.onion", Decision: "allow"},
+			{Onion: "*", Decision: "deny"},
+			{Onion: "weird.onion", Decision: "bogus"}, // invalid → deny
+		},
+	}
+	out := ResolveTorConfig(in)
+	if len(out.OnionRules) != 3 {
+		t.Fatalf("want 3 onion rules, got %d", len(out.OnionRules))
+	}
+	if out.OnionRules[0].Decision != "allow" {
+		t.Errorf("rule0 decision = %q, want allow", out.OnionRules[0].Decision)
+	}
+	if out.OnionRules[1].Decision != "deny" {
+		t.Errorf("rule1 decision = %q, want deny", out.OnionRules[1].Decision)
+	}
+	if out.OnionRules[2].Decision != "deny" {
+		t.Errorf("rule2 (invalid) decision = %q, want deny", out.OnionRules[2].Decision)
+	}
+}
+
+func TestResolveTorConfig_OnionRulesAbsent(t *testing.T) {
+	out := ResolveTorConfig(TorConfig{Mode: "allow"})
+	if len(out.OnionRules) != 0 {
+		t.Fatalf("absent onion_rules should resolve empty, got %d", len(out.OnionRules))
+	}
+}

--- a/internal/netmonitor/socks.go
+++ b/internal/netmonitor/socks.go
@@ -1,10 +1,14 @@
 package netmonitor
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
 	"net"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/tor"
 )
 
 // SOCKS5 reply codes (RFC 1928).
@@ -116,4 +120,117 @@ func encodeConnectReq(req socksReq) []byte {
 func writeSocksReply(w io.Writer, rep byte) error {
 	_, err := w.Write([]byte{socksVer, rep, 0x00, atypIPv4, 0, 0, 0, 0, 0, 0})
 	return err
+}
+
+// TorGatewayPolicy is the subset of *tor.Policy the SOCKS front-end needs.
+type TorGatewayPolicy interface {
+	GatewayActive() bool
+	EvalSocksTarget(host string, port int) (tor.Verdict, bool)
+}
+
+// handleTorSocks terminates a client SOCKS5 CONNECT, evaluates the target
+// against the onion gateway policy, and either proxies the stream to the
+// real Tor SOCKS daemon at upstreamAddr or replies "not allowed by ruleset".
+// Fail-closed on any error. Emits one tor_control{vector:onion} event.
+func handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string) error {
+	defer conn.Close()
+
+	if err := readSocksGreeting(conn); err != nil {
+		return err
+	}
+	if err := writeSocksMethod(conn, 0x00); err != nil { // no-auth
+		return err
+	}
+	req, err := readSocksConnect(conn)
+	if err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+
+	v, ok := pol.EvalSocksTarget(req.host, req.port)
+	if ok {
+		emitOnionEvent(emit, sessionID, commandID, v)
+	}
+	if !ok || v.Decision != "allow" {
+		_ = writeSocksReply(conn, socksRepNotAllowed)
+		return nil
+	}
+
+	up, err := net.DialTimeout("tcp", upstreamAddr, 20*time.Second)
+	if err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	defer up.Close()
+
+	// Act as a SOCKS5 client to the real Tor daemon for the same target.
+	if _, err := up.Write([]byte{socksVer, 0x01, 0x00}); err != nil { // greeting: 1 method, no-auth
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	if _, err := io.ReadFull(up, make([]byte, 2)); err != nil { // method selection
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	if _, err := up.Write(encodeConnectReq(req)); err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	upReply, err := readSocksReply(up)
+	if err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	// Relay the upstream's reply verbatim to the client.
+	if _, err := conn.Write(upReply); err != nil {
+		return err
+	}
+
+	splice(conn, up)
+	return nil
+}
+
+// readSocksReply reads a full SOCKS5 reply (VER REP RSV ATYP ADDR PORT).
+func readSocksReply(r io.Reader) ([]byte, error) {
+	head := make([]byte, 4)
+	if _, err := io.ReadFull(r, head); err != nil {
+		return nil, err
+	}
+	var addrLen int
+	switch head[3] {
+	case atypIPv4:
+		addrLen = 4
+	case atypIPv6:
+		addrLen = 16
+	case atypDomain:
+		lb := make([]byte, 1)
+		if _, err := io.ReadFull(r, lb); err != nil {
+			return nil, err
+		}
+		head = append(head, lb[0])
+		addrLen = int(lb[0])
+	default:
+		return nil, fmt.Errorf("socks: bad reply atyp 0x%02x", head[3])
+	}
+	rest := make([]byte, addrLen+2) // addr + port
+	if _, err := io.ReadFull(r, rest); err != nil {
+		return nil, err
+	}
+	return append(head, rest...), nil
+}
+
+func splice(a, b net.Conn) {
+	errCh := make(chan error, 2)
+	go func() { _, e := io.Copy(a, b); errCh <- e }()
+	go func() { _, e := io.Copy(b, a); errCh <- e }()
+	<-errCh
+}
+
+func emitOnionEvent(emit Emitter, sessionID, commandID string, v tor.Verdict) {
+	if emit == nil {
+		return
+	}
+	ev := tor.BuildControlEvent(sessionID, commandID, 0, v)
+	_ = emit.AppendEvent(context.Background(), ev)
+	emit.Publish(ev)
 }

--- a/internal/netmonitor/socks.go
+++ b/internal/netmonitor/socks.go
@@ -171,9 +171,14 @@ func handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, em
 		_ = writeSocksReply(conn, socksRepGeneralFailure)
 		return err
 	}
-	if _, err := io.ReadFull(up, make([]byte, 2)); err != nil { // method selection
+	methodReply := make([]byte, 2)
+	if _, err := io.ReadFull(up, methodReply); err != nil { // method selection
 		_ = writeSocksReply(conn, socksRepGeneralFailure)
 		return err
+	}
+	if methodReply[0] != socksVer || methodReply[1] != 0x00 { // upstream must accept no-auth
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return fmt.Errorf("socks: upstream selected auth method 0x%02x (want no-auth)", methodReply[1])
 	}
 	if _, err := up.Write(encodeConnectReq(req)); err != nil {
 		_ = writeSocksReply(conn, socksRepGeneralFailure)
@@ -228,12 +233,39 @@ func readSocksReply(r io.Reader) ([]byte, error) {
 	return append(head, rest...), nil
 }
 
-func splice(a, b net.Conn) {
-	errCh := make(chan error, 2)
-	go func() { _, e := io.Copy(a, b); errCh <- e }()
-	go func() { _, e := io.Copy(b, a); errCh <- e }()
-	<-errCh
-	<-errCh
+// splice copies bidirectionally between a and b, returning bytes copied
+// a->b and b->a. When one direction finishes it half-closes the write side
+// of that direction's destination (CloseWrite, or a full Close when the
+// conn has no CloseWrite, e.g. net.Pipe), so the peer sees EOF and the other
+// copy cannot hang on a half-open connection.
+func splice(a, b net.Conn) (ab, ba int64) {
+	done := make(chan struct{}, 2)
+	go func() {
+		n, _ := io.Copy(b, a)
+		ab = n
+		halfCloseWrite(b)
+		done <- struct{}{}
+	}()
+	go func() {
+		n, _ := io.Copy(a, b)
+		ba = n
+		halfCloseWrite(a)
+		done <- struct{}{}
+	}()
+	<-done
+	<-done
+	return ab, ba
+}
+
+// halfCloseWrite signals EOF on c's write side without tearing down its read
+// side when the conn supports it (TCP CloseWrite); otherwise falls back to a
+// full Close (e.g. net.Pipe in tests).
+func halfCloseWrite(c net.Conn) {
+	if cw, ok := c.(interface{ CloseWrite() error }); ok {
+		_ = cw.CloseWrite()
+		return
+	}
+	_ = c.Close()
 }
 
 func emitOnionEvent(emit Emitter, sessionID, commandID string, v tor.Verdict) {

--- a/internal/netmonitor/socks.go
+++ b/internal/netmonitor/socks.go
@@ -151,6 +151,9 @@ func handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, em
 	if ok {
 		emitOnionEvent(emit, sessionID, commandID, v)
 	}
+	// Callers invoke handleTorSocks only when GatewayActive() is true.
+	// ok=false means the policy returned no verdict; treat as fail-closed
+	// (reply not-allowed, emit no event — there is no decision to report).
 	if !ok || v.Decision != "allow" {
 		_ = writeSocksReply(conn, socksRepNotAllowed)
 		return nil
@@ -184,6 +187,12 @@ func handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, em
 	// Relay the upstream's reply verbatim to the client.
 	if _, err := conn.Write(upReply); err != nil {
 		return err
+	}
+
+	// Only enter bidirectional proxy when the upstream accepted the connection.
+	// A non-success reply means Tor refused it; do not splice a refused stream.
+	if len(upReply) < 2 || upReply[1] != socksRepSuccess {
+		return nil
 	}
 
 	splice(conn, up)
@@ -223,6 +232,7 @@ func splice(a, b net.Conn) {
 	errCh := make(chan error, 2)
 	go func() { _, e := io.Copy(a, b); errCh <- e }()
 	go func() { _, e := io.Copy(b, a); errCh <- e }()
+	<-errCh
 	<-errCh
 }
 

--- a/internal/netmonitor/socks.go
+++ b/internal/netmonitor/socks.go
@@ -1,0 +1,119 @@
+package netmonitor
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+)
+
+// SOCKS5 reply codes (RFC 1928).
+const (
+	socksVer               = 0x05
+	socksCmdConnect        = 0x01
+	socksRepSuccess        = 0x00
+	socksRepGeneralFailure = 0x01
+	socksRepNotAllowed     = 0x02 // connection not allowed by ruleset
+
+	atypIPv4   = 0x01
+	atypDomain = 0x03
+	atypIPv6   = 0x04
+)
+
+// readSocksGreeting consumes the client's method-selection greeting:
+// VER NMETHODS METHODS...
+func readSocksGreeting(r io.Reader) error {
+	head := make([]byte, 2)
+	if _, err := io.ReadFull(r, head); err != nil {
+		return err
+	}
+	if head[0] != socksVer {
+		return fmt.Errorf("socks: bad version 0x%02x", head[0])
+	}
+	n := int(head[1])
+	if n > 0 {
+		if _, err := io.ReadFull(r, make([]byte, n)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// writeSocksMethod replies to the greeting with the selected method.
+func writeSocksMethod(w io.Writer, method byte) error {
+	_, err := w.Write([]byte{socksVer, method})
+	return err
+}
+
+type socksReq struct {
+	atyp byte
+	addr []byte // raw address bytes (domain text, or 4/16-byte IP)
+	host string
+	port int
+}
+
+// readSocksConnect reads a CONNECT request: VER CMD RSV ATYP ADDR PORT.
+func readSocksConnect(r io.Reader) (socksReq, error) {
+	head := make([]byte, 4)
+	if _, err := io.ReadFull(r, head); err != nil {
+		return socksReq{}, err
+	}
+	if head[0] != socksVer {
+		return socksReq{}, fmt.Errorf("socks: bad version 0x%02x", head[0])
+	}
+	if head[1] != socksCmdConnect {
+		return socksReq{}, fmt.Errorf("socks: unsupported command 0x%02x", head[1])
+	}
+	var req socksReq
+	req.atyp = head[3]
+	switch req.atyp {
+	case atypIPv4:
+		req.addr = make([]byte, 4)
+		if _, err := io.ReadFull(r, req.addr); err != nil {
+			return socksReq{}, err
+		}
+		req.host = net.IP(req.addr).String()
+	case atypIPv6:
+		req.addr = make([]byte, 16)
+		if _, err := io.ReadFull(r, req.addr); err != nil {
+			return socksReq{}, err
+		}
+		req.host = net.IP(req.addr).String()
+	case atypDomain:
+		lb := make([]byte, 1)
+		if _, err := io.ReadFull(r, lb); err != nil {
+			return socksReq{}, err
+		}
+		req.addr = make([]byte, int(lb[0]))
+		if _, err := io.ReadFull(r, req.addr); err != nil {
+			return socksReq{}, err
+		}
+		req.host = string(req.addr)
+	default:
+		return socksReq{}, fmt.Errorf("socks: bad atyp 0x%02x", req.atyp)
+	}
+	portB := make([]byte, 2)
+	if _, err := io.ReadFull(r, portB); err != nil {
+		return socksReq{}, err
+	}
+	req.port = int(binary.BigEndian.Uint16(portB))
+	return req, nil
+}
+
+// encodeConnectReq re-serializes a CONNECT request for the upstream Tor SOCKS.
+func encodeConnectReq(req socksReq) []byte {
+	out := []byte{socksVer, socksCmdConnect, 0x00, req.atyp}
+	if req.atyp == atypDomain {
+		out = append(out, byte(len(req.addr)))
+	}
+	out = append(out, req.addr...)
+	var p [2]byte
+	binary.BigEndian.PutUint16(p[:], uint16(req.port))
+	return append(out, p[:]...)
+}
+
+// writeSocksReply writes a reply with a null IPv4 bind address.
+func writeSocksReply(w io.Writer, rep byte) error {
+	_, err := w.Write([]byte{socksVer, rep, 0x00, atypIPv4, 0, 0, 0, 0, 0, 0})
+	return err
+}

--- a/internal/netmonitor/socks_handler_test.go
+++ b/internal/netmonitor/socks_handler_test.go
@@ -1,0 +1,153 @@
+package netmonitor
+
+import (
+	"context"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agentsh/agentsh/internal/tor"
+	"github.com/agentsh/agentsh/pkg/types"
+)
+
+// fakeGatewayPolicy allows exactly one host.
+type fakeGatewayPolicy struct{ allow string }
+
+func (f fakeGatewayPolicy) GatewayActive() bool { return true }
+func (f fakeGatewayPolicy) EvalSocksTarget(host string, port int) (tor.Verdict, bool) {
+	dec := "deny"
+	if host == f.allow {
+		dec = "allow"
+	}
+	return tor.Verdict{Vector: tor.VectorOnion, Mode: "allow", Decision: dec, Target: host}, true
+}
+
+// torCaptureEmitter records published events (thread-safe; named to avoid
+// collision with the plain captureEmitter in dns_test.go).
+type torCaptureEmitter struct {
+	mu  sync.Mutex
+	evs []types.Event
+}
+
+func (c *torCaptureEmitter) AppendEvent(_ context.Context, ev types.Event) error {
+	c.mu.Lock()
+	c.evs = append(c.evs, ev)
+	c.mu.Unlock()
+	return nil
+}
+func (c *torCaptureEmitter) Publish(_ types.Event) {}
+func (c *torCaptureEmitter) events() []types.Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]types.Event(nil), c.evs...)
+}
+
+// fakeTorUpstream is a minimal SOCKS5 server that always succeeds and echoes.
+func fakeTorUpstream(t *testing.T) (addr string, stop func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer c.Close()
+				_ = readSocksGreeting(c)
+				_ = writeSocksMethod(c, 0x00)
+				if _, err := readSocksConnect(c); err != nil {
+					return
+				}
+				_ = writeSocksReply(c, socksRepSuccess)
+				_, _ = io.Copy(c, c) // echo
+			}()
+		}
+	}()
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+// driveClient runs a SOCKS5 client handshake for host:port over conn and returns the reply code.
+func driveClient(t *testing.T, conn net.Conn, host string, port int) byte {
+	t.Helper()
+	_, _ = conn.Write([]byte{0x05, 0x01, 0x00}) // greeting
+	method := make([]byte, 2)
+	if _, err := io.ReadFull(conn, method); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = conn.Write(encodeConnectReq(socksReq{atyp: atypDomain, addr: []byte(host), host: host, port: port}))
+	reply := make([]byte, 10)
+	if _, err := io.ReadFull(conn, reply); err != nil {
+		t.Fatal(err)
+	}
+	return reply[1]
+}
+
+func TestHandleTorSocks_Allowed(t *testing.T) {
+	upstream, stop := fakeTorUpstream(t)
+	defer stop()
+
+	client, server := net.Pipe()
+	emit := &torCaptureEmitter{}
+	go func() {
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+	}()
+
+	rep := driveClient(t, client, "ok.onion", 443)
+	if rep != socksRepSuccess {
+		t.Fatalf("allowed target got reply 0x%02x, want success", rep)
+	}
+	// data path echoes through real upstream
+	_, _ = client.Write([]byte("ping"))
+	got := make([]byte, 4)
+	_ = client.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, err := io.ReadFull(client, got); err != nil {
+		t.Fatalf("echo read: %v", err)
+	}
+	if string(got) != "ping" {
+		t.Fatalf("echo = %q", got)
+	}
+	client.Close()
+
+	assertOneOnionEvent(t, emit, "allow")
+}
+
+func TestHandleTorSocks_Denied(t *testing.T) {
+	upstream, stop := fakeTorUpstream(t)
+	defer stop()
+
+	client, server := net.Pipe()
+	emit := &torCaptureEmitter{}
+	go func() {
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+	}()
+
+	rep := driveClient(t, client, "blocked.onion", 443)
+	if rep != socksRepNotAllowed {
+		t.Fatalf("denied target got reply 0x%02x, want not-allowed", rep)
+	}
+	client.Close()
+	assertOneOnionEvent(t, emit, "deny")
+}
+
+func assertOneOnionEvent(t *testing.T, emit *torCaptureEmitter, wantDecision string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, ev := range emit.events() {
+			if ev.Type == "tor_control" && ev.Fields["vector"] == tor.VectorOnion {
+				if ev.Fields["decision"] != wantDecision {
+					t.Fatalf("event decision = %v, want %v", ev.Fields["decision"], wantDecision)
+				}
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("no tor_control{vector:onion,decision:%s} event seen", wantDecision)
+}

--- a/internal/netmonitor/socks_handler_test.go
+++ b/internal/netmonitor/socks_handler_test.go
@@ -47,6 +47,13 @@ func (c *torCaptureEmitter) events() []types.Event {
 // fakeTorUpstream is a minimal SOCKS5 server that always succeeds and echoes.
 func fakeTorUpstream(t *testing.T) (addr string, stop func()) {
 	t.Helper()
+	return fakeTorUpstreamWithReply(t, socksRepSuccess)
+}
+
+// fakeTorUpstreamWithReply is like fakeTorUpstream but sends the given reply code.
+// When the reply is non-success, it closes after sending the reply (no echo).
+func fakeTorUpstreamWithReply(t *testing.T, rep byte) (addr string, stop func()) {
+	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
@@ -64,8 +71,10 @@ func fakeTorUpstream(t *testing.T) (addr string, stop func()) {
 				if _, err := readSocksConnect(c); err != nil {
 					return
 				}
-				_ = writeSocksReply(c, socksRepSuccess)
-				_, _ = io.Copy(c, c) // echo
+				_ = writeSocksReply(c, rep)
+				if rep == socksRepSuccess {
+					_, _ = io.Copy(c, c) // echo only on success
+				}
 			}()
 		}
 	}()
@@ -150,4 +159,40 @@ func assertOneOnionEvent(t *testing.T, emit *torCaptureEmitter, wantDecision str
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("no tor_control{vector:onion,decision:%s} event seen", wantDecision)
+}
+
+// TestHandleTorSocks_UpstreamRefuses verifies that when the upstream Tor daemon
+// replies with a non-success code, the handler forwards that reply to the client
+// and returns promptly without entering bidirectional proxy mode.
+func TestHandleTorSocks_UpstreamRefuses(t *testing.T) {
+	upstream, stop := fakeTorUpstreamWithReply(t, socksRepGeneralFailure)
+	defer stop()
+
+	client, server := net.Pipe()
+	emit := &torCaptureEmitter{}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+	}()
+
+	// Drive client: should receive the upstream's non-success reply.
+	rep := driveClient(t, client, "ok.onion", 443)
+	if rep != socksRepGeneralFailure {
+		t.Fatalf("upstream-refused target got reply 0x%02x, want general-failure (0x%02x)", rep, socksRepGeneralFailure)
+	}
+
+	// Close the client side; the handler must exit without hanging.
+	client.Close()
+
+	// Bound the wait so the test never hangs if splice is called unexpectedly.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleTorSocks did not return after upstream refusal (possible spurious splice)")
+	}
+
+	// The allow event should still have been emitted for the allowed target.
+	assertOneOnionEvent(t, emit, "allow")
 }

--- a/internal/netmonitor/socks_handler_test.go
+++ b/internal/netmonitor/socks_handler_test.go
@@ -196,3 +196,167 @@ func TestHandleTorSocks_UpstreamRefuses(t *testing.T) {
 	// The allow event should still have been emitted for the allowed target.
 	assertOneOnionEvent(t, emit, "allow")
 }
+
+// fakeTorUpstreamRequiresAuth is a fake upstream that rejects the method
+// negotiation by replying with method 0xFF (no acceptable method) — simulating
+// a misconfigured or auth-requiring upstream.
+func fakeTorUpstreamRequiresAuth(t *testing.T) (addr string, stop func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer c.Close()
+				_ = readSocksGreeting(c)
+				// Reply with 0xFF — no acceptable method / auth required.
+				_ = writeSocksMethod(c, 0xFF)
+				// Do not read a CONNECT or send a CONNECT reply; just close.
+			}()
+		}
+	}()
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+// TestHandleTorSocks_UpstreamRequiresAuth verifies that when the upstream
+// selects a non-zero (auth-requiring) method, the handler sends
+// socksRepGeneralFailure to the client and returns promptly — no splice.
+func TestHandleTorSocks_UpstreamRequiresAuth(t *testing.T) {
+	upstream, stop := fakeTorUpstreamRequiresAuth(t)
+	defer stop()
+
+	client, server := net.Pipe()
+	emit := &torCaptureEmitter{}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+	}()
+
+	// The client must get a general-failure reply — not a success, not a hang.
+	_ = client.SetDeadline(time.Now().Add(2 * time.Second))
+	rep := driveClient(t, client, "ok.onion", 443)
+	if rep != socksRepGeneralFailure {
+		t.Fatalf("auth-requiring upstream: client got reply 0x%02x, want general-failure (0x%02x)", rep, socksRepGeneralFailure)
+	}
+	client.Close()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleTorSocks did not return after upstream required auth (possible spurious splice)")
+	}
+
+	// Policy is evaluated (and the onion event emitted) before the upstream
+	// auth failure, so an allow event is still recorded.
+	assertOneOnionEvent(t, emit, "allow")
+}
+
+// TestSplice_HalfClose verifies that splice returns the correct byte counts and
+// does not hang when one direction EOF's. Uses a real TCP socket pair so that
+// CloseWrite is exercised (net.Pipe does not implement CloseWrite).
+func TestSplice_HalfClose(t *testing.T) {
+	// Set up a real TCP listener.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		accepted <- c
+	}()
+
+	dialConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	listenConn := <-accepted
+
+	// We'll use a second real TCP pair as the "b" side of splice.
+	ln2, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln2.Close()
+
+	accepted2 := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln2.Accept()
+		if err != nil {
+			return
+		}
+		accepted2 <- c
+	}()
+
+	dialConn2, err := net.Dial("tcp", ln2.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	listenConn2 := <-accepted2
+
+	// a = listenConn  (receives from dialConn, sends to dialConn)
+	// b = listenConn2 (receives from dialConn2, sends to dialConn2)
+	// splice(a, b): ab = a->b, ba = b->a
+	//
+	// To drive bytes a->b: write on dialConn, then CloseWrite dialConn so
+	//   listenConn reads EOF (io.Copy a->b finishes).
+	// To drive bytes b->a: write on dialConn2, then CloseWrite dialConn2 so
+	//   listenConn2 reads EOF (io.Copy b->a finishes).
+
+	aPayload := []byte("hello from a")
+	bPayload := []byte("world from b")
+
+	// Write a->b side and close-write so splice can drain it.
+	if _, err := dialConn.Write(aPayload); err != nil {
+		t.Fatal(err)
+	}
+	if err := dialConn.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+	// Write b->a side and close-write.
+	if _, err := dialConn2.Write(bPayload); err != nil {
+		t.Fatal(err)
+	}
+	if err := dialConn2.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatal(err)
+	}
+
+	type result struct {
+		ab, ba int64
+	}
+	ch := make(chan result, 1)
+	go func() {
+		ab, ba := splice(listenConn, listenConn2)
+		ch <- result{ab, ba}
+	}()
+
+	select {
+	case r := <-ch:
+		if r.ab != int64(len(aPayload)) {
+			t.Errorf("ab bytes = %d, want %d", r.ab, len(aPayload))
+		}
+		if r.ba != int64(len(bPayload)) {
+			t.Errorf("ba bytes = %d, want %d", r.ba, len(bPayload))
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("splice did not return (half-close hang)")
+	}
+
+	dialConn.Close()
+	dialConn2.Close()
+	listenConn.Close()
+	listenConn2.Close()
+}

--- a/internal/netmonitor/socks_test.go
+++ b/internal/netmonitor/socks_test.go
@@ -1,0 +1,68 @@
+package netmonitor
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestReadSocksConnect_Domain(t *testing.T) {
+	// VER CMD RSV ATYP LEN "ab.onion" PORT(443)
+	host := "ab.onion"
+	buf := []byte{0x05, 0x01, 0x00, 0x03, byte(len(host))}
+	buf = append(buf, []byte(host)...)
+	buf = append(buf, 0x01, 0xBB) // 443
+	req, err := readSocksConnect(bytes.NewReader(buf))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.host != "ab.onion" || req.port != 443 || req.atyp != 0x03 {
+		t.Fatalf("got host=%q port=%d atyp=%d", req.host, req.port, req.atyp)
+	}
+}
+
+func TestReadSocksConnect_IPv4(t *testing.T) {
+	buf := []byte{0x05, 0x01, 0x00, 0x01, 10, 0, 0, 7, 0x00, 0x50} // 10.0.0.7:80
+	req, err := readSocksConnect(bytes.NewReader(buf))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.host != "10.0.0.7" || req.port != 80 {
+		t.Fatalf("got host=%q port=%d", req.host, req.port)
+	}
+}
+
+func TestReadSocksConnect_RejectsNonConnect(t *testing.T) {
+	buf := []byte{0x05, 0x02, 0x00, 0x01, 1, 1, 1, 1, 0, 80} // CMD=2 (bind)
+	if _, err := readSocksConnect(bytes.NewReader(buf)); err == nil {
+		t.Fatal("expected error for non-CONNECT command")
+	}
+}
+
+func TestEncodeConnectReq_RoundTrips(t *testing.T) {
+	host := "x.onion"
+	in := []byte{0x05, 0x01, 0x00, 0x03, byte(len(host))}
+	in = append(in, []byte(host)...)
+	in = append(in, 0x01, 0xBB)
+	req, err := readSocksConnect(bytes.NewReader(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := encodeConnectReq(req); !bytes.Equal(got, in) {
+		t.Fatalf("re-encode mismatch:\n got %v\nwant %v", got, in)
+	}
+}
+
+func TestGreetingAndReply(t *testing.T) {
+	greet := []byte{0x05, 0x01, 0x00} // 1 method: no-auth
+	if err := readSocksGreeting(bytes.NewReader(greet)); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	if err := writeSocksReply(&out, socksRepNotAllowed); err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{0x05, socksRepNotAllowed, 0x00, 0x01, 0, 0, 0, 0, 0, 0}
+	if !bytes.Equal(out.Bytes(), want) {
+		t.Fatalf("reply = %v, want %v", out.Bytes(), want)
+	}
+}

--- a/internal/netmonitor/transparent_tcp.go
+++ b/internal/netmonitor/transparent_tcp.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"io"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -182,20 +181,8 @@ func (t *TransparentTCP) handle(conn net.Conn) error {
 	}
 	defer up.Close()
 
-	var upBytes, downBytes int64
-	errCh := make(chan error, 2)
-	go func() {
-		n, e := io.Copy(up, conn)
-		upBytes = n
-		errCh <- e
-	}()
-	go func() {
-		n, e := io.Copy(conn, up)
-		downBytes = n
-		errCh <- e
-	}()
-	<-errCh
-	<-errCh
+	// conn->up = upBytes (sent), up->conn = downBytes (received).
+	upBytes, downBytes := splice(conn, up)
 
 	closeEv := t.netEvent("net_close", commandID, domain, remote, dstPort, dec, map[string]any{"bytes_sent": upBytes, "bytes_received": downBytes})
 	_ = t.emit.AppendEvent(context.Background(), closeEv)

--- a/internal/netmonitor/transparent_tcp.go
+++ b/internal/netmonitor/transparent_tcp.go
@@ -33,6 +33,8 @@ type TransparentTCP struct {
 	emit      Emitter
 	dbBypass  atomic.Pointer[dbevents.BypassEmitter]
 
+	torGW atomic.Pointer[torGatewayConfig]
+
 	ln   net.Listener
 	wg   sync.WaitGroup
 	done chan struct{}
@@ -113,6 +115,10 @@ func (t *TransparentTCP) handle(conn net.Conn) error {
 		commandID = t.sess.CurrentCommandID()
 	}
 	engine := t.policyEngine()
+
+	if cfg, ok := t.torGatewayFor(dstPort); ok {
+		return handleTorSocks(conn, cfg.upstream, cfg.pol, t.emit, t.sessionID, commandID)
+	}
 
 	domain := dstIP.String()
 	if t.dnsCache != nil {
@@ -295,6 +301,43 @@ func (t *TransparentTCP) netEvent(evType string, commandID string, domain string
 		},
 	}
 	return ev
+}
+
+type torGatewayConfig struct {
+	pol        TorGatewayPolicy
+	upstream   string
+	socksPorts map[int]struct{}
+}
+
+// SetTorGateway enables (or, with nil/empty args, disables) Phase 2 onion
+// gateway routing for connections whose original destination is a Tor SOCKS
+// port. Safe to call concurrently.
+func (t *TransparentTCP) SetTorGateway(pol TorGatewayPolicy, upstream string, socksPorts []int) {
+	if t == nil {
+		return
+	}
+	if pol == nil || upstream == "" || len(socksPorts) == 0 {
+		t.torGW.Store(nil)
+		return
+	}
+	ports := make(map[int]struct{}, len(socksPorts))
+	for _, p := range socksPorts {
+		ports[p] = struct{}{}
+	}
+	t.torGW.Store(&torGatewayConfig{pol: pol, upstream: upstream, socksPorts: ports})
+}
+
+// torGatewayFor returns the gateway config when it is active and port is a
+// configured Tor SOCKS port.
+func (t *TransparentTCP) torGatewayFor(port int) (*torGatewayConfig, bool) {
+	cfg := t.torGW.Load()
+	if cfg == nil || !cfg.pol.GatewayActive() {
+		return nil, false
+	}
+	if _, ok := cfg.socksPorts[port]; !ok {
+		return nil, false
+	}
+	return cfg, true
 }
 
 func originalDst(c *net.TCPConn) (net.IP, int, error) {

--- a/internal/netmonitor/transparent_tcp_gateway_test.go
+++ b/internal/netmonitor/transparent_tcp_gateway_test.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+package netmonitor
+
+import "testing"
+
+func TestSetTorGateway_PortPredicate(t *testing.T) {
+	tcp := &TransparentTCP{}
+	tcp.SetTorGateway(fakeGatewayPolicy{allow: "ok.onion"}, "127.0.0.1:9050", []int{9050, 9150})
+
+	if _, ok := tcp.torGatewayFor(9050); !ok {
+		t.Error("9050 should route to gateway")
+	}
+	if _, ok := tcp.torGatewayFor(9150); !ok {
+		t.Error("9150 should route to gateway")
+	}
+	if _, ok := tcp.torGatewayFor(443); ok {
+		t.Error("443 must NOT route to gateway")
+	}
+
+	// Clearing disables routing.
+	tcp.SetTorGateway(nil, "", nil)
+	if _, ok := tcp.torGatewayFor(9050); ok {
+		t.Error("cleared gateway must not route")
+	}
+}

--- a/internal/netmonitor/transparent_tcp_unsupported.go
+++ b/internal/netmonitor/transparent_tcp_unsupported.go
@@ -20,4 +20,6 @@ func StartTransparentTCP(listenAddr string, sessionID string, sess *session.Sess
 
 func (t *TransparentTCP) SetDBBypassEmitter(em *dbevents.BypassEmitter) {}
 
+func (t *TransparentTCP) SetTorGateway(pol TorGatewayPolicy, upstream string, socksPorts []int) {}
+
 func (t *TransparentTCP) Close() error { return nil }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -80,7 +80,6 @@ type Server struct {
 	threatStore  *threatfeed.Store
 
 	torSyncer *tor.Syncer
-	torPol    *tor.Policy
 
 	skillcheckDaemon *skillcheck.Daemon // nil when skillcheck.enabled=false
 
@@ -783,7 +782,6 @@ func New(cfg *config.Config) (*Server, error) {
 		threatSyncer:     threatSyncer,
 		threatStore:      threatStore,
 		torSyncer:        torSyncer,
-		torPol:           torPol,
 		skillcheckDaemon: skillcheckDaemon,
 		app:              app,
 		kmsProvider:      kmsProvider,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -80,6 +80,7 @@ type Server struct {
 	threatStore  *threatfeed.Store
 
 	torSyncer *tor.Syncer
+	torPol    *tor.Policy
 
 	skillcheckDaemon *skillcheck.Daemon // nil when skillcheck.enabled=false
 
@@ -202,15 +203,17 @@ func New(cfg *config.Config) (*Server, error) {
 
 	torCfg := config.ResolveTorConfig(cfg.Tor)
 	var torSyncer *tor.Syncer
+	var torPol *tor.Policy
 	if torCfg.Enabled {
 		// Default the relay-feed cache dir alongside the threat-feed cache.
 		if torCfg.RelayFeed.Enabled && torCfg.RelayFeed.CacheDir == "" {
 			torCfg.RelayFeed.CacheDir = filepath.Join(config.GetDataDir(), "tor-relays")
 		}
-		torPol, err := tor.New(torCfg)
+		p, err := tor.New(torCfg)
 		if err != nil {
 			return nil, fmt.Errorf("tor policy: %w", err)
 		}
+		torPol = p
 		engine.SetTorPolicy(&tor.PolicyAdapter{Policy: torPol})
 		slog.Info("tor access control enabled", "mode", torCfg.Mode)
 		if torPol.RelayFeedEnabled() {
@@ -553,7 +556,7 @@ func New(cfg *config.Config) (*Server, error) {
 		}
 	}
 
-	app := api.NewApp(cfg, sessions, store, engine, broker, apiKeyAuth, oidcAuth, approvalsMgr, metricsCollector, policyLoader, cgroupMgr)
+	app := api.NewApp(cfg, sessions, store, engine, broker, apiKeyAuth, oidcAuth, approvalsMgr, metricsCollector, policyLoader, cgroupMgr, torPol)
 	// Publish to the WTP install hook so subsequent pushed-policy
 	// receipts can SwapPolicy in-process (next CheckCommand sees the
 	// new rules without an agentsh restart).
@@ -780,6 +783,7 @@ func New(cfg *config.Config) (*Server, error) {
 		threatSyncer:     threatSyncer,
 		threatStore:      threatStore,
 		torSyncer:        torSyncer,
+		torPol:           torPol,
 		skillcheckDaemon: skillcheckDaemon,
 		app:              app,
 		kmsProvider:      kmsProvider,

--- a/internal/server/wtp_install_hook_test.go
+++ b/internal/server/wtp_install_hook_test.go
@@ -42,10 +42,10 @@ func (memEventStore) Close() error { return nil }
 type installHookFixture struct {
 	policiesDir string
 	trustDir    string
-	keyID       string                    // hex(sha256(pub))
+	keyID       string // hex(sha256(pub))
 	privKey     ed25519.PrivateKey
-	manager     *policy.Manager           // points at policiesDir
-	appHolder   *atomic.Pointer[api.App]  // intentionally empty; SwapPolicy skipped
+	manager     *policy.Manager          // points at policiesDir
+	appHolder   *atomic.Pointer[api.App] // intentionally empty; SwapPolicy skipped
 }
 
 // newInstallHookFixture writes a real ed25519 keypair into the trust
@@ -271,14 +271,14 @@ func TestMakePolicyInstallHook_NoTrustStore_ReturnsNil(t *testing.T) {
 //
 // Two arms:
 //
-//   1. EngineSwapped path: pm + a non-nil App in the appHolder so the
-//      first call reaches SwapPolicy and flips the dedup gate. The
-//      second call with matching (id, hash) MUST short-circuit; the
-//      proof is that a file deleted between the two calls stays gone.
+//  1. EngineSwapped path: pm + a non-nil App in the appHolder so the
+//     first call reaches SwapPolicy and flips the dedup gate. The
+//     second call with matching (id, hash) MUST short-circuit; the
+//     proof is that a file deleted between the two calls stays gone.
 //
-//   2. EngineNotSwapped path: appHolder.Load() returns nil so the
-//      first call skips SwapPolicy. The second call MUST re-run the
-//      install — dedup requires engineSwapped=true.
+//  2. EngineNotSwapped path: appHolder.Load() returns nil so the
+//     first call skips SwapPolicy. The second call MUST re-run the
+//     install — dedup requires engineSwapped=true.
 func TestMakePolicyInstallHook_IdempotentReinstall(t *testing.T) {
 	t.Run("dedups after engine swap", func(t *testing.T) {
 		f := newInstallHookFixture(t)
@@ -295,7 +295,7 @@ func TestMakePolicyInstallHook_IdempotentReinstall(t *testing.T) {
 			composite.New(memEventStore{}, nil),
 			initial,
 			events.NewBroker(),
-			nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil,
 		)
 		f.appHolder.Store(app)
 
@@ -370,7 +370,7 @@ func TestMakePolicyInstallHook_IdempotentReinstall(t *testing.T) {
 			composite.New(memEventStore{}, nil),
 			initial,
 			events.NewBroker(),
-			nil, nil, nil, nil, nil, nil,
+			nil, nil, nil, nil, nil, nil, nil,
 		)
 		f.appHolder.Store(app)
 
@@ -471,7 +471,7 @@ command_rules:
 		composite.New(memEventStore{}, nil),
 		engineP1,
 		events.NewBroker(),
-		nil, nil, nil, nil, nil, nil,
+		nil, nil, nil, nil, nil, nil, nil,
 	)
 	f.appHolder.Store(app)
 

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -98,6 +98,8 @@ type Session struct {
 	// Injected into spawned processes bypassing policy filtering.
 	// Nil if no services declare inject.env.
 	serviceEnvVars map[string]string
+
+	torGatewayAddr string // per-session Tor onion-gateway upstream addr (empty if none)
 }
 
 // SetPolicyEngine stores the session-specific policy engine with expanded variables.
@@ -136,6 +138,20 @@ func (s *Session) SetServiceEnvVars(env map[string]string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.serviceEnvVars = env
+}
+
+// SetTorGatewayAddr records the per-session Tor onion-gateway upstream addr.
+func (s *Session) SetTorGatewayAddr(addr string) {
+	s.mu.Lock()
+	s.torGatewayAddr = addr
+	s.mu.Unlock()
+}
+
+// TorGatewayAddr returns the recorded gateway upstream addr (empty if none).
+func (s *Session) TorGatewayAddr() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.torGatewayAddr
 }
 
 // ServiceEnvVars returns a copy of the service env var map.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -98,8 +98,6 @@ type Session struct {
 	// Injected into spawned processes bypassing policy filtering.
 	// Nil if no services declare inject.env.
 	serviceEnvVars map[string]string
-
-	torGatewayAddr string // per-session Tor onion-gateway upstream addr (empty if none)
 }
 
 // SetPolicyEngine stores the session-specific policy engine with expanded variables.
@@ -138,20 +136,6 @@ func (s *Session) SetServiceEnvVars(env map[string]string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.serviceEnvVars = env
-}
-
-// SetTorGatewayAddr records the per-session Tor onion-gateway upstream addr.
-func (s *Session) SetTorGatewayAddr(addr string) {
-	s.mu.Lock()
-	s.torGatewayAddr = addr
-	s.mu.Unlock()
-}
-
-// TorGatewayAddr returns the recorded gateway upstream addr (empty if none).
-func (s *Session) TorGatewayAddr() string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.torGatewayAddr
 }
 
 // ServiceEnvVars returns a copy of the service env var map.

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -674,14 +674,3 @@ func TestSessionCleanup_ClosesDBProxy(t *testing.T) {
 		t.Fatalf("DBProxySocketDir after cleanup = %q, want empty", got)
 	}
 }
-
-func TestSession_TorGatewayAddr(t *testing.T) {
-	s := &Session{}
-	if s.TorGatewayAddr() != "" {
-		t.Error("default gateway addr should be empty")
-	}
-	s.SetTorGatewayAddr("127.0.0.1:9050")
-	if s.TorGatewayAddr() != "127.0.0.1:9050" {
-		t.Errorf("got %q", s.TorGatewayAddr())
-	}
-}

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -674,3 +674,14 @@ func TestSessionCleanup_ClosesDBProxy(t *testing.T) {
 		t.Fatalf("DBProxySocketDir after cleanup = %q, want empty", got)
 	}
 }
+
+func TestSession_TorGatewayAddr(t *testing.T) {
+	s := &Session{}
+	if s.TorGatewayAddr() != "" {
+		t.Error("default gateway addr should be empty")
+	}
+	s.SetTorGatewayAddr("127.0.0.1:9050")
+	if s.TorGatewayAddr() != "127.0.0.1:9050" {
+		t.Errorf("got %q", s.TorGatewayAddr())
+	}
+}

--- a/internal/tor/gateway.go
+++ b/internal/tor/gateway.go
@@ -56,3 +56,11 @@ func (p *Policy) UpstreamSocksAddr() string {
 	}
 	return net.JoinHostPort("127.0.0.1", strconv.Itoa(p.cfg.SocksPorts[0]))
 }
+
+// ConfiguredSocksPorts returns the SOCKS ports treated as Tor (for routing).
+func (p *Policy) ConfiguredSocksPorts() []int {
+	if p == nil {
+		return nil
+	}
+	return append([]int(nil), p.cfg.SocksPorts...)
+}

--- a/internal/tor/gateway.go
+++ b/internal/tor/gateway.go
@@ -1,0 +1,58 @@
+package tor
+
+import (
+	"net"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// onionRule is a compiled Phase 2 gateway rule.
+type onionRule struct {
+	pattern  string // lowercased onion/host glob (filepath.Match)
+	decision string // "allow" | "deny"
+}
+
+// GatewayActive reports whether the Phase 2 SOCKS onion gateway should run:
+// enabled, mode=allow, and at least one onion rule configured.
+func (p *Policy) GatewayActive() bool {
+	return p != nil && p.cfg.Enabled && p.cfg.Mode == ModeAllow && len(p.onionRules) > 0
+}
+
+// EvalSocksTarget evaluates a SOCKS CONNECT target host:port against the
+// onion rules. When the gateway is active it always returns ok=true with a
+// concrete allow/deny decision; an unmatched target fails closed (deny).
+func (p *Policy) EvalSocksTarget(host string, port int) (Verdict, bool) {
+	if !p.GatewayActive() {
+		return Verdict{}, false
+	}
+	h := strings.ToLower(strings.TrimSuffix(strings.TrimSpace(host), "."))
+	target := net.JoinHostPort(host, strconv.Itoa(port))
+	for _, r := range p.onionRules {
+		if r.pattern == h {
+			return p.onionVerdict(r.decision, target), true
+		}
+		if m, err := filepath.Match(r.pattern, h); err == nil && m {
+			return p.onionVerdict(r.decision, target), true
+		}
+	}
+	return p.onionVerdict("deny", target), true // fail closed
+}
+
+func (p *Policy) onionVerdict(decision, target string) Verdict {
+	return Verdict{
+		Vector:   VectorOnion,
+		Mode:     p.cfg.Mode,
+		Decision: decision,
+		Target:   target,
+	}
+}
+
+// UpstreamSocksAddr returns the loopback address of the real Tor SOCKS
+// daemon (the gateway forwards allowed streams here). Empty if unset.
+func (p *Policy) UpstreamSocksAddr() string {
+	if p == nil || len(p.cfg.SocksPorts) == 0 {
+		return ""
+	}
+	return net.JoinHostPort("127.0.0.1", strconv.Itoa(p.cfg.SocksPorts[0]))
+}

--- a/internal/tor/gateway_test.go
+++ b/internal/tor/gateway_test.go
@@ -1,0 +1,81 @@
+package tor
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+)
+
+func gwPolicy(t *testing.T, rules []config.TorOnionRule) *Policy {
+	t.Helper()
+	p, err := New(config.ResolvedTorConfig{
+		Enabled:    true,
+		Mode:       ModeAllow,
+		SocksPorts: []int{9050, 9150},
+		Vectors:    config.ResolvedTorVectors{Processes: true, SocksPorts: true, Onion: true, RelayIPs: true},
+		OnionRules: rules,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestGatewayActive(t *testing.T) {
+	if gwPolicy(t, nil).GatewayActive() {
+		t.Error("no onion_rules → gateway inactive")
+	}
+	if !gwPolicy(t, []config.TorOnionRule{{Onion: "*", Decision: "deny"}}).GatewayActive() {
+		t.Error("allow mode + onion_rules → gateway active")
+	}
+	// deny mode is never a gateway, even with rules.
+	p, _ := New(config.ResolvedTorConfig{Enabled: true, Mode: ModeDeny, SocksPorts: []int{9050},
+		OnionRules: []config.TorOnionRule{{Onion: "*", Decision: "deny"}}})
+	if p.GatewayActive() {
+		t.Error("deny mode must not activate gateway")
+	}
+}
+
+func TestEvalSocksTarget(t *testing.T) {
+	p := gwPolicy(t, []config.TorOnionRule{
+		{Onion: "good.onion", Decision: "allow"},
+		{Onion: "*.evil.onion", Decision: "deny"},
+		{Onion: "*", Decision: "deny"},
+	})
+	cases := []struct {
+		host    string
+		wantDec string
+	}{
+		{"good.onion", "allow"},
+		{"GOOD.onion", "allow"},  // case-insensitive
+		{"x.evil.onion", "deny"}, // glob
+		{"random.onion", "deny"}, // catch-all
+		{"example.com", "deny"},  // clearnet via Tor, catch-all denies
+	}
+	for _, c := range cases {
+		v, ok := p.EvalSocksTarget(c.host, 443)
+		if !ok {
+			t.Fatalf("%s: expected ok (gateway active)", c.host)
+		}
+		if v.Decision != c.wantDec {
+			t.Errorf("%s: decision = %q, want %q", c.host, v.Decision, c.wantDec)
+		}
+		if v.Vector != VectorOnion {
+			t.Errorf("%s: vector = %q, want onion", c.host, v.Vector)
+		}
+	}
+}
+
+func TestEvalSocksTarget_NoMatchFailsClosed(t *testing.T) {
+	p := gwPolicy(t, []config.TorOnionRule{{Onion: "only.onion", Decision: "allow"}})
+	v, ok := p.EvalSocksTarget("other.onion", 443)
+	if !ok || v.Decision != "deny" {
+		t.Fatalf("unmatched target must fail closed: ok=%v dec=%q", ok, v.Decision)
+	}
+}
+
+func TestUpstreamSocksAddr(t *testing.T) {
+	if got := gwPolicy(t, nil).UpstreamSocksAddr(); got != "127.0.0.1:9050" {
+		t.Errorf("UpstreamSocksAddr = %q, want 127.0.0.1:9050", got)
+	}
+}

--- a/internal/tor/policy.go
+++ b/internal/tor/policy.go
@@ -25,13 +25,14 @@ const (
 	VectorOnionDNS  = "onion_dns"
 	VectorOnionHTTP = "onion_http"
 	VectorRelayIP   = "relay_ip"
+	VectorOnion     = "onion" // Phase 2 SOCKS gateway
 )
 
 // Verdict is the result of a positive Tor match.
 type Verdict struct {
 	Vector   string // one of the Vector* constants
 	Mode     string // resolved policy mode
-	Decision string // "deny" or "audit" (allow mode never yields a verdict)
+	Decision string // "deny" or "audit"; also "allow" for the Phase 2 onion gateway
 	Target   string // binary path, ip:port, or onion host
 }
 
@@ -45,6 +46,7 @@ type Policy struct {
 	controlPorts map[int]struct{}
 	seed         *ipset.Set                // directory-authority seed (immutable)
 	relays       atomic.Pointer[ipset.Set] // feed-populated, hot-swappable
+	onionRules   []onionRule               // Phase 2 gateway rules, compiled in order
 }
 
 // New builds a Policy from resolved config. Returns a Policy even when
@@ -70,6 +72,12 @@ func New(cfg config.ResolvedTorConfig) (*Policy, error) {
 	}
 	for _, ip := range DirectoryAuthoritySeed() {
 		_ = p.seed.Add(ip) // seed entries are known-valid
+	}
+	for _, r := range cfg.OnionRules {
+		p.onionRules = append(p.onionRules, onionRule{
+			pattern:  strings.ToLower(strings.TrimSpace(r.Onion)),
+			decision: r.Decision,
+		})
 	}
 	p.relays.Store(ipset.New())
 	return p, nil


### PR DESCRIPTION
## Summary

Implements **Phase 2** of Tor access control (the onion gateway sketched in `docs/superpowers/specs/2026-06-14-tor-access-control-design.md`). When `tor.mode: allow` and an `onion_rules:` list is configured, agentsh becomes a SOCKS5-aware **managed Tor egress**: it terminates the app's SOCKS5 handshake, evaluates the CONNECT target against ordered `onion_rules` (glob, case-insensitive, fail-closed), and either forwards the stream to the real Tor SOCKS daemon or replies "connection not allowed by ruleset" — emitting a `tor_control{vector: onion, decision: allow|deny}` event per CONNECT.

Phase 1 (deny/audit category control) is unchanged: the gateway is inert unless `enabled && mode==allow && len(onion_rules)>0`, and the allow-mode gateway and Phase-1 deny/audit checks are mutually exclusive by mode.

```yaml
tor:
  mode: allow
  onion_rules:
    - onion: "abcdefghij234567.onion"
      decision: allow
    - onion: "*"
      decision: deny
```

## What's in here

- **Config** (`internal/config/tor.go`): `onion_rules` parsing; invalid/empty `decision` → `deny` (fail-closed).
- **Policy** (`internal/tor/{policy.go,gateway.go}`): `GatewayActive()`, `EvalSocksTarget()` (ordered, glob, fail-closed), `VectorOnion`, `UpstreamSocksAddr()`.
- **SOCKS5 front-end** (`internal/netmonitor/socks.go`): greeting/CONNECT/reply wire helpers + `handleTorSocks` — forwards allowed streams to the real Tor SOCKS daemon, resets denied ones, never proxies on a refusing/non-success upstream.
- **Routing** (`internal/netmonitor/transparent_tcp.go`): Tor SOCKS-port connections are handed to the gateway instead of the normal splice path; non-Tor traffic unaffected. Non-linux no-op stub keeps cross-compile clean.
- **Wiring** (`internal/server/server.go`, `internal/api/app.go`, `internal/session/manager.go`): `*tor.Policy` exposed to the App; gateway started per session in the transparent-network setup.

## Honest scope

Per-onion filtering applies only to Tor SOCKS connections that reach agentsh's transparent-TCP interceptor. A loopback Tor daemon outside interception degrades to Phase-1 unfiltered allow — documented in the design spec's Phase 2 "Honest scope" section, not papered over.

## Verification

- `GOOS=windows go build ./...` clean; `go build ./...` clean.
- `internal/ocsf` exhaustiveness green (no new `events.EventType`; `onion` is a new `vector` field value only).
- All touched packages green (`tor`, `config`, `netmonitor`, `api`, `session`, `server`).
- Full `go test ./...`: only a known pre-existing local-env FUSE flake (`internal/fsmonitor`, untouched here, passes in CI).
- Built TDD task-by-task with per-task spec+quality review and a final whole-branch review (verdict: ready to merge; only Minor follow-ups: two dead fields, a pre-existing splice half-close pattern, an upstream method-selection nit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)