### PR TITLE
feat(tor): Tor access control Phase 4 — SOCKS RESOLVE in the onion gateway

### DIFF
--- a/docs/superpowers/plans/2026-06-22-tor-access-control-phase4.md
+++ b/docs/superpowers/plans/2026-06-22-tor-access-control-phase4.md
@@ -1,0 +1,648 @@
+# Tor Access Control — Phase 4 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the onion gateway command-aware — filter-and-forward SOCKS `RESOLVE` (0xF0) through `onion_rules`, and reject `RESOLVE_PTR` (0xF1) and all other non-CONNECT commands with the correct SOCKS `command not supported` (0x07).
+
+**Architecture:** Generalize the existing single-command `handleTorSocks` in `internal/netmonitor/socks.go` into a command-aware dispatcher. A generic `readSocksRequest` captures the command byte; the handler switches on it — CONNECT keeps its existing tunnel path, RESOLVE filters via the same `EvalSocksTarget` then forwards the request and relays the single reply (no splice), and everything else gets `0x07`. The shared upstream SOCKS handshake is factored into one helper. Audit events gain a `socks_cmd` field set in `emitOnionEvent`.
+
+**Tech Stack:** Go; SOCKS5 (RFC 1928) + Tor's RESOLVE extension; existing `internal/netmonitor` SOCKS front-end and `internal/tor` policy/event packages.
+
+## Global Constraints
+
+- No new `events.EventType` — reuse the existing `tor_control` event (`Type: "tor_control"`); the OCSF registry stays untouched.
+- No new config knobs — behavior derives from existing `onion_rules` / `socks_ports`; gateway activation (`GatewayActive()`) is unchanged.
+- No new data path — CONNECT's tunnel behavior is unchanged; RESOLVE is request/reply (no `splice`).
+- `RESOLVE` (0xF0): filter through `onion_rules` exactly like CONNECT; allowed → forward + relay single reply; denied/unmatched → `not allowed` (0x02), fail-closed.
+- `RESOLVE_PTR` (0xF1) and every other non-CONNECT/non-RESOLVE command → `command not supported` (0x07); no upstream dial; no event.
+- Fail-closed parity: any parse/dial/upstream error → `general failure` (0x01); denied target → `not allowed` (0x02).
+- Audit: one `tor_control{vector: onion}` event per evaluated request, with `Fields["socks_cmd"]` = `"connect"` or `"resolve"`; RESOLVE_PTR / unsupported commands emit none.
+- Cross-compile clean: `GOOS=windows go build ./...` must stay green.
+
+---
+
+### Task 1: Command-aware dispatch + correct unsupported-command handling
+
+Generalize the parser/encoder, split the CONNECT body into `gatewayConnect`, add the command switch (RESOLVE still rejected with `0x07` here — it becomes a real branch in Task 2), factor the upstream handshake into `upstreamHandshake`, and add `socks_cmd: "connect"` to CONNECT events. Net behavior change: non-CONNECT commands now get the correct `0x07` instead of a misleading `general failure`, and CONNECT events carry `socks_cmd`.
+
+**Files:**
+- Modify: `internal/netmonitor/socks.go`
+- Test: `internal/netmonitor/socks_handler_test.go`
+
+**Interfaces:**
+- Consumes (existing, unchanged): `readSocksGreeting`, `writeSocksMethod`, `writeSocksReply`, `readSocksReply`, `splice`, `TorGatewayPolicy.EvalSocksTarget(host string, port int) (tor.Verdict, bool)`, `tor.BuildControlEvent(sessionID, commandID string, pid int, v tor.Verdict) types.Event`, `Emitter`.
+- Produces (for Task 2): `readSocksRequest(r io.Reader) (socksReq, error)` (sets `socksReq.cmd`), `encodeReq(req socksReq) []byte`, `upstreamHandshake(up net.Conn) error`, `gatewayConnect(...)`, `emitOnionEvent(emit Emitter, sessionID, commandID string, v tor.Verdict, socksCmd string)`, and the constants `socksCmdResolve = 0xF0`, `socksCmdResolvePtr = 0xF1`, `socksRepCmdNotSupported = 0x07`. `socksReq` gains a `cmd byte` field.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/netmonitor/socks_handler_test.go`. These replace the decision-only `assertOneOnionEvent` with a command-aware `assertOnionEvent` and add an unsupported-command test.
+
+```go
+// assertOnionEvent waits for one tor_control{vector:onion} event and asserts
+// both its decision and its socks_cmd field.
+func assertOnionEvent(t *testing.T, emit *torCaptureEmitter, wantDecision, wantCmd string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, ev := range emit.events() {
+			if ev.Type == "tor_control" && ev.Fields["vector"] == tor.VectorOnion {
+				if ev.Fields["decision"] != wantDecision {
+					t.Fatalf("event decision = %v, want %v", ev.Fields["decision"], wantDecision)
+				}
+				if ev.Fields["socks_cmd"] != wantCmd {
+					t.Fatalf("event socks_cmd = %v, want %v", ev.Fields["socks_cmd"], wantCmd)
+				}
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("no tor_control{vector:onion,decision:%s,socks_cmd:%s} event seen", wantDecision, wantCmd)
+}
+
+// driveCmd sends a SOCKS5 request with an explicit command byte and returns the
+// reply's REP code (reply is the fixed 10-byte IPv4-form reply for the cases
+// exercised here).
+func driveCmd(t *testing.T, conn net.Conn, cmd byte, host string, port int) byte {
+	t.Helper()
+	_, _ = conn.Write([]byte{0x05, 0x01, 0x00}) // greeting
+	method := make([]byte, 2)
+	if _, err := io.ReadFull(conn, method); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = conn.Write(encodeReq(socksReq{cmd: cmd, atyp: atypDomain, addr: []byte(host), host: host, port: port}))
+	reply := make([]byte, 10)
+	if _, err := io.ReadFull(conn, reply); err != nil {
+		t.Fatal(err)
+	}
+	return reply[1]
+}
+
+// TestHandleTorSocks_UnsupportedCommand verifies a non-CONNECT/non-RESOLVE
+// command (here BIND 0x02) gets command-not-supported (0x07), no upstream dial,
+// and emits no event.
+func TestHandleTorSocks_UnsupportedCommand(t *testing.T) {
+	client, server := net.Pipe()
+	emit := &torCaptureEmitter{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// upstreamAddr is unreachable on purpose; it must never be dialed.
+		_ = handleTorSocks(server, "127.0.0.1:1", fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+	}()
+	rep := driveCmd(t, client, 0x02 /* BIND */, "ok.onion", 443)
+	if rep != socksRepCmdNotSupported {
+		t.Fatalf("BIND got reply 0x%02x, want command-not-supported (0x%02x)", rep, socksRepCmdNotSupported)
+	}
+	client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleTorSocks did not return for unsupported command")
+	}
+	if len(emit.events()) != 0 {
+		t.Fatalf("unsupported command emitted %d events, want 0", len(emit.events()))
+	}
+}
+```
+
+Also update the existing `assertOneOnionEvent` call sites (in `TestHandleTorSocks_Allowed`, `TestHandleTorSocks_Denied`, `TestHandleTorSocks_UpstreamRefuses`, `TestHandleTorSocks_UpstreamRequiresAuth`) to the new `assertOnionEvent` with the `"connect"` command, and delete the old `assertOneOnionEvent` helper:
+- `assertOneOnionEvent(t, emit, "allow")` → `assertOnionEvent(t, emit, "allow", "connect")`
+- `assertOneOnionEvent(t, emit, "deny")` → `assertOnionEvent(t, emit, "deny", "connect")`
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/netmonitor/ -run 'TestHandleTorSocks' -v`
+Expected: compile failure — `encodeReq`, `socksRepCmdNotSupported`, `socksReq.cmd`, and `assertOnionEvent` are undefined.
+
+- [ ] **Step 3: Generalize the constants, request struct, parser, and encoder in `socks.go`**
+
+Replace the constant block (lines 14-25) with:
+
+```go
+// SOCKS5 reply / command codes (RFC 1928) and Tor's RESOLVE extension.
+const (
+	socksVer                = 0x05
+	socksCmdConnect         = 0x01
+	socksCmdResolve         = 0xF0 // Tor RESOLVE extension
+	socksCmdResolvePtr      = 0xF1 // Tor RESOLVE_PTR extension (deliberately unsupported)
+	socksRepSuccess         = 0x00
+	socksRepGeneralFailure  = 0x01
+	socksRepNotAllowed      = 0x02 // connection not allowed by ruleset
+	socksRepCmdNotSupported = 0x07 // command not supported
+
+	atypIPv4   = 0x01
+	atypDomain = 0x03
+	atypIPv6   = 0x04
+)
+```
+
+Add the `cmd` field to `socksReq`:
+
+```go
+type socksReq struct {
+	cmd  byte
+	atyp byte
+	addr []byte // raw address bytes (domain text, or 4/16-byte IP)
+	host string
+	port int
+}
+```
+
+Rename `readSocksConnect` to `readSocksRequest` and capture the command byte without judging it (the handler dispatches on it):
+
+```go
+// readSocksRequest reads a SOCKS5 request: VER CMD RSV ATYP ADDR PORT. The
+// command byte is captured verbatim into req.cmd; the caller dispatches on it
+// (CONNECT and RESOLVE are handled, others get command-not-supported).
+func readSocksRequest(r io.Reader) (socksReq, error) {
+	head := make([]byte, 4)
+	if _, err := io.ReadFull(r, head); err != nil {
+		return socksReq{}, err
+	}
+	if head[0] != socksVer {
+		return socksReq{}, fmt.Errorf("socks: bad version 0x%02x", head[0])
+	}
+	var req socksReq
+	req.cmd = head[1]
+	req.atyp = head[3]
+	switch req.atyp {
+	case atypIPv4:
+		req.addr = make([]byte, 4)
+		if _, err := io.ReadFull(r, req.addr); err != nil {
+			return socksReq{}, err
+		}
+		req.host = net.IP(req.addr).String()
+	case atypIPv6:
+		req.addr = make([]byte, 16)
+		if _, err := io.ReadFull(r, req.addr); err != nil {
+			return socksReq{}, err
+		}
+		req.host = net.IP(req.addr).String()
+	case atypDomain:
+		lb := make([]byte, 1)
+		if _, err := io.ReadFull(r, lb); err != nil {
+			return socksReq{}, err
+		}
+		req.addr = make([]byte, int(lb[0]))
+		if _, err := io.ReadFull(r, req.addr); err != nil {
+			return socksReq{}, err
+		}
+		req.host = string(req.addr)
+	default:
+		return socksReq{}, fmt.Errorf("socks: bad atyp 0x%02x", req.atyp)
+	}
+	portB := make([]byte, 2)
+	if _, err := io.ReadFull(r, portB); err != nil {
+		return socksReq{}, err
+	}
+	req.port = int(binary.BigEndian.Uint16(portB))
+	return req, nil
+}
+```
+
+Rename `encodeConnectReq` to `encodeReq` and emit the request's own command:
+
+```go
+// encodeReq re-serializes req (preserving its command byte) for the upstream
+// Tor SOCKS daemon.
+func encodeReq(req socksReq) []byte {
+	out := []byte{socksVer, req.cmd, 0x00, req.atyp}
+	if req.atyp == atypDomain {
+		out = append(out, byte(len(req.addr)))
+	}
+	out = append(out, req.addr...)
+	var p [2]byte
+	binary.BigEndian.PutUint16(p[:], uint16(req.port))
+	return append(out, p[:]...)
+}
+```
+
+- [ ] **Step 4: Rewrite `handleTorSocks` as a dispatcher, extract `gatewayConnect` + `upstreamHandshake`, and thread `socks_cmd` into events**
+
+Replace `handleTorSocks` (lines 131-205) and `emitOnionEvent` (lines 271-278) with:
+
+```go
+// handleTorSocks terminates a client SOCKS5 handshake, reads the request, and
+// dispatches on the command: CONNECT tunnels through the onion gateway,
+// RESOLVE is filtered-and-forwarded, and every other command is rejected with
+// command-not-supported. Fail-closed on any error.
+func handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string) error {
+	defer conn.Close()
+
+	if err := readSocksGreeting(conn); err != nil {
+		return err
+	}
+	if err := writeSocksMethod(conn, 0x00); err != nil { // no-auth
+		return err
+	}
+	req, err := readSocksRequest(conn)
+	if err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+
+	switch req.cmd {
+	case socksCmdConnect:
+		return gatewayConnect(conn, upstreamAddr, pol, emit, sessionID, commandID, req)
+	// case socksCmdResolve is added in Task 2.
+	default:
+		// RESOLVE_PTR (0xF1), BIND, UDP ASSOCIATE, etc. — deliberately
+		// unsupported. Reply the correct SOCKS code and close; no event,
+		// since no onion_rules decision was made.
+		_ = writeSocksReply(conn, socksRepCmdNotSupported)
+		return nil
+	}
+}
+
+// gatewayConnect handles a SOCKS CONNECT: evaluate the target against the onion
+// gateway policy, and either proxy the stream to the real Tor SOCKS daemon or
+// reply not-allowed. Fail-closed on any error. Emits one tor_control{vector:
+// onion, socks_cmd: connect} event.
+func gatewayConnect(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string, req socksReq) error {
+	v, ok := pol.EvalSocksTarget(req.host, req.port)
+	if ok {
+		emitOnionEvent(emit, sessionID, commandID, v, "connect")
+	}
+	if !ok || v.Decision != "allow" {
+		_ = writeSocksReply(conn, socksRepNotAllowed)
+		return nil
+	}
+
+	up, err := net.DialTimeout("tcp", upstreamAddr, 20*time.Second)
+	if err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	defer up.Close()
+
+	if err := upstreamHandshake(up); err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	if _, err := up.Write(encodeReq(req)); err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	upReply, err := readSocksReply(up)
+	if err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	// Relay the upstream's reply verbatim to the client.
+	if _, err := conn.Write(upReply); err != nil {
+		return err
+	}
+	// Only tunnel when the upstream accepted the connection.
+	if len(upReply) < 2 || upReply[1] != socksRepSuccess {
+		return nil
+	}
+	splice(conn, up)
+	return nil
+}
+
+// upstreamHandshake performs the SOCKS5 no-auth client handshake with the real
+// Tor daemon (greeting with one method, no-auth, then method-selection reply
+// validation). Returns an error if the upstream does not accept no-auth.
+func upstreamHandshake(up net.Conn) error {
+	if _, err := up.Write([]byte{socksVer, 0x01, 0x00}); err != nil { // greeting: 1 method, no-auth
+		return err
+	}
+	methodReply := make([]byte, 2)
+	if _, err := io.ReadFull(up, methodReply); err != nil {
+		return err
+	}
+	if methodReply[0] != socksVer || methodReply[1] != 0x00 {
+		return fmt.Errorf("socks: upstream selected auth method 0x%02x (want no-auth)", methodReply[1])
+	}
+	return nil
+}
+```
+
+Replace `emitOnionEvent` to set `socks_cmd`:
+
+```go
+func emitOnionEvent(emit Emitter, sessionID, commandID string, v tor.Verdict, socksCmd string) {
+	if emit == nil {
+		return
+	}
+	ev := tor.BuildControlEvent(sessionID, commandID, 0, v)
+	ev.Fields["socks_cmd"] = socksCmd
+	_ = emit.AppendEvent(context.Background(), ev)
+	emit.Publish(ev)
+}
+```
+
+- [ ] **Step 5: Update test-helper references to the renamed functions**
+
+In `internal/netmonitor/socks_handler_test.go`, the package will not compile until the helpers use the new names:
+- In `driveClient`: `encodeConnectReq(socksReq{atyp: atypDomain, ...})` → `encodeReq(socksReq{cmd: socksCmdConnect, atyp: atypDomain, addr: []byte(host), host: host, port: port})`.
+- In `fakeTorUpstreamWithReply`: `if _, err := readSocksConnect(c); err != nil {` → `if _, err := readSocksRequest(c); err != nil {`.
+- `fakeTorUpstreamRequiresAuth` does not call `readSocksConnect` (it closes after the method reply) — no change.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `go test ./internal/netmonitor/ -run 'TestHandleTorSocks|TestSplice' -v`
+Expected: PASS — including the existing CONNECT tests (now asserting `socks_cmd: "connect"`) and `TestHandleTorSocks_UnsupportedCommand`.
+
+- [ ] **Step 7: Verify build, cross-compile, and format**
+
+Run: `go build ./... && GOOS=windows go build ./... && gofmt -l internal/netmonitor/socks.go internal/netmonitor/socks_handler_test.go`
+Expected: both builds succeed; `gofmt -l` prints nothing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/netmonitor/socks.go internal/netmonitor/socks_handler_test.go
+git commit -m "feat(tor): command-aware SOCKS gateway dispatch + correct unsupported-command reply"
+```
+
+---
+
+### Task 2: RESOLVE (0xF0) filter-and-forward
+
+Add the RESOLVE branch: evaluate the target via the same `EvalSocksTarget`, and when allowed forward the RESOLVE to upstream Tor and relay the single reply verbatim — no splice. Reuse `upstreamHandshake`/`encodeReq`/`readSocksReply` from Task 1.
+
+**Files:**
+- Modify: `internal/netmonitor/socks.go`
+- Test: `internal/netmonitor/socks_handler_test.go`
+
+**Interfaces:**
+- Consumes (from Task 1): `readSocksRequest`, `encodeReq`, `upstreamHandshake`, `emitOnionEvent(..., socksCmd string)`, `socksCmdResolve`, `assertOnionEvent`, `driveCmd`.
+- Produces: `gatewayResolve(...)` and the `case socksCmdResolve` dispatch arm.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `internal/netmonitor/socks_handler_test.go`:
+
+```go
+// fakeTorResolveUpstream answers a forwarded RESOLVE (0xF0) with a fixed
+// resolved IPv4 address (REP success). It asserts the forwarded command is
+// RESOLVE; on any other command it closes without replying.
+func fakeTorResolveUpstream(t *testing.T, resolved net.IP) (addr string, stop func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer c.Close()
+				_ = readSocksGreeting(c)
+				_ = writeSocksMethod(c, 0x00)
+				req, err := readSocksRequest(c)
+				if err != nil || req.cmd != socksCmdResolve {
+					return
+				}
+				ip4 := resolved.To4()
+				reply := []byte{socksVer, socksRepSuccess, 0x00, atypIPv4}
+				reply = append(reply, ip4...)
+				reply = append(reply, 0, 0) // port
+				_, _ = c.Write(reply)
+			}()
+		}
+	}()
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+// driveResolve sends a SOCKS5 RESOLVE for host and returns the full 10-byte
+// IPv4-form reply (VER REP RSV ATYP ADDR PORT).
+func driveResolve(t *testing.T, conn net.Conn, host string) []byte {
+	t.Helper()
+	_, _ = conn.Write([]byte{0x05, 0x01, 0x00}) // greeting
+	method := make([]byte, 2)
+	if _, err := io.ReadFull(conn, method); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = conn.Write(encodeReq(socksReq{cmd: socksCmdResolve, atyp: atypDomain, addr: []byte(host), host: host}))
+	reply := make([]byte, 10)
+	if _, err := io.ReadFull(conn, reply); err != nil {
+		t.Fatal(err)
+	}
+	return reply
+}
+
+// TestHandleTorSocks_ResolveAllowed verifies an allowed RESOLVE is forwarded to
+// upstream Tor and its reply (resolved IP) relayed verbatim, with no splice.
+func TestHandleTorSocks_ResolveAllowed(t *testing.T) {
+	upstream, stop := fakeTorResolveUpstream(t, net.IPv4(1, 2, 3, 4))
+	defer stop()
+
+	client, server := net.Pipe()
+	emit := &torCaptureEmitter{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+	}()
+
+	reply := driveResolve(t, client, "ok.onion")
+	if reply[1] != socksRepSuccess {
+		t.Fatalf("RESOLVE reply REP = 0x%02x, want success", reply[1])
+	}
+	if reply[3] != atypIPv4 || !net.IP(reply[4:8]).Equal(net.IPv4(1, 2, 3, 4)) {
+		t.Fatalf("RESOLVE reply addr = %v (atyp 0x%02x), want 1.2.3.4/IPv4", net.IP(reply[4:8]), reply[3])
+	}
+	client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleTorSocks did not return after RESOLVE (possible spurious splice)")
+	}
+	assertOnionEvent(t, emit, "allow", "resolve")
+}
+
+// TestHandleTorSocks_ResolveDenied verifies a denied RESOLVE replies not-allowed
+// with no upstream dial.
+func TestHandleTorSocks_ResolveDenied(t *testing.T) {
+	client, server := net.Pipe()
+	emit := &torCaptureEmitter{}
+	go func() {
+		// upstreamAddr unreachable on purpose; a denied RESOLVE must not dial.
+		_ = handleTorSocks(server, "127.0.0.1:1", fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+	}()
+	reply := driveResolve(t, client, "blocked.onion")
+	if reply[1] != socksRepNotAllowed {
+		t.Fatalf("denied RESOLVE reply REP = 0x%02x, want not-allowed", reply[1])
+	}
+	client.Close()
+	assertOnionEvent(t, emit, "deny", "resolve")
+}
+
+// TestHandleTorSocks_ResolveUpstreamError verifies a non-success RESOLVE reply
+// from upstream Tor is relayed verbatim (the client sees Tor's error code) and
+// the handler returns without splicing.
+func TestHandleTorSocks_ResolveUpstreamError(t *testing.T) {
+	upstream, stop := fakeTorUpstreamWithReply(t, 0x04) // host unreachable
+	defer stop()
+
+	client, server := net.Pipe()
+	emit := &torCaptureEmitter{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+	}()
+	reply := driveResolve(t, client, "ok.onion")
+	if reply[1] != 0x04 {
+		t.Fatalf("RESOLVE reply REP = 0x%02x, want host-unreachable (0x04)", reply[1])
+	}
+	client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleTorSocks did not return after RESOLVE upstream error")
+	}
+	assertOnionEvent(t, emit, "allow", "resolve")
+}
+```
+
+Note: `fakeTorUpstreamWithReply` already reads the request via `readSocksRequest` (Task 1) and replies with the given code, so it serves the upstream-error case for RESOLVE too (it sends a 10-byte null-IPv4 reply with REP 0x04).
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/netmonitor/ -run 'TestHandleTorSocks_Resolve' -v`
+Expected: FAIL — `driveResolve` returns `not-allowed`/`command-not-supported` because RESOLVE currently falls into the `default` arm (no `gatewayResolve` yet); `TestHandleTorSocks_ResolveAllowed` fails the REP/addr assertion.
+
+- [ ] **Step 3: Add the RESOLVE dispatch arm and `gatewayResolve` in `socks.go`**
+
+In `handleTorSocks`, add the case (replacing the `// case socksCmdResolve is added in Task 2.` comment):
+
+```go
+	case socksCmdResolve:
+		return gatewayResolve(conn, upstreamAddr, pol, emit, sessionID, commandID, req)
+```
+
+Add the handler:
+
+```go
+// gatewayResolve handles a SOCKS RESOLVE (0xF0): it filters the target through
+// the same onion_rules as CONNECT and, when allowed, forwards the RESOLVE to
+// the upstream Tor daemon and relays its single reply verbatim. RESOLVE is a
+// request/reply exchange, not a tunnel — there is no splice. Emits one
+// tor_control{vector: onion, socks_cmd: resolve} event.
+func gatewayResolve(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string, req socksReq) error {
+	v, ok := pol.EvalSocksTarget(req.host, req.port)
+	if ok {
+		emitOnionEvent(emit, sessionID, commandID, v, "resolve")
+	}
+	if !ok || v.Decision != "allow" {
+		_ = writeSocksReply(conn, socksRepNotAllowed)
+		return nil
+	}
+
+	up, err := net.DialTimeout("tcp", upstreamAddr, 20*time.Second)
+	if err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	defer up.Close()
+
+	if err := upstreamHandshake(up); err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	if _, err := up.Write(encodeReq(req)); err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	reply, err := readSocksReply(up)
+	if err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	// Relay Tor's reply verbatim — success carries the resolved address, an
+	// error carries Tor's REP code. No splice: RESOLVE is request/reply.
+	_, err = conn.Write(reply)
+	return err
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/netmonitor/ -run 'TestHandleTorSocks' -v`
+Expected: PASS — all RESOLVE tests plus the Task 1 CONNECT/unsupported tests.
+
+- [ ] **Step 5: Verify build, cross-compile, and format**
+
+Run: `go build ./... && GOOS=windows go build ./... && gofmt -l internal/netmonitor/socks.go internal/netmonitor/socks_handler_test.go`
+Expected: both builds succeed; `gofmt -l` prints nothing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/netmonitor/socks.go internal/netmonitor/socks_handler_test.go
+git commit -m "feat(tor): filter-and-forward SOCKS RESOLVE through the onion gateway"
+```
+
+---
+
+### Task 3: Spec status + full gates
+
+Mark the Phase 4 spec implemented, note RESOLVE as done in the base design's tracked-future list, and run the full gate suite.
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-06-22-tor-access-control-phase4-design.md`
+- Modify: `docs/superpowers/specs/2026-06-20-tor-access-control-phase3-design.md`
+
+- [ ] **Step 1: Update the Phase 4 spec status**
+
+In `docs/superpowers/specs/2026-06-22-tor-access-control-phase4-design.md`, change the status line:
+
+```markdown
+**Status:** Implemented (PR pending)
+```
+
+- [ ] **Step 2: Mark RESOLVE done in the Phase 3 spec's future list**
+
+In `docs/superpowers/specs/2026-06-20-tor-access-control-phase3-design.md`, under "Out of scope / future", change the "Gateway SOCKS protocol completeness" bullet to record that RESOLVE is now handled:
+
+```markdown
+- **Gateway SOCKS protocol completeness** — `handleTorSocks` now filters and
+  forwards `RESOLVE` (0xF0) through `onion_rules` (Phase 4,
+  `2026-06-22-tor-access-control-phase4-design.md`); `RESOLVE_PTR` (0xF1)
+  remains deliberately unsupported (`command not supported`), tracked there.
+```
+
+- [ ] **Step 3: Run the full gate suite**
+
+Run:
+```
+go build ./...
+GOOS=windows go build ./...
+gofmt -l internal/netmonitor
+go test ./internal/netmonitor/ ./internal/tor/
+go test ./...
+```
+Expected: builds clean; `gofmt -l` empty; `internal/netmonitor` + `internal/tor` green; full suite green except the known pre-existing local-env flakes (the `internal/fsmonitor` FUSE flake and the `internal/ocsf` exhaustiveness flake that passes when run standalone — neither is a regression, and Phase 4 adds no `events.EventType`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-06-22-tor-access-control-phase4-design.md docs/superpowers/specs/2026-06-20-tor-access-control-phase3-design.md
+git commit -m "docs(tor): mark Phase 4 RESOLVE handling implemented"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- RESOLVE (0xF0) filter-and-forward via `onion_rules` → Task 2 (`gatewayResolve` + `EvalSocksTarget` + forward/relay).
+- RESOLVE_PTR (0xF1) + other commands → `command not supported` (0x07) → Task 1 (dispatch `default` arm) + test (`TestHandleTorSocks_UnsupportedCommand`).
+- No `.onion`-RESOLVE special-casing → honored (RESOLVE is forwarded uniformly; Tor's natural error is relayed by `TestHandleTorSocks_ResolveUpstreamError`'s relay-verbatim path).
+- `socks_cmd` field on `vector: onion` events (`connect`/`resolve`) → Task 1 (`emitOnionEvent` + `assertOnionEvent` on connect) + Task 2 (resolve assertions).
+- No new `events.EventType` → honored (reuses `tor.BuildControlEvent`; only a free-form `Fields` key added).
+- No new config knobs / no new data path → honored (CONNECT splices unchanged; RESOLVE is request/reply).
+- Fail-closed parity → Task 1/2 (general-failure on errors, not-allowed on deny) + `TestHandleTorSocks_ResolveDenied`.
+- Cross-compile clean → Steps build `GOOS=windows` in every task.
+- Reply-verbatim incl. errors → `TestHandleTorSocks_ResolveUpstreamError`.
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code; the only inline comment marker (`// case socksCmdResolve is added in Task 2.`) is replaced by real code in Task 2 Step 3.
+
+**Type consistency:** `socksReq.cmd byte` is set by `readSocksRequest` and read by `handleTorSocks`/`encodeReq` (all Task 1). `emitOnionEvent(..., socksCmd string)` defined in Task 1, called with `"connect"` (Task 1) and `"resolve"` (Task 2). `upstreamHandshake`, `encodeReq`, `readSocksReply` defined/reused consistently. `assertOnionEvent(t, emit, wantDecision, wantCmd)` and `driveCmd`/`driveResolve` signatures match their call sites. Constants `socksCmdResolve`/`socksRepCmdNotSupported` defined in Task 1, used in both tasks.

--- a/docs/superpowers/specs/2026-06-20-tor-access-control-phase3-design.md
+++ b/docs/superpowers/specs/2026-06-20-tor-access-control-phase3-design.md
@@ -246,10 +246,10 @@ unit-testable without root; netns/iptables end-to-end is gated integration.
 
 These remain candidates for later, independent of this gap:
 
-- **Gateway SOCKS protocol completeness** — `handleTorSocks` accepts only SOCKS
-  `CONNECT` (0x01); Tor's `RESOLVE` (0xF0) / `RESOLVE_PTR` (0xF1) extensions are
-  rejected as "unsupported command." Apps resolving `.onion` names over SOCKS
-  break or route around policy.
+- **Gateway SOCKS protocol completeness** — `handleTorSocks` now filters and
+  forwards `RESOLVE` (0xF0) through `onion_rules` (Phase 4,
+  `2026-06-22-tor-access-control-phase4-design.md`); `RESOLVE_PTR` (0xF1)
+  remains deliberately unsupported (`command not supported`), tracked there.
 - **Stream isolation / SOCKS-auth pass-through** — the gateway forces upstream
   no-auth; operators relying on per-stream isolation via SOCKS
   username/password (`IsolateSOCKSAuth`) cannot use it through the gateway.

--- a/docs/superpowers/specs/2026-06-22-tor-access-control-phase4-design.md
+++ b/docs/superpowers/specs/2026-06-22-tor-access-control-phase4-design.md
@@ -1,0 +1,217 @@
+# Tor Access Control — Phase 4 Design (SOCKS RESOLVE in the onion gateway)
+
+**Status:** Draft — proposed
+
+**Builds on:** [Tor Access Control — Design](2026-06-14-tor-access-control-design.md) (Phase 1 deny/audit, PR #424; Phase 2 onion gateway, PR #428) and [Phase 3 — fail-open gap closed](2026-06-20-tor-access-control-phase3-design.md) (PR #429).
+
+## Summary
+
+The Phase 2 onion gateway terminates the client's SOCKS5 handshake and filters
+per-`.onion` — but `handleTorSocks` accepts only the `CONNECT` command (0x01);
+every other command is rejected as "unsupported command." After Phase 3
+force-redirects **all** `socks_ports` traffic into the gateway, a Tor-aware
+client that issues a SOCKS `RESOLVE` (0xF0) — the standard Tor extension for
+resolving a hostname *through* Tor without leaking DNS to the local resolver —
+is now redirected into the gateway and rejected. The result is fail-closed
+(nothing leaks) but breaks allow-mode usability: an app permitted to reach
+`foo.onion` cannot resolve names over Tor at all.
+
+Phase 4 closes that usability gap by making the gateway **command-aware**:
+`RESOLVE` (0xF0) is filtered through the same `onion_rules` as `CONNECT` and,
+when allowed, forwarded to the real Tor SOCKS daemon and its single reply
+relayed back. `RESOLVE_PTR` (0xF1) and all other non-`CONNECT` commands are
+**deliberately** rejected with the correct SOCKS error code.
+
+Phase 4 adds **no new data path**, **no new event type**, and **no new config
+knobs**.
+
+## Motivation
+
+`RESOLVE` is how Tor-aware tooling avoids a DNS leak: instead of resolving a
+hostname with the system resolver (plaintext, off-Tor) and then connecting to
+the resulting IP, the client asks Tor to resolve the name inside the circuit.
+Before Phase 3 a loopback Tor daemon outside agentsh's interception answered
+these directly; after Phase 3 they are force-redirected into the gateway, where
+the CONNECT-only parser rejects them. For a control whose allow-mode purpose is
+"permit specific onions, deny the rest," refusing the very resolution step a
+permitted client needs is an avoidable rough edge.
+
+Root cause, concretely: `internal/netmonitor/socks.go` —
+
+```go
+if head[1] != socksCmdConnect {
+    return socksReq{}, fmt.Errorf("socks: unsupported command 0x%02x", head[1])
+}
+```
+
+The request wire format of `RESOLVE` is identical to `CONNECT`
+(`VER CMD RSV ATYP ADDR PORT`), and the existing `readSocksReply` already
+parses every reply address type — so the gap is narrow and the fix is local.
+
+## Scope decisions (locked)
+
+- **`RESOLVE` (0xF0): filter-and-forward.** Evaluated through the existing
+  `onion_rules` exactly like `CONNECT`; allowed → forwarded to upstream Tor and
+  the single reply relayed; denied/unmatched → fail-closed (`not allowed`).
+- **`RESOLVE_PTR` (0xF1): deliberately unsupported.** Its target is an IP
+  (reverse DNS), which `onion_rules` (`.onion`/host globs matched with
+  `filepath.Match`) cannot naturally express; agent tooling essentially never
+  uses reverse-DNS-over-Tor. Rejected with SOCKS `command not supported`
+  (0x07). Leaving it rejected is already fail-closed-safe (nothing leaks). A
+  future phase can add it if a real need appears.
+- **No `.onion`-RESOLVE special-casing.** Resolving a `.onion` to an IP is
+  meaningless (onions have no IP); real Tor returns its own error. An allowed
+  `.onion` RESOLVE is simply forwarded and Tor's error reply relayed — honest,
+  zero extra code.
+- **No new config knobs.** Behavior derives entirely from the existing
+  `onion_rules` / `socks_ports`. Gateway activation is unchanged
+  (`GatewayActive()` = mode==allow && len(onion_rules)>0).
+
+## Architecture: one command-aware path
+
+Phase 4 generalizes the existing `handleTorSocks` rather than adding a parallel
+handler (which would duplicate the greeting, target evaluation, and upstream
+handshake for no benefit). After the greeting and no-auth method selection, the
+request is read by a command-aware parser and dispatched on the command byte:
+
+```
+greeting → no-auth → readSocksRequest → switch cmd:
+    CONNECT (0x01)     → eval → forward → relay reply → splice   (tunnel; unchanged)
+    RESOLVE (0xF0)     → eval → forward → relay reply → close    (request/reply; new)
+    RESOLVE_PTR (0xF1) → reply command-not-supported (0x07); close
+    other              → reply command-not-supported (0x07); close
+```
+
+No change to `transparent_tcp.go`, the force-redirect, or the SOCKS5 *data*
+path for CONNECT. The command byte is only known after the SOCKS request is
+read inside the gateway, so dispatch necessarily lives here, not in the
+transparent-TCP layer.
+
+## Request parsing generalization
+
+`internal/netmonitor/socks.go`:
+
+- `socksReq` gains a `cmd byte` field carrying the request command.
+- `readSocksConnect` becomes `readSocksRequest`: it reads `cmd = head[1]` and
+  accepts `0x01` (CONNECT) and `0xF0` (RESOLVE). For `0xF1` it returns a typed
+  sentinel error (`errResolvePtrUnsupported`) so the handler can map it to the
+  `command not supported` reply; for any other command it returns the existing
+  "unsupported command" error, which the handler also maps to `0x07`. Address
+  parsing (`atypIPv4`/`atypIPv6`/`atypDomain`) is unchanged and shared.
+- `encodeConnectReq` becomes `encodeReq`: it emits `req.cmd` rather than a
+  hardcoded `socksCmdConnect`, so the forwarded request carries CONNECT or
+  RESOLVE faithfully.
+- New constants: `socksCmdResolve = 0xF0`, `socksCmdResolvePtr = 0xF1`,
+  `socksRepCmdNotSupported = 0x07`.
+
+`EvalSocksTarget(host, port)` is **port-agnostic** — it matches host globs and
+uses the port only to build the `Target` string — so a RESOLVE request (which
+typically carries port 0) is evaluated correctly with no rule-semantics change.
+
+## RESOLVE forwarding and reply
+
+For an **allowed** RESOLVE, the handler reuses the existing upstream
+SOCKS-client handshake unchanged: greeting (one method, no-auth), read and
+validate the method-selection reply (must be no-auth), then
+`up.Write(encodeReq(req))` with `cmd == 0xF0`. It then reads exactly one reply
+with the existing `readSocksReply` (which already parses `atypIPv4`/`IPv6`/
+`atypDomain` reply addresses — Tor's RESOLVE answer is the resolved IP, or an
+error reply such as host-unreachable) and relays it verbatim to the client.
+The reply is relayed **whatever its REP code**, so the client receives Tor's
+real result, including errors. Then the connection closes — there is **no
+`splice`**: RESOLVE is a single request/reply, not a tunnel.
+
+For a **denied/unmatched** RESOLVE the handler replies `not allowed` (0x02) and
+emits the deny event, exactly as CONNECT does — no upstream connection is made.
+
+## RESOLVE_PTR and other unsupported commands
+
+`RESOLVE_PTR` (0xF1) and any non-CONNECT/non-RESOLVE command are answered with
+SOCKS `command not supported` (0x07) and the connection closed. This corrects a
+latent inaccuracy: today such commands fall through `readSocksConnect`'s generic
+error and the client receives `general failure` (0x01), a misleading code. No
+`tor_control` event is emitted for these — no `onion_rules` decision was made
+(consistent with the existing "no verdict → emit nothing" path). The startup
+posture and `onion_rules` are unaffected.
+
+## Events / observability
+
+Reuse the existing `tor_control` event (`Type: "tor_control"`, free-form
+`Fields map[string]any`). **No new `events.EventType`** → the OCSF registry is
+untouched, consistent with Phase 2 (`vector: onion`) and Phase 3
+(`vector: gateway`).
+
+- **New free-form `socks_cmd` key** in `Fields`, value `"resolve"` for a
+  RESOLVE decision and `"connect"` for a CONNECT decision. The per-CONNECT
+  events gain `socks_cmd: "connect"` for symmetry; this is the only change to
+  existing CONNECT event records.
+- The command string is threaded into the onion event's `Fields` (carried on
+  the `tor.Verdict` or passed to the event builder — an implementation detail;
+  the contract is that `Fields["socks_cmd"]` is present).
+- **Emit exactly one `vector: onion` event per evaluated request** (CONNECT or
+  RESOLVE), `decision: allow|deny`, `target: host:port`, `pid: 0` (same
+  correlation-by-session-and-target limitation as the other connection-layer
+  vectors).
+- RESOLVE_PTR / unsupported commands emit **no** event.
+
+## Configuration
+
+**No new config knobs.** RESOLVE filtering is automatic whenever the gateway is
+active (`mode: allow` + `onion_rules`); it uses the same rules and the same
+`socks_ports`. There is nothing new to opt into or out of.
+
+## Testing
+
+Security and protocol invariants are unit-testable without root (the gateway
+runs over in-memory/loopback connections), reusing the existing
+`fakeTorUpstream*` / `driveClient` helpers in `socks_handler_test.go`.
+
+1. **Request parsing** (`readSocksRequest`): parses a CONNECT and a RESOLVE
+   request identically except for `cmd`; returns the typed sentinel for
+   `RESOLVE_PTR` (0xF1); returns the unsupported-command error for an arbitrary
+   other command (e.g. BIND 0x02).
+2. **RESOLVE allowed**: target matches an allow rule → the gateway performs the
+   upstream handshake, forwards a RESOLVE (cmd 0xF0) to a fake Tor upstream that
+   answers with a resolved-IP reply, and relays that reply verbatim to the
+   client; assert the connection is **not** spliced (no tunnel) and one
+   `tor_control{vector: onion, socks_cmd: "resolve", decision: allow}` event is
+   emitted.
+3. **RESOLVE denied**: target matches no rule (or a deny rule) → client receives
+   `not allowed` (0x02), no upstream dial, one deny event with
+   `socks_cmd: "resolve"`.
+4. **RESOLVE_PTR**: client sends 0xF1 → receives `command not supported`
+   (0x07); no upstream dial; no event emitted.
+5. **CONNECT regression**: an allowed CONNECT still tunnels (splices) and now
+   carries `socks_cmd: "connect"` in its event; a denied CONNECT still replies
+   `not allowed`.
+6. **Fail-closed parity**: upstream dial failure on an allowed RESOLVE →
+   `general failure` (0x01); a malformed request → `general failure`.
+7. **RESOLVE error relay**: a fake upstream that returns a non-success RESOLVE
+   reply (e.g. host-unreachable) has that reply relayed verbatim to the client
+   (the client sees Tor's real error, and the stream is not spliced).
+
+## Non-Goals
+
+- **`RESOLVE_PTR` (0xF1) support.** Reverse-DNS-over-Tor targets an IP that
+  `onion_rules` cannot naturally express, and agent tooling does not use it.
+  Deliberately rejected with `command not supported`; a cheap follow-up if a
+  real need appears.
+- **UDP `ASSOCIATE` (0x03) and `BIND` (0x02).** Tor's SOCKS does not provide
+  general UDP, and BIND is unused by the agent threat model. Rejected with
+  `command not supported`.
+- **New config surface, new event type, new data path.** All derive from the
+  existing `onion_rules` / `socks_ports` and the existing `tor_control` event.
+- **PID/command attribution for the onion events.** Still `pid: 0`,
+  correlated by session and target — unchanged from Phase 2, tracked
+  separately.
+
+## Out of scope / future (tracked, not built here)
+
+Carried forward from Phase 3, independent of this gap:
+
+- **`RESOLVE_PTR` support** (above) — if a concrete consumer appears.
+- **Stream isolation / SOCKS-auth pass-through** — the gateway forces upstream
+  no-auth; operators relying on per-stream isolation via SOCKS
+  username/password (`IsolateSOCKSAuth`) cannot use it through the gateway.
+- **PID/command attribution for `onion_dns` / `onion_http` events** — those
+  layers report `target` only.

--- a/docs/superpowers/specs/2026-06-22-tor-access-control-phase4-design.md
+++ b/docs/superpowers/specs/2026-06-22-tor-access-control-phase4-design.md
@@ -1,6 +1,6 @@
 # Tor Access Control — Phase 4 Design (SOCKS RESOLVE in the onion gateway)
 
-**Status:** Draft — proposed
+**Status:** Implemented (PR pending)
 
 **Builds on:** [Tor Access Control — Design](2026-06-14-tor-access-control-design.md) (Phase 1 deny/audit, PR #424; Phase 2 onion gateway, PR #428) and [Phase 3 — fail-open gap closed](2026-06-20-tor-access-control-phase3-design.md) (PR #429).
 

--- a/internal/netmonitor/socks.go
+++ b/internal/netmonitor/socks.go
@@ -11,13 +11,16 @@ import (
 	"github.com/agentsh/agentsh/internal/tor"
 )
 
-// SOCKS5 reply codes (RFC 1928).
+// SOCKS5 reply / command codes (RFC 1928) and Tor's RESOLVE extension.
 const (
-	socksVer               = 0x05
-	socksCmdConnect        = 0x01
-	socksRepSuccess        = 0x00
-	socksRepGeneralFailure = 0x01
-	socksRepNotAllowed     = 0x02 // connection not allowed by ruleset
+	socksVer                = 0x05
+	socksCmdConnect         = 0x01
+	socksCmdResolve         = 0xF0 // Tor RESOLVE extension
+	socksCmdResolvePtr      = 0xF1 // Tor RESOLVE_PTR extension (deliberately unsupported)
+	socksRepSuccess         = 0x00
+	socksRepGeneralFailure  = 0x01
+	socksRepNotAllowed      = 0x02 // connection not allowed by ruleset
+	socksRepCmdNotSupported = 0x07 // command not supported
 
 	atypIPv4   = 0x01
 	atypDomain = 0x03
@@ -50,14 +53,17 @@ func writeSocksMethod(w io.Writer, method byte) error {
 }
 
 type socksReq struct {
+	cmd  byte
 	atyp byte
 	addr []byte // raw address bytes (domain text, or 4/16-byte IP)
 	host string
 	port int
 }
 
-// readSocksConnect reads a CONNECT request: VER CMD RSV ATYP ADDR PORT.
-func readSocksConnect(r io.Reader) (socksReq, error) {
+// readSocksRequest reads a SOCKS5 request: VER CMD RSV ATYP ADDR PORT. The
+// command byte is captured verbatim into req.cmd; the caller dispatches on it
+// (CONNECT and RESOLVE are handled, others get command-not-supported).
+func readSocksRequest(r io.Reader) (socksReq, error) {
 	head := make([]byte, 4)
 	if _, err := io.ReadFull(r, head); err != nil {
 		return socksReq{}, err
@@ -65,10 +71,8 @@ func readSocksConnect(r io.Reader) (socksReq, error) {
 	if head[0] != socksVer {
 		return socksReq{}, fmt.Errorf("socks: bad version 0x%02x", head[0])
 	}
-	if head[1] != socksCmdConnect {
-		return socksReq{}, fmt.Errorf("socks: unsupported command 0x%02x", head[1])
-	}
 	var req socksReq
+	req.cmd = head[1]
 	req.atyp = head[3]
 	switch req.atyp {
 	case atypIPv4:
@@ -104,9 +108,10 @@ func readSocksConnect(r io.Reader) (socksReq, error) {
 	return req, nil
 }
 
-// encodeConnectReq re-serializes a CONNECT request for the upstream Tor SOCKS.
-func encodeConnectReq(req socksReq) []byte {
-	out := []byte{socksVer, socksCmdConnect, 0x00, req.atyp}
+// encodeReq re-serializes req (preserving its command byte) for the upstream
+// Tor SOCKS daemon.
+func encodeReq(req socksReq) []byte {
+	out := []byte{socksVer, req.cmd, 0x00, req.atyp}
 	if req.atyp == atypDomain {
 		out = append(out, byte(len(req.addr)))
 	}
@@ -128,10 +133,10 @@ type TorGatewayPolicy interface {
 	EvalSocksTarget(host string, port int) (tor.Verdict, bool)
 }
 
-// handleTorSocks terminates a client SOCKS5 CONNECT, evaluates the target
-// against the onion gateway policy, and either proxies the stream to the
-// real Tor SOCKS daemon at upstreamAddr or replies "not allowed by ruleset".
-// Fail-closed on any error. Emits one tor_control{vector:onion} event.
+// handleTorSocks terminates a client SOCKS5 handshake, reads the request, and
+// dispatches on the command: CONNECT tunnels through the onion gateway,
+// RESOLVE is filtered-and-forwarded, and every other command is rejected with
+// command-not-supported. Fail-closed on any error.
 func handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string) error {
 	defer conn.Close()
 
@@ -141,19 +146,34 @@ func handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, em
 	if err := writeSocksMethod(conn, 0x00); err != nil { // no-auth
 		return err
 	}
-	req, err := readSocksConnect(conn)
+	req, err := readSocksRequest(conn)
 	if err != nil {
 		_ = writeSocksReply(conn, socksRepGeneralFailure)
 		return err
 	}
 
+	switch req.cmd {
+	case socksCmdConnect:
+		return gatewayConnect(conn, upstreamAddr, pol, emit, sessionID, commandID, req)
+	// case socksCmdResolve is added in Task 2.
+	default:
+		// RESOLVE_PTR (0xF1), BIND, UDP ASSOCIATE, etc. — deliberately
+		// unsupported. Reply the correct SOCKS code and close; no event,
+		// since no onion_rules decision was made.
+		_ = writeSocksReply(conn, socksRepCmdNotSupported)
+		return nil
+	}
+}
+
+// gatewayConnect handles a SOCKS CONNECT: evaluate the target against the onion
+// gateway policy, and either proxy the stream to the real Tor SOCKS daemon or
+// reply not-allowed. Fail-closed on any error. Emits one tor_control{vector:
+// onion, socks_cmd: connect} event.
+func gatewayConnect(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string, req socksReq) error {
 	v, ok := pol.EvalSocksTarget(req.host, req.port)
 	if ok {
-		emitOnionEvent(emit, sessionID, commandID, v)
+		emitOnionEvent(emit, sessionID, commandID, v, "connect")
 	}
-	// Callers invoke handleTorSocks only when GatewayActive() is true.
-	// ok=false means the policy returned no verdict; treat as fail-closed
-	// (reply not-allowed, emit no event — there is no decision to report).
 	if !ok || v.Decision != "allow" {
 		_ = writeSocksReply(conn, socksRepNotAllowed)
 		return nil
@@ -166,21 +186,11 @@ func handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, em
 	}
 	defer up.Close()
 
-	// Act as a SOCKS5 client to the real Tor daemon for the same target.
-	if _, err := up.Write([]byte{socksVer, 0x01, 0x00}); err != nil { // greeting: 1 method, no-auth
+	if err := upstreamHandshake(up); err != nil {
 		_ = writeSocksReply(conn, socksRepGeneralFailure)
 		return err
 	}
-	methodReply := make([]byte, 2)
-	if _, err := io.ReadFull(up, methodReply); err != nil { // method selection
-		_ = writeSocksReply(conn, socksRepGeneralFailure)
-		return err
-	}
-	if methodReply[0] != socksVer || methodReply[1] != 0x00 { // upstream must accept no-auth
-		_ = writeSocksReply(conn, socksRepGeneralFailure)
-		return fmt.Errorf("socks: upstream selected auth method 0x%02x (want no-auth)", methodReply[1])
-	}
-	if _, err := up.Write(encodeConnectReq(req)); err != nil {
+	if _, err := up.Write(encodeReq(req)); err != nil {
 		_ = writeSocksReply(conn, socksRepGeneralFailure)
 		return err
 	}
@@ -193,14 +203,28 @@ func handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, em
 	if _, err := conn.Write(upReply); err != nil {
 		return err
 	}
-
-	// Only enter bidirectional proxy when the upstream accepted the connection.
-	// A non-success reply means Tor refused it; do not splice a refused stream.
+	// Only tunnel when the upstream accepted the connection.
 	if len(upReply) < 2 || upReply[1] != socksRepSuccess {
 		return nil
 	}
-
 	splice(conn, up)
+	return nil
+}
+
+// upstreamHandshake performs the SOCKS5 no-auth client handshake with the real
+// Tor daemon (greeting with one method, no-auth, then method-selection reply
+// validation). Returns an error if the upstream does not accept no-auth.
+func upstreamHandshake(up net.Conn) error {
+	if _, err := up.Write([]byte{socksVer, 0x01, 0x00}); err != nil { // greeting: 1 method, no-auth
+		return err
+	}
+	methodReply := make([]byte, 2)
+	if _, err := io.ReadFull(up, methodReply); err != nil {
+		return err
+	}
+	if methodReply[0] != socksVer || methodReply[1] != 0x00 {
+		return fmt.Errorf("socks: upstream selected auth method 0x%02x (want no-auth)", methodReply[1])
+	}
 	return nil
 }
 
@@ -268,11 +292,12 @@ func halfCloseWrite(c net.Conn) {
 	_ = c.Close()
 }
 
-func emitOnionEvent(emit Emitter, sessionID, commandID string, v tor.Verdict) {
+func emitOnionEvent(emit Emitter, sessionID, commandID string, v tor.Verdict, socksCmd string) {
 	if emit == nil {
 		return
 	}
 	ev := tor.BuildControlEvent(sessionID, commandID, 0, v)
+	ev.Fields["socks_cmd"] = socksCmd
 	_ = emit.AppendEvent(context.Background(), ev)
 	emit.Publish(ev)
 }

--- a/internal/netmonitor/socks.go
+++ b/internal/netmonitor/socks.go
@@ -155,7 +155,8 @@ func handleTorSocks(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, em
 	switch req.cmd {
 	case socksCmdConnect:
 		return gatewayConnect(conn, upstreamAddr, pol, emit, sessionID, commandID, req)
-	// case socksCmdResolve is added in Task 2.
+	case socksCmdResolve:
+		return gatewayResolve(conn, upstreamAddr, pol, emit, sessionID, commandID, req)
 	default:
 		// RESOLVE_PTR (0xF1), BIND, UDP ASSOCIATE, etc. — deliberately
 		// unsupported. Reply the correct SOCKS code and close; no event,
@@ -290,6 +291,47 @@ func halfCloseWrite(c net.Conn) {
 		return
 	}
 	_ = c.Close()
+}
+
+// gatewayResolve handles a SOCKS RESOLVE (0xF0): it filters the target through
+// the same onion_rules as CONNECT and, when allowed, forwards the RESOLVE to
+// the upstream Tor daemon and relays its single reply verbatim. RESOLVE is a
+// request/reply exchange, not a tunnel — there is no splice. Emits one
+// tor_control{vector: onion, socks_cmd: resolve} event.
+func gatewayResolve(conn net.Conn, upstreamAddr string, pol TorGatewayPolicy, emit Emitter, sessionID, commandID string, req socksReq) error {
+	v, ok := pol.EvalSocksTarget(req.host, req.port)
+	if ok {
+		emitOnionEvent(emit, sessionID, commandID, v, "resolve")
+	}
+	if !ok || v.Decision != "allow" {
+		_ = writeSocksReply(conn, socksRepNotAllowed)
+		return nil
+	}
+
+	up, err := net.DialTimeout("tcp", upstreamAddr, 20*time.Second)
+	if err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	defer up.Close()
+
+	if err := upstreamHandshake(up); err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	if _, err := up.Write(encodeReq(req)); err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	reply, err := readSocksReply(up)
+	if err != nil {
+		_ = writeSocksReply(conn, socksRepGeneralFailure)
+		return err
+	}
+	// Relay Tor's reply verbatim — success carries the resolved address, an
+	// error carries Tor's REP code. No splice: RESOLVE is request/reply.
+	_, err = conn.Write(reply)
+	return err
 }
 
 func emitOnionEvent(emit Emitter, sessionID, commandID string, v tor.Verdict, socksCmd string) {

--- a/internal/netmonitor/socks_handler_test.go
+++ b/internal/netmonitor/socks_handler_test.go
@@ -410,3 +410,128 @@ func TestSplice_HalfClose(t *testing.T) {
 	listenConn.Close()
 	listenConn2.Close()
 }
+
+// fakeTorResolveUpstream answers a forwarded RESOLVE (0xF0) with a fixed
+// resolved IPv4 address (REP success). It asserts the forwarded command is
+// RESOLVE; on any other command it closes without replying.
+func fakeTorResolveUpstream(t *testing.T, resolved net.IP) (addr string, stop func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer c.Close()
+				_ = readSocksGreeting(c)
+				_ = writeSocksMethod(c, 0x00)
+				req, err := readSocksRequest(c)
+				if err != nil || req.cmd != socksCmdResolve {
+					return
+				}
+				ip4 := resolved.To4()
+				reply := []byte{socksVer, socksRepSuccess, 0x00, atypIPv4}
+				reply = append(reply, ip4...)
+				reply = append(reply, 0, 0) // port
+				_, _ = c.Write(reply)
+			}()
+		}
+	}()
+	return ln.Addr().String(), func() { _ = ln.Close() }
+}
+
+// driveResolve sends a SOCKS5 RESOLVE for host and returns the full 10-byte
+// IPv4-form reply (VER REP RSV ATYP ADDR PORT).
+func driveResolve(t *testing.T, conn net.Conn, host string) []byte {
+	t.Helper()
+	_, _ = conn.Write([]byte{0x05, 0x01, 0x00}) // greeting
+	method := make([]byte, 2)
+	if _, err := io.ReadFull(conn, method); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = conn.Write(encodeReq(socksReq{cmd: socksCmdResolve, atyp: atypDomain, addr: []byte(host), host: host}))
+	reply := make([]byte, 10)
+	if _, err := io.ReadFull(conn, reply); err != nil {
+		t.Fatal(err)
+	}
+	return reply
+}
+
+// TestHandleTorSocks_ResolveAllowed verifies an allowed RESOLVE is forwarded to
+// upstream Tor and its reply (resolved IP) relayed verbatim, with no splice.
+func TestHandleTorSocks_ResolveAllowed(t *testing.T) {
+	upstream, stop := fakeTorResolveUpstream(t, net.IPv4(1, 2, 3, 4))
+	defer stop()
+
+	client, server := net.Pipe()
+	emit := &torCaptureEmitter{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+	}()
+
+	reply := driveResolve(t, client, "ok.onion")
+	if reply[1] != socksRepSuccess {
+		t.Fatalf("RESOLVE reply REP = 0x%02x, want success", reply[1])
+	}
+	if reply[3] != atypIPv4 || !net.IP(reply[4:8]).Equal(net.IPv4(1, 2, 3, 4)) {
+		t.Fatalf("RESOLVE reply addr = %v (atyp 0x%02x), want 1.2.3.4/IPv4", net.IP(reply[4:8]), reply[3])
+	}
+	client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleTorSocks did not return after RESOLVE (possible spurious splice)")
+	}
+	assertOnionEvent(t, emit, "allow", "resolve")
+}
+
+// TestHandleTorSocks_ResolveDenied verifies a denied RESOLVE replies not-allowed
+// with no upstream dial.
+func TestHandleTorSocks_ResolveDenied(t *testing.T) {
+	client, server := net.Pipe()
+	emit := &torCaptureEmitter{}
+	go func() {
+		// upstreamAddr unreachable on purpose; a denied RESOLVE must not dial.
+		_ = handleTorSocks(server, "127.0.0.1:1", fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+	}()
+	reply := driveResolve(t, client, "blocked.onion")
+	if reply[1] != socksRepNotAllowed {
+		t.Fatalf("denied RESOLVE reply REP = 0x%02x, want not-allowed", reply[1])
+	}
+	client.Close()
+	assertOnionEvent(t, emit, "deny", "resolve")
+}
+
+// TestHandleTorSocks_ResolveUpstreamError verifies a non-success RESOLVE reply
+// from upstream Tor is relayed verbatim (the client sees Tor's error code) and
+// the handler returns without splicing.
+func TestHandleTorSocks_ResolveUpstreamError(t *testing.T) {
+	upstream, stop := fakeTorUpstreamWithReply(t, 0x04) // host unreachable
+	defer stop()
+
+	client, server := net.Pipe()
+	emit := &torCaptureEmitter{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = handleTorSocks(server, upstream, fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+	}()
+	reply := driveResolve(t, client, "ok.onion")
+	if reply[1] != 0x04 {
+		t.Fatalf("RESOLVE reply REP = 0x%02x, want host-unreachable (0x04)", reply[1])
+	}
+	client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleTorSocks did not return after RESOLVE upstream error")
+	}
+	assertOnionEvent(t, emit, "allow", "resolve")
+}

--- a/internal/netmonitor/socks_handler_test.go
+++ b/internal/netmonitor/socks_handler_test.go
@@ -68,7 +68,7 @@ func fakeTorUpstreamWithReply(t *testing.T, rep byte) (addr string, stop func())
 				defer c.Close()
 				_ = readSocksGreeting(c)
 				_ = writeSocksMethod(c, 0x00)
-				if _, err := readSocksConnect(c); err != nil {
+				if _, err := readSocksRequest(c); err != nil {
 					return
 				}
 				_ = writeSocksReply(c, rep)
@@ -81,6 +81,46 @@ func fakeTorUpstreamWithReply(t *testing.T, rep byte) (addr string, stop func())
 	return ln.Addr().String(), func() { _ = ln.Close() }
 }
 
+// assertOnionEvent waits for one tor_control{vector:onion} event and asserts
+// both its decision and its socks_cmd field.
+func assertOnionEvent(t *testing.T, emit *torCaptureEmitter, wantDecision, wantCmd string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, ev := range emit.events() {
+			if ev.Type == "tor_control" && ev.Fields["vector"] == tor.VectorOnion {
+				if ev.Fields["decision"] != wantDecision {
+					t.Fatalf("event decision = %v, want %v", ev.Fields["decision"], wantDecision)
+				}
+				if ev.Fields["socks_cmd"] != wantCmd {
+					t.Fatalf("event socks_cmd = %v, want %v", ev.Fields["socks_cmd"], wantCmd)
+				}
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("no tor_control{vector:onion,decision:%s,socks_cmd:%s} event seen", wantDecision, wantCmd)
+}
+
+// driveCmd sends a SOCKS5 request with an explicit command byte and returns the
+// reply's REP code (reply is the fixed 10-byte IPv4-form reply for the cases
+// exercised here).
+func driveCmd(t *testing.T, conn net.Conn, cmd byte, host string, port int) byte {
+	t.Helper()
+	_, _ = conn.Write([]byte{0x05, 0x01, 0x00}) // greeting
+	method := make([]byte, 2)
+	if _, err := io.ReadFull(conn, method); err != nil {
+		t.Fatal(err)
+	}
+	_, _ = conn.Write(encodeReq(socksReq{cmd: cmd, atyp: atypDomain, addr: []byte(host), host: host, port: port}))
+	reply := make([]byte, 10)
+	if _, err := io.ReadFull(conn, reply); err != nil {
+		t.Fatal(err)
+	}
+	return reply[1]
+}
+
 // driveClient runs a SOCKS5 client handshake for host:port over conn and returns the reply code.
 func driveClient(t *testing.T, conn net.Conn, host string, port int) byte {
 	t.Helper()
@@ -89,7 +129,7 @@ func driveClient(t *testing.T, conn net.Conn, host string, port int) byte {
 	if _, err := io.ReadFull(conn, method); err != nil {
 		t.Fatal(err)
 	}
-	_, _ = conn.Write(encodeConnectReq(socksReq{atyp: atypDomain, addr: []byte(host), host: host, port: port}))
+	_, _ = conn.Write(encodeReq(socksReq{cmd: socksCmdConnect, atyp: atypDomain, addr: []byte(host), host: host, port: port}))
 	reply := make([]byte, 10)
 	if _, err := io.ReadFull(conn, reply); err != nil {
 		t.Fatal(err)
@@ -123,7 +163,7 @@ func TestHandleTorSocks_Allowed(t *testing.T) {
 	}
 	client.Close()
 
-	assertOneOnionEvent(t, emit, "allow")
+	assertOnionEvent(t, emit, "allow", "connect")
 }
 
 func TestHandleTorSocks_Denied(t *testing.T) {
@@ -141,24 +181,7 @@ func TestHandleTorSocks_Denied(t *testing.T) {
 		t.Fatalf("denied target got reply 0x%02x, want not-allowed", rep)
 	}
 	client.Close()
-	assertOneOnionEvent(t, emit, "deny")
-}
-
-func assertOneOnionEvent(t *testing.T, emit *torCaptureEmitter, wantDecision string) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		for _, ev := range emit.events() {
-			if ev.Type == "tor_control" && ev.Fields["vector"] == tor.VectorOnion {
-				if ev.Fields["decision"] != wantDecision {
-					t.Fatalf("event decision = %v, want %v", ev.Fields["decision"], wantDecision)
-				}
-				return
-			}
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	t.Fatalf("no tor_control{vector:onion,decision:%s} event seen", wantDecision)
+	assertOnionEvent(t, emit, "deny", "connect")
 }
 
 // TestHandleTorSocks_UpstreamRefuses verifies that when the upstream Tor daemon
@@ -194,7 +217,7 @@ func TestHandleTorSocks_UpstreamRefuses(t *testing.T) {
 	}
 
 	// The allow event should still have been emitted for the allowed target.
-	assertOneOnionEvent(t, emit, "allow")
+	assertOnionEvent(t, emit, "allow", "connect")
 }
 
 // fakeTorUpstreamRequiresAuth is a fake upstream that rejects the method
@@ -256,7 +279,34 @@ func TestHandleTorSocks_UpstreamRequiresAuth(t *testing.T) {
 
 	// Policy is evaluated (and the onion event emitted) before the upstream
 	// auth failure, so an allow event is still recorded.
-	assertOneOnionEvent(t, emit, "allow")
+	assertOnionEvent(t, emit, "allow", "connect")
+}
+
+// TestHandleTorSocks_UnsupportedCommand verifies a non-CONNECT/non-RESOLVE
+// command (here BIND 0x02) gets command-not-supported (0x07), no upstream dial,
+// and emits no event.
+func TestHandleTorSocks_UnsupportedCommand(t *testing.T) {
+	client, server := net.Pipe()
+	emit := &torCaptureEmitter{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// upstreamAddr is unreachable on purpose; it must never be dialed.
+		_ = handleTorSocks(server, "127.0.0.1:1", fakeGatewayPolicy{allow: "ok.onion"}, emit, "session-1", "cmd-1")
+	}()
+	rep := driveCmd(t, client, 0x02 /* BIND */, "ok.onion", 443)
+	if rep != socksRepCmdNotSupported {
+		t.Fatalf("BIND got reply 0x%02x, want command-not-supported (0x%02x)", rep, socksRepCmdNotSupported)
+	}
+	client.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleTorSocks did not return for unsupported command")
+	}
+	if len(emit.events()) != 0 {
+		t.Fatalf("unsupported command emitted %d events, want 0", len(emit.events()))
+	}
 }
 
 // TestSplice_HalfClose verifies that splice returns the correct byte counts and

--- a/internal/netmonitor/socks_test.go
+++ b/internal/netmonitor/socks_test.go
@@ -5,49 +5,53 @@ import (
 	"testing"
 )
 
-func TestReadSocksConnect_Domain(t *testing.T) {
+func TestReadSocksRequest_Domain(t *testing.T) {
 	// VER CMD RSV ATYP LEN "ab.onion" PORT(443)
 	host := "ab.onion"
 	buf := []byte{0x05, 0x01, 0x00, 0x03, byte(len(host))}
 	buf = append(buf, []byte(host)...)
 	buf = append(buf, 0x01, 0xBB) // 443
-	req, err := readSocksConnect(bytes.NewReader(buf))
+	req, err := readSocksRequest(bytes.NewReader(buf))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if req.host != "ab.onion" || req.port != 443 || req.atyp != 0x03 {
-		t.Fatalf("got host=%q port=%d atyp=%d", req.host, req.port, req.atyp)
+	if req.host != "ab.onion" || req.port != 443 || req.atyp != 0x03 || req.cmd != 0x01 {
+		t.Fatalf("got host=%q port=%d atyp=%d cmd=%d", req.host, req.port, req.atyp, req.cmd)
 	}
 }
 
-func TestReadSocksConnect_IPv4(t *testing.T) {
+func TestReadSocksRequest_IPv4(t *testing.T) {
 	buf := []byte{0x05, 0x01, 0x00, 0x01, 10, 0, 0, 7, 0x00, 0x50} // 10.0.0.7:80
-	req, err := readSocksConnect(bytes.NewReader(buf))
+	req, err := readSocksRequest(bytes.NewReader(buf))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if req.host != "10.0.0.7" || req.port != 80 {
-		t.Fatalf("got host=%q port=%d", req.host, req.port)
+	if req.host != "10.0.0.7" || req.port != 80 || req.cmd != 0x01 {
+		t.Fatalf("got host=%q port=%d cmd=%d", req.host, req.port, req.cmd)
 	}
 }
 
-func TestReadSocksConnect_RejectsNonConnect(t *testing.T) {
+func TestReadSocksRequest_AcceptsNonConnect(t *testing.T) {
 	buf := []byte{0x05, 0x02, 0x00, 0x01, 1, 1, 1, 1, 0, 80} // CMD=2 (bind)
-	if _, err := readSocksConnect(bytes.NewReader(buf)); err == nil {
-		t.Fatal("expected error for non-CONNECT command")
+	req, err := readSocksRequest(bytes.NewReader(buf))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if req.cmd != 0x02 {
+		t.Fatalf("expected readSocksRequest to accept non-CONNECT, got cmd=%d", req.cmd)
 	}
 }
 
-func TestEncodeConnectReq_RoundTrips(t *testing.T) {
+func TestEncodeReq_RoundTrips(t *testing.T) {
 	host := "x.onion"
 	in := []byte{0x05, 0x01, 0x00, 0x03, byte(len(host))}
 	in = append(in, []byte(host)...)
 	in = append(in, 0x01, 0xBB)
-	req, err := readSocksConnect(bytes.NewReader(in))
+	req, err := readSocksRequest(bytes.NewReader(in))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got := encodeConnectReq(req); !bytes.Equal(got, in) {
+	if got := encodeReq(req); !bytes.Equal(got, in) {
 		t.Fatalf("re-encode mismatch:\n got %v\nwant %v", got, in)
 	}
 }


### PR DESCRIPTION
## Tor Access Control — Phase 4: SOCKS RESOLVE in the onion gateway

Phase 2 (#428) filters per-`.onion`, but `handleTorSocks` accepted only the SOCKS `CONNECT` command. After Phase 3 (#429) force-redirected **all** `socks_ports` traffic into the gateway, a Tor-aware client issuing a SOCKS `RESOLVE` (0xF0) — resolve-a-hostname-*through*-Tor, the standard way to avoid a DNS leak — was rejected, breaking allow-mode usability for an app permitted to reach a given `.onion`.

Phase 4 makes the gateway **command-aware**:

- **`RESOLVE` (0xF0): filter-and-forward.** Evaluated through the same `onion_rules` as CONNECT; allowed → forwarded to the real Tor SOCKS daemon and its single reply relayed verbatim (incl. Tor's own errors); denied/unmatched → `not allowed` (0x02), fail-closed. RESOLVE is request/reply — **no `splice`**, no tunnel.
- **`RESOLVE_PTR` (0xF1) and all other commands: deliberately rejected** with the correct SOCKS `command not supported` (0x07) — correcting a latent inaccuracy where non-CONNECT commands previously got a misleading `general failure` (0x01). No upstream dial, no event.
- **Audit:** one `tor_control{vector: onion, socks_cmd: "connect"|"resolve"}` event per evaluated request; unsupported commands emit none.

### Properties

- **No policy bypass** — every command either passes `onion_rules` (CONNECT, RESOLVE) or is rejected; an allowed RESOLVE dials upstream only after an `allow` verdict.
- **No new data path, event type, or config knobs** — reuses the existing `tor_control` event (OCSF registry untouched) and the existing `onion_rules` / `socks_ports`.
- **CONNECT unchanged** beyond the added `socks_cmd: "connect"` field.

### Testing

Unit tests over in-memory/loopback connections: command-aware parsing; RESOLVE allowed (forwarded + resolved address relayed, no splice), denied (not-allowed + no dial), and upstream-error (Tor's REP relayed verbatim); unsupported-command -> 0x07. `go build ./...` + `GOOS=windows go build ./...` clean; `internal/netmonitor` + `internal/tor` green.

Design: `docs/superpowers/specs/2026-06-22-tor-access-control-phase4-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
