### PR TITLE
feat(tor): Tor access control Phase 3 — close allow-mode onion-gateway fail-open

### DIFF
--- a/docs/superpowers/plans/2026-06-20-tor-access-control-phase3.md
+++ b/docs/superpowers/plans/2026-06-20-tor-access-control-phase3.md
@@ -1,0 +1,768 @@
+# Tor Access Control — Phase 3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the Phase-2 allow-mode onion-gateway fail-open gap: guarantee the app's Tor SOCKS connection reaches the gateway (force-redirect), deny Tor for the session when the gateway can't be wired (fail-closed), and fix the pre-existing gap where per-session policy engines drop the Tor coordinator.
+
+**Architecture:** One per-session predicate at startup picks a branch. Force-redirect adds a netns loopback-DNAT for `socks_ports` so loopback Tor reaches the existing transparent-TCP interceptor. Fail-closed attaches a deny-mode Tor policy clone to the session's engine. A foundational task first wires the shared Tor coordinator onto every per-session engine, since the fail-closed seam and Phase-1 enforcement both depend on it.
+
+**Tech Stack:** Go, Linux network namespaces + iptables (`internal/netmonitor/netns_linux.go`), the policy engine + Tor coordinator (`internal/policy`, `internal/tor`), session/app wiring (`internal/api`).
+
+## Global Constraints
+
+- **No new data path; no new `events.EventType`.** Reuse the `tor_control` event (`Type: "tor_control"`, free-form `Fields map[string]any`); add observability via a new `vector` value and `Fields` keys only. (OCSF registry exhaustiveness is keyed on `EventType` — reusing `tor_control` leaves it untouched.)
+- **No new config knobs.** Behavior derives from existing `tor.mode` / `onion_rules` / `socks_ports`.
+- **Never mutate the shared `tor.Policy` or the global `*policy.Engine` for one session.** `SetTorPolicy` writes `e.torChecker` without a lock; only ever call it on a freshly-constructed per-session engine, guarded by `eng != a.Policy()`.
+- **Force-redirect is all-or-nothing.** If any force-redirect step fails to install, the session must NOT proceed with interceptor-up-but-unfiltered-Tor; `SetupNetNS` already `rollbackAll()`s on any rule failure and returns an error, which routes the session to the fail-closed branch.
+- **Rule ordering invariant:** the loopback-DNAT rules for `socks_ports` MUST be emitted before the `127.0.0.0/8 -j RETURN` rule, or the RETURN short-circuits them.
+- **Cross-compile:** `internal/netmonitor/netns_linux.go` is linux-only with a `netns_other.go` stub; any `SetupNetNS` signature change updates BOTH. `GOOS=windows go build ./...` must stay clean.
+- **Staging discipline:** stage only changed files by explicit path; never `git add -A`/`git add .` (the repo carries untracked `.claude/worktrees/*`, `*.key.json`, `.agentsh/`, `.superpowers/sdd/*`).
+- **Branch:** `feat-tor-phase3-gateway-failopen` (already created; design committed at `d797cf26`).
+
+## File Structure
+
+- `internal/api/session_policy.go` — add `attachSessionTor` (Task 0) + `attachDenyTor` (Task 3); both decorate a session engine with a Tor coordinator.
+- `internal/api/core.go` — call `attachSessionTor` before each `s.SetPolicyEngine` (Task 0); call `applyTorFailClosed` after the transparent-network block (Task 3).
+- `internal/tor/policy.go` — add `VectorGateway` const (Task 1).
+- `internal/tor/gateway.go` — add `DenyModeClone` (Task 1).
+- `internal/tor/event.go` — add `BuildGatewayEvent` (Task 1).
+- `internal/netmonitor/netns_linux.go` — add `natOutputRules` pure helper + `torRedirectPorts` param to `SetupNetNS` + `route_localnet` (Task 2).
+- `internal/netmonitor/netns_other.go` — update the `SetupNetNS` stub signature (Task 2).
+- `internal/api/app.go` — pass `socksPorts` into `SetupNetNS`; emit the force-redirect event (Task 2/3); `gatewayBranchFor` predicate (Task 3); static startup advisory (Task 5).
+- `internal/server/server.go` — static startup advisory log (Task 5).
+- `docs/superpowers/specs/2026-06-14-tor-access-control-design.md` — append Phase 3 status (Task 5).
+
+---
+
+### Task 0: Attach the shared Tor coordinator to per-session engines
+
+Fixes the pre-existing gap: a session that compiles its own engine from a named policy file gets `torChecker == nil`, so ptrace `CheckExecve`/`CheckNetwork` skip Tor entirely. The fail-closed seam (Task 3) builds on this.
+
+**Files:**
+- Modify: `internal/api/session_policy.go` (add helper)
+- Modify: `internal/api/core.go:568`, `:758`, `:1500` (call sites — verify exact lines before editing)
+- Test: `internal/api/session_policy_tor_test.go` (create)
+
+**Interfaces:**
+- Consumes: `App.torPolicy *tor.Policy` (app.go:130); `App.Policy() *policy.Engine`; `policy.Engine.SetTorPolicy(tc policy.TorChecker)`; `tor.PolicyAdapter{Policy: *tor.Policy}` (satisfies `policy.TorChecker`).
+- Produces: `func (a *App) attachSessionTor(eng *policy.Engine)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// internal/api/session_policy_tor_test.go
+package api
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/tor"
+)
+
+func newDenyTorPolicy(t *testing.T) *tor.Policy {
+	t.Helper()
+	p, err := tor.New(config.ResolveTorConfig(config.TorConfig{Mode: "deny"}))
+	if err != nil {
+		t.Fatalf("tor.New: %v", err)
+	}
+	return p
+}
+
+// A per-session engine (distinct from the global one) must enforce Tor after
+// attachSessionTor — without it, CheckExecve("tor") would be allowed.
+func TestAttachSessionTor_PerSessionEngineEnforcesTor(t *testing.T) {
+	global, err := policy.NewEngine(&policy.Policy{}, false, true)
+	if err != nil {
+		t.Fatalf("global engine: %v", err)
+	}
+	a := &App{torPolicy: newDenyTorPolicy(t), policy: global}
+
+	sessionEng, err := policy.NewEngine(&policy.Policy{}, false, true)
+	if err != nil {
+		t.Fatalf("session engine: %v", err)
+	}
+	a.attachSessionTor(sessionEng)
+
+	dec := sessionEng.CheckExecve("/usr/bin/tor", []string{"tor"}, 0)
+	if dec.Action != "deny" {
+		t.Fatalf("per-session engine should deny the tor binary, got action=%q", dec.Action)
+	}
+}
+
+// The global engine must NOT be re-decorated (guard prevents racing shared state).
+func TestAttachSessionTor_SkipsGlobalEngine(t *testing.T) {
+	global, err := policy.NewEngine(&policy.Policy{}, false, true)
+	if err != nil {
+		t.Fatalf("global engine: %v", err)
+	}
+	a := &App{torPolicy: newDenyTorPolicy(t), policy: global}
+	a.attachSessionTor(global) // same pointer as a.Policy()
+	// Global had no tor checker; attaching to it is skipped, so tor stays absent.
+	dec := global.CheckExecve("/usr/bin/tor", []string{"tor"}, 0)
+	if dec.Action == "deny" {
+		t.Fatal("global engine must not be decorated by attachSessionTor")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/api/ -run TestAttachSessionTor -v`
+Expected: FAIL — `a.attachSessionTor` undefined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `internal/api/session_policy.go` (add `"github.com/agentsh/agentsh/internal/tor"` to imports):
+
+```go
+// attachSessionTor installs the shared Tor coordinator on a per-session engine.
+// The process-global engine already carries it (set once at server start in
+// server.go); sessions that compiled their own engine from a named policy file
+// would otherwise have torChecker == nil, silently skipping the ptrace
+// connect/execve Tor vectors. Guarded so the shared global engine is never
+// re-written (SetTorPolicy is unsynchronized).
+func (a *App) attachSessionTor(eng *policy.Engine) {
+	if a == nil || a.torPolicy == nil || eng == nil {
+		return
+	}
+	if eng == a.Policy() {
+		return
+	}
+	eng.SetTorPolicy(&tor.PolicyAdapter{Policy: a.torPolicy})
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/api/ -run TestAttachSessionTor -v`
+Expected: PASS (both).
+
+- [ ] **Step 5: Wire the three call sites**
+
+In `internal/api/core.go`, immediately before each `s.SetPolicyEngine(engine)` (lines ~568, ~758, ~1500 — confirm by reading), insert:
+
+```go
+	a.attachSessionTor(engine)
+	s.SetPolicyEngine(engine)
+```
+
+(At line ~1500 the variable is also `engine`; verify the local name at each site and match it.)
+
+- [ ] **Step 6: Build + full api package test + commit**
+
+Run: `go build ./... && go test ./internal/api/ -run 'TestAttachSessionTor|TestSession' -v`
+Expected: PASS.
+
+```bash
+git add internal/api/session_policy.go internal/api/session_policy_tor_test.go internal/api/core.go
+git commit -m "fix(tor): attach Tor coordinator to per-session policy engines"
+```
+
+---
+
+### Task 1: tor-package primitives (VectorGateway, DenyModeClone, BuildGatewayEvent)
+
+**Files:**
+- Modify: `internal/tor/policy.go` (add `VectorGateway` const)
+- Modify: `internal/tor/gateway.go` (add `DenyModeClone`)
+- Modify: `internal/tor/event.go` (add `BuildGatewayEvent`)
+- Test: `internal/tor/gateway_test.go` (add cases), `internal/tor/event_test.go` (add cases) — create if absent.
+
+**Interfaces:**
+- Consumes: `tor.New(cfg config.ResolvedTorConfig) (*Policy, error)`; `Policy.cfg config.ResolvedTorConfig` (unexported, same package); `ModeDeny` const; `types.Event`.
+- Produces: `const VectorGateway = "gateway"`; `func (p *Policy) DenyModeClone() (*Policy, error)`; `func BuildGatewayEvent(sessionID, decision, reason string, enforced bool) types.Event`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// internal/tor/gateway_test.go (add)
+func TestDenyModeClone_ForcesDenyWithoutMutatingOriginal(t *testing.T) {
+	allow, err := New(config.ResolveTorConfig(config.TorConfig{
+		Mode:       "allow",
+		OnionRules: []config.TorOnionRule{{Onion: "*", Decision: "deny"}},
+	}))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	deny, err := allow.DenyModeClone()
+	if err != nil {
+		t.Fatalf("DenyModeClone: %v", err)
+	}
+	if deny.Mode() != ModeDeny {
+		t.Fatalf("clone mode = %q, want deny", deny.Mode())
+	}
+	if allow.Mode() != ModeAllow {
+		t.Fatalf("original mutated: mode = %q, want allow", allow.Mode())
+	}
+	// Deny-mode clone enforces the Phase-1 execve vector; allow-mode never does.
+	if _, ok := deny.EvalExecve("/usr/bin/tor", nil); !ok {
+		t.Fatal("deny clone should match the tor binary via EvalExecve")
+	}
+	if _, ok := allow.EvalExecve("/usr/bin/tor", nil); ok {
+		t.Fatal("allow-mode original should not produce an execve verdict")
+	}
+}
+```
+
+```go
+// internal/tor/event_test.go (add)
+func TestBuildGatewayEvent_Fields(t *testing.T) {
+	ev := BuildGatewayEvent("session-1", "deny", "proxy_env_fallback", false)
+	if ev.Type != "tor_control" {
+		t.Fatalf("type = %q, want tor_control", ev.Type)
+	}
+	if ev.Fields["vector"] != VectorGateway {
+		t.Fatalf("vector = %v, want %q", ev.Fields["vector"], VectorGateway)
+	}
+	if ev.Fields["decision"] != "deny" || ev.Fields["reason"] != "proxy_env_fallback" {
+		t.Fatalf("unexpected fields: %v", ev.Fields)
+	}
+	if ev.Fields["enforced"] != false {
+		t.Fatalf("enforced = %v, want false", ev.Fields["enforced"])
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/tor/ -run 'TestDenyModeClone|TestBuildGatewayEvent' -v`
+Expected: FAIL — undefined `DenyModeClone`, `BuildGatewayEvent`, `VectorGateway`.
+
+- [ ] **Step 3: Implement**
+
+In `internal/tor/policy.go`, add to the Vector constants block:
+
+```go
+	VectorGateway   = "gateway" // Phase 3 session-level onion-gateway wiring outcome
+```
+
+In `internal/tor/gateway.go`, add:
+
+```go
+// DenyModeClone returns a sibling Policy built from the same resolved config
+// but with Mode forced to deny. Used for fail-closed sessions where the onion
+// gateway cannot be wired: the session enforces Phase-1 Tor deny instead of
+// silently allowing unfiltered Tor. The receiver is not modified.
+func (p *Policy) DenyModeClone() (*Policy, error) {
+	if p == nil {
+		return nil, nil
+	}
+	cfg := p.cfg // value copy; New only reads the (shared) slices
+	cfg.Mode = ModeDeny
+	return New(cfg)
+}
+```
+
+In `internal/tor/event.go`, add (imports `time`, `uuid`, `types` are already present):
+
+```go
+// BuildGatewayEvent constructs a session-level tor_control event describing the
+// Phase 3 onion-gateway wiring outcome. decision is "allow" (force-redirect
+// armed) or "deny" (fail-closed). reason names the cause. enforced is false
+// only when a fail-closed deny cannot actually be enforced (no live syscall
+// enforcement subsystem for the session).
+func BuildGatewayEvent(sessionID, decision, reason string, enforced bool) types.Event {
+	return types.Event{
+		ID:        uuid.NewString(),
+		Timestamp: time.Now().UTC(),
+		Type:      "tor_control",
+		SessionID: sessionID,
+		Fields: map[string]any{
+			"vector":   VectorGateway,
+			"decision": decision,
+			"reason":   reason,
+			"enforced": enforced,
+			"rule":     "tor",
+		},
+	}
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `go test ./internal/tor/ -run 'TestDenyModeClone|TestBuildGatewayEvent' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/tor/policy.go internal/tor/gateway.go internal/tor/event.go internal/tor/gateway_test.go internal/tor/event_test.go
+git commit -m "feat(tor): VectorGateway, DenyModeClone, BuildGatewayEvent (Phase 3 primitives)"
+```
+
+---
+
+### Task 2: netns force-redirect (loopback-DNAT for socks_ports)
+
+**Files:**
+- Modify: `internal/netmonitor/netns_linux.go` (add `natOutputRules` + `torRedirectPorts` param + `route_localnet`)
+- Modify: `internal/netmonitor/netns_other.go` (stub signature)
+- Modify: `internal/api/app.go:715` (pass `socksPorts` into `SetupNetNS`)
+- Test: `internal/netmonitor/netns_rules_test.go` (create — pure, no root)
+
+**Interfaces:**
+- Consumes: existing `SetupNetNS(ctx, nsName, subnetCIDR, hostIf, nsIf, hostIPCIDR, nsIPCIDR string, proxyTCPPort, dnsUDPPort int) (*NetNS, error)`; `a.torGateway()` → `(pol, upstream, socksPorts, ok)`.
+- Produces: `SetupNetNS(..., dnsUDPPort int, torRedirectPorts []int) (*NetNS, error)` (new final param); `func natOutputRules(hostIP, hostTCP, hostDNS string, torRedirectPorts []int) [][]string`.
+
+- [ ] **Step 1: Write the failing test (pure rule generation)**
+
+```go
+// internal/netmonitor/netns_rules_test.go
+//go:build linux
+
+package netmonitor
+
+import "testing"
+
+func TestNatOutputRules_LoopbackDNATBeforeLoopbackReturn(t *testing.T) {
+	rules := natOutputRules("10.0.0.1", "10.0.0.1:5000", "10.0.0.1:5300", []int{9050, 9150})
+
+	idxReturn := -1
+	idx9050, idx9150 := -1, -1
+	for i, r := range rules {
+		joined := ""
+		for _, a := range r {
+			joined += a + " "
+		}
+		switch {
+		case contains(r, "127.0.0.0/8") && contains(r, "RETURN"):
+			idxReturn = i
+		case contains(r, "127.0.0.1") && contains(r, "9050"):
+			idx9050 = i
+		case contains(r, "127.0.0.1") && contains(r, "9150"):
+			idx9150 = i
+		}
+		_ = joined
+	}
+	if idx9050 < 0 || idx9150 < 0 || idxReturn < 0 {
+		t.Fatalf("missing rules: dnat9050=%d dnat9150=%d return=%d", idx9050, idx9150, idxReturn)
+	}
+	if idx9050 >= idxReturn || idx9150 >= idxReturn {
+		t.Fatalf("loopback DNAT must precede 127.0.0.0/8 RETURN: dnat9050=%d dnat9150=%d return=%d", idx9050, idx9150, idxReturn)
+	}
+}
+
+func TestNatOutputRules_NoTorPorts_NoLoopbackDNAT(t *testing.T) {
+	rules := natOutputRules("10.0.0.1", "10.0.0.1:5000", "10.0.0.1:5300", nil)
+	for _, r := range rules {
+		if contains(r, "127.0.0.1") && contains(r, "DNAT") {
+			t.Fatal("no Tor ports → no loopback DNAT rule expected")
+		}
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/netmonitor/ -run TestNatOutputRules -v`
+Expected: FAIL — `natOutputRules` undefined.
+
+- [ ] **Step 3: Implement `natOutputRules` + rewire `SetupNetNS`**
+
+In `internal/netmonitor/netns_linux.go` add `"strconv"` to imports, and add:
+
+```go
+// natOutputRules returns the ordered nat OUTPUT rule bodies (args after
+// "OUTPUT") for the session netns. Tor SOCKS ports get a loopback DNAT inserted
+// BEFORE the 127.0.0.0/8 RETURN so the app's connect(127.0.0.1:<port>) is
+// steered across the veth to the host interceptor; all other loopback traffic
+// is still exempted. Ordering is a correctness invariant (see Phase 3 design).
+func natOutputRules(hostIP, hostTCP, hostDNS string, torRedirectPorts []int) [][]string {
+	rules := [][]string{
+		{"-d", hostIP, "-j", "RETURN"},
+	}
+	for _, p := range torRedirectPorts {
+		rules = append(rules, []string{
+			"-d", "127.0.0.1", "-p", "tcp", "--dport", strconv.Itoa(p),
+			"-j", "DNAT", "--to-destination", hostTCP,
+		})
+	}
+	rules = append(rules,
+		[]string{"-d", "127.0.0.0/8", "-j", "RETURN"},
+		[]string{"-p", "tcp", "-j", "DNAT", "--to-destination", hostTCP},
+		[]string{"-p", "udp", "--dport", "53", "-j", "DNAT", "--to-destination", hostDNS},
+	)
+	return rules
+}
+```
+
+Change the `SetupNetNS` signature to add the final param:
+
+```go
+func SetupNetNS(ctx context.Context, nsName string, subnetCIDR string, hostIf string, nsIf string, hostIPCIDR string, nsIPCIDR string, proxyTCPPort int, dnsUDPPort int, torRedirectPorts []int) (*NetNS, error) {
+```
+
+Replace the inline OUTPUT-rule block (currently lines ~121–144, from `hostTCP := ...` through the udp DNAT) with:
+
+```go
+	// Netns DNAT outbound to host-side interceptors.
+	hostTCP := fmt.Sprintf("%s:%d", hostIP, proxyTCPPort)
+	hostDNS := fmt.Sprintf("%s:%d", hostIP, dnsUDPPort)
+	if len(torRedirectPorts) > 0 {
+		// Permit routing of loopback-destined packets so the Tor SOCKS DNAT can
+		// forward them across the veth to the host interceptor.
+		if err := run(ctx, "ip", "netns", "exec", nsName, "sysctl", "-w", "net.ipv4.conf.all.route_localnet=1"); err != nil {
+			rollbackAll()
+			cleanupNS()
+			return nil, err
+		}
+	}
+	for _, body := range natOutputRules(hostIP, hostTCP, hostDNS, torRedirectPorts) {
+		args := append([]string{"ip", "netns", "exec", nsName, "iptables", "-t", "nat", "-A", "OUTPUT"}, body...)
+		if err := run(ctx, args[0], args[1:]...); err != nil {
+			rollbackAll()
+			cleanupNS()
+			return nil, err
+		}
+	}
+```
+
+- [ ] **Step 4: Update the non-linux stub**
+
+In `internal/netmonitor/netns_other.go`, match the new signature:
+
+```go
+func SetupNetNS(ctx context.Context, nsName string, subnetCIDR string, hostIf string, nsIf string, hostIPCIDR string, nsIPCIDR string, proxyTCPPort int, dnsUDPPort int, torRedirectPorts []int) (*NetNS, error) {
+```
+
+(Keep its existing body, e.g. `return nil, errNetNSUnsupported` — read the file and preserve whatever it returns.)
+
+- [ ] **Step 5: Pass the ports from app.go**
+
+In `internal/api/app.go` `tryStartTransparentNetwork`, capture the gateway ports and pass them. Replace the gateway block + `SetupNetNS` call:
+
+```go
+	var torRedirectPorts []int
+	if pol, upstream, socksPorts, ok := a.torGateway(); ok {
+		tcp.SetTorGateway(pol, upstream, socksPorts)
+		torRedirectPorts = socksPorts
+		slog.Info("tor onion gateway active for session", "session", s.ID, "upstream", upstream)
+	}
+	// ... StartDNS unchanged ...
+	ns, err := netmonitor.SetupNetNS(ctx, nsName, subnetCIDR, hostIf, nsIf, hostIPCIDR, nsIPCIDR, tcpPort, dnsPort, torRedirectPorts)
+```
+
+- [ ] **Step 6: Run tests + both builds**
+
+Run: `go test ./internal/netmonitor/ -run TestNatOutputRules -v && go build ./... && GOOS=windows go build ./...`
+Expected: PASS; both builds clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/netmonitor/netns_linux.go internal/netmonitor/netns_other.go internal/netmonitor/netns_rules_test.go internal/api/app.go
+git commit -m "feat(tor): netns loopback-DNAT force-redirect of Tor SOCKS ports"
+```
+
+---
+
+### Task 3: Branch predicate + fail-closed deny + gateway events
+
+**Files:**
+- Modify: `internal/api/app.go` (add `gatewayBranchFor`; emit force-redirect event in `tryStartTransparentNetwork`)
+- Modify: `internal/api/session_policy.go` (add `attachDenyTor`)
+- Modify: `internal/api/core.go` (call `applyTorFailClosed` after the transparent-network block ~813)
+- Test: `internal/api/tor_failclosed_test.go` (create)
+
+**Interfaces:**
+- Consumes: `App.torPolicy`; `Policy.GatewayActive()`; `Policy.DenyModeClone()`; `tor.BuildGatewayEvent`; `clonePolicy`; `policy.NewEngineWithVariables`; `App.execveEnforcementActive()`; `s.PolicyEngine()` / `s.SetPolicyEngine()`.
+- Produces: `func gatewayBranchFor(gatewayActive, interceptorUp bool) gatewayBranch`; `func (a *App) attachDenyTor(s *session.Session, deny *tor.Policy) bool`; `func (a *App) applyTorFailClosed(ctx context.Context, s *session.Session, interceptorUp bool)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+// internal/api/tor_failclosed_test.go
+package api
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/tor"
+)
+
+func TestGatewayBranchFor(t *testing.T) {
+	cases := []struct {
+		active, up bool
+		want       gatewayBranch
+	}{
+		{false, false, gatewayNone},
+		{false, true, gatewayNone},
+		{true, true, gatewayForceRedirect},
+		{true, false, gatewayFailClosed},
+	}
+	for _, c := range cases {
+		if got := gatewayBranchFor(c.active, c.up); got != c.want {
+			t.Fatalf("gatewayBranchFor(%v,%v)=%v want %v", c.active, c.up, got, c.want)
+		}
+	}
+}
+
+// Default-engine session: attachDenyTor must give it a NEW per-session engine
+// that denies Tor, without mutating the shared global engine.
+func TestAttachDenyTor_DefaultEngine_ClonesAndDenies(t *testing.T) {
+	global, err := policy.NewEngine(&policy.Policy{}, false, true)
+	if err != nil {
+		t.Fatalf("global: %v", err)
+	}
+	a := &App{policy: global, cfg: &config.Config{}}
+	deny, _ := tor.New(config.ResolveTorConfig(config.TorConfig{Mode: "deny"}))
+
+	s := &session.Session{} // PolicyEngine() == nil → policyEngineFor returns global
+	ok := a.attachDenyTor(s, deny)
+	if !ok {
+		t.Fatal("attachDenyTor should succeed")
+	}
+	if s.PolicyEngine() == nil || s.PolicyEngine() == global {
+		t.Fatal("session must get its own cloned engine, not the global one")
+	}
+	if dec := s.PolicyEngine().CheckExecve("/usr/bin/tor", []string{"tor"}, 0); dec.Action != "deny" {
+		t.Fatalf("session engine should deny tor, got %q", dec.Action)
+	}
+	if dec := global.CheckExecve("/usr/bin/tor", []string{"tor"}, 0); dec.Action == "deny" {
+		t.Fatal("global engine must remain undecorated")
+	}
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `go test ./internal/api/ -run 'TestGatewayBranchFor|TestAttachDenyTor' -v`
+Expected: FAIL — undefined identifiers.
+
+- [ ] **Step 3: Implement the predicate (app.go)**
+
+```go
+type gatewayBranch int
+
+const (
+	gatewayNone gatewayBranch = iota
+	gatewayForceRedirect
+	gatewayFailClosed
+)
+
+// gatewayBranchFor selects the Phase 3 branch from the per-session predicate.
+func gatewayBranchFor(gatewayActive, interceptorUp bool) gatewayBranch {
+	switch {
+	case !gatewayActive:
+		return gatewayNone
+	case interceptorUp:
+		return gatewayForceRedirect
+	default:
+		return gatewayFailClosed
+	}
+}
+```
+
+- [ ] **Step 4: Implement `attachDenyTor` (session_policy.go)**
+
+```go
+// attachDenyTor makes a session enforce Tor deny (fail-closed). If the session
+// already has its OWN engine, the deny coordinator is installed on it directly.
+// Otherwise the session is using the shared global engine; we clone that
+// engine's policy, attach deny-Tor to the clone, and install it per session —
+// never mutating shared state. Returns true if a deny coordinator was installed.
+func (a *App) attachDenyTor(s *session.Session, deny *tor.Policy) bool {
+	if a == nil || s == nil || deny == nil {
+		return false
+	}
+	adapter := &tor.PolicyAdapter{Policy: deny}
+	if eng := s.PolicyEngine(); eng != nil && eng != a.Policy() {
+		eng.SetTorPolicy(adapter)
+		return true
+	}
+	base := a.Policy().Policy()
+	clone := clonePolicy(base)
+	enforceApprovals := a.cfg.Approvals.Enabled && a.cfg.Approvals.Mode != ""
+	eng, err := policy.NewEngineWithVariables(clone, enforceApprovals, true, nil)
+	if err != nil || eng == nil {
+		return false
+	}
+	eng.SetTorPolicy(adapter)
+	s.SetPolicyEngine(eng)
+	return true
+}
+```
+
+- [ ] **Step 5: Implement `applyTorFailClosed` (session_policy.go) + emit force-redirect event (app.go)**
+
+In `internal/api/session_policy.go`:
+
+```go
+// applyTorFailClosed denies Tor for a session when the onion gateway is active
+// in policy but could not be wired (proxy-env fallback or transparent disabled).
+// No-op when the gateway is inactive or the interceptor came up (force-redirect
+// handled it). Emits one session-level gateway event recording the outcome.
+func (a *App) applyTorFailClosed(ctx context.Context, s *session.Session, interceptorUp bool) {
+	if a.torPolicy == nil || !a.torPolicy.GatewayActive() {
+		return
+	}
+	if gatewayBranchFor(true, interceptorUp) != gatewayFailClosed {
+		return
+	}
+	deny, err := a.torPolicy.DenyModeClone()
+	attached := false
+	if err == nil {
+		attached = a.attachDenyTor(s, deny)
+	}
+	enforced := attached && a.execveEnforcementActive()
+	reason := "proxy_env_fallback"
+	if !a.cfg.Sandbox.Network.Transparent.Enabled {
+		reason = "transparent_disabled"
+	}
+	ev := tor.BuildGatewayEvent(s.ID, "deny", reason, enforced)
+	_ = a.store.AppendEvent(ctx, ev)
+	a.broker.Publish(ev)
+}
+```
+
+In `internal/api/app.go` `tryStartTransparentNetwork`, after `SetupNetNS` succeeds and when `len(torRedirectPorts) > 0`, emit the armed event (place just before the function's `return nil`):
+
+```go
+	if len(torRedirectPorts) > 0 {
+		gw := tor.BuildGatewayEvent(s.ID, "allow", "force_redirect_installed", true)
+		_ = a.store.AppendEvent(ctx, gw)
+		a.broker.Publish(gw)
+	}
+```
+
+(Add `"github.com/agentsh/agentsh/internal/tor"` to app.go imports if not already present.)
+
+- [ ] **Step 6: Call `applyTorFailClosed` from core.go**
+
+In `internal/api/core.go`, replace the transparent-network block (~811–end of that `if`) so the interceptor outcome is captured and fail-closed runs in every path:
+
+```go
+	interceptorUp := false
+	if a.cfg.Sandbox.Network.Transparent.Enabled {
+		if err := a.tryStartTransparentNetwork(ctx, s); err != nil {
+			fail := types.Event{ /* existing transparent_net_failed event, unchanged */ }
+			_ = a.store.AppendEvent(ctx, fail)
+			a.broker.Publish(fail)
+		} else {
+			interceptorUp = true
+		}
+	}
+	a.applyTorFailClosed(ctx, s, interceptorUp)
+```
+
+(Preserve the existing `transparent_net_failed` event body exactly; only add the `interceptorUp` tracking and the `applyTorFailClosed` call.)
+
+- [ ] **Step 7: Run tests + build**
+
+Run: `go test ./internal/api/ -run 'TestGatewayBranchFor|TestAttachDenyTor|TestAttachSessionTor' -v && go build ./... && GOOS=windows go build ./...`
+Expected: PASS; builds clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/api/app.go internal/api/session_policy.go internal/api/core.go internal/api/tor_failclosed_test.go
+git commit -m "feat(tor): Phase 3 branch predicate + fail-closed deny + gateway events"
+```
+
+---
+
+### Task 4: Gated netns integration test (loopback Tor → gateway filters)
+
+Proves force-redirect end-to-end: loopback traffic to a Tor SOCKS port is actually filtered by `onion_rules`. Needs root + Linux + iptables; gated like the repo's other netns integration tests.
+
+**Files:**
+- Test: `internal/api/tor_gateway_integration_linux_test.go` (create)
+
+**Interfaces:**
+- Consumes: the same gating helper the existing netns/transparent integration tests use (find it: `grep -rn "skip" internal/api/*linux_test.go | grep -i 'root\|netns'`). Reuse that skip guard verbatim.
+
+- [ ] **Step 1: Write the integration test**
+
+Model it on the nearest existing transparent-network integration test (locate with `grep -rln "SetupNetNS\|StartTransparentTCP" internal/api/*_test.go`). The test must:
+1. Skip unless running as root on Linux with iptables available (reuse the existing guard).
+2. Start a fake Tor SOCKS5 server bound to `127.0.0.1:9050` that completes the SOCKS handshake and echoes (reuse the fake-upstream pattern from `internal/netmonitor/socks_handler_test.go`).
+3. Build an `App` with `tor.mode: allow` and `onion_rules: [{onion: "allowed.onion", decision: allow}, {onion: "*", decision: deny}]`, transparent network enabled.
+4. Create a session, then from inside the netns (`ip netns exec <ns> ...` or a dialer bound into the ns) issue two SOCKS CONNECTs to `127.0.0.1:9050` — one to `allowed.onion:80`, one to `blocked.onion:80`.
+5. Assert the allowed target gets a success SOCKS reply and the blocked target gets `socksRepNotAllowed` (0x02) — proving the loopback connection reached `handleTorSocks` via the force-redirect.
+
+- [ ] **Step 2: Run (on a root Linux host)**
+
+Run: `sudo -E go test ./internal/api/ -run TestTorGatewayForceRedirect_Integration -v`
+Expected: PASS where privileged; SKIP otherwise. Also confirm it SKIPs cleanly as non-root: `go test ./internal/api/ -run TestTorGatewayForceRedirect_Integration -v`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/api/tor_gateway_integration_linux_test.go
+git commit -m "test(tor): gated netns integration — loopback Tor reaches the gateway"
+```
+
+---
+
+### Task 5: Static startup advisory + spec status + final gates
+
+**Files:**
+- Modify: `internal/server/server.go` (advisory log near the tor-enable block ~206–218)
+- Modify: `docs/superpowers/specs/2026-06-14-tor-access-control-design.md` (append Phase 3 status)
+- Test: none new (advisory is a log line; covered by build).
+
+- [ ] **Step 1: Add the startup advisory**
+
+In `internal/server/server.go`, inside the `if torCfg.Enabled` block after the policy is built, add:
+
+```go
+		if torCfg.Mode == "allow" && len(torCfg.OnionRules) > 0 && !cfg.Sandbox.Network.Transparent.Enabled {
+			slog.Warn("tor onion gateway configured (mode=allow + onion_rules) but transparent network is disabled; every session will fail-closed (Tor denied). Enable sandbox.network.transparent to use the gateway.")
+		}
+```
+
+- [ ] **Step 2: Update the design spec status**
+
+In `docs/superpowers/specs/2026-06-14-tor-access-control-design.md`, under the Phase 2 "Honest scope (Phase 2)" paragraph, append a short note:
+
+```markdown
+**Phase 3 (fail-open gap closed — implemented).** The silent degrade described
+above is closed: in netns transparent mode a loopback-DNAT force-redirect steers
+the app's Tor SOCKS connection into the gateway automatically; in any mode where
+the gateway cannot be wired the session fails closed (Tor denied, `tor_control`
+`vector: gateway` audit event). See
+`docs/superpowers/specs/2026-06-20-tor-access-control-phase3-design.md`.
+```
+
+- [ ] **Step 3: Full gates**
+
+Run:
+```
+go build ./...
+GOOS=windows go build ./...
+gofmt -l internal/api internal/tor internal/netmonitor internal/server
+go test ./internal/tor/ ./internal/netmonitor/ ./internal/api/ ./internal/server/
+go test ./...
+```
+Expected: builds clean; `gofmt -l` empty; touched packages green; full suite green except known pre-existing local-env flakes (the `internal/fsmonitor` FUSE flake and the documented `-race` DB-proxy/transport-loss flakes are not regressions).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/server/server.go docs/superpowers/specs/2026-06-14-tor-access-control-design.md
+git commit -m "feat(tor): startup advisory for ungatewayable allow-mode + Phase 3 spec status"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Force-redirect (Branch 1) → Task 2 + Task 3 event. Fail-closed (Branch 2) → Task 3 (`applyTorFailClosed`/`attachDenyTor`), posture = deny + audit. Per-session-engine Tor attachment (the discovered gap, folded in by user decision) → Task 0. No-new-knobs → honored (only derived behavior). Events (`vector: gateway`, `reason`, `enforced`) → Task 1 + Task 3. Rule ordering / fully-installed-or-deny → Task 2 (ordering test + `SetupNetNS` rollback routing to fail-closed). Honest-scope floor (`enforced: false`) → Task 3 (`enforced := attached && execveEnforcementActive()`). Static advisory → Task 5. Testing matrix → Tasks 0–4. Cross-compile → Task 2/5.
+
+**Type consistency:** `SetupNetNS` final param `torRedirectPorts []int` is used identically in netns_linux.go, netns_other.go, and the app.go call. `attachSessionTor`/`attachDenyTor`/`applyTorFailClosed`/`gatewayBranchFor`/`natOutputRules`/`DenyModeClone`/`BuildGatewayEvent` signatures match between their definition task and consumer task. `gatewayBranch` constants (`gatewayNone`/`gatewayForceRedirect`/`gatewayFailClosed`) defined in Task 3 Step 3, consumed in Step 4–5 and the test.
+
+**Placeholder scan:** the integration test (Task 4) intentionally describes structure rather than full code because it must mirror an existing in-repo gating helper and fake-upstream pattern the implementer will locate; every other code step contains complete, compilable code.

--- a/docs/superpowers/specs/2026-06-14-tor-access-control-design.md
+++ b/docs/superpowers/specs/2026-06-14-tor-access-control-design.md
@@ -395,3 +395,10 @@ transparent interception for the gateway to take effect. The gateway emits one
 `tor_control{vector: onion, decision: allow|deny}` event per CONNECT; like the
 other connection-layer vectors it reports `pid: 0` and is correlated by session
 and target.
+
+**Phase 3 (fail-open gap closed — implemented).** The silent degrade described
+above is closed: in netns transparent mode a loopback-DNAT force-redirect steers
+the app's Tor SOCKS connection into the gateway automatically; in any mode where
+the gateway cannot be wired the session fails closed (Tor denied, `tor_control`
+`vector: gateway` audit event). See
+`docs/superpowers/specs/2026-06-20-tor-access-control-phase3-design.md`.

--- a/docs/superpowers/specs/2026-06-20-tor-access-control-phase3-design.md
+++ b/docs/superpowers/specs/2026-06-20-tor-access-control-phase3-design.md
@@ -95,7 +95,7 @@ iptables -t nat -A OUTPUT -d 127.0.0.1 -p tcp --dport <port> -j DNAT --to-destin
 and enable routing of loopback-originated packets inside the netns:
 
 ```
-sysctl -w net.ipv4.conf.<veth>.route_localnet=1
+sysctl -w net.ipv4.conf.all.route_localnet=1
 ```
 
 Result: the app's `connect(127.0.0.1:9050)` crosses the veth to the existing
@@ -114,9 +114,9 @@ install, the session MUST NOT proceed with "interceptor up, Tor unfiltered." It
 tears the partially-installed rules back to a known state and transitions to
 Branch 2 (fail-closed deny). A force-redirect is all-or-nothing.
 
-**route_localnet scope.** `route_localnet=1` is set on the netns veth only; its
-effect is contained to the sandbox network namespace and does not alter host
-routing.
+**route_localnet scope.** `route_localnet=1` is set on `net.ipv4.conf.all` inside the session netns; its
+effect is contained to the sandbox network namespace (the sysctl write occurs
+inside the per-session netns, so it does not alter host routing).
 
 ## Branch 2 — Fail-closed (gateway not wired)
 

--- a/docs/superpowers/specs/2026-06-20-tor-access-control-phase3-design.md
+++ b/docs/superpowers/specs/2026-06-20-tor-access-control-phase3-design.md
@@ -1,0 +1,257 @@
+# Tor Access Control — Phase 3 Design (close the allow-mode fail-open gap)
+
+**Status:** Draft — proposed
+
+**Builds on:** [Tor Access Control — Design](2026-06-14-tor-access-control-design.md) (Phase 1 deny/audit, PR #424; Phase 2 onion gateway, PR #428).
+
+## Summary
+
+Phase 2's onion gateway gives true per-`.onion` allow/deny, but only for Tor
+SOCKS connections that reach agentsh's transparent-TCP interceptor. In any
+session where the app reaches a loopback Tor daemon that is **not** routed
+through that interceptor, allow-mode silently degrades to Phase-1 *unfiltered*
+allow: Tor is permitted and the `onion_rules` are never consulted. For a
+security control whose entire purpose is to *permit specific onions while
+denying the rest*, a silent fail-open at its finest granularity is the gap
+worth closing.
+
+Phase 3 closes it from both ends:
+
+1. **Force-redirect (netns transparent mode):** agentsh itself guarantees the
+   app's connection to the configured `socks_ports` lands in the gateway, by
+   adding a loopback DNAT rule inside the session network namespace. The
+   gateway "just works" — no operator routing required.
+2. **Fail-closed (every other mode):** when allow-mode `onion_rules` are
+   configured but the gateway cannot be wired for the session, agentsh denies
+   Tor for that session (Phase-1 deny semantics) and emits an audit event,
+   rather than allowing unfiltered Tor.
+
+Phase 3 adds **no new data path** and **no new event type**.
+
+## Motivation
+
+The Phase 2 spec documents this limitation honestly ("Honest scope (Phase 2)")
+but leaves the failure *silent*: an operator who configures
+`mode: allow` + `onion_rules`, expecting per-onion enforcement, gets unfiltered
+Tor whenever their Tor daemon is reached over loopback outside interception —
+with nothing in the audit stream to say enforcement did not happen.
+
+Root cause, concretely: `internal/netmonitor/netns_linux.go` sets up the netns
+NAT so that all outbound TCP is DNAT'd to the host interceptor —
+
+```
+iptables -t nat -A OUTPUT -d <hostIP>      -j RETURN        # host veth: don't redirect
+iptables -t nat -A OUTPUT -d 127.0.0.0/8   -j RETURN        # loopback: don't redirect  <-- the gap
+iptables -t nat -A OUTPUT -p tcp           -j DNAT --to <hostTCP>
+```
+
+The `127.0.0.0/8 RETURN` rule deliberately exempts loopback from redirection.
+A Tor daemon on `127.0.0.1:9050` is therefore reached directly, bypassing the
+interceptor (and thus the gateway) entirely.
+
+## Architecture: one decision, two branches
+
+Phase 3 introduces a single per-session predicate evaluated at session startup,
+after the transparent-network attempt:
+
+```
+gatewayActive := GatewayActive(policy)          // mode==allow && len(onion_rules)>0
+interceptorUp := tryStartTransparentNetwork succeeded
+
+switch {
+case !gatewayActive:                 // deny/audit, or allow with no onion_rules
+    // Phase 1 / Phase 2 unchanged; Phase 3 inert.
+case gatewayActive && interceptorUp: // BRANCH 1
+    installForceRedirect()           // fully install, or fall to fail-closed
+case gatewayActive && !interceptorUp:// BRANCH 2
+    failClosedDenyTor()
+}
+```
+
+No change to `transparent_tcp.go`, `socks.go`, or the SOCKS5 data path. Phase 3
+is entirely in the *wiring* that decides whether a session's Tor traffic reaches
+the existing gateway, and what happens when it cannot.
+
+## Branch 1 — Force-redirect (netns transparent mode)
+
+**Mechanism:** iptables loopback-DNAT inside the session netns. (The rejected
+alternative — ptrace `connect()` sockaddr-rewrite — is invasive on the hot
+syscall path, must handle the IPv4/IPv6/blocking/`EINPROGRESS` matrix, and the
+non-netns modes it would additionally cover have no interceptor to redirect
+into anyway; see Non-Goals.)
+
+**File:** `internal/netmonitor/netns_linux.go`.
+
+The netns setup already receives `hostTCP` (the interceptor `host:port`) and
+writes the OUTPUT nat rules. Phase 3 adds a `torRedirectPorts []int` parameter,
+populated **only** when `GatewayActive()` holds for the session. For each port,
+insert — **before** the existing `-d 127.0.0.0/8 -j RETURN` rule, so it takes
+precedence:
+
+```
+iptables -t nat -A OUTPUT -d 127.0.0.1 -p tcp --dport <port> -j DNAT --to-destination <hostTCP>
+```
+
+and enable routing of loopback-originated packets inside the netns:
+
+```
+sysctl -w net.ipv4.conf.<veth>.route_localnet=1
+```
+
+Result: the app's `connect(127.0.0.1:9050)` crosses the veth to the existing
+interceptor; `SO_ORIGINAL_DST` recovers `127.0.0.1:9050`; the existing
+`torGatewayFor(dstPort)` hook in `transparent_tcp.handle` matches the port and
+routes the stream through `handleTorSocks`. Per-onion filtering applies exactly
+as in Phase 2 — Phase 3 only guarantees the bytes get there.
+
+**Rule ordering is a correctness invariant.** The per-port DNAT rules MUST be
+emitted before the `127.0.0.0/8 RETURN` rule. If they followed it, the RETURN
+would short-circuit loopback traffic and the redirect would never fire.
+
+**Fully installed or deny — no half-redirect.** `route_localnet` or the DNAT
+insert can fail on a restricted host. If **any** force-redirect step fails to
+install, the session MUST NOT proceed with "interceptor up, Tor unfiltered." It
+tears the partially-installed rules back to a known state and transitions to
+Branch 2 (fail-closed deny). A force-redirect is all-or-nothing.
+
+**route_localnet scope.** `route_localnet=1` is set on the netns veth only; its
+effect is contained to the sandbox network namespace and does not alter host
+routing.
+
+## Branch 2 — Fail-closed (gateway not wired)
+
+**Trigger:** `GatewayActive()` policy, but the session did not bring up the
+netns interceptor (proxy-env fallback), or force-redirect could not be fully
+installed (per Branch 1).
+
+**Enforcement — reuse Phase-1 deny, per session.** The shared `tor.Policy` is
+built once at server start and is attached to the global engine; it MUST NOT be
+mutated for one session. Instead, fail-closed builds a **session-scoped policy
+clone** from the same resolved config with `Mode` forced to `deny`, and
+attaches it to the session's engine (`policyEngineFor(s)`). Semantically:
+
+> Run this session as if `tor.mode: deny`.
+
+This reuses every Phase-1 deny vector unchanged — execve kills the Tor client
+binary, the connect vector denies the SOCKS/control ports, relay-IP and
+onion-name vectors apply — on whatever enforcement subsystem is live for the
+session. No new enforcement code path is introduced.
+
+**Honest-scope floor.** Fail-closed deny is only as strong as the enforcement
+subsystem available. In proxy-env fallback with ptrace active, the connect and
+execve vectors still bite. If *no* enforcement subsystem is active for the
+session (no ptrace, no netns — pure passthrough), even deny cannot be enforced;
+Phase 3 does not pretend otherwise — the audit event carries `enforced: false`
+(see Events). This is the irreducible floor, documented rather than papered
+over, consistent with the Phase 1/2 "Honest scope" sections.
+
+**Dual connect-eval paths.** The Phase-1 SOCKS-port connect deny must fire on
+whichever connect-evaluation path is live in the degraded mode. The connect
+vector is evaluated on the ptrace connect path (`CheckNetwork` →
+`CheckNetworkCtx`), which is the path active in proxy-env fallback; the
+implementation must confirm the session-scoped deny policy is consulted there,
+not only on the transparent-TCP `CheckNetworkIP` path (which by definition is
+absent when the interceptor did not come up).
+
+## Configuration
+
+**No new config knobs.** All behavior derives from existing config:
+
+- Force-redirect activates automatically when `GatewayActive()` and the netns
+  interceptor is up.
+- Fail-closed activates automatically when `GatewayActive()` but the interceptor
+  is not up (or force-redirect could not fully install).
+- Ports redirected = the configured `tor.socks_ports` (default `[9050, 9150]`),
+  all of them.
+
+Operators who deliberately want allow-without-gateway retain two existing
+escape hatches: empty `onion_rules` (→ Phase-1, Tor allowed unfiltered, no
+gateway) or `mode: audit`. There is nothing new to opt out of.
+
+**Static advisory (optional, cheap).** At server start, if `mode: allow` +
+`onion_rules` are configured but the platform fundamentally cannot host the
+gateway (non-Linux, or netns unsupported), emit a single startup log line so
+the operator knows every session will fail-closed. Advisory only; enforcement
+remains per-session.
+
+## Events / observability
+
+Reuse the existing `tor_control` event (`Type: "tor_control"`, free-form
+`Fields map[string]any`). **No new `events.EventType`** → the OCSF registry is
+untouched, the same approach Phase 2 used for `vector: onion`.
+
+- **New session-level vector value** `VectorGateway = "gateway"` (in
+  `internal/tor/policy.go`), distinct from the per-CONNECT `VectorOnion`.
+- **New free-form `reason` key** in `Fields` (the map permits this with no
+  schema change).
+- **Emit exactly one session-scoped `gateway` event at the branch decision:**
+  - Force-redirect installed →
+    `{vector: gateway, decision: allow, target: "127.0.0.1:9050,9150", reason: "force_redirect_installed"}`
+    — distinguishes "gateway armed and enforcing" from plain Phase-1 allow.
+  - Fail-closed deny →
+    `{vector: gateway, decision: deny, reason: <cause>}` where `<cause>` ∈
+    `{proxy_env_fallback, force_redirect_install_failed}`.
+  - Honest-scope floor (fail-closed but nothing can enforce) → the same deny
+    event additionally carries `enforced: false`, so the record never implies a
+    block it cannot deliver.
+- **Per-CONNECT `vector: onion` events are unchanged** from Phase 2.
+
+## Testing
+
+Security-critical invariants are factored into pure functions so they are
+unit-testable without root; netns/iptables end-to-end is gated integration.
+
+1. **Force-redirect rule generation** (`netns_linux.go`): separate rule-list
+   construction from execution. Given `socks_ports=[9050,9150]` + `hostTCP`, the
+   generated sequence contains a loopback-DNAT per port **positioned before** the
+   `127.0.0.0/8 RETURN` rule, and includes the `route_localnet` sysctl. Assert
+   the DNAT-before-RETURN ordering explicitly.
+2. **Branch predicate** (`app.go`): pure
+   `(gatewayActive, interceptorUp) → {forceRedirect | failClosed | none}`,
+   table-driven: allow+rules+up → force-redirect; allow+rules+down →
+   fail-closed; deny/audit → none; allow+empty-rules → none.
+3. **Fail-closed policy clone**: the per-session policy is built from the same
+   config with `Mode=deny`; `EvalConnect/EvalExecve/EvalOnionName` then return
+   deny verdicts; the **shared Policy is not mutated** (a concurrent allow-mode
+   session is unaffected).
+4. **Partial-install → fail-closed**: inject a forced install failure; assert
+   the session ends in fail-closed deny, not interceptor-up-with-unfiltered-Tor.
+5. **Events**: force-redirect → one `gateway/allow/force_redirect_installed`;
+   fail-closed → one `gateway/deny/<reason>`; floor → `enforced: false` present.
+6. **Integration (gated, root + Linux)**: one end-to-end test in the existing
+   netns integration suite — session with `mode: allow` + `onion_rules` + a fake
+   Tor SOCKS on `127.0.0.1:9050`; connect through it; assert an allowed `.onion`
+   passes and a denied one is reset — proving loopback traffic actually reaches
+   the gateway. Gated like the repo's other netns tests.
+7. **Cross-compile**: `netns_linux.go` is linux-only; `GOOS=windows go build
+   ./...` must stay clean (no new params leaking into shared code without stubs).
+
+## Non-Goals
+
+- **ptrace `connect()` sockaddr-rewrite as the force-redirect mechanism.**
+  Rejected in favor of netns loopback-DNAT: it is invasive on the hot syscall
+  path, must cover the full connect matrix, and the only modes it would
+  additionally reach have no interceptor to redirect into (they are the
+  fail-closed branch by definition).
+- **Making the gateway work in non-netns modes.** Proxy-env fallback has no
+  transparent interceptor; Phase 3's answer there is fail-closed deny, not a
+  second gateway implementation.
+- **New config surface.** Behavior is derived from existing `tor.mode` /
+  `onion_rules` / `socks_ports`; no new knobs (YAGNI).
+- **Non-Linux enforcement.** Force-redirect is Linux/netns-only (matches the
+  repo posture); other platforms with allow-mode `onion_rules` fail-closed, and
+  the static advisory names that at startup.
+
+## Out of scope / future (tracked, not built here)
+
+These remain candidates for later, independent of this gap:
+
+- **Gateway SOCKS protocol completeness** — `handleTorSocks` accepts only SOCKS
+  `CONNECT` (0x01); Tor's `RESOLVE` (0xF0) / `RESOLVE_PTR` (0xF1) extensions are
+  rejected as "unsupported command." Apps resolving `.onion` names over SOCKS
+  break or route around policy.
+- **Stream isolation / SOCKS-auth pass-through** — the gateway forces upstream
+  no-auth; operators relying on per-stream isolation via SOCKS
+  username/password (`IsolateSOCKSAuth`) cannot use it through the gateway.
+- **PID/command attribution for `onion_dns` / `onion_http` events** — those
+  layers report `target` only.

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -700,8 +700,10 @@ func (a *App) tryStartTransparentNetwork(ctx context.Context, s *session.Session
 	if err != nil {
 		return err
 	}
+	var torRedirectPorts []int
 	if pol, upstream, socksPorts, ok := a.torGateway(); ok {
 		tcp.SetTorGateway(pol, upstream, socksPorts)
+		torRedirectPorts = socksPorts
 		slog.Info("tor onion gateway active for session", "session", s.ID, "upstream", upstream)
 	}
 	dns, dnsPort, err := netmonitor.StartDNS("0.0.0.0:0", "8.8.8.8:53", s.ID, s, dnsCache, a.policy, a.approvals, em, correlationMap)
@@ -712,7 +714,7 @@ func (a *App) tryStartTransparentNetwork(ctx context.Context, s *session.Session
 
 	nsName := "agentsh-" + strings.TrimPrefix(s.ID, "session-")
 	subnetCIDR, hostIPCIDR, nsIPCIDR, hostIf, nsIf := netmonitor.AllocateSubnet(a.cfg.Sandbox.Network.Transparent.SubnetBase, nsName)
-	ns, err := netmonitor.SetupNetNS(ctx, nsName, subnetCIDR, hostIf, nsIf, hostIPCIDR, nsIPCIDR, tcpPort, dnsPort)
+	ns, err := netmonitor.SetupNetNS(ctx, nsName, subnetCIDR, hostIf, nsIf, hostIPCIDR, nsIPCIDR, tcpPort, dnsPort, torRedirectPorts)
 	if err != nil {
 		_ = tcp.Close()
 		_ = dns.Close()

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -249,6 +249,26 @@ func (a *App) Close() {
 	a.closePtraceTracer()
 }
 
+type gatewayBranch int
+
+const (
+	gatewayNone gatewayBranch = iota
+	gatewayForceRedirect
+	gatewayFailClosed
+)
+
+// gatewayBranchFor selects the Phase 3 branch from the per-session predicate.
+func gatewayBranchFor(gatewayActive, interceptorUp bool) gatewayBranch {
+	switch {
+	case !gatewayActive:
+		return gatewayNone
+	case interceptorUp:
+		return gatewayForceRedirect
+	default:
+		return gatewayFailClosed
+	}
+}
+
 // torGateway reports the Phase 2 onion-gateway wiring when active.
 func (a *App) torGateway() (pol *tor.Policy, upstream string, socksPorts []int, ok bool) {
 	if a == nil || a.torPolicy == nil || !a.torPolicy.GatewayActive() {
@@ -746,6 +766,11 @@ func (a *App) tryStartTransparentNetwork(ctx context.Context, s *session.Session
 	}
 	_ = a.store.AppendEvent(ctx, ev)
 	a.broker.Publish(ev)
+	if len(torRedirectPorts) > 0 {
+		gw := tor.BuildGatewayEvent(s.ID, "allow", "force_redirect_installed", true)
+		_ = a.store.AppendEvent(ctx, gw)
+		a.broker.Publish(gw)
+	}
 	return nil
 }
 

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -565,6 +565,7 @@ func (a *App) createSessionWithProfile(ctx context.Context, req types.CreateSess
 		}
 		s.ProjectRoot = policyVars["PROJECT_ROOT"]
 		s.GitRoot = policyVars["GIT_ROOT"]
+		a.attachSessionTor(engine)
 		s.SetPolicyEngine(engine)
 		if err := a.startSessionDBProxy(ctx, s, dbRuleSet, dbStateDir); err != nil {
 			a.cleanupCreatedSession(s)
@@ -755,6 +756,7 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 	// Store roots and session-specific policy engine
 	s.ProjectRoot = policyVars["PROJECT_ROOT"]
 	s.GitRoot = policyVars["GIT_ROOT"]
+	a.attachSessionTor(engine)
 	s.SetPolicyEngine(engine)
 
 	// Apply real-paths mode if requested
@@ -1497,6 +1499,7 @@ func (a *App) ensureFUSEMount(ctx context.Context, s *session.Session) {
 
 	// Store session-specific engine if session doesn't have one yet
 	if s.PolicyEngine() == nil {
+		a.attachSessionTor(engine)
 		s.SetPolicyEngine(engine)
 	}
 

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -616,6 +616,11 @@ func (a *App) createSessionWithProfile(ctx context.Context, req types.CreateSess
 		s.Mounts = mounts
 	}
 
+	// Profile sessions never wire the transparent interceptor; if the onion
+	// gateway is active for this session, fail closed (deny Tor) rather than
+	// allowing unfiltered Tor. No-op when the gateway is not active.
+	a.applyTorFailClosed(ctx, s, false)
+
 	return s.Snapshot(), http.StatusCreated, nil
 }
 

--- a/internal/api/core.go
+++ b/internal/api/core.go
@@ -811,6 +811,7 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 	}
 
 	// Optional: start transparent network interception; fall back to explicit proxy on failure.
+	interceptorUp := false
 	if a.cfg.Sandbox.Network.Transparent.Enabled {
 		if err := a.tryStartTransparentNetwork(ctx, s); err != nil {
 			fail := types.Event{
@@ -829,6 +830,7 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 				a.startExplicitProxy(ctx, s)
 			}
 		} else {
+			interceptorUp = true
 			okEv := types.Event{
 				ID:        uuid.NewString(),
 				Timestamp: time.Now().UTC(),
@@ -841,6 +843,7 @@ func (a *App) createSessionCore(ctx context.Context, req types.CreateSessionRequ
 	} else if a.cfg.Sandbox.Network.Enabled {
 		a.startExplicitProxy(ctx, s)
 	}
+	a.applyTorFailClosed(ctx, s, interceptorUp)
 
 	// Start embedded LLM proxy if configured
 	if a.cfg.Proxy.Mode == "embedded" || a.cfg.Proxy.IsMCPOnly() {

--- a/internal/api/session_policy.go
+++ b/internal/api/session_policy.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+
 	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/internal/session"
 	"github.com/agentsh/agentsh/internal/tor"
@@ -94,4 +96,56 @@ func (a *App) attachSessionTor(eng *policy.Engine) {
 		return
 	}
 	eng.SetTorPolicy(&tor.PolicyAdapter{Policy: a.torPolicy})
+}
+
+// attachDenyTor makes a session enforce Tor deny (fail-closed). If the session
+// already has its OWN engine, the deny coordinator is installed on it directly.
+// Otherwise the session is using the shared global engine; we clone that
+// engine's policy, attach deny-Tor to the clone, and install it per session —
+// never mutating shared state. Returns true if a deny coordinator was installed.
+func (a *App) attachDenyTor(s *session.Session, deny *tor.Policy) bool {
+	if a == nil || s == nil || deny == nil {
+		return false
+	}
+	adapter := &tor.PolicyAdapter{Policy: deny}
+	if eng := s.PolicyEngine(); eng != nil && eng != a.Policy() {
+		eng.SetTorPolicy(adapter)
+		return true
+	}
+	base := a.Policy().Policy()
+	clone := clonePolicy(base)
+	enforceApprovals := a.cfg.Approvals.Enabled && a.cfg.Approvals.Mode != ""
+	eng, err := policy.NewEngineWithVariables(clone, enforceApprovals, true, nil)
+	if err != nil || eng == nil {
+		return false
+	}
+	eng.SetTorPolicy(adapter)
+	s.SetPolicyEngine(eng)
+	return true
+}
+
+// applyTorFailClosed denies Tor for a session when the onion gateway is active
+// in policy but could not be wired (proxy-env fallback or transparent disabled).
+// No-op when the gateway is inactive or the interceptor came up (force-redirect
+// handled it). Emits one session-level gateway event recording the outcome.
+func (a *App) applyTorFailClosed(ctx context.Context, s *session.Session, interceptorUp bool) {
+	if a.torPolicy == nil || !a.torPolicy.GatewayActive() {
+		return
+	}
+	if gatewayBranchFor(true, interceptorUp) != gatewayFailClosed {
+		return
+	}
+	deny, err := a.torPolicy.DenyModeClone()
+	attached := false
+	if err == nil {
+		attached = a.attachDenyTor(s, deny)
+	}
+	enforced := attached && a.execveEnforcementActive()
+	reason := "proxy_env_fallback"
+	if !a.cfg.Sandbox.Network.Transparent.Enabled {
+		reason = "transparent_disabled"
+	}
+	ev := tor.BuildGatewayEvent(s.ID, "deny", reason, enforced)
+	_ = a.store.AppendEvent(ctx, ev)
+	a.broker.Publish(ev)
 }

--- a/internal/api/session_policy.go
+++ b/internal/api/session_policy.go
@@ -129,9 +129,13 @@ func (a *App) attachDenyTor(s *session.Session, deny *tor.Policy) bool {
 // No-op when the gateway is inactive or the interceptor came up (force-redirect
 // handled it). Emits one session-level gateway event recording the outcome.
 func (a *App) applyTorFailClosed(ctx context.Context, s *session.Session, interceptorUp bool) {
+	if a == nil || s == nil {
+		return
+	}
 	if a.torPolicy == nil || !a.torPolicy.GatewayActive() {
 		return
 	}
+	// interceptorUp == true means the force-redirect path already handled this session.
 	if gatewayBranchFor(true, interceptorUp) != gatewayFailClosed {
 		return
 	}

--- a/internal/api/session_policy.go
+++ b/internal/api/session_policy.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/tor"
 )
 
 // policyEngineFor returns the effective policy engine to consult for the given
@@ -77,4 +78,20 @@ func (a *App) execveEnforcementActive() bool {
 // config (sandbox.seccomp.shellc.opaque) for command pre-checks. Issue #378.
 func (a *App) shellCOpaqueMode() policy.ShellCOpaqueMode {
 	return policy.ParseShellCOpaqueMode(a.cfg.Sandbox.Seccomp.Shellc.Opaque)
+}
+
+// attachSessionTor installs the shared Tor coordinator on a per-session engine.
+// The process-global engine already carries it (set once at server start in
+// server.go); sessions that compiled their own engine from a named policy file
+// would otherwise have torChecker == nil, silently skipping the ptrace
+// connect/execve Tor vectors. Guarded so the shared global engine is never
+// re-written (SetTorPolicy is unsynchronized).
+func (a *App) attachSessionTor(eng *policy.Engine) {
+	if a == nil || a.torPolicy == nil || eng == nil {
+		return
+	}
+	if eng == a.Policy() {
+		return
+	}
+	eng.SetTorPolicy(&tor.PolicyAdapter{Policy: a.torPolicy})
 }

--- a/internal/api/session_policy_tor_test.go
+++ b/internal/api/session_policy_tor_test.go
@@ -1,0 +1,63 @@
+// internal/api/session_policy_tor_test.go
+package api
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/tor"
+)
+
+func newDenyTorPolicy(t *testing.T) *tor.Policy {
+	t.Helper()
+	p, err := tor.New(config.ResolveTorConfig(config.TorConfig{Mode: "deny"}))
+	if err != nil {
+		t.Fatalf("tor.New: %v", err)
+	}
+	return p
+}
+
+// A per-session engine (distinct from the global one) must enforce Tor after
+// attachSessionTor. We verify via dec.Tor != nil — that field is set only by
+// the Tor checker path in CheckExecve, not by the regular command rules.
+func TestAttachSessionTor_PerSessionEngineEnforcesTor(t *testing.T) {
+	global, err := policy.NewEngine(&policy.Policy{}, false, true)
+	if err != nil {
+		t.Fatalf("global engine: %v", err)
+	}
+	a := &App{torPolicy: newDenyTorPolicy(t), policy: global}
+
+	sessionEng, err := policy.NewEngine(&policy.Policy{}, false, true)
+	if err != nil {
+		t.Fatalf("session engine: %v", err)
+	}
+	a.attachSessionTor(sessionEng)
+
+	dec := sessionEng.CheckExecve("/usr/bin/tor", []string{"tor"}, 0)
+	if dec.Tor == nil {
+		t.Fatalf("per-session engine should have Tor verdict set after attachSessionTor, got dec.Tor=nil (EffectiveDecision=%q)", dec.EffectiveDecision)
+	}
+	if dec.Tor.Decision != "deny" {
+		t.Fatalf("per-session Tor verdict should be deny, got %q", dec.Tor.Decision)
+	}
+}
+
+// The global engine must NOT be re-decorated (guard prevents racing shared state).
+// The guard returns early when eng == a.Policy(), so no SetTorPolicy is called on
+// the global engine. We confirm by checking dec.Tor == nil: any deny on the global
+// engine comes from the default-deny-execve rule, not Tor policy.
+func TestAttachSessionTor_SkipsGlobalEngine(t *testing.T) {
+	global, err := policy.NewEngine(&policy.Policy{}, false, true)
+	if err != nil {
+		t.Fatalf("global engine: %v", err)
+	}
+	a := &App{torPolicy: newDenyTorPolicy(t), policy: global}
+	a.attachSessionTor(global) // same pointer as a.Policy()
+	// dec.Tor is nil when Tor policy was NOT installed: any deny here is
+	// the regular default-deny-execve rule, confirming the guard fired.
+	dec := global.CheckExecve("/usr/bin/tor", []string{"tor"}, 0)
+	if dec.Tor != nil {
+		t.Fatal("global engine must not be decorated by attachSessionTor: dec.Tor is non-nil")
+	}
+}

--- a/internal/api/tor_failclosed_test.go
+++ b/internal/api/tor_failclosed_test.go
@@ -1,0 +1,57 @@
+// internal/api/tor_failclosed_test.go
+package api
+
+import (
+	"testing"
+
+	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/policy"
+	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/tor"
+)
+
+func TestGatewayBranchFor(t *testing.T) {
+	cases := []struct {
+		active, up bool
+		want       gatewayBranch
+	}{
+		{false, false, gatewayNone},
+		{false, true, gatewayNone},
+		{true, true, gatewayForceRedirect},
+		{true, false, gatewayFailClosed},
+	}
+	for _, c := range cases {
+		if got := gatewayBranchFor(c.active, c.up); got != c.want {
+			t.Fatalf("gatewayBranchFor(%v,%v)=%v want %v", c.active, c.up, got, c.want)
+		}
+	}
+}
+
+// Default-engine session: attachDenyTor must give it a NEW per-session engine
+// that denies Tor, without mutating the shared global engine.
+func TestAttachDenyTor_DefaultEngine_ClonesAndDenies(t *testing.T) {
+	global, err := policy.NewEngine(&policy.Policy{}, false, true)
+	if err != nil {
+		t.Fatalf("global: %v", err)
+	}
+	a := &App{policy: global, cfg: &config.Config{}}
+	deny, _ := tor.New(config.ResolveTorConfig(config.TorConfig{Mode: "deny"}))
+
+	s := &session.Session{} // PolicyEngine() == nil -> policyEngineFor returns global
+	ok := a.attachDenyTor(s, deny)
+	if !ok {
+		t.Fatal("attachDenyTor should succeed")
+	}
+	if s.PolicyEngine() == nil || s.PolicyEngine() == global {
+		t.Fatal("session must get its own cloned engine, not the global one")
+	}
+	// Use dec.Tor as discriminator (NOT dec.Action — the default-deny-execve rule
+	// makes Action=="deny" for any binary; only Tor checker sets dec.Tor).
+	if dec := s.PolicyEngine().CheckExecve("/usr/bin/tor", []string{"tor"}, 0); dec.Tor == nil || dec.Tor.Decision != "deny" {
+		t.Fatalf("session engine should have Tor deny verdict, got dec.Tor=%v", dec.Tor)
+	}
+	// Global must remain undecorated: dec.Tor nil means no Tor policy was installed.
+	if dec := global.CheckExecve("/usr/bin/tor", []string{"tor"}, 0); dec.Tor != nil {
+		t.Fatal("global engine must remain undecorated: dec.Tor is non-nil")
+	}
+}

--- a/internal/api/tor_failclosed_test.go
+++ b/internal/api/tor_failclosed_test.go
@@ -2,11 +2,14 @@
 package api
 
 import (
+	"context"
 	"testing"
 
 	"github.com/agentsh/agentsh/internal/config"
+	"github.com/agentsh/agentsh/internal/events"
 	"github.com/agentsh/agentsh/internal/policy"
 	"github.com/agentsh/agentsh/internal/session"
+	"github.com/agentsh/agentsh/internal/store/composite"
 	"github.com/agentsh/agentsh/internal/tor"
 )
 
@@ -53,5 +56,85 @@ func TestAttachDenyTor_DefaultEngine_ClonesAndDenies(t *testing.T) {
 	// Global must remain undecorated: dec.Tor nil means no Tor policy was installed.
 	if dec := global.CheckExecve("/usr/bin/tor", []string{"tor"}, 0); dec.Tor != nil {
 		t.Fatal("global engine must remain undecorated: dec.Tor is non-nil")
+	}
+}
+
+// newGatewayActiveTorPolicy returns an allow-mode Tor policy with an onion rule
+// so that GatewayActive() returns true (Enabled + ModeAllow + onion_rules set).
+// ClientBinaries and Vectors.Processes are populated so the DenyModeClone
+// produced by applyTorFailClosed will match /usr/bin/tor via EvalExecve.
+func newGatewayActiveTorPolicy(t *testing.T) *tor.Policy {
+	t.Helper()
+	p, err := tor.New(config.ResolvedTorConfig{
+		Enabled:        true,
+		Mode:           tor.ModeAllow,
+		SocksPorts:     []int{9050},
+		ClientBinaries: []string{"tor"},
+		Vectors:        config.ResolvedTorVectors{Processes: true},
+		OnionRules:     []config.TorOnionRule{{Onion: "*", Decision: "allow"}},
+	})
+	if err != nil {
+		t.Fatalf("tor.New gateway-active: %v", err)
+	}
+	if !p.GatewayActive() {
+		t.Fatal("test setup error: GatewayActive() is false; check TorConfig")
+	}
+	return p
+}
+
+// TestApplyTorFailClosed_ProfileSession verifies that a session whose gateway is
+// active (allow-mode + onion_rules) but has no interceptor running (profile
+// sessions never wire the transparent interceptor) receives a deny-mode Tor
+// policy clone. This is the regression test for the profile-path fail-open fixed
+// in createSessionWithProfile by inserting applyTorFailClosed(ctx, s, false).
+//
+// Coverage note: we cannot instantiate a full profile session (createSessionWithProfile
+// requires a mounted filesystem, a loaded profile config, a TOTP key store, and a
+// working store/broker — heavyweight infrastructure not available in a unit test).
+// The fix is a one-line wiring call at the exit of createSessionWithProfile; the
+// deny behaviour itself is already covered by TestAttachDenyTor_DefaultEngine_ClonesAndDenies
+// and TestAttachSessionTor_PerSessionEngineEnforcesTor. This test confirms
+// applyTorFailClosed(ctx, s, false) performs the wiring when interceptorUp=false
+// (the invariant that holds for every profile session).
+func TestApplyTorFailClosed_ProfileSession_DeniesTor(t *testing.T) {
+	global, err := policy.NewEngine(&policy.Policy{}, false, true)
+	if err != nil {
+		t.Fatalf("global engine: %v", err)
+	}
+	st := composite.New(memEventStore{}, nil)
+	br := events.NewBroker()
+	a := &App{
+		torPolicy: newGatewayActiveTorPolicy(t),
+		policy:    global,
+		cfg:       &config.Config{},
+		store:     st,
+		broker:    br,
+	}
+
+	s := &session.Session{}
+	// interceptorUp=false mirrors the profile-session path: the transparent
+	// interceptor is never brought up in createSessionWithProfile.
+	a.applyTorFailClosed(context.Background(), s, false)
+
+	// The session must now have its own cloned engine with a deny Tor policy.
+	eng := s.PolicyEngine()
+	if eng == nil {
+		t.Fatal("session engine is nil after applyTorFailClosed: deny policy was not attached")
+	}
+	if eng == global {
+		t.Fatal("session must receive its own cloned engine, not the shared global engine")
+	}
+	// Use dec.Tor as discriminator (NOT dec.Action — the default-deny-execve rule
+	// makes Action=="deny" for any binary; only the Tor checker path sets dec.Tor).
+	dec := eng.CheckExecve("/usr/bin/tor", []string{"tor"}, 0)
+	if dec.Tor == nil {
+		t.Fatalf("dec.Tor is nil: Tor policy was not installed on the session engine")
+	}
+	if dec.Tor.Decision != "deny" {
+		t.Fatalf("expected dec.Tor.Decision=deny, got %q", dec.Tor.Decision)
+	}
+	// Global engine must remain undecorated.
+	if gdec := global.CheckExecve("/usr/bin/tor", []string{"tor"}, 0); gdec.Tor != nil {
+		t.Fatal("global engine must remain undecorated after applyTorFailClosed")
 	}
 }

--- a/internal/netmonitor/netns_integration_linux_test.go
+++ b/internal/netmonitor/netns_integration_linux_test.go
@@ -1,0 +1,122 @@
+//go:build linux
+
+package netmonitor
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestSetupNetNS_InstallsTorLoopbackDNAT is a root-gated integration test that
+// creates a real network namespace via SetupNetNS (with Tor redirect ports
+// 9050 and 9150) and asserts that:
+//  1. The loopback-DNAT rules for --dport 9050 and --dport 9150 exist in the
+//     netns OUTPUT chain.
+//  2. Both DNAT rules appear BEFORE the 127.0.0.0/8 RETURN rule (ordering
+//     invariant required for force-redirect correctness).
+//  3. net.ipv4.conf.all.route_localnet == 1 inside the netns.
+//
+// The test SKIPS cleanly (not fails) when run unprivileged or when the
+// required binaries (ip, iptables) are absent.
+//
+// NOTE: The full app→onion-filter e2e (driving real traffic through the
+// gateway) is a deferred CI/manual check and is out of scope here.
+func TestSetupNetNS_InstallsTorLoopbackDNAT(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root for netns/iptables")
+	}
+	if _, err := exec.LookPath("ip"); err != nil {
+		t.Skip("requires 'ip' binary in PATH")
+	}
+	if _, err := exec.LookPath("iptables"); err != nil {
+		t.Skip("requires 'iptables' binary in PATH")
+	}
+
+	const nsName = "agentsh-test-tordnat"
+	const subnetBase = "10.250.0.0/16"
+
+	subnetCIDR, hostIPCIDR, nsIPCIDR, hostIf, nsIf := AllocateSubnet(subnetBase, nsName)
+
+	ctx := context.Background()
+
+	// Best-effort pre-cleanup in case a prior run left the ns behind.
+	_ = exec.CommandContext(ctx, "ip", "netns", "del", nsName).Run()
+	_ = exec.CommandContext(ctx, "ip", "link", "del", hostIf).Run()
+
+	ns, err := SetupNetNS(ctx, nsName, subnetCIDR, hostIf, nsIf, hostIPCIDR, nsIPCIDR,
+		50000, 50053, []int{9050, 9150})
+	if err != nil {
+		t.Fatalf("SetupNetNS: %v", err)
+	}
+	defer func() {
+		if err := ns.Close(context.Background()); err != nil {
+			t.Logf("ns.Close: %v", err)
+		}
+	}()
+
+	// --- Assert 1 & 2: iptables OUTPUT chain rule order ---
+	out, err := exec.CommandContext(ctx, "ip", "netns", "exec", nsName,
+		"iptables", "-t", "nat", "-S", "OUTPUT").Output()
+	if err != nil {
+		t.Fatalf("iptables -t nat -S OUTPUT: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	t.Logf("iptables nat OUTPUT rules:\n%s", bytes.TrimSpace(out))
+
+	idx9050, idx9150, idxReturn := -1, -1, -1
+	for i, line := range lines {
+		switch {
+		case strings.Contains(line, "--dport 9050") && strings.Contains(line, "127.0.0.1") && strings.Contains(line, "DNAT"):
+			idx9050 = i
+		case strings.Contains(line, "--dport 9150") && strings.Contains(line, "127.0.0.1") && strings.Contains(line, "DNAT"):
+			idx9150 = i
+		case strings.Contains(line, "127.0.0.0/8") && strings.Contains(line, "RETURN"):
+			idxReturn = i
+		}
+	}
+
+	if idx9050 < 0 {
+		t.Error("missing loopback-DNAT rule for --dport 9050")
+	}
+	if idx9150 < 0 {
+		t.Error("missing loopback-DNAT rule for --dport 9150")
+	}
+	if idxReturn < 0 {
+		t.Error("missing 127.0.0.0/8 RETURN rule")
+	}
+	if t.Failed() {
+		t.FailNow()
+	}
+
+	if idx9050 >= idxReturn {
+		t.Errorf("--dport 9050 DNAT (line %d) must precede 127.0.0.0/8 RETURN (line %d)", idx9050, idxReturn)
+	}
+	if idx9150 >= idxReturn {
+		t.Errorf("--dport 9150 DNAT (line %d) must precede 127.0.0.0/8 RETURN (line %d)", idx9150, idxReturn)
+	}
+
+	// --- Assert 3: route_localnet == 1 ---
+	rlOut, err := exec.CommandContext(ctx, "ip", "netns", "exec", nsName,
+		"sysctl", "-n", "net.ipv4.conf.all.route_localnet").Output()
+	if err != nil {
+		t.Fatalf("sysctl route_localnet: %v", err)
+	}
+	got := strings.TrimSpace(string(rlOut))
+	if got != "1" {
+		t.Errorf("net.ipv4.conf.all.route_localnet = %q, want \"1\"", got)
+	} else {
+		t.Logf("net.ipv4.conf.all.route_localnet = %s (correct)", got)
+	}
+
+	t.Logf("all assertions passed: dnat9050@%d dnat9150@%d return@%d route_localnet=%s",
+		idx9050, idx9150, idxReturn, got)
+
+	// Diagnostic: log the AllocateSubnet output used.
+	t.Logf("AllocateSubnet(%q, %q) → subnet=%s hostIPCIDR=%s nsIPCIDR=%s hostIf=%s nsIf=%s",
+		subnetBase, nsName, subnetCIDR, hostIPCIDR, nsIPCIDR, hostIf, nsIf)
+}

--- a/internal/netmonitor/netns_linux.go
+++ b/internal/netmonitor/netns_linux.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -21,7 +22,30 @@ type NetNS struct {
 	DNSUDPPort   int
 }
 
-func SetupNetNS(ctx context.Context, nsName string, subnetCIDR string, hostIf string, nsIf string, hostIPCIDR string, nsIPCIDR string, proxyTCPPort int, dnsUDPPort int) (*NetNS, error) {
+// natOutputRules returns the ordered nat OUTPUT rule bodies (args after
+// "OUTPUT") for the session netns. Tor SOCKS ports get a loopback DNAT inserted
+// BEFORE the 127.0.0.0/8 RETURN so the app's connect(127.0.0.1:<port>) is
+// steered across the veth to the host interceptor; all other loopback traffic
+// is still exempted. Ordering is a correctness invariant (see Phase 3 design).
+func natOutputRules(hostIP, hostTCP, hostDNS string, torRedirectPorts []int) [][]string {
+	rules := [][]string{
+		{"-d", hostIP, "-j", "RETURN"},
+	}
+	for _, p := range torRedirectPorts {
+		rules = append(rules, []string{
+			"-d", "127.0.0.1", "-p", "tcp", "--dport", strconv.Itoa(p),
+			"-j", "DNAT", "--to-destination", hostTCP,
+		})
+	}
+	rules = append(rules,
+		[]string{"-d", "127.0.0.0/8", "-j", "RETURN"},
+		[]string{"-p", "tcp", "-j", "DNAT", "--to-destination", hostTCP},
+		[]string{"-p", "udp", "--dport", "53", "-j", "DNAT", "--to-destination", hostDNS},
+	)
+	return rules
+}
+
+func SetupNetNS(ctx context.Context, nsName string, subnetCIDR string, hostIf string, nsIf string, hostIPCIDR string, nsIPCIDR string, proxyTCPPort int, dnsUDPPort int, torRedirectPorts []int) (*NetNS, error) {
 	if os.Geteuid() != 0 {
 		return nil, fmt.Errorf("transparent netns requires root (euid=%d)", os.Geteuid())
 	}
@@ -121,26 +145,22 @@ func SetupNetNS(ctx context.Context, nsName string, subnetCIDR string, hostIf st
 	// Netns DNAT outbound to host-side interceptors.
 	hostTCP := fmt.Sprintf("%s:%d", hostIP, proxyTCPPort)
 	hostDNS := fmt.Sprintf("%s:%d", hostIP, dnsUDPPort)
-	// Avoid rewriting traffic destined to the host veth IP.
-	if err := run(ctx, "ip", "netns", "exec", nsName, "iptables", "-t", "nat", "-A", "OUTPUT", "-d", hostIP, "-j", "RETURN"); err != nil {
-		rollbackAll()
-		cleanupNS()
-		return nil, err
+	if len(torRedirectPorts) > 0 {
+		// Permit routing of loopback-destined packets so the Tor SOCKS DNAT can
+		// forward them across the veth to the host interceptor.
+		if err := run(ctx, "ip", "netns", "exec", nsName, "sysctl", "-w", "net.ipv4.conf.all.route_localnet=1"); err != nil {
+			rollbackAll()
+			cleanupNS()
+			return nil, err
+		}
 	}
-	if err := run(ctx, "ip", "netns", "exec", nsName, "iptables", "-t", "nat", "-A", "OUTPUT", "-d", "127.0.0.0/8", "-j", "RETURN"); err != nil {
-		rollbackAll()
-		cleanupNS()
-		return nil, err
-	}
-	if err := run(ctx, "ip", "netns", "exec", nsName, "iptables", "-t", "nat", "-A", "OUTPUT", "-p", "tcp", "-j", "DNAT", "--to-destination", hostTCP); err != nil {
-		rollbackAll()
-		cleanupNS()
-		return nil, err
-	}
-	if err := run(ctx, "ip", "netns", "exec", nsName, "iptables", "-t", "nat", "-A", "OUTPUT", "-p", "udp", "--dport", "53", "-j", "DNAT", "--to-destination", hostDNS); err != nil {
-		rollbackAll()
-		cleanupNS()
-		return nil, err
+	for _, body := range natOutputRules(hostIP, hostTCP, hostDNS, torRedirectPorts) {
+		args := append([]string{"ip", "netns", "exec", nsName, "iptables", "-t", "nat", "-A", "OUTPUT"}, body...)
+		if err := run(ctx, args[0], args[1:]...); err != nil {
+			rollbackAll()
+			cleanupNS()
+			return nil, err
+		}
 	}
 
 	return &NetNS{

--- a/internal/netmonitor/netns_other.go
+++ b/internal/netmonitor/netns_other.go
@@ -18,7 +18,7 @@ type NetNS struct {
 	DNSUDPPort   int
 }
 
-func SetupNetNS(ctx context.Context, nsName string, subnetCIDR string, hostIf string, nsIf string, hostIPCIDR string, nsIPCIDR string, proxyTCPPort int, dnsUDPPort int) (*NetNS, error) {
+func SetupNetNS(ctx context.Context, nsName string, subnetCIDR string, hostIf string, nsIf string, hostIPCIDR string, nsIPCIDR string, proxyTCPPort int, dnsUDPPort int, torRedirectPorts []int) (*NetNS, error) {
 	return nil, fmt.Errorf("transparent netns not supported on this platform")
 }
 

--- a/internal/netmonitor/netns_rules_test.go
+++ b/internal/netmonitor/netns_rules_test.go
@@ -1,0 +1,51 @@
+//go:build linux
+
+package netmonitor
+
+import "testing"
+
+func TestNatOutputRules_LoopbackDNATBeforeLoopbackReturn(t *testing.T) {
+	rules := natOutputRules("10.0.0.1", "10.0.0.1:5000", "10.0.0.1:5300", []int{9050, 9150})
+
+	idxReturn := -1
+	idx9050, idx9150 := -1, -1
+	for i, r := range rules {
+		joined := ""
+		for _, a := range r {
+			joined += a + " "
+		}
+		switch {
+		case contains(r, "127.0.0.0/8") && contains(r, "RETURN"):
+			idxReturn = i
+		case contains(r, "127.0.0.1") && contains(r, "9050"):
+			idx9050 = i
+		case contains(r, "127.0.0.1") && contains(r, "9150"):
+			idx9150 = i
+		}
+		_ = joined
+	}
+	if idx9050 < 0 || idx9150 < 0 || idxReturn < 0 {
+		t.Fatalf("missing rules: dnat9050=%d dnat9150=%d return=%d", idx9050, idx9150, idxReturn)
+	}
+	if idx9050 >= idxReturn || idx9150 >= idxReturn {
+		t.Fatalf("loopback DNAT must precede 127.0.0.0/8 RETURN: dnat9050=%d dnat9150=%d return=%d", idx9050, idx9150, idxReturn)
+	}
+}
+
+func TestNatOutputRules_NoTorPorts_NoLoopbackDNAT(t *testing.T) {
+	rules := natOutputRules("10.0.0.1", "10.0.0.1:5000", "10.0.0.1:5300", nil)
+	for _, r := range rules {
+		if contains(r, "127.0.0.1") && contains(r, "DNAT") {
+			t.Fatal("no Tor ports → no loopback DNAT rule expected")
+		}
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -215,6 +215,9 @@ func New(cfg *config.Config) (*Server, error) {
 		torPol = p
 		engine.SetTorPolicy(&tor.PolicyAdapter{Policy: torPol})
 		slog.Info("tor access control enabled", "mode", torCfg.Mode)
+		if torCfg.Mode == "allow" && len(torCfg.OnionRules) > 0 && !cfg.Sandbox.Network.Transparent.Enabled {
+			slog.Warn("tor onion gateway configured (mode=allow + onion_rules) but transparent network is disabled; every session will fail-closed (Tor denied). Enable sandbox.network.transparent to use the gateway.")
+		}
 		if torPol.RelayFeedEnabled() {
 			torSyncer = tor.NewSyncer(torPol, slog.Default())
 		}

--- a/internal/tor/event.go
+++ b/internal/tor/event.go
@@ -26,3 +26,24 @@ func BuildControlEvent(sessionID, commandID string, pid int, v Verdict) types.Ev
 		},
 	}
 }
+
+// BuildGatewayEvent constructs a session-level tor_control event describing the
+// Phase 3 onion-gateway wiring outcome. decision is "allow" (force-redirect
+// armed) or "deny" (fail-closed). reason names the cause. enforced is false
+// only when a fail-closed deny cannot actually be enforced (no live syscall
+// enforcement subsystem for the session).
+func BuildGatewayEvent(sessionID, decision, reason string, enforced bool) types.Event {
+	return types.Event{
+		ID:        uuid.NewString(),
+		Timestamp: time.Now().UTC(),
+		Type:      "tor_control",
+		SessionID: sessionID,
+		Fields: map[string]any{
+			"vector":   VectorGateway,
+			"decision": decision,
+			"reason":   reason,
+			"enforced": enforced,
+			"rule":     "tor",
+		},
+	}
+}

--- a/internal/tor/event_test.go
+++ b/internal/tor/event_test.go
@@ -25,3 +25,19 @@ func TestBuildControlEvent(t *testing.T) {
 		t.Fatalf("ID/Timestamp not populated: id=%q ts=%v", ev.ID, ev.Timestamp)
 	}
 }
+
+func TestBuildGatewayEvent_Fields(t *testing.T) {
+	ev := BuildGatewayEvent("session-1", "deny", "proxy_env_fallback", false)
+	if ev.Type != "tor_control" {
+		t.Fatalf("type = %q, want tor_control", ev.Type)
+	}
+	if ev.Fields["vector"] != VectorGateway {
+		t.Fatalf("vector = %v, want %q", ev.Fields["vector"], VectorGateway)
+	}
+	if ev.Fields["decision"] != "deny" || ev.Fields["reason"] != "proxy_env_fallback" {
+		t.Fatalf("unexpected fields: %v", ev.Fields)
+	}
+	if ev.Fields["enforced"] != false {
+		t.Fatalf("enforced = %v, want false", ev.Fields["enforced"])
+	}
+}

--- a/internal/tor/gateway.go
+++ b/internal/tor/gateway.go
@@ -19,6 +19,19 @@ func (p *Policy) GatewayActive() bool {
 	return p != nil && p.cfg.Enabled && p.cfg.Mode == ModeAllow && len(p.onionRules) > 0
 }
 
+// DenyModeClone returns a sibling Policy built from the same resolved config
+// but with Mode forced to deny. Used for fail-closed sessions where the onion
+// gateway cannot be wired: the session enforces Phase-1 Tor deny instead of
+// silently allowing unfiltered Tor. The receiver is not modified.
+func (p *Policy) DenyModeClone() (*Policy, error) {
+	if p == nil {
+		return nil, nil
+	}
+	cfg := p.cfg // value copy; New only reads the (shared) slices
+	cfg.Mode = ModeDeny
+	return New(cfg)
+}
+
 // EvalSocksTarget evaluates a SOCKS CONNECT target host:port against the
 // onion rules. When the gateway is active it always returns ok=true with a
 // concrete allow/deny decision; an unmatched target fails closed (deny).

--- a/internal/tor/gateway_test.go
+++ b/internal/tor/gateway_test.go
@@ -79,3 +79,34 @@ func TestUpstreamSocksAddr(t *testing.T) {
 		t.Errorf("UpstreamSocksAddr = %q, want 127.0.0.1:9050", got)
 	}
 }
+
+func TestDenyModeClone_ForcesDenyWithoutMutatingOriginal(t *testing.T) {
+	allow, err := New(config.ResolvedTorConfig{
+		Enabled:        true,
+		Mode:           ModeAllow,
+		ClientBinaries: []string{"tor"},
+		SocksPorts:     []int{9050, 9150},
+		Vectors:        config.ResolvedTorVectors{Processes: true, SocksPorts: true, Onion: true, RelayIPs: true},
+		OnionRules:     []config.TorOnionRule{{Onion: "*", Decision: "deny"}},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	deny, err := allow.DenyModeClone()
+	if err != nil {
+		t.Fatalf("DenyModeClone: %v", err)
+	}
+	if deny.Mode() != ModeDeny {
+		t.Fatalf("clone mode = %q, want deny", deny.Mode())
+	}
+	if allow.Mode() != ModeAllow {
+		t.Fatalf("original mutated: mode = %q, want allow", allow.Mode())
+	}
+	// Deny-mode clone enforces the Phase-1 execve vector; allow-mode never does.
+	if _, ok := deny.EvalExecve("/usr/bin/tor", nil); !ok {
+		t.Fatal("deny clone should match the tor binary via EvalExecve")
+	}
+	if _, ok := allow.EvalExecve("/usr/bin/tor", nil); ok {
+		t.Fatal("allow-mode original should not produce an execve verdict")
+	}
+}

--- a/internal/tor/policy.go
+++ b/internal/tor/policy.go
@@ -25,7 +25,8 @@ const (
 	VectorOnionDNS  = "onion_dns"
 	VectorOnionHTTP = "onion_http"
 	VectorRelayIP   = "relay_ip"
-	VectorOnion     = "onion" // Phase 2 SOCKS gateway
+	VectorOnion     = "onion"   // Phase 2 SOCKS gateway
+	VectorGateway   = "gateway" // Phase 3 session-level onion-gateway wiring outcome
 )
 
 // Verdict is the result of a positive Tor match.


### PR DESCRIPTION
## Tor Access Control — Phase 3: close the allow-mode onion-gateway fail-open gap

Phase 2 (#428) gave true per-`.onion` allow/deny, but **only** for Tor SOCKS that reaches agentsh's transparent-TCP interceptor. When the app reached a loopback Tor daemon (`127.0.0.1:9050`) not routed through that interceptor, allow-mode silently degraded to **unfiltered** Tor allow — a fail-open at the control's finest granularity, with nothing in the audit stream. Phase 3 closes it from both ends.

### Two branches, one decision (evaluated per session at startup)

1. **Force-redirect (netns transparent mode):** a loopback-DNAT rule inside the session netns steers the app's Tor SOCKS connection into the existing interceptor/gateway. `SO_ORIGINAL_DST` recovers the original dst so the Phase-2 gateway filters per-`.onion` exactly as before — Phase 3 only guarantees the bytes get there. The DNAT is inserted **before** the `127.0.0.0/8 RETURN` rule (correctness invariant), `route_localnet` is enabled only when redirect ports are present, and install is **all-or-nothing** (a partial install tears down and falls to fail-closed).
2. **Fail-closed (every other mode):** when the gateway cannot be wired — proxy-env fallback, transparent networking disabled, partial force-redirect install, or **profile-based sessions** — agentsh denies all Tor for that session (Phase-1 deny semantics via a per-session deny-mode `tor.Policy` clone) and emits an audit event, rather than allowing unfiltered Tor.

### Also fixes a pre-existing enforcement gap

`SetTorPolicy` was called once on the global engine, but ptrace handlers consult the **per-session** engine — so named-policy/profile sessions silently dropped the Tor coordinator (`torChecker == nil`). `attachSessionTor` now attaches it to every per-session engine, guarded so the unsynchronized `SetTorPolicy` never races the shared global.

### Properties

- **No new data path, no new `events.EventType`** — reuses `tor_control` with a new `vector: gateway` value (OCSF registry untouched).
- **No shared-state mutation** — fail-closed deep-clones the policy and builds a fresh engine; the global engine's `torChecker` is written exactly once at startup.
- **Honest scope** — the deny event's `enforced` flag is `attached && execveEnforcementActive()`, never claiming a block the session can't deliver; a startup advisory warns when allow-mode + `onion_rules` can't be gatewayed on the platform.
- **No new config knobs** — all behavior derives from existing `tor.mode` / `onion_rules` / `socks_ports`.

### Testing

- Pure-function unit tests for the rule-ordering invariant (`natOutputRules`), the branch predicate (`gatewayBranchFor`), the deny-clone (no shared mutation), and the gateway events.
- Root-gated netns integration test asserts the loopback-DNAT rules install in a live namespace in the correct order with `route_localnet=1` (skips cleanly unprivileged).
- `go build ./...` + `GOOS=windows go build ./...` clean; touched packages (`tor`, `netmonitor`, `api`, `server`) green.

Design: `docs/superpowers/specs/2026-06-20-tor-access-control-phase3-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
